### PR TITLE
Fix build with Pathscale's EKOPath

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -171,6 +171,7 @@ bool RecursiveDelete(std::string path)
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 std::vector<DirListNode> GetDirListing(std::string pathstring)
 {

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -1,6 +1,7 @@
 #ifndef GETTEXT_HEADER
 #include "config.h" // for USE_GETTEXT
 #include <iostream>
+#include <clocale>
 
 #if USE_GETTEXT
 #include <libintl.h>


### PR DESCRIPTION
Some includes were required to build correctly on GNU/Linux.
