### PR TITLE
Fixed null pointer dereference errors found by cppcheck

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1345,8 +1345,6 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 			i.atEnd()==false; i++)
 	{
 		ServerActiveObject* obj = i.getNode()->getValue();
-		u16 id = i.getNode()->getKey();
-		v3f objectpos = obj->getBasePosition();
 
 		// This shouldn't happen but check it
 		if(obj == NULL)
@@ -1357,9 +1355,12 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 			continue;
 		}
 
+		u16 id = i.getNode()->getKey();		
+		v3f objectpos = obj->getBasePosition();	
+
 		// The block in which the object resides in
 		v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
-		
+
 		// If block is active, don't remove
 		if(m_active_blocks.contains(blockpos_o))
 			continue;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4109,7 +4109,7 @@ void Server::UpdateCrafting(u16 peer_id)
 		InventoryList *clist = player->inventory.getList("craft");
 		InventoryList *rlist = player->inventory.getList("craftresult");
 
-		if(rlist->getUsedSlots() == 0)
+		if(rlist && rlist->getUsedSlots() == 0)
 			player->craftresult_is_preview = true;
 
 		if(rlist && player->craftresult_is_preview)


### PR DESCRIPTION
As an issue opened by Merkel points out, cppcheck finds a few errors in upstream. These are:

[environment.cpp:1349]: (error) Possible null pointer dereference: obj - otherwise it is redundant to check if obj is null at line 1352
[porting.cpp]: (information) Interrupted checking because of too many #ifdef configurations.
[server.cpp:4112]: (error) Possible null pointer dereference: rlist - otherwise it is redundant to check if rlist is null at line 4115
[sqlite/sqlite3.c:43174]: (error) Possible null pointer dereference: pPgOld - otherwise it is redundant to check if pPgOld is null at line 43175
[sqlite/sqlite3.c:57233]: (error) Possible null pointer dereference: pColl - otherwise it is redundant to check if pColl is null at line 57235
[sqlite/sqlite3.c:102233]: (error) Possible null pointer dereference: pRangeStart - otherwise it is redundant to check if pRangeStart is null at line 102239
[sqlite/sqlite3.c]: (information) Interrupted checking because of too many #ifdef configurations.

I fixed the error in environment.cpp by moving the dereference to after the null pointer check, and I fixed the error in server.cpp by adding an extra non-null check for rlist before it's used. I think the errors in sqlite3.c are false positives.
