### PR TITLE
Add jungletree -> wood recipe

### DIFF
--- a/data/mods/default/init.lua
+++ b/data/mods/default/init.lua
@@ -452,6 +452,13 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
+	output = 'node "wood" 4',
+	recipe = {
+		{'node "jungletree"'},
+	}
+})
+
+minetest.register_craft({
 	output = 'craft "Stick" 4',
 	recipe = {
 		{'node "wood"'},


### PR DESCRIPTION
Perhaps this is intentional, but I was quite sad that I couldn't make wood from jungletrees. This commit adds the recipe.
