### PR TITLE
Add compilation dependencies for Fedora in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,6 +55,9 @@ Compiling on GNU/Linux:
 
 Install dependencies. Here's an example for Debian/Ubuntu:
 $ apt-get install build-essential libirrlicht-dev cmake libbz2-dev libpng12-dev libjpeg8-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev
+Example for Fedora:
+$ yum groupinstall "Development Tools" "Development Libraries"
+$ yum install irrlicht-devel libXxf86vm-devel mesa-libGL-devel libsqlite3x-devel
 
 Download source, extract (this is the URL to the latest of source repository, which might not work at all times):
 $ wget https://github.com/celeron55/minetest/tarball/master -O master.tar.gz


### PR DESCRIPTION
Btw, I tested Minetest from sources on Fedora 15 and 16, and it works perfectly well.
