### PR TITLE
Small fix to socket.cpp for Linux users

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -325,7 +325,7 @@ bool UDPSocket::WaitData(int timeout_ms)
 	// select()
 	result = select(m_handle+1, &readset, NULL, NULL, &tv);
 
-	if(result == 0){
+	if(result == 0  || errno == EINTR){
 		// Timeout
 		/*dstream<<"Select timed out (timeout_ms="
 				<<timeout_ms<<")"<<std::endl;*/


### PR DESCRIPTION
See issue #57.  This simply changes line 328 in socket.cpp to check for a system interrupt.  See http://support.sas.com/documentation/onlinedoc/sasc/doc750/html/lr2/select.htm#zid-6057 for an explanation.
