### PR TITLE
Fix a compile error with clang++

### DIFF
--- a/src/tool.h
+++ b/src/tool.h
@@ -49,18 +49,20 @@ struct ToolGroupCap
 	}
 };
 
+
+typedef std::map<std::string, struct ToolGroupCap> ToolGCMap;
+
 struct ToolCapabilities
 {
 	float full_punch_interval;
 	int max_drop_level;
-	std::map<std::string, ToolGroupCap> groupcaps;
+	ToolGCMap groupcaps;
 
 	ToolCapabilities(
 			float full_punch_interval_=1.4,
 			int max_drop_level_=1,
-			std::map<std::string, ToolGroupCap> groupcaps_ =
-					std::map<std::string, ToolGroupCap>()
-	):
+			ToolGCMap groupcaps_=ToolGCMap()
+	) :
 		full_punch_interval(full_punch_interval_),
 		max_drop_level(max_drop_level_),
 		groupcaps(groupcaps_)


### PR DESCRIPTION
clang++ (And reportedly old versions of g++) have trouble parsing the default arguments in constructors when the defaults involve templates. This fixes the issue (For clang++, at least, I don't have g++ 4.2.X sitting around to try it.)
