### PR TITLE
Fix nil player crash when using minetest.env:place_node()

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -148,11 +148,13 @@ function minetest.item_place_node(itemstack, placer, pointed_thing)
 			local dir = {x = under.x - above.x, y = under.y - above.y, z = under.z - above.z}
 			newnode.param2 = minetest.dir_to_wallmounted(dir)
 		-- Calculate the direction for furnaces and chests and stuff
-		elseif def.paramtype2 == 'facedir' and placer then
+		elseif def.paramtype2 == 'facedir' then
 			local playerpos = placer:getpos()
-			local dir = {x = pos.x - playerpos.x, y = pos.y - playerpos.y, z = pos.z - playerpos.z}
-			newnode.param2 = minetest.dir_to_facedir(dir)
-			minetest.log("action", "facedir: " .. newnode.param2)
+			if playerpos ~= nil then
+				local dir = {x = pos.x - playerpos.x, y = pos.y - playerpos.y, z = pos.z - playerpos.z}
+				newnode.param2 = minetest.dir_to_facedir(dir)
+				minetest.log("action", "facedir: " .. newnode.param2)
+			end
 		end
 
 		-- Add node and update


### PR DESCRIPTION
Basically just added a check to ensure that the placer is not nil before trying to index :getpos().
