### PR TITLE
Prevent /me when not allowed to shout and random chat message changes (consistency)

### DIFF
--- a/builtin/chatcommands.lua
+++ b/builtin/chatcommands.lua
@@ -41,7 +41,7 @@ end)
 --
 
 -- Register C++ commands without functions
-minetest.register_chatcommand("me", {params = nil, description = "chat action (eg. /me orders a pizza)"})
+minetest.register_chatcommand("me", {params = nil, description = "chat action (eg. /me orders a pizza)", privs = {shout=true}})
 minetest.register_chatcommand("status", {description = "print server status line"})
 minetest.register_chatcommand("shutdown", {params = "", description = "shutdown server", privs = {server=true}})
 minetest.register_chatcommand("clearobjects", {params = "", description = "clear all objects in world", privs = {server=true}})

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2277,7 +2277,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 				std::wstring message;
 				message += L"*** ";
 				message += name;
-				message += L" joined game";
+				message += L" joined the game.";
 				BroadcastChatMessage(message);
 			}
 		}
@@ -2285,7 +2285,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 		// Warnings about protocol version can be issued here
 		if(getClient(peer_id)->net_proto_version < PROTOCOL_VERSION)
 		{
-			SendChatMessage(peer_id, L"# Server: WARNING: YOUR CLIENT IS OLD AND MAY WORK PROPERLY WITH THIS SERVER");
+			SendChatMessage(peer_id, L"# Server: WARNING: YOUR CLIENT IS OLD AND MAY WORK PROPERLY WITH THIS SERVER!");
 		}
 
 		/*
@@ -2707,7 +2707,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 				line += message;
 				send_to_others = true;
 			} else {
-				line += L"Server: You are not allowed to shout";
+				line += L"-!- You don't have permission to shout.";
 				send_to_sender = true;
 			}
 		}
@@ -2816,11 +2816,11 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 		bool success = scriptapi_set_password(m_lua, playername, newpwd);
 		if(success){
 			actionstream<<player->getName()<<" changes password"<<std::endl;
-			SendChatMessage(peer_id, L"Password change successful");
+			SendChatMessage(peer_id, L"Password change successful.");
 		} else {
 			actionstream<<player->getName()<<" tries to change password but "
 					<<"it fails"<<std::endl;
-			SendChatMessage(peer_id, L"Password change failed or inavailable");
+			SendChatMessage(peer_id, L"Password change failed or inavailable.");
 		}
 	}
 	else if(command == TOSERVER_PLAYERITEM)
@@ -4653,7 +4653,7 @@ void Server::handlePeerChange(PeerChange &c)
 				std::wstring name = narrow_to_wide(player->getName());
 				message += L"*** ";
 				message += name;
-				message += L" left game";
+				message += L" left the game.";
 				if(c.timeout)
 					message += L" (timed out)";
 			}

--- a/src/servercommand.cpp
+++ b/src/servercommand.cpp
@@ -32,6 +32,12 @@ void cmd_status(std::wostringstream &os,
 void cmd_me(std::wostringstream &os,
 	ServerCommandContext *ctx)
 {
+	if(!ctx->server->checkPriv(ctx->player->getName(), "shout"))
+	{
+		os<<L"-!- You don't have permission to shout.";
+		return;
+	}
+
 	std::wstring name = narrow_to_wide(ctx->player->getName());
 	os << L"* " << name << L" " << ctx->paramstring;
 	ctx->flags |= SEND_TO_OTHERS | SEND_NO_PREFIX;
@@ -48,13 +54,13 @@ void cmd_time(std::wostringstream &os,
 	
 	if(!ctx->server->checkPriv(ctx->player->getName(), "settime"))
 	{
-		os<<L"-!- You don't have permission to do that";
+		os<<L"-!- You don't have permission to do this.";
 		return;
 	}
 
 	u32 time = stoi(wide_to_narrow(ctx->parms[1]));
 	ctx->server->setTimeOfDay(time);
-	os<<L"-!- time_of_day changed.";
+	os<<L"-!- Time of day changed.";
 
 	actionstream<<ctx->player->getName()<<" sets time "
 			<<time<<std::endl;
@@ -65,7 +71,7 @@ void cmd_shutdown(std::wostringstream &os,
 {
 	if(!ctx->server->checkPriv(ctx->player->getName(), "server"))
 	{
-		os<<L"-!- You don't have permission to do that";
+		os<<L"-!- You don't have permission to do this.";
 		return;
 	}
 
@@ -74,7 +80,7 @@ void cmd_shutdown(std::wostringstream &os,
 
 	ctx->server->requestShutdown();
 					
-	os<<L"*** Server shutting down (operator request)";
+	os<<L"*** Server shutting down (operator request).";
 	ctx->flags |= SEND_TO_OTHERS;
 }
 
@@ -82,7 +88,7 @@ void cmd_banunban(std::wostringstream &os, ServerCommandContext *ctx)
 {
 	if(!ctx->server->checkPriv(ctx->player->getName(), "ban"))
 	{
-		os<<L"-!- You don't have permission to do that";
+		os<<L"-!- You don't have permission to do this.";
 		return;
 	}
 
@@ -132,7 +138,7 @@ void cmd_clearobjects(std::wostringstream &os,
 {
 	if(!ctx->server->checkPriv(ctx->player->getName(), "server"))
 	{
-		os<<L"-!- You don't have permission to do that";
+		os<<L"-!- You don't have permission to do this.";
 		return;
 	}
 
@@ -152,7 +158,7 @@ void cmd_clearobjects(std::wostringstream &os,
 					
 	actionstream<<"object clearing done"<<std::endl;
 	
-	os<<L"*** cleared all objects";
+	os<<L"*** Cleared all objects.";
 	ctx->flags |= SEND_TO_OTHERS;
 }
 


### PR DESCRIPTION
This is a simple commit, preventing the use of the /me command when not allowed to shout. It also changes some messages around a bit for consistency.
