### PR TITLE
Fix black display inside opaque water

### DIFF
--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -556,8 +556,6 @@ public:
 					f->solidness = 0;
 				} else {
 					f->solidness = 1;
-					if(f->alpha == 255)
-						f->solidness = 2;
 					f->backface_culling = false;
 				}
 				break;


### PR DESCRIPTION
This will prevent the display from going black when the player swims in opaque water.  Description from the commit:

> Opaque water's solidness was being set to 2, like a normal node.  When you swim, it is treated like a solid block, and the display goes black.  Setting it to 1 like transparent water allows you to see.
> 
> It looks somewhat awkward when you swim, look up, and see an opaque wall of water (the surface), but there isn't much that can be done about it.  If you made the water transparent so it looked good, it would defeat the purpose :) .
