### PR TITLE
Allow digging of unknown nodes

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -262,7 +262,8 @@ function minetest.node_dig(pos, node, digger)
 	minetest.debug("node_dig")
 
 	local def = ItemStack({name=node.name}):get_definition()
-	if not def.diggable or (def.can_dig and not def.can_dig(pos,digger)) then
+	-- Check if def ~= 0 because we always want to be able to remove unknown nodes
+	if #def ~= 0 and not def.diggable or (def.can_dig and not def.can_dig(pos,digger)) then
 		minetest.debug("not diggable")
 		minetest.log("info", digger:get_player_name() .. " tried to dig "
 			.. node.name .. " which is not diggable "


### PR DESCRIPTION
I'm not sure if this is a good way to solve this issue, but it works.  From the commit:

> This allows the removal of nodes with unknown types.  get_item_callback() (C++) would fail if a node has an unknown type.  Now it will try using the callback from minetest.nodedef_default in this case.  Also, minetest.node_dig() (Lua) was altered to always allow digging when the node definition is empty (i.e. unknown node).

I changed get_item_callback() in scriptapi.cpp to try getting the callback from minetest.nodedef_default instead if the item type does not appear to exist.  This way unknown nodes can still be manipulated to some degree.  I'm not sure if this is a good solution or not, but it's the best I have come up with so far.
