### PR TITLE
Add liquid_renewable property, allow non-renewable liquids.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1345,6 +1345,8 @@ Node definition (register_node)
     liquid_alternative_flowing = "", -- Flowing version of source liquid
     liquid_alternative_source = "", -- Source version of flowing liquid
     liquid_viscosity = 0, -- Higher viscosity = slower flow (max. 7)
+    liquid_renewable = true, -- Can new liquid source be created by placing
+    two or more sources nearly?
     light_source = 0, -- Amount of light emitted by node
     damage_per_second = 0, -- If player is inside node, this damage is caused
     node_box = {type="regular"}, -- See "Node boxes"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1746,12 +1746,12 @@ void Map::transformLiquids(core::map<v3s16, MapBlock*> & modified_blocks)
 		content_t new_node_content;
 		s8 new_node_level = -1;
 		s8 max_node_level = -1;
-		if (num_sources >= 2 || liquid_type == LIQUID_SOURCE) {
+		if ((num_sources >= 2 && nodemgr->get(liquid_kind).liquid_renewable) || liquid_type == LIQUID_SOURCE) {
 			// liquid_kind will be set to either the flowing alternative of the node (if it's a liquid)
 			// or the flowing alternative of the first of the surrounding sources (if it's air), so
 			// it's perfectly safe to use liquid_kind here to determine the new node content.
 			new_node_content = nodemgr->getId(nodemgr->get(liquid_kind).liquid_alternative_source);
-		} else if (num_sources == 1 && sources[0].t != NEIGHBOR_LOWER) {
+		} else if (num_sources >= 1 && sources[0].t != NEIGHBOR_LOWER) {
 			// liquid_kind is set properly, see above
 			new_node_content = liquid_kind;
 			max_node_level = new_node_level = LIQUID_LEVEL_MAX;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -203,6 +203,7 @@ void ContentFeatures::reset()
 	liquid_alternative_flowing = "";
 	liquid_alternative_source = "";
 	liquid_viscosity = 0;
+	liquid_renewable = true;
 	light_source = 0;
 	damage_per_second = 0;
 	node_box = NodeBox();
@@ -253,6 +254,7 @@ void ContentFeatures::serialize(std::ostream &os)
 	os<<serializeString(liquid_alternative_flowing);
 	os<<serializeString(liquid_alternative_source);
 	writeU8(os, liquid_viscosity);
+	writeU8(os, liquid_renewable);
 	writeU8(os, light_source);
 	writeU32(os, damage_per_second);
 	node_box.serialize(os);
@@ -307,6 +309,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 	liquid_alternative_flowing = deSerializeString(is);
 	liquid_alternative_source = deSerializeString(is);
 	liquid_viscosity = readU8(is);
+	liquid_renewable = readU8(is);
 	light_source = readU8(is);
 	damage_per_second = readU32(is);
 	node_box.deSerialize(is);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -209,6 +209,8 @@ struct ContentFeatures
 	// 1 giving almost instantaneous propagation and 7 being
 	// the slowest possible
 	u8 liquid_viscosity;
+	// Is liquid renewable (new liquid source will be created between 2 existing)
+	bool liquid_renewable;
 	// Amount of light the node emits
 	u8 light_source;
 	u32 damage_per_second;

--- a/src/scriptapi.cpp
+++ b/src/scriptapi.cpp
@@ -1238,6 +1238,7 @@ static ContentFeatures read_content_features(lua_State *L, int index)
 	// the slowest possible
 	f.liquid_viscosity = getintfield_default(L, index,
 			"liquid_viscosity", f.liquid_viscosity);
+	getboolfield(L, index, "liquid_renewable", f.liquid_renewable);
 	// Amount of light the node emits
 	f.light_source = getintfield_default(L, index,
 			"light_source", f.light_source);


### PR DESCRIPTION
Currently player can make infinite-generator of any liquid; this patch adds liquid_renewable boolean parameter to node definition so such behavior could be disallowed.
