### PR TITLE
Add #include guards to base64.h

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -1,5 +1,10 @@
+#ifndef BASE64_HEADER
+#define BASE64_HEADER
+
 #include <string>
 
 bool base64_is_valid(std::string const& s);
 std::string base64_encode(unsigned char const* , unsigned int len);
 std::string base64_decode(std::string const& s);
+
+#endif // BASE64_HEADER


### PR DESCRIPTION
I spotted this about a month ago.  It hasn't caused an issue yet, and probably never will, but there is still a possibility that an issue could arise in the future.
