### PR TITLE
Added optional anisotropic filtering, mip-mapping, bi/trilineaer filtering

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -544,6 +544,11 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			for(u32 i=0; i<c; i++)
 			{
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
+
+				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, g_settings->getBool("trilinear_filter"));
+				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, g_settings->getBool("bilinear_filter"));
+				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, g_settings->getBool("anisotropic_filter"));
+
 				const video::SMaterial& material = buf->getMaterial();
 				video::IMaterialRenderer* rnd =
 						driver->getMaterialRenderer(material.MaterialType);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -142,5 +142,10 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.05");
 	settings->setDefault("ignore_world_load_errors", "false");
+
+	settings->setDefault("mip_map", "false");
+	settings->setDefault("anisotropic_filter", "false");
+	settings->setDefault("bilinear_filter", "false");
+	settings->setDefault("trilinear_filter", "false");
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1292,8 +1292,10 @@ int main(int argc, char *argv[])
 
 	video::IVideoDriver* driver = device->getVideoDriver();
 
-	// Disable mipmaps (because some of them look ugly)
-	driver->setTextureCreationFlag(video::ETCF_CREATE_MIP_MAPS, false);
+	// Allow user to set mip-mapping by config file
+	// (see also, clientmap.cpp line 548)
+
+	driver->setTextureCreationFlag(video::ETCF_CREATE_MIP_MAPS, g_settings->getBool("mip_map"));
 
 	/*
 		This changes the minimum allowed number of vertices in a VBO.


### PR DESCRIPTION
This patch adds the above along with a minimal amount of code to make it possible to turn each one on/off via the config file.  No GUI stuff yet.  Does not implement the desired bi/trilinear threshold yet.  By default, all four options are turned off, so the game behaves as if it has not been altered.
