### PR TITLE
Allow transparent image_buttons

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -458,6 +458,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			
 			video::ITexture *texture = m_gamedef->tsrc()->getTextureRaw(fimage);
 			gui::IGUIButton *e = Environment->addButton(rect, this, spec.fid, spec.flabel.c_str());
+			e->setUseAlphaChannel(true);
 			e->setImage(texture);
 			e->setPressedImage(texture);
 			e->setScaleImage(true);


### PR DESCRIPTION
Turns out there _was_ a button under the blackened image!
Found by hmmmm, this fixes celeron55/minetest/issues/264.
Using this formspec instead of the other one:

``` lua
on_punch = function(pos, node, puncher)
  minetest.env:get_meta(pos):set_string("formspec",
    "size[2,2]"..
    "image[0,0;1,1;default_apple.png]"..
    "image_button_exit[0,1;1,1;default_apple.png;apple2;]"..
    "image[1,0;1,1;default_dirt.png]"..
    "image_button_exit[1,1;1,1;default_dirt.png;dirt2;]"..
  '')
end,
```

![four images](http://farm9.staticflickr.com/8191/8100697764_b8acd79323_b_d.jpg)
Don't pay any attention to the land behind the cotton. Just trying to worldedit a cone.
