### PR TITLE
Make air and ignore drop nothing

### DIFF
--- a/builtin/misc_register.lua
+++ b/builtin/misc_register.lua
@@ -259,6 +259,7 @@ minetest.register_node(":air", {
 	diggable = false,
 	buildable_to = true,
 	air_equivalent = true,
+	drop = "",
 	groups = {not_in_creative_inventory=1},
 })
 
@@ -274,6 +275,7 @@ minetest.register_node(":ignore", {
 	diggable = false,
 	buildable_to = true, -- A way to remove accidentally placed ignores
 	air_equivalent = true,
+	drop = "",
 	groups = {not_in_creative_inventory=1},
 })
 


### PR DESCRIPTION
In some cases (when a node is removed by Lua while digging) it can happen that you dig air or ignore. Adding drop = "" to them fixes this bug.
