### PR TITLE
Fix a bug in falling code where entities get stuck

### DIFF
--- a/builtin/falling.lua
+++ b/builtin/falling.lua
@@ -111,6 +111,11 @@ function nodeupdate_single(p)
 end
 
 function nodeupdate(p)
+	-- Round p to prevent falling entities to get stuck
+	p.x = math.floor(p.x+0.5)
+	p.y = math.floor(p.y+0.5)
+	p.z = math.floor(p.z+0.5)
+	
 	for x = -1,1 do
 	for y = -1,1 do
 	for z = -1,1 do


### PR DESCRIPTION
In some cases the function nodeupdate() gets not integer coordinates. For example in RealBadAngels technic mod is a laser. When it digs nodes under sand the falling entity for sand spawns not at the correct position but half in the neighbour nodes, so it gets stuck.
RealBadAngel has tested this patch and confirmed that it works with his laser. There is no effect on the default spawning of sand.
