### PR TITLE
Fix trees growing into any type of node

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -131,7 +131,7 @@ void make_tree(ManualMapVoxelManipulator &vmanip, v3s16 p0,
 	v3s16 p1 = p0;
 	for(s16 ii=0; ii<trunk_h; ii++)
 	{
-		if(vmanip.m_area.contains(p1))
+		if(ii == 0 || vmanip.m_area.contains(p1))
  		{
  			// Trunk may replace only air
  			if(vmanip.getNodeNoExNoEmerge(p1).getContent() == CONTENT_AIR)


### PR DESCRIPTION
0gb.us had [discovered a while ago](http://minetest.net/forum/viewtopic.php?pid=48897#p48897) that tree trunks can grow into any type of node.

This has recently become an issue when it started being [used to grief servers](http://webcache.googleusercontent.com/search?q=cache:9LPjJU_6JmcJ:minetest.net/forum/viewtopic.php%3Fid%3D3693+&cd=1&hl=en&ct=clnk). As it circumvents the rollback mechanism, it's pretty obvious how this is a serious problem.

I made a quick fix for the issue that allows the tree to grow only in air. The patch was originally posted in #280, but I thought it would be better to submit it separately.
