### PR TITLE
Fix server crash on /clearpassword

### DIFF
--- a/builtin/chatcommands.lua
+++ b/builtin/chatcommands.lua
@@ -215,8 +215,8 @@ minetest.register_chatcommand("clearpassword", {
 	privs = {password=true},
 	func = function(name, param)
 		toname = param
-		if not toname then
-			minetest.chat_send_player(toname, "Name field required")
+		if toname == "" then
+			minetest.chat_send_player(name, "Name field required")
 			return
 		end
 		minetest.set_player_password(toname, '')


### PR DESCRIPTION
According to #253, using `/clearpassword` without an argument causes the server to crash from an assertion failure. I've resubmitted matttpt's patch as a pull request to aid in merging.
