### PR TITLE
Send player position 10 times a second instead of 5. Uses more bandwidth but looks much better.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -658,7 +658,7 @@ void Client::step(float dtime)
 	{
 		float &counter = m_playerpos_send_timer;
 		counter += dtime;
-		if(counter >= 0.2)
+		if(counter >= 0.1)
 		{
 			counter = 0.0;
 			sendPlayerPos();


### PR DESCRIPTION
See title. I haven't really tested the bandwidth increase (iftop -i lo reports numbers between 20 and 40 kbits/s), but I think this would be good.
