### PR TITLE
make dragged itemstack following the mouse cursor much smoother

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1513,7 +1513,7 @@ void the_game(
 					<<"Launching inventory"<<std::endl;
 			
 			GUIFormSpecMenu *menu =
-				new GUIFormSpecMenu(guienv, guiroot, -1,
+				new GUIFormSpecMenu(device, guiroot, -1,
 					&g_menumgr,
 					&client, gamedef);
 
@@ -2296,7 +2296,7 @@ void the_game(
 					/* Create menu */
 
 					GUIFormSpecMenu *menu =
-						new GUIFormSpecMenu(guienv, guiroot, -1,
+						new GUIFormSpecMenu(device, guiroot, -1,
 							&g_menumgr,
 							&client, gamedef);
 					menu->setFormSpec(meta->getString("formspec"),

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -125,13 +125,14 @@ void drawItemStack(video::IVideoDriver *driver,
 	GUIFormSpecMenu
 */
 
-GUIFormSpecMenu::GUIFormSpecMenu(gui::IGUIEnvironment* env,
+GUIFormSpecMenu::GUIFormSpecMenu(irr::IrrlichtDevice* dev,
 		gui::IGUIElement* parent, s32 id,
 		IMenuManager *menumgr,
 		InventoryManager *invmgr,
 		IGameDef *gamedef
 ):
-	GUIModalMenu(env, parent, id, menumgr),
+	GUIModalMenu(dev->getGUIEnvironment(), parent, id, menumgr),
+	m_device(dev),
 	m_invmgr(invmgr),
 	m_gamedef(gamedef),
 	m_form_src(NULL),
@@ -698,6 +699,8 @@ void GUIFormSpecMenu::drawMenu()
 		}
 	}
 
+	m_pointer = m_device->getCursorControl()->getPosition();
+
 	updateSelectedItem();
 
 	gui::IGUISkin* skin = Environment->getSkin();
@@ -938,23 +941,14 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		}
 	}
 	if(event.EventType==EET_MOUSE_INPUT_EVENT
-			&& event.MouseInput.Event == EMIE_MOUSE_MOVED)
-	{
-		// Mouse moved
-		m_pointer = v2s32(event.MouseInput.X, event.MouseInput.Y);
-	}
-	if(event.EventType==EET_MOUSE_INPUT_EVENT
 			&& event.MouseInput.Event != EMIE_MOUSE_MOVED)
 	{
 		// Mouse event other than movement
 
-		v2s32 p(event.MouseInput.X, event.MouseInput.Y);
-		m_pointer = p;
-
 		// Get selected item and hovered/clicked item (s)
 
 		updateSelectedItem();
-		ItemSpec s = getItemAtPos(p);
+		ItemSpec s = getItemAtPos(m_pointer);
 
 		Inventory *inv_selected = NULL;
 		Inventory *inv_s = NULL;

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -144,7 +144,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 	};
 
 public:
-	GUIFormSpecMenu(gui::IGUIEnvironment* env,
+	GUIFormSpecMenu(irr::IrrlichtDevice* dev,
 			gui::IGUIElement* parent, s32 id,
 			IMenuManager *menumgr,
 			InventoryManager *invmgr,
@@ -197,6 +197,7 @@ protected:
 	v2s32 spacing;
 	v2s32 imgsize;
 	
+	irr::IrrlichtDevice* m_device;
 	InventoryManager *m_invmgr;
 	IGameDef *m_gamedef;
 


### PR DESCRIPTION
by using the cursor coordinates directly, instead of updating them only when a mouse event is seen.
