### PR TITLE
Add the ability to check if image exists

### DIFF
--- a/src/tile.h
+++ b/src/tile.h
@@ -131,6 +131,7 @@ public:
 	virtual IrrlichtDevice* getDevice()
 		{return NULL;}
 	virtual void updateAP(AtlasPointer &ap){};
+	virtual bool isKnownSourceImage(const std::string &name)=0;
 };
 
 class IWritableTextureSource : public ITextureSource
@@ -149,6 +150,7 @@ public:
 	virtual IrrlichtDevice* getDevice()
 		{return NULL;}
 	virtual void updateAP(AtlasPointer &ap){};
+	virtual bool isKnownSourceImage(const std::string &name)=0;
 
 	virtual void processQueue()=0;
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;


### PR DESCRIPTION
This patch by celeron55 (see discussion here: http://irc.minetest.ru/minetest-dev/2012-11-28#i_2668712) adds isKnownSourceImage to TextureSource which
lets us check if a image exists or not.

<b>Example:</b> With my textured crosshair branch it lets us check if the image exists and if not we fall back to the old style crosshair instead of just creating a dummy image.
