### PR TITLE
Fix incorrect fullscreen_bpp value

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -71,7 +71,9 @@
 #screenW = 800
 #screenH = 600
 #fullscreen = false
-#fullscreen_bpp = 24
+# Number of bits per pixel when in fullscreen mode. This should be 16 or 32. 
+# This parameter is ignored when running in windowed mode which always uses 16bpp.
+#fullscreen_bpp = 32
 # Experimental option, might cause visible spaces between blocks
 # when set to higher number than 0
 #fsaa = 0

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -78,7 +78,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("screenW", "800");
 	settings->setDefault("screenH", "600");
 	settings->setDefault("fullscreen", "false");
-	settings->setDefault("fullscreen_bpp", "24");
+	settings->setDefault("fullscreen_bpp", "32");
 	settings->setDefault("fsaa", "0");
 	settings->setDefault("vsync", "false");
 	settings->setDefault("address", "");


### PR DESCRIPTION
Irrlicht only likes a value of 16 or 32 being passed to this. 

Any other value will cause problems when in fullscreen mode for example on my windows system it would just show the client window without its window frame in stead of going fullscreen and stretching it to fit.
