### PR TITLE
Add SQLite build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ src/jthread/Makefile
 src/jthread/cmake_config.h
 src/jthread/cmake_install.cmake
 src/jthread/libjthread.a
+src/sqlite/CMakeFiles/*
+src/sqlite/libsqlite3.a
 src/lua/build/
 src/lua/CMakeFiles/
 CMakeCache.txt


### PR DESCRIPTION
The SQLite CMakeFiles directory and the built SQLite static library show up as untracked files:

```
$ git status
# On branch master
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#   src/sqlite/CMakeFiles/
#   src/sqlite/libsqlite3.a
nothing added to commit but untracked files present (use "git add" to track)
```

This commit simply adds them to .gitignore.
