### PR TITLE
Allow falling nodes to pass through solid "buildable_to" nodes.

### DIFF
--- a/builtin/falling.lua
+++ b/builtin/falling.lua
@@ -84,6 +84,7 @@ minetest.register_entity("__builtin:falling_node", {
 			-- Create node and remove entity
 			minetest.env:add_node(np, {name=self.nodename})
 			self.object:remove()
+			nodeupdate(np)
 		else
 			-- Do nothing
 		end


### PR DESCRIPTION
This allows for example, for falling nodes to fall on snow and replace it.
Also run a nodeupdate() in-case a falling node lands on another falling node which is floating.
