### PR TITLE
Fix attachment bug: the parent going faster than the camera

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -218,6 +218,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, v2u32 screensize,
 	// Smooth the movement when walking up stairs
 	v3f old_player_position = m_playernode->getPosition();
 	v3f player_position = player->getPosition();
+	if (player->isAttached && player->parent)
+		player_position = player->parent->getPosition();
 	//if(player->touching_ground && player_position.Y > old_player_position.Y)
 	if(player->touching_ground &&
 			player_position.Y > old_player_position.Y)

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1111,6 +1111,7 @@ public:
 			{
 				LocalPlayer *player = m_env->getLocalPlayer();
 				player->overridePosition = getParent()->getPosition();
+				m_env->getLocalPlayer()->parent = getParent();
 			}
 		}
 		else

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 LocalPlayer::LocalPlayer(IGameDef *gamedef):
 	Player(gamedef),
+	parent(0),
 	isAttached(false),
 	overridePosition(v3f(0,0,0)),
 	last_position(v3f(0,0,0)),

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "player.h"
 
+class ClientActiveObject;
+
 class LocalPlayer : public Player
 {
 public:
@@ -32,6 +34,8 @@ public:
 	{
 		return true;
 	}
+	
+	ClientActiveObject *parent;
 
 	bool isAttached;
 


### PR DESCRIPTION
This fixes the camera not following correctly, when the player is attached to an entity that goes too fast.
