### PR TITLE
Implement "textarea", a multi-line input field in formspec

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -725,6 +725,9 @@ field[<name>;<label>;<default>]
 ^ must be used without a size[] element
 ^ a 'Proceed' button will be added automatically
 
+textarea[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]
+^ same as fields above, but with multi-line input
+
 label[<X>,<Y>;<label>]
 ^ x and y work as per field
 ^ label is the text on the label


### PR DESCRIPTION
<img src=http://i.imgur.com/pTY7z.png>

As the title says, this is a textarea element for formspec.
For instance, this can be used by the microcontroller in mesecons.
Use it just like a positioned field.

You may want to download a reference mod in order to test the change: http://mesecons.net/random/test.zip

test:test1 is a block that can be used to test the new textarea.

(test:test2 is basically the mesecon command block's formspec from that proofs the old fields still work)
