### PR TITLE
Greater FOV when running or using free_move

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -146,6 +146,8 @@
 # (1: low level shaders; not implemented)
 # 2: enable high level shaders
 #enable_shaders = 2
+# Greater FOV when running or flying
+#enable_movement_fov = true
 
 # will only work for servers which use remote_media setting
 # and only for clients compiled with cURL

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -306,6 +306,10 @@ void Camera::update(LocalPlayer* player, f32 frametime, v2u32 screensize,
 	fov_degrees = MYMAX(fov_degrees, 10.0);
 	fov_degrees = MYMIN(fov_degrees, 170.0);
 
+	// Greater FOV if running
+	if (g_settings->getBool("enable_movement_fov"))
+		fov_degrees += player->movement_fov;
+
 	// FOV and aspect ratio
 	m_aspect = (f32)screensize.X / (f32) screensize.Y;
 	m_fov_y = fov_degrees * M_PI / 180.0;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -121,6 +121,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("trilinear_filter", "false");
 	settings->setDefault("preload_item_visuals", "true");
 	settings->setDefault("enable_shaders", "2");
+	settings->setDefault("enable_movement_fov", "true");
 
 	settings->setDefault("media_fetch_threads", "8");
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3081,6 +3081,21 @@ void the_game(
 		}
 
 		/*
+			Movement FOV (for superspeed and flying)
+		*/
+
+		float max_fov = 0;
+		if(player->free_move)
+			max_fov += 5;
+		if(player->superspeed)
+			max_fov += 8;
+
+		if((player->free_move || player->superspeed) && player->movement_fov < max_fov)
+			player->movement_fov += dtime*50;
+		if(player->movement_fov > max_fov)
+			player->movement_fov -= dtime*50;
+
+		/*
 			Draw gui
 		*/
 		// 0-1ms

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -385,7 +385,7 @@ void LocalPlayer::applyControl(float dtime)
 	bool fly_allowed = m_gamedef->checkLocalPrivilege("fly");
 	bool fast_allowed = m_gamedef->checkLocalPrivilege("fast");
 
-	bool free_move = fly_allowed && g_settings->getBool("free_move");
+	free_move = fly_allowed && g_settings->getBool("free_move");
 	bool fast_move = fast_allowed && g_settings->getBool("fast_move");
 	bool continuous_forward = g_settings->getBool("continuous_forward");
 
@@ -397,7 +397,7 @@ void LocalPlayer::applyControl(float dtime)
 	}
 
 	// Whether superspeed mode is used or not
-	bool superspeed = false;
+	superspeed = false;
 	
 	// Old descend control
 	if(g_settings->getBool("aux1_descends"))

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -34,6 +34,9 @@ Player::Player(IGameDef *gamedef):
 	camera_barely_in_ceiling(false),
 	inventory(gamedef->idef()),
 	hp(PLAYER_MAX_HP),
+	superspeed(false),
+	free_move(false),
+	movement_fov(0),
 	peer_id(PEER_ID_INEXISTENT),
 // protected
 	m_gamedef(gamedef),

--- a/src/player.h
+++ b/src/player.h
@@ -212,6 +212,10 @@ public:
 	float hurt_tilt_timer;
 	float hurt_tilt_strength;
 
+	bool  superspeed;
+	bool  free_move;
+	float movement_fov;
+
 	u16 peer_id;
 	
 	std::string inventory_formspec;


### PR DESCRIPTION
Without greater FOV
![screenshot_32508184](https://f.cloud.github.com/assets/1311964/41523/e148d368-55dd-11e2-8964-10a7f3cce5ed.png)

With greater FOV (running + flying)
![screenshot_32512950](https://f.cloud.github.com/assets/1311964/41524/e15a53c2-55dd-11e2-9e31-e181fd35c238.png)

There are smooth transitions from normal to greater FOV.
