### PR TITLE
Fixed content_abm aliases

### DIFF
--- a/src/content_abm.cpp
+++ b/src/content_abm.cpp
@@ -54,7 +54,7 @@ public:
 				!ndef->get(n_top).isLiquid() &&
 				n_top.getLightBlend(env->getDayNightRatio(), ndef) >= 13)
 		{
-			n.setContent(ndef->getId("dirt_with_grass"));
+			n.setContent(ndef->getId("mapgen_dirt_with_grass"));
 			map->addNodeWithEvent(p, n);
 		}
 	}
@@ -83,7 +83,7 @@ public:
 		if(!ndef->get(n_top).light_propagates ||
 				ndef->get(n_top).isLiquid())
 		{
-			n.setContent(ndef->getId("dirt"));
+			n.setContent(ndef->getId("mapgen_dirt"));
 			map->addNodeWithEvent(p, n);
 		}
 	}


### PR DESCRIPTION
Since commit 5a13c49492 when I'm in a new area of the world that hasn't yet been generated the debug log gets flooded with the following error:

```
21:49:43: ERROR[ServerThread]: Map::setNode(): Not allowing to place CONTENT_IGNORE
while trying to replace "default:dirt_with_grass" at (729,1,-219) (block (45,0,-14))
21:49:43: INFO[ServerThread]: Debug stacks:
21:49:43: INFO[ServerThread]: DEBUG STACK FOR THREAD 4688: 
21:49:43: INFO[ServerThread]: #0  MeshUpdateThread::Thread
21:49:43: INFO[ServerThread]: DEBUG STACK FOR THREAD 5304: 
21:49:43: INFO[ServerThread]: #0  ServerThread::Thread
21:49:43: INFO[ServerThread]: #1  Server::AsyncRunStep
21:49:43: INFO[ServerThread]: #2  ServerEnvironment::step
21:49:43: INFO[ServerThread]: DEBUG STACK FOR THREAD 7392: 
21:49:43: INFO[ServerThread]: #0  main
21:49:43: INFO[ServerThread]: #1  ClientMap::renderMap
21:49:43: INFO[ServerThread]: DEBUG STACK FOR THREAD 8936: 
21:49:43: INFO[ServerThread]: #0  EmergeThread::Thread
```

This commit fixes that, However, I'm not 100% sure if this is the correct fix as I'm not really sure why the aliases in the above mentioned commit were changed in the first place. 

**So if someone could please double check this is fine or indeed the correct way to fix the issue before pushing upstream.**
