### PR TITLE
fixes node timer bug (fixes #407).

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -804,7 +804,8 @@ void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 				i = elapsed_timers.begin();
 				i != elapsed_timers.end(); i++){
 			n = block->getNodeNoEx(i->first);
-			if(scriptapi_node_on_timer(m_lua,i->first,n,i->second.elapsed))
+			v3s16 p = i->first + block->getPosRelative();
+			if(scriptapi_node_on_timer(m_lua,p,n,i->second.elapsed))
 				block->setNodeTimer(i->first,NodeTimer(i->second.timeout,0));
 		}
 	}


### PR DESCRIPTION
Previously, when a block was activated, on_timer callbacks where
called with the relative position of the node inside the block,
instead of the absolute position of the node.
