### PR TITLE
fix integer overflow (fixes #414)

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1651,7 +1651,7 @@ void Map::transformLiquids(core::map<v3s16, MapBlock*> & modified_blocks)
 			Collect information about current node
 		 */
 		s8 liquid_level = -1;
-		u8 liquid_kind = CONTENT_IGNORE;
+		content_t liquid_kind = CONTENT_IGNORE;
 		LiquidType liquid_type = nodemgr->get(n0).liquid_type;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:


### PR DESCRIPTION
liquid_kind was declared as an u8, but used to hold a content_t value, which is delcared to be a u16.

changing this fixes (at least for me) the problem reported in bug #414.
