### PR TITLE
add limit for (collision handling) steps to avoid runaway memory consumption 

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -199,6 +199,10 @@ collisionMoveResult collisionMoveSimple(Map *map, IGameDef *gamedef,
 	/*
 		Calculate new velocity
 	*/
+	if( dtime > 0.5 ) {
+		infostream<<"collisionMoveSimple: WARNING: maximum step interval exceeded, lost movement details!"<<std::endl;
+		dtime = 0.5;
+	}
 	speed_f += accel_f * dtime;
 
     // If there is no speed, there are no collisions


### PR DESCRIPTION
this isn't a 100% solution, if you overload server on purpose it will still be unresponsive. But any random load spike will be handled gracefully.
