### PR TITLE
Add sched policy and priority support in order to avoid EmergeThread lockup

### DIFF
--- a/src/jthread/jthread.h
+++ b/src/jthread/jthread.h
@@ -37,16 +37,45 @@
 #define ERR_JTHREAD_NOTRUNNING							-4
 #define ERR_JTHREAD_ALREADYRUNNING						-5
 
+
+enum SchedulingPolicy {
+	SCHED_DEFAULT,
+	FIFO,
+	ROUND_ROBIN
+};
+
+enum JThreadPriority {
+	PRIO_DEFAULT,
+	PRIO_00,
+	PRIO_01,
+	PRIO_02,
+	PRIO_03,
+	PRIO_04,
+	PRIO_05,
+	PRIO_06,
+	PRIO_07,
+	PRIO_08,
+	PRIO_09
+};
+
+
 class JThread
 {
 public:
 	JThread();
+	JThread(SchedulingPolicy policy,JThreadPriority);
 	virtual ~JThread();
 	int Start();
 	int Kill();
 	virtual void *Thread() = 0;
 	bool IsRunning();
 	void *GetReturnValue();
+
+	SchedulingPolicy GetSchedulingPolicy();
+	bool SetSchedulingPolicy(SchedulingPolicy policy);
+
+	JThreadPriority GetThreadPriority();
+	bool SetThreadPriority(JThreadPriority prio);
 protected:
 	void ThreadStarted();
 private:
@@ -71,6 +100,10 @@ private:
 	JMutex runningmutex;
 	JMutex continuemutex,continuemutex2;
 	bool mutexinit;
+
+	SchedulingPolicy m_SchedPolicy;
+	JThreadPriority m_ThreadPriority;
+
 };
 
 #endif // JTHREAD_H

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -155,9 +155,13 @@ void * ServerThread::Thread()
 	return NULL;
 }
 
+#include <pthread.h>
+
 void * EmergeThread::Thread()
 {
 	ThreadStarted();
+
+	SetThreadPriority(PRIO_06);
 
 	log_register_thread("EmergeThread");
 

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -72,7 +72,7 @@ class SimpleThread : public JThread
 public:
 
 	SimpleThread():
-		JThread(),
+		JThread(ROUND_ROBIN,PRIO_04),
 		run(true)
 	{
 		run_mutex.Init();


### PR DESCRIPTION
Win32 code is untested!
Changeing scheduling policy and lifting emerge thread priority is only one step. 
For a full solution big env lock needs to be split throughout minetest.
