### PR TITLE
Add missing faces for flowing liquids and liquid sources.

### DIFF
--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -79,9 +79,11 @@ SharedBuffer<u8> makePacket_TOCLIENT_TIME_OF_DAY(u16 time, float time_speed);
 		Serialization format changes
 	PROTOCOL_VERSION 16:
 		TOCLIENT_SHOW_FORMSPEC
+	PROTOCOL_VERSION 17:
+		Serialization format change: include backface_culling flag in TileDef
 */
 
-#define LATEST_PROTOCOL_VERSION 16
+#define LATEST_PROTOCOL_VERSION 17
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -535,7 +535,10 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 	u8 c2 = f2.solidness;
 
 	bool solidness_differs = (c1 != c2);
-	bool makes_face = contents_differ && solidness_differs;
+	bool both_liquids = f1.isLiquid() && f2.isLiquid();
+	bool different_liquids =  both_liquids && !f1.sameLiquid(f2);
+
+	bool makes_face = (contents_differ && solidness_differs) || different_liquids;
 
 	if(makes_face == false)
 		return 0;
@@ -546,8 +549,9 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 		c2 = f2.visual_solidness;
 	
 	if(c1 == c2){
-		*equivalent = true;
-		// If same solidness, liquid takes precense
+		if(!both_liquids) // don't enable backface-culling for face between two liquids
+			*equivalent = true;
+		// If same solidness, liquid takes precedense
 		if(f1.isLiquid())
 			return 1;
 		if(f2.isLiquid())

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -107,26 +107,31 @@ void NodeBox::deSerialize(std::istream &is)
 	TileDef
 */
 
-void TileDef::serialize(std::ostream &os) const
+void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 {
-	writeU8(os, 0); // version
+	if(protocol_version >= 17)
+		writeU8(os, 1); 
+	else
+		writeU8(os, 0);
 	os<<serializeString(name);
 	writeU8(os, animation.type);
 	writeU16(os, animation.aspect_w);
 	writeU16(os, animation.aspect_h);
 	writeF1000(os, animation.length);
+	if(protocol_version >= 17)
+		writeU8(os, backface_culling);
 }
 
 void TileDef::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if(version != 0)
-		throw SerializationError("unsupported TileDef version");
 	name = deSerializeString(is);
 	animation.type = (TileAnimationType)readU8(is);
 	animation.aspect_w = readU16(is);
 	animation.aspect_h = readU16(is);
 	animation.length = readF1000(is);
+	if(version >= 1)
+		backface_culling = readU8(is);
 }
 
 /*
@@ -234,10 +239,10 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version)
 	writeF1000(os, visual_scale);
 	writeU8(os, 6);
 	for(u32 i=0; i<6; i++)
-		tiledef[i].serialize(os);
+		tiledef[i].serialize(os, protocol_version);
 	writeU8(os, CF_SPECIAL_COUNT);
 	for(u32 i=0; i<CF_SPECIAL_COUNT; i++){
-		tiledef_special[i].serialize(os);
+		tiledef_special[i].serialize(os, protocol_version);
 	}
 	writeU8(os, alpha);
 	writeU8(os, post_effect_color.getAlpha());
@@ -806,10 +811,10 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version)
 		writeF1000(os, visual_scale);
 		writeU8(os, 6);
 		for(u32 i=0; i<6; i++)
-			tiledef[i].serialize(os);
+			tiledef[i].serialize(os, protocol_version);
 		writeU8(os, CF_SPECIAL_COUNT);
 		for(u32 i=0; i<CF_SPECIAL_COUNT; i++){
-			tiledef_special[i].serialize(os);
+			tiledef_special[i].serialize(os, protocol_version);
 		}
 		writeU8(os, alpha);
 		writeU8(os, post_effect_color.getAlpha());

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -119,7 +119,7 @@ struct TileDef
 		animation.length = 1.0;
 	}
 
-	void serialize(std::ostream &os) const;
+	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is);
 };
 


### PR DESCRIPTION
1. Draw the bottom face of a flowing liquid node if the node below is not
the same liquid, and not solid.

2. Change the texture to draw for top and bottom faces to the source
liquid texture when the liquid flows straight down, so the liquid
doesn't appear to flow in some random direction.

3. Include backface_culling flag in serialization format for TileDefs. 
This way flowing liquids actually show the backface when specified to
do so. Without this, TileDefs where by default initialized with
backface_culling = true and never set otherwise.

4. Draw face between liquid sources of different kinds.
This is not the ideal way to do it. Ideally, we would take the
textures from both kinds of liquids, and show them on the opposite
sides, with backface_culling enabled. That would involve further
changes in the code, though.

With this patch, we take the texture from one liquid and show it on
both sides, i.e., with backface_culling disabled,