### PR TITLE
Add minetest.env:set_nodes(list)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1039,6 +1039,11 @@ methods:
 - set_node(pos, node)
 - add_node(pos, node): alias set_node(pos, node)
  ^ Set node at position (node = {name="foo", param1=0, param2=0})
+- set_nodes(list)
+ ^ list: a table that contains {pos, node} and/or {minp, maxp, node}
+   for {pos, node} sets node at pos
+   for {minp, maxp, node} makes a cuboid between these corners
+   Using set_nodes instead of set_node is faster when setting a great amount of nodes
 - remove_node(pos)
   ^ Equivalent to set_node(pos, "air")
 - get_node(pos)


### PR DESCRIPTION
set_nodes(list)
list: a table that contains {pos, node} and/or {minp, maxp, node}
for {pos, node} sets node at pos
for {minp, maxp, node} makes a cuboid between these corners

Example:

``` lua
local setnodes = function()
    minetest.env:set_nodes(
    {
        {pos={x=0,y=0,z=0}, node = {name="default:wood"}},
        {pos={x=0,y=1,z=0}, node = {name="default:stone"}},
        {minp={x=2,y=12,z=2}, maxp={x=5,y=5, z=5}, node = {name="default:dirt"}},
        {minp={x=6,y=16,z=6}, maxp={x=8,y=10,z=4},  node = {name="default:tree"}}
    })
end

minetest.after(0, setnodes)
```

Using set_nodes with a table of nodes is up to 15% faster
Using set_nodes with an area (a cuboid defined by maxp and minp) is up to 50% faster.
Based on measurements with this script by PilzAdam and me: https://gist.github.com/4604759 (test at least 50 times to get results; does only measure seconds and is therefore not precise, use a script with luasocket for precise measurements instead)
