### PR TITLE
Make mapgen factory setup more elegant, add mapgen_v6.h

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -358,7 +358,7 @@ public:
 	/*
 		savedir: directory to which map data should be saved
 	*/
-	ServerMap(std::string savedir, IGameDef *gamedef);
+	ServerMap(std::string savedir, IGameDef *gamedef, EmergeManager *emerge);
 	~ServerMap();
 
 	s32 mapType() const
@@ -480,16 +480,12 @@ public:
 
 	MapgenParams *getMapgenParams(){ return m_mgparams; }
 
-	void setEmerge(EmergeManager *emerge){ m_emerge = emerge; }
-
 	// Parameters fed to the Mapgen
 	MapgenParams *m_mgparams;
 private:
 	// Seed used for all kinds of randomness in generation
 	u64 m_seed;
-
-
-
+	
 	// Emerge manager
 	EmergeManager *m_emerge;
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapnode.h"
 #include "noise.h"
 #include "settings.h"
+#include <map>
 
 /////////////////// Mapgen flags
 #define MG_TREES         0x01
@@ -34,38 +35,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV6_FORESTS     0x08
 #define MGV6_BIOME_BLEND 0x10
 
-#define AVERAGE_MUD_AMOUNT 4
-
 class BiomeDefManager;
 class Biome;
-
-//struct BlockMakeData;
+class EmergeManager;
 class MapBlock;
 class ManualMapVoxelManipulator;
 class VoxelManipulator;
 class INodeDefManager;
-
-extern NoiseParams nparams_v6_def_terrain_base;
-extern NoiseParams nparams_v6_def_terrain_higher;
-extern NoiseParams nparams_v6_def_steepness;
-extern NoiseParams nparams_v6_def_height_select;
-extern NoiseParams nparams_v6_def_trees;
-extern NoiseParams nparams_v6_def_mud;
-extern NoiseParams nparams_v6_def_beach;
-extern NoiseParams nparams_v6_def_biome;
-extern NoiseParams nparams_v6_def_cave;
-
-extern NoiseParams nparams_v7_def_terrain;
-extern NoiseParams nparams_v7_def_bgroup;
-extern NoiseParams nparams_v7_def_heat;
-extern NoiseParams nparams_v7_def_humidity;
-
-enum BiomeType
-{
-	BT_NORMAL,
-	BT_DESERT
-};
-
 
 struct BlockMakeData {
 	bool no_op;
@@ -81,7 +57,6 @@ struct BlockMakeData {
 	~BlockMakeData();
 };
 
-
 struct MapgenParams {
 	std::string mg_name;
 	int chunksize;
@@ -96,40 +71,10 @@ struct MapgenParams {
 		chunksize   = 5;
 		flags       = MG_TREES | MG_CAVES | MGV6_BIOME_BLEND;
 	}
-
-	static MapgenParams *createMapgenParams(std::string &mgname);
-	static MapgenParams *getParamsFromSettings(Settings *settings);
-
+	
+	virtual bool readParams(Settings *settings) = 0;
+	virtual void writeParams(Settings *settings) {};
 };
-
-struct MapgenV6Params : public MapgenParams {
-	float freq_desert;
-	float freq_beach;
-	NoiseParams *np_terrain_base;
-	NoiseParams *np_terrain_higher;
-	NoiseParams *np_steepness;
-	NoiseParams *np_height_select;
-	NoiseParams *np_trees;
-	NoiseParams *np_mud;
-	NoiseParams *np_beach;
-	NoiseParams *np_biome;
-	NoiseParams *np_cave;
-
-	MapgenV6Params() {
-		freq_desert       = 0.45;
-		freq_beach        = 0.15;
-		np_terrain_base   = &nparams_v6_def_terrain_base;
-		np_terrain_higher = &nparams_v6_def_terrain_higher;
-		np_steepness      = &nparams_v6_def_steepness;
-		np_height_select  = &nparams_v6_def_height_select;
-		np_trees          = &nparams_v6_def_trees;
-		np_mud            = &nparams_v6_def_mud;
-		np_beach          = &nparams_v6_def_beach;
-		np_biome          = &nparams_v6_def_biome;
-		np_cave           = &nparams_v6_def_cave;
-	}
-};
-
 
 class Mapgen {
 public:
@@ -147,64 +92,16 @@ public:
 	static s16 find_ground_level_from_noise(u64 seed, v2s16 p2d, s16 precision);
 };
 
-
-class MapgenV6 : public Mapgen {
-public:
-	//ManualMapVoxelManipulator &vmanip;
-
-	int ystride;
-	v3s16 csize;
-
-	v3s16 node_min;
-	v3s16 node_max;
-
-	Noise *noise_terrain_base;
-	Noise *noise_terrain_higher;
-	Noise *noise_steepness;
-	Noise *noise_height_select;
-	Noise *noise_trees;
-	Noise *noise_mud;
-	Noise *noise_beach;
-	Noise *noise_biome;
-
-	float *map_terrain_base;
-	float *map_terrain_higher;
-	float *map_steepness;
-	float *map_height_select;
-	float *map_trees;
-	float *map_mud;
-	float *map_beach;
-	float *map_biome;
-
-	NoiseParams *np_cave;
-
-	u32 flags;
-	float freq_desert;
-	float freq_beach;
-
-	MapgenV6(int mapgenid, MapgenV6Params *params);
-	~MapgenV6();
-
-	void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
-
-	double baseRockLevelFromNoise(v2s16 p);
-	static s16 find_ground_level(VoxelManipulator &vmanip, v2s16 p2d, INodeDefManager *ndef);
-	static s16 find_stone_level(VoxelManipulator &vmanip, v2s16 p2d, INodeDefManager *ndef);
-	void make_tree(ManualMapVoxelManipulator &vmanip, v3s16 p0, bool is_apple_tree, INodeDefManager *ndef);
-	double tree_amount_2d(u64 seed, v2s16 p);
-	bool block_is_underground(u64 seed, v3s16 blockpos);
-	double base_rock_level_2d(u64 seed, v2s16 p);
-	s16 find_ground_level_from_noise(u64 seed, v2s16 p2d, s16 precision);
-	double get_mud_add_amount(u64 seed, v2s16 p);
-	bool get_have_beach(u64 seed, v2s16 p2d);
-	BiomeType get_biome(u64 seed, v2s16 p2d);
-	u32 get_blockseed(u64 seed, v3s16 p);
+struct MapgenFactory {
+	virtual Mapgen *createMapgen(int mgid, MapgenParams *params,
+								 EmergeManager *emerge) = 0;
+	virtual MapgenParams *createMapgenParams() = 0;
 };
-
 
 class EmergeManager {
 public:
+	std::map<std::string, MapgenFactory *> mglist;
+
 	//settings
 	MapgenParams *params;
 
@@ -214,12 +111,19 @@ public:
 	//biome manager
 	BiomeDefManager *biomedef;
 
-	EmergeManager(IGameDef *gamedef, BiomeDefManager *bdef, MapgenParams *mgparams);
+	EmergeManager(IGameDef *gamedef, BiomeDefManager *bdef);
 	~EmergeManager();
 
+	void initMapgens(MapgenParams *mgparams);
+	Mapgen *createMapgen(std::string mgname, int mgid,
+						MapgenParams *mgparams, EmergeManager *emerge);
+	MapgenParams *createMapgenParams(std::string mgname);
 	Mapgen *getMapgen();
 	void addBlockToQueue();
-
+	
+	bool registerMapgen(std::string name, MapgenFactory *mgfactory);
+	MapgenParams *getParamsFromSettings(Settings *settings);
+	
 	//mapgen helper methods
 	Biome *getBiomeAtPoint(v3s16 p);
 	int getGroundLevelAtPoint(v2s16 p);

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -31,6 +31,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "profiler.h"
 #include "settings.h" // For g_settings
 #include "main.h" // For g_profiler
+#include "mapgen_v6.h"
+
+/////////////////// Mapgen V6 perlin noise default values
+NoiseParams nparams_v6_def_terrain_base =
+	{-AVERAGE_MUD_AMOUNT, 20.0, v3f(250.0, 250.0, 250.0), 82341, 5, 0.6};
+NoiseParams nparams_v6_def_terrain_higher =
+	{20.0, 16.0, v3f(500.0, 500.0, 500.0), 85039, 5, 0.6};
+NoiseParams nparams_v6_def_steepness =
+	{0.85, 0.5, v3f(125.0, 125.0, 125.0), -932, 5, 0.7};
+NoiseParams nparams_v6_def_height_select =
+	{0.5, 1.0, v3f(250.0, 250.0, 250.0), 4213, 5, 0.69};
+NoiseParams nparams_v6_def_trees =
+	{0.0, 1.0, v3f(125.0, 125.0, 125.0), 2, 4, 0.66};
+NoiseParams nparams_v6_def_mud =
+	{AVERAGE_MUD_AMOUNT, 2.0, v3f(200.0, 200.0, 200.0), 91013, 3, 0.55};
+NoiseParams nparams_v6_def_beach =
+	{0.0, 1.0, v3f(250.0, 250.0, 250.0), 59420, 3, 0.50};
+NoiseParams nparams_v6_def_biome =
+	{0.0, 1.0, v3f(250.0, 250.0, 250.0), 9130, 3, 0.50};
+NoiseParams nparams_v6_def_cave =
+	{6.0, 6.0, v3f(250.0, 250.0, 250.0), 34329, 3, 0.50};
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -396,7 +417,6 @@ u32 MapgenV6::get_blockseed(u64 seed, v3s16 p)
 int MapgenV6::getGroundLevelAtPoint(v2s16 p) {
 	return baseRockLevelFromNoise(p) + AVERAGE_MUD_AMOUNT;
 }
-
 
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
 

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -1,0 +1,141 @@
+/*
+Minetest-c55
+Copyright (C) 2010-2011 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef MAPGENV6_HEADER
+#define MAPGENV6_HEADER
+
+#include "mapgen.h"
+
+#define AVERAGE_MUD_AMOUNT 4
+
+enum BiomeType
+{
+	BT_NORMAL,
+	BT_DESERT
+};
+
+extern NoiseParams nparams_v6_def_terrain_base;
+extern NoiseParams nparams_v6_def_terrain_higher;
+extern NoiseParams nparams_v6_def_steepness;
+extern NoiseParams nparams_v6_def_height_select;
+extern NoiseParams nparams_v6_def_trees;
+extern NoiseParams nparams_v6_def_mud;
+extern NoiseParams nparams_v6_def_beach;
+extern NoiseParams nparams_v6_def_biome;
+extern NoiseParams nparams_v6_def_cave;
+
+struct MapgenV6Params : public MapgenParams {
+	float freq_desert;
+	float freq_beach;
+	NoiseParams *np_terrain_base;
+	NoiseParams *np_terrain_higher;
+	NoiseParams *np_steepness;
+	NoiseParams *np_height_select;
+	NoiseParams *np_trees;
+	NoiseParams *np_mud;
+	NoiseParams *np_beach;
+	NoiseParams *np_biome;
+	NoiseParams *np_cave;
+
+	MapgenV6Params() {
+		freq_desert       = 0.45;
+		freq_beach        = 0.15;
+		np_terrain_base   = &nparams_v6_def_terrain_base;
+		np_terrain_higher = &nparams_v6_def_terrain_higher;
+		np_steepness      = &nparams_v6_def_steepness;
+		np_height_select  = &nparams_v6_def_height_select;
+		np_trees          = &nparams_v6_def_trees;
+		np_mud            = &nparams_v6_def_mud;
+		np_beach          = &nparams_v6_def_beach;
+		np_biome          = &nparams_v6_def_biome;
+		np_cave           = &nparams_v6_def_cave;
+	}
+	
+	bool readParams(Settings *settings);
+	void writeParams(Settings *settings);
+};
+
+class MapgenV6 : public Mapgen {
+public:
+	//ManualMapVoxelManipulator &vmanip;
+
+	int ystride;
+	v3s16 csize;
+
+	v3s16 node_min;
+	v3s16 node_max;
+
+	Noise *noise_terrain_base;
+	Noise *noise_terrain_higher;
+	Noise *noise_steepness;
+	Noise *noise_height_select;
+	Noise *noise_trees;
+	Noise *noise_mud;
+	Noise *noise_beach;
+	Noise *noise_biome;
+
+	float *map_terrain_base;
+	float *map_terrain_higher;
+	float *map_steepness;
+	float *map_height_select;
+	float *map_trees;
+	float *map_mud;
+	float *map_beach;
+	float *map_biome;
+
+	NoiseParams *np_cave;
+
+	u32 flags;
+	float freq_desert;
+	float freq_beach;
+
+	MapgenV6(int mapgenid, MapgenV6Params *params);
+	~MapgenV6();
+	
+	void makeChunk(BlockMakeData *data);
+	int getGroundLevelAtPoint(v2s16 p);
+
+	double baseRockLevelFromNoise(v2s16 p);
+	static s16 find_ground_level(VoxelManipulator &vmanip,
+								 v2s16 p2d, INodeDefManager *ndef);
+	static s16 find_stone_level(VoxelManipulator &vmanip,
+								 v2s16 p2d, INodeDefManager *ndef);
+	void make_tree(ManualMapVoxelManipulator &vmanip, v3s16 p0,
+					 bool is_apple_tree, INodeDefManager *ndef);
+	double tree_amount_2d(u64 seed, v2s16 p);
+	bool block_is_underground(u64 seed, v3s16 blockpos);
+	double base_rock_level_2d(u64 seed, v2s16 p);
+	s16 find_ground_level_from_noise(u64 seed, v2s16 p2d, s16 precision);
+	double get_mud_add_amount(u64 seed, v2s16 p);
+	bool get_have_beach(u64 seed, v2s16 p2d);
+	BiomeType get_biome(u64 seed, v2s16 p2d);
+	u32 get_blockseed(u64 seed, v3s16 p);
+};
+
+struct MapgenFactoryV6 : public MapgenFactory {
+	Mapgen *createMapgen(int mgid, MapgenParams *params, EmergeManager *emerge) {
+		return new MapgenV6(mgid, (MapgenV6Params *)params);
+	};
+	
+	MapgenParams *createMapgenParams() {
+		return new MapgenV6Params();
+	};
+};
+
+#endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1097,15 +1097,14 @@ Server::Server(
 	// Add default biomes after nodedef had its aliases added
 	m_biomedef->addDefaultBiomes();
 
-	// Initialize Environment
-	ServerMap *servermap = new ServerMap(path_world, this);
-	m_env = new ServerEnvironment(servermap, m_lua, this, this);
-
 	// Create emerge manager
-	m_emerge = new EmergeManager(this, m_biomedef, servermap->getMapgenParams());
+	m_emerge = new EmergeManager(this, m_biomedef);
 
-	// Give map pointer to the emerge manager
-	servermap->setEmerge(m_emerge);
+	// Initialize Environment
+	ServerMap *servermap = new ServerMap(path_world, this, m_emerge);
+	m_env = new ServerEnvironment(servermap, m_lua, this, this);
+	
+	m_emerge->initMapgens(servermap->getMapgenParams());
 
 	// Give environment reference to scripting api
 	scriptapi_add_environment(m_lua, m_env);


### PR DESCRIPTION
This fixes the quick hack previously introduced by my last commit in a rather clean, elegant manner.  To register a mapgen, one now must provide a MapgenFactory object to EmergeManager::registerMapgen(), so that an object of the derived Mapgen and MapgenParams are used.
