### PR TITLE
Disable placement prediction when attaching items to nodes that use on_rightclick

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2528,7 +2528,8 @@ void the_game(
 					// make that happen
 					const ItemDefinition &def =
 							playeritem.getDefinition(itemdef);
-					if(def.node_placement_prediction != "")
+					if(def.node_placement_prediction != ""
+							&& !nodedef->get(map.getNode(nodepos)).rightclickable)
 					do{ // breakable
 						verbosestream<<"Node placement prediction for "
 								<<playeritem.name<<" is "

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -100,6 +100,7 @@ void ItemDefinition::reset()
 	wield_scale = v3f(1.0, 1.0, 1.0);
 	stack_max = 99;
 	usable = false;
+	rightclickable = false;
 	liquids_pointable = false;
 	if(tool_capabilities)
 	{

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -62,6 +62,8 @@ struct ItemDefinition
 	*/
 	s16 stack_max;
 	bool usable;
+	// If true, don't use node placement prediction
+	bool rightclickable;
 	bool liquids_pointable;
 	// May be NULL. If non-NULL, deleted by destructor
 	ToolCapabilities *tool_capabilities;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -199,6 +199,7 @@ void ContentFeatures::reset()
 	diggable = true;
 	climbable = false;
 	buildable_to = false;
+	rightclickable = true;
 	liquid_type = LIQUID_NONE;
 	liquid_alternative_flowing = "";
 	liquid_alternative_source = "";
@@ -271,6 +272,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version)
 	serializeSimpleSoundSpec(sound_dug, os);
 	// Stuff below should be moved to correct place in a version that otherwise changes
 	// the protocol version
+	writeU8(os, rightclickable);
 }
 
 void ContentFeatures::deSerialize(std::istream &is)
@@ -334,6 +336,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 	try{
 		// Stuff below should be moved to correct place in a version that
 		// otherwise changes the protocol version
+		rightclickable = readU8(is);
 	}catch(SerializationError &e) {};
 }
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -199,6 +199,8 @@ struct ContentFeatures
 	bool climbable;
 	// Player can build on these
 	bool buildable_to;
+	// Player cannot build to these (placement prediction disabled)
+	bool rightclickable;
 	// Whether the node is non-liquid, source liquid or flowing liquid
 	enum LiquidType liquid_type;
 	// If the content is liquid, this is the flowing version of the liquid.

--- a/src/scriptapi.cpp
+++ b/src/scriptapi.cpp
@@ -1039,6 +1039,10 @@ static ItemDefinition read_item_definition(lua_State *L, int index,
 	def.usable = lua_isfunction(L, -1);
 	lua_pop(L, 1);
 
+	lua_getfield(L, index, "on_rightclick");
+	def.rightclickable = lua_isfunction(L, -1);
+	lua_pop(L, 1);
+
 	getboolfield(L, index, "liquids_pointable", def.liquids_pointable);
 
 	warn_if_field_exists(L, index, "tool_digging_properties",
@@ -4567,7 +4571,7 @@ static int l_register_item_raw(lua_State *L)
 	// Default to having client-side placement prediction for nodes
 	// ("" in item definition sets it off)
 	if(def.node_placement_prediction == "__default"){
-		if(def.type == ITEM_NODE)
+		if(def.type == ITEM_NODE && !def.rightclickable)
 			def.node_placement_prediction = name;
 		else
 			def.node_placement_prediction = "";


### PR DESCRIPTION
This fixes some glitches in Multiplayer if connection is too slow and on older PCs in singleplayer.
Try it out by placing any node to e.g. door (at best hold righclick). You will most likely  notice some flickering, this patch fixes that.
