### PR TITLE
Dont remove grass under unloaded blocks

### DIFF
--- a/src/content_abm.cpp
+++ b/src/content_abm.cpp
@@ -80,7 +80,8 @@ public:
 		ServerMap *map = &env->getServerMap();
 		
 		MapNode n_top = map->getNodeNoEx(p+v3s16(0,1,0));
-		if(!ndef->get(n_top).light_propagates ||
+		if((!ndef->get(n_top).light_propagates &&
+				n_top.getContent() != CONTENT_IGNORE) ||
 				ndef->get(n_top).isLiquid())
 		{
 			n.setContent(ndef->getId("mapgen_dirt"));


### PR DESCRIPTION
![Bug](https://f.cloud.github.com/assets/2159710/102930/41abba44-6944-11e2-90db-acd98691086c.png)

Grass under unloaded blocks is removed. It causes some strange dirt squares.
