### PR TITLE
Disable backface culling for drawtype plantlike and only draw 2 faces in...

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -733,7 +733,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			u16 l = getInteriorLight(n, 1, data);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
-			for(u32 j=0; j<4; j++)
+			for(u32 j=0; j<2; j++)
 			{
 				video::S3DVertex vertices[4] =
 				{
@@ -758,16 +758,6 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				{
 					for(u16 i=0; i<4; i++)
 						vertices[i].Pos.rotateXZBy(-45);
-				}
-				else if(j == 2)
-				{
-					for(u16 i=0; i<4; i++)
-						vertices[i].Pos.rotateXZBy(135);
-				}
-				else if(j == 3)
-				{
-					for(u16 i=0; i<4; i++)
-						vertices[i].Pos.rotateXZBy(-135);
 				}
 
 				for(u16 i=0; i<4; i++)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -604,9 +604,12 @@ public:
 					}
 				}
 				break;
+			case NDT_PLANTLIKE:
+				f->solidness = 0;
+				f->backface_culling = false;
+				break;
 			case NDT_TORCHLIKE:
 			case NDT_SIGNLIKE:
-			case NDT_PLANTLIKE:
 			case NDT_FENCELIKE:
 			case NDT_RAILLIKE:
 			case NDT_NODEBOX:


### PR DESCRIPTION
...stead of 4

This way, plants actually show the real backface on their back side,
i.e., the front face mirrored around the vertical axis, instead of
showing the front face on both sides. This looked weird when the
texture was not symmetrical around the vertical axis.
