### PR TITLE
Add minetest.get_locale()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -790,6 +790,8 @@ minetest.get_worldpath() -> eg. "/home/user/.minetest/world"
 ^ Useful for storing custom data
 minetest.is_singleplayer()
 
+minetest.get_locale()
+^ Returns LC_MESSAGES locale, returns "C" if Gettext disabled
 minetest.debug(line)
 ^ Always printed to stderr and logfile (print() is redirected here)
 minetest.log(line)

--- a/src/scriptapi.cpp
+++ b/src/scriptapi.cpp
@@ -5151,6 +5151,14 @@ static int l_get_worldpath(lua_State *L)
 	return 1;
 }
 
+// get_locale()
+static int l_get_locale(lua_State *L)
+{
+	char* l = setlocale(LC_MESSAGES, NULL);
+	lua_pushstring(L, l);
+	return 1;
+}
+
 // sound_play(spec, parameters)
 static int l_sound_play(lua_State *L)
 {
@@ -5374,6 +5382,7 @@ static const struct luaL_Reg minetest_f [] = {
 	{"get_modpath", l_get_modpath},
 	{"get_modnames", l_get_modnames},
 	{"get_worldpath", l_get_worldpath},
+	{"get_locale", l_get_locale},
 	{"sound_play", l_sound_play},
 	{"sound_stop", l_sound_stop},
 	{"is_singleplayer", l_is_singleplayer},


### PR DESCRIPTION
This allowes lua mods to change the language of strings based on the language of the user.

If Gettext is not enabled, it returns "C".
