### PR TITLE
Don't see through nodes without noclip privileges

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -864,7 +864,7 @@ void ClientMap::renderPostFx()
 	// - If the player is in liquid, draw a semi-transparent overlay.
 	const ContentFeatures& features = nodemgr->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
-	if(features.solidness == 2 && g_settings->getBool("free_move") == false)
+	if(features.solidness == 2 && !(g_settings->getBool("noclip") && m_gamedef->checkLocalPrivilege("noclip")))
 	{
 		post_effect_color = video::SColor(255, 0, 0, 0);
 	}


### PR DESCRIPTION
If you get yourself inside a node and have free_move enabled you will be able to see through the ground without noclip privileges, this commit fixes that.
