### PR TITLE
Allow minetest.after to take a variable number of arguments

### DIFF
--- a/builtin/misc.lua
+++ b/builtin/misc.lua
@@ -14,14 +14,14 @@ minetest.register_globalstep(function(dtime)
 	for index, timer in ipairs(minetest.timers) do
 		timer.time = timer.time - dtime
 		if timer.time <= 0 then
-			timer.func(timer.param)
+			timer.func(unpack(timer.args))
 			table.remove(minetest.timers,index)
 		end
 	end
 end)
 
-function minetest.after(time, func, param)
-	table.insert(minetest.timers_to_add, {time=time, func=func, param=param})
+function minetest.after(time, func, ...)
+	table.insert(minetest.timers_to_add, {time=time, func=func, args=arg})
 end
 
 function minetest.check_player_privs(name, privs)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -969,9 +969,9 @@ minetest.sound_play(spec, parameters) -> handle
 minetest.sound_stop(handle)
 
 Timing:
-minetest.after(time, func, param)
+minetest.after(time, func, ...)
 ^ Call function after time seconds
-^ param is optional; to pass multiple parameters, pass a table.
+^ Optional: Variable number of arguments that are passed to func
 
 Server:
 minetest.request_shutdown() -> request for server shutdown


### PR DESCRIPTION
Example:

``` lua
function foobar(foo, bar)
    print(foo)
    print(bar)
end

minetest.after(2, foobar, "foo", "bar")
```
