### PR TITLE
Allow downloading files/requesting urls from Lua

### DIFF
--- a/builtin/misc.lua
+++ b/builtin/misc.lua
@@ -24,6 +24,25 @@ function minetest.after(time, func, param)
 	table.insert(minetest.timers_to_add, {time=time, func=func, param=param})
 end
 
+if minetest.curl_fetch then --cURL enabled
+	minetest.downloads = {}
+	function minetest.download_http(url, timeout, callback)
+		table.insert(minetest.downloads, {
+			callback = callback,
+			handle = minetest.curl_fetch(url, timeout)
+		})
+	end
+
+	minetest.register_globalstep(function(dtime)
+		for _, download in ipairs(minetest.downloads) do
+			local result, code = minetest.get_curl_fetch_result(download.handle)
+			if code ~= nil then
+				download.callback(result, code)
+			end
+		end
+	end)
+end
+
 function minetest.check_player_privs(name, privs)
 	local player_privs = minetest.get_player_privs(name)
 	local missing_privileges = {}

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1002,6 +1002,11 @@ minetest.deserialize(string) -> table
 ^ Example: deserialize('return { ["foo"] = "bar" }') -> {foo='bar'}
 ^ Example: deserialize('print("foo")') -> nil (function call fails)
   ^ error:[string "print("foo")"]:1: attempt to call global 'print' (a nil value)
+minetest.download_http(url, timeout, function (data, curlcode))
+^ Call url with timeout of timeout seconds
+^ When download is finished, calls function with data from the website and
+^ the CURLcode (0 is success)
+^ Only available if server was built with cURL
 
 Global objects:
 minetest.env - EnvRef of the server environment and world.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -328,16 +328,6 @@ if(BUILD_CLIENT)
 		${PLATFORM_LIBS}
 		${CLIENT_PLATFORM_LIBS}
 	)
-
-	if(USE_CURL)
-		target_link_libraries(
-			${PROJECT_NAME}
-			${CURL_LIBRARY}
-		)
-		include_directories(
-			${CURL_INCLUDE_DIR}
-		)
-	endif(USE_CURL)
 endif(BUILD_CLIENT)
 
 if(BUILD_SERVER)
@@ -351,6 +341,20 @@ if(BUILD_SERVER)
 		${PLATFORM_LIBS}
 	)
 endif(BUILD_SERVER)
+
+if(USE_CURL)
+	target_link_libraries(
+		${PROJECT_NAME}
+		${CURL_LIBRARY}
+	)
+	target_link_libraries(
+		${PROJECT_NAME}server
+		${CURL_LIBRARY}
+	)
+	include_directories(
+		${CURL_INCLUDE_DIR}
+	)
+endif(USE_CURL)
 
 #
 # Set some optimizations and tweaks


### PR DESCRIPTION
<h4>Example</h4>

``` Lua
    on_punch = function (pos, node)
        minetest.download_http("mesecons.net", 10, function (result, code)
            print(result)
            print(code)
        end)
    end
```

<h4>Use cases</h4>
- Tell user when update for a mod is available
- Share creations with others (Buildings, mesecons microcontroller code snippets)
- Interaction with other servers (Inter-Server Chat, Inter-Server Trade)
- Interface to Real-Life devices (e.g. Mod that notifys server owners e.g. by email or sms)
- There are propably more cases you can think of

<h4>How it works</h4>

Downloads/Calls are all in seperate threads (CurlFetchThread : SimpleThread)
The lua function minetest.curl_fetch(url, timeout) starts a thread and returns a handle.
The handle can be used in data, curlcode = minetest.get_curl_fetch_result(handle)
Returns nil if not finished or data from website and curlcode if succesful.
The function minetest.download_http(url, timeout, callbackfunction) defined in builtin/misc.lua defines a callback-like interface to be used by mods, by polling the status of the current downloads.
For some reason the timeout doesn't seem to work on all setups, but as downloads are in a seperate thread anyway, that doesn't really matter anyway.

<h4>Security</h4>

Being able to send stuff across the internet likely sounds like a vulnerability. I propose to merge sapier's pull request concerning the safe file opening API, so that mods cannot remotely modify the server's computer. Additionaly, when accessing curl, the server will output something like

```
20:01:32: ACTION[ServerThread]: WARNING: A mod accesses URL 'example.org'. Remove it if you don't trust that site.
```
