### PR TITLE
Dont drop tools on rightclick

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -243,9 +243,8 @@ function minetest.item_place(itemstack, placer, pointed_thing)
 
 	if itemstack:get_definition().type == "node" then
 		return minetest.item_place_node(itemstack, placer, pointed_thing)
-	elseif itemstack:get_definition().type ~= "none" then
-		return minetest.item_place_object(itemstack, placer, pointed_thing)
 	end
+	return itemstack
 end
 
 function minetest.item_drop(itemstack, dropper, pos)


### PR DESCRIPTION
This irritates many players. Especially buckets are a problem, because MC players tend to try rightclick first.
And we still have Q to drop things.
