### PR TITLE
Change EditBox behaviour

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -1389,12 +1389,16 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		}
 		if(event.GUIEvent.EventType==gui::EGET_EDITBOX_ENTER)
 		{
-			if(event.GUIEvent.Caller->getID() > 257)
+			for(u32 i=0; i<m_fields.size(); i++)
 			{
-				acceptInput();
-				quitMenu();
-				// quitMenu deallocates menu
-				return true;
+				FieldSpec &s = m_fields[i];
+				if(s.fid == event.GUIEvent.Caller->getID())
+				{
+					s.send = true;
+					acceptInput();
+					Environment->setFocus(this);
+					return true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Change EditBox when hit Enter to send data and not exiting formspec, just loose focus.
When no object is focused, Enter will close formspec.
