### PR TITLE
Diagonal Rail

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -165,6 +165,363 @@ void makeCuboid(MeshCollector *collector, const aabb3f &box,
 	}
 }
 
+class neighborRail {
+	public:
+		bool is_rail_x_all[2];
+		bool is_rail_z_all[2];
+		int adjacencies;
+		bool is_straight;
+		bool force_end;
+}; neighborRail recurseRail(v3s16 p, MeshMakeData *data, MeshCollector &collector, int recurse = 0)
+{
+	INodeDefManager *nodedef = data->m_gamedef->ndef();
+	v3s16 blockpos_nodes = data->m_blockpos*MAP_BLOCKSIZE;
+	s16 x = p.X, y = p.Y, z = p.Z;
+	MapNode n = data->m_vmanip.getNodeNoEx(blockpos_nodes+p);
+	const ContentFeatures &f = nodedef->get(n);
+
+	bool is_rail_x [] = { false, false };  /* x-1, x+1 */
+	bool is_rail_z [] = { false, false };  /* z-1, z+1 */
+
+	bool is_rail_z_minus_y [] = { false, false };  /* z-1, z+1; y-1 */
+	bool is_rail_x_minus_y [] = { false, false };  /* x-1, z+1; y-1 */
+	bool is_rail_z_plus_y [] = { false, false };  /* z-1, z+1; y+1 */
+	bool is_rail_x_plus_y [] = { false, false };  /* x-1, x+1; y+1 */
+
+	MapNode n_minus_x = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1,y,z));
+	MapNode n_plus_x = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1,y,z));
+	MapNode n_minus_z = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x,y,z-1));
+	MapNode n_plus_z = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x,y,z+1));
+	MapNode n_plus_x_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1, y+1, z));
+	MapNode n_plus_x_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1, y-1, z));
+	MapNode n_minus_x_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1, y+1, z));
+	MapNode n_minus_x_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1, y-1, z));
+	MapNode n_plus_z_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y+1, z+1));
+	MapNode n_minus_z_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y+1, z-1));
+	MapNode n_plus_z_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y-1, z+1));
+	MapNode n_minus_z_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y-1, z-1));
+
+	content_t thiscontent = n.getContent();
+	std::string groupname = "connect_to_raillike"; // name of the group that enables connecting to raillike nodes of different kind
+	bool self_connect_to_raillike = ((ItemGroupList) nodedef->get(n).groups)[groupname] != 0;
+	
+	if ((nodedef->get(n_minus_x).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_x).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_x.getContent() == thiscontent)
+		is_rail_x[0] = true;
+
+	if ((nodedef->get(n_minus_x_minus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_x_minus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_x_minus_y.getContent() == thiscontent)
+		is_rail_x_minus_y[0] = true;
+
+	if ((nodedef->get(n_minus_x_plus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_x_plus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_x_plus_y.getContent() == thiscontent)
+		is_rail_x_plus_y[0] = true;
+
+	if ((nodedef->get(n_plus_x).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_x).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_x.getContent() == thiscontent)
+		is_rail_x[1] = true;
+
+	if ((nodedef->get(n_plus_x_minus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_x_minus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_x_minus_y.getContent() == thiscontent)
+		is_rail_x_minus_y[1] = true;
+
+	if ((nodedef->get(n_plus_x_plus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_x_plus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_x_plus_y.getContent() == thiscontent)
+		is_rail_x_plus_y[1] = true;
+
+	if ((nodedef->get(n_minus_z).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_z).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_z.getContent() == thiscontent)
+		is_rail_z[0] = true;
+
+	if ((nodedef->get(n_minus_z_minus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_z_minus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_z_minus_y.getContent() == thiscontent)
+		is_rail_z_minus_y[0] = true;
+
+	if ((nodedef->get(n_minus_z_plus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_minus_z_plus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_minus_z_plus_y.getContent() == thiscontent)
+		is_rail_z_plus_y[0] = true;
+
+	if ((nodedef->get(n_plus_z).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_z).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_z.getContent() == thiscontent)
+		is_rail_z[1] = true;
+
+	if ((nodedef->get(n_plus_z_minus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_z_minus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_z_minus_y.getContent() == thiscontent)
+		is_rail_z_minus_y[1] = true;
+
+	if ((nodedef->get(n_plus_z_plus_y).drawtype == NDT_RAILLIKE
+			&& ((ItemGroupList) nodedef->get(n_plus_z_plus_y).groups)[groupname] != 0
+			&& self_connect_to_raillike)
+			|| n_plus_z_plus_y.getContent() == thiscontent)
+		is_rail_z_plus_y[1] = true;
+
+	bool is_rail_x_all[] = {false, false};
+	bool is_rail_z_all[] = {false, false};
+	is_rail_x_all[0]=is_rail_x[0] || is_rail_x_minus_y[0] || is_rail_x_plus_y[0];
+	is_rail_x_all[1]=is_rail_x[1] || is_rail_x_minus_y[1] || is_rail_x_plus_y[1];
+	is_rail_z_all[0]=is_rail_z[0] || is_rail_z_minus_y[0] || is_rail_z_plus_y[0];
+	is_rail_z_all[1]=is_rail_z[1] || is_rail_z_minus_y[1] || is_rail_z_plus_y[1];
+
+	// reasonable default, flat straight unrotated rail
+	bool is_straight = true;
+	int adjacencies = 0;
+	int angle = 0;
+	u8 tileindex = 0;
+
+	// check for sloped rail
+	if (is_rail_x_plus_y[0] || is_rail_x_plus_y[1] || is_rail_z_plus_y[0] || is_rail_z_plus_y[1])
+	{
+		adjacencies = 5; //5 means sloped
+		is_straight = true; // sloped is always straight
+	}
+	else
+	{
+		// is really straight, rails on both sides
+		is_straight = (is_rail_x_all[0] && is_rail_x_all[1]) || (is_rail_z_all[0] && is_rail_z_all[1]);
+		adjacencies = is_rail_x_all[0] + is_rail_x_all[1] + is_rail_z_all[0] + is_rail_z_all[1];
+	}
+
+	bool diagonalflip = false, force_end = false;
+
+	neighborRail self;
+	memcpy(self.is_rail_x_all,is_rail_x_all, sizeof(bool[2]));
+	memcpy(self.is_rail_z_all,is_rail_z_all, sizeof(bool[2]));
+	self.adjacencies = adjacencies;
+	self.is_straight = is_straight;
+	self.force_end = force_end;
+	if (recurse >= 2)
+		return self;
+
+	neighborRail neighbor_x_all[2], neighbor_z_all[2];
+	if(is_rail_x_all[0]) {
+		if(is_rail_x_plus_y[0]) {
+			neighbor_x_all[0] = recurseRail(v3s16(x-1, y+1, z), data, collector, recurse+1);
+		} else if (is_rail_x[0]) {
+			neighbor_x_all[0] = recurseRail(v3s16(x-1, y  , z), data, collector, recurse+1);
+		} else { //if (is_rail_x_minus_y[0]) {
+			neighbor_x_all[0] = recurseRail(v3s16(x-1, y-1, z), data, collector, recurse+1);
+		}
+	}
+	if(is_rail_x_all[1]) {
+		if(is_rail_x_plus_y[1]) {
+			neighbor_x_all[1] = recurseRail(v3s16(x+1, y+1, z), data, collector, recurse+1);
+		} else if (is_rail_x[1]) {
+			neighbor_x_all[1] = recurseRail(v3s16(x+1, y  , z), data, collector, recurse+1);
+		} else { //if (is_rail_x_minus_y[1]) {
+			neighbor_x_all[1] = recurseRail(v3s16(x+1, y-1, z), data, collector, recurse+1);
+		}
+	}
+	if(is_rail_z_all[0]) {
+		if(is_rail_z_plus_y[0]) {
+			neighbor_z_all[0] = recurseRail(v3s16(x, y+1, z-1), data, collector, recurse+1);
+		} else if (is_rail_z[0]) {
+			neighbor_z_all[0] = recurseRail(v3s16(x, y  , z-1), data, collector, recurse+1);
+		} else { //if (is_rail_z_minus_y[0]) {
+			neighbor_z_all[0] = recurseRail(v3s16(x, y-1, z-1), data, collector, recurse+1);
+		}
+	}
+	if(is_rail_z_all[1]) {
+		if(is_rail_z_plus_y[1]) {
+			neighbor_z_all[1] = recurseRail(v3s16(x, y+1, z+1), data, collector, recurse+1);
+		} else if (is_rail_z[1]) {
+			neighbor_z_all[1] = recurseRail(v3s16(x, y  , z+1), data, collector, recurse+1);
+		} else { //if (is_rail_z_minus_y[1]) {
+			neighbor_z_all[1] = recurseRail(v3s16(x, y-1, z+1), data, collector, recurse+1);
+		}
+	}
+
+	bool is_corner_x_all[2], is_corner_z_all[2];
+	is_corner_x_all[0] = is_rail_x_all[0] && neighbor_x_all[0].adjacencies == 2 && !neighbor_x_all[0].is_straight;
+	is_corner_x_all[1] = is_rail_x_all[1] && neighbor_x_all[1].adjacencies == 2 && !neighbor_x_all[1].is_straight;
+	is_corner_z_all[0] = is_rail_z_all[0] && neighbor_z_all[0].adjacencies == 2 && !neighbor_z_all[0].is_straight;
+	is_corner_z_all[1] = is_rail_z_all[1] && neighbor_z_all[1].adjacencies == 2 && !neighbor_z_all[1].is_straight;
+
+	switch (adjacencies) {
+	case 1: //straight
+		tileindex = 5; //diagonal rail end
+		       if(is_corner_z_all[0] && neighbor_z_all[0].force_end) {
+			//angle = 0;
+		    if(neighbor_z_all[0].is_rail_x_all[1]) {
+		    	angle -= 90;
+		    	diagonalflip = true;
+		    }
+		} else if(is_corner_x_all[0] && neighbor_x_all[0].force_end) {
+			angle = -90;
+			if(neighbor_x_all[0].is_rail_z_all[0]) {
+				angle -= 90;
+				diagonalflip = true;
+			}
+		} else if(is_corner_z_all[1] && neighbor_z_all[1].force_end) {
+			angle = -180;
+			if(neighbor_z_all[1].is_rail_x_all[0]) {
+				angle -= 90;
+				diagonalflip = true;
+			}
+		} else if(is_corner_x_all[1] && neighbor_x_all[1].force_end) {
+			angle = -270;
+			if(neighbor_x_all[1].is_rail_z_all[1]) {
+				angle -= 90;
+				diagonalflip = true;
+			}
+		} else {
+			tileindex = 0; //straight
+			if(is_rail_x_all[0] || is_rail_x_all[1])
+				angle = 90;
+		}
+		break;
+	case 2:
+		if(!is_straight) {
+			tileindex = 1; //curved
+			//attempt diagonal
+			if (
+					(is_rail_x_all[0] && (
+							(is_corner_z_all[0] && neighbor_z_all[0].is_rail_x_all[1]) ||
+							(is_corner_z_all[1] && neighbor_z_all[1].is_rail_x_all[1])
+					)) ||
+					(is_rail_x_all[1] && (
+							(is_corner_z_all[0] && neighbor_z_all[0].is_rail_x_all[0]) ||
+							(is_corner_z_all[1] && neighbor_z_all[1].is_rail_x_all[0])
+					)) ||
+					(is_rail_z_all[0] && (
+							(is_corner_x_all[0] && neighbor_x_all[0].is_rail_z_all[1]) ||
+							(is_corner_x_all[1] && neighbor_x_all[1].is_rail_z_all[1])
+					)) ||
+					(is_rail_z_all[1] && (
+							(is_corner_x_all[0] && neighbor_x_all[0].is_rail_z_all[0]) ||
+							(is_corner_x_all[1] && neighbor_x_all[1].is_rail_z_all[0])
+					))
+			) { //at least one adjacent corner, not a U-turn
+				tileindex = 4; //diagonal (middle)
+				if((is_corner_x_all[0] || is_corner_x_all[1]) && (is_corner_z_all[0] || is_corner_z_all[1])) {
+					//keep middle diagonal
+				} else { //diagonal end/start/force_end
+					if(
+							(is_rail_x_all[0] && neighbor_x_all[0].adjacencies == 1) ||
+							(is_rail_x_all[1] && neighbor_x_all[1].adjacencies == 1) ||
+							(is_rail_z_all[0] && neighbor_z_all[0].adjacencies == 1) ||
+							(is_rail_z_all[1] && neighbor_z_all[1].adjacencies == 1)
+					) {
+						//Rail end is the new end, keep middle diagonal.
+						force_end = true;
+					} else {
+						tileindex = 5; //diagonal end (or start)
+						if(
+								((is_rail_z_all[0] && !is_corner_z_all[0]) && (is_rail_x_all[1] && is_corner_x_all[1])) ||
+								((is_rail_x_all[0] && !is_corner_x_all[0]) && (is_rail_z_all[0] && is_corner_z_all[0])) ||
+								((is_rail_z_all[1] && !is_corner_z_all[1]) && (is_rail_x_all[0] && is_corner_x_all[0])) ||
+								((is_rail_x_all[1] && !is_corner_x_all[1]) && (is_rail_z_all[1] && is_corner_z_all[1]))
+						) {
+							diagonalflip = true; //diagonal start
+						}
+					}
+				}
+			}
+		}
+		if(is_rail_x_all[0] && is_rail_x_all[1])
+			angle = 90;
+		if(is_rail_z_all[0] && is_rail_z_all[1]){
+			if (is_rail_z_plus_y[0])
+				angle = 180;
+		}
+		else if(is_rail_x_all[0] && is_rail_z_all[0])
+			angle = 270;
+		else if(is_rail_x_all[0] && is_rail_z_all[1])
+			angle = 180;
+		else if(is_rail_x_all[1] && is_rail_z_all[1])
+			angle = 90;
+		break;
+	case 3:
+		// here is where the potential to 'switch' a junction is, but not implemented at present
+		tileindex = 2; // t-junction
+		if(!is_rail_x_all[1])
+			angle=180;
+		if(!is_rail_z_all[0])
+			angle=90;
+		if(!is_rail_z_all[1])
+			angle=270;
+		break;
+	case 4:
+		tileindex = 3; // crossing
+		break;
+	case 5: //sloped
+		if(is_rail_z_plus_y[0])
+			angle = 180;
+		if(is_rail_x_plus_y[0])
+			angle = 90;
+		if(is_rail_x_plus_y[1])
+			angle = -90;
+		break;
+	default:
+		break;
+	}
+
+	self.force_end = force_end;
+	if (recurse >= 1)
+		return self;
+
+	TileSpec tile = getNodeTileN(n, p, tileindex, data);
+	tile.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
+	tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
+
+	u16 l = getInteriorLight(n, 0, data);
+	video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
+
+	float d = (float)BS/64;
+	
+	char g=-1;
+	if (is_rail_x_plus_y[0] || is_rail_x_plus_y[1] || is_rail_z_plus_y[0] || is_rail_z_plus_y[1])
+		g=1; //Object is at a slope
+
+	video::S3DVertex vertices[4] =
+	{
+		video::S3DVertex(-BS/2,-BS/2+d,-BS/2, 0,0,0, c, 0,1),
+		video::S3DVertex(BS/2,-BS/2+d,-BS/2, 0,0,0, c, 1,1),
+		video::S3DVertex(BS/2,g*BS/2+d,BS/2, 0,0,0, c, 1,0),
+		video::S3DVertex(-BS/2,g*BS/2+d,BS/2, 0,0,0, c, 0,0),
+	};
+
+	for(s32 i=0; i<4; i++)
+	{
+		if(diagonalflip) {
+			//swap -x,-z with +x,+z
+			vertices[i].Pos.rotateXZBy(90);
+			vertices[i].Pos.Z = -vertices[i].Pos.Z;
+		}
+		if(angle != 0)
+			vertices[i].Pos.rotateXZBy(angle);
+		vertices[i].Pos += intToFloat(p, BS);
+	}
+
+	u16 indices[] = {0,1,2,2,3,0};
+
+	collector.append(tile, vertices, 4, indices, 6);
+
+	//required return, not used.
+	return self;
+}
+
 void mapblock_mesh_generate_special(MeshMakeData *data,
 		MeshCollector &collector)
 {
@@ -1115,205 +1472,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 		break;}
 		case NDT_RAILLIKE:
 		{
-			bool is_rail_x [] = { false, false };  /* x-1, x+1 */
-			bool is_rail_z [] = { false, false };  /* z-1, z+1 */
-
-			bool is_rail_z_minus_y [] = { false, false };  /* z-1, z+1; y-1 */
-			bool is_rail_x_minus_y [] = { false, false };  /* x-1, z+1; y-1 */
-			bool is_rail_z_plus_y [] = { false, false };  /* z-1, z+1; y+1 */
-			bool is_rail_x_plus_y [] = { false, false };  /* x-1, x+1; y+1 */
-
-			MapNode n_minus_x = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1,y,z));
-			MapNode n_plus_x = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1,y,z));
-			MapNode n_minus_z = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x,y,z-1));
-			MapNode n_plus_z = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x,y,z+1));
-			MapNode n_plus_x_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1, y+1, z));
-			MapNode n_plus_x_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x+1, y-1, z));
-			MapNode n_minus_x_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1, y+1, z));
-			MapNode n_minus_x_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x-1, y-1, z));
-			MapNode n_plus_z_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y+1, z+1));
-			MapNode n_minus_z_plus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y+1, z-1));
-			MapNode n_plus_z_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y-1, z+1));
-			MapNode n_minus_z_minus_y = data->m_vmanip.getNodeNoEx(blockpos_nodes + v3s16(x, y-1, z-1));
-
-			content_t thiscontent = n.getContent();
-			std::string groupname = "connect_to_raillike"; // name of the group that enables connecting to raillike nodes of different kind
-			bool self_connect_to_raillike = ((ItemGroupList) nodedef->get(n).groups)[groupname] != 0;
-
-			if ((nodedef->get(n_minus_x).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_x).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_x.getContent() == thiscontent)
-				is_rail_x[0] = true;
-
-			if ((nodedef->get(n_minus_x_minus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_x_minus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_x_minus_y.getContent() == thiscontent)
-				is_rail_x_minus_y[0] = true;
-
-			if ((nodedef->get(n_minus_x_plus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_x_plus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_x_plus_y.getContent() == thiscontent)
-				is_rail_x_plus_y[0] = true;
-
-			if ((nodedef->get(n_plus_x).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_x).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_x.getContent() == thiscontent)
-				is_rail_x[1] = true;
-
-			if ((nodedef->get(n_plus_x_minus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_x_minus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_x_minus_y.getContent() == thiscontent)
-				is_rail_x_minus_y[1] = true;
-
-			if ((nodedef->get(n_plus_x_plus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_x_plus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_x_plus_y.getContent() == thiscontent)
-				is_rail_x_plus_y[1] = true;
-
-			if ((nodedef->get(n_minus_z).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_z).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_z.getContent() == thiscontent)
-				is_rail_z[0] = true;
-
-			if ((nodedef->get(n_minus_z_minus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_z_minus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_z_minus_y.getContent() == thiscontent)
-				is_rail_z_minus_y[0] = true;
-
-			if ((nodedef->get(n_minus_z_plus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_minus_z_plus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_minus_z_plus_y.getContent() == thiscontent)
-				is_rail_z_plus_y[0] = true;
-
-			if ((nodedef->get(n_plus_z).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_z).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_z.getContent() == thiscontent)
-				is_rail_z[1] = true;
-
-			if ((nodedef->get(n_plus_z_minus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_z_minus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_z_minus_y.getContent() == thiscontent)
-				is_rail_z_minus_y[1] = true;
-
-			if ((nodedef->get(n_plus_z_plus_y).drawtype == NDT_RAILLIKE
-					&& ((ItemGroupList) nodedef->get(n_plus_z_plus_y).groups)[groupname] != 0
-					&& self_connect_to_raillike)
-					|| n_plus_z_plus_y.getContent() == thiscontent)
-				is_rail_z_plus_y[1] = true;
-
-			bool is_rail_x_all[] = {false, false};
-			bool is_rail_z_all[] = {false, false};
-			is_rail_x_all[0]=is_rail_x[0] || is_rail_x_minus_y[0] || is_rail_x_plus_y[0];
-			is_rail_x_all[1]=is_rail_x[1] || is_rail_x_minus_y[1] || is_rail_x_plus_y[1];
-			is_rail_z_all[0]=is_rail_z[0] || is_rail_z_minus_y[0] || is_rail_z_plus_y[0];
-			is_rail_z_all[1]=is_rail_z[1] || is_rail_z_minus_y[1] || is_rail_z_plus_y[1];
-
-			// reasonable default, flat straight unrotated rail
-			bool is_straight = true;
-			int adjacencies = 0;
-			int angle = 0;
-			u8 tileindex = 0;
-
-			// check for sloped rail
-			if (is_rail_x_plus_y[0] || is_rail_x_plus_y[1] || is_rail_z_plus_y[0] || is_rail_z_plus_y[1])
-			{
-				adjacencies = 5; //5 means sloped
-				is_straight = true; // sloped is always straight
-			}
-			else
-			{
-				// is really straight, rails on both sides
-				is_straight = (is_rail_x_all[0] && is_rail_x_all[1]) || (is_rail_z_all[0] && is_rail_z_all[1]);
-				adjacencies = is_rail_x_all[0] + is_rail_x_all[1] + is_rail_z_all[0] + is_rail_z_all[1];
-			}
-
-			switch (adjacencies) {
-			case 1:
-				if(is_rail_x_all[0] || is_rail_x_all[1])
-					angle = 90;
-				break;
-			case 2:
-				if(!is_straight)
-					tileindex = 1; // curved
-				if(is_rail_x_all[0] && is_rail_x_all[1])
-					angle = 90;
-				if(is_rail_z_all[0] && is_rail_z_all[1]){
-					if (is_rail_z_plus_y[0])
-						angle = 180;
-				}
-				else if(is_rail_x_all[0] && is_rail_z_all[0])
-					angle = 270;
-				else if(is_rail_x_all[0] && is_rail_z_all[1])
-					angle = 180;
-				else if(is_rail_x_all[1] && is_rail_z_all[1])
-					angle = 90;
-				break;
-			case 3:
-				// here is where the potential to 'switch' a junction is, but not implemented at present
-				tileindex = 2; // t-junction
-				if(!is_rail_x_all[1])
-					angle=180;
-				if(!is_rail_z_all[0])
-					angle=90;
-				if(!is_rail_z_all[1])
-					angle=270;
-				break;
-			case 4:
-				tileindex = 3; // crossing
-				break;
-			case 5: //sloped
-				if(is_rail_z_plus_y[0])
-					angle = 180;
-				if(is_rail_x_plus_y[0])
-					angle = 90;
-				if(is_rail_x_plus_y[1])
-					angle = -90;
-				break;
-			default:
-				break;
-			}
-
-			TileSpec tile = getNodeTileN(n, p, tileindex, data);
-			tile.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
-			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
-
-			u16 l = getInteriorLight(n, 0, data);
-			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
-
-			float d = (float)BS/64;
-			
-			char g=-1;
-			if (is_rail_x_plus_y[0] || is_rail_x_plus_y[1] || is_rail_z_plus_y[0] || is_rail_z_plus_y[1])
-				g=1; //Object is at a slope
-
-			video::S3DVertex vertices[4] =
-			{
-					video::S3DVertex(-BS/2,-BS/2+d,-BS/2, 0,0,0, c, 0,1),
-					video::S3DVertex(BS/2,-BS/2+d,-BS/2, 0,0,0, c, 1,1),
-					video::S3DVertex(BS/2,g*BS/2+d,BS/2, 0,0,0, c, 1,0),
-					video::S3DVertex(-BS/2,g*BS/2+d,BS/2, 0,0,0, c, 0,0),
-			};
-
-			for(s32 i=0; i<4; i++)
-			{
-				if(angle != 0)
-					vertices[i].Pos.rotateXZBy(angle);
-				vertices[i].Pos += intToFloat(p, BS);
-			}
-
-			u16 indices[] = {0,1,2,2,3,0};
-			collector.append(tile, vertices, 4, indices, 6);
+			recurseRail(p, data, collector);
 		break;}
 		case NDT_NODEBOX:
 		{


### PR DESCRIPTION
## Abstract

This self-referencing pull request adds diagonal rails.
## Proof of Concept

![minetestdiagonalrail8](https://f.cloud.github.com/assets/1996449/226181/69c78826-861f-11e2-8edd-21c295b12fa2.png)
[Gif](https://f.cloud.github.com/assets/1996449/226179/698502bc-861f-11e2-96fd-941008bb496c.gif)
![minetestdiagonalrail9](https://f.cloud.github.com/assets/1996449/226180/69c593e0-861f-11e2-9a62-f73643ba5dc0.png)
## Images

They are just the same as regular rail except that they use two more images:

```
-       tiles = {"default_rail.png", "default_rail_curved.png", "default_rail_t_junction.png", "default_rail_crossing.png"},
+       tiles = {"default_rail.png", "default_rail_curved.png", "default_rail_t_junction.png", "default_rail_crossing.png", "default_rail_diagonal.png", "default_rail_diagonal_end.png"},
```

If this commit is used without the supplementary images, diagonals will appear as crossings. That is why I include child pull requests in three places [see Merging]
End diagonals aren't simply rotated to turn left like curves/diagonals are, they must be flipped so the end is on the other side.
If you use raillike nodes for roofing, this probably won't affect you, unless you use unusual non-rectangular roofing.
## Pseudo-rules

A curve will turn diagonal if there are two or more curves in the same diagonal direction (no U-turns)
A rail will end diagonal if it is between a diagonal and a non-curve – unless it is next to the end of the line, in which case _that_ will end diagonal (so non-curve includes non-rail)
Height differences don't apply, as they always create straight rail.
## Intersections

There are no diagonal intersections. To do this, one would first have know how to keep two adjacent rail lines from intersecting. They aren't needed at this time.
## How it works

It (a rail) reads its neighbors to know how many adjacencies there are, then based on that decides its image. Diagonals are based on more than just the immediate neighbors, so a recursive function is used. The top-level recursion is for a rail, and has its neighbors. The middle level gets its neighbors' neighbors. Using the neighbors' neighbors, a rail can decide if its neighbor is indeed curved, and become diagonal (as its neighbor does the same when the top-level function gets called at that position). But it goes one level further; there are three levels of recursion. The very end of a diagonal rail line (1) needs to know that its neighbor (2) is curved, and that _its_ neighbor (3) is also curved (so it (1) knows that its neighbor (2) would've been an end diagonal had it (1) not been the end of a line). That is the end of the recursion.
## Merging

May not automatically merge with [connect_to_raillike](https://github.com/minetest/minetest/pull/473) but will merge manually (this moves the code it changes)
Merge around the same time as these child pull requests: [minetest_game](https://github.com/minetest/minetest_game/pull/135), [carts](https://github.com/PilzAdam/carts/pull/8), [moreores](https://github.com/khonkhortisan/calinou_mods/pull/1)
## Problems

1) Occasionally a rail will appear straight after restarting my singleplayer game. Tapping the node makes it behave. I do not believe my code is part of this problem.
2) Coding style. If you see something you would like me to change, tell me (I'll git commit --amend; git push --force)
3) Usefulness. This is a graphical change. If you use rails, this will make them prettier, but any potential train/cart-like vehicles that travel along them may (will) still zig-zag as if there are left/right alternating curves. The visual appearance of a straight diagonal rail line may encourage a vehicle designer to let the vehicle travel diagonally, using the same rules in lua form.
4) I didn't care to look whether this was a client or server change.
