### PR TITLE
use place_node instead of add_node

### DIFF
--- a/builtin/falling.lua
+++ b/builtin/falling.lua
@@ -78,7 +78,7 @@ minetest.register_entity("__builtin:falling_node", {
 				end
 			end
 			-- Create node and remove entity
-			minetest.env:add_node(np, {name=self.nodename})
+			minetest.env:place_node(np, {name=self.nodename})
 			self.object:remove()
 		else
 			-- Do nothing


### PR DESCRIPTION
So nodes get placed correctly. Fixes bug when falling nodes are wallmounted or torchlike.
Only merge when #537 is merged.
