### PR TITLE
Support game-specific minetest.conf

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -57,6 +57,9 @@ eg.
 
 Common mods are loaded from the pseudo-game "common".
 
+The game directory can contain the file minetest.conf, which will be used
+to set default settings when running the particular game.
+
 Mod load path
 -------------
 Generic:

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -243,3 +243,12 @@ void set_default_settings(Settings *settings)
 
 }
 
+void override_default_settings(Settings *settings, Settings *from)
+{
+	std::vector<std::string> names = from->getNames();
+	for(size_t i=0; i<names.size(); i++){
+		const std::string &name = names[i];
+		settings->setDefault(name, from->get(name));
+	}
+}
+

--- a/src/defaultsettings.h
+++ b/src/defaultsettings.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class Settings;
 
 void set_default_settings(Settings *settings);
+void override_default_settings(Settings *settings, Settings *from);
 
 #endif
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -58,6 +58,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/mathconstants.h"
 #include "rollback.h"
 #include "util/serialize.h"
+#include "defaultsettings.h"
 
 void * ServerThread::Thread()
 {
@@ -686,6 +687,13 @@ Server::Server(
 	infostream<<"- world:  "<<m_path_world<<std::endl;
 	infostream<<"- config: "<<m_path_config<<std::endl;
 	infostream<<"- game:   "<<m_gamespec.path<<std::endl;
+
+	// Initialize default settings and override defaults with those provided
+	// by the game
+	set_default_settings(g_settings);
+	Settings gamedefaults;
+	getGameMinetestConfig(gamespec.path, gamedefaults);
+	override_default_settings(g_settings, &gamedefaults);
 
 	// Create biome definition manager
 	m_biomedef = new BiomeDefManager(this);

--- a/src/subgame.cpp
+++ b/src/subgame.cpp
@@ -24,6 +24,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "util/string.h"
 
+bool getGameMinetestConfig(const std::string &game_path, Settings &conf)
+{
+	std::string conf_path = game_path + DIR_DELIM + "minetest.conf";
+	return conf.readConfigFile(conf_path.c_str());
+}
+
 bool getGameConfig(const std::string &game_path, Settings &conf)
 {
 	std::string conf_path = game_path + DIR_DELIM + "game.conf";

--- a/src/subgame.h
+++ b/src/subgame.h
@@ -54,6 +54,9 @@ struct SubgameSpec
 	}
 };
 
+// minetest.conf
+bool getGameMinetestConfig(const std::string &game_path, Settings &conf);
+// game.conf
 bool getGameConfig(const std::string &game_path, Settings &conf);
 
 std::string getGameName(const std::string &game_path);


### PR DESCRIPTION
This can be used to make a game have it's own default settings. Settings from this file will never be saved to persistent user configuration. Useful for eg. setting map generator and player physics parameters while there isn't a better interface for those.
