### PR TITLE
Minor changes to build minetest on VS 11.0 

### DIFF
--- a/src/guiMainMenu.cpp
+++ b/src/guiMainMenu.cpp
@@ -43,6 +43,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "subgame.h"
 
 #define ARRAYLEN(x) (sizeof(x) / sizeof((x)[0]))
+#define LSTRING(x) LSTRING_(x)
+#define LSTRING_(x) L##x
 
 const wchar_t *contrib_core_strs[] = {
 	L"Perttu Ahola (celeron55) <celeron55@gmail.com>",
@@ -748,7 +750,7 @@ void GUIMainMenu::regenerateGui(v2u32 screensize)
 			core::rect<s32> rect(0, 0, 130, 70);
 			rect += m_topleft_client + v2s32(35, 160);
 			Environment->addStaticText(
-				L"Minetest " VERSION_STRING "\nhttp://minetest.net/",
+				L"Minetest " LSTRING(VERSION_STRING) L"\nhttp://minetest.net/",
 				 rect, false, true, this, -1);
 		}
 		{

--- a/src/map.h
+++ b/src/map.h
@@ -50,7 +50,7 @@ class NodeMetadata;
 class IGameDef;
 class IRollbackReportSink;
 class EmergeManager;
-class BlockMakeData;
+struct BlockMakeData;
 
 
 /*

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -45,7 +45,7 @@ class MapBlock;
 class ManualMapVoxelManipulator;
 class VoxelManipulator;
 class INodeDefManager;
-class BlockMakeData;
+struct BlockMakeData;
 class VoxelArea;
 
 struct MapgenParams {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -73,7 +73,7 @@ public:
 			else{
 				/* No add shall have been used */
 				assert(n->second != -2);
-				n->second = std::max(n->second, 0) + 1;
+				n->second = (std::max)(n->second, 0) + 1;
 			}
 		}
 		{


### PR DESCRIPTION
Hi,
While building mineTest on Visual Studio, I encountered a couple of minor problems that I attempted to fix in a x-platform manner. I think this might be beneficial enough to be pulled back -- the changes are pretty minor and self explanatory in themselves.
Here's the change description:
Set of changes to build mineTest using Visual Studio 11.0. These affect the following:
1. String concatenation in guiMainMenu.cpp - it is required for all
individual strings to be of the same type <unicode/non-unicode>; adding
explicit L qualifier before the other strings.
2. Correcting type of BlockMakeData to struct in place of class forward
declarations. This information is used for name decoration by Visual
Studio, leading to linker errors in case of mismatches.
3. Windows headers define max as a macro somewhere, leading to a compile
time error in profiler.h; using () around function to prevent macro match
from occurring.
