### PR TITLE
Fix locales not being loaded when RUN_IN_PLACE=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ elseif(UNIX) # Linux, BSD etc
 		set(EXAMPLE_CONF_DIR ${DOCDIR})
 		set(XDG_APPS_DIR "${CMAKE_INSTALL_PREFIX}/share/applications")
 		set(ICONDIR "${CMAKE_INSTALL_PREFIX}/share/icons")
-		set(LOCALEDIR "${CMAKE_INSTALL_PREFIX}/share/locale")
+		set(LOCALEDIR "${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/locale")
 	endif()
 endif()
 


### PR DESCRIPTION
When minetest is installed system-wide (on unix-like systems), locales aren't loaded, the game keeps being in english.
This is because locales are installed to share/locales, and the game tries to load them from share/minetest/locales.

This simple fix just installs them to share/minetest/locales, but you might think it would be better to fix it in source code so they are loaded from share/locales
