### PR TITLE
Fix node replacement in not-quite-loaded chunks

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -134,8 +134,9 @@ function minetest.item_place_node(itemstack, placer, pointed_thing)
 	local oldnode_above = minetest.env:get_node_or_nil(above)
 
 	if not oldnode_under or not oldnode_above then
-		return minetest.log("info", placer:get_player_name() .. " tried to place"
+		minetest.log("info", placer:get_player_name() .. " tried to place"
 			.. " node in unloaded position " .. minetest.pos_to_string(above))
+		return itemstack
 	end
 
 	local olddef_under = ItemStack({name=oldnode_under.name}):get_definition()


### PR DESCRIPTION
When first entering an area, sometimes placing nodes replaces other nodes that are not buildable_to. This seems to be caused by the fact that nodes in unloaded map blocks are treated as ignore, a node that is buildable_to. This fixes that, by using get_node_or_nil() instead of the previously-used get_node(), then checking to see if the nodes were actually loaded before replacing.
