### PR TITLE
Don't test the existence of menu textures every frame

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -618,7 +618,7 @@ void drawMenuBackground(video::IVideoDriver* driver) {
 
 	std::string path = getTexturePath("menubg.png");
 	if (path[0]) {
-		video::ITexture *bgtexture =
+		static const video::ITexture *bgtexture =
 			driver->getTexture(path.c_str());
 
 		if (bgtexture) {
@@ -646,7 +646,7 @@ void drawMenuFooter(video::IVideoDriver* driver, bool clouds) {
 	std::string path = getTexturePath(clouds ?
 						"menufooter_clouds.png" : "menufooter.png");
 	if (path[0]) {
-		video::ITexture *footertexture =
+		static const video::ITexture *footertexture =
 			driver->getTexture(path.c_str());
 
 		if (footertexture) {
@@ -678,7 +678,7 @@ void drawMenuHeader(video::IVideoDriver* driver) {
 
 	std::string path = getTexturePath("menuheader.png");
 	if (path[0]) {
-		video::ITexture *splashtexture =
+		static const video::ITexture *splashtexture =
 		driver->getTexture(path.c_str());
 
 		if(splashtexture) {
@@ -713,7 +713,7 @@ void drawMenuHeader(video::IVideoDriver* driver) {
 void drawMenuSplash(video::IVideoDriver* driver) {
 	core::dimension2d<u32> screensize = driver->getScreenSize();
 	if (getTexturePath("menusplash.png") != "") {
-		video::ITexture *splashtexture =
+		static const video::ITexture *splashtexture =
 			driver->getTexture(getTexturePath("menusplash.png").c_str());
 
 		if(splashtexture) {


### PR DESCRIPTION
test
`strace bin/minetest`
example of one frame
before

```
read(4, 0xa076c4, 4096)                 = -1 EAGAIN (Resource temporarily unavailable)
lstat("/home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle", {st_mode=S_IFDIR|0755, st_size=20480, ...}) = 0
lstat("/home/kyle/src", {st_mode=S_IFDIR|0755, st_size=65536, ...}) = 0
lstat("/home/kyle/src/minetest", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle/src/minetest/bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle/src/minetest/textures", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle/src/minetest/textures/base", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle/src/minetest/textures/base/pack", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/home/kyle/src/minetest/textures/base/pack/menuheader.png", {st_mode=S_IFREG|0644, st_size=578, ...}) = 0
sched_yield()                           = 0
sched_yield()                           = 0
getpid()                                = 26660
clock_gettime(CLOCK_MONOTONIC, {873163, 673204305}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673236521}) = 0
poll([{fd=8, events=POLLIN|POLLPRI}], 1, 1000) = 1 ([{fd=8, revents=POLLIN|POLLPRI}])
ioctl(8, 0xc0104652, 0x7fff91f4af30)    = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673366159}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673400942}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673428661}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673461448}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673493482}) = 0
clock_gettime(CLOCK_MONOTONIC, {873163, 673526042}) = 0
sched_yield()                           = 0
sched_yield()                           = 0
sched_yield()                           = 0
nanosleep({0, 16000000}, NULL)          = 0
```

after

```
read(4, 0xa076c4, 4096)                 = -1 EAGAIN (Resource temporarily unavailable)
sched_yield()                           = 0
sched_yield()                           = 0
getpid()                                = 26293
clock_gettime(CLOCK_MONOTONIC, {873083, 976309642}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 976636863}) = 0
poll([{fd=8, events=POLLIN|POLLPRI}], 1, 1000) = 1 ([{fd=8, revents=POLLIN|POLLPRI}])
ioctl(8, 0xc0104652, 0x7fff4b649fc0)    = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 977729992}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 978079880}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 978430750}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 978853681}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 979200123}) = 0
clock_gettime(CLOCK_MONOTONIC, {873083, 979525994}) = 0
sched_yield()                           = 0
sched_yield()                           = 0
sched_yield()                           = 0
nanosleep({0, 16000000}, NULL)          = 0
```

Every frame, it was testing for the existence of menu textures (bg,clouds,footer,header,splash) after testing every directory above those textures, even when the disappearance of those textures didn't cause them to disappear from a running game.
