### PR TITLE
Per-player speed / jump / gravity overrides

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1348,6 +1348,8 @@ Player-only: (no-op for other objects)
     {jump=bool,right=bool,left=bool,LMB=bool,RMB=bool,sneak=bool,aux1=bool,down=bool,up=bool}
 - get_player_control_bits(): returns integer with bit packed player pressed keys
     bit nr/meaning: 0/up ,1/down ,2/left ,3/right ,4/jump ,5/aux1 ,6/sneak ,7/LMB ,8/RMB
+- set_physics_override(speed, jump, gravity)
+    modifies per-player walking speed, jump height, and gravity. Values default to 1 and act as offsets to the physics settings in minetest.conf
     
 InvRef: Reference to an inventory
 methods:

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -88,9 +88,11 @@ SharedBuffer<u8> makePacket_TOCLIENT_TIME_OF_DAY(u16 time, float time_speed);
 	PROTOCOL_VERSION 18:
 		damageGroups added to ToolCapabilities
 		sound_place added to ItemDefinition
+	PROTOCOL_VERSION 19:
+		GENERIC_CMD_SET_PHYSICS_OVERRIDE
 */
 
-#define LATEST_PROTOCOL_VERSION 18
+#define LATEST_PROTOCOL_VERSION 19
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1679,6 +1679,19 @@ public:
 
 			updateTexturePos();
 		}
+		else if(cmd == GENERIC_CMD_SET_PHYSICS_OVERRIDE)
+		{
+			float override_speed = readF1000(is);
+			float override_jump = readF1000(is);
+			float override_gravity = readF1000(is);
+			if(m_is_local_player)
+			{
+				LocalPlayer *player = m_env->getLocalPlayer();
+				player->physics_override_speed = override_speed;
+				player->physics_override_jump = override_jump;
+				player->physics_override_gravity = override_gravity;
+			}
+		}
 		else if(cmd == GENERIC_CMD_SET_ANIMATION)
 		{
 			m_animation_range = readV2F1000(is);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -101,7 +101,7 @@ private:
 	float m_last_sent_position_timer;
 	float m_last_sent_move_precision;
 	bool m_armor_groups_sent;
-	
+
 	v2f m_animation_range;
 	float m_animation_speed;
 	float m_animation_blend;
@@ -164,6 +164,7 @@ public:
 	void setHP(s16 hp);
 	
 	void setArmorGroups(const ItemGroupList &armor_groups);
+	void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity);
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend);
 	void setBonePosition(std::string bone, v3f position, v3f rotation);
 	void setAttachment(int parent_id, std::string bone, v3f position, v3f rotation);
@@ -257,8 +258,6 @@ private:
 	ItemGroupList m_armor_groups;
 	bool m_armor_groups_sent;
 
-
-
 	bool m_properties_sent;
 	struct ObjectProperties m_prop;
 	// Cached privileges for enforcement
@@ -269,6 +268,11 @@ private:
 	float m_animation_speed;
 	float m_animation_blend;
 	bool m_animation_sent;
+
+	float m_physics_override_speed;
+	float m_physics_override_jump;
+	float m_physics_override_gravity;
+	bool m_physics_override_sent;
 
 	std::map<std::string, core::vector2d<v3f> > m_bone_position; // Stores position and rotation for each bone name
 	bool m_bone_position_sent;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2057,7 +2057,7 @@ void ClientEnvironment::step(float dtime)
 				// Gravity
 				v3f speed = lplayer->getSpeed();
 				if(lplayer->in_liquid == false)
-					speed.Y -= lplayer->movement_gravity * dtime_part * 2;
+					speed.Y -= lplayer->movement_gravity * lplayer->physics_override_gravity * dtime_part * 2;
 
 				// Liquid floating / sinking
 				if(lplayer->in_liquid && !lplayer->swimming_vertical)

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -117,6 +117,18 @@ std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups)
 	return os.str();
 }
 
+std::string gob_cmd_update_physics_override(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
+{
+	std::ostringstream os(std::ios::binary);
+	// command 
+	writeU8(os, GENERIC_CMD_SET_PHYSICS_OVERRIDE);
+	// parameters
+	writeF1000(os, physics_override_speed);
+	writeF1000(os, physics_override_jump);
+	writeF1000(os, physics_override_gravity);
+	return os.str();
+}
+
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend)
 {
 	std::ostringstream os(std::ios::binary);

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GENERIC_CMD_SET_ANIMATION 6
 #define GENERIC_CMD_SET_BONE_POSITION 7
 #define GENERIC_CMD_SET_ATTACHMENT 8
+#define GENERIC_CMD_SET_PHYSICS_OVERRIDE 9
 
 #include "object_properties.h"
 std::string gob_cmd_set_properties(const ObjectProperties &prop);
@@ -61,6 +62,8 @@ std::string gob_cmd_punched(s16 damage, s16 result_hp);
 
 #include "itemgroup.h"
 std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups);
+
+std::string gob_cmd_update_physics_override(float physics_override_speed, float physics_override_jump, float physics_override_gravity);
 
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend);
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -529,7 +529,7 @@ void LocalPlayer::applyControl(float dtime)
 			v3f speedJ = getSpeed();
 			if(speedJ.Y >= -0.5 * BS)
 			{
-				speedJ.Y = movement_speed_jump;
+				speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				
 				MtEvent *e = new SimpleTriggerEvent("PlayerJump");
@@ -584,8 +584,8 @@ void LocalPlayer::applyControl(float dtime)
 		incH = incV = movement_acceleration_default * BS * dtime;
 
 	// Accelerate to target speed with maximum increment
-	accelerateHorizontal(speedH, incH);
-	accelerateVertical(speedV, incV);
+	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed);
+	accelerateVertical(speedV * physics_override_speed, incV * physics_override_speed);
 }
 
 v3s16 LocalPlayer::getStandingNodePos()

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -71,6 +71,11 @@ Player::Player(IGameDef *gamedef):
 	movement_liquid_fluidity_smooth = 0.5 * BS;
 	movement_liquid_sink = 10 * BS;
 	movement_gravity = 9.81 * BS;
+
+	// Movement overrides are multipliers and must be 1 by default
+	physics_override_speed = 1;
+	physics_override_jump = 1;
+	physics_override_gravity = 1;
 }
 
 Player::~Player()

--- a/src/player.h
+++ b/src/player.h
@@ -222,6 +222,10 @@ public:
 	f32 movement_liquid_sink;
 	f32 movement_gravity;
 
+	float physics_override_speed;
+	float physics_override_jump;
+	float physics_override_gravity;
+
 	u16 hp;
 
 	float hurt_tilt_timer;

--- a/src/scriptapi_object.cpp
+++ b/src/scriptapi_object.cpp
@@ -297,6 +297,26 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 	return 0;
 }
 
+// set_physics_override(self, physics_override_speed, physics_override_jump, physics_override_gravity)
+int ObjectRef::l_set_physics_override(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if(co == NULL) return 0;
+	// Do it
+	float physics_override_speed = 1;
+	if(!lua_isnil(L, 2))
+		physics_override_speed = lua_tonumber(L, 2);
+	float physics_override_jump = 1;
+	if(!lua_isnil(L, 3))
+		physics_override_jump = lua_tonumber(L, 3);
+	float physics_override_gravity = 1;
+	if(!lua_isnil(L, 4))
+		physics_override_gravity = lua_tonumber(L, 4);
+	co->setPhysicsOverride(physics_override_speed, physics_override_jump, physics_override_gravity);
+	return 0;
+}
+
 // set_animation(self, frame_range, frame_speed, frame_blend)
 int ObjectRef::l_set_animation(lua_State *L)
 {
@@ -756,6 +776,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_wielded_item),
 	luamethod(ObjectRef, set_wielded_item),
 	luamethod(ObjectRef, set_armor_groups),
+	luamethod(ObjectRef, set_physics_override),
 	luamethod(ObjectRef, set_animation),
 	luamethod(ObjectRef, set_bone_position),
 	luamethod(ObjectRef, set_attach),

--- a/src/scriptapi_object.h
+++ b/src/scriptapi_object.h
@@ -103,6 +103,9 @@ private:
 	// set_armor_groups(self, groups)
 	static int l_set_armor_groups(lua_State *L);
 
+	// set_physics_override(self, physics_override_speed, physics_override_jump, physics_override_gravity)
+	static int l_set_physics_override(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend)
 	static int l_set_animation(lua_State *L);
 

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -152,6 +152,8 @@ public:
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}
+	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
+	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend)
 	{}
 	virtual void setBonePosition(std::string bone, v3f position, v3f rotation)


### PR DESCRIPTION
Since I coded the new player physics, people frequently asked if something could be done to create low gravity areas and allow per-player weights. RealBadAngel also said he's like to do a jump boots powerup for one of his ideas, and I don't think running boots would be a bad idea either (or slow nodes like MineCraft's "soul sand").

So here's a patch which allows doing all that. It implements a new Lua function that can modify walking speed, jump height and gravity for individual players. To test it, use this function in a Lua script: player:set_physics_override(float_speed, float_jump, float_gravity). By default all values are 1... 0.5 means half of the normal amount while 2 means double the normal amount. They basically multiply the global physics settings in minetest.conf for individual players as optional overrides. I found this the cleanest and safest implementation so I hope no major changes are needed.
