### PR TITLE
No automatic superspeed when swimming / climbing & aux1_descends is on

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -389,7 +389,7 @@ void LocalPlayer::applyControl(float dtime)
 
 	bool free_move = fly_allowed && g_settings->getBool("free_move");
 	bool fast_move = fast_allowed && g_settings->getBool("fast_move");
-	bool fast_or_aux1_descends = (fast_move && control.aux1) || (fast_move && g_settings->getBool("aux1_descends"));
+	bool fast_climb = fast_move && control.aux1 && !g_settings->getBool("aux1_descends"); // When aux1_descends is enabled the fast key is used to go down, so fast isn't possible
 	bool continuous_forward = g_settings->getBool("continuous_forward");
 
 	// Whether superspeed mode is used or not
@@ -418,14 +418,12 @@ void LocalPlayer::applyControl(float dtime)
 			}
 			else if(in_liquid || in_liquid_stable)
 			{
-				// Always use fast when aux1_descends & fast_move are enabled in liquid, since the aux1 button would mean both turbo and "swim down" causing a conflict
-				speedV.Y = -movement_speed_fast;
+				speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
 			}
 			else if(is_climbing)
 			{
-				// Always use fast when aux1_descends & fast_move are enabled when climbing, since the aux1 button would mean both turbo and "descend" causing a conflict
-				speedV.Y = -movement_speed_fast;
+				speedV.Y = -movement_speed_climb;
 			}
 			else
 			{
@@ -462,8 +460,7 @@ void LocalPlayer::applyControl(float dtime)
 			}
 			else if(in_liquid || in_liquid_stable)
 			{
-				if(fast_or_aux1_descends)
-					// Always use fast when aux1_descends & fast_move are enabled in liquid, since the aux1 button would mean both turbo and "swim down" causing a conflict
+				if(fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
@@ -471,8 +468,7 @@ void LocalPlayer::applyControl(float dtime)
 			}
 			else if(is_climbing)
 			{
-				if(fast_or_aux1_descends)
-					// Always use fast when aux1_descends & fast_move are enabled when climbing, since the aux1 button would mean both turbo and "descend" causing a conflict
+				if(fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_climb;
@@ -538,8 +534,7 @@ void LocalPlayer::applyControl(float dtime)
 		}
 		else if(in_liquid)
 		{
-			if(fast_or_aux1_descends)
-				// Always use fast when aux1_descends & fast_move are enabled in liquid, since the aux1 button would mean both turbo and "swim down" causing a conflict
+			if(fast_climb)
 				speedV.Y = movement_speed_fast;
 			else
 				speedV.Y = movement_speed_walk;
@@ -547,8 +542,7 @@ void LocalPlayer::applyControl(float dtime)
 		}
 		else if(is_climbing)
 		{
-			if(fast_or_aux1_descends)
-				// Always use fast when aux1_descends & fast_move are enabled when climbing, since the aux1 button would mean both turbo and "descend" causing a conflict
+			if(fast_climb)
 				speedV.Y = movement_speed_fast;
 			else
 				speedV.Y = movement_speed_climb;
@@ -556,7 +550,7 @@ void LocalPlayer::applyControl(float dtime)
 	}
 
 	// The speed of the player (Y is ignored)
-	if(superspeed || (is_climbing && fast_or_aux1_descends) || ((in_liquid || in_liquid_stable) && fast_or_aux1_descends))
+	if(superspeed || (is_climbing && fast_climb) || ((in_liquid || in_liquid_stable) && fast_climb))
 		speedH = speedH.normalize() * movement_speed_fast;
 	else if(control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch;
@@ -575,10 +569,7 @@ void LocalPlayer::applyControl(float dtime)
 			incH = movement_acceleration_air * BS * dtime;
 		incV = 0; // No vertical acceleration in air
 	}
-	else if(superspeed || (fast_move && control.aux1))
-		incH = incV = movement_acceleration_fast * BS * dtime;
-	else if ((in_liquid || in_liquid_stable) && fast_or_aux1_descends)
-		// Always use fast when aux1_descends & fast_move are enabled in liquid, since the aux1 button would mean both turbo and "swim down" causing a conflict
+	else if (superspeed || (is_climbing && fast_climb) || ((in_liquid || in_liquid_stable) && fast_climb))
 		incH = incV = movement_acceleration_fast * BS * dtime;
 	else
 		incH = incV = movement_acceleration_default * BS * dtime;


### PR DESCRIPTION
First of all, sorry I took so long to fix this. Since adding the new physics, people who use aux1_descends complained about superspeed happening automatically when climbing ladders or swimming. That's because the 'fast' button is used as 'go down', so the two functions can no longer be separated into two separate keys.

I came to the conclusion that the best choice is to disable fast on ladders and underwater when aux1_descends is being used. It's sadly the only sane choice, and less annoying than always going fast.
