### PR TITLE
Shaded chat text.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1281,6 +1281,11 @@ void the_game(
 			core::rect<s32>(0,0,0,0),
 			//false, false); // Disable word wrap as of now
 			false, true);
+	// Slightly shaded so it's easier to read.
+	// I'd like to set the shadow to the width of the text.
+	// Irrlicht IGUIStaticText has getTextWidth,
+	// but it seems to have no effect on the core::rect above.
+	guitext_chat->setBackgroundColor(video::SColor(40,0,0,0));
 	// Remove stale "recent" chat messages from previous connections
 	chat_backend.clearRecentChat();
 	// Chat backend and console


### PR DESCRIPTION
![shadow](https://f.cloud.github.com/assets/3681804/353747/62313fe6-a08a-11e2-9346-ecadc0616635.jpg)
Slightly shaded so it's easier to read. Especially while looking at the sky / clouds / white objects.
