### PR TITLE
Implement ObjectRef:rotate_yaw(radians, speed) to continuously rotate objects

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1352,6 +1352,9 @@ LuaEntitySAO-only: (no-op for other objects)
 - getacceleration() -> {x=num, y=num, z=num}
 - setyaw(radians)
 - getyaw() -> radians
+- rotate_yaw(radians, speed)
+  ^ Rotate to radians continously
+  ^ with speed in radians/second (positive/negative for direction)
 - settexturemod(mod)
 - setsprite(p={x=0,y=0}, num_frames=1, framelength=0.2,
 -           select_horiz_by_yawpitch=false)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -74,6 +74,7 @@ public:
 	v3f getAcceleration();
 	void setYaw(float yaw);
 	float getYaw();
+	void rotateYaw(float yaw, float speed);
 	void setTextureMod(const std::string &mod);
 	void setSprite(v2s16 p, int num_frames, float framelength,
 			bool select_horiz_by_yawpitch);
@@ -92,6 +93,8 @@ private:
 	v3f m_velocity;
 	v3f m_acceleration;
 	float m_yaw;
+	float m_dest_yaw;
+	float m_rotate_yaw_speed;
 	ItemGroupList m_armor_groups;
 	
 	bool m_properties_sent;

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -43,7 +43,9 @@ std::string gob_cmd_update_position(
 	f32 yaw,
 	bool do_interpolate,
 	bool is_movement_end,
-	f32 update_interval
+	f32 update_interval,
+	f32 m_yaw_dest,
+	f32 m_rotate_yaw_speed
 ){
 	std::ostringstream os(std::ios::binary);
 	// command
@@ -62,6 +64,10 @@ std::string gob_cmd_update_position(
 	writeU8(os, is_movement_end);
 	// update_interval (for interpolation)
 	writeF1000(os, update_interval);
+	// m_yaw_dest (for continuous rotation)
+	writeF1000(os, m_yaw_dest);
+	// m_rotate_yaw_speed
+	writeF1000(os, m_rotate_yaw_speed);
 	return os.str();
 }
 

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -46,7 +46,9 @@ std::string gob_cmd_update_position(
 	f32 yaw,
 	bool do_interpolate,
 	bool is_movement_end,
-	f32 update_interval
+	f32 update_interval,
+	f32 m_yaw_dest,
+	f32 m_rotate_yaw_speed
 );
 
 std::string gob_cmd_set_texture_mod(const std::string &mod);

--- a/src/scriptapi_object.cpp
+++ b/src/scriptapi_object.cpp
@@ -482,6 +482,20 @@ int ObjectRef::l_getyaw(lua_State *L)
 	return 1;
 }
 
+// rotate_yaw(self, radians, speed)
+// speed in radians per second
+int ObjectRef::l_rotate_yaw(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *co = getluaobject(ref);
+	if(co == NULL) return 0;
+	float yaw = luaL_checknumber(L, 2) * core::RADTODEG;
+	float speed = luaL_checknumber(L, 3) * core::RADTODEG;
+	// Do it
+	co->rotateYaw(yaw, speed);
+	return 1;
+}
+
 // settexturemod(self, mod)
 int ObjectRef::l_settexturemod(lua_State *L)
 {
@@ -791,6 +805,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, getacceleration),
 	luamethod(ObjectRef, setyaw),
 	luamethod(ObjectRef, getyaw),
+	luamethod(ObjectRef, rotate_yaw),
 	luamethod(ObjectRef, settexturemod),
 	luamethod(ObjectRef, setsprite),
 	luamethod(ObjectRef, get_entity_name),

--- a/src/scriptapi_object.h
+++ b/src/scriptapi_object.h
@@ -141,6 +141,9 @@ private:
 	// getyaw(self)
 	static int l_getyaw(lua_State *L);
 
+	// setyaw(self, radians, speed)
+	static int l_rotate_yaw(lua_State *L);
+
 	// settexturemod(self, mod)
 	static int l_settexturemod(lua_State *L);
 


### PR DESCRIPTION
In action: http://www.youtube.com/watch?v=g0vk8DsjIoQ

Continuously rotates a LuaEntity to a yaw with speed.
Simple use cases would be mobs, e.g. slimes to make rotation animations smoother and more precise.
The main advantage of this over automatic rotation is that both server and client make the entity stop when the yaw is reached and that also during rotation yaw values are available on the server

Acces from lua e.g. using
self.object:rotate_yaw(math.pi, math.pi/2)
for half a rotation in 2 seconds.
