### PR TITLE
Fix build on big endian architectures.

### DIFF
--- a/src/cguittfont/irrUString.h
+++ b/src/cguittfont/irrUString.h
@@ -802,7 +802,7 @@ public:
 	ustring16()
 	: array(0), allocated(1), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -816,7 +816,7 @@ public:
 	ustring16(const ustring16<TAlloc>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -830,7 +830,7 @@ public:
 	ustring16(const string<B, A>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -845,7 +845,7 @@ public:
 	ustring16(const std::basic_string<B, A, Alloc>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -859,7 +859,7 @@ public:
 	ustring16(Itr first, Itr last)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -878,7 +878,7 @@ public:
 	ustring16(const char* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -893,7 +893,7 @@ public:
 	ustring16(const char* const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -908,7 +908,7 @@ public:
 	ustring16(const uchar8_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -922,7 +922,7 @@ public:
 	ustring16(const char c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -936,7 +936,7 @@ public:
 	ustring16(const uchar8_t* const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -950,7 +950,7 @@ public:
 	ustring16(const uchar16_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -964,7 +964,7 @@ public:
 	ustring16(const uchar16_t* const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -978,7 +978,7 @@ public:
 	ustring16(const uchar32_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -992,7 +992,7 @@ public:
 	ustring16(const uchar32_t* const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -1006,7 +1006,7 @@ public:
 	ustring16(const wchar_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -1025,7 +1025,7 @@ public:
 	ustring16(const wchar_t* const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#ifdef __BIG_ENDIAN__
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;


### PR DESCRIPTION
On big endian architectures, the build fails with the following error:

```
In file included from /build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/xCGUITTFont.h:6:0,
                 from /build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/xCGUITTFont.cpp:4:
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:805:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:819:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:833:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:848:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:862:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:881:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:896:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:911:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:925:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:939:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:953:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:967:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:981:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:995:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:1009:19: error: #if with no expression
/build/buildd-minetest_0.4.6+repack-3-powerpc-92VoFb/minetest-0.4.6+repack/src/cguittfont/irrUString.h:1028:19: error: #if with no expression
```

(Full build log at:https://buildd.debian.org/status/fetch.php?pkg=minetest&arch=powerpc&ver=0.4.6%2Brepack-3&stamp=1366277397 )
