### PR TITLE
HUD alignment and offset parameters

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -412,6 +412,9 @@ The direction field is the direction in which something is drawn.
 The alignment field specifies how the item will be aligned. It ranges from -1 to 1,
 with 0 being the center, -1 is moved to the left/up, and 1 is to the right/down. Fractional
 values can be used.
+The offset field specifies a pixel offset from the position. Contrary to position,
+the offset is not scaled to screen size. This allows for some precisely-positioned
+items in the HUD.
 Below are the specific uses for fields in each type; fields not listed for that type are ignored.
 
 Note: Future revisions to the HUD API may be incompatible; the HUD API is still in the experimental stages.
@@ -422,6 +425,7 @@ Note: Future revisions to the HUD API may be incompatible; the HUD API is still 
              Only the X coordinate scale is used.
     - text: The name of the texture that is displayed.
     - alignment: The alignment of the image.
+    - offset: offset in pixels from position.
 - text
     Displays text on the HUD.
     - scale: Defines the bounding rectangle of the text.
@@ -430,12 +434,14 @@ Note: Future revisions to the HUD API may be incompatible; the HUD API is still 
     - number: An integer containing the RGB value of the color used to draw the text.
               Specify 0xFFFFFF for white text, 0xFF0000 for red, and so on.
     - alignment: The alignment of the text.
+    - offset: offset in pixels from position.
 - statbar
     Displays a horizontal bar made up of half-images.
     - text: The name of the texture that is used.
     - number: The number of half-textures that are displayed.
               If odd, will end with a vertically center-split texture.
     - direction
+    - offset: offset in pixels from position.
 - inventory
     - text: The name of the inventory list to be displayed.
     - number: Number of items in the inventory to be displayed.
@@ -1863,5 +1869,7 @@ HUD Definition (hud_add, hud_get)
     direction = 0,
     ^ Direction: 0: left-right, 1: right-left, 2: top-bottom, 3: bottom-top
     alignment = {x=0, y=0},
+    ^ See "HUD Element Types"
+    offset = {x=0, y=0},
     ^ See "HUD Element Types"
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -2055,6 +2055,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		u32 item         = readU32(is);
 		u32 dir          = readU32(is);
 		v2f align        = readV2F1000(is);
+		v2f offset       = readV2F1000(is);
 
 		ClientEvent event;
 		event.type = CE_HUDADD;
@@ -2068,6 +2069,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		event.hudadd.item   = item;
 		event.hudadd.dir    = dir;
 		event.hudadd.align  = new v2f(align);
+		event.hudadd.offset = new v2f(offset);
 		m_client_event_queue.push_back(event);
 	}
 	else if(command == TOCLIENT_HUDRM)

--- a/src/client.h
+++ b/src/client.h
@@ -231,6 +231,7 @@ struct ClientEvent
 			u32 item;
 			u32 dir;
 			v2f *align;
+			v2f *offset;
 		} hudadd;
 		struct{
 			u32 id;

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -453,6 +453,7 @@ enum ToClientCommand
 		u32 item
 		u32 dir
 		v2f1000 align
+		v2f1000 offset
 	*/
 
 	TOCLIENT_HUDRM = 0x50,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2107,6 +2107,7 @@ void the_game(
 						delete event.hudadd.scale;
 						delete event.hudadd.text;
 						delete event.hudadd.align;
+						delete event.hudadd.offset;
 						continue;
 					}
 					
@@ -2120,6 +2121,7 @@ void the_game(
 					e->item   = event.hudadd.item;
 					e->dir    = event.hudadd.dir;
 					e->align  = *event.hudadd.align;
+					e->offset = *event.hudadd.offset;
 					
 					if (id == nhudelem)
 						player->hud.push_back(e);
@@ -2131,6 +2133,7 @@ void the_game(
 					delete event.hudadd.scale;
 					delete event.hudadd.text;
 					delete event.hudadd.align;
+					delete event.hudadd.offset;
 				}
 				else if (event.type == CE_HUDRM)
 				{
@@ -2174,6 +2177,9 @@ void the_game(
 							break;
 						case HUD_STAT_ALIGN:
 							e->align = *event.hudchange.v2fdata;
+							break;
+						case HUD_STAT_OFFSET:
+							e->offset = *event.hudchange.v2fdata;
 							break;
 					}
 					

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -189,6 +189,7 @@ void Hud::drawLuaElements() {
 				v2s32 offset((e->align.X - 1.0) * ((imgsize.Width  * e->scale.X) / 2),
 				             (e->align.Y - 1.0) * ((imgsize.Height * e->scale.X) / 2));
 				rect += offset;
+				rect += v2s32(e->offset.X, e->offset.Y);
 				driver->draw2DImage(texture, rect,
 					core::rect<s32>(core::position2d<s32>(0,0), imgsize),
 					NULL, colors, true);
@@ -202,11 +203,13 @@ void Hud::drawLuaElements() {
 				core::dimension2d<u32> textsize = font->getDimension(text.c_str());
 				v2s32 offset((e->align.X - 1.0) * (textsize.Width / 2),
 				             (e->align.Y - 1.0) * (textsize.Height / 2));
-				font->draw(text.c_str(), size + pos + offset, color);
+				v2s32 offs(e->offset.X, e->offset.Y);
+				font->draw(text.c_str(), size + pos + offset + offs, color);
 				break; }
-			case HUD_ELEM_STATBAR:
-				drawStatbar(pos, HUD_CORNER_UPPER, e->dir, e->text, e->number);
-				break;
+			case HUD_ELEM_STATBAR: {
+				v2s32 offs(e->offset.X, e->offset.Y);
+				drawStatbar(pos, HUD_CORNER_UPPER, e->dir, e->text, e->number, offs);
+				break; }
 			case HUD_ELEM_INVENTORY: {
 				InventoryList *inv = inventory->getList(e->text);
 				drawItem(pos, hotbar_imagesize, e->number, inv, e->item, e->dir);
@@ -219,7 +222,7 @@ void Hud::drawLuaElements() {
 }
 
 
-void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s32 count) {
+void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s32 count, v2s32 offset) {
 	const video::SColor color(255, 255, 255, 255);
 	const video::SColor colors[] = {color, color, color, color};
 	
@@ -233,6 +236,8 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s
 	v2s32 p = pos;
 	if (corner & HUD_CORNER_LOWER)
 		p -= srcd.Height;
+
+	p += offset;
 
 	v2s32 steppos;
 	switch (drawdir) {
@@ -285,7 +290,7 @@ void Hud::drawHotbar(v2s32 centerlowerpos, s32 halfheartcount, u16 playeritem) {
 	
 	drawItem(pos, hotbar_imagesize, hotbar_itemcount, mainlist, playeritem + 1, 0);
 	drawStatbar(pos - v2s32(0, 4), HUD_CORNER_LOWER, HUD_DIR_LEFT_RIGHT,
-				"heart.png", halfheartcount);
+				"heart.png", halfheartcount, v2s32(0, 0));
 }
 
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -48,7 +48,8 @@ enum HudElementStat {
 	HUD_STAT_NUMBER,
 	HUD_STAT_ITEM,
 	HUD_STAT_DIR,
-	HUD_STAT_ALIGN
+	HUD_STAT_ALIGN,
+	HUD_STAT_OFFSET
 };
 
 struct HudElement {
@@ -61,6 +62,7 @@ struct HudElement {
 	u32 item;
 	u32 dir;
 	v2f align;
+	v2f offset;
 };
 
 
@@ -108,7 +110,7 @@ public:
 	void drawItem(v2s32 upperleftpos, s32 imgsize, s32 itemcount,
 		InventoryList *mainlist, u16 selectitem, u16 direction);
 	void drawLuaElements();
-	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s32 count);
+	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s32 count, v2s32 offset);
 	
 	void drawHotbar(v2s32 centerlowerpos, s32 halfheartcount, u16 playeritem);
 	void resizeHotbar();

--- a/src/scriptapi_object.cpp
+++ b/src/scriptapi_object.cpp
@@ -48,6 +48,7 @@ struct EnumString es_HudElementStat[] =
 	{HUD_STAT_ITEM,   "item"},
 	{HUD_STAT_DIR,    "direction"},
 	{HUD_STAT_ALIGN,  "alignment"},
+	{HUD_STAT_OFFSET, "offset"},
 	{0, NULL},
 };
 
@@ -756,6 +757,10 @@ int ObjectRef::l_hud_add(lua_State *L)
 	elem->align = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
 	lua_pop(L, 1);
 
+	lua_getfield(L, 2, "offset");
+	elem->offset = lua_istable(L, -1) ? read_v2f(L, -1) : v2f();
+	lua_pop(L, 1);
+
 	u32 id = get_server(L)->hudAdd(player, elem);
 	if (id == (u32)-1) {
 		delete elem;
@@ -839,6 +844,9 @@ int ObjectRef::l_hud_change(lua_State *L)
 		case HUD_STAT_ALIGN:
 			e->align = read_v2f(L, 4);
 			value = &e->align;
+		case HUD_STAT_OFFSET:
+			e->offset = read_v2f(L, 4);
+			value = &e->offset;
 	}
 	
 	get_server(L)->hudChange(player, id, stat, value);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3617,6 +3617,7 @@ void Server::SendHUDAdd(u16 peer_id, u32 id, HudElement *form)
 	writeU32(os, form->item);
 	writeU32(os, form->dir);
 	writeV2F1000(os, form->align);
+	writeV2F1000(os, form->offset);
 
 	// Make data buffer
 	std::string s = os.str();
@@ -3652,6 +3653,7 @@ void Server::SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value
 		case HUD_STAT_POS:
 		case HUD_STAT_SCALE:
 		case HUD_STAT_ALIGN:
+		case HUD_STAT_OFFSET:
 			writeV2F1000(os, *(v2f *)value);
 			break;
 		case HUD_STAT_NAME:


### PR DESCRIPTION
This adds the possibility to specify both alignment (relative to item size), and offset (in pixels, without regard to user's screen resolution). This would allow most (or all) kinds of layout, like specifying some stuff to be shown always on the bottom-left corner, or to use an "image" item as crosshair as in the following image:

https://dl.dropboxusercontent.com/u/100008207/screenshot_828120402.jpg
