### PR TITLE
Allow custom liquids to have drops

### DIFF
--- a/builtin/falling.lua
+++ b/builtin/falling.lua
@@ -66,19 +66,17 @@ minetest.register_entity("__builtin:falling_node", {
 			local n2 = minetest.env:get_node(np)
 			-- If it's not air or liquid, remove node and replace it with
 			-- it's drops
-			if n2.name ~= "air" then
-				local drops = minetest.get_node_drops(n2.name, "")
-				minetest.env:remove_node(np)
-				-- Add dropped items
-				local _, dropped_item
-				for _, dropped_item in ipairs(drops) do
-					minetest.env:add_item(np, dropped_item)
-				end
-				-- Run script hook
-				local _, callback
-				for _, callback in ipairs(minetest.registered_on_dignodes) do
-					callback(np, n2, nil)
-				end
+			local drops = minetest.get_node_drops(n2.name, "")
+			minetest.env:remove_node(np)
+			-- Add dropped items
+			local _, dropped_item
+			for _, dropped_item in ipairs(drops) do
+				minetest.env:add_item(np, dropped_item)
+			end
+			-- Run script hook
+			local _, callback
+			for _, callback in ipairs(minetest.registered_on_dignodes) do
+				callback(np, n2, nil)
 			end
 			-- Create node and remove entity
 			minetest.env:add_node(np, {name=self.nodename})


### PR DESCRIPTION
The falling node handler previously checked to see if the replaced node was a liquid, and didn't drop any items if it was. THis was a hacky way to make sure the liquids in minetest_game didn't drop water and lava items when filled in.

This has now been fixed in minetest_game by setting the drops property. By removing the builtin check, we now allow user-defined liquids to have a drop if wanted.
