### PR TITLE
Add tool callback

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -383,14 +383,19 @@ function minetest.node_dig(pos, node, digger)
 
 	local wielded = digger:get_wielded_item()
 	local drops = minetest.get_node_drops(node.name, wielded:get_name())
-
-	-- Wear out tool
-	if not minetest.setting_getbool("creative_mode") then
-		local tp = wielded:get_tool_capabilities()
-		local dp = minetest.get_dig_params(def.groups, tp)
-		wielded:add_wear(dp.wear)
-		digger:set_wielded_item(wielded)
+	
+	local wdef = wielded:get_definition()
+	local tp = wielded:get_tool_capabilities()
+	local dp = minetest.get_dig_params(def.groups, tp)
+	if wdef and wdef.after_use then
+		wielded = wdef.after_use(wielded, digger, node, dp) or wielded
+	else
+		-- Wear out tool
+		if not minetest.setting_getbool("creative_mode") then
+			wielded:add_wear(dp.wear)
+		end
 	end
+	digger:set_wielded_item(wielded)
 	
 	-- Handle drops
 	minetest.handle_node_drops(pos, drops, digger)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1944,6 +1944,15 @@ Item definition (register_node, register_craftitem, register_tool)
         eg. itemstack:take_item(); return itemstack
     ^ Otherwise, the function is free to do what it wants.
     ^ The default functions handle regular use cases.
+    after_use = func(itemstack, user, node, digparams),
+    ^  default: nil
+    ^ If defined, should return an itemstack and will be called instead of
+      wearing out the tool. If returns nil, does nothing.
+      If after_use doesn't exist, it is the same as:
+        function(itemstack, user, node, digparams)
+          itemstack:add_wear(digparams.wear)
+          return itemstack
+        end
 }
 
 Tile definition:


### PR DESCRIPTION
This commit adds a tool callback, that is called instead of wearing the tool if a tool wants to use custom code when being used. It could already be done before, but would require to override a global function, which is not a good solution.
