### PR TITLE
Make mods global

### DIFF
--- a/src/subgame.cpp
+++ b/src/subgame.cpp
@@ -88,9 +88,9 @@ SubgameSpec findSubgame(const std::string &id)
 	// Find mod directories
 	std::set<std::string> mods_paths;
 	if(!user_game)
-		mods_paths.insert(share + DIR_DELIM + "mods" + DIR_DELIM + id);
+		mods_paths.insert(share + DIR_DELIM + "mods");
 	if(user != share || user_game)
-		mods_paths.insert(user + DIR_DELIM + "mods" + DIR_DELIM + id);
+		mods_paths.insert(user + DIR_DELIM + "mods");
 	std::string game_name = getGameName(game_path);
 	if(game_name == "")
 		game_name = id;


### PR DESCRIPTION
Since splitting the game there are many people, especially newbies, having problems to install mods. With global mods it will be much easier. Also the mods dont have to be stored (and updated) multiple times for every game.

And players can still disable mods for each game by using the gui.
