### PR TITLE
Add code to play main menu music.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "subgame.h"
 #include "quicktune.h"
 #include "serverlist.h"
+#include "sound.h"
+#include "sound_openal.h"
 
 /*
 	Settings.
@@ -196,7 +198,49 @@ u32 getTime(TimePrecision prec) {
 		return 0;
 	return g_timegetter->getTime(prec);
 }
+#endif
 
+//Client side main menu music fetcher
+#ifndef SERVER
+class MenuMusicFetcher: public OnDemandSoundFetcher
+{
+	std::set<std::string> m_fetched;
+public:
+
+	void fetchSounds(const std::string &name,
+			std::set<std::string> &dst_paths,
+			std::set<std::string> &dst_datas)
+	{
+		if(m_fetched.count(name))
+			return;
+		m_fetched.insert(name);
+		std::string base;
+		base = porting::path_share + DIR_DELIM + "sounds";
+		dst_paths.insert(base + DIR_DELIM + name + ".ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".0.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".1.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".2.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".3.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".4.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".5.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".6.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".7.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".8.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".9.ogg");
+		base = porting::path_user + DIR_DELIM + "sounds";
+		dst_paths.insert(base + DIR_DELIM + name + ".ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".0.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".1.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".2.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".3.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".4.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".5.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".6.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".7.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".8.ogg");
+		dst_paths.insert(base + DIR_DELIM + name + ".9.ogg");
+		}
+};
 #endif
 
 class StderrLogOutput: public ILogOutput
@@ -1668,6 +1712,16 @@ int main(int argc, char *argv[])
 					// Time is in milliseconds, for clouds
 					u32 lasttime = device->getTimer()->getTime();
 
+					MenuMusicFetcher soundfetcher;
+					ISoundManager *sound = NULL;
+					sound = createOpenALSoundManager(&soundfetcher);
+					if(!sound)
+						sound = &dummySoundManager;
+					SimpleSoundSpec spec;
+					spec.name = "main_menu";
+					spec.gain = 1;
+					s32 handle = sound->playSound(spec, true);
+
 					infostream<<"Created main menu"<<std::endl;
 
 					while(device->run() && kill == false)
@@ -1731,7 +1785,8 @@ int main(int argc, char *argv[])
 							sleep_ms(25);
 						}
 					}
-					
+					sound->stopSound(handle);
+
 					infostream<<"Dropping main menu"<<std::endl;
 
 					menu->drop();


### PR DESCRIPTION
In system wide installation path_user and path_share will be checked for music file. path_user/sounds/ overwrites path_share/sounds , so every user can have own music or use global defined one.

When built in place use build's folder /sounds

Music score shall be named main_menu.ogg
