### PR TITLE
Add prepend argument to minetest.chat_send_all

### DIFF
--- a/builtin/misc_helpers.lua
+++ b/builtin/misc_helpers.lua
@@ -91,4 +91,10 @@ function minetest.pos_to_string(pos)
 	return "(" .. pos.x .. "," .. pos.y .. "," .. pos.z .. ")"
 end
 
+minetest.chat_send_all = function(text, prepend)
+	local pls = minetest.get_connected_players()
+	for _, pl in pairs(pls) do
+		minetest.chat_send_player(pl:get_player_name(), text, prepend)
+	end
+end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1006,7 +1006,7 @@ minetest.check_player_privs(name, {priv1=true,...}) -> bool, missing_privs
 minetest.get_player_ip(name) -> IP address string
 
 Chat:
-minetest.chat_send_all(text)
+minetest.chat_send_all(text, prepend)
 minetest.chat_send_player(name, text, prepend)
 ^ prepend: optional, if it is set to false "Server -!- " will not be prepended to the message
 


### PR DESCRIPTION
Allow prepend argument with minetest.chat_send_all
