### PR TITLE
Optional dependencies

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -120,6 +120,17 @@ depends.txt:
   List of mods that have to be loaded before loading this mod.
   A single line contains a single modname.
 
+  Optional dependencies can be defined by appending a question mark
+  to a single modname. Their meaning is that if the specified mod
+  is missing, that does not prevent this mod from being loaded.
+
+optdepends.txt:
+  An alternative way of specifying optional dependencies.
+  Like depends.txt, a single line contains a single modname.
+
+  NOTE: This file exists for compatibility purposes only and
+  support for it will be removed from the engine by the end of 2013.
+
 init.lua:
   The main Lua script. Running this script should register everything it
   wants to register. Subsequent execution depends on minetest calling the

--- a/src/guiConfigureWorld.cpp
+++ b/src/guiConfigureWorld.cpp
@@ -407,14 +407,26 @@ bool GUIConfigureWorld::OnEvent(const SEvent& event)
 				delete[] text;
 				menu->drop();
 
-				ModConfiguration modconf(m_wspec.path);
-				if(!modconf.isConsistent())
+				try
 				{
-					wchar_t* text = wgettext("Warning: Configuration not consistent.  ");
+					ModConfiguration modconf(m_wspec.path);
+					if(!modconf.isConsistent())
+					{
+						wchar_t* text = wgettext("Warning: Configuration not consistent.  ");
+						GUIMessageMenu *menu =
+							new GUIMessageMenu(Environment, Parent, -1, m_menumgr, 
+										 text );
+						delete[] text;
+						menu->drop();
+					}
+				}
+				catch(ModError &err)
+				{
+					errorstream<<err.what()<<std::endl;
+					std::wstring text = narrow_to_wide(err.what()) + wgettext("\nCheck debug.txt for details.");
 					GUIMessageMenu *menu =
 						new GUIMessageMenu(Environment, Parent, -1, m_menumgr, 
-										 text );
-					delete[] text;
+									 text );
 					menu->drop();
 				}
 

--- a/src/scriptapi.cpp
+++ b/src/scriptapi.cpp
@@ -76,8 +76,7 @@ bool scriptapi_loadmod(lua_State *L, const std::string &scriptpath,
 {
 	ModNameStorer modnamestorer(L, modname);
 
-	if(!string_allowed(modname, "abcdefghijklmnopqrstuvwxyz"
-			"0123456789_")){
+	if(!string_allowed(modname, MODNAME_ALLOWED_CHARS)){
 		errorstream<<"Error loading mod \""<<modname
 				<<"\": modname does not follow naming conventions: "
 				<<"Only chararacters [a-z0-9_] are allowed."<<std::endl;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -707,11 +707,11 @@ Server::Server(
 
 	ModConfiguration modconf(m_path_world);
 	m_mods = modconf.getMods();
-	std::list<ModSpec> unsatisfied_mods = modconf.getUnsatisfiedMods();
+	std::vector<ModSpec> unsatisfied_mods = modconf.getUnsatisfiedMods();
 	// complain about mods with unsatisfied dependencies
 	if(!modconf.isConsistent())	
 	{
-		for(std::list<ModSpec>::iterator it = unsatisfied_mods.begin();
+		for(std::vector<ModSpec>::iterator it = unsatisfied_mods.begin();
 			it != unsatisfied_mods.end(); ++it)
 		{
 			ModSpec mod = *it;
@@ -745,7 +745,7 @@ Server::Server(
 	for(std::vector<ModSpec>::iterator it = m_mods.begin();
 			it != m_mods.end(); ++it)
 		load_mod_names.erase((*it).name);
-	for(std::list<ModSpec>::iterator it = unsatisfied_mods.begin();
+	for(std::vector<ModSpec>::iterator it = unsatisfied_mods.begin();
 			it != unsatisfied_mods.end(); ++it)
 		load_mod_names.erase((*it).name);
 	if(!load_mod_names.empty())


### PR DESCRIPTION
This adds optional dependencies to the mod loader. They can be specified by appending a question mark to a line in depends.txt, like so:

```
wool?
```

The implication is that the mod can use functionality from the wool mod and would therefore like to be loaded after wool, but it can also work without it.

Alternatively optional dependencies can be given in optdepends.txt (without question marks). This is purely a compatibility feature and should be removed after some time. The idea is that mods wouldn't want to use the '?' syntax in depends.txt initially, because it would break on older but supported versions of the core. Once mods phase out support for those versions, they can switch to the '?' syntax and at some point the core can stop looking for optdepends.txt.

The patch also adds checks for duplicated mod names. The exact behaviour is documented here: http://dev.minetest.net/Mod_name_conflicts#Future_versions_of_Minetest
