### PR TITLE
Fix world selection a bit (also fixes a main menu segfault)

### DIFF
--- a/src/guiMainMenu.cpp
+++ b/src/guiMainMenu.cpp
@@ -726,9 +726,11 @@ void GUIMainMenu::regenerateGui(v2u32 screensize)
 			gui::IGUIListBox *e = Environment->addListBox(rect, this,
 					GUI_ID_WORLD_LISTBOX);
 			e->setDrawBackground(true);
-			for(std::vector<WorldSpec>::const_iterator i = m_data->worlds.begin();
-					i != m_data->worlds.end(); i++){
-				e->addItem(narrow_to_wide(i->name+" ["+i->gameid+"]").c_str());
+			m_world_indices.clear();
+			for(size_t wi = 0; wi < m_data->worlds.size(); wi++){
+				const WorldSpec &spec = m_data->worlds[wi];
+				e->addItem(narrow_to_wide(spec.name+" ["+spec.gameid+"]").c_str());
+				m_world_indices.push_back(wi);
 			}
 			e->setSelected(m_data->selected_world);
 		}
@@ -1379,6 +1381,10 @@ bool GUIMainMenu::OnEvent(const SEvent& event)
 				quitMenu();
 				return true;
 			}
+		}
+		if(event.GUIEvent.EventType==gui::EGET_LISTBOX_CHANGED)
+		{
+			readInput(m_data);
 		}
 		if(event.GUIEvent.EventType==gui::EGET_LISTBOX_SELECTED_AGAIN)
 		{


### PR DESCRIPTION
This patch does two things:
1. It properly fills m_world_indices when opening the advanced tab in the main menu. Some other code in guiMainMenu relies on this. This fixes a segfault that can be reproduced as follows: (a) make sure at least one world exists, and select it; (b) go to the advanced tab and quit the game, so that the setting selected_mainmenu_tab is set to 2; (c) start the game, then try to switch to a different tab; (d) watch it burn.
2. Always update MainMenuData.selected_world when selecting a world, so that the world will be initially selected when you next start the game. Without this the behaviour is confusing: the selected world is only saved when starting it (fair enough) or configuring it (hmm?) or interacting with other gui elements such as switching to a different tab (wut?).
