### PR TITLE
Dont use game filter in all tabs

### DIFF
--- a/src/guiMainMenu.cpp
+++ b/src/guiMainMenu.cpp
@@ -166,15 +166,6 @@ enum
 	GUI_ID_GAME_BUTTON_MAX = 150,
 };
 
-enum
-{
-	TAB_SINGLEPLAYER=0,
-	TAB_MULTIPLAYER,
-	TAB_ADVANCED,
-	TAB_SETTINGS,
-	TAB_CREDITS
-};
-
 GUIMainMenu::GUIMainMenu(gui::IGUIEnvironment* env,
 		gui::IGUIElement* parent, s32 id,
 		IMenuManager *menumgr,
@@ -258,7 +249,8 @@ void GUIMainMenu::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, size.X, 40);
 		rect += v2s32(4, 0);
 		std::string t = "Minetest " VERSION_STRING;
-		if(m_data->selected_game_name != ""){
+		if(m_data->selected_game_name != "" &&
+				m_data->selected_tab == TAB_SINGLEPLAYER){
 			t += "/";
 			t += m_data->selected_game_name;
 		}
@@ -428,6 +420,26 @@ void GUIMainMenu::regenerateGui(v2u32 screensize)
 			delete[] text;
 		}
 		changeCtype("C");
+
+		/* Add game selection buttons */
+		video::IVideoDriver* driver = Environment->getVideoDriver();
+		for(size_t i=0; i<m_data->games.size(); i++){
+			const SubgameSpec *spec = &m_data->games[i];
+			v2s32 p(8 + i*(48+8), screensize.Y - (48+8));
+			core::rect<s32> rect(0, 0, 48, 48);
+			rect += p;
+			video::ITexture *bgtexture = NULL;
+			if(spec->menuicon_path != "")
+				bgtexture = driver->getTexture(spec->menuicon_path.c_str());
+			gui::IGUIButton *b = Environment->addButton(rect, this,
+					GUI_ID_GAME_BUTTON_FIRST+i, narrow_to_wide(wrap_rows(spec->id, 4)).c_str());
+			if(bgtexture){
+				b->setImage(bgtexture);
+				b->setText(L"");
+				b->setDrawBorder(false);
+				b->setUseAlphaChannel(true);
+			}
+		}
 	}
 	else if(m_data->selected_tab == TAB_MULTIPLAYER)
 	{
@@ -917,27 +929,6 @@ void GUIMainMenu::regenerateGui(v2u32 screensize)
 			for (int i = 0; i != ARRAYLEN(contrib_previous_strs); i++)
 				list->addItem(contrib_previous_strs[i]);
 			list->addItem(L"");
-		}
-	}
-
-	/* Add game selection buttons */
-
-	video::IVideoDriver* driver = Environment->getVideoDriver();
-	for(size_t i=0; i<m_data->games.size(); i++){
-		const SubgameSpec *spec = &m_data->games[i];
-		v2s32 p(8 + i*(48+8), screensize.Y - (48+8));
-		core::rect<s32> rect(0, 0, 48, 48);
-		rect += p;
-		video::ITexture *bgtexture = NULL;
-		if(spec->menuicon_path != "")
-			bgtexture = driver->getTexture(spec->menuicon_path.c_str());
-		gui::IGUIButton *b = Environment->addButton(rect, this,
-				GUI_ID_GAME_BUTTON_FIRST+i, narrow_to_wide(wrap_rows(spec->id, 4)).c_str());
-		if(bgtexture){
-			b->setImage(bgtexture);
-			b->setText(L"");
-			b->setDrawBorder(false);
-			b->setUseAlphaChannel(true);
 		}
 	}
 

--- a/src/guiMainMenu.h
+++ b/src/guiMainMenu.h
@@ -34,6 +34,15 @@ enum {
 	SERVERLIST_PUBLIC,
 };
 
+enum
+{
+	TAB_SINGLEPLAYER=0,
+	TAB_MULTIPLAYER,
+	TAB_ADVANCED,
+	TAB_SETTINGS,
+	TAB_CREDITS
+};
+
 struct MainMenuData
 {
 	// These are in the native format of the gui elements


### PR DESCRIPTION
The game filter will be only used in singleplayer tab. The textures from the game are only used there.
In the other tabs menu_{background,overlay,header,footer}.png is used.
