### PR TITLE
Use max FOV for isBlockInSight.  Fix/workaround for issue #718.

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -343,7 +343,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, v2u32 screensize,
 	// Increase vertical FOV on lower aspect ratios (<16:10)
 	m_fov_y *= MYMAX(1.0, MYMIN(1.4, sqrt(16./10. / m_aspect)));
 	// WTF is this? It can't be right
-	m_fov_x = 2 * atan(0.5 * m_aspect * tan(m_fov_y));
+	m_fov_x = 2 * atan(m_aspect * tan(0.5 * m_fov_y));
 	m_cameranode->setAspectRatio(m_aspect);
 	m_cameranode->setFOV(m_fov_y);
 


### PR DESCRIPTION
This addresses 2 problems: the server not sending blocks to the client that are visible (because the server's assumption about the client's FOV is incorrect), and the client not drawing blocks that are visible on-screen.

In both cases, this commit just ignores the FOV (or assumptions thereabout) and uses the worst-case 180-degree FOV, which ensures that at least all required blocks are sent/drawn.

I also removed a redundant check that was repeated 2 lines below with the same values.

In the long run, someone with better geometry skills may want to make another attempt at the optimized solution.
