### PR TITLE
modified print format codes to use platform specific 64-bit codes (mingw)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -69,6 +69,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include "util/directiontables.h"
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+
 /*
 	Text input system
 */
@@ -2984,7 +2987,7 @@ void the_game(
 			char temptext[300];
 			snprintf(temptext, 300,
 					"(% .1f, % .1f, % .1f)"
-					" (yaw = %.1f) (seed = %llu)",
+					" (yaw = %.1f) (seed = %" PRIu64 ")",
 					player_position.X/BS,
 					player_position.Y/BS,
 					player_position.Z/BS,

--- a/src/settings.h
+++ b/src/settings.h
@@ -37,6 +37,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <set>
 
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+
 enum ValueType
 {
 	VALUETYPE_STRING,
@@ -767,19 +770,19 @@ fail:
 					if (width == 16) {
 						bufpos += PADDING(bufpos, u16);
 						nprinted = snprintf(sbuf + pos, sbuflen,
-									is_unsigned ? "%u, " : "%d, ",
+									is_unsigned ? "%" PRIu16 ", " : "%" PRId16 ", ",
 									*((u16 *)bufpos));
 						bufpos += sizeof(u16);
 					} else if (width == 32) {
 						bufpos += PADDING(bufpos, u32);
 						nprinted = snprintf(sbuf + pos, sbuflen,
-									is_unsigned ? "%u, " : "%d, ",
+									is_unsigned ? "%" PRIu32 ", " : "%" PRId32 ", ",
 									*((u32 *)bufpos));
 						bufpos += sizeof(u32);
 					} else if (width == 64) {
 						bufpos += PADDING(bufpos, u64);
 						nprinted = snprintf(sbuf + pos, sbuflen,
-									is_unsigned ? "%llu, " : "%lli, ",
+									is_unsigned ? "%" PRIu64 ", " : "%" PRId64 ", ",
 									(unsigned long long)*((u64 *)bufpos));
 						bufpos += sizeof(u64);
 					}


### PR DESCRIPTION
MinGW uses different format codes for 64bit ints. While it throws just a warning when compiling, it will i.e. display a wrong number for the seed due to the unrecognized format code.

The 16/32bit format codes in the construct are replaced for consistency - since they explicitely handling width-specific values this seemed like a good idea...
