### PR TITLE
fixes single spawned particles from ignoring collision-detection flag

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1987,7 +1987,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 
 		event.spawn_particle.expirationtime = expirationtime;
 		event.spawn_particle.size = size;
-		event.add_particlespawner.collisiondetection =
+		event.spawn_particle.collisiondetection =
 				collisiondetection;
 		event.spawn_particle.texture = new std::string(texture);
 


### PR DESCRIPTION
Fixes a typo: The client command handler initialises the wrong member, as a result single spawned particles ignore the coll-det flag and may have an unpreditable state, i.e. from Lua add_particle (which during testing happened to be always on)
