### PR TITLE
Fix multiple texture update support for animated meshnodes.

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1308,7 +1308,7 @@ public:
 					}
 
 					// Set material flags and texture
-					m_animated_meshnode->setMaterialTexture(i, texture);
+					m_animated_meshnode->getMaterial(i).TextureLayer[0].Texture = texture;
 					video::SMaterial& material = m_animated_meshnode->getMaterial(i);
 					material.setFlag(video::EMF_LIGHTING, false);
 					material.setFlag(video::EMF_BILINEAR_FILTER, false);


### PR DESCRIPTION
This will allow 3d entity models with multiple UV textures and materials to be updated through Lua.
Currently only the first material texture gets updated which was clearly not the author's intention.

Test mod and model available for download.
Forum topic: http://forum.minetest.net/viewtopic.php?pid=91372
