### PR TITLE
fixed wrongly named invref:get_location() table members for nodes, so th...

### DIFF
--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -306,10 +306,10 @@ int InvRef::l_get_location(lua_State *L)
 		return 1;
 	case InventoryLocation::NODEMETA:
 		lua_newtable(L);
-		lua_pushstring(L, "nodemeta");
+		lua_pushstring(L, "node");
 		lua_setfield(L, -2, "type");
 		push_v3s16(L, loc.p);
-		lua_setfield(L, -2, "name");
+		lua_setfield(L, -2, "pos");
 		return 1;
 	case InventoryLocation::DETACHED:
 		lua_newtable(L);


### PR DESCRIPTION
...at the result is compatible with the minetest.get_inventory(location) param 
(as it is stated in the api docs)
