### PR TITLE
fix cmake-gui causing run_in_place to be always off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ else()
 	set(RUN_IN_PLACE 0 CACHE BOOL "Run directly in source directory structure")
 endif()
 
+# RUN_IN_PLACE is exported as a #define value, ensure it's 1/0 instead of ON/OFF
+if(RUN_IN_PLACE)
+	set(RUN_IN_PLACE 1)
+else()
+	set(RUN_IN_PLACE 0)
+endif()
+
 set(BUILD_CLIENT 1 CACHE BOOL "Build client")
 if(WIN32)
 	set(BUILD_SERVER 0 CACHE BOOL "Build server")


### PR DESCRIPTION
The boolean checkbox state for RUN_IN_PLACE seems to be cached by cmake (after using cmake-gui for the initial setup) as either "ON" or "OFF".

This value is directly used in the "cmake_config.h.in" template to generate a define, which will set RUN_IN_PLACE=ON.
Since "ON" isn't defined, subsequent makes will never build the run-in-place version, but always the user-dir-storage version.

This fix normalises the RUN_IN_PLACE value right after it's been set from the cache - maybe someone with cmake knowledge knows how to enforce the boolean to 1/0 in the first place?
