### PR TITLE
fixed editbox default text being pre-selected in some cases

### DIFF
--- a/src/guiCreateWorld.cpp
+++ b/src/guiCreateWorld.cpp
@@ -135,6 +135,9 @@ void GUICreateWorld::regenerateGui(v2u32 screensize)
 		evt.EventType = EET_KEY_INPUT_EVENT;
 		evt.KeyInput.Key = KEY_END;
 		evt.KeyInput.PressedDown = true;
+		evt.KeyInput.Char = 0;
+		evt.KeyInput.Control = 0;
+		evt.KeyInput.Shift = 0;
 		e->OnEvent(evt);
 	}
 	{

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -418,9 +418,12 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 					e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 				} else {
 					irr::SEvent evt;
-					evt.KeyInput.Key = KEY_END;
 					evt.EventType = EET_KEY_INPUT_EVENT;
+					evt.KeyInput.Key = KEY_END;
 					evt.KeyInput.PressedDown = true;
+					evt.KeyInput.Char = 0;
+					evt.KeyInput.Control = 0;
+					evt.KeyInput.Shift = 0;
 					e->OnEvent(evt);
 				}
 

--- a/src/guiTextInputMenu.cpp
+++ b/src/guiTextInputMenu.cpp
@@ -121,6 +121,9 @@ void GUITextInputMenu::regenerateGui(v2u32 screensize)
 		evt.EventType = EET_KEY_INPUT_EVENT;
 		evt.KeyInput.Key = KEY_END;
 		evt.KeyInput.PressedDown = true;
+		evt.KeyInput.Char = 0;
+		evt.KeyInput.Control = 0;
+		evt.KeyInput.Shift = 0;
 		e->OnEvent(evt);
 	}
 	changeCtype("");


### PR DESCRIPTION
Mostly noticed when using the command key "/", this happens because the irr::SEvent is a simple uninitialized struct and KeyInput.Shift is just a bitfield bit, resulting in an increased chance that the injected End-key (move cursor to end and remove selection) is seen as Shift-End (select text until the end).

The fix adds the missing inits to where this end-key trick is used - at least I hope I haven't overlooked any places.
