### PR TITLE
Unload blocks during /clearobjects

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -254,6 +254,8 @@
 #max_block_send_distance = 10
 # From how far blocks are generated for clients (value * 16 nodes)
 #max_block_generate_distance = 6
+# Number of extra blocks that can be loaded by /clearobjects at once
+#max_clearobjects_extra_loaded_blocks = 4096
 # Interval of sending time of day to clients
 #time_send_interval = 5
 # Length of day/night cycle. 72=20min, 360=4min, 1=24hour, 0=day/night/whatever stays unchanged

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -175,6 +175,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_simultaneous_block_sends_server_total", "20");
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("max_block_generate_distance", "7");
+	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_send_interval", "5");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1510,6 +1510,11 @@ void Map::timerUpdate(float dtime, float unload_timeout,
 	}
 }
 
+void Map::unloadUnreferencedBlocks(std::list<v3s16> *unloaded_blocks)
+{
+	timerUpdate(0.0, -1.0, unloaded_blocks);
+}
+
 void Map::deleteSectors(std::list<v2s16> &list)
 {
 	for(std::list<v2s16>::iterator j = list.begin();
@@ -3404,6 +3409,26 @@ void ServerMap::listAllLoadableBlocks(std::list<v3s16> &dst)
 			sqlite3_int64 block_i = sqlite3_column_int64(m_database_list, 0);
 			v3s16 p = getIntegerAsBlock(block_i);
 			//dstream<<"block_i="<<block_i<<" p="<<PP(p)<<std::endl;
+			dst.push_back(p);
+		}
+	}
+}
+
+void ServerMap::listAllLoadedBlocks(std::list<v3s16> &dst)
+{
+	for(std::map<v2s16, MapSector*>::iterator si = m_sectors.begin();
+		si != m_sectors.end(); ++si)
+	{
+		MapSector *sector = si->second;
+
+		std::list<MapBlock*> blocks;
+		sector->getBlocks(blocks);
+
+		for(std::list<MapBlock*>::iterator i = blocks.begin();
+				i != blocks.end(); ++i)
+		{
+			MapBlock *block = (*i);
+			v3s16 p = block->getPos();
 			dst.push_back(p);
 		}
 	}

--- a/src/map.h
+++ b/src/map.h
@@ -279,6 +279,12 @@ public:
 	void timerUpdate(float dtime, float unload_timeout,
 			std::list<v3s16> *unloaded_blocks=NULL);
 
+	/*
+		Unloads all blocks with a zero refCount().
+		Saves modified blocks before unloading on MAPTYPE_SERVER.
+	*/
+	void unloadUnreferencedBlocks(std::list<v3s16> *unloaded_blocks=NULL);
+
 	// Deletes sectors and their blocks from memory
 	// Takes cache into account
 	// If deleted sector is in sector cache, clears cache
@@ -433,8 +439,8 @@ public:
 	void endSave();
 
 	void save(ModifiedState save_level);
-	//void loadAll();
 	void listAllLoadableBlocks(std::list<v3s16> &dst);
+	void listAllLoadedBlocks(std::list<v3s16> &dst);
 	// Saves map seed and possibly other stuff
 	void saveMapMeta();
 	void loadMapMeta();


### PR DESCRIPTION
Currently /clearobjects never unloads the blocks it loads (until the command completes and the normal server operation resumes, causing Map::timerUpdate() to be called again). /clearobjects consumes <del>13GB</del> <ins>22.5GB</ins> on VanessaE's server, for example.

With this patch, Environment::clearAllObjects() unloads unused blocks in an interval
defined by max_clearobjects_extra_loaded_blocks (default 4096). Blocks that were already loaded before /clearobjects won't be unloaded by the new code.
