### PR TITLE
Replace c55.me links

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1,6 +1,7 @@
 Minetest Lua Modding API Reference 0.4.6
 ========================================
-More information at http://c55.me/minetest/
+More information at http://www.minetest.net/
+Developer Wiki: http://dev.minetest.net/
 
 Introduction
 -------------

--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -88,7 +88,7 @@ This man page was originally written by
 Juhani Numminen <juhaninumminen0@gmail.com>.
 
 .SH WWW
-http://c55.me/minetest/
+http://www.minetest.net/
 
 .SH "SEE ALSO"
 .BR minetestserver(6)

--- a/doc/minetestserver.6
+++ b/doc/minetestserver.6
@@ -64,7 +64,7 @@ This man page was originally written by
 Juhani Numminen <juhaninumminen0@gmail.com>.
 
 .SH WWW
-http://c55.me/minetest/
+http://www.minetest.net/
 
 .SH "SEE ALSO"
 .BR minetest(6)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -8,7 +8,7 @@
 # Uncomment settings by removing the preceding #.
 #
 # Further documentation:
-# http://c55.me/minetest/wiki/doku.php
+# http://wiki.minetest.com/
 #
 # NOTE: This file might not be up-to-date, refer to the
 #       defaultsettings.cpp file for an up-to-date list:


### PR DESCRIPTION
This replaces the c55.me links in the manpages, lua_api.txt and minetest.conf.example with links to minetest.net/com.
