### PR TITLE
Fix keyboard focus when closing a menu

### DIFF
--- a/src/modalMenu.h
+++ b/src/modalMenu.h
@@ -99,6 +99,7 @@ public:
 		allowFocusRemoval(true);
 		// This removes Environment's grab on us
 		Environment->removeFocus(this);
+		m_menumgr->deletingMenu(this);
 		this->remove();
 	}
 


### PR DESCRIPTION
This fixes the bug where noMenuActive() keeps returning false after
closing a menu until the mouse is moved, rendering the keyboard
unusable (the_game calls input->clear() every frame when
noMenuActive() is false).

&lt;kahrl> my one-liner hides a deeper symptom that is caused by irrlicht
&lt;kahrl> when the currently hovered gui element is removed from the gui
            manager, the "Hovered" variable in the gui manager still points
            to the element
&lt;kahrl> and this means the element can't be deleted because the
            reference count is nonzero
&lt;kahrl> minetest currently gives keyboard focus back to the main menu in
            the menu destructor, my patch makes it do that earlier
