### PR TITLE
Corrected segfault when registering new biomes.

### DIFF
--- a/src/script/lua_api/luaapi.cpp
+++ b/src/script/lua_api/luaapi.cpp
@@ -178,9 +178,9 @@ int ModApiBasic::l_register_biome(lua_State *L)
 	b->flags = 0; //reserved
 	b->c_top = CONTENT_IGNORE;
 	b->c_filler = CONTENT_IGNORE;
+	verbosestream << "register_biome: " << b->name << std::endl;
 	bmgr->addBiome(b);
 
-	verbosestream << "register_biome: " << b->name << std::endl;
 	return 0;
 }
 


### PR DESCRIPTION
Whenever addBiome discards a new biome (more than 255 biomes, or biome registering process already finished), it deletes it.

The code afterwards assumed the biome could not be deleted, and evoked it for a streaminfo print.
This fix corrects that.
