### PR TITLE
Fix/Add basic unicode support in the console

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -545,7 +545,13 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)
 		{
-			m_chat_backend->getPrompt().input(event.KeyInput.Char);
+			#if (defined(linux) || defined(__linux))
+				wchar_t wc = L'_';
+				mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
+				m_chat_backend->getPrompt().input(wc);
+			#else
+				m_chat_backend->getPrompt().input(event.KeyInput.Char);
+			#endif
 			return true;
 		}
 	}


### PR DESCRIPTION
Actually, you can't type "non-ascii" characters in the console (on linux), with this patch the same workaround used here ( https://github.com/minetest/minetest/commit/b24b8de00b7ab5f81b0e0255509af3f10f6e2514#L16R276 ), is used for the console.

edit: this is only valid for linux
