### PR TITLE
Fix formspecs mixing up with the console

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2250,6 +2250,7 @@ void the_game(
 								new GUIFormSpecMenu(device, guiroot, -1,
 										&g_menumgr,
 										&client, gamedef);
+						gui_chat_console->closeConsoleAtOnce(); // close the console for avoiding glitches
 						menu->setFormSource(current_formspec);
 						menu->setTextDest(current_textdest);
 						menu->drop();


### PR DESCRIPTION
Actually; if you try to "open" a formspec with the console opened, it will glitch and "mess up" (having to exit the formspec, and press f10 for "enabling" the console other time, then press it other time for closing it properly)

This makes the console "close" when a formspec is going to be opened.
