### PR TITLE
Close console when it loses focus but it is still on screen

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1684,6 +1684,10 @@ void the_game(
 		{
 			input->clear();
 		}
+		if (!guienv->hasFocus(gui_chat_console) && gui_chat_console->isOpen())
+		{
+			gui_chat_console->closeConsoleAtOnce();
+		}
 
 		// Input handler step() (used by the random input generator)
 		input->step(dtime);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -134,6 +134,11 @@ void GUIChatConsole::openConsole(f32 height)
 	reformatConsole();
 }
 
+bool GUIChatConsole::isOpen() const
+{
+	return m_open;
+}
+
 bool GUIChatConsole::isOpenInhibited() const
 {
 	return m_open_inhibited > 0;

--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -39,6 +39,9 @@ public:
 	// This doesn't open immediately but initiates an animation.
 	// You should call isOpenInhibited() before this.
 	void openConsole(f32 height);
+
+	bool isOpen() const;
+
 	// Check if the console should not be opened at the moment
 	// This is to avoid reopening the console immediately after closing
 	bool isOpenInhibited() const;


### PR DESCRIPTION
Close the console when it loses focus, like when you die (respawn screen), a formspec "opens", etc. 
