### PR TITLE
Fix being able to sneak on a node with only 1 air space above it

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -259,8 +259,10 @@ void LocalPlayer::move(f32 dtime, ClientEnvironment *env, f32 pos_max_d,
 				// The node to be sneaked on has to be walkable
 				if(nodemgr->get(map->getNode(p)).walkable == false)
 					continue;
-				// And the node above it has to be nonwalkable
+				// And the 2 nodes above it have to be nonwalkable
 				if(nodemgr->get(map->getNode(p+v3s16(0,1,0))).walkable == true)
+					continue;
+				if(nodemgr->get(map->getNode(p+v3s16(0,2,0))).walkable == true)
 					continue;
 			}
 			catch(InvalidPositionException &e)


### PR DESCRIPTION
Commonly used for _Sneak+Jump_ "Ladder"
![screenshot_441891317](https://f.cloud.github.com/assets/1042418/619185/27b21e88-cec7-11e2-9f70-7dd1bf6582da.png)
