### PR TITLE
Fix multiple texture support for animated meshnodes

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1308,8 +1308,8 @@ public:
 					}
 
 					// Set material flags and texture
-					m_animated_meshnode->setMaterialTexture(i, texture);
 					video::SMaterial& material = m_animated_meshnode->getMaterial(i);
+					material.TextureLayer[0].Texture = texture;
 					material.setFlag(video::EMF_LIGHTING, false);
 					material.setFlag(video::EMF_BILINEAR_FILTER, false);
 


### PR DESCRIPTION
This will allow 3d entity models with multiple UV textures and materials to be updated through Lua.
Currently only the first material texture gets updated which clearly was not the author's intention.
A test mod and model are available for download in the forum topic linked below.

This was previously merged then (imo) unnecessarily reverted. Only one mod I am aware of was effected and that particular problem can be easily remedied. Please read the updated forum topic for full details.

Minetest forum topic: http://forum.minetest.net/viewtopic.php?pid=91372
Irrlicht forum topic: http://irrlicht.sourceforge.net/forum/viewtopic.php?f=1&t=37046&p=215659
