### PR TITLE
Better handling of TOCLIENT_MEDIA after client is started

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -802,7 +802,8 @@ void Client::step(float dtime)
 			all_stopped &= !(*thread)->IsRunning();
 			while (!(*thread)->m_file_data.empty()) {
 				std::pair <std::string, std::string> out = (*thread)->m_file_data.pop_front();
-				++m_media_received_count;
+				if(m_media_received_count < m_media_count)
+					m_media_received_count++;
 
 				bool success = loadMedia(out.second, out.first);
 				if(success){
@@ -1736,14 +1737,8 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 	}
 	else if(command == TOCLIENT_MEDIA)
 	{
-		if (m_media_count == 0)
-			return;
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
-
-		// Mesh update thread must be stopped while
-		// updating content definitions
-		assert(!m_mesh_update_thread.IsRunning());
 
 		/*
 			u16 command
@@ -1759,11 +1754,31 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		*/
 		int num_bunches = readU16(is);
 		int bunch_i = readU16(is);
-		int num_files = readU32(is);
+		u32 num_files = readU32(is);
 		infostream<<"Client: Received files: bunch "<<bunch_i<<"/"
 				<<num_bunches<<" files="<<num_files
 				<<" size="<<datasize<<std::endl;
-		for(int i=0; i<num_files; i++){
+
+		// Check total and received media count
+		assert(m_media_received_count <= m_media_count);
+		if (num_files > m_media_count - m_media_received_count) {
+			errorstream<<"Client: Received more files than requested:"
+				<<" total count="<<m_media_count
+				<<" total received="<<m_media_received_count
+				<<" bunch "<<bunch_i<<"/"<<num_bunches
+				<<" files="<<num_files
+				<<" size="<<datasize<<std::endl;
+			num_files = m_media_count - m_media_received_count;
+		}
+		if (num_files == 0)
+			return;
+
+		// Mesh update thread must be stopped while
+		// updating content definitions
+		assert(!m_mesh_update_thread.IsRunning());
+
+		for(u32 i=0; i<num_files; i++){
+			assert(m_media_received_count < m_media_count);
 			m_media_received_count++;
 			std::string name = deSerializeString(is);
 			std::string data = deSerializeLongString(is);


### PR DESCRIPTION
This is an attempt to fix the "Assertion '!m_mesh_update_thread.IsRunning()' failed." crash shown in http://pastebin.com/4ctZUC2v. When TOCLIENT_MEDIA is received when all media has already been received, write an error message to errorstream (unless num_files is 0) and return before the mesh update thread assertion.

Since the assertion failure can not reliably be reproduced, I don't know if this patch really fixes it. This needs testing, also in combination with cURL enabled clients and servers.
