### PR TITLE
Lua function to add multiple nodes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1035,6 +1035,8 @@ Environment access:
 minetest.set_node(pos, node)
 minetest.add_node(pos, node): alias set_node(pos, node)
 ^ Set node at position (node = {name="foo", param1=0, param2=0})
+minetest.set_node_group( { {pos1, node1}, {pos2, node2} } )
+^ Same as set_node but using a list to add multiple nodes
 minetest.remove_node(pos)
 ^ Equivalent to set_node(pos, "air")
 minetest.get_node(pos)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -97,6 +97,59 @@ int ModApiEnvMod::l_add_node(lua_State *L)
 	return l_set_node(L);
 }
 
+// minetest.set_node( { {pos1, node1}, {pos2, node2} } )
+// pos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_set_node_group(lua_State *L)
+{
+	GET_ENV_PTR;
+	INodeDefManager *ndef = env->getGameDef()->ndef();
+
+	if(!lua_istable(L, 1))
+		return 0;
+
+	lua_pushnil(L);
+	while(lua_next(L, 1) != 0){
+		// key at index -2 and value at index -1
+		if(!lua_istable(L, -1))
+			return 0;
+
+		v3s16 pos;
+		MapNode n;
+
+		lua_pushnil(L);
+		while(lua_next(L, -2) != 0){
+			// key at index -2 and value at index -1
+			if(!lua_istable(L, -1))
+				return 0;
+
+			int id = lua_tonumber(L, -2);
+			switch (id) {
+				case 1: {
+					// pos
+					pos = read_v3s16(L, -1);
+					break;
+				}
+				case 2: {
+					// node
+					n = readnode(L, -1, ndef);
+					break;
+				}
+				default:
+					break;
+			}
+			lua_pop(L, 1);
+		}
+
+		// Do it
+		env->setNode(pos, n);
+
+		lua_pop(L, 1);
+	}
+
+	lua_pushboolean(L, true);
+	return 1;
+}
+
 // minetest.remove_node(pos)
 // pos = {x=num, y=num, z=num}
 int ModApiEnvMod::l_remove_node(lua_State *L)
@@ -659,6 +712,7 @@ bool ModApiEnvMod::Initialize(lua_State *L,int top)
 
 	retval &= API_FCT(set_node);
 	retval &= API_FCT(add_node);
+	retval &= API_FCT(set_node_group);
 	retval &= API_FCT(add_item);
 	retval &= API_FCT(remove_node);
 	retval &= API_FCT(get_node);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -38,6 +38,10 @@ private:
 
 	static int l_add_node(lua_State *L);
 
+	// minetest.set_node_group( { {pos1, node1}, {pos2, node2} } )
+	// pos = {x=num, y=num, z=num}
+	static int l_set_node_group(lua_State *L);
+
 	// minetest.remove_node(pos)
 	// pos = {x=num, y=num, z=num}
 	static int l_remove_node(lua_State *L);


### PR DESCRIPTION
New Lua function aimed at solving slowness and potential failure when using set_node to spawn a lot of nodes simultaneously. The new function has the same architecture as set_node only that it sends a list instead, allowing the code to handle them. This is a lot quicker and safer and should benefit mods which spawn large structures.
