### PR TITLE
Brighter sun faces

### DIFF
--- a/client/shaders/test_shader_1/opengl_vertex.glsl
+++ b/client/shaders/test_shader_1/opengl_vertex.glsl
@@ -48,6 +48,10 @@ void main(void)
 	if(gl_Normal.y <= 0.5)
 		color *= 0.6;
 		//color *= 0.7;
+	// Also make sides not facing the sun / moon darker
+	if(gl_Normal.z <= -0.5 || gl_Normal.z >= 0.5)
+		color *= 0.6;
+
 	color = sqrt(color); // Linear -> SRGB
 
 	color.a = gl_Color.a;

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1161,6 +1161,13 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data):
 					vc.setGreen(srgb_linear_multiply(vc.getGreen(), 1.3, 255.0));
 					vc.setBlue (srgb_linear_multiply(vc.getBlue(),  1.3, 255.0));
 				}
+				// Brighten sides facing sun / moon (no shaders)
+				if(p.vertices[j].Normal.Z > -0.5 || p.vertices[j].Normal.Z < 0.5)
+				{
+					vc.setRed  (srgb_linear_multiply(vc.getRed(),   1.3, 255.0));
+					vc.setGreen(srgb_linear_multiply(vc.getGreen(), 1.3, 255.0));
+					vc.setBlue (srgb_linear_multiply(vc.getBlue(),  1.3, 255.0));
+				}
 			}
 		}
 
@@ -1314,10 +1321,17 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack, u32 daynight_rat
 				u8 night = j->second.second;
 				finalColorBlend(vertices[vertexIndex].Color,
 						day, night, daynight_ratio);
+				video::SColor &vc = vertices[vertexIndex].Color;
 				// Brighten topside (no shaders)
 				if(vertices[vertexIndex].Normal.Y > 0.5)
 				{
-					video::SColor &vc = vertices[vertexIndex].Color;
+					vc.setRed  (srgb_linear_multiply(vc.getRed(),   1.3, 255.0));
+					vc.setGreen(srgb_linear_multiply(vc.getGreen(), 1.3, 255.0));
+					vc.setBlue (srgb_linear_multiply(vc.getBlue(),  1.3, 255.0));
+				}
+				// Brighten sides facing sun / moon (no shaders)
+				if(vertices[vertexIndex].Normal.Z > -0.5 || vertices[vertexIndex].Normal.Z < 0.5)
+				{
 					vc.setRed  (srgb_linear_multiply(vc.getRed(),   1.3, 255.0));
 					vc.setGreen(srgb_linear_multiply(vc.getGreen(), 1.3, 255.0));
 					vc.setBlue (srgb_linear_multiply(vc.getBlue(),  1.3, 255.0));


### PR DESCRIPTION
Intended as a suggestion, please reject if the idea is bad.

I noticed in MineCraft that the environment looks a lot more beautiful and real when there's a brightness difference between block faces. Minetest already has brighter top surfaces, so I also made sides facing the sun / moon axis a bit brighter. I think it gives a lot more feel and realism until we'll have hardware lighting at last.

I only tested the shader version since for some reason the C++ / non-shader topside brightening won't work.

http://i42.tinypic.com/9an53q.png

http://i39.tinypic.com/2mgns3l.png
