### PR TITLE
Add an option to disable object <-> object collision for Lua entities

### DIFF
--- a/builtin/falling.lua
+++ b/builtin/falling.lua
@@ -7,6 +7,7 @@
 minetest.register_entity("__builtin:falling_node", {
 	initial_properties = {
 		physical = true,
+		collide_with_objects = false,
 		collisionbox = {-0.5,-0.5,-0.5, 0.5,0.5,0.5},
 		visual = "wielditem",
 		textures = {},

--- a/builtin/item_entity.lua
+++ b/builtin/item_entity.lua
@@ -12,6 +12,7 @@ minetest.register_entity("__builtin:item", {
 	initial_properties = {
 		hp_max = 1,
 		physical = true,
+		collide_with_objects = false,
 		collisionbox = {-0.17,-0.17,-0.17, 0.17,0.17,0.17},
 		visual = "sprite",
 		visual_size = {x=0.5, y=0.5},

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1563,6 +1563,7 @@ Object Properties
 {
     hp_max = 1,
     physical = true,
+    collide_with_objects = true, -- collide with other objects if physical=true
     weight = 5,
     collisionbox = {-0.5,-0.5,-0.5, 0.5,0.5,0.5},
     visual = "cube"/"sprite"/"upright_sprite"/"mesh",

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -62,6 +62,7 @@ public:
 
 	virtual u8 getType() const = 0;
 	virtual bool getCollisionBox(aabb3f *toset) = 0;
+	virtual bool collideWithObjects() = 0;
 protected:
 	u16 m_id; // 0 is invalid, "no id"
 };

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -56,6 +56,7 @@ public:
 	virtual v3s16 getLightPosition(){return v3s16(0,0,0);}
 	virtual core::aabbox3d<f32>* getSelectionBox(){return NULL;}
 	virtual core::aabbox3d<f32>* getCollisionBox(){return NULL;}
+	virtual bool collideWithObjects(){return false;}
 	virtual v3f getPosition(){return v3f(0,0,0);}
 	virtual scene::IMeshSceneNode *getMeshSceneNode(){return NULL;}
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode(){return NULL;}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -192,7 +192,9 @@ bool wouldCollideWithCeiling(
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		f32 pos_max_d, const aabb3f &box_0,
 		f32 stepheight, f32 dtime,
-		v3f &pos_f, v3f &speed_f, v3f &accel_f,ActiveObject* self)
+		v3f &pos_f, v3f &speed_f,
+		v3f &accel_f,ActiveObject* self,
+		bool collideWithObjects)
 {
 	Map *map = &env->getMap();
 	//TimeTaker tt("collisionMoveSimple");
@@ -283,6 +285,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	}
 	} // tt2
 
+	if(collideWithObjects)
 	{
 		ScopeProfiler sp(g_profiler, "collisionMoveSimple objects avg", SPT_AVG);
 		//TimeTaker tt3("collisionMoveSimple collect object boxes");
@@ -330,7 +333,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			if (object != NULL)
 			{
 				aabb3f object_collisionbox;
-				if (object->getCollisionBox(&object_collisionbox))
+				if (object->getCollisionBox(&object_collisionbox) &&
+						object->collideWithObjects())
 				{
 					cboxes.push_back(object_collisionbox);
 					is_unloaded.push_back(false);

--- a/src/collision.h
+++ b/src/collision.h
@@ -71,7 +71,9 @@ struct collisionMoveResult
 collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
 		f32 pos_max_d, const aabb3f &box_0,
 		f32 stepheight, f32 dtime,
-		v3f &pos_f, v3f &speed_f, v3f &accel_f,ActiveObject* self=0);
+		v3f &pos_f, v3f &speed_f,
+		v3f &accel_f,ActiveObject* self=0,
+		bool collideWithObjects=true);
 
 #if 0
 // This doesn't seem to work and isn't used

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -661,6 +661,10 @@ public:
 		return false;
 	}
 
+	bool collideWithObjects() {
+		return m_prop.collideWithObjects;
+	}
+
 	void initialize(const std::string &data)
 	{
 		infostream<<"GenericCAO: Got init data"<<std::endl;
@@ -1152,7 +1156,8 @@ public:
 				v3f p_acceleration = m_acceleration;
 				moveresult = collisionMoveSimple(env,env->getGameDef(),
 						pos_max_d, box, stepheight, dtime,
-						p_pos, p_velocity, p_acceleration,this);
+						p_pos, p_velocity, p_acceleration,
+						this, m_prop.collideWithObjects);
 				// Apply results
 				m_position = p_pos;
 				m_velocity = p_velocity;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -68,6 +68,10 @@ public:
 		return false;
 	}
 
+	bool collideWithObjects() {
+		return false;
+	}
+
 private:
 };
 
@@ -137,6 +141,10 @@ public:
 	}
 
 	bool getCollisionBox(aabb3f *toset) {
+		return false;
+	}
+
+	bool collideWithObjects() {
 		return false;
 	}
 
@@ -325,6 +333,9 @@ public:
 		return false;
 	}
 
+	bool collideWithObjects() {
+		return false;
+	}
 
 private:
 	std::string m_itemstring;
@@ -500,7 +511,8 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			v3f p_acceleration = m_acceleration;
 			moveresult = collisionMoveSimple(m_env,m_env->getGameDef(),
 					pos_max_d, box, stepheight, dtime,
-					p_pos, p_velocity, p_acceleration,this);
+					p_pos, p_velocity, p_acceleration,
+					this, m_prop.collideWithObjects);
 			// Apply results
 			m_base_position = p_pos;
 			m_velocity = p_velocity;
@@ -903,6 +915,10 @@ bool LuaEntitySAO::getCollisionBox(aabb3f *toset) {
 	}
 
 	return false;
+}
+
+bool LuaEntitySAO::collideWithObjects(){
+	return m_prop.collideWithObjects;
 }
 
 /*
@@ -1483,5 +1499,9 @@ bool PlayerSAO::getCollisionBox(aabb3f *toset) {
 	toset->MinEdge += m_base_position;
 	toset->MaxEdge += m_base_position;
 
+	return true;
+}
+
+bool PlayerSAO::collideWithObjects(){
 	return true;
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -79,6 +79,7 @@ public:
 			bool select_horiz_by_yawpitch);
 	std::string getName();
 	bool getCollisionBox(aabb3f *toset);
+	bool collideWithObjects();
 private:
 	std::string getPropertyPacket();
 	void sendPosition(bool do_interpolate, bool is_movement_end);
@@ -237,6 +238,7 @@ public:
 	}
 
 	bool getCollisionBox(aabb3f *toset);
+	bool collideWithObjects();
 
 private:
 	std::string getPropertyPacket();

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 ObjectProperties::ObjectProperties():
 	hp_max(1),
 	physical(false),
+	collideWithObjects(true),
 	weight(5),
 	collisionbox(-0.5,-0.5,-0.5, 0.5,0.5,0.5),
 	visual("sprite"),
@@ -49,6 +50,7 @@ std::string ObjectProperties::dump()
 	std::ostringstream os(std::ios::binary);
 	os<<"hp_max="<<hp_max;
 	os<<", physical="<<physical;
+	os<<", collideWithObjects="<<collideWithObjects;
 	os<<", weight="<<weight;
 	os<<", collisionbox="<<PP(collisionbox.MinEdge)<<","<<PP(collisionbox.MaxEdge);
 	os<<", visual="<<visual;
@@ -97,6 +99,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	for(u32 i=0; i<colors.size(); i++){
 		writeARGB8(os, colors[i]);
 	}
+	writeU8(os, collideWithObjects);
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -129,6 +132,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 			for(u32 i=0; i<color_count; i++){
 				colors.push_back(readARGB8(is));
 			}
+			collideWithObjects = readU8(is);
 		}catch(SerializationError &e){}
 	}
 	else

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -31,6 +31,7 @@ struct ObjectProperties
 	// Values are BS=1
 	s16 hp_max;
 	bool physical;
+	bool collideWithObjects;
 	float weight;
 	core::aabbox3d<f32> collisionbox;
 	std::string visual;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -120,6 +120,7 @@ void read_object_properties(lua_State *L, int index,
 	prop->hp_max = getintfield_default(L, -1, "hp_max", 10);
 
 	getboolfield(L, -1, "physical", prop->physical);
+	getboolfield(L, -1, "collide_with_objects", prop->collideWithObjects);
 
 	getfloatfield(L, -1, "weight", prop->weight);
 

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -169,6 +169,7 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	prop->hp_max = getintfield_default(L, -1, "hp_max", 10);
 
 	getboolfield(L, -1, "physical", prop->physical);
+	getboolfield(L, -1, "collide_with_objects", prop->collideWithObjects);
 
 	getfloatfield(L, -1, "weight", prop->weight);
 


### PR DESCRIPTION
Disables it for dropped items and falling nodes (it is just too glitchy for falling nodes).
