### PR TITLE
Fixed bug when building in Visual Studio 2012

### DIFF
--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "numeric.h"
+#include "mathconstants.h"
 
 #include "../log.h"
 #include "../constants.h" // BS, MAP_BLOCKSIZE


### PR DESCRIPTION
Visual Studio 2012 was giving me this error when building:

> error C2065: 'M_PI' : undeclared identifier

I solved this by adding #include "mathconstants.h" to "numeric.cpp"
