### PR TITLE
Test IPv6 on startup and disable its use on failure

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1050,7 +1050,7 @@ void the_game(
 		if(address == "")
 		{
 			//connect_address.Resolve("localhost");
-			if(g_settings->getBool("enable_ipv6") && g_settings->getBool("ipv6_server"))
+			if(sockets_use_ipv6() && g_settings->getBool("ipv6_server"))
 			{
 				IPv6AddressBytes addr_bytes;
 				addr_bytes.bytes[15] = 1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -59,6 +59,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "rollback.h"
 #include "util/serialize.h"
 #include "defaultsettings.h"
+#include "socket.h"
 
 void * ServerThread::Thread()
 {
@@ -640,7 +641,7 @@ Server::Server(
 	m_async_fatal_error(""),
 	m_env(NULL),
 	m_con(PROTOCOL_ID, 512, CONNECTION_TIMEOUT,
-	      g_settings->getBool("enable_ipv6") && g_settings->getBool("ipv6_server"), this),
+	      sockets_use_ipv6() && g_settings->getBool("ipv6_server"), this),
 	m_banmanager(path_world+DIR_DELIM+"ipban.txt"),
 	m_rollback(NULL),
 	m_rollback_sink_enabled(true),

--- a/src/socket.h
+++ b/src/socket.h
@@ -71,6 +71,7 @@ public:
 
 void sockets_init();
 void sockets_cleanup();
+bool sockets_use_ipv6();
 
 class IPv6AddressBytes
 {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1295,6 +1295,7 @@ struct TestSocket: public TestBase
 		const int port = 30003;
 
 		// IPv6 socket test
+		if(sockets_use_ipv6())
 		{
 			UDPSocket socket6(true);
 			socket6.Bind(port);


### PR DESCRIPTION
On systems that don't support IPv6, IPv6 currently has to be disabled manually.  With this patch IPv6 is tested on startup if it is enabled.  If the test fails, a warning is printed and IPv6 is disabled for the time being.  This patch addresses #793.
