### PR TITLE
Add VoxelArea helpers

### DIFF
--- a/builtin/voxelarea.lua
+++ b/builtin/voxelarea.lua
@@ -44,6 +44,22 @@ function VoxelArea:indexp(p)
 	return math.floor(i)
 end
 
+function VoxelArea:position(i)
+	local p = {}
+ 
+	i = i - 1
+
+	p.z = math.floor(i / self.zstride) + self.MinEdge.z
+	i = i % self.zstride
+
+	p.y = math.floor(i / self.ystride) + self.MinEdge.y
+	i = i % self.ystride
+
+	p.x = math.floor(i) + self.MinEdge.x
+
+	return p
+end
+
 function VoxelArea:contains(x, y, z)
 	return (x >= self.MinEdge.x) and (x <= self.MaxEdge.x) and
 		   (y >= self.MinEdge.y) and (y <= self.MaxEdge.y) and
@@ -60,3 +76,28 @@ function VoxelArea:containsi(i)
 	return (i >= 1) and (i <= self:getVolume())
 end
 
+function VoxelArea:iter(minx, miny, minz, maxx, maxy, maxz)
+	local i = self:index(minx, miny, minz) - 1
+	local last = self:index(maxx, maxy, maxz)
+	local ystride = self.ystride
+	local zstride = self.zstride
+	local yoff = (last+1) % ystride
+	local zoff = (last+1) % zstride
+	local ystridediff = (i - last) % ystride
+	local zstridediff = (i - last) % zstride
+	return function()
+		i = i + 1
+		if i % zstride == zoff then
+			i = i + zstridediff
+		elseif i % ystride == yoff then
+			i = i + ystridediff
+		end
+		if i <= last then
+			return i
+		end
+	end
+end
+
+function VoxelArea:iterp(minp, maxp)
+	return self:iter(minp.x, minp.y, minp.z, maxp.x, maxp.y, maxp.z)
+end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1676,6 +1676,13 @@ methods:
 - index(x, y, z):  returns the index of an absolute position in a flat array starting at 1
   ^ useful for things like VoxelManip, raw Schematic specifiers, PerlinNoiseMap:get2d/3dMap, and so on
 - indexp(p):  same as above, except takes a vector
+- position(i):  returns the absolute position vector corresponding to index i
+- contains(x, y, z):  check if (x,y,z) is inside area formed by MinEdge and MaxEdge
+- containsp(p):  same as above, except takes a vector
+- containsi(i):  same as above, except takes an index
+- iter(minx, miny, minz, maxx, maxy, maxz):  returns an iterator that returns indices
+  ^ from (minx,miny,minz) to (maxx,maxy,maxz) in the order of [z [y [x]]]
+- iterp(minp, maxp):  same as above, except takes a vector
 
 Mapgen objects
 ---------------


### PR DESCRIPTION
Adds three methods to VoxelArea:
- position(i): returns the absolute position corresponding to index i
- iter(minx, miny, minz, maxx, maxy, maxz): returns an iterator that iterates over all indices between the minimum and maximum position (in Z [Y [X]] order).
- iterp(minp, maxp): like iter but positions are gives as tables

Can be used like:

```
for i in voxelarea:iterp({x=1,y=1,z=1}, {x=3,y=3,z=3}) do
  p = voxelarea:position(i)  -- optional
  -- do something at index i, for example:
  data[i] = c_air
end
```

Also adds the missing contains\* methods to lua_api.txt.
