### PR TITLE
Add basic protection support to builtin

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -218,6 +218,15 @@ function minetest.item_place_node(itemstack, placer, pointed_thing, param2)
 		place_to = {x = under.x, y = under.y, z = under.z}
 	end
 
+	if minetest.is_protected(place_to, placer:get_player_name()) then
+		minetest.log("action", placer:get_player_name()
+				.. " tried to place " .. def.name
+				.. " at protected position "
+				.. minetest.pos_to_string(place_to))
+		minetest.record_protection_violation(place_to, placer:get_player_name())
+		return itemstack
+	end
+
 	minetest.log("action", placer:get_player_name() .. " places node "
 		.. def.name .. " at " .. minetest.pos_to_string(place_to))
 	
@@ -374,6 +383,15 @@ function minetest.node_dig(pos, node, digger)
 		minetest.log("info", digger:get_player_name() .. " tried to dig "
 			.. node.name .. " which is not diggable "
 			.. minetest.pos_to_string(pos))
+		return
+	end
+
+	if minetest.is_protected(pos, digger:get_player_name()) then
+		minetest.log("action", digger:get_player_name()
+				.. " tried to dig " .. node.name
+				.. " at protected position "
+				.. minetest.pos_to_string(pos))
+		minetest.record_protection_violation(pos, digger:get_player_name())
 		return
 	end
 

--- a/builtin/misc.lua
+++ b/builtin/misc.lua
@@ -106,3 +106,14 @@ function minetest.setting_get_pos(name)
 	return minetest.string_to_pos(value)
 end
 
+-- To be overriden by protection mods
+function minetest.is_protected(pos, name)
+	return false
+end
+
+function minetest.record_protection_violation(pos, name)
+	for _, func in pairs(minetest.registered_on_protection_violation) do
+		func(pos, name)
+	end
+end
+

--- a/builtin/misc_register.lua
+++ b/builtin/misc_register.lua
@@ -344,4 +344,5 @@ minetest.registered_on_player_receive_fields, minetest.register_on_player_receiv
 minetest.registered_on_cheats, minetest.register_on_cheat = make_registration()
 minetest.registered_on_crafts, minetest.register_on_craft = make_registration()
 minetest.registered_craft_predicts, minetest.register_craft_predict = make_registration()
+minetest.registered_on_protection_violation, minetest.register_on_protection_violation = make_registration()
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1154,6 +1154,13 @@ minetest.register_on_craft(func(itemstack, player, old_craft_grid, craft_inv))
 minetest.register_craft_predict(func(itemstack, player, old_craft_grid, craft_inv))
 ^ The same as before, except that it is called before the player crafts, to make
 ^ craft prediction, and it should not change anything.
+minetest.register_on_protection_violation(func(pos, name))
+^ Called by builtin and mods when a player violates protection at a position
+  (eg, digs a node or punches a protected entity).
+^ The registered functions can be called using minetest.record_protection_violation
+^ The provided function should check that the position is protected by the mod
+  calling this function before it prints a message, if it does, to allow for
+  multiple protection mods.
 
 Other registration functions:
 minetest.register_chatcommand(cmd, chatcommand definition)
@@ -1483,6 +1490,22 @@ minetest.deserialize(string) -> table
 ^ Example: deserialize('return { ["foo"] = "bar" }') -> {foo='bar'}
 ^ Example: deserialize('print("foo")') -> nil (function call fails)
   ^ error:[string "print("foo")"]:1: attempt to call global 'print' (a nil value)
+minetest.is_protected(pos, name) -> bool
+^ This function should be overriden by protection mods and should be used to
+  check if a player can interact at a position.
+^ This function should call the old version of itself if the position is not
+  protected by the mod.
+^ Example:
+	local old_is_protected = minetest.is_protected
+	function minetest.is_protected(pos, name)
+		if mymod:position_protected_from(pos, name) then
+			return true
+		end
+		return old_is_protected(pos, name)
+	end
+minetest.record_protection_violation(pos, name)
+^ This function calls functions registered with
+  minetest.register_on_protection_violation.
 
 Global objects:
 minetest.env - EnvRef of the server environment and world.


### PR DESCRIPTION
This adds minetest.is_protected(pos, name), minetest.record_protection_violation(pos, name), and minetest.register_on_protection_violation(func(pos, name)).
minetest.is_protected should be overriden by protection mods.
functions registered with minetest.register_on_protection_violation can be used to print protection violation messages and for things like *shudder* auto-ban.
It fixes hacky things like this: https://github.com/VanessaE/homedecor/blob/27280bc69929729c72e71742cd24385cd0f9cfc1/init.lua#L33
