### PR TITLE
Airtime Improvement

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -548,6 +548,13 @@ void LocalPlayer::applyControl(float dtime)
 	else
 		speedH = speedH.normalize() * movement_speed_walk;
 
+	if(speedH.getLengthSQ() == 0 && m_speed.getLengthSQ() >= 0.01)
+	{
+		f32 damping = (touching_ground) ? movement_damping_ground : movement_damping_air;
+		speedH.X = m_speed.X * damping;
+		speedH.Z = m_speed.Z * damping;
+	}
+
 	// Acceleration increase
 	f32 incH = 0; // Horizontal (X, Z)
 	f32 incV = 0; // Vertical (Y)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -84,6 +84,9 @@ Player::Player(IGameDef *gamedef):
 	movement_liquid_fluidity_smooth = 0.5  * BS;
 	movement_liquid_sink            = 10   * BS;
 	movement_gravity                = 9.81 * BS;
+	
+	movement_damping_ground = 0.5;
+	movement_damping_air = 0.95;
 
 	// Movement overrides are multipliers and must be 1 by default
 	physics_override_speed   = 1;

--- a/src/player.h
+++ b/src/player.h
@@ -253,6 +253,9 @@ public:
 	f32 movement_liquid_fluidity_smooth;
 	f32 movement_liquid_sink;
 	f32 movement_gravity;
+	
+	f32 movement_damping_ground;
+	f32 movement_damping_air;
 
 	float physics_override_speed;
 	float physics_override_jump;


### PR DESCRIPTION
Previously, when moving and jumping, as soon as the arrow keys were released, all velocity would instantly slow to a stop. This fix adds a damping system that doesn't stop the player in midair. Instead of being stopped when speedH's length was zero, it is eased down to zero based on configurable damping values. This system could be extended to work slippery materials too, such as ice.