### PR TITLE
Fix formspec escaping, add escaping to info.txt for texture packs.

### DIFF
--- a/builtin/mainmenu.lua
+++ b/builtin/mainmenu.lua
@@ -36,11 +36,11 @@ function menu.render_favorite(spec,render_details)
 	local text = ""
 	
 	if spec.name ~= nil then
-		text = text .. fs_escape_string(spec.name:trim())
+		text = text .. engine.formspec_escape(spec.name:trim())
 		
 --		if spec.description ~= nil and
---			fs_escape_string(spec.description):trim() ~= "" then
---			text = text .. " (" .. fs_escape_string(spec.description) .. ")"
+--			engine.formspec_escape(spec.description):trim() ~= "" then
+--			text = text .. " (" .. engine.formspec_escape(spec.description) .. ")"
 --		end
 	else
 		if spec.address ~= nil then
@@ -90,7 +90,7 @@ function menu.render_favorite(spec,render_details)
 						string.format("%03d",spec.clients_max) .. " "
 	end
 	
-	return playercount .. fs_escape_string(details) ..  text
+	return playercount .. engine.formspec_escape(details) ..  text
 end
 
 --------------------------------------------------------------------------------
@@ -897,7 +897,7 @@ function tabbuilder.tab_multiplayer()
 	if menu.fav_selected ~= nil and 
 		menu.favorites[menu.fav_selected].description ~= nil then
 		retval = retval .. 
-			fs_escape_string(menu.favorites[menu.fav_selected].description,true)
+			engine.formspec_escape(menu.favorites[menu.fav_selected].description,true)
 	end
 	
 	retval = retval .. 
@@ -1037,7 +1037,7 @@ function tabbuilder.tab_TP()
 			menu.render_TP_list(TPlist) ..
 			";" .. index .. "]" ..
 			"image[0.65,0.25;4.0,3.7;"..(menu.TPscreen or no_screenshot).."]"..
-			"textarea[1.0,3.25;3.7,1.5;;"..(menu.TPinfo or "")..";]"
+			"textarea[1.0,3.25;3.7,1.5;;"..engine.formspec_escape(menu.TPinfo or "")..";]"
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/misc.lua
+++ b/builtin/misc.lua
@@ -99,10 +99,3 @@ function minetest.setting_get_pos(name)
 	return minetest.string_to_pos(value)
 end
 
-function minetest.formspec_escape(str)
-	str = string.gsub(str, "\\", "\\\\")
-	str = string.gsub(str, "%[", "\\[")
-	str = string.gsub(str, "%]", "\\]")
-	return str
-end
-

--- a/builtin/misc_helpers.lua
+++ b/builtin/misc_helpers.lua
@@ -184,6 +184,18 @@ function cleanup_path(temppath)
 	return temppath
 end
 
+local tbl = engine or minetest
+function tbl.formspec_escape(text)
+	if text ~= nil then
+		text = string.gsub(text,"\\","\\\\")
+		text = string.gsub(text,"%]","\\]")
+		text = string.gsub(text,"%[","\\[")
+		text = string.gsub(text,";","\\;")
+		text = string.gsub(text,",","\\,")
+	end
+	return text
+end
+
 --------------------------------------------------------------------------------
 -- mainmenu only functions
 --------------------------------------------------------------------------------
@@ -197,41 +209,7 @@ if engine ~= nil then
 		
 		return nil
 	end
-	
-	--------------------------------------------------------------------------------
-	function fs_escape_string(text)
-		if text ~= nil then
-			while (text:find("\r\n") ~= nil) do
-				local newtext = text:sub(1,text:find("\r\n")-1)
-				newtext = newtext .. " " .. text:sub(text:find("\r\n")+3)
-				
-				text = newtext
-			end
-			
-			while (text:find("\n") ~= nil) do
-				local newtext = text:sub(1,text:find("\n")-1)
-				newtext = newtext .. " " .. text:sub(text:find("\n")+1)
-				
-				text = newtext
-			end
-			
-			while (text:find("\r") ~= nil) do
-				local newtext = text:sub(1,text:find("\r")-1)
-				newtext = newtext .. " " .. text:sub(text:find("\r")+1)
-				
-				text = newtext
-			end
-			
-			text = string.gsub(text,"\\","\\\\")
-			text = string.gsub(text,"%]","\\]")
-			text = string.gsub(text,"%[","\\[")
-			text = string.gsub(text,";","\\;")
-			text = string.gsub(text,",","\\,")
-		end
-		return text
-	end
 end
-
 --------------------------------------------------------------------------------
 -- core only fct
 --------------------------------------------------------------------------------
@@ -241,3 +219,4 @@ if minetest ~= nil then
 		return "(" .. pos.x .. "," .. pos.y .. "," .. pos.z .. ")"
 	end
 end
+

--- a/builtin/modstore.lua
+++ b/builtin/modstore.lua
@@ -233,12 +233,12 @@ function modstore.getmodlist(list)
 			
 			--title + author
 			retval = retval .."label[2.75," .. screenshot_ypos .. ";" .. 
-				fs_escape_string(details.title) .. " (" .. details.author .. ")]"
+				engine.formspec_escape(details.title) .. " (" .. details.author .. ")]"
 			
 			--description
 			local descriptiony = screenshot_ypos + 0.5
 			retval = retval .. "textarea[3," .. descriptiony .. ";6.5,1.55;;" .. 
-				fs_escape_string(details.description) .. ";]"
+				engine.formspec_escape(details.description) .. ";]"
 			--rating
 			local ratingy = screenshot_ypos + 0.6
 			retval = retval .."label[10.1," .. ratingy .. ";Rating: " .. details.rating .."]"

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -228,51 +228,34 @@ int GUIFormSpecMenu::getListboxIndex(std::string listboxname) {
 	return -1;
 }
 
-std::vector<std::string> split(const std::string &s, char delim, bool escape=false) {
+std::vector<std::string> split(const std::string &s, char delim) {
 	std::vector<std::string> tokens;
 
-	if (!escape) {
-		int startpos = 0;
-		size_t nextpos = s.find(delim);
-
-		while(nextpos != std::string::npos) {
-			std::string toadd = s.substr(startpos,nextpos-startpos);
-			tokens.push_back(toadd);
-			startpos = nextpos+1;
-			nextpos = s.find(delim,nextpos+1);
+	std::string current = "";
+	bool last_was_escape = false;
+	for(unsigned int i=0; i < s.size(); i++) {
+		if (last_was_escape) {
+			current += '\\';
+			current += s.c_str()[i];
+			last_was_escape = false;
 		}
-
-		//push last element
-		tokens.push_back(s.substr(startpos));
-	}
-	else {
-		std::string current = "";
-		current += s.c_str()[0];
-		bool last_was_escape = false;
-		for(unsigned int i=1; i < s.size(); i++) {
-			if (last_was_escape) {
-				current += '\\';
+		else {
+			if (s.c_str()[i] == delim) {
+				tokens.push_back(current);
+				current = "";
+				last_was_escape = false;
+			}
+			else if (s.c_str()[i] == '\\'){
+				last_was_escape = true;
+			}
+			else {
 				current += s.c_str()[i];
 				last_was_escape = false;
 			}
-			else {
-				if (s.c_str()[i] == delim) {
-					tokens.push_back(current);
-					current = "";
-					last_was_escape = false;
-				}
-				else if (s.c_str()[i] == '\\'){
-					last_was_escape = true;
-				}
-				else {
-					current += s.c_str()[i];
-					last_was_escape = false;
-				}
-			}
 		}
-		//push last element
-		tokens.push_back(current);
 	}
+	//push last element
+	tokens.push_back(current);
 
 	return tokens;
 }
@@ -603,7 +586,7 @@ void GUIFormSpecMenu::parseTextList(parserData* data,std::string element) {
 		std::vector<std::string> v_pos = split(parts[0],',');
 		std::vector<std::string> v_geom = split(parts[1],',');
 		std::string name = parts[2];
-		std::vector<std::string> items = split(parts[3],',',true);
+		std::vector<std::string> items = split(parts[3],',');
 		std::string str_initial_selection = "";
 		std::string str_transparent = "false";
 
@@ -996,7 +979,7 @@ void GUIFormSpecMenu::parseTextArea(parserData* data,std::vector<std::string>& p
 }
 
 void GUIFormSpecMenu::parseField(parserData* data,std::string element,std::string type) {
-	std::vector<std::string> parts = split(element,';',true);
+	std::vector<std::string> parts = split(element,';');
 
 	if (parts.size() == 3) {
 		parseSimpleField(data,parts);
@@ -1360,7 +1343,7 @@ void GUIFormSpecMenu::parseElement(parserData* data,std::string element) {
 	if (element == "")
 		return;
 
-	std::vector<std::string> parts = split(element,'[', true);
+	std::vector<std::string> parts = split(element,'[');
 
 	// ugly workaround to keep compatibility
 	if (parts.size() > 2) {
@@ -1513,7 +1496,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_boxes.clear();
 
 
-	std::vector<std::string> elements = split(m_formspec_string,']',true);
+	std::vector<std::string> elements = split(m_formspec_string,']');
 
 	for (unsigned int i=0;i< elements.size();i++) {
 		parseElement(&mydata,elements[i]);


### PR DESCRIPTION
This fixes bugs with escaping for labels, plus fixes also the bugs that would occur if an info.txt file for texture packs contained formspec characters (formspec content injection was even possible).
Server and mod description may looks slightly different.
