### PR TITLE
Fix umlauts/special character issue in lua gettext

### DIFF
--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -983,9 +983,8 @@ int ModApiMainMenu::l_download_file(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_gettext(lua_State *L)
 {
-	const char* str = luaL_checkstring(L, 1);
-	str = gettext(str);
-	lua_pushstring(L, str);
+	std::wstring wtext = wstrgettext((std::string) luaL_checkstring(L, 1));
+	lua_pushstring(L, wide_to_narrow(wtext).c_str());
 
 	return 1;
 }


### PR DESCRIPTION
Fixes issue with umlauts caused by commit 09a50d0 and described like here https://forum.minetest.net/viewtopic.php?pid=106213#p106213 and caused by MSVC compiling aswell
