### PR TITLE
Use player:set_hotbar_image() instead of hardcoded hotbar.png

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1618,6 +1618,10 @@ Player-only: (no-op for other objects)
   ^ if a flag is nil, the flag is not modified
 - hud_set_hotbar_itemcount(count): sets number of items in builtin hotbar
   ^ count: number of items, must be between 1 and 23
+- hud_set_hotbar_image(texturename)
+  ^ sets background image for hotbar
+- hud_set_hotbar_selected_image(texturename)
+  ^ sets image for selected item of hotbar
 
 InvRef: Reference to an inventory
 methods:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -2175,6 +2175,10 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 			s32 hotbar_itemcount = readS32((u8*) value.c_str());
 			if(hotbar_itemcount > 0 && hotbar_itemcount <= HUD_HOTBAR_ITEMCOUNT_MAX)
 				player->hud_hotbar_itemcount = hotbar_itemcount;
+		} else if (param == HUD_PARAM_HOTBAR_IMAGE) {
+			((LocalPlayer *) player)->hotbar_image = value;
+		} else if (param == HUD_PARAM_HOTBAR_SELECTED_IMAGE) {
+			((LocalPlayer *) player)->hotbar_selected_image = value;
 		}
 	}
 	else

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -64,8 +64,11 @@ Hud::Hud(video::IVideoDriver *driver, gui::IGUIEnvironment* guienv,
 	selectionbox_argb = video::SColor(255, sbox_r, sbox_g, sbox_b);
 	
 	use_crosshair_image = tsrc->isKnownSourceImage("crosshair.png");
-	use_hotbar_bg_img = tsrc->isKnownSourceImage("hotbar.png");
-	use_hotbar_border_img = tsrc->isKnownSourceImage("hotbar_selected.png");
+
+	hotbar_image = "";
+	use_hotbar_image = false;
+	hotbar_selected_image = "";
+	use_hotbar_selected_image = false;
 }
 
 
@@ -95,10 +98,26 @@ void Hud::drawItem(v2s32 upperleftpos, s32 imgsize, s32 itemcount,
 	const video::SColor hbar_color(255, 255, 255, 255);
 	const video::SColor hbar_colors[] = {hbar_color, hbar_color, hbar_color, hbar_color};
 
-	if (use_hotbar_bg_img) {
+	if (hotbar_image != player->hotbar_image) {
+		hotbar_image = player->hotbar_image;
+		if (hotbar_image != "")
+			use_hotbar_image = tsrc->isKnownSourceImage(hotbar_image);
+		else
+			use_hotbar_image = false;
+	}
+
+	if (hotbar_selected_image != player->hotbar_selected_image) {
+		hotbar_selected_image = player->hotbar_selected_image;
+		if (hotbar_selected_image != "")
+			use_hotbar_selected_image = tsrc->isKnownSourceImage(hotbar_selected_image);
+		else
+			use_hotbar_selected_image = false;
+	}
+
+	if (use_hotbar_image) {
 		core::rect<s32> imgrect2(-padding/2, -padding/2, width+padding/2, height+padding/2);
 		core::rect<s32> rect2 = imgrect2 + pos;
-		video::ITexture *texture = tsrc->getTexture("hotbar.png");
+		video::ITexture *texture = tsrc->getTexture(hotbar_image);
 		core::dimension2di imgsize(texture->getOriginalSize());
 		driver->draw2DImage(texture, rect2,
 			core::rect<s32>(core::position2d<s32>(0,0), imgsize),
@@ -127,10 +146,10 @@ void Hud::drawItem(v2s32 upperleftpos, s32 imgsize, s32 itemcount,
 		core::rect<s32> rect = imgrect + pos + steppos;
 
 		if (selectitem == i + 1) {
-			if (use_hotbar_border_img) {
+			if (use_hotbar_selected_image) {
 				core::rect<s32> imgrect2(-padding*2, -padding*2, height, height);
 				rect = imgrect2 + pos + steppos;
-				video::ITexture *texture = tsrc->getTexture("hotbar_selected.png");
+				video::ITexture *texture = tsrc->getTexture(hotbar_selected_image);
 				core::dimension2di imgsize(texture->getOriginalSize());
 				driver->draw2DImage(texture, rect,
 					core::rect<s32>(core::position2d<s32>(0,0), imgsize),
@@ -192,7 +211,7 @@ void Hud::drawItem(v2s32 upperleftpos, s32 imgsize, s32 itemcount,
 		}
 
 		video::SColor bgcolor2(128, 0, 0, 0);
-		if (!use_hotbar_bg_img)
+		if (!use_hotbar_image)
 			driver->draw2DRectangle(bgcolor2, rect, NULL);
 		drawItemStack(driver, font, item, rect, NULL, gamedef);
 	}

--- a/src/hud.h
+++ b/src/hud.h
@@ -39,6 +39,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define HUD_FLAG_BREATHBAR_VISIBLE (1 << 4)
 
 #define HUD_PARAM_HOTBAR_ITEMCOUNT 1
+#define HUD_PARAM_HOTBAR_IMAGE 2
+#define HUD_PARAM_HOTBAR_SELECTED_IMAGE 3
 
 #define HUD_HOTBAR_ITEMCOUNT_DEFAULT 8
 #define HUD_HOTBAR_ITEMCOUNT_MAX     23
@@ -106,8 +108,10 @@ public:
 	video::SColor crosshair_argb;
 	video::SColor selectionbox_argb;
 	bool use_crosshair_image;
-	bool use_hotbar_border_img;
-	bool use_hotbar_bg_img;
+	std::string hotbar_image;
+	bool use_hotbar_image;
+	std::string hotbar_selected_image;
+	bool use_hotbar_selected_image;
 	
 	Hud(video::IVideoDriver *driver, gui::IGUIEnvironment* guienv,
 		gui::IGUIFont *font, u32 text_height, IGameDef *gamedef,

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -43,6 +43,8 @@ LocalPlayer::LocalPlayer(IGameDef *gamedef):
 	last_pitch(0),
 	last_yaw(0),
 	last_keyPressed(0),
+	hotbar_image(""),
+	hotbar_selected_image(""),
 	m_sneak_node(32767,32767,32767),
 	m_sneak_node_exists(false),
 	m_old_node_below(32767,32767,32767),

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -61,6 +61,9 @@ public:
 
 	float camera_impact;
 
+	std::string hotbar_image;
+	std::string hotbar_selected_image;
+
 private:
 	// This is used for determining the sneaking range
 	v3s16 m_sneak_node;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1022,6 +1022,34 @@ int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 	return 1;
 }
 
+// hud_set_hotbar_image(self, name)
+int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	std::string name = lua_tostring(L, 2);
+
+	getServer(L)->hudSetHotbarImage(player, name);
+	return 1;
+}
+
+// hud_set_hotbar_selected_image(self, name)
+int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	std::string name = lua_tostring(L, 2);
+
+	getServer(L)->hudSetHotbarSelectedImage(player, name);
+	return 1;
+}
+
 ObjectRef::ObjectRef(ServerActiveObject *object):
 	m_object(object)
 {
@@ -1136,5 +1164,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_get),
 	luamethod(ObjectRef, hud_set_flags),
 	luamethod(ObjectRef, hud_set_hotbar_itemcount),
+	luamethod(ObjectRef, hud_set_hotbar_image),
+	luamethod(ObjectRef, hud_set_hotbar_selected_image),
 	{0,0}
 };

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -215,6 +215,12 @@ private:
 	// hud_set_hotbar_itemcount(self, hotbar_itemcount)
 	static int l_hud_set_hotbar_itemcount(lua_State *L);
 
+	// hud_set_hotbar_image(self, name)
+	static int l_hud_set_hotbar_image(lua_State *L);
+
+	// hud_set_hotbar_selected_image(self, name)
+	static int l_hud_set_hotbar_selected_image(lua_State *L);
+
 public:
 	ObjectRef(ServerActiveObject *object);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4999,6 +4999,20 @@ bool Server::hudSetHotbarItemcount(Player *player, s32 hotbar_itemcount) {
 	return true;
 }
 
+void Server::hudSetHotbarImage(Player *player, std::string name) {
+	if (!player)
+		return;
+
+	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_IMAGE, name);
+}
+
+void Server::hudSetHotbarSelectedImage(Player *player, std::string name) {
+	if (!player)
+		return;
+
+	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_SELECTED_IMAGE, name);
+}
+
 void Server::notifyPlayers(const std::wstring msg)
 {
 	BroadcastChatMessage(msg);

--- a/src/server.h
+++ b/src/server.h
@@ -493,7 +493,9 @@ public:
 	bool hudChange(Player *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(Player *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(Player *player, s32 hotbar_itemcount);
-	
+	void hudSetHotbarImage(Player *player, std::string name);
+	void hudSetHotbarSelectedImage(Player *player, std::string name);
+
 private:
 
 	// con::PeerHandler implementation.


### PR DESCRIPTION
This gives games the ability to e.g have a 5 item hotbar in survival and a 8 item hotbar in creative mode with proper images.
