### PR TITLE
Add ISimpleTextureSource for cleaning up main menu resources

### DIFF
--- a/builtin/gamemgr.lua
+++ b/builtin/gamemgr.lua
@@ -225,7 +225,8 @@ function gamemgr.tab()
 		if current_game.menuicon_path ~= nil and
 			current_game.menuicon_path ~= "" then
 			retval = retval .. 
-				"image[5.8,-0.25;2,2;" .. current_game.menuicon_path .. "]"
+				"image[5.8,-0.25;2,2;" ..
+				engine.formspec_escape(current_game.menuicon_path) .. "]"
 		end
 		
 		retval = retval ..
@@ -251,7 +252,8 @@ function gamemgr.dialog_edit_game()
 		if current_game.menuicon_path ~= nil and
 			current_game.menuicon_path ~= "" then
 			retval = retval .. 
-				"image[5.25,0;2,2;" .. current_game.menuicon_path .. "]"			
+				"image[5.25,0;2,2;" ..
+				engine.formspec_escape(current_game.menuicon_path) .. "]"			
 		end
 		
 		retval = retval .. 

--- a/builtin/mainmenu.lua
+++ b/builtin/mainmenu.lua
@@ -1057,16 +1057,17 @@ function tabbuilder.tab_texture_packs()
 	return	retval ..
 			menu.render_texture_pack_list(list) ..
 			";" .. index .. "]" ..
-			"image[0.65,0.25;4.0,3.7;"..(screenfile or no_screenshot).."]"..
+			"image[0.65,0.25;4.0,3.7;"..engine.formspec_escape(screenfile or no_screenshot).."]"..
 			"textarea[1.0,3.25;3.7,1.5;;"..engine.formspec_escape(infotext or "")..";]"
 end
 
 --------------------------------------------------------------------------------
 function tabbuilder.tab_credits()
+	local logofile = menu.defaulttexturedir .. "logo.png"
 	return	"vertlabel[0,-0.5;CREDITS]" ..
 			"label[0.5,3;Minetest " .. engine.get_version() .. "]" ..
 			"label[0.5,3.3;http://minetest.net]" .. 
-			"image[0.5,1;" .. menu.defaulttexturedir .. "logo.png]" ..
+			"image[0.5,1;" .. engine.formspec_escape(logofile) .. "]" ..
 			"textlist[3.5,-0.25;8.5,5.8;list_credits;" ..
 			"#FFFF00" .. fgettext("Core Developers") .."," ..
 			"Perttu Ahola (celeron55) <celeron55@gmail.com>,"..

--- a/builtin/mm_menubar.lua
+++ b/builtin/mm_menubar.lua
@@ -51,7 +51,8 @@ function menubar.refresh()
 
 			menubar.formspec = menubar.formspec ..
 				"image_button[" .. buttonpos ..  ",5.7;1.3,1.3;"  ..
-				gamemgr.games[i].menuicon_path .. ";" .. btn_name .. ";;true;false]"
+				engine.formspec_escape(gamemgr.games[i].menuicon_path) .. ";" ..
+				btn_name .. ";;true;false]"
 		else
 		
 			local part1 = gamemgr.games[i].id:sub(1,5)

--- a/builtin/modstore.lua
+++ b/builtin/modstore.lua
@@ -227,7 +227,7 @@ function modstore.getmodlist(list)
 			end
 			
 			retval = retval .. "image[0,".. screenshot_ypos .. ";3,2;" .. 
-					list.data[i].texturename .. "]"
+					engine.formspec_escape(list.data[i].texturename) .. "]"
 			
 			--title + author
 			retval = retval .."label[2.75," .. screenshot_ypos .. ";" .. 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1720,7 +1720,7 @@ void the_game(
 			GUIFormSpecMenu *menu =
 				new GUIFormSpecMenu(device, guiroot, -1,
 					&g_menumgr,
-					&client, gamedef);
+					&client, gamedef, tsrc);
 
 			InventoryLocation inventoryloc;
 			inventoryloc.setCurrentPlayer();
@@ -2259,7 +2259,7 @@ void the_game(
 						GUIFormSpecMenu *menu =
 								new GUIFormSpecMenu(device, guiroot, -1,
 										&g_menumgr,
-										&client, gamedef);
+										&client, gamedef, tsrc);
 						menu->setFormSource(current_formspec);
 						menu->setTextDest(current_textdest);
 						menu->drop();
@@ -2755,7 +2755,7 @@ void the_game(
 					GUIFormSpecMenu *menu =
 						new GUIFormSpecMenu(device, guiroot, -1,
 							&g_menumgr,
-							&client, gamedef);
+							&client, gamedef, tsrc);
 					menu->setFormSpec(meta->getString("formspec"),
 							inventoryloc);
 					menu->setFormSource(new NodeMetadataFormSource(

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class IGameDef;
 class InventoryManager;
+class ISimpleTextureSource;
 
 typedef enum {
 	f_Button,
@@ -176,7 +177,8 @@ public:
 			gui::IGUIElement* parent, s32 id,
 			IMenuManager *menumgr,
 			InventoryManager *invmgr,
-			IGameDef *gamedef
+			IGameDef *gamedef,
+			ISimpleTextureSource *tsrc
 			);
 
 	~GUIFormSpecMenu();
@@ -245,6 +247,7 @@ protected:
 	irr::IrrlichtDevice* m_device;
 	InventoryManager *m_invmgr;
 	IGameDef *m_gamedef;
+	ISimpleTextureSource *m_tsrc;
 
 	std::string m_formspec_string;
 	InventoryLocation m_current_inventory_location;
@@ -301,8 +304,6 @@ private:
 		bool key_enter;
 		bool key_escape;
 	} fs_key_pendig;
-
-	std::vector<video::ITexture *> m_Textures;
 
 	fs_key_pendig current_keys_pending;
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -82,22 +82,27 @@ struct TextureFromMeshParams
 	TextureSource creates and caches textures.
 */
 
-class ITextureSource
+class ISimpleTextureSource
+{
+public:
+	ISimpleTextureSource(){}
+	virtual ~ISimpleTextureSource(){}
+	virtual video::ITexture* getTexture(
+			const std::string &name, u32 *id = NULL) = 0;
+};
+
+class ITextureSource : public ISimpleTextureSource
 {
 public:
 	ITextureSource(){}
 	virtual ~ITextureSource(){}
-	virtual u32 getTextureId(const std::string &name){return 0;}
-	virtual u32 getTextureIdDirect(const std::string &name){return 0;}
-	virtual std::string getTextureName(u32 id){return "";}
-	virtual video::ITexture* getTexture(u32 id){return NULL;}
+	virtual u32 getTextureId(const std::string &name)=0;
+	virtual u32 getTextureIdDirect(const std::string &name)=0;
+	virtual std::string getTextureName(u32 id)=0;
+	virtual video::ITexture* getTexture(u32 id)=0;
 	virtual video::ITexture* getTexture(
-			const std::string &name, u32 *id = NULL){
-		if(id) *id = 0;
-		return NULL;
-	}
-	virtual IrrlichtDevice* getDevice()
-		{return NULL;}
+			const std::string &name, u32 *id = NULL)=0;
+	virtual IrrlichtDevice* getDevice()=0;
 	virtual bool isKnownSourceImage(const std::string &name)=0;
 	virtual video::ITexture* generateTextureFromMesh(
 			const TextureFromMeshParams &params)=0;
@@ -108,23 +113,20 @@ class IWritableTextureSource : public ITextureSource
 public:
 	IWritableTextureSource(){}
 	virtual ~IWritableTextureSource(){}
-	virtual u32 getTextureId(const std::string &name){return 0;}
-	virtual u32 getTextureIdDirect(const std::string &name){return 0;}
-	virtual std::string getTextureName(u32 id){return "";}
-	virtual video::ITexture* getTexture(u32 id){return NULL;}
+	virtual u32 getTextureId(const std::string &name)=0;
+	virtual u32 getTextureIdDirect(const std::string &name)=0;
+	virtual std::string getTextureName(u32 id)=0;
+	virtual video::ITexture* getTexture(u32 id)=0;
 	virtual video::ITexture* getTexture(
-			const std::string &name, u32 *id = NULL){
-		if(id) *id = 0;
-		return NULL;
-	}
-	virtual IrrlichtDevice* getDevice(){return NULL;}
+			const std::string &name, u32 *id = NULL)=0;
+	virtual IrrlichtDevice* getDevice()=0;
 	virtual bool isKnownSourceImage(const std::string &name)=0;
+	virtual video::ITexture* generateTextureFromMesh(
+			const TextureFromMeshParams &params)=0;
 
 	virtual void processQueue()=0;
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;
 	virtual void rebuildImagesAndTextures()=0;
-	virtual video::ITexture* generateTextureFromMesh(
-			const TextureFromMeshParams &params)=0;
 };
 
 IWritableTextureSource* createTextureSource(IrrlichtDevice *device);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -295,7 +295,7 @@ inline std::string unescape_string(std::string &s)
 {
 	std::string res;
 	
-	for (size_t i = 0; i <= s.length(); i++) {
+	for (size_t i = 0; i < s.length(); i++) {
 		if (s[i] == '\\')
 			i++;
 		res += s[i];


### PR DESCRIPTION
This patch adds an interface ISimpleTextureSource which is a single-method texture source. ITextureSource and IWritableTextureSource continue to exist and they extend ISimpleTextureSource.

There is an implementation of ISimpleTextureSource (MenuTextureSource) used for the main menu.

The point of this endeavor is to simplify GUIFormSpecMenu. Currently whenever the formspec menu needs some texture, it checks whether a game is running or the main menu is active, and respectively asks IGameDef or IVideoDriver for the texture. The unified ISimpleTextureSource interface removes the need for those checks. Also, textures loaded by the mainmenu formspec are now unloaded before starting the game - previously the formspec menu just called getTexture but never removeTexture.

Other notable changes:
- Texture names must now be escaped in formspec elements image[], background[], image_button[], image_button_exit[]. The patch contains required changes in builtin.
- Fixed an off-by-one bug in unescape_string; it caused requests for a texture called "\0".
