### PR TITLE
Added callback to harness 6D facedir in node definitions.

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -121,7 +121,7 @@ function minetest.get_node_drops(nodename, toolname)
 	return got_items
 end
 
-function minetest.item_place_node(itemstack, placer, pointed_thing)
+function minetest.item_place_node(itemstack, placer, pointed_thing, facedir)
 	local item = itemstack:peek_item()
 	local def = itemstack:get_definition()
 	if def.type ~= "node" or pointed_thing.type ~= "node" then
@@ -176,16 +176,20 @@ function minetest.item_place_node(itemstack, placer, pointed_thing)
 		newnode.param2 = minetest.dir_to_wallmounted(dir)
 	-- Calculate the direction for furnaces and chests and stuff
 	elseif def.paramtype2 == 'facedir' then
-		local placer_pos = placer:getpos()
-		if placer_pos then
-			local dir = {
-				x = above.x - placer_pos.x,
-				y = above.y - placer_pos.y,
-				z = above.z - placer_pos.z
-			}
-			newnode.param2 = minetest.dir_to_facedir(dir)
-			minetest.log("action", "facedir: " .. newnode.param2)
+		if facedir then
+			newnode.param2 = facedir	
+		else
+			local placer_pos = placer:getpos()
+			if placer_pos then
+				local dir = {
+					x = above.x - placer_pos.x,
+					y = above.y - placer_pos.y,
+					z = above.z - placer_pos.z
+				}
+				newnode.param2 = minetest.dir_to_facedir(dir)
+			end
 		end
+		minetest.log("action", "facedir: " .. newnode.param2)
 	end
 
 	-- Check if the node is attached and if it can be placed there
@@ -237,7 +241,7 @@ function minetest.item_place_object(itemstack, placer, pointed_thing)
 	return itemstack
 end
 
-function minetest.item_place(itemstack, placer, pointed_thing)
+function minetest.item_place(itemstack, placer, pointed_thing, facedir)
 	-- Call on_rightclick if the pointed node defines it
 	if pointed_thing.type == "node" and placer and
 			not placer:get_player_control().sneak then
@@ -249,7 +253,7 @@ function minetest.item_place(itemstack, placer, pointed_thing)
 	end
 
 	if itemstack:get_definition().type == "node" then
-		return minetest.item_place_node(itemstack, placer, pointed_thing)
+		return minetest.item_place_node(itemstack, placer, pointed_thing, facedir)
 	end
 	return itemstack
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1085,7 +1085,7 @@ minetest.rollback_revert_actions_by(actor, seconds) -> bool, log messages
 
 Defaults for the on_* item definition functions:
 (These return the leftover itemstack)
-minetest.item_place_node(itemstack, placer, pointed_thing)
+minetest.item_place_node(itemstack, placer, pointed_thing, facedir)
 ^ Place item as a node
 minetest.item_place_object(itemstack, placer, pointed_thing)
 ^ Place item as-is

--- a/games/minimal/mods/stairs/init.lua
+++ b/games/minimal/mods/stairs/init.lua
@@ -17,6 +17,36 @@ function stairs.register_stair(subname, recipeitem, groups, images, description)
 				{-0.5, 0, 0, 0.5, 0.5, 0.5},
 			},
 		},
+		on_place = function(itemstack, placer, pointed_thing)
+			if pointed_thing.type ~= "node" then
+				return itemstack
+			end
+			
+			local p0 = pointed_thing.under
+			local p1 = pointed_thing.above
+			if p0.y-1 == p1.y then
+				local placer_pos = placer:getpos()
+				local dir = {
+					x = pointed_thing.above.x - placer_pos.x,
+					y = pointed_thing.above.y - placer_pos.y,
+					z = pointed_thing.above.z - placer_pos.z
+				}
+				local param2 = minetest.dir_to_facedir(dir)
+				if param2 == 0 then
+					param2 = 20
+				elseif param2 == 1 then
+					param2 = 23
+				elseif param2 == 2 then
+					param2 = 22
+				elseif param2 == 3 then
+					param2 = 21
+				end
+				return minetest.item_place(itemstack, placer, pointed_thing, param2)
+			end
+			
+			-- Otherwise place regularly
+			return minetest.item_place(itemstack, placer, pointed_thing)
+		end,
 	})
 
 	minetest.register_craft({


### PR DESCRIPTION
This allows a custom facedir handler to be used by user-defined nodes. For example, this could be used to allow upside down stairs without a dedicated node for them, as shown in the minimal game.

This could also be applied to upside down slabs, but figuring out how to do that without disrupting the current "slab + slab == full node" mechanic would be a challenge, and is beyond the scope of this pull request.
