### PR TITLE
Add offset to automatic_face_movement_dir

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1888,7 +1888,8 @@ Object Properties
     makes_footstep_sound = false,
     automatic_rotate = false,
     stepheight = 0,
-    automatic_face_movement_dir = false,
+    automatic_face_movement_dir = 0.0,
+    ^ automatically set yaw to movement direction; offset in degrees
 }
 
 Entity definition (register_entity)

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -98,7 +98,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		drowning, leveled and liquid_range added to ContentFeatures
 		stepheight and collideWithObjects added to object properties
 		version, heat and humidity transfer in MapBock
-		added new property to entities automatic_face_movement_dir
+		automatic_face_movement_dir and automatic_face_movement_dir_offset
+			added to object properties
 */
 
 #define LATEST_PROTOCOL_VERSION 21

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1211,8 +1211,9 @@ public:
 			updateNodePos();
 		}
 
-		if (getParent() == NULL && m_prop.automatic_face_movement_dir){
-			m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI;
+		if (getParent() == NULL && m_prop.automatic_face_movement_dir &&
+				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)){
+			m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI + m_prop.automatic_face_movement_dir_offset;
 			updateNodePos();
 		}
 	}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -527,8 +527,9 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			m_velocity += dtime * m_acceleration;
 		}
 
-		if(m_prop.automatic_face_movement_dir){
-			m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI;
+		if((m_prop.automatic_face_movement_dir) &&
+				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)){
+			m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI + m_prop.automatic_face_movement_dir_offset;
 		}
 	}
 

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -41,7 +41,8 @@ ObjectProperties::ObjectProperties():
 	makes_footstep_sound(false),
 	automatic_rotate(0),
 	stepheight(0),
-	automatic_face_movement_dir(false)
+	automatic_face_movement_dir(false),
+	automatic_face_movement_dir_offset(0.0)
 {
 	textures.push_back("unknown_object.png");
 	colors.push_back(video::SColor(255,255,255,255));
@@ -104,6 +105,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, collideWithObjects);
 	writeF1000(os,stepheight);
 	writeU8(os, automatic_face_movement_dir);
+	writeF1000(os, automatic_face_movement_dir_offset);
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -139,6 +141,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 			collideWithObjects = readU8(is);
 			stepheight = readF1000(is);
 			automatic_face_movement_dir = readU8(is);
+			automatic_face_movement_dir_offset = readF1000(is);
 		}catch(SerializationError &e){}
 	}
 	else

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -46,6 +46,7 @@ struct ObjectProperties
 	float automatic_rotate;
 	f32 stepheight;
 	bool automatic_face_movement_dir;
+	f32 automatic_face_movement_dir_offset;
 
 
 	ObjectProperties();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -191,7 +191,12 @@ void read_object_properties(lua_State *L, int index,
 	getfloatfield(L, -1, "automatic_rotate", prop->automatic_rotate);
 	getfloatfield(L, -1, "stepheight", prop->stepheight);
 	prop->stepheight*=BS;
-	getboolfield(L, -1, "automatic_face_movement_dir", prop->automatic_face_movement_dir);
+	lua_getfield(L, -1, "automatic_face_movement_dir");
+	if (!lua_isnil(L, -1)) {
+		prop->automatic_face_movement_dir = true;
+		prop->automatic_face_movement_dir_offset = luaL_checknumber(L, -1);
+	}
+	lua_pop(L, 1);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This is especially needed for upright_sprite, since without an offset it always moves "sideways".
Also includes the fix from #879.
