### PR TITLE
Add sanity checks to vector functions

### DIFF
--- a/builtin/vector.lua
+++ b/builtin/vector.lua
@@ -2,10 +2,12 @@
 vector = {}
 
 function vector.new(a, b, c)
+	assert(a)
 	v = {x=0, y=0, z=0}
 	if type(a) == "table" then
 		v = {x=a.x, y=a.y, z=a.z}
-	elseif a and b and c then
+	else
+		assert(b and c)
 		v = {x=a, y=b, z=c}
 	end
 	setmetatable(v, {
@@ -21,16 +23,19 @@ function vector.new(a, b, c)
 end
 
 function vector.equals(a, b)
+	assert(a and b)
 	return a.x == b.x and
 	       a.y == b.y and
 	       a.z == b.z
 end
 
 function vector.length(v)
+	assert(v)
 	return math.hypot(v.x, math.hypot(v.y, v.z))
 end
 
 function vector.normalize(v)
+	assert(v)
 	local len = vector.length(v)
 	if len == 0 then
 		return vector.new()
@@ -40,6 +45,7 @@ function vector.normalize(v)
 end
 
 function vector.round(v)
+	assert(v)
 	return {
 		x = math.floor(v.x + 0.5),
 		y = math.floor(v.y + 0.5),
@@ -48,6 +54,7 @@ function vector.round(v)
 end
 
 function vector.distance(a, b)
+	assert(a and b)
 	local x = a.x - b.x
 	local y = a.y - b.y
 	local z = a.z - b.z
@@ -55,6 +62,7 @@ function vector.distance(a, b)
 end
 
 function vector.direction(pos1, pos2)
+	assert(pos1 and pos2)
 	local x_raw = pos2.x - pos1.x
 	local y_raw = pos2.y - pos1.y
 	local z_raw = pos2.z - pos1.z
@@ -84,6 +92,7 @@ end
 
 
 function vector.add(a, b)
+	assert(a and b)
 	if type(b) == "table" then
 		 return vector.new(
 			a.x + b.x,
@@ -98,6 +107,7 @@ function vector.add(a, b)
 end
 
 function vector.subtract(a, b)
+	assert(a and b)
 	if type(b) == "table" then
 		return vector.new(
 			a.x - b.x,
@@ -112,6 +122,7 @@ function vector.subtract(a, b)
 end
 
 function vector.multiply(a, b)
+	assert(a and b)
 	if type(b) == "table" then
 		return vector.new(
 			a.x * b.x,
@@ -126,6 +137,7 @@ function vector.multiply(a, b)
 end
 
 function vector.divide(a, b)
+	assert(a and b)
 	if type(b) == "table" then
 		return vector.new(
 			a.x / b.x,


### PR DESCRIPTION
Previously passing nil to the vector functions would cause a untraceable error. Now it produces a backtrace.
