### PR TITLE
Removed mapgen_air

### DIFF
--- a/games/minimal/mods/default/mapgen.lua
+++ b/games/minimal/mods/default/mapgen.lua
@@ -4,7 +4,6 @@
 -- Aliases for map generator outputs
 --
 
-minetest.register_alias("mapgen_air", "air")
 minetest.register_alias("mapgen_stone", "default:stone")
 minetest.register_alias("mapgen_tree", "default:tree")
 minetest.register_alias("mapgen_leaves", "default:leaves")

--- a/src/content_abm.cpp
+++ b/src/content_abm.cpp
@@ -209,7 +209,7 @@ class LiquidDropABM : public ActiveBlockModifier {
 		{ return contents; }
 		virtual std::set<std::string> getRequiredNeighbors() {
 			std::set<std::string> neighbors;
-			neighbors.insert("mapgen_air");
+			neighbors.insert("air");
 			return neighbors;
 		}
 		virtual float getTriggerInterval()
@@ -241,7 +241,7 @@ class LiquidFreeze : public ActiveBlockModifier {
 		}
 		virtual std::set<std::string> getRequiredNeighbors() {
 			std::set<std::string> s;
-			s.insert("mapgen_air");
+			s.insert("air");
 			s.insert("group:melts");
 			return s;
 		}
@@ -303,7 +303,7 @@ class LiquidMeltWeather : public ActiveBlockModifier {
 		}
 		virtual std::set<std::string> getRequiredNeighbors() {
 			std::set<std::string> s;
-			s.insert("mapgen_air");
+			s.insert("air");
 			s.insert("group:freezes");
 			return s;
 		}


### PR DESCRIPTION
The mapgen_air alias is only used in content_abm.cpp to facilitate melting and freezing, which makes no sense. Because air is defined in C++, not Lua (the Lua definition doesn't even properly override the C++ definition in C++ functions), it is always available, and doesn't need an alias for games (as games are unable to define their own version of air anyway). It seems like for both consistency and logical reasons, mapgen_air should be removed.
