### PR TITLE
Increase the amount of particles that breaking a node generates

### DIFF
--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -243,7 +243,7 @@ void addDiggingParticles(IGameDef* gamedef, scene::ISceneManager* smgr,
 		LocalPlayer *player, ClientEnvironment &env, v3s16 pos,
 		const TileSpec tiles[])
 {
-	for (u16 j = 0; j < 32; j++) // set the amount of particles here
+	for (u16 j = 0; j < 256; j++) // set the amount of particles here
 	{
 		addNodeParticle(gamedef, smgr, player, env, pos, tiles);
 	}


### PR DESCRIPTION
When a node breaks the particles don't seem to indicate that. This is especially noticeable with dig_immediate = 3 where it simply seems to disappear rather than breaking.