### PR TITLE
Add support for visual_scale for drawtype signlike and torchlike

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1998,7 +1998,9 @@ Node definition (register_node)
     <all fields allowed in item definitions>,
 
     drawtype = "normal", -- See "Node drawtypes"
-    visual_scale = 1.0,
+    visual_scale = 1.0, -- supported for drawtypes "plantlike", "signlike", "torchlike"
+                        -- for plantlike, the image will start at the bottom of the node; for the other drawtypes, the image
+                        -- will be centered on the node
     tiles = {tile definition 1, def2, def3, def4, def5, def6},
     ^ Textures of node; +Y, -Y, +X, -X, +Z, -Z (old field name: tile_images)
     ^ List can be shortened to needed length

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -908,13 +908,14 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			u16 l = getInteriorLight(n, 1, data);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
+			float s = BS/2*f.visual_scale;
 			// Wall at X+ of node
 			video::S3DVertex vertices[4] =
 			{
-				video::S3DVertex(-BS/2,-BS/2,0, 0,0,0, c, 0,1),
-				video::S3DVertex(BS/2,-BS/2,0, 0,0,0, c, 1,1),
-				video::S3DVertex(BS/2,BS/2,0, 0,0,0, c, 1,0),
-				video::S3DVertex(-BS/2,BS/2,0, 0,0,0, c, 0,0),
+				video::S3DVertex(-s,-s,0, 0,0,0, c, 0,1),
+				video::S3DVertex( s,-s,0, 0,0,0, c, 1,1),
+				video::S3DVertex( s, s,0, 0,0,0, c, 1,0),
+				video::S3DVertex(-s, s,0, 0,0,0, c, 0,0),
 			};
 
 			for(s32 i=0; i<4; i++)
@@ -949,13 +950,14 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 				
 			float d = (float)BS/16;
+			float s = BS/2*f.visual_scale;
 			// Wall at X+ of node
 			video::S3DVertex vertices[4] =
 			{
-				video::S3DVertex(BS/2-d,BS/2,BS/2, 0,0,0, c, 0,0),
-				video::S3DVertex(BS/2-d,BS/2,-BS/2, 0,0,0, c, 1,0),
-				video::S3DVertex(BS/2-d,-BS/2,-BS/2, 0,0,0, c, 1,1),
-				video::S3DVertex(BS/2-d,-BS/2,BS/2, 0,0,0, c, 0,1),
+				video::S3DVertex(BS/2-d,  s,  s, 0,0,0, c, 0,0),
+				video::S3DVertex(BS/2-d,  s, -s, 0,0,0, c, 1,0),
+				video::S3DVertex(BS/2-d, -s, -s, 0,0,0, c, 1,1),
+				video::S3DVertex(BS/2-d, -s,  s, 0,0,0, c, 0,1),
 			};
 
 			v3s16 dir = n.getWallMountedDir(nodedef);
@@ -990,16 +992,16 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			u16 l = getInteriorLight(n, 1, data);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
+			float s = BS/2*f.visual_scale;
+
 			for(u32 j=0; j<2; j++)
 			{
 				video::S3DVertex vertices[4] =
 				{
-					video::S3DVertex(-BS/2*f.visual_scale,-BS/2,0, 0,0,0, c, 0,1),
-					video::S3DVertex( BS/2*f.visual_scale,-BS/2,0, 0,0,0, c, 1,1),
-					video::S3DVertex( BS/2*f.visual_scale,
-						-BS/2 + f.visual_scale*BS,0, 0,0,0, c, 1,0),
-					video::S3DVertex(-BS/2*f.visual_scale,
-						-BS/2 + f.visual_scale*BS,0, 0,0,0, c, 0,0),
+					video::S3DVertex(-s,-BS/2,      0, 0,0,0, c, 0,1),
+					video::S3DVertex( s,-BS/2,      0, 0,0,0, c, 1,1),
+					video::S3DVertex( s,-BS/2 + s*2,0, 0,0,0, c, 1,0),
+					video::S3DVertex(-s,-BS/2 + s*2,0, 0,0,0, c, 0,0),
 				};
 
 				if(j == 0)


### PR DESCRIPTION
visual_scale can now be used for drawtype signlike (previously: only plantlike); advantage: animated wind- and watermills become possible
