### PR TITLE
Assume a selection box for fences

### DIFF
--- a/builtin/misc_register.lua
+++ b/builtin/misc_register.lua
@@ -106,6 +106,11 @@ function minetest.register_item(name, itemdef)
 		-- Use the nodebox as selection box if it's not set manually
 		if itemdef.drawtype == "nodebox" and not itemdef.selection_box then
 			itemdef.selection_box = itemdef.node_box
+		elseif itemdef.drawtype == "fencelike" and not itemdef.selection_box then
+			itemdef.selection_box = {
+				type = "fixed",
+				fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
+			}
 		end
 		setmetatable(itemdef, {__index = minetest.nodedef_default})
 		minetest.registered_nodes[itemdef.name] = itemdef


### PR DESCRIPTION
Similar to assuming a selection box for the nodebox drawtype, minetest.register_item() now assumes a selection box for the fencelike drawtype.

The default selection box for fences is as ugly as the default selection box for nodebox drawtype nodes used to be. This pull fixes that problem in a similar manner as how the nodebox drawtype nodes were fixed.
