### PR TITLE
Portability fixes for OpenBSD (and possibly NetBSD and others).

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -373,8 +373,13 @@ void initializePaths()
 	//TODO: Get path of executable. This assumes working directory is bin/
 	dstream<<"WARNING: Relative path not properly supported on this platform"
 			<<std::endl;
-	path_share = std::string("..");
-	path_user = std::string("..");
+
+	/* scriptapi no longer allows paths that start with "..", so assuming that
+	   the current working directory is bin/, strip off the last component. */
+	char *cwd = getcwd(NULL, 0);
+	pathRemoveFile(cwd, '/');
+	path_share = std::string(cwd);
+	path_user = std::string(cwd);
 
 	#endif
 
@@ -477,7 +482,7 @@ void initializePaths()
 
 	path_user = std::string(getenv("HOME")) + "/Library/Application Support/" + PROJECT_NAME;
 
-	#elif defined(__FreeBSD__)
+	#else // FreeBSD, and probably many other POSIX-like systems.
 
 	path_share = STATIC_SHAREDIR;
 	path_user = std::string(getenv("HOME")) + "/." + PROJECT_NAME;


### PR DESCRIPTION
Compiling and running on OpenBSD was working as of the 0.4.7 release, but not working in current master.  This patch fixes it.

A change was made to the way lua code is included that no longer works with relative paths, e.g. the built-in default "../" path to the minetest project root.

For RUN_IN_PLACE=1, Some OS-specific hacks were added for various operating systems (MacOS, Windows, FreeBSD, Linux) to determine the absolute path of the program being run, but there is apparently no POSIX standard way to get this information (probably due to the difference between spawn and fork/exec).  For all other operating systems, this patch restores the original behavior of assuming that ../ is the project root, but uses getcwd() to convert it to an absolute path.

For RUN_IN_PLACE=0, #if blocks were defined only for enumerated operating systems; all others would use the built-in (and no longer working) default of "../".  Since FreeBSD's code here is the simplest and looks very standard, this fix extends that code to cover OpenBSD, NetBSD, etc.
