### PR TITLE
Fixed ignoring of "diggable" property of nodes.

### DIFF
--- a/builtin/item.lua
+++ b/builtin/item.lua
@@ -370,8 +370,7 @@ end
 
 function minetest.node_dig(pos, node, digger)
 	local def = ItemStack({name=node.name}):get_definition()
-	-- Check if def ~= 0 because we always want to be able to remove unknown nodes
-	if #def ~= 0 and not def.diggable or (def.can_dig and not def.can_dig(pos,digger)) then
+	if not def.diggable or (def.can_dig and not def.can_dig(pos,digger)) then
 		minetest.log("info", digger:get_player_name() .. " tried to dig "
 			.. node.name .. " which is not diggable "
 			.. minetest.pos_to_string(pos))

--- a/builtin/misc_register.lua
+++ b/builtin/misc_register.lua
@@ -256,6 +256,7 @@ minetest.register_item(":unknown", {
 	on_place = minetest.item_place,
 	on_drop = minetest.item_drop,
 	groups = {not_in_creative_inventory=1},
+	diggable = true,
 })
 
 minetest.register_node(":air", {


### PR DESCRIPTION
Previously, the "diggable" property of nodes was being ignored, due to the node_dig() function making two false assumptions. First, it assumes that a valid node definition can be counted using the # operator. This is not true, as Lua ignores table entries that aren't indexed by number when using the # operator, causing all valid node definitions to return 0 when using it. Second, the function assumes that unknown nodes will return an empty table. This is also untrue, as they will return the unknown item's definition table.

This removes the faulty table count checker and adds "diggable = true" to the unknown node's definition, to allow diggability of undefined nodes while now allowing other nodes to be defined as not diggable.
