### PR TITLE
Add more checks to vector functions

### DIFF
--- a/builtin/vector.lua
+++ b/builtin/vector.lua
@@ -1,41 +1,46 @@
 
 vector = {}
 
+local function assert_vector(v)
+	assert(type(v) == "table" and v.x and v.y and v.z, "Invalid vector")
+end
+
 function vector.new(a, b, c)
-	assert(a)
 	if type(a) == "table" then
+		assert(a.x and a.y and a.z, "Invalid vector passed to vector.new()")
 		return {x=a.x, y=a.y, z=a.z}
-	else
-		assert(b and c)
+	elseif a then
+		assert(b and c, "Invalid arguments for vector.new()")
 		return {x=a, y=b, z=c}
 	end
 	return {x=0, y=0, z=0}
 end
 
 function vector.equals(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	return a.x == b.x and
 	       a.y == b.y and
 	       a.z == b.z
 end
 
 function vector.length(v)
-	assert(v)
+	assert_vector(v)
 	return math.hypot(v.x, math.hypot(v.y, v.z))
 end
 
 function vector.normalize(v)
-	assert(v)
+	assert_vector(v)
 	local len = vector.length(v)
 	if len == 0 then
-		return vector.new()
+		return {x=0, y=0, z=0}
 	else
 		return vector.divide(v, len)
 	end
 end
 
 function vector.round(v)
-	assert(v)
+	assert_vector(v)
 	return {
 		x = math.floor(v.x + 0.5),
 		y = math.floor(v.y + 0.5),
@@ -44,7 +49,8 @@ function vector.round(v)
 end
 
 function vector.distance(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	local x = a.x - b.x
 	local y = a.y - b.y
 	local z = a.z - b.z
@@ -52,7 +58,8 @@ function vector.distance(a, b)
 end
 
 function vector.direction(pos1, pos2)
-	assert(pos1 and pos2)
+	assert_vector(pos1)
+	assert_vector(pos2)
 	local x_raw = pos2.x - pos1.x
 	local y_raw = pos2.y - pos1.y
 	local z_raw = pos2.z - pos1.z
@@ -82,7 +89,8 @@ end
 
 
 function vector.add(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	if type(b) == "table" then
 		return {x = a.x + b.x,
 			y = a.y + b.y,
@@ -95,7 +103,8 @@ function vector.add(a, b)
 end
 
 function vector.subtract(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	if type(b) == "table" then
 		return {x = a.x - b.x,
 			y = a.y - b.y,
@@ -108,7 +117,8 @@ function vector.subtract(a, b)
 end
 
 function vector.multiply(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	if type(b) == "table" then
 		return {x = a.x * b.x,
 			y = a.y * b.y,
@@ -121,7 +131,8 @@ function vector.multiply(a, b)
 end
 
 function vector.divide(a, b)
-	assert(a and b)
+	assert_vector(a)
+	assert_vector(b)
 	if type(b) == "table" then
 		return {x = a.x / b.x,
 			y = a.y / b.y,


### PR DESCRIPTION
This causes, eg, `vector.add({}, 5)` to fail properly.
