### PR TITLE
Pass a errfunc to lua_pcall to get a traceback

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -871,6 +871,8 @@ void read_groups(lua_State *L, int index,
 /******************************************************************************/
 void push_items(lua_State *L, const std::vector<ItemStack> &items)
 {
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
 	// Get the table insert function
 	lua_getglobal(L, "table");
 	lua_getfield(L, -1, "insert");
@@ -883,11 +885,12 @@ void push_items(lua_State *L, const std::vector<ItemStack> &items)
 		lua_pushvalue(L, table_insert);
 		lua_pushvalue(L, table);
 		LuaItemStack::create(L, item);
-		if(lua_pcall(L, 2, 0, 0))
-			script_error(L, "error: %s", lua_tostring(L, -1));
+		if(lua_pcall(L, 2, 0, errorhandler))
+			script_error(L);
 	}
-	lua_remove(L, -2); // Remove table
 	lua_remove(L, -2); // Remove insert
+	lua_remove(L, -2); // Remove table
+	lua_remove(L, -2); // Remove error handler
 }
 
 /******************************************************************************/

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -64,9 +64,10 @@ enum RunCallbacksMode
 	// are converted by lua_toboolean to true or false, respectively.
 };
 
-std::string script_get_backtrace   (lua_State *L);
-void        script_error           (lua_State *L, const char *fmt, ...);
-void        script_run_callbacks   (lua_State *L, int nargs,
-                                    RunCallbacksMode mode);
+std::string script_get_backtrace(lua_State *L);
+int script_error_handler(lua_State *L);
+void script_error(lua_State *L);
+void script_run_callbacks(lua_State *L, int nargs,
+		RunCallbacksMode mode);
 
 #endif /* C_INTERNAL_H_ */

--- a/src/script/common/c_types.cpp
+++ b/src/script/common/c_types.cpp
@@ -25,9 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 LuaError::LuaError(lua_State *L, const std::string &s)
 {
-	m_s = "LuaError: ";
-	m_s += s + "\n";
-	m_s += script_get_backtrace(L);
+	m_s = "LuaError: " + s;
+	if (L) m_s += '\n' + script_get_backtrace(L);
 }
 
 struct EnumString es_ItemType[] =

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -31,6 +31,7 @@ extern "C" {
 #include "jthread/jmutex.h"
 #include "jthread/jmutexautolock.h"
 #include "common/c_types.h"
+#include "common/c_internal.h"
 
 #define SCRIPTAPI_LOCK_DEBUG
 
@@ -65,7 +66,7 @@ protected:
 		{ return m_luastack; }
 
 	void realityCheck();
-	void scriptError(const char *fmt, ...);
+	void scriptError();
 	void stackDump(std::ostream &o);
 
 	Server* getServer() { return m_server; }

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -78,25 +78,29 @@ void ScriptApiEntity::luaentity_Activate(u16 id,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	verbosestream<<"scriptapi_luaentity_activate: id="<<id<<std::endl;
 
 	// Get minetest.luaentities[id]
-	luaentity_get(L,id);
+	luaentity_get(L, id);
 	int object = lua_gettop(L);
 
 	// Get on_activate function
-	lua_pushvalue(L, object);
 	lua_getfield(L, -1, "on_activate");
-	if(!lua_isnil(L, -1)){
+	if(!lua_isnil(L, -1)) {
 		luaL_checktype(L, -1, LUA_TFUNCTION);
 		lua_pushvalue(L, object); // self
 		lua_pushlstring(L, staticdata.c_str(), staticdata.size());
 		lua_pushinteger(L, dtime_s);
 		// Call with 3 arguments, 0 results
-		if(lua_pcall(L, 3, 0, 0))
-			scriptError("error running function on_activate: %s\n",
-					lua_tostring(L, -1));
+		if(lua_pcall(L, 3, 0, errorhandler))
+			scriptError();
+	} else {
+		lua_pop(L, 1);
 	}
+	lua_pop(L, 2); // Pop object and error handler
 }
 
 void ScriptApiEntity::luaentity_Remove(u16 id)
@@ -123,14 +127,16 @@ std::string ScriptApiEntity::luaentity_GetStaticdata(u16 id)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	//infostream<<"scriptapi_luaentity_get_staticdata: id="<<id<<std::endl;
 
 	// Get minetest.luaentities[id]
-	luaentity_get(L,id);
+	luaentity_get(L, id);
 	int object = lua_gettop(L);
 
 	// Get get_staticdata function
-	lua_pushvalue(L, object);
 	lua_getfield(L, -1, "get_staticdata");
 	if(lua_isnil(L, -1))
 		return "";
@@ -138,11 +144,12 @@ std::string ScriptApiEntity::luaentity_GetStaticdata(u16 id)
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_pushvalue(L, object); // self
 	// Call with 1 arguments, 1 results
-	if(lua_pcall(L, 1, 1, 0))
-		scriptError("error running function get_staticdata: %s\n",
-				lua_tostring(L, -1));
+	if(lua_pcall(L, 1, 1, errorhandler))
+		scriptError();
+	lua_remove(L, object); // Remove object
+	lua_remove(L, errorhandler); // Remove error handler
 
-	size_t len=0;
+	size_t len = 0;
 	const char *s = lua_tolstring(L, -1, &len);
 	return std::string(s, len);
 }
@@ -192,10 +199,13 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
 	// Get minetest.luaentities[id]
-	luaentity_get(L,id);
+	luaentity_get(L, id);
 	int object = lua_gettop(L);
 	// State: object is at top of stack
 	// Get step function
@@ -206,8 +216,10 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 	lua_pushvalue(L, object); // self
 	lua_pushnumber(L, dtime); // dtime
 	// Call with 2 arguments, 0 results
-	if(lua_pcall(L, 2, 0, 0))
-		scriptError("error running function 'on_step': %s\n", lua_tostring(L, -1));
+	if(lua_pcall(L, 2, 0, errorhandler))
+		scriptError();
+	lua_remove(L, object); // Remove object
+	lua_remove(L, errorhandler); // Remove error handler
 }
 
 // Calls entity:on_punch(ObjectRef puncher, time_from_last_punch,
@@ -217,6 +229,9 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 		const ToolCapabilities *toolcap, v3f dir)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
 
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
@@ -235,8 +250,10 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 	push_tool_capabilities(L, *toolcap);
 	push_v3f(L, dir);
 	// Call with 5 arguments, 0 results
-	if(lua_pcall(L, 5, 0, 0))
-		scriptError("error running function 'on_punch': %s\n", lua_tostring(L, -1));
+	if(lua_pcall(L, 5, 0, errorhandler))
+		scriptError();
+	lua_remove(L, object); // Remove object
+	lua_remove(L, errorhandler); // Remove error handler
 }
 
 // Calls entity:on_rightclick(ObjectRef clicker)
@@ -244,6 +261,9 @@ void ScriptApiEntity::luaentity_Rightclick(u16 id,
 		ServerActiveObject *clicker)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
 
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
@@ -259,7 +279,9 @@ void ScriptApiEntity::luaentity_Rightclick(u16 id,
 	lua_pushvalue(L, object); // self
 	objectrefGetOrCreate(clicker); // Clicker reference
 	// Call with 2 arguments, 0 results
-	if(lua_pcall(L, 2, 0, 0))
-		scriptError("error running function 'on_rightclick': %s\n", lua_tostring(L, -1));
+	if(lua_pcall(L, 2, 0, errorhandler))
+		scriptError();
+	lua_remove(L, object); // Remove object
+	lua_remove(L, errorhandler); // Remove error handler
 }
 

--- a/src/script/cpp_api/s_inventory.cpp
+++ b/src/script/cpp_api/s_inventory.cpp
@@ -33,6 +33,9 @@ int ScriptApiDetached::detached_inventory_AllowMove(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "allow_move"))
 		return count;
@@ -42,23 +45,19 @@ int ScriptApiDetached::detached_inventory_AllowMove(
 	InventoryLocation loc;
 	loc.setDetached(name);
 	InvRef::create(L, loc);
-	// from_list
-	lua_pushstring(L, from_list.c_str());
-	// from_index
-	lua_pushinteger(L, from_index + 1);
-	// to_list
-	lua_pushstring(L, to_list.c_str());
-	// to_index
-	lua_pushinteger(L, to_index + 1);
-	// count
-	lua_pushinteger(L, count);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 7, 1, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	lua_pushstring(L, from_list.c_str()); // from_list
+	lua_pushinteger(L, from_index + 1);   // from_index
+	lua_pushstring(L, to_list.c_str());   // to_list
+	lua_pushinteger(L, to_index + 1);     // to_index
+	lua_pushinteger(L, count);            // count
+	objectrefGetOrCreate(player);         // player
+	if(lua_pcall(L, 7, 1, errorhandler))
+		scriptError();
 	if(!lua_isnumber(L, -1))
 		throw LuaError(L, "allow_move should return a number");
-	return luaL_checkinteger(L, -1);
+	int ret = luaL_checkinteger(L, -1);
+	lua_pop(L, 2); // Pop integer and error handler
+	return ret;
 }
 
 // Return number of accepted items to be put
@@ -69,28 +68,28 @@ int ScriptApiDetached::detached_inventory_AllowPut(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "allow_put"))
 		return stack.count; // All will be accepted
 
 	// Call function(inv, listname, index, stack, player)
-	// inv
 	InventoryLocation loc;
 	loc.setDetached(name);
-	InvRef::create(L, loc);
-	// listname
-	lua_pushstring(L, listname.c_str());
-	// index
-	lua_pushinteger(L, index + 1);
-	// stack
-	LuaItemStack::create(L, stack);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 5, 1, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	InvRef::create(L, loc);              // inv
+	lua_pushstring(L, listname.c_str()); // listname
+	lua_pushinteger(L, index + 1);       // index
+	LuaItemStack::create(L, stack);      // stack
+	objectrefGetOrCreate(player);        // player
+	if(lua_pcall(L, 5, 1, errorhandler))
+		scriptError();
 	if(!lua_isnumber(L, -1))
 		throw LuaError(L, "allow_put should return a number");
-	return luaL_checkinteger(L, -1);
+	int ret = luaL_checkinteger(L, -1);
+	lua_pop(L, 2); // Pop integer and error handler
+	return ret;
 }
 
 // Return number of accepted items to be taken
@@ -101,28 +100,28 @@ int ScriptApiDetached::detached_inventory_AllowTake(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "allow_take"))
 		return stack.count; // All will be accepted
 
 	// Call function(inv, listname, index, stack, player)
-	// inv
 	InventoryLocation loc;
 	loc.setDetached(name);
-	InvRef::create(L, loc);
-	// listname
-	lua_pushstring(L, listname.c_str());
-	// index
-	lua_pushinteger(L, index + 1);
-	// stack
-	LuaItemStack::create(L, stack);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 5, 1, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	InvRef::create(L, loc);              // inv
+	lua_pushstring(L, listname.c_str()); // listname
+	lua_pushinteger(L, index + 1);       // index
+	LuaItemStack::create(L, stack);      // stack
+	objectrefGetOrCreate(player);        // player
+	if(lua_pcall(L, 5, 1, errorhandler))
+		scriptError();
 	if(!lua_isnumber(L, -1))
 		throw LuaError(L, "allow_take should return a number");
-	return luaL_checkinteger(L, -1);
+	int ret = luaL_checkinteger(L, -1);
+	lua_pop(L, 2); // Pop integer and error handler
+	return ret;
 }
 
 // Report moved items
@@ -134,6 +133,9 @@ void ScriptApiDetached::detached_inventory_OnMove(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "on_move"))
 		return;
@@ -143,20 +145,15 @@ void ScriptApiDetached::detached_inventory_OnMove(
 	InventoryLocation loc;
 	loc.setDetached(name);
 	InvRef::create(L, loc);
-	// from_list
-	lua_pushstring(L, from_list.c_str());
-	// from_index
-	lua_pushinteger(L, from_index + 1);
-	// to_list
-	lua_pushstring(L, to_list.c_str());
-	// to_index
-	lua_pushinteger(L, to_index + 1);
-	// count
-	lua_pushinteger(L, count);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 7, 0, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	lua_pushstring(L, from_list.c_str()); // from_list
+	lua_pushinteger(L, from_index + 1);   // from_index
+	lua_pushstring(L, to_list.c_str());   // to_list
+	lua_pushinteger(L, to_index + 1);     // to_index
+	lua_pushinteger(L, count);            // count
+	objectrefGetOrCreate(player);         // player
+	if(lua_pcall(L, 7, 0, errorhandler))
+		scriptError();
+	lua_pop(L, 1); // Pop error handler
 }
 
 // Report put items
@@ -167,6 +164,9 @@ void ScriptApiDetached::detached_inventory_OnPut(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "on_put"))
 		return;
@@ -176,16 +176,13 @@ void ScriptApiDetached::detached_inventory_OnPut(
 	InventoryLocation loc;
 	loc.setDetached(name);
 	InvRef::create(L, loc);
-	// listname
-	lua_pushstring(L, listname.c_str());
-	// index
-	lua_pushinteger(L, index + 1);
-	// stack
-	LuaItemStack::create(L, stack);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 5, 0, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	lua_pushstring(L, listname.c_str()); // listname
+	lua_pushinteger(L, index + 1);       // index
+	LuaItemStack::create(L, stack);      // stack
+	objectrefGetOrCreate(player);        // player
+	if(lua_pcall(L, 5, 0, errorhandler))
+		scriptError();
+	lua_pop(L, 1); // Pop error handler
 }
 
 // Report taken items
@@ -196,6 +193,9 @@ void ScriptApiDetached::detached_inventory_OnTake(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Push callback function on stack
 	if(!getDetachedInventoryCallback(name, "on_take"))
 		return;
@@ -205,16 +205,13 @@ void ScriptApiDetached::detached_inventory_OnTake(
 	InventoryLocation loc;
 	loc.setDetached(name);
 	InvRef::create(L, loc);
-	// listname
-	lua_pushstring(L, listname.c_str());
-	// index
-	lua_pushinteger(L, index + 1);
-	// stack
-	LuaItemStack::create(L, stack);
-	// player
-	objectrefGetOrCreate(player);
-	if(lua_pcall(L, 5, 0, 0))
-		scriptError("error: %s", lua_tostring(L, -1));
+	lua_pushstring(L, listname.c_str()); // listname
+	lua_pushinteger(L, index + 1);       // index
+	LuaItemStack::create(L, stack);      // stack
+	objectrefGetOrCreate(player);        // player
+	if(lua_pcall(L, 5, 0, errorhandler))
+		scriptError();
+	lua_pop(L, 1); // Pop error handler
 }
 
 // Retrieves minetest.detached_inventories[name][callbackname]

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -37,29 +37,41 @@ void ScriptApiMainMenu::handleMainMenuEvent(std::string text)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Get handler function
 	lua_getglobal(L, "engine");
 	lua_getfield(L, -1, "event_handler");
-	if(lua_isnil(L, -1))
+	lua_remove(L, -2); // Remove engine
+	if(lua_isnil(L, -1)) {
+		lua_pop(L, 1); // Pop event_handler
 		return;
+	}
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 
 	// Call it
 	lua_pushstring(L, text.c_str());
-	if(lua_pcall(L, 1, 0, 0))
-		scriptError("error running function engine.event_handler: %s\n",
-				lua_tostring(L, -1));
+	if(lua_pcall(L, 1, 0, errorhandler))
+		scriptError();
+	lua_pop(L, 1); // Pop error handler
 }
 
 void ScriptApiMainMenu::handleMainMenuButtons(std::map<std::string, std::string> fields)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	lua_pushcfunction(L, script_error_handler);
+	int errorhandler = lua_gettop(L);
+
 	// Get handler function
 	lua_getglobal(L, "engine");
 	lua_getfield(L, -1, "button_handler");
-	if(lua_isnil(L, -1))
+	lua_remove(L, -2); // Remove engine
+	if(lua_isnil(L, -1)) {
+		lua_pop(L, 1); // Pop button handler
 		return;
+	}
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 
 	// Convert fields to lua table
@@ -74,7 +86,7 @@ void ScriptApiMainMenu::handleMainMenuButtons(std::map<std::string, std::string>
 	}
 
 	// Call it
-	if(lua_pcall(L, 1, 0, 0))
-		scriptError("error running function engine.button_handler: %s\n",
-				lua_tostring(L, -1));
+	if(lua_pcall(L, 1, 0, errorhandler))
+		scriptError();
+	lua_pop(L, 1); // Pop error handler
 }

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define L_BASE_H_
 
 #include "common/c_types.h"
+#include "common/c_internal.h"
 
 extern "C" {
 #include <lua.h>

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -449,7 +449,7 @@ int ModApiCraft::l_get_all_craft_recipes(lua_State *L)
 			lua_pushstring(L, &tmpout.item[0]);
 			lua_setfield(L, -2, "output");
 			if (lua_pcall(L, 2, 0, 0))
-				script_error(L, "error: %s", lua_tostring(L, -1));
+				script_error(L);
 		}
 	}
 	return 1;

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -333,7 +333,10 @@ int LuaPseudoRandom::l_next(lua_State *L)
 		throw LuaError(L, "PseudoRandom.next(): max < min");
 	}
 	if(max - min != 32767 && max - min > 32767/5)
-		throw LuaError(L, "PseudoRandom.next() max-min is not 32767 and is > 32768/5. This is disallowed due to the bad random distribution the implementation would otherwise make.");
+		throw LuaError(L, "PseudoRandom.next() max-min is not 32767"
+				" and is > 32768/5. This is disallowed due to"
+				" the bad random distribution the"
+				" implementation would otherwise make.");
 	PseudoRandom &pseudo = o->m_pseudo;
 	int val = pseudo.next();
 	val = (val % (max-min+1)) + min;

--- a/src/script/lua_api/l_rollback.cpp
+++ b/src/script/lua_api/l_rollback.cpp
@@ -66,7 +66,7 @@ int ModApiRollback::l_rollback_revert_actions_by(lua_State *L)
 		lua_pushvalue(L, table);
 		lua_pushstring(L, i->c_str());
 		if(lua_pcall(L, 2, 0, 0))
-			script_error(L, "error: %s", lua_tostring(L, -1));
+			script_error(L);
 	}
 	lua_remove(L, -2); // Remove table
 	lua_remove(L, -2); // Remove insert

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -220,6 +220,7 @@ int ModApiServer::l_get_modpath(lua_State *L)
 int ModApiServer::l_get_modnames(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
+
 	// Get a list of mods
 	std::list<std::string> mods_unsorted, mods_sorted;
 	getServer(L)->getModNames(mods_unsorted);
@@ -263,7 +264,7 @@ int ModApiServer::l_get_modnames(lua_State *L)
 		lua_pushstring(L, (*i).c_str());
 		if(lua_pcall(L, 2, 0, 0) != 0)
 		{
-			script_error(L, "error: %s", lua_tostring(L, -1));
+			script_error(L);
 		}
 		++i;
 	}


### PR DESCRIPTION
Previously any errors after the initial loading stage would only print a error line, and not the backtrace.
This caused untraceable crashes, notably in the vector lib.
This has been tested on VanessaE's servers for a few days and has helped find a number of otherwise untraceable bugs.
