### PR TITLE
fixed array limit check when reading Lua specialtiles table

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -334,7 +334,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 			// removes value, keeps key for next iteration
 			lua_pop(L, 1);
 			i++;
-			if(i==6){
+			if(i==CF_SPECIAL_COUNT){
 				lua_pop(L, 1);
 				break;
 			}


### PR DESCRIPTION
Fixes a potential crash when having more than 2 entries in the Lua nodedef's special_tiles table (which would exceed the array's limit).
This also removes a corresponding and pretty vague GCC array-bounds warning...
