### PR TITLE
fix gettext compile issues under win32

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -56,7 +56,7 @@ inline wchar_t* chartowchar_t(const char *str)
 	int nResult = MultiByteToWideChar( CP_UTF8, 0, (LPCSTR) str, -1, 0, 0 );
 	if( nResult == 0 )
 	{
-		fprintf( stderr, "error: MultiByteToWideChar returned null\n" );
+		errorstream<<"gettext: MultiByteToWideChar returned null"<<std::endl;
 	}
 	else
 	{


### PR DESCRIPTION
This stopped to compile the _win32-specific part, which needed a stdio.h included somewhere (which seemingly isn't the case anymore..?) - this fix uses the already provided errorstream for the error output, and removes the dependency on stdio.h.
