### PR TITLE
fixed potential NULLptr problems and leaked objects when setting node metadata

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2299,23 +2299,37 @@ NodeMetadata* Map::getNodeMetadata(v3s16 p)
 	return meta;
 }
 
-void Map::setNodeMetadata(v3s16 p, NodeMetadata *meta)
+/**
+ * Sets metadata for a node.
+ * This method sets the metadata for a given node.
+ * On succes, it returns @c true and the object pointed to
+ * by @p meta is then managed by the system and should
+ * not be deleted by the caller.
+ *
+ * In case of failure however, the method returns @c false
+ * an the caller is still responsible for deleting the object!
+ *
+ * @param p node coordinates
+ * @param meta pointer to @c NodeMetadata object
+ * @return @c true on success, false on failure
+ */
+bool Map::setNodeMetadata(v3s16 p, NodeMetadata *meta)
 {
 	v3s16 blockpos = getNodeBlockPos(p);
 	v3s16 p_rel = p - blockpos*MAP_BLOCKSIZE;
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
-	if(!block){
+	if(!block) {
 		infostream<<"Map::setNodeMetadata(): Need to emerge "
 				<<PP(blockpos)<<std::endl;
 		block = emergeBlock(blockpos, false);
 	}
-	if(!block)
-	{
+	if(!block) {
 		infostream<<"WARNING: Map::setNodeMetadata(): Block not found"
 				<<std::endl;
-		return;
+		return false;
 	}
 	block->m_node_metadata.set(p_rel, meta);
+	return true;
 }
 
 void Map::removeNodeMetadata(v3s16 p)

--- a/src/map.h
+++ b/src/map.h
@@ -307,7 +307,7 @@ public:
 	*/
 
 	NodeMetadata* getNodeMetadata(v3s16 p);
-	void setNodeMetadata(v3s16 p, NodeMetadata *meta);
+	bool setNodeMetadata(v3s16 p, NodeMetadata *meta);
 	void removeNodeMetadata(v3s16 p);
 
 	/*

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -338,9 +338,15 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 				}
 				NodeMetadata *meta = map->getNodeMetadata(p);
 				if(n_old.meta != ""){
-					if(!meta){
+					if(!meta) {
 						meta = new NodeMetadata(gamedef);
-						map->setNodeMetadata(p, meta);
+						if(!map->setNodeMetadata(p, meta)) {
+							delete meta;
+							infostream<<"RollbackAction::applyRevert(): "
+									<<"setNodeMetadata failed at "
+									<<PP(p)<<" for "<<n_old.name<<std::endl;
+							return false;
+						}
 					}
 					std::istringstream is(n_old.meta, std::ios::binary);
 					meta->deSerialize(is);


### PR DESCRIPTION
When a mapblock cannot be emerged, a given NodeMetadata object will never be deleted because it is not added to a mapblock's metadata list, which takes care of the deletion at some point. Due to this, also the Lua related getmeta() may fail even with auto_create.

It may be a bit unstylish to fix this thorugh a setter with a return value, but I can't see a way which doesn't involve larger refactoring, involving callers which currently still have the object reference and doing things with it...(so the setter cannot just delete the object in case of failure), so I hope this will do - comments added, to point this out.
