### PR TITLE
Dont move item back when not clicking on a slot

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2462,12 +2462,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 						move_amount = 0;
 					}
 				}
-				else if(getAbsoluteClippingRect().isPointInside(m_pointer))
-				{
-					// Clicked somewhere else: deselect
-					m_selected_amount = 0;
-				}
-				else
+				else if (!getAbsoluteClippingRect().isPointInside(m_pointer))
 				{
 					// Clicked outside of the window: drop
 					if(button == 1)  // right


### PR DESCRIPTION
This is a leftover from the old item movement, and it doesnt make much sense with the "new" one.
Its especially annyoing when you actually want to click on a slot, but miss it by a few pixels.
