### PR TITLE
Fix shaders on some GPUs

### DIFF
--- a/client/shaders/alpha_shader/opengl_fragment.glsl
+++ b/client/shaders/alpha_shader/opengl_fragment.glsl
@@ -21,13 +21,15 @@ const float e = 2.718281828459;
 
 void main (void)
 {
-	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
-	float enable_bumpmapping = enableBumpmapping;
-
 	vec3 color;
 	vec2 uv = gl_TexCoord[0].st;
+	
+#ifdef NORMALS
 	float height;
 	vec2 tsEye = vec2(tsEyeVec.x,-tsEyeVec.y);
+	
+	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
+	float enable_bumpmapping = enableBumpmapping;
 	
 	if ((enableParallaxOcclusion == 1.0) && (use_normalmap > 0.0)) {
 		float map_height = texture2D(normalTexture, uv).a;
@@ -49,6 +51,9 @@ void main (void)
 	} else {
 		color = texture2D(baseTexture, uv).rgb;
 	}
+#else
+	color = texture2D(baseTexture, uv).rgb;
+#endif
 
 	float alpha = texture2D(baseTexture, uv).a;
 	vec4 col = vec4(color.r, color.g, color.b, alpha);

--- a/client/shaders/leaves_shader/opengl_fragment.glsl
+++ b/client/shaders/leaves_shader/opengl_fragment.glsl
@@ -18,11 +18,12 @@ const float e = 2.718281828459;
 
 void main (void)
 {
-	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
-	float enable_bumpmapping = enableBumpmapping;
-
 	vec3 color;
 	vec2 uv = gl_TexCoord[0].st;
+
+#ifdef NORMALS
+	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
+	float enable_bumpmapping = enableBumpmapping;
 
 	if ((enable_bumpmapping == 1.0) && (use_normalmap > 0.0)) {
 		vec3 base = texture2D(baseTexture, uv).rgb;
@@ -36,6 +37,9 @@ void main (void)
 	} else {
 		color = texture2D(baseTexture, uv).rgb;
 	}
+#else
+	color = texture2D(baseTexture, uv).rgb;
+#endif
 
 	float alpha = texture2D(baseTexture, uv).a;
 	vec4 col = vec4(color.r, color.g, color.b, alpha);

--- a/client/shaders/liquids_shader/opengl_fragment.glsl
+++ b/client/shaders/liquids_shader/opengl_fragment.glsl
@@ -17,11 +17,12 @@ const float e = 2.718281828459;
 
 void main (void)
 {
-	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
-	float enable_bumpmapping = enableBumpmapping;
-
 	vec3 color;
 	vec2 uv = gl_TexCoord[0].st;
+	
+#ifdef NORMALS
+	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
+	float enable_bumpmapping = enableBumpmapping;
 
 	if ((enable_bumpmapping == 1.0) && (use_normalmap > 0.0)) {
 		vec3 base = texture2D(baseTexture, uv).rgb;
@@ -35,6 +36,9 @@ void main (void)
 	} else {
 		color = texture2D(baseTexture, uv).rgb;
 	}
+#else
+	color = texture2D(baseTexture, uv).rgb;
+#endif
 
 	float alpha = gl_Color.a;
 	vec4 col = vec4(color.r, color.g, color.b, alpha);

--- a/client/shaders/plants_shader/opengl_fragment.glsl
+++ b/client/shaders/plants_shader/opengl_fragment.glsl
@@ -17,11 +17,12 @@ const float e = 2.718281828459;
 
 void main (void)
 {
-	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
-	float enable_bumpmapping = enableBumpmapping;
-
 	vec3 color;
 	vec2 uv = gl_TexCoord[0].st;
+	
+#ifdef NORMALS
+	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
+	float enable_bumpmapping = enableBumpmapping;
 
 	if ((enable_bumpmapping == 1.0) && (use_normalmap > 0.0)) {
 		vec3 base = texture2D(baseTexture, uv).rgb;
@@ -35,6 +36,9 @@ void main (void)
 	} else {
 		color = texture2D(baseTexture, uv).rgb;
 	}
+#else
+	color = texture2D(baseTexture, uv).rgb;
+#endif
 
 	float alpha = texture2D(baseTexture, uv).a;
 	vec4 col = vec4(color.r, color.g, color.b, alpha);

--- a/client/shaders/solids_shader/opengl_fragment.glsl
+++ b/client/shaders/solids_shader/opengl_fragment.glsl
@@ -23,13 +23,15 @@ const float e = 2.718281828459;
 
 void main (void)
 {
-	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
-	float enable_bumpmapping = enableBumpmapping;
-
 	vec3 color;
 	vec2 uv = gl_TexCoord[0].st;
+	
+#ifdef NORMALS
 	float height;
 	vec2 tsEye = vec2(tsEyeVec.x,-tsEyeVec.y);
+	
+	float use_normalmap = texture2D(useNormalmap,vec2(1.0,1.0)).r;
+	float enable_bumpmapping = enableBumpmapping;
 	
 	if ((enableParallaxOcclusion == 1.0) && (use_normalmap > 0.0)) {
 		float map_height = texture2D(normalTexture, uv).a;
@@ -69,6 +71,9 @@ void main (void)
 	} else {
 		color = texture2D(baseTexture, uv).rgb;
 	}
+#else
+	color = texture2D(baseTexture, uv).rgb;
+#endif
 
 	float alpha = texture2D(baseTexture, uv).a;
 	vec4 col = vec4(color.r, color.g, color.b, alpha);

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -673,6 +673,15 @@ ShaderInfo generate_shader(std::string name, IrrlichtDevice *device,
 	if(vertex_program == "" && pixel_program == "" && geometry_program == "")
 		return shaderinfo;
 
+	if (g_settings->getBool("enable_bumpmapping") || g_settings->getBool("enable_parallax_occlusion")) {
+		if(vertex_program != "")
+			vertex_program = "#define NORMALS\n" + vertex_program;
+		if(pixel_program != "")
+			pixel_program = "#define NORMALS\n" + pixel_program;
+		if(geometry_program != "")
+			geometry_program = "#define NORMALS\n" + geometry_program;
+	}
+	
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
 	const c8* vertex_program_ptr = 0;
 	const c8* pixel_program_ptr = 0;


### PR DESCRIPTION
Some GPUs don't handle having 2 or more textures at once. Therefore, because of the way the information about the existence of normalmaps is passed to them (a second texture), you get black textures when shaders are enabled. This pull fixes it by putting that code in an #ifdef, and by adding a corresponding #define when compiling the shader if either bumpmapping or parallax mapping is enabled
