### PR TITLE
Make line_of_sight more useful, return blocking node position when false

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1305,8 +1305,9 @@ minetest.set_mapgen_params(MapgenParams)
 ^ flags and flagmask are in the same format and have the same options as 'mgflags' in minetest.conf
 minetest.clear_objects()
 ^ clear all objects in the environments
-minetest.line_of_sight(pos1,pos2,stepsize) ->true/false
+minetest.line_of_sight(pos1,pos2,stepsize) ->true/false, pos
 ^ checkif there is a direct line of sight between pos1 and pos2
+^ returns the position of the blocking node when false
 ^ pos1 First position
 ^ pos2 Second position
 ^ stepsize smaller gives more accurate results but requires more computing

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -354,7 +354,7 @@ ServerMap & ServerEnvironment::getServerMap()
 	return *m_map;
 }
 
-bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize)
+bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 *p)
 {
 	float distance = pos1.getDistanceFrom(pos2);
 
@@ -372,6 +372,7 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize)
 		MapNode n = getMap().getNodeNoEx(pos);
 
 		if(n.param0 != CONTENT_AIR) {
+			if (p != NULL) *p = pos;
 			return false;
 		}
 	}

--- a/src/environment.h
+++ b/src/environment.h
@@ -295,7 +295,7 @@ public:
 	void step(f32 dtime);
 	
 	//check if there's a line of sight between two positions
-	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0);
+	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, v3s16 *p=NULL);
 
 	u32 getGameTime() { return m_game_time; }
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -648,7 +648,7 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 	return 0;
 }
 
-// minetest.line_of_sight(pos1, pos2, stepsize) -> true/false
+// minetest.line_of_sight(pos1, pos2, stepsize) -> true/false, pos
 int ModApiEnvMod::l_line_of_sight(lua_State *L) {
 	float stepsize = 1.0;
 
@@ -663,7 +663,13 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L) {
 		stepsize = lua_tonumber(L, 3);
 	}
 
-	lua_pushboolean(L, env->line_of_sight(pos1,pos2,stepsize));
+	v3s16 p;
+	bool success = env->line_of_sight(pos1,pos2,stepsize,&p);
+	lua_pushboolean(L, success);
+	if (!success) {
+		push_v3s16(L, p);
+		return 2;
+	}
 	return 1;
 }
 


### PR DESCRIPTION
A simple modification to return potentially useful information which is currently discarded.

Forum topic: https://forum.minetest.net/viewtopic.php?id=7857

Example code:

```
local success, pos = minetest.line_of_sight(pos1, pos2, 1)
if success == false then
    print(dump(pos))
end
```

Possible uses might include shooting, long range pointing, sonar, sight though glass etc.
These are just some ideas, I am sure there will be more.
