### PR TITLE
Add `on_prejoinplayer' callback.

### DIFF
--- a/builtin/misc_register.lua
+++ b/builtin/misc_register.lua
@@ -380,6 +380,7 @@ minetest.registered_on_generateds, minetest.register_on_generated = make_registr
 minetest.registered_on_newplayers, minetest.register_on_newplayer = make_registration()
 minetest.registered_on_dieplayers, minetest.register_on_dieplayer = make_registration()
 minetest.registered_on_respawnplayers, minetest.register_on_respawnplayer = make_registration()
+minetest.registered_on_prejoinplayers, minetest.register_on_prejoinplayer = make_registration()
 minetest.registered_on_joinplayers, minetest.register_on_joinplayer = make_registration()
 minetest.registered_on_leaveplayers, minetest.register_on_leaveplayer = make_registration()
 minetest.registered_on_player_receive_fields, minetest.register_on_player_receive_fields = make_registration_reverse()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1175,6 +1175,9 @@ minetest.register_on_respawnplayer(func(ObjectRef))
 ^ Called when player is to be respawned
 ^ Called _before_ repositioning of player occurs
 ^ return true in func to disable regular player placement
+minetest.register_on_prejoinplayer(func(name, ip))
+^ Called before a player joins the game
+^ If it returns a string, the player is disconnected with that string as reason
 minetest.register_on_joinplayer(func(ObjectRef))
 ^ Called when a player joins the game
 minetest.register_on_leaveplayer(func(ObjectRef))

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_internal.h"
+#include "util/string.h"
 
 void ScriptApiPlayer::on_newplayer(ServerActiveObject *player)
 {
@@ -56,6 +57,23 @@ bool ScriptApiPlayer::on_respawnplayer(ServerActiveObject *player)
 	script_run_callbacks(L, 1, RUN_CALLBACKS_MODE_OR);
 	bool positioning_handled_by_some = lua_toboolean(L, -1);
 	return positioning_handled_by_some;
+}
+
+bool ScriptApiPlayer::on_prejoinplayer(std::string name, std::string ip, std::string &reason)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get minetest.registered_on_prejoinplayers
+	lua_getglobal(L, "minetest");
+	lua_getfield(L, -1, "registered_on_prejoinplayers");
+	lua_pushstring(L, name.c_str());
+	lua_pushstring(L, ip.c_str());
+	script_run_callbacks(L, 2, RUN_CALLBACKS_MODE_OR);
+	if (lua_isstring(L, -1)) {
+		reason.assign(lua_tostring(L, -1));
+		return true;
+	}
+	return false;
 }
 
 void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player)

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -34,6 +34,7 @@ public:
 	void on_newplayer(ServerActiveObject *player);
 	void on_dieplayer(ServerActiveObject *player);
 	bool on_respawnplayer(ServerActiveObject *player);
+	bool on_prejoinplayer(std::string name, std::string ip, std::string &reason);
 	void on_joinplayer(ServerActiveObject *player);
 	void on_leaveplayer(ServerActiveObject *player);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1970,6 +1970,19 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 			return;
 		}
 
+		{
+			std::string reason;
+			if(m_script->on_prejoinplayer(playername, addr_s, reason))
+			{
+				actionstream<<"Server: Player with the name \""<<playername<<"\" "
+						<<"tried to connect from "<<addr_s<<" "
+						<<"but it was disallowed for the following reason: "
+						<<reason<<std::endl;
+				DenyAccess(peer_id, narrow_to_wide(reason.c_str()));
+				return;
+			}
+		}
+
 		infostream<<"Server: New connection: \""<<playername<<"\" from "
 				<<addr_s<<" (peer_id="<<peer_id<<")"<<std::endl;
 


### PR DESCRIPTION
Adds the ability for mods to register callbacks called before a player is initialized.

This can be used for customized ban managers (for example, ban by regex match, IP range, wordlist, etc), or simply to deny guest players from entering your server and cluttering up your world's `players` directory. There may be other uses as well, such as logging or whatever.

Simple example: http://pastebin.com/akMiaR6e
