### PR TITLE
Better mod naming.

### DIFF
--- a/src/mods.cpp
+++ b/src/mods.cpp
@@ -48,6 +48,19 @@ void parseModContents(ModSpec &spec)
 {
 	// NOTE: this function works in mutual recursion with getModsInPath
 
+	Settings info;
+
+	// Remove everything after the first dash ('-')
+	int i = spec.name.find('-');
+	if (i > 0) {
+		spec.name = spec.name.substr(0, i);
+	}
+
+	info.readConfigFile((spec.path+DIR_DELIM+"mod.conf").c_str());
+
+	if (info.exists("name"))
+		spec.name = info.get("name");
+
 	spec.depends.clear();
 	spec.optdepends.clear();
 	spec.is_modpack = false;


### PR DESCRIPTION
This patch does the following:
- Allows mod authors to provide a `mod.conf` file, to specify the mod name directly (and can later be used for  other information about mods).
- Strips everything after the first dash. This makes it possible to have the `-master` suffix added by GitHub to the directory name.

This should avoid the need to rename the mod folders in most cases (with the first point, in all cases).