### PR TITLE
Compare values instead of pointers in Inventory::operator==

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -882,7 +882,7 @@ bool Inventory::operator == (const Inventory &other)
 
 	for(u32 i=0; i<m_lists.size(); i++)
 	{
-		if(m_lists[i] != other.m_lists[i])
+		if(!(*m_lists[i] == *other.m_lists[i]))
 			return false;
 	}
 	return true;


### PR DESCRIPTION
This fix to Inventory::operator== makes it so only modified player files are written on each cycle, as is the intention of the checkModified call near environment.cpp:429.
