### PR TITLE
Add success and output return values to chat commands

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2543,10 +2543,11 @@ Decoration definition (register_decoration)
 
 Chatcommand definition (register_chatcommand)
 {
-    params = "<name> <privilege>", -- short parameter description
-    description = "Remove privilege from player", -- full description
-    privs = {privs=true}, -- require the "privs" privilege to run
-    func = function(name, param), -- called when command is run
+    params = "<name> <privilege>", -- Short parameter description
+    description = "Remove privilege from player", -- Full description
+    privs = {privs=true}, -- Require the "privs" privilege to run
+    func = function(name, param), -- Called when command is run.
+                                  -- Returns boolean success and text output.
 }
 
 Detached inventory callbacks


### PR DESCRIPTION
This is useful for capturing the output of commands, for example to reply to a IRC channel with it or save the output of the last command.
The success return value can be used for stringing commands together conditional on success like shell's `&&` operator (My textarea commandblock could make use of this).
Example usage: https://gist.github.com/ShadowNinja/48b263aead046086a75d
