### PR TITLE
Remove lots of dead code

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -170,15 +170,6 @@ void * MeshUpdateThread::Thread()
 
 	while(!StopRequested())
 	{
-		/*// Wait for output queue to flush.
-		// Allow 2 in queue, this makes less frametime jitter.
-		// Umm actually, there is no much difference
-		if(m_queue_out.size() >= 2)
-		{
-			sleep_ms(3);
-			continue;
-		}*/
-
 		QueuedMeshUpdate *q = m_queue_in.pop();
 		if(q == NULL)
 		{
@@ -199,10 +190,6 @@ void * MeshUpdateThread::Thread()
 		r.p = q->p;
 		r.mesh = mesh_new;
 		r.ack_block_to_server = q->ack_block_to_server;
-
-		/*infostream<<"MeshUpdateThread: Processed "
-				<<"("<<q->p.X<<","<<q->p.Y<<","<<q->p.Z<<")"
-				<<std::endl;*/
 
 		m_queue_out.push_back(r);
 
@@ -302,10 +289,7 @@ bool Client::isShutdown()
 
 Client::~Client()
 {
-	{
-		//JMutexAutoLock conlock(m_con_mutex); //bulk comment-out
-		m_con.Disconnect();
-	}
+	m_con.Disconnect();
 
 	m_mesh_update_thread.Stop();
 	m_mesh_update_thread.Wait();
@@ -318,12 +302,10 @@ Client::~Client()
 	delete m_inventory_from_server;
 
 	// Delete detached inventories
-	{
-		for(std::map<std::string, Inventory*>::iterator
-				i = m_detached_inventories.begin();
-				i != m_detached_inventories.end(); i++){
-			delete i->second;
-		}
+	for(std::map<std::string, Inventory*>::iterator
+			i = m_detached_inventories.begin();
+			i != m_detached_inventories.end(); i++){
+		delete i->second;
 	}
 
 	// cleanup 3d model meshes on client shutdown
@@ -339,15 +321,12 @@ Client::~Client()
 void Client::connect(Address address)
 {
 	DSTACK(__FUNCTION_NAME);
-	//JMutexAutoLock lock(m_con_mutex); //bulk comment-out
 	m_con.SetTimeoutMs(0);
 	m_con.Connect(address);
 }
 
 bool Client::connectedAndInitialized()
 {
-	//JMutexAutoLock lock(m_con_mutex); //bulk comment-out
-
 	if(m_con.Connected() == false)
 		return false;
 	
@@ -375,14 +354,8 @@ void Client::step(float dtime)
 		m_animation_time -= 60.0;
 
 	m_time_of_day_update_timer += dtime;
-	
-	//infostream<<"Client steps "<<dtime<<std::endl;
 
-	{
-		//TimeTaker timer("ReceiveAll()", m_device);
-		// 0ms
-		ReceiveAll();
-	}
+	ReceiveAll();
 
 	/*
 		Packet counter
@@ -607,15 +580,11 @@ void Client::step(float dtime)
 		Handle environment
 	*/
 	{
-		// 0ms
-		//JMutexAutoLock lock(m_env_mutex); //bulk comment-out
-
 		// Control local player (0ms)
 		LocalPlayer *player = m_env.getLocalPlayer();
 		assert(player != NULL);
 		player->applyControl(dtime);
 
-		//TimeTaker envtimer("env step", m_device);
 		// Step environment
 		m_env.step(dtime);
 		
@@ -662,7 +631,6 @@ void Client::step(float dtime)
 		if(counter >= 10)
 		{
 			counter = 0.0;
-			//JMutexAutoLock lock(m_con_mutex); //bulk comment-out
 			// connectedAndInitialized() is true, peer exists.
 			float avg_rtt = m_con.GetPeerAvgRTT(PEER_ID_SERVER);
 			infostream<<"Client: avg_rtt="<<avg_rtt<<std::endl;
@@ -686,15 +654,6 @@ void Client::step(float dtime)
 		Replace updated meshes
 	*/
 	{
-		//JMutexAutoLock lock(m_env_mutex); //bulk comment-out
-
-		//TimeTaker timer("** Processing mesh update result queue");
-		// 0ms
-		
-		/*infostream<<"Mesh update result queue size is "
-				<<m_mesh_update_thread.m_queue_out.size()
-				<<std::endl;*/
-		
 		int num_processed_meshes = 0;
 		while(!m_mesh_update_thread.m_queue_out.empty())
 		{
@@ -703,8 +662,6 @@ void Client::step(float dtime)
 			MapBlock *block = m_env.getMap().getBlockNoCreateNoEx(r.p);
 			if(block)
 			{
-				//JMutexAutoLock lock(block->mesh_mutex);
-
 				// Delete the old mesh
 				if(block->mesh != NULL)
 				{
@@ -720,8 +677,6 @@ void Client::step(float dtime)
 			}
 			if(r.ack_block_to_server)
 			{
-				/*infostream<<"Client: ACK block ("<<r.p.X<<","<<r.p.Y
-						<<","<<r.p.Z<<")"<<std::endl;*/
 				/*
 					Acknowledge block
 				*/
@@ -827,7 +782,9 @@ void Client::step(float dtime)
 		{
 			std::ostringstream os(std::ios_base::binary);
 			writeU16(os, TOSERVER_REMOVED_SOUNDS);
-			writeU16(os, removed_server_ids.size());
+			size_t server_ids = removed_server_ids.size();
+			assert(server_ids <= 0xFFFF);
+			writeU16(os, (u16) (server_ids & 0xFFFF));
 			for(std::set<s32>::iterator i = removed_server_ids.begin();
 					i != removed_server_ids.end(); i++)
 				writeS32(os, *i);
@@ -940,7 +897,9 @@ void Client::request_media(const std::list<std::string> &file_requests)
 {
 	std::ostringstream os(std::ios_base::binary);
 	writeU16(os, TOSERVER_REQUEST_MEDIA);
-	writeU16(os, file_requests.size());
+	size_t file_requests_size = file_requests.size();
+	assert(file_requests_size <= 0xFFFF);
+	writeU16(os, (u16) (file_requests_size & 0xFFFF));
 
 	for(std::list<std::string>::const_iterator i = file_requests.begin();
 			i != file_requests.end(); ++i) {
@@ -1002,13 +961,7 @@ void Client::Receive()
 	DSTACK(__FUNCTION_NAME);
 	SharedBuffer<u8> data;
 	u16 sender_peer_id;
-	u32 datasize;
-	{
-		//TimeTaker t1("con mutex and receive", m_device);
-		//JMutexAutoLock lock(m_con_mutex); //bulk comment-out
-		datasize = m_con.Receive(sender_peer_id, data);
-	}
-	//TimeTaker t1("ProcessData", m_device);
+	u32 datasize = m_con.Receive(sender_peer_id, data);
 	ProcessData(*data, datasize, sender_peer_id);
 }
 
@@ -1045,8 +998,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 
 	u8 ser_version = m_server_ser_ver;
 
-	//infostream<<"Client received command="<<(int)command<<std::endl;
-
 	if(command == TOCLIENT_INIT)
 	{
 		if(datasize < 3)
@@ -1072,14 +1023,11 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 			playerpos_s16 = readV3S16(&data[2+1]);
 		v3f playerpos_f = intToFloat(playerpos_s16, BS) - v3f(0, BS/2, 0);
 
-		{ //envlock
-			//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
 			
-			// Set player position
-			Player *player = m_env.getLocalPlayer();
-			assert(player != NULL);
-			player->setPosition(playerpos_f);
-		}
+		// Set player position
+		Player *player = m_env.getLocalPlayer();
+		assert(player != NULL);
+		player->setPosition(playerpos_f);
 		
 		if(datasize >= 2+1+6+8)
 		{
@@ -1130,9 +1078,13 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		return;
 	}
 	
-	// Just here to avoid putting the two if's together when
-	// making some copypasta
-	{}
+	/*
+	  Handle runtime commands
+	*/
+	// there's no sane reason why we shouldn't have a player and
+	// almost everyone needs a player reference
+	Player *player = m_env.getLocalPlayer();
+	assert(player != NULL);
 
 	if(command == TOCLIENT_REMOVENODE)
 	{
@@ -1142,9 +1094,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		p.X = readS16(&data[2]);
 		p.Y = readS16(&data[4]);
 		p.Z = readS16(&data[6]);
-		
-		//TimeTaker t1("TOCLIENT_REMOVENODE");
-		
 		removeNode(p);
 	}
 	else if(command == TOCLIENT_ADDNODE)
@@ -1156,8 +1105,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		p.X = readS16(&data[2]);
 		p.Y = readS16(&data[4]);
 		p.Z = readS16(&data[6]);
-		
-		//TimeTaker t1("TOCLIENT_ADDNODE");
 
 		MapNode n;
 		n.deSerialize(&data[8], ser_version);
@@ -1181,11 +1128,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		p.Y = readS16(&data[4]);
 		p.Z = readS16(&data[6]);
 		
-		/*infostream<<"Client: Thread: BLOCKDATA for ("
-				<<p.X<<","<<p.Y<<","<<p.Z<<")"<<std::endl;*/
-		/*infostream<<"Client: Thread: BLOCKDATA for ("
-				<<p.X<<","<<p.Y<<","<<p.Z<<")"<<std::endl;*/
-		
 		std::string datastring((char*)&data[8], datasize-8);
 		std::istringstream istr(datastring, std::ios_base::binary);
 		
@@ -1196,9 +1138,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		sector = m_env.getMap().emergeSector(p2d);
 		
 		assert(sector->getPos() == p2d);
-
-		//TimeTaker timer("MapBlock deSerialize");
-		// 0ms
 		
 		block = sector->getBlockNoCreateNoEx(p.Y);
 		if(block)
@@ -1206,7 +1145,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 			/*
 				Update an existing block
 			*/
-			//infostream<<"Updating"<<std::endl;
 			block->deSerialize(istr, ser_version, false);
 			block->deSerializeNetworkSpecific(istr);
 		}
@@ -1215,37 +1153,15 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 			/*
 				Create a new block
 			*/
-			//infostream<<"Creating new"<<std::endl;
 			block = new MapBlock(&m_env.getMap(), p, this);
 			block->deSerialize(istr, ser_version, false);
 			block->deSerializeNetworkSpecific(istr);
 			sector->insertBlock(block);
 		}
 
-#if 0
-		/*
-			Acknowledge block
-		*/
-		/*
-			[0] u16 command
-			[2] u8 count
-			[3] v3s16 pos_0
-			[3+6] v3s16 pos_1
-			...
-		*/
-		u32 replysize = 2+1+6;
-		SharedBuffer<u8> reply(replysize);
-		writeU16(&reply[0], TOSERVER_GOTBLOCKS);
-		reply[2] = 1;
-		writeV3S16(&reply[3], p);
-		// Send as reliable
-		m_con.Send(PEER_ID_SERVER, 1, reply, true);
-#endif
-
 		/*
 			Add it to mesh update queue and set it to be acknowledged after update.
 		*/
-		//infostream<<"Adding mesh update task for received block"<<std::endl;
 		addUpdateMeshTaskWithEdge(p, true);
 	}
 	else if(command == TOCLIENT_INVENTORY)
@@ -1253,61 +1169,47 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		if(datasize < 3)
 			return;
 
-		//TimeTaker t1("Parsing TOCLIENT_INVENTORY", m_device);
+		std::string datastring((char*)&data[2], datasize-2);
+		std::istringstream is(datastring, std::ios_base::binary);
 
-		{ //envlock
-			//TimeTaker t2("mutex locking", m_device);
-			//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
-			//t2.stop();
-			
-			//TimeTaker t3("istringstream init", m_device);
-			std::string datastring((char*)&data[2], datasize-2);
-			std::istringstream is(datastring, std::ios_base::binary);
-			//t3.stop();
-			
-			//TimeTaker t4("player get", m_device);
-			Player *player = m_env.getLocalPlayer();
-			assert(player != NULL);
-			//t4.stop();
+		player->inventory.deSerialize(is);
 
-			//TimeTaker t1("inventory.deSerialize()", m_device);
-			player->inventory.deSerialize(is);
-			//t1.stop();
+		m_inventory_updated = true;
 
-			m_inventory_updated = true;
+		delete m_inventory_from_server;
+		m_inventory_from_server = new Inventory(player->inventory);
+		m_inventory_from_server_age = 0.0;
 
-			delete m_inventory_from_server;
-			m_inventory_from_server = new Inventory(player->inventory);
-			m_inventory_from_server_age = 0.0;
-
-			//infostream<<"Client got player inventory:"<<std::endl;
-			//player->inventory.print(infostream);
-		}
 	}
 	else if(command == TOCLIENT_TIME_OF_DAY)
 	{
 		if(datasize < 4)
 			return;
 		
-		u16 time_of_day = readU16(&data[2]);
-		time_of_day = time_of_day % 24000;
-		//infostream<<"Client: time_of_day="<<time_of_day<<std::endl;
+		u16 time_of_day  = readU16(&data[2]);
+		time_of_day      = time_of_day % 24000;
 		float time_speed = 0;
-		if(datasize >= 2 + 2 + 4){
+
+		if(datasize >= 2 + 2 + 4)
+		{
 			time_speed = readF1000(&data[4]);
-		} else {
+		}
+		else {
 			// Old message; try to approximate speed of time by ourselves
 			float time_of_day_f = (float)time_of_day / 24000.0;
 			float tod_diff_f = 0;
+
 			if(time_of_day_f < 0.2 && m_last_time_of_day_f > 0.8)
 				tod_diff_f = time_of_day_f - m_last_time_of_day_f + 1.0;
 			else
 				tod_diff_f = time_of_day_f - m_last_time_of_day_f;
-			m_last_time_of_day_f = time_of_day_f;
-			float time_diff = m_time_of_day_update_timer;
+
+			m_last_time_of_day_f         = time_of_day_f;
+			float time_diff            = m_time_of_day_update_timer;
 			m_time_of_day_update_timer = 0;
+
 			if(m_time_of_day_set){
-				time_speed = 3600.0*24.0 * tod_diff_f / time_diff;
+				time_speed = (3600.0*24.0) * tod_diff_f / time_diff;
 				infostream<<"Client: Measured time_of_day speed (old format): "
 						<<time_speed<<" tod_diff_f="<<tod_diff_f
 						<<" time_diff="<<time_diff<<std::endl;
@@ -1336,151 +1238,126 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::istringstream is(datastring, std::ios_base::binary);
 		
 		// Read stuff
-		is.read((char*)buf, 2);
+		is.read((char*) buf, 2);
 		u16 len = readU16(buf);
 		
 		std::wstring message;
-		for(u16 i=0; i<len; i++)
+		for(unsigned int i=0; i<len; i++)
 		{
 			is.read((char*)buf, 2);
 			message += (wchar_t)readU16(buf);
 		}
-
-		/*infostream<<"Client received chat message: "
-				<<wide_to_narrow(message)<<std::endl;*/
 		
 		m_chat_queue.push_back(message);
 	}
 	else if(command == TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD)
 	{
-		//if(g_settings->getBool("enable_experimental"))
+		/*
+			u16 command
+			u16 count of removed objects
+			for all removed objects {
+				u16 id
+			}
+			u16 count of added objects
+			for all added objects {
+				u16 id
+				u8 type
+				u32 initialization data length
+				string initialization data
+			}
+		*/
+
+		char buf[6];
+		// Get all data except the command number
+		std::string datastring((char*)&data[2], datasize-2);
+		// Throw them in an istringstream
+		std::istringstream is(datastring, std::ios_base::binary);
+
+		// Read removed objects
+		is.read(buf, 2);
+		u16 removed_count = readU16((u8*)buf);
+		for(unsigned int i=0; i<removed_count; i++)
 		{
-			/*
-				u16 command
-				u16 count of removed objects
-				for all removed objects {
-					u16 id
-				}
-				u16 count of added objects
-				for all added objects {
-					u16 id
-					u8 type
-					u32 initialization data length
-					string initialization data
-				}
-			*/
-
-			char buf[6];
-			// Get all data except the command number
-			std::string datastring((char*)&data[2], datasize-2);
-			// Throw them in an istringstream
-			std::istringstream is(datastring, std::ios_base::binary);
-
-			// Read stuff
-			
-			// Read removed objects
 			is.read(buf, 2);
-			u16 removed_count = readU16((u8*)buf);
-			for(u16 i=0; i<removed_count; i++)
-			{
-				is.read(buf, 2);
-				u16 id = readU16((u8*)buf);
-				// Remove it
-				{
-					//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
-					m_env.removeActiveObject(id);
-				}
-			}
-			
-			// Read added objects
+			u16 id = readU16((u8*)buf);
+			m_env.removeActiveObject(id);
+		}
+
+		// Read added objects
+		is.read(buf, 2);
+		u16 added_count = readU16((u8*)buf);
+		for(unsigned int i=0; i<added_count; i++)
+		{
 			is.read(buf, 2);
-			u16 added_count = readU16((u8*)buf);
-			for(u16 i=0; i<added_count; i++)
-			{
-				is.read(buf, 2);
-				u16 id = readU16((u8*)buf);
-				is.read(buf, 1);
-				u8 type = readU8((u8*)buf);
-				std::string data = deSerializeLongString(is);
-				// Add it
-				{
-					//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
-					m_env.addActiveObject(id, type, data);
-				}
-			}
+			u16 id = readU16((u8*)buf);
+			is.read(buf, 1);
+			u8 type = readU8((u8*)buf);
+			std::string data = deSerializeLongString(is);
+			// Add it
+			m_env.addActiveObject(id, type, data);
 		}
 	}
 	else if(command == TOCLIENT_ACTIVE_OBJECT_MESSAGES)
 	{
-		//if(g_settings->getBool("enable_experimental"))
-		{
-			/*
-				u16 command
-				for all objects
-				{
-					u16 id
-					u16 message length
-					string message
-				}
-			*/
-			char buf[6];
-			// Get all data except the command number
-			std::string datastring((char*)&data[2], datasize-2);
-			// Throw them in an istringstream
-			std::istringstream is(datastring, std::ios_base::binary);
-			
-			while(is.eof() == false)
+		/*
+			u16 command
+			for all objects
 			{
-				// Read stuff
-				is.read(buf, 2);
-				u16 id = readU16((u8*)buf);
-				if(is.eof())
-					break;
-				is.read(buf, 2);
-				u16 message_size = readU16((u8*)buf);
-				std::string message;
-				message.reserve(message_size);
-				for(u16 i=0; i<message_size; i++)
-				{
-					is.read(buf, 1);
-					message.append(buf, 1);
-				}
-				// Pass on to the environment
-				{
-					//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
-					m_env.processActiveObjectMessage(id, message);
-				}
+				u16 id
+				u16 message length
+				string message
 			}
+		*/
+		char buf[6];
+		// Get all data except the command number
+		std::string datastring((char*)&data[2], datasize-2);
+		// Throw them in an istringstream
+		std::istringstream is(datastring, std::ios_base::binary);
+
+		while(is.eof() == false)
+		{
+			is.read(buf, 2);
+			u16 id = readU16((u8*)buf);
+			if(is.eof())
+				break;
+			is.read(buf, 2);
+			size_t message_size = readU16((u8*)buf);
+			std::string message;
+			message.reserve(message_size);
+			for(unsigned int i=0; i<message_size; i++)
+			{
+				is.read(buf, 1);
+				message.append(buf, 1);
+			}
+			// Pass on to the environment
+			m_env.processActiveObjectMessage(id, message);
 		}
 	}
 	else if(command == TOCLIENT_MOVEMENT)
 	{
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
 
-		player->movement_acceleration_default = readF1000(is) * BS;
-		player->movement_acceleration_air = readF1000(is) * BS;
-		player->movement_acceleration_fast = readF1000(is) * BS;
-		player->movement_speed_walk = readF1000(is) * BS;
-		player->movement_speed_crouch = readF1000(is) * BS;
-		player->movement_speed_fast = readF1000(is) * BS;
-		player->movement_speed_climb = readF1000(is) * BS;
-		player->movement_speed_jump = readF1000(is) * BS;
-		player->movement_liquid_fluidity = readF1000(is) * BS;
+		player->movement_acceleration_default   = readF1000(is) * BS;
+		player->movement_acceleration_air       = readF1000(is) * BS;
+		player->movement_acceleration_fast      = readF1000(is) * BS;
+		player->movement_speed_walk             = readF1000(is) * BS;
+		player->movement_speed_crouch           = readF1000(is) * BS;
+		player->movement_speed_fast             = readF1000(is) * BS;
+		player->movement_speed_climb            = readF1000(is) * BS;
+		player->movement_speed_jump             = readF1000(is) * BS;
+		player->movement_liquid_fluidity        = readF1000(is) * BS;
 		player->movement_liquid_fluidity_smooth = readF1000(is) * BS;
-		player->movement_liquid_sink = readF1000(is) * BS;
-		player->movement_gravity = readF1000(is) * BS;
+		player->movement_liquid_sink            = readF1000(is) * BS;
+		player->movement_gravity                = readF1000(is) * BS;
 	}
 	else if(command == TOCLIENT_HP)
 	{
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
-		u8 oldhp = player->hp;
-		u8 hp = readU8(is);
+
+		u8 oldhp   = player->hp;
+		u8 hp      = readU8(is);
 		player->hp = hp;
 
 		if(hp < oldhp)
@@ -1496,23 +1373,18 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 	{
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
-		u16 breath = readU16(is);
-		player->setBreath(breath) ;
+
+		player->setBreath(readU16(is));
 	}
 	else if(command == TOCLIENT_MOVE_PLAYER)
 	{
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
+
 		v3f pos = readV3F1000(is);
 		f32 pitch = readF1000(is);
 		f32 yaw = readF1000(is);
 		player->setPosition(pos);
-		/*player->setPitch(pitch);
-		player->setYaw(yaw);*/
 
 		infostream<<"Client got TOCLIENT_MOVE_PLAYER"
 				<<" pos=("<<pos.X<<","<<pos.Y<<","<<pos.Z<<")"
@@ -1549,11 +1421,11 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		v3f camera_point_target = readV3F1000(is);
 		
 		ClientEvent event;
-		event.type = CE_DEATHSCREEN;
+		event.type                                = CE_DEATHSCREEN;
 		event.deathscreen.set_camera_point_target = set_camera_point_target;
-		event.deathscreen.camera_point_target_x = camera_point_target.X;
-		event.deathscreen.camera_point_target_y = camera_point_target.Y;
-		event.deathscreen.camera_point_target_z = camera_point_target.Z;
+		event.deathscreen.camera_point_target_x   = camera_point_target.X;
+		event.deathscreen.camera_point_target_y   = camera_point_target.Y;
+		event.deathscreen.camera_point_target_z   = camera_point_target.Z;
 		m_client_event_queue.push_back(event);
 	}
 	else if(command == TOCLIENT_ANNOUNCE_MEDIA)
@@ -1599,7 +1471,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 					m_media_downloader->addRemoteServer(baseurl);
 			}
 		}
-		catch(SerializationError) {
+		catch(SerializationError& e) {
 			// not supported by server or turned off
 		}
 
@@ -1649,7 +1521,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		// updating content definitions
 		assert(!m_mesh_update_thread.IsRunning());
 
-		for(u32 i=0; i<num_files; i++){
+		for(unsigned int i=0; i<num_files; i++){
 			std::string name = deSerializeString(is);
 			std::string data = deSerializeLongString(is);
 			m_media_downloader->conventionalTransferDone(
@@ -1765,7 +1637,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		m_privileges.clear();
 		infostream<<"Client: Privileges updated: ";
 		u16 num_privileges = readU16(is);
-		for(u16 i=0; i<num_privileges; i++){
+		for(unsigned int i=0; i<num_privileges; i++){
 			std::string priv = deSerializeString(is);
 			m_privileges.insert(priv);
 			infostream<<priv<<" ";
@@ -1778,8 +1650,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::istringstream is(datastring, std::ios_base::binary);
 
 		// Store formspec in LocalPlayer
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
 		player->inventory_formspec = deSerializeLongString(is);
 	}
 	else if(command == TOCLIENT_DETACHED_INVENTORY)
@@ -1821,30 +1691,28 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		v3f pos = readV3F1000(is);
-		v3f vel = readV3F1000(is);
-		v3f acc = readV3F1000(is);
-		float expirationtime = readF1000(is);
-		float size = readF1000(is);
+		v3f pos                 = readV3F1000(is);
+		v3f vel                 = readV3F1000(is);
+		v3f acc                 = readV3F1000(is);
+		float expirationtime    = readF1000(is);
+		float size              = readF1000(is);
 		bool collisiondetection = readU8(is);
-		std::string texture = deSerializeLongString(is);
-		bool vertical = false;
+		std::string texture     = deSerializeLongString(is);
+		bool vertical           = false;
 		try {
 			vertical = readU8(is);
 		} catch (...) {}
 
 		ClientEvent event;
-		event.type = CE_SPAWN_PARTICLE;
-		event.spawn_particle.pos = new v3f (pos);
-		event.spawn_particle.vel = new v3f (vel);
-		event.spawn_particle.acc = new v3f (acc);
-
-		event.spawn_particle.expirationtime = expirationtime;
-		event.spawn_particle.size = size;
-		event.spawn_particle.collisiondetection =
-				collisiondetection;
-		event.spawn_particle.vertical = vertical;
-		event.spawn_particle.texture = new std::string(texture);
+		event.type                              = CE_SPAWN_PARTICLE;
+		event.spawn_particle.pos                = new v3f (pos);
+		event.spawn_particle.vel                = new v3f (vel);
+		event.spawn_particle.acc                = new v3f (acc);
+		event.spawn_particle.expirationtime     = expirationtime;
+		event.spawn_particle.size               = size;
+		event.spawn_particle.collisiondetection = collisiondetection;
+		event.spawn_particle.vertical           = vertical;
+		event.spawn_particle.texture            = new std::string(texture);
 
 		m_client_event_queue.push_back(event);
 	}
@@ -1853,46 +1721,44 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char*)&data[2], datasize-2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		u16 amount = readU16(is);
-		float spawntime = readF1000(is);
-		v3f minpos = readV3F1000(is);
-		v3f maxpos = readV3F1000(is);
-		v3f minvel = readV3F1000(is);
-		v3f maxvel = readV3F1000(is);
-		v3f minacc = readV3F1000(is);
-		v3f maxacc = readV3F1000(is);
-		float minexptime = readF1000(is);
-		float maxexptime = readF1000(is);
-		float minsize = readF1000(is);
-		float maxsize = readF1000(is);
+		u16 amount              = readU16(is);
+		float spawntime         = readF1000(is);
+		v3f minpos              = readV3F1000(is);
+		v3f maxpos              = readV3F1000(is);
+		v3f minvel              = readV3F1000(is);
+		v3f maxvel              = readV3F1000(is);
+		v3f minacc              = readV3F1000(is);
+		v3f maxacc              = readV3F1000(is);
+		float minexptime        = readF1000(is);
+		float maxexptime        = readF1000(is);
+		float minsize           = readF1000(is);
+		float maxsize           = readF1000(is);
 		bool collisiondetection = readU8(is);
-		std::string texture = deSerializeLongString(is);
-		u32 id = readU32(is);
+		std::string texture     = deSerializeLongString(is);
+		u32 id                  = readU32(is);
 		bool vertical = false;
 		try {
 			vertical = readU8(is);
 		} catch (...) {}
 
 		ClientEvent event;
-		event.type = CE_ADD_PARTICLESPAWNER;
-		event.add_particlespawner.amount = amount;
-		event.add_particlespawner.spawntime = spawntime;
-
-		event.add_particlespawner.minpos = new v3f (minpos);
-		event.add_particlespawner.maxpos = new v3f (maxpos);
-		event.add_particlespawner.minvel = new v3f (minvel);
-		event.add_particlespawner.maxvel = new v3f (maxvel);
-		event.add_particlespawner.minacc = new v3f (minacc);
-		event.add_particlespawner.maxacc = new v3f (maxacc);
-
-		event.add_particlespawner.minexptime = minexptime;
-		event.add_particlespawner.maxexptime = maxexptime;
-		event.add_particlespawner.minsize = minsize;
-		event.add_particlespawner.maxsize = maxsize;
+		event.type                                   = CE_ADD_PARTICLESPAWNER;
+		event.add_particlespawner.amount             = amount;
+		event.add_particlespawner.spawntime          = spawntime;
+		event.add_particlespawner.minpos             = new v3f (minpos);
+		event.add_particlespawner.maxpos             = new v3f (maxpos);
+		event.add_particlespawner.minvel             = new v3f (minvel);
+		event.add_particlespawner.maxvel             = new v3f (maxvel);
+		event.add_particlespawner.minacc             = new v3f (minacc);
+		event.add_particlespawner.maxacc             = new v3f (maxacc);
+		event.add_particlespawner.minexptime         = minexptime;
+		event.add_particlespawner.maxexptime         = maxexptime;
+		event.add_particlespawner.minsize            = minsize;
+		event.add_particlespawner.maxsize            = maxsize;
 		event.add_particlespawner.collisiondetection = collisiondetection;
-		event.add_particlespawner.vertical = vertical;
-		event.add_particlespawner.texture = new std::string(texture);
-		event.add_particlespawner.id = id;
+		event.add_particlespawner.vertical           = vertical;
+		event.add_particlespawner.texture            = new std::string(texture);
+		event.add_particlespawner.id                 = id;
 
 		m_client_event_queue.push_back(event);
 	}
@@ -1904,7 +1770,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		u32 id = readU16(is);
 
 		ClientEvent event;
-		event.type = CE_DELETE_PARTICLESPAWNER;
+		event.type                      = CE_DELETE_PARTICLESPAWNER;
 		event.delete_particlespawner.id = id;
 
 		m_client_event_queue.push_back(event);
@@ -1931,18 +1797,18 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		}catch(SerializationError &e) {};
 
 		ClientEvent event;
-		event.type = CE_HUDADD;
-		event.hudadd.id     = id;
-		event.hudadd.type   = type;
-		event.hudadd.pos    = new v2f(pos);
-		event.hudadd.name   = new std::string(name);
-		event.hudadd.scale  = new v2f(scale);
-		event.hudadd.text   = new std::string(text);
-		event.hudadd.number = number;
-		event.hudadd.item   = item;
-		event.hudadd.dir    = dir;
-		event.hudadd.align  = new v2f(align);
-		event.hudadd.offset = new v2f(offset);
+		event.type             = CE_HUDADD;
+		event.hudadd.id        = id;
+		event.hudadd.type      = type;
+		event.hudadd.pos       = new v2f(pos);
+		event.hudadd.name      = new std::string(name);
+		event.hudadd.scale     = new v2f(scale);
+		event.hudadd.text      = new std::string(text);
+		event.hudadd.number    = number;
+		event.hudadd.item      = item;
+		event.hudadd.dir       = dir;
+		event.hudadd.align     = new v2f(align);
+		event.hudadd.offset    = new v2f(offset);
 		event.hudadd.world_pos = new v3f(world_pos);
 		m_client_event_queue.push_back(event);
 	}
@@ -1954,7 +1820,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		u32 id = readU32(is);
 
 		ClientEvent event;
-		event.type = CE_HUDRM;
+		event.type     = CE_HUDRM;
 		event.hudrm.id = id;
 		m_client_event_queue.push_back(event);
 	}
@@ -1982,7 +1848,7 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 			intdata = readU32(is);
 		
 		ClientEvent event;
-		event.type = CE_HUDCHANGE;
+		event.type              = CE_HUDCHANGE;
 		event.hudchange.id      = id;
 		event.hudchange.stat    = (HudElementStat)stat;
 		event.hudchange.v2fdata = new v2f(v2fdata);
@@ -1996,9 +1862,6 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char *)&data[2], datasize - 2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
-
 		u32 flags = readU32(is);
 		u32 mask  = readU32(is);
 		
@@ -2010,19 +1873,18 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char *)&data[2], datasize - 2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		Player *player = m_env.getLocalPlayer();
-		assert(player != NULL);
-
 		u16 param         = readU16(is);
 		std::string value = deSerializeString(is);
 
-		if(param == HUD_PARAM_HOTBAR_ITEMCOUNT && value.size() == 4){
+		if(param == HUD_PARAM_HOTBAR_ITEMCOUNT && value.size() == 4) {
 			s32 hotbar_itemcount = readS32((u8*) value.c_str());
 			if(hotbar_itemcount > 0 && hotbar_itemcount <= HUD_HOTBAR_ITEMCOUNT_MAX)
 				player->hud_hotbar_itemcount = hotbar_itemcount;
-		} else if (param == HUD_PARAM_HOTBAR_IMAGE) {
+		}
+		else if (param == HUD_PARAM_HOTBAR_IMAGE) {
 			((LocalPlayer *) player)->hotbar_image = value;
-		} else if (param == HUD_PARAM_HOTBAR_SELECTED_IMAGE) {
+		}
+		else if (param == HUD_PARAM_HOTBAR_SELECTED_IMAGE) {
 			((LocalPlayer *) player)->hotbar_selected_image = value;
 		}
 	}
@@ -2031,18 +1893,19 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char *)&data[2], datasize - 2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		video::SColor *bgcolor = new video::SColor(readARGB8(is));
-		std::string *type = new std::string(deSerializeString(is));
-		u16 count = readU16(is);
+		video::SColor *bgcolor           = new video::SColor(readARGB8(is));
+		std::string *type                = new std::string(deSerializeString(is));
+		u16 count                        = readU16(is);
 		std::vector<std::string> *params = new std::vector<std::string>;
+
 		for(size_t i=0; i<count; i++)
 			params->push_back(deSerializeString(is));
 
 		ClientEvent event;
-		event.type = CE_SET_SKY;
+		event.type            = CE_SET_SKY;
 		event.set_sky.bgcolor = bgcolor;
-		event.set_sky.type = type;
-		event.set_sky.params = params;
+		event.set_sky.type    = type;
+		event.set_sky.params  = params;
 		m_client_event_queue.push_back(event);
 	}
 	else if(command == TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO)
@@ -2050,13 +1913,13 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		std::string datastring((char *)&data[2], datasize - 2);
 		std::istringstream is(datastring, std::ios_base::binary);
 
-		bool do_override = readU8(is);
+		bool do_override        = readU8(is);
 		float day_night_ratio_f = (float)readU16(is) / 65536;
 
 		ClientEvent event;
-		event.type = CE_OVERRIDE_DAY_NIGHT_RATIO;
+		event.type                                 = CE_OVERRIDE_DAY_NIGHT_RATIO;
 		event.override_day_night_ratio.do_override = do_override;
-		event.override_day_night_ratio.ratio_f = day_night_ratio_f;
+		event.override_day_night_ratio.ratio_f     = day_night_ratio_f;
 		m_client_event_queue.push_back(event);
 	}
 	else
@@ -2118,7 +1981,9 @@ void Client::sendNodemetaFields(v3s16 p, const std::string &formname,
 	writeU16(os, TOSERVER_NODEMETA_FIELDS);
 	writeV3S16(os, p);
 	os<<serializeString(formname);
-	writeU16(os, fields.size());
+	size_t fields_size = fields.size();
+	assert(fields_size <= 0xFFFF);
+	writeU16(os, (u16) (fields_size & 0xFFFF));
 	for(std::map<std::string, std::string>::const_iterator
 			i = fields.begin(); i != fields.end(); i++){
 		const std::string &name = i->first;
@@ -2141,10 +2006,12 @@ void Client::sendInventoryFields(const std::string &formname,
 
 	writeU16(os, TOSERVER_INVENTORY_FIELDS);
 	os<<serializeString(formname);
-	writeU16(os, fields.size());
+	size_t fields_size = fields.size();
+	assert(fields_size <= 0xFFFF);
+	writeU16(os, (u16) (fields_size & 0xFFFF));
 	for(std::map<std::string, std::string>::const_iterator
 			i = fields.begin(); i != fields.end(); i++){
-		const std::string &name = i->first;
+		const std::string &name  = i->first;
 		const std::string &value = i->second;
 		os<<serializeString(name);
 		os<<serializeLongString(value);
@@ -2185,11 +2052,13 @@ void Client::sendChatMessage(const std::wstring &message)
 	os.write((char*)buf, 2);
 	
 	// Write length
-	writeU16(buf, message.size());
+	size_t messagesize = message.size();
+	assert(messagesize <= 0xFFFF);
+	writeU16(buf, (u16) (messagesize & 0xFF));
 	os.write((char*)buf, 2);
 	
 	// Write string
-	for(u32 i=0; i<message.size(); i++)
+	for(unsigned int i=0; i<message.size(); i++)
 	{
 		u16 w = message[i];
 		writeU16(buf, w);
@@ -2223,7 +2092,7 @@ void Client::sendChangePassword(const std::wstring oldpassword,
 	*/
 
 	writeU16(buf, TOSERVER_PASSWORD);
-	for(u32 i=0;i<PASSWORD_SIZE-1;i++)
+	for(unsigned int i=0;i<PASSWORD_SIZE-1;i++)
 	{
 		buf[2+i] = i<oldpwd.length()?oldpwd[i]:0;
 		buf[30+i] = i<newpwd.length()?newpwd[i]:0;
@@ -2285,24 +2154,22 @@ void Client::sendRespawn()
 
 void Client::sendPlayerPos()
 {
-	//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
-	
 	LocalPlayer *myplayer = m_env.getLocalPlayer();
 	if(myplayer == NULL)
 		return;
 
 	// Save bandwidth by only updating position when something changed
-	if(myplayer->last_position == myplayer->getPosition() &&
-			myplayer->last_speed == myplayer->getSpeed() &&
-			myplayer->last_pitch == myplayer->getPitch() &&
-			myplayer->last_yaw == myplayer->getYaw() &&
+	if(myplayer->last_position        == myplayer->getPosition() &&
+			myplayer->last_speed      == myplayer->getSpeed()    &&
+			myplayer->last_pitch      == myplayer->getPitch()    &&
+			myplayer->last_yaw        == myplayer->getYaw()      &&
 			myplayer->last_keyPressed == myplayer->keyPressed)
 		return;
 
-	myplayer->last_position = myplayer->getPosition();
-	myplayer->last_speed = myplayer->getSpeed();
-	myplayer->last_pitch = myplayer->getPitch();
-	myplayer->last_yaw = myplayer->getYaw();
+	myplayer->last_position   = myplayer->getPosition();
+	myplayer->last_speed      = myplayer->getSpeed();
+	myplayer->last_pitch      = myplayer->getPitch();
+	myplayer->last_yaw        = myplayer->getYaw();
 	myplayer->last_keyPressed = myplayer->keyPressed;
 
 	u16 our_peer_id;
@@ -2317,13 +2184,14 @@ void Client::sendPlayerPos()
 	// Check that an existing peer_id is the same as the connection's
 	assert(myplayer->peer_id == our_peer_id);
 	
-	v3f pf = myplayer->getPosition();
+	v3f pf         = myplayer->getPosition();
+	v3f sf         = myplayer->getSpeed();
+	s32 pitch      = myplayer->getPitch() * 100;
+	s32 yaw        = myplayer->getYaw() * 100;
+	u32 keyPressed = myplayer->keyPressed;
+
 	v3s32 position(pf.X*100, pf.Y*100, pf.Z*100);
-	v3f sf = myplayer->getSpeed();
 	v3s32 speed(sf.X*100, sf.Y*100, sf.Z*100);
-	s32 pitch = myplayer->getPitch() * 100;
-	s32 yaw = myplayer->getYaw() * 100;
-	u32 keyPressed=myplayer->keyPressed;
 	/*
 		Format:
 		[0] u16 command
@@ -2372,7 +2240,6 @@ void Client::removeNode(v3s16 p)
 
 	try
 	{
-		//TimeTaker t("removeNodeAndUpdate", m_device);
 		m_env.getMap().removeNodeAndUpdate(p, modified_blocks);
 	}
 	catch(InvalidPositionException &e)
@@ -2414,7 +2281,6 @@ void Client::addNode(v3s16 p, MapNode n, bool remove_metadata)
 	
 void Client::setPlayerControl(PlayerControl &control)
 {
-	//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
 	player->control = control;
@@ -2422,7 +2288,6 @@ void Client::setPlayerControl(PlayerControl &control)
 
 void Client::selectPlayerItem(u16 item)
 {
-	//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
 	m_playeritem = item;
 	m_inventory_updated = true;
 	sendPlayerItem(item);
@@ -2432,8 +2297,6 @@ void Client::selectPlayerItem(u16 item)
 // updated from the server. If it is true, it is set to false.
 bool Client::getLocalInventoryUpdated()
 {
-	// m_inventory_updated is behind envlock
-	//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
 	bool updated = m_inventory_updated;
 	m_inventory_updated = false;
 	return updated;
@@ -2442,7 +2305,6 @@ bool Client::getLocalInventoryUpdated()
 // Copies the inventory of the local player to parameter
 void Client::getLocalInventory(Inventory &dst)
 {
-	//JMutexAutoLock envlock(m_env_mutex); //bulk comment-out
 	Player *player = m_env.getLocalPlayer();
 	assert(player != NULL);
 	dst = player->inventory;
@@ -2489,6 +2351,7 @@ Inventory* Client::getInventory(const InventoryLocation &loc)
 	}
 	return NULL;
 }
+
 void Client::inventoryAction(InventoryAction *a)
 {
 	/*
@@ -2514,14 +2377,12 @@ ClientActiveObject * Client::getSelectedActiveObject(
 	std::vector<DistanceSortedActiveObject> objects;
 
 	m_env.getActiveObjects(from_pos_f_on_map, max_d, objects);
-
-	//infostream<<"Collected "<<objects.size()<<" nearby objects"<<std::endl;
 	
 	// Sort them.
 	// After this, the closest object is the first in the array.
 	std::sort(objects.begin(), objects.end());
 
-	for(u32 i=0; i<objects.size(); i++)
+	for(unsigned int i=0; i<objects.size(); i++)
 	{
 		ClientActiveObject *obj = objects[i].obj;
 		
@@ -2538,24 +2399,11 @@ ClientActiveObject * Client::getSelectedActiveObject(
 
 		if(offsetted_box.intersectsWithLine(shootline_on_map))
 		{
-			//infostream<<"Returning selected object"<<std::endl;
 			return obj;
 		}
 	}
 
-	//infostream<<"No object selected; returning NULL."<<std::endl;
 	return NULL;
-}
-
-void Client::printDebugInfo(std::ostream &os)
-{
-	//JMutexAutoLock lock1(m_fetchblock_mutex);
-	/*JMutexAutoLock lock2(m_incoming_queue_mutex);
-
-	os<<"m_incoming_queue.getSize()="<<m_incoming_queue.getSize()
-		//<<", m_fetchblock_history.size()="<<m_fetchblock_history.size()
-		//<<", m_opt_not_found_history.size()="<<m_opt_not_found_history.size()
-		<<std::endl;*/
 }
 
 std::list<std::string> Client::getConnectedPlayerNames()
@@ -2642,12 +2490,6 @@ void Client::typeChatMessage(const std::wstring &message)
 
 void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 {
-	/*infostream<<"Client::addUpdateMeshTask(): "
-			<<"("<<p.X<<","<<p.Y<<","<<p.Z<<")"
-			<<" ack_to_server="<<ack_to_server
-			<<" urgent="<<urgent
-			<<std::endl;*/
-
 	MapBlock *b = m_env.getMap().getBlockNoCreateNoEx(p);
 	if(b == NULL)
 		return;
@@ -2666,33 +2508,20 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 		data->setCrack(m_crack_level, m_crack_pos);
 		data->setSmoothLighting(g_settings->getBool("smooth_lighting"));
 	}
-
-	// Debug wait
-	//while(m_mesh_update_thread.m_queue_in.size() > 0) sleep_ms(10);
 	
 	// Add task to queue
 	m_mesh_update_thread.m_queue_in.addBlock(p, data, ack_to_server, urgent);
-
-	/*infostream<<"Mesh update input queue size is "
-			<<m_mesh_update_thread.m_queue_in.size()
-			<<std::endl;*/
 }
 
 void Client::addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server, bool urgent)
 {
-	/*{
-		v3s16 p = blockpos;
-		infostream<<"Client::addUpdateMeshTaskWithEdge(): "
-				<<"("<<p.X<<","<<p.Y<<","<<p.Z<<")"
-				<<std::endl;
-	}*/
-
 	try{
 		v3s16 p = blockpos + v3s16(0,0,0);
 		//MapBlock *b = m_env.getMap().getBlockNoCreate(p);
 		addUpdateMeshTask(p, ack_to_server, urgent);
 	}
 	catch(InvalidPositionException &e){}
+
 	// Leading edge
 	for (int i=0;i<6;i++)
 	{
@@ -2713,7 +2542,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 				<<std::endl;
 	}
 
-	v3s16 blockpos = getNodeBlockPos(nodepos);
+	v3s16 blockpos          = getNodeBlockPos(nodepos);
 	v3s16 blockpos_relative = blockpos * MAP_BLOCKSIZE;
 
 	try{
@@ -2721,6 +2550,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 		addUpdateMeshTask(p, ack_to_server, urgent);
 	}
 	catch(InvalidPositionException &e){}
+
 	// Leading edge
 	if(nodepos.X == blockpos_relative.X){
 		try{
@@ -2729,6 +2559,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 		}
 		catch(InvalidPositionException &e){}
 	}
+
 	if(nodepos.Y == blockpos_relative.Y){
 		try{
 			v3s16 p = blockpos + v3s16(0,-1,0);
@@ -2736,6 +2567,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 		}
 		catch(InvalidPositionException &e){}
 	}
+
 	if(nodepos.Z == blockpos_relative.Z){
 		try{
 			v3s16 p = blockpos + v3s16(0,0,-1);
@@ -2767,6 +2599,7 @@ float Client::mediaReceiveProgress()
 void draw_load_screen(const std::wstring &text,
 		IrrlichtDevice* device, gui::IGUIFont* font,
 		float dtime=0 ,int percent=0, bool clouds=true);
+
 void Client::afterContentReceived(IrrlichtDevice *device, gui::IGUIFont* font)
 {
 	infostream<<"Client::afterContentReceived() started"<<std::endl;
@@ -2877,16 +2710,17 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename)
 				<<std::endl;
 		return NULL;
 	}
-	const std::string &data = i->second;
+	const std::string &data    = i->second;
 	scene::ISceneManager *smgr = m_device->getSceneManager();
 
 	// Create the mesh, remove it from cache and return it
 	// This allows unique vertex colors and other properties for each instance
 	Buffer<char> data_rw(data.c_str(), data.size()); // Const-incorrect Irrlicht
 	io::IFileSystem *irrfs = m_device->getFileSystem();
-	io::IReadFile *rfile = irrfs->createMemoryReadFile(
+	io::IReadFile *rfile   = irrfs->createMemoryReadFile(
 			*data_rw, data_rw.getSize(), filename.c_str());
 	assert(rfile);
+
 	scene::IAnimatedMesh *mesh = smgr->getMesh(rfile);
 	rfile->drop();
 	// NOTE: By playing with Irrlicht refcounts, maybe we could cache a bunch

--- a/src/client.h
+++ b/src/client.h
@@ -384,9 +384,6 @@ public:
 			core::line3d<f32> shootline_on_map
 	);
 
-	// Prints a line or two of info
-	void printDebugInfo(std::ostream &os);
-
 	std::list<std::string> getConnectedPlayerNames();
 
 	float getAnimationTime();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1518,6 +1518,9 @@ void the_game(
 	str += "]";
 	device->setWindowCaption(str.c_str());
 
+	// Info text
+	std::wstring infotext;
+
 	for(;;)
 	{
 		if(device->run() == false || kill == true)
@@ -1700,23 +1703,9 @@ void the_game(
 		
 		// Hilight boxes collected during the loop and displayed
 		std::vector<aabb3f> hilightboxes;
-		
-		// Info text
-		std::wstring infotext;
 
-		/*
-			Debug info for client
-		*/
-		{
-			static float counter = 0.0;
-			counter -= dtime;
-			if(counter < 0)
-			{
-				counter = 30.0;
-				client.printDebugInfo(infostream);
-			}
-		}
-
+		/* reset infotext */
+		infotext = L"";
 		/*
 			Profiler
 		*/


### PR DESCRIPTION
- Remove lots of dead code.
- Add check for datatype overflows.
- Use native datatype indices instead of fixed 16bit/32bit ones.
