### PR TITLE
Protocol version <= 22 compatibility mode + clean new client init

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1200,6 +1200,29 @@ minetest.features
 minetest.has_feature(arg) -> bool, missing_features
 ^ arg: string or table in format {foo=true, bar=true}
 ^ missing_features: {foo=true, bar=true}
+minetest.get_player_information(playername)
+^ table containing information about player peer:
+{
+	address = "127.0.0.1",     -- ip address of client
+	ip_version = 4,            -- IPv4 / IPv6
+	min_rtt = 0.01,            -- minimum round trip time
+	max_rtt = 0.2,             -- maximum round trip time
+	avg_rtt = 0.02,            -- average round trip time
+	min_jitter = 0.01,         -- minimum packet time jitter
+	max_jitter = 0.5,          -- maximum packet time jitter
+	avg_jitter = 0.03,         -- average packet time jitter
+	connection_uptime = 200,   -- seconds since client connected
+	
+	-- following information is available on debug build only!!!
+	-- DO NOT USE IN MODS
+	--ser_vers = 26,             -- serialization version used by client
+	--prot_vers = 23,            -- protocol version used by client
+	--major = 0,                 -- major version number
+	--minor = 4,                 -- minor version number
+	--patch = 10,                -- patch version number
+	--vers_string = "0.4.9-git", -- full version string
+	--state = "Active"           -- current client state
+}
 
 Logging:
 minetest.debug(line)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -47,6 +47,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serialization.h"
 #include "util/serialize.h"
 #include "config.h"
+#include "cmake_config_githash.h"
 #include "util/directiontables.h"
 #include "util/pointedthing.h"
 #include "version.h"
@@ -252,7 +253,8 @@ Client::Client(
 	m_last_time_of_day_f(-1),
 	m_time_of_day_update_timer(0),
 	m_recommended_send_interval(0.1),
-	m_removed_sounds_check_timer(0)
+	m_removed_sounds_check_timer(0),
+	m_state(LC_Created)
 {
 	m_packetcounter_timer = 0.0;
 	//m_delete_unused_sectors_timer = 0.0;
@@ -325,17 +327,6 @@ void Client::connect(Address address)
 	m_con.Connect(address);
 }
 
-bool Client::connectedAndInitialized()
-{
-	if(m_con.Connected() == false)
-		return false;
-	
-	if(m_server_ser_ver == SER_FMT_VER_INVALID)
-		return false;
-	
-	return true;
-}
-
 void Client::step(float dtime)
 {
 	DSTACK(__FUNCTION_NAME);
@@ -372,9 +363,6 @@ void Client::step(float dtime)
 			m_packetcounter.clear();
 		}
 	}
-	
-	// Get connection status
-	bool connected = connectedAndInitialized();
 
 #if 0
 	{
@@ -467,7 +455,7 @@ void Client::step(float dtime)
 	}
 #endif
 
-	if(connected == false)
+	if(m_state == LC_Created)
 	{
 		float &counter = m_connection_reinit_timer;
 		counter -= dtime;
@@ -632,7 +620,7 @@ void Client::step(float dtime)
 		{
 			counter = 0.0;
 			// connectedAndInitialized() is true, peer exists.
-			float avg_rtt = m_con.GetPeerAvgRTT(PEER_ID_SERVER);
+			float avg_rtt = getRTT();
 			infostream<<"Client: avg_rtt="<<avg_rtt<<std::endl;
 		}
 	}
@@ -643,7 +631,7 @@ void Client::step(float dtime)
 	{
 		float &counter = m_playerpos_send_timer;
 		counter += dtime;
-		if(counter >= m_recommended_send_interval)
+		if((m_state == LC_Ready) && (counter >= m_recommended_send_interval))
 		{
 			counter = 0.0;
 			sendPlayerPos();
@@ -1050,6 +1038,8 @@ void Client::ProcessData(u8 *data, u32 datasize, u16 sender_peer_id)
 		writeU16(&reply[0], TOSERVER_INIT2);
 		// Send as reliable
 		m_con.Send(PEER_ID_SERVER, 1, reply, true);
+
+		m_state = LC_Init;
 
 		return;
 	}
@@ -1937,7 +1927,7 @@ void Client::Send(u16 channelnum, SharedBuffer<u8> data, bool reliable)
 
 void Client::interact(u8 action, const PointedThing& pointed)
 {
-	if(connectedAndInitialized() == false){
+	if(m_state != LC_Ready){
 		infostream<<"Client::interact() "
 				"cancelled (not connected)"
 				<<std::endl;
@@ -2144,6 +2134,27 @@ void Client::sendRespawn()
 	std::ostringstream os(std::ios_base::binary);
 
 	writeU16(os, TOSERVER_RESPAWN);
+
+	// Make data buffer
+	std::string s = os.str();
+	SharedBuffer<u8> data((u8*)s.c_str(), s.size());
+	// Send as reliable
+	Send(0, data, true);
+}
+
+void Client::sendReady()
+{
+	DSTACK(__FUNCTION_NAME);
+	std::ostringstream os(std::ios_base::binary);
+
+	writeU16(os, TOSERVER_CLIENT_READY);
+	writeU8(os,VERSION_MAJOR);
+	writeU8(os,VERSION_MINOR);
+	writeU8(os,VERSION_PATCH_ORIG);
+	writeU8(os,0);
+
+	writeU16(os,strlen(CMAKE_VERSION_GITHASH));
+	os.write(CMAKE_VERSION_GITHASH,strlen(CMAKE_VERSION_GITHASH));
 
 	// Make data buffer
 	std::string s = os.str();
@@ -2650,16 +2661,14 @@ void Client::afterContentReceived(IrrlichtDevice *device, gui::IGUIFont* font)
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_thread.Start();
 	
+	m_state = LC_Ready;
+	sendReady();
 	infostream<<"Client::afterContentReceived() done"<<std::endl;
 }
 
 float Client::getRTT(void)
 {
-	try{
-		return m_con.GetPeerAvgRTT(PEER_ID_SERVER);
-	} catch(con::PeerNotFoundException &e){
-		return 1337;
-	}
+	return m_con.getPeerStat(PEER_ID_SERVER,con::AVG_RTT);
 }
 
 // IGameDef interface

--- a/src/client.h
+++ b/src/client.h
@@ -57,6 +57,12 @@ struct QueuedMeshUpdate
 	~QueuedMeshUpdate();
 };
 
+enum LocalClientState {
+	LC_Created,
+	LC_Init,
+	LC_Ready
+};
+
 /*
 	A thread-safe queue of mesh update tasks
 */
@@ -319,14 +325,7 @@ public:
 		calling this, as it is sent in the initialization.
 	*/
 	void connect(Address address);
-	/*
-		returns true when
-			m_con.Connected() == true
-			AND m_server_ser_ver != SER_FMT_VER_INVALID
-		throws con::PeerNotFoundException if connection has been deleted,
-		eg. timed out.
-	*/
-	bool connectedAndInitialized();
+
 	/*
 		Stuff that references the environment is valid only as
 		long as this is not called. (eg. Players)
@@ -354,6 +353,7 @@ public:
 	void sendDamage(u8 damage);
 	void sendBreath(u16 breath);
 	void sendRespawn();
+	void sendReady();
 
 	ClientEnvironment& getEnv()
 	{ return m_env; }
@@ -454,6 +454,8 @@ public:
 	// Send a notification that no conventional media transfer is needed
 	void received_media();
 
+	LocalClientState getState() { return m_state; }
+
 private:
 
 	// Virtual methods from con::PeerHandler
@@ -537,6 +539,9 @@ private:
 
 	// Storage for mesh data for creating multiple instances of the same mesh
 	std::map<std::string, std::string> m_mesh_data;
+
+	// own state
+	LocalClientState m_state;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -100,9 +100,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		version, heat and humidity transfer in MapBock
 		automatic_face_movement_dir and automatic_face_movement_dir_offset
 			added to object properties
+	PROTOCOL_VERSION 22:
+		add swap_node
+	PROTOCOL_VERSION 23:
+		TOSERVER_CLIENT_READY
 */
 
-#define LATEST_PROTOCOL_VERSION 22
+#define LATEST_PROTOCOL_VERSION 23
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -129,7 +133,7 @@ enum ToClientCommand
 
 		[0] u16 TOSERVER_INIT
 		[2] u8 deployed version
-		[3] v3s16 player's position + v3f(0,BS/2,0) floatToInt'd 
+		[3] v3s16 player's position + v3f(0,BS/2,0) floatToInt'd
 		[12] u64 map seed (new as of 2011-02-27)
 		[20] f1000 recommended send interval (in seconds) (new as of 14)
 
@@ -754,6 +758,16 @@ enum ToServerCommand
 	/*
 		u16 command
 		u16 breath
+	*/
+
+	TOSERVER_CLIENT_READY = 0x43,
+	/*
+		u8 major
+		u8 minor
+		u8 patch
+		u8 reserved
+		u16 len
+		u8[len] full_version_string
 	*/
 };
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -2875,11 +2875,11 @@ Address Connection::GetPeerAddress(u16 peer_id)
 	return peer_address;
 }
 
-float Connection::GetPeerAvgRTT(u16 peer_id)
+float Connection::getPeerStat(u16 peer_id, rtt_stat_type type)
 {
 	PeerHelper peer = getPeerNoEx(peer_id);
 	if (!peer) return -1;
-	return peer->getStat(AVG_RTT);
+	return peer->getStat(type);
 }
 
 u16 Connection::createPeer(Address& sender, MTProtocols protocol, int fd)

--- a/src/connection.h
+++ b/src/connection.h
@@ -1004,7 +1004,7 @@ public:
 	void Send(u16 peer_id, u8 channelnum, SharedBuffer<u8> data, bool reliable);
 	u16 GetPeerID(){ return m_peer_id; }
 	Address GetPeerAddress(u16 peer_id);
-	float GetPeerAvgRTT(u16 peer_id);
+	float getPeerStat(u16 peer_id, rtt_stat_type type);
 	const u32 GetProtocolID() const { return m_protocol_id; };
 	const std::string getDesc();
 	void DisconnectPeer(u16 peer_id);

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -116,6 +116,11 @@ public:
 	FatalSystemException(const std::string &s): BaseException(s) {}
 };
 
+class ClientStateError : public BaseException {
+public:
+	ClientStateError(std::string s): BaseException(s) {}
+};
+
 /*
 	Some "old-style" interrupts:
 */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1266,7 +1266,7 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 				server->step(dtime);
 			
 			// End condition
-			if(client.connectedAndInitialized()){
+			if(client.getState() == LC_Init){
 				could_connect = true;
 				break;
 			}
@@ -1373,7 +1373,7 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 				errorstream<<wide_to_narrow(error_message)<<std::endl;
 				break;
 			}
-			if(!client.connectedAndInitialized()){
+			if(client.getState() < LC_Init){
 				error_message = L"Client disconnected";
 				errorstream<<wide_to_narrow(error_message)<<std::endl;
 				break;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -143,7 +143,7 @@ void Hud::drawItem(v2s32 upperleftpos, s32 imgsize, s32 itemcount,
 				steppos = v2s32(padding, -(padding + i * fullimglen));
 				break;
 			default:
-				steppos = v2s32(padding + i * fullimglen, padding);	
+				steppos = v2s32(padding + i * fullimglen, padding);
 		}
 			
 		core::rect<s32> rect = imgrect + pos + steppos;
@@ -334,7 +334,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s
 			steppos = v2s32(0, -1);
 			break;
 		default:
-			steppos = v2s32(1, 0);	
+			steppos = v2s32(1, 0);
 	}
 	steppos.X *= srcd.Width;
 	steppos.Y *= srcd.Height;
@@ -363,7 +363,7 @@ void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture, s
 void Hud::drawHotbar(v2s32 centerlowerpos, s32 halfheartcount, u16 playeritem, s32 breath) {
 	InventoryList *mainlist = inventory->getList("main");
 	if (mainlist == NULL) {
-		errorstream << "draw_hotbar(): mainlist == NULL" << std::endl;
+		//silently ignore this we may not be initialized completely
 		return;
 	}
 	

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -99,7 +99,7 @@ int ModApiServer::l_get_player_ip(lua_State *L)
 	}
 	try
 	{
-		Address addr = getServer(L)->getPeerAddress(getEnv(L)->getPlayer(name)->peer_id);
+		Address addr = getServer(L)->getPeerAddress(player->peer_id);
 		std::string ip_str = addr.serializeString();
 		lua_pushstring(L, ip_str.c_str());
 		return 1;
@@ -110,6 +110,135 @@ int ModApiServer::l_get_player_ip(lua_State *L)
 		lua_pushnil(L); // error
 		return 1;
 	}
+}
+
+// get_player_information()
+int ModApiServer::l_get_player_information(lua_State *L)
+{
+
+	NO_MAP_LOCK_REQUIRED;
+	const char * name = luaL_checkstring(L, 1);
+	Player *player = getEnv(L)->getPlayer(name);
+	if(player == NULL)
+	{
+		lua_pushnil(L); // no such player
+		return 1;
+	}
+
+	Address addr;
+	try
+	{
+		addr = getServer(L)->getPeerAddress(player->peer_id);
+	}
+	catch(con::PeerNotFoundException) // unlikely
+	{
+		dstream << __FUNCTION_NAME << ": peer was not found" << std::endl;
+		lua_pushnil(L); // error
+		return 1;
+	}
+
+	float min_rtt,max_rtt,avg_rtt,min_jitter,max_jitter,avg_jitter;
+	ClientState state;
+	u32 uptime;
+	u16 prot_vers;
+	u8 ser_vers,major,minor,patch;
+	std::string vers_string;
+
+#define ERET(code)                                                             \
+	if (!(code)) {                                                             \
+		dstream << __FUNCTION_NAME << ": peer was not found" << std::endl;     \
+		lua_pushnil(L); /* error */                                            \
+		return 1;                                                              \
+	}
+
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::MIN_RTT,&min_rtt))
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::MAX_RTT,&max_rtt))
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::AVG_RTT,&avg_rtt))
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::MIN_JITTER,&min_jitter))
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::MAX_JITTER,&max_jitter))
+	ERET(getServer(L)->getClientConInfo(player->peer_id,con::AVG_JITTER,&avg_jitter))
+
+	ERET(getServer(L)->getClientInfo(player->peer_id,
+										&state, &uptime, &ser_vers, &prot_vers,
+										&major, &minor, &patch, &vers_string))
+
+	lua_newtable(L);
+	int table = lua_gettop(L);
+
+	lua_pushstring(L,"address");
+	lua_pushstring(L, addr.serializeString().c_str());
+	lua_settable(L, table);
+
+	lua_pushstring(L,"ip_version");
+	if (addr.getFamily() == AF_INET) {
+		lua_pushnumber(L, 4);
+	} else if (addr.getFamily() == AF_INET6) {
+		lua_pushnumber(L, 6);
+	} else {
+		lua_pushnumber(L, 0);
+	}
+	lua_settable(L, table);
+
+	lua_pushstring(L,"min_rtt");
+	lua_pushnumber(L, min_rtt);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"max_rtt");
+	lua_pushnumber(L, max_rtt);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"avg_rtt");
+	lua_pushnumber(L, avg_rtt);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"min_jitter");
+	lua_pushnumber(L, min_jitter);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"max_jitter");
+	lua_pushnumber(L, max_jitter);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"avg_jitter");
+	lua_pushnumber(L, avg_jitter);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"connection_uptime");
+	lua_pushnumber(L, uptime);
+	lua_settable(L, table);
+
+#ifndef NDEBUG
+	lua_pushstring(L,"serialization_version");
+	lua_pushnumber(L, ser_vers);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"protocol_version");
+	lua_pushnumber(L, prot_vers);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"major");
+	lua_pushnumber(L, major);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"minor");
+	lua_pushnumber(L, minor);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"patch");
+	lua_pushnumber(L, patch);
+	lua_settable(L, table);
+
+	lua_pushstring(L,"version_string");
+	lua_pushstring(L, vers_string.c_str());
+	lua_settable(L, table);
+
+	lua_pushstring(L,"state");
+	lua_pushstring(L,ClientInterface::state2Name(state).c_str());
+	lua_settable(L, table);
+#endif
+
+#undef ERET
+	return 1;
 }
 
 // get_ban_list()
@@ -343,6 +472,7 @@ void ModApiServer::Initialize(lua_State *L, int top)
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 
+	API_FCT(get_player_information);
 	API_FCT(get_player_privs);
 	API_FCT(get_player_ip);
 	API_FCT(get_ban_list);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -67,6 +67,9 @@ private:
 	// get_player_ip()
 	static int l_get_player_ip(lua_State *L);
 
+	// get_player_information()
+	static int l_get_player_information(lua_State *L);
+
 	// get_ban_list()
 	static int l_get_ban_list(lua_State *L);
 

--- a/src/server.h
+++ b/src/server.h
@@ -185,6 +185,7 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
+	PlayerSAO* StageTwoClientInit(u16 peer_id);
 	void ProcessData(u8 *data, u32 datasize, u16 peer_id);
 
 	// Environment must be locked when called
@@ -331,6 +332,10 @@ public:
 	void deletingPeer(con::Peer *peer, bool timeout);
 
 	void DenyAccess(u16 peer_id, const std::wstring &reason);
+	bool getClientConInfo(u16 peer_id, con::rtt_stat_type type,float* retval);
+	bool getClientInfo(u16 peer_id,ClientState* state, u32* uptime,
+			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
+			std::string* vers_string);
 
 private:
 


### PR DESCRIPTION
This pull contains multiple dependent changes
1) Don't use TOSERVER_RECEIVED_MEDIA message as client ready because it's not consistent used in old clients. Therefore old clients can't benefit from these changes anyway.
2) Make client use proper state handling too
3) Make client tell server about it's version (version is used for informational reason ONLY)

Second commit (optional)
make all the information available to lua mods.
