### PR TITLE
Fix for unloaded but active block problem

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -796,6 +796,14 @@ neighbor_found:
 
 void ServerEnvironment::activateBlock(MapBlock *block, u32 additional_dtime)
 {
+	// Reset usage timer immediately, otherwise a block that becomes active
+	// again at around the same time as it would normally be unloaded will
+	// get unloaded incorrectly. (I think this still leaves a small possibility
+	// of a race condition between this and server::AsyncRunStep, which only
+	// some kind of synchronisation will fix, but it at least reduces the window
+	// of opportunity for it to break from seconds to nanoseconds)
+	block->resetUsageTimer();
+
 	// Get time difference
 	u32 dtime_s = 0;
 	u32 stamp = block->getTimestamp();


### PR DESCRIPTION
This is the bug: firstly a map block becomes inactive, and then 29 seconds (by default) later it becomes active again, but at the same time the server async thread unloads the block, because it's been inactive for long enough to do so.

In other words, when a block becomes active, aside from making it load, nothing actually updates the 'last used' time, so there is still a short window when it can be unloaded. This results in all manner of strange behaviour. From the player's perspective, placing blocks and having them disappear, occasionally, randomly, etc. For a lua entity that moves at looks at the map nodes around it, complete breakage, because once a block is in this state, it stays that way potentially indefinitely.

This fix just resets the usage timer as soon as a block is activated. I think that still leaves a tiny window (microseconds) for a race condition allowing the block to be unloaded before the usage timer gets reset, but that's a whole lot better than the several seconds as it is now.

I can reproduce this problem regularly and frequently (not to order, but within 15 minutes of play), but with this change it hasn't happened in 10 hours of constant testing.
