### PR TITLE
Correct misleading detached inventory error message

### DIFF
--- a/src/script/cpp_api/s_inventory.cpp
+++ b/src/script/cpp_api/s_inventory.cpp
@@ -232,7 +232,7 @@ bool ScriptApiDetached::getDetachedInventoryCallback(
 	// Should be a table
 	if(lua_type(L, -1) != LUA_TTABLE)
 	{
-		errorstream<<"Item \""<<name<<"\" not defined"<<std::endl;
+		errorstream<<"Detached inventory \""<<name<<"\" not defined"<<std::endl;
 		lua_pop(L, 1);
 		return false;
 	}


### PR DESCRIPTION
Looks like a bit of hasty copying and pasting from s_item.cpp.
