### PR TITLE
Add support for autonomous lua entities

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1790,6 +1790,13 @@ LuaEntitySAO-only: (no-op for other objects)
 - getacceleration() -> {x=num, y=num, z=num}
 - setyaw(radians)
 - getyaw() -> radians
+- set_autonomous(mode)
+  When mode is 1, sets the entity to autonomous mode. This means it will
+  remain active even when there is no player in range of it - effectively
+  loading and activating map blocks like a player would. This should be
+  used with caution, and set back to 0 when no longer required.
+  In any case, it will have no effect without a global configuration change
+  on the server to enable it.
 - settexturemod(mod)
 - setsprite(p={x=0,y=0}, num_frames=1, framelength=0.2,
 -           select_horiz_by_yawpitch=false)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -361,6 +361,17 @@
 # try reducing it, but don't reduce it to a number below double of targeted
 # client number
 #max_packets_per_iteration = 1024
+
+#
+# Autonomous objects
+#
+# Set to true to allow objects (lua entities) to remain active outside the
+# range of any player. Enable with caution.
+#autonomous_objects_allowed = false
+# As for active_block_range, but for objects. Can usually be set lower than
+# the player's setting.
+#objects_block_range = 1
+
 #
 # Physics stuff
 #

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -384,7 +384,8 @@ LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos,
 	m_animation_sent(false),
 	m_bone_position_sent(false),
 	m_attachment_parent_id(0),
-	m_attachment_sent(false)
+	m_attachment_sent(false),
+	m_autonomous(false)
 {
 	// Only register type if no environment supplied
 	if(env == NULL){
@@ -456,6 +457,19 @@ ServerActiveObject* LuaEntitySAO::create(ServerEnvironment *env, v3f pos,
 	sao->m_velocity = velocity;
 	sao->m_yaw = yaw;
 	return sao;
+}
+
+bool LuaEntitySAO::isAutonomous()
+{
+	return m_autonomous;
+}
+
+bool LuaEntitySAO::setAutonomous(bool autonomous)
+{
+	if(!g_settings->getBool("autonomous_objects_allowed"))
+		return false;
+	m_autonomous = autonomous;
+	return true;
 }
 
 bool LuaEntitySAO::isAttached()

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -80,6 +80,8 @@ public:
 	std::string getName();
 	bool getCollisionBox(aabb3f *toset);
 	bool collideWithObjects();
+	bool isAutonomous();
+	bool setAutonomous(bool);
 private:
 	std::string getPropertyPacket();
 	void sendPosition(bool do_interpolate, bool is_movement_end);
@@ -116,6 +118,8 @@ private:
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
 	bool m_attachment_sent;
+
+	bool m_autonomous;
 };
 
 /*

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -227,7 +227,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");
 	settings->setDefault("num_emerge_threads", "1");
-	
+	settings->setDefault("autonomous_objects_allowed", "false");
+	settings->setDefault("objects_block_range", "1");
+
 	// physics stuff
 	settings->setDefault("movement_acceleration_default", "3");
 	settings->setDefault("movement_acceleration_air", "2");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -254,6 +254,8 @@ void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 
 void ActiveBlockList::update(std::list<v3s16> &active_positions,
 		s16 radius,
+		std::list<v3s16> &object_positions,
+		s16 object_radius,
 		std::set<v3s16> &blocks_removed,
 		std::set<v3s16> &blocks_added)
 {
@@ -265,6 +267,11 @@ void ActiveBlockList::update(std::list<v3s16> &active_positions,
 			i != active_positions.end(); ++i)
 	{
 		fillRadiusBlock(*i, radius, newlist);
+	}
+	for(std::list<v3s16>::iterator i = object_positions.begin();
+			i != object_positions.end(); ++i)
+	{
+		fillRadiusBlock(*i, object_radius, newlist);
 	}
 
 	/*
@@ -1123,15 +1130,37 @@ void ServerEnvironment::step(float dtime)
 			v3s16 blockpos = getNodeBlockPos(
 					floatToInt(player->getPosition(), BS));
 			players_blockpos.push_back(blockpos);
+
+
 		}
-		
+
+		// In addition to players, include active objects that are currently
+		// flagged as being autonomous
+		std::list<v3s16> objects_blockpos;
+		if(g_settings->getBool("autonomous_objects_allowed")) {
+			for(std::map<u16, ServerActiveObject*>::iterator
+					i = m_active_objects.begin();
+					i != m_active_objects.end(); ++i)
+			{
+				ServerActiveObject* obj = i->second;
+				if(obj->isAutonomous()) {
+					v3f objectpos = obj->getBasePosition();
+					v3s16 blockpos = getNodeBlockPos(
+						floatToInt(objectpos, BS));
+					objects_blockpos.push_back(blockpos);
+				}
+			}
+		}
+
 		/*
 			Update list of active blocks, collecting changes
 		*/
 		const s16 active_block_range = g_settings->getS16("active_block_range");
+		const s16 objects_block_range = g_settings->getS16("objects_block_range");
 		std::set<v3s16> blocks_removed;
 		std::set<v3s16> blocks_added;
 		m_active_blocks.update(players_blockpos, active_block_range,
+				objects_blockpos, objects_block_range,
 				blocks_removed, blocks_added);
 
 		/*

--- a/src/environment.h
+++ b/src/environment.h
@@ -169,9 +169,11 @@ class ActiveBlockList
 {
 public:
 	void update(std::list<v3s16> &active_positions,
-			s16 radius,
-			std::set<v3s16> &blocks_removed,
-			std::set<v3s16> &blocks_added);
+		s16 radius,
+		std::list<v3s16> &object_positions,
+		s16 object_radius,
+		std::set<v3s16> &blocks_removed,
+		std::set<v3s16> &blocks_added);
 
 	bool contains(v3s16 p){
 		return (m_list.find(p) != m_list.end());

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -48,7 +48,6 @@ struct ObjectProperties
 	bool automatic_face_movement_dir;
 	f32 automatic_face_movement_dir_offset;
 
-
 	ObjectProperties();
 	std::string dump();
 	void serialize(std::ostream &os) const;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -478,6 +478,17 @@ int ObjectRef::l_set_properties(lua_State *L)
 	return 0;
 }
 
+// set_autonomous(self, autonomous)
+int ObjectRef::l_set_autonomous(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *co = getluaobject(ref);
+	if(co == NULL) return 0;
+	u16 autonomous = luaL_checknumber(L, 2);
+	return co->setAutonomous(autonomous == 1);
+}
+
 /* LuaEntitySAO-only */
 
 // setvelocity(self, {x=num, y=num, z=num})
@@ -1234,6 +1245,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_attach),
 	luamethod(ObjectRef, set_detach),
 	luamethod(ObjectRef, set_properties),
+	luamethod(ObjectRef, set_autonomous),
 	// LuaEntitySAO-only
 	luamethod(ObjectRef, setvelocity),
 	luamethod(ObjectRef, getvelocity),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -120,6 +120,9 @@ private:
 	// set_properties(self, properties)
 	static int l_set_properties(lua_State *L);
 
+	// set_autonomous(self, autonomous)
+	static int l_set_autonomous(lua_State *L);
+
 	/* LuaEntitySAO-only */
 
 	// setvelocity(self, {x=num, y=num, z=num})

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -136,7 +136,10 @@ public:
 	*/
 	virtual bool isStaticAllowed() const
 	{return true;}
-	
+
+	virtual bool isAutonomous()
+	{return true;}
+
 	// Returns tool wear
 	virtual int punch(v3f dir,
 			const ToolCapabilities *toolcap=NULL,


### PR DESCRIPTION
Autonomous entities remain active at all times, keeping a radius of
blocks around them active in the same way a player does (although with a
different and configurable radius to that used for players).

A lua entity can set itself into autonomous mode via the api, and should
switch it off again when it no longer needs it.

Autonomous capability is completely disabled by default and can only be
enabled by a setting in minetest.conf.
