### PR TITLE
Pass pointer to nodedef directly ...

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -219,7 +219,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			if(ntop.getContent() == c_flowing || ntop.getContent() == c_source)
 				top_is_same_liquid = true;
 
-			u16 l = getInteriorLight(n, 0, data);
+			u16 l = getInteriorLight(n, 0, nodedef);
 			video::SColor c = MapBlock_LightColor(f.alpha, l, decode_light(f.light_source));
 
 			/*
@@ -389,10 +389,10 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			}
 			// Use the light of the node on top if possible
 			else if(nodedef->get(ntop).param_type == CPT_LIGHT)
-				l = getInteriorLight(ntop, 0, data);
+				l = getInteriorLight(ntop, 0, nodedef);
 			// Otherwise use the light of this node (the liquid)
 			else
-				l = getInteriorLight(n, 0, data);
+				l = getInteriorLight(n, 0, nodedef);
 			video::SColor c = MapBlock_LightColor(f.alpha, l, decode_light(f.light_source));
 			
 			u8 range = rangelim(nodedef->get(c_flowing).liquid_range, 1, 8);
@@ -696,7 +696,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 		{
 			TileSpec tile = getNodeTile(n, p, v3s16(0,0,0), data);
 
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			for(u32 j=0; j<6; j++)
@@ -758,7 +758,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			TileSpec tiles[2];
 			tiles[0] = getNodeTile(n, p, dirs[0], data);
 			tiles[1] = getNodeTile(n, p, dirs[1], data);
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 			v3f pos = intToFloat(p, BS);
 			static const float a=BS/2;
@@ -876,7 +876,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			TileSpec tile_leaves = getNodeTile(n, p,
 					v3s16(0,0,0), data);
 
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			v3f pos = intToFloat(p, BS);
@@ -909,7 +909,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			tile.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
 			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			float s = BS/2*f.visual_scale;
@@ -950,7 +950,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			tile.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
 			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 
-			u16 l = getInteriorLight(n, 0, data);
+			u16 l = getInteriorLight(n, 0, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 				
 			float d = (float)BS/16;
@@ -993,7 +993,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			TileSpec tile = getNodeTileN(n, p, 0, data);
 			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 			
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			float s = BS/2*f.visual_scale;
@@ -1045,7 +1045,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 					texturestring_rot,
 					&tile_rot.texture_id);
 			
-			u16 l = getInteriorLight(n, 1, data);
+			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			const f32 post_rad=(f32)BS/8;
@@ -1294,7 +1294,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			tile.material_flags &= ~MATERIAL_FLAG_BACKFACE_CULLING;
 			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 
-			u16 l = getInteriorLight(n, 0, data);
+			u16 l = getInteriorLight(n, 0, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			float d = (float)BS/64;
@@ -1333,7 +1333,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			};
 			TileSpec tiles[6];
 			
-			u16 l = getInteriorLight(n, 0, data);
+			u16 l = getInteriorLight(n, 0, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, decode_light(f.light_source));
 
 			v3f pos = intToFloat(p, BS);

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -150,9 +150,8 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	Single light bank.
 */
 static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
-		MeshMakeData *data)
+		INodeDefManager *ndef)
 {
-	INodeDefManager *ndef = data->m_gamedef->ndef();
 	u8 light = n.getLight(bank, ndef);
 
 	while(increment > 0)
@@ -173,10 +172,10 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 	Calculate non-smooth lighting at interior of node.
 	Both light banks.
 */
-u16 getInteriorLight(MapNode n, s32 increment, MeshMakeData *data)
+u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef)
 {
-	u16 day = getInteriorLight(LIGHTBANK_DAY, n, increment, data);
-	u16 night = getInteriorLight(LIGHTBANK_NIGHT, n, increment, data);
+	u16 day = getInteriorLight(LIGHTBANK_DAY, n, increment, ndef);
+	u16 night = getInteriorLight(LIGHTBANK_NIGHT, n, increment, ndef);
 	return day | (night << 8);
 }
 
@@ -185,10 +184,8 @@ u16 getInteriorLight(MapNode n, s32 increment, MeshMakeData *data)
 	Single light bank.
 */
 static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
-		v3s16 face_dir, MeshMakeData *data)
+		v3s16 face_dir, INodeDefManager *ndef)
 {
-	INodeDefManager *ndef = data->m_gamedef->ndef();
-
 	u8 light;
 	u8 l1 = n.getLight(bank, ndef);
 	u8 l2 = n2.getLight(bank, ndef);
@@ -227,10 +224,10 @@ static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
 	Calculate non-smooth lighting at face of node.
 	Both light banks.
 */
-u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, MeshMakeData *data)
+u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef)
 {
-	u16 day = getFaceLight(LIGHTBANK_DAY, n, n2, face_dir, data);
-	u16 night = getFaceLight(LIGHTBANK_NIGHT, n, n2, face_dir, data);
+	u16 day = getFaceLight(LIGHTBANK_DAY, n, n2, face_dir, ndef);
+	u16 night = getFaceLight(LIGHTBANK_NIGHT, n, n2, face_dir, ndef);
 	return day | (night << 8);
 }
 
@@ -812,7 +809,7 @@ static void getTileInfo(
 	if(data->m_smooth_lighting == false)
 	{
 		lights[0] = lights[1] = lights[2] = lights[3] =
-				getFaceLight(n0, n1, face_dir, data);
+				getFaceLight(n0, n1, face_dir, ndef);
 	}
 	else
 	{

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -172,8 +172,8 @@ inline video::SColor MapBlock_LightColor(u8 alpha, u16 light, u8 light_source=0)
 }
 
 // Compute light at node
-u16 getInteriorLight(MapNode n, s32 increment, MeshMakeData *data);
-u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, MeshMakeData *data);
+u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef);
+u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef);
 u16 getSmoothLight(v3s16 p, v3s16 corner, MeshMakeData *data);
 
 // Retrieves the TileSpec of a face of a node


### PR DESCRIPTION
to avoid recalculation in quite often called light calculation functions
