### PR TITLE
Remove a lot of superfluous ifndef USE_CURL checks

### DIFF
--- a/src/convert_json.cpp
+++ b/src/convert_json.cpp
@@ -32,19 +32,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 
 Json::Value                 fetchJsonValue(const std::string &url,
-                                           struct curl_slist *chunk) {
-#if USE_CURL
+		struct curl_slist *chunk) {
 
 	HTTPFetchRequest fetchrequest;
 	HTTPFetchResult fetchresult;
 	fetchrequest.url = url;
 	fetchrequest.caller = HTTPFETCH_SYNC;
 
+#if USE_CURL
 	struct curl_slist* runptr = chunk;
 	while(runptr) {
 		fetchrequest.extra_headers.push_back(runptr->data);
 		runptr = runptr->next;
 	}
+#endif
 	httpfetch_sync(fetchrequest,fetchresult);
 
 	if (!fetchresult.succeeded) {
@@ -71,12 +72,12 @@ Json::Value                 fetchJsonValue(const std::string &url,
 	else {
 		return root;
 	}
-#endif
+
 	return Json::Value();
 }
 
 std::vector<ModStoreMod>    readModStoreList(Json::Value& modlist) {
-	std::vector<ModStoreMod> retval;
+		std::vector<ModStoreMod> retval;
 
 	if (modlist.isArray()) {
 		for (unsigned int i = 0; i < modlist.size(); i++)

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -447,15 +447,12 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 	}
 
 	std::vector<ServerListSpec> servers;
-#if USE_CURL
+
 	if(listtype == "online") {
 		servers = ServerList::getOnline();
 	} else {
 		servers = ServerList::getLocal();
 	}
-#else
-	servers = ServerList::getLocal();
-#endif
 
 	lua_newtable(L);
 	int top = lua_gettop(L);
@@ -573,15 +570,12 @@ int ModApiMainMenu::l_delete_favorite(lua_State *L)
 		(listtype != "online"))
 		return 0;
 
-#if USE_CURL
+
 	if(listtype == "online") {
 		servers = ServerList::getOnline();
 	} else {
 		servers = ServerList::getLocal();
 	}
-#else
-	servers = ServerList::getLocal();
-#endif
 
 	int fav_idx	= luaL_checkinteger(L,1) -1;
 

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -68,7 +68,6 @@ std::vector<ServerListSpec> getLocal()
 }
 
 
-#if USE_CURL
 std::vector<ServerListSpec> getOnline()
 {
 	Json::Value root = fetchJsonValue((g_settings->get("serverlist_url")+"/list").c_str(),0);
@@ -86,8 +85,6 @@ std::vector<ServerListSpec> getOnline()
 
 	return serverlist;
 }
-
-#endif
 
 /*
 	Delete a server fromt he local favorites list

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -30,9 +30,7 @@ typedef Json::Value ServerListSpec;
 namespace ServerList
 {
 	std::vector<ServerListSpec> getLocal();
-	#if USE_CURL
 	std::vector<ServerListSpec> getOnline();
-	#endif
 	bool deleteEntry(ServerListSpec server);
 	bool insert(ServerListSpec server);
 	std::vector<ServerListSpec> deSerialize(std::string liststring);


### PR DESCRIPTION
There aren't a lot of locations where we really need to check against USE_CURL since we switched to new httpfetch implementation.
