### PR TITLE
Scripted player camera

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1848,6 +1848,13 @@ Player-only: (no-op for other objects)
     sneak = true, -- whether player can sneak
     sneak_glitch = true, -- whether player can use the sneak glitch
   })
+- set_camera_override(
+    position = {x=0, y=0, z=0}, -- offset to default value
+    rotation = {x=0, y=0, z=0}, -- offset to default value
+    fov = 1.0, -- multiplier to default value
+	speed = 1.0 -- 0 = never, 1 = instant
+	eye = true -- first person or third person camera
+  )
 - hud_add(hud definition): add a HUD element described by HUD def, returns ID number on success
 - hud_remove(id): remove the HUD element of the specified id
 - hud_change(id, stat, value): change a value of a previously added HUD element

--- a/src/camera.h
+++ b/src/camera.h
@@ -153,6 +153,11 @@ private:
 	// Camera offset
 	v3s16 m_camera_offset;
 
+	// Lua offsets
+	v3f m_camera_lua_position;
+	v3f m_camera_lua_rotation;
+	float m_camera_lua_fov;
+
 	// Field of view and aspect ratio stuff
 	f32 m_aspect;
 	f32 m_fov_x;

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -104,9 +104,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		add swap_node
 	PROTOCOL_VERSION 23:
 		TOSERVER_CLIENT_READY
+	PROTOCOL_VERSION 24:
+		GENERIC_CMD_SET_CAMERA_OVERRIDE
 */
 
-#define LATEST_PROTOCOL_VERSION 23
+#define LATEST_PROTOCOL_VERSION 24
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -858,7 +858,7 @@ public:
 		
 		m_visuals_expired = false;
 
-		if(!m_prop.is_visible || m_is_local_player)
+		if(!m_prop.is_visible)
 			return;
 	
 		//video::IVideoDriver* driver = smgr->getVideoDriver();
@@ -1078,6 +1078,16 @@ public:
 	
 	void step(float dtime, ClientEnvironment *env)
 	{
+		// Only show the local player when third person camera is used
+		if(m_is_local_player)
+		{
+			LocalPlayer *player = m_env->getLocalPlayer();
+			if(player->camera_override_eye)
+				m_is_visible = false;
+			else
+				m_is_visible = true;
+		}
+
 		if(m_visuals_expired && m_smgr && m_irr){
 			m_visuals_expired = false;
 
@@ -1709,6 +1719,25 @@ public:
 				player->physics_override_gravity = override_gravity;
 				player->physics_override_sneak = sneak;
 				player->physics_override_sneak_glitch = sneak_glitch;
+			}
+		}
+		else if(cmd == GENERIC_CMD_SET_CAMERA_OVERRIDE)
+		{
+			v3f override_position = readV3F1000(is);
+			v3f override_rotation = readV3F1000(is);
+			float override_fov = readF1000(is);
+			float override_speed = readF1000(is);
+			bool override_eye = readU8(is);
+			
+			if(m_is_local_player)
+			{
+				LocalPlayer *player = m_env->getLocalPlayer();
+				player->camera_override_position = override_position;
+				player->camera_override_rotation = override_rotation;
+				player->camera_override_fov = override_fov;
+				player->camera_override_speed = override_speed;
+				// these are sent inverted so we get true when the server sends nothing
+				player->camera_override_eye = !override_eye;
 			}
 		}
 		else if(cmd == GENERIC_CMD_SET_ANIMATION)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -971,7 +971,13 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, Player *player_, u16 peer_id_,
 	m_physics_override_gravity(1),
 	m_physics_override_sneak(true),
 	m_physics_override_sneak_glitch(true),
-	m_physics_override_sent(false)
+	m_physics_override_sent(false),
+	m_camera_override_position(0,0,0),
+	m_camera_override_rotation(0,0,0),
+	m_camera_override_fov(1),
+	m_camera_override_speed(1),
+	m_camera_override_eye(true),
+	m_camera_override_sent(false)
 {
 	assert(m_player);
 	assert(m_peer_id != 0);
@@ -1194,6 +1200,16 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		std::string str = gob_cmd_update_physics_override(m_physics_override_speed,
 				m_physics_override_jump, m_physics_override_gravity,
 				m_physics_override_sneak, m_physics_override_sneak_glitch);
+		// create message and add to list
+		ActiveObjectMessage aom(getId(), true, str);
+		m_messages_out.push_back(aom);
+	}
+
+	if(m_camera_override_sent == false){
+		m_camera_override_sent = true;
+		std::string str = gob_cmd_update_camera_override(m_camera_override_position,
+				m_camera_override_rotation, m_camera_override_fov,
+				m_camera_override_speed, m_camera_override_eye);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push_back(aom);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -333,6 +333,13 @@ public:
 	bool m_physics_override_sneak;
 	bool m_physics_override_sneak_glitch;
 	bool m_physics_override_sent;
+
+	v3f m_camera_override_position;
+	v3f m_camera_override_rotation;
+	float m_camera_override_fov;
+	float m_camera_override_speed;
+	bool m_camera_override_eye;
+	bool m_camera_override_sent;
 };
 
 #endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3500,8 +3500,10 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 		*/
 		if(show_hud && (player->hud_flags & HUD_FLAG_WIELDITEM_VISIBLE))
 		{
+			// Don't draw wielded tool when using 3rd person camera
 			// Warning: This clears the Z buffer.
-			camera.drawWieldedTool();
+			if(player->camera_override_eye)
+				camera.drawWieldedTool();
 		}
 
 		/*

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -133,6 +133,22 @@ std::string gob_cmd_update_physics_override(float physics_override_speed, float 
 	return os.str();
 }
 
+std::string gob_cmd_update_camera_override(v3f camera_position, v3f camera_rotation,
+		float camera_fov, float camera_speed, bool camera_eye)
+{
+	std::ostringstream os(std::ios::binary);
+	// command 
+	writeU8(os, GENERIC_CMD_SET_CAMERA_OVERRIDE);
+	// parameters
+	writeV3F1000(os, camera_position);
+	writeV3F1000(os, camera_rotation);
+	writeF1000(os, camera_fov);
+	writeF1000(os, camera_speed);
+	// these are sent inverted so we get true when the server sends nothing
+	writeU8(os, !camera_eye);
+	return os.str();
+}
+
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend)
 {
 	std::ostringstream os(std::ios::binary);

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GENERIC_CMD_SET_BONE_POSITION 7
 #define GENERIC_CMD_SET_ATTACHMENT 8
 #define GENERIC_CMD_SET_PHYSICS_OVERRIDE 9
+#define GENERIC_CMD_SET_CAMERA_OVERRIDE 10
 
 #include "object_properties.h"
 std::string gob_cmd_set_properties(const ObjectProperties &prop);
@@ -65,6 +66,9 @@ std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups);
 
 std::string gob_cmd_update_physics_override(float physics_override_speed,
 		float physics_override_jump, float physics_override_gravity, bool sneak, bool sneak_glitch);
+
+std::string gob_cmd_update_camera_override(v3f camera_position, v3f camera_rotation,
+		float camera_fov, float camera_speed, bool camera_eye);
 
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend);
 

--- a/src/player.h
+++ b/src/player.h
@@ -269,6 +269,12 @@ public:
 	bool physics_override_sneak;
 	bool physics_override_sneak_glitch;
 
+	v3f camera_override_position;
+	v3f camera_override_rotation;
+	float camera_override_fov;
+	float camera_override_speed;
+	bool camera_override_eye;
+
 	u16 hp;
 
 	float hurt_tilt_timer;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -385,6 +385,42 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	return 0;
 }
 
+// set_camera_override(self, camera_position, camera_rotation, camera_fov,
+//                      camera_speed, camera_eye)
+int ObjectRef::l_set_camera_override(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *co = (PlayerSAO *) getobject(ref);
+	if(co == NULL) return 0;
+	// Do it
+	if(!lua_isnil(L, 2))
+	{
+		co->m_camera_override_position = read_v3f(L, 2);
+		co->m_camera_override_sent = false;
+	}
+	if(!lua_isnil(L, 3))
+	{
+		co->m_camera_override_rotation = read_v3f(L, 3);
+		co->m_camera_override_sent = false;
+	}
+	if(!lua_isnil(L, 4))
+	{
+		co->m_camera_override_fov = lua_tonumber(L, 4);
+		co->m_camera_override_sent = false;
+	}
+	if(!lua_isnil(L, 5))
+	{
+		co->m_camera_override_speed = lua_tonumber(L, 5);
+		co->m_camera_override_sent = false;
+	}
+	if(!lua_isnil(L, 6))
+	{
+		co->m_camera_override_eye = lua_toboolean(L, 6);
+		co->m_camera_override_sent = false;
+	}
+	return 0;
+}
+
 // set_animation(self, frame_range, frame_speed, frame_blend)
 int ObjectRef::l_set_animation(lua_State *L)
 {
@@ -1229,6 +1265,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_wielded_item),
 	luamethod(ObjectRef, set_armor_groups),
 	luamethod(ObjectRef, set_physics_override),
+	luamethod(ObjectRef, set_camera_override),
 	luamethod(ObjectRef, set_animation),
 	luamethod(ObjectRef, set_bone_position),
 	luamethod(ObjectRef, set_attach),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -105,6 +105,10 @@ private:
 	//                      physics_override_gravity, sneak, sneak_glitch)
 	static int l_set_physics_override(lua_State *L);
 
+	// set_camera_override(self, camera_position, camera_rotation, camera_fov,
+	//                      camera_speed, camera_eye)
+	static int l_set_camera_override(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend)
 	static int l_set_animation(lua_State *L);
 


### PR DESCRIPTION
I have created a Lua function which allows scripting the player's camera. You specify a position offset, rotation offset, FOV multiplier, and transition time. Additionally you can specify whether that's a third person viewpoint, in which case the wielded item is hidden and the player can see their own model.

One practical use is allowing players of different sizes to have a correct eye position... so a server can offer both giant and midget player models, while this makes it possible to define a proper camera height for each. Another is vehicles, which can now setup a behind view like any racing game when entered. Also beds, for which you can offset the location and rotation of the camera to make it look like you're laying down. It can also be used to change the FOV as an effect for specific actions... like being underwater or running. Many more uses can probably be found.

Note that this might invalidate existing "third person camera" patches, as it adds the ability to have a 3rd person camera but with a lot more features... no harm meant to the authors of those patches, since a choice between this and them might have to be taken. Also note that the local player model is still networked and will visually lag like any player on the server, which can probably be fixed later.
