### PR TITLE
Move packet creation to a central location (work in progress)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,6 +312,7 @@ add_subdirectory(util)
 
 set(common_SRCS
 	version.cpp
+	clientserver.cpp
 	rollback_interface.cpp
 	rollback.cpp
 	genericobject.cpp

--- a/src/clientserver.cpp
+++ b/src/clientserver.cpp
@@ -2,6 +2,7 @@
 #include "util/serialize.h"
 #include "mapblock.h"
 #include "inventory.h"
+#include "activeobject.h"
 
 namespace protocol {
 
@@ -150,7 +151,12 @@ SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_MESSAGES(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_ACTIVE_OBJECT_MESSAGES);
+	for(size_t i=0; i<messages.size(); i++){
+		const ActiveObjectMessage &aom = messages[i];
+		writeU16(os, aom.id);
+		os<<serializeString(aom.datastring);
+	}
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -162,7 +168,8 @@ SharedBuffer<u8> create_TOCLIENT_HP(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_HP);
+	writeU8(os, hp);
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -176,7 +183,10 @@ SharedBuffer<u8> create_TOCLIENT_MOVE_PLAYER(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_MOVE_PLAYER);
+	writeV3F1000(os, p);
+	writeF1000(os, pitch);
+	writeF1000(os, yaw);
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -188,7 +198,8 @@ SharedBuffer<u8> create_TOCLIENT_ACCESS_DENIED(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_ACCESS_DENIED);
+	os<<serializeWideString(reason);
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());

--- a/src/clientserver.cpp
+++ b/src/clientserver.cpp
@@ -1,0 +1,45 @@
+#include "clientserver.h"
+#include "util/serialize.h"
+#include "mapblock.h"
+
+namespace protocol {
+
+SharedBuffer<u8> create_TOCLIENT_INIT(
+		u16 net_proto_version,
+		u8 deployed_block_version,
+		const v3s16 &player_pos,
+		const u64 &map_seed,
+		const float recommended_send_interval
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	writeU16(os, TOCLIENT_INIT);
+	writeU8(os, deployed_block_version);
+	writeV3S16(os, player_pos);
+	writeU64(os, map_seed);
+	writeF1000(os, recommended_send_interval);
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_BLOCKDATA(
+		u16 net_proto_version,
+		v3s16 position,
+		const MapBlock *block,
+		u8 block_format_version
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	writeU16(os, TOCLIENT_BLOCKDATA);
+	writeS16(os, position.X);
+	writeS16(os, position.Y);
+	writeS16(os, position.Z);
+	block->serialize(os, block_format_version, false);
+	block->serializeNetworkSpecific(os, net_proto_version);
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+} // protocol

--- a/src/clientserver.cpp
+++ b/src/clientserver.cpp
@@ -212,7 +212,9 @@ SharedBuffer<u8> create_TOCLIENT_DEATHSCREEN(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_DEATHSCREEN);
+	writeU8(os, set_camera_point_target);
+	writeV3F1000(os, camera_point_target);
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -222,12 +224,20 @@ SharedBuffer<u8> create_TOCLIENT_MEDIA(
 		u16 net_proto_version, // Always
 		u16 num_bunches,
 		u16 bunch_i,
-		const std::list<SendableMedia> &files,
-		std::string remote_media_url
+		const std::list<SendableMedia> &files
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_MEDIA);
+	writeU16(os, num_bunches);
+	writeU16(os, bunch_i);
+	writeU32(os, files.size());
+	for(std::list<SendableMedia>::const_iterator
+			j = files.begin();
+			j != files.end(); ++j){
+		os<<serializeString(j->name);
+		os<<serializeLongString(j->data);
+	}
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -247,7 +257,8 @@ SharedBuffer<u8> create_TOCLIENT_NODEDEF(
 
 SharedBuffer<u8> create_TOCLIENT_ANNOUNCE_MEDIA(
 		u16 net_proto_version, // Always
-		const std::list<SendableMediaAnnouncement> &announcements
+		const std::list<SendableMediaAnnouncement> &announcements,
+		std::string remote_media_url
 ){
 	std::ostringstream os(std::ios_base::binary);
 

--- a/src/clientserver.cpp
+++ b/src/clientserver.cpp
@@ -3,6 +3,8 @@
 #include "mapblock.h"
 #include "inventory.h"
 #include "activeobject.h"
+#include "nodedef.h"
+#include "serialization.h" // compressZlib
 
 namespace protocol {
 
@@ -249,7 +251,12 @@ SharedBuffer<u8> create_TOCLIENT_NODEDEF(
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_NODEDEF);
+	std::ostringstream tmp_os(std::ios::binary);
+	ndef.serialize(tmp_os, net_proto_version);
+	std::ostringstream tmp_os2(std::ios::binary);
+	compressZlib(tmp_os.str(), tmp_os2);
+	os<<serializeLongString(tmp_os2.str());
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
@@ -286,13 +293,20 @@ SharedBuffer<u8> create_TOCLIENT_PLAY_SOUND(
 		const std::string &sound_name,
 		float gain,
 		u8 type,
-		v3f pos_nodes,
+		v3f pos,
 		u16 object_id,
 		bool loop
 ){
 	std::ostringstream os(std::ios_base::binary);
 
-	// TODO
+	writeU16(os, TOCLIENT_PLAY_SOUND);
+	writeS32(os, sound_id);
+	os<<serializeString(sound_name);
+	writeF1000(os, gain);
+	writeU8(os, type);
+	writeV3F1000(os, pos);
+	writeU16(os, object_id);
+	writeU8(os, loop);
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());

--- a/src/clientserver.cpp
+++ b/src/clientserver.cpp
@@ -5,7 +5,7 @@
 namespace protocol {
 
 SharedBuffer<u8> create_TOCLIENT_INIT(
-		u16 net_proto_version,
+		u16 net_proto_version, // Always
 		u8 deployed_block_version,
 		const v3s16 &player_pos,
 		const u64 &map_seed,
@@ -24,10 +24,10 @@ SharedBuffer<u8> create_TOCLIENT_INIT(
 }
 
 SharedBuffer<u8> create_TOCLIENT_BLOCKDATA(
-		u16 net_proto_version,
+		u16 net_proto_version, // Always
+		u8 block_format_version,
 		v3s16 position,
-		const MapBlock *block,
-		u8 block_format_version
+		const MapBlock *block
 ){
 	std::ostringstream os(std::ios_base::binary);
 
@@ -37,6 +37,472 @@ SharedBuffer<u8> create_TOCLIENT_BLOCKDATA(
 	writeS16(os, position.Z);
 	block->serialize(os, block_format_version, false);
 	block->serializeNetworkSpecific(os, net_proto_version);
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ADDNODE(
+		u16 net_proto_version, // Always
+		u8 block_format_version,
+		const v3s16 &p,
+		const MapNode &n,
+		bool keep_metadata
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_REMOVENODE(
+		u16 net_proto_version, // Always
+		const v3s16 &p
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_INVENTORY(
+		u16 net_proto_version, // Always
+		const Inventory* inventory
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_TIME_OF_DAY(
+		u16 net_proto_version, // Always
+		u16 time,
+		float time_speed
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_CHAT_MESSAGE(
+		u16 net_proto_version, // Always
+		std::wstring message
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD(
+		u16 net_proto_version, // Always
+		const std::set<u16> &removed_objects,
+		const std::vector<AddedObject> &added_objects
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_MESSAGES(
+		u16 net_proto_version, // Always
+		const std::vector<ActiveObjectMessage> &messages
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HP(
+		u16 net_proto_version, // Always
+		u8 hp
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_MOVE_PLAYER(
+		u16 net_proto_version, // Always
+		v3f p,
+		float pitch,
+		float yaw
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ACCESS_DENIED(
+		u16 net_proto_version, // Always
+		std::wstring reason
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_DEATHSCREEN(
+		u16 net_proto_version, // Always
+		bool set_camera_point_target,
+		v3f camera_point_target
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_MEDIA(
+		u16 net_proto_version, // Always
+		u16 num_bunches,
+		u16 bunch_i,
+		const std::list<SendableMedia> &files,
+		std::string remote_media_url
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_NODEDEF(
+		u16 net_proto_version, // Always
+		INodeDefManager &ndef
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ANNOUNCE_MEDIA(
+		u16 net_proto_version, // Always
+		const std::list<SendableMediaAnnouncement> &announcements
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ITEMDEF(
+		u16 net_proto_version, // Always
+		IItemDefManager &idef
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_PLAY_SOUND(
+		u16 net_proto_version, // Always
+		s32 sound_id,
+		const std::string &sound_name,
+		float gain,
+		u8 type,
+		v3f pos_nodes,
+		u16 object_id,
+		bool loop
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_STOP_SOUND(
+		u16 net_proto_version, // Always
+		s32 sound_id
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_PRIVILEGES(
+		u16 net_proto_version, // Always
+		const std::set<std::string> privileges
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_INVENTORY_FORMSPEC(
+		u16 net_proto_version, // Always
+		const std::string &formspec
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_DETACHED_INVENTORY(
+		u16 net_proto_version, // Always
+		const std::string &name,
+		const Inventory *inventory
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_SHOW_FORMSPEC(
+		u16 net_proto_version, // Always
+		const std::string &formspec,
+		const std::string &formname
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_MOVEMENT(
+		u16 net_proto_version, // Always
+		float movement_acceleration_default,
+		float movement_acceleration_air,
+		float movement_acceleration_fast,
+		float movement_speed_walk,
+		float movement_speed_crouch,
+		float movement_speed_fast,
+		float movement_speed_climb,
+		float movement_speed_jump,
+		float movement_liquid_fluidity,
+		float movement_liquid_fluidity_smooth,
+		float movement_liquid_sink,
+		float movement_gravity
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_SPAWN_PARTICLE(
+		u16 net_proto_version, // Always
+		v3f pos,
+		v3f velocity,
+		v3f acceleration,
+		float expirationtime,
+		float size,
+		bool collision_detection,
+		bool vertical,
+		const std::string &texture
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_ADD_PARTICLESPAWNER(
+		u16 net_proto_version, // Always
+		u16 amount,
+		float spawntime,
+		v3f minpos,
+		v3f maxpos,
+		v3f minvel,
+		v3f maxvel,
+		v3f minacc,
+		v3f maxacc,
+		float minexptime,
+		float maxexptime,
+		float minsize,
+		float maxsize,
+		bool collisiondetection,
+		bool vertical,
+		const std::string &texture,
+		u32 id
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_DELETE_PARTICLESPAWNER(
+		u16 net_proto_version, // Always
+		u32 id
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HUDADD(
+		u16 net_proto_version, // Always
+		u16 command,
+		u32 id,
+		u8 type,
+		v2f pos,
+		const std::string &name,
+		v2f scale,
+		const std::string &text,
+		u32 number,
+		u32 item,
+		u32 dir,
+		v2f align,
+		v2f offset
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HUDRM(
+		u16 net_proto_version, // Always
+		u32 id
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HUDCHANGE(
+		u16 net_proto_version, // Always
+		u32 id,
+		u8 stat,
+		void *value
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HUD_SET_FLAGS(
+		u16 net_proto_version, // Always
+		u32 flags,
+		u32 mask
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_HUD_SET_PARAM(
+		u16 net_proto_version, // Always
+		u16 param,
+		const std::string &value
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_BREATH(
+		u16 net_proto_version, // Always
+		u16 breath
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_SET_SKY(
+		u16 net_proto_version, // Always
+		const video::SColor &color,
+		const std::string &type,
+		const std::vector<std::string> &params
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
+
+	std::string s = os.str();
+	return SharedBuffer<u8>((u8*)s.c_str(), s.size());
+}
+
+SharedBuffer<u8> create_TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO(
+		u16 net_proto_version, // Always
+		bool do_override,
+		u16 day_night_ratio
+){
+	std::ostringstream os(std::ios_base::binary);
+
+	// TODO
 
 	std::string s = os.str();
 	return SharedBuffer<u8>((u8*)s.c_str(), s.size());

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -839,7 +839,7 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ADDNODE(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u8 block_format_version,
 			const v3s16 &p,
 			const MapNode &n,
@@ -847,23 +847,23 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_REMOVENODE(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const v3s16 &p
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_INVENTORY(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const Inventory* inventory
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_TIME_OF_DAY(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 time,
 			float time_speed
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_CHAT_MESSAGE(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			std::wstring message
 	);
 
@@ -873,41 +873,41 @@ namespace protocol
 		std::string init_data;
 	};
 	SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::set<u16> &removed_objects,
 			const std::vector<AddedObject> &added_objects
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_MESSAGES(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::vector<ActiveObjectMessage> &messages
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HP(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u8 hp
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_MOVE_PLAYER(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			v3f p,
 			float pitch,
 			float yaw
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ACCESS_DENIED(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			std::wstring reason
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_DEATHSCREEN(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			bool set_camera_point_target,
 			v3f camera_point_target
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_MEDIA(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 num_bunches,
 			u16 bunch_i,
 			const std::list<SendableMedia> &files,
@@ -915,22 +915,22 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_NODEDEF(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			INodeDefManager &ndef
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ANNOUNCE_MEDIA(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::list<SendableMediaAnnouncement> &announcements
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ITEMDEF(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			IItemDefManager &idef
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_PLAY_SOUND(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			s32 sound_id,
 			const std::string &sound_name,
 			float gain,
@@ -941,34 +941,34 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_STOP_SOUND(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			s32 sound_id
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_PRIVILEGES(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::set<std::string> privileges
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_INVENTORY_FORMSPEC(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::string &formspec
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_DETACHED_INVENTORY(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::string &name,
 			const Inventory *inventory
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_SHOW_FORMSPEC(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const std::string &formspec,
 			const std::string &formname
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_MOVEMENT(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			float movement_acceleration_default,
 			float movement_acceleration_air,
 			float movement_acceleration_fast,
@@ -984,7 +984,7 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_SPAWN_PARTICLE(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			v3f pos,
 			v3f velocity,
 			v3f acceleration,
@@ -996,7 +996,7 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ADD_PARTICLESPAWNER(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 amount,
 			float spawntime,
 			v3f minpos,
@@ -1016,12 +1016,12 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_DELETE_PARTICLESPAWNER(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u32 id
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HUDADD(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 command,
 			u32 id,
 			u8 type,
@@ -1037,43 +1037,43 @@ namespace protocol
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HUDRM(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u32 id
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HUDCHANGE(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u32 id,
 			u8 stat,
 			void *value
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HUD_SET_FLAGS(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u32 flags,
 			u32 mask
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_HUD_SET_PARAM(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 param,
 			const std::string &value
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_BREATH(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			u16 breath
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_SET_SKY(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			const video::SColor &color,
 			const std::string &type,
 			const std::vector<std::string> &params
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 			bool do_override,
 			u16 day_night_ratio
 	);
@@ -1081,7 +1081,7 @@ namespace protocol
 #if 0
 
 	SharedBuffer<u8> create_(
-			u16 net_proto_version,
+			u16 net_proto_version, // Always
 	);
 #endif
 }

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -332,7 +332,7 @@ enum ToClientCommand
 	/*
 		u16 command
 		u32 length of the next item
-		serialized NodeDefManager
+		zlib-compressed serialized NodeDefManager
 	*/
 	
 	TOCLIENT_CRAFTITEMDEF = 0x3b, // Obsolete
@@ -359,7 +359,7 @@ enum ToClientCommand
 	/*
 		u16 command
 		u32 length of next item
-		serialized ItemDefManager
+		zlib-compressed serialized ItemDefManager
 	*/
 	
 	TOCLIENT_PLAY_SOUND = 0x3f,

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -317,8 +317,6 @@ enum ToClientCommand
 			u32 length of data
 			data
 		}
-		u16 length of remote media server url (if applicable)
-		string url
 	*/
 	
 	TOCLIENT_TOOLDEF = 0x39, // Obsolete
@@ -353,6 +351,8 @@ enum ToClientCommand
 			u16 length of sha1_digest
 			string sha1_digest
 		}
+		u16 length of remote media server url (if applicable)
+		string url
 	*/
 
 	TOCLIENT_ITEMDEF = 0x3d,
@@ -913,8 +913,7 @@ namespace protocol
 			u16 net_proto_version, // Always
 			u16 num_bunches,
 			u16 bunch_i,
-			const std::list<SendableMedia> &files,
-			std::string remote_media_url
+			const std::list<SendableMedia> &files
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_NODEDEF(
@@ -924,7 +923,8 @@ namespace protocol
 
 	SharedBuffer<u8> create_TOCLIENT_ANNOUNCE_MEDIA(
 			u16 net_proto_version, // Always
-			const std::list<SendableMediaAnnouncement> &announcements
+			const std::list<SendableMediaAnnouncement> &announcements,
+			std::string remote_media_url
 	);
 
 	SharedBuffer<u8> create_TOCLIENT_ITEMDEF(

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -823,6 +823,9 @@ struct SendableMediaAnnouncement
 
 namespace protocol
 {
+	// NOTE: net_proto_version shall be set to 0 if packet is created in a bulk
+	// fashion instead of being directed towards a certain client
+
 	SharedBuffer<u8> create_TOCLIENT_INIT(
 			u16 net_proto_version, // Always
 			u8 deployed_block_version,

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -20,6 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef CLIENTSERVER_HEADER
 #define CLIENTSERVER_HEADER
 
+#include "util/pointer.h"
+#include "irrlichttypes_bloated.h"
+
 /*
 	changes by PROTOCOL_VERSION:
 
@@ -142,6 +145,12 @@ enum ToClientCommand
 	*/
 
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
+	/*
+		u16 command
+		v3s16 position
+		serialized block
+		serialized block network specific part
+	*/
 	TOCLIENT_ADDNODE = 0x21,
 	/*
 		u16 command
@@ -771,5 +780,30 @@ enum ToServerCommand
 	*/
 };
 
-#endif
+class MapBlock;
 
+namespace protocol
+{
+	SharedBuffer<u8> create_TOCLIENT_INIT(
+			u16 net_proto_version, // Always
+			u8 deployed_block_version,
+			const v3s16 &player_pos,
+			const u64 &map_seed,
+			const float recommended_send_interval
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_BLOCKDATA(
+			u16 net_proto_version, // Always
+			v3s16 position,
+			const MapBlock *block,
+			u8 block_format_version
+	);
+
+#if 0
+	SharedBuffer<u8> create_(
+			u16 net_proto_version,
+	);
+#endif
+}
+
+#endif

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -938,7 +938,7 @@ namespace protocol
 			const std::string &sound_name,
 			float gain,
 			u8 type,
-			v3f pos_nodes,
+			v3f pos,
 			u16 object_id,
 			bool loop
 	);

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -22,6 +22,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "util/pointer.h"
 #include "irrlichttypes_bloated.h"
+#include <set>
+#include <vector>
+#include <list>
+#include <string>
 
 /*
 	changes by PROTOCOL_VERSION:
@@ -159,6 +163,10 @@ enum ToClientCommand
 		u8 keep_metadata // Added in protocol version 22
 	*/
 	TOCLIENT_REMOVENODE = 0x22,
+	/*
+		u16 command
+		v3s16 position
+	*/
 	
 	TOCLIENT_PLAYERPOS = 0x23, // Obsolete
 	/*
@@ -313,7 +321,7 @@ enum ToClientCommand
 		string url
 	*/
 	
-	TOCLIENT_TOOLDEF = 0x39,
+	TOCLIENT_TOOLDEF = 0x39, // Obsolete
 	/*
 		u16 command
 		u32 length of the next item
@@ -327,7 +335,7 @@ enum ToClientCommand
 		serialized NodeDefManager
 	*/
 	
-	TOCLIENT_CRAFTITEMDEF = 0x3b,
+	TOCLIENT_CRAFTITEMDEF = 0x3b, // Obsolete
 	/*
 		u16 command
 		u32 length of the next item
@@ -781,6 +789,37 @@ enum ToServerCommand
 };
 
 class MapBlock;
+class MapNode;
+struct ActiveObjectMessage;
+class INodeDefManager;
+class IItemDefManager;
+class Inventory;
+
+struct SendableMedia
+{
+	std::string name;
+	std::string path;
+	std::string data;
+
+	SendableMedia(const std::string &name_="", const std::string &path_="",
+	              const std::string &data_=""):
+		name(name_),
+		path(path_),
+		data(data_)
+	{}
+};
+
+struct SendableMediaAnnouncement
+{
+	std::string name;
+	std::string sha1_digest;
+
+	SendableMediaAnnouncement(const std::string &name_="",
+	                          const std::string &sha1_digest_=""):
+		name(name_),
+		sha1_digest(sha1_digest_)
+	{}
+};
 
 namespace protocol
 {
@@ -794,12 +833,253 @@ namespace protocol
 
 	SharedBuffer<u8> create_TOCLIENT_BLOCKDATA(
 			u16 net_proto_version, // Always
+			u8 block_format_version,
 			v3s16 position,
-			const MapBlock *block,
-			u8 block_format_version
+			const MapBlock *block
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ADDNODE(
+			u16 net_proto_version,
+			u8 block_format_version,
+			const v3s16 &p,
+			const MapNode &n,
+			bool keep_metadata
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_REMOVENODE(
+			u16 net_proto_version,
+			const v3s16 &p
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_INVENTORY(
+			u16 net_proto_version,
+			const Inventory* inventory
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_TIME_OF_DAY(
+			u16 net_proto_version,
+			u16 time,
+			float time_speed
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_CHAT_MESSAGE(
+			u16 net_proto_version,
+			std::wstring message
+	);
+
+	struct AddedObject {
+		u16 id;
+		u8 type;
+		std::string init_data;
+	};
+	SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD(
+			u16 net_proto_version,
+			const std::set<u16> &removed_objects,
+			const std::vector<AddedObject> &added_objects
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ACTIVE_OBJECT_MESSAGES(
+			u16 net_proto_version,
+			const std::vector<ActiveObjectMessage> &messages
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HP(
+			u16 net_proto_version,
+			u8 hp
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_MOVE_PLAYER(
+			u16 net_proto_version,
+			v3f p,
+			float pitch,
+			float yaw
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ACCESS_DENIED(
+			u16 net_proto_version,
+			std::wstring reason
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_DEATHSCREEN(
+			u16 net_proto_version,
+			bool set_camera_point_target,
+			v3f camera_point_target
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_MEDIA(
+			u16 net_proto_version,
+			u16 num_bunches,
+			u16 bunch_i,
+			const std::list<SendableMedia> &files,
+			std::string remote_media_url
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_NODEDEF(
+			u16 net_proto_version,
+			INodeDefManager &ndef
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ANNOUNCE_MEDIA(
+			u16 net_proto_version,
+			const std::list<SendableMediaAnnouncement> &announcements
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ITEMDEF(
+			u16 net_proto_version,
+			IItemDefManager &idef
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_PLAY_SOUND(
+			u16 net_proto_version,
+			s32 sound_id,
+			const std::string &sound_name,
+			float gain,
+			u8 type,
+			v3f pos_nodes,
+			u16 object_id,
+			bool loop
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_STOP_SOUND(
+			u16 net_proto_version,
+			s32 sound_id
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_PRIVILEGES(
+			u16 net_proto_version,
+			const std::set<std::string> privileges
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_INVENTORY_FORMSPEC(
+			u16 net_proto_version,
+			const std::string &formspec
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_DETACHED_INVENTORY(
+			u16 net_proto_version,
+			const std::string &name,
+			const Inventory *inventory
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_SHOW_FORMSPEC(
+			u16 net_proto_version,
+			const std::string &formspec,
+			const std::string &formname
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_MOVEMENT(
+			u16 net_proto_version,
+			float movement_acceleration_default,
+			float movement_acceleration_air,
+			float movement_acceleration_fast,
+			float movement_speed_walk,
+			float movement_speed_crouch,
+			float movement_speed_fast,
+			float movement_speed_climb,
+			float movement_speed_jump,
+			float movement_liquid_fluidity,
+			float movement_liquid_fluidity_smooth,
+			float movement_liquid_sink,
+			float movement_gravity
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_SPAWN_PARTICLE(
+			u16 net_proto_version,
+			v3f pos,
+			v3f velocity,
+			v3f acceleration,
+			float expirationtime,
+			float size,
+			bool collision_detection,
+			bool vertical,
+			const std::string &texture
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_ADD_PARTICLESPAWNER(
+			u16 net_proto_version,
+			u16 amount,
+			float spawntime,
+			v3f minpos,
+			v3f maxpos,
+			v3f minvel,
+			v3f maxvel,
+			v3f minacc,
+			v3f maxacc,
+			float minexptime,
+			float maxexptime,
+			float minsize,
+			float maxsize,
+			bool collisiondetection,
+			bool vertical,
+			const std::string &texture,
+			u32 id
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_DELETE_PARTICLESPAWNER(
+			u16 net_proto_version,
+			u32 id
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HUDADD(
+			u16 net_proto_version,
+			u16 command,
+			u32 id,
+			u8 type,
+			v2f pos,
+			const std::string &name,
+			v2f scale,
+			const std::string &text,
+			u32 number,
+			u32 item,
+			u32 dir,
+			v2f align,
+			v2f offset
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HUDRM(
+			u16 net_proto_version,
+			u32 id
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HUDCHANGE(
+			u16 net_proto_version,
+			u32 id,
+			u8 stat,
+			void *value
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HUD_SET_FLAGS(
+			u16 net_proto_version,
+			u32 flags,
+			u32 mask
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_HUD_SET_PARAM(
+			u16 net_proto_version,
+			u16 param,
+			const std::string &value
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_BREATH(
+			u16 net_proto_version,
+			u16 breath
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_SET_SKY(
+			u16 net_proto_version,
+			const video::SColor &color,
+			const std::string &type,
+			const std::vector<std::string> &params
+	);
+
+	SharedBuffer<u8> create_TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO(
+			u16 net_proto_version,
+			bool do_override,
+			u16 day_night_ratio
 	);
 
 #if 0
+
 	SharedBuffer<u8> create_(
 			u16 net_proto_version,
 	);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -361,7 +361,7 @@ void MapBlock::copyFrom(VoxelManipulator &dst)
 			getPosRelative(), data_size);
 }
 
-void MapBlock::actuallyUpdateDayNightDiff()
+void MapBlock::actuallyUpdateDayNightDiff() const
 {
 	INodeDefManager *nodemgr = m_gamedef->ndef();
 	// Running this function un-expires m_day_night_differs
@@ -546,7 +546,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	}
 }
 
-void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
+void MapBlock::serialize(std::ostream &os, u8 version, bool disk) const
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
@@ -637,7 +637,7 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
 	}
 }
 
-void MapBlock::serializeNetworkSpecific(std::ostream &os, u16 net_proto_version)
+void MapBlock::serializeNetworkSpecific(std::ostream &os, u16 net_proto_version) const
 {
 	if(data == NULL)
 	{

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -360,14 +360,14 @@ public:
 		Sets m_day_night_differs to appropriate value.
 		These methods don't care about neighboring blocks.
 	*/
-	void actuallyUpdateDayNightDiff();
+	void actuallyUpdateDayNightDiff() const;
 	/*
 		Call this to schedule what the previous function does to be done
 		when the value is actually needed.
 	*/
 	void expireDayNightDiff();
 
-	bool getDayNightDiff()
+	bool getDayNightDiff() const
 	{
 		if(m_day_night_differs_expired)
 			actuallyUpdateDayNightDiff();
@@ -401,7 +401,7 @@ public:
 	{
 		m_timestamp = time;
 	}
-	u32 getTimestamp()
+	u32 getTimestamp() const
 	{
 		return m_timestamp;
 	}
@@ -468,12 +468,12 @@ public:
 	
 	// These don't write or read version by itself
 	// Set disk to true for on-disk format, false for over-the-network format
-	void serialize(std::ostream &os, u8 version, bool disk);
+	void serialize(std::ostream &os, u8 version, bool disk) const;
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);
 
-	void serializeNetworkSpecific(std::ostream &os, u16 net_proto_version);
+	void serializeNetworkSpecific(std::ostream &os, u16 net_proto_version) const;
 	void deSerializeNetworkSpecific(std::istream &is);
 
 private:
@@ -566,8 +566,8 @@ private:
 	bool m_lighting_expired;
 	
 	// Whether day and night lighting differs
-	bool m_day_night_differs;
-	bool m_day_night_differs_expired;
+	mutable bool m_day_night_differs;
+	mutable bool m_day_night_differs_expired;
 
 	bool m_generated;
 	

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -459,7 +459,7 @@ u32 MapNode::serializedLength(u8 version)
 	else
 		return 4;
 }
-void MapNode::serialize(u8 *dest, u8 version)
+void MapNode::serialize(u8 *dest, u8 version) const
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapNode format not supported");

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -239,7 +239,7 @@ struct MapNode
 	*/
 
 	static u32 serializedLength(u8 version);
-	void serialize(u8 *dest, u8 version);
+	void serialize(u8 *dest, u8 version) const;
 	void deSerialize(u8 *source, u8 version);
 	
 	// Serializes or deserializes a list of nodes in bulk format (first the

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3808,9 +3808,9 @@ void Server::SendBlocks(float dtime)
 
 		m_clients.send(q.peer_id, 2, protocol::create_TOCLIENT_BLOCKDATA(
 				client->net_proto_version,
+				client->serialization_version,
 				block->getPos(),
-				block,
-				client->serialization_version
+				block
 		), true);
 
 		client->SentBlock(q.pos);
@@ -3915,18 +3915,6 @@ void Server::fillMediaCache()
 	}
 }
 
-struct SendableMediaAnnouncement
-{
-	std::string name;
-	std::string sha1_digest;
-
-	SendableMediaAnnouncement(const std::string &name_="",
-	                          const std::string &sha1_digest_=""):
-		name(name_),
-		sha1_digest(sha1_digest_)
-	{}
-};
-
 void Server::sendMediaAnnouncement(u16 peer_id)
 {
 	DSTACK(__FUNCTION_NAME);
@@ -3975,20 +3963,6 @@ void Server::sendMediaAnnouncement(u16 peer_id)
 	// Send as reliable
 	m_clients.send(peer_id, 0, data, true);
 }
-
-struct SendableMedia
-{
-	std::string name;
-	std::string path;
-	std::string data;
-
-	SendableMedia(const std::string &name_="", const std::string &path_="",
-	              const std::string &data_=""):
-		name(name_),
-		path(path_),
-		data(data_)
-	{}
-};
 
 void Server::sendRequestedMedia(u16 peer_id,
 		const std::list<std::string> &tosend)

--- a/src/server.h
+++ b/src/server.h
@@ -343,10 +343,9 @@ private:
 	friend class EmergeThread;
 	friend class RemoteClient;
 
-	void SendMovement(u16 peer_id);
-	void SendHP(u16 peer_id, u8 hp);
-	void SendBreath(u16 peer_id, u16 breath);
-	void SendAccessDenied(u16 peer_id,const std::wstring &reason);
+	void SendMovement(u16 peer_id); // TODO: Remove
+	void SendBreath(u16 peer_id, u16 breath); // TODO: Remove
+	void SendAccessDenied(u16 peer_id,const std::wstring &reason); // TODO: Remove
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
 	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);

--- a/src/server.h
+++ b/src/server.h
@@ -343,9 +343,8 @@ private:
 	friend class EmergeThread;
 	friend class RemoteClient;
 
-	void SendMovement(u16 peer_id); // TODO: Remove
+	void SendMovement(u16 peer_id);
 	void SendBreath(u16 peer_id, u16 breath); // TODO: Remove
-	void SendAccessDenied(u16 peer_id,const std::wstring &reason); // TODO: Remove
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
 	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);

--- a/src/server.h
+++ b/src/server.h
@@ -386,9 +386,6 @@ private:
 			bool remove_metadata=true);
 	void setBlockNotSent(v3s16 p);
 
-	// Environment and Connection must be locked when called
-	void SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto_version);
-
 	// Sends blocks to clients (locks env and con on its own)
 	void SendBlocks(float dtime);
 

--- a/src/staticobject.cpp
+++ b/src/staticobject.cpp
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "staticobject.h"
 #include "util/serialize.h"
 
-void StaticObject::serialize(std::ostream &os)
+void StaticObject::serialize(std::ostream &os) const
 {
 	char buf[12];
 	// type
@@ -48,7 +48,7 @@ void StaticObject::deSerialize(std::istream &is, u8 version)
 	data = deSerializeString(is);
 }
 
-void StaticObjectList::serialize(std::ostream &os)
+void StaticObjectList::serialize(std::ostream &os) const
 {
 	char buf[12];
 	// version
@@ -58,18 +58,18 @@ void StaticObjectList::serialize(std::ostream &os)
 	u16 count = m_stored.size() + m_active.size();
 	writeU16((u8*)buf, count);
 	os.write(buf, 2);
-	for(std::list<StaticObject>::iterator
+	for(std::list<StaticObject>::const_iterator
 			i = m_stored.begin();
 			i != m_stored.end(); ++i)
 	{
-		StaticObject &s_obj = *i;
+		const StaticObject &s_obj = *i;
 		s_obj.serialize(os);
 	}
-	for(std::map<u16, StaticObject>::iterator
+	for(std::map<u16, StaticObject>::const_iterator
 			i = m_active.begin();
 			i != m_active.end(); ++i)
 	{
-		StaticObject s_obj = i->second;
+		const StaticObject s_obj = i->second;
 		s_obj.serialize(os);
 	}
 }

--- a/src/staticobject.h
+++ b/src/staticobject.h
@@ -45,7 +45,7 @@ struct StaticObject
 	{
 	}
 
-	void serialize(std::ostream &os);
+	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is, u8 version);
 };
 
@@ -87,7 +87,7 @@ public:
 		m_active.erase(id);
 	}
 
-	void serialize(std::ostream &os);
+	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
 	
 	/*

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -242,6 +242,19 @@ inline u16 readU16(std::istream &is)
 	return readU16((u8*)buf);
 }
 
+inline void writeU64(std::ostream &os, u64 p)
+{
+	char buf[8] = {0};
+	writeU64((u8*)buf, p);
+	os.write(buf, 8);
+}
+inline u64 readU64(std::istream &is)
+{
+	char buf[8] = {0};
+	is.read(buf, 8);
+	return readU64((u8*)buf);
+}
+
 inline void writeU32(std::ostream &os, u32 p)
 {
 	char buf[4] = {0};


### PR DESCRIPTION
Move packet creation to a central location for easier review, documentation and compatibility handling.

It is a common problem that badly designed packet formats (e.g. wrong serialization types or bad version handling) is merged to upstream because nobody spots the problems when they are in random locations around the commits. This fixes it, by making most protocol changes clearly identitifiable and reviewable. It also removes the need for redudant trivial documentation because the simple code already serves the purpose.

This changeset is currently incomplete and shouldn't be merged until it is finished. Many packet creations still have to be moved to the new location in clientserver.cpp.