### PR TITLE
Add proper Lua API deprecated handling

### DIFF
--- a/builtin/misc.lua
+++ b/builtin/misc.lua
@@ -85,6 +85,7 @@ function minetest.get_item_group(name, group)
 end
 
 function minetest.get_node_group(name, group)
+	minetest.log("deprecated", "Deprecated usage of get_node_group, use get_item_group instead")
 	return minetest.get_item_group(name, group)
 end
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -285,6 +285,11 @@
 #disable_anticheat = false
 # If true, actions are recorded for rollback
 #enable_rollback_recording = false
+# handling for deprecated lua api calls
+#    "legacy" = (try to) mimic old behaviour (default for release)
+#    "log"    = mimic and log backtrace of deprecated call (default for debug)
+#    "error"  = abort on usage of deprecated call (suggested for mod developers)
+#deprecated_lua_api_handling = legacy
 
 # Profiler data print interval. #0 = disable.
 #profiler_print_interval = 0

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -201,6 +201,11 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("disallow_empty_password", "false");
 	settings->setDefault("disable_anticheat", "false");
 	settings->setDefault("enable_rollback_recording", "false");
+#ifdef NDEBUG
+	settings->setDefault("deprecated_lua_api_handling", "legacy");
+#else
+	settings->setDefault("deprecated_lua_api_handling", "log");
+#endif
 
 	settings->setDefault("profiler_print_interval", "0");
 	settings->setDefault("enable_mapgen_debug_info", "false");

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -45,6 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "gettime.h"
 #include "gettext.h"
+#include "scripting_game.h"
 
 #define MY_CHECKPOS(a,b)													\
 	if (v_pos.size() != 2) {												\
@@ -1478,7 +1479,13 @@ void GUIFormSpecMenu::parseElement(parserData* data,std::string element)
 	std::string type = trim(parts[0]);
 	std::string description = trim(parts[1]);
 
-	if ((type == "size") || (type == "invsize")){
+	if (type == "size") {
+		parseSize(data,description);
+		return;
+	}
+
+	if (type == "invsize") {
+		log_deprecated("Deprecated formspec element \"invsize\" is used");
 		parseSize(data,description);
 		return;
 	}

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -68,7 +68,7 @@ std::string script_get_backtrace(lua_State *L);
 int script_error_handler(lua_State *L);
 int script_exception_wrapper(lua_State *L, lua_CFunction f);
 void script_error(lua_State *L);
-void script_run_callbacks(lua_State *L, int nargs,
-		RunCallbacksMode mode);
+void script_run_callbacks(lua_State *L, int nargs, RunCallbacksMode mode);
+void log_deprecated(lua_State *L, std::string message);
 
 #endif /* C_INTERNAL_H_ */

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -659,6 +659,7 @@ int ObjectRef::l_get_entity_name(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	LuaEntitySAO *co = getluaobject(ref);
+	log_deprecated(L,"Deprecated call to \"get_entity_name");
 	if(co == NULL) return 0;
 	// Do it
 	std::string name = co->getName();

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -44,6 +44,7 @@ int ModApiParticles::l_add_particle(lua_State *L)
 
 	if (lua_gettop(L) > 1) // deprecated
 	{
+		log_deprecated(L,"Deprecated add_particle call with individual parameters instead of definition");
 		pos = check_v3f(L, 1);
 		vel = check_v3f(L, 2);
 		acc = check_v3f(L, 3);
@@ -128,6 +129,7 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 
 	if (lua_gettop(L) > 1) //deprecated
 	{
+		log_deprecated(L,"Deprecated add_particlespawner call with individual parameters instead of definition");
 		amount = luaL_checknumber(L, 1);
 		time = luaL_checknumber(L, 2);
 		minpos = check_v3f(L, 3);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -78,6 +78,11 @@ int ModApiUtil::l_log(lua_State *L)
 			level = LMT_ACTION;
 		else if(levelname == "verbose")
 			level = LMT_VERBOSE;
+		else if (levelname == "deprecated") {
+			log_deprecated(L,text);
+			return 0;
+		}
+
 	}
 	log_printline(level, text);
 	return 0;

--- a/src/script/scripting_game.cpp
+++ b/src/script/scripting_game.cpp
@@ -98,3 +98,8 @@ void GameScripting::InitializeModApi(lua_State *L, int top)
 	ObjectRef::Register(L);
 	LuaSettings::Register(L);
 }
+
+void log_deprecated(std::string message)
+{
+	log_deprecated(NULL,message);
+}

--- a/src/script/scripting_game.h
+++ b/src/script/scripting_game.h
@@ -50,4 +50,6 @@ private:
 	void InitializeModApi(lua_State *L, int top);
 };
 
+void log_deprecated(std::string message);
+
 #endif /* SCRIPTING_GAME_H_ */


### PR DESCRIPTION
As various discussions about broken lua api revealed we've got need for proper handling of old and sometimes broken lua api calls.

In order to get rid about them we need a way to give mod authors chance to replace them prior removal.
This patch adds (configurable) logging of deprecated functions mod authors are suggested to set
 "deprecated_lua_api_handling" to error in order to replace those calls as soon as possible.

Server owners running >>>release build<<< don't need to do anything as legacy handling is done there.

Everyone running >>>debug build<<< will see log messages about deprecated functions, unless having manually set "deprecated_lua_api_handling" to "legacy"
