### PR TITLE
Make directional fog colors respect tonemap

### DIFF
--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -593,14 +593,31 @@ void Sky::update(float time_of_day, float time_brightness,
 			// invert direction to match where the sun and moon are rising
 			if (m_time_of_day > 0.5)
 				pointcolor_blend = 1 - pointcolor_blend;
-
 			// horizon colors of sun and moon
 			f32 pointcolor_light = rangelim(m_time_brightness * 3, 0.2, 1);
+
 			video::SColorf pointcolor_sun_f(1, 1, 1, 1);
-			pointcolor_sun_f.r = pointcolor_light * 1;
-			pointcolor_sun_f.b = pointcolor_light * (0.25 + (rangelim(m_time_brightness, 0.25, 0.75) - 0.25) * 2 * 0.75);
-			pointcolor_sun_f.g = pointcolor_light * (pointcolor_sun_f.b * 0.375 + (rangelim(m_time_brightness, 0.05, 0.15) - 0.05) * 10 * 0.625);
+			if (m_sun_tonemap)
+			{
+				pointcolor_sun_f.r = pointcolor_light * (float)m_materials[3].EmissiveColor.getRed() / 255;
+				pointcolor_sun_f.b = pointcolor_light * (float)m_materials[3].EmissiveColor.getBlue() / 255;
+				pointcolor_sun_f.g = pointcolor_light * (float)m_materials[3].EmissiveColor.getGreen() / 255;
+			}
+			else
+			{
+				pointcolor_sun_f.r = pointcolor_light * 1;
+				pointcolor_sun_f.b = pointcolor_light * (0.25 + (rangelim(m_time_brightness, 0.25, 0.75) - 0.25) * 2 * 0.75);
+				pointcolor_sun_f.g = pointcolor_light * (pointcolor_sun_f.b * 0.375 + (rangelim(m_time_brightness, 0.05, 0.15) - 0.05) * 10 * 0.625);
+			}
+
 			video::SColorf pointcolor_moon_f(0.5 * pointcolor_light, 0.6 * pointcolor_light, 0.8 * pointcolor_light, 1);
+			if (m_moon_tonemap)
+			{
+				pointcolor_moon_f.r = pointcolor_light * (float)m_materials[4].EmissiveColor.getRed() / 255;
+				pointcolor_moon_f.b = pointcolor_light * (float)m_materials[4].EmissiveColor.getBlue() / 255;
+				pointcolor_moon_f.g = pointcolor_light * (float)m_materials[4].EmissiveColor.getGreen() / 255;
+			}
+
 			video::SColor pointcolor_sun = pointcolor_sun_f.toSColor();
 			video::SColor pointcolor_moon = pointcolor_moon_f.toSColor();
 			// calculate the blend color


### PR DESCRIPTION
Adapts directional sky colors to use tonemap sun & moon. Behavior remains unchanged when no tonemap is present.

http://i59.tinypic.com/2mn22hs.png
http://i59.tinypic.com/262wtwn.png
