### PR TITLE
Add item eat callback

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -353,6 +353,12 @@ end
 
 function core.item_eat(hp_change, replace_with_item)
 	return function(itemstack, user, pointed_thing)  -- closure
+		for _, callback in pairs(core.registered_on_item_eats) do
+			local result = callback(hp_change, replace_with_item, itemstack, user, pointed_thing)
+			if result then
+				return result
+			end
+		end
 		if itemstack:take_item() ~= nil then
 			user:set_hp(user:get_hp() + hp_change)
 			itemstack:add_item(replace_with_item) -- note: replace_with_item is optional

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -8,7 +8,7 @@ local register_item_raw = core.register_item_raw
 core.register_item_raw = nil
 
 local register_alias_raw = core.register_alias_raw
-core.register_item_raw = nil
+core.register_alias_raw = nil
 
 --
 -- Item / entity / ABM registration functions
@@ -407,4 +407,5 @@ core.registered_on_cheats, core.register_on_cheat = make_registration()
 core.registered_on_crafts, core.register_on_craft = make_registration()
 core.registered_craft_predicts, core.register_craft_predict = make_registration()
 core.registered_on_protection_violation, core.register_on_protection_violation = make_registration()
+core.registered_on_item_eats, core.register_on_item_eat = make_registration()
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1313,6 +1313,9 @@ minetest.register_on_protection_violation(func(pos, name))
 ^ The provided function should check that the position is protected by the mod
   calling this function before it prints a message, if it does, to allow for
   multiple protection mods.
+minetest.register_on_item_eat(func(hp_change, replace_with_item, itemstack, user, pointed_thing))
+^ Called when an item is eaten, by minetest.item_eat
+^ Return true or itemstack to cancel the default item eat response (ie: hp increase)
 
 Other registration functions:
 minetest.register_chatcommand(cmd, chatcommand definition)


### PR DESCRIPTION
This pull request, as requested in <a href="https://forum.minetest.net/viewtopic.php?f=3&t=9179">this thread</a>, adds a callback to builtin item eat function.

**Current Problem**
Currently, modders need to override the nodedef.on_use function in the food they want to support, which requires a list of foods and their values.

**Solution**
With this pull request, modders can just add a callback to minetest.item_eat and then override the default eat behaviour. They do not need a list of foods and their values.

**The API**
The call back is registered using minetest.register_on_item_eat, and will look like the following.

```
minetest.register_on_item_eat(
    function(hp_change, replace_with_item, itemstack, user, pointed_thing)
        if itemstack:take_item() ~= nil then
            hunger.changeHunger(hp_change)
        end
        return itemstack
    end
)
```

**Why is this useful? Why can't they just add it to on_use?**
This is not useful if you create the food in your own mod. However, it is useful if you want to override how food is handled in other mods. For example, adding hunger, diets and immersive sound. It means you don't need to have a list of foods and their values.

Old pull: #1255
