### PR TITLE
fixes in src/gettext.cpp

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -200,6 +200,7 @@ void init_gettext(const char *path,std::string configured_language) {
 			else {
 				exit(0);
 			}
+		}
 #else
 			errorstream << "*******************************************************" << std::endl;
 			errorstream << "Can't apply locale workaround for server!" << std::endl;
@@ -207,7 +208,6 @@ void init_gettext(const char *path,std::string configured_language) {
 			errorstream << "*******************************************************" << std::endl;
 
 #endif
-		}
 
 		setlocale(LC_ALL,configured_language.c_str());
 #else // Mingw


### PR DESCRIPTION
Hello minetest programmers,
I found a typo in file src/gettext.cpp while compiling on Windows XP with VS 2010 sp0.
Could you please accept my fix?
Thank you
EDIT: I also found "wild" bracket in wrong preprocessor block.
