### PR TITLE
Replace HP/breath by generic stat mechanism

### DIFF
--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -8,6 +8,7 @@ local health_bar_definition =
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = { x=(-10*24)-25, y=-(48+24+10)},
+	name = "health"
 }
 
 local breath_bar_definition =
@@ -19,6 +20,7 @@ local breath_bar_definition =
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = {x=25,y=-(48+24+10)},
+	name = "breath"
 }
 
 local hud_ids = {}
@@ -45,7 +47,6 @@ local function initialize_builtin_statbars(player)
 	if player:hud_get_flags().healthbar and
 			core.is_yes(core.setting_get("enable_damage")) then
 		if hud_ids[name].id_healthbar == nil then
-			health_bar_definition.number = player:get_hp()
 			hud_ids[name].id_healthbar  = player:hud_add(health_bar_definition)
 		end
 	else
@@ -55,7 +56,7 @@ local function initialize_builtin_statbars(player)
 		end
 	end
 
-	if (player:get_breath() < 11) then
+	if (player:get_stat("breath") < 11) then
 		if player:hud_get_flags().breathbar and
 			core.is_yes(core.setting_get("enable_damage")) then
 			if hud_ids[name].id_breathbar == nil then
@@ -97,64 +98,8 @@ local function player_event_handler(player,eventname)
 		return
 	end
 
-	if eventname == "health_changed" then
-		initialize_builtin_statbars(player)
-
-		if hud_ids[name].id_healthbar ~= nil then
-			player:hud_change(hud_ids[name].id_healthbar,"number",player:get_hp())
-			return true
-		end
-	end
-
 	if eventname == "breath_changed" then
 		initialize_builtin_statbars(player)
-
-		if hud_ids[name].id_breathbar ~= nil then
-			player:hud_change(hud_ids[name].id_breathbar,"number",player:get_breath()*2)
-			return true
-		end
-	end
-
-	if eventname == "hud_changed" then
-		initialize_builtin_statbars(player)
-		return true
-	end
-
-	return false
-end
-
-function core.hud_replace_builtin(name, definition)
-
-	if definition == nil or
-		type(definition) ~= "table" or
-		definition.hud_elem_type ~= "statbar" then
-		return false
-	end
-
-	if name == "health" then
-		health_bar_definition = definition
-
-		for name,ids in pairs(hud_ids) do
-			local player = core.get_player_by_name(name)
-			if  player and hud_ids[name].id_healthbar then
-				player:hud_remove(hud_ids[name].id_healthbar)
-				initialize_builtin_statbars(player)
-			end
-		end
-		return true
-	end
-
-	if name == "breath" then
-		breath_bar_definition = definition
-
-		for name,ids in pairs(hud_ids) do
-			local player = core.get_player_by_name(name)
-			if  player and hud_ids[name].id_breathbar then
-				player:hud_remove(hud_ids[name].id_breathbar)
-				initialize_builtin_statbars(player)
-			end
-		end
-		return true
 	end
 
 	return false

--- a/src/client.h
+++ b/src/client.h
@@ -396,7 +396,6 @@ public:
 	void setCrack(int level, v3s16 pos);
 
 	u16 getHP();
-	u16 getBreath();
 
 	bool checkPrivilege(const std::string &priv)
 	{ return (m_privileges.count(priv) != 0); }

--- a/src/clientserver.h
+++ b/src/clientserver.h
@@ -549,6 +549,22 @@ enum ToClientCommand
 		v3f1000 first
 		v3f1000 third
 	*/
+	TOCLIENT_ADD_STAT = 0x53,
+	/*
+	 * u16 command
+	 * u8 len
+	 * u8[len] statname
+	 * s16 value
+	 * s16 min
+	 * s16 max
+	 */
+	TOCLIENT_UPDATE_STAT = 0x54
+	/*
+	 * u16 command
+	 * u8 len
+	 * u8[len] statname
+	 * s16 value
+	 */
 };
 
 enum ToServerCommand

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -191,17 +191,30 @@ public:
 		ServerActiveObject *puncher,
 		float time_from_last_punch);
 	void rightClick(ServerActiveObject *clicker);
-	s16 getHP() const;
-	void setHP(s16 hp);
 	s16 readDamage();
-	u16 getBreath() const;
-	void setBreath(u16 breath);
 	void setArmorGroups(const ItemGroupList &armor_groups);
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend);
 	void setBonePosition(std::string bone, v3f position, v3f rotation);
 	void setAttachment(int parent_id, std::string bone, v3f position, v3f rotation);
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
+
+	/*
+	 * Stat handling
+	 */
+	bool getStat(std::string name, s16& retval);
+	s16 getStat(std::string name)
+	{
+		s16 retval = 0xFFFF;
+		bool successfull = getStat(name, retval);
+		assert(successfull);
+		return retval;
+	}
+	void setStat(std::string name, s16 value);
+
+	bool isStatSent(std::string name);
+	void setStatSent(std::string name);
+	std::vector<std::string> getStatNames();
 
 	/*
 		Inventory interface
@@ -323,8 +336,6 @@ public:
 	// Some flags used by Server
 	bool m_moved;
 	bool m_inventory_not_sent;
-	bool m_hp_not_sent;
-	bool m_breath_not_sent;
 	bool m_wielded_item_not_sent;
 
 	float m_physics_override_speed;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1379,7 +1379,7 @@ bool ServerEnvironment::addActiveObjectAsStatic(ServerActiveObject *obj)
 {
 	assert(obj);
 
-	v3f objectpos = obj->getBasePosition();	
+	v3f objectpos = obj->getBasePosition();
 
 	// The block in which the object resides in
 	v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
@@ -1591,7 +1591,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 			object->m_static_block = blockpos;
 
 			if(set_changed)
-				block->raiseModified(MOD_STATE_WRITE_NEEDED, 
+				block->raiseModified(MOD_STATE_WRITE_NEEDED,
 						"addActiveObjectRaw");
 		} else {
 			v3s16 p = floatToInt(objectpos, BS);
@@ -1828,7 +1828,7 @@ void ServerEnvironment::activateObjects(MapBlock *block, u32 dtime_s)
 	If force_delete is set, active object is deleted nevertheless. It
 	shall only be set so in the destructor of the environment.
 
-	If block wasn't generated (not in memory or on disk), 
+	If block wasn't generated (not in memory or on disk),
 */
 void ServerEnvironment::deactivateFarObjects(bool force_delete)
 {
@@ -1849,7 +1849,7 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 			continue;
 
 		u16 id = i->first;
-		v3f objectpos = obj->getBasePosition();	
+		v3f objectpos = obj->getBasePosition();
 
 		// The block in which the object resides in
 		v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
@@ -2342,19 +2342,19 @@ void ClientEnvironment::step(float dtime)
 		MapNode n = m_map->getNodeNoEx(p);
 		ContentFeatures c = m_gamedef->ndef()->get(n);
 		u8 drowning_damage = c.drowning;
-		if(drowning_damage > 0 && lplayer->hp > 0){
-			u16 breath = lplayer->getBreath();
+		if(drowning_damage > 0 && lplayer->getStat(BUILTIN_HEALTH) > 0){
+			u16 breath = lplayer->getStat(BUILTIN_BREATH);
 			if(breath > 10){
 				breath = 11;
 			}
 			if(breath > 0){
 				breath -= 1;
 			}
-			lplayer->setBreath(breath);
+			lplayer->setStat(BUILTIN_BREATH, breath);
 			updateLocalPlayerBreath(breath);
 		}
 
-		if(lplayer->getBreath() == 0 && drowning_damage > 0){
+		if(lplayer->getStat(BUILTIN_BREATH) == 0 && drowning_damage > 0){
 			damageLocalPlayer(drowning_damage, true);
 		}
 	}
@@ -2366,14 +2366,14 @@ void ClientEnvironment::step(float dtime)
 		v3s16 p = floatToInt(pf + v3f(0, BS*1.6, 0), BS);
 		MapNode n = m_map->getNodeNoEx(p);
 		ContentFeatures c = m_gamedef->ndef()->get(n);
-		if (!lplayer->hp){
-			lplayer->setBreath(11);
+		if (!lplayer->getStat(BUILTIN_HEALTH)){
+			lplayer->setStat(BUILTIN_BREATH, 11);
 		}
 		else if(c.drowning == 0){
-			u16 breath = lplayer->getBreath();
+			u16 breath = lplayer->getStat(BUILTIN_BREATH);
 			if(breath <= 10){
 				breath += 1;
-				lplayer->setBreath(breath);
+				lplayer->setStat(BUILTIN_BREATH, breath);
 				updateLocalPlayerBreath(breath);
 			}
 		}
@@ -2625,10 +2625,8 @@ void ClientEnvironment::damageLocalPlayer(u8 damage, bool handle_hp)
 	assert(lplayer);
 	
 	if(handle_hp){
-		if(lplayer->hp > damage)
-			lplayer->hp -= damage;
-		else
-			lplayer->hp = 0;
+		lplayer->setStat(BUILTIN_HEALTH,
+				lplayer->getStat(BUILTIN_HEALTH) - damage);
 	}
 
 	ClientEnvEvent event;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -270,7 +270,13 @@ void Hud::drawLuaElements(v3s16 camera_offset) {
 				break; }
 			case HUD_ELEM_STATBAR: {
 				v2s32 offs(e->offset.X, e->offset.Y);
-				drawStatbar(pos, HUD_CORNER_UPPER, e->dir, e->text, e->number, offs, e->size);
+				s16 count = e->number;
+
+				if (e->name != "")
+				{
+					player->getStat(e->name, count);
+				}
+				drawStatbar(pos, HUD_CORNER_UPPER, e->dir, e->text, count, offs, e->size);
 				break; }
 			case HUD_ELEM_INVENTORY: {
 				InventoryList *inv = inventory->getList(e->text);
@@ -414,23 +420,6 @@ void Hud::drawHotbar(u16 playeritem) {
 			drawItems(secondpos, hotbar_itemcount, hotbar_itemcount/2, mainlist, playeritem + 1, 0);
 		}
 	}
-
-	//////////////////////////// compatibility code to be removed //////////////
-	// this is ugly as hell but there's no other way to keep compatibility to
-	// old servers
-	if ( player->hud_flags & HUD_FLAG_HEALTHBAR_VISIBLE)
-		drawStatbar(v2s32(floor(0.5 * (float) m_screensize.X + 0.5),
-				floor(1 * (float) m_screensize.Y + 0.5)),
-				HUD_CORNER_UPPER, 0, "heart.png",
-				player->hp, v2s32((-10*24)-25,-(48+24+10)), v2s32(24,24));
-
-	if ((player->hud_flags & HUD_FLAG_BREATHBAR_VISIBLE) &&
-			(player->getBreath() < 11))
-		drawStatbar(v2s32(floor(0.5 * (float) m_screensize.X + 0.5),
-				floor(1 * (float) m_screensize.Y + 0.5)),
-				HUD_CORNER_UPPER, 0, "heart.png",
-				player->getBreath(), v2s32(25,-(48+24+10)), v2s32(24,24));
-	////////////////////////////////////////////////////////////////////////////
 }
 
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -55,11 +55,7 @@ LocalPlayer::LocalPlayer(IGameDef *gamedef):
 	m_need_to_get_new_sneak_node(true),
 	m_can_jump(false),
 	m_cao(NULL)
-{
-	// Initialize hp to 0, so that no hearts will be shown if server
-	// doesn't support health points
-	hp = 0;
-}
+{}
 
 LocalPlayer::~LocalPlayer()
 {

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -180,11 +180,14 @@ private:
 	// set_look_yaw(self, radians)
 	static int l_set_look_yaw(lua_State *L);
 
-	// set_breath(self, breath)
-	static int l_set_breath(lua_State *L);
+	// set_stat(self, name, value)
+	static int l_set_stat(lua_State *L);
 
-	// get_breath(self, breath)
-	static int l_get_breath(lua_State *L);
+	// set_stat(self, name, value, min, max)
+	static int l_create_stat(lua_State *L);
+
+	// get_stat(self, name)
+	static int l_get_stat(lua_State *L);
 
 	// set_inventory_formspec(self, formspec)
 	static int l_set_inventory_formspec(lua_State *L);

--- a/src/server.h
+++ b/src/server.h
@@ -55,6 +55,7 @@ class GameScripting;
 class ServerEnvironment;
 struct SimpleSoundSpec;
 class ServerThread;
+struct player_stat;
 
 enum ClientDeletionReason {
 	CDR_LEAVE,
@@ -347,8 +348,8 @@ private:
 	friend class RemoteClient;
 
 	void SendMovement(u16 peer_id);
-	void SendHP(u16 peer_id, u8 hp);
-	void SendBreath(u16 peer_id, u16 breath);
+	void SendStatUpdate(u16 peer_id, std::string name, s16 value);
+	void SendStatAdd(u16 peer_id, std::string name, std::string ser_stats);
 	void SendAccessDenied(u16 peer_id,const std::wstring &reason);
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
@@ -361,8 +362,6 @@ private:
 	void SendInventory(u16 peer_id);
 	void SendChatMessage(u16 peer_id, const std::wstring &message);
 	void SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(u16 peer_id);
-	void SendPlayerBreath(u16 peer_id);
 	void SendMovePlayer(u16 peer_id);
 	void SendLocalPlayerAnimations(u16 peer_id, v2s32 animation_frames[4], f32 animation_speed);
 	void SendEyeOffset(u16 peer_id, v3f first, v3f third);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -145,10 +145,18 @@ public:
 	{ return 0; }
 	virtual void rightClick(ServerActiveObject *clicker)
 	{}
-	virtual void setHP(s16 hp)
-	{}
-	virtual s16 getHP() const
-	{ return 0; }
+
+	virtual bool getStat(std::string name, s16& result)
+		{ return false; }
+
+	/** throws exception of stat doesn't exist */
+	virtual s16 getStat(std::string name)
+		{ return 0; }
+
+	virtual void setStat(std::string name, s16 value)
+		{ return; }
+	virtual bool createStat(std::string name, s16 initial, s16 min, s16 max)
+		{ return false; }
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}


### PR DESCRIPTION
This is not compatible to current servers and requires a min protocol bump.

Main benefits:
 -playerside stats (saved along with player not separate)
 -new lua hud statbar type bound to player stat
 -slightly reduced network overhead (now equals same as old c++ statbars)
 
Midterm benefits:
 -adding of new stats isn't core issue any longer
 -clients may read information about other items too

Longterm benefits:
 -stat values could be evaluated by client side lua code too

Open issues:
 -compatibility
 -strange behaviour on death (almost always within own bones)
 -add support for lua entity stats too