### PR TITLE
Add strict module

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -1,0 +1,47 @@
+
+-- Always warn when creating a global variable, even outside of a function.
+-- This ignores mod namespaces (variables with the same name as the current mod).
+local WARN_INIT = true
+
+
+local function warn(message)
+	print(os.date("%H:%M:%S: WARNING: ")..message)
+end
+
+
+local meta = {}
+local declared = {}
+
+
+function meta:__newindex(name, value)
+	local info = debug.getinfo(2, "Sl")
+	local desc = ("%s:%d"):format(info.short_src, info.currentline)
+	if not declared[name] then
+		if info.what ~= "main" and info.what ~= "C" then
+			warn(("Assignment to undeclared global %q inside"
+					.." a function at %s.")
+				:format(name, desc))
+		end
+		declared[name] = true
+	end
+	-- Ignore mod namespaces
+	if WARN_INIT and (not core.get_current_modname or
+			name ~= core.get_current_modname()) then
+		warn(("Global variable %q created at %s.")
+			:format(name, desc))
+	end
+	rawset(self, name, value)
+end
+
+
+function meta:__index(name)
+	local info = debug.getinfo(2, "Sl")
+	if not declared[name] and info.what ~= "C" then
+		warn(("Undeclared global variable %q accessed at %s:%s")
+				:format(name, info.short_src, info.currentline))
+	end
+	return rawget(self, name)
+end
+
+setmetatable(_G, meta)
+

--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -7,7 +7,7 @@
 function core.string_to_privs(str, delim)
 	assert(type(str) == "string")
 	delim = delim or ','
-	privs = {}
+	local privs = {}
 	for _, priv in pairs(string.split(str, delim)) do
 		privs[priv:trim()] = true
 	end
@@ -17,7 +17,7 @@ end
 function core.privs_to_string(privs, delim)
 	assert(type(privs) == "table")
 	delim = delim or ','
-	list = {}
+	local list = {}
 	for priv, bool in pairs(privs) do
 		if bool then
 			table.insert(list, priv)

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -56,7 +56,7 @@ core.register_entity(":__builtin:item", {
 			item_texture = core.registered_items[itemname].inventory_image
 			item_type = core.registered_items[itemname].type
 		end
-		prop = {
+		local prop = {
 			is_visible = true,
 			visual = "wielditem",
 			textures = {itemname},

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -17,6 +17,7 @@ local gamepath = scriptdir.."game"..DIR_DELIM
 local commonpath = scriptdir.."common"..DIR_DELIM
 local asyncpath = scriptdir.."async"..DIR_DELIM
 
+dofile(commonpath.."strict.lua")
 dofile(commonpath.."serialize.lua")
 dofile(commonpath.."misc_helpers.lua")
 


### PR DESCRIPTION
Also fixes leaking globals found by it.

This module helps prevent bugs of the form:

``` Lua
function foo()
    print(bar)  -- Global variable "bar" does not exist!
    bar = true  -- Assignment to a global variable from inside a function!
    -- Assign "bar" to something (even nil) from the main file scope to
    -- avoid these errors (if you really need to use global variables).
end
```

The downside is that it slows down access of global variables a bit, but speed-critical functions use locals anyway.

This can also, optionally, warn on the creation of any globals.  Mod namespaces (variables with the same name as the current mod name) are always ignored.
