### PR TITLE
Add mainmenu settings for video_driver and fullscreen

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -259,10 +259,6 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		gamedata.errormessage = fgettext("Minetest needs to be restarted to take this change in effect.")
 		return true
 	end
-	if fields["btn_screen"] then
-		gamedata.errormessage = core.get_screen_info()
-		return true
-	end
 	if fields["cb_fullscreen"] then
 		local screen = core.get_screen_info()
 		if not screen.display_width or not screen.display_height then


### PR DESCRIPTION
The settings tab of the main menu lacks two important settings: video_driver (Important for those who want to use shaders, but get an error message when direct3d9 is used) and fullscreen (which uses core.get_screen_info()). video_driver only supports direct3d9 and opengl, but this should be suficient for most users and for me, those are the only working ones ;)

I added them to the menu, but both of them need the user to restart Minetest to take the changes in effect.
