### PR TITLE
Add configurable key bindings for selecting next/previous hotbar item and changing the volume

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -48,8 +48,11 @@
 #keymap_rangeselect = KEY_KEY_R
 #keymap_freemove = KEY_KEY_K
 #keymap_fastmove = KEY_KEY_J
-#keymap_hotbar_next = KEY_KEY_M
-#keymap_hotbar_previous = KEY_KEY_N
+#keymap_hotbar_next = KEY_KEY_N
+#keymap_hotbar_previous = KEY_KEY_B
+#keymap_mute = KEY_KEY_M
+#keymap_increase_volume = KEY_PERIOD
+#keymap_decrease_volume = KEY_COMMA
 #keymap_screenshot = KEY_F12
 # If true, keymap_special1 instead of keymap_sneak is used for climbing down and descending
 #aux1_descends = false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -48,6 +48,8 @@
 #keymap_rangeselect = KEY_KEY_R
 #keymap_freemove = KEY_KEY_K
 #keymap_fastmove = KEY_KEY_J
+#keymap_hotbar_next = KEY_KEY_M
+#keymap_hotbar_previous = KEY_KEY_N
 #keymap_screenshot = KEY_F12
 # If true, keymap_special1 instead of keymap_sneak is used for climbing down and descending
 #aux1_descends = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -48,6 +48,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");
 	settings->setDefault("keymap_noclip", "KEY_KEY_H");
+	settings->setDefault("keymap_hotbar_next", "KEY_KEY_M");
+	settings->setDefault("keymap_hotbar_previous", "KEY_KEY_N");
 	settings->setDefault("keymap_screenshot", "KEY_F12");
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -48,9 +48,12 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");
 	settings->setDefault("keymap_noclip", "KEY_KEY_H");
-	settings->setDefault("keymap_hotbar_next", "KEY_KEY_M");
-	settings->setDefault("keymap_hotbar_previous", "KEY_KEY_N");
+	settings->setDefault("keymap_hotbar_next", "KEY_KEY_N");
+	settings->setDefault("keymap_hotbar_previous", "KEY_KEY_B");
 	settings->setDefault("keymap_screenshot", "KEY_F12");
+	settings->setDefault("keymap_mute", "KEY_KEY_M");
+	settings->setDefault("keymap_increase_volume", "KEY_PERIOD");
+	settings->setDefault("keymap_decrease_volume", "KEY_COMMA");
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");
 	settings->setDefault("keymap_toggle_force_fog_off", "KEY_F3");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -65,6 +65,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "event_manager.h"
 #include <iomanip>
 #include <list>
+#include <math.h>
 #include "util/directiontables.h"
 #include "util/pointedthing.h"
 #include "drawscene.h"
@@ -2044,6 +2045,37 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 				}
 				image->drop();
 			}
+		}
+		else if(input->wasKeyDown(getKeySetting("keymap_mute")))
+		{
+			g_settings->setFloat("sound_volume", 0.0),
+			statustext = narrow_to_wide(
+					"Volume changed to 0%");
+			statustext_time = 0;
+		}
+		else if(input->wasKeyDown(getKeySetting("keymap_increase_volume")))
+		{
+			float volume = g_settings->getFloat("sound_volume");
+			float new_volume = volume + 0.1;
+			if(new_volume > 1)
+				new_volume = 1;
+			g_settings->setFloat("sound_volume", new_volume);
+			statustext = narrow_to_wide(
+					"Volume changed to "
+					+ itos((int) round(new_volume*100)) + "%");
+			statustext_time = 0;
+		}
+		else if(input->wasKeyDown(getKeySetting("keymap_decrease_volume")))
+		{
+			float volume = g_settings->getFloat("sound_volume");
+			float new_volume = volume - 0.1;
+			if(new_volume < 0)
+				new_volume = 0;
+			g_settings->setFloat("sound_volume", new_volume);
+			statustext = narrow_to_wide(
+					"Volume changed to "
+					+ itos((int) round(new_volume*100)) + "%");
+			statustext_time = 0;
 		}
 		else if(input->wasKeyDown(getKeySetting("keymap_toggle_hud")))
 		{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2048,9 +2048,16 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 		}
 		else if(input->wasKeyDown(getKeySetting("keymap_mute")))
 		{
-			g_settings->setFloat("sound_volume", 0.0),
-			statustext = narrow_to_wide(
-					"Volume changed to 0%");
+			float volume = g_settings->getFloat("sound_volume");
+			if(volume < 0.001) {
+				g_settings->setFloat("sound_volume", 1.0);
+				statustext = narrow_to_wide(
+						"Volume changed to 100%");
+			} else {
+				g_settings->setFloat("sound_volume", 0.0);
+				statustext = narrow_to_wide(
+						"Volume changed to 0%");
+			}
 			statustext_time = 0;
 		}
 		else if(input->wasKeyDown(getKeySetting("keymap_increase_volume")))

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2199,8 +2199,29 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 					new_playeritem = max_item;
 			}
 		}
+		// Item selection with next/previous keys
+		if(input->wasKeyDown(getKeySetting("keymap_hotbar_next")))
+		{
+			u16 max_item = MYMIN(PLAYER_INVENTORY_SIZE-1,
+				player->hud_hotbar_itemcount-1);
 
-		// Item selection
+			if(new_playeritem < max_item)
+				new_playeritem++;
+			else
+				new_playeritem = 0;
+		}
+		if(input->wasKeyDown(getKeySetting("keymap_hotbar_previous")))
+		{
+			u16 max_item = MYMIN(PLAYER_INVENTORY_SIZE-1,
+				player->hud_hotbar_itemcount-1);
+
+			if(new_playeritem > 0)
+				new_playeritem--;
+			else
+				new_playeritem = max_item;
+		}
+
+		// Item selection with number keys
 		for(u16 i=0; i<10; i++)
 		{
 			const KeyPress *kp = NumberKey + (i + 1) % 10;

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -55,6 +55,9 @@ enum
 	GUI_ID_KEY_INVENTORY_BUTTON,
 	GUI_ID_KEY_HOTBAR_PREV_BUTTON,
 	GUI_ID_KEY_HOTBAR_NEXT_BUTTON,
+	GUI_ID_KEY_MUTE_BUTTON,
+	GUI_ID_KEY_DEC_VOLUME_BUTTON,
+	GUI_ID_KEY_INC_VOLUME_BUTTON,
 	GUI_ID_KEY_DUMP_BUTTON,
 	GUI_ID_KEY_RANGE_BUTTON,
 	// other
@@ -399,6 +402,9 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON, wgettext("Inventory"),     "keymap_inventory");
 	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,wgettext("Prev. item"),   "keymap_hotbar_previous");
 	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,wgettext("Next item"),    "keymap_hotbar_next");
+	this->add_key(GUI_ID_KEY_MUTE_BUTTON,      wgettext("Mute"),          "keymap_mute");
+	this->add_key(GUI_ID_KEY_DEC_VOLUME_BUTTON,wgettext("Dec. volume"),   "keymap_decrease_volume");
+	this->add_key(GUI_ID_KEY_INC_VOLUME_BUTTON,wgettext("Inc. volume"),   "keymap_increase_volume");
 	this->add_key(GUI_ID_KEY_CHAT_BUTTON,      wgettext("Chat"),          "keymap_chat");
 	this->add_key(GUI_ID_KEY_CMD_BUTTON,       wgettext("Command"),       "keymap_cmd");
 	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,   wgettext("Console"),       "keymap_console");

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -53,6 +53,8 @@ enum
 	GUI_ID_KEY_SNEAK_BUTTON,
 	GUI_ID_KEY_DROP_BUTTON,
 	GUI_ID_KEY_INVENTORY_BUTTON,
+	GUI_ID_KEY_HOTBAR_PREV_BUTTON,
+	GUI_ID_KEY_HOTBAR_NEXT_BUTTON,
 	GUI_ID_KEY_DUMP_BUTTON,
 	GUI_ID_KEY_RANGE_BUTTON,
 	// other
@@ -395,6 +397,8 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,     wgettext("Sneak"),         "keymap_sneak");
 	this->add_key(GUI_ID_KEY_DROP_BUTTON,      wgettext("Drop"),          "keymap_drop");
 	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON, wgettext("Inventory"),     "keymap_inventory");
+	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,wgettext("Prev. item"),   "keymap_hotbar_previous");
+	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,wgettext("Next item"),    "keymap_hotbar_next");
 	this->add_key(GUI_ID_KEY_CHAT_BUTTON,      wgettext("Chat"),          "keymap_chat");
 	this->add_key(GUI_ID_KEY_CMD_BUTTON,       wgettext("Command"),       "keymap_cmd");
 	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,   wgettext("Console"),       "keymap_console");


### PR DESCRIPTION
This PR adds configurable key bindings for:
- selecting next item in hotbar (default: `N`)
- selecting previous item in hotbar (default: `B`)
- increasing volume by 10% (default: `.`)
- decreasing volume by 10% (default: `,`)
- muting (set volume to 0%) (default: `M`)

The key bindings for hotbar item selection are additional to the number keys and the mouse wheel key binding; they do not replace them.

New `keymap_` settings are provided. Also the keybinding menu contains the new key bindings.
