### PR TITLE
Remove remains of weather

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -323,8 +323,6 @@ param2 is reserved for the engine when any of these are used:
     facedir modulo 4 = axisdir
     0 = y+    1 = z+    2 = z-    3 = x+    4 = x-    5 = y-
     facedir's two less significant bits are rotation around the axis
-  paramtype2 == "leveled"
-  ^ The drawn node level is read from param2, like flowingliquid
 
 Nodes can also contain extra data. See "Node Metadata".
 
@@ -356,7 +354,7 @@ Node selection boxes are defined using "node boxes"
 
 The "nodebox" node drawtype allows defining visual of nodes consisting of
 arbitrary number of boxes. It allows defining stuff like stairs. Only the
-"fixed" and "leveled" box type is supported for these.
+"fixed" box type is supported for these.
 ^ Please note that this is still experimental, and may be incompatibly
   changed in the future.
 
@@ -383,8 +381,6 @@ A box is defined as:
   {x1, y1, z1, x2, y2, z2}
 A box of a regular node would look like:
   {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
-
-type = "leveled" is same as "fixed", but y2 will be automatically set to level from param2
 
 Ore types
 ---------------
@@ -1438,16 +1434,6 @@ minetest.find_path(pos1,pos2,searchdistance,max_jump,max_drop,algorithm)
 ^ algorithm: A*_noprefetch(default), A*, Dijkstra
 minetest.spawn_tree (pos, {treedef})
 ^ spawns L-System tree at given pos with definition in treedef table
-minetest.transforming_liquid_add(pos)
-^ add node to liquid update queue
-minetest.get_node_max_level(pos)
-^ get max available level for leveled node
-minetest.get_node_level(pos)
-^ get level of leveled node (water, snow)
-minetest.set_node_level(pos, level)
-^ set level of leveled node, default level = 1, if totallevel > maxlevel returns rest (total-max).
-minetest.add_node_level(pos, level)
-^ increase level of leveled node by level, default level = 1, if totallevel > maxlevel returns rest (total-max). can be negative for decreasing
 
 Inventory:
 minetest.get_inventory(location) -> InvRef
@@ -2314,8 +2300,6 @@ Node definition (register_node)
     liquid_alternative_source = "", -- Source version of flowing liquid
     liquid_viscosity = 0, -- Higher viscosity = slower flow (max. 7)
     liquid_renewable = true, -- Can new liquid source be created by placing two or more sources nearby?
-    freezemelt = "", -- water for snow/ice, ice/snow for water
-    leveled = 0, -- Block contain level in param2. value - default level, used for snow. Don't forget use "leveled" type nodebox
     liquid_range = 8, -- number of flowing nodes around source (max. 8)
     drowning = 0, -- Player will take this amount of damage if no bubbles are left
     light_source = 0, -- Amount of light emitted by node

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -331,8 +331,7 @@
 #time_send_interval = 5
 # Length of day/night cycle. 72=20min, 360=4min, 1=24hour, 0=day/night/whatever stays unchanged
 #time_speed = 72
-# Length of year in days for seasons change. With default time_speed 365 days = 5 real days for year. 30 days = 10 real hours
-#year_days = 30
+#Timeout for server to remove unused map data from memory
 #server_unload_unused_data_timeout = 29
 # Maximum number of statically stored objects in a block
 #max_objects_per_block = 49

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -223,7 +223,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_send_interval", "5");
 	settings->setDefault("time_speed", "72");
-	settings->setDefault("year_days", "30");
 	settings->setDefault("server_unload_unused_data_timeout", "29");
 	settings->setDefault("max_objects_per_block", "49");
 	settings->setDefault("server_map_save_interval", "5.3");


### PR DESCRIPTION
This removes a few remains from the weather feature and also adds a missing description for `server_unload_unused_data_timeout` in minetest.conf.example.
#1263
