### PR TITLE
Disable shaders when Direct3D is used

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -109,6 +109,14 @@ local function init_globals()
 	ui.update()
 
 	core.sound_play("main_menu", true)
+
+	-- Disable shaders if directx is used.
+	if core.is_yes(core.setting_get("enable_shaders")) and
+			(core.setting_get("video_driver") == "direct3d8"
+			or core.setting_get("video_driver") == "direct3d9") then
+		core.setting_set("enable_shaders", "false")
+		engine.log("error", "To enable shaders the OpenGL driver needs to be used.")
+	end
 end
 
 init_globals()


### PR DESCRIPTION
This check is [already done in the settings tab](https://github.com/minetest/minetest/blob/master/builtin/mainmenu/tab_settings.lua#L221), however it is not done on the game's start up.
