### PR TITLE
Make player names case-insensitive

### DIFF
--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -185,4 +185,15 @@ function core.auth_reload()
 	return false
 end
 
+core.register_on_prejoinplayer(function(name, ip)
+	local lname = name:lower()
+	for iname, data in pairs(core.auth_table) do
+		if iname:lower() == lname and iname ~= name then
+			return "Sorry, someone else is already using this"
+				.." name.  Please pick another name."
+				.."  Annother posibility is that you used the"
+				.." wrong case for your name."
+		end
+	end
+end)
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -708,3 +708,22 @@ core.register_chatcommand("msg", {
 	end,
 })
 
+local worldpath = core.get_worldpath()
+-- Compatability, for old servers with conflicting players
+core.register_chatcommand("choosecase", {
+	description = "Choose the casing that a player name should have.",
+	params = "<name>",
+	privs = {server=true},
+	func = function(name, params)
+		local lname = params:lower()
+		for iname, data in pairs(core.auth_table) do
+			if iname:lower() == lname and iname ~= params then
+				core.auth_table[iname] = nil
+				assert(not iname:find("[/\\]"))
+				os.remove(worldpath..DIR_DELIM.."players"..DIR_DELIM..iname)
+			end
+		end
+		return true, "Done."
+	end,
+})
+

--- a/src/constants.h
+++ b/src/constants.h
@@ -89,11 +89,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Maximum hit points of a player
 #define PLAYER_MAX_HP 20
 
-// Number of different files to try to save a player to if the first fails
-// (because of a case-insensitive filesystem)
-// TODO: Use case-insensitive player names instead of this hack.
-#define PLAYER_FILE_ALTERNATE_TRIES 1000
-
 /*
  *    GUI related things
  */

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -443,39 +443,25 @@ void ServerEnvironment::savePlayer(const std::string &playername)
 
 Player *ServerEnvironment::loadPlayer(const std::string &playername)
 {
-	std::string players_path = m_path_world + DIR_DELIM "players" DIR_DELIM;
-
 	RemotePlayer *player = static_cast<RemotePlayer*>(getPlayer(playername.c_str()));
-	bool newplayer = false;
-	bool found = false;
+	bool new_player = false;
 	if (!player) {
 		player = new RemotePlayer(m_gamedef);
-		newplayer = true;
+		new_player = true;
 	}
 
-	RemotePlayer testplayer(m_gamedef);
-	std::string path = players_path + playername;
-	for (u32 i = 0; i < PLAYER_FILE_ALTERNATE_TRIES; i++) {
-		// Open file and deserialize
-		std::ifstream is(path.c_str(), std::ios_base::binary);
-		if (!is.good()) {
-			return NULL;
-		}
-		testplayer.deSerialize(is, path);
-		is.close();
-		if (testplayer.getName() == playername) {
-			*player = testplayer;
-			found = true;
-			break;
-		}
-		path = players_path + playername + itos(i);
-	}
-	if (!found) {
-		infostream << "Player file for player " << playername
-				<< " not found" << std::endl;
+	std::string path = m_path_world + DIR_DELIM "players" DIR_DELIM
+			+ playername;
+	// Open file and deserialize
+	std::ifstream is(path.c_str(), std::ios_base::binary);
+	if (!is.good()) {
+		infostream << "Unable to open player file for "
+				<< playername << std::endl;
 		return NULL;
 	}
-	if (newplayer) {
+	player->deSerialize(is, path);
+	is.close();
+	if (new_player) {
 		addPlayer(player);
 	}
 	return player;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -285,50 +285,15 @@ void Player::clearHud()
 }
 
 
-void RemotePlayer::save(std::string savedir)
+void RemotePlayer::save(const std::string & savedir)
 {
-	/*
-	 * We have to open all possible player files in the players directory
-	 * and check their player names because some file systems are not
-	 * case-sensitive and player names are case-sensitive.
-	 */
-
-	// A player to deserialize files into to check their names
-	RemotePlayer testplayer(m_gamedef);
-
-	savedir += DIR_DELIM;
-	std::string path = savedir + m_name;
-	for (u32 i = 0; i < PLAYER_FILE_ALTERNATE_TRIES; i++) {
-		if (!fs::PathExists(path)) {
-			// Open file and serialize
-			std::ostringstream ss(std::ios_base::binary);
-			serialize(ss);
-			if (!fs::safeWriteToFile(path, ss.str())) {
-				infostream << "Failed to write " << path << std::endl;
-			}
-			return;
-		}
-		// Open file and deserialize
-		std::ifstream is(path.c_str(), std::ios_base::binary);
-		if (!is.good()) {
-			infostream << "Failed to open " << path << std::endl;
-			return;
-		}
-		testplayer.deSerialize(is, path);
-		is.close();
-		if (strcmp(testplayer.getName(), m_name) == 0) {
-			// Open file and serialize
-			std::ostringstream ss(std::ios_base::binary);
-			serialize(ss);
-			if (!fs::safeWriteToFile(path, ss.str())) {
-				infostream << "Failed to write " << path << std::endl;
-			}
-			return;
-		}
-		path = savedir + m_name + itos(i);
+	std::string path = DIR_DELIM + savedir + m_name;
+	// Open file and serialize
+	std::ostringstream ss(std::ios_base::binary);
+	serialize(ss);
+	if (!fs::safeWriteToFile(path, ss.str())) {
+		infostream << "Failed to write " << path << std::endl;
 	}
-
-	infostream << "Didn't find free file for player " << m_name << std::endl;
 	return;
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -335,7 +335,7 @@ public:
 	RemotePlayer(IGameDef *gamedef): Player(gamedef), m_sao(0) {}
 	virtual ~RemotePlayer() {}
 
-	void save(std::string savedir);
+	void save(const std::string &savedir);
 
 	PlayerSAO *getPlayerSAO()
 	{ return m_sao; }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1451,11 +1451,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 
 		// Get player name
 		char playername[PLAYERNAME_SIZE];
-		for(u32 i=0; i<PLAYERNAME_SIZE-1; i++)
-		{
-			playername[i] = data[3+i];
-		}
-		playername[PLAYERNAME_SIZE-1] = 0;
+		strlcpy(playername, (char *) data + 3, PLAYERNAME_SIZE);
 
 		if(playername[0]=='\0')
 		{
@@ -1499,18 +1495,16 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 
 		// Get password
 		char given_password[PASSWORD_SIZE];
-		if(datasize < 2+1+PLAYERNAME_SIZE+PASSWORD_SIZE)
+		if(datasize < 2 + 1 + PLAYERNAME_SIZE + PASSWORD_SIZE)
 		{
 			// old version - assume blank password
 			given_password[0] = 0;
 		}
 		else
 		{
-			for(u32 i=0; i<PASSWORD_SIZE-1; i++)
-			{
-				given_password[i] = data[23+i];
-			}
-			given_password[PASSWORD_SIZE-1] = 0;
+			strlcpy(given_password,
+					(char *) data + 2 + 1 + PLAYERNAME_SIZE,
+					PASSWORD_SIZE);
 		}
 
 		if(!base64_is_valid(given_password)){
@@ -1543,7 +1537,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 		if(!has_auth){
 			if(!isSingleplayer() &&
 					g_settings->getBool("disallow_empty_password") &&
-					std::string(given_password) == ""){
+					given_password[0] == '\0'){
 				actionstream<<"Server: "<<playername
 						<<" supplied empty password"<<std::endl;
 				DenyAccess(peer_id, L"Empty passwords are "


### PR DESCRIPTION
This is rather ugly, due to the password hashing system and compatibility concerns.  It does, however, make the loading and saving section of the code much cleaner.

The player name can't be changed by the server to the proper case because the hash is generated with the client's version of the player name, therefore the hash from the initial connect may be generated with `ShadowNinja` and subsequent connections with `sHaDoWnInJa`, which the server can't compare.
This simply denys access to clients that don't spell their player name correctly.
A `/choosecase` command is added for removing duplicate entries.

A proper implementation requires breaking compatibility, and is scheduled for 0.5.
