### PR TITLE
Add minetest.register_on_time_change

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -212,6 +212,19 @@ function core.register_tool(name, tooldef)
 	core.register_item(name, tooldef)
 end
 
+core.time_change_functions = core.time_change_functions or {}
+function core.register_on_time_change(func)
+	table.insert(core.time_change_functions, func)
+end
+
+local change_time = core.set_timeofday
+function core.set_timeofday(time)
+	for _,func in pairs(core.time_change_functions) do
+		func(time)
+	end
+	change_time(time)
+end
+
 function core.register_alias(name, convert_to)
 	if forbidden_item_names[name] then
 		error("Unable to register alias: Name is forbidden: " .. name)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1403,6 +1403,8 @@ minetest.register_on_protection_violation(func(pos, name))
 minetest.register_on_item_eat(func(hp_change, replace_with_item, itemstack, user, pointed_thing))
 ^ Called when an item is eaten, by minetest.item_eat
 ^ Return true or itemstack to cancel the default item eat response (ie: hp increase)
+minetest.register_on_time_change(func(time))
+^ Called before the time is changed by minetest.set_timeofday()
 
 Other registration functions:
 minetest.register_chatcommand(cmd, chatcommand definition)


### PR DESCRIPTION
This function allows mods to react easier if someone uses /time.
Maybe I should make the time change functions local.