### PR TITLE
Disable preload_item_visuals by default

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -133,7 +133,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("anisotropic_filter", "false");
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
-	settings->setDefault("preload_item_visuals", "true");
+	settings->setDefault("preload_item_visuals", "false");
 	settings->setDefault("enable_bumpmapping", "false");
 	settings->setDefault("enable_parallax_occlusion", "false");
 	settings->setDefault("generate_normalmaps", "false");


### PR DESCRIPTION
This can delay connections by several minutes, and when it's on it doesn't same much time when opening inventories.
This causes frustrations for users and makes Minetest seem like it's crashed or locked up, see http://youtu.be/1k7mqD5XIY8?t=19m8s.
