### PR TITLE
fixed error in ' dlg_create_world.lua'

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -50,7 +50,7 @@ local function create_world_formspec(dialogdata)
 		"field[4.5,0.4;6,0.5;te_world_name;;]" ..
 
 		"label[2,1;" .. fgettext("Seed") .. "]"..
-		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
+		"field[4.5,1.4;6,0.5;te_seed;;]" ..
 
 		"label[2,2;" .. fgettext("Mapgen") .. "]"..
 		"dropdown[4.2,2;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]" ..


### PR DESCRIPTION
this error comes up, well it did now crazyginger72 fixed it :)

02:48:39: ERROR[main]: MAINMENU ERROR: ...cal/share/minetest/builtin/mainmenu/dlg_create_world.lua:89: bad argument #2 to 'setting_set' (string expected, got nil)
02:48:39: ERROR[main]: stack traceback:
02:48:39: ERROR[main]:  [C]: in function 'setting_set'
02:48:39: ERROR[main]:  ...cal/share/minetest/builtin/mainmenu/dlg_create_world.lua:89: in function 'handle_buttons'
02:48:39: ERROR[main]:  /usr/local/share/minetest/builtin/fstk/ui.lua:118: in function 'handle_buttons'
02:48:39: ERROR[main]:  /usr/local/share/minetest/builtin/fstk/ui.lua:155: in function </usr/local/share/minetest/builtin/fstk/ui.lua:148>
