### PR TITLE
Disallow object:remove() if the object is a player

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1876,6 +1876,7 @@ ObjectRef: Moving things in the game are generally these
 (basically reference to a C++ ServerActiveObject)
 methods:
 - remove(): remove object (after returning from Lua)
+  Note: doesn't work on players, use minetest.kick_player instead
 - getpos() -> {x=num, y=num, z=num}
 - setpos(pos); pos={x=num, y=num, z=num}
 - moveto(pos, continuous=false): interpolated move

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -132,6 +132,7 @@ int ObjectRef::l_remove(lua_State *L)
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
 	if(co == NULL) return 0;
+	if(co->getType() == ACTIVEOBJECT_TYPE_PLAYER) return 0;
 	verbosestream<<"ObjectRef::l_remove(): id="<<co->getId()<<std::endl;
 	co->m_removed = true;
 	return 0;


### PR DESCRIPTION
For example, this fixes the following error reported by VanessaE, using worldedit:

1. define an area using //pos1 and //pos2
1. position yourself inside this area and run //clearobjects

Without the patch, this will delete your player object, emit an error message like
<code>ERROR[ServerThread]: Server::ProcessData(): Cancelling: No player for peer_id=2 disconnecting peer!</code>
and you will then be disconnected.