### PR TITLE
Add player name lenght checks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "httpfetch.h"
 #include "guiEngine.h"
 #include "mapsector.h"
+#include "player.h"
 
 #include "database-sqlite3.h"
 #ifdef USE_LEVELDB
@@ -1841,6 +1842,13 @@ int main(int argc, char *argv[])
 					g_settings->updateConfigFile(g_settings_path.c_str());
 				}
 				break;
+			}
+
+			if (current_playername.length() > PLAYERNAME_SIZE-1) {
+				error_message = wgettext("Player name to long.");
+				playername = current_playername.substr(0,PLAYERNAME_SIZE-1);
+				g_settings->set("name", playername);
+				continue;
 			}
 
 			/*

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1448,14 +1448,21 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 		/*
 			Set up player
 		*/
-
-		// Get player name
 		char playername[PLAYERNAME_SIZE];
-		for(u32 i=0; i<PLAYERNAME_SIZE-1; i++)
-		{
-			playername[i] = data[3+i];
+		unsigned int playername_length = 0;
+		for (; playername_length < PLAYERNAME_SIZE; playername_length++ ) {
+			playername[playername_length] = data[3+playername_length];
+			if (data[3+playername_length] == 0)
+				break;
 		}
-		playername[PLAYERNAME_SIZE-1] = 0;
+
+		if (playername_length == PLAYERNAME_SIZE) {
+			actionstream<<"Server: Player with name exceeding max length "
+					<<"tried to connect from "<<addr_s<<std::endl;
+			DenyAccess(peer_id, L"Name to long");
+			return;
+		}
+
 
 		if(playername[0]=='\0')
 		{


### PR DESCRIPTION
Check against size of struct used to transfer playername prior starting game.
Make server check received data for player names to long. (shouldn't actually happen but just to be sure)

Replacement for : https://github.com/minetest/minetest/pull/1568
