### PR TITLE
Fix LuaJIT exception wrapper

### DIFF
--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -64,8 +64,10 @@ int script_exception_wrapper(lua_State *L, lua_CFunction f)
 		return f(L);  // Call wrapped function and return result.
 	} catch (const char *s) {  // Catch and convert exceptions.
 		lua_pushstring(L, s);
-	} catch (LuaError& e) {
+	} catch (std::exception& e) {
 		lua_pushstring(L, e.what());
+	} catch (...) {
+		lua_pushliteral(L, "caught (...)");
 	}
 	return lua_error(L);  // Rethrow as a Lua error.
 }


### PR DESCRIPTION
This reverts the LuaJIT exception wrapper to the recommended version shown at:
http://luajit.org/ext_c_api.html#mode_wrapcfunc

The current exception wrapper fails to handle C++ exceptions thrown inside C++ code called from Lua. This is why the error message in #1556 is just "C++ exception" and nothing more specific.

To test this fix, apply #1579 and run the chat command "/exceptiontest immediate exception" in the minimal game.
