### PR TITLE
Lua api extensions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1456,10 +1456,14 @@ Environment access:
 minetest.set_node(pos, node)
 minetest.add_node(pos, node): alias set_node(pos, node)
 ^ Set node at position (node = {name="foo", param1=0, param2=0})
+minetest.set_nodes_in_area(minp, maxp, node)
+^ Set nodes in area (node = {name="foo", param1=0, param2=0})
 minetest.swap_node(pos, node)
 ^ Set node at position, but don't remove metadata
 minetest.remove_node(pos)
 ^ Equivalent to set_node(pos, "air")
+minetest.remove_nodes_in_area(minp, maxp)
+^ Replaces all nodes in area with "air"
 minetest.get_node(pos)
 ^ Returns {name="ignore", ...} for unloaded area
 minetest.get_node_or_nil(pos)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -31,10 +31,17 @@ private:
 
 	static int l_add_node(lua_State *L);
 
+	// set_nodes_in_area(minp, maxp, node) -> true (success) or false
+	// node = {name="foo", param1=0, param2=0}
+	static int l_set_nodes_in_area(lua_State *L);
+
 	// remove_node(pos)
 	// pos = {x=num, y=num, z=num}
 	static int l_remove_node(lua_State *L);
 	
+	// remove_nodes_in_area(minp, maxp) -> true (success) or false
+	static int l_remove_nodes_in_area(lua_State *L);
+
 	// swap_node(pos, node)
 	// pos = {x=num, y=num, z=num}
 	static int l_swap_node(lua_State *L);


### PR DESCRIPTION
Added:
minetest.set_nodes_in_area(minp, maxp, node)
minetest.remove_nodes_in_area(minp, maxp)

Rationale:
Some mods (for example, worldedit and plants_lib) currently do bulk operations on nodes in an area, such as clearing or replacing them. Currently this is done in Lua via an x,y,z loop calling either set_node or remove_node -- whichever is appropriate. Since these are "bulk" operations it makes sense to have them as part of the Lua API. An alternative is to use vmanip, however this (currently) causes problems between different (mapgen, for example) mods that use different methods: directly calling set_node or remove_node vs. those that use vmanip. Additionally, the execution time to create a vmanip area exceeds the total execution times of these new functions.

Advantages:
a) A single call to one function to set/remove the nodes in an area is arguably "cleaner"  than having to write a loop in Lua that achieves the same function, making Lua code more readable and concise
b) Undertaking the operations in C++ is slighty faster (between approximately 1.4 to 4 times faster using LuaJIT)

Backward compatibility:
Does not affect existing Lua scripts
