### PR TITLE
Add an error message.

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -365,8 +365,9 @@ core.register_chatcommand("teleport", {
 						.. " at " .. core.pos_to_string(p)
 			end
 		else
-			return false, 'You can't teleport any other player. (missing privilege : bring)'
+			return false, "You can't teleport any other players. (missing privilege: bring)"
 		end
+		
 		return false, 'Invalid parameters ("' .. param
 				.. '") or player not found (see /help teleport)'
 	end,


### PR DESCRIPTION
Add an error message to tell the player that he can't teleport any other player without bring privilege. Thanks to RentedMule for discovering the issue.
Without this change, when you type /teleport player1 player2, both are connected and you only have got the teleport privilege, it tells you : "Invalid parameters ("player1 player2", or player not found (see /help teleport)".
