### PR TITLE
Use a larger and wider screen resolution by default

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -74,7 +74,7 @@
 #viewing_range_nodes_max = 160
 #viewing_range_nodes_min = 35
 # Initial window size
-#screenW = 800
+#screenW = 1024
 #screenH = 600
 #fullscreen = false
 #fullscreen_bpp = 24

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -86,7 +86,7 @@ void set_default_settings(Settings *settings)
 	// A bit more than the server will send around the player, to make fog blend well
 	settings->setDefault("viewing_range_nodes_max", "240");
 	settings->setDefault("viewing_range_nodes_min", "35");
-	settings->setDefault("screenW", "800");
+	settings->setDefault("screenW", "1024");
 	settings->setDefault("screenH", "600");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("fullscreen_bpp", "24");


### PR DESCRIPTION
As most screens are wide today, this makes more sense.

This is bigger than what Minecraft uses by default, but all screens (even netbooks') support 1024 × 600 anyway.
