### PR TITLE
Add mod security

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -222,6 +222,7 @@ LOCAL_SRC_FILES +=                                \
 		jni/src/script/common/c_converter.cpp     \
 		jni/src/script/common/c_internal.cpp      \
 		jni/src/script/common/c_types.cpp         \
+		jni/src/script/cpp_api/s_async.cpp        \
 		jni/src/script/cpp_api/s_base.cpp         \
 		jni/src/script/cpp_api/s_entity.cpp       \
 		jni/src/script/cpp_api/s_env.cpp          \
@@ -231,8 +232,8 @@ LOCAL_SRC_FILES +=                                \
 		jni/src/script/cpp_api/s_node.cpp         \
 		jni/src/script/cpp_api/s_nodemeta.cpp     \
 		jni/src/script/cpp_api/s_player.cpp       \
+		jni/src/script/cpp_api/s_security.cpp     \
 		jni/src/script/cpp_api/s_server.cpp       \
-		jni/src/script/cpp_api/s_async.cpp        \
 		jni/src/script/lua_api/l_base.cpp         \
 		jni/src/script/lua_api/l_craft.cpp        \
 		jni/src/script/lua_api/l_env.cpp          \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2211,11 +2211,18 @@ These functions return the leftover itemstack.
 * `minetest.forceload_block(pos)`
     * forceloads the position `pos`.
     * returns `true` if area could be forceloaded
+    * Please note that forceloaded areas are saved when the server restarts.
 
 * `minetest.forceload_free_block(pos)`
     * stops forceloading the position `pos`
 
-Please note that forceloaded areas are saved when the server restarts.
+* `minetest.request_insecure_environment()`:
+  Returns an environment containing insecure functions if the calling mod has
+  been listed as trusted in the secure_trusted_mods setting, otherwise returns
+  `nil`.  Only works at init time.
+  DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED ENVIRONMENT, STORE IT IN
+  A LOCAL VARIABLE!
+
 
 ### Global objects
 * `minetest.env`: `EnvRef` of the server environment and world.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1777,8 +1777,12 @@ Call these functions only at load time!
 
 ### Setting-related
 * `minetest.setting_set(name, value)`
+  Note that only characters in the set [a-zA-Z0-9_-.] are allowed in setting
+  names, and setting values can't contain the sequence "\n\"\"\"".  Settings
+  starting with "secure_" also can't be set.
 * `minetest.setting_get(name)`: returns string or `nil`
 * `minetest.setting_setbool(name, value)`
+  See documentation on setting_set for restrictions.
 * `minetest.setting_getbool(name)`: returns boolean or `nil`
 * `minetest.setting_get_pos(name)`: returns position or nil
 * `minetest.setting_save()`, returns `nil`, save all settings to config file

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2218,8 +2218,8 @@ These functions return the leftover itemstack.
 
 * `minetest.request_insecure_environment()`:
   Returns an environment containing insecure functions if the calling mod has
-  been listed as trusted in the secure.trusted_mods setting, otherwise returns
-  `nil`.  Only works at init time.
+  been listed as trusted in the `secure.trusted_mods` setting or security is
+  disabled, otherwise returns `nil`.  Only works at init time.
   DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED ENVIRONMENT, STORE IT IN
   A LOCAL VARIABLE!
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1779,7 +1779,7 @@ Call these functions only at load time!
 * `minetest.setting_set(name, value)`
   Note that only characters in the set [a-zA-Z0-9_-.] are allowed in setting
   names, and setting values can't contain the sequence "\n\"\"\"".  Settings
-  starting with "secure_" also can't be set.
+  starting with "secure." also can't be set.
 * `minetest.setting_get(name)`: returns string or `nil`
 * `minetest.setting_setbool(name, value)`
   See documentation on setting_set for restrictions.
@@ -2218,7 +2218,7 @@ These functions return the leftover itemstack.
 
 * `minetest.request_insecure_environment()`:
   Returns an environment containing insecure functions if the calling mod has
-  been listed as trusted in the secure_trusted_mods setting, otherwise returns
+  been listed as trusted in the secure.trusted_mods setting, otherwise returns
   `nil`.  Only works at init time.
   DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED ENVIRONMENT, STORE IT IN
   A LOCAL VARIABLE!

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -553,3 +553,7 @@
 #    Noise parameters for biome API temperature and humidity
 #mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0
 #mg_biome_np_humidity = 50, 50, (500, 500, 500), 842, 3, 0.5, 2.0
+
+#    Prevent mods from doing insecure things like running shell commands
+#secure_mod_api = true
+

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -556,4 +556,7 @@
 
 #    Prevent mods from doing insecure things like running shell commands
 #secure_mod_api = true
+#    Comma-separated list of trusted mods that are allowed to access insecure
+#    functions even when mod security is on (via request_insecure_environment()).
+#secure_trusted_mods =
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -554,9 +554,9 @@
 #mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0
 #mg_biome_np_humidity = 50, 50, (500, 500, 500), 842, 3, 0.5, 2.0
 
-#    Prevent mods from doing insecure things like running shell commands
-#secure_mod_api = true
+#    Prevent mods from doing insecure things like running shell commands.
+#secure.enable_security = true
 #    Comma-separated list of trusted mods that are allowed to access insecure
 #    functions even when mod security is on (via request_insecure_environment()).
-#secure_trusted_mods =
+#secure.trusted_mods =
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -264,6 +264,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_generate", "32");
 	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure_mod_api", "true");
+	settings->setDefault("secure_trusted_mods", "");
 
 	// physics stuff
 	settings->setDefault("movement_acceleration_default", "3");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -263,6 +263,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");
 	settings->setDefault("num_emerge_threads", "1");
+	settings->setDefault("secure_mod_api", "true");
 
 	// physics stuff
 	settings->setDefault("movement_acceleration_default", "3");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -263,8 +263,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");
 	settings->setDefault("num_emerge_threads", "1");
-	settings->setDefault("secure_mod_api", "true");
-	settings->setDefault("secure_trusted_mods", "");
+	settings->setDefault("secure.enable_security", "true");
+	settings->setDefault("secure.trusted_mods", "");
 
 	// physics stuff
 	settings->setDefault("movement_acceleration_default", "3");

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -370,6 +370,7 @@ std::string TempPath()
 
 #endif
 
+
 void GetRecursiveSubPaths(std::string path, std::vector<std::string> &dst)
 {
 	std::vector<DirListNode> content = GetDirListing(path);
@@ -649,6 +650,22 @@ std::string RemoveRelativePathComponents(std::string path)
 	while(pos != 0 && IsDirDelimiter(path[pos-1]))
 		pos--;
 	return path.substr(0, pos);
+}
+
+std::string AbsolutePath(const std::string & path)
+{
+	char * abs_path;
+#ifdef _WIN32
+	abs_path = _fullpath(NULL, path.c_str(), MAX_PATH);
+#else
+	abs_path = realpath(path.c_str(), NULL);
+#endif
+	if (abs_path == NULL) {
+		return std::string();
+	}
+	std::string abs_path_str(abs_path);
+	free(abs_path);
+	return abs_path_str;
 }
 
 bool safeWriteToFile(const std::string &path, const std::string &content)

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -98,6 +98,10 @@ std::string RemoveLastPathComponent(std::string path,
 // this does not resolve symlinks and check for existence of directories.
 std::string RemoveRelativePathComponents(std::string path);
 
+// Returns the absolute path for the passed path, with "." and ".." path
+// components and symlinks removed.  Returns "" on error.
+std::string AbsolutePath(const std::string & path);
+
 bool safeWriteToFile(const std::string &path, const std::string &content);
 
 }//fs

--- a/src/script/cpp_api/CMakeLists.txt
+++ b/src/script/cpp_api/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Used by server and client
 set(common_SCRIPT_CPP_API_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/s_async.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_base.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_entity.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_env.cpp
@@ -8,8 +9,8 @@ set(common_SCRIPT_CPP_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/s_node.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_nodemeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_player.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/s_security.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_server.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/s_async.cpp
 	PARENT_SCOPE)
 
 # Used by client only

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -46,18 +46,18 @@ class ModNameStorer
 private:
 	lua_State *L;
 public:
-	ModNameStorer(lua_State *L_, const std::string &modname):
+	ModNameStorer(lua_State *L_, const std::string &mod_name):
 		L(L_)
 	{
-		// Store current modname in registry
-		lua_pushstring(L, modname.c_str());
-		lua_setfield(L, LUA_REGISTRYINDEX, "current_modname");
+		// Store current mod name in registry
+		lua_pushstring(L, mod_name.c_str());
+		lua_setfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
 	}
 	~ModNameStorer()
 	{
-		// Clear current modname in registry
+		// Clear current mod name from registry
 		lua_pushnil(L);
-		lua_setfield(L, LUA_REGISTRYINDEX, "current_modname");
+		lua_setfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
 	}
 };
 
@@ -113,38 +113,31 @@ ScriptApiBase::~ScriptApiBase()
 	lua_close(m_luastack);
 }
 
-bool ScriptApiBase::loadMod(const std::string &scriptpath,
-		const std::string &modname)
+bool ScriptApiBase::loadMod(const std::string &script_path,
+		const std::string &mod_name)
 {
-	ModNameStorer modnamestorer(getStack(), modname);
+	ModNameStorer mod_name_storer(getStack(), mod_name);
 
-	if (!string_allowed(modname, MODNAME_ALLOWED_CHARS)) {
-		errorstream<<"Error loading mod \""<<modname
-				<<"\": modname does not follow naming conventions: "
-				<<"Only chararacters [a-z0-9_] are allowed."<<std::endl;
-		return false;
-	}
-
-	return loadScript(scriptpath);
+	return loadScript(script_path);
 }
 
-bool ScriptApiBase::loadScript(const std::string &scriptpath)
+bool ScriptApiBase::loadScript(const std::string &script_path)
 {
-	verbosestream<<"Loading and running script from "<<scriptpath<<std::endl;
+	verbosestream << "Loading and running script from " << script_path << std::endl;
 
 	lua_State *L = getStack();
 
 	bool ok;
 	if (m_secure) {
-		ok = ScriptApiSecurity::safeLoadFile(L, scriptpath.c_str());
+		ok = ScriptApiSecurity::safeLoadFile(L, script_path.c_str());
 	} else {
-		ok = !luaL_loadfile(L, scriptpath.c_str());
+		ok = !luaL_loadfile(L, script_path.c_str());
 	}
 	ok = ok && !lua_pcall(L, 0, 0, m_errorhandler);
 	if (!ok) {
 		errorstream << "========== ERROR FROM LUA ===========" << std::endl;
 		errorstream << "Failed to load and run script from " << std::endl;
-		errorstream << scriptpath << ":" << std::endl;
+		errorstream << script_path << ":" << std::endl;
 		errorstream << std::endl;
 		errorstream << lua_tostring(L, -1) << std::endl;
 		errorstream << std::endl;

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -35,6 +35,10 @@ extern "C" {
 
 #define SCRIPTAPI_LOCK_DEBUG
 
+#define SCRIPT_MOD_NAME_FIELD "current_mod_name"
+#define BUILTIN_MOD_NAME "*builtin*"
+
+
 class Server;
 class Environment;
 class GUIEngine;
@@ -45,8 +49,8 @@ public:
 	ScriptApiBase();
 	virtual ~ScriptApiBase();
 
-	bool loadMod(const std::string &scriptpath, const std::string &modname);
-	bool loadScript(const std::string &scriptpath);
+	bool loadMod(const std::string &script_path, const std::string &mod_name);
+	bool loadScript(const std::string &script_path);
 
 	/* object */
 	void addObjectReference(ServerActiveObject *cobj);

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -42,7 +42,6 @@ class ServerActiveObject;
 
 class ScriptApiBase {
 public:
-
 	ScriptApiBase();
 	virtual ~ScriptApiBase();
 
@@ -52,6 +51,8 @@ public:
 	/* object */
 	void addObjectReference(ServerActiveObject *cobj);
 	void removeObjectReference(ServerActiveObject *cobj);
+
+	Server* getServer() { return m_server; }
 
 protected:
 	friend class LuaABM;
@@ -69,7 +70,6 @@ protected:
 	void scriptError();
 	void stackDump(std::ostream &o);
 
-	Server* getServer() { return m_server; }
 	void setServer(Server* server) { m_server = server; }
 
 	Environment* getEnv() { return m_environment; }
@@ -84,6 +84,7 @@ protected:
 	JMutex          m_luastackmutex;
 	// Stack index of Lua error handler
 	int             m_errorhandler;
+	bool            m_secure;
 #ifdef SCRIPTAPI_LOCK_DEBUG
 	bool            m_locked;
 #endif

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -280,20 +280,22 @@ bool ScriptApiSecurity::checkPath(lua_State * L, const char * path)
 {
 	std::string str;  // Transient
 
-	// First remove last component to allow opening non-existing files
-	std::string abs_path = fs::RemoveLastPathComponent(path, &str);
-	// Don't allow modifying minetest.conf (main or of games)
-	if (str == "minetest.conf") {
-		return false;
-	}
-
 	// Get absolute path
-	abs_path = fs::AbsolutePath(abs_path);
-	if (abs_path.empty()) {
-		return false;
+	std::string abs_path = fs::AbsolutePath(path);
+	if (!abs_path.empty()) {
+		// Don't allow accessing the settings file
+		str = fs::AbsolutePath(g_settings_path);
+		if (str == abs_path) {
+			return false;
+		}
 	}
 
-	DISALLOW_IN_PATH(g_settings_path);
+	// Remove last component to allow opening non-existing files
+	abs_path = fs::AbsolutePath(fs::RemoveLastPathComponent(path, &str));
+	// Don't allow accessing minetest.conf (main or of games)
+	if (abs_path.empty() || str == "minetest.conf") {
+		return false;
+	}
 
 	// Get server from registry
 	lua_getfield(L, LUA_REGISTRYINDEX, "scriptapi");

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -143,7 +143,7 @@ void ScriptApiSecurity::initializeSecurity()
 	lua_newtable(L);  // Create new environment
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "_G");  // Set _G of new environment
-#if LUA_VERSION_NUM >= 502  // Lua >= 5.2 (untested)
+#if LUA_VERSION_NUM >= 502  // Lua >= 5.2
 	// Set the global environment
 	lua_rawseti(L, LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS);
 #else  // Lua <= 5.1

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -226,6 +226,10 @@ bool ScriptApiSecurity::safeLoadFile(lua_State * L, const char * path)
 		chunk_name = const_cast<char *>("=stdin");
 	} else {
 		fp = fopen(path, "r");
+		if (fp == NULL) {
+			lua_pushfstring(L, "%s: %s", path, strerror(errno));
+			return false;
+		}
 		chunk_name = new char[strlen(path) + 2];
 		chunk_name[0] = '@';
 		chunk_name[1] = '\0';

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -110,6 +110,12 @@ void ScriptApiSecurity::initializeSecurity()
 		"getupvalue",
 		"setlocal",
 	};
+	static const char * package_whitelist[] = {
+		"config",
+		"searchpath",
+		"cpath",
+		"path",
+	};
 	static const char * jit_whitelist[] = {
 		"arch",
 		"flush",
@@ -159,6 +165,7 @@ void ScriptApiSecurity::initializeSecurity()
 	SECURE_API(load);
 	SECURE_API(loadfile);
 	SECURE_API(loadstring);
+	SECURE_API(require);
 	lua_pop(L, 1);
 
 	// Copy safe IO functions
@@ -188,6 +195,13 @@ void ScriptApiSecurity::initializeSecurity()
 	COPY_SAFE(debug_whitelist);
 	lua_setglobal(L, "debug");
 	lua_pop(L, 1);  // Pop backup debug
+
+	// Copy safe package fields
+	lua_getfield(L, -1, "package");
+	lua_newtable(L);
+	COPY_SAFE(package_whitelist);
+	lua_setglobal(L, "package");
+	lua_pop(L, 1);  // Pop backup package
 
 	// Copy safe jit functions, if they exist
 	lua_getfield(L, -1, "jit");
@@ -454,6 +468,13 @@ int ScriptApiSecurity::sl_g_loadstring(lua_State * L)
 		return 2;
 	}
 	return 1;
+}
+
+
+int ScriptApiSecurity::sl_g_require(lua_State * L)
+{
+	lua_pushliteral(L, "require() is disabled when mod security is on.");
+	return lua_error(L);
 }
 
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -224,7 +224,7 @@ bool ScriptApiSecurity::safeLoadFile(lua_State * L, const char * path)
 	}
 
 	size_t start = 0;
-	char c = std::getc(fp);
+	int c = std::getc(fp);
 	if (c == '#') {
 		// Skip the first line
 		while ((c = std::getc(fp)) != EOF && c != '\n');

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -115,6 +115,17 @@ void ScriptApiSecurity::initializeSecurity()
 		"getupvalue",
 		"setlocal",
 	};
+	static const char * jit_whitelist[] = {
+		"arch",
+		"flush",
+		"off",
+		"on",
+		"opt",
+		"os",
+		"status",
+		"version",
+		"version_num",
+	};
 
 	m_secure = true;
 
@@ -182,6 +193,15 @@ void ScriptApiSecurity::initializeSecurity()
 	COPY_SAFE(debug_whitelist);
 	lua_setglobal(L, "debug");
 	lua_pop(L, 1);  // Pop backup debug
+
+	// Copy safe jit functions, if they exist
+	lua_getfield(L, -1, "jit");
+	if (!lua_isnil(L, -1)) {
+		lua_newtable(L);
+		COPY_SAFE(jit_whitelist);
+		lua_setglobal(L, "jit");
+	}
+	lua_pop(L, 1);  // Pop backup jit
 
 	lua_pop(L, 1); // Pop globals_backup
 }

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -79,11 +79,11 @@ void ScriptApiSecurity::initializeSecurity()
 		"math",
 	};
 	static const char * io_whitelist[] = {
-		"read",
-		"write",
-		"flush",
-		"type",
 		"close",
+		"flush",
+		"read",
+		"type",
+		"write",
 	};
 	static const char * os_whitelist[] = {
 		"clock",
@@ -176,6 +176,7 @@ void ScriptApiSecurity::initializeSecurity()
 	SECURE_LIB_API(io, open);
 	SECURE_LIB_API(io, input);
 	SECURE_LIB_API(io, output);
+	SECURE_LIB_API(io, lines);
 	lua_setglobal(L, "io");
 	lua_pop(L, 1);  // Pop backup IO
 
@@ -517,6 +518,23 @@ int ScriptApiSecurity::sl_io_output(lua_State * L)
 	lua_pushvalue(L, 1);
 	lua_call(L, 1, 1);
 	return 1;
+}
+
+
+int ScriptApiSecurity::sl_io_lines(lua_State * L)
+{
+	if (lua_isstring(L, 1)) {
+		const char * path = lua_tostring(L, 1);
+		CHECK_SECURE_PATH(L, path);
+	}
+
+	GET_ORIGINAL("io", "lines");
+	lua_pushvalue(L, 1);
+	int top_precall = lua_gettop(L);
+	lua_call(L, 1, LUA_MULTRET);
+	// Return number of arguments returned by the function,
+	// adjusting for the function being poped.
+	return lua_gettop(L) - (top_precall - 1);
 }
 
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1,0 +1,472 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "cpp_api/s_security.h"
+#include "filesys.h"
+#include "porting.h"
+#include "server.h"
+#include <string>
+
+#define SECURE_LIB_API(lib, name) \
+	lua_pushcfunction(L, sl_##lib##_##name);\
+	lua_setfield(L, -2, #name);
+
+#define SECURE_API(name) SECURE_LIB_API(g, name)
+
+// Copies from second-top-most to top-most table
+#define COPY_SAFE(list) \
+	for (unsigned i = 0; i < (sizeof(list) / sizeof(list[0])); i++) {\
+		lua_getfield(L, -2, list[i]);\
+		lua_setfield(L, -2, list[i]);\
+	}
+
+#define CHECK_PATH(path) \
+	if (!checkPath(L, path)) {\
+		lua_pushstring(L, (std::string("Attempt to access external file ") +\
+					path + " with mod security on.").c_str());\
+		lua_error(L);\
+	}
+
+#define GET_ORIGINAL(lib, func) \
+	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");\
+	lua_getfield(L, -1, lib);\
+	lua_remove(L, -2);  /* Remove globals_backup */\
+	lua_getfield(L, -1, func);\
+	lua_remove(L, -2);  /* Remove lib */
+
+
+void ScriptApiSecurity::initializeSecurity()
+{
+	static const char * whitelist[] = {
+		"assert",
+		"core",
+		"collectgarbage",
+		"DIR_DELIM",
+		"error",
+		"getfenv",
+		"getmetatable",
+		"ipairs",
+		"next",
+		"pairs",
+		"pcall",
+		"print",
+		"rawequal",
+		"rawget",
+		"rawset",
+		"select",
+		"setfenv",
+		"setmetatable",
+		"tonumber",
+		"tostring",
+		"type",
+		"unpack",
+		"_VERSION",
+		"xpcall",
+		"coroutine",
+		"string",
+		"table",
+		"math",
+	};
+	static const char * io_whitelist[] = {
+		"read",
+		"write",
+		"flush",
+		"type",
+		"close",
+	};
+	static const char * os_whitelist[] = {
+		"clock",
+		"date",
+		"difftime",
+		"exit",
+		"getenv",
+		"setlocale",
+		"time",
+		"tmpname",
+	};
+	static const char * debug_whitelist[] = {
+		"gethook",
+		"traceback",
+		"getinfo",
+		"getmetatable",
+		"setupvalue",
+		"setmetatable",
+		"upvalueid",
+		"upvaluejoin",
+		"sethook",
+		"getlocal",
+		"debug",
+		"getupvalue",
+		"setlocal",
+	};
+
+	m_secure = true;
+
+	lua_State * L = getStack();
+
+	// Backup globals to the registry
+	lua_getglobal(L, "_G");
+	lua_setfield(L, LUA_REGISTRYINDEX, "globals_backup");
+
+	// Replace the global environment with an empty one
+#if LUA_VERSION_NUM <= 501
+	int is_main = lua_pushthread(L);  // Push the main thread
+	assert(is_main);
+#endif
+	lua_newtable(L);  // Create new environment
+	lua_pushvalue(L, -1);
+	lua_setfield(L, -2, "_G");  // Set _G of new environment
+#if LUA_VERSION_NUM >= 502  // Lua >= 5.2 (untested)
+	// Set the global environment
+	lua_rawseti(L, LUA_REGISTRYINDEX, LUA_RIDX_GLOBALS);
+#else  // Lua <= 5.1
+	// Set the environment of the main thread
+	int ok = lua_setfenv(L, -2);
+	assert(ok);
+	lua_pop(L, 1);  // Pop thread
+#endif
+
+	// Copy over safe things
+	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+
+	// Copy safe globals
+	lua_getglobal(L, "_G");
+	COPY_SAFE(whitelist);
+	// And replace unsafe ones
+	SECURE_API(dofile);
+	SECURE_API(load);
+	SECURE_API(loadfile);
+	SECURE_API(loadstring);
+	lua_pop(L, 1);
+
+	// Copy safe IO functions
+	lua_getfield(L, -1, "io");
+	lua_newtable(L);
+	COPY_SAFE(io_whitelist);
+	// And replace unsafe ones
+	SECURE_LIB_API(io, open);
+	SECURE_LIB_API(io, input);
+	SECURE_LIB_API(io, output);
+	lua_setglobal(L, "io");
+	lua_pop(L, 1);  // Pop backup IO
+
+	// Copy safe OS functions
+	lua_getfield(L, -1, "os");
+	lua_newtable(L);
+	COPY_SAFE(os_whitelist);
+	// And replace unsafe ones
+	SECURE_LIB_API(os, remove);
+	SECURE_LIB_API(os, rename);
+	lua_setglobal(L, "os");
+	lua_pop(L, 1);  // Pop backup OS
+
+	// Copy safe debug functions
+	lua_getfield(L, -1, "debug");
+	lua_newtable(L);
+	COPY_SAFE(debug_whitelist);
+	lua_setglobal(L, "debug");
+	lua_pop(L, 1);  // Pop backup debug
+
+	lua_pop(L, 1); // Pop globals_backup
+}
+
+
+bool ScriptApiSecurity::safeLoadFile(lua_State * L, const char * path)
+{
+	FILE * fp;
+	char * chunk_name;
+	if (path == NULL) {
+		fp = stdin;
+		chunk_name = const_cast<char *>("=stdin");
+	} else {
+		fp = fopen(path, "r");
+		chunk_name = new char[strlen(path) + 2];
+		chunk_name[0] = '@';
+		strcat(chunk_name, path);
+	}
+
+	size_t start = 0;
+	char c = std::getc(fp);
+	if (c == '#') {
+		// Skip the first line
+		while ((c = std::getc(fp)) != EOF && c != '\n');
+		if (c == '\n') c = std::getc(fp);
+		start = std::ftell(fp);
+	}
+
+	if (c == LUA_SIGNATURE[0]) {
+		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
+		return false;
+	}
+
+	// Read the file
+	std::fseek(fp, 0, SEEK_END);
+	size_t size = std::ftell(fp) - start;
+	char * code = new char[size];
+	std::fseek(fp, start, SEEK_SET);
+	size_t num_read = std::fread(code, 1, size, fp);
+	if (path) {
+		std::fclose(fp);
+	}
+	if (num_read != size) {
+		lua_pushliteral(L, "Error reading file to load.");
+		return false;
+	}
+
+	if (luaL_loadbuffer(L, code, size, chunk_name)) {
+		return false;
+	}
+
+	if (path) {
+		delete [] chunk_name;
+	}
+	return true;
+}
+
+
+#define ALLOW_IN_PATH(allow_path) \
+	str = fs::AbsolutePath(allow_path);\
+	if (!str.empty() &&\
+			fs::PathStartsWith(abs_path, str)) {\
+		return true;\
+	}
+
+bool ScriptApiSecurity::checkPath(lua_State * L, const char * path)
+{
+	std::string str;  // Transient
+
+	// First remove last component to allow opening non-existing files
+	std::string abs_path = fs::RemoveLastPathComponent(path, &str);
+	// Don't allow modifying minetest.conf
+	if (str == "minetest.conf") {
+		return false;
+	}
+
+	// Get absolute path
+	abs_path = fs::AbsolutePath(abs_path);
+	if (abs_path.empty()) {
+		return false;
+	}
+
+	// Get server from registry
+	lua_getfield(L, LUA_REGISTRYINDEX, "scriptapi");
+	ScriptApiBase *script = (ScriptApiBase*) lua_touserdata(L, -1);
+	lua_pop(L, 1);
+	const Server *server = script->getServer();
+
+	if (server) {
+		// Allow paths in world path
+		ALLOW_IN_PATH(server->getWorldPath());
+
+		// Get modname and allow paths in modpath if possible
+		lua_getfield(L, LUA_REGISTRYINDEX, "current_modname");
+		if (lua_isstring(L, -1)) {
+			std::string modname = lua_tostring(L, -1);
+			const ModSpec *mod = server->getModSpec(modname);
+			if (mod) {
+				ALLOW_IN_PATH(mod->path);
+			}
+		}
+		lua_pop(L, 1);
+	}
+
+	// Allow paths in user path
+	ALLOW_IN_PATH(porting::path_user);
+
+	// Allow paths in share path
+	ALLOW_IN_PATH(porting::path_share);
+
+	return false;
+}
+
+
+int ScriptApiSecurity::sl_g_dofile(lua_State * L)
+{
+	int nret = sl_g_loadfile(L);
+	if (nret != 1) {
+		return nret;
+	}
+	int top_precall = lua_gettop(L);
+	lua_call(L, 0, LUA_MULTRET);
+	// Return number of arguments returned by the function,
+	// adjusting for the function being poped.
+	return lua_gettop(L) - (top_precall - 1);
+}
+
+
+int ScriptApiSecurity::sl_g_load(lua_State * L)
+{
+	size_t len;
+	const char * buf;
+	std::string code;
+	const char * chunk_name = "=(load)";
+
+	luaL_checktype(L, 1, LUA_TFUNCTION);
+	if (!lua_isnone(L, 2)) {
+		luaL_checktype(L, 2, LUA_TSTRING);
+		chunk_name = lua_tostring(L, 2);
+	}
+
+	while (true) {
+		lua_pushvalue(L, 1);
+		lua_call(L, 0, 1);
+		int t = lua_type(L, -1);
+		if (t == LUA_TNIL) {
+			break;
+		} else if (t != LUA_TSTRING) {
+			lua_pushnil(L);
+			lua_pushliteral(L, "Loader didn't return a string");
+			return 2;
+		}
+		buf = lua_tolstring(L, -1, &len);
+		code += std::string(buf, len);
+		lua_pop(L, 1); // Pop return value
+	}
+	if (code[0] == LUA_SIGNATURE[0]) {
+		lua_pushnil(L);
+		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
+		return 2;
+	}
+	if (luaL_loadbuffer(L, code.data(), code.size(), chunk_name)) {
+		lua_pushnil(L);
+		lua_insert(L, lua_gettop(L) - 1);
+		return 2;
+	}
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_g_loadfile(lua_State * L)
+{
+	const char * path = NULL;
+
+	if (lua_isstring(L, 1)) {
+		path = lua_tostring(L, 1);
+		CHECK_PATH(path);
+	}
+
+	if (!safeLoadFile(L, path)) {
+		lua_pushnil(L);
+		lua_insert(L, -2);
+		return 2;
+	}
+
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_g_loadstring(lua_State * L)
+{
+	const char * chunk_name = "=(load)";
+
+	luaL_checktype(L, 1, LUA_TSTRING);
+	if (!lua_isnone(L, 2)) {
+		luaL_checktype(L, 2, LUA_TSTRING);
+		chunk_name = lua_tostring(L, 2);
+	}
+
+	size_t size;
+	const char * code = lua_tolstring(L, 1, &size);
+
+	if (size > 0 && code[0] == LUA_SIGNATURE[0]) {
+		lua_pushnil(L);
+		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
+		return 2;
+	}
+	if (luaL_loadbuffer(L, code, size, chunk_name)) {
+		lua_pushnil(L);
+		lua_insert(L, lua_gettop(L) - 1);
+		return 2;
+	}
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_io_open(lua_State * L)
+{
+	luaL_checktype(L, 1, LUA_TSTRING);
+	const char * path = lua_tostring(L, 1);
+	CHECK_PATH(path);
+
+	GET_ORIGINAL("io", "open");
+	lua_pushvalue(L, 1);
+	lua_pushvalue(L, 2);
+	lua_call(L, 2, 2);
+	return 2;
+}
+
+
+int ScriptApiSecurity::sl_io_input(lua_State * L)
+{
+	if (lua_isstring(L, 1)) {
+		const char * path = lua_tostring(L, 1);
+		CHECK_PATH(path);
+	}
+
+	GET_ORIGINAL("io", "input");
+	lua_pushvalue(L, 1);
+	lua_call(L, 1, 1);
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_io_output(lua_State * L)
+{
+	if (lua_isstring(L, 1)) {
+		const char * path = lua_tostring(L, 1);
+		CHECK_PATH(path);
+	}
+
+	GET_ORIGINAL("io", "output");
+	lua_pushvalue(L, 1);
+	lua_call(L, 1, 1);
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_os_rename(lua_State * L)
+{
+	luaL_checktype(L, 1, LUA_TSTRING);
+	const char * path1 = lua_tostring(L, 1);
+	CHECK_PATH(path1);
+
+	luaL_checktype(L, 2, LUA_TSTRING);
+	const char * path2 = lua_tostring(L, 2);
+	CHECK_PATH(path2);
+
+	GET_ORIGINAL("os", "rename");
+	lua_pushvalue(L, 1);
+	lua_pushvalue(L, 2);
+	lua_call(L, 2, 2);
+	return 2;
+}
+
+
+int ScriptApiSecurity::sl_os_remove(lua_State * L)
+{
+	luaL_checktype(L, 1, LUA_TSTRING);
+	const char * path = lua_tostring(L, 1);
+	CHECK_PATH(path);
+
+	GET_ORIGINAL("os", "remove");
+	lua_pushvalue(L, 1);
+	lua_call(L, 1, 2);
+	return 2;
+}
+

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -208,6 +208,15 @@ void ScriptApiSecurity::initializeSecurity()
 }
 
 
+bool ScriptApiSecurity::isSecure(lua_State * L)
+{
+	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	bool secure = !lua_isnil(L, -1);
+	lua_pop(L, 1);
+	return secure;
+}
+
+
 bool ScriptApiSecurity::safeLoadFile(lua_State * L, const char * path)
 {
 	FILE * fp;

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -319,14 +319,14 @@ bool ScriptApiSecurity::checkPath(lua_State * L, const char * path)
 		lua_pop(L, 1);
 	}
 
-	// Allow paths in user path
-	ALLOW_IN_PATH(porting::path_user);
-
 	// Don't allow accessing binaries
 	DISALLOW_IN_PATH(porting::path_share + DIR_DELIM "bin");
 
 	// Don't allow accessing utility scripts
 	DISALLOW_IN_PATH(porting::path_share + DIR_DELIM "util");
+
+	// Allow paths in user path
+	ALLOW_IN_PATH(porting::path_user);
 
 	// Allow paths in share path
 	ALLOW_IN_PATH(porting::path_share);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -198,6 +198,7 @@ bool ScriptApiSecurity::safeLoadFile(lua_State * L, const char * path)
 		fp = fopen(path, "r");
 		chunk_name = new char[strlen(path) + 2];
 		chunk_name[0] = '@';
+		chunk_name[1] = '\0';
 		strcat(chunk_name, path);
 	}
 
@@ -288,6 +289,18 @@ bool ScriptApiSecurity::checkPath(lua_State * L, const char * path)
 
 	// Allow paths in user path
 	ALLOW_IN_PATH(porting::path_user);
+
+	// Don't allow accessing binaries
+	str = fs::AbsolutePath(porting::path_share + DIR_DELIM "bin");
+	if (str.empty() || fs::PathStartsWith(abs_path, str)) {
+		return false;
+	}
+
+	// Don't allow accessing utility scripts
+	str = fs::AbsolutePath(porting::path_share + DIR_DELIM "util");
+	if (!str.empty() && fs::PathStartsWith(abs_path, str)) {
+		return false;
+	}
 
 	// Allow paths in share path
 	ALLOW_IN_PATH(porting::path_share);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -105,7 +105,6 @@ void ScriptApiSecurity::initializeSecurity()
 		"upvalueid",
 		"upvaluejoin",
 		"sethook",
-		"getlocal",
 		"debug",
 		"getupvalue",
 		"setlocal",

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -1,0 +1,52 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef S_SECURITY_H
+#define S_SECURITY_H
+
+#include "cpp_api/s_base.h"
+
+class ScriptApiSecurity : virtual public ScriptApiBase
+{
+public:
+	void initializeSecurity();
+	static bool safeLoadFile(lua_State * L, const char * path);
+
+private:
+	// Checks if mods are allowed to read and write to the path
+	static bool checkPath(lua_State * L, const char * path);
+
+	// Syntax: "sl_" <Library name or 'g' (global)> '_' <Function name>
+	// (sl stands for Secure Lua)
+
+	static int sl_g_dofile(lua_State * L);
+	static int sl_g_load(lua_State * L);
+	static int sl_g_loadfile(lua_State * L);
+	static int sl_g_loadstring(lua_State * L);
+
+	static int sl_io_open(lua_State * L);
+	static int sl_io_input(lua_State * L);
+	static int sl_io_output(lua_State * L);
+
+	static int sl_os_rename(lua_State * L);
+	static int sl_os_remove(lua_State * L);
+};
+
+#endif
+

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -25,13 +25,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class ScriptApiSecurity : virtual public ScriptApiBase
 {
 public:
+	// Sets up security on the ScriptApi's Lua state
 	void initializeSecurity();
+	// Checks if the Lua state has been secured
+	static bool isSecure(lua_State * L);
+	// Loads a file as Lua code safely (doesn't allow bytecode).
 	static bool safeLoadFile(lua_State * L, const char * path);
-
-private:
 	// Checks if mods are allowed to read and write to the path
 	static bool checkPath(lua_State * L, const char * path);
 
+private:
 	// Syntax: "sl_" <Library name or 'g' (global)> '_' <Function name>
 	// (sl stands for Secure Lua)
 

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -50,6 +50,7 @@ private:
 	static int sl_g_load(lua_State * L);
 	static int sl_g_loadfile(lua_State * L);
 	static int sl_g_loadstring(lua_State * L);
+	static int sl_g_require(lua_State * L);
 
 	static int sl_io_open(lua_State * L);
 	static int sl_io_input(lua_State * L);

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -22,6 +22,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 
+#define CHECK_SECURE_PATH(L, path) \
+	if (!ScriptApiSecurity::checkPath(L, path)) {\
+		lua_pushstring(L, (std::string("Attempt to access external file ") +\
+					path + " with mod security on.").c_str());\
+		lua_error(L);\
+	}
+
+
 class ScriptApiSecurity : virtual public ScriptApiBase
 {
 public:

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -55,6 +55,7 @@ private:
 	static int sl_io_open(lua_State * L);
 	static int sl_io_input(lua_State * L);
 	static int sl_io_output(lua_State * L);
+	static int sl_io_lines(lua_State * L);
 
 	static int sl_os_rename(lua_State * L);
 	static int sl_os_remove(lua_State * L);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_vmanip.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "cpp_api/s_security.h"
 #include "util/serialize.h"
 #include "server.h"
 #include "environment.h"
@@ -755,6 +756,10 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 {
 	Schematic schem;
 
+	const char *filename = luaL_checkstring(L, 4);
+
+	CHECK_SECURE_PATH(L, filename);
+
 	Map *map = &(getEnv(L)->getMap());
 	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
@@ -792,8 +797,6 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 			lua_pop(L, 1);
 		}
 	}
-
-	const char *filename = luaL_checkstring(L, 4);
 
 	if (!schem.getSchematicFromMap(map, p1, p2)) {
 		errorstream << "create_schematic: failed to get schematic "

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_internal.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "cpp_api/s_base.h"
 #include "server.h"
 #include "environment.h"
 #include "player.h"
@@ -342,7 +343,7 @@ int ModApiServer::l_show_formspec(lua_State *L)
 int ModApiServer::l_get_current_modname(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	lua_getfield(L, LUA_REGISTRYINDEX, "current_modname");
+	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
 	return 1;
 }
 

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_settings.h"
 #include "lua_api/l_internal.h"
+#include "cpp_api/s_security.h"
 #include "settings.h"
 #include "log.h"
 
@@ -188,6 +189,11 @@ int LuaSettings::create_object(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char* filename = luaL_checkstring(L, 1);
+	if (ScriptApiSecurity::isSecure(L) &&
+			!ScriptApiSecurity::checkPath(L, filename)) {
+		lua_pushliteral(L, "Settings path not allowed.");
+		lua_error(L);
+	}
 	LuaSettings* o = new LuaSettings(filename);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -189,10 +189,8 @@ int LuaSettings::create_object(lua_State* L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char* filename = luaL_checkstring(L, 1);
-	if (ScriptApiSecurity::isSecure(L) &&
-			!ScriptApiSecurity::checkPath(L, filename)) {
-		lua_pushliteral(L, "Settings path not allowed.");
-		lua_error(L);
+	if (ScriptApiSecurity::isSecure(L)) {
+		CHECK_SECURE_PATH(L, filename);
 	}
 	LuaSettings* o = new LuaSettings(filename);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_async.h"
 #include "serialization.h"
 #include "json/json.h"
+#include "cpp_api/s_security.h"
 #include "debug.h"
 #include "porting.h"
 #include "log.h"
@@ -337,6 +338,19 @@ int ModApiUtil::l_decompress(lua_State *L)
 	return 1;
 }
 
+// mkdir(path)
+int ModApiUtil::l_mkdir(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	const char *path = luaL_checkstring(L, 1);
+	if (ScriptApiSecurity::isSecure(L)) {
+		CHECK_SECURE_PATH(L, path);
+	}
+	lua_pushboolean(L, fs::CreateAllDirs(path));
+	return 1;
+}
+
+
 void ModApiUtil::Initialize(lua_State *L, int top)
 {
 	API_FCT(debug);
@@ -362,6 +376,8 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 
 	API_FCT(compress);
 	API_FCT(decompress);
+
+	API_FCT(mkdir);
 }
 
 void ModApiUtil::InitializeAsync(AsyncEngine& engine)
@@ -384,5 +400,7 @@ void ModApiUtil::InitializeAsync(AsyncEngine& engine)
 
 	ASYNC_API_FCT(compress);
 	ASYNC_API_FCT(decompress);
+
+	ASYNC_API_FCT(mkdir);
 }
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -93,8 +93,8 @@ int ModApiUtil::l_log(lua_State *L)
 }
 
 #define CHECK_SECURE_SETTING() \
-	if (name.compare(0, 6, "secure_", 7) == 0) {\
-		lua_pushstring(L, "Attempt to set secure setting.");\
+	if (name.compare(0, 7, "secure_", 7) == 0) {\
+		lua_pushliteral(L, "Attempt to set secure setting.");\
 		lua_error(L);\
 	}
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -100,7 +100,7 @@ int ModApiUtil::l_log(lua_State *L)
 		lua_pushliteral(L, "Bad setting name, only [A-Za-z0-9_-.] allowed.");\
 		lua_error(L);\
 	}\
-	if (name.compare(0, 7, "secure_", 7) == 0) {\
+	if (name.compare(0, 7, "secure.") == 0) {\
 		lua_pushliteral(L, "Attempt to set secure setting.");\
 		lua_error(L);\
 	}
@@ -364,7 +364,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State * L)
 		return 1;
 	}
 	const char * mod_name = lua_tostring(L, -1);
-	std::string trusted_mods = g_settings->get("secure_trusted_mods");
+	std::string trusted_mods = g_settings->get("secure.trusted_mods");
 	std::vector<std::string> mod_list = str_split(trusted_mods, ',');
 	if (std::find(mod_list.begin(), mod_list.end(), mod_name) == mod_list.end()) {
 		lua_pushnil(L);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -94,12 +94,7 @@ int ModApiUtil::l_log(lua_State *L)
 	return 0;
 }
 
-#define SETTING_ALLOWED_CHARS "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-."
-#define CHECK_SETTING() \
-	if (!string_allowed(name, SETTING_ALLOWED_CHARS)) {\
-		lua_pushliteral(L, "Bad setting name, only [A-Za-z0-9_-.] allowed.");\
-		lua_error(L);\
-	}\
+#define CHECK_SECURE_SETTING(L, name) \
 	if (name.compare(0, 7, "secure.") == 0) {\
 		lua_pushliteral(L, "Attempt to set secure setting.");\
 		lua_error(L);\
@@ -111,11 +106,7 @@ int ModApiUtil::l_setting_set(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	std::string name = luaL_checkstring(L, 1);
 	std::string value = luaL_checkstring(L, 2);
-	if (value.find_first_of("\r\n") != std::string::npos) {
-		lua_pushliteral(L, "Bad setting value, newlines not allowed.");
-		lua_error(L);
-	}
-	CHECK_SETTING();
+	CHECK_SECURE_SETTING(L, name);
 	g_settings->set(name, value);
 	return 0;
 }
@@ -140,7 +131,7 @@ int ModApiUtil::l_setting_setbool(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	std::string name = luaL_checkstring(L, 1);
 	bool value = lua_toboolean(L, 2);
-	CHECK_SETTING();
+	CHECK_SECURE_SETTING(L, name);
 	g_settings->setBool(name, value);
 	return 0;
 }

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -358,7 +358,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State * L)
 		lua_getglobal(L, "_G");
 		return 1;
 	}
-	lua_getfield(L, LUA_REGISTRYINDEX, "current_modname");
+	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
 	if (!lua_isstring(L, -1)) {
 		lua_pushnil(L);
 		return 1;

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -92,12 +92,19 @@ int ModApiUtil::l_log(lua_State *L)
 	return 0;
 }
 
+#define CHECK_SECURE_SETTING() \
+	if (name.compare(0, 6, "secure_", 7) == 0) {\
+		lua_pushstring(L, "Attempt to set secure setting.");\
+		lua_error(L);\
+	}
+
 // setting_set(name, value)
 int ModApiUtil::l_setting_set(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	const char *name = luaL_checkstring(L, 1);
+	std::string name = trim(luaL_checkstring(L, 1));
 	const char *value = luaL_checkstring(L, 2);
+	CHECK_SECURE_SETTING();
 	g_settings->set(name, value);
 	return 0;
 }
@@ -108,7 +115,7 @@ int ModApiUtil::l_setting_get(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
 	try{
-		std::string value = g_settings->get(name);
+		std::string value = g_settings->get(trim(name));
 		lua_pushstring(L, value.c_str());
 	} catch(SettingNotFoundException &e){
 		lua_pushnil(L);
@@ -120,8 +127,9 @@ int ModApiUtil::l_setting_get(lua_State *L)
 int ModApiUtil::l_setting_setbool(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	const char *name = luaL_checkstring(L, 1);
+	std::string name = trim(luaL_checkstring(L, 1));
 	bool value = lua_toboolean(L, 2);
+	CHECK_SECURE_SETTING();
 	g_settings->setBool(name, value);
 	return 0;
 }
@@ -132,7 +140,7 @@ int ModApiUtil::l_setting_getbool(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
 	try{
-		bool value = g_settings->getBool(name);
+		bool value = g_settings->getBool(trim(name));
 		lua_pushboolean(L, value);
 	} catch(SettingNotFoundException &e){
 		lua_pushnil(L);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -78,7 +78,7 @@ private:
 	// is_yes(arg)
 	static int l_is_yes(lua_State *L);
 
-	// get_scriptdir()
+	// get_builtin_path()
 	static int l_get_builtin_path(lua_State *L);
 
 	// compress(data, method, ...)
@@ -86,6 +86,9 @@ private:
 
 	// decompress(data, method, ...)
 	static int l_decompress(lua_State *L);
+
+	// mkdir(path)
+	static int l_mkdir(lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -90,6 +90,9 @@ private:
 	// mkdir(path)
 	static int l_mkdir(lua_State *L);
 
+	// request_insecure_environment()
+	static int l_request_insecure_environment(lua_State * L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 

--- a/src/script/scripting_game.cpp
+++ b/src/script/scripting_game.cpp
@@ -53,7 +53,7 @@ GameScripting::GameScripting(Server* server)
 
 	SCRIPTAPI_PRECHECKHEADER
 
-	if (g_settings->getBool("secure_mod_api")) {
+	if (g_settings->getBool("secure.enable_security")) {
 		initializeSecurity();
 	}
 

--- a/src/script/scripting_game.cpp
+++ b/src/script/scripting_game.cpp
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "scripting_game.h"
 #include "server.h"
 #include "log.h"
+#include "main.h"
+#include "settings.h"
 #include "cpp_api/s_internal.h"
 #include "lua_api/l_base.h"
 #include "lua_api/l_craft.h"
@@ -49,9 +51,11 @@ GameScripting::GameScripting(Server* server)
 	// setEnv(env) is called by ScriptApiEnv::initializeEnvironment()
 	// once the environment has been created
 
-	//TODO add security
-
 	SCRIPTAPI_PRECHECKHEADER
+
+	if (g_settings->getBool("secure_mod_api")) {
+		initializeSecurity();
+	}
 
 	lua_getglobal(L, "core");
 	int top = lua_gettop(L);

--- a/src/script/scripting_game.h
+++ b/src/script/scripting_game.h
@@ -27,19 +27,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_node.h"
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_server.h"
+#include "cpp_api/s_security.h"
 
 /*****************************************************************************/
 /* Scripting <-> Game Interface                                              */
 /*****************************************************************************/
 
-class GameScripting
-		: virtual public ScriptApiBase,
-		  public ScriptApiDetached,
-		  public ScriptApiEntity,
-		  public ScriptApiEnv,
-		  public ScriptApiNode,
-		  public ScriptApiPlayer,
-		  public ScriptApiServer
+class GameScripting :
+		virtual public ScriptApiBase,
+		public ScriptApiDetached,
+		public ScriptApiEntity,
+		public ScriptApiEnv,
+		public ScriptApiNode,
+		public ScriptApiPlayer,
+		public ScriptApiServer,
+		public ScriptApiSecurity
 {
 public:
 	GameScripting(Server* server);

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -38,8 +38,6 @@ MainMenuScripting::MainMenuScripting(GUIEngine* guiengine)
 {
 	setGuiEngine(guiengine);
 
-	//TODO add security
-
 	SCRIPTAPI_PRECHECKHEADER
 
 	lua_getglobal(L, "core");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -307,31 +307,37 @@ Server::Server(
 
 	m_script = new GameScripting(this);
 
-	std::string scriptpath = getBuiltinLuaPath() + DIR_DELIM "init.lua";
+	std::string script_path = getBuiltinLuaPath() + DIR_DELIM "init.lua";
 
-	if (!m_script->loadScript(scriptpath))
-		throw ModError("Failed to load and run " + scriptpath);
-
-	// Print 'em
-	infostream<<"Server: Loading mods: ";
-	for(std::vector<ModSpec>::iterator i = m_mods.begin();
-			i != m_mods.end(); i++){
-		const ModSpec &mod = *i;
-		infostream<<mod.name<<" ";
+	if (!m_script->loadMod(script_path, BUILTIN_MOD_NAME)) {
+		throw ModError("Failed to load and run " + script_path);
 	}
-	infostream<<std::endl;
-	// Load and run "mod" scripts
+
+	// Print mods
+	infostream << "Server: Loading mods: ";
 	for(std::vector<ModSpec>::iterator i = m_mods.begin();
 			i != m_mods.end(); i++){
 		const ModSpec &mod = *i;
-		std::string scriptpath = mod.path + DIR_DELIM + "init.lua";
-		infostream<<"  ["<<padStringRight(mod.name, 12)<<"] [\""
-				<<scriptpath<<"\"]"<<std::endl;
-		bool success = m_script->loadMod(scriptpath, mod.name);
-		if(!success){
-			errorstream<<"Server: Failed to load and run "
-					<<scriptpath<<std::endl;
-			throw ModError("Failed to load and run "+scriptpath);
+		infostream << mod.name << " ";
+	}
+	infostream << std::endl;
+	// Load and run "mod" scripts
+	for (std::vector<ModSpec>::iterator i = m_mods.begin();
+			i != m_mods.end(); i++) {
+		const ModSpec &mod = *i;
+		if (!string_allowed(mod.name, MODNAME_ALLOWED_CHARS)) {
+			errorstream << "Error loading mod \"" << mod.name
+					<< "\": mod_name does not follow naming conventions: "
+					<< "Only chararacters [a-z0-9_] are allowed." << std::endl;
+			throw ModError("Mod \"" + mod.name + "\" does not follow naming conventions.");
+		}
+		std::string script_path = mod.path + DIR_DELIM "init.lua";
+		infostream << "  [" << padStringRight(mod.name, 12) << "] [\""
+				<< script_path << "\"]" << std::endl;
+		if (!m_script->loadMod(script_path, mod.name)) {
+			errorstream << "Server: Failed to load and run "
+					<< script_path << std::endl;
+			throw ModError("Failed to load and run " + script_path);
 		}
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4928,9 +4928,9 @@ IWritableCraftDefManager* Server::getWritableCraftDefManager()
 	return m_craftdef;
 }
 
-const ModSpec* Server::getModSpec(const std::string &modname)
+const ModSpec* Server::getModSpec(const std::string &modname) const
 {
-	for(std::vector<ModSpec>::iterator i = m_mods.begin();
+	for(std::vector<ModSpec>::const_iterator i = m_mods.begin();
 			i != m_mods.end(); i++){
 		const ModSpec &mod = *i;
 		if(mod.name == modname)

--- a/src/server.h
+++ b/src/server.h
@@ -294,10 +294,10 @@ public:
 	IWritableNodeDefManager* getWritableNodeDefManager();
 	IWritableCraftDefManager* getWritableCraftDefManager();
 
-	const ModSpec* getModSpec(const std::string &modname);
+	const ModSpec* getModSpec(const std::string &modname) const;
 	void getModNames(std::list<std::string> &modlist);
 	std::string getBuiltinLuaPath();
-	inline std::string getWorldPath()
+	inline std::string getWorldPath() const
 			{ return m_path_world; }
 
 	inline bool isSingleplayer()


### PR DESCRIPTION
This preserves compatibility with most mods.

Things that you can't do anymore:
  * Access any files not in the mod or world path.
  * Run Lua bytecode (it's insecure).
  * Use `require()`, `package.loadlib()` and the like (they can load C modules).
  * Use `os.execute()` or `io.popen()` to run shell commands.
  * Use the registry (insecure env is stored there).
  * Get/set user values (may be unsafe, Lua 5.2 feature anyway).
  * Get locals of the caller with the debug library (can be used to steal an insecure env).

You can do just about anything else, including using `getfenv` / `setfenv` and `getmetatable` / `setmetatable` (these functions are only dangerous if the sandbox is created from Lua).

Mods that **NEED** access to insecure functions (very few do) can use `minetest.request_insecure_environment()` to get the original globals table with all insecure functions included.  This function will only work if the user adds the mod to their `secure_trusted_mods` setting or has mod security disabled.

I'd appreciate any comments on other possible security holes.
