### PR TITLE
Search for subgames using $MINETEST_SUBGAME_PATH.

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -83,6 +83,12 @@ Set world path
 Migrate from current map backend to another. Possible values are sqlite3
 and leveldb. Only works when using --server.
 
+.SH ENVIRONMENT VARIABLES
+
+.TP
+MINETEST_SUBGAME_PATH
+Colon delimited list of directories to search for subgames.
+
 .SH BUGS
 Please report all bugs to Perttu Ahola <celeron55@gmail.com>.
 

--- a/src/subgame.cpp
+++ b/src/subgame.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 #include "log.h"
+#include "strfnd.h"
 #ifndef SERVER
 #include "tile.h" // getImagePath
 #endif
@@ -59,6 +60,17 @@ struct GameFindPath
 	{}
 };
 
+Strfnd getSubgamePathEnv() {
+  std::string sp;
+  char *subgame_path = getenv("MINETEST_SUBGAME_PATH");
+
+  if(subgame_path) {
+    sp = std::string(subgame_path);
+  }
+
+  return Strfnd(sp);
+}
+
 SubgameSpec findSubgame(const std::string &id)
 {
 	if(id == "")
@@ -66,6 +78,17 @@ SubgameSpec findSubgame(const std::string &id)
 	std::string share = porting::path_share;
 	std::string user = porting::path_user;
 	std::vector<GameFindPath> find_paths;
+
+        Strfnd search_paths = getSubgamePathEnv();
+
+        while(!search_paths.atend()) {
+                std::string path = search_paths.next(":");
+                find_paths.push_back(GameFindPath(
+                                       path + DIR_DELIM + id, false));
+                find_paths.push_back(GameFindPath(
+                                       path + DIR_DELIM + id + "_game", false));
+        }
+
 	find_paths.push_back(GameFindPath(
 			user + DIR_DELIM + "games" + DIR_DELIM + id + "_game", true));
 	find_paths.push_back(GameFindPath(
@@ -129,6 +152,13 @@ std::set<std::string> getAvailableGameIds()
 	std::set<std::string> gamespaths;
 	gamespaths.insert(porting::path_share + DIR_DELIM + "games");
 	gamespaths.insert(porting::path_user + DIR_DELIM + "games");
+
+        Strfnd search_paths = getSubgamePathEnv();
+
+        while(!search_paths.atend()) {
+                gamespaths.insert(search_paths.next(":"));
+        }
+
 	for(std::set<std::string>::const_iterator i = gamespaths.begin();
 			i != gamespaths.end(); i++){
 		std::vector<fs::DirListNode> dirlist = fs::GetDirListing(*i);


### PR DESCRIPTION
Using an environment variable allows the subgame search paths to be defined by the user, rather than fixed at compile time.  This patch will search the paths contained within the environment variable `MINETEST_SUBGAME_PATH` for subgames before searching the share and home directories.  When this environment variable is not set, Minetest behaves as it has prior to this patch.

One particular use-case for this patch is to allow Minetest to be played on the GNU system running the [GNU Guix](https://gnu.org/s/guix) package manager, where applications are installed on a per-user basis and packaged files are immutable.  In other words, there's no `/usr/share/minetest/games` directory to write to.  The necessary search path is dependent upon which user is running Minetest and where their "profile" (installed packages) is located.
