### PR TITLE
Add compression API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1763,6 +1763,18 @@ minetest.deserialize(string) -> table
 ^ Example: deserialize('return { ["foo"] = "bar" }') -> {foo='bar'}
 ^ Example: deserialize('print("foo")') -> nil (function call fails)
   ^ error:[string "print("foo")"]:1: attempt to call global 'print' (a nil value)
+minetest.compress(data, method, ...) -> compressed_data
+^ Compress a string of data.
+^ `method` is a string identifying the compression method to be used.
+^ Supported compression methods:
+^     Deflate (zlib): "deflate"
+^ `...` indicates method-specific arguments.  Currently defined arguments are:
+^     Deflate: `level` - Compression level, 0-9 or nil.
+minetest.decompress(compressed_data, method, ...) -> data
+^ Decompress a string of data (using ZLib).
+^ See documentation on minetest.compress() for supported compression methods.
+^ currently supported.
+^ `...` indicates method-specific arguments.  Currently, no methods use this.
 minetest.is_protected(pos, name) -> bool
 ^ This function should be overridden by protection mods and should be used to
   check if a player can interact at a position.

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -81,6 +81,12 @@ private:
 	// get_scriptdir()
 	static int l_get_builtin_path(lua_State *L);
 
+	// compress(data, method, ...)
+	static int l_compress(lua_State *L);
+
+	// decompress(data, method, ...)
+	static int l_decompress(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -53,7 +53,7 @@ void zerr(int ret)
     }
 }
 
-void compressZlib(SharedBuffer<u8> data, std::ostream &os)
+void compressZlib(SharedBuffer<u8> data, std::ostream &os, int level)
 {
 	z_stream z;
 	const s32 bufsize = 16384;
@@ -65,7 +65,7 @@ void compressZlib(SharedBuffer<u8> data, std::ostream &os)
 	z.zfree = Z_NULL;
 	z.opaque = Z_NULL;
 
-	ret = deflateInit(&z, -1);
+	ret = deflateInit(&z, level);
 	if(ret != Z_OK)
 		throw SerializationError("compressZlib: deflateInit failed");
 	
@@ -94,13 +94,12 @@ void compressZlib(SharedBuffer<u8> data, std::ostream &os)
 	}
 
 	deflateEnd(&z);
-
 }
 
-void compressZlib(const std::string &data, std::ostream &os)
+void compressZlib(const std::string &data, std::ostream &os, int level)
 {
 	SharedBuffer<u8> databuf((u8*)data.c_str(), data.size());
-	compressZlib(databuf, os);
+	compressZlib(databuf, os, level);
 }
 
 void decompressZlib(std::istream &is, std::ostream &os)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -78,8 +78,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	Misc. serialization functions
 */
 
-void compressZlib(SharedBuffer<u8> data, std::ostream &os);
-void compressZlib(const std::string &data, std::ostream &os);
+void compressZlib(SharedBuffer<u8> data, std::ostream &os, int level = -1);
+void compressZlib(const std::string &data, std::ostream &os, int level = -1);
 void decompressZlib(std::istream &is, std::ostream &os);
 
 // These choose between zlib and a self-made one according to version


### PR DESCRIPTION
Simple ZLib compression API for mods.  Useful for, eg, WorldEdit schematics.
A `method` argument could be added in the future to allow other methods.
