### PR TITLE
Added colored Chat. Ported from Freeminer

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -67,7 +67,7 @@ core.register_chatcommand("help", {
 	description = "Get help for commands or list privileges",
 	func = function(name, param)
 		local function format_help_line(cmd, def)
-			local msg = "/"..cmd
+			local msg = core.colorize("00ffff", "/"..cmd)
 			if def.params and def.params ~= "" then
 				msg = msg .. " " .. def.params
 			end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -136,3 +136,20 @@ function core.record_protection_violation(pos, name)
 	end
 end
 
+function core.color(color)
+	if string.len(color) == 3 then
+		local r = string.sub(color, 1, 1)
+		local g = string.sub(color, 2, 2)
+		local b = string.sub(color, 3, 3)
+		color = r ..  r .. g .. g .. b .. b
+	end
+
+	assert(#color == 6, "Color must be six characters in length.")
+
+	return "\v" .. color
+end
+
+function core.colorize(color, message)
+	return core.color(color) .. message .. core.color("ffffff")
+end
+

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1450,6 +1450,10 @@ minetest.get_player_ip(name) -> IP address string
 Chat:
 minetest.chat_send_all(text)
 minetest.chat_send_player(name, text)
+minetest.colorize(color, text)
+^ color is a six characters string, this will reset color to white after the text
+minetest.color(color)
+^ will output color escape sequence
 
 Environment access:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -401,6 +401,7 @@ set(common_SRCS
 	convert_json.cpp
 	gettext.cpp
 	httpfetch.cpp
+	ColoredString.cpp
 	${JTHREAD_SRCS}
 	${common_SCRIPT_SRCS}
 	${UTIL_SRCS}
@@ -486,6 +487,13 @@ include_directories(
 	${JSON_INCLUDE_DIR}
 	${PROJECT_SOURCE_DIR}/script
 )
+
+# Don't compile StaticText.cpp when not using Freetype. [Temporary Fix]
+if (USE_FREETYPE)
+    LIST(
+		APPEND minetest_SRCS StaticText.cpp
+	)
+endif (USE_FREETYPE)
 
 if(USE_FREETYPE)
 	include_directories(

--- a/src/ColoredString.cpp
+++ b/src/ColoredString.cpp
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 2013 xyz, Ilya Zhuravlev <whatever@xyz.is>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "ColoredString.h"
+#include "util/string.h"
+
+ColoredString::ColoredString()
+{}
+
+ColoredString::ColoredString(const std::wstring &string, const std::vector<SColor> &colors):
+	m_string(string),
+	m_colors(colors)
+{}
+
+ColoredString::ColoredString(const std::wstring &s) {
+	m_string = colorizeText(s, m_colors, SColor(255, 255, 255, 255));
+}
+
+void ColoredString::operator=(const wchar_t *str) {
+	m_string = colorizeText(str, m_colors, SColor(255, 255, 255, 255));
+}
+
+size_t ColoredString::size() const {
+	return m_string.size();
+}
+
+ColoredString ColoredString::substr(size_t pos, size_t len) const {
+	if (pos == m_string.length())
+		return ColoredString();
+	if (len == std::string::npos || pos + len > m_string.length()) {
+		return ColoredString(
+		           m_string.substr(pos, std::string::npos),
+		           std::vector<SColor>(m_colors.begin() + pos, m_colors.end())
+		       );
+	} else {
+		return ColoredString(
+		           m_string.substr(pos, len),
+		           std::vector<SColor>(m_colors.begin() + pos, m_colors.begin() + pos + len)
+		       );
+	}
+}
+
+const wchar_t *ColoredString::c_str() const {
+	return m_string.c_str();
+}
+
+const std::vector<SColor> &ColoredString::getColors() const {
+	return m_colors;
+}
+
+const std::wstring &ColoredString::getString() const {
+	return m_string;
+}
+
+/*std::wstring ColoredString::serialize() const {
+	std::wstring out;
+	for (size_t i = 0; i < m_string.size(); ++i) {
+		if (i == 0 || m_colors[i] != m_colors[i - 1])
+			out += L"\vAABBCC";
+		out += m_string[i];
+	}
+	return out;
+}*/

--- a/src/ColoredString.h
+++ b/src/ColoredString.h
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2013 xyz, Ilya Zhuravlev <whatever@xyz.is>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef COLOREDSTRING_HEADER
+#define COLOREDSTRING_HEADER
+
+#include <string>
+#include <vector>
+#include <SColor.h>
+
+using namespace irr::video;
+
+class ColoredString {
+public:
+	ColoredString();
+	ColoredString(const std::wstring &s);
+	ColoredString(const std::wstring &string, const std::vector<SColor> &colors);
+	void operator=(const wchar_t *str);
+	size_t size() const;
+	ColoredString substr(size_t pos = 0, size_t len = std::string::npos) const;
+	const wchar_t *c_str() const;
+	const std::vector<SColor> &getColors() const;
+	const std::wstring &getString() const;
+private:
+	std::wstring m_string;
+	std::vector<SColor> m_colors;
+};
+
+#endif

--- a/src/StaticText.cpp
+++ b/src/StaticText.cpp
@@ -1,0 +1,656 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "StaticText.h"
+#ifdef _IRR_COMPILE_WITH_GUI_
+
+//Only compile this if freetype is enabled.
+
+#include "IGUISkin.h"
+#include "IGUIEnvironment.h"
+#include "IGUIFont.h"
+#include "IVideoDriver.h"
+#include "rect.h"
+#include "SColor.h"
+
+#include "cguittfont/xCGUITTFont.h"
+
+#include "util/string.h"
+
+#include <vector>
+#include <string>
+#include <iostream>
+
+namespace irr
+{
+namespace gui
+{
+//! constructor
+StaticText::StaticText(const wchar_t* text, bool border,
+			IGUIEnvironment* environment, IGUIElement* parent,
+			s32 id, const core::rect<s32>& rectangle,
+			bool background)
+: IGUIStaticText(environment, parent, id, rectangle),
+	HAlign(EGUIA_UPPERLEFT), VAlign(EGUIA_UPPERLEFT),
+	Border(border), OverrideColorEnabled(false), OverrideBGColorEnabled(false), WordWrap(false), Background(background),
+	RestrainTextInside(true), RightToLeft(false),
+	OverrideColor(video::SColor(101,255,255,255)), BGColor(video::SColor(101,210,210,210)),
+	OverrideFont(0), LastBreakFont(0)
+{
+	#ifdef _DEBUG
+	setDebugName("StaticText");
+	#endif
+
+	Text = text;
+	if (environment && environment->getSkin())
+	{
+		BGColor = environment->getSkin()->getColor(gui::EGDC_3D_FACE);
+	}
+}
+
+
+//! destructor
+StaticText::~StaticText()
+{
+	if (OverrideFont)
+		OverrideFont->drop();
+}
+
+
+//! draws the element and its children
+void StaticText::draw()
+{
+	if (!IsVisible)
+		return;
+
+	IGUISkin* skin = Environment->getSkin();
+	if (!skin)
+		return;
+	video::IVideoDriver* driver = Environment->getVideoDriver();
+
+	core::rect<s32> frameRect(AbsoluteRect);
+
+	// draw background
+
+	if (Background)
+	{
+		if ( !OverrideBGColorEnabled )	// skin-colors can change
+			BGColor = skin->getColor(gui::EGDC_3D_FACE);
+
+		driver->draw2DRectangle(BGColor, frameRect, &AbsoluteClippingRect);
+	}
+
+	// draw the border
+
+	if (Border)
+	{
+		skin->draw3DSunkenPane(this, 0, true, false, frameRect, &AbsoluteClippingRect);
+		frameRect.UpperLeftCorner.X += skin->getSize(EGDS_TEXT_DISTANCE_X);
+	}
+
+	// draw the text
+	if (Text.size())
+	{
+		IGUIFont* font = getActiveFont();
+
+		if (font)
+		{
+			if (!WordWrap)
+			{
+				// TODO: add colors here
+				if (VAlign == EGUIA_LOWERRIGHT)
+				{
+					frameRect.UpperLeftCorner.Y = frameRect.LowerRightCorner.Y -
+						font->getDimension(L"A").Height - font->getKerningHeight();
+				}
+				if (HAlign == EGUIA_LOWERRIGHT)
+				{
+					frameRect.UpperLeftCorner.X = frameRect.LowerRightCorner.X -
+						font->getDimension(Text.c_str()).Width;
+				}
+
+				font->draw(Text.c_str(), frameRect,
+					OverrideColorEnabled ? OverrideColor : skin->getColor(isEnabled() ? EGDC_BUTTON_TEXT : EGDC_GRAY_TEXT),
+					HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER, (RestrainTextInside ? &AbsoluteClippingRect : NULL));
+			}
+			else
+			{
+				if (font != LastBreakFont)
+					breakText();
+
+				core::rect<s32> r = frameRect;
+				s32 height = font->getDimension(L"A").Height + font->getKerningHeight();
+				s32 totalHeight = height * BrokenText.size();
+				if (VAlign == EGUIA_CENTER)
+				{
+					r.UpperLeftCorner.Y = r.getCenter().Y - (totalHeight / 2);
+				}
+				else if (VAlign == EGUIA_LOWERRIGHT)
+				{
+					r.UpperLeftCorner.Y = r.LowerRightCorner.Y - totalHeight;
+				}
+
+				irr::video::SColor previous_color(255, 255, 255, 255);
+				for (u32 i=0; i<BrokenText.size(); ++i)
+				{
+					if (HAlign == EGUIA_LOWERRIGHT)
+					{
+						r.UpperLeftCorner.X = frameRect.LowerRightCorner.X -
+							font->getDimension(BrokenText[i].c_str()).Width;
+					}
+
+					std::vector<irr::video::SColor> colors;
+					std::wstring str;
+
+					str = colorizeText(BrokenText[i].c_str(), colors, previous_color);
+					if (!colors.empty())
+						previous_color = colors[colors.size() - 1];
+
+					irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
+					tmp->draw(str.c_str(), r,
+						colors,
+						HAlign == EGUIA_CENTER, false, (RestrainTextInside ? &AbsoluteClippingRect : NULL));
+
+					r.LowerRightCorner.Y += height;
+					r.UpperLeftCorner.Y += height;
+				}
+			}
+		}
+	}
+
+	IGUIElement::draw();
+}
+
+
+//! Sets another skin independent font.
+void StaticText::setOverrideFont(IGUIFont* font)
+{
+	if (OverrideFont == font)
+		return;
+
+	if (OverrideFont)
+		OverrideFont->drop();
+
+	OverrideFont = font;
+
+	if (OverrideFont)
+		OverrideFont->grab();
+
+	breakText();
+}
+
+//! Gets the override font (if any)
+IGUIFont * StaticText::getOverrideFont() const
+{
+	return OverrideFont;
+}
+
+//! Get the font which is used right now for drawing
+IGUIFont* StaticText::getActiveFont() const
+{
+	if ( OverrideFont )
+		return OverrideFont;
+	IGUISkin* skin = Environment->getSkin();
+	if (skin)
+		return skin->getFont();
+	return 0;
+}
+
+//! Sets another color for the text.
+void StaticText::setOverrideColor(video::SColor color)
+{
+	OverrideColor = color;
+	OverrideColorEnabled = true;
+}
+
+
+//! Sets another color for the text.
+void StaticText::setBackgroundColor(video::SColor color)
+{
+	BGColor = color;
+	OverrideBGColorEnabled = true;
+	Background = true;
+}
+
+
+//! Sets whether to draw the background
+void StaticText::setDrawBackground(bool draw)
+{
+	Background = draw;
+}
+
+
+//! Gets the background color
+video::SColor StaticText::getBackgroundColor() const
+{
+	return BGColor;
+}
+
+
+//! Checks if background drawing is enabled
+bool StaticText::isDrawBackgroundEnabled() const
+{
+	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
+	return Background;
+}
+
+
+//! Sets whether to draw the border
+void StaticText::setDrawBorder(bool draw)
+{
+	Border = draw;
+}
+
+
+//! Checks if border drawing is enabled
+bool StaticText::isDrawBorderEnabled() const
+{
+	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
+	return Border;
+}
+
+
+void StaticText::setTextRestrainedInside(bool restrainTextInside)
+{
+	RestrainTextInside = restrainTextInside;
+}
+
+
+bool StaticText::isTextRestrainedInside() const
+{
+	return RestrainTextInside;
+}
+
+
+void StaticText::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical)
+{
+	HAlign = horizontal;
+	VAlign = vertical;
+}
+
+
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
+const video::SColor& StaticText::getOverrideColor() const
+#else
+video::SColor StaticText::getOverrideColor() const
+#endif
+{
+	return OverrideColor;
+}
+
+
+//! Sets if the static text should use the overide color or the
+//! color in the gui skin.
+void StaticText::enableOverrideColor(bool enable)
+{
+	OverrideColorEnabled = enable;
+}
+
+
+bool StaticText::isOverrideColorEnabled() const
+{
+	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
+	return OverrideColorEnabled;
+}
+
+
+//! Enables or disables word wrap for using the static text as
+//! multiline text control.
+void StaticText::setWordWrap(bool enable)
+{
+	WordWrap = enable;
+	breakText();
+}
+
+
+bool StaticText::isWordWrapEnabled() const
+{
+	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
+	return WordWrap;
+}
+
+
+void StaticText::setRightToLeft(bool rtl)
+{
+	if (RightToLeft != rtl)
+	{
+		RightToLeft = rtl;
+		breakText();
+	}
+}
+
+
+bool StaticText::isRightToLeft() const
+{
+	return RightToLeft;
+}
+
+
+//! Breaks the single text line.
+void StaticText::breakText()
+{
+	if (!WordWrap)
+		return;
+
+	BrokenText.clear();
+
+	IGUISkin* skin = Environment->getSkin();
+	IGUIFont* font = getActiveFont();
+	if (!font)
+		return;
+
+	LastBreakFont = font;
+
+	core::stringw line;
+	core::stringw word;
+	core::stringw whitespace;
+	s32 size = Text.size();
+	s32 length = 0;
+	s32 elWidth = RelativeRect.getWidth();
+	if (Border)
+		elWidth -= 2*skin->getSize(EGDS_TEXT_DISTANCE_X);
+	wchar_t c;
+
+	std::vector<irr::video::SColor> colors;
+
+	// We have to deal with right-to-left and left-to-right differently
+	// However, most parts of the following code is the same, it's just
+	// some order and boundaries which change.
+	if (!RightToLeft)
+	{
+		// regular (left-to-right)
+		for (s32 i=0; i<size; ++i)
+		{
+			c = Text[i];
+			bool lineBreak = false;
+
+			if (c == L'\r') // Mac or Windows breaks
+			{
+				lineBreak = true;
+				if (Text[i+1] == L'\n') // Windows breaks
+				{
+					Text.erase(i+1);
+					--size;
+				}
+				c = '\0';
+			}
+			else if (c == L'\n') // Unix breaks
+			{
+				lineBreak = true;
+				c = '\0';
+			}
+
+			bool isWhitespace = (c == L' ' || c == 0);
+			if ( !isWhitespace )
+			{
+				// part of a word
+				word += c;
+			}
+
+			if ( isWhitespace || i == (size-1))
+			{
+				if (word.size())
+				{
+					// here comes the next whitespace, look if
+					// we must break the last word to the next line.
+					const s32 whitelgth = font->getDimension(whitespace.c_str()).Width;
+					const std::wstring sanitized = sanitizeChatString(word.c_str());
+					const s32 wordlgth = font->getDimension(sanitized.c_str()).Width;
+
+					if (wordlgth > elWidth)
+					{
+						// This word is too long to fit in the available space, look for
+						// the Unicode Soft HYphen (SHY / 00AD) character for a place to
+						// break the word at
+						int where = word.findFirst( wchar_t(0x00AD) );
+						if (where != -1)
+						{
+							core::stringw first  = word.subString(0, where);
+							core::stringw second = word.subString(where, word.size() - where);
+							BrokenText.push_back(line + first + L"-");
+							const s32 secondLength = font->getDimension(second.c_str()).Width;
+
+							length = secondLength;
+							line = second;
+						}
+						else
+						{
+							// No soft hyphen found, so there's nothing more we can do
+							// break to next line
+							if (length)
+								BrokenText.push_back(line);
+							length = wordlgth;
+							line = word;
+						}
+					}
+					else if (length && (length + wordlgth + whitelgth > elWidth))
+					{
+						// break to next line
+						BrokenText.push_back(line);
+						length = wordlgth;
+						line = word;
+					}
+					else
+					{
+						// add word to line
+						line += whitespace;
+						line += word;
+						length += whitelgth + wordlgth;
+					}
+
+					word = L"";
+					whitespace = L"";
+				}
+
+				if ( isWhitespace )
+				{
+					whitespace += c;
+				}
+
+				// compute line break
+				if (lineBreak)
+				{
+					line += whitespace;
+					line += word;
+					BrokenText.push_back(line);
+					line = L"";
+					word = L"";
+					whitespace = L"";
+					length = 0;
+				}
+			}
+		}
+
+		line += whitespace;
+		line += word;
+		BrokenText.push_back(line);
+	}
+	else
+	{
+		// right-to-left
+		for (s32 i=size; i>=0; --i)
+		{
+			c = Text[i];
+			bool lineBreak = false;
+
+			if (c == L'\r') // Mac or Windows breaks
+			{
+				lineBreak = true;
+				if ((i>0) && Text[i-1] == L'\n') // Windows breaks
+				{
+					Text.erase(i-1);
+					--size;
+				}
+				c = '\0';
+			}
+			else if (c == L'\n') // Unix breaks
+			{
+				lineBreak = true;
+				c = '\0';
+			}
+
+			if (c==L' ' || c==0 || i==0)
+			{
+				if (word.size())
+				{
+					// here comes the next whitespace, look if
+					// we must break the last word to the next line.
+					const s32 whitelgth = font->getDimension(whitespace.c_str()).Width;
+					const s32 wordlgth = font->getDimension(word.c_str()).Width;
+
+					if (length && (length + wordlgth + whitelgth > elWidth))
+					{
+						// break to next line
+						BrokenText.push_back(line);
+						length = wordlgth;
+						line = word;
+					}
+					else
+					{
+						// add word to line
+						line = whitespace + line;
+						line = word + line;
+						length += whitelgth + wordlgth;
+					}
+
+					word = L"";
+					whitespace = L"";
+				}
+
+				if (c != 0)
+					whitespace = core::stringw(&c, 1) + whitespace;
+
+				// compute line break
+				if (lineBreak)
+				{
+					line = whitespace + line;
+					line = word + line;
+					BrokenText.push_back(line);
+					line = L"";
+					word = L"";
+					whitespace = L"";
+					length = 0;
+				}
+			}
+			else
+			{
+				// yippee this is a word..
+				word = core::stringw(&c, 1) + word;
+			}
+		}
+
+		line = whitespace + line;
+		line = word + line;
+		BrokenText.push_back(line);
+	}
+}
+
+
+//! Sets the new caption of this element.
+void StaticText::setText(const wchar_t* text)
+{
+	IGUIElement::setText(text);
+	breakText();
+}
+
+
+void StaticText::updateAbsolutePosition()
+{
+	IGUIElement::updateAbsolutePosition();
+	breakText();
+}
+
+
+//! Returns the height of the text in pixels when it is drawn.
+s32 StaticText::getTextHeight() const
+{
+	IGUIFont* font = getActiveFont();
+	if (!font)
+		return 0;
+
+	s32 height = font->getDimension(L"A").Height + font->getKerningHeight();
+
+	if (WordWrap)
+		height *= BrokenText.size();
+
+	return height;
+}
+
+
+s32 StaticText::getTextWidth() const
+{
+	IGUIFont * font = getActiveFont();
+	if(!font)
+		return 0;
+
+	if(WordWrap)
+	{
+		s32 widest = 0;
+
+		for(u32 line = 0; line < BrokenText.size(); ++line)
+		{
+			s32 width = font->getDimension(BrokenText[line].c_str()).Width;
+
+			if(width > widest)
+				widest = width;
+		}
+
+		return widest;
+	}
+	else
+	{
+		return font->getDimension(Text.c_str()).Width;
+	}
+}
+
+
+//! Writes attributes of the element.
+//! Implement this to expose the attributes of your element for
+//! scripting languages, editors, debuggers or xml serialization purposes.
+void StaticText::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options=0) const
+{
+	IGUIStaticText::serializeAttributes(out,options);
+
+	out->addBool	("Border",              Border);
+	out->addBool	("OverrideColorEnabled",OverrideColorEnabled);
+	out->addBool	("OverrideBGColorEnabled",OverrideBGColorEnabled);
+	out->addBool	("WordWrap",		WordWrap);
+	out->addBool	("Background",          Background);
+	out->addBool	("RightToLeft",         RightToLeft);
+	out->addBool	("RestrainTextInside",  RestrainTextInside);
+	out->addColor	("OverrideColor",       OverrideColor);
+	out->addColor	("BGColor",       	BGColor);
+	out->addEnum	("HTextAlign",          HAlign, GUIAlignmentNames);
+	out->addEnum	("VTextAlign",          VAlign, GUIAlignmentNames);
+
+	// out->addFont ("OverrideFont",	OverrideFont);
+}
+
+
+//! Reads attributes of the element
+void StaticText::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options=0)
+{
+	IGUIStaticText::deserializeAttributes(in,options);
+
+	Border = in->getAttributeAsBool("Border");
+	enableOverrideColor(in->getAttributeAsBool("OverrideColorEnabled"));
+	OverrideBGColorEnabled = in->getAttributeAsBool("OverrideBGColorEnabled");
+	setWordWrap(in->getAttributeAsBool("WordWrap"));
+	Background = in->getAttributeAsBool("Background");
+	RightToLeft = in->getAttributeAsBool("RightToLeft");
+	RestrainTextInside = in->getAttributeAsBool("RestrainTextInside");
+	OverrideColor = in->getAttributeAsColor("OverrideColor");
+	BGColor = in->getAttributeAsColor("BGColor");
+
+	setTextAlignment( (EGUI_ALIGNMENT) in->getAttributeAsEnumeration("HTextAlign", GUIAlignmentNames),
+                      (EGUI_ALIGNMENT) in->getAttributeAsEnumeration("VTextAlign", GUIAlignmentNames));
+
+	// OverrideFont = in->getAttributeAsFont("OverrideFont");
+}
+
+} // end namespace gui
+} // end namespace irr
+
+
+#endif // _IRR_COMPILE_WITH_GUI_

--- a/src/StaticText.h
+++ b/src/StaticText.h
@@ -1,0 +1,150 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#ifndef __C_GUI_STATIC_TEXT_H_INCLUDED__
+#define __C_GUI_STATIC_TEXT_H_INCLUDED__
+
+#include "IrrCompileConfig.h"
+#ifdef _IRR_COMPILE_WITH_GUI_
+
+#include "IGUIStaticText.h"
+#include "irrArray.h"
+
+#include <vector>
+
+namespace irr
+{
+namespace gui
+{
+	class StaticText : public IGUIStaticText
+	{
+	public:
+
+		//! constructor
+		StaticText(const wchar_t* text, bool border, IGUIEnvironment* environment,
+			IGUIElement* parent, s32 id, const core::rect<s32>& rectangle,
+			bool background = false);
+
+		//! destructor
+		virtual ~StaticText();
+
+		//! draws the element and its children
+		virtual void draw();
+
+		//! Sets another skin independent font.
+		virtual void setOverrideFont(IGUIFont* font=0);
+
+		//! Gets the override font (if any)
+		virtual IGUIFont* getOverrideFont() const;
+
+		//! Get the font which is used right now for drawing
+		virtual IGUIFont* getActiveFont() const;
+
+		//! Sets another color for the text.
+		virtual void setOverrideColor(video::SColor color);
+
+		//! Sets another color for the background.
+		virtual void setBackgroundColor(video::SColor color);
+
+		//! Sets whether to draw the background
+		virtual void setDrawBackground(bool draw);
+
+		//! Gets the background color
+		virtual video::SColor getBackgroundColor() const;
+
+		//! Checks if background drawing is enabled
+		virtual bool isDrawBackgroundEnabled() const;
+
+		//! Sets whether to draw the border
+		virtual void setDrawBorder(bool draw);
+
+		//! Checks if border drawing is enabled
+		virtual bool isDrawBorderEnabled() const;
+
+		//! Sets alignment mode for text
+		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical);
+
+		//! Gets the override color
+		#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
+		virtual const video::SColor& getOverrideColor() const;
+		#else
+		virtual video::SColor getOverrideColor() const;
+		#endif
+
+		//! Sets if the static text should use the overide color or the
+		//! color in the gui skin.
+		virtual void enableOverrideColor(bool enable);
+
+		//! Checks if an override color is enabled
+		virtual bool isOverrideColorEnabled() const;
+
+		//! Set whether the text in this label should be clipped if it goes outside bounds
+		virtual void setTextRestrainedInside(bool restrainedInside);
+
+		//! Checks if the text in this label should be clipped if it goes outside bounds
+		virtual bool isTextRestrainedInside() const;
+
+		//! Enables or disables word wrap for using the static text as
+		//! multiline text control.
+		virtual void setWordWrap(bool enable);
+
+		//! Checks if word wrap is enabled
+		virtual bool isWordWrapEnabled() const;
+
+		//! Sets the new caption of this element.
+		virtual void setText(const wchar_t* text);
+
+		//! Returns the height of the text in pixels when it is drawn.
+		virtual s32 getTextHeight() const;
+
+		//! Returns the width of the current text, in the current font
+		virtual s32 getTextWidth() const;
+
+		//! Updates the absolute position, splits text if word wrap is enabled
+		virtual void updateAbsolutePosition();
+
+		//! Set whether the string should be interpreted as right-to-left (RTL) text
+		/** \note This component does not implement the Unicode bidi standard, the
+		text of the component should be already RTL if you call this. The
+		main difference when RTL is enabled is that the linebreaks for multiline
+		elements are performed starting from the end.
+		*/
+		virtual void setRightToLeft(bool rtl);
+
+		//! Checks if the text should be interpreted as right-to-left text
+		virtual bool isRightToLeft() const;
+
+		//! Writes attributes of the element.
+		virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;
+
+		//! Reads attributes of the element
+		virtual void deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options);
+
+	private:
+
+		//! Breaks the single text line.
+		void breakText();
+
+		EGUI_ALIGNMENT HAlign, VAlign;
+		bool Border;
+		bool OverrideColorEnabled;
+		bool OverrideBGColorEnabled;
+		bool WordWrap;
+		bool Background;
+		bool RestrainTextInside;
+		bool RightToLeft;
+
+		video::SColor OverrideColor, BGColor;
+		gui::IGUIFont* OverrideFont;
+		gui::IGUIFont* LastBreakFont; // stored because: if skin changes, line break must be recalculated.
+
+		core::array< core::stringw > BrokenText;
+	};
+
+} // end namespace gui
+} // end namespace irr
+
+#endif // _IRR_COMPILE_WITH_GUI_
+
+#endif // C_GUI_STATIC_TEXT_H_INCLUDED

--- a/src/cguittfont/CGUITTFont.cpp
+++ b/src/cguittfont/CGUITTFont.cpp
@@ -527,6 +527,13 @@ void CGUITTFont::setFontHinting(const bool enable, const bool enable_auto_hintin
 
 void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>* clip)
 {
+	std::vector<video::SColor> tmp;
+	tmp.push_back(color);
+	draw(text, position, tmp, hcenter, vcenter, clip);
+}
+
+void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position, const std::vector<video::SColor>& color, bool hcenter, bool vcenter, const core::rect<s32>* clip)
+{
 	if (!Driver)
 		return;
 
@@ -563,6 +570,8 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 	u32 n;
 	uchar32_t previousChar = 0;
 	core::ustring::const_iterator iter(utext);
+	std::vector<video::SColor> applied_colors;
+	size_t current_color = 0;
 	while (!iter.atEnd())
 	{
 		uchar32_t currentChar = *iter;
@@ -609,11 +618,14 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 			page->render_positions.push_back(core::position2di(offset.X + offx, offset.Y + offy));
 			page->render_source_rects.push_back(glyph.source_rect);
 			Render_Map.set(glyph.glyph_page, page);
+			if (current_color < color.size())
+				applied_colors.push_back(color[current_color]);
 		}
 		offset.X += getWidthFromCharacter(currentChar);
 
 		previousChar = currentChar;
 		++iter;
+		++current_color;
 	}
 
 	// Draw now.
@@ -627,8 +639,6 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 
 		CGUITTGlyphPage* page = n->getValue();
 
-		if (!use_transparency) color.color |= 0xff000000;
-
 		if (shadow_offset) {
 			for (size_t i = 0; i < page->render_positions.size(); ++i)
 				page->render_positions[i] += core::vector2di(shadow_offset, shadow_offset);
@@ -636,7 +646,21 @@ void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position
 			for (size_t i = 0; i < page->render_positions.size(); ++i)
 				page->render_positions[i] -= core::vector2di(shadow_offset, shadow_offset);
 		}
-		Driver->draw2DImageBatch(page->texture, page->render_positions, page->render_source_rects, clip, color, true);
+		
+		for (size_t i = 0; i < page->render_positions.size(); ++i) {
+			irr::video::SColor col;
+			if(applied_colors.size() > 0) {
+				col = applied_colors[0];
+				if (i < applied_colors.size())
+					col = applied_colors[i];
+			} else {
+				col = irr::video::SColor(255, 255, 255, 255);
+			}
+			if (!use_transparency)
+					col.color |= 0xff000000;
+			Driver->draw2DImage(page->texture, page->render_positions[i], page->render_source_rects[i], clip, col, true);
+		}
+		// Driver->draw2DImageBatch(page->texture, page->render_positions, page->render_source_rects, clip, color, true);
 	}
 }
 

--- a/src/cguittfont/CGUITTFont.h
+++ b/src/cguittfont/CGUITTFont.h
@@ -33,6 +33,7 @@
 
 #include <irrlicht.h>
 #include <ft2build.h>
+#include <vector>
 #include FT_FREETYPE_H
 
 namespace irr
@@ -257,6 +258,9 @@ namespace gui
 			//! Draws some text and clips it to the specified rectangle if wanted.
 			virtual void draw(const core::stringw& text, const core::rect<s32>& position,
 				video::SColor color, bool hcenter=false, bool vcenter=false,
+				const core::rect<s32>* clip=0);
+			virtual void draw(const core::stringw& text, const core::rect<s32>& position,
+				const std::vector<video::SColor>& color, bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
 			//! Returns the dimension of a character produced by this font.

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "chat.h"
 #include "debug.h"
+#include "config.h"
 #include "strfnd.h"
 #include <cctype>
 #include <sstream>
@@ -259,28 +260,30 @@ u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
 		next_frags.push_back(temp_frag);
 	}
 
+	std::wstring name_sanitized = sanitizeChatString(line.name);
 	// Choose an indentation level
 	if (line.name.empty())
 	{
 		// Server messages
 		hanging_indentation = 0;
 	}
-	else if (line.name.size() + 3 <= cols/2)
+	else if (name_sanitized.size() + 3 <= cols/2)
 	{
 		// Names shorter than about half the console width
-		hanging_indentation = line.name.size() + 3;
+		hanging_indentation = name_sanitized.size() + 3;
 	}
 	else
 	{
 		// Very long names
 		hanging_indentation = 2;
 	}
+	ColoredString line_text(line.text);
 
 	next_line.first = true;
 	bool text_processing = false;
 
 	// Produce fragments and layout them into lines
-	while (!next_frags.empty() || in_pos < line.text.size())
+	while (!next_frags.empty() || in_pos < line_text.size())
 	{
 		// Layout fragments into lines
 		while (!next_frags.empty())
@@ -318,9 +321,9 @@ u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
 		}
 
 		// Produce fragment
-		if (in_pos < line.text.size())
+		if (in_pos < line_text.size())
 		{
-			u32 remaining_in_input = line.text.size() - in_pos;
+			u32 remaining_in_input = line_text.size() - in_pos;
 			u32 remaining_in_output = cols - out_column;
 
 			// Determine a fragment length <= the minimum of
@@ -330,14 +333,14 @@ u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
 			while (frag_length < remaining_in_input &&
 					frag_length < remaining_in_output)
 			{
-				if (isspace(line.text[in_pos + frag_length]))
+				if (isspace(line_text.getString()[in_pos + frag_length]))
 					space_pos = frag_length;
 				++frag_length;
 			}
 			if (space_pos != 0 && frag_length < remaining_in_input)
 				frag_length = space_pos + 1;
 
-			temp_frag.text = line.text.substr(in_pos, frag_length);
+			temp_frag.text = line_text.substr(in_pos, frag_length);
 			temp_frag.column = 0;
 			//temp_frag.bold = 0;
 			next_frags.push_back(temp_frag);
@@ -668,6 +671,14 @@ ChatBackend::~ChatBackend()
 void ChatBackend::addMessage(std::wstring name, std::wstring text)
 {
 	// Note: A message may consist of multiple lines, for example the MOTD.
+
+	// Strip colors out of chat if not using freetype.
+	#if USE_FREETYPE
+	#else
+		text = sanitizeChatString(text);
+		name = sanitizeChatString(name);
+	#endif
+
 	WStrfnd fnd(text);
 	while (!fnd.atend())
 	{
@@ -717,7 +728,11 @@ std::wstring ChatBackend::getRecentChat()
 	{
 		const ChatLine& line = m_recent_buffer.getLine(i);
 		if (i != 0)
-			stream << L"\n";
+			#if USE_FREETYPE
+				stream << L"\n\vffffff";
+			#else
+				stream << L"\n";
+			#endif
 		if (!line.name.empty())
 			stream << L"<" << line.name << L"> ";
 		stream << line.text;

--- a/src/chat.h
+++ b/src/chat.h
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include <list>
 
+#include "ColoredString.h"
+
 // Chat console related classes, only used by the client
 
 struct ChatLine
@@ -47,7 +49,7 @@ struct ChatLine
 struct ChatFormattedFragment
 {
 	// text string
-	std::wstring text;
+	ColoredString text;
 	// starting column
 	u32 column;
 	// formatting

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -70,8 +70,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "drawscene.h"
 #include "content_cao.h"
 
+#if USE_FREETYPE
+	#include "StaticText.h"
+#endif
+
 #ifdef HAVE_TOUCHSCREENGUI
-#include "touchscreengui.h"
+	#include "touchscreengui.h"
 #endif
 
 /*
@@ -1594,11 +1598,23 @@ void the_game(bool &kill, bool random_input, InputHandler *input,
 	float statustext_time = 0;
 
 	// Chat text
+
+#if USE_FREETYPE
+	//Colored chat support when using FreeType
+	gui::StaticText *guitext_chat = new gui::StaticText(L"", false, guienv, guiroot, -1, core::rect<s32>(0, 0, 0, 0), false);
+	guitext_chat->setWordWrap(true);
+	guitext_chat->drop();
+#else
+	//Standard chat when FreeType is disabled
 	gui::IGUIStaticText *guitext_chat = guienv->addStaticText(
-			L"",
-			core::rect<s32>(0,0,0,0),
-			//false, false); // Disable word wrap as of now
-			false, true, guiroot);
+		L"",
+		core::rect<s32>(0,0,0,0),
+		//false, false); // Disable word wrap as of now
+		false, true, guiroot);
+#endif
+
+	
+	
 	// Remove stale "recent" chat messages from previous connections
 	chat_backend.clearRecentChat();
 	// Chat backend and console

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 
 #if USE_FREETYPE
-#include "xCGUITTFont.h"
+	#include "xCGUITTFont.h"
 #endif
 
 inline u32 clamp_u8(s32 value)
@@ -334,13 +334,27 @@ void GUIChatConsole::drawText()
 			s32 x = (fragment.column + 1) * m_fontsize.X;
 			core::rect<s32> destrect(
 				x, y, x + m_fontsize.X * fragment.text.size(), y + m_fontsize.Y);
-			m_font->draw(
+				
+			#if USE_FREETYPE
+			//Draw colored text if FreeType is enabled
+				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(m_font);
+				tmp->draw(
+					fragment.text.c_str(),
+					destrect,
+					fragment.text.getColors(),
+					false,
+					false,
+					&AbsoluteClippingRect);
+			#else
+			//Otherwise use standard text
+				m_font->draw(
 				fragment.text.c_str(),
-				destrect,
+ 				destrect,
 				video::SColor(255, 255, 255, 255),
-				false,
-				false,
-				&AbsoluteClippingRect);
+ 				false,
+ 				false,
+ 				&AbsoluteClippingRect);
+ 			#endif
 		}
 	}
 }

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -3377,63 +3377,9 @@ std::wstring GUIFormSpecMenu::getLabelByID(s32 id)
 bool GUIFormSpecMenu::parseColor(const std::string &value, video::SColor &color,
 		bool quiet)
 {
-	const char *hexpattern = NULL;
-	if (value[0] == '#') {
-		if (value.size() == 9)
-			hexpattern = "#RRGGBBAA";
-		else if (value.size() == 7)
-			hexpattern = "#RRGGBB";
-		else if (value.size() == 5)
-			hexpattern = "#RGBA";
-		else if (value.size() == 4)
-			hexpattern = "#RGB";
-	}
-
-	if (hexpattern) {
-		assert(strlen(hexpattern) == value.size());
-		video::SColor outcolor(255, 255, 255, 255);
-		for (size_t pos = 0; pos < value.size(); ++pos) {
-			// '#' in the pattern means skip that character
-			if (hexpattern[pos] == '#')
-				continue;
-
-			// Else assume hexpattern[pos] is one of 'R' 'G' 'B' 'A'
-			// Read one or two digits, depending on hexpattern
-			unsigned char c1, c2;
-			if (hexpattern[pos+1] == hexpattern[pos]) {
-				// Two digits, e.g. hexpattern == "#RRGGBB"
-				if (!hex_digit_decode(value[pos], c1) ||
-				    !hex_digit_decode(value[pos+1], c2))
-					goto fail;
-				++pos;
-			}
-			else {
-				// One digit, e.g. hexpattern == "#RGB"
-				if (!hex_digit_decode(value[pos], c1))
-					goto fail;
-				c2 = c1;
-			}
-			u32 colorpart = ((c1 & 0x0f) << 4) | (c2 & 0x0f);
-
-			// Update outcolor with newly read color part
-			if (hexpattern[pos] == 'R')
-				outcolor.setRed(colorpart);
-			else if (hexpattern[pos] == 'G')
-				outcolor.setGreen(colorpart);
-			else if (hexpattern[pos] == 'B')
-				outcolor.setBlue(colorpart);
-			else if (hexpattern[pos] == 'A')
-				outcolor.setAlpha(colorpart);
-		}
-
-		color = outcolor;
-		return true;
-	}
-
-	// Optionally, named colors could be implemented here
-
-fail:
-	if (!quiet)
+	if (!::parseColor(value, color) && !quiet) {
 		errorstream<<"Invalid color: \""<<value<<"\""<<std::endl;
-	return false;
+		return false;
+	}
+	return true;
 }

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cstring>
 #include <vector>
 #include <sstream>
+#include "SColor.h"
 #include <cctype>
 
 #define STRINGIFY(x) #x
@@ -340,5 +341,9 @@ size_t mystrlcpy(char *dst, const char *src, size_t size);
 char *mystrtok_r(char *s, const char *sep, char **lasts);
 u64 read_seed(const char *str);
 
+bool parseColor(const std::string &value, video::SColor &color);
+std::wstring colorizeText(const std::wstring &s, std::vector<video::SColor> &colors, const video::SColor &initial_color);
+std::wstring sanitizeChatString(const std::wstring &s);
+bool char_icompare(char c1, char c2);
+bool string_icompare(const std::string& a, const std::string& b);
 #endif
-


### PR DESCRIPTION
Adds colored chat which can be used in the form of:
`core.colorize('HEXXXX', string)`

Should be compatible with almost any application of text on-screen, though I am not sure.

This is back-ported from Freeminer while their license was still LGPL, should be compatible with MT.

Escape code is \vHEXXXX

NOTES:
~~Causes compilation to fail if compiled with -DENABLE_FREETYPE=0 or no -DENABLE_FREETYPE flag~~ - **Fixed**

TODO:

LONG-TERM:
Perhaps make non-freetype builds have colored chat as well?

Please discuss :smile: 