### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,33 @@
+0gb.us <0gb.us@0gb.us> <us_0gb@laptop-0gb-us.0gb.us>
+Calinou <calinou9999@gmail.com> <calinou9999spam@gmail.com>
+Perttu Ahola <celeron55@gmail.com> celeron55 <celeron55@gmail.com>
+Perttu Ahola <celeron55@gmail.com> celeron55 <celeron55@armada.(none)>
+Craig Robbins <kde.psych@gmail.com> <crobbins@localhost.localdomain>
+Diego Martínez <kaeza@users.sf.net> <lkaezadl3@gmail.com>
+Ilya Zhuravlev <zhuravlevilya@ya.ru> <whatever@xyz.is>
+kwolekr <kwolekr@minetest.net> <mirrorisim@gmail.com>
+PilzAdam <pilzadam@minetest.net> PilzAdam <adam-k@outlook.com>
+PilzAdam <pilzadam@minetest.net> Pilz Adam <PilzAdam@gmx.de>
+PilzAdam <pilzadam@minetest.net> PilzAdam <PilzAdam@gmx.de>
+proller <proller@github.com> <proler@github.com>
+proller <proller@github.com> <proler@gmail.com>
+RealBadAngel <maciej.kasatkin@o2.pl> <mk@realbadangel.pl>
+RealBadAngel <maciej.kasatkin@o2.pl> <maciej.kasatkin@yahoo.com>
+Selat <LongExampleTestName@gmail.com> <LongExampletestName@gmail.com>
+ShadowNinja <shadowninja@minetest.net> ShadowNinja <noreply@gmail.com>
+Shen Zheyu <arsdragonfly@gmail.com> arsdragonfly <arsdragonfly@gmail.com>
+Pavel Elagin <elagin.pasha@gmail.com> elagin <elagin.pasha@gmail.com>
+Esteban I. Ruiz Moreno <exio4.com@gmail.com> Esteban I. RM <exio4.com@gmail.com>
+manuel duarte <ffrogger0@yahoo.com> manuel joaquim <ffrogger0@yahoo.com>
+manuel duarte <ffrogger0@yahoo.com> sweetbomber <ffrogger _zero_ at yahoo dot com>
+Diego Martínez <kaeza@users.sf.net> kaeza <kaeza@users.sf.net>
+Diego Martínez <kaeza@users.sf.net> Diego Martinez <kaeza@users.sf.net>
+Lord James <neftali_dtctv@hotmail.com> Lord89James <neftali_dtctv@hotmail.com>
+BlockMen <nmuelll@web.de> Block Men <nmuelll@web.de>
+Sfan5 <sfan5@live.de> sfan5 <sfan5@live.de>
+DannyDark <the_skeleton_of_a_child@yahoo.co.uk> dannydark <the_skeleton_of_a_child@yahoo.co.uk>
+Ilya Pavlov <TTChangeTheWorld@gmail.com> Ilya <TTChangeTheWorld@gmail.com>
+Ilya Zhuravlev <zhuravlevilya@ya.ru> xyzz <zhuravlevilya@ya.ru>
+sapier <Sapier at GMX dot net> sapier <sapier AT gmx DOT net>
+sapier <Sapier at GMX dot net> sapier <sapier at gmx dot net>
+


### PR DESCRIPTION
So I was checking out minetest and wondered how many developers there are
and how they development community is setup and such, so I decided to have
a look at the git shortlog. There were lot of double entries for some
persons, so it was harder to estimate the number of people involved.

By adding a .mailmap file, the overview of the authors is much improved
For details on the .mailmap file, see
https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html
