### PR TITLE
Smoother player movement (Faster jumping, slight height boost)

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2153,7 +2153,7 @@ void ClientEnvironment::step(float dtime)
 				// Gravity
 				v3f speed = lplayer->getSpeed();
 				if(lplayer->in_liquid == false)
-					speed.Y -= lplayer->movement_gravity * lplayer->physics_override_gravity * dtime_part * 2;
+					speed.Y -= (lplayer->movement_gravity+25) * lplayer->physics_override_gravity * dtime_part * 2;
 
 				// Liquid floating / sinking
 				if(lplayer->in_liquid && !lplayer->swimming_vertical)

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -157,7 +157,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	//f32 d = pos_max_d * 1.1;
 	// A fairly large value in here makes moving smoother
-	f32 d = 0.15*BS;
+	f32 d = 0.3*BS;
 
 	// This should always apply, otherwise there are glitches
 	assert(d > pos_max_d);
@@ -313,7 +313,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		for(size_t i=0; i<result.collisions.size(); i++){
 			const CollisionInfo &info = result.collisions[i];
 			collision_info->push_back(info);
-			if(info.new_speed.Y - info.old_speed.Y > 0.1*BS &&
+			if(info.new_speed.Y - info.old_speed.Y > 0.2*BS &&
 					info.bouncy)
 				bouncy_jump = true;
 		}
@@ -529,7 +529,7 @@ void LocalPlayer::applyControl(float dtime)
 			v3f speedJ = getSpeed();
 			if(speedJ.Y >= -0.5 * BS)
 			{
-				speedJ.Y = movement_speed_jump * physics_override_jump;
+				speedJ.Y = (movement_speed_jump+14.3) * physics_override_jump;
 				setSpeed(speedJ);
 				
 				MtEvent *e = new SimpleTriggerEvent("PlayerJump");


### PR DESCRIPTION
Changed a few numbers and added some magic numbers to make the player movement feel a lot more integrated and smoother. (I know how it works, I think)

Jumping is faster, and puts the player a tiny bit above the node, allowing them to fall down a bit. Makes the jumping sensation seem more effective and makes is easier to climb out of caves.

Player falling is a bit faster, helps the world feel more solid.

Removes the strange slight "sinking" that happens sometimes when you hop on top of a node while pushing against it.

A helpful side effect of these changes is that placing blocks under you while jumping is less glitchy, feels better, and lowers the chance of placing two at a time (though it still happens unfortunately.)

I will squash these commits after fine-tuning everything and fixing any glitches anyone finds.