### PR TITLE
.travis.yml: fix possible issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ compiler:
   - gcc
   - clang
 before_install:
-  - if [ $CC = "clang" ]; then export PATH="/usr/bin/:$PATH"; sudo sh -c 'echo "deb http://ppa.launchpad.net/eudoxos/llvm-3.1/ubuntu precise main" >> /etc/apt/sources.list'; sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 92DE8183; sudo apt-get update; sudo apt-get install llvm-3.1; sudo apt-get install clang; fi
+  - if [ $CC = "clang" ]; then export PATH="/usr/bin/:$PATH"; sudo sh -c 'echo "deb http://ppa.launchpad.net/eudoxos/llvm-3.1/ubuntu precise main" >> /etc/apt/sources.list'; sudo apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 92DE8183; sudo apt-get update; sudo apt-get install llvm-3.1; sudo apt-get install clang; fi
   - sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev libjpeg8-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev
-script: cmake . && make
+script:
+  - mkdir -p travisbuild
+  - cd travisbuild
+  - cmake ..
+  - make -j2
 notifications:
   email: false
+matrix:
+  fast_finish: true


### PR DESCRIPTION
- use `pool.sks-keyservers.net` as keyserver as it's often more reliable than `keyserver.ubuntu.com` as you can see with Google.
- put script to multiple lines
  - build out-of-source
  - use two CPUs
    - make seems to fail if $(nproc) is used unlike WeeChat. ZNC has same issue.
- mark build as failed if one job fails immediately without waiting for all builds to finish.
  - this doesn't stop jobs that didn't finish before build was marked failed.
