### PR TITLE
Add multi-line settings and setting escapes

### DIFF
--- a/src/settings.h
+++ b/src/settings.h
@@ -147,10 +147,9 @@ private:
 	 ***********************/
 
 	bool parseConfigObject(std::istream &is,
-			std::string &name, std::string &value);
-	bool parseConfigObject(std::istream &is,
 			std::string &name, std::string &value,
-			const std::string &end, bool &end_found);
+			const std::string &end = "",
+			bool *end_found = NULL) const;
 	/*
 	 * Reads a configuration object from stream (usually a single line)
 	 * and adds it to dst.
@@ -160,12 +159,12 @@ private:
 	void getUpdatedConfigObject(std::istream &is,
 			std::list<std::string> &dst,
 			std::set<std::string> &updated,
-			bool &changed);
+			bool &changed) const;
 
+	std::string escape(const std::string &str) const;
 
 	void updateNoLock(const Settings &other);
 	void clearNoLock();
-
 
 	std::map<std::string, std::string> m_settings;
 	std::map<std::string, std::string> m_defaults;

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -430,11 +430,23 @@ struct TestSettings: public TestBase
 			"leetleet_neg = -13371337\n"
 			"floaty_thing = 1.1\n"
 			"stringy_thing = asd /( ¤%&(/\" BLÖÄRP\n"
-			"coord = (1, 2, 4.5)");
+			"coord = (1, 2, 4.5)\n"
+			"multi_line = a\\\n b\n"
+			"\\sspaces\\ttabs\\rcarriage\\treturns\\r\\t = \\s\\t\\rfoo\\s\\t\\r\n"
+			"equals\\=in\\=name = bar\n"
+			"# Comment\n"
+			"  # Comment with leading spaces\n"
+			"no#inline#comments = #\n"
+			"no_trailing_newline = x");
 		s.parseConfigLines(is);
 		UASSERT(s.getS32("leet") == 1337);
 		UASSERT(s.getS16("leetleet") == 32767);
 		UASSERT(s.getS16("leetleet_neg") == -32768);
+		UASSERT(s.get("multi_line") == "a b");
+		UASSERT(s.get(" spaces\ttabs\rcarriage\treturns\r\t") == " \t\rfoo \t\r");
+		UASSERT(s.get("equals=in=name") == "bar");
+		UASSERT(s.get("no#inline#comments") == "#");
+		UASSERT(s.get("no_trailing_newline") == "x");
 		// Not sure if 1.1 is an exact value as a float, but doesn't matter
 		UASSERT(fabs(s.getFloat("floaty_thing") - 1.1) < 0.001);
 		UASSERT(s.get("stringy_thing") == "asd /( ¤%&(/\" BLÖÄRP");


### PR DESCRIPTION
This is a little ugly, but the current settings format doesn't lend itself
easily to multi-line settings.  I also added new tests for this.

Examples:

```
multi_line = a
 b
\sspaces\ttabs\rcarriage\treturns\r\t = \s\t\rfoo\s\t\r
equals\=in\=name = bar
```

Results in (in Lua table format):

``` Lua
multi_line = "a b"
[" spaces\ttabs\rcarriage\treturns\r\t"] = " \t\rfoo \t\r"
["equals=in=name"] = "bar"
```
