### PR TITLE
Add version API

### DIFF
--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -22,7 +22,8 @@ tab_credits = {
 	caption = fgettext("Credits"),
 	cbf_formspec = function (tabview, name, tabdata)
 			local logofile = defaulttexturedir .. "logo.png"
-			return "label[0.5,3.2;Minetest " .. core.get_version() .. "]" ..
+			local version = core.get_version()
+			return "label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
 				"label[0.5,3.5;http://minetest.net]" ..
 				"image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
 				"tablecolumns[color;text]" ..

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1791,6 +1791,11 @@ Helper functions
       * nil: return all entries,
       * true: return only subdirectory names, or
       * false: return only file names.
+* `minetest.get_version()`: returns a table containing components of the
+   engine version.  Components:
+    * `project`: Name of the project, eg, "Minetest"
+    * `string`: Simple version, eg, "1.2.3-dev"
+    * `hash`: Full git version (only set if available), eg, "1.2.3-dev-01234567-dirty"
 
 ### Logging
 * `minetest.debug(...)`

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -956,13 +956,6 @@ int ModApiMainMenu::l_show_file_open_dialog(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_get_version(lua_State *L)
-{
-	lua_pushstring(L, g_version_string);
-	return 1;
-}
-
-/******************************************************************************/
 int ModApiMainMenu::l_sound_play(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
@@ -1157,7 +1150,6 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(extract_zip);
 	API_FCT(get_mainmenu_path);
 	API_FCT(show_file_open_dialog);
-	API_FCT(get_version);
 	API_FCT(download_file);
 	API_FCT(get_modstore_details);
 	API_FCT(get_modstore_list);
@@ -1188,7 +1180,6 @@ void ModApiMainMenu::InitializeAsync(AsyncEngine& engine)
 	ASYNC_API_FCT(delete_dir);
 	ASYNC_API_FCT(copy_dir);
 	//ASYNC_API_FCT(extract_zip); //TODO remove dependency to GuiEngine
-	ASYNC_API_FCT(get_version);
 	ASYNC_API_FCT(download_file);
 	ASYNC_API_FCT(get_modstore_details);
 	ASYNC_API_FCT(get_modstore_list);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -79,8 +79,6 @@ private:
 
 	static int l_delete_favorite(lua_State *L);
 
-	static int l_get_version(lua_State *L);
-
 	static int l_sound_play(lua_State *L);
 
 	static int l_sound_stop(lua_State *L);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -32,7 +32,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 #include "util/auth.h"
+#include "config.h"
+#include "version.h"
 #include <algorithm>
+
 
 // log([level,] text)
 // Writes a line to the logger.
@@ -272,12 +275,14 @@ int ModApiUtil::l_is_yes(lua_State *L)
 	return 1;
 }
 
+// get_builtin_path()
 int ModApiUtil::l_get_builtin_path(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
 	std::string path = porting::path_share + DIR_DELIM + "builtin";
 	lua_pushstring(L, path.c_str());
+
 	return 1;
 }
 
@@ -401,6 +406,26 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 	return 1;
 }
 
+// get_version()
+int ModApiUtil::l_get_version(lua_State *L)
+{
+	lua_createtable(L, 0, 3);
+	int table = lua_gettop(L);
+
+	lua_pushstring(L, PROJECT_NAME_C);
+	lua_setfield(L, table, "project");
+
+	lua_pushstring(L, g_version_string);
+	lua_setfield(L, table, "string");
+
+	if (strcmp(g_version_string, g_version_hash)) {
+		lua_pushstring(L, g_version_hash);
+		lua_setfield(L, table, "hash");
+	}
+
+	return 1;
+}
+
 
 void ModApiUtil::Initialize(lua_State *L, int top)
 {
@@ -433,6 +458,8 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(get_dir_list);
 
 	API_FCT(request_insecure_environment);
+
+	API_FCT(get_version);
 }
 
 void ModApiUtil::InitializeAsync(AsyncEngine& engine)
@@ -459,5 +486,7 @@ void ModApiUtil::InitializeAsync(AsyncEngine& engine)
 
 	ASYNC_API_FCT(mkdir);
 	ASYNC_API_FCT(get_dir_list);
+
+	ASYNC_API_FCT(get_version);
 }
 

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -95,6 +95,9 @@ private:
 	// request_insecure_environment()
 	static int l_request_insecure_environment(lua_State *L);
 
+	// get_version()
+	static int l_get_version(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 


### PR DESCRIPTION
Pro:
- Allows for informational display of the version (useful for, eg, `/CTCP MinetestServer VERSION`).  In fact the main menu already has access to `get_version()` for the credits.

Con:
- Mods could use the version to detect features, instead of using `minetest.features` or a simple existence check.  This patch doesn't include any version numbers, so mods will have to parse the numbers out of the version string, making it especially unlikely that they will use this method (and even if they do it isn't really our problem).
