### PR TITLE
Add optional framed glasslike drawtype

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -132,18 +132,18 @@ local function formspec(tabview, name, tabdata)
 	local tab_string =
 		"vertlabel[0,-0.25;" .. fgettext("SETTINGS") .. "]" ..
 		"box[0.75,0;3.25,4;#999999]" ..
-		"checkbox[1,0;cb_fancy_trees;".. fgettext("Fancy Trees") .. ";"
-				.. dump(core.setting_getbool("new_style_leaves")) .. "]"..
-		"checkbox[1,0.5;cb_smooth_lighting;".. fgettext("Smooth Lighting")
+		"checkbox[1,0;cb_smooth_lighting;".. fgettext("Smooth Lighting")
 				.. ";".. dump(core.setting_getbool("smooth_lighting")) .. "]"..
+		"checkbox[1,0.5;cb_particles;".. fgettext("Enable Particles") .. ";"
+				.. dump(core.setting_getbool("enable_particles"))	.. "]"..
 		"checkbox[1,1;cb_3d_clouds;".. fgettext("3D Clouds") .. ";"
 				.. dump(core.setting_getbool("enable_3d_clouds")) .. "]"..
-		"checkbox[1,1.5;cb_opaque_water;".. fgettext("Opaque Water") .. ";"
+		"checkbox[1,1.5;cb_fancy_trees;".. fgettext("Fancy Trees") .. ";"
+				.. dump(core.setting_getbool("new_style_leaves")) .. "]"..
+		"checkbox[1,2.0;cb_opaque_water;".. fgettext("Opaque Water") .. ";"
 				.. dump(core.setting_getbool("opaque_water")) .. "]"..
-		"checkbox[1,2.0;cb_pre_ivis;".. fgettext("Preload item visuals") .. ";"
-				.. dump(core.setting_getbool("preload_item_visuals"))	.. "]"..
-		"checkbox[1,2.5;cb_particles;".. fgettext("Enable Particles") .. ";"
-				.. dump(core.setting_getbool("enable_particles"))	.. "]"..
+		"checkbox[1,2.5;cb_connected_glass;".. fgettext("Connected Glass") .. ";"
+				.. dump(core.setting_getbool("connected_glass"))	.. "]"..
 		"dropdown[1,3.25;3;dd_video_driver;"
 			.. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
@@ -259,8 +259,8 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		end
 		return true
 	end
-	if fields["cb_pre_ivis"] then
-		core.setting_set("preload_item_visuals", fields["cb_pre_ivis"])
+	if fields["cb_connected_glass"] then
+		core.setting_set("connected_glass", fields["cb_connected_glass"])
 		return true
 	end
 	if fields["cb_particles"] then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -406,8 +406,7 @@ Nodes can also contain extra data. See "Node Metadata".
 
 Node drawtypes
 ---------------
-There are a bunch of different looking node types. These are mostly just
-copied from Minetest 0.3; more may be made in the future.
+There are a bunch of different looking node types.
 
 Look for examples in games/minimal or games/minetest_game.
 
@@ -417,6 +416,7 @@ Look for examples in games/minimal or games/minetest_game.
 - flowingliquid
 - glasslike
 - glasslike_framed
+- glasslike_framed_optional
 - allfaces
 - allfaces_optional
 - torchlike
@@ -426,6 +426,8 @@ Look for examples in games/minimal or games/minetest_game.
 - fencelike
 - raillike
 - nodebox -- See below. EXPERIMENTAL
+
+*_optional drawtypes need less rendering time if deactivated (always client side)
 
 Node boxes
 -----------

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -101,6 +101,8 @@
 #liquid_update = 1.0
 # Enable nice leaves; disable for speed
 #new_style_leaves = true
+# Connects glass if supported by node
+#connected_glass = false
 # Enable smooth lighting with simple ambient occlusion;
 # disable for speed or for different looks.
 #smooth_lighting = true

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -794,6 +794,10 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				collector.append(tile, vertices, 4, indices, 6);
 			}
 		break;}
+		case NDT_GLASSLIKE_FRAMED_OPTIONAL:
+			// This is always pre-converted to something else
+			assert(0);
+			break;
 		case NDT_GLASSLIKE_FRAMED:
 		{
 			static const v3s16 dirs[6] = {

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -100,6 +100,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("view_bobbing", "true");
 	settings->setDefault("new_style_water", "false");
 	settings->setDefault("new_style_leaves", "true");
+	settings->setDefault("connected_glass", "false");
 	settings->setDefault("smooth_lighting", "true");
 	settings->setDefault("texture_path", "");
 	settings->setDefault("shader_path", "");

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -607,6 +607,7 @@ public:
 
 		bool new_style_water = g_settings->getBool("new_style_water");
 		bool new_style_leaves = g_settings->getBool("new_style_leaves");
+		bool connected_glass = g_settings->getBool("connected_glass");
 		bool opaque_water = g_settings->getBool("opaque_water");
 		bool enable_shaders = g_settings->getBool("enable_shaders");
 		bool enable_bumpmapping = g_settings->getBool("enable_bumpmapping");
@@ -665,6 +666,15 @@ public:
 			case NDT_GLASSLIKE_FRAMED:
 				f->solidness = 0;
 				f->visual_solidness = 1;
+				break;
+			case NDT_GLASSLIKE_FRAMED_OPTIONAL:
+				f->solidness = 0;
+				f->visual_solidness = 1;
+				if (connected_glass) {
+					f->drawtype = NDT_GLASSLIKE_FRAMED;
+				} else {
+					f->drawtype = NDT_GLASSLIKE;
+				}
 				break;
 			case NDT_ALLFACES:
 				f->solidness = 0;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -149,7 +149,9 @@ enum NodeDrawType
 	NDT_GLASSLIKE_FRAMED, // Glass-like, draw connected frames and all all
 	                      // visible faces
 						  // uses 2 textures, one for frames, second for faces
-	NDT_FIRELIKE, // Draw faces slightly rotated and only on connecting nodes
+	NDT_FIRELIKE, // Draw faces slightly rotated and only on connecting nodes,
+	NDT_GLASSLIKE_FRAMED_OPTIONAL,	// enabled -> connected, disabled -> Glass-like
+									// uses 2 textures, one for frames, second for faces
 };
 
 #define CF_SPECIAL_COUNT 6

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -35,6 +35,7 @@ struct EnumString ScriptApiNode::es_DrawType[] =
 		{NDT_FLOWINGLIQUID, "flowingliquid"},
 		{NDT_GLASSLIKE, "glasslike"},
 		{NDT_GLASSLIKE_FRAMED, "glasslike_framed"},
+		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
 		{NDT_ALLFACES, "allfaces"},
 		{NDT_ALLFACES_OPTIONAL, "allfaces_optional"},
 		{NDT_TORCHLIKE, "torchlike"},

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -645,7 +645,8 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 		"NDT_RAILLIKE",
 		"NDT_NODEBOX",
 		"NDT_GLASSLIKE_FRAMED",
-		"NDT_FIRELIKE"
+		"NDT_FIRELIKE",
+		"NDT_GLASSLIKE_FRAMED_OPTIONAL"
 	};
 	
 	for (int i = 0; i < 14; i++){


### PR DESCRIPTION
Needed for sane solution for requests like this: https://github.com/minetest/minetest_game/pull/321

Adds an option to mainmenu (replaces the IMO not needed preload items cb) to enabled connected glass clientside if node drawtype is "glasslike_framed_optional".
