### PR TITLE
Remove xCGUITTFont.cpp and xCGUITTFont.h wrapper files

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -248,7 +248,7 @@ LOCAL_SRC_FILES +=                                \
 		
 #freetype2 support
 LOCAL_SRC_FILES +=                                \
-		jni/src/cguittfont/xCGUITTFont.cpp
+		jni/src/cguittfont/CGUITTFont.cpp
 
 # lua
 LOCAL_SRC_FILES +=                                \

--- a/src/cguittfont/CGUITTFont.cpp
+++ b/src/cguittfont/CGUITTFont.cpp
@@ -29,6 +29,8 @@
 */
 
 #include <irrlicht.h>
+#include <stddef.h>
+#include "irrUString.h"
 #include "CGUITTFont.h"
 
 namespace irr

--- a/src/cguittfont/CMakeLists.txt
+++ b/src/cguittfont/CMakeLists.txt
@@ -1,8 +1,4 @@
-# CGUITTFont authors, y u no include headers you use?
-#   Do not add CGUITTFont.cpp to the line below.
-#   xCGUITTFont.cpp is a wrapper file that includes
-#   additional required headers.
-add_library(cguittfont xCGUITTFont.cpp)
+add_library(cguittfont CGUITTFont.cpp)
 
 if(FREETYPE_PKGCONFIG_FOUND)
 	set_target_properties(cguittfont

--- a/src/cguittfont/xCGUITTFont.cpp
+++ b/src/cguittfont/xCGUITTFont.cpp
@@ -1,5 +1,0 @@
-// A wrapper source file to avoid hack with gcc and modifying
-// the CGUITTFont files.
-
-#include "xCGUITTFont.h"
-#include "CGUITTFont.cpp"

--- a/src/cguittfont/xCGUITTFont.h
+++ b/src/cguittfont/xCGUITTFont.h
@@ -1,7 +1,0 @@
-// A wrapper header to avoid hack with gcc and modifying
-// the CGUITTFont files.
-
-#include <algorithm>
-#include <stddef.h>
-#include "irrUString.h"
-#include "CGUITTFont.h"

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gettext.h"
 
 #if USE_FREETYPE
-#include "xCGUITTFont.h"
+#include "CGUITTFont.h"
 #endif
 
 inline u32 clamp_u8(s32 value)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "mods.h"
 #if USE_FREETYPE
-#include "xCGUITTFont.h"
+#include "CGUITTFont.h"
 #endif
 #include "util/string.h"
 #include "subgame.h"


### PR DESCRIPTION
They were an attempt to avoid modifying CGUITTFont.cpp/CGUITTFont.h,
an attempt which clearly failed.