### PR TITLE
Fixed undesirable right-click and move mouse behaviour introduced by f6...

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2948,7 +2948,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 	if((event.EventType==EET_MOUSE_INPUT_EVENT &&
 			event.MouseInput.Event != EMIE_MOUSE_MOVED) ||
 			(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-			event.MouseInput.isRightPressed() && getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i)){
+			!event.MouseInput.isRightPressed() && getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i)) {
 		// Mouse event other than movement or crossing the border of inventory field while holding rmb
 
 		// Get selected item and hovered/clicked item (s)


### PR DESCRIPTION
Fixed undesirable right-click and move mouse behaviour introduced by f6321e2

Not sure about the rest of the changes, but this one change (by f6321e2) is NOT correct and makes using the craft grid almost impossible. f6321e2 makes it impossible to right-click an item stack and place half of that item stack somewhere else in either the inv. grid or the craft grid because moving the mouse wants to occupy blank cells with one of the source item.
