### PR TITLE
Right mouse button behaviour for craft/inventory

### DIFF
--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -328,6 +328,8 @@ protected:
 	s32 m_old_tooltip_id;
 	std::string m_old_tooltip;
 
+	bool m_rmouse_auto_place;
+
 	bool m_allowclose;
 	bool m_lock;
 	v2u32 m_lockscreensize;


### PR DESCRIPTION
If right mousebutton clicked once then don't drop single items into slots. If right mouse button has been clicked and held a second time, drop items as the mouse is moved. In the second case (automatically drop/place items as mouse is moved) only auto-drop into blank slots, or slots that contain the same item.
