### PR TITLE
Add table.copy(table)

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -471,6 +471,18 @@ function core.pos_to_string(pos)
 end
 
 --------------------------------------------------------------------------------
+function table.copy(t, seen)
+	local n = {}
+	seen = seen or {}
+	seen[t] = n
+	for k, v in pairs(t) do
+		n[type(k) ~= "table" and k or seen[k] or table.copy(k, seen)] =
+			type(v) ~= "table" and v or seen[v] or table.copy(v, seen)
+	end
+	return n
+end
+
+--------------------------------------------------------------------------------
 -- mainmenu only functions
 --------------------------------------------------------------------------------
 if INIT == "mainmenu" then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1281,6 +1281,8 @@ minetest.is_yes(arg)
 ^ returns whether arg can be interpreted as yes
 minetest.get_us_time()
 ^ returns time with microsecond precision
+table.copy(table) -> table
+^ returns a deep copy of a table
 
 minetest namespace reference
 -----------------------------


### PR DESCRIPTION
To get rid off the "table references".
