### PR TITLE
Fixed using unitialized variables in mouse button handling

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2946,11 +2946,14 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 	}
 
-	if((event.EventType==EET_MOUSE_INPUT_EVENT &&
-			event.MouseInput.Event != EMIE_MOUSE_MOVED) ||
-			(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
-			event.MouseInput.isRightPressed() && getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i)){
-		// Mouse event other than movement or crossing the border of inventory field while holding rmb
+	/* Mouse event other than movement, or crossing the border of inventory
+	  field while holding right mouse button
+	 */
+	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
+			(event.MouseInput.Event != EMIE_MOUSE_MOVED ||
+			  (event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+			   event.MouseInput.isRightPressed() &&
+			   getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i))) {
 
 		// Get selected item and hovered/clicked item (s)
 


### PR DESCRIPTION
See also: https://github.com/minetest/minetest/pull/1707

event.MouseInput.Event is not initialized if event.EventType != EET_MOUSE_INPUT_EVENT and the previous code didn't check that EET_MOUSE_INPUT_EVENT was indeed the event type before checking the MouseEvent (and it was therefore invalid/not initialized).
