### PR TITLE
Add tooltips to main menu subgames button bar

### DIFF
--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -57,10 +57,10 @@ local function buttonbar_formspec(self)
 		end
 			
 		formspec = formspec ..
-			string.format("image_button[%f,%f;%f,%f;%s;%s;%s;true;%s]",
+			string.format("image_button[%f,%f;%f,%f;%s;%s;%s;true;%s]tooltip[%s;%s]",
 					btn_pos.x, btn_pos.y, self.btn_size, self.btn_size,
 					self.buttons[i].image, btn_name, self.buttons[i].caption,
-					borders)
+					borders, btn_name, self.buttons[i].tooltip)
 		else
 			--print("end of displayable buttons: orientation: " .. self.orientation)
 			--print( "button_end: " .. (btn_pos.y + self.btn_size - (self.btn_size * 0.05)))
@@ -140,11 +140,12 @@ local buttonbar_metatable = {
 
 	delete = function(self) ui.delete(self) end,
 	
-	add_button = function(self, name, caption, image)
+	add_button = function(self, name, caption, image, tooltip)
 			if caption == nil then caption = "" end
 			if image == nil then image = "" end
+			if tooltip == nil then tooltip = "" end
 			
-			table.insert(self.buttons,{ name=name, caption=caption, image=image})
+			table.insert(self.buttons,{ name=name, caption=caption, image=image, tooltip=tooltip})
 			if self.orientation == "horizontal" then
 				if ( (self.btn_size * #self.buttons) + (self.btn_size * 0.05 *2)
 					> self.size.x ) then

--- a/builtin/mainmenu/tab_singleplayer.lua
+++ b/builtin/mainmenu/tab_singleplayer.lua
@@ -52,6 +52,7 @@ local function singleplayer_refresh_gamebar()
 		
 		local image = nil
 		local text = nil
+		local tooltip = gamemgr.games[i].name
 		
 		if gamemgr.games[i].menuicon_path ~= nil and
 			gamemgr.games[i].menuicon_path ~= "" then
@@ -68,7 +69,7 @@ local function singleplayer_refresh_gamebar()
 				text = text .. "\n" .. part3
 			end
 		end
-		btnbar:add_button(btn_name, text, image)
+		btnbar:add_button(btn_name, text, image, tooltip)
 	end
 end
 


### PR DESCRIPTION
This small PR changes the builtin code.

It adds a new feature to button bars: Every button can now have a tooltip.
The main menu is also modified. Now every game icon has a tooltip containing the name of the subgame.
