### PR TITLE
Only set the camera update keymap when using a debug build

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -52,7 +52,12 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");
 	settings->setDefault("keymap_toggle_force_fog_off", "KEY_F3");
-	settings->setDefault("keymap_toggle_update_camera", "KEY_F4");
+	settings->setDefault("keymap_toggle_update_camera",
+#if DEBUG
+			"KEY_F4");
+#else
+			"none");
+#endif
 	settings->setDefault("keymap_toggle_debug", "KEY_F5");
 	settings->setDefault("keymap_toggle_profiler", "KEY_F6");
 	settings->setDefault("keymap_camera_mode", "KEY_F7");


### PR DESCRIPTION
To stop noobs accidentally pressing the wrong button and disabling it.

An alternative is removing the feature when not using a debug build, instead of just removing the keybinding.

If you use a normal build, hitting F4 does nothing. If you use a debug build, it toggles camera updates. You can still set F4 to toggle camera updates in minetest.conf
