### PR TITLE
line_of_sight: Allow sight through sunlight_propagates nodes

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -405,7 +405,7 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 
 
 		MapNode n = getMap().getNodeNoEx(pos);
 
-		if(n.param0 != CONTENT_AIR) {
+		if(n.param0 != CONTENT_AIR && m_gamedef->ndef()->get(n).sunlight_propagates == false) {
 			if (p) {
 				*p = pos;
 			}


### PR DESCRIPTION
Add the sunlight_propagates condition in the line_of_sight function. If the sun light can pass through a node then it should also be possible to see through it.

I think it is an improvement. If not just explain me why ! ;-)