### PR TITLE
minetest.registered_ores lua table (and idem for decorations and biomes)

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -10,6 +10,15 @@ core.register_item_raw = nil
 local register_alias_raw = core.register_alias_raw
 core.register_alias_raw = nil
 
+local register_ore_raw = core.register_ore
+core.register_ore = nil
+
+local register_decoration_raw = core.register_decoration
+core.register_decoration = nil
+
+local register_biome_raw = core.register_biome
+core.register_biome = nil
+
 --
 -- Item / entity / ABM registration functions
 --
@@ -369,6 +378,29 @@ function core.run_callbacks(callbacks, mode, ...)
 		end
 	end
 	return ret
+end
+
+--
+-- Mapgen registrations functions
+--
+
+core.registered_ores = {}
+core.registered_decorations = {}
+core.registered_biomes = {}
+
+function core.register_ore(def)
+	table.insert(core.registered_ores, def)
+	register_ore_raw(def)
+end
+
+function core.register_decoration(def)
+	table.insert(core.registered_decorations, def)
+	register_decoration_raw(def)
+end
+
+function core.register_biome(def)
+	table.insert(core.registered_biomes, def)
+	register_biome_raw(def)
 end
 
 --


### PR DESCRIPTION
I've already made mapgens, and I wanted to put minerals in these mapgens. The problem is that we can't use the ores API to place ores. And there isn't any list of registered ores in LUA, I had to redefine all of the ores. So I've fixed it, and I've done the same for decorations and biomes.
So we have `minetest.registered_ores`, `minetest.registered_decorations` and `minetest.registered_biomes`.

In practice, the behaviour of the registration functions isn't changed.