### PR TITLE
Add ability to escape commands with a back-slash

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1566,16 +1566,14 @@ void Client::typeChatMessage(const std::wstring &message)
 	sendChatMessage(message);
 
 	// Show locally
-	if (message[0] == L'/')
-	{
+	if (message[0] == L'/') {
 		m_chat_queue.push((std::wstring)L"issued command: " + message);
-	}
-	else
-	{
+	} else {
 		LocalPlayer *player = m_env.getLocalPlayer();
 		assert(player != NULL);
 		std::wstring name = narrow_to_wide(player->getName());
-		m_chat_queue.push((std::wstring)L"<" + name + L"> " + message);
+		m_chat_queue.push((std::wstring)L"<" + name + L"> " +
+			(message[0] == L'\\' ? message.substr(1) : message));
 	}
 }
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1085,13 +1085,12 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 			line += L"-!- Empty command";
 		else
 			line += L"-!- Invalid command: " + str_split(message, L' ')[0];
-	}
-	else {
+	} else {
 		if (checkPriv(player->getName(), "shout")) {
 			line += L"<";
 			line += name;
 			line += L"> ";
-			line += message;
+			line += (message[0] == L'\\' ? message.substr(1) : message);
 		} else {
 			line += L"-!- You don't have permission to shout.";
 			send_to_sender_only = true;


### PR DESCRIPTION
Rationale: Useful when telling a user to run a specific command.

Older clients will see the back slash on their display when they send a message, and older servers will show the backslash on all other displays.
