### PR TITLE
Improved VoxelArea variable locality, thus performance

### DIFF
--- a/builtin/game/voxelarea.lua
+++ b/builtin/game/voxelarea.lua
@@ -18,10 +18,11 @@ function VoxelArea:new(o)
 end
 
 function VoxelArea:getExtent()
+	local MaxEdge, MinEdge = self.MaxEdge, self.MinEdge
 	return {
-		x = self.MaxEdge.x - self.MinEdge.x + 1,
-		y = self.MaxEdge.y - self.MinEdge.y + 1,
-		z = self.MaxEdge.z - self.MinEdge.z + 1,
+		x = MaxEdge.x - MinEdge.x + 1,
+		y = MaxEdge.y - MinEdge.y + 1,
+		z = MaxEdge.z - MinEdge.z + 1,
 	}
 end
 
@@ -31,45 +32,50 @@ function VoxelArea:getVolume()
 end
 
 function VoxelArea:index(x, y, z)
-	local i = (z - self.MinEdge.z) * self.zstride +
-			  (y - self.MinEdge.y) * self.ystride +
-			  (x - self.MinEdge.x) + 1
+	local MinEdge = self.MinEdge
+	local i = (z - MinEdge.z) * self.zstride +
+			  (y - MinEdge.y) * self.ystride +
+			  (x - MinEdge.x) + 1
 	return math.floor(i)
 end
 
 function VoxelArea:indexp(p)
-	local i = (p.z - self.MinEdge.z) * self.zstride +
-			  (p.y - self.MinEdge.y) * self.ystride +
-			  (p.x - self.MinEdge.x) + 1
+	local MinEdge = self.MinEdge
+	local i = (p.z - MinEdge.z) * self.zstride +
+			  (p.y - MinEdge.y) * self.ystride +
+			  (p.x - MinEdge.x) + 1
 	return math.floor(i)
 end
 
 function VoxelArea:position(i)
 	local p = {}
+	local MinEdge = self.MinEdge
  
 	i = i - 1
 
-	p.z = math.floor(i / self.zstride) + self.MinEdge.z
+	p.z = math.floor(i / self.zstride) + MinEdge.z
 	i = i % self.zstride
 
-	p.y = math.floor(i / self.ystride) + self.MinEdge.y
+	p.y = math.floor(i / self.ystride) + MinEdge.y
 	i = i % self.ystride
 
-	p.x = math.floor(i) + self.MinEdge.x
+	p.x = math.floor(i) + MinEdge.x
 
 	return p
 end
 
 function VoxelArea:contains(x, y, z)
-	return (x >= self.MinEdge.x) and (x <= self.MaxEdge.x) and
-		   (y >= self.MinEdge.y) and (y <= self.MaxEdge.y) and
-		   (z >= self.MinEdge.z) and (z <= self.MaxEdge.z)
+	local MaxEdge, MinEdge = self.MaxEdge, self.MinEdge
+	return (x >= MinEdge.x) and (x <= MaxEdge.x) and
+		   (y >= MinEdge.y) and (y <= MaxEdge.y) and
+		   (z >= MinEdge.z) and (z <= MaxEdge.z)
 end
 
 function VoxelArea:containsp(p)
-	return (p.x >= self.MinEdge.x) and (p.x <= self.MaxEdge.x) and
-		   (p.y >= self.MinEdge.y) and (p.y <= self.MaxEdge.y) and
-		   (p.z >= self.MinEdge.z) and (p.z <= self.MaxEdge.z)
+	local MaxEdge, MinEdge = self.MaxEdge, self.MinEdge
+	return (p.x >= MinEdge.x) and (p.x <= MaxEdge.x) and
+		   (p.y >= MinEdge.y) and (p.y <= MaxEdge.y) and
+		   (p.z >= MinEdge.z) and (p.z <= MaxEdge.z)
 end
 
 function VoxelArea:containsi(i)


### PR DESCRIPTION
I remembered of some Lua optimization tips, including the speed penalty introduced by globals and table element fetching (including `self`), so optimized away VoxelArea because it is somewhat performance-critical code in Lua-based mapgens.

Here's a benchmark script I used to test if my changes did make a difference (only tests original and optimized `VoxelArea:getExtent()`): http://pastebin.com/SSm10Nh0, and here are my results:

``` sh
$ lua vx.lua && luajit vx.lua
C  LUA Time  self: 0.87
C  LUA Time local: 0.77
LuaJIT Time  self: 0.41
LuaJIT Time local: 0.40
```

So on LuaJIT it makes little to no difference, and for builds without LuaJIT it _does_ make a little improvement.
