### PR TITLE
Tune cave noise scales to 6. Fix blobs spflag, now usable. Update conf.example

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -425,15 +425,17 @@
 # Perlin noise attributes for different map generation parameters
 # Offset, scale, spread factor, seed offset, number of octaves, persistence
 
+#mgv5_spflags = blobs
 #mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7
 #mgv5_np_factor = 0, 1, (250, 250, 250), 920381, 3, 0.45
 #mgv5_np_height = 0, 10, (250, 250, 250), 84174, 4, 0.5
-#mgv5_np_cave1 = 0, 7.5, (50, 50, 50), 52534, 4, 0.5
-#mgv5_np_cave2 = 0, 7.5, (50, 50, 50), 10325, 4, 0.5
+#mgv5_np_cave1 = 0, 6, (50, 50, 50), 52534, 4, 0.5
+#mgv5_np_cave2 = 0, 6, (50, 50, 50), 10325, 4, 0.5
 #mgv5_np_ground = 0, 40, (80, 80, 80), 983240, 4, 0.55
 #mgv5_np_crumble = 0, 1, (20, 20, 20), 34413, 3, 1.3
 #mgv5_np_wetness = 0, 1, (40, 40, 40), 32474, 4, 1.1
 
+#mgv6_spflags = biomeblend, jungles, mudflow
 #mgv6_np_terrain_base = -4, 20, (250, 250, 250), 82341, 5, 0.6
 #mgv6_np_terrain_higher = 20, 16, (500, 500, 500), 85039, 5, 0.6
 #mgv6_np_steepness = 0.85, 0.5, (125, 125, 125), -932, 5, 0.7

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen.h"
 
 /////////////////// Mapgen V5 flags
-//#define MGV5_BLOBS 0x01
+#define MGV5_BLOBS 0x01
 
 extern FlagDesc flagdesc_mapgen_v5[];
 


### PR DESCRIPTION
6 now seems the best match to me from flying underground and attempting to match caves width visually to my build with the original noise code. Calinou helped me tune the cave width with his experience of the original mgv5, the caves were still too narrow with the noise scale of 7.5.
Kwolekr spotted my mistake with spflags, dirt/sand/gravel/lava blobs are now optional, enabled by default.
