### PR TITLE
Fix for various Android build errors. Enable landscape rotation.

### DIFF
--- a/build/android/AndroidManifest.xml.template
+++ b/build/android/AndroidManifest.xml.template
@@ -15,7 +15,7 @@
 		android:label="Minetest"
 		android:launchMode="singleTask"
 		android:configChanges="orientation|keyboardHidden"
-		android:screenOrientation="landscape"
+		android:screenOrientation="sensorLandscape"
 		android:clearTaskOnLaunch="true">
 		<intent-filter>
 			<action android:name="android.intent.action.MAIN" />

--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -125,6 +125,11 @@ FREETYPE_URL_GIT = https://github.com/cdave1/freetype2-android
 
 -include $(PATHCFGFILE)
 
+#use interim target variable to switch leveldb on or off
+ifeq ($(HAVE_LEVELDB),1)
+	LEVELDB_TARGET = $(LEVELDB_LIB)
+endif
+
 .PHONY : debug release reconfig delconfig \
 	leveldb_download clean_leveldb leveldb\
 	irrlicht_download clean_irrlicht irrlicht \
@@ -140,11 +145,6 @@ FREETYPE_URL_GIT = https://github.com/cdave1/freetype2-android
 	$(OPENSSL_TIMESTAMP) curl_binary \
 	$(ROOT)/jni/src/android_version.h
 	
-#use interim target variable to switch leveldb on or off
-ifeq ($(HAVE_LEVELDB),1)
-	LEVELDB_TARGET = $(LEVELDB_LIB)
-endif
-
 debug : $(PATHCFGFILE)
 	export NDEBUG=;                                                            \
 	export BUILD_TYPE=debug;                                                   \
@@ -172,9 +172,9 @@ $(PATHCFGFILE) :
 		exit 1;                                                                \
 	fi;                                                                        \
 	echo "ANDROID_NDK = $$ANDROID_NDK" > ${PATHCFGFILE};                       \
-	echo "NDK_MODULE_PATH = $$ANDROID_NDK/tools" >> ${PATHCFGFILE};            \
+	echo "NDK_MODULE_PATH = $$ANDROID_NDK/toolchains" >> ${PATHCFGFILE};            \
 	echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++";\
-	echo "+ Note: NDK_MODULE_PATH is set to $$ANDROID_NDK/tools";              \
+	echo "+ Note: NDK_MODULE_PATH is set to $$ANDROID_NDK/toolchains";              \
 	echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++";\
 	echo "Please specify path of ANDROID SDK";                                 \
 	echo "e.g. /home/user/adt-bundle-linux-x86_64-20131030/sdk/";              \

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -159,6 +159,7 @@ LOCAL_SRC_FILES :=                                \
 		jni/src/mapblock_mesh.cpp                 \
 		jni/src/mapgen.cpp                        \
 		jni/src/mapgen_singlenode.cpp             \
+		jni/src/mapgen_v5.cpp                     \
 		jni/src/mapgen_v6.cpp                     \
 		jni/src/mapgen_v7.cpp                     \
 		jni/src/mapnode.cpp                       \

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2053,7 +2053,7 @@ bool Game::initGui(std::wstring *error_message)
 #ifdef HAVE_TOUCHSCREENGUI
 
 	if (g_touchscreengui)
-		g_touchscreengui->init(tsrc, porting::getDisplayDensity());
+		g_touchscreengui->init(texture_src, porting::getDisplayDensity());
 
 #endif
 
@@ -2844,8 +2844,8 @@ void Game::updateCameraDirection(CameraOrientation *cam,
 #ifdef HAVE_TOUCHSCREENGUI
 
 		if (g_touchscreengui) {
-			camera_yaw   = g_touchscreengui->getYaw();
-			camera_pitch = g_touchscreengui->getPitch();
+			cam->camera_yaw   = g_touchscreengui->getYaw();
+			cam->camera_pitch = g_touchscreengui->getPitch();
 		} else {
 #endif
 			s32 dx = input->getMousePos().X - (driver->getScreenSize().Width / 2);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -212,11 +212,11 @@ inline std::string trim(const std::string &s)
 {
 	size_t front = 0;
 
-	while (isspace(s[front]))
+	while (std::isspace(s[front]))
 		++front;
 
 	size_t back = s.size();
-	while (back > front && isspace(s[back-1]))
+	while (back > front && std::isspace(s[back-1]))
 		--back;
 
 	return s.substr(front, back - front);
@@ -481,7 +481,7 @@ inline std::string unescape_string(std::string &s)
 inline bool is_number(const std::string &tocheck)
 {
 	for (size_t i = 0; i < tocheck.size(); i++)
-	    if (!isdigit(tocheck[i]))
+	    if (!std::isdigit(tocheck[i]))
 	        return false;
 
 	return !tocheck.empty();


### PR DESCRIPTION
- Fix typo in Android Makefile ndk path. #1678  
- Fix Makefile not checking leveldb.
- Fix touchscreen parts of game.cpp to work after Zeno's refactor.
- Fix isdigit and isspace overload conflict with Android Irrlicht in string.h
- Enable sensor landscape rotation in Android Manifiest.
- Add mapgen v5 to Android build.
