### PR TITLE
Serverlist: announce mg_name from map_meta.txt instead of minetest.conf

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -687,6 +687,7 @@ void Server::AsyncRunStep(bool initial_step)
 					m_env->getGameTime(),
 					m_lag,
 					m_gamespec.id,
+					m_emerge->params.mg_name,
 					m_mods);
 			counter = 0.01;
 		}

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -194,6 +194,7 @@ void sendAnnounce(const std::string &action,
 		const u32 game_time,
 		const float lag,
 		const std::string &gameid,
+		const std::string &mg_name,
 		const std::vector<ModSpec> &mods)
 {
 	Json::Value server;
@@ -227,7 +228,7 @@ void sendAnnounce(const std::string &action,
 	if (action == "start") {
 		server["dedicated"]         = g_settings->getBool("server_dedicated");
 		server["rollback"]          = g_settings->getBool("enable_rollback_recording");
-		server["mapgen"]            = g_settings->get("mg_name");
+		server["mapgen"]            = mg_name;
 		server["privs"]             = g_settings->get("default_privs");
 		server["can_see_far_names"] = g_settings->getS16("player_transfer_distance") <= 0;
 		server["mods"]              = Json::Value(Json::arrayValue);

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -42,6 +42,7 @@ namespace ServerList
 			const std::vector<std::string> &clients_names = std::vector<std::string>(),
 			const double uptime = 0, const u32 game_time = 0,
 			const float lag = 0, const std::string &gameid = "",
+			const std::string &mg_name = "",
 			const std::vector<ModSpec> &mods = std::vector<ModSpec>());
 	#endif
 } // ServerList namespace


### PR DESCRIPTION
This bug caused e.g. Amaz's Cube World to be announced with v5 instead of singlenode.
