### PR TITLE
Fix raillike bug (currently manifests itself on Android), and minor improvement to readability.

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1621,17 +1621,18 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			video::SColor c = MapBlock_LightColor(255, l, f.light_source);
 
 			float d = (float)BS/64;
-			
-			char g=-1;
+			float s = BS/2;
+
+			int g=-1;
 			if (is_rail_x_plus_y[0] || is_rail_x_plus_y[1] || is_rail_z_plus_y[0] || is_rail_z_plus_y[1])
 				g=1; //Object is at a slope
 
 			video::S3DVertex vertices[4] =
 			{
-					video::S3DVertex(-BS/2,-BS/2+d,-BS/2, 0,0,0, c, 0,1),
-					video::S3DVertex(BS/2,-BS/2+d,-BS/2, 0,0,0, c, 1,1),
-					video::S3DVertex(BS/2,g*BS/2+d,BS/2, 0,0,0, c, 1,0),
-					video::S3DVertex(-BS/2,g*BS/2+d,BS/2, 0,0,0, c, 0,0),
+					video::S3DVertex(-s, -s+d,-s, 0,0,0, c, 0,1),
+					video::S3DVertex( s, -s+d,-s, 0,0,0, c, 1,1),
+					video::S3DVertex( s,g*s+d, s, 0,0,0, c, 1,0),
+					video::S3DVertex(-s,g*s+d, s, 0,0,0, c, 0,0),
 			};
 
 			for(s32 i=0; i<4; i++)


### PR DESCRIPTION
Corrects this annoying bug: <link>https://forum.minetest.net/viewtopic.php?f=3&t=9389&start=75#p149910</link> where horizontal raillikes will shoot into the sky.
