### PR TITLE
Mgv5 get ground level at point function for locating spawn of new player

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -94,6 +94,7 @@ public:
 	~MapgenV5();
 	
 	virtual void makeChunk(BlockMakeData *data);
+	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	void generateBaseTerrain();
 	void generateBlobs();


### PR DESCRIPTION
Time per search: slow 50-230us, fast 0-13us.
This commit is now simplfied, with the slow precise search for true highest ground in column commented out for possible future use. The default code is speed optimised for how server:findspawnpos works, it only searches the 16 nodes above water level for ground under at least 8 nodes of air, since findspawnpos only accepts a low altitude spawn.
