### PR TITLE
Add setting to customise stack max

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -106,7 +106,7 @@ function core.facedir_to_dir(facedir)
 					{x=0, y=1, z=0}})
 
 					--indexed into by a table of correlating facedirs
-					[({[0]=1, 2, 3, 4, 
+					[({[0]=1, 2, 3, 4,
 						5, 2, 6, 4,
 						6, 2, 5, 4,
 						1, 5, 3, 6,
@@ -238,7 +238,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 
 	core.log("action", placer:get_player_name() .. " places node "
 		.. def.name .. " at " .. core.pos_to_string(place_to))
-	
+
 	local oldnode = core.get_node(place_to)
 	local newnode = {name = def.name, param1 = 0, param2 = param2}
 
@@ -425,7 +425,7 @@ function core.node_dig(pos, node, digger)
 
 	local wielded = digger:get_wielded_item()
 	local drops = core.get_node_drops(node.name, wielded:get_name())
-	
+
 	local wdef = wielded:get_definition()
 	local tp = wielded:get_tool_capabilities()
 	local dp = core.get_dig_params(def.groups, tp)
@@ -438,7 +438,7 @@ function core.node_dig(pos, node, digger)
 		end
 	end
 	digger:set_wielded_item(wielded)
-	
+
 	-- Handle drops
 	core.handle_node_drops(pos, drops, digger)
 
@@ -449,7 +449,7 @@ function core.node_dig(pos, node, digger)
 
 	-- Remove node and update
 	core.remove_node(pos)
-	
+
 	-- Run callback
 	if def.after_dig_node then
 		-- Copy pos and node because callback can modify them
@@ -490,7 +490,7 @@ core.nodedef_default = {
 	inventory_image = "",
 	wield_image = "",
 	wield_scale = {x=1,y=1,z=1},
-	stack_max = 99,
+	stack_max = tonumber(core.setting_get("default_stack_max")) or 99,
 	usable = false,
 	liquids_pointable = false,
 	tool_capabilities = nil,
@@ -507,7 +507,7 @@ core.nodedef_default = {
 	on_dig = redef_wrapper(core, 'node_dig'), -- core.node_dig
 
 	on_receive_fields = nil,
-	
+
 	on_metadata_inventory_move = core.node_metadata_inventory_move_allow_all,
 	on_metadata_inventory_offer = core.node_metadata_inventory_offer_allow_all,
 	on_metadata_inventory_take = core.node_metadata_inventory_take_allow_all,
@@ -553,7 +553,7 @@ core.craftitemdef_default = {
 	inventory_image = "",
 	wield_image = "",
 	wield_scale = {x=1,y=1,z=1},
-	stack_max = 99,
+	stack_max = tonumber(core.setting_get("default_stack_max")) or 99,
 	liquids_pointable = false,
 	tool_capabilities = nil,
 
@@ -589,7 +589,7 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 	inventory_image = "",
 	wield_image = "",
 	wield_scale = {x=1,y=1,z=1},
-	stack_max = 99,
+	stack_max = tonumber(core.setting_get("default_stack_max")) or 99,
 	liquids_pointable = false,
 	tool_capabilities = nil,
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -547,6 +547,26 @@ Look for examples in `games/minimal` or `games/minetest_game`.
 
 `*_optional` drawtypes need less rendering time if deactivated (always client side).
 
+default_stack_max
+-----------------
+
+Players on singleplayer or hosting a server can
+modify the stack max which is used when no
+stack_max is defined by the item's definition
+using default_stack_max in minetest.conf
+If you don't want players to do this, you can
+override the default_stack_max like this:
+
+    minetest.nodedef_default.stack_max = 123
+    minetest.craftitemdef_default.stack_max = 123
+    minetest.noneitemdef_default.stack_max = 123
+
+You should only do this if you absolutely don't want
+the player to change the stack_max. If you don't mind,
+then you can set default_stack_max in game/minetest.conf
+
+It only affects nodes registered after this call.
+
 Node boxes
 -----------
 Node selection boxes are defined using "node boxes"
@@ -593,7 +613,7 @@ set to level from `param2`.
 Meshes
 ------
 If drawtype `mesh` is used, tiles should hold model materials textures.
-Only static meshes are implemented.  
+Only static meshes are implemented.
 For supported model formats see Irrlicht engine documentation.
 
 
@@ -688,7 +708,7 @@ The relative height of the sheet can be controlled by the same perlin noise as w
 a non-zero `scale` parameter in `noise_params`.
 
 **IMPORTANT**: The noise is not transformed by `offset` or `scale` when comparing against the noise
-threshold, but scale is used to determine relative height.  
+threshold, but scale is used to determine relative height.
 The height of the blob is randomly scattered, with a maximum height of `clust_size`.
 
 `clust_scarcity` and `clust_num_ores` are ignored.
@@ -696,7 +716,7 @@ The height of the blob is randomly scattered, with a maximum height of `clust_si
 This is essentially an improved version of the so-called "stratus" ore seen in some unofficial mods.
 
 ### `blob`
-Creates a deformed sphere of ore according to 3d perlin noise described by 
+Creates a deformed sphere of ore according to 3d perlin noise described by
 `noise_params`.  The maximum size of the blob is `clust_size`, and
 `clust_scarcity` has the same meaning as with the `scatter` type.
 ### `vein
@@ -1185,7 +1205,7 @@ Damage calculation:
 Client predicts damage based on damage groups. Because of this, it is able to
 give an immediate response when an entity is damaged or dies; the response is
 pre-defined somehow (e.g. by defining a sprite animation) (not implemented;
-TODO).  
+TODO).
 Currently a smoke puff will appear when an entity dies.
 
 The group `immortal` completely disables normal damage.
@@ -2244,7 +2264,7 @@ Class reference
 ---------------
 
 ### `NodeMetaRef`
-Node metadata: reference extra data and functionality stored in a node.  
+Node metadata: reference extra data and functionality stored in a node.
 Can be gotten via `minetest.get_meta(pos)`.
 
 #### Methods
@@ -2260,7 +2280,7 @@ Can be gotten via `minetest.get_meta(pos)`.
     * See "Node Metadata"
 
 ### `NoteTimerRef`
-Node Timers: a high resolution persistent per-node timer.  
+Node Timers: a high resolution persistent per-node timer.
 Can be gotten via `minetest.get_node_timer(pos)`.
 
 #### Methods
@@ -2485,7 +2505,7 @@ It can be created via `PseudoRandom(seed)`.
 ### `PerlinNoise`
 A perlin noise generator.
 It can be created via `PerlinNoise(seed, octaves, persistence, scale)`
-or `PerlinNoise(noiseparams)`.  
+or `PerlinNoise(noiseparams)`.
 Alternatively with `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
 or `minetest.get_perlin(noiseparams)`.
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -421,6 +421,10 @@
 #    to IPv6 clients, depending on system configuration.
 #    Ignored if bind_address is set.
 #ipv6_server = false
+#    Set the default maximum stack size in the inventory, if the item's definition does not set it
+#    Games can stop the user from overriding the stack maximum.
+#    See "default_stack_max" in lua_api.txt for more information.
+#default_stack_max = 99
 
 #
 #    Physics stuff


### PR DESCRIPTION
eg:
```
default_stack_max = 34
```
in minetest.conf.

**To add this to a subgame:**

You should add the line to minetest.conf in your game's directory.
However, sometimes you may not want players to be able to override it.
To stop this, add the following lines before any items are defined:
```
minetest.nodedef_default.stack_max      = 123
minetest.craftitemdef_default.stack_max = 123
```