### PR TITLE
Split block position in SQLite3 database

### DIFF
--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -196,52 +196,26 @@ SQLite3 was slammed in, and blocks files were directly inserted as blobs
 in a single table, indexed by integer primary keys, oddly mangled from
 coordinates.
 
-Today we know that SQLite3 allows multiple primary keys (which would allow
-storing coordinates separately), but the format has been kept unchanged for
-that part. So, this is where it has come.
-</history>
+Now the SQLite3 format has been changed to store the coordinates in seperate
+database fields, however the other database backends still use the mangled
+position hash -- usually encoded as ASCII decimal.
 
 So here goes
 -------------
-map.sqlite is an sqlite3 database, containing a single table, called
+map.sqlite is an SQLite3 database, containing a single table, called
 "blocks". It looks like this:
 
-  CREATE TABLE `blocks` (`pos` INT NOT NULL PRIMARY KEY,`data` BLOB);
+	CREATE TABLE `blocks` (
+		`x` INTEGER NOT NULL,
+		`y` INTEGER NOT NULL,
+		`z` INTEGER NOT NULL,
+		`data` BLOB,
+		PRIMARY KEY (`x`, `y`, `z`)
+	);
 
-The key
---------
-"pos" is created from the three coordinates of a MapBlock using this
-algorithm, defined here in Python:
-
-  def getBlockAsInteger(p):
-      return int64(p[2]*16777216 + p[1]*4096 + p[0])
-
-  def int64(u):
-      while u >= 2**63:
-          u -= 2**64
-      while u <= -2**63:
-          u += 2**64
-      return u
-
-It can be converted the other way by using this code:
-
-  def getIntegerAsBlock(i):
-      x = unsignedToSigned(i % 4096, 2048)
-      i = int((i - x) / 4096)
-      y = unsignedToSigned(i % 4096, 2048)
-      i = int((i - y) / 4096)
-      z = unsignedToSigned(i % 4096, 2048)
-      return x,y,z
-
-  def unsignedToSigned(i, max_positive):
-      if i < max_positive:
-          return i
-      else:
-          return i - 2*max_positive
-
-The blob
+The BLOB
 ---------
-The blob is the data that would have otherwise gone into the file.
+The BLOB is the data that would have otherwise gone into the file.
 
 See below for description.
 

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -20,7 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 SQLite format specification:
 	blocks:
-		(PK) INT id
+		int PK x
+		int PK y
+		int PK z
 		BLOB data
 */
 
@@ -35,6 +37,10 @@ SQLite format specification:
 #include "util/string.h"
 
 #include <cassert>
+#include <iostream>
+
+
+#define LATEST_DB_VERSION 1
 
 // When to print messages when the database is being held locked by another process
 // Note: I've seen occasional delays of over 250ms while running minetestmapper.
@@ -52,8 +58,8 @@ SQLite format specification:
 	}
 #define SQLOK(s, m) SQLRES(s, SQLITE_OK, m)
 
-#define PREPARE_STATEMENT(name, query) \
-	SQLOK(sqlite3_prepare_v2(m_database, query, -1, &m_stmt_##name, NULL),\
+#define PREPARE_STATEMENT(stmt, query) \
+	SQLOK(sqlite3_prepare_v2(m_database, query, -1, &(stmt), NULL),\
 		"Failed to prepare query '" query "'")
 
 #define SQLOK_ERRSTREAM(s, m)                           \
@@ -64,6 +70,20 @@ SQLite format specification:
 
 #define FINALIZE_STATEMENT(statement) SQLOK_ERRSTREAM(sqlite3_finalize(statement), \
 	"Failed to finalize " #statement)
+
+
+Database_SQLite3::Database_SQLite3(const std::string &savedir) :
+	m_savedir(savedir),
+	m_database(NULL),
+	m_stmt_read(NULL),
+	m_stmt_write(NULL),
+	m_stmt_list(NULL),
+	m_stmt_delete(NULL),
+	m_stmt_begin(NULL),
+	m_stmt_end(NULL)
+{
+	openDatabase();
+}
 
 int Database_SQLite3::busyHandler(void *data, int count)
 {
@@ -110,29 +130,123 @@ int Database_SQLite3::busyHandler(void *data, int count)
 	return cur_time - first_time < BUSY_FATAL_TRESHOLD;
 }
 
-
-Database_SQLite3::Database_SQLite3(const std::string &savedir) :
-	m_initialized(false),
-	m_savedir(savedir),
-	m_database(NULL),
-	m_stmt_read(NULL),
-	m_stmt_write(NULL),
-	m_stmt_list(NULL),
-	m_stmt_delete(NULL),
-	m_stmt_begin(NULL),
-	m_stmt_end(NULL)
+void Database_SQLite3::checkMigrate()
 {
+	sqlite3_stmt *stmt_get_version = NULL;
+	PREPARE_STATEMENT(stmt_get_version, "PRAGMA user_version");
+
+	if (sqlite3_step(stmt_get_version) != SQLITE_ROW) {
+		throw FileNotGoodException("Fetching SQLite3 database "
+			"version failed!");
+	}
+
+	int version = sqlite3_column_int(stmt_get_version, 0);
+	FINALIZE_STATEMENT(stmt_get_version);
+
+	switch (version) {
+	case 0: {
+		std::string flag_path = m_savedir + DIR_DELIM + "map.sqlite.migrating";
+		bool migrationStarted = fs::PathExists(flag_path);
+		if (!migrationStarted) {
+			std::ofstream flag(flag_path.c_str());
+		}
+		if (!migrate(migrationStarted))
+			throw FileNotGoodException("Migration paused");
+		std::cerr << "Map schema successfully migrated!" << std::endl;
+		fs::DeleteSingleFileOrEmptyDirectory(flag_path);
+	}
+	case LATEST_DB_VERSION:
+		// Up-to-date
+		break;
+	default:
+		throw FileNotGoodException("Unsupported database version " +
+			std::to_string(version) + "!");
+	}
 }
 
-void Database_SQLite3::beginSave() {
-	verifyDatabase();
+bool Database_SQLite3::migrate(bool started)
+{
+	std::cerr << "Migrating map schema..." << std::endl;
+
+	beginSave();
+
+	// TODO: Check table instead of relying on flag file
+	if (!started) {
+		SQLOK(sqlite3_exec(m_database,
+			"ALTER TABLE `blocks` RENAME TO `old_blocks`;",
+			NULL, NULL, NULL), "Failed to rename table for migration");
+		createDatabase(false);
+	}
+
+	prepareStatements();
+
+	sqlite3_stmt *stmt_get = NULL;
+	sqlite3_stmt *stmt_delete = NULL;
+
+	PREPARE_STATEMENT(stmt_get, "SELECT `pos`, `data` FROM `old_blocks`");
+	PREPARE_STATEMENT(stmt_delete, "DELETE FROM `old_blocks` WHERE `pos` = ?");
+
+	bool &kill = *porting::signal_handler_killstatus();
+	time_t last_time = time(NULL);
+	char spinner[] = "|/-\\";
+	unsigned short spinidx = 0;
+	unsigned long num_converted = 0;
+
+	while (sqlite3_step(stmt_get) == SQLITE_ROW) {
+		s64 posHash = sqlite3_column_int64(stmt_get, 0);
+		v3s16 pos = getIntegerAsBlock(posHash);
+		const char *data = static_cast<const char *>(sqlite3_column_blob(stmt_get, 1));
+		size_t data_len = sqlite3_column_bytes(stmt_get, 1);
+
+		saveBlock(pos, data, data_len, false);
+
+		// Delete block from old table now to allow migration resumption
+		SQLOK(sqlite3_bind_int64(stmt_delete, 1, posHash),
+			"Failed to bind old migrated block pos for delete");
+		SQLRES(sqlite3_step(stmt_delete), SQLITE_DONE,
+			"Failed to delete old migrated block");
+		sqlite3_reset(stmt_delete);
+
+		num_converted++;
+		if (time(NULL) - last_time > 1) {
+			endSave();
+			spinidx = (spinidx + 1) & 3;
+			std::cerr << spinner[spinidx] << " Converted "
+				<< num_converted << " blocks...\r"
+				<< std::flush;
+			beginSave();
+			last_time = time(NULL);
+		}
+		if (kill)
+			goto finish;
+	}
+
+	SQLOK(sqlite3_exec(m_database,
+		"DROP TABLE `old_blocks`;\n"
+		"PRAGMA user_version = 1;\n",
+		NULL, NULL, NULL), "Failed to delete old block table "
+			"and update database version");
+
+finish:
+	endSave();
+
+	FINALIZE_STATEMENT(stmt_get);
+	FINALIZE_STATEMENT(stmt_delete);
+
+	std::cerr << std::endl;
+
+	return !kill;
+}
+
+void Database_SQLite3::beginSave()
+{
 	SQLRES(sqlite3_step(m_stmt_begin), SQLITE_DONE,
 		"Failed to start SQLite3 transaction");
 	sqlite3_reset(m_stmt_begin);
 }
 
-void Database_SQLite3::endSave() {
-	verifyDatabase();
+void Database_SQLite3::endSave()
+{
 	SQLRES(sqlite3_step(m_stmt_end), SQLITE_DONE,
 		"Failed to commit SQLite3 transaction");
 	sqlite3_reset(m_stmt_end);
@@ -140,7 +254,8 @@ void Database_SQLite3::endSave() {
 
 void Database_SQLite3::openDatabase()
 {
-	if (m_database) return;
+	if (m_database)
+		return;
 
 	std::string dbp = m_savedir + DIR_DELIM + "map.sqlite";
 
@@ -162,47 +277,52 @@ void Database_SQLite3::openDatabase()
 	SQLOK(sqlite3_busy_handler(m_database, Database_SQLite3::busyHandler,
 		m_busy_handler_data), "Failed to set SQLite3 busy handler");
 
-	if (needs_create) {
+	if (needs_create)
 		createDatabase();
-	}
 
 	std::string query_str = std::string("PRAGMA synchronous = ")
 			 + itos(g_settings->getU16("sqlite_synchronous"));
 	SQLOK(sqlite3_exec(m_database, query_str.c_str(), NULL, NULL, NULL),
 		"Failed to modify sqlite3 synchronous mode");
-}
 
-void Database_SQLite3::verifyDatabase()
-{
-	if (m_initialized) return;
+	PREPARE_STATEMENT(m_stmt_begin, "BEGIN");
+	PREPARE_STATEMENT(m_stmt_end, "COMMIT");
 
-	openDatabase();
+	checkMigrate();
 
-	PREPARE_STATEMENT(begin, "BEGIN");
-	PREPARE_STATEMENT(end, "COMMIT");
-	PREPARE_STATEMENT(read, "SELECT `data` FROM `blocks` WHERE `pos` = ? LIMIT 1");
-#ifdef __ANDROID__
-	PREPARE_STATEMENT(write,  "INSERT INTO `blocks` (`pos`, `data`) VALUES (?, ?)");
-#else
-	PREPARE_STATEMENT(write, "REPLACE INTO `blocks` (`pos`, `data`) VALUES (?, ?)");
-#endif
-	PREPARE_STATEMENT(delete, "DELETE FROM `blocks` WHERE `pos` = ?");
-	PREPARE_STATEMENT(list, "SELECT `pos` FROM `blocks`");
-
-	m_initialized = true;
+	prepareStatements();
 
 	verbosestream << "ServerMap: SQLite3 database opened." << std::endl;
 }
 
-inline void Database_SQLite3::bindPos(sqlite3_stmt *stmt, const v3s16 &pos, int index)
+void Database_SQLite3::prepareStatements()
 {
-	SQLOK(sqlite3_bind_int64(stmt, index, getBlockAsInteger(pos)),
-		"Internal error: failed to bind query at " __FILE__ ":" TOSTRING(__LINE__));
+	if (m_stmt_read != NULL)
+		return;
+
+	PREPARE_STATEMENT(m_stmt_read, "SELECT `data` FROM `blocks` WHERE "
+			"`x` = ? AND `y` = ? AND `z` = ?");
+#ifdef __ANDROID__
+	PREPARE_STATEMENT(m_stmt_write,  "INSERT INTO `blocks` "
+			"(`x`, `y`, `z`, `data`) VALUES (?, ?, ?, ?)");
+#else
+	PREPARE_STATEMENT(m_stmt_write, "REPLACE INTO `blocks` "
+			"(`x`, `y`, `z`, `data`) VALUES (?, ?, ?, ?)");
+#endif
+	PREPARE_STATEMENT(m_stmt_delete, "DELETE FROM `blocks` WHERE "
+			"`x` = ? AND `y` = ? AND `z` = ?");
+	PREPARE_STATEMENT(m_stmt_list, "SELECT `x`, `y`, `z` FROM `blocks`");
+}
+
+inline void Database_SQLite3::bindPos(sqlite3_stmt *stmt, const v3s16 &pos, int start)
+{
+	SQLOK(sqlite3_bind_int(stmt, start,     pos.X), "Failed to bind block X coordinate");
+	SQLOK(sqlite3_bind_int(stmt, start + 1, pos.Y), "Failed to bind block Y coordinate");
+	SQLOK(sqlite3_bind_int(stmt, start + 2, pos.Z), "Failed to bind block Z coordinate");
 }
 
 bool Database_SQLite3::deleteBlock(const v3s16 &pos)
 {
-	verifyDatabase();
 
 	bindPos(m_stmt_delete, pos);
 
@@ -216,26 +336,27 @@ bool Database_SQLite3::deleteBlock(const v3s16 &pos)
 	return good;
 }
 
-bool Database_SQLite3::saveBlock(const v3s16 &pos, const std::string &data)
+bool Database_SQLite3::saveBlock(const v3s16 &pos, const char *data,
+		size_t data_len, bool overwrite)
 {
-	verifyDatabase();
-
 #ifdef __ANDROID__
 	/**
 	 * Note: For some unknown reason SQLite3 fails to REPLACE blocks on Android,
 	 * deleting them and then inserting works.
 	 */
-	bindPos(m_stmt_read, pos);
+	if (overwrite) {
+		bindPos(m_stmt_read, pos);
 
-	if (sqlite3_step(m_stmt_read) == SQLITE_ROW) {
-		deleteBlock(pos);
+		if (sqlite3_step(m_stmt_read) == SQLITE_ROW) {
+			deleteBlock(pos);
+		}
+		sqlite3_reset(m_stmt_read);
 	}
-	sqlite3_reset(m_stmt_read);
 #endif
 
 	bindPos(m_stmt_write, pos);
-	SQLOK(sqlite3_bind_blob(m_stmt_write, 2, data.data(), data.size(), NULL),
-		"Internal error: failed to bind query at " __FILE__ ":" TOSTRING(__LINE__));
+	SQLOK(sqlite3_bind_blob(m_stmt_write, 4, data, data_len, NULL),
+		"Failed to bind block data");
 
 	SQLRES(sqlite3_step(m_stmt_write), SQLITE_DONE, "Failed to save block")
 	sqlite3_reset(m_stmt_write);
@@ -245,8 +366,6 @@ bool Database_SQLite3::saveBlock(const v3s16 &pos, const std::string &data)
 
 void Database_SQLite3::loadBlock(const v3s16 &pos, std::string *block)
 {
-	verifyDatabase();
-
 	bindPos(m_stmt_read, pos);
 
 	if (sqlite3_step(m_stmt_read) != SQLITE_ROW) {
@@ -264,13 +383,22 @@ void Database_SQLite3::loadBlock(const v3s16 &pos, std::string *block)
 	sqlite3_reset(m_stmt_read);
 }
 
-void Database_SQLite3::createDatabase()
+void Database_SQLite3::createDatabase(bool set_ver)
 {
 	assert(m_database); // Pre-condition
+	if (set_ver) {
+		std::string q = "PRAGMA user_version = " +
+			std::to_string(LATEST_DB_VERSION) + ';';
+		SQLOK(sqlite3_exec(m_database, q.c_str(), NULL, NULL, NULL),
+			"Failed to initialize database version");
+	}
 	SQLOK(sqlite3_exec(m_database,
 		"CREATE TABLE IF NOT EXISTS `blocks` (\n"
-		"	`pos` INT PRIMARY KEY,\n"
-		"	`data` BLOB\n"
+		"	`x` INTEGER NOT NULL,\n"
+		"	`y` INTEGER NOT NULL,\n"
+		"	`z` INTEGER NOT NULL,\n"
+		"	`data` BLOB,\n"
+		"	PRIMARY KEY (`x`, `y`, `z`)\n"
 		");\n",
 		NULL, NULL, NULL),
 		"Failed to create database table");
@@ -278,10 +406,12 @@ void Database_SQLite3::createDatabase()
 
 void Database_SQLite3::listAllLoadableBlocks(std::vector<v3s16> &dst)
 {
-	verifyDatabase();
-
 	while (sqlite3_step(m_stmt_list) == SQLITE_ROW) {
-		dst.push_back(getIntegerAsBlock(sqlite3_column_int64(m_stmt_list, 0)));
+		v3s16 p;
+		p.X = sqlite3_column_int(m_stmt_list, 0);
+		p.Y = sqlite3_column_int(m_stmt_list, 1);
+		p.Z = sqlite3_column_int(m_stmt_list, 2);
+		dst.push_back(p);
 	}
 	sqlite3_reset(m_stmt_list);
 }

--- a/src/database-sqlite3.h
+++ b/src/database-sqlite3.h
@@ -57,7 +57,9 @@ private:
 	bool migrate(bool started);
 
 	bool saveBlock(const v3s16 &pos, const char *data, size_t data_len,
-		bool overwrite = true);
+			s64 id = -1);
+
+	bool deleteBlock(s64 id);
 
 	void bindPos(sqlite3_stmt *stmt, const v3s16 &pos, int start = 1);
 
@@ -65,9 +67,13 @@ private:
 
 	sqlite3 *m_database;
 	sqlite3_stmt *m_stmt_read;
-	sqlite3_stmt *m_stmt_write;
+	sqlite3_stmt *m_stmt_insert;
+	sqlite3_stmt *m_stmt_insert_pos;
+	sqlite3_stmt *m_stmt_update;
 	sqlite3_stmt *m_stmt_list;
+	sqlite3_stmt *m_stmt_get_id;
 	sqlite3_stmt *m_stmt_delete;
+	sqlite3_stmt *m_stmt_delete_pos;
 	sqlite3_stmt *m_stmt_begin;
 	sqlite3_stmt *m_stmt_end;
 


### PR DESCRIPTION
Old databases are automagically converted when they're loaded.

Rationale: Cramming all of the position fields into one field is just messy.  But besides that, it's also a lot harder to process, so many tools that operate on databases have to iterate over a large portion of the database, decoding and checking positions, rather than using a simple SQL statement to fetch only the blocks they need.

This also switches to R*Tree based storage.  This _may_ improve performance, but it will only be substantial with very big databases.  Small databases _will_ be slower with the R*Tree.

Real-world improvements:
1. The mapper(s) can load only the blocks that they need.  The C++ mapper currently loads whole Z-slices at a time, rather than just blocks in it's generation range, because it can't limit the selection through SQL.
2. Some map editing tools that I've written would be substantially shorter or could be done with only SQL.  Eg, a script that removed all block that were more that a certain distance from the origin could be done with `DELETE FROM blocks WHERE ABS(x) > 3 OR ABS(y) > 3 ABS(z) > 3;`.
3. Corrupted blocks can be deleted without having to write a script to convert the block position to a position hash.

I've converted a map with over 100,000 blocks in about ten seconds.

TODO:
- Update the C++ mapper.
