### PR TITLE
Mgv5 1 up 1 down overgeneration for biome surface continuity, thinner biomes.

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -63,7 +63,7 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge_) {
 	// amount of elements to skip for the next index
 	// for noise/height/biome maps (not vmanip)
 	this->ystride = csize.X;
-	this->zstride = csize.X * csize.Y;
+	this->zstride = csize.X * (csize.Y + 2);
 
 	this->biomemap  = new u8[csize.X * csize.Z];
 	this->heightmap = new s16[csize.X * csize.Z];
@@ -78,11 +78,11 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge_) {
 	noise_height       = new Noise(&sp->np_height,       seed, csize.X, csize.Z);
 
 	// 3D terrain noise
-	noise_cave1        = new Noise(&sp->np_cave1,   seed, csize.X, csize.Y, csize.Z);
-	noise_cave2        = new Noise(&sp->np_cave2,   seed, csize.X, csize.Y, csize.Z);
-	noise_ground       = new Noise(&sp->np_ground,  seed, csize.X, csize.Y, csize.Z);
-	noise_crumble      = new Noise(&sp->np_crumble, seed, csize.X, csize.Y, csize.Z);
-	noise_wetness      = new Noise(&sp->np_wetness, seed, csize.X, csize.Y, csize.Z);
+	noise_cave1        = new Noise(&sp->np_cave1,   seed, csize.X, csize.Y + 2, csize.Z);
+	noise_cave2        = new Noise(&sp->np_cave2,   seed, csize.X, csize.Y + 2, csize.Z);
+	noise_ground       = new Noise(&sp->np_ground,  seed, csize.X, csize.Y + 2, csize.Z);
+	noise_crumble      = new Noise(&sp->np_crumble, seed, csize.X, csize.Y + 2, csize.Z);
+	noise_wetness      = new Noise(&sp->np_wetness, seed, csize.X, csize.Y + 2, csize.Z);
 
 	// Biome noise
 	noise_heat         = new Noise(bmgr->np_heat,     seed, csize.X, csize.Z);
@@ -258,8 +258,8 @@ void MapgenV5::makeChunk(BlockMakeData *data) {
 	
 	// Calculate lighting
 	if (flags & MG_LIGHT)
-		calcLighting(node_min - v3s16(1, 0, 1) * MAP_BLOCKSIZE,
-					 node_max + v3s16(1, 0, 1) * MAP_BLOCKSIZE);
+		calcLighting(node_min - v3s16(0, 1, 0) - v3s16(1, 0, 1) * MAP_BLOCKSIZE,
+			node_max + v3s16(0, 1, 0) + v3s16(1, 0, 1) * MAP_BLOCKSIZE);
 	
 	this->generating = false;
 }
@@ -268,7 +268,7 @@ void MapgenV5::makeChunk(BlockMakeData *data) {
 void MapgenV5::calculateNoise() {
 	//TimeTaker t("calculateNoise", NULL, PRECISION_MICRO);
 	int x = node_min.X;
-	int y = node_min.Y;
+	int y = node_min.Y - 1;
 	int z = node_min.Z;
 	
 	noise_filler_depth->perlinMap2D(x, z);
@@ -319,7 +319,7 @@ void MapgenV5::generateBaseTerrain() {
 	u32 index2d = 0;
 
 	for(s16 z=node_min.Z; z<=node_max.Z; z++) {
-		for(s16 y=node_min.Y; y<=node_max.Y; y++) {
+		for(s16 y=node_min.Y - 1; y<=node_max.Y + 1; y++) {
 			u32 i = vm->m_area.index(node_min.X, y, z);
 			for(s16 x=node_min.X; x<=node_max.X; x++, i++, index++, index2d++) {
 				if(vm->m_data[i].getContent() != CONTENT_IGNORE)
@@ -333,6 +333,7 @@ void MapgenV5::generateBaseTerrain() {
 				float h = water_level + noise_height->result[index2d];
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
+
 				if(noise_ground->result[index] * f < y - h) {
 					if(y <= water_level)
 						vm->m_data[i] = MapNode(c_water_source);
@@ -356,7 +357,7 @@ void MapgenV5::generateBlobs() {
 	u32 index = 0;
 
 	for(s16 z=node_min.Z; z<=node_max.Z; z++) {
-		for(s16 y=node_min.Y; y<=node_max.Y; y++) {
+		for(s16 y=node_min.Y - 1; y<=node_max.Y + 1; y++) {
 			u32 i = vm->m_area.index(node_min.X, y, z);
 			for(s16 x=node_min.X; x<=node_max.X; x++, i++, index++) {
 				content_t c = vm->m_data[i].getContent();
@@ -398,7 +399,7 @@ void MapgenV5::generateBiomes() {
 		Biome *biome  = (Biome *)bmgr->get(biomemap[index]);
 		s16 dfiller   = biome->depth_filler + noise_filler_depth->result[index];
 		s16 y0_top    = biome->depth_top;
-		s16 y0_filler = biome->depth_filler + biome->depth_top + dfiller;
+		s16 y0_filler = biome->depth_top + dfiller;
 		
 		s16 nplaced = 0;
 		u32 i = vm->m_area.index(x, node_max.Y, z);	
@@ -462,7 +463,7 @@ void MapgenV5::dustTopNodes() {
 		if (biome->c_dust == CONTENT_IGNORE)
 			continue;
 
-		s16 y = node_max.Y;
+		s16 y = node_max.Y + 1;
 		u32 vi = vm->m_area.index(x, y, z);
 		for (; y >= node_min.Y; y--) {
 			if (vm->m_data[vi].getContent() != CONTENT_AIR)
@@ -473,12 +474,13 @@ void MapgenV5::dustTopNodes() {
 			
 		content_t c = vm->m_data[vi].getContent();
 		if (c == biome->c_water && biome->c_dust_water != CONTENT_IGNORE) {
-			if (y < node_min.Y)
+			if (y < node_min.Y - 1)
 				continue;
 				
 			vm->m_data[vi] = MapNode(biome->c_dust_water);
-		} else if (!ndef->get(c).buildable_to && c != CONTENT_IGNORE) {
-			if (y == node_max.Y)
+		} else if (!ndef->get(c).buildable_to && c != CONTENT_IGNORE
+				&& c != biome->c_dust) {
+			if (y == node_max.Y + 1)
 				continue;
 				
 			vm->m_area.add_y(em, vi, 1);


### PR DESCRIPTION
![screenshot_3488555948](https://cloud.githubusercontent.com/assets/3686677/5136687/5e9db794-7124-11e4-9e70-babed4bce9da.png)

^ Here i am at y = 47, the biome surface nodes and snowblock dust nodes are continuous

A new pull request for a simplified overgeneration, extending 1 up 1 down beyond the mapchunk. This makes biome surface continuous at y = 47, although the full depth of the biome is still interrupted.
The biome API needs some work to make it (more) continuous across mapchunk borders, in the meantime this commit fixes the ugly line of missing biome nodes at y = 47.

At line 401/402 i made a change to the depth of biomes, 'biome->depth_filler' was used twice in the depth calculation, perhaps on purpose, but it results in very deep biomes not averaging at the value set in the API.
