### PR TITLE
Add minetest.global_exists()

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -4,6 +4,11 @@
 local WARN_INIT = false
 
 
+function core.global_exists(name)
+	return rawget(_G, name) ~= nil
+end
+
+
 local function warn(message)
 	print(os.date("%H:%M:%S: WARNING: ")..message)
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1863,6 +1863,9 @@ minetest.forceload_free_block(pos)
 
 Please note that forceloaded areas are saved when the server restarts.
 
+minetest.global_exists(name)
+^ Checks if a global variable has been set.
+
 Global objects:
 minetest.env - EnvRef of the server environment and world.
 ^ Any function in the minetest namespace can be called using the syntax


### PR DESCRIPTION
Allows for global existence checks without warnings.