### PR TITLE
Fix compiling if no endian.h found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -315,6 +315,9 @@ if(ENABLE_REDIS)
 endif(ENABLE_REDIS)
 
 CHECK_INCLUDE_FILES(endian.h HAVE_ENDIAN_H)
+if(NOT HAVE_ENDIAN_H)
+  set(HAVE_ENDIAN_H 0)
+endif(NOT HAVE_ENDIAN_H)
 
 configure_file(
 	"${PROJECT_SOURCE_DIR}/cmake_config.h.in"


### PR DESCRIPTION
f7d6509 introduces error when no endian.h found in the system.

Since "CHECK_INCLUDE_FILE" returns empty string instead of "0", when
"cmake_config.h" is generated it has "#define CMAKE_HAVE_ENDIAN_H " line.
Later we have "#define HAVE_ENDIAN_H CMAKE_HAVE_ENDIAN_H" in the
"config.h", an thus "HAVE_ENDIAN_H" is also empty sting. Because of
this, "#if HAVE_ENDIAN_H" is incorrect preprocessor directive.
