### PR TITLE
added enable_build_where_you_stand option

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -62,6 +62,9 @@
 #keymap_quicktune_dec = KEY_NEXT
 #keymap_quicktune_inc = KEY_PRIOR
 
+#if set to true, you can place blocks at the position (feet + eye level) where you stand; this is helpful when working with nodeboxes
+#enable_build_where_you_stand = false
+
 # Minimum FPS
 # The amount of rendered stuff is dynamically set according to this
 #wanted_fps = 30

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -58,6 +58,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_camera_mode", "KEY_F7");
 	settings->setDefault("keymap_increase_viewing_range_min", "+");
 	settings->setDefault("keymap_decrease_viewing_range_min", "-");
+	settings->setDefault("enable_build_where_you_stand", "false" );
 	settings->setDefault("3d_mode", "none");
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("aux1_descends", "false");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -967,6 +967,7 @@ bool nodePlacementPrediction(Client &client,
 			// Dont place node when player would be inside new node
 			// NOTE: This is to be eventually implemented by a mod as client-side Lua
 			if (!nodedef->get(n).walkable ||
+					g_settings->getBool("enable_build_where_you_stand") ||
 					(client.checkPrivilege("noclip") && g_settings->getBool("noclip")) ||
 					(nodedef->get(n).walkable &&
 					 neighbourpos != player->getStandingNodePos() + v3s16(0, 1, 0) &&


### PR DESCRIPTION
Following pull request 1b4908b, "Prevent placing node when player would be inside new node", nodes can no longer be placed where the player stands. This is a problem when trying to align nodeboxes, signs and other nodes in tight corners or when pillaring up. This pull request here allows players who are using the game for building houses etc. to set
`enable_build_where_you_stand = true`
in their minetest.conf and subsequently place nodes where the alignment of the player is critial to how these nodes will be placed.
The other effect of the old, merged pull request 1b4908b, namely that the screen gets black if the player is burried inside a node and does not have the noclip privilege, remains as it is.

In general, players who aim at constructing something with the blocks in the game-world will want to set this option to true.
