### PR TITLE
Fix wielditem node materials

### DIFF
--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -353,7 +353,11 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
 				material.setTexture(0, f.tiles[i].texture);
 			}
 			if (m_enable_shaders) {
-				material.MaterialType = shdrsrc->getShaderInfo(f.tiles[i].shader_id).material;
+				u8 material_type = f.tiles[i].material_type;
+				if (material_type != TILE_MATERIAL_ALPHA)
+					material_type = TILE_MATERIAL_BASIC;
+				u32 shader_id = shdrsrc->getShader("nodes_shader", material_type, f.drawtype);
+				material.MaterialType = shdrsrc->getShaderInfo(shader_id).material;
 				f.tiles[i].applyMaterialOptionsWithShaders(material);
 				if (f.tiles[i].normal_texture) {
 					if (animated) {

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -352,8 +352,9 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
 			} else {
 				material.setTexture(0, f.tiles[i].texture);
 			}
-			material.MaterialType = m_material_type;
 			if (m_enable_shaders) {
+				material.MaterialType = shdrsrc->getShaderInfo(f.tiles[i].shader_id).material;
+				f.tiles[i].applyMaterialOptionsWithShaders(material);
 				if (f.tiles[i].normal_texture) {
 					if (animated) {
 						FrameSpec animation_frame = f.tiles[i].frames.find(0)->second;
@@ -365,6 +366,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
 				} else {
 					material.setTexture(2, tsrc->getTexture("disable_img.png"));
 				}
+			} else {
+				f.tiles[i].applyMaterialOptions(material);
 			}
 		}
 		return;


### PR DESCRIPTION
This fixes #1857 which is caused by material.MaterialType being set incorrectly.

This more closely matches the way textures and shaders are handled in mapblock_mesh.cpp.
