### PR TITLE
Fix client "double saving" simple singleplayer local maps

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -219,6 +219,7 @@ Client::Client(
 		IrrlichtDevice *device,
 		const char *playername,
 		std::string password,
+		bool is_simple_singleplayer_game,
 		MapDrawControl &control,
 		IWritableTextureSource *tsrc,
 		IWritableShaderSource *shsrc,
@@ -280,7 +281,8 @@ Client::Client(
 		m_env.addPlayer(player);
 	}
 
-	if (g_settings->getBool("enable_local_map_saving")) {
+	if (g_settings->getBool("enable_local_map_saving")
+			&& !is_simple_singleplayer_game) {
 		const std::string world_path = porting::path_user + DIR_DELIM + "worlds"
 				+ DIR_DELIM + "server_" + g_settings->get("address")
 				+ "_" + g_settings->get("remote_port");

--- a/src/client.h
+++ b/src/client.h
@@ -305,6 +305,7 @@ public:
 			IrrlichtDevice *device,
 			const char *playername,
 			std::string password,
+			bool is_simple_singleplayer_game,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2103,9 +2103,11 @@ bool Game::connectToServer(const std::string &playername,
 		return false;
 	}
 
-	client = new Client(device, playername.c_str(), password, *draw_control,
-		    texture_src, shader_src, itemdef_manager, nodedef_manager, sound,
-			eventmgr, connect_address.isIPv6());
+	client = new Client(device,
+			playername.c_str(), password, simple_singleplayer_mode,
+			*draw_control, texture_src, shader_src,
+			itemdef_manager, nodedef_manager, sound, eventmgr,
+			connect_address.isIPv6());
 
 	if (!client)
 		return false;


### PR DESCRIPTION
Prevent trying to save a local copy of the server map if the game mode is "simple singleplayer"

See: https://github.com/minetest/minetest/issues/1866
