### PR TITLE
Temporary fix for irrlicht bug that cause MT not going to be compiled on BSD-like

### DIFF
--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -20,6 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef IRRLICHTTYPES_HEADER
 #define IRRLICHTTYPES_HEADER
 
+#ifndef _MSC_VER // see https://sourceforge.net/p/irrlicht/bugs/433/
+#include <stdint.h>
+#endif
+
 #include <irrTypes.h>
 
 using namespace irr;
@@ -32,7 +36,6 @@ using namespace irr;
 	typedef unsigned long long u64;
 #else
 	// Posix
-	#include <stdint.h>
 	typedef int64_t s64;
 	typedef uint64_t u64;
 #endif


### PR DESCRIPTION
Details:
- https://sourceforge.net/p/irrlicht/bugs/433/
- https://github.com/minetest/minetest/issues/1687#issuecomment-61368769
- https://forum.minetest.net/viewtopic.php?f=42&t=9190&start=125#p159364

In case when "settings.h" is included from "emerge.cpp" or
"environment.cpp", u64 type has "unsigned long" length because
previously <stdint> was included. When "settings.h" is included from
"settings.cpp", u64 has "unsigned long long" length because no <stdint>
was included previously. This leads to different signatures of "setU64" method
and linker cannot find appropriate symbol.

The best fix of this bug should be done in the Irrlicht, but as hotfix I
think this is OK and better than types changing.

Previously this bug didn't appear because there was no "settings.cpp" file and
implementation of all methods was done in the header file.
