### PR TITLE
Fix some undeclared global variables

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -252,7 +252,7 @@ core.register_chatcommand("clearpassword", {
 	description = "set empty password",
 	privs = {password=true},
 	func = function(name, param)
-		toname = param
+		local toname = param
 		if toname == "" then
 			return false, "Name field required"
 		end
@@ -426,6 +426,7 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 		return false, receiver .. " is not a known player"
 	end
 	local leftover = receiverref:get_inventory():add_item("main", itemstack)
+	local partiality = nil
 	if leftover:is_empty() then
 		partiality = ""
 	elseif leftover:get_count() == itemstack:get_count() then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -30,7 +30,7 @@ core.register_entity(":__builtin:falling_node", {
 			item_texture = core.registered_items[itemname].inventory_image
 			item_type = core.registered_items[itemname].type
 		end
-		prop = {
+		local prop = {
 			is_visible = true,
 			textures = {node.name},
 		}
@@ -112,7 +112,7 @@ core.register_entity(":__builtin:falling_node", {
 })
 
 function spawn_falling_node(p, node)
-	obj = core.add_entity(p, "__builtin:falling_node")
+	local obj = core.add_entity(p, "__builtin:falling_node")
 	obj:get_luaentity():set_node(node)
 end
 
@@ -163,10 +163,10 @@ end
 --
 
 function nodeupdate_single(p, delay)
-	n = core.get_node(p)
+	local n = core.get_node(p)
 	if core.get_item_group(n.name, "falling_node") ~= 0 then
-		p_bottom = {x=p.x, y=p.y-1, z=p.z}
-		n_bottom = core.get_node(p_bottom)
+		local p_bottom = {x=p.x, y=p.y-1, z=p.z}
+		local n_bottom = core.get_node(p_bottom)
 		-- Note: walkable is in the node definition, not in item groups
 		if core.registered_nodes[n_bottom.name] and
 				(core.get_item_group(n.name, "float") == 0 or


### PR DESCRIPTION
Fixes this:

```
08:52:31: ERROR[ServerThread]: Assignment to undeclared global "prop" inside a function at ...inetest/minetest-servers/bin/../builtin/game/falling.lua:36.
16:06:10: ERROR[ServerThread]: Assignment to undeclared global "obj" inside a function at ...inetest/minetest-servers/bin/../builtin/game/falling.lua:115. 
08:52:48: ERROR[ServerThread]: Assignment to undeclared global "n" inside a function at ...inetest/minetest-servers/bin/../builtin/game/falling.lua:166.
13:37:44: ERROR[ServerThread]: Assignment to undeclared global "p_bottom" inside a function at ...inetest/minetest-servers/bin/../builtin/game/falling.lua:168.
13:37:44: ERROR[ServerThread]: Assignment to undeclared global "n_bottom" inside a function at ...inetest/minetest-servers/bin/../builtin/game/falling.lua:169.
```
