### PR TITLE
Add setting for m_nothing_to_send_pause_timer

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -336,6 +336,8 @@
 #max_simultaneous_block_sends_per_client = 10
 # how many blocks are flying in the wire simultaneously per server
 #max_simultaneous_block_sends_server_total = 40
+# Interval in which block updates are sent to the client
+#block_update_send_interval = 0.2
 # From how far blocks are sent to clients (value * 16 nodes)
 #max_block_send_distance = 10
 # From how far blocks are generated for clients (value * 16 nodes)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -362,7 +362,8 @@ queue_full_break:
 	} else {
 		if(d > g_settings->getS16("max_block_send_distance")){
 			new_nearest_unsent_d = 0;
-			m_nothing_to_send_pause_timer = 2.0;
+			m_nothing_to_send_pause_timer =
+				g_settings->getFloat("block_update_send_interval");
 		} else {
 			if(nearest_sent_d != -1)
 				new_nearest_unsent_d = nearest_sent_d;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -228,6 +228,7 @@ void set_default_settings(Settings *settings)
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
 	settings->setDefault("max_simultaneous_block_sends_server_total", "40");
+	settings->setDefault("block_update_send_interval", "0.2");
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("max_block_generate_distance", "7");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");


### PR DESCRIPTION
And decrease default value from 2.0 to 0.2 seconds. This sends block updates to clients on a far more regular basis, yet it may increase CPU usage. Therefore, I can't tell for sure how this affects servers with multiple players. That's why I'm putting this out for discussion and for people to test it.

On the positive side, this makes mods that modify large numbers of blocks on the server side, like mesecons, way faster (tested in singleplayer and low number of clients): https://www.youtube.com/watch?v=B0YwfGVp3o8
