### PR TITLE
Use a wider default screen resolution

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -77,7 +77,7 @@
 #viewing_range_nodes_max = 160
 #viewing_range_nodes_min = 35
 # Initial window size
-#screenW = 800
+#screenW = 1024
 #screenH = 600
 #fullscreen = false
 #fullscreen_bpp = 24

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -92,7 +92,7 @@ void set_default_settings(Settings *settings)
 	// A bit more than the server will send around the player, to make fog blend well
 	settings->setDefault("viewing_range_nodes_max", "240");
 	settings->setDefault("viewing_range_nodes_min", "35");
-	settings->setDefault("screenW", "800");
+	settings->setDefault("screenW", "1024");
 	settings->setDefault("screenH", "600");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("fullscreen_bpp", "24");


### PR DESCRIPTION
800 × 600 is a 4:3 resolution, whereas 1024 × 600 is more suited to modern screens.