### PR TITLE
Add node_stone to mgv5 biomes. Remove unnecessary underwater grass hack

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -451,23 +451,31 @@ void MapgenV5::generateBiomes() {
 				
 				if (c_below != CONTENT_AIR) {
 					if (nplaced < y0_top) {
-						// A hack to prevent dirt_with_grass from being
-						// placed below water.  TODO: fix later
-						content_t c_place = ((y < water_level) &&
-								(biome->c_top ==
-								c_dirt_with_grass)) ?
-								 c_dirt : biome->c_top;
-						
-						vm->m_data[i] = MapNode(c_place);
+						if(y < water_level)
+							vm->m_data[i] = MapNode(biome->c_filler);
+						else
+							vm->m_data[i] = MapNode(biome->c_top);
 						nplaced++;
 					} else if (nplaced < y0_filler && nplaced >= y0_top) {
 						vm->m_data[i] = MapNode(biome->c_filler);
 						nplaced++;
+					} else if (c == c_stone) {
+						have_air = false;
+						nplaced  = 0;
+						vm->m_data[i] = MapNode(biome->c_stone);
 					} else {
 						have_air = false;
 						nplaced  = 0;
 					}
+				} else if (c == c_stone) {
+					have_air = false;
+					nplaced = 0;
+					vm->m_data[i] = MapNode(biome->c_stone);
 				}
+			} else if (c == c_stone) {
+				have_air = false;
+				nplaced = 0;
+				vm->m_data[i] = MapNode(biome->c_stone);
 			} else if (c == c_water_source) {
 				have_air = true;
 				nplaced = 0;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -534,7 +534,7 @@ void MapgenV7::generateBiomes() {
 		Biome *biome  = (Biome *)bmgr->get(biomemap[index]);
 		s16 dfiller   = biome->depth_filler + noise_filler_depth->result[index];
 		s16 y0_top    = biome->depth_top;
-		s16 y0_filler = biome->depth_filler + biome->depth_top + dfiller;
+		s16 y0_filler = biome->depth_top + dfiller;
 
 		s16 nplaced = 0;
 		u32 i = vm->m_area.index(x, node_max.Y, z);	
@@ -560,22 +560,31 @@ void MapgenV7::generateBiomes() {
 				
 				if (c_below != CONTENT_AIR) {
 					if (nplaced < y0_top) {
-						// A hack to prevent dirt_with_grass from being
-						// placed below water.  TODO: fix later
-						content_t c_place = ((y < water_level) &&
-								(biome->c_top == c_dirt_with_grass)) ?
-								 c_dirt : biome->c_top;
-						
-						vm->m_data[i] = MapNode(c_place);
+						if(y < water_level)
+							vm->m_data[i] = MapNode(biome->c_filler);
+						else
+							vm->m_data[i] = MapNode(biome->c_top);
 						nplaced++;
 					} else if (nplaced < y0_filler && nplaced >= y0_top) {
 						vm->m_data[i] = MapNode(biome->c_filler);
 						nplaced++;
+					} else if (c == c_stone) {
+						have_air = false;
+						nplaced  = 0;
+						vm->m_data[i] = MapNode(biome->c_stone);
 					} else {
 						have_air = false;
 						nplaced  = 0;
 					}
+				} else if (c == c_stone) {
+					have_air = false;
+					nplaced = 0;
+					vm->m_data[i] = MapNode(biome->c_stone);
 				}
+			} else if (c == c_stone) {
+				have_air = false;
+				nplaced = 0;
+				vm->m_data[i] = MapNode(biome->c_stone);
 			} else if (c == c_water_source) {
 				have_air = true;
 				nplaced = 0;

--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -58,6 +58,7 @@ BiomeManager::BiomeManager(IGameDef *gamedef)
 
 	resolver->addNode("air",                 "", CONTENT_AIR, &b->c_top);
 	resolver->addNode("air",                 "", CONTENT_AIR, &b->c_filler);
+	resolver->addNode("mapgen_stone",        "", CONTENT_AIR, &b->c_stone);
 	resolver->addNode("mapgen_water_source", "", CONTENT_AIR, &b->c_water);
 	resolver->addNode("air",                 "", CONTENT_AIR, &b->c_dust);
 	resolver->addNode("mapgen_water_source", "", CONTENT_AIR, &b->c_dust_water);
@@ -112,3 +113,4 @@ Biome *BiomeManager::getBiome(float heat, float humidity, s16 y)
 	
 	return biome_closest ? biome_closest : (Biome *)m_elements[0];
 }
+

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -42,6 +42,7 @@ public:
 
 	content_t c_top;
 	content_t c_filler;
+	content_t c_stone;
 	content_t c_water;
 	content_t c_dust;
 	content_t c_dust_water;
@@ -77,3 +78,4 @@ public:
 };
 
 #endif
+

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mg_ore.h"
 #include "mg_decoration.h"
 #include "mg_schematic.h"
+#include "mapgen_v5.h"
 #include "mapgen_v7.h"
 #include "settings.h"
 #include "main.h"
@@ -336,6 +337,8 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 		 "mapgen_dirt_with_grass", CONTENT_AIR, &b->c_top);
 	resolver->addNode(getstringfield_default(L, index, "node_filler", ""),
 		"mapgen_dirt", CONTENT_AIR, &b->c_filler);
+	resolver->addNode(getstringfield_default(L, index, "node_stone", ""),
+		"mapgen_stone", CONTENT_AIR, &b->c_stone);
 	resolver->addNode(getstringfield_default(L, index, "node_water", ""),
 		"mapgen_water_source", CONTENT_AIR, &b->c_water);
 	resolver->addNode(getstringfield_default(L, index, "node_dust", ""),


### PR DESCRIPTION
![screenshot_72794710](https://cloud.githubusercontent.com/assets/3686677/5242546/437b2d82-792d-11e4-9729-7480cf62dfd1.png)

^ Here i am at y = 47

node_stone = "default:xxxxxxx"
can be added to a biome definition, the chosen stone will extend down to y = -32.

![screenshot_63343680](https://cloud.githubusercontent.com/assets/3686677/5242601/2006ef70-792e-11e4-819f-5eb48c8e973b.png)

^ Obsidian biome
