### PR TITLE
Fix node 0,0,0 being highlighted when enable_node_highlighting == false

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -255,10 +255,11 @@ Client::Client(
 	m_inventory_updated(false),
 	m_inventory_from_server(NULL),
 	m_inventory_from_server_age(0.0),
-	m_show_hud(true),
+	m_show_highlighted(false),
 	m_animation_time(0),
 	m_crack_level(-1),
 	m_crack_pos(0,0,0),
+	m_highlighted_pos(0,0,0),
 	m_map_seed(0),
 	m_password(password),
 	m_access_denied(false),
@@ -2515,9 +2516,9 @@ int Client::getCrackLevel()
 	return m_crack_level;
 }
 
-void Client::setHighlighted(v3s16 pos, bool show_hud)
+void Client::setHighlighted(v3s16 pos, bool show_highlighted)
 {
-	m_show_hud = show_hud;
+	m_show_highlighted = show_highlighted;
 	v3s16 old_highlighted_pos = m_highlighted_pos;
 	m_highlighted_pos = pos;
 	addUpdateMeshTaskForNode(old_highlighted_pos, false, true);
@@ -2607,7 +2608,7 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 		// Debug: 1-6ms, avg=2ms
 		data->fill(b);
 		data->setCrack(m_crack_level, m_crack_pos);
-		data->setHighlighted(m_highlighted_pos, m_show_hud);
+		data->setHighlighted(m_highlighted_pos, m_show_highlighted);
 		data->setSmoothLighting(g_settings->getBool("smooth_lighting"));
 	}
 

--- a/src/client.h
+++ b/src/client.h
@@ -398,7 +398,7 @@ public:
 	int getCrackLevel();
 	void setCrack(int level, v3s16 pos);
 
-	void setHighlighted(v3s16 pos, bool show_hud);
+	void setHighlighted(v3s16 pos, bool show_higlighted);
 	v3s16 getHighlighted(){ return m_highlighted_pos; }
 
 	u16 getHP();
@@ -509,7 +509,7 @@ private:
 	float m_inventory_from_server_age;
 	std::set<v3s16> m_active_blocks;
 	PacketCounter m_packetcounter;
-	bool m_show_hud;
+	bool m_show_highlighted;
 	// Block mesh animation parameters
 	float m_animation_time;
 	int m_crack_level;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2697,7 +2697,8 @@ void Game::toggleHud(float *statustext_time, bool *flag)
 	*flag = !*flag;
 	*statustext_time = 0;
 	statustext = msg[*flag];
-	client->setHighlighted(client->getHighlighted(), *flag);
+	if (g_settings->getBool("enable_node_highlighting"))
+		client->setHighlighted(client->getHighlighted(), *flag);
 }
 
 


### PR DESCRIPTION
Without this patch node 0,0,0 is highlighted when enable_node_highligting is false
There is a minor lighting issue remaining, however it seems to be related to a different bug (https://github.com/minetest/minetest/issues/1887)

See: https://forum.minetest.net/viewtopic.php?f=6&t=10549
