### PR TITLE
Make maximal view bobbing speed faster

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -292,7 +292,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 		PlayerEyeOffset += player->eye_offset_first;
 	else
 		PlayerEyeOffset += player->eye_offset_third;
-	
+
 	// Set head node transformation
 	m_headnode->setPosition(PlayerEyeOffset+v3f(0,cameratilt*-player->hurt_tilt_strength+fall_bobbing,0));
 	m_headnode->setRotation(v3f(player->getPitch(), 0, cameratilt*player->hurt_tilt_strength));
@@ -354,7 +354,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 
 	// Seperate camera position for calculation
 	v3f my_cp = m_camera_position;
-	
+
 	// Reposition the camera for third person view
 	if (m_camera_mode > CAMERA_MODE_FIRST)
 	{
@@ -398,7 +398,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 			(((s16)(my_cp.Y/BS) - m_camera_offset.Y)/CAMERA_OFFSET_STEP);
 	m_camera_offset.Z += CAMERA_OFFSET_STEP*
 			(((s16)(my_cp.Z/BS) - m_camera_offset.Z)/CAMERA_OFFSET_STEP);
-	
+
 	// Set camera node transformation
 	m_cameranode->setPosition(my_cp-intToFloat(m_camera_offset, BS));
 	m_cameranode->setUpVector(abs_cam_up);
@@ -451,7 +451,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 		wield_position.X -= 50 * sin(pow(digfrac, 0.8f) * M_PI);
 		wield_position.Y += 24 * sin(digfrac * 1.8 * M_PI);
 		wield_position.Z += 25 * 0.5;
-	
+
 		// Euler angles are PURE EVIL, so why not use quaternions?
 		core::quaternion quat_begin(wield_rotation * core::DEGTORAD);
 		core::quaternion quat_end(v3f(80, 30, 100) * core::DEGTORAD);
@@ -488,7 +488,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	{
 		// Start animation
 		m_view_bobbing_state = 1;
-		m_view_bobbing_speed = MYMIN(speed.getLength(), 40);
+		m_view_bobbing_speed = MYMIN(speed.getLength(), 50);
 	}
 	else if (m_view_bobbing_state == 1)
 	{
@@ -527,7 +527,7 @@ void Camera::updateViewingRange(f32 frametime_in, f32 busytime_in)
 
 	f32 viewing_range_max = g_settings->getS16("viewing_range_nodes_max");
 	viewing_range_max = MYMAX(viewing_range_min, viewing_range_max);
-	
+
 	// Immediately apply hard limits
 	if(m_draw_control.wanted_range < viewing_range_min)
 		m_draw_control.wanted_range = viewing_range_min;
@@ -624,7 +624,7 @@ void Camera::updateViewingRange(f32 frametime_in, f32 busytime_in)
 	}
 
 	new_range += wanted_range_change;
-	
+
 	//f32 new_range_unclamped = new_range;
 	new_range = MYMAX(new_range, viewing_range_min);
 	new_range = MYMIN(new_range, viewing_range_max);


### PR DESCRIPTION
This makes the maximal view bobbing speed faster, which is good for subgames like Carbone which increase the walking speed.