### PR TITLE
Increase client performance

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -209,6 +209,14 @@ private:
 	ItemStack m_wield_item_next;
 
 	CameraMode m_camera_mode;
+
+	f32 m_cache_fall_bobbing_amount;
+	f32 m_cache_view_bobbing_amount;
+	f32 m_cache_viewing_range_min;
+	f32 m_cache_viewing_range_max;
+	f32 m_cache_wanted_fps;
+	f32 m_cache_fov;
+	bool m_cache_view_bobbing;
 };
 
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -309,6 +309,8 @@ Client::Client(
 	} else {
 		localdb = NULL;
 	}
+
+	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
 }
 
 void Client::Stop()
@@ -2609,7 +2611,7 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 		data->fill(b);
 		data->setCrack(m_crack_level, m_crack_pos);
 		data->setHighlighted(m_highlighted_pos, m_show_highlighted);
-		data->setSmoothLighting(g_settings->getBool("smooth_lighting"));
+		data->setSmoothLighting(m_cache_smooth_lighting);
 	}
 
 	// Add task to queue

--- a/src/client.h
+++ b/src/client.h
@@ -562,6 +562,9 @@ private:
 	// Used for saving server map to disk client-side
 	Database *localdb;
 	Server *localserver;
+
+	// TODO: Add callback to update this when g_settings changes
+	bool m_cache_smooth_lighting;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -53,6 +53,20 @@ ClientMap::ClientMap(
 {
 	m_box = core::aabbox3d<f32>(-BS*1000000,-BS*1000000,-BS*1000000,
 			BS*1000000,BS*1000000,BS*1000000);
+
+	/* TODO: Add a callback function so these can be updated when a setting
+	 *       changes.  At this point in time it doesn't matter (e.g. /set
+	 *       is documented to change server settings only)
+	 *
+	 * TODO: Local caching of settings is not optimal and should at some stage
+	 *       be updated to use a global settings object for getting thse values
+	 *       (as opposed to the this local caching). This can be addressed in
+	 *       a later release.
+	 */
+	m_cache_trilinear_filter  = g_settings->getBool("trilinear_filter");
+	m_cache_bilinear_filter   = g_settings->getBool("bilinear_filter");
+	m_cache_anistropic_filter = g_settings->getBool("anisotropic_filter");
+
 }
 
 ClientMap::~ClientMap()
@@ -433,10 +447,6 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 		m_last_drawn_sectors.clear();
 	}
 
-	bool use_trilinear_filter = g_settings->getBool("trilinear_filter");
-	bool use_bilinear_filter = g_settings->getBool("bilinear_filter");
-	bool use_anisotropic_filter = g_settings->getBool("anisotropic_filter");
-
 	/*
 		Get time for measuring timeout.
 
@@ -566,9 +576,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			{
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 
-				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
-				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
+				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, m_cache_trilinear_filter);
+				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, m_cache_bilinear_filter);
+				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, m_cache_anistropic_filter);
 
 				const video::SMaterial& material = buf->getMaterial();
 				video::IMaterialRenderer* rnd =

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -154,6 +154,10 @@ private:
 	std::map<v3s16, MapBlock*> m_drawlist;
 	
 	std::set<v2s16> m_last_drawn_sectors;
+
+	bool m_cache_trilinear_filter;
+	bool m_cache_bilinear_filter;
+	bool m_cache_anistropic_filter;
 };
 
 #endif

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -55,6 +55,7 @@ Environment::Environment():
 	m_enable_day_night_ratio_override(false),
 	m_day_night_ratio_override(0.0f)
 {
+	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
 }
 
 Environment::~Environment()
@@ -206,8 +207,7 @@ u32 Environment::getDayNightRatio()
 {
 	if(m_enable_day_night_ratio_override)
 		return m_day_night_ratio_override;
-	bool smooth = g_settings->getBool("enable_shaders");
-	return time_to_daynight_ratio(m_time_of_day_f*24000, smooth);
+	return time_to_daynight_ratio(m_time_of_day_f*24000, m_cache_enable_shaders);
 }
 
 void Environment::setTimeOfDaySpeed(float speed)

--- a/src/environment.h
+++ b/src/environment.h
@@ -121,6 +121,17 @@ protected:
 	// Overriding the day-night ratio is useful for custom sky visuals
 	bool m_enable_day_night_ratio_override;
 	u32 m_day_night_ratio_override;
+
+	/* TODO: Add a callback function so these can be updated when a setting
+	 *       changes.  At this point in time it doesn't matter (e.g. /set
+	 *       is documented to change server settings only)
+	 *
+	 * TODO: Local caching of settings is not optimal and should at some stage
+	 *       be updated to use a global settings object for getting thse values
+	 *       (as opposed to the this local caching). This can be addressed in
+	 *       a later release.
+	 */
+	bool m_cache_enable_shaders;
 	
 private:
 	JMutex m_lock;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1581,6 +1581,23 @@ private:
 	KeyCache keycache;
 
 	IntervalLimiter profiler_interval;
+
+	/* TODO: Add a callback function so these can be updated when a setting
+	 *       changes.  At this point in time it doesn't matter (e.g. /set
+	 *       is documented to change server settings only)
+	 *
+	 * TODO: Local caching of settings is not optimal and should at some stage
+	 *       be updated to use a global settings object for getting thse values
+	 *       (as opposed to the this local caching). This can be addressed in
+	 *       a later release.
+	 */
+	bool m_cache_doubletap_jump;
+	bool m_cache_enable_node_highlighting;
+	bool m_cache_enable_clouds;
+	bool m_cache_enable_particles;
+	bool m_cache_enable_fog;
+	f32  m_cache_mouse_sensitivity;
+	f32  m_repeat_right_click_time;
 };
 
 Game::Game() :
@@ -1605,7 +1622,13 @@ Game::Game() :
 	local_inventory(NULL),
 	hud(NULL)
 {
-
+	m_cache_doubletap_jump            = g_settings->getBool("doubletap_jump");
+	m_cache_enable_node_highlighting  = g_settings->getBool("enable_node_highlighting");
+	m_cache_enable_clouds             = g_settings->getBool("enable_clouds");
+	m_cache_enable_particles          = g_settings->getBool("enable_particles");
+	m_cache_enable_fog                = g_settings->getBool("enable_fog");
+	m_cache_mouse_sensitivity         = g_settings->getFloat("mouse_sensitivity");
+	m_repeat_right_click_time         = g_settings->getFloat("repeat_rightclick_time");
 }
 
 
@@ -1934,7 +1957,7 @@ bool Game::createClient(const std::string &playername,
 
 	/* Clouds
 	 */
-	if (g_settings->getBool("enable_clouds")) {
+	if (m_cache_enable_clouds) {
 		clouds = new Clouds(smgr->getRootSceneNode(), smgr, -1, time(0));
 		if (!clouds) {
 			*error_message = L"Memory allocation error";
@@ -2454,7 +2477,7 @@ void Game::processUserInput(VolatileRunFlags *flags,
 #endif
 
 	// Increase timer for double tap of "keymap_jump"
-	if (g_settings->getBool("doubletap_jump") && interact_args->jump_timer <= 0.2)
+	if (m_cache_doubletap_jump && interact_args->jump_timer <= 0.2)
 		interact_args->jump_timer += dtime;
 
 	processKeyboardInput(
@@ -2648,7 +2671,7 @@ void Game::toggleFreeMove(float *statustext_time)
 
 void Game::toggleFreeMoveAlt(float *statustext_time, float *jump_timer)
 {
-	if (g_settings->getBool("doubletap_jump") && *jump_timer < 0.2f)
+	if (m_cache_doubletap_jump && *jump_timer < 0.2f)
 		toggleFreeMove(statustext_time);
 }
 
@@ -2859,7 +2882,7 @@ void Game::updateCameraDirection(CameraOrientation *cam,
 
 			//infostream<<"window active, pos difference "<<dx<<","<<dy<<std::endl;
 
-			float d = g_settings->getFloat("mouse_sensitivity");
+			float d = m_cache_mouse_sensitivity;
 			d = rangelim(d, 0.01, 100.0);
 			cam->camera_yaw -= dx * d;
 			cam->camera_pitch += dy * d;
@@ -3333,7 +3356,7 @@ void Game::processPlayerInteraction(std::vector<aabb3f> &highlight_boxes,
 	if (pointed != runData->pointed_old) {
 		infostream << "Pointing at " << pointed.dump() << std::endl;
 
-		if (g_settings->getBool("enable_node_highlighting")) {
+		if (m_cache_enable_node_highlighting) {
 			if (pointed.type == POINTEDTHING_NODE) {
 				client->setHighlighted(pointed.node_undersurface, show_hud);
 			} else {
@@ -3446,8 +3469,7 @@ void Game::handlePointingAtNode(GameRunData *runData,
 	}
 
 	if ((input->getRightClicked() ||
-			runData->repeat_rightclick_timer >=
-			g_settings->getFloat("repeat_rightclick_time")) &&
+			runData->repeat_rightclick_timer >= m_repeat_right_click_time) &&
 			client->checkPrivilege("interact")) {
 		runData->repeat_rightclick_timer = 0;
 		infostream << "Ground right-clicked" << std::endl;
@@ -3582,7 +3604,7 @@ void Game::handleDigging(GameRunData *runData,
 	} else {
 		runData->dig_time_complete = params.time;
 
-		if (g_settings->getBool("enable_particles")) {
+		if (m_cache_enable_particles) {
 			const ContentFeatures &features =
 					client->getNodeDefManager()->get(n);
 			addPunchingParticles(gamedef, smgr, player,
@@ -3629,7 +3651,7 @@ void Game::handleDigging(GameRunData *runData,
 		if (is_valid_position)
 			client->removeNode(nodepos);
 
-		if (g_settings->getBool("enable_particles")) {
+		if (m_cache_enable_particles) {
 			const ContentFeatures &features =
 				client->getNodeDefManager()->get(wasnode);
 			addDiggingParticles
@@ -3765,7 +3787,7 @@ void Game::updateFrame(std::vector<aabb3f> &highlight_boxes,
 		Fog
 	*/
 
-	if (g_settings->getBool("enable_fog") && !flags.force_fog_off) {
+	if (m_cache_enable_fog && !flags.force_fog_off) {
 		driver->setFog(
 				sky->getBgColor(),
 				video::EFT_FOG_LINEAR,


### PR DESCRIPTION
Increase performance by 'caching' settings where safe to do so.

Performance of main client loop up to 2x faster
In places, up to 3 times faster

NOTE 1: This does not mean a 2x increase in framerate. Increase in fps may be up to 1-2fps
NOTE 2: This local 'caching' of settings is not optimal and an alternative solution will be worked on after 0.4.11 is released
