### PR TITLE
Add space

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4468,7 +4468,7 @@ std::wstring Server::getStatusString()
 			name = narrow_to_wide(player->getName());
 		// Add name to information string
 		if(!first)
-			os<<L",";
+			os<<L", ";
 		else
 			first = false;
 		os<<name;


### PR DESCRIPTION
Add space between two online user:
What we want:

```
# Server: version=0.4.10, uptime=190.5, max_lag=0.001, clients={user1,user2,user3,user4,user5,foobar,userplayedminetestthismorning,thismorningiplayedminetestwithmyfriend}
```

Reality:

```
Server: version=0.4.10, uptime=190.5, max_lag=0.001, 
clients={user1,user2,user3,user4,user5,foobar,userplayedminetestthismorning,thismorningiplayed
```

Yes, the text is not complete.
So, I edit the file and it will show like this:

```
# Server: version=0.4.10, uptime=190.5, max_lag=0.001, clients={user1, user2, user3, user4,
user5, foobar, userplayedminetestthismorning, thismorningiplayedminetestwithmyfriend}
```

Also, this makes player to read it better.

Hope this helps!
