### PR TITLE
Liquid node footsteps

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -496,7 +496,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	// start (or continue) the view bobbing animation.
 	v3f speed = player->getSpeed();
 	if ((hypot(speed.X, speed.Z) > BS) &&
-		(player->touching_ground) &&
+		(player->touching_ground || player->in_liquid || player->is_climbing) &&
 		(m_cache_view_bobbing == true) &&
 		(g_settings->getBool("free_move") == false ||
 				!m_gamedef->checkLocalPrivilege("fly")))


### PR DESCRIPTION
Allow footstep sounds to play for liquid and ladder nodes, making swimming and climbing sounds possible. This needs to be done by enabling view bobbing for swimming and climbing, but this looks fine and is also preferred functionality.
