### PR TITLE
Increase performance of getLight() by at least 100%

### DIFF
--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -259,8 +259,8 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 			light_source_max = f.light_source;
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
-			light_day += decode_light(n.getLight(LIGHTBANK_DAY, ndef));
-			light_night += decode_light(n.getLight(LIGHTBANK_NIGHT, ndef));
+			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_DAY, &f));
+			light_night += decode_light(n.getLightNoChecks(LIGHTBANK_NIGHT, &f));
 			light_count++;
 		} else {
 			ambient_occlusion++;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -88,6 +88,12 @@ u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
 	return MYMAX(f.light_source, light);
 }
 
+u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f)
+{
+	return MYMAX(f->light_source,
+	             bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f);
+}
+
 bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const
 {
 	// Select the brightest of [light source, propagated light]

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -108,6 +108,9 @@ enum Rotation {
 #define LEVELED_MASK 0x3F
 #define LEVELED_MAX LEVELED_MASK
 
+
+struct ContentFeatures;
+
 /*
 	This is the stuff what the whole world consists of.
 */
@@ -188,6 +191,24 @@ struct MapNode
 	
 	void setLight(enum LightBank bank, u8 a_light, INodeDefManager *nodemgr);
 	u8 getLight(enum LightBank bank, INodeDefManager *nodemgr) const;
+
+	/**
+	 * This function differs from getLight(enum LightBank bank, INodeDefManager *nodemgr)
+	 * in that the ContentFeatures of the node in question are not retrieved by
+	 * the function itself.  Thus, if you have already called nodemgr->get() to
+	 * get the ContentFeatures you pass it to this function instead of the
+	 * function getting ContentFeatures itself.  Since INodeDefManager::get()
+	 * is relatively expensive this can lead to significant performance
+	 * improvements in some situations.  Call this function if (and only if)
+	 * you have already retrieved the ContentFeatures by calling
+	 * INodeDefManager::get() for the node you're working with and the
+	 * pre-conditions listed are true.
+	 *
+	 * @pre f != NULL
+	 * @pre f->param_type == CPT_LIGHT
+	 */
+	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f);
+
 	bool getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const;
 	
 	// 0 <= daylight_factor <= 1000


### PR DESCRIPTION
Leads to the following increases:

```
getSmoothLight() approx.     40% increase
getTileInfo() approx.        25% increase
MapBlockMesh::MapBlockMesh() 25-30%
```
