### PR TITLE
Ignore downloaded public serverlist if public_serverlist is false

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -162,8 +162,10 @@ function asyncOnlineFavourites()
 		end,
 		nil,
 		function(result)
-			menudata.favorites = result
-			core.event_handler("Refresh")
+			if core.setting_getbool("public_serverlist") then
+				menudata.favorites = result
+				core.event_handler("Refresh")
+			end
 		end
 		)
 end


### PR DESCRIPTION
Fixes #1807: When the server list finishes downloading, the local server
list resets in certain conditions
