### PR TITLE
Use the console instead of a dedicated window when pressing chat/command keys

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -390,6 +390,7 @@ ChatPrompt::ChatPrompt(std::wstring prompt, u32 history_limit):
 	m_cols(0),
 	m_view(0),
 	m_cursor(0),
+	m_cursor_len(0),
 	m_nick_completion_start(0),
 	m_nick_completion_end(0)
 {
@@ -424,11 +425,6 @@ void ChatPrompt::addToHistory(std::wstring line)
 	if (m_history.size() > m_history_limit)
 		m_history.erase(m_history.begin());
 	m_history_index = m_history.size();
-}
-
-std::wstring ChatPrompt::getLine()
-{
-	return m_line;
 }
 
 void ChatPrompt::clear()
@@ -590,14 +586,12 @@ void ChatPrompt::cursorOperation(CursorOp op, CursorOpDir dir, CursorOpScope sco
 	s32 length = m_line.size();
 	s32 increment = (dir == CURSOROP_DIR_RIGHT) ? 1 : -1;
 
-	if (scope == CURSOROP_SCOPE_CHARACTER)
-	{
+	switch (scope) {
+	case CURSOROP_SCOPE_CHARACTER:
 		new_cursor += increment;
-	}
-	else if (scope == CURSOROP_SCOPE_WORD)
-	{
-		if (increment > 0)
-		{
+		break;
+	case CURSOROP_SCOPE_WORD:
+		if (dir == CURSOROP_DIR_RIGHT) {
 			// skip one word to the right
 			while (new_cursor < length && isspace(m_line[new_cursor]))
 				new_cursor++;
@@ -605,39 +599,47 @@ void ChatPrompt::cursorOperation(CursorOp op, CursorOpDir dir, CursorOpScope sco
 				new_cursor++;
 			while (new_cursor < length && isspace(m_line[new_cursor]))
 				new_cursor++;
-		}
-		else
-		{
+		} else {
 			// skip one word to the left
 			while (new_cursor >= 1 && isspace(m_line[new_cursor - 1]))
 				new_cursor--;
 			while (new_cursor >= 1 && !isspace(m_line[new_cursor - 1]))
 				new_cursor--;
 		}
-	}
-	else if (scope == CURSOROP_SCOPE_LINE)
-	{
+		break;
+	case CURSOROP_SCOPE_LINE:
 		new_cursor += increment * length;
+		break;
+	case CURSOROP_SCOPE_SELECTION:
+		break;
 	}
 
 	new_cursor = MYMAX(MYMIN(new_cursor, length), 0);
 
-	if (op == CURSOROP_MOVE)
-	{
+	switch (op) {
+	case CURSOROP_MOVE:
 		m_cursor = new_cursor;
-	}
-	else if (op == CURSOROP_DELETE)
-	{
-		if (new_cursor < old_cursor)
-		{
-			m_line.erase(new_cursor, old_cursor - new_cursor);
-			m_cursor = new_cursor;
+		m_cursor_len = 0;
+		break;
+	case CURSOROP_DELETE:
+		if (m_cursor_len > 0) { // Delete selected text first
+			m_line.erase(m_cursor, m_cursor_len);
+		} else {
+			m_cursor = MYMIN(new_cursor, old_cursor);
+			m_line.erase(m_cursor, abs(new_cursor - old_cursor));
 		}
-		else if (new_cursor > old_cursor)
-		{
-			m_line.erase(old_cursor, new_cursor - old_cursor);
-			m_cursor = old_cursor;
+		m_cursor_len = 0;
+		break;
+	case CURSOROP_SELECT:
+		if (scope == CURSOROP_SCOPE_LINE) {
+			m_cursor = 0;
+			m_cursor_len = length;
+		} else {
+			m_cursor = MYMIN(new_cursor, old_cursor);
+			m_cursor_len += abs(new_cursor - old_cursor);
+			m_cursor_len = MYMIN(m_cursor_len, length - m_cursor);
 		}
+		break;
 	}
 
 	clampView();

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -417,20 +417,18 @@ void ChatPrompt::input(const std::wstring &str)
 	m_nick_completion_end = 0;
 }
 
-std::wstring ChatPrompt::submit()
+void ChatPrompt::addToHistory(std::wstring line)
 {
-	std::wstring line = m_line;
-	m_line.clear();
 	if (!line.empty())
 		m_history.push_back(line);
 	if (m_history.size() > m_history_limit)
 		m_history.erase(m_history.begin());
 	m_history_index = m_history.size();
-	m_view = 0;
-	m_cursor = 0;
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
-	return line;
+}
+
+std::wstring ChatPrompt::getLine()
+{
+	return m_line;
 }
 
 void ChatPrompt::clear()
@@ -442,13 +440,15 @@ void ChatPrompt::clear()
 	m_nick_completion_end = 0;
 }
 
-void ChatPrompt::replace(std::wstring line)
+std::wstring ChatPrompt::replace(std::wstring line)
 {
+	std::wstring old_line = m_line;
 	m_line =  line;
 	m_view = m_cursor = line.size();
 	clampView();
 	m_nick_completion_start = 0;
 	m_nick_completion_end = 0;
+	return old_line;
 }
 
 void ChatPrompt::historyPrev()

--- a/src/chat.h
+++ b/src/chat.h
@@ -150,7 +150,11 @@ public:
 	void addToHistory(std::wstring line);
 
 	// Get current line
-	std::wstring getLine();
+	std::wstring getLine() const { return m_line; }
+
+	// Get section of line that is currently selected
+	std::wstring getSelection() const
+		{ return m_line.substr(m_cursor, m_cursor_len); }
 
 	// Clear the current line
 	void clear();
@@ -172,10 +176,13 @@ public:
 	std::wstring getVisiblePortion() const;
 	// Get cursor position (relative to visible portion). -1 if invalid
 	s32 getVisibleCursorPosition() const;
+	// Get length of cursor selection
+	s32 getCursorLength() const { return m_cursor_len; }
 
 	// Cursor operations
 	enum CursorOp {
 		CURSOROP_MOVE,
+		CURSOROP_SELECT,
 		CURSOROP_DELETE
 	};
 
@@ -189,7 +196,8 @@ public:
 	enum CursorOpScope {
 		CURSOROP_SCOPE_CHARACTER,
 		CURSOROP_SCOPE_WORD,
-		CURSOROP_SCOPE_LINE
+		CURSOROP_SCOPE_LINE,
+		CURSOROP_SCOPE_SELECTION
 	};
 
 	// Cursor operation
@@ -227,6 +235,8 @@ private:
 	s32 m_view;
 	// Cursor (index into m_line)
 	s32 m_cursor;
+	// Cursor length (length of selected portion of line)
+	s32 m_cursor_len;
 
 	// Last nick completion start (index into m_line)
 	s32 m_nick_completion_start;

--- a/src/chat.h
+++ b/src/chat.h
@@ -146,14 +146,17 @@ public:
 	void input(wchar_t ch);
 	void input(const std::wstring &str);
 
-	// Submit, clear and return current line
-	std::wstring submit();
+	// Add a string to the history
+	void addToHistory(std::wstring line);
+
+	// Get current line
+	std::wstring getLine();
 
 	// Clear the current line
 	void clear();
 
 	// Replace the current line with the given text
-	void replace(std::wstring line);
+	std::wstring replace(std::wstring line);
 
 	// Select previous command from history
 	void historyPrev();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2175,7 +2175,7 @@ bool Game::initGui()
 
 	// Chat backend and console
 	gui_chat_console = new GUIChatConsole(guienv, guienv->getRootGUIElement(),
-			-1, chat_backend, client);
+			-1, chat_backend, client, &g_menumgr);
 	if (!gui_chat_console) {
 		*error_message = "Could not allocate memory for chat console";
 		errorstream << *error_message << std::endl;
@@ -2809,7 +2809,6 @@ void Game::openConsole(float height, const wchar_t *line)
 			gui_chat_console->setCloseOnEnter(true);
 			gui_chat_console->replaceAndAddToHistory(line);
 		}
-		guienv->setFocus(gui_chat_console);
 	}
 }
 

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -536,7 +536,8 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			// Copy text to clipboard
 			if (prompt.getCursorLength() <= 0)
 				return true;
-			std::string selected = wide_to_narrow(prompt.getSelection());
+			std::wstring wselected = prompt.getSelection();
+			std::string selected(wselected.begin(), wselected.end());
 			Environment->getOSOperator()->copyToClipboard(selected.c_str());
 			return true;
 		}
@@ -553,8 +554,10 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			}
 			IOSOperator *os_operator = Environment->getOSOperator();
 			const c8 *text = os_operator->getTextFromClipboard();
-			if (text)
-				prompt.input(narrow_to_wide(text));
+			if (!text)
+				return true;
+			std::basic_string<unsigned char> str((const unsigned char*)text);
+			prompt.input(std::wstring(str.begin(), str.end()));
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_KEY_X && event.KeyInput.Control)

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -55,6 +55,7 @@ GUIChatConsole::GUIChatConsole(
 	m_screensize(v2u32(0,0)),
 	m_animate_time_old(0),
 	m_open(false),
+	m_close_on_enter(false),
 	m_height(0),
 	m_desired_height(0),
 	m_desired_height_fraction(0.0),
@@ -147,6 +148,14 @@ f32 GUIChatConsole::getDesiredHeight() const
 {
 	return m_desired_height_fraction;
 }
+
+void GUIChatConsole::replaceAndAddToHistory(std::wstring line)
+{
+	ChatPrompt& prompt = m_chat_backend->getPrompt();
+	prompt.addToHistory(prompt.getLine());
+	prompt.replace(line);
+}
+
 
 void GUIChatConsole::setCursor(
 	bool visible, bool blinking, f32 blink_speed, f32 relative_height)
@@ -381,6 +390,9 @@ void GUIChatConsole::drawPrompt()
 
 bool GUIChatConsole::OnEvent(const SEvent& event)
 {
+
+	ChatPrompt &prompt = m_chat_backend->getPrompt();
+
 	if(event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown)
 	{
 		// Key input
@@ -391,13 +403,16 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 
 			// inhibit open so the_game doesn't reopen immediately
 			m_open_inhibited = 50;
+			m_close_on_enter = false;
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_ESCAPE)
 		{
 			closeConsoleAtOnce();
 			Environment->removeFocus(this);
-			// the_game will open the pause menu
+			m_close_on_enter = false;
+			// inhibit open so the_game doesn't reopen immediately
+			m_open_inhibited = 1; // so the ESCAPE button doesn't open the "pause menu"
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_PRIOR)
@@ -412,22 +427,28 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Key == KEY_RETURN)
 		{
-			std::wstring text = m_chat_backend->getPrompt().submit();
+			prompt.addToHistory(prompt.getLine());
+			std::wstring text = prompt.replace(L"");
 			m_client->typeChatMessage(text);
+			if (m_close_on_enter) {
+				closeConsoleAtOnce();
+				Environment->removeFocus(this);
+				m_close_on_enter = false;
+			}
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_UP)
 		{
 			// Up pressed
 			// Move back in history
-			m_chat_backend->getPrompt().historyPrev();
+			prompt.historyPrev();
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_DOWN)
 		{
 			// Down pressed
 			// Move forward in history
-			m_chat_backend->getPrompt().historyNext();
+			prompt.historyNext();
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_LEFT)
@@ -438,7 +459,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				event.KeyInput.Control ?
 				ChatPrompt::CURSOROP_SCOPE_WORD :
 				ChatPrompt::CURSOROP_SCOPE_CHARACTER;
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_MOVE,
 				ChatPrompt::CURSOROP_DIR_LEFT,
 				scope);
@@ -452,7 +473,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				event.KeyInput.Control ?
 				ChatPrompt::CURSOROP_SCOPE_WORD :
 				ChatPrompt::CURSOROP_SCOPE_CHARACTER;
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_MOVE,
 				ChatPrompt::CURSOROP_DIR_RIGHT,
 				scope);
@@ -462,7 +483,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			// Home pressed
 			// move to beginning of line
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_MOVE,
 				ChatPrompt::CURSOROP_DIR_LEFT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
@@ -472,7 +493,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			// End pressed
 			// move to end of line
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_MOVE,
 				ChatPrompt::CURSOROP_DIR_RIGHT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
@@ -486,7 +507,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				event.KeyInput.Control ?
 				ChatPrompt::CURSOROP_SCOPE_WORD :
 				ChatPrompt::CURSOROP_SCOPE_CHARACTER;
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_DELETE,
 				ChatPrompt::CURSOROP_DIR_LEFT,
 				scope);
@@ -500,7 +521,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				event.KeyInput.Control ?
 				ChatPrompt::CURSOROP_SCOPE_WORD :
 				ChatPrompt::CURSOROP_SCOPE_CHARACTER;
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_DELETE,
 				ChatPrompt::CURSOROP_DIR_RIGHT,
 				scope);
@@ -513,17 +534,14 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			IOSOperator *os_operator = Environment->getOSOperator();
 			const c8 *text = os_operator->getTextFromClipboard();
 			if (text)
-			{
-				std::wstring wtext = narrow_to_wide(text);
-				m_chat_backend->getPrompt().input(wtext);
-			}
+				prompt.input(narrow_to_wide(text));
 			return true;
 		}
 		else if(event.KeyInput.Key == KEY_KEY_U && event.KeyInput.Control)
 		{
 			// Ctrl-U pressed
 			// kill line to left end
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_DELETE,
 				ChatPrompt::CURSOROP_DIR_LEFT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
@@ -533,7 +551,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			// Ctrl-K pressed
 			// kill line to right end
-			m_chat_backend->getPrompt().cursorOperation(
+			prompt.cursorOperation(
 				ChatPrompt::CURSOROP_DELETE,
 				ChatPrompt::CURSOROP_DIR_RIGHT,
 				ChatPrompt::CURSOROP_SCOPE_LINE);
@@ -545,7 +563,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			// Nick completion
 			std::list<std::string> names = m_client->getConnectedPlayerNames();
 			bool backwards = event.KeyInput.Shift;
-			m_chat_backend->getPrompt().nickCompletion(names, backwards);
+			prompt.nickCompletion(names, backwards);
 			return true;
 		}
 		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)
@@ -553,9 +571,9 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';
 				mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
-				m_chat_backend->getPrompt().input(wc);
+				prompt.input(wc);
 			#else
-				m_chat_backend->getPrompt().input(event.KeyInput.Char);
+				prompt.input(event.KeyInput.Char);
 			#endif
 			return true;
 		}

--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -51,10 +51,15 @@ public:
 	void closeConsole();
 	// Close the console immediately, without animation.
 	void closeConsoleAtOnce();
+	// Set whether to close the console after the user presses enter.
+	void setCloseOnEnter(bool close) { m_close_on_enter = close; }
 
 	// Return the desired height (fraction of screen size)
 	// Zero if the console is closed or getting closed
 	f32 getDesiredHeight() const;
+
+	// Replace actual line when adding the actual to the history (if there is any)
+	void replaceAndAddToHistory(std::wstring line);
 
 	// Change how the cursor looks
 	void setCursor(
@@ -95,6 +100,8 @@ private:
 
 	// should the console be opened or closed?
 	bool m_open;
+	// should it close after you press enter?
+	bool m_close_on_enter;
 	// current console height [pixels]
 	s32 m_height;
 	// desired height [pixels]

--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GUICHATCONSOLE_HEADER
 
 #include "irrlichttypes_extrabloated.h"
+#include "modalMenu.h"
 #include "chat.h"
 #include "config.h"
 
@@ -33,7 +34,8 @@ public:
 			gui::IGUIElement* parent,
 			s32 id,
 			ChatBackend* backend,
-			Client* client);
+			Client* client,
+			IMenuManager* menumgr);
 	virtual ~GUIChatConsole();
 
 	// Open the console (height = desired fraction of screen size)
@@ -86,11 +88,9 @@ private:
 	void drawPrompt();
 
 private:
-	// pointer to the chat backend
 	ChatBackend* m_chat_backend;
-
-	// pointer to the client
 	Client* m_client;
+	IMenuManager* m_menumgr;
 
 	// current screen size
 	v2u32 m_screensize;

--- a/src/mainmenumanager.h
+++ b/src/mainmenumanager.h
@@ -47,9 +47,9 @@ extern gui::IGUIStaticText *guiroot;
 class MainMenuManager : public IMenuManager
 {
 public:
-	virtual void createdMenu(GUIModalMenu *menu)
+	virtual void createdMenu(gui::IGUIElement *menu)
 	{
-		for(std::list<GUIModalMenu*>::iterator
+		for(std::list<gui::IGUIElement*>::iterator
 				i = m_stack.begin();
 				i != m_stack.end(); ++i)
 		{
@@ -61,13 +61,13 @@ public:
 		m_stack.push_back(menu);
 	}
 
-	virtual void deletingMenu(GUIModalMenu *menu)
+	virtual void deletingMenu(gui::IGUIElement *menu)
 	{
 		// Remove all entries if there are duplicates
 		bool removed_entry;
 		do{
 			removed_entry = false;
-			for(std::list<GUIModalMenu*>::iterator
+			for(std::list<gui::IGUIElement*>::iterator
 					i = m_stack.begin();
 					i != m_stack.end(); ++i)
 			{
@@ -91,10 +91,10 @@ public:
 	// Returns true to prevent further processing
 	virtual bool preprocessEvent(const SEvent& event)
 	{
-		if(!m_stack.empty())
-			return m_stack.back()->preprocessEvent(event);
-		else
+		if (m_stack.empty())
 			return false;
+		GUIModalMenu *mm = dynamic_cast<GUIModalMenu*>(m_stack.back());
+		return mm && mm->preprocessEvent(event);
 	}
 
 	u32 menuCount()
@@ -104,16 +104,17 @@ public:
 
 	bool pausesGame()
 	{
-		for(std::list<GUIModalMenu*>::iterator
+		for(std::list<gui::IGUIElement*>::iterator
 				i = m_stack.begin(); i != m_stack.end(); ++i)
 		{
-			if((*i)->pausesGame())
+			GUIModalMenu *mm = dynamic_cast<GUIModalMenu*>(*i);
+			if (mm && mm->pausesGame())
 				return true;
 		}
 		return false;
 	}
 
-	std::list<GUIModalMenu*> m_stack;
+	std::list<gui::IGUIElement*> m_stack;
 };
 
 extern MainMenuManager g_menumgr;

--- a/src/modalMenu.h
+++ b/src/modalMenu.h
@@ -31,8 +31,8 @@ class IMenuManager
 {
 public:
 	// A GUIModalMenu calls these when this class is passed as a parameter
-	virtual void createdMenu(GUIModalMenu *menu) = 0;
-	virtual void deletingMenu(GUIModalMenu *menu) = 0;
+	virtual void createdMenu(gui::IGUIElement *menu) = 0;
+	virtual void deletingMenu(gui::IGUIElement *menu) = 0;
 };
 
 /*


### PR DESCRIPTION
Heavily rebased and enhanced version of @EXio4's old pull request.

This version makes the window only cover 20% of the screen if it's launched with `keymap_chat` or `keymap_command`.  Opening it with `keymap_console` opens it up to full size.

![screenshot_20160227_170942](https://cloud.githubusercontent.com/assets/3399154/13375723/330c7b10-dd75-11e5-92ac-3d2c54889365.png)
