### PR TITLE
Add zoom, tweakable with zoom_fov, default key: Z (like optifine)

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -40,6 +40,7 @@
 #keymap_jump = KEY_SPACE
 #keymap_sneak = KEY_LSHIFT
 #keymap_inventory = KEY_KEY_I
+#keymap_zoom = KEY_KEY_Z
 #    Go down ladder / go down in fly mode / go fast in fast mode
 #keymap_special1 = KEY_KEY_E
 #keymap_chat = KEY_KEY_T
@@ -55,6 +56,8 @@
 #doubletap_jump = false
 #    If false aux1 is used to fly fast
 #always_fly_fast = true
+#    FOV when using zoom
+#zoom_fov = 15
 #    Some (temporary) keys for debugging
 #keymap_print_debug_stacks = KEY_KEY_P
 #keymap_quicktune_prev = KEY_HOME

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -111,6 +111,7 @@ Camera::Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
 	m_cache_view_bobbing_amount = g_settings->getFloat("view_bobbing_amount");
 	m_cache_wanted_fps          = g_settings->getFloat("wanted_fps");
 	m_cache_fov                 = g_settings->getFloat("fov");
+	m_cache_zoom_fov            = g_settings->getFloat("zoom_fov");
 	m_cache_view_bobbing        = g_settings->getBool("view_bobbing");
 }
 
@@ -424,8 +425,13 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	if (m_camera_mode == CAMERA_MODE_THIRD_FRONT)
 		m_camera_position = my_cp;
 
-	// Get FOV setting
-	f32 fov_degrees = m_cache_fov;
+	// Get FOV
+	f32 fov_degrees;
+	if (player->getPlayerControl().zoom) {
+		fov_degrees = m_cache_zoom_fov;
+	} else {
+		fov_degrees = m_cache_fov;
+	}
 	fov_degrees = MYMAX(fov_degrees, 10.0);
 	fov_degrees = MYMIN(fov_degrees, 170.0);
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -214,6 +214,7 @@ private:
 	f32 m_cache_view_bobbing_amount;
 	f32 m_cache_wanted_fps;
 	f32 m_cache_fov;
+	f32 m_cache_zoom_fov;
 	bool m_cache_view_bobbing;
 };
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -39,6 +39,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_jump", "KEY_SPACE");
 	settings->setDefault("keymap_sneak", "KEY_LSHIFT");
 	settings->setDefault("keymap_drop", "KEY_KEY_Q");
+	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
 	settings->setDefault("keymap_inventory", "KEY_KEY_I");
 	settings->setDefault("keymap_special1", "KEY_KEY_E");
 	settings->setDefault("keymap_chat", "KEY_KEY_T");
@@ -71,6 +72,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("always_fly_fast", "true");
 	settings->setDefault("directional_colored_fog", "true");
 	settings->setDefault("tooltip_show_delay", "400");
+	settings->setDefault("zoom_fov", "15");
 
 	// Some (temporary) keys for debugging
 	settings->setDefault("keymap_print_debug_stacks", "KEY_KEY_P");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1243,6 +1243,7 @@ struct KeyCache {
 		KEYMAP_ID_INCREASE_VIEWING_RANGE,
 		KEYMAP_ID_DECREASE_VIEWING_RANGE,
 		KEYMAP_ID_RANGESELECT,
+		KEYMAP_ID_ZOOM,
 
 		KEYMAP_ID_QUICKTUNE_NEXT,
 		KEYMAP_ID_QUICKTUNE_PREV,
@@ -1299,6 +1300,7 @@ void KeyCache::populate()
 			= getKeySetting("keymap_decrease_viewing_range_min");
 	key[KEYMAP_ID_RANGESELECT]
 			= getKeySetting("keymap_rangeselect");
+	key[KEYMAP_ID_ZOOM] = getKeySetting("keymap_zoom");
 
 	key[KEYMAP_ID_QUICKTUNE_NEXT] = getKeySetting("keymap_quicktune_next");
 	key[KEYMAP_ID_QUICKTUNE_PREV] = getKeySetting("keymap_quicktune_prev");
@@ -2927,6 +2929,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_JUMP]),
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]),
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SNEAK]),
+		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_ZOOM]),
 		input->getLeftState(),
 		input->getRightState(),
 		cam.camera_pitch,

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -59,6 +59,7 @@ enum
 	GUI_ID_KEY_INVENTORY_BUTTON,
 	GUI_ID_KEY_DUMP_BUTTON,
 	GUI_ID_KEY_RANGE_BUTTON,
+	GUI_ID_KEY_ZOOM_BUTTON,
 	// other
 	GUI_ID_CB_AUX1_DESCENDS,
 	GUI_ID_CB_DOUBLETAP_JUMP,
@@ -411,4 +412,5 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,    wgettext("Toggle noclip"), "keymap_noclip");
 	this->add_key(GUI_ID_KEY_RANGE_BUTTON,     wgettext("Range select"),  "keymap_rangeselect");
 	this->add_key(GUI_ID_KEY_DUMP_BUTTON,      wgettext("Print stacks"),  "keymap_print_debug_stacks");
+	this->add_key(GUI_ID_KEY_ZOOM_BUTTON,      wgettext("Zoom"),          "keymap_zoom");
 }

--- a/src/player.h
+++ b/src/player.h
@@ -33,18 +33,8 @@ struct PlayerControl
 {
 	PlayerControl()
 	{
-		up = false;
-		down = false;
-		left = false;
-		right = false;
-		jump = false;
-		aux1 = false;
-		sneak = false;
-		LMB = false;
-		RMB = false;
-		pitch = 0;
-		yaw = 0;
 	}
+
 	PlayerControl(
 		bool a_up,
 		bool a_down,
@@ -53,6 +43,7 @@ struct PlayerControl
 		bool a_jump,
 		bool a_aux1,
 		bool a_sneak,
+		bool a_zoom,
 		bool a_LMB,
 		bool a_RMB,
 		float a_pitch,
@@ -66,6 +57,7 @@ struct PlayerControl
 		jump = a_jump;
 		aux1 = a_aux1;
 		sneak = a_sneak;
+		zoom = a_zoom;
 		LMB = a_LMB;
 		RMB = a_RMB;
 		pitch = a_pitch;
@@ -78,6 +70,7 @@ struct PlayerControl
 	bool jump;
 	bool aux1;
 	bool sneak;
+	bool zoom;
 	bool LMB;
 	bool RMB;
 	float pitch;


### PR DESCRIPTION
Rebased version of #583 by @EXio4.

Note: When zooming out you can see blocks loading that got unloaded because of culling when zooming.