### PR TITLE
Remove the liquid_loop_max setting which should not be needed and essentially causes a memory leak

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -98,8 +98,6 @@
 #show_debug = false
 # Enable a bit lower water surface; disable for speed (not quite optimized)
 #new_style_water = false
-# Max liquids processed per step
-#liquid_loop_max = 10000
 # Update liquids every .. recommend for finite: 0.2
 #liquid_update = 1.0
 # Enable nice leaves; disable for speed

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -276,7 +276,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("movement_gravity", "9.81");
 
 	//liquid stuff
-	settings->setDefault("liquid_loop_max", "10000");
 	settings->setDefault("liquid_update", "1.0");
 
 	//mapgen stuff

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1628,12 +1628,14 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks)
 	// List of MapBlocks that will require a lighting update (due to lava)
 	std::map<v3s16, MapBlock*> lighting_modified_blocks;
 
-	u16 loop_max = g_settings->getU16("liquid_loop_max");
+	// TODO: Dynamic limiting of the loop count for smoothing bursts
+	// TODO: DoS prevention by dropping the queue if processing it takes too
+	//       long (maybe 30 seconds or so)
 
 	while(m_transforming_liquid.size() != 0)
 	{
 		// This should be done here so that it is done when continue is used
-		if(loopcount >= initial_size || loopcount >= loop_max)
+		if(loopcount >= initial_size)
 			break;
 		loopcount++;
 


### PR DESCRIPTION
The liquid_loop_max setting is practically never adjusted by users, and there is also no practical way of figuring out a value to adjust it to. liquid_loop_max was intended to provide smoothing for large bursts of queued liquid updates to keep the server's step interval less spiky, but it is quite useless in its current state.

When this setting has a value that is too low, a memory leak can appear due to more stuff going into the queue than being read out from it. This has been noticed by @Zeno- and some other people.

Later some kind of auto-adjusted smoothing should be added that does not need configuration based on parameters that cannot even be looked up from anywhere.

Also, later some kind of a denial-of-service time limit for the liquid processing loop should be added, which, when triggered, will just delete the queue content without attempting to process it.
