### PR TITLE
Rename testsounds/ directory to sounds/

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -788,7 +788,7 @@ public:
 			return;
 
 		m_fetched.insert(name);
-		std::string base = porting::path_share + DIR_DELIM + "testsounds";
+		std::string base = porting::path_share + DIR_DELIM + "sounds";
 		dst_paths.insert(base + DIR_DELIM + name + ".ogg");
 		dst_paths.insert(base + DIR_DELIM + name + ".0.ogg");
 		dst_paths.insert(base + DIR_DELIM + name + ".1.ogg");


### PR DESCRIPTION
In order to make it feel officially supported, rename the `testsounds/` directory to `sounds/`.

This lets players replace sounds found on servers, which is good when a server plays annoying sounds (you can replace them with silence).
