### PR TITLE
Fix visual_scale for plantlike nodes

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1188,8 +1188,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				for (int i = 0; i < 4; i++)
 				{
 					vertices[i].Pos *= f.visual_scale;
-					if (f.visual_scale < 1)
-						vertices[i].Pos.Y -= BS/2 * (1 - f.visual_scale);
+					vertices[i].Pos.Y += BS/2 * (f.visual_scale - 1);
 					vertices[i].Pos += intToFloat(p, BS);
 				}
 


### PR DESCRIPTION
move the plant to the bottom of its node properly, without affecting its scale.  See isue #1989
