### PR TITLE
Make limiting of the reflow liquids queue size optional

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -99,10 +99,11 @@
 # Enable a bit lower water surface; disable for speed (not quite optimized)
 #new_style_water = false
 # Max liquids processed per step
-#liquid_loop_max = 10000
+#liquid_loop_max = 100000
 # The time (in seconds) that the liquids queue may grow beyond processing
-# capacity until an attempt is made to decrease its size by dumping old queue items
-#liquid_queue_purge_time = 30
+# capacity until an attempt is made to decrease its size by dumping old queue
+# items.  A value of 0 disables the functionality.
+#liquid_queue_purge_time = 0
 # Update liquids every .. recommend for finite: 0.2
 #liquid_update = 1.0
 # Enable nice leaves; disable for speed

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -276,8 +276,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("movement_gravity", "9.81");
 
 	//liquid stuff
-	settings->setDefault("liquid_loop_max", "10000");
-	settings->setDefault("liquid_queue_purge_time", "30");
+	settings->setDefault("liquid_loop_max", "100000");
+	settings->setDefault("liquid_queue_purge_time", "0");
 	settings->setDefault("liquid_update", "1.0");
 
 	//mapgen stuff


### PR DESCRIPTION
If liquid_queue_purge_time == 0 then disable the queue size limiting and make this the default setting
