### PR TITLE
Fix redundancy in a comment

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -166,7 +166,7 @@
 #sound_volume = 0.7
 # Whether node texture animations should be desynchronized per MapBlock
 #desynchronize_mapblock_texture_animation = true
-# (useful if you've there's something to be displayed right or left of hotbar)
+# (useful if there's something to be displayed right or left of hotbar)
 # Width of the selectionbox's lines (Between 1 and 5)
 #selectionbox_width = 2
 # maximum percentage of current window to be used for hotbar


### PR DESCRIPTION
Changed "Useful if you've there's something..." to "Useful if there's something..."
