### PR TITLE
Fixed issue #2007

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1859,6 +1859,10 @@ bool ClientLauncher::launch_game(std::wstring *error_message,
 	if (!skip_main_menu) {
 		main_menu(&menudata);
 
+		// Skip further loading if there was an exit signal.
+		if (*porting::signal_handler_killstatus())
+			return false;
+
 		address = menudata.address;
 		int newport = stoi(menudata.port);
 		if (newport != 0)


### PR DESCRIPTION
The function ClientLauncher::launch_game would try loading the game, even if there was an exit signal in the main menu. This should fix it.
