### PR TITLE
Mgv7: Remove mountain height limits, don't let mountains chop dungeons. All mapgens: generate dungeons throughout world and speed optimise

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -70,10 +70,7 @@ DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams) {
 
 void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax) {
 	//TimeTaker t("gen dungeons");
-	int approx_groundlevel = 10 + mg->water_level;
-
-	if ((nmin.Y + nmax.Y) / 2 >= approx_groundlevel ||
-		NoisePerlin3D(&dp.np_rarity, nmin.X, nmin.Y, nmin.Z, mg->seed) < 0.2)
+	if (NoisePerlin3D(&dp.np_rarity, nmin.X, nmin.Y, nmin.Z, mg->seed) < 0.2)
 		return;
 
 	this->blockseed = bseed;

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -252,7 +252,8 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	calculateNoise();
 
 	// Generate base terrain
-	generateBaseTerrain();
+	s16 stone_surface_max_y = generateBaseTerrain();
+
 	updateHeightmap(node_min, node_max);
 
 	// Generate underground dirt, sand, gravel and lava blobs
@@ -268,7 +269,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	generateBiomes();
 
 	// Generate dungeons and desert temples
-	if (flags & MG_DUNGEONS) {
+	if ((flags & MG_DUNGEONS) && (stone_surface_max_y >= node_min.Y)) {
 		DungeonGen dgen(this, NULL);
 		dgen.generate(blockseed, full_node_min, full_node_max);
 	}
@@ -342,10 +343,11 @@ void MapgenV5::calculateNoise()
 
 
 // Make base ground level
-void MapgenV5::generateBaseTerrain()
+int MapgenV5::generateBaseTerrain()
 {
 	u32 index = 0;
 	u32 index2d = 0;
+	int stone_surface_max_y = -MAP_GENERATION_LIMIT;
 
 	for(s16 z=node_min.Z; z<=node_max.Z; z++) {
 		for(s16 y=node_min.Y - 1; y<=node_max.Y + 1; y++) {
@@ -372,12 +374,16 @@ void MapgenV5::generateBaseTerrain()
 					vm->m_data[i] = MapNode(CONTENT_AIR);
 				} else {
 					vm->m_data[i] = MapNode(c_stone);
+					if (y > stone_surface_max_y)
+						stone_surface_max_y = y;
 				}
 			}
 			index2d = index2d - ystride;
 		}
 		index2d = index2d + ystride;
 	}
+
+	return stone_surface_max_y;
 }
 
 

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -94,7 +94,7 @@ public:
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
-	void generateBaseTerrain();
+	int generateBaseTerrain();
 	void generateBlobs();
 	void generateBiomes();
 	void dustTopNodes();

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -500,7 +500,7 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 	}
 
 	// Add dungeons
-	if (flags & MG_DUNGEONS) {
+	if ((flags & MG_DUNGEONS) && (stone_surface_max_y >= node_min.Y)) {
 		DungeonParams dp;
 
 		dp.np_rarity  = nparams_dungeon_rarity;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -350,7 +350,7 @@ float MapgenV7::baseTerrainLevelFromMap(int index)
 bool MapgenV7::getMountainTerrainAtPoint(int x, int y, int z)
 {
 	float mnt_h_n = NoisePerlin2D(&noise_mount_height->np, x, z, seed);
-	float height_modifier = -((float)y / rangelim(mnt_h_n, 80.0, 150.0));
+	float height_modifier = -((float)y / mnt_h_n);
 	float mnt_n = NoisePerlin3D(&noise_mountain->np, x, y, z, seed);
 
 	return mnt_n + height_modifier >= 0.6;
@@ -360,7 +360,7 @@ bool MapgenV7::getMountainTerrainAtPoint(int x, int y, int z)
 bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, int y)
 {
 	float mounthn = noise_mount_height->result[idx_xz];
-	float height_modifier = -((float)y / rangelim(mounthn, 80.0, 150.0));
+	float height_modifier = -((float)y / mounthn);
 	return (noise_mountain->result[idx_xyz] + height_modifier >= 0.6);
 }
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -241,7 +241,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y);
 
-	if (flags & MG_DUNGEONS) {
+	if ((flags & MG_DUNGEONS) && (stone_surface_max_y >= node_min.Y)) {
 		DungeonGen dgen(this, NULL);
 		dgen.generate(blockseed, full_node_min, full_node_max);
 	}
@@ -405,7 +405,7 @@ int MapgenV7::generateTerrain()
 	int ymax = generateBaseTerrain();
 
 	if (spflags & MGV7_MOUNTAINS)
-		generateMountainTerrain();
+		ymax = generateMountainTerrain(ymax);
 
 	if (spflags & MGV7_RIDGES)
 		generateRidgeTerrain();
@@ -453,10 +453,10 @@ int MapgenV7::generateBaseTerrain()
 }
 
 
-void MapgenV7::generateMountainTerrain()
+int MapgenV7::generateMountainTerrain(int ymax)
 {
 	if (node_max.Y <= water_level)
-		return;
+		return ymax;
 
 	MapNode n_stone(c_stone);
 	u32 j = 0;
@@ -466,14 +466,21 @@ void MapgenV7::generateMountainTerrain()
 		u32 vi = vm->m_area.index(node_min.X, y, z);
 		for (s16 x = node_min.X; x <= node_max.X; x++) {
 			int index = (z - node_min.Z) * csize.X + (x - node_min.X);
+			content_t c = vm->m_data[vi].getContent();
 
-			if (getMountainTerrainFromMap(j, index, y))
+			if (getMountainTerrainFromMap(j, index, y)
+					&& (c == CONTENT_AIR || c == c_water_source)) {
 				vm->m_data[vi] = n_stone;
+				if (y > ymax)
+					ymax = y;
+			}
 
 			vi++;
 			j++;
 		}
 	}
+
+	return ymax;
 }
 
 

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -107,7 +107,7 @@ public:
 
 	virtual int generateTerrain();
 	int generateBaseTerrain();
-	void generateMountainTerrain();
+	int generateMountainTerrain(int ymax);
 	void generateRidgeTerrain();
 
 	void generateBiomes();


### PR DESCRIPTION
![screenshot_2645831388](https://cloud.githubusercontent.com/assets/3686677/5584415/2aa2fc18-9084-11e4-9b58-96f3831e9d90.png)

Currently mgv7 mountain height noiseparams are range limited between 80 and 150, the first commit removes these limits to enable free modification through .conf.

Currently dungeons are only generated in and below surface mapchunks (the mapchunk containing sea level), because until recently terrain (mgv6) never extended above the surface chunk. The second commit enables dungeons throughout the world, in mountains and floatlands.
Also, checks for air or water are added to mgv7 mountain terrain generation to prevent dungeons being chopped at mapchunk borders.