### PR TITLE
Add non-global mod namespaces

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -154,6 +154,9 @@ registered callbacks.
 `minetest.setting_get(name)` and `minetest.setting_getbool(name)` can be used
 to read custom or existing settings at load time, if necessary.
 
+If your mod uses a namespace, this function should return it (see Mod
+Namespaces).
+
 ### `models`
 Models for entities or meshnodes.
 
@@ -1665,6 +1668,18 @@ Helper functions
 
 `minetest` namespace reference
 ------------------------------
+
+### Mod Namespaces
+
+Anything returned by a mod's `init.lua` is stored in the `minetest.mods`
+table, indexed by the mod name.  If a mod returns nothing (`nil`) a value of
+`true` will be stored instead.  Returning `false` indicates that the mod did
+not successfully complete loading, but there was no fatal error (for example,
+exiting because an `enable_mymod` setting is `false`).
+
+This is often useful for exposing an external API, or for storing an internal
+API where all parts of a large mod can access it.
+
 
 ### Utilities
 

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -46,8 +46,8 @@ public:
 	ScriptApiBase();
 	virtual ~ScriptApiBase();
 
-	bool loadMod(const std::string &scriptpath, const std::string &modname);
-	bool loadScript(const std::string &scriptpath);
+	bool loadMod(const std::string &script_path, const std::string &mod_name);
+	bool loadScript(const std::string &script_path, int nret=0);
 
 	/* object */
 	void addObjectReference(ServerActiveObject *cobj);


### PR DESCRIPTION
# Overview

This puts mod namespaces in `minetest.mods`.
A mod creates a namespace by returning a table.
This also adds a cleaner way to check for mod existence than `get_modpath`.
A mod can return `false` to indicate that it did not successfully complete loading, but the error is not critical.  (useful for, eg, the tnt mod's enabled check, where the mod runs but doesn't actually do anything).
# Example
### `foo` mod

``` Lua
local foo = {}

if minetest.setting_getbool("disable_foo") then
    return false
end

function foo.do()
    error("Foo doesn't do anything!")
end

return foo
```
### `bar` mod

``` Lua
local foo_mod = minetest.mods.foo
if foo_mod then
    print("Foo support enabled!")
    foo_mod.do()
end
```
## Big mods

Big mods use multiple Lua files and have to pass the namespace to other files.
You can do this with two different methods:
### init.lua

``` Lua
local m = {}  -- Mod namespace (m stands for module)
local mod_name = minetest.get_current_modname()

-- Method 1: Register mod namespace early
minetest.mods[mod_name] = m

local mod_path = minetest.get_modpath(mod_name)
local dirsep = package.config:match("^([^\n]+)")

-- Method 2: Pass namespace to files as an argument
loadfile(mod_path..dirsep.."other_file.lua")(m)
```
### other_file.lua

``` Lua
-- Method 1
local m = minetest.mods[minetest.get_current_modname()]

-- Method 2
local m = ...  -- Literal "..." expands to arguments passed to the file.

function m.foo()
    -- ...
end
```
