### PR TITLE
Fix off-by-one error in `string:split` implementation.

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -178,7 +178,7 @@ function string.split(str, delim, include_empty, max_splits, sep_is_pattern)
 			table_insert(items, s)
 		end
 		pos = npe + 1
-	until (max_splits == 0) or (pos > len)
+	until (max_splits == 0) or (pos > (len + 1))
 	return items
 end
 


### PR DESCRIPTION
http://irc.minetest.ru/minetest-dev/2015-01-04#i_4093192