### PR TITLE
Reorganizing client and settings tabs

### DIFF
--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -22,9 +22,9 @@ local function get_formspec(tabview, name, tabdata)
 	local retval =
 		"label[7.9,-0.15;" .. fgettext("Address / Port") .. "]" ..
 		"label[7.9,1.05;" .. fgettext("Name / Password") .. "]" ..
-		"field[8.1,0.75;3.35,0.5;te_address;;" ..
+		"field[8,0.75;3.4,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .. "]" ..
-		"field[11.3,0.75;1.15,0.5;te_port;;" ..
+		"field[11.25,0.75;1.3,0.5;te_port;;" ..
 		core.formspec_escape(core.setting_get("remote_port")) .. "]" ..
 		"checkbox[0,4.85;cb_public_serverlist;" .. fgettext("Public Serverlist") .. ";" ..
 		dump(core.setting_getbool("public_serverlist")) .. "]"
@@ -36,9 +36,9 @@ local function get_formspec(tabview, name, tabdata)
 
 	retval = retval ..
 		"button[10,4.9;2,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]" ..
-		"field[8.1,1.95;2.89,0.5;te_name;;" ..
+		"field[8,1.95;2.95,0.5;te_name;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..
-		"pwdfield[10.85,1.95;1.6,0.5;te_pwd;]" ..
+		"pwdfield[10.78,1.95;1.77,0.5;te_pwd;]" ..
 		"box[7.8,2.35;4.16,2.28;#999999]" ..
 		"textarea[8.15,2.4;4.25,2.6;;"
 		

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -20,26 +20,29 @@ local function get_formspec(tabview, name, tabdata)
 	local render_details = core.is_yes(core.setting_getbool("public_serverlist"))
 	
 	local retval =
-		"label[0,4.25;" .. fgettext("Address/Port") .. "]" ..
-		"label[9,2.75;" .. fgettext("Name/Password") .. "]" ..
-		"field[0.25,5.25;5.5,0.5;te_address;;" ..
+		"label[8,0;" .. fgettext("Address / Port") .. "]" ..
+		"label[8,1.35;" .. fgettext("Name / Password") .. "]" ..
+		"field[8.25,1;3.15,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .. "]" ..
-		"field[5.75,5.25;2.25,0.5;te_port;;" ..
+		"field[11.25,1;1.15,0.5;te_port;;" ..
 		core.formspec_escape(core.setting_get("remote_port")) .. "]" ..
-		"checkbox[0,3.6;cb_public_serverlist;" .. fgettext("Public Serverlist") .. ";" ..
-		dump(core.setting_getbool("public_serverlist")) .. "]"
+		"checkbox[0,4.85;cb_public_serverlist;" .. fgettext("Public Serverlist") .. ";" ..
+		dump(core.setting_getbool("public_serverlist")) .. "]" ..
+		"checkbox[2.85,4.85;cb_map_saving;" .. fgettext("Local Map Saving") .. ";" ..
+		dump(core.setting_getbool("enable_local_map_saving")) .. "]"
 
 	if not core.setting_getbool("public_serverlist") then
 		retval = retval ..
-		"button[6.45,3.95;2.25,0.5;btn_delete_favorite;" .. fgettext("Delete") .. "]"
+		"button[8,4.9;2,0.5;btn_delete_favorite;" .. fgettext("Delete") .. "]"
 	end
 
 	retval = retval ..
-		"button[9,4.95;2.5,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]" ..
-		"field[9.3,3.75;2.5,0.5;te_name;;" ..
+		"button[10,4.9;2,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]" ..
+		"field[8.25,2.35;2.65,0.5;te_name;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..
-		"pwdfield[9.3,4.5;2.5,0.5;te_pwd;]" ..
-		"textarea[9.3,0;2.5,3.1;;"
+		"pwdfield[10.75,2.35;1.65,0.5;te_pwd;]" ..
+		"box[7.95,2.75;4,1.8;#999999]" ..
+		"textarea[8.35,2.75;4,3.1;;"
 		
 	if tabdata.fav_selected ~= nil and
 		menudata.favorites[tabdata.fav_selected] ~= nil and
@@ -66,7 +69,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "tablecolumns[text]"
 	end
 	retval = retval ..
-		"table[0,0;8.5,3.7;favourites;"
+		"table[0,0;7.75,4.9;favourites;"
 
 	if #menudata.favorites > 0 then
 		retval = retval .. render_favorite(menudata.favorites[1],render_details)
@@ -91,6 +94,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields["te_name"] ~= nil then
 		gamedata.playername = fields["te_name"]
 		core.setting_set("name", fields["te_name"])
+	end
+	
+	if fields["cb_map_saving"] then
+	core.setting_set("enable_local_map_saving", fields["cb_map_saving"])
+		return true
 	end
 
 	if fields["favourites"] ~= nil then

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -20,16 +20,14 @@ local function get_formspec(tabview, name, tabdata)
 	local render_details = core.is_yes(core.setting_getbool("public_serverlist"))
 	
 	local retval =
-		"label[8,0;" .. fgettext("Address / Port") .. "]" ..
-		"label[8,1.35;" .. fgettext("Name / Password") .. "]" ..
-		"field[8.25,1;3.15,0.5;te_address;;" ..
+		"label[7.9,-0.15;" .. fgettext("Address / Port") .. "]" ..
+		"label[7.9,1.05;" .. fgettext("Name / Password") .. "]" ..
+		"field[8.1,0.75;3.35,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .. "]" ..
-		"field[11.25,1;1.15,0.5;te_port;;" ..
+		"field[11.3,0.75;1.15,0.5;te_port;;" ..
 		core.formspec_escape(core.setting_get("remote_port")) .. "]" ..
 		"checkbox[0,4.85;cb_public_serverlist;" .. fgettext("Public Serverlist") .. ";" ..
-		dump(core.setting_getbool("public_serverlist")) .. "]" ..
-		"checkbox[2.85,4.85;cb_map_saving;" .. fgettext("Local Map Saving") .. ";" ..
-		dump(core.setting_getbool("enable_local_map_saving")) .. "]"
+		dump(core.setting_getbool("public_serverlist")) .. "]"
 
 	if not core.setting_getbool("public_serverlist") then
 		retval = retval ..
@@ -38,11 +36,11 @@ local function get_formspec(tabview, name, tabdata)
 
 	retval = retval ..
 		"button[10,4.9;2,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]" ..
-		"field[8.25,2.35;2.65,0.5;te_name;;" ..
+		"field[8.1,1.95;2.89,0.5;te_name;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..
-		"pwdfield[10.75,2.35;1.65,0.5;te_pwd;]" ..
-		"box[7.95,2.75;4,1.8;#999999]" ..
-		"textarea[8.35,2.75;4,3.1;;"
+		"pwdfield[10.85,1.95;1.6,0.5;te_pwd;]" ..
+		"box[7.8,2.35;4.16,2.28;#999999]" ..
+		"textarea[8.15,2.4;4.25,2.6;;"
 		
 	if tabdata.fav_selected ~= nil and
 		menudata.favorites[tabdata.fav_selected] ~= nil and
@@ -69,7 +67,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "tablecolumns[text]"
 	end
 	retval = retval ..
-		"table[0,0;7.75,4.9;favourites;"
+		"table[-0.1,-0.1;7.75,5;favourites;"
 
 	if #menudata.favorites > 0 then
 		retval = retval .. render_favorite(menudata.favorites[1],render_details)
@@ -94,11 +92,6 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields["te_name"] ~= nil then
 		gamedata.playername = fields["te_name"]
 		core.setting_set("name", fields["te_name"])
-	end
-	
-	if fields["cb_map_saving"] then
-	core.setting_set("enable_local_map_saving", fields["cb_map_saving"])
-		return true
 	end
 
 	if fields["favourites"] ~= nil then

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -20,8 +20,8 @@ local function get_formspec(tabview, name, tabdata)
 	local render_details = core.is_yes(core.setting_getbool("public_serverlist"))
 	
 	local retval =
-		"label[7.9,-0.15;" .. fgettext("Address / Port") .. "]" ..
-		"label[7.9,1.05;" .. fgettext("Name / Password") .. "]" ..
+		"label[7.75,-0.15;" .. fgettext("Address / Port :") .. "]" ..
+		"label[7.75,1.05;" .. fgettext("Name / Password :") .. "]" ..
 		"field[8,0.75;3.4,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .. "]" ..
 		"field[11.25,0.75;1.3,0.5;te_port;;" ..

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -128,6 +128,36 @@ local function formspec(tabview, name, tabdata)
 		end
 	end
 
+local filters = {
+    {"No Filter,Bilinear Filter,Trilinear Filter"}, 
+    {"", "bilinear_filter", "trilinear_filter"},
+}
+
+local mipmap = {
+    {"No Mipmap,Mipmap,Mipmap + Aniso. Filter"},
+    {"", "mip_map", "anisotropic_filter"},
+}
+
+local function getFilterSettingIndex()
+     if (core.setting_get(filters[2][3]) == "true") then
+        return 3
+     end
+     if (core.setting_get(filters[2][3]) == "false" and core.setting_get(filters[2][2]) == "true") then
+        return 2
+     end
+     return 1
+end	
+
+local function getMipmapSettingIndex()
+     if (core.setting_get(mipmap[2][3]) == "true") then
+        return 3
+     end
+     if (core.setting_get(mipmap[2][3]) == "false" and core.setting_get(mipmap[2][2]) == "true") then
+        return 2
+     end
+     return 1
+end
+
 	local tab_string =
 		"box[0,0;3.5,3.9;#999999]" ..
 		"checkbox[0.25,0;cb_smooth_lighting;".. fgettext("Smooth Lighting")
@@ -144,60 +174,18 @@ local function formspec(tabview, name, tabdata)
 				.. dump(core.setting_getbool("connected_glass"))	.. "]"..
 		"checkbox[0.25,3.0;cb_node_highlighting;".. fgettext("Node Highlighting") .. ";"
 				.. dump(core.setting_getbool("enable_node_highlighting")) .. "]"..
-		"box[3.75,0;3.75,2.9;#999999]" ..
-		"dropdown[3.86,2;3.75;dd_video_driver;"
+		"box[3.75,0;3.75,3.45;#999999]" ..
+		"label[3.85,0.1;".. fgettext("Texturing:") .. "]"..
+		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";" .. getFilterSettingIndex() .. "]" ..		
+	    "dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";" .. getMipmapSettingIndex() .. "]" ..
+	    "label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
+	    "dropdown[3.85,2.6;3.85;dd_video_driver;"
 			    .. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
 			fgettext("Restart minetest for driver change to take effect") .. "]" ..
 		"box[7.75,0;4,4;#999999]" ..
 		"checkbox[8,0;cb_shaders;".. fgettext("Shaders") .. ";"
 				.. dump(core.setting_getbool("enable_shaders")) .. "]"
-						
-local filters = {
-    {"No Filter", ""},
-    {"Bilinear Filter", "bilinear_filter"},
-    {"Trilinear Filter", "trilinear_filter"},
-}
-
-local function getFilterSettingIndex()
-     for i in ipairs(filters) do
-         if i > 1 then
-             if core.setting_getbool(filters[i][2]) then
-                 return i
-             end
-         end
-     end
-     return 1
-end
-
-for i in ipairs(filters) do
-  tab_string = tab_string ..		
-	    "dropdown[3.86,0.2;3.75;dd_filters;" .. filters[1][1] .. "," .. filters[2][1] .. "," .. filters[3][1]
-	      .. ";" .. getFilterSettingIndex() .. "]"
-end
-
-local mipmap = {
-    {"No Mipmap", ""},
-    {"Mipmap", "mip_map"},
-    {"Mipmap + Aniso. Filter", "anisotropic_filter"},
-}
-
-local function getMipmapSettingIndex()
-     for i in ipairs(mipmap) do
-         if i > 1 then
-             if core.setting_getbool(mipmap[i][2]) then
-                 return i
-             end
-         end
-     end
-     return 1
-end
-
-for i in ipairs(mipmap) do
-  tab_string = tab_string ..		
-	    "dropdown[3.86,1.12;3.75;dd_mipmap;" .. mipmap[1][1] .. "," .. mipmap[2][1] .. "," .. mipmap[3][1]
-	      .. ";" .. getMipmapSettingIndex() .. "]"
-end
 	 		
 	if PLATFORM ~= "Android" then
 		tab_string = tab_string ..
@@ -217,15 +205,15 @@ end
 
 	if PLATFORM == "Android" then
 		tab_string = tab_string ..
-		"box[3.75,3;3.75,2;#999999]" ..
-		"checkbox[3.9,2.95;cb_touchscreen_target;".. fgettext("Touch free target") .. ";"
+		"box[3.75,3.55;3.75,1.8;#999999]" ..
+		"checkbox[3.9,3.45;cb_touchscreen_target;".. fgettext("Touch free target") .. ";"
 				.. dump(core.setting_getbool("touchtarget")) .. "]"
 	end
 
 	if core.setting_get("touchscreen_threshold") ~= nil then
 		tab_string = tab_string ..
-				"label[4.3,3.7;" .. fgettext("Touchthreshold (px)") .. "]" ..
-				"dropdown[3.86,4.2;3.75;dd_touchthreshold;0,10,20,30,40,50;" ..
+				"label[4.3,4.1;" .. fgettext("Touchthreshold (px)") .. "]" ..
+				"dropdown[3.85,4.55;3.85;dd_touchthreshold;0,10,20,30,40,50;" ..
 				((tonumber(core.setting_get("touchscreen_threshold"))/10)+1) .. "]"
 	end
 
@@ -340,18 +328,6 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 
 	--Note dropdowns have to be handled LAST!
 	local ddhandled = false
-	
-	local filters = {
-    {"No Filter", ""},
-    {"Bilinear Filter", "bilinear_filter"},
-    {"Trilinear Filter", "trilinear_filter"},
-    }
-    
-    local mipmap = {
-    {"No Mipmap", ""},
-    {"Mipmap", "mip_map"},
-    {"Mipmap + Aniso. Filter", "anisotropic_filter"},
-    }
 
 	if fields["dd_touchthreshold"] then
 		core.setting_set("touchscreen_threshold",fields["dd_touchthreshold"])
@@ -362,31 +338,29 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		core.setting_set("video_driver",string.lower(video_driver))
 		ddhandled = true
 	end
-	
-    if fields["dd_filters"] == filters[1][1] then
-      core.setting_set(filters[2][2], "false")
-      core.setting_set(filters[3][2], "false")
+	if fields["dd_filters"] == "No Filter" then
+      core.setting_set("bilinear_filter", "false")
+      core.setting_set("trilinear_filter", "false")
     end
-    if fields["dd_filters"] == filters[2][1] then
-      core.setting_set(filters[2][2], "true")
-      core.setting_set(filters[3][2], "false")
+    if fields["dd_filters"] == "Bilinear Filter" then
+      core.setting_set("bilinear_filter", "true")
+      core.setting_set("trilinear_filter", "false")
     end
-    if fields["dd_filters"] == filters[3][1] then
-      core.setting_set(filters[2][2], "false")
-      core.setting_set(filters[3][2], "true")
+    if fields["dd_filters"] == "Trilinear Filter" then
+      core.setting_set("bilinear_filter", "false")
+      core.setting_set("trilinear_filter", "true")
     end
-    
-    if fields["dd_mipmap"] == mipmap[1][1] then
-      core.setting_set(mipmap[2][2], "false")
-      core.setting_set(mipmap[3][2], "false")
+    if fields["dd_mipmap"] == "No Mipmap" then
+      core.setting_set("mip_map", "false")
+      core.setting_set("anisotropic_filter", "false")
     end
-    if fields["dd_mipmap"] == mipmap[2][1] then
-      core.setting_set(mipmap[2][2], "true")
-      core.setting_set(mipmap[3][2], "false")
+    if fields["dd_mipmap"] == "Mipmap" then
+      core.setting_set("mip_map", "true")
+      core.setting_set("anisotropic_filter", "false")
     end
-    if fields["dd_mipmap"] == mipmap[3][1] then
-      core.setting_set(mipmap[2][2], "true")
-      core.setting_set(mipmap[3][2], "true")
+    if fields["dd_mipmap"] == "Mipmap + Aniso. Filter" then
+      core.setting_set("mip_map", "true")
+      core.setting_set("anisotropic_filter", "true")
     end
 
 	return ddhandled

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -176,13 +176,15 @@ end
 				.. dump(core.setting_getbool("enable_node_highlighting")) .. "]"..
 		"box[3.75,0;3.75,3.45;#999999]" ..
 		"label[3.85,0.1;".. fgettext("Texturing:") .. "]"..
-		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";" .. getFilterSettingIndex() .. "]" ..		
-		"dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";" .. getMipmapSettingIndex() .. "]" ..
+		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";"
+				.. getFilterSettingIndex() .. "]" ..
+		"dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";"
+				.. getMipmapSettingIndex() .. "]" ..
 		"label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
 		"dropdown[3.85,2.6;3.85;dd_video_driver;"
-			    .. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
+				.. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
-			fgettext("Restart minetest for driver change to take effect") .. "]" ..
+				fgettext("Restart minetest for driver change to take effect") .. "]" ..
 		"box[7.75,0;4,4;#999999]" ..
 		"checkbox[8,0;cb_shaders;".. fgettext("Shaders") .. ";"
 				.. dump(core.setting_getbool("enable_shaders")) .. "]"
@@ -339,29 +341,29 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		ddhandled = true
 	end
 	if fields["dd_filters"] == "No Filter" then
-      core.setting_set("bilinear_filter", "false")
-      core.setting_set("trilinear_filter", "false")
-    end
-    if fields["dd_filters"] == "Bilinear Filter" then
-      core.setting_set("bilinear_filter", "true")
-      core.setting_set("trilinear_filter", "false")
-    end
-    if fields["dd_filters"] == "Trilinear Filter" then
-      core.setting_set("bilinear_filter", "false")
-      core.setting_set("trilinear_filter", "true")
-    end
-    if fields["dd_mipmap"] == "No Mipmap" then
-      core.setting_set("mip_map", "false")
-      core.setting_set("anisotropic_filter", "false")
-    end
-    if fields["dd_mipmap"] == "Mipmap" then
-      core.setting_set("mip_map", "true")
-      core.setting_set("anisotropic_filter", "false")
-    end
-    if fields["dd_mipmap"] == "Mipmap + Aniso. Filter" then
-      core.setting_set("mip_map", "true")
-      core.setting_set("anisotropic_filter", "true")
-    end
+		core.setting_set("bilinear_filter", "false")
+		core.setting_set("trilinear_filter", "false")
+	end
+	if fields["dd_filters"] == "Bilinear Filter" then
+		core.setting_set("bilinear_filter", "true")
+		core.setting_set("trilinear_filter", "false")
+	end
+	if fields["dd_filters"] == "Trilinear Filter" then
+		core.setting_set("bilinear_filter", "false")
+		core.setting_set("trilinear_filter", "true")
+	end
+	if fields["dd_mipmap"] == "No Mipmap" then
+		core.setting_set("mip_map", "false")
+		core.setting_set("anisotropic_filter", "false")
+	end
+	if fields["dd_mipmap"] == "Mipmap" then
+		core.setting_set("mip_map", "true")
+		core.setting_set("anisotropic_filter", "false")
+	end
+	if fields["dd_mipmap"] == "Mipmap + Aniso. Filter" then
+		core.setting_set("mip_map", "true")
+		core.setting_set("anisotropic_filter", "true")
+	end
 
 	return ddhandled
 end

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -177,9 +177,9 @@ end
 		"box[3.75,0;3.75,3.45;#999999]" ..
 		"label[3.85,0.1;".. fgettext("Texturing:") .. "]"..
 		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";" .. getFilterSettingIndex() .. "]" ..		
-	    "dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";" .. getMipmapSettingIndex() .. "]" ..
-	    "label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
-	    "dropdown[3.85,2.6;3.85;dd_video_driver;"
+		"dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";" .. getMipmapSettingIndex() .. "]" ..
+		"label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
+		"dropdown[3.85,2.6;3.85;dd_video_driver;"
 			    .. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
 			fgettext("Restart minetest for driver change to take effect") .. "]" ..

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -130,7 +130,7 @@ local function formspec(tabview, name, tabdata)
 	
 	
 	local tab_string =
-		"box[0,0;3.5,4;#999999]" ..
+		"box[0,0;3.5,3.9;#999999]" ..
 		"checkbox[0.25,0;cb_smooth_lighting;".. fgettext("Smooth Lighting")
 				.. ";".. dump(core.setting_getbool("smooth_lighting")) .. "]"..
 		"checkbox[0.25,0.5;cb_particles;".. fgettext("Enable Particles") .. ";"
@@ -143,11 +143,9 @@ local function formspec(tabview, name, tabdata)
 				.. dump(core.setting_getbool("opaque_water")) .. "]"..
 		"checkbox[0.25,2.5;cb_connected_glass;".. fgettext("Connected Glass") .. ";"
 				.. dump(core.setting_getbool("connected_glass"))	.. "]"..
-		"dropdown[0.25,3.25;3.25;dd_video_driver;"
-			.. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
-		"tooltip[dd_video_driver;" ..
-			fgettext("Restart minetest for driver change to take effect") .. "]" ..
-		"box[3.75,0;3.75,2.5;#999999]" ..
+		"checkbox[0.25,3.0;cb_node_highlighting;".. fgettext("Node Highlighting") .. ";"
+				.. dump(core.setting_getbool("enable_node_highlighting")) .. "]"..
+		"box[3.75,0;3.75,3.35;#999999]" ..
 		"checkbox[4,0;cb_mipmapping;".. fgettext("Mip-Mapping") .. ";"
 				.. dump(core.setting_getbool("mip_map")) .. "]"..
 		"checkbox[4,0.5;cb_anisotrophic;".. fgettext("Anisotropic Filtering") .. ";"
@@ -156,6 +154,10 @@ local function formspec(tabview, name, tabdata)
 				.. dump(core.setting_getbool("bilinear_filter")) .. "]"..
 		"checkbox[4,1.5;cb_trilinear;".. fgettext("Tri-Linear Filtering") .. ";"
 				.. dump(core.setting_getbool("trilinear_filter")) .. "]"..
+		"dropdown[4.2,2.4;3;dd_video_driver;"
+			    .. video_driver_string .. ";" .. current_video_driver_idx .. "]" ..
+		"tooltip[dd_video_driver;" ..
+			fgettext("Restart minetest for driver change to take effect") .. "]" ..
 		"box[7.75,0;4,4;#999999]" ..
 		"checkbox[8,0;cb_shaders;".. fgettext("Shaders") .. ";"
 				.. dump(core.setting_getbool("enable_shaders")) .. "]"
@@ -167,7 +169,7 @@ local function formspec(tabview, name, tabdata)
 		"button[8,4.75;3.75,0.5;btn_reset_singleplayer;".. fgettext("Reset singleplayer world") .. "]"
 	end
 	tab_string = tab_string ..
-		"box[0,4.25;3.5,1.25;#999999]" ..
+		"box[0,4.25;3.5,1.1;#999999]" ..
 		"label[0.25,4.25;" .. fgettext("GUI scale factor") .. "]" ..
 		"scrollbar[0.25,4.75;3,0.4;sb_gui_scaling;horizontal;" ..
 		 gui_scale_to_scrollbar() .. "]" ..
@@ -260,6 +262,10 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 	if fields["cb_connected_glass"] then
 		core.setting_set("connected_glass", fields["cb_connected_glass"])
+		return true
+	end
+	if fields["cb_node_highlighting"] then
+		core.setting_set("enable_node_highlighting", fields["cb_node_highlighting"])
 		return true
 	end
 	if fields["cb_particles"] then


### PR DESCRIPTION
Client tab : 
- Various moving/scaling for enhance the ergonomy.

Settings tab : 
- Added the "Node Highlighting" option.
- Added 2 dropdown lists for filters and mipmapping.
- Moved the dropdown drivers list for offset the middle column.
- Moved the Android part downward.

Tested and perfectly functional. Screenshots here : https://mediacru.sh/785348121907 (EDIT : settings tab screenshot outdated, see below).
