### PR TITLE
Fixes for android

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -20,6 +20,8 @@ PATHCFGFILE = path.cfg
 
 ROOT = $(shell pwd)
 
+GAMES_TO_COPY = minetest_game
+
 ################################################################################
 # Android Version code
 # Increase for each build!
@@ -631,15 +633,23 @@ assets : $(ASSETS_TIMESTAMP)
 	cp -r ${ROOT}/../../client ${ROOT}/assets/Minetest;                        \
 	cp -r ${ROOT}/../../doc ${ROOT}/assets/Minetest;                           \
 	cp -r ${ROOT}/../../fonts ${ROOT}/assets/Minetest;                         \
-	cp -r ${ROOT}/../../games ${ROOT}/assets/Minetest;                         \
+	mkdir ${ROOT}/assets/Minetest/games;                                       \
+	for game in ${GAMES_TO_COPY};                                              \
+	do                                                                         \
+	    cp -r ${ROOT}/../../games/$$game ${ROOT}/assets/Minetest/games/;       \
+	done;                                                                      \
 	cp -r ${ROOT}/../../mods ${ROOT}/assets/Minetest;                          \
 	cp -r ${ROOT}/../../po ${ROOT}/assets/Minetest;                            \
 	cp -r ${ROOT}/../../textures ${ROOT}/assets/Minetest;                      \
 	mkdir -p ${ROOT}/assets/Minetest/media;                                    \
 	cp -r ${IRRLICHT_DIR}/media/Shaders ${ROOT}/assets/Minetest/media;         \
-	cd ${ROOT}/assets;                                                         \
+	cd ${ROOT}/assets ||  exit 1;                                              \
 	find . -name "timestamp" -exec rm {} \; ;                                  \
 	find . -name "*.blend" -exec rm {} \; ;                                    \
+	find . -name "*~" -exec rm {} \; ;                                         \
+	find . -type d -path "*.git" -exec rm -rf {} \; ;                          \
+	find . -type d -path "*.svn" -exec rm -rf {} \; ;                          \
+	find . -type f -path "*.gitignore" -exec rm -rf {} \; ;                    \
 	ls -R | grep ":$$" | sed -e 's/:$$//' -e 's/\.//' -e 's/^\///' > "index.txt"; \
 	find Minetest >"filelist.txt";                                             \
 	cp ${ROOT}/${ASSETS_TIMESTAMP} ${ROOT}/${ASSETS_TIMESTAMP}.old;            \

--- a/build/android/src/org/minetest/minetest/MinetestAssetCopy.java
+++ b/build/android/src/org/minetest/minetest/MinetestAssetCopy.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Vector;
 import java.util.Iterator;
+import java.lang.Object;
 
 import android.app.Activity;
 import android.content.res.AssetFileDescriptor;
@@ -20,6 +21,9 @@ import android.util.Log;
 import android.view.Display;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.graphics.Rect;
+import android.graphics.Paint;
+import android.text.TextPaint;
 
 public class MinetestAssetCopy extends Activity
 {
@@ -244,14 +248,62 @@ public class MinetestAssetCopy extends Activity
 		 */
 		protected void onProgressUpdate(Integer... progress)
 		{
+			
 			if (m_copy_started)
 			{
+				boolean shortened = false;
+				String todisplay = m_tocopy.get(progress[0]);
 				m_ProgressBar.setProgress(progress[0]);
-				m_Filename.setText(m_tocopy.get(progress[0]));
+				
+				// make sure our text doesn't exceed our layout width
+				Rect bounds = new Rect();
+				Paint textPaint = m_Filename.getPaint();
+				textPaint.getTextBounds(todisplay, 0, todisplay.length(), bounds);
+				
+				while (bounds.width() > getResources().getDisplayMetrics().widthPixels * 0.7) {
+					Log.e("MinetestAssetCopy", todisplay + ": " +
+							bounds.width() + " > " + (getResources().getDisplayMetrics().widthPixels * 0.7));
+					if (todisplay.length() < 2) {
+						break;
+					}
+					todisplay = todisplay.substring(1);
+					textPaint.getTextBounds(todisplay, 0, todisplay.length(), bounds);
+					shortened = true;
+				}
+				
+				if (! shortened) {
+					m_Filename.setText(todisplay);
+				}
+				else {
+					m_Filename.setText(".." + todisplay);
+				}
 			}
 			else
 			{
-				m_Filename.setText("scanning " + m_Foldername + " ...");
+				boolean shortened = false;
+				String todisplay = m_Foldername;
+				String full_text = "scanning " + todisplay + " ...";
+				// make sure our text doesn't exceed our layout width
+				Rect bounds = new Rect();
+				Paint textPaint = m_Filename.getPaint();
+				textPaint.getTextBounds(full_text, 0, full_text.length(), bounds);
+				
+				while (bounds.width() > getResources().getDisplayMetrics().widthPixels * 0.7) {
+					if (todisplay.length() < 2) {
+						break;
+					}
+					todisplay = todisplay.substring(1);
+					full_text = "scanning " + todisplay + " ...";
+					textPaint.getTextBounds(full_text, 0, full_text.length(), bounds);
+					shortened = true;
+				}
+				
+				if (! shortened) {
+					m_Filename.setText(full_text);
+				}
+				else {
+					m_Filename.setText("scanning .." + todisplay + " ...");
+				}
 			}
 		}
 		

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -76,21 +76,6 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 
 static gui::IGUIFont *select_font_by_line_height(double target_line_height)
 {
-	return g_fontengine->getFont();
-
-/* I have no idea what this is trying to achieve, but scaling the font according
- * to the size of a formspec/dialog does not seem to be a standard (G)UI
- * design and AFAIK no existing nor proposed GUI does this. Besides that it:
- * a) breaks most (current) formspec layouts
- * b) font sizes change depending on the size of the formspec/dialog (see above)
- *    meaning that there is no UI consistency
- * c) the chosen fonts are, in general, probably too large
- *
- * Disabling for now.
- *
- * FIXME
- */
-#if 0
 	// We don't get to directly select a font according to its
 	// baseline-to-baseline height.  Rather, we select by em size.
 	// The ratio between these varies between fonts.  The font
@@ -120,7 +105,6 @@ static gui::IGUIFont *select_font_by_line_height(double target_line_height)
 		}
 	}
 	return g_fontengine->getFont(target_line_height - lohgt < hihgt - target_line_height ? loreq : hireq);
-#endif
 }
 
 GUIFormSpecMenu::GUIFormSpecMenu(irr::IrrlichtDevice* dev,

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -29,6 +29,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include "config.h"
 
+#ifdef __ANDROID__
+unsigned int android_log_level_mapping[] {
+		/* LMT_ERROR */   ANDROID_LOG_ERROR,
+		/* LMT_ACTION */  ANDROID_LOG_WARN,
+		/* LMT_INFO */    ANDROID_LOG_INFO,
+		/* LMT_VERBOSE */ ANDROID_LOG_VERBOSE
+	};
+#endif
+
 std::list<ILogOutput*> log_outputs[LMT_NUM_VALUES];
 std::map<threadid_t, std::string> log_threadnames;
 JMutex                            log_threadnamemutex;
@@ -160,7 +169,7 @@ public:
 	{
 		log_printline(m_lev, m_buf);
 #ifdef __ANDROID__
-		__android_log_print(ANDROID_LOG_ERROR, PROJECT_NAME, "%s", m_buf.c_str());
+		__android_log_print(android_log_level_mapping[m_lev], PROJECT_NAME, "%s", m_buf.c_str());
 #endif
 	}
 

--- a/src/touchscreengui.cpp
+++ b/src/touchscreengui.cpp
@@ -683,6 +683,10 @@ void TouchScreenGUI::step(float dtime)
 		if (btn->ids.size() > 0) {
 			btn->repeatcounter += dtime;
 
+			/* in case we're moving around digging does not happen */
+			if (m_move_id != -1)
+				m_move_has_really_moved = true;
+
 			if (btn->repeatcounter < 0.2) continue;
 
 			btn->repeatcounter              = 0;


### PR DESCRIPTION
Copy only minetest_game to apk by default
Don't copy .git and .svn folders to apk
Fix bouncing asset copy scrollbar due to long filepaths
Reenable font scaling to fix broken menu on high dpi screens
Implement minetest loglevel to android loglevel mapping
Disable touch digging while moving around