### PR TITLE
Remove last installed mods name concatenation

### DIFF
--- a/builtin/mainmenu/store.lua
+++ b/builtin/mainmenu/store.lua
@@ -122,9 +122,7 @@ end
 function modstore.showdownloading(title)
 	local new_dlg = dialog_create("store_downloading",
 		function(data)
-			return "size[6,2]label[0.25,0.75;" .. fgettext("Downloading") ..
-				" " .. data.title .. " " ..
-				fgettext("please wait...") .. "]"
+			return "size[6,2]label[0.25,0.75;" .. fgettext("Downloading $1, please wait...", data.title) .. "]"
 		end,
 		function(this,fields)
 			if fields["btn_hidden_close_download"] ~= nil then
@@ -180,7 +178,7 @@ function modstore.successfulldialog()
 		nil,
 		modstore.tv_store)
 
-	new_dlg.data.title = title
+	new_dlg.data.title = modstore.lastmodtitle
 	new_dlg:show()
 end
 
@@ -229,11 +227,7 @@ function modstore.handle_buttons(parent, fields, name, data)
 				if modstore.modlist_unsorted.data[i].id == modid then
 					local moddetails = modstore.modlist_unsorted.data[i].details
 
-					if modstore.lastmodtitle ~= "" then
-						modstore.lastmodtitle = modstore.lastmodtitle .. ", "
-					end
-
-					modstore.lastmodtitle = modstore.lastmodtitle .. moddetails.title
+					modstore.lastmodtitle = moddetails.title
 
 					if not core.handle_async(
 						function(param)


### PR DESCRIPTION
Hello,
I think that the dialog showing "installing ... please wait" doesn't have to show all mods installed in current modstore instance but only the actual one.
Old first:
![minetest1](https://cloud.githubusercontent.com/assets/6003171/5631524/a51363f0-95c7-11e4-86d8-bd81084963f0.png)
Old second:
![minetest2](https://cloud.githubusercontent.com/assets/6003171/5631526/a518958c-95c7-11e4-9e6c-ffb767c5913a.png)
New (no old mods anymore, only currently installing mod):
![minetest3](https://cloud.githubusercontent.com/assets/6003171/5631525/a51798bc-95c7-11e4-92ac-f410b778474e.png)


