### PR TITLE
Return step smoothing value to 23

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -270,7 +270,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	{
 		f32 oldy = old_player_position.Y;
 		f32 newy = player_position.Y;
-		f32 t = exp(-10*frametime);
+		f32 t = exp(-23*frametime);
 		player_position.Y = oldy * t + newy * (1-t);
 	}
 


### PR DESCRIPTION
Reverts this commit https://github.com/minetest/minetest/commit/1c9f05d792562374046e74ad3eb75988d529b15c
Step smoothing is currently extremely mushy and sluggish.
Try building a wall immediately beside a single step, face the wall and tap the A or D key to walk very slowly sideways up the step to see the camera rise time clearly. The camera rise time has changed from roughly 1/5th second to over 1 second. Now consider that with 1:1 steps the player climbs a step 8 times a second, the camera cannot even remotely keep up and therefore sinks significantly down towards a long set of steps.
I tested the old and new values on a long 1:1 set of steps.
The responsive 'spring' of a player jump is also lost.
There was nothing wrong with the old value which has been used since June 2012 and  was probably carefully tuned. Smoothing should be subtle, only just enough to take the uncomfortable sharpness out of a camera rise, it should feel agile and responsive.
Celeron55's comment http://irc.minetest.ru/minetest-dev/2015-01-05#i_4095451
VanessaE's comment http://irc.minetest.ru/minetest-dev/2015-01-05#i_4095264