### PR TITLE
Disable font scaling on non-Android platforms

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -76,6 +76,9 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 
 static gui::IGUIFont *select_font_by_line_height(double target_line_height)
 {
+#ifndef __ANDROID__
+	return g_fontengine->getFont();
+#else
 	// We don't get to directly select a font according to its
 	// baseline-to-baseline height.  Rather, we select by em size.
 	// The ratio between these varies between fonts.  The font
@@ -105,6 +108,7 @@ static gui::IGUIFont *select_font_by_line_height(double target_line_height)
 		}
 	}
 	return g_fontengine->getFont(target_line_height - lohgt < hihgt - target_line_height ? loreq : hireq);
+#endif
 }
 
 GUIFormSpecMenu::GUIFormSpecMenu(irr::IrrlichtDevice* dev,


### PR DESCRIPTION
I think Zeno- puts it best here:

"I have no idea what this is trying to achieve, but scaling the font according
to the size of a formspec/dialog does not seem to be a standard (G)UI
design and AFAIK no existing nor proposed GUI does this. Besides that it:
a) breaks most (current) formspec layouts
b) font sizes change depending on the size of the formspec/dialog (see above)
meaning that there is no UI consistency
c) the chosen fonts are, in general, probably too large"

So, since font scaling is apparently only needed on Android, why is it on all the time? This change turns it off everywhere except there, which would fix bug #2077, while keeping the fonts the way sapier wants them on Android.
