### PR TITLE
Speed up extent calculations

### DIFF
--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -145,7 +145,7 @@ void VoxelManipulator::print(std::ostream &o, INodeDefManager *ndef,
 void VoxelManipulator::addArea(const VoxelArea &area)
 {
 	// Cancel if requested area has zero volume
-	if(area.getExtent() == v3s16(0,0,0))
+	if(area.hasEmptyExtent())
 		return;
 
 	// Cancel if m_area already contains the requested area
@@ -157,7 +157,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	// Calculate new area
 	VoxelArea new_area;
 	// New area is the requested area if m_area has zero volume
-	if(m_area.getExtent() == v3s16(0,0,0))
+	if (area.hasEmptyExtent())
 	{
 		new_area = area;
 	}
@@ -167,6 +167,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 		new_area = m_area;
 		new_area.addArea(area);
 	}
+	new_area.addArea(area);
 
 	s32 new_size = new_area.getVolume();
 

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -82,7 +82,7 @@ public:
 
 	void addArea(const VoxelArea &a)
 	{
-		if(getExtent() == v3s16(0,0,0))
+		if(hasEmptyExtent())
 		{
 			*this = a;
 			return;
@@ -96,7 +96,7 @@ public:
 	}
 	void addPoint(const v3s16 &p)
 	{
-		if(getExtent() == v3s16(0,0,0))
+		if (hasEmptyExtent())
 		{
 			MinEdge = p;
 			MaxEdge = p;
@@ -137,6 +137,12 @@ public:
 	{
 		return MaxEdge - MinEdge + v3s16(1,1,1);
 	}
+
+	bool hasEmptyExtent() const
+	{
+		return MaxEdge - MinEdge == v3s16(-1, -1, -1);
+	}
+
 	s32 getVolume() const
 	{
 		v3s16 e = getExtent();
@@ -146,7 +152,7 @@ public:
 	{
 		// No area contains an empty area
 		// NOTE: Algorithms depend on this, so do not change.
-		if(a.getExtent() == v3s16(0,0,0))
+		if(a.hasEmptyExtent())
 			return false;
 
 		return(


### PR DESCRIPTION
Surprisingly, adding a function called hasEmptyExtent to VoxelArea seems to reduce the time taken for algorithms that care about an empty extent.