### PR TITLE
Remove automatic consistent formspec size <-> font size (now has to be d...

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -139,10 +139,9 @@ local function init_globals()
 	tv_main:add(tab_credits)
 
 	tv_main:set_global_event_handler(main_event_handler)
+	tv_main:set_fixed_size(false)
 
-	if PLATFORM == "Android" then
-		tv_main:set_fixed_size(false)
-	else
+	if not (PLATFORM == "Android") then
 		tv_main:set_tab(core.setting_get("maintab_LAST"))
 	end
 	ui.set_default("maintab")

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1024,11 +1024,7 @@ static inline void create_formspec_menu(GUIFormSpecMenu **cur_formspec,
 	}
 }
 
-#ifdef __ANDROID__
 #define SIZE_TAG "size[11,5.5]"
-#else
-#define SIZE_TAG "size[11,5.5,true]"
-#endif
 
 static void show_chat_menu(GUIFormSpecMenu **cur_formspec,
 		InventoryManager *invmgr, IGameDef *gamedef,


### PR DESCRIPTION
...one manually)

Set builtin formspecs to autoscale in order to get consistent formspec look and feel
Uncouple label positioning from font size (May break some formspecs but is required to allow manual font adjustment)