### PR TITLE
Fix offset being ignored by inventory bar HUD

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -945,6 +945,7 @@ Displays a horizontal bar made up of half-images.
 * `number`: Number of items in the inventory to be displayed.
 * `item`: Position of item that is selected.
 * `direction`
+* `offset`: offset in pixels from position.
 
 ### `waypoint`
 Displays distance to selected world position.

--- a/src/hud.h
+++ b/src/hud.h
@@ -130,7 +130,7 @@ public:
 	void drawCrosshair();
 	void drawSelectionMesh();
 	void updateSelectionMesh(const v3s16 &camera_offset);
-	
+
 	std::vector<aabb3f> *getSelectionBoxes()
 	{ return &m_selection_boxes; }
 
@@ -148,8 +148,9 @@ private:
 	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture,
 			s32 count, v2s32 offset, v2s32 size=v2s32());
 
-	void drawItems(v2s32 upperleftpos, s32 itemcount, s32 offset,
-		InventoryList *mainlist, u16 selectitem, u16 direction);
+	void drawItems(v2s32 upperleftpos, s32 itemcount, s32 inv_offset,
+		InventoryList *mainlist, u16 selectitem, u16 direction,
+		const v2s32 &offset = v2s32(0, 0));
 
 	void drawItem(const ItemStack &item, const core::rect<s32>& rect,
 		bool selected);


### PR DESCRIPTION
```lua
minetest.register_on_joinplayer(function(player)
	minetest.chat_send_player(player:get_player_name(), "Hello!")
	minetest.after(2, function()
		player:hud_add({
			hud_elem_type = "inventory",
			text = "main",
			number = 3,
			item = 1,
			direction = 2,
			position = {x=0, y=0.5},
			offset = {x=300, y = 100}
		})
		player:hud_add({
			hud_elem_type = "inventory",
			text = "main",
			number = 3,
			item = 2,
			direction = 0,
			position = {x=0, y=0.5}
		})
	end)
end)
```