### PR TITLE
Mgv5: Move cave generation from base terrain loop to optional function, fixes biome surface in tunnels

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -97,6 +97,7 @@ public:
 	int generateBaseTerrain();
 	void generateBlobs();
 	void generateBiomes();
+	void generateCaves();
 	void dustTopNodes();
 };
 


### PR DESCRIPTION
So now caves can be disabled in mgv5 and biome surface nodes do not appear in tunnels.