### PR TITLE
Added configurable ambient_occlusion_gamma. Default is 2.2 (same as before)

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -216,6 +216,9 @@
 #    Set to true enables waving plants. Requires shaders enabled.
 #enable_waving_plants = false
 #    Enables caching of facedir rotated meshes
+#ambient_occlusion_gamma = 2.2
+#    The strength (darkness) of node ambient-occlusion shading.
+#    Lower is darker, Higher is lighter.
 #enable_mesh_cache = true
 #    The time in seconds it takes between repeated
 #    right clicks when holding the right mouse button.
@@ -548,4 +551,3 @@
 #    Noise parameters for biome API temperature and humidity
 #mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0
 #mg_biome_np_humidity = 50, 50, (500, 500, 500), 842, 3, 0.5, 2.0
-

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -159,6 +159,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_wave_speed", "5.0");
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
+	settings->setDefault("ambient_occlusion_gamma", "2.2");
 	settings->setDefault("enable_shaders", "true");
 	settings->setDefault("repeat_rightclick_time", "0.25");
 	settings->setDefault("enable_particles", "true");
@@ -346,4 +347,3 @@ void override_default_settings(Settings *settings, Settings *from)
 		settings->setDefault(name, from->get(name));
 	}
 }
-

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -288,9 +288,14 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 
 	if (ambient_occlusion > 4)
 	{
-		//table of precalculated gamma space multiply factors
-		//light^2.2 * factor (0.75, 0.5, 0.25, 0.0), so table holds factor ^ (1 / 2.2)
-		static const float light_amount[4] = { 0.877424315, 0.729740053, 0.532520545, 0.0 };
+		static const float ao_gamma = g_settings->getFloat("ambient_occlusion_gamma");
+		
+		// Table of gamma space multiply factors.
+		static const float light_amount[3] = {
+			powf(0.75, 1.0 / ao_gamma),
+			powf(0.5,  1.0 / ao_gamma),
+			powf(0.25, 1.0 / ao_gamma)
+		};
 
 		//calculate table index for gamma space multiplier
 		ambient_occlusion -= 5;


### PR DESCRIPTION
_This commit is primarily for discussion and will need some clarification and changes before it is fully ready._

Adds a minetest.conf option for increasing or decreasing the ambient occlusion strength. (darkness)
The default is 0.65, which is slightly darker than the current value. Different games look better with different values. I like Carbone with 0.7, minetest_game with 0.65, and minimal with 0.53.

I'm not entirely sure what that gamma section was for, and it seems quite purposeful, so if anyone could explain how that works, and how to integrate this with it, I'd be quite thankful and it might help get this merged.

Also, everything works fine underwater and in caves now.

*Old:*
![](https://forum.minetest.net/download/file.php?id=1820)
*New (0.68 or so):*
![](https://forum.minetest.net/download/file.php?id=1821)