### PR TITLE
Fix Android crash on keyboard connection change.

### DIFF
--- a/build/android/AndroidManifest.xml.template
+++ b/build/android/AndroidManifest.xml.template
@@ -14,7 +14,7 @@
 	<activity android:name=".MtNativeActivity"
 		android:label="Minetest"
 		android:launchMode="singleTask"
-		android:configChanges="orientation|keyboardHidden"
+		android:configChanges="orientation|keyboard|keyboardHidden|navigation"
 		android:screenOrientation="sensorLandscape"
 		android:clearTaskOnLaunch="true">
 		<intent-filter>


### PR DESCRIPTION
Partial fix for #2113. No more crashes after keyboard/mouse plug/unplug.