### PR TITLE
Add autojump (increased stepheight).

### DIFF
--- a/builtin/mainmenu/tab_simple_main.lua
+++ b/builtin/mainmenu/tab_simple_main.lua
@@ -72,12 +72,15 @@ local function get_formspec(tabview, name, tabdata)
 
 	-- checkboxes
 	retval = retval ..
-		"checkbox[1.0,3.9;cb_creative;".. fgettext("Creative Mode") .. ";" ..
+		"checkbox[0.8,3.9;cb_creative;".. fgettext("Creative Mode") .. ";" ..
 		dump(core.setting_getbool("creative_mode")) .. "]"..
-		"checkbox[5.0,3.9;cb_damage;".. fgettext("Enable Damage") .. ";" ..
+		"checkbox[3.7,3.9;cb_damage;".. fgettext("Enable Damage") .. ";" ..
 		dump(core.setting_getbool("enable_damage")) .. "]" ..
-		"checkbox[8,3.9;cb_fly_mode;".. fgettext("Fly mode") .. ";" ..
-		dump(core.setting_getbool("free_move")) .. "]"
+		"checkbox[6.8,3.9;cb_fly_mode;".. fgettext("Fly mode") .. ";" ..
+		dump(core.setting_getbool("free_move")) .. "]" ..
+		"checkbox[9,3.9;cb_autojump;".. fgettext("Autojump") .. ";" ..
+		dump(core.setting_getbool("autojump")) .. "]"
+
 	-- buttons
 	retval = retval ..
 		"button[2.0,4.5;6,1.5;btn_start_singleplayer;" .. fgettext("Start Singleplayer") .. "]" ..
@@ -140,6 +143,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 	if fields["cb_fly_mode"] then
 		core.setting_set("free_move", fields["cb_fly_mode"])
+		return true
+	end
+
+	if fields["cb_autojump"] then
+		core.setting_set("autojump", fields["cb_autojump"])
 		return true
 	end
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -46,6 +46,7 @@
 #keymap_cmd = /
 #keyman_console = KEY_F10
 #keymap_rangeselect = KEY_KEY_R
+#keymap_autojump = KEY_KEY_L
 #keymap_freemove = KEY_KEY_K
 #keymap_fastmove = KEY_KEY_J
 #keymap_screenshot = KEY_F12
@@ -55,6 +56,7 @@
 #doubletap_jump = false
 #    If false aux1 is used to fly fast
 #always_fly_fast = true
+#autojump = false
 #    Some (temporary) keys for debugging
 #keymap_print_debug_stacks = KEY_KEY_P
 #keymap_quicktune_prev = KEY_HOME

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -45,6 +45,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_cmd", "/");
 	settings->setDefault("keymap_console", "KEY_F10");
 	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");
+	settings->setDefault("keymap_autojump", "KEY_KEY_L");
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
 	settings->setDefault("keymap_fastmove", "KEY_KEY_J");
 	settings->setDefault("keymap_noclip", "KEY_KEY_H");
@@ -69,6 +70,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");
 	settings->setDefault("always_fly_fast", "true");
+	settings->setDefault("autojump", "false");
 	settings->setDefault("directional_colored_fog", "true");
 	settings->setDefault("tooltip_show_delay", "400");
 
@@ -312,6 +314,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_particles", "false");
 	settings->setDefault("video_driver", "ogles1");
 	settings->setDefault("touchtarget", "true");
+	settings->setDefault("autojump", "true");
 	settings->setDefault("TMPFolder","/sdcard/Minetest/tmp/");
 	settings->setDefault("touchscreen_threshold","20");
 	settings->setDefault("smooth_lighting", "false");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1227,6 +1227,7 @@ struct KeyCache {
 		KEYMAP_ID_CHAT,
 		KEYMAP_ID_CMD,
 		KEYMAP_ID_CONSOLE,
+		KEYMAP_ID_AUTOJUMP,
 		KEYMAP_ID_FREEMOVE,
 		KEYMAP_ID_FASTMOVE,
 		KEYMAP_ID_NOCLIP,
@@ -1275,6 +1276,7 @@ void KeyCache::populate()
 	key[KEYMAP_ID_CHAT]         = getKeySetting("keymap_chat");
 	key[KEYMAP_ID_CMD]          = getKeySetting("keymap_cmd");
 	key[KEYMAP_ID_CONSOLE]      = getKeySetting("keymap_console");
+	key[KEYMAP_ID_AUTOJUMP]     = getKeySetting("keymap_autojump");
 	key[KEYMAP_ID_FREEMOVE]     = getKeySetting("keymap_freemove");
 	key[KEYMAP_ID_FASTMOVE]     = getKeySetting("keymap_fastmove");
 	key[KEYMAP_ID_NOCLIP]       = getKeySetting("keymap_noclip");
@@ -1470,6 +1472,7 @@ protected:
 	void dropSelectedItem();
 	void openInventory();
 	void openConsole();
+	void toggleAutoJump(float *statustext_time);
 	void toggleFreeMove(float *statustext_time);
 	void toggleFreeMoveAlt(float *statustext_time, float *jump_timer);
 	void toggleFast(float *statustext_time);
@@ -2533,6 +2536,8 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 				client, "/");
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_CONSOLE])) {
 		openConsole();
+	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_AUTOJUMP])) {
+		toggleAutoJump(statustext_time);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_FREEMOVE])) {
 		toggleFreeMove(statustext_time);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_JUMP])) {
@@ -2668,6 +2673,18 @@ void Game::openConsole()
 		gui_chat_console->openConsole(0.6);
 		guienv->setFocus(gui_chat_console);
 	}
+}
+
+
+void Game::toggleAutoJump(float *statustext_time)
+{
+	static const wchar_t *msg[] = { L"autojump disabled", L"autojump enabled" };
+
+	bool autojump = !g_settings->getBool("autojump");
+	g_settings->set("autojump", bool_to_cstr(autojump));
+
+	*statustext_time = 0;
+	statustext = msg[autojump];
 }
 
 

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -47,6 +47,7 @@ enum
 	GUI_ID_KEY_LEFT_BUTTON,
 	GUI_ID_KEY_RIGHT_BUTTON,
 	GUI_ID_KEY_USE_BUTTON,
+	GUI_ID_KEY_AUTOJUMP_BUTTON,
 	GUI_ID_KEY_FLY_BUTTON,
 	GUI_ID_KEY_FAST_BUTTON,
 	GUI_ID_KEY_JUMP_BUTTON,
@@ -62,6 +63,7 @@ enum
 	// other
 	GUI_ID_CB_AUX1_DESCENDS,
 	GUI_ID_CB_DOUBLETAP_JUMP,
+	GUI_ID_CB_AUTOJUMP,
 };
 
 GUIKeyChangeMenu::GUIKeyChangeMenu(gui::IGUIEnvironment* env,
@@ -107,7 +109,7 @@ void GUIKeyChangeMenu::removeChildren()
 void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 {
 	removeChildren();
-	v2s32 size(620, 430);
+	v2s32 size(720, 430);
 	
 	core::rect < s32 > rect(screensize.X / 2 - size.X / 2,
 							screensize.Y / 2 - size.Y / 2, screensize.X / 2 + size.X / 2,
@@ -119,7 +121,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	v2s32 topleft(0, 0);
 	
 	{
-		core::rect < s32 > rect(0, 0, 600, 40);
+		core::rect < s32 > rect(0, 0, 700, 40);
 		rect += topleft + v2s32(25, 3);
 		//gui::IGUIStaticText *t =
 		wchar_t* text = wgettext("Keybindings. (If this menu screws up, remove stuff from minetest.conf)");
@@ -137,20 +139,20 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	{
 		key_setting *k = key_settings.at(i);
 		{
-			core::rect < s32 > rect(0, 0, 100, 20);
+			core::rect < s32 > rect(0, 0, 140, 20);
 			rect += topleft + v2s32(offset.X, offset.Y);
 			Environment->addStaticText(k->button_name, rect, false, true, this, -1);
 		}
 
 		{
-			core::rect < s32 > rect(0, 0, 100, 30);
-			rect += topleft + v2s32(offset.X + 105, offset.Y - 5);
+			core::rect < s32 > rect(0, 0, 140, 30);
+			rect += topleft + v2s32(offset.X + 150, offset.Y - 5);
 			wchar_t* text = wgettext(k->key.name());
 			k->button = Environment->addButton(rect, this, k->id, text );
 			delete[] text;
 		}
 		if(i + 1 == KMaxButtonPerColumns)
-			offset = v2s32(250, 60);
+			offset = v2s32(350, 60);
 		else
 			offset += v2s32(0, 25);
 	}
@@ -200,7 +202,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		Environment->addButton(rect, this, GUI_ID_ABORT_BUTTON,
 							 text );
 		delete[] text;
-	}	
+	}
 }
 
 void GUIKeyChangeMenu::drawMenu()
@@ -213,7 +215,7 @@ void GUIKeyChangeMenu::drawMenu()
 	video::SColor bgcolor(140, 0, 0, 0);
 
 	{
-		core::rect < s32 > rect(0, 0, 620, 620);
+		core::rect < s32 > rect(0, 0, 720, 720);
 		rect += AbsoluteRect.UpperLeftCorner;
 		driver->draw2DRectangle(bgcolor, rect, &AbsoluteClippingRect);
 	}
@@ -237,6 +239,11 @@ bool GUIKeyChangeMenu::acceptInput()
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_DOUBLETAP_JUMP);
 		if(e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
 			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
+	}
+	{
+		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUTOJUMP);
+		if(e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
+			g_settings->setBool("autojump", ((gui::IGUICheckBox*)e)->isChecked());
 	}
 
 	clearKeyCache();
@@ -291,7 +298,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 		// Display Key already in use message
 		if (std::find(this->key_used.begin(), this->key_used.end(), kp) != this->key_used.end())
 		{
-			core::rect < s32 > rect(0, 0, 600, 40);
+			core::rect < s32 > rect(0, 0, 700, 40);
 			rect += v2s32(0, 0) + v2s32(25, 30);
 			wchar_t* text = wgettext("Key already in use");
 			this->key_used_text = Environment->addStaticText(text,
@@ -406,7 +413,8 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_CHAT_BUTTON,      wgettext("Chat"),          "keymap_chat");
 	this->add_key(GUI_ID_KEY_CMD_BUTTON,       wgettext("Command"),       "keymap_cmd");
 	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,   wgettext("Console"),       "keymap_console");
-	this->add_key(GUI_ID_KEY_FLY_BUTTON,       wgettext("Toggle fly"),    "keymap_freemove");
+	this->add_key(GUI_ID_KEY_AUTOJUMP_BUTTON,  wgettext("Toggle autojump"),"keymap_autojump");
+ 	this->add_key(GUI_ID_KEY_FLY_BUTTON,       wgettext("Toggle fly"),    "keymap_freemove");
 	this->add_key(GUI_ID_KEY_FAST_BUTTON,      wgettext("Toggle fast"),   "keymap_fastmove");
 	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,    wgettext("Toggle noclip"), "keymap_noclip");
 	this->add_key(GUI_ID_KEY_RANGE_BUTTON,     wgettext("Range select"),  "keymap_rangeselect");

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -208,10 +208,9 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// this shouldn't be hardcoded but transmitted from server
 	float player_stepheight = touching_ground ? (BS*0.6) : (BS*0.2);
 
-#ifdef __ANDROID__
-	player_stepheight += (0.5 * BS);
-#endif
-	
+	if (g_settings->getBool("autojump")) 
+		player_stepheight += (0.5 * BS);
+
 	v3f accel_f = v3f(0,0,0);
 
 	collisionMoveResult result = collisionMoveSimple(env, m_gamedef,


### PR DESCRIPTION
Adds option to increase stepheight by hotkey L for all platforms. It's on by default only on android, where it's been added as a checkbox on simple_main. I'd like to add a button to the in-game android gui, but that will wait for sapiers rework.