### PR TITLE
Hide minetest version string

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -78,6 +78,10 @@
 	#define HAVE_ENDIAN_H CMAKE_HAVE_ENDIAN_H
 #endif
 
+#ifndef VERSION_EXTRA_STRING
+	#define VERSION_EXTRA_STRING ""
+#endif
+
 #ifdef __ANDROID__
 	#include "android_version.h"
 	#define VERSION_STRING CMAKE_VERSION_STRING

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3935,7 +3935,7 @@ void Game::updateGui(float *statustext_time, const RunStats &stats,
 		   << ", RTT = " << client->getRTT();
 		guitext->setText(narrow_to_wide(os.str()).c_str());
 		guitext->setVisible(true);
-	} else if (flags.show_hud || flags.show_chat) {
+	} else if ((flags.show_hud || flags.show_chat) && VERSION_EXTRA_STRING != "") {
 		std::ostringstream os(std::ios_base::binary);
 		os << "Minetest " << minetest_version_hash;
 		guitext->setText(narrow_to_wide(os.str()).c_str());


### PR DESCRIPTION
Version is still visible in the debug view.

Source of this idea:
![Ugly](http://puu.sh/eBGgZ/272715c788.png)