### PR TITLE
Create empty default constructor for MapNode

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1189,8 +1189,7 @@ void Map::removeNodeAndUpdate(v3s16 p,
 		This also clears the lighting.
 	*/
 
-	MapNode n;
-	n.setContent(replace_material);
+	MapNode n(replace_material);
 	setNode(p, n);
 
 	for(s32 i=0; i<2; i++)
@@ -1603,6 +1602,16 @@ struct NodeNeighbor {
 	NeighborType t;
 	v3s16 p;
 	bool l; //can liquid
+
+	NodeNeighbor()
+		: n(CONTENT_AIR)
+	{ }
+
+	NodeNeighbor(const MapNode &node, NeighborType n_type, v3s16 pos)
+		: n(node),
+		  t(n_type),
+		  p(pos)
+	{ }
 };
 
 void Map::transforming_liquid_add(v3s16 p) {
@@ -1716,7 +1725,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks)
 					break;
 			}
 			v3s16 npos = p0 + dirs[i];
-			NodeNeighbor nb = {getNodeNoEx(npos), nt, npos};
+			NodeNeighbor nb(getNodeNoEx(npos), nt, npos);
 			switch (nodemgr->get(nb.n.getContent()).liquid_type) {
 				case LIQUID_NONE:
 					if (nb.n.getContent() == CONTENT_AIR) {

--- a/src/map.h
+++ b/src/map.h
@@ -80,9 +80,9 @@ struct MapEditEvent
 
 	MapEditEvent():
 		type(MEET_OTHER),
+		n(CONTENT_AIR),
 		already_known_by_peer(0)
-	{
-	}
+	{ }
 
 	MapEditEvent * clone()
 	{

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -139,12 +139,15 @@ struct MapNode
 	*/
 	u8 param2;
 
+	MapNode()
+	{ }
+
 	MapNode(const MapNode & n)
 	{
 		*this = n;
 	}
 
-	MapNode(content_t content = CONTENT_AIR, u8 a_param1=0, u8 a_param2=0)
+	MapNode(content_t content, u8 a_param1=0, u8 a_param2=0)
 		: param0(content),
 		  param1(a_param1),
 		  param2(a_param2)

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -855,9 +855,8 @@ struct TestMapNode: public TestBase
 {
 	void Run(INodeDefManager *nodedef)
 	{
-		MapNode n;
+		MapNode n(CONTENT_AIR);
 
-		// Default values
 		UASSERT(n.getContent() == CONTENT_AIR);
 		UASSERT(n.getLight(LIGHTBANK_DAY, nodedef) == 0);
 		UASSERT(n.getLight(LIGHTBANK_NIGHT, nodedef) == 0);

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -173,10 +173,8 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	dstream<<", new_size="<<new_size;
 	dstream<<std::endl;*/
 
-	// Allocate and clear new data
-	// FIXME: UGLY KLUDGE because MapNode default constructor is FUBAR; it
-	//        initialises data that is going to be overwritten anyway
-	MapNode *new_data = (MapNode*)new char[new_size * sizeof (*new_data)];
+	// Allocate new data and clear flags
+	MapNode *new_data = new MapNode[new_size];
 	assert(new_data);
 	u8 *new_flags = new u8[new_size];
 	assert(new_flags);


### PR DESCRIPTION
Add a default constructor to MapNode that does nothing (for performance).
Also removed kludge in VoxelManipulator::addArea() that was added to avoid (before this patch) needless initialisation of data