### PR TITLE
Mgv5: Various improvements, bugfix, uneasiness, speed increase

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -95,9 +95,9 @@ public:
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	int generateBaseTerrain();
-	void generateBlobs();
 	void generateBiomes();
 	void generateCaves();
+	void generateBlobs();
 	void dustTopNodes();
 };
 


### PR DESCRIPTION
Dirt/sand/gravel/lava blobgen is moved to after cavegen so that cavegen does not need extra node checks for those materials. Blobgen is now just before oregen, seems the optimum place
(blobgen will soon be replaced by registered ore bloblike anyway).

Now that cavegen is after biomegen it must run checks on biome nodes not just base terrain nodes. So it now accesses the biome manager to run a check for biome stone.
Below water level only biome stone or base terrain stone is excavated, this leaves biome surface nodes (seabed sand) plugging the underwater tunnel entrances, to reduce underground floods but also to give the nice-looking impression of sand being washed into the tunnel entrances and sealing them. A nice gameplay feature of this is a player encountering a tunnel blockage: digging it causes a flood and access to the ocean.

Recently we discovered the original MT 0.3 mgv5 used non-eased noise, trying this for cavegen i was surprised to find the structure improved, more defined and less messy. It also seems more suitable to have sharper, spikier more jagged structures underground for what are essentially cracks and fissures in rock that IRL experience less weathering. Seems to me caves don't need to be rounded and smoothed.
Cave noises are therefore now uneased, speeding up generation. The original parameters for noise scale and noise threshold are used.

Since biomegen is now directly after base terrain gen the now unnecessary 'is replaceable content' bool has been removed as only default stone needs to be checked for.

Eased 3D noise is still used for terrain noise.

Sorry for the long commit message without newlines, i did try to reword it while rebasing but this screwed up my repo for some reason, i need to practice this and work out how to do it properly.