### PR TITLE
Fix use of uninitialized data in Sky and (potentially) GUIChatConsole constructors

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1984,7 +1984,7 @@ bool Game::createClient(const std::string &playername,
 
 	/* Skybox
 	 */
-	sky = new Sky(smgr->getRootSceneNode(), smgr, -1);
+	sky = new Sky(smgr->getRootSceneNode(), smgr, -1, texture_src);
 	skybox = NULL;	// This is used/set later on in the main run loop
 
 	local_inventory = new Inventory(itemdef_manager);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -72,24 +72,21 @@ GUIChatConsole::GUIChatConsole(
 	m_animate_time_old = getTimeMs();
 
 	// load background settings
-	bool console_color_set = !g_settings->get("console_color").empty();
 	s32 console_alpha = g_settings->getS32("console_alpha");
+	m_background_color.setAlpha(clamp_u8(console_alpha));
 
 	// load the background texture depending on settings
-	m_background_color.setAlpha(clamp_u8(console_alpha));
-	if (console_color_set)
-	{
+	ITextureSource *tsrc = client->getTextureSource();
+	if (tsrc->isKnownSourceImage("background_chat.jpg")) {
+		m_background = tsrc->getTexture("background_chat.jpg");
+		m_background_color.setRed(255);
+		m_background_color.setGreen(255);
+		m_background_color.setBlue(255);
+	} else {
 		v3f console_color = g_settings->getV3F("console_color");
 		m_background_color.setRed(clamp_u8(myround(console_color.X)));
 		m_background_color.setGreen(clamp_u8(myround(console_color.Y)));
 		m_background_color.setBlue(clamp_u8(myround(console_color.Z)));
-	}
-	else
-	{
-		m_background = env->getVideoDriver()->getTexture(getTexturePath("background_chat.jpg").c_str());
-		m_background_color.setRed(255);
-		m_background_color.setGreen(255);
-		m_background_color.setBlue(255);
 	}
 
 	m_font = g_fontengine->getFont(FONT_SIZE_UNSPECIFIED, FM_Mono);

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -3,7 +3,7 @@
 #include "ISceneManager.h"
 #include "ICameraSceneNode.h"
 #include "S3DVertex.h"
-#include "tile.h" // getTexturePath
+#include "tile.h"
 #include "noise.h" // easeCurve
 #include "main.h" // g_profiler
 #include "profiler.h"
@@ -13,7 +13,8 @@
 #include "camera.h" // CameraModes
 
 //! constructor
-Sky::Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id):
+Sky::Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id,
+		ITextureSource *tsrc):
 		scene::ISceneNode(parent, mgr, id),
 		m_visible(true),
 		m_fallback_bg_color(255,255,255,255),
@@ -46,19 +47,18 @@ Sky::Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id):
 	m_materials[1].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
 	m_materials[2] = mat;
-	m_materials[2].setTexture(0, mgr->getVideoDriver()->getTexture(
-			getTexturePath("sunrisebg.png").c_str()));
+	m_materials[2].setTexture(0, tsrc->getTexture("sunrisebg.png"));
 	m_materials[2].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 	//m_materials[2].MaterialType = video::EMT_TRANSPARENT_ADD_COLOR;
 
-	m_sun_texture = mgr->getVideoDriver()->getTexture(
-			getTexturePath("sun.png").c_str());
-	m_moon_texture = mgr->getVideoDriver()->getTexture(
-			getTexturePath("moon.png").c_str());
-	m_sun_tonemap = mgr->getVideoDriver()->getTexture(
-			getTexturePath("sun_tonemap.png").c_str());
-	m_moon_tonemap = mgr->getVideoDriver()->getTexture(
-			getTexturePath("moon_tonemap.png").c_str());
+	m_sun_texture = tsrc->isKnownSourceImage("sun.png") ?
+		tsrc->getTexture("sun.png") : NULL;
+	m_moon_texture = tsrc->isKnownSourceImage("moon.png") ?
+		tsrc->getTexture("moon.png") : NULL;
+	m_sun_tonemap = tsrc->isKnownSourceImage("sun_tonemap.png") ?
+		tsrc->getTexture("sun_tonemap.png") : NULL;
+	m_moon_tonemap = tsrc->isKnownSourceImage("moon_tonemap.png") ?
+		tsrc->getTexture("moon_tonemap.png") : NULL;
 
 	if (m_sun_texture){
 		m_materials[3] = mat;

--- a/src/sky.h
+++ b/src/sky.h
@@ -27,12 +27,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define SKY_MATERIAL_COUNT 5
 #define SKY_STAR_COUNT 200
 
+class ITextureSource;
+
 // Skybox, rendered with zbuffer turned off, before all other nodes.
 class Sky : public scene::ISceneNode
 {
 public:
 	//! constructor
-	Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id);
+	Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id,
+			ITextureSource *tsrc);
 
 	virtual void OnRegisterSceneNode();
 


### PR DESCRIPTION
Clean up nearby code a bit

As a small side effect, it is now possible to add a background texture
to the chat console by simply providing background_chat.jpg, it is no
longer necessary to also add "console_color =" to minetest.conf.

Valgrind errors without this fix: http://sprunge.us/idhD
Explanation as given in #minetest-dev:
```
<kahrl> 1. getTexturePath returns an empty string
<kahrl> 2. this is passed to CNullDriver::getTexture
<kahrl> 3. getTexture calls getAbsolutePath on that, this returns "/"
<kahrl> 4. an IReadFile is opened on "/", which succeeds
           (a directory is treated like an empty file by fopen)
<kahrl> 5. then createImageFromFile calls the various image loaders'
           isALoadableFileFormat methods, which don't check if the reads succeed
```