### PR TITLE
Mgv7: Improve rivers and remove abysses. Speed optimise perlinmap calculations.

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -510,16 +510,16 @@ void MapgenV7::generateRidgeTerrain()
 		for (s16 x = node_min.X; x <= node_max.X; x++, index++, vi++) {
 			int j = (z - node_min.Z) * csize.X + (x - node_min.X);
 
-			if (heightmap[j] < water_level - 4)
+			if (heightmap[j] < water_level - 16)
+				continue;
+
+			float width = 0.2; // TODO: figure out acceptable perlin noise values
+			float uwatern = noise_ridge_uwater->result[j] * 2;
+			if (fabs(uwatern) > width)
 				continue;
 
 			float widthn = (noise_terrain_persist->result[j] - 0.6) / 0.1;
-			//widthn = rangelim(widthn, -0.05, 0.5);
-
-			float width = 0.3; // TODO: figure out acceptable perlin noise values
-			float uwatern = noise_ridge_uwater->result[j] * 2;
-			if (uwatern < -width || uwatern > width)
-				continue;
+			widthn = rangelim(widthn, -0.05, 0.5);
 
 			float height_mod = (float)(y + 17) / 2.5;
 			float width_mod  = (width - fabs(uwatern));

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -521,15 +521,10 @@ void MapgenV7::generateRidgeTerrain()
 			if (fabs(uwatern) > width)
 				continue;
 
-			float widthn = (noise_terrain_persist->result[j] - 0.6) / 0.1;
-			widthn = rangelim(widthn, -0.05, 0.5);
-
-			float height_mod = (float)(y + 17) / 2.5;
-			float width_mod  = (width - fabs(uwatern));
-			float nridge = noise_ridge->result[index] * (float)y / 7.0;
-
-			if (y < water_level)
-				nridge = -fabs(nridge) * 3.0 * widthn * 0.3;
+			float altitude = y - water_level;
+			float height_mod = (altitude + 17) / 2.5;
+			float width_mod  = width - fabs(uwatern);
+			float nridge = noise_ridge->result[index] * MYMAX(altitude, 0) / 7.0;
 
 			if (nridge + width_mod * height_mod < 0.6)
 				continue;


### PR DESCRIPTION
Commit 5dc:
The commented-out line that range-limits 'widthn' is enabled to remove the abysses underground. 'widthn' is calculated later in the function to speed optimise.
River width is reduced from 0.3 to 0.2 for less impact on terrain and less calculation, width now varies from narrow (but passable by boat) to fairly wide.
River channels used to abruptly stop in an ugly way when approaching deep water, now river channels are carved into much deeper water (16 nodes) to form beautiful channels through the seabed.

![screenshot_4241566599](https://cloud.githubusercontent.com/assets/3686677/5812517/92a04204-a064-11e4-8043-4fdcace859a6.png)

Commit e3d:
Huge amounts of speed optimisation =)
generateRidgeTerrain is now skipped in underground mapchunks.
The 'persistmap' values are already nicely controlled by the noiseparams and don't need range limiting, that is now removed.
Calculation of filler, mountain, ridge, heat and humidity perlinmaps is now skipped in underground mapchunks.

Commit 84c:
With range-limiting of 'widthn' enabled the amount of noise in the underwater channel structure is either zero or very subtle, so i decided to remove 'widthn' and set noise to zero underwater for simplicity, speed and very smooth flowing lines in the underwater channel.
The float 'altitude' is added to replace 'y' and make rivers channel structure relative to water level in case that is changed.