### PR TITLE
Fix FTBFS on GNU/Hurd platform

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -81,7 +81,7 @@ Set world path
 .TP
 \-\-migrate <value>
 Migrate from current map backend to another. Possible values are sqlite3
-and leveldb. Only works when using --server.
+and leveldb. Only works when using \-\-server.
 
 .SH ENVIRONMENT VARIABLES
 

--- a/misc/minetest.desktop
+++ b/misc/minetest.desktop
@@ -8,4 +8,5 @@ Terminal=false
 Type=Application
 Categories=Game;
 StartupNotify=false
+Keywords=sandbox;world;mining;crafting;blocks;nodes;multiplayer;roleplaying;
 

--- a/src/cguittfont/irrUString.h
+++ b/src/cguittfont/irrUString.h
@@ -45,7 +45,7 @@
 #define __BYTE_ORDER 0
 #define __LITTLE_ENDIAN 0
 #define __BIG_ENDIAN 1
-#elif __MACH__
+#elif defined(__MACH__) && defined(__APPLE__)
 #include <machine/endian.h>
 #elif defined(__FreeBSD__)
 #include <sys/endian.h>

--- a/src/jthread/jevent.h
+++ b/src/jthread/jevent.h
@@ -30,7 +30,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#elif __MACH__
+#elif defined(__MACH__) && defined(__APPLE__)
 #include <mach/mach.h>
 #include <mach/task.h>
 #include <mach/semaphore.h>
@@ -43,7 +43,7 @@
 class Event {
 #ifdef _WIN32
 	HANDLE hEvent;
-#elif __MACH__
+#elif defined(__MACH__) && defined(__APPLE__)
 	semaphore_t sem;
 #else
 	sem_t sem;

--- a/src/jthread/jsemaphore.h
+++ b/src/jthread/jsemaphore.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <windows.h>
 #include <assert.h>
 #define MAX_SEMAPHORE_COUNT 1024
-#elif __MACH__
+#elif defined(__MACH__) && defined(__APPLE__)
 #include <pthread.h>
 #include <mach/mach.h>
 #include <mach/task.h>
@@ -52,7 +52,7 @@ public:
 private:
 #if defined(WIN32)
 	HANDLE m_hSemaphore;
-#elif __MACH__
+#elif defined(__MACH__) && defined(__APPLE__)
 	semaphore_t m_semaphore;
 	int semcount;
 #else

--- a/src/jthread/pthread/jevent.cpp
+++ b/src/jthread/pthread/jevent.cpp
@@ -29,7 +29,7 @@
 
 #define UNUSED(expr) do { (void)(expr); } while (0)
 
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #undef sem_t
 #define sem_t semaphore_t
 #undef sem_init

--- a/src/porting.h
+++ b/src/porting.h
@@ -60,7 +60,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <unistd.h>
 	#include <stdint.h> //for uintptr_t
 
-	#if (defined(linux) || defined(__linux)) && !defined(_GNU_SOURCE)
+#if (defined(linux) || defined(__linux) || defined(__GNU__)) && !defined(_GNU_SOURCE)
 		#define _GNU_SOURCE
 	#endif
 
@@ -228,7 +228,7 @@ void initIrrlicht(irr::IrrlichtDevice * );
 #else // Posix
 #include <sys/time.h>
 #include <time.h>
-#ifdef __MACH__
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -258,7 +258,7 @@ void initIrrlicht(irr::IrrlichtDevice * );
 	{
 		struct timespec ts;
 		// from http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
-#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+#if defined(__MACH__) && defined(__APPLE__) // OS X does not have clock_gettime, use clock_get_time
 		clock_serv_t cclock;
 		mach_timespec_t mts;
 		host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
@@ -360,6 +360,9 @@ inline u32 getDeltaMs(u32 old_time_ms, u32 new_time_ms)
 	}
 #elif defined(_WIN32)
 	inline void setThreadName(const char* name) {}
+#elif defined(__GNU__)
+//#warning "GNU/Hurd platform, pthread_setname_np not yet supported"
+inline void setThreadName(const char* name) {}
 #else
 	#warning "Unrecognized platform, thread names will not be available."
 	inline void setThreadName(const char* name) {}


### PR DESCRIPTION
In Debian this patch was applied to achieve the following.

Minetest fails to build on GNU/Hurd due to a name clash with OSX/Apple, both are defining the __MACH__ keyword. This commit fixes the issue.

One commit adds keywords to minetest.desktop. This might improve a desktop search in modern desktop environments such as GNOME3 or KDE. The other one fixes a minor issue in the minetest.6. An explanation can be found here:

https://lintian.debian.org/tags/hyphen-used-as-minus-sign.html



Thanks for considering the patch.