### PR TITLE
Fix hyphen used as minus sign

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -81,7 +81,7 @@ Set world path
 .TP
 \-\-migrate <value>
 Migrate from current map backend to another. Possible values are sqlite3
-and leveldb. Only works when using --server.
+and leveldb. Only works when using \-\-server.
 
 .SH ENVIRONMENT VARIABLES
 


### PR DESCRIPTION
This one fixes a minor issue in minetest.6.

For more information see:

https://lintian.debian.org/tags/hyphen-used-as-minus-sign.html