### PR TITLE
Send real port to server list

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -428,6 +428,9 @@ Server::~Server()
 void Server::start(Address bind_addr)
 {
 	DSTACK(__FUNCTION_NAME);
+
+	m_bind_addr = bind_addr;
+
 	infostream<<"Starting server on "
 			<< bind_addr.serializeString() <<"..."<<std::endl;
 
@@ -678,6 +681,7 @@ void Server::AsyncRunStep(bool initial_step)
 				g_settings->getBool("server_announce"))
 		{
 			ServerList::sendAnnounce(counter ? "update" : "start",
+					m_bind_addr.getPort(),
 					m_clients.getPlayerNames(),
 					m_uptime.get(),
 					m_env->getGameTime(),
@@ -5093,8 +5097,8 @@ void dedicated_server_loop(Server &server, bool &kill)
 		{
 			infostream<<"Dedicated server quitting"<<std::endl;
 #if USE_CURL
-			if(g_settings->getBool("server_announce") == true)
-				ServerList::sendAnnounce("delete");
+			if(g_settings->getBool("server_announce"))
+				ServerList::sendAnnounce("delete", server.m_bind_addr.getPort());
 #endif
 			break;
 		}

--- a/src/server.h
+++ b/src/server.h
@@ -340,6 +340,9 @@ public:
 			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
 			std::string* vers_string);
 
+	// Bind address
+	Address m_bind_addr;
+
 private:
 
 	friend class EmergeThread;

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -189,6 +189,7 @@ const std::string serializeJson(const std::vector<ServerListSpec> &serverlist)
 
 #if USE_CURL
 void sendAnnounce(const std::string &action,
+		const u16 port,
 		const std::vector<std::string> &clients_names,
 		const double uptime,
 		const u32 game_time,
@@ -199,7 +200,7 @@ void sendAnnounce(const std::string &action,
 {
 	Json::Value server;
 	server["action"] = action;
-	server["port"]    = g_settings->getU16("port");
+	server["port"] = port;
 	if (g_settings->exists("server_address")) {
 		server["address"] = g_settings->get("server_address");
 	}

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -38,7 +38,7 @@ namespace ServerList
 	std::vector<ServerListSpec> deSerializeJson(const std::string &liststring);
 	const std::string serializeJson(const std::vector<ServerListSpec> &serverlist);
 	#if USE_CURL
-	void sendAnnounce(const std::string &action,
+	void sendAnnounce(const std::string &action, const u16 port,
 			const std::vector<std::string> &clients_names = std::vector<std::string>(),
 			const double uptime = 0, const u32 game_time = 0,
 			const float lag = 0, const std::string &gameid = "",


### PR DESCRIPTION
Fixes server list announcing breaking if you use a different `--port` than specified in the config file.
