### PR TITLE
Fix NDT_GLASSLIKE normals

### DIFF
--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -886,7 +886,6 @@ minetest.register_node("default:glass", {
 	description = "Glass",
 	drawtype = "glasslike",
 	tiles ={"default_glass.png"},
-	inventory_image = minetest.inventorycube("default_glass.png"),
 	paramtype = "light",
 	sunlight_propagates = true,
 	groups = {snappy=2,cracky=3,oddly_breakable_by_hand=3},

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -756,7 +756,8 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			for(u32 j=0; j<6; j++)
 			{
 				// Check this neighbor
-				v3s16 n2p = blockpos_nodes + p + g_6dirs[j];
+				v3s16 dir = g_6dirs[j];
+				v3s16 n2p = blockpos_nodes + p + dir;
 				MapNode n2 = data->m_vmanip.getNodeNoEx(n2p);
 				// Don't make face if neighbor is of same type
 				if(n2.getContent() == n.getContent())
@@ -764,10 +765,10 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 
 				// The face at Z+
 				video::S3DVertex vertices[4] = {
-					video::S3DVertex(-BS/2,-BS/2,BS/2, 0,0,0, c, 1,1),
-					video::S3DVertex(BS/2,-BS/2,BS/2, 0,0,0, c, 0,1),
-					video::S3DVertex(BS/2,BS/2,BS/2, 0,0,0, c, 0,0),
-					video::S3DVertex(-BS/2,BS/2,BS/2, 0,0,0, c, 1,0),
+					video::S3DVertex(-BS/2,-BS/2,BS/2, dir.X,dir.Y,dir.Z, c, 1,1),
+					video::S3DVertex(BS/2,-BS/2,BS/2, dir.X,dir.Y,dir.Z, c, 0,1),
+					video::S3DVertex(BS/2,BS/2,BS/2, dir.X,dir.Y,dir.Z, c, 0,0),
+					video::S3DVertex(-BS/2,BS/2,BS/2, dir.X,dir.Y,dir.Z, c, 1,0),
 				};
 				
 				// Rotations in the g_6dirs format


### PR DESCRIPTION
At the moment, NDT_GLASSLIKE sets the normals of all vertices to (0,0,0). This commit fixes the normals, which has two effects:

1. Glasslike nodes will be rendered with correct lighting in the inventory, without having to use inventorycube (as is done in minetest_game currently).
2. Glasslike nodes get the same "top face is brighter" treatment as all other cubic nodes.
See [this screenshot](http://digitalaudioconcepts.com/vanessa/hobbies/minetest/screenshots/Screenshot%20-%2001222015%20-%2006%3a58%3a10%20PM.png) (thanks to VanessaE!)

This affects drawtype = "glasslike" and also drawtype = "glasslike_framed_optional" if the connected_glass setting is disabled.

Semi-offtopic performance question: would it be a good idea to unroll the loop (sacrificing brevity for performance)?