### PR TITLE
Fix unitialised variable occassionally being used

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2116,6 +2116,9 @@ bool Game::connectToServer(const std::string &playername,
 		const std::string &password, std::string *address, u16 port,
 		bool *connect_ok, bool *aborted)
 {
+	*connect_ok = false;	// Let's not be overly optimistic
+	*aborted = false;
+
 	showOverlayMessage("Resolving address...", 0, 15);
 
 	Address connect_address(0, 0, 0, 0, port);
@@ -2158,13 +2161,11 @@ bool Game::connectToServer(const std::string &playername,
 
 	gamedef = client;	// Client acts as our GameDef
 
-
 	infostream << "Connecting to server at ";
 	connect_address.print(&infostream);
 	infostream << std::endl;
 
 	client->connect(connect_address);
-
 
 	/*
 		Wait for server to accept connection


### PR DESCRIPTION
This happens only rarely on my computer, but:
```
=18067== Conditional jump or move depends on uninitialised value(s)
==18067==    at 0x7F9CC1: Game::createClient(std::string const&, std::string const&, std::string*, unsigned short, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >*) (game.cpp:1946)
==18067==    by 0x7F86B6: Game::startup(bool*, bool, InputHandler*, irr::IrrlichtDevice*, std::string const&, std::string const&, std::string const&, std::string*, unsigned short, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >*, ChatBackend*, SubgameSpec const&, bool) (game.cpp:1706)
==18067==    by 0x805E96: the_game(bool*, bool, InputHandler*, irr::IrrlichtDevice*, std::string const&, std::string const&, std::string const&, std::string const&, unsigned short, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >&, ChatBackend&, SubgameSpec const&, bool) (game.cpp:4158)
==18067==    by 0x8886EB: ClientLauncher::run(GameParams&, Settings const&) (main.cpp:1750)
==18067==    by 0x881805: main (main.cpp:866)
==18067==  Uninitialised value was created by a stack allocation
==18067==    at 0x7F9BD1: Game::createClient(std::string const&, std::string const&, std::string*, unsigned short, std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >*) (game.cpp:1933)
```