### PR TITLE
Fix a crash (assert) when client set serial version < 24 in INIT command

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -526,12 +526,6 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
 		throw SerializationError("ERROR: Not writing dummy block.");
 	}
 
-	// Can't do this anymore; we have 16-bit dynamically allocated node IDs
-	// in memory; conversion just won't work in this direction.
-	if(version < 24)
-		throw SerializationError("MapBlock::serialize: serialization to "
-				"version < 24 not possible");
-
 	// First byte
 	u8 flags = 0;
 	if(is_underground)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -30,11 +30,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	--------------------------------
 
 	For map data (blocks, nodes, sectors).
-	
+
 	NOTE: The goal is to increment this so that saved maps will be
 	      loadable by any version. Other compatibility is not
 		  maintained.
-		  
+
 	0: original networked test with 1-byte nodes
 	1: update with 2-byte nodes
 	2: lighting is transmitted in param
@@ -70,7 +70,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Saved on disk version
 #define SER_FMT_VER_HIGHEST_WRITE 25
 // Lowest supported serialization version
-#define SER_FMT_VER_LOWEST 0
+#define SER_FMT_VER_LOWEST 24
 
 inline bool ser_ver_supported(s32 v) {
 	return v >= SER_FMT_VER_LOWEST && v <= SER_FMT_VER_HIGHEST_READ;


### PR DESCRIPTION
SER_FMT_VER_LOWEST is set to zero, then the test is stupid in INIT because all client works.
In mapblock we check if client's serialization version is < 24, but if client sent serialization version < 24 (15 for example) the server set it and tried to serialize mapblocks, then BOOM

Here we fix the check in init, then the client can't connect if serialization < 24. Then i remove the Mapblock::serialize throw, which become useless.

At this time i can go on any server -stable and if i send this wrong serialization value every server crashes.