### PR TITLE
Fix map_meta.txt error when loading a new world (again)

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -90,14 +90,15 @@ local function create_world_buttonhandler(this, fields)
 
 			local message = nil
 
+			-- it's used in core.create_world, must be before
+			core.setting_set("fixed_map_seed", fields["te_seed"])
+
 			if not menudata.worldlist:uid_exists_raw(worldname) then
 				core.setting_set("mg_name",fields["dd_mapgen"])
 				message = core.create_world(worldname,gameindex)
 			else
 				message = fgettext("A world named \"$1\" already exists", worldname)
 			end
-
-			core.setting_set("fixed_map_seed", fields["te_seed"])
 
 			if message ~= nil then
 				gamedata.errormessage = message

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3136,7 +3136,7 @@ void ServerMap::loadMapMeta()
 	std::string fullpath = m_savedir + DIR_DELIM "map_meta.txt";
 	std::ifstream is(fullpath.c_str(), std::ios_base::binary);
 	if (!is.good()) {
-		errorstream << "ServerMap::loadMapMeta(): "
+		infostream << "ServerMap::loadMapMeta(): "
 				<< "could not open" << fullpath << std::endl;
 		throw FileNotGoodException("Cannot open map metadata");
 	}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -632,10 +632,9 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 		// Create world if it doesn't exist
 		if(!initializeWorld(path, games[gameidx].id)){
 			lua_pushstring(L, "Failed to initialize world");
-
 		}
 		else {
-		lua_pushnil(L);
+			lua_pushnil(L);
 		}
 	}
 	else {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -295,7 +295,13 @@ Server::Server(
 	// Lock environment
 	JMutexAutoLock envlock(m_env_mutex);
 
-	// Load mapgen params from Settings
+	// Load mapgen params from global Settings
+	if (worldmt_settings.exists("mapgen") && worldmt_settings.exists("seedstr")) {
+		std::string mapgen = worldmt_settings.get("mapgen");
+		std::string seedstr = worldmt_settings.get("seedstr");
+		g_settings->set("mg_name",        mapgen);
+		g_settings->set("fixed_map_seed", seedstr);
+	}
 	m_emerge->loadMapgenParams();
 
 	// Create the Map (loads map_meta.txt, overriding configured mapgen params)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -297,12 +297,24 @@ Server::Server(
 
 	// Load mapgen params from global Settings
 	if (worldmt_settings.exists("mapgen") && worldmt_settings.exists("seedstr")) {
+		// save current global Settings
+		std::string old_mapgen;
+		std::string old_seedstr;
+		g_settings->getNoEx("mg_name",        old_mapgen);
+		g_settings->getNoEx("fixed_map_seed", old_seedstr);
+		// overwrite mg_name and fixed_map_seed parameters
 		std::string mapgen = worldmt_settings.get("mapgen");
 		std::string seedstr = worldmt_settings.get("seedstr");
 		g_settings->set("mg_name",        mapgen);
 		g_settings->set("fixed_map_seed", seedstr);
+		// load mapgen params from global Settings
+		m_emerge->loadMapgenParams();
+		// restore old global Settings
+		g_settings->set("mg_name",        old_mapgen);
+		g_settings->set("fixed_map_seed", old_seedstr);
+	} else {
+		m_emerge->loadMapgenParams();
 	}
-	m_emerge->loadMapgenParams();
 
 	// Create the Map (loads map_meta.txt, overriding configured mapgen params)
 	ServerMap *servermap = new ServerMap(path_world, this, m_emerge);

--- a/src/subgame.cpp
+++ b/src/subgame.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include "filesys.h"
 #include "settings.h"
+#include "main.h" // for g_settings
 #include "log.h"
 #include "strfnd.h"
 #ifndef SERVER
@@ -269,10 +270,19 @@ bool initializeWorld(const std::string &path, const std::string &gameid)
 	// Create world.mt if does not already exist
 	std::string worldmt_path = path + DIR_DELIM + "world.mt";
 	if(!fs::PathExists(worldmt_path)){
+		
+		std::string mg_name;
+		std::string seed_str;
+		g_settings->getNoEx("mg_name", mg_name);
+		g_settings->getNoEx("fixed_map_seed", seed_str);
+		
 		infostream<<"Creating world.mt ("<<worldmt_path<<")"<<std::endl;
 		fs::CreateAllDirs(path);
 		std::ostringstream ss(std::ios_base::binary);
-		ss<<"gameid = "<<gameid<< "\nbackend = sqlite3\n";
+		ss << "gameid = " << gameid << "\n";
+		ss << "backend = sqlite3" << "\n";
+		ss << "mapgen = " << mg_name << "\n";
+		ss << "seedstr = " << seed_str << "\n";
 		fs::safeWriteToFile(worldmt_path, ss.str());
 	}
 	return true;


### PR DESCRIPTION
Fixes #1708 and #2180.
I'm saving the map generator and the seed in world.mt so when you play this new world this parameters are loaded and overwrite default config. I know this solution is not very elegant but it is impossible to do otherwise without rewriting EmergeManager class. It's backwards compatible.