### PR TITLE
Allow any mod to be explicitly disabled in world.mt

### DIFF
--- a/src/mods.h
+++ b/src/mods.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include "json/json.h"
 #include "config.h"
+#include "settings.h"
 
 #define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
 
@@ -57,9 +58,10 @@ struct ModSpec
 };
 
 // Retrieves depends, optdepends, is_modpack and modpack_content
-void parseModContents(ModSpec &mod);
+void parseModContents(ModSpec &mod, const Settings &worldmt_settings);
 
-std::map<std::string,ModSpec> getModsInPath(std::string path, bool part_of_modpack = false);
+std::map<std::string,ModSpec> getModsInPath(std::string path,
+		const Settings &worldmt_settings, bool part_of_modpack = false);
 
 // If failed, returned modspec has name==""
 ModSpec findCommonMod(const std::string &modname);
@@ -104,7 +106,7 @@ public:
 private:
 	// adds all mods in the given path. used for games, modpacks
 	// and world-specific mods (worldmods-folders)
-	void addModsInPath(std::string path);
+	void addModsInPath(std::string path, const Settings &worldmt_settings);
 
 	// adds all mods in the set.
 	void addMods(std::vector<ModSpec> new_mods);


### PR DESCRIPTION
Without this patch, only worldmods and modpath mods can be
disabled, but you can never disable default game mods, like
fire, tnt, bucket, bones, which are likely to be disabled
by server admins to prevent griefing.

A message that the mod is explicitly disabled is printed out. Any
other mod remains enabled by default as usual.

The alternative solutions were insufficient for people who run
multiple servers, as updating minetest_game would overwrite the
removal of default mods.

v2: typo fix, move world.mt reading out of loop, remove debug msg.
