### PR TITLE
Fix map_meta.txt error when loading a new world (last try)

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -90,14 +90,15 @@ local function create_world_buttonhandler(this, fields)
 
 			local message = nil
 
+			-- it's used in core.create_world, must be before
+			core.setting_set("fixed_map_seed", fields["te_seed"])
+
 			if not menudata.worldlist:uid_exists_raw(worldname) then
 				core.setting_set("mg_name",fields["dd_mapgen"])
 				message = core.create_world(worldname,gameindex)
 			else
 				message = fgettext("A world named \"$1\" already exists", worldname)
 			end
-
-			core.setting_set("fixed_map_seed", fields["te_seed"])
 
 			if message ~= nil then
 				gamedata.errormessage = message

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -66,6 +66,13 @@ struct BlockEmergeData {
 	u8 flags;
 };
 
+class MapgenParamsManager {
+public:
+	MapgenSpecificParams *createMapgenParams(const std::string &mgname);
+	void loadParamsFromSettings(Settings *settings, MapgenParams *params);
+	void saveParamsToSettings(Settings *settings, MapgenParams *params);
+};
+
 class EmergeManager {
 public:
 	INodeDefManager *ndef;
@@ -77,6 +84,7 @@ public:
 
 	//settings
 	MapgenParams params;
+	MapgenParamsManager *mpmanager;
 	bool mapgen_debug_info;
 	u16 qlimit_total;
 	u16 qlimit_diskonly;
@@ -105,14 +113,10 @@ public:
 	Mapgen *getCurrentMapgen();
 	Mapgen *createMapgen(const std::string &mgname, int mgid,
 		MapgenParams *mgparams);
-	MapgenSpecificParams *createMapgenParams(const std::string &mgname);
 	static void getMapgenNames(std::list<const char *> &mgnames);
 	void startThreads();
 	void stopThreads();
 	bool enqueueBlockEmerge(u16 peer_id, v3s16 p, bool allow_generate);
-
-	void loadParamsFromSettings(Settings *settings);
-	void saveParamsToSettings(Settings *settings);
 
 	//mapgen helper methods
 	Biome *getBiomeAtPoint(v3s16 p);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3112,10 +3112,10 @@ void ServerMap::saveMapMeta()
 	std::string fullpath = m_savedir + DIR_DELIM + "map_meta.txt";
 	std::ostringstream ss(std::ios_base::binary);
 
-	Settings params;
-
-	m_emerge->saveParamsToSettings(&params);
-	params.writeLines(ss);
+	Settings tsettings;
+	
+	m_emerge->mpmanager->saveParamsToSettings(&tsettings, &m_emerge->params);
+	tsettings.writeLines(ss);
 
 	ss<<"[end_of_params]\n";
 
@@ -3141,14 +3141,14 @@ void ServerMap::loadMapMeta()
 		throw FileNotGoodException("Cannot open map metadata");
 	}
 
-	Settings params;
+	Settings tsettings;
 
-	if (!params.parseConfigLines(is, "[end_of_params]")) {
+	if (!tsettings.parseConfigLines(is, "[end_of_params]")) {
 		throw SerializationError("ServerMap::loadMapMeta(): "
 				"[end_of_params] not found!");
 	}
 
-	m_emerge->loadParamsFromSettings(&params);
+	m_emerge->mpmanager->loadParamsFromSettings(&tsettings, &m_emerge->params);
 
 	verbosestream << "ServerMap::loadMapMeta(): seed="
 		<< m_emerge->params.seed << std::endl;


### PR DESCRIPTION
Fixes #1708 and #2180. 
In this commit I'm creating the full map_meta.txt file when new world is created. I had to split the class EmergeManager in two classes to reuse the functions that read and write the file. This change seems very radical but I can't use the EmergeManager class directly.
If this solution is not accepted but helps someone to fix the problem I am satisfied.
