### PR TITLE
 Fix a crash (assert) when client set serial version < 24 in INIT and

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -526,11 +526,7 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
 		throw SerializationError("ERROR: Not writing dummy block.");
 	}
 
-	// Can't do this anymore; we have 16-bit dynamically allocated node IDs
-	// in memory; conversion just won't work in this direction.
-	if(version < 24)
-		throw SerializationError("MapBlock::serialize: serialization to "
-				"version < 24 not possible");
+	assert(version >= SER_FMT_CLIENT_VER_LOWEST);
 
 	// First byte
 	u8 flags = 0;

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -71,6 +71,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define SER_FMT_VER_HIGHEST_WRITE 25
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST 0
+// Lowest client supported serialization version
+#define SER_FMT_CLIENT_VER_LOWEST 24
 
 inline bool ser_ver_supported(s32 v) {
 	return v >= SER_FMT_VER_LOWEST && v <= SER_FMT_VER_HIGHEST_READ;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1366,7 +1366,7 @@ void Server::ProcessData(u8 *data, u32 datasize, u16 peer_id)
 		// Use the highest version supported by both
 		int deployed = std::min(client_max, our_max);
 		// If it's lower than the lowest supported, give up.
-		if(deployed < SER_FMT_VER_LOWEST)
+		if(deployed < SER_FMT_CLIENT_VER_LOWEST)
 			deployed = SER_FMT_VER_INVALID;
 
 		if(deployed == SER_FMT_VER_INVALID)


### PR DESCRIPTION
When SER_FMT_VER_LOWEST is set to zero, then the test is stupid in INIT because all client works. In mapblock we check if client's serialization version is < 24, but if client sent serialization version < 24 (15 for example) the server set it and tried to send nodes, then BOOM
Create a different CLIENT_MIN_VERSION to handle this problem and remove the assert, because the test never matches