### PR TITLE
Fix Exit to OS button focus in Pause Menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1157,7 +1157,7 @@ static void show_pause_menu(GUIFormSpecMenu **cur_formspec,
 	LocalFormspecHandler *txt_dst = new LocalFormspecHandler("MT_PAUSE_MENU");
 
 	create_formspec_menu(cur_formspec, invmgr, gamedef, tsrc, device,  fs_src, txt_dst, NULL);
-
+	(*cur_formspec)->setFocus(L"btn_continue");
 	(*cur_formspec)->doPause = true;
 }
 

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -97,6 +97,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(irr::IrrlichtDevice* dev,
 	m_form_src(fsrc),
 	m_text_dst(tdst),
 	m_formspec_version(0),
+	m_focused_element(L""),
 	m_font(NULL)
 #ifdef __ANDROID__
 	,m_JavaDialogFieldName(L"")
@@ -1757,8 +1758,6 @@ void GUIFormSpecMenu::parseElement(parserData* data, std::string element)
 		<<std::endl;
 }
 
-
-
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 {
 	/* useless to regenerate without a screensize */
@@ -1774,6 +1773,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		GUITable *table = m_tables[i].second;
 		mydata.table_dyndata[tablename] = table->getDynamicData();
 	}
+
+	//set focus
+	if (!m_focused_element.empty())
+		mydata.focused_fieldname = m_focused_element;
 
 	//preserve focus
 	gui::IGUIElement *focused_element = Environment->getFocus();

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -246,13 +246,20 @@ public:
 		m_allowclose = value;
 	}
 
-	void lockSize(bool lock,v2u32 basescreensize=v2u32(0,0)) {
+	void lockSize(bool lock,v2u32 basescreensize=v2u32(0,0))
+	{
 		m_lock = lock;
 		m_lockscreensize = basescreensize;
 	}
 
 	void removeChildren();
 	void setInitialFocus();
+	
+	void setFocus(std::wstring elementname)
+	{
+		m_focused_element = elementname;
+	}
+	
 	/*
 		Remove and re-add (or reposition) stuff
 	*/
@@ -348,6 +355,7 @@ private:
 	IFormSource      *m_form_src;
 	TextDest         *m_text_dst;
 	unsigned int      m_formspec_version;
+	std::wstring      m_focused_element;
 
 	typedef struct {
 		bool explicit_size;


### PR DESCRIPTION
Fix  #2158.
I added the setFocus method to set the focus passing the element name. Can be used in all forms and with all kinds of elements.