### PR TITLE
Suppress 1 gcc 4.9.2 warning and 1 clang 3.5.1 error

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -914,7 +914,7 @@ video::ITexture* TextureSource::generateTextureFromMesh(
 	smgr->drop();
 
 	// Unset render target
-	driver->setRenderTarget(0, false, true, 0);
+	driver->setRenderTarget(0, false, true, video::SColor(0,0,0,0));
 
 	if (params.delete_texture_on_shutdown)
 		m_texture_trash.push_back(rtt);


### PR DESCRIPTION
The setRenderTarget method has 3 constructors and there is ambiguity. In gcc is just a warning but in clang compiler this is an error and you can't get the executable. With this fix it's posible full compilation with clang.
http://irrlicht.sourceforge.net/docu/classirr_1_1video_1_1_i_video_driver.html