### PR TITLE
Fix jumping at node edge

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -246,8 +246,9 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	s16 max_y = MYMAX(oldpos_i.Y, newpos_i.Y) + (box_0.MaxEdge.Y / BS) + 1;
 	s16 max_z = MYMAX(oldpos_i.Z, newpos_i.Z) + (box_0.MaxEdge.Z / BS) + 1;
 
+	// The order is important here, must be y first
+	for(s16 y = max_y-1; y >= min_y; y--)
 	for(s16 x = min_x; x <= max_x; x++)
-	for(s16 y = min_y; y <= max_y; y++)
 	for(s16 z = min_z; z <= max_z; z++)
 	{
 		v3s16 p(x,y,z);
@@ -405,13 +406,16 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		for(u32 boxindex = 0; boxindex < cboxes.size(); boxindex++)
 		{
 			// Ignore if already stepped up this nodebox.
-			if(is_step_up[boxindex])
-				continue;
 
 			// Find nearest collision of the two boxes (raytracing-like)
 			f32 dtime_tmp;
 			int collided = axisAlignedCollision(
-					cboxes[boxindex], movingbox, speed_f, d, dtime_tmp);
+				cboxes[boxindex], movingbox, speed_f, d, dtime_tmp);
+
+			if (is_step_up[boxindex]) {
+				pos_f.Y += (cboxes[boxindex].MaxEdge.Y - movingbox.MinEdge.Y);
+				continue;
+			}
 
 			if(collided == -1 || dtime_tmp >= nearest_dtime)
 				continue;
@@ -500,8 +504,10 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			{
 				if(fabs(speed_f.Y) > BS*3)
 					speed_f.Y *= bounce;
-				else
+				else {
 					speed_f.Y = 0;
+					result.touching_ground = true;
+				}
 				result.collides = true;
 			}
 			else if(nearest_collided == 2) // Z
@@ -520,47 +526,6 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 			if(is_collision){
 				result.collisions.push_back(info);
-			}
-		}
-	}
-
-	/*
-		Final touches: Check if standing on ground, step up stairs.
-	*/
-	aabb3f box = box_0;
-	box.MinEdge += pos_f;
-	box.MaxEdge += pos_f;
-	for(u32 boxindex = 0; boxindex < cboxes.size(); boxindex++)
-	{
-		const aabb3f& cbox = cboxes[boxindex];
-
-		/*
-			See if the object is touching ground.
-
-			Object touches ground if object's minimum Y is near node's
-			maximum Y and object's X-Z-area overlaps with the node's
-			X-Z-area.
-
-			Use 0.15*BS so that it is easier to get on a node.
-		*/
-		if(
-				cbox.MaxEdge.X-d > box.MinEdge.X &&
-				cbox.MinEdge.X+d < box.MaxEdge.X &&
-				cbox.MaxEdge.Z-d > box.MinEdge.Z &&
-				cbox.MinEdge.Z+d < box.MaxEdge.Z
-		){
-			if(is_step_up[boxindex])
-			{
-				pos_f.Y += (cbox.MaxEdge.Y - box.MinEdge.Y);
-				box = box_0;
-				box.MinEdge += pos_f;
-				box.MaxEdge += pos_f;
-			}
-			if(fabs(cbox.MaxEdge.Y-box.MinEdge.Y) < 0.15*BS)
-			{
-				result.touching_ground = true;
-				if(is_unloaded[boxindex])
-					result.standing_on_unloaded = true;
 			}
 		}
 	}


### PR DESCRIPTION
The problem with the old code is that there were two pieces of logic to determine if a user was colliding with the world, and they were not in agreement.
Effectively this meant that you were colliding with the block, but you were not standing on it.
I have made the standing logic hinge off the colliding logic, which is more accurate.
I believe I have fixed this issue, but I need eyes on it and people to test this.

Fixes #123.
