### PR TITLE
Mgv7: Bugfixes for 0.4.12 and update conf.example

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -547,8 +547,10 @@
 #mgv7_np_filler_depth = 0, 1.2, (150, 150, 150), 261, 4, 0.7, 2.0
 #mgv7_np_mount_height = 100, 30, (500, 500, 500), 72449, 4, 0.6, 2.0
 #mgv7_np_ridge_uwater = 0, 1, (500, 500, 500), 85039, 4, 0.6, 2.0
-#mgv7_np_mountain = 0, 1, (250, 350, 250), 5333, 5, 0.68, 2.0
+#mgv7_np_mountain = -0.6, 1, (250, 350, 250), 5333, 5, 0.68, 2.0
 #mgv7_np_ridge = 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+#mgv7_np_cave1 = 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
+#mgv7_np_cave2 = 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
 
 #    Noise parameters for biome API temperature and humidity
 #mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0


### PR DESCRIPTION
![screenshot_749542316](https://cloud.githubusercontent.com/assets/3686677/5943854/547fd4b4-a71a-11e4-8a36-59642b75c8d4.png)

^ The endless vertical walls caused by the divide-by-zero bug. Mountain height noise is now used as a multiplier for mountain noise, as in mgv5. The removal of range limiting mountain height allowed the bug to occur when using custom noiseparams in .conf. Default mountain noise offset is now -0.6 to compensate, terrain matches the previous output.

![screenshot_823978375](https://cloud.githubusercontent.com/assets/3686677/5943690/10dedb98-a719-11e4-9c43-5b8e0527e41b.png)

^ Water level set to y = 50, flooded world example. 

![screenshot_1362916130](https://cloud.githubusercontent.com/assets/3686677/6054212/60512d74-ace2-11e4-818f-f15fb97fe756.png)

^ Water level set to y = -160, ravine rivers and deep pools. Code is updated to work with the de-linking of average terrain level from water level.