### PR TITLE
Security Fix: Empty the password after sending it to server

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -518,6 +518,9 @@ void Client::step(float dtime)
 
 			// Send as unreliable
 			Send(1, data, false);
+
+			// Empty the password, don't let it in memory !!!
+			m_password = "";
 		}
 
 		// Not connected, return


### PR DESCRIPTION
The password is passed to Client class and never cleaned. Then it stay in memory every time the user was connected. It's possible to recover it by accessing to minetest process memory.

This fix clear the string after sending _INIT packet.

Please merge fast