### PR TITLE
Fix dying of lava causes repeated death

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2567,6 +2567,8 @@ void ClientEnvironment::damageLocalPlayer(u8 damage, bool handle_hp)
 	assert(lplayer);
 	
 	if(handle_hp){
+		if (lplayer->hp == 0) // Don't damage a dead player
+			return;
 		if(lplayer->hp > damage)
 			lplayer->hp -= damage;
 		else


### PR DESCRIPTION
This is a bugfix for issue #81

It does it by ensuring the client doesn't take damage when already dead.
Mods can't hook player damage, so i don't believe this can break any mods.