### PR TITLE
Change assignment to global to warning

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -22,7 +22,7 @@ function meta:__newindex(name, value)
 				info.currentline, name)
 		if not warned[warn_key] and info.what ~= "main" and
 				info.what ~= "C" then
-			minetest.log("error", ("Assignment to undeclared "..
+			warn(("Assignment to undeclared "..
 					"global %q inside a function at %s.")
 				:format(name, desc))
 			warned[warn_key] = true


### PR DESCRIPTION
The warning confuses new players. It is only useful for mod developers to prevent bugs, so it should be demoted to a warning. It should not go into the chat.

Are we creating a game for developers or for players?

**This should be merged before 0.4.12.**