### PR TITLE
damage_per_second negative number implementation

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2912,7 +2912,7 @@ Definition tables
         liquid_range = 8, -- number of flowing nodes around source (max. 8)
         drowning = 0, -- Player will take this amount of damage if no bubbles are left
         light_source = 0, -- Amount of light emitted by node
-        damage_per_second = 0, -- If player is inside node, this damage is caused
+        damage_per_second = 0, -- If player is inside node, this damage(or heal) is caused
         node_box = {type="regular"}, -- See "Node boxes"
         mesh = "model",
         selection_box = {type="regular"}, -- See "Node boxes" --[[

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -519,7 +519,7 @@ void Client::step(float dtime)
 		}
 		else if(event.type == CEE_PLAYER_DAMAGE) {
 			if(m_ignore_damage_timer <= 0) {
-				u8 damage = event.player_damage.amount;
+				s16 damage = event.player_damage.amount;
 
 				if(event.player_damage.send_to_server)
 					sendDamage(damage);
@@ -1100,11 +1100,11 @@ void Client::sendChangePassword(const std::wstring &oldpassword,
 }
 
 
-void Client::sendDamage(u8 damage)
+void Client::sendDamage(s16 damage)
 {
 	DSTACK(__FUNCTION_NAME);
 
-	NetworkPacket* pkt = new NetworkPacket(TOSERVER_DAMAGE, sizeof(u8));
+	NetworkPacket* pkt = new NetworkPacket(TOSERVER_DAMAGE, sizeof(s16));
 	*pkt << damage;
 	Send(pkt);
 }

--- a/src/client.h
+++ b/src/client.h
@@ -156,7 +156,7 @@ struct ClientEvent
 		//struct{
 		//} none;
 		struct{
-			u8 amount;
+			s16 amount;
 		} player_damage;
 		struct{
 			f32 pitch;
@@ -408,7 +408,7 @@ public:
 	void sendChatMessage(const std::wstring &message);
 	void sendChangePassword(const std::wstring &oldpassword,
 	                        const std::wstring &newpassword);
-	void sendDamage(u8 damage);
+	void sendDamage(s16 damage);
 	void sendBreath(u16 breath);
 	void sendRespawn();
 	void sendReady();

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "localplayer.h"
 #include "mapblock_mesh.h"
 #include "event.h"
+#include "constants.h"
 #endif
 #include "daynightratio.h"
 #include "map.h"
@@ -2237,32 +2238,59 @@ void ClientEnvironment::step(float dtime)
 	}
 	
 	/*
-		A quick draft of lava damage
+		A draft of node damage
 	*/
-	if(m_lava_hurt_interval.step(dtime, 1.0))
-	{
+	if (m_lava_hurt_interval.step(dtime, 1.0)) {
 		v3f pf = lplayer->getPosition();
 		
 		// Feet, middle and head
-		v3s16 p1 = floatToInt(pf + v3f(0, BS*0.1, 0), BS);
-		MapNode n1 = m_map->getNodeNoEx(p1);
+		v3s16 p1 = floatToInt(pf + v3f(0, BS*0.1, 0), BS); // get pos
 		v3s16 p2 = floatToInt(pf + v3f(0, BS*0.8, 0), BS);
-		MapNode n2 = m_map->getNodeNoEx(p2);
 		v3s16 p3 = floatToInt(pf + v3f(0, BS*1.6, 0), BS);
+		MapNode n1 = m_map->getNodeNoEx(p1); // get node
+		MapNode n2 = m_map->getNodeNoEx(p2);
 		MapNode n3 = m_map->getNodeNoEx(p3);
 
-		u32 damage_per_second = 0;
-		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n1).damage_per_second);
-		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n2).damage_per_second);
-		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n3).damage_per_second);
-		
-		if(damage_per_second != 0)
-		{
-			damageLocalPlayer(damage_per_second, true);
+		s32 damage_per_second = 0;
+		s32 damage_max = 0;
+		s32 damage_min = 0; // Healing
+
+		// check body
+		s32 d1 = m_gamedef->ndef()->get(n1).damage_per_second;
+		s32 d2 = m_gamedef->ndef()->get(n2).damage_per_second;
+		s32 d3 = m_gamedef->ndef()->get(n3).damage_per_second;
+		damage_max = MYMAX(damage_max, d1);
+		damage_min = MYMIN(damage_min, d1);
+		damage_max = MYMAX(damage_max, d2);
+		damage_min = MYMIN(damage_min, d2);
+		damage_max = MYMAX(damage_max, d3);
+		damage_min = MYMIN(damage_min, d3);
+
+		// check colliding nodes - iterate through collision list from lplayer->move
+		for (std::list<CollisionInfo>::iterator i = player_collisions.begin();
+				i != player_collisions.end();
+				++i) {
+			CollisionInfo &info = *i;
+			if (info.type == COLLISION_NODE) {
+				MapNode n = m_map->getNodeNoEx(info.node_p);
+				s32 d = m_gamedef->ndef()->get(n).damage_per_second;
+				damage_max = MYMAX(damage_max, d);
+				damage_min = MYMIN(damage_min, d);
+			}
 		}
+
+		// calculate dmg/s
+		if (damage_max >= 0) {
+			if (damage_min >= 0) // just damage
+				damage_per_second = damage_max;
+			else // damage - (-heal)
+				damage_per_second = damage_max + damage_min;
+		}
+		else if (damage_min < 0)
+			damage_per_second = damage_min; // just heal
+
+		if (damage_per_second != 0)
+			damageLocalPlayer(damage_per_second, true); // push damage
 	}
 
 	/*
@@ -2561,18 +2589,26 @@ void ClientEnvironment::processActiveObjectMessage(u16 id,
 	Callbacks for activeobjects
 */
 
-void ClientEnvironment::damageLocalPlayer(u8 damage, bool handle_hp)
+void ClientEnvironment::damageLocalPlayer(s16 damage, bool handle_hp)
 {
 	LocalPlayer *lplayer = getLocalPlayer();
 	assert(lplayer);
 	
-	if(handle_hp){
+	if (handle_hp) {
 		if (lplayer->hp == 0) // Don't damage a dead player
 			return;
-		if(lplayer->hp > damage)
-			lplayer->hp -= damage;
-		else
-			lplayer->hp = 0;
+		if (damage > 0) {
+			if (lplayer->hp > damage)
+				lplayer->hp -= damage;
+			else
+				lplayer->hp = 0;
+		}
+		else if (damage < 0) {
+			if (lplayer->hp < PLAYER_MAX_HP)
+				lplayer->hp -= damage; // damage is negative
+			else
+				lplayer->hp = PLAYER_MAX_HP;
+		}
 	}
 
 	ClientEnvEvent event;

--- a/src/environment.h
+++ b/src/environment.h
@@ -436,7 +436,7 @@ struct ClientEnvEvent
 		//struct{
 		//} none;
 		struct{
-			u8 amount;
+			s16 amount;
 			bool send_to_server;
 		} player_damage;
 		struct{
@@ -495,7 +495,7 @@ public:
 		Callbacks for activeobjects
 	*/
 
-	void damageLocalPlayer(u8 damage, bool handle_hp=true);
+	void damageLocalPlayer(s16 damage, bool handle_hp=true);
 	void updateLocalPlayerBreath(u16 breath);
 
 	/*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3006,16 +3006,17 @@ void Game::processClientEvents(CameraOrientation *cam, float *damage_flash)
 
 		if (event.type == CE_PLAYER_DAMAGE &&
 				client->getHP() != 0) {
-			//u16 damage = event.player_damage.amount;
+			//s16 damage = event.player_damage.amount;
 			//infostream<<"Player damage: "<<damage<<std::endl;
 
-			*damage_flash += 100.0;
-			*damage_flash += 8.0 * event.player_damage.amount;
+			if (event.player_damage.amount > 0) {
+				*damage_flash += 100.0;
+				*damage_flash += 8.0 * event.player_damage.amount;
 
-			player->hurt_tilt_timer = 1.5;
-			player->hurt_tilt_strength = event.player_damage.amount / 4;
-			player->hurt_tilt_strength = rangelim(player->hurt_tilt_strength, 1.0, 4.0);
-
+				player->hurt_tilt_timer = 1.5;
+				player->hurt_tilt_strength = event.player_damage.amount / 4;
+				player->hurt_tilt_strength = rangelim(player->hurt_tilt_strength, 1.0, 4.0);
+			}
 			MtEvent *e = new SimpleTriggerEvent("PlayerDamage");
 			gamedef->event()->put(e);
 		} else if (event.type == CE_PLAYER_FORCE_MOVE) {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -259,7 +259,7 @@ enum ToClientCommand
 	TOCLIENT_HP = 0x33,
 	/*
 		u16 command
-		u8 hp
+		u8 hp // TODO should be u16
 	*/
 
 	TOCLIENT_MOVE_PLAYER = 0x34,
@@ -691,7 +691,7 @@ enum ToServerCommand
 	TOSERVER_DAMAGE = 0x35,
 	/*
 		u16 command
-		u8 amount
+		s16 amount // in new protocol
 	*/
 
 	TOSERVER_PASSWORD=0x36,

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -239,7 +239,8 @@ struct ContentFeatures
 	u8 drowning;
 	// Amount of light the node emits
 	u8 light_source;
-	u32 damage_per_second;
+	// damage/heal
+	s32 damage_per_second;
 	NodeBox node_box;
 	NodeBox selection_box;
 	NodeBox collision_box;


### PR DESCRIPTION
Fixes #2248 
In addition, damage / healing is calculated from the blocks that a) contain the player, b) collide with the player (player walks against them/stands on them)
b) could change with #2224 
I think this breaks server-client protocol cross-version compatibility a bit, but at least in singleplayer it works.