### PR TITLE
Mgv7: Add lower limit of zero to mountain height noise

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -361,7 +361,7 @@ float MapgenV7::baseTerrainLevelFromMap(int index)
 
 bool MapgenV7::getMountainTerrainAtPoint(int x, int y, int z)
 {
-	float mnt_h_n = NoisePerlin2D(&noise_mount_height->np, x, z, seed);
+	float mnt_h_n = MYMAX(NoisePerlin2D(&noise_mount_height->np, x, z, seed), 0);
 	float mnt_n = NoisePerlin3D(&noise_mountain->np, x, y, z, seed);
 	return mnt_n * mnt_h_n >= (float)y;
 }
@@ -369,7 +369,7 @@ bool MapgenV7::getMountainTerrainAtPoint(int x, int y, int z)
 
 bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, int y)
 {
-	float mounthn = noise_mount_height->result[idx_xz];
+	float mounthn = MYMAX(noise_mount_height->result[idx_xz], 0);
 	float mountn = noise_mountain->result[idx_xyz];
 	return mountn * mounthn >= (float)y;
 }


### PR DESCRIPTION
For more useful modulation control of 3D mountain noise. Mountain height noise used to be range limited to roughy 50 to 150, i removed the range limiting recently for freedom of adjustibility, this allowed a now possible zero value to cause the divide by zero bug (now fixed).
I'm working on alternative / improved noise parameters for mgv7 and find mountain height noise is most useful if optionally allowed to fall to zero for a chosen proportion of world. However negative values are a problem because they combine with negative 3D mountain noise to result in a positive and therefore mountains where you don't want them.
Essentially a zero value is useful but negative values a problem, so it's very useful to be able to clip the noise with a lower limit of zero, then by varying noise 'offset' and 'scale' the value can be optionally held at zero for a chosen proportion of world.
I'm also working on floatland generation through alternative noise parameters, the tricks i use to create them rely on this commit.
This commit doesn't change terrain shape because the current default noise parameters for mountain height always result in a positive value.