### PR TITLE
Remove shader workaround in itemdef.cpp

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -283,6 +283,7 @@ Client::Client(
 	}
 
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
+	m_cache_enable_shaders  = g_settings->getBool("enable_shaders");
 }
 
 void Client::Stop()
@@ -2681,7 +2682,7 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 		Create a task to update the mesh of the block
 	*/
 
-	MeshMakeData *data = new MeshMakeData(this);
+	MeshMakeData *data = new MeshMakeData(this, m_cache_enable_shaders);
 
 	{
 		//TimeTaker timer("data fill");

--- a/src/client.h
+++ b/src/client.h
@@ -623,8 +623,9 @@ private:
 	Database *localdb;
 	Server *localserver;
 
-	// TODO: Add callback to update this when g_settings changes
+	// TODO: Add callback to update these when g_settings changes
 	bool m_cache_smooth_lighting;
+	bool m_cache_enable_shaders;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -362,8 +362,6 @@ public:
 
 			scene::IMesh *node_mesh = NULL;
 
-			bool reenable_shaders = false;
-
 			if (need_rtt_mesh || need_wield_mesh) {
 				u8 param1 = 0;
 				if (f.param_type == CPT_LIGHT)
@@ -372,11 +370,7 @@ public:
 				/*
 					Make a mesh from the node
 				*/
-				if (g_settings->getBool("enable_shaders")) {
-					reenable_shaders = true;
-					g_settings->setBool("enable_shaders", false);
-				}
-				MeshMakeData mesh_make_data(gamedef);
+				MeshMakeData mesh_make_data(gamedef, false);
 				u8 param2 = 0;
 				if (f.param_type_2 == CPT2_WALLMOUNTED)
 					param2 = 1;
@@ -443,9 +437,6 @@ public:
 
 			if (node_mesh)
 				node_mesh->drop();
-
-			if (reenable_shaders)
-				g_settings->setBool("enable_shaders",true);
 		}
 
 		// Put in cache

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -42,7 +42,7 @@ static void applyFacesShading(video::SColor& color, float factor)
 	MeshMakeData
 */
 
-MeshMakeData::MeshMakeData(IGameDef *gamedef):
+MeshMakeData::MeshMakeData(IGameDef *gamedef, bool use_shaders):
 	m_vmanip(),
 	m_blockpos(-1337,-1337,-1337),
 	m_crack_pos_relative(-1337, -1337, -1337),
@@ -50,7 +50,8 @@ MeshMakeData::MeshMakeData(IGameDef *gamedef):
 	m_smooth_lighting(false),
 	m_show_hud(false),
 	m_highlight_mesh_color(255, 255, 255, 255),
-	m_gamedef(gamedef)
+	m_gamedef(gamedef),
+	m_use_shaders(use_shaders)
 {}
 
 void MeshMakeData::fill(MapBlock *block)
@@ -1028,7 +1029,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 	m_last_daynight_ratio((u32) -1),
 	m_daynight_diffs()
 {
-	m_enable_shaders = g_settings->getBool("enable_shaders");
+	m_enable_shaders = data->m_use_shaders;
 	m_enable_highlighting = g_settings->getBool("enable_node_highlighting");
 
 	// 4-21ms for MAP_BLOCKSIZE=16  (NOTE: probably outdated)

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -45,8 +45,9 @@ struct MeshMakeData
 	video::SColor m_highlight_mesh_color;
 
 	IGameDef *m_gamedef;
+	bool m_use_shaders;
 
-	MeshMakeData(IGameDef *gamedef);
+	MeshMakeData(IGameDef *gamedef, bool use_shaders);
 
 	/*
 		Copy central data directly from block, and other data from

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -340,7 +340,9 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
 		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES) {
 			setCube(f.tiles, def.wield_scale, tsrc);
 		} else {
-			MeshMakeData mesh_make_data(gamedef);
+			//// TODO: Change false in the following constructor args to
+			//// appropriate value when shader is added for wield items (if applicable)
+			MeshMakeData mesh_make_data(gamedef, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);
 			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));


### PR DESCRIPTION
Remove workaround in itemdef.cpp to enable/disable/enable "enable_shader" setting

- Increase performance (client)
- Avoid changing a global value to solve a local problem