### PR TITLE
Open inventory only when inventory could be loaded

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2669,6 +2669,15 @@ void Game::dropSelectedItem()
 
 void Game::openInventory()
 {
+	/*
+	 * Don't permit to open inventory is CAO or player doesn't exists.
+	 * This prevent showing an empty inventory at player load
+	 */
+
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (player == NULL || player->getCAO() == NULL)
+		return;
+
 	infostream << "the_game: " << "Launching inventory" << std::endl;
 
 	PlayerInventoryFormSource *fs_src = new PlayerInventoryFormSource(client);


### PR DESCRIPTION
This change prevent player to open its inventory whereas the player isn't fully loaded and inventory isn't loaded. You will see this change easily on high latency/low bandwidth servers.