### PR TITLE
Enable LUA_USE_POSIX if possible in bundled Lua

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -47,10 +47,6 @@ else()
 endif()
 mark_as_advanced(LUA_USE_DLOPEN)
 
-if(DEFAULT_POSIX)
-else()
-endif()
-
 if(DEFAULT_ANSI)
 	option(LUA_ANSI "Disable non-ansi features." ON)
 else()
@@ -86,6 +82,10 @@ if(LUA_USE_DLOPEN)
 		set(COMMON_LDFLAGS "${COMMON_LDFLAGS} -ldl ")
 	endif(NOT APPLE)
 endif(LUA_USE_DLOPEN)
+
+if(DEFAULT_POSIX)
+	set(COMMON_CFLAGS "${COMMON_CFLAGS} -DLUA_USE_POSIX")
+endif(DEFAULT_POSIX)
 
 if(LUA_ANSI)
 	set(COMMON_CFLAGS "${COMMON_CFLAGS} -DLUA_ANSI")


### PR DESCRIPTION
Fixed warning:
`src/lua/src/loslib.c:60: Warning: the use of \`tmpnam' is dangerous, better use \`mkstemp'`

@nerzhul