### PR TITLE
Remove unused variables to make clang happy

### DIFF
--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -122,9 +122,6 @@ private:
 	// font
 	gui::IGUIFont* m_font;
 	v2u32 m_fontsize;
-#if USE_FREETYPE
-	bool m_use_freetype;
-#endif
 };
 
 

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -194,7 +194,6 @@ private:
 	HTTPFetchRequest request;
 	HTTPFetchResult result;
 	std::ostringstream oss;
-	char *post_fields;
 	struct curl_slist *http_header;
 	curl_httppost *post;
 };


### PR DESCRIPTION
Those variables aren't used and Clang report it:

http://jenkins.unix-experience.fr/job/minetest/124/console

Everybody agrees ?

Merge date: 13/02 