### PR TITLE
Fix minetest.item_eat's replace_with_item, fixes #2292

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -106,7 +106,7 @@ function core.facedir_to_dir(facedir)
 					{x=0, y=1, z=0}})
 
 					--indexed into by a table of correlating facedirs
-					[({[0]=1, 2, 3, 4, 
+					[({[0]=1, 2, 3, 4,
 						5, 2, 6, 4,
 						6, 2, 5, 4,
 						1, 5, 3, 6,
@@ -238,7 +238,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 
 	core.log("action", placer:get_player_name() .. " places node "
 		.. def.name .. " at " .. core.pos_to_string(place_to))
-	
+
 	local oldnode = core.get_node(place_to)
 	local newnode = {name = def.name, param1 = 0, param2 = param2}
 
@@ -357,19 +357,37 @@ function core.item_drop(itemstack, dropper, pos)
 	return itemstack
 end
 
-function core.item_eat(hp_change, replace_with_item)
-	return function(itemstack, user, pointed_thing)  -- closure
-		for _, callback in pairs(core.registered_on_item_eats) do
-			local result = callback(hp_change, replace_with_item, itemstack, user, pointed_thing)
-			if result then
-				return result
+function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
+	for _, callback in pairs(core.registered_on_item_eats) do
+		local result = callback(hp_change, replace_with_item, itemstack, user, pointed_thing)
+		if result then
+			return result
+		end
+	end
+	if itemstack:take_item() ~= nil then
+		user:set_hp(user:get_hp() + hp_change)
+
+		if replace_with_item then
+			if itemstack:is_empty() then
+				itemstack:add_item(replace_with_item)
+			else
+				local inv = user:get_inventory()
+				if inv:room_for_item("main", {name=replace_with_item}) then
+					inv:add_item("main", replace_with_item)
+				else
+					local pos = user:getpos()
+					pos.y = math.floor(pos.y + 0.5)
+					core.add_item(pos, replace_with_item)
+				end
 			end
 		end
-		if itemstack:take_item() ~= nil then
-			user:set_hp(user:get_hp() + hp_change)
-			itemstack:add_item(replace_with_item) -- note: replace_with_item is optional
-		end
-		return itemstack
+	end
+	return itemstack
+end
+
+function core.item_eat(hp_change, replace_with_item)
+	return function(itemstack, user, pointed_thing)  -- closure
+		return core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
 	end
 end
 
@@ -425,7 +443,7 @@ function core.node_dig(pos, node, digger)
 
 	local wielded = digger:get_wielded_item()
 	local drops = core.get_node_drops(node.name, wielded:get_name())
-	
+
 	local wdef = wielded:get_definition()
 	local tp = wielded:get_tool_capabilities()
 	local dp = core.get_dig_params(def.groups, tp)
@@ -438,7 +456,7 @@ function core.node_dig(pos, node, digger)
 		end
 	end
 	digger:set_wielded_item(wielded)
-	
+
 	-- Handle drops
 	core.handle_node_drops(pos, drops, digger)
 
@@ -449,7 +467,7 @@ function core.node_dig(pos, node, digger)
 
 	-- Remove node and update
 	core.remove_node(pos)
-	
+
 	-- Run callback
 	if def.after_dig_node then
 		-- Copy pos and node because callback can modify them
@@ -507,7 +525,7 @@ core.nodedef_default = {
 	on_dig = redef_wrapper(core, 'node_dig'), -- core.node_dig
 
 	on_receive_fields = nil,
-	
+
 	on_metadata_inventory_move = core.node_metadata_inventory_move_allow_all,
 	on_metadata_inventory_offer = core.node_metadata_inventory_offer_allow_all,
 	on_metadata_inventory_take = core.node_metadata_inventory_take_allow_all,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -593,7 +593,7 @@ set to level from `param2`.
 Meshes
 ------
 If drawtype `mesh` is used, tiles should hold model materials textures.
-Only static meshes are implemented.  
+Only static meshes are implemented.
 For supported model formats see Irrlicht engine documentation.
 
 
@@ -688,7 +688,7 @@ The relative height of the sheet can be controlled by the same perlin noise as w
 a non-zero `scale` parameter in `noise_params`.
 
 **IMPORTANT**: The noise is not transformed by `offset` or `scale` when comparing against the noise
-threshold, but scale is used to determine relative height.  
+threshold, but scale is used to determine relative height.
 The height of the blob is randomly scattered, with a maximum height of `clust_size`.
 
 `clust_scarcity` and `clust_num_ores` are ignored.
@@ -696,7 +696,7 @@ The height of the blob is randomly scattered, with a maximum height of `clust_si
 This is essentially an improved version of the so-called "stratus" ore seen in some unofficial mods.
 
 ### `blob`
-Creates a deformed sphere of ore according to 3d perlin noise described by 
+Creates a deformed sphere of ore according to 3d perlin noise described by
 `noise_params`.  The maximum size of the blob is `clust_size`, and
 `clust_scarcity` has the same meaning as with the `scatter` type.
 ### `vein
@@ -1185,7 +1185,7 @@ Damage calculation:
 Client predicts damage based on damage groups. Because of this, it is able to
 give an immediate response when an entity is damaged or dies; the response is
 pre-defined somehow (e.g. by defining a sprite animation) (not implemented;
-TODO).  
+TODO).
 Currently a smoke puff will appear when an entity dies.
 
 The group `immortal` completely disables normal damage.
@@ -1926,6 +1926,8 @@ and `minetest.auth_reload` call the authetification handler.
 * `minetest.create_detached_inventory(name, callbacks)`: returns an `InvRef`
     * callbacks: See "Detached inventory callbacks"
     * Creates a detached inventory. If it already exists, it is cleared.
+* `minetest.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)`: returns left over ItemStack
+    * See `minetest.item_eat` and `minetest.register_on_item_eat`
 
 ### Formspec
 * `minetest.show_formspec(playername, formname, formspec)`
@@ -2037,7 +2039,11 @@ These functions return the leftover itemstack.
 * `minetest.item_drop(itemstack, dropper, pos)`
     * Drop the item
 * `minetest.item_eat(hp_change, replace_with_item)`
-    * Eat the item. `replace_with_item` can be `nil`.
+    * Eat the item.
+    * `replace_with_item` is the itemstring which is added to the inventory.
+      If the player is eating a stack, then replace_with_item goes to a
+      different spot. Can be `nil`
+    * See `minetest.do_item_eat`
 
 ### Defaults for the `on_punch` and `on_dig` node definition callbacks
 * `minetest.node_punch(pos, node, puncher, pointed_thing)`
@@ -2244,7 +2250,7 @@ Class reference
 ---------------
 
 ### `NodeMetaRef`
-Node metadata: reference extra data and functionality stored in a node.  
+Node metadata: reference extra data and functionality stored in a node.
 Can be gotten via `minetest.get_meta(pos)`.
 
 #### Methods
@@ -2260,7 +2266,7 @@ Can be gotten via `minetest.get_meta(pos)`.
     * See "Node Metadata"
 
 ### `NoteTimerRef`
-Node Timers: a high resolution persistent per-node timer.  
+Node Timers: a high resolution persistent per-node timer.
 Can be gotten via `minetest.get_node_timer(pos)`.
 
 #### Methods
@@ -2485,7 +2491,7 @@ It can be created via `PseudoRandom(seed)`.
 ### `PerlinNoise`
 A perlin noise generator.
 It can be created via `PerlinNoise(seed, octaves, persistence, scale)`
-or `PerlinNoise(noiseparams)`.  
+or `PerlinNoise(noiseparams)`.
 Alternatively with `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
 or `minetest.get_perlin(noiseparams)`.
 


### PR DESCRIPTION
When a stack is bigger than 1, it adds the replace_with_item to the inventory rather than to the stack, which overwrites them.

From a patch submitted to better hud by @tenplus1

BlockMen/hud/issues/14