### PR TITLE
Update zlib support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -211,10 +211,9 @@ VORBIS_DLL                      - Only if building with sound on Windows; path t
 VORBIS_INCLUDE_DIR              - Only if building with sound; directory that contains a directory vorbis with vorbisenc.h inside
 VORBIS_LIBRARY                  - Only if building with sound; path to libvorbis.a/libvorbis.so/libvorbis.dll.a
 XXF86VM_LIBRARY                 - Only on Linux; path to libXXf86vm.a/libXXf86vm.so
-ZLIB_DLL                        - Only on Windows; path to zlib1.dll
-ZLIBWAPI_DLL                    - Only on Windows; path to zlibwapi.dll
+ZLIB_DLL                        - Only on Windows; path to zlib.dll/zlibwapi.dll
 ZLIB_INCLUDE_DIR                - directory where zlib.h is located
-ZLIB_LIBRARY                    - path to libz.a/libz.so/zlibwapi.lib
+ZLIB_LIBRARY                    - path to libz.a/libz.so/zlib.lib/zlibwapi.lib
 
 Compiling on Windows:
 ---------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,13 +135,13 @@ if(WIN32)
 		set(PLATFORM_LIBS ws2_32.lib)
 	endif()
 	# Zlib stuff
-	set(ZLIB_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/../../zlib/zlib-1.2.5"
+	set(ZLIB_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/../../zlib/zlib-1.2.8"
 			CACHE PATH "Zlib include directory")
-	set(ZLIB_LIBRARIES "${PROJECT_SOURCE_DIR}/../../zlib125dll/dll32/zlibwapi.lib"
-			CACHE FILEPATH "Path to zlibwapi.lib")
-	set(ZLIB_DLL "${PROJECT_SOURCE_DIR}/../../zlib125dll/dll32/zlibwapi.dll"
-			CACHE FILEPATH "Path to zlibwapi.dll (for installation)")
-	set(IRRLICHT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../irrlicht-1.7.2"
+	set(ZLIB_LIBRARIES "${PROJECT_SOURCE_DIR}/../../zlib/zlib-1.2.8/Release/zlib.lib"
+			CACHE FILEPATH "Path to zlib.lib/zlibwapi.lib")
+	set(ZLIB_DLL "${PROJECT_SOURCE_DIR}/../../zlib/zlib-1.2.8/Release/zlib.dll"
+			CACHE FILEPATH "Path to zlib.dll/zlibwapi.dll (for installation)")
+	set(IRRLICHT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../irrlicht-1.8.1"
 			CACHE PATH "irrlicht dir")
 	if(USE_FREETYPE)
 		set(FREETYPE_INCLUDE_DIR_ft2build "${PROJECT_SOURCE_DIR}/../../freetype2/include/"
@@ -718,9 +718,6 @@ if(WIN32)
 	endif()
 	if(ZLIB_DLL)
 		install(FILES ${ZLIB_DLL} DESTINATION ${BINDIR})
-	endif()
-	if(ZLIBWAPI_DLL)
-		install(FILES ${ZLIBWAPI_DLL} DESTINATION ${BINDIR})
 	endif()
 	if(FREETYPE_DLL)
 		install(FILES ${FREETYPE_DLL} DESTINATION ${BINDIR})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	// This would get rid of the console window
 	//#pragma comment(linker, "/subsystem:windows /ENTRY:mainCRTStartup")
 #endif
-	#pragma comment(lib, "zlibwapi.lib")
 	#pragma comment(lib, "Shell32.lib")
 #endif
 


### PR DESCRIPTION
Allow using newer zlib versions on Windows


Tested with zlib 1.2.8 (MSVC compiler) on Windows XP