### PR TITLE
Fix font_size

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -252,16 +252,16 @@
 #freetype = true
 #    Path to TrueTypeFont or bitmap
 #font_path = fonts/liberationsans.ttf
-#font_size = 13
+#font_size = 15
 #    Font shadow offset, if 0 then shadow will not be drawn
 #font_shadow = 1
 #    Font shadow alpha (opaqueness, between 0 and 255)
 #font_shadow_alpha = 128
 #mono_font_path = fonts/liberationmono.ttf
-#mono_font_size = 13
+#mono_font_size = 15
 #    This font will be used for certain languages
 #fallback_font_path = fonts/DroidSansFallbackFull.ttf
-#fallback_font_size = 13
+#fallback_font_size = 15
 #fallback_font_shadow = 1
 #fallback_font_shadow_alpha = 128
 #    Override language. When no value is provided (default) system language is used.

--- a/src/constants.h
+++ b/src/constants.h
@@ -105,7 +105,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if defined(_WIN32)
 	#define TTF_DEFAULT_FONT_SIZE   (18)
 #else
-	#define TTF_DEFAULT_FONT_SIZE	(14)
+	#define TTF_DEFAULT_FONT_SIZE	(15)
 #endif
 #define DEFAULT_FONT_SIZE       (10)
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -100,7 +100,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
     GUI related things
 */
-#define TTF_DEFAULT_FONT_SIZE   (14)
+
+// TODO: implement dpi-based scaling for windows and remove this hack
+#if defined(_WIN32)
+	#define TTF_DEFAULT_FONT_SIZE   (18)
+#else
+	#define TTF_DEFAULT_FONT_SIZE	(14)
+#endif
 #define DEFAULT_FONT_SIZE       (10)
 
 #endif


### PR DESCRIPTION
Currently the font gets scaled really tiny, this restores font_size as know from 0.4.10 and before
![font_size](https://cloud.githubusercontent.com/assets/3742497/6199977/50199fae-b462-11e4-9baa-ad97b685b47c.png)
