### PR TITLE
Add an option to disallow guest connection (disabled by default)

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -333,6 +333,11 @@
 #    If this is set, players will always (re)spawn at the given position
 #static_spawnpoint = 0, 10, 0
 #    If true, new players cannot join with an empty password
+#disallow_guest_connection = false
+# If true, guests will not be allowed to connect to the server
+# Guests are defined by a playername starting with 'Guest' or 'guest'
+#min_playername_size = 3
+# Minimum size for playernames
 #disallow_empty_password = false
 #    If true, disable cheat prevention in multiplayer
 #disable_anticheat = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -227,6 +227,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("default_privs", "interact, shout");
 	settings->setDefault("player_transfer_distance", "0");
 	settings->setDefault("enable_pvp", "true");
+	settings->setDefault("disallow_guest_connection", "false");
+	settings->setDefault("min_playername_size", "3");
 	settings->setDefault("disallow_empty_password", "false");
 	settings->setDefault("disable_anticheat", "false");
 	settings->setDefault("enable_rollback_recording", "false");

--- a/src/network/packethandlers/server.cpp
+++ b/src/network/packethandlers/server.cpp
@@ -209,18 +209,35 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 		return;
 	}
 
-
-	if (playername[0]=='\0') {
+	if (playername[0] == '\0') {
 		actionstream << "Server: Player with an empty name "
 				<< "tried to connect from " << addr_s << std::endl;
 		DenyAccess(pkt->getPeerId(), L"Empty name");
 		return;
 	}
 
-	if (string_allowed(playername, PLAYERNAME_ALLOWED_CHARS) == false) {
+	if (!string_allowed(playername, PLAYERNAME_ALLOWED_CHARS)) {
 		actionstream << "Server: Player with an invalid name "
 				<< "tried to connect from " << addr_s << std::endl;
 		DenyAccess(pkt->getPeerId(), L"Name contains unallowed characters");
+		return;
+	}
+
+	if (strlen(playername) < g_settings->getU16("min_playername_size")) {
+		actionstream << "Server: Player with a too short name "
+				<< " tried to connect from " << addr_s << std::endl;
+		DenyAccess(pkt->getPeerId(), L"Your nickname is too short. "
+				L"Please choose a valid nickname.");
+		return;
+	}
+
+	if (g_settings->getBool("disallow_guest_connection") && (
+			strncmp(playername,"Guest",5) == 0 ||
+			strncmp(playername,"guest",5) == 0)) {
+		actionstream << "Server: Player with a guest name "
+				<< " tried to connect from " << addr_s << std::endl;
+		DenyAccess(pkt->getPeerId(), L"Guest nicknames are not allowed on "
+				L"this server. Please choose a valid nickname.");
 		return;
 	}
 


### PR DESCRIPTION
This add an option to prevent guest connection on the server. 
I know there is a mod to prevent it, but handling this in core is faster, as we could handle this on _INIT packet, mods cannot.
