### PR TITLE
Performance Improvement: Use a factory which caches result for getFacePositions.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -59,7 +59,7 @@ void RemoteClient::ResendBlockIfOnWire(v3s16 p)
 	}
 }
 
-void RemoteClient::GetNextBlocks(
+void RemoteClient::GetNextBlocks (
 		ServerEnvironment *env,
 		EmergeManager * emerge,
 		float dtime,
@@ -182,18 +182,15 @@ void RemoteClient::GetNextBlocks(
 	//bool queue_is_full = false;
 
 	s16 d;
-	for(d = d_start; d <= d_max; d++)
-	{
+	for(d = d_start; d <= d_max; d++) {
 		/*
 			Get the border/face dot coordinates of a "d-radiused"
 			box
 		*/
-		std::list<v3s16> list;
-		getFacePositions(list, d);
+		std::vector<v3s16> list = FacePositionCache::getFacePositions(d);
 
-		std::list<v3s16>::iterator li;
-		for(li=list.begin(); li!=list.end(); ++li)
-		{
+		std::vector<v3s16>::iterator li;
+		for(li = list.begin(); li != list.end(); ++li) {
 			v3s16 p = *li + center;
 
 			/*

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -530,9 +530,8 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 	}
 
 	for(int d=1; d<=radius; d++){
-		std::list<v3s16> list;
-		getFacePositions(list, d);
-		for(std::list<v3s16>::iterator i = list.begin();
+		std::vector<v3s16> list = FacePositionCache::getFacePositions(d);
+		for(std::vector<v3s16>::iterator i = list.begin();
 				i != list.end(); ++i){
 			v3s16 p = pos + (*i);
 			content_t c = env->getMap().getNodeNoEx(p).getContent();

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -25,10 +25,23 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../irr_v3d.h"
 #include "../irr_aabb3d.h"
 #include <list>
+#include <map>
+#include <vector>
 #include <algorithm>
 
-// Calculate the borders of a "d-radius" cube
-void getFacePositions(std::list<v3s16> &list, u16 d);
+
+/*
+ * This class permits to cache getFacePosition call results
+ * This reduces CPU usage and vector calls
+ */
+class FacePositionCache
+{
+public:
+	static std::vector<v3s16> getFacePositions(u16 d);
+private:
+	static void generateFacePosition(u16 d);
+	static std::map<u16, std::vector<v3s16> > m_cache;
+};
 
 class IndentationRaiser
 {


### PR DESCRIPTION

![capture d ecran de 2015-02-15 17 31 29](https://cloud.githubusercontent.com/assets/119752/6203940/5943d1e4-b539-11e4-89a5-d7d61e9818e7.png)
This greatly reduce the number of std::list generated by caching the result, which is always constant for each radius selected.
In the callgrind map, you will see original (right)
* 3.3M calls to std::list for 9700 calls to getFacePositions
In the modified version, you will see (left)
* 3.3K calls to std::list for 6900 call to getFacePositions

it's a huge performance improvement to l_find_node_near