### PR TITLE
[Patch 3/4] Network rework: Packet fixes & cleanups

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2959,7 +2959,7 @@ Definition tables
         liquid_range = 8, -- number of flowing nodes around source (max. 8)
         drowning = 0, -- Player will take this amount of damage if no bubbles are left
         light_source = 0, -- Amount of light emitted by node
-        damage_per_second = 0, -- If player is inside node, this damage is caused
+        damage_per_second = 0, -- If player is inside node, this damage(or heal) is caused
         node_box = {type="regular"}, -- See "Node boxes"
         mesh = "model",
         selection_box = {type="regular"}, -- See "Node boxes" --[[

--- a/src/client.h
+++ b/src/client.h
@@ -156,7 +156,7 @@ struct ClientEvent
 		//struct{
 		//} none;
 		struct{
-			u8 amount;
+			s16 amount;
 		} player_damage;
 		struct{
 			f32 pitch;
@@ -368,7 +368,6 @@ public:
 	void handleCommand_DeathScreen(NetworkPacket* pkt);
 	void handleCommand_AnnounceMedia(NetworkPacket* pkt);
 	void handleCommand_Media(NetworkPacket* pkt);
-	void handleCommand_ToolDef(NetworkPacket* pkt);
 	void handleCommand_NodeDef(NetworkPacket* pkt);
 	void handleCommand_CraftItemDef(NetworkPacket* pkt);
 	void handleCommand_ItemDef(NetworkPacket* pkt);
@@ -391,7 +390,7 @@ public:
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);
 
-	void ProcessData(u8 *data, u32 datasize, u16 sender_peer_id);
+	void ProcessData(NetworkPacket* pkt);
 
 	// Returns true if something was received
 	bool AsyncProcessPacket();
@@ -408,7 +407,7 @@ public:
 	void sendChatMessage(const std::wstring &message);
 	void sendChangePassword(const std::wstring &oldpassword,
 	                        const std::wstring &newpassword);
-	void sendDamage(u8 damage);
+	void sendDamage(s16 damage);
 	void sendBreath(u16 breath);
 	void sendRespawn();
 	void sendReady();
@@ -535,7 +534,6 @@ private:
 			bool is_local_server);
 
 	void ReceiveAll();
-	void Receive();
 
 	void sendPlayerPos();
 	// Send the item number 'item' as player item to the server

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -623,12 +623,9 @@ void ClientInterface::UpdatePlayerList()
 }
 
 void ClientInterface::send(u16 peer_id, u8 channelnum,
-		NetworkPacket* pkt, bool reliable, bool deletepkt)
+		NetworkPacket* pkt, bool reliable)
 {
 	m_con->Send(peer_id, channelnum, pkt, reliable);
-
-	if (deletepkt)
-		delete pkt;
 }
 
 void ClientInterface::sendToAll(u16 channelnum,
@@ -644,8 +641,6 @@ void ClientInterface::sendToAll(u16 channelnum,
 			m_con->Send(client->peer_id, channelnum, pkt, reliable);
 		}
 	}
-
-	delete pkt;
 }
 
 RemoteClient* ClientInterface::getClientNoEx(u16 peer_id, ClientState state_min)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -217,6 +217,7 @@ public:
 		m_version_minor(0),
 		m_version_patch(0),
 		m_full_version("unknown"),
+		m_supported_compressions(0),
 		m_connection_time(getTime(PRECISION_SECONDS))
 	{
 	}
@@ -308,6 +309,8 @@ public:
 		m_full_version = full;
 	}
 
+	void setSupportedCompressionModes(u8 byteFlag) { m_supported_compressions = byteFlag; }
+
 	/* read version information */
 	u8 getMajor() { return m_version_major; }
 	u8 getMinor() { return m_version_minor; }
@@ -370,6 +373,8 @@ private:
 
 	std::string m_full_version;
 
+	u8 m_supported_compressions;
+
 	/*
 		time this client was created
 	 */
@@ -394,7 +399,7 @@ public:
 	std::vector<std::string> getPlayerNames();
 
 	/* send message to client */
-	void send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable, bool deletepkt=true);
+	void send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
 
 	/* send to all clients */
 	void sendToAll(u16 channelnum, NetworkPacket* pkt, bool reliable);

--- a/src/environment.h
+++ b/src/environment.h
@@ -436,7 +436,7 @@ struct ClientEnvEvent
 		//struct{
 		//} none;
 		struct{
-			u8 amount;
+			s16 amount;
 			bool send_to_server;
 		} player_damage;
 		struct{
@@ -495,7 +495,7 @@ public:
 		Callbacks for activeobjects
 	*/
 
-	void damageLocalPlayer(u8 damage, bool handle_hp=true);
+	void damageLocalPlayer(s16 damage, bool handle_hp=true);
 	void updateLocalPlayerBreath(u16 breath);
 
 	/*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3036,16 +3036,17 @@ void Game::processClientEvents(CameraOrientation *cam, float *damage_flash)
 
 		if (event.type == CE_PLAYER_DAMAGE &&
 				client->getHP() != 0) {
-			//u16 damage = event.player_damage.amount;
+			//s16 damage = event.player_damage.amount;
 			//infostream<<"Player damage: "<<damage<<std::endl;
 
-			*damage_flash += 100.0;
-			*damage_flash += 8.0 * event.player_damage.amount;
+			if (event.player_damage.amount > 0) {
+				*damage_flash += 100.0;
+				*damage_flash += 8.0 * event.player_damage.amount;
 
-			player->hurt_tilt_timer = 1.5;
-			player->hurt_tilt_strength = event.player_damage.amount / 4;
-			player->hurt_tilt_strength = rangelim(player->hurt_tilt_strength, 1.0, 4.0);
-
+				player->hurt_tilt_timer = 1.5;
+				player->hurt_tilt_strength = event.player_damage.amount / 4;
+				player->hurt_tilt_strength = rangelim(player->hurt_tilt_strength, 1.0, 4.0);
+			}
 			MtEvent *e = new SimpleTriggerEvent("PlayerDamage");
 			gamedef->event()->put(e);
 		} else if (event.type == CE_PLAYER_FORCE_MOVE) {

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -81,9 +81,9 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_PLAYERITEM",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerItem }, // 0x36
 	{ "TOCLIENT_DEATHSCREEN",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeathScreen }, // 0x37
 	{ "TOCLIENT_MEDIA",                    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Media }, // 0x38
-	{ "TOCLIENT_TOOLDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ToolDef }, // 0x39
+	{ "TOCLIENT_TOOLDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Deprecated }, // 0x39
 	{ "TOCLIENT_NODEDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_NodeDef }, // 0x3a
-	{ "TOCLIENT_CRAFTITEMDEF",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CraftItemDef }, // 0x3b
+	{ "TOCLIENT_CRAFTITEMDEF",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Deprecated }, // 0x3b
 	{ "TOCLIENT_ANNOUNCE_MEDIA",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AnnounceMedia }, // 0x3c
 	{ "TOCLIENT_ITEMDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ItemDef }, // 0x3d
 	null_command_handler,

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -1032,7 +1032,7 @@ public:
 	void Connect(Address address);
 	bool Connected();
 	void Disconnect();
-	u32 Receive(u16 &peer_id, SharedBuffer<u8> &data);
+	NetworkPacket* Receive();
 	void Send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
 	u16 GetPeerID() { return m_peer_id; }
 	Address GetPeerAddress(u16 peer_id);

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -45,14 +45,9 @@ public:
 		NetworkPacket& operator>>(std::string& dst);
 		NetworkPacket& operator<<(std::string src);
 
-		void putLongString(std::string src);
-
 		NetworkPacket& operator>>(std::wstring& dst);
 		NetworkPacket& operator<<(std::wstring src);
 
-		std::string readLongString();
-
-		char getChar(u32 offset);
 		NetworkPacket& operator>>(char& dst);
 		NetworkPacket& operator<<(char src);
 

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -89,7 +89,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x3e
 	null_command_handler, // 0x3f
 	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia }, // 0x40
-	{ "TOSERVER_RECEIVED_MEDIA",           TOSERVER_STATE_STARTUP, &Server::handleCommand_ReceivedMedia }, // 0x41
+	{ "TOSERVER_RECEIVED_MEDIA",           TOSERVER_STATE_STARTUP, &Server::handleCommand_Deprecated }, // 0x41
 	{ "TOSERVER_BREATH",                   TOSERVER_STATE_INGAME, &Server::handleCommand_Breath }, // 0x42
 	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady }, // 0x43
 };

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -239,7 +239,8 @@ struct ContentFeatures
 	u8 drowning;
 	// Amount of light the node emits
 	u8 light_source;
-	u32 damage_per_second;
+	// damage/heal
+	s32 damage_per_second;
 	NodeBox node_box;
 	NodeBox selection_box;
 	NodeBox collision_box;

--- a/src/server.h
+++ b/src/server.h
@@ -200,7 +200,6 @@ public:
 	void handleCommand_Init(NetworkPacket* pkt);
 	void handleCommand_Init2(NetworkPacket* pkt);
 	void handleCommand_RequestMedia(NetworkPacket* pkt);
-	void handleCommand_ReceivedMedia(NetworkPacket* pkt);
 	void handleCommand_ClientReady(NetworkPacket* pkt);
 	void handleCommand_GotBlocks(NetworkPacket* pkt);
 	void handleCommand_PlayerPos(NetworkPacket* pkt);
@@ -217,7 +216,7 @@ public:
 	void handleCommand_NodeMetaFields(NetworkPacket* pkt);
 	void handleCommand_InventoryFields(NetworkPacket* pkt);
 
-	void ProcessData(u8 *data, u32 datasize, u16 peer_id);
+	void ProcessData(NetworkPacket* pkt);
 
 	void Send(NetworkPacket* pkt);
 
@@ -366,7 +365,8 @@ public:
 	void peerAdded(con::Peer *peer);
 	void deletingPeer(con::Peer *peer, bool timeout);
 
-	void DenyAccess(u16 peer_id, const std::wstring &reason);
+	void DenyAccess(u16 peer_id, AccessDeniedCode reason);
+	void DenyAccess(u16 peer_id, std::wstring reason);
 	bool getClientConInfo(u16 peer_id, con::rtt_stat_type type,float* retval);
 	bool getClientInfo(u16 peer_id,ClientState* state, u32* uptime,
 			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
@@ -383,7 +383,8 @@ private:
 	void SendMovement(u16 peer_id);
 	void SendHP(u16 peer_id, u8 hp);
 	void SendBreath(u16 peer_id, u16 breath);
-	void SendAccessDenied(u16 peer_id,const std::wstring &reason);
+	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason);
+	void SendAccessDenied(u16 peer_id, std::wstring reason);
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
 	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);


### PR DESCRIPTION
Cleanups:
* remove unhandled handlers and use deprecated handler
* remove some useless functions

Packet fixes:
* Rewrite TOCLIENT_DENYACCESS packet properly
* Fix DELETE_PARTICLESPAWNER
* Rewrite TOSERVER_INIT packet to use a dynamic size
* Rewrite TOSERVER_PASSWORD to use dynamic size

Misc:
* Connection::Receive function now uses NetworkPacket.