### PR TITLE
Add protocol version logic to master server

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -564,7 +564,7 @@ if INIT == "mainmenu" then
 		return nil
 	end
 
-	function fgettext(text, ...)
+	function fgettext_ne(text, ...)
 		text = core.gettext(text)
 		local arg = {n=select('#', ...), ...}
 		if arg.n >= 1 then
@@ -586,7 +586,11 @@ if INIT == "mainmenu" then
 			end
 			text = result
 		end
-		return core.formspec_escape(text)
+		return text
+	end
+
+	function fgettext(text, ...)
+		return core.formspec_escape(fgettext_ne(text, ...))
 	end
 end
 

--- a/builtin/mainmenu/tab_simple_main.lua
+++ b/builtin/mainmenu/tab_simple_main.lua
@@ -15,6 +15,9 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+local min_supp_proto = core.get_min_supp_proto()
+local max_supp_proto = core.get_max_supp_proto()
+
 --------------------------------------------------------------------------------
 local function get_formspec(tabview, name, tabdata)
 	local retval = ""
@@ -45,6 +48,7 @@ local function get_formspec(tabview, name, tabdata)
 			image_column(fgettext("Creative mode"), "creative") .. ",padding=1;" ..
 			image_column(fgettext("Damage enabled"), "damage") .. ",padding=0.25;" ..
 			image_column(fgettext("PvP enabled"), "pvp") .. ",padding=0.25;" ..
+			"color,span=1;" ..
 			"text,padding=1]"                               -- name
 	else
 		retval = retval .. "tablecolumns[text]"
@@ -159,6 +163,17 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 			gamedata.servername			= menudata.favorites[fav_idx].name
 			gamedata.serverdescription	= menudata.favorites[fav_idx].description
+
+			local proto_max = menudata.favorites[fav_idx].proto_max
+			local proto_min = menudata.favorites[fav_idx].proto_min
+			if proto_max and proto_min and
+				(min_supp_proto > proto_max or
+				max_supp_proto < proto_min) then
+				gamedata.errormessage = fgettext_ne("Protocol version mismatch, server " ..
+						((proto_min ~= proto_max) and "supports protocols between $1 and $2" or "enforces protocol version $1") ..
+						", we support protocols between $3 and $4.", proto_min, proto_max, min_supp_proto, max_supp_proto)
+				return true
+			end
 		else
 			gamedata.servername			= ""
 			gamedata.serverdescription	= ""

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -197,9 +197,11 @@ core.delete_world(index)
 Helpers:
 core.gettext(string) -> string
 ^ look up the translation of a string in the gettext message catalog
-fgettext(string, ...) -> string
+fgettext_ne(string, ...)
 ^ call core.gettext(string), replace "$1"..."$9" with the given
-^ extra arguments, call core.formspec_escape and return the result
+^ extra arguments and return the result
+fgettext(string, ...) -> string
+^ same as fgettext_ne(), but calls core.formspec_escape before returning result
 core.parse_json(string[, nullvalue]) -> something (possible in async calls)
 ^ see core.parse_json (lua_api.txt)
 dump(obj, dumped={})
@@ -210,6 +212,12 @@ string:trim()
 ^ eg. string.trim("\n \t\tfoo bar\t ") == "foo bar"
 core.is_yes(arg) (possible in async calls)
 ^ returns whether arg can be interpreted as yes
+
+Version compat:
+core.get_min_supp_proto()
+^ returns the minimum supported network protocol version
+core.get_max_supp_proto()
+^ returns the maximum supported network protocol version
 
 Async:
 core.handle_async(async_job,parameters,finished)

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -472,6 +472,7 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 	for (unsigned int i = 0; i < servers.size(); i++)
 	{
+
 		lua_pushnumber(L,index);
 
 		lua_newtable(L);
@@ -506,6 +507,18 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 			lua_pushstring(L,"version");
 			std::string topush = servers[i]["version"].asString();
 			lua_pushstring(L,topush.c_str());
+			lua_settable(L, top_lvl2);
+		}
+
+		if (servers[i]["proto_min"].asString().size()) {
+			lua_pushstring(L,"proto_min");
+			lua_pushinteger(L,servers[i]["proto_min"].asInt());
+			lua_settable(L, top_lvl2);
+		}
+
+		if (servers[i]["proto_max"].asString().size()) {
+			lua_pushstring(L,"proto_max");
+			lua_pushinteger(L,servers[i]["proto_max"].asInt());
 			lua_settable(L, top_lvl2);
 		}
 
@@ -1083,6 +1096,19 @@ int ModApiMainMenu::l_get_screen_info(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_get_min_supp_proto(lua_State *L)
+{
+	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MIN);
+	return 1;
+}
+
+int ModApiMainMenu::l_get_max_supp_proto(lua_State *L)
+{
+	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MAX);
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_do_async_callback(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
@@ -1142,6 +1168,8 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
 	API_FCT(get_screen_info);
+	API_FCT(get_min_supp_proto);
+	API_FCT(get_max_supp_proto);
 	API_FCT(do_async_callback);
 }
 

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -137,6 +137,12 @@ private:
 
 	static int l_get_video_drivers(lua_State *L);
 
+	//version compatibility
+	static int l_get_min_supp_proto(lua_State *L);
+
+	static int l_get_max_supp_proto(lua_State *L);
+
+
 	// async
 	static int l_do_async_callback(lua_State *L);
 


### PR DESCRIPTION
#2327 breaks protocol. Currently, the server list has no feature to distinguish between supported servers with a compatible version, and those witout. This PR enables server to send protocol version, and makes client filter for protocol version. This commit should go to the freeze branch to, as @ShadowNinja suggested, not make two masterserver lists, one for clients which distinguish after protocol version, and one for clients which don't, but only have one production master server instance.