### PR TITLE
Change minimum viewing range with constant speed, even when the framerate is low

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -76,6 +76,8 @@
 #    The allowed adjustment range for the automatic rendering range adjustment
 #viewing_range_nodes_max = 160
 #viewing_range_nodes_min = 35
+#    Speed by which the minimum viewing range is increased / decreased when adjusting it
+#viewing_range_change_speed = 300
 #    Initial window size
 #screenW = 800
 #screenH = 600

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -92,6 +92,7 @@ void set_default_settings(Settings *settings)
 	// A bit more than the server will send around the player, to make fog blend well
 	settings->setDefault("viewing_range_nodes_max", "240");
 	settings->setDefault("viewing_range_nodes_min", "35");
+	settings->setDefault("viewing_range_change_speed", "300");
 	settings->setDefault("screenW", "800");
 	settings->setDefault("screenH", "600");
 	settings->setDefault("fullscreen", "false");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1483,7 +1483,8 @@ protected:
 			float *jump_timer,
 			bool *reset_jump_timer,
 			u32 *profiler_current_page,
-			u32 profiler_max_page);
+			u32 profiler_max_page,
+			f32 dtime);
 	void processItemSelection(u16 *new_playeritem);
 
 	void dropSelectedItem();
@@ -1503,8 +1504,8 @@ protected:
 	void toggleProfiler(float *statustext_time, u32 *profiler_current_page,
 			u32 profiler_max_page);
 
-	void increaseViewRange(float *statustext_time);
-	void decreaseViewRange(float *statustext_time);
+	void increaseViewRange(float *statustext_time, f32 dtime);
+	void decreaseViewRange(float *statustext_time, f32 dtime);
 	void toggleFullViewRange(float *statustext_time);
 
 	void updateCameraDirection(CameraOrientation *cam, VolatileRunFlags *flags);
@@ -2524,7 +2525,8 @@ void Game::processUserInput(VolatileRunFlags *flags,
 			&interact_args->jump_timer,
 			&interact_args->reset_jump_timer,
 			&interact_args->profiler_current_page,
-			interact_args->profiler_max_page);
+			interact_args->profiler_max_page,
+			dtime);
 
 	processItemSelection(&interact_args->new_playeritem);
 }
@@ -2535,7 +2537,8 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 		float *jump_timer,
 		bool *reset_jump_timer,
 		u32 *profiler_current_page,
-		u32 profiler_max_page)
+		u32 profiler_max_page,
+		f32 dtime)
 {
 
 	//TimeTaker tt("process kybd input", NULL, PRECISION_NANO);
@@ -2579,9 +2582,9 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_TOGGLE_PROFILER])) {
 		toggleProfiler(statustext_time, profiler_current_page, profiler_max_page);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_INCREASE_VIEWING_RANGE])) {
-		increaseViewRange(statustext_time);
+		increaseViewRange(statustext_time, dtime);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_DECREASE_VIEWING_RANGE])) {
-		decreaseViewRange(statustext_time);
+		decreaseViewRange(statustext_time, dtime);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_RANGESELECT])) {
 		toggleFullViewRange(statustext_time);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_QUICKTUNE_NEXT]))
@@ -2839,10 +2842,14 @@ void Game::toggleProfiler(float *statustext_time, u32 *profiler_current_page,
 }
 
 
-void Game::increaseViewRange(float *statustext_time)
+void Game::increaseViewRange(float *statustext_time, f32 dtime)
 {
 	s16 range = g_settings->getS16("viewing_range_nodes_min");
-	s16 range_new = range + 10;
+	s16 speed = g_settings->getS16("viewing_range_change_speed");
+	s16 rate = speed * dtime;
+
+	s16 range_new = range + (rate <= 10 ? 10 : (rate - rate % 10));
+
 	g_settings->set("viewing_range_nodes_min", itos(range_new));
 	statustext = narrow_to_wide("Minimum viewing range changed to "
 			+ itos(range_new));
@@ -2850,13 +2857,14 @@ void Game::increaseViewRange(float *statustext_time)
 }
 
 
-void Game::decreaseViewRange(float *statustext_time)
+void Game::decreaseViewRange(float *statustext_time, f32 dtime)
 {
 	s16 range = g_settings->getS16("viewing_range_nodes_min");
-	s16 range_new = range - 10;
+	s16 speed = g_settings->getS16("viewing_range_change_speed");
+	s16 rate = speed * dtime;
 
-	if (range_new < 0)
-		range_new = range;
+	s16 range_new = range - (rate <= 10 ? 10 : (rate - rate % 10));
+	if (range_new <= 0) range_new = range;
 
 	g_settings->set("viewing_range_nodes_min", itos(range_new));
 	statustext = narrow_to_wide("Minimum viewing range changed to "


### PR DESCRIPTION
When you turn your viewing range to a very high value (with +/- keys) and the framerate gets low, it takes some time do decrease the viewing range again, as the range is always only decreased by 10 per frame, no matter what framerate you actually have.
With this pull request, this behaviour stays just the same for high framerates (~ >30fps). If, however, the framerate drops too far, the viewing range is changed by `viewing_range_change_speed` (setting, default is 300) per second (rounded to a multiple of ten).
That way, you can easily increase and decrease the viewing range, even if the game lags badly.