### PR TITLE
Improve FindIrrlicht.cmake module

### DIFF
--- a/cmake/Modules/FindIrrlicht.cmake
+++ b/cmake/Modules/FindIrrlicht.cmake
@@ -44,7 +44,7 @@ else()
 		/usr/include/irrlicht
 	)
 
-	FIND_LIBRARY(IRRLICHT_LIBRARY NAMES libIrrlicht.a Irrlicht
+	FIND_LIBRARY(IRRLICHT_LIBRARY NAMES libIrrlicht.so libIrrlicht.a Irrlicht
 		PATHS
 		/usr/local/lib
 		/usr/lib


### PR DESCRIPTION
Linux distributions prefer to link against a shared version of the Irrlicht
engine instead of using embedded code copies. Search for this
shared version first and use that but fall back to the static version if it
does not exist.

This also fixes https://github.com/minetest/minetest/issues/2163