### PR TITLE
Add find_surface_nodes_in_area Lua call which permit to only get the nodes which are under air nodes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1849,6 +1849,9 @@ and `minetest.auth_reload` call the authetification handler.
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
 * `minetest.find_nodes_in_area(minp, maxp, nodenames)`: returns a list of positions
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
+* `minetest.find_surface_nodes_in_area(minp, maxp, nodenames)`: returns a list of positions
+    * returned positions are nodes with a node air above
+    * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
 * `minetest.get_perlin(noiseparams)`
 * `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
     * Return world-specific perlin noise (`int(worldseed)+seeddiff`)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -119,6 +119,10 @@ private:
 	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
 	static int l_find_nodes_in_area(lua_State *L);
 
+	// find_surface_nodes_in_area(minp, maxp, nodenames) -> list of positions
+	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
+	static int l_find_surface_nodes_in_area(lua_State *L);
+
 	// delete_area(p1, p2) -> true/false
 	static int l_delete_area(lua_State *L);
 


### PR DESCRIPTION
This permit to massively improve performance for mods like plantlife which needs to only know surface nodes

requested by @VanessaE 
