### PR TITLE
Remap Mouse and Key Buttons

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -37,6 +37,8 @@
 #keymap_backward = KEY_KEY_S
 #keymap_left = KEY_KEY_A
 #keymap_right = KEY_KEY_D
+#keymap_dig = KEY_LBUTTON
+#keymap_place = KEY_RBUTTON
 #keymap_jump = KEY_SPACE
 #keymap_sneak = KEY_LSHIFT
 #keymap_inventory = KEY_KEY_I

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -41,13 +41,24 @@ public:
 		}
 
 		// Remember whether each key is down or up
+		// Get the Key that triggered the Event
+
 		if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
-			if (event.KeyInput.PressedDown) {
+      			bool down = event.KeyInput.PressedDown;
+
+		  	if (down) {
+			     	if (keyIsDown[event.KeyInput]) {
+					keyPressed.set(event.KeyInput);
+			     	}
+				keyDown.set(event.KeyInput);
 				keyIsDown.set(event.KeyInput);
 				keyWasDown.set(event.KeyInput);
-			} else {
-				keyIsDown.unset(event.KeyInput);
-			}
+		  	} else {
+		     		keyDown.unset(event.KeyInput);
+		     		keyIsDown.unset(event.KeyInput);
+	     			keyPressed.unset(event.KeyInput);
+				keyReleased.set(event.KeyInput);	
+		  	}
 		}
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -60,32 +71,59 @@ public:
 #endif
 		// handle mouse events
 		if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
-			if (noMenuActive() == false) {
-				left_active = false;
-				middle_active = false;
-				right_active = false;
-			} else {
-				left_active = event.MouseInput.isLeftPressed();
-				middle_active = event.MouseInput.isMiddlePressed();
-				right_active = event.MouseInput.isRightPressed();
+			// handle mouse buttons
+			// left
+			if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+			     	if (keyIsDown["KEY_LBUTTON"]) {
+					keyPressed.set("KEY_LBUTTON");
+			     	}
+				keyDown.set("KEY_LBUTTON");
+				keyIsDown.set("KEY_LBUTTON");
+				keyWasDown.set("KEY_LBUTTON");
+		  	} else if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
+		     		keyDown.unset("KEY_LBUTTON");
+		     		keyIsDown.unset("KEY_LBUTTON");
+	     			keyPressed.unset("KEY_LBUTTON");
+				keyReleased.set("KEY_LBUTTON");	
+		  	}
 
-				if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
-					leftclicked = true;
-				}
-				if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
-					rightclicked = true;
-				}
-				if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
-					leftreleased = true;
-				}
-				if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
-					rightreleased = true;
-				}
+			// right
+			else if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
+			     	if (keyIsDown["KEY_RBUTTON"]) {
+					keyPressed.set("KEY_RBUTTON");
+			     	}
+				keyDown.set("KEY_RBUTTON");
+				keyIsDown.set("KEY_RBUTTON");
+				keyWasDown.set("KEY_RBUTTON");
+		  	} else if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
+		     		keyDown.unset("KEY_RBUTTON");
+		     		keyIsDown.unset("KEY_RBUTTON");
+	     			keyPressed.unset("KEY_RBUTTON");
+				keyReleased.set("KEY_RBUTTON");	
+		  	}
+
+			// middle
+			else if (event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN) {
+			     	if (keyIsDown["KEY_MBUTTON"]) {
+					keyPressed.set("KEY_MBUTTON");
+			     	}
+				keyDown.set("KEY_MBUTTON");
+				keyIsDown.set("KEY_MBUTTON");
+				keyWasDown.set("KEY_MBUTTON");
+		  	} else if (event.MouseInput.Event == EMIE_MMOUSE_LEFT_UP) {
+		     		keyDown.unset("KEY_MBUTTON");
+		     		keyIsDown.set("KEY_MBUTTON");
+	     			keyPressed.unset("KEY_MBUTTON");
+				keyReleased.set("KEY_MBUTTON");	
+		  	}
+
+		  	else if (noMenuActive()) {
 				if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
 					mouse_wheel += event.MouseInput.Wheel;
 				}
 			}
 		}
+
 		if (event.EventType == irr::EET_LOG_TEXT_EVENT) {
 			dstream << std::string("Irrlicht log: ") + std::string(event.LogEvent.Text)
 			        << std::endl;
@@ -97,7 +135,17 @@ public:
 
 	bool IsKeyDown(const KeyPress &keyCode) const
 	{
-		return keyIsDown[keyCode];
+		return keyDown[keyCode];
+	}
+	
+	bool IsKeyActive(const KeyPress &keyCode) const
+	{
+		return keyPressed[keyCode] || keyIsDown[keyCode];
+	}
+
+	bool IsKeyReleased(const KeyPress &keyCode) const
+	{
+		return keyReleased[keyCode];
 	}
 
 	// Checks whether a key was down and resets the state
@@ -109,6 +157,16 @@ public:
 		return b;
 	}
 
+	void resetKeyClicked(const KeyPress &keyCode)
+	{
+		keyDown.unset(keyCode);
+	}
+
+	void resetKeyReleased(const KeyPress &keyCode)
+	{
+		keyReleased.unset(keyCode);
+	}
+
 	s32 getMouseWheel()
 	{
 		s32 a = mouse_wheel;
@@ -118,17 +176,11 @@ public:
 
 	void clearInput()
 	{
+		keyDown.clear();
 		keyIsDown.clear();
 		keyWasDown.clear();
-
-		leftclicked = false;
-		rightclicked = false;
-		leftreleased = false;
-		rightreleased = false;
-
-		left_active = false;
-		middle_active = false;
-		right_active = false;
+		keyReleased.clear();
+		keyPressed.clear();
 
 		mouse_wheel = 0;
 	}
@@ -141,15 +193,6 @@ public:
 #endif
 	}
 
-	bool leftclicked;
-	bool rightclicked;
-	bool leftreleased;
-	bool rightreleased;
-
-	bool left_active;
-	bool middle_active;
-	bool right_active;
-
 	s32 mouse_wheel;
 
 #ifdef HAVE_TOUCHSCREENGUI
@@ -158,7 +201,10 @@ public:
 
 private:
 	// The current state of keys
+	KeyList keyDown;
 	KeyList keyIsDown;
+	KeyList keyPressed;
+   	KeyList keyReleased;
 	// Whether a key has been pressed or not
 	KeyList keyWasDown;
 };
@@ -185,12 +231,28 @@ public:
 	{
 		return m_receiver->WasKeyDown(keyCode);
 	}
+	virtual bool getKeyState(const KeyPress &keyCode)
+	{
+		return m_receiver->IsKeyActive(keyCode);
+	}
+	virtual bool getKeyReleased(const KeyPress &keyCode)
+	{
+		return m_receiver->IsKeyReleased(keyCode);
+	}
+	virtual void resetKeyClicked(const KeyPress &keyCode)
+	{
+		m_receiver->resetKeyClicked(keyCode);
+	}
+	virtual void resetKeyReleased(const KeyPress &keyCode)
+	{
+		m_receiver->resetKeyReleased(keyCode);
+	}
+
 	virtual v2s32 getMousePos()
 	{
 		if (m_device->getCursorControl()) {
 			return m_device->getCursorControl()->getPosition();
-		}
-		else {
+		} else {
 			return m_mousepos;
 		}
 	}
@@ -198,53 +260,9 @@ public:
 	{
 		if (m_device->getCursorControl()) {
 			m_device->getCursorControl()->setPosition(x, y);
-		}
-		else {
+		} else {
 			m_mousepos = v2s32(x,y);
 		}
-	}
-
-	virtual bool getLeftState()
-	{
-		return m_receiver->left_active;
-	}
-	virtual bool getRightState()
-	{
-		return m_receiver->right_active;
-	}
-
-	virtual bool getLeftClicked()
-	{
-		return m_receiver->leftclicked;
-	}
-	virtual bool getRightClicked()
-	{
-		return m_receiver->rightclicked;
-	}
-	virtual void resetLeftClicked()
-	{
-		m_receiver->leftclicked = false;
-	}
-	virtual void resetRightClicked()
-	{
-		m_receiver->rightclicked = false;
-	}
-
-	virtual bool getLeftReleased()
-	{
-		return m_receiver->leftreleased;
-	}
-	virtual bool getRightReleased()
-	{
-		return m_receiver->rightreleased;
-	}
-	virtual void resetLeftReleased()
-	{
-		m_receiver->leftreleased = false;
-	}
-	virtual void resetRightReleased()
-	{
-		m_receiver->rightreleased = false;
 	}
 
 	virtual s32 getMouseWheel()
@@ -269,20 +287,80 @@ public:
 	{
 		leftdown = false;
 		rightdown = false;
+		middledown = false;
 		leftclicked = false;
 		rightclicked = false;
+		middleclicked = false;
 		leftreleased = false;
 		rightreleased = false;
+		middlereleased = false;
 		keydown.clear();
 	}
 	virtual bool isKeyDown(const KeyPress &keyCode)
 	{
+		if (keyCode == getKeySetting("keymap_dig")) {
+			return leftclicked;
+		}
+		else if (keyCode == getKeySetting("keymap_place")) {
+			return rightclicked;
+		} /*else if (keyCode == getKeySetting("keymap_middle")) {
+			return middleclicked;
+		}*/
 		return keydown[keyCode];
 	}
 	virtual bool wasKeyDown(const KeyPress &keyCode)
 	{
 		return false;
 	}
+	virtual bool getKeyState(const KeyPress &keyCode)
+	{
+		if (keyCode == getKeySetting("keymap_dig")) {
+			return leftdown;
+		} else if (keyCode == getKeySetting("keymap_place")) {
+			return rightdown;
+		} /*else if (keyCode == getKeySetting("keymap_middle")) {
+			return middledown;
+		}*/
+		return false;
+	}
+	virtual bool getKeyReleased(const KeyPress &keyCode)
+	{
+		if (keyCode == getKeySetting("keymap_dig")) {
+			return leftreleased;
+		} else if (keyCode == getKeySetting("keymap_place")) {
+			return rightreleased;
+		} /*else if (keyCode == getKeySetting("keymap_middle")) {
+			return middlereleased;
+		}*/
+		return false;
+	}
+	virtual void resetKeyClicked(const KeyPress &keyCode)
+	{
+		if (keyCode == getKeySetting("keymap_dig")) {
+			leftclicked = false;
+			return;
+		} else if (keyCode == getKeySetting("keymap_place")) {
+			rightclicked = false;
+			return;
+		} /*else if (keyCode == getKeySetting("keymap_middle")) {
+			middleclicked = false;
+			return;
+		}*/
+	}
+	virtual void resetKeyReleased(const KeyPress &keyCode)
+	{
+		if (keyCode == getKeySetting("keymap_dig")) {
+			leftreleased = false;
+			return;
+		} else if (keyCode == getKeySetting("keymap_place")) {
+			rightreleased = false;
+			return;
+		} /*else if (keyCode == getKeySetting("keymap_middle")) {
+			middlereleased = false;
+			return;
+		}*/
+	}
+
 	virtual v2s32 getMousePos()
 	{
 		return mousepos;
@@ -291,50 +369,6 @@ public:
 	{
 		mousepos = v2s32(x, y);
 	}
-
-	virtual bool getLeftState()
-	{
-		return leftdown;
-	}
-	virtual bool getRightState()
-	{
-		return rightdown;
-	}
-
-	virtual bool getLeftClicked()
-	{
-		return leftclicked;
-	}
-	virtual bool getRightClicked()
-	{
-		return rightclicked;
-	}
-	virtual void resetLeftClicked()
-	{
-		leftclicked = false;
-	}
-	virtual void resetRightClicked()
-	{
-		rightclicked = false;
-	}
-
-	virtual bool getLeftReleased()
-	{
-		return leftreleased;
-	}
-	virtual bool getRightReleased()
-	{
-		return rightreleased;
-	}
-	virtual void resetLeftReleased()
-	{
-		leftreleased = false;
-	}
-	virtual void resetRightReleased()
-	{
-		rightreleased = false;
-	}
-
 	virtual s32 getMouseWheel()
 	{
 		return 0;
@@ -406,6 +440,18 @@ public:
 					rightreleased = true;
 			}
 		}
+		{
+			static float counter1 = 0;
+			counter1 -= dtime;
+			if (counter1 < 0.0) {
+				counter1 = 0.1 * Rand(1, 45);
+				middledown = !middledown;
+				if (middledown)
+					middleclicked = true;
+				if (!middledown)
+					middlereleased = true;
+			}
+		}
 		mousepos += mousespeed;
 	}
 
@@ -419,10 +465,13 @@ private:
 	v2s32 mousespeed;
 	bool leftdown;
 	bool rightdown;
+	bool middledown;
 	bool leftclicked;
 	bool rightclicked;
+	bool middleclicked;
 	bool leftreleased;
 	bool rightreleased;
+	bool middlereleased;
 };
 
 #endif

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -32,6 +32,8 @@ void set_default_settings(Settings *settings)
 
 	// Client stuff
 	settings->setDefault("remote_port", "30000");
+	settings->setDefault("keymap_dig", "KEY_LBUTTON");
+	settings->setDefault("keymap_place", "KEY_RBUTTON");
 	settings->setDefault("keymap_forward", "KEY_KEY_W");
 	settings->setDefault("keymap_backward", "KEY_KEY_S");
 	settings->setDefault("keymap_left", "KEY_KEY_A");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1220,6 +1220,10 @@ struct KeyCache {
 	KeyCache() { populate(); }
 
 	enum {
+		// Player interaction
+		KEYMAP_ID_DIG,
+		KEYMAP_ID_PLACE,
+
 		// Player movement
 		KEYMAP_ID_FORWARD,
 		KEYMAP_ID_BACKWARD,
@@ -1271,6 +1275,9 @@ struct KeyCache {
 
 void KeyCache::populate()
 {
+	key[KEYMAP_ID_DIG]      = getKeySetting("keymap_dig");
+	key[KEYMAP_ID_PLACE]      = getKeySetting("keymap_place");
+
 	key[KEYMAP_ID_FORWARD]      = getKeySetting("keymap_forward");
 	key[KEYMAP_ID_BACKWARD]     = getKeySetting("keymap_backward");
 	key[KEYMAP_ID_LEFT]         = getKeySetting("keymap_left");
@@ -2964,8 +2971,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_JUMP]),
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]),
 		input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SNEAK]),
-		input->getLeftState(),
-		input->getRightState(),
+		input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG]),
+		input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_PLACE]),
 		cam.camera_pitch,
 		cam.camera_yaw
 	);
@@ -2978,8 +2985,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 			( (u32)(input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_JUMP])     & 0x1) << 4) |
 			( (u32)(input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]) & 0x1) << 5) |
 			( (u32)(input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_SNEAK])    & 0x1) << 6) |
-			( (u32)(input->getLeftState()                                        & 0x1) << 7) |
-			( (u32)(input->getRightState()                                       & 0x1) << 8
+			( (u32)(input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])    & 0x1) << 7) |
+			( (u32)(input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_PLACE])  & 0x1) << 8
 		);
 
 #ifdef ANDROID
@@ -3404,7 +3411,7 @@ void Game::processPlayerInteraction(std::vector<aabb3f> &highlight_boxes,
 		- pointing away from node
 	*/
 	if (runData->digging) {
-		if (input->getLeftReleased()) {
+		if (input->getKeyReleased(keycache.key[KeyCache::KEYMAP_ID_DIG])) {
 			infostream << "Left button released"
 			           << " (stopped digging)" << std::endl;
 			runData->digging = false;
@@ -3429,7 +3436,7 @@ void Game::processPlayerInteraction(std::vector<aabb3f> &highlight_boxes,
 		}
 	}
 
-	if (!runData->digging && runData->ldown_for_dig && !input->getLeftState()) {
+	if (!runData->digging && runData->ldown_for_dig && !input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])) {
 		runData->ldown_for_dig = false;
 	}
 
@@ -3437,13 +3444,13 @@ void Game::processPlayerInteraction(std::vector<aabb3f> &highlight_boxes,
 
 	soundmaker->m_player_leftpunch_sound.name = "";
 
-	if (input->getRightState())
+	if (input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_PLACE]))
 		runData->repeat_rightclick_timer += dtime;
 	else
 		runData->repeat_rightclick_timer = 0;
 
-	if (playeritem_def.usable && input->getLeftState()) {
-		if (input->getLeftClicked())
+	if (playeritem_def.usable && input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])) {
+		if (input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_DIG]))
 			client->interact(4, pointed);
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		ToolCapabilities playeritem_toolcap =
@@ -3453,21 +3460,21 @@ void Game::processPlayerInteraction(std::vector<aabb3f> &highlight_boxes,
 	} else if (pointed.type == POINTEDTHING_OBJECT) {
 		handlePointingAtObject(runData, pointed, playeritem,
 				player_position, show_debug);
-	} else if (input->getLeftState()) {
+	} else if (input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])) {
 		// When button is held down in air, show continuous animation
 		runData->left_punch = true;
 	}
 
 	runData->pointed_old = pointed;
 
-	if (runData->left_punch || input->getLeftClicked())
+	if (runData->left_punch || input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_DIG]))
 		camera->setDigging(0); // left click animation
 
-	input->resetLeftClicked();
-	input->resetRightClicked();
+	input->resetKeyClicked(keycache.key[KeyCache::KEYMAP_ID_DIG]);
+	input->resetKeyClicked(keycache.key[KeyCache::KEYMAP_ID_PLACE]);
 
-	input->resetLeftReleased();
-	input->resetRightReleased();
+	input->resetKeyReleased(keycache.key[KeyCache::KEYMAP_ID_DIG]);
+	input->resetKeyReleased(keycache.key[KeyCache::KEYMAP_ID_PLACE]);
 }
 
 
@@ -3496,12 +3503,12 @@ void Game::handlePointingAtNode(GameRunData *runData,
 		}
 	}
 
-	if (runData->nodig_delay_timer <= 0.0 && input->getLeftState()
+	if (runData->nodig_delay_timer <= 0.0 && input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])
 			&& client->checkPrivilege("interact")) {
 		handleDigging(runData, pointed, nodepos, playeritem_toolcap, dtime);
 	}
 
-	if ((input->getRightClicked() ||
+	if ((input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_PLACE]) ||
 			runData->repeat_rightclick_timer >= m_repeat_right_click_time) &&
 			client->checkPrivilege("interact")) {
 		runData->repeat_rightclick_timer = 0;
@@ -3564,7 +3571,7 @@ void Game::handlePointingAtObject(GameRunData *runData,
 		infotext = narrow_to_wide(runData->selected_object->debugInfoText());
 	}
 
-	if (input->getLeftState()) {
+	if (input->getKeyState(keycache.key[KeyCache::KEYMAP_ID_DIG])) {
 		bool do_punch = false;
 		bool do_punch_damage = false;
 
@@ -3574,7 +3581,7 @@ void Game::handlePointingAtObject(GameRunData *runData,
 			runData->object_hit_delay_timer = object_hit_delay;
 		}
 
-		if (input->getLeftClicked())
+		if (input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_DIG]))
 			do_punch = true;
 
 		if (do_punch) {
@@ -3594,7 +3601,7 @@ void Game::handlePointingAtObject(GameRunData *runData,
 			if (!disable_send)
 				client->interact(0, pointed);
 		}
-	} else if (input->getRightClicked()) {
+	} else if (input->isKeyDown(keycache.key[KeyCache::KEYMAP_ID_PLACE])) {
 		infostream << "Right-clicked object" << std::endl;
 		client->interact(3, pointed);  // place
 	}

--- a/src/game.h
+++ b/src/game.h
@@ -109,22 +109,13 @@ public:
 
 	virtual bool isKeyDown(const KeyPress &keyCode) = 0;
 	virtual bool wasKeyDown(const KeyPress &keyCode) = 0;
+	virtual bool getKeyState(const KeyPress &keyCode) = 0;
+	virtual bool getKeyReleased(const KeyPress &keyCode) = 0;
+	virtual void resetKeyClicked(const KeyPress &keyCode) = 0;
+	virtual void resetKeyReleased(const KeyPress &keyCode) = 0;
 
 	virtual v2s32 getMousePos() = 0;
 	virtual void setMousePos(s32 x, s32 y) = 0;
-
-	virtual bool getLeftState() = 0;
-	virtual bool getRightState() = 0;
-
-	virtual bool getLeftClicked() = 0;
-	virtual bool getRightClicked() = 0;
-	virtual void resetLeftClicked() = 0;
-	virtual void resetRightClicked() = 0;
-
-	virtual bool getLeftReleased() = 0;
-	virtual bool getRightReleased() = 0;
-	virtual void resetLeftReleased() = 0;
-	virtual void resetRightReleased() = 0;
 
 	virtual s32 getMouseWheel() = 0;
 


### PR DESCRIPTION
fixes #2361 

Remap mouse buttons in keychange menu.
Mouse Button Events are now handled like key button events.
