### PR TITLE
Biome API: Re-calculate biome at every new surface in mapchunk column

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -93,7 +93,7 @@ public:
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	int generateBaseTerrain();
-	void generateBiomes();
+	void generateBiomes(float *heat_map, float *humidity_map);
 	void generateCaves(int max_stone_y);
 	void dustTopNodes();
 };

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -239,14 +239,15 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	// Generate base terrain, mountains, and ridges with initial heightmaps
 	s16 stone_surface_max_y = generateTerrain();
 
+	// Create heightmap
 	updateHeightmap(node_min, node_max);
 
-	// Calculate biomes
+	// Create biomemap at heightmap surface
 	bmgr->calcBiomes(csize.X, csize.Z, noise_heat->result,
 		noise_humidity->result, heightmap, biomemap);
 
-	// Actually place the biome-specific nodes and what not
-	generateBiomes();
+	// Actually place the biome-specific nodes
+	generateBiomes(noise_heat->result, noise_humidity->result);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y);
@@ -534,7 +535,7 @@ void MapgenV7::generateRidgeTerrain()
 }
 
 
-void MapgenV7::generateBiomes()
+void MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 {
 	if (node_max.Y < water_level)
 		return;
@@ -548,12 +549,11 @@ void MapgenV7::generateBiomes()
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
-		Biome *biome        = (Biome *)bmgr->get(biomemap[index]);
-		s16 dfiller         = biome->depth_filler + noise_filler_depth->result[index];
-		s16 y0_top          = biome->depth_top;
-		s16 y0_filler       = biome->depth_top + dfiller;
-		s16 shore_max       = water_level + biome->height_shore;
-		s16 depth_water_top = biome->depth_water_top;
+		Biome *biome = NULL;
+		s16 dfiller = 0;
+		s16 y0_top = 0;
+		s16 y0_filler = 0;
+		s16 depth_water_top = 0;
 
 		s16 nplaced = 0;
 		u32 i = vm->m_area.index(x, node_max.Y, z);
@@ -574,25 +574,23 @@ void MapgenV7::generateBiomes()
 				have_air = !getMountainTerrainFromMap(j, index, y);
 			}
 
+			if (c != CONTENT_IGNORE && c != CONTENT_AIR && (y == node_max.Y || have_air)) {
+				biome           = bmgr->getBiome(heat_map[index], humidity_map[index], y);
+				dfiller         = biome->depth_filler + noise_filler_depth->result[index];
+				y0_top          = biome->depth_top;
+				y0_filler       = biome->depth_top + dfiller;
+				depth_water_top = biome->depth_water_top;
+			}
+
 			if (c == c_stone && have_air) {
 				content_t c_below = vm->m_data[i - em.X].getContent();
 
 				if (c_below != CONTENT_AIR) {
 					if (nplaced < y0_top) {
-						if(y < water_level)
-							vm->m_data[i] = MapNode(biome->c_underwater);
-						else if(y <= shore_max)
-							vm->m_data[i] = MapNode(biome->c_shore_top);
-						else
-							vm->m_data[i] = MapNode(biome->c_top);
+						vm->m_data[i] = MapNode(biome->c_top);
 						nplaced++;
 					} else if (nplaced < y0_filler && nplaced >= y0_top) {
-						if(y < water_level)
-							vm->m_data[i] = MapNode(biome->c_underwater);
-						else if(y <= shore_max)
-							vm->m_data[i] = MapNode(biome->c_shore_filler);
-						else
-							vm->m_data[i] = MapNode(biome->c_filler);
+						vm->m_data[i] = MapNode(biome->c_filler);
 						nplaced++;
 					} else if (c == c_stone) {
 						have_air = false;

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -114,7 +114,7 @@ public:
 	int generateMountainTerrain(int ymax);
 	void generateRidgeTerrain();
 
-	void generateBiomes();
+	void generateBiomes(float *heat_map, float *humidity_map);
 	void dustTopNodes();
 
 	//void addTopNodes();

--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -43,7 +43,6 @@ BiomeManager::BiomeManager(IGameDef *gamedef) :
 	b->flags           = 0;
 	b->depth_top       = 0;
 	b->depth_filler    = 0;
-	b->height_shore    = 0;
 	b->depth_water_top = 0;
 	b->y_min           = -MAP_GENERATION_LIMIT;
 	b->y_max           = MAP_GENERATION_LIMIT;
@@ -51,9 +50,6 @@ BiomeManager::BiomeManager(IGameDef *gamedef) :
 	b->humidity_point  = 0.0;
 
 	NodeResolveInfo *nri = new NodeResolveInfo(b);
-	nri->nodenames.push_back("air");
-	nri->nodenames.push_back("air");
-	nri->nodenames.push_back("air");
 	nri->nodenames.push_back("air");
 	nri->nodenames.push_back("air");
 	nri->nodenames.push_back("mapgen_stone");
@@ -126,9 +122,6 @@ void Biome::resolveNodeNames(NodeResolveInfo *nri)
 {
 	m_ndef->getIdFromResolveInfo(nri, "mapgen_dirt_with_grass", CONTENT_AIR,    c_top);
 	m_ndef->getIdFromResolveInfo(nri, "mapgen_dirt",            CONTENT_AIR,    c_filler);
-	m_ndef->getIdFromResolveInfo(nri, "mapgen_sand",            CONTENT_AIR,    c_shore_top);
-	m_ndef->getIdFromResolveInfo(nri, "mapgen_sand",            CONTENT_AIR,    c_shore_filler);
-	m_ndef->getIdFromResolveInfo(nri, "mapgen_sand",            CONTENT_AIR,    c_underwater);
 	m_ndef->getIdFromResolveInfo(nri, "mapgen_stone",           CONTENT_AIR,    c_stone);
 	m_ndef->getIdFromResolveInfo(nri, "mapgen_water_source",    CONTENT_AIR,    c_water_top);
 	m_ndef->getIdFromResolveInfo(nri, "mapgen_water_source",    CONTENT_AIR,    c_water);

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -39,9 +39,6 @@ public:
 
 	content_t c_top;
 	content_t c_filler;
-	content_t c_shore_top;
-	content_t c_shore_filler;
-	content_t c_underwater;
 	content_t c_stone;
 	content_t c_water_top;
 	content_t c_water;
@@ -49,7 +46,6 @@ public:
 
 	s16 depth_top;
 	s16 depth_filler;
-	s16 height_shore;
 	s16 depth_water_top;
 
 	s16 y_min;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -444,8 +444,7 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 
 	b->name            = getstringfield_default(L, index, "name", "");
 	b->depth_top       = getintfield_default(L, index, "depth_top",          1);
-	b->depth_filler    = getintfield_default(L, index, "depth_filler",       3);
-	b->height_shore    = getintfield_default(L, index, "height_shore",       3);
+	b->depth_filler    = getintfield_default(L, index, "depth_filler",       2);
 	b->depth_water_top = getintfield_default(L, index, "depth_water_top",    0);
 	b->y_min           = getintfield_default(L, index, "y_min",         -31000);
 	b->y_max           = getintfield_default(L, index, "y_max",          31000);
@@ -463,9 +462,6 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 	std::list<std::string> &nnames = nri->nodenames;
 	nnames.push_back(getstringfield_default(L, index, "node_top",          ""));
 	nnames.push_back(getstringfield_default(L, index, "node_filler",       ""));
-	nnames.push_back(getstringfield_default(L, index, "node_shore_top",    ""));
-	nnames.push_back(getstringfield_default(L, index, "node_shore_filler", ""));
-	nnames.push_back(getstringfield_default(L, index, "node_underwater",   ""));
 	nnames.push_back(getstringfield_default(L, index, "node_stone",        ""));
 	nnames.push_back(getstringfield_default(L, index, "node_water_top",    ""));
 	nnames.push_back(getstringfield_default(L, index, "node_water",        ""));


### PR DESCRIPTION
Also, biome is only calculated if non-air nodes are encountered.
Removes 'node shore top', 'node shore filler', 'node underwater', 'height shore'.
Enables old biome definitions to be used.
Enables multiple biome layers within a mapchunk.
Completes a job hmmmm wished to be done.