### PR TITLE
Disable protocol version checking for favourite list

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -262,16 +262,22 @@ end
 function is_server_protocol_compat(proto_min, proto_max)
 	return not ((min_supp_proto > (proto_max or 24)) or (max_supp_proto < (proto_min or 13)))
 end
+
 --------------------------------------------------------------------------------
-function is_server_protocol_compat_or_error(proto_min, proto_max)
+function confirm_no_server_compat(proto_min, proto_max)
+	-- disable version compat checking for favourite list.
+	if not core.setting_getbool("public_serverlist") then
+		return false
+	end
+
 	if not is_server_protocol_compat(proto_min, proto_max) then
 		gamedata.errormessage = fgettext_ne("Protocol version mismatch, server " ..
 			((proto_min ~= proto_max) and "supports protocols between $1 and $2" or "enforces protocol version $1") ..
 			", we " ..
 			((min_supp_proto ~= max_supp_proto) and "support protocols between version $3 and $4." or "only support protocol version $3"),
 			proto_min or 13, proto_max or 24, min_supp_proto, max_supp_proto)
-		return false
+		return true
 	end
 
-	return true
+	return false
 end

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -98,7 +98,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		local event = core.explode_table_event(fields["favourites"])
 		if event.type == "DCL" then
 			if event.row <= #menudata.favorites then
-				if not is_server_protocol_compat_or_error(menudata.favorites[event.row].proto_min,
+				if confirm_no_server_compat(menudata.favorites[event.row].proto_min,
 						menudata.favorites[event.row].proto_max) then
 					return true
 				end
@@ -220,8 +220,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			gamedata.servername        = menudata.favorites[fav_idx].name
 			gamedata.serverdescription = menudata.favorites[fav_idx].description
 
-			if not is_server_protocol_compat_or_error(menudata.favorites[fav_idx].proto_min,
-					menudata.favorites[fav_idx].proto_max)then
+			if confirm_no_server_compat(menudata.favorites[fav_idx].proto_min,
+					menudata.favorites[fav_idx].proto_max) then
 				return true
 			end
 		else

--- a/builtin/mainmenu/tab_simple_main.lua
+++ b/builtin/mainmenu/tab_simple_main.lua
@@ -160,7 +160,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			gamedata.servername			= menudata.favorites[fav_idx].name
 			gamedata.serverdescription	= menudata.favorites[fav_idx].description
 
-			if not is_server_protocol_compat_or_error(menudata.favorites[fav_idx].proto_min,
+			if confirm_no_server_compat(menudata.favorites[fav_idx].proto_min,
 					menudata.favorites[fav_idx].proto_max) then
 				return true
 			end


### PR DESCRIPTION
Also refactoring, the `not` is redundant, also the function does more than checking, so the "is_" prefix shouldn't be used here.

This got neccessary as the commit (originally written by me) that introduced version checking got default versions for nil entries as it was commited (done by the committer), while the semantics nil entries carried for favourite list servers wasn't accounted for.
@nerzhul for this.
