### PR TITLE
Mgv6: Add heightmap. Do not make large caves that are entirely above ground

### DIFF
--- a/src/cavegen.cpp
+++ b/src/cavegen.cpp
@@ -173,6 +173,36 @@ void CaveV6::makeTunnel(bool dirswitch) {
 		);
 	}
 
+	// Do not make large caves that are entirely above ground.
+	// It is only necessary to check the startpoint and endpoint.
+	if (large_cave) {
+		v3s16 orpi(orp.X, orp.Y, orp.Z);
+		v3s16 veci(vec.X, vec.Y, vec.Z);
+		s16 h1;
+		s16 h2;
+
+		v3s16 p1 = orpi + veci + of + rs / 2;
+		if (p1.Z >= node_min.Z && p1.Z <= node_max.Z &&
+				p1.X >= node_min.X && p1.X <= node_max.X) {
+			u32 index1 = (p1.Z - node_min.Z) * mg->ystride + (p1.X - node_min.X);
+			h1 = mg->heightmap[index1];
+		} else {
+			h1 = water_level; // If not in heightmap
+		}
+
+		v3s16 p2 = orpi + of + rs / 2;
+		if (p2.Z >= node_min.Z && p2.Z <= node_max.Z &&
+				p2.X >= node_min.X && p2.X <= node_max.X) {
+			u32 index2 = (p2.Z - node_min.Z) * mg->ystride + (p2.X - node_min.X);
+			h2 = mg->heightmap[index2];
+		} else {
+			h2 = water_level;
+		}
+
+		if (p1.Y > h1 && p2.Y > h2) // If startpoint and endpoint are above ground
+			return;
+	}
+
 	vec += main_direction;
 
 	v3f rp = orp + vec;

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -55,6 +55,8 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->m_emerge = emerge;
 	this->ystride = csize.X; //////fix this
 
+	this->heightmap = new s16[csize.X * csize.Z];
+
 	MapgenV6Params *sp = (MapgenV6Params *)params->sparams;
 	this->spflags     = sp->spflags;
 	this->freq_desert = sp->freq_desert;
@@ -497,6 +499,9 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 			flowMud(mudflow_minpos, mudflow_maxpos);
 
 	}
+
+	// Create heightmap after mudflow
+	updateHeightmap(node_min, node_max);
 
 	// Add dungeons
 	if ((flags & MG_DUNGEONS) && (stone_surface_max_y >= node_min.Y)) {


### PR DESCRIPTION
Adds a heightmap to mgv6, which is needed by decorations if they are used in future in mgv6.
Mgv5 and mgv7 already have heightmaps, the heightmap is available for use in an 'on generated' function as the 'mapgen object heightmap'.
Checks startpoint and endpoint of large caves, if both are above ground aborts cave generation, if one is above and one below the cave passes through the surface and therefore is needed to shape terrain as currently.
Tested by flying around for 5 minutes, could not find a single shadow bug.
I also tested the code by making large caves formed from water nodes to confirm they are still often formed intersecting (and therefore shaping) the terrain surface, while also not being formed high above terrain as noticed before.
This may occasionally slightly change mgv6 terrain from how it has been before, but this will be very rare and i feel is justified by the bugfix.