### PR TITLE
Update Makefile and use ARMv7 (Android)

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -293,7 +293,6 @@ openssl_download :
 		mkdir -p ${ROOT}/deps;                                                 \
 		cd ${ROOT}/deps ;                                                      \
 		git clone ${OPENSSL_URL} || exit 1;                                         \
-		tar -xzf ${OPENSSL_BASEDIR}.tar.gz;                                    \
 		cd ${OPENSSL_BASEDIR};                                                 \
 		patch -p1 < ../../openssl_arch.patch;                                  \
 	fi

--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -31,31 +31,31 @@ ANDROID_VERSION_CODE = 6
 ################################################################################
 # toolchain config for arm old processors
 ################################################################################
-TARGET_HOST = arm-linux
-TARGET_ABI = armeabi
-TARGET_LIBDIR = armeabi
-TARGET_TOOLCHAIN = arm-linux-androideabi-
-TARGET_CFLAGS_ADDON = -mfloat-abi=softfp -mfpu=vfp
-TARGET_ARCH = arm
-CROSS_PREFIX = arm-linux-androideabi-
-COMPILER_VERSION = 4.8
-HAVE_LEVELDB = 1
+#TARGET_HOST = arm-linux
+#TARGET_ABI = armeabi
+#TARGET_LIBDIR = armeabi
+#TARGET_TOOLCHAIN = arm-linux-androideabi-
+#TARGET_CFLAGS_ADDON = -mfloat-abi=softfp -mfpu=vfp
+#TARGET_ARCH = arm
+#CROSS_PREFIX = arm-linux-androideabi-
+#COMPILER_VERSION = 4.8
+#HAVE_LEVELDB = 1
 
 ################################################################################
 # toolchain config for arm new processors
 ################################################################################
-#TARGET_HOST = arm-linux
-#TARGET_ABI = armeabi-v7a-hard
-#TARGET_LIBDIR = armeabi-v7a
-#TARGET_TOOLCHAIN = arm-linux-androideabi-
-#TARGET_CFLAGS_ADDON =  -mfpu=vfpv3-d16 -D_NDK_MATH_NO_SOFTFP=1 \
-#						-mfloat-abi=hard -march=armv7-a
-#TARGET_CXXFLAGS_ADDON = $(TARGET_CFLAGS_ADDON)
-#TARGET_LDFLAGS_ADDON = -Wl,--no-warn-mismatch -lm_hard
-#TARGET_ARCH = armv7
-#CROSS_PREFIX = arm-linux-androideabi-
-#COMPILER_VERSION = 4.8
-#HAVE_LEVELDB = 1
+TARGET_HOST = arm-linux
+TARGET_ABI = armeabi-v7a-hard
+TARGET_LIBDIR = armeabi-v7a
+TARGET_TOOLCHAIN = arm-linux-androideabi-
+TARGET_CFLAGS_ADDON =  -mfpu=vfpv3-d16 -D_NDK_MATH_NO_SOFTFP=1 \
+						-mfloat-abi=hard -march=armv7-a
+TARGET_CXXFLAGS_ADDON = $(TARGET_CFLAGS_ADDON)
+TARGET_LDFLAGS_ADDON = -Wl,--no-warn-mismatch -lm_hard
+TARGET_ARCH = armv7
+CROSS_PREFIX = arm-linux-androideabi-
+COMPILER_VERSION = 4.8
+HAVE_LEVELDB = 1
 
 ################################################################################
 # toolchain config for little endian mips
@@ -109,13 +109,12 @@ IRRLICHT_TIMESTAMP = $(IRRLICHT_DIR)timestamp
 IRRLICHT_TIMESTAMP_INT = $(ROOT)/deps/irrlicht_timestamp
 IRRLICHT_URL_SVN = http://svn.code.sf.net/p/irrlicht/code/branches/ogl-es/
 
-OPENSSL_VERSION = 1.0.1j
-OPENSSL_BASEDIR = openssl-$(OPENSSL_VERSION)
+OPENSSL_BASEDIR = openssl
 OPENSSL_DIR = $(ROOT)/deps/$(OPENSSL_BASEDIR)/
 OPENSSL_LIB = $(OPENSSL_DIR)/libssl.so.1.0.0
 OPENSSL_TIMESTAMP = $(OPENSSL_DIR)timestamp
 OPENSSL_TIMESTAMP_INT = $(ROOT)/deps/openssl_timestamp
-OPENSSL_URL = http://www.openssl.org/source/openssl-$(OPENSSL_VERSION).tar.gz
+OPENSSL_URL = https://github.com/openssl/openssl
 
 CURL_VERSION = 7.40.0
 CURL_DIR = $(ROOT)/deps/curl-$(CURL_VERSION)
@@ -293,7 +292,7 @@ openssl_download :
 		echo "openssl sources missing, downloading...";                        \
 		mkdir -p ${ROOT}/deps;                                                 \
 		cd ${ROOT}/deps ;                                                      \
-		wget ${OPENSSL_URL} || exit 1;                                         \
+		git clone ${OPENSSL_URL} || exit 1;                                         \
 		tar -xzf ${OPENSSL_BASEDIR}.tar.gz;                                    \
 		cd ${OPENSSL_BASEDIR};                                                 \
 		patch -p1 < ../../openssl_arch.patch;                                  \


### PR DESCRIPTION
Fix OpenSSL download URL
Just Freeminer long used ARMv7 assembly, since it is faster.