### PR TITLE
[dev-0.5] New Packet: SendPlayerGameEvent

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1057,6 +1057,10 @@ int PlayerSAO::punch(v3f dir,
 			<<" HP"<<std::endl;
 
 	setHP(getHP() - hitparams.hp);
+	if (getHP() == 0) {
+		getServer(L)->SendPlayerGameEvent(PLAYER_GAMEEVENT_DIE,
+				m_player->getName());
+	}
 
 	return hitparams.wear;
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -111,6 +111,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL_VERSION_25:
 		Fixes on many packets
 		TOSERVER_INIT: add compression_mode byteflag
+		TOCLIENT_PLAYER_GAMEEVENT
 		@TODO
 */
 
@@ -141,20 +142,24 @@ enum ToClientCommand
 		Server's reply to TOSERVER_INIT.
 		Sent second after connected.
 
-		[0] u16 TOSERVER_INIT
-		[2] u8 deployed version
-		[3] v3s16 player's position + v3f(0,BS/2,0) floatToInt'd
-		[12] u64 map seed (new as of 2011-02-27)
-		[20] f1000 recommended send interval (in seconds) (new as of 14)
+		[0] u8 deployed version
+		[1] v3s16 player's position + v3f(0,BS/2,0) floatToInt'd
+		[10] u64 map seed (new as of 2011-02-27)
+		[18] f1000 recommended send interval (in seconds) (new as of 14)
 
 		NOTE: The position in here is deprecated; position is
 		      explicitly sent afterwards
 	*/
 
+	TOCLIENT_PLAYER_GAMEEVENT = 0x11,
+	/*
+		u8 PlayerGameEvent ID
+		std::string player name
+	*/
+
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
 	TOCLIENT_ADDNODE = 0x21,
 	/*
-		u16 command
 		v3s16 position
 		serialized mapnode
 		u8 keep_metadata // Added in protocol version 22

--- a/src/player.h
+++ b/src/player.h
@@ -29,6 +29,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define PLAYERNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 
+enum PlayerGameEvent {
+        PLAYER_GAMEEVENT_JOIN	= 1,
+        PLAYER_GAMEEVENT_LEAVE	= 2,
+        PLAYER_GAMEEVENT_DIE	= 3,
+};
+
 struct PlayerControl
 {
 	PlayerControl()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1579,6 +1579,15 @@ void Server::SendBreath(u16 peer_id, u16 breath)
 	Send(&pkt);
 }
 
+void Server::SendPlayerGameEvent(PlayerGameEvent event, const std::string playername)
+{
+	DSTACK(__FUNCTION_NAME);
+
+	NetworkPacket* pkt = new NetworkPacket(TOCLIENT_PLAYER_GAMEEVENT, 0);
+	*pkt << (u8)event << playername;
+	m_clients.sendToAll(0, pkt, true);
+}
+
 void Server::SendAccessDenied(u16 peer_id, AccessDeniedCode reason)
 {
 	DSTACK(__FUNCTION_NAME);
@@ -2577,9 +2586,9 @@ void Server::DiePlayer(u16 peer_id)
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
 
-	infostream<<"Server::DiePlayer(): Player "
-			<<playersao->getPlayer()->getName()
-			<<" dies"<<std::endl;
+	infostream << "Server::DiePlayer(): Player "
+			<< playersao->getPlayer()->getName()
+			<< " dies"<<std::endl;
 
 	playersao->setHP(0);
 
@@ -2588,6 +2597,7 @@ void Server::DiePlayer(u16 peer_id)
 
 	SendPlayerHP(peer_id);
 	SendDeathscreen(peer_id, false, v3f(0,0,0));
+	SendPlayerGameEvent(PLAYER_GAMEEVENT_DIE, playersao->getPlayer()->getName());
 }
 
 void Server::RespawnPlayer(u16 peer_id)

--- a/src/server.h
+++ b/src/server.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serialization.h" // For SER_FMT_VER_INVALID
 #include "mods.h"
 #include "inventorymanager.h"
+#include "player.h"
 #include "subgame.h"
 #include "util/numeric.h"
 #include "util/thread.h"
@@ -47,7 +48,6 @@ class IWritableCraftDefManager;
 class BanManager;
 class EventManager;
 class Inventory;
-class Player;
 class PlayerSAO;
 class IRollbackManager;
 struct RollbackAction;
@@ -381,6 +381,7 @@ private:
 	friend class RemoteClient;
 
 	void SendMovement(u16 peer_id);
+	void SendPlayerGameEvent(PlayerGameEvent event, const std::string name);
 	void SendHP(u16 peer_id, u8 hp);
 	void SendBreath(u16 peer_id, u16 breath);
 	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason);


### PR DESCRIPTION
This packet permit to sent a static event ID to client to handle some things (patch not finished yet)
- [ ] Event Player death
- [ ] Event Player connection
- [ ] Event Player leave
- [ ] Event server disconnect (proper server shutdown)

This patch permit to send only an event ID to clients to tell them something about player/server. This permit to translate some serverside strings like player disconnects/dies...