### PR TITLE
Send Player HP when setHP (or a setHP caller) is called

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -718,7 +718,6 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, Player *player_, u16 peer_id_,
 	// public
 	m_moved(false),
 	m_inventory_not_sent(false),
-	m_hp_not_sent(false),
 	m_breath_not_sent(false),
 	m_wielded_item_not_sent(false),
 	m_physics_override_speed(1),
@@ -1081,27 +1080,18 @@ void PlayerSAO::setHP(s16 hp)
 {
 	s16 oldhp = m_player->hp;
 
-	if(hp < 0)
+	if (hp < 0)
 		hp = 0;
-	else if(hp > PLAYER_MAX_HP)
+	else if (hp > PLAYER_MAX_HP)
 		hp = PLAYER_MAX_HP;
-
-	if(hp < oldhp && g_settings->getBool("enable_damage") == false)
-	{
-		m_hp_not_sent = true; // fix wrong prediction on client
-		return;
-	}
 
 	m_player->hp = hp;
 
-	if(hp != oldhp) {
-		m_hp_not_sent = true;
-		if(oldhp > hp)
-			m_damage += oldhp - hp;
-	}
+	if (oldhp > hp)
+		m_damage += (oldhp - hp);
 
 	// Update properties on death
-	if((hp == 0) != (oldhp == 0))
+	if ((hp == 0) != (oldhp == 0))
 		m_properties_sent = false;
 }
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -318,7 +318,6 @@ public:
 	// Some flags used by Server
 	bool m_moved;
 	bool m_inventory_not_sent;
-	bool m_hp_not_sent;
 	bool m_breath_not_sent;
 	bool m_wielded_item_not_sent;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -208,8 +208,26 @@ int ObjectRef::l_punch(lua_State *L)
 		time_from_last_punch = lua_tonumber(L, 3);
 	ToolCapabilities toolcap = read_tool_capabilities(L, 4);
 	dir.normalize();
+
+	s16 src_original_hp = co->getHP();
+	s16 dst_origin_hp = puncher->getHP();
+
 	// Do it
 	co->punch(dir, &toolcap, puncher, time_from_last_punch);
+
+	// If the punched is a player, and its HP changed
+	if (src_original_hp != co->getHP() &&
+			co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		getServer(L)->SendPlayerHPOrDie(((PlayerSAO*)co)->getPeerID(),
+				co->getHP() == 0);
+	}
+
+	// If the puncher is a player, and its HP changed
+	if (dst_origin_hp != puncher->getHP() &&
+			puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		getServer(L)->SendPlayerHPOrDie(((PlayerSAO*)puncher)->getPeerID(),
+				puncher->getHP() == 0);
+	}
 	return 0;
 }
 
@@ -243,6 +261,9 @@ int ObjectRef::l_set_hp(lua_State *L)
 			<<" hp="<<hp<<std::endl;*/
 	// Do it
 	co->setHP(hp);
+	if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		getServer(L)->SendPlayerHPOrDie(((PlayerSAO*)co)->getPeerID(), co->getHP() == 0);
+	}
 	// Return
 	return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -605,17 +605,6 @@ void Server::AsyncRunStep(bool initial_step)
 				continue;
 
 			/*
-				Handle player HPs (die if hp=0)
-			*/
-			if(playersao->m_hp_not_sent && g_settings->getBool("enable_damage"))
-			{
-				if(playersao->getHP() == 0)
-					DiePlayer(*i);
-				else
-					SendPlayerHP(*i);
-			}
-
-			/*
 				Send player breath if changed
 			*/
 			if(playersao->m_breath_not_sent) {
@@ -1889,7 +1878,6 @@ void Server::SendPlayerHP(u16 peer_id)
 	DSTACK(__FUNCTION_NAME);
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
-	playersao->m_hp_not_sent = false;
 	SendHP(peer_id, playersao->getHP());
 	m_script->player_event(playersao,"health_changed");
 
@@ -2588,9 +2576,9 @@ void Server::DiePlayer(u16 peer_id)
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
 
-	infostream<<"Server::DiePlayer(): Player "
-			<<playersao->getPlayer()->getName()
-			<<" dies"<<std::endl;
+	infostream << "Server::DiePlayer(): Player "
+			<< playersao->getPlayer()->getName()
+			<< " dies" << std::endl;
 
 	playersao->setHP(0);
 
@@ -2608,12 +2596,14 @@ void Server::RespawnPlayer(u16 peer_id)
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
 
-	infostream<<"Server::RespawnPlayer(): Player "
-			<<playersao->getPlayer()->getName()
-			<<" respawns"<<std::endl;
+	infostream << "Server::RespawnPlayer(): Player "
+			<< playersao->getPlayer()->getName()
+			<< " respawns" << std::endl;
 
 	playersao->setHP(PLAYER_MAX_HP);
 	playersao->setBreath(PLAYER_MAX_BREATH);
+
+	SendPlayerHP(peer_id);
 
 	bool repositioned = m_script->on_respawnplayer(playersao);
 	if(!repositioned){

--- a/src/server.h
+++ b/src/server.h
@@ -372,6 +372,7 @@ public:
 			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
 			std::string* vers_string);
 
+	void SendPlayerHPOrDie(u16 peer_id, bool die) { die ? DiePlayer(peer_id) : SendPlayerHP(peer_id); }
 	// Bind address
 	Address m_bind_addr;
 


### PR DESCRIPTION
Instead of waiting the next AsyncRunStepCall for sending the player HP's and looping over all players to test if the HP have to be sent, send the HP modification to player directly at modification.

This improve a little bit the AsyncRunStep performance by removing some tests and only triggering packets when the proper conditions are reached