### PR TITLE
Use indicator colors in list of mod dependencies

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -50,7 +50,7 @@ local function get_formspec(data)
 		"label[0.75,0.45;" .. mod.name .. "]" ..
 		"label[0,1;" .. fgettext("Depends:") .. "]" ..
 		"textlist[0,1.5;5,4.25;world_config_depends;" ..
-		modmgr.get_dependencies(mod.path) .. ";0]" ..
+		modmgr.get_dependencies(mod.path, true, data.list) .. ";0]" ..
 		"button[9.25,6.35;2,0.5;btn_config_world_save;" .. fgettext("Save") .. "]" ..
 		"button[7.4,6.35;2,0.5;btn_config_world_cancel;" .. fgettext("Cancel") .. "]"
 

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -19,6 +19,7 @@ mt_color_grey  = "#AAAAAA"
 mt_color_blue  = "#0000DD"
 mt_color_green = "#00DD00"
 mt_color_dark_green = "#003300"
+mt_color_red = "#DD0000"
 
 --for all other colors ask sfan5 to complete his work!
 

--- a/builtin/mainmenu/tab_mods.lua
+++ b/builtin/mainmenu/tab_mods.lua
@@ -98,7 +98,7 @@ local function get_formspec(tabview, name, tabdata)
 
 			retval = retval .. "," .. fgettext("Depends:") .. ","
 
-			local toadd = modmgr.get_dependencies(selected_mod.path)
+			local toadd = modmgr.get_dependencies(selected_mod.path, false)
 
 			retval = retval .. toadd .. ";0]"
 


### PR DESCRIPTION
This PR alters the main menu. It alters the world config dialog (where you can config the mods), the mod tab stays unaltered.

Each mod in the dependency list now gets a color, depending on the mod's state

Color key:
- red = mod not found
- green = mod found and activated
- blue = mod found, it's a subgame mod (the subgame of the selected world is used)
- default color = mod found, but not activated

The colors are the same both for mandatory and optional mods.

Screenshot:
![Screenshot of the world config dialog with this PR applied](https://i.imgur.com/eik6Gyv.png)
