### PR TITLE
Remove Queue class which uses std::list and use native std::queue

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -512,7 +512,7 @@ void Client::step(float dtime)
 				ClientEvent event;
 				event.type = CE_PLAYER_DAMAGE;
 				event.player_damage.amount = damage;
-				m_client_event_queue.push_back(event);
+				m_client_event_queue.push(event);
 			}
 		}
 		else if(event.type == CEE_PLAYER_BREATH) {
@@ -1429,7 +1429,8 @@ bool Client::getChatMessage(std::wstring &message)
 {
 	if(m_chat_queue.size() == 0)
 		return false;
-	message = m_chat_queue.pop_front();
+	message = m_chat_queue.front();
+	m_chat_queue.pop();
 	return true;
 }
 
@@ -1445,14 +1446,14 @@ void Client::typeChatMessage(const std::wstring &message)
 	// Show locally
 	if (message[0] == L'/')
 	{
-		m_chat_queue.push_back((std::wstring)L"issued command: " + message);
+		m_chat_queue.push((std::wstring)L"issued command: " + message);
 	}
 	else
 	{
 		LocalPlayer *player = m_env.getLocalPlayer();
 		assert(player != NULL);
 		std::wstring name = narrow_to_wide(player->getName());
-		m_chat_queue.push_back((std::wstring)L"<" + name + L"> " + message);
+		m_chat_queue.push((std::wstring)L"<" + name + L"> " + message);
 	}
 }
 
@@ -1545,13 +1546,15 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 
 ClientEvent Client::getClientEvent()
 {
-	if(m_client_event_queue.size() == 0)
-	{
-		ClientEvent event;
+	ClientEvent event;
+	if(m_client_event_queue.size() == 0) {
 		event.type = CE_NONE;
-		return event;
 	}
-	return m_client_event_queue.pop_front();
+	else {
+		event = m_client_event_queue.front();
+		m_client_event_queue.pop();
+	}
+	return event;
 }
 
 float Client::mediaReceiveProgress()
@@ -1669,7 +1672,7 @@ void Client::makeScreenshot(IrrlichtDevice *device)
 			} else {
 				sstr << "Failed to save screenshot '" << filename << "'";
 			}
-			m_chat_queue.push_back(narrow_to_wide(sstr.str()));
+			m_chat_queue.push(narrow_to_wide(sstr.str()));
 			infostream << sstr.str() << std::endl;
 			image->drop();
 		}

--- a/src/client.h
+++ b/src/client.h
@@ -578,13 +578,13 @@ private:
 	// 0 <= m_daynight_i < DAYNIGHT_CACHE_COUNT
 	//s32 m_daynight_i;
 	//u32 m_daynight_ratio;
-	Queue<std::wstring> m_chat_queue;
+	std::queue<std::wstring> m_chat_queue;
 	// The seed returned by the server in TOCLIENT_INIT is stored here
 	u64 m_map_seed;
 	std::string m_password;
 	bool m_access_denied;
 	std::wstring m_access_denied_reason;
-	Queue<ClientEvent> m_client_event_queue;
+	std::queue<ClientEvent> m_client_event_queue;
 	bool m_itemdef_received;
 	bool m_nodedef_received;
 	ClientMediaDownloader *m_media_downloader;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -91,7 +91,7 @@ public:
 			data += itos(m_base_position.Z);
 
 			ActiveObjectMessage aom(getId(), false, data);
-			m_messages_out.push_back(aom);
+			m_messages_out.push(aom);
 		}
 	}
 
@@ -233,7 +233,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		std::string str = getPropertyPacket();
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.
@@ -320,7 +320,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 				m_armor_groups);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_animation_sent == false){
@@ -328,7 +328,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		std::string str = gob_cmd_update_animation(m_animation_range, m_animation_speed, m_animation_blend);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_bone_position_sent == false){
@@ -337,7 +337,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			std::string str = gob_cmd_update_bone_position((*ii).first, (*ii).second.X, (*ii).second.Y);
 			// create message and add to list
 			ActiveObjectMessage aom(getId(), true, str);
-			m_messages_out.push_back(aom);
+			m_messages_out.push(aom);
 		}
 	}
 
@@ -346,7 +346,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		std::string str = gob_cmd_update_attachment(m_attachment_parent_id, m_attachment_bone, m_attachment_position, m_attachment_rotation);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 }
 
@@ -461,7 +461,7 @@ int LuaEntitySAO::punch(v3f dir,
 			std::string str = gob_cmd_punched(result.damage, getHP());
 			// create message and add to list
 			ActiveObjectMessage aom(getId(), true, str);
-			m_messages_out.push_back(aom);
+			m_messages_out.push(aom);
 		}
 
 		if(getHP() == 0)
@@ -610,7 +610,7 @@ void LuaEntitySAO::setTextureMod(const std::string &mod)
 	std::string str = gob_cmd_set_texture_mod(mod);
 	// create message and add to list
 	ActiveObjectMessage aom(getId(), true, str);
-	m_messages_out.push_back(aom);
+	m_messages_out.push(aom);
 }
 
 void LuaEntitySAO::setSprite(v2s16 p, int num_frames, float framelength,
@@ -624,7 +624,7 @@ void LuaEntitySAO::setSprite(v2s16 p, int num_frames, float framelength,
 	);
 	// create message and add to list
 	ActiveObjectMessage aom(getId(), true, str);
-	m_messages_out.push_back(aom);
+	m_messages_out.push(aom);
 }
 
 std::string LuaEntitySAO::getName()
@@ -664,7 +664,7 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 	);
 	// create message and add to list
 	ActiveObjectMessage aom(getId(), false, str);
-	m_messages_out.push_back(aom);
+	m_messages_out.push(aom);
 }
 
 bool LuaEntitySAO::getCollisionBox(aabb3f *toset) {
@@ -856,7 +856,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		std::string str = getPropertyPacket();
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.
@@ -919,7 +919,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), false, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_armor_groups_sent == false) {
@@ -928,7 +928,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 				m_armor_groups);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_physics_override_sent == false){
@@ -938,7 +938,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 				m_physics_override_sneak, m_physics_override_sneak_glitch);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_animation_sent == false){
@@ -946,7 +946,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		std::string str = gob_cmd_update_animation(m_animation_range, m_animation_speed, m_animation_blend);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 
 	if(m_bone_position_sent == false){
@@ -955,7 +955,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			std::string str = gob_cmd_update_bone_position((*ii).first, (*ii).second.X, (*ii).second.Y);
 			// create message and add to list
 			ActiveObjectMessage aom(getId(), true, str);
-			m_messages_out.push_back(aom);
+			m_messages_out.push(aom);
 		}
 	}
 
@@ -964,7 +964,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		std::string str = gob_cmd_update_attachment(m_attachment_parent_id, m_attachment_bone, m_attachment_position, m_attachment_rotation);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push_back(aom);
+		m_messages_out.push(aom);
 	}
 }
 
@@ -1025,7 +1025,7 @@ int PlayerSAO::punch(v3f dir,
 			std::string str = gob_cmd_punched(0, getHP());
 			// create message and add to list
 			ActiveObjectMessage aom(getId(), true, str);
-			m_messages_out.push_back(aom);
+			m_messages_out.push(aom);
 			return 0;
 		}
 	}

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1239,7 +1239,8 @@ void ServerEnvironment::step(float dtime)
 			while(!obj->m_messages_out.empty())
 			{
 				m_active_object_messages.push_back(
-						obj->m_messages_out.pop_front());
+						obj->m_messages_out.front());
+				obj->m_messages_out.pop();
 			}
 		}
 	}

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -505,10 +505,10 @@ public:
 	ReliablePacketBuffer outgoing_reliables_sent;
 
 	//queued reliable packets
-	Queue<BufferedPacket> queued_reliables;
+	std::queue<BufferedPacket> queued_reliables;
 
 	//queue commands prior splitting to packets
-	Queue<ConnectionCommand> queued_commands;
+	std::queue<ConnectionCommand> queued_commands;
 
 	IncomingSplitBuffer incoming_splits;
 
@@ -964,7 +964,7 @@ private:
 	Connection*           m_connection;
 	unsigned int          m_max_packet_size;
 	float                 m_timeout;
-	Queue<OutgoingPacket> m_outgoing_queue;
+	std::queue<OutgoingPacket> m_outgoing_queue;
 	JSemaphore            m_send_sleep_semaphore;
 
 	unsigned int          m_iteration_packets_avaialble;

--- a/src/network/packethandlers/client.cpp
+++ b/src/network/packethandlers/client.cpp
@@ -263,7 +263,7 @@ void Client::handleCommand_ChatMessage(NetworkPacket* pkt)
 		message += (wchar_t)read_wchar;
 	}
 
-	m_chat_queue.push_back(message);
+	m_chat_queue.push(message);
 }
 
 void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
@@ -380,7 +380,7 @@ void Client::handleCommand_HP(NetworkPacket* pkt)
 		ClientEvent event;
 		event.type = CE_PLAYER_DAMAGE;
 		event.player_damage.amount = oldhp - hp;
-		m_client_event_queue.push_back(event);
+		m_client_event_queue.push(event);
 	}
 }
 
@@ -424,7 +424,7 @@ void Client::handleCommand_MovePlayer(NetworkPacket* pkt)
 	event.type = CE_PLAYER_FORCE_MOVE;
 	event.player_force_move.pitch = pitch;
 	event.player_force_move.yaw = yaw;
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 
 	// Ignore damage for a few seconds, so that the player doesn't
 	// get damage from falling on ground
@@ -450,7 +450,7 @@ void Client::handleCommand_DeathScreen(NetworkPacket* pkt)
 	event.deathscreen.camera_point_target_x   = camera_point_target.X;
 	event.deathscreen.camera_point_target_y   = camera_point_target.Y;
 	event.deathscreen.camera_point_target_z   = camera_point_target.Z;
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_AnnounceMedia(NetworkPacket* pkt)
@@ -735,7 +735,7 @@ void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
 	// adding a std:string to a struct isn't possible
 	event.show_formspec.formspec = new std::string(formspec);
 	event.show_formspec.formname = new std::string(formname);
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
@@ -766,7 +766,7 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	event.spawn_particle.vertical           = vertical;
 	event.spawn_particle.texture            = new std::string(texture);
 
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
@@ -818,7 +818,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	event.add_particlespawner.texture            = new std::string(texture);
 	event.add_particlespawner.id                 = id;
 
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 
@@ -832,7 +832,7 @@ void Client::handleCommand_DeleteParticleSpawner(NetworkPacket* pkt)
 	event.type                      = CE_DELETE_PARTICLESPAWNER;
 	event.delete_particlespawner.id = (u32) id;
 
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_HudAdd(NetworkPacket* pkt)
@@ -880,7 +880,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event.hudadd.offset    = new v2f(offset);
 	event.hudadd.world_pos = new v3f(world_pos);
 	event.hudadd.size      = new v2s32(size);
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_HudRemove(NetworkPacket* pkt)
@@ -892,7 +892,7 @@ void Client::handleCommand_HudRemove(NetworkPacket* pkt)
 	ClientEvent event;
 	event.type     = CE_HUDRM;
 	event.hudrm.id = id;
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_HudChange(NetworkPacket* pkt)
@@ -928,7 +928,7 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	event.hudchange.sdata   = new std::string(sdata);
 	event.hudchange.data    = intdata;
 	event.hudchange.v2s32data = new v2s32(v2s32data);
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
@@ -984,7 +984,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	event.set_sky.bgcolor = bgcolor;
 	event.set_sky.type    = type;
 	event.set_sky.params  = params;
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
@@ -1000,7 +1000,7 @@ void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
 	event.type                                 = CE_OVERRIDE_DAY_NIGHT_RATIO;
 	event.override_day_night_ratio.do_override = do_override;
 	event.override_day_night_ratio.ratio_f     = day_night_ratio_f;
-	m_client_event_queue.push_back(event);
+	m_client_event_queue.push(event);
 }
 
 void Client::handleCommand_LocalPlayerAnimations(NetworkPacket* pkt)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -906,7 +906,8 @@ void Server::AsyncRunStep(bool initial_step)
 
 		while(m_unsent_map_edit_queue.size() != 0)
 		{
-			MapEditEvent* event = m_unsent_map_edit_queue.pop_front();
+			MapEditEvent* event = m_unsent_map_edit_queue.front();
+			m_unsent_map_edit_queue.pop();
 
 			// Players far away from the change are stored here.
 			// Instead of sending the changes, MapBlocks are set not sent
@@ -1292,7 +1293,7 @@ void Server::onMapEditEvent(MapEditEvent *event)
 	if(m_ignore_map_edit_events_area.contains(event->getArea()))
 		return;
 	MapEditEvent *e = event->clone();
-	m_unsent_map_edit_queue.push_back(e);
+	m_unsent_map_edit_queue.push(e);
 }
 
 Inventory* Server::getInventory(const InventoryLocation &loc)
@@ -1395,7 +1396,7 @@ void Server::peerAdded(con::Peer *peer)
 	c.type = con::PEER_ADDED;
 	c.peer_id = peer->id;
 	c.timeout = false;
-	m_peer_change_queue.push_back(c);
+	m_peer_change_queue.push(c);
 }
 
 void Server::deletingPeer(con::Peer *peer, bool timeout)
@@ -1409,7 +1410,7 @@ void Server::deletingPeer(con::Peer *peer, bool timeout)
 	c.type = con::PEER_REMOVED;
 	c.peer_id = peer->id;
 	c.timeout = timeout;
-	m_peer_change_queue.push_back(c);
+	m_peer_change_queue.push(c);
 }
 
 bool Server::getClientConInfo(u16 peer_id, con::rtt_stat_type type, float* retval)
@@ -1458,7 +1459,8 @@ void Server::handlePeerChanges()
 {
 	while(m_peer_change_queue.size() > 0)
 	{
-		con::PeerChange c = m_peer_change_queue.pop_front();
+		con::PeerChange c = m_peer_change_queue.front();
+		m_peer_change_queue.pop();
 
 		verbosestream<<"Server: Handling peer change: "
 				<<"id="<<c.peer_id<<", timeout="<<c.timeout
@@ -1837,7 +1839,7 @@ void Server::SendPlayerHP(u16 peer_id)
 	// Send to other clients
 	std::string str = gob_cmd_punched(playersao->readDamage(), playersao->getHP());
 	ActiveObjectMessage aom(playersao->getId(), true, str);
-	playersao->m_messages_out.push_back(aom);
+	playersao->m_messages_out.push(aom);
 }
 
 void Server::SendPlayerBreath(u16 peer_id)

--- a/src/server.h
+++ b/src/server.h
@@ -582,7 +582,7 @@ private:
 		Queues stuff from peerAdded() and deletingPeer() to
 		handlePeerChanges()
 	*/
-	Queue<con::PeerChange> m_peer_change_queue;
+	std::queue<con::PeerChange> m_peer_change_queue;
 
 	/*
 		Random stuff
@@ -606,7 +606,7 @@ private:
 		Queue of map edits from the environment for sending to the clients
 		This is behind m_env_mutex
 	*/
-	Queue<MapEditEvent*> m_unsent_map_edit_queue;
+	std::queue<MapEditEvent*> m_unsent_map_edit_queue;
 	/*
 		Set to true when the server itself is modifying the map and does
 		all sending of information by itself.

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -218,7 +218,7 @@ public:
 	/*
 		Queue of messages to be sent to the client
 	*/
-	Queue<ActiveObjectMessage> m_messages_out;
+	std::queue<ActiveObjectMessage> m_messages_out;
 	
 protected:
 	// Used for creating objects based on type

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -184,67 +184,6 @@ private:
 };
 
 /*
-FIFO queue (well, actually a FILO also)
-*/
-template<typename T>
-class Queue
-{
-public:
-	Queue():
-		m_list_size(0)
-	{}
-
-	void push_back(T t)
-	{
-		m_list.push_back(t);
-		++m_list_size;
-	}
-
-	void push_front(T t)
-	{
-		m_list.push_front(t);
-		++m_list_size;
-	}
-
-	T pop_front()
-	{
-		if(m_list.empty())
-			throw ItemNotFoundException("Queue: queue is empty");
-
-		typename std::list<T>::iterator begin = m_list.begin();
-		T t = *begin;
-		m_list.erase(begin);
-		--m_list_size;
-		return t;
-	}
-	T pop_back()
-	{
-		if(m_list.empty())
-			throw ItemNotFoundException("Queue: queue is empty");
-
-		typename std::list<T>::iterator last = m_list.back();
-		T t = *last;
-		m_list.erase(last);
-		--m_list_size;
-		return t;
-	}
-
-	u32 size()
-	{
-		return m_list_size;
-	}
-
-	bool empty()
-	{
-		return m_list.empty();
-	}
-
-protected:
-	std::list<T> m_list;
-	u32 m_list_size;
-};
-
-/*
 Thread-safe FIFO queue (well, actually a FILO also)
 */
 


### PR DESCRIPTION
in util/container.h we have a FIFO queue which is using a std::list. Remove this useless class and use native std::queue which is FIFO (http://fr.cppreference.com/w/cpp/container/queue).