### PR TITLE
Fix mapgen using unitialised height map values

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -41,6 +41,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 const char *GenElementManager::ELEMENT_TITLE = "element";
 
+static const s16 INVALID_HEIGHT = MAP_GENERATION_LIMIT + 1;
+
 FlagDesc flagdesc_mapgen[] = {
 	{"trees",    MG_TREES},
 	{"caves",    MG_CAVES},
@@ -155,6 +157,12 @@ s16 Mapgen::findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax)
 }
 
 
+void Mapgen::initHeightMap(s16 *dest, size_t len)
+{
+	for (size_t i = 0; i < len; i++)
+		dest[i] = INVALID_HEIGHT;
+}
+
 void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 {
 	if (!heightmap)
@@ -166,11 +174,13 @@ void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 		for (s16 x = nmin.X; x <= nmax.X; x++, index++) {
 			s16 y = findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
 
-			// if the values found are out of range, trust the old heightmap
-			if (y == nmax.Y && heightmap[index] > nmax.Y)
-				continue;
-			if (y == nmin.Y - 1 && heightmap[index] < nmin.Y)
-				continue;
+			if (heightmap[index] != INVALID_HEIGHT) {
+				// if the values found are out of range, trust the old heightmap
+				if (y == nmax.Y && heightmap[index] > nmax.Y)
+					continue;
+				if (y == nmin.Y - 1 && heightmap[index] < nmin.Y)
+					continue;
+			}
 
 			heightmap[index] = y;
 		}

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -151,6 +151,7 @@ public:
 	static u32 getBlockSeed2(v3s16 p, int seed);
 	s16 findGroundLevelFull(v2s16 p2d);
 	s16 findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax);
+	void initHeightMap(s16 *dest, size_t len);
 	void updateHeightmap(v3s16 nmin, v3s16 nmax);
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -60,6 +60,8 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->biomemap  = new u8[csize.X * csize.Z];
 	this->heightmap = new s16[csize.X * csize.Z];
 
+	initHeightMap(this->heightmap, csize.X * csize.Z);
+
 	MapgenV5Params *sp = (MapgenV5Params *)params->sparams;
 	this->spflags      = sp->spflags;
 

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -57,6 +57,8 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 
 	this->heightmap = new s16[csize.X * csize.Z];
 
+	initHeightMap(this->heightmap, csize.X * csize.Z);
+
 	MapgenV6Params *sp = (MapgenV6Params *)params->sparams;
 	this->spflags     = sp->spflags;
 	this->freq_desert = sp->freq_desert;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -64,6 +64,8 @@ MapgenV7::MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->heightmap = new s16[csize.X * csize.Z];
 	this->ridge_heightmap = new s16[csize.X * csize.Z];
 
+	initHeightMap(this->heightmap, csize.X * csize.Z);
+
 	MapgenV7Params *sp = (MapgenV7Params *)params->sparams;
 	this->spflags = sp->spflags;
 


### PR DESCRIPTION
Because Mapgen::updateHeightmap() did not update *all* values some positions in the array were not initalised; this caused cavegen to use unitialised values.