### PR TITLE
Add tooltips for many elements of the main menu

### DIFF
--- a/builtin/fstk/buttonbar.lua
+++ b/builtin/fstk/buttonbar.lua
@@ -96,14 +96,18 @@ local function buttonbar_formspec(self)
 		end
 		
 		formspec = formspec ..
-			string.format("image_button[%f,%f;%f,%f;;btnbar_dec_%s;%s;true;true]",
+			string.format("image_button[%f,%f;%f,%f;;btnbar_dec_%s;%s;true;true]"..
+					"tooltip[btnbar_dec_%s;%s]",
 					btn_dec_pos.x, btn_dec_pos.y, btn_size.x, btn_size.y,
-					self.name, text_dec)
+					self.name, text_dec, self.name,
+					fgettext("Show the previous entries"))
 				
 		formspec = formspec ..
-			string.format("image_button[%f,%f;%f,%f;;btnbar_inc_%s;%s;true;true]",
+			string.format("image_button[%f,%f;%f,%f;;btnbar_inc_%s;%s;true;true]"..
+					"tooltip[btnbar_inc_%s;%s]",
 					btn_inc_pos.x, btn_inc_pos.y, btn_size.x, btn_size.y,
-					 self.name, text_inc)
+					self.name, text_inc, self.name,
+					fgettext("Show the next entries"))
 	end
 	
 	return formspec

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -33,8 +33,10 @@ tooltips.cb_public_serverlist = fgettext(
 master server.
 Disable this to view a list of servers you have visited recently.]])
 tooltips.btn_mp_connect = fgettext(
-[[Connect to the host specified in the address and port fields]])
-tooltips.te_name = fgettext("Your player name used on the server")
+[[Connect to the server specified in the address and port fields]])
+tooltips.te_name = fgettext(
+[[Player name. This name is used on the server to which you will connect to
+and will be visible to other players.]])
 tooltips.te_pwd = fgettext(
 [[Password for the server, it is accociated with the name. Leave this field
 empty if you don't want to use a password.

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -25,29 +25,30 @@ menudata = {}
 tooltips = {}
 
 tooltips.te_address = fgettext("The hostname or IP address of the server")
-tooltips.te_port = fgettext("The UDP port of the server. Must be a number. "..
-		"If left empty, 30000 is used by default.")
-tooltips.cb_public_serverlist = fgettext("Enable this to see a list of "..
-		"servers from the Internet announced by a public master "..
-		"server.\nDisable this to view a list of servers you have "..
-		"visited recently.")
-tooltips.btn_mp_connect = fgettext("Connect to the host specified in the "..
-		"address and port fields")
+tooltips.te_port = fgettext(
+[[The UDP port of the server. Must be a number.
+If left empty, 30000 is used by default.]])
+tooltips.cb_public_serverlist = fgettext(
+[[Enable this to see a list of servers from the Internet announced by a public
+master server.
+Disable this to view a list of servers you have visited recently.]])
+tooltips.btn_mp_connect = fgettext(
+[[Connect to the host specified in the address and port fields]])
 tooltips.te_name = fgettext("Your player name used on the server")
-tooltips.te_pwd = fgettext("Password for the server, it is accociated with "..
-		"the name. Leave this field empty if you don't want to use a "..
-		"password.\nWARNING: Setting the password for the first time "..
-		"on a server will automatically create an account on the "..
-		"server and you need to use the same password afterwards.")
+tooltips.te_pwd = fgettext(
+[[Password for the server, it is accociated with the name. Leave this field
+empty if you don't want to use a password.
+WARNING: Setting the password for the first time on a server will
+automatically create an account on the server and you need to use the same
+password afterwards.]])
 
-tooltips.cb_creative_mode = fgettext("Creative Mode is intended to make "..
-		"creative activity easier, which is done by i.e. giving the "..
-		"player infinite supplies, higher damage, and so on.\nThe "..
-		"actual behaviour of Creative Mode depends a lot on the "..
-		"subgame.")
-tooltips.cb_enable_damage = fgettext("Enabling damage makes players mortal "..
-		"and they can take damage from attacks, falling, drowning "..
-		"and other hazards.\nDisabling damage makes players immortal.")
+tooltips.cb_creative_mode = fgettext(
+[[Creative Mode is intended to make creative activity easier, which is done by
+i.e. giving the player infinite supplies, higher damage, and so on.
+The actual behaviour of Creative Mode depends a lot on the subgame.]])
+tooltips.cb_enable_damage = fgettext(
+[[Enabling damage makes players mortal and they can take damage from attacks,
+falling, drowning and other hazards. Disabling damage makes players immortal.]])
 
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -20,6 +20,37 @@
 menudata = {}
 
 --------------------------------------------------------------------------------
+-- Text for tool tips which are used more than 1 time
+--------------------------------------------------------------------------------
+tooltips = {}
+
+tooltips.te_address = fgettext("The hostname or IP address of the server")
+tooltips.te_port = fgettext("The UDP port of the server. Must be a number. "..
+		"If left empty, 30000 is used by default.")
+tooltips.cb_public_serverlist = fgettext("Enable this to see a list of "..
+		"servers from the Internet announced by a public master "..
+		"server.\nDisable this to view a list of servers you have "..
+		"visited recently.")
+tooltips.btn_mp_connect = fgettext("Connect to the host specified in the "..
+		"address and port fields")
+tooltips.te_name = fgettext("Your player name used on the server")
+tooltips.te_pwd = fgettext("Password for the server, it is accociated with "..
+		"the name. Leave this field empty if you don't want to use a "..
+		"password.\nWARNING: Setting the password for the first time "..
+		"on a server will automatically create an account on the "..
+		"server and you need to use the same password afterwards.")
+
+tooltips.cb_creative_mode = fgettext("Creative Mode is intended to make "..
+		"creative activity easier, which is done by i.e. giving the "..
+		"player infinite supplies, higher damage, and so on.\nThe "..
+		"actual behaviour of Creative Mode depends a lot on the "..
+		"subgame.")
+tooltips.cb_enable_damage = fgettext("Enabling damage makes players mortal "..
+		"and they can take damage from attacks, falling, drowning "..
+		"and other hazards.\nDisabling damage makes players immortal.")
+
+
+--------------------------------------------------------------------------------
 -- Local cached values
 --------------------------------------------------------------------------------
 local min_supp_proto = core.get_min_supp_proto()

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -34,12 +34,16 @@ local function get_formspec(data)
 	else
 		retval = retval .. "checkbox[0,5.75;cb_hide_gamemods;" .. fgettext("Hide Game") .. ";false]"
 	end
+	retval = retval .. "tooltip[cb_hide_gamemods;"..
+		fgettext("Enabling this checkbox will hide all mods from subgames in the main list.").."]"
 
 	if data.hide_modpackcontents then
 		retval = retval .. "checkbox[2,5.75;cb_hide_mpcontent;" .. fgettext("Hide mp content") .. ";true]"
 	else
 		retval = retval .. "checkbox[2,5.75;cb_hide_mpcontent;" .. fgettext("Hide mp content") .. ";false]"
 	end
+	retval = retval .. "tooltip[cb_hide_mpcontent;"..
+		fgettext("Enabling this checkbox Will hide all mods which are part of a mod pack.").."]"
 
 	if mod == nil then
 		mod = {name=""}
@@ -69,8 +73,12 @@ local function get_formspec(data)
 
 			if all_enabled == false then
 				retval = retval .. "button[5.5,-0.125;2,0.5;btn_mp_enable;" .. fgettext("Enable MP") .. "]"
+				retval = retval .. "tooltip[btn_mp_enable;"..
+					fgettext("Enable all mods in the selected mod pack").."]"
 			else
 				retval = retval .. "button[5.5,-0.125;2,0.5;btn_mp_disable;" .. fgettext("Disable MP") .. "]"
+				retval = retval .. "tooltip[btn_mp_disable;"..
+					fgettext("Disable all mods in the selected mod pack").."]"
 			end
 		else
 			if mod.enabled then
@@ -78,6 +86,7 @@ local function get_formspec(data)
 			else
 				retval = retval .. "checkbox[5.5,-0.375;cb_mod_enable;" .. fgettext("enabled") .. ";false]"
 			end
+			retval = retval .. "tooltip[cb_mod_enable;"..fgettext("Enable the selected mod").."]"
 		end
 	end
 
@@ -87,6 +96,8 @@ local function get_formspec(data)
 
 	retval = retval .. modmgr.render_modlist(data.list)
 	retval = retval .. ";" .. data.selected_mod .."]"
+
+	retval = retval .. "tooltip[btn_all_mods;"..fgettext("Enable all mods").."]"
 
 	return retval
 end

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -49,12 +49,25 @@ local function create_world_formspec(dialogdata)
 		"size[12,6,true]" ..
 		"label[2,0;" .. fgettext("World name") .. "]"..
 		"field[4.5,0.4;6,0.5;te_world_name;;]" ..
+		"tooltip[te_world_name;"..
+		fgettext("An unique identifier for your new world, used to tell "..
+			"different worlds apart. You may choose almost "..
+			"any name.") .. "]" ..
 
 		"label[2,1;" .. fgettext("Seed") .. "]"..
 		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
+		"tooltip[te_seed;"..
+		fgettext("A non-negative integer used for the map generator, "..
+			"which will use this number to generate the world. Identical seeds "..
+			"produce identical results.\nIf left empty, Minetest will choose a "..
+			"random seed.") .. "]" ..
 
 		"label[2,2;" .. fgettext("Mapgen") .. "]"..
 		"dropdown[4.2,2;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]" ..
+		"tooltip[dd_mapgen;"..
+		fgettext("The map generator which is used to create most parts of the "..
+		"world. Different map generators produce different types of worlds.\nPlease "..
+		"note that mods may alter the world on their own, too.") .. "]" ..
 
 		"label[2,3;" .. fgettext("Game") .. "]"..
 		"textlist[4.2,3;5.8,2.3;games;" .. gamemgr.gamelist() ..

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -58,8 +58,9 @@ apart. You may choose almost any name.]]) .. "]" ..
 		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
 		"tooltip[te_seed;"..
 		fgettext(
-[[A non-negative integer used for the map generator, which will use this number
-to generate the world. Identical seeds produce identical results.
+[[A non-negative integer or some text used for the map generator, which will
+use this number to generate the world. Identical seeds produce identical
+results.
 If left empty, Minetest will choose a random seed.]]) .. "]" ..
 
 		"label[2,2;" .. fgettext("Mapgen") .. "]"..

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -50,24 +50,25 @@ local function create_world_formspec(dialogdata)
 		"label[2,0;" .. fgettext("World name") .. "]"..
 		"field[4.5,0.4;6,0.5;te_world_name;;]" ..
 		"tooltip[te_world_name;"..
-		fgettext("An unique identifier for your new world, used to tell "..
-			"different worlds apart. You may choose almost "..
-			"any name.") .. "]" ..
+		fgettext(
+[[An unique identifier for your new world, used to tell different worlds
+apart. You may choose almost any name.]]) .. "]" ..
 
 		"label[2,1;" .. fgettext("Seed") .. "]"..
 		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
 		"tooltip[te_seed;"..
-		fgettext("A non-negative integer used for the map generator, "..
-			"which will use this number to generate the world. Identical seeds "..
-			"produce identical results.\nIf left empty, Minetest will choose a "..
-			"random seed.") .. "]" ..
+		fgettext(
+[[A non-negative integer used for the map generator, which will use this number
+to generate the world. Identical seeds produce identical results.
+If left empty, Minetest will choose a random seed.]]) .. "]" ..
 
 		"label[2,2;" .. fgettext("Mapgen") .. "]"..
 		"dropdown[4.2,2;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]" ..
 		"tooltip[dd_mapgen;"..
-		fgettext("The map generator which is used to create most parts of the "..
-		"world. Different map generators produce different types of worlds.\nPlease "..
-		"note that mods may alter the world on their own, too.") .. "]" ..
+		fgettext(
+[[The map generator which is used to create most parts of the world. Different
+map generators produce different types of worlds.
+Please note that mods may alter the world on their own, too.]]) .. "]" ..
 
 		"label[2,3;" .. fgettext("Game") .. "]"..
 		"textlist[4.2,3;5.8,2.3;games;" .. gamemgr.gamelist() ..

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -24,10 +24,13 @@ local function get_formspec(tabview, name, tabdata)
 		"label[7.75,1.05;" .. fgettext("Name / Password :") .. "]" ..
 		"field[8,0.75;3.4,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .. "]" ..
+		"tooltip[te_address;" .. tooltips.te_address .. "]" ..
 		"field[11.25,0.75;1.3,0.5;te_port;;" ..
 		core.formspec_escape(core.setting_get("remote_port")) .. "]" ..
+		"tooltip[te_port;" .. tooltips.te_port .. "]" ..
 		"checkbox[0,4.85;cb_public_serverlist;" .. fgettext("Public Serverlist") .. ";" ..
-		dump(core.setting_getbool("public_serverlist")) .. "]"
+		dump(core.setting_getbool("public_serverlist")) .. "]" ..
+		"tooltip[cb_public_serverlist;" .. tooltips.cb_public_serverlist.. "]"
 
 	if not core.setting_getbool("public_serverlist") then
 		retval = retval ..
@@ -36,9 +39,12 @@ local function get_formspec(tabview, name, tabdata)
 
 	retval = retval ..
 		"button[10,4.9;2,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]" ..
+		"tooltip[btn_mp_connect;" .. tooltips.btn_mp_connect.. "]" ..
 		"field[8,1.95;2.95,0.5;te_name;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..
+		"tooltip[te_name;" .. tooltips.te_name.. "]" ..
 		"pwdfield[10.78,1.95;1.77,0.5;te_pwd;]" ..
+		"tooltip[te_pwd;" .. tooltips.te_pwd.. "]" ..
 		"box[7.73,2.35;4.3,2.28;#999999]" ..
 		"textarea[8.1,2.4;4.26,2.6;;"
 		

--- a/builtin/mainmenu/tab_server.lua
+++ b/builtin/mainmenu/tab_server.lua
@@ -36,9 +36,9 @@ local function get_formspec(tabview, name, tabdata)
 		"tooltip[cb_enable_damage;"..tooltips.cb_enable_damage.. "]" ..
 		"checkbox[0.25,1.15;cb_server_announce;" .. fgettext("Public") .. ";" ..
 		dump(core.setting_getbool("server_announce")) .. "]" ..
-		"tooltip[cb_server_announce;"..fgettext("If enabled, your server will be "..
-			"announced to the public server list, where it can easily be seen "..
-			"and found by other players.").. "]" ..
+		"tooltip[cb_server_announce;"..fgettext(
+[[If enabled, your server will be announced to the public server list, where it
+can easily be seen and found by other players.]]).. "]" ..
 		"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
 		"field[0.55,3.2;3.5,0.5;te_playername;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..

--- a/builtin/mainmenu/tab_server.lua
+++ b/builtin/mainmenu/tab_server.lua
@@ -30,14 +30,21 @@ local function get_formspec(tabview, name, tabdata)
 		"label[4,-0.25;" .. fgettext("Select World:") .. "]" ..
 		"checkbox[0.25,0.25;cb_creative_mode;" .. fgettext("Creative Mode") .. ";" ..
 		dump(core.setting_getbool("creative_mode")) .. "]" ..
+		"tooltip[cb_creative_mode;"..tooltips.cb_creative_mode .. "]" ..
 		"checkbox[0.25,0.7;cb_enable_damage;" .. fgettext("Enable Damage") .. ";" ..
 		dump(core.setting_getbool("enable_damage")) .. "]" ..
+		"tooltip[cb_enable_damage;"..tooltips.cb_enable_damage.. "]" ..
 		"checkbox[0.25,1.15;cb_server_announce;" .. fgettext("Public") .. ";" ..
 		dump(core.setting_getbool("server_announce")) .. "]" ..
+		"tooltip[cb_server_announce;"..fgettext("If enabled, your server will be "..
+			"announced to the public server list, where it can easily be seen "..
+			"and found by other players.").. "]" ..
 		"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
 		"field[0.55,3.2;3.5,0.5;te_playername;;" ..
 		core.formspec_escape(core.setting_get("name")) .. "]" ..
-		"pwdfield[0.55,4;3.5,0.5;te_passwd;]"
+		"tooltip[te_playername;"..tooltips.te_name.. "]" ..
+		"pwdfield[0.55,4;3.5,0.5;te_passwd;]" ..
+		"tooltip[te_passwd;"..tooltips.te_pwd.. "]"
 
 	local bind_addr = core.setting_get("bind_address")
 	if bind_addr ~= nil and bind_addr ~= "" then
@@ -49,7 +56,8 @@ local function get_formspec(tabview, name, tabdata)
 	else
 		retval = retval ..
 			"field[0.55,5.2;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
-			core.formspec_escape(core.setting_get("port")) .. "]"
+			core.formspec_escape(core.setting_get("port")) .. "]" ..
+			"tooltip[te_serverport;"..tooltips.te_port.. "]"
 	end
 	
 	retval = retval ..

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -181,14 +181,15 @@ local function formspec(tabview, name, tabdata)
 		"checkbox[0.25,0;cb_smooth_lighting;".. fgettext("Smooth Lighting")
 				.. ";".. dump(core.setting_getbool("smooth_lighting")) .. "]"..
 		"tooltip[cb_smooth_lighting;"..
-		fgettext("If enabled, the light on surfaces will appear to be smooth.\nIf " ..
-				"disabled, the light will look rather flat, but is more " ..
-				"processor-friendly.") .. "]" ..
+		fgettext(
+[[If enabled, the light on surfaces will appear to be smooth. If disabled,
+the light will look rather flat, but is more processor-friendly.]]) .. "]" ..
 		"checkbox[0.25,0.5;cb_particles;".. fgettext("Enable Particles") .. ";"
 				.. dump(core.setting_getbool("enable_particles"))	.. "]"..
 		"tooltip[cb_particles;"..
-		fgettext("If enabled, particles are displayed for a variety of events, most "..
-				"often for digging blocks.") .. "]" ..
+		fgettext(
+[[If enabled, particles are displayed for a variety of events, most often
+for digging blocks.]]) .. "]" ..
 		"checkbox[0.25,1;cb_3d_clouds;".. fgettext("3D Clouds") .. ";"
 				.. dump(core.setting_getbool("enable_3d_clouds")) .. "]"..
 		"tooltip[cb_3d_clouds;"..
@@ -196,9 +197,11 @@ local function formspec(tabview, name, tabdata)
 		"checkbox[0.25,1.5;cb_fancy_trees;".. fgettext("Fancy Trees") .. ";"
 				.. dump(core.setting_getbool("new_style_leaves")) .. "]"..
 		"tooltip[cb_fancy_trees;"..
-		fgettext("If enabled, it is possible to look through leaves (and some other "..
-				"blocks).\nIf disabled, these blocks are opaque.\n\nIt may be "..
-				"neccessary to disable this effect on slow machines.") .. "]" ..
+		fgettext(
+[[If enabled, it is possible to look through leaves (and some other blocks).
+If disabled, these blocks are opaque.
+
+It may be neccessary to disable this effect on slow machines.]]) .. "]" ..
 		"checkbox[0.25,2.0;cb_opaque_water;".. fgettext("Opaque Water") .. ";"
 				.. dump(core.setting_getbool("opaque_water")) .. "]"..
 		"tooltip[cb_opaque_water;"..
@@ -206,53 +209,64 @@ local function formspec(tabview, name, tabdata)
 		"checkbox[0.25,2.5;cb_connected_glass;".. fgettext("Connected Glass") .. ";"
 				.. dump(core.setting_getbool("connected_glass"))	.. "]"..
 		"tooltip[cb_connected_glass;"..
-		fgettext("If enabled, certain glass blocks (and other, similar blocks) will "..
-				"form larger shapes when placed next to each other.\nIf disabled, "..
-				"each such block will be displayed as \"singleton\", without "..
-				"connections.") .. "]" ..
+		fgettext(
+[[If enabled, certain glass blocks (and other, similar blocks) will form larger
+shapes when placed next to each other.
+If disabled, each such block will be displayed as "singleton", without
+connections.]]) .. "]" ..
 		"checkbox[0.25,3.0;cb_node_highlighting;".. fgettext("Node Highlighting") .. ";"
 				.. dump(core.setting_getbool("enable_node_highlighting")) .. "]"..
 		"tooltip[cb_node_highlighting;"..
-		fgettext("If enabled, the pointed node (block) will be surrounded by a bright "..
-				"translucent cuboid in a certain color.\nIf disabled, the pointed "..
-				"node will have drawn a thin wireframe around it.") .. "]" ..
+		fgettext(
+[[If enabled, the pointed node (block) will be surrounded by a bright
+translucent cuboid in a certain color.
+If disabled, the pointed node will have drawn a thin wireframe around it.]]) .. "]" ..
 		"box[3.75,0;3.75,3.45;#999999]" ..
 		"label[3.85,0.1;".. fgettext("Texturing:") .. "]"..
 		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";"
 				.. getFilterSettingIndex() .. "]" ..
 		"tooltip[dd_filters;"..
-		fgettext("This changes the way how the surface images (textures) of blocks look.\n"..
-				"Using no filters will show the textures in their original form, "..
-				"which usually gives them a \"pixelated\" look.\nThe bilinear filter "..
-				"smoothens the textures.\nThe trilinear filter smoothens them "..
-				"even further.") .. "]" ..
+		fgettext(
+[[This changes the way how the surface images (textures) of blocks look.
+Using no filters will show the textures in their original form, which usually
+gives them a "pixelated" look.
+The bilinear filter smoothens the textures.
+The trilinear filter smoothens them even further.]]) .. "]" ..
 		"dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";"
 				.. getMipmapSettingIndex() .. "]" ..
 		"tooltip[dd_mipmap;" ..
-		fgettext("By using mip-mapping, objects which are further away will "..
-				"be using images of lower resolution.\nThe difference is barely "..
-				"visually noticable, but mip-mapping is great for slow machines.\n\n"..
-				"The anisotropic filter is another filter which will make the block "..
-				"surfaces look more smooth.") .. "]" ..
+		fgettext(
+[[By using mip-mapping, objects which are further away will be using images of
+lower resolution.
+The difference is barely visually noticable, but mip-mapping is great for slow
+machines.
+
+The anisotropic filter is another filter which will make the block surfaces
+look more smooth.]]) .. "]" ..
 
 		"label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
 		"dropdown[3.85,2.6;3.85;dd_video_driver;"
 				.. driver_formspec_string .. ";" .. driver_current_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
-		fgettext("The renderer is the most basic component which calculates and draws "..
-				"almost everything you will see in Minetest.\nOpenGL is the best "..
-				"and fastest renderer, but is only available if your video card supports "..
-				"it. Always use OpenGL if you can.\nBurning's video is a legacy driver "..
-				"which is not well-supported by Minetest, it is not recommended to use "..
-				"it unless you know what you do.\nThe software renderer works without a "..
-				"video card, but produces the worst results.\n\nYou must restart "..
-				"Minetest for a renderer change to take effect.") .. "]" ..
+		fgettext(
+[[The renderer is the most basic component which calculates and draws almost
+everything you will see in Minetest.
+OpenGL is the best and fastest renderer, but is only available if your video
+card supports it. Always use OpenGL if you can.
+Burning's video is a legacy driver which is not well-supported by Minetest,
+it is not recommended to use it unless you know what you do.
+The software renderer works without a video card, but produces the worst
+results.
+
+You must restart Minetest for a renderer change to take effect.]]) .. "]" ..
 		"box[7.75,0;4,4;#999999]" ..
 		"checkbox[8,0;cb_shaders;".. fgettext("Shaders") .. ";"
 				.. dump(core.setting_getbool("enable_shaders")) .. "]" ..
 		"tooltip[cb_shaders;"..
-		fgettext("This enables a variety of shading and other techniques, which make the "..
-				"shadows look more realistic.\nDisable shaders on slow systems.") .. "]"
+		fgettext(
+[[This enables a variety of shading and other techniques, which make the
+shadows look more realistic.
+Disable shaders on slow systems.]]) .. "]"
 
 	if PLATFORM ~= "Android" then
 		tab_string = tab_string ..
@@ -264,8 +278,9 @@ local function formspec(tabview, name, tabdata)
 	end
 
 	local scale_tooltip
-	local scale_tooltip_pt1 = fgettext("This slider determines the size of all GUI elements.\n"..
-			"WARNING: The changes will immediately take effect.")
+	local scale_tooltip_pt1 = fgettext(
+[[This slider determines the size of all GUI elements.
+WARNING: The changes will immediately take effect.]])
 	local scale_tooltip_pt2 = fgettext("Currently, a scaling factor of %.2f is applied "..
 			"to the GUI elements.")
 	local gui_scale = tonumber(core.setting_get("gui_scaling"))
@@ -301,33 +316,34 @@ local function formspec(tabview, name, tabdata)
 				"checkbox[8,0.5;cb_bumpmapping;".. fgettext("Bumpmapping") .. ";"
 						.. dump(core.setting_getbool("enable_bumpmapping")) .. "]"..
 				"tooltip[cb_bumpmapping;" ..
-				fgettext("Bump-mapping simulates bumps and wrinkles on an otherwise flat "..
-						"surface.\nIt will enhance the looks of surfaces and is "..
-						"not too demanding on the hardware.") .. "]" ..
+				fgettext(
+[[Bump-mapping simulates bumps and wrinkles on an otherwise flat surface.
+It will enhance the looks of surfaces and is not too demanding on the hardware.]]) .. "]" ..
 				"checkbox[8,1.0;cb_generate_normalmaps;".. fgettext("Generate Normalmaps") .. ";"
 						.. dump(core.setting_getbool("generate_normalmaps")) .. "]"..
 				"checkbox[8,1.5;cb_parallax;".. fgettext("Parallax Occlusion") .. ";"
 						.. dump(core.setting_getbool("enable_parallax_occlusion")) .. "]"..
 				"tooltip[cb_parallax;" ..
-				fgettext("Gives more the illusion of depth to the entire scene by using "..
-						"shadows.\nThis effect is not very much demanding on your "..
-						"hardware.") .. "]" ..
+				fgettext(
+[[Gives more the illusion of depth to the entire scene by using shadows.
+This effect is not very much demanding on your hardware.]]) .. "]" ..
 				"checkbox[8,2.0;cb_waving_water;".. fgettext("Waving Water") .. ";"
 						.. dump(core.setting_getbool("enable_waving_water")) .. "]"..
 				"tooltip[cb_waving_water;" ..
-				fgettext("If enabled, water blocks (and other liquids) will have a "..
-						"subtle wave animation.") .. "]" ..
+				fgettext(
+[[If enabled, water blocks (and other liquids) will have a subtle wave animation.]]) .. "]" ..
 				"checkbox[8,2.5;cb_waving_leaves;".. fgettext("Waving Leaves") .. ";"
 						.. dump(core.setting_getbool("enable_waving_leaves")) .. "]"..
 				"tooltip[cb_waving_leaves;" ..
-				fgettext("If enabled, leaf blocks (and other, similar blocks) will have "..
-						"a waving animation, as if the wind blows into the "..
-						"leaves.") .. "]" ..
+				fgettext(
+[[If enabled, leaf blocks (and other, similar blocks) will have a waving
+animation, as if the wind blows into the leaves.]]) .. "]" ..
 				"checkbox[8,3.0;cb_waving_plants;".. fgettext("Waving Plants") .. ";"
 						.. dump(core.setting_getbool("enable_waving_plants")) .. "]" ..
 				"tooltip[cb_waving_plants;" ..
-				fgettext("If enabled, plants (and other, similar-looking blocks) will "..
-						"wiggle, as if the wind blows into them.") .. "]"
+				fgettext(
+[[If enabled, plants (and other, similar-looking blocks) will wiggle, as if the
+wind blows into them.]]) .. "]"
 
 	else
 		tab_string = tab_string ..

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -180,48 +180,107 @@ local function formspec(tabview, name, tabdata)
 		"box[0,0;3.5,3.9;#999999]" ..
 		"checkbox[0.25,0;cb_smooth_lighting;".. fgettext("Smooth Lighting")
 				.. ";".. dump(core.setting_getbool("smooth_lighting")) .. "]"..
+		"tooltip[cb_smooth_lighting;"..
+		fgettext("If enabled, the light on surfaces will appear to be smooth.\nIf " ..
+				"disabled, the light will look rather flat, but is more " ..
+				"processor-friendly.") .. "]" ..
 		"checkbox[0.25,0.5;cb_particles;".. fgettext("Enable Particles") .. ";"
 				.. dump(core.setting_getbool("enable_particles"))	.. "]"..
+		"tooltip[cb_particles;"..
+		fgettext("If enabled, particles are displayed for a variety of events, most "..
+				"often for digging blocks.") .. "]" ..
 		"checkbox[0.25,1;cb_3d_clouds;".. fgettext("3D Clouds") .. ";"
 				.. dump(core.setting_getbool("enable_3d_clouds")) .. "]"..
+		"tooltip[cb_3d_clouds;"..
+		fgettext("If disabled, the clouds will be flat instead of 3-dimensional.") .. "]" ..
 		"checkbox[0.25,1.5;cb_fancy_trees;".. fgettext("Fancy Trees") .. ";"
 				.. dump(core.setting_getbool("new_style_leaves")) .. "]"..
+		"tooltip[cb_fancy_trees;"..
+		fgettext("If enabled, it is possible to look through leaves (and some other "..
+				"blocks).\nIf disabled, these blocks are opaque.\n\nIt may be "..
+				"neccessary to disable this effect on slow machines.") .. "]" ..
 		"checkbox[0.25,2.0;cb_opaque_water;".. fgettext("Opaque Water") .. ";"
 				.. dump(core.setting_getbool("opaque_water")) .. "]"..
+		"tooltip[cb_opaque_water;"..
+		fgettext("If enabled, you can't look through water (and some other blocks).") .. "]" ..
 		"checkbox[0.25,2.5;cb_connected_glass;".. fgettext("Connected Glass") .. ";"
 				.. dump(core.setting_getbool("connected_glass"))	.. "]"..
+		"tooltip[cb_connected_glass;"..
+		fgettext("If enabled, certain glass blocks (and other, similar blocks) will "..
+				"form larger shapes when placed next to each other.\nIf disabled, "..
+				"each such block will be displayed as \"singleton\", without "..
+				"connections.") .. "]" ..
 		"checkbox[0.25,3.0;cb_node_highlighting;".. fgettext("Node Highlighting") .. ";"
 				.. dump(core.setting_getbool("enable_node_highlighting")) .. "]"..
+		"tooltip[cb_node_highlighting;"..
+		fgettext("If enabled, the pointed node (block) will be surrounded by a bright "..
+				"translucent cuboid in a certain color.\nIf disabled, the pointed "..
+				"node will have drawn a thin wireframe around it.") .. "]" ..
 		"box[3.75,0;3.75,3.45;#999999]" ..
 		"label[3.85,0.1;".. fgettext("Texturing:") .. "]"..
 		"dropdown[3.85,0.55;3.85;dd_filters;" .. filters[1][1] .. ";"
 				.. getFilterSettingIndex() .. "]" ..
+		"tooltip[dd_filters;"..
+		fgettext("This changes the way how the surface images (textures) of blocks look.\n"..
+				"Using no filters will show the textures in their original form, "..
+				"which usually gives them a \"pixelated\" look.\nThe bilinear filter "..
+				"smoothens the textures.\nThe trilinear filter smoothens them "..
+				"even further.") .. "]" ..
 		"dropdown[3.85,1.35;3.85;dd_mipmap;" .. mipmap[1][1] .. ";"
 				.. getMipmapSettingIndex() .. "]" ..
+		"tooltip[dd_mipmap;" ..
+		fgettext("By using mip-mapping, objects which are further away will "..
+				"be using images of lower resolution.\nThe difference is barely "..
+				"visually noticable, but mip-mapping is great for slow machines.\n\n"..
+				"The anisotropic filter is another filter which will make the block "..
+				"surfaces look more smooth.") .. "]" ..
+
 		"label[3.85,2.15;".. fgettext("Rendering:") .. "]"..
 		"dropdown[3.85,2.6;3.85;dd_video_driver;"
 				.. driver_formspec_string .. ";" .. driver_current_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
-				fgettext("Restart minetest for driver change to take effect") .. "]" ..
+		fgettext("The renderer is the most basic component which calculates and draws "..
+				"almost everything you will see in Minetest.\nOpenGL is the best "..
+				"and fastest renderer, but is only available if your video card supports "..
+				"it. Always use OpenGL if you can.\nBurning's video is a legacy driver "..
+				"which is not well-supported by Minetest, it is not recommended to use "..
+				"it unless you know what you do.\nThe software renderer works without a "..
+				"video card, but produces the worst results.\n\nYou must restart "..
+				"Minetest for a renderer change to take effect.") .. "]" ..
 		"box[7.75,0;4,4;#999999]" ..
 		"checkbox[8,0;cb_shaders;".. fgettext("Shaders") .. ";"
-				.. dump(core.setting_getbool("enable_shaders")) .. "]"
+				.. dump(core.setting_getbool("enable_shaders")) .. "]" ..
+		"tooltip[cb_shaders;"..
+		fgettext("This enables a variety of shading and other techniques, which make the "..
+				"shadows look more realistic.\nDisable shaders on slow systems.") .. "]"
 
 	if PLATFORM ~= "Android" then
 		tab_string = tab_string ..
-		"button[8,4.75;3.75,0.5;btn_change_keys;".. fgettext("Change keys") .. "]"
+		"button[8,4.75;3.75,0.5;btn_change_keys;".. fgettext("Change keys") .. "]" ..
+		"tooltip[btn_change_keys;".. fgettext("Change the key-bindings") .. "]"
 	else
 		tab_string = tab_string ..
 		"button[8,4.75;3.75,0.5;btn_reset_singleplayer;".. fgettext("Reset singleplayer world") .. "]"
 	end
+
+	local scale_tooltip
+	local scale_tooltip_pt1 = fgettext("This slider determines the size of all GUI elements.\n"..
+			"WARNING: The changes will immediately take effect.")
+	local scale_tooltip_pt2 = fgettext("Currently, a scaling factor of %.2f is applied "..
+			"to the GUI elements.")
+	local gui_scale = tonumber(core.setting_get("gui_scaling"))
+	if gui_scale ~= nil then
+		scale_tooltip = scale_tooltip_pt1 .. "\n\n" .. string.format(scale_tooltip_pt2, gui_scale)
+	else
+		scale_tooltip = scale_tooltip_pt1
+	end
 	tab_string = tab_string ..
+
 		"box[0,4.25;3.5,1.1;#999999]" ..
 		"label[0.25,4.25;" .. fgettext("GUI scale factor") .. "]" ..
 		"scrollbar[0.25,4.75;3,0.4;sb_gui_scaling;horizontal;" ..
 		 gui_scale_to_scrollbar() .. "]" ..
-		"tooltip[sb_gui_scaling;" ..
-			fgettext("Scaling factor applied to menu elements: ") ..
-			dump(core.setting_get("gui_scaling")) .. "]"
+		"tooltip[sb_gui_scaling;" .. scale_tooltip.. "]"
 
 	if PLATFORM == "Android" then
 		tab_string = tab_string ..
@@ -241,16 +300,35 @@ local function formspec(tabview, name, tabdata)
 		tab_string = tab_string ..
 				"checkbox[8,0.5;cb_bumpmapping;".. fgettext("Bumpmapping") .. ";"
 						.. dump(core.setting_getbool("enable_bumpmapping")) .. "]"..
+				"tooltip[cb_bumpmapping;" ..
+				fgettext("Bump-mapping simulates bumps and wrinkles on an otherwise flat "..
+						"surface.\nIt will enhance the looks of surfaces and is "..
+						"not too demanding on the hardware.") .. "]" ..
 				"checkbox[8,1.0;cb_generate_normalmaps;".. fgettext("Generate Normalmaps") .. ";"
 						.. dump(core.setting_getbool("generate_normalmaps")) .. "]"..
 				"checkbox[8,1.5;cb_parallax;".. fgettext("Parallax Occlusion") .. ";"
 						.. dump(core.setting_getbool("enable_parallax_occlusion")) .. "]"..
+				"tooltip[cb_parallax;" ..
+				fgettext("Gives more the illusion of depth to the entire scene by using "..
+						"shadows.\nThis effect is not very much demanding on your "..
+						"hardware.") .. "]" ..
 				"checkbox[8,2.0;cb_waving_water;".. fgettext("Waving Water") .. ";"
 						.. dump(core.setting_getbool("enable_waving_water")) .. "]"..
+				"tooltip[cb_waving_water;" ..
+				fgettext("If enabled, water blocks (and other liquids) will have a "..
+						"subtle wave animation.") .. "]" ..
 				"checkbox[8,2.5;cb_waving_leaves;".. fgettext("Waving Leaves") .. ";"
 						.. dump(core.setting_getbool("enable_waving_leaves")) .. "]"..
+				"tooltip[cb_waving_leaves;" ..
+				fgettext("If enabled, leaf blocks (and other, similar blocks) will have "..
+						"a waving animation, as if the wind blows into the "..
+						"leaves.") .. "]" ..
 				"checkbox[8,3.0;cb_waving_plants;".. fgettext("Waving Plants") .. ";"
-						.. dump(core.setting_getbool("enable_waving_plants")) .. "]"
+						.. dump(core.setting_getbool("enable_waving_plants")) .. "]" ..
+				"tooltip[cb_waving_plants;" ..
+				fgettext("If enabled, plants (and other, similar-looking blocks) will "..
+						"wiggle, as if the wind blows into them.") .. "]"
+
 	else
 		tab_string = tab_string ..
 				"textlist[8.33,0.7;4,1;;#888888" .. fgettext("Bumpmapping") .. ";0;true]" ..

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -251,8 +251,10 @@ look more smooth.]]) .. "]" ..
 		fgettext(
 [[The renderer is the most basic component which calculates and draws almost
 everything you will see in Minetest.
-OpenGL is the best and fastest renderer, but is only available if your video
-card supports it. Always use OpenGL if you can.
+OpenGL is a cross-platform renderer which needs support from your video card.
+It supports shaders.
+DirectX 9.0 (direct3d9) is the native renderer for Windows and is only
+available on Windows systems and if your video card supports it.
 Burning's video is a legacy driver which is not well-supported by Minetest,
 it is not recommended to use it unless you know what you do.
 The software renderer works without a video card, but produces the worst
@@ -266,21 +268,19 @@ You must restart Minetest for a renderer change to take effect.]]) .. "]" ..
 		fgettext(
 [[This enables a variety of shading and other techniques, which make the
 shadows look more realistic.
+Shaders are only available if you choose OpenGL as renderer.
 Disable shaders on slow systems.]]) .. "]"
 
 	if PLATFORM ~= "Android" then
 		tab_string = tab_string ..
-		"button[8,4.75;3.75,0.5;btn_change_keys;".. fgettext("Change keys") .. "]" ..
-		"tooltip[btn_change_keys;".. fgettext("Change the key-bindings") .. "]"
+		"button[8,4.75;3.75,0.5;btn_change_keys;".. fgettext("Change key-bindings") .. "]"
 	else
 		tab_string = tab_string ..
 		"button[8,4.75;3.75,0.5;btn_reset_singleplayer;".. fgettext("Reset singleplayer world") .. "]"
 	end
 
 	local scale_tooltip
-	local scale_tooltip_pt1 = fgettext(
-[[This slider determines the size of all GUI elements.
-WARNING: The changes will immediately take effect.]])
+	local scale_tooltip_pt1 = fgettext("WARNING: The changes will immediately take effect.")
 	local scale_tooltip_pt2 = fgettext("Currently, a scaling factor of %.2f is applied "..
 			"to the GUI elements.")
 	local gui_scale = tonumber(core.setting_get("gui_scaling"))

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -249,9 +249,7 @@ look more smooth.]]) .. "]" ..
 				.. driver_formspec_string .. ";" .. driver_current_idx .. "]" ..
 		"tooltip[dd_video_driver;" ..
 		fgettext(
-[[The renderer is the most basic component which calculates and draws almost
-everything you will see in Minetest.
-OpenGL is a cross-platform renderer which needs support from your video card.
+[[OpenGL is a cross-platform renderer which needs support from your video card.
 It supports shaders.
 DirectX 9.0 (direct3d9) is the native renderer for Windows and is only
 available on Windows systems and if your video card supports it.

--- a/builtin/mainmenu/tab_simple_main.lua
+++ b/builtin/mainmenu/tab_simple_main.lua
@@ -25,17 +25,24 @@ local function get_formspec(tabview, name, tabdata)
 		"label[8,0.5;".. fgettext("Name/Password") .. "]" ..
 		"field[0.25,3.25;5.5,0.5;te_address;;" ..
 		core.formspec_escape(core.setting_get("address")) .."]" ..
+		"tooltip[te_address;" .. tooltips.te_address .. "]" ..
 		"field[5.75,3.25;2.25,0.5;te_port;;" ..
 		core.formspec_escape(core.setting_get("remote_port")) .."]" ..
+		"tooltip[te_port;" .. tooltips.te_port .. "]" ..
 		"checkbox[8,-0.25;cb_public_serverlist;".. fgettext("Public Serverlist") .. ";" ..
 		render_details .. "]"
+		"tooltip[cb_public_serverlist;" .. tooltips.cb_public_serverlist .. "]" ..
 
 	retval = retval ..
 		"button[8,2.5;4,1.5;btn_mp_connect;".. fgettext("Connect") .. "]" ..
+		"tooltip[btn_mp_connect;" .. tooltips.btn_mp_connect .. "]" ..
 		"field[8.75,1.5;3.5,0.5;te_name;;" ..
 		core.formspec_escape(core.setting_get("name")) .."]" ..
-		"pwdfield[8.75,2.3;3.5,0.5;te_pwd;]"
-		
+		"tooltip[te_name;" .. tooltips.te_name .. "]" ..
+		"pwdfield[8.75,2.3;3.5,0.5;te_pwd;]" ..
+		"tooltip[te_pwd;" .. tooltips.te_pwd .. "]"
+
+
 	if render_details then
 		retval = retval .. "tablecolumns[" ..
 			"color,span=3;" ..

--- a/builtin/mainmenu/tab_singleplayer.lua
+++ b/builtin/mainmenu/tab_singleplayer.lua
@@ -89,8 +89,10 @@ local function get_formspec(tabview, name, tabdata)
 			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
 			"checkbox[0.25,0.25;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.setting_getbool("creative_mode")) .. "]"..
+			"tooltip[cb_creative_mode;"..tooltips.cb_creative_mode .. "]" ..
 			"checkbox[0.25,0.7;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
 			dump(core.setting_getbool("enable_damage")) .. "]"..
+			"tooltip[cb_enable_damage;"..tooltips.cb_enable_damage .. "]" ..
 			"textlist[4,0.25;7.5,3.7;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]"


### PR DESCRIPTION
This PR adds a lot of tooltips throughout the main menu for the menu elements where I thought that they may need more explanation.

Included:
- Almost all checkboxes everywhere
- All drop-down menus
- Most non-obvious buttons
- “Arrow buttons” of the buttonbar

You will probably notice 2 problems:
- (now fixed) “\,” is written in tooltips where it should just be “,”. This is a bug with tooltips in Minetest, see #2428
- The drop-down menu appear to have no tooltips. They actually have tooltips, they are not shown because of another bug in Minetest, see: #1577 

Fixing those bugs is _not_ a goal of this PR, those are problems which should be handled in different commits (IMHO).

This PR is slightly WIP, but mostly finishe. Basically I just want to have some feedback to ensure that everything is OK.

I would like to hear comments in particular about the tooltips themselves. Please proofread them for factual accuracy. I am not a pro in graphics programming, so a couple of settings tooltips may be wrong.
A tooltip for the checkbox “Generate normalmaps” is missing, because I don't really know what is actually happening there. Suggestions for a tooltip text are welcome. (Also an explanation of what this does :-))
