### PR TITLE
Make MutexedQueue use std::deque instead of using a std::list member

### DIFF
--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -130,9 +130,9 @@ public:
 			/*
 				If the caller is already on the list, only update CallerData
 			*/
-			for(typename std::list< GetRequest<Key, T, Caller, CallerData> >::iterator
-					i = m_queue.getList().begin();
-					i != m_queue.getList().end(); ++i)
+			for(typename std::deque< GetRequest<Key, T, Caller, CallerData> >::iterator
+					i = m_queue.getQueue().begin();
+					i != m_queue.getQueue().end(); ++i)
 			{
 				GetRequest<Key, T, Caller, CallerData> &request = *i;
 


### PR DESCRIPTION
At this moment MutexedQueue is a queue which is using JMutex. Instead of using a std::list we should use a std::deque which is optimized for reading from front or back.