### PR TITLE
Dungeongen: Optionally set ignore to be untouchable to disable floating dungeons

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -469,6 +469,8 @@
 #    Controls size of deserts and beaches in Mapgen V6
 #mgv6_freq_desert = 0.45
 #mgv6_freq_beach = 0.15
+#    Enable/disable floating dungeons and dungeon slices
+#enable_floating_dungeons = true
 
 #    Perlin noise attributes for different map generation parameters.
 #    Noise parameters can be specified as a set of positional values:

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -292,6 +292,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_level", "1");
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "");
+	settings->setDefault("enable_floating_dungeons", "true");
 
 	// IPv6
 	settings->setDefault("enable_ipv6", "true");

--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -79,14 +79,17 @@ void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax) {
 	// Dungeon generator doesn't modify places which have this set
 	vm->clearFlag(VMANIP_FLAG_DUNGEON_INSIDE | VMANIP_FLAG_DUNGEON_PRESERVE);
 
-	// Set all air and water to be untouchable to make dungeons open
-	// to caves and open air
+	bool no_float = !g_settings->getBool("enable_floating_dungeons");
+
+	// Set all air and water (and optionally ignore) to be untouchable
+	// to make dungeons open to caves and open air
 	for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 		for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 			u32 i = vm->m_area.index(nmin.X, y, z);
 			for (s16 x = nmin.X; x <= nmax.X; x++) {
 				content_t c = vm->m_data[i].getContent();
-				if (c == CONTENT_AIR || c == dp.c_water)
+				if (c == CONTENT_AIR || c == dp.c_water
+						|| (no_float && c == CONTENT_IGNORE))
 					vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 				i++;
 			}


### PR DESCRIPTION
Needs testing. To test you will need to disable floating dungeons with this line in .conf:
enable_floating_dungeons = false
That is set to true by default.