### PR TITLE
Heightmaps: Generalise for all mapgens. findGroundLevel: Return -MAP_GENERATION_LIMIT if surface not found

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -41,8 +41,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 const char *GenElementManager::ELEMENT_TITLE = "element";
 
-static const s16 INVALID_HEIGHT = MAP_GENERATION_LIMIT + 1;
-
 FlagDesc flagdesc_mapgen[] = {
 	{"trees",    MG_TREES},
 	{"caves",    MG_CAVES},
@@ -140,6 +138,7 @@ s16 Mapgen::findGroundLevelFull(v2s16 p2d)
 }
 
 
+// Returns -MAP_GENERATION_LIMIT if not found
 s16 Mapgen::findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax)
 {
 	v3s16 em = vm->m_area.getExtent();
@@ -153,15 +152,9 @@ s16 Mapgen::findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax)
 
 		vm->m_area.add_y(em, i, -1);
 	}
-	return y;
+	return (y >= ymin) ? y : -MAP_GENERATION_LIMIT;
 }
 
-
-void Mapgen::initHeightMap(s16 *dest, size_t len)
-{
-	for (size_t i = 0; i < len; i++)
-		dest[i] = INVALID_HEIGHT;
-}
 
 void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 {
@@ -173,14 +166,6 @@ void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 	for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 		for (s16 x = nmin.X; x <= nmax.X; x++, index++) {
 			s16 y = findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
-
-			if (heightmap[index] != INVALID_HEIGHT) {
-				// if the values found are out of range, trust the old heightmap
-				if (y == nmax.Y && heightmap[index] > nmax.Y)
-					continue;
-				if (y == nmin.Y - 1 && heightmap[index] < nmin.Y)
-					continue;
-			}
 
 			heightmap[index] = y;
 		}

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -154,7 +154,6 @@ public:
 	static u32 getBlockSeed2(v3s16 p, int seed);
 	s16 findGroundLevelFull(v2s16 p2d);
 	s16 findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax);
-	void initHeightMap(s16 *dest, size_t len);
 	void updateHeightmap(v3s16 nmin, v3s16 nmax);
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -60,8 +60,6 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->biomemap  = new u8[csize.X * csize.Z];
 	this->heightmap = new s16[csize.X * csize.Z];
 
-	initHeightMap(this->heightmap, csize.X * csize.Z);
-
 	MapgenV5Params *sp = (MapgenV5Params *)params->sparams;
 	this->spflags      = sp->spflags;
 

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -57,8 +57,6 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 
 	this->heightmap = new s16[csize.X * csize.Z];
 
-	initHeightMap(this->heightmap, csize.X * csize.Z);
-
 	MapgenV6Params *sp = (MapgenV6Params *)params->sparams;
 	this->spflags     = sp->spflags;
 	this->freq_desert = sp->freq_desert;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -64,8 +64,6 @@ MapgenV7::MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->heightmap = new s16[csize.X * csize.Z];
 	this->ridge_heightmap = new s16[csize.X * csize.Z];
 
-	initHeightMap(this->heightmap, csize.X * csize.Z);
-
 	MapgenV7Params *sp = (MapgenV7Params *)params->sparams;
 	this->spflags = sp->spflags;
 


### PR DESCRIPTION
Previously only mgv7 used updateHeightmap, generateBaseTerrain first calculated the heightmap values, and if updateHeightmap didn't find ground the previous values were used instead.
Now mgv5 and mgv6 also use heightmaps, the base terrain functions of these do not first calculate the heightmap values, so when updateHeightmap was run and found no ground the height value was wrongly set to nmin.Y - 1, this commit corrects this by returning -MAP_GENERATION_LIMIT instead.