### PR TITLE
Add Android Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ notifications:
   email: false
 matrix:
   fast_finish: true
+  include:
+    - env: ANDROID=yes
+      compiler: gcc
   exclude:
     - env: WINDOWS=32
       compiler: clang

--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -3,10 +3,12 @@
 OS := $(shell uname)
 
 #automaticaly set number of jobs
-ifeq ($(OS),Linux)
-  PARALLEL := $(shell grep -c ^processor /proc/cpuinfo)
-else
-  PARALLEL := 1
+ifndef PARALLEL
+	ifeq ($(OS),Linux)
+		PARALLEL := $(shell grep -c ^processor /proc/cpuinfo)
+	else
+		PARALLEL := 1
+	endif
 endif
 
 # compile with GPROF

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -9,7 +9,35 @@ if [ $CC = "clang" ]; then
 	sudo apt-get install clang
 fi
 sudo apt-get install p7zip-full
-if [ $WINDOWS = "no" ]; then
+if [ $ANDROID = "yes" ]; then
+	
+	printf "Generating swap..."
+	# create approx 5 GB swap
+	sudo dd if=/dev/zero of=/swap count=10000000 
+	sudo mkswap /swap
+	sudo swapon -p1 /swap
+	echo " Done."
+	mount
+
+	# Android builds require this, otherwise they give obscure "no such file or directory" error
+	if [ `uname -m` = x86_64 ]; then
+		sudo apt-get update
+		sudo apt-get install --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch
+	fi
+
+	# Download sdk and ndk
+	wget https://dl.google.com/android/android-sdk_r24.0.1-linux.tgz -O android-sdk.tgz
+	wget https://dl.google.com/android/ndk/android-ndk-r9b-linux-x86_64.tar.bz2 -O android-ndk.tar.bz2
+	printf "Extracting sdk and ndk archives..."
+	tar xf android-sdk.tgz
+	tar xf android-ndk.tar.bz2
+	echo " Done."
+	sudo mv android-sdk-linux /usr/local/android-sdk
+	sudo mv android-ndk-r9b /usr/local/android-ndk
+	( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) |\
+		/usr/local/android-sdk/tools/android update sdk --no-ui --filter \
+		platform-tool,android-10,build-tools-21.1.2
+elif [ $WINDOWS = "no" ]; then
 	sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
 	libjpeg8-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libhiredis-dev \
 	libogg-dev libvorbis-dev libopenal-dev gettext

--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -1,6 +1,17 @@
 #!/bin/bash -e
 
-if [ $WINDOWS = "no" ]; then
+if [ $ANDROID = "yes" ]; then
+	cd build/android
+	printf "%s\n%s\n%s" \
+		"ANDROID_NDK = /usr/local/android-ndk" \
+		"NDK_MODULE_PATH = /usr/local/android-ndk/toolchains" \
+		"SDKFOLDER = /usr/local/android-sdk" > path.cfg
+	# Parallelism is still unstable. Disable it.
+	export PARALLEL=1
+	ramreport() { while true; do sleep 21; df -h ; done }
+	ramreport &
+	make
+elif [ $WINDOWS = "no" ]; then
 	mkdir -p travisbuild
 	cd travisbuild
 	cmake -DENABLE_GETTEXT=1 -DENABLE_LEVELDB=1 -DENABLE_REDIS=1 -DCMAKE_BUILD_TYPE=Debug ..


### PR DESCRIPTION
fixes #2436. Build time needed: around 17 minutes. A must-have as android build can break without anyone noticing. Working builds are required for bisecting to work.