### PR TITLE
Configurable automatic texture scaling and filtering at load time.

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -193,6 +193,19 @@
 #anisotropic_filter = false
 #bilinear_filter = false
 #trilinear_filter = false
+#    Filtered textures can blend RGB values with fully-transparent neighbors,
+#    which PNG optimizers usually discard, sometimes resulting in a dark or
+#    light edge to transparent textures.  Apply this filter to clean that up
+#    at texture load time.
+#texture_clean_transparent = true
+#    When using bilinear/trilinear/anisotropic filters, low-resolution textures
+#    can be blurred, so automatically upscale them with nearest-neighbor
+#    interpolation to preserve crisp pixels.  This sets the minimum texture size
+#    for the upscaled textures; higher values look sharper, but require more
+#    memory.  Powers of 2 are recommended.  Setting this higher than 1 may not
+#    have a visible effect unless bilinear/trilinear/anisotropic filtering is
+#    enabled.
+#texture_min_size = 16
 #    Set to true to pre-generate all item visuals
 #preload_item_visuals = false
 #    Set to true to enable shaders. Disable them if video_driver = direct3d9/8.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -149,6 +149,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("anisotropic_filter", "false");
 	settings->setDefault("bilinear_filter", "false");
 	settings->setDefault("trilinear_filter", "false");
+	settings->setDefault("texture_clean_transparent", "true");
+	settings->setDefault("texture_min_size", "64");
 	settings->setDefault("preload_item_visuals", "false");
 	settings->setDefault("enable_bumpmapping", "false");
 	settings->setDefault("enable_parallax_occlusion", "false");


### PR DESCRIPTION
Adds options to improve texture quality on low-end systems.  Filters are applied at texture load time, so performance impact in-game should be minimal.  "Fixes" #2154.

Before:
![screenshot_4144981704](https://cloud.githubusercontent.com/assets/324806/6544177/2708118a-c511-11e4-963e-e5c6567583af.png)

After (both filters enabled):
![screenshot_4145080761](https://cloud.githubusercontent.com/assets/324806/6544179/34b2bd44-c511-11e4-9208-72c9b7c746fe.png)
