### PR TITLE
lua_api/l_mapgen: Fix overlapping areas of minetest.generate_ores/decorations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1903,10 +1903,10 @@ and `minetest.auth_reload` call the authetification handler.
     * Sets the noiseparams setting of `name` to the noiseparams table specified in `noiseparams`.
     * `set_default` is an optional boolean (default: `true`) that specifies whether the setting
       should be applied to the default config or current active config
-* `minetest.generate_ores(vm)`
-   * Generate all registered ores within the VoxelManip specified by `vm`.
-* `minetest.generate_decorations(vm)`
-   * Generate all registered decorations within the VoxelManip specified by `vm`.
+* `minetest.generate_ores(vm, p1, p2)`
+   * Generate all registered ores within the VoxelManip `vm` and in the area from p1 to p2.
+* `minetest.generate_decorations(vm, p1, p2)`
+   * Generate all registered decorations within the VoxelManip `vm` and in the area from p1 to p2.
 * `minetest.clear_objects()`
     * clear all objects in the environments
 * `minetest.delete_area(pos1, pos2)`

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -806,7 +806,7 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 	return 1;
 }
 
-// generate_ores(vm, [ore_id])
+// generate_ores(vm, p1, p2, [ore_id])
 int ModApiMapgen::l_generate_ores(lua_State *L)
 {
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
@@ -818,13 +818,15 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(mg.vm->m_area.MinEdge, mg.seed);
 
-	emerge->oremgr->placeAllOres(&mg, blockseed,
-		mg.vm->m_area.MinEdge, mg.vm->m_area.MaxEdge);
+	v3s16 pmin = read_v3s16(L, 2);
+	v3s16 pmax = read_v3s16(L, 3);
+
+	emerge->oremgr->placeAllOres(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }
 
-// generate_decorations(vm, [deco_id])
+// generate_decorations(vm, p1, p2, [deco_id])
 int ModApiMapgen::l_generate_decorations(lua_State *L)
 {
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
@@ -836,8 +838,10 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(mg.vm->m_area.MinEdge, mg.seed);
 
-	emerge->decomgr->placeAllDecos(&mg, blockseed,
-		mg.vm->m_area.MinEdge, mg.vm->m_area.MaxEdge);
+	v3s16 pmin = read_v3s16(L, 2);
+	v3s16 pmax = read_v3s16(L, 3);
+
+	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
 
 	return 0;
 }

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -62,10 +62,10 @@ private:
 	// clear_registered_decorations()
 	static int l_clear_registered_decorations(lua_State *L);
 
-	// generate_ores(vm)
+	// generate_ores(vm, p1, p2)
 	static int l_generate_ores(lua_State *L);
 
-	// generate_decorations(vm)
+	// generate_decorations(vm, p1, p2)
 	static int l_generate_decorations(lua_State *L);
 
 	// clear_registered_ores


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/2464 by adding p1, p2 to define area, normally set to minp, maxp of mapchunk.