### PR TITLE
Mgv6: Fix uninitialised heightmap used by cavegen

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -56,7 +56,6 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->ystride = csize.X; //////fix this
 
 	this->heightmap = new s16[csize.X * csize.Z];
-	memset(this->heightmap, 0, csize.X * csize.Z * sizeof(*this->heightmap));
 
 	MapgenV6Params *sp = (MapgenV6Params *)params->sparams;
 	this->spflags     = sp->spflags;
@@ -480,6 +479,9 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 
 	generateExperimental();
 
+	// Create initial heightmap to limit caves
+	updateHeightmap(node_min, node_max);
+
 	const s16 max_spread_amount = MAP_BLOCKSIZE;
 	// Limit dirt flow area by 1 because mud is flown into neighbors.
 	s16 mudflow_minpos = -max_spread_amount + 1;
@@ -504,7 +506,7 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 
 	}
 
-	// Create heightmap after mudflow
+	// Update heightmap after mudflow
 	updateHeightmap(node_min, node_max);
 
 	// Add dungeons


### PR DESCRIPTION
Fixes error introduced when heightmap was added to mgv6. Heightmap needs creating before cavegen and updating after mudflow.