### PR TITLE
mg_decoration: increase max_y to fix missing trees

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -148,7 +148,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				continue;
 
 			int height = getHeight();
-			int max_y = nmax.Y;// + MAP_BLOCKSIZE - 1;
+			int max_y = nmax.Y + MAP_BLOCKSIZE - 1;
 			if (y + 1 + height > max_y) {
 				continue;
 #if 0


### PR DESCRIPTION
Currenty, the max_y for decorations is wrongly set to the top of the mapchunk. Any simple or schematic decoration that exceeds this y is not placed, resulting in missing trees at certain altitudes.
There is a comment in the line that increases the max_y to the top of the voxelmanip volume, as it should be. The voxelmanip volume is the mapchunk plus a shell of mapblocks, this enables trees below 16 nodes in height to be placed at y = 47 without being chopped.
Tested, the missing trees return.