### PR TITLE
 mg_decoration: Raise highest allowed deco top to max edge of voxelmanip

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -147,9 +147,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				y < y_min  || y > y_max)
 				continue;
 
-			int height = getHeight();
-			int max_y = nmax.Y;// + MAP_BLOCKSIZE - 1;
-			if (y + 1 + height > max_y) {
+			if (y + getHeight() >= mg->vm->m_area.MaxEdge.Y) {
 				continue;
 #if 0
 				printf("Decoration at (%d %d %d) cut off\n", x, y, z);
@@ -170,7 +168,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 			}
 
 			v3s16 pos(x, y, z);
-			if (generate(mg->vm, &ps, max_y, pos))
+			if (generate(mg->vm, &ps, pos))
 				mg->gennotify.addEvent(GENNOTIFY_DECORATION, pos, id);
 		}
 	}
@@ -289,7 +287,7 @@ bool DecoSimple::canPlaceDecoration(MMVManip *vm, v3s16 p)
 }
 
 
-size_t DecoSimple::generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p)
+size_t DecoSimple::generate(MMVManip *vm, PseudoRandom *pr, v3s16 p)
 {
 	if (!canPlaceDecoration(vm, p))
 		return 0;
@@ -298,8 +296,6 @@ size_t DecoSimple::generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p)
 
 	s16 height = (deco_height_max > 0) ?
 		pr->range(deco_height, deco_height_max) : deco_height;
-
-	height = MYMIN(height, max_y - p.Y);
 
 	v3s16 em = vm->m_area.getExtent();
 	u32 vi = vm->m_area.index(p);
@@ -326,7 +322,7 @@ int DecoSimple::getHeight()
 ///////////////////////////////////////////////////////////////////////////////
 
 
-size_t DecoSchematic::generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p)
+size_t DecoSchematic::generate(MMVManip *vm, PseudoRandom *pr, v3s16 p)
 {
 	if (flags & DECO_PLACE_CENTER_X)
 		p.X -= (schematic->size.X + 1) / 2;

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -84,7 +84,7 @@ public:
 	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	//size_t placeCutoffs(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
-	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p) = 0;
+	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, v3s16 p) = 0;
 	virtual int getHeight() = 0;
 };
 
@@ -99,7 +99,7 @@ public:
 	virtual void resolveNodeNames(NodeResolveInfo *nri);
 
 	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
-	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p);
+	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, v3s16 p);
 	virtual int getHeight();
 };
 
@@ -109,7 +109,7 @@ public:
 	Schematic *schematic;
 	std::string filename;
 
-	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, s16 max_y, v3s16 p);
+	virtual size_t generate(MMVManip *vm, PseudoRandom *pr, v3s16 p);
 	virtual int getHeight();
 };
 


### PR DESCRIPTION
Currenty, the max_y for decorations is wrongly set to the top of the mapchunk. Any simple or schematic decoration that exceeds this y is not placed, resulting in missing trees at certain altitudes.
The voxelmanip volume is the mapchunk plus a shell of mapblocks, this enables trees below 16 nodes in height to be placed at y = 47 without being chopped.
Tested, the missing trees return.