### PR TITLE
Server::step throw is never catched in minetestserver

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -481,8 +481,16 @@ void Server::step(float dtime)
 	}
 	// Throw if fatal error occurred in thread
 	std::string async_err = m_async_fatal_error.get();
-	if(async_err != ""){
-		throw ServerError(async_err);
+	if(async_err != "") {
+		if (m_simple_singleplayer_mode) {
+			throw ServerError(async_err);
+		}
+		else {
+			errorstream << "UNRECOVERABLE error occurred. Stopping server. "
+					<< "Please fix the following error:" << std::endl
+					<< async_err << std::endl;
+			FATAL_ERROR(async_err.c_str());
+		}
 	}
 }
 


### PR DESCRIPTION
Replace it with an errorstream + assert for server

This throw can be trigger by LuaError exception or ConnectionBindFailed exception in the following functions:
* EmergeThread::Thread()
* ScriptApiEnv::environment_Step()
* ScriptApiEnv::player_event()
* ServerThread::Thread()