### PR TITLE
Pass version information to joinplayer callback

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1751,7 +1751,7 @@ Call these functions only at load time!
 * `minetest.register_on_prejoinplayer(func(name, ip))`
      * Called before a player joins the game
      * If it returns a string, the player is disconnected with that string as reason
-* `minetest.register_on_joinplayer(func(ObjectRef))`
+* `minetest.register_on_joinplayer(func(ObjectRef, client_version))`
     * Called when a player joins the game
 * `minetest.register_on_leaveplayer(func(ObjectRef))`
     * Called when a player leaves the game

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -683,7 +683,8 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	///// begin compatibility code
 	if (protocol_version <= 22) {
 		m_clients.event(pkt->getPeerId(), CSE_SetClientReady);
-		m_script->on_joinplayer(playersao);
+		RemoteClient* client = getClientNoEx(pkt->getPeerId());
+		m_script->on_joinplayer(playersao, client);
 	}
 	///// end compatibility code
 
@@ -764,7 +765,8 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 			std::string(pkt->getString(6),(u16) pkt->getU8(4)));
 
 	m_clients.event(peer_id, CSE_SetClientReady);
-	m_script->on_joinplayer(playersao);
+	RemoteClient* client = getClientNoEx(pkt->getPeerId());
+	m_script->on_joinplayer(playersao, client);
 }
 
 void Server::handleCommand_GotBlocks(NetworkPacket* pkt)

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -76,16 +76,34 @@ bool ScriptApiPlayer::on_prejoinplayer(std::string name, std::string ip, std::st
 	return false;
 }
 
-void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player)
+void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player, RemoteClient *client)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_joinplayers
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_joinplayers");
-	// Call callbacks
+	// Set arguments
 	objectrefGetOrCreate(L, player);
-	script_run_callbacks(L, 1, RUN_CALLBACKS_MODE_FIRST);
+	if (client) {
+		lua_newtable(L);
+		lua_pushstring(L, "major");
+		lua_pushnumber(L, client->getMajor());
+		lua_settable(L, -3);
+		lua_pushstring(L, "minor");
+		lua_pushnumber(L, client->getMinor());
+		lua_settable(L, -3);
+		lua_pushstring(L, "patch");
+		lua_pushnumber(L, client->getPatch());
+		lua_settable(L, -3);
+		lua_pushstring(L, "full_version");
+		lua_pushstring(L, client->getVersion().c_str());
+		lua_settable(L, -3);
+	} else {
+		lua_pushnil(L);
+	}
+	// Call callbacks
+	script_run_callbacks(L, 2, RUN_CALLBACKS_MODE_FIRST);
 }
 
 void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player)

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 
 #include "cpp_api/s_base.h"
-
+#include "clientiface.h"
 
 class ScriptApiPlayer
 		: virtual public ScriptApiBase
@@ -35,7 +35,7 @@ public:
 	void on_dieplayer(ServerActiveObject *player);
 	bool on_respawnplayer(ServerActiveObject *player);
 	bool on_prejoinplayer(std::string name, std::string ip, std::string &reason);
-	void on_joinplayer(ServerActiveObject *player);
+	void on_joinplayer(ServerActiveObject *player, RemoteClient *client);
 	void on_leaveplayer(ServerActiveObject *player);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
 


### PR DESCRIPTION
This allows to make nice remainders that a player's minetest version is outdated easier. nerzhul, can you approve that I add these changes under minetest's license?
You can test this by:
```
minetest.register_on_joinplayer(function(player, client_version)
	print(player:get_player_name() .. " joined with version " .. dump(client_version))
end)
```
The main goal for this PR is to enable server owners to add nice "please use a recent version of minetest" messages to their servers, to notify them of a latest minetest version. This is simpler than writing an own updater inside the mainmenu, and also catches legacy clients.