### PR TITLE
Add a Lua call to do damages / heals

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2336,6 +2336,7 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `right_click(clicker)`; `clicker` is another `ObjectRef`
 * `get_hp()`: returns number of hitpoints (2 * number of hearts)
 * `set_hp(hp)`: set number of hitpoints (2 * number of hearts)
+* `apply_damage(damage)`: set amount of damage to object. If damage < 0, heal the target
 * `get_inventory()`: returns an `InvRef`
 * `get_wield_list()`: returns the name of the inventory list the wielded item is in
 * `get_wield_index()`: returns the index of the wielded item

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -83,6 +83,12 @@ private:
 	// 0 if not applicable to this type of object
 	static int l_get_hp(lua_State *L);
 
+	// apply_damage(self, damage)
+	// damage = amount of damage to apply
+	// if damage is negative, heal the player
+	// returns: nil
+	static int l_apply_damage(lua_State *L);
+
 	// get_inventory(self)
 	static int l_get_inventory(lua_State *L);
 


### PR DESCRIPTION
This Lua call permit mods which are doing damages, like TNT, Nuke, and some others to do damages properly and disable the damages if the configuration doesn't permit it.
This permits to replace the misused set_hp call in many mods which doesn't care about enable_damage settings (and this is normal, it's a set_hp setter, not set_damage setter)