### PR TITLE
Mgv5/mgv7: Sprinkle dust from full_node_max.Y if chunk above is generated

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
+#define LARGE_CAVE_DEPTH -256
+
 /////////////////// Mapgen V5 flags
 //#define MGV5_   0x01
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -691,9 +691,28 @@ void MapgenV7::dustTopNodes()
 		if (biome->c_dust == CONTENT_IGNORE)
 			continue;
 
-		s16 y = node_max.Y;
-		u32 vi = vm->m_area.index(x, y, z);
-		for (; y >= node_min.Y; y--) {
+		s16 y_full_max = full_node_max.Y;
+		u32 vi_full_max = vm->m_area.index(x, y_full_max, z);
+		content_t c_full_max = vm->m_data[vi_full_max].getContent();
+		s16 y_start;
+
+		if (c_full_max == CONTENT_AIR) {
+			y_start = y_full_max - 1;
+		} else if (c_full_max == CONTENT_IGNORE) {
+			s16 y_max = node_max.Y;
+			u32 vi_max = vm->m_area.index(x, y_max, z);
+			content_t c_max = vm->m_data[vi_max].getContent();
+
+			if (c_max == CONTENT_AIR)
+				y_start = y_max - 1;
+			else
+				continue;
+		} else {
+			continue;
+		}
+
+		u32 vi = vm->m_area.index(x, y_start, z);
+		for (s16 y = y_start; y >= node_min.Y - 1; y--) {
 			if (vm->m_data[vi].getContent() != CONTENT_AIR)
 				break;
 
@@ -701,10 +720,7 @@ void MapgenV7::dustTopNodes()
 		}
 
 		content_t c = vm->m_data[vi].getContent();
-		if (!ndef->get(c).buildable_to && c != CONTENT_IGNORE) {
-			if (y == node_max.Y)
-				continue;
-
+		if (!ndef->get(c).buildable_to && c != CONTENT_IGNORE && c != biome->c_dust) {
 			vm->m_area.add_y(em, vi, 1);
 			vm->m_data[vi] = MapNode(biome->c_dust);
 		}


### PR DESCRIPTION
Recently decorations and trees were allowed to be generated to 'full_node_max.Y' which is 16 nodes above the chunk top.
Because biome 'dust' was still dropped from the mapchunk top (node_max.Y) the tops of trees were missing their dusting if the chunk above had been generated first (if the chunk above is generated afterwards its own dust does the job).
First i always dropped dust from full node max Y but discovered dust within the chunk failed if the chunk above had not been generated first, the ignore nodes were blocking the dust.

Now the dust is dropped from full node max Y if the chunk above was generated first, and dropped from node max Y if it wasn't. This works in all circumstances but still has a glitch at y = 47 that i don't yet understand, the dust on top of y = 47 is missing if the chunk below generates first.

This PR could probably be improved, any input from hmmmm would be much appreciated.