### PR TITLE
findSpawnPos should use the static_spawnpoint to set the player position

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3180,18 +3180,18 @@ std::string Server::getBuiltinLuaPath()
 	return porting::path_share + DIR_DELIM + "builtin";
 }
 
-v3f findSpawnPos(ServerMap &map)
+v3f Server::findSpawnPos(ServerMap &map)
 {
-	//return v3f(50,50,50)*BS;
-
 	v3s16 nodepos;
+	v3f nodeposf;
 
-#if 0
-	nodepos = v2s16(0,0);
-	groundheight = 20;
-#endif
+	// Initialize nodepos with static_spawnpoint if set this permit to solve
+	// some spawnpoints sets to 0,0,0 if the static_spawnpoint is set and
+	// we don't find a good place
+	if (g_settings->getV3FNoEx("static_spawnpoint", nodeposf)) {
+		return nodeposf * BS;
+	}
 
-#if 1
 	s16 water_level = map.getWaterLevel();
 
 	// Try to find a good place a few times
@@ -3232,7 +3232,6 @@ v3f findSpawnPos(ServerMap &map)
 			break;
 		}
 	}
-#endif
 
 	return intToFloat(nodepos, BS);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -491,6 +491,8 @@ private:
 	*/
 	PlayerSAO *emergePlayer(const char *name, u16 peer_id);
 
+	v3f findSpawnPos(ServerMap &map);
+
 	void handlePeerChanges();
 
 	/*


### PR DESCRIPTION
...t creation and respawn

Also make findSpawnPos as a private member of Server, it's only called by RespawnPlayer and EmergePlayer which are members of Server
This fix cases when static_spawnpoint is set and the player is teleported to 0,0,0 because we don't find any position
This also override this behaviour because the documentation said static_spawnpoint must be the player respawn position (creation and after-death)
For respawn, mods can override this value, it's the normal behavior and doesn't need to change