### PR TITLE
Protect Player::hud from concurrent modifications

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -240,6 +240,7 @@ void Player::deSerialize(std::istream &is, std::string playername)
 
 u32 Player::addHud(HudElement *toadd)
 {
+	JMutexAutoLock lock(m_mutex);
 	u32 id = getFreeHudID();
 
 	if (id < hud.size())
@@ -252,6 +253,8 @@ u32 Player::addHud(HudElement *toadd)
 
 HudElement* Player::getHud(u32 id)
 {
+	JMutexAutoLock lock(m_mutex);
+
 	if (id < hud.size())
 		return hud[id];
 
@@ -260,6 +263,8 @@ HudElement* Player::getHud(u32 id)
 
 HudElement* Player::removeHud(u32 id)
 {
+	JMutexAutoLock lock(m_mutex);
+
 	HudElement* retval = NULL;
 	if (id < hud.size()) {
 		retval = hud[id];
@@ -270,6 +275,8 @@ HudElement* Player::removeHud(u32 id)
 
 void Player::clearHud()
 {
+	JMutexAutoLock lock(m_mutex);
+
 	while(!hud.empty()) {
 		delete hud.back();
 		hud.pop_back();

--- a/src/player.h
+++ b/src/player.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
 #include "constants.h" // BS
+#include "jthread/jmutexautolock.h"
 #include <list>
 
 #define PLAYERNAME_SIZE 20
@@ -202,7 +203,8 @@ public:
 		return m_collisionbox;
 	}
 
-	u32 getFreeHudID() const {
+	u32 getFreeHudID() {
+		JMutexAutoLock lock(m_mutex);
 		size_t size = hud.size();
 		for (size_t i = 0; i != size; i++) {
 			if (!hud[i])
@@ -318,6 +320,11 @@ protected:
 	bool m_dirty;
 
 	std::vector<HudElement *> hud;
+private:
+	// Protect some critical areas
+	// hud for example can be modified by EmergeThread
+	// and ServerThread
+	JMutex m_mutex;
 };
 
 


### PR DESCRIPTION
Sometimes HUD can be modified by ServerThread and EmergeThread results in a crash on client side because the HUD is not correct