### PR TITLE
NetworkPacket -> Connection performance improvement

### DIFF
--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -444,7 +444,8 @@ struct ConnectionCommand
 		type = CONNCMD_SEND;
 		peer_id = peer_id_;
 		channelnum = channelnum_;
-		data = pkt->oldForgePacket();
+		data = Buffer<u8>(pkt->getSize() + 2);
+		pkt->oldForgePacket(data);
 		reliable = reliable_;
 	}
 

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -513,14 +513,12 @@ NetworkPacket& NetworkPacket::operator<<(video::SColor src)
 	return *this;
 }
 
-Buffer<u8> NetworkPacket::oldForgePacket()
+void NetworkPacket::oldForgePacket(Buffer<u8> &buf)
 {
-	Buffer<u8> sb(m_datasize + 2);
-	writeU16(&sb[0], m_command);
+	writeU16(&buf[0], m_command);
 
 	u8* datas = getU8Ptr(0);
 
 	if (datas != NULL)
-		memcpy(&sb[2], datas, m_datasize);
-	return sb;
+		memcpy(&buf[2], datas, m_datasize);
 }

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -106,8 +106,8 @@ public:
 		NetworkPacket& operator>>(video::SColor& dst);
 		NetworkPacket& operator<<(video::SColor src);
 
-		// Temp, we remove SharedBuffer when migration finished
-		Buffer<u8> oldForgePacket();
+		// Temp, we remove Buffer when migration finished
+		void oldForgePacket(Buffer<u8> &buf);
 private:
 		template<typename T> void checkDataSize()
 		{

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -2021,7 +2021,8 @@ struct TestConnection: public TestBase
 			NetworkPacket pkt;
 			pkt.putRawPacket((u8*) "Hello World !", 14, 0);
 
-			Buffer<u8> sentdata = pkt.oldForgePacket();
+			Buffer<u8> sentdata(14+2);
+			pkt.oldForgePacket(sentdata);
 
 			infostream<<"** running client.Send()"<<std::endl;
 			client.Send(PEER_ID_SERVER, 0, &pkt, true);
@@ -2036,7 +2037,8 @@ struct TestConnection: public TestBase
 					<< ", data=" << (const char*)pkt.getU8Ptr(0)
 					<< std::endl;
 
-			Buffer<u8> recvdata = pkt.oldForgePacket();
+			Buffer<u8> recvdata(14+2);
+			pkt.oldForgePacket(recvdata);
 
 			UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
 		}
@@ -2063,7 +2065,8 @@ struct TestConnection: public TestBase
 				infostream << "...";
 			infostream << std::endl;
 
-			Buffer<u8> sentdata = pkt.oldForgePacket();
+			Buffer<u8> sentdata(datasize+2);
+			pkt.oldForgePacket(sentdata);
 
 			server.Send(peer_id_client, 0, &pkt, true);
 
@@ -2083,7 +2086,8 @@ struct TestConnection: public TestBase
 					client.Receive(&pkt);
 					size = pkt.getSize();
 					peer_id = pkt.getPeerId();
-					recvdata = pkt.oldForgePacket();
+					recvdata = Buffer<u8>(size+2);
+					pkt.oldForgePacket(recvdata);
 					received = true;
 				} catch(con::NoIncomingDataException &e) {
 				}


### PR DESCRIPTION
Before this change, we are doing this thing in ConnectionCommand:

Forge packet to a SharedBuffer/Buffer -> Copy Buffer to ConnectionCommand

With this fix we forge packet directly into ConnectionCommand, this remove a copy operation.
