### PR TITLE
Add options to control timestamps for logging

### DIFF
--- a/doc/minetest.6
+++ b/doc/minetest.6
@@ -76,6 +76,12 @@ Print even more information to console
 \-\-trace
 Print enormous amounts of information to console
 .TP
+\-\-disable-timestamps
+Don't prepend timestamps to log messages
+.TP
+\-\-short-timestamps
+Don't add the date to timestamps for log messages
+.TP
 \-\-world <value>
 Set world path
 .TP

--- a/doc/minetestserver.6
+++ b/doc/minetestserver.6
@@ -52,6 +52,12 @@ Print even more information to console
 \-\-trace
 Print enormous amounts of information to console
 .TP
+\-\-disable-timestamps
+Don't prepend timestamps to log messages
+.TP
+\-\-short-timestamps
+Don't add the date to timestamps for log messages
+.TP
 \-\-world <value>
 Set world path
 .TP

--- a/src/debug.h
+++ b/src/debug.h
@@ -54,7 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	Debug output
 */
 
-#define DTIME (getTimestamp()+": ")
+#define DTIME (getTimestampStr()+": ")
 
 extern void debugstreams_init(bool disable_stderr, const char *filename);
 extern void debugstreams_deinit();

--- a/src/gettime.h
+++ b/src/gettime.h
@@ -48,7 +48,18 @@ extern u32 getTime(TimePrecision prec);
 #include <time.h>
 #include <string>
 
-inline std::string getTimestamp()
+inline std::string getShortTimestampStr()
+{
+	time_t t = time(NULL);
+	// This is not really thread-safe but it won't break anything
+	// except its own output, so just go with it.
+	struct tm *tm = localtime(&t);
+	char cs[20]; //HH:MM:SS + '\0'
+	strftime(cs, 20, "%H:%M:%S", tm);
+	return cs;
+}
+
+inline std::string getTimestampStr()
 {
 	time_t t = time(NULL);
 	// This is not really thread-safe but it won't break anything

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -124,7 +124,12 @@ void log_printline(enum LogMessageLevel lev, const std::string &text)
 		threadname = i->second;
 	std::string levelname = get_lev_string(lev);
 	std::ostringstream os(std::ios_base::binary);
-	os << getTimestamp() << ": " << levelname << "["<<threadname<<"]: " << text;
+	if (log_timestamps_mode  == 1)
+		os << getShortTimestampStr() << ": ";
+	else if (log_timestamps_mode  == 2)
+		os << getTimestampStr() << ": ";
+	os << levelname << "[" << threadname << "]: " << text;
+	std::string log_str = os.str();
 
 	for(std::vector<ILogOutput*>::iterator i = log_outputs[lev].begin();
 			i != log_outputs[lev].end(); i++) {
@@ -132,8 +137,8 @@ void log_printline(enum LogMessageLevel lev, const std::string &text)
 		if (out->silence)
 			continue;
 
-		out->printLog(os.str());
-		out->printLog(os.str(), lev);
+		out->printLog(log_str);
+		out->printLog(log_str, lev);
 		out->printLog(lev, text);
 	}
 }
@@ -195,5 +200,6 @@ std::ostream actionstream(&actionbuf);
 std::ostream infostream(&infobuf);
 std::ostream verbosestream(&verbosebuf);
 
+int log_timestamps_mode = 2;
 bool log_trace_level_enabled = false;
 

--- a/src/log.h
+++ b/src/log.h
@@ -64,19 +64,13 @@ void log_deregister_thread();
 
 void log_printline(enum LogMessageLevel lev, const std::string &text);
 
-#define LOGLINEF(lev, ...)\
-{\
-	char buf[10000];\
-	snprintf(buf, 10000, __VA_ARGS__);\
-	log_printline(lev, buf);\
-}
-
 extern std::ostream errorstream;
 extern std::ostream actionstream;
 extern std::ostream infostream;
 extern std::ostream verbosestream;
 
 extern bool log_trace_level_enabled;
+extern int log_timestamps_mode; /* 2 (default) da, 1 dates only, 0 disable */
 
 #define TRACESTREAM(x){ if(log_trace_level_enabled) verbosestream x; }
 #define TRACEDO(x){ if(log_trace_level_enabled){ x ;} }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -349,6 +349,10 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Print enormous amounts of information to log and console"))));
 	allowed_options->insert(std::make_pair("logfile", ValueSpec(VALUETYPE_STRING,
 			_("Set logfile path ('' = no logging)"))));
+	allowed_options->insert(std::make_pair("disable-timestamps", ValueSpec(VALUETYPE_FLAG,
+			_("Don't prepend timestamps to log messages"))));
+	allowed_options->insert(std::make_pair("short-timestamps", ValueSpec(VALUETYPE_FLAG,
+			_("Don't add the date to timestamps for log messages"))));
 	allowed_options->insert(std::make_pair("gameid", ValueSpec(VALUETYPE_STRING,
 			_("Set gameid (\"--gameid list\" prints available ones)"))));
 	allowed_options->insert(std::make_pair("migrate", ValueSpec(VALUETYPE_STRING,
@@ -461,6 +465,13 @@ static void setup_log_params(const Settings &cmd_args)
 	if (cmd_args.getFlag("quiet")) {
 		log_remove_output(&main_stderr_log_out);
 		log_add_output_maxlev(&main_stderr_log_out, LMT_ERROR);
+	}
+
+	// If we are told to, don't prepend timestamps to log messages
+	if (cmd_args.getFlag("disable-timestamps")) {
+		log_timestamps_mode = 0;
+	} else if (cmd_args.getFlag("short-timestamps")) {
+		log_timestamps_mode = 1;
 	}
 
 	// If trace is enabled, enable logging of certain things

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -898,7 +898,7 @@ void Map::updateLighting(enum LightBank bank,
 	}
 #endif
 
-	//m_dout<<"Done ("<<getTimestamp()<<")"<<std::endl;
+	//m_dout<<"Done ("<<getTimestampStr()<<")"<<std::endl;
 }
 
 void Map::updateLighting(std::map<v3s16, MapBlock*> & a_blocks,


### PR DESCRIPTION
Fixes #2554. The commit message:

```
Adds two command line options --disable-timestamps and --short-timestamps to better control the stdout of the application.
Also, removes an unused define from log.h and renames the gettime.h function "getTimestamp()" to "getTimestampStr()",
as it is global, and could be confused with a function from the mapblock class with the same name.
```

Additionally, we cache the string during the for loop in log.cpp, and spare some copies. Perhaps compilers have recognized this already.
