### PR TITLE
Android fix buildbugs

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -717,11 +717,11 @@ clean_all :
 	clean_openal clean_ogg clean_manifest;                                     \
 	sleep 1;                                                                   \
 	$(RM) -r gen libs obj deps bin Debug and_env
-	
+
 $(ROOT)/jni/src/android_version.h :
-	@echo "#define STR_HELPER(x) #x"                                           \
+	@echo "#ifndef ANDROID_MT_VERSION_H"                                       \
 	>${ROOT}/jni/src/android_version.h;                                        \
-	echo "#define STR(x) STR_HELPER(x)"                                        \
+	echo "#define ANDROID_MT_VERSION_H"                                        \
 	>> ${ROOT}/jni/src/android_version.h;                                      \
 	echo "#define VERSION_MAJOR $$(cat ${ROOT}/../../CMakeLists.txt |          \
 	grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | awk '{print $$2;}')"            \
@@ -734,12 +734,14 @@ $(ROOT)/jni/src/android_version.h :
 	>> ${ROOT}/jni/src/android_version.h;                                      \
 	export GITHASH=$$(git rev-parse --short=8 HEAD);                           \
 	export GITTAG=$$(git describe --abbrev=0 --tags);                          \
-	echo "#define VERSION_GITHASH \"$$GITTAG-$$GITHASH-Android\""        \
+	echo "#define VERSION_GITHASH \"$$GITTAG-$$GITHASH-Android\""              \
 	>> ${ROOT}/jni/src/android_version.h;                                      \
 	echo "#define VERSION_STRING STR(VERSION_MAJOR)\".\"STR(VERSION_MINOR)\
 	\".\"STR(VERSION_PATCH)"                                                   \
+	>> ${ROOT}/jni/src/android_version.h;                                      \
+	echo "#endif"                                                              \
 	>> ${ROOT}/jni/src/android_version.h;
-	
+
 manifest :
 	@VERS_MAJOR=$$(cat ${ROOT}/../../CMakeLists.txt |                          \
 	grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | awk '{print $$2;}');            \

--- a/src/config.h
+++ b/src/config.h
@@ -10,29 +10,23 @@
 #define STR(x) STRINGIFY(x)
 
 
-#ifdef USE_CMAKE_CONFIG_H
+#if defined USE_CMAKE_CONFIG_H
 	#include "cmake_config.h"
-#else
+#elif defined (__ANDROID__) || defined (ANDROID)
 	#define PROJECT_NAME "Minetest"
-	#define RUN_IN_PLACE 0
-	#define USE_CURL 0
-	#define USE_FREETYPE 0
-	#define USE_GETTEXT 0
-	#define USE_LEVELDB 0
-	#define USE_LUAJIT 0
-	#define USE_REDIS 0
-	#define USE_SOUND 0
-	#define HAVE_ENDIAN_H 0
 	#define STATIC_SHAREDIR ""
+	#include "android_version.h"
 	#ifdef NDEBUG
 		#define BUILD_TYPE "Release"
 	#else
 		#define BUILD_TYPE "Debug"
 	#endif
-#endif
-
-#ifdef __ANDROID__
-	#include "android_version.h"
+#else
+	#ifdef NDEBUG
+		#define BUILD_TYPE "Release"
+	#else
+		#define BUILD_TYPE "Debug"
+	#endif
 #endif
 
 #define BUILD_INFO "BUILD_TYPE=" BUILD_TYPE \
@@ -45,4 +39,3 @@
 		" STATIC_SHAREDIR=" STR(STATIC_SHAREDIR)
 
 #endif
-


### PR DESCRIPTION
Changes to build system were overriding C preprocessor directives causing, for example, sound to always be disabled on Android.