### PR TITLE
Add texture overriding

### DIFF
--- a/doc/texture_overrides.txt
+++ b/doc/texture_overrides.txt
@@ -1,0 +1,35 @@
+Texture Overrides
+=================
+
+You can override the textures of a node from a texture pack using
+texture overrides. To do this, create a file in a texture pack
+called override.txt
+
+Basic Format
+------------
+
+Each line in an override.txt file is a rule. It consists of
+
+	nodes face-selector texture
+
+For example,
+
+	default:dirt_with_grass sides default_stone.png
+
+You can use ^ operators as usual:
+
+	default:dirt_with_grass sides default_stone.png^[brighten
+
+Face Selectors
+--------------
+
+| face-selector | behavior                                          |
+|---------------|---------------------------------------------------|
+| left          | x-                                                |
+| right         | x+                                                |
+| front         | z-                                                |
+| back          | z+                                                |
+| top           | z+                                                |
+| bottom        | z-                                                |
+| sides         | x-, x+, z-, z+                                    |
+| all           | All faces. You can also use '*' instead of 'all'. |

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1741,6 +1741,9 @@ void Client::afterContentReceived(IrrlichtDevice *device)
 	text = wgettext("Initializing nodes...");
 	draw_load_screen(text, device, guienv, 0, 72);
 	m_nodedef->updateAliases(m_itemdef);
+	std::string texture_path = g_settings->get("texture_path");
+	if (texture_path != "" && fs::IsDir(texture_path))
+		m_nodedef->applyTextureOverrides(texture_path + DIR_DELIM + "override.txt");
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 	delete[] text;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -336,6 +336,11 @@ public:
 	virtual void updateAliases(IItemDefManager *idef)=0;
 
 	/*
+		Override textures from servers with ones specified in texturepack/override.txt
+	*/
+	virtual void applyTextureOverrides(std::string override_filepath)=0;
+
+	/*
 		Update tile textures to latest return values of TextueSource.
 	*/
 	virtual void updateTextures(IGameDef *gamedef,
@@ -378,4 +383,3 @@ public:
 };
 
 #endif
-

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -335,6 +335,11 @@ Server::Server(
 	// Apply item aliases in the node definition manager
 	m_nodedef->updateAliases(m_itemdef);
 
+	// Apply texture overrides from texturepack/override.txt
+	std::string texture_path = g_settings->get("texture_path");
+	if (texture_path != "" && fs::IsDir(texture_path))
+		m_nodedef->applyTextureOverrides(texture_path + DIR_DELIM + "override.txt");
+
 	m_nodedef->setNodeRegistrationStatus(true);
 
 	// Perform pending node name resolutions
@@ -3397,5 +3402,3 @@ void dedicated_server_loop(Server &server, bool &kill)
 		}
 	}
 }
-
-


### PR DESCRIPTION
Allows texture packs to override what texture each side of a node has.
Currently texture packs have to work with the texture names that mods use.
Unless you edit the mod's lua, you can't make ores look different on the sides
compared to the top and bottom.

You can place a file called override.txt in your texture pack folder:

    default:dirt_with_grass sides default_stone.png
    default:wood left default_nyancat.png
    default:stone all default_sand.png