### PR TITLE
Update tab_singleplayer.lua

### DIFF
--- a/builtin/mainmenu/tab_singleplayer.lua
+++ b/builtin/mainmenu/tab_singleplayer.lua
@@ -150,29 +150,33 @@ local function main_button_handler(this, fields, name, tabdata)
 	if fields["cb_creative_mode"] then
 		core.setting_set("creative_mode", fields["cb_creative_mode"])
 		local selected = core.get_textlist_index("sp_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		if selected ~= nil then
+			local filename = menudata.worldlist:get_list()[selected].path ..
+					DIR_DELIM .. "world.mt"
 
-		local worldfile = Settings(filename)
-		worldfile:set("creative_mode", fields["cb_creative_mode"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
+			local worldfile = Settings(filename)
+			worldfile:set("creative_mode", fields["cb_creative_mode"])
+			if not worldfile:write() then
+				core.log("error", "Failed to write world config file")
+			end
+			return true
 		end
-		return true
 	end
 
 	if fields["cb_enable_damage"] then
 		core.setting_set("enable_damage", fields["cb_enable_damage"])
 		local selected = core.get_textlist_index("sp_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		if selected ~= nil then
+			local filename = menudata.worldlist:get_list()[selected].path ..
+					DIR_DELIM .. "world.mt"
 
-		local worldfile = Settings(filename)
-		worldfile:set("enable_damage", fields["cb_enable_damage"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
+			local worldfile = Settings(filename)
+			worldfile:set("enable_damage", fields["cb_enable_damage"])
+			if not worldfile:write() then
+				core.log("error", "Failed to write world config file")
+			end
+			return true
 		end
-		return true
 	end
 
 	if fields["play"] ~= nil or


### PR DESCRIPTION
This fixes the situation where it would give you "builtin/mainmenu/tab_singleplayer.lua:167: attempt to index a nil value" where you have nothing selected (for example, switch to minimal game, delete all your old worlds, and then click the toggle buttons for creative or damage).
