### PR TITLE
Add the default settings of mg_flags

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -293,7 +293,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mg_name", "v6");
 	settings->setDefault("water_level", "1");
 	settings->setDefault("chunksize", "5");
-	settings->setDefault("mg_flags", "");
+	settings->setDefault("mg_flags", "trees, caves, v6_jungles, v6_biome_blend");
 	settings->setDefault("enable_floating_dungeons", "true");
 
 	// IPv6


### PR DESCRIPTION
I received a report to be different in a map produced by a version of Minetest.
So, I want to set by default.
Priority is low.
Whether this commit is necessary, I don't know.