### PR TITLE
Fix some bugs in mainmenu tab_singleplayer and tab_server

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -231,6 +231,29 @@ function menu_handle_key_up_down(fields,textlist,settingname)
 	return false
 end
 
+function menu_save_worldmt(selected, setting, value)
+	if menudata.worldlist:get_list()[selected] ~= nil then
+		local filename = menudata.worldlist:get_list()[selected].path ..
+				DIR_DELIM .. "world.mt"
+		local worldfile = Settings(filename)
+		worldfile:set(setting, value)
+		if not worldfile:write() then
+			core.log("error", "Failed to write world config file")
+		end
+	end
+end
+
+function menu_get_worldmt(selected, setting)
+	if menudata.worldlist:get_list()[selected] ~= nil then
+		local filename = menudata.worldlist:get_list()[selected].path ..
+				DIR_DELIM .. "world.mt"
+		local worldfile = Settings(filename)
+		return worldfile:get(setting)
+	else
+		return nil
+	end
+end
+
 --------------------------------------------------------------------------------
 function asyncOnlineFavourites()
 

--- a/builtin/mainmenu/tab_server.lua
+++ b/builtin/mainmenu/tab_server.lua
@@ -69,28 +69,18 @@ local function main_button_handler(this, fields, name, tabdata)
 		local event = core.explode_textlist_event(fields["srv_worlds"])
 
 		local selected = core.get_textlist_index("srv_worlds")
-		if selected ~= nil then
-			local filename = menudata.worldlist:get_list()[selected].path
-			local worldconfig = modmgr.get_worldconfig(filename)
-			filename = filename .. DIR_DELIM .. "world.mt"
-
-			if worldconfig.creative_mode ~= nil then
-				core.setting_set("creative_mode", worldconfig.creative_mode)
+		if menudata.worldlist:get_list()[selected] ~= nil then
+			local creative_mode = menu_get_worldmt(selected, "creative_mode")
+			if creative_mode ~= nil then
+				core.setting_set("creative_mode", creative_mode)
 			else
-				local worldfile = Settings(filename)
-				worldfile:set("creative_mode", core.setting_get("creative_mode"))
-				if not worldfile:write() then
-					core.log("error", "Failed to write world config file")
-				end
+				menu_save_worldmt(selected, "creative_mode", core.setting_get("creative_mode"))
 			end
-			if worldconfig.enable_damage ~= nil then
-				core.setting_set("enable_damage", worldconfig.enable_damage)
+			local enable_damage = menu_get_worldmt(selected, "enable_damage")
+			if enable_damage ~= nil then
+				core.setting_set("enable_damage", enable_damage)
 			else
-				local worldfile = Settings(filename)
-				worldfile:set("enable_damage", core.setting_get("enable_damage"))
-				if not worldfile:write() then
-					core.log("error", "Failed to write world config file")
-				end
+				menu_save_worldmt(selected, "enable_damage", core.setting_get("enable_damage"))
 			end
 		end
 
@@ -111,28 +101,16 @@ local function main_button_handler(this, fields, name, tabdata)
 	if fields["cb_creative_mode"] then
 		core.setting_set("creative_mode", fields["cb_creative_mode"])
 		local selected = core.get_textlist_index("srv_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		menu_save_worldmt(selected, "creative_mode", fields["cb_creative_mode"])
 
-		local worldfile = Settings(filename)
-		worldfile:set("creative_mode", fields["cb_creative_mode"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
-		end
 		return true
 	end
 
 	if fields["cb_enable_damage"] then
 		core.setting_set("enable_damage", fields["cb_enable_damage"])
 		local selected = core.get_textlist_index("srv_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		menu_save_worldmt(selected, "enable_damage", fields["cb_enable_damage"])
 
-		local worldfile = Settings(filename)
-		worldfile:set("enable_damage", fields["cb_enable_damage"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
-		end
 		return true
 	end
 
@@ -159,9 +137,11 @@ local function main_button_handler(this, fields, name, tabdata)
 
 			--update last game
 			local world = menudata.worldlist:get_raw_element(gamedata.selected_world)
+			if world ~= nil then
+				local game, index = gamemgr.find_by_gameid(world.gameid)
+				core.setting_set("menu_last_game", game.id)
+			end
 			
-			local game,index = gamemgr.find_by_gameid(world.gameid)
-			core.setting_set("menu_last_game",game.id)
 			core.start()
 			return true
 		end

--- a/builtin/mainmenu/tab_singleplayer.lua
+++ b/builtin/mainmenu/tab_singleplayer.lua
@@ -23,9 +23,9 @@ local function current_game()
 end
 
 local function singleplayer_refresh_gamebar()
-	
+
 	local old_bar = ui.find_by_name("game_button_bar")
-	
+
 	if old_bar ~= nil then
 		old_bar:delete()
 	end
@@ -76,7 +76,7 @@ end
 
 local function get_formspec(tabview, name, tabdata)
 	local retval = ""
-	
+
 	local index = filterlist.get_current_index(menudata.worldlist,
 				tonumber(core.setting_get("mainmenu_last_selected_world"))
 				)
@@ -107,28 +107,18 @@ local function main_button_handler(this, fields, name, tabdata)
 		local event = core.explode_textlist_event(fields["sp_worlds"])
 
 		local selected = core.get_textlist_index("sp_worlds")
-		if selected ~= nil then
-			local filename = menudata.worldlist:get_list()[selected].path
-			local worldconfig = modmgr.get_worldconfig(filename)
-			filename = filename .. DIR_DELIM .. "world.mt"
-
-			if worldconfig.creative_mode ~= nil then
-				core.setting_set("creative_mode", worldconfig.creative_mode)
+		if menudata.worldlist:get_list()[selected] ~= nil then
+			local creative_mode = menu_get_worldmt(selected, "creative_mode")
+			if creative_mode ~= nil then
+				core.setting_set("creative_mode", creative_mode)
 			else
-				local worldfile = Settings(filename)
-				worldfile:set("creative_mode", core.setting_get("creative_mode"))
-				if not worldfile:write() then
-					core.log("error", "Failed to write world config file")
-				end
+				menu_save_worldmt(selected, "creative_mode", core.setting_get("creative_mode"))
 			end
-			if worldconfig.enable_damage ~= nil then
-				core.setting_set("enable_damage", worldconfig.enable_damage)
+			local enable_damage = menu_get_worldmt(selected, "enable_damage")
+			if enable_damage ~= nil then
+				core.setting_set("enable_damage", enable_damage)
 			else
-				local worldfile = Settings(filename)
-				worldfile:set("enable_damage", core.setting_get("enable_damage"))
-				if not worldfile:write() then
-					core.log("error", "Failed to write world config file")
-				end
+				menu_save_worldmt(selected, "enable_damage", core.setting_get("enable_damage"))
 			end
 		end
 
@@ -150,28 +140,16 @@ local function main_button_handler(this, fields, name, tabdata)
 	if fields["cb_creative_mode"] then
 		core.setting_set("creative_mode", fields["cb_creative_mode"])
 		local selected = core.get_textlist_index("sp_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		menu_save_worldmt(selected, "creative_mode", fields["cb_creative_mode"])
 
-		local worldfile = Settings(filename)
-		worldfile:set("creative_mode", fields["cb_creative_mode"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
-		end
 		return true
 	end
 
 	if fields["cb_enable_damage"] then
 		core.setting_set("enable_damage", fields["cb_enable_damage"])
 		local selected = core.get_textlist_index("sp_worlds")
-		local filename = menudata.worldlist:get_list()[selected].path ..
-				DIR_DELIM .. "world.mt"
+		menu_save_worldmt(selected, "enable_damage", fields["cb_enable_damage"])
 
-		local worldfile = Settings(filename)
-		worldfile:set("enable_damage", fields["cb_enable_damage"])
-		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
-		end
 		return true
 	end
 


### PR DESCRIPTION
introduced by 8ca08a850ff2494652aa0ac2daa3d00f03aa4e7a.

tab_singleplayer and tab_server crashed on enable/disable
creative or damage

Print same Error message on double click world
for tab_singleplayer and tab_server