### PR TITLE
Fix MSVC error caused by ed10005

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "voxelalgorithms.h"
 #include "profiler.h"
 #include "settings.h"
+#include "porting.h" // For str functions
 #include "treegen.h"
 #include "serialization.h"
 #include "util/serialize.h"


### PR DESCRIPTION
Fixes following error:
> minetest\src\mapgen.cpp(521): error C3861: "strcasecmp": Identifier was not found.