### PR TITLE
Crafting speedup

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -334,6 +334,9 @@ Server::Server(
 	// Perform pending node name resolutions
 	m_nodedef->runNodeResolverCallbacks();
 
+	// init the recipe hashes to speed up crafting
+	m_craftdef->initHashes(this);
+
 	// Initialize Environment
 	m_env = new ServerEnvironment(servermap, m_script, this, m_path_world);
 


### PR DESCRIPTION
This greatly increases crafting performance, especially in worlds with many mods, like dreambuilder.

See the commit message for a detailed description what this commit does and why.
Fixes #2379.

Using the script specified there, I get with the traditional method `ms spent per craft lookup: 218.31534`, and with the new method: `ms spent per craft lookup: 0.06688`.

This does need testing.