### PR TITLE
Disable mesh cache by default

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -249,13 +249,13 @@
 #enable_waving_leaves = false
 #    Set to true enables waving plants. Requires shaders enabled.
 #enable_waving_plants = false
-#    Enables caching of facedir rotated meshes
-#ambient_occlusion_gamma = 2.2
 #    The strength (darkness) of node ambient-occlusion shading.
 #    Lower is darker, Higher is lighter. The valid range of values for this
 #    setting is 0.25 to 4.0 inclusive. If the value is out of range it will be
 #    set to the nearest valid value.
-#enable_mesh_cache = true
+#ambient_occlusion_gamma = 2.2
+#    Enables caching of facedir rotated meshes
+#enable_mesh_cache = false
 #    The time in seconds it takes between repeated
 #    right clicks when holding the right mouse button.
 #repeat_rightclick_time = 0.25

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -171,7 +171,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_shaders", "true");
 	settings->setDefault("repeat_rightclick_time", "0.25");
 	settings->setDefault("enable_particles", "true");
-	settings->setDefault("enable_mesh_cache", "true");
+	settings->setDefault("enable_mesh_cache", "false");
 
 	settings->setDefault("curl_timeout", "5000");
 	settings->setDefault("curl_parallel_limit", "8");


### PR DESCRIPTION
mesh cache is responsible for a majority of the allocated RAM of a freshly started minetest instance.
I think the mesh cache isn't useful for enough people to justify it being enabled by default.
Some ideas how to improve it:
1. the cache shouldn't be allocated at joining a server, but start 
2. there isn't any boolean on/off trigger to disable/enable the cache, but a number setting which defaults to e.g. 100 MB, and specifies the cache's limit. If the limit is reached, and the cache needs to accomodate new elements, old and unused elements are discarded.
