### PR TITLE
move particle spawners to env

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1256,6 +1256,50 @@ void ServerEnvironment::step(float dtime)
 		*/
 		removeRemovedObjects();
 	}
+
+	/*
+		Manage particle spawner expiration
+	*/
+	if (m_particle_management_interval.step(dtime, 1.0)) {
+		for(std::map<u32, float>::iterator i =
+		    m_particle_spawners.begin();
+		    i != m_particle_spawners.end();) {
+			//non expiring spawners
+			if (i->second <= -1.f) {
+				i++;
+				continue;
+			}
+
+			i->second -= 1.0;
+			if (i->second < 0.f)
+				m_particle_spawners.erase(i++);
+			else
+				i++;
+		}
+	}
+}
+
+u32 ServerEnvironment::addParticleSpawner(float exptime)
+{
+	// Timers with lifetime 0 do not expire
+	float time = exptime > 0.f ? exptime : -1.f;
+
+	u32 id = 0;
+	for (;;) { // look for unused particlespawner id
+		id++;
+		std::map<u32, float>::iterator f;
+		f = m_particle_spawners.find(id);
+		if (f == m_particle_spawners.end()) {
+			m_particle_spawners[id] = time;
+			break;
+		}
+	}
+	return id;
+}
+
+void ServerEnvironment::deleteParticleSpawner(u32 id)
+{
+	m_particle_spawners.erase(id);
 }
 
 ServerActiveObject* ServerEnvironment::getActiveObject(u16 id)

--- a/src/environment.h
+++ b/src/environment.h
@@ -231,6 +231,9 @@ public:
 	void saveMeta();
 	void loadMeta();
 
+	u32 addParticleSpawner(float exptime);
+	void deleteParticleSpawner(u32 id);
+
 	/*
 		External ActiveObject interface
 		-------------------------------------------
@@ -399,6 +402,10 @@ private:
 	// Estimate for general maximum lag as determined by server.
 	// Can raise to high values like 15s with eg. map generation mods.
 	float m_max_lag_estimate;
+
+	// Particles
+	IntervalLimiter m_particle_management_interval;
+	std::map<u32, float> m_particle_spawners;
 };
 
 #ifndef SERVER

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2953,19 +2953,7 @@ u32 Server::addParticleSpawner(const char *playername,
 	if(!player)
 		return -1;
 
-	u32 id = 0;
-	for(;;) // look for unused particlespawner id
-	{
-		id++;
-		if (std::find(m_particlespawner_ids.begin(),
-				m_particlespawner_ids.end(), id)
-				== m_particlespawner_ids.end())
-		{
-			m_particlespawner_ids.push_back(id);
-			break;
-		}
-	}
-
+	u32 id = m_env->addParticleSpawner(spawntime);
 	SendAddParticleSpawner(player->peer_id, amount, spawntime,
 		minpos, maxpos, minvel, maxvel, minacc, maxacc,
 		minexptime, maxexptime, minsize, maxsize,
@@ -2982,19 +2970,7 @@ u32 Server::addParticleSpawnerAll(u16 amount, float spawntime,
 		float minsize, float maxsize,
 		bool collisiondetection, bool vertical, std::string texture)
 {
-	u32 id = 0;
-	for(;;) // look for unused particlespawner id
-	{
-		id++;
-		if (std::find(m_particlespawner_ids.begin(),
-				m_particlespawner_ids.end(), id)
-				== m_particlespawner_ids.end())
-		{
-			m_particlespawner_ids.push_back(id);
-			break;
-		}
-	}
-
+	u32 id = m_env->addParticleSpawner(spawntime);
 	SendAddParticleSpawner(PEER_ID_INEXISTENT, amount, spawntime,
 		minpos, maxpos, minvel, maxvel, minacc, maxacc,
 		minexptime, maxexptime, minsize, maxsize,
@@ -3009,19 +2985,13 @@ void Server::deleteParticleSpawner(const char *playername, u32 id)
 	if(!player)
 		return;
 
-	m_particlespawner_ids.erase(
-			std::remove(m_particlespawner_ids.begin(),
-			m_particlespawner_ids.end(), id),
-			m_particlespawner_ids.end());
+	m_env->deleteParticleSpawner(id);
 	SendDeleteParticleSpawner(player->peer_id, id);
 }
 
 void Server::deleteParticleSpawnerAll(u32 id)
 {
-	m_particlespawner_ids.erase(
-			std::remove(m_particlespawner_ids.begin(),
-			m_particlespawner_ids.end(), id),
-			m_particlespawner_ids.end());
+	m_env->deleteParticleSpawner(id);
 	SendDeleteParticleSpawner(PEER_ID_INEXISTENT, id);
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -644,11 +644,6 @@ private:
 	*/
 	// key = name
 	std::map<std::string, Inventory*> m_detached_inventories;
-
-	/*
-		Particles
-	*/
-	std::vector<u32> m_particlespawner_ids;
 };
 
 /*


### PR DESCRIPTION
move m_particlespawner_ids and related housekeeping to env.
add code to handle expiration of particle ids for expiring spawners.

here is some code to test with:
https://gist.github.com/obneq/e46553eb518f3ef79ac2

note ever increasing ids for expiring spawners.