### PR TITLE
Mgv5: Fix above/below ground spawn when water level is altered

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -175,7 +175,7 @@ int MapgenV5::getGroundLevelAtPoint(v2s16 p)
 		f = 0.01;
 	else if (f >= 1.0)
 		f *= 1.6;
-	float h = water_level + NoisePerlin2D(&noise_height->np, p.X, p.Y, seed);
+	float h = NoisePerlin2D(&noise_height->np, p.X, p.Y, seed);
 
 	s16 search_top = water_level + 15;
 	s16 search_base = water_level;


### PR DESCRIPTION
When i de-linked terrain level from water_level back in 38e62805527b774e478617d9781bde72ce2bdcb9 i forgot to also change the expression for 'h' in getGroundLevelAtPoint. This resuts in spawns high above or below ground when water_level is altered.