### PR TITLE
Fix minetest.clear_* breaking the corresponding minetest.registered_* tables

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -398,7 +398,9 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 
 	local orig_clear_fn = core[clear_fn_name]
 	core[clear_fn_name] = function()
-		list = {}
+		for k in list do
+		 list[k]=nil
+		end
 		return orig_clear_fn()
 	end
 

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -398,7 +398,7 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 
 	local orig_clear_fn = core[clear_fn_name]
 	core[clear_fn_name] = function()
-		for k in list do
+		for k in pairs(list) do
 		 list[k]=nil
 		end
 		return orig_clear_fn()


### PR DESCRIPTION
On calling clear_redistered_biomes the registered_biomes table is cleared
by creating a new empty table, but the pointer is not updated to point to
the new one. So after calling more register_biome, the registered_biome
table always contains 0 items, which is an error. Instead, the table is
cleared by removing all its items so the pointer (minetest.registered_*)
remains valid.