### PR TITLE
Fix OSX build by coercing to uint32_t

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -386,12 +386,9 @@ bool getCurrentExecPath(char *buf, size_t len)
 //// Mac OS X, Darwin
 #elif defined(__APPLE__)
 
-bool getCurrentExecPath(char *buf, size_t len)
+bool getCurrentExecPath(char *buf, uint32_t len)
 {
-	if (_NSGetExecutablePath(buf, &len) == -1)
-		return false;
-
-	return true;
+	return _NSGetExecutablePath(buf, &len) != -1;
 }
 
 


### PR DESCRIPTION
Recent OSX build [is broken] (https://travis-ci.org/neoascetic/minetest/builds/59180520#L395). This is because call to `_NSGetExecutablePath` requires `uint32_t` as type for the last argument, while `size_t` is provided.