### PR TITLE
Fix player pitch and yaw not being set properly

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1793,7 +1793,7 @@ void Game::run()
 				cam_view.camera_pitch) * cam_smoothing;
 		updatePlayerControl(cam_view);
 		step(&dtime);
-		processClientEvents(&cam_view, &runData.damage_flash);
+		processClientEvents(&cam_view_target, &runData.damage_flash);
 		updateCamera(&flags, draw_times.busy_time, dtime,
 				runData.time_from_last_punch);
 		updateSound(dtime);


### PR DESCRIPTION
This is my attempt at a fix for bug #2649.

Because `cam_view_target` holds the eventual target of the view, it should be the one having events applied to it, not `cam_view`.