### PR TITLE
Clean up mod profiler

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -14,16 +14,13 @@ function core.register_chatcommand(cmd, def)
 end
 
 if core.setting_getbool("mod_profiling") then
-	local tracefct = profiling_print_log
+	core.register_chatcommand("dump_mod_profile", {
+		params      = "[filter]",
+		description = "Dump mod profiling data to log",
+		privs       = {server=true},
+		func        = profiling_print_log,
+	})
 	profiling_print_log = nil
-	core.register_chatcommand("save_mod_profile",
-			{
-				params      = "",
-				description = "save mod profiling data to logfile " ..
-						"(depends on default loglevel)",
-				func        = tracefct,
-				privs       = { server=true }
-			})
 end
 
 core.register_on_chat_message(function(name, message)


### PR DESCRIPTION
  * Fix wrappers only supporting 10 return values (used to use `local r0, r1, r2, r3 [...] = callback()`).
  * Fix looking up the same value in a hash table many, many, many times; cache it.
    This should improve speed pretty substantially.
  * Reduce duplication through local functions.
  * Use closures instead of storing functions in global lookup tables.
  * `total` and `builtin` are valid mod names, don't blow up if someone uses them.
  * Improve table logging format (it's more precise now).
  * Rename `save_mod_profile` to `dump_mod_profile` (it sends the data to the log, which isn't necessarily saved persistently).
  * Fix code style.

Note: This somewhat depends on #2628 (it uses the special `none` log level, which was `info` in previous versions).  It could be changed to use `minetest.debug` or similar though.
