### PR TITLE
Better version detection for shallow clones

### DIFF
--- a/cmake/Modules/GenerateVersion.cmake
+++ b/cmake/Modules/GenerateVersion.cmake
@@ -3,7 +3,7 @@
 if(VERSION_EXTRA)
 	set(VERSION_GITHASH "${VERSION_STRING}")
 else()
-	execute_process(COMMAND git describe --always --tag --dirty
+	execute_process(COMMAND git describe --tag --dirty
 		WORKING_DIRECTORY "${GENERATE_VERSION_SOURCE_DIR}"
 		OUTPUT_VARIABLE VERSION_GITHASH OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET)
@@ -11,7 +11,16 @@ else()
 	if(VERSION_GITHASH)
 		message(STATUS "*** Detected Git version ${VERSION_GITHASH} ***")
 	else()
-		set(VERSION_GITHASH "${VERSION_STRING}")
+		execute_process(COMMAND git describe --always --tag --dirty
+			WORKING_DIRECTORY "${GENERATE_VERSION_SOURCE_DIR}"
+			OUTPUT_VARIABLE VERSION_GITHASH OUTPUT_STRIP_TRAILING_WHITESPACE
+			ERROR_QUIET)
+		if(VERSION_GITHASH)
+			set(VERSION_GITHASH "${VERSION_STRING}-${VERSION_GITHASH}")
+			message(STATUS "*** Detected shallow Git version ${VERSION_GITHASH} ***")
+		else()
+			set(VERSION_GITHASH "${VERSION_STRING}")
+		endif()
 	endif()
 endif()
 


### PR DESCRIPTION
From irc:
```
<sfan5> >Minetest aef1b41
<sfan5> where is the version
<sfan5> [...] "Minetest/aef1b41 (Linux/3.19.3-3-ARCH x86_64)" "-"
<sfan5> also this is wonderful for statical purposes
<sfan5> not
<sfan5> ..would be nice if it could displays the version if there are no tags in the repos
```
This patch tries to achieve that.
