### PR TITLE
Use libjpeg-dev instead of libjpeg8-dev

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -103,7 +103,7 @@ Compiling on GNU/Linux:
 -----------------------
 
 Install dependencies. Here's an example for Debian/Ubuntu:
-$ sudo apt-get install build-essential libirrlicht-dev cmake libbz2-dev libpng12-dev libjpeg8-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libjsoncpp-dev
+$ sudo apt-get install build-essential libirrlicht-dev cmake libbz2-dev libpng12-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libjsoncpp-dev
 
 You can install git for easily keeping your copy up to date.
 If you dont want git, read below on how to get the source without git.

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -11,7 +11,7 @@ fi
 sudo apt-get install p7zip-full
 if [[ $PLATFORM == "Linux" ]]; then
 	sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
-		libjpeg8-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
+		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
 		libhiredis-dev libogg-dev libvorbis-dev libopenal-dev gettext
 	# Linking to LevelDB is broken, use a custom build
 	wget http://sfan5.pf-control.de/libleveldb-1.18-ubuntu12.04.7z


### PR DESCRIPTION
Replaced libjpeg dependency on apt-get, it should be libjpeg-dev instead of libjpeg8-dev.

On Debian 8...
```
Package libjpeg8-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libjpeg62-turbo-dev
```
Using libjpeg-dev should make the OS select the most appropriate lib to be installed. 
These are the packages available on Debian 8.
```
libjpeg-dev - Development files for the JPEG library [dummy package]
libjpeg-turbo-progs - Programs for manipulating JPEG files
libjpeg-turbo-progs-dbg - Programs for manipulating JPEG files (debugging symbols)
libjpeg62-turbo - libjpeg-turbo JPEG runtime library
libjpeg62-turbo-dbg - Debugging symbols for the libjpeg-turbo JPEG library
libjpeg62-turbo-dev - Development files for the libjpeg-turbo JPEG library
libturbojpeg1 - TurboJPEG runtime library - SIMD optimized
libturbojpeg1-dbg - TurboJPEG runtime library - SIMD optimized (debugging symbols)
libturbojpeg1-dev - Development files for the TurboJPEG library

```
This seems to work on all current Debian versions, Wheezy, Jessie and Sid.
https://packages.debian.org/wheezy/libjpeg-dev
https://packages.debian.org/jessie/libjpeg-dev
https://packages.debian.org/stretch/libjpeg-dev

Im not sure if Ubuntu has this dummy package.

http://packages.ubuntu.com/search?keywords=libjpeg-dev

Perhaps this should be further discussed.