### PR TITLE
RotateAlongYAxis: For facedir case, return if param2 >= 4

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -163,6 +163,9 @@ void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot) {
 	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
 
 	if (cpt2 == CPT2_FACEDIR) {
+		if (param2 >= 4)
+			return;
+
 		u8 newrot = param2 & 3;
 		param2 &= ~3;
 		param2 |= (newrot + rot) & 3;


### PR DESCRIPTION
Because in facedir case, the function does not support rotation of nodes with param2 >=4. This change increases performance slightly and avoids any unwanted and incorrect rotation of horizontal (param2 = 4 to 19) or inverted (param2 = 20 to 23) nodes, for example horizontal branches may be being rotated around their horizontal axes, not visibly noticeable but incorrect.