### PR TITLE
Clouds: Make cloud area radius settable in .conf

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -142,6 +142,9 @@
 #    Enable/disable clouds
 #enable_clouds = true
 #cloud_height = 120
+#    Radius of cloud area stated in number of 64 node cloud squares.
+#    Values > 22 will start to produce clipping of the cloud area corners.
+#cloud_radius = 12
 #enable_3d_clouds = true
 #    Use a cloud animation for the main menu background
 #menu_clouds = true

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -96,10 +96,10 @@ void Clouds::render()
 	driver->setMaterial(m_material);
 	
 	/*
-		Clouds move from X+ towards X-
+		Clouds move from Z+ towards Z-
 	*/
 
-	const s16 cloud_radius_i = 12;
+	const s16 cloud_radius_i = g_settings->getS16("cloud_radius");
 	const float cloud_size = BS * 64;
 	const v2f cloud_speed(0, -BS * 2);
 	

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -127,6 +127,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fall_bobbing_amount", "0.0");
 	settings->setDefault("enable_3d_clouds", "true");
 	settings->setDefault("cloud_height", "120");
+	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");
 	settings->setDefault("opaque_water", "false");
 	settings->setDefault("console_color", "(0,0,0)");


### PR DESCRIPTION
See issue #2662 for details and comments from players. Default is set to the current value of 12.