### PR TITLE
Fix Android shutdown error

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -34,6 +34,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "fontengine.h"
 #include "clientlauncher.h"
 
+#ifdef ANDROID
+	#include "porting_android.h"
+#endif
+
 /* mainmenumanager.h
  */
 gui::IGUIEnvironment *guienv = NULL;
@@ -67,8 +71,11 @@ u32 getTime(TimePrecision prec) {
 
 ClientLauncher::~ClientLauncher()
 {
-	if (receiver)
+	if (receiver) {
+		if (device)
+			device->setEventReceiver(NULL);
 		delete receiver;
+	}
 
 	if (input)
 		delete input;
@@ -76,8 +83,10 @@ ClientLauncher::~ClientLauncher()
 	if (g_fontengine)
 		delete g_fontengine;
 
-	if (device)
+	if (device) {
+		device->closeDevice();
 		device->drop();
+	}
 }
 
 
@@ -185,6 +194,10 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 		const wchar_t *text = wgettext("Main Menu");
 		device->setWindowCaption((narrow_to_wide(PROJECT_NAME_C) + L" [" + text + L"]").c_str());
 		delete[] text;
+
+#ifdef ANDROID
+		porting::handleAndroidActivityEvents();
+#endif
 
 		try {	// This is used for catching disconnects
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -68,6 +68,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include "touchscreengui.h"
 #endif
 
+#ifdef ANDROID
+	#include "porting_android.h"
+#endif
+
 extern Settings *g_settings;
 extern Profiler *g_profiler;
 
@@ -1758,6 +1762,10 @@ void Game::run()
 	set_light_table(g_settings->getFloat("display_gamma"));
 
 	while (device->run() && !(*kill || g_gamecallback->shutdown_requested)) {
+
+#ifdef ANDROID
+		porting::handleAndroidActivityEvents();
+#endif
 
 		/* Must be called immediately after a device->run() call because it
 		 * uses device->getTimer()->getTime()

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -76,6 +76,7 @@ int getInputDialogState();
  */
 std::string getInputDialogValue();
 
+void handleAndroidActivityEvents();
 }
 
 #endif


### PR DESCRIPTION
E.g.
Prior to patch:
```
V/minetest(16024): 2015-05-06 14:45:12: ERROR[main]: Shutting down minetest.
E/minetest(16024): Shutting down minetest.
I/ActivityManager(  783): Process net.minetest.minetest (pid 16024) (adj 0) has died.
I/WindowState(  783): WIN DEATH: Window{426a8c88 u0 net.minetest.minetest/net.minetest.minetest.MtNativeActivity}
W/ActivityManager(  783): Force removing ActivityRecord{4285eb28 u0 net.minetest.minetest/.MtNativeActivity t350}: app died, no saved state
```
After patch:
```
V/minetest( 2372): httpfetch_cleanup: cleaning up
V/minetest( 2372): 2015-05-06 17:32:59: ERROR[main]: Shutting down minetest.
E/minetest( 2372): Shutting down minetest
```