### PR TITLE
Mapgen v5/6/7: Cleanup node resolver and aliases

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -79,30 +79,28 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	//// Resolve nodes to be used
 	INodeDefManager *ndef = emerge->ndef;
 
-	c_stone           = ndef->getId("mapgen_stone");
-	c_dirt            = ndef->getId("mapgen_dirt");
-	c_dirt_with_grass = ndef->getId("mapgen_dirt_with_grass");
-	c_sand            = ndef->getId("mapgen_sand");
-	c_water_source    = ndef->getId("mapgen_water_source");
-	c_lava_source     = ndef->getId("mapgen_lava_source");
-	c_gravel          = ndef->getId("mapgen_gravel");
-	c_cobble          = ndef->getId("mapgen_cobble");
-	c_ice             = ndef->getId("default:ice");
-	c_desert_stone    = ndef->getId("mapgen_desert_stone");
-	c_mossycobble     = ndef->getId("mapgen_mossycobble");
-	c_sandbrick       = ndef->getId("mapgen_sandstonebrick");
-	c_stair_cobble    = ndef->getId("mapgen_stair_cobble");
-	c_stair_sandstone = ndef->getId("mapgen_stair_sandstone");
+	c_stone                = ndef->getId("mapgen_stone");
+	c_water_source         = ndef->getId("mapgen_water_source");
+	c_lava_source          = ndef->getId("mapgen_lava_source");
+	c_desert_stone         = ndef->getId("mapgen_desert_stone");
+	c_ice                  = ndef->getId("mapgen_ice");
+
+	c_cobble               = ndef->getId("mapgen_cobble");
+	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
+	c_mossycobble          = ndef->getId("mapgen_mossycobble");
+	c_sandstonebrick       = ndef->getId("mapgen_sandstonebrick");
+	c_stair_sandstonebrick = ndef->getId("mapgen_stair_sandstonebrick");
+
 	if (c_ice == CONTENT_IGNORE)
 		c_ice = CONTENT_AIR;
 	if (c_mossycobble == CONTENT_IGNORE)
 		c_mossycobble = c_cobble;
-	if (c_sandbrick == CONTENT_IGNORE)
-		c_sandbrick = c_desert_stone;
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
-	if (c_stair_sandstone == CONTENT_IGNORE)
-		c_stair_sandstone = c_sandbrick;
+	if (c_sandstonebrick == CONTENT_IGNORE)
+		c_sandstonebrick = c_desert_stone;
+	if (c_stair_sandstonebrick == CONTENT_IGNORE)
+		c_stair_sandstonebrick = c_sandstonebrick;
 }
 
 
@@ -251,27 +249,27 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 		dp.np_rarity  = nparams_dungeon_rarity;
 		dp.np_density = nparams_dungeon_density;
 		dp.np_wetness = nparams_dungeon_wetness;
-		dp.c_water = c_water_source;
+		dp.c_water    = c_water_source;
 		if (desert_stone) {
-			dp.c_cobble  = c_sandbrick;
-			dp.c_moss    = c_sandbrick; // should make this 'cracked sandstone' later
-			dp.c_stair   = c_stair_sandstone;
+			dp.c_cobble = c_desert_stone;
+			dp.c_moss   = c_desert_stone;
+			dp.c_stair  = c_desert_stone;
 
 			dp.diagonal_dirs = true;
-			dp.mossratio  = 0.0;
-			dp.holesize   = v3s16(2, 3, 2);
-			dp.roomsize   = v3s16(2, 5, 2);
-			dp.notifytype = GENNOTIFY_TEMPLE;
+			dp.mossratio     = 0.0;
+			dp.holesize      = v3s16(2, 3, 2);
+			dp.roomsize      = v3s16(2, 5, 2);
+			dp.notifytype    = GENNOTIFY_TEMPLE;
 		} else {
-			dp.c_cobble  = c_cobble;
-			dp.c_moss    = c_mossycobble;
-			dp.c_stair   = c_stair_cobble;
+			dp.c_cobble = c_cobble;
+			dp.c_moss   = c_mossycobble;
+			dp.c_stair  = c_stair_cobble;
 
 			dp.diagonal_dirs = false;
-			dp.mossratio  = 3.0;
-			dp.holesize   = v3s16(1, 2, 1);
-			dp.roomsize   = v3s16(0, 0, 0);
-			dp.notifytype = GENNOTIFY_DUNGEON;
+			dp.mossratio     = 3.0;
+			dp.holesize      = v3s16(1, 2, 1);
+			dp.roomsize      = v3s16(0, 0, 0);
+			dp.notifytype    = GENNOTIFY_DUNGEON;
 		}
 
 		DungeonGen dgen(this, &dp);

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -73,20 +73,16 @@ public:
 	Noise *noise_humidity;
 
 	content_t c_stone;
-	content_t c_dirt;
-	content_t c_dirt_with_grass;
-	content_t c_sand;
 	content_t c_water_source;
 	content_t c_lava_source;
-	content_t c_ice;
-	content_t c_gravel;
-	content_t c_cobble;
-	content_t c_desert_sand;
 	content_t c_desert_stone;
-	content_t c_mossycobble;
-	content_t c_sandbrick;
+	content_t c_ice;
+
+	content_t c_cobble;
 	content_t c_stair_cobble;
-	content_t c_stair_sandstone;
+	content_t c_mossycobble;
+	content_t c_sandstonebrick;
+	content_t c_stair_sandstonebrick;
 
 	MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge);
 	~MapgenV5();

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -89,30 +89,25 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	c_water_source    = ndef->getId("mapgen_water_source");
 	c_lava_source     = ndef->getId("mapgen_lava_source");
 	c_gravel          = ndef->getId("mapgen_gravel");
-	c_cobble          = ndef->getId("mapgen_cobble");
-	c_desert_sand     = ndef->getId("mapgen_desert_sand");
 	c_desert_stone    = ndef->getId("mapgen_desert_stone");
+	c_desert_sand     = ndef->getId("mapgen_desert_sand");
 	c_dirt_with_snow  = ndef->getId("mapgen_dirt_with_snow");
 	c_snow            = ndef->getId("mapgen_snow");
 	c_snowblock       = ndef->getId("mapgen_snowblock");
 	c_ice             = ndef->getId("mapgen_ice");
 
-	c_mossycobble     = ndef->getId("mapgen_mossycobble");
-	c_sandbrick       = ndef->getId("mapgen_sandstonebrick");
+	c_cobble          = ndef->getId("mapgen_cobble");
 	c_stair_cobble    = ndef->getId("mapgen_stair_cobble");
-	c_stair_sandstone = ndef->getId("mapgen_stair_sandstone");
+	c_mossycobble     = ndef->getId("mapgen_mossycobble");
+
 	if (c_desert_sand == CONTENT_IGNORE)
 		c_desert_sand = c_sand;
 	if (c_desert_stone == CONTENT_IGNORE)
 		c_desert_stone = c_stone;
 	if (c_mossycobble == CONTENT_IGNORE)
 		c_mossycobble = c_cobble;
-	if (c_sandbrick == CONTENT_IGNORE)
-		c_sandbrick = c_desert_stone;
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
-	if (c_stair_sandstone == CONTENT_IGNORE)
-		c_stair_sandstone = c_sandbrick;
 }
 
 
@@ -543,27 +538,27 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 		dp.np_rarity  = nparams_dungeon_rarity;
 		dp.np_density = nparams_dungeon_density;
 		dp.np_wetness = nparams_dungeon_wetness;
-		dp.c_water = c_water_source;
+		dp.c_water    = c_water_source;
 		if (getBiome(0, v2s16(node_min.X, node_min.Z)) == BT_DESERT) {
-			dp.c_cobble  = c_sandbrick;
-			dp.c_moss    = c_sandbrick; // should make this 'cracked sandstone' later
-			dp.c_stair   = c_stair_sandstone;
+			dp.c_cobble = c_desert_stone;
+			dp.c_moss   = c_desert_stone;
+			dp.c_stair  = c_desert_stone;
 
 			dp.diagonal_dirs = true;
-			dp.mossratio  = 0.0;
-			dp.holesize   = v3s16(2, 3, 2);
-			dp.roomsize   = v3s16(2, 5, 2);
-			dp.notifytype = GENNOTIFY_TEMPLE;
+			dp.mossratio     = 0.0;
+			dp.holesize      = v3s16(2, 3, 2);
+			dp.roomsize      = v3s16(2, 5, 2);
+			dp.notifytype    = GENNOTIFY_TEMPLE;
 		} else {
-			dp.c_cobble  = c_cobble;
-			dp.c_moss    = c_mossycobble;
-			dp.c_stair   = c_stair_cobble;
+			dp.c_cobble = c_cobble;
+			dp.c_moss   = c_mossycobble;
+			dp.c_stair  = c_stair_cobble;
 
 			dp.diagonal_dirs = false;
-			dp.mossratio  = 3.0;
-			dp.holesize   = v3s16(1, 2, 1);
-			dp.roomsize   = v3s16(0, 0, 0);
-			dp.notifytype = GENNOTIFY_DUNGEON;
+			dp.mossratio     = 3.0;
+			dp.holesize      = v3s16(1, 2, 1);
+			dp.roomsize      = v3s16(0, 0, 0);
+			dp.notifytype    = GENNOTIFY_DUNGEON;
 		}
 
 		DungeonGen dgen(this, &dp);

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -111,18 +111,16 @@ public:
 	content_t c_water_source;
 	content_t c_lava_source;
 	content_t c_gravel;
-	content_t c_cobble;
-	content_t c_desert_sand;
 	content_t c_desert_stone;
+	content_t c_desert_sand;
 	content_t c_dirt_with_snow;
 	content_t c_snow;
 	content_t c_snowblock;
 	content_t c_ice;
 
+	content_t c_cobble;
 	content_t c_mossycobble;
-	content_t c_sandbrick;
 	content_t c_stair_cobble;
-	content_t c_stair_sandstone;
 
 	MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge);
 	~MapgenV6();

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -88,29 +88,28 @@ MapgenV7::MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	//// Resolve nodes to be used
 	INodeDefManager *ndef = emerge->ndef;
 
-	c_stone           = ndef->getId("mapgen_stone");
-	c_dirt            = ndef->getId("mapgen_dirt");
-	c_dirt_with_grass = ndef->getId("mapgen_dirt_with_grass");
-	c_sand            = ndef->getId("mapgen_sand");
-	c_water_source    = ndef->getId("mapgen_water_source");
-	c_lava_source     = ndef->getId("mapgen_lava_source");
-	c_ice             = ndef->getId("default:ice");
-	c_cobble          = ndef->getId("mapgen_cobble");
-	c_desert_stone    = ndef->getId("mapgen_desert_stone");
-	c_mossycobble     = ndef->getId("mapgen_mossycobble");
-	c_sandbrick       = ndef->getId("mapgen_sandstonebrick");
-	c_stair_cobble    = ndef->getId("mapgen_stair_cobble");
-	c_stair_sandstone = ndef->getId("mapgen_stair_sandstone");
+	c_stone                = ndef->getId("mapgen_stone");
+	c_water_source         = ndef->getId("mapgen_water_source");
+	c_lava_source          = ndef->getId("mapgen_lava_source");
+	c_desert_stone         = ndef->getId("mapgen_desert_stone");
+	c_ice                  = ndef->getId("mapgen_ice");
+
+	c_cobble               = ndef->getId("mapgen_cobble");
+	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
+	c_mossycobble          = ndef->getId("mapgen_mossycobble");
+	c_sandstonebrick       = ndef->getId("mapgen_sandstonebrick");
+	c_stair_sandstonebrick = ndef->getId("mapgen_stair_sandstonebrick");
+
 	if (c_ice == CONTENT_IGNORE)
 		c_ice = CONTENT_AIR;
 	if (c_mossycobble == CONTENT_IGNORE)
 		c_mossycobble = c_cobble;
-	if (c_sandbrick == CONTENT_IGNORE)
-		c_sandbrick = c_desert_stone;
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
-	if (c_stair_sandstone == CONTENT_IGNORE)
-		c_stair_sandstone = c_sandbrick;
+	if (c_sandstonebrick == CONTENT_IGNORE)
+		c_sandstonebrick = c_desert_stone;
+	if (c_stair_sandstonebrick == CONTENT_IGNORE)
+		c_stair_sandstonebrick = c_sandstonebrick;
 }
 
 
@@ -272,27 +271,27 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 		dp.np_rarity  = nparams_dungeon_rarity;
 		dp.np_density = nparams_dungeon_density;
 		dp.np_wetness = nparams_dungeon_wetness;
-		dp.c_water = c_water_source;
+		dp.c_water    = c_water_source;
 		if (desert_stone) {
-			dp.c_cobble  = c_sandbrick;
-			dp.c_moss    = c_sandbrick; // should make this 'cracked sandstone' later
-			dp.c_stair   = c_stair_sandstone;
+			dp.c_cobble = c_desert_stone;
+			dp.c_moss   = c_desert_stone;
+			dp.c_stair  = c_desert_stone;
 
 			dp.diagonal_dirs = true;
-			dp.mossratio  = 0.0;
-			dp.holesize   = v3s16(2, 3, 2);
-			dp.roomsize   = v3s16(2, 5, 2);
-			dp.notifytype = GENNOTIFY_TEMPLE;
+			dp.mossratio     = 0.0;
+			dp.holesize      = v3s16(2, 3, 2);
+			dp.roomsize      = v3s16(2, 5, 2);
+			dp.notifytype    = GENNOTIFY_TEMPLE;
 		} else {
-			dp.c_cobble  = c_cobble;
-			dp.c_moss    = c_mossycobble;
-			dp.c_stair   = c_stair_cobble;
+			dp.c_cobble = c_cobble;
+			dp.c_moss   = c_mossycobble;
+			dp.c_stair  = c_stair_cobble;
 
 			dp.diagonal_dirs = false;
-			dp.mossratio  = 3.0;
-			dp.holesize   = v3s16(1, 2, 1);
-			dp.roomsize   = v3s16(0, 0, 0);
-			dp.notifytype = GENNOTIFY_DUNGEON;
+			dp.mossratio     = 3.0;
+			dp.holesize      = v3s16(1, 2, 1);
+			dp.roomsize      = v3s16(0, 0, 0);
+			dp.notifytype    = GENNOTIFY_DUNGEON;
 		}
 
 		DungeonGen dgen(this, &dp);

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -84,20 +84,16 @@ public:
 	Noise *noise_humidity;
 
 	content_t c_stone;
-	content_t c_dirt;
-	content_t c_dirt_with_grass;
-	content_t c_sand;
 	content_t c_water_source;
 	content_t c_lava_source;
-	content_t c_ice;
-	content_t c_gravel;
-	content_t c_cobble;
-	content_t c_desert_sand;
 	content_t c_desert_stone;
-	content_t c_mossycobble;
-	content_t c_sandbrick;
+	content_t c_ice;
+
+	content_t c_cobble;
 	content_t c_stair_cobble;
-	content_t c_stair_sandstone;
+	content_t c_mossycobble;
+	content_t c_sandstonebrick;
+	content_t c_stair_sandstonebrick;
 
 	MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge);
 	~MapgenV7();


### PR DESCRIPTION
Remove unnecessary nodes.
Use mapgen_ice alias instead of defult:ice.
Correct 'sandbrick' to 'sandstonebrick', matching my MTGame PR for sandstone aliases, in preparation for possible sandstone dungeons.
Use 'desert stone' instead of 'sandbrick' in desert temple parameters.