### PR TITLE
Add get and set functions for the nametag color

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2482,6 +2482,12 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_eye_offset({x=0,y=0,z=0},{x=0,y=0,z=0})`: defines offset value for camera per player
     * in first person view
     * in third person view (max. values `{x=-10/10,y=-10,15,z=-5/5}`)
+* `get_nametag_color()`
+    * returns the color of the nametag as table
+    * { a = 0...255, r = 0...255, g = 0...255, b = 0...255 }
+* `set_nametag_color(color)`
+    * sets the color of the nametag
+    * `color`: { a = 0...255, r = 0...255, g = 0...255, b = 0...255 }
 
 ### `InvRef`
 An `InvRef` is a reference to an inventory.

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -552,6 +552,7 @@ GenericCAO::GenericCAO(IGameDef *gamedef, ClientEnvironment *env):
 		m_animated_meshnode(NULL),
 		m_wield_meshnode(NULL),
 		m_spritenode(NULL),
+		m_nametag_color(video::SColor(255, 255, 255, 255)),
 		m_textnode(NULL),
 		m_position(v3f(0,10*BS,0)),
 		m_velocity(v3f(0,0,0)),
@@ -962,7 +963,7 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
 		gui::IGUIEnvironment* gui = irr->getGUIEnvironment();
 		std::wstring wname = narrow_to_wide(m_name);
 		m_textnode = smgr->addTextSceneNode(gui->getSkin()->getFont(),
-				wname.c_str(), video::SColor(255,255,255,255), node);
+				wname.c_str(), m_nametag_color, node);
 		m_textnode->grab();
 		m_textnode->setPosition(v3f(0, BS*1.1, 0));
 	}
@@ -1713,6 +1714,11 @@ void GenericCAO::processMessage(const std::string &data)
 			std::string name = deSerializeString(is);
 			int rating = readS16(is);
 			m_armor_groups[name] = rating;
+		}
+	} else if (cmd == GENERIC_CMD_SET_NAMETAG_COLOR) {
+		m_nametag_color = readARGB8(is);
+		if (m_textnode != NULL) {
+			m_textnode->setTextColor(m_nametag_color);
 		}
 	}
 }

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -71,6 +71,7 @@ private:
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode;
 	WieldMeshSceneNode *m_wield_meshnode;
 	scene::IBillboardSceneNode *m_spritenode;
+	video::SColor m_nametag_color;
 	scene::ITextSceneNode* m_textnode;
 	v3f m_position;
 	v3f m_velocity;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -197,6 +197,8 @@ public:
 	void setAttachment(int parent_id, std::string bone, v3f position, v3f rotation);
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
+	void setNametagColor(video::SColor color);
+	video::SColor getNametagColor();
 
 	/*
 		Inventory interface
@@ -312,6 +314,9 @@ private:
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
 	bool m_attachment_sent;
+
+	video::SColor m_nametag_color;
+	bool m_nametag_sent;
 
 public:
 	float m_physics_override_speed;

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -170,3 +170,12 @@ std::string gob_cmd_update_attachment(int parent_id, std::string bone, v3f posit
 	return os.str();
 }
 
+std::string gob_cmd_set_nametag_color(video::SColor color)
+{
+	std::ostringstream os(std::ios::binary);
+	// command
+	writeU8(os, GENERIC_CMD_SET_NAMETAG_COLOR);
+	// parameters
+	writeARGB8(os, color);
+	return os.str();
+}

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GENERIC_CMD_SET_BONE_POSITION 7
 #define GENERIC_CMD_SET_ATTACHMENT 8
 #define GENERIC_CMD_SET_PHYSICS_OVERRIDE 9
+#define GENERIC_CMD_SET_NAMETAG_COLOR 10
 
 #include "object_properties.h"
 std::string gob_cmd_set_properties(const ObjectProperties &prop);
@@ -71,6 +72,8 @@ std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_
 std::string gob_cmd_update_bone_position(std::string bone, v3f position, v3f rotation);
 
 std::string gob_cmd_update_attachment(int parent_id, std::string bone, v3f position, v3f rotation);
+
+std::string gob_cmd_set_nametag_color(video::SColor color);
 
 #endif
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1274,6 +1274,48 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 	return 1;
 }
 
+// set_nametag_color(self, color)
+int ObjectRef::l_set_nametag_color(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *playersao = getplayersao(ref);
+	if (playersao == NULL)
+		return 0;
+
+	video::SColor color(255,255,255,255);
+	if (!lua_isnil(L, 2))
+		color = readARGB8(L, 2);
+	playersao->setNametagColor(color);
+
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_nametag_color(self)
+int ObjectRef::l_get_nametag_color(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *playersao = getplayersao(ref);
+	if (playersao == NULL)
+		return 0;
+
+	video::SColor color = playersao->getNametagColor();
+
+	lua_newtable(L);
+	lua_pushnumber(L, color.getAlpha());
+	lua_setfield(L, -2, "a");
+	lua_pushnumber(L, color.getRed());
+	lua_setfield(L, -2, "r");
+	lua_pushnumber(L, color.getGreen());
+	lua_setfield(L, -2, "g");
+	lua_pushnumber(L, color.getBlue());
+	lua_setfield(L, -2, "b");
+
+	return 1;
+}
+
 ObjectRef::ObjectRef(ServerActiveObject *object):
 	m_object(object)
 {
@@ -1396,5 +1438,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, override_day_night_ratio),
 	luamethod(ObjectRef, set_local_animation),
 	luamethod(ObjectRef, set_eye_offset),
+	luamethod(ObjectRef, set_nametag_color),
+	luamethod(ObjectRef, get_nametag_color),
 	{0,0}
 };

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -240,6 +240,12 @@ private:
 	// set_eye_offset(self, v3f first pv, v3f third pv)
 	static int l_set_eye_offset(lua_State *L);
 
+	// set_nametag_color(self, color)
+	static int l_set_nametag_color(lua_State *L);
+
+	// get_nametag_color(self)
+	static int l_get_nametag_color(lua_State *L);
+
 public:
 	ObjectRef(ServerActiveObject *object);
 


### PR DESCRIPTION
Let's you set the color of the nametag of a player by
player:set_nametag_color({ a = 0, r = 0, g = 0, b = 0 })

And you can get the current color with
local color = player:get_nametag_color()

Fixes https://github.com/minetest/minetest/issues/1345, at least for the part of color and hiding.