### PR TITLE
Mapgen v5/v7: Detect sandstone, enable sandstone brick dungeons

### DIFF
--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -70,6 +70,13 @@ enum GenNotifyType {
 	NUM_GENNOTIFY_TYPES
 };
 
+// TODO(hmmmm/paramat): make stone type selection dynamic
+enum MgStoneType {
+	STONE,
+	DESERT_STONE,
+	SANDSTONE,
+};
+
 struct GenNotifyEvent {
 	GenNotifyType type;
 	v3s16 pos;

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -84,6 +84,7 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	c_lava_source          = ndef->getId("mapgen_lava_source");
 	c_desert_stone         = ndef->getId("mapgen_desert_stone");
 	c_ice                  = ndef->getId("mapgen_ice");
+	c_sandstone            = ndef->getId("mapgen_sandstone");
 
 	c_cobble               = ndef->getId("mapgen_cobble");
 	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
@@ -98,9 +99,9 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
 	if (c_sandstonebrick == CONTENT_IGNORE)
-		c_sandstonebrick = c_desert_stone;
+		c_sandstonebrick = c_sandstone;
 	if (c_stair_sandstonebrick == CONTENT_IGNORE)
-		c_stair_sandstonebrick = c_sandstonebrick;
+		c_stair_sandstonebrick = c_sandstone;
 }
 
 
@@ -236,7 +237,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 		noise_humidity->result, heightmap, biomemap);
 
 	// Actually place the biome-specific nodes
-	bool desert_stone = generateBiomes(noise_heat->result, noise_humidity->result);
+	MgStoneType stone_type = generateBiomes(noise_heat->result, noise_humidity->result);
 
 	// Generate caves
 	if ((flags & MG_CAVES) && (stone_surface_max_y >= node_min.Y))
@@ -250,7 +251,17 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 		dp.np_density = nparams_dungeon_density;
 		dp.np_wetness = nparams_dungeon_wetness;
 		dp.c_water    = c_water_source;
-		if (desert_stone) {
+		if (stone_type == STONE) {
+			dp.c_cobble = c_cobble;
+			dp.c_moss   = c_mossycobble;
+			dp.c_stair  = c_stair_cobble;
+
+			dp.diagonal_dirs = false;
+			dp.mossratio     = 3.0;
+			dp.holesize      = v3s16(1, 2, 1);
+			dp.roomsize      = v3s16(0, 0, 0);
+			dp.notifytype    = GENNOTIFY_DUNGEON;
+		} else if (stone_type == DESERT_STONE) {
 			dp.c_cobble = c_desert_stone;
 			dp.c_moss   = c_desert_stone;
 			dp.c_stair  = c_desert_stone;
@@ -260,15 +271,15 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 			dp.holesize      = v3s16(2, 3, 2);
 			dp.roomsize      = v3s16(2, 5, 2);
 			dp.notifytype    = GENNOTIFY_TEMPLE;
-		} else {
-			dp.c_cobble = c_cobble;
-			dp.c_moss   = c_mossycobble;
-			dp.c_stair  = c_stair_cobble;
+		} else if (stone_type == SANDSTONE) {
+			dp.c_cobble = c_sandstonebrick;
+			dp.c_moss   = c_sandstonebrick;
+			dp.c_stair  = c_sandstonebrick;
 
 			dp.diagonal_dirs = false;
-			dp.mossratio     = 3.0;
-			dp.holesize      = v3s16(1, 2, 1);
-			dp.roomsize      = v3s16(0, 0, 0);
+			dp.mossratio     = 0.0;
+			dp.holesize      = v3s16(2, 2, 2);
+			dp.roomsize      = v3s16(2, 0, 2);
 			dp.notifytype    = GENNOTIFY_DUNGEON;
 		}
 
@@ -383,14 +394,14 @@ int MapgenV5::generateBaseTerrain()
 }
 
 
-bool MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
+MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 {
 	if (node_max.Y < water_level)
-		return false;
+		return STONE;
 
 	v3s16 em = vm->m_area.getExtent();
 	u32 index = 0;
-	bool desert_stone = false;
+	MgStoneType stone_type = STONE;
 
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
@@ -418,7 +429,9 @@ bool MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 				depth_water_top = biome->depth_water_top;
 
 				if (biome->c_stone == c_desert_stone)
-					desert_stone = true;
+					stone_type = DESERT_STONE;
+				else if (biome->c_stone == c_sandstone)
+					stone_type = SANDSTONE;
 			}
 
 			if (c == c_stone && have_air) {
@@ -464,7 +477,7 @@ bool MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 		}
 	}
 
-	return desert_stone;
+	return stone_type;
 }
 
 

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -77,6 +77,7 @@ public:
 	content_t c_lava_source;
 	content_t c_desert_stone;
 	content_t c_ice;
+	content_t c_sandstone;
 
 	content_t c_cobble;
 	content_t c_stair_cobble;
@@ -91,7 +92,7 @@ public:
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	int generateBaseTerrain();
-	bool generateBiomes(float *heat_map, float *humidity_map);
+	MgStoneType generateBiomes(float *heat_map, float *humidity_map);
 	void generateCaves(int max_stone_y);
 	void dustTopNodes();
 };

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -88,6 +88,7 @@ public:
 	content_t c_lava_source;
 	content_t c_desert_stone;
 	content_t c_ice;
+	content_t c_sandstone;
 
 	content_t c_cobble;
 	content_t c_stair_cobble;
@@ -114,7 +115,7 @@ public:
 	int generateMountainTerrain(int ymax);
 	void generateRidgeTerrain();
 
-	bool generateBiomes(float *heat_map, float *humidity_map);
+	MgStoneType generateBiomes(float *heat_map, float *humidity_map);
 	void dustTopNodes();
 
 	//void addTopNodes();


### PR DESCRIPTION
![screenshot_20150515_023305](https://cloud.githubusercontent.com/assets/3686677/7645296/e43053a2-faaa-11e4-9602-913a9bf9d075.png)

If sandstone is detected within a mapchunk, any dungeons generated in that mapchunk will use sandstone brick.
The characteristic of desert temples is vertical: the slightly wider and much higher rooms and the 2 wide by 3 high corridors. To give sandstone dungeons their own character i have made corridors 2 wide by 2 high and made rooms wider without being any higher, their characteristic is therefore horizontal.
Stair placing code does not work with 2-wide corridors so full nodes are used for stairs, as in desert temples.