### PR TITLE
Biome API: Increase heat / humidity spreads. Mgv7: Improve terrain noise parameters

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -526,8 +526,8 @@
 #    other noise parameters are shown in positional format to save space.
 
 #    Noise parameters for biome API temperature and humidity
-#mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0
-#mg_biome_np_humidity = 50, 50, (500, 500, 500), 842, 3, 0.5, 2.0
+#mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
+#mg_biome_np_humidity = 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
 
 #mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 #mgv5_np_factor = 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -125,8 +125,8 @@ struct MapgenParams {
 		seed(0),
 		water_level(1),
 		flags(MG_TREES | MG_CAVES | MG_LIGHT),
-		np_biome_heat(NoiseParams(50, 50, v3f(500.0, 500.0, 500.0), 5349, 3, 0.5, 2.0)),
-		np_biome_humidity(NoiseParams(50, 50, v3f(500.0, 500.0, 500.0), 842, 3, 0.5, 2.0)),
+		np_biome_heat(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0)),
+		np_biome_humidity(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0)),
 		sparams(NULL)
 	{}
 


### PR DESCRIPTION
Increases heat and humidity spreads from 500 to 750 nodes. Biomes are currently too small in the 8 biome system being prepared for mgv5/v7, and are certainly too small in the ethereal mod and BFD game. Player's custom biome sytems tend to have more than 8 biomes.

SInce mgv7 noise parameters will be changed soon i think i'll add those to this PR, to combine the changes for less disruption to player's worlds. Currently testing these changes:

mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 6, 0.5, 2.0
mgv7_np_height_select = -8, 16, (500, 500, 500), 4213, 5, 0.69, 2.0
mgv7_np_mount_height = 184, 72, (500, 500, 500), 72449, 4, 0.6, 2.0

I felt base terrain was varying over too small a distance for cliff top terran, so i have doubled the spread. I felt 6 octaves with 300 spread was creating fine detail too small at roughly 10 nodes so i kept the octaves at 6 for a new fine detail of roughly 19 nodes.
The much larger scale of height offset creates mgv6 type cliffs.
Mountains are boosted to occasionally reach 256 nodes in height, twice cloud height.