### PR TITLE
Biome API, mgv7: Increase heat/humidity spreads. Improve mgv7 noise parameters

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -526,8 +526,8 @@
 #    other noise parameters are shown in positional format to save space.
 
 #    Noise parameters for biome API temperature and humidity
-#mg_biome_np_heat = 50, 50, (500, 500, 500), 5349, 3, 0.5, 2.0
-#mg_biome_np_humidity = 50, 50, (500, 500, 500), 842, 3, 0.5, 2.0
+#mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
+#mg_biome_np_humidity = 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
 
 #mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 #mgv5_np_factor = 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0
@@ -557,13 +557,13 @@
 #mgv6_np_trees = 0, 1, (125, 125, 125), 2, 4, 0.66, 2.0
 #mgv6_np_apple_trees = 0, 1, (100, 100, 100), 342902, 3, 0.45, 2.0
 
-#mgv7_np_terrain_base = 4, 70, (300, 300, 300), 82341, 6, 0.7, 2.0
+#mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 6, 0.7, 2.0
 #mgv7_np_terrain_alt = 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0
 #mgv7_np_terrain_persist = 0.6, 0.1, (500, 500, 500), 539, 3, 0.6, 2.0
-#mgv7_np_height_select = -0.5, 1, (250, 250, 250), 4213, 5, 0.69, 2.0
+#mgv7_np_height_select = -12, 24, (500, 500, 500), 4213, 6, 0.69, 2.0
 #mgv7_np_filler_depth = 0, 1.2, (150, 150, 150), 261, 4, 0.7, 2.0
-#mgv7_np_mount_height = 100, 30, (500, 500, 500), 72449, 4, 0.6, 2.0
-#mgv7_np_ridge_uwater = 0, 1, (500, 500, 500), 85039, 4, 0.6, 2.0
+#mgv7_np_mount_height = 184, 72, (500, 500, 500), 72449, 4, 0.6, 2.0
+#mgv7_np_ridge_uwater = 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0
 #mgv7_np_mountain = -0.6, 1, (250, 350, 250), 5333, 5, 0.68, 2.0
 #mgv7_np_ridge = 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
 #mgv7_np_cave1 = 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -125,8 +125,8 @@ struct MapgenParams {
 		seed(0),
 		water_level(1),
 		flags(MG_TREES | MG_CAVES | MG_LIGHT),
-		np_biome_heat(NoiseParams(50, 50, v3f(500.0, 500.0, 500.0), 5349, 3, 0.5, 2.0)),
-		np_biome_humidity(NoiseParams(50, 50, v3f(500.0, 500.0, 500.0), 842, 3, 0.5, 2.0)),
+		np_biome_heat(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0)),
+		np_biome_humidity(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0)),
 		sparams(NULL)
 	{}
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -141,17 +141,17 @@ MapgenV7Params::MapgenV7Params()
 {
 	spflags = MGV7_MOUNTAINS | MGV7_RIDGES;
 
-	np_terrain_base    = NoiseParams(4,    70,  v3f(300, 300, 300), 82341, 6, 0.7,  2.0);
-	np_terrain_alt     = NoiseParams(4,    25,  v3f(600, 600, 600), 5934,  5, 0.6,  2.0);
-	np_terrain_persist = NoiseParams(0.6,  0.1, v3f(500, 500, 500), 539,   3, 0.6,  2.0);
-	np_height_select   = NoiseParams(-0.5, 1,   v3f(250, 250, 250), 4213,  5, 0.69, 2.0);
-	np_filler_depth    = NoiseParams(0,    1.2, v3f(150, 150, 150), 261,   4, 0.7,  2.0);
-	np_mount_height    = NoiseParams(100,  30,  v3f(500, 500, 500), 72449, 4, 0.6,  2.0);
-	np_ridge_uwater    = NoiseParams(0,    1,   v3f(500, 500, 500), 85039, 4, 0.6,  2.0);
-	np_mountain        = NoiseParams(-0.6, 1,   v3f(250, 350, 250), 5333,  5, 0.68, 2.0);
-	np_ridge           = NoiseParams(0,    1,   v3f(100, 100, 100), 6467,  4, 0.75, 2.0);
-	np_cave1           = NoiseParams(0,    12,  v3f(100, 100, 100), 52534, 4, 0.5,  2.0);
-	np_cave2           = NoiseParams(0,    12,  v3f(100, 100, 100), 10325, 4, 0.5,  2.0);
+	np_terrain_base    = NoiseParams(4,    70,  v3f(600,  600,  600),  82341, 6, 0.7,  2.0);
+	np_terrain_alt     = NoiseParams(4,    25,  v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
+	np_terrain_persist = NoiseParams(0.6,  0.1, v3f(500,  500,  500),  539,   3, 0.6,  2.0);
+	np_height_select   = NoiseParams(-12,  24,  v3f(500,  500,  500),  4213,  6, 0.69, 2.0);
+	np_filler_depth    = NoiseParams(0,    1.2, v3f(150,  150,  150),  261,   4, 0.7,  2.0);
+	np_mount_height    = NoiseParams(184,  72,  v3f(500,  500,  500),  72449, 4, 0.6,  2.0);
+	np_ridge_uwater    = NoiseParams(0,    1,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0);
+	np_mountain        = NoiseParams(-0.6, 1,   v3f(250,  350,  250),  5333,  5, 0.68, 2.0);
+	np_ridge           = NoiseParams(0,    1,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0);
+	np_cave1           = NoiseParams(0,    12,  v3f(100,  100,  100),  52534, 4, 0.5,  2.0);
+	np_cave2           = NoiseParams(0,    12,  v3f(100,  100,  100),  10325, 4, 0.5,  2.0);
 }
 
 


### PR DESCRIPTION
Increases heat and humidity spreads from 500 to 750 nodes. Biomes are currently too small in the 8 biome system being prepared for mgv5/v7, and are certainly too small in the ethereal mod and BFD game. Player's custom biome systems tend to have more than 8 biomes.

mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 6, 0.5, 2.0
mgv7_np_height_select = -12, 24, (500, 500, 500), 4213, 6, 0.69, 2.0
mgv7_np_mount_height = 184, 72, (500, 500, 500), 72449, 4, 0.6, 2.0
#mgv7_np_ridge_uwater = 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0

I found base terrain (cliff top) variation too small-scale, too-steep plateaus, so have doubled the spread. I felt 6 octaves with 300 spread was creating fine detail too small at roughly 10 nodes so i kept the octaves at 6 for a new fine detail of roughly 19 nodes.
The much larger scale of height offset creates mgv6 type cliffs, the spread of 250 was too small so is doubled and an octave is added, so now we have larger areas without cliffs, instead of cliffs everywhere every 250 nodes or so.
Mountains are boosted to occasionally reach 256 nodes in height, twice cloud height, minimum height is the same.
River systems now have longer routes and less small-scale looping by doubling the spread and adding an octave. This might also reduce the density of rivers a little as they are possibly a little too common.