### PR TITLE
Mgv6: Enable snowbiomes by default. Double biome noise spread.

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -496,7 +496,7 @@
 #    Map generation attributes specific to Mapgen V6.
 #    Currently supported: jungles, biomeblend, mudflow, snowbiomes.
 #    When snowbiomes are enabled jungles are enabled and the jungles flag is ignored.
-#mgv6_spflags = jungles, biomeblend, mudflow
+#mgv6_spflags = jungles, biomeblend, mudflow, snowbiomes
 #    Controls size of deserts and beaches in Mapgen V6
 #    When snowbiomes are enabled 'mgv6_freq_desert' is ignored.
 #mgv6_freq_desert = 0.45
@@ -551,9 +551,9 @@
 #mgv6_np_height_select = 0.5, 1, (250, 250, 250), 4213, 5, 0.69, 2.0
 #mgv6_np_mud = 4, 2, (200, 200, 200), 91013, 3, 0.55, 2.0
 #mgv6_np_beach = 0, 1, (250, 250, 250), 59420, 3, 0.50, 2.0
-#mgv6_np_biome = 0, 1, (250, 250, 250), 9130, 3, 0.50, 2.0
+#mgv6_np_biome = 0, 1, (500, 500, 500), 9130, 3, 0.50, 2.0
 #mgv6_np_cave = 6, 6, (250, 250, 250), 34329, 3, 0.50, 2.0
-#mgv6_np_humidity = 0.5, 0.5, (500, 500, 500), 72384, 4, 0.66, 2.0
+#mgv6_np_humidity = 0.5, 0.5, (500, 500, 500), 72384, 3, 0.50, 2.0
 #mgv6_np_trees = 0, 1, (125, 125, 125), 2, 4, 0.66, 2.0
 #mgv6_np_apple_trees = 0, 1, (100, 100, 100), 342902, 3, 0.45, 2.0
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -299,7 +299,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_level", "1");
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "dungeons");
-	settings->setDefault("mgv6_spflags", "jungles");
+	settings->setDefault("mgv6_spflags", "jungles, snowbiomes");
 	settings->setDefault("enable_floating_dungeons", "true");
 
 	// IPv6

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -138,9 +138,9 @@ MapgenV6Params::MapgenV6Params()
 	np_height_select  = NoiseParams(0,    1.0,  v3f(250.0, 250.0, 250.0), 4213,   5, 0.69, 2.0);
 	np_mud            = NoiseParams(4,    2.0,  v3f(200.0, 200.0, 200.0), 91013,  3, 0.55, 2.0);
 	np_beach          = NoiseParams(0,    1.0,  v3f(250.0, 250.0, 250.0), 59420,  3, 0.50, 2.0);
-	np_biome          = NoiseParams(0,    1.0,  v3f(250.0, 250.0, 250.0), 9130,   3, 0.50, 2.0);
+	np_biome          = NoiseParams(0,    1.0,  v3f(500.0, 500.0, 500.0), 9130,   3, 0.50, 2.0);
 	np_cave           = NoiseParams(6,    6.0,  v3f(250.0, 250.0, 250.0), 34329,  3, 0.50, 2.0);
-	np_humidity       = NoiseParams(0.5,  0.5,  v3f(500.0, 500.0, 500.0), 72384,  4, 0.66, 2.0);
+	np_humidity       = NoiseParams(0.5,  0.5,  v3f(500.0, 500.0, 500.0), 72384,  3, 0.50, 2.0);
 	np_trees          = NoiseParams(0,    1.0,  v3f(125.0, 125.0, 125.0), 2,      4, 0.66, 2.0);
 	np_apple_trees    = NoiseParams(0,    1.0,  v3f(100.0, 100.0, 100.0), 342902, 3, 0.45, 2.0);
 }

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define FREQ_HOT 0.4
 #define FREQ_SNOW -0.4
 #define FREQ_TAIGA 0.5
-#define FREQ_JUNGLE 0.7
+#define FREQ_JUNGLE 0.5
 
 //////////// Mapgen V6 flags
 #define MGV6_JUNGLES    0x01


### PR DESCRIPTION
Also:
3 octaves, 0.5 persistence for humidity.
Change new biome system jungle humidity threshold to 0.5 for equal size jungles and deserts.

This makes both biome and humidity noises have 500 spread, 3 octaves and 0.5 persistence.
Currently humidity has 4 octaves with 0.66 persistence, this creates small jungle biome bubbles.
The original biome system jungle humidity threshold of 0.75 also tends to create small jungle patches, so for the new biome system i have chosen 0.5 for equal size jungles and deserts.

Stuff to consider:
These noise parameter changes will not break old worlds but will be in effect in new worlds even if the original biome system is chosen by disabling snowbiomes. In new worlds the original biome system will have larger biomes in new locations, if the original biome system is wanted with original biome size and location the original noise parameters will have to be set in .conf.
This seems unavoidable if we are to avoid tiny biomes with the new default biome system.
