### PR TITLE
Add some missing getter functions to the lua API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1932,6 +1932,7 @@ and `minetest.auth_reload` call the authetification handler.
     * `flags` is a flag field with the available flags: `dungeon`, `temple`, `cave_begin`,
    `cave_end`, `large_cave_begin`, `large_cave_end`, `decoration`
    * The second parameter is a list of IDS of decorations which notification is requested for
+* `get_gen_notify()`: returns a flagstring and a table with the deco_ids
 * `minetest.get_mapgen_object(objectname)`
     * Return requested mapgen object if available (see "Mapgen objects")
 * `minetest.get_mapgen_params()` Returns mapgen parameters, a table containing
@@ -1950,6 +1951,7 @@ and `minetest.auth_reload` call the authetification handler.
     * Sets the noiseparams setting of `name` to the noiseparams table specified in `noiseparams`.
     * `set_default` is an optional boolean (default: `true`) that specifies whether the setting
       should be applied to the default config or current active config
+* `minetest.get_noiseparams(name)`: returns a table of the noiseparams for name
 * `minetest.generate_ores(vm, pos1, pos2)`
     * Generate all registered ores within the VoxelManip `vm` and in the area from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
@@ -2412,17 +2414,22 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_wielded_item()`: returns an `ItemStack`
 * `set_wielded_item(item)`: replaces the wielded item, returns `true` if successful
 * `set_armor_groups({group1=rating, group2=rating, ...})`
+* `get_armor_groups()`: returns a table with the armor group ratings
 * `set_animation({x=1,y=1}, frame_speed=15, frame_blend=0)`
+* `get_animation()`: returns range, frame_speed and frame_blend
 * `set_attach(parent, bone, position, rotation)`
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative)
     * `rotation`: `{x=num, y=num, z=num}`
+* `get_attach()`: returns parent, bone, position, rotation or nil if it isn't attached
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative)
     * `rotation`: `{x=num, y=num, z=num}`
+* `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
+* `get_properties()`: returns object property table
 * `is_player()`: returns true for players, false otherwise
 
 ##### LuaEntitySAO-only (no-op for other objects)
@@ -2468,6 +2475,7 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the sneak glitch (default: `true`)
+* `get_physics_override()`: returns the table given to set_physics_override
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success
 * `hud_remove(id)`: remove the HUD element of the specified id
@@ -2482,10 +2490,13 @@ This is basically a reference to a C++ `ServerActiveObject`
     * returns `{ hotbar=true, healthbar=true, crosshair=true, wielditem=true, breathbar=true }`
 * `hud_set_hotbar_itemcount(count)`: sets number of items in builtin hotbar
     * `count`: number of items, must be between `1` and `23`
+* `hud_get_hotbar_itemcount`: returns number of visible items
 * `hud_set_hotbar_image(texturename)`
     * sets background image for hotbar
+* `hud_get_hotbar_image`: returns texturename
 * `hud_set_hotbar_selected_image(texturename)`
     * sets image for selected item of hotbar
+* `hud_get_hotbar_selected_image`: returns texturename
 * `hud_replace_builtin(name, hud_definition)`
     * replace definition of a builtin hud element
     * `name`: `"breath"` or `"health"`
@@ -2498,10 +2509,12 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"plain"`: Uses 0 textures, `bgcolor` used
     * **Note**: currently does not work directly in `on_joinplayer`; use
       `minetest.after(0)` in there.
+* `get_sky()`: returns bgcolor, type and a table with the textures
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount
     * `nil`: Disables override, defaulting to sunlight based on day-night cycle
-* `set_local_animation(walk, dig, walk+dig, frame_speed=frame_speed)`
+* `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
+* `set_local_animation(stand/idle, walk, dig, walk+dig, frame_speed=frame_speed)`
 
 	set animation for player model in third person view
 
@@ -2510,10 +2523,11 @@ This is basically a reference to a C++ `ServerActiveObject`
             {x=189, y=198}, -- <  dig animation key frames
             {x=200, y=219}, -- <  walk+dig animation key frames
             frame_speed=30): -- <  animation frame speed
-
+* `get_local_animation()`: returns stand, walk, dig, dig+walk tables and frame_speed
 * `set_eye_offset({x=0,y=0,z=0},{x=0,y=0,z=0})`: defines offset value for camera per player
     * in first person view
     * in third person view (max. values `{x=-10/10,y=-10,15,z=-5/5}`)
+* `get_eye_offset()`: returns offset_first and offset_third
 * `get_nametag_attributes()`
     * returns a table with the attributes of the nametag of the player
     * {

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -533,6 +533,11 @@ void LuaEntitySAO::setArmorGroups(const ItemGroupList &armor_groups)
 	m_armor_groups_sent = false;
 }
 
+ItemGroupList LuaEntitySAO::getArmorGroups()
+{
+	return m_armor_groups;
+}
+
 void LuaEntitySAO::setAnimation(v2f frame_range, float frame_speed, float frame_blend)
 {
 	m_animation_range = frame_range;
@@ -541,10 +546,23 @@ void LuaEntitySAO::setAnimation(v2f frame_range, float frame_speed, float frame_
 	m_animation_sent = false;
 }
 
+void LuaEntitySAO::getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend)
+{
+	*frame_range = m_animation_range;
+	*frame_speed = m_animation_speed;
+	*frame_blend = m_animation_blend;
+}
+
 void LuaEntitySAO::setBonePosition(const std::string &bone, v3f position, v3f rotation)
 {
 	m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
 	m_bone_position_sent = false;
+}
+
+void LuaEntitySAO::getBonePosition(const std::string &bone, v3f *position, v3f *rotation)
+{
+	*position = m_bone_position[bone].X;
+	*rotation = m_bone_position[bone].Y;
 }
 
 void LuaEntitySAO::setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation)
@@ -562,6 +580,15 @@ void LuaEntitySAO::setAttachment(int parent_id, const std::string &bone, v3f pos
 	m_attachment_position = position;
 	m_attachment_rotation = rotation;
 	m_attachment_sent = false;
+}
+
+void LuaEntitySAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
+	v3f *rotation)
+{
+	*parent_id = m_attachment_parent_id;
+	*bone = m_attachment_bone;
+	*position = m_attachment_position;
+	*rotation = m_attachment_rotation;
 }
 
 ObjectProperties* LuaEntitySAO::accessObjectProperties()
@@ -1133,6 +1160,11 @@ void PlayerSAO::setArmorGroups(const ItemGroupList &armor_groups)
 	m_armor_groups_sent = false;
 }
 
+ItemGroupList PlayerSAO::getArmorGroups()
+{
+	return m_armor_groups;
+}
+
 void PlayerSAO::setAnimation(v2f frame_range, float frame_speed, float frame_blend)
 {
 	// store these so they can be updated to clients
@@ -1142,11 +1174,24 @@ void PlayerSAO::setAnimation(v2f frame_range, float frame_speed, float frame_ble
 	m_animation_sent = false;
 }
 
+void PlayerSAO::getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend)
+{
+	*frame_range = m_animation_range;
+	*frame_speed = m_animation_speed;
+	*frame_blend = m_animation_blend;
+}
+
 void PlayerSAO::setBonePosition(const std::string &bone, v3f position, v3f rotation)
 {
 	// store these so they can be updated to clients
 	m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
 	m_bone_position_sent = false;
+}
+
+void PlayerSAO::getBonePosition(const std::string &bone, v3f *position, v3f *rotation)
+{
+	*position = m_bone_position[bone].X;
+	*rotation = m_bone_position[bone].Y;
 }
 
 void PlayerSAO::setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation)
@@ -1164,6 +1209,15 @@ void PlayerSAO::setAttachment(int parent_id, const std::string &bone, v3f positi
 	m_attachment_position = position;
 	m_attachment_rotation = rotation;
 	m_attachment_sent = false;
+}
+
+void PlayerSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
+	v3f *rotation)
+{
+	*parent_id = m_attachment_parent_id;
+	*bone = m_attachment_bone;
+	*position = m_attachment_position;
+	*rotation = m_attachment_rotation;
 }
 
 ObjectProperties* PlayerSAO::accessObjectProperties()

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -58,9 +58,13 @@ public:
 	void setHP(s16 hp);
 	s16 getHP() const;
 	void setArmorGroups(const ItemGroupList &armor_groups);
+	ItemGroupList getArmorGroups();
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend);
+	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend);
 	void setBonePosition(const std::string &bone, v3f position, v3f rotation);
+	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
+	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
 	/* LuaEntitySAO-specific */
@@ -192,9 +196,13 @@ public:
 	u16 getBreath() const;
 	void setBreath(u16 breath);
 	void setArmorGroups(const ItemGroupList &armor_groups);
+	ItemGroupList getArmorGroups();
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend);
+	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend);
 	void setBonePosition(const std::string &bone, v3f position, v3f rotation);
+	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
+	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
 	void setNametagColor(video::SColor color);

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -42,8 +42,6 @@ LocalPlayer::LocalPlayer(IGameDef *gamedef, const char *name):
 	last_pitch(0),
 	last_yaw(0),
 	last_keyPressed(0),
-	eye_offset_first(v3f(0,0,0)),
-	eye_offset_third(v3f(0,0,0)),
 	last_animation(NO_ANIM),
 	hotbar_image(""),
 	hotbar_selected_image(""),
@@ -59,6 +57,8 @@ LocalPlayer::LocalPlayer(IGameDef *gamedef, const char *name):
 	// Initialize hp to 0, so that no hearts will be shown if server
 	// doesn't support health points
 	hp = 0;
+	eye_offset_first = v3f(0,0,0);
+	eye_offset_third = v3f(0,0,0);
 }
 
 LocalPlayer::~LocalPlayer()

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -62,8 +62,6 @@ public:
 	unsigned int last_keyPressed;
 
 	float camera_impact;
-	v3f eye_offset_first;
-	v3f eye_offset_third;
 
 	int last_animation;
 	float last_animation_speed;

--- a/src/player.h
+++ b/src/player.h
@@ -215,6 +215,56 @@ public:
 		return size;
 	}
 
+	void setHotbarItemcount(s32 hotbar_itemcount) {
+		hud_hotbar_itemcount = hotbar_itemcount;
+	}
+	s32 getHotbarItemcount() {
+		return hud_hotbar_itemcount;
+	}
+	void setHotbarImage(std::string name) {
+		hud_hotbar_image = name;
+	}
+	std::string getHotbarImage() {
+		return hud_hotbar_image;
+	}
+	void setHotbarSelectedImage(std::string name) {
+		hud_hotbar_selected_image = name;
+	}
+	std::string getHotbarSelectedImage() {
+		return hud_hotbar_selected_image;
+	}
+
+	void setSky(const video::SColor &bgcolor, const std::string &type,
+			const std::vector<std::string> &params) {
+		m_sky_bgcolor = bgcolor;
+		m_sky_type = type;
+		m_sky_params = params;
+	}
+	void getSky(video::SColor *bgcolor, std::string *type,
+			std::vector<std::string> *params) {
+		*bgcolor = m_sky_bgcolor;
+		*type = m_sky_type;
+		*params = m_sky_params;
+	}
+	void overrideDayNightRatio(bool do_override, float ratio) {
+		m_day_night_ratio_do_override = do_override;
+		m_day_night_ratio = ratio;
+	}
+	void getDayNightRatio(bool *do_override, float *ratio) {
+		*do_override = m_day_night_ratio_do_override;
+		*ratio = m_day_night_ratio;
+	}
+	void setLocalAnimations(v2s32 frames[4], float frame_speed) {
+		for (int i = 0; i < 4; i++)
+			local_animations[i] = frames[i];
+		local_animation_speed = frame_speed;
+	}
+	void getLocalAnimations(v2s32 *frames, float *frame_speed) {
+		for (int i = 0; i < 4; i++)
+			frames[i] = local_animations[i];
+		*frame_speed = local_animation_speed;
+	}
+
 	virtual bool isLocal() const
 	{ return false; }
 	virtual PlayerSAO *getPlayerSAO()
@@ -255,6 +305,8 @@ public:
 	bool is_climbing;
 	bool swimming_vertical;
 	bool camera_barely_in_ceiling;
+	v3f eye_offset_first;
+	v3f eye_offset_third;
 
 	Inventory inventory;
 
@@ -308,6 +360,8 @@ public:
 
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;
+	std::string hud_hotbar_image;
+	std::string hud_hotbar_selected_image;
 protected:
 	IGameDef *m_gamedef;
 
@@ -322,6 +376,13 @@ protected:
 	bool m_dirty;
 
 	std::vector<HudElement *> hud;
+
+	std::string m_sky_type;
+	video::SColor m_sky_bgcolor;
+	std::vector<std::string> m_sky_params;
+
+	bool m_day_night_ratio_do_override;
+	float m_day_night_ratio;
 private:
 	// Protect some critical areas
 	// hud for example can be modified by EmergeThread

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -88,6 +88,8 @@ ItemDefinition     read_item_definition      (lua_State *L,
 void               read_object_properties    (lua_State *L,
                                               int index,
                                               ObjectProperties *prop);
+void		   push_object_properties    (lua_State *L,
+					      ObjectProperties *prop);
 
 void               push_inventory_list       (lua_State *L,
                                               Inventory *inv,
@@ -127,6 +129,8 @@ bool               getflagsfield             (lua_State *L, int table,
 bool               read_flags                (lua_State *L, int index,
                                               FlagDesc *flagdesc,
                                               u32 *flags, u32 *flagmask);
+void		   push_flags_string	     (lua_State *L, FlagDesc *flagdesc,
+					      u32 flags, u32 flagmask);
 
 u32                read_flags_table          (lua_State *L, int table,
                                               FlagDesc *flagdesc, u32 *flagmask);
@@ -149,6 +153,7 @@ bool               string_to_enum            (const EnumString *spec,
 
 bool               read_noiseparams          (lua_State *L, int index,
                                               NoiseParams *np);
+void		   push_noiseparams	     (lua_State *L, NoiseParams *np);
 
 void               luaentity_get             (lua_State *L,u16 id);
 

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -88,6 +88,24 @@ v2s16 check_v2s16(lua_State *L, int index)
 	return p;
 }
 
+void push_v2s16(lua_State *L, v2s16 p)
+{
+	lua_newtable(L);
+	lua_pushnumber(L, p.X);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, p.Y);
+	lua_setfield(L, -2, "y");
+}
+
+void push_v2s32(lua_State *L, v2s32 p)
+{
+	lua_newtable(L);
+	lua_pushnumber(L, p.X);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, p.Y);
+	lua_setfield(L, -2, "y");
+}
+
 v2s32 read_v2s32(lua_State *L, int index)
 {
 	v2s32 p;
@@ -275,6 +293,23 @@ aabb3f read_aabb3f(lua_State *L, int index, f32 scale)
 		lua_pop(L, 1);
 	}
 	return box;
+}
+
+void push_aabb3f(lua_State *L, aabb3f box)
+{
+	lua_newtable(L);
+	lua_pushnumber(L, box.MinEdge.X);
+	lua_rawseti(L, -2, 1);
+	lua_pushnumber(L, box.MinEdge.Y);
+	lua_rawseti(L, -2, 2);
+	lua_pushnumber(L, box.MinEdge.Z);
+	lua_rawseti(L, -2, 3);
+	lua_pushnumber(L, box.MaxEdge.X);
+	lua_rawseti(L, -2, 4);
+	lua_pushnumber(L, box.MaxEdge.Y);
+	lua_rawseti(L, -2, 5);
+	lua_pushnumber(L, box.MaxEdge.Z);
+	lua_rawseti(L, -2, 6);
 }
 
 std::vector<aabb3f> read_aabb3f_vector(lua_State *L, int index, f32 scale)

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -96,11 +96,16 @@ std::vector<aabb3f> read_aabb3f_vector  (lua_State *L, int index, f32 scale);
 size_t              read_stringlist     (lua_State *L, int index,
                                          std::vector<std::string> *result);
 
+void                push_v2s16          (lua_State *L, v2s16 p);
+void                push_v2s32          (lua_State *L, v2s32 p);
 void                push_v3s16          (lua_State *L, v3s16 p);
+void                push_aabb3f         (lua_State *L, aabb3f box);
 void                push_ARGB8          (lua_State *L, video::SColor color);
 void                pushFloatPos        (lua_State *L, v3f p);
 void                push_v3f            (lua_State *L, v3f p);
 void                push_v2f            (lua_State *L, v2f p);
+void		    push_groups		(lua_State *L,
+					 std::map<std::string, int> groups);
 
 void                warn_if_field_exists(lua_State *L, int table,
                                          const char *fieldname,

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -637,6 +637,20 @@ int ModApiMapgen::l_set_noiseparams(lua_State *L)
 }
 
 
+// get_noiseparams(name)
+int ModApiMapgen::l_get_noiseparams(lua_State *L)
+{
+	std::string name = luaL_checkstring(L, 1);
+
+	NoiseParams np;
+	if (!g_settings->getNoiseParams(name, np))
+		return 0;
+
+	push_noiseparams(L, &np);
+	return 1;
+}
+
+
 // set_gen_notify(flags, {deco_id_table})
 int ModApiMapgen::l_set_gen_notify(lua_State *L)
 {
@@ -658,6 +672,25 @@ int ModApiMapgen::l_set_gen_notify(lua_State *L)
 	}
 
 	return 0;
+}
+
+
+// get_gen_notify()
+int ModApiMapgen::l_get_gen_notify(lua_State *L)
+{
+	EmergeManager *emerge = getServer(L)->getEmergeManager();
+	push_flags_string(L, flagdesc_gennotify, emerge->gen_notify_on,
+		emerge->gen_notify_on);
+
+	lua_newtable(L);
+	int i = 1;
+	for (std::set<u32>::iterator it = emerge->gen_notify_on_deco_ids.begin();
+			it != emerge->gen_notify_on_deco_ids.end(); ++it) {
+		lua_pushnumber(L, *it);
+		lua_rawseti(L, -2, i);
+		i++;
+	}
+	return 2;
 }
 
 
@@ -1187,7 +1220,9 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 	API_FCT(get_mapgen_params);
 	API_FCT(set_mapgen_params);
 	API_FCT(set_noiseparams);
+	API_FCT(get_noiseparams);
 	API_FCT(set_gen_notify);
+	API_FCT(get_gen_notify);
 
 	API_FCT(register_biome);
 	API_FCT(register_decoration);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -39,8 +39,14 @@ private:
 	// set_noiseparam_defaults(name, noiseparams, set_default)
 	static int l_set_noiseparams(lua_State *L);
 
+	// get_noiseparam_defaults(name)
+	static int l_get_noiseparams(lua_State *L);
+
 	// set_gen_notify(flagstring)
 	static int l_set_gen_notify(lua_State *L);
+
+	// set_gen_notify(flagstring)
+	static int l_get_gen_notify(lua_State *L);
 
 	// register_biome({lots of stuff})
 	static int l_register_biome(lua_State *L);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -29,7 +29,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content_sao.h"
 #include "server.h"
 #include "hud.h"
+#include "scripting_game.h"
 
+#define GET_ENV_PTR ServerEnvironment* env =                                   \
+				dynamic_cast<ServerEnvironment*>(getEnv(L));                   \
+				if (env == NULL) return 0
 
 struct EnumString es_HudElementType[] =
 {
@@ -376,6 +380,20 @@ int ObjectRef::l_set_armor_groups(lua_State *L)
 	return 0;
 }
 
+// get_armor_groups(self)
+int ObjectRef::l_get_armor_groups(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL)
+		return 0;
+	// Do it
+	ItemGroupList groups = co->getArmorGroups();
+	push_groups(L, groups);
+	return 1;
+}
+
 // set_physics_override(self, physics_override_speed, physics_override_jump,
 //                      physics_override_gravity, sneak, sneak_glitch)
 int ObjectRef::l_set_physics_override(lua_State *L)
@@ -409,6 +427,28 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	return 0;
 }
 
+// get_physics_override(self)
+int ObjectRef::l_get_physics_override(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *co = (PlayerSAO *)getobject(ref);
+	if (co == NULL)
+		return 0;
+	// Do it
+	lua_newtable(L);
+	lua_pushnumber(L, co->m_physics_override_speed);
+	lua_setfield(L, -2, "speed");
+	lua_pushnumber(L, co->m_physics_override_jump);
+	lua_setfield(L, -2, "jump");
+	lua_pushnumber(L, co->m_physics_override_gravity);
+	lua_setfield(L, -2, "gravity");
+	lua_pushboolean(L, co->m_physics_override_sneak);
+	lua_setfield(L, -2, "sneak");
+	lua_pushboolean(L, co->m_physics_override_sneak_glitch);
+	lua_setfield(L, -2, "sneak_glitch");
+	return 1;
+}
+
 // set_animation(self, frame_range, frame_speed, frame_blend)
 int ObjectRef::l_set_animation(lua_State *L)
 {
@@ -428,6 +468,26 @@ int ObjectRef::l_set_animation(lua_State *L)
 		frame_blend = lua_tonumber(L, 4);
 	co->setAnimation(frames, frame_speed, frame_blend);
 	return 0;
+}
+
+// get_animation(self)
+int ObjectRef::l_get_animation(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL)
+		return 0;
+	// Do it
+	v2f frames = v2f(1,1);
+	float frame_speed = 15;
+	float frame_blend = 0;
+	co->getAnimation(&frames, &frame_speed, &frame_blend);
+
+	push_v2f(L, frames);
+	lua_pushnumber(L, frame_speed);
+	lua_pushnumber(L, frame_blend);
+	return 3;
 }
 
 // set_local_animation(self, {stand/idle}, {walk}, {dig}, {walk+dig}, frame_speed)
@@ -453,6 +513,27 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 
 	lua_pushboolean(L, true);
 	return 0;
+}
+
+// get_local_animation(self)
+int ObjectRef::l_get_local_animation(lua_State *L)
+{
+	//NO_MAP_LOCK_REQUIRED
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	v2s32 frames[4];
+	float frame_speed;
+	player->getLocalAnimations(frames, &frame_speed);
+
+	for (int i = 0; i < 4; i++) {
+		push_v2s32(L, frames[i]);
+	}
+
+	lua_pushnumber(L, frame_speed);
+	return 5;
 }
 
 // set_eye_offset(self, v3f first pv, v3f third pv)
@@ -485,6 +566,20 @@ int ObjectRef::l_set_eye_offset(lua_State *L)
 	return 0;
 }
 
+// get_eye_offset(self)
+int ObjectRef::l_get_eye_offset(lua_State *L)
+{
+	//NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	// Do it
+	push_v3f(L, player->eye_offset_first);
+	push_v3f(L, player->eye_offset_third);
+	return 2;
+}
+
 // set_bone_position(self, std::string bone, v3f position, v3f rotation)
 int ObjectRef::l_set_bone_position(lua_State *L)
 {
@@ -504,6 +599,28 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 		rotation = read_v3f(L, 4);
 	co->setBonePosition(bone, position, rotation);
 	return 0;
+}
+
+// get_bone_position(self, bone)
+int ObjectRef::l_get_bone_position(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL)
+		return 0;
+	// Do it
+	std::string bone = "";
+	if(!lua_isnil(L, 2))
+		bone = lua_tostring(L, 2);
+
+	v3f position = v3f(0, 0, 0);
+	v3f rotation = v3f(0, 0, 0);
+	co->getBonePosition(bone, &position, &rotation);
+
+	push_v3f(L, position);
+	push_v3f(L, rotation);
+	return 2;
 }
 
 // set_attach(self, parent, bone, position, rotation)
@@ -528,6 +645,34 @@ int ObjectRef::l_set_attach(lua_State *L)
 		rotation = read_v3f(L, 5);
 	co->setAttachment(parent->getId(), bone, position, rotation);
 	return 0;
+}
+
+// get_attach(self)
+int ObjectRef::l_get_attach(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	GET_ENV_PTR;
+
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL)
+		return 0;
+
+	// Do it
+	int parent_id = 0;
+	std::string bone = "";
+	v3f position = v3f(0, 0, 0);
+	v3f rotation = v3f(0, 0, 0);
+	co->getAttachment(&parent_id, &bone, &position, &rotation);
+	if (!parent_id)
+		return 0;
+	ServerActiveObject *parent = env->getActiveObject(parent_id);
+
+	getScriptApiBase(L)->objectrefGetOrCreate(L, parent);
+	lua_pushlstring(L, bone.c_str(), bone.size());
+	push_v3f(L, position);
+	push_v3f(L, rotation);
+	return 4;
 }
 
 // set_detach(self)
@@ -555,6 +700,21 @@ int ObjectRef::l_set_properties(lua_State *L)
 	read_object_properties(L, 2, prop);
 	co->notifyObjectPropertiesModified();
 	return 0;
+}
+
+// get_properties(self)
+int ObjectRef::l_get_properties(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL)
+		return 0;
+	ObjectProperties *prop = co->accessObjectProperties();
+	if (!prop)
+		return 0;
+	push_object_properties(L, prop);
+	return 1;
 }
 
 // is_player(self)
@@ -1185,6 +1345,20 @@ int ObjectRef::l_hud_set_hotbar_itemcount(lua_State *L)
 	return 1;
 }
 
+// hud_get_hotbar_itemcount(self)
+int ObjectRef::l_hud_get_hotbar_itemcount(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	s32 hotbar_itemcount = getServer(L)->hudGetHotbarItemcount(player);
+
+	lua_pushnumber(L, hotbar_itemcount);
+	return 1;
+}
+
 // hud_set_hotbar_image(self, name)
 int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 {
@@ -1199,6 +1373,19 @@ int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 	return 1;
 }
 
+// hud_get_hotbar_image(self)
+int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	std::string name = getServer(L)->hudGetHotbarImage(player);
+	lua_pushlstring(L, name.c_str(), name.size());
+	return 1;
+}
+
 // hud_set_hotbar_selected_image(self, name)
 int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 {
@@ -1210,6 +1397,19 @@ int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 	std::string name = lua_tostring(L, 2);
 
 	getServer(L)->hudSetHotbarSelectedImage(player, name);
+	return 1;
+}
+
+// hud_get_hotbar_selected_image(self)
+int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	std::string name = getServer(L)->hudGetHotbarSelectedImage(player);
+	lua_pushlstring(L, name.c_str(), name.size());
 	return 1;
 }
 
@@ -1251,6 +1451,33 @@ int ObjectRef::l_set_sky(lua_State *L)
 	return 1;
 }
 
+// get_sky(self)
+int ObjectRef::l_get_sky(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	video::SColor bgcolor(255, 255, 255, 255);
+	std::string type;
+	std::vector<std::string> params;
+
+	player->getSky(&bgcolor, &type, &params);
+	type = type == "" ? "regular" : type;
+
+	push_ARGB8(L, bgcolor);
+	lua_pushlstring(L, type.c_str(), type.size());
+	lua_newtable(L);
+	s16 i = 1;
+	for (std::vector<std::string>::iterator it = params.begin();
+			it != params.end(); ++it) {
+		lua_pushlstring(L, it->c_str(), it->size());
+		lua_rawseti(L, -2, i);
+		i++;
+	}
+	return 3;
+}
+
 // override_day_night_ratio(self, brightness=0...1)
 int ObjectRef::l_override_day_night_ratio(lua_State *L)
 {
@@ -1270,6 +1497,26 @@ int ObjectRef::l_override_day_night_ratio(lua_State *L)
 		return 0;
 
 	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_day_night_ratio(self)
+int ObjectRef::l_get_day_night_ratio(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	bool do_override;
+	float ratio;
+	player->getDayNightRatio(&do_override, &ratio);
+
+	if (do_override)
+		lua_pushnumber(L, ratio);
+	else
+		lua_pushnil(L);
+
 	return 1;
 }
 
@@ -1389,12 +1636,16 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_wielded_item),
 	luamethod(ObjectRef, set_wielded_item),
 	luamethod(ObjectRef, set_armor_groups),
-	luamethod(ObjectRef, set_physics_override),
+	luamethod(ObjectRef, get_armor_groups),
 	luamethod(ObjectRef, set_animation),
+	luamethod(ObjectRef, get_animation),
 	luamethod(ObjectRef, set_bone_position),
+	luamethod(ObjectRef, get_bone_position),
 	luamethod(ObjectRef, set_attach),
+	luamethod(ObjectRef, get_attach),
 	luamethod(ObjectRef, set_detach),
 	luamethod(ObjectRef, set_properties),
+	luamethod(ObjectRef, get_properties),
 	// LuaEntitySAO-only
 	luamethod(ObjectRef, setvelocity),
 	luamethod(ObjectRef, getvelocity),
@@ -1421,6 +1672,8 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_inventory_formspec),
 	luamethod(ObjectRef, get_player_control),
 	luamethod(ObjectRef, get_player_control_bits),
+	luamethod(ObjectRef, set_physics_override),
+	luamethod(ObjectRef, get_physics_override),
 	luamethod(ObjectRef, hud_add),
 	luamethod(ObjectRef, hud_remove),
 	luamethod(ObjectRef, hud_change),
@@ -1428,12 +1681,19 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_set_flags),
 	luamethod(ObjectRef, hud_get_flags),
 	luamethod(ObjectRef, hud_set_hotbar_itemcount),
+	luamethod(ObjectRef, hud_get_hotbar_itemcount),
 	luamethod(ObjectRef, hud_set_hotbar_image),
+	luamethod(ObjectRef, hud_get_hotbar_image),
 	luamethod(ObjectRef, hud_set_hotbar_selected_image),
+	luamethod(ObjectRef, hud_get_hotbar_selected_image),
 	luamethod(ObjectRef, set_sky),
+	luamethod(ObjectRef, get_sky),
 	luamethod(ObjectRef, override_day_night_ratio),
+	luamethod(ObjectRef, get_day_night_ratio),
 	luamethod(ObjectRef, set_local_animation),
+	luamethod(ObjectRef, get_local_animation),
 	luamethod(ObjectRef, set_eye_offset),
+	luamethod(ObjectRef, get_eye_offset),
 	luamethod(ObjectRef, set_nametag_attributes),
 	luamethod(ObjectRef, get_nametag_attributes),
 	{0,0}

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -101,24 +101,42 @@ private:
 	// set_armor_groups(self, groups)
 	static int l_set_armor_groups(lua_State *L);
 
+	// get_armor_groups(self)
+	static int l_get_armor_groups(lua_State *L);
+
 	// set_physics_override(self, physics_override_speed, physics_override_jump,
 	//                      physics_override_gravity, sneak, sneak_glitch)
 	static int l_set_physics_override(lua_State *L);
 
+	// get_physics_override(self)
+	static int l_get_physics_override(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend)
 	static int l_set_animation(lua_State *L);
+
+	// get_animation(self)
+	static int l_get_animation(lua_State *L);
 
 	// set_bone_position(self, std::string bone, v3f position, v3f rotation)
 	static int l_set_bone_position(lua_State *L);
 
+	// get_bone_position(self, bone)
+	static int l_get_bone_position(lua_State *L);
+
 	// set_attach(self, parent, bone, position, rotation)
 	static int l_set_attach(lua_State *L);
+
+	// get_attach(self)
+	static int l_get_attach(lua_State *L);
 
 	// set_detach(self)
 	static int l_set_detach(lua_State *L);
 
 	// set_properties(self, properties)
 	static int l_set_properties(lua_State *L);
+
+	// get_properties(self)
+	static int l_get_properties(lua_State *L);
 
 	// is_player(self)
 	static int l_is_player(lua_State *L);
@@ -222,23 +240,44 @@ private:
 	// hud_set_hotbar_itemcount(self, hotbar_itemcount)
 	static int l_hud_set_hotbar_itemcount(lua_State *L);
 
+	// hud_get_hotbar_itemcount(self)
+	static int l_hud_get_hotbar_itemcount(lua_State *L);
+
 	// hud_set_hotbar_image(self, name)
 	static int l_hud_set_hotbar_image(lua_State *L);
+
+	// hud_get_hotbar_image(self)
+	static int l_hud_get_hotbar_image(lua_State *L);
 
 	// hud_set_hotbar_selected_image(self, name)
 	static int l_hud_set_hotbar_selected_image(lua_State *L);
 
+	// hud_get_hotbar_selected_image(self)
+	static int l_hud_get_hotbar_selected_image(lua_State *L);
+
 	// set_sky(self, type, list)
 	static int l_set_sky(lua_State *L);
 
-	// override_day_night_ratio(self, type, list)
+	// get_sky(self, type, list)
+	static int l_get_sky(lua_State *L);
+
+	// override_day_night_ratio(self, type)
 	static int l_override_day_night_ratio(lua_State *L);
+
+	// get_day_night_ratio(self)
+	static int l_get_day_night_ratio(lua_State *L);
 
 	// set_local_animation(self, {stand/idle}, {walk}, {dig}, {walk+dig}, frame_speed)
 	static int l_set_local_animation(lua_State *L);
 
+	// get_local_animation(self)
+	static int l_get_local_animation(lua_State *L);
+
 	// set_eye_offset(self, v3f first pv, v3f third pv)
 	static int l_set_eye_offset(lua_State *L);
+
+	// get_eye_offset(self)
+	static int l_get_eye_offset(lua_State *L);
 
 	// set_nametag_attributes(self, attributes)
 	static int l_set_nametag_attributes(lua_State *L);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2915,24 +2915,46 @@ bool Server::hudSetHotbarItemcount(Player *player, s32 hotbar_itemcount) {
 	if (hotbar_itemcount <= 0 || hotbar_itemcount > HUD_HOTBAR_ITEMCOUNT_MAX)
 		return false;
 
+	player->setHotbarItemcount(hotbar_itemcount);
 	std::ostringstream os(std::ios::binary);
 	writeS32(os, hotbar_itemcount);
 	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_ITEMCOUNT, os.str());
 	return true;
 }
 
+s32 Server::hudGetHotbarItemcount(Player *player) {
+	if (!player)
+		return 0;
+	return player->getHotbarItemcount();
+}
+
 void Server::hudSetHotbarImage(Player *player, std::string name) {
 	if (!player)
 		return;
 
+	player->setHotbarImage(name);
 	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_IMAGE, name);
+}
+
+std::string Server::hudGetHotbarImage(Player *player) {
+	if (!player)
+		return "";
+	return player->getHotbarImage();
 }
 
 void Server::hudSetHotbarSelectedImage(Player *player, std::string name) {
 	if (!player)
 		return;
 
+	player->setHotbarSelectedImage(name);
 	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_SELECTED_IMAGE, name);
+}
+
+std::string Server::hudGetHotbarSelectedImage(Player *player) {
+	if (!player)
+		return "";
+
+	return player->getHotbarSelectedImage();
 }
 
 bool Server::setLocalPlayerAnimations(Player *player, v2s32 animation_frames[4], f32 frame_speed)
@@ -2940,6 +2962,7 @@ bool Server::setLocalPlayerAnimations(Player *player, v2s32 animation_frames[4],
 	if (!player)
 		return false;
 
+	player->setLocalAnimations(animation_frames, frame_speed);
 	SendLocalPlayerAnimations(player->peer_id, animation_frames, frame_speed);
 	return true;
 }
@@ -2949,6 +2972,8 @@ bool Server::setPlayerEyeOffset(Player *player, v3f first, v3f third)
 	if (!player)
 		return false;
 
+	player->eye_offset_first = first;
+	player->eye_offset_third = third;
 	SendEyeOffset(player->peer_id, first, third);
 	return true;
 }
@@ -2959,6 +2984,7 @@ bool Server::setSky(Player *player, const video::SColor &bgcolor,
 	if (!player)
 		return false;
 
+	player->setSky(bgcolor, type, params);
 	SendSetSky(player->peer_id, bgcolor, type, params);
 	return true;
 }
@@ -2969,6 +2995,7 @@ bool Server::overrideDayNightRatio(Player *player, bool do_override,
 	if (!player)
 		return false;
 
+	player->overrideDayNightRatio(do_override, ratio);
 	SendOverrideDayNightRatio(player->peer_id, do_override, ratio);
 	return true;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -343,8 +343,11 @@ public:
 	bool hudChange(Player *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(Player *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(Player *player, s32 hotbar_itemcount);
+	s32 hudGetHotbarItemcount(Player *player);
 	void hudSetHotbarImage(Player *player, std::string name);
+	std::string hudGetHotbarImage(Player *player);
 	void hudSetHotbarSelectedImage(Player *player, std::string name);
+	std::string hudGetHotbarSelectedImage(Player *player);
 
 	inline Address getPeerAddress(u16 peer_id)
 			{ return m_con.GetPeerAddress(peer_id); }

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -147,13 +147,21 @@ public:
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}
+	virtual ItemGroupList getArmorGroups()
+	{ return ItemGroupList(); }
 	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
 	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend)
 	{}
+	virtual void getAnimation(v2f *frames, float *frame_spee, float *frame_blend)
+	{}
 	virtual void setBonePosition(const std::string &bone, v3f position, v3f rotation)
 	{}
+	virtual void getBonePosition(const std::string &bone, v3f *position, v3f *lotation)
+	{}
 	virtual void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation)
+	{}
+	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation)
 	{}
 	virtual ObjectProperties* accessObjectProperties()
 	{ return NULL; }


### PR DESCRIPTION
Fixes #1496

Adds:
ObjectRef:
* get_properties
* get_armor_groups
* get_animation
* get_attach
* get_bone_position

Players:
* get_physics_override
* hud_get_hotbar_itemcount
* hud_get_hotbar_image
* hud_get_hotbar_selected_image
* get_sky
* get_day_night_ratio
* get_local_animation
* get_eye_offset

Global:
* minetest.get_gen_notify
* minetest.get_noiseparams (set_noiseparams_defaults got renamed)

Doesn't add:
* minetest.get_player_password
* minetest.get_mapgen_params => is already there