### PR TITLE
Make the player collisionbox settable

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3683,7 +3683,8 @@ Definition tables
         collisionbox = {-0.5,-0.5,-0.5, 0.5,0.5,0.5},
         visual = "cube"/"sprite"/"upright_sprite"/"mesh"/"wielditem",
         visual_size = {x=1, y=1},
-        mesh = "model",
+        mesh = "model", -- for players (0, -1, 0) is ground level,
+			-- for all other entities (0, 0, 0) is ground level.
         textures = {}, -- number of required textures depends on visual
         colors = {}, -- number of required colors depends on visual
         spritediv = {x=1, y=1},

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1589,6 +1589,13 @@ void GenericCAO::processMessage(const std::string &data)
 			m_initial_tx_basepos_set = true;
 			m_tx_basepos = m_prop.initial_sprite_basepos;
 		}
+		if (m_is_local_player) {
+			LocalPlayer *player = m_env->getLocalPlayer();
+			aabb3f collisionbox = m_selection_box;
+			collisionbox.MinEdge += v3f(0, BS, 0);
+			collisionbox.MaxEdge += v3f(0, BS, 0);
+			player->setCollisionbox(collisionbox);
+		}
 
 		if ((m_is_player && !m_is_local_player) && m_prop.nametag == "")
 			m_prop.nametag = m_name;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1428,7 +1428,10 @@ bool PlayerSAO::checkMovementCheat()
 
 bool PlayerSAO::getCollisionBox(aabb3f *toset) const
 {
-	*toset = aabb3f(-BS * 0.30, 0.0, -BS * 0.30, BS * 0.30, BS * 1.75, BS * 0.30);
+	//update collision box
+	toset->MinEdge = m_prop.collisionbox.MinEdge * BS + v3f(0, BS, 0);
+	toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS + v3f(0, BS, 0);
+
 	toset->MinEdge += m_base_position;
 	toset->MaxEdge += m_base_position;
 	return true;

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -132,6 +132,8 @@ public:
 	v3f getEyePosition() const { return m_position + getEyeOffset(); }
 	v3f getEyeOffset() const;
 
+	void setCollisionbox(aabb3f box) { m_collisionbox = box; }
+
 private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);


### PR DESCRIPTION
It's not ideal since the collisionbox of players is off by 1. But fixing this problem would be incompatible with previous minetest versions, mods and games.
