### PR TITLE
Add minetest.register_on_player_hpchange

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -407,6 +407,34 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 	return list
 end
 
+core.registered_on_player_hpchanges = { modifiers = { }, loggers = { } }
+function core.registered_on_player_hpchange(player, hp_change)
+	local last = false
+	for i = #core.registered_on_player_hpchanges.modifiers, 1, -1 do
+		local func = core.registered_on_player_hpchanges.modifiers[i]
+		hp_change, last = func(player, hp_change)
+		if type(hp_change) ~= "number" then
+			local debuginfo = debug.getinfo(func)
+			error("The register_on_hp_changes function has to return a number at " ..
+				debuginfo.short_src .. " line " .. debuginfo.linedefined)
+		end
+		if last then
+			break
+		end
+	end
+	for i, func in ipairs(core.registered_on_player_hpchanges.loggers) do
+		func(player, hp_change)
+	end
+	return hp_change
+end
+function core.register_on_player_hpchange(func, modifier)
+	if modifier then
+		table.insert(core.registered_on_player_hpchanges.modifiers, func)
+	else
+		table.insert(core.registered_on_player_hpchanges.loggers, func)
+	end
+end
+
 core.registered_biomes      = make_registration_wrap("register_biome",      "clear_registered_biomes")
 core.registered_ores        = make_registration_wrap("register_ore",        "clear_registered_ores")
 core.registered_decorations = make_registration_wrap("register_decoration", "clear_registered_decorations")

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1785,6 +1785,13 @@ Call these functions only at load time!
        the puncher to the punched.
      * `damage` - number that represents the damage calculated by the engine
      * should return `true` to prevent the default damage mechanism
+* `minetest.register_on_player_hpchange(func(player, hp_change), modifier)`
+    * Called when the player gets damaged or healed
+    * `player`: ObjectRef of the player
+    * `hp_change`: the amount of change. Negative when it is damage.
+    * `modifier`: when true, the function should return the actual hp_change.
+      Note: modifiers only get a temporary hp_change that can be modified by later modifiers.
+      modifiers can return true as a second argument to stop the execution of further functions.
 * `minetest.register_on_respawnplayer(func(ObjectRef))`
      * Called when player is to be respawned
      * Called _before_ repositioning of player occurs

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1125,6 +1125,12 @@ void PlayerSAO::setHP(s16 hp)
 {
 	s16 oldhp = m_player->hp;
 
+	s16 hp_change = m_env->getScriptIface()->on_player_hpchange(this,
+		hp - oldhp);
+	if (hp_change == 0)
+		return;
+	hp = oldhp + hp_change;
+
 	if (hp < 0)
 		hp = 0;
 	else if (hp > PLAYER_MAX_HP)

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -69,6 +69,25 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 	return lua_toboolean(L, -1);
 }
 
+s16 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
+	s16 hp_change)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_player_hpchange
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_player_hpchange");
+	lua_remove(L, -2);
+
+	objectrefGetOrCreate(L, player);
+	lua_pushnumber(L, hp_change);
+	if (lua_pcall(L, 2, 1, m_errorhandler))
+		scriptError();
+	hp_change = lua_tointeger(L, -1);
+	lua_pop(L, -1);
+	return hp_change;
+}
+
 bool ScriptApiPlayer::on_respawnplayer(ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -43,6 +43,7 @@ public:
 	bool on_punchplayer(ServerActiveObject *player,
 		ServerActiveObject *hitter, float time_from_last_punch,
 		const ToolCapabilities *toolcap, v3f dir, s16 damage);
+	s16 on_player_hpchange(ServerActiveObject *player, s16 hp_change);
 	void on_playerReceiveFields(ServerActiveObject *player,
 		const std::string &formname, const StringMap &fields);
 };


### PR DESCRIPTION
Adds a new callback on_player_hpchange.
I split the callbacks in modifying functions and logging functions since there are some use cases where you only want to know, what damage actually was dealt without modifying it and this wouldn't be possible if they were mixed with functions modifying the value.