### PR TITLE
Minimal subgame: Update mapgen aliases, ores, simple biomes

### DIFF
--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -452,9 +452,7 @@ minetest.register_craft({
 	}
 })
 
---
--- Crafting (tool repair)
---
+-- Tool repair
 minetest.register_craft({
 	type = "toolrepair",
 	additional_wear = -0.02,
@@ -707,7 +705,7 @@ function default.node_sound_glass_defaults(table)
 	return table
 end
 
---
+-- Register nodes
 
 minetest.register_node("default:stone", {
 	description = "Stone",
@@ -1496,6 +1494,9 @@ minetest.register_node("default:apple", {
 	sounds = default.node_sound_defaults(),
 })
 
+--
+-- Grow tree function
+--
 
 local c_air = minetest.get_content_id("air")
 local c_ignore = minetest.get_content_id("ignore")
@@ -1567,6 +1568,10 @@ function default.grow_tree(data, a, pos, is_apple_tree, seed)
 	end
 	end
 end
+
+--
+-- ABMs
+--
 
 minetest.register_abm({
 	nodenames = {"default:sapling"},
@@ -1674,29 +1679,9 @@ minetest.register_craftitem("default:scorched_stuff", {
 })
 
 --
--- Aliases for the current map generator outputs
+-- Support old code
 --
 
-minetest.register_alias("mapgen_air", "air")
-minetest.register_alias("mapgen_stone", "default:stone")
-minetest.register_alias("mapgen_tree", "default:tree")
-minetest.register_alias("mapgen_leaves", "default:leaves")
-minetest.register_alias("mapgen_apple", "default:apple")
-minetest.register_alias("mapgen_water_source", "default:water_source")
-minetest.register_alias("mapgen_dirt", "default:dirt")
-minetest.register_alias("mapgen_sand", "default:sand")
-minetest.register_alias("mapgen_gravel", "default:gravel")
-minetest.register_alias("mapgen_clay", "default:clay")
-minetest.register_alias("mapgen_lava_source", "default:lava_source")
-minetest.register_alias("mapgen_cobble", "default:cobble")
-minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
-minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")
-minetest.register_alias("mapgen_junglegrass", "default:junglegrass")
-minetest.register_alias("mapgen_stone_with_coal", "default:stone_with_coal")
-minetest.register_alias("mapgen_stone_with_iron", "default:stone_with_iron")
-minetest.register_alias("mapgen_mese", "default:mese")
-
--- Support old code
 function default.spawn_falling_node(p, nodename)
 	spawn_falling_node(p, nodename)
 end
@@ -1795,3 +1780,4 @@ test_get_craft_result()
 --dump2(minetest.registered_entities)
 
 -- END
+

--- a/games/minimal/mods/default/mapgen.lua
+++ b/games/minimal/mods/default/mapgen.lua
@@ -1,52 +1,61 @@
--- minetest/default/mapgen.lua
-
 --
 -- Aliases for map generator outputs
 --
 
+
 minetest.register_alias("mapgen_stone", "default:stone")
+minetest.register_alias("mapgen_dirt", "default:dirt")
+minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")
+minetest.register_alias("mapgen_sand", "default:sand")
+minetest.register_alias("mapgen_water_source", "default:water_source")
+minetest.register_alias("mapgen_lava_source", "default:lava_source")
+minetest.register_alias("mapgen_gravel", "default:gravel")
+
 minetest.register_alias("mapgen_tree", "default:tree")
 minetest.register_alias("mapgen_leaves", "default:leaves")
 minetest.register_alias("mapgen_apple", "default:apple")
-minetest.register_alias("mapgen_water_source", "default:water_source")
-minetest.register_alias("mapgen_dirt", "default:dirt")
-minetest.register_alias("mapgen_sand", "default:sand")
-minetest.register_alias("mapgen_gravel", "default:gravel")
-minetest.register_alias("mapgen_clay", "default:clay")
-minetest.register_alias("mapgen_lava_source", "default:lava_source")
-minetest.register_alias("mapgen_cobble", "default:cobble")
-minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
-minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")
 minetest.register_alias("mapgen_junglegrass", "default:junglegrass")
-minetest.register_alias("mapgen_stone_with_coal", "default:stone_with_coal")
-minetest.register_alias("mapgen_stone_with_iron", "default:stone_with_iron")
-minetest.register_alias("mapgen_mese", "default:mese")
+
+minetest.register_alias("mapgen_cobble", "default:cobble")
 minetest.register_alias("mapgen_stair_cobble", "stairs:stair_cobble")
+minetest.register_alias("mapgen_mossycobble", "default:mossycobble")
+
 
 --
 -- Ore generation
 --
+
+
+-- Blob ore first to avoid other ores inside blobs
+
+minetest.register_ore({ 
+	ore_type         = "blob",
+	ore              = "default:clay",
+	wherein          = {"default:sand"},
+	clust_scarcity   = 24*24*24,
+	clust_size       = 7,
+	y_min            = -15,
+	y_max            = 0,
+	noise_threshhold = 0,
+	noise_params     = {
+		offset=0.35,
+		scale=0.2,
+		spread={x=5, y=5, z=5},
+		seed=-316,
+		octaves=1,
+		persist=0.5
+	},
+})
 
 minetest.register_ore({
 	ore_type       = "scatter",
 	ore            = "default:stone_with_coal",
 	wherein        = "default:stone",
 	clust_scarcity = 8*8*8,
-	clust_num_ores = 5,
+	clust_num_ores = 8,
 	clust_size     = 3,
-	height_min     = -31000,
-	height_max     = 64,
-})
-
-minetest.register_ore({
-	ore_type       = "scatter",
-	ore            = "default:stone_with_iron",
-	wherein        = "default:stone",
-	clust_scarcity = 16*16*16,
-	clust_num_ores = 5,
-	clust_size     = 3,
-	height_min     = -5,
-	height_max     = 7,
+	y_min          = -31000,
+	y_max          = 64,
 })
 
 minetest.register_ore({
@@ -54,10 +63,10 @@ minetest.register_ore({
 	ore            = "default:stone_with_iron",
 	wherein        = "default:stone",
 	clust_scarcity = 12*12*12,
-	clust_num_ores = 5,
-	clust_size     = 3,
-	height_min     = -16,
-	height_max     = -5,
+	clust_num_ores = 3,
+	clust_size     = 2,
+	y_min          = -15,
+	y_max          = 2,
 })
 
 minetest.register_ore({
@@ -67,60 +76,60 @@ minetest.register_ore({
 	clust_scarcity = 9*9*9,
 	clust_num_ores = 5,
 	clust_size     = 3,
-	height_min     = -31000,
-	height_max     = -17,
+	y_min          = -63,
+	y_max          = -16,
 })
 
-minetest.register_on_generated(function(minp, maxp, seed)
-	-- Generate clay
-	if maxp.y >= 2 and minp.y <= 0 then
-		-- Assume X and Z lengths are equal
-		local divlen = 4
-		local divs = (maxp.x-minp.x)/divlen+1;
-		for divx=0+1,divs-1-1 do
-		for divz=0+1,divs-1-1 do
-			local cx = minp.x + math.floor((divx+0.5)*divlen)
-			local cz = minp.z + math.floor((divz+0.5)*divlen)
-			if minetest.get_node({x=cx,y=1,z=cz}).name == "default:water_source" and
-					minetest.get_node({x=cx,y=0,z=cz}).name == "default:sand" then
-				local is_shallow = true
-				local num_water_around = 0
-				if minetest.get_node({x=cx-divlen*2,y=1,z=cz+0}).name == "default:water_source" then
-					num_water_around = num_water_around + 1 end
-				if minetest.get_node({x=cx+divlen*2,y=1,z=cz+0}).name == "default:water_source" then
-					num_water_around = num_water_around + 1 end
-				if minetest.get_node({x=cx+0,y=1,z=cz-divlen*2}).name == "default:water_source" then
-					num_water_around = num_water_around + 1 end
-				if minetest.get_node({x=cx+0,y=1,z=cz+divlen*2}).name == "default:water_source" then
-					num_water_around = num_water_around + 1 end
-				if num_water_around >= 2 then
-					is_shallow = false
-				end	
-				if is_shallow then
-					for x1=-divlen,divlen do
-					for z1=-divlen,divlen do
-						if minetest.get_node({x=cx+x1,y=0,z=cz+z1}).name == "default:sand" then
-							minetest.set_node({x=cx+x1,y=0,z=cz+z1}, {name="default:clay"})
-						end
-					end
-					end
-				end
-			end
-		end
-		end
-	end
-end)
+minetest.register_ore({
+	ore_type       = "scatter",
+	ore            = "default:stone_with_iron",
+	wherein        = "default:stone",
+	clust_scarcity = 7*7*7,
+	clust_num_ores = 5,
+	clust_size     = 3,
+	y_min          = -31000,
+	y_max          = -64,
+})
+
 
 --
--- Register biome for biome API
+-- Register biomes for biome API
 --
+
+
+minetest.clear_registered_biomes()
 
 minetest.register_biome({
-	name           = "Grassland",
-	-- Will use defaults of omitted parameters
-	y_min          = -31000,
-	y_max          = 31000,
-	heat_point     = 50,
+	name = "default:grassland",
+	--node_dust = "",
+	node_top = "default:dirt_with_grass",
+	depth_top = 1,
+	node_filler = "default:dirt",
+	depth_filler = 1,
+	--node_stone = "",
+	--node_water_top = "",
+	--depth_water_top = ,
+	--node_water = "",
+	y_min = 5,
+	y_max = 31000,
+	heat_point = 50,
+	humidity_point = 50,
+})
+
+minetest.register_biome({
+	name = "default:grassland_ocean",
+	--node_dust = "",
+	node_top = "default:sand",
+	depth_top = 1,
+	node_filler = "default:sand",
+	depth_filler = 2,
+	--node_stone = "",
+	--node_water_top = "",
+	--depth_water_top = ,
+	--node_water = "",
+	y_min = -31000,
+	y_max = 4,
+	heat_point = 50,
 	humidity_point = 50,
 })
 


### PR DESCRIPTION
Also remove duplicated mapgen aliases in init.lua.

The simple biome system needed updating for the new system.
Ore definitions are updated but kept to the minimal of 1 coal and 3 iron.
Clay generation is now done using new blob ore.
Code cleanup adds some section title comments and adds newline at EOF.
Unnecessary mapgen aliases (ores and clay) are removed.