### PR TITLE
Biome API: Noise defined biome blend

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -532,9 +532,11 @@
 #    Mgv5 uses eased noise for np_ground so this is shown in group format,
 #    other noise parameters are shown in positional format to save space.
 
-#    Noise parameters for biome API temperature and humidity
+#    Noise parameters for biome API temperature, humidity and biome blend
 #mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
+#mg_biome_np_heat_blend = 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
 #mg_biome_np_humidity = 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
+#mg_biome_np_humidity_blend = 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0
 
 #mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 #mgv5_np_factor = 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -445,7 +445,9 @@ void MapgenParams::load(const Settings &settings)
 	settings.getS16NoEx("chunksize", chunksize);
 	settings.getFlagStrNoEx("mg_flags", flags, flagdesc_mapgen);
 	settings.getNoiseParams("mg_biome_np_heat", np_biome_heat);
+	settings.getNoiseParams("mg_biome_np_heat_blend", np_biome_heat_blend);
 	settings.getNoiseParams("mg_biome_np_humidity", np_biome_humidity);
+	settings.getNoiseParams("mg_biome_np_humidity_blend", np_biome_humidity_blend);
 
 	delete sparams;
 	sparams = EmergeManager::createMapgenParams(mg_name);
@@ -462,7 +464,9 @@ void MapgenParams::save(Settings &settings) const
 	settings.setS16("chunksize", chunksize);
 	settings.setFlagStr("mg_flags", flags, flagdesc_mapgen, (u32)-1);
 	settings.setNoiseParams("mg_biome_np_heat", np_biome_heat);
+	settings.setNoiseParams("mg_biome_np_heat_blend", np_biome_heat_blend);
 	settings.setNoiseParams("mg_biome_np_humidity", np_biome_humidity);
+	settings.setNoiseParams("mg_biome_np_humidity_blend", np_biome_humidity_blend);
 
 	if (sparams)
 		sparams->writeParams(&settings);

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -115,7 +115,9 @@ struct MapgenParams {
 	u32 flags;
 
 	NoiseParams np_biome_heat;
+	NoiseParams np_biome_heat_blend;
 	NoiseParams np_biome_humidity;
+	NoiseParams np_biome_humidity_blend;
 
 	MapgenSpecificParams *sparams;
 
@@ -126,7 +128,9 @@ struct MapgenParams {
 		water_level(1),
 		flags(MG_TREES | MG_CAVES | MG_LIGHT),
 		np_biome_heat(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0)),
+		np_biome_heat_blend(NoiseParams(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0)),
 		np_biome_humidity(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0)),
+		np_biome_humidity_blend(NoiseParams(0, 1.5, v3f(8.0, 8.0, 8.0), 90003, 2, 1.0, 2.0)),
 		sparams(NULL)
 	{}
 

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -68,13 +68,15 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	noise_height       = new Noise(&sp->np_height,       seed, csize.X, csize.Z);
 
 	// 3D terrain noise
-	noise_cave1        = new Noise(&sp->np_cave1,   seed, csize.X, csize.Y + 2, csize.Z);
-	noise_cave2        = new Noise(&sp->np_cave2,   seed, csize.X, csize.Y + 2, csize.Z);
-	noise_ground       = new Noise(&sp->np_ground,  seed, csize.X, csize.Y + 2, csize.Z);
+	noise_cave1  = new Noise(&sp->np_cave1,  seed, csize.X, csize.Y + 2, csize.Z);
+	noise_cave2  = new Noise(&sp->np_cave2,  seed, csize.X, csize.Y + 2, csize.Z);
+	noise_ground = new Noise(&sp->np_ground, seed, csize.X, csize.Y + 2, csize.Z);
 
 	// Biome noise
-	noise_heat         = new Noise(&params->np_biome_heat,     seed, csize.X, csize.Z);
-	noise_humidity     = new Noise(&params->np_biome_humidity, seed, csize.X, csize.Z);
+	noise_heat           = new Noise(&params->np_biome_heat,           seed, csize.X, csize.Z);
+	noise_humidity       = new Noise(&params->np_biome_humidity,       seed, csize.X, csize.Z);
+	noise_heat_blend     = new Noise(&params->np_biome_heat_blend,     seed, csize.X, csize.Z);
+	noise_humidity_blend = new Noise(&params->np_biome_humidity_blend, seed, csize.X, csize.Z);
 
 	//// Resolve nodes to be used
 	INodeDefManager *ndef = emerge->ndef;
@@ -116,6 +118,8 @@ MapgenV5::~MapgenV5()
 
 	delete noise_heat;
 	delete noise_humidity;
+	delete noise_heat_blend;
+	delete noise_humidity_blend;
 
 	delete[] heightmap;
 	delete[] biomemap;
@@ -330,7 +334,13 @@ void MapgenV5::calculateNoise()
 	noise_filler_depth->perlinMap2D(x, z);
 	noise_heat->perlinMap2D(x, z);
 	noise_humidity->perlinMap2D(x, z);
+	noise_heat_blend->perlinMap2D(x, z);
+	noise_humidity_blend->perlinMap2D(x, z);
 
+	for (s32 i = 0; i < csize.X * csize.Z; i++) {
+		noise_heat->result[i] += noise_heat_blend->result[i];
+		noise_humidity->result[i] += noise_humidity_blend->result[i];
+	}
 	//printf("calculateNoise: %dus\n", t.stop());
 }
 

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -69,8 +69,11 @@ public:
 	Noise *noise_cave1;
 	Noise *noise_cave2;
 	Noise *noise_ground;
+
 	Noise *noise_heat;
 	Noise *noise_humidity;
+	Noise *noise_heat_blend;
+	Noise *noise_humidity_blend;
 
 	content_t c_stone;
 	content_t c_water_source;

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -82,6 +82,8 @@ public:
 
 	Noise *noise_heat;
 	Noise *noise_humidity;
+	Noise *noise_heat_blend;
+	Noise *noise_humidity_blend;
 
 	content_t c_stone;
 	content_t c_water_source;


### PR DESCRIPTION
![screenshot_20150604_035741](https://cloud.githubusercontent.com/assets/3686677/8028091/a4f9b290-0d9d-11e5-974f-58231a021ab3.png)

Noise defined biome blend for the biome API. Uses 2 noises, each with 2 octaves. Blend noises are grouped with heat and humidity noises and parameters are settable in .conf for custom blends.