### PR TITLE
Biome API: Enable generateBiomes to world base

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -327,11 +327,9 @@ void MapgenV5::calculateNoise()
 		noise_cave2->perlinMap3D(x, y, z);
 	}
 
-	if (node_max.Y >= BIOMEGEN_BASE_V5) {
-		noise_filler_depth->perlinMap2D(x, z);
-		noise_heat->perlinMap2D(x, z);
-		noise_humidity->perlinMap2D(x, z);
-	}
+	noise_filler_depth->perlinMap2D(x, z);
+	noise_heat->perlinMap2D(x, z);
+	noise_humidity->perlinMap2D(x, z);
 
 	//printf("calculateNoise: %dus\n", t.stop());
 }
@@ -396,9 +394,6 @@ int MapgenV5::generateBaseTerrain()
 
 MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 {
-	if (node_max.Y < BIOMEGEN_BASE_V5)
-		return STONE;
-
 	v3s16 em = vm->m_area.getExtent();
 	u32 index = 0;
 	MgStoneType stone_type = STONE;

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen.h"
 
 #define LARGE_CAVE_DEPTH -256
-#define BIOMEGEN_BASE_V5 -192
 
 /////////////////// Mapgen V5 flags
 //#define MGV5_   0x01

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -362,11 +362,9 @@ void MapgenV7::calculateNoise()
 		noise_mount_height->perlinMap2D(x, z);
 	}
 
-	if (node_max.Y >= BIOMEGEN_BASE_V7) {
-		noise_filler_depth->perlinMap2D(x, z);
-		noise_heat->perlinMap2D(x, z);
-		noise_humidity->perlinMap2D(x, z);
-	}
+	noise_filler_depth->perlinMap2D(x, z);
+	noise_heat->perlinMap2D(x, z);
+	noise_humidity->perlinMap2D(x, z);
 	//printf("calculateNoise: %dus\n", t.stop());
 }
 
@@ -591,9 +589,6 @@ void MapgenV7::generateRidgeTerrain()
 
 MgStoneType MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 {
-	if (node_max.Y < BIOMEGEN_BASE_V7)
-		return STONE;
-
 	v3s16 em = vm->m_area.getExtent();
 	u32 index = 0;
 	MgStoneType stone_type = STONE;

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -22,8 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-#define BIOMEGEN_BASE_V7 -192
-
 /////////////////// Mapgen V7 flags
 #define MGV7_MOUNTAINS   0x01
 #define MGV7_RIDGES      0x02

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -129,7 +129,6 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 			s16 y = mg->heightmap ?
 					mg->heightmap[mapindex] :
 					mg->findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
-			y = MYMAX(y, mg->water_level);
 
 			if (y < nmin.Y || y > nmax.Y ||
 				y < y_min  || y > y_max)


### PR DESCRIPTION
Also: Revert the lower limit of water level for placement of decorations.

Because the biome API can replace stone with chosen nodes it is now enabled to world base. This enables layers of chosen nodes to be placed deep underground, for example bedrock near world base or at any height. Underground, biome is calculated only once at mapchunk column top so chosen nodes are placable in layers of mapchunk thickness.
Desert stone and sandstone can now extend to world base if desired.