### PR TITLE
Fixed crash caused by saplings trying to grow on unknown nodes

### DIFF
--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -1660,7 +1660,11 @@ minetest.register_abm({
 	interval = 10,
 	chance = 50,
 	action = function(pos, node)
-		local is_soil = minetest.registered_nodes[minetest.get_node({x=pos.x, y=pos.y-1, z=pos.z}).name].groups.soil
+		local node_under = minetest.registered_nodes[minetest.get_node({x=pos.x, y=pos.y-1, z=pos.z}).name]
+		if not node_under then
+			return
+		end
+		local is_soil = node_under.groups.soil
 		if is_soil == nil or is_soil == 0 then return end
 		print("A sapling grows into a tree at "..minetest.pos_to_string(pos))
 		local vm = minetest.get_voxel_manip()


### PR DESCRIPTION
The minimal game assumes that the node under a sapling will be defined, and will therefor have an indexable "groups" value. For unknown nodes, the "unknown" is not returned as the name of the node, the original (missing) node's name is, causing the came to try to index a nil value. This small patch fixes it.

It's not a big deal because it's only in the minimal testing game, but it does cause a needless annoying crash in some test cases.