### PR TITLE
Fixed space issues.

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -474,7 +474,7 @@ void ChatPrompt::historyNext()
 	}
 }
 
-void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwards)
+void ChatPrompt::nickCompletion(const std::list<std::string> &names, bool backwards)
 {
 	// Two cases:
 	// (a) m_nick_completion_start == m_nick_completion_end == 0
@@ -511,7 +511,7 @@ void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwa
 		{
 			std::wstring completion = narrow_to_wide(*i);
 			if (prefix_start == 0)
-				completion += L":";
+				completion += L": ";
 			completions.push_back(completion);
 		}
 	}
@@ -541,7 +541,7 @@ void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwa
 			}
 		}
 	}
-	std::wstring replacement = completions[replacement_index] + L" ";
+	std::wstring replacement = completions[replacement_index] + L"";
 	if (word_end < m_line.size() && isspace(word_end))
 		++word_end;
 
@@ -551,7 +551,7 @@ void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwa
 	m_cursor = prefix_start + replacement.size();
 	clampView();
 	m_nick_completion_start = prefix_start;
-	m_nick_completion_end = prefix_end;
+	   m_nick_completion_end = prefix_end;
 }
 
 void ChatPrompt::reformat(u32 cols)

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -474,7 +474,7 @@ void ChatPrompt::historyNext()
 	}
 }
 
-void ChatPrompt::nickCompletion(const std::list<std::string> &names, bool backwards)
+void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwards)
 {
 	// Two cases:
 	// (a) m_nick_completion_start == m_nick_completion_end == 0
@@ -551,7 +551,7 @@ void ChatPrompt::nickCompletion(const std::list<std::string> &names, bool backwa
 	m_cursor = prefix_start + replacement.size();
 	clampView();
 	m_nick_completion_start = prefix_start;
-	   m_nick_completion_end = prefix_end;
+	m_nick_completion_end = prefix_end;
 }
 
 void ChatPrompt::reformat(u32 cols)

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -541,7 +541,7 @@ void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwa
 			}
 		}
 	}
-	std::wstring replacement = completions[replacement_index] + L"";
+	std::wstring replacement = completions[replacement_index];
 	if (word_end < m_line.size() && isspace(word_end))
 		++word_end;
 

--- a/src/chat.h
+++ b/src/chat.h
@@ -161,7 +161,7 @@ public:
 	void historyNext();
 
 	// Nick completion
-	void nickCompletion(const std::list<std::string>& names, bool backwards);
+	void nickCompletion(const std::list<std::string> &names, bool backwards);
 
 	// Update console size and reformat the visible portion of the prompt
 	void reformat(u32 cols);

--- a/src/chat.h
+++ b/src/chat.h
@@ -161,7 +161,7 @@ public:
 	void historyNext();
 
 	// Nick completion
-	void nickCompletion(const std::list<std::string> &names, bool backwards);
+	void nickCompletion(const std::list<std::string>& names, bool backwards);
 
 	// Update console size and reformat the visible portion of the prompt
 	void reformat(u32 cols);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -552,7 +552,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';
-				mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
+				mbtowc(&wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
 				m_chat_backend->getPrompt().input(wc);
 			#else
 				m_chat_backend->getPrompt().input(event.KeyInput.Char);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -552,7 +552,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';
-				mbtowc(&wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
+				mbtowc(&wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char));
 				m_chat_backend->getPrompt().input(wc);
 			#else
 				m_chat_backend->getPrompt().input(event.KeyInput.Char);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -552,7 +552,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';
-				mbtowc(&wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char));
+				mbtowc( &wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
 				m_chat_backend->getPrompt().input(wc);
 			#else
 				m_chat_backend->getPrompt().input(event.KeyInput.Char);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -552,7 +552,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		{
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';
-				mbtowc( &wc, (char*) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
+                                mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
 				m_chat_backend->getPrompt().input(wc);
 			#else
 				m_chat_backend->getPrompt().input(event.KeyInput.Char);


### PR DESCRIPTION
This fix the space issue with the chat part.
Commands like /teleport are picky, If you use the tab on a name, like tab f, and becomes foo, it creates a space, like /teleport foo*space*, but it doesn't ignore the space, instead it thinks you want to teleport to foo, with a space, This PR fixes that by removing space when tabbed, but keeping space on non commands.