### PR TITLE
Add list-rings

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1340,6 +1340,17 @@ examples.
 #### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 * Show an inventory list
 
+#### `listring[<inventory location>;<list name>]`
+* Allows to create a ring of inventory lists
+* Shift-clicking on items in one element of the ring
+* will send them to the next inventory list inside the ring
+* The first occurrence of an element inside the ring will
+* determine the inventory where items will be sent to
+
+#### `listring[]`
+* Shorthand for doing `listring[<inventory location>;<list name>]`
+* for the last two inventory lists added by list[...]
+
 #### `listcolors[<slot_bg_normal>;<slot_bg_hover>]`
 * Sets background color of slots as `ColorString`
 * Sets background color of slots on mouse hovering

--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -1158,7 +1158,8 @@ minetest.register_node("default:chest", {
 		meta:set_string("formspec",
 				"size[8,9]"..
 				"list[current_name;main;0,0;8,4;]"..
-				"list[current_player;main;0,5;8,4;]")
+				"list[current_player;main;0,5;8,4;]" ..
+				"listring[]")
 		meta:set_string("infotext", "Chest")
 		local inv = meta:get_inventory()
 		inv:set_size("main", 8*4)
@@ -1197,7 +1198,8 @@ minetest.register_node("default:chest_locked", {
 		meta:set_string("formspec",
 				"size[8,9]"..
 				"list[current_name;main;0,0;8,4;]"..
-				"list[current_player;main;0,5;8,4;]")
+				"list[current_player;main;0,5;8,4;]" ..
+				"listring[]")
 		meta:set_string("infotext", "Locked Chest")
 		meta:set_string("owner", "")
 		local inv = meta:get_inventory()
@@ -1261,7 +1263,11 @@ default.furnace_inactive_formspec =
 	"list[current_name;fuel;2,3;1,1;]"..
 	"list[current_name;src;2,1;1,1;]"..
 	"list[current_name;dst;5,1;2,2;]"..
-	"list[current_player;main;0,5;8,4;]"
+	"list[current_player;main;0,5;8,4;]" ..
+	"listring[current_name;dst]" ..
+	"listring[current_player;main]" ..
+	"listring[current_name;src]" ..
+	"listring[current_player;main]"
 
 minetest.register_node("default:furnace", {
 	description = "Furnace",
@@ -1398,7 +1404,11 @@ minetest.register_abm({
 				"list[current_name;fuel;2,3;1,1;]"..
 				"list[current_name;src;2,1;1,1;]"..
 				"list[current_name;dst;5,1;2,2;]"..
-				"list[current_player;main;0,5;8,4;]")
+				"list[current_player;main;0,5;8,4;]" ..
+				"listring[current_name;dst]" ..
+				"listring[current_player;main]" ..
+				"listring[current_name;src]" ..
+				"listring[current_player;main]")
 			return
 		end
 

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -121,6 +121,22 @@ class GUIFormSpecMenu : public GUIModalMenu
 		s32 start_item_i;
 	};
 
+	struct ListRingSpec
+	{
+		ListRingSpec()
+		{
+		}
+		ListRingSpec(const InventoryLocation &a_inventoryloc,
+				const std::string &a_listname):
+			inventoryloc(a_inventoryloc),
+			listname(a_listname)
+		{
+		}
+
+		InventoryLocation inventoryloc;
+		std::string listname;
+	};
+
 	struct ImageDrawSpec
 	{
 		ImageDrawSpec()
@@ -306,6 +322,7 @@ protected:
 
 
 	std::vector<ListDrawSpec> m_inventorylists;
+	std::vector<ListRingSpec> m_inventory_rings;
 	std::vector<ImageDrawSpec> m_backgrounds;
 	std::vector<ImageDrawSpec> m_images;
 	std::vector<ImageDrawSpec> m_itemimages;
@@ -384,6 +401,7 @@ private:
 
 	void parseSize(parserData* data,std::string element);
 	void parseList(parserData* data,std::string element);
+	void parseListRing(parserData* data,std::string element);
 	void parseCheckbox(parserData* data,std::string element);
 	void parseImage(parserData* data,std::string element);
 	void parseItemImage(parserData* data,std::string element);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -71,6 +71,7 @@ Player::Player(IGameDef *gamedef, const char *name):
 		//"image[1,0.6;1,2;player.png]"
 		"list[current_player;main;0,3.5;8,4;]"
 		"list[current_player;craft;3,0;3,3;]"
+		"listring[]"
 		"list[current_player;craftpreview;7,1;1,1;]";
 
 	// Initialize movement settings at default values, so movement can work if the server fails to send them


### PR DESCRIPTION
Adds list-rings, a method to implement item sending between inventories via shift-click.
Nice insider feature: a ring consisting of a single inventory list serves as nice clean-up method.
Also adds them to minimal game.
Fixes #521