### PR TITLE
Mgv6: Don't create air gap in tundra at y = 48 in custom high terrain

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -1007,7 +1007,7 @@ void MapgenV6::growGrass() // Add surface nodes
 			} else if (bt == BT_TUNDRA) {
 				if (c == c_dirt) {
 					vm->m_data[i] = n_dirt_with_snow;
-				} else if (c == c_stone) {
+				} else if (c == c_stone && surface_y < node_max.Y) {
 					vm->m_area.add_y(em, i, 1);
 					vm->m_data[i] = n_snow;
 				}


### PR DESCRIPTION
![screenshot_20150618_030552](https://cloud.githubusercontent.com/assets/3686677/8222748/1d881136-1567-11e5-994f-4483eda71a28.png)

Mgv6 with custom high terrain has bugs at y = 47 but this one is particularly ugly, so here's a simple fix.