### PR TITLE
Mapgen objects: Enable heatmap and humidmap for all biome api mapgens

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -67,33 +67,37 @@ FlagDesc flagdesc_gennotify[] = {
 
 Mapgen::Mapgen()
 {
-	generating    = false;
-	id            = -1;
-	seed          = 0;
-	water_level   = 0;
-	flags         = 0;
+	generating  = false;
+	id          = -1;
+	seed        = 0;
+	water_level = 0;
+	flags       = 0;
 
-	vm          = NULL;
-	ndef        = NULL;
-	heightmap   = NULL;
-	biomemap    = NULL;
+	vm        = NULL;
+	ndef      = NULL;
+	heightmap = NULL;
+	biomemap  = NULL;
+	heatmap   = NULL;
+	humidmap  = NULL;
 }
 
 
 Mapgen::Mapgen(int mapgenid, MapgenParams *params, EmergeManager *emerge) :
 	gennotify(emerge->gen_notify_on, &emerge->gen_notify_on_deco_ids)
 {
-	generating    = false;
-	id            = mapgenid;
-	seed          = (int)params->seed;
-	water_level   = params->water_level;
-	flags         = params->flags;
-	csize         = v3s16(1, 1, 1) * (params->chunksize * MAP_BLOCKSIZE);
+	generating  = false;
+	id          = mapgenid;
+	seed        = (int)params->seed;
+	water_level = params->water_level;
+	flags       = params->flags;
+	csize       = v3s16(1, 1, 1) * (params->chunksize * MAP_BLOCKSIZE);
 
 	vm        = NULL;
 	ndef      = NULL;
 	heightmap = NULL;
 	biomemap  = NULL;
+	heatmap   = NULL;
+	humidmap  = NULL;
 }
 
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -152,6 +152,8 @@ public:
 	u32 blockseed;
 	s16 *heightmap;
 	u8 *biomemap;
+	float *heatmap;
+	float *humidmap;
 	v3s16 csize;
 
 	GenerateNotifier gennotify;

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -58,6 +58,8 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 
 	this->biomemap  = new u8[csize.X * csize.Z];
 	this->heightmap = new s16[csize.X * csize.Z];
+	this->heatmap   = NULL;
+	this->humidmap  = NULL;
 
 	MapgenV5Params *sp = (MapgenV5Params *)params->sparams;
 	this->spflags      = sp->spflags;
@@ -341,6 +343,9 @@ void MapgenV5::calculateNoise()
 		noise_heat->result[i] += noise_heat_blend->result[i];
 		noise_humidity->result[i] += noise_humidity_blend->result[i];
 	}
+
+	heatmap = noise_heat->result;
+	humidmap = noise_humidity->result;
 	//printf("calculateNoise: %dus\n", t.stop());
 }
 

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -24,9 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define LARGE_CAVE_DEPTH -256
 
-/////////////////// Mapgen V5 flags
-//#define MGV5_   0x01
-
 class BiomeManager;
 
 extern FlagDesc flagdesc_mapgen_v5[];

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -59,8 +59,10 @@ MapgenV7::MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->ystride = csize.X;
 	this->zstride = csize.X * (csize.Y + 2);
 
-	this->biomemap  = new u8[csize.X * csize.Z];
-	this->heightmap = new s16[csize.X * csize.Z];
+	this->biomemap        = new u8[csize.X * csize.Z];
+	this->heightmap       = new s16[csize.X * csize.Z];
+	this->heatmap         = NULL;
+	this->humidmap        = NULL;
 	this->ridge_heightmap = new s16[csize.X * csize.Z];
 
 	MapgenV7Params *sp = (MapgenV7Params *)params->sparams;
@@ -376,6 +378,9 @@ void MapgenV7::calculateNoise()
 		noise_heat->result[i] += noise_heat_blend->result[i];
 		noise_humidity->result[i] += noise_humidity_blend->result[i];
 	}
+
+	heatmap = noise_heat->result;
+	humidmap = noise_humidity->result;
 	//printf("calculateNoise: %dus\n", t.stop());
 }
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -510,21 +510,26 @@ int ModApiMapgen::l_get_mapgen_object(lua_State *L)
 
 		return 1;
 	}
-	case MGOBJ_HEATMAP: { // Mapgen V7 specific objects
-	case MGOBJ_HUMIDMAP:
-		if (strcmp(emerge->params.mg_name.c_str(), "v7"))
-			return 0;
-
-		MapgenV7 *mgv7 = (MapgenV7 *)mg;
-
-		float *arr = (mgobj == MGOBJ_HEATMAP) ?
-			mgv7->noise_heat->result : mgv7->noise_humidity->result;
-		if (!arr)
+	case MGOBJ_HEATMAP: {
+		if (!mg->heatmap)
 			return 0;
 
 		lua_newtable(L);
 		for (size_t i = 0; i != maplen; i++) {
-			lua_pushnumber(L, arr[i]);
+			lua_pushnumber(L, mg->heatmap[i]);
+			lua_rawseti(L, -2, i + 1);
+		}
+
+		return 1;
+	}
+
+	case MGOBJ_HUMIDMAP: {
+		if (!mg->humidmap)
+			return 0;
+
+		lua_newtable(L);
+		for (size_t i = 0; i != maplen; i++) {
+			lua_pushnumber(L, mg->humidmap[i]);
 			lua_rawseti(L, -2, i + 1);
 		}
 


### PR DESCRIPTION
Previously heatmap and humidtymap were only usable in mgv7, this PR makes them usable by all bime api mapgens.
Tested with a mod and works in mgv5 and mgv7, but game crashes when exiting to menu or OS:

*** Error in `.../minetest/bin/minetest': double free or corruption (!prev): 0x0000000001a18690 ***

Program received signal SIGABRT, Aborted.
0x00007ffff52c0cc9 in __GI_raise (sig=sig@entry=6)
    at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.

EDIT Fixed.