### PR TITLE
Add MoveSomewhere inventory action

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -493,6 +493,9 @@ public:
 	bool mediaReceived()
 	{ return m_media_downloader == NULL; }
 
+	u8 getProtoVersion()
+	{ return m_proto_ver; }
+
 	float mediaReceiveProgress();
 
 	void afterContentReceived(IrrlichtDevice *device);

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -3384,31 +3384,42 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					break;
 				ItemStack stack_from = list_from->getItem(s.i);
 				assert(shift_move_amount <= stack_from.count);
-
-				// find a place (or more than one) to add the new item
-				u32 ilt_size = list_to->getSize();
-				ItemStack leftover;
-				for (u32 slot_to = 0; slot_to < ilt_size
-						&& shift_move_amount > 0; slot_to++) {
-					list_to->itemFits(slot_to, stack_from, &leftover);
-					if (leftover.count < stack_from.count) {
-						infostream << "Handing IACTION_MOVE to manager" << std::endl;
-						IMoveAction *a = new IMoveAction();
-						a->count = MYMIN(shift_move_amount,
-							(u32) (stack_from.count - leftover.count));
-						shift_move_amount -= a->count;
-						a->from_inv = s.inventoryloc;
-						a->from_list = s.listname;
-						a->from_i = s.i;
-						a->to_inv = to_inv_sp.inventoryloc;
-						a->to_list = to_inv_sp.listname;
-						a->to_i = slot_to;
-						m_invmgr->inventoryAction(a);
-						stack_from = leftover;
+				if (m_client->getProtoVersion() >= 25) {
+					infostream << "Handing IACTION_MOVE to manager" << std::endl;
+					IMoveAction *a = new IMoveAction();
+					a->count = shift_move_amount;
+					a->from_inv = s.inventoryloc;
+					a->from_list = s.listname;
+					a->from_i = s.i;
+					a->to_inv = to_inv_sp.inventoryloc;
+					a->to_list = to_inv_sp.listname;
+					a->move_somewhere = true;
+					m_invmgr->inventoryAction(a);
+				} else {
+					// find a place (or more than one) to add the new item
+					u32 ilt_size = list_to->getSize();
+					ItemStack leftover;
+					for (u32 slot_to = 0; slot_to < ilt_size
+							&& shift_move_amount > 0; slot_to++) {
+						list_to->itemFits(slot_to, stack_from, &leftover);
+						if (leftover.count < stack_from.count) {
+							infostream << "Handing IACTION_MOVE to manager" << std::endl;
+							IMoveAction *a = new IMoveAction();
+							a->count = MYMIN(shift_move_amount,
+								(u32) (stack_from.count - leftover.count));
+							shift_move_amount -= a->count;
+							a->from_inv = s.inventoryloc;
+							a->from_list = s.listname;
+							a->from_i = s.i;
+							a->to_inv = to_inv_sp.inventoryloc;
+							a->to_list = to_inv_sp.listname;
+							a->to_i = slot_to;
+							m_invmgr->inventoryAction(a);
+							stack_from = leftover;
+						}
 					}
 				}
 			} while (0);
-
 		} else if (drop_amount > 0) {
 			m_selected_content_guess = ItemStack(); // Clear
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -244,7 +244,13 @@ public:
 
 	// Move an item to a different list (or a different stack in the same list)
 	// count is the maximum number of items to move (0 for everything)
-	void moveItem(u32 i, InventoryList *dest, u32 dest_i, u32 count = 0);
+	// returns number of moved items
+	u32 moveItem(u32 i, InventoryList *dest, u32 dest_i,
+		u32 count = 0, bool swap_if_needed = true);
+
+	// like moveItem, but without a fixed destination index
+	// also with optional rollback recording
+	void moveItemSomewhere(u32 i, InventoryList *dest, u32 count);
 
 private:
 	std::vector<ItemStack> m_items;

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -143,15 +143,24 @@ struct IMoveAction : public InventoryAction
 	InventoryLocation to_inv;
 	std::string to_list;
 	s16 to_i;
+	bool move_somewhere;
+
+	// treat these as private
+	// related to movement to somewhere
+	bool caused_by_move_somewhere;
+	u32 move_count;
 	
 	IMoveAction()
 	{
 		count = 0;
 		from_i = -1;
 		to_i = -1;
+		move_somewhere = false;
+		caused_by_move_somewhere = false;
+		move_count = 0;
 	}
 	
-	IMoveAction(std::istream &is);
+	IMoveAction(std::istream &is, bool somewhere);
 
 	u16 getType() const
 	{
@@ -160,14 +169,18 @@ struct IMoveAction : public InventoryAction
 
 	void serialize(std::ostream &os) const
 	{
-		os<<"Move ";
-		os<<count<<" ";
-		os<<from_inv.dump()<<" ";
-		os<<from_list<<" ";
-		os<<from_i<<" ";
-		os<<to_inv.dump()<<" ";
-		os<<to_list<<" ";
-		os<<to_i;
+		if (!move_somewhere)
+			os << "Move ";
+		else
+			os << "MoveSomewhere ";
+		os << count << " ";
+		os << from_inv.dump() << " ";
+		os << from_list << " ";
+		os << from_i << " ";
+		os << to_inv.dump() << " ";
+		os << to_list;
+		if (!move_somewhere)
+			os << " " << to_i;
 	}
 
 	void apply(InventoryManager *mgr, ServerActiveObject *player, IGameDef *gamedef);


### PR DESCRIPTION
Improve shift+click experience. Needed because even if client prediction were perfect, the server can send an "updated" inventory before informations about the actually updated inventory came in, and fast shift-clickers will have swapped slots.
TODO:
- [x] Get a way to determine the "reduced" count.
- [x] It doesn't handle infinite inventories well
- [x] There is a "when you click on item that will be removed because it has already been transmitted to the server, you will 'get' something back from the 'destination stack'" bug.
