### PR TITLE
Allow overriding the hand

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1759,6 +1759,13 @@ Inventory locations
 * `"nodemeta:<X>,<Y>,<Z>"`: Any node metadata
 * `"detached:<name>"`: A detached inventory
 
+Player Inventory lists
+----------------------
+* `main`: list containing the default inventory
+* `craft`: list containing the craft input
+* `craftpreview`: list containing the craft output
+* `hand`: list containing an override for the empty hand
+
 `ColorString`
 -------------
 `#RGB` defines a color in hexadecimal format.

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1341,6 +1341,42 @@ std::string PlayerSAO::getWieldList() const
 	return "main";
 }
 
+ItemStack PlayerSAO::getWieldedItem() const
+{
+	const Inventory *inv = getInventory();
+	ItemStack ret;
+	const InventoryList *mlist = inv->getList(getWieldList());
+	if (mlist && getWieldIndex() < (s32)mlist->getSize())
+		ret = mlist->getItem(getWieldIndex());
+	if (ret.name.empty()) {
+		const InventoryList *hlist = inv->getList("hand");
+		if (hlist)
+			ret = hlist->getItem(0);
+	}
+	return ret;
+}
+bool PlayerSAO::setWieldedItem(const ItemStack &item)
+{
+	Inventory *inv = getInventory();
+	if (inv) {
+		InventoryList *mlist = inv->getList(getWieldList());
+		if (mlist) {
+			ItemStack olditem = mlist->getItem(getWieldIndex());
+			if (olditem.name.empty()) {
+				InventoryList *hlist = inv->getList("hand");
+				if (hlist) {
+					hlist->changeItem(0, item);
+					return true;
+				}
+			}
+			mlist->changeItem(getWieldIndex(), item);
+			return true;
+		}
+	}
+	return false;
+}
+
+
 int PlayerSAO::getWieldIndex() const
 {
 	return m_wield_index;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -251,6 +251,8 @@ public:
 	const Inventory* getInventory() const;
 	InventoryLocation getInventoryLocation() const;
 	std::string getWieldList() const;
+	ItemStack getWieldedItem() const;
+	bool setWieldedItem(const ItemStack &item);
 	int getWieldIndex() const;
 	void setWieldIndex(int i);
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3684,6 +3684,12 @@ void Game::updateCamera(VolatileRunFlags *flags, u32 busy_time,
 		if (mlist && client->getPlayerItem() < mlist->getSize())
 			playeritem = mlist->getItem(client->getPlayerItem());
 	}
+	if (playeritem.getDefinition(itemdef_manager).name.empty()) { // override the hand
+		InventoryList *hlist = local_inventory->getList("hand");
+		if (hlist)
+			playeritem = hlist->getItem(0);
+	}
+
 
 	ToolCapabilities playeritem_toolcap =
 		playeritem.getToolCapabilities(itemdef_manager);
@@ -3768,6 +3774,11 @@ void Game::processPlayerInteraction(GameRunData *runData,
 			playeritem = mlist->getItem(client->getPlayerItem());
 	}
 
+	if (playeritem.getDefinition(itemdef_manager).name.empty()) { // override the hand
+		InventoryList *hlist = local_inventory->getList("hand");
+		if (hlist)
+			playeritem = hlist->getItem(0);
+	}
 	const ItemDefinition &playeritem_def =
 			playeritem.getDefinition(itemdef_manager);
 
@@ -4321,8 +4332,14 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats,
 
 		if (mlist && (client->getPlayerItem() < mlist->getSize())) {
 			ItemStack item = mlist->getItem(client->getPlayerItem());
+			if (item.getDefinition(itemdef_manager).name.empty()) { // override the hand
+				InventoryList *hlist = local_inventory->getList("hand");
+				if (hlist)
+					item = hlist->getItem(0);
+			}
 			camera->wield(item);
 		}
+
 		runData->update_wielded_item_trigger = false;
 	}
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1529,10 +1529,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 					m_script->on_cheat(playersao, "finished_unknown_dig");
 				}
 				// Get player's wielded item
-				ItemStack playeritem;
-				InventoryList *mlist = playersao->getInventory()->getList("main");
-				if (mlist != NULL)
-					playeritem = mlist->getItem(playersao->getWieldIndex());
+				ItemStack playeritem = playersao->getWieldedItem();
 				ToolCapabilities playeritem_toolcap =
 						playeritem.getToolCapabilities(m_itemdef);
 				// Get diggability and expected digging time

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -40,6 +40,7 @@ Player::Player(const char *name, IItemDefManager *idef):
 
 	inventory.clear();
 	inventory.addList("main", PLAYER_INVENTORY_SIZE);
+	inventory.addList("hand", 1);
 	InventoryList *craft = inventory.addList("craft", 9);
 	craft->setWidth(3);
 	inventory.addList("craftpreview", 1);


### PR DESCRIPTION
You can set a custom hand by assigning an item to the "hand" inventory list.
This can be used for different appearance and for different player classes.
Where should I document this behaviour?
Fixes #1368
