### PR TITLE
Mgv5/mgv7 caves: Fix sand in underground caves

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -506,30 +506,24 @@ MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 
 void MapgenV5::generateCaves(int max_stone_y)
 {
-	u32 index = 0;
-	u32 index2d = 0;
+	if (max_stone_y >= node_min.Y) {
+		u32 index = 0;
 
-	for (s16 z=node_min.Z; z<=node_max.Z; z++) {
-		for (s16 y=node_min.Y - 1; y<=node_max.Y + 1; y++) {
+		for (s16 z = node_min.Z; z <= node_max.Z; z++)
+		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
 			u32 i = vm->m_area.index(node_min.X, y, z);
-			for (s16 x=node_min.X; x<=node_max.X; x++, i++, index++, index2d++) {
+			for (s16 x = node_min.X; x <= node_max.X; x++, i++, index++) {
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
 				if (d1*d2 > 0.125) {
-					Biome *biome = (Biome *)bmgr->getRaw(biomemap[index2d]);
 					content_t c = vm->m_data[i].getContent();
-					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR ||
-							(y <= water_level &&
-							c != biome->c_stone &&
-							c != c_stone))
+					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
 						continue;
 
 					vm->m_data[i] = MapNode(CONTENT_AIR);
 				}
 			}
-			index2d -= ystride;
 		}
-		index2d += ystride;
 	}
 
 	if (node_max.Y > LARGE_CAVE_DEPTH)

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -852,32 +852,21 @@ void MapgenV7::generateCaves(int max_stone_y)
 {
 	if (max_stone_y >= node_min.Y) {
 		u32 index   = 0;
-		u32 index2d = 0;
 
-		for (s16 z = node_min.Z; z <= node_max.Z; z++) {
-			for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
-				u32 i = vm->m_area.index(node_min.X, y, z);
-				for (s16 x = node_min.X; x <= node_max.X;
-						x++, i++, index++, index2d++) {
-					float d1 = contour(noise_cave1->result[index]);
-					float d2 = contour(noise_cave2->result[index]);
-					if (d1 * d2 > 0.3) {
-						Biome *biome = (Biome *)bmgr->
-									getRaw(biomemap[index2d]);
-						content_t c = vm->m_data[i].getContent();
-						if (!ndef->get(c).is_ground_content ||
-								c == CONTENT_AIR ||
-								(y <= water_level &&
-								c != biome->c_stone &&
-								c != c_stone))
-							continue;
+		for (s16 z = node_min.Z; z <= node_max.Z; z++)
+		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
+			u32 i = vm->m_area.index(node_min.X, y, z);
+			for (s16 x = node_min.X; x <= node_max.X; x++, i++, index++) {
+				float d1 = contour(noise_cave1->result[index]);
+				float d2 = contour(noise_cave2->result[index]);
+				if (d1 * d2 > 0.3) {
+					content_t c = vm->m_data[i].getContent();
+					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
+						continue;
 
-						vm->m_data[i] = MapNode(CONTENT_AIR);
-					}
+					vm->m_data[i] = MapNode(CONTENT_AIR);
 				}
-				index2d -= ystride;
 			}
-			index2d += ystride;
 		}
 	}
 


### PR DESCRIPTION
Also add check for max_stone_y to mgv5

Fix for game issue https://github.com/minetest/minetest_game/issues/546
Lines 870-872 https://github.com/minetest/minetest/blob/master/src/mapgen_v7.cpp#L870 are causing the issue and were added to stop caves removing sand from the seabed to avoid causng huge underground waterfalls.
Where a cave meets a mapchunk's lower border an upper surface is formed, biomegen then detects this and places sand at the top of the mapchunk below, this sand is then not being removed by cavegen.
This PR simplifies and speeds up cave generation as i am no longer checking for biome stone nodes, getting biome, or using a 2D index.