### PR TITLE
Make players respect makes_footstep_sound in the object properties

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1583,6 +1583,10 @@ void GenericCAO::processMessage(const std::string &data)
 			m_initial_tx_basepos_set = true;
 			m_tx_basepos = m_prop.initial_sprite_basepos;
 		}
+		if (m_is_local_player) {
+			LocalPlayer *player = m_env->getLocalPlayer();
+			player->makes_footstep_sound = m_prop.makes_footstep_sound;
+		}
 
 		if ((m_is_player && !m_is_local_player) && m_prop.nametag == "")
 			m_prop.nametag = m_name;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -476,6 +476,7 @@ class SoundMaker
 	ISoundManager *m_sound;
 	INodeDefManager *m_ndef;
 public:
+	bool makes_footstep_sound;
 	float m_player_step_timer;
 
 	SimpleSoundSpec m_player_step_sound;
@@ -485,6 +486,7 @@ public:
 	SoundMaker(ISoundManager *sound, INodeDefManager *ndef):
 		m_sound(sound),
 		m_ndef(ndef),
+		makes_footstep_sound(true),
 		m_player_step_timer(0)
 	{
 	}
@@ -493,7 +495,8 @@ public:
 	{
 		if (m_player_step_timer <= 0 && m_player_step_sound.exists()) {
 			m_player_step_timer = 0.03;
-			m_sound->playSound(m_player_step_sound, false);
+			if (makes_footstep_sound)
+				m_sound->playSound(m_player_step_sound, false);
 		}
 	}
 
@@ -3400,11 +3403,14 @@ void Game::updateSound(f32 dtime)
 			      camera->getCameraNode()->getUpVector());
 	sound->setListenerGain(g_settings->getFloat("sound_volume"));
 
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+
+	// Tell the sound maker whether to make footstep sounds
+	soundmaker->makes_footstep_sound = player->makes_footstep_sound;
 
 	//	Update sound maker
-	soundmaker->step(dtime);
-
-	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (player->makes_footstep_sound)
+		soundmaker->step(dtime);
 
 	ClientMap &map = client->getEnv().getClientMap();
 	MapNode n = map.getNodeNoEx(player->getFootstepNodePos());

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -59,6 +59,7 @@ LocalPlayer::LocalPlayer(Client *client, const char *name):
 	last_camera_fov(0),
 	last_wanted_range(0),
 	camera_impact(0.f),
+	makes_footstep_sound(true),
 	last_animation(NO_ANIM),
 	hotbar_image(""),
 	hotbar_selected_image(""),

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -92,6 +92,8 @@ public:
 
 	float camera_impact;
 
+	bool makes_footstep_sound;
+
 	int last_animation;
 	float last_animation_speed;
 


### PR DESCRIPTION
Now you can disable footstep sounds for players.
