### PR TITLE
Fix invisible player when the attached entity is removed

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -591,6 +591,21 @@ void LuaEntitySAO::getAttachment(int *parent_id, std::string *bone, v3f *positio
 	*rotation = m_attachment_rotation;
 }
 
+void LuaEntitySAO::addAttachmentChild(int child_id)
+{
+	m_attachment_child_ids.insert(child_id);
+}
+
+void LuaEntitySAO::removeAttachmentChild(int child_id)
+{
+	m_attachment_child_ids.erase(child_id);
+}
+
+std::set<int> LuaEntitySAO::getAttachmentChildIds()
+{
+	return m_attachment_child_ids;
+}
+
 ObjectProperties* LuaEntitySAO::accessObjectProperties()
 {
 	return &m_prop;
@@ -1229,6 +1244,21 @@ void PlayerSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
 	*bone = m_attachment_bone;
 	*position = m_attachment_position;
 	*rotation = m_attachment_rotation;
+}
+
+void PlayerSAO::addAttachmentChild(int child_id)
+{
+	m_attachment_child_ids.insert(child_id);
+}
+
+void PlayerSAO::removeAttachmentChild(int child_id)
+{
+	m_attachment_child_ids.erase(child_id);
+}
+
+std::set<int> PlayerSAO::getAttachmentChildIds()
+{
+	return m_attachment_child_ids;
 }
 
 ObjectProperties* PlayerSAO::accessObjectProperties()

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -65,6 +65,9 @@ public:
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
 	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void addAttachmentChild(int child_id);
+	void removeAttachmentChild(int child_id);
+	std::set<int> getAttachmentChildIds();
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
 	/* LuaEntitySAO-specific */
@@ -113,6 +116,7 @@ private:
 	bool m_bone_position_sent;
 
 	int m_attachment_parent_id;
+	std::set<int> m_attachment_child_ids;
 	std::string m_attachment_bone;
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
@@ -204,6 +208,9 @@ public:
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
 	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void addAttachmentChild(int child_id);
+	void removeAttachmentChild(int child_id);
+	std::set<int> getAttachmentChildIds();
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
 	void setNametagColor(video::SColor color);
@@ -320,6 +327,7 @@ private:
 	bool m_bone_position_sent;
 
 	int m_attachment_parent_id;
+	std::set<int> m_attachment_child_ids;
 	std::string m_attachment_bone;
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -163,6 +163,12 @@ public:
 	{}
 	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation)
 	{}
+	virtual void addAttachmentChild(int child_id)
+	{}
+	virtual void removeAttachmentChild(int child_id)
+	{}
+	virtual std::set<int> getAttachmentChildIds()
+	{ return std::set<int>(); }
 	virtual ObjectProperties* accessObjectProperties()
 	{ return NULL; }
 	virtual void notifyObjectPropertiesModified()


### PR DESCRIPTION
Makes the parent aware of its children and detaches them on delete.
Fixes  #1467