### PR TITLE
Mgv7: Lower base of mountain generation to -112 and define constant

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -363,7 +363,7 @@ void MapgenV7::calculateNoise()
 		noise_ridge_uwater->perlinMap2D(x, z);
 	}
 
-	if ((spflags & MGV7_MOUNTAINS) && node_max.Y >= 0) {
+	if ((spflags & MGV7_MOUNTAINS) && node_max.Y >= MOUNTAIN_BASE) {
 		noise_mountain->perlinMap3D(x, y, z);
 		noise_mount_height->perlinMap2D(x, z);
 	}
@@ -536,7 +536,7 @@ int MapgenV7::generateBaseTerrain()
 
 int MapgenV7::generateMountainTerrain(int ymax)
 {
-	if (node_max.Y < 0)
+	if (node_max.Y < MOUNTAIN_BASE)
 		return ymax;
 
 	MapNode n_stone(c_stone);

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
+#define MOUNTAIN_BASE -112
+
 /////////////////// Mapgen V7 flags
 #define MGV7_MOUNTAINS   0x01
 #define MGV7_RIDGES      0x02


### PR DESCRIPTION
Mgv7 ocean floor can go as low as y = -53, therefore passing under mountain terrain which has it's base at y = -32. This creates a floating mountain with a flat underside, fairly rare but embarassing.
This commit lowers mountain terrain base to the mapchunk border at y = -112 by defining a constant MOUNTAIN_BASE.