### PR TITLE
Fix remnant bugs on mainmenu

### DIFF
--- a/builtin/mainmenu/tab_server.lua
+++ b/builtin/mainmenu/tab_server.lua
@@ -113,12 +113,12 @@ local function main_button_handler(this, fields, name, tabdata)
 		world_doubleclick or
 		fields["key_enter"] then
 		local selected = core.get_textlist_index("srv_worlds")
-		if selected ~= nil then
+		gamedata.selected_world = menudata.worldlist:get_raw_index(selected)
+		if selected ~= nil and gamedata.selected_world ~= 0 then
 			gamedata.playername     = fields["te_playername"]
 			gamedata.password       = fields["te_passwd"]
 			gamedata.port           = fields["te_serverport"]
 			gamedata.address        = ""
-			gamedata.selected_world = menudata.worldlist:get_raw_index(selected)
 
 			core.setting_set("port",gamedata.port)
 			if fields["te_serveraddr"] ~= nil then
@@ -133,8 +133,11 @@ local function main_button_handler(this, fields, name, tabdata)
 			end
 			
 			core.start()
-			return true
+		else
+			gamedata.errormessage =
+				fgettext("No world created or selected!")
 		end
+		return true
 	end
 
 	if fields["world_create"] ~= nil then

--- a/builtin/mainmenu/tab_singleplayer.lua
+++ b/builtin/mainmenu/tab_singleplayer.lua
@@ -40,10 +40,13 @@ local function singleplayer_refresh_gamebar()
 					menudata.worldlist:set_filtercriteria(gamemgr.games[j].id)
 					local index = filterlist.get_current_index(menudata.worldlist,
 						tonumber(core.setting_get("mainmenu_last_selected_world")))
-					local selected = core.get_textlist_index("sp_worlds")
 					if not index or index < 1 then
-						index = math.min(core.get_textlist_index("sp_worlds"),
-							#menudata.worldlist:get_list())
+						local selected = core.get_textlist_index("sp_worlds")
+						if selected ~= nil and selected < #menudata.worldlist:get_list() then
+							index = selected
+						else
+							index = #menudata.worldlist:get_list()
+						end
 					end
 					menu_worldmt_legacy(index)
 					return true


### PR DESCRIPTION
- Stop attempting to start a world when no world's created/selected in server tab (see https://github.com/minetest/minetest/issues/2872)
- Better world's indexes handling between subgames lists (preventing error when no world created anywhere and subgame icon clicked).
