### PR TITLE
Utf8 based chat

### DIFF
--- a/src/chat.h
+++ b/src/chat.h
@@ -32,11 +32,11 @@ struct ChatLine
 	// age in seconds
 	f32 age;
 	// name of sending player, or empty if sent by server
-	std::wstring name;
+	std::string name;
 	// message text
-	std::wstring text;
+	std::string text;
 
-	ChatLine(std::wstring a_name, std::wstring a_text):
+	ChatLine(const std::string &a_name, const std::string &a_text):
 		age(0.0),
 		name(a_name),
 		text(a_text)
@@ -47,7 +47,7 @@ struct ChatLine
 struct ChatFormattedFragment
 {
 	// text string
-	std::wstring text;
+	std::string text;
 	// starting column
 	u32 column;
 	// formatting
@@ -70,7 +70,7 @@ public:
 
 	// Append chat line
 	// Removes oldest chat line if scrollback size is reached
-	void addLine(std::wstring name, std::wstring text);
+	void addLine(const std::string &name, const std::string &text);
 
 	// Remove all chat lines
 	void clear();
@@ -147,13 +147,13 @@ public:
 	void input(const std::wstring &str);
 
 	// Submit, clear and return current line
-	std::wstring submit();
+	std::string submit();
 
 	// Clear the current line
 	void clear();
 
 	// Replace the current line with the given text
-	void replace(std::wstring line);
+	void replace(const std::wstring &line);
 
 	// Select previous command from history
 	void historyPrev();
@@ -238,16 +238,16 @@ public:
 	~ChatBackend();
 
 	// Add chat message
-	void addMessage(std::wstring name, std::wstring text);
+	void addMessage(const std::string &name, const std::string &text);
 	// Parse and add unparsed chat message
-	void addUnparsedMessage(std::wstring line);
+	void addUnparsedMessage(const std::string &line);
 
 	// Get the console buffer
 	ChatBuffer& getConsoleBuffer();
 	// Get the recent messages buffer
 	ChatBuffer& getRecentBuffer();
 	// Concatenate all recent messages
-	std::wstring getRecentChat();
+	std::string getRecentChat();
 	// Get the console prompt
 	ChatPrompt& getPrompt();
 

--- a/src/client.h
+++ b/src/client.h
@@ -415,7 +415,8 @@ public:
 	void sendInventoryFields(const std::string &formname,
 		const StringMap &fields);
 	void sendInventoryAction(InventoryAction *a);
-	void sendChatMessage(const std::wstring &message);
+	void sendChatMessage(const std::string &message);
+	void sendChatMessageLegacy(const std::string &message);
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
 	void sendDamage(u8 damage);
@@ -470,8 +471,8 @@ public:
 	bool checkPrivilege(const std::string &priv)
 	{ return (m_privileges.count(priv) != 0); }
 
-	bool getChatMessage(std::wstring &message);
-	void typeChatMessage(const std::wstring& message);
+	bool getChatMessage(std::pair<std::string, std::string> &message_pair);
+	void typeChatMessage(const std::string &message);
 
 	u64 getMapSeed(){ return m_map_seed; }
 
@@ -617,7 +618,14 @@ private:
 	// 0 <= m_daynight_i < DAYNIGHT_CACHE_COUNT
 	//s32 m_daynight_i;
 	//u32 m_daynight_ratio;
-	std::queue<std::wstring> m_chat_queue;
+
+	std::queue<std::pair<std::string, std::string> > m_chat_queue;
+
+	void pushChatQueue(const std::string &msg)
+	{ m_chat_queue.push(std::make_pair("", msg)); }
+
+	void pushChatQueueNamed(const std::string &name, const std::string &msg)
+	{ m_chat_queue.push(std::make_pair(name, msg)); }
 
 	// The authentication methods we can use to enter sudo mode (=change password)
 	u32 m_sudo_auth_methods;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -687,7 +687,7 @@ void ClientInterface::sendToAll(u16 channelnum,
 		NetworkPacket* pkt, bool reliable)
 {
 	JMutexAutoLock clientslock(m_clients_mutex);
-	for(std::map<u16, RemoteClient*>::iterator
+	for (std::map<u16, RemoteClient*>::iterator
 		i = m_clients.begin();
 		i != m_clients.end(); ++i) {
 		RemoteClient *client = i->second;

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -314,10 +314,11 @@ void GUIChatConsole::drawText()
 		{
 			const ChatFormattedFragment& fragment = line.fragments[i];
 			s32 x = (fragment.column + 1) * m_fontsize.X;
+			std::wstring wtext =  utf8_to_wide(fragment.text);
 			core::rect<s32> destrect(
-				x, y, x + m_fontsize.X * fragment.text.size(), y + m_fontsize.Y);
+				x, y, x + m_fontsize.X * wtext.size(), y + m_fontsize.Y);
 			m_font->draw(
-				fragment.text.c_str(),
+				wtext.c_str(),
 				destrect,
 				video::SColor(255, 255, 255, 255),
 				false,
@@ -412,7 +413,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Key == KEY_RETURN)
 		{
-			std::wstring text = m_chat_backend->getPrompt().submit();
+			std::string text = m_chat_backend->getPrompt().submit();
 			m_client->typeChatMessage(text);
 			return true;
 		}
@@ -514,7 +515,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			const c8 *text = os_operator->getTextFromClipboard();
 			if (text)
 			{
-				std::wstring wtext = narrow_to_wide(text);
+				std::wstring wtext = utf8_to_wide(text);
 				m_chat_backend->getPrompt().input(wtext);
 			}
 			return true;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -130,9 +130,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			presentation
 		Add TOCLIENT_AUTH_ACCEPT to accept connection from client
 		Rename GENERIC_CMD_SET_ATTACHMENT to GENERIC_CMD_ATTACH_TO
+	PROTOCOL_VERSION 26:
+		TOCLIENT_CHAT_MESSAGE uses utf-8 strings now,
+			instead of locale dependent wstring.
+		TOSERVER_CHAT_MESSAGE uses utf-8 strings now,
+			instead of locale dependent wstring.
+		TOCLIENT_CHAT_MESSAGE got an extra field for the sender name.
 */
 
-#define LATEST_PROTOCOL_VERSION 25
+#define LATEST_PROTOCOL_VERSION 26
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -278,9 +284,8 @@ enum ToClientCommand
 
 	TOCLIENT_CHAT_MESSAGE = 0x30,
 	/*
-		u16 command
-		u16 length
-		wstring message
+		std::string from_player (since v26, empty for non-chat messages)
+		std::string message (since v26, wstring message before)
 	*/
 
 	TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD = 0x31,
@@ -746,9 +751,7 @@ enum ToServerCommand
 
 	TOSERVER_CHAT_MESSAGE = 0x32,
 	/*
-		u16 command
-		u16 length
-		wstring message
+		std::string message (since v26, wstring message before)
 	*/
 
 	TOSERVER_SIGNNODETEXT = 0x33, // obsolete

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -38,7 +38,7 @@ int ModApiServer::l_request_shutdown(lua_State *L)
 int ModApiServer::l_get_server_status(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	lua_pushstring(L, wide_to_narrow(getServer(L)->getStatusString()).c_str());
+	lua_pushstring(L, getServer(L)->getStatusString().c_str());
 	return 1;
 }
 
@@ -50,7 +50,7 @@ int ModApiServer::l_chat_send_all(lua_State *L)
 	// Get server from registry
 	Server *server = getServer(L);
 	// Send
-	server->notifyPlayers(narrow_to_wide(text));
+	server->notifyPlayers(text);
 	return 0;
 }
 
@@ -64,7 +64,7 @@ int ModApiServer::l_chat_send_player(lua_State *L)
 	// Get server from registry
 	Server *server = getServer(L);
 	// Send
-	server->notifyPlayer(name, narrow_to_wide(text));
+	server->notifyPlayer(name, text);
 	return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -218,6 +218,7 @@ public:
 
 	void ProcessData(NetworkPacket *pkt);
 
+	void SendTo(NetworkPacket* pkt, u16 peer_id);
 	void Send(NetworkPacket* pkt);
 
 	// Environment must be locked when called
@@ -237,7 +238,7 @@ public:
 	void setInventoryModified(const InventoryLocation &loc, bool playerSend = true);
 
 	// Connection must be locked when called
-	std::wstring getStatusString();
+	std::string getStatusString();
 
 	// read shutdown state
 	inline bool getShutdownRequested()
@@ -262,8 +263,8 @@ public:
 	void unsetIpBanned(const std::string &ip_or_name);
 	std::string getBanDescription(const std::string &ip_or_name);
 
-	void notifyPlayer(const char *name, const std::wstring &msg);
-	void notifyPlayers(const std::wstring &msg);
+	void notifyPlayer(const char *name, const std::string &msg);
+	void notifyPlayers(const std::string &msg);
 	void spawnParticle(const char *playername,
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
@@ -400,7 +401,10 @@ private:
 	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
 
 
-	void SendChatMessage(u16 peer_id, const std::wstring &message);
+	void SendChatMessage(u16 peer_id, const std::string &message,
+		const std::string &from_player = "", bool has_wstring = false,
+		const std::wstring &wmessage = L"",
+		u16 avoid_peer_id = PEER_ID_INEXISTENT);
 	void SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed);
 	void SendPlayerHP(u16 peer_id);
 


### PR DESCRIPTION
Make chat UTF-8 based, so that we finally have a well-defined charset.
Also, sends the username in a separate field (server->client), so that we don't have to parse the chat message anymore in the future (when we drop compat).
Tries to avoid conversion to utf8 and back on the server, to support legacy clients to chat with each other on exotic locales.
Fixes #2847.

This needs testing. Can a tester confirm that the following works:
- [ ] **on new server**: special chars from old to new client
- [x] **on new server**: special chars from new to new client
- [ ] **on new server**: special chars from new to old client
- [ ] **on new server**: special chars from old to old client
- [ ] **on old server**: special chars from old to new client
- [x] **on old server**: special chars from new to new client _(working if bugfix #2889 is merged)_
- [ ] **on old server**: special chars from new to old client
- [x] **on old server**: special chars from old to old client _(well, this must work :) )_

Bugs to fix:
- [x] display of special chars in f10 menu is broken
