### PR TITLE
Client: fix m_proto_ver initialisation for legacy protocol

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -229,6 +229,7 @@ Client::Client(
 	m_con(PROTOCOL_ID, 512, CONNECTION_TIMEOUT, ipv6, this),
 	m_device(device),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
+	m_proto_ver(0),
 	m_playeritem(0),
 	m_inventory_updated(false),
 	m_inventory_from_server(NULL),

--- a/src/client.h
+++ b/src/client.h
@@ -595,8 +595,14 @@ private:
 	Mapper *m_mapper;
 	// Server serialization version
 	u8 m_server_ser_ver;
+
 	// Used version of the protocol with server
+	// Values smaller than 25 only mean they are smaller than 25,
+	// and aren't accurate. We simply just don't know, because
+	// the server didn't send the version back then.
+	// If 0, server init hasn't been received yet.
 	u8 m_proto_ver;
+
 	u16 m_playeritem;
 	bool m_inventory_updated;
 	Inventory *m_inventory_from_server;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -151,20 +151,23 @@ void Client::handleCommand_InitLegacy(NetworkPacket* pkt)
 	if (pkt->getSize() < 1)
 		return;
 
-	u8 deployed;
-	*pkt >> deployed;
+	u8 server_ser_ver;
+	*pkt >> server_ser_ver;
 
 	infostream << "Client: TOCLIENT_INIT_LEGACY received with "
-			"deployed=" << ((int)deployed & 0xff) << std::endl;
+		"server_ser_ver=" << ((int)server_ser_ver & 0xff) << std::endl;
 
-	if (!ser_ver_supported(deployed)) {
+	if (!ser_ver_supported(server_ser_ver)) {
 		infostream << "Client: TOCLIENT_INIT_LEGACY: Server sent "
 				<< "unsupported ser_fmt_ver"<< std::endl;
 		return;
 	}
 
-	m_server_ser_ver = deployed;
-	m_proto_ver = deployed;
+	m_server_ser_ver = server_ser_ver;
+
+	// We can be totally wrong with this guess
+	// but we only need some value < 25.
+	m_proto_ver = 24;
 
 	// Get player position
 	v3s16 playerpos_s16(0, BS * 2 + BS * 20, 0);


### PR DESCRIPTION
Previously, m_proto_ver was set to the serialisation version
inside the legacy init packet.

Now, if the server doesn't send a protocol version (protocols < 25),
we set m_proto_ver to some value < 25 and > 0.

This is a fix needed for #2885, but there should be other bugs this fixes too: currently, clients will send movesomewhere (#2808) inventory actions for servers that don't support it, and changing passwords doesn't work on legacy servers.
The commit 8dbf6833 did the same fix for the new init protocol.