### PR TITLE
Mgv7: Auto-set lowest mountain generation level

### DIFF
--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -22,8 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-#define MOUNTAIN_BASE -112
-
 /////////////////// Mapgen V7 flags
 #define MGV7_MOUNTAINS   0x01
 #define MGV7_RIDGES      0x02
@@ -107,16 +105,16 @@ public:
 	int getGroundLevelAtPoint(v2s16 p);
 	Biome *getBiomeAtPoint(v3s16 p);
 
-	float baseTerrainLevelAtPoint(int x, int z);
+	float baseTerrainLevelAtPoint(s16 x, s16 z);
 	float baseTerrainLevelFromMap(int index);
-	bool getMountainTerrainAtPoint(int x, int y, int z);
-	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, int y);
+	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
+	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
 
 	void calculateNoise();
 
 	virtual int generateTerrain();
-	int generateBaseTerrain();
-	int generateMountainTerrain(int ymax);
+	void generateBaseTerrain(s16 *stone_surface_min_y, s16 *stone_surface_max_y);
+	int generateMountainTerrain(s16 ymax);
 	void generateRidgeTerrain();
 
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);
@@ -124,7 +122,7 @@ public:
 
 	//void addTopNodes();
 
-	void generateCaves(int max_stone_y);
+	void generateCaves(s16 max_stone_y);
 };
 
 struct MapgenFactoryV7 : public MapgenFactory {


### PR DESCRIPTION
Fixing the lowest level of mountain generation results in floating mountains with flat undersides when custom noise parameters are used to make deeper oceans, or, results in unnecessary mountain generation if base terrain is raised.
This commit automates the lowest level of mountain generation to optimise efficiency with any custom noise parameters.
In generateBaseTerrain, if base terrain surface level is at any point < node_max.Y mountain generation will be enabled for that mapchunk.
Calculation of mountain noises is moved into generateTerrain because their calculation depends on the bool decided by generateBaseTerrain.
Tested by printing data to terminal and altering noise parameters.