### PR TITLE
Fix some warnings.

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -142,7 +142,7 @@ bool RecursiveDelete(const std::string &path)
 		infostream<<"RecursiveDelete: Deleting content of directory "
 				<<path<<std::endl;
 		std::vector<DirListNode> content = GetDirListing(path);
-		for(int i=0; i<content.size(); i++){
+		for(size_t i=0; i<content.size(); i++){
 			const DirListNode &n = content[i];
 			std::string fullpath = path + DIR_DELIM + n.name;
 			bool did = RecursiveDelete(fullpath);
@@ -183,7 +183,7 @@ bool DeleteSingleFileOrEmptyDirectory(const std::string &path)
 
 std::string TempPath()
 {
-	DWORD bufsize = GetTempPath(0, "");
+	DWORD bufsize = GetTempPath(0, NULL);
 	if(bufsize == 0){
 		errorstream<<"GetTempPath failed, error = "<<GetLastError()<<std::endl;
 		return "";


### PR DESCRIPTION
Fixes some minor warnings when compiling with MinGW (gcc 4.8.1).

```
src/filesys.cpp:145:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
src/filesys.cpp:186:35: warning: deprecated conversion from string constant to 'fs::LPSTR {aka char*}' [-Wwrite-strings]
src/util/srp.cpp:497:13: warning: 'void srp_pcgrandom_seed(srp_pcgrandom*, long long unsigned int, long long unsigned int)' defined but not used [-Wunused-function]
```
