### PR TITLE
toolchain_mingw64.cmake use mingw-w64

### DIFF
--- a/util/buildbot/toolchain_mingw64.cmake
+++ b/util/buildbot/toolchain_mingw64.cmake
@@ -2,12 +2,12 @@
 SET(CMAKE_SYSTEM_NAME Windows)
 
 # which compilers to use for C and C++
-SET(CMAKE_C_COMPILER x86_64-mingw32-gcc)
-SET(CMAKE_CXX_COMPILER x86_64-mingw32-g++)
-SET(CMAKE_RC_COMPILER x86_64-mingw32-windres)
+SET(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+SET(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+SET(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
 
 # here is the target environment located
-SET(CMAKE_FIND_ROOT_PATH /usr/x86_64-mingw32)
+SET(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search


### PR DESCRIPTION
Fix this error:
```
CMake Error at CMakeLists.txt:9 (project):
  The CMAKE_C_COMPILER:

    x86_64-mingw32-gcc

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
  the compiler, or to the compiler name if it is in the PATH.


CMake Error at CMakeLists.txt:9 (project):
  The CMAKE_CXX_COMPILER:

    x86_64-mingw32-g++

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```