### PR TITLE
Mgv6/treegen: (Re)Add fallback nodes for compatibility with subgames

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -108,6 +108,14 @@ MapgenV6::MapgenV6(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 		c_mossycobble = c_cobble;
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
+	if (c_dirt_with_snow == CONTENT_IGNORE)
+		c_dirt_with_snow = c_dirt_with_grass;
+	if (c_snow == CONTENT_IGNORE)
+		c_snow = CONTENT_AIR;
+	if (c_snowblock == CONTENT_IGNORE)
+		c_snowblock = c_dirt_with_grass;
+	if (c_ice == CONTENT_IGNORE)
+		c_ice = c_water_source;
 }
 
 

--- a/src/treegen.cpp
+++ b/src/treegen.cpp
@@ -656,8 +656,15 @@ void make_jungletree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, int seed
 		and in games that have saplings; both are deprecated but not
 		replaced yet
 	*/
-	MapNode treenode(ndef->getId("mapgen_jungletree"));
-	MapNode leavesnode(ndef->getId("mapgen_jungleleaves"));
+	content_t c_tree   = ndef->getId("mapgen_jungletree");
+	content_t c_leaves = ndef->getId("mapgen_jungleleaves");
+	if (c_tree == CONTENT_IGNORE)
+		c_tree = ndef->getId("mapgen_tree");
+	if (c_leaves == CONTENT_IGNORE)
+		c_leaves = ndef->getId("mapgen_leaves");
+
+	MapNode treenode(c_tree);
+	MapNode leavesnode(c_leaves);
 
 	PseudoRandom pr(seed);
 	for (s16 x= -1; x <= 1; x++)
@@ -748,9 +755,19 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, int seed)
 		and in games that have saplings; both are deprecated but not
 		replaced yet
 	*/
-	MapNode treenode(ndef->getId("mapgen_pinetree"));
-	MapNode leavesnode(ndef->getId("mapgen_pine_needles"));
-	MapNode snownode(ndef->getId("mapgen_snow"));
+	content_t c_tree   = ndef->getId("mapgen_pinetree");
+	content_t c_leaves = ndef->getId("mapgen_pine_needles");
+	content_t c_snow = ndef->getId("mapgen_snow");
+	if (c_tree == CONTENT_IGNORE)
+		c_tree = ndef->getId("mapgen_tree");
+	if (c_leaves == CONTENT_IGNORE)
+		c_leaves = ndef->getId("mapgen_leaves");
+	if (c_snow == CONTENT_IGNORE)
+		c_snow = CONTENT_AIR;
+
+	MapNode treenode(c_tree);
+	MapNode leavesnode(c_leaves);
+	MapNode snownode(c_snow);
 
 	PseudoRandom pr(seed);
 	s16 trunk_h = pr.range(9, 13);


### PR DESCRIPTION
Fallback nodes added to mgv6 to replace snow nodes.
Fallback nodes re-added to jungletree generation.
Fallback nodes added to pinetree generation.
Snowblock is replaced with 'dirt with grass' because in mgv6 taiga snowblock is the ground level node.

Tested by removing all snow, pine tree and jungletree nodes from MTGame.