### PR TITLE
Treegen: Add enable_unique_ids option

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -864,6 +864,7 @@ int ModApiEnvMod::l_spawn_tree(lua_State *L)
 			getintfield(L, 2, "fruit_chance",tree_def.fruit_chance);
 		}
 		tree_def.explicit_seed = getintfield(L, 2, "seed", tree_def.seed);
+		tree_def.enable_unique_ids = getboolfield_default(L, 2, "enable_unique_ids", false);
 	}
 	else
 		return 0;

--- a/src/treegen.h
+++ b/src/treegen.h
@@ -56,6 +56,7 @@ namespace treegen {
 		int fruit_chance;
 		int seed;
 		bool explicit_seed;
+		bool enable_unique_ids;
 	};
 
 	// Add default tree
@@ -72,8 +73,8 @@ namespace treegen {
 	treegen::error make_ltree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef,
 		TreeDef tree_definition);
 	// Spawn L-systems tree from LUA
-	treegen::error spawn_ltree (ServerEnvironment *env, v3s16 p0, INodeDefManager *ndef,
-		TreeDef tree_definition);
+	treegen::error spawn_ltree(ServerEnvironment *env, v3s16 p0,
+		INodeDefManager *ndef, const TreeDef &tree_definition);
 
 	// L-System tree gen helper functions
 	void tree_node_placement(MMVManip &vmanip, v3f p0,


### PR DESCRIPTION
Adds an option for `minetest.spawn_tree` to give trees (more or less) unique identifiers inside the param2.
