### PR TITLE
Allow random menu images for subgames

### DIFF
--- a/builtin/mainmenu/textures.lua
+++ b/builtin/mainmenu/textures.lua
@@ -145,6 +145,29 @@ function mm_texture.set_game(identifier,gamedetails)
 	
 	local path = gamedetails.path .. DIR_DELIM .."menu" ..
 									 DIR_DELIM .. identifier .. ".png"
+
+	local count = 1
+	for i = 1, 9 do
+		local check_path = gamedetails.path .. DIR_DELIM .."menu" ..
+			DIR_DELIM .. identifier .. "." .. i .. ".png"
+		local file = io.open(check_path, "rb")
+		if file == nil then
+			count = i - 1
+			break
+		else
+			io.close(file)
+		end
+	end
+	local new_path = gamedetails.path .. DIR_DELIM .."menu" .. DIR_DELIM ..
+		identifier .. "." .. math.random(1, count) .. ".png"
+	local exists = io.open(new_path, "rb")
+	if exists ~= nil and math.random(1, (count+1)) ~= 1 then
+		io.close(exists)
+		path = new_path
+	elseif exists ~= nil then
+		io.close(exists)
+	end
+
 	if core.set_background(identifier,path) then
 		return true
 	end


### PR DESCRIPTION
This allows subgames to put images into the menu folder, and one of them shall be chosen at random, depending on how many are placed in the folder (under 9).

The images must follow a naming schedule along the lines of:
<game>/menu
    -background.png
    -background.1.png
    -background.2.png
    -background.3.png
    and so on up to 9
(ofc, background.png can be replaced by overlay.png or header.png)
I based it on the sound naming scheme.
