### PR TITLE
Protocol 25: Make access deny packet future proof

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -217,9 +217,11 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 		*pkt >> denyCode;
 		if (denyCode == SERVER_ACCESSDENIED_CUSTOM_STRING) {
 			*pkt >> m_access_denied_reason;
-		}
-		else if (denyCode < SERVER_ACCESSDENIED_MAX) {
+		} else if (denyCode < SERVER_ACCESSDENIED_MAX) {
 			m_access_denied_reason = accessDeniedStrings[denyCode];
+		} else {
+			// Use the fallback string sent by the server
+			*pkt >> m_access_denied_reason;
 		}
 	}
 	// 13/03/15 Legacy code from 0.4.12 and lesser. must stay 1 year

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -202,7 +202,8 @@ enum ToClientCommand
 	TOCLIENT_ACCESS_DENIED = 0x0A,
 	/*
 		u8 reason
-		std::string custom reason (if reason == SERVER_ACCESSDENIED_CUSTOM_STRING)
+		std::string custom reason (if reason == SERVER_ACCESSDENIED_CUSTOM_STRING),
+			also used as string fallback for new reasons beyond the initial 10.
 	*/
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
 	TOCLIENT_ADDNODE = 0x21,

--- a/src/server.h
+++ b/src/server.h
@@ -390,7 +390,7 @@ private:
 	void SendMovement(u16 peer_id);
 	void SendHP(u16 peer_id, u8 hp);
 	void SendBreath(u16 peer_id, u16 breath);
-	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason, const std::string &custom_reason);
+	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason, const std::string &str_reason);
 	void SendAccessDenied_Legacy(u16 peer_id, const std::wstring &reason);
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);


### PR DESCRIPTION
Send string field always, and make client use it as fallback for unknown reason strings.

This enables us to add new reasons in the future without much fuss.