### PR TITLE
Optional reconnect functionality

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -54,29 +54,42 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+local function wordwrap_quickhack(str)
+	local res = ""
+	local ar = str:split("\n")
+	for i = 1, #ar do
+		local text = ar[i]
+		-- Hack to add word wrapping.
+		-- TODO: Add engine support for wrapping in formspecs
+		while #text > 80 do
+			if res ~= "" then
+				res = res .. ","
+			end
+			res = res .. core.formspec_escape(string.sub(text, 1, 79))
+			text = string.sub(text, 80, #text)
+		end
+		if res ~= "" then
+			res = res .. ","
+		end
+		res = res .. core.formspec_escape(text)
+	end
+	return res
+end
+
 --------------------------------------------------------------------------------
 function ui.update()
 	local formspec = ""
 
 	-- handle errors
-	if gamedata ~= nil and gamedata.errormessage ~= nil then
-		local ar = gamedata.errormessage:split("\n")
-		for i = 1, #ar do
-			local text = ar[i]
-			-- Hack to add word wrapping.
-			-- TODO: Add engine support for wrapping in formspecs
-			while #text > 80 do
-				if formspec ~= "" then
-					formspec = formspec .. ","
-				end
-				formspec = formspec .. core.formspec_escape(string.sub(text, 1, 79))
-				text = string.sub(text, 80, #text)
-			end
-			if formspec ~= "" then
-				formspec = formspec .. ","
-			end
-			formspec = formspec .. core.formspec_escape(text)
-		end
+	if gamedata ~= nil and gamedata.reconnect_requested then
+		formspec = wordwrap_quickhack(gamedata.errormessage or "")
+		formspec = "size[12,5]" ..
+				"label[0.5,0;" .. fgettext("The server has requested a reconnect:") ..
+				"]textlist[0.2,0.8;11.5,3.5;;" .. formspec ..
+				"]button[6,4.6;3,0.5;btn_reconnect_no;" .. fgettext("Main menu") .. "]" ..
+				"button[3,4.6;3,0.5;btn_reconnect_yes;" .. fgettext("Reconnect") .. "]"
+	elseif gamedata ~= nil and gamedata.errormessage ~= nil then
+		formspec = wordwrap_quickhack(gamedata.errormessage)
 		local error_title
 		if string.find(gamedata.errormessage, "ModError") then
 			error_title = fgettext("An error occured in a Lua script, such as a mod:")
@@ -128,13 +141,6 @@ end
 
 --------------------------------------------------------------------------------
 function ui.handle_buttons(fields)
-
-	if fields["btn_error_confirm"] then
-		gamedata.errormessage = nil
-		update_menu()
-		return
-	end
-
 	for key,value in pairs(ui.childlist) do
 
 		local retval = value:handle_buttons(fields)
@@ -168,8 +174,15 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 core.button_handler = function(fields)
-	if fields["btn_error_confirm"] then
+	if fields["btn_reconnect_yes"] then
+		gamedata.reconnect_requested = false
 		gamedata.errormessage = nil
+		gamedata.do_reconnect = true
+		core.start()
+		return
+	elseif fields["btn_reconnect_no"] or fields["btn_error_confirm"] then
+		gamedata.errormessage = nil
+		gamedata.reconnect_requested = false
 		ui.update()
 		return
 	end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2174,7 +2174,8 @@ These functions return the leftover itemstack.
     * Optional: Variable number of arguments that are passed to `func`
 
 ### Server
-* `minetest.request_shutdown()`: request for server shutdown
+* `minetest.request_shutdown([message],[reconnect])`: request for server shutdown. Will display `message` to clients,
+    and `reconnect` == true displays a reconnect button.
 * `minetest.get_server_status()`: returns server status string
 
 ### Bans

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -393,6 +393,9 @@
 #    A message to be displayed to all clients when the server shuts down
 #kick_msg_crash = This server has experienced an internal error. You will now be disconnected.
 #    A message to be displayed to all clients when the server crashes
+#ask_reconnect_on_crash = false
+#    Whether to ask clients to reconnect after a (lua) crash.
+#    Set this to true if your server is set up to restart automatically.
 
 #    Mod profiler
 #mod_profiling = false

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -244,6 +244,7 @@ Client::Client(
 	m_chosen_auth_mech(AUTH_MECHANISM_NONE),
 	m_auth_data(NULL),
 	m_access_denied(false),
+	m_access_denied_reconnect(false),
 	m_itemdef_received(false),
 	m_nodedef_received(false),
 	m_media_downloader(new ClientMediaDownloader()),

--- a/src/client.h
+++ b/src/client.h
@@ -489,6 +489,8 @@ public:
 	bool accessDenied()
 	{ return m_access_denied; }
 
+	bool reconnectRequested() { return m_access_denied_reconnect; }
+
 	std::string accessDeniedReason()
 	{ return m_access_denied_reason; }
 
@@ -636,6 +638,7 @@ private:
 
 
 	bool m_access_denied;
+	bool m_access_denied_reconnect;
 	std::string m_access_denied_reason;
 	std::queue<ClientEvent> m_client_event_queue;
 	bool m_itemdef_received;

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -92,8 +92,8 @@ protected:
 	void init_args(GameParams &game_params, const Settings &cmd_args);
 	bool init_engine(int log_level);
 
-	bool launch_game(std::string &error_message, GameParams &game_params,
-			const Settings &cmd_args);
+	bool launch_game(std::string &error_message, bool reconnect_requested,
+		GameParams &game_params, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);
 	bool create_engine_device(int log_level);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -254,6 +254,7 @@ void set_default_settings(Settings *settings)
 
 	settings->setDefault("kick_msg_shutdown", "Server shutting down.");
 	settings->setDefault("kick_msg_crash", "This server has experienced an internal error. You will now be disconnected.");
+	settings->setDefault("ask_reconnect_on_crash", "false");
 
 	settings->setDefault("profiler_print_interval", "0");
 	settings->setDefault("enable_mapgen_debug_info", "false");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -426,13 +426,15 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 
 	return true;
 }
 
-void ServerEnvironment::kickAllPlayers(const std::string &reason)
+void ServerEnvironment::kickAllPlayers(AccessDeniedCode reason,
+		const std::string &str_reason, bool reconnect)
 {
-	std::wstring wreason = utf8_to_wide(reason);
 	for (std::vector<Player*>::iterator it = m_players.begin();
 			it != m_players.end();
 			++it) {
-		((Server*)m_gamedef)->DenyAccess_Legacy((*it)->peer_id, wreason);
+		((Server*)m_gamedef)->DenyAccessVerCompliant((*it)->peer_id,
+			(*it)->protocol_version, (AccessDeniedCode)reason,
+			str_reason, reconnect);
 	}
 }
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapnode.h"
 #include "mapblock.h"
 #include "jthread/jmutex.h"
+#include "network/networkprotocol.h" // for AccessDeniedCode
 
 class ServerEnvironment;
 class ActiveBlockModifier;
@@ -221,7 +222,8 @@ public:
 	float getSendRecommendedInterval()
 		{ return m_recommended_send_interval; }
 
-	void kickAllPlayers(const std::string &reason);
+	void kickAllPlayers(AccessDeniedCode reason,
+		const std::string &str_reason, bool reconnect);
 	// Save players
 	void saveLoadedPlayers();
 	void savePlayer(const std::string &playername);

--- a/src/game.h
+++ b/src/game.h
@@ -147,6 +147,7 @@ void the_game(bool *kill,
 		u16 port,
 		std::string &error_message,
 		ChatBackend &chat_backend,
+		bool *reconnect_requested,
 		const SubgameSpec &gamespec, // Used for local game
 		bool simple_singleplayer_mode);
 

--- a/src/guiEngine.cpp
+++ b/src/guiEngine.cpp
@@ -208,10 +208,8 @@ GUIEngine::GUIEngine(	irr::IrrlichtDevice* dev,
 	m_script = new MainMenuScripting(this);
 
 	try {
-		if (m_data->errormessage != "") {
-			m_script->setMainMenuErrorMessage(m_data->errormessage);
-			m_data->errormessage = "";
-		}
+		m_script->setMainMenuData(&m_data->script_data);
+		m_data->script_data.errormessage = "";
 
 		if (!loadMainMenuScript()) {
 			errorstream << "No future without mainmenu" << std::endl;
@@ -219,10 +217,9 @@ GUIEngine::GUIEngine(	irr::IrrlichtDevice* dev,
 		}
 
 		run();
-	}
-	catch(LuaError &e) {
+	} catch (LuaError &e) {
 		errorstream << "MAINMENU ERROR: " << e.what() << std::endl;
-		m_data->errormessage = e.what();
+		m_data->script_data.errormessage = e.what();
 	}
 
 	m_menu->quitMenu();

--- a/src/guiMainMenu.h
+++ b/src/guiMainMenu.h
@@ -25,17 +25,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <list>
 
-enum
-{
-	TAB_SINGLEPLAYER=0,
-	TAB_MULTIPLAYER,
-	TAB_ADVANCED,
-	TAB_SETTINGS,
-	TAB_CREDITS
+struct MainMenuDataForScript {
+
+	MainMenuDataForScript() :
+		reconnect_requested(false)
+	{}
+
+	// Whether the server has requested a reconnect
+	bool reconnect_requested;
+
+	std::string errormessage;
 };
 
-struct MainMenuData
-{
+struct MainMenuData {
 	// Client options
 	std::string servername;
 	std::string serverdescription;
@@ -43,19 +45,22 @@ struct MainMenuData
 	std::string port;
 	std::string name;
 	std::string password;
+	// Whether to reconnect
+	bool do_reconnect;
 
 	// Server options
 	bool enable_public;
 	int selected_world;
 	bool simple_singleplayer_mode;
 
-	//error handling
-	std::string errormessage;
+	// Data to be passed to the script
+	MainMenuDataForScript script_data;
+
 	MainMenuData():
+		do_reconnect(false),
 		enable_public(false),
 		selected_world(0),
-		simple_singleplayer_mode(false),
-		errormessage("")
+		simple_singleplayer_mode(false)
 	{}
 };
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -202,7 +202,8 @@ enum ToClientCommand
 	TOCLIENT_ACCESS_DENIED = 0x0A,
 	/*
 		u8 reason
-		std::string custom reason (if reason == SERVER_ACCESSDENIED_CUSTOM_STRING)
+		std::string custom reason (if needed, otherwise "")
+		u8 (bool) reconnect
 	*/
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
 	TOCLIENT_ADDNODE = 0x21,
@@ -937,6 +938,8 @@ enum AccessDeniedCode {
 	SERVER_ACCESSDENIED_ALREADY_CONNECTED,
 	SERVER_ACCESSDENIED_SERVER_FAIL,
 	SERVER_ACCESSDENIED_CUSTOM_STRING,
+	SERVER_ACCESSDENIED_SHUTDOWN,
+	SERVER_ACCESSDENIED_CRASH,
 	SERVER_ACCESSDENIED_MAX,
 };
 
@@ -954,8 +957,10 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"Too many users.",
 	"Empty passwords are disallowed.  Set a password and try again.",
 	"Another client is connected with this name.  If your client closed unexpectedly, try again in a minute.",
-	"Server authention failed.  This is likely a server error."
+	"Server authentication failed.  This is likely a server error.",
 	"",
+	"Server shutting down.",
+	"This server has experienced an internal error. You will now be disconnected."
 };
 
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -44,6 +44,7 @@ Player::Player(IGameDef *gamedef, const char *name):
 	hp(PLAYER_MAX_HP),
 	hurt_tilt_timer(0),
 	hurt_tilt_strength(0),
+	protocol_version(0),
 	peer_id(PEER_ID_INEXISTENT),
 	keyPressed(0),
 // protected

--- a/src/player.h
+++ b/src/player.h
@@ -362,6 +362,7 @@ public:
 	float hurt_tilt_timer;
 	float hurt_tilt_strength;
 
+	u16 protocol_version;
 	u16 peer_id;
 
 	std::string inventory_formspec;

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -21,15 +21,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
 
-void ScriptApiMainMenu::setMainMenuErrorMessage(std::string errormessage)
+void ScriptApiMainMenu::setMainMenuData(MainMenuDataForScript *data)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
 	lua_getglobal(L, "gamedata");
 	int gamedata_idx = lua_gettop(L);
 	lua_pushstring(L, "errormessage");
-	lua_pushstring(L, errormessage.c_str());
+	if (!data->errormessage.empty()) {
+		lua_pushstring(L, data->errormessage.c_str());
+	} else {
+		lua_pushnil(L);
+	}
 	lua_settable(L, gamedata_idx);
+	setboolfield(L, gamedata_idx, "reconnect_requested",
+		data->reconnect_requested);
 	lua_pop(L, 1);
 }
 

--- a/src/script/cpp_api/s_mainmenu.h
+++ b/src/script/cpp_api/s_mainmenu.h
@@ -22,16 +22,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 #include "util/string.h"
+#include "../guiMainMenu.h"
 
-class ScriptApiMainMenu
-		: virtual public ScriptApiBase
-{
+class ScriptApiMainMenu : virtual public ScriptApiBase {
 public:
 	/**
-	 * set gamedata.errormessage to inform lua of an error
-	 * @param errormessage the error message
+	 * Hand over MainMenuDataForScript to lua to inform lua of the content
+	 * @param data the data
 	 */
-	void setMainMenuErrorMessage(std::string errormessage);
+	void setMainMenuData(MainMenuDataForScript *data);
 
 	/**
 	 * process events received from formspec

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -114,15 +114,19 @@ int ModApiMainMenu::l_start(lua_State *L)
 
 	bool valid = false;
 
+	MainMenuData *data = engine->m_data;
 
-	engine->m_data->selected_world		= getIntegerData(L, "selected_world",valid) -1;
-	engine->m_data->simple_singleplayer_mode = getBoolData(L,"singleplayer",valid);
-	engine->m_data->name				= getTextData(L,"playername");
-	engine->m_data->password			= getTextData(L,"password");
-	engine->m_data->address				= getTextData(L,"address");
-	engine->m_data->port				= getTextData(L,"port");
-	engine->m_data->serverdescription	= getTextData(L,"serverdescription");
-	engine->m_data->servername			= getTextData(L,"servername");
+	data->selected_world = getIntegerData(L, "selected_world",valid) -1;
+	data->simple_singleplayer_mode = getBoolData(L,"singleplayer",valid);
+	data->do_reconnect = getBoolData(L, "do_reconnect", valid);
+	if (!data->do_reconnect) {
+		data->name     = getTextData(L,"playername");
+		data->password = getTextData(L,"password");
+		data->address  = getTextData(L,"address");
+		data->port     = getTextData(L,"port");
+	}
+	data->serverdescription = getTextData(L,"serverdescription");
+	data->servername        = getTextData(L,"servername");
 
 	//close menu next time
 	engine->m_startgame = true;

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -30,7 +30,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // request_shutdown()
 int ModApiServer::l_request_shutdown(lua_State *L)
 {
-	getServer(L)->requestShutdown();
+	const char *msg = lua_tolstring(L, 1, NULL);
+	bool reconnect = lua_toboolean(L, 2);
+	getServer(L)->requestShutdown(msg ? msg : "", reconnect);
 	return 0;
 }
 

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class ModApiServer : public ModApiBase {
 private:
-	// request_shutdown()
+	// request_shutdown([message], [reconnect])
 	static int l_request_shutdown(lua_State *L);
 
 	// get_server_status()

--- a/src/server.h
+++ b/src/server.h
@@ -244,8 +244,13 @@ public:
 			{ return m_shutdown_requested; }
 
 	// request server to shutdown
-	inline void requestShutdown(void)
-			{ m_shutdown_requested = true; }
+	inline void requestShutdown() { m_shutdown_requested = true; }
+	void requestShutdown(const std::string &msg, bool reconnect)
+	{
+		m_shutdown_requested = true;
+		m_shutdown_msg = msg;
+		m_shutdown_ask_reconnect = reconnect;
+	}
 
 	// Returns -1 if failed, sound handle on success
 	// Envlock
@@ -366,6 +371,8 @@ public:
 	void deletingPeer(con::Peer *peer, bool timeout);
 
 	void DenySudoAccess(u16 peer_id);
+	void DenyAccessVerCompliant(u16 peer_id, u16 proto_ver, AccessDeniedCode reason,
+		const std::string &str_reason = "", bool reconnect = false);
 	void DenyAccess(u16 peer_id, AccessDeniedCode reason, const std::string &custom_reason="");
 	void acceptAuth(u16 peer_id, bool forSudoMode);
 	void DenyAccess_Legacy(u16 peer_id, const std::wstring &reason);
@@ -390,7 +397,8 @@ private:
 	void SendMovement(u16 peer_id);
 	void SendHP(u16 peer_id, u8 hp);
 	void SendBreath(u16 peer_id, u16 breath);
-	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason, const std::string &custom_reason);
+	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason,
+		const std::string &custom_reason, bool reconnect = false);
 	void SendAccessDenied_Legacy(u16 peer_id, const std::wstring &reason);
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
@@ -490,7 +498,7 @@ private:
 
 		Call with env and con locked.
 	*/
-	PlayerSAO *emergePlayer(const char *name, u16 peer_id);
+	PlayerSAO *emergePlayer(const char *name, u16 peer_id, u16 proto_version);
 
 	void handlePeerChanges();
 
@@ -596,6 +604,8 @@ private:
 	*/
 
 	bool m_shutdown_requested;
+	std::string m_shutdown_msg;
+	bool m_shutdown_ask_reconnect;
 
 	/*
 		Map edit event queue. Automatically receives all map edits.


### PR DESCRIPTION
Enable the server to request the client to reconnect.

This can be done by mods with the now extended `minetest.request_shutdown([reason], [reconnect])` setting.