### PR TITLE
Cavegen: Mgv6: No small caves entirely above ground

### DIFF
--- a/src/cavegen.h
+++ b/src/cavegen.h
@@ -69,7 +69,7 @@ public:
 	CaveV5(MapgenV5 *mg, PseudoRandom *ps);
 	void makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height);
 	void makeTunnel(bool dirswitch);
-	void carveRoute(v3f vec, float f, bool randomize_xz, bool is_ravine);
+	void carveRoute(v3f vec, float f, bool randomize_xz);
 };
 
 class CaveV6 {
@@ -158,7 +158,7 @@ public:
 	CaveV7(MapgenV7 *mg, PseudoRandom *ps);
 	void makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height);
 	void makeTunnel(bool dirswitch);
-	void carveRoute(v3f vec, float f, bool randomize_xz, bool is_ravine);
+	void carveRoute(v3f vec, float f, bool randomize_xz);
 };
 
 #endif


### PR DESCRIPTION
Also:
Mgv5/mgv7: Remove 'should make cave hole' feature
Remove ravine code

Mgv6:
There is code to stop large caves generating entirely above ground, the code was copied from mgv7 and is not active for small caves, i can't see any reason why this is so i am enabling the check for small caves, this should save some processing.

Mgv5/mgv7:
The 'cave hole' feature is rarely effective as these mapgens now only have large pseudorandom caves which rarely intersect the surface, the processing is unnecessary deep underground, so removed for simplicity and performance.
Ravine code has been disabled for years, having ravines is a cool idea but i'm not keen on this implementation.
hmmmm i hope you don't mind these two features being removed.

Fails jenkins checks but compiles and is tested.