### PR TITLE
Mgv7: Use density noise + density gradient for mountain terrain

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -146,17 +146,17 @@ MapgenV7Params::MapgenV7Params()
 {
 	spflags = MGV7_MOUNTAINS | MGV7_RIDGES;
 
-	np_terrain_base    = NoiseParams(4,    70,   v3f(600,  600,  600),  82341, 5, 0.6,  2.0);
-	np_terrain_alt     = NoiseParams(4,    25,   v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
-	np_terrain_persist = NoiseParams(0.6,  0.12, v3f(2000, 2000, 2000), 539,   3, 0.5,  2.0);
-	np_height_select   = NoiseParams(-12,  24,   v3f(500,  500,  500),  4213,  6, 0.69, 2.0);
-	np_filler_depth    = NoiseParams(0,    1.2,  v3f(150,  150,  150),  261,   4, 0.7,  2.0);
-	np_mount_height    = NoiseParams(184,  72,   v3f(1000, 1000, 1000), 72449, 3, 0.5,  2.0);
-	np_ridge_uwater    = NoiseParams(0,    1,    v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0);
-	np_mountain        = NoiseParams(-0.6, 1,    v3f(250,  350,  250),  5333,  5, 0.68, 2.0);
-	np_ridge           = NoiseParams(0,    1,    v3f(100,  100,  100),  6467,  4, 0.75, 2.0);
-	np_cave1           = NoiseParams(0,    12,   v3f(100,  100,  100),  52534, 4, 0.5,  2.0);
-	np_cave2           = NoiseParams(0,    12,   v3f(100,  100,  100),  10325, 4, 0.5,  2.0);
+	np_terrain_base    = NoiseParams(4,    70,  v3f(600,  600,  600),  82341, 5, 0.6,  2.0);
+	np_terrain_alt     = NoiseParams(4,    25,  v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
+	np_terrain_persist = NoiseParams(0.6,  0.1, v3f(2000, 2000, 2000), 539,   3, 0.6,  2.0);
+	np_height_select   = NoiseParams(-12,  24,  v3f(500,  500,  500),  4213,  6, 0.7,  2.0);
+	np_filler_depth    = NoiseParams(0,    1.2, v3f(150,  150,  150),  261,   3, 0.7,  2.0);
+	np_mount_height    = NoiseParams(256,  112, v3f(1000, 1000, 1000), 72449, 3, 0.6,  2.0);
+	np_ridge_uwater    = NoiseParams(0,    1,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0);
+	np_mountain        = NoiseParams(-0.6, 1,   v3f(250,  350,  250),  5333,  5, 0.63, 2.0);
+	np_ridge           = NoiseParams(0,    1,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0);
+	np_cave1           = NoiseParams(0,    12,  v3f(100,  100,  100),  52534, 4, 0.5,  2.0);
+	np_cave2           = NoiseParams(0,    12,  v3f(100,  100,  100),  10325, 4, 0.5,  2.0);
 }
 
 
@@ -429,16 +429,20 @@ float MapgenV7::baseTerrainLevelFromMap(int index)
 bool MapgenV7::getMountainTerrainAtPoint(s16 x, s16 y, s16 z)
 {
 	float mnt_h_n = NoisePerlin2D(&noise_mount_height->np, x, z, seed);
+	float density_gradient = -((float)y / mnt_h_n);
 	float mnt_n = NoisePerlin3D(&noise_mountain->np, x, y, z, seed);
-	return mnt_n * mnt_h_n >= (float)y;
+
+	return mnt_n + density_gradient >= 0.0;
 }
 
 
 bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y)
 {
 	float mounthn = noise_mount_height->result[idx_xz];
+	float density_gradient = -((float)y / mounthn);
 	float mountn = noise_mountain->result[idx_xyz];
-	return mountn * mounthn >= (float)y;
+
+	return mountn + density_gradient >= 0.0;
 }
 
 


### PR DESCRIPTION
![screenshot_20150721_021850](https://cloud.githubusercontent.com/assets/3686677/8791228/136f5ada-2f50-11e5-9fbe-61b9cb6754e0.png)

Also:
Tune and optimise noise parameters

This changes the form of the equation for 3D mountain terrain to:
Terrain when 'density = density noise + density gradient > 0'
The form is very close to how it was before January when i changed it here https://github.com/minetest/minetest/commit/bec5d3ab227c1535797c286ad0b02d8190fd19fd
This is also the method explained in celeron55's blog post about mgv5 mapgen.
The 0.6 is absorbed into the mountain noise, making it definable for controlling mountain rarity.
This does not change the terrain shape so worlds are not broken.

Using a 'density gradient' variable allows this variable to be optionally manipulated in future to create high altitude floatlands or even extra realm levels stacked above, using methods explored in my lua mapgen mods.

Terrain persistence noise now has scale and persistence as they were before January.
Height select noise has persistence rounded up from 0.69 to 0.7.
Filler depth has lost an octave because 4 is unnecessary with a small spread of 150, and because it is visually unnoticeable.
Mountain height noise persistence returns to the classic value of 0.6.
Mountain height is boosted a little to help the current problem of unsatisfyingly short mountains, while staying in character and proportionate for mgv7.
The new mountain noise has a persistence of 0.63, a value i found in lua mapgens to be satisfyingly crazy without excessive small fragmented floatlands, the current value of 0.68 is too high.