### PR TITLE
Make Android use proper paths

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -15,6 +15,9 @@ ROOT = $(shell pwd)
 
 GAMES_TO_COPY = minetest_game
 
+# has to be the same value as the one you pass in
+PROJECT_NAME = minetest
+
 ################################################################################
 # Android Version code
 # Increase for each build!
@@ -737,23 +740,23 @@ assets : $(ASSETS_TIMESTAMP)
 	if [ $$REFRESH -ne 0 ] ; then                                              \
 	echo "assets changed, refreshing...";                                      \
 	$(MAKE) clean_assets;                                                      \
-	mkdir -p ${ROOT}/assets/Minetest;                                          \
-	cp ${ROOT}/../../minetest.conf.example ${ROOT}/assets/Minetest;            \
-	cp ${ROOT}/../../README.txt ${ROOT}/assets/Minetest;                       \
-	cp -r ${ROOT}/../../builtin ${ROOT}/assets/Minetest;                       \
-	cp -r ${ROOT}/../../client ${ROOT}/assets/Minetest;                        \
-	cp -r ${ROOT}/../../doc ${ROOT}/assets/Minetest;                           \
-	cp -r ${ROOT}/../../fonts ${ROOT}/assets/Minetest;                         \
-	mkdir ${ROOT}/assets/Minetest/games;                                       \
+	mkdir -p ${ROOT}/assets/${PROJECT_NAME};                                   \
+	cp ${ROOT}/../../minetest.conf.example ${ROOT}/assets/${PROJECT_NAME};     \
+	cp ${ROOT}/../../README.txt ${ROOT}/assets/${PROJECT_NAME};                \
+	cp -r ${ROOT}/../../builtin ${ROOT}/assets/${PROJECT_NAME};                \
+	cp -r ${ROOT}/../../client ${ROOT}/assets/${PROJECT_NAME};                 \
+	cp -r ${ROOT}/../../doc ${ROOT}/assets/${PROJECT_NAME};                    \
+	cp -r ${ROOT}/../../fonts ${ROOT}/assets/${PROJECT_NAME};                  \
+	mkdir ${ROOT}/assets/${PROJECT_NAME}/games;                                \
 	for game in ${GAMES_TO_COPY};                                              \
 	do                                                                         \
-	    cp -r ${ROOT}/../../games/$$game ${ROOT}/assets/Minetest/games/;       \
+	    cp -r ${ROOT}/../../games/$$game ${ROOT}/assets/${PROJECT_NAME}/games/;\
 	done;                                                                      \
-	cp -r ${ROOT}/../../mods ${ROOT}/assets/Minetest;                          \
-	cp -r ${ROOT}/../../po ${ROOT}/assets/Minetest;                            \
-	cp -r ${ROOT}/../../textures ${ROOT}/assets/Minetest;                      \
-	mkdir -p ${ROOT}/assets/Minetest/media;                                    \
-	cp -r ${IRRLICHT_DIR}/media/Shaders ${ROOT}/assets/Minetest/media;         \
+	cp -r ${ROOT}/../../mods ${ROOT}/assets/${PROJECT_NAME};                   \
+	cp -r ${ROOT}/../../po ${ROOT}/assets/${PROJECT_NAME};                     \
+	cp -r ${ROOT}/../../textures ${ROOT}/assets/${PROJECT_NAME};               \
+	mkdir -p ${ROOT}/assets/${PROJECT_NAME}/media;                             \
+	cp -r ${IRRLICHT_DIR}/media/Shaders ${ROOT}/assets/${PROJECT_NAME}/media;  \
 	cd ${ROOT}/assets ||  exit 1;                                              \
 	find . -name "timestamp" -exec rm {} \; ;                                  \
 	find . -name "*.blend" -exec rm {} \; ;                                    \
@@ -762,7 +765,7 @@ assets : $(ASSETS_TIMESTAMP)
 	find . -type d -path "*.svn" -exec rm -rf {} \; ;                          \
 	find . -type f -path "*.gitignore" -exec rm -rf {} \; ;                    \
 	ls -R | grep ":$$" | sed -e 's/:$$//' -e 's/\.//' -e 's/^\///' > "index.txt"; \
-	find Minetest >"filelist.txt";                                             \
+	find ${PROJECT_NAME} >"filelist.txt";                                      \
 	cp ${ROOT}/${ASSETS_TIMESTAMP} ${ROOT}/${ASSETS_TIMESTAMP}.old;            \
 	else                                                                       \
 		echo "nothing to be done for assets";                                  \

--- a/build/android/src/net/minetest/minetest/MtNativeActivity.java
+++ b/build/android/src/net/minetest/minetest/MtNativeActivity.java
@@ -6,29 +6,30 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.WindowManager;
 
+import android.content.Context;
+
 public class MtNativeActivity extends NativeActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		m_MessagReturnCode = -1;
 		m_MessageReturnValue = "";
-		
 	}
 
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
 	}
-	
-	
+
+
 	public void copyAssets() {
 		Intent intent = new Intent(this, MinetestAssetCopy.class);
 		startActivity(intent);
 	}
-	
+
 	public void showDialog(String acceptButton, String hint, String current,
 			int editType) {
-		
+
 		Intent intent = new Intent(this, MinetestTextEntry.class);
 		Bundle params = new Bundle();
 		params.putString("acceptButton", acceptButton);
@@ -40,37 +41,37 @@ public class MtNativeActivity extends NativeActivity {
 		m_MessageReturnValue = "";
 		m_MessagReturnCode   = -1;
 	}
-	
+
 	public static native void putMessageBoxResult(String text);
-	
+
 	/* ugly code to workaround putMessageBoxResult not beeing found */
 	public int getDialogState() {
 		return m_MessagReturnCode;
 	}
-	
+
 	public String getDialogValue() {
 		m_MessagReturnCode = -1;
 		return m_MessageReturnValue;
 	}
-	
+
 	public float getDensity() {
 		return getResources().getDisplayMetrics().density;
 	}
-	
+
 	public int getDisplayWidth() {
 		return getResources().getDisplayMetrics().widthPixels;
 	}
-	
+
 	public int getDisplayHeight() {
 		return getResources().getDisplayMetrics().heightPixels;
 	}
-	
+
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode,
 			Intent data) {
 		if (requestCode == 101) {
 			if (resultCode == RESULT_OK) {
-				String text = data.getStringExtra("text"); 
+				String text = data.getStringExtra("text");
 				m_MessagReturnCode = 0;
 				m_MessageReturnValue = text;
 			}
@@ -79,7 +80,21 @@ public class MtNativeActivity extends NativeActivity {
 			}
 		}
 	}
-	
+
+	public String getFilesDirStr()
+	{
+		return getFilesDir().getAbsolutePath();
+	}
+
+	/*public String getExternalFilesDirStr()
+	{
+		return getExternalFilesDir().getAbsolutePath();
+	}*/
+
+	public static String ProjectName;
+
+	private static native String getProjectName();
+
 	static {
 		System.loadLibrary("openal");
 		System.loadLibrary("ogg");
@@ -92,8 +107,10 @@ public class MtNativeActivity extends NativeActivity {
 		// but if we do, we get nicer logcat errors when
 		// loading fails.
 		System.loadLibrary("minetest");
+
+		ProjectName = getProjectName();
 	}
-	
+
 	private int m_MessagReturnCode;
 	private String m_MessageReturnValue;
 }


### PR DESCRIPTION
Made to fix #2097.
* Use an app-owned directory for the app's data, forestalling conflicts between clones, and deleting the data when we uninstall the app
* Add generic PROJECT_NAME variable for android makefile, settable by clones
* Remove trailing whitespaces in affected files
* Fix UGLY bug where we've written to a directory Minetest, but read from minetest,
   relying on the fs being case insensitive.

**TODO:**

* Right now we save to main storage, we should save at least textures and worlds to external. Perhaps we can store everything on external, I'm not sure however if users will be happy if they see no main menu without sd card.
* We still copy everything. Perhaps we can at least load some things from the apk.
* There is no migration feature where we load worlds, mods and the config from the old location.
* Use android's native cache for the texture cache