### PR TITLE
Precalculate mapblock relative size. 

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -69,6 +69,7 @@ static const char *modified_reason_strings[] = {
 MapBlock::MapBlock(Map *parent, v3s16 pos, IGameDef *gamedef, bool dummy):
 		m_parent(parent),
 		m_pos(pos),
+		m_pos_relative(pos * MAP_BLOCKSIZE),
 		m_gamedef(gamedef),
 		m_modified(MOD_STATE_WRITE_NEEDED),
 		m_modified_reason(MOD_REASON_INITIAL),

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -258,7 +258,7 @@ public:
 
 	inline v3s16 getPosRelative()
 	{
-		return m_pos * MAP_BLOCKSIZE;
+		return m_pos_relative;
 	}
 
 	inline core::aabbox3d<s16> getBox()
@@ -563,6 +563,14 @@ private:
 	Map *m_parent;
 	// Position in blocks on parent
 	v3s16 m_pos;
+
+	/* This is the precalculated m_pos_relative value
+	* This caches the value, improving performance by removing 3 s16 multiplications
+	* at runtime on each getPosRelative call
+	* For a 5 minutes runtime with valgrind this removes 3 * 19M s16 multiplications
+	* The gain can be estimated in Release Build to 3 * 100M multiply operations for 5 mins
+	*/
+	v3s16 m_pos_relative;
 
 	IGameDef *m_gamedef;
 


### PR DESCRIPTION
Calcul this relative size at creation prevent millions of s16 calculs at runtime.

Please look at the following valgrind reporting
![capture d ecran de 2015-07-29 10-54-33](https://cloud.githubusercontent.com/assets/119752/8953626/23fe8ede-35e0-11e5-9011-3d2baadcc8ca.png)
