### PR TITLE
Dungeon generation: Fix code style issues in dungeongen.cpp

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -38,7 +38,8 @@ NoiseParams nparams_dungeon_density(0.0, 1.0, v3f(2.5, 2.5, 2.5), 0, 2, 1.4, 2.0
 ///////////////////////////////////////////////////////////////////////////////
 
 
-DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams) {
+DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams)
+{
 	this->mg = mapgen;
 	this->vm = mapgen->vm;
 
@@ -55,10 +56,10 @@ DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams) {
 		dp.c_stair  = mg->ndef->getId("mapgen_stair_cobble");
 
 		dp.diagonal_dirs = false;
-		dp.mossratio  = 3.0;
-		dp.holesize   = v3s16(1, 2, 1);
-		dp.roomsize   = v3s16(0,0,0);
-		dp.notifytype = GENNOTIFY_DUNGEON;
+		dp.mossratio     = 3.0;
+		dp.holesize      = v3s16(1, 2, 1);
+		dp.roomsize      = v3s16(0, 0, 0);
+		dp.notifytype    = GENNOTIFY_DUNGEON;
 
 		dp.np_rarity  = nparams_dungeon_rarity;
 		dp.np_wetness = nparams_dungeon_wetness;
@@ -67,7 +68,8 @@ DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams) {
 }
 
 
-void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax) {
+void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax)
+{
 	//TimeTaker t("gen dungeons");
 	if (NoisePerlin3D(&dp.np_rarity, nmin.X, nmin.Y, nmin.Z, mg->seed) < 0.2)
 		return;
@@ -87,8 +89,8 @@ void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax) {
 			u32 i = vm->m_area.index(nmin.X, y, z);
 			for (s16 x = nmin.X; x <= nmax.X; x++) {
 				content_t c = vm->m_data[i].getContent();
-				if (c == CONTENT_AIR || c == dp.c_water
-						|| (no_float && c == CONTENT_IGNORE))
+				if (c == CONTENT_AIR || c == dp.c_water ||
+						(no_float && c == CONTENT_IGNORE))
 					vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 				i++;
 			}
@@ -96,7 +98,7 @@ void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax) {
 	}
 
 	// Add it
-	makeDungeon(v3s16(1,1,1) * MAP_BLOCKSIZE);
+	makeDungeon(v3s16(1, 1, 1) * MAP_BLOCKSIZE);
 
 	// Convert some cobble to mossy cobble
 	if (dp.mossratio != 0.0) {
@@ -129,20 +131,19 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		Find place for first room
 	*/
 	bool fits = false;
-	for (u32 i = 0; i < 100 && !fits; i++)
-	{
+	for (u32 i = 0; i < 100 && !fits; i++) {
 		bool is_large_room = ((random.next() & 3) == 1);
 		roomsize = is_large_room ?
-			v3s16(random.range(8, 16),random.range(8, 16),random.range(8, 16)) :
-			v3s16(random.range(4,  8),random.range(4,  6),random.range(4, 8));
+			v3s16(random.range(8, 16), random.range(8, 16), random.range(8, 16)) :
+			v3s16(random.range(4, 8), random.range(4, 6), random.range(4, 8));
 		roomsize += dp.roomsize;
 
 		// start_padding is used to disallow starting the generation of
 		// a dungeon in a neighboring generation chunk
 		roomplace = vm->m_area.MinEdge + start_padding + v3s16(
-			random.range(0,areasize.X-roomsize.X-1-start_padding.X),
-			random.range(0,areasize.Y-roomsize.Y-1-start_padding.Y),
-			random.range(0,areasize.Z-roomsize.Z-1-start_padding.Z));
+			random.range(0, areasize.X - roomsize.X - 1 - start_padding.X),
+			random.range(0, areasize.Y - roomsize.Y - 1 - start_padding.Y),
+			random.range(0, areasize.Z - roomsize.Z - 1 - start_padding.Z));
 
 		/*
 			Check that we're not putting the room to an unknown place,
@@ -151,12 +152,11 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		fits = true;
 		for (s16 z = 1; z < roomsize.Z - 1; z++)
 		for (s16 y = 1; y < roomsize.Y - 1; y++)
-		for (s16 x = 1; x < roomsize.X - 1; x++)
-		{
+		for (s16 x = 1; x < roomsize.X - 1; x++) {
 			v3s16 p = roomplace + v3s16(x, y, z);
 			u32 vi = vm->m_area.index(p);
 			if ((vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_INSIDE) ||
-				vm->m_data[vi].getContent() == CONTENT_IGNORE) {
+					vm->m_data[vi].getContent() == CONTENT_IGNORE) {
 				fits = false;
 				break;
 			}
@@ -174,8 +174,7 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 	v3s16 last_room_center = roomplace + v3s16(roomsize.X / 2, 1, roomsize.Z / 2);
 
 	u32 room_count = random.range(2, 16);
-	for (u32 i = 0; i < room_count; i++)
-	{
+	for (u32 i = 0; i < room_count; i++) {
 		// Make a room to the determined place
 		makeRoom(roomsize, roomplace);
 
@@ -213,7 +212,7 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		if (!findPlaceForDoor(doorplace, doordir))
 			return;
 
-		if (random.range(0,1) == 0)
+		if (random.range(0, 1) == 0)
 			// Make the door
 			makeDoor(doorplace, doordir);
 		else
@@ -226,7 +225,7 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		makeCorridor(doorplace, doordir, corridor_end, corridor_end_dir);
 
 		// Find a place for a random sized room
-		roomsize = v3s16(random.range(4,8),random.range(4,6),random.range(4,8));
+		roomsize = v3s16(random.range(4, 8), random.range(4, 6), random.range(4, 8));
 		roomsize += dp.roomsize;
 
 		m_pos = corridor_end;
@@ -234,7 +233,7 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		if (!findPlaceForRoomDoor(roomsize, doorplace, doordir, roomplace))
 			return;
 
-		if (random.range(0,1) == 0)
+		if (random.range(0, 1) == 0)
 			// Make the door
 			makeDoor(doorplace, doordir);
 		else
@@ -252,11 +251,10 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 
 	// Make +-X walls
 	for (s16 z = 0; z < roomsize.Z; z++)
-	for (s16 y = 0; y < roomsize.Y; y++)
-	{
+	for (s16 y = 0; y < roomsize.Y; y++) {
 		{
 			v3s16 p = roomplace + v3s16(0, y, z);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -265,7 +263,7 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 		}
 		{
 			v3s16 p = roomplace + v3s16(roomsize.X - 1, y, z);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -276,11 +274,10 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 
 	// Make +-Z walls
 	for (s16 x = 0; x < roomsize.X; x++)
-	for (s16 y = 0; y < roomsize.Y; y++)
-	{
+	for (s16 y = 0; y < roomsize.Y; y++) {
 		{
 			v3s16 p = roomplace + v3s16(x, y, 0);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -289,7 +286,7 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 		}
 		{
 			v3s16 p = roomplace + v3s16(x, y, roomsize.Z - 1);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -300,11 +297,10 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 
 	// Make +-Y walls (floor and ceiling)
 	for (s16 z = 0; z < roomsize.Z; z++)
-	for (s16 x = 0; x < roomsize.X; x++)
-	{
+	for (s16 x = 0; x < roomsize.X; x++) {
 		{
 			v3s16 p = roomplace + v3s16(x, 0, z);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -313,7 +309,7 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 		}
 		{
 			v3s16 p = roomplace + v3s16(x,roomsize. Y - 1, z);
-			if (vm->m_area.contains(p) == false)
+			if (!vm->m_area.contains(p))
 				continue;
 			u32 vi = vm->m_area.index(p);
 			if (vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE)
@@ -325,41 +321,39 @@ void DungeonGen::makeRoom(v3s16 roomsize, v3s16 roomplace)
 	// Fill with air
 	for (s16 z = 1; z < roomsize.Z - 1; z++)
 	for (s16 y = 1; y < roomsize.Y - 1; y++)
-	for (s16 x = 1; x < roomsize.X - 1; x++)
-	{
+	for (s16 x = 1; x < roomsize.X - 1; x++) {
 		v3s16 p = roomplace + v3s16(x, y, z);
-		if (vm->m_area.contains(p) == false)
+		if (!vm->m_area.contains(p))
 			continue;
 		u32 vi = vm->m_area.index(p);
 		vm->m_flags[vi] |= VMANIP_FLAG_DUNGEON_UNTOUCHABLE;
-		vm->m_data[vi]   = n_air;
+		vm->m_data[vi] = n_air;
 	}
 }
 
 
 void DungeonGen::makeFill(v3s16 place, v3s16 size,
-		u8 avoid_flags, MapNode n, u8 or_flags)
+	u8 avoid_flags, MapNode n, u8 or_flags)
 {
 	for (s16 z = 0; z < size.Z; z++)
 	for (s16 y = 0; y < size.Y; y++)
-	for (s16 x = 0; x < size.X; x++)
-	{
+	for (s16 x = 0; x < size.X; x++) {
 		v3s16 p = place + v3s16(x, y, z);
-		if (vm->m_area.contains(p) == false)
+		if (!vm->m_area.contains(p))
 			continue;
 		u32 vi = vm->m_area.index(p);
 		if (vm->m_flags[vi] & avoid_flags)
 			continue;
 		vm->m_flags[vi] |= or_flags;
-		vm->m_data[vi]   = n;
+		vm->m_data[vi] = n;
 	}
 }
 
 
 void DungeonGen::makeHole(v3s16 place)
 {
-	makeFill(place, dp.holesize, 0,
-		MapNode(CONTENT_AIR), VMANIP_FLAG_DUNGEON_INSIDE);
+	makeFill(place, dp.holesize, 0, MapNode(CONTENT_AIR),
+		VMANIP_FLAG_DUNGEON_INSIDE);
 }
 
 
@@ -374,8 +368,8 @@ void DungeonGen::makeDoor(v3s16 doorplace, v3s16 doordir)
 }
 
 
-void DungeonGen::makeCorridor(v3s16 doorplace,
-		v3s16 doordir, v3s16 &result_place, v3s16 &result_dir)
+void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
+	v3s16 &result_place, v3s16 &result_dir)
 {
 	makeHole(doorplace);
 	v3s16 p0 = doorplace;
@@ -398,22 +392,26 @@ void DungeonGen::makeCorridor(v3s16 doorplace,
 		if (partcount != 0)
 			p.Y += make_stairs;
 
-		if (vm->m_area.contains(p) == true &&
-			vm->m_area.contains(p + v3s16(0, 1, 0)) == true) {
+		if (vm->m_area.contains(p) && vm->m_area.contains(p + v3s16(0, 1, 0))) {
 			if (make_stairs) {
-				makeFill(p + v3s16(-1, -1, -1), dp.holesize + v3s16(2, 3, 2),
-						VMANIP_FLAG_DUNGEON_UNTOUCHABLE, MapNode(dp.c_cobble), 0);
+				makeFill(p + v3s16(-1, -1, -1),
+					dp.holesize + v3s16(2, 3, 2),
+					VMANIP_FLAG_DUNGEON_UNTOUCHABLE,
+					MapNode(dp.c_cobble),
+					0);
 				makeHole(p);
 				makeHole(p - dir);
 
-				// TODO: fix stairs code so it works 100% (quite difficult)
+				// TODO: fix stairs code so it works 100%
+				// (quite difficult)
 
 				// exclude stairs from the bottom step
 				// exclude stairs from diagonal steps
 				if (((dir.X ^ dir.Z) & 1) &&
-					(((make_stairs ==  1) && i != 0) ||
-					((make_stairs == -1) && i != length - 1))) {
-					// rotate face 180 deg if making stairs backwards
+						(((make_stairs ==  1) && i != 0) ||
+						((make_stairs == -1) && i != length - 1))) {
+					// rotate face 180 deg if
+					// making stairs backwards
 					int facedir = dir_to_facedir(dir * make_stairs);
 
 					u32 vi = vm->m_area.index(p.X - dir.X, p.Y - 1, p.Z - dir.Z);
@@ -425,8 +423,11 @@ void DungeonGen::makeCorridor(v3s16 doorplace,
 						vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
 				}
 			} else {
-				makeFill(p + v3s16(-1, -1, -1), dp.holesize + v3s16(2, 2, 2),
-						VMANIP_FLAG_DUNGEON_UNTOUCHABLE, MapNode(dp.c_cobble), 0);
+				makeFill(p + v3s16(-1, -1, -1),
+					dp.holesize + v3s16(2, 2, 2),
+					VMANIP_FLAG_DUNGEON_UNTOUCHABLE,
+					MapNode(dp.c_cobble),
+					0);
 				makeHole(p);
 			}
 
@@ -446,7 +447,7 @@ void DungeonGen::makeCorridor(v3s16 doorplace,
 
 			dir = random_turn(random, dir);
 
-			partlength = random.range(1,length);
+			partlength = random.range(1, length);
 
 			make_stairs = 0;
 			if (random.next() % 2 == 0 && partlength >= 3)
@@ -460,20 +461,15 @@ void DungeonGen::makeCorridor(v3s16 doorplace,
 
 bool DungeonGen::findPlaceForDoor(v3s16 &result_place, v3s16 &result_dir)
 {
-	for (u32 i = 0; i < 100; i++)
-	{
+	for (u32 i = 0; i < 100; i++) {
 		v3s16 p = m_pos + m_dir;
 		v3s16 p1 = p + v3s16(0, 1, 0);
-		if (vm->m_area.contains(p) == false
-		 || vm->m_area.contains(p1) == false
-		 || i % 4 == 0)
-		{
+		if (!vm->m_area.contains(p) || !vm->m_area.contains(p1) || i % 4 == 0) {
 			randomizeDir();
 			continue;
 		}
-		if (vm->getNodeNoExNoEmerge(p).getContent()  == dp.c_cobble
-		 && vm->getNodeNoExNoEmerge(p1).getContent() == dp.c_cobble)
-		{
+		if (vm->getNodeNoExNoEmerge(p).getContent() == dp.c_cobble &&
+				vm->getNodeNoExNoEmerge(p1).getContent() == dp.c_cobble) {
 			// Found wall, this is a good place!
 			result_place = p;
 			result_dir = m_dir;
@@ -485,19 +481,25 @@ bool DungeonGen::findPlaceForDoor(v3s16 &result_place, v3s16 &result_dir)
 			Determine where to move next
 		*/
 		// Jump one up if the actual space is there
-		if (vm->getNodeNoExNoEmerge(p+v3s16(0,0,0)).getContent() == dp.c_cobble
-		 && vm->getNodeNoExNoEmerge(p+v3s16(0,1,0)).getContent() == CONTENT_AIR
-		 && vm->getNodeNoExNoEmerge(p+v3s16(0,2,0)).getContent() == CONTENT_AIR)
+		if (vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 0, 0)).getContent() == dp.c_cobble &&
+				vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 1, 0)).getContent() == CONTENT_AIR &&
+				vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 2, 0)).getContent() == CONTENT_AIR)
 			p += v3s16(0,1,0);
 		// Jump one down if the actual space is there
-		if (vm->getNodeNoExNoEmerge(p+v3s16(0,1,0)).getContent() == dp.c_cobble
-		 && vm->getNodeNoExNoEmerge(p+v3s16(0,0,0)).getContent() == CONTENT_AIR
-		 && vm->getNodeNoExNoEmerge(p+v3s16(0,-1,0)).getContent() == CONTENT_AIR)
-			p += v3s16(0,-1,0);
+		if (vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 1, 0)).getContent() == dp.c_cobble &&
+				vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 0, 0)).getContent() == CONTENT_AIR &&
+				vm->getNodeNoExNoEmerge(p +
+				v3s16(0, -1, 0)).getContent() == CONTENT_AIR)
+			p += v3s16(0, -1, 0);
 		// Check if walking is now possible
-		if (vm->getNodeNoExNoEmerge(p).getContent() != CONTENT_AIR
-		 || vm->getNodeNoExNoEmerge(p+v3s16(0,1,0)).getContent() != CONTENT_AIR)
-		{
+		if (vm->getNodeNoExNoEmerge(p).getContent() != CONTENT_AIR ||
+				vm->getNodeNoExNoEmerge(p +
+				v3s16(0, 1, 0)).getContent() != CONTENT_AIR) {
 			// Cannot continue walking here
 			randomizeDir();
 			continue;
@@ -510,10 +512,9 @@ bool DungeonGen::findPlaceForDoor(v3s16 &result_place, v3s16 &result_dir)
 
 
 bool DungeonGen::findPlaceForRoomDoor(v3s16 roomsize, v3s16 &result_doorplace,
-		v3s16 &result_doordir, v3s16 &result_roomplace)
+	v3s16 &result_doordir, v3s16 &result_roomplace)
 {
-	for (s16 trycount = 0; trycount < 30; trycount++)
-	{
+	for (s16 trycount = 0; trycount < 30; trycount++) {
 		v3s16 doorplace;
 		v3s16 doordir;
 		bool r = findPlaceForDoor(doorplace, doordir);
@@ -524,16 +525,16 @@ bool DungeonGen::findPlaceForRoomDoor(v3s16 roomsize, v3s16 &result_doorplace,
 #if 1
 		if (doordir == v3s16(1, 0, 0)) // X+
 			roomplace = doorplace +
-					v3s16(0, -1, random.range(-roomsize.Z + 2, -2));
+				v3s16(0, -1, random.range(-roomsize.Z + 2, -2));
 		if (doordir == v3s16(-1, 0, 0)) // X-
 			roomplace = doorplace +
-					v3s16(-roomsize.X + 1, -1, random.range(-roomsize.Z + 2, -2));
+				v3s16(-roomsize.X + 1, -1, random.range(-roomsize.Z + 2, -2));
 		if (doordir == v3s16(0, 0, 1)) // Z+
 			roomplace = doorplace +
-					v3s16(random.range(-roomsize.X + 2, -2), -1, 0);
+				v3s16(random.range(-roomsize.X + 2, -2), -1, 0);
 		if (doordir == v3s16(0, 0, -1)) // Z-
 			roomplace = doorplace +
-					v3s16(random.range(-roomsize.X + 2, -2), -1, -roomsize.Z + 1);
+				v3s16(random.range(-roomsize.X + 2, -2), -1, -roomsize.Z + 1);
 #endif
 #if 0
 		if (doordir == v3s16(1, 0, 0)) // X+
@@ -550,23 +551,18 @@ bool DungeonGen::findPlaceForRoomDoor(v3s16 roomsize, v3s16 &result_doorplace,
 		bool fits = true;
 		for (s16 z = 1; z < roomsize.Z - 1; z++)
 		for (s16 y = 1; y < roomsize.Y - 1; y++)
-		for (s16 x = 1; x < roomsize.X - 1; x++)
-		{
+		for (s16 x = 1; x < roomsize.X - 1; x++) {
 			v3s16 p = roomplace + v3s16(x, y, z);
-			if (vm->m_area.contains(p) == false)
-			{
+			if (!vm->m_area.contains(p)) {
 				fits = false;
 				break;
 			}
-			if (vm->m_flags[vm->m_area.index(p)]
-					& VMANIP_FLAG_DUNGEON_INSIDE)
-			{
+			if (vm->m_flags[vm->m_area.index(p)] & VMANIP_FLAG_DUNGEON_INSIDE) {
 				fits = false;
 				break;
 			}
 		}
-		if(fits == false)
-		{
+		if (fits == false) {
 			// Find new place
 			continue;
 		}
@@ -604,15 +600,12 @@ v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs)
 v3s16 turn_xz(v3s16 olddir, int t)
 {
 	v3s16 dir;
-	if (t == 0)
-	{
+	if (t == 0) {
 		// Turn right
 		dir.X = olddir.Z;
 		dir.Z = -olddir.X;
 		dir.Y = olddir.Y;
-	}
-	else
-	{
+	} else {
 		// Turn left
 		dir.X = -olddir.Z;
 		dir.Z = olddir.X;
@@ -627,10 +620,8 @@ v3s16 random_turn(PseudoRandom &random, v3s16 olddir)
 	int turn = random.range(0, 2);
 	v3s16 dir;
 	if (turn == 0)
-	{
 		// Go straight
 		dir = olddir;
-	}
 	else if (turn == 1)
 		// Turn right
 		dir = turn_xz(olddir, 0);
@@ -641,7 +632,8 @@ v3s16 random_turn(PseudoRandom &random, v3s16 olddir)
 }
 
 
-int dir_to_facedir(v3s16 d) {
+int dir_to_facedir(v3s16 d)
+{
 	if (abs(d.X) > abs(d.Z))
 		return d.X < 0 ? 3 : 1;
 	else


### PR DESCRIPTION
Shorten lines to roughly 85.
Add missing spaces.
Move curly brackets to correct positions.
Fix indentations.
Indent broken conditionals by 2 tabs not 1.
Change 'if (vm->m_area.contains(p) == true)' to 'if (vm->m_area.contains(p))'.
Change 'if (vm->m_area.contains(p) == false)' to 'if (!vm->m_area.contains(p))'.