### PR TITLE
Android: Add githash header to spare rebuilds after new commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ doc/doxygen_*
 CMakeFiles/*
 src/CMakeFiles/*
 src/Makefile
+src/android_config_githash.h
 src/android_version.h
 src/cmake_config.h
 src/cmake_config_githash.h

--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -15,6 +15,18 @@ ROOT = $(shell pwd)
 
 GAMES_TO_COPY = minetest_game
 
+
+# Doens't work:
+#VERSION_MAJOR := $(shell awk '/^set\(VERSION_MAJOR .*\)\/{print sub("/[)]/"," ",$2)}' \
+	$(ROOT)/../../CMakeLists.txt)
+#VERSION_MINOR := $(shell awk '/^set\(VERSION_MINOR .*\)\/{print sub("/[)]/"," ",$2)}' \
+	$(ROOT)/../../CMakeLists.txt)
+#VERSION_PATCH := $(shell awk '/^set\(VERSION_PATCH .*\)\/{print sub("/[)]/"," ",$2)}' \
+	${ROOT}/../../CMakeLists.txt)
+VERSION_MAJOR := $(shell cat $(ROOT)/../../CMakeLists.txt | grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | cut -f2 -d' ')
+VERSION_MINOR := $(shell cat $(ROOT)/../../CMakeLists.txt | grep ^set\(VERSION_MINOR\ | sed 's/)/ /' | cut -f2 -d' ')
+VERSION_PATCH := $(shell cat $(ROOT)/../../CMakeLists.txt | grep ^set\(VERSION_PATCH\ | sed 's/)/ /' | cut -f2 -d' ')
+
 ################################################################################
 # Android Version code
 # Increase for each build!
@@ -161,7 +173,8 @@ endif
 	$(OPENAL_TIMESTAMP) $(OGG_TIMESTAMP) \
 	$(IRRLICHT_TIMESTAMP) $(CURL_TIMESTAMP) \
 	$(OPENSSL_TIMESTAMP) curl_binary \
-	$(ROOT)/jni/src/android_version.h
+	$(ROOT)/jni/src/android_version.h \
+	$(ROOT)/jni/src/android_version_githash.h
 
 debug : $(PATHCFGFILE)
 	export NDEBUG=;                                                            \
@@ -773,7 +786,7 @@ clean_assets :
 
 apk: $(PATHCFGFILE) assets $(ICONV_LIB) $(IRRLICHT_LIB) $(CURL_LIB) $(GMP_LIB) $(LEVELDB_TARGET)       \
 	$(OPENAL_LIB) $(OGG_LIB) prep_srcdir $(ROOT)/jni/src/android_version.h     \
-	sqlite3_download
+	$(ROOT)/jni/src/android_version_githash.h sqlite3_download
 	@export NDEBUG=$$NDEBUG; $(MAKE) manifest;                                 \
 	export PATH=$$PATH:${SDKFOLDER}/platform-tools:${ANDROID_NDK};             \
 	export ANDROID_HOME=${SDKFOLDER};                                          \
@@ -819,44 +832,47 @@ clean_all :
 	sleep 1;                                                                   \
 	$(RM) -r gen libs obj deps bin Debug and_env
 
+$(ROOT)/jni/src/android_version_githash.h : prep_srcdir
+	@export VERSION_FILE=${ROOT}/jni/src/android_version_githash.h;            \
+	export VERSION_FILE_NEW=$${VERSION_FILE}.new;                              \
+	{                                                                          \
+	echo "#ifndef ANDROID_MT_VERSION_GITHASH_H";                               \
+	echo "#define ANDROID_MT_VERSION_GITHASH_H";                               \
+	export GITHASH=$$(git rev-parse --short=8 HEAD);                           \
+	export VERSION_STR="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}";   \
+	echo "#define VERSION_GITHASH \"$$VERSION_STR-$$GITHASH-Android\"";        \
+	echo "#endif";                                                             \
+	} > "$${VERSION_FILE_NEW}";                                                \
+	if ! cmp -s $${VERSION_FILE} $${VERSION_FILE_NEW}; then                    \
+		echo "android_version_githash.h changed, updating...";             \
+		mv "$${VERSION_FILE_NEW}" "$${VERSION_FILE}";                      \
+	else                                                                       \
+		rm "$${VERSION_FILE_NEW}";                                         \
+	fi
+
+
 $(ROOT)/jni/src/android_version.h : prep_srcdir
 	@export VERSION_FILE=${ROOT}/jni/src/android_version.h;                    \
 	export VERSION_FILE_NEW=$${VERSION_FILE}.new;                              \
 	{                                                                          \
 	echo "#ifndef ANDROID_MT_VERSION_H";                                       \
 	echo "#define ANDROID_MT_VERSION_H";                                       \
-	export CMAKE_FILE=${ROOT}/../../CMakeLists.txt;                            \
-	export VERSION_MAJOR=$$(cat $${CMAKE_FILE} |                               \
-	grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | cut -f2 -d' ');                 \
-	export VERSION_MINOR=$$(cat $${CMAKE_FILE} |                               \
-	grep ^set\(VERSION_MINOR\ | sed 's/)/ /' | cut -f2 -d' ');                 \
-	export VERSION_PATCH=$$(cat $${CMAKE_FILE} |                               \
-	grep ^set\(VERSION_PATCH\ | sed 's/)/ /' | cut -f2 -d' ');                 \
-	echo "#define VERSION_MAJOR $${VERSION_MAJOR}";                            \
-	echo "#define VERSION_MINOR $${VERSION_MINOR}";                            \
-	echo "#define VERSION_PATCH $${VERSION_PATCH}";                            \
-	export GITHASH=$$(git rev-parse --short=8 HEAD);                           \
-	export VERSION_STR="$${VERSION_MAJOR}.$${VERSION_MINOR}.$${VERSION_PATCH}";\
-	echo "#define VERSION_GITHASH \"$$VERSION_STR-$$GITHASH-Android\"";        \
+	echo "#define VERSION_MAJOR ${VERSION_MAJOR}";                             \
+	echo "#define VERSION_MINOR ${VERSION_MINOR}";                             \
+	echo "#define VERSION_PATCH ${VERSION_PATCH}";                             \
 	echo "#define VERSION_STRING STR(VERSION_MAJOR)\".\"STR(VERSION_MINOR)\
 	\".\"STR(VERSION_PATCH)";                                                  \
 	echo "#endif";                                                             \
 	} > $${VERSION_FILE_NEW};                                                  \
 	if ! cmp -s $${VERSION_FILE} $${VERSION_FILE_NEW}; then                    \
 		echo "android_version.h changed, updating...";                     \
-		mv $${VERSION_FILE_NEW} $${VERSION_FILE};                          \
+		mv "$${VERSION_FILE_NEW}" "$${VERSION_FILE}";                      \
 	else                                                                       \
-		rm $${VERSION_FILE_NEW};                                           \
+		rm "$${VERSION_FILE_NEW}";                                         \
 	fi
 
 manifest :
-	@VERS_MAJOR=$$(cat ${ROOT}/../../CMakeLists.txt |                          \
-	grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | awk '{print $$2;}');            \
-	VERS_MINOR=$$(cat ${ROOT}/../../CMakeLists.txt |                           \
-	grep ^set\(VERSION_MINOR\ | sed 's/)/ /' | awk '{print $$2;}');            \
-	VERS_PATCH=$$(cat ${ROOT}/../../CMakeLists.txt |                           \
-	grep ^set\(VERSION_PATCH\ | sed 's/)/ /' | awk '{print $$2;}');            \
-	BASE_VERSION="$$VERS_MAJOR.$$VERS_MINOR.$$VERS_PATCH";                     \
+	@BASE_VERSION="${VERS_MAJOR}.${VERS_MINOR}.${VERS_PATCH}";                 \
 	if [ "${NDEBUG}x" != "x" ] ; then                                          \
 		DBG='';                                                                \
 		DBG_FLAG="android:debuggable=\"false\"";                               \

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1011,7 +1011,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 
 	std::string last_part_of_name = name.substr(last_separator_pos + 1);
 
-	/* 
+	/*
 		If this name is enclosed in parentheses, generate it
 		and blit it onto the base image
 	*/

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if defined(__ANDROID__)
 	#include "android_version.h"
+	#include "android_version_githash.h"
 #elif defined(USE_CMAKE_CONFIG_H)
 	#include "cmake_config_githash.h"
 #endif


### PR DESCRIPTION
Before, android_version.h got changed at every new commit. Now, we
only change it with new minetest releases. Analogous to the cmake
progress, we add an android_version_githash.h file that communicates
the git hash file to C++ code.

Also, unify VERS_MAJOR, VERS_MINOR and VERS_PATCH version variable
calculation inside the whole makefile.

Only thing to do is to chose one of the variable setting methods. Currently the non-working one is commented out and waits for @nerzhul  to get fixed. Then its ok to merge, I think.