### PR TITLE
Prepend "Lua: " before lua exceptions

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -494,8 +494,8 @@ void *EmergeThread::Thread()
 					try {  // takes about 90ms with -O1 on an e3-1230v2
 						m_server->getScriptIface()->environment_OnGenerated(
 								minp, maxp, mapgen->blockseed);
-					} catch(LuaError &e) {
-						m_server->setAsyncFatalError(e.what());
+					} catch (LuaError &e) {
+						m_server->setAsyncFatalError("Lua: " + std::string(e.what()));
 					}
 
 					EMERGE_DBG_OUT("ended up with: " << analyze_block(block));

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -86,7 +86,7 @@ public:
 	void * Thread();
 };
 
-void * ServerThread::Thread()
+void *ServerThread::Thread()
 {
 	log_register_thread("ServerThread");
 
@@ -99,33 +99,22 @@ void * ServerThread::Thread()
 
 	porting::setThreadName("ServerThread");
 
-	while(!StopRequested())
-	{
-		try{
+	while (!StopRequested()) {
+		try {
 			//TimeTaker timer("AsyncRunStep() + Receive()");
 
 			m_server->AsyncRunStep();
 
 			m_server->Receive();
 
-		}
-		catch(con::NoIncomingDataException &e)
-		{
-		}
-		catch(con::PeerNotFoundException &e)
-		{
+		} catch (con::NoIncomingDataException &e) {
+		} catch (con::PeerNotFoundException &e) {
 			infostream<<"Server: PeerNotFoundException"<<std::endl;
-		}
-		catch(ClientNotFoundException &e)
-		{
-		}
-		catch(con::ConnectionBindFailed &e)
-		{
+		} catch (ClientNotFoundException &e) {
+		} catch (con::ConnectionBindFailed &e) {
 			m_server->setAsyncFatalError(e.what());
-		}
-		catch(LuaError &e)
-		{
-			m_server->setAsyncFatalError(e.what());
+		} catch (LuaError &e) {
+			m_server->setAsyncFatalError("Lua: " + std::string(e.what()));
 		}
 	}
 


### PR DESCRIPTION
Currently, if lua prints "not enough memory", it looks like the message comes from the core server.