### PR TITLE
Biome API: Make fallback biome stone and water, disable filler

### DIFF
--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -43,15 +43,15 @@ BiomeManager::BiomeManager(IGameDef *gamedef) :
 	b->name            = "Default";
 	b->flags           = 0;
 	b->depth_top       = 0;
-	b->depth_filler    = 0;
+	b->depth_filler    = -MAX_MAP_GENERATION_LIMIT;
 	b->depth_water_top = 0;
 	b->y_min           = -MAX_MAP_GENERATION_LIMIT;
 	b->y_max           = MAX_MAP_GENERATION_LIMIT;
 	b->heat_point      = 0.0;
 	b->humidity_point  = 0.0;
 
-	b->m_nodenames.push_back("air");
-	b->m_nodenames.push_back("air");
+	b->m_nodenames.push_back("mapgen_stone");
+	b->m_nodenames.push_back("mapgen_stone");
 	b->m_nodenames.push_back("mapgen_stone");
 	b->m_nodenames.push_back("mapgen_water_source");
 	b->m_nodenames.push_back("mapgen_water_source");
@@ -132,8 +132,8 @@ void BiomeManager::clear()
 
 void Biome::resolveNodeNames()
 {
-	getIdFromNrBacklog(&c_top,         "mapgen_dirt_with_grass",    CONTENT_AIR);
-	getIdFromNrBacklog(&c_filler,      "mapgen_dirt",               CONTENT_AIR);
+	getIdFromNrBacklog(&c_top,         "mapgen_stone",              CONTENT_AIR);
+	getIdFromNrBacklog(&c_filler,      "mapgen_stone",              CONTENT_AIR);
 	getIdFromNrBacklog(&c_stone,       "mapgen_stone",              CONTENT_AIR);
 	getIdFromNrBacklog(&c_water_top,   "mapgen_water_source",       CONTENT_AIR);
 	getIdFromNrBacklog(&c_water,       "mapgen_water_source",       CONTENT_AIR);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -374,8 +374,8 @@ Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef)
 	Biome *b = BiomeManager::create(biometype);
 
 	b->name            = getstringfield_default(L, index, "name", "");
-	b->depth_top       = getintfield_default(L,    index, "depth_top",       1);
-	b->depth_filler    = getintfield_default(L,    index, "depth_filler",    2);
+	b->depth_top       = getintfield_default(L,    index, "depth_top",       0);
+	b->depth_filler    = getintfield_default(L,    index, "depth_filler",    -31000);
 	b->depth_water_top = getintfield_default(L,    index, "depth_water_top", 0);
 	b->y_min           = getintfield_default(L,    index, "y_min",           -31000);
 	b->y_max           = getintfield_default(L,    index, "y_max",           31000);


### PR DESCRIPTION
From my experience working with the biome API and fixing other user's biome definitions, the fallback biome and the fallback biome parameters need to be of an all-stone biome with filler disabled.

Setting filler to 0 still results in filler appearing because there is a filler depth noise added to it, users would often also leave filler undefined, so it would fallback to dirt which would then appear when not wanted. This has happened to me too.

Top and filler fallback is now stone, instead of dirt and grass, for no change to the terrain. All nodes are now base terrain nodes, reducing the number of harmless errors printed if a subgame does not have dirt or grass.
Top depth fallback is now 0.
Filler depth is kept below 0 by setting a large negative number as the fallback value, no amount of filler depth noise will make it positive.