### PR TITLE
Add count based unload limit for mapblocks

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -94,6 +94,9 @@
 #random_input = false
 #    Timeout for client to remove unused map data from memory
 #client_unload_unused_data_timeout = 600
+#    Maximum number of mapblocks for client to be kept in memory
+#    Set to -1 for unlimited amount
+#client_mapblock_limit = 1000
 #    Whether to fog out the end of the visible area
 #enable_fog = true
 #    Whether to show the client debug info (has the same effect as hitting F5)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -421,8 +421,9 @@ void Client::step(float dtime)
 		ScopeProfiler sp(g_profiler, "Client: map timer and unload");
 		std::vector<v3s16> deleted_blocks;
 		m_env.getMap().timerUpdate(map_timer_and_unload_dtime,
-				g_settings->getFloat("client_unload_unused_data_timeout"),
-				&deleted_blocks);
+			g_settings->getFloat("client_unload_unused_data_timeout"),
+			g_settings->getFloat("client_mapblock_limit"),
+			&deleted_blocks);
 
 		/*
 			Send info to server

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -104,6 +104,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("address", "");
 	settings->setDefault("random_input", "false");
 	settings->setDefault("client_unload_unused_data_timeout", "600");
+	settings->setDefault("client_mapblock_limit", "1000");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fov", "72");
 	settings->setDefault("view_bobbing", "true");

--- a/src/map.h
+++ b/src/map.h
@@ -277,7 +277,7 @@ public:
 		Updates usage timers and unloads unused blocks and sectors.
 		Saves modified blocks before unloading on MAPTYPE_SERVER.
 	*/
-	void timerUpdate(float dtime, float unload_timeout,
+	void timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 			std::vector<v3s16> *unloaded_blocks=NULL);
 
 	/*

--- a/src/mapsector.cpp
+++ b/src/mapsector.cpp
@@ -59,7 +59,7 @@ MapBlock * MapSector::getBlockBuffered(s16 y)
 	if(m_block_cache != NULL && y == m_block_cache_y){
 		return m_block_cache;
 	}
-	
+
 	// If block doesn't exist, return NULL
 	std::map<s16, MapBlock*>::iterator n = m_blocks.find(y);
 	if(n == m_blocks.end())
@@ -70,11 +70,11 @@ MapBlock * MapSector::getBlockBuffered(s16 y)
 	else{
 		block = n->second;
 	}
-	
+
 	// Cache the last result
 	m_block_cache_y = y;
 	m_block_cache = block;
-	
+
 	return block;
 }
 
@@ -88,16 +88,16 @@ MapBlock * MapSector::createBlankBlockNoInsert(s16 y)
 	assert(getBlockBuffered(y) == NULL);	// Pre-condition
 
 	v3s16 blockpos_map(m_pos.X, y, m_pos.Y);
-	
+
 	MapBlock *block = new MapBlock(m_parent, blockpos_map, m_gamedef);
-	
+
 	return block;
 }
 
 MapBlock * MapSector::createBlankBlock(s16 y)
 {
 	MapBlock *block = createBlankBlockNoInsert(y);
-	
+
 	m_blocks[y] = block;
 
 	return block;
@@ -114,7 +114,7 @@ void MapSector::insertBlock(MapBlock *block)
 
 	v2s16 p2d(block->getPos().X, block->getPos().Z);
 	assert(p2d == m_pos);
-	
+
 	// Insert into container
 	m_blocks[block_y] = block;
 }
@@ -125,7 +125,7 @@ void MapSector::deleteBlock(MapBlock *block)
 
 	// Clear from cache
 	m_block_cache = NULL;
-	
+
 	// Remove from container
 	m_blocks.erase(block_y);
 
@@ -140,6 +140,11 @@ void MapSector::getBlocks(MapBlockVect &dest)
 	{
 		dest.push_back(bi->second);
 	}
+}
+
+bool MapSector::empty()
+{
+	return m_blocks.empty();
 }
 
 /*
@@ -159,18 +164,18 @@ void ServerMapSector::serialize(std::ostream &os, u8 version)
 {
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapSector format not supported");
-	
+
 	/*
 		[0] u8 serialization version
 		+ heightmap data
 	*/
-	
+
 	// Server has both of these, no need to support not having them.
 	//assert(m_objects != NULL);
 
 	// Write version
 	os.write((char*)&version, 1);
-	
+
 	/*
 		Add stuff here, if needed
 	*/
@@ -193,18 +198,18 @@ ServerMapSector* ServerMapSector::deSerialize(
 	/*
 		Read stuff
 	*/
-	
+
 	// Read version
 	u8 version = SER_FMT_VER_INVALID;
 	is.read((char*)&version, 1);
-	
+
 	if(!ser_ver_supported(version))
 		throw VersionMismatchException("ERROR: MapSector format not supported");
-	
+
 	/*
 		Add necessary reading stuff here
 	*/
-	
+
 	/*
 		Get or create sector
 	*/

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -40,7 +40,7 @@ class IGameDef;
 class MapSector
 {
 public:
-	
+
 	MapSector(Map *parent, v2s16 pos, IGameDef *gamedef);
 	virtual ~MapSector();
 
@@ -58,16 +58,18 @@ public:
 	MapBlock * createBlankBlock(s16 y);
 
 	void insertBlock(MapBlock *block);
-	
+
 	void deleteBlock(MapBlock *block);
-	
+
 	void getBlocks(MapBlockVect &dest);
-	
+
+	bool empty();
+
 	// Always false at the moment, because sector contains no metadata.
 	bool differs_from_disk;
 
 protected:
-	
+
 	// The pile of MapBlocks
 	std::map<s16, MapBlock*> m_blocks;
 
@@ -76,12 +78,12 @@ protected:
 	v2s16 m_pos;
 
 	IGameDef *m_gamedef;
- 	
+
 	// Last-used block is cached here for quicker access.
-	// Be sure to set this to NULL when the cached block is deleted 
+	// Be sure to set this to NULL when the cached block is deleted
 	MapBlock *m_block_cache;
 	s16 m_block_cache_y;
-	
+
 	/*
 		Private methods
 	*/
@@ -94,7 +96,7 @@ class ServerMapSector : public MapSector
 public:
 	ServerMapSector(Map *parent, v2s16 pos, IGameDef *gamedef);
 	~ServerMapSector();
-	
+
 	u32 getId() const
 	{
 		return MAPSECTOR_SERVER;
@@ -106,7 +108,7 @@ public:
 	*/
 
 	void serialize(std::ostream &os, u8 version);
-	
+
 	static ServerMapSector* deSerialize(
 			std::istream &is,
 			Map *parent,
@@ -114,7 +116,7 @@ public:
 			std::map<v2s16, MapSector*> & sectors,
 			IGameDef *gamedef
 		);
-		
+
 private:
 };
 
@@ -124,7 +126,7 @@ class ClientMapSector : public MapSector
 public:
 	ClientMapSector(Map *parent, v2s16 pos, IGameDef *gamedef);
 	~ClientMapSector();
-	
+
 	u32 getId() const
 	{
 		return MAPSECTOR_CLIENT;
@@ -133,6 +135,6 @@ public:
 private:
 };
 #endif
-	
+
 #endif
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -594,7 +594,8 @@ void Server::AsyncRunStep(bool initial_step)
 		// Run Map's timers and unload unused data
 		ScopeProfiler sp(g_profiler, "Server: map timer and unload");
 		m_env->getMap().timerUpdate(map_timer_and_unload_dtime,
-				g_settings->getFloat("server_unload_unused_data_timeout"));
+			g_settings->getFloat("server_unload_unused_data_timeout"),
+			(u32)-1);
 	}
 
 	/*


### PR DESCRIPTION
Fixes the memory leak from #2653 (@ least if the theory is right). Either way, the leak should be fixed now, hard limit at 1000 blocks by default.
