### PR TITLE
SEnv: Remove static_exists from ActiveObjects in deleted blocks

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1424,6 +1424,33 @@ void ServerEnvironment::getRemovedActiveObjects(v3s16 pos, s16 radius,
 	}
 }
 
+void ServerEnvironment::setStaticForObjectsInBlock(
+	v3s16 blockpos, bool static_exists, v3s16 static_block)
+{
+	MapBlock *block = m_map->getBlockNoCreateNoEx(blockpos);
+	if (!block)
+		return;
+
+	for (std::map<u16, StaticObject>::iterator
+			so_it = block->m_static_objects.m_active.begin();
+			so_it != block->m_static_objects.m_active.end(); ++so_it) {
+		// Get the ServerActiveObject counterpart to this StaticObject
+		std::map<u16, ServerActiveObject *>::iterator ao_it;
+		ao_it = m_active_objects.find(so_it->first);
+		if (ao_it == m_active_objects.end()) {
+			// If this ever happens, there must be some kind of nasty bug.
+			errorstream << "ServerEnvironment::setStaticForObjectsInBlock(): "
+				"Object from MapBlock::m_static_objects::m_active not found "
+				"in m_active_objects";
+			continue;
+		}
+
+		ServerActiveObject *sao = ao_it->second;
+		sao->m_static_exists = static_exists;
+		sao->m_static_block  = static_block;
+	}
+}
+
 ActiveObjectMessage ServerEnvironment::getActiveObjectMessage()
 {
 	if(m_active_object_messages.empty())
@@ -1959,7 +1986,6 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 		m_active_objects.erase(*i);
 	}
 }
-
 
 #ifndef SERVER
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -327,6 +327,11 @@ public:
 
 	std::set<v3s16>* getForceloadedBlocks() { return &m_active_blocks.m_forceloaded_list; };
 
+	// Sets the static object status all the active objects in the specified block
+	// This is only really needed for deleting blocks from the map
+	void setStaticForObjectsInBlock(v3s16 blockpos,
+		bool static_exists, v3s16 static_block=v3s16(0,0,0));
+
 private:
 
 	/*

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -773,10 +773,12 @@ int ModApiEnvMod::l_delete_area(lua_State *L)
 	for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
 	for (s16 x = bpmin.X; x <= bpmax.X; x++) {
 		v3s16 bp(x, y, z);
-		if (map.deleteBlock(bp))
+		if (map.deleteBlock(bp)) {
+			env->setStaticForObjectsInBlock(bp, false);
 			event.modified_blocks.insert(bp);
-		else
+		} else {
 			success = false;
+		}
 	}
 
 	map.dispatchEvent(&event);


### PR DESCRIPTION
This fixes a potential problem where the server log could get spammed with messages about static counterparts not existing for active objects in blocks that have been deleted and regenerated.