### PR TITLE
Remove use of engine sent texture tiling flags - theyre no longer needed

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -94,7 +94,7 @@ void main(void)
 
 	// Don't generate heightmaps when too far from the eye
 	float dist = distance (vec3(0.0, 0.0 ,0.0), vPosition);
-	if (dist > 300.0) {
+	if (dist > 150.0) {
 		area_enable_parallax = 0.0;
 	}
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -385,8 +385,7 @@ public:
 
 	video::ITexture* getNormalTexture(const std::string &name);
 	video::SColor getTextureAverageColor(const std::string &name);
-	video::ITexture *getShaderFlagsTexture(
-		bool normamap_present, bool tileable_vertical, bool tileable_horizontal);
+	video::ITexture *getShaderFlagsTexture(bool normamap_present);
 
 private:
 
@@ -2054,14 +2053,11 @@ video::SColor TextureSource::getTextureAverageColor(const std::string &name)
 }
 
 
-video::ITexture *TextureSource::getShaderFlagsTexture(
-	bool normalmap_present, bool tileable_vertical, bool tileable_horizontal)
+video::ITexture *TextureSource::getShaderFlagsTexture(bool normalmap_present)
 {
 	std::string tname = "__shaderFlagsTexture";
 	tname += normalmap_present ? "1" : "0";
-	tname += tileable_horizontal ? "1" : "0";
-	tname += tileable_vertical ? "1" : "0";
-
+	
 	if (isKnownSourceImage(tname)) {
 		return getTexture(tname);
 	} else {
@@ -2069,11 +2065,7 @@ video::ITexture *TextureSource::getShaderFlagsTexture(
 		video::IImage *flags_image = driver->createImage(
 			video::ECF_A8R8G8B8, core::dimension2d<u32>(1, 1));
 		sanity_check(flags_image != NULL);
-		video::SColor c(
-			255,
-			normalmap_present ? 255 : 0,
-			tileable_horizontal ? 255 : 0,
-			tileable_vertical ? 255 : 0);
+		video::SColor c(255, normalmap_present ? 255 : 0, 0, 0);
 		flags_image->setPixel(0, 0, c);
 		insertSourceImage(tname, flags_image);
 		flags_image->drop();

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -113,8 +113,7 @@ public:
 			const TextureFromMeshParams &params)=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
-	virtual video::ITexture *getShaderFlagsTexture(bool normamap_present,
-			bool tileable_vertical, bool tileable_horizontal)=0;
+	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
 
 class IWritableTextureSource : public ITextureSource
@@ -137,8 +136,7 @@ public:
 	virtual void rebuildImagesAndTextures()=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
-	virtual video::ITexture *getShaderFlagsTexture(bool normamap_present,
-			bool tileable_vertical, bool tileable_horizontal)=0;
+	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
 
 IWritableTextureSource* createTextureSource(IrrlichtDevice *device);
@@ -218,9 +216,7 @@ struct TileSpec
 			alpha == other.alpha &&
 			material_type == other.material_type &&
 			material_flags == other.material_flags &&
-			rotation == other.rotation &&
-			(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL) &&
-			(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)
+			rotation == other.rotation
 		);
 	}
 
@@ -254,12 +250,6 @@ struct TileSpec
 		}
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING)
 			? true : false;
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-		}
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-		}
 	}
 
 	void applyMaterialOptionsWithShaders(video::SMaterial &material) const

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1012,9 +1012,7 @@ void CNodeDefManager::fillTileAttribs(ITextureSource *tsrc, TileSpec *tile,
 	if (use_normal_texture) {
 		tile->normal_texture = tsrc->getNormalTexture(tiledef->name);
 	}
-	tile->flags_texture = tsrc->getShaderFlagsTexture(
-		tile->normal_texture ? true : false,
-		tiledef->tileable_vertical, tiledef->tileable_horizontal);
+	tile->flags_texture = tsrc->getShaderFlagsTexture(tile->normal_texture ? true : false);
 
 	// Material flags
 	tile->material_flags = 0;

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -302,7 +302,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 	material.setFlag(video::EMF_USE_MIP_MAPS, false);
 #endif
 	if (m_enable_shaders) {
-		material.setTexture(2, tsrc->getShaderFlagsTexture(false, true, true));
+		material.setTexture(2, tsrc->getShaderFlagsTexture(false));
 	}
 }
 


### PR DESCRIPTION
Shaders do not have to take care of it anymore because setting material clamping flag in core is enough to fix tiling issues.