### PR TITLE
Improve custom drowning values

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3150,9 +3150,13 @@ Definition tables
         ^ Block contains level in param2. Value is default level, used for snow.
         ^ Don't forget to use "leveled" type nodebox. ]]
         liquid_range = 8, -- number of flowing nodes around source (max. 8)
-        drowning = 0, -- Player will take this amount of damage if no bubbles are left
+        drowning = 0, -- Amount of breath player loses every 2 seconds when inside [[
+		^ drowning damage can be defined via "damage_per_second"
+		]]
         light_source = 0, -- Amount of light emitted by node
-        damage_per_second = 0, -- If player is inside node, this damage is caused
+        damage_per_second = 0, -- If player is inside node, this damage is caused [[ 
+		^ If drowning > 0 and head inside only applied when breath == 0
+		]]
         node_box = {type="regular"}, -- See "Node boxes"
         mesh = "model",
         selection_box = {type="regular"}, -- See "Node boxes" --[[

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2217,77 +2217,86 @@ void ClientEnvironment::step(float dtime)
 		}
 	}
 
-	/*
-		A quick draft of lava damage
-	*/
-	if(m_lava_hurt_interval.step(dtime, 1.0))
-	{
+	if (m_node_damage_interval.step(dtime, 1.0)) {
 		v3f pf = lplayer->getPosition();
 
-		// Feet, middle and head
-		v3s16 p1 = floatToInt(pf + v3f(0, BS*0.1, 0), BS);
-		MapNode n1 = m_map->getNodeNoEx(p1);
-		v3s16 p2 = floatToInt(pf + v3f(0, BS*0.8, 0), BS);
-		MapNode n2 = m_map->getNodeNoEx(p2);
-		v3s16 p3 = floatToInt(pf + v3f(0, BS*1.6, 0), BS);
-		MapNode n3 = m_map->getNodeNoEx(p3);
+		// Notes at feet, body and head
+		v3s16 p1 = floatToInt(pf + v3f(0, BS * 0.1, 0), BS);
+		MapNode n_feet = m_map->getNodeNoEx(p1);
+		v3s16 p2 = floatToInt(pf + v3f(0, BS * 0.8, 0), BS);
+		MapNode n_body = m_map->getNodeNoEx(p2);
+		v3s16 p3 = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
+		MapNode n_head = m_map->getNodeNoEx(p3);
 
+		/*
+			Damage by drowning
+		*/
+		const ContentFeatures &f = m_gamedef->ndef()->get(n_head);
+		if (f.drowning > 0) {
+			// Use damage_per_second damage if specified
+			u32 drowning_damage = f.damage_per_second > 0 ? f.damage_per_second : 1;
+			if (lplayer->getBreath() == 0) {
+				damageLocalPlayer(drowning_damage, true);
+			}
+		}
+
+		/*
+			Damage by any other node, e.g. lava
+		*/
 		u32 damage_per_second = 0;
 		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n1).damage_per_second);
+			m_gamedef->ndef()->get(n_feet).damage_per_second);
 		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n2).damage_per_second);
-		damage_per_second = MYMAX(damage_per_second,
-				m_gamedef->ndef()->get(n3).damage_per_second);
+			m_gamedef->ndef()->get(n_feet).damage_per_second);
+		if (f.drowning == 0)
+			damage_per_second = MYMAX(damage_per_second,
+				f.damage_per_second);
 
 		if(damage_per_second != 0)
-		{
 			damageLocalPlayer(damage_per_second, true);
-		}
 	}
 
 	/*
-		Drowning
+		Breathing
 	*/
-	if(m_drowning_interval.step(dtime, 2.0))
-	{
+	
+	if (m_drowning_interval.step(dtime, 2.0)) {
 		v3f pf = lplayer->getPosition();
 
 		// head
-		v3s16 p = floatToInt(pf + v3f(0, BS*1.6, 0), BS);
+		v3s16 p = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
 		MapNode n = m_map->getNodeNoEx(p);
-		ContentFeatures c = m_gamedef->ndef()->get(n);
-		u8 drowning_damage = c.drowning;
-		if(drowning_damage > 0 && lplayer->hp > 0){
+		const ContentFeatures &f = m_gamedef->ndef()->get(n);
+		u8 breath_loss = f.drowning;
+
+		if (breath_loss > 0 && lplayer->hp > 0) {
 			u16 breath = lplayer->getBreath();
-			if(breath > 10){
+			if(breath > 10) {
 				breath = 11;
 			}
-			if(breath > 0){
-				breath -= 1;
+			if (breath > 0) {
+				if (breath_loss >= breath)
+					breath = 0;
+				else
+					breath -= breath_loss;
 			}
 			lplayer->setBreath(breath);
 			updateLocalPlayerBreath(breath);
 		}
-
-		if(lplayer->getBreath() == 0 && drowning_damage > 0){
-			damageLocalPlayer(drowning_damage, true);
-		}
 	}
-	if(m_breathing_interval.step(dtime, 0.5))
-	{
+
+	if (m_breathing_interval.step(dtime, 0.5)) {
 		v3f pf = lplayer->getPosition();
 
 		// head
-		v3s16 p = floatToInt(pf + v3f(0, BS*1.6, 0), BS);
+		v3s16 p = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
 		MapNode n = m_map->getNodeNoEx(p);
-		ContentFeatures c = m_gamedef->ndef()->get(n);
-		if (!lplayer->hp){
+		const ContentFeatures &f = m_gamedef->ndef()->get(n);
+		if (!lplayer->hp) {
 			lplayer->setBreath(11);
-		}
-		else if(c.drowning == 0){
+		} else if (f.drowning == 0) {
 			u16 breath = lplayer->getBreath();
-			if(breath <= 10){
+			if (breath <= 10) {
 				breath += 1;
 				lplayer->setBreath(breath);
 				updateLocalPlayerBreath(breath);

--- a/src/environment.h
+++ b/src/environment.h
@@ -536,7 +536,7 @@ private:
 	std::vector<ClientSimpleObject*> m_simple_objects;
 	std::list<ClientEnvEvent> m_client_event_queue;
 	IntervalLimiter m_active_object_light_update_interval;
-	IntervalLimiter m_lava_hurt_interval;
+	IntervalLimiter m_node_damage_interval;
 	IntervalLimiter m_drowning_interval;
 	IntervalLimiter m_breathing_interval;
 	std::list<std::string> m_player_names;


### PR DESCRIPTION
Allows e.g. more complex suffocation in nodes. The amount of breath lost is now specified by drowning value, while the damage is set via damage_per_second.

Explained:
If drowning = `<x>` and damage_per_second = 0 its behaves like now.
If drowning = 0 and damage_per_second = `<y>` its behaves like now.
If drowning = `<x>` and damage_per_second = `<y>` you are loosing x bubbles air every 2 seconds and get damage of y each second when breath == 0