### PR TITLE
FindJson: use PATH_SUFFIXES jsoncpp to find incdir

### DIFF
--- a/cmake/Modules/FindJson.cmake
+++ b/cmake/Modules/FindJson.cmake
@@ -8,7 +8,7 @@ option(ENABLE_SYSTEM_JSONCPP "Enable using a system-wide JSONCPP.  May cause seg
 
 if(ENABLE_SYSTEM_JSONCPP)
 	find_library(JSON_LIBRARY NAMES jsoncpp)
-	find_path(JSON_INCLUDE_DIR json/features.h)
+	find_path(JSON_INCLUDE_DIR json/features.h PATH_SUFFIXES jsoncpp)
 
 	include(FindPackageHandleStandardArgs)
 	find_package_handle_standard_args(JSONCPP DEFAULT_MSG JSON_LIBRARY JSON_INCLUDE_DIR)


### PR DESCRIPTION
For example, on Fedora systems jsoncpp headers is installed in `/usr/include/jsoncpp`.