### PR TITLE
Add seperate cache path

### DIFF
--- a/src/clientmedia.cpp
+++ b/src/clientmedia.cpp
@@ -34,7 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 static std::string getMediaCacheDir()
 {
-	return porting::path_user + DIR_DELIM + "cache" + DIR_DELIM + "media";
+	return porting::path_cache + DIR_DELIM + "media";
 }
 
 /*

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -707,5 +707,10 @@ bool safeWriteToFile(const std::string &path, const std::string &content)
 	}
 }
 
+bool Rename(const std::string &from, const std::string &to)
+{
+	return rename(from.c_str(), to.c_str()) == 0;
+}
+
 } // namespace fs
 

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -115,6 +115,8 @@ const char *GetFilenameFromPath(const char *path);
 
 bool safeWriteToFile(const std::string &path, const std::string &content);
 
+bool Rename(const std::string &from, const std::string &to);
+
 } // namespace fs
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,7 +164,13 @@ int main(int argc, char *argv[])
 	setup_log_params(cmd_args);
 
 	porting::signal_handler_init();
+
+#ifdef __ANDROID__
+	porting::initAndroid();
+	porting::initializePathsAndroid();
+#else
 	porting::initializePaths();
+#endif
 
 	if (!create_userdata_path()) {
 		errorstream << "Cannot create user data directory" << std::endl;
@@ -422,9 +428,6 @@ static bool create_userdata_path()
 	bool success;
 
 #ifdef __ANDROID__
-	porting::initAndroid();
-
-	porting::setExternalStorageDir(porting::jnienv);
 	if (!fs::PathExists(porting::path_user)) {
 		success = fs::CreateDir(porting::path_user);
 	} else {
@@ -435,9 +438,6 @@ static bool create_userdata_path()
 	// Create user data directory
 	success = fs::CreateDir(porting::path_user);
 #endif
-
-	infostream << "path_share = " << porting::path_share << std::endl;
-	infostream << "path_user  = " << porting::path_user << std::endl;
 
 	return success;
 }

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -139,6 +139,7 @@ void signal_handler_init(void)
 std::string path_share = "..";
 std::string path_user = "..";
 std::string path_locale = path_share + DIR_DELIM + "locale";
+std::string path_cache = path_user + DIR_DELIM + "cache";
 
 
 std::string getDataPath(const char *subpath)
@@ -463,6 +464,25 @@ bool setSystemPaths()
 
 #endif
 
+void migrateCachePath()
+{
+	const std::string local_cache_path = path_user + DIR_DELIM + "cache";
+
+	// Delete tmp folder if it exists (it only ever contained
+	// a temporary ogg file, which is no longer used).
+	if (fs::PathExists(local_cache_path + DIR_DELIM + "tmp"))
+		fs::RecursiveDelete(local_cache_path + DIR_DELIM + "tmp");
+
+	// Bail if migration impossible
+	if (path_cache == local_cache_path || !fs::PathExists(local_cache_path)
+			|| fs::PathExists(path_cache)) {
+		return;
+	}
+	if (!fs::Rename(local_cache_path, path_cache)) {
+		errorstream << "Failed to migrate local cache path "
+			"to system path!" << std::endl;
+	}
+}
 
 void initializePaths()
 {
@@ -513,10 +533,27 @@ void initializePaths()
 	if (!setSystemPaths())
 		errorstream << "Failed to get one or more system-wide path" << std::endl;
 
+	// Initialize path_cache
+	// First try $XDG_CACHE_HOME/PROJECT_NAME
+	const char *cache_dir = getenv("XDG_CACHE_HOME");
+	if (cache_dir) {
+		path_cache = std::string(cache_dir) + DIR_DELIM + PROJECT_NAME;
+	} else {
+		// Then try $HOME/.cache/PROJECT_NAME
+		const char *home_dir = getenv("HOME");
+		if (home_dir) {
+			path_cache = std::string(home_dir) + DIR_DELIM + ".cache"
+				+ DIR_DELIM + PROJECT_NAME;
+		}
+		// If neither works, leave it at $PATH_USER/cache
+	}
+	// Migrate cache folder to new location if possible
+	migrateCachePath();
 #endif
 
 	infostream << "Detected share path: " << path_share << std::endl;
 	infostream << "Detected user path: " << path_user << std::endl;
+	infostream << "Detected cache path: " << path_cache << std::endl;
 
 	bool found_localedir = false;
 #ifdef STATIC_LOCALEDIR
@@ -542,7 +579,6 @@ void initializePaths()
 	if (!found_localedir) {
 		errorstream << "Couldn't find a locale directory!" << std::endl;
 	}
-
 }
 
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -148,10 +148,21 @@ extern std::string path_user;
 extern std::string path_locale;
 
 /*
+	Path to directory for storing caches.
+*/
+extern std::string path_cache;
+
+/*
 	Get full path of stuff in data directory.
 	Example: "stone.png" -> "../data/stone.png"
 */
 std::string getDataPath(const char *subpath);
+
+/*
+	Move cache folder from path_user to the
+	system cache location if possible.
+*/
+void migrateCachePath();
 
 /*
 	Initialize path_*.

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -43,10 +43,10 @@ void initAndroid();
 void cleanupAndroid();
 
 /**
- * set storage dir on external sdcard#
- * @param lJNIEnv environment from android
+ * Initializes path_* variables for Android
+ * @param env Android JNI environment
  */
-void setExternalStorageDir(JNIEnv* lJNIEnv);
+void initializePathsAndroid();
 
 /**
  * use java function to copy media from assets to external storage


### PR DESCRIPTION
This is set to the XDG cache path where possible (as discussed in #864).
It's set to the app's cache path on Android (fixes part of #2097 and adds to #2966).

I compiled this for Android but haven't tested it on that platform yet.