### PR TITLE
Push error handler afresh each time lua_pcall is used

### DIFF
--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -136,28 +136,28 @@ void script_run_callbacks_f(lua_State *L, int nargs,
 	FATAL_ERROR_IF(lua_gettop(L) < nargs + 1, "Not enough arguments");
 
 	// Insert error handler
-	lua_pushcfunction(L, script_error_handler);
-	int errorhandler = lua_gettop(L) - nargs - 1;
-	lua_insert(L, errorhandler);
+	PUSH_ERROR_HANDLER(L);
+	int error_handler = lua_gettop(L) - nargs - 1;
+	lua_insert(L, error_handler);
 
 	// Insert run_callbacks between error handler and table
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "run_callbacks");
 	lua_remove(L, -2);
-	lua_insert(L, errorhandler + 1);
+	lua_insert(L, error_handler + 1);
 
 	// Insert mode after table
 	lua_pushnumber(L, (int) mode);
-	lua_insert(L, errorhandler + 3);
+	lua_insert(L, error_handler + 3);
 
 	// Stack now looks like this:
 	// ... <error handler> <run_callbacks> <table> <mode> <arg#1> <arg#2> ... <arg#n>
 
-	int result = lua_pcall(L, nargs + 2, 1, errorhandler);
+	int result = lua_pcall(L, nargs + 2, 1, error_handler);
 	if (result != 0)
 		script_error(L, result, NULL, fxn);
 
-	lua_remove(L, -2); // Remove error handler
+	lua_remove(L, error_handler);
 }
 
 void log_deprecated(lua_State *L, const std::string &message)

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -34,6 +34,27 @@ extern "C" {
 
 #include "common/c_types.h"
 
+
+/*
+	Define our custom indices into the Lua registry table.
+
+	Lua 5.2 and above define the LUA_RIDX_LAST macro. Only numbers above that
+	may be used for custom indices, anything else is reserved.
+
+	Lua 5.1 / LuaJIT do not use any numeric indices (only string indices),
+	so we can use numeric indices freely.
+*/
+#ifdef LUA_RIDX_LAST
+#define CUSTOM_RIDX_BASE ((LUA_RIDX_LAST)+1)
+#else
+#define CUSTOM_RIDX_BASE 1
+#endif
+
+#define CUSTOM_RIDX_SCRIPTAPI           (CUSTOM_RIDX_BASE)
+#define CUSTOM_RIDX_GLOBALS_BACKUP      (CUSTOM_RIDX_BASE + 1)
+#define CUSTOM_RIDX_CURRENT_MOD_NAME    (CUSTOM_RIDX_BASE + 2)
+
+
 #define PCALL_RESL(L, RES) do {                         \
 	int result_ = (RES);                                \
 	if (result_ != 0) {                                 \

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -53,7 +53,11 @@ extern "C" {
 #define CUSTOM_RIDX_SCRIPTAPI           (CUSTOM_RIDX_BASE)
 #define CUSTOM_RIDX_GLOBALS_BACKUP      (CUSTOM_RIDX_BASE + 1)
 #define CUSTOM_RIDX_CURRENT_MOD_NAME    (CUSTOM_RIDX_BASE + 2)
+#define CUSTOM_RIDX_ERROR_HANDLER       (CUSTOM_RIDX_BASE + 3)
 
+// Pushes the error handler onto the stack and returns its index
+#define PUSH_ERROR_HANDLER(L) \
+	(lua_rawgeti((L), LUA_REGISTRYINDEX, CUSTOM_RIDX_ERROR_HANDLER), lua_gettop((L)))
 
 #define PCALL_RESL(L, RES) do {                         \
 	int result_ = (RES);                                \

--- a/src/script/cpp_api/s_async.h
+++ b/src/script/cpp_api/s_async.h
@@ -95,9 +95,8 @@ public:
 	 * Engine step to process finished jobs
 	 *   the engine step is one way to pass events back, PushFinishedJobs another
 	 * @param L The Lua stack
-	 * @param errorhandler Stack index of the Lua error handler
 	 */
-	void step(lua_State *L, int errorhandler);
+	void step(lua_State *L);
 
 	/**
 	 * Push a list of finished jobs onto the stack

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -52,13 +52,13 @@ public:
 	{
 		// Store current mod name in registry
 		lua_pushstring(L, mod_name.c_str());
-		lua_setfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+		lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	}
 	~ModNameStorer()
 	{
 		// Clear current mod name from registry
 		lua_pushnil(L);
-		lua_setfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+		lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	}
 };
 
@@ -84,7 +84,7 @@ ScriptApiBase::ScriptApiBase()
 
 	// Make the ScriptApiBase* accessible to ModApiBase
 	lua_pushlightuserdata(m_luastack, this);
-	lua_setfield(m_luastack, LUA_REGISTRYINDEX, "scriptapi");
+	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
 	// If we are using LuaJIT add a C++ wrapper function to catch
 	// exceptions thrown in Lua -> C++ calls

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -78,13 +78,13 @@ ScriptApiBase::ScriptApiBase()
 
 	luaL_openlibs(m_luastack);
 
-	// Add and save an error handler
-	lua_pushcfunction(m_luastack, script_error_handler);
-	m_errorhandler = lua_gettop(m_luastack);
-
 	// Make the ScriptApiBase* accessible to ModApiBase
 	lua_pushlightuserdata(m_luastack, this);
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
+
+	// Add and save an error handler
+	lua_pushcfunction(m_luastack, script_error_handler);
+	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_ERROR_HANDLER);
 
 	// If we are using LuaJIT add a C++ wrapper function to catch
 	// exceptions thrown in Lua -> C++ calls
@@ -133,13 +133,15 @@ bool ScriptApiBase::loadScript(const std::string &script_path, std::string *erro
 
 	lua_State *L = getStack();
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	bool ok;
 	if (m_secure) {
 		ok = ScriptApiSecurity::safeLoadFile(L, script_path.c_str());
 	} else {
 		ok = !luaL_loadfile(L, script_path.c_str());
 	}
-	ok = ok && !lua_pcall(L, 0, 0, m_errorhandler);
+	ok = ok && !lua_pcall(L, 0, 0, error_handler);
 	if (!ok) {
 		std::string error_msg = lua_tostring(L, -1);
 		if (error)
@@ -150,9 +152,9 @@ bool ScriptApiBase::loadScript(const std::string &script_path, std::string *erro
 			<< error_msg << std::endl << std::endl
 			<< "======= END OF ERROR FROM LUA ========" << std::endl;
 		lua_pop(L, 1); // Pop error message from stack
-		return false;
 	}
-	return true;
+	lua_pop(L, 1); // Pop error handler
+	return ok;
 }
 
 // Push the list of callbacks (a lua table).
@@ -168,28 +170,28 @@ void ScriptApiBase::runCallbacksRaw(int nargs,
 	FATAL_ERROR_IF(lua_gettop(L) < nargs + 1, "Not enough arguments");
 
 	// Insert error handler
-	lua_pushcfunction(L, script_error_handler);
-	int errorhandler = lua_gettop(L) - nargs - 1;
-	lua_insert(L, errorhandler);
+	PUSH_ERROR_HANDLER(L);
+	int error_handler = lua_gettop(L) - nargs - 1;
+	lua_insert(L, error_handler);
 
 	// Insert run_callbacks between error handler and table
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "run_callbacks");
 	lua_remove(L, -2);
-	lua_insert(L, errorhandler + 1);
+	lua_insert(L, error_handler + 1);
 
 	// Insert mode after table
 	lua_pushnumber(L, (int)mode);
-	lua_insert(L, errorhandler + 3);
+	lua_insert(L, error_handler + 3);
 
 	// Stack now looks like this:
 	// ... <error handler> <run_callbacks> <table> <mode> <arg#1> <arg#2> ... <arg#n>
 
-	int result = lua_pcall(L, nargs + 2, 1, errorhandler);
+	int result = lua_pcall(L, nargs + 2, 1, error_handler);
 	if (result != 0)
 		scriptError(result, fxn);
 
-	lua_remove(L, -2); // Remove error handler
+	lua_remove(L, error_handler);
 }
 
 void ScriptApiBase::realityCheck()

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -36,7 +36,6 @@ extern "C" {
 #define SCRIPTAPI_LOCK_DEBUG
 #define SCRIPTAPI_DEBUG
 
-#define SCRIPT_MOD_NAME_FIELD "current_mod_name"
 // MUST be an invalid mod name so that mods can't
 // use that name to bypass security!
 #define BUILTIN_MOD_NAME "*builtin*"

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -109,8 +109,6 @@ protected:
 
 	Mutex           m_luastackmutex;
 	std::string     m_last_run_mod;
-	// Stack index of Lua error handler
-	int             m_errorhandler;
 	bool            m_secure;
 #ifdef SCRIPTAPI_LOCK_DEBUG
 	bool            m_locked;

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -80,6 +80,8 @@ void ScriptApiEntity::luaentity_Activate(u16 id,
 
 	verbosestream << "scriptapi_luaentity_activate: id=" << id << std::endl;
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Get core.luaentities[id]
 	luaentity_get(L, id);
 	int object = lua_gettop(L);
@@ -93,11 +95,11 @@ void ScriptApiEntity::luaentity_Activate(u16 id,
 		lua_pushinteger(L, dtime_s);
 
 		setOriginFromTable(object);
-		PCALL_RES(lua_pcall(L, 3, 0, m_errorhandler));
+		PCALL_RES(lua_pcall(L, 3, 0, error_handler));
 	} else {
 		lua_pop(L, 1);
 	}
-	lua_pop(L, 1); // Pop object
+	lua_pop(L, 2); // Pop object and error handler
 }
 
 void ScriptApiEntity::luaentity_Remove(u16 id)
@@ -126,6 +128,8 @@ std::string ScriptApiEntity::luaentity_GetStaticdata(u16 id)
 
 	//infostream<<"scriptapi_luaentity_get_staticdata: id="<<id<<std::endl;
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Get core.luaentities[id]
 	luaentity_get(L, id);
 	int object = lua_gettop(L);
@@ -140,9 +144,10 @@ std::string ScriptApiEntity::luaentity_GetStaticdata(u16 id)
 	lua_pushvalue(L, object); // self
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 1, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 1, error_handler));
 
-	lua_remove(L, object); // Remove object
+	lua_remove(L, object);
+	lua_remove(L, error_handler);
 
 	size_t len = 0;
 	const char *s = lua_tolstring(L, -1, &len);
@@ -196,6 +201,8 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Get core.luaentities[id]
 	luaentity_get(L, id);
 	int object = lua_gettop(L);
@@ -211,9 +218,9 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 	lua_pushnumber(L, dtime); // dtime
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 2, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
 
-	lua_pop(L, 1); // Pop object
+	lua_pop(L, 2); // Pop object and error handler
 }
 
 // Calls entity:on_punch(ObjectRef puncher, time_from_last_punch,
@@ -225,6 +232,8 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 	SCRIPTAPI_PRECHECKHEADER
 
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get core.luaentities[id]
 	luaentity_get(L,id);
@@ -244,9 +253,9 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 	push_v3f(L, dir);
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 5, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
 
-	lua_pop(L, 1); // Pop object
+	lua_pop(L, 2); // Pop object and error handler
 }
 
 // Calls entity:on_rightclick(ObjectRef clicker)
@@ -256,6 +265,8 @@ void ScriptApiEntity::luaentity_Rightclick(u16 id,
 	SCRIPTAPI_PRECHECKHEADER
 
 	//infostream<<"scriptapi_luaentity_step: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get core.luaentities[id]
 	luaentity_get(L, id);
@@ -272,8 +283,8 @@ void ScriptApiEntity::luaentity_Rightclick(u16 id,
 	objectrefGetOrCreate(L, clicker); // Clicker reference
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 2, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
 
-	lua_pop(L, 1); // Pop object
+	lua_pop(L, 2); // Pop object and error handler
 }
 

--- a/src/script/cpp_api/s_inventory.cpp
+++ b/src/script/cpp_api/s_inventory.cpp
@@ -33,6 +33,8 @@ int ScriptApiDetached::detached_inventory_AllowMove(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "allow_move"))
 		return count;
@@ -48,11 +50,11 @@ int ScriptApiDetached::detached_inventory_AllowMove(
 	lua_pushinteger(L, to_index + 1);     // to_index
 	lua_pushinteger(L, count);            // count
 	objectrefGetOrCreate(L, player);      // player
-	PCALL_RES(lua_pcall(L, 7, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 7, 1, error_handler));
 	if(!lua_isnumber(L, -1))
 		throw LuaError("allow_move should return a number. name=" + name);
 	int ret = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return ret;
 }
 
@@ -63,6 +65,8 @@ int ScriptApiDetached::detached_inventory_AllowPut(
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "allow_put"))
@@ -76,11 +80,11 @@ int ScriptApiDetached::detached_inventory_AllowPut(
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 1, error_handler));
 	if (!lua_isnumber(L, -1))
 		throw LuaError("allow_put should return a number. name=" + name);
 	int ret = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return ret;
 }
 
@@ -91,6 +95,8 @@ int ScriptApiDetached::detached_inventory_AllowTake(
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "allow_take"))
@@ -104,11 +110,11 @@ int ScriptApiDetached::detached_inventory_AllowTake(
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 1, error_handler));
 	if (!lua_isnumber(L, -1))
 		throw LuaError("allow_take should return a number. name=" + name);
 	int ret = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return ret;
 }
 
@@ -120,6 +126,8 @@ void ScriptApiDetached::detached_inventory_OnMove(
 		int count, ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "on_move"))
@@ -136,7 +144,8 @@ void ScriptApiDetached::detached_inventory_OnMove(
 	lua_pushinteger(L, to_index + 1);     // to_index
 	lua_pushinteger(L, count);            // count
 	objectrefGetOrCreate(L, player);      // player
-	PCALL_RES(lua_pcall(L, 7, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 7, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 // Report put items
@@ -146,6 +155,8 @@ void ScriptApiDetached::detached_inventory_OnPut(
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "on_put"))
@@ -160,7 +171,8 @@ void ScriptApiDetached::detached_inventory_OnPut(
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 // Report taken items
@@ -170,6 +182,8 @@ void ScriptApiDetached::detached_inventory_OnTake(
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getDetachedInventoryCallback(name, "on_take"))
@@ -184,7 +198,8 @@ void ScriptApiDetached::detached_inventory_OnTake(
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 // Retrieves core.detached_inventories[name][callbackname]

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -34,6 +34,8 @@ bool ScriptApiItem::item_OnDrop(ItemStack &item,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Push callback function on stack
 	if (!getItemCallback(item.name.c_str(), "on_drop"))
 		return false;
@@ -42,7 +44,7 @@ bool ScriptApiItem::item_OnDrop(ItemStack &item,
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, dropper);
 	pushFloatPos(L, pos);
-	PCALL_RES(lua_pcall(L, 3, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 3, 1, error_handler));
 	if (!lua_isnil(L, -1)) {
 		try {
 			item = read_item(L,-1, getServer());
@@ -50,7 +52,7 @@ bool ScriptApiItem::item_OnDrop(ItemStack &item,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
-	lua_pop(L, 1);  // Pop item
+	lua_pop(L, 2);  // Pop item and error handler
 	return true;
 }
 
@@ -58,6 +60,8 @@ bool ScriptApiItem::item_OnPlace(ItemStack &item,
 		ServerActiveObject *placer, const PointedThing &pointed)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getItemCallback(item.name.c_str(), "on_place"))
@@ -67,7 +71,7 @@ bool ScriptApiItem::item_OnPlace(ItemStack &item,
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, placer);
 	pushPointedThing(pointed);
-	PCALL_RES(lua_pcall(L, 3, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 3, 1, error_handler));
 	if (!lua_isnil(L, -1)) {
 		try {
 			item = read_item(L,-1, getServer());
@@ -75,7 +79,7 @@ bool ScriptApiItem::item_OnPlace(ItemStack &item,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
-	lua_pop(L, 1);  // Pop item
+	lua_pop(L, 2);  // Pop item and error handler
 	return true;
 }
 
@@ -83,6 +87,8 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 		ServerActiveObject *user, const PointedThing &pointed)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Push callback function on stack
 	if (!getItemCallback(item.name.c_str(), "on_use"))
@@ -92,7 +98,7 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);
 	pushPointedThing(pointed);
-	PCALL_RES(lua_pcall(L, 3, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 3, 1, error_handler));
 	if(!lua_isnil(L, -1)) {
 		try {
 			item = read_item(L,-1, getServer());
@@ -100,7 +106,7 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
-	lua_pop(L, 1);  // Pop item
+	lua_pop(L, 2);  // Pop item and error handler
 	return true;
 }
 
@@ -108,6 +114,8 @@ bool ScriptApiItem::item_OnCraft(ItemStack &item, ServerActiveObject *user,
 		const InventoryList *old_craft_grid, const InventoryLocation &craft_inv)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "on_craft");
@@ -122,7 +130,7 @@ bool ScriptApiItem::item_OnCraft(ItemStack &item, ServerActiveObject *user,
 	push_items(L, items);
 
 	InvRef::create(L, craft_inv);
-	PCALL_RES(lua_pcall(L, 4, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 4, 1, error_handler));
 	if (!lua_isnil(L, -1)) {
 		try {
 			item = read_item(L,-1, getServer());
@@ -130,7 +138,7 @@ bool ScriptApiItem::item_OnCraft(ItemStack &item, ServerActiveObject *user,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
-	lua_pop(L, 1);  // Pop item
+	lua_pop(L, 2);  // Pop item and error handler
 	return true;
 }
 
@@ -138,6 +146,8 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 		const InventoryList *old_craft_grid, const InventoryLocation &craft_inv)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "craft_predict");
@@ -152,7 +162,7 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 	push_items(L, items);
 
 	InvRef::create(L, craft_inv);
-	PCALL_RES(lua_pcall(L, 4, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 4, 1, error_handler));
 	if (!lua_isnil(L, -1)) {
 		try {
 			item = read_item(L,-1, getServer());
@@ -160,7 +170,7 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
-	lua_pop(L, 1);  // Pop item
+	lua_pop(L, 2);  // Pop item and error handler
 	return true;
 }
 

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -43,6 +43,8 @@ void ScriptApiMainMenu::handleMainMenuEvent(std::string text)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Get handler function
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "event_handler");
@@ -55,12 +57,15 @@ void ScriptApiMainMenu::handleMainMenuEvent(std::string text)
 
 	// Call it
 	lua_pushstring(L, text.c_str());
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 void ScriptApiMainMenu::handleMainMenuButtons(const StringMap &fields)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get handler function
 	lua_getglobal(L, "core");
@@ -84,6 +89,7 @@ void ScriptApiMainMenu::handleMainMenuButtons(const StringMap &fields)
 	}
 
 	// Call it
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -95,6 +95,8 @@ bool ScriptApiNode::node_on_punch(v3s16 p, MapNode node,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	INodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
@@ -106,7 +108,8 @@ bool ScriptApiNode::node_on_punch(v3s16 p, MapNode node,
 	pushnode(L, node, ndef);
 	objectrefGetOrCreate(L, puncher);
 	pushPointedThing(pointed);
-	PCALL_RES(lua_pcall(L, 4, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 4, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 	return true;
 }
 
@@ -114,6 +117,8 @@ bool ScriptApiNode::node_on_dig(v3s16 p, MapNode node,
 		ServerActiveObject *digger)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -125,13 +130,16 @@ bool ScriptApiNode::node_on_dig(v3s16 p, MapNode node,
 	push_v3s16(L, p);
 	pushnode(L, node, ndef);
 	objectrefGetOrCreate(L, digger);
-	PCALL_RES(lua_pcall(L, 3, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 3, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 	return true;
 }
 
 void ScriptApiNode::node_on_construct(v3s16 p, MapNode node)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -141,12 +149,15 @@ void ScriptApiNode::node_on_construct(v3s16 p, MapNode node)
 
 	// Call function
 	push_v3s16(L, p);
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 void ScriptApiNode::node_on_destruct(v3s16 p, MapNode node)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -156,12 +167,15 @@ void ScriptApiNode::node_on_destruct(v3s16 p, MapNode node)
 
 	// Call function
 	push_v3s16(L, p);
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 void ScriptApiNode::node_after_destruct(v3s16 p, MapNode node)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -172,12 +186,15 @@ void ScriptApiNode::node_after_destruct(v3s16 p, MapNode node)
 	// Call function
 	push_v3s16(L, p);
 	pushnode(L, node, ndef);
-	PCALL_RES(lua_pcall(L, 2, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 bool ScriptApiNode::node_on_timer(v3s16 p, MapNode node, f32 dtime)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -188,7 +205,8 @@ bool ScriptApiNode::node_on_timer(v3s16 p, MapNode node, f32 dtime)
 	// Call function
 	push_v3s16(L, p);
 	lua_pushnumber(L,dtime);
-	PCALL_RES(lua_pcall(L, 2, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
+	lua_remove(L, error_handler);
 	return (bool) lua_isboolean(L, -1) && (bool) lua_toboolean(L, -1) == true;
 }
 
@@ -198,6 +216,8 @@ void ScriptApiNode::node_on_receive_fields(v3s16 p,
 		ServerActiveObject *sender)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -223,23 +243,30 @@ void ScriptApiNode::node_on_receive_fields(v3s16 p,
 		lua_settable(L, -3);
 	}
 	objectrefGetOrCreate(L, sender);        // player
-	PCALL_RES(lua_pcall(L, 4, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 4, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 void ScriptApiNode::node_falling_update(v3s16 p)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	lua_getglobal(L, "nodeupdate");
 	push_v3s16(L, p);
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 void ScriptApiNode::node_falling_update_single(v3s16 p)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	lua_getglobal(L, "nodeupdate_single");
 	push_v3s16(L, p);
-	PCALL_RES(lua_pcall(L, 1, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }

--- a/src/script/cpp_api/s_nodemeta.cpp
+++ b/src/script/cpp_api/s_nodemeta.cpp
@@ -34,6 +34,8 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowMove(v3s16 p,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	INodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
@@ -54,12 +56,12 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowMove(v3s16 p,
 	lua_pushinteger(L, to_index + 1);     // to_index
 	lua_pushinteger(L, count);            // count
 	objectrefGetOrCreate(L, player);      // player
-	PCALL_RES(lua_pcall(L, 7, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 7, 1, error_handler));
 	if (!lua_isnumber(L, -1))
 		throw LuaError("allow_metadata_inventory_move should"
 				" return a number, guilty node: " + nodename);
 	int num = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return num;
 }
 
@@ -70,6 +72,8 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowPut(v3s16 p,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+	
 	INodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
@@ -88,12 +92,12 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowPut(v3s16 p,
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 1, error_handler));
 	if(!lua_isnumber(L, -1))
 		throw LuaError("allow_metadata_inventory_put should"
 				" return a number, guilty node: " + nodename);
 	int num = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return num;
 }
 
@@ -103,6 +107,8 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowTake(v3s16 p,
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -122,12 +128,12 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowTake(v3s16 p,
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 1, error_handler));
 	if (!lua_isnumber(L, -1))
 		throw LuaError("allow_metadata_inventory_take should"
 				" return a number, guilty node: " + nodename);
 	int num = luaL_checkinteger(L, -1);
-	lua_pop(L, 1); // Pop integer
+	lua_pop(L, 2); // Pop integer and error handler
 	return num;
 }
 
@@ -138,6 +144,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnMove(v3s16 p,
 		int count, ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -159,7 +167,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnMove(v3s16 p,
 	lua_pushinteger(L, to_index + 1);     // to_index
 	lua_pushinteger(L, count);            // count
 	objectrefGetOrCreate(L, player);      // player
-	PCALL_RES(lua_pcall(L, 7, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 7, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 // Report put items
@@ -168,6 +177,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnPut(v3s16 p,
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -187,7 +198,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnPut(v3s16 p,
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 // Report taken items
@@ -196,6 +208,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnTake(v3s16 p,
 		ServerActiveObject *player)
 {
 	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	INodeDefManager *ndef = getServer()->ndef();
 
@@ -215,7 +229,8 @@ void ScriptApiNodemeta::nodemeta_inventory_OnTake(v3s16 p,
 	lua_pushinteger(L, index + 1);       // index
 	LuaItemStack::create(L, stack);      // stack
 	objectrefGetOrCreate(L, player);     // player
-	PCALL_RES(lua_pcall(L, 5, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
+	lua_pop(L, 1);  // Pop error handler
 }
 
 ScriptApiNodemeta::ScriptApiNodemeta()

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -74,6 +74,8 @@ s16 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
 	// Get core.registered_on_player_hpchange
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_player_hpchange");
@@ -81,9 +83,9 @@ s16 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
 
 	objectrefGetOrCreate(L, player);
 	lua_pushnumber(L, hp_change);
-	PCALL_RES(lua_pcall(L, 2, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
 	hp_change = lua_tointeger(L, -1);
-	lua_pop(L, -1);
+	lua_pop(L, 2); // Pop result and error handler
 	return hp_change;
 }
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -47,7 +47,7 @@ static inline void copy_safe(lua_State *L, const char *list[], unsigned len, int
 // Pushes the original version of a library function on the stack, from the old version
 static inline void push_original(lua_State *L, const char *lib, const char *func)
 {
-	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 	lua_getfield(L, -1, lib);
 	lua_remove(L, -2);  // Remove globals_backup
 	lua_getfield(L, -1, func);
@@ -143,7 +143,7 @@ void ScriptApiSecurity::initializeSecurity()
 
 	// Backup globals to the registry
 	lua_getglobal(L, "_G");
-	lua_setfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 
 	// Replace the global environment with an empty one
 #if LUA_VERSION_NUM <= 501
@@ -165,7 +165,7 @@ void ScriptApiSecurity::initializeSecurity()
 #endif
 
 	// Get old globals
-	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 	int old_globals = lua_gettop(L);
 
 
@@ -241,7 +241,7 @@ void ScriptApiSecurity::initializeSecurity()
 
 bool ScriptApiSecurity::isSecure(lua_State *L)
 {
-	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 	bool secure = !lua_isnil(L, -1);
 	lua_pop(L, 1);
 	return secure;
@@ -356,7 +356,7 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path)
 	if (!removed.empty()) abs_path += DIR_DELIM + removed;
 
 	// Get server from registry
-	lua_getfield(L, LUA_REGISTRYINDEX, "scriptapi");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
 	lua_pop(L, 1);
 	const Server *server = script->getServer();
@@ -364,7 +364,7 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path)
 	if (!server) return false;
 
 	// Get mod name
-	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	if (lua_isstring(L, -1)) {
 		std::string mod_name = lua_tostring(L, -1);
 

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -27,13 +27,15 @@ bool ScriptApiServer::getAuth(const std::string &playername,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
 	getAuthHandler();
 	lua_getfield(L, -1, "get_auth");
 	if (lua_type(L, -1) != LUA_TFUNCTION)
 		throw LuaError("Authentication handler missing get_auth");
 	lua_pushstring(L, playername.c_str());
-	PCALL_RES(lua_pcall(L, 1, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 1, 1, error_handler));
 	lua_remove(L, -2); // Remove auth handler
+	lua_remove(L, error_handler);
 
 	// nil = login not allowed
 	if (lua_isnil(L, -1))
@@ -99,6 +101,7 @@ void ScriptApiServer::createAuth(const std::string &playername,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
 	getAuthHandler();
 	lua_getfield(L, -1, "create_auth");
 	lua_remove(L, -2); // Remove auth handler
@@ -106,7 +109,8 @@ void ScriptApiServer::createAuth(const std::string &playername,
 		throw LuaError("Authentication handler missing create_auth");
 	lua_pushstring(L, playername.c_str());
 	lua_pushstring(L, password.c_str());
-	PCALL_RES(lua_pcall(L, 2, 0, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+	lua_pop(L, 1); // Pop error handler
 }
 
 bool ScriptApiServer::setPassword(const std::string &playername,
@@ -114,6 +118,7 @@ bool ScriptApiServer::setPassword(const std::string &playername,
 {
 	SCRIPTAPI_PRECHECKHEADER
 
+	int error_handler = PUSH_ERROR_HANDLER(L);
 	getAuthHandler();
 	lua_getfield(L, -1, "set_password");
 	lua_remove(L, -2); // Remove auth handler
@@ -121,7 +126,8 @@ bool ScriptApiServer::setPassword(const std::string &playername,
 		throw LuaError("Authentication handler missing set_password");
 	lua_pushstring(L, playername.c_str());
 	lua_pushstring(L, password.c_str());
-	PCALL_RES(lua_pcall(L, 2, 1, m_errorhandler));
+	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
+	lua_remove(L, error_handler);
 	return lua_toboolean(L, -1);
 }
 

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 ScriptApiBase *ModApiBase::getScriptApiBase(lua_State *L)
 {
 	// Get server from registry
-	lua_getfield(L, LUA_REGISTRYINDEX, "scriptapi");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 	ScriptApiBase *sapi_ptr = (ScriptApiBase*) lua_touserdata(L, -1);
 	lua_pop(L, 1);
 	return sapi_ptr;
@@ -49,7 +49,7 @@ GUIEngine *ModApiBase::getGuiEngine(lua_State *L)
 
 std::string ModApiBase::getCurrentModPath(lua_State *L)
 {
-	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	const char *current_mod_name = lua_tostring(L, -1);
 	if (!current_mod_name)
 		return ".";

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -52,8 +52,7 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 	sanity_check(lua_checkstack(L, 20));
 	StackUnroller stack_unroller(L);
 
-	lua_pushcfunction(L, script_error_handler);
-	int errorhandler = lua_gettop(L);
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get registered_abms
 	lua_getglobal(L, "core");
@@ -80,7 +79,7 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 	lua_pushnumber(L, active_object_count);
 	lua_pushnumber(L, active_object_count_wider);
 
-	int result = lua_pcall(L, 4, 0, errorhandler);
+	int result = lua_pcall(L, 4, 0, error_handler);
 	if (result)
 		scriptIface->scriptError(result, "LuaABM::trigger");
 
@@ -412,8 +411,7 @@ int ModApiEnvMod::l_add_item(lua_State *L)
 	if(item.empty() || !item.isKnown(getServer(L)->idef()))
 		return 0;
 
-	lua_pushcfunction(L, script_error_handler);
-	int errorhandler = lua_gettop(L);
+	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Use spawn_item to spawn a __builtin:item
 	lua_getglobal(L, "core");
@@ -424,9 +422,9 @@ int ModApiEnvMod::l_add_item(lua_State *L)
 	lua_pushvalue(L, 1);
 	lua_pushstring(L, item.getItemString().c_str());
 
-	PCALL_RESL(L, lua_pcall(L, 2, 1, errorhandler));
+	PCALL_RESL(L, lua_pcall(L, 2, 1, error_handler));
 
-	lua_remove(L, errorhandler); // Remove error handler
+	lua_remove(L, error_handler);
 	return 1;
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -345,7 +345,7 @@ int ModApiServer::l_show_formspec(lua_State *L)
 int ModApiServer::l_get_current_modname(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	return 1;
 }
 
@@ -442,7 +442,7 @@ int ModApiServer::l_notify_authentication_modified(lua_State *L)
 int ModApiServer::l_get_last_run_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	const char *current_mod = lua_tostring(L, -1);
 	if (current_mod == NULL || current_mod[0] == '\0') {
 		lua_pop(L, 1);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -371,7 +371,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 		lua_getglobal(L, "_G");
 		return 1;
 	}
-	lua_getfield(L, LUA_REGISTRYINDEX, SCRIPT_MOD_NAME_FIELD);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
 	if (!lua_isstring(L, -1)) {
 		lua_pushnil(L);
 		return 1;
@@ -383,7 +383,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 		lua_pushnil(L);
 		return 1;
 	}
-	lua_getfield(L, LUA_REGISTRYINDEX, "globals_backup");
+	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 	return 1;
 }
 

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -78,7 +78,7 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 
 /******************************************************************************/
 void MainMenuScripting::step() {
-	asyncEngine.step(getStack(), m_errorhandler);
+	asyncEngine.step(getStack());
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes "double fault" / "error in error handling" messages (issue #1423) and instead show a complete backtrace.

Related to  #3011 and #3024.

The purpose of the first commit is to speed up LUA_REGISTRYINDEX usage.