### PR TITLE
Dungeongen: Remove floating stone rings

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -516,18 +516,19 @@
 #    Mapgen stuff
 #
 
-#    Name of map generator to be used.  Currently supported: v5, v6, v7, singlenode.
+#    Name of map generator to be used.
+#    Currently supported: v5, v6, v7, singlenode.
 #mg_name = v6
 #    Water surface level of map
 #water_level = 1
 #    Size of chunks to be generated, stated in mapblocks (16 nodes)
 #chunksize = 5
-#    Global map generation attributes.  Currently supported: trees, caves, flat, dungeons, light.
+#    Global map generation attributes.
+#    Currently supported: trees, caves, flat, dungeons, light.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    To explicitly turn off a flag, prepend "no" to the beginning, e.g. nolight.
+#    'trees' and 'flat' flags only have effect in mgv6.
 #mg_flags = trees, caves, dungeons, light
-#    Enable/disable floating dungeons and dungeon slices
-#enable_floating_dungeons = true
 
 #    Map generation attributes specific to Mapgen V6.
 #    Currently supported: jungles, biomeblend, mudflow, snowbiomes.
@@ -540,11 +541,13 @@
 
 #    Map generation attributes specific to Mapgen V7.
 #    Currently supported: mountains, ridges.
+#    'ridges' are the rivers.
 #mgv7_spflags = mountains, ridges
 
 #    Perlin noise attributes for different map generation parameters.
 #    Noise parameters can be specified as a set of positional values:
 #    Offset, scale, (spread factors), seed offset, number of octaves, persistence, lacunarity.
+#    For example:
 #mgv6_np_terrain_base = -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0
 #    Or the new group format can be used instead, for example:
 #mgv6_np_terrain_base = {

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -312,7 +312,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "dungeons");
 	settings->setDefault("mgv6_spflags", "jungles, snowbiomes");
-	settings->setDefault("enable_floating_dungeons", "true");
 
 	// IPv6
 	settings->setDefault("enable_ipv6", "true");

--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -80,17 +80,14 @@ void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax)
 	// Dungeon generator doesn't modify places which have this set
 	vm->clearFlag(VMANIP_FLAG_DUNGEON_INSIDE | VMANIP_FLAG_DUNGEON_PRESERVE);
 
-	bool no_float = !g_settings->getBool("enable_floating_dungeons");
-
-	// Set all air and water (and optionally ignore) to be untouchable
+	// Set all air and water to be untouchable
 	// to make dungeons open to caves and open air
 	for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 		for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 			u32 i = vm->m_area.index(nmin.X, y, z);
 			for (s16 x = nmin.X; x <= nmax.X; x++) {
 				content_t c = vm->m_data[i].getContent();
-				if (c == CONTENT_AIR || c == dp.c_water ||
-						(no_float && c == CONTENT_IGNORE))
+				if (c == CONTENT_AIR || c == dp.c_water)
 					vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 				i++;
 			}
@@ -141,21 +138,21 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		// start_padding is used to disallow starting the generation of
 		// a dungeon in a neighboring generation chunk
 		roomplace = vm->m_area.MinEdge + start_padding + v3s16(
-			random.range(0, areasize.X - roomsize.X - 1 - start_padding.X),
-			random.range(0, areasize.Y - roomsize.Y - 1 - start_padding.Y),
-			random.range(0, areasize.Z - roomsize.Z - 1 - start_padding.Z));
+			random.range(0, areasize.X - roomsize.X - start_padding.X),
+			random.range(0, areasize.Y - roomsize.Y - start_padding.Y),
+			random.range(0, areasize.Z - roomsize.Z - start_padding.Z));
 
 		/*
 			Check that we're not putting the room to an unknown place,
 			otherwise it might end up floating in the air
 		*/
 		fits = true;
-		for (s16 z = 1; z < roomsize.Z - 1; z++)
-		for (s16 y = 1; y < roomsize.Y - 1; y++)
-		for (s16 x = 1; x < roomsize.X - 1; x++) {
+		for (s16 z = 0; z < roomsize.Z; z++)
+		for (s16 y = 0; y < roomsize.Y; y++)
+		for (s16 x = 0; x < roomsize.X; x++) {
 			v3s16 p = roomplace + v3s16(x, y, z);
 			u32 vi = vm->m_area.index(p);
-			if ((vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_INSIDE) ||
+			if ((vm->m_flags[vi] & VMANIP_FLAG_DUNGEON_UNTOUCHABLE) ||
 					vm->m_data[vi].getContent() == CONTENT_IGNORE) {
 				fits = false;
 				break;


### PR DESCRIPTION
![screenshot_20150828_070140](https://cloud.githubusercontent.com/assets/3686677/9540168/390efe00-4d53-11e5-84cb-f43703609d3b.png)

Fix random range for first room roomplace
Fix checked volume for first room 'fits' bool
and check for 'untouchable' flag instead of 'inside'

Seems to remove the now-far-too-common floating dungeon rings without removing the rare and stunning protruding dungeons (as shown above).
See #2926 for more details.