### PR TITLE
Change ore chance in clusters

### DIFF
--- a/src/mg_ore.cpp
+++ b/src/mg_ore.cpp
@@ -132,7 +132,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 				 (nmax.Y - nmin.Y + 1) *
 				 (nmax.Z - nmin.Z + 1);
 	u32 csize     = clust_size;
-	u32 orechance = (csize * csize * csize) / clust_num_ores;
+	u32 cvolume    = csize * csize * csize;
 	u32 nclusters = volume / clust_scarcity;
 
 	for (u32 i = 0; i != nclusters; i++) {
@@ -154,7 +154,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 		for (u32 z1 = 0; z1 != csize; z1++)
 		for (u32 y1 = 0; y1 != csize; y1++)
 		for (u32 x1 = 0; x1 != csize; x1++) {
-			if (pr.range(1, orechance) != 1)
+			if (pr.range(1, cvolume) > clust_num_ores)
 				continue;
 
 			u32 i = vm->m_area.index(x0 + x1, y0 + y1, z0 + z1);


### PR DESCRIPTION
The actual code `pr.range(1, orechance) != 1` has the fault to badly modelize dense ore clusters. For example :
`clust_size = 5` and `clust_num_ores = 64` (used in MinetestForFun), the volume of the clusters is 125, so the ore chance is around 1.95, and is rounded down, resulting a chance of 1, and 125/125 ores, where we expect 64 ores.
I want to calculate it differently : take a random number between 1 and `cvolume` (volume of the cluster) and place ore if not superior to `clust_num_ores`. So every node has exactly a probability of `clust_num_ores / cvolume` of being changed into ore, so the whole cluster will contain, in average, exactly `clust_num_ores` ores.

The mentioned cluster before:
![Before](http://i.imgur.com/ANP7udi.png)
And after:
![After](http://imgur.com/bwEjHgz.png)