### PR TITLE
Fix occasionally failing travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - PLATFORM=Linux
 before_install: ./util/travis/before_install.sh
 script: ./util/travis/script.sh
+sudo: required
 notifications:
   email: false
 matrix:


### PR DESCRIPTION
We require sudo right now, tell this travis, so that they don't try to
run it on their container based infrastructure.

On the long term, we'll have to abandon sudo I guess (they call it "legacy infrastructure"), and [get our packages we install into whitelists](http://docs.travis-ci.com/user/apt/).

Anybody know why d6f0bf9eef30819d91f89f2181ac5278d238f1a9 has added llvm 3.1 installation? Do we need it? As it seems, we have llvm 3.4 available on travis.
