### PR TITLE
check_player_privs does now accept the player/player name and varargs.

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -74,18 +74,37 @@ function core.after(time, func, ...)
 	}
 end
 
-function core.check_player_privs(name, privs)
+function core.check_player_privs(player_or_name, ...)
+	local name = player_or_name
+	-- Check if we have been provided with a Player object.
+	if type(name) ~= "string" then
+		name = name:get_player_name()
+	end
+	
+	local requested_privs = {...}
 	local player_privs = core.get_player_privs(name)
 	local missing_privileges = {}
-	for priv, val in pairs(privs) do
-		if val
-		and not player_privs[priv] then
-			table.insert(missing_privileges, priv)
+	
+	if type(requested_privs[1]) == "table" then
+		-- We were provided with a table like { privA = true, privB = true }.
+		for priv, value in pairs(requested_privs[1]) do
+			if value and not player_privs[priv] then
+				table.insert(missing_privileges, priv)
+			end
+		end
+	else
+		-- Only a list, we can process it directly.
+		for key, priv in pairs(requested_privs) do
+			if not player_privs[priv] then
+				table.insert(missing_privileges, priv)
+			end
 		end
 	end
+	
 	if #missing_privileges > 0 then
 		return false, missing_privileges
 	end
+	
 	return true, ""
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1891,8 +1891,11 @@ Call these functions only at load time!
 * `minetest.set_player_privs(name, {priv1=true,...})`
 * `minetest.get_player_privs(name) -> {priv1=true,...}`
 * `minetest.auth_reload()`
-* `minetest.check_player_privs(name, {priv1=true,...})`: returns `bool, missing_privs`
-    * A quickhand for checking privileges
+* `minetest.check_player_privs(player_or_name, ...)`: returns `bool, missing_privs`
+    * A quickhand for checking privileges.
+	* `player_or_name`: Either a Player object or the name of a player.
+	* `...` is either a list of strings, e.g. `"priva", "privb"` or
+	  a table, e.g. `{ priva = true, privb = true }`.
 * `minetest.get_player_ip(name)`: returns an IP address string
 
 `minetest.set_player_password`, `minetest_set_player_privs`, `minetest_get_player_privs`


### PR DESCRIPTION
The command can now be invoked with either the player object or name as
the first parameter, and with either a table or a list of strings, like
this:

    minetest.check_player_privs(player_name, { shout = true, fly = true })
    minetest.check_player_privs(player_name, "shout", "fly")
    minetest.check_player_privs(player, { shout = true, fly = true })
    minetest.check_player_privs(player, "shout", "fly")