### PR TITLE
Shaders: Use triple-frequency waving for leaves and plants

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -15,22 +15,29 @@ varying vec3 lightVec;
 varying vec3 tsEyeVec;
 varying vec3 tsLightVec;
 varying float area_enable_parallax;
+varying float disp;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
+
 
 float smoothCurve(float x)
 {
 	return x * x * (3.0 - 2.0 * x);
 }
+
+
 float triangleWave(float x)
 {
 	return abs(fract(x + 0.5) * 2.0 - 1.0);
 }
+
+
 float smoothTriangleWave(float x)
 {
 	return smoothCurve(triangleWave(x)) * 2.0 - 1.0;
 }
+
 
 void main(void)
 {
@@ -47,47 +54,38 @@ void main(void)
 	area_enable_parallax = 0.0;
 #endif
 
-#if ((MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE) && ENABLE_WAVING_WATER)
+
+#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
+	vec4 pos2 = mWorld * gl_Vertex;
+	float tOffset = (pos2.x + pos2.y) * 0.001 + pos2.z * 0.002;
+	disp = (smoothTriangleWave(animationTimer * 31.0 + tOffset) +
+		smoothTriangleWave(animationTimer * 29.0 + tOffset) +
+		smoothTriangleWave(animationTimer * 13.0 + tOffset)) - 0.9;
+#endif
+	
+
+#if (MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE) && ENABLE_WAVING_WATER
 	vec4 pos = gl_Vertex;
 	pos.y -= 2.0;
-
 	float posYbuf = (pos.z / WATER_WAVE_LENGTH + animationTimer * WATER_WAVE_SPEED * WATER_WAVE_LENGTH);
-
 	pos.y -= sin(posYbuf) * WATER_WAVE_HEIGHT + sin(posYbuf / 7.0) * WATER_WAVE_HEIGHT;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	vec4 pos = gl_Vertex;
-	vec4 pos2 = mWorld * gl_Vertex;
-
-	/*
-	 * Mathematic optimization: pos2.x * A + pos2.z * A (2 multiplications + 1 addition)
-	 * replaced with: (pos2.x + pos2.z) * A (1 addition + 1 multiplication)
-	 * And bufferize calcul to a float
-	 */
-	float pos2XpZ = pos2.x + pos2.z;
-
-	pos.x += (smoothTriangleWave(animationTimer*10.0 + pos2XpZ * 0.01) * 2.0 - 1.0) * 0.4;
-	pos.y += (smoothTriangleWave(animationTimer*15.0 + pos2XpZ * -0.01) * 2.0 - 1.0) * 0.2;
-	pos.z += (smoothTriangleWave(animationTimer*10.0 + pos2XpZ * -0.01) * 2.0 - 1.0) * 0.4;
+	pos.x += disp * 0.1;
+	pos.y += disp * 0.1;
+	pos.z += disp;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
 	vec4 pos = gl_Vertex;
-	vec4 pos2 = mWorld * gl_Vertex;
 	if (gl_TexCoord[0].y < 0.05) {
-		/*
-		 * Mathematic optimization: pos2.x * A + pos2.z * A (2 multiplications + 1 addition)
-		 * replaced with: (pos2.x + pos2.z) * A (1 addition + 1 multiplication)
-		 * And bufferize calcul to a float
-		 */
-		float pos2XpZ = pos2.x + pos2.z;
-
-		pos.x += (smoothTriangleWave(animationTimer * 20.0 + pos2XpZ * 0.1) * 2.0 - 1.0) * 0.8;
-		pos.y -= (smoothTriangleWave(animationTimer * 10.0 + pos2XpZ * -0.5) * 2.0 - 1.0) * 0.4;
+		pos.z += disp;
 	}
 	gl_Position = mWorldViewProj * pos;
 #else
 	gl_Position = mWorldViewProj * gl_Vertex;
 #endif
+
 
 	vPosition = gl_Position.xyz;
 	worldPosition = (mWorld * gl_Vertex).xyz;


### PR DESCRIPTION
Combine 3 prime-number frequencies for complex oscillation
Change main displacement from X to Z to match wind direction
Remove plant Y stretching, allows flowers to wave without texture-split
Tune timer Z offset to create air waves in wind direction
Use same oscillation for plants and leaves for consistent reaction to wind
Calculate displacement only once for use with leaves and/or plants
Also displace leaves slightly in X and Y to avoid texture overlap flicker

As a bonus this commit will allow the adding of 'waving = 1' to current flower textures without the splitting of the 2 plantlike textures.

Prime number frequencies are used because they create a less repetitive, more complex, natural, organic motion. The 2 higher and close frequencies create waving with a slow variation of amplitude like the coming and going of a breeze. The 3rd and lower frequency interacts for a more complex motion.

Due to some simplifications the code is no more heavy than before.

The average displacement is slightly south of centre, giving the impression of a prevailing southward wind.

A good way to test this commit is near a mgv6 jungle, viewing junglegrass, trees and clouds. Waves of air ripple through the flora in the direction of Minetest wind (southwards). The plants and leaves react consistently to the rise and fall of the wind strength because they use the same oscillation.