### PR TITLE
Mgv5/mgv7 biomes: Reduce heat and humidity noise spreads to former value of 750

### DIFF
--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -733,9 +733,9 @@
 #    other noise parameters are shown in positional format to save space.
 
 #    Noise parameters for biome API temperature, humidity and biome blend
-#mg_biome_np_heat = 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0
+#mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
 #mg_biome_np_heat_blend = 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
-#mg_biome_np_humidity = 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0
+#mg_biome_np_humidity = 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
 #mg_biome_np_humidity_blend = 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0
 
 #mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -127,9 +127,9 @@ struct MapgenParams {
 		seed(0),
 		water_level(1),
 		flags(MG_TREES | MG_CAVES | MG_LIGHT),
-		np_biome_heat(NoiseParams(50, 50, v3f(1000.0, 1000.0, 1000.0), 5349, 3, 0.5, 2.0)),
+		np_biome_heat(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0)),
 		np_biome_heat_blend(NoiseParams(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0)),
-		np_biome_humidity(NoiseParams(50, 50, v3f(1000.0, 1000.0, 1000.0), 842, 3, 0.5, 2.0)),
+		np_biome_humidity(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0)),
 		np_biome_humidity_blend(NoiseParams(0, 1.5, v3f(8.0, 8.0, 8.0), 90003, 2, 1.0, 2.0)),
 		sparams(NULL)
 	{}


### PR DESCRIPTION
See issue https://github.com/minetest/minetest_game/issues/653 problems with getting wood in mgv7.