### PR TITLE
Add minetest.override_item_groups

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -329,6 +329,18 @@ function core.override_item(name, redefinition)
 	register_item_raw(item)
 end
 
+function core.override_item_groups(name, groups)
+	local item = core.registered_items[name]
+	if not item then
+		error("Attempt to override non-existent item "..name, 2)
+	end
+	item.groups = item.groups or {}
+	for k, v in pairs(groups) do
+		rawset(item.groups, k, v)
+	end
+	register_item_raw(item)
+end
+
 
 core.callback_origins = {}
 
@@ -502,4 +514,3 @@ core.registered_on_punchplayers, core.register_on_punchplayer = make_registratio
 --
 
 core.register_on_mapgen_init = function(func) func(core.get_mapgen_params()) end
-

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1763,6 +1763,12 @@ Call these functions only at load time!
     * Overrides fields of an item registered with register_node/tool/craftitem.
     * Note: Item must already be defined, (opt)depend on the mod defining it.
     * Example: `minetest.override_item("default:mese", {light_source=LIGHT_MAX})`
+* `minetest.override_item_groups(name, groups)`
+    * Overrides individual groups of an item registered with
+      register_node/tool/craftitem.
+    * Use to add groups to/modify the groups of an item without deleting old groups.
+    * Note: Item must already be defined, (opt)depend on the mod defining it.
+    * Example: `minetest.override_item_groups("default:mese", {cracky=56})`
 
 * `minetest.clear_registered_ores()`
 * `minetest.clear_registered_decorations()`


### PR DESCRIPTION
Test usage:

```Lua
print(dump(minetest.registered_nodes["default:dirt"].groups))

minetest.override_item_groups("default:dirt", {
	some = 1,
	crumbly = 13
})

print(dump(minetest.registered_nodes["default:dirt"].groups))
```

-----

* `minetest.override_item_groups(name, groups)`
    * Overrides individual groups of an item registered with
      register_node/tool/craftitem.
    * Use to add groups to/modify the groups of an item without deleting old groups.
    * Note: Item must already be defined, (opt)depend on the mod defining it.
    * Example: `minetest.override_item_groups("default:mese", {cracky=56})`


----

Todo:

* Copy groups table first, as it may use a shared container.