### PR TITLE
Improve locale directory detection

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -512,14 +512,35 @@ void initializePaths()
 		errorstream << "Failed to get one or more system-wide path" << std::endl;
 
 #endif
-#ifdef STATIC_LOCALEDIR
-	path_locale = STATIC_LOCALEDIR[0] ? STATIC_LOCALEDIR : getDataPath("locale");
-#else
-	path_locale = getDataPath("locale");
-#endif
 
 	infostream << "Detected share path: " << path_share << std::endl;
 	infostream << "Detected user path: " << path_user << std::endl;
+
+	bool found_localedir = false;
+#ifdef STATIC_LOCALEDIR
+	if (STATIC_LOCALEDIR[0] && fs::PathExists(STATIC_LOCALEDIR)) {
+		found_localedir = true;
+		path_locale = STATIC_LOCALEDIR;
+		infostream << "Using locale directory " << STATIC_LOCALEDIR << std::endl;
+	} else {
+		path_locale = getDataPath("locale");
+		if (fs::PathExists(path_locale)) {
+			found_localedir = true;
+			infostream << "Using in-place locale directory " << path_locale
+				<< " even though a static one was provided "
+				<< "(RUN_IN_PLACE or CUSTOM_LOCALEDIR)." << std::endl;
+		}
+	}
+#else
+	path_locale = getDataPath("locale");
+	if (fs::PathExists(path_locale)) {
+		found_localedir = true;
+	}
+#endif
+	if (!found_localedir) {
+		errorstream << "Couldn't find a locale directory!" << std::endl;
+	}
+
 }
 
 


### PR DESCRIPTION
Use in-place locale directory if that exists, and
static one (RUN_IN_PLACE or CUSTOM_LOCALEDIR) doesn't exist.
Report to errorstream if neither static nor in-place locale
dirs exist, and report successfully found paths to infostreem.

Fixes two bugs:

-> Regression of commit [1] where if we use RUN_IN_PLACE=false,
	but don't make install, locales aren't found. One might
	think this is no regression, as its no bug, but all other
	paths (mainmenu, etc.) are detected properly.
-> Regression of commit [1] where locales don't work on windows.

References:
[1]: Commit 645e2086734e3d2d1ec95f50faa39f0f24304761 "Use CUSTOM_LOCALEDIR if specified" by @ShadowNinja
Fixes #3158