### PR TITLE
Send to clients only changed node metadata instad of whole mapblock

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -358,6 +358,7 @@ public:
 	void handleCommand_AccessDenied(NetworkPacket* pkt);
 	void handleCommand_RemoveNode(NetworkPacket* pkt);
 	void handleCommand_AddNode(NetworkPacket* pkt);
+	void handleCommand_NodemetaChanged(NetworkPacket *pkt);
 	void handleCommand_BlockData(NetworkPacket* pkt);
 	void handleCommand_Inventory(NetworkPacket* pkt);
 	void handleCommand_TimeOfDay(NetworkPacket* pkt);

--- a/src/map.h
+++ b/src/map.h
@@ -64,8 +64,7 @@ enum MapEditEventType{
 	MEET_REMOVENODE,
 	// Node swapped (changed without metadata change)
 	MEET_SWAPNODE,
-	// Node metadata of block changed (not knowing which node exactly)
-	// p stores block coordinate
+	// Node metadata changed
 	MEET_BLOCK_NODE_METADATA_CHANGED,
 	// Anything else (modified_blocks are set unsent)
 	MEET_OTHER

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_NODEMETA_CHANGED",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_NodemetaChanged }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -277,6 +277,29 @@ void Client::handleCommand_AddNode(NetworkPacket* pkt)
 
 	addNode(p, n, remove_metadata);
 }
+
+void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
+{
+	if (pkt->getSize() < 6)
+		return;
+
+
+	NodeMetadata *meta = new NodeMetadata(this);
+	v3s16 p;
+	*pkt >> p;
+	std::string datastring = pkt->readLongString();
+	std::istringstream is(datastring, std::ios::binary);
+	std::ostringstream oss(std::ios::binary);
+	decompressZlib(is, oss);
+	std::istringstream iss(oss.str(), std::ios::binary);
+	meta->deSerialize(iss);
+	try {
+		m_env.getMap().setNodeMetadata(p, meta);
+	}
+	catch(InvalidPositionException &e) {
+	}
+}
+
 void Client::handleCommand_BlockData(NetworkPacket* pkt)
 {
 	// Ignore too small packet

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -132,9 +132,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Rename GENERIC_CMD_SET_ATTACHMENT to GENERIC_CMD_ATTACH_TO
 	PROTOCOL_VERSION 26:
 		Add TileDef tileable_horizontal, tileable_vertical flags
+	PROTOCOL_VERSION 27:
+		Add TOCLIENT_NODEMETA_CHANGED 
 */
 
-#define LATEST_PROTOCOL_VERSION 26
+#define LATEST_PROTOCOL_VERSION 27
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -620,6 +622,11 @@ enum ToClientCommand
 		u32 id
 	*/
 
+	TOCLIENT_NODEMETA_CHANGED = 0x54,
+	/*
+		serialized and compressed node metadata
+	*/
+	
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
 		Belonging to AUTH_MECHANISM_LEGACY_PASSWORD and AUTH_MECHANISM_SRP.

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_NODEMETA_CHANGED",         0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -925,8 +925,8 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		ma->from_inv.applyCurrentPlayer(player->getName());
 		ma->to_inv.applyCurrentPlayer(player->getName());
-
-		setInventoryModified(ma->from_inv, false);
+		if (ma->from_inv != ma->to_inv)
+			setInventoryModified(ma->from_inv, false);
 		setInventoryModified(ma->to_inv, false);
 
 		bool from_inv_is_current_player =

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -64,7 +64,6 @@ void NodeMetadata::deSerialize(std::istream &is)
 		std::string var = deSerializeLongString(is);
 		m_stringvars[name] = var;
 	}
-
 	m_inventory->deSerialize(is);
 }
 

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -169,17 +169,10 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 					meta->deSerialize(is);
 				}
 				// Inform other things that the meta data has changed
-				v3s16 blockpos = getContainerPos(p, MAP_BLOCKSIZE);
 				MapEditEvent event;
 				event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-				event.p = blockpos;
+				event.p = p;
 				map->dispatchEvent(&event);
-				// Set the block to be saved
-				MapBlock *block = map->getBlockNoCreateNoEx(blockpos);
-				if (block) {
-					block->raiseModified(MOD_STATE_WRITE_NEEDED,
-						MOD_REASON_REPORT_META_CHANGE);
-				}
 			} catch (InvalidPositionException &e) {
 				infostream << "RollbackAction::applyRevert(): "
 					<< "InvalidPositionException: " << e.what()

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -56,17 +56,10 @@ void NodeMetaRef::reportMetadataChange(NodeMetaRef *ref)
 {
 	// NOTE: This same code is in rollback_interface.cpp
 	// Inform other things that the metadata has changed
-	v3s16 blockpos = getNodeBlockPos(ref->m_p);
 	MapEditEvent event;
 	event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-	event.p = blockpos;
+	event.p = ref->m_p;
 	ref->m_env->getMap().dispatchEvent(&event);
-	// Set the block to be saved
-	MapBlock *block = ref->m_env->getMap().getBlockNoCreateNoEx(blockpos);
-	if (block) {
-		block->raiseModified(MOD_STATE_WRITE_NEEDED,
-			MOD_REASON_REPORT_META_CHANGE);
-	}
 }
 
 // Exported functions

--- a/src/server.h
+++ b/src/server.h
@@ -424,6 +424,9 @@ private:
 	void sendAddNode(v3s16 p, MapNode n, u16 ignore_id=0,
 			std::vector<u16> *far_players=NULL, float far_d_nodes=100,
 			bool remove_metadata=true);
+	void sendMetadataChanged(v3s16 p, std::vector<u16> *far_players=NULL,
+			float far_d_nodes=100);
+
 	void setBlockNotSent(v3s16 p);
 
 	// Environment and Connection must be locked when called


### PR DESCRIPTION
thx to sending single meta packet is very small, circa 200-300 bytes for a chest, and it doesnt cause mapblock mesh updates (not only origin block mesh was updated but also neighbours).
Also sending whole block was causing each meta for that block being deleted and restored.
Effect on VE server, known to be laggy as hell and with usually slidshow (~10 fps as on my box):
![screenshot_20150909_191925](https://cloud.githubusercontent.com/assets/2177790/9772193/e5d3dc8c-573a-11e5-9e57-abc4a1d6b903.png)