### PR TITLE
Firelike drawtype: Simplify and improve

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1157,7 +1157,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			u16 l = getInteriorLight(n, 1, nodedef);
 			video::SColor c = MapBlock_LightColor(255, l, f.light_source);
 
-			float s = BS/2*f.visual_scale;
+			float s = BS / 2 * f.visual_scale;
 
 			content_t current = n.getContent();
 			content_t n2c;
@@ -1165,148 +1165,93 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			v3s16 n2p;
 
 			static const v3s16 dirs[6] = {
-				v3s16( 0, 1, 0),
-				v3s16( 0,-1, 0),
-				v3s16( 1, 0, 0),
-				v3s16(-1, 0, 0),
-				v3s16( 0, 0, 1),
-				v3s16( 0, 0,-1)
+				v3s16( 0,  1,  0),
+				v3s16( 0, -1,  0),
+				v3s16( 1,  0,  0),
+				v3s16(-1,  0,  0),
+				v3s16( 0,  0,  1),
+				v3s16( 0,  0, -1)
 			};
 
-			int doDraw[6] = {0,0,0,0,0,0};
+			int doDraw[6] = {0, 0, 0, 0, 0, 0};
 
 			bool drawAllFaces = true;
 
-			bool drawBottomFacesOnly = false; // Currently unused
-
 			// Check for adjacent nodes
-			for(int i = 0; i < 6; i++)
-			{
+			for (int i = 0; i < 6; i++) {
 				n2p = blockpos_nodes + p + dirs[i];
 				n2 = data->m_vmanip.getNodeNoEx(n2p);
 				n2c = n2.getContent();
 				if (n2c != CONTENT_IGNORE && n2c != CONTENT_AIR && n2c != current) {
 					doDraw[i] = 1;
-					if(drawAllFaces)
+					if (drawAllFaces)
 						drawAllFaces = false;
 
 				}
 			}
 
-			for(int j = 0; j < 6; j++)
-			{
-				int vOffset = 0; // Vertical offset of faces after rotation
-				int hOffset = 4; // Horizontal offset of faces to reach the edge
+			for (int j = 0; j < 6; j++) {
+				float vOffset = 0.39; // Vertical offset of faces after rotation
+				float hOffset = 3.08; // Horizontal offset of faces to reach the edge
 
 				video::S3DVertex vertices[4] =
 				{
-					video::S3DVertex(-s,-BS/2,      0, 0,0,0, c, 0,1),
-					video::S3DVertex( s,-BS/2,      0, 0,0,0, c, 1,1),
-					video::S3DVertex( s,-BS/2 + s*2,0, 0,0,0, c, 1,0),
-					video::S3DVertex(-s,-BS/2 + s*2,0, 0,0,0, c, 0,0),
+					video::S3DVertex(-s, -BS/2,       0, 0, 0, 0, c, 0, 1),
+					video::S3DVertex( s, -BS/2,       0, 0, 0, 0, c, 1, 1),
+					video::S3DVertex( s, -BS/2 + s*2, 0, 0, 0, 0, c, 1, 0),
+					video::S3DVertex(-s, -BS/2 + s*2, 0, 0, 0, 0, c, 0, 0),
 				};
 
 				// Calculate which faces should be drawn, (top or sides)
-				if(j == 0 && (drawAllFaces || (doDraw[3] == 1 || doDraw[1] == 1)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateXZBy(90 + n.param2 * 2);
-						vertices[i].Pos.rotateXYBy(-10);
+				if (j == 0 && (drawAllFaces ||
+						(doDraw[3] == 1 || doDraw[1] == 1))) {
+					for (int i = 0; i < 4; i++) {
+						vertices[i].Pos.rotateXZBy(90);
+						vertices[i].Pos.rotateXYBy(-22.5);
 						vertices[i].Pos.Y -= vOffset;
 						vertices[i].Pos.X -= hOffset;
 					}
-				}
-				else if(j == 1 && (drawAllFaces || (doDraw[5] == 1 || doDraw[1] == 1)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateXZBy(180 + n.param2 * 2);
-						vertices[i].Pos.rotateYZBy(10);
+				} else if (j == 1 && (drawAllFaces ||
+						(doDraw[5] == 1 || doDraw[1] == 1))) {
+					for (int i = 0; i < 4; i++) {
+						vertices[i].Pos.rotateXZBy(180);
+						vertices[i].Pos.rotateYZBy(22.5);
 						vertices[i].Pos.Y -= vOffset;
 						vertices[i].Pos.Z -= hOffset;
 					}
-				}
-				else if(j == 2 && (drawAllFaces || (doDraw[2] == 1 || doDraw[1] == 1)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateXZBy(270 + n.param2 * 2);
-						vertices[i].Pos.rotateXYBy(10);
+				} else if (j == 2 && (drawAllFaces ||
+						(doDraw[2] == 1 || doDraw[1] == 1))) {
+					for (int i = 0; i < 4; i++) {
+						vertices[i].Pos.rotateXZBy(270);
+						vertices[i].Pos.rotateXYBy(22.5);
 						vertices[i].Pos.Y -= vOffset;
 						vertices[i].Pos.X += hOffset;
 					}
-				}
-				else if(j == 3 && (drawAllFaces || (doDraw[4] == 1 || doDraw[1] == 1)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateYZBy(-10);
+				} else if (j == 3 && (drawAllFaces ||
+						(doDraw[4] == 1 || doDraw[1] == 1))) {
+					for (int i = 0; i < 4; i++) {
+						vertices[i].Pos.rotateYZBy(-22.5);
 						vertices[i].Pos.Y -= vOffset;
 						vertices[i].Pos.Z += hOffset;
 					}
-				}
-
-				// Center cross-flames
-				else if(j == 4 && (drawAllFaces || doDraw[1] == 1))
-				{
-					for(int i=0; i<4; i++) {
-						vertices[i].Pos.rotateXZBy(45 + n.param2 * 2);
-						vertices[i].Pos.Y -= vOffset;
+				// Render flame on bottom
+				} else if (j == 4 && doDraw[0] == 1 && doDraw[1] == 0) {
+					for (int i = 0; i < 4; i++) {
+						vertices[i].Pos.rotateYZBy(90);
+						vertices[i].Pos.Y += 4.375;
+						vertices[i].Pos.X += 0;
 					}
-				}
-				else if(j == 5 && (drawAllFaces || doDraw[1] == 1))
-				{
-					for(int i=0; i<4; i++) {
-						vertices[i].Pos.rotateXZBy(-45 + n.param2 * 2);
-						vertices[i].Pos.Y -= vOffset;
-					}
-				}
-
-				// Render flames on bottom
-				else if(j == 0 && (drawBottomFacesOnly || (doDraw[0] == 1 && doDraw[1] == 0)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateYZBy(70);
-						vertices[i].Pos.rotateXZBy(90 + n.param2 * 2);
-						vertices[i].Pos.Y += 4.84;
-						vertices[i].Pos.X -= hOffset+0.7;
-					}
-				}
-				else if(j == 1 && (drawBottomFacesOnly || (doDraw[0] == 1 && doDraw[1] == 0)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateYZBy(70);
-						vertices[i].Pos.rotateXZBy(180 + n.param2 * 2);
-						vertices[i].Pos.Y += 4.84;
-						vertices[i].Pos.Z -= hOffset+0.7;
-					}
-				}
-				else if(j == 2 && (drawBottomFacesOnly || (doDraw[0] == 1 && doDraw[1] == 0)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateYZBy(70);
-						vertices[i].Pos.rotateXZBy(270 + n.param2 * 2);
-						vertices[i].Pos.Y += 4.84;
-						vertices[i].Pos.X += hOffset+0.7;
-					}
-				}
-				else if(j == 3 && (drawBottomFacesOnly || (doDraw[0] == 1 && doDraw[1] == 0)))
-				{
-					for(int i = 0; i < 4; i++) {
-						vertices[i].Pos.rotateYZBy(70);
-						vertices[i].Pos.Y += 4.84;
-						vertices[i].Pos.Z += hOffset+0.7;
-					}
-				}
-				else {
+				} else {
 					// Skip faces that aren't adjacent to a node
 					continue;
 				}
 
-				for(int i=0; i<4; i++)
-				{
+				for (int i = 0; i < 4; i++) {
 					vertices[i].Pos *= f.visual_scale;
 					vertices[i].Pos += intToFloat(p, BS);
 				}
 
-				u16 indices[] = {0,1,2,2,3,0};
+				u16 indices[] = {0, 1, 2, 2, 3, 0};
 				// Add to mesh collector
 				collector.append(tile, vertices, 4, indices, 6);
 			}


### PR DESCRIPTION
Remove 2 central diagonal textures
Remove unusable param2 fine rotation that would break
orientation to neighbouring nodes
Replace top 4 textures with 1, spaced by 1/16 node
The new total of 5 fixes top textures missing in certain
circumstances
Tilt textures in by 22.5 (90/4) degrees instead of 10
Use floats, not ints, for vOffset and hOffset, and tune these
Fix code style issues and long lines

Current firelike has a problem, it uses 10 textures within a limit of 6. The lower 4 side flames override the top 4 flames (the burning underside of the node above). Depending on which of the lower side flames are used some of the top textures are missing. Also, using 4 flames for the single node surface above is over-complex.

With this commit:

![screenshot_20150912_054644](https://cloud.githubusercontent.com/assets/3686677/9829955/52b8b9f0-5914-11e5-8edf-3820e442dfd9.png)

^ On it's own has a pyramid campfire look.

![screenshot_20150912_054613](https://cloud.githubusercontent.com/assets/3686677/9829958/5866381e-5914-11e5-9be1-5f950cb03fba.png)

^ Textures are tilted in more for more density when seen from above.

This commit removes the 2 central diagonal flames and uses a single top flame, for a new total of 5 textures, because this is less than the limit of 6 these are all independant so none will be missing in certain circumstances.

The top texture is spaced by a single 16px texture pixel from the node above:

![screenshot_20150912_054356](https://cloud.githubusercontent.com/assets/3686677/9829959/5dbdc25a-5914-11e5-85b7-bd0e529ea301.png)

The side flames are tilted in more (from 10 to 22.5 degrees) to help with visual flame density. I was considering what angles are suitable in Minetest, we have 90 and 45 degree angles which are 360 / 2^n, repeated division of 360 by 2, which results in 22.5 degrees.

I removed the fine-step rotation by param2 (a feature recently added to plantlike by RealBadAngel), this would be unusable because the flames of firelike need to be orientated to surrounding nodes.

'int's were being used for vOffset and hOffset, i changed these to 'float's for the necessary accuracy in positioning the textures to meet the lower edges.

Firelike code is now more lightweight during mesh generation, the fewer textures will help with the significant FPS drop of a large fire which players have reported.
