### PR TITLE
Blob ore: Fix partial blobs

### DIFF
--- a/src/mg_ore.cpp
+++ b/src/mg_ore.cpp
@@ -358,9 +358,9 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 			float noiseval = noise->result[index];
 
-			float xdist = x1 - csize / 2;
-			float ydist = y1 - csize / 2;
-			float zdist = z1 - csize / 2;
+			float xdist = (s32)x1 - (s32)csize / 2;
+			float ydist = (s32)y1 - (s32)csize / 2;
+			float zdist = (s32)z1 - (s32)csize / 2;
 
 			noiseval -= (sqrt(xdist * xdist + ydist * ydist + zdist * zdist) / csize);
 


### PR DESCRIPTION
![screenshot_20150918_200941](https://cloud.githubusercontent.com/assets/3686677/9969402/3d4f5fc4-5e46-11e5-9a6c-ccbe38a4fb40.png)

While testing clay blob ore with noise parameters mant to completely fill the cluster volume with ore, i noticed that with a 'clust size = 5' i could only ever create a 3x3x3 cube of ore. 'clust size = 11' created a 6x6x6 cube and 'clust size = 23' created a 12x12x12 cube. All roughly half size.

Using noise parameters to create a perfect sphere 23 nodes across only the 12 node positive segment of a sphere appears as shown above.

The problem is here:

			float xdist = x1 - csize / 2;
			float ydist = y1 - csize / 2;
			float zdist = z1 - csize / 2;

x1, y1, z1 and csize are all unsigned u32, when 'x/y/z1 - csize / 2' is negative the unsigned data type causes a problem which then breaks the following line:

			noiseval -= (sqrt(xdist * xdist + ydist * ydist + zdist * zdist) / csize);

My fix is to cast the u32 values as s32, allowing a negative value.

Another solution that works is this:

			float xdist = (s32)(x1 - csize / 2);
			float ydist = (s32)(y1 - csize / 2);
			float zdist = (s32)(z1 - csize / 2);

I'm not sure what the ideal data type / cast solution is for this though.