### PR TITLE
Clarify radii and distance types in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,46 @@
-## Generic ignorable patterns and files
+## Editors and Development environments
 *~
-.*.swp
-.*-swp
-*bak*
-tags
-*.vim
+*.swp
+*.bak*
 *.orig
-*.rej
+# Vim
+*.vim
+# Kate
+.*.kate-swp
+.swp.*
+# KDevelop4
+.kdev4/
+*.kdev4
+# Eclipse (CDT and LDT)
+.project
+.cproject
+.settings/
+.buildpath
+.metadata
+# GNU Global
+tags
+!tags/
+gtags.files
 
 ## Files related to minetest development cycle
 /*.patch
+# GNU Patch reject file
+*.rej
 
-## Non-static Minetest directories
+## Non-static Minetest directories or symlinks to these
 /bin/
 /games/*
 !/games/minimal/
-/cache/
+/cache
 /textures/*
 !/textures/base/
-/sounds/
+/screenshots
+/sounds
 /mods/*
 !/mods/minetest/
 /mods/minetest/*
 !/mods/minetest/mods_here.txt
-/worlds/
+/worlds
 /world/
 
 ## Configuration/log files
@@ -50,9 +67,7 @@ src/cmake_config_githash.h
 src/lua/build/
 locale/
 .directory
-.kdev4/
 *.cbp
-*.kdev4
 *.layout
 *.o
 *.a
@@ -70,4 +85,3 @@ build/android/path.cfg
 build/android/and_env
 build/android/AndroidManifest.xml
 timestamp
-

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -393,13 +393,13 @@ Examples of sound parameter tables:
     {
         pos = {x=1,y=2,z=3},
         gain = 1.0, -- default
-        max_hear_distance = 32, -- default
+        max_hear_distance = 32, -- default, uses an euclidean metric
     }
     -- Play connected to an object, looped
     {
         object = <an ObjectRef>,
         gain = 1.0, -- default
-        max_hear_distance = 32, -- default
+        max_hear_distance = 32, -- default, uses an euclidean metric
         loop = true, -- only sounds connected to objects can be looped
     }
 
@@ -1664,7 +1664,7 @@ numerical form, the raw integer value of an ARGB8 quad:
 or string form, a ColorString (defined above):
     `colorspec = "green"`
 
-Vector helpers
+Spatial Vectors
 --------------
 
 * `vector.new([x[, y, z]])`: returns a vector.
@@ -1682,8 +1682,8 @@ For the following functions `x` can be either a vector or a number:
 
 * `vector.add(v, x)`: returns a vector
 * `vector.subtract(v, x)`: returns a vector
-* `vector.multiply(v, x)`: returns a vector
-* `vector.divide(v, x)`: returns a vector
+* `vector.multiply(v, x)`: returns a scaled vector or Schur product
+* `vector.divide(v, x)`: returns a scaled vector or Schur quotient
 
 Helper functions
 -----------------
@@ -1969,11 +1969,13 @@ and `minetest.auth_reload` call the authetification handler.
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
 * `minetest.get_objects_inside_radius(pos, radius)`
+    * `radius`: using an euclidean metric
 * `minetest.set_timeofday(val)`
     * `val` is between `0` and `1`; `0` for midnight, `0.5` for midday
 * `minetest.get_timeofday()`
 * `minetest.get_gametime()`: returns the time, in seconds, since the world was created
 * `minetest.find_node_near(pos, radius, nodenames)`: returns pos or `nil`
+    * `radius`: using a maximum metric
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
 * `minetest.find_nodes_in_area(minp, maxp, nodenames)`: returns a list of positions
     * returns as second value a table with the count of the individual nodes found
@@ -2034,7 +2036,7 @@ and `minetest.auth_reload` call the authetification handler.
     * returns a table of 3D points representing a path from `pos1` to `pos2` or `nil`
     * `pos1`: start position
     * `pos2`: end position
-    * `searchdistance`: number of blocks to search in each direction
+    * `searchdistance`: number of blocks to search in each direction using a maximum metric
     * `max_jump`: maximum height difference to consider walkable
     * `max_drop`: maximum height difference to consider droppable
     * `algorithm`: One of `"A*_noprefetch"` (default), `"A*"`, `"Dijkstra"`


### PR DESCRIPTION
Addresses #2235 
Because not all circles are round:
* circles using an euclidean metric are what we usually call "round"
* circles using a maximum metric look like euclidean rectangles with equal adjacent sides (squares)
* circles using a manhattan metric look like an euclidean right angled rhombus (squares, but 45° rotated to the former one)