### PR TITLE
Mapnode: Add rotateAlongYAxisFull supporting 24 facedirs

### DIFF
--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -236,6 +236,7 @@ struct MapNode
 	v3s16 getWallMountedDir(INodeDefManager *nodemgr) const;
 
 	void rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot);
+	void rotateAlongYAxisFull(INodeDefManager *nodemgr, Rotation rot);
 
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))

--- a/src/mg_schematic.cpp
+++ b/src/mg_schematic.cpp
@@ -167,7 +167,7 @@ void Schematic::blitToVManip(v3s16 p, MMVManip *vm, Rotation rot, bool force_pla
 				vm->m_data[vi].param1 = 0;
 
 				if (rot)
-					vm->m_data[vi].rotateAlongYAxis(m_ndef, rot);
+					vm->m_data[vi].rotateAlongYAxisFull(m_ndef, rot);
 			}
 		}
 		y_map++;


### PR DESCRIPTION
![screenshot_20150921_221204](https://cloud.githubusercontent.com/assets/3686677/10005244/09d1f1d8-60ae-11e5-96ac-4a364deb63ff.png)

PR for #3191 and #3093 
With this commit rotation of schematics should support all 24 node orientations instead of just the first 4.