### PR TITLE
Save and remove player by pointer

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -821,8 +821,8 @@ void PlayerSAO::removingFromEnvironment()
 	{
 		m_player->setPlayerSAO(NULL);
 		m_player->peer_id = 0;
-		m_env->savePlayer(m_player->getName());
-		m_env->removePlayer(m_player->getName());
+		m_env->savePlayer((RemotePlayer*)m_player);
+		m_env->removePlayer(m_player);
 	}
 }
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -85,28 +85,11 @@ void Environment::addPlayer(Player *player)
 	m_players.push_back(player);
 }
 
-void Environment::removePlayer(u16 peer_id)
-{
-	DSTACK(__FUNCTION_NAME);
-
-	for(std::vector<Player*>::iterator i = m_players.begin();
-			i != m_players.end();)
-	{
-		Player *player = *i;
-		if(player->peer_id == peer_id) {
-			delete player;
-			i = m_players.erase(i);
-		} else {
-			++i;
-		}
-	}
-}
-
-void Environment::removePlayer(const char *name)
+void Environment::removePlayer(Player* player)
 {
 	for (std::vector<Player*>::iterator it = m_players.begin();
 			it != m_players.end(); ++it) {
-		if (strcmp((*it)->getName(), name) == 0) {
+		if ((*it) == player) {
 			delete *it;
 			m_players.erase(it);
 			return;
@@ -453,15 +436,12 @@ void ServerEnvironment::saveLoadedPlayers()
 	}
 }
 
-void ServerEnvironment::savePlayer(const std::string &playername)
+void ServerEnvironment::savePlayer(RemotePlayer *player)
 {
 	std::string players_path = m_path_world + DIR_DELIM "players";
 	fs::CreateDir(players_path);
 
-	RemotePlayer *player = static_cast<RemotePlayer*>(getPlayer(playername.c_str()));
-	if (player) {
-		player->save(players_path);
-	}
+	player->save(players_path);
 }
 
 Player *ServerEnvironment::loadPlayer(const std::string &playername)

--- a/src/environment.h
+++ b/src/environment.h
@@ -52,6 +52,7 @@ class ServerMap;
 class ClientMap;
 class GameScripting;
 class Player;
+class RemotePlayer;
 
 class Environment
 {
@@ -71,8 +72,7 @@ public:
 	virtual Map & getMap() = 0;
 
 	virtual void addPlayer(Player *player);
-	void removePlayer(u16 peer_id);
-	void removePlayer(const char *name);
+	void removePlayer(Player *player);
 	Player * getPlayer(u16 peer_id);
 	Player * getPlayer(const char *name);
 	Player * getRandomConnectedPlayer();
@@ -226,7 +226,7 @@ public:
 		const std::string &str_reason, bool reconnect);
 	// Save players
 	void saveLoadedPlayers();
-	void savePlayer(const std::string &playername);
+	void savePlayer(RemotePlayer *player);
 	Player *loadPlayer(const std::string &playername);
 
 	/*


### PR DESCRIPTION
Why doing things simple ? Use pointer instead of strings to save players and remove them. Saving players by name does a lookup to find pointer we already have ! Idem with removePlayer Also remove unused removePlayer(peer_id), it's never called