### PR TITLE
Decorations: Remove error message 'chunksize not divisable by sidelen'

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -90,11 +90,9 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 	int carea_size = nmax.X - nmin.X + 1;
 
 	// Divide area into parts
-	if (carea_size % sidelen) {
-		errorstream << "Decoration::placeDeco: chunk size is not divisible by "
-			"sidelen; setting sidelen to " << carea_size << std::endl;
+	// If chunksize is changed it may no longer be divisable by sidelen
+	if (carea_size % sidelen)
 		sidelen = carea_size;
-	}
 
 	s16 divlen = carea_size / sidelen;
 	int area = sidelen * sidelen;


### PR DESCRIPTION
Sidelen larger than 16 is essential for low density decorations
With sidelen > 16 chunksize may not be divisable by sidelen if
chunksize is changed, in this situation setting sidelen = chunksize
is desirable and should not create error messages.

From IRC:
eugd
20:22 		chunksize not really definable
20:22 		or it is and it works fine but generates a constant stream of errors
20:22 		'chunksize not divisible by sidelen, setting sidelen to 16'

paramat
21:56 	eugd hmmmm that error is my fault, i am using a sidelen of 80 for some decorations. i found this necessary because decoration code fails at very low densities (acacia tree, cacti), the larger sidelen helped. however it is better to alter the decoration code, i'll work on this
22:29 	problem is .. to work with all chunksizes (without printing an error) sidelen cannot be larger than 16. at low density deco_count can only be 0 or 1 per 16x16 node area which looks bad
22:30 		so i will continue to use sidelen = 80. for low densities the code does the right thing setting sidelen = carea_size, maybe the error should not be printed as it's not really an error