### PR TITLE
allow changing the velocity of objects relatively to their current velocity

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -39,7 +39,7 @@ core.register_entity(":__builtin:falling_node", {
 
 	on_activate = function(self, staticdata)
 		self.object:set_armor_groups({immortal = 1})
-		
+
 		local ds = core.deserialize(staticdata)
 		if ds and ds.node then
 			self:set_node(ds.node, ds.meta)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4029,6 +4029,10 @@ This is basically a reference to a C++ `ServerActiveObject`
 ##### LuaEntitySAO-only (no-op for other objects)
 * `set_velocity(vel)`
     * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
+* `add_velocity(vel)`
+    * `vel` is a vector, e.g. `{x=0.0, y=2.3, z=1.0}`
+    * In comparison to using get_velocity, adding the velocity and then using
+      set_velocity, add_velocity is supposed to avoid synchronization problems.
 * `get_velocity()`: returns the velocity, a vector
 * `set_acceleration(acc)`
     * `acc` is a vector

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -652,11 +652,6 @@ void LuaEntitySAO::setVelocity(v3f velocity)
 	m_velocity = velocity;
 }
 
-void LuaEntitySAO::addVelocity(v3f velocity)
-{
-	m_velocity += velocity;
-}
-
 v3f LuaEntitySAO::getVelocity()
 {
 	return m_velocity;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -652,6 +652,11 @@ void LuaEntitySAO::setVelocity(v3f velocity)
 	m_velocity = velocity;
 }
 
+void LuaEntitySAO::addVelocity(v3f velocity)
+{
+	m_velocity += velocity;
+}
+
 v3f LuaEntitySAO::getVelocity()
 {
 	return m_velocity;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -121,6 +121,7 @@ public:
 	s16 getHP() const;
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
+	void addVelocity(v3f velocity);
 	v3f getVelocity();
 	void setAcceleration(v3f acceleration);
 	v3f getAcceleration();

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -121,7 +121,10 @@ public:
 	s16 getHP() const;
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
-	void addVelocity(v3f velocity);
+	void addVelocity(v3f velocity)
+	{
+		m_velocity += velocity;
+	}
 	v3f getVelocity();
 	void setAcceleration(v3f acceleration);
 	v3f getAcceleration();

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -856,7 +856,8 @@ int ObjectRef::l_add_velocity(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	LuaEntitySAO *co = getluaobject(ref);
-	if (co == NULL) return 0;
+	if (!co)
+		return 0;
 	v3f pos = checkFloatPos(L, 2);
 	// Do it
 	co->addVelocity(pos);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1854,6 +1854,7 @@ const luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_nametag_attributes),
 	// LuaEntitySAO-only
 	luamethod_aliased(ObjectRef, set_velocity, setvelocity),
+	luamethod(ObjectRef, add_velocity),
 	luamethod_aliased(ObjectRef, get_velocity, getvelocity),
 	luamethod_aliased(ObjectRef, set_acceleration, setacceleration),
 	luamethod_aliased(ObjectRef, get_acceleration, getacceleration),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -850,6 +850,19 @@ int ObjectRef::l_set_velocity(lua_State *L)
 	return 0;
 }
 
+// add_velocity(self, {x=num, y=num, z=num})
+int ObjectRef::l_add_velocity(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *co = getluaobject(ref);
+	if (co == NULL) return 0;
+	v3f pos = checkFloatPos(L, 2);
+	// Do it
+	co->addVelocity(pos);
+	return 0;
+}
+
 // get_velocity(self)
 int ObjectRef::l_get_velocity(lua_State *L)
 {

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -161,6 +161,9 @@ private:
 	// set_velocity(self, {x=num, y=num, z=num})
 	static int l_set_velocity(lua_State *L);
 
+	// add_velocity(self, {x=num, y=num, z=num})
+	static int l_add_velocity(lua_State *L);
+
 	// get_velocity(self)
 	static int l_get_velocity(lua_State *L);
 


### PR DESCRIPTION
Often some object needs to be pushed somewhere, e.g.:
- pushing a ball
- mesecons piston
- tnt explosion
- weapon recoil

If one day the possibility of changing the velocity of players gets added, using getvelocity and setvelocity not relatively doesn't work for this because the player may move when the server "calculates" that.