### PR TITLE
get_biome_id lua function

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1999,6 +1999,9 @@ and `minetest.auth_reload` call the authetification handler.
 * `get_gen_notify()`: returns a flagstring and a table with the deco_ids
 * `minetest.get_mapgen_object(objectname)`
     * Return requested mapgen object if available (see "Mapgen objects")
+* `minetest.get_biome_id(biome_name)`
+    * Returns the biome id, as used in the biomemap Mapgen object, for a
+      given biome_name string.
 * `minetest.get_mapgen_params()` Returns mapgen parameters, a table containing
   `mgname`, `seed`, `chunksize`, `water_level`, and `flags`.
 * `minetest.set_mapgen_params(MapgenParams)`
@@ -2394,10 +2397,6 @@ These functions return the leftover itemstack.
 
 * `minetest.global_exists(name)`
     * Checks if a global variable has been set, without triggering a warning.
-
-* `minetest.get_biome_id(biome_name)`
-    * Returns the biome id, as used in the biomemap Mapgen object, for a
-      given biome_name string.
 
 ### Global objects
 * `minetest.env`: `EnvRef` of the server environment and world.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2395,6 +2395,10 @@ These functions return the leftover itemstack.
 * `minetest.global_exists(name)`
     * Checks if a global variable has been set, without triggering a warning.
 
+* `minetest.get_biome_id(biome_name)`
+    * Returns the biome id, as used in the biomemap Mapgen object, for a
+      given biome_name string.
+
 ### Global objects
 * `minetest.env`: `EnvRef` of the server environment and world.
     * Any function in the minetest namespace can be called using the syntax

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -135,7 +135,6 @@ ObjDef *get_objdef(lua_State *L, int index, ObjDefManager *objmgr)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names)
 {
@@ -455,14 +454,12 @@ size_t get_biome_list(lua_State *L, int index,
 // returns the biome id used in biomemap
 int ModApiMapgen::l_get_biome_id(lua_State *L)
 {
-	//std::string val("new biome function test");
 	const char *biome_str = lua_tostring(L, 1);
 	if (!biome_str) {
-		lua_pushnil(L);
-		return 1;
+		return 0;
 	}
 
-	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
+	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
 
 	if (!bmgr)
 		return 0;
@@ -471,7 +468,7 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 	if (biome && biome->index != OBJDEF_INVALID_INDEX)
 		lua_pushinteger(L, biome->index);
 	else
-		lua_pushnil(L);
+		return 0;
 
 	return 1;
 }

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -455,9 +455,8 @@ size_t get_biome_list(lua_State *L, int index,
 int ModApiMapgen::l_get_biome_id(lua_State *L)
 {
 	const char *biome_str = lua_tostring(L, 1);
-	if (!biome_str) {
+	if (!biome_str)
 		return 0;
-	}
 
 	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -135,6 +135,7 @@ ObjDef *get_objdef(lua_State *L, int index, ObjDefManager *objmgr)
 
 ///////////////////////////////////////////////////////////////////////////////
 
+
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names)
 {
@@ -449,6 +450,27 @@ size_t get_biome_list(lua_State *L, int index,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+// get_biome_id(biomename)
+// returns the biome id used in biomemap
+int ModApiMapgen::l_get_biome_id(lua_State *L)
+{
+	//std::string val("new biome function test");
+	const char *biome_str = lua_tostring(L, 1);
+	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
+
+	if (!bmgr)
+		return 0;
+
+	Biome *biome = (Biome *) bmgr->getByName(biome_str);
+	if (biome && biome->index)
+		lua_pushinteger(L, biome->index);
+	else
+		lua_pushnil(L);
+
+	return 1;
+}
+
 
 // get_mapgen_object(objectname)
 // returns the requested object used during map generation
@@ -1257,6 +1279,7 @@ int ModApiMapgen::l_serialize_schematic(lua_State *L)
 
 void ModApiMapgen::Initialize(lua_State *L, int top)
 {
+	API_FCT(get_biome_id);
 	API_FCT(get_mapgen_object);
 
 	API_FCT(get_mapgen_params);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -464,10 +464,11 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 		return 0;
 
 	Biome *biome = (Biome *) bmgr->getByName(biome_str);
-	if (biome && biome->index != OBJDEF_INVALID_INDEX)
-		lua_pushinteger(L, biome->index);
-	else
+
+	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
+
+	lua_pushinteger(L, biome->index);
 
 	return 1;
 }

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -457,6 +457,11 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 {
 	//std::string val("new biome function test");
 	const char *biome_str = lua_tostring(L, 1);
+	if (!biome_str) {
+		lua_pushnil(L);
+		return 1;
+	}
+
 	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
 
 	if (!bmgr)

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -468,7 +468,7 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 		return 0;
 
 	Biome *biome = (Biome *) bmgr->getByName(biome_str);
-	if (biome && biome->index)
+	if (biome && biome->index != OBJDEF_INVALID_INDEX)
 		lua_pushinteger(L, biome->index);
 	else
 		lua_pushnil(L);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class ModApiMapgen : public ModApiBase {
 private:
+	static int l_get_biome_id(lua_State *L);
+
 	// get_mapgen_object(objectname)
 	// returns the requested object used during map generation
 	static int l_get_mapgen_object(lua_State *L);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class ModApiMapgen : public ModApiBase {
 private:
+	// get_biome_id(biomename)
+	// returns the biome id used in biomemap
 	static int l_get_biome_id(lua_State *L);
 
 	// get_mapgen_object(objectname)


### PR DESCRIPTION
get_biome_id(biome_name) returns the index used in mg->biomemap for a given biome name. The biomemap is useless without this unless you
re-register all existing biomes, which could cause problems for anyone
else trying to use biomemap. With this, you can quickly create a lookup
table of ids and names.