### PR TITLE
Mapnode: Replace rotateAlongYAxis with improved version

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -164,29 +164,7 @@ void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
 	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
 
 	if (cpt2 == CPT2_FACEDIR) {
-		if (param2 >= 4)
-			return;
-
-		u8 newrot = param2 & 3;
-		param2 &= ~3;
-		param2 |= (newrot + rot) & 3;
-	} else if (cpt2 == CPT2_WALLMOUNTED) {
-		u8 wmountface = (param2 & 7);
-		if (wmountface <= 1)
-			return;
-
-		Rotation oldrot = wallmounted_to_rot[wmountface - 2];
-		param2 &= ~7;
-		param2 |= rot_to_wallmounted[(oldrot - rot) & 3];
-	}
-}
-
-void MapNode::rotateAlongYAxisFull(INodeDefManager *nodemgr, Rotation rot)
-{
-	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
-
-	if (cpt2 == CPT2_FACEDIR) {
-		static const u16 rotate_facedir[24 * 4] = {
+		static const u8 rotate_facedir[24 * 4] = {
 			// Table value = rotated facedir
 			// Columns: 0, 90, 180, 270 degrees rotation around vertical axis
 			// Rotation is anticlockwise as seen from above (+Y)
@@ -221,8 +199,10 @@ void MapNode::rotateAlongYAxisFull(INodeDefManager *nodemgr, Rotation rot)
 			22, 21, 20, 23,
 			23, 22, 21, 20
 		};
-		u16 index = param2 * 4 + rot;
-		param2 = rotate_facedir[index];
+		u8 facedir = (param2 & 31) % 24;
+		u8 index = facedir * 4 + rot;
+		param2 &= ~31;
+		param2 |= rotate_facedir[index];
 	} else if (cpt2 == CPT2_WALLMOUNTED) {
 		u8 wmountface = (param2 & 7);
 		if (wmountface <= 1)

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -236,7 +236,6 @@ struct MapNode
 	v3s16 getWallMountedDir(INodeDefManager *nodemgr) const;
 
 	void rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot);
-	void rotateAlongYAxisFull(INodeDefManager *nodemgr, Rotation rot);
 
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))

--- a/src/mg_schematic.cpp
+++ b/src/mg_schematic.cpp
@@ -167,7 +167,7 @@ void Schematic::blitToVManip(v3s16 p, MMVManip *vm, Rotation rot, bool force_pla
 				vm->m_data[vi].param1 = 0;
 
 				if (rot)
-					vm->m_data[vi].rotateAlongYAxisFull(m_ndef, rot);
+					vm->m_data[vi].rotateAlongYAxis(m_ndef, rot);
 			}
 		}
 		y_map++;


### PR DESCRIPTION
Get facedir by using lowest 5 bits of param2 and limiting to 23
More robust, frees up higher param2 bits for other uses
Change lookup table and table index to u8

This commit finishes the job of node rotation supporting all 24 values of facedir, by actually replacing 'rotateAlongYAxis' with the new code (currently another function 'rotateAlongYAxisFull').
To get initial facedir the lowest 5 bits of param2 are extracted with '(param2 & 31)', and for extra robustness limited to 23 using '% 24'.
The lowest 5 bits of param2 are set to 00000 using 'param2 &= ~31;'
Finally the rotated facedir is inserted into param2 using 'param2 |= rotate_facedir[index];'