### PR TITLE
Add minetest.wallmounted_to_dir

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -139,6 +139,19 @@ function core.dir_to_wallmounted(dir)
 	end
 end
 
+function core.wallmounted_to_dir(wallmounted)
+	-- table of dirs in wallmounted order
+	return ({[0]={x=0, y=1, z=0},
+					{x=0, y=-1, z=0},
+					{x=1, y=0, z=0},
+					{x=-1, y=0, z=0},
+					{x=0, y=0, z=1},
+					{x=0, y=0, z=-1}})
+
+					--indexed into by the wallmounted in question
+					[wallmounted]
+end
+
 function core.get_node_drops(nodename, toolname)
 	local drop = ItemStack({name=nodename}):get_definition().drop
 	if drop == nil then


### PR DESCRIPTION
There's already a facedir_to_dir matching the dir_to_facedir. So why not a wallmounted_to_dir matching dir_to_wallmounted?

I'm implementing some rotation logic in my mod and I need to be able to convert the values to vector, transform them and convert them back. I can do this with facedir nodes but not wallmounted without manually figuring out the values.