### PR TITLE
Improve ABM performance: pre-resolve node ids

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -589,34 +589,20 @@ public:
 			if(aabm.chance == 0)
 				aabm.chance = 1;
 			// Trigger neighbors
-			std::set<std::string> required_neighbors_s
-					= abm->getRequiredNeighbors();
-			for(std::set<std::string>::iterator
-					i = required_neighbors_s.begin();
-					i != required_neighbors_s.end(); ++i)
-			{
-				ndef->getIds(*i, aabm.required_neighbors);
-			}
+			aabm.required_neighbors	= abm->getRequiredNeighbors();
 			// Trigger contents
-			std::set<std::string> contents_s = abm->getTriggerContents();
-			for(std::set<std::string>::iterator
-					i = contents_s.begin(); i != contents_s.end(); ++i)
-			{
-				std::set<content_t> ids;
-				ndef->getIds(*i, ids);
-				for(std::set<content_t>::const_iterator k = ids.begin();
-						k != ids.end(); ++k)
-				{
-					content_t c = *k;
-					std::map<content_t, std::vector<ActiveABM> >::iterator j;
+			std::vector<content_t> ids = abm->getTriggerContents();
+			for(std::vector<content_t>::const_iterator k = ids.begin();
+					k != ids.end(); ++k) {
+				content_t c = *k;
+				std::map<content_t, std::vector<ActiveABM> >::iterator j;
+				j = m_aabms.find(c);
+				if(j == m_aabms.end()) {
+					std::vector<ActiveABM> aabmlist;
+					m_aabms[c] = aabmlist;
 					j = m_aabms.find(c);
-					if(j == m_aabms.end()){
-						std::vector<ActiveABM> aabmlist;
-						m_aabms[c] = aabmlist;
-						j = m_aabms.find(c);
-					}
-					j->second.push_back(aabm);
 				}
+				j->second.push_back(aabm);
 			}
 		}
 	}

--- a/src/environment.h
+++ b/src/environment.h
@@ -146,11 +146,11 @@ public:
 	virtual ~ActiveBlockModifier(){};
 
 	// Set of contents to trigger on
-	virtual std::set<std::string> getTriggerContents()=0;
+	virtual std::vector<content_t> getTriggerContents()=0;
 	// Set of required neighbors (trigger doesn't happen if none are found)
 	// Empty = do not check neighbors
-	virtual std::set<std::string> getRequiredNeighbors()
-	{ return std::set<std::string>(); }
+	virtual std::set<content_t> getRequiredNeighbors()
+	{ return std::set<content_t>(); }
 	// Trigger interval in seconds
 	virtual float getTriggerInterval() = 0;
 	// Random chance of (1 / return value), 0 is disallowed

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -180,14 +180,14 @@ class LuaABM : public ActiveBlockModifier
 private:
 	int m_id;
 
-	std::set<std::string> m_trigger_contents;
-	std::set<std::string> m_required_neighbors;
+	std::vector<content_t> m_trigger_contents;
+	std::set<content_t> m_required_neighbors;
 	float m_trigger_interval;
 	u32 m_trigger_chance;
 public:
 	LuaABM(lua_State *L, int id,
-			const std::set<std::string> &trigger_contents,
-			const std::set<std::string> &required_neighbors,
+			const std::vector<content_t> &trigger_contents,
+			const std::set<content_t> &required_neighbors,
 			float trigger_interval, u32 trigger_chance):
 		m_id(id),
 		m_trigger_contents(trigger_contents),
@@ -196,11 +196,11 @@ public:
 		m_trigger_chance(trigger_chance)
 	{
 	}
-	virtual std::set<std::string> getTriggerContents()
+	virtual std::vector<content_t> getTriggerContents()
 	{
 		return m_trigger_contents;
 	}
-	virtual std::set<std::string> getRequiredNeighbors()
+	virtual std::set<content_t> getRequiredNeighbors()
 	{
 		return m_required_neighbors;
 	}


### PR DESCRIPTION
ABM are actually resolving their node names on runtime.
Because we only can set it at creation, resolve ABM required_neighbors and required_nodes when registering them not at runtime to save some CPU cycles