### PR TITLE
Mapgen: Use mapgen-specific names for constants in headers

### DIFF
--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2010-2015 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2010-2015 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
-Copyright (C) 2010-2013 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 paramat, Matt Gregory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -527,7 +528,7 @@ void MapgenV5::generateCaves(int max_stone_y)
 		}
 	}
 
-	if (node_max.Y > LARGE_CAVE_DEPTH)
+	if (node_max.Y > MGV5_LARGE_CAVE_DEPTH)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -1,6 +1,7 @@
 /*
 Minetest
-Copyright (C) 2010-2013 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 paramat, Matt Gregory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-#define LARGE_CAVE_DEPTH -256
+#define MGV5_LARGE_CAVE_DEPTH -256
 
 class BiomeManager;
 

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2010-2015 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -304,13 +304,13 @@ float MapgenV6::baseTerrainLevelFromMap(int index)
 
 s16 MapgenV6::find_ground_level_from_noise(u64 seed, v2s16 p2d, s16 precision)
 {
-	return baseTerrainLevelFromNoise(p2d) + AVERAGE_MUD_AMOUNT;
+	return baseTerrainLevelFromNoise(p2d) + MGV6_AVERAGE_MUD_AMOUNT;
 }
 
 
 int MapgenV6::getGroundLevelAtPoint(v2s16 p)
 {
-	return baseTerrainLevelFromNoise(p) + AVERAGE_MUD_AMOUNT;
+	return baseTerrainLevelFromNoise(p) + MGV6_AVERAGE_MUD_AMOUNT;
 }
 
 
@@ -387,7 +387,7 @@ bool MapgenV6::getHaveAppleTree(v2s16 p)
 float MapgenV6::getMudAmount(int index)
 {
 	if (flags & MG_FLAT)
-		return AVERAGE_MUD_AMOUNT;
+		return MGV6_AVERAGE_MUD_AMOUNT;
 
 	/*return ((float)AVERAGE_MUD_AMOUNT + 2.0 * noise2d_perlin(
 			0.5+(float)p.X/200, 0.5+(float)p.Y/200,
@@ -422,13 +422,13 @@ BiomeV6Type MapgenV6::getBiome(int index, v2s16 p)
 	if (spflags & MGV6_SNOWBIOMES) {
 		float blend = (spflags & MGV6_BIOMEBLEND) ? noise2d(p.X, p.Y, seed) / 40 : 0;
 
-		if (d > FREQ_HOT + blend) {
-			if (h > FREQ_JUNGLE + blend)
+		if (d > MGV6_FREQ_HOT + blend) {
+			if (h > MGV6_FREQ_JUNGLE + blend)
 				return BT_JUNGLE;
 			else
 				return BT_DESERT;
-		} else if (d < FREQ_SNOW + blend) {
-			if (h > FREQ_TAIGA + blend)
+		} else if (d < MGV6_FREQ_SNOW + blend) {
+			if (h > MGV6_FREQ_TAIGA + blend)
 				return BT_TAIGA;
 			else
 				return BT_TUNDRA;
@@ -646,11 +646,11 @@ int MapgenV6::generateGround()
 		for (s16 y = node_min.Y; y <= node_max.Y; y++) {
 			if (vm->m_data[i].getContent() == CONTENT_IGNORE) {
 				if (y <= surface_y) {
-					vm->m_data[i] = (y >= DESERT_STONE_BASE
+					vm->m_data[i] = (y >= MGV6_DESERT_STONE_BASE
 							&& bt == BT_DESERT) ?
 						n_desert_stone : n_stone;
 				} else if (y <= water_level) {
-					vm->m_data[i] = (y >= ICE_BASE
+					vm->m_data[i] = (y >= MGV6_ICE_BASE
 							&& bt == BT_TUNDRA) ?
 						n_ice : n_water_source;
 				} else {

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2010-2015 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -23,13 +23,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen.h"
 #include "noise.h"
 
-#define AVERAGE_MUD_AMOUNT 4
-#define DESERT_STONE_BASE -32
-#define ICE_BASE 0
-#define FREQ_HOT 0.4
-#define FREQ_SNOW -0.4
-#define FREQ_TAIGA 0.5
-#define FREQ_JUNGLE 0.5
+#define MGV6_AVERAGE_MUD_AMOUNT 4
+#define MGV6_DESERT_STONE_BASE -32
+#define MGV6_ICE_BASE 0
+#define MGV6_FREQ_HOT 0.4
+#define MGV6_FREQ_SNOW -0.4
+#define MGV6_FREQ_TAIGA 0.5
+#define MGV6_FREQ_JUNGLE 0.5
 
 //////////// Mapgen V6 flags
 #define MGV6_JUNGLES    0x01

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
-Copyright (C) 2010-2013 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 paramat, Matt Gregory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -1,6 +1,7 @@
 /*
 Minetest
-Copyright (C) 2010-2013 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2010-2015 paramat, Matt Gregory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by


### PR DESCRIPTION
Also:
Update copyright years in all mapgens
Add myself to copyright notices in mgv5 and mgv7

To avoid possible duplication of constant names if multiple mapgen header files are #included elsewhere.