### PR TITLE
Fixed issue #3087, sneak glitch.

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -176,6 +176,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Maximum distance over border for sneaking
 	f32 sneak_max = BS*0.4;
 
+	// If not touching_ground then we cannot let player sneak
+	if (!touching_ground)
+	{
+		control.sneak = false;
+	}
+
 	/*
 		If sneaking, keep in range from the last walked node and don't
 		fall off from it


### PR DESCRIPTION
Me and a couple of student had for assignment to make a change in a public git repository. This is what we came up with.
Comparing to Minecraft you cannot latch on to a block by sneaking if you are already in the air. With this implementation the same goes for Minetest.

Please come with feed-back if you have any.