### PR TITLE
Fractal mapgen: Independant offset and slice params for mandelbrot and julia

### DIFF
--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -37,13 +37,13 @@ struct MapgenFractalParams : public MapgenSpecificParams {
 	u32 spflags;
 
 	u16 iterations;
-	float scale_x;
-	float scale_y;
-	float scale_z;
-	float offset_x;
-	float offset_y;
-	float offset_z;
-	float slice_w;
+	v3f scale;
+
+	v3f moffset;
+	float mslice_w;
+
+	v3f joffset;
+	float jslice_w;
 	float julia_x;
 	float julia_y;
 	float julia_z;
@@ -75,13 +75,13 @@ public:
 	v3s16 full_node_max;
 
 	u16 iterations;
-	float scale_x;
-	float scale_y;
-	float scale_z;
-	float offset_x;
-	float offset_y;
-	float offset_z;
-	float slice_w;
+	v3f scale;
+
+	v3f moffset;
+	float mslice_w;
+
+	v3f joffset;
+	float jslice_w;
 	float julia_x;
 	float julia_y;
 	float julia_z;


### PR DESCRIPTION
Also:

Player now spawns on julia set due to julia offset
Add commented-out '#include profiler.h' for timetaker use
Use v3fs to reduce number of parameters
Tune tunnel width to match mgv7