### PR TITLE
 ABMs: Make catch-up behaviour optional

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3063,10 +3063,14 @@ Definition tables
     {
     --  In the following two fields, also group:groupname will work.
         nodenames = {"default:lava_source"},
-        neighbors = {"default:water_source", "default:water_flowing"}, -- (any of these)
-    --  ^ If left out or empty, any neighbor will do
-        interval = 1.0, -- (operation interval)
-        chance = 1, -- (chance of trigger is 1.0/this)
+        neighbors = {"default:water_source", "default:water_flowing"}, -- Any of these --[[
+        ^ If left out or empty, any neighbor will do ]]
+        interval = 1.0, -- Operation interval in seconds
+        chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
+        catch_up = true, -- If true, catch-up behaviour is enabled --[[
+        ^ The chance value is temporarily reduced when returning to
+          an area to simulate time lost by the area being unattended.
+        ^ Note chance value can often be reduced to 1 ]]
         action = func(pos, node, active_object_count, active_object_count_wider),
     }
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -577,17 +577,21 @@ public:
 				i->timer -= trigger_interval;
 				actual_interval = trigger_interval;
 			}
-			float intervals = actual_interval / trigger_interval;
-			if(intervals == 0)
-				continue;
 			float chance = abm->getTriggerChance();
 			if(chance == 0)
 				chance = 1;
 			ActiveABM aabm;
 			aabm.abm = abm;
-			aabm.chance = chance / intervals;
-			if(aabm.chance == 0)
-				aabm.chance = 1;
+			if(abm->getSimpleCatchUp()) {
+				float intervals = actual_interval / trigger_interval;
+				if(intervals == 0)
+					continue;
+				aabm.chance = chance / intervals;
+				if(aabm.chance == 0)
+					aabm.chance = 1;
+			} else {
+				aabm.chance = chance;
+			}
 			// Trigger neighbors
 			std::set<std::string> required_neighbors_s
 					= abm->getRequiredNeighbors();

--- a/src/environment.h
+++ b/src/environment.h
@@ -155,6 +155,8 @@ public:
 	virtual float getTriggerInterval() = 0;
 	// Random chance of (1 / return value), 0 is disallowed
 	virtual u32 getTriggerChance() = 0;
+	// Whether to modify chance to simulate time lost by an unnattended block
+	virtual bool getSimpleCatchUp() = 0;
 	// This is called usually at interval for 1/chance of the nodes
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n){};
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -143,8 +143,11 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 			int trigger_chance = 50;
 			getintfield(L, current_abm, "chance", trigger_chance);
 
-			LuaABM *abm = new LuaABM(L, id, trigger_contents,
-					required_neighbors, trigger_interval, trigger_chance);
+			bool simple_catch_up = true;
+			getboolfield(L, current_abm, "catch_up", simple_catch_up);
+
+			LuaABM *abm = new LuaABM(L, id, trigger_contents, required_neighbors,
+				trigger_interval, trigger_chance, simple_catch_up);
 
 			env->addActiveBlockModifier(abm);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -184,16 +184,18 @@ private:
 	std::set<std::string> m_required_neighbors;
 	float m_trigger_interval;
 	u32 m_trigger_chance;
+	bool m_simple_catch_up;
 public:
 	LuaABM(lua_State *L, int id,
 			const std::set<std::string> &trigger_contents,
 			const std::set<std::string> &required_neighbors,
-			float trigger_interval, u32 trigger_chance):
+			float trigger_interval, u32 trigger_chance, bool simple_catch_up):
 		m_id(id),
 		m_trigger_contents(trigger_contents),
 		m_required_neighbors(required_neighbors),
 		m_trigger_interval(trigger_interval),
-		m_trigger_chance(trigger_chance)
+		m_trigger_chance(trigger_chance),
+		m_simple_catch_up(simple_catch_up)
 	{
 	}
 	virtual std::set<std::string> getTriggerContents()
@@ -211,6 +213,10 @@ public:
 	virtual u32 getTriggerChance()
 	{
 		return m_trigger_chance;
+	}
+	virtual bool getSimpleCatchUp()
+	{
+		return m_simple_catch_up;
 	}
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 			u32 active_object_count, u32 active_object_count_wider);


### PR DESCRIPTION
Default is true for backwards compatibility
Update lua_api.txt

Requested by Oldcoder and celeron55, see discussion here http://irc.minetest.ru/minetest-dev/2015-10-04#i_4414381
I agree a bool is needed, in almost every use of ABMs in my mods i find the catch up feature causes problems.
This is intended to be backwards compatible such that old ABM definitions missing the bool have the catch up behaviour enabled. The default is catchup enabled.
Tested and seems to work.