### PR TITLE
Report the effective dedicated server mode to serverlist

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1998,7 +1998,7 @@ bool Game::createSingleplayerServer(const std::string map_dir,
 	}
 
 	server = new Server(map_dir, gamespec, simple_singleplayer_mode,
-			    bind_addr.isIPv6());
+			    bind_addr.isIPv6(), false);
 
 	server->start(bind_addr);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -824,7 +824,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 
 	// Create server
 	Server server(game_params.world_path, game_params.game_spec, false,
-		bind_addr.isIPv6());
+		bind_addr.isIPv6(), game_params.is_dedicated_server);
 	server.start(bind_addr);
 
 	// Run server

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -148,8 +148,8 @@ Server::Server(
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		bool ipv6
-	):
+		bool ipv6,
+		bool dedicated) :
 	m_path_world(path_world),
 	m_gamespec(gamespec),
 	m_simple_singleplayer_mode(simple_singleplayer_mode),
@@ -177,8 +177,8 @@ Server::Server(
 	m_shutdown_ask_reconnect(false),
 	m_ignore_map_edit_events(false),
 	m_ignore_map_edit_events_peer_id(0),
-	m_next_sound_id(0)
-
+	m_next_sound_id(0),
+	m_dedicated(dedicated)
 {
 	m_liquid_transform_timer = 0.0;
 	m_liquid_transform_every = 1.0;
@@ -651,7 +651,8 @@ void Server::AsyncRunStep(bool initial_step)
 					m_lag,
 					m_gamespec.id,
 					m_emerge->params.mg_name,
-					m_mods);
+					m_mods,
+					m_dedicated);
 			counter = 0.01;
 		}
 		counter += dtime;

--- a/src/server.h
+++ b/src/server.h
@@ -171,8 +171,8 @@ public:
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		bool ipv6
-	);
+		bool ipv6,
+		bool dedicated);
 	~Server();
 	void start(Address bind_addr);
 	void stop();
@@ -500,6 +500,8 @@ private:
 	// If true, do not allow multiple players and hide some multiplayer
 	// functionality
 	bool m_simple_singleplayer_mode;
+
+	bool m_dedicated;
 
 	// Thread can set; step() will throw as ServerError
 	MutexedVariable<std::string> m_async_fatal_error;

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -200,7 +200,8 @@ void sendAnnounce(const std::string &action,
 		const float lag,
 		const std::string &gameid,
 		const std::string &mg_name,
-		const std::vector<ModSpec> &mods)
+		const std::vector<ModSpec> &mods,
+		bool dedicated)
 {
 	Json::Value server;
 	server["action"] = action;
@@ -234,7 +235,7 @@ void sendAnnounce(const std::string &action,
 	}
 
 	if (action == "start") {
-		server["dedicated"]         = g_settings->getBool("server_dedicated");
+		server["dedicated"]         = dedicated;
 		server["rollback"]          = g_settings->getBool("enable_rollback_recording");
 		server["mapgen"]            = mg_name;
 		server["privs"]             = g_settings->get("default_privs");

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -43,7 +43,8 @@ namespace ServerList
 			const double uptime = 0, const u32 game_time = 0,
 			const float lag = 0, const std::string &gameid = "",
 			const std::string &mg_name = "",
-			const std::vector<ModSpec> &mods = std::vector<ModSpec>());
+			const std::vector<ModSpec> &mods = std::vector<ModSpec>(),
+			bool dedicated = false);
 	#endif
 } // ServerList namespace
 


### PR DESCRIPTION
This fixes the case where servers started from within the game do not always have their dedicated server status reported correctly.
