### PR TITLE
findSpawnPos: Allow spawn up to 16 nodes above water level

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3277,9 +3277,8 @@ v3f Server::findSpawnPos()
 
 		// Get ground height at point
 		s16 groundheight = map.findGroundLevel(nodepos2d);
-		if (groundheight <= water_level) // Don't go underwater
-			continue;
-		if (groundheight > water_level + 6) // Don't go to high places
+		// Don't go underwater or to high places
+		if (groundheight <= water_level || groundheight > water_level + 16)
 			continue;
 
 		v3s16 nodepos(nodepos2d.X, groundheight, nodepos2d.Y);


### PR DESCRIPTION
Change from 6 to 16 nodes above water_level.
Mgv6 is on a small scale, now we have mapgens on larger scales (and more specialised mapgens possibly coming in future) there is less chance of low land close to (0, 0).
With this commit spawn is found faster and closer to (0, 0), there is less chance of the 1000 attempts being unsuccessful and the player being spawned at (0, 0, 0) underground or in an ocean.