### PR TITLE
Fixed issue #3262, add checking for empty log file name.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,7 +540,7 @@ static void init_log_streams(const Settings &cmd_args)
 		conf_loglev = lev_name[lev_i];
 	}
 
-	if (conf_loglev.empty())  // No logging
+	if (log_filename.empty() || conf_loglev.empty())  // No logging
 		return;
 
 	LogLevel log_level = Logger::stringToLevel(conf_loglev);


### PR DESCRIPTION
This should make `--logfile ''` working.