### PR TITLE
Decoration API: Add flag for placement on liquid surface

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -801,15 +801,13 @@ Decoration types
 ----------------
 The varying types of decorations that can be placed.
 
-The default value is `simple`, and is currently the only type supported.
-
 ### `simple`
 Creates a 1 times `H` times 1 column of a specified node (or a random node from
 a list, if a decoration list is specified). Can specify a certain node it must
 spawn next to, such as water or lava, for example. Can also generate a
 decoration of random height between a specified lower and upper bound.
 This type of decoration is intended for placement of grass, flowers, cacti,
-papyri, and so on.
+papyri, waterlilies and so on.
 
 ### `schematic`
 Copies a box of `MapNodes` from a specified schematic file (or raw description).
@@ -848,8 +846,8 @@ Schematic attributes
 --------------------
 See section "Flag Specifier Format".
 
-Currently supported flags: `place_center_x`, `place_center_y`,
-			   `place_center_z`, `force_placement`.
+Currently supported flags: `place_center_x`, `place_center_y`, `place_center_z`,
+                           `force_placement`.
 
 * `place_center_x`: Placement of this decoration is centered along the X axis.
 * `place_center_y`: Placement of this decoration is centered along the Y axis.
@@ -3418,6 +3416,11 @@ Definition tables
     -- ^ Minimum and maximum `y` positions these decorations can be generated at.
     -- ^ This parameter refers to the `y` position of the decoration base, so
     --   the actual maximum height would be `height_max + size.Y`.
+        flags = "liquid_surface",
+    --  ^ Flags for all decoration types.
+    --  ^ "liquid_surface": Instead of placement on the highest solid surface
+    --  ^ in a mapchunk column, placement is on the highest liquid surface.
+    --  ^ Placement is disabled if solid nodes are found above the liquid surface.
 
         ----- Simple-type parameters
         decoration = "default:grass",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -161,6 +161,26 @@ s16 Mapgen::findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax)
 }
 
 
+// Returns -MAX_MAP_GENERATION_LIMIT if not found or if ground is found first
+s16 Mapgen::findLiquidSurface(v2s16 p2d, s16 ymin, s16 ymax)
+{
+	v3s16 em = vm->m_area.getExtent();
+	u32 i = vm->m_area.index(p2d.X, ymax, p2d.Y);
+	s16 y;
+
+	for (y = ymax; y >= ymin; y--) {
+		MapNode &n = vm->m_data[i];
+		if (ndef->get(n).walkable)
+			return -MAX_MAP_GENERATION_LIMIT;
+		else if (ndef->get(n).isLiquid())
+			break;
+
+		vm->m_area.add_y(em, i, -1);
+	}
+	return (y >= ymin) ? y : -MAX_MAP_GENERATION_LIMIT;
+}
+
+
 void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 {
 	if (!heightmap)

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -166,6 +166,7 @@ public:
 	static u32 getBlockSeed2(v3s16 p, int seed);
 	s16 findGroundLevelFull(v2s16 p2d);
 	s16 findGroundLevel(v2s16 p2d, s16 ymin, s16 ymax);
+	s16 findLiquidSurface(v2s16 p2d, s16 ymin, s16 ymax);
 	void updateHeightmap(v3s16 nmin, v3s16 nmax);
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -30,6 +30,7 @@ FlagDesc flagdesc_deco[] = {
 	{"place_center_y", DECO_PLACE_CENTER_Y},
 	{"place_center_z", DECO_PLACE_CENTER_Z},
 	{"force_placement", DECO_FORCE_PLACEMENT},
+	{"liquid_surface", DECO_LIQUID_SURFACE},
 	{NULL,             0}
 };
 
@@ -124,9 +125,13 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 
 			int mapindex = carea_size * (z - nmin.Z) + (x - nmin.X);
 
-			s16 y = mg->heightmap ?
-					mg->heightmap[mapindex] :
-					mg->findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
+			s16 y = -MAX_MAP_GENERATION_LIMIT;
+			if (flags & DECO_LIQUID_SURFACE)
+				y = mg->findLiquidSurface(v2s16(x, z), nmin.Y, nmax.Y);
+			else if (mg->heightmap)
+				y = mg->heightmap[mapindex];
+			else
+				y = mg->findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
 
 			if (y < nmin.Y || y > nmax.Y ||
 				y < y_min  || y > y_max)

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -41,6 +41,7 @@ enum DecorationType {
 #define DECO_PLACE_CENTER_Z  0x04
 #define DECO_USE_NOISE       0x08
 #define DECO_FORCE_PLACEMENT 0x10
+#define DECO_LIQUID_SURFACE  0x20
 
 extern FlagDesc flagdesc_deco[];
 


### PR DESCRIPTION
Add findLiquidSurface() function to mapgen.cpp
Update lua_api.txt

![screenshot_20151021_130024](https://cloud.githubusercontent.com/assets/3686677/10636019/a8342b86-77f4-11e5-8210-a7075caa1383.png)

Currently a mess is made if water level is changed in mgv5/mgv7. Water lily and papyrus schematics appear at the wrong altitude, the water node placed by the waterlily schematic causes floods. This reminded me to add the long-overdue option of placing decorations on a liquid surface.

The new findLiquidSurface() function searches downwards through a mapchunk column and returns the level of the first liquid node found, if ground is found first the function returns -31000 disabling the decoration placement, this is to prevent decorations being placed under overhangs and in dark places.

Placing waterlilies this way does not allow random rotation, so a follow-up commit could add optional random rotation to simple decorations.

Keeping the waterlilies in shallow water will be another issue but can be solved using biome definitions (making swamp biomes shallower). Anyway it's not absolutely certain we will stop using schematics for waterlilies.

Works for schematic decorations too:

![screenshot_20151021_130559](https://cloud.githubusercontent.com/assets/3686677/10636041/c5bc6df8-77f4-11e5-9c79-c982e2da49d5.png)