### PR TITLE
Fix MSVC compiling errors in threading and gettext

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -119,7 +119,7 @@ const char* MSVC_LocaleLookup(const char* raw_shortname) {
 /******************************************************************************/
 #ifdef _MSC_VER
 void init_gettext(const char *path, const std::string &configured_language,
-	int argc, const char *argv[])
+	int argc, char *argv[])
 #else
 void init_gettext(const char *path, const std::string &configured_language)
 #endif
@@ -164,7 +164,7 @@ void init_gettext(const char *path, const std::string &configured_language)
 
 			// Allow calling without an extension
 			std::string app_name = argv[0];
-			if (app_name.compare(appname.size() - 4, 4, ".exe") != 0)
+			if (app_name.compare(app_name.size() - 4, 4, ".exe") != 0)
 				app_name += ".exe";
 
 			STARTUPINFO startup_info = {0};

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -34,7 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifdef _MSC_VER
 void init_gettext(const char *path, const std::string &configured_language,
-		int argc, const char *argv[]);
+		int argc, char *argv[]);
 #else
 void init_gettext(const char *path, const std::string &configured_language);
 #endif


### PR DESCRIPTION
- Can not convert `char*[]` to `const char*[]`
- Remove brackets of name definition

MSVC fails to compile without those changes.