### PR TITLE
Improve rollback database indexing

### DIFF
--- a/src/rollback.cpp
+++ b/src/rollback.cpp
@@ -240,8 +240,7 @@ bool RollbackManager::createTables()
 		"	FOREIGN KEY (`oldNode`)   REFERENCES `node`(`id`),\n"
 		"	FOREIGN KEY (`newNode`)   REFERENCES `node`(`id`)\n"
 		");\n"
-		"CREATE INDEX IF NOT EXISTS `actionActor` ON `action`(`actor`);\n"
-		"CREATE INDEX IF NOT EXISTS `actionTimestamp` ON `action`(`timestamp`);\n",
+		"CREATE INDEX IF NOT EXISTS `actionIndex` ON `action`(`x`,`y`,`z`,`timestamp`,`actor`);\n",
 		NULL, NULL, NULL));
 	verbosestream << "SQL Rollback: SQLite3 database structure was created" << std::endl;
 


### PR DESCRIPTION
This change makes the rollback database be indexed on x, y, and z in addition to the previous actor and timestamp. This makes /rollback_check much faster.

I did some testing on a copy of the rollback DB from VanessaE's basic server (1.6 GB, although it did grow to around 2 GB with the extra indexes), and it reduced the approximate time for a /rollback_check in many areas from ~10s to <100ms.

As far as the concern of row insertion performance, est31 and I did some performance tests, and couldn't find a significant difference.

Note that this does not affect existing databases, only newly created ones (although it is backwards- and forwards-compatible). The following SQL commands would have the same effect on an existing DB:

DROP INDEX actionActor;
DROP INDEX actionTimestamp;
CREATE INDEX actionIndex ON action(x,y,z,timestamp,actor);