### PR TITLE
Environment: Time of day fixes and add serverside getter

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -180,20 +180,21 @@ std::vector<Player*> Environment::getPlayers(bool ignore_disconnected)
 
 u32 Environment::getDayNightRatio()
 {
-	if(m_enable_day_night_ratio_override)
+	MutexAutoLock(this->m_time_lock);
+	if (m_enable_day_night_ratio_override)
 		return m_day_night_ratio_override;
-	return time_to_daynight_ratio(m_time_of_day_f*24000, m_cache_enable_shaders);
+	return time_to_daynight_ratio(m_time_of_day_f * 24000, m_cache_enable_shaders);
 }
 
 void Environment::setTimeOfDaySpeed(float speed)
 {
-	MutexAutoLock(this->m_timeofday_lock);
+	MutexAutoLock(this->m_time_lock);
 	m_time_of_day_speed = speed;
 }
 
 float Environment::getTimeOfDaySpeed()
 {
-	MutexAutoLock(this->m_timeofday_lock);
+	MutexAutoLock(this->m_time_lock);
 	float retval = m_time_of_day_speed;
 	return retval;
 }
@@ -221,29 +222,28 @@ float Environment::getTimeOfDayF()
 
 void Environment::stepTimeOfDay(float dtime)
 {
-	// getTimeOfDaySpeed lock the value we need to prevent MT problems
-	float day_speed = getTimeOfDaySpeed();
+	MutexAutoLock(this->m_time_lock);
 
 	m_time_counter += dtime;
-	f32 speed = day_speed * 24000./(24.*3600);
-	u32 units = (u32)(m_time_counter*speed);
+	f32 speed = m_time_of_day_speed * 24000. / (24. * 3600);
+	u32 units = (u32)(m_time_counter * speed);
 	bool sync_f = false;
-	if(units > 0){
+	if (units > 0) {
 		// Sync at overflow
-		if(m_time_of_day + units >= 24000)
+		if (m_time_of_day + units >= 24000)
 			sync_f = true;
 		m_time_of_day = (m_time_of_day + units) % 24000;
-		if(sync_f)
+		if (sync_f)
 			m_time_of_day_f = (float)m_time_of_day / 24000.0;
 	}
 	if (speed > 0) {
 		m_time_counter -= (f32)units / speed;
 	}
-	if(!sync_f){
-		m_time_of_day_f += day_speed/24/3600*dtime;
-		if(m_time_of_day_f > 1.0)
+	if (!sync_f) {
+		m_time_of_day_f += m_time_of_day_speed / 24 / 3600 * dtime;
+		if (m_time_of_day_f > 1.0)
 			m_time_of_day_f -= 1.0;
-		if(m_time_of_day_f < 0.0)
+		if (m_time_of_day_f < 0.0)
 			m_time_of_day_f += 1.0;
 	}
 }

--- a/src/environment.h
+++ b/src/environment.h
@@ -104,6 +104,11 @@ public:
 protected:
 	// peer_ids in here should be unique, except that there may be many 0s
 	std::vector<Player*> m_players;
+
+
+	/*
+	 *  Below: values under m_time_lock
+	 */
 	// Time of day in milli-hours (0-23999); determines day and night
 	u32 m_time_of_day;
 	// Time of day in 0...1
@@ -114,6 +119,9 @@ protected:
 	// Overriding the day-night ratio is useful for custom sky visuals
 	bool m_enable_day_night_ratio_override;
 	u32 m_day_night_ratio_override;
+	/*
+	 * Above: values under m_time_lock
+	 */
 
 	/* TODO: Add a callback function so these can be updated when a setting
 	 *       changes.  At this point in time it doesn't matter (e.g. /set
@@ -127,7 +135,6 @@ protected:
 	bool m_cache_enable_shaders;
 
 private:
-	Mutex m_timeofday_lock;
 	Mutex m_time_lock;
 
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1249,6 +1249,11 @@ void Server::setTimeOfDay(u32 time)
 	m_time_of_day_send_timer = 0;
 }
 
+u32 Server::getTimeOfDay()
+{
+	return m_env->getTimeOfDay();
+}
+
 void Server::onMapEditEvent(MapEditEvent *event)
 {
 	if(m_ignore_map_edit_events)

--- a/src/server.h
+++ b/src/server.h
@@ -220,8 +220,10 @@ public:
 
 	void Send(NetworkPacket* pkt);
 
-	// Environment must be locked when called
+	// Both setter and getter need no envlock,
+	// can be called freely from threads
 	void setTimeOfDay(u32 time);
+	inline u32 getTimeOfDay();
 
 	/*
 		Shall be called with the environment locked.


### PR DESCRIPTION
-> Put access to time variables under the time lock.
-> Merge both time locks, there is no point to have two locks.
-> Fix the lock being released too early in Environment::setTimeOfDay
-> Add serverside getter so that you don't have to get
	the environment if you only have the server