### PR TITLE
Use standard sized integer types

### DIFF
--- a/src/chat.h
+++ b/src/chat.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef CHAT_HEADER
 #define CHAT_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include <string>
 #include <vector>
 #include <list>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1472,13 +1472,13 @@ ClientActiveObject * Client::getSelectedActiveObject(
 	{
 		ClientActiveObject *obj = objects[i].obj;
 
-		core::aabbox3d<f32> *selection_box = obj->getSelectionBox();
+		aabb3f *selection_box = obj->getSelectionBox();
 		if(selection_box == NULL)
 			continue;
 
 		v3f pos = obj->getPosition();
 
-		core::aabbox3d<f32> offsetted_box(
+		aabb3f offsetted_box(
 				selection_box->MinEdge + pos,
 				selection_box->MaxEdge + pos
 		);

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -530,7 +530,7 @@ bool ClientLauncher::create_engine_device()
 			"defaulting to opengl" << std::endl;
 	}
 
-	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
+	irr::SIrrlichtCreationParameters params;
 	params.DriverType    = driverType;
 	params.WindowSize    = core::dimension2d<u32>(screenW, screenH);
 	params.Bits          = bits;
@@ -546,7 +546,7 @@ bool ClientLauncher::create_engine_device()
 			"media" + DIR_DELIM + "Shaders" + DIR_DELIM).c_str();
 #endif
 
-	device = createDeviceEx(params);
+	device = irr::createDeviceEx(params);
 
 	if (device) {
 		porting::initIrrlicht(device);
@@ -662,7 +662,7 @@ bool ClientLauncher::print_video_modes()
 	u16 fsaa = g_settings->getU16("fsaa");
 	MyEventReceiver* receiver = new MyEventReceiver();
 
-	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
+	irr::SIrrlichtCreationParameters params;
 	params.DriverType    = video::EDT_NULL;
 	params.WindowSize    = core::dimension2d<u32>(640, 480);
 	params.Bits          = 24;
@@ -673,7 +673,7 @@ bool ClientLauncher::print_video_modes()
 	params.EventReceiver = receiver;
 	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
 
-	nulldevice = createDeviceEx(params);
+	nulldevice = irr::createDeviceEx(params);
 
 	if (nulldevice == NULL) {
 		delete receiver;

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes_extrabloated.h"
 
-class MyEventReceiver : public IEventReceiver
+class MyEventReceiver : public irr::IEventReceiver
 {
 public:
 	// This is the one method that we have to implement
@@ -69,20 +69,13 @@ public:
 				middle_active = event.MouseInput.isMiddlePressed();
 				right_active = event.MouseInput.isRightPressed();
 
-				if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
-					leftclicked = true;
-				}
-				if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
-					rightclicked = true;
-				}
-				if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
-					leftreleased = true;
-				}
-				if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
-					rightreleased = true;
-				}
-				if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
-					mouse_wheel += event.MouseInput.Wheel;
+				switch (event.MouseInput.Event) {
+				case irr::EMIE_LMOUSE_PRESSED_DOWN: leftclicked = true; break;
+				case irr::EMIE_RMOUSE_PRESSED_DOWN: rightclicked = true; break;
+				case irr::EMIE_LMOUSE_LEFT_UP: leftreleased = true; break;
+				case irr::EMIE_RMOUSE_LEFT_UP: rightreleased = true; break;
+				case irr::EMIE_MOUSE_WHEEL: mouse_wheel += event.MouseInput.Wheel; break;
+				default: break;
 				}
 			}
 		} else if (event.EventType == irr::EET_LOG_TEXT_EVENT) {

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef TILE_HEADER
 #define TILE_HEADER
 
+#include "int_types.h"
 #include "irrlichttypes.h"
 #include "irr_v2d.h"
 #include "irr_v3d.h"

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -50,7 +50,7 @@ ClientMap::ClientMap(
 	m_camera_direction(0,0,1),
 	m_camera_fov(M_PI)
 {
-	m_box = core::aabbox3d<f32>(-BS*1000000,-BS*1000000,-BS*1000000,
+	m_box = aabb3f(-BS*1000000,-BS*1000000,-BS*1000000,
 			BS*1000000,BS*1000000,BS*1000000);
 
 	/* TODO: Add a callback function so these can be updated when a setting

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -116,7 +116,7 @@ public:
 		renderMap(driver, SceneManager->getSceneNodeRenderPass());
 	}
 	
-	virtual const core::aabbox3d<f32>& getBoundingBox() const
+	virtual const aabb3f& getBoundingBox() const
 	{
 		return m_box;
 	}
@@ -141,7 +141,7 @@ public:
 private:
 	Client *m_client;
 	
-	core::aabbox3d<f32> m_box;
+	aabb3f m_box;
 	
 	MapDrawControl &m_control;
 

--- a/src/clientmedia.h
+++ b/src/clientmedia.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef CLIENTMEDIA_HEADER
 #define CLIENTMEDIA_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "filecache.h"
 #include <ostream>
 #include <map>

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -56,7 +56,7 @@ public:
 	virtual void updateLight(u8 light_at_pos){}
 	virtual void updateLightNoCheck(u8 light_at_pos){}
 	virtual v3s16 getLightPosition(){return v3s16(0,0,0);}
-	virtual core::aabbox3d<f32>* getSelectionBox(){return NULL;}
+	virtual aabb3f* getSelectionBox(){return NULL;}
 	virtual bool getCollisionBox(aabb3f *toset){return false;}
 	virtual bool collideWithObjects(){return false;}
 	virtual v3f getPosition(){return v3f(0,0,0);}

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -62,7 +62,7 @@ Clouds::Clouds(
 	g_settings->registerChangedCallback("enable_3d_clouds",
 		&cloud_3d_setting_changed, this);
 
-	m_box = core::aabbox3d<f32>(-BS*1000000,m_cloud_y-BS,-BS*1000000,
+	m_box = aabb3f(-BS*1000000,m_cloud_y-BS,-BS*1000000,
 			BS*1000000,m_cloud_y+BS,BS*1000000);
 
 }

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -53,7 +53,7 @@ public:
 
 	virtual void render();
 	
-	virtual const core::aabbox3d<f32>& getBoundingBox() const
+	virtual const aabb3f& getBoundingBox() const
 	{
 		return m_box;
 	}
@@ -79,7 +79,7 @@ public:
 	void updateCameraOffset(v3s16 camera_offset)
 	{
 		m_camera_offset = camera_offset;
-		m_box = core::aabbox3d<f32>(-BS * 1000000, m_cloud_y - BS - BS * camera_offset.Y, -BS * 1000000,
+		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS - BS * camera_offset.Y, -BS * 1000000,
 			BS * 1000000, m_cloud_y + BS - BS * camera_offset.Y, BS * 1000000);
 	}
 
@@ -87,7 +87,7 @@ public:
 
 private:
 	video::SMaterial m_material;
-	core::aabbox3d<f32> m_box;
+	aabb3f m_box;
 	s16 m_passed_cloud_y;
 	float m_cloud_y;
 	u16 m_cloud_radius_i;

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -309,7 +309,7 @@ public:
 
 	void initialize(const std::string &data);
 
-	core::aabbox3d<f32>* getSelectionBox()
+	aabb3f* getSelectionBox()
 		{return &m_selection_box;}
 	v3f getPosition()
 		{return m_position;}
@@ -319,7 +319,7 @@ public:
 
 	bool getCollisionBox(aabb3f *toset) { return false; }
 private:
-	core::aabbox3d<f32> m_selection_box;
+	aabb3f m_selection_box;
 	scene::IMeshSceneNode *m_node;
 	v3f m_position;
 	std::string m_itemstring;
@@ -675,7 +675,7 @@ GenericCAO::~GenericCAO()
 	removeFromScene(true);
 }
 
-core::aabbox3d<f32>* GenericCAO::getSelectionBox()
+aabb3f* GenericCAO::getSelectionBox()
 {
 	if(!m_prop.is_visible || !m_is_visible || m_is_local_player || getParent() != NULL)
 		return NULL;
@@ -1186,7 +1186,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		if(m_prop.physical)
 		{
-			core::aabbox3d<f32> box = m_prop.collisionbox;
+			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
 			collisionMoveResult moveresult;

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -65,7 +65,7 @@ private:
 	//
 	scene::ISceneManager *m_smgr;
 	IrrlichtDevice *m_irr;
-	core::aabbox3d<f32> m_selection_box;
+	aabb3f m_selection_box;
 	scene::IMeshSceneNode *m_meshnode;
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode;
 	WieldMeshSceneNode *m_wield_meshnode;
@@ -128,7 +128,7 @@ public:
 
 	bool collideWithObjects();
 
-	core::aabbox3d<f32>* getSelectionBox();
+	aabb3f* getSelectionBox();
 
 	v3f getPosition();
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -259,7 +259,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	else
 	{
 		if(m_prop.physical){
-			core::aabbox3d<f32> box = m_prop.collisionbox;
+			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
 			collisionMoveResult moveresult;
@@ -776,7 +776,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, Player *player_, u16 peer_id_,
 	m_prop.hp_max = PLAYER_MAX_HP;
 	m_prop.physical = false;
 	m_prop.weight = 75;
-	m_prop.collisionbox = core::aabbox3d<f32>(-1/3.,-1.0,-1/3., 1/3.,1.0,1/3.);
+	m_prop.collisionbox = aabb3f(-1/3.,-1.0,-1/3., 1/3.,1.0,1/3.);
 	// start of default appearance, this should be overwritten by LUA
 	m_prop.visual = "upright_sprite";
 	m_prop.visual_size = v2f(1, 2);

--- a/src/database-dummy.h
+++ b/src/database-dummy.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <string>
 #include "database.h"
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 class Database_Dummy : public Database
 {

--- a/src/database.h
+++ b/src/database.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include <string>
 #include "irr_v3d.h"
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 #ifndef PP
 	#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GAMEDEF_HEADER
 
 #include <string>
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 class IItemDefManager;
 class INodeDefManager;
@@ -63,9 +63,9 @@ public:
 	// Only usable on the client
 	virtual ISoundManager* getSoundManager()=0;
 	virtual MtEventManager* getEventManager()=0;
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename)
+	virtual irr::scene::IAnimatedMesh* getMesh(const std::string &filename)
 	{ return NULL; }
-	virtual scene::ISceneManager* getSceneManager()=0;
+	virtual irr::scene::ISceneManager* getSceneManager()=0;
 
 	// Only usable on the server, and NOT thread-safe. It is usable from the
 	// environment thread.

--- a/src/gettime.h
+++ b/src/gettime.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef GETTIME_HEADER
 #define GETTIME_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 /*
 	Get a millisecond counter value.

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -381,7 +381,7 @@ void GUIChatConsole::drawPrompt()
 
 bool GUIChatConsole::OnEvent(const SEvent& event)
 {
-	if(event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown)
+	if(event.EventType == irr::EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown)
 	{
 		// Key input
 		if(KeyPress(event.KeyInput) == getKeySetting("keymap_console"))
@@ -393,44 +393,44 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			m_open_inhibited = 50;
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_ESCAPE)
+		else if(event.KeyInput.Key == irr::KEY_ESCAPE)
 		{
 			closeConsoleAtOnce();
 			Environment->removeFocus(this);
 			// the_game will open the pause menu
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_PRIOR)
+		else if(event.KeyInput.Key == irr::KEY_PRIOR)
 		{
 			m_chat_backend->scrollPageUp();
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_NEXT)
+		else if(event.KeyInput.Key == irr::KEY_NEXT)
 		{
 			m_chat_backend->scrollPageDown();
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_RETURN)
+		else if(event.KeyInput.Key == irr::KEY_RETURN)
 		{
 			std::wstring text = m_chat_backend->getPrompt().submit();
 			m_client->typeChatMessage(text);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_UP)
+		else if(event.KeyInput.Key == irr::KEY_UP)
 		{
 			// Up pressed
 			// Move back in history
 			m_chat_backend->getPrompt().historyPrev();
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_DOWN)
+		else if(event.KeyInput.Key == irr::KEY_DOWN)
 		{
 			// Down pressed
 			// Move forward in history
 			m_chat_backend->getPrompt().historyNext();
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_LEFT)
+		else if(event.KeyInput.Key == irr::KEY_LEFT)
 		{
 			// Left or Ctrl-Left pressed
 			// move character / word to the left
@@ -444,7 +444,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_RIGHT)
+		else if(event.KeyInput.Key == irr::KEY_RIGHT)
 		{
 			// Right or Ctrl-Right pressed
 			// move character / word to the right
@@ -458,7 +458,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_HOME)
+		else if(event.KeyInput.Key == irr::KEY_HOME)
 		{
 			// Home pressed
 			// move to beginning of line
@@ -468,7 +468,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_END)
+		else if(event.KeyInput.Key == irr::KEY_END)
 		{
 			// End pressed
 			// move to end of line
@@ -478,7 +478,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_BACK)
+		else if(event.KeyInput.Key == irr::KEY_BACK)
 		{
 			// Backspace or Ctrl-Backspace pressed
 			// delete character / word to the left
@@ -492,7 +492,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_DELETE)
+		else if(event.KeyInput.Key == irr::KEY_DELETE)
 		{
 			// Delete or Ctrl-Delete pressed
 			// delete character / word to the right
@@ -506,12 +506,12 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				scope);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_KEY_V && event.KeyInput.Control)
+		else if(event.KeyInput.Key == irr::KEY_KEY_V && event.KeyInput.Control)
 		{
 			// Ctrl-V pressed
 			// paste text from clipboard
-			IOSOperator *os_operator = Environment->getOSOperator();
-			const c8 *text = os_operator->getTextFromClipboard();
+			irr::IOSOperator *os_operator = Environment->getOSOperator();
+			const irr::c8 *text = os_operator->getTextFromClipboard();
 			if (text)
 			{
 				std::wstring wtext = narrow_to_wide(text);
@@ -519,7 +519,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			}
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_KEY_U && event.KeyInput.Control)
+		else if(event.KeyInput.Key == irr::KEY_KEY_U && event.KeyInput.Control)
 		{
 			// Ctrl-U pressed
 			// kill line to left end
@@ -529,7 +529,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_KEY_K && event.KeyInput.Control)
+		else if(event.KeyInput.Key == irr::KEY_KEY_K && event.KeyInput.Control)
 		{
 			// Ctrl-K pressed
 			// kill line to right end
@@ -539,7 +539,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			return true;
 		}
-		else if(event.KeyInput.Key == KEY_TAB)
+		else if(event.KeyInput.Key == irr::KEY_TAB)
 		{
 			// Tab or Shift-Tab pressed
 			// Nick completion
@@ -560,9 +560,9 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			return true;
 		}
 	}
-	else if(event.EventType == EET_MOUSE_INPUT_EVENT)
+	else if(event.EventType == irr::EET_MOUSE_INPUT_EVENT)
 	{
-		if(event.MouseInput.Event == EMIE_MOUSE_WHEEL)
+		if(event.MouseInput.Event == irr::EMIE_MOUSE_WHEEL)
 		{
 			s32 rows = myround(-3.0 * event.MouseInput.Wheel);
 			m_chat_backend->scroll(rows);

--- a/src/guiEngine.h
+++ b/src/guiEngine.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /******************************************************************************/
 /* Includes                                                                   */
 /******************************************************************************/
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "modalMenu.h"
 #include "guiFormSpecMenu.h"
 #include "sound.h"

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -959,8 +959,8 @@ void GUIFormSpecMenu::parsePwdField(parserData* data,std::string element)
 		e->setPasswordBox(true,L'*');
 
 		irr::SEvent evt;
-		evt.EventType            = EET_KEY_INPUT_EVENT;
-		evt.KeyInput.Key         = KEY_END;
+		evt.EventType            = irr::EET_KEY_INPUT_EVENT;
+		evt.KeyInput.Key         = irr::KEY_END;
 		evt.KeyInput.Char        = 0;
 		evt.KeyInput.Control     = 0;
 		evt.KeyInput.Shift       = 0;
@@ -1032,8 +1032,8 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 		}
 
 		irr::SEvent evt;
-		evt.EventType            = EET_KEY_INPUT_EVENT;
-		evt.KeyInput.Key         = KEY_END;
+		evt.EventType            = irr::EET_KEY_INPUT_EVENT;
+		evt.KeyInput.Key         = irr::KEY_END;
 		evt.KeyInput.Char        = 0;
 		evt.KeyInput.Control     = 0;
 		evt.KeyInput.Shift       = 0;
@@ -1139,8 +1139,8 @@ void GUIFormSpecMenu::parseTextArea(parserData* data,
 			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 		} else {
 			irr::SEvent evt;
-			evt.EventType            = EET_KEY_INPUT_EVENT;
-			evt.KeyInput.Key         = KEY_END;
+			evt.EventType            = irr::EET_KEY_INPUT_EVENT;
+			evt.KeyInput.Key         = irr::KEY_END;
 			evt.KeyInput.Char        = 0;
 			evt.KeyInput.Control     = 0;
 			evt.KeyInput.Shift       = 0;
@@ -2776,8 +2776,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	// using the font that is selected at the time of button release.
 	// To make these two consistent, temporarily override the skin's
 	// font while the IGUITabControl is processing the event.
-	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
-			event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+			event.MouseInput.Event == irr::EMIE_LMOUSE_LEFT_UP) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
 		gui::IGUIElement *hovered =
@@ -2796,11 +2796,11 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	}
 
 	// Fix Esc/Return key being eaten by checkboxen and tables
-	if(event.EventType==EET_KEY_INPUT_EVENT) {
+	if(event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
-		if (kp == EscapeKey || kp == CancelKey
-				|| kp == getKeySetting("keymap_inventory")
-				|| event.KeyInput.Key==KEY_RETURN) {
+		if (kp == EscapeKey || kp == CancelKey ||
+				kp == getKeySetting("keymap_inventory") ||
+				event.KeyInput.Key == irr::KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
 			if (focused && isMyChild(focused) &&
 					(focused->getType() == gui::EGUIET_LIST_BOX ||
@@ -2811,8 +2811,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		}
 	}
 	// Mouse wheel events: send to hovered element instead of focused
-	if(event.EventType==EET_MOUSE_INPUT_EVENT
-			&& event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
+	if(event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+			event.MouseInput.Event == irr::EMIE_MOUSE_WHEEL) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
 		gui::IGUIElement *hovered =
@@ -2824,13 +2824,13 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		}
 	}
 
-	if (event.EventType == EET_MOUSE_INPUT_EVENT) {
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
 		gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(x, y));
-		if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+		if (event.MouseInput.Event == irr::EMIE_LMOUSE_PRESSED_DOWN) {
 			m_old_tooltip_id = -1;
 			m_old_tooltip = "";
 		}
@@ -2843,8 +2843,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 
 	#ifdef __ANDROID__
 	// display software keyboard when clicking edit boxes
-	if (event.EventType == EET_MOUSE_INPUT_EVENT
-			&& event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+			event.MouseInput.Event == irr::EMIE_LMOUSE_PRESSED_DOWN) {
 		gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
@@ -2881,11 +2881,11 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		}
 	}
 
-	if (event.EventType == EET_TOUCH_INPUT_EVENT)
+	if (event.EventType == irr::EET_TOUCH_INPUT_EVENT)
 	{
 		SEvent translated;
 		memset(&translated, 0, sizeof(SEvent));
-		translated.EventType   = EET_MOUSE_INPUT_EVENT;
+		translated.EventType   = irr::EET_MOUSE_INPUT_EVENT;
 		gui::IGUIElement* root = Environment->getRootGUIElement();
 
 		if (!root) {
@@ -2909,17 +2909,17 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 			switch (event.TouchInput.Event) {
 				case ETIE_PRESSED_DOWN:
 					m_pointer = v2s32(event.TouchInput.X,event.TouchInput.Y);
-					translated.MouseInput.Event = EMIE_LMOUSE_PRESSED_DOWN;
+					translated.MouseInput.Event = irr::EMIE_LMOUSE_PRESSED_DOWN;
 					translated.MouseInput.ButtonStates = EMBSM_LEFT;
 					m_down_pos = m_pointer;
 					break;
 				case ETIE_MOVED:
 					m_pointer = v2s32(event.TouchInput.X,event.TouchInput.Y);
-					translated.MouseInput.Event = EMIE_MOUSE_MOVED;
+					translated.MouseInput.Event = irr::EMIE_MOUSE_MOVED;
 					translated.MouseInput.ButtonStates = EMBSM_LEFT;
 					break;
 				case ETIE_LEFT_UP:
-					translated.MouseInput.Event = EMIE_LMOUSE_LEFT_UP;
+					translated.MouseInput.Event = irr::EMIE_LMOUSE_LEFT_UP;
 					translated.MouseInput.ButtonStates = 0;
 					hovered = root->getElementFromPoint(m_down_pos);
 					/* we don't have a valid pointer element use last
@@ -2941,7 +2941,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 				(event.TouchInput.Event == ETIE_PRESSED_DOWN) ) {
 			hovered = root->getElementFromPoint(m_down_pos);
 
-			translated.MouseInput.Event = EMIE_RMOUSE_PRESSED_DOWN;
+			translated.MouseInput.Event = irr::EMIE_RMOUSE_PRESSED_DOWN;
 			translated.MouseInput.ButtonStates = EMBSM_LEFT | EMBSM_RIGHT;
 			translated.MouseInput.X = m_pointer.X;
 			translated.MouseInput.Y = m_pointer.Y;
@@ -2950,7 +2950,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 				hovered->OnEvent(translated);
 			}
 
-			translated.MouseInput.Event = EMIE_RMOUSE_LEFT_UP;
+			translated.MouseInput.Event = irr::EMIE_RMOUSE_LEFT_UP;
 			translated.MouseInput.ButtonStates = EMBSM_LEFT;
 
 
@@ -3010,14 +3010,14 @@ bool GUIFormSpecMenu::DoubleClickDetection(const SEvent event)
 	if (!m_remap_dbl_click)
 		return false;
 
-	if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+	if (event.MouseInput.Event == irr::EMIE_LMOUSE_PRESSED_DOWN) {
 		m_doubleclickdetect[0].pos  = m_doubleclickdetect[1].pos;
 		m_doubleclickdetect[0].time = m_doubleclickdetect[1].time;
 
 		m_doubleclickdetect[1].pos  = m_pointer;
 		m_doubleclickdetect[1].time = getTimeMs();
 	}
-	else if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
+	else if (event.MouseInput.Event == irr::EMIE_LMOUSE_LEFT_UP) {
 		u32 delta = porting::getDeltaMs(m_doubleclickdetect[0].time, getTimeMs());
 		if (delta > 400) {
 			return false;
@@ -3036,7 +3036,7 @@ bool GUIFormSpecMenu::DoubleClickDetection(const SEvent event)
 		//translate doubleclick to escape
 		memset(translated, 0, sizeof(SEvent));
 		translated->EventType = irr::EET_KEY_INPUT_EVENT;
-		translated->KeyInput.Key         = KEY_ESCAPE;
+		translated->KeyInput.Key         = irr::KEY_ESCAPE;
 		translated->KeyInput.Control     = false;
 		translated->KeyInput.Shift       = false;
 		translated->KeyInput.PressedDown = true;
@@ -3054,7 +3054,7 @@ bool GUIFormSpecMenu::DoubleClickDetection(const SEvent event)
 
 bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 {
-	if (event.EventType==EET_KEY_INPUT_EVENT) {
+	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
 		if (event.KeyInput.PressedDown && ( (kp == EscapeKey) ||
 				(kp == getKeySetting("keymap_inventory")) || (kp == CancelKey))) {
@@ -3071,25 +3071,22 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			m_client->makeScreenshot(m_device);
 		}
 		if (event.KeyInput.PressedDown &&
-			(event.KeyInput.Key==KEY_RETURN ||
-			 event.KeyInput.Key==KEY_UP ||
-			 event.KeyInput.Key==KEY_DOWN)
-			) {
+				(event.KeyInput.Key == irr::KEY_RETURN ||
+				 event.KeyInput.Key == irr::KEY_UP ||
+				 event.KeyInput.Key == irr::KEY_DOWN)
+				) {
 			switch (event.KeyInput.Key) {
-				case KEY_RETURN:
-					current_keys_pending.key_enter = true;
-					break;
-				case KEY_UP:
-					current_keys_pending.key_up = true;
-					break;
-				case KEY_DOWN:
-					current_keys_pending.key_down = true;
-					break;
+			case irr::KEY_RETURN:
+				current_keys_pending.key_enter = true;
 				break;
-				default:
-					//can't happen at all!
-					FATAL_ERROR("Reached a source line that can't ever been reached");
-					break;
+			case irr::KEY_UP:
+				current_keys_pending.key_up = true;
+				break;
+			case irr::KEY_DOWN:
+				current_keys_pending.key_down = true;
+				break;
+			default:
+				FATAL_ERROR("Reached code that should be unreachable!");
 			}
 			if (current_keys_pending.key_enter && m_allowclose) {
 				acceptInput(quit_mode_accept);
@@ -3105,9 +3102,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 	/* Mouse event other than movement, or crossing the border of inventory
 	  field while holding right mouse button
 	 */
-	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
-			(event.MouseInput.Event != EMIE_MOUSE_MOVED ||
-			 (event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+			(event.MouseInput.Event != irr::EMIE_MOUSE_MOVED ||
+			 (event.MouseInput.Event == irr::EMIE_MOUSE_MOVED &&
 			  event.MouseInput.isRightPressed() &&
 			  getItemAtPos(m_pointer).i != getItemAtPos(m_old_pointer).i))) {
 
@@ -3169,20 +3166,16 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		// up/down: 0 = down (press), 1 = up (release), 2 = unknown event, -1 movement
 		int button = 0;
 		int updown = 2;
-		if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN)
-			{ button = 0; updown = 0; }
-		else if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN)
-			{ button = 1; updown = 0; }
-		else if (event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN)
-			{ button = 2; updown = 0; }
-		else if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP)
-			{ button = 0; updown = 1; }
-		else if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP)
-			{ button = 1; updown = 1; }
-		else if (event.MouseInput.Event == EMIE_MMOUSE_LEFT_UP)
-			{ button = 2; updown = 1; }
-		else if (event.MouseInput.Event == EMIE_MOUSE_MOVED)
-			{ updown = -1;}
+		switch (event.MouseInput.Event) {
+		case irr::EMIE_LMOUSE_PRESSED_DOWN: button = 0; updown = 0; break;
+		case irr::EMIE_RMOUSE_PRESSED_DOWN: button = 1; updown = 0; break;
+		case irr::EMIE_MMOUSE_PRESSED_DOWN: button = 2; updown = 0; break;
+		case irr::EMIE_LMOUSE_LEFT_UP: button = 0; updown = 1; break;
+		case irr::EMIE_RMOUSE_LEFT_UP: button = 1; updown = 1; break;
+		case irr::EMIE_MMOUSE_LEFT_UP: button = 2; updown = 1; break;
+		case irr::EMIE_MOUSE_MOVED: updown = -1; break;
+		default: break;
+		}
 
 		// Set this number to a positive value to generate a move action
 		// from m_selected_item to s.
@@ -3470,7 +3463,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		}
 		m_old_pointer = m_pointer;
 	}
-	if (event.EventType == EET_GUI_EVENT) {
+	if (event.EventType == irr::EET_GUI_EVENT) {
 
 		if (event.GUIEvent.EventType == gui::EGET_TAB_CHANGED
 				&& isVisible()) {

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -268,7 +268,7 @@ bool GUIKeyChangeMenu::resetMenu()
 }
 bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 {
-	if (event.EventType == EET_KEY_INPUT_EVENT && activeKey >= 0
+	if (event.EventType == irr::EET_KEY_INPUT_EVENT && activeKey >= 0
 			&& event.KeyInput.PressedDown) {
 		
 		bool prefer_character = shift_down;
@@ -327,12 +327,12 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 				return true;
 			}
 		}
-	} else if (event.EventType == EET_KEY_INPUT_EVENT && activeKey < 0
+	} else if (event.EventType == irr::EET_KEY_INPUT_EVENT && activeKey < 0
 			&& event.KeyInput.PressedDown
 			&& event.KeyInput.Key == irr::KEY_ESCAPE) {
 		quitMenu();
 		return true;
-	} else if (event.EventType == EET_GUI_EVENT) {
+	} else if (event.EventType == irr::EET_GUI_EVENT) {
 		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
 			&& isVisible())
 		{

--- a/src/guiPasswordChange.cpp
+++ b/src/guiPasswordChange.cpp
@@ -210,51 +210,34 @@ bool GUIPasswordChange::acceptInput()
 
 bool GUIPasswordChange::OnEvent(const SEvent& event)
 {
-	if(event.EventType==EET_KEY_INPUT_EVENT)
-	{
-		if(event.KeyInput.Key==KEY_ESCAPE && event.KeyInput.PressedDown)
-		{
+	if (event.EventType == irr::EET_KEY_INPUT_EVENT &&
+			event.KeyInput.PressedDown) {
+		if (event.KeyInput.Key == irr::KEY_ESCAPE) {
 			quitMenu();
 			return true;
-		}
-		if(event.KeyInput.Key==KEY_RETURN && event.KeyInput.PressedDown)
-		{
-			if(acceptInput())
+		} else if (event.KeyInput.Key == irr::KEY_RETURN) {
+			if (acceptInput())
 				quitMenu();
 			return true;
 		}
-	}
-	if(event.EventType==EET_GUI_EVENT)
-	{
-		if(event.GUIEvent.EventType==gui::EGET_ELEMENT_FOCUS_LOST
-				&& isVisible())
-		{
-			if(!canTakeFocus(event.GUIEvent.Element))
-			{
-				dstream<<"GUIPasswordChange: Not allowing focus change."
-						<<std::endl;
-				// Returning true disables focus change
-				return true;
-			}
-		}
-		if(event.GUIEvent.EventType==gui::EGET_BUTTON_CLICKED)
-		{
-			switch(event.GUIEvent.Caller->getID())
-			{
-			case ID_change:
-				if(acceptInput())
-					quitMenu();
-				return true;
-			}
-		}
-		if(event.GUIEvent.EventType==gui::EGET_EDITBOX_ENTER)
-		{
-			switch(event.GUIEvent.Caller->getID())
-			{
+	} else if (event.EventType == irr::EET_GUI_EVENT) {
+		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST &&
+				isVisible() && !canTakeFocus(event.GUIEvent.Element)) {
+			infostream << "GUIPasswordChange: Not allowing focus change."
+					<< std::endl;
+			// Returning true disables focus change
+			return true;
+		} else if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED &&
+				event.GUIEvent.Caller->getID() == ID_change) {
+			if (acceptInput())
+				quitMenu();
+			return true;
+		} else if (event.GUIEvent.EventType == gui::EGET_EDITBOX_ENTER) {
+			switch (event.GUIEvent.Caller->getID()) {
 			case ID_oldPassword:
 			case ID_newPassword1:
 			case ID_newPassword2:
-				if(acceptInput())
+				if (acceptInput())
 					quitMenu();
 				return true;
 			}

--- a/src/guiTable.cpp
+++ b/src/guiTable.cpp
@@ -625,7 +625,7 @@ void GUITable::setDynamicData(const DynamicData &dyndata)
 	m_scrollbar->setPos(dyndata.scrollpos);
 }
 
-const c8* GUITable::getTypeName() const
+const irr::c8* GUITable::getTypeName() const
 {
 	return "GUITable";
 }
@@ -765,32 +765,32 @@ bool GUITable::OnEvent(const SEvent &event)
 	if (!isEnabled())
 		return IGUIElement::OnEvent(event);
 
-	if (event.EventType == EET_KEY_INPUT_EVENT) {
+	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		if (event.KeyInput.PressedDown && (
-				event.KeyInput.Key == KEY_DOWN ||
-				event.KeyInput.Key == KEY_UP   ||
-				event.KeyInput.Key == KEY_HOME ||
-				event.KeyInput.Key == KEY_END  ||
-				event.KeyInput.Key == KEY_NEXT ||
-				event.KeyInput.Key == KEY_PRIOR)) {
+				event.KeyInput.Key == irr::KEY_DOWN ||
+				event.KeyInput.Key == irr::KEY_UP   ||
+				event.KeyInput.Key == irr::KEY_HOME ||
+				event.KeyInput.Key == irr::KEY_END  ||
+				event.KeyInput.Key == irr::KEY_NEXT ||
+				event.KeyInput.Key == irr::KEY_PRIOR)) {
 			s32 offset = 0;
 			switch (event.KeyInput.Key) {
-				case KEY_DOWN:
+				case irr::KEY_DOWN:
 					offset = 1;
 					break;
-				case KEY_UP:
+				case irr::KEY_UP:
 					offset = -1;
 					break;
-				case KEY_HOME:
+				case irr::KEY_HOME:
 					offset = - (s32) m_visible_rows.size();
 					break;
-				case KEY_END:
+				case irr::KEY_END:
 					offset = m_visible_rows.size();
 					break;
-				case KEY_NEXT:
+				case irr::KEY_NEXT:
 					offset = AbsoluteRect.getHeight() / m_rowheight;
 					break;
-				case KEY_PRIOR:
+				case irr::KEY_PRIOR:
 					offset = - (s32) (AbsoluteRect.getHeight() / m_rowheight);
 					break;
 				default:
@@ -809,23 +809,23 @@ bool GUITable::OnEvent(const SEvent &event)
 			return true;
 		}
 		else if (event.KeyInput.PressedDown && (
-				event.KeyInput.Key == KEY_LEFT ||
-				event.KeyInput.Key == KEY_RIGHT)) {
+				event.KeyInput.Key == irr::KEY_LEFT ||
+				event.KeyInput.Key == irr::KEY_RIGHT)) {
 			// Open/close subtree via keyboard
 			if (m_selected >= 0) {
-				int dir = event.KeyInput.Key == KEY_LEFT ? -1 : 1;
+				int dir = event.KeyInput.Key == irr::KEY_LEFT ? -1 : 1;
 				toggleVisibleTree(m_selected, dir, true);
 			}
 			return true;
 		}
 		else if (!event.KeyInput.PressedDown && (
-				event.KeyInput.Key == KEY_RETURN ||
-				event.KeyInput.Key == KEY_SPACE)) {
+				event.KeyInput.Key == irr::KEY_RETURN ||
+				event.KeyInput.Key == irr::KEY_SPACE)) {
 			sendTableEvent(0, true);
 			return true;
 		}
-		else if (event.KeyInput.Key == KEY_ESCAPE ||
-				event.KeyInput.Key == KEY_SPACE) {
+		else if (event.KeyInput.Key == irr::KEY_ESCAPE ||
+				event.KeyInput.Key == irr::KEY_SPACE) {
 			// pass to parent
 		}
 		else if (event.KeyInput.PressedDown && event.KeyInput.Char) {
@@ -862,10 +862,10 @@ bool GUITable::OnEvent(const SEvent &event)
 			return true;
 		}
 	}
-	if (event.EventType == EET_MOUSE_INPUT_EVENT) {
+	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
 		core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
 
-		if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
+		if (event.MouseInput.Event == irr::EMIE_MOUSE_WHEEL) {
 			m_scrollbar->setPos(m_scrollbar->getPos() +
 					(event.MouseInput.Wheel < 0 ? -3 : 3) *
 					- (s32) m_rowheight / 2);
@@ -888,32 +888,32 @@ bool GUITable::OnEvent(const SEvent &event)
 		// Fix for #1567/#1806:
 		// IGUIScrollBar passes double click events to its parent,
 		// which we don't want. Detect this case and discard the event
-		if (event.MouseInput.Event != EMIE_MOUSE_MOVED &&
+		if (event.MouseInput.Event != irr::EMIE_MOUSE_MOVED &&
 				m_scrollbar->isVisible() &&
 				m_scrollbar->isPointInside(p))
 			return true;
 
 		if (event.MouseInput.isLeftPressed() &&
 				(isPointInside(p) ||
-				 event.MouseInput.Event == EMIE_MOUSE_MOVED)) {
+				 event.MouseInput.Event == irr::EMIE_MOUSE_MOVED)) {
 			s32 sel_column = 0;
 			bool sel_doubleclick = (event.MouseInput.Event
-					== EMIE_LMOUSE_DOUBLE_CLICK);
+					== irr::EMIE_LMOUSE_DOUBLE_CLICK);
 			bool plusminus_clicked = false;
 
 			// For certain events (left click), report column
 			// Also open/close subtrees when the +/- is clicked
 			if (cell && (
-					event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN ||
-					event.MouseInput.Event == EMIE_LMOUSE_DOUBLE_CLICK ||
-					event.MouseInput.Event == EMIE_LMOUSE_TRIPLE_CLICK)) {
+					event.MouseInput.Event == irr::EMIE_LMOUSE_PRESSED_DOWN ||
+					event.MouseInput.Event == irr::EMIE_LMOUSE_DOUBLE_CLICK ||
+					event.MouseInput.Event == irr::EMIE_LMOUSE_TRIPLE_CLICK)) {
 				sel_column = cell->reported_column;
 				if (cell->content_type == COLUMN_TYPE_TREE)
 					plusminus_clicked = true;
 			}
 
 			if (plusminus_clicked) {
-				if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+				if (event.MouseInput.Event == irr::EMIE_LMOUSE_PRESSED_DOWN) {
 					toggleVisibleTree(row_i, 0, false);
 				}
 			}
@@ -937,7 +937,7 @@ bool GUITable::OnEvent(const SEvent &event)
 		}
 		return true;
 	}
-	if (event.EventType == EET_GUI_EVENT &&
+	if (event.EventType == irr::EET_GUI_EVENT &&
 			event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED &&
 			event.GUIEvent.Caller == m_scrollbar) {
 		// Don't pass events from our scrollbar to the parent
@@ -1097,7 +1097,7 @@ void GUITable::sendTableEvent(s32 column, bool doubleclick)
 	if (Parent) {
 		SEvent e;
 		memset(&e, 0, sizeof e);
-		e.EventType = EET_GUI_EVENT;
+		e.EventType = irr::EET_GUI_EVENT;
 		e.GUIEvent.Caller = this;
 		e.GUIEvent.Element = 0;
 		e.GUIEvent.EventType = gui::EGET_TABLE_CHANGED;

--- a/src/guiTable.h
+++ b/src/guiTable.h
@@ -139,7 +139,7 @@ public:
 	void setDynamicData(const DynamicData &dyndata);
 
 	/* Returns "GUITable" */
-	virtual const c8* getTypeName() const;
+	virtual const irr::c8* getTypeName() const;
 
 	/* Must be called when position or size changes */
 	virtual void updateAbsolutePosition();

--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -144,14 +144,14 @@ void GUIVolumeChange::drawMenu()
 
 bool GUIVolumeChange::OnEvent(const SEvent& event)
 {
-	if(event.EventType==EET_KEY_INPUT_EVENT)
+	if(event.EventType==irr::EET_KEY_INPUT_EVENT)
 	{
-		if(event.KeyInput.Key==KEY_ESCAPE && event.KeyInput.PressedDown)
+		if(event.KeyInput.Key==irr::KEY_ESCAPE && event.KeyInput.PressedDown)
 		{
 			quitMenu();
 			return true;
 		}
-		if(event.KeyInput.Key==KEY_RETURN && event.KeyInput.PressedDown)
+		if(event.KeyInput.Key==irr::KEY_RETURN && event.KeyInput.PressedDown)
 		{
 			quitMenu();
 			return true;

--- a/src/int_types.h
+++ b/src/int_types.h
@@ -1,0 +1,66 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef INT_TYPES_HEADER
+#define INT_TYPES_HEADER
+
+#if defined(_MSC_VER) && _MSC_VER >= 1310 && _MSC_VER <= 1600
+	// MSVC 2003-2010
+	typedef   signed __int8  s8;
+	typedef unsigned __int8  u8;
+	typedef   signed __int16 s16;
+	typedef unsigned __int16 u16;
+	typedef   signed __int32 s32;
+	typedef unsigned __int32 u32;
+	typedef   signed __int32 s64;
+	typedef unsigned __int32 u64;
+#else
+	// C99 / Posix
+	#include <stdint.h>
+	typedef  int8_t  s8;
+	typedef uint8_t  u8;
+	typedef  int16_t s16;
+	typedef uint16_t u16;
+	typedef  int32_t s32;
+	typedef uint32_t u32;
+	typedef  int64_t s64;
+	typedef uint64_t u64;
+#endif
+
+#ifndef UINT8_MAX
+	#define UINT8_MAX  0xFF
+	#define UINT16_MAX 0xFFFF
+	#define UINT32_MAX 0xFFFFFFFFU
+	#define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
+	#define INT8_MAX  0x7F
+	#define INT16_MAX 0x7FFF
+	#define INT32_MAX 0x7FFFFFFF
+	#define INT64_MAX 0x7FFFFFFFFFFFFFFFLL
+	#define INT8_MIN  (-INT8_MAX-1)
+	#define INT16_MIN (-INT16_MAX-1)
+	#define INT32_MIN (-INT32_MAX-1)
+	#define INT64_MIN (-INT64_MAX-1)
+#endif
+
+// This is for compatability.  This definition is the same as Irrlicht's,
+// but it isn't actually guaranteed to be 32 bits.
+typedef float f32;
+
+#endif
+

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "debug.h"
 #include "itemdef.h"
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include <istream>
 #include <ostream>
 #include <string>

--- a/src/irr_aabb3d.h
+++ b/src/irr_aabb3d.h
@@ -20,11 +20,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef IRR_AABB3D_HEADER
 #define IRR_AABB3D_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 #include <aabbox3d.h>
 
-typedef core::aabbox3d<f32> aabb3f;
+typedef irr::core::aabbox3d<float> aabb3f;
 
 #endif
 

--- a/src/irr_v2d.h
+++ b/src/irr_v2d.h
@@ -20,15 +20,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef IRR_V2D_HEADER
 #define IRR_V2D_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 #include <vector2d.h>
 
-typedef core::vector2d<f32> v2f;
-typedef core::vector2d<s16> v2s16;
-typedef core::vector2d<s32> v2s32;
-typedef core::vector2d<u32> v2u32;
-typedef core::vector2d<f32> v2f32;
+typedef irr::core::vector2d<float> v2f;
+typedef irr::core::vector2d<s16> v2s16;
+typedef irr::core::vector2d<s32> v2s32;
+typedef irr::core::vector2d<u32> v2u32;
+typedef irr::core::vector2d<float> v2f32;
 
 #endif
 

--- a/src/irr_v3d.h
+++ b/src/irr_v3d.h
@@ -20,14 +20,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef IRR_V3D_HEADER
 #define IRR_V3D_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 #include <vector3d.h>
 
-typedef core::vector3df v3f;
-typedef core::vector3d<s16> v3s16;
-typedef core::vector3d<u16> v3u16;
-typedef core::vector3d<s32> v3s32;
+typedef irr::core::vector3df v3f;
+typedef irr::core::vector3d<s16> v3s16;
+typedef irr::core::vector3d<u16> v3u16;
+typedef irr::core::vector3d<s32> v3s32;
 
 #endif
 

--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -20,47 +20,34 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef IRRLICHTTYPES_HEADER
 #define IRRLICHTTYPES_HEADER
 
-/* Ensure that <stdint.h> is included before <irrTypes.h>, unless building on
- * MSVC, to address an irrlicht issue: https://sourceforge.net/p/irrlicht/bugs/433/
- *
- * TODO: Decide whether or not we support non-compliant C++ compilers like old
- *       versions of MSCV.  If we do not then <stdint.h> can always be included
- *       regardless of the compiler.
- */
-#ifndef _MSC_VER
-#	include <stdint.h>
-#endif
+namespace irr {
+	class IrrlichtDevice;
+	struct SEvent;
 
-#include <irrTypes.h>
+	namespace video {};
+	namespace scene {};
+	namespace core {};
+	namespace gui {};
+	namespace io {};
+};
 
-using namespace irr;
+using irr::IrrlichtDevice;
+using irr::SEvent;
 
-// Irrlicht 1.8+ defines 64bit unsigned symbol in irrTypes.h
-#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
-#ifdef _MSC_VER
-	// Windows
-	typedef long long s64;
-	typedef unsigned long long u64;
-#else
-	// Posix
-	typedef int64_t s64;
-	typedef uint64_t u64;
-#endif
-#endif
+namespace video = irr::video;
+namespace scene = irr::scene;
+namespace core = irr::core;
+namespace gui = irr::gui;
+namespace io = irr::io;
 
-#define S8_MIN  (-0x7F - 1)
-#define S16_MIN (-0x7FFF - 1)
-#define S32_MIN (-0x7FFFFFFF - 1)
-#define S64_MIN (-0x7FFFFFFFFFFFFFFF - 1)
+// We can't forward-declare enums
 
-#define S8_MAX  0x7F
-#define S16_MAX 0x7FFF
-#define S32_MAX 0x7FFFFFFF
-#define S64_MAX 0x7FFFFFFFFFFFFFFF
+#include <IEventReceiver.h>
+using irr::EEVENT_TYPE;
+using irr::EMOUSE_INPUT_EVENT;
 
-#define U8_MAX  0xFF
-#define U16_MAX 0xFFFF
-#define U32_MAX 0xFFFFFFFF
-#define U64_MAX 0xFFFFFFFFFFFFFFFF
+#include <Keycodes.h>
+using irr::EKEY_CODE;
 
 #endif
+

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -105,10 +105,10 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual irr::video::ITexture* getInventoryTexture(const std::string &name,
 			IGameDef *gamedef) const=0;
 	// Get item wield mesh
-	virtual scene::IMesh* getWieldMesh(const std::string &name,
+	virtual irr::scene::IMesh* getWieldMesh(const std::string &name,
 		IGameDef *gamedef) const=0;
 #endif
 
@@ -131,10 +131,10 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual irr::video::ITexture* getInventoryTexture(const std::string &name,
 			IGameDef *gamedef) const=0;
 	// Get item wield mesh
-	virtual scene::IMesh* getWieldMesh(const std::string &name,
+	virtual irr::scene::IMesh* getWieldMesh(const std::string &name,
 		IGameDef *gamedef) const=0;
 #endif
 

--- a/src/keycode.h
+++ b/src/keycode.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef KEYCODE_HEADER
 #define KEYCODE_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "Keycodes.h"
 #include <IEventReceiver.h>
 #include <string>

--- a/src/light.h
+++ b/src/light.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef LIGHT_HEADER
 #define LIGHT_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 /*
 	Lower level lighting stuff

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1434,7 +1434,7 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 	beginSave();
 
 	// If there is no practical limit, we spare creation of mapblock_queue
-	if (max_loaded_blocks == U32_MAX) {
+	if (max_loaded_blocks == UINT32_MAX) {
 		for (std::map<v2s16, MapSector*>::iterator si = m_sectors.begin();
 				si != m_sectors.end(); ++si) {
 			MapSector *sector = si->second;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -468,7 +468,7 @@ void MapgenParams::save(Settings &settings) const
 	settings.setU64("seed", seed);
 	settings.setS16("water_level", water_level);
 	settings.setS16("chunksize", chunksize);
-	settings.setFlagStr("mg_flags", flags, flagdesc_mapgen, U32_MAX);
+	settings.setFlagStr("mg_flags", flags, flagdesc_mapgen, UINT32_MAX);
 	settings.setNoiseParams("mg_biome_np_heat", np_biome_heat);
 	settings.setNoiseParams("mg_biome_np_heat_blend", np_biome_heat_blend);
 	settings.setNoiseParams("mg_biome_np_humidity", np_biome_humidity);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -190,7 +190,7 @@ void MapgenFractalParams::readParams(const Settings *settings)
 
 void MapgenFractalParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, UINT32_MAX);
 
 	settings->setU16("mgfractal_m_iterations", m_iterations);
 	settings->setV3F("mgfractal_m_scale", m_scale);
@@ -475,7 +475,7 @@ MgStoneType MapgenFractal::generateBiomes(float *heat_map, float *humidity_map)
 
 		// If there is air or water above enable top/filler placement, otherwise force
 		// nplaced to stone level by setting a number exceeding any possible filler depth.
-		u16 nplaced = (air_above || water_above) ? 0 : U16_MAX;
+		u16 nplaced = (air_above || water_above) ? 0 : UINT16_MAX;
 
 
 		for (s16 y = node_max.Y; y >= node_min.Y; y--) {
@@ -512,7 +512,7 @@ MgStoneType MapgenFractal::generateBiomes(float *heat_map, float *humidity_map)
 				// This is done by aborting the cycle of top/filler placement
 				// immediately by forcing nplaced to stone level.
 				if (c_below == CONTENT_AIR || c_below == c_water_source)
-					nplaced = U16_MAX;
+					nplaced = UINT16_MAX;
 
 				if (nplaced < depth_top) {
 					vm->m_data[vi] = MapNode(biome->c_top);
@@ -537,7 +537,7 @@ MgStoneType MapgenFractal::generateBiomes(float *heat_map, float *humidity_map)
 				air_above = true;
 				water_above = false;
 			} else {  // Possible various nodes overgenerated from neighbouring mapchunks
-				nplaced = U16_MAX;  // Disable top/filler placement
+				nplaced = UINT16_MAX;  // Disable top/filler placement
 				air_above = false;
 				water_above = false;
 			}

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -161,7 +161,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 
 void MapgenV5Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, U32_MAX);
+	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, UINT32_MAX);
 
 	settings->setNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgv5_np_factor",       np_factor);
@@ -431,7 +431,7 @@ MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 
 		// If there is air or water above enable top/filler placement, otherwise force
 		// nplaced to stone level by setting a number exceeding any possible filler depth.
-		u16 nplaced = (air_above || water_above) ? 0 : U16_MAX;
+		u16 nplaced = (air_above || water_above) ? 0 : UINT16_MAX;
 
 		for (s16 y = node_max.Y; y >= node_min.Y; y--) {
 			content_t c = vm->m_data[vi].getContent();
@@ -468,7 +468,7 @@ MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 				// This is done by aborting the cycle of top/filler placement
 				// immediately by forcing nplaced to stone level.
 				if (c_below == CONTENT_AIR || c_below == c_water_source)
-					nplaced = U16_MAX;
+					nplaced = UINT16_MAX;
 
 				if (nplaced < depth_top) {
 					vm->m_data[vi] = MapNode(biome->c_top);
@@ -493,7 +493,7 @@ MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 				air_above = true;
 				water_above = false;
 			} else {  // Possible various nodes overgenerated from neighbouring mapchunks
-				nplaced = U16_MAX;  // Disable top/filler placement
+				nplaced = UINT16_MAX;  // Disable top/filler placement
 				air_above = false;
 				water_above = false;
 			}

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -175,7 +175,7 @@ void MapgenV6Params::readParams(const Settings *settings)
 
 void MapgenV6Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv6_spflags", spflags, flagdesc_mapgen_v6, U32_MAX);
+	settings->setFlagStr("mgv6_spflags", spflags, flagdesc_mapgen_v6, UINT32_MAX);
 	settings->setFloat("mgv6_freq_desert", freq_desert);
 	settings->setFloat("mgv6_freq_beach",  freq_beach);
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -182,7 +182,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 
 void MapgenV7Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7, U32_MAX);
+	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7, UINT32_MAX);
 
 	settings->setNoiseParams("mgv7_np_terrain_base",    np_terrain_base);
 	settings->setNoiseParams("mgv7_np_terrain_alt",     np_terrain_alt);
@@ -637,7 +637,7 @@ MgStoneType MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 
 		// If there is air or water above enable top/filler placement, otherwise force
 		// nplaced to stone level by setting a number exceeding any possible filler depth.
-		u16 nplaced = (air_above || water_above) ? 0 : U16_MAX;
+		u16 nplaced = (air_above || water_above) ? 0 : UINT16_MAX;
 
 		for (s16 y = node_max.Y; y >= node_min.Y; y--) {
 			content_t c = vm->m_data[vi].getContent();
@@ -674,7 +674,7 @@ MgStoneType MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 				// This is done by aborting the cycle of top/filler placement
 				// immediately by forcing nplaced to stone level.
 				if (c_below == CONTENT_AIR || c_below == c_water_source)
-					nplaced = U16_MAX;
+					nplaced = UINT16_MAX;
 
 				if (nplaced < depth_top) {
 					vm->m_data[vi] = MapNode(biome->c_top);
@@ -699,7 +699,7 @@ MgStoneType MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 				air_above = true;
 				water_above = false;
 			} else {  // Possible various nodes overgenerated from neighbouring mapchunks
-				nplaced = U16_MAX;  // Disable top/filler placement
+				nplaced = UINT16_MAX;  // Disable top/filler placement
 				air_above = false;
 				water_above = false;
 			}

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef MAPNODE_HEADER
 #define MAPNODE_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "irr_v3d.h"
 #include "irr_aabb3d.h"
 #include "light.h"

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef MAPSECTOR_HEADER
 #define MAPSECTOR_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "irr_v2d.h"
 #include "mapblock.h"
 #include <ostream>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -104,7 +104,7 @@ void scaleMesh(scene::IMesh *mesh, v3f scale)
 	if (mesh == NULL)
 		return;
 
-	core::aabbox3d<f32> bbox;
+	aabb3f bbox;
 	bbox.reset(0, 0, 0);
 
 	u32 mc = mesh->getMeshBufferCount();
@@ -132,7 +132,7 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 	if (mesh == NULL)
 		return;
 
-	core::aabbox3d<f32> bbox;
+	aabb3f bbox;
 	bbox.reset(0, 0, 0);
 
 	u32 mc = mesh->getMeshBufferCount();
@@ -231,7 +231,7 @@ void setMeshColorByNormalXYZ(scene::IMesh *mesh,
 	}
 }
 
-void rotateMeshXYby (scene::IMesh *mesh, f64 degrees) 
+void rotateMeshXYby (scene::IMesh *mesh, irr::f64 degrees) 
 {	
 	u16 mc = mesh->getMeshBufferCount();
 	for(u16 j = 0; j < mc; j++)
@@ -246,7 +246,7 @@ void rotateMeshXYby (scene::IMesh *mesh, f64 degrees)
 	}
 }
 
-void rotateMeshXZby (scene::IMesh *mesh, f64 degrees) 
+void rotateMeshXZby (scene::IMesh *mesh, irr::f64 degrees) 
 {	
 	u16 mc = mesh->getMeshBufferCount();
 	for(u16 j = 0; j < mc; j++)
@@ -261,7 +261,7 @@ void rotateMeshXZby (scene::IMesh *mesh, f64 degrees)
 	}
 }
 
-void rotateMeshYZby (scene::IMesh *mesh, f64 degrees) 
+void rotateMeshYZby (scene::IMesh *mesh, irr::f64 degrees) 
 {	
 	u16 mc = mesh->getMeshBufferCount();
 	for(u16 j = 0; j < mc; j++)
@@ -353,7 +353,7 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir)
 
 void recalculateBoundingBox(scene::IMesh *src_mesh)
 {
-	core::aabbox3d<f32> bbox;
+	aabb3f bbox;
 	bbox.reset(0,0,0);
 	for(u16 j = 0; j < src_mesh->getMeshBufferCount(); j++)
 	{

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -73,9 +73,9 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir);
 /*
 	Rotate the mesh around the axis and given angle in degrees.
 */
-void rotateMeshXYby (scene::IMesh *mesh, f64 degrees);
-void rotateMeshXZby (scene::IMesh *mesh, f64 degrees);
-void rotateMeshYZby (scene::IMesh *mesh, f64 degrees); 
+void rotateMeshXYby (scene::IMesh *mesh, irr::f64 degrees);
+void rotateMeshXZby (scene::IMesh *mesh, irr::f64 degrees);
+void rotateMeshYZby (scene::IMesh *mesh, irr::f64 degrees); 
  
 /*
 	Clone the mesh.

--- a/src/mods.h
+++ b/src/mods.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef MODS_HEADER
 #define MODS_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include <list>
 #include <set>
 #include <vector>

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -33,7 +33,7 @@ struct ObjectProperties
 	bool physical;
 	bool collideWithObjects;
 	float weight;
-	core::aabbox3d<f32> collisionbox;
+	aabb3f collisionbox;
 	std::string visual;
 	std::string mesh;
 	v2f visual_size;

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -88,7 +88,7 @@ Particle::Particle(
 	m_vertical = vertical;
 
 	// Irrlicht stuff
-	m_collisionbox = core::aabbox3d<f32>
+	m_collisionbox = aabb3f
 			(-size/2,-size/2,-size/2,size/2,size/2,size/2);
 	this->setAutomaticCulling(scene::EAC_OFF);
 
@@ -128,7 +128,7 @@ void Particle::step(float dtime)
 	m_time += dtime;
 	if (m_collisiondetection)
 	{
-		core::aabbox3d<f32> box = m_collisionbox;
+		aabb3f box = m_collisionbox;
 		v3f p_pos = m_pos*BS;
 		v3f p_velocity = m_velocity*BS;
 		v3f p_acceleration = m_acceleration*BS;

--- a/src/particles.h
+++ b/src/particles.h
@@ -52,7 +52,7 @@ class Particle : public scene::ISceneNode
 	);
 	~Particle();
 
-	virtual const core::aabbox3d<f32>& getBoundingBox() const
+	virtual const aabb3f& getBoundingBox() const
 	{
 		return m_box;
 	}
@@ -85,8 +85,8 @@ private:
 
 	ClientEnvironment *m_env;
 	IGameDef *m_gamedef;
-	core::aabbox3d<f32> m_box;
-	core::aabbox3d<f32> m_collisionbox;
+	aabb3f m_box;
+	aabb3f m_collisionbox;
 	video::SMaterial m_material;
 	v2f m_texpos;
 	v2f m_texsize;

--- a/src/player.h
+++ b/src/player.h
@@ -197,7 +197,7 @@ public:
 		return m_name;
 	}
 
-	core::aabbox3d<f32> getCollisionbox()
+	aabb3f getCollisionbox()
 	{
 		return m_collisionbox;
 	}
@@ -397,7 +397,7 @@ protected:
 	f32 m_yaw;
 	v3f m_speed;
 	v3f m_position;
-	core::aabbox3d<f32> m_collisionbox;
+	aabb3f m_collisionbox;
 
 	bool m_dirty;
 

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -584,7 +584,7 @@ v2u32 getWindowSize()
 
 std::vector<core::vector3d<u32> > getSupportedVideoModes()
 {
-	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
+	IrrlichtDevice *nulldevice = irr::createDevice(video::EDT_NULL);
 	sanity_check(nulldevice != NULL);
 
 	std::vector<core::vector3d<u32> > mlist;
@@ -691,10 +691,10 @@ float getDisplayDensity()
 
 v2u32 getDisplaySize()
 {
-	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
+	IrrlichtDevice *nulldevice = irr::createDevice(video::EDT_NULL);
 
 	core::dimension2d<u32> deskres = nulldevice->getVideoModeList()->getDesktopResolution();
-	nulldevice -> drop();
+	nulldevice->drop();
 
 	return deskres;
 }

--- a/src/porting.h
+++ b/src/porting.h
@@ -35,7 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <vector>
 #include "irrlicht.h"
-#include "irrlichttypes.h" // u32
+#include "int_types.h"
 #include "irrlichttypes_extrabloated.h"
 #include "debug.h"
 #include "constants.h"

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef PROFILER_HEADER
 #define PROFILER_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include <string>
 #include <map>
 

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -27,6 +27,7 @@ extern "C" {
 #include <lua.h>
 }
 
+#include "int_types.h"
 #include "irrlichttypes.h"
 #include "threading/mutex.h"
 #include "threading/mutex_auto_lock.h"

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 #include "log.h"
+#include "int_types.h"
 
 struct EnumString ModApiMapgen::es_BiomeTerrainType[] =
 {
@@ -610,7 +611,7 @@ int ModApiMapgen::l_get_mapgen_params(lua_State *L)
 	lua_pushinteger(L, params->chunksize);
 	lua_setfield(L, -2, "chunksize");
 
-	std::string flagstr = writeFlagString(params->flags, flagdesc_mapgen, U32_MAX);
+	std::string flagstr = writeFlagString(params->flags, flagdesc_mapgen, UINT32_MAX);
 	lua_pushstring(L, flagstr.c_str());
 	lua_setfield(L, -2, "flags");
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1182,7 +1182,7 @@ int ObjectRef::l_hud_add(lua_State *L)
 	}
 
 	u32 id = getServer(L)->hudAdd(player, elem);
-	if (id == U32_MAX) {
+	if (id == UINT32_MAX) {
 		delete elem;
 		return 0;
 	}

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define L_OBJECT_H_
 
 #include "lua_api/l_base.h"
-#include "irrlichttypes.h"
+#include "int_types.h"
 
 class ServerActiveObject;
 class LuaEntitySAO;

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERIALIZATION_HEADER
 #define SERIALIZATION_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "exceptions.h"
 #include <iostream>
 #include "util/pointer.h"

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -589,7 +589,7 @@ void Server::AsyncRunStep(bool initial_step)
 		ScopeProfiler sp(g_profiler, "Server: map timer and unload");
 		m_env->getMap().timerUpdate(map_timer_and_unload_dtime,
 			g_settings->getFloat("server_unload_unused_data_timeout"),
-			U32_MAX);
+			UINT32_MAX);
 	}
 
 	/*

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -771,9 +771,9 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 	if(geometry_program != "")
 		geometry_program = shaders_header + geometry_program;
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
-	const c8* vertex_program_ptr = 0;
-	const c8* pixel_program_ptr = 0;
-	const c8* geometry_program_ptr = 0;
+	const char* vertex_program_ptr = 0;
+	const char* pixel_program_ptr = 0;
+	const char* geometry_program_ptr = 0;
 	if(vertex_program != "")
 		vertex_program_ptr = vertex_program.c_str();
 	if(pixel_program != "")

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -94,7 +94,7 @@ void Sky::OnRegisterSceneNode()
 	scene::ISceneNode::OnRegisterSceneNode();
 }
 
-const core::aabbox3d<f32>& Sky::getBoundingBox() const
+const aabb3f& Sky::getBoundingBox() const
 {
 	return Box;
 }

--- a/src/sky.h
+++ b/src/sky.h
@@ -42,7 +42,7 @@ public:
 	//! renders the node.
 	virtual void render();
 
-	virtual const core::aabbox3d<f32>& getBoundingBox() const;
+	virtual const aabb3f& getBoundingBox() const;
 
 	// Used by Irrlicht for optimizing rendering
 	virtual video::SMaterial& getMaterial(u32 i)
@@ -74,7 +74,7 @@ public:
 	}
 
 private:
-	core::aabbox3d<f32> Box;
+	aabb3f Box;
 	video::SMaterial m_materials[SKY_MATERIAL_COUNT];
 
 	// How much sun & moon transition should affect horizon color

--- a/src/socket.h
+++ b/src/socket.h
@@ -37,7 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <ostream>
 #include <string.h>
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "exceptions.h"
 
 extern bool socket_enable_debug_output;

--- a/src/staticobject.cpp
+++ b/src/staticobject.cpp
@@ -50,7 +50,7 @@ void StaticObjectList::serialize(std::ostream &os)
 	size_t count = m_stored.size() + m_active.size();
 	// Make sure it fits into u16, else it would get truncated and cause e.g.
 	// issue #2610 (Invalid block data in database: unsupported NameIdMapping version).
-	if (count > U16_MAX) {
+	if (count > UINT16_MAX) {
 		errorstream << "StaticObjectList::serialize(): "
 			<< "too many objects (" << count << ") in list, "
 			<< "not writing them to disk." << std::endl;

--- a/src/tool.h
+++ b/src/tool.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef TOOL_HEADER
 #define TOOL_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include <string>
 #include <iostream>
 #include <map>

--- a/src/touchscreengui.cpp
+++ b/src/touchscreengui.cpp
@@ -35,7 +35,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Very slow button repeat frequency (in seconds)
 #define SLOW_BUTTON_REPEAT	(1.0f)
 
-using namespace irr::core;
 
 extern Settings *g_settings;
 

--- a/src/touchscreengui.h
+++ b/src/touchscreengui.h
@@ -29,9 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "game.h"
 #include "client/tile.h"
 
-using namespace irr;
-using namespace irr::core;
-using namespace irr::gui;
 
 typedef enum {
 	forward_id = 0,
@@ -83,7 +80,7 @@ public:
 private:
 	IrrlichtDevice*         m_device;
 	IGUIEnvironment*        m_guienv;
-	IEventReceiver*         m_receiver;
+	irr::IEventReceiver*    m_receiver;
 	ISimpleTextureSource*   m_texturesource;
 	v2u32                   m_screensize;
 	std::map<int,rect<s32> > m_hud_rects;

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -282,7 +282,7 @@ void TestUtilities::testIsPowerOfTwo()
 		UASSERT(is_power_of_two((1 << exponent)) == true);
 		UASSERT(is_power_of_two((1 << exponent) + 1) == false);
 	}
-	UASSERT(is_power_of_two(U32_MAX) == false);
+	UASSERT(is_power_of_two(UINT32_MAX) == false);
 }
 
 void TestUtilities::testMyround()

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_CONTAINER_HEADER
 #define UTIL_CONTAINER_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../exceptions.h"
 #include "../threading/mutex.h"
 #include "../threading/mutex_auto_lock.h"

--- a/src/util/directiontables.h
+++ b/src/util/directiontables.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_DIRECTIONTABLES_HEADER
 #define UTIL_DIRECTIONTABLES_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../irr_v3d.h"
 
 extern const v3s16 g_6dirs[6];

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -21,7 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define UTIL_NUMERIC_HEADER
 
 #include "../basicmacros.h"
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../irr_v2d.h"
 #include "../irr_v3d.h"
 #include "../irr_aabb3d.h"
@@ -310,9 +310,9 @@ inline v3f intToFloat(v3s16 p, f32 d)
 }
 
 // Random helper. Usually d=BS
-inline core::aabbox3d<f32> getNodeBox(v3s16 p, float d)
+inline aabb3f getNodeBox(v3s16 p, float d)
 {
-	return core::aabbox3d<f32>(
+	return aabb3f(
 		(float)p.X * d - 0.5*d,
 		(float)p.Y * d - 0.5*d,
 		(float)p.Z * d - 0.5*d,

--- a/src/util/pointedthing.h
+++ b/src/util/pointedthing.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_POINTEDTHING_HEADER
 #define UTIL_POINTEDTHING_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../irr_v3d.h"
 #include <iostream>
 #include <string>

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_POINTER_HEADER
 #define UTIL_POINTER_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../debug.h" // For assert()
 #include <cstring>
 

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_THREAD_HEADER
 #define UTIL_THREAD_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../threading/thread.h"
 #include "../threading/mutex.h"
 #include "../threading/mutex_auto_lock.h"

--- a/src/util/timetaker.h
+++ b/src/util/timetaker.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UTIL_TIMETAKER_HEADER
 #define UTIL_TIMETAKER_HEADER
 
-#include "../irrlichttypes.h"
+#include "../int_types.h"
 #include "../gettime.h"
 
 /*

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef VOXEL_HEADER
 #define VOXEL_HEADER
 
-#include "irrlichttypes.h"
+#include "int_types.h"
 #include "irr_v3d.h"
 #include <iostream>
 #include "debug.h"

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -130,7 +130,7 @@ static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 	rendering related classes (such as WieldMeshSceneNode) will be
 	used from the rendering thread only.
 */
-class ExtrusionMeshCache: public IReferenceCounted
+class ExtrusionMeshCache: public irr::IReferenceCounted
 {
 public:
 	// Constructor

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -53,7 +53,7 @@ public:
 
 	virtual void render();
 
-	virtual const core::aabbox3d<f32>& getBoundingBox() const
+	virtual const aabb3f& getBoundingBox() const
 	{ return m_bounding_box; }
 
 private:
@@ -74,7 +74,7 @@ private:
 	// Bounding box culling is disabled for this type of scene node,
 	// so this variable is just required so we can implement
 	// getBoundingBox() and is set to an empty box.
-	core::aabbox3d<f32> m_bounding_box;
+	aabb3f m_bounding_box;
 };
 
 #endif


### PR DESCRIPTION
Instead of depending on Irrlicht's platform-detection (which has [issues](a1ea017b512ea8f99c40dca52a57ff58054c5acc)) we use the standard integer types (`<stdint.h>`).
To avoid massive changes, I've added all the short type name aliases (u8, u16, etc).
However, this means that using `using namespace irr;` will cause type name
conflicts, so I imported just the irrlicht sub-namespaces.
This means that some things (almost entirely enum values) have to be qualified
with `irr::`.  I imported IrrlichtDevice and SEvent into the global namespace
to avoid having to update those (they have a lot of occurances).
I'd import the enums (`EEVENT_TYPE`, `EMOUSE_INPUT_EVENT`, and `EKEY_CODE`) too, but that appears to be impossible with C++03 enums without importing every value individually.

This also replaces `U*_MAX`, with the standard `UINT*_MAX`.