### PR TITLE
Mgfractal: Add filler depth noise

### DIFF
--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -51,6 +51,7 @@ struct MapgenFractalParams : public MapgenSpecificParams {
 	float julia_w;
 
 	NoiseParams np_seabed;
+	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 
@@ -90,7 +91,7 @@ public:
 	float julia_w;
 
 	Noise *noise_seabed;
-
+	Noise *noise_filler_depth;
 	Noise *noise_cave1;
 	Noise *noise_cave2;
 


### PR DESCRIPTION
Was previously ommited because i thought a fixed depth more suitable for a mathematical fractal mapgen. However filler depth noise can be used to create patches of bare stone in biomes, the mapgen should support this feature and be consistent with other biome API mapgens.