### PR TITLE
findSpawnPos: Add setting for max height above water level

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -693,6 +693,12 @@ enable_pvp (Player versus Player) bool true
 #    If this is set, players will always (re)spawn at the given position.
 static_spawnpoint (Static spawnpoint) string
 
+#    Maximum distance above water level for player spawn.
+#    Larger values result in spawn points closer to (x = 0, z = 0).
+#    Smaller values may result in a suitable spawn point not being found,
+#    resulting in a spawn at (0, 0, 0) possibly buried underground.
+vertical_spawn_range (Vertical spawn range) int 16
+
 #    If enabled, new players cannot join with an empty password.
 disallow_empty_password (Disallow empty passwords) bool false
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -829,6 +829,13 @@
 #    type: string
 # static_spawnpoint = 
 
+#    Maximum distance above water level for player spawn.
+#    Larger values result in spawn points closer to (x = 0, z = 0).
+#    Smaller values may result in a suitable spawn point not being found,
+#    resulting in a spawn at (0, 0, 0) possibly buried underground.
+#    type: int
+# vertical_spawn_range = 16
+
 #    If enabled, new players cannot join with an empty password.
 #    type: bool
 # disallow_empty_password = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -245,6 +245,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("default_privs", "interact, shout");
 	settings->setDefault("player_transfer_distance", "0");
 	settings->setDefault("enable_pvp", "true");
+	settings->setDefault("vertical_spawn_range", "16");
 	settings->setDefault("disallow_empty_password", "false");
 	settings->setDefault("disable_anticheat", "false");
 	settings->setDefault("enable_rollback_recording", "false");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3269,7 +3269,7 @@ v3f Server::findSpawnPos()
 	}
 
 	s16 water_level = map.getWaterLevel();
-
+	s16 vertical_spawn_range = g_settings->getS16("vertical_spawn_range");
 	bool is_good = false;
 
 	// Try to find a good place a few times
@@ -3282,9 +3282,9 @@ v3f Server::findSpawnPos()
 
 		// Get ground height at point
 		s16 groundheight = map.findGroundLevel(nodepos2d);
-		if (groundheight <= water_level) // Don't go underwater
-			continue;
-		if (groundheight > water_level + 6) // Don't go to high places
+		// Don't go underwater or to high places
+		if (groundheight <= water_level ||
+				groundheight > water_level + vertical_spawn_range)
 			continue;
 
 		v3s16 nodepos(nodepos2d.X, groundheight, nodepos2d.Y);


### PR DESCRIPTION
New mapgens (and existing mapgens using custom noise parameters) may have large scales, reducing the chance of low land within 1000 nodes of (0, 0).
This can result in no suitable spawn point being found, which results in a spawn at (0, 0, 0), often buried underground or in the ocean.
The default value is also changed from 6 to 16 for spawns clustered a little closer together near world centre, and to cope with the newer mapgens that have larger scale terrain (mgv7).