### PR TITLE
Fix server crashing on Lua errors

### DIFF
--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -125,6 +125,12 @@ public:
 	PrngException(std::string s): BaseException(s) {}
 };
 
+class ModError : public BaseException {
+public:
+	ModError(const std::string &s): BaseException(s) {}
+};
+
+
 /*
 	Some "old-style" interrupts:
 */

--- a/src/guiEngine.cpp
+++ b/src/guiEngine.cpp
@@ -238,13 +238,13 @@ bool GUIEngine::loadMainMenuScript()
 	}
 
 	std::string script = porting::path_share + DIR_DELIM "builtin" + DIR_DELIM "init.lua";
-	if (m_script->loadScript(script)) {
+	try {
+		m_script->loadScript(script);
 		// Menu script loaded
 		return true;
-	} else {
-		infostream
-			<< "GUIEngine: execution of menu script in: \""
-			<< m_scriptdir << "\" failed!" << std::endl;
+	} catch (const ModError &e) {
+		errorstream << "GUIEngine: execution of menu script failed: "
+			<< e.what() << std::endl;
 	}
 
 	return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -816,14 +816,22 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 	if (cmd_args.exists("migrate"))
 		return migrate_database(game_params, cmd_args);
 
-	// Create server
-	Server server(game_params.world_path, game_params.game_spec, false,
-		bind_addr.isIPv6());
-	server.start(bind_addr);
+	try {
+		// Create server
+		Server server(game_params.world_path, game_params.game_spec, false,
+			bind_addr.isIPv6());
+		server.start(bind_addr);
 
-	// Run server
-	bool &kill = *porting::signal_handler_killstatus();
-	dedicated_server_loop(server, kill);
+		// Run server
+		bool &kill = *porting::signal_handler_killstatus();
+		dedicated_server_loop(server, kill);
+	} catch (const ModError &e) {
+		errorstream << "ModError: " << e.what() << std::endl;
+		return false;
+	} catch (const ServerError &e) {
+		errorstream << "ServerError: " << e.what() << std::endl;
+		return false;
+	}
 
 	return true;
 }

--- a/src/mods.cpp
+++ b/src/mods.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "strfnd.h"
 #include "convert_json.h"
+#include "exceptions.h"
 
 static bool parseDependsLine(std::istream &is,
 		std::string &dep, std::set<char> &symbols)

--- a/src/mods.h
+++ b/src/mods.h
@@ -26,28 +26,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include <string>
 #include <map>
-#include <exception>
 #include "json/json.h"
 #include "config.h"
 
 #define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
-
-class ModError : public std::exception
-{
-public:
-	ModError(const std::string &s)
-	{
-		m_s = "ModError: ";
-		m_s += s;
-	}
-	virtual ~ModError() throw()
-	{}
-	virtual const char * what() const throw()
-	{
-		return m_s.c_str();
-	}
-	std::string m_s;
-};
 
 struct ModSpec
 {

--- a/src/script/common/c_types.h
+++ b/src/script/common/c_types.h
@@ -52,10 +52,10 @@ public:
 	}
 };
 
-class LuaError : public ServerError
+class LuaError : public ModError
 {
 public:
-	LuaError(const std::string &s) : ServerError(s) {}
+	LuaError(const std::string &s) : ModError(s) {}
 };
 
 

--- a/src/script/cpp_api/s_async.cpp
+++ b/src/script/cpp_api/s_async.cpp
@@ -243,8 +243,12 @@ void* AsyncWorkerThread::run()
 	lua_State *L = getStack();
 
 	std::string script = getServer()->getBuiltinLuaPath() + DIR_DELIM + "init.lua";
-	if (!loadScript(script)) {
-		FATAL_ERROR("execution of async base environment failed!");
+	try {
+		loadScript(script);
+	} catch (const ModError &e) {
+		errorstream << "Execution of async base environment failed: "
+			<< e.what() << std::endl;
+		FATAL_ERROR("Execution of async base environment failed");
 	}
 
 	int error_handler = PUSH_ERROR_HANDLER(L);

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -63,9 +63,9 @@ public:
 	ScriptApiBase();
 	virtual ~ScriptApiBase();
 
-	bool loadMod(const std::string &script_path, const std::string &mod_name,
-		std::string *error=NULL);
-	bool loadScript(const std::string &script_path, std::string *error=NULL);
+	// These throw a ModError on failure
+	void loadMod(const std::string &script_path, const std::string &mod_name);
+	void loadScript(const std::string &script_path);
 
 	void runCallbacksRaw(int nargs,
 		RunCallbacksMode mode, const char *fxn);


### PR DESCRIPTION
Previously, the server called `FATAL_ERROR` when a Lua error occured.
This caused a (mostly useless) core dump, and, in servers running managed in gdb, a similarly useless and confusing backtrace.
The server now simply throws an exception, which is caught and printed before exiting with a non-zero return value.
This also fixes a number of instances where errors were logged multiple times (as many as three times).

Fixes #3213 (which was also reported by VanessaE). 

Implementation note: I changed loadMod and loadScript from returning a bool and taking a error argument to just throwing an exception on error.  This made things easier since the error message was often just turned into an exception and thrown.