### PR TITLE
Append Lua backtrace to C++ exceptions when using regular Lua instead of LuaJIT

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -610,8 +610,10 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 	try {
 		m_server->getScriptIface()->environment_OnGenerated(
 			minp, maxp, m_mapgen->blockseed);
+	} catch (ProcessedLuaError &e) {
+		m_server->setAsyncFatalProcessedLuaError(e.what());
 	} catch (LuaError &e) {
-		m_server->setAsyncFatalError("Lua: " + std::string(e.what()));
+		m_server->setAsyncFatalLuaError(e.what());
 	}
 
 	EMERGE_DBG_OUT("ended up with: " << analyze_block(block));

--- a/src/guiEngine.cpp
+++ b/src/guiEngine.cpp
@@ -217,8 +217,12 @@ GUIEngine::GUIEngine(	irr::IrrlichtDevice* dev,
 		}
 
 		run();
-	} catch (LuaError &e) {
+	} catch (ProcessedLuaError &e) {
 		errorstream << "MAINMENU ERROR: " << e.what() << std::endl;
+		m_data->script_data.errormessage = e.what();
+	} catch (LuaError &e) {
+		errorstream << "MAINMENU ERROR: " << e.what() << std::endl
+				<< m_script->getBacktrace() << std::endl;
 		m_data->script_data.errormessage = e.what();
 	}
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -121,7 +121,9 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 			+ itos(lua_gc(L, LUA_GCCOUNT, 0) >> 10) + " MB";
 	}
 
-	throw LuaError(err_msg);
+	// This is now a processed Lua error as it contains the backtrace and other
+	// information.
+	throw ProcessedLuaError(err_msg);
 }
 
 // Push the list of callbacks (a lua table).

--- a/src/script/common/c_types.h
+++ b/src/script/common/c_types.h
@@ -52,10 +52,20 @@ public:
 	}
 };
 
+// A regular Lua error contains only the original error message from the
+// original error's location
 class LuaError : public ModError
 {
 public:
 	LuaError(const std::string &s) : ModError(s) {}
+};
+
+// A processed Lua error contains a backtrace and other information in addition
+// to the original error message
+class ProcessedLuaError : public LuaError
+{
+public:
+	ProcessedLuaError(const std::string &s) : LuaError(s) {}
 };
 
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -231,6 +231,11 @@ void ScriptApiBase::stackDump(std::ostream &o)
 	o << std::endl;
 }
 
+std::string ScriptApiBase::getBacktrace()
+{
+	return script_get_backtrace(getStack());
+}
+
 void ScriptApiBase::setOriginDirect(const char *origin)
 {
 	m_last_run_mod = origin ? origin : "??";

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -75,6 +75,7 @@ public:
 	void removeObjectReference(ServerActiveObject *cobj);
 
 	Server* getServer() { return m_server; }
+	std::string getBacktrace();
 
 	std::string getOrigin() { return m_last_run_mod; }
 	void setOriginDirect(const char *origin);

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -56,7 +56,7 @@ void ScriptApiEnv::environment_Step(float dtime)
 	} catch (ProcessedLuaError &e) {
 		getServer()->setAsyncFatalProcessedLuaError(e.what());
 	} catch (LuaError &e) {
-		getServer()->setAsyncFatalLuaError(e.what());
+		getServer()->setAsyncFatalLuaErrorFromEnvironment(e.what());
 	}
 }
 
@@ -79,7 +79,7 @@ void ScriptApiEnv::player_event(ServerActiveObject* player, std::string type)
 	} catch (ProcessedLuaError &e) {
 		getServer()->setAsyncFatalProcessedLuaError(e.what());
 	} catch (LuaError &e) {
-		getServer()->setAsyncFatalLuaError(e.what());
+		getServer()->setAsyncFatalLuaErrorFromEnvironment(e.what());
 	}
 }
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -53,8 +53,10 @@ void ScriptApiEnv::environment_Step(float dtime)
 	lua_pushnumber(L, dtime);
 	try {
 		runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+	} catch (ProcessedLuaError &e) {
+		getServer()->setAsyncFatalProcessedLuaError(e.what());
 	} catch (LuaError &e) {
-		getServer()->setAsyncFatalError(e.what());
+		getServer()->setAsyncFatalLuaError(e.what());
 	}
 }
 
@@ -74,8 +76,10 @@ void ScriptApiEnv::player_event(ServerActiveObject* player, std::string type)
 	lua_pushstring(L,type.c_str()); // event type
 	try {
 		runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
+	} catch (ProcessedLuaError &e) {
+		getServer()->setAsyncFatalProcessedLuaError(e.what());
 	} catch (LuaError &e) {
-		getServer()->setAsyncFatalError(e.what());
+		getServer()->setAsyncFatalLuaError(e.what());
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2857,6 +2857,13 @@ void Server::setAsyncFatalProcessedLuaError(const std::string &error)
 
 void Server::setAsyncFatalLuaError(const std::string &error)
 {
+	MutexAutoLock lock(m_env_mutex);
+	setAsyncFatalLuaErrorFromEnvironment(error);
+}
+
+// Environment (Lua) must be locked when calling this
+void Server::setAsyncFatalLuaErrorFromEnvironment(const std::string &error)
+{
 	// Regular Lua passes exceptions directly into here, requiring a backtrace
 	// to be appended at this point.
 
@@ -2866,10 +2873,7 @@ void Server::setAsyncFatalLuaError(const std::string &error)
 
 	std::ostringstream os(std::ios::binary);
 	os << "Lua: " << error;
-	{
-		MutexAutoLock lock(m_env_mutex);
-		os << std::endl << m_script->getBacktrace();
-	}
+	os << std::endl << m_script->getBacktrace();
 
 	setAsyncFatalError(os.str());
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -107,8 +107,10 @@ void *ServerThread::run()
 		} catch (ClientNotFoundException &e) {
 		} catch (con::ConnectionBindFailed &e) {
 			m_server->setAsyncFatalError(e.what());
+		} catch (ProcessedLuaError &e) {
+			m_server->setAsyncFatalProcessedLuaError(e.what());
 		} catch (LuaError &e) {
-			m_server->setAsyncFatalError("Lua: " + std::string(e.what()));
+			m_server->setAsyncFatalLuaError(e.what());
 		}
 	}
 
@@ -2844,6 +2846,32 @@ void Server::notifyPlayer(const char *name, const std::wstring &msg)
 		return;
 
 	SendChatMessage(player->peer_id, msg);
+}
+
+void Server::setAsyncFatalProcessedLuaError(const std::string &error)
+{
+	// ProcessedLuaErrors already contain a backtrace and other information.
+
+	setAsyncFatalError(std::string("Lua: ") + error);
+}
+
+void Server::setAsyncFatalLuaError(const std::string &error)
+{
+	// Regular Lua passes exceptions directly into here, requiring a backtrace
+	// to be appended at this point.
+
+	// LuaJIT provides a way to catch exceptions directly at the C++->Lua
+	// interface and we invoke regular Lua error handling in there, which
+	// appends a backtrace to the error and converts it to a ProcessedLuaError.
+
+	std::ostringstream os(std::ios::binary);
+	os << "Lua: " << error;
+	{
+		MutexAutoLock lock(m_env_mutex);
+		os << std::endl << m_script->getBacktrace();
+	}
+
+	setAsyncFatalError(os.str());
 }
 
 bool Server::showFormspec(const char *playername, const std::string &formspec,

--- a/src/server.h
+++ b/src/server.h
@@ -330,6 +330,8 @@ public:
 
 	void setAsyncFatalProcessedLuaError(const std::string &error);
 	void setAsyncFatalLuaError(const std::string &error);
+	// Environment (Lua) must be locked when calling this
+	void setAsyncFatalLuaErrorFromEnvironment(const std::string &error);
 
 	bool showFormspec(const char *name, const std::string &formspec, const std::string &formname);
 	Map & getMap() { return m_env->getMap(); }

--- a/src/server.h
+++ b/src/server.h
@@ -328,6 +328,9 @@ public:
 	inline void setAsyncFatalError(const std::string &error)
 			{ m_async_fatal_error.set(error); }
 
+	void setAsyncFatalProcessedLuaError(const std::string &error);
+	void setAsyncFatalLuaError(const std::string &error);
+
 	bool showFormspec(const char *name, const std::string &formspec, const std::string &formname);
 	Map & getMap() { return m_env->getMap(); }
 	ServerEnvironment & getEnv() { return *m_env; }


### PR DESCRIPTION
~~I am considering this good to go after some testing. Comparisons between Lua and LuaJIT with and without this patch need to be made.~~

The practical tests pass, but there's still at least a race condition issue.
