### PR TITLE
Check that LuaEntitySAO::setVelocity's parameter and generally Lua's v3f inputs are not NaN

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -617,6 +617,9 @@ void LuaEntitySAO::notifyObjectPropertiesModified()
 
 void LuaEntitySAO::setVelocity(v3f velocity)
 {
+	if(util_isnan(velocity.X) || util_isnan(velocity.Y) ||
+			util_isnan(velocity.Z))
+		throw BaseException("LuaEntitySAO::setVelocity(): Given value is NaN");
 	m_velocity = velocity;
 }
 

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -179,6 +179,12 @@ v3f check_v3f(lua_State *L, int index)
 	CHECK_POS_COORD("z");
 	pos.Z = lua_tonumber(L, -1);
 	lua_pop(L, 1);
+	if(util_isnan(pos.X))
+		throw LuaError("NaN passed as X coordinate");
+	if(util_isnan(pos.Y))
+		throw LuaError("NaN passed as Y coordinate");
+	if(util_isnan(pos.Z))
+		throw LuaError("NaN passed as Z coordinate");
 	return pos;
 }
 

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -416,4 +416,9 @@ inline u32 npot2(u32 orig) {
 	return orig + 1;
 }
 
+// http://stackoverflow.com/questions/2249110/how-do-i-make-a-portable-isnan-isinf-function
+// Let's just use our own macro like Lua does internally. At least it works
+// reliably and is portable...
+#define util_isnan(a) (!((a)==(a)))
+
 #endif


### PR DESCRIPTION
Check that LuaEntitySAO::setVelocity's parameter and generally Lua's v3f inputs are not NaN.

Without this change, a mod can crash the server in a hard-to-debug way when NaN is catched at serialization time, losing information about who actually supplied the erroneus value.
