### PR TITLE
Make spreadLight 2.5x faster

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -217,7 +217,7 @@ public:
 			std::map<v3s16, MapBlock*> & modified_blocks);
 
 	void spreadLight(enum LightBank bank,
-			std::set<v3s16> & from_nodes,
+			std::vector<v3s16> & from_nodes,
 			std::map<v3s16, MapBlock*> & modified_blocks);
 
 	void lightNeighbors(enum LightBank bank,


### PR DESCRIPTION
Makes spreadLight 2.5 faster by changing from a std::set to set::vector + sort + unique

On Windows x64 release build this is a 2.5x speed improvement.

spreadLight was 17% CPU, now it's 7%
