### PR TITLE
Time: Remove serverside getter, and use atomic operations

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapnode.h"
 #include "mapblock.h"
 #include "threading/mutex.h"
+#include "threading/atomic.h"
 #include "network/networkprotocol.h" // for AccessDeniedCode
 
 class ServerEnvironment;
@@ -94,8 +95,7 @@ public:
 
 	void setDayNightRatioOverride(bool enable, u32 value)
 	{
-		m_enable_day_night_ratio_override = enable;
-		m_day_night_ratio_override = value;
+		m_day_night_ratio_override_storage = value | ((u64)enable >> 63);
 	}
 
 	// counter used internally when triggering ABMs
@@ -105,23 +105,25 @@ protected:
 	// peer_ids in here should be unique, except that there may be many 0s
 	std::vector<Player*> m_players;
 
+	// Time of day in milli-hours (0-23999); determines day and night
+	Atomic<u32> m_time_of_day;
 
 	/*
-	 *  Below: values under m_time_lock
-	 */
-	// Time of day in milli-hours (0-23999); determines day and night
-	u32 m_time_of_day;
+	 * Below: values managed by m_time_floats_lock
+	*/
 	// Time of day in 0...1
 	float m_time_of_day_f;
 	float m_time_of_day_speed;
-	// Used to buffer dtime for adding to m_time_of_day
-	float m_time_counter;
-	// Overriding the day-night ratio is useful for custom sky visuals
-	bool m_enable_day_night_ratio_override;
-	u32 m_day_night_ratio_override;
+	// Stores the skew created by the float -> u32 conversion
+	// to be applied at next conversion, so that there is no real skew.
+	float m_time_conversion_skew;
 	/*
-	 * Above: values under m_time_lock
-	 */
+	 * Above: values managed by m_time_floats_lock
+	*/
+
+	// Overriding the day-night ratio is useful for custom sky visuals
+	// lowest 32 bits store the overriden ratio, highest bit stores whether its enabled
+	Atomic<u64> m_day_night_ratio_override_storage;
 
 	/* TODO: Add a callback function so these can be updated when a setting
 	 *       changes.  At this point in time it doesn't matter (e.g. /set
@@ -135,7 +137,7 @@ protected:
 	bool m_cache_enable_shaders;
 
 private:
-	Mutex m_time_lock;
+	Mutex m_time_floats_lock;
 
 	DISABLE_CLASS_COPY(Environment);
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1232,11 +1232,6 @@ void Server::setTimeOfDay(u32 time)
 	m_time_of_day_send_timer = 0;
 }
 
-u32 Server::getTimeOfDay()
-{
-	return m_env->getTimeOfDay();
-}
-
 void Server::onMapEditEvent(MapEditEvent *event)
 {
 	if(m_ignore_map_edit_events)

--- a/src/server.h
+++ b/src/server.h
@@ -223,7 +223,6 @@ public:
 	// Both setter and getter need no envlock,
 	// can be called freely from threads
 	void setTimeOfDay(u32 time);
-	inline u32 getTimeOfDay();
 
 	/*
 		Shall be called with the environment locked.

--- a/src/threading/atomic.h
+++ b/src/threading/atomic.h
@@ -29,64 +29,83 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GCC_VERSION   (__GNUC__        * 100 + __GNUC_MINOR__)
 #define CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #if GCC_VERSION >= 407 || CLANG_VERSION >= 302
-	#define ATOMIC_LOAD(T, v)      return __atomic_load_n(&(v),       __ATOMIC_SEQ_CST)
-	#define ATOMIC_STORE(T, v, x)  __atomic_store (&(v), &(x), __ATOMIC_SEQ_CST); return x
-	#define ATOMIC_ADD_EQ(T, v, x) return __atomic_add_fetch(&(v), (x), __ATOMIC_SEQ_CST)
-	#define ATOMIC_SUB_EQ(T, v, x) return __atomic_sub_fetch(&(v), (x), __ATOMIC_SEQ_CST)
-	#define ATOMIC_POST_INC(T, v)  return __atomic_fetch_add(&(v), 1, __ATOMIC_SEQ_CST)
-	#define ATOMIC_POST_DEC(T, v)  return __atomic_fetch_sub(&(v), 1, __ATOMIC_SEQ_CST)
+	#define ATOMIC_LOAD(T, v)        return __atomic_load_n    (&(v),       __ATOMIC_SEQ_CST)
+	#define ATOMIC_STORE(T, v, x)           __atomic_store     (&(v), &(x), __ATOMIC_SEQ_CST); return x
+	#define ATOMIC_EXCHANGE(T, v, x) return __atomic_exchange_n(&(v), (x),  __ATOMIC_SEQ_CST)
+	#define ATOMIC_ADD_EQ(T, v, x)   return __atomic_add_fetch (&(v), (x),  __ATOMIC_SEQ_CST)
+	#define ATOMIC_SUB_EQ(T, v, x)   return __atomic_sub_fetch (&(v), (x),  __ATOMIC_SEQ_CST)
+	#define ATOMIC_POST_INC(T, v)    return __atomic_fetch_add (&(v), 1,    __ATOMIC_SEQ_CST)
+	#define ATOMIC_POST_DEC(T, v)    return __atomic_fetch_sub (&(v), 1,    __ATOMIC_SEQ_CST)
+	#define ATOMIC_CAS(T, v, e, d)   return __atomic_compare_exchange_n(&(v), &(e), (d), \
+		false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
 #else
 	#define ATOMIC_USE_LOCK
 	#include "threading/mutex.h"
 
 	#define ATOMIC_LOCK_OP(T, op) do { \
-			mutex.lock(); \
-			T _val = (op); \
-			mutex.unlock(); \
-			return _val; \
+			m_mutex.lock();            \
+			T _val = (op);             \
+			m_mutex.unlock();          \
+			return _val;               \
 		} while (0)
-	#define ATOMIC_LOAD(T, v) \
+	#define ATOMIC_LOCK_CAS(T, v, e, d) do { \
+			m_mutex.lock();                  \
+			bool _eq = (v == e);             \
+			if (_eq)                         \
+				v = d;                       \
+			m_mutex.unlock();                \
+			return _eq;                      \
+		} while (0)
+	#define ATOMIC_LOAD(T, v)                     \
 		if (sizeof(T) <= sizeof(void*)) return v; \
 		else ATOMIC_LOCK_OP(T, v);
-	#define ATOMIC_STORE(T, v, x) \
+	#define ATOMIC_STORE(T, v, x)                     \
 		if (sizeof(T) <= sizeof(void*)) return v = x; \
 		else ATOMIC_LOCK_OP(T, v = x);
-# if GCC_VERSION >= 401
-	#define ATOMIC_ADD_EQ(T, v, x) return __sync_add_and_fetch(&(v), (x))
-	#define ATOMIC_SUB_EQ(T, v, x) return __sync_sub_and_fetch(&(v), (x))
-	#define ATOMIC_POST_INC(T, v)  return __sync_fetch_and_add(&(v), 1)
-	#define ATOMIC_POST_DEC(T, v)  return __sync_fetch_and_sub(&(v), 1)
-# else
-	#define ATOMIC_ADD_EQ(T, v, x) ATOMIC_LOCK_OP(T, v += x)
-	#define ATOMIC_SUB_EQ(T, v, x) ATOMIC_LOCK_OP(T, v -= x)
-	#define ATOMIC_POST_INC(T, v)  ATOMIC_LOCK_OP(T, v++)
-	#define ATOMIC_POST_DEC(T, v)  ATOMIC_LOCK_OP(T, v--)
-# endif
+	#define ATOMIC_EXCHANGE(T, v, x) do { \
+			m_mutex.lock();               \
+			T _val = v;                   \
+			v = x;                        \
+			m_mutex.unlock();             \
+			return _val;                  \
+		} while (0)
+	#if GCC_VERSION >= 401
+		#define ATOMIC_ADD_EQ(T, v, x) return __sync_add_and_fetch(&(v), (x))
+		#define ATOMIC_SUB_EQ(T, v, x) return __sync_sub_and_fetch(&(v), (x))
+		#define ATOMIC_POST_INC(T, v)  return __sync_fetch_and_add(&(v), 1)
+		#define ATOMIC_POST_DEC(T, v)  return __sync_fetch_and_sub(&(v), 1)
+		#define ATOMIC_CAS(T, v, e, d) return __sync_bool_compare_and_swap(&(v), &(e), (d))
+	#else
+		#define ATOMIC_ADD_EQ(T, v, x) ATOMIC_LOCK_OP(T, v += x)
+		#define ATOMIC_SUB_EQ(T, v, x) ATOMIC_LOCK_OP(T, v -= x)
+		#define ATOMIC_POST_INC(T, v)  ATOMIC_LOCK_OP(T, v++)
+		#define ATOMIC_POST_DEC(T, v)  ATOMIC_LOCK_OP(T, v--)
+		#define ATOMIC_CAS(T, v, e, d) ATOMIC_LOCK_CAS(T, v, e, d)
+	#endif
 #endif
 
 
 template<typename T>
-class Atomic
-{
-	// Like C++11 std::enable_if, but defaults to char since C++03 doesn't support SFINAE
-	template<bool B, typename T_ = void> struct enable_if { typedef char type; };
-	template<typename T_> struct enable_if<true, T_> { typedef T_ type; };
+class Atomic {
 public:
-	Atomic(const T &v=0) : val(v) {}
+	Atomic(const T &v = 0) : val(v) {}
 
 	operator T () { ATOMIC_LOAD(T, val); }
-	T operator = (T x) { ATOMIC_STORE(T, val, x); }
+
+	T exchange(T x)  { ATOMIC_EXCHANGE(T, val, x); }
+	bool compare_exchange_strong(T &expected, T desired) { ATOMIC_CAS(T, val, expected, desired); }
+
+	T operator =  (T x) { ATOMIC_STORE(T, val, x); }
 	T operator += (T x) { ATOMIC_ADD_EQ(T, val, x); }
 	T operator -= (T x) { ATOMIC_SUB_EQ(T, val, x); }
-	T operator ++ () { return *this += 1; }
-	T operator -- () { return *this -= 1; }
+	T operator ++ ()    { return *this += 1; }
+	T operator -- ()    { return *this -= 1; }
 	T operator ++ (int) { ATOMIC_POST_INC(T, val); }
 	T operator -- (int) { ATOMIC_POST_DEC(T, val); }
-
 private:
-	volatile T val;
+	T val;
 #ifdef ATOMIC_USE_LOCK
-	typename enable_if<sizeof(T) <= sizeof(void*), Mutex>::type mutex;
+	Mutex m_mutex;
 #endif
 };
 


### PR DESCRIPTION
It isn't possible to use atomic operators for floats, so don't use them there.

Having a lock is good out of other reasons too, because this way the float time
and the integer time both match, and can't get different values in a race,
e.g. when setTimeofDay() gets executed simultaneously.

PR also includes commit to clean up atomic.h, which was necessary because android build failed.