### PR TITLE
Fix time of day skew update and store almost all time related stuff in Atomic

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -105,21 +105,19 @@ protected:
 	// peer_ids in here should be unique, except that there may be many 0s
 	std::vector<Player*> m_players;
 
+	// Encodes the time of day in a thread safe manner.
+	// First 4 bytes:
 	// Time of day in milli-hours (0-23999); determines day and night
-	Atomic<u32> m_time_of_day;
+	// The remaining 4 bytes:
+	// Time of day in 0...1 formatted as f32.
+	Atomic<u64> m_time_of_day_storage;
 
-	/*
-	 * Below: values managed by m_time_floats_lock
-	*/
-	// Time of day in 0...1
-	float m_time_of_day_f;
-	float m_time_of_day_speed;
+	GenericAtomic<float> m_time_of_day_speed;
+
 	// Stores the skew created by the float -> u32 conversion
 	// to be applied at next conversion, so that there is no real skew.
+	// Make sure to aquire m_time_skew_lock when you access this
 	float m_time_conversion_skew;
-	/*
-	 * Above: values managed by m_time_floats_lock
-	*/
 
 	// Overriding the day-night ratio is useful for custom sky visuals
 	// lowest 32 bits store the overriden ratio, highest bit stores whether its enabled
@@ -137,7 +135,7 @@ protected:
 	bool m_cache_enable_shaders;
 
 private:
-	Mutex m_time_floats_lock;
+	Mutex m_time_skew_lock;
 
 	DISABLE_CLASS_COPY(Environment);
 };

--- a/src/threading/atomic.h
+++ b/src/threading/atomic.h
@@ -24,19 +24,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if __cplusplus >= 201103L
 	#include <atomic>
 	template<typename T> using Atomic = std::atomic<T>;
+	template<typename T> using GenericAtomic = std::atomic<T>;
 #else
 
 #define GCC_VERSION   (__GNUC__        * 100 + __GNUC_MINOR__)
 #define CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #if GCC_VERSION >= 407 || CLANG_VERSION >= 302
+	#define ATOMIC_LOAD_GENERIC(T, v) do {               \
+		T _val;                                          \
+		 __atomic_load(&(v), &(_val), __ATOMIC_SEQ_CST); \
+		return _val;                                     \
+	} while(0)
 	#define ATOMIC_LOAD(T, v)        return __atomic_load_n    (&(v),       __ATOMIC_SEQ_CST)
 	#define ATOMIC_STORE(T, v, x)           __atomic_store     (&(v), &(x), __ATOMIC_SEQ_CST); return x
-	#define ATOMIC_EXCHANGE(T, v, x) return __atomic_exchange_n(&(v), (x),  __ATOMIC_SEQ_CST)
+	#define ATOMIC_EXCHANGE(T, v, x) return __atomic_exchange  (&(v), &(x), __ATOMIC_SEQ_CST)
 	#define ATOMIC_ADD_EQ(T, v, x)   return __atomic_add_fetch (&(v), (x),  __ATOMIC_SEQ_CST)
 	#define ATOMIC_SUB_EQ(T, v, x)   return __atomic_sub_fetch (&(v), (x),  __ATOMIC_SEQ_CST)
 	#define ATOMIC_POST_INC(T, v)    return __atomic_fetch_add (&(v), 1,    __ATOMIC_SEQ_CST)
 	#define ATOMIC_POST_DEC(T, v)    return __atomic_fetch_sub (&(v), 1,    __ATOMIC_SEQ_CST)
-	#define ATOMIC_CAS(T, v, e, d)   return __atomic_compare_exchange_n(&(v), &(e), (d), \
+	#define ATOMIC_CAS(T, v, e, d)   return __atomic_compare_exchange(&(v), &(e), &(d), \
 		false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
 #else
 	#define ATOMIC_USE_LOCK
@@ -56,12 +62,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			m_mutex.unlock();                \
 			return _eq;                      \
 		} while (0)
-	#define ATOMIC_LOAD(T, v)                     \
-		if (sizeof(T) <= sizeof(void*)) return v; \
-		else ATOMIC_LOCK_OP(T, v);
-	#define ATOMIC_STORE(T, v, x)                     \
-		if (sizeof(T) <= sizeof(void*)) return v = x; \
-		else ATOMIC_LOCK_OP(T, v = x);
+	#define ATOMIC_LOAD(T, v) ATOMIC_LOCK_OP(T, v)
+	#define ATOMIC_LOAD_GENERIC(T, v) ATOMIC_LOAD(T, v)
+	#define ATOMIC_STORE(T, v, x) ATOMIC_LOCK_OP(T, v = x)
 	#define ATOMIC_EXCHANGE(T, v, x) do { \
 			m_mutex.lock();               \
 			T _val = v;                   \
@@ -88,22 +91,40 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 template<typename T>
 class Atomic {
 public:
-	Atomic(const T &v = 0) : val(v) {}
+	Atomic(const T &v = 0) : m_val(v) {}
 
-	operator T () { ATOMIC_LOAD(T, val); }
+	operator T () { ATOMIC_LOAD(T, m_val); }
 
-	T exchange(T x)  { ATOMIC_EXCHANGE(T, val, x); }
-	bool compare_exchange_strong(T &expected, T desired) { ATOMIC_CAS(T, val, expected, desired); }
+	T exchange(T x)  { ATOMIC_EXCHANGE(T, m_val, x); }
+	bool compare_exchange_strong(T &expected, T desired) { ATOMIC_CAS(T, m_val, expected, desired); }
 
-	T operator =  (T x) { ATOMIC_STORE(T, val, x); }
-	T operator += (T x) { ATOMIC_ADD_EQ(T, val, x); }
-	T operator -= (T x) { ATOMIC_SUB_EQ(T, val, x); }
+	T operator =  (T x) { ATOMIC_STORE(T, m_val, x); }
+	T operator += (T x) { ATOMIC_ADD_EQ(T, m_val, x); }
+	T operator -= (T x) { ATOMIC_SUB_EQ(T, m_val, x); }
 	T operator ++ ()    { return *this += 1; }
 	T operator -- ()    { return *this -= 1; }
-	T operator ++ (int) { ATOMIC_POST_INC(T, val); }
-	T operator -- (int) { ATOMIC_POST_DEC(T, val); }
+	T operator ++ (int) { ATOMIC_POST_INC(T, m_val); }
+	T operator -- (int) { ATOMIC_POST_DEC(T, m_val); }
 private:
-	T val;
+	T m_val;
+#ifdef ATOMIC_USE_LOCK
+	Mutex m_mutex;
+#endif
+};
+
+template<typename T>
+class GenericAtomic {
+public:
+	GenericAtomic(const T &v = 0) : m_val(v) {}
+
+	operator T () { ATOMIC_LOAD_GENERIC(T, m_val); }
+
+	T exchange(T x)  { ATOMIC_EXCHANGE(T, m_val, x); }
+	bool compare_exchange_strong(T &expected, T desired) { ATOMIC_CAS(T, m_val, expected, desired); }
+
+	T operator = (T x) { ATOMIC_STORE(T, m_val, x); }
+private:
+	T m_val;
 #ifdef ATOMIC_USE_LOCK
 	Mutex m_mutex;
 #endif


### PR DESCRIPTION
Store almost every time related variable in Atomic or GenericAtomic:

	* Store the time of day into a storage Atomic<u64> so that
	  the integral time of day doesn't get set differently than the
	  float time of day in a race.

	* Only the skew needs a lock now, there is no other way however
	  than to use a lock, except removing the lock and hoping the best.
	  floats can't get non-generic atomic operations, not with the
	  current support of gcc. C++11 has an abstraction layer for them,
	  but there is no widespread implementation in hardware.

Fix the skew update so that it is added too, not just substracted from.
This has been a regression since commit [1].

atomic.h changes:
	* Add GenericAtomic<T> class for non-integral types like floats.

	* Remove some last remainders from atomic.h of the volatile use.

[1] f9b09368f063cdace93a042d5bdd45987c084d94 "Time: Remove serverside getter, and use atomic operations"