### PR TITLE
Add the player name to dropped items.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -348,7 +348,7 @@ function core.item_place(itemstack, placer, pointed_thing, param2)
 end
 
 function core.item_drop(itemstack, dropper, pos)
-	if dropper.is_player then
+	if dropper and dropper:is_player() then
 		local v = dropper:get_look_dir()
 		local p = {x=pos.x, y=pos.y+1.2, z=pos.z}
 		local cs = itemstack:get_count()
@@ -362,6 +362,7 @@ function core.item_drop(itemstack, dropper, pos)
 			v.y = v.y*2 + 2
 			v.z = v.z*2
 			obj:setvelocity(v)
+			obj:get_luaentity().dropped_by = dropper:get_player_name()
 			return itemstack
 		end
 

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -74,7 +74,8 @@ core.register_entity(":__builtin:item", {
 		return core.serialize({
 			itemstring = self.itemstring,
 			always_collect = self.always_collect,
-			age = self.age
+			age = self.age,
+			dropped_by = self.dropped_by
 		})
 	end,
 
@@ -89,6 +90,7 @@ core.register_entity(":__builtin:item", {
 				else
 					self.age = dtime_s
 				end
+				self.dropped_by = data.dropped_by
 			end
 		else
 			self.itemstring = staticdata


### PR DESCRIPTION
The player name is now added in the field "dropped_by" on the created
entity.

This is interesting for mods as they'd have the ability to determine if the item which they get with get_objects_inside_radius has just been dropped by the player. The main benefectors of this would be the auto pickup mods, which allow to pickup items when walking over them. Currently they either prevent the players form dropping something (because the item is just being picked up again) or they have to override and duplicate the minetest.item_drop function to add this functionality.