### PR TITLE
Increase performance of updateDrawListPerf by 25%.

### DIFF
--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -132,12 +132,6 @@ public:
 	// For debug printing
 	virtual void PrintInfo(std::ostream &out);
 	
-	// Check if sector was drawn on last render()
-	bool sectorWasDrawn(v2s16 p)
-	{
-		return (m_last_drawn_sectors.find(p) != m_last_drawn_sectors.end());
-	}
-	
 private:
 	Client *m_client;
 	
@@ -151,9 +145,7 @@ private:
 	v3s16 m_camera_offset;
 	Mutex m_camera_mutex;
 
-	std::map<v3s16, MapBlock*> m_drawlist;
-	
-	std::set<v2s16> m_last_drawn_sectors;
+	std::vector<MapBlock*> m_drawlist;
 
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;


### PR DESCRIPTION
Increase performance of updateDrawListPerf by 25% by:
Replacing a map with a vector
Hoisting settings reading out of a loop (settings reading takes a lock)
Deleting an unused variable which was getting populated

Before changes, updateDrawListPerf took 780us
After changes, it took 517us
That's a 30% speed improvement, however updateDrawListPerf is not called every frame. At least called 5 times a second. (So at minimum, this saves 1.3ms every second).

Side effect is the settings related change actually eliminates a lot of FPS jitter in singleplayer (which is to be expected).

Performance was tested with a MSVC release build on windows 7 x64.
