### PR TITLE
Mgv6: Move global mapgen flag 'flat' into mgv6 spflags

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -829,10 +829,10 @@ max_block_generate_distance (Max block generate distance) int 6
 map_generation_limit (Map generation limit) int 31000 0 31000
 
 #    Global map generation attributes.
+#    The 'trees' flag only has effect in mgv6.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    'trees' and 'flat' flags only have effect in mgv6.
-mg_flags (Mapgen flags) flags trees,caves,dungeons,light trees,caves,dungeons,light,flat,notrees,nocaves,nodungeons,nolight,noflat
+mg_flags (Mapgen flags) flags trees,caves,dungeons,light trees,caves,dungeons,light,notrees,nocaves,nodungeons,nolight
 
 [**Advanced]
 
@@ -889,7 +889,7 @@ mgv5_np_cave2 (Mapgen v5 cave2 noise parameters) noise_params 0, 12, (50, 50, 50
 #    When snowbiomes are enabled jungles are enabled and the jungles flag is ignored.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-mgv6_spflags (Mapgen v6 flags) flags jungles,biomeblend,mudflow,snowbiomes jungles,biomeblend,mudflow,snowbiomes,nojungles,nobiomeblend,nomudflow,nosnowbiomes
+mgv6_spflags (Mapgen v6 flags) flags jungles,biomeblend,mudflow,snowbiomes jungles,biomeblend,mudflow,snowbiomes,flat,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat
 
 #    Controls size of deserts and beaches in Mapgen v6.
 #    When snowbiomes are enabled 'mgv6_freq_desert' is ignored.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1021,10 +1021,10 @@
 # map_generation_limit = 31000
 
 #    Global map generation attributes.
+#    The 'trees' flag only has effect in mgv6.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    'trees' and 'flat' flags only have effect in mgv6.
-#    type: flags possible values: trees, caves, dungeons, light, flat, notrees, nocaves, nodungeons, nolight, noflat
+#    type: flags possible values: trees, caves, dungeons, light, notrees, nocaves, nodungeons, nolight
 # mg_flags = trees,caves,dungeons,light
 
 ### Advanced
@@ -1093,7 +1093,7 @@
 #    When snowbiomes are enabled jungles are enabled and the jungles flag is ignored.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    type: flags possible values: jungles, biomeblend, mudflow, snowbiomes, nojungles, nobiomeblend, nomudflow, nosnowbiomes
+#    type: flags possible values: jungles, biomeblend, mudflow, snowbiomes, flat, nojungles, nobiomeblend, nomudflow, nosnowbiomes, noflat
 # mgv6_spflags = jungles,biomeblend,mudflow,snowbiomes
 
 #    Controls size of deserts and beaches in Mapgen v6.

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -42,6 +42,7 @@ FlagDesc flagdesc_mapgen_v6[] = {
 	{"biomeblend", MGV6_BIOMEBLEND},
 	{"mudflow",    MGV6_MUDFLOW},
 	{"snowbiomes", MGV6_SNOWBIOMES},
+	{"flat",       MGV6_FLAT},
 	{NULL,         0}
 };
 
@@ -263,7 +264,7 @@ float MapgenV6::baseTerrainLevel(float terrain_base, float terrain_higher,
 
 float MapgenV6::baseTerrainLevelFromNoise(v2s16 p)
 {
-	if (flags & MG_FLAT)
+	if ((spflags & MGV6_FLAT) || (flags & MG_FLAT))
 		return water_level;
 
 	float terrain_base   = NoisePerlin2D_PO(&noise_terrain_base->np,
@@ -289,7 +290,7 @@ float MapgenV6::baseTerrainLevelFromMap(v2s16 p)
 
 float MapgenV6::baseTerrainLevelFromMap(int index)
 {
-	if (flags & MG_FLAT)
+	if ((spflags & MGV6_FLAT) || (flags & MG_FLAT))
 		return water_level;
 
 	float terrain_base   = noise_terrain_base->result[index];
@@ -386,7 +387,7 @@ bool MapgenV6::getHaveAppleTree(v2s16 p)
 
 float MapgenV6::getMudAmount(int index)
 {
-	if (flags & MG_FLAT)
+	if ((spflags & MGV6_FLAT) || (flags & MG_FLAT))
 		return MGV6_AVERAGE_MUD_AMOUNT;
 
 	/*return ((float)AVERAGE_MUD_AMOUNT + 2.0 * noise2d_perlin(
@@ -603,7 +604,7 @@ void MapgenV6::calculateNoise()
 	int fx = full_node_min.X;
 	int fz = full_node_min.Z;
 
-	if (!(flags & MG_FLAT)) {
+	if (!((spflags & MGV6_FLAT) || (flags & MG_FLAT))) {
 		noise_terrain_base->perlinMap2D_PO(x, 0.5, z, 0.5);
 		noise_terrain_higher->perlinMap2D_PO(x, 0.5, z, 0.5);
 		noise_steepness->perlinMap2D_PO(x, 0.5, z, 0.5);

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV6_BIOMEBLEND 0x02
 #define MGV6_MUDFLOW    0x04
 #define MGV6_SNOWBIOMES 0x08
+#define MGV6_FLAT       0x10
 
 
 extern FlagDesc flagdesc_mapgen_v6[];


### PR DESCRIPTION
Add mgv6 spflag 'flat'
Leave global flag in for backwards compatibility but undocumented

I'll update documentation later closer to possible merge to help avoid conflicts.

The global flat flag has no effect outside of mgv6, so should be a mgv6 spflag. We now have the new flat mapgen for non-mgv6 flat worlds.
The documentation for the global flat flag is removed so that new worlds will be created using the new mgv6 flat spflag. The code in mgv6 recognises either flag for automatic backwards compatibility.

I feel we should not break existing mgv6 flat worlds, they cannot use the new mgflat mapgen because that has a different default ground height, different biomes, decorations and caves.