### PR TITLE
Mgfractal: Create a choice of 4 mandelbrot formulas

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -970,10 +970,15 @@ mgflat_np_cave2 (Mapgen flat cave2 noise parameters) noise_params 0, 12, (128, 1
 [***Mapgen fractal]
 
 #    Map generation attributes specific to Mapgen fractal.
-#    'julia' selects a julia set to be generated instead of a mandelbrot set.
+#    The 'julia' flag results in the corresponding julia set being generated.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
 mgfractal_spflags (Mapgen fractal flags) flags nojulia julia,nojulia
+
+#    Choice of 4 mandelbrot set variations.
+#    1 = 4D "Roundy" mandelbrot set, 2 = 4D "Squarry" mandelbrot set,
+#    3 = 4D "Mandy Cousin" mandelbrot set, 4 = 4D mandelbrot set variation.
+mgfractal_formula (Mapgen fractal formula) int 1 1 4
 
 #    Mandelbrot set: Iterations of the recursive function.
 #    Controls scale of finest detail.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1234,11 +1234,17 @@
 #### Mapgen fractal
 
 #    Map generation attributes specific to Mapgen fractal.
-#    'julia' selects a julia set to be generated instead of a mandelbrot set.
+#    The 'julia' flag results in the corresponding julia set being generated.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
 #    type: flags possible values: julia, nojulia
 # mgfractal_spflags = nojulia
+
+#    Choice of 4 mandelbrot set variations.
+#    1 = 4D "Roundy" mandelbrot set, 2 = 4D "Squarry" mandelbrot set,
+#    3 = 4D "Mandy Cousin" mandelbrot set, 4 = 4D mandelbrot set variation.
+#    type: int
+# mgfractal_formula = 1
 
 #    Mandelbrot set: Iterations of the recursive function.
 #    Controls scale of finest detail.

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -36,6 +36,8 @@ extern FlagDesc flagdesc_mapgen_fractal[];
 struct MapgenFractalParams : public MapgenSpecificParams {
 	u32 spflags;
 
+	u16 formula;
+
 	u16 m_iterations;
 	v3f m_scale;
 	v3f m_offset;
@@ -75,6 +77,8 @@ public:
 	v3s16 node_max;
 	v3s16 full_node_min;
 	v3s16 full_node_max;
+
+	u16 formula;
 
 	u16 m_iterations;
 	v3f m_scale;


### PR DESCRIPTION
A new parameter 'formula' creates a choice of 4 4D mandelbrot variations.
Formulas and images from http://www.bugman123.com/Hypercomplex/index.html
Is tested.

![mandelbrot-roundy](https://cloud.githubusercontent.com/assets/3686677/11139317/b5fdd14e-89c5-11e5-9827-de14766d88c1.jpg)

![mandelbrot0110](https://cloud.githubusercontent.com/assets/3686677/11139323/beb65e00-89c5-11e5-899a-225fd1143ec8.jpg)

![mandelbrot1111](https://cloud.githubusercontent.com/assets/3686677/11139326/c25ab7ae-89c5-11e5-9f42-082da448149b.jpg)

![mandelbrot0101](https://cloud.githubusercontent.com/assets/3686677/11139327/c5960e6e-89c5-11e5-9947-8720a859d742.jpg)

The existing 'julia' flag generates the corresponding julia set for each, making a total of 8 fractals to choose from.