### PR TITLE
Decoration API: Allow very low density decorations

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -117,7 +117,15 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 		float nval = (flags & DECO_USE_NOISE) ?
 			NoisePerlin2D(&np, p2d_center.X, p2d_center.Y, mapseed) :
 			fill_ratio;
-		u32 deco_count = area * MYMAX(nval, 0.f);
+		u32 deco_count = 0;
+		float deco_count_f = (float)area * nval;
+		if (deco_count_f >= 1.f) {
+			deco_count = deco_count_f;
+		} else if (deco_count_f > 0.f) {
+			// For low density decorations calculate a chance for 1 decoration
+			if (ps.range(1000) <= deco_count_f * 1000.f)
+				deco_count = 1;
+		}
 
 		for (u32 i = 0; i < deco_count; i++) {
 			s16 x = ps.range(p2d_min.X, p2d_max.X);


### PR DESCRIPTION
![screenshot_20151114_065713](https://cloud.githubusercontent.com/assets/3686677/11162527/8b343dbc-8a9d-11e5-9a94-e9cb93710126.png)

For a deco count between 0 and 1 allow a chance for 1

Fixes low density decorations never appearing due to deco_count being rounded down to 0 in each 16x16 node division.
Now if deco_count is between 0 and 1 a chance for 1 decoration is allowed.
If deco_count is >=1, as in most use cases, code runs as before with no slowdown.
Can cope with densities as low as 1 decoration per 5x5 mapchunk (400x400 node) area, fill_ratio = 0.000005, see screenshot for that test.