### PR TITLE
Mapgen: Add global 'decorations' flag

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -829,10 +829,11 @@ max_block_generate_distance (Max block generate distance) int 6
 map_generation_limit (Map generation limit) int 31000 0 31000
 
 #    Global map generation attributes.
-#    The 'trees' flag only has effect in mgv6.
+#    In Mapgen v6 the 'decorations' flag controls all decorations except trees
+#    and junglegrass, in all other mapgens this flag controls all decorations.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-mg_flags (Mapgen flags) flags trees,caves,dungeons,light trees,caves,dungeons,light,notrees,nocaves,nodungeons,nolight
+mg_flags (Mapgen flags) flags caves,dungeons,light,decorations caves,dungeons,light,decorations,nocaves,nodungeons,nolight,nodecorations
 
 [**Advanced]
 
@@ -889,7 +890,7 @@ mgv5_np_cave2 (Mapgen v5 cave2 noise parameters) noise_params 0, 12, (50, 50, 50
 #    When snowbiomes are enabled jungles are enabled and the jungles flag is ignored.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-mgv6_spflags (Mapgen v6 flags) flags jungles,biomeblend,mudflow,snowbiomes jungles,biomeblend,mudflow,snowbiomes,flat,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat
+mgv6_spflags (Mapgen v6 flags) flags jungles,biomeblend,mudflow,snowbiomes,trees jungles,biomeblend,mudflow,snowbiomes,flat,trees,nojungles,nobiomeblend,nomudflow,nosnowbiomes,noflat,notrees
 
 #    Controls size of deserts and beaches in Mapgen v6.
 #    When snowbiomes are enabled 'mgv6_freq_desert' is ignored.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1021,11 +1021,12 @@
 # map_generation_limit = 31000
 
 #    Global map generation attributes.
-#    The 'trees' flag only has effect in mgv6.
+#    In Mapgen v6 the 'decorations' flag controls all decorations except trees
+#    and junglegrass, in all other mapgens this flag controls all decorations.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    type: flags possible values: trees, caves, dungeons, light, notrees, nocaves, nodungeons, nolight
-# mg_flags = trees,caves,dungeons,light
+#    type: flags possible values: caves, dungeons, light, decorations, nocaves, nodungeons, nolight, nodecorations
+# mg_flags = caves,dungeons,light,decorations
 
 ### Advanced
 
@@ -1093,8 +1094,8 @@
 #    When snowbiomes are enabled jungles are enabled and the jungles flag is ignored.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    type: flags possible values: jungles, biomeblend, mudflow, snowbiomes, flat, nojungles, nobiomeblend, nomudflow, nosnowbiomes, noflat
-# mgv6_spflags = jungles,biomeblend,mudflow,snowbiomes
+#    type: flags possible values: jungles, biomeblend, mudflow, snowbiomes, flat, trees, nojungles, nobiomeblend, nomudflow, nosnowbiomes, noflat, notrees
+# mgv6_spflags = jungles,biomeblend,mudflow,snowbiomes,trees
 
 #    Controls size of deserts and beaches in Mapgen v6.
 #    When snowbiomes are enabled 'mgv6_freq_desert' is ignored.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -313,7 +313,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_level", "1");
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "dungeons");
-	settings->setDefault("mgv6_spflags", "jungles, snowbiomes");
+	settings->setDefault("mgv6_spflags", "jungles, snowbiomes, trees");
 
 	// IPv6
 	settings->setDefault("enable_ipv6", "true");

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -41,11 +41,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 
 FlagDesc flagdesc_mapgen[] = {
-	{"trees",    MG_TREES},
-	{"caves",    MG_CAVES},
-	{"dungeons", MG_DUNGEONS},
-	{"flat",     MG_FLAT},
-	{"light",    MG_LIGHT},
+	{"trees",       MG_TREES},
+	{"caves",       MG_CAVES},
+	{"dungeons",    MG_DUNGEONS},
+	{"flat",        MG_FLAT},
+	{"light",       MG_LIGHT},
+	{"decorations", MG_DECORATIONS},
 	{NULL,       0}
 };
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -29,11 +29,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define DEFAULT_MAPGEN "v6"
 
 /////////////////// Mapgen flags
-#define MG_TREES         0x01
-#define MG_CAVES         0x02
-#define MG_DUNGEONS      0x04
-#define MG_FLAT          0x08
-#define MG_LIGHT         0x10
+#define MG_TREES       0x01
+#define MG_CAVES       0x02
+#define MG_DUNGEONS    0x04
+#define MG_FLAT        0x08
+#define MG_LIGHT       0x10
+#define MG_DECORATIONS 0x20
 
 class Settings;
 class MMVManip;
@@ -126,7 +127,7 @@ struct MapgenParams {
 		chunksize(5),
 		seed(0),
 		water_level(1),
-		flags(MG_TREES | MG_CAVES | MG_LIGHT),
+		flags(MG_CAVES | MG_LIGHT | MG_DECORATIONS),
 		np_biome_heat(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0)),
 		np_biome_heat_blend(NoiseParams(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0)),
 		np_biome_humidity(NoiseParams(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0)),

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -296,7 +296,8 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate the registered decorations
-	m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+	if (flags & MG_DECORATIONS)
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -310,7 +310,8 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate the registered decorations
-	m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+	if (flags & MG_DECORATIONS)
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -296,7 +296,8 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate the registered decorations
-	m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+	if (flags & MG_DECORATIONS)
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -43,6 +43,7 @@ FlagDesc flagdesc_mapgen_v6[] = {
 	{"mudflow",    MGV6_MUDFLOW},
 	{"snowbiomes", MGV6_SNOWBIOMES},
 	{"flat",       MGV6_FLAT},
+	{"trees",      MGV6_TREES},
 	{NULL,         0}
 };
 
@@ -580,11 +581,12 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 	growGrass();
 
 	// Generate some trees, and add grass, if a jungle
-	if (flags & MG_TREES)
+	if ((spflags & MGV6_TREES) || (flags & MG_TREES))
 		placeTreesAndJungleGrass();
 
 	// Generate the registered decorations
-	m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+	if (flags & MG_DECORATIONS)
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV6_MUDFLOW    0x04
 #define MGV6_SNOWBIOMES 0x08
 #define MGV6_FLAT       0x10
+#define MGV6_TREES      0x20
 
 
 extern FlagDesc flagdesc_mapgen_v6[];

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -317,7 +317,8 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate the registered decorations
-	m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+	if (flags & MG_DECORATIONS)
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);


### PR DESCRIPTION
Flag is set by default in MapgenParams
The global 'trees' flag remains but is now
undocumented and unset by default in MapgenParams
Add mgv6_spflag 'trees' set by default in
defaultsettings.cpp to affect new worlds only
This is automatically backwards
compatible for existing worlds

Easily switchable decorations is needed for mgflat but is useful for all mapgens.
The plans for flags were briefly discussed here https://github.com/minetest/minetest/pull/3313#issuecomment-152686605
Test worlds were used to confirm this does not break existing worlds.

The global 'trees' flag is from a time when we only had 1 mapgen and trees were almost the only decoration. Now, in most mapgens all decorations are placed by the decorations API so trees cannot be separated from other decoratons.

The global 'trees' flag only affects mgv6 trees so needs to be moved into mgv6-specific-flags, and replaced by a global 'decorations' flag to keep the intended feature of switchable decorations and add it to all other mapgens. Essentially this is a long-overdue fix for mapgen decoration flags.

My implementation is backwards-compatible and keeps mgv6 trees independently-switchable from mgv6 decorations, there may be mgv6 worlds where the trees are disabled but the other decorations are wanted.
