### PR TITLE
Find spawn pos: Get spawn search centre from mapgen

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -328,6 +328,18 @@ v3s16 EmergeManager::getContainingChunk(v3s16 blockpos, s16 chunksize)
 }
 
 
+v2s16 EmergeManager::getSpawnSearchCentre()
+{
+	if (m_mapgens.size() == 0 || !m_mapgens[0]) {
+		errorstream << "EmergeManager: getSpawnSearchCentre() called"
+			" before mapgen init" << std::endl;
+		return v2s16(0, 0);
+	}
+
+	return m_mapgens[0]->getSpawnSearchCentre();
+}
+
+
 int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 {
 	if (m_mapgens.size() == 0 || !m_mapgens[0]) {

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -136,6 +136,7 @@ public:
 
 	// Mapgen helpers methods
 	Biome *getBiomeAtPoint(v3s16 p);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 	bool isBlockUnderground(v3s16 blockpos);
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -181,6 +181,7 @@ public:
 	void spreadLight(v3s16 nmin, v3s16 nmax);
 
 	virtual void makeChunk(BlockMakeData *data) {}
+	virtual v2s16 getSpawnSearchCentre() { return v2s16(0, 0); }
 	virtual int getGroundLevelAtPoint(v2s16 p) { return 0; }
 
 private:

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -192,6 +192,12 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 /////////////////////////////////////////////////////////////////
 
 
+v2s16 MapgenFlat::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
+
+
 int MapgenFlat::getGroundLevelAtPoint(v2s16 p)
 {
 	float n_terrain = NoisePerlin2D(&noise_terrain->np, p.X, p.Y, seed);

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -102,6 +102,7 @@ public:
 	~MapgenFlat();
 
 	virtual void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	s16 generateTerrain();

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -207,6 +207,12 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 /////////////////////////////////////////////////////////////////
 
 
+v2s16 MapgenFractal::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
+
+
 int MapgenFractal::getGroundLevelAtPoint(v2s16 p)
 {
 	s16 search_start = 128;

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -111,6 +111,7 @@ public:
 	~MapgenFractal();
 
 	virtual void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	bool getFractalAtPoint(s16 x, s16 y, s16 z);

--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -45,7 +45,9 @@ MapgenSinglenode::~MapgenSinglenode()
 {
 }
 
+
 //////////////////////// Map generator
+
 
 void MapgenSinglenode::makeChunk(BlockMakeData *data)
 {
@@ -93,6 +95,13 @@ void MapgenSinglenode::makeChunk(BlockMakeData *data)
 
 	this->generating = false;
 }
+
+
+v2s16 MapgenSinglenode::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
+
 
 int MapgenSinglenode::getGroundLevelAtPoint(v2s16 p)
 {

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -40,6 +40,7 @@ public:
 	~MapgenSinglenode();
 	
 	void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 };
 

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -172,6 +172,12 @@ void MapgenV5Params::writeParams(Settings *settings) const
 }
 
 
+v2s16 MapgenV5::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
+
+
 int MapgenV5::getGroundLevelAtPoint(v2s16 p)
 {
 	//TimeTaker t("getGroundLevelAtPoint", NULL, PRECISION_MICRO);

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -90,6 +90,7 @@ public:
 	~MapgenV5();
 
 	virtual void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	int generateBaseTerrain();

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -459,7 +459,14 @@ u32 MapgenV6::get_blockseed(u64 seed, v3s16 p)
 }
 
 
-//////////////////////// Map generator
+////////////////////////////////////////
+
+
+v2s16 MapgenV6::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
+
 
 void MapgenV6::makeChunk(BlockMakeData *data)
 {

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -127,6 +127,7 @@ public:
 	~MapgenV6();
 
 	void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 
 	float baseTerrainLevel(float terrain_base, float terrain_higher,

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -198,7 +198,13 @@ void MapgenV7Params::writeParams(Settings *settings) const
 }
 
 
-///////////////////////////////////////
+////////////////////////////////////////
+
+
+v2s16 MapgenV7::getSpawnSearchCentre()
+{
+	return v2s16(0, 0);
+}
 
 
 int MapgenV7::getGroundLevelAtPoint(v2s16 p)

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -103,6 +103,7 @@ public:
 	~MapgenV7();
 
 	virtual void makeChunk(BlockMakeData *data);
+	v2s16 getSpawnSearchCentre();
 	int getGroundLevelAtPoint(v2s16 p);
 	Biome *getBiomeAtPoint(v3s16 p);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3385,17 +3385,18 @@ v3f Server::findSpawnPos()
 	s16 water_level = map.getWaterLevel();
 	s16 vertical_spawn_range = g_settings->getS16("vertical_spawn_range");
 	bool is_good = false;
+	v2s16 search_centre = m_emerge->getSpawnSearchCentre();
 
 	// Try to find a good place a few times
 	for(s32 i = 0; i < 1000 && !is_good; i++) {
 		s32 range = 1 + i;
 		// We're going to try to throw the player to this position
-		v2s16 nodepos2d = v2s16(
+		v2s16 nodepos2d = search_centre + v2s16(
 				-range + (myrand() % (range * 2)),
 				-range + (myrand() % (range * 2)));
 
 		// Get ground height at point
-		s16 groundheight = map.findGroundLevel(nodepos2d);
+		s16 groundheight = m_emerge->getGroundLevelAtPoint(nodepos2d);
 		// Don't go underwater or to high places
 		if (groundheight <= water_level ||
 				groundheight > water_level + vertical_spawn_range)


### PR DESCRIPTION
Add getSpawnSearchCentre() to all mapgens, returning (0, 0)
for now, to be used by watershed or other large-scale mapgens
Also add it to class Mapgen and add a helper method to EmergeManager
In findSpawnPos() get groundheight directly from EmergeManager
instead of being redirected there in ServerMap