### PR TITLE
[WIP] Add the ability to set the dependecies of a mod in mod.conf and add conflicts and provides

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -49,8 +49,14 @@ local function get_formspec(data)
 		"label[0,0.45;" .. fgettext("Mod:") .. "]" ..
 		"label[0.75,0.45;" .. mod.name .. "]" ..
 		"label[0,1;" .. fgettext("Depends:") .. "]" ..
-		"textlist[0,1.5;5,4.25;world_config_depends;" ..
+		"textlist[0,1.5;5,2;world_config_depends;" ..
 		modmgr.get_dependencies(mod.path) .. ";0]" ..
+		"label[0,3.5;" .. fgettext("Provides:") .. "]" ..
+		"textlist[0,4;2.25,1.75;world_config_provides;" ..
+		modmgr.get_provides(mod.path) .. ";0]" ..
+		"label[2.5,3.5;" .. fgettext("Conflicts:") .. "]" ..
+		"textlist[2.5,4;2.25,1.75;world_config_conflicts;" ..
+		modmgr.get_conflicts(mod.path) .. ";0]" ..
 		"button[9.25,6.35;2,0.5;btn_config_world_save;" .. fgettext("Save") .. "]" ..
 		"button[7.4,6.35;2,0.5;btn_config_world_cancel;" .. fgettext("Cancel") .. "]"
 

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -286,24 +286,83 @@ end
 function modmgr.get_dependencies(modfolder)
 	local toadd = ""
 	if modfolder ~= nil then
-		local filename = modfolder ..
-					DIR_DELIM .. "depends.txt"
-
-		local dependencyfile = io.open(filename,"r")
-
-		if dependencyfile then
-			local dependency = dependencyfile:read("*l")
-			while dependency do
+		local mod_conf = Settings(modfolder .. DIR_DELIM .. "mod.conf")
+		local dependencies = nil
+		if mod_conf then
+			dependencies = mod_conf:get("depends");
+		end
+		if dependencies then
+			local list = dependencies:split()
+			for i, element in ipairs(list) do
 				if toadd ~= "" then
 					toadd = toadd .. ","
 				end
-				toadd = toadd .. dependency
-				dependency = dependencyfile:read()
+				toadd = toadd .. element:trim()
 			end
-			dependencyfile:close()
+		else
+			local filename = modfolder ..
+						DIR_DELIM .. "depends.txt"
+
+			local dependencyfile = io.open(filename,"r")
+
+			if dependencyfile then
+				local dependency = dependencyfile:read("*l")
+				while dependency do
+					if toadd ~= "" then
+						toadd = toadd .. ","
+					end
+					toadd = toadd .. dependency
+					dependency = dependencyfile:read()
+				end
+				dependencyfile:close()
+			end
 		end
 	end
 
+	return toadd
+end
+
+--------------------------------------------------------------------------------
+function modmgr.get_provides(modfolder)
+	local toadd = ""
+	if modfolder ~= nil then
+		local mod_conf = Settings(modfolder .. DIR_DELIM .. "mod.conf")
+		local provides = nil
+		if mod_conf then
+			provides = mod_conf:get("provides");
+		end
+		if provides then
+			local list = provides:split()
+			for i, element in ipairs(list) do
+				if toadd ~= "" then
+					toadd = toadd .. ","
+				end
+				toadd = toadd .. element:trim()
+			end
+		end
+	end
+	return toadd
+end
+
+--------------------------------------------------------------------------------
+function modmgr.get_conflicts(modfolder)
+	local toadd = ""
+	if modfolder ~= nil then
+		local mod_conf = Settings(modfolder .. DIR_DELIM .. "mod.conf")
+		local conflicts = nil
+		if mod_conf then
+			conflicts = mod_conf:get("conflicts");
+		end
+		if conflicts then
+			local list = conflicts:split()
+			for i, element in ipairs(list) do
+				if toadd ~= "" then
+					toadd = toadd .. ","
+				end
+				toadd = toadd .. element:trim()
+			end
+		end
+	end
 	return toadd
 end
 

--- a/builtin/mainmenu/tab_mods.lua
+++ b/builtin/mainmenu/tab_mods.lua
@@ -68,17 +68,26 @@ local function get_formspec(tabview, name, tabdata)
 				.. "label[8.25,0.6;" .. selected_mod.name .. "]"
 
 		local descriptionlines = nil
-		error = nil
-		local descriptionfilename = selected_mod.path .. "description.txt"
-		local descriptionfile,error = io.open(descriptionfilename,"r")
-		if error == nil then
-			local descriptiontext = descriptionfile:read("*all")
-
-			descriptionlines = core.splittext(descriptiontext,42)
-			descriptionfile:close()
+		local mod_conf = Settings(selected_mod.path .. "mod.conf")
+		local descriptiontext
+		if (mod_conf) then
+			descriptiontext = mod_conf:get("description")
+		end
+		if descriptiontext then
+			descriptionlines = core.splittext(descriptiontext, 42)
 		else
-			descriptionlines = {}
-			table.insert(descriptionlines,fgettext("No mod description available"))
+			error = nil
+			local descriptionfilename = selected_mod.path .. "description.txt"
+			local descriptionfile,error = io.open(descriptionfilename, "r")
+			if error == nil then
+				local descriptiontext = descriptionfile:read("*all")
+
+				descriptionlines = core.splittext(descriptiontext, 42)
+				descriptionfile:close()
+			else
+				descriptionlines = {}
+				table.insert(descriptionlines,fgettext("No mod description available"))
+			end
 		end
 
 		retval = retval ..
@@ -102,6 +111,14 @@ local function get_formspec(tabview, name, tabdata)
 			retval = retval .. "," .. fgettext("Depends:") .. ","
 
 			local toadd = modmgr.get_dependencies(selected_mod.path)
+
+			retval = retval .. toadd .. ",," .. fgettext("Provides:") .. ","
+
+			toadd = modmgr.get_provides(selected_mod.path)
+
+			retval = retval .. toadd .. ",," .. fgettext("Conflicts with:") .. ","
+
+			toadd = modmgr.get_conflicts(selected_mod.path)
 
 			retval = retval .. toadd .. ";0]"
 

--- a/src/mods.h
+++ b/src/mods.h
@@ -39,6 +39,8 @@ struct ModSpec
 	std::set<std::string> depends;
 	std::set<std::string> optdepends;
 	std::set<std::string> unsatisfied_depends;
+	std::set<std::string> conflicts;
+	std::set<std::string> provides;
 
 	bool part_of_modpack;
 	bool is_modpack;
@@ -88,7 +90,7 @@ public:
 	// checks if all dependencies are fullfilled.
 	bool isConsistent()
 	{
-		return m_unsatisfied_mods.empty();
+		return m_unsatisfied_mods.empty() && m_mod_conflicts.empty();
 	}
 
 	std::vector<ModSpec> getMods()
@@ -99,6 +101,11 @@ public:
 	std::vector<ModSpec> getUnsatisfiedMods()
 	{
 		return m_unsatisfied_mods;
+	}
+
+	std::map<std::string, std::string> getModConflicts()
+	{
+		return m_mod_conflicts;
 	}
 
 private:
@@ -133,6 +140,9 @@ private:
 	// 5. addon mod in modpack; 6. addon mod.
 	std::set<std::string> m_name_conflicts;
 
+	// map of mod names and error messages for mods that don't work well
+	// together
+	std::map<std::string, std::string> m_mod_conflicts;
 };
 
 #if USE_CURL

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -224,9 +224,10 @@ Server::Server(
 	ModConfiguration modconf(m_path_world);
 	m_mods = modconf.getMods();
 	std::vector<ModSpec> unsatisfied_mods = modconf.getUnsatisfiedMods();
+	std::map<std::string, std::string> mod_conflicts = modconf.getModConflicts();
 	// complain about mods with unsatisfied dependencies
-	if(!modconf.isConsistent()) {
-		for(std::vector<ModSpec>::iterator it = unsatisfied_mods.begin();
+	if (!modconf.isConsistent()) {
+		for (std::vector<ModSpec>::iterator it = unsatisfied_mods.begin();
 			it != unsatisfied_mods.end(); ++it) {
 			ModSpec mod = *it;
 			errorstream << "mod \"" << mod.name << "\" has unsatisfied dependencies: ";
@@ -234,6 +235,11 @@ Server::Server(
 				dep_it != mod.unsatisfied_depends.end(); ++dep_it)
 				errorstream << " \"" << *dep_it << "\"";
 			errorstream << std::endl;
+		}
+		for (std::map<std::string, std::string>::iterator it = mod_conflicts.begin();
+				it != mod_conflicts.end(); ++it) {
+			errorstream << "mod \"" << it->first << "\" conflicts with:"
+				<< it->second << std::endl;
 		}
 	}
 
@@ -255,6 +261,9 @@ Server::Server(
 	for(std::vector<ModSpec>::iterator it = unsatisfied_mods.begin();
 			it != unsatisfied_mods.end(); ++it)
 		load_mod_names.erase((*it).name);
+	for (std::map<std::string, std::string>::iterator it = mod_conflicts.begin();
+			it != mod_conflicts.end(); ++it)
+		load_mod_names.erase(it->first);
 	if(!load_mod_names.empty()) {
 		errorstream << "The following mods could not be found:";
 		for(std::set<std::string>::iterator it = load_mod_names.begin();


### PR DESCRIPTION
TODO:
- [x] move dependencies to mod.conf
- [x] add conflicts to mod.conf
- [x] add provides to mod.conf
- [ ] add preloads to mod.conf
- [x] make the changes visible for the user in the menu
    - [x] load the dependencies also from mod.conf
    - [x] add boxes like the dependencies for the other options
- [x] add description.txt into mod.conf
- [ ] document the changes

implements #3200, though it is still heavily WIP.