### PR TITLE
Add option to give every object a nametag or change the nametag text of players

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2544,6 +2544,19 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table
 * `is_player()`: returns true for players, false otherwise
+* `get_nametag_attributes()`
+    * returns a table with the attributes of the nametag of an object
+    * {
+        color = {a=0..255, r=0..255, g=0..255, b=0..255},
+        text = "",
+      }
+* `set_nametag_attributes(attributes)`
+    * sets the attributes of the nametag of an object
+    * `attributes`:
+      {
+        color = ColorSpec,
+        text = "My Nametag",
+      }
 
 ##### LuaEntitySAO-only (no-op for other objects)
 * `setvelocity({x=num, y=num, z=num})`
@@ -2644,17 +2657,6 @@ This is basically a reference to a C++ `ServerActiveObject`
     * in first person view
     * in third person view (max. values `{x=-10/10,y=-10,15,z=-5/5}`)
 * `get_eye_offset()`: returns offset_first and offset_third
-* `get_nametag_attributes()`
-    * returns a table with the attributes of the nametag of the player
-    * {
-        color = {a=0..255, r=0..255, g=0..255, b=0..255},
-      }
-* `set_nametag_attributes(attributes)`
-    * sets the attributes of the nametag of the player
-    * `attributes`:
-      {
-        color = ColorSpec,
-      }
 
 ### `InvRef`
 An `InvRef` is a reference to an inventory.
@@ -3232,6 +3234,8 @@ Definition tables
         automatic_face_movement_dir = 0.0,
     --  ^ automatically set yaw to movement direction; offset in degrees; false to disable
         backface_culling = true, -- false to disable backface_culling for model
+        nametag = "", -- by default empty, for players their name is shown if empty
+        nametag_color = <color>, -- sets color of nametag as ColorSpec
     }
 
 ### Entity definition (`register_entity`)

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -551,7 +551,6 @@ GenericCAO::GenericCAO(IGameDef *gamedef, ClientEnvironment *env):
 		m_animated_meshnode(NULL),
 		m_wield_meshnode(NULL),
 		m_spritenode(NULL),
-		m_nametag_color(video::SColor(255, 255, 255, 255)),
 		m_textnode(NULL),
 		m_position(v3f(0,10*BS,0)),
 		m_velocity(v3f(0,0,0)),
@@ -972,19 +971,19 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
 	updateTextures("");
 
 	scene::ISceneNode *node = getSceneNode();
-	if (node && m_is_player && !m_is_local_player) {
+	if (node && m_prop.nametag != "" && !m_is_local_player) {
 		// Add a text node for showing the name
 		gui::IGUIEnvironment* gui = irr->getGUIEnvironment();
-		std::wstring wname = utf8_to_wide(m_name);
+		std::wstring nametag_text = utf8_to_wide(m_prop.nametag);
 		m_textnode = smgr->addTextSceneNode(gui->getSkin()->getFont(),
-				wname.c_str(), m_nametag_color, node);
+				nametag_text.c_str(), m_prop.nametag_color, node);
 		m_textnode->grab();
 		m_textnode->setPosition(v3f(0, BS*1.1, 0));
 
 		// Enforce hiding nametag,
 		// because if freetype is enabled, a grey
 		// shadow can remain.
-		m_textnode->setVisible(m_nametag_color.getAlpha() > 0);
+		m_textnode->setVisible(m_prop.nametag_color.getAlpha() > 0);
 	}
 
 	updateNodePos();
@@ -1594,6 +1593,9 @@ void GenericCAO::processMessage(const std::string &data)
 			m_tx_basepos = m_prop.initial_sprite_basepos;
 		}
 
+		if ((m_is_player && !m_is_local_player) && m_prop.nametag == "")
+			m_prop.nametag = m_name;
+
 		expireVisuals();
 	}
 	else if(cmd == GENERIC_CMD_UPDATE_POSITION)
@@ -1772,15 +1774,15 @@ void GenericCAO::processMessage(const std::string &data)
 			m_armor_groups[name] = rating;
 		}
 	} else if (cmd == GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) {
+		// Deprecated, for backwards compatibility only.
 		readU8(is); // version
-		m_nametag_color = readARGB8(is);
+		m_prop.nametag_color = readARGB8(is);
 		if (m_textnode != NULL) {
-			m_textnode->setTextColor(m_nametag_color);
+			m_textnode->setTextColor(m_prop.nametag_color);
 
 			// Enforce hiding nametag,
-			// because if freetype is enabled, a grey
-			// shadow can remain.
-			m_textnode->setVisible(m_nametag_color.getAlpha() > 0);
+			// because if freetype is enabled, a grey shadow can remain.
+			m_textnode->setVisible(m_prop.nametag_color.getAlpha() > 0);
 		}
 	}
 }

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -70,7 +70,6 @@ private:
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode;
 	WieldMeshSceneNode *m_wield_meshnode;
 	scene::IBillboardSceneNode *m_spritenode;
-	video::SColor m_nametag_color;
 	scene::ITextSceneNode* m_textnode;
 	v3f m_position;
 	v3f m_velocity;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -757,8 +757,6 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, Player *player_, u16 peer_id_,
 	m_bone_position_sent(false),
 	m_attachment_parent_id(0),
 	m_attachment_sent(false),
-	m_nametag_color(video::SColor(255, 255, 255, 255)),
-	m_nametag_sent(false),
 	// public
 	m_physics_override_speed(1),
 	m_physics_override_jump(1),
@@ -857,7 +855,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 		os<<serializeLongString(gob_cmd_update_physics_override(m_physics_override_speed,
 				m_physics_override_jump, m_physics_override_gravity, m_physics_override_sneak,
 				m_physics_override_sneak_glitch)); // 5
-		os << serializeLongString(gob_cmd_update_nametag_attributes(m_nametag_color)); // 6
+		os << serializeLongString(gob_cmd_update_nametag_attributes(m_prop.nametag_color)); // 6 (GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) : Deprecated, for backwards compatibility only.
 	}
 	else
 	{
@@ -1008,14 +1006,6 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	if(m_attachment_sent == false){
 		m_attachment_sent = true;
 		std::string str = gob_cmd_update_attachment(m_attachment_parent_id, m_attachment_bone, m_attachment_position, m_attachment_rotation);
-		// create message and add to list
-		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push(aom);
-	}
-
-	if (m_nametag_sent == false) {
-		m_nametag_sent = true;
-		std::string str = gob_cmd_update_nametag_attributes(m_nametag_color);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);
@@ -1270,17 +1260,6 @@ void PlayerSAO::notifyObjectPropertiesModified()
 	m_properties_sent = false;
 }
 
-void PlayerSAO::setNametagColor(video::SColor color)
-{
-	m_nametag_color = color;
-	m_nametag_sent = false;
-}
-
-video::SColor PlayerSAO::getNametagColor()
-{
-	return m_nametag_color;
-}
-
 Inventory* PlayerSAO::getInventory()
 {
 	return m_inventory;
@@ -1396,4 +1375,3 @@ bool PlayerSAO::getCollisionBox(aabb3f *toset) {
 bool PlayerSAO::collideWithObjects(){
 	return true;
 }
-

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -91,13 +91,13 @@ private:
 	std::string m_init_state;
 	bool m_registered;
 	struct ObjectProperties m_prop;
-	
+
 	s16 m_hp;
 	v3f m_velocity;
 	v3f m_acceleration;
 	float m_yaw;
 	ItemGroupList m_armor_groups;
-	
+
 	bool m_properties_sent;
 	float m_last_sent_yaw;
 	v3f m_last_sent_position;
@@ -213,8 +213,6 @@ public:
 	std::set<int> getAttachmentChildIds();
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
-	void setNametagColor(video::SColor color);
-	video::SColor getNametagColor();
 
 	/*
 		Inventory interface
@@ -292,7 +290,7 @@ public:
 
 private:
 	std::string getPropertyPacket();
-	
+
 	Player *m_player;
 	u16 m_peer_id;
 	Inventory *m_inventory;
@@ -333,8 +331,6 @@ private:
 	v3f m_attachment_rotation;
 	bool m_attachment_sent;
 
-	video::SColor m_nametag_color;
-	bool m_nametag_sent;
 
 public:
 	float m_physics_override_speed;
@@ -346,4 +342,3 @@ public:
 };
 
 #endif
-

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -43,7 +43,9 @@ ObjectProperties::ObjectProperties():
 	stepheight(0),
 	automatic_face_movement_dir(false),
 	automatic_face_movement_dir_offset(0.0),
-	backface_culling(true)
+	backface_culling(true),
+	nametag(""),
+	nametag_color(255, 255, 255, 255)
 {
 	textures.push_back("unknown_object.png");
 	colors.push_back(video::SColor(255,255,255,255));
@@ -76,6 +78,9 @@ std::string ObjectProperties::dump()
 	os<<", makes_footstep_sound="<<makes_footstep_sound;
 	os<<", automatic_rotate="<<automatic_rotate;
 	os<<", backface_culling="<<backface_culling;
+	os << ", nametag=" << nametag;
+	os << ", nametag_color=" << "\"" << nametag_color.getAlpha() << "," << nametag_color.getRed()
+			<< "," << nametag_color.getGreen() << "," << nametag_color.getBlue() << "\" ";
 	return os.str();
 }
 
@@ -109,6 +114,8 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, automatic_face_movement_dir);
 	writeF1000(os, automatic_face_movement_dir_offset);
 	writeU8(os, backface_culling);
+	os << serializeString(nametag);
+	writeARGB8(os, nametag_color);
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -146,6 +153,8 @@ void ObjectProperties::deSerialize(std::istream &is)
 			automatic_face_movement_dir = readU8(is);
 			automatic_face_movement_dir_offset = readF1000(is);
 			backface_culling = readU8(is);
+			nametag = deSerializeString(is);
+			nametag_color = readARGB8(is);
 		}catch(SerializationError &e){}
 	}
 	else

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -48,6 +48,8 @@ struct ObjectProperties
 	bool automatic_face_movement_dir;
 	f32 automatic_face_movement_dir_offset;
 	bool backface_culling;
+	std::string nametag;
+	video::SColor nametag_color;
 
 
 	ObjectProperties();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -201,6 +201,14 @@ void read_object_properties(lua_State *L, int index,
 	}
 	lua_pop(L, 1);
 	getboolfield(L, -1, "backface_culling", prop->backface_culling);
+	getstringfield(L, -1, "nametag", prop->nametag);
+	lua_getfield(L, -1, "nametag_color");
+	if (!lua_isnil(L, -1)) {
+		video::SColor color = prop->nametag_color;
+		if (read_color(L, -1, &color))
+			prop->nametag_color = color;
+	}
+	lua_pop(L, 1);
 }
 
 /******************************************************************************/
@@ -261,6 +269,11 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "automatic_face_movement_dir");
 	lua_pushboolean(L, prop->backface_culling);
 	lua_setfield(L, -2, "backface_culling");
+	lua_pushlstring(L, prop->nametag.c_str(), prop->nametag.size());
+	lua_setfield(L, -2, "nametag");
+	lua_newtable(L);
+	push_ARGB8(L, prop->nametag_color);
+	lua_setfield(L, -2, "nametag_color");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Default behavior: Only other playernames visible (like currently)