### PR TITLE
Dungeongen: Also preserve river water nodes

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -65,6 +65,9 @@ DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams)
 		dp.np_wetness = nparams_dungeon_wetness;
 		dp.np_density = nparams_dungeon_density;
 	}
+
+	// For mapgens using river water
+	dp.c_river_water = mg->ndef->getId("mapgen_river_water_source");
 }
 
 
@@ -87,7 +90,7 @@ void DungeonGen::generate(u32 bseed, v3s16 nmin, v3s16 nmax)
 			u32 i = vm->m_area.index(nmin.X, y, z);
 			for (s16 x = nmin.X; x <= nmax.X; x++) {
 				content_t c = vm->m_data[i].getContent();
-				if (c == CONTENT_AIR || c == dp.c_water)
+				if (c == CONTENT_AIR || c == dp.c_water || c == dp.c_river_water)
 					vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 				i++;
 			}

--- a/src/dungeongen.h
+++ b/src/dungeongen.h
@@ -40,6 +40,7 @@ int dir_to_facedir(v3s16 d);
 
 struct DungeonParams {
 	content_t c_water;
+	content_t c_river_water;
 	content_t c_cobble;
 	content_t c_moss;
 	content_t c_stair;


### PR DESCRIPTION
For future river mapgens
Dungeons will not generate in river water, to
avoid dungeons filling and blocking river channels

![screenshot_20151128_152703](https://cloud.githubusercontent.com/assets/3686677/11452571/900c665a-95e4-11e5-9c25-9f0dc90da114.png)

Dungeons make a mess of rivers. This commit adds river water as a node not to be touched by dungeon generation.