### PR TITLE
Fix Event implementation

### DIFF
--- a/src/threading/CMakeLists.txt
+++ b/src/threading/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(JTHREAD_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mutex.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/thread.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/semaphore.cpp


### PR DESCRIPTION
On non-windows platforms this was just a wrapper around a semaphore, which meant that multiple calls to signal() would result in wait() returning multiple times.