### PR TITLE
Mgv5/v7/flat/fractal: More large pseudorandom caves

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -148,8 +148,8 @@ MapgenFlatParams::MapgenFlatParams()
 
 	np_terrain      = NoiseParams(0, 1,   v3f(600, 600, 600), 7244,  5, 0.6, 2.0);
 	np_filler_depth = NoiseParams(0, 1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0);
-	np_cave1        = NoiseParams(0, 12,  v3f(128, 128, 128), 52534, 4, 0.5, 2.0);
-	np_cave2        = NoiseParams(0, 12,  v3f(128, 128, 128), 10325, 4, 0.5, 2.0);
+	np_cave1        = NoiseParams(0, 12,  v3f(96,  96,  96),  52534, 4, 0.5, 2.0);
+	np_cave2        = NoiseParams(0, 12,  v3f(96,  96,  96),  10325, 4, 0.5, 2.0);
 }
 
 
@@ -559,7 +559,7 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 			for (s16 x = node_min.X; x <= node_max.X; x++, vi++, index++) {
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
-				if (d1 * d2 > 0.4f) {
+				if (d1 * d2 > 0.3f) {
 					content_t c = vm->m_data[vi].getContent();
 					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
 						continue;
@@ -574,7 +574,7 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = (ps.range(1, 4) == 1) ? ps.range(1, 2) : 0;
+	u32 bruises_count = ps.range(0, 2);
 	for (u32 i = 0; i < bruises_count; i++) {
 		CaveV5 cave(this, &ps);
 		cave.makeCave(node_min, node_max, max_stone_y);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -154,8 +154,8 @@ MapgenFractalParams::MapgenFractalParams()
 
 	np_seabed       = NoiseParams(-14, 9,   v3f(600, 600, 600), 41900, 5, 0.6, 2.0);
 	np_filler_depth = NoiseParams(0,   1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0);
-	np_cave1        = NoiseParams(0,   12,  v3f(128, 128, 128), 52534, 4, 0.5, 2.0);
-	np_cave2        = NoiseParams(0,   12,  v3f(128, 128, 128), 10325, 4, 0.5, 2.0);
+	np_cave1        = NoiseParams(0,   12,  v3f(96,  96,  96),  52534, 4, 0.5, 2.0);
+	np_cave2        = NoiseParams(0,   12,  v3f(96,  96,  96),  10325, 4, 0.5, 2.0);
 }
 
 
@@ -624,7 +624,7 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 			for (s16 x = node_min.X; x <= node_max.X; x++, vi++, index++) {
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
-				if (d1 * d2 > 0.4f) {
+				if (d1 * d2 > 0.3f) {
 					content_t c = vm->m_data[vi].getContent();
 					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
 						continue;
@@ -639,7 +639,7 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = (ps.range(1, 4) == 1) ? ps.range(1, 2) : 0;
+	u32 bruises_count = ps.range(0, 2);
 	for (u32 i = 0; i < bruises_count; i++) {
 		CaveV5 cave(this, &ps);
 		cave.makeCave(node_min, node_max, max_stone_y);

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -518,7 +518,7 @@ void MapgenV5::generateCaves(int max_stone_y)
 			for (s16 x = node_min.X; x <= node_max.X; x++, i++, index++) {
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
-				if (d1*d2 > 0.125) {
+				if (d1 * d2 > 0.125f) {
 					content_t c = vm->m_data[i].getContent();
 					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
 						continue;
@@ -533,7 +533,7 @@ void MapgenV5::generateCaves(int max_stone_y)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = (ps.range(1, 4) == 1) ? ps.range(1, 2) : 0;
+	u32 bruises_count = ps.range(0, 2);
 	for (u32 i = 0; i < bruises_count; i++) {
 		CaveV5 cave(this, &ps);
 		cave.makeCave(node_min, node_max, max_stone_y);

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -157,8 +157,8 @@ MapgenV7Params::MapgenV7Params()
 	np_ridge_uwater    = NoiseParams(0,    1,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0);
 	np_mountain        = NoiseParams(-0.6, 1,   v3f(250,  350,  250),  5333,  5, 0.63, 2.0);
 	np_ridge           = NoiseParams(0,    1,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0);
-	np_cave1           = NoiseParams(0,    12,  v3f(100,  100,  100),  52534, 4, 0.5,  2.0);
-	np_cave2           = NoiseParams(0,    12,  v3f(100,  100,  100),  10325, 4, 0.5,  2.0);
+	np_cave1           = NoiseParams(0,    12,  v3f(96,   96,   96),   52534, 4, 0.5,  2.0);
+	np_cave2           = NoiseParams(0,    12,  v3f(96,   96,   96),   10325, 4, 0.5,  2.0);
 }
 
 
@@ -870,7 +870,7 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 			for (s16 x = node_min.X; x <= node_max.X; x++, i++, index++) {
 				float d1 = contour(noise_cave1->result[index]);
 				float d2 = contour(noise_cave2->result[index]);
-				if (d1 * d2 > 0.3) {
+				if (d1 * d2 > 0.3f) {
 					content_t c = vm->m_data[i].getContent();
 					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
 						continue;
@@ -882,7 +882,7 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 	}
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = (ps.range(1, 4) == 1) ? ps.range(1, 2) : 0;
+	u32 bruises_count = ps.range(0, 2);
 	for (u32 i = 0; i < bruises_count; i++) {
 		CaveV7 cave(this, &ps);
 		cave.makeCave(node_min, node_max, max_stone_y);


### PR DESCRIPTION
Mgv7/flat/fractal: Reduce tunnel noise spreads to 96

![screenshot_20151201_013835](https://cloud.githubusercontent.com/assets/3686677/11490027/bd92b248-97cc-11e5-882a-7ac38bad35a8.png)

^ Mgv7 looking much better, more intersections of tunnels and large caves.

After discussion and feedback the number of large pseudorandom caves is increased to mgv6 type density. In mgv7/flat/fractal tunnel density is increased by reducing noise spreads to 96.