### PR TITLE
Mapgen: Add propagate_shadow bool to calcLighting

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2996,7 +2996,7 @@ will place the schematic inside of the VoxelManip.
 * `update_map()`: Update map after writing chunk back to map.
     * To be used only by `VoxelManip` objects created by the mod itself;
       not a `VoxelManip` that was retrieved from `minetest.get_mapgen_object`
-* `set_lighting(light, p1, p2)`: Set the lighting within the `VoxelManip` to a uniform value
+* `set_lighting(light, [p1, p2])`: Set the lighting within the `VoxelManip` to a uniform value
     * `light` is a table, `{day=<0...15>, night=<0...15>}`
     * To be used only by a `VoxelManip` object from `minetest.get_mapgen_object`
     * (`p1`, `p2`) is the area in which lighting is set;
@@ -3010,10 +3010,12 @@ will place the schematic inside of the VoxelManip.
     * expects lighting data in the same format that `get_light_data()` returns
 * `get_param2_data()`: Gets the raw `param2` data read into the `VoxelManip` object
 * `set_param2_data(param2_data)`: Sets the `param2` contents of each node in the `VoxelManip`
-* `calc_lighting(p1, p2)`:  Calculate lighting within the `VoxelManip`
+* `calc_lighting([p1, p2], [propagate_shadow])`:  Calculate lighting within the `VoxelManip`
     * To be used only by a `VoxelManip` object from `minetest.get_mapgen_object`
     * (`p1`, `p2`) is the area in which lighting is set; defaults to the whole area
-      if left out
+      if left out or nil
+    * `propagate_shadow` is an optional boolean deciding whether shadows in a generated
+      mapchunk above are propagated down into the mapchunk; defaults to `true` if left out
 * `update_liquids()`: Update liquid flow
 * `was_modified()`: Returns `true` or `false` if the data in the voxel manipulator
   had been modified since the last read from map, due to a call to

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -264,37 +264,20 @@ void Mapgen::lightSpread(VoxelArea &a, v3s16 p, u8 light)
 }
 
 
-void Mapgen::calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax)
+void Mapgen::calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
+	bool propagate_shadow)
 {
 	ScopeProfiler sp(g_profiler, "EmergeThread: mapgen lighting update", SPT_AVG);
 	//TimeTaker t("updateLighting");
 
-	propagateSunlight(nmin, nmax);
+	propagateSunlight(nmin, nmax, propagate_shadow);
 	spreadLight(full_nmin, full_nmax);
 
 	//printf("updateLighting: %dms\n", t.stop());
 }
 
 
-
-void Mapgen::calcLighting(v3s16 nmin, v3s16 nmax)
-{
-	ScopeProfiler sp(g_profiler, "EmergeThread: mapgen lighting update", SPT_AVG);
-	//TimeTaker t("updateLighting");
-
-	propagateSunlight(
-		nmin - v3s16(1, 1, 1) * MAP_BLOCKSIZE,
-		nmax + v3s16(1, 0, 1) * MAP_BLOCKSIZE);
-
-	spreadLight(
-		nmin - v3s16(1, 1, 1) * MAP_BLOCKSIZE,
-		nmax + v3s16(1, 1, 1) * MAP_BLOCKSIZE);
-
-	//printf("updateLighting: %dms\n", t.stop());
-}
-
-
-void Mapgen::propagateSunlight(v3s16 nmin, v3s16 nmax)
+void Mapgen::propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow)
 {
 	//TimeTaker t("propagateSunlight");
 	VoxelArea a(nmin, nmax);
@@ -308,7 +291,8 @@ void Mapgen::propagateSunlight(v3s16 nmin, v3s16 nmax)
 			if (vm->m_data[i].getContent() == CONTENT_IGNORE) {
 				if (block_is_underground)
 					continue;
-			} else if ((vm->m_data[i].param1 & 0x0F) != LIGHT_SUN) {
+			} else if ((vm->m_data[i].param1 & 0x0F) != LIGHT_SUN &&
+					propagate_shadow) {
 				continue;
 			}
 			vm->m_area.add_y(em, i, -1);
@@ -324,7 +308,6 @@ void Mapgen::propagateSunlight(v3s16 nmin, v3s16 nmax)
 	}
 	//printf("propagateSunlight: %dms\n", t.stop());
 }
-
 
 
 void Mapgen::spreadLight(v3s16 nmin, v3s16 nmax)

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -173,12 +173,9 @@ public:
 
 	void setLighting(u8 light, v3s16 nmin, v3s16 nmax);
 	void lightSpread(VoxelArea &a, v3s16 p, u8 light);
-
-	void calcLighting(v3s16 nmin, v3s16 nmax);
-	void calcLighting(v3s16 nmin, v3s16 nmax,
-		v3s16 full_nmin, v3s16 full_nmax);
-
-	void propagateSunlight(v3s16 nmin, v3s16 nmax);
+	void calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
+		bool propagate_shadow = true);
+	void propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow);
 	void spreadLight(v3s16 nmin, v3s16 nmax);
 
 	virtual void makeChunk(BlockMakeData *data) {}

--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -38,12 +38,16 @@ MapgenSinglenode::MapgenSinglenode(int mapgenid,
 	c_node = ndef->getId("mapgen_singlenode");
 	if (c_node == CONTENT_IGNORE)
 		c_node = CONTENT_AIR;
+
+	MapNode n_node(c_node);
+	set_light = (ndef->get(n_node).sunlight_propagates) ? LIGHT_SUN : 0x00;
 }
 
 
 MapgenSinglenode::~MapgenSinglenode()
 {
 }
+
 
 //////////////////////// Map generator
 
@@ -53,11 +57,11 @@ void MapgenSinglenode::makeChunk(BlockMakeData *data)
 	assert(data->vmanip);
 	assert(data->nodedef);
 	assert(data->blockpos_requested.X >= data->blockpos_min.X &&
-		   data->blockpos_requested.Y >= data->blockpos_min.Y &&
-		   data->blockpos_requested.Z >= data->blockpos_min.Z);
+		data->blockpos_requested.Y >= data->blockpos_min.Y &&
+		data->blockpos_requested.Z >= data->blockpos_min.Z);
 	assert(data->blockpos_requested.X <= data->blockpos_max.X &&
-		   data->blockpos_requested.Y <= data->blockpos_max.Y &&
-		   data->blockpos_requested.Z <= data->blockpos_max.Z);
+		data->blockpos_requested.Y <= data->blockpos_max.Y &&
+		data->blockpos_requested.Z <= data->blockpos_max.Z);
 
 	this->generating = true;
 	this->vm   = data->vmanip;
@@ -67,8 +71,8 @@ void MapgenSinglenode::makeChunk(BlockMakeData *data)
 	v3s16 blockpos_max = data->blockpos_max;
 
 	// Area of central chunk
-	v3s16 node_min = blockpos_min*MAP_BLOCKSIZE;
-	v3s16 node_max = (blockpos_max+v3s16(1,1,1))*MAP_BLOCKSIZE-v3s16(1,1,1);
+	v3s16 node_min = blockpos_min * MAP_BLOCKSIZE;
+	v3s16 node_max = (blockpos_max + v3s16(1, 1, 1)) * MAP_BLOCKSIZE - v3s16(1, 1, 1);
 
 	blockseed = getBlockSeed2(node_min, data->seed);
 
@@ -87,15 +91,15 @@ void MapgenSinglenode::makeChunk(BlockMakeData *data)
 	// Add top and bottom side of water to transforming_liquid queue
 	updateLiquid(&data->transforming_liquid, node_min, node_max);
 
-	// Calculate lighting
-	if (flags & MG_LIGHT)
-		calcLighting(node_min, node_max);
+	// Set lighting
+	if ((flags & MG_LIGHT) && set_light == LIGHT_SUN)
+		setLighting(LIGHT_SUN, node_min, node_max);
 
 	this->generating = false;
 }
+
 
 int MapgenSinglenode::getGroundLevelAtPoint(v2s16 p)
 {
 	return 0;
 }
-

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -35,6 +35,7 @@ class MapgenSinglenode : public Mapgen {
 public:
 	u32 flags;
 	content_t c_node;
+	u8 set_light;
 
 	MapgenSinglenode(int mapgenid, MapgenParams *params, EmergeManager *emerge);
 	~MapgenSinglenode();

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -593,7 +593,9 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 
 	// Calculate lighting
 	if (flags & MG_LIGHT)
-		calcLighting(node_min, node_max);
+		calcLighting(node_min - v3s16(1, 1, 1) * MAP_BLOCKSIZE,
+			node_max + v3s16(1, 0, 1) * MAP_BLOCKSIZE,
+			full_node_min, full_node_max);
 
 	this->generating = false;
 }

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -181,6 +181,7 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 	v3s16 fpmax  = vm->m_area.MaxEdge;
 	v3s16 pmin   = lua_istable(L, 2) ? check_v3s16(L, 2) : fpmin + yblock;
 	v3s16 pmax   = lua_istable(L, 3) ? check_v3s16(L, 3) : fpmax - yblock;
+	bool propagate_shadow = lua_isboolean(L, 4) ? lua_toboolean(L, 4) : true;
 
 	sortBoxVerticies(pmin, pmax);
 	if (!vm->m_area.contains(VoxelArea(pmin, pmax)))
@@ -191,7 +192,7 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 	mg.ndef        = ndef;
 	mg.water_level = emerge->params.water_level;
 
-	mg.calcLighting(pmin, pmax, fpmin, fpmax);
+	mg.calcLighting(pmin, pmax, fpmin, fpmax, propagate_shadow);
 
 	return 0;
 }


### PR DESCRIPTION
"To terminate unwanted shadows from floatlands or realms above
Also add to LuaVoxelManip calc_lighting for use in mapgen mods
Remove the 2 argument calcLighting, mapgens now use the 5
argument form to specify the volumes for propagateSunlight and
spreadLight
In mgsinglenode replace calcLighting with setLighting and
clean-up use of tabs and spaces"

In use the bool is set to false at a certain y (preferably in empty space to avoid a visible shadow cutoff) below floatlands or an upper realm. The shadow cutoff is no different to when world is generated upwards causing mapchunks above to not cast shadow on mapchunks below.

This solution is very simple and much faster than any complex and problematic 'shadow decay' or 'shadow taper' solution, unlike those it is controllable to terminate shadows at the most convenient y (empty space).