### PR TITLE
Fix spelling of noise_threshold

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -763,7 +763,7 @@ Creates veins of ore varying in density by according to the intersection of two
 instances of 3d perlin noise with diffferent seeds, both described by
 `noise_params`.  `random_factor` varies the influence random chance has on
 placement of an ore inside the vein, which is `1` by default. Note that
-modifying this parameter may require adjusting `noise_threshhold`.
+modifying this parameter may require adjusting `noise_threshold`.
 The parameters `clust_scarcity`, `clust_num_ores`, and `clust_size` are ignored
 by this ore type.  This ore type is difficult to control since it is sensitive
 to small changes.  The following is a decent set of parameters to work from:
@@ -777,7 +777,7 @@ to small changes.  The following is a decent set of parameters to work from:
 	    persist = 0.5,
 	    flags = "eased",
 	},
-	noise_threshhold = 1.6
+	noise_threshold = 1.6
 
 WARNING:  Use this ore type *very* sparingly since it is ~200x more
 computationally expensive than any other ore.
@@ -3572,7 +3572,7 @@ Definition tables
         y_max = 64,
         flags = "",
     --  ^ Attributes for this ore generation
-        noise_threshhold = 0.5,
+        noise_threshold = 0.5,
     --  ^ If noise is above this threshold, ore is placed.  Not needed for a uniform distribution
         noise_params = {offset=0, scale=1, spread={x=100, y=100, z=100}, seed=23, octaves=3, persist=0.70}
     --  ^ NoiseParams structure describing the perlin noise used for ore distribution.

--- a/games/minimal/mods/default/mapgen.lua
+++ b/games/minimal/mods/default/mapgen.lua
@@ -36,7 +36,7 @@ minetest.register_ore({
 	clust_size       = 7,
 	y_min            = -15,
 	y_max            = 0,
-	noise_threshhold = 0,
+	noise_threshold = 0,
 	noise_params     = {
 		offset=0.35,
 		scale=0.2,

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -61,7 +61,7 @@ public:
 	s16 y_max;
 	u8 ore_param2;		// to set node-specific attributes
 	u32 flags;          // attributes for this ore
-	float nthresh;      // threshhold for noise at which an ore is placed
+	float nthresh;      // threshold for noise at which an ore is placed
 	NoiseParams np;     // noise for distribution of clusters (NULL for uniform scattering)
 	Noise *noise;
 	std::set<u8> biomes;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -99,17 +99,17 @@ u32 PcgRandom::range(u32 bound)
 	Using rand() % 3, the number 0 would be twice as likely to appear.
 	With a very large RNG range, the effect becomes less prevalent but
 	still present.  This can be solved by modifying the range of the RNG
-	to become a multiple of bound by dropping values above the a threshhold.
-	In our example, threshhold == 4 - 3 = 1 % 3 == 1, so reject 0, thus
+	to become a multiple of bound by dropping values above the a threshold.
+	In our example, threshold == 4 - 3 = 1 % 3 == 1, so reject 0, thus
 	making the range 3 with no bias.
 
 	This loop looks dangerous, but will always terminate due to the
 	RNG's property of uniformity.
 	*/
-	u32 threshhold = -bound % bound;
+	u32 threshold = -bound % bound;
 	u32 r;
 
-	while ((r = next()) < threshhold)
+	while ((r = next()) < threshold)
 		;
 
 	return r % bound;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -944,9 +944,18 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->clust_scarcity = getintfield_default(L, index, "clust_scarcity", 1);
 	ore->clust_num_ores = getintfield_default(L, index, "clust_num_ores", 1);
 	ore->clust_size     = getintfield_default(L, index, "clust_size", 0);
-	ore->nthresh        = getfloatfield_default(L, index, "noise_threshhold", 0);
 	ore->noise          = NULL;
 	ore->flags          = 0;
+
+	//// Get noise_threshold
+	warn_if_field_exists(L, index, "noise_threshhold",
+		"Deprecated: new name is \"noise_threshold\".");
+
+	int nthresh;
+	if (!getintfield(L, index, "noise_threshold", nthresh) &&
+		!getintfield(L, index, "noise_threshhold", nthresh))
+		nthresh = 0;
+	ore->nthresh = nthresh;
 
 	//// Get y_min/y_max
 	warn_if_field_exists(L, index, "height_min",


### PR DESCRIPTION
Deprecate `noise_threshhold`.
Addressing this issue https://github.com/minetest/minetest/issues/3321 .