### PR TITLE
Fix plantlike mesh size to be horizontally filling a node.

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1120,10 +1120,10 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			{
 				video::S3DVertex vertices[4] =
 				{
-					video::S3DVertex(-s,-BS/2, 0, 0,0,0, c, 0,1),
-					video::S3DVertex( s,-BS/2, 0, 0,0,0, c, 1,1),
-					video::S3DVertex( s,-BS/2 + s*2,0, 0,0,0, c, 1,0),
-					video::S3DVertex(-s,-BS/2 + s*2,0, 0,0,0, c, 0,0),
+					video::S3DVertex(-s*1.4,-BS/2, 0, 0,0,0, c, 0,1),
+					video::S3DVertex( s*1.4,-BS/2, 0, 0,0,0, c, 1,1),
+					video::S3DVertex( s*1.4,-BS/2 + s*2,0, 0,0,0, c, 1,0),
+					video::S3DVertex(-s*1.4,-BS/2 + s*2,0, 0,0,0, c, 0,0),
 				};
 				float rotate_degree = 0;
 				if (f.param_type_2 == CPT2_DEGROTATE)


### PR DESCRIPTION
fixes #1589: plantlike meshes are only 70% of a node size.

Subsequently, all plantlike textures are stretched by 40% horizontally. Without texture adjustment, this is actually still acceptable, but I intend to submit new textures to minetest_game to repaint all the plantlike textures to the new size. Some will just have extra empty pixels added on the side, but some will get some artwork done to make them look better while retaining the current style.