### PR TITLE
Allow client to randomize x,z placement of plantlike nodes.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -592,6 +592,7 @@ core.nodedef_default = {
 	selection_box = {type="regular"},
 	legacy_facedir_simple = false,
 	legacy_wallmounted = false,
+	random_xz = false,
 }
 
 core.craftitemdef_default = {

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3380,6 +3380,7 @@ Definition tables
         paramtype2 = "none", -- See "Nodes"
         is_ground_content = true, -- If false, the cave generator will not carve through this
         sunlight_propagates = false, -- If true, sunlight will go infinitely through this
+        random_xz = false, -- If true, plantlike objects will be planted with a slight random x/z offset
         walkable = true, -- If true, objects collide with node
         pointable = true, -- If true, can be pointed at
         diggable = true, -- If false, can never be dug

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IMeshManipulator.h>
 #include "gamedef.h"
 #include "log.h"
+#include "noise.h"
 
 
 // Create a cuboid.
@@ -1108,6 +1109,9 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 		break;}
 		case NDT_PLANTLIKE:
 		{
+			float random_offset_X = 0, random_offset_Z = 0;
+			PseudoRandom rng(x<<8 | z);
+
 			TileSpec tile = getNodeTileN(n, p, 0, data);
 			tile.material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 
@@ -1115,6 +1119,11 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			video::SColor c = MapBlock_LightColor(255, l, f.light_source);
 
 			float s = BS / 2 * f.visual_scale;
+
+			if (f.random_xz) {
+				random_offset_X = BS * ((rng.next() % 16 / 16.0) * 0.29 - 0.145);
+				random_offset_Z = BS * ((rng.next() % 16 / 16.0) * 0.29 - 0.145);
+			}
 
 			for (int j = 0; j < 2; j++)
 			{
@@ -1142,6 +1151,11 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 					vertices[i].Pos *= f.visual_scale;
 					vertices[i].Pos.Y += BS/2 * (f.visual_scale - 1);
 					vertices[i].Pos += intToFloat(p, BS);
+					// move to a random spot to avoid moire
+					if (f.random_xz) {
+						vertices[i].Pos.X += random_offset_X;
+						vertices[i].Pos.Z += random_offset_Z;
+					}
 				}
 
 				u16 indices[] = {0, 1, 2, 2, 3, 0};

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -248,6 +248,7 @@ void ContentFeatures::reset()
 	selection_box = NodeBox();
 	collision_box = NodeBox();
 	waving = 0;
+	random_xz = false;
 	legacy_facedir_simple = false;
 	legacy_wallmounted = false;
 	sound_footstep = SimpleSoundSpec();
@@ -318,6 +319,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	// the protocol version
 	os<<serializeString(mesh);
 	collision_box.serialize(os, protocol_version);
+	writeU8(os, random_xz);
 }
 
 void ContentFeatures::deSerialize(std::istream &is)
@@ -388,6 +390,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 		// otherwise changes the protocol version
 	mesh = deSerializeString(is);
 	collision_box.deSerialize(is);
+	random_xz = readU8(is);
 	}catch(SerializationError &e) {};
 }
 
@@ -1257,6 +1260,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 		writeU8(os, drowning);
 		writeU8(os, leveled);
 		writeU8(os, liquid_range);
+		writeU8(os, random_xz);
 	} else
 		throw SerializationError("ContentFeatures::serialize(): "
 			"Unsupported version requested");
@@ -1368,6 +1372,7 @@ void ContentFeatures::deSerializeOld(std::istream &is, int version)
 		drowning = readU8(is);
 		leveled = readU8(is);
 		liquid_range = readU8(is);
+		random_xz = readU8(is);
 	} else {
 		throw SerializationError("unsupported ContentFeatures version");
 	}

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -256,6 +256,8 @@ struct ContentFeatures
 	NodeBox collision_box;
 	// Used for waving leaves/plants
 	u8 waving;
+	// for wild plants - offset random x,z
+	bool random_xz;
 	// Compatibility with old maps
 	// Set to true if paramtype used to be 'facedir_simple'
 	bool legacy_facedir_simple;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -348,6 +348,8 @@ ContentFeatures read_content_features(lua_State *L, int index)
 			ScriptApiNode::es_DrawType,NDT_NORMAL);
 	getfloatfield(L, index, "visual_scale", f.visual_scale);
 
+	getboolfield(L, index, "random_xz", f.random_xz);
+
 	/* Meshnode model filename */
 	getstringfield(L, index, "mesh", f.mesh);
 


### PR DESCRIPTION
Different approach to visually awkward grass plains: Slightly randomize x,z placement by +/- 0.2 for nodes defined with the "random_xz" boolean set. Only applies to plantlike.

Addresses #1589 - monotonous grass plains.

Backwards compatible with older clients. Protocol version bumped but optional and tested.

I needed a simple and fast psrng, and though perlin noise would likely be too heavy. The psrng used is 8bit and is reseeded for every block, so the random offsets never change.
