### PR TITLE
Display custom metedata description instead of node name in tooltip.

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2237,8 +2237,13 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
 
 			// Draw tooltip
 			std::string tooltip_text = "";
-			if (hovering && !m_selected_item)
-				tooltip_text = item.getDefinition(m_gamedef->idef()).description;
+			if (hovering && !m_selected_item) {
+				std::string d = item.getMetadataDescription();
+				if (!d.empty())
+					tooltip_text = d;
+				else
+					tooltip_text = item.getDefinition(m_gamedef->idef()).description;
+			}
 			if (tooltip_text != "") {
 				std::vector<std::string> tt_rows = str_split(tooltip_text, '\n');
 				m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -311,6 +311,26 @@ void ItemStack::deSerialize(const std::string &str, IItemDefManager *itemdef)
 	deSerialize(is, itemdef);
 }
 
+std::string ItemStack::getMetadataDescription()
+{
+	std::string d("");
+	std::string m(metadata);
+	size_t p1;
+
+	if (m.empty())
+		return d;
+
+	if (m.substr(0,8).compare("return {") == 0) {
+		m = m.substr(8, m.length() - 9);
+		p1 = m.find("[\"description\"] = \"");
+		if (p1 != std::string::npos) {
+			size_t p2 = m.find("\"", p1 + 20);
+			return m.substr(p1 + 21, p2 - p1 - 21);
+		}
+	}
+	return d;
+}
+
 std::string ItemStack::getItemString() const
 {
 	std::ostringstream os(std::ios::binary);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -44,6 +44,9 @@ struct ItemStack
 	void deSerialize(std::istream &is, IItemDefManager *itemdef = NULL);
 	void deSerialize(const std::string &s, IItemDefManager *itemdef = NULL);
 
+	// Parse metadata to retrieve a custom description
+	std::string getMetadataDescription();
+
 	// Returns the string used for inventory
 	std::string getItemString() const;
 


### PR DESCRIPTION
Allows items that have a max_stacks = 1 to be "named". I intend to make a "name tag" module implementing arbitrary item naming. And for the purpose of this patch I've used my "key" mod to show that multiple items with the same craftitem name can have different descriptions showing in the tooltip. The screenshots show that the 3 keys have a description that's set by the key mod.

![key 1](http://i.imgur.com/rCvtJBb.png)
![key 2](http://i.imgur.com/Zaeo7OM.png)
![key 3](http://i.imgur.com/gMZRff0.png)
- [ ] - Create new meta data storage unit, and API to use from Lua, similar to how node metadata is done (`ItemStack:get_meta()`)
- [ ] - figure out how to store the new meta storage in player inventories when they go offline
- [ ] - Design an API that allows for predefined uses
- [ ] - Documentation, lua_api.txt, etc.
