### PR TITLE
ability to add text to ItemStack inventory tooltip

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2240,6 +2240,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
 			if (hovering && !m_selected_item)
 				tooltip_text = item.getDefinition(m_gamedef->idef()).description;
 			if (tooltip_text != "") {
+
+				if (item.metadata.substr(0,7) == "tooltip") 
+					tooltip_text += item.metadata.substr(7);
+
 				std::vector<std::string> tt_rows = str_split(tooltip_text, '\n');
 				m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
 				m_tooltip_element->setOverrideColor(m_default_tooltip_color);


### PR DESCRIPTION
With this you can set an ItemStack metadata to "tooltip 50" and it will add the '50' to the inventory tooltip.
In my case I needed a way to display the luck value of a lucky block. With this the inventory tooltip can now say "Lucky Block 50", or whatever you set the metadata to.
If there is a better way to do this please let me know.