### PR TITLE
Mgfractal: Add 3D and 4D fractals

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -970,49 +970,60 @@ mgflat_np_cave2 (Mapgen flat cave2 noise parameters) noise_params 0, 12, (128, 1
 
 [***Mapgen fractal]
 
-#    Choice of 8 4-dimensional fractals.
-#    1 = "Roundy" mandelbrot set.
-#    2 = "Roundy" julia set.
-#    3 = "Squarry" mandelbrot set.
-#    4 = "Squarry" julia set.
-#    5 = "Mandy Cousin" mandelbrot set.
-#    6 = "Mandy Cousin" julia set.
-#    7 = "Variation" mandelbrot set.
-#    8 = "Variation" julia set.
-mgfractal_formula (Mapgen fractal formula) int 1 1 8
+#    Choice of 18 fractals from 9 formulas.
+#    1 = 4D "Roundy" mandelbrot set.
+#    2 = 4D "Roundy" julia set.
+#    3 = 4D "Squarry" mandelbrot set.
+#    4 = 4D "Squarry" julia set.
+#    5 = 4D "Mandy Cousin" mandelbrot set.
+#    6 = 4D "Mandy Cousin" julia set.
+#    7 = 4D "Variation" mandelbrot set.
+#    8 = 4D "Variation" julia set.
+#    9 = 3D "Mandelbrot/Mandelbar" mandelbrot set.
+#    10 = 3D "Mandelbrot/Mandelbar" julia set.
+#    11 = 3D "Christmas Tree" mandelbrot set.
+#    12 = 3D "Christmas Tree" julia set.
+#    13 = 3D "Mandelbulb" mandelbrot set.
+#    14 = 3D "Mandelbulb" julia set.
+#    15 = 3D "Cosine Mandelbulb" mandelbrot set.
+#    16 = 3D "Cosine Mandelbulb" julia set.
+#    17 = 4D "Mandelbulb" mandelbrot set.
+#    18 = 4D "Mandelbulb" julia set.
+mgfractal_fractal (Mapgen fractal fractal) int 1 1 18
 
 #    Iterations of the recursive function.
-#    Controls scale of finest detail.
+#    Controls the amount of fine detail.
 mgfractal_iterations (Mapgen fractal iterations) int 11
 
 #    Approximate (X,Y,Z) scale of fractal in nodes.
 mgfractal_scale (Mapgen fractal scale) v3f (4096.0, 1024.0, 4096.0)
 
-#    (X,Y,Z) offset of fractal from world centre.
+#    (X,Y,Z) offset of fractal from world centre in units of 'scale'.
 #    Used to move a suitable spawn area of low land close to (0, 0).
-#    The default is suitable for mandelbrot sets, it needs to be edited for julia sets,
-#    do this by greatly reducing 'scale' and setting 'offset' initially to (0, 0, 0).
+#    The default is suitable for mandelbrot sets, it needs to be edited for julia sets.
 #    Range roughly -2 to 2. Multiply by 'scale' for offset in nodes.
 mgfractal_offset (Mapgen fractal offset) v3f (1.79, 0.0, 0.0)
 
-#    W co-ordinate of the generated 3D slice of the 4D shape.
-#    Alters the generated 3D shape.
+#    W co-ordinate of the generated 3D slice of a 4D fractal.
+#    Determines which 3D slice of the 4D shape is generated.
+#    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
 mgfractal_slice_w (Mapgen fractal slice w) float 0.0
 
-#    Julia set only: X value determining the 4D shape.
+#    Julia set only: X component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 mgfractal_julia_x (Mapgen fractal julia x) float 0.33
 
-#    Julia set only: Y value determining the 4D shape.
+#    Julia set only: Y component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 mgfractal_julia_y (Mapgen fractal julia y) float 0.33
 
-#    Julia set only: Z value determining the 4D shape.
+#    Julia set only: Z component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 mgfractal_julia_z (Mapgen fractal julia z) float 0.33
 
-#    Julia set only: W value determining the 4D shape.
+#    Julia set only: W component of hypercomplex constant determining julia shape.
+#    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
 mgfractal_julia_w (Mapgen fractal julia w) float 0.33
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1234,20 +1234,30 @@
 
 #### Mapgen fractal
 
-#    Choice of 8 4-dimensional fractals.
-#    1 = "Roundy" mandelbrot set.
-#    2 = "Roundy" julia set.
-#    3 = "Squarry" mandelbrot set.
-#    4 = "Squarry" julia set.
-#    5 = "Mandy Cousin" mandelbrot set.
-#    6 = "Mandy Cousin" julia set.
-#    7 = "Variation" mandelbrot set.
-#    8 = "Variation" julia set.
-#    type: int min: 1 max: 8
-# mgfractal_formula = 1
+#    Choice of 18 fractals from 9 formulas.
+#    1 = 4D "Roundy" mandelbrot set.
+#    2 = 4D "Roundy" julia set.
+#    3 = 4D "Squarry" mandelbrot set.
+#    4 = 4D "Squarry" julia set.
+#    5 = 4D "Mandy Cousin" mandelbrot set.
+#    6 = 4D "Mandy Cousin" julia set.
+#    7 = 4D "Variation" mandelbrot set.
+#    8 = 4D "Variation" julia set.
+#    9 = 3D "Mandelbrot/Mandelbar" mandelbrot set.
+#    10 = 3D "Mandelbrot/Mandelbar" julia set.
+#    11 = 3D "Christmas Tree" mandelbrot set.
+#    12 = 3D "Christmas Tree" julia set.
+#    13 = 3D "Mandelbulb" mandelbrot set.
+#    14 = 3D "Mandelbulb" julia set.
+#    15 = 3D "Cosine Mandelbulb" mandelbrot set.
+#    16 = 3D "Cosine Mandelbulb" julia set.
+#    17 = 4D "Mandelbulb" mandelbrot set.
+#    18 = 4D "Mandelbulb" julia set.
+#    type: int min: 1 max: 18
+# mgfractal_fractal = 1
 
 #    Iterations of the recursive function.
-#    Controls scale of finest detail.
+#    Controls the amount of fine detail.
 #    type: int
 # mgfractal_iterations = 11
 
@@ -1255,36 +1265,37 @@
 #    type: v3f
 # mgfractal_scale = (4096.0, 1024.0, 4096.0)
 
-#    (X,Y,Z) offset of fractal from world centre.
+#    (X,Y,Z) offset of fractal from world centre in units of 'scale'.
 #    Used to move a suitable spawn area of low land close to (0, 0).
-#    The default is suitable for mandelbrot sets, it needs to be edited for julia sets,
-#    do this by greatly reducing 'scale' and setting 'offset' initially to (0, 0, 0).
+#    The default is suitable for mandelbrot sets, it needs to be edited for julia sets.
 #    Range roughly -2 to 2. Multiply by 'scale' for offset in nodes.
 #    type: v3f
 # mgfractal_offset = (1.79, 0.0, 0.0)
 
-#    W co-ordinate of the generated 3D slice of the 4D shape.
-#    Alters the generated 3D shape.
+#    W co-ordinate of the generated 3D slice of a 4D fractal.
+#    Determines which 3D slice of the 4D shape is generated.
+#    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
 #    type: float
 # mgfractal_slice_w = 0.0
 
-#    Julia set only: X value determining the 4D shape.
+#    Julia set only: X component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 #    type: float
 # mgfractal_julia_x = 0.33
 
-#    Julia set only: Y value determining the 4D shape.
+#    Julia set only: Y component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 #    type: float
 # mgfractal_julia_y = 0.33
 
-#    Julia set only: Z value determining the 4D shape.
+#    Julia set only: Z component of hypercomplex constant determining julia shape.
 #    Range roughly -2 to 2.
 #    type: float
 # mgfractal_julia_z = 0.33
 
-#    Julia set only: W value determining the 4D shape.
+#    Julia set only: W component of hypercomplex constant determining julia shape.
+#    Has no effect on 3D fractals.
 #    Range roughly -2 to 2.
 #    type: float
 # mgfractal_julia_w = 0.33

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -3,6 +3,9 @@ Minetest
 Copyright (C) 2010-2015 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 Copyright (C) 2010-2015 paramat, Matt Gregory
 
+Fractal formulas from http://www.bugman123.com/Hypercomplex/index.html
+by Paul Nylander, and from http://www.fractalforums.com, thank you.
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation; either version 2.1 of the License, or
@@ -33,7 +36,7 @@ extern FlagDesc flagdesc_mapgen_fractal[];
 struct MapgenFractalParams : public MapgenSpecificParams {
 	u32 spflags;
 
-	u16 formula;
+	u16 fractal;
 	u16 iterations;
 	v3f scale;
 	v3f offset;
@@ -63,14 +66,17 @@ public:
 
 	int ystride;
 	int zstride;
-	u32 spflags;
+	u16 formula;
+	bool julia;
 
 	v3s16 node_min;
 	v3s16 node_max;
 	v3s16 full_node_min;
 	v3s16 full_node_max;
 
-	u16 formula;
+	u32 spflags;
+
+	u16 fractal;
 	u16 iterations;
 	v3f scale;
 	v3f offset;


### PR DESCRIPTION
"3D Mandelbrot/Mandelbar
3D Christmas Tree
3D Mandelbulb
3D Cosine Mandelbulb
4D Mandelbulb
Plus corresponding julia set for each
Add credits for formulas
Rename parameter 'formula' to 'fractal'
Speed optimisations"

![screenshot_20150419_065248](https://cloud.githubusercontent.com/assets/3686677/11769581/bf68729a-a1e2-11e5-872b-d9b64c0ad1ba.png)

![screenshot_20151212_211651](https://cloud.githubusercontent.com/assets/3686677/11769567/57a8f2d8-a1e2-11e5-807c-6b3f9cd349e9.png)

Add 5 more variations of mandelbrot sets, each with a corresponding julia set.
Formulas from http://www.bugman123.com/Hypercomplex/index.html and http://www.fractalforums.com/index.php these are now mentioned in credits.
Parameter 'formula' was incorrectly named, there are 9 formulas and 18 fractals.
From parameter 'fractal', variables 'formula' and 'julia' are calculated in ctor to speed up the iteration loop.