### PR TITLE
Add support for limiting rotation of automatic face movement dir entities

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1260,8 +1260,18 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 	if (getParent() == NULL && m_prop.automatic_face_movement_dir &&
 			(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001))
 	{
-		m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI
+		float optimal_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
+		float max_rotation_delta =
+				dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
+
+		if ((m_prop.automatic_face_movement_max_rotation_per_sec > 0) &&
+			(fabs(m_yaw - optimal_yaw) > max_rotation_delta)) {
+
+			m_yaw = optimal_yaw < m_yaw ? m_yaw - max_rotation_delta : m_yaw + max_rotation_delta;
+		} else {
+			m_yaw = optimal_yaw;
+		}
 		updateNodePos();
 	}
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -283,8 +283,20 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		}
 
 		if((m_prop.automatic_face_movement_dir) &&
-				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)){
-			m_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI + m_prop.automatic_face_movement_dir_offset;
+				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001))
+		{
+			float optimal_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI
+					+ m_prop.automatic_face_movement_dir_offset;
+			float max_rotation_delta =
+					dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
+
+			if ((m_prop.automatic_face_movement_max_rotation_per_sec > 0) &&
+				(fabs(m_yaw - optimal_yaw) > max_rotation_delta)) {
+
+				m_yaw = optimal_yaw < m_yaw ? m_yaw - max_rotation_delta : m_yaw + max_rotation_delta;
+			} else {
+				m_yaw = optimal_yaw;
+			}
 		}
 	}
 

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -45,7 +45,8 @@ ObjectProperties::ObjectProperties():
 	automatic_face_movement_dir_offset(0.0),
 	backface_culling(true),
 	nametag(""),
-	nametag_color(255, 255, 255, 255)
+	nametag_color(255, 255, 255, 255),
+	automatic_face_movement_max_rotation_per_sec(-1)
 {
 	textures.push_back("unknown_object.png");
 	colors.push_back(video::SColor(255,255,255,255));
@@ -116,6 +117,8 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, backface_culling);
 	os << serializeString(nametag);
 	writeARGB8(os, nametag_color);
+	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
+
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -155,6 +158,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 			backface_culling = readU8(is);
 			nametag = deSerializeString(is);
 			nametag_color = readARGB8(is);
+			automatic_face_movement_max_rotation_per_sec = readF1000(is);
 		}catch(SerializationError &e){}
 	}
 	else

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -50,7 +50,7 @@ struct ObjectProperties
 	bool backface_culling;
 	std::string nametag;
 	video::SColor nametag_color;
-
+	f32 automatic_face_movement_max_rotation_per_sec;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -201,12 +201,18 @@ void read_object_properties(lua_State *L, int index,
 	}
 	lua_pop(L, 1);
 	getboolfield(L, -1, "backface_culling", prop->backface_culling);
+
 	getstringfield(L, -1, "nametag", prop->nametag);
 	lua_getfield(L, -1, "nametag_color");
 	if (!lua_isnil(L, -1)) {
 		video::SColor color = prop->nametag_color;
 		if (read_color(L, -1, &color))
 			prop->nametag_color = color;
+	}
+
+	lua_getfield(L, -1, "automatic_face_movement_max_rotation_per_sec");
+	if (lua_isnumber(L, -1)) {
+		prop->automatic_face_movement_max_rotation_per_sec = luaL_checknumber(L, -1);
 	}
 	lua_pop(L, 1);
 }


### PR DESCRIPTION
There's already support for making entities look towards their movement direction. On drastic movement changes, e.g. stop to move somewhere this can cause quite ugly jumping of orientation.
This patch adds support for limiting the maximum rotation in degrees per second.
If you don't specify this value behaviour keeps as it is atm.