### PR TITLE
Fences

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1294,7 +1294,6 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 
 			const f32 post_rad=(f32)BS/8;
 			const f32 bar_rad=(f32)BS/16;
-			const f32 bar_len=(f32)(BS/2)-post_rad;
 
 			v3f pos = intToFloat(p, BS);
 
@@ -1318,17 +1317,43 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			const ContentFeatures *f2 = &nodedef->get(n2);
 			if(f2->drawtype == NDT_FENCELIKE)
 			{
-				aabb3f bar(-bar_len+BS/2,-bar_rad+BS/4,-bar_rad,
-						bar_len+BS/2,bar_rad+BS/4,bar_rad);
+				aabb3f bar(post_rad, -bar_rad+BS/4, -bar_rad,
+						BS/2, bar_rad+BS/4, bar_rad);
 				bar.MinEdge += pos;
 				bar.MaxEdge += pos;
 				f32 xrailuv[24]={
-					0/16.,2/16.,16/16.,4/16.,
-					0/16.,4/16.,16/16.,6/16.,
+					10/16.,0/16.,16/16.,2/16.,
+					10/16.,0/16.,16/16.,2/16.,
 					6/16.,6/16.,8/16.,8/16.,
 					10/16.,10/16.,12/16.,12/16.,
-					0/16.,8/16.,16/16.,10/16.,
-					0/16.,14/16.,16/16.,16/16.};
+					10/16.,2/16.,16/16.,4/16.,
+					10/16.,14/16.,16/16.,16/16.};
+				makeCuboid(&collector, bar, &tile_nocrack, 1,
+						c, xrailuv);
+				bar.MinEdge.Y -= BS/2;
+				bar.MaxEdge.Y -= BS/2;
+				makeCuboid(&collector, bar, &tile_nocrack, 1,
+						c, xrailuv);
+			}
+
+			// Now a section of fence, -X, if there's a post there
+			p2 = p;
+			p2.X--;
+			n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+			f2 = &nodedef->get(n2);
+			if(f2->drawtype == NDT_FENCELIKE)
+			{
+				aabb3f bar(-BS/2, -bar_rad+BS/4, -bar_rad,
+						-post_rad, bar_rad+BS/4, bar_rad);
+				bar.MinEdge += pos;
+				bar.MaxEdge += pos;
+				f32 xrailuv[24]={
+					8/16.,8/16.,14/16.,10/16.,
+					8/16.,12/16.,14/16.,14/16.,
+					14/16.,8/16.,16/16.,10/16.,
+					6/16.,8/16.,8/16.,10/16.,
+					8/16.,10/16.,14/16.,12/16.,
+					8/16.,14/16.,14/16.,16/16.};
 				makeCuboid(&collector, bar, &tile_nocrack, 1,
 						c, xrailuv);
 				bar.MinEdge.Y -= BS/2;
@@ -1344,8 +1369,33 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			f2 = &nodedef->get(n2);
 			if(f2->drawtype == NDT_FENCELIKE)
 			{
-				aabb3f bar(-bar_rad,-bar_rad+BS/4,-bar_len+BS/2,
-						bar_rad,bar_rad+BS/4,bar_len+BS/2);
+				aabb3f bar(-bar_rad,-bar_rad+BS/4,post_rad,
+						bar_rad,bar_rad+BS/4,BS/2);
+				bar.MinEdge += pos;
+				bar.MaxEdge += pos;
+				f32 zrailuv[24]={
+					3/16.,1/16.,5/16.,5/16., // cannot rotate; stretch
+					4/16.,1/16.,6/16.,5/16., // for wood texture instead
+					0/16.,9/16.,16/16.,11/16.,
+					0/16.,6/16.,16/16.,8/16.,
+					6/16.,6/16.,8/16.,8/16.,
+					10/16.,10/16.,12/16.,12/16.};
+				makeCuboid(&collector, bar, &tile_nocrack, 1,
+						c, zrailuv);
+				bar.MinEdge.Y -= BS/2;
+				bar.MaxEdge.Y -= BS/2;
+				makeCuboid(&collector, bar, &tile_nocrack, 1,
+						c, zrailuv);
+			}
+
+			p2 = p;
+			p2.Z--;
+			n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+			f2 = &nodedef->get(n2);
+			if(f2->drawtype == NDT_FENCELIKE)
+			{
+				aabb3f bar(-bar_rad,-bar_rad+BS/4,-BS/2,
+						bar_rad,bar_rad+BS/4,-post_rad);
 				bar.MinEdge += pos;
 				bar.MaxEdge += pos;
 				f32 zrailuv[24]={

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1315,7 +1315,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			p2.X++;
 			MapNode n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 			const ContentFeatures *f2 = &nodedef->get(n2);
-			if(f2->drawtype == NDT_FENCELIKE)
+			if(f2->drawtype == NDT_FENCELIKE || f2->drawtype == NDT_NORMAL)
 			{
 				aabb3f bar(post_rad, -bar_rad+BS/4, -bar_rad,
 						BS/2, bar_rad+BS/4, bar_rad);
@@ -1341,7 +1341,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			p2.X--;
 			n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 			f2 = &nodedef->get(n2);
-			if(f2->drawtype == NDT_FENCELIKE)
+			if(f2->drawtype == NDT_FENCELIKE || f2->drawtype == NDT_NORMAL)
 			{
 				aabb3f bar(-BS/2, -bar_rad+BS/4, -bar_rad,
 						-post_rad, bar_rad+BS/4, bar_rad);
@@ -1367,7 +1367,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			p2.Z++;
 			n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 			f2 = &nodedef->get(n2);
-			if(f2->drawtype == NDT_FENCELIKE)
+			if(f2->drawtype == NDT_FENCELIKE || f2->drawtype == NDT_NORMAL)
 			{
 				aabb3f bar(-bar_rad,-bar_rad+BS/4,post_rad,
 						bar_rad,bar_rad+BS/4,BS/2);
@@ -1392,7 +1392,7 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 			p2.Z--;
 			n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
 			f2 = &nodedef->get(n2);
-			if(f2->drawtype == NDT_FENCELIKE)
+			if(f2->drawtype == NDT_FENCELIKE || f2->drawtype == NDT_NORMAL)
 			{
 				aabb3f bar(-bar_rad,-bar_rad+BS/4,-BS/2,
 						bar_rad,bar_rad+BS/4,-post_rad);


### PR DESCRIPTION
2 patches, plan to maybe add more later:

1.  Draw fence bars on each side of the fence post, not just +x and +z
    
    To connect fences from different wood types, the game currently
    draws a bar from one pole to +x and a bar to +z, which has the
    effect that bars are always one color, while most people expect
    the color to split in the middle.
    
    This patch changes the bar into "halves" drawn in all 4 horizontal
    directions from fence posts out. This enables mixing of multiple
    fence posts to look a bit more natural, and will later on allow
    fence posts to connect "naturally" to other node types, like walls.
    
![image]
(http://i.imgur.com/1QYTVqE.png)
    
To get the screenshot you'll need to patch multiple fence materials from a minetest_game PR.
    
In a next patch, we'll allow fences to connect to normal nodes.


2. Connect fencelike drawtype to normal drawtype nodes
    
    Makes fencese pleasantly connect to normal (cube) nodes. This is
    expected behavior for most players and allows fences to connect
    to walls, dirt, rock etc - natural ingredients of a fenced in
    structure.

![image]    
(http://i.imgur.com/ctrEbB7.png)


Options:

- add option to disallow certain fence types from connecting to normal nodes (I'd rather not just yet)
- automatically connect to other nodes like mesh, glass block nodes, and other solid/cube type nodes that exist.