### PR TITLE
New 3D Mode: Pageflip

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -454,7 +454,8 @@ fall_bobbing_amount (Fall bobbing) float 0.0
 #    -    interlaced: odd/even line based polarisation screen support.
 #    -    topbottom: split screen top/bottom.
 #    -    sidebyside: split screen side by side.
-3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside
+#    -    pageflip: quadbuffer based 3d.
+3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,pageflip
 
 #    In-game chat console background color (R,G,B).
 console_color (Console color) string (0,0,0)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -518,7 +518,8 @@
 #    -    interlaced: odd/even line based polarisation screen support.
 #    -    topbottom: split screen top/bottom.
 #    -    sidebyside: split screen side by side.
-#    type: enum values: none, anaglyph, interlaced, topbottom, sidebyside
+#    -    pageflip: quadbuffer based 3d.
+#    type: enum values: none, anaglyph, interlaced, topbottom, sidebyside, pageflip
 # 3d_mode = none
 
 #    In-game chat console background color (R,G,B).

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -512,6 +512,9 @@ bool ClientLauncher::create_engine_device()
 	u16 bits = g_settings->getU16("fullscreen_bpp");
 	u16 fsaa = g_settings->getU16("fsaa");
 
+	// stereo buffer required for pageflip stereo
+	bool stereo_buffer = g_settings->get("3d_mode") == "pageflip";
+
 	// Determine driver
 	video::E_DRIVER_TYPE driverType = video::EDT_OPENGL;
 	std::string driverstring = g_settings->get("video_driver");
@@ -537,6 +540,7 @@ bool ClientLauncher::create_engine_device()
 	params.AntiAlias     = fsaa;
 	params.Fullscreen    = fullscreen;
 	params.Stencilbuffer = false;
+	params.Stereobuffer  = stereo_buffer;
 	params.Vsync         = vsync;
 	params.EventReceiver = receiver;
 	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -404,6 +404,87 @@ void draw_top_bottom_3d_mode(Camera& camera, bool show_hud,
 	camera.getCameraNode()->setTarget(oldTarget);
 }
 
+void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
+		Hud& hud, std::vector<aabb3f> hilightboxes, video::IVideoDriver* driver,
+		scene::ISceneManager* smgr, const v2u32& screensize,
+		bool draw_wield_tool, Client& client, gui::IGUIEnvironment* guienv,
+		video::SColor skycolor )
+{
+	/* preserve old setup*/
+	irr::core::vector3df oldPosition = camera.getCameraNode()->getPosition();
+	irr::core::vector3df oldTarget   = camera.getCameraNode()->getTarget();
+
+	irr::core::matrix4 startMatrix =
+			camera.getCameraNode()->getAbsoluteTransformation();
+	irr::core::vector3df focusPoint = (camera.getCameraNode()->getTarget()
+			- camera.getCameraNode()->getAbsolutePosition()).setLength(1)
+			+ camera.getCameraNode()->getAbsolutePosition();
+
+
+	//Left eye...
+	driver->setRenderTarget( irr::video::ERT_STEREO_LEFT_BUFFER);
+
+	irr::core::vector3df leftEye;
+	irr::core::matrix4 leftMove;
+	leftMove.setTranslation(
+			irr::core::vector3df(-g_settings->getFloat("3d_paralax_strength"),
+					0.0f, 0.0f));
+	leftEye = (startMatrix * leftMove).getTranslation();
+
+	//clear the depth buffer, and color
+	driver->beginScene( true, true, irr::video::SColor(200, 200, 200, 255));
+	camera.getCameraNode()->setPosition(leftEye);
+	camera.getCameraNode()->setTarget(focusPoint);
+	smgr->drawAll();
+	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
+
+	if (show_hud)
+	{
+		draw_selectionbox(driver, hud, hilightboxes, show_hud);
+
+		if (draw_wield_tool)
+			camera.drawWieldedTool(&leftMove);
+
+		hud.drawHotbar(client.getPlayerItem());
+		hud.drawLuaElements(camera.getOffset());
+	}
+
+	guienv->drawAll();
+
+	//Right eye...
+	driver->setRenderTarget( irr::video::ERT_STEREO_RIGHT_BUFFER);
+
+	irr::core::vector3df rightEye;
+	irr::core::matrix4 rightMove;
+	rightMove.setTranslation(
+			irr::core::vector3df(g_settings->getFloat("3d_paralax_strength"),
+					0.0f, 0.0f));
+	rightEye = (startMatrix * rightMove).getTranslation();
+
+	//clear the depth buffer, and color
+	driver->beginScene( true, true, irr::video::SColor(200, 200, 200, 255));
+	camera.getCameraNode()->setPosition(rightEye);
+	camera.getCameraNode()->setTarget(focusPoint);
+	smgr->drawAll();
+	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
+
+	if (show_hud)
+	{
+		draw_selectionbox(driver, hud, hilightboxes, show_hud);
+
+		if (draw_wield_tool)
+			camera.drawWieldedTool(&rightMove);
+
+		hud.drawHotbar(client.getPlayerItem());
+		hud.drawLuaElements(camera.getOffset());
+	}
+
+	guienv->drawAll();
+
+	camera.getCameraNode()->setPosition(oldPosition);
+	camera.getCameraNode()->setTarget(oldTarget);
+}
+
 void draw_plain(Camera& camera, bool show_hud, Hud& hud,
 		std::vector<aabb3f> hilightboxes, video::IVideoDriver* driver,
 		bool draw_wield_tool, Client& client, gui::IGUIEnvironment* guienv)
@@ -464,6 +545,13 @@ void draw_scene(video::IVideoDriver *driver, scene::ISceneManager *smgr,
 	{
 		draw_top_bottom_3d_mode(camera, show_hud, hud, hilightboxes, driver,
 				smgr, screensize, draw_wield_tool, client, guienv, skycolor);
+		show_hud = false;
+	}
+	else if (draw_mode == "pageflip")
+	{
+		draw_pageflip_3d_mode(camera, show_hud, hud, hilightboxes, driver,
+				smgr, screensize, draw_wield_tool, client, guienv, skycolor);
+		draw_crosshair = false;
 		show_hud = false;
 	}
 	else {

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -408,7 +408,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 		Hud& hud, std::vector<aabb3f> hilightboxes, video::IVideoDriver* driver,
 		scene::ISceneManager* smgr, const v2u32& screensize,
 		bool draw_wield_tool, Client& client, gui::IGUIEnvironment* guienv,
-		video::SColor skycolor )
+		video::SColor skycolor)
 {
 	/* preserve old setup*/
 	irr::core::vector3df oldPosition = camera.getCameraNode()->getPosition();
@@ -421,7 +421,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 			+ camera.getCameraNode()->getAbsolutePosition();
 
 	//Left eye...
-	driver->setRenderTarget( irr::video::ERT_STEREO_LEFT_BUFFER);
+	driver->setRenderTarget(irr::video::ERT_STEREO_LEFT_BUFFER);
 
 	irr::core::vector3df leftEye;
 	irr::core::matrix4 leftMove;
@@ -431,7 +431,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 	leftEye = (startMatrix * leftMove).getTranslation();
 
 	//clear the depth buffer, and color
-	driver->beginScene( true, true, irr::video::SColor(200, 200, 200, 255));
+	driver->beginScene(true, true, irr::video::SColor(200, 200, 200, 255));
 	camera.getCameraNode()->setPosition(leftEye);
 	camera.getCameraNode()->setTarget(focusPoint);
 	smgr->drawAll();
@@ -450,7 +450,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 	guienv->drawAll();
 
 	//Right eye...
-	driver->setRenderTarget( irr::video::ERT_STEREO_RIGHT_BUFFER);
+	driver->setRenderTarget(irr::video::ERT_STEREO_RIGHT_BUFFER);
 
 	irr::core::vector3df rightEye;
 	irr::core::matrix4 rightMove;
@@ -460,7 +460,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 	rightEye = (startMatrix * rightMove).getTranslation();
 
 	//clear the depth buffer, and color
-	driver->beginScene( true, true, irr::video::SColor(200, 200, 200, 255));
+	driver->beginScene(true, true, irr::video::SColor(200, 200, 200, 255));
 	camera.getCameraNode()->setPosition(rightEye);
 	camera.getCameraNode()->setTarget(focusPoint);
 	smgr->drawAll();

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -420,7 +420,6 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 			- camera.getCameraNode()->getAbsolutePosition()).setLength(1)
 			+ camera.getCameraNode()->getAbsolutePosition();
 
-
 	//Left eye...
 	driver->setRenderTarget( irr::video::ERT_STEREO_LEFT_BUFFER);
 
@@ -438,8 +437,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 	smgr->drawAll();
 	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
 
-	if (show_hud)
-	{
+	if (show_hud) {
 		draw_selectionbox(driver, hud, hilightboxes, show_hud);
 
 		if (draw_wield_tool)
@@ -468,8 +466,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 	smgr->drawAll();
 	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
 
-	if (show_hud)
-	{
+	if (show_hud) {
 		draw_selectionbox(driver, hud, hilightboxes, show_hud);
 
 		if (draw_wield_tool)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1870,6 +1870,10 @@ void Game::run()
 
 void Game::shutdown()
 {
+	if (g_settings->get("3d_mode") == "pageflip") {
+		driver->setRenderTarget(irr::video::ERT_STEREO_BOTH_BUFFERS);
+	}
+
 	showOverlayMessage(wgettext("Shutting down..."), 0, 0, false);
 
 	if (clouds)

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -213,7 +213,7 @@ fake_function() {
 	gettext("Fall bobbing");
 	gettext("Multiplier for fall bobbing.\nFor example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.");
 	gettext("3D mode");
-	gettext("3D support.\nCurrently supported:\n-    none: no 3d output.\n-    anaglyph: cyan/magenta color 3d.\n-    interlaced: odd/even line based polarisation screen support.\n-    topbottom: split screen top/bottom.\n-    sidebyside: split screen side by side.");
+	gettext("3D support.\nCurrently supported:\n-    none: no 3d output.\n-    anaglyph: cyan/magenta color 3d.\n-    interlaced: odd/even line based polarisation screen support.\n-    topbottom: split screen top/bottom.\n-    sidebyside: split screen side by side.\n-    pageflip: quadbuffer based 3d.");
 	gettext("Console color");
 	gettext("In-game chat console background color (R,G,B).");
 	gettext("Console alpha");

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -213,7 +213,7 @@ fake_function() {
 	gettext("Fall bobbing");
 	gettext("Multiplier for fall bobbing.\nFor example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.");
 	gettext("3D mode");
-	gettext("3D support.\nCurrently supported:\n-    none: no 3d output.\n-    anaglyph: cyan/magenta color 3d.\n-    interlaced: odd/even line based polarisation screen support.\n-    topbottom: split screen top/bottom.\n-    sidebyside: split screen side by side.\n-    pageflip: quadbuffer based 3d.");
+	gettext("3D support.\nCurrently supported:\n-    none: no 3d output.\n-    anaglyph: cyan/magenta color 3d.\n-    interlaced: odd/even line based polarisation screen support.\n-    topbottom: split screen top/bottom.\n-    sidebyside: split screen side by side.");
 	gettext("Console color");
 	gettext("In-game chat console background color (R,G,B).");
 	gettext("Console alpha");


### PR DESCRIPTION
The pageflip mode requires a stereo quadbuffer, and a modern graphic
card. Patch tested with NVidia 3D Vision + Quadro FX 580 on Linux.

The mini-map is not drawn, but that's what is done for topbottom and
sidebyside modes as well.

Also most of the time the user would prefer the HUD to be off. That's
for the user to decide though, and toggle it manually.

Finally, the interocular distance (aka eye separation) is twice as much
as the "3d_paralax_strength" settings. I find this a strange design
decision. I didn't want to chance this though, since it's how the other
3d modes interpret this settings.