### PR TITLE
Fix cache path with RUN_IN_PLACE

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -527,6 +527,7 @@ void initializePaths()
 		path_share = execpath;
 		path_user  = execpath;
 	}
+	path_cache = path_user + DIR_DELIM + "cache";
 #else
 	infostream << "Using system-wide paths (NOT RUN_IN_PLACE)" << std::endl;
 
@@ -536,16 +537,16 @@ void initializePaths()
 	// Initialize path_cache
 	// First try $XDG_CACHE_HOME/PROJECT_NAME
 	const char *cache_dir = getenv("XDG_CACHE_HOME");
+	const char *home_dir = getenv("HOME");
 	if (cache_dir) {
 		path_cache = std::string(cache_dir) + DIR_DELIM + PROJECT_NAME;
-	} else {
+	} else if (home_dir) {
 		// Then try $HOME/.cache/PROJECT_NAME
-		const char *home_dir = getenv("HOME");
-		if (home_dir) {
-			path_cache = std::string(home_dir) + DIR_DELIM + ".cache"
-				+ DIR_DELIM + PROJECT_NAME;
-		}
-		// If neither works, leave it at $PATH_USER/cache
+		path_cache = std::string(home_dir) + DIR_DELIM + ".cache"
+			+ DIR_DELIM + PROJECT_NAME;
+	} else {
+		// If neither works, use $PATH_USER/cache
+		path_cache = path_user + DIR_DELIM + "cache";
 	}
 	// Migrate cache folder to new location if possible
 	migrateCachePath();


### PR DESCRIPTION
If an `XDG_CACHE_HOME` can't be found or `RUN_IN_PLACE` is enabled,
`path_cache` is left at its default of `$PATH_USER/cache`
(at a time when `PATH_USER` is `..`), rather than being reset to
`$PATH_USER/cache` after `PATH_USER` has been properly set.

Fixes #3463