### PR TITLE
Fix textarea bug: clicking right of the end of a line caused the cursor to be in one of the next lines

### DIFF
--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -1120,6 +1120,8 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 
 	if (x < CurrentTextRect.UpperLeftCorner.X)
 		x = CurrentTextRect.UpperLeftCorner.X;
+	else if (x > CurrentTextRect.LowerRightCorner.X)
+		x = CurrentTextRect.LowerRightCorner.X;
 
 	s32 idx = font->getCharacterFromPos(Text.c_str(), x - CurrentTextRect.UpperLeftCorner.X);
 
@@ -1127,7 +1129,7 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 	if (idx != -1)
 		return idx + startPos;
 
-	// click was off the right edge of the line, go to end.
+	// click was off the right edge of the last line, go to end.
 	return txtLine->size() + startPos;
 }
 


### PR DESCRIPTION
textarea is a formspec element which can be used to simulate a text editor in minetest
https://github.com/minetest/minetest/blob/master/doc/lua_api.txt#L1476

a video of the bug (sry for the low quality, the site converted it to a small ogg video):
https://videobin.org/+azz/ee0.ogg
