### PR TITLE
shutdown when requested from lua in singleplayer too

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1816,7 +1816,9 @@ void Game::run()
 			&& client->checkPrivilege("fast");
 #endif
 
-	while (device->run() && !(*kill || g_gamecallback->shutdown_requested)) {
+	while (device->run()
+			&& !(*kill || g_gamecallback->shutdown_requested
+			|| server->getShutdownRequested())) {
 
 		/* Must be called immediately after a device->run() call because it
 		 * uses device->getTimer()->getTime()


### PR DESCRIPTION
Before, minetest.request_shutdown didn't shut down
singleplayer instances or server instances from the server tab.

Fixes #3489.