### PR TITLE
Database backends: fix bug, and small speedup

### DIFF
--- a/src/database-dummy.cpp
+++ b/src/database-dummy.cpp
@@ -47,6 +47,7 @@ bool Database_Dummy::deleteBlock(const v3s16 &pos)
 
 void Database_Dummy::listAllLoadableBlocks(std::vector<v3s16> &dst)
 {
+	dst.reserve(m_database.size());
 	for (std::map<s64, std::string>::const_iterator x = m_database.begin();
 			x != m_database.end(); ++x) {
 		dst.push_back(getIntegerAsBlock(x->first));

--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -169,10 +169,12 @@ void Database_Redis::listAllLoadableBlocks(std::vector<v3s16> &dst)
 	}
 	switch (reply->type) {
 	case REDIS_REPLY_ARRAY:
+		dst.reserve(reply->elements);
 		for (size_t i = 0; i < reply->elements; i++) {
 			assert(reply->element[i]->type == REDIS_REPLY_STRING);
 			dst.push_back(getIntegerAsBlock(stoi64(reply->element[i]->str)));
 		}
+		break;
 	case REDIS_REPLY_ERROR:
 		throw FileNotGoodException(std::string(
 			"Failed to get keys from database: ") + reply->str);


### PR DESCRIPTION
-> Redis backend: break from switch to fix bug
-> Dummy and redis backends: reserve the count so that creating the list is faster

Its untested though.