### PR TITLE
Call lua on_punch if on_use for an item didn't result in an ItemStack

### DIFF
--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -89,6 +89,7 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 	SCRIPTAPI_PRECHECKHEADER
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
+	bool retval = true;
 
 	// Push callback function on stack
 	if (!getItemCallback(item.name.c_str(), "on_use"))
@@ -106,8 +107,11 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 			throw LuaError(std::string(e.what()) + ". item=" + item.name);
 		}
 	}
+	else {
+		retval = false;
+	}
 	lua_pop(L, 2);  // Pop item and error handler
-	return true;
+	return retval;
 }
 
 bool ScriptApiItem::item_OnSecondaryUse(ItemStack &item, ServerActiveObject *user)

--- a/src/server.h
+++ b/src/server.h
@@ -57,6 +57,7 @@ class GameScripting;
 class ServerEnvironment;
 struct SimpleSoundSpec;
 class ServerThread;
+struct PointedThing;
 
 enum ClientDeletionReason {
 	CDR_LEAVE,
@@ -667,7 +668,12 @@ private:
 	*/
 	std::vector<u32> m_particlespawner_ids;
 
+	void punch_object(const PointedThing& pointed, Player* player,
+			ServerActiveObject* pointed_object, PlayerSAO* playersao);
+
 	DISABLE_CLASS_COPY(Server);
+
+
 };
 
 /*


### PR DESCRIPTION
Usecases:
Situation: 
A item defined by some mod having the on_use function set
A new mod not known by original mod

Problem:
on_use doesn't do anything for the new mod thus you can't do any left click interactions to entities using that item.

Solution:
If the item ain't consumed by on_use assume nothing or at least nothing critical has happened in it and call the  on_punch hook for a pointed at object too.
