### PR TITLE
Add 3d_plantlike optional drawtype

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -269,6 +269,10 @@ leaves_style (Leaves style) enum fancy fancy,simple,opaque
 #    Connects glass if supported by node.
 connected_glass (Connect glass) bool false
 
+#    Makes plants 3D if supported by node.
+#    Requires 16px textures.
+3d_plants (3D Plants) bool false
+
 #    Enable smooth lighting with simple ambient occlusion.
 #    Disable for speed or for different looks.
 smooth_lighting (Smooth lighting) bool true

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -15,11 +15,10 @@ varying vec3 lightVec;
 varying vec3 tsEyeVec;
 varying vec3 tsLightVec;
 varying float area_enable_parallax;
-varying float disp;
 
+float disp;
 const float e = 2.718281828459;
 const float BS = 10.0;
-
 
 float smoothCurve(float x)
 {
@@ -76,16 +75,20 @@ void main(void)
 	pos.y += disp * 0.1;
 	pos.z += disp;
 	gl_Position = mWorldViewProj * pos;
-#elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
+#elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS && DRAW_TYPE == NDT_PLANTLIKE
 	vec4 pos = gl_Vertex;
 	if (gl_TexCoord[0].y < 0.05) {
 		pos.z += disp;
 	}
 	gl_Position = mWorldViewProj * pos;
+#elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS && DRAW_TYPE == NDT_3D_PLANTLIKE
+	vec4 pos = gl_Vertex;
+	float d = floor((1.0 - gl_TexCoord[0].y) * 16.0) / 16.0;
+	pos.z += d * disp;
+	gl_Position = mWorldViewProj * pos;
 #else
 	gl_Position = mWorldViewProj * gl_Vertex;
 #endif
-
 
 	vPosition = gl_Position.xyz;
 	worldPosition = (mWorld * gl_Vertex).xyz;

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -287,6 +287,11 @@
 #    type: bool
 # connected_glass = false
 
+#    Makes plants 3D if supported by node.
+#    Requires 16px textures.		
+#    type: bool
+# 3d_plants = false
+
 #    Enable smooth lighting with simple ambient occlusion.
 #    Disable for speed or for different looks.
 #    type: bool

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1613,6 +1613,39 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				mesh->drop();
 			}
 		break;}
+		case NDT_3D_PLANTLIKE:
+		{
+			v3f pos = intToFloat(p, BS);
+			u16 l = getInteriorLight(n, 1, nodedef);
+			video::SColor c = MapBlock_LightColor(255, l, f.light_source);
+			float rotate_degree = 0;
+			if (f.param_type_2 == CPT2_DEGROTATE)
+				rotate_degree = n.param2 * 2;
+
+			scene::IMesh* mesh = cloneMesh(f.mesh_ptr[0]);
+			rotateMeshXZby (mesh, 46 + rotate_degree);
+			recalculateBoundingBox(mesh);
+			meshmanip->recalculateNormals(mesh, true, false);
+			for(u16 j = 0; j < mesh->getMeshBufferCount(); j++) {
+				scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
+				collector.append(getNodeTileN(n, p, j, data),
+					(video::S3DVertex *)buf->getVertices(), buf->getVertexCount(),
+					buf->getIndices(), buf->getIndexCount(), pos, c);
+			}
+			mesh->drop();
+
+			mesh = cloneMesh(f.mesh_ptr[0]);
+			rotateMeshXZby (mesh, -44 + rotate_degree);
+			recalculateBoundingBox(mesh);
+			meshmanip->recalculateNormals(mesh, true, false);
+			for(u16 j = 0; j < mesh->getMeshBufferCount(); j++) {
+				scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
+				collector.append(getNodeTileN(n, p, j, data),
+					(video::S3DVertex *)buf->getVertices(), buf->getVertexCount(),
+					buf->getIndices(), buf->getIndexCount(), pos, c);
+			}
+			mesh->drop();
+		break;}
 		}
 	}
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -112,6 +112,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("new_style_water", "false");
 	settings->setDefault("leaves_style", "fancy");
 	settings->setDefault("connected_glass", "false");
+	settings->setDefault("3d_plants", "false");
 	settings->setDefault("smooth_lighting", "true");
 	settings->setDefault("display_gamma", "1.8");
 	settings->setDefault("texture_path", "");

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -23,6 +23,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "nodedef.h"
 
+scene::IMesh* createExtrudedPlantlikeMesh(ITextureSource *tsrc,
+		video::ITexture *texture);
+
 /*
 	Create a new cube mesh.
 	Vertices are at (+-scale.X/2, +-scale.Y/2, +-scale.Z/2).

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -162,6 +162,8 @@ enum NodeDrawType
 	NDT_GLASSLIKE_FRAMED_OPTIONAL,	// enabled -> connected, disabled -> Glass-like
 									// uses 2 textures, one for frames, second for faces
 	NDT_MESH, // Uses static meshes
+	NDT_3D_PLANTLIKE_OPTIONAL, // enabled -> 3d plants, disabled -> regular plantlike
+	NDT_3D_PLANTLIKE, // plantlike using 3D pixels, only useable with 16px textures
 };
 
 #define CF_SPECIAL_COUNT 6

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -46,6 +46,8 @@ struct EnumString ScriptApiNode::es_DrawType[] =
 		{NDT_RAILLIKE, "raillike"},
 		{NDT_NODEBOX, "nodebox"},
 		{NDT_MESH, "mesh"},
+		{NDT_3D_PLANTLIKE_OPTIONAL, "3d_plantlike_optional"},
+		{NDT_3D_PLANTLIKE, "3d_plantlike"},
 		{0, NULL},
 	};
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -645,10 +645,13 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 		"NDT_NODEBOX",
 		"NDT_GLASSLIKE_FRAMED",
 		"NDT_FIRELIKE",
-		"NDT_GLASSLIKE_FRAMED_OPTIONAL"
+		"NDT_GLASSLIKE_FRAMED_OPTIONAL",
+		"NDT_MESH",
+		"NDT_3D_PLANTLIKE_OPTIONAL",
+		"NDT_3D_PLANTLIKE"
 	};
 
-	for (int i = 0; i < 14; i++){
+	for (int i = 0; i < 19; i++) {
 		shaders_header += "#define ";
 		shaders_header += drawTypes[i];
 		shaders_header += " ";


### PR DESCRIPTION
New drawtype that creates its own "extrusion" meshes out of 16px texture.
It can be enabled via settings same way as connected glass is.
Heres video on the end effect:
https://www.youtube.com/watch?v=L_Az4mEQEtI
And some screenshots:
![screenshot_20151228_221409](https://cloud.githubusercontent.com/assets/2177790/12025577/a361cde2-adb0-11e5-84e5-9fd8b4ecf0f8.png)
![screenshot_20151228_222219](https://cloud.githubusercontent.com/assets/2177790/12025676/8773c1de-adb1-11e5-8e42-72da37c81265.png)
