### PR TITLE
Allow mesh and nodeboxes to wave like plants or leaves.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3971,6 +3971,12 @@ Definition tables
         ^ If drawtype "nodebox" is used and selection_box is nil, then node_box is used. ]]
         legacy_facedir_simple = false, -- Support maps made in and before January 2012
         legacy_wallmounted = false, -- Support maps made in and before January 2012
+        waving = 0, --[[ valid for mesh, nodebox, plantlike, allfaces_optional nodes
+        ^ 1 - wave node like plants (top of node moves, bottom is fixed)
+        ^ 2 - wave node like leaves (whole node moves side-to-side synchronously)
+        ^ caveats: not all models will properly wave
+        ^ plantlike drawtype nodes can only wave like plants
+        ^ allfaces_optional drawtype nodes can only wave like leaves --]]
         sounds = {
             footstep = <SimpleSoundSpec>,
             dig = <SimpleSoundSpec>, -- "__group" = group-based sound (default)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -733,25 +733,29 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			for (u32 i = 0; i < 6; i++)
 				tdef[i].name += std::string("^[noalpha");
 		}
-		if (waving == 1)
+		if (waving >= 1)
 			material_type = TILE_MATERIAL_WAVING_LEAVES;
 		break;
 	case NDT_PLANTLIKE:
 		solidness = 0;
-		if (waving == 1)
+		if (waving >= 1)
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		break;
 	case NDT_FIRELIKE:
 		solidness = 0;
 		break;
 	case NDT_MESH:
+	case NDT_NODEBOX:
 		solidness = 0;
+		if (waving == 1)
+			material_type = TILE_MATERIAL_WAVING_PLANTS;
+		else if (waving == 2)
+			material_type = TILE_MATERIAL_WAVING_LEAVES;
 		break;
 	case NDT_TORCHLIKE:
 	case NDT_SIGNLIKE:
 	case NDT_FENCELIKE:
 	case NDT_RAILLIKE:
-	case NDT_NODEBOX:
 		solidness = 0;
 		break;
 	}


### PR DESCRIPTION
We introduce a new value for "waving" - 2:

0 - waving disabled
1 - wave like a plant
2 - wave like leaves

For current nodes already waving, a value of 1 or 2 results in no
change - e.g. plantlike will not wave like leaves, and vice versa.

For mesh and nodebox, values 1 and 2 are both valid, and the node
can wave in both fashions as desired.

This makes it somewhat backwards compatible.

I've tested this with the crops:corn plants, which are mesh nodes,
and the results are really good. The code change is trivial as
well, so I've opted to document the waving parameter in lua_api.txt
because it was missing from there.
