### PR TITLE
Minimal: Add mapgen alias for air

### DIFF
--- a/games/minimal/mods/default/mapgen.lua
+++ b/games/minimal/mods/default/mapgen.lua
@@ -3,6 +3,7 @@
 --
 
 
+minetest.register_alias("mapgen_air", "air")
 minetest.register_alias("mapgen_stone", "default:stone")
 minetest.register_alias("mapgen_dirt", "default:dirt")
 minetest.register_alias("mapgen_dirt_with_grass", "default:dirt_with_grass")


### PR DESCRIPTION
Once core mapgen are modified to work with this, will enable subgames to use core mapgen to create space or alien realms with vacuum nodes or alien atmosphere nodes.
This was agreed by myself and hmmmm a few months ago so i will push merge soon.
One issue to consider and work on: liquids currently don't flow into airlike nodes.