### PR TITLE
Shaders: Reduce amplitudes of waving leaves and plants

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -15,7 +15,6 @@ varying vec3 lightVec;
 varying vec3 tsEyeVec;
 varying vec3 tsLightVec;
 varying float area_enable_parallax;
-varying float disp;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -55,6 +54,7 @@ void main(void)
 #endif
 
 
+float disp;
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
 	vec4 pos2 = mWorld * gl_Vertex;
 	float tOffset = (pos2.x + pos2.y) * 0.001 + pos2.z * 0.002;
@@ -74,12 +74,12 @@ void main(void)
 	vec4 pos = gl_Vertex;
 	pos.x += disp * 0.1;
 	pos.y += disp * 0.1;
-	pos.z += disp;
+	pos.z += disp * 0.7;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
 	vec4 pos = gl_Vertex;
 	if (gl_TexCoord[0].y < 0.05) {
-		pos.z += disp;
+		pos.z += disp * 0.5;
 	}
 	gl_Position = mWorldViewProj * pos;
 #else


### PR DESCRIPTION
"Fix initialisation of 'disp' variable"

I received feedback about my changes to leaves/plants waving having too high amplitude, i agree and have now made the wave amplitudes of leaves and plants independant and have reduced and tuned each one.
Leaves amplitude is mulitplied by 0.7.
Plants amplitude is mulitplied by 0.5.
Both are now more of a gentle swaying.

For some reason git thinks i have changed 62 lines, only 2 lines are changed:
line 77 is now:
pos.z += disp \* 0.7;
line 82 is now:
pos.z += disp \* 0.5;

This PR is easy to test it doesn't require recompiling as opengl shaders are compiled on game startup.
