### PR TITLE
Far map and improved map transfer and rendering (WIP)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -299,8 +299,10 @@ far_map_range (Far map range) int 500
 #    Far map far/near priorization factor. Client tells this to the server.
 #    A priorization factor for far map transfers is created by dividing distance
 #    of FarBlocks by this and then comparing it to distance to regular
-#    MapBlocks. The one having the smaller value is sent first.
-far_map_far_weight (Far/near priorization factor) float 4.0
+#    MapBlocks. The one having the smaller value is sent first. If zero, then
+#    MapBlocks always take higher priority. If you like to have FarMap appear
+#    first, then something like 4.0 works well.
+far_map_far_weight (Far/near priorization factor) float 0.0
 
 #    Resolution of nodes in far map's texture atlas
 #    If you have a gigabyte of RAM to spare or play a game with less than a

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -878,11 +878,11 @@ emergequeue_limit_total (Absolute limit of emerge queues) int 256
 
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    Set to blank for an appropriate amount to be chosen automatically.
-emergequeue_limit_diskonly (Limit of emerge queues on disk) int 32
+emergequeue_limit_diskonly (Limit of emerge queues on disk) int 64
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    Set to blank for an appropriate amount to be chosen automatically.
-emergequeue_limit_generate (Limit of emerge queues to generate) int 32
+emergequeue_limit_generate (Limit of emerge queues to generate) int 16
 
 #    Number of emerge threads to use. Make this field blank, or increase this number
 #    to use multiple threads. On multiprocessor systems, this will improve mapgen speed greatly

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -217,9 +217,17 @@ keymap_increase_viewing_range_min (View range increase key) key +
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_decrease_viewing_range_min (View range decrease key) key -
 
+#    Modifier key for altering the far map range instead of viewing range
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+keymap_far_range_modifier (Far range modifier key) key KEY_LCONTROL
+
 #    Key for printing debug stacks. Used for development.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_print_debug_stacks (Print stacks) key KEY_KEY_P
+
+#    Toggle far map visibility
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+# keymap_toggle_far_map_visibility (Toggle far map) key
 
 [*Network]
 
@@ -279,6 +287,27 @@ enable_3d_clouds (3D clouds) bool true
 
 #    Method used to highlight selected object.
 node_highlighting (Node highlighting) enum box box,halo
+
+[***Far Map]
+
+#    Enable low level-of-detail rendering at large distances
+enable_far_map (Far map) bool true
+
+#    Far map rendering range in nodes
+far_map_range (Far map range) int 500
+
+#    Far map far/near priorization factor. Client tells this to the server.
+#    A priorization factor for far map transfers is created by dividing distance
+#    of FarBlocks by this and then comparing it to distance to regular
+#    MapBlocks. The one having the smaller value is sent first.
+far_map_far_weight (Far/near priorization factor) float 4.0
+
+#    Resolution of nodes in far map's texture atlas
+#    If you have a gigabyte of RAM to spare or play a game with less than a
+#    thousand nodes, setting this to 16 doesn't hurt.
+#    Otherwise 8 looks reasonable and doesn't take a lot of resources.
+#    You can get unique styles by setting this to low values like 1 or 2.
+far_map_atlas_node_resolution (Far map atlas: node resolution) int 8
 
 [***Filtering]
 
@@ -832,6 +861,9 @@ map_generation_limit (Map generation limit) int 31000 0 31000
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
 mg_flags (Mapgen flags) flags caves,dungeons,light,decorations caves,dungeons,light,decorations,nocaves,nodungeons,nolight,nodecorations
+
+#    Allow far map to use the map generator
+far_map_allow_generate (Allow far map to use mapgen) bool false
 
 [**Advanced]
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -4,6 +4,7 @@ uniform sampler2D textureFlags;
 
 uniform vec4 skyBgColor;
 uniform float fogDistance;
+uniform float fogDistanceStart;
 uniform vec3 eyePosition;
 
 varying vec3 vPosition;
@@ -197,13 +198,13 @@ void main(void)
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(vPosition.z / fogDistance * 1.5 - 0.6, 1.0));
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		alpha = mix(alpha, 0.0, d);
 	}
 	col = vec4(col.rgb, alpha);
 #else
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(vPosition.z / fogDistance * 1.5 - 0.6, 1.0));
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		col = mix(col, skyBgColor, d);
 	}
 	col = vec4(col.rgb, base.a);

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -4,6 +4,7 @@ uniform sampler2D textureFlags;
 
 uniform vec4 skyBgColor;
 uniform float fogDistance;
+uniform float fogDistanceStart;
 uniform vec3 eyePosition;
 
 varying vec3 vPosition;
@@ -153,13 +154,13 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(vPosition.z / fogDistance * 1.5 - 0.6, 1.0));
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		alpha = mix(alpha, 0.0, d);
 	}
 	col = vec4(col.rgb, alpha);
 #else
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(vPosition.z / fogDistance * 1.5 - 0.6, 1.0));
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		col = mix(col, skyBgColor, d);
 	}
 	col = vec4(col.rgb, base.a);

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -4,6 +4,7 @@ uniform sampler2D textureFlags;
 
 uniform vec4 skyBgColor;
 uniform float fogDistance;
+uniform float fogDistanceStart;
 uniform vec3 eyePosition;
 
 varying vec3 vPosition;
@@ -94,7 +95,7 @@ void main(void)
 	if (use_normalmap) {
 		vec3 L = normalize(lightVec);
 		vec3 E = normalize(eyeVec);
-		float specular = pow(clamp(dot(reflect(L, bump.xyz), E), 0.0, 1.0), 1.0);
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		float diffuse = dot(-E,bump.xyz);
 		color = (diffuse + 0.1 * specular) * base.rgb;
 	} else {
@@ -107,7 +108,7 @@ void main(void)
 	vec4 col = vec4(color.rgb, base.a);
 	col *= gl_Color;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(vPosition.z / fogDistance * 1.5 - 0.6, 1.0));
+		float d = max(0.0, min((vPosition.z - fogDistanceStart) / fogDistance, 1.0));
 		col = mix(col, skyBgColor, d);
 	}
 	gl_FragColor = vec4(col.rgb, base.a);

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -322,8 +322,10 @@
 #    Far map far/near priorization factor
 #    A priorization factor for far map transfers is created by dividing distance
 #    of FarBlocks by this and then comparing it to distance to regular
-#    MapBlocks. The one having the smaller value is sent first.
-# far_map_far_weight = 4.0
+#    MapBlocks. The one having the smaller value is sent first. If zero, then
+#    MapBlocks always take higher priority. If you like to have FarMap appear
+#    first, then something like 4.0 works well.
+# far_map_far_weight = 0.0
 
 #    Resolution of nodes in far map's texture atlas
 #    If you have a gigabyte of RAM to spare or play a game with less than a

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -224,10 +224,19 @@
 #    type: key
 # keymap_decrease_viewing_range_min = -
 
+#    Modifier key for altering the far map range instead of viewing range
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#keymap_far_range_modifier = KEY_LCONTROL
+
 #    Key for printing debug stacks. Used for development.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
 # keymap_print_debug_stacks = KEY_KEY_P
+
+#    Toggle far map visibility
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#    type: key
+# keymap_toggle_far_map_visibility =
 
 ## Network
 
@@ -301,6 +310,27 @@
 #    Method used to highlight selected object.
 #    type: enum values: box, halo
 # node_highlighting = box
+
+#### Far Map
+
+#    Enable low level-of-detail rendering at large distances
+# enable_far_map = true
+
+#    Far map rendering range in nodes
+# far_map_range = 500
+
+#    Far map far/near priorization factor
+#    A priorization factor for far map transfers is created by dividing distance
+#    of FarBlocks by this and then comparing it to distance to regular
+#    MapBlocks. The one having the smaller value is sent first.
+# far_map_far_weight = 4.0
+
+#    Resolution of nodes in far map's texture atlas
+#    If you have a gigabyte of RAM to spare or play a game with less than a
+#    thousand nodes, setting this to 16 doesn't hurt.
+#    Otherwise 8 looks reasonable and doesn't take a lot of resources.
+#    Setting this down to 1 is supported.
+# far_map_atlas_node_resolution = 8
 
 #### Filtering
 
@@ -1025,6 +1055,9 @@
 #    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: caves, dungeons, light, decorations, nocaves, nodungeons, nolight, nodecorations
 # mg_flags = caves,dungeons,light,decorations
+
+#    Allow far map to use the map generator
+# far_map_allow_generate = false
 
 ### Advanced
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1076,12 +1076,12 @@
 #    Maximum number of blocks to be queued that are to be loaded from file.
 #    Set to blank for an appropriate amount to be chosen automatically.
 #    type: int
-# emergequeue_limit_diskonly = 32
+# emergequeue_limit_diskonly = 64
 
 #    Maximum number of blocks to be queued that are to be generated.
 #    Set to blank for an appropriate amount to be chosen automatically.
 #    type: int
-# emergequeue_limit_generate = 32
+# emergequeue_limit_generate = 16
 
 #    Number of emerge threads to use. Make this field blank, or increase this number
 #    to use multiple threads. On multiprocessor systems, this will improve mapgen speed greatly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -424,6 +424,8 @@ set(common_SRCS
 	version.cpp
 	voxel.cpp
 	voxelalgorithms.cpp
+	far_map_common.cpp
+	far_map_server.cpp
 	${common_network_SRCS}
 	${JTHREAD_SRCS}
 	${common_SCRIPT_SRCS}
@@ -498,6 +500,8 @@ set(client_SRCS
 	shader.cpp
 	sky.cpp
 	wieldmesh.cpp
+	far_map.cpp
+	util/atlas.cpp
 	${client_SCRIPT_SRCS}
 )
 list(SORT client_SRCS)
@@ -686,10 +690,10 @@ else()
 	if(APPLE)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
 	else()
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fomit-frame-pointer")
+		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fomit-frame-pointer -Wno-deprecated-declarations")
 	endif(APPLE)
-	set(CMAKE_CXX_FLAGS_SEMIDEBUG "-g -O1 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS}")
-	set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS}")
+	set(CMAKE_CXX_FLAGS_SEMIDEBUG "-g -O1 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS} -Wno-deprecated-declarations")
+	set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS} -Wno-deprecated-declarations")
 
 	if(USE_GPROF)
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")

--- a/src/client.h
+++ b/src/client.h
@@ -525,6 +525,7 @@ public:
 	bool getFarMapVisible();
 	void setFarMapVisible(bool b);
 	float getFarMapFogDistance();
+	s32 calculateReasonableMapblockLimit();
 
 	// IGameDef interface
 	virtual IItemDefManager* getItemDefManager();

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -110,6 +110,7 @@ public:
 	virtual bool isKnownSourceImage(const std::string &name)=0;
 	virtual video::ITexture* generateTextureFromMesh(
 			const TextureFromMeshParams &params)=0;
+	virtual video::IImage* generateImage(const std::string &name)=0;
 	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -887,6 +887,13 @@ void AutosendAlgorithm::resetMapblockSearchRadius()
 {
 	m_cycle->mapblock.nearest_unsent_d = 0;
 	m_cycle->mapblock.i = 0;
+	// Apparently all of these have to be reset in order to have the search
+	// start at 0 because of what finish() does.
+	m_cycle->mapblock.nearest_emergequeued_d = 0;
+	m_cycle->mapblock.nearest_emergefull_d = 0;
+	m_cycle->mapblock.nearest_sendqueued_d = 0;
+	// Immediately start searching for MapBlocks to be sent
+	m_cycle->mapblock.nothing_to_send_pause_timer = 0.0f;
 }
 
 std::string AutosendAlgorithm::describeStatus()
@@ -1102,8 +1109,7 @@ void RemoteClient::GotBlock(const WantedMapSend &wms)
 		m_blocks_sent[wms] = m_blocks_sending[wms];
 		m_blocks_sending.erase(wms);
 	} else {
-			m_excess_gotblocks++;
-
+		m_excess_gotblocks++;
 	}
 }
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -17,8 +17,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <sstream>
+// These two lines should surely get us INT32_MAX
+#define __STDC_LIMIT_MACROS
 #include <stdint.h>
+
+#include <sstream>
 
 #include "clientiface.h"
 #include "util/numeric.h"

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -31,7 +31,873 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "serverobject.h"              // TODO this is used for cleanup of only
 #include "log.h"
+#include "far_map_server.h"
+#include "network/wms_priority.h"
 #include "util/srp.h"
+
+#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
+
+struct WMSSPriority: WMSPriority
+{
+	WMSSPriority(v3s16 player_p, float far_weight):
+		WMSPriority(player_p, far_weight)
+	{}
+
+	// Lower is more important
+	float getPriority(const WMSSuggestion &wmss) {
+		return WMSPriority::getPriority(wmss.wms);
+	}
+
+	// Sorts WMSSuggestions in descending order of priority
+	bool operator() (const WMSSuggestion& wms1, const WMSSuggestion& wms2) {
+		return (getPriority(wms1) < getPriority(wms2));
+	}
+};
+
+/*
+	AutosendAlgorithm
+*/
+
+u16 figure_out_max_simultaneous_block_sends(u16 base_setting,
+		float time_from_building, float time_from_building_limit_setting,
+		s16 block_distance_in_blocks)
+{
+	// If block is very close, always send the configured amount
+	if (block_distance_in_blocks <= BLOCK_SEND_DISABLE_LIMITS_MAX_D)
+		return base_setting;
+
+	// If the time from last addNode/removeNode is small, don't send as much
+	// stuff in order to reduce lag
+	if (time_from_building < time_from_building_limit_setting)
+		return LIMITED_MAX_SIMULTANEOUS_BLOCK_SENDS;
+
+	// Send the configured amount if nothing special is happening
+	return base_setting;
+}
+
+struct AutosendCycle
+{
+	bool disabled;
+	AutosendAlgorithm *alg;
+	RemoteClient *client;
+	ServerEnvironment *env;
+
+	v3f camera_p;
+	v3f camera_dir;
+	v3s16 focus_point;
+
+	u16 max_simul_sends_setting;
+	float time_from_building_limit_s;
+	s16 max_mapblock_send_distance_setting;
+	s16 max_mapblock_generate_distance;
+	bool far_map_allow_generate;
+
+	struct Search {
+		// All of these are reset by start()
+		s16 max_send_distance;
+		s16 fov_limit_activation_distance;
+		s16 d_start;
+		s16 d_max;
+		s16 d;
+		size_t i;
+		s32 nearest_emergequeued_d;
+		s32 nearest_emergefull_d;
+		s32 nearest_sendqueued_d;
+
+		// All of these are persistent
+		s16 nearest_unsent_d;
+		bool fov_limit_enabled; // Automatically turned off to transfer the rest
+		float nothing_to_send_timer;
+		float nothing_to_send_pause_timer; // CPU usage optimization
+
+		Search():
+			nearest_unsent_d(0),
+			fov_limit_enabled(true),
+			nothing_to_send_timer(0), // Counts up from 0
+			nothing_to_send_pause_timer(0) // Pause if >=0; decrements
+		{}
+
+		void runTimers(float dtime);
+
+		void start(s16 max_send_distance_, s16 fov_limit_activation_distance_);
+
+		void finish(bool enable_fov_toggle);
+	};
+	
+	Search mapblock;
+	Search farblock;
+
+	AutosendCycle():
+		disabled(true)
+	{}
+
+	void start(AutosendAlgorithm *alg_,
+			RemoteClient *client_, ServerEnvironment *env_);
+
+	WMSSuggestion getNextBlock(EmergeManager *emerge, ServerFarMap *far_map);
+
+	void finish();
+
+private:
+	WMSSuggestion suggestNextMapBlock(EmergeManager *emerge);
+	WMSSuggestion suggestNextFarBlock(EmergeManager *emerge, ServerFarMap *far_map);
+};
+
+void AutosendCycle::start(AutosendAlgorithm *alg_,
+		RemoteClient *client_, ServerEnvironment *env_)
+{
+	//dstream<<"AutosendCycle::start()"<<std::endl;
+
+	alg = alg_;
+	client = client_;
+	env = env_;
+
+	disabled = false;
+
+	if (alg->m_radius_map == 0 && alg->m_radius_far == 0) {
+		//dstream<<"radius=0"<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	// Disable if MapBlock and FarBlock pauses are active
+	if (mapblock.nothing_to_send_pause_timer >= 0 &&
+			farblock.nothing_to_send_pause_timer >= 0) {
+		//dstream<<"nothing to send pause (map+far)"<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	Player *player = env->getPlayer(client->peer_id);
+	if (player == NULL) {
+		//dstream<<"player==NULL"<<std::endl;
+		// This can happen sometimes; clients and players are not in perfect sync.
+		disabled = true;
+		return;
+	}
+
+	// Won't send anything if already sending
+	if (client->m_blocks_sending.size() >= g_settings->getU16
+			("max_simultaneous_block_sends_per_client")) {
+		//dstream<<"max_simul_sends"<<std::endl;
+		//infostream<<"Not sending any blocks, Queue full."<<std::endl;
+		disabled = true;
+		return;
+	}
+
+	camera_p = player->getEyePosition();
+	v3f player_speed = player->getSpeed();
+
+	// Get player position and figure out a good focus point for block selection
+	v3f player_speed_dir(0,0,0);
+	if(player_speed.getLength() > 1.0*BS)
+		player_speed_dir = player_speed / player_speed.getLength();
+	// Predict to next block
+	v3f camera_p_predicted = camera_p + player_speed_dir*MAP_BLOCKSIZE*BS;
+	v3s16 focus_point_nodepos = floatToInt(camera_p_predicted, BS);
+	focus_point = getNodeBlockPos(focus_point_nodepos);
+
+	// Camera position and direction
+	camera_dir = v3f(0,0,1);
+	camera_dir.rotateYZBy(player->getPitch());
+	camera_dir.rotateXZBy(player->getYaw());
+
+	// If focus point has changed to a different MapBlock, reset radius value
+	// for iterating from zero again
+	if (alg->m_last_focus_point != focus_point) {
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+		alg->m_last_focus_point = focus_point;
+	}
+
+	// Get some settings
+	max_simul_sends_setting =
+			g_settings->getU16("max_simultaneous_block_sends_per_client");
+	time_from_building_limit_s =
+			g_settings->getFloat("full_block_send_enable_min_time_from_building");
+	max_mapblock_send_distance_setting =
+			g_settings->getS16("max_block_send_distance");
+	max_mapblock_generate_distance =
+			g_settings->getS16("max_block_generate_distance");
+	far_map_allow_generate =
+			g_settings->getBool("far_map_allow_generate");
+
+	// Derived settings
+	s16 max_mapblock_send_distance =
+			alg->m_radius_map < max_mapblock_send_distance_setting ?
+			alg->m_radius_map : max_mapblock_send_distance_setting;
+
+	// Reset periodically to workaround possible glitches due to whatever
+	// reasons (this is somewhat guided by just heuristics, after all)
+	if (alg->m_nearest_unsent_reset_timer > 20.0) {
+		alg->m_nearest_unsent_reset_timer = 0;
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+	}
+
+	// MapBlock search iteration
+	// Out-of-FOV distance limit is halved when limit is enabled
+	s16 mb_fov_limit_activation_distance = mapblock.fov_limit_enabled ?
+			max_mapblock_send_distance / 2 : max_mapblock_send_distance;
+	mapblock.start(max_mapblock_send_distance, mb_fov_limit_activation_distance);
+
+	// FarBlock search iteration
+	// Out-of-FOV distance limit is always disabled
+	s16 fb_fov_limit_activation_distance = alg->m_radius_far;
+	farblock.start(alg->m_radius_far, fb_fov_limit_activation_distance);
+}
+
+WMSSuggestion AutosendCycle::suggestNextMapBlock(EmergeManager *emerge)
+{
+	for (; mapblock.d <= mapblock.d_max; mapblock.d++) {
+		//dstream<<"AutosendMap: mapblock.d="<<mapblock.d<<std::endl;
+
+		// Get the border/face dot coordinates of a mapblock.d-"radiused" box
+		std::vector<v3s16> face_ps = FacePositionCache::getFacePositions(mapblock.d);
+		// Continue from the last mapblock.i unless it was reset by something
+		for (; mapblock.i < face_ps.size(); mapblock.i++) {
+			v3s16 p = face_ps[mapblock.i] + focus_point;
+			WantedMapSend wms(WMST_MAPBLOCK, p);
+
+			// Limit fetched MapBlocks to a ball radius instead of a square
+			// because that is how they are limited when drawing too
+			v3s16 blockpos_nodes = p * MAP_BLOCKSIZE;
+			v3f blockpos_center(
+					blockpos_nodes.X * BS + MAP_BLOCKSIZE/2 * BS,
+					blockpos_nodes.Y * BS + MAP_BLOCKSIZE/2 * BS,
+					blockpos_nodes.Z * BS + MAP_BLOCKSIZE/2 * BS
+			);
+			v3f blockpos_relative = blockpos_center - camera_p;
+			f32 distance = blockpos_relative.getLength();
+			if (distance > mapblock.max_send_distance * MAP_BLOCKSIZE * BS) {
+				/*dstream<<"AutosendMap: "<<wms.describe()
+						<<": continue: distance: "<<distance<<std::endl;*/
+				continue; // Not in range
+			}
+
+			// Calculate this thing
+			u16 max_simultaneous_block_sends =
+					figure_out_max_simultaneous_block_sends(
+							max_simul_sends_setting,
+							client->m_time_from_building,
+							time_from_building_limit_s,
+							mapblock.d);
+
+			// Don't select too many blocks for sending
+			if (client->SendingCount() >= max_simultaneous_block_sends) {
+				/*dstream<<"AutosendMap: "<<wms.describe()
+						<<": return: num_selected"<<std::endl;*/
+				// Nothing to suggest
+				return WMSSuggestion();
+			}
+
+			// Don't send blocks that are currently being transferred
+			if (client->m_blocks_sending.count(wms)) {
+				/*dstream<<"AutosendMap: "<<wms.describe()
+						<<": continue: num sending"<<std::endl;*/
+				continue;
+			}
+
+			// Don't go over hard map limits
+			if (blockpos_over_limit(p)) {
+				/*dstream<<"AutosendMap: "<<wms.describe()
+						<<": continue: over limit"<<std::endl;*/
+				continue;
+			}
+
+			// If this is true, inexistent blocks will be made from scratch
+			bool allow_generate = mapblock.d <= max_mapblock_generate_distance;
+
+			/*// Limit the generating area vertically to 2/3
+			if(abs(p.Y - focus_point.Y) >
+					max_mapblock_generate_distance - max_mapblock_generate_distance / 3)
+				allow_generate = false;*/
+
+			/*// Limit the send area vertically to 1/2
+			if (abs(p.Y - focus_point.Y) > max_block_send_distance / 2)
+				continue;*/
+
+			if (mapblock.d >= mapblock.fov_limit_activation_distance) {
+				// Don't generate or send if not in sight
+				if(isBlockInSight(p, camera_p, camera_dir, alg->m_fov,
+						10000*BS) == false)
+				{
+					/*dstream<<"AutosendMap: "<<wms.describe()
+							<<": continue: not in sight"<<std::endl;*/
+					continue;
+				}
+			}
+
+			// Don't send blocks that have already been sent
+			std::map<WantedMapSend, time_t>::const_iterator
+					blocks_sent_i = client->m_blocks_sent.find(wms);
+			if (blocks_sent_i != client->m_blocks_sent.end()){
+				if (client->m_blocks_updated_since_last_send.count(wms) == 0) {
+					/*dstream<<"AutosendMap: "<<wms.describe()
+							<<": Already sent and not updated"<<std::endl;*/
+					continue;
+				}
+				// NOTE: Don't do rate limiting for MapBlocks
+				//time_t sent_time = blocks_sent_i->second;
+				/*dstream<<"AutosendMap: "<<wms.describe()
+						<<": Already sent but updated"<<std::endl;*/
+			}
+
+			/*
+				Check if map has this block
+			*/
+			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
+
+			bool surely_not_found_on_disk = false;
+			bool emerge_required = false;
+			if(block != NULL)
+			{
+				// Reset usage timer, this block will be of use in the future.
+				block->resetUsageTimer();
+
+				// Block is dummy if data doesn't exist.
+				// It means it has been not found from disk and not generated
+				if(block->isDummy())
+					surely_not_found_on_disk = true;
+
+				// Block is valid if lighting is up-to-date and data exists
+				if(block->isValid() == false)
+					emerge_required = true;
+
+				// If a block hasn't been generated but we would ask it to be
+				// generated, it's invalid.
+				if(block->isGenerated() == false && allow_generate)
+					emerge_required = true;
+
+				// This check is disabled because it mis-guesses sea floors to
+				// not be worth transferring to the client, while they are.
+				/*if (mapblock.d >= 4 && block->getDayNightDiff() == false)
+					continue;*/
+			}
+
+			/*
+				If block has been marked to not exist on disk (dummy)
+				and generating new ones is not wanted, skip block.
+			*/
+			if(allow_generate == false && surely_not_found_on_disk == true)
+			{
+				//dstream<<"continue: not on disk, no generate"<<std::endl;
+				// get next one.
+				continue;
+			}
+
+			if(!block || surely_not_found_on_disk || emerge_required)
+			{
+				// Queue the block for loading or generating
+				bool queue_full = !emerge->enqueueBlockEmerge(
+						client->peer_id, p, allow_generate);
+				if (!queue_full) {
+					if (mapblock.nearest_emergequeued_d == INT32_MAX)
+						mapblock.nearest_emergequeued_d = mapblock.d;
+					// Queue is not full; continue searching
+					continue;
+				} else {
+					if (mapblock.nearest_emergefull_d == INT32_MAX)
+						mapblock.nearest_emergefull_d = mapblock.d;
+					// Queue is full; don't bother searching futher
+					return WMSSuggestion();
+				}
+			}
+
+			// Suggest this block (is already loaded)
+			return WMSSuggestion(wms);
+		}
+
+		// Now reset i as we go to next d
+		mapblock.i = 0;
+	}
+
+	// Nothing to suggest
+	return WMSSuggestion();
+}
+
+WMSSuggestion AutosendCycle::suggestNextFarBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)
+{
+	v3s16 focus_point_fb = getContainerPos(focus_point, FMP_SCALE);
+
+	const float fb_size_bs = FMP_SCALE * MAP_BLOCKSIZE * BS;
+	const float max_distance_f = fb_size_bs * farblock.max_send_distance;
+
+	const size_t max_blind_generate_requests = 1;
+	size_t num_blind_generate_requests = 0;
+
+	for (; farblock.d <= farblock.d_max; farblock.d++) {
+		//dstream<<"AutosendFar: farblock.d="<<farblock.d<<std::endl;
+
+		// Get the border/face dot coordinates of a farblock.d-"radiused" box
+		std::vector<v3s16> face_ps = FacePositionCache::getFacePositions(farblock.d);
+		// Continue from the last farblock.i unless it was reset by something
+		for (; farblock.i < face_ps.size(); farblock.i++) {
+			v3s16 p = focus_point_fb + face_ps[farblock.i];
+
+			WantedMapSend wms(WMST_FARBLOCK, p);
+
+			// Calculate this thing
+			u16 max_simultaneous_block_sends =
+					figure_out_max_simultaneous_block_sends(
+							max_simul_sends_setting,
+							client->m_time_from_building,
+							time_from_building_limit_s,
+							farblock.d * FMP_SCALE);
+
+			// Don't select too many blocks for sending
+			if (client->SendingCount() >= max_simultaneous_block_sends) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": return: num_selected"<<std::endl;*/
+				// Nothing to suggest
+				return WMSSuggestion();
+			}
+
+			// Limit distance to a circular radius
+			v3f farblock_pf(
+				((float)p.X + 0.5) * fb_size_bs,
+				((float)p.Y + 0.5) * fb_size_bs,
+				((float)p.Z + 0.5) * fb_size_bs
+			);
+			float df = (camera_p - farblock_pf).getLength();
+			if (df > max_distance_f) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": continue: distance"
+						<<" (df="<<df<<", max_distance_f="<<max_distance_f<<")"
+						<<std::endl;*/
+				continue;
+			}
+
+			// Don't send blocks that are currently being transferred
+			if (client->m_blocks_sending.count(wms)) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": continue: num sending"<<std::endl;*/
+				continue;
+			}
+
+			// Don't go over hard map limits
+			if (blockpos_over_limit(p * FMP_SCALE)) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": continue: over limit"<<std::endl;*/
+				continue;
+			}
+
+			// We really can't generate everything; it would bloat up
+			// the world database way too much.
+			// TODO: Figure out how to do this in a good way
+			bool allow_generate = wms.p.Y >= -1 && wms.p.Y <= 1;
+			bool allow_load = wms.p.Y >= -1 && wms.p.Y <= 1;
+
+			if (!far_map_allow_generate)
+				allow_generate = false;
+
+			ServerFarBlock *fb = far_map->getBlock(wms.p);
+
+			// Check load states of MapBlocks
+			const size_t mbs_total = FMP_SCALE * FMP_SCALE * FMP_SCALE;
+			size_t mbs_unknown = mbs_total;
+			size_t mbs_not_loaded = 0;
+			size_t mbs_not_generated = 0;
+			size_t mbs_generated = 0;
+			if (fb) {
+				const BlockAreaBitmap<ServerFarBlock::LoadState> &lm =
+						fb->loaded_mapblocks;
+				mbs_unknown = lm.count(ServerFarBlock::LS_UNKNOWN);
+				mbs_not_loaded = lm.count(ServerFarBlock::LS_NOT_LOADED);
+				mbs_not_generated = lm.count(ServerFarBlock::LS_NOT_GENERATED);
+				mbs_generated = lm.count(ServerFarBlock::LS_GENERATED);
+			}
+			bool fully_loaded = allow_generate ? (mbs_generated == mbs_total) :
+					(mbs_unknown + mbs_not_loaded == 0);
+
+			// If none of this FarBlock is loaded (it may be if a player has
+			// been very close to it) and we are generally not allowing loading
+			// of this area for FarBlock purposes, completely skip this
+			// FarBlock. This allows much faster loading of relevant FarBlocks
+			// as we neither try to load nor send these FarBlocks at all.
+			if (mbs_unknown + mbs_not_loaded == mbs_total && !allow_load) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": continue: not loaded and load disabled"<<std::endl;*/
+				continue;
+			}
+
+			// FarBlock area in divisions (FarNodes)
+			static const v3s16 divs_per_mb(
+					SERVER_FB_MB_DIV, SERVER_FB_MB_DIV, SERVER_FB_MB_DIV);
+
+			v3s16 area_offset_mb(
+				FMP_SCALE * wms.p.X,
+				FMP_SCALE * wms.p.Y,
+				FMP_SCALE * wms.p.Z
+			);
+
+			v3s16 area_size_mb(FMP_SCALE, FMP_SCALE, FMP_SCALE);
+
+			// Queue emergement of missing MapBlocks
+			v3s16 bp;
+			bool emerge_queue_full = false;
+			for (bp.Z=area_offset_mb.Z; bp.Z<area_offset_mb.Z+area_size_mb.Z; bp.Z++)
+			// From top towards bottom; loading looks better this way
+			for (bp.Y=area_offset_mb.Y+area_size_mb.Y-1; bp.Y>=area_offset_mb.Y; bp.Y--)
+			for (bp.X=area_offset_mb.X; bp.X<area_offset_mb.X+area_size_mb.X; bp.X++)
+			{
+				ServerFarBlock::LoadState load_state = fb ?
+						fb->loaded_mapblocks.get(bp) : ServerFarBlock::LS_UNKNOWN;
+
+				// There's nothing we can or need to do to generated ones
+				if (load_state == ServerFarBlock::LS_GENERATED) {
+					continue;
+				}
+
+				// Limit blind geneartions; i.e. generation-allowing emerge
+				// requests of unloaded MapBlocks
+				bool would_be_blind_generate =
+						load_state < ServerFarBlock::LS_NOT_GENERATED;
+				bool allow_generate_now = allow_generate;
+				if (would_be_blind_generate &&
+						num_blind_generate_requests >= max_blind_generate_requests)
+					allow_generate_now = false;
+
+				// If it's already loaded and we don't want to generate it, skip
+				// it
+				if (!allow_generate_now &&
+						load_state == ServerFarBlock::LS_NOT_GENERATED) {
+					/*dstream<<"AutosendFar: "<<wms.describe()
+							<<": Not generating "<<PP(bp)<<std::endl;*/
+					continue;
+				}
+
+				// Load or generate it
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": Adding "<<PP(bp)<<" to emerge queue"
+						<<" (allow_generate_now="<<allow_generate_now<<")"
+						<<std::endl;*/
+				emerge_queue_full = !emerge->enqueueBlockEmerge(
+						client->peer_id, bp, allow_generate_now);
+
+				if (emerge_queue_full) {
+					if (farblock.nearest_emergefull_d == INT32_MAX)
+						farblock.nearest_emergefull_d = farblock.d;
+					// Emerge queue is full; don't bother attempting to add more
+					// stuff to it from this FarBlock and don't increment our
+					// counters
+					goto farblock_mapblocks_iterate_break;
+				}
+
+				if (farblock.nearest_emergequeued_d == INT32_MAX)
+					farblock.nearest_emergequeued_d = farblock.d;
+
+				if (allow_generate_now) {
+					if (would_be_blind_generate) {
+						num_blind_generate_requests++;
+					}
+				}
+			}
+farblock_mapblocks_iterate_break:
+
+			if (mbs_unknown + mbs_not_loaded == mbs_total) {
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": continue: not loaded"<<std::endl;*/
+
+				// None MapBlocks inside this FarBlock have not been loaded.
+				// Many of them are being queued for emerging, so just wait for
+				// them and don't go poking other FarBlocks.
+				return WMSSuggestion();
+			}
+
+			// Don't send blocks that have already been sent and have not been
+			// updated. Check this after the emerge queuing so that they have a
+			// chance of being loaded so that they can pass this check later.
+			std::map<WantedMapSend, time_t>::const_iterator
+					blocks_sent_i = client->m_blocks_sent.find(wms);
+			if (blocks_sent_i != client->m_blocks_sent.end()){
+				if (client->m_blocks_updated_since_last_send.count(wms) == 0) {
+					/*dstream<<"AutosendFar: "<<wms.describe()
+							<<": Already sent and not updated"<<std::endl;*/
+					continue;
+				}
+				time_t sent_time = blocks_sent_i->second;
+				if (sent_time + 2 > time(NULL)) {
+					/*dstream<<"AutosendFar: "<<wms.describe()
+							<<": Already sent; rate-limiting"<<std::endl;*/
+					continue;
+				}
+				/*dstream<<"AutosendFar: "<<wms.describe()
+						<<": Already sent but updated; allowing"<<std::endl;*/
+			}
+
+			// Suggest this block
+			WMSSuggestion wmss(wms);
+			wmss.is_fully_loaded = fully_loaded;
+			return wmss;
+		}
+
+		// Now reset i as we go to next d
+		farblock.i = 0;
+	}
+
+	// Nothing to suggest
+	return WMSSuggestion();
+}
+
+WMSSuggestion AutosendCycle::getNextBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)
+{
+	DSTACK(FUNCTION_NAME);
+
+	//dstream<<"AutosendCycle::getNextBlock()"<<std::endl;
+
+	if (disabled)
+		return WMSSuggestion();
+
+	// Get MapBlock and FarBlock suggestions
+
+	WMSSuggestion suggested_mb = suggestNextMapBlock(emerge);
+	WMSSuggestion suggested_fb = suggestNextFarBlock(emerge, far_map);
+
+	//dstream<<"suggested_mb = "<<suggested_mb.describe()<<std::endl;
+	//dstream<<"suggested_fb = "<<suggested_fb.describe()<<std::endl;
+
+	// Prioritize suggestions
+
+	std::vector<WMSSuggestion> suggestions;
+	if (suggested_mb.wms.type != WMST_INVALID)
+		suggestions.push_back(suggested_mb);
+	if (suggested_fb.wms.type != WMST_INVALID)
+		suggestions.push_back(suggested_fb);
+
+	if (suggestions.empty()) {
+		// Nothing to send or prioritize
+		return WMSSuggestion();
+	}
+
+	// Prioritize if there is more than one option
+	if (suggestions.size() > 1) {
+		v3s16 camera_np = floatToInt(camera_p, BS);
+		std::sort(suggestions.begin(), suggestions.end(),
+				WMSSPriority(camera_np, alg->m_far_weight));
+	}
+
+	// Take the most important one
+	WMSSuggestion wmss = suggestions[0];
+
+	//dstream<<"wmss = "<<wmss.describe()<<std::endl;
+
+	// Keep track of the distance of the closest block being sent (separetely
+	// for MapBlocks and FarBlocks)
+
+	if (wmss.wms.type == WMST_MAPBLOCK) {
+		if(mapblock.nearest_sendqueued_d == INT32_MAX)
+			mapblock.nearest_sendqueued_d = mapblock.d;
+		mapblock.nothing_to_send_timer = 0.0f;
+	}
+
+	if (wmss.wms.type == WMST_FARBLOCK) {
+		if(farblock.nearest_sendqueued_d == INT32_MAX)
+			farblock.nearest_sendqueued_d = farblock.d;
+		farblock.nothing_to_send_timer = 0.0f;
+	}
+
+	return wmss;
+}
+
+void AutosendCycle::Search::runTimers(float dtime)
+{
+	nothing_to_send_timer += dtime;
+	nothing_to_send_pause_timer -= dtime;
+}
+
+void AutosendCycle::Search::start(s16 max_send_distance_,
+		s16 fov_limit_activation_distance_)
+{
+	/*dstream<<"AutosendCycle::Search::start()"
+			<<": max_send_distance="<<max_send_distance_
+			<<", fov_limit_activation_distance="<<fov_limit_activation_distance_
+			<<std::endl;*/
+
+	max_send_distance = max_send_distance_; // Needed by finish()
+	fov_limit_activation_distance = fov_limit_activation_distance_;
+	i = 0;
+
+	// We will start from a radius that still has unsent MapBlocks
+	d_start = nearest_unsent_d >= 0 ? nearest_unsent_d : 0;
+	d = d_start;
+
+	//dstream<<"d_start="<<d_start<<std::endl;
+	//infostream<<"d_start="<<d_start<<std::endl;
+
+	// Don't loop very much at a time. This function is called each server tick
+	// so just a few steps will work fine (+2 is 3 steps per call).
+	d_max = 0;
+	if (d_start < 5)
+		d_max = d_start + 2;
+	else if (d_max < 8)
+		d_max = d_start + 1;
+	else
+		d_max = d_start; // These iterations start to be rather heavy
+
+	if (d_max > max_send_distance)
+		d_max = max_send_distance;
+
+	//dstream<<"d_max="<<d_max<<std::endl;
+
+	// Keep track of... things. We need these in order to figure out where to
+	// continue iterating on the next call to this function.
+	// TODO: Put these in the class
+	nearest_emergequeued_d = INT32_MAX;
+	nearest_emergefull_d = INT32_MAX;
+	nearest_sendqueued_d = INT32_MAX;
+}
+
+void AutosendCycle::Search::finish(bool enable_fov_toggle)
+{
+	/*infostream << "nearest_emergequeued_d = "<<nearest_emergequeued_d
+			<<", nearest_emergefull_d = "<<nearest_emergefull_d
+			<<", nearest_sendqueued_d = "<<nearest_sendqueued_d
+			<<std::endl;*/
+
+	// Because none of the things we queue for sending or emerging or anything
+	// will necessarily be sent or anything, next time we need to continue
+	// iterating from the closest radius of any of that happening so that we can
+	// check whether they were sent or emerged or otherwise handled.
+	s32 closest_required_re_check = INT32_MAX;
+	if (nearest_emergequeued_d < closest_required_re_check)
+		closest_required_re_check = nearest_emergequeued_d;
+	if (nearest_emergefull_d < closest_required_re_check)
+		closest_required_re_check = nearest_emergefull_d;
+	if (nearest_sendqueued_d < closest_required_re_check)
+		closest_required_re_check = nearest_sendqueued_d;
+
+	bool searched_full_range = false;
+	bool result_may_be_available_later_at_this_d = false;
+
+	if (closest_required_re_check != INT32_MAX) {
+		// We did something that requires a result to be checked later. Continue
+		// from that on the next time.
+		nearest_unsent_d = closest_required_re_check;
+		// If nothing has been sent in a moment, indicating that the emerge
+		// thread is not finding anything on disk anymore, caller should start a
+		// fresh pass without the FOV limit.
+		result_may_be_available_later_at_this_d = true;
+	} else if (d > max_send_distance) {
+		// We iterated all the way through to the end of the send radius, if you
+		// can believe that.
+		nearest_unsent_d = 0;
+		// Caller should do a second pass with FOV limiting disabled or start
+		// from the beginning after a short idle delay. (with FOV limiting
+		// enabled because nobody knows what the future holds.)
+		searched_full_range = true;
+	} else {
+		// Absolutely nothing interesting happened. Next time we will continue
+		// iterating from the next radius.
+		nearest_unsent_d = d;
+	}
+
+	// Trigger FOV limit removal in certain situations
+	if (result_may_be_available_later_at_this_d) {
+		/*dstream<<"CycleResult: Result may be available later at "
+				<<nearest_unsent_d<<std::endl;*/
+
+		// If nothing has been sent in a moment, indicating that the emerge
+		// thread is not finding anything on disk anymore, start a fresh
+		// pass without the FOV limit.
+		if (enable_fov_toggle && fov_limit_enabled &&
+				nothing_to_send_timer >= 3.0f) {
+			/*dstream<<"CycleResult: Nothing to send"
+					<<"; Disabling FOV limit"<<std::endl;*/
+
+			fov_limit_enabled = false;
+			// Have to be reset in order to not trigger this immediately again
+			nothing_to_send_timer = 0.0f;
+		}
+	} else if(searched_full_range) {
+		//dstream<<"CycleResult: Searched full range"<<std::endl;
+
+		// We iterated all the way through to the end of the send radius, if you
+		// can believe that.
+		if (enable_fov_toggle && fov_limit_enabled) {
+			/*dstream<<"CycleResult: Iterated all the way through"
+					<<"; Disabling FOV limit"<<std::endl;*/
+
+			// Do a second pass with FOV limiting disabled
+			fov_limit_enabled = false;
+		} else {
+			/*dstream<<"CycleResult: Initiating idle sleep"<<std::endl;*/
+
+			// Start from the beginning after a short idle delay, with FOV
+			// limiting enabled because nobody knows what the future holds.
+			fov_limit_enabled = true;
+			nothing_to_send_pause_timer = 2.0;
+		}
+	} else {
+		/*dstream<<"CycleResult: Continuing at "
+				<<nearest_unsent_d<<std::endl;*/
+	}
+}
+
+void AutosendCycle::finish()
+{
+	//dstream<<"AutosendCycle::finish()"<<std::endl;
+
+	if (disabled) {
+		// If disabled, none of our variables are even initialized
+		return;
+	}
+
+	bool enable_fov_toggle = (alg->m_fov != 0.0f);
+	mapblock.finish(enable_fov_toggle);
+	farblock.finish(enable_fov_toggle);
+}
+
+AutosendAlgorithm::AutosendAlgorithm(RemoteClient *client):
+	m_client(client),
+	m_cycle(new AutosendCycle()),
+	m_radius_map(0),
+	m_radius_far(0),
+	m_far_weight(8.0f),
+	m_fov(1.72f), // In radians
+	m_nearest_unsent_reset_timer(0.0)
+{}
+
+AutosendAlgorithm::~AutosendAlgorithm()
+{
+	delete m_cycle;
+}
+
+void AutosendAlgorithm::cycle(float dtime, ServerEnvironment *env)
+{
+	m_cycle->finish();
+
+	// Increment timers
+	m_cycle->mapblock.runTimers(dtime);
+	m_cycle->farblock.runTimers(dtime);
+	m_nearest_unsent_reset_timer += dtime;
+
+	m_cycle->start(this, m_client, env);
+}
+
+WMSSuggestion AutosendAlgorithm::getNextBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)
+{
+	return m_cycle->getNextBlock(emerge, far_map);
+}
+
+void AutosendAlgorithm::resetMapblockSearchRadius()
+{
+	m_cycle->mapblock.nearest_unsent_d = 0;
+	m_cycle->mapblock.i = 0;
+}
+
+std::string AutosendAlgorithm::describeStatus()
+{
+	return "(mapblock.nearest_unsent_d="+itos(m_cycle->mapblock.nearest_unsent_d)+", "
+			"farblock.nearest_unsent_d="+itos(m_cycle->farblock.nearest_unsent_d)+")";
+}
+
+/*
+	ClientInterface
+*/
 
 const char *ClientInterface::statenames[] = {
 	"Invalid",
@@ -46,228 +912,75 @@ const char *ClientInterface::statenames[] = {
 	"SudoMode",
 };
 
-
-
 std::string ClientInterface::state2Name(ClientState state)
 {
 	return statenames[state];
 }
 
-void RemoteClient::ResendBlockIfOnWire(v3s16 p)
+WMSSuggestion RemoteClient::getNextBlock(
+		EmergeManager *emerge, ServerFarMap *far_map)
 {
-	// if this block is on wire, mark it for sending again as soon as possible
-	if (m_blocks_sending.find(p) != m_blocks_sending.end()) {
-		SetBlockNotSent(p);
-	}
-}
-
-void RemoteClient::GetNextBlocks (
-		ServerEnvironment *env,
-		EmergeManager * emerge,
-		float dtime,
-		std::vector<PrioritySortedBlockTransfer> &dest)
-{
-	DSTACK(FUNCTION_NAME);
-
-
-	// Increment timers
-	m_nothing_to_send_pause_timer -= dtime;
-	m_nearest_unsent_reset_timer += dtime;
-
-	if(m_nothing_to_send_pause_timer >= 0)
-		return;
-
-	Player *player = env->getPlayer(peer_id);
-	// This can happen sometimes; clients and players are not in perfect sync.
-	if(player == NULL)
-		return;
-
-	// Won't send anything if already sending
-	if(m_blocks_sending.size() >= g_settings->getU16
-			("max_simultaneous_block_sends_per_client"))
+	// If the client has not indicated it supports the new algorithm, fill in
+	// autosend parameters and things should work fine
+	if (m_fallback_autosend_active)
 	{
-		//infostream<<"Not sending any blocks, Queue full."<<std::endl;
-		return;
-	}
+		s16 radius_map = g_settings->getS16("max_block_send_distance");
+		s16 radius_far = 0; // Old client does not understand FarBlocks
+		float far_weight = 8.0f; // Whatever non-zero
+		float fov = 1.72f; // Assume something (radians)
+		m_autosend.setParameters(radius_map, radius_far, far_weight, fov);
 
-	v3f playerpos = player->getPosition();
-	v3f playerspeed = player->getSpeed();
-	v3f playerspeeddir(0,0,0);
-	if(playerspeed.getLength() > 1.0*BS)
-		playerspeeddir = playerspeed / playerspeed.getLength();
-	// Predict to next block
-	v3f playerpos_predicted = playerpos + playerspeeddir*MAP_BLOCKSIZE*BS;
-
-	v3s16 center_nodepos = floatToInt(playerpos_predicted, BS);
-
-	v3s16 center = getNodeBlockPos(center_nodepos);
-
-	// Camera position and direction
-	v3f camera_pos = player->getEyePosition();
-	v3f camera_dir = v3f(0,0,1);
-	camera_dir.rotateYZBy(player->getPitch());
-	camera_dir.rotateXZBy(player->getYaw());
-
-	/*infostream<<"camera_dir=("<<camera_dir.X<<","<<camera_dir.Y<<","
-			<<camera_dir.Z<<")"<<std::endl;*/
-
-	/*
-		Get the starting value of the block finder radius.
-	*/
-
-	if(m_last_center != center)
-	{
-		m_nearest_unsent_d = 0;
-		m_last_center = center;
-	}
-
-	/*infostream<<"m_nearest_unsent_reset_timer="
-			<<m_nearest_unsent_reset_timer<<std::endl;*/
-
-	// Reset periodically to workaround for some bugs or stuff
-	if(m_nearest_unsent_reset_timer > 20.0)
-	{
-		m_nearest_unsent_reset_timer = 0;
-		m_nearest_unsent_d = 0;
-		//infostream<<"Resetting m_nearest_unsent_d for "
-		//		<<server->getPlayerName(peer_id)<<std::endl;
-	}
-
-	//s16 last_nearest_unsent_d = m_nearest_unsent_d;
-	s16 d_start = m_nearest_unsent_d;
-
-	//infostream<<"d_start="<<d_start<<std::endl;
-
-	u16 max_simul_sends_setting = g_settings->getU16
-			("max_simultaneous_block_sends_per_client");
-	u16 max_simul_sends_usually = max_simul_sends_setting;
-
-	/*
-		Check the time from last addNode/removeNode.
-
-		Decrease send rate if player is building stuff.
-	*/
-	m_time_from_building += dtime;
-	if(m_time_from_building < g_settings->getFloat(
-				"full_block_send_enable_min_time_from_building"))
-	{
-		max_simul_sends_usually
-			= LIMITED_MAX_SIMULTANEOUS_BLOCK_SENDS;
+		// Continue normally.
 	}
 
 	/*
-		Number of blocks sending + number of blocks selected for sending
+		Autosend
+
+		NOTE: All auto-sent stuff is considered higher priority than custom
+		transfers. If the client wants to get custom stuff quickly, it has to
+		disable autosend.
 	*/
-	u32 num_blocks_selected = m_blocks_sending.size();
+	WMSSuggestion wmss = m_autosend.getNextBlock(emerge, far_map);
+	WantedMapSend wms = wmss.wms;
+	if (wms.type != WMST_INVALID)
+		return wmss;
 
 	/*
-		next time d will be continued from the d from which the nearest
-		unsent block was found this time.
+		Handle map send queue as set by the client for custom map transfers
 
-		This is because not necessarily any of the blocks found this
-		time are actually sent.
+		// TODO: This needs rework
 	*/
-	s32 new_nearest_unsent_d = -1;
+	for (size_t i=0; i<m_map_send_queue.size(); i++) {
+		const WantedMapSend &wms = m_map_send_queue[i];
+		if (wms.type == WMST_MAPBLOCK) {
+			/*verbosestream << "Server: Client "<<peer_id<<" wants MapBlock ("
+					<<wms.p.X<<","<<wms.p.Y<<","<<wms.p.Z<<")"
+					<< std::endl;*/
 
-	const s16 full_d_max = g_settings->getS16("max_block_send_distance");
-	s16 d_max = full_d_max;
-	s16 d_max_gen = g_settings->getS16("max_block_generate_distance");
-
-	// Don't loop very much at a time
-	s16 max_d_increment_at_time = 2;
-	if(d_max > d_start + max_d_increment_at_time)
-		d_max = d_start + max_d_increment_at_time;
-
-	s32 nearest_emerged_d = -1;
-	s32 nearest_emergefull_d = -1;
-	s32 nearest_sent_d = -1;
-	//bool queue_is_full = false;
-
-	s16 d;
-	for(d = d_start; d <= d_max; d++) {
-		/*
-			Get the border/face dot coordinates of a "d-radiused"
-			box
-		*/
-		std::vector<v3s16> list = FacePositionCache::getFacePositions(d);
-
-		std::vector<v3s16>::iterator li;
-		for(li = list.begin(); li != list.end(); ++li) {
-			v3s16 p = *li + center;
-
-			/*
-				Send throttling
-				- Don't allow too many simultaneous transfers
-				- EXCEPT when the blocks are very close
-
-				Also, don't send blocks that are already flying.
-			*/
-
-			// Start with the usual maximum
-			u16 max_simul_dynamic = max_simul_sends_usually;
-
-			// If block is very close, allow full maximum
-			if(d <= BLOCK_SEND_DISABLE_LIMITS_MAX_D)
-				max_simul_dynamic = max_simul_sends_setting;
-
-			// Don't select too many blocks for sending
-			if (num_blocks_selected >= max_simul_dynamic) {
-				//queue_is_full = true;
-				goto queue_full_break;
-			}
+			// Do not go over-limit
+			if (blockpos_over_limit(wms.p))
+				continue;
 
 			// Don't send blocks that are currently being transferred
-			if (m_blocks_sending.find(p) != m_blocks_sending.end())
+			if (m_blocks_sending.find(wms) != m_blocks_sending.end())
 				continue;
 
-			/*
-				Do not go over-limit
-			*/
-			if (blockpos_over_limit(p))
-				continue;
-
-			// If this is true, inexistent block will be made from scratch
-			bool generate = d <= d_max_gen;
-
-			{
-				/*// Limit the generating area vertically to 2/3
-				if(abs(p.Y - center.Y) > d_max_gen - d_max_gen / 3)
-					generate = false;*/
-
-				// Limit the send area vertically to 1/2
-				if (abs(p.Y - center.Y) > full_d_max / 2)
+			// Don't send blocks that have already been sent, unless it has been
+			// updated
+			if (m_blocks_sent.find(wms) != m_blocks_sent.end()) {
+				if (m_blocks_updated_since_last_send.count(wms) == 0)
 					continue;
 			}
 
-			/*
-				Don't generate or send if not in sight
-				FIXME This only works if the client uses a small enough
-				FOV setting. The default of 72 degrees is fine.
-			*/
+			// If the MapBlock is not loaded, it will be queued to be loaded or
+			// generated. Otherwise it will be added to 'dest'.
 
-			float camera_fov = (72.0*M_PI/180) * 4./3.;
-			if(isBlockInSight(p, camera_pos, camera_dir, camera_fov, 10000*BS) == false)
-			{
-				continue;
-			}
+			const bool allow_generate = true;
 
-			/*
-				Don't send already sent blocks
-			*/
-			{
-				if(m_blocks_sent.find(p) != m_blocks_sent.end())
-				{
-					continue;
-				}
-			}
-
-			/*
-				Check if map has this block
-			*/
-			MapBlock *block = env->getMap().getBlockNoCreateNoEx(p);
+			MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(wms.p);
 
 			bool surely_not_found_on_disk = false;
-			bool block_is_invalid = false;
+			bool emerge_required = false;
 			if(block != NULL)
 			{
 				// Reset usage timer, this block will be of use in the future.
@@ -276,150 +989,181 @@ void RemoteClient::GetNextBlocks (
 				// Block is dummy if data doesn't exist.
 				// It means it has been not found from disk and not generated
 				if(block->isDummy())
-				{
 					surely_not_found_on_disk = true;
-				}
 
 				// Block is valid if lighting is up-to-date and data exists
 				if(block->isValid() == false)
-				{
-					block_is_invalid = true;
-				}
+					emerge_required = true;
 
-				if(block->isGenerated() == false)
-					block_is_invalid = true;
+				if(block->isGenerated() == false && allow_generate)
+					emerge_required = true;
 
-				/*
-					If block is not close, don't send it unless it is near
-					ground level.
+				// This check is disabled because it mis-guesses sea floors to
+				// not be worth transferring to the client, while they are.
+				/*if (d >= 4 && block->getDayNightDiff() == false)
+					continue;*/
+			}
 
-					Block is near ground level if night-time mesh
-					differs from day-time mesh.
-				*/
-				if(d >= 4)
-				{
-					if(block->getDayNightDiff() == false)
-						continue;
-				}
+			if(allow_generate == false && surely_not_found_on_disk == true) {
+				// NOTE: If we wanted to avoid generating new blocks based on
+				// some criterion, that check woould go here and we would call
+				// 'continue' if the block should not be generated.
+
+				// TODO: There needs to be some new way or limiting which
+				// positions are allowed to be generated, because we aren't
+				// going to look up the player's position and compare it with
+				// max_mapblock_generate_distance anymore. Maybe a configured set
+				// of allowed areas, or maybe a callback to Lua.
+
+				// NOTE: There may need to be a way to tell the client that this
+				// block will not be transferred to it no matter how nicely it
+				// asks. Otherwise the requested send queue is going to get
+				// filled up by these and less important blocks further away
+				// that happen to have been already generated will not transfer.
 			}
 
 			/*
-				If block has been marked to not exist on disk (dummy)
-				and generating new ones is not wanted, skip block.
+				If block does not exist, add it to the emerge queue.
 			*/
-			if(generate == false && surely_not_found_on_disk == true)
+			if(block == NULL || surely_not_found_on_disk || emerge_required)
 			{
-				// get next one.
+				bool allow_generate = true;
+				if (!emerge->enqueueBlockEmerge(peer_id, wms.p, allow_generate)) {
+					// EmergeThread's queue is full; maybe it's not full on the
+					// next time this is called.
+				}
+
+				// This block is not available now; hopefully it appears on some
+				// next call to this function.
 				continue;
 			}
 
-			/*
-				Add inexistent block to emerge queue.
-			*/
-			if(block == NULL || surely_not_found_on_disk || block_is_invalid)
-			{
-				if (emerge->enqueueBlockEmerge(peer_id, p, generate)) {
-					if (nearest_emerged_d == -1)
-						nearest_emerged_d = d;
-				} else {
-					if (nearest_emergefull_d == -1)
-						nearest_emergefull_d = d;
-					goto queue_full_break;
-				}
+			// The block is available
+			return wms;
+		}
+		if (wms.type == WMST_FARBLOCK) {
+			/*verbosestream << "Server: Client "<<peer_id<<" wants FarBlock ("
+					<<wms.p.X<<","<<wms.p.Y<<","<<wms.p.Z<<")"
+					<< std::endl;*/
 
-				// get next one.
+			// Do not go over-limit
+			if (blockpos_over_limit(wms.p))
 				continue;
+
+			// Don't send blocks that are currently being transferred
+			if (m_blocks_sending.find(wms) != m_blocks_sending.end())
+				continue;
+
+			// Don't send blocks that have already been sent
+			std::map<WantedMapSend, time_t>::const_iterator
+					blocks_sent_i = m_blocks_sent.find(wms);
+			if (blocks_sent_i != m_blocks_sent.end()){
+				if (m_blocks_updated_since_last_send.count(wms) == 0) {
+					/*dstream<<"RemoteClient: Already sent and not updated: "
+							<<"("<<wms.p.X<<","<<wms.p.Y<<","<<wms.p.Z<<")"
+							<<std::endl;*/
+					continue;
+				}
+				time_t sent_time = blocks_sent_i->second;
+				if (sent_time + 5 > time(NULL)) {
+					/*dstream<<"RemoteClient: Already sent; rate-limiting: "
+							<<"("<<wms.p.X<<","<<wms.p.Y<<","<<wms.p.Z<<")"
+							<<std::endl;*/
+					continue;
+				}
+				dstream<<"RemoteClient: Already sent but updated; allowing re-send: "
+						<<"("<<wms.p.X<<","<<wms.p.Y<<","<<wms.p.Z<<")"
+						<<std::endl;
 			}
 
-			if(nearest_sent_d == -1)
-				nearest_sent_d = d;
+			// TODO: Stay determined at which FarBlock to load so that we don't
+			//       load them all at the same time in weird stripes
 
-			/*
-				Add block to send queue
-			*/
-			PrioritySortedBlockTransfer q((float)d, p, peer_id);
+			// TODO: Use modification counter?
 
-			dest.push_back(q);
+			// TODO: Check if data for this is available and if not, possibly
+			//       request an emerge of the required area
 
-			num_blocks_selected += 1;
-		}
-	}
-queue_full_break:
-
-	// If nothing was found for sending and nothing was queued for
-	// emerging, continue next time browsing from here
-	if(nearest_emerged_d != -1){
-		new_nearest_unsent_d = nearest_emerged_d;
-	} else if(nearest_emergefull_d != -1){
-		new_nearest_unsent_d = nearest_emergefull_d;
-	} else {
-		if(d > g_settings->getS16("max_block_send_distance")){
-			new_nearest_unsent_d = 0;
-			m_nothing_to_send_pause_timer = 2.0;
-		} else {
-			if(nearest_sent_d != -1)
-				new_nearest_unsent_d = nearest_sent_d;
-			else
-				new_nearest_unsent_d = d;
+			return wms;
 		}
 	}
 
-	if(new_nearest_unsent_d != -1)
-		m_nearest_unsent_d = new_nearest_unsent_d;
+	return WantedMapSend();
 }
 
-void RemoteClient::GotBlock(v3s16 p)
+void RemoteClient::cycleAutosendAlgorithm(float dtime)
 {
-	if (m_blocks_modified.find(p) == m_blocks_modified.end()) {
-		if (m_blocks_sending.find(p) != m_blocks_sending.end())
-			m_blocks_sending.erase(p);
-		else
+	m_autosend.cycle(dtime, m_env);
+}
+
+void RemoteClient::GotBlock(const WantedMapSend &wms)
+{
+	if (m_blocks_sending.find(wms) != m_blocks_sending.end()) {
+		m_blocks_sent[wms] = m_blocks_sending[wms];
+		m_blocks_sending.erase(wms);
+	} else {
 			m_excess_gotblocks++;
 
-		m_blocks_sent.insert(p);
 	}
 }
 
-void RemoteClient::SentBlock(v3s16 p)
+void RemoteClient::SendingBlock(const WantedMapSend &wms)
 {
-	if (m_blocks_modified.find(p) != m_blocks_modified.end())
-		m_blocks_modified.erase(p);
+	assert(!m_blocks_sending.count(wms) ||
+			m_blocks_updated_while_sending.count(wms) &&
+			"Block shouldn't be re-sent if it is being sent and was not"
+			" updated while being sent");
 
-	if(m_blocks_sending.find(p) == m_blocks_sending.end())
-		m_blocks_sending[p] = 0.0;
-	else
-		infostream<<"RemoteClient::SentBlock(): Sent block"
-				" already in m_blocks_sending"<<std::endl;
+	m_blocks_sending[wms] = time(NULL);
+	m_blocks_updated_since_last_send.erase(wms);
+	m_blocks_updated_while_sending.erase(wms);
 }
 
-void RemoteClient::SetBlockNotSent(v3s16 p)
+void RemoteClient::SetBlockUpdated(const WantedMapSend &wms)
 {
-	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer = 0;
+	//dstream<<"SetBlockUpdated: "<<wms.describe()<<std::endl;
 
-	if(m_blocks_sending.find(p) != m_blocks_sending.end())
-		m_blocks_sending.erase(p);
-	if(m_blocks_sent.find(p) != m_blocks_sent.end())
-		m_blocks_sent.erase(p);
-	m_blocks_modified.insert(p);
+	// Reset autosend's search radius but only if it's a MapBlock
+	if (wms.type == WMST_MAPBLOCK) {
+		m_autosend.resetMapblockSearchRadius();
+	}
+
+	m_blocks_updated_since_last_send.insert(wms);
+
+	if (m_blocks_sending.count(wms)) {
+		m_blocks_updated_while_sending.insert(wms);
+	}
 }
 
-void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
+void RemoteClient::SetMapBlockUpdated(v3s16 p)
 {
-	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer = 0;
+	SetBlockUpdated(WantedMapSend(WMST_MAPBLOCK, p));
 
+	// Also set the corresponding FarBlock not sent
+	v3s16 farblock_p = getContainerPos(p, FMP_SCALE);
+	SetBlockUpdated(WantedMapSend(WMST_FARBLOCK, farblock_p));
+
+	/*dstream<<"RemoteClient: now not sent: MB"<<"("<<p.X<<","<<p.Y<<","<<p.Z<<")"
+			<<" FB"<<"("<<farblock_p.X<<","<<farblock_p.Y<<","<<farblock_p.Z<<")"
+			<<std::endl;*/
+}
+
+void RemoteClient::SetMapBlocksUpdated(std::map<v3s16, MapBlock*> &blocks)
+{
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = blocks.begin();
 			i != blocks.end(); ++i)
 	{
 		v3s16 p = i->first;
-		m_blocks_modified.insert(p);
+		SetMapBlockUpdated(p);
+	}
+}
 
-		if(m_blocks_sending.find(p) != m_blocks_sending.end())
-			m_blocks_sending.erase(p);
-		if(m_blocks_sent.find(p) != m_blocks_sent.end())
-			m_blocks_sent.erase(p);
+void RemoteClient::ResendBlockIfOnWire(const WantedMapSend &wms)
+{
+	// if this block is on wire, mark it for sending again as soon as possible
+	if (m_blocks_sending.find(wms) != m_blocks_sending.end()) {
+		SetBlockUpdated(wms);
 	}
 }
 
@@ -803,7 +1547,7 @@ void ClientInterface::CreateClient(u16 peer_id)
 	if(n != m_clients.end()) return;
 
 	// Create client
-	RemoteClient *client = new RemoteClient();
+	RemoteClient *client = new RemoteClient(m_env);
 	client->peer_id = peer_id;
 	m_clients[client->peer_id] = client;
 }

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <sstream>
+#include <stdint.h>
 
 #include "clientiface.h"
 #include "util/numeric.h"

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -213,6 +213,13 @@ void AutosendCycle::start(AutosendAlgorithm *alg_,
 		alg->m_cycle->farblock.nearest_unsent_d = 0;
 		alg->m_last_focus_point = focus_point;
 	}
+	// If camera has turned considerably, reset radius value for iterating from
+	// zero again (has to be done because of FOV dependence of some things)
+	if (alg->m_last_camera_dir.dotProduct(camera_dir) < 0.8f) {
+		alg->m_cycle->mapblock.nearest_unsent_d = 0;
+		alg->m_cycle->farblock.nearest_unsent_d = 0;
+		alg->m_last_camera_dir = camera_dir;
+	}
 
 	// Get some settings
 	max_simul_sends_setting =

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -241,11 +241,13 @@ public:
 	WMSSuggestion getNextBlock(EmergeManager *emerge, ServerFarMap *far_map);
 
 	void setParameters(s16 radius_map, s16 radius_far, float far_weight,
-			float fov) {
+			float fov, u32 max_total_mapblocks, u32 max_total_farblocks) {
 		m_radius_map = radius_map;
 		m_radius_far = radius_far;
 		m_far_weight = far_weight;
 		m_fov = fov;
+		m_max_total_mapblocks = max_total_mapblocks;
+		m_max_total_farblocks = max_total_farblocks;
 	}
 
 	// If something is modified near a player, this should probably be called so
@@ -262,6 +264,8 @@ private:
 	s16 m_radius_far; // Updated by the client; 0 disables autosend.
 	float m_far_weight; // Updated by the client.
 	float m_fov; // Updated by the client; 0 disables FOV limit.
+	u32 m_max_total_mapblocks;
+	u32 m_max_total_farblocks;
 	v3s16 m_last_focus_point;
 	v3f m_last_camera_dir;
 	float m_nearest_unsent_reset_timer;
@@ -355,9 +359,10 @@ public:
 	}
 
 	void setAutosendParameters(s16 radius_map, s16 radius_far, float far_weight,
-			float fov)
+			float fov, u32 max_total_mapblocks, u32 max_total_farblocks)
 	{
-		m_autosend.setParameters(radius_map, radius_far, far_weight, fov);
+		m_autosend.setParameters(radius_map, radius_far, far_weight, fov,
+				max_total_mapblocks, max_total_farblocks);
 
 		// Disable fallback algorithm
 		m_fallback_autosend_active = false;
@@ -374,7 +379,8 @@ public:
 	void PrintInfo(std::ostream &o)
 	{
 		o<<"RemoteClient "<<peer_id<<": "
-				<<"m_blocks_sent.size()="<<m_blocks_sent.size()
+				<<"m_mapblocks_sent.size()="<<m_mapblocks_sent.size()
+				<<", m_farblocks_sent.size()="<<m_farblocks_sent.size()
 				<<", m_blocks_sending.size()="<<m_blocks_sending.size()
 				<<", m_excess_gotblocks="<<m_excess_gotblocks
 				<<", m_autosend.describeStatus()="<<m_autosend.describeStatus()
@@ -462,7 +468,9 @@ private:
 		- Value is timestamp when block was sent. It is used for rate-limiting
 		  updates.
 	*/
-	std::map<WantedMapSend, time_t> m_blocks_sent;
+	//std::map<WantedMapSend, time_t> m_blocks_sent;
+	std::map<v3s16, time_t> m_mapblocks_sent;
+	std::map<v3s16, time_t> m_farblocks_sent;
 
 	/*
 		Blocks that are currently on the line.

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -263,6 +263,7 @@ private:
 	float m_far_weight; // Updated by the client; 0 is invalid.
 	float m_fov; // Updated by the client; 0 disables FOV limit.
 	v3s16 m_last_focus_point;
+	v3f m_last_camera_dir;
 	float m_nearest_unsent_reset_timer;
 
 	friend struct AutosendCycle;

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -251,7 +251,7 @@ public:
 	// If something is modified near a player, this should probably be called so
 	// that it gets sent as quickly as possible while being prioritized
 	// correctly
-	void resetMapblockSearchRadius();
+	void resetMapblockSearchRadius(const v3s16 &mb_p);
 
 	std::string describeStatus();
 

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -260,7 +260,7 @@ private:
 	AutosendCycle *m_cycle;
 	s16 m_radius_map; // Updated by the client; 0 disables autosend.
 	s16 m_radius_far; // Updated by the client; 0 disables autosend.
-	float m_far_weight; // Updated by the client; 0 is invalid.
+	float m_far_weight; // Updated by the client.
 	float m_fov; // Updated by the client; 0 disables FOV limit.
 	v3s16 m_last_focus_point;
 	v3f m_last_camera_dir;

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -54,6 +54,8 @@ struct MapDrawControl
 class Client;
 class ITextureSource;
 
+struct DrawListUpdate;
+
 /*
 	ClientMap
 	
@@ -120,6 +122,7 @@ public:
 	void getBlocksInViewRange(v3s16 cam_pos_nodes, 
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
 	void updateDrawList(video::IVideoDriver* driver);
+	void updateDrawListImmediately(video::IVideoDriver* driver);
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
 	int getBackgroundBrightness(float max_d, u32 daylight_factor,
@@ -147,6 +150,8 @@ private:
 	f32 m_camera_fov;
 	v3s16 m_camera_offset;
 
+	DrawListUpdate *m_update;
+
 	std::map<v3s16, MapBlock*> m_drawlist;
 	
 	bool m_cache_trilinear_filter;
@@ -156,6 +161,8 @@ private:
 	// Fetch suggestion algorithm
 	s16 m_mapblocks_exist_up_to_d;
 	s16 m_mapblocks_exist_up_to_d_reset_counter;
+
+	friend struct DrawListUpdate;
 };
 
 #endif

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -34,7 +34,8 @@ struct MapDrawControl
 		wanted_max_blocks(0),
 		blocks_drawn(0),
 		blocks_would_have_drawn(0),
-		farthest_drawn(0)
+		farthest_drawn(0),
+		num_blocks_dont_exist_but_probably_should_be_requested_from_server(0)
 	{
 	}
 	// Overrides limits by drawing everything
@@ -49,6 +50,9 @@ struct MapDrawControl
 	u32 blocks_would_have_drawn;
 	// Distance to the farthest block drawn
 	float farthest_drawn;
+	// The maximum-number-of-blocks value told to the server is floated up by
+	// this value so that new areas can be received
+	u32 num_blocks_dont_exist_but_probably_should_be_requested_from_server;
 };
 
 class Client;
@@ -94,6 +98,11 @@ public:
 		m_camera_offset = offset;
 	}
 
+	const MapDrawControl& getMapDrawControl()
+	{
+		return m_control;
+	}
+
 	/*
 		Forcefully get a sector from somewhere
 	*/
@@ -121,8 +130,12 @@ public:
 	
 	void getBlocksInViewRange(v3s16 cam_pos_nodes, 
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
+	void getBlocksInCriticalViewRange(v3s16 cam_pos_nodes, 
+		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
+
 	void updateDrawList(video::IVideoDriver* driver);
 	void updateDrawListImmediately(video::IVideoDriver* driver);
+
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 
 	int getBackgroundBrightness(float max_d, u32 daylight_factor,

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -130,12 +130,11 @@ public:
 	// For debug printing
 	virtual void PrintInfo(std::ostream &out);
 	
-	// Check if sector was drawn on last render()
-	bool sectorWasDrawn(v2s16 p)
-	{
-		return (m_last_drawn_sectors.find(p) != m_last_drawn_sectors.end());
-	}
-	
+	std::vector<v3s16> suggestMapBlocksToFetch(v3s16 camera_p,
+			size_t wanted_num_results);
+	s16 suggestAutosendMapblocksRadius(); // Result in MapBlocks
+	float suggestAutosendFov();
+
 private:
 	Client *m_client;
 	
@@ -150,11 +149,13 @@ private:
 
 	std::map<v3s16, MapBlock*> m_drawlist;
 	
-	std::set<v2s16> m_last_drawn_sectors;
-
 	bool m_cache_trilinear_filter;
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
+
+	// Fetch suggestion algorithm
+	s16 m_mapblocks_exist_up_to_d;
+	s16 m_mapblocks_exist_up_to_d_reset_counter;
 };
 
 #endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -80,6 +80,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // the main loop (related to TempMods and day/night)
 //#define MAP_BLOCKSIZE 32
 
+// FarBlock size in MapBlocks in every dimension. This is hardcoded too so that
+// caching and networking can be done efficiently as no conversions are needed.
+#define FMP_SCALE 8
+
 /*
     Old stuff that shouldn't be hardcoded
 */

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -66,6 +66,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_camera_mode", "KEY_F7");
 	settings->setDefault("keymap_increase_viewing_range_min", "+");
 	settings->setDefault("keymap_decrease_viewing_range_min", "-");
+	settings->setDefault("keymap_far_range_modifier", "KEY_LCONTROL");
+	settings->setDefault("keymap_toggle_far_map_visibility", "");
 	settings->setDefault("enable_build_where_you_stand", "false" );
 	settings->setDefault("3d_mode", "none");
 	settings->setDefault("3d_paralax_strength", "0.025");
@@ -183,6 +185,12 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_minimap", "true");
 	settings->setDefault("minimap_shape_round", "true");
 	settings->setDefault("minimap_double_scan_height", "true");
+
+	settings->setDefault("enable_far_map", "true");
+	settings->setDefault("far_map_range", "500");
+	settings->setDefault("far_map_allow_generate", "false");
+	settings->setDefault("far_map_far_weight", "4.0");
+	settings->setDefault("far_map_atlas_node_resolution", "8");
 
 	settings->setDefault("curl_timeout", "5000");
 	settings->setDefault("curl_parallel_limit", "8");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -189,7 +189,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_far_map", "true");
 	settings->setDefault("far_map_range", "500");
 	settings->setDefault("far_map_allow_generate", "false");
-	settings->setDefault("far_map_far_weight", "4.0");
+	settings->setDefault("far_map_far_weight", "0.0");
 	settings->setDefault("far_map_atlas_node_resolution", "8");
 
 	settings->setDefault("curl_timeout", "5000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -290,8 +290,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
 	settings->setDefault("emergequeue_limit_total", "256");
-	settings->setDefault("emergequeue_limit_diskonly", "32");
-	settings->setDefault("emergequeue_limit_generate", "32");
+	settings->setDefault("emergequeue_limit_diskonly", "64");
+	settings->setDefault("emergequeue_limit_generate", "16");
 	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure.enable_security", "false");
 	settings->setDefault("secure.trusted_mods", "");

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -117,12 +117,14 @@ public:
 	void stopThreads();
 	bool isRunning();
 
+	// Returns false if queue is full
 	bool enqueueBlockEmerge(
 		u16 peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
 		bool ignore_queue_limits=false);
 
+	// Returns false if queue is full
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,
 		u16 peer_id,
@@ -160,7 +162,7 @@ private:
 
 	// Requires m_queue_mutex held
 	EmergeThread *getOptimalThread();
-
+	// Returns false if queue is full
 	bool pushBlockEmergeData(
 		v3s16 pos,
 		u16 peer_requested,

--- a/src/environment.h
+++ b/src/environment.h
@@ -50,6 +50,7 @@ class ITextureSource;
 class IGameDef;
 class Map;
 class ServerMap;
+class FarMap;
 class ClientMap;
 class GameScripting;
 class Player;

--- a/src/far_map.cpp
+++ b/src/far_map.cpp
@@ -1,0 +1,1776 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "far_map.h"
+#include "constants.h"
+#include "settings.h"
+#include "mapblock_mesh.h" // MeshCollector
+#include "mesh.h" // translateMesh
+#include "util/numeric.h" // getContainerPos
+#include "client.h" // For use of Client's IGameDef interface
+#include "profiler.h"
+#include "serialization.h" // decompressZlib
+#include "util/atlas.h"
+#include "util/serialize.h"
+#include "irrlichttypes_extrabloated.h"
+#include <IMaterialRenderer.h>
+
+#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
+
+/*
+	FarBlockBasicParameters
+*/
+
+FarBlockBasicParameters::FarBlockBasicParameters(v3s16 p, v3s16 divs_per_mb):
+	p(p),
+	divs_per_mb(divs_per_mb)
+{
+	// Block's effective origin in FarNodes based on divs_per_mb
+	dp00 = v3s16(
+		p.X * FMP_SCALE * divs_per_mb.X,
+		p.Y * FMP_SCALE * divs_per_mb.Y,
+		p.Z * FMP_SCALE * divs_per_mb.Z
+	);
+
+	// Effective size of content in FarNodes based on divs_per_mb in global
+	// coordinates
+	effective_size = v3s16(
+			FMP_SCALE * divs_per_mb.X,
+			FMP_SCALE * divs_per_mb.Y,
+			FMP_SCALE * divs_per_mb.Z);
+
+	v3s16 edp0 = dp00;
+	v3s16 edp1 = edp0 + effective_size - v3s16(1,1,1); // Inclusive
+
+	effective_area = VoxelArea(edp0, edp1);
+
+	// One extra FarNode layer per edge as required by mesh generation
+	content_size = effective_size + v3s16(2,2,2);
+
+	// Min and max edge of content (one extra FarNode layer per edge as
+	// required by mesh generation)
+	v3s16 dp0 = dp00 - v3s16(1,1,1);
+	v3s16 dp1 = dp0 + content_size - v3s16(1,1,1); // Inclusive
+
+	content_area = VoxelArea(dp0, dp1);
+}
+
+/*
+	FarBlock
+*/
+
+FarBlock::FarBlock(v3s16 p, v3s16 divs_per_mb):
+	FarBlockBasicParameters(p, divs_per_mb),
+	is_culled_by_server(false),
+	load_in_progress_on_server(false),
+	refresh_from_server_counter(0),
+	crude_mesh(NULL),
+	fine_mesh(NULL),
+	generating_mesh(false),
+	mesh_is_outdated(false),
+	mesh_is_empty(false)
+{
+}
+
+FarBlock::~FarBlock()
+{
+	if(crude_mesh)
+		crude_mesh->drop();
+
+	unloadFineMesh();
+	unloadMapblockMeshes();
+}
+
+void FarBlock::unloadFineMesh()
+{
+	if (!fine_mesh)
+		return;
+	fine_mesh->drop();
+	fine_mesh = NULL;
+}
+
+void FarBlock::unloadMapblockMeshes()
+{
+	for (size_t i=0; i<mapblock_meshes.size(); i++) {
+		if (!mapblock_meshes[i])
+			continue;
+		mapblock_meshes[i]->drop();
+		mapblock_meshes[i] = NULL;
+	}
+	for (size_t i=0; i<mapblock2_meshes.size(); i++) {
+		if (!mapblock2_meshes[i])
+			continue;
+		mapblock2_meshes[i]->drop();
+		mapblock2_meshes[i] = NULL;
+	}
+	mapblock_meshes.clear();
+	mapblock2_meshes.clear();
+}
+
+FarMeshLevel FarBlock::getCurrentMeshLevel()
+{
+	if (!mapblock_meshes.empty() && !mapblock2_meshes.empty() && fine_mesh)
+		return FML_FINE_AND_SMALL;
+	if (fine_mesh)
+		return FML_FINE;
+	if (!mesh_is_empty)
+		return FML_CRUDE;
+	return FML_NONE;
+}
+
+void FarBlock::updateCameraOffset(v3s16 camera_offset)
+{
+	if (camera_offset == current_camera_offset)
+		return;
+
+	if (crude_mesh) {
+		translateMesh(crude_mesh,
+				intToFloat(current_camera_offset-camera_offset, BS));
+	}
+
+	if (fine_mesh) {
+		translateMesh(fine_mesh,
+				intToFloat(current_camera_offset-camera_offset, BS));
+
+		for (size_t i=0; i<mapblock_meshes.size(); i++) {
+			if (!mapblock_meshes[i])
+				continue;
+			translateMesh(mapblock_meshes[i],
+					intToFloat(current_camera_offset-camera_offset, BS));
+		}
+		for (size_t i=0; i<mapblock2_meshes.size(); i++) {
+			if (!mapblock2_meshes[i])
+				continue;
+			translateMesh(mapblock2_meshes[i],
+					intToFloat(current_camera_offset-camera_offset, BS));
+		}
+	}
+
+	current_camera_offset = camera_offset;
+}
+
+void FarBlock::resetCameraOffset(v3s16 camera_offset)
+{
+	current_camera_offset = v3s16(0, 0, 0);
+	updateCameraOffset(camera_offset);
+}
+
+std::string analyze_far_block(FarBlock *b)
+{
+	if (b == NULL)
+		return "NULL";
+	std::string s = "["+analyze_far_block(
+			b->p, b->content, b->content_area, b->effective_area);
+	s += ", is_culled_by_server="+itos(b->is_culled_by_server);
+	s += ", load_in_progress_on_server="+itos(b->load_in_progress_on_server);
+	s += ", generating_mesh="+itos(b->generating_mesh);
+	s += ", mesh_is_outdated="+itos(b->mesh_is_outdated);
+	s += ", mesh_is_empty="+itos(b->mesh_is_empty);
+	return s+"]";
+}
+
+/*
+	FarSector
+*/
+
+FarSector::FarSector(v2s16 p):
+	p(p)
+{
+}
+
+FarSector::~FarSector()
+{
+	for (std::map<s16, FarBlock*>::iterator i = blocks.begin();
+			i != blocks.end(); i++) {
+		delete i->second;
+	}
+}
+
+FarBlock* FarSector::getBlock(s16 y)
+{
+	std::map<s16, FarBlock*>::iterator i = blocks.find(y);
+	if(i != blocks.end())
+		return i->second;
+	return NULL;
+}
+
+FarBlock* FarSector::getOrCreateBlock(s16 y, v3s16 divs_per_mb)
+{
+	std::map<s16, FarBlock*>::iterator i = blocks.find(y);
+	if(i != blocks.end())
+		return i->second;
+	v3s16 p3d(p.X, y, p.Y);
+	FarBlock *b = new FarBlock(p3d, divs_per_mb);
+	blocks[y] = b;
+	return b;
+}
+
+/*
+	FarBlockMeshGenerateTask
+*/
+
+FarBlockMeshGenerateTask::FarBlockMeshGenerateTask(
+		FarMap *far_map, const FarBlock &source_block,
+		FarMeshLevel level):
+	far_map(far_map),
+	block(source_block),
+	level(level)
+{
+	// We don't want to deal with whatever mesh the block was currently holding;
+	// set things to NULL so that FarBlock's destructor will not drop the
+	// original contents and we can store our results in it.
+	block.fine_mesh = NULL;
+	block.crude_mesh = NULL;
+	for (size_t i=0; i<block.mapblock_meshes.size(); i++) {
+		block.mapblock_meshes[i] = NULL;
+	}
+	for (size_t i=0; i<block.mapblock2_meshes.size(); i++) {
+		block.mapblock2_meshes[i] = NULL;
+	}
+}
+
+FarBlockMeshGenerateTask::~FarBlockMeshGenerateTask()
+{
+}
+
+static void add_face(MeshCollector *collector,
+		const FarNode &n, const v3s16 &p,
+		const FarNode &n2, s16 dir_x, s16 dir_y, s16 dir_z,
+		const std::vector<FarNode> &data,
+		const VoxelArea &data_area,
+		const v3s16 &divs_per_mb,
+		const FarMap *far_map)
+{
+	ITextureSource *tsrc = far_map->client->getTextureSource();
+	//IShaderSource *ssrc = far_map->client->getShaderSource();
+	INodeDefManager *ndef = far_map->client->getNodeDefManager();
+
+	static const u16 indices[] = {0,1,2,2,3,0};
+
+	v3s16 dir(dir_x, dir_y, dir_z);
+	v3s16 vertex_dirs[4];
+	getNodeVertexDirs(dir, vertex_dirs);
+
+	// This is the size of one FarNode (without BS being factored in)
+	v3f scale(
+		MAP_BLOCKSIZE / divs_per_mb.X,
+		MAP_BLOCKSIZE / divs_per_mb.Y,
+		MAP_BLOCKSIZE / divs_per_mb.Z
+	);
+
+	v3f pf(
+		(scale.X * p.X + scale.X/2 - 0.5) * BS,
+		(scale.Y * p.Y + scale.Y/2 - 0.5) * BS,
+		(scale.Z * p.Z + scale.Z/2 - 0.5) * BS
+	);
+
+	v3f vertex_pos[4];
+	for(u16 i=0; i<4; i++)
+	{
+		vertex_pos[i] = v3f(
+			BS / 2 * vertex_dirs[i].X,
+			BS / 2 * vertex_dirs[i].Y,
+			BS / 2 * vertex_dirs[i].Z
+		);
+		vertex_pos[i].X *= scale.X;
+		vertex_pos[i].Y *= scale.Y;
+		vertex_pos[i].Z *= scale.Z;
+		vertex_pos[i] += pf;
+	}
+
+	v3f normal(dir.X, dir.Y, dir.Z);
+
+	u8 alpha = 255;
+
+	u8 selected_light = n2.id != CONTENT_IGNORE ? n2.light : n.light;
+	u8 light_day_4 = selected_light & 0x0f;
+	u8 light_night_4 = (selected_light & 0xf0) >> 4;
+	u8 light_day_8 = decode_light(light_day_4);
+	u8 light_night_8 = decode_light(light_night_4);
+	// Both lightbanks as 16-bit values from decode_light() as produced by
+	// getFaceLight (day | (night << 8))
+	u16 light_encoded_16 = (light_day_8) | (light_night_8<<8);
+	//u16 light_encoded_16 = (255) | (255<<8);
+	// Light produced by the node itself
+	u8 light_source = 0;
+
+	// Get texture from texture atlas
+	u8 face = dir.Y == 1 ? 0 : dir.Y == -1 ? 1 : 2;
+	bool crude = (divs_per_mb.X == 1);
+	const atlas::AtlasSegmentCache *asc =
+			far_map->atlas.getNode(n.id, face, crude);
+	if (!asc) {
+		const ContentFeatures &f = ndef->get(n.id);
+		assert(f.tiledef[0].name == "" && "All nodes that have a texture should"
+				" be found in FarMap's atlas");
+		return; // Makes no faces
+	}
+	assert(asc->texture_pp);
+	assert(*asc->texture_pp);
+
+	// Texture coordinates
+	float x0 = asc->coord0.X;
+	float y0 = asc->coord0.Y;
+	float x1 = asc->coord1.X;
+	float y1 = asc->coord1.Y;
+
+	TileSpec t;
+	t.texture_id = 0; // atlas::AtlasRegistry doesn't provide this
+	t.texture = *asc->texture_pp;
+	t.alpha = alpha;
+	t.material_type = TILE_MATERIAL_BASIC;
+
+	if (far_map->config_enable_shaders) {
+		t.shader_id = far_map->farblock_shader_id;
+		bool normalmap_present = false;
+		t.flags_texture = tsrc->getShaderFlagsTexture(normalmap_present);
+	}
+
+	// Finally create the vertices that we have been preparing for
+	video::S3DVertex vertices[4];
+	vertices[0] = video::S3DVertex(vertex_pos[0], normal,
+			MapBlock_LightColor(alpha, light_encoded_16, light_source),
+			core::vector2d<f32>(x1, y1));
+	vertices[1] = video::S3DVertex(vertex_pos[1], normal,
+			MapBlock_LightColor(alpha, light_encoded_16, light_source),
+			core::vector2d<f32>(x0, y1));
+	vertices[2] = video::S3DVertex(vertex_pos[2], normal,
+			MapBlock_LightColor(alpha, light_encoded_16, light_source),
+			core::vector2d<f32>(x0, y0));
+	vertices[3] = video::S3DVertex(vertex_pos[3], normal,
+			MapBlock_LightColor(alpha, light_encoded_16, light_source),
+			core::vector2d<f32>(x1, y0));
+
+	collector->append(t, vertices, 4, indices, 6);
+}
+
+static int get_solidness(const ContentFeatures &f)
+{
+	if (f.solidness != 0)
+		return f.solidness;
+	if (f.drawtype == NDT_NODEBOX)
+		return 1;
+	if (f.drawtype == NDT_MESH)
+		return 1;
+	if (f.drawtype == NDT_LIQUID)
+		return 1;
+	if (f.drawtype == NDT_FLOWINGLIQUID)
+		return 1;
+	return f.visual_solidness;
+}
+
+static void extract_faces(MeshCollector *collector,
+		const std::vector<FarNode> &data,
+		const VoxelArea &data_area, const VoxelArea &gen_area,
+		const v3s16 &divs_per_mb,
+		const FarMap *far_map,
+		size_t *num_faces_added)
+{
+	// At least one extra node at each edge is required. This enables speed
+	// optimization of lookups in this algorithm.
+	assert(data_area.MinEdge.X <= gen_area.MinEdge.X - 1);
+	assert(data_area.MinEdge.Y <= gen_area.MinEdge.Y - 1);
+	assert(data_area.MinEdge.Z <= gen_area.MinEdge.Z - 1);
+	assert(data_area.MaxEdge.X >= gen_area.MaxEdge.X + 1);
+	assert(data_area.MaxEdge.Y >= gen_area.MaxEdge.Y + 1);
+	assert(data_area.MaxEdge.Z >= gen_area.MaxEdge.Z + 1);
+
+	INodeDefManager *ndef = far_map->client->getNodeDefManager();
+
+	v3s16 data_extent = data_area.getExtent();
+
+	v3s16 p000;
+	for (p000.Y=gen_area.MinEdge.Y-1; p000.Y<=gen_area.MaxEdge.Y; p000.Y++)
+	for (p000.X=gen_area.MinEdge.X-1; p000.X<=gen_area.MaxEdge.X; p000.X++)
+	for (p000.Z=gen_area.MinEdge.Z-1; p000.Z<=gen_area.MaxEdge.Z; p000.Z++)
+	{
+		size_t i000 = data_area.index(p000);
+		const FarNode &n000 = data[i000];
+		const FarNode &n001 = data[data_area.added_z(data_extent, i000, 1)];
+		const FarNode &n010 = data[data_area.added_y(data_extent, i000, 1)];
+		const FarNode &n100 = data[data_area.added_x(data_extent, i000, 1)];
+		const ContentFeatures &f000 = ndef->get(n000.id);
+		const ContentFeatures &f001 = ndef->get(n001.id);
+		const ContentFeatures &f010 = ndef->get(n010.id);
+		const ContentFeatures &f100 = ndef->get(n100.id);
+		int s000 = get_solidness(f000);
+		int s001 = get_solidness(f001);
+		int s010 = get_solidness(f010);
+		int s100 = get_solidness(f100);
+
+		if(s000 > s001){
+			add_face(collector, n000, p000, n001,  0,0,1, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+		else if(s000 < s001){
+			v3s16 p001 = p000 + v3s16(0,0,1);
+			add_face(collector, n001, p001, n000,  0,0,-1, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+		if(s000 > s010){
+			add_face(collector, n000, p000, n010,  0,1,0, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+		else if(s000 < s010){
+			v3s16 p010 = p000 + v3s16(0,1,0);
+			add_face(collector, n010, p010, n000,  0,-1,0, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+		if(s000 > s100){
+			add_face(collector, n000, p000, n100,  1,0,0, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+		else if(s000 < s100){
+			v3s16 p100 = p000 + v3s16(1,0,0);
+			add_face(collector, n100, p100, n000, -1,0,0, data,
+					data_area, divs_per_mb, far_map);
+			(*num_faces_added)++;
+		}
+	}
+}
+
+static scene::SMesh* create_farblock_mesh(scene::SMesh *old_mesh,
+		FarMap *far_map, MeshCollector *collector)
+{
+	IShaderSource *ssrc = far_map->client->getShaderSource();
+
+	scene::SMesh *mesh = NULL;
+	if (old_mesh) {
+		old_mesh->clear();
+		mesh = old_mesh;
+	} else {
+		mesh = new scene::SMesh();
+	}
+
+	for(u32 i = 0; i < collector->prebuffers.size(); i++)
+	{
+		PreMeshBuffer &p = collector->prebuffers[i];
+
+		for(u32 j = 0; j < p.vertices.size(); j++)
+		{
+			video::S3DVertex *vertex = &p.vertices[j];
+			video::SColor &vc = vertex->Color;
+			/*// Note applyFacesShading second parameter is precalculated sqrt
+			// value for speed improvement
+			// Skip it for lightsources and top faces.
+			// NOTE: Don't use this because we bake shading into the atlas
+			//       textures in order to cheat with lighting effects
+			if (!vc.getBlue()) {
+				if (vertex->Normal.Y < -0.5) {
+					applyFacesShading (vc, 0.447213);
+				} else if (vertex->Normal.X > 0.5) {
+					applyFacesShading (vc, 0.670820);
+				} else if (vertex->Normal.X < -0.5) {
+					applyFacesShading (vc, 0.670820);
+				} else if (vertex->Normal.Z > 0.5) {
+					applyFacesShading (vc, 0.836660);
+				} else if (vertex->Normal.Z < -0.5) {
+					applyFacesShading (vc, 0.836660);
+				}
+			}*/
+			if(!far_map->config_enable_shaders)
+			{
+				// - Classic lighting (shaders handle this by themselves)
+				// Set initial real color and store for later updates
+				u8 day = vc.getRed();
+				u8 night = vc.getGreen();
+				finalColorBlend(vc, day, night, 1000);
+			}
+		}
+
+		// Create material
+		video::SMaterial material;
+		material.setFlag(video::EMF_LIGHTING, false);
+		material.setFlag(video::EMF_BACK_FACE_CULLING, true);
+		material.setFlag(video::EMF_BILINEAR_FILTER, false);
+		material.setFlag(video::EMF_FOG_ENABLE, true);
+		material.setTexture(0, p.tile.texture);
+
+		if (far_map->config_enable_shaders) {
+			material.MaterialType = ssrc->getShaderInfo(p.tile.shader_id).material;
+			p.tile.applyMaterialOptionsWithShaders(material);
+			if (p.tile.normal_texture) {
+				material.setTexture(1, p.tile.normal_texture);
+			}
+			material.setTexture(2, p.tile.flags_texture);
+		} else {
+			p.tile.applyMaterialOptions(material);
+		}
+
+		// Create meshbuffer
+		scene::SMeshBuffer *buf = new scene::SMeshBuffer();
+		// Set material
+		buf->Material = material;
+		// Add to mesh
+		mesh->addMeshBuffer(buf);
+		// Mesh grabbed it
+		buf->drop();
+		buf->append(&p.vertices[0], p.vertices.size(),
+				&p.indices[0], p.indices.size());
+	}
+
+	if (far_map->config_enable_shaders) {
+		scene::IMeshManipulator* meshmanip =
+				far_map->client->getSceneManager()->getMeshManipulator();
+		meshmanip->recalculateTangents(mesh, true, false, false);
+	}
+
+	return mesh;
+}
+
+void FarBlockMeshGenerateTask::inThread()
+{
+	/*dstream<<"Generating FarBlock mesh for "
+			<<PP(block.p)<<", level="<<level<<std::endl;*/
+
+	if (block.content.empty() || block.content_area.getVolume() == 0) {
+		// This will have no meshes whatsoever
+		return;
+	}
+
+	// Crude main mesh (always generated)
+	{
+		MeshCollector collector(false);
+
+		size_t num_faces_added = 0;
+
+		// FarBlock position in MapBlocks
+		v3s16 bp00 = block.p * FMP_SCALE;
+		v3s16 bp01 = bp00 + v3s16(1,1,1) * FMP_SCALE - v3s16(1,1,1);
+
+		// Effective area in MapBlocks
+		VoxelArea gen_area(bp00, bp01);
+
+		// Content buffer area in MapBlocks
+		VoxelArea content_buf_area(
+			gen_area.MinEdge - v3s16(1,1,1),
+			gen_area.MaxEdge + v3s16(1,1,1)
+		);
+
+		std::vector<FarNode> content_buf;
+		content_buf.resize(content_buf_area.getVolume(), CONTENT_IGNORE);
+
+		v3s16 p;
+		// Fill in everything but leave edges at air with light or ignore
+		for (p.Z = content_buf_area.MinEdge.Z;
+				p.Z <= content_buf_area.MaxEdge.Z; p.Z++)
+		for (p.Y = content_buf_area.MinEdge.Y;
+				p.Y <= content_buf_area.MaxEdge.Y; p.Y++)
+		for (p.X = content_buf_area.MinEdge.X;
+				p.X <= content_buf_area.MaxEdge.X; p.X++)
+		{
+			// Get topmost visible node
+			FarNode n(CONTENT_IGNORE);
+			v3s16 source_p(
+				p.X * block.divs_per_mb.X + block.divs_per_mb.X / 2,
+				p.Y * block.divs_per_mb.Y + block.divs_per_mb.Y - 1,
+				p.Z * block.divs_per_mb.Z + block.divs_per_mb.Z / 2
+			);
+			if (block.content_area.contains(source_p)) {
+				for (; source_p.Y >= p.Y * block.divs_per_mb.Y; source_p.Y--) {
+					n = block.content[block.content_area.index(source_p)];
+					if (n.id != CONTENT_IGNORE && n.id != CONTENT_AIR) {
+						break;
+					}
+				}
+			}
+			if (gen_area.contains(p)) {
+				content_buf[content_buf_area.index(p)] = n;
+			} else if(n.id != CONTENT_IGNORE) {
+				// Only copy light into air
+				content_buf[content_buf_area.index(p)] =
+						FarNode(CONTENT_AIR, n.light);
+			} else {
+				content_buf[content_buf_area.index(p)] = FarNode(CONTENT_IGNORE);
+			}
+		}
+
+		extract_faces(&collector, content_buf, content_buf_area,
+				gen_area, v3s16(1,1,1), far_map,
+				&num_faces_added);
+
+		g_profiler->avg("Far: num faces per crude mesh", num_faces_added);
+		g_profiler->add("Far: num crude meshes generated", 1);
+
+		assert(block.crude_mesh == NULL);
+		if (num_faces_added > 0) {
+			block.crude_mesh = create_farblock_mesh(
+					block.crude_mesh, far_map, &collector);
+			// This gives Irrlicht permission to store this mesh on the GPU
+			block.crude_mesh->setHardwareMappingHint(scene::EHM_STATIC);
+		}
+	}
+
+	// Fine main mesh
+	if (level >= FML_FINE) {
+		MeshCollector collector(false);
+
+		size_t num_faces_added = 0;
+
+		extract_faces(&collector, block.content, block.content_area,
+				block.effective_area, block.divs_per_mb, far_map,
+				&num_faces_added);
+
+		g_profiler->avg("Far: num faces per mesh", num_faces_added);
+		g_profiler->add("Far: num meshes generated", 1);
+
+		assert(block.fine_mesh == NULL);
+		if (num_faces_added > 0) {
+			block.fine_mesh = create_farblock_mesh(
+					block.fine_mesh, far_map, &collector);
+			// This gives Irrlicht permission to store this mesh on the GPU
+			block.fine_mesh->setHardwareMappingHint(scene::EHM_STATIC);
+		}
+	}
+
+	// Auxiliary meshes
+	if (level >= FML_FINE_AND_SMALL) {
+		v3s16 mp;
+
+		// MapBlock-sized meshes
+		block.mapblock_meshes.resize(FMP_SCALE * FMP_SCALE * FMP_SCALE);
+		VoxelArea mapblock_meshes_area(
+			v3s16(0, 0, 0),
+			v3s16(FMP_SCALE-1, FMP_SCALE-1, FMP_SCALE-1)
+		);
+		std::vector<FarNode> content_buf;
+		for (mp.Z=0; mp.Z<FMP_SCALE; mp.Z++)
+		for (mp.Y=0; mp.Y<FMP_SCALE; mp.Y++)
+		for (mp.X=0; mp.X<FMP_SCALE; mp.X++) {
+			// Index to mapblock_meshes
+			size_t mi = mapblock_meshes_area.index(mp);
+
+			MeshCollector collector(false);
+
+			VoxelArea gen_area( // effective
+				block.dp00 + v3s16(
+					block.divs_per_mb.X * mp.X,
+					block.divs_per_mb.Y * mp.Y,
+					block.divs_per_mb.Z * mp.Z
+				),
+				block.dp00 + v3s16(
+					block.divs_per_mb.X * mp.X + block.divs_per_mb.X - 1,
+					block.divs_per_mb.Y * mp.Y + block.divs_per_mb.Y - 1,
+					block.divs_per_mb.Z * mp.Z + block.divs_per_mb.Z - 1
+				)
+			);
+			VoxelArea content_buf_area(
+				gen_area.MinEdge - v3s16(1,1,1),
+				gen_area.MaxEdge + v3s16(1,1,1)
+			);
+			content_buf.clear();
+			content_buf.resize(content_buf_area.getVolume(), CONTENT_IGNORE);
+			v3s16 p;
+			// Fill in everything but leave edges at air with light or ignore
+			for (p.Z = content_buf_area.MinEdge.Z;
+					p.Z <= content_buf_area.MaxEdge.Z; p.Z++)
+			for (p.Y = content_buf_area.MinEdge.Y;
+					p.Y <= content_buf_area.MaxEdge.Y; p.Y++)
+			for (p.X = content_buf_area.MinEdge.X;
+					p.X <= content_buf_area.MaxEdge.X; p.X++)
+			{
+				if (gen_area.contains(p)) {
+					content_buf[content_buf_area.index(p)] =
+							block.content[block.content_area.index(p)];
+				} else if(block.content_area.contains(p) &&
+						block.content[block.content_area.index(p)].id
+								!= CONTENT_IGNORE) {
+					// Only copy light into air
+					u8 light = block.content[block.content_area.index(p)].light;
+					content_buf[content_buf_area.index(p)] =
+							FarNode(CONTENT_AIR, light);
+				} else {
+					content_buf[content_buf_area.index(p)] =
+							FarNode(CONTENT_IGNORE);
+				}
+			}
+
+			size_t num_faces_added = 0;
+
+			extract_faces(&collector, content_buf, content_buf_area,
+					gen_area, block.divs_per_mb, far_map,
+					&num_faces_added);
+
+			g_profiler->avg("Far: num faces per mb mesh", num_faces_added);
+			g_profiler->add("Far: num mb meshes generated", 1);
+
+			if (num_faces_added > 0) {
+				block.mapblock_meshes[mi] = create_farblock_mesh(
+						block.mapblock_meshes[mi], far_map, &collector);
+				// NOTE: Don't se this scene::EHM_STATIC. This is so small that
+				// a VBO will do nothing but waste GPU resources, and we
+				// actively avoid rendering many of these at a time.
+			}
+		}
+
+		// 2x2x2-MapBlock-sized meshes
+		block.mapblock2_meshes.resize(FMP_SCALE/2 * FMP_SCALE/2 * FMP_SCALE/2);
+		VoxelArea mapblock2_meshes_area(
+			v3s16(0, 0, 0),
+			v3s16(FMP_SCALE/2-1, FMP_SCALE/2-1, FMP_SCALE/2-1)
+		);
+		for (mp.Z=0; mp.Z<FMP_SCALE/2; mp.Z++)
+		for (mp.Y=0; mp.Y<FMP_SCALE/2; mp.Y++)
+		for (mp.X=0; mp.X<FMP_SCALE/2; mp.X++) {
+			// Index to mapblock2_meshes
+			size_t mi = mapblock2_meshes_area.index(mp);
+
+			MeshCollector collector(false);
+
+			VoxelArea gen_area( // effective
+				block.dp00 + v3s16(
+					block.divs_per_mb.X * mp.X * 2,
+					block.divs_per_mb.Y * mp.Y * 2,
+					block.divs_per_mb.Z * mp.Z * 2
+				),
+				block.dp00 + v3s16(
+					block.divs_per_mb.X * mp.X * 2 + block.divs_per_mb.X * 2 - 1,
+					block.divs_per_mb.Y * mp.Y * 2 + block.divs_per_mb.Y * 2 - 1,
+					block.divs_per_mb.Z * mp.Z * 2 + block.divs_per_mb.Z * 2 - 1
+				)
+			);
+			VoxelArea content_buf_area(
+				gen_area.MinEdge - v3s16(1,1,1),
+				gen_area.MaxEdge + v3s16(1,1,1)
+			);
+			content_buf.clear();
+			content_buf.resize(content_buf_area.getVolume(), CONTENT_IGNORE);
+			v3s16 p;
+			// Fill in everything but leave edges at air with light or ignore
+			for (p.Z = content_buf_area.MinEdge.Z;
+					p.Z <= content_buf_area.MaxEdge.Z; p.Z++)
+			for (p.Y = content_buf_area.MinEdge.Y;
+					p.Y <= content_buf_area.MaxEdge.Y; p.Y++)
+			for (p.X = content_buf_area.MinEdge.X;
+					p.X <= content_buf_area.MaxEdge.X; p.X++)
+			{
+				if (gen_area.contains(p)) {
+					content_buf[content_buf_area.index(p)] =
+							block.content[block.content_area.index(p)];
+				} else if(block.content_area.contains(p) &&
+						block.content[block.content_area.index(p)].id
+								!= CONTENT_IGNORE) {
+					// Only copy light into air
+					u8 light = block.content[block.content_area.index(p)].light;
+					content_buf[content_buf_area.index(p)] =
+							FarNode(CONTENT_AIR, light);
+				} else {
+					content_buf[content_buf_area.index(p)] =
+							FarNode(CONTENT_IGNORE);
+				}
+			}
+
+			size_t num_faces_added = 0;
+
+			extract_faces(&collector, content_buf, content_buf_area,
+					gen_area, block.divs_per_mb, far_map,
+					&num_faces_added);
+
+			g_profiler->avg("Far: num faces per mb mesh", num_faces_added);
+			g_profiler->add("Far: num mb meshes generated", 1);
+
+			if (num_faces_added > 0) {
+				block.mapblock2_meshes[mi] = create_farblock_mesh(
+						block.mapblock2_meshes[mi], far_map, &collector);
+				// NOTE: Do not set this to be a VBO because it will hit some
+				//       kind of number-of-VBOs limit really fast and make
+				//       rendering choppy
+			}
+		}
+	}
+}
+
+void FarBlockMeshGenerateTask::sync()
+{
+	far_map->insertGeneratedBlockMesh(
+			block.p, block.crude_mesh, block.fine_mesh,
+			block.mapblock_meshes, block.mapblock2_meshes);
+	if (block.crude_mesh) {
+		block.crude_mesh->drop();
+		block.crude_mesh = NULL;
+	}
+	if (block.fine_mesh) {
+		block.fine_mesh->drop();
+		block.fine_mesh = NULL;
+	}
+	for (size_t i=0; i<block.mapblock_meshes.size(); i++) {
+		if (block.mapblock_meshes[i] != NULL) {
+			block.mapblock_meshes[i]->drop();
+			block.mapblock_meshes[i] = NULL;
+		}
+	}
+	for (size_t i=0; i<block.mapblock2_meshes.size(); i++) {
+		if (block.mapblock2_meshes[i] != NULL) {
+			block.mapblock2_meshes[i]->drop();
+			block.mapblock2_meshes[i] = NULL;
+		}
+	}
+}
+
+/*
+	FarBlockInsertTask
+*/
+
+FarBlockInsertTask::FarBlockInsertTask(
+		FarMap *far_map, const CompressedFarBlock &source):
+	far_map(far_map),
+	source(source)
+{
+}
+
+FarBlockInsertTask::~FarBlockInsertTask()
+{
+}
+
+void FarBlockInsertTask::inThread()
+{
+	result_params = FarBlockBasicParameters(source.fbp, source.divs_per_mb);
+
+	if (source.status == FBRS_FULLY_LOADED || source.status == FBRS_PARTLY_LOADED) {
+		std::istringstream is1(source.compressed_data, std::ios::binary);
+		std::ostringstream os2(std::ios::binary);
+		{
+			ScopeProfiler sp(g_profiler, "Zlib: decompress farblock", SPT_ADD);
+			decompressZlib(is1, os2);
+		}
+		std::istringstream is2(os2.str(), std::ios::binary);
+
+		result_content.resize(result_params.content_area.getVolume(),
+				FarNode(CONTENT_IGNORE, (15)|(15<<4)));
+
+		v3s16 dp_in_fb;
+		for (dp_in_fb.Z=0; dp_in_fb.Z<result_params.effective_size.Z; dp_in_fb.Z++)
+		for (dp_in_fb.Y=0; dp_in_fb.Y<result_params.effective_size.Y; dp_in_fb.Y++)
+		for (dp_in_fb.X=0; dp_in_fb.X<result_params.effective_size.X; dp_in_fb.X++) {
+			// Position has to be translated from raw data index to
+			// padded-for-mesh-generation content index
+			v3s16 dp1 = result_params.dp00 + dp_in_fb;
+			size_t i = result_params.content_area.index(dp1);
+			result_content[i].id = readU16(is2);
+			result_content[i].light = readU8(is2);
+		}
+	}
+}
+
+void FarBlockInsertTask::sync()
+{
+	if (source.status == FBRS_FULLY_LOADED || source.status == FBRS_PARTLY_LOADED) {
+		bool partly_loaded = (source.status == FBRS_PARTLY_LOADED);
+		far_map->insertFarBlock(result_params.p, result_params.divs_per_mb,
+				result_content, partly_loaded);
+	} else if(source.status == FBRS_EMPTY) {
+		far_map->insertEmptyBlock(source.fbp);
+	} else if(source.status == FBRS_CULLED) {
+		far_map->insertCulledBlock(source.fbp);
+	} else if(source.status == FBRS_LOAD_IN_PROGRESS) {
+		far_map->insertLoadInProgressBlock(source.fbp);
+	} else {
+		// ?
+	}
+}
+
+/*
+	FarMapWorkerThread
+*/
+
+FarMapWorkerThread::~FarMapWorkerThread()
+{
+	verbosestream<<"FarMapWorkerThread: Deleting remaining tasks (in)"<<std::endl;
+	for(;;){
+		try {
+			FarMapTask *t = m_queue_in.pop_front(0);
+			delete t;
+		} catch(ItemNotFoundException &e){
+			break;
+		}
+	}
+	verbosestream<<"FarMapWorkerThread: Deleting remaining tasks (sync)"<<std::endl;
+	for(;;){
+		try {
+			FarMapTask *t = m_queue_sync.pop_front(0);
+			delete t;
+		} catch(ItemNotFoundException &e){
+			break;
+		}
+	}
+}
+
+void FarMapWorkerThread::addTask(FarMapTask *task)
+{
+	g_profiler->add("Far: tasks added", 1);
+
+	s32 length = ++m_queue_in_length;
+	g_profiler->avg("Far: task queue length (avg)", length);
+
+	m_queue_in.push_back(task);
+	deferUpdate();
+}
+
+void FarMapWorkerThread::sync()
+{
+	for(;;){
+		try {
+			FarMapTask *t = m_queue_sync.pop_front(0);
+			//infostream<<"FarMapWorkerThread: Running task in sync"<<std::endl;
+			// TODO: Spread these sync() calls as thin as possible, because if a
+			// bunch of them is called in a single frame, screen updates become
+			// choppy
+			t->sync();
+			delete t;
+			g_profiler->add("Far: tasks finished", 1);
+		} catch(ItemNotFoundException &e){
+			break;
+		}
+	}
+}
+
+void FarMapWorkerThread::doUpdate()
+{
+	for(;;){
+		try {
+			FarMapTask *t = m_queue_in.pop_front(250);
+			infostream<<"FarMapWorkerThread: Running task in thread"<<std::endl;
+			t->inThread();
+			m_queue_sync.push_back(t);
+
+			s32 length = --m_queue_in_length;
+			g_profiler->avg("Far: task queue length (avg)", length);
+		} catch(ItemNotFoundException &e){
+			break;
+		}
+	}
+}
+
+/*
+	FarAtlas
+*/
+
+FarAtlas::FarAtlas(FarMap *far_map)
+{
+	video::IVideoDriver* driver =
+			far_map->client->getSceneManager()->getVideoDriver();
+
+	atlas = atlas::createAtlasRegistry("FarMap", driver, far_map->client);
+
+	mapnode_resolution = g_settings->getS32("far_map_atlas_node_resolution");
+	if (mapnode_resolution < 1)
+		mapnode_resolution = 1;
+}
+
+FarAtlas::~FarAtlas()
+{
+	delete atlas;
+}
+
+void FarAtlas::prepareForNodes(size_t num_nodes)
+{
+	v2s32 segment_size(mapnode_resolution * 4, mapnode_resolution * 4);
+	size_t segments_per_node = 2 * 3;
+	infostream<<"FarAtlas: Optimizing for "<<num_nodes<<" nodes of size "
+			<<segment_size.X<<"x"<<segment_size.Y<<std::endl;
+	atlas->prepare_for_segments(num_nodes * segments_per_node, segment_size);
+}
+
+atlas::AtlasSegmentReference FarAtlas::addTexture(const std::string &name,
+		bool is_top, bool crude, bool is_liquid)
+{
+	atlas::AtlasSegmentDefinition def;
+	def.image_name = name;
+	def.total_segments = v2s32(1, 1);
+	def.select_segment = v2s32(0, 0);
+	int lod = crude ? 16 : 4;
+	def.lod_simulation = lod;
+	// This is independent of LOD
+	def.target_size = v2s32(mapnode_resolution * 4, mapnode_resolution * 4);
+	if (is_liquid) {
+		// Do this always
+		def.lod_simulation |= atlas::ATLAS_LOD_TOP_FACE;
+
+		def.lod_simulation |= atlas::ATLAS_LOD_DARKEN_LIKE_LIQUID;
+	} else {
+		if (is_top)
+			def.lod_simulation |= atlas::ATLAS_LOD_TOP_FACE;
+	}
+	def.lod_simulation |= atlas::ATLAS_LOD_BAKE_SHADOWS;
+	return atlas->find_or_add_segment(def);
+}
+
+void FarAtlas::addNode(content_t id, const std::string &top,
+		const std::string &bottom, const std::string &side,
+		bool is_liquid)
+{
+	NodeSegRefs nsr;
+	nsr.refs[0] = addTexture(top, true, false, is_liquid);
+	nsr.refs[1] = addTexture(bottom, false, false, is_liquid);
+	nsr.refs[2] = addTexture(side, false, false, is_liquid);
+	nsr.crude_refs[0] = addTexture(top, true, true, is_liquid);
+	nsr.crude_refs[1] = addTexture(bottom, false, true, is_liquid);
+	nsr.crude_refs[2] = addTexture(side, false, true, is_liquid);
+
+	if((content_t)node_segrefs.size() < id + 1)
+		node_segrefs.resize(id + 1);
+	node_segrefs[id] = nsr;
+}
+
+const atlas::AtlasSegmentCache* FarAtlas::getNode(
+	content_t id, u8 face, bool crude) const
+{
+	assert(face < 3);
+	if(node_segrefs.size() <= id)
+		return NULL;
+	if (crude) {
+		return atlas->get_texture(node_segrefs[id].crude_refs[face]);
+	} else {
+		return atlas->get_texture(node_segrefs[id].refs[face]);
+	}
+}
+
+/*
+	FarMap
+*/
+
+FarMap::FarMap(
+		Client *client,
+		scene::ISceneNode* parent,
+		scene::ISceneManager* mgr,
+		s32 id
+):
+	scene::ISceneNode(parent, mgr, id),
+	client(client),
+	atlas(this),
+	config_enable_shaders(false),
+	config_trilinear_filter(false),
+	config_bilinear_filter(false),
+	config_anisotropic_filter(false),
+	config_far_map_range(800),
+	farblock_shader_id(0),
+	m_farblocks_exist_up_to_d(0),
+	m_farblocks_exist_up_to_d_reset_counter(0)
+{
+	m_bounding_box = core::aabbox3d<f32>(-BS*1000000,-BS*1000000,-BS*1000000,
+			BS*1000000,BS*1000000,BS*1000000);
+
+	updateSettings();
+	
+	m_worker_thread.start();
+}
+
+FarMap::~FarMap()
+{
+	m_worker_thread.stop();
+	m_worker_thread.wait();
+
+	for (std::map<v2s16, FarSector*>::iterator i = m_sectors.begin();
+			i != m_sectors.end(); i++) {
+		delete i->second;
+	}
+}
+
+FarSector* FarMap::getSector(v2s16 p)
+{
+	std::map<v2s16, FarSector*>::iterator i = m_sectors.find(p);
+	if(i != m_sectors.end())
+		return i->second;
+	return NULL;
+}
+
+FarBlock* FarMap::getBlock(v3s16 p)
+{
+	v2s16 p2d(p.X, p.Z);
+	FarSector *s = getSector(p2d);
+	if (!s) return NULL;
+	return s->getBlock(p.Y);
+}
+
+FarSector* FarMap::getOrCreateSector(v2s16 p)
+{
+	std::map<v2s16, FarSector*>::iterator i = m_sectors.find(p);
+	if(i != m_sectors.end())
+		return i->second;
+	FarSector *s = new FarSector(p);
+	m_sectors[p] = s;
+	return s;
+}
+
+FarBlock* FarMap::getOrCreateBlock(v3s16 p, v3s16 divs_per_mb)
+{
+	v2s16 p2d(p.X, p.Z);
+	FarSector *s = getOrCreateSector(p2d);
+	return s->getOrCreateBlock(p.Y, divs_per_mb);
+}
+
+void FarMap::insertCompressedFarBlock(const CompressedFarBlock &source_block)
+{
+	FarBlockInsertTask *t = new FarBlockInsertTask(this, source_block);
+
+	m_worker_thread.addTask(t);
+}
+
+void FarMap::insertFarBlock(v3s16 fbp, v3s16 divs_per_mb,
+		std::vector<FarNode> &content, bool is_partly_loaded)
+{
+	//dstream<<"FarMap::insertFarBlock: FarBlock "<<PP(fbp)<<std::endl;
+
+	FarBlock *b = getOrCreateBlock(fbp, divs_per_mb);
+	b->is_culled_by_server = false;
+	b->load_in_progress_on_server = is_partly_loaded;
+	b->mesh_is_empty = false;
+	b->mesh_is_outdated = true;
+	assert(content.size() == (size_t)b->content_area.getVolume());
+	b->content.swap(content);
+
+	/*// Call analyze_far_block before starting the line to keep lines
+	// mostly intact when multiple threads are printing
+	std::string s = analyze_far_block(b);
+	dstream<<"FarMap: Updated block: "<<s<<std::endl;*/
+}
+
+void FarMap::insertEmptyBlock(v3s16 fbp)
+{
+	dstream<<PP(fbp)<<" reported empty"<<std::endl;
+	FarBlock *b = getOrCreateBlock(fbp, v3s16(0,0,0));
+	b->is_culled_by_server = false;
+	b->load_in_progress_on_server = false;
+}
+
+void FarMap::insertCulledBlock(v3s16 fbp)
+{
+	dstream<<PP(fbp)<<" reported culled"<<std::endl;
+	FarBlock *b = getOrCreateBlock(fbp, v3s16(0,0,0));
+	b->is_culled_by_server = true;
+	b->load_in_progress_on_server = false;
+}
+
+void FarMap::insertLoadInProgressBlock(v3s16 fbp)
+{
+	dstream<<PP(fbp)<<" reported load-in-progress"<<std::endl;
+	FarBlock *b = getOrCreateBlock(fbp, v3s16(0,0,0));
+	b->is_culled_by_server = false;
+	b->load_in_progress_on_server = true;
+}
+
+void FarMap::startGeneratingBlockMesh(FarBlock *b,
+		FarMeshLevel level)
+{
+	/*dstream<<"FarMap::startGeneratingBlockMesh: "<<PP(b->p)
+			<<" level="<<level<<std::endl;*/
+
+	assert(!b->generating_mesh);
+
+	b->generating_mesh = true;
+	b->mesh_is_outdated = false;
+
+	FarBlockMeshGenerateTask *t = new FarBlockMeshGenerateTask(
+			this, *b, level);
+
+	m_worker_thread.addTask(t);
+}
+
+void FarMap::insertGeneratedBlockMesh(
+		v3s16 p, scene::SMesh *crude_mesh, scene::SMesh *fine_mesh,
+		const std::vector<scene::SMesh*> &mapblock_meshes,
+		const std::vector<scene::SMesh*> &mapblock2_meshes)
+{
+	/*dstream<<"FarMap::insertGeneratedBlockMesh: "<<PP(p)
+			<<": crude_mesh="<<!!crude_mesh
+			<<", mesh="<<!!fine_mesh
+			<<", mb1_meshes="<<!mapblock_meshes.empty()
+			<<", mb2_meshes="<<!mapblock2_meshes.empty()
+			<<std::endl;*/
+
+	FarBlock *b = getBlock(p);
+	if (!b)
+		return;
+
+	b->generating_mesh = false;
+
+	if (b->crude_mesh) {
+		b->crude_mesh->drop();
+		b->crude_mesh = NULL;
+	}
+	if (crude_mesh) {
+		crude_mesh->grab();
+		b->crude_mesh = crude_mesh;
+	}
+
+	if (b->fine_mesh) {
+		b->fine_mesh->drop();
+		b->fine_mesh = NULL;
+	}
+	if (fine_mesh) {
+		fine_mesh->grab();
+		b->fine_mesh = fine_mesh;
+	}
+
+	if (b->crude_mesh == NULL && b->fine_mesh == NULL) {
+		b->mesh_is_empty = true;
+	} else {
+		b->mesh_is_empty = false;
+	}
+
+	for (size_t i=0; i<b->mapblock_meshes.size(); i++) {
+		if(b->mapblock_meshes[i])
+			b->mapblock_meshes[i]->drop();
+		b->mapblock_meshes[i] = NULL;
+	}
+	b->mapblock_meshes.resize(mapblock_meshes.size());
+	for (size_t i=0; i<mapblock_meshes.size(); i++) {
+		if (mapblock_meshes[i] != NULL) {
+			mapblock_meshes[i]->grab();
+			b->mapblock_meshes[i] = mapblock_meshes[i];
+		}
+	}
+
+	for (size_t i=0; i<b->mapblock2_meshes.size(); i++) {
+		if(b->mapblock2_meshes[i])
+			b->mapblock2_meshes[i]->drop();
+		b->mapblock2_meshes[i] = NULL;
+	}
+	b->mapblock2_meshes.resize(mapblock2_meshes.size());
+	for (size_t i=0; i<mapblock2_meshes.size(); i++) {
+		if (mapblock2_meshes[i] != NULL) {
+			mapblock2_meshes[i]->grab();
+			b->mapblock2_meshes[i] = mapblock2_meshes[i];
+		}
+	}
+
+	b->resetCameraOffset(current_camera_offset);
+
+	g_profiler->add("Far: generated farblock meshes", 1);
+}
+
+void FarMap::update()
+{
+	updateSettings();
+
+	if (farblock_shader_id == 0 && config_enable_shaders) {
+		// Fetch a basic node shader
+		// NOTE: ShaderSource does not implement asynchronous fetching of
+		// shaders from the main thread like TextureSource. While it probably
+		// should do that, we can just fetch this id here for now as we use a
+		// static shader anyway.
+		u8 material_type = TILE_MATERIAL_BASIC;
+		enum NodeDrawType drawtype = NDT_NORMAL;
+		infostream<<"FarBlockMeshGenerate: Getting shader..."<<std::endl;
+		IShaderSource *ssrc = client->getShaderSource();
+		farblock_shader_id = ssrc->getShader(
+				"nodes_shader", material_type, drawtype);
+		infostream<<"FarBlockMeshGenerate: shader_id="<<farblock_shader_id
+				<<std::endl;
+	}
+
+	m_worker_thread.sync();
+}
+
+void FarMap::updateCameraOffset(v3s16 camera_offset)
+{
+	if (camera_offset == current_camera_offset) return;
+
+	current_camera_offset = camera_offset;
+
+	for (std::map<v2s16, FarSector*>::iterator i = m_sectors.begin();
+			i != m_sectors.end(); i++) {
+		FarSector *s = i->second;
+
+		for (std::map<s16, FarBlock*>::iterator i = s->blocks.begin();
+				i != s->blocks.end(); i++) {
+			FarBlock *b = i->second;
+			b->updateCameraOffset(camera_offset);
+		}
+	}
+}
+
+void FarMap::reportNormallyRenderedBlocks(const BlockAreaBitmap<bool> &nrb)
+{
+	normally_rendered_blocks = nrb;
+
+	/*verbosestream<<"FarMap::reportNormallyRenderedBlocks: "
+			<<"reported area: ";
+			normally_rendered_blocks.blocks_area.print(verbosestream);
+			verbosestream<<std::endl;*/
+}
+
+void FarMap::createAtlas()
+{
+	INodeDefManager *ndef = client->getNodeDefManager();
+
+	u32 num_nodes = 0;
+	for(u32 id=0; ; id++){
+		const ContentFeatures &f = ndef->get(id);
+		if ((f.name.empty() || f.name == "unknown") && id != CONTENT_UNKNOWN)
+			break;
+
+		num_nodes++;
+
+		if(id == 65535)
+			break;
+	}
+
+	atlas.prepareForNodes(num_nodes);
+
+	// Umm... let's just start from zero and see how far we get?
+	for(u32 id=0; id<num_nodes; id++){
+		const ContentFeatures &f = ndef->get(id);
+
+		infostream<<"FarMap: Adding node "<<id<<" = \""<<f.name<<"\""<<std::endl;
+
+		std::string top = f.tiledef[0].name;
+		if (!top.empty()) {
+			std::string bottom = f.tiledef[1].name;
+			std::string side = f.tiledef[2].name;
+			if(bottom.empty())
+				bottom = top;
+			if(side.empty())
+				side = top;
+			infostream<<"* top="<<top<<", bottom="<<bottom
+					<<", side="<<side<<std::endl;
+			bool is_liquid =
+					f.drawtype == NDT_LIQUID ||
+					f.drawtype == NDT_FLOWINGLIQUID;
+			atlas.addNode(id, top, bottom, side, is_liquid);
+		}
+	}
+
+	infostream<<"FarMap: Refreshing atlas textures"<<std::endl;
+
+	atlas.atlas->refresh_textures();
+
+	infostream<<"FarMap: Created atlas out of "<<atlas.node_segrefs.size()
+			<<" nodes"<<std::endl;
+}
+
+std::vector<v3s16> FarMap::suggestFarBlocksToFetch(v3s16 camera_p)
+{
+	// Don't fetch anything if the task queue length is too high
+	// TODO: Where to get this value?
+	const size_t max_queue_length = 50;
+	size_t queue_length = m_worker_thread.getQueueLength();
+	if (queue_length >= max_queue_length)
+		return std::vector<v3s16>();
+	static const size_t wanted_num_results = max_queue_length - queue_length;
+
+	std::vector<v3s16> suggested_fbs;
+
+	v3s16 center_mb = getContainerPos(camera_p, MAP_BLOCKSIZE);
+	v3s16 center_fb = getContainerPos(center_mb, FMP_SCALE);
+
+	s16 fetch_distance_farblocks =
+			ceilf((float)config_far_map_range / MAP_BLOCKSIZE / FMP_SCALE);
+
+	// Avoid running the algorithm through all the close FarBlocks that probably
+	// have already been fetched, except once in a while to catch up with
+	// possible missed FarBlocks due to player movement or whatever.
+	s16 start_d = m_farblocks_exist_up_to_d; // Start one lower than have to
+	if (++m_farblocks_exist_up_to_d_reset_counter >= 10) {
+		m_farblocks_exist_up_to_d_reset_counter = 0;
+		start_d = 0;
+	}
+	m_farblocks_exist_up_to_d = -1; // Reset and recalculate
+	if (start_d < 0)
+		start_d = 0;
+
+	for (s16 d = start_d; d <= fetch_distance_farblocks; d++) {
+		std::vector<v3s16> ps = FacePositionCache::getFacePositions(d);
+		for (size_t i=0; i<ps.size(); i++) {
+			v3s16 p = center_fb + ps[i];
+			FarBlock *b = getBlock(p);
+			/*dstream<<"FarMap::suggestFarBlocksToFetch: "
+					<<PP(p)<<" = "<<b<<std::endl;*/
+			if (b != NULL) {
+				if (!b->load_in_progress_on_server) {
+					//dstream<<"* "<<PP(p)<<" is fully loaded"<<std::endl;
+					continue; // Exists and was received fully loaded
+				}
+				b->refresh_from_server_counter++;
+				if (b->refresh_from_server_counter < 5) {
+					/*dstream<<"* "<<PP(p)<<" is being loaded on server; counting "
+							<<b->refresh_from_server_counter<<std::endl;*/
+					continue; // Don't try reloading this time
+				}
+				dstream<<"* "<<PP(p)<<" is being loaded on server"
+						<<"; asking update from server"<<std::endl;
+				// Try reloading this time
+				b->refresh_from_server_counter = 0;
+			} else {
+				dstream<<"* "<<PP(p)<<" is unfetched"
+						<<"; asking from server"<<std::endl;
+			}
+			if (m_farblocks_exist_up_to_d == -1)
+				m_farblocks_exist_up_to_d = d - 1;
+			suggested_fbs.push_back(p);
+			if (suggested_fbs.size() >= wanted_num_results)
+				goto done;
+		}
+	}
+done:
+
+	infostream << "suggested_fbs.size()=" << suggested_fbs.size() << std::endl;
+	return suggested_fbs;
+}
+
+s16 FarMap::suggestAutosendFarblocksRadius()
+{
+	s16 fetch_distance_farblocks =
+			ceilf((float)config_far_map_range / MAP_BLOCKSIZE / FMP_SCALE);
+	return fetch_distance_farblocks;
+}
+
+float FarMap::suggestFogDistance()
+{
+	if (config_far_map_range < 150) {
+		// We are clearly trying to squeeze as much range from a poorly
+		// performing machine as possible, so try to help with that
+		return (config_far_map_range - MAP_BLOCKSIZE * FMP_SCALE / 4) * BS;
+	} else {
+		return (config_far_map_range - MAP_BLOCKSIZE * FMP_SCALE / 2) * BS;
+	}
+}
+
+void FarMap::updateSettings()
+{
+	config_enable_shaders = g_settings->getBool("enable_shaders");
+	config_trilinear_filter = g_settings->getBool("trilinear_filter");
+	config_bilinear_filter = g_settings->getBool("bilinear_filter");
+	config_anisotropic_filter = g_settings->getBool("anisotropic_filter");
+	config_far_map_range = g_settings->getS16("far_map_range");
+
+	// Sanitize these a bit
+	if (config_far_map_range < 100)
+		config_far_map_range = 100;
+}
+
+static void renderMesh(FarMap *far_map, scene::SMesh *mesh,
+		video::IVideoDriver* driver)
+{
+	u32 c = mesh->getMeshBufferCount();
+	/*infostream<<"FarMap::renderBlock: "<<PP(b->p)<<": Rendering "
+			<<c<<" meshbuffers"<<std::endl;*/
+	for (u32 i=0; i<c; i++)
+	{
+		scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
+		buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER,
+				far_map->config_trilinear_filter);
+		buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER,
+				far_map->config_bilinear_filter);
+		buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER,
+				far_map->config_anisotropic_filter);
+
+		const video::SMaterial& material = buf->getMaterial();
+
+		driver->setMaterial(material);
+
+		driver->drawMeshBuffer(buf);
+	}
+}
+
+static void renderBlock(FarMap *far_map, FarBlock *b,
+		video::IVideoDriver* driver,
+		u32 *profiler_render_time_farblocks_us,
+		u32 *profiler_render_time_fbcrudes_us,
+		u32 *profiler_render_time_fbmbparts_us,
+		u32 *profiler_render_time_fbmb2parts_us,
+		size_t *profiler_num_rendered_farblocks,
+		size_t *profiler_num_rendered_fbcrudes,
+		size_t *profiler_num_rendered_fbmbparts,
+		size_t *profiler_num_rendered_fbmb2parts)
+{
+	if (b->mesh_is_empty && !b->mesh_is_outdated) {
+		/*infostream<<"FarMap::renderBlock: "<<PP(b->p)<<": Mesh is empty"
+				<<std::endl;*/
+		return;
+	}
+
+	/*
+		Cull FarBlock if possible so that we don't have to generate so many
+		meshes. Meshes use nasty amounts of memory.
+	*/
+
+	scene::ICameraSceneNode *camera =
+			far_map->getSceneManager()->getActiveCamera();
+	v3f camera_pf = camera->getAbsolutePosition();
+	camera_pf += v3f(
+		far_map->current_camera_offset.X * BS,
+		far_map->current_camera_offset.Y * BS,
+		far_map->current_camera_offset.Z * BS
+	);
+	v3f block_pf(
+		((float)b->p.X + 0.5) * FMP_SCALE * MAP_BLOCKSIZE * BS,
+		((float)b->p.Y + 0.5) * FMP_SCALE * MAP_BLOCKSIZE * BS,
+		((float)b->p.Z + 0.5) * FMP_SCALE * MAP_BLOCKSIZE * BS
+	);
+	float d = (camera_pf - block_pf).getLength();
+
+	/*infostream<<"b->p="<<PP(b->p)
+			<<", camera_pf="<<PP(camera_pf)
+			<<", b->current_camera_offset="<<PP(b->current_camera_offset)
+			<<", far_map->current_camera_offset="
+					<<PP(far_map->current_camera_offset)
+			<<", block_pf="<<PP(block_pf)
+			<<", d="<<d
+			<<std::endl;*/
+
+	// Distance culling
+	if (d > far_map->config_far_map_range * BS)
+		return;
+
+	// TODO: Frustum culling
+
+	// TODO: Occlusion culling?
+
+	/*
+		This FarBlock will be rendered
+	*/
+
+	// Check what ClientMap is rendering and avoid rendering over it
+	VoxelArea area_in_mapblocks_from_origin(
+		v3s16(0, 0, 0),
+		v3s16(FMP_SCALE-1, FMP_SCALE-1, FMP_SCALE-1)
+	);
+	v3s16 fb_origin_mapblock = b->p * FMP_SCALE;
+	VoxelArea area_in_mapblocks(
+		area_in_mapblocks_from_origin.MinEdge + fb_origin_mapblock,
+		area_in_mapblocks_from_origin.MaxEdge + fb_origin_mapblock
+	);
+	VoxelArea area_in_mapblock2x2x2s_from_origin(
+		v3s16(0, 0, 0),
+		v3s16(FMP_SCALE/2-1, FMP_SCALE/2-1, FMP_SCALE/2-1)
+	);
+
+	// If some of the MapBlocks inside this FarBlock are rendered normally, we
+	// have to render MapBlock-sized pieces instead of the full FarBlock.
+	bool fb_being_normally_rendered = false;
+	if (far_map->normally_rendered_blocks.blocks_area.touches(area_in_mapblocks)) {
+		v3s16 mp0;
+		for (mp0.Z=0; mp0.Z<FMP_SCALE; mp0.Z++)
+		for (mp0.Y=0; mp0.Y<FMP_SCALE; mp0.Y++)
+		for (mp0.X=0; mp0.X<FMP_SCALE; mp0.X++) {
+			v3s16 mp = fb_origin_mapblock + mp0;
+			if (far_map->normally_rendered_blocks.get(mp)) {
+				// This MapBlock is being rendered by ClientMap
+				fb_being_normally_rendered = true;
+				goto big_break;
+			}
+		}
+big_break:;
+	}
+
+	FarMeshLevel level_wanted = FML_CRUDE;
+
+	if (fb_being_normally_rendered) {
+		//dstream<<"Being normally rendered: "<<PP(b->p)<<std::endl;
+		level_wanted = FML_FINE_AND_SMALL;
+	}
+
+	bool render_in_pieces = fb_being_normally_rendered;
+	bool avoid_crude_mesh = false;
+
+	if (render_in_pieces && b->getCurrentMeshLevel() < FML_FINE_AND_SMALL) {
+		//dstream<<"Missing small meshes: "<<PP(b->p)<<std::endl;
+		// Can't render in pieces because we don't have meshes for the pieces.
+		// Render normally so that things don't blink annoyingly meanwhile.
+		render_in_pieces = false;
+		// Don't render crude mesh here even temporarily; it would look horrible
+		// and would then immediately blink away making it even more horrible.
+		avoid_crude_mesh = true;
+	}
+
+	if (render_in_pieces) {
+		v3s16 mp20;
+		for (mp20.Z=0; mp20.Z<FMP_SCALE/2; mp20.Z++)
+		for (mp20.Y=0; mp20.Y<FMP_SCALE/2; mp20.Y++)
+		for (mp20.X=0; mp20.X<FMP_SCALE/2; mp20.X++) {
+			v3s16 mp0 = mp20 * 2;
+			v3s16 mp1 = fb_origin_mapblock + mp0;
+			if (!far_map->normally_rendered_blocks.get(mp1 + v3s16(1,0,0)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(1,1,0)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(0,1,0)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(0,0,0)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(1,0,1)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(1,1,1)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(0,1,1)) &&
+				!far_map->normally_rendered_blocks.get(mp1 + v3s16(0,0,1)))
+			{
+				TimeTaker tt(NULL, NULL, PRECISION_MICRO);
+				// Index to mapblock2_meshes
+				size_t mi = area_in_mapblock2x2x2s_from_origin.index(mp20);
+				scene::SMesh *mesh = b->mapblock2_meshes[mi];
+				if (!mesh)
+					continue;
+				renderMesh(far_map, mesh, driver);
+				(*profiler_num_rendered_fbmb2parts)++;
+				*profiler_render_time_fbmb2parts_us += tt.stop(true);
+			} else {
+				TimeTaker tt(NULL, NULL, PRECISION_MICRO);
+				v3s16 mp01;
+				for (mp01.Z=0; mp01.Z<2; mp01.Z++)
+				for (mp01.Y=0; mp01.Y<2; mp01.Y++)
+				for (mp01.X=0; mp01.X<2; mp01.X++) {
+					v3s16 mp = mp1 + mp01;
+					if (far_map->normally_rendered_blocks.get(mp))
+						continue;
+					assert(area_in_mapblocks.contains(mp));
+					// Index to mapblock_meshes
+					size_t mi = area_in_mapblocks.index(mp);
+					scene::SMesh *mesh = b->mapblock_meshes[mi];
+					if (!mesh)
+						continue;
+					renderMesh(far_map, mesh, driver);
+					(*profiler_num_rendered_fbmbparts)++;
+				}
+				*profiler_render_time_fbmbparts_us += tt.stop(true);
+			}
+		}
+	} else {
+		// Decide when to draw a normal mesh or a crude mesh
+		// TODO: Configurable
+		bool fine_mesh_wanted = (d < BS * 1000);
+
+		if (fine_mesh_wanted && b->fine_mesh) {
+			scene::SMesh *mesh = b->fine_mesh;
+			TimeTaker tt(NULL, NULL, PRECISION_MICRO);
+			renderMesh(far_map, mesh, driver);
+			*profiler_render_time_farblocks_us += tt.stop(true);
+			(*profiler_num_rendered_farblocks)++;
+		} else if(b->crude_mesh && !avoid_crude_mesh) {
+			scene::SMesh *mesh = b->crude_mesh;
+			TimeTaker tt(NULL, NULL, PRECISION_MICRO);
+			renderMesh(far_map, mesh, driver);
+			*profiler_render_time_fbcrudes_us += tt.stop(true);
+			(*profiler_num_rendered_fbcrudes)++;
+		}
+
+		if (fine_mesh_wanted &&
+				level_wanted <= FML_CRUDE) {
+			level_wanted = FML_FINE;
+		}
+	}
+
+	if (b->generating_mesh) {
+		//dstream<<"Currently generating mesh: "<<PP(b->p)<<std::endl;
+
+	} else if (b->getCurrentMeshLevel() < level_wanted) {
+		/*dstream<<"Wants mesh level="<<level_wanted<<", has "
+				<<b->getCurrentMeshLevel()<<": "<<PP(b->p)<<std::endl;*/
+
+		far_map->startGeneratingBlockMesh(b, level_wanted);
+
+	} else if (b->mesh_is_outdated) {
+		//dstream<<"Has outdated mesh: "<<PP(b->p)<<std::endl;
+
+		far_map->startGeneratingBlockMesh(b, level_wanted);
+
+	} else if (b->getCurrentMeshLevel() > level_wanted) {
+		/*dstream<<"Needs only mesh level="<<level_wanted<<", has "
+				<<b->getCurrentMeshLevel()<<": "<<PP(b->p)<<std::endl;*/
+
+		// Save RAM from these monstrosities if at all possible. We can unload
+		// them if we didn't start generating anything in the previous check.
+		// TODO: A timeout instead of an immediate drop would be good
+		if (level_wanted < FML_FINE_AND_SMALL) {
+			b->unloadMapblockMeshes();
+		}
+		if (level_wanted < FML_FINE) {
+			b->unloadFineMesh();
+		}
+	} else {
+		// Has the mesh it needs and is not generating mesh
+	}
+}
+
+void FarMap::render()
+{
+	ScopeProfiler sp_render(g_profiler, "Far: render time /frame", SPT_AVG);
+
+	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
+
+	u32 profiler_render_time_farblocks_us = 0;
+	u32 profiler_render_time_fbcrudes_us = 0;
+	u32 profiler_render_time_fbmbparts_us = 0;
+	u32 profiler_render_time_fbmb2parts_us = 0;
+	size_t profiler_num_total_farblocks = 0;
+	size_t profiler_num_rendered_farblocks = 0;
+	size_t profiler_num_rendered_fbcrudes = 0;
+	size_t profiler_num_rendered_fbmbparts = 0;
+	size_t profiler_num_rendered_fbmb2parts = 0;
+
+	//ClientEnvironment *client_env = &client->getEnv();
+	//ClientMap *map = &client_env->getClientMap();
+
+	for (std::map<v2s16, FarSector*>::iterator i = m_sectors.begin();
+			i != m_sectors.end(); i++) {
+		FarSector *s = i->second;
+		profiler_num_total_farblocks += s->blocks.size();
+
+		for (std::map<s16, FarBlock*>::iterator i = s->blocks.begin();
+				i != s->blocks.end(); i++) {
+			FarBlock *b = i->second;
+
+			renderBlock(this, b, driver,
+					&profiler_render_time_farblocks_us,
+					&profiler_render_time_fbcrudes_us,
+					&profiler_render_time_fbmbparts_us,
+					&profiler_render_time_fbmb2parts_us,
+					&profiler_num_rendered_farblocks,
+					&profiler_num_rendered_fbcrudes,
+					&profiler_num_rendered_fbmbparts,
+					&profiler_num_rendered_fbmb2parts);
+		}
+	}
+
+	g_profiler->avg("Far: total: farblocks",
+			profiler_num_total_farblocks);
+	g_profiler->avg("Far: render count: farblocks /frame",
+			profiler_num_rendered_farblocks);
+	g_profiler->avg("Far: render count: fbcrudes /frame",
+			profiler_num_rendered_fbcrudes);
+	g_profiler->avg("Far: render count: fbmbparts /frame",
+			profiler_num_rendered_fbmbparts);
+	g_profiler->avg("Far: render count: fbmb2parts /frame",
+			profiler_num_rendered_fbmb2parts);
+	g_profiler->avg("Far: render time: farblocks /frame",
+			profiler_render_time_farblocks_us / 1000000.f);
+	g_profiler->avg("Far: render time: fbcrudes /frame",
+			profiler_render_time_fbcrudes_us / 1000000.f);
+	g_profiler->avg("Far: render time: fbmbparts /frame",
+			profiler_render_time_fbmbparts_us / 1000000.f);
+	g_profiler->avg("Far: render time: fbmb2parts /frame",
+			profiler_render_time_fbmb2parts_us / 1000000.f);
+}
+
+void FarMap::OnRegisterSceneNode()
+{
+	if(IsVisible)
+	{
+		SceneManager->registerNodeForRendering(this, scene::ESNRP_SOLID);
+		//SceneManager->registerNodeForRendering(this, scene::ESNRP_TRANSPARENT);
+	}
+
+	ISceneNode::OnRegisterSceneNode();
+}
+
+const core::aabbox3d<f32>& FarMap::getBoundingBox() const
+{
+	return m_bounding_box;
+}

--- a/src/far_map.cpp
+++ b/src/far_map.cpp
@@ -1185,6 +1185,8 @@ void FarMap::startGeneratingBlockMesh(FarBlock *b,
 			this, *b, level);
 
 	m_worker_thread.addTask(t);
+
+	g_profiler->graphAdd("num_processed_far_meshes", 1);
 }
 
 void FarMap::insertGeneratedBlockMesh(
@@ -1431,6 +1433,8 @@ done:
 
 s16 FarMap::suggestAutosendFarblocksRadius()
 {
+	if (!isVisible())
+		return 0;
 	s16 fetch_distance_farblocks =
 			ceilf((float)config_far_map_range / MAP_BLOCKSIZE / FMP_SCALE);
 	return fetch_distance_farblocks;

--- a/src/far_map.h
+++ b/src/far_map.h
@@ -1,0 +1,320 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+#ifndef __FAR_MAP_H__
+#define __FAR_MAP_H__
+
+#include "far_map_common.h"
+#include "irrlichttypes_bloated.h"
+#include "util/thread.h" // UpdateThread
+#include "threading/atomic.h"
+#include "voxel.h" // VoxelArea
+#include "util/atlas.h"
+#include <ISceneNode.h>
+#include <SMesh.h>
+#include <vector>
+#include <map>
+
+class Client;
+class FarMap;
+
+enum FarMeshLevel {
+	FML_NONE,
+	FML_CRUDE,
+	FML_FINE,
+	FML_FINE_AND_SMALL
+};
+
+struct FarBlockBasicParameters
+{
+	// Position in FarBlocks
+	v3s16 p;
+	// In how many pieces MapBlocks have been divided per dimension
+	v3s16 divs_per_mb;
+	// Block's effective origin in FarNodes based on divs_per_mb
+	v3s16 dp00;
+	// Effective size of content in FarNodes based on divs_per_mb in global
+	// coordinates
+	v3s16 effective_size;
+	// Effective size of content in FarNodes based on divs_per_mb in global
+	// coordinates
+	VoxelArea effective_area;
+	// Raw size of content in FarNodes based on divs_per_mb in global
+	// coordinates
+	v3s16 content_size;
+	// Raw area of content in FarNodes based on divs_per_mb in global
+	// coordinates
+	VoxelArea content_area;
+
+	FarBlockBasicParameters(){}
+	FarBlockBasicParameters(v3s16 p, v3s16 divs_per_mb);
+};
+
+struct FarBlock: public FarBlockBasicParameters
+{
+	// Can be empty if server reports the FarBlock to be completely empty
+	std::vector<FarNode> content;
+
+	// If true, server has opted not to send this to us but may send it later.
+	// If true, content should always be empty.
+	bool is_culled_by_server;
+
+	// Information given by server. Really the important bit about this is that
+	// it's partially NOT loaded, which means we should ask again sometime so
+	// that the server may give us a more full loaded version.
+	bool load_in_progress_on_server;
+	s32 refresh_from_server_counter;
+
+	// Very crude mesh covering everything in this FarBlock
+	scene::SMesh *crude_mesh;
+
+	// Mesh covering everything in this FarBlock
+	scene::SMesh *fine_mesh;
+
+	// An array of MapBlock-sized meshes to be used when the area is partly
+	// being rendered from the regular Map and the whole mesh cannnot be used
+	std::vector<scene::SMesh*> mapblock_meshes;
+
+	// An array of 2x2x2-MapBlock-sized meshes to be used when the area is
+	// partly being rendered from the regular Map and the whole mesh cannnot be
+	// used
+	std::vector<scene::SMesh*> mapblock2_meshes;
+
+	// TODO: Some kind of usage timer for these small meshes so that they can be
+	//       unloaded when they are not needed anymore. However it is not
+	//       important because relatively few of them will be generated to begin
+	//       with.
+
+	// True while the mesh generator is running for this FarBlock. Old meshes
+	// may be available for rendering while it is running.
+	bool generating_mesh;
+
+	// Can be set to true while the mesh generator is running if needed
+	bool mesh_is_outdated;
+
+	// This is true after mesh has been generated and it has turned out that
+	// this FarBlock does not require any geometry. In that case, mesh will be
+	// NULL and regeneration should not be triggered based on it being NULL.
+	bool mesh_is_empty;
+
+	// Used by the faraway rendering error minimizing system
+	v3s16 current_camera_offset;
+
+	FarBlock(v3s16 p, v3s16 divs_per_mb);
+	~FarBlock();
+
+	void unloadFineMesh();
+	void unloadMapblockMeshes();
+
+	FarMeshLevel getCurrentMeshLevel();
+
+	void updateCameraOffset(v3s16 camera_offset);
+	void resetCameraOffset(v3s16 camera_offset = v3s16(0, 0, 0));
+
+	size_t index(v3s16 p) {
+		//p -= dp00;
+		assert(content_area.contains(p));
+		return content_area.index(p);
+	}
+};
+
+std::string analyze_far_block(FarBlock *b);
+
+// For some reason sectors seem to be faster than just a plain std::map<v3s16,
+// FarBlock*>, so that's what we use here.
+struct FarSector
+{
+	v2s16 p;
+
+	std::map<s16, FarBlock*> blocks;
+
+	FarSector(v2s16 p);
+	~FarSector();
+
+	FarBlock* getBlock(s16 p);
+	FarBlock* getOrCreateBlock(s16 p, v3s16 divs_per_mb);
+};
+
+struct FarMapTask
+{
+	virtual ~FarMapTask(){}
+	virtual void inThread() = 0;
+	virtual void sync() = 0;
+};
+
+struct FarBlockMeshGenerateTask: public FarMapTask
+{
+	FarMap *far_map;
+	FarBlock block;
+	FarMeshLevel level;
+
+	FarBlockMeshGenerateTask(FarMap *far_map, const FarBlock &source_block,
+			FarMeshLevel level);
+	~FarBlockMeshGenerateTask();
+	void inThread();
+	void sync();
+};
+
+struct CompressedFarBlock
+{
+	v3s16 fbp;
+	u8 status;
+	u8 flags;
+	v3s16 divs_per_mb;
+	std::string compressed_data;
+};
+
+struct FarBlockInsertTask: public FarMapTask
+{
+	FarMap *far_map;
+	CompressedFarBlock source;
+	FarBlockBasicParameters result_params;
+	std::vector<FarNode> result_content;
+
+	FarBlockInsertTask(FarMap *far_map, const CompressedFarBlock &source);
+	~FarBlockInsertTask();
+	void inThread();
+	void sync();
+};
+
+class FarMapWorkerThread: public UpdateThread
+{
+public:
+	FarMapWorkerThread():
+		UpdateThread("FarMapWorker"),
+		m_queue_in_length(0)
+	{}
+	~FarMapWorkerThread();
+
+	void addTask(FarMapTask *task);
+	void sync();
+	s32 getQueueLength() { return m_queue_in_length; }
+
+private:
+	void doUpdate();
+
+	MutexedQueue<FarMapTask*> m_queue_in;
+	MutexedQueue<FarMapTask*> m_queue_sync;
+
+	Atomic<s32> m_queue_in_length; // For profiling
+};
+
+struct FarAtlas
+{
+	struct NodeSegRefs {
+		atlas::AtlasSegmentReference refs[3]; // top, bottom, side
+		atlas::AtlasSegmentReference crude_refs[3]; // top, bottom, side
+	};
+
+	atlas::AtlasRegistry *atlas;
+	std::vector<NodeSegRefs> node_segrefs;
+	s32 mapnode_resolution;
+
+	FarAtlas(FarMap *far_map);
+	~FarAtlas();
+	void prepareForNodes(size_t num_nodes);
+	atlas::AtlasSegmentReference addTexture(const std::string &name,
+			bool is_top, bool crude, bool is_liquid);
+	void addNode(content_t id, const std::string &top,
+			const std::string &bottom, const std::string &side,
+			bool is_liquid);
+	const atlas::AtlasSegmentCache* getNode(
+			content_t id, u8 face, bool crude) const;
+};
+
+class FarMap: public scene::ISceneNode
+{
+public:
+	FarMap(
+			Client *client,
+			scene::ISceneNode* parent,
+			scene::ISceneManager* mgr,
+			s32 id
+	);
+	~FarMap();
+
+	FarSector* getSector(v2s16 p);
+	FarBlock* getBlock(v3s16 p);
+	FarSector* getOrCreateSector(v2s16 p);
+	FarBlock* getOrCreateBlock(v3s16 p, v3s16 divs_per_mb);
+
+	// Parameter dimensions are in MapBlocks
+	void insertCompressedFarBlock(const CompressedFarBlock &source_block);
+	// Swaps content into the FarBlock for efficiency
+	void insertFarBlock(v3s16 fbp, v3s16 divs_per_mb,
+			std::vector<FarNode> &content, bool is_partly_loaded);
+	void insertEmptyBlock(v3s16 fbp);
+	void insertCulledBlock(v3s16 fbp);
+	void insertLoadInProgressBlock(v3s16 fbp);
+
+	void startGeneratingBlockMesh(FarBlock *b, FarMeshLevel level);
+	void insertGeneratedBlockMesh(
+			v3s16 p, scene::SMesh *crude_mesh, scene::SMesh *fine_mesh,
+			const std::vector<scene::SMesh*> &mapblock_meshes,
+			const std::vector<scene::SMesh*> &mapblock2_meshes);
+
+	void update();
+	void updateCameraOffset(v3s16 camera_offset);
+
+	// ClientMap uses this to report what it's rendering so that FarMap can avoid
+	// rendering over it
+	void reportNormallyRenderedBlocks(const BlockAreaBitmap<bool> &nrb);
+
+	// Shall be called after the client receives all node definitions
+	void createAtlas();
+
+	std::vector<v3s16> suggestFarBlocksToFetch(v3s16 camera_p);
+	s16 suggestAutosendFarblocksRadius(); // Result in FarBlocks
+	float suggestFogDistance();
+
+	// ISceneNode methods
+	void OnRegisterSceneNode();
+	void render();
+	const core::aabbox3d<f32>& getBoundingBox() const;
+
+	Client *client;
+	FarAtlas atlas;
+
+	bool config_enable_shaders;
+	bool config_trilinear_filter;
+	bool config_bilinear_filter;
+	bool config_anisotropic_filter;
+	s16 config_far_map_range;
+
+	u32 farblock_shader_id;
+	BlockAreaBitmap<bool> normally_rendered_blocks;
+
+	v3s16 current_camera_offset;
+
+private:
+	void updateSettings();
+
+	FarMapWorkerThread m_worker_thread;
+
+	// Source data
+	std::map<v2s16, FarSector*> m_sectors;
+
+	// Rendering stuff
+	core::aabbox3d<f32> m_bounding_box;
+
+	// Fetch suggestion algorithm
+	s16 m_farblocks_exist_up_to_d;
+	s16 m_farblocks_exist_up_to_d_reset_counter;
+};
+
+#endif

--- a/src/far_map_common.cpp
+++ b/src/far_map_common.cpp
@@ -1,0 +1,75 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "far_map_common.h"
+#include <sstream>
+
+std::string analyze_far_block(v3s16 p, const std::vector<FarNode> &content,
+		const VoxelArea &content_area, const VoxelArea &effective_area)
+{
+	std::ostringstream os(std::ios::binary);
+	os<<"("<<p.X<<","<<p.Y<<","<<p.Z<<")";
+
+	if (content_area == effective_area)
+		os<<", no extra content area";
+	else if (content_area.contains(effective_area))
+		os<<", content area contains effective area";
+	else if (effective_area.contains(content_area))
+		os<<", effective area contains content area (WARNING)";
+	else
+		os<<", neither area contain each other (WARNING)";
+
+	s32 num_zero = 0;
+	s32 num_ignore = 0;
+	s32 num_air = 0;
+	s32 num_other = 0;
+	s32 num_zero_daylight = 0;
+	s32 num_max_daylight = 0;
+
+	v3s16 fnp;
+	for (fnp.Y=effective_area.MinEdge.Y; fnp.Y<=effective_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=effective_area.MinEdge.X; fnp.X<=effective_area.MaxEdge.X; fnp.X++)
+	for (fnp.Z=effective_area.MinEdge.Z; fnp.Z<=effective_area.MaxEdge.Z; fnp.Z++) {
+		size_t ci = content_area.index(fnp);
+		const FarNode &n = content[ci];
+		if (n.id == 0)
+			num_zero++;
+		else if (n.id == CONTENT_IGNORE)
+			num_ignore++;
+		else if (n.id == CONTENT_AIR)
+			num_air++;
+		else
+			num_other++;
+
+		if ((n.light & 0x0f) == 0)
+			num_zero_daylight++;
+		else if ((n.light & 0x0f) == 15)
+			num_max_daylight++;
+	}
+
+	os<<", "<<num_zero<<" zero";
+	os<<", "<<num_ignore<<" ignore";
+	os<<", "<<num_air<<" air";
+	os<<", "<<num_other<<" other";
+	os<<", "<<num_zero_daylight<<" zero_daylight";
+	os<<", "<<num_max_daylight<<" max_daylight";
+
+	return os.str();
+}
+

--- a/src/far_map_common.h
+++ b/src/far_map_common.h
@@ -1,0 +1,38 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+#ifndef __FAR_MAP_COMMON_H__
+#define __FAR_MAP_COMMON_H__
+
+#include "irrlichttypes.h" // v3s16
+#include "mapnode.h" // CONTENT_IGNORE
+#include "voxel.h" // VoxelArea
+#include <string>
+
+struct FarNode
+{
+	u16 id;
+	u8 light; // (day | (night << 4))
+
+	FarNode(u16 id=CONTENT_IGNORE, u8 light=0): id(id), light(light) {}
+};
+
+std::string analyze_far_block(v3s16 p, const std::vector<FarNode> &content,
+		const VoxelArea &content_area, const VoxelArea &effective_area);
+
+#endif

--- a/src/far_map_server.cpp
+++ b/src/far_map_server.cpp
@@ -1,0 +1,579 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "far_map_server.h"
+#include "constants.h"
+#include "nodedef.h"
+#include "profiler.h"
+#include "util/numeric.h"
+#include "util/string.h"
+
+#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
+
+/*
+	ServerFarBlock
+*/
+
+ServerFarBlock::ServerFarBlock(v3s16 p):
+	p(p),
+	modification_counter(0)
+{
+	// Block's effective origin in FarNodes based on block_div
+	v3s16 fnp0 = v3s16(
+			p.X * FMP_SCALE * SERVER_FB_MB_DIV,
+			p.Y * FMP_SCALE * SERVER_FB_MB_DIV,
+			p.Z * FMP_SCALE * SERVER_FB_MB_DIV);
+	
+	v3s16 area_size_fns = v3s16(
+			FMP_SCALE * SERVER_FB_MB_DIV,
+			FMP_SCALE * SERVER_FB_MB_DIV,
+			FMP_SCALE * SERVER_FB_MB_DIV);
+
+	v3s16 fnp1 = fnp0 + area_size_fns - v3s16(1,1,1); // Inclusive
+
+	content_area = VoxelArea(fnp0, fnp1);
+
+	size_t content_size_n = content_area.getVolume();
+
+	content.resize(content_size_n, CONTENT_IGNORE);
+
+	VoxelArea blocks_area(p * FMP_SCALE, (p+1) * FMP_SCALE - v3s16(1,1,1));
+	loaded_mapblocks.reset(blocks_area, ServerFarBlock::LS_UNKNOWN);
+}
+
+ServerFarBlock::~ServerFarBlock()
+{
+}
+
+std::string analyze_far_block(ServerFarBlock *b)
+{
+	if (b == NULL)
+		return "NULL";
+	std::string s = "["+analyze_far_block(
+			b->p, b->content, b->content_area, b->content_area);
+	s += ", modification_counter="+itos(b->modification_counter);
+	s += ", loaded_mapblocks=";
+	s += itos(b->loaded_mapblocks.count(ServerFarBlock::LS_UNKNOWN))+"U+";
+	s += itos(b->loaded_mapblocks.count(ServerFarBlock::LS_NOT_LOADED))+"N+";
+	s += itos(b->loaded_mapblocks.count(ServerFarBlock::LS_NOT_GENERATED))+"L+";
+	s += itos(b->loaded_mapblocks.count(ServerFarBlock::LS_GENERATED))+"G";
+	s += "/"+itos(b->loaded_mapblocks.size());
+	return s+"]";
+}
+
+/*
+	ServerFarMapPiece
+*/
+
+void ServerFarMapPiece::generateFrom(VoxelManipulator &vm, INodeDefManager *ndef)
+{
+	TimeTaker tt(NULL, NULL, PRECISION_MICRO);
+
+	v3s16 fnp0 = getContainerPos(vm.m_area.MinEdge, SERVER_FN_SIZE);
+	v3s16 fnp1 = getContainerPos(vm.m_area.MaxEdge, SERVER_FN_SIZE);
+	content_area = VoxelArea(fnp0, fnp1);
+
+	size_t content_size_n = content_area.getVolume();
+
+	content.resize(content_size_n, CONTENT_IGNORE);
+
+#if 0
+	v3s16 fnp;
+	for (fnp.Y=content_area.MinEdge.Y; fnp.Y<=content_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=content_area.MinEdge.X; fnp.X<=content_area.MaxEdge.X; fnp.X++)
+	for (fnp.Z=content_area.MinEdge.Z; fnp.Z<=content_area.MaxEdge.Z; fnp.Z++) {
+		size_t i = content_area.index(fnp);
+
+		u16 node_id = CONTENT_IGNORE;
+		u8 light = 0;
+
+		// Node at center of FarNode (horizontally)
+		v3s16 np(
+			fnp.X * SERVER_FN_SIZE + SERVER_FN_SIZE/2,
+			fnp.Y * SERVER_FN_SIZE + SERVER_FN_SIZE/2,
+			fnp.Z * SERVER_FN_SIZE + SERVER_FN_SIZE/2);
+		for(s32 i=0; i<SERVER_FN_SIZE+1; i++){
+			MapNode n = vm.getNodeNoEx(np);
+			if(n.getContent() == CONTENT_IGNORE)
+				break;
+			const ContentFeatures &f = ndef->get(n);
+			if (!f.name.empty() && f.param_type == CPT_LIGHT) {
+				light = n.param1;
+				if(node_id == CONTENT_IGNORE){
+					node_id = n.getContent();
+				}
+				break;
+			} else {
+				// TODO: Get light of a nearby node; something that defines
+				//       how brightly this division should be rendered
+				// (day | (night << 4))
+				light = (15) | (0<<4);
+				node_id = n.getContent();
+			}
+			np.Y++;
+		}
+
+		content[i].id = node_id;
+		content[i].light = light;
+	}
+#endif
+
+#if 0
+	v3s16 fnp;
+	for (fnp.Z=content_area.MinEdge.Z; fnp.Z<=content_area.MaxEdge.Z; fnp.Z++)
+	for (fnp.Y=content_area.MinEdge.Y; fnp.Y<=content_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=content_area.MinEdge.X; fnp.X<=content_area.MaxEdge.X; fnp.X++) {
+		size_t i = content_area.index(fnp);
+
+		std::map<u16, u16> node_amounts;
+		// (day | (night << 4))
+		u8 light = (15) | (0<<4);
+		bool light_found = false;
+
+		// Node at center of FarNode (horizontally)
+		v3s16 np0(
+			fnp.X * SERVER_FN_SIZE,
+			fnp.Y * SERVER_FN_SIZE,
+			fnp.Z * SERVER_FN_SIZE);
+		v3s16 np1(
+			fnp.X * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Y * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Z * SERVER_FN_SIZE + SERVER_FN_SIZE - 1);
+		v3s16 np;
+
+		for (np.Z = np0.Z; np.Z <= np1.Z; np.Z++)
+		for (np.Y = np0.Y; np.Y <= np1.Y; np.Y++)
+		for (np.X = np0.X; np.X <= np1.X; np.X++) {
+			MapNode n = vm.getNodeNoEx(np);
+			if(n.getContent() == CONTENT_IGNORE)
+				break;
+
+			node_amounts[n.getContent()]++;
+
+			if (!light_found) {
+				const ContentFeatures &f = ndef->get(n);
+				if (!f.name.empty() && f.param_type == CPT_LIGHT) {
+					light = n.param1;
+					light_found = true;
+				}
+			}
+		}
+
+		u16 max_id = CONTENT_IGNORE;
+		u16 max_amount = 0;
+		for (std::map<u16, u16>::const_iterator i = node_amounts.begin();
+				i != node_amounts.end(); i++) {
+			if (max_id == CONTENT_IGNORE || i->second > max_amount) {
+				max_id = i->first;
+				max_amount = i->second;
+				break;
+			}
+		}
+
+		content[i].id = max_id;
+		content[i].light = light;
+	}
+#endif
+
+#if 0
+	v3s16 fnp;
+	for (fnp.Z=content_area.MinEdge.Z; fnp.Z<=content_area.MaxEdge.Z; fnp.Z++)
+	for (fnp.Y=content_area.MinEdge.Y; fnp.Y<=content_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=content_area.MinEdge.X; fnp.X<=content_area.MaxEdge.X; fnp.X++) {
+		size_t i = content_area.index(fnp);
+
+		std::map<u16, u16> node_amounts;
+		// (day | (night << 4))
+		u8 light = (15) | (0<<4);
+		bool light_found = false;
+
+		// Node at center of FarNode (horizontally)
+		v3s16 np0(
+			fnp.X * SERVER_FN_SIZE,
+			fnp.Y * SERVER_FN_SIZE,
+			fnp.Z * SERVER_FN_SIZE);
+		v3s16 np1(
+			fnp.X * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Y * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Z * SERVER_FN_SIZE + SERVER_FN_SIZE - 1);
+		v3s16 np;
+
+		for (np.Z = np0.Z; np.Z <= np1.Z; np.Z++)
+		for (np.X = np0.X; np.X <= np1.X; np.X++) {
+			// Find the topmost solid-ish node from this Y column and add it in
+			// node_amounts
+			for (np.Y = np1.Y; np.Y >= np0.Y; np.Y--) {
+				MapNode n = vm.getNodeNoEx(np);
+				if(n.getContent() == CONTENT_IGNORE)
+					break;
+				const ContentFeatures &f = ndef->get(n);
+				// Skip if definition doesn't exist
+				if (f.name.empty())
+					continue;
+				// Get a light level if available
+				if (!light_found) {
+					if (!f.name.empty() && f.param_type == CPT_LIGHT) {
+						light = n.param1;
+						light_found = true;
+					}
+				}
+				// Skip if drawtype isn't something that a relatively solid node
+				// would have
+				if (
+					f.drawtype != NDT_NORMAL &&
+					f.drawtype != NDT_AIRLIKE &&
+					f.drawtype != NDT_LIQUID &&
+					f.drawtype != NDT_FLOWINGLIQUID &&
+					f.drawtype != NDT_GLASSLIKE &&
+					f.drawtype != NDT_ALLFACES &&
+					f.drawtype != NDT_ALLFACES_OPTIONAL &&
+					f.drawtype != NDT_NODEBOX &&
+					f.drawtype != NDT_GLASSLIKE_FRAMED &&
+					f.drawtype != NDT_GLASSLIKE_FRAMED_OPTIONAL
+				) {
+					continue;
+				}
+				// We guess this is good then
+				node_amounts[n.getContent()]++;
+				// Next Y column
+				break;
+			}
+		}
+
+		u16 max_id = CONTENT_IGNORE;
+		u16 max_amount = 0;
+		for (std::map<u16, u16>::const_iterator i = node_amounts.begin();
+				i != node_amounts.end(); i++) {
+			if (max_id == CONTENT_IGNORE || i->second > max_amount) {
+				max_id = i->first;
+				max_amount = i->second;
+				break;
+			}
+		}
+
+		content[i].id = max_id;
+		content[i].light = light;
+	}
+#endif
+
+#if 1
+	/*
+		Just... don't touch this. This is insanely delicate. -celeron55
+	*/
+	std::vector<v3s16> missing_light_fnps;
+	v3s16 fnp;
+	for (fnp.Z=content_area.MinEdge.Z; fnp.Z<=content_area.MaxEdge.Z; fnp.Z++)
+	for (fnp.Y=content_area.MinEdge.Y; fnp.Y<=content_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=content_area.MinEdge.X; fnp.X<=content_area.MaxEdge.X; fnp.X++) {
+		size_t content_i = content_area.index(fnp);
+
+		u32 light_day_sum = 0;
+		u32 light_night_sum = 0;
+		u16 light_count = 0;
+
+		std::map<u16, u16> node_amounts;
+
+		u16 amount_air = 0;
+		u16 amount_non_air = 0;
+
+		// Half of whatever the loops below do
+		const u16 half_amount_limit =
+				SERVER_FN_SIZE * SERVER_FN_SIZE * SERVER_FN_SIZE / 2 / 2;
+
+		// FarNode corners in MapNodes
+		v3s16 np0(
+			fnp.X * SERVER_FN_SIZE,
+			fnp.Y * SERVER_FN_SIZE,
+			fnp.Z * SERVER_FN_SIZE);
+		v3s16 np1(
+			fnp.X * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Y * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Z * SERVER_FN_SIZE + SERVER_FN_SIZE - 1);
+		v3s16 np;
+
+		// Divide only the other axis in half; that gives us enough speed for
+		// enough detail
+		for (np.Z = np0.Z; np.Z <= np1.Z; np.Z+=2)
+		for (np.X = np0.X; np.X <= np1.X; np.X++) {
+			// Find the topmost solid-ish node from this Y column and add it in
+			// node_amounts
+			// Start higher and go only halfway down because that looks better
+			for (np.Y = np1.Y; np.Y >= np0.Y; np.Y--) {
+				MapNode n = vm.getNodeNoEx(np);
+				if(n.getContent() == CONTENT_IGNORE)
+					continue;
+				const ContentFeatures &f = ndef->get(n);
+				// Skip if definition doesn't exist
+				if (f.name.empty())
+					continue;
+				// Get a light level if available
+				if (f.param_type == CPT_LIGHT) {
+					light_day_sum += (n.param1 & 0x0f);
+					light_night_sum += (n.param1 & 0xf0) >> 4;
+					light_count++;
+				}
+				// Continue through air, but still collect them
+				if (f.drawtype == NDT_AIRLIKE) {
+					amount_air++;
+					if (amount_air >= half_amount_limit &&
+							amount_air >= amount_non_air * 3) {
+						// Fast path
+						content[content_i].id = n.getContent();
+						goto already_chosen;
+					}
+					continue;
+				}
+				// Skip if drawtype isn't something that a relatively solid node
+				// would have
+				if (
+					f.drawtype != NDT_NORMAL &&
+					f.drawtype != NDT_LIQUID &&
+					f.drawtype != NDT_FLOWINGLIQUID &&
+					f.drawtype != NDT_GLASSLIKE &&
+					f.drawtype != NDT_ALLFACES &&
+					f.drawtype != NDT_ALLFACES_OPTIONAL &&
+					f.drawtype != NDT_NODEBOX &&
+					f.drawtype != NDT_GLASSLIKE_FRAMED &&
+					f.drawtype != NDT_GLASSLIKE_FRAMED_OPTIONAL &&
+					f.drawtype != NDT_MESH
+				) {
+					continue;
+				}
+				// We guess this is good then
+				amount_non_air++;
+				u16 amount_now = ++node_amounts[n.getContent()];
+				// Check fast path
+				if (amount_now >= half_amount_limit) {
+					content[content_i].id = n.getContent();
+					goto already_chosen;
+				}
+				// Next Y column
+				break;
+			}
+		}
+
+		// We don't really want to show air because it generally reveals dirt or
+		// stone from underneath but if there's a huge amount of it, then just
+		// show air.
+		if (amount_air >= amount_non_air * 3) {
+			content[content_i].id = CONTENT_AIR;
+		} else {
+			u16 max_id = CONTENT_IGNORE;
+			u16 max_amount = 0;
+			for (std::map<u16, u16>::const_iterator i = node_amounts.begin();
+					i != node_amounts.end(); i++) {
+				if (max_id == CONTENT_IGNORE || i->second > max_amount) {
+					max_id = i->first;
+					max_amount = i->second;
+				}
+			}
+			content[content_i].id = max_id;
+		}
+already_chosen:
+
+		if (light_count > 0) {
+			u8 light_day = light_day_sum / light_count;
+			u8 light_night = light_night_sum / light_count;
+			// (day | (night << 4))
+			content[content_i].light = (light_day) | (light_night<<4);
+			//content[content_i].light = (2) | (0<<4); // TODO: Remove
+		} else {
+			// Guess something that isn't too striking in neither when showing
+			// up inside a brightly lit surface or a completely black surface.
+			// Well, it's going to look kind of bad, but let's hope for the
+			// best.
+			static const u8 light_day = 8;
+			static const u8 light_night = 0;
+			// (day | (night << 4))
+			content[content_i].light = (light_day) | (light_night<<4);
+			//content[content_i].light = (11) | (0<<4); // TODO: Remove
+
+			// Try to figure a proper light value for this by special methods
+			missing_light_fnps.push_back(fnp);
+		}
+	}
+	// This loop is entered mainly for FarNodes that are buried completely
+	// underground, but not entirely due to inaccuracy of heuristic-based
+	// optimizations.
+	// The lighting this generates is used in special occasions like at FarBlock
+	// edges, as the nearby FarBlock may not be available for lighting
+	// information and the FarNode internal value of solid ground is used
+	// instead.
+	for (size_t fnp_i=0; fnp_i<missing_light_fnps.size(); fnp_i++) {
+		const v3s16 &fnp = missing_light_fnps[fnp_i];
+		size_t content_i = content_area.index(fnp);
+
+		// FarNode corners in MapNodes
+		v3s16 np0(
+			fnp.X * SERVER_FN_SIZE,
+			fnp.Y * SERVER_FN_SIZE,
+			fnp.Z * SERVER_FN_SIZE);
+		v3s16 np1(
+			fnp.X * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Y * SERVER_FN_SIZE + SERVER_FN_SIZE - 1,
+			fnp.Z * SERVER_FN_SIZE + SERVER_FN_SIZE - 1);
+
+		u32 light_day_sum = 0;
+		u32 light_night_sum = 0;
+		u16 light_count = 0;
+
+		static const v3s16 dps_to_try[] = {
+			// Middle of FarNode
+			v3s16(SERVER_FN_SIZE/2, SERVER_FN_SIZE/2, SERVER_FN_SIZE/2),
+			// Every inside corner of the FarNode
+			v3s16(0               , 0               , 0),
+			v3s16(SERVER_FN_SIZE-1, 0               , 0),
+			v3s16(0               , SERVER_FN_SIZE-1, 0),
+			v3s16(SERVER_FN_SIZE-1, SERVER_FN_SIZE-1, 0),
+			v3s16(0               , 0               , SERVER_FN_SIZE-1),
+			v3s16(SERVER_FN_SIZE-1, 0               , SERVER_FN_SIZE-1),
+			v3s16(0               , SERVER_FN_SIZE-1, SERVER_FN_SIZE-1),
+			v3s16(SERVER_FN_SIZE-1, SERVER_FN_SIZE-1, SERVER_FN_SIZE-1),
+		};
+		for (size_t i=0; i<ARRLEN(dps_to_try); i++) {
+			MapNode n = vm.getNodeNoEx(np0 + dps_to_try[i]);
+			if(n.getContent() == CONTENT_IGNORE)
+				continue;
+			const ContentFeatures &f = ndef->get(n);
+			if (f.param_type == CPT_LIGHT) {
+				light_day_sum += (n.param1 & 0x0f);
+				light_night_sum += (n.param1 & 0xf0) >> 4;
+				light_count++;
+			}
+		}
+		if (light_count > 0) {
+			u8 light_day = light_day_sum / light_count;
+			u8 light_night = light_night_sum / light_count;
+			// (day | (night << 4))
+			content[content_i].light = (light_day) | (light_night<<4);
+			//content[content_i].light = (15) | (0<<4); // TODO: Remove
+			// Figure out next missing light
+			continue;
+		}
+	}
+#endif
+
+	u32 t_us = tt.stop(true);
+	g_profiler->avg("Far: gen from MapBlock (avg us)", t_us);
+	g_profiler->add("Far: gen from MapBlock (total s)",
+			(float)t_us / 1000000.0f);
+}
+
+void ServerFarMapPiece::generateEmpty(const VoxelArea &area_nodes)
+{
+	v3s16 fnp0 = getContainerPos(area_nodes.MinEdge, SERVER_FN_SIZE);
+	v3s16 fnp1 = getContainerPos(area_nodes.MaxEdge, SERVER_FN_SIZE);
+	content_area = VoxelArea(fnp0, fnp1);
+
+	size_t content_size_n = content_area.getVolume();
+
+	content.resize(content_size_n, CONTENT_IGNORE);
+
+	v3s16 fnp;
+	for (fnp.Y=content_area.MinEdge.Y; fnp.Y<=content_area.MaxEdge.Y; fnp.Y++)
+	for (fnp.X=content_area.MinEdge.X; fnp.X<=content_area.MaxEdge.X; fnp.X++)
+	for (fnp.Z=content_area.MinEdge.Z; fnp.Z<=content_area.MaxEdge.Z; fnp.Z++) {
+		size_t i = content_area.index(fnp);
+		content[i].id = CONTENT_IGNORE;
+		content[i].light = 0; // (day | (night << 4))
+	}
+}
+
+/*
+	ServerFarMap
+*/
+
+ServerFarMap::ServerFarMap()
+{
+}
+
+ServerFarMap::~ServerFarMap()
+{
+	for (std::map<v3s16, ServerFarBlock*>::iterator i = m_blocks.begin();
+			i != m_blocks.end(); i++) {
+		delete i->second;
+	}
+}
+
+ServerFarBlock* ServerFarMap::getBlock(v3s16 p)
+{
+	std::map<v3s16, ServerFarBlock*>::iterator i = m_blocks.find(p);
+	if(i != m_blocks.end())
+		return i->second;
+	return NULL;
+}
+
+ServerFarBlock* ServerFarMap::getOrCreateBlock(v3s16 p)
+{
+	std::map<v3s16, ServerFarBlock*>::iterator i = m_blocks.find(p);
+	if(i != m_blocks.end())
+		return i->second;
+	ServerFarBlock *b = new ServerFarBlock(p);
+	m_blocks[p] = b;
+	return b;
+}
+
+void ServerFarMap::updateFrom(const ServerFarMapPiece &piece,
+		ServerFarBlock::LoadState load_state)
+{
+	v3s16 fnp000 = piece.content_area.MinEdge;
+	v3s16 fnp001 = piece.content_area.MaxEdge;
+
+	// TODO: Assert that this is the area of a single MapBlock because otherwise
+	//       load states are not handled properly
+
+	// Convert to ServerFarBlock positions (this can cover extra area)
+	VoxelArea fb_area(
+		getContainerPos(fnp000, FMP_SCALE * SERVER_FB_MB_DIV),
+		getContainerPos(fnp001, FMP_SCALE * SERVER_FB_MB_DIV)
+	);
+
+	v3s16 fbp;
+	for (fbp.Y=fb_area.MinEdge.Y; fbp.Y<=fb_area.MaxEdge.Y; fbp.Y++)
+	for (fbp.X=fb_area.MinEdge.X; fbp.X<=fb_area.MaxEdge.X; fbp.X++)
+	for (fbp.Z=fb_area.MinEdge.Z; fbp.Z<=fb_area.MaxEdge.Z; fbp.Z++) {
+		ServerFarBlock *b = getOrCreateBlock(fbp);
+
+		v3s16 fp00 = piece.content_area.MinEdge;
+		v3s16 fp01 = piece.content_area.MaxEdge;
+		v3s16 fp1;
+		for (fp1.Y=fp00.Y; fp1.Y<=fp01.Y; fp1.Y++)
+		for (fp1.X=fp00.X; fp1.X<=fp01.X; fp1.X++)
+		for (fp1.Z=fp00.Z; fp1.Z<=fp01.Z; fp1.Z++) {
+			// The source area does not necessarily contain all positions that
+			// the matching blocks contain
+			if(!piece.content_area.contains(fp1))
+				continue;
+			size_t source_i = piece.content_area.index(fp1);
+			size_t dst_i = b->content_area.index(fp1);
+			b->content[dst_i] = piece.content[source_i];
+
+			v3s16 mbp = getContainerPos(fp1, SERVER_FB_MB_DIV);
+			b->loaded_mapblocks.set(mbp, load_state);
+		}
+
+		b->modification_counter++;
+
+		/*// Call analyze_far_block before starting the line to keep lines
+		// mostly intact when multiple threads are printing
+		std::string s = analyze_far_block(b);
+		dstream<<"ServerFarMap: Updated block: "<<s<<std::endl;*/
+	}
+}
+

--- a/src/far_map_server.h
+++ b/src/far_map_server.h
@@ -1,0 +1,97 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+#ifndef __FAR_MAP_SERVER_H__
+#define __FAR_MAP_SERVER_H__
+
+#include "far_map_common.h"
+#include "irrlichttypes.h"
+#include "voxel.h" // VoxelArea
+#include <map>
+
+class INodeDefManager;
+
+// In how many pieces MapBlocks have been divided in each dimension to create
+// FarNodes
+#define SERVER_FB_MB_DIV 4
+#define SERVER_FN_SIZE (MAP_BLOCKSIZE / SERVER_FB_MB_DIV)
+
+struct ServerFarBlock
+{
+	// Position in FarBlocks
+	v3s16 p;
+	// Contained area in FarNodes. Is used to index node_ids and lights.
+	VoxelArea content_area;
+
+	std::vector<FarNode> content;
+
+	u32 modification_counter;
+
+	enum LoadState {
+		// State is not known; could be anything until checked
+		LS_UNKNOWN,
+		// Known to not having been checked from disk. Can be gotten to
+		// LS_NOT_GENERATED or LS_GENERATED state by emerging it with generation
+		// unallowed, or to LS_GENERATED state by emerging with generation
+		// allowed.
+		LS_NOT_LOADED,
+		// Checked from disk, and found to be not generated. Can be gotten to
+		// LS_GENERATED state by emerging with generation allowed.
+		LS_NOT_GENERATED,
+		// Checked from disk and found to be generated (or generated and written
+		// to disk).
+		LS_GENERATED,
+	};
+	BlockAreaBitmap<LoadState> loaded_mapblocks;
+
+	ServerFarBlock(v3s16 p);
+	~ServerFarBlock();
+};
+
+std::string analyze_far_block(ServerFarBlock *b);
+
+struct ServerFarMapPiece
+{
+	VoxelArea content_area;
+
+	std::vector<FarNode> content;
+
+	// Fills piece with CONTENT_IGNORE
+	void generateEmpty(const VoxelArea &area_nodes);
+
+	void generateFrom(VoxelManipulator &vm, INodeDefManager *ndef);
+};
+
+class ServerFarMap
+{
+public:
+	ServerFarMap();
+	~ServerFarMap();
+
+	ServerFarBlock* getBlock(v3s16 p);
+	ServerFarBlock* getOrCreateBlock(v3s16 p);
+
+	// Piece must consist of full MapBlocks
+	void updateFrom(const ServerFarMapPiece &piece,
+			ServerFarBlock::LoadState load_state);
+
+private:
+	std::map<v3s16, ServerFarBlock*> m_blocks;
+};
+
+#endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1809,7 +1809,7 @@ void Game::run()
 	f32 dtime; // in seconds
 
 	runData.time_from_last_punch  = 10.0;
-	runData.profiler_max_page = 3;
+	runData.profiler_max_page = 4;
 	runData.update_wielded_item_trigger = true;
 
 	flags.show_chat = true;

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -59,6 +59,7 @@ enum
 	GUI_ID_KEY_INVENTORY_BUTTON,
 	GUI_ID_KEY_DUMP_BUTTON,
 	GUI_ID_KEY_RANGE_BUTTON,
+	GUI_ID_KEY_TOGGLE_FAR_MAP_BUTTON,
 	// other
 	GUI_ID_CB_AUX1_DESCENDS,
 	GUI_ID_CB_DOUBLETAP_JUMP,
@@ -414,5 +415,6 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,    wgettext("Toggle noclip"),    "keymap_noclip");
 	this->add_key(GUI_ID_KEY_RANGE_BUTTON,     wgettext("Range select"),     "keymap_rangeselect");
 	this->add_key(GUI_ID_KEY_DUMP_BUTTON,      wgettext("Print stacks"),     "keymap_print_debug_stacks");
+	this->add_key(GUI_ID_KEY_TOGGLE_FAR_MAP_BUTTON, wgettext("Toggle far map"), "keymap_toggle_far_map_visibility");
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1431,6 +1431,8 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 	u32 saved_blocks_count = 0;
 	u32 block_count_all = 0;
 
+	u32 for_profiler_unloaded_due_to_total_number = 0;
+
 	beginSave();
 
 	// If there is no practical limit, we spare creation of mapblock_queue
@@ -1522,6 +1524,8 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 			// Delete from memory
 			b.sect->deleteBlock(block);
 
+			for_profiler_unloaded_due_to_total_number++;
+
 			if (unloaded_blocks)
 				unloaded_blocks->push_back(p);
 
@@ -1537,6 +1541,8 @@ void Map::timerUpdate(float dtime, float unload_timeout, u32 max_loaded_blocks,
 		}
 	}
 	endSave();
+
+	g_profiler->add("Map: Unloaded due to limit", for_profiler_unloaded_due_to_total_number);
 
 	// Finally delete the empty sectors
 	deleteSectors(sector_deletion_queue);

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/directiontables.h"
 #include <IMeshManipulator.h>
 
-static void applyFacesShading(video::SColor &color, const float factor)
+void applyFacesShading(video::SColor& color, float factor)
 {
 	color.setRed(core::clamp(core::round32(color.getRed() * factor), 0, 255));
 	color.setGreen(core::clamp(core::round32(color.getGreen() * factor), 0, 255));
@@ -364,7 +364,7 @@ void finalColorBlend(video::SColor& result,
 /*
 	vertex_dirs: v3s16[4]
 */
-static void getNodeVertexDirs(v3s16 dir, v3s16 *vertex_dirs)
+void getNodeVertexDirs(v3s16 dir, v3s16 *vertex_dirs)
 {
 	/*
 		If looked from outside the node towards the face, the corners are:

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -32,6 +32,8 @@ class IShaderSource;
 	Mesh making stuff
 */
 
+void applyFacesShading(video::SColor& color, float factor);
+void getNodeVertexDirs(v3s16 dir, v3s16 *vertex_dirs);
 
 class MapBlock;
 struct MinimapMapblock;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -153,6 +153,7 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 			bbox.addInternalBox(buf->getBoundingBox());
 	}
 	mesh->setBoundingBox(bbox);
+	mesh->setDirty(scene::EBT_VERTEX);
 }
 
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_FAR_BLOCKS_RESULT",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FarBlocksResult }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,
@@ -210,4 +210,6 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",          1, true }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",        1, true }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",        1, true }, // 0x52
+	null_command_factory, // 0x53
+	{ "TOSERVER_SET_WANTED_MAP_SEND_QUEUE", 2, true }, // 0x54
 };

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -108,6 +108,22 @@ public:
 		NetworkPacket& operator>>(video::SColor& dst);
 		NetworkPacket& operator<<(video::SColor src);
 
+		// With this function you can control the format you are reading from
+		// vs. the type you are putting your result into. Use for enums and
+		// stuff. Also allows nicer-looking code when you don't have to split
+		// reads into two statements.
+		template<typename T> T read() {
+			T buf;
+			*this >> buf;
+			return buf;
+		}
+
+		// Same thing for writing. Create a copy of the parameter just so that
+		// it can be implicitly or non-implicitly cast.
+		template<typename T> void write(T v) {
+			*this << v;
+		}
+
 		// Temp, we remove SharedBuffer when migration finished
 		Buffer<u8> oldForgePacket();
 private:

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -888,6 +888,8 @@ enum ToServerCommand
 		s16 radius_far
 		f1000 far_weight
 		f1000 fov (radians)
+		u32 max_total_mapblocks
+		u32 max_total_farblocks
 		Manual requests:
 		u32 len
 		for len:

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2010-2015 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -588,6 +588,19 @@ enum ToClientCommand
 		u32 id
 	*/
 
+	TOCLIENT_FAR_BLOCKS_RESULT = 0x54,
+	/*
+		v3s16 p (position in farblocks)
+		u8 status
+		u8 flags
+		v3s16 divs_per_mb (amount of divisions (FarNodes) per mapblock)
+		u32 data_len
+		Zlib-compressed:
+			for each FarNode (indexed by VoxelArea):
+				u16 node_id
+				u8 light (both lightbanks; raw value)
+	*/
+
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
 		Belonging to AUTH_MECHANISM_LEGACY_PASSWORD and AUTH_MECHANISM_SRP.
@@ -648,11 +661,13 @@ enum ToServerCommand
 
 	TOSERVER_GOTBLOCKS = 0x24,
 	/*
-		[0] u16 command
-		[2] u8 count
-		[3] v3s16 pos_0
-		[3+6] v3s16 pos_1
-		...
+		u8 count_mb
+		for count_mb:
+			v3s16 mapblock_p
+		# Following added mid of version 26
+		u8 count_fb
+		for count_fb
+			v3s16 farblock_p
 	*/
 
 	TOSERVER_DELETEDBLOCKS = 0x25,
@@ -866,7 +881,21 @@ enum ToServerCommand
 		std::string bytes_M
 	*/
 
-	TOSERVER_NUM_MSG_TYPES = 0x53,
+	TOSERVER_SET_WANTED_MAP_SEND_QUEUE = 0x54,
+	/*
+		Autosend parameters:
+		s16 radius_map
+		s16 radius_far
+		f1000 far_weight
+		f1000 fov (radians)
+		Manual requests:
+		u32 len
+		for len:
+			u8 type // 1=MapBlock, 2=FarBlock
+			v3s16 p
+	*/
+
+	TOSERVER_NUM_MSG_TYPES = 0x55,
 };
 
 enum AuthMechanism
@@ -919,6 +948,53 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"",
 	"Server shutting down.",
 	"This server has experienced an internal error. You will now be disconnected."
+};
+
+enum WantedMapSendType {
+	WMST_INVALID = 0,
+	WMST_MAPBLOCK = 1,
+	WMST_FARBLOCK = 2,
+};
+
+struct WantedMapSend
+{
+	WantedMapSendType type; // Sent as u8
+	v3s16 p;
+
+	WantedMapSend(WantedMapSendType type=WMST_INVALID, v3s16 p=v3s16(0,0,0)):
+		type(type), p(p) {}
+
+	// This is for insertion in an std::map or std::set
+	bool operator < (const WantedMapSend &other) const
+	{
+		if (type < other.type) return true;
+		if (type > other.type) return false;
+		if (p < other.p) return true;
+		return false;
+	}
+
+	std::string describe() const {
+		if (type == WMST_INVALID)
+			return "INVALID";
+		else if(type == WMST_MAPBLOCK)
+			return "MAPBLOCK("+itos(p.X)+","+itos(p.Y)+","+itos(p.Z)+")";
+		else if(type == WMST_FARBLOCK)
+			return "FARBLOCK("+itos(p.X)+","+itos(p.Y)+","+itos(p.Z)+")";
+		else
+			return "?("+itos(p.X)+","+itos(p.Y)+","+itos(p.Z)+")";
+	}
+};
+
+enum FarBlocksResultStatus {
+	FBRS_FULLY_LOADED = 0,
+	FBRS_PARTLY_LOADED = 1,
+	FBRS_EMPTY = 2,
+	FBRS_CULLED = 3,
+	FBRS_LOAD_IN_PROGRESS = 4,
+};
+
+enum FarBlocksResultFlag {
+	// Nothing for now
 };
 
 #endif

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -107,6 +107,8 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	{ "TOSERVER_FIRST_SRP",          TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_FirstSrp }, // 0x50
 	{ "TOSERVER_SRP_BYTES_A",        TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesA }, // 0x51
 	{ "TOSERVER_SRP_BYTES_M",        TOSERVER_STATE_NOT_CONNECTED, &Server::handleCommand_SrpBytesM }, // 0x52
+	null_command_handler, // 0x53
+	{ "TOSERVER_SET_WANTED_MAP_SEND_QUEUE", TOSERVER_STATE_INGAME, &Server::handleCommand_SetWantedMapSendQueue }, // 0x54
 };
 
 const static ClientCommandFactory null_command_factory = { "TOCLIENT_NULL", 0, false };
@@ -197,7 +199,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_FAR_BLOCKS_RESULT",        2, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -2068,6 +2068,8 @@ void Server::handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt_in)
 		s16 radius_far
 		f1000 far_weight
 		f1000 fov
+		u32 max_total_mapblocks
+		u32 max_total_farblocks
 		Manual requests:
 		u32 len
 		for len:
@@ -2079,6 +2081,8 @@ void Server::handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt_in)
 	s16 autosend_radius_far = pkt_in->read<s16>();
 	float autosend_far_weight = pkt_in->read<float>();
 	float autosend_fov = pkt_in->read<float>();
+	u32 autosend_max_total_mapblocks = pkt_in->read<u32>();
+	u32 autosend_max_total_farblocks = pkt_in->read<u32>();
 	u32 wanted_map_send_queue_len = pkt_in->read<u32>();
 
 	/*dstream << "Client " << pkt_in->getPeerId()
@@ -2086,6 +2090,8 @@ void Server::handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt_in)
 			<< ", radius_far=" << autosend_radius_far
 			<< ", far_weight=" << autosend_far_weight
 			<< ", fov=" << autosend_fov
+			<< ", max_total_mapblocks=" << autosend_max_total_mapblocks
+			<< ", max_total_farblocks=" << autosend_max_total_farblocks
 			<< ", wanted_map_send_queue_len=" << wanted_map_send_queue_len
 			<< std::endl;*/
 
@@ -2103,7 +2109,8 @@ void Server::handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt_in)
 	// Set the values in RemoteClient; data transfer is handled elsewhere.
 	RemoteClient* client = getClient(pkt_in->getPeerId(), CS_Created);
 	client->setAutosendParameters(autosend_radius_map, autosend_radius_far,
-			autosend_far_weight, autosend_fov);
+			autosend_far_weight, autosend_fov, autosend_max_total_mapblocks,
+			autosend_max_total_farblocks);
 	client->setMapSendQueue(wanted_map_send_queue);
 }
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -750,27 +750,31 @@ void Server::handleCommand_GotBlocks(NetworkPacket* pkt)
 		return;
 
 	/*
-		[0] u16 command
-		[2] u8 count
-		[3] v3s16 pos_0
-		[3+6] v3s16 pos_1
-		...
+		u8 count_mb
+		for count_mb:
+			v3s16 mapblock_p
+		# Following added mid of version 26
+		u8 count_fb
+		for count_fb
+			v3s16 farblock_p
 	*/
 
-	u8 count;
-	*pkt >> count;
+	u8 count = pkt->read<u8>();
 
 	RemoteClient *client = getClient(pkt->getPeerId());
 
-	if ((s16)pkt->getSize() < 1 + (int)count * 6) {
-		throw con::InvalidIncomingDataException
-				("GOTBLOCKS length is too short");
-	}
-
 	for (u16 i = 0; i < count; i++) {
-		v3s16 p;
-		*pkt >> p;
-		client->GotBlock(p);
+		v3s16 p = pkt->read<v3s16>();
+		client->GotBlock(WantedMapSend(WMST_MAPBLOCK, p));
+	}
+	try {
+		u8 farblock_count = pkt->read<u8>();
+		for (u16 i = 0; i < farblock_count; i++) {
+			v3s16 p = pkt->read<v3s16>();
+			client->GotBlock(WantedMapSend(WMST_FARBLOCK, p));
+		}
+	} catch(PacketError &e) {
+		// It's the old packet without the farblock list
 	}
 }
 
@@ -873,7 +877,7 @@ void Server::handleCommand_DeletedBlocks(NetworkPacket* pkt)
 	for (u16 i = 0; i < count; i++) {
 		v3s16 p;
 		*pkt >> p;
-		client->SetBlockNotSent(p);
+		client->SetMapBlockUpdated(p);
 	}
 }
 
@@ -1373,7 +1377,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			// Re-send block to revert change on client-side
 			RemoteClient *client = getClient(pkt->getPeerId());
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_under, BS));
-			client->SetBlockNotSent(blockpos);
+			client->SetMapBlockUpdated(blockpos);
 			// Call callbacks
 			m_script->on_cheat(playersao, "interacted_too_far");
 			// Do nothing else
@@ -1393,12 +1397,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		// Digging completed -> under
 		if (action == 2) {
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_under, BS));
-			client->SetBlockNotSent(blockpos);
+			client->SetMapBlockUpdated(blockpos);
 		}
 		// Placement -> above
 		if (action == 3) {
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_above, BS));
-			client->SetBlockNotSent(blockpos);
+			client->SetMapBlockUpdated(blockpos);
 		}
 		return;
 	}
@@ -1576,10 +1580,10 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			// Send unusual result (that is, node not being removed)
 			if (m_env->getMap().getNodeNoEx(p_under).getContent() != CONTENT_AIR) {
 				// Re-send block to revert change on client-side
-				client->SetBlockNotSent(blockpos);
+				client->SetMapBlockUpdated(blockpos);
 			}
 			else {
-				client->ResendBlockIfOnWire(blockpos);
+				client->ResendMapBlockIfOnWire(blockpos);
 			}
 		}
 	} // action == 2
@@ -1625,15 +1629,15 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_above, BS));
 		v3s16 blockpos2 = getNodeBlockPos(floatToInt(pointed_pos_under, BS));
 		if (item.getDefinition(m_itemdef).node_placement_prediction != "") {
-			client->SetBlockNotSent(blockpos);
+			client->SetMapBlockUpdated(blockpos);
 			if (blockpos2 != blockpos) {
-				client->SetBlockNotSent(blockpos2);
+				client->SetMapBlockUpdated(blockpos2);
 			}
 		}
 		else {
-			client->ResendBlockIfOnWire(blockpos);
+			client->ResendMapBlockIfOnWire(blockpos);
 			if (blockpos2 != blockpos) {
-				client->ResendBlockIfOnWire(blockpos2);
+				client->ResendMapBlockIfOnWire(blockpos2);
 			}
 		}
 	} // action == 3
@@ -1977,7 +1981,7 @@ void Server::handleCommand_SrpBytesM(NetworkPacket* pkt)
 
 	bool wantSudo = (cstate == CS_Active);
 
-	verbosestream << "Server: Recieved TOCLIENT_SRP_BYTES_M." << std::endl;
+	verbosestream << "Server: Received TOCLIENT_SRP_BYTES_M." << std::endl;
 
 	if (!((cstate == CS_HelloSent) || (cstate == CS_Active))) {
 		actionstream << "Server: got SRP _M packet in wrong state "
@@ -2053,3 +2057,53 @@ void Server::handleCommand_SrpBytesM(NetworkPacket* pkt)
 
 	acceptAuth(pkt->getPeerId(), wantSudo);
 }
+
+void Server::handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt_in)
+{
+	infostream << "Server: Received SET_WANTED_MAP_SEND_QUEUE" << std::endl;
+
+	/*
+		Autosend parameters:
+		s16 radius_map
+		s16 radius_far
+		f1000 far_weight
+		f1000 fov
+		Manual requests:
+		u32 len
+		for len:
+			u8 type // 1=MapBlock, 2=FarBlock
+			v3s16 p
+	*/
+
+	s16 autosend_radius_map = pkt_in->read<s16>();
+	s16 autosend_radius_far = pkt_in->read<s16>();
+	float autosend_far_weight = pkt_in->read<float>();
+	float autosend_fov = pkt_in->read<float>();
+	u32 wanted_map_send_queue_len = pkt_in->read<u32>();
+
+	/*dstream << "Client " << pkt_in->getPeerId()
+			<< ": radius_map=" << autosend_radius_map
+			<< ", radius_far=" << autosend_radius_far
+			<< ", far_weight=" << autosend_far_weight
+			<< ", fov=" << autosend_fov
+			<< ", wanted_map_send_queue_len=" << wanted_map_send_queue_len
+			<< std::endl;*/
+
+	// Use a vector, because this is not really strictly a queue. It's more like
+	// a pre-prioritized list.
+	std::vector<WantedMapSend> wanted_map_send_queue;
+	wanted_map_send_queue.reserve(wanted_map_send_queue_len);
+	for (u32 i=0; i<wanted_map_send_queue_len; i++) {
+		WantedMapSend wms;
+		wms.type = (WantedMapSendType)pkt_in->read<u8>();
+		wms.p = pkt_in->read<v3s16>();
+		wanted_map_send_queue.push_back(wms);
+	}
+
+	// Set the values in RemoteClient; data transfer is handled elsewhere.
+	RemoteClient* client = getClient(pkt_in->getPeerId(), CS_Created);
+	client->setAutosendParameters(autosend_radius_map, autosend_radius_far,
+			autosend_far_weight, autosend_fov);
+	client->setMapSendQueue(wanted_map_send_queue);
+}
+

--- a/src/network/wms_priority.h
+++ b/src/network/wms_priority.h
@@ -1,0 +1,76 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef WMS_PRIORITY_HEADER
+#define WMS_PRIORITY_HEADER
+#include "constants.h"
+#include "networkprotocol.h"
+
+struct WMSPriority
+{
+	v3s16 player_p;
+	float far_weight;
+
+	WMSPriority(v3s16 player_p, float far_weight):
+		player_p(player_p),
+		far_weight(far_weight)
+	{}
+
+	// Lower is more important
+	float getPriority(const WantedMapSend &wms) {
+		float priority;
+		switch (wms.type) {
+		case WMST_INVALID:
+			assert("WMST_INVALID");
+			priority = 1000000;
+			break;
+		case WMST_MAPBLOCK:
+			{
+				v3s16 center_p = wms.p * MAP_BLOCKSIZE +
+						v3s16(1,1,1) * (MAP_BLOCKSIZE/2);
+				priority = (player_p - center_p).getLength();
+			}
+			break;
+		case WMST_FARBLOCK:
+			{
+				v3s16 center_p = wms.p * MAP_BLOCKSIZE * FMP_SCALE +
+						v3s16(1,1,1) * (MAP_BLOCKSIZE*FMP_SCALE/2);
+				priority = (player_p - center_p).getLength();
+
+				// Lessen priority by a static amount so that close-by MapBlocks
+				// are always transferred first
+				priority += MAP_BLOCKSIZE * FMP_SCALE;
+
+				priority /= far_weight;
+			}
+			break;
+		default:
+			priority = 1000000;
+			break;
+		}
+		return priority;
+	}
+
+	// Sorts WantedMapSends in descending order of priority
+	bool operator() (const WantedMapSend& wms1, const WantedMapSend& wms2) {
+		return (getPriority(wms1) < getPriority(wms2));
+	}
+};
+
+#endif

--- a/src/network/wms_priority.h
+++ b/src/network/wms_priority.h
@@ -57,7 +57,12 @@ struct WMSPriority
 				// are always transferred first
 				priority += MAP_BLOCKSIZE * FMP_SCALE;
 
-				priority /= far_weight;
+				if (far_weight <= 0.0f)
+					priority /= 0.1f; // Just get some proportional large value
+					                  // so that FarBlocks are in correct order
+					                  // to each other
+				else
+					priority /= far_weight;
 			}
 			break;
 		default:

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -205,7 +205,7 @@ public:
 		m_type(type)
 	{
 		if(m_profiler)
-			m_timer = new TimeTaker(m_name.c_str());
+			m_timer = new TimeTaker(m_name.c_str(), NULL, PRECISION_MICRO);
 	}
 	// name is copied
 	ScopeProfiler(Profiler *profiler, const char *name,
@@ -216,14 +216,14 @@ public:
 		m_type(type)
 	{
 		if(m_profiler)
-			m_timer = new TimeTaker(m_name.c_str());
+			m_timer = new TimeTaker(m_name.c_str(), NULL, PRECISION_MICRO);
 	}
 	~ScopeProfiler()
 	{
 		if(m_timer)
 		{
-			float duration_ms = m_timer->stop(true);
-			float duration = duration_ms / 1000.0;
+			float duration_us = m_timer->stop(true);
+			float duration = duration_us / 1000000.0;
 			if(m_profiler){
 				switch(m_type){
 				case SPT_ADD:

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2181,7 +2181,7 @@ void Server::SendBlocks(float dtime)
 
 	ScopeProfiler sp(g_profiler, "Server: sel and send blocks to clients");
 
-	bool max_simultaneous_block_sends_server_total =
+	s32 max_simultaneous_block_sends_server_total =
 			g_settings->getS32("max_simultaneous_block_sends_server_total");
 
 	std::vector<u16> clients = m_clients.getClientIDs();

--- a/src/server.h
+++ b/src/server.h
@@ -57,6 +57,7 @@ class GameScripting;
 class ServerEnvironment;
 struct SimpleSoundSpec;
 class ServerThread;
+class ServerFarMap;
 
 enum ClientDeletionReason {
 	CDR_LEAVE,
@@ -217,6 +218,7 @@ public:
 	void handleCommand_FirstSrp(NetworkPacket* pkt);
 	void handleCommand_SrpBytesA(NetworkPacket* pkt);
 	void handleCommand_SrpBytesM(NetworkPacket* pkt);
+	void handleCommand_SetWantedMapSendQueue(NetworkPacket* pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -400,7 +402,7 @@ private:
 	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);
 
 	/* mark blocks not sent for all clients */
-	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
+	void SetMapBlocksUpdated(std::map<v3s16, MapBlock *>& blocks);
 
 
 	void SendChatMessage(u16 peer_id, const std::wstring &message);
@@ -565,6 +567,9 @@ private:
 
 	// Mods
 	std::vector<ModSpec> m_mods;
+
+	// Server-side far map
+	ServerFarMap *m_far_map;
 
 	/*
 		Threads

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -622,6 +622,12 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 		geometry_program = "";
 	}
 
+	/*infostream<<"Shader "<<name
+			<<": vertex_program.size()="<<vertex_program.size()
+			<<", pixel_program.size()="<<pixel_program.size()
+			<<", geometry_program.size()="<<geometry_program.size()
+			<<std::endl;*/
+
 	// If no shaders are used, don't make a separate material type
 	if(vertex_program == "" && pixel_program == "" && geometry_program == "")
 		return shaderinfo;

--- a/src/util/atlas.cpp
+++ b/src/util/atlas.cpp
@@ -1,0 +1,572 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "atlas.h"
+#include "string.h"
+#include "log.h"
+#include "../gamedef.h"
+#include "../client/tile.h" // ITextureSource
+#include "../exceptions.h"
+#include "irrlichttypes_extrabloated.h"
+
+namespace atlas {
+
+bool AtlasSegmentDefinition::operator==(const AtlasSegmentDefinition &other) const
+{
+	return (
+			image_name == other.image_name &&
+			total_segments == other.total_segments &&
+			select_segment == other.select_segment &&
+			lod_simulation == other.lod_simulation
+	);
+}
+
+struct CAtlasRegistry: public AtlasRegistry
+{
+	std::string m_name; // Required for unique texture name generation in Irrlicht
+	video::IVideoDriver *m_driver;
+	IGameDef *m_gamedef;
+	std::vector<AtlasDefinition> m_defs;
+	std::vector<AtlasCache> m_cache;
+	v2u32 m_max_texture_resolution;
+
+	CAtlasRegistry(const std::string &name, video::IVideoDriver *driver,
+			IGameDef *gamedef):
+		m_name(name),
+		m_driver(driver),
+		m_gamedef(gamedef)
+	{
+		m_defs.resize(1); // id=0 is ATLAS_UNDEFINED
+		m_max_texture_resolution = driver->getMaxTextureSize();
+		infostream<<"AtlasRegistry: Maximum texture resolution: "
+				<<m_max_texture_resolution.X<<"x"
+				<<m_max_texture_resolution.Y<<std::endl;
+	}
+
+	void prepare_for_segments(size_t num_segments, v2s32 segment_size)
+	{
+		// Lessen the maximum texture size if we don't need such a large one
+		// The size needed is 2x2 the segment size due to padding that is used
+		// for avoiding texture bleeding
+		size_t size_needed = 2 * npot2(ceilf(sqrt(
+				segment_size.X * segment_size.Y * num_segments)));
+		if (m_max_texture_resolution.X > size_needed)
+			m_max_texture_resolution.X = size_needed;
+		if (m_max_texture_resolution.Y > size_needed)
+			m_max_texture_resolution.Y = size_needed;
+		infostream<<"AtlasRegistry: Optimized texture resolution: "
+				<<m_max_texture_resolution.X<<"x"
+				<<m_max_texture_resolution.Y<<std::endl;
+	}
+
+	video::IImage* textureToImage(video::ITexture* texture)
+	{
+		if (!texture) return NULL;
+		video::IImage* image = m_driver->createImageFromData(
+				texture->getColorFormat(),
+				texture->getSize(),
+				texture->lock(),
+				false, // ownForeignMemory
+				false // deleteMemory
+		);
+		texture->unlock();
+		return image;
+	}
+
+	const AtlasSegmentReference add_segment(
+			const AtlasSegmentDefinition &segment_def)
+	{
+		ITextureSource *tsrc = m_gamedef->getTextureSource();
+
+		// TODO: Maybe creating an image out of a texture isn't a very good idea
+		//       as images are the actual in-memory source format
+		//video::ITexture *seg_tex = tsrc->getTexture(segment_def.image_name);
+		//video::IImage *seg_img = textureToImage(seg_tex);
+
+		video::IImage *seg_img = tsrc->generateImage(segment_def.image_name);
+
+		// Get resolution of texture
+		v2s32 seg_img_size(seg_img->getDimension().Width, seg_img->getDimension().Height);
+		if (segment_def.target_size != v2s32(0, 0)) {
+			// Override target size as requested
+			seg_img_size = segment_def.target_size;
+		} else if (segment_def.lod_simulation >= 2) {
+			// Force the same size for everything in order to optimize number of
+			// texture atlases
+			seg_img_size.X = 64;
+			seg_img_size.Y = 64;
+		}
+		// Try to find a texture atlas for this texture size
+		AtlasDefinition *atlas_def = NULL;
+		for(size_t i=0; i<m_defs.size(); i++){
+			AtlasDefinition &def0 = m_defs[i];
+			if(def0.id == ATLAS_UNDEFINED)
+				continue;
+			if(def0.segment_resolution == seg_img_size){
+				size_t max = def0.total_segments.X * def0.total_segments.Y;
+				if(def0.segments.size() >= max){
+					/*log_d(MODULE, "add_segment(): Found atlas for segment size "
+							"(%i, %i) %p, but it is full",
+							seg_img_size.X, seg_img_size.Y, &def0);*/
+					continue; // Full
+				}
+				atlas_def = &def0;
+				break;
+			}
+		}
+		// If not found, create a texture atlas for this texture size
+		if(atlas_def){
+			/*log_d(MODULE, "add_segment(): Found atlas for segment size "
+					"(%i, %i): %p", seg_img_size.X, seg_img_size.Y, atlas_def);*/
+		} else {
+			// Create a new texture atlas
+			m_defs.resize(m_defs.size()+1);
+			atlas_def = &m_defs[m_defs.size()-1];
+			/*log_d(MODULE, "add_segment(): Creating atlas for segment size "
+					"(%i, %i): %p", seg_img_size.X, seg_img_size.Y, atlas_def);*/
+			atlas_def->id = m_defs.size()-1;
+			if(segment_def.total_segments.X == 0 ||
+					segment_def.total_segments.Y == 0)
+				throw BaseException("segment_def.total_segments is zero");
+			// Calculate segment resolution
+			v2s32 seg_res(
+					seg_img_size.X / segment_def.total_segments.X,
+					seg_img_size.Y / segment_def.total_segments.Y
+			);
+			atlas_def->segment_resolution = seg_res;
+			// Calculate total segments based on segment resolution
+			atlas_def->total_segments = v2s32(
+					m_max_texture_resolution.X / seg_res.X / 2,
+					m_max_texture_resolution.Y / seg_res.Y / 2
+			);
+			v2s32 atlas_resolution(
+					atlas_def->total_segments.X * seg_res.X * 2,
+					atlas_def->total_segments.Y * seg_res.Y * 2
+			);
+			// Create image for new atlas
+			video::IImage *atlas_img = m_driver->createImage(video::ECF_A8R8G8B8,
+					core::dimension2d<u32>(atlas_resolution.X, atlas_resolution.Y));
+			// Add new atlas to cache
+			const size_t &id = atlas_def->id;
+			m_cache.resize(id+1);
+			AtlasCache &atlas_cache = m_cache[id];
+			atlas_cache.id = id;
+			atlas_cache.image = atlas_img;
+			atlas_cache.image->grab();
+			atlas_cache.texture = NULL;
+			atlas_cache.texture_name = std::string()+"atlas_"+m_name+"_texture_"+itos(id);
+			atlas_cache.segment_resolution = atlas_def->segment_resolution;
+			atlas_cache.total_segments = atlas_def->total_segments;
+		}
+		// Add this segment to the atlas definition
+		size_t seg_id = atlas_def->segments.size();
+		atlas_def->segments.resize(seg_id + 1);
+		atlas_def->segments[seg_id] = segment_def;
+		// Update this segment in cache
+		AtlasCache &atlas_cache = m_cache[atlas_def->id];
+		atlas_cache.segments.resize(seg_id + 1);
+		AtlasSegmentCache &seg_cache = atlas_cache.segments[seg_id];
+		update_segment_cache(seg_id, seg_img, seg_cache, segment_def, atlas_cache);
+		/*// DEBUG
+		static int si = 0;
+		std::string path = std::string()+"/tmp/seg_img_"+itos(si++)+".png";
+		m_driver->writeImageToFile(seg_img, path.c_str(), 0);*/
+		seg_img->drop();
+		// Return reference to new segment
+		AtlasSegmentReference ref;
+		ref.atlas_id = atlas_def->id;
+		ref.segment_id = seg_id;
+		return ref;
+	}
+
+	const AtlasSegmentReference find_or_add_segment(
+			const AtlasSegmentDefinition &segment_def)
+	{
+		// Find an atlas that contains this segment; return reference if found
+		for(size_t i=0; i<m_defs.size(); i++){
+			AtlasDefinition &atlas_def = m_defs[i];
+			for(size_t seg_id = 0; seg_id<atlas_def.segments.size(); seg_id++){
+				AtlasSegmentDefinition &segment_def0 = atlas_def.segments[seg_id];
+				if(segment_def0 == segment_def){
+					AtlasSegmentReference ref;
+					ref.atlas_id = atlas_def.id;
+					ref.segment_id = seg_id;
+					return ref;
+				}
+			}
+		}
+		// Segment was not found; add a new one
+		return add_segment(segment_def);
+	}
+
+	const AtlasDefinition* get_atlas_definition(size_t atlas_id)
+	{
+		if(atlas_id == ATLAS_UNDEFINED)
+			return NULL;
+		if(atlas_id >= m_defs.size())
+			return NULL;
+		return &m_defs[atlas_id];
+	}
+
+	const AtlasSegmentDefinition* get_segment_definition(
+			const AtlasSegmentReference &ref)
+	{
+		const AtlasDefinition *atlas = get_atlas_definition(ref.atlas_id);
+		if(!atlas)
+			return NULL;
+		if(ref.segment_id >= atlas->segments.size())
+			return NULL;
+		return &atlas->segments[ref.segment_id];
+	}
+
+	void update_segment_cache(size_t seg_id, video::IImage *seg_img,
+			AtlasSegmentCache &cache, const AtlasSegmentDefinition &def,
+			const AtlasCache &acache)
+	{
+		// Check if atlas has too many segments
+		size_t max_segments = acache.total_segments.X * acache.total_segments.Y;
+		if(acache.segments.size() > max_segments){
+			throw BaseException("Atlas has too many segments (segments.size()="+
+					itos(acache.segments.size())+", total_segments=("+
+					itos(acache.total_segments.X)+", "+
+					itos(acache.total_segments.Y)+"))");
+		}
+		// Calculate segment's position in atlas texture
+		v2s32 total_segs = acache.total_segments;
+		size_t seg_iy = seg_id / total_segs.X;
+		size_t seg_ix = seg_id - seg_iy * total_segs.X;
+		/*log_d(MODULE, "update_segment_cache(): seg_id=%i, seg_iy=%i, seg_ix=%i",
+				seg_id, seg_iy, seg_ix);*/
+		v2s32 seg_size = acache.segment_resolution;
+		v2s32 dst_p00(
+				seg_ix * seg_size.X * 2,
+				seg_iy * seg_size.Y * 2
+		);
+		v2s32 dst_p0 = dst_p00 + seg_size / 2;
+		v2s32 dst_p1 = dst_p0 + seg_size;
+		// Set coordinates in cache
+		cache.coord0 = v2f(
+				(float)dst_p0.X / (float)(total_segs.X * seg_size.X * 2),
+				(float)dst_p0.Y / (float)(total_segs.Y * seg_size.Y * 2)
+		);
+		cache.coord1 = v2f(
+				(float)dst_p1.X / (float)(total_segs.X * seg_size.X * 2),
+				(float)dst_p1.Y / (float)(total_segs.Y * seg_size.Y * 2)
+		);
+		// Draw segment into atlas image
+		v2s32 src_size(seg_img->getDimension().Width, seg_img->getDimension().Height);
+		v2s32 src_off(
+				src_size.X / def.total_segments.X * def.select_segment.X,
+				src_size.Y / def.total_segments.Y * def.select_segment.Y
+		);
+		// Draw main texture
+		if(def.lod_simulation == 0){
+			for(int y = 0; y<seg_size.Y * 2; y++){
+				for(int x = 0; x<seg_size.X * 2; x++){
+					/*float fx = (float)src_size.X / seg_size.X;
+					float fy = (float)src_size.Y / seg_size.Y;
+					v2s32 src_p = src_off + v2s32(
+							(int)(x * fx + src_size.X / 2) % src_size.X,
+							(int)(y * fy + src_size.Y / 2) % src_size.Y
+					);*/
+					// TODO: Not sure if this is right
+					v2s32 src_p = src_off + v2s32(
+							(x + seg_size.X / 2) % seg_size.X,
+							(y + seg_size.Y / 2) % seg_size.Y
+					);
+					v2s32 dst_p = dst_p00 + v2s32(x, y);
+					video::SColor c = seg_img->getPixel(src_p.X, src_p.Y);
+					if (src_p.X % 8 == 0 && src_p.Y % 8 == 0) {
+						infostream<<"seg_img->getPixel("<<src_p.X<<","<<src_p.Y
+								<<") -> r="<<c.getRed()<<",g="<<c.getGreen()
+								<<",b="<<c.getBlue()<<",a="<<c.getAlpha()
+								<<std::endl;
+					}
+					//c.set(255, 128, 128, 128); // DEBUG
+					acache.image->setPixel(dst_p.X, dst_p.Y, c);
+				}
+			}
+		} else {
+			int lod = def.lod_simulation & 0x00ff;
+			uint16_t flags = def.lod_simulation & 0xff00;
+
+			// Cache for an on-demand search of an opaque pixel
+			bool any_opaque_color_searched = false;
+			video::SColor any_opaque_color;
+			any_opaque_color.setAlpha(0);
+
+			for(int y = 0; y<seg_size.Y * 2; y++){
+				for(int x = 0; x<seg_size.X * 2; x++){
+					float fx = (float)src_size.X * lod / seg_size.X;
+					float fy = (float)src_size.Y * lod / seg_size.Y;
+					// TODO: Not sure if this is right
+					v2s32 src_p = src_off + v2s32(
+							(int)(x * fx + src_size.X * lod / 2) % src_size.X,
+							(int)(y * fy + src_size.Y * lod / 2) % src_size.Y
+					);
+					/*v2s32 src_p = src_off + v2s32(
+							((x + seg_size.X / 2) * lod) % seg_size.X,
+							((y + seg_size.Y / 2) * lod) % seg_size.Y
+					);*/
+					v2s32 dst_p = dst_p00 + v2s32(x, y);
+
+					video::SColor c = seg_img->getPixel(src_p.X, src_p.Y);
+
+					// Try to get a pixel that isn't transparent
+					if (c.getAlpha() < 255) {
+						video::SColor c2;
+						c2.setAlpha(0);
+						for (s32 x = src_p.X-1; x <= src_p.X + 1 &&
+								c2.getAlpha() < 255; x++)
+						for (s32 y = src_p.Y-1; y <= src_p.Y + 1 &&
+								c2.getAlpha() < 255; y++) {
+							if (x < 0 || x >= src_size.X ||
+									y < 0 || y > src_size.Y)
+								continue;
+							c2 = seg_img->getPixel(x, y);
+						}
+						if (c2.getAlpha() == 255) {
+							c = c2;
+						} else if(any_opaque_color_searched) {
+							if (any_opaque_color.getAlpha() != 0) {
+								c = any_opaque_color;
+							} else {
+								// We don't have any
+							}
+						} else {
+							any_opaque_color_searched = true;
+							// Well, crap. Search for the whole source texture
+							// for a non-transparent pixel then. There's
+							// probably at least one in it, and if there isn't,
+							// at least we tried.
+							for (s32 x = src_off.X; x < src_off.X + src_size.X &&
+									c2.getAlpha() < 255; x++)
+							for (s32 y = src_off.Y; y < src_off.Y + src_size.Y &&
+									c2.getAlpha() < 255; y++) {
+								c2 = seg_img->getPixel(x, y);
+							}
+							if (c2.getAlpha() == 255) {
+								c = c2;
+								any_opaque_color = c2;
+							} else {
+								// Tough luck
+							}
+						}
+					}
+
+					if(flags & ATLAS_LOD_TOP_FACE){
+						// Preserve original colors
+						if(flags & ATLAS_LOD_BAKE_SHADOWS){
+							// This value has been calibrated
+							c.set(
+								c.getAlpha(),
+								c.getRed() * 0.97f,
+								c.getGreen() * 0.97f,
+								c.getBlue() * 0.99f
+							);
+						} else {
+							// This value has been calibrated
+							c.set(
+								c.getAlpha(),
+								c.getRed() * 0.97f,
+								c.getGreen() * 0.97f,
+								c.getBlue() * 1.0f
+							);
+						}
+					} else {
+						// Simulate sides
+						// Leave horizontal edges look like they are bright
+						// topsides
+						// TODO: This should be variable according to the
+						// camera's height relative to the thing the atlas
+						// segment is representing
+						int edge_size = src_size.Y / 16;
+						bool is_edge = (
+								src_p.Y <= edge_size ||
+								src_p.Y >= src_size.Y - edge_size
+						);
+						if(flags & ATLAS_LOD_BAKE_SHADOWS){
+							if(is_edge){
+								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.75f,
+										c.getGreen() * 0.75f,
+										c.getBlue() * 0.8f
+									);
+								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.75f,
+										c.getGreen() * 0.75f,
+										c.getBlue() * 0.8f
+									);
+								} else {
+									// This value has been calibrated
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.97f * 0.9f,
+										c.getGreen() * 0.97f * 0.9f,
+										c.getBlue() * 1.0f * 0.9f
+									);
+								}
+							} else {
+								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.70f * 0.75f,
+										c.getGreen() * 0.70f * 0.75f,
+										c.getBlue() * 0.65f * 0.8f
+									);
+								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.50f * 0.75f,
+										c.getGreen() * 0.50f * 0.75f,
+										c.getBlue() * 0.50f * 0.8f
+									);
+								} else {
+									// This value has been calibrated
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.61f * 1.0f,
+										c.getGreen() * 0.61f * 1.0f,
+										c.getBlue() * 0.67f * 1.0f
+									);
+								}
+							}
+						} else {
+							if(is_edge){
+								// This value has been calibrated
+								c.set(
+									c.getAlpha(),
+									c.getRed() * 0.97f,
+									c.getGreen() * 0.97f,
+									c.getBlue() * 1.0f
+								);
+							} else {
+								if(flags & ATLAS_LOD_SEMIBRIGHT1_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.7f,
+										c.getGreen() * 0.7f,
+										c.getBlue() * 0.7f
+									);
+								} else if(flags & ATLAS_LOD_SEMIBRIGHT2_FACE){
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.7f,
+										c.getGreen() * 0.7f,
+										c.getBlue() * 0.7f
+									);
+								} else {
+									// This value has been calibrated
+									c.set(
+										c.getAlpha(),
+										c.getRed() * 0.7f,
+										c.getGreen() * 0.7f,
+										c.getBlue() * 0.8f
+									);
+								}
+							}
+						}
+					}
+
+					if(flags & ATLAS_LOD_DARKEN_LIKE_LIQUID){
+						// This value has been calibrated
+						c.set(
+							c.getAlpha(),
+							c.getRed() * 0.5,
+							c.getGreen() * 0.5,
+							c.getBlue() * 0.5
+						);
+					}
+
+					acache.image->setPixel(dst_p.X, dst_p.Y, c);
+				}
+			}
+		}
+		// Drop old texture so that a new one will be generated
+		if (acache.texture != NULL) {
+			infostream<<"Dropping acache.texture "<<acache.texture<<std::endl;
+			acache.texture->drop();
+			acache.texture = NULL;
+			for(size_t i=0; i<acache.segments.size(); i++){
+				AtlasSegmentCache &scache = acache.segments[i];
+				scache.texture_pp = NULL;
+			}
+		}
+	}
+
+	void refresh_textures()
+	{
+		for(size_t i=0; i<m_cache.size(); i++){
+			AtlasCache &acache = m_cache[i];
+			if (acache.texture != NULL)
+				continue;
+			if (acache.image == NULL)
+				continue;
+
+			// Uncomment for debugging
+			/*std::string path = std::string()+"/tmp/"+acache.texture_name+".png";
+			m_driver->writeImageToFile(acache.image, path.c_str(), 0);*/
+
+			acache.texture = m_driver->addTexture(acache.texture_name.c_str(),
+					acache.image);
+			acache.texture->grab();
+			for(size_t i=0; i<acache.segments.size(); i++){
+				AtlasSegmentCache &scache = acache.segments[i];
+				scache.texture_pp = &acache.texture;
+			}
+			infostream<<"Created acache.texture "<<acache.texture<<std::endl;
+		}
+	}
+
+	const AtlasCache* get_atlas_cache(size_t atlas_id)
+	{
+		if(atlas_id == ATLAS_UNDEFINED)
+			return NULL;
+		if(atlas_id >= m_cache.size()){
+			// Cache is always up-to-date
+			return NULL;
+		}
+		return &m_cache[atlas_id];
+	}
+
+	const AtlasSegmentCache* get_texture(const AtlasSegmentReference &ref)
+	{
+		const AtlasCache *cache = get_atlas_cache(ref.atlas_id);
+		if(cache == NULL)
+			return NULL;
+		if(ref.segment_id >= cache->segments.size()){
+			// Cache is always up-to-date
+			return NULL;
+		}
+		const AtlasSegmentCache &seg_cache = cache->segments[ref.segment_id];
+		return &seg_cache;
+	}
+};
+
+AtlasRegistry* createAtlasRegistry(const std::string &name,
+		video::IVideoDriver* driver, IGameDef *gamedef)
+{
+	return new CAtlasRegistry(name, driver, gamedef);
+}
+
+}

--- a/src/util/atlas.h
+++ b/src/util/atlas.h
@@ -1,0 +1,160 @@
+/*
+Minetest
+Copyright (C) 2015 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef __ATLAS_H__
+#define __ATLAS_H__
+#include "irrlichttypes_bloated.h"
+#include <ITexture.h>
+#include <string>
+#include <vector>
+
+class IGameDef;
+
+namespace irr {
+	namespace video {
+		class IVideoDriver;
+	}
+}
+
+namespace atlas
+{
+	static const size_t ATLAS_UNDEFINED = 0;
+
+	struct AtlasSegmentReference
+	{
+		size_t atlas_id; // 0 = undefined atlas
+		size_t segment_id;
+
+		AtlasSegmentReference():
+			atlas_id(ATLAS_UNDEFINED),
+			segment_id(0)
+		{}
+	};
+
+	const uint16_t ATLAS_LOD_TOP_FACE = 0x100;
+	const uint16_t ATLAS_LOD_SEMIBRIGHT1_FACE = 0x200;
+	const uint16_t ATLAS_LOD_SEMIBRIGHT2_FACE = 0x400;
+	const uint16_t ATLAS_LOD_BAKE_SHADOWS = 0x800;
+	const uint16_t ATLAS_LOD_DARKEN_LIKE_LIQUID = 0x1600;
+
+	struct AtlasSegmentDefinition
+	{
+		std::string image_name; // If "", segment won't be added
+		v2s32 total_segments;
+		v2s32 select_segment;
+		v2s32 target_size;
+		// Mask 0x00ff: LOD level, mask 0xff00: flags
+		uint16_t lod_simulation;
+		// TODO: Rotation
+
+		AtlasSegmentDefinition():
+			lod_simulation(0)
+		{}
+
+		bool operator==(const AtlasSegmentDefinition &other) const;
+	};
+
+	struct AtlasSegmentCache
+	{
+		video::ITexture **texture_pp;
+		v2f coord0;
+		v2f coord1;
+
+		AtlasSegmentCache():
+			texture_pp(NULL)
+		{}
+	};
+
+	struct AtlasDefinition
+	{
+		size_t id;
+		v2s32 segment_resolution;
+		v2s32 total_segments;
+		std::vector<AtlasSegmentDefinition> segments;
+
+		AtlasDefinition():
+			id(ATLAS_UNDEFINED)
+		{}
+	};
+
+	struct AtlasCache
+	{
+		size_t id;
+		video::IImage *image;
+		std::string texture_name;
+		mutable video::ITexture *texture;
+		v2s32 segment_resolution;
+		v2s32 total_segments;
+		mutable std::vector<AtlasSegmentCache> segments;
+
+		AtlasCache():
+			id(ATLAS_UNDEFINED),
+			image(NULL),
+			texture(NULL)
+		{}
+		AtlasCache(const AtlasCache &other):
+			id(other.id),
+			image(other.image),
+			texture_name(other.texture_name),
+			texture(other.texture),
+			segment_resolution(other.segment_resolution),
+			total_segments(other.total_segments),
+			segments(other.segments)
+		{
+			if (image)   image->grab();
+			if (texture) texture->grab();
+		}
+		~AtlasCache() {
+			if (image)   image->drop();
+			if (texture) texture->drop();
+		}
+	};
+
+	struct AtlasRegistry
+	{
+		virtual ~AtlasRegistry(){}
+
+		// Allows the atlas to optimize itself for upcoming segmnets
+		virtual void prepare_for_segments(
+				size_t num_segments, v2s32 segment_size) = 0;
+
+		// These two may only be called from Urho3D main thread
+		virtual const AtlasSegmentReference add_segment(
+				const AtlasSegmentDefinition &segment_def) = 0;
+		virtual const AtlasSegmentReference find_or_add_segment(
+				const AtlasSegmentDefinition &segment_def) = 0;
+
+		virtual const AtlasDefinition* get_atlas_definition(
+				size_t atlas_id) = 0;
+		virtual const AtlasSegmentDefinition* get_segment_definition(
+				const AtlasSegmentReference &ref) = 0;
+
+		virtual void refresh_textures() = 0;
+
+		virtual const AtlasCache* get_atlas_cache(size_t atlas_id) = 0;
+
+		virtual const AtlasSegmentCache* get_texture(
+				const AtlasSegmentReference &ref) = 0;
+	};
+
+	AtlasRegistry* createAtlasRegistry(const std::string &name,
+			video::IVideoDriver* driver, IGameDef *gamedef);
+}
+
+#endif

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -416,4 +416,10 @@ inline u32 npot2(u32 orig) {
 	return orig + 1;
 }
 
+// NOTE: Irrlicht only provides something like this for v3s32
+inline v3s16 v3s16_div(const v3s16 &a, s16 b)
+{
+	return v3s16(a.X/b, a.Y/b, a.Z/b);
+}
+
 #endif

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -100,6 +100,20 @@ inline v3s16 getContainerPos(v3s16 p, v3s16 d)
 	);
 }
 
+inline s32 getContainerPos32(s32 p, s32 d)
+{
+	return (p>=0 ? p : p-d+1) / d;
+}
+
+inline v3s16 getContainerPos32to16(v3s32 p, s32 d)
+{
+	return v3s16(
+		getContainerPos32(p.X, d),
+		getContainerPos32(p.Y, d),
+		getContainerPos32(p.Z, d)
+	);
+}
+
 inline void getContainerPosWithOffset(s16 p, s16 d, s16 &container, s16 &offset)
 {
 	container = (p >= 0 ? p : p - d + 1) / d;

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../threading/mutex_auto_lock.h"
 #include "porting.h"
 #include "log.h"
+#include "container.h"
 
 template<typename T>
 class MutexedVariable {


### PR DESCRIPTION
This does two things like the title says: far map rendering and improved map transfer, and includes a couple of supporting commits.

I request testing and comments about whether this is upstream-worthy. This is causing a lot of conflicts at the moment because people are eager to work on the map transfer which this reworks heavily.

You can see the original spammy commit log by looking at celeron55:far_map_wip_2.

This is my to-do list at the moment of posting this PR. All of the items on this list are strongly "maybe", subject to changes and/or practically undecipherable.

```
- Check how empty MapBlocks and FarBlocks are handled and possibly improve it

? Make it so that empty FarBlocks don't consume huge amounts of memory

- Rename enable_far_map to enable_far_map_system to indicate that it completely
  switches it into and out of use

- Merge gregorycu's patch

- Rename TOSERVER_SET_WANTED_MAP_SEND_QUEUE to TOSERVER_SET_MAP_SENDS

? Add max_simultaneous_block_sends to TOSERVER_SET_WANTED_MAP_SEND_QUEUE

- Unload FarBlocks sometimes
    - May have to use IVideoDriver::removeHardwareBuffer

? Increase default target FPS to 60

? Should FarBlocks be aligned with map generator chunks?

? Make FarBlocks to be scene nodes so that irrlicht will render them on its own

- Maybe store zlib-compressed data on ServerFarBlocks

- The server has to do occlusion culling for FarBlocks due to network usage
    * Or maybe not?

- The server must be able to tell the client that a FarBlock was culled and may
  not be actually empty

- Add a setting for disabling far map on server side

- Use frustum culling when rendering FarBlocks

- The client has to do occlusion culling for FarBlocks due to the GPU having a
  limited amount of space for VBO meshes

- Inform FarMap about blocks that were found to not exist too

- far_map_enable_maximum_resolution: Basically the "ultra" setting of Minetest
    - ServerFarMapPiece::content_max_res

- Add a minimal logging subsystem for map transfer that can be turned on

- Profile some useful stuff:
    - Number of MapBlocks sent
    - Number of FarBlocks sent

- Time out and drop FarBlock meshes that are not rendered at all

- Add a setting for maximum far map send distance on the server

- far_map_allow_generate_to_distance (replace)

- Maybe do something to Z fighting that happens sometimes, or at least explain
  it somehow

- The far map generation limits should be a world-specific setting so that if
  you want to have a large world with a lot of wasted hard drive space, you can
  set it as such, and if not, you don't accidentally bloat it up by leaving some
  global setting enabled

- Allow the client to tell the server how many meshes it wants per second so
  that systems that get choppy framerates with 20 meshes per frame but work fine
  with 5 meshes per frame can be made playable
```
