### PR TITLE
Nodebox: Allow nodeboxes to "connect"

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -617,6 +617,18 @@ A nodebox is defined as any of:
         wall_bottom = box,
         wall_side = box
     }
+    {
+        -- A node that has optional boxes depending on neighbouring nodes'
+        -- presence and type. See also `connects_to`.
+        type = "connected",
+        fixed = box OR {box1, box2, ...}
+        connect_top = box OR {box1, box2, ...}
+        connect_bottom = box OR {box1, box2, ...}
+        connect_front = box OR {box1, box2, ...}
+        connect_left = box OR {box1, box2, ...}
+        connect_back = box OR {box1, box2, ...}
+        connect_right = box OR {box1, box2, ...}
+    }
 
 A `box` is defined as:
 
@@ -3461,6 +3473,10 @@ Definition tables
         light_source = 0, -- Amount of light emitted by node
         damage_per_second = 0, -- If player is inside node, this damage is caused
         node_box = {type="regular"}, -- See "Node boxes"
+        connects_to = nodenames, --[[
+        * Used for nodebox nodes with the type == "connected"
+        * Specifies to what neighboring nodes connections will be drawn
+        * e.g. `{"group:fence", "default:wood"}` or `"default:stone"` ]]
         mesh = "model",
         selection_box = {type="regular"}, -- See "Node boxes" --[[
         ^ If drawtype "nodebox" is used and selection_box is nil, then node_box is used. ]]

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3477,6 +3477,8 @@ Definition tables
         * Used for nodebox nodes with the type == "connected"
         * Specifies to what neighboring nodes connections will be drawn
         * e.g. `{"group:fence", "default:wood"}` or `"default:stone"` ]]
+        connect_sides = { "top", "bottom", "front", "left", "back", "right" }, --[[
+        * tells connected nodebox nodes to connect only to these sides of this node,
         mesh = "model",
         selection_box = {type="regular"}, -- See "Node boxes" --[[
         ^ If drawtype "nodebox" is used and selection_box is nil, then node_box is used. ]]

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -185,6 +185,13 @@ bool wouldCollideWithCeiling(
 	return false;
 }
 
+static inline void getNeighborConnectingFace(v3s16 p, INodeDefManager *nodedef,
+		Map *map, MapNode n, int v, int *neighbors)
+{
+	MapNode n2 = map->getNodeNoEx(p);
+	if (nodedef->nodeboxConnects(n, n2))
+		*neighbors |= v;
+}
 
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		f32 pos_max_d, const aabb3f &box_0,
@@ -261,12 +268,41 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			// Object collides into walkable nodes
 
 			any_position_valid = true;
-			const ContentFeatures &f = gamedef->getNodeDefManager()->get(n);
+			INodeDefManager *nodedef = gamedef->getNodeDefManager();
+			const ContentFeatures &f = nodedef->get(n);
 			if(f.walkable == false)
 				continue;
 			int n_bouncy_value = itemgroup_get(f.groups, "bouncy");
 
-			std::vector<aabb3f> nodeboxes = n.getCollisionBoxes(gamedef->ndef());
+			int neighbors = 0;
+			if (f.drawtype == NDT_NODEBOX && f.node_box.type == NODEBOX_CONNECTED) {
+				v3s16 p2 = p;
+
+				p2.Y++;
+				getNeighborConnectingFace(p2, nodedef, map, n, 1, &neighbors);
+
+				p2 = p;
+				p2.Y--;
+				getNeighborConnectingFace(p2, nodedef, map, n, 2, &neighbors);
+
+				p2 = p;
+				p2.Z--;
+				getNeighborConnectingFace(p2, nodedef, map, n, 4, &neighbors);
+
+				p2 = p;
+				p2.X--;
+				getNeighborConnectingFace(p2, nodedef, map, n, 8, &neighbors);
+
+				p2 = p;
+				p2.Z++;
+				getNeighborConnectingFace(p2, nodedef, map, n, 16, &neighbors);
+
+				p2 = p;
+				p2.X++;
+				getNeighborConnectingFace(p2, nodedef, map, n, 32, &neighbors);
+			}
+			std::vector<aabb3f> nodeboxes;
+			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
 			for(std::vector<aabb3f>::iterator
 					i = nodeboxes.begin();
 					i != nodeboxes.end(); ++i)

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -189,7 +189,7 @@ static inline void getNeighborConnectingFace(v3s16 p, INodeDefManager *nodedef,
 		Map *map, MapNode n, int v, int *neighbors)
 {
 	MapNode n2 = map->getNodeNoEx(p);
-	if (nodedef->nodeboxConnects(n, n2))
+	if (nodedef->nodeboxConnects(n, n2, v))
 		*neighbors |= v;
 }
 

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -163,6 +163,14 @@ void makeCuboid(MeshCollector *collector, const aabb3f &box,
 	}
 }
 
+static inline void getNeighborConnectingFace(v3s16 p, INodeDefManager *nodedef,
+		MeshMakeData *data, MapNode n, int v, int *neighbors)
+{
+	MapNode n2 = data->m_vmanip.getNodeNoEx(p);
+	if (nodedef->nodeboxConnects(n, n2))
+		*neighbors |= v;
+}
+
 /*
 	TODO: Fix alpha blending for special nodes
 	Currently only the last element rendered is blended correct
@@ -1501,7 +1509,38 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 
 			v3f pos = intToFloat(p, BS);
 
-			std::vector<aabb3f> boxes = n.getNodeBoxes(nodedef);
+			int neighbors = 0;
+
+			// locate possible neighboring nodes to connect to
+			if (f.node_box.type == NODEBOX_CONNECTED) {
+				v3s16 p2 = p;
+
+				p2.Y++;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 1, &neighbors);
+
+				p2 = p;
+				p2.Y--;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 2, &neighbors);
+
+				p2 = p;
+				p2.Z--;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 4, &neighbors);
+
+				p2 = p;
+				p2.X--;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 8, &neighbors);
+
+				p2 = p;
+				p2.Z++;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 16, &neighbors);
+
+				p2 = p;
+				p2.X++;
+				getNeighborConnectingFace(blockpos_nodes + p2, nodedef, data, n, 32, &neighbors);
+			}
+
+			std::vector<aabb3f> boxes;
+			n.getNodeBoxes(nodedef, &boxes, neighbors);
 			for(std::vector<aabb3f>::iterator
 					i = boxes.begin();
 					i != boxes.end(); ++i)

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -167,7 +167,7 @@ static inline void getNeighborConnectingFace(v3s16 p, INodeDefManager *nodedef,
 		MeshMakeData *data, MapNode n, int v, int *neighbors)
 {
 	MapNode n2 = data->m_vmanip.getNodeNoEx(p);
-	if (nodedef->nodeboxConnects(n, n2))
+	if (nodedef->nodeboxConnects(n, n2, v))
 		*neighbors |= v;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -358,7 +358,9 @@ PointedThing getPointedThing(Client *client, Hud *hud, const v3f &player_positio
 				if (!isPointableNode(n, client, liquids_pointable)) {
 					continue;
 				}
-				std::vector<aabb3f> boxes = n.getSelectionBoxes(nodedef);
+
+				std::vector<aabb3f> boxes;
+				n.getSelectionBoxes(nodedef, &boxes);
 
 				v3s16 np(x, y, z);
 				v3f npf = intToFloat(np, BS);
@@ -389,7 +391,8 @@ PointedThing getPointedThing(Client *client, Hud *hud, const v3f &player_positio
 		f32 d = 0.001 * BS;
 		MapNode n = map.getNodeNoEx(pointed_pos);
 		v3f npf = intToFloat(pointed_pos, BS);
-		std::vector<aabb3f> boxes = n.getSelectionBoxes(nodedef);
+		std::vector<aabb3f> boxes;
+		n.getSelectionBoxes(nodedef, &boxes);
 		f32 face_min_distance = 1000 * BS;
 		for (std::vector<aabb3f>::const_iterator
 				i = boxes.begin();

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -310,7 +310,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		if (sneak_node_found) {
 			f32 cb_max = 0;
 			MapNode n = map->getNodeNoEx(m_sneak_node);
-			std::vector<aabb3f> nodeboxes = n.getCollisionBoxes(nodemgr);
+			std::vector<aabb3f> nodeboxes;
+			n.getCollisionBoxes(nodemgr, &nodeboxes);
 			for (std::vector<aabb3f>::iterator it = nodeboxes.begin();
 					it != nodeboxes.end(); ++it) {
 				aabb3f box = *it;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -214,12 +214,12 @@ void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
 	}
 }
 
-static std::vector<aabb3f> transformNodeBox(const MapNode &n,
-		const NodeBox &nodebox, INodeDefManager *nodemgr)
+void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
+		INodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes, u8 neighbors = 0)
 {
-	std::vector<aabb3f> boxes;
-	if(nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED)
-	{
+	std::vector<aabb3f> &boxes = *p_boxes;
+
+	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
 		const std::vector<aabb3f> &fixed = nodebox.fixed;
 		int facedir = n.getFaceDir(nodemgr);
 		u8 axisdir = facedir>>2;
@@ -395,32 +395,71 @@ static std::vector<aabb3f> transformNodeBox(const MapNode &n,
 			boxes.push_back(box);
 		}
 	}
+	else if (nodebox.type == NODEBOX_CONNECTED)
+	{
+		size_t boxes_size = boxes.size();
+		boxes_size += nodebox.fixed.size();
+		if (neighbors & 1)
+			boxes_size += nodebox.connect_top.size();
+		if (neighbors & 2)
+			boxes_size += nodebox.connect_bottom.size();
+		if (neighbors & 4)
+			boxes_size += nodebox.connect_front.size();
+		if (neighbors & 8)
+			boxes_size += nodebox.connect_left.size();
+		if (neighbors & 16)
+			boxes_size += nodebox.connect_back.size();
+		if (neighbors & 32)
+			boxes_size += nodebox.connect_right.size();
+		boxes.reserve(boxes_size);
+
+#define BOXESPUSHBACK(c) do { \
+		for (std::vector<aabb3f>::const_iterator \
+				it = (c).begin(); \
+				it != (c).end(); ++it) \
+			(boxes).push_back(*it); \
+		} while (0)
+
+		BOXESPUSHBACK(nodebox.fixed);
+
+		if (neighbors & 1)
+			BOXESPUSHBACK(nodebox.connect_top);
+		if (neighbors & 2)
+			BOXESPUSHBACK(nodebox.connect_bottom);
+		if (neighbors & 4)
+			BOXESPUSHBACK(nodebox.connect_front);
+		if (neighbors & 8)
+			BOXESPUSHBACK(nodebox.connect_left);
+		if (neighbors & 16)
+			BOXESPUSHBACK(nodebox.connect_back);
+		if (neighbors & 32)
+			BOXESPUSHBACK(nodebox.connect_right);
+	}
 	else // NODEBOX_REGULAR
 	{
 		boxes.push_back(aabb3f(-BS/2,-BS/2,-BS/2,BS/2,BS/2,BS/2));
 	}
-	return boxes;
 }
 
-std::vector<aabb3f> MapNode::getNodeBoxes(INodeDefManager *nodemgr) const
+void MapNode::getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	return transformNodeBox(*this, f.node_box, nodemgr);
+	transformNodeBox(*this, f.node_box, nodemgr, boxes, neighbors);
 }
 
-std::vector<aabb3f> MapNode::getCollisionBoxes(INodeDefManager *nodemgr) const
+void MapNode::getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.collision_box.fixed.empty())
-		return transformNodeBox(*this, f.node_box, nodemgr);
+		transformNodeBox(*this, f.node_box, nodemgr, boxes, neighbors);
 	else
-		return transformNodeBox(*this, f.collision_box, nodemgr);
+		transformNodeBox(*this, f.collision_box, nodemgr, boxes, neighbors);
 }
 
-std::vector<aabb3f> MapNode::getSelectionBoxes(INodeDefManager *nodemgr) const
+void MapNode::getSelectionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	return transformNodeBox(*this, f.selection_box, nodemgr);
+	transformNodeBox(*this, f.selection_box, nodemgr, boxes);
 }
 
 u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -240,17 +240,17 @@ struct MapNode
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))
 	*/
-	std::vector<aabb3f> getNodeBoxes(INodeDefManager *nodemgr) const;
+	void getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Gets list of selection boxes
 	*/
-	std::vector<aabb3f> getSelectionBoxes(INodeDefManager *nodemgr) const;
+	void getSelectionBoxes(INodeDefManager *nodemg, std::vector<aabb3f> *boxes);
 
 	/*
 		Gets list of collision boxes
 	*/
-	std::vector<aabb3f> getCollisionBoxes(INodeDefManager *nodemgr) const;
+	void getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Liquid helpers

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -135,6 +135,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL_VERSION 27:
 		backface_culling: backwards compatibility for playing with
 		newer client on pre-27 servers.
+		Add nodedef v3 - connected nodeboxes
 */
 
 #define LATEST_PROTOCOL_VERSION 27

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -271,6 +271,8 @@ struct ContentFeatures
 	bool legacy_facedir_simple;
 	// Set to true if wall_mounted used to be set to true
 	bool legacy_wallmounted;
+	// for NDT_CONNECTED pairing
+	u8 connect_sides;
 
 	// Sound properties
 	SimpleSoundSpec sound_footstep;
@@ -325,7 +327,7 @@ public:
 
 	virtual void pendNodeResolve(NodeResolver *nr)=0;
 	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
-	virtual bool nodeboxConnects(const MapNode from, const MapNode to)=0;
+	virtual bool nodeboxConnects(const MapNode from, const MapNode to, u8 connect_face)=0;
 };
 
 class IWritableNodeDefManager : public INodeDefManager {

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -80,6 +80,7 @@ enum NodeBoxType
 	NODEBOX_FIXED, // Static separately defined box(es)
 	NODEBOX_WALLMOUNTED, // Box for wall mounted nodes; (top, bottom, side)
 	NODEBOX_LEVELED, // Same as fixed, but with dynamic height from param2. for snow, ...
+	NODEBOX_CONNECTED, // optionally draws nodeboxes if a neighbor node attaches
 };
 
 struct NodeBox
@@ -92,6 +93,13 @@ struct NodeBox
 	aabb3f wall_top;
 	aabb3f wall_bottom;
 	aabb3f wall_side; // being at the -X side
+	// NODEBOX_CONNECTED
+	std::vector<aabb3f> connect_top;
+	std::vector<aabb3f> connect_bottom;
+	std::vector<aabb3f> connect_front;
+	std::vector<aabb3f> connect_left;
+	std::vector<aabb3f> connect_back;
+	std::vector<aabb3f> connect_right;
 
 	NodeBox()
 	{ reset(); }
@@ -269,6 +277,9 @@ struct ContentFeatures
 	SimpleSoundSpec sound_dig;
 	SimpleSoundSpec sound_dug;
 
+	std::vector<std::string> connects_to;
+	std::set<content_t> connects_to_ids;
+
 	/*
 		Methods
 	*/
@@ -314,6 +325,7 @@ public:
 
 	virtual void pendNodeResolve(NodeResolver *nr)=0;
 	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
+	virtual bool nodeboxConnects(const MapNode from, const MapNode to)=0;
 };
 
 class IWritableNodeDefManager : public INodeDefManager {
@@ -368,6 +380,7 @@ public:
 	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
 	virtual void runNodeResolveCallbacks()=0;
 	virtual void resetNodeResolveState()=0;
+	virtual void mapNodeboxConnections()=0;
 };
 
 IWritableNodeDefManager *createNodeDefManager();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -535,6 +535,20 @@ ContentFeatures read_content_features(lua_State *L, int index)
 		f.node_box = read_nodebox(L, -1);
 	lua_pop(L, 1);
 
+	lua_getfield(L, index, "connects_to");
+	if (lua_istable(L, -1)) {
+		int table = lua_gettop(L);
+		lua_pushnil(L);
+		int i = 0;
+		while (lua_next(L, table) != 0) {
+			// Value at -1
+			f.connects_to.push_back(lua_tostring(L, -1));
+			lua_pop(L, 1);
+			i++;
+		}
+	}
+	lua_pop(L, 1);
+
 	lua_getfield(L, index, "selection_box");
 	if(lua_istable(L, -1))
 		f.selection_box = read_nodebox(L, -1);
@@ -627,25 +641,31 @@ NodeBox read_nodebox(lua_State *L, int index)
 		nodebox.type = (NodeBoxType)getenumfield(L, index, "type",
 				ScriptApiNode::es_NodeBoxType, NODEBOX_REGULAR);
 
-		lua_getfield(L, index, "fixed");
-		if(lua_istable(L, -1))
-			nodebox.fixed = read_aabb3f_vector(L, -1, BS);
-		lua_pop(L, 1);
+#define NODEBOXREAD(n, s) \
+	do { \
+		lua_getfield(L, index, (s)); \
+		if (lua_istable(L, -1)) \
+			(n) = read_aabb3f(L, -1, BS); \
+		lua_pop(L, 1); \
+	} while (0)
 
-		lua_getfield(L, index, "wall_top");
-		if(lua_istable(L, -1))
-			nodebox.wall_top = read_aabb3f(L, -1, BS);
-		lua_pop(L, 1);
-
-		lua_getfield(L, index, "wall_bottom");
-		if(lua_istable(L, -1))
-			nodebox.wall_bottom = read_aabb3f(L, -1, BS);
-		lua_pop(L, 1);
-
-		lua_getfield(L, index, "wall_side");
-		if(lua_istable(L, -1))
-			nodebox.wall_side = read_aabb3f(L, -1, BS);
-		lua_pop(L, 1);
+#define NODEBOXREADVEC(n, s) \
+	do { \
+		lua_getfield(L, index, (s)); \
+		if (lua_istable(L, -1)) \
+			(n) = read_aabb3f_vector(L, -1, BS); \
+		lua_pop(L, 1); \
+	} while (0)
+		NODEBOXREADVEC(nodebox.fixed, "fixed");
+		NODEBOXREAD(nodebox.wall_top, "wall_top");
+		NODEBOXREAD(nodebox.wall_bottom, "wall_bottom");
+		NODEBOXREAD(nodebox.wall_side, "wall_side");
+		NODEBOXREADVEC(nodebox.connect_top, "connect_top");
+		NODEBOXREADVEC(nodebox.connect_bottom, "connect_bottom");
+		NODEBOXREADVEC(nodebox.connect_front, "connect_front");
+		NODEBOXREADVEC(nodebox.connect_left, "connect_left");
+		NODEBOXREADVEC(nodebox.connect_back, "connect_back");
+		NODEBOXREADVEC(nodebox.connect_right, "connect_right");
 	}
 	return nodebox;
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -549,6 +549,36 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	}
 	lua_pop(L, 1);
 
+	lua_getfield(L, index, "connect_sides");
+	if (lua_istable(L, -1)) {
+		int table = lua_gettop(L);
+		lua_pushnil(L);
+		int i = 0;
+		while (lua_next(L, table) != 0) {
+			// Value at -1
+			std::string side(lua_tostring(L, -1));
+			// Note faces are flipped to make checking easier
+			if (side.compare("top") == 0)
+				f.connect_sides |= 2;
+			else if (side.compare("bottom") == 0)
+				f.connect_sides |= 1;
+			else if (side.compare("front") == 0)
+				f.connect_sides |= 16;
+			else if (side.compare("left") == 0)
+				f.connect_sides |= 32;
+			else if (side.compare("back") == 0)
+				f.connect_sides |= 4;
+			else if (side.compare("right") == 0)
+				f.connect_sides |= 8;
+			else
+				warningstream << "Unknown value for \"connect_sides\": "
+				<< side << std::endl;
+			lua_pop(L, 1);
+			i++;
+		}
+	}
+	lua_pop(L, 1);
+
 	lua_getfield(L, index, "selection_box");
 	if(lua_istable(L, -1))
 		f.selection_box = read_nodebox(L, -1);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -82,6 +82,7 @@ struct EnumString ScriptApiNode::es_NodeBoxType[] =
 		{NODEBOX_FIXED, "fixed"},
 		{NODEBOX_WALLMOUNTED, "wallmounted"},
 		{NODEBOX_LEVELED, "leveled"},
+		{NODEBOX_CONNECTED, "connected"},
 		{0, NULL},
 	};
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -320,6 +320,9 @@ Server::Server(
 	// Perform pending node name resolutions
 	m_nodedef->runNodeResolveCallbacks();
 
+	// unmap node names for connected nodeboxes
+	m_nodedef->mapNodeboxConnections();
+
 	// init the recipe hashes to speed up crafting
 	m_craftdef->initHashes(this);
 


### PR DESCRIPTION
We introduce a new nodebox type "connected", and allow these
nodes to have optional nodeboxes that connect it to other
connecting nodeboxes.

This is all done at scenedraw time in the client. The client
will inspect the surrounding nodes and if they are to be connected
to, it will draw the appropriate connecting nodeboxes to make those
connections.

In the node_box definition, we have to specify separate nodeboxes
for each valid connection. This allows us to make nodes that connect
only horizontally (the common case) by providing optional nodeboxes
for +x, -x, +z, -z directions. Or this allows us to make wires
that can connect up and down, by providing nodeboxes that connect it
up and down (+y, -y) as well.

The optional nodeboxes can be arrays. They are named "connect_up",
"connect_down", and "connect_n|e|w|s".

Additionally, a "fixed" nodebox list present will always be drawn,
so one can make a central post, for instance. This "fixed" nodebox
can be omitted.

I've posted a screenshot demonstrating the flexibility at
![screenie]
(http://i.imgur.com/rRKZ1lR.png)
In the screenshot, all connecting nodes are of this new subtype.

There are several things to note that are not yet in order:

Transparent textures render incorrectly, need tuning.

These nodes all connect to eachother. This needs to be a configurable
thing, so that one may opt to connect nodes based on a group, or
drawtype. This logic is not in place yet.

Example lua code needed to generate these nodes can be found here:
  https://gist.github.com/sofar/b381c8c192c8e53e6062

Lastly, this requires a protocol bump as it needs to send the new
optional nodeboxes to the client in a structured method.

![configurable connections]
(http://i.imgur.com/HRN1lIa.png)

- [x] use reserve in boxes.
- [x] collisionboxes need to be updated as well
- [x] use default 0 more often to avoid passing in 0
- [x] fix up style copy-paste errors
- [x] figure out what nodes can actually connect to in the first place
- [X] protocol bump. Old clients won't be able to understand the new nodeboxes.
- [x] API change documentation
- [x] connect_sides parameter