### PR TITLE
Support for node slip amounts affecting players & items

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2604,6 +2604,7 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `speed`: multiplier to default walking speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
+        * `slip` : multiplier to current walkable node groups slip value (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the sneak glitch (default: `true`)
 * `get_physics_override()`: returns the table given to set_physics_override

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1118,6 +1118,10 @@ Another example: Make red wool from white wool and red dye:
 * `soil`: saplings will grow on nodes in this group
 * `connect_to_raillike`: makes nodes of raillike drawtype with same group value
   connect to each other
+* `slip`: players and items will slide on the node. A value of 100 produces
+  medium slip. Positive values slow to stop, negative values continue speeding up!
+  Larger positive & negative values produce more gradual change in speed.  Small
+  negative values cause rapid acceleration!
 
 ### Known damage and digging time defining groups
 * `crumbly`: dirt, sand

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -464,7 +464,7 @@ void Client::step(float dtime)
 	// Control local player (0ms)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
-	player->applyControl(dtime);
+	player->applyControl(dtime, &m_env);
 
 	// Step environment
 	m_env.step(dtime);

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1661,7 +1661,6 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_speed = readF1000(is);
 		float override_jump = readF1000(is);
 		float override_gravity = readF1000(is);
-///TODO: detect protocol VERSION!
 		float override_slip = readF1000(is);
 		// these are sent inverted so we get true when the server sends nothing
 		bool sneak = !readU8(is);

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1661,6 +1661,8 @@ void GenericCAO::processMessage(const std::string &data)
 		float override_speed = readF1000(is);
 		float override_jump = readF1000(is);
 		float override_gravity = readF1000(is);
+///TODO: detect protocol VERSION!
+		float override_slip = readF1000(is);
 		// these are sent inverted so we get true when the server sends nothing
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
@@ -1672,6 +1674,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->physics_override_speed = override_speed;
 			player->physics_override_jump = override_jump;
 			player->physics_override_gravity = override_gravity;
+			player->physics_override_slip = override_slip;
 			player->physics_override_sneak = sneak;
 			player->physics_override_sneak_glitch = sneak_glitch;
 		}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -773,6 +773,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, Player *player_, u16 peer_id_,
 	m_physics_override_speed(1),
 	m_physics_override_jump(1),
 	m_physics_override_gravity(1),
+	m_physics_override_slip(1),
 	m_physics_override_sneak(true),
 	m_physics_override_sneak_glitch(true),
 	m_physics_override_sent(false)
@@ -865,7 +866,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 		}
 		os<<serializeLongString(gob_cmd_update_attachment(m_attachment_parent_id, m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
 		os<<serializeLongString(gob_cmd_update_physics_override(m_physics_override_speed,
-				m_physics_override_jump, m_physics_override_gravity, m_physics_override_sneak,
+				m_physics_override_jump, m_physics_override_gravity, m_physics_override_slip, m_physics_override_sneak,
 				m_physics_override_sneak_glitch)); // 5
 		os << serializeLongString(gob_cmd_update_nametag_attributes(m_prop.nametag_color)); // 6 (GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) : Deprecated, for backwards compatibility only.
 	}
@@ -989,7 +990,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	if(m_physics_override_sent == false){
 		m_physics_override_sent = true;
 		std::string str = gob_cmd_update_physics_override(m_physics_override_speed,
-				m_physics_override_jump, m_physics_override_gravity,
+				m_physics_override_jump, m_physics_override_gravity, m_physics_override_slip,
 				m_physics_override_sneak, m_physics_override_sneak_glitch);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -336,6 +336,7 @@ public:
 	float m_physics_override_speed;
 	float m_physics_override_jump;
 	float m_physics_override_gravity;
+	float m_physics_override_slip;
 	bool m_physics_override_sneak;
 	bool m_physics_override_sneak_glitch;
 	bool m_physics_override_sent;

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -118,7 +118,7 @@ std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups)
 }
 
 std::string gob_cmd_update_physics_override(float physics_override_speed, float physics_override_jump,
-		float physics_override_gravity, bool sneak, bool sneak_glitch)
+		float physics_override_gravity, float physics_override_slip, bool sneak, bool sneak_glitch)
 {
 	std::ostringstream os(std::ios::binary);
 	// command 
@@ -127,6 +127,7 @@ std::string gob_cmd_update_physics_override(float physics_override_speed, float 
 	writeF1000(os, physics_override_speed);
 	writeF1000(os, physics_override_jump);
 	writeF1000(os, physics_override_gravity);
+	writeF1000(os, physics_override_slip);
 	// these are sent inverted so we get true when the server sends nothing
 	writeU8(os, !sneak);
 	writeU8(os, !sneak_glitch);

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -67,7 +67,7 @@ std::string gob_cmd_punched(s16 damage, s16 result_hp);
 std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups);
 
 std::string gob_cmd_update_physics_override(float physics_override_speed,
-		float physics_override_jump, float physics_override_gravity, bool sneak, bool sneak_glitch);
+		float physics_override_jump, float physics_override_gravity, float physics_override_slip, bool sneak, bool sneak_glitch);
 
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend, bool frame_loop);
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -398,7 +398,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d)
 	move(dtime, env, pos_max_d, NULL);
 }
 
-void LocalPlayer::applyControl(float dtime)
+void LocalPlayer::applyControl(float dtime, Environment *env)
 {
 	// Clear stuff
 	swimming_vertical = false;
@@ -611,7 +611,17 @@ void LocalPlayer::applyControl(float dtime)
 		incH = incV = movement_acceleration_default * BS * dtime;
 
 	// Accelerate to target speed with maximum increment
-	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed);
+	INodeDefManager *nodemgr = m_gamedef->ndef();
+	Map *map = &env->getMap();
+	v3s16 p = floatToInt(getPosition() - v3f(0,BS/2,0), BS);
+	ContentFeatures node = nodemgr->get(map->getNodeNoEx(p));
+	int slippery = itemgroup_get(node.groups, "slippery");
+	if (slippery==0 && (node.name=="air" || itemgroup_get(node.groups, "liquid")) && !free_move && !is_climbing && !control.sneak)
+	{
+		slippery = 10;
+	}
+
+	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed, slippery);
 	accelerateVertical(speedV * physics_override_speed, incV * physics_override_speed);
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -610,19 +610,25 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	else
 		incH = incV = movement_acceleration_default * BS * dtime;
 
-	// Accelerate to target speed with maximum increment
+	int slippery;
+	if (!free_move && !control.sneak && !is_climbing)
+	{
 	INodeDefManager *nodemgr = m_gamedef->ndef();
 	Map *map = &env->getMap();
-	v3s16 p = floatToInt(getPosition() - v3f(0,BS/2,0), BS);
-	ContentFeatures node = nodemgr->get(map->getNodeNoEx(p));
-	int slippery = itemgroup_get(node.groups, "slippery");
-	// Sliding onto a non-walkable node, set a default to allow sliding off edges
-	if (slippery==0 && node.walkable==false && !free_move && !is_climbing && !control.sneak)
-	{
-		slippery = 10;
-	}
+		v3s16 position = floatToInt(getPosition() - v3f(0,BS/2,0), BS);
+		ContentFeatures node = nodemgr->get(map->getNodeNoEx(position));
 
-	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed, slippery);
+		slippery = itemgroup_get(node.groups, "slippery");
+
+		// Sliding onto a non-walkable node that you should fall through?
+		if (slippery==0 && !node.walkable)
+			slippery = 100; // override to allow sliding off edges into
+	}
+	else
+		slippery = 0;
+
+	// Accelerate to target speed with maximum increment
+	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed, slippery * physics_override_slip);
 	accelerateVertical(speedV * physics_override_speed, incV * physics_override_speed);
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -610,7 +610,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	else
 		incH = incV = movement_acceleration_default * BS * dtime;
 
-	int slippery;
+	int slip;
 	if (!free_move && !control.sneak && !is_climbing)
 	{
 	INodeDefManager *nodemgr = m_gamedef->ndef();
@@ -618,17 +618,17 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		v3s16 position = floatToInt(getPosition() - v3f(0,BS/2,0), BS);
 		ContentFeatures node = nodemgr->get(map->getNodeNoEx(position));
 
-		slippery = itemgroup_get(node.groups, "slippery");
+		slip = itemgroup_get(node.groups, "slip");
 
 		// Sliding onto a non-walkable node that you should fall through?
-		if (slippery==0 && !node.walkable)
-			slippery = 100; // override to allow sliding off edges into
+		if (slip==0 && !node.walkable)
+			slip = 100; // override to allow sliding off edges into
 	}
 	else
-		slippery = 0;
+		slip = 0;
 
 	// Accelerate to target speed with maximum increment
-	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed, slippery * physics_override_slip);
+	accelerateHorizontal(speedH * physics_override_speed, incH * physics_override_speed, slip * physics_override_slip);
 	accelerateVertical(speedV * physics_override_speed, incV * physics_override_speed);
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -616,7 +616,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	v3s16 p = floatToInt(getPosition() - v3f(0,BS/2,0), BS);
 	ContentFeatures node = nodemgr->get(map->getNodeNoEx(p));
 	int slippery = itemgroup_get(node.groups, "slippery");
-	if (slippery==0 && (node.name=="air" || itemgroup_get(node.groups, "liquid")) && !free_move && !is_climbing && !control.sneak)
+	// Sliding onto a non-walkable node, set a default to allow sliding off edges
+	if (slippery==0 && node.walkable==false && !free_move && !is_climbing && !control.sneak)
 	{
 		slippery = 10;
 	}

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -50,7 +50,7 @@ public:
 	void move(f32 dtime, Environment *env, f32 pos_max_d,
 			std::vector<CollisionInfo> *collision_info);
 
-	void applyControl(float dtime);
+	void applyControl(float dtime, Environment *env);
 
 	v3s16 getStandingNodePos();
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -132,9 +132,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Rename GENERIC_CMD_SET_ATTACHMENT to GENERIC_CMD_ATTACH_TO
 	PROTOCOL_VERSION 26:
 		Add TileDef tileable_horizontal, tileable_vertical flags
+	PROTOCOL_VERSION 27:
+		Add physics_override_slip
 */
 
-#define LATEST_PROTOCOL_VERSION 26
+#define LATEST_PROTOCOL_VERSION 27
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -95,7 +95,7 @@ Player::Player(IGameDef *gamedef, const char *name):
 	physics_override_speed        = 1;
 	physics_override_jump         = 1;
 	physics_override_gravity      = 1;
-	physics_override_slip		  = 1;
+	physics_override_slip         = 1;
 	physics_override_sneak        = true;
 	physics_override_sneak_glitch = true;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -95,6 +95,7 @@ Player::Player(IGameDef *gamedef, const char *name):
 	physics_override_speed        = 1;
 	physics_override_jump         = 1;
 	physics_override_gravity      = 1;
+	physics_override_slip		  = 1;
 	physics_override_sneak        = true;
 	physics_override_sneak_glitch = true;
 
@@ -121,9 +122,9 @@ void Player::accelerateHorizontal(v3f target_speed, f32 max_increase, int slippe
 	if (slippery)
 	{
 		if (target_speed == v3f(0))
-			d_wanted = -m_speed*.5/slippery;
+			d_wanted = -m_speed * 5 / slippery;
 		else
-			d_wanted = target_speed*.1 - m_speed*.1;
+			d_wanted = target_speed * .1 - m_speed * .1;
 	}
 	d_wanted.Y = 0;
 	f32 dl = d_wanted.getLength();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -112,12 +112,19 @@ Player::~Player()
 }
 
 // Horizontal acceleration (X and Z), Y direction is ignored
-void Player::accelerateHorizontal(v3f target_speed, f32 max_increase)
+void Player::accelerateHorizontal(v3f target_speed, f32 max_increase, int slippery)
 {
 	if(max_increase == 0)
 		return;
 
 	v3f d_wanted = target_speed - m_speed;
+	if (slippery)
+	{
+		if (target_speed == v3f(0))
+			d_wanted = -m_speed*.5/slippery;
+		else
+			d_wanted = target_speed*.1 - m_speed*.1;
+	}
 	d_wanted.Y = 0;
 	f32 dl = d_wanted.getLength();
 	if(dl > max_increase)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -113,29 +113,26 @@ Player::~Player()
 }
 
 // Horizontal acceleration (X and Z), Y direction is ignored
-void Player::accelerateHorizontal(v3f target_speed, f32 max_increase, int slippery)
+void Player::accelerateHorizontal(v3f target_speed, f32 max_increase, int slip)
 {
 	if(max_increase == 0)
 		return;
 
 	v3f d_wanted = target_speed - m_speed;
-	if (slippery)
+	if(slip)
 	{
-		if (target_speed == v3f(0))
-			d_wanted = -m_speed * 5 / slippery;
+		if(target_speed == v3f(0))
+			d_wanted = -m_speed * 5 / slip;
 		else
 			d_wanted = target_speed * .1 - m_speed * .1;
 	}
 	d_wanted.Y = 0;
-	f32 dl = d_wanted.getLength();
-	if(dl > max_increase)
-		dl = max_increase;
+	f32 wanted_speed = d_wanted.getLength();
+	if(wanted_speed > max_increase)
+		d_wanted = d_wanted * (max_increase / wanted_speed);
 
-	v3f d = d_wanted.normalize() * dl;
-
-	m_speed.X += d.X;
-	m_speed.Z += d.Z;
-
+	m_speed.X += d_wanted.X;
+	m_speed.Z += d_wanted.Z;
 }
 
 // Vertical acceleration (Y), X and Z directions are ignored

--- a/src/player.h
+++ b/src/player.h
@@ -119,7 +119,7 @@ public:
 		m_speed = speed;
 	}
 
-	void accelerateHorizontal(v3f target_speed, f32 max_increase, int slippery);
+	void accelerateHorizontal(v3f target_speed, f32 max_increase, int slip);
 	void accelerateVertical(v3f target_speed, f32 max_increase);
 
 	v3f getPosition()

--- a/src/player.h
+++ b/src/player.h
@@ -352,6 +352,7 @@ public:
 	float physics_override_speed;
 	float physics_override_jump;
 	float physics_override_gravity;
+	float physics_override_slip;
 	bool physics_override_sneak;
 	bool physics_override_sneak_glitch;
 

--- a/src/player.h
+++ b/src/player.h
@@ -119,7 +119,7 @@ public:
 		m_speed = speed;
 	}
 
-	void accelerateHorizontal(v3f target_speed, f32 max_increase);
+	void accelerateHorizontal(v3f target_speed, f32 max_increase, int slippery);
 	void accelerateVertical(v3f target_speed, f32 max_increase);
 
 	v3f getPosition()

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -401,7 +401,7 @@ int ObjectRef::l_get_armor_groups(lua_State *L)
 }
 
 // set_physics_override(self, physics_override_speed, physics_override_jump,
-//                      physics_override_gravity, sneak, sneak_glitch)
+//                      physics_override_gravity, physics_override_slip, sneak, sneak_glitch)
 int ObjectRef::l_set_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -413,6 +413,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 		co->m_physics_override_speed = getfloatfield_default(L, 2, "speed", co->m_physics_override_speed);
 		co->m_physics_override_jump = getfloatfield_default(L, 2, "jump", co->m_physics_override_jump);
 		co->m_physics_override_gravity = getfloatfield_default(L, 2, "gravity", co->m_physics_override_gravity);
+		co->m_physics_override_slip = getfloatfield_default(L, 2, "slip", co->m_physics_override_slip);
 		co->m_physics_override_sneak = getboolfield_default(L, 2, "sneak", co->m_physics_override_sneak);
 		co->m_physics_override_sneak_glitch = getboolfield_default(L, 2, "sneak_glitch", co->m_physics_override_sneak_glitch);
 		co->m_physics_override_sent = false;
@@ -450,6 +451,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "jump");
 	lua_pushnumber(L, co->m_physics_override_gravity);
 	lua_setfield(L, -2, "gravity");
+	lua_pushnumber(L, co->m_physics_override_slip);
+	lua_setfield(L, -2, "slip");
 	lua_pushboolean(L, co->m_physics_override_sneak);
 	lua_setfield(L, -2, "sneak");
 	lua_pushboolean(L, co->m_physics_override_sneak_glitch);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -105,7 +105,7 @@ private:
 	static int l_get_armor_groups(lua_State *L);
 
 	// set_physics_override(self, physics_override_speed, physics_override_jump,
-	//                      physics_override_gravity, sneak, sneak_glitch)
+	//                      physics_override_gravity, physics_override_slip, sneak, sneak_glitch)
 	static int l_set_physics_override(lua_State *L);
 
 	// get_physics_override(self)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -149,7 +149,7 @@ public:
 	{}
 	virtual ItemGroupList getArmorGroups()
 	{ return ItemGroupList(); }
-	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
+	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity, float physics_override_slip)
 	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)
 	{}


### PR DESCRIPTION
Intentionally, does not affect non-item entities!  Item slip support is added in "builtin/game/item_entity.lua".

All slipping is cancelled automatically while in free move or on sneaking.

Provides a range of slip amounts set with the node groups setting: 'slip'.
Provides a player physics_override slip factor (Example potential use by mods: Good grip boots).

See included "lua_API.txt" for details.

I have some default values available for testing the effect here: https://github.com/minetest/minetest_game/compare/master...cmdskp:master

(Please note: The negative slip on Jungle Tree logs is provided temporarily to demo what happens with continuous acceleration via it.  To ensure smooth integration with existing worlds, it's expected to be desirable to change it to a normal positive 'slip' to allow players to slow easier on Jungle Tree logs without using sneak.)

Please test and give feedback where time permits.  Please note, most nodes(with a <100 slip setting) only cause a slight delay to coming to a stop, other than Ice (which has a larger value of 180).