### PR TITLE
Mapgen: Make spawn search per-mapgen WIP

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -340,6 +340,18 @@ int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 EmergeManager::getSpawnPos()
+{
+	if (m_mapgens.size() == 0 || !m_mapgens[0]) {
+		errorstream << "EmergeManager: getSpawnPos() called"
+			" before mapgen init" << std::endl;
+		return v3s16(0, 0, 0);
+	}
+
+	return m_mapgens[0]->getSpawnPos();
+}
+
+
 bool EmergeManager::isBlockUnderground(v3s16 blockpos)
 {
 #if 0

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -137,6 +137,7 @@ public:
 	// Mapgen helpers methods
 	Biome *getBiomeAtPoint(v3s16 p);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 	bool isBlockUnderground(v3s16 blockpos);
 
 	static MapgenFactory *getMapgenFactory(const std::string &mgname);

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -180,6 +180,7 @@ public:
 
 	virtual void makeChunk(BlockMakeData *data) {}
 	virtual int getGroundLevelAtPoint(v2s16 p) { return 0; }
+	virtual v3s16 getSpawnPos() { return v3s16(0, 0, 0); }
 
 private:
 	DISABLE_CLASS_COPY(Mapgen);

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -207,6 +207,12 @@ int MapgenFlat::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 MapgenFlat::getSpawnPos()
+{
+	return v3s16(0, 128, 0);
+}
+
+
 void MapgenFlat::makeChunk(BlockMakeData *data)
 {
 	// Pre-conditions

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -103,6 +103,7 @@ public:
 
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 	void calculateNoise();
 	s16 generateTerrain();
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -223,6 +223,12 @@ int MapgenFractal::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 MapgenFractal::getSpawnPos()
+{
+	return v3s16(0, 128, 0);
+}
+
+
 void MapgenFractal::makeChunk(BlockMakeData *data)
 {
 	// Pre-conditions

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -115,6 +115,7 @@ public:
 
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 	void calculateNoise();
 	bool getFractalAtPoint(s16 x, s16 y, s16 z);
 	s16 generateTerrain();

--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -103,3 +103,9 @@ int MapgenSinglenode::getGroundLevelAtPoint(v2s16 p)
 {
 	return 0;
 }
+
+
+v3s16 MapgenSinglenode::getSpawnPos()
+{
+	return v3s16(0, 128, 0);
+}

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -42,6 +42,7 @@ public:
 	
 	void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 };
 
 struct MapgenFactorySinglenode : public MapgenFactory {

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -204,6 +204,12 @@ int MapgenV5::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 MapgenV5::getSpawnPos()
+{
+	return v3s16(0, 128, 0);
+}
+
+
 void MapgenV5::makeChunk(BlockMakeData *data)
 {
 	// Pre-conditions

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -91,6 +91,7 @@ public:
 
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 	void calculateNoise();
 	int generateBaseTerrain();
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -316,6 +316,32 @@ int MapgenV6::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 MapgenV6::getSpawnPos()
+{
+	s16 vertical_spawn_range = g_settings->getS16("vertical_spawn_range");
+
+	// Try to find a good place a few times
+	for (s32 i = 0; i < 1000; i++) {
+		s32 range = 1 + i;
+		// We're going to try to throw the player to this position
+		v2s16 nodepos2d = v2s16(
+				-range + (myrand() % (range * 2)),
+				-range + (myrand() % (range * 2)));
+
+		// Get ground height at point
+		s16 groundheight = getGroundLevelAtPoint(nodepos2d);
+		// Don't go underwater or to high places
+		if (groundheight <= water_level ||
+				groundheight > water_level + vertical_spawn_range)
+			continue;
+
+		return v3s16(nodepos2d.X, groundheight, nodepos2d.Y);
+	}
+
+	return v3s16(0, 0, 0);
+}
+
+
 //////////////////////// Noise functions
 
 float MapgenV6::getMudAmount(v2s16 p)

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -129,6 +129,7 @@ public:
 
 	void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 
 	float baseTerrainLevel(float terrain_base, float terrain_higher,
 		float steepness, float height_select);

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -228,6 +228,12 @@ int MapgenV7::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+v3s16 MapgenV7::getSpawnPos()
+{
+	return v3s16(0, 128, 0);
+}
+
+
 void MapgenV7::makeChunk(BlockMakeData *data)
 {
 	// Pre-conditions

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -104,6 +104,7 @@ public:
 
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	v3s16 getSpawnPos();
 	Biome *getBiomeAtPoint(v3s16 p);
 
 	float baseTerrainLevelAtPoint(s16 x, s16 z);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3378,31 +3378,15 @@ std::string Server::getBuiltinLuaPath()
 v3f Server::findSpawnPos()
 {
 	ServerMap &map = m_env->getServerMap();
-	v3f nodeposf;
+	v3f nodeposf = v3f(0.0f, 0.0f, 0.0f);
 	if (g_settings->getV3FNoEx("static_spawnpoint", nodeposf)) {
 		return nodeposf * BS;
 	}
 
-	s16 water_level = map.getWaterLevel();
-	s16 vertical_spawn_range = g_settings->getS16("vertical_spawn_range");
 	bool is_good = false;
-
 	// Try to find a good place a few times
-	for(s32 i = 0; i < 1000 && !is_good; i++) {
-		s32 range = 1 + i;
-		// We're going to try to throw the player to this position
-		v2s16 nodepos2d = v2s16(
-				-range + (myrand() % (range * 2)),
-				-range + (myrand() % (range * 2)));
-
-		// Get ground height at point
-		s16 groundheight = map.findGroundLevel(nodepos2d);
-		// Don't go underwater or to high places
-		if (groundheight <= water_level ||
-				groundheight > water_level + vertical_spawn_range)
-			continue;
-
-		v3s16 nodepos(nodepos2d.X, groundheight, nodepos2d.Y);
+	for (s32 i = 0; i < 10 && !is_good; i++) {
+		v3s16 nodepos = m_emerge->getSpawnPos();
 
 		s32 air_count = 0;
 		for (s32 i = 0; i < 10; i++) {
@@ -3415,7 +3399,8 @@ v3f Server::findSpawnPos()
 					nodeposf = intToFloat(nodepos, BS);
 					// Don't spawn the player outside map boundaries
 					if (objectpos_over_limit(nodeposf))
-						continue;
+						break;
+
 					is_good = true;
 					break;
 				}


### PR DESCRIPTION
The new variety of mapgens means the existing spawn search function often fails, this PR will move spawn search into per-mapgen functions, each designed to cope with the mapgen's structure.