### PR TITLE
Improve waving definitions

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -80,11 +80,11 @@ function core.check_player_privs(player_or_name, ...)
 	if type(name) ~= "string" then
 		name = name:get_player_name()
 	end
-	
+
 	local requested_privs = {...}
 	local player_privs = core.get_player_privs(name)
 	local missing_privileges = {}
-	
+
 	if type(requested_privs[1]) == "table" then
 		-- We were provided with a table like { privA = true, privB = true }.
 		for priv, value in pairs(requested_privs[1]) do
@@ -100,11 +100,11 @@ function core.check_player_privs(player_or_name, ...)
 			end
 		end
 	end
-	
+
 	if #missing_privileges > 0 then
 		return false, missing_privileges
 	end
-	
+
 	return true, ""
 end
 
@@ -203,4 +203,9 @@ function core.raillike_group(name)
 		id = raillike_cur_id
 	end
 	return id
+end
+
+local waving_groups = {leaves = 1, plants = 2}
+function core.get_waving_value(name)
+	return waving_groups[name] or 0
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2335,6 +2335,9 @@ These functions return the leftover itemstack.
     * Returns rating of the connect_to_raillike group corresponding to name
     * If name is not yet the name of a connect_to_raillike group, a new group id
     * is created, with that name
+* `minetest.get_waving_value(name)`: returns a numeric value
+    * name can be "leaves" or "plants"
+    * returned value defines which kind of waving is used by shaders
 * `minetest.get_content_id(name)`: returns an integer
     * Gets the internal content ID of `name`
 * `minetest.get_name_from_content_id(content_id)`: returns a string

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -806,6 +806,11 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 
 	u32 size = m_content_features.size();
 
+	// TILE_MATERIAL_ + offset, used for waving parameter
+	// e.g. use TILE_MATERIAL_WAVING_PLANTS = f->waving + offset
+	// 5 = 2 + 3
+	const u8 offset = 3;
+
 	for (u32 i = 0; i < size; i++) {
 		ContentFeatures *f = &m_content_features[i];
 
@@ -890,18 +895,20 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 				for (u32 i = 0; i < 6; i++)
 					tiledef[i].name += std::string("^[noalpha");
 			}
-			if (f->waving == 1)
-				material_type = TILE_MATERIAL_WAVING_LEAVES;
+			if (f->waving > 0)
+				material_type = offset + f->waving;
 			break;
 		case NDT_PLANTLIKE:
 			f->solidness = 0;
 			f->backface_culling = false;
-			if (f->waving == 1)
-				material_type = TILE_MATERIAL_WAVING_PLANTS;
+			if (f->waving > 0)
+				material_type = offset + f->waving;
 			break;
 		case NDT_FIRELIKE:
 			f->backface_culling = false;
 			f->solidness = 0;
+			if (f->waving > 0)
+				material_type = offset + f->waving;
 			break;
 		case NDT_MESH:
 			f->solidness = 0;
@@ -913,6 +920,8 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 		case NDT_RAILLIKE:
 		case NDT_NODEBOX:
 			f->solidness = 0;
+			if (f->waving > 0)
+				material_type = offset + f->waving;
 			break;
 		}
 


### PR DESCRIPTION
- Allow more drawtypes to use waving (firelike, mesh, nodebox)
- Don't hardcode waving type, defined by nodedef

Backport from https://github.com/blockplanet/blockplanet. Since I'm the copyright holder and doin this PR here it can be used ofc.
