### PR TITLE
Prevent technically unsafe access with empty vector

### DIFF
--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -77,6 +77,9 @@ void NetworkPacket::putRawString(const char* src, u32 len)
 		m_data.resize(m_datasize);
 	}
 
+	if (m_datasize == 0)
+		return;
+
 	memcpy(&m_data[m_read_offset], src, len);
 	m_read_offset += len;
 }


### PR DESCRIPTION
This flags an assert with Visual Studio