### PR TITLE
Add MinSizeRel and RelWithDebInfo to MSVCBuildDir check

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -162,6 +162,8 @@ bool detectMSVCBuildDir(const std::string &path)
 {
 	const char *ends[] = {
 		"bin\\Release",
+		"bin\\MinSizeRel",
+		"bin\\RelWithDebInfo",
 		"bin\\Debug",
 		"bin\\Build",
 		NULL


### PR DESCRIPTION
These are two configurations that cmake generates.