### PR TITLE
Prevent ub

### DIFF
--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -77,7 +77,7 @@ void NetworkPacket::putRawString(const char* src, u32 len)
 		m_data.resize(m_datasize);
 	}
 
-	if (m_datasize == 0)
+	if (len == 0)
 		return;
 
 	memcpy(&m_data[m_read_offset], src, len);

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -163,6 +163,8 @@ bool detectMSVCBuildDir(const std::string &path)
 {
 	const char *ends[] = {
 		"bin\\Release",
+		"bin\\MinSizeRel",
+		"bin\\RelWithDebInfo",
 		"bin\\Debug",
 		"bin\\Build",
 		NULL


### PR DESCRIPTION
Commit 87dcee6ac2058bbf5264ea7f82874bba67277252 actually uses the wrong variable and only covers some use cases.
This change covers all use cases.