### PR TITLE
Add reason for leave to `on_leaveplayer` callbacks.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1861,8 +1861,9 @@ Call these functions only at load time!
      * If it returns a string, the player is disconnected with that string as reason
 * `minetest.register_on_joinplayer(func(ObjectRef))`
     * Called when a player joins the game
-* `minetest.register_on_leaveplayer(func(ObjectRef))`
+* `minetest.register_on_leaveplayer(func(ObjectRef, timed_out))`
     * Called when a player leaves the game
+    * `timed_out`: True for timeout, false for other reasons.
 * `minetest.register_on_cheat(func(ObjectRef, cheat))`
     * Called when a player cheats
     * `cheat`: `{type=<cheat_type>}`, where `<cheat_type>` is one of:

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -135,7 +135,8 @@ void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player)
 	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
 }
 
-void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player)
+void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player,
+		bool timeout)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -144,7 +145,8 @@ void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player)
 	lua_getfield(L, -1, "registered_on_leaveplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
-	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+	lua_pushboolean(L, timeout);
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
 
 void ScriptApiPlayer::on_cheat(ServerActiveObject *player,

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -38,7 +38,7 @@ public:
 	bool on_prejoinplayer(const std::string &name, const std::string &ip,
 		std::string *reason);
 	void on_joinplayer(ServerActiveObject *player);
-	void on_leaveplayer(ServerActiveObject *player);
+	void on_leaveplayer(ServerActiveObject *player, bool timeout);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
 	bool on_punchplayer(ServerActiveObject *player,
 		ServerActiveObject *hitter, float time_from_last_punch,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2671,7 +2671,7 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 				PlayerSAO *playersao = player->getPlayerSAO();
 				assert(playersao);
 
-				m_script->on_leaveplayer(playersao);
+				m_script->on_leaveplayer(playersao, reason == CDR_TIMEOUT);
 
 				playersao->disconnected();
 			}


### PR DESCRIPTION
Main use case is to report timeouts instead of regular disconnects in [irc mod](https://github.com/kaeza/minetest-irc.git). There are probably other use cases modders can think of.

This is quite a low priority enhanncement.

##### Example usage

```lua
minetest.register_on_leaveplayer(function(player, timed_out)
	if timed_out then
		print("Player timed out!")
	else
		print("Player left normally.")
	end
end)
```
