### PR TITLE
Improve parsing of setting types from settingtypes.txt for settings tab

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -506,8 +506,8 @@ local function handle_change_setting_buttons(this, fields)
 			local new_value = fields["te_setting_value"]
 			for _,value in ipairs(new_value:split(",", true)) do
 				value = value:trim()
-				if not value:match(CHAR_CLASSES.FLAGS .. "+")
-						or not setting.possible:match("[,]?" .. value .. "[,]?") then
+				local possible = "," .. setting.possible .. ","
+				if not possible:find("," .. value .. ",", 0, true) then
 					this.data.error_message = fgettext_ne("\"$1\" is not a valid flag.", value)
 					this.data.entered_text = fields["te_setting_value"]
 					core.update_formspec(this:get_formspec())


### PR DESCRIPTION
In settingtypes.txt, lines containing variable specifications are very sensitive to whitespace-errors, also, empty default values for flags are not accepted.

Accepted definitions:
```
    variable1 (My variable 1) int 1 0 3
    variable2 (My variable 2) flags flag1 flag1,flag2,flag3
```
Not accepted (error message printed and setting is ignored):
```
    variable1 (My variable 1)  int 1 0 3
    variable2 (My variable 2) flags   flag1,flag2,flag3
```

This patch fixes those things, and allows numbers to be prefixed with '+' as well, instead of just '-'
