### PR TITLE
Fix redis error reporting

### DIFF
--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -92,7 +92,7 @@ bool Database_Redis::saveBlock(const v3s16 &pos, const std::string &data)
 
 	if (reply->type == REDIS_REPLY_ERROR) {
 		warningstream << "saveBlock: saving block " << PP(pos)
-			<< " failed: " << reply->str << std::endl;
+			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;
 	}
@@ -119,7 +119,7 @@ std::string Database_Redis::loadBlock(const v3s16 &pos)
 		return str;
 	}
 	case REDIS_REPLY_ERROR: {
-		std::string errstr = reply->str;
+		std::string errstr(reply->str, reply->len);
 		freeReplyObject(reply);
 		errorstream << "loadBlock: loading block " << PP(pos)
 			<< " failed: " << errstr << std::endl;
@@ -134,7 +134,7 @@ std::string Database_Redis::loadBlock(const v3s16 &pos)
 	}
 	errorstream << "loadBlock: loading block " << PP(pos)
 		<< " returned invalid reply type " << reply->type
-		<< ": " << reply->str << std::endl;
+		<< ": " << std::string(reply->str, reply->len) << std::endl;
 	freeReplyObject(reply);
 	throw FileNotGoodException(std::string(
 		"Redis command 'HGET %s %s' gave invalid reply."));
@@ -151,7 +151,7 @@ bool Database_Redis::deleteBlock(const v3s16 &pos)
 			"Redis command 'HDEL %s %s' failed: ") + ctx->errstr);
 	} else if (reply->type == REDIS_REPLY_ERROR) {
 		warningstream << "deleteBlock: deleting block " << PP(pos)
-			<< " failed: " << reply->str << std::endl;
+			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;
 	}
@@ -177,7 +177,8 @@ void Database_Redis::listAllLoadableBlocks(std::vector<v3s16> &dst)
 		break;
 	case REDIS_REPLY_ERROR:
 		throw FileNotGoodException(std::string(
-			"Failed to get keys from database: ") + reply->str);
+			"Failed to get keys from database: ") +
+			std::string(reply->str, reply->len));
 	}
 	freeReplyObject(reply);
 }


### PR DESCRIPTION
It seems that our redis error reporting did an out of bounds read in order to determine the string length. And we didn't notice, all the time :{

Originated in the crash report: https://github.com/minetest/minetest/issues/2610#issuecomment-169936057

More info in the commit message.