### PR TITLE
Mgflat: Set blank default spflags. Unhide

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -936,7 +936,7 @@ mgv7_np_cave2 (Mapgen v7 cave2 noise parameters) noise_params 0, 12, (100, 100, 
 #    Occasional lakes and hills added to the flat world.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-mgflat_spflags (Mapgen flat flags) flags nolakes,nohills lakes,hills,nolakes,nohills
+mgflat_spflags (Mapgen flat flags) flags  lakes,hills,,nolakes,nohills
 
 #    Y of flat ground.
 mgflat_ground_level (Mapgen flat ground level) int 8

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1187,8 +1187,8 @@
 #    Occasional lakes and hills added to the flat world.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with "no" are used to explicitly disable them.
-#    type: flags possible values: lakes, hills, nolakes, nohills
-# mgflat_spflags = nolakes,nohills
+#    type: flags possible values: lakes, hills, , nolakes, nohills
+# mgflat_spflags = 
 
 #    Y of flat ground.
 #    type: int

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -106,7 +106,7 @@ MapgenDesc g_reg_mapgens[] = {
 	{"v5",         new MapgenFactoryV5,         true},
 	{"v6",         new MapgenFactoryV6,         true},
 	{"v7",         new MapgenFactoryV7,         true},
-	{"flat",       new MapgenFactoryFlat,       false},
+	{"flat",       new MapgenFactoryFlat,       true},
 	{"fractal",    new MapgenFactoryFractal,    true},
 	{"singlenode", new MapgenFactorySinglenode, false},
 };


### PR DESCRIPTION
Improvements to settings mean blank mapgen flags are now allowed and can be set by the player.
This was needed by mgflat which has no flags set by default, now we can unhide mgflat.