### PR TITLE
Mgv7/flat/fractal: Place biome top node on tunnel entrance floor

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -551,20 +551,39 @@ void MapgenFlat::dustTopNodes()
 void MapgenFlat::generateCaves(s16 max_stone_y)
 {
 	if (max_stone_y >= node_min.Y) {
-		u32 index = 0;
+		v3s16 em = vm->m_area.getExtent();
+		u32 index2d = 0;
+		u32 index3d;
 
 		for (s16 z = node_min.Z; z <= node_max.Z; z++)
-		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
-			u32 vi = vm->m_area.index(node_min.X, y, z);
-			for (s16 x = node_min.X; x <= node_max.X; x++, vi++, index++) {
-				float d1 = contour(noise_cave1->result[index]);
-				float d2 = contour(noise_cave2->result[index]);
-				if (d1 * d2 > 0.3f) {
-					content_t c = vm->m_data[vi].getContent();
-					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
-						continue;
+		for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
+			bool open = false;  // Is column open to overground
+			u32 vi = vm->m_area.index(x, node_max.Y + 1, z);
+			index3d = (z - node_min.Z) * zstride + (csize.Y + 1) * ystride +
+				(x - node_min.X);
+			// Biome of column
+			Biome *biome = (Biome *)bmgr->getRaw(biomemap[index2d]);
 
+			for (s16 y = node_max.Y + 1; y >= node_min.Y - 1;
+					y--, index3d -= ystride, vm->m_area.add_y(em, vi, -1)) {
+				content_t c = vm->m_data[vi].getContent();
+				if (c == CONTENT_AIR || c == biome->c_water_top ||
+						c == biome->c_water) {
+					open = true;
+					continue;
+				}
+				// Ground
+				float d1 = contour(noise_cave1->result[index3d]);
+				float d2 = contour(noise_cave2->result[index3d]);
+				if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
+					// In tunnel and ground content, excavate
 					vm->m_data[vi] = MapNode(CONTENT_AIR);
+				} else if (open && (c == biome->c_filler || c == biome->c_stone)) {
+					// Tunnel entrance floor
+					vm->m_data[vi] = MapNode(biome->c_top);
+					open = false;
+				} else {
+					open = false;
 				}
 			}
 		}

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -863,20 +863,39 @@ void MapgenV7::addTopNodes()
 void MapgenV7::generateCaves(s16 max_stone_y)
 {
 	if (max_stone_y >= node_min.Y) {
-		u32 index   = 0;
+		v3s16 em = vm->m_area.getExtent();
+		u32 index2d = 0;
+		u32 index3d;
 
 		for (s16 z = node_min.Z; z <= node_max.Z; z++)
-		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
-			u32 i = vm->m_area.index(node_min.X, y, z);
-			for (s16 x = node_min.X; x <= node_max.X; x++, i++, index++) {
-				float d1 = contour(noise_cave1->result[index]);
-				float d2 = contour(noise_cave2->result[index]);
-				if (d1 * d2 > 0.3f) {
-					content_t c = vm->m_data[i].getContent();
-					if (!ndef->get(c).is_ground_content || c == CONTENT_AIR)
-						continue;
+		for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
+			bool open = false;  // Is column open to overground
+			u32 vi = vm->m_area.index(x, node_max.Y + 1, z);
+			index3d = (z - node_min.Z) * zstride + (csize.Y + 1) * ystride +
+				(x - node_min.X);
+			// Biome of column
+			Biome *biome = (Biome *)bmgr->getRaw(biomemap[index2d]);
 
-					vm->m_data[i] = MapNode(CONTENT_AIR);
+			for (s16 y = node_max.Y + 1; y >= node_min.Y - 1;
+					y--, index3d -= ystride, vm->m_area.add_y(em, vi, -1)) {
+				content_t c = vm->m_data[vi].getContent();
+				if (c == CONTENT_AIR || c == biome->c_water_top ||
+						c == biome->c_water) {
+					open = true;
+					continue;
+				}
+				// Ground
+				float d1 = contour(noise_cave1->result[index3d]);
+				float d2 = contour(noise_cave2->result[index3d]);
+				if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
+					// In tunnel and ground content, excavate
+					vm->m_data[vi] = MapNode(CONTENT_AIR);
+				} else if (open && (c == biome->c_filler || c == biome->c_stone)) {
+					// Tunnel entrance floor
+					vm->m_data[vi] = MapNode(biome->c_top);
+					open = false;
+				} else {
+					open = false;
 				}
 			}
 		}


### PR DESCRIPTION
![screenshot_20160113_023424](https://cloud.githubusercontent.com/assets/3686677/12283707/e230fcfe-b9a0-11e5-85fe-8b39257cab20.png)

![screenshot_20160112_015850](https://cloud.githubusercontent.com/assets/3686677/12283711/eba33fa4-b9a0-11e5-8dbc-810bc84b6346.png)

![screenshot_20160113_023403](https://cloud.githubusercontent.com/assets/3686677/12283715/f5e4f386-b9a0-11e5-8623-8046db03f255.png)

![screenshot_20160113_022752](https://cloud.githubusercontent.com/assets/3686677/12283723/02e8e07e-b9a1-11e5-8a23-bfe227409e57.png)

^ Before / after.
For underwater tunnels this commit places the sand that would inevitably be washed into the tunnel entrance.

![screenshot_20160112_015156](https://cloud.githubusercontent.com/assets/3686677/12283732/23596dd8-b9a1-11e5-9f10-d4fdc0be8991.png)

![screenshot_20160113_024720](https://cloud.githubusercontent.com/assets/3686677/12283738/344a210a-b9a1-11e5-8b4c-6506ae5bc2f0.png)

^ Quite often tunnel routes run along the terrain surface, often this would be a bare stone scar or an area of biome filler node without biome top node, now the biome top node is placed on any area of the tunnel floor that is open to sky.

![screenshot_20160112_015644](https://cloud.githubusercontent.com/assets/3686677/12283736/29844886-b9a1-11e5-8fbe-cfc29b74cbee.png)

Credit for the method @duane-r, used in C++ valleys mapgen.