### PR TITLE
Prevent spawning in rivers with valleys mapgen.

### DIFF
--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -81,15 +81,15 @@ struct MapgenValleysParams : public MapgenSpecificParams {
 };
 
 struct TerrainNoise {
-	s16 x; 
-	s16 z; 
-	float terrain_height; 
-	float *rivers; 
-	float *valley; 
-	float valley_profile; 
-	float *slope; 
-	float inter_valley_fill; 
-	float cliffs; 
+	s16 x;
+	s16 z;
+	float terrain_height;
+	float *rivers;
+	float *valley;
+	float valley_profile;
+	float *slope;
+	float inter_valley_fill;
+	float cliffs;
 	float corr;
 };
 
@@ -100,7 +100,7 @@ public:
 	~MapgenValleys();
 
 	virtual void makeChunk(BlockMakeData *data);
-	inline int getGroundLevelAtPoint(v2s16 p);
+	int getGroundLevelAtPoint(v2s16 p);
 
 private:
 	EmergeManager *m_emerge;


### PR DESCRIPTION
Returns an unusable value when asked for an altitude in a river, to prevent people getting wet during spawn.

This could adversely affect decorations (if they're ever placed on rivers), lighting (if the commented code in isBlockUnderground is ever uncommented), or anything else that chooses to use getGroundLevelAtPoint in the future.