### PR TITLE
Allow per-tiles culling.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3358,7 +3358,7 @@ Definition tables
 * `{name="image.png", animation={Tile Animation definition}}`
 * `{name="image.png", backface_culling=bool, tileable_vertical=bool,
     tileable_horizontal=bool}`
-    * backface culling only supported in special tiles.
+    * backface culling enabled by default for most nodes
     * tileable flags are info for shaders, how they should treat texture
 	  when displacement mapping is used
 	  Directions are from the point of view of the tile texture,

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -843,12 +843,7 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 			assert(f->liquid_type == LIQUID_SOURCE);
 			if (opaque_water)
 				f->alpha = 255;
-			if (new_style_water){
-				f->solidness = 0;
-			} else {
-				f->solidness = 1;
-				f->backface_culling = false;
-			}
+			f->solidness = new_style_water ? 0 : 1;
 			is_liquid = true;
 			break;
 		case NDT_FLOWINGLIQUID:
@@ -899,17 +894,14 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 			break;
 		case NDT_PLANTLIKE:
 			f->solidness = 0;
-			f->backface_culling = false;
 			if (f->waving == 1)
 				material_type = TILE_MATERIAL_WAVING_PLANTS;
 			break;
 		case NDT_FIRELIKE:
-			f->backface_culling = false;
 			f->solidness = 0;
 			break;
 		case NDT_MESH:
 			f->solidness = 0;
-			f->backface_culling = false;
 			break;
 		case NDT_TORCHLIKE:
 		case NDT_SIGNLIKE:
@@ -941,7 +933,7 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 		// Tiles (fill in f->tiles[])
 		for (u16 j = 0; j < 6; j++) {
 			fillTileAttribs(tsrc, &f->tiles[j], &tiledef[j], tile_shader[j],
-				use_normal_texture, f->backface_culling, f->alpha, material_type);
+				use_normal_texture, f->tiledef[j].backface_culling, f->alpha, material_type);
 		}
 
 		// Special tiles (fill in f->special_tiles[])

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -294,14 +294,31 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 		index = lua_gettop(L) + 1 + index;
 
 	TileDef tiledef;
-	bool default_tiling = (drawtype == NDT_PLANTLIKE || drawtype == NDT_FIRELIKE)
-		? false : true;
+
+	bool default_tiling = true;
+	bool default_culling = true;
+	switch (drawtype) {
+		case NDT_PLANTLIKE:
+		case NDT_FIRELIKE:
+			default_tiling = false;
+			// "break" is omitted here intentionaly, as PLANTLIKE
+			// FIRELIKE drawtype both should default to having
+			// backface_culling to false.
+		case NDT_MESH:
+		case NDT_LIQUID:
+			default_culling = false;
+			break;
+		default:
+			break;
+	}
+
 	// key at index -2 and value at index
 	if(lua_isstring(L, index)){
 		// "default_lava.png"
 		tiledef.name = lua_tostring(L, index);
 		tiledef.tileable_vertical = default_tiling;
 		tiledef.tileable_horizontal = default_tiling;
+		tiledef.backface_culling = default_culling;
 	}
 	else if(lua_istable(L, index))
 	{
@@ -310,7 +327,7 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 		getstringfield(L, index, "name", tiledef.name);
 		getstringfield(L, index, "image", tiledef.name); // MaterialSpec compat.
 		tiledef.backface_culling = getboolfield_default(
-			L, index, "backface_culling", true);
+			L, index, "backface_culling", default_culling);
 		tiledef.tileable_horizontal = getboolfield_default(
 			L, index, "tileable_horizontal", default_tiling);
 		tiledef.tileable_vertical = getboolfield_default(


### PR DESCRIPTION
Backface culling is enabled by default for all tiles, as this
is how the lua parser initializes each tiledef. We revert to
always using the value from the tiledef since it is always
read and serialized.

Mods that wish to disable culling for e.g. mesh nodes, now can
specify the following to disable culling:
    
        tiles = {{ name = "tex.png", backface_culling = false }},
    
Note the double '{'! and use of 'name' key here.
    
I've tested this against the new door models and this properly
allows me to disable culling per node.
    
This does enable culling for almost all nodes by default. Mod
authors may have to update their mods to disable culling where
needed or wanted.