### PR TITLE
Make INodeDefManager::getIds return a vector, not a set

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -552,7 +552,8 @@ struct ActiveABM
 {
 	ActiveBlockModifier *abm;
 	int chance;
-	std::set<content_t> required_neighbors;
+	std::vector<content_t> required_neighbors;
+	bool check_required_neighbors;
 };
 
 class ABMHandler
@@ -569,63 +570,49 @@ public:
 		if(dtime_s < 0.001)
 			return;
 		INodeDefManager *ndef = env->getGameDef()->ndef();
-		for(std::vector<ABMWithState>::iterator
-				i = abms.begin(); i != abms.end(); ++i) {
-			ActiveBlockModifier *abm = i->abm;
+		for (u32 i = 0; i < abms.size(); ++i) {
+			ActiveBlockModifier *abm = abms[i].abm;
 			float trigger_interval = abm->getTriggerInterval();
-			if(trigger_interval < 0.001)
+			if (trigger_interval < 0.001)
 				trigger_interval = 0.001;
 			float actual_interval = dtime_s;
-			if(use_timers){
-				i->timer += dtime_s;
-				if(i->timer < trigger_interval)
+			if (use_timers) {
+				abms[i].timer += dtime_s;
+				if (abms[i].timer < trigger_interval)
 					continue;
-				i->timer -= trigger_interval;
+				abms[i].timer -= trigger_interval;
 				actual_interval = trigger_interval;
 			}
 			float chance = abm->getTriggerChance();
-			if(chance == 0)
+			if (chance == 0)
 				chance = 1;
 			ActiveABM aabm;
 			aabm.abm = abm;
-			if(abm->getSimpleCatchUp()) {
+			if (abm->getSimpleCatchUp()) {
 				float intervals = actual_interval / trigger_interval;
-				if(intervals == 0)
+				if (intervals == 0)
 					continue;
 				aabm.chance = chance / intervals;
-				if(aabm.chance == 0)
+				if (aabm.chance == 0)
 					aabm.chance = 1;
 			} else {
 				aabm.chance = chance;
 			}
 			// Trigger neighbors
-			std::set<std::string> required_neighbors_s
+			std::vector<std::string> required_neighbors_s
 					= abm->getRequiredNeighbors();
-			for(std::set<std::string>::iterator
-					i = required_neighbors_s.begin();
-					i != required_neighbors_s.end(); ++i)
-			{
-				ndef->getIds(*i, aabm.required_neighbors);
+			for (u32 j = 0; j < required_neighbors_s.size(); ++j) {
+				ndef->getIds(required_neighbors_s[j], aabm.required_neighbors);
 			}
+			aabm.check_required_neighbors = !required_neighbors_s.empty();
 			// Trigger contents
-			std::set<std::string> contents_s = abm->getTriggerContents();
-			for(std::set<std::string>::iterator
-					i = contents_s.begin(); i != contents_s.end(); ++i)
-			{
-				std::set<content_t> ids;
-				ndef->getIds(*i, ids);
-				for(std::set<content_t>::const_iterator k = ids.begin();
-						k != ids.end(); ++k)
-				{
-					content_t c = *k;
-					std::map<content_t, std::vector<ActiveABM> >::iterator j;
-					j = m_aabms.find(c);
-					if(j == m_aabms.end()){
-						std::vector<ActiveABM> aabmlist;
-						m_aabms[c] = aabmlist;
-						j = m_aabms.find(c);
-					}
-					j->second.push_back(aabm);
+			std::vector<std::string> contents_s = abm->getTriggerContents();
+			for (u32 j = 0; j < contents_s.size(); ++j) {
+				std::vector<content_t> ids;
+				ndef->getIds(contents_s[j], ids);
+				for (u32 k = 0; k < ids.size(); ++k) {
+					content_t c = ids[k];
+					m_aabms[c].push_back(aabm);
 				}
 			}
 		}
@@ -689,20 +676,17 @@ public:
 					continue;
 
 				// Check neighbors
-				if(!i->required_neighbors.empty())
-				{
+				if (i->check_required_neighbors) {
 					v3s16 p1;
-					for(p1.X = p.X-1; p1.X <= p.X+1; p1.X++)
-					for(p1.Y = p.Y-1; p1.Y <= p.Y+1; p1.Y++)
-					for(p1.Z = p.Z-1; p1.Z <= p.Z+1; p1.Z++)
+					for (p1.X = p.X-1; p1.X <= p.X+1; p1.X++)
+					for (p1.Y = p.Y-1; p1.Y <= p.Y+1; p1.Y++)
+					for (p1.Z = p.Z-1; p1.Z <= p.Z+1; p1.Z++)
 					{
 						if(p1 == p)
 							continue;
 						MapNode n = map->getNodeNoEx(p1);
 						content_t c = n.getContent();
-						std::set<content_t>::const_iterator k;
-						k = i->required_neighbors.find(c);
-						if(k != i->required_neighbors.end()){
+						if (CONTAINS(i->required_neighbors, c)) {
 							goto neighbor_found;
 						}
 					}

--- a/src/environment.h
+++ b/src/environment.h
@@ -152,11 +152,11 @@ public:
 	virtual ~ActiveBlockModifier(){};
 
 	// Set of contents to trigger on
-	virtual std::set<std::string> getTriggerContents()=0;
+	virtual std::vector<std::string> getTriggerContents() = 0;
 	// Set of required neighbors (trigger doesn't happen if none are found)
 	// Empty = do not check neighbors
-	virtual std::set<std::string> getRequiredNeighbors()
-	{ return std::set<std::string>(); }
+	virtual std::vector<std::string> getRequiredNeighbors()
+	{ return std::vector<std::string>(); }
 	// Trigger interval in seconds
 	virtual float getTriggerInterval() = 0;
 	// Random chance of (1 / return value), 0 is disallowed

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -408,7 +408,7 @@ public:
 	inline virtual const ContentFeatures& get(const MapNode &n) const;
 	virtual bool getId(const std::string &name, content_t &result) const;
 	virtual content_t getId(const std::string &name) const;
-	virtual void getIds(const std::string &name, std::set<content_t> &result) const;
+	virtual void getIds(const std::string &name, std::vector<content_t> &result) const;
 	virtual const ContentFeatures& get(const std::string &name) const;
 	content_t allocateId();
 	virtual content_t set(const std::string &name, const ContentFeatures &def);
@@ -449,10 +449,10 @@ private:
 
 	std::map<std::string, content_t> m_name_id_mapping_with_aliases;
 
-	// A mapping from groups to a list of content_ts (and their levels)
+	// A mapping from groups to a vector of content_ts
 	// that belong to it.  Necessary for a direct lookup in getIds().
 	// Note: Not serialized.
-	std::map<std::string, GroupItems> m_group_to_items;
+	std::map<std::string, std::vector<content_t> > m_group_to_items;
 
 	// Next possibly free id
 	content_t m_next_id;
@@ -593,28 +593,24 @@ content_t CNodeDefManager::getId(const std::string &name) const
 
 
 void CNodeDefManager::getIds(const std::string &name,
-		std::set<content_t> &result) const
+		std::vector<content_t> &result) const
 {
 	//TimeTaker t("getIds", NULL, PRECISION_MICRO);
 	if (name.substr(0,6) != "group:") {
 		content_t id = CONTENT_IGNORE;
-		if(getId(name, id))
-			result.insert(id);
+		if (getId(name, id))
+			result.push_back(id);
 		return;
 	}
 	std::string group = name.substr(6);
 
-	std::map<std::string, GroupItems>::const_iterator
+	std::map<std::string, std::vector<content_t> >::const_iterator
 		i = m_group_to_items.find(group);
 	if (i == m_group_to_items.end())
 		return;
 
-	const GroupItems &items = i->second;
-	for (GroupItems::const_iterator j = items.begin();
-		j != items.end(); ++j) {
-		if ((*j).second != 0)
-			result.insert((*j).first);
-	}
+	const std::vector<content_t> &items = i->second;
+	result.insert(result.end(), items.begin(), items.end());
 	//printf("getIds: %dus\n", t.stop());
 }
 
@@ -683,17 +679,8 @@ content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &d
 	// belongs to when a node is re-registered
 	for (ItemGroupList::const_iterator i = def.groups.begin();
 		i != def.groups.end(); ++i) {
-		std::string group_name = i->first;
-
-		std::map<std::string, GroupItems>::iterator
-			j = m_group_to_items.find(group_name);
-		if (j == m_group_to_items.end()) {
-			m_group_to_items[group_name].push_back(
-				std::make_pair(id, i->second));
-		} else {
-			GroupItems &items = j->second;
-			items.push_back(std::make_pair(id, i->second));
-		}
+		const std::string &group_name = i->first;
+		m_group_to_items[group_name].push_back(id);
 	}
 	return id;
 }
@@ -1531,11 +1518,7 @@ bool NodeResolver::getIdsFromNrBacklog(std::vector<content_t> *result_out,
 				success = false;
 			}
 		} else {
-			std::set<content_t> cids;
-			std::set<content_t>::iterator it;
-			m_ndef->getIds(name, cids);
-			for (it = cids.begin(); it != cids.end(); ++it)
-				result_out->push_back(*it);
+			m_ndef->getIds(name, *result_out);
 		}
 	}
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -670,15 +670,23 @@ content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &d
 		assert(id != CONTENT_IGNORE);
 		addNameIdMapping(id, name);
 	}
+
+	// Remove this content to the list of all groups it previously belonged to
+	for (ItemGroupList::const_iterator i = m_content_features[id].groups.begin();
+			i != m_content_features[id].groups.end(); ++i) {
+		const std::string &group_name = i->first;
+		std::vector<content_t> &ids = m_group_to_items[group_name];
+		ids.erase(std::remove(ids.begin(), ids.end(), id), ids.end());
+	}
+
+	// Update ContentFeatures
 	m_content_features[id] = def;
 	verbosestream << "NodeDefManager: registering content id \"" << id
 		<< "\": name=\"" << def.name << "\""<<std::endl;
 
 	// Add this content to the list of all groups it belongs to
-	// FIXME: This should remove a node from groups it no longer
-	// belongs to when a node is re-registered
 	for (ItemGroupList::const_iterator i = def.groups.begin();
-		i != def.groups.end(); ++i) {
+			i != def.groups.end(); ++i) {
 		const std::string &group_name = i->first;
 		m_group_to_items[group_name].push_back(id);
 	}

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <iostream>
 #include <map>
-#include <list>
 #include "util/numeric.h"
 #include "mapnode.h"
 #ifndef SERVER
@@ -41,8 +40,6 @@ class ITextureSource;
 class IShaderSource;
 class IGameDef;
 class NodeResolver;
-
-typedef std::list<std::pair<content_t, int> > GroupItems;
 
 enum ContentParamType
 {
@@ -303,7 +300,7 @@ public:
 	virtual bool getId(const std::string &name, content_t &result) const=0;
 	virtual content_t getId(const std::string &name) const=0;
 	// Allows "group:name" in addition to regular node names
-	virtual void getIds(const std::string &name, std::set<content_t> &result)
+	virtual void getIds(const std::string &name, std::vector<content_t> &result)
 			const=0;
 	virtual const ContentFeatures &get(const std::string &name) const=0;
 
@@ -327,7 +324,7 @@ public:
 	// If not found, returns CONTENT_IGNORE
 	virtual content_t getId(const std::string &name) const=0;
 	// Allows "group:name" in addition to regular node names
-	virtual void getIds(const std::string &name, std::set<content_t> &result)
+	virtual void getIds(const std::string &name, std::vector<content_t> &result)
 		const=0;
 	// If not found, returns the features of CONTENT_UNKNOWN
 	virtual const ContentFeatures &get(const std::string &name) const=0;

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -103,37 +103,37 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 			int id = lua_tonumber(L, -2);
 			int current_abm = lua_gettop(L);
 
-			std::set<std::string> trigger_contents;
+			std::vector<std::string> trigger_contents;
 			lua_getfield(L, current_abm, "nodenames");
-			if(lua_istable(L, -1)){
+			if (lua_istable(L, -1)) {
 				int table = lua_gettop(L);
 				lua_pushnil(L);
-				while(lua_next(L, table) != 0){
+				while (lua_next(L, table) != 0){
 					// key at index -2 and value at index -1
 					luaL_checktype(L, -1, LUA_TSTRING);
-					trigger_contents.insert(lua_tostring(L, -1));
+					trigger_contents.push_back(lua_tostring(L, -1));
 					// removes value, keeps key for next iteration
 					lua_pop(L, 1);
 				}
-			} else if(lua_isstring(L, -1)){
-				trigger_contents.insert(lua_tostring(L, -1));
+			} else if (lua_isstring(L, -1)) {
+				trigger_contents.push_back(lua_tostring(L, -1));
 			}
 			lua_pop(L, 1);
 
-			std::set<std::string> required_neighbors;
+			std::vector<std::string> required_neighbors;
 			lua_getfield(L, current_abm, "neighbors");
-			if(lua_istable(L, -1)){
+			if (lua_istable(L, -1)) {
 				int table = lua_gettop(L);
 				lua_pushnil(L);
-				while(lua_next(L, table) != 0){
+				while (lua_next(L, table) != 0) {
 					// key at index -2 and value at index -1
 					luaL_checktype(L, -1, LUA_TSTRING);
-					required_neighbors.insert(lua_tostring(L, -1));
+					required_neighbors.push_back(lua_tostring(L, -1));
 					// removes value, keeps key for next iteration
 					lua_pop(L, 1);
 				}
-			} else if(lua_isstring(L, -1)){
-				required_neighbors.insert(lua_tostring(L, -1));
+			} else if (lua_isstring(L, -1)) {
+				required_neighbors.push_back(lua_tostring(L, -1));
 			}
 			lua_pop(L, 1);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -176,15 +176,15 @@ class LuaABM : public ActiveBlockModifier {
 private:
 	int m_id;
 
-	std::set<std::string> m_trigger_contents;
-	std::set<std::string> m_required_neighbors;
+	std::vector<std::string> m_trigger_contents;
+	std::vector<std::string> m_required_neighbors;
 	float m_trigger_interval;
 	u32 m_trigger_chance;
 	bool m_simple_catch_up;
 public:
 	LuaABM(lua_State *L, int id,
-			const std::set<std::string> &trigger_contents,
-			const std::set<std::string> &required_neighbors,
+			const std::vector<std::string> &trigger_contents,
+			const std::vector<std::string> &required_neighbors,
 			float trigger_interval, u32 trigger_chance, bool simple_catch_up):
 		m_id(id),
 		m_trigger_contents(trigger_contents),
@@ -194,11 +194,11 @@ public:
 		m_simple_catch_up(simple_catch_up)
 	{
 	}
-	virtual std::set<std::string> getTriggerContents()
+	virtual std::vector<std::string> getTriggerContents()
 	{
 		return m_trigger_contents;
 	}
-	virtual std::set<std::string> getRequiredNeighbors()
+	virtual std::vector<std::string> getRequiredNeighbors()
 	{
 		return m_required_neighbors;
 	}


### PR DESCRIPTION
Change std::set to std::vector in the interface of INodeDefManager::getIds() (like already done in NodeResolver::getIdsFromNrBacklog) and everywhere that calls getIds().

This should bring performance improvements for ABMs and the Lua API functions that use getIds(): find_node_near, find_nodes_in_area, find_nodes_in_area_under_air, since std::vector is generally faster than std::set.

However, linear lookup in a vector might cause performance regressions, so the changes have to be profiled with various workloads.

The second commit fixes https://forum.minetest.net/viewtopic.php?f=6&t=13870 (ABM gets executed even if node is not longer in group). If requested, I can split it into a different PR, but in its current state it would have to depend on this one.

TODO:
- [ ] Performance measurements
- [ ] Keep ABMHandler's content_t vectors/maps around instead of re-creating them each ABM interval?
