### PR TITLE
Liquids: Prevent liquid spreading on ignore

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1732,11 +1732,14 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks)
 						if (nb.t != NEIGHBOR_UPPER && liquid_type != LIQUID_NONE)
 							m_transforming_liquid.push_back(npos);
 						// if the current node happens to be a flowing node, it will start to flow down here.
-						if (nb.t == NEIGHBOR_LOWER) {
+						if (nb.t == NEIGHBOR_LOWER)
 							flowing_down = true;
-						}
 					} else {
 						neutrals[num_neutrals++] = nb;
+						// If neutral below is ignore prevent water spreading outwards
+						if (nb.t == NEIGHBOR_LOWER &&
+								nb.n.getContent() == CONTENT_IGNORE)
+							flowing_down = true;
 					}
 					break;
 				case LIQUID_SOURCE:


### PR DESCRIPTION
![screenshot_20160117_053200](https://cloud.githubusercontent.com/assets/3686677/12376182/08ed76ce-bcdf-11e5-9ba9-24349ef7864b.png)

^ Before
After v

![screenshot_20160117_071156](https://cloud.githubusercontent.com/assets/3686677/12376394/bf4e1572-bce9-11e5-903e-733d672d504f.png)

See #2977 

When the node below water is 'ignore' the 'flowing_down' flag is set to true to prevent water spreading outwards on the surface of ignore, however because water cannot penetrate ignore it doesn't actually flow down it just stops at ignore.
It does not fix the updating of stuck water but at least it's not as ugly as the spreading and could be considered water dissolving into spray at the column base.
Later some sort of liquid updating ABM could be added to MTgame, see below, obviously the spreading must be solved first otherwise all that spread water will start to flow down.
Tests were in floatlands by placing a source and watchiing the water column flow down below until it reaches an ungenerated mapchunk and either stops or spreads out.

//////////////////////////////////////////////////////

The ABM below is not part of this commit.

Flying down to the column base does not start it flowing down again, so i experimented with a hacky ABM for updating water nodes to start the column flowing down again (nodeupdate(pos) does not work):
```
minetest.register_abm({
	nodenames = {"group:water"},
	neighbors = {"air"},
	interval = 8,
	chance = 256,
	catch_up = false,
	action = function(pos, node)
		minetest.place_node(pos, {name = node.name})
	end
})
```
Even with a single node column this will start it flowing again within a minute or two, while hopefully being lightweight enough for the case of being near sealevel.
If updating the water by ABM is eventually done perhaps we need a new API that updates a water node by adding it to the liquid queue, i will look into this.
EDIT It already exists 'transforming_liquid_add(pos)'.
EDIT But it doesn't work.

Some time later after descending the column using the ABM:

![screenshot_20160117_073010](https://cloud.githubusercontent.com/assets/3686677/12376444/879b4dd6-bcec-11e5-807f-83507a93a76b.png)

![screenshot_20160117_073210](https://cloud.githubusercontent.com/assets/3686677/12376446/964ec808-bcec-11e5-869c-d9aa85d883fb.png)

Making liquid columns less ugly is essential for floatlands, and this (with an ABM) allows long water columns for vertical travel between floatlands.