### PR TITLE
on_leaveplayer callbacks are now invoked on server shutdown.

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -421,6 +421,12 @@ void ServerEnvironment::kickAllPlayers(AccessDeniedCode reason,
 	for (std::vector<Player*>::iterator it = m_players.begin();
 			it != m_players.end();
 			++it) {
+		
+		// Invoke the on_leaveplayer callbacks but make sure that
+		// we hand them a valid player object.
+		if ((*it)->peer_id > 0)
+			m_script->on_leaveplayer((*it)->getPlayerSAO());
+		
 		((Server*)m_gamedef)->DenyAccessVerCompliant((*it)->peer_id,
 			(*it)->protocol_version, (AccessDeniedCode)reason,
 			str_reason, reconnect);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -366,9 +366,6 @@ Server::~Server()
 	{
 		MutexAutoLock envlock(m_env_mutex);
 
-		// Execute script shutdown hooks
-		m_script->on_shutdown();
-
 		infostream << "Server: Saving players" << std::endl;
 		m_env->saveLoadedPlayers();
 
@@ -384,6 +381,9 @@ Server::~Server()
 		}
 		m_env->kickAllPlayers(SERVER_ACCESSDENIED_SHUTDOWN,
 			kick_msg, reconnect);
+
+		// Execute script shutdown hooks
+		m_script->on_shutdown();
 
 		infostream << "Server: Saving environment metadata" << std::endl;
 		m_env->saveMeta();


### PR DESCRIPTION
See #420, the registered on_leaveplayer callbacks are now invoked when
the server shuts down. Also the on_shutdown callbacks are now invoked
after all payers have been kicked.