### PR TITLE
Add V7 caves to Valleys mapgen.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1046,7 +1046,8 @@ mgfractal_np_cave2 (Mapgen fractal cave2 noise parameters) noise_params 0, 12, (
 #    "fast" produces softer terrain, more quickly
 #    "humid_rivers" modifies the humidity around rivers and in areas where water would tend to pool. It may interfere with delicately adjusted biomes.
 #    "rugged" and "cliffs" do nothing unless "fast" is enabled
-mg_valleys_spflags (Valleys C Flags) flags altitude_chill,cliffs,humid_rivers,nofast,rugged altitude_chill,noaltitude_chill,cliffs,nocliffs,fast,nofast,humid_rivers,nohumid_rivers,rugged,norugged
+#    "v7_caves" uses the v7 cave generator
+mg_valleys_spflags (Valleys C Flags) flags altitude_chill,cliffs,humid_rivers,nofast,rugged,nov7_caves altitude_chill,noaltitude_chill,cliffs,nocliffs,fast,nofast,humid_rivers,nohumid_rivers,rugged,norugged,v7_caves,nov7_caves
 
 # The altitude at which temperature drops by 20C
 mg_valleys_altitude_chill (Altitude Chill) int 90
@@ -1110,6 +1111,10 @@ mg_valleys_np_valley_profile (Valley Profile) noise_params 0.6, 0.5, (512, 512, 
 
 # Slope and fill work together to modify the heights
 mg_valleys_np_inter_valley_slope (Valley Slope) noise_params 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0
+
+# These are the noises for v7 caves.
+mg_valleys_np_v7_cave1 (V7 cave1 noise) noise_params 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
+mg_valleys_np_v7_cave2 (V7 cave2 noise) noise_params 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
 
 [*Security]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1315,11 +1315,12 @@
 
 #### Mapgen Valleys
 
-#mg_valleys_spflags = altitude_chill,cliffs,humid_rivers,nofast,rugged
+#mg_valleys_spflags = altitude_chill,cliffs,humid_rivers,nofast,rugged,nov7_caves
 #    "altitude_chill" makes higher elevations colder, which may cause biome issues.
 #    "fast" produces softer terrain, more quickly
 #    "humid_rivers" modifies the humidity around rivers and in areas where water would tend to pool. It may interfere with delicately adjusted biomes.
 #    "rugged" and "cliffs" do nothing unless "fast" is enabled
+#    "v7_caves" uses the v7 cave generator
 #
 #mg_valleys_altitude_chill = 90  # the altitude at which temperature drops by 20C
 #mg_valleys_cave_water_max_height = 31000   # max altitude of water in caves
@@ -1340,6 +1341,9 @@
 #
 #mg_valleys_np_simple_caves_1 = 0, 1, v3f(64, 64, 64), -8402, 3, 0.5, 2.0
 #mg_valleys_np_simple_caves_2 = 0, 1, v3f(64, 64, 64), 3944, 3, 0.5, 2.0
+#
+# mg_valleys_np_v7_cave1 = 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
+# mg_valleys_np_v7_cave2 = 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
 #
 # Base terrain height
 #mg_valleys_np_terrain_height = -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0

--- a/src/cavegen.cpp
+++ b/src/cavegen.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen_v5.h"
 #include "mapgen_v6.h"
 #include "mapgen_v7.h"
+#include "mapgen_valleys.h"
 #include "cavegen.h"
 
 NoiseParams nparams_caveliquids(0, 1, v3f(150.0, 150.0, 150.0), 776, 3, 0.6, 2.0);
@@ -572,7 +573,8 @@ void CaveV6::carveRoute(v3f vec, float f, bool randomize_xz, bool tunnel_above_g
 ///////////////////////////////////////// Caves V7
 
 
-CaveV7::CaveV7(MapgenV7 *mg, PseudoRandom *ps)
+template <class MapgenType>
+CaveV7plus<MapgenType>::CaveV7plus(MapgenType *mg, PseudoRandom *ps)
 {
 	this->mg             = mg;
 	this->vm             = mg->vm;
@@ -596,7 +598,8 @@ CaveV7::CaveV7(MapgenV7 *mg, PseudoRandom *ps)
 }
 
 
-void CaveV7::makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height)
+template <class MapgenType>
+void CaveV7plus<MapgenType>::makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height)
 {
 	node_min = nmin;
 	node_max = nmax;
@@ -659,7 +662,8 @@ void CaveV7::makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height)
 }
 
 
-void CaveV7::makeTunnel(bool dirswitch)
+template <class MapgenType>
+void CaveV7plus<MapgenType>::makeTunnel(bool dirswitch)
 {
 	// Randomize size
 	s16 min_d = min_tunnel_diameter;
@@ -745,7 +749,8 @@ void CaveV7::makeTunnel(bool dirswitch)
 }
 
 
-void CaveV7::carveRoute(v3f vec, float f, bool randomize_xz)
+template <class MapgenType>
+void CaveV7plus<MapgenType>::carveRoute(v3f vec, float f, bool randomize_xz)
 {
 	MapNode airnode(CONTENT_AIR);
 	MapNode waternode(c_water_source);
@@ -812,3 +817,7 @@ void CaveV7::carveRoute(v3f vec, float f, bool randomize_xz)
 		}
 	}
 }
+
+template class CaveV7plus<MapgenV7>;
+template class CaveV7plus<MapgenValleys>;
+

--- a/src/cavegen.h
+++ b/src/cavegen.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class MapgenV5;
 class MapgenV6;
 class MapgenV7;
+class MapgenValleys;
 
 class CaveV5 {
 public:
@@ -118,9 +119,10 @@ public:
 	void carveRoute(v3f vec, float f, bool randomize_xz, bool tunnel_above_ground);
 };
 
-class CaveV7 {
+template <class MapgenType>
+class CaveV7plus {
 public:
-	MapgenV7 *mg;
+	MapgenType *mg;
 	MMVManip *vm;
 	INodeDefManager *ndef;
 
@@ -156,11 +158,14 @@ public:
 
 	int water_level;
 
-	CaveV7() {}
-	CaveV7(MapgenV7 *mg, PseudoRandom *ps);
+	CaveV7plus() {}
+	CaveV7plus(MapgenType *mg, PseudoRandom *ps);
 	void makeCave(v3s16 nmin, v3s16 nmax, int max_stone_height);
 	void makeTunnel(bool dirswitch);
 	void carveRoute(v3f vec, float f, bool randomize_xz);
 };
+
+typedef CaveV7plus<MapgenV7> CaveV7;
+typedef CaveV7plus<MapgenValleys> CaveV7Valleys;
 
 #endif

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define  MG_VALLEYS_FAST          0x04
 #define  MG_VALLEYS_HUMID_RIVERS  0x08
 #define  MG_VALLEYS_RUGGED        0x10
+#define  MG_VALLEYS_V7_CAVES      0x20
 
 class BiomeManager;
 
@@ -61,6 +62,8 @@ struct MapgenValleysParams : public MapgenSpecificParams {
 	NoiseParams np_biome_heat_blend;
 	NoiseParams np_biome_humidity;
 	NoiseParams np_biome_humidity_blend;
+	NoiseParams np_cave1;
+	NoiseParams np_cave2;
 	NoiseParams np_cliffs;
 	NoiseParams np_corr;
 	NoiseParams np_filler_depth;
@@ -102,11 +105,18 @@ public:
 	virtual void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
 
+	// Required by cavegen
+	content_t c_water_source;
+	content_t c_lava_source;
+	content_t c_ice;
+
+	int ystride;
+	s16 *ridge_heightmap;
+
 private:
 	EmergeManager *m_emerge;
 	BiomeManager *bmgr;
 
-	int ystride;
 	int zstride;
 
 	u32 spflags;
@@ -115,6 +125,7 @@ private:
 	bool rugged_terrain;
 	bool humid_rivers;
 	bool use_altitude_chill;
+	bool v7_caves;
 
 	v3s16 node_min;
 	v3s16 node_max;
@@ -123,6 +134,8 @@ private:
 
 	Noise *noise_filler_depth;
 
+	Noise *noise_cave1;
+	Noise *noise_cave2;
 	Noise *noise_cliffs;
 	Noise *noise_corr;
 	Noise *noise_heat;
@@ -151,8 +164,6 @@ private:
 	content_t c_cobble;
 	content_t c_desert_stone;
 	content_t c_dirt;
-	content_t c_ice;
-	content_t c_lava_source;
 	content_t c_mossycobble;
 	content_t c_river_water_source;
 	content_t c_sand;
@@ -161,7 +172,6 @@ private:
 	content_t c_stair_cobble;
 	content_t c_stair_sandstonebrick;
 	content_t c_stone;
-	content_t c_water_source;
 
 	float terrainLevelAtPoint(s16 x, s16 z);
 
@@ -177,6 +187,7 @@ private:
 	void dustTopNodes();
 
 	void generateSimpleCaves(s16 max_stone_y);
+	void generateV7Caves(s16 max_stone_y);
 };
 
 struct MapgenFactoryValleys : public MapgenFactory {


### PR DESCRIPTION
This adds a template for the CaveV7 class, so that Valleys mapgen can
use it without duplicating code.