### PR TITLE
New timer design.

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -4,74 +4,46 @@
 -- Misc. API functions
 --
 
-local timers = {}
-local mintime
-local function update_timers(delay)
-	mintime = false
-	local sub = 0
-	for index = 1, #timers do
-		index = index - sub
-		local timer = timers[index]
-		timer.time = timer.time - delay
-		if timer.time <= 0 then
-			core.set_last_run_mod(timer.mod_origin)
-			timer.func(unpack(timer.args or {}))
-			table.remove(timers, index)
-			sub = sub + 1
-		elseif mintime then
-			mintime = math.min(mintime, timer.time)
-		else
-			mintime = timer.time
+local jobs = {}
+local time = 0.0
+local last = 0.0
+
+core.register_globalstep(function(dtime)
+	local new = core.get_us_time() / 1000000
+	if new > last then
+		time = time + (new - last)
+	else
+		-- rollover, may lose a little bit of time here but
+		-- only 1 tick max, potentially running timers slightly
+		-- too early
+		time = time + new
+	end
+	last = new
+
+	if #jobs < 1 then
+		return
+	end
+
+	-- iterate backwards to assure no table corruption
+	for i = #jobs, 1, -1 do
+		local job = jobs[i]
+		if time >= job.expire then
+			core.set_last_run_mod(job.mod_origin)
+			job.func(unpack(job.arg))
+			table.remove(jobs, i)
 		end
 	end
-end
-
-local timers_to_add
-local function add_timers()
-	for _, timer in ipairs(timers_to_add) do
-		table.insert(timers, timer)
-	end
-	timers_to_add = false
-end
-
-local delay = 0
-core.register_globalstep(function(dtime)
-	if not mintime then
-		-- abort if no timers are running
-		return
-	end
-	if timers_to_add then
-		add_timers()
-	end
-	delay = delay + dtime
-	if delay < mintime then
-		return
-	end
-	update_timers(delay)
-	delay = 0
 end)
 
-function core.after(time, func, ...)
+function core.after(after, func, ...)
 	assert(tonumber(time) and type(func) == "function",
 			"Invalid core.after invocation")
-	if not mintime then
-		mintime = time
-		timers_to_add = {{
-			time   = time+delay,
-			func   = func,
-			args   = {...},
-			mod_origin = core.get_last_run_mod(),
-		}}
-		return
-	end
-	mintime = math.min(mintime, time)
-	timers_to_add = timers_to_add or {}
-	timers_to_add[#timers_to_add+1] = {
-		time   = time+delay,
-		func   = func,
-		args   = {...},
-		mod_origin = core.get_last_run_mod(),
-	}
+	table.insert(jobs, {
+		func = func,
+		expire = time + after,
+		arg = { ... },
+		mod_origin = core.get_last_run_mod()
+	})
 end
 
 function core.check_player_privs(player_or_name, ...)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2242,7 +2242,7 @@ These functions return the leftover itemstack.
 
 ### Timing
 * `minetest.after(time, func, ...)`
-    * Call the function `func` after `time` seconds
+    * Call the function `func` after `time` seconds, may be fractional
     * Optional: Variable number of arguments that are passed to `func`
 
 ### Server

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1727,7 +1727,7 @@ Helper functions
 * `minetest.is_yes(arg)`
     * returns whether `arg` can be interpreted as yes
 * `minetest.get_us_time()`
-    * returns time with microsecond precision
+    * returns time with microsecond precision. May not return wall time.
 * `table.copy(table)`: returns a table
     * returns a deep copy of `table`
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -211,33 +211,11 @@ void initIrrlicht(irr::IrrlichtDevice * );
 	}
 
 #else // Posix
-
-	inline u32 getTimeS()
+	inline void _os_get_clock(struct timespec *ts)
 	{
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		return tv.tv_sec;
-	}
-
-	inline u32 getTimeMs()
-	{
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		return tv.tv_sec * 1000 + tv.tv_usec / 1000;
-	}
-
-	inline u32 getTimeUs()
-	{
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		return tv.tv_sec * 1000000 + tv.tv_usec;
-	}
-
-	inline u32 getTimeNs()
-	{
-		struct timespec ts;
-		// from http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
-#if defined(__MACH__) && defined(__APPLE__) // OS X does not have clock_gettime, use clock_get_time
+#if defined(__MACH__) && defined(__APPLE__)
+	// from http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
+	// OS X does not have clock_gettime, use clock_get_time
 		clock_serv_t cclock;
 		mach_timespec_t mts;
 		host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
@@ -245,9 +223,44 @@ void initIrrlicht(irr::IrrlichtDevice * );
 		mach_port_deallocate(mach_task_self(), cclock);
 		ts.tv_sec = mts.tv_sec;
 		ts.tv_nsec = mts.tv_nsec;
+#elif defined(CLOCK_MONOTONIC_RAW)
+		clock_gettime(CLOCK_MONOTONIC_RAW, ts);
+#elif defined(_POSIX_MONOTONIC_CLOCK)
+		clock_gettime(CLOCK_MONOTONIC, ts);
 #else
-		clock_gettime(CLOCK_REALTIME, &ts);
-#endif
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+		TIMEVAL_TO_TIMESPEC(&tv, ts);
+#endif // defined(__MACH__) && defined(__APPLE__)
+	}
+
+	// Note: these clock functions do not return wall time, but
+	// generally a clock that starts at 0 when the process starts.
+	inline u32 getTimeS()
+	{
+		struct timespec ts;
+		_os_get_clock(&ts);
+		return ts.tv_sec;
+	}
+
+	inline u32 getTimeMs()
+	{
+		struct timespec ts;
+		_os_get_clock(&ts);
+		return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+	}
+
+	inline u32 getTimeUs()
+	{
+		struct timespec ts;
+		_os_get_clock(&ts);
+		return ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+	}
+
+	inline u32 getTimeNs()
+	{
+		struct timespec ts;
+		_os_get_clock(&ts);
 		return ts.tv_sec * 1000000000 + ts.tv_nsec;
 	}
 


### PR DESCRIPTION
I could honestly not make much sense of the timer implementation
that was here. Instead I've implemented the type of timer algorithm
that I've used before, and tested it instead.

This implementation uses dtime as passed to this function and
assumes it can be used for rough timekeeping, while giving sub
second precision. Since no os.time() is used, we have excellent
sub-second scheduling precision, but it should be assumed that
server ticks can cause ticks to be delayed for well over seconds
in case of server load.

Timers are guaranteed to execute, even if delayed well beyond their
scheduled time. Timers will never run before their allotted time
occurs.

If server load is high, all expired timers will trigger and
server lag may be increased. It is therefore important to
schedule smaller jobs more often, and use fractional numbers
and prime numbers to prevent coalescing of events.
