### PR TITLE
Backface culling: Ignore setting in tiledef from old servers.

### DIFF
--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -132,9 +132,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Rename GENERIC_CMD_SET_ATTACHMENT to GENERIC_CMD_ATTACH_TO
 	PROTOCOL_VERSION 26:
 		Add TileDef tileable_horizontal, tileable_vertical flags
+	PROTOCOL_VERSION 27:
+		backface_culling: backwards compatibility for playing with
+		newer client on pre-27 servers.
 */
 
-#define LATEST_PROTOCOL_VERSION 26
+#define LATEST_PROTOCOL_VERSION 27
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -137,7 +137,7 @@ struct TileDef
 	}
 
 	void serialize(std::ostream &os, u16 protocol_version) const;
-	void deSerialize(std::istream &is);
+	void deSerialize(std::istream &is, bool culling_ignore);
 };
 
 enum NodeDrawType


### PR DESCRIPTION
Outdated servers are always sending tiledefs with culling
enabled no matter what, as the value was previously entirely
ignored.

To compensate, we must (1) detect that we're running against
an old server with a new client, and (2) disable culling for
mesh, plantlike, firelike and liquid draw types no matter what
the server is telling us.

In order to achieve this, we need to bump the protocol version
since we cannot rely on the tiledef version, and test for it
being older. I've bumped the protocol version, although that
should have likely happened in the actual change that introduced
the new backface_culling PR #3578

We also explicitly test for the drawtype to assure we are not
changing the culling value for other nodes, where it should
remain enabled.

This was tested against various pub servers, including 0.4.13 and
0.4.12.

Fixes #3598