### PR TITLE
Play tool breaking sounds.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -467,6 +467,9 @@ function core.node_dig(pos, node, digger)
 		-- Wear out tool
 		if not core.setting_getbool("creative_mode") then
 			wielded:add_wear(dp.wear)
+			if wielded:get_count() == 0 and wdef.sound and wdef.sound.breaks then
+				core.sound_play(wdef.sound.breaks, {pos = pos, gain = 1.0})
+			end
 		end
 	end
 	digger:set_wielded_item(wielded)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3315,6 +3315,7 @@ Definition tables
           actual result to client in a short moment.
         ]]
         sound = {
+            breaks = "default_tool_break", -- tools only
             place = --[[<SimpleSoundSpec>]],
         },
 


### PR DESCRIPTION
If a tool wears out and is destroyed, it's itemstack count
goes to 0, and we can optionally play a breaking sound.

This patch implements playing a breaking sound when this
occurs. Sounds need to be added to the tool itemdef
registration as the sound name string in the .sound_break
member.
