### PR TITLE
Sort public server list by player count, descending.

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -243,7 +243,12 @@ function asyncOnlineFavourites()
 	menudata.favorites = menudata.public_known
 	core.handle_async(
 		function(param)
-			return core.get_favorites("online")
+			local listsort = function(a, b)
+				return b.clients < a.clients
+			end
+			local list = core.get_favorites("online")
+			table.sort(list, listsort)
+			return list
 		end,
 		nil,
 		function(result)


### PR DESCRIPTION
Random lists are very, very hard to work with. We can
sort by name, but that is going to be a fairly random
way to order it as well. Sorting them descending by
player count is likely the best default way to order
this list.

In the future, I'd like to see that the list can be:
- sorted by name
- filtered out full servers
- filtered out empty servers
- filtered out pvp or non-pvp servers
- filtered out damage or non-player damage servers
- filtered out creative or non-creative...