### PR TITLE
Use meshes to display inventory items

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -508,6 +508,9 @@ directional_colored_fog (Colored fog) bool true
 #    set to the nearest valid value.
 ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
 
+#    Enables animation of inventory items.
+inventory_items_animations (Inventory items animations) bool false
+
 [**Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -588,6 +588,9 @@
 #    type: float min: 0.25 max: 4
 # ambient_occlusion_gamma = 2.2
 
+#    Enable animation of inventory items.
+# inventory_items_animations = false
+
 ### Menus
 
 #    Use a cloud animation for the main menu background.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -138,6 +138,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("console_alpha", "200");
 	settings->setDefault("selectionbox_color", "(0,0,0)");
 	settings->setDefault("enable_node_highlighting", "false");
+	settings->setDefault("inventory_items_animations", "false");
 	settings->setDefault("crosshair_color", "(255,255,255)");
 	settings->setDefault("crosshair_alpha", "255");
 	settings->setDefault("hud_scaling", "1.0");

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -572,7 +572,7 @@ void GUIFormSpecMenu::parseItemImage(parserData* data,std::string element)
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of item_image without a size[] element"<<std::endl;
-		m_itemimages.push_back(ImageDrawSpec(name, pos, geom));
+		m_itemimages.push_back(ImageDrawSpec("", name, pos, geom));
 		return;
 	}
 	errorstream<< "Invalid ItemImage element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -1483,7 +1483,6 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data,std::string element)
 		IItemDefManager *idef = m_gamedef->idef();
 		ItemStack item;
 		item.deSerialize(item_name, idef);
-		video::ITexture *texture = idef->getInventoryTexture(item.getDefinition(idef).name, m_gamedef);
 
 		m_tooltips[name] =
 			TooltipSpec(item.getDefinition(idef).description,
@@ -1505,13 +1504,17 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data,std::string element)
 		}
 
 		e->setUseAlphaChannel(true);
-		e->setImage(guiScalingImageButton(Environment->getVideoDriver(), texture, geom.X, geom.Y));
-		e->setPressedImage(guiScalingImageButton(Environment->getVideoDriver(), texture, geom.X, geom.Y));
+		e->setImage(guiScalingImageButton(Environment->getVideoDriver(), NULL, geom.X, geom.Y));
+		e->setPressedImage(guiScalingImageButton(Environment->getVideoDriver(), NULL, geom.X, geom.Y));
 		e->setScaleImage(true);
 		spec.ftype = f_Button;
 		rect+=data->basepos-padding;
 		spec.rect=rect;
 		m_fields.push_back(spec);
+		pos = padding + AbsoluteRect.UpperLeftCorner;
+		pos.X += stof(v_pos[0]) * (float) spacing.X;
+		pos.Y += stof(v_pos[1]) * (float) spacing.Y;
+		m_itemimages.push_back(ImageDrawSpec("", item_name, pos, geom));
 		return;
 	}
 	errorstream<< "Invalid ItemImagebutton element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -2151,7 +2154,8 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 	return ItemSpec(InventoryLocation(), "", -1);
 }
 
-void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
+void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
+		bool &item_hovered)
 {
 	video::IVideoDriver* driver = Environment->getVideoDriver();
 
@@ -2193,12 +2197,13 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
 			&& m_selected_item->i == item_i;
 		bool hovering = rect.isPointInside(m_pointer);
 
-		if(phase == 0)
-		{
-			if(hovering)
+		if (phase == 0) {
+			if (hovering) {
+				item_hovered = true;
 				driver->draw2DRectangle(m_slotbg_h, rect, &AbsoluteClippingRect);
-			else
+			} else {
 				driver->draw2DRectangle(m_slotbg_n, rect, &AbsoluteClippingRect);
+			}
 		}
 
 		//Draw inv slot borders
@@ -2232,7 +2237,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
 			if(!item.empty())
 			{
 				drawItemStack(driver, m_font, item,
-						rect, &AbsoluteClippingRect, m_gamedef);
+					rect, &AbsoluteClippingRect, m_gamedef,
+					selected, hovering, false);
 			}
 
 			// Draw tooltip
@@ -2273,10 +2279,14 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase)
 
 void GUIFormSpecMenu::drawSelectedItem()
 {
-	if(!m_selected_item)
-		return;
-
 	video::IVideoDriver* driver = Environment->getVideoDriver();
+
+	if (!m_selected_item) {
+		drawItemStack(driver, m_font, ItemStack(),
+			core::rect<s32>(v2s32(0, 0), v2s32(0, 0)),
+			NULL, m_gamedef, false, false, true);
+		return;
+	}
 
 	Inventory *inv = m_invmgr->getInventory(m_selected_item->inventoryloc);
 	sanity_check(inv);
@@ -2287,7 +2297,7 @@ void GUIFormSpecMenu::drawSelectedItem()
 
 	core::rect<s32> imgrect(0,0,imgsize.X,imgsize.Y);
 	core::rect<s32> rect = imgrect + (m_pointer - imgrect.getCenter());
-	drawItemStack(driver, m_font, stack, rect, NULL, m_gamedef);
+	drawItemStack(driver, m_font, stack, rect, NULL, m_gamedef, false, false, true);
 }
 
 void GUIFormSpecMenu::drawMenu()
@@ -2369,6 +2379,12 @@ void GUIFormSpecMenu::drawMenu()
 
 		driver->draw2DRectangle(todraw, rect, 0);
 	}
+
+	/*
+		Call base class
+	*/
+	gui::IGUIElement::draw();
+
 	/*
 		Draw images
 	*/
@@ -2413,18 +2429,12 @@ void GUIFormSpecMenu::drawMenu()
 		const ImageDrawSpec &spec = m_itemimages[i];
 		IItemDefManager *idef = m_gamedef->idef();
 		ItemStack item;
-		item.deSerialize(spec.name, idef);
-		video::ITexture *texture = idef->getInventoryTexture(item.getDefinition(idef).name, m_gamedef);
-		// Image size on screen
+		item.deSerialize(spec.item_name, idef);
 		core::rect<s32> imgrect(0, 0, spec.geom.X, spec.geom.Y);
-		// Image rectangle on screen
+		// Viewport rectangle on screen
 		core::rect<s32> rect = imgrect + spec.pos;
-		const video::SColor color(255,255,255,255);
-		const video::SColor colors[] = {color,color,color,color};
-		draw2DImageFilterScaled(driver, texture, rect,
-			core::rect<s32>(core::position2d<s32>(0,0),
-					core::dimension2di(texture->getOriginalSize())),
-			NULL/*&AbsoluteClippingRect*/, colors, true);
+		drawItemStack(driver, m_font, item, rect, &AbsoluteClippingRect,
+				m_gamedef, false, false, false);
 	}
 
 	/*
@@ -2432,18 +2442,19 @@ void GUIFormSpecMenu::drawMenu()
 		Phase 0: Item slot rectangles
 		Phase 1: Item images; prepare tooltip
 	*/
-	int start_phase=0;
-	for(int phase=start_phase; phase<=1; phase++)
-	for(u32 i=0; i<m_inventorylists.size(); i++)
-	{
-		drawList(m_inventorylists[i], phase);
+	bool item_hovered = false;
+	int start_phase = 0;
+	for (int phase = start_phase; phase <= 1; phase++) {
+		for (u32 i = 0; i < m_inventorylists.size(); i++) {
+			drawList(m_inventorylists[i], phase, item_hovered);
+		}
 	}
-
-	/*
-		Call base class
-	*/
-	gui::IGUIElement::draw();
-
+	if (!item_hovered) {
+		drawItemStack(driver, m_font, ItemStack(),
+			core::rect<s32>(v2s32(0, 0), v2s32(0, 0)),
+			NULL, m_gamedef, false, true, false);
+	}	
+		
 /* TODO find way to show tooltips on touchscreen */
 #ifndef HAVE_TOUCHSCREENGUI
 	m_pointer = m_device->getCursorControl()->getPosition();

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -143,7 +143,17 @@ class GUIFormSpecMenu : public GUIModalMenu
 		{
 		}
 		ImageDrawSpec(const std::string &a_name,
-				v2s32 a_pos, v2s32 a_geom):
+				const std::string &a_item_name,
+				const v2s32 &a_pos, const v2s32 &a_geom):
+			name(a_name),
+			item_name (a_item_name),
+			pos(a_pos),
+			geom(a_geom)
+		{
+			scale = true;
+		}
+		ImageDrawSpec(const std::string &a_name,
+				const v2s32 &a_pos, const v2s32 &a_geom):
 			name(a_name),
 			pos(a_pos),
 			geom(a_geom)
@@ -151,13 +161,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 			scale = true;
 		}
 		ImageDrawSpec(const std::string &a_name,
-				v2s32 a_pos):
+				const v2s32 &a_pos):
 			name(a_name),
 			pos(a_pos)
 		{
 			scale = false;
 		}
 		std::string name;
+		std::string item_name;
 		v2s32 pos;
 		v2s32 geom;
 		bool scale;
@@ -282,7 +293,7 @@ public:
 	void regenerateGui(v2u32 screensize);
 
 	ItemSpec getItemAtPos(v2s32 p) const;
-	void drawList(const ListDrawSpec &s, int phase);
+	void drawList(const ListDrawSpec &s, int phase,	bool &item_hovered);
 	void drawSelectedItem();
 	void drawMenu();
 	void updateSelectedItem();
@@ -334,6 +345,8 @@ protected:
 	std::vector<std::pair<FieldSpec,gui::IGUIScrollBar*> > m_scrollbars;
 
 	ItemSpec *m_selected_item;
+	f32 m_timer1;
+	f32 m_timer2;
 	u32 m_selected_amount;
 	bool m_selected_dragging;
 
@@ -373,6 +386,7 @@ private:
 	TextDest         *m_text_dst;
 	unsigned int      m_formspec_version;
 	std::string       m_focused_element;
+	bool              m_selection_active;
 
 	typedef struct {
 		bool explicit_size;

--- a/src/hud.h
+++ b/src/hud.h
@@ -137,7 +137,8 @@ private:
 	void drawItems(v2s32 upperleftpos, s32 itemcount, s32 offset,
 		InventoryList *mainlist, u16 selectitem, u16 direction);
 
-	void drawItem(const ItemStack &item, const core::rect<s32>& rect, bool selected);
+	void drawItem(const ItemStack &item, const core::rect<s32>& rect,
+		bool selected);
 
 	v2u32 m_screensize;
 	v2s32 m_displaycenter;
@@ -151,8 +152,10 @@ void drawItemStack(video::IVideoDriver *driver,
 		const ItemStack &item,
 		const core::rect<s32> &rect,
 		const core::rect<s32> *clip,
-		IGameDef *gamedef);
-
+		IGameDef *gamedef,
+		bool selected,
+		bool hovered,
+		bool dragged);
 
 #endif
 

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -332,7 +332,6 @@ public:
 			return cc;
 
 		ITextureSource *tsrc = gamedef->getTextureSource();
-		INodeDefManager *nodedef = gamedef->getNodeDefManager();
 		const ItemDefinition &def = get(name);
 
 		// Create new ClientCached
@@ -343,103 +342,11 @@ public:
 		if(def.inventory_image != "")
 			cc->inventory_texture = tsrc->getTexture(def.inventory_image);
 
-		// Additional processing for nodes:
-		// - Create a wield mesh if WieldMeshSceneNode can't render
-		//   the node on its own.
-		// - If inventory_texture isn't set yet, create one using
-		//   render-to-texture.
-		if (def.type == ITEM_NODE) {
-			// Get node properties
-			content_t id = nodedef->getId(name);
-			const ContentFeatures &f = nodedef->get(id);
+		ItemStack item = ItemStack();
+		item.name = def.name;
 
-			bool need_rtt_mesh = cc->inventory_texture == NULL;
-
-			// Keep this in sync with WieldMeshSceneNode::setItem()
-			bool need_wield_mesh =
-				!(f.mesh_ptr[0] ||
-				  f.drawtype == NDT_NORMAL ||
-				  f.drawtype == NDT_ALLFACES ||
-				  f.drawtype == NDT_AIRLIKE);
-
-			scene::IMesh *node_mesh = NULL;
-
-			if (need_rtt_mesh || need_wield_mesh) {
-				u8 param1 = 0;
-				if (f.param_type == CPT_LIGHT)
-					param1 = 0xee;
-
-				/*
-					Make a mesh from the node
-				*/
-				MeshMakeData mesh_make_data(gamedef, false);
-				u8 param2 = 0;
-				if (f.param_type_2 == CPT2_WALLMOUNTED)
-					param2 = 1;
-				MapNode mesh_make_node(id, param1, param2);
-				mesh_make_data.fillSingleNode(&mesh_make_node);
-				MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
-				node_mesh = mapblock_mesh.getMesh();
-				node_mesh->grab();
-				video::SColor c(255, 255, 255, 255);
-				setMeshColor(node_mesh, c);
-
-				// scale and translate the mesh so it's a
-				// unit cube centered on the origin
-				scaleMesh(node_mesh, v3f(1.0/BS, 1.0/BS, 1.0/BS));
-				translateMesh(node_mesh, v3f(-1.0, -1.0, -1.0));
-			}
-
-			/*
-				Draw node mesh into a render target texture
-			*/
-			if (need_rtt_mesh) {
-				TextureFromMeshParams params;
-				params.mesh = node_mesh;
-				params.dim.set(64, 64);
-				params.rtt_texture_name = "INVENTORY_"
-					+ def.name + "_RTT";
-				params.delete_texture_on_shutdown = true;
-				params.camera_position.set(0, 1.0, -1.5);
-				params.camera_position.rotateXZBy(45);
-				params.camera_lookat.set(0, 0, 0);
-				// Set orthogonal projection
-				params.camera_projection_matrix.buildProjectionMatrixOrthoLH(
-						1.65, 1.65, 0, 100);
-				params.ambient_light.set(1.0, 0.2, 0.2, 0.2);
-				params.light_position.set(10, 100, -50);
-				params.light_color.set(1.0, 0.5, 0.5, 0.5);
-				params.light_radius = 1000;
-
-#ifdef __ANDROID__
-				params.camera_position.set(0, -1.0, -1.5);
-				params.camera_position.rotateXZBy(45);
-				params.light_position.set(10, -100, -50);
-#endif
-				cc->inventory_texture =
-					tsrc->generateTextureFromMesh(params);
-
-				// render-to-target didn't work
-				if (cc->inventory_texture == NULL) {
-					cc->inventory_texture =
-						tsrc->getTexture(f.tiledef[0].name);
-				}
-			}
-
-			/*
-				Use the node mesh as the wield mesh
-			*/
-			if (need_wield_mesh) {
-				cc->wield_mesh = node_mesh;
-				cc->wield_mesh->grab();
-
-				// no way reference count can be smaller than 2 in this place!
-				assert(cc->wield_mesh->getReferenceCount() >= 2);
-			}
-
-			if (node_mesh)
-				node_mesh->drop();
-		}
+		scene::IMesh *mesh = getItemMesh(gamedef, item);
+		cc->wield_mesh = mesh;
 
 		// Put in cache
 		m_clientcached.set(name, cc);

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -77,4 +77,8 @@ private:
 	core::aabbox3d<f32> m_bounding_box;
 };
 
+scene::IMesh *getItemMesh(IGameDef *gamedef, const ItemStack &item);
+
+scene::IMesh *getExtrudedMesh(ITextureSource *tsrc,
+		const std::string &imagename);
 #endif


### PR DESCRIPTION
This makes preloading item visuals obsolete and practically eliminates blackouts when switching inventory pages.
