### PR TITLE
clientiface.cpp: Reset m_nothing_to_send_pause_timer when invoking setBlockNotSent()

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -391,7 +391,7 @@ void RemoteClient::SentBlock(v3s16 p)
 void RemoteClient::SetBlockNotSent(v3s16 p)
 {
 	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer=0.1;
+	m_nothing_to_send_pause_timer = 0.1;
 
 	if(m_blocks_sending.find(p) != m_blocks_sending.end())
 		m_blocks_sending.erase(p);
@@ -402,8 +402,8 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
 {
 	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer=0.1;
-	
+	m_nothing_to_send_pause_timer = 0.1;
+
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = blocks.begin();
 			i != blocks.end(); ++i)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -391,6 +391,7 @@ void RemoteClient::SentBlock(v3s16 p)
 void RemoteClient::SetBlockNotSent(v3s16 p)
 {
 	m_nearest_unsent_d = 0;
+	m_nothing_to_send_pause_timer=0.1;
 
 	if(m_blocks_sending.find(p) != m_blocks_sending.end())
 		m_blocks_sending.erase(p);
@@ -401,7 +402,8 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
 {
 	m_nearest_unsent_d = 0;
-
+	m_nothing_to_send_pause_timer=0.1;
+	
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = blocks.begin();
 			i != blocks.end(); ++i)


### PR DESCRIPTION
As stated in [this forum thread](https://forum.minetest.net/viewtopic.php?f=6&t=12748), I noticed that there is a 2 seconds interval in which inventory changes are shown on the client. yyt16384 found the source of these 2 seconds:
m_nothing_to_send_pause_timer is set to 2.0 every time there are no changes to make, but this timer is not resetted when SetBlockNotSent or setBlocksNotSent are invoked. So in worst case, the changed block will be sent over 2 seconds too late.
With this change, changed inventories are updated almost immediately, but it causes additional connection load.
Please notice that I am a C++ newbie and if I did anything wrong, please let me know. I don't know how threading works and what would happen the functions are called in different threads, this maybe could cause inconsistencies.
This will probably only be a temporary solution until [this pull request](https://github.com/minetest/minetest/pull/3166) gets merged.
