### PR TITLE
builtin: Fix `print` crashing on nil "holes".

### DIFF
--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -12,7 +12,11 @@ if core.print then
 	-- Override native print and use
 	-- terminal if that's turned on
 	function print(...)
-		core_print(table.concat({...}, "\t"))
+		local n, t = select("#", ...), { ... }
+		for i = 1, n do
+			t[i] = tostring(t[i])
+		end
+		core_print(table.concat(t, "\t"))
 	end
 	core.print = nil -- don't pollute our namespace
 end


### PR DESCRIPTION
The engine implementation of `print` packs the varargs into a table and passes the table directly to `table.concat`. If you pass any value not supported by `table.concat` (particularly `nil`), the server crashes. This is unexpected behavior, as `print` is supposed to be able to work with anything.

This patch changes the implementation so it first converts all arguments using `tostring`, which fixes the issue and makes the custom `print` function compatible with the stock Lua behavior.

To reproduce this bug, simply make a mod that uses this code:

```lua
print(nil, 1)
```
