### PR TITLE
FindSpawnPos: Let mapgens decide what spawn altitude is suitable

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -247,7 +247,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("default_privs", "interact, shout");
 	settings->setDefault("player_transfer_distance", "0");
 	settings->setDefault("enable_pvp", "true");
-	settings->setDefault("vertical_spawn_range", "16");
 	settings->setDefault("disallow_empty_password", "false");
 	settings->setDefault("disable_anticheat", "false");
 	settings->setDefault("enable_rollback_recording", "false");

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -334,6 +334,18 @@ v3s16 EmergeManager::getContainingChunk(v3s16 blockpos, s16 chunksize)
 }
 
 
+int EmergeManager::getSpawnLevelAtPoint(v2s16 p)
+{
+	if (m_mapgens.size() == 0 || !m_mapgens[0]) {
+		errorstream << "EmergeManager: getSpawnLevelAtPoint() called"
+			" before mapgen init" << std::endl;
+		return 0;
+	}
+
+	return m_mapgens[0]->getSpawnLevelAtPoint(p);
+}
+
+
 int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 {
 	if (m_mapgens.size() == 0 || !m_mapgens[0]) {

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -136,6 +136,7 @@ public:
 
 	// Mapgen helpers methods
 	Biome *getBiomeAtPoint(v3s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 	int getGroundLevelAtPoint(v2s16 p);
 	bool isBlockUnderground(v3s16 blockpos);
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -181,6 +181,13 @@ public:
 	virtual void makeChunk(BlockMakeData *data) {}
 	virtual int getGroundLevelAtPoint(v2s16 p) { return 0; }
 
+	// getSpawnLevelAtPoint() is a function within each mapgen that returns a
+	// suitable y co-ordinate for player spawn ('suitable' usually meaning
+	// within 16 nodes of water_level). If a suitable spawn level cannot be
+	// found at the specified (X, Z) 'MAX_MAP_GENERATION_LIMIT' is returned to
+	// signify this and to cause Server::findSpawnPos() to try another (X, Z).
+	virtual int getSpawnLevelAtPoint(v2s16 p) { return 0; }
+
 private:
 	DISABLE_CLASS_COPY(Mapgen);
 };

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -102,7 +102,7 @@ public:
 	~MapgenFlat();
 
 	virtual void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	s16 generateTerrain();
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -114,7 +114,7 @@ public:
 	~MapgenFractal();
 
 	virtual void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	bool getFractalAtPoint(s16 x, s16 y, s16 z);
 	s16 generateTerrain();

--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -99,7 +99,7 @@ void MapgenSinglenode::makeChunk(BlockMakeData *data)
 }
 
 
-int MapgenSinglenode::getGroundLevelAtPoint(v2s16 p)
+int MapgenSinglenode::getSpawnLevelAtPoint(v2s16 p)
 {
 	return 0;
 }

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -41,7 +41,7 @@ public:
 	~MapgenSinglenode();
 	
 	void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 };
 
 struct MapgenFactorySinglenode : public MapgenFactory {

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -90,7 +90,7 @@ public:
 	~MapgenV5();
 
 	virtual void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 	void calculateNoise();
 	int generateBaseTerrain();
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -318,6 +318,17 @@ int MapgenV6::getGroundLevelAtPoint(v2s16 p)
 }
 
 
+int MapgenV6::getSpawnLevelAtPoint(v2s16 p)
+{
+	s16 level_at_point = baseTerrainLevelFromNoise(p) + MGV6_AVERAGE_MUD_AMOUNT;
+	if (level_at_point <= water_level ||
+			level_at_point > water_level + 16)
+		return MAX_MAP_GENERATION_LIMIT;  // Unsuitable spawn point
+	else
+		return level_at_point;
+}
+
+
 //////////////////////// Noise functions
 
 float MapgenV6::getMudAmount(v2s16 p)

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -129,6 +129,7 @@ public:
 
 	void makeChunk(BlockMakeData *data);
 	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 
 	float baseTerrainLevel(float terrain_base, float terrain_higher,
 		float steepness, float height_select);

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -103,7 +103,7 @@ public:
 	~MapgenV7();
 
 	virtual void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 	Biome *getBiomeAtPoint(v3s16 p);
 
 	float baseTerrainLevelAtPoint(s16 x, s16 z);

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -30,9 +30,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-/////////////////// Mapgen Valleys flags
-#define MG_VALLEYS_ALT_CHILL    0x01
-#define MG_VALLEYS_HUMID_RIVERS 0x02
+////////////// Mapgen Valleys flags
+#define MGVALLEYS_ALT_CHILL    0x01
+#define MGVALLEYS_HUMID_RIVERS 0x02
 
 // Feed only one variable into these.
 #define MYSQUARE(x) (x) * (x)
@@ -96,7 +96,7 @@ public:
 	~MapgenValleys();
 
 	virtual void makeChunk(BlockMakeData *data);
-	int getGroundLevelAtPoint(v2s16 p);
+	int getSpawnLevelAtPoint(v2s16 p);
 
 	s16 large_cave_depth;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3383,26 +3383,24 @@ v3f Server::findSpawnPos()
 		return nodeposf * BS;
 	}
 
-	s16 water_level = map.getWaterLevel();
-	s16 vertical_spawn_range = g_settings->getS16("vertical_spawn_range");
 	bool is_good = false;
 
 	// Try to find a good place a few times
-	for(s32 i = 0; i < 1000 && !is_good; i++) {
+	for(s32 i = 0; i < 4000 && !is_good; i++) {
 		s32 range = 1 + i;
 		// We're going to try to throw the player to this position
 		v2s16 nodepos2d = v2s16(
 				-range + (myrand() % (range * 2)),
 				-range + (myrand() % (range * 2)));
 
-		// Get ground height at point
-		s16 groundheight = map.findGroundLevel(nodepos2d);
-		// Don't go underwater or to high places
-		if (groundheight <= water_level ||
-				groundheight > water_level + vertical_spawn_range)
+		// Get spawn level at point
+		s16 spawn_level = m_emerge->getSpawnLevelAtPoint(nodepos2d);
+		// Continue if MAX_MAP_GENERATION_LIMIT was returned by
+		// the mapgen to signify an unsuitable spawn position
+		if (spawn_level == MAX_MAP_GENERATION_LIMIT)
 			continue;
 
-		v3s16 nodepos(nodepos2d.X, groundheight, nodepos2d.Y);
+		v3s16 nodepos(nodepos2d.X, spawn_level, nodepos2d.Y);
 
 		s32 air_count = 0;
 		for (s32 i = 0; i < 10; i++) {


### PR DESCRIPTION
To avoid spawn search failing in new specialised mapgens
Increase spawn search range to 4000 nodes
Add getSpawnLevelAtPoint() functions to EmergeManager, class Mapgen
and all mapgens
Remove getGroundLevelAtPoint() functions from all mapgens except mgv6
(possibly to be re-added later in the correct form to return actual
ground level)
Make mgvalleys flag names consistent with other mapgens
Remove now unused 'vertical spawn range' setting

///////////////////////////////////////////

The new more specialised mapgens are causing spawn search to sometimes fail, causing burial or being dumped in the ocean, at (0,0,0).
The problem is having a single vertical spawn range for all mapgens (water_level + 1 to water_level + 16). This can fail, for example, in mgflat if the user sets ground level above water_level + 16. The bizarre structures in mgfractal often need a much higher acceptable spawn altitude.

Future large scale mapgens, or mapgens with custom noise parameters, need a larger spawn search range, it is increased to 4000 nodes (more than enough even for something like mgwatershed) because a slightly slower spawn is preferable to spawn failing.

Each mapgen has a dedicated getSpawnLevelAtPoint() function added suitable for the mapgen's character or use. Now the mapgen itself decides what is an acceptable spawn altitude, if the spawn column is unsuitable MAX_MAP_GENERATION_LIMIT is returned to findSpawnPos() to cause a new column to be chosen.

For example in mgflat if ground_level is set to below water_level, the function now recognises this as an intended water world and allows a spawn in water at (0,0,0), if hills were enabled this avoids spawning on a tiny island 1000s of nodes away from world centre.

The function in mgfractal allows spawns up to cloud level and on any overhanging structure created by the fractal, this is essential for a successful spawn on the fractal structure which is often the only dry land in a world-ocean.

Spawn behaviour in mgv5/6/7/valleys/singlenode is unchanged.