### PR TITLE
Fix disappearing-world problem

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -506,6 +506,7 @@ void Camera::updateViewingRange(f32 frametime_in, f32 busytime_in)
 
 	// Get current viewing range and FPS settings
 	f32 viewing_range_min = g_settings->getFloat("viewing_range_nodes_min");
+	viewing_range_min = MYMIN(MAXMINVRANGE, viewing_range_min);
 	viewing_range_min = MYMAX(15.0, viewing_range_min);
 
 	f32 viewing_range_max = g_settings->getFloat("viewing_range_nodes_max");

--- a/src/camera.h
+++ b/src/camera.h
@@ -29,6 +29,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "client.h"
 
+// OldCoder:  If minimum viewing range (MIVR) is  above about 900 node
+// units, a confusing problem  may occur. Specifically,  if the player
+// travels to a point that is too far away from the origin at (0,0,0),
+// the screen may go blank abruptly except for mobs.  The cutoff point
+// is located at about 32,767 node units minus ( MIVR plus 100 ) along
+// any axis.
+
+// As one part of the solution,  MIVR is clipped to a maximum value of
+// MAXMINVRANGE.  There are related changes elsewhere in the code that
+// clip  the current,  as  opposed to  the minimum,  viewing range  as
+// well.
+
+#define MAXMINVRANGE 900
+
 class LocalPlayer;
 struct MapDrawControl;
 class IGameDef;

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -30,7 +30,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "camera.h"               // CameraModes
 #include "util/mathconstants.h"
+
 #include <algorithm>
+#include <cmath>
 
 #define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
 
@@ -171,6 +173,16 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
 	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1,1,1);
+
+// OldCoder: This block is an attempt to prevent  16-bit overflows re-
+// lated  to high viewing ranges while  at the same time not  limiting
+// them more than necessary. This should help to prevent a "disappear-
+// ing world" problem that occurred previously.
+
+	box_nodes_d.X = MYMIN (box_nodes_d.X, 32650 - abs (cam_pos_nodes.X));
+	box_nodes_d.Y = MYMIN (box_nodes_d.Y, 32650 - abs (cam_pos_nodes.Y));
+	box_nodes_d.Z = MYMIN (box_nodes_d.Z, 32650 - abs (cam_pos_nodes.Z));
+
 	v3s16 p_nodes_min = cam_pos_nodes - box_nodes_d;
 	v3s16 p_nodes_max = cam_pos_nodes + box_nodes_d;
 	// Take a fair amount as we will be dropping more out later
@@ -446,6 +458,15 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
 
 	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1,1,1);
+
+// OldCoder: This block is an attempt to prevent  16-bit overflows re-
+// lated  to high viewing ranges while  at the same time not  limiting
+// them more than necessary. This should help to prevent a "disappear-
+// ing world" problem that occurred previously.
+
+	box_nodes_d.X = MYMIN (box_nodes_d.X, 32650 - abs (cam_pos_nodes.X));
+	box_nodes_d.Y = MYMIN (box_nodes_d.Y, 32650 - abs (cam_pos_nodes.Y));
+	box_nodes_d.Z = MYMIN (box_nodes_d.Z, 32650 - abs (cam_pos_nodes.Z));
 
 	v3s16 p_nodes_min = cam_pos_nodes - box_nodes_d;
 	v3s16 p_nodes_max = cam_pos_nodes + box_nodes_d;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3012,6 +3012,7 @@ void Game::increaseViewRange(float *statustext_time)
 {
 	s16 range = g_settings->getS16("viewing_range_nodes_min");
 	s16 range_new = range + 10;
+	if (range_new > MAXMINVRANGE) range_new = MAXMINVRANGE;
 	g_settings->set("viewing_range_nodes_min", itos(range_new));
 	statustext = utf8_to_wide("Minimum viewing range changed to "
 			+ itos(range_new));


### PR DESCRIPTION
If viewing range is too high, a confusing problem may occur. Specifically, if the player travels to a point that is too far away from the origin at (0,0,0), the screen may go blank abruptly except for mobs.

The problem occurs because of overflows that occur in 16-bit signed values. This patch clips viewing range, but tries not to do so more than is necessary.

Thanks go to est31 and paramat for assistance with this fix.
