### PR TITLE
Add '/clearobjects quick'

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -848,14 +848,24 @@ core.register_chatcommand("kick", {
 })
 
 core.register_chatcommand("clearobjects", {
+	params = "[full|quick]",
 	description = "clear all objects in world",
 	privs = {server=true},
 	func = function(name, param)
+		options = {}
+		if param == "" or param == "full" then
+			options.mode = "full"
+		elseif param == "quick" then
+			options.mode = "quick"
+		else
+			return false, "Invalid usage, see /help clearobjects."
+		end
+
 		core.log("action", name .. " clears all objects.")
 		core.chat_send_all("Clearing all objects.  This may take long."
 				.. "  You may experience a timeout.  (by "
 				.. name .. ")")
-		core.clear_objects()
+		core.clear_objects(options)
 		core.log("action", "Object clearing done.")
 		core.chat_send_all("*** Cleared all objects.")
 	end,

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -861,7 +861,8 @@ core.register_chatcommand("clearobjects", {
 			return false, "Invalid usage, see /help clearobjects."
 		end
 
-		core.log("action", name .. " clears all objects.")
+		core.log("action", name .. " clears all objects ("
+				.. options.mode .. " mode).")
 		core.chat_send_all("Clearing all objects.  This may take long."
 				.. "  You may experience a timeout.  (by "
 				.. name .. ")")

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2046,8 +2046,12 @@ and `minetest.auth_reload` call the authetification handler.
 * `minetest.generate_decorations(vm, pos1, pos2)`
     * Generate all registered decorations within the VoxelManip `vm` and in the area from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
-* `minetest.clear_objects()`
-    * clear all objects in the environments
+* `minetest.clear_objects([options])`
+    * Clear all objects in the environment
+    * Takes an optional table as an argument with the field `mode`.
+        * mode = `"full"`: Load and go through every mapblock, clearing objects (default).
+        * mode = `"quick"`: Clear objects immediately in loaded mapblocks;
+          clear objects in unloaded mapblocks only when the mapblocks are next activated.
 * `minetest.emerge_area(pos1, pos2, [callback], [param])`
     * Queue all blocks in the area from `pos1` to `pos2`, inclusive, to be asynchronously
     * fetched from memory, loaded from disk, or if inexistent, generates them.

--- a/src/environment.h
+++ b/src/environment.h
@@ -204,6 +204,18 @@ private:
 };
 
 /*
+	Operation mode for ServerEnvironment::clearObjects()
+*/
+enum ClearObjectsMode {
+	// Load and go through every mapblock, clearing objects
+	CLEAR_OBJECTS_MODE_FULL,
+
+	// Clear objects immediately in loaded mapblocks;
+	// clear objects in unloaded mapblocks only when the mapblocks are next activated.
+	CLEAR_OBJECTS_MODE_QUICK,
+};
+
+/*
 	The server-side environment.
 
 	This is not thread-safe. Server uses an environment mutex.
@@ -319,8 +331,8 @@ public:
 	// Find all active objects inside a radius around a point
 	void getObjectsInsideRadius(std::vector<u16> &objects, v3f pos, float radius);
 
-	// Clear all objects, loading and going through every MapBlock
-	void clearAllObjects();
+	// Clear objects, loading and going through every MapBlock
+	void clearObjects(ClearObjectsMode mode);
 
 	// This makes stuff happen
 	void step(f32 dtime);
@@ -410,6 +422,10 @@ private:
 	u32 m_game_time;
 	// A helper variable for incrementing the latter
 	float m_game_time_fraction_counter;
+	// Time of last clearObjects call (game time).
+	// When a mapblock older than this is loaded, its objects are cleared.
+	u32 m_last_clear_objects_time;
+	// Active block modifiers
 	std::vector<ABMWithState> m_abms;
 	// An interval for generally sending object positions and stuff
 	float m_recommended_send_interval;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -36,6 +36,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "pathfinder.h"
 
+struct EnumString ModApiEnvMod::es_ClearObjectsMode[] =
+{
+	{CLEAR_OBJECTS_MODE_FULL,  "full"},
+	{CLEAR_OBJECTS_MODE_QUICK, "quick"},
+	{0, NULL},
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 
 
@@ -727,13 +734,20 @@ int ModApiEnvMod::l_get_voxel_manip(lua_State *L)
 	return 1;
 }
 
-// clear_objects()
+// clear_objects([options])
 // clear all objects in the environment
+// where options = {mode = "full" or "quick"}
 int ModApiEnvMod::l_clear_objects(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	env->clearAllObjects();
+	ClearObjectsMode mode = CLEAR_OBJECTS_MODE_FULL;
+	if (lua_istable(L, 1)) {
+		mode = (ClearObjectsMode)getenumfield(L, 1, "mode",
+			ModApiEnvMod::es_ClearObjectsMode, mode);
+	}
+
+	env->clearObjects(mode);
 	return 0;
 }
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -170,6 +170,8 @@ private:
 
 public:
 	static void Initialize(lua_State *L, int top);
+
+	static struct EnumString es_ClearObjectsMode[];
 };
 
 class LuaABM : public ActiveBlockModifier {


### PR DESCRIPTION
Add a mode parameter to `/clearobjects` which can be either `full` or `quick`.
* `/clearobjects full` is exactly the old `/clearobjects`, and is the default if no mode is specified.
* `/clearobjects quick` works similarly, but only immediately clears objects in loaded mapblocks. Objects in unloaded mapblocks will be cleared when the corresponding mapblock is next activated.

To implement the `/clearobjects quick` behaviour, ServerEnvironment has a new field `m_last_clear_objects_time` which is set to `m_game_time` whenever `/clearobjects` is run, and compared to the block timestamp whenever a block is activated. If the block timestamp is older than `m_last_clear_objects_time`, the stored objects are deleted instead of activated.

So `/clearobjects quick` runs much faster, but objects may remain in the database until the mapblocks are loaded from the database and saved back. The new command gives the user a choice over this space-time tradeoff.