### PR TITLE
shader.cpp: don't test twice if shader programs are present

### DIFF
--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -767,22 +767,22 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 	if (g_settings->getBool("tone_mapping"))
 		shaders_header += "#define ENABLE_TONE_MAPPING\n";
 
-	if(pixel_program != "")
-		pixel_program = shaders_header + pixel_program;
-	if(vertex_program != "")
-		vertex_program = shaders_header + vertex_program;
-	if(geometry_program != "")
-		geometry_program = shaders_header + geometry_program;
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
 	const c8* vertex_program_ptr = 0;
 	const c8* pixel_program_ptr = 0;
 	const c8* geometry_program_ptr = 0;
-	if(vertex_program != "")
+	if (!vertex_program.empty()) {
+		pixel_program = shaders_header + pixel_program;
 		vertex_program_ptr = vertex_program.c_str();
-	if(pixel_program != "")
+	}
+	if (!pixel_program.empty()) {
+		vertex_program = shaders_header + vertex_program;
 		pixel_program_ptr = pixel_program.c_str();
-	if(geometry_program != "")
+	}
+	if (!geometry_program.empty()) {
+		geometry_program = shaders_header + geometry_program;
 		geometry_program_ptr = geometry_program.c_str();
+	}
 	s32 shadermat = -1;
 	if(is_highlevel){
 		infostream<<"Compiling high level shaders for "<<name<<std::endl;


### PR DESCRIPTION
string::empty method is better than compare with empty string for empty strings.