### PR TITLE
Small clean up and documentation additions.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -88,25 +88,26 @@ function core.dir_to_facedir(dir, is6d)
 	end
 end
 
+-- Table of possible dirs
+local facedir_to_dir = {
+	{x= 0, y=0,  z= 1},
+	{x= 1, y=0,  z= 0},
+	{x= 0, y=0,  z=-1},
+	{x=-1, y=0,  z= 0},
+	{x= 0, y=-1, z= 0},
+	{x= 0, y=1,  z= 0},
+}
+-- Mapping from facedir value to index in facedir_to_dir.
+local facedir_to_dir_map = {
+	[0]=1, 2, 3, 4,
+	5, 2, 6, 4,
+	6, 2, 5, 4,
+	1, 5, 3, 6,
+	1, 6, 3, 5,
+	1, 4, 3, 2,
+}
 function core.facedir_to_dir(facedir)
-	--a table of possible dirs
-	return ({{x=0, y=0, z=1},
-					{x=1, y=0, z=0},
-					{x=0, y=0, z=-1},
-					{x=-1, y=0, z=0},
-					{x=0, y=-1, z=0},
-					{x=0, y=1, z=0}})
-
-					--indexed into by a table of correlating facedirs
-					[({[0]=1, 2, 3, 4,
-						5, 2, 6, 4,
-						6, 2, 5, 4,
-						1, 5, 3, 6,
-						1, 6, 3, 5,
-						1, 4, 3, 2})
-
-						--indexed into by the facedir in question
-						[facedir]]
+	return facedir_to_dir[facedir_to_dir_map[facedir]]
 end
 
 function core.dir_to_wallmounted(dir)
@@ -131,17 +132,17 @@ function core.dir_to_wallmounted(dir)
 	end
 end
 
+-- table of dirs in wallmounted order
+local wallmounted_to_dir = {
+	[0] = {x = 0, y = 1, z = 0},
+	{x =  0, y = -1, z =  0},
+	{x =  1, y =  0, z =  0},
+	{x = -1, y =  0, z =  0},
+	{x =  0, y =  0, z =  1},
+	{x =  0, y =  0, z = -1},
+}
 function core.wallmounted_to_dir(wallmounted)
-	-- table of dirs in wallmounted order
-	return ({[0] = {x = 0, y = 1, z = 0},
-		{x = 0,  y = -1, z = 0},
-		{x = 1,  y = 0,  z = 0},
-		{x = -1, y = 0,  z = 0},
-		{x = 0,  y = 0,  z = 1},
-		{x = 0,  y = 0,  z = -1}})
-
-		--indexed into by the wallmounted in question
-		[wallmounted]
+	return wallmounted_to_dir[wallmounted]
 end
 
 function core.get_node_drops(nodename, toolname)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2149,6 +2149,8 @@ and `minetest.auth_reload` call the authetification handler.
     * Convert a facedir back into a vector aimed directly out the "back" of a node
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for `paramtype2="wallmounted"`
+* `minetest.wallmounted_to_dir(wallmounted)`
+    * Convert a wallmounted value back into a vector aimed directly out the "back" of a node
 * `minetest.get_node_drops(nodename, toolname)`
     * Returns list of item names.
     * **Note**: This will be removed or modified in a future version.


### PR DESCRIPTION
Move the table initializations in `facedir_to_dir` and `wallmounted_to_dir` to avoid the overhead of creating the tables every time and make the function clearer.

Also document `wallmounted_to_dir`.
