### PR TITLE
Use single box for halo mesh

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -84,6 +84,8 @@ Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
 
 	m_selection_mesh = NULL;
 	m_selection_boxes.clear();
+	m_halo_boxes.clear();
+	
 	m_selection_pos = v3f(0.0, 0.0, 0.0);
 	std::string mode = g_settings->get("node_highlighting");
 	m_selection_material.Lighting = false;
@@ -574,10 +576,23 @@ void Hud::updateSelectionMesh(const v3s16 &camera_offset)
 		0,0,1,1
 	};
 
-	m_selection_mesh = convertNodeboxesToMesh(m_selection_boxes, texture_uv);
+	// Use single halo box instead of multiple overlapping boxes.
+	// Temporary solution - problem can be solved with multiple
+	// rendering targets, or some method to remove inner surfaces.
+	// Thats because of halo transparency.
 
-	// scale final halo mesh
-	scaleMesh(m_selection_mesh, v3f(1.08, 1.08, 1.08));
+	aabb3f halo_box(100.0, 100.0, 100.0, -100.0, -100.0, -100.0);
+	m_halo_boxes.clear();
+
+	for (std::vector<aabb3f>::iterator
+			i = m_selection_boxes.begin();
+			i != m_selection_boxes.end(); ++i) {
+		halo_box.addInternalBox(*i);
+	}
+
+	m_halo_boxes.push_back(halo_box);
+	m_selection_mesh = convertNodeboxesToMesh(
+		m_halo_boxes, texture_uv, 0.5);
 }
 
 void Hud::resizeHotbar() {

--- a/src/hud.h
+++ b/src/hud.h
@@ -162,6 +162,7 @@ private:
 	video::SColor hbar_colors[4];
 
 	std::vector<aabb3f> m_selection_boxes;
+	std::vector<aabb3f> m_halo_boxes;
 	v3f m_selection_pos;
 	v3f m_selection_pos_with_offset;
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -406,7 +406,7 @@ scene::IMesh* cloneMesh(scene::IMesh *src_mesh)
 }
 
 scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
-		const f32 *uv_coords)
+		const f32 *uv_coords, float expand)
 {
 	scene::SMesh* dst_mesh = new scene::SMesh();
 
@@ -421,31 +421,19 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 
 	video::SColor c(255,255,255,255);	
 
-	for(std::vector<aabb3f>::const_iterator
+	for (std::vector<aabb3f>::const_iterator
 			i = boxes.begin();
 			i != boxes.end(); ++i)
 	{
 		aabb3f box = *i;
-
-		f32 temp;
-		if (box.MinEdge.X > box.MaxEdge.X)
-			{
-				temp=box.MinEdge.X;
-				box.MinEdge.X=box.MaxEdge.X;
-				box.MaxEdge.X=temp;
-			}
-		if (box.MinEdge.Y > box.MaxEdge.Y)
-			{
-				temp=box.MinEdge.Y;
-				box.MinEdge.Y=box.MaxEdge.Y;
-				box.MaxEdge.Y=temp;
-			}
-		if (box.MinEdge.Z > box.MaxEdge.Z)
-			{
-				temp=box.MinEdge.Z;
-				box.MinEdge.Z=box.MaxEdge.Z;
-				box.MaxEdge.Z=temp;
-			}
+		box.repair();
+		
+		box.MinEdge.X -= expand;
+		box.MinEdge.Y -= expand;
+		box.MinEdge.Z -= expand;
+		box.MaxEdge.X += expand;
+		box.MaxEdge.Y += expand;
+		box.MaxEdge.Z += expand;
 
 		// Compute texture UV coords
 		f32 tx1 = (box.MinEdge.X / BS) + 0.5;

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -86,9 +86,10 @@ scene::IMesh* cloneMesh(scene::IMesh *src_mesh);
 	Convert nodeboxes to mesh.
 	boxes - set of nodeboxes to be converted into cuboids
 	uv_coords[24] - table of texture uv coords for each cuboid face
+	expand - factor by which cuboids will be resized
 */
 scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
-		const f32 *uv_coords = NULL);
+		const f32 *uv_coords = NULL, float expand = 0);
 
 /*
 	Update bounding box for a mesh.


### PR DESCRIPTION
Thats because of inner faces of the mesh and overlapping boxes, so surfaces accumulating transparent layers colors get darker. Instead single bounding box is calculated ouf of selection boxes.