### PR TITLE
Set proper GLSL pixel shader version

### DIFF
--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -792,7 +792,7 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 			video::EVST_VS_1_1,   // Vertex shader version
 			pixel_program_ptr,    // Pixel shader program
 			"pixelMain",          // Pixel shader entry point
-			video::EPST_PS_1_1,   // Pixel shader version
+			video::EPST_PS_1_2,   // Pixel shader version
 			geometry_program_ptr, // Geometry shader program
 			"geometryMain",       // Geometry shader entry point
 			video::EGST_GS_4_0,   // Geometry shader version


### PR DESCRIPTION
Version was set to 1.1 for compiler, while we are using in headers 1.2. That could lead to unexpected behaviour with vendor specific drivers.