### PR TITLE
Use vertices with tangents only when its needed.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -263,6 +263,9 @@ Client::Client(
 
 	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
 	m_cache_enable_shaders  = g_settings->getBool("enable_shaders");
+	m_cache_use_tangent_vertices = m_cache_enable_shaders && (
+		g_settings->getBool("enable_bumpmapping") || 
+		g_settings->getBool("enable_parallax_occlusion"));
 }
 
 void Client::Stop()
@@ -1582,7 +1585,8 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 		Create a task to update the mesh of the block
 	*/
 
-	MeshMakeData *data = new MeshMakeData(this, m_cache_enable_shaders);
+	MeshMakeData *data = new MeshMakeData(this, m_cache_enable_shaders,
+		m_cache_use_tangent_vertices);
 
 	{
 		//TimeTaker timer("data fill");

--- a/src/client.h
+++ b/src/client.h
@@ -677,6 +677,7 @@ private:
 	// TODO: Add callback to update these when g_settings changes
 	bool m_cache_smooth_lighting;
 	bool m_cache_enable_shaders;
+	bool m_cache_use_tangent_vertices;
 
 	DISABLE_CLASS_COPY(Client);
 };

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -46,8 +46,10 @@ struct MeshMakeData
 
 	IGameDef *m_gamedef;
 	bool m_use_shaders;
+	bool m_use_tangent_vertices;
 
-	MeshMakeData(IGameDef *gamedef, bool use_shaders);
+	MeshMakeData(IGameDef *gamedef, bool use_shaders,
+			bool use_tangent_vertices = false);
 
 	/*
 		Copy central data directly from block, and other data from
@@ -130,6 +132,7 @@ private:
 	IShaderSource *m_shdrsrc;
 
 	bool m_enable_shaders;
+	bool m_use_tangent_vertices;
 
 	// Must animate() be called before rendering?
 	bool m_has_animation;
@@ -167,11 +170,19 @@ struct PreMeshBuffer
 	TileSpec tile;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
+	std::vector<video::S3DVertexTangents> tangent_vertices;
 };
 
 struct MeshCollector
 {
 	std::vector<PreMeshBuffer> prebuffers;
+	bool m_use_tangent_vertices;
+
+	MeshCollector(bool use_tangent_vertices):
+		m_use_tangent_vertices(use_tangent_vertices)
+	{
+	}
+
 	void append(const TileSpec &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);


### PR DESCRIPTION
Atm its needed only when bumpmapping and parallax mapping is enabled.
Theres also changed way the tangent mesh is prepared. Trick used before to create mesh without tangents and convert it to tangent space using irrlicht method apparently is too slow, and was causing mesh update lags on slower machines.

This will allow use basic shader effect like tonemapping, waving etc without tangent space.