### PR TITLE
Move object nametags to camera

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -26,6 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/tile.h"
 #include "util/numeric.h"
 #include <ICameraSceneNode.h>
+#include <ISceneNode.h>
+#include <list>
 
 #include "client.h"
 
@@ -33,6 +35,20 @@ class LocalPlayer;
 struct MapDrawControl;
 class IGameDef;
 class WieldMeshSceneNode;
+
+struct Nametag {
+	Nametag(scene::ISceneNode *a_parent_node,
+			const std::string &a_nametag_text,
+			const video::SColor &a_nametag_color):
+		parent_node(a_parent_node),
+		nametag_text(a_nametag_text),
+		nametag_color(a_nametag_color)
+	{
+	}
+	scene::ISceneNode *parent_node;
+	std::string nametag_text;
+	video::SColor nametag_color;
+};
 
 enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};
 
@@ -84,7 +100,7 @@ public:
 	{
 		return m_camera_direction;
 	}
-	
+
 	// Get the camera offset
 	inline v3s16 getOffset() const
 	{
@@ -151,6 +167,13 @@ public:
 		return m_camera_mode;
 	}
 
+	Nametag *addNametag(scene::ISceneNode *parent_node,
+		std::string nametag_text, video::SColor nametag_color);
+
+	void removeNametag(Nametag *nametag);
+
+	void drawNametags();
+
 private:
 	// Nodes
 	scene::ISceneNode* m_playernode;
@@ -162,8 +185,9 @@ private:
 
 	// draw control
 	MapDrawControl& m_draw_control;
-	
+
 	IGameDef *m_gamedef;
+	video::IVideoDriver *m_driver;
 
 	// Absolute camera position
 	v3f m_camera_position;
@@ -214,6 +238,8 @@ private:
 	f32 m_cache_wanted_fps;
 	f32 m_cache_fov;
 	bool m_cache_view_bobbing;
+
+	std::list<Nametag *> m_nametags;
 };
 
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -228,6 +228,7 @@ Client::Client(
 	m_particle_manager(&m_env),
 	m_con(PROTOCOL_ID, 512, CONNECTION_TIMEOUT, ipv6, this),
 	m_device(device),
+	m_camera(NULL),
 	m_minimap_disabled_by_server(false),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
 	m_proto_ver(0),

--- a/src/client.h
+++ b/src/client.h
@@ -50,6 +50,7 @@ struct PointedThing;
 class Database;
 class Mapper;
 struct MinimapMapblock;
+class Camera;
 
 struct QueuedMeshUpdate
 {
@@ -507,6 +508,12 @@ public:
 	Mapper* getMapper ()
 	{ return m_mapper; }
 
+	void setCamera(Camera* camera)
+	{ m_camera = camera; }
+
+	Camera* getCamera ()
+	{ return m_camera; }
+
 	bool isMinimapDisabledByServer()
 	{ return m_minimap_disabled_by_server; }
 
@@ -589,6 +596,7 @@ private:
 	ParticleManager m_particle_manager;
 	con::Connection m_con;
 	IrrlichtDevice *m_device;
+	Camera *m_camera;
 	Mapper *m_mapper;
 	bool m_minimap_disabled_by_server;
 	// Server serialization version

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -26,6 +26,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "object_properties.h"
 #include "itemgroup.h"
 
+class Camera;
+struct Nametag;
+
 /*
 	SmoothTranslator
 */
@@ -65,12 +68,14 @@ private:
 	//
 	scene::ISceneManager *m_smgr;
 	IrrlichtDevice *m_irr;
+	Camera* m_camera;
+	IGameDef *m_gamedef;
 	aabb3f m_selection_box;
 	scene::IMeshSceneNode *m_meshnode;
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode;
 	WieldMeshSceneNode *m_wield_meshnode;
 	scene::IBillboardSceneNode *m_spritenode;
-	scene::ITextSceneNode* m_textnode;
+	Nametag* m_nametag;
 	v3f m_position;
 	v3f m_velocity;
 	v3f m_acceleration;

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -195,7 +195,7 @@ video::ITexture*  draw_hud(video::IVideoDriver* driver, const v2u32& screensize,
 			hud.drawCrosshair();
 		hud.drawHotbar(client.getPlayerItem());
 		hud.drawLuaElements(camera.getOffset());
-
+		camera.drawNametags();
 		guienv->drawAll();
 	}
 
@@ -416,6 +416,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 			camera.drawWieldedTool(&leftMove);
 		hud.drawHotbar(client.getPlayerItem());
 		hud.drawLuaElements(camera.getOffset());
+		camera.drawNametags();
 	}
 
 	guienv->drawAll();
@@ -443,6 +444,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 			camera.drawWieldedTool(&rightMove);
 		hud.drawHotbar(client.getPlayerItem());
 		hud.drawLuaElements(camera.getOffset());
+		camera.drawNametags();
 	}
 
 	guienv->drawAll();
@@ -538,8 +540,11 @@ void draw_scene(video::IVideoDriver *driver, scene::ISceneManager *smgr,
 	{
 		if (draw_crosshair)
 			hud.drawCrosshair();
+
 		hud.drawHotbar(client.getPlayerItem());
 		hud.drawLuaElements(camera.getOffset());
+		camera.drawNametags();
+
 		if (show_minimap)
 			mapper.drawMinimap();
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2087,6 +2087,7 @@ bool Game::createClient(const std::string &playername,
 	camera = new Camera(smgr, *draw_control, gamedef);
 	if (!camera || !camera->successfullyCreated(*error_message))
 		return false;
+	client->setCamera(camera);
 
 	/* Clouds
 	 */

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -32,6 +32,8 @@ class IShaderSource;
 class MtEventManager;
 class IRollbackManager;
 class EmergeManager;
+class Camera;
+
 namespace irr { namespace scene {
 	class IAnimatedMesh;
 	class ISceneManager;
@@ -66,6 +68,10 @@ public:
 	virtual scene::IAnimatedMesh* getMesh(const std::string &filename)
 	{ return NULL; }
 	virtual scene::ISceneManager* getSceneManager()=0;
+
+	virtual Camera* getCamera()
+	{ return NULL; }
+	virtual void setCamera(Camera *camera) {}
 
 	// Only usable on the server, and NOT thread-safe. It is usable from the
 	// environment thread.


### PR DESCRIPTION
This code moves displaying of nametags out of world geometry. The reasons to do that:
- texts as world objects cannot write their own depth, they will break all the effects basing on scene depth
- texts would be shaded, outlined, bumpmapped as everything else without a posibility to provide correct data to do so
- also, since text scene node is broken for irrlicht 1.8, using it was causing MANY strange bugs: things go randomly opaque etc

My idea is to move them to HUD, its an information for player shown as extra. Turining HUD off would disable them, quite useful when trying to get a screenshot on multiplayer servers...
@est31 is opposing to make them part of HUD, so please share your opinions on that

EDIT: moved them to camera