### PR TITLE
Use real camera clipping and single view_range setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -393,10 +393,6 @@ enable_waving_plants (Waving plants) bool false
 
 [***Advanced]
 
-#    Minimum wanted FPS.
-#    The amount of rendered stuff is dynamically set according to this. and viewing range min and max.
-wanted_fps (Wanted FPS) int 30
-
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
 fps_max (Maximum FPS) int 60
@@ -404,13 +400,8 @@ fps_max (Maximum FPS) int 60
 #    Maximum FPS when game is paused.
 pause_fps_max (FPS in pause menu) int 20
 
-#    The allowed adjustment range for the automatic rendering range adjustment.
-#    Set this to be equal to viewing range minimum to disable the auto-adjustment algorithm.
-viewing_range_nodes_max (Viewing range maximum) int 160
-
-#    The allowed adjustment range for the automatic rendering range adjustment.
-#    Set this to be equal to viewing range maximum to disable the auto-adjustment algorithm.
-viewing_range_nodes_min (Viewing range minimum) int 35
+#    View distance in nodes
+viewing_range (Viewing range) int 100
 
 #    Width component of the initial window size.
 screenW (Screen width) int 800

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -437,11 +437,6 @@
 
 #### Advanced
 
-#    Minimum wanted FPS.
-#    The amount of rendered stuff is dynamically set according to this. and viewing range min and max.
-#    type: int
-# wanted_fps = 30
-
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
 #    type: int
@@ -451,15 +446,9 @@
 #    type: int
 # pause_fps_max = 20
 
-#    The allowed adjustment range for the automatic rendering range adjustment.
-#    Set this to be equal to viewing range minimum to disable the auto-adjustment algorithm.
+#    View range in nodes.
 #    type: int
-# viewing_range_nodes_max = 160
-
-#    The allowed adjustment range for the automatic rendering range adjustment.
-#    Set this to be equal to viewing range maximum to disable the auto-adjustment algorithm.
-#    type: int
-# viewing_range_nodes_min = 35
+# viewing_range = 100
 
 #    Width component of the initial window size.
 #    type: int

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -107,7 +107,6 @@ Camera::Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
 	 */
 	m_cache_fall_bobbing_amount = g_settings->getFloat("fall_bobbing_amount");
 	m_cache_view_bobbing_amount = g_settings->getFloat("view_bobbing_amount");
-	m_cache_wanted_fps          = g_settings->getFloat("wanted_fps");
 	m_cache_fov                 = g_settings->getFloat("fov");
 	m_cache_view_bobbing        = g_settings->getBool("view_bobbing");
 }
@@ -452,8 +451,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 
 	m_wieldnode->setColor(player->light_color);
 
-	// Render distance feedback loop
-	updateViewingRange(frametime, busytime);
+	// Set render distance
+	updateViewingRange();
 
 	// If the player is walking, swimming, or climbing,
 	// view bobbing is enabled and free_move is off,
@@ -481,143 +480,16 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	}
 }
 
-void Camera::updateViewingRange(f32 frametime_in, f32 busytime_in)
+void Camera::updateViewingRange()
 {
-	if (m_draw_control.range_all)
-		return;
-
-	m_added_busytime += busytime_in;
-	m_added_frames += 1;
-
-	m_frametime_counter -= frametime_in;
-	if (m_frametime_counter > 0)
-		return;
-	m_frametime_counter = 0.2; // Same as ClientMap::updateDrawList interval
-
-	/*dstream<<FUNCTION_NAME
-			<<": Collected "<<m_added_frames<<" frames, total of "
-			<<m_added_busytime<<"s."<<std::endl;
-
-	dstream<<"m_draw_control.blocks_drawn="
-			<<m_draw_control.blocks_drawn
-			<<", m_draw_control.blocks_would_have_drawn="
-			<<m_draw_control.blocks_would_have_drawn
-			<<std::endl;*/
-
-	// Get current viewing range and FPS settings
-	f32 viewing_range_min = g_settings->getFloat("viewing_range_nodes_min");
-	viewing_range_min = MYMAX(15.0, viewing_range_min);
-
-	f32 viewing_range_max = g_settings->getFloat("viewing_range_nodes_max");
-	viewing_range_max = MYMAX(viewing_range_min, viewing_range_max);
-
-	// Immediately apply hard limits
-	if(m_draw_control.wanted_range < viewing_range_min)
-		m_draw_control.wanted_range = viewing_range_min;
-	if(m_draw_control.wanted_range > viewing_range_max)
-		m_draw_control.wanted_range = viewing_range_max;
-
-	// Just so big a value that everything rendered is visible
-	// Some more allowance than viewing_range_max * BS because of clouds,
-	// active objects, etc.
-	if(viewing_range_max < 200*BS)
-		m_cameranode->setFarValue(200 * BS * 10);
-	else
-		m_cameranode->setFarValue(viewing_range_max * BS * 10);
-
-	f32 wanted_fps = m_cache_wanted_fps;
-	wanted_fps = MYMAX(wanted_fps, 1.0);
-	f32 wanted_frametime = 1.0 / wanted_fps;
-
-	m_draw_control.wanted_min_range = viewing_range_min;
-	m_draw_control.wanted_max_blocks = (2.0*m_draw_control.blocks_would_have_drawn)+1;
-	if (m_draw_control.wanted_max_blocks < 10)
-		m_draw_control.wanted_max_blocks = 10;
-
-	f32 block_draw_ratio = 1.0;
-	if (m_draw_control.blocks_would_have_drawn != 0)
-	{
-		block_draw_ratio = (f32)m_draw_control.blocks_drawn
-			/ (f32)m_draw_control.blocks_would_have_drawn;
-	}
-
-	// Calculate the average frametime in the case that all wanted
-	// blocks had been drawn
-	f32 frametime = m_added_busytime / m_added_frames / block_draw_ratio;
-
-	m_added_busytime = 0.0;
-	m_added_frames = 0;
-
-	f32 wanted_frametime_change = wanted_frametime - frametime;
-	//dstream<<"wanted_frametime_change="<<wanted_frametime_change<<std::endl;
-	g_profiler->avg("wanted_frametime_change", wanted_frametime_change);
-
-	// If needed frametime change is small, just return
-	// This value was 0.4 for many months until 2011-10-18 by c55;
-	if (fabs(wanted_frametime_change) < wanted_frametime*0.33)
-	{
-		//dstream<<"ignoring small wanted_frametime_change"<<std::endl;
+	if (m_draw_control.range_all) {
+		m_cameranode->setFarValue(100000.0);
 		return;
 	}
 
-	f32 range = m_draw_control.wanted_range;
-	f32 new_range = range;
-
-	f32 d_range = range - m_range_old;
-	f32 d_busytime = busytime_in - m_busytime_old;
-	if (d_range != 0)
-	{
-		m_time_per_range = d_busytime / d_range;
-	}
-	//dstream<<"time_per_range="<<m_time_per_range<<std::endl;
-	g_profiler->avg("time_per_range", m_time_per_range);
-
-	// The minimum allowed calculated frametime-range derivative:
-	// Practically this sets the maximum speed of changing the range.
-	// The lower this value, the higher the maximum changing speed.
-	// A low value here results in wobbly range (0.001)
-	// A low value can cause oscillation in very nonlinear time/range curves.
-	// A high value here results in slow changing range (0.0025)
-	// SUGG: This could be dynamically adjusted so that when
-	//       the camera is turning, this is lower
-	//f32 min_time_per_range = 0.0010; // Up to 0.4.7
-	f32 min_time_per_range = 0.0005;
-	if(m_time_per_range < min_time_per_range)
-	{
-		m_time_per_range = min_time_per_range;
-		//dstream<<"m_time_per_range="<<m_time_per_range<<" (min)"<<std::endl;
-	}
-	else
-	{
-		//dstream<<"m_time_per_range="<<m_time_per_range<<std::endl;
-	}
-
-	f32 wanted_range_change = wanted_frametime_change / m_time_per_range;
-	// Dampen the change a bit to kill oscillations
-	//wanted_range_change *= 0.9;
-	//wanted_range_change *= 0.75;
-	wanted_range_change *= 0.5;
-	//dstream<<"wanted_range_change="<<wanted_range_change<<std::endl;
-
-	// If needed range change is very small, just return
-	if(fabs(wanted_range_change) < 0.001)
-	{
-		//dstream<<"ignoring small wanted_range_change"<<std::endl;
-		return;
-	}
-
-	new_range += wanted_range_change;
-
-	//f32 new_range_unclamped = new_range;
-	new_range = MYMAX(new_range, viewing_range_min);
-	new_range = MYMIN(new_range, viewing_range_max);
-	/*dstream<<"new_range="<<new_range_unclamped
-			<<", clamped to "<<new_range<<std::endl;*/
-
-	m_range_old = m_draw_control.wanted_range;
-	m_busytime_old = busytime_in;
-
-	m_draw_control.wanted_range = new_range;
+	f32 viewing_range = g_settings->getFloat("viewing_range");
+	m_draw_control.wanted_range = viewing_range;
+	m_cameranode->setFarValue(viewing_range * BS);
 }
 
 void Camera::setDigging(s32 button)

--- a/src/camera.h
+++ b/src/camera.h
@@ -120,8 +120,8 @@ public:
 	void update(LocalPlayer* player, f32 frametime, f32 busytime,
 			f32 tool_reload_ratio, ClientEnvironment &c_env);
 
-	// Render distance feedback loop
-	void updateViewingRange(f32 frametime_in, f32 busytime_in);
+	// Update render distance
+	void updateViewingRange();
 
 	// Start digging animation
 	// Pass 0 for left click, 1 for right click
@@ -211,7 +211,6 @@ private:
 
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;
-	f32 m_cache_wanted_fps;
 	f32 m_cache_fov;
 	bool m_cache_view_bobbing;
 };

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -324,7 +324,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			blocks_would_have_drawn++;
 			if(blocks_drawn >= m_control.wanted_max_blocks
 					&& m_control.range_all == false
-					&& d > m_control.wanted_min_range * BS)
+					&& d > m_control.wanted_range * BS)
 				continue;
 
 			// Add to set

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -30,9 +30,8 @@ struct MapDrawControl
 {
 	MapDrawControl():
 		range_all(false),
-		wanted_range(50),
+		wanted_range(0),
 		wanted_max_blocks(0),
-		wanted_min_range(0),
 		blocks_drawn(0),
 		blocks_would_have_drawn(0),
 		farthest_drawn(0)
@@ -44,8 +43,6 @@ struct MapDrawControl
 	float wanted_range;
 	// Maximum number of blocks to draw
 	u32 wanted_max_blocks;
-	// Blocks in this range are drawn regardless of number of blocks drawn
-	float wanted_min_range;
 	// Number of blocks rendered is written here by the renderer
 	u32 blocks_drawn;
 	// Number of blocks that would have been drawn in wanted_range

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -62,8 +62,8 @@ Clouds::Clouds(
 	g_settings->registerChangedCallback("enable_3d_clouds",
 		&cloud_3d_setting_changed, this);
 
-	m_box = aabb3f(-BS*1000000,m_cloud_y-BS,-BS*1000000,
-			BS*1000000,m_cloud_y+BS,BS*1000000);
+	m_box = aabb3f(- BS * 1000000, - BS * 1000000, - BS * 1000000,
+			BS * 1000000, BS * 1000000, BS * 1000000);
 
 }
 
@@ -100,9 +100,16 @@ void Clouds::render()
 	
 	m_material.setFlag(video::EMF_BACK_FACE_CULLING, m_enable_3d);
 
+	core::matrix4 projection = driver->getTransform(video::ETS_PROJECTION);
+	core::matrix4 old_projection = projection;
+	//set clipping
+	projection[10] = 1.00001;
+	projection[14] = -1.00001;
+
+	driver->setTransform(video::ETS_PROJECTION, projection);
 	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
 	driver->setMaterial(m_material);
-	
+
 	/*
 		Clouds move from Z+ towards Z-
 	*/
@@ -338,6 +345,7 @@ void Clouds::render()
 
 	delete[] grid;
 	
+	driver->setTransform(video::ETS_PROJECTION, old_projection);
 	// Restore fog settings
 	driver->setFog(fog_color, fog_type, fog_start, fog_end, fog_density,
 			fog_pixelfog, fog_rangefog);

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -76,11 +76,9 @@ public:
 
 	void update(v2f camera_p, video::SColorf color);
 	
-	void updateCameraOffset(v3s16 camera_offset)
+	void updateCameraOffset(const v3s16 &camera_offset)
 	{
 		m_camera_offset = camera_offset;
-		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS - BS * camera_offset.Y, -BS * 1000000,
-			BS * 1000000, m_cloud_y + BS - BS * camera_offset.Y, BS * 1000000);
 	}
 
 	void readSettings();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -89,12 +89,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("show_debug", "true");
 	#endif
 
-	settings->setDefault("wanted_fps", "30");
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
-	// A bit more than the server will send around the player, to make fog blend well
-	settings->setDefault("viewing_range_nodes_max", "240");
-	settings->setDefault("viewing_range_nodes_min", "35");
+	settings->setDefault("viewing_range", "100");
 	settings->setDefault("map_generation_limit", "31000");
 	settings->setDefault("screenW", "800");
 	settings->setDefault("screenH", "600");
@@ -347,8 +344,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_generate", "8");
 	settings->setDefault("preload_item_visuals", "false");
 
-	settings->setDefault("viewing_range_nodes_max", "50");
-	settings->setDefault("viewing_range_nodes_min", "20");
+	settings->setDefault("viewing_range", "50");
 	settings->setDefault("inventory_image_hack", "false");
 
 	//check for device with small screen

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3038,10 +3038,10 @@ void Game::toggleProfiler(float *statustext_time, u32 *profiler_current_page,
 
 void Game::increaseViewRange(float *statustext_time)
 {
-	s16 range = g_settings->getS16("viewing_range_nodes_min");
+	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range + 10;
-	g_settings->set("viewing_range_nodes_min", itos(range_new));
-	statustext = utf8_to_wide("Minimum viewing range changed to "
+	g_settings->set("viewing_range", itos(range_new));
+	statustext = utf8_to_wide("Viewing range changed to "
 			+ itos(range_new));
 	*statustext_time = 0;
 }
@@ -3049,14 +3049,14 @@ void Game::increaseViewRange(float *statustext_time)
 
 void Game::decreaseViewRange(float *statustext_time)
 {
-	s16 range = g_settings->getS16("viewing_range_nodes_min");
+	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range - 10;
 
-	if (range_new < 0)
-		range_new = range;
+	if (range_new < 40)
+		range_new = 40;
 
-	g_settings->set("viewing_range_nodes_min", itos(range_new));
-	statustext = utf8_to_wide("Minimum viewing range changed to "
+	g_settings->set("viewing_range", itos(range_new));
+	statustext = utf8_to_wide("Viewing range changed to "
 			+ itos(range_new));
 	*statustext_time = 0;
 }
@@ -3934,12 +3934,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats,
 	if (draw_control->range_all) {
 		runData->fog_range = 100000 * BS;
 	} else {
-		runData->fog_range = draw_control->wanted_range * BS
-				+ 0.0 * MAP_BLOCKSIZE * BS;
-		runData->fog_range = MYMIN(
-				runData->fog_range,
-				(draw_control->farthest_drawn + 20) * BS);
-		runData->fog_range *= 0.9;
+		runData->fog_range = 0.85 * draw_control->wanted_range * BS;
 	}
 
 	/*


### PR DESCRIPTION
Code should be a slight speedup, so please test it

Theres single setting viewing_range instead of 2. I have also tweaked a fog for edges of visible area  to blend nicer.

Do note that settings means now EXACT view range (fog starts at 70% of view range), nothing past it can be shown, be it terrain or entity. 
View range is not auto tuned anymore.