### PR TITLE
Clientmap: Define p_nodes_min/max as v3s32 instead of v3s16

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -141,6 +141,33 @@ static bool isOccluded(Map *map, v3s16 p0, v3s16 p1, float step, float stepfac,
 	return false;
 }
 
+void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes, 
+		v3s16 *p_blocks_min, v3s16 *p_blocks_max)
+{
+	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1, 1, 1);
+	// Define p_nodes_min/max as v3s32 because 'cam_pos_nodes -/+ box_nodes_d'
+	// can exceed the range of v3s16 when a large view range is used near the
+	// world edges.
+	v3s32 p_nodes_min(
+		cam_pos_nodes.X - box_nodes_d.X,
+		cam_pos_nodes.Y - box_nodes_d.Y,
+		cam_pos_nodes.Z - box_nodes_d.Z);
+	v3s32 p_nodes_max(
+		cam_pos_nodes.X + box_nodes_d.X,
+		cam_pos_nodes.Y + box_nodes_d.Y,
+		cam_pos_nodes.Z + box_nodes_d.Z);
+	// Take a fair amount as we will be dropping more out later
+	// Umm... these additions are a bit strange but they are needed.
+	*p_blocks_min = v3s16(
+			p_nodes_min.X / MAP_BLOCKSIZE - 3,
+			p_nodes_min.Y / MAP_BLOCKSIZE - 3,
+			p_nodes_min.Z / MAP_BLOCKSIZE - 3);
+	*p_blocks_max = v3s16(
+			p_nodes_max.X / MAP_BLOCKSIZE + 1,
+			p_nodes_max.Y / MAP_BLOCKSIZE + 1,
+			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
+}
+
 void ClientMap::updateDrawList(video::IVideoDriver* driver)
 {
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
@@ -148,10 +175,8 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 	INodeDefManager *nodemgr = m_gamedef->ndef();
 
-	for(std::map<v3s16, MapBlock*>::iterator
-			i = m_drawlist.begin();
-			i != m_drawlist.end(); ++i)
-	{
+	for (std::map<v3s16, MapBlock*>::iterator i = m_drawlist.begin();
+			i != m_drawlist.end(); ++i) {
 		MapBlock *block = i->second;
 		block->refDrop();
 	}
@@ -167,19 +192,9 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 	camera_fov *= 1.2;
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
-	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1,1,1);
-	v3s16 p_nodes_min = cam_pos_nodes - box_nodes_d;
-	v3s16 p_nodes_max = cam_pos_nodes + box_nodes_d;
-	// Take a fair amount as we will be dropping more out later
-	// Umm... these additions are a bit strange but they are needed.
-	v3s16 p_blocks_min(
-			p_nodes_min.X / MAP_BLOCKSIZE - 3,
-			p_nodes_min.Y / MAP_BLOCKSIZE - 3,
-			p_nodes_min.Z / MAP_BLOCKSIZE - 3);
-	v3s16 p_blocks_max(
-			p_nodes_max.X / MAP_BLOCKSIZE + 1,
-			p_nodes_max.Y / MAP_BLOCKSIZE + 1,
-			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
+	v3s16 p_blocks_min;
+	v3s16 p_blocks_max;
+	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
 
 	// Number of blocks in rendering range
 	u32 blocks_in_range = 0;
@@ -199,19 +214,14 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 	// Distance to farthest drawn block
 	float farthest_drawn = 0;
 
-	for(std::map<v2s16, MapSector*>::iterator
-			si = m_sectors.begin();
-			si != m_sectors.end(); ++si)
-	{
+	for (std::map<v2s16, MapSector*>::iterator si = m_sectors.begin();
+			si != m_sectors.end(); ++si) {
 		MapSector *sector = si->second;
 		v2s16 sp = sector->getPos();
 
-		if(m_control.range_all == false)
-		{
-			if(sp.X < p_blocks_min.X
-			|| sp.X > p_blocks_max.X
-			|| sp.Y < p_blocks_min.Z
-			|| sp.Y > p_blocks_max.Z)
+		if (m_control.range_all == false) {
+			if (sp.X < p_blocks_min.X || sp.X > p_blocks_max.X ||
+					sp.Y < p_blocks_min.Z || sp.Y > p_blocks_max.Z)
 				continue;
 		}
 
@@ -224,9 +234,8 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 		u32 sector_blocks_drawn = 0;
 
-		for(MapBlockVect::iterator i = sectorblocks.begin();
-				i != sectorblocks.end(); ++i)
-		{
+		for (MapBlockVect::iterator i = sectorblocks.begin();
+				i != sectorblocks.end(); ++i) {
 			MapBlock *block = *i;
 
 			/*
@@ -238,16 +247,13 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 				block->mesh->updateCameraOffset(m_camera_offset);
 
 			float range = 100000 * BS;
-			if(m_control.range_all == false)
+			if (m_control.range_all == false)
 				range = m_control.wanted_range * BS;
 
 			float d = 0.0;
-			if(isBlockInSight(block->getPos(), camera_position,
-					camera_direction, camera_fov,
-					range, &d) == false)
-			{
+			if (!isBlockInSight(block->getPos(), camera_position,
+					camera_direction, camera_fov, range, &d))
 				continue;
-			}
 
 			// This is ugly (spherical distance limit?)
 			/*if(m_control.range_all == false &&
@@ -262,7 +268,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			{
 				//MutexAutoLock lock(block->mesh_mutex);
 
-				if(block->mesh == NULL){
+				if (block->mesh == NULL) {
 					blocks_in_range_without_mesh++;
 					continue;
 				}
@@ -275,44 +281,41 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			// No occlusion culling when free_move is on and camera is
 			// inside ground
 			bool occlusion_culling_enabled = true;
-			if(g_settings->getBool("free_move")){
+			if (g_settings->getBool("free_move")) {
 				MapNode n = getNodeNoEx(cam_pos_nodes);
-				if(n.getContent() == CONTENT_IGNORE ||
+				if (n.getContent() == CONTENT_IGNORE ||
 						nodemgr->get(n).solidness == 2)
 					occlusion_culling_enabled = false;
 			}
 
 			v3s16 cpn = block->getPos() * MAP_BLOCKSIZE;
-			cpn += v3s16(MAP_BLOCKSIZE/2, MAP_BLOCKSIZE/2, MAP_BLOCKSIZE/2);
-			float step = BS*1;
+			cpn += v3s16(MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2);
+			float step = BS * 1;
 			float stepfac = 1.1;
-			float startoff = BS*1;
-			float endoff = -BS*MAP_BLOCKSIZE*1.42*1.42;
-			v3s16 spn = cam_pos_nodes + v3s16(0,0,0);
-			s16 bs2 = MAP_BLOCKSIZE/2 + 1;
+			float startoff = BS * 1;
+			float endoff = -BS*MAP_BLOCKSIZE * 1.42 * 1.42;
+			v3s16 spn = cam_pos_nodes + v3s16(0, 0, 0);
+			s16 bs2 = MAP_BLOCKSIZE / 2 + 1;
 			u32 needed_count = 1;
-			if(
-				occlusion_culling_enabled &&
-				isOccluded(this, spn, cpn + v3s16(0,0,0),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(bs2,bs2,bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(bs2,bs2,-bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(bs2,-bs2,bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(bs2,-bs2,-bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(-bs2,bs2,bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(-bs2,bs2,-bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr) &&
-				isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,-bs2),
-					step, stepfac, startoff, endoff, needed_count, nodemgr)
-			)
-			{
+			if (occlusion_culling_enabled &&
+					isOccluded(this, spn, cpn + v3s16(0, 0, 0),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs2,bs2,bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs2,bs2,-bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs2,-bs2,bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs2,-bs2,-bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs2,bs2,bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs2,bs2,-bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,-bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr)) {
 				blocks_occlusion_culled++;
 				continue;
 			}
@@ -322,9 +325,9 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 			// Limit block count in case of a sudden increase
 			blocks_would_have_drawn++;
-			if(blocks_drawn >= m_control.wanted_max_blocks
-					&& m_control.range_all == false
-					&& d > m_control.wanted_min_range * BS)
+			if (blocks_drawn >= m_control.wanted_max_blocks &&
+					!m_control.range_all &&
+					d > m_control.wanted_min_range * BS)
 				continue;
 
 			// Add to set
@@ -333,12 +336,12 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 			sector_blocks_drawn++;
 			blocks_drawn++;
-			if(d/BS > farthest_drawn)
-				farthest_drawn = d/BS;
+			if (d / BS > farthest_drawn)
+				farthest_drawn = d / BS;
 
 		} // foreach sectorblocks
 
-		if(sector_blocks_drawn != 0)
+		if (sector_blocks_drawn != 0)
 			m_last_drawn_sectors.insert(sp);
 	}
 
@@ -348,9 +351,9 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 
 	g_profiler->avg("CM: blocks in range", blocks_in_range);
 	g_profiler->avg("CM: blocks occlusion culled", blocks_occlusion_culled);
-	if(blocks_in_range != 0)
+	if (blocks_in_range != 0)
 		g_profiler->avg("CM: blocks in range without mesh (frac)",
-				(float)blocks_in_range_without_mesh/blocks_in_range);
+				(float)blocks_in_range_without_mesh / blocks_in_range);
 	g_profiler->avg("CM: blocks drawn", blocks_drawn);
 	g_profiler->avg("CM: farthest drawn", farthest_drawn);
 	g_profiler->avg("CM: wanted max blocks", m_control.wanted_max_blocks);
@@ -402,7 +405,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	bool is_transparent_pass = pass == scene::ESNRP_TRANSPARENT;
 
 	std::string prefix;
-	if(pass == scene::ESNRP_SOLID)
+	if (pass == scene::ESNRP_SOLID)
 		prefix = "CM: solid: ";
 	else
 		prefix = "CM: transparent: ";
@@ -410,10 +413,8 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	/*
 		This is called two times per frame, reset on the non-transparent one
 	*/
-	if(pass == scene::ESNRP_SOLID)
-	{
+	if (pass == scene::ESNRP_SOLID)
 		m_last_drawn_sectors.clear();
-	}
 
 	/*
 		Get time for measuring timeout.
@@ -439,22 +440,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	*/
 
 	v3s16 cam_pos_nodes = floatToInt(camera_position, BS);
-
-	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1,1,1);
-
-	v3s16 p_nodes_min = cam_pos_nodes - box_nodes_d;
-	v3s16 p_nodes_max = cam_pos_nodes + box_nodes_d;
-
-	// Take a fair amount as we will be dropping more out later
-	// Umm... these additions are a bit strange but they are needed.
-	v3s16 p_blocks_min(
-			p_nodes_min.X / MAP_BLOCKSIZE - 3,
-			p_nodes_min.Y / MAP_BLOCKSIZE - 3,
-			p_nodes_min.Z / MAP_BLOCKSIZE - 3);
-	v3s16 p_blocks_max(
-			p_nodes_max.X / MAP_BLOCKSIZE + 1,
-			p_nodes_max.Y / MAP_BLOCKSIZE + 1,
-			p_nodes_max.Z / MAP_BLOCKSIZE + 1);
+	v3s16 p_blocks_min;
+	v3s16 p_blocks_max;
+	getBlocksInViewRange(cam_pos_nodes, &p_blocks_min, &p_blocks_max);
 
 	u32 vertex_count = 0;
 	u32 meshbuffer_count = 0;
@@ -475,27 +463,22 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	*/
 
 	{
-	ScopeProfiler sp(g_profiler, prefix+"drawing blocks", SPT_AVG);
+	ScopeProfiler sp(g_profiler, prefix + "drawing blocks", SPT_AVG);
 
 	MeshBufListList drawbufs;
 
-	for(std::map<v3s16, MapBlock*>::iterator
-			i = m_drawlist.begin();
-			i != m_drawlist.end(); ++i)
-	{
+	for (std::map<v3s16, MapBlock*>::iterator i = m_drawlist.begin();
+			i != m_drawlist.end(); ++i) {
 		MapBlock *block = i->second;
 
 		// If the mesh of the block happened to get deleted, ignore it
-		if(block->mesh == NULL)
+		if (block->mesh == NULL)
 			continue;
 
 		float d = 0.0;
-		if(isBlockInSight(block->getPos(), camera_position,
-				camera_direction, camera_fov,
-				100000*BS, &d) == false)
-		{
+		if (!isBlockInSight(block->getPos(), camera_position,
+				camera_direction, camera_fov, 100000 * BS, &d))
 			continue;
-		}
 
 		// Mesh animation
 		{
@@ -503,24 +486,17 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			MapBlockMesh *mapBlockMesh = block->mesh;
 			assert(mapBlockMesh);
 			// Pretty random but this should work somewhat nicely
-			bool faraway = d >= BS*50;
+			bool faraway = d >= BS * 50;
 			//bool faraway = d >= m_control.wanted_range * BS;
-			if(mapBlockMesh->isAnimationForced() ||
-					!faraway ||
-					mesh_animate_count_far < (m_control.range_all ? 200 : 50))
-			{
-				bool animated = mapBlockMesh->animate(
-						faraway,
-						animation_time,
-						crack,
-						daynight_ratio);
-				if(animated)
+			if (mapBlockMesh->isAnimationForced() || !faraway ||
+					mesh_animate_count_far < (m_control.range_all ? 200 : 50)) {
+				bool animated = mapBlockMesh->animate(faraway, animation_time,
+					crack, daynight_ratio);
+				if (animated)
 					mesh_animate_count++;
-				if(animated && faraway)
+				if (animated && faraway)
 					mesh_animate_count_far++;
-			}
-			else
-			{
+			} else {
 				mapBlockMesh->decreaseAnimationForceTimer();
 			}
 		}
@@ -538,7 +514,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			assert(mesh);
 
 			u32 c = mesh->getMeshBufferCount();
-			for(u32 i=0; i<c; i++)
+			for (u32 i = 0; i < c; i++)
 			{
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 
@@ -550,11 +526,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 				video::IMaterialRenderer* rnd =
 						driver->getMaterialRenderer(material.MaterialType);
 				bool transparent = (rnd && rnd->isTransparent());
-				if(transparent == is_transparent_pass)
-				{
-					if(buf->getVertexCount() == 0)
-						errorstream<<"Block ["<<analyze_block(block)
-								<<"] contains an empty meshbuf"<<std::endl;
+				if (transparent == is_transparent_pass) {
+					if (buf->getVertexCount() == 0)
+						errorstream << "Block [" << analyze_block(block)
+							 << "] contains an empty meshbuf" << std::endl;
 					drawbufs.add(buf);
 				}
 			}
@@ -564,13 +539,13 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	std::vector<MeshBufList> &lists = drawbufs.lists;
 
 	int timecheck_counter = 0;
-	for(std::vector<MeshBufList>::iterator i = lists.begin();
+	for (std::vector<MeshBufList>::iterator i = lists.begin();
 			i != lists.end(); ++i) {
 		timecheck_counter++;
-		if(timecheck_counter > 50) {
+		if (timecheck_counter > 50) {
 			timecheck_counter = 0;
 			int time2 = time(0);
-			if(time2 > time1 + 4) {
+			if (time2 > time1 + 4) {
 				infostream << "ClientMap::renderMap(): "
 					"Rendering takes ages, returning."
 					<< std::endl;
@@ -582,7 +557,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 
 		driver->setMaterial(list.m);
 
-		for(std::vector<scene::IMeshBuffer*>::iterator j = list.bufs.begin();
+		for (std::vector<scene::IMeshBuffer*>::iterator j = list.bufs.begin();
 				j != list.bufs.end(); ++j) {
 			scene::IMeshBuffer *buf = *j;
 			driver->drawMeshBuffer(buf);
@@ -594,18 +569,18 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	} // ScopeProfiler
 
 	// Log only on solid pass because values are the same
-	if(pass == scene::ESNRP_SOLID){
+	if (pass == scene::ESNRP_SOLID) {
 		g_profiler->avg("CM: animated meshes", mesh_animate_count);
 		g_profiler->avg("CM: animated meshes (far)", mesh_animate_count_far);
 	}
 
-	g_profiler->avg(prefix+"vertices drawn", vertex_count);
-	if(blocks_had_pass_meshbuf != 0)
-		g_profiler->avg(prefix+"meshbuffers per block",
-				(float)meshbuffer_count / (float)blocks_had_pass_meshbuf);
-	if(blocks_drawn != 0)
-		g_profiler->avg(prefix+"empty blocks (frac)",
-				(float)blocks_without_stuff / blocks_drawn);
+	g_profiler->avg(prefix + "vertices drawn", vertex_count);
+	if (blocks_had_pass_meshbuf != 0)
+		g_profiler->avg(prefix + "meshbuffers per block",
+			(float)meshbuffer_count / (float)blocks_had_pass_meshbuf);
+	if (blocks_drawn != 0)
+		g_profiler->avg(prefix + "empty blocks (frac)",
+			(float)blocks_without_stuff / blocks_drawn);
 
 	/*infostream<<"renderMap(): is_transparent_pass="<<is_transparent_pass
 			<<", rendered "<<vertex_count<<" vertices."<<std::endl;*/

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -120,6 +120,8 @@ public:
 		return m_box;
 	}
 	
+	void getBlocksInViewRange(v3s16 cam_pos_nodes, 
+		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
 	void updateDrawList(video::IVideoDriver* driver);
 	void renderMap(video::IVideoDriver* driver, s32 pass);
 


### PR DESCRIPTION
'cam_pos_nodes -/+ box_nodes_d' can exceed the range of v3s16
when a player is near the world edge using a large view range
This previously caused world to disappear
Create new function getBlocksInViewRange() called from
updateDrawList() and renderMap()
Correct code style throughout updateDrawList() and renderMap()
///////////////////////////////////////////
See #3659 for details.
In the end the fix was simple and lightweight, stating p_nodes_min/max as v3s32, it does not need to be limited afterwards to s16 values.
p_nodes_min.max have to be stated in component format to enable each component to be converted from s16 to s32.
Tested at world corner, confirmed that previously world disappears when at (30927, Y, 30927) and view range is increased beyond 1838. 30927 + 1838 = 32765.

v At world corner with high view range.

![screenshot_20160217_042252](https://cloud.githubusercontent.com/assets/3686677/13099890/1b01c5d2-d52f-11e5-80bb-f2b6202dd72f.png)