### PR TITLE
Require request_insecure_environment to be called from the mod's main scope

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2437,7 +2437,7 @@ These functions return the leftover itemstack.
 * `minetest.request_insecure_environment()`: returns an environment containing
   insecure functions if the calling mod has been listed as trusted in the
   `secure.trusted_mods` setting or security is disabled, otherwise returns `nil`.
-    * Only works at init time.
+    * Only works at init time and must be called from the mod's main scope (not from a function).
     * **DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED ENVIRONMENT, STORE IT IN
       A LOCAL VARIABLE!**
 


### PR DESCRIPTION
Previously you could steal a secure environment from a trusted mod by wrapping
`request_insecure_environment` with some code like this:

```Lua
local rie_cp = minetest.request_insecure_environment
local stolen_ie
function minetest.request_insecure_environment()
	local ie = rie_cp()
	stolen_ie = stolen_ie or ie
	return ie
end
```
This prevents that by simply checking the stack to ensure that R.I.E. is being called directly.

Fixes #3132.