### PR TITLE
Ignore spaces in secure.trusted_mods setting

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -368,6 +368,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 	}
 	const char *mod_name = lua_tostring(L, -1);
 	std::string trusted_mods = g_settings->get("secure.trusted_mods");
+	trusted_mods.erase(std::remove(trusted_mods.begin(), trusted_mods.end(), ' '), trusted_mods.end());
 	std::vector<std::string> mod_list = str_split(trusted_mods, ',');
 	if (std::find(mod_list.begin(), mod_list.end(), mod_name) == mod_list.end()) {
 		lua_pushnil(L);


### PR DESCRIPTION
Currently, when adding a mod to `secure.trusted_mods` you have to make sure that there are no spaces somewhere in the comma-separated list, like this:
```
secure.trusted_mods = irc,foo,bar
```

With this patch, this is now also possible:
```
secure.trusted_mods = irc, foo, bar
```

I think the way it currently works is very confusing to many people that automatically add spaces behind commas. Since mods aren't allowed to have spaces in their name anyways, there should be no issues.