### PR TITLE
Moddable Minimap

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2147,7 +2147,6 @@ bool Game::createClient(const std::string &playername,
 	}
 
 	mapper = client->getMapper();
-	mapper->setMinimapMode(MINIMAP_MODE_OFF);
 
 	return true;
 }
@@ -2927,48 +2926,17 @@ void Game::toggleMinimap(float *statustext_time, bool *flag,
 	if (!show_hud || !g_settings->getBool("enable_minimap"))
 		return;
 
-	if (shift_pressed) {
-		mapper->toggleMinimapShape();
-		return;
-	}
-
 	u32 hud_flags = client->getEnv().getLocalPlayer()->hud_flags;
 
-	MinimapMode mode = MINIMAP_MODE_OFF;
 	if (hud_flags & HUD_FLAG_MINIMAP_VISIBLE) {
-		mode = mapper->getMinimapMode();
-		mode = (MinimapMode)((int)mode + 1);
+		std::string txt;
+		mapper->changeMode(shift_pressed, flag, &txt);
+		statustext = utf8_to_wide(txt);
+	} else {
+		statustext = L"Minimap disabled by server";
 	}
-
-	*flag = true;
-	switch (mode) {
-		case MINIMAP_MODE_SURFACEx1:
-			statustext = L"Minimap in surface mode, Zoom x1";
-			break;
-		case MINIMAP_MODE_SURFACEx2:
-			statustext = L"Minimap in surface mode, Zoom x2";
-			break;
-		case MINIMAP_MODE_SURFACEx4:
-			statustext = L"Minimap in surface mode, Zoom x4";
-			break;
-		case MINIMAP_MODE_RADARx1:
-			statustext = L"Minimap in radar mode, Zoom x1";
-			break;
-		case MINIMAP_MODE_RADARx2:
-			statustext = L"Minimap in radar mode, Zoom x2";
-			break;
-		case MINIMAP_MODE_RADARx4:
-			statustext = L"Minimap in radar mode, Zoom x4";
-			break;
-		default:
-			mode = MINIMAP_MODE_OFF;
-			*flag = false;
-			statustext = (hud_flags & HUD_FLAG_MINIMAP_VISIBLE) ?
-				L"Minimap hidden" : L"Minimap disabled by server";
-	}
-
 	*statustext_time = 0;
-	mapper->setMinimapMode(mode);
+
 }
 
 void Game::toggleFog(float *statustext_time, bool *flag)

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -59,7 +59,7 @@ MinimapModeMachine::~MinimapModeMachine()
 
 void MinimapModeMachine::serialize(std::ostream &os)
 {
-	for (u16 i; i < m_mode_count; i++) {
+	for (u16 i = 0; i < m_mode_count; i++) {
 		std::ostringstream oss(std::ios::binary);
 		MinimapModeDef &m = m_defs[i];
 		writeU8(oss, m.is_minimap_shown);
@@ -84,7 +84,7 @@ void MinimapModeMachine::serialize(std::ostream &os)
 
 void MinimapModeMachine::deserialize(std::istream &is)
 {
-	for (u16 i; i < m_mode_count; i++) {
+	for (u16 i = 0; i < m_mode_count; i++) {
 		std::string str = deSerializeString(is);
 		std::istringstream iss(str, std::ios::binary);
 		MinimapModeDef &m = m_defs[i];

--- a/src/hud.h
+++ b/src/hud.h
@@ -45,12 +45,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define HUD_PARAM_HOTBAR_ITEMCOUNT 1
 #define HUD_PARAM_HOTBAR_IMAGE 2
 #define HUD_PARAM_HOTBAR_SELECTED_IMAGE 3
+#define HUD_PARAM_SET_MINIMAP_MODE 4
+#define HUD_PARAM_SET_MINIMAP_MODE_MACHINE 5
 
 #define HUD_HOTBAR_ITEMCOUNT_DEFAULT 8
 #define HUD_HOTBAR_ITEMCOUNT_MAX     23
 
 
 #define HOTBAR_IMAGE_SIZE 48
+
+#define MINIMAP_MAX_SX 512
+#define MINIMAP_MAX_SY 512
 
 enum HudElementType {
 	HUD_ELEM_IMAGE     = 0,
@@ -87,6 +92,42 @@ struct HudElement {
 	v2f offset;
 	v3f world_pos;
 	v2s32 size;
+};
+
+struct MinimapModeDef {
+	bool is_minimap_shown;
+	std::string status_text;
+	std::string overlay_texture_name;
+	std::string mask_texture_name;
+	std::string player_marker_name;
+	std::string other_players_marker_name;
+	bool is_radar;
+	bool show_player_marker;
+	bool show_other_player_markers;
+	bool rotate_with_yaw;
+	u16 scan_height;
+	u16 map_size;
+	u16 next_mode;
+	u16 next_mode_shift;
+};
+
+class MinimapModeMachine {
+public:
+	MinimapModeMachine(u16 mode_count);
+	virtual ~MinimapModeMachine();
+
+	void serialize(std::ostream &os);
+	void deserialize(std::istream &is);
+
+	void setModeAt(u16 idx, const MinimapModeDef &m)
+	{ m_defs[idx] = m; }
+
+	u16 getModeCount()
+	{ return m_mode_count; }
+
+protected:
+	u16 m_mode_count;
+	MinimapModeDef *m_defs;
 };
 
 #ifndef SERVER
@@ -186,6 +227,32 @@ void drawItemStack(video::IVideoDriver *driver,
 		const core::rect<s32> *clip,
 		IGameDef *gamedef,
 		ItemRotationKind rotation_kind);
+
+class ClientMinimapModeMachine : MinimapModeMachine {
+public:
+	ClientMinimapModeMachine(u16 mode_count) :
+			MinimapModeMachine(mode_count),
+			m_current_mode(0),
+			m_overlays(NULL)
+		{}
+	~ClientMinimapModeMachine();
+
+	MinimapModeDef *getCurrentMode()
+	{ return m_defs + m_current_mode; }
+
+	// returns true iff the mode is now a different one
+	bool modeChange(bool shift);
+
+	void initMasks(video::IVideoDriver *driver, ITextureSource *tsrc,
+		const core::dimension2d<u32> &siz);
+
+	// Only call this after initMasks ran
+	video::IImage *getCurrentModeMask()
+	{ return m_overlays[m_current_mode]; }
+private:
+	u16 m_current_mode;
+	video::IImage **m_overlays;
+};
 
 #endif
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1095,18 +1095,17 @@ void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
 	Player *player = m_env.getLocalPlayer();
 	assert(player != NULL);
 
-	bool was_minimap_visible = player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE;
+	bool old_disabled_by_server = player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE;
 
 	player->hud_flags &= ~mask;
 	player->hud_flags |= flags;
 
-	m_minimap_disabled_by_server = !(player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE);
+	m_minimap_disabled_by_server = player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE;
 
-	// Hide minimap if it has been disabled by the server
-	if (m_minimap_disabled_by_server && was_minimap_visible) {
+	if (m_minimap_disabled_by_server != old_disabled_by_server) {
 		// defers a minimap update, therefore only call it if really
 		// needed, by checking that minimap was visible before
-		m_mapper->setMinimapMode(MINIMAP_MODE_OFF);
+		m_mapper->setMinimapDisabled(m_minimap_disabled_by_server);
 	}
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1181,6 +1181,29 @@ int ObjectRef::l_get_player_control_bits(lua_State *L)
 	return 1;
 }
 
+
+// set_minimap_mode(self, id)
+int ObjectRef::l_set_minimap_mode(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	// TODO
+}
+
+// set_minimap_modes(self, modes)
+int ObjectRef::l_set_minimap_modes(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+	// TODO
+}
+
 // hud_add(self, form)
 int ObjectRef::l_hud_add(lua_State *L)
 {
@@ -1762,6 +1785,8 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_inventory_formspec),
 	luamethod(ObjectRef, get_player_control),
 	luamethod(ObjectRef, get_player_control_bits),
+	luamethod(ObjectRef, set_minimap_mode),
+	luamethod(ObjectRef, set_minimap_modes),
 	luamethod(ObjectRef, set_physics_override),
 	luamethod(ObjectRef, get_physics_override),
 	luamethod(ObjectRef, hud_add),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -219,6 +219,12 @@ private:
 	// get_player_control_bits(self)
 	static int l_get_player_control_bits(lua_State *L);
 
+	// set_minimap_mode(self, id)
+	static int l_set_minimap_mode(lua_State *L);
+
+	// set_minimap_modes(self, modes)
+	static int l_set_minimap_modes(lua_State *L);
+
 	// hud_add(self, id, form)
 	static int l_hud_add(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3100,6 +3100,20 @@ std::string Server::hudGetHotbarSelectedImage(Player *player)
 	return player->getHotbarSelectedImage();
 }
 
+void Server::hudSetMinimapModeMachine(Player *player, MinimapModeMachine *machine)
+{
+	std::ostringstream os(std::ios::binary);
+	writeU16(os, machine->getModeCount());
+	machine->serialize(os);
+	SendHUDSetParam(player->peer_id, HUD_PARAM_SET_MINIMAP_MODE_MACHINE, os.str());
+}
+void Server::hudSetMinimapMode(Player *player, u16 mode)
+{
+	std::ostringstream os(std::ios::binary);
+	writeU16(os, mode);
+	SendHUDSetParam(player->peer_id, HUD_PARAM_SET_MINIMAP_MODE, os.str());
+}
+
 bool Server::setLocalPlayerAnimations(Player *player,
 	v2s32 animation_frames[4], f32 frame_speed)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -343,6 +343,8 @@ public:
 	std::string hudGetHotbarImage(Player *player);
 	void hudSetHotbarSelectedImage(Player *player, std::string name);
 	std::string hudGetHotbarSelectedImage(Player *player);
+	void hudSetMinimapModeMachine(Player *player, MinimapModeMachine *machine);
+	void hudSetMinimapMode(Player *player, u16 mode);
 
 	inline Address getPeerAddress(u16 peer_id)
 			{ return m_con.GetPeerAddress(peer_id); }


### PR DESCRIPTION
This commit allows most aspects of the minimap to be
controlled from server side LUA, while still allowing
for lag free control of the minimap via client keyboard.

The server can upload a state machine of their desire
to the client.

The network protocol format is kept extensible to
allow for additional fields without protocol bumps.

Thanks to the design the server can take over full
control and use single-state state machines to change
every aspect of the minimap without ways to intervene
from the client (expect for disabling minimap altogether).

This allows for "map" mods that only display the minimap
if you wield a "map" craftitem.

This is still very WIP and in early development stage.

TODO: see commit msg, but lots of stuff
