### PR TITLE
Add on_tool_break callback

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -468,6 +468,9 @@ function core.node_dig(pos, node, digger)
 		-- Wear out tool
 		if not core.setting_getbool("creative_mode") then
 			wielded:add_wear(dp.wear)
+			if wielded:get_count() == 0 and wdef and wdef.on_tool_break then
+				wielded = wdef.on_tool_break(wielded, digger, node, dp) or wielded
+			end
 		end
 	end
 	digger:set_wielded_item(wielded)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3357,6 +3357,13 @@ Definition tables
               return itemstack
             end
         ]]
+        on_tool_break = func(itemstack, user, node, digparams),
+        --[[
+        ^  default: nil
+        ^ Will be called instead when tool breaks after wear out.
+          If returns nil, does nothing. If returns itemstack
+          wielded will be set this itemstack.
+        ]]
     }
 
 ### Tile definition


### PR DESCRIPTION
This callback allows mods taking action when after a tool got worn out
and breaks.
In opposite to "after_use" callback it does not hinder wearing out.

Can also be used for games to define tool breaking sounds. By default
nothing happens, the callback is only called if defined by tool.

More generic way to allow things like #3605 
