### PR TITLE
Valleys mapgen: do not generate river water below sea level

### DIFF
--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -590,9 +590,6 @@ int MapgenValleys::generateTerrain()
 				} else if (river && y <= surface_y) {
 					// ground
 					vm->m_data[index_data] = n_stone;
-				} else if (river && y < river_y) {
-					// river
-					vm->m_data[index_data] = n_river_water;
 				} else if ((!river) && myround(fill * slope) >= y - surface_y) {
 					// ground
 					vm->m_data[index_data] = n_stone;
@@ -600,6 +597,9 @@ int MapgenValleys::generateTerrain()
 				} else if (y <= water_level) {
 					// sea
 					vm->m_data[index_data] = n_water;
+				} else if (river && y < river_y) {
+					// river
+					vm->m_data[index_data] = n_river_water;
 				} else {
 					vm->m_data[index_data] = n_air;
 				}


### PR DESCRIPTION
Where a river meets the sea, some river water is generated under the sea level, resulting this:
![screenshot_20160220_131832](https://cloud.githubusercontent.com/assets/6905002/13196656/a86adfba-d7d4-11e5-88d3-bbb66277c386.png)

So I've changed that. River water is no longer generated below sea level.
![screenshot_20160220_133036](https://cloud.githubusercontent.com/assets/6905002/13196702/2980541c-d7d6-11e5-860e-e82e475d37fc.png)
