### PR TITLE
Send to clients only changed node metadata instead of whole mapblock

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -359,6 +359,7 @@ public:
 	void handleCommand_AccessDenied(NetworkPacket* pkt);
 	void handleCommand_RemoveNode(NetworkPacket* pkt);
 	void handleCommand_AddNode(NetworkPacket* pkt);
+	void handleCommand_NodemetaChanged(NetworkPacket *pkt);
 	void handleCommand_BlockData(NetworkPacket* pkt);
 	void handleCommand_Inventory(NetworkPacket* pkt);
 	void handleCommand_TimeOfDay(NetworkPacket* pkt);

--- a/src/map.h
+++ b/src/map.h
@@ -64,9 +64,8 @@ enum MapEditEventType{
 	MEET_REMOVENODE,
 	// Node swapped (changed without metadata change)
 	MEET_SWAPNODE,
-	// Node metadata of block changed (not knowing which node exactly)
-	// p stores block coordinate
-	MEET_BLOCK_NODE_METADATA_CHANGED,
+	// Node metadata changed
+ 	MEET_BLOCK_NODE_METADATA_CHANGED,
 	// Anything else (modified_blocks are set unsent)
 	MEET_OTHER
 };

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_NODEMETA_CHANGED",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_NodemetaChanged }, // 0x54 
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -277,6 +277,33 @@ void Client::handleCommand_AddNode(NetworkPacket* pkt)
 
 	addNode(p, n, remove_metadata);
 }
+
+void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
+{
+	if (pkt->getSize() < 1)
+		return;
+
+	NodeMetadataList *meta_updates_list = new NodeMetadataList();
+	std::string datastring = pkt->readLongString();
+	std::istringstream is(datastring, std::ios::binary);
+	std::ostringstream oss(std::ios::binary);
+	decompressZlib(is, oss);
+	std::istringstream iss(oss.str(), std::ios::binary);
+	meta_updates_list->deSerialize(iss, m_itemdef, true);
+	std::vector<v3s16> meta_updates = meta_updates_list->getAllKeys();
+	for (std::vector<v3s16>::const_iterator i = meta_updates.begin();
+			i != meta_updates.end(); ++i) {
+		v3s16 pos = *i;
+		NodeMetadata *meta = meta_updates_list->get(pos);
+		try {
+			m_env.getMap().setNodeMetadata(pos, meta);
+		}
+		catch(InvalidPositionException &e) {
+			delete meta;
+		}
+	}
+}
+
 void Client::handleCommand_BlockData(NetworkPacket* pkt)
 {
 	// Ignore too small packet

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -135,9 +135,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL_VERSION 27:
 		backface_culling: backwards compatibility for playing with
 		newer client on pre-27 servers.
+	PROTOCOL_VERSION 28:
+		Add TOCLIENT_NODEMETA_CHANGED
 */
 
-#define LATEST_PROTOCOL_VERSION 27
+#define LATEST_PROTOCOL_VERSION 28
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -585,6 +587,11 @@ enum ToClientCommand
 	TOCLIENT_DELETE_PARTICLESPAWNER = 0x53,
 	/*
 		u32 id
+	*/
+
+	TOCLIENT_NODEMETA_CHANGED = 0x54,
+	/*
+		serialized and compressed node metadata
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_NODEMETA_CHANGED",         0, true }, // 0x54 
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -929,7 +929,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		ma->to_inv.applyCurrentPlayer(player->getName());
 
 		setInventoryModified(ma->from_inv, false);
-		setInventoryModified(ma->to_inv, false);
+		if (ma->from_inv != ma->to_inv) {
+			setInventoryModified(ma->to_inv, false);
+		}
 
 		bool from_inv_is_current_player =
 			(ma->from_inv.type == InventoryLocation::PLAYER) &&

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -79,8 +79,9 @@ class NodeMetadataList
 public:
 	~NodeMetadataList();
 
-	void serialize(std::ostream &os) const;
-	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr);
+	void serialize(std::ostream &os, bool uncompressed_pos = false) const;
+	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr,
+		bool uncompressed_pos = false);
 
 	// Add all keys in this list to the vector keys
 	std::vector<v3s16> getAllKeys();

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -169,17 +169,10 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 					meta->deSerialize(is);
 				}
 				// Inform other things that the meta data has changed
-				v3s16 blockpos = getContainerPos(p, MAP_BLOCKSIZE);
 				MapEditEvent event;
 				event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-				event.p = blockpos;
+				event.p = p;
 				map->dispatchEvent(&event);
-				// Set the block to be saved
-				MapBlock *block = map->getBlockNoCreateNoEx(blockpos);
-				if (block) {
-					block->raiseModified(MOD_STATE_WRITE_NEEDED,
-						MOD_REASON_REPORT_META_CHANGE);
-				}
 			} catch (InvalidPositionException &e) {
 				infostream << "RollbackAction::applyRevert(): "
 					<< "InvalidPositionException: " << e.what()

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -57,17 +57,10 @@ void NodeMetaRef::reportMetadataChange(NodeMetaRef *ref)
 {
 	// NOTE: This same code is in rollback_interface.cpp
 	// Inform other things that the metadata has changed
-	v3s16 blockpos = getNodeBlockPos(ref->m_p);
 	MapEditEvent event;
 	event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-	event.p = blockpos;
+	event.p = ref->m_p;
 	ref->m_env->getMap().dispatchEvent(&event);
-	// Set the block to be saved
-	MapBlock *block = ref->m_env->getMap().getBlockNoCreateNoEx(blockpos);
-	if (block) {
-		block->raiseModified(MOD_STATE_WRITE_NEEDED,
-			MOD_REASON_REPORT_META_CHANGE);
-	}
 }
 
 // Exported functions

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -893,6 +893,8 @@ void Server::AsyncRunStep(bool initial_step)
 		// We'll log the amount of each
 		Profiler prof;
 
+		std::list<v3s16> node_meta_updates;
+
 		while(m_unsent_map_edit_queue.size() != 0)
 		{
 			MapEditEvent* event = m_unsent_map_edit_queue.front();
@@ -917,9 +919,19 @@ void Server::AsyncRunStep(bool initial_step)
 						&far_players, disable_single_change_sending ? 5 : 30);
 				break;
 			case MEET_BLOCK_NODE_METADATA_CHANGED:
-				infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
+				{
+					infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
 						prof.add("MEET_BLOCK_NODE_METADATA_CHANGED", 1);
-						setBlockNotSent(event->p);
+					//Dont send the change yet. Collect them to eliminate dupes.
+					node_meta_updates.remove(event->p);
+					node_meta_updates.push_back(event->p);
+					MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(
+						getNodeBlockPos(event->p));
+					if (block) {
+						block->raiseModified(MOD_STATE_WRITE_NEEDED,
+							MOD_REASON_REPORT_META_CHANGE);
+					}
+				}
 				break;
 			case MEET_OTHER:
 				infostream << "Server: MEET_OTHER" << std::endl;
@@ -975,6 +987,10 @@ void Server::AsyncRunStep(bool initial_step)
 			prof.print(verbosestream);
 		}
 
+		// Send all metadata updates
+		if (node_meta_updates.size()) {
+			sendMetadataChanged(node_meta_updates);
+		}
 	}
 
 	/*
@@ -1301,6 +1317,7 @@ Inventory* Server::getInventory(const InventoryLocation &loc)
 	}
 	return NULL;
 }
+
 void Server::setInventoryModified(const InventoryLocation &loc, bool playerSend)
 {
 	switch(loc.type){
@@ -1323,13 +1340,10 @@ void Server::setInventoryModified(const InventoryLocation &loc, bool playerSend)
 		break;
 	case InventoryLocation::NODEMETA:
 	{
-		v3s16 blockpos = getNodeBlockPos(loc.p);
-
-		MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(blockpos);
-		if(block)
-			block->raiseModified(MOD_STATE_WRITE_NEEDED);
-
-		setBlockNotSent(blockpos);
+		MapEditEvent event;
+ 		event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
+		event.p = loc.p;
+ 		m_env->getMap().dispatchEvent(&event);
 	}
 		break;
 	case InventoryLocation::DETACHED:
@@ -2117,6 +2131,59 @@ void Server::sendAddNode(v3s16 p, MapNode n, u16 ignore_id,
 		// Send as reliable
 		if (pkt.getSize() > 0)
 			m_clients.send(*i, 0, &pkt, true);
+	}
+}
+
+void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far_d_nodes)
+{
+	float maxd = far_d_nodes * BS;
+	NodeMetadataList *meta_updates_list = new NodeMetadataList();
+
+	std::vector<u16> clients = m_clients.getClientIDs();
+	for (std::vector<u16>::iterator i = clients.begin();
+			i != clients.end(); ++i) {
+		meta_updates_list->clear();
+		Player *player = m_env->getPlayer(*i);
+		m_clients.lock();
+		RemoteClient* client = m_clients.lockedGetClientNoEx(*i);
+		if (client != 0) {
+			if (client->net_proto_version >= 28) {
+				for (std::list<v3s16>::const_iterator i2 = meta_updates.begin();
+						i2 != meta_updates.end(); ++i2) {
+					v3s16 pos = *i2;
+					NodeMetadata *meta = m_env->getMap().getNodeMetadata(pos);
+					if (!meta) {
+						continue;
+					}
+					if (player) {
+						// If player is far away, only set modified blocks not sent
+						v3f player_pos = player->getPosition();
+						if (player_pos.getDistanceFrom(intToFloat(pos, BS)) > maxd) {
+							client->SetBlockNotSent(getNodeBlockPos(pos));
+							continue;
+						}
+					}
+					// Add the change to send list
+					meta_updates_list->set(pos, meta);
+				}
+				// Send the meta changes
+				NetworkPacket pkt(TOCLIENT_NODEMETA_CHANGED, 0);
+				std::ostringstream os(std::ios::binary);
+				meta_updates_list->serialize(os, true);
+				std::ostringstream oss(std::ios::binary);
+				compressZlib(os.str(), oss);
+				pkt.putLongString(oss.str());
+				m_clients.send(*i, 0, &pkt, true);
+			} else {
+				// Older clients expect whole blocks, set them not sent
+				for (std::list<v3s16>::const_iterator i2 = meta_updates.begin();
+						i2 != meta_updates.end(); ++i2) {
+					v3s16 pos = *i2;
+					client->SetBlockNotSent(getNodeBlockPos(pos));
+				}
+			}
+		}
+		m_clients.unlock();
 	}
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -433,6 +433,8 @@ private:
 			std::vector<u16> *far_players=NULL, float far_d_nodes=100,
 			bool remove_metadata=true);
 	void setBlockNotSent(v3s16 p);
+	void sendMetadataChanged(const std::list<v3s16> &meta_updates,
+			float far_d_nodes=100);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto_version);


### PR DESCRIPTION
Rebased and improved #3166 
fixed so far:
- some compilation errors
- sending meta packets to distant players (happened sometimes)
- meta being null issue
- removed duplicate packets
- gather all changes done in one tick into single packet 

TODO: 
all goals achieved :)