### PR TITLE
Fix minetest.request_insecure_environment() always returning nil

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_security.h"
 #include "areastore.h"
 #include "porting.h"
+#include "debug.h"
 #include "log.h"
 #include "tool.h"
 #include "filesys.h"
@@ -372,8 +373,8 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 	if (lua_getstack(L, 2, &info)) {
 		return 0;
 	}
-	assert(lua_getstack(L, 1, &info));
-	assert(lua_getinfo(L, "S", &info));
+	FATAL_ERROR_IF(!lua_getstack(L, 1, &info), "lua_getstack() failed");
+	FATAL_ERROR_IF(!lua_getinfo(L, "S", &info), "lua_getinfo() failed");
 	// ...and that that item is the main file scope.
 	if (strcmp(info.what, "main") != 0) {
 		return 0;


### PR DESCRIPTION
Since https://github.com/minetest/minetest/commit/4827ee1258ac9d68808ca4e2a9cb88bf49473e6b `minetest.request_insecure_environment()` always returns `nil`, even if the mod is listed in `secure.trusted_mods`.
Tested with an empty mod without dependenices and only one line of code directly in `init.lua`:

``` Lua
print("environment: " .. dump(minetest.request_insecure_environment()))
```

Seems to be broken both when using LuaJIT and the bundled Lua. This obviously makes `minetest.request_insecure_environment()` useless for me.

I converted this issue into a pull request with a possible solution to the problem. It seems like at least on my setup (gcc 5.3.0) the relevant lines of code just got optimized away. This PR solves the issue for me with both LuaJIT and the bundled Lua.
