### PR TITLE
Require minetest.request_http_api to be called from the mod's main scope

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2337,7 +2337,7 @@ These functions return the leftover itemstack.
       otherwise returns `nil`.
     * The returned table contains the functions `fetch`, `fetch_async` and `fetch_async_get`
       described below.
-    * Only works at init time.
+    * Only works at init time and must be called from the mod's main scope (not from a function).
     * Function only exists if minetest server was built with cURL support.
     * **DO NOT ALLOW ANY OTHER MODS TO ACCESS THE RETURNED TABLE, STORE IT IN
       A LOCAL VARIABLE!**


### PR DESCRIPTION
Fixes #3764 . Basically #3738 + #3765 for the HTTP API.

My test setup for the record:
One "good" mod that is trusted and somehow uses the curl API:
```Lua
print("----------------------- Loading CURL Mod --------------------------")
local http_api = minetest.request_http_api()
...
```

One "evil" mod that is not trusted, but gets loaded *before* the good mod. The evil mod overrides `minetest.request_http_api` to get an own copy of the HTTP API. It then returns the HTTP API to the unsuspecting trusted mod:
```Lua
print("----------------------- Loading Evil Mod --------------------------")

local my_request_http_api = minetest.request_http_api

minetest.request_http_api = function ()
	local httpenv = my_request_http_api()
	print("I am so evil, I got " .. dump(httpenv))
	return httpenv
end
```

**This happens without this PR:**
```
----------------------- Loading Evil Mod --------------------------
----------------------- Loading CURL Mod --------------------------
I am so evil, I got {
	fetch_async_get = <function>,
	fetch_async = <function>,
	fetch = <function>
}
```

**This happens with this PR:**
```
----------------------- Loading Evil Mod --------------------------
----------------------- Loading CURL Mod --------------------------
I am so evil, I got nil
```