### PR TITLE
Nodedef: Restore smooth lighting to water

### DIFF
--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -853,7 +853,7 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 			assert(f->liquid_type == LIQUID_SOURCE);
 			if (opaque_water)
 				f->alpha = 255;
-			f->solidness = 0;
+			f->solidness = 1;
 			is_liquid = true;
 			break;
 		case NDT_FLOWINGLIQUID:


### PR DESCRIPTION
Fixes a mistake in https://github.com/minetest/minetest/commit/8eb7ddb0a2f03ae514a96191f6edba9333ba2423 see #3790 
Tested.
Will merge soon is trivial.