### PR TITLE
Decoration API: Allow force_placement of simple decorations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3698,11 +3698,12 @@ Definition tables
     -- ^ Minimum and maximum `y` positions these decorations can be generated at.
     -- ^ This parameter refers to the `y` position of the decoration base, so
     --   the actual maximum height would be `height_max + size.Y`.
-        flags = "liquid_surface",
+        flags = "liquid_surface, force_placement",
     --  ^ Flags for all decoration types.
     --  ^ "liquid_surface": Instead of placement on the highest solid surface
     --  ^ in a mapchunk column, placement is on the highest liquid surface.
     --  ^ Placement is disabled if solid nodes are found above the liquid surface.
+    --  ^ "force_placement": Nodes other than "air" and "ignore" are replaced by the decoration.
 
         ----- Simple-type parameters
         decoration = "default:grass",
@@ -3746,7 +3747,7 @@ Definition tables
         },
     --  ^ See 'Schematic specifier' for details.
         replacements = {["oldname"] = "convert_to", ...},
-        flags = "place_center_x, place_center_y, place_center_z, force_placement",
+        flags = "place_center_x, place_center_y, place_center_z",
     --  ^ Flags for schematic decorations.  See 'Schematic attributes'.
         rotation = "90" -- rotate schematic 90 degrees on placement
     --  ^ Rotation can be "0", "90", "180", "270", or "random".

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -304,13 +304,16 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 	s16 height = (deco_height_max > 0) ?
 		pr->range(deco_height, deco_height_max) : deco_height;
 
+	bool force_placement = (flags & DECO_FORCE_PLACEMENT);
+
 	v3s16 em = vm->m_area.getExtent();
 	u32 vi = vm->m_area.index(p);
 	for (int i = 0; i < height; i++) {
 		vm->m_area.add_y(em, vi, 1);
 
 		content_t c = vm->m_data[vi].getContent();
-		if (c != CONTENT_AIR && c != CONTENT_IGNORE)
+		if (c != CONTENT_AIR && c != CONTENT_IGNORE &&
+				!force_placement)
 			break;
 
 		vm->m_data[vi] = MapNode(c_place);


### PR DESCRIPTION
![screenshot_20160228_000602](https://cloud.githubusercontent.com/assets/3686677/13376252/26f80634-ddaf-11e5-9686-bf34e8510f36.png)

Extends the use of the 'force placement' flag to simple decorations, for use underwater or in vacuum/atmosphere nodes of a space mapgen.
Useful and requested by a modder recently.