### PR TITLE
Predict inventory list movement and add list_predict to formspec

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1363,6 +1363,7 @@ examples.
     size[8,9]
     list[context;fuel;2,3;1,1;]
     list[context;src;2,1;1,1;]
+    list_predict[all,0]
     list[context;dst;5,1;2,2;]
     list[current_player;main;0,5;8,4;]
 
@@ -1372,6 +1373,7 @@ examples.
     image[1,0.6;1,2;player.png]
     list[current_player;main;0,3.5;8,4;]
     list[current_player;craft;3,0;3,3;]
+    list_predict[all,0]
     list[current_player;craftpreview;7,1;1,1;]
 
 ### Elements
@@ -1397,6 +1399,11 @@ examples.
 #### `listring[]`
 * Shorthand for doing `listring[<inventory location>;<list name>]`
 * for the last two inventory lists added by list[...]
+
+#### `list_predict[<take_predict>,<put_predict>]
+* Predict how many items can be taken or put in the subsequent list[]
+* `take_predict`: `all`/integer >= 0
+* `put_predict`: `all`/integer >= 0
 
 #### `listcolors[<slot_bg_normal>;<slot_bg_hover>]`
 * Sets background color of slots as `ColorString`

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -297,6 +297,25 @@ void GUIFormSpecMenu::parseSize(parserData* data,std::string element)
 	errorstream<< "Invalid size element (" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
+void GUIFormSpecMenu::parseListPredict(parserData* data, std::string element)
+{
+	if (!m_gamedef) {
+		warningstream<<"WARNING: invalid use of 'list_predict' with m_gamedef==0"<<std::endl;
+		return;
+	}
+	std::vector<std::string> parts = split(element, ',');
+	if ((parts.size() == 2) ||
+			((parts.size() > 2) && (m_formspec_version > FORMSPEC_API_VERSION))) {
+		int take = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+		int put = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+		if (parts[0] != "all")
+			take = stoi(parts[0]);
+		if (parts[1] != "all")
+			put = stoi(parts[1]);
+		data->list_predict = ListPredict(take, put);
+	}
+}
+
 void GUIFormSpecMenu::parseList(parserData* data,std::string element)
 {
 	if (m_gamedef == 0) {
@@ -346,7 +365,9 @@ void GUIFormSpecMenu::parseList(parserData* data,std::string element)
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of list without a size[] element"<<std::endl;
-		m_inventorylists.push_back(ListDrawSpec(loc, listname, pos, geom, start_i));
+		m_inventorylists.push_back(ListDrawSpec(loc, listname, pos, geom, start_i, data->list_predict));
+		// reset the list_predict for other lists
+		data->list_predict = ListPredict();
 		return;
 	}
 	errorstream<< "Invalid list element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -1692,6 +1713,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, std::string element)
 	std::string type = trim(parts[0]);
 	std::string description = trim(parts[1]);
 
+	if (type == "list_predict") {
+		parseListPredict(data, description);
+		return;
+	}
+
 	if (type == "list") {
 		parseList(data,description);
 		return;
@@ -2142,14 +2168,13 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 			s32 y = (i/s.geom.X) * spacing.Y;
 			v2s32 p0(x,y);
 			core::rect<s32> rect = imgrect + s.pos + p0;
-			if(rect.isPointInside(p))
-			{
-				return ItemSpec(s.inventoryloc, s.listname, item_i);
-			}
+			if (rect.isPointInside(p))
+				return ItemSpec(s.inventoryloc, s.listname, item_i, s.list_predict);
 		}
 	}
 
-	return ItemSpec(InventoryLocation(), "", -1);
+	ListPredict list_predict;
+	return ItemSpec(InventoryLocation(), "", -1, list_predict);
 }
 
 void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
@@ -2597,7 +2622,7 @@ void GUIFormSpecMenu::updateSelectedItem()
 							<<s.inventoryloc.dump()<<" "<<s.listname
 							<<" "<<item_i<<std::endl;
 					delete m_selected_item;
-					m_selected_item = new ItemSpec(s.inventoryloc, s.listname, item_i);
+					m_selected_item = new ItemSpec(s.inventoryloc, s.listname, item_i, s.list_predict);
 					m_selected_amount = stack.count;
 				}
 			}
@@ -2621,10 +2646,7 @@ void GUIFormSpecMenu::updateSelectedItem()
 				InventoryList *list = inv->getList("craftresult");
 				if(list && list->getSize() >= 1 && !list->getItem(0).empty())
 				{
-					m_selected_item = new ItemSpec;
-					m_selected_item->inventoryloc = s.inventoryloc;
-					m_selected_item->listname = "craftresult";
-					m_selected_item->i = 0;
+					m_selected_item = new ItemSpec(s.inventoryloc, "craftresult", 0, s.list_predict);
 					m_selected_amount = 0;
 					m_selected_dragging = false;
 					break;
@@ -3400,9 +3422,11 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			a->from_inv = m_selected_item->inventoryloc;
 			a->from_list = m_selected_item->listname;
 			a->from_i = m_selected_item->i;
+			a->take_predict = m_selected_item->list_predict.take;
 			a->to_inv = s.inventoryloc;
 			a->to_list = s.listname;
 			a->to_i = s.i;
+			a->put_predict = s.list_predict.put;
 			m_invmgr->inventoryAction(a);
 		} else if (shift_move_amount > 0) {
 			u32 mis = m_inventory_rings.size();
@@ -3487,6 +3511,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			a->from_inv = m_selected_item->inventoryloc;
 			a->from_list = m_selected_item->listname;
 			a->from_i = m_selected_item->i;
+			a->take_predict = m_selected_item->list_predict.take;
 			m_invmgr->inventoryAction(a);
 		} else if (craft_amount > 0) {
 			m_selected_content_guess = ItemStack(); // Clear

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -74,6 +74,25 @@ public:
 
 class GUIFormSpecMenu : public GUIModalMenu
 {
+	/**
+	 * Stores client predction values
+	 */
+	struct ListPredict
+	{
+		int take;
+		int put;
+
+		ListPredict() {
+			take = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+			put = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+		}
+
+		ListPredict(int a_take, int a_put) {
+			take = a_take;
+			put = a_put;
+		}
+	};
+
 	struct ItemSpec
 	{
 		ItemSpec()
@@ -82,11 +101,13 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i)
+				s32 a_i,
+				ListPredict a_list_predict)
 		{
 			inventoryloc = a_inventoryloc;
 			listname = a_listname;
 			i = a_i;
+			list_predict = a_list_predict;
 		}
 		bool isValid() const
 		{
@@ -96,6 +117,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i;
+		ListPredict list_predict;
 	};
 
 	struct ListDrawSpec
@@ -105,12 +127,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				ListPredict a_list_predict):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			list_predict(a_list_predict)
 		{
 		}
 
@@ -119,6 +143,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+		ListPredict list_predict;
 	};
 
 	struct ListRingSpec
@@ -442,6 +467,7 @@ private:
 		GUITable::TableColumns table_columns;
 		// used to restore table selection/scroll/treeview state
 		std::map<std::string, GUITable::DynamicData> table_dyndata;
+		ListPredict list_predict;
 	} parserData;
 
 	typedef struct {
@@ -456,6 +482,7 @@ private:
 	void parseElement(parserData* data,std::string element);
 
 	void parseSize(parserData* data,std::string element);
+	void parseListPredict(parserData* data, std::string element);
 	void parseList(parserData* data,std::string element);
 	void parseListRing(parserData* data,std::string element);
 	void parseCheckbox(parserData* data,std::string element);

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -269,8 +269,8 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	if(try_take_count == 0)
 		try_take_count = list_from->getItem(from_i).count;
 
-	int src_can_take_count = 0xffff;
-	int dst_can_put_count = 0xffff;
+	int src_can_take_count = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
+	int dst_can_put_count = DEFAULT_MAX_MOVE_INVENTORY_ITEMS;
 
 	/* Query detached inventories */
 
@@ -533,20 +533,42 @@ void IMoveAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 	// Optional InventoryAction operation that is run on the client
 	// to make lag less apparent.
 
-	Inventory *inv_from = mgr->getInventory(from_inv);
-	Inventory *inv_to = mgr->getInventory(to_inv);
-	if(!inv_from || !inv_to)
+	/*
+		Disable moving items out of craftpreview
+	*/
+	if (from_list == "craftpreview")
 		return;
 
-	InventoryLocation current_player;
-	current_player.setCurrentPlayer();
-	Inventory *inv_player = mgr->getInventory(current_player);
-	if(inv_from != inv_player || inv_to != inv_player)
+	/*
+		Disable moving items into craftresult and craftpreview
+	*/
+	if (to_list == "craftpreview" || to_list == "craftresult")
+		return;
+
+	Inventory *inv_from = mgr->getInventory(from_inv);
+	Inventory *inv_to = mgr->getInventory(to_inv);
+	if (!inv_from || !inv_to)
 		return;
 
 	InventoryList *list_from = inv_from->getList(from_list);
 	InventoryList *list_to = inv_to->getList(to_list);
-	if(!list_from || !list_to)
+	if (!list_from || !list_to)
+		return;
+
+	if (count == 0)
+		count = list_from->getItem(from_i).count;
+
+	// Modify count according to collected data
+	if (count > take_predict)
+		count = take_predict;
+	if (count > put_predict)
+		count = put_predict;
+	// Limit according to source item count
+	if (count > list_from->getItem(from_i).count)
+		count = list_from->getItem(from_i).count;
+
+	// If no items will be moved, don't go further
+	if (count == 0)
 		return;
 
 	if (!move_somewhere)
@@ -555,7 +577,7 @@ void IMoveAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 		list_from->moveItemSomewhere(from_i, list_to, count);
 
 	mgr->setInventoryModified(from_inv);
-	if(inv_from != inv_to)
+	if (inv_from != inv_to)
 		mgr->setInventoryModified(to_inv);
 }
 
@@ -726,21 +748,31 @@ void IDropAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
 	// Optional InventoryAction operation that is run on the client
 	// to make lag less apparent.
 
-	Inventory *inv_from = mgr->getInventory(from_inv);
-	if(!inv_from)
+	/*
+		Disable moving items out of craftpreview
+	*/
+	if (from_list == "craftpreview")
 		return;
 
-	InventoryLocation current_player;
-	current_player.setCurrentPlayer();
-	Inventory *inv_player = mgr->getInventory(current_player);
-	if(inv_from != inv_player)
+	Inventory *inv_from = mgr->getInventory(from_inv);
+	if (!inv_from)
 		return;
 
 	InventoryList *list_from = inv_from->getList(from_list);
-	if(!list_from)
+	if (!list_from)
 		return;
 
-	if(count == 0)
+	if (count == 0)
+		count = list_from->getItem(from_i).count;
+
+	// Modify count according to collected data
+	if (count > take_predict)
+		count = take_predict;
+	// Limit according to source item count
+	if (count > list_from->getItem(from_i).count)
+		count = list_from->getItem(from_i).count;
+
+	if (count == 0)
 		list_from->changeItem(from_i, ItemStack());
 	else
 		list_from->takeItem(from_i, count);

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -121,6 +121,9 @@ public:
 #define IACTION_DROP 1
 #define IACTION_CRAFT 2
 
+// default maximum number of items that can be moved between inventories
+#define DEFAULT_MAX_MOVE_INVENTORY_ITEMS 65535
+
 struct InventoryAction
 {
 	static InventoryAction * deSerialize(std::istream &is);
@@ -149,6 +152,10 @@ struct IMoveAction : public InventoryAction
 	// related to movement to somewhere
 	bool caused_by_move_somewhere;
 	u32 move_count;
+
+	// take_predict and put_predict are calculated and used on the client only
+	int take_predict;
+	int put_predict;
 
 	IMoveAction()
 	{
@@ -195,6 +202,9 @@ struct IDropAction : public InventoryAction
 	InventoryLocation from_inv;
 	std::string from_list;
 	s16 from_i;
+
+	// take_predict is calculated and used on the client only
+	int take_predict;
 
 	IDropAction()
 	{


### PR DESCRIPTION
list_predict can be used for mods to customize the list movement
prediction. The format is list_predict[<take predict>,<put predict>].
'all' means to allow the entire stack to move and is the default if
list_predict is not present.

Rebased by sofar, removed FORMSPEC_API_VERSION number bump.
