### PR TITLE
Allow NodeTimer and ABM interval configuration.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -795,6 +795,15 @@ sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 #    Length of a server tick and the interval at which objects are generally updated over network.
 dedicated_server_step (Dedicated server step) float 0.1
 
+#    Time in between active block management cycles
+active_block_mgmt_interval (Active Block Management interval) float 2.0
+
+#    Length of time between ABM execution cycles
+abm_interval (Active Block Modifier interval) float 1.0
+
+#    Length of time between NodeTimer execution cycles
+nodetimer_interval (NodeTimer interval) float 1.0
+
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.
 ignore_world_load_errors (Ignore world errors) bool false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -980,6 +980,18 @@
 #    type: float
 # dedicated_server_step = 0.1
 
+#    Length of time between Active Block Management execution cycles
+#    type: float
+# active_block_mgmt_interval = 2.0
+
+#    Length of time between ABM execution cycles
+#    type: float
+# abm_interval = 1.0
+
+#    Length of time between NodeTimer execution cycles
+#    type: float
+# nodetimer_interval = 1.0
+
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.
 #    type: bool

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -280,6 +280,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("sqlite_synchronous", "2");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.1");
+	settings->setDefault("active_block_mgmt_interval", "2.0");
+	settings->setDefault("abm_interval", "1.0");
+	settings->setDefault("nodetimer_interval", "1.0");
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");

--- a/src/environment.h
+++ b/src/environment.h
@@ -136,6 +136,9 @@ protected:
 	 *       a later release.
 	 */
 	bool m_cache_enable_shaders;
+	float m_cache_active_block_mgmt_interval;
+	float m_cache_abm_interval;
+	float m_cache_nodetimer_interval;
 
 private:
 	Mutex m_time_lock;

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -409,6 +409,12 @@ fake_function() {
 	gettext("See http://www.sqlite.org/pragma.html#pragma_synchronous");
 	gettext("Dedicated server step");
 	gettext("Length of a server tick and the interval at which objects are generally updated over network.");
+	gettext("Active Block Management interval");
+	gettext("Time in between active block management cycles");
+	gettext("ABM modifier interval");
+	gettext("Length of time between ABM execution cycles");
+	gettext("NodeTimer interval");
+	gettext("Length of time between NodeTimer execution cycles");
 	gettext("Ignore world errors");
 	gettext("If enabled, invalid world data won't cause the server to shut down.\nOnly enable this if you know what you are doing.");
 	gettext("Liquid loop max");


### PR DESCRIPTION
ABM's are hardcoded to run every 2.0s, NodeTimers are hard coded
to run at every 1.0s.

However, these timers can be better tuned for both higher and
lower values by server owners. Some server owners want to, and
have the resources to send more packets per second to clients,
and so they may wish to send smaller updates sooner. Right now
all ABM's are coalesced into 2.0 second intervals, resulting
in large send queues to all clients. By reducing the amount
of possible timers, one can get a far better response rate
and lower the perception of lag.

On the other side of the camp, some servers may want to increase
these values, which again isn't easily doable.

The global settings abm_interval and nodetimer_interval are
set to current values by default. I've tested with 0.2/0.5
type values and noticed a greatly improved response and better
scattering of nodetimers, as well as enjoying not faceplanting
into doors with pressure plates anymore.