### PR TITLE
Try to fix jumping at node edge again

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -562,9 +562,9 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 			Use 0.15*BS so that it is easier to get on a node.
 		*/
-		if (cbox.MaxEdge.X - d > box.MinEdge.X && cbox.MinEdge.X + d < box.MaxEdge.X &&
-				cbox.MaxEdge.Z - d > box.MinEdge.Z &&
-				cbox.MinEdge.Z + d < box.MaxEdge.Z) {
+		if (cbox.MaxEdge.X > box.MinEdge.X && cbox.MinEdge.X < box.MaxEdge.X &&
+				cbox.MaxEdge.Z > box.MinEdge.Z &&
+				cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (is_step_up[boxindex]) {
 				pos_f->Y += (cbox.MaxEdge.Y - box.MinEdge.Y);
 				box = box_0;


### PR DESCRIPTION
Another attempt at fixing the bug.  This fix was suggested by @zhangjunphy, but may have its own issues, please test it with all sorts of weird collision scenarios!

This seems to work, and it at least doesn't break jumping up node stairs.
