### PR TITLE
Add forgotten valleys mapgen in mapgen name

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -800,7 +800,7 @@ liquid_update (Liquid update tick) float 1.0
 
 #    Name of map generator to be used when creating a new world.
 #    Creating a world in the main menu will override this.
-mg_name (Mapgen name) enum v6 v5,v6,v7,flat,fractal,singlenode
+mg_name (Mapgen name) enum v6 v5,v6,v7,flat,valleys,fractal,singlenode
 
 #    Water surface level of the world.
 water_level (Water level) int 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -986,7 +986,7 @@
 
 #    Name of map generator to be used when creating a new world.
 #    Creating a world in the main menu will override this.
-#    type: enum values: v5, v6, v7, flat, fractal, singlenode
+#    type: enum values: v5, v6, v7, flat, fractal, valleys, singlenode
 # mg_name = v6
 
 #    Water surface level of the world.


### PR DESCRIPTION
Missing `valleys` in `settingtypes.txt` and `minetest.conf.example`.
First mentioned here: http://irc.minetest.ru/minetest-dev/2016-03-05#i_4549883
Also here: http://irc.minetest.ru/minetest-dev/2016-03-05#i_4549961