### PR TITLE
Fix race on thread creation (fixes OSX thread tests)

### DIFF
--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -116,9 +116,7 @@ bool Thread::start()
 #if USE_CPP11_THREADS
 
 	try {
-		m_thread_obj    = new std::thread(threadProc, this);
-		m_thread_id     = m_thread_obj->get_id();
-		m_thread_handle = m_thread_obj->native_handle();
+		m_thread_obj = new std::thread(threadProc, this);
 	} catch (const std::system_error &e) {
 		return false;
 	}
@@ -134,8 +132,6 @@ bool Thread::start()
 	int status = pthread_create(&m_thread_handle, NULL, threadProc, this);
 	if (status)
 		return false;
-
-	m_thread_id = m_thread_handle;
 
 #endif
 
@@ -231,12 +227,6 @@ bool Thread::getReturnValue(void **ret)
 
 	*ret = m_retval;
 	return true;
-}
-
-
-bool Thread::isCurrentThread()
-{
-	return thr_is_current_thread(m_thread_id);
 }
 
 

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -90,12 +90,22 @@ public:
 	/*
 	 * Returns true if the calling thread is this Thread object.
 	 */
-	bool isCurrentThread();
+	bool isCurrentThread() { return thr_is_current_thread(getThreadId()); }
 
 	inline bool isRunning() { return m_running; }
 	inline bool stopRequested() { return m_request_stop; }
+
+#if USE_CPP11_THREADS
+	inline threadid_t getThreadId() { return m_thread_obj->get_id(); }
+	inline threadhandle_t getThreadHandle() { return m_thread_obj->native_handle(); }
+#else
+#  if USE_WIN_THREADS
 	inline threadid_t getThreadId() { return m_thread_id; }
+#  else
+	inline threadid_t getThreadId() { return m_thread_handle; }
+#  endif
 	inline threadhandle_t getThreadHandle() { return m_thread_handle; }
+#endif
 
 	/*
 	 * Gets the thread return value.
@@ -147,8 +157,12 @@ private:
 	Atomic<bool> m_running;
 	Mutex m_mutex;
 
-	threadid_t m_thread_id;
+#if !USE_CPP11_THREADS
 	threadhandle_t m_thread_handle;
+#if _WIN32
+	threadid_t m_thread_id;
+#endif
+#endif
 
 	static ThreadStartFunc threadProc;
 


### PR DESCRIPTION
There was a race condition on `m_thread_id`.  `m_thread_id` wasn't set until after the thread was started, and if the thread used it before the creating thread set it it would be in an inconsistent state.