### PR TITLE
Fix ask_reconnect_on_crash config option being ignored

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -391,7 +391,7 @@ void RemoteClient::SentBlock(v3s16 p)
 void RemoteClient::SetBlockNotSent(v3s16 p)
 {
 	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer=0.1;
+	m_nothing_to_send_pause_timer = 0.1;
 
 	if(m_blocks_sending.find(p) != m_blocks_sending.end())
 		m_blocks_sending.erase(p);
@@ -402,8 +402,8 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
 {
 	m_nearest_unsent_d = 0;
-	m_nothing_to_send_pause_timer=0.1;
-	
+	m_nothing_to_send_pause_timer = 0.1;
+
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = blocks.begin();
 			i != blocks.end(); ++i)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -391,6 +391,7 @@ void RemoteClient::SentBlock(v3s16 p)
 void RemoteClient::SetBlockNotSent(v3s16 p)
 {
 	m_nearest_unsent_d = 0;
+	m_nothing_to_send_pause_timer=0.1;
 
 	if(m_blocks_sending.find(p) != m_blocks_sending.end())
 		m_blocks_sending.erase(p);
@@ -401,7 +402,8 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
 {
 	m_nearest_unsent_d = 0;
-
+	m_nothing_to_send_pause_timer=0.1;
+	
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = blocks.begin();
 			i != blocks.end(); ++i)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -486,7 +486,7 @@ void Server::step(float dtime)
 		if (!m_simple_singleplayer_mode) {
 			m_env->kickAllPlayers(SERVER_ACCESSDENIED_CRASH,
 				g_settings->get("kick_msg_crash"),
-				true);//g_settings->getBool("ask_reconnect_on_crash"));
+				g_settings->getBool("ask_reconnect_on_crash"));
 		}
 		throw ServerError(async_err);
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -486,7 +486,7 @@ void Server::step(float dtime)
 		if (!m_simple_singleplayer_mode) {
 			m_env->kickAllPlayers(SERVER_ACCESSDENIED_CRASH,
 				g_settings->get("kick_msg_crash"),
-				g_settings->getBool("ask_reconnect_on_crash"));
+				true);//g_settings->getBool("ask_reconnect_on_crash"));
 		}
 		throw ServerError(async_err);
 	}
@@ -2565,7 +2565,7 @@ void Server::DenyAccessVerCompliant(u16 peer_id, u16 proto_ver, AccessDeniedCode
 		const std::string &str_reason, bool reconnect)
 {
 	if (proto_ver >= 25) {
-		SendAccessDenied(peer_id, reason, str_reason);
+		SendAccessDenied(peer_id, reason, str_reason, reconnect);
 	} else {
 		std::wstring wreason = utf8_to_wide(
 			reason == SERVER_ACCESSDENIED_CUSTOM_STRING ? str_reason :


### PR DESCRIPTION
Since the release of 0.4.13, there is a config option named ask_reconnect_on_crash. It asks the client to reconnect to the server if it crashed. It has been implemeted and works, but due to a function parameter not being passed it never showed effect.
This PR fixes the issue by adding the missing parameter.