### PR TITLE
42Send only changed node metadata to clients instead of whole mapblock

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -359,6 +359,7 @@ public:
 	void handleCommand_AccessDenied(NetworkPacket* pkt);
 	void handleCommand_RemoveNode(NetworkPacket* pkt);
 	void handleCommand_AddNode(NetworkPacket* pkt);
+	void handleCommand_NodemetaChanged(NetworkPacket *pkt);
 	void handleCommand_BlockData(NetworkPacket* pkt);
 	void handleCommand_Inventory(NetworkPacket* pkt);
 	void handleCommand_TimeOfDay(NetworkPacket* pkt);

--- a/src/map.h
+++ b/src/map.h
@@ -64,8 +64,7 @@ enum MapEditEventType{
 	MEET_REMOVENODE,
 	// Node swapped (changed without metadata change)
 	MEET_SWAPNODE,
-	// Node metadata of block changed (not knowing which node exactly)
-	// p stores block coordinate
+	// Node metadata changed
 	MEET_BLOCK_NODE_METADATA_CHANGED,
 	// Anything else (modified_blocks are set unsent)
 	MEET_OTHER

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_NODEMETA_CHANGED",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_NodemetaChanged }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -286,10 +286,9 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 	NodeMetadataList *meta_updates_list = new NodeMetadataList();
 	std::string datastring = pkt->readLongString();
 	std::istringstream is(datastring, std::ios::binary);
-	std::ostringstream oss(std::ios::binary);
-	decompressZlib(is, oss);
-	std::istringstream iss(oss.str(), std::ios::binary);
-	meta_updates_list->deSerialize(iss, m_itemdef, true);
+	std::stringstream sstr;
+	decompressZlib(is, sstr);
+	meta_updates_list->deSerialize(sstr, m_itemdef, true);
 	std::vector<v3s16> meta_updates = meta_updates_list->getAllKeys();
 	for (std::vector<v3s16>::const_iterator i = meta_updates.begin();
 			i != meta_updates.end(); ++i) {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -297,8 +297,7 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 		NodeMetadata *meta = meta_updates_list->get(pos);
 		try {
 			m_env.getMap().setNodeMetadata(pos, meta);
-		}
-		catch(InvalidPositionException &e) {
+		} catch (InvalidPositionException &e) {
 			delete meta;
 		}
 	}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -277,6 +277,33 @@ void Client::handleCommand_AddNode(NetworkPacket* pkt)
 
 	addNode(p, n, remove_metadata);
 }
+
+void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
+{
+	if (pkt->getSize() < 1)
+		return;
+
+	NodeMetadataList *meta_updates_list = new NodeMetadataList();
+	std::string datastring = pkt->readLongString();
+	std::istringstream is(datastring, std::ios::binary);
+	std::ostringstream oss(std::ios::binary);
+	decompressZlib(is, oss);
+	std::istringstream iss(oss.str(), std::ios::binary);
+	meta_updates_list->deSerialize(iss, m_itemdef, true);
+	std::vector<v3s16> meta_updates = meta_updates_list->getAllKeys();
+	for (std::vector<v3s16>::const_iterator i = meta_updates.begin();
+			i != meta_updates.end(); ++i) {
+		v3s16 pos = *i;
+		NodeMetadata *meta = meta_updates_list->get(pos);
+		try {
+			m_env.getMap().setNodeMetadata(pos, meta);
+		}
+		catch(InvalidPositionException &e) {
+			delete meta;
+		}
+	}
+}
+
 void Client::handleCommand_BlockData(NetworkPacket* pkt)
 {
 	// Ignore too small packet

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -136,9 +136,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		backface_culling: backwards compatibility for playing with
 		newer client on pre-27 servers.
 		Add nodedef v3 - connected nodeboxes
+	PROTOCOL_VERSION 28:
+		Add TOCLIENT_NODEMETA_CHANGED
 */
 
-#define LATEST_PROTOCOL_VERSION 27
+#define LATEST_PROTOCOL_VERSION 28
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -586,6 +588,11 @@ enum ToClientCommand
 	TOCLIENT_DELETE_PARTICLESPAWNER = 0x53,
 	/*
 		u32 id
+	*/
+
+	TOCLIENT_NODEMETA_CHANGED = 0x54,
+	/*
+		serialized and compressed node metadata
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_NODEMETA_CHANGED",         0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -930,7 +930,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		ma->to_inv.applyCurrentPlayer(player->getName());
 
 		setInventoryModified(ma->from_inv, false);
-		setInventoryModified(ma->to_inv, false);
+		if (ma->from_inv != ma->to_inv) {
+			setInventoryModified(ma->to_inv, false);
+		}
 
 		bool from_inv_is_current_player =
 			(ma->from_inv.type == InventoryLocation::PLAYER) &&

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -79,8 +79,9 @@ class NodeMetadataList
 public:
 	~NodeMetadataList();
 
-	void serialize(std::ostream &os) const;
-	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr);
+	void serialize(std::ostream &os, bool uncompressed_pos = false) const;
+	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr,
+		bool uncompressed_pos = false);
 
 	// Add all keys in this list to the vector keys
 	std::vector<v3s16> getAllKeys();

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -169,17 +169,10 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 					meta->deSerialize(is);
 				}
 				// Inform other things that the meta data has changed
-				v3s16 blockpos = getContainerPos(p, MAP_BLOCKSIZE);
 				MapEditEvent event;
 				event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-				event.p = blockpos;
+				event.p = p;
 				map->dispatchEvent(&event);
-				// Set the block to be saved
-				MapBlock *block = map->getBlockNoCreateNoEx(blockpos);
-				if (block) {
-					block->raiseModified(MOD_STATE_WRITE_NEEDED,
-						MOD_REASON_REPORT_META_CHANGE);
-				}
 			} catch (InvalidPositionException &e) {
 				infostream << "RollbackAction::applyRevert(): "
 					<< "InvalidPositionException: " << e.what()

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -57,17 +57,10 @@ void NodeMetaRef::reportMetadataChange(NodeMetaRef *ref)
 {
 	// NOTE: This same code is in rollback_interface.cpp
 	// Inform other things that the metadata has changed
-	v3s16 blockpos = getNodeBlockPos(ref->m_p);
 	MapEditEvent event;
 	event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
-	event.p = blockpos;
+	event.p = ref->m_p;
 	ref->m_env->getMap().dispatchEvent(&event);
-	// Set the block to be saved
-	MapBlock *block = ref->m_env->getMap().getBlockNoCreateNoEx(blockpos);
-	if (block) {
-		block->raiseModified(MOD_STATE_WRITE_NEEDED,
-			MOD_REASON_REPORT_META_CHANGE);
-	}
 }
 
 // Exported functions

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -924,21 +924,20 @@ void Server::AsyncRunStep(bool initial_step)
 				sendRemoveNode(event->p, event->already_known_by_peer,
 						&far_players, disable_single_change_sending ? 5 : 30);
 				break;
-			case MEET_BLOCK_NODE_METADATA_CHANGED:
-				{
-					infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
-						prof.add("MEET_BLOCK_NODE_METADATA_CHANGED", 1);
-					//Dont send the change yet. Collect them to eliminate dupes.
-					node_meta_updates.remove(event->p);
-					node_meta_updates.push_back(event->p);
-					MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(
-						getNodeBlockPos(event->p));
-					if (block) {
-						block->raiseModified(MOD_STATE_WRITE_NEEDED,
-							MOD_REASON_REPORT_META_CHANGE);
-					}
+			case MEET_BLOCK_NODE_METADATA_CHANGED: {
+				infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
+				prof.add("MEET_BLOCK_NODE_METADATA_CHANGED", 1);
+				// Don't send the change yet. Collect them to eliminate dupes.
+				node_meta_updates.remove(event->p);
+				node_meta_updates.push_back(event->p);
+				MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(
+					getNodeBlockPos(event->p));
+				if (block) {
+					block->raiseModified(MOD_STATE_WRITE_NEEDED,
+						MOD_REASON_REPORT_META_CHANGE);
 				}
 				break;
+			}
 			case MEET_OTHER:
 				infostream << "Server: MEET_OTHER" << std::endl;
 				prof.add("MEET_OTHER", 1);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -925,16 +925,20 @@ void Server::AsyncRunStep(bool initial_step)
 						&far_players, disable_single_change_sending ? 5 : 30);
 				break;
 			case MEET_BLOCK_NODE_METADATA_CHANGED: {
-				infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
+				verbosestream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
 				prof.add("MEET_BLOCK_NODE_METADATA_CHANGED", 1);
 				// Don't send the change yet. Collect them to eliminate dupes.
 				node_meta_updates.remove(event->p);
 				node_meta_updates.push_back(event->p);
-				MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(
-					getNodeBlockPos(event->p));
-				if (block) {
+
+				if (MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(
+						getNodeBlockPos(event->p))) {
 					block->raiseModified(MOD_STATE_WRITE_NEEDED,
 						MOD_REASON_REPORT_META_CHANGE);
+				} else {
+					errorstream << "Can't raise metadata modification for "
+						<< " block at position " << event->p << ": the block "
+						<< " is not inside the loaded Map." << std::endl;
 				}
 				break;
 			}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -937,7 +937,7 @@ void Server::AsyncRunStep(bool initial_step)
 						MOD_REASON_REPORT_META_CHANGE);
 				} else {
 					errorstream << "Can't raise metadata modification for "
-						<< " block at position " << event->p << ": the block "
+						<< " block at blockpos " << PP(event->p) << ": the block "
 						<< " is not inside the loaded Map." << std::endl;
 				}
 				break;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2078,10 +2078,10 @@ void Server::sendRemoveNode(v3s16 p, u16 ignore_id,
 		i != clients.end(); ++i) {
 		if (far_players) {
 			// Get player
-			if(Player *player = m_env->getPlayer(*i)) {
+			if (Player *player = m_env->getPlayer(*i)) {
 				// If player is far away, only set modified blocks not sent
 				v3f player_pos = player->getPosition();
-				if(player_pos.getDistanceFrom(p_f) > maxd) {
+				if (player_pos.getDistanceFrom(p_f) > maxd) {
 					far_players->push_back(*i);
 					continue;
 				}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -935,10 +935,6 @@ void Server::AsyncRunStep(bool initial_step)
 						getNodeBlockPos(event->p))) {
 					block->raiseModified(MOD_STATE_WRITE_NEEDED,
 						MOD_REASON_REPORT_META_CHANGE);
-				} else {
-					errorstream << "Can't raise metadata modification for "
-						<< " block at blockpos " << PP(event->p) << ": the block "
-						<< " is not inside the loaded Map." << std::endl;
 				}
 				break;
 			}

--- a/src/server.h
+++ b/src/server.h
@@ -433,6 +433,8 @@ private:
 			std::vector<u16> *far_players=NULL, float far_d_nodes=100,
 			bool remove_metadata=true);
 	void setBlockNotSent(v3s16 p);
+	void sendMetadataChanged(const std::list<v3s16> &meta_updates,
+			float far_d_nodes=100);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto_version);


### PR DESCRIPTION
Rebased version of  #3775 (and #3166).

Also added some of my own improvements. Will squash before merge.
