### PR TITLE
Mapgen: Fix light in tunnels at mapchunk borders

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -573,6 +573,12 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 
 		for (s16 y = node_max.Y + 1; y >= node_min.Y - 1;
 				y--, index3d -= ystride, vm->m_area.add_y(em, vi, -1)) {
+			// Don't excavate the overgenerated stone at node_max.Y + 1,
+			// this creates a 'roof' over the tunnel, preventing light in
+			// tunnels at mapchunk borders when generating mapchunks upwards.
+			if (y > node_max.Y)
+				continue;
+
 			content_t c = vm->m_data[vi].getContent();
 			if (c == CONTENT_AIR || c == biome->c_water_top ||
 					c == biome->c_water) {

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -701,6 +701,12 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 
 		for (s16 y = node_max.Y + 1; y >= node_min.Y - 1;
 				y--, index3d -= ystride, vm->m_area.add_y(em, vi, -1)) {
+			// Don't excavate the overgenerated stone at node_max.Y + 1,
+			// this creates a 'roof' over the tunnel, preventing light in
+			// tunnels at mapchunk borders when generating mapchunks upwards.
+			if (y > node_max.Y)
+				continue;
+
 			content_t c = vm->m_data[vi].getContent();
 			if (c == CONTENT_AIR || c == biome->c_water_top ||
 					c == biome->c_water) {

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -519,6 +519,12 @@ void MapgenV5::generateCaves(int max_stone_y)
 	for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
 		u32 vi = vm->m_area.index(node_min.X, y, z);
 		for (s16 x = node_min.X; x <= node_max.X; x++, vi++, index++) {
+			// Don't excavate the overgenerated stone at node_max.Y + 1,
+			// this creates a 'roof' over the tunnel, preventing light in
+			// tunnels at mapchunk borders when generating mapchunks upwards.
+			if (y > node_max.Y)
+				continue;
+
 			float d1 = contour(noise_cave1->result[index]);
 			float d2 = contour(noise_cave2->result[index]);
 			if (d1 * d2 > 0.125f) {

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -883,6 +883,12 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 
 		for (s16 y = node_max.Y + 1; y >= node_min.Y - 1;
 				y--, index3d -= ystride, vm->m_area.add_y(em, vi, -1)) {
+			// Don't excavate the overgenerated stone at node_max.Y + 1,
+			// this creates a 'roof' over the tunnel, preventing light in
+			// tunnels at mapchunk borders when generating mapchunks upwards.
+			if (y > node_max.Y)
+				continue;
+
 			content_t c = vm->m_data[vi].getContent();
 			if (c == CONTENT_AIR || c == biome->c_water_top ||
 					c == biome->c_water) {

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -931,6 +931,12 @@ void MapgenValleys::generateCaves(s16 max_stone_y)
 		for (s16 y = node_max.Y + 1;
 				y >= node_min.Y - 1;
 				y--, index_3d -= ystride, vm->m_area.add_y(em, index_data, -1)) {
+			// Don't excavate the overgenerated stone at node_max.Y + 1,
+			// this creates a 'roof' over the tunnel, preventing light in
+			// tunnels at mapchunk borders when generating mapchunks upwards.
+			if (y > node_max.Y)
+				continue;
+
 			float terrain = noise_terrain_height->result[index_2d];
 
 			// Saves some time.


### PR DESCRIPTION
Don't excavate the overgenerated stone at node_max.Y + 1,
this creates a 'roof' over the tunnel, preventing light in
tunnels at mapchunk borders when generating mapchunks upwards.
/////////////////////////////////////////

![screenshot_20160313_090012](https://cloud.githubusercontent.com/assets/3686677/13727922/ea008030-e8fd-11e5-9341-4e87f0ef305a.png)

^ Current bug

Currently, when generating chunks upwards and above sea level, light shines into the top of a tunnel creating bright tunnels at every mapchunk border.
This commit preserves the overgenerated stone at node_max.Y + 1 to form a roof over the tunnel to keep light out, this roof is of course excavated when the mapchunk above is generated.
Not processing the top node layer also speeds up tunnel generation a little.