### PR TITLE
Mapgen: Unhide singlenode mapgen

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -110,7 +110,7 @@ MapgenDesc g_reg_mapgens[] = {
 	{"flat",       new MapgenFactoryFlat,       true},
 	{"fractal",    new MapgenFactoryFractal,    true},
 	{"valleys",    new MapgenFactoryValleys,    true},
-	{"singlenode", new MapgenFactorySinglenode, false},
+	{"singlenode", new MapgenFactorySinglenode, true},
 };
 
 ////


### PR DESCRIPTION
See #3844 
It was hidden by hmmmm to avoid confusing newbies, but i have now been asked many times how to enable it, have seen many players irritated by the change, and have never seen a confused newbie.