### PR TITLE
Add option to not send pre v25 init packet

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -22,9 +22,14 @@ menudata = {}
 --------------------------------------------------------------------------------
 -- Local cached values
 --------------------------------------------------------------------------------
-local min_supp_proto = core.get_min_supp_proto()
-local max_supp_proto = core.get_max_supp_proto()
+local min_supp_proto
+local max_supp_proto
 
+function common_update_cached_supp_proto()
+	min_supp_proto = core.get_min_supp_proto()
+	max_supp_proto = core.get_max_supp_proto()
+end
+common_update_cached_supp_proto()
 --------------------------------------------------------------------------------
 -- Menu helper functions
 --------------------------------------------------------------------------------
@@ -105,7 +110,7 @@ function render_favorite(spec,render_details)
 	end
 
 	local details = ""
-	local grey_out = not is_server_protocol_compat(spec.proto_max, spec.proto_min)
+	local grey_out = not is_server_protocol_compat(spec.proto_min, spec.proto_max)
 
 	if spec.clients ~= nil and spec.clients_max ~= nil then
 		local clients_color = ''

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -17,6 +17,10 @@
 
 --------------------------------------------------------------------------------
 local function get_formspec(tabview, name, tabdata)
+	-- Update the cached supported proto info,
+	-- it may have changed after a change by the settings menu.
+	common_update_cached_supp_proto()
+
 	local render_details = core.is_yes(core.setting_getbool("public_serverlist"))
 	
 	local retval =

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -232,6 +232,12 @@ address (Server address) string
 #    Note that the port field in the main menu overrides this setting.
 remote_port (Remote port) int 30000 1 65535
 
+#    Whether to support older servers before protocol version 25.
+#    Enable if you want to connect to 0.4.12 servers and before.
+#    Servers starting with 0.4.13 will work, 0.4.12-dev servers may work.
+#    Disabling this option will protect your password better.
+send_pre_v25_init (Support older servers) bool true
+
 #    Save the map received by the client on disk.
 enable_local_map_saving (Saving map received from server) bool false
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -242,6 +242,13 @@
 #    type: int min: 1 max: 65535
 # remote_port = 30000
 
+#    Whether to support older servers before protocol version 25.
+#    Enable if you want to connect to 0.4.12 servers and before.
+#    Servers starting with 0.4.13 will work, 0.4.12-dev servers may work.
+#    Disabling this option will protect your password better.
+#    type: bool
+# send_pre_v25_init = true
+
 #    Save the map received by the client on disk.
 #    type: bool
 # enable_local_map_saving = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -184,6 +184,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("minimap_shape_round", "true");
 	settings->setDefault("minimap_double_scan_height", "true");
 
+	settings->setDefault("send_pre_v25_init", "true");
+
 	settings->setDefault("curl_timeout", "5000");
 	settings->setDefault("curl_parallel_limit", "8");
 	settings->setDefault("curl_file_download_timeout", "300000");

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -145,7 +145,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define SERVER_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Client's supported network protocol range
-#define CLIENT_PROTOCOL_VERSION_MIN 13
+// The minimal version depends on whether
+// send_pre_v25_init is enabled or not
+#define CLIENT_PROTOCOL_VERSION_MIN 25
+#define CLIENT_PROTOCOL_VERSION_MIN_LEGACY 13
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Constant that differentiates the protocol from random data and other protocols

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1095,7 +1095,9 @@ int ModApiMainMenu::l_get_screen_info(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_min_supp_proto(lua_State *L)
 {
-	lua_pushinteger(L, CLIENT_PROTOCOL_VERSION_MIN);
+	u16 proto_version_min = g_settings->getFlag("send_pre_v25_init") ?
+		CLIENT_PROTOCOL_VERSION_MIN_LEGACY : CLIENT_PROTOCOL_VERSION_MIN;
+	lua_pushinteger(L, proto_version_min);
 	return 1;
 }
 

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -69,8 +69,12 @@ std::vector<ServerListSpec> getLocal()
 std::vector<ServerListSpec> getOnline()
 {
 	std::ostringstream geturl;
+
+	u16 proto_version_min = g_settings->getFlag("send_pre_v25_init") ?
+		CLIENT_PROTOCOL_VERSION_MIN_LEGACY : CLIENT_PROTOCOL_VERSION_MIN;
+
 	geturl << g_settings->get("serverlist_url") <<
-		"/list?proto_version_min=" << CLIENT_PROTOCOL_VERSION_MIN <<
+		"/list?proto_version_min=" << proto_version_min <<
 		"&proto_version_max=" << CLIENT_PROTOCOL_VERSION_MAX;
 	Json::Value root = fetchJsonValue(geturl.str(), NULL);
 

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -98,6 +98,8 @@ fake_function() {
 	gettext("Address to connect to.\nLeave this blank to start a local server.\nNote that the address field in the main menu overrides this setting.");
 	gettext("Remote port");
 	gettext("Port to connect to (UDP).\nNote that the port field in the main menu overrides this setting.");
+	gettext("Support older servers");
+	gettext("Whether to support older servers before protocol version 25.\nEnable if you want to connect to 0.4.12 servers and before.\nServers starting with 0.4.13 will work, 0.4.12-dev servers may work.\nDisabling this option will protect your password better.");
 	gettext("Saving map received from server");
 	gettext("Save the map received by the client on disk.");
 	gettext("Connect to external media server");


### PR DESCRIPTION
Sending the pre v25 init packet exposes sensitive information about the password which servers can use to enter other servers with the same name/password combination. Users can now disable sending the v25 packet.

#3854 is related.