### PR TITLE
Add minetest.check_password_entry callback

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1951,12 +1951,21 @@ Call these functions only at load time!
 * `minetest.notify_authentication_modified(name)`
     * Should be called by the authentication handler if privileges changes.
     * To report everybody, set `name=nil`.
+* `minetest.check_password_entry(name, entry, password)`
+    * Returns true if the "db entry" for a player with name matches given
+    * password, false otherwise.
+    * The "db entry" is the usually player-individual value that is derived
+    * from the player's chosen password and stored on the server in order to allow
+    * authentication whenever the player desires to log in.
+    * Only use this function for making it possible to log in via the password from
+    * via protocols like IRC, other uses for inside the game are frowned upon.
 * `minetest.get_password_hash(name, raw_password)`
     * Convert a name-password pair to a password hash that Minetest can use.
     * The returned value alone is not a good basis for password checks based
     * on comparing the password hash in the database with the password hash
     * from the function, with an externally provided password, as the hash
     * in the db might use the new SRP verifier format.
+    * For this purpose, use minetest.check_password_entry instead.
 * `minetest.string_to_privs(str)`: returns `{priv1=true,...}`
 * `minetest.privs_to_string(privs)`: returns `"priv1,priv2,..."`
     * Convert between two privilege representations

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 #include "util/auth.h"
+#include "util/base64.h"
 #include <algorithm>
 
 // log([level,] text)
@@ -245,6 +246,34 @@ int ModApiUtil::l_get_hit_params(lua_State *L)
 	return 1;
 }
 
+// check_password_entry(name, entry, password)
+int ModApiUtil::l_check_password_entry(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::string name = luaL_checkstring(L, 1);
+	std::string entry = luaL_checkstring(L, 2);
+	std::string password = luaL_checkstring(L, 3);
+
+	if (base64_is_valid(entry)) {
+		std::string hash = translate_password(name, password);
+		lua_pushboolean(L, hash == entry);
+		return 1;
+	}
+
+	std::string salt;
+	std::string verifier;
+
+	if (!decode_srp_verifier_and_salt(entry, &verifier, &salt)) {
+		// invalid format
+		lua_pushboolean(L, false);
+		return 1;
+	}
+	std::string gen_verifier = generate_srp_verifier(name, password, salt);
+
+	lua_pushboolean(L, gen_verifier == verifier);
+	return 1;
+}
+
 // get_password_hash(name, raw_password)
 int ModApiUtil::l_get_password_hash(lua_State *L)
 {
@@ -420,6 +449,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(get_dig_params);
 	API_FCT(get_hit_params);
 
+	API_FCT(check_password_entry);
 	API_FCT(get_password_hash);
 
 	API_FCT(is_yes);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -71,6 +71,9 @@ private:
 	// get_hit_params(groups, tool_capabilities[, time_from_last_punch])
 	static int l_get_hit_params(lua_State *L);
 
+	// check_password_entry(name, entry, password)
+	static int l_check_password_entry(lua_State *L);
+
 	// get_password_hash(name, raw_password)
 	static int l_get_password_hash(lua_State *L);
 

--- a/src/util/auth.h
+++ b/src/util/auth.h
@@ -45,6 +45,6 @@ std::string encode_srp_verifier(const std::string &verifier,
 /// Reads the DB-formatted SRP verifier and gets the verifier
 /// and salt components.
 bool decode_srp_verifier_and_salt(const std::string &encoded,
-	std::string *salt, std::string *bytes_v);
+	std::string *verifier, std::string *salt);
 
 #endif


### PR DESCRIPTION
Gives a convenient way to check a player's password.

This entirely bypasses the SRP protocol, so should be used
with great care.

This function is not intended to be used
in-game, but solely by external protocols, where no
authentication of the minetest engine is provided, and
also only for protocols, in which the user already gives the
server the plaintext password.

Examples for good use are the classical http form, or irc,
an example for a bad use is a password change dialog inside
formspec.

Users should be aware that they lose the advantages of the SRP
protocol if they enter their passwords for servers outside the
normal entry box, like in in-game formspec menus,
or through irc /msg s,