### PR TITLE
Remove chat escape sequences from chat messages, for future colored chat.

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -679,6 +679,9 @@ ChatBackend::~ChatBackend()
 
 void ChatBackend::addMessage(std::wstring name, std::wstring text)
 {
+	name = removeChatEscapes(name);
+	text = removeChatEscapes(text);
+
 	// Note: A message may consist of multiple lines, for example the MOTD.
 	WStrfnd fnd(text);
 	while (!fnd.atend())

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -729,6 +729,33 @@ static bool parseNamedColorString(const std::string &value, video::SColor &color
 	return true;
 }
 
+std::wstring removeChatEscapes(const std::wstring &s) {
+	std::wstring output;
+	size_t i = 0;
+	while (i < s.length()) {
+		if (s[i] == L'\v') {
+			++i;
+			if (i == s.length()) continue;
+			if (s[i] == L'(') {
+				++i;
+				while (i < s.length() && s[i] != L')') {
+					if (s[i] == L'\\') {
+						++i;
+					}
+					++i;
+				}
+				++i;
+			} else {
+				++i;
+			}
+			continue;
+		}
+		output += s[i];
+		++i;
+	}
+	return output;
+}
+
 void str_replace(std::string &str, char from, char to)
 {
 	std::replace(str.begin(), str.end(), from, to);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -386,6 +386,13 @@ inline void str_replace(std::string &str, const std::string &pattern,
 	}
 }
 
+/**
+ * Remove all chat escape sequences in \p s.
+ *
+ * @param s The string in which to remove escape sequences.
+ * @return \p s, with escape sequences removed.
+ */
+std::wstring removeChatEscapes(const std::wstring &s);
 
 /**
  * Replace all occurrences of the character \p from in \p str with \p to.


### PR DESCRIPTION
This removes escape sequences from chat messages received by the client, which have the form "\v[single character]" or "\v([string])". It prepares for pulls like #2411 by making it a no longer incompatible change (i.e. if this can get merged in a stable release, then pulls like colored chat would be possible after it).