### PR TITLE
Mapgen: Stop tunnel-floor biome nodes being placed everywhere

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -565,6 +565,7 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
 		bool column_is_open = false;  // Is column open to overground
+		bool is_tunnel = false;  // Is tunnel or tunnel floor
 		u32 vi = vm->m_area.index(x, node_max.Y + 1, z);
 		u32 index3d = (z - node_min.Z) * zstride + (csize.Y + 1) * ystride +
 			(x - node_min.X);
@@ -591,13 +592,16 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
-			} else if (column_is_open &&
+				is_tunnel = true;
+			} else if (is_tunnel && column_is_open &&
 					(c == biome->c_filler || c == biome->c_stone)) {
 				// Tunnel entrance floor
 				vm->m_data[vi] = MapNode(biome->c_top);
 				column_is_open = false;
+				is_tunnel = false;
 			} else {
 				column_is_open = false;
+				is_tunnel = false;
 			}
 		}
 	}

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -693,6 +693,7 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
 		bool column_is_open = false;  // Is column open to overground
+		bool is_tunnel = false;  // Is tunnel or tunnel floor
 		u32 vi = vm->m_area.index(x, node_max.Y + 1, z);
 		u32 index3d = (z - node_min.Z) * zstride + (csize.Y + 1) * ystride +
 			(x - node_min.X);
@@ -719,13 +720,16 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
-			} else if (column_is_open &&
+				is_tunnel = true;
+			} else if (is_tunnel && column_is_open &&
 					(c == biome->c_filler || c == biome->c_stone)) {
 				// Tunnel entrance floor
 				vm->m_data[vi] = MapNode(biome->c_top);
 				column_is_open = false;
+				is_tunnel = false;
 			} else {
 				column_is_open = false;
+				is_tunnel = false;
 			}
 		}
 	}

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -875,6 +875,7 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
 		bool column_is_open = false;  // Is column open to overground
+		bool is_tunnel = false;  // Is tunnel or tunnel floor
 		u32 vi = vm->m_area.index(x, node_max.Y + 1, z);
 		u32 index3d = (z - node_min.Z) * zstride + (csize.Y + 1) * ystride +
 			(x - node_min.X);
@@ -901,13 +902,16 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
-			} else if (column_is_open &&
+				is_tunnel = true;
+			} else if (is_tunnel && column_is_open &&
 					(c == biome->c_filler || c == biome->c_stone)) {
 				// Tunnel entrance floor
 				vm->m_data[vi] = MapNode(biome->c_top);
 				column_is_open = false;
+				is_tunnel = false;
 			} else {
 				column_is_open = false;
+				is_tunnel = false;
 			}
 		}
 	}


### PR DESCRIPTION
When i added biome surface material to tunnel entrance floors a few weeks ago #3558 , i failed to check for being in a tunnel, the result has been biome surface nodes being placed everywhere, replacing 1 node thick stone ledges in mgv7, flat, fractal. I recently started noticing unsupported biome nodes where there should be stone ledges.