### PR TITLE
Fix connected nodes' selection boxes.

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -456,10 +456,10 @@ void MapNode::getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *b
 		transformNodeBox(*this, f.collision_box, nodemgr, boxes, neighbors);
 }
 
-void MapNode::getSelectionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes)
+void MapNode::getSelectionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	transformNodeBox(*this, f.selection_box, nodemgr, boxes);
+	transformNodeBox(*this, f.selection_box, nodemgr, boxes, neighbors);
 }
 
 u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -245,7 +245,7 @@ struct MapNode
 	/*
 		Gets list of selection boxes
 	*/
-	void getSelectionBoxes(INodeDefManager *nodemg, std::vector<aabb3f> *boxes);
+	void getSelectionBoxes(INodeDefManager *nodemg, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Gets list of collision boxes


### PR DESCRIPTION
This allows the player to more easily target and punch connected
nodeboxes, especially if they have a fixed nodebox that is very
small, like technic cabling, or xpanes. Tried it on fences and
my xpane conversion, and happy with the result.