### PR TITLE
Shaders: Reduce amplitude of waving leaves and plants

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -15,7 +15,6 @@ varying vec3 lightVec;
 varying vec3 tsEyeVec;
 varying vec3 tsLightVec;
 varying float area_enable_parallax;
-varying float disp;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
@@ -55,6 +54,7 @@ void main(void)
 #endif
 
 
+float disp;
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
 	vec4 pos2 = mWorld * gl_Vertex;
 	float tOffset = (pos2.x + pos2.y) * 0.001 + pos2.z * 0.002;
@@ -74,12 +74,12 @@ void main(void)
 	vec4 pos = gl_Vertex;
 	pos.x += disp * 0.1;
 	pos.y += disp * 0.1;
-	pos.z += disp;
+	pos.z += disp * 0.7;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS
 	vec4 pos = gl_Vertex;
 	if (gl_TexCoord[0].y < 0.05) {
-		pos.z += disp;
+		pos.z += disp * 0.5;
 	}
 	gl_Position = mWorldViewProj * pos;
 #else
@@ -91,7 +91,7 @@ void main(void)
 	worldPosition = (mWorld * gl_Vertex).xyz;
 
 	// Don't generate heightmaps when too far from the eye
-	float dist = distance (vec3(0.0, 0.0 ,0.0), vPosition);
+	float dist = distance (vec3(0.0, 0.0, 0.0), vPosition);
 	if (dist > 150.0) {
 		area_enable_parallax = 0.0;
 	}
@@ -132,16 +132,16 @@ void main(void)
 
 	// Emphase blue a bit in darker places
 	// See C++ implementation in mapblock_mesh.cpp finalColorBlend()
-	b += max(0.0, (1.0 - abs(b - 0.13)/0.17) * 0.025);
+	b += max(0.0, (1.0 - abs(b - 0.13) / 0.17) * 0.025);
 
 	// Artificial light is yellow-ish
 	// See C++ implementation in mapblock_mesh.cpp finalColorBlend()
-	rg += max(0.0, (1.0 - abs(rg - 0.85)/0.15) * 0.065);
+	rg += max(0.0, (1.0 - abs(rg - 0.85) / 0.15) * 0.065);
 
 	color.r = rg;
 	color.g = rg;
 	color.b = b;
 
 	color.a = gl_Color.a;
-	gl_FrontColor = gl_BackColor = clamp(color,0.0,1.0);
+	gl_FrontColor = gl_BackColor = clamp(color, 0.0, 1.0);
 }


### PR DESCRIPTION
New version of #3500 but with a little extra code cleanup.

I received feedback about my changes to leaves/plants waving having too high amplitude, i agree and have now made the wave amplitudes of leaves and plants independant and have reduced and tuned each one.
Leaves amplitude is mulitplied by 0.7.
Plants amplitude is mulitplied by 0.5.
Both are now more of a gentle swaying.
```varying float disp;``` is removed and instead ```disp``` is initialised in ```void main(void)```

Unfortunately the line ending issue is also present here, causing every line to be part of the diff.
Which type of line ending is required for our code?

True diff (without code cleanups) is:
```
18 - varying float disp;
57 + float disp;
77 - pos.z += disp;
77 + pos.z += disp * 0.7;
82 - pos.z += disp;
82 + pos.z += disp * 0.5;
```

RobertZenz > "The changes are lineendings, your version has replaced CR with CRLF.
Also, the lineendings are not specified in the style guidelines, should be added."

With some research it seems LF (Linux) is the required code style for Git. I was wondering if the file had been changed to CRLF in an earlier commit, but the prevous commit was my own.

My local repo .gitattributes file is:
```
*.cpp diff=cpp
*.h diff=cpp
```