### PR TITLE
Add serverside noclip enforcement

### DIFF
--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -289,6 +289,10 @@ public:
 	bool collideWithObjects();
 
 private:
+	// Cheat checking, returns true if cheated
+	bool checkSpeedCheat();
+	bool checkNoclipCheat(std::string *err_str);
+
 	std::string getPropertyPacket();
 
 	Player *m_player;


### PR DESCRIPTION
Proper noclip. Addresses parts of #3822, and will fix https://github.com/minetest/minetest_game/issues/954 .

However, its still bit WIP, as the path search that's being done unfortunately doesn't work precisely in those cases for which it was added: when jumping off / onto nodes, this is currently very jittery and doesn't work always.

Also I'm not really convinced yet that `collisionMoveSimple` doesn't tell there is no collision when you fly very fast through a single node wall...

What I am sure of is that there are still ways to somehow fly through walls, no idea how that happens, so its not really watertight as I hoped, but it certainly improves the protection, and can be considered mergeable IMO when that "jumping up node" bug gets fixed. Perhaps its a good thing to fix during the freeze.
