### PR TITLE
Make item groups support floating point values

### DIFF
--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -146,10 +146,10 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	}
 	os<<serializeString(tool_capabilities_s);
 	writeU16(os, groups.size());
-	for(std::map<std::string, int>::const_iterator
-			i = groups.begin(); i != groups.end(); ++i){
-		os<<serializeString(i->first);
-		writeS16(os, i->second);
+	for (ItemGroupList::const_iterator it = groups.begin();
+			it != groups.end(); ++it) {
+		os << serializeString(it->first);
+		writeS16(os, it->second);
 	}
 	os<<serializeString(node_placement_prediction);
 	if(protocol_version > 17){
@@ -190,8 +190,8 @@ void ItemDefinition::deSerialize(std::istream &is)
 		tool_capabilities->deSerialize(tmp_is);
 	}
 	groups.clear();
-	u32 groups_size = readU16(is);
-	for(u32 i=0; i<groups_size; i++){
+	u16 groups_size = readU16(is);
+	for (u16 i = 0; i < groups_size; i++) {
 		std::string name = deSerializeString(is);
 		int value = readS16(is);
 		groups[name] = value;

--- a/src/itemgroup.h
+++ b/src/itemgroup.h
@@ -23,15 +23,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <map>
 
-typedef std::map<std::string, int> ItemGroupList;
+typedef std::map<std::string, float> ItemGroupList;
 
-static inline int itemgroup_get(const ItemGroupList &groups,
+static inline float itemgroup_get(const ItemGroupList &groups,
 		const std::string &name)
 {
-	std::map<std::string, int>::const_iterator i = groups.find(name);
-	if(i == groups.end())
+	ItemGroupList::const_iterator it = groups.find(name);
+	if (it == groups.end())
 		return 0;
-	return i->second;
+	return it->second;
 }
 
 #endif

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -42,7 +42,7 @@ class IShaderSource;
 class IGameDef;
 class NodeResolver;
 
-typedef std::list<std::pair<content_t, int> > GroupItems;
+typedef std::list<std::pair<content_t, float> > GroupItems;
 
 enum ContentParamType
 {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1067,7 +1067,7 @@ void push_flags_string(lua_State *L, FlagDesc *flagdesc, u32 flags, u32 flagmask
 
 /******************************************************************************/
 void read_groups(lua_State *L, int index,
-		std::map<std::string, int> &result)
+		std::map<std::string, float> &result)
 {
 	if (!lua_istable(L,index))
 		return;
@@ -1078,7 +1078,7 @@ void read_groups(lua_State *L, int index,
 	while(lua_next(L, index) != 0){
 		// key at index -2 and value at index -1
 		std::string name = luaL_checkstring(L, -2);
-		int rating = luaL_checkinteger(L, -1);
+		float rating = luaL_checknumber(L, -1);
 		result[name] = rating;
 		// removes value, keeps key for next iteration
 		lua_pop(L, 1);
@@ -1086,10 +1086,10 @@ void read_groups(lua_State *L, int index,
 }
 
 /******************************************************************************/
-void push_groups(lua_State *L, const std::map<std::string, int> &groups)
+void push_groups(lua_State *L, const std::map<std::string, float> &groups)
 {
 	lua_newtable(L);
-	std::map<std::string, int>::const_iterator it;
+	std::map<std::string, float>::const_iterator it;
 	for (it = groups.begin(); it != groups.end(); ++it) {
 		lua_pushnumber(L, it->second);
 		lua_setfield(L, -2, it->first.c_str());

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -106,10 +106,10 @@ void               pushnode                  (lua_State *L, const MapNode &n,
 NodeBox            read_nodebox              (lua_State *L, int index);
 
 void               read_groups               (lua_State *L, int index,
-                                              std::map<std::string, int> &result);
+                                              std::map<std::string, float> &result);
 
 void               push_groups               (lua_State *L,
-                                              const std::map<std::string, int> &groups);
+                                              const std::map<std::string, float> &groups);
 
 //TODO rename to "read_enum_field"
 int                getenumfield              (lua_State *L, int table,

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -60,7 +60,7 @@ bool               getintfield(lua_State *L, int table,
 bool               getintfield(lua_State *L, int table,
                              const char *fieldname, u32 &result);
 void               read_groups(lua_State *L, int index,
-                             std::map<std::string, int> &result);
+                             std::map<std::string, float> &result);
 bool               getboolfield(lua_State *L, int table,
                              const char *fieldname, bool &result);
 bool               getfloatfield(lua_State *L, int table,

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -219,7 +219,7 @@ int ModApiUtil::l_write_json(lua_State *L)
 int ModApiUtil::l_get_dig_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	std::map<std::string, int> groups;
+	std::map<std::string, float> groups;
 	read_groups(L, 1, groups);
 	ToolCapabilities tp = read_tool_capabilities(L, 2);
 	if(lua_isnoneornil(L, 3))
@@ -234,7 +234,7 @@ int ModApiUtil::l_get_dig_params(lua_State *L)
 int ModApiUtil::l_get_hit_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	std::map<std::string, int> groups;
+	std::map<std::string, float> groups;
 	read_groups(L, 1, groups);
 	ToolCapabilities tp = read_tool_capabilities(L, 2);
 	if(lua_isnoneornil(L, 3))

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -96,7 +96,7 @@ DigParams getDigParams(const ItemGroupList &groups,
 {
 	//infostream<<"getDigParams"<<std::endl;
 	/* Check group dig_immediate */
-	switch(itemgroup_get(groups, "dig_immediate")){
+	switch((int)itemgroup_get(groups, "dig_immediate")){
 	case 2:
 		//infostream<<"dig_immediate=2"<<std::endl;
 		return DigParams(true, 0.5, 0, "dig_immediate");


### PR DESCRIPTION
This fixes, eg, a ABM set to trigger on "group:radioactive" not triggering if the node has radioactive=0.5.  The floating-point groups are still sent to the client as integers to avoid a protocol upgrade.

Note: Marking this as WIP because there may still be some places where groups are treated as ints.
