### PR TITLE
Mgv7: Decrease cliff steepness

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -937,7 +937,7 @@ mgv7_spflags (Mapgen v7 flags) flags mountains,ridges mountains,ridges,nomountai
 mgv7_np_terrain_base (Mapgen v7 terrain base noise parameters) noise_params 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 mgv7_np_terrain_alt (Mapgen v7 terrain altitude noise parameters) noise_params 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0
 mgv7_np_terrain_persist (Mapgen v7 terrain persistation noise parameters) noise_params 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0
-mgv7_np_height_select (Mapgen v7 height select noise parameters) noise_params -12, 24, (500, 500, 500), 4213, 6, 0.7, 2.0
+mgv7_np_height_select (Mapgen v7 height select noise parameters) noise_params -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0
 mgv7_np_filler_depth (Mapgen v7 filler depth noise parameters) noise_params 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0
 mgv7_np_mount_height (Mapgen v7 mount height noise parameters) noise_params 256, 112, (1000, 1000, 1000), 72449, 3, 0.6, 2.0
 mgv7_np_ridge_uwater (Mapgen v7 ridge water noise parameters) noise_params 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1178,7 +1178,7 @@
 # mgv7_np_terrain_persist = 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0
 
 #    type: noise_params
-# mgv7_np_height_select = -12, 24, (500, 500, 500), 4213, 6, 0.7, 2.0
+# mgv7_np_height_select = -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0
 
 #    type: noise_params
 # mgv7_np_filler_depth = 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -152,7 +152,7 @@ MapgenV7Params::MapgenV7Params()
 	np_terrain_base    = NoiseParams(4,    70,  v3f(600,  600,  600),  82341, 5, 0.6,  2.0);
 	np_terrain_alt     = NoiseParams(4,    25,  v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
 	np_terrain_persist = NoiseParams(0.6,  0.1, v3f(2000, 2000, 2000), 539,   3, 0.6,  2.0);
-	np_height_select   = NoiseParams(-12,  24,  v3f(500,  500,  500),  4213,  6, 0.7,  2.0);
+	np_height_select   = NoiseParams(-8,   16,  v3f(500,  500,  500),  4213,  6, 0.7,  2.0);
 	np_filler_depth    = NoiseParams(0,    1.2, v3f(150,  150,  150),  261,   3, 0.7,  2.0);
 	np_mount_height    = NoiseParams(256,  112, v3f(1000, 1000, 1000), 72449, 3, 0.6,  2.0);
 	np_ridge_uwater    = NoiseParams(0,    1,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0);


### PR DESCRIPTION
![screenshot_20160325_151409](https://cloud.githubusercontent.com/assets/3686677/14047606/ca58fcba-f2a0-11e5-9ca7-3fe5538ea893.png)

![screenshot_20160325_153805](https://cloud.githubusercontent.com/assets/3686677/14047617/d5d3bd50-f2a0-11e5-946c-817dc857ef01.png)

I'm happy with mgv7 but something has been bothering me, the cliffs are near-vertical too often.
This commit slighltly reduces the average steepness, creating more variety of steepnesses. It's now more often possible to jump down a cliff face without dying. The screenshots show the typical variation with this commit. The more gentle cliffs of the last screenshot are very welcome and beautiful. Near-vertical cliffs are still present but more rare.
Adding own approval.