### PR TITLE
Fix warnings reported by clang and its analyzer

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -546,7 +546,6 @@ GenericCAO::GenericCAO(IGameDef *gamedef, ClientEnvironment *env):
 		//
 		m_smgr(NULL),
 		m_irr(NULL),
-		m_camera(NULL),
 		m_gamedef(NULL),
 		m_selection_box(-BS/3.,-BS/3.,-BS/3., BS/3.,BS/3.,BS/3.),
 		m_meshnode(NULL),

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -68,7 +68,6 @@ private:
 	//
 	scene::ISceneManager *m_smgr;
 	IrrlichtDevice *m_irr;
-	Camera* m_camera;
 	IGameDef *m_gamedef;
 	aabb3f m_selection_box;
 	scene::IMeshSceneNode *m_meshnode;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1091,7 +1091,7 @@ int PlayerSAO::punch(v3f dir,
 
 	std::string punchername = "nil";
 
-	if (puncher != 0)
+	if (puncher)
 		punchername = puncher->getDescription();
 
 	PlayerSAO *playersao = m_player->getPlayerSAO();
@@ -1102,13 +1102,12 @@ int PlayerSAO::punch(v3f dir,
 
 	if (!damage_handled) {
 		setHP(getHP() - hitparams.hp);
-	} else { // override client prediction
-		if (puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-			std::string str = gob_cmd_punched(0, getHP());
-			// create message and add to list
-			ActiveObjectMessage aom(getId(), true, str);
-			m_messages_out.push(aom);
-		}
+	} else if (puncher && puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		// override client prediction
+		std::string str = gob_cmd_punched(0, getHP());
+		// create message and add to list
+		ActiveObjectMessage aom(getId(), true, str);
+		m_messages_out.push(aom);
 	}
 
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4010,10 +4010,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats,
 				    / 255.0;
 	}
 
-	float time_of_day = runData->time_of_day;
+	float time_of_day = client->getEnv().getTimeOfDayF();
 	float time_of_day_smooth = runData->time_of_day_smooth;
-
-	time_of_day = client->getEnv().getTimeOfDayF();
 
 	const float maxsm = 0.05;
 	const float todsm = 0.05;

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -1017,10 +1017,10 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 		spec.send = true;
 		gui::IGUIElement *e;
 #if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
-		if (g_settings->getBool("freetype")) {
+		bool use_freetype = g_settings->getBool("freetype");
+		if (use_freetype) {
 			e = (gui::IGUIElement *) new gui::intlGUIEditBox(spec.fdefault.c_str(),
 				true, Environment, this, spec.fid, rect);
-			e->drop();
 		} else {
 #else
 		{
@@ -1039,6 +1039,11 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 		evt.KeyInput.Shift       = 0;
 		evt.KeyInput.PressedDown = true;
 		e->OnEvent(evt);
+
+#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
+		if (use_freetype)
+			e->drop();
+#endif
 
 		if (label.length() >= 1)
 		{
@@ -2728,13 +2733,14 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 					// without rtti support in irrlicht
 					IGUIElement * element = getElementFromId(s.fid);
 					gui::IGUIComboBox *e = NULL;
+					s32 selected = -1;
 					if ((element) && (element->getType() == gui::EGUIET_COMBO_BOX)) {
 						e = static_cast<gui::IGUIComboBox*>(element);
+						selected = e->getSelected();
 					}
-					s32 selected = e->getSelected();
 					if (selected >= 0) {
-						fields[name] =
-							wide_to_utf8(e->getItem(selected));
+						fields[name] = wide_to_utf8(
+							e->getItem(selected));
 					}
 				}
 				else if (s.ftype == f_TabHeader) {
@@ -2746,7 +2752,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 						e = static_cast<gui::IGUITabControl*>(element);
 					}
 
-					if (e != 0) {
+					if (e != NULL) {
 						std::stringstream ss;
 						ss << (e->getActiveTab() +1);
 						fields[name] = ss.str();
@@ -2761,7 +2767,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 						e = static_cast<gui::IGUICheckBox*>(element);
 					}
 
-					if (e != 0) {
+					if (e != NULL) {
 						if (e->isChecked())
 							fields[name] = "true";
 						else
@@ -2777,7 +2783,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 						e = static_cast<gui::IGUIScrollBar*>(element);
 					}
 
-					if (e != 0) {
+					if (e != NULL) {
 						std::stringstream os;
 						os << e->getPos();
 						if (s.fdefault == L"Changed")
@@ -2789,7 +2795,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 				else
 				{
 					IGUIElement* e = getElementFromId(s.fid);
-					if(e != NULL) {
+					if (e != NULL) {
 						fields[name] = wide_to_utf8(e->getText());
 					}
 				}

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -283,6 +283,7 @@ public:
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;
 	std::vector<const InventoryList*> getLists();
+	IItemDefManager *getItemDef() const { return m_itemdef; }
 	bool deleteList(const std::string &name);
 	// A shorthand for adding items. Returns leftover item (possibly empty).
 	ItemStack addItem(const std::string &listname, const ItemStack &newitem)

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -842,7 +842,8 @@ void ICraftAction::apply(InventoryManager *mgr,
 			count_remaining--;
 
 		// Get next crafting result
-		found = getCraftingResult(inv_craft, crafted, temp, false, gamedef);
+		if (!getCraftingResult(inv_craft, crafted, temp, false, gamedef))
+			break;
 		PLAYER_TO_SA(player)->item_CraftPredict(crafted, player, list_craft, craft_inv);
 		found = !crafted.empty();
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1774,7 +1774,6 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks)
 		 */
 		content_t new_node_content;
 		s8 new_node_level = -1;
-		s8 max_node_level = -1;
 
 		u8 range = nodemgr->get(liquid_kind).liquid_range;
 		if (range > LIQUID_LEVEL_MAX + 1)
@@ -1787,12 +1786,13 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks)
 			new_node_content = nodemgr->getId(nodemgr->get(liquid_kind).liquid_alternative_source);
 		} else if (num_sources >= 1 && sources[0].t != NEIGHBOR_LOWER) {
 			// liquid_kind is set properly, see above
-			max_node_level = new_node_level = LIQUID_LEVEL_MAX;
+			new_node_level = LIQUID_LEVEL_MAX;
 			if (new_node_level >= (LIQUID_LEVEL_MAX + 1 - range))
 				new_node_content = liquid_kind;
 			else
 				new_node_content = floodable_node;
 		} else {
+			s8 max_node_level = -1;
 			// no surrounding sources, so get the maximum level that can flow into this node
 			for (u16 i = 0; i < num_flows; i++) {
 				u8 nb_liquid_level = (flows[i].n.param2 & LIQUID_LEVEL_MASK);

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1233,10 +1233,10 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			buf->Material = material;
 			// Add to mesh
 			mesh->addMeshBuffer(buf);
-			// Mesh grabbed it
-			buf->drop();
 			buf->append(&p.vertices[0], p.vertices.size(),
 				&p.indices[0], p.indices.size());
+			// Mesh grabbed it
+			buf->drop();
 		}
 	}
 
@@ -1285,8 +1285,10 @@ MapBlockMesh::~MapBlockMesh()
 			m_driver->removeHardwareBuffer(buf);
 		}
 	}
-	m_mesh->drop();
-	m_mesh = NULL;
+	if (m_mesh) {
+		m_mesh->drop();
+		m_mesh = NULL;
+	}
 	delete m_minimap_mapblock;
 }
 

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -453,6 +453,8 @@ MgStoneType MapgenFlat::generateBiomes(float *heat_map, float *humidity_map)
 					stone_type = DESERT_STONE;
 				else if (biome->c_stone == c_sandstone)
 					stone_type = SANDSTONE;
+			} else {
+				continue;
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -581,6 +581,8 @@ MgStoneType MapgenFractal::generateBiomes(float *heat_map, float *humidity_map)
 					stone_type = DESERT_STONE;
 				else if (biome->c_stone == c_sandstone)
 					stone_type = SANDSTONE;
+			} else {
+				continue;
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -457,6 +457,8 @@ MgStoneType MapgenV5::generateBiomes(float *heat_map, float *humidity_map)
 					stone_type = DESERT_STONE;
 				else if (biome->c_stone == c_sandstone)
 					stone_type = SANDSTONE;
+			} else {
+				continue;
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -667,6 +667,8 @@ MgStoneType MapgenV7::generateBiomes(float *heat_map, float *humidity_map)
 					stone_type = DESERT_STONE;
 				else if (biome->c_stone == c_sandstone)
 					stone_type = SANDSTONE;
+			} else {
+				continue;
 			}
 
 			if (c == c_stone) {

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -750,6 +750,8 @@ MgStoneType MapgenValleys::generateBiomes(float *heat_map, float *humidity_map)
 					stone_type = DESERT_STONE;
 				else if (biome->c_stone == c_sandstone)
 					stone_type = SANDSTONE;
+			} else {
+				continue;
 			}
 
 			if (c == c_stone) {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -971,22 +971,21 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 
 void Client::handleCommand_DeleteParticleSpawner(NetworkPacket* pkt)
 {
-	u16 legacy_id;
-	u32 id;
+	u16 legacy_id = 0;
+	u32 id = 0;
 
 	// Modification set 13/03/15, 1 year of compat for protocol v24
-	if (pkt->getCommand() == TOCLIENT_DELETE_PARTICLESPAWNER_LEGACY) {
+	bool is_legacy = pkt->getCommand() == TOCLIENT_DELETE_PARTICLESPAWNER_LEGACY;
+	if (is_legacy) {
 		*pkt >> legacy_id;
-	}
-	else {
+	} else {
 		*pkt >> id;
 	}
 
 
 	ClientEvent event;
 	event.type                      = CE_DELETE_PARTICLESPAWNER;
-	event.delete_particlespawner.id =
-			(pkt->getCommand() == TOCLIENT_DELETE_PARTICLESPAWNER_LEGACY ? (u32) legacy_id : id);
+	event.delete_particlespawner.id = (is_legacy ? (u32) legacy_id : id);
 
 	m_client_event_queue.push(event);
 }

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1275,7 +1275,7 @@ void * ConnectionSendThread::run()
 			<<"ConnectionSend thread started"<<std::endl);
 
 	u32 curtime = porting::getTimeMs();
-	u32 lasttime = curtime;
+	u32 lasttime;
 
 	PROFILE(std::stringstream ThreadIdentifier);
 	PROFILE(ThreadIdentifier << "ConnectionSend: [" << m_connection->getDesc() << "]");

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -640,7 +640,6 @@ void Noise::gradientMap3D(
 
 	//calculate interpolations
 	index  = 0;
-	noisey = 0;
 	noisez = 0;
 	for (k = 0; k != sz; k++) {
 		v = orig_v;

--- a/src/script/lua_api/l_areastore.cpp
+++ b/src/script/lua_api/l_areastore.cpp
@@ -338,14 +338,7 @@ int LuaAreaStore::create_object(lua_State *L)
 LuaAreaStore *LuaAreaStore::checkobject(lua_State *L, int narg)
 {
 	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaAreaStore **)ud;  // unbox pointer
+	return *(LuaAreaStore **)luaL_checkudata(L, narg, className);
 }
 
 void LuaAreaStore::Register(lua_State *L)

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -30,10 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 InvRef* InvRef::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(InvRef**)ud;  // unbox pointer
+	return *(InvRef**)luaL_checkudata(L, narg, className);
 }
 
 Inventory* InvRef::getinv(lua_State *L, InvRef *ref)
@@ -273,18 +270,17 @@ int InvRef::l_set_lists(lua_State *L)
 	}
 
 	// Make a temporary inventory in case reading fails
-	Inventory *tempInv(inv);
-	tempInv->clear();
+	Inventory tempInv(inv->getItemDef());
 
 	Server *server = getServer(L);
 
 	lua_pushnil(L);
 	while (lua_next(L, 2)) {
 		const char *listname = lua_tostring(L, -2);
-		read_inventory_list(L, -1, tempInv, listname, server);
+		read_inventory_list(L, -1, &tempInv, listname, server);
 		lua_pop(L, 1);
 	}
-	inv = tempInv;
+	*inv = tempInv;
 	return 0;
 }
 

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -400,10 +400,7 @@ int LuaItemStack::create(lua_State *L, const ItemStack &item)
 
 LuaItemStack* LuaItemStack::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(LuaItemStack**)ud;  // unbox pointer
+	return *(LuaItemStack**)luaL_checkudata(L, narg, className);
 }
 
 void LuaItemStack::Register(lua_State *L)

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -34,10 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 NodeMetaRef* NodeMetaRef::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(NodeMetaRef**)ud;  // unbox pointer
+	return *(NodeMetaRef**)luaL_checkudata(L, narg, className);
 }
 
 NodeMetadata* NodeMetaRef::getmeta(NodeMetaRef *ref, bool auto_create)

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -31,10 +31,7 @@ int NodeTimerRef::gc_object(lua_State *L) {
 
 NodeTimerRef* NodeTimerRef::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(NodeTimerRef**)ud;  // unbox pointer
+	return *(NodeTimerRef**)luaL_checkudata(L, narg, className);
 }
 
 int NodeTimerRef::l_set(lua_State *L)

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -98,11 +98,7 @@ int LuaPerlinNoise::gc_object(lua_State *L)
 LuaPerlinNoise *LuaPerlinNoise::checkobject(lua_State *L, int narg)
 {
 	NO_MAP_LOCK_REQUIRED;
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPerlinNoise **)ud;
+	return *(LuaPerlinNoise **)luaL_checkudata(L, narg, className);
 }
 
 
@@ -354,13 +350,7 @@ int LuaPerlinNoiseMap::gc_object(lua_State *L)
 
 LuaPerlinNoiseMap *LuaPerlinNoiseMap::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaPerlinNoiseMap **)ud;
+	return *(LuaPerlinNoiseMap **)luaL_checkudata(L, narg, className);
 }
 
 
@@ -461,11 +451,7 @@ int LuaPseudoRandom::gc_object(lua_State *L)
 
 LuaPseudoRandom *LuaPseudoRandom::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPseudoRandom **)ud;
+	return *(LuaPseudoRandom **)luaL_checkudata(L, narg, className);
 }
 
 
@@ -560,11 +546,7 @@ int LuaPcgRandom::gc_object(lua_State *L)
 
 LuaPcgRandom *LuaPcgRandom::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaPcgRandom **)ud;
+	return *(LuaPcgRandom **)luaL_checkudata(L, narg, className);
 }
 
 
@@ -675,11 +657,7 @@ int LuaSecureRandom::gc_object(lua_State *L)
 
 LuaSecureRandom *LuaSecureRandom::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-	return *(LuaSecureRandom **)ud;
+	return *(LuaSecureRandom **)luaL_checkudata(L, narg, className);
 }
 
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -75,10 +75,7 @@ struct EnumString es_HudBuiltinElement[] =
 
 ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
 {
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud) luaL_typerror(L, narg, className);
-	return *(ObjectRef**)ud;  // unbox pointer
+	return *(ObjectRef**)luaL_checkudata(L, narg, className);
 }
 
 ServerActiveObject* ObjectRef::getobject(ObjectRef *ref)

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -200,10 +200,7 @@ int LuaSettings::create_object(lua_State* L)
 LuaSettings* LuaSettings::checkobject(lua_State* L, int narg)
 {
 	NO_MAP_LOCK_REQUIRED;
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-	void *ud = luaL_checkudata(L, narg, className);
-	if(!ud) luaL_typerror(L, narg, className);
-	return *(LuaSettings**)ud;  // unbox pointer
+	return *(LuaSettings**)luaL_checkudata(L, narg, className);
 }
 
 const char LuaSettings::className[] = "Settings";

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -419,14 +419,7 @@ int LuaVoxelManip::create_object(lua_State *L)
 LuaVoxelManip *LuaVoxelManip::checkobject(lua_State *L, int narg)
 {
 	NO_MAP_LOCK_REQUIRED;
-
-	luaL_checktype(L, narg, LUA_TUSERDATA);
-
-	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud)
-		luaL_typerror(L, narg, className);
-
-	return *(LuaVoxelManip **)ud;  // unbox pointer
+	return *(LuaVoxelManip **)luaL_checkudata(L, narg, className);
 }
 
 void LuaVoxelManip::Register(lua_State *L)

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -142,6 +142,7 @@ SoundBuffer *load_opened_ogg_file(OggVorbis_File *oggFile,
 		if(bytes < 0)
 		{
 			ov_clear(oggFile);
+			delete snd;
 			infostream << "Audio: Error decoding "
 				<< filename_for_logging << std::endl;
 			return NULL;

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -158,6 +158,7 @@ public:
 	}
 	T & operator[](unsigned int i) const
 	{
+		assert(data != NULL && i < m_size);
 		return data[i];
 	}
 	T * operator*() const

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -36,8 +36,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <new>
 
-#include <config.h>
+#include "config.h"
 
 #if USE_SYSTEM_GMP || defined (__ANDROID__) || defined (ANDROID)
 	#include <gmp.h>
@@ -444,7 +445,7 @@ static void hash_num( SRP_HashAlgorithm alg, const mpz_t n, unsigned char *dest 
 	int nbytes = mpz_num_bytes(n);
 	unsigned char *bin = (unsigned char *) srp_alloc(nbytes);
 	if(!bin)
-		return;
+		throw std::bad_alloc();
 	mpz_to_bin(n, bin);
 	hash(alg, bin, nbytes, dest);
 	srp_free(bin);


### PR DESCRIPTION
Some of these were harmless warnings, but a few were substantial bugs.
- `m_camera` was unused.
- There were possible null dereferences with `puncher`, `e` (GUIElement),
  `m_mesh`, and `biome`.
- `time_of_day` was set and immediately reset.
- `drop` was called too hastily.
- `set_lists` Inventory copying was broken (pointer was copied instead of value).
- `getCraftingResult`'s return value was ignored.
- `max_node_level` was set but never used.
- There was a false positive in `handleCommand_DeleteParticleSpawner`, but
  the code could be easily cleaned up to avoid it, so I changed it.
- `lasttime` and `noisey` were set but not used (they're set in the following loops).
- `chunk_name` and `code` could leak in `safeLoadFile`.
- `snd` could leak in `load_opened_ogg_file`.
- There was another false positive in `checkobject`, but it duplicated checks
  from `luaL_checkudata`, so I simplified it a bunch, and removed the false
  positive in the process.
- `generate_M` could use uninitialized data if `hash_num` failed to allocate
  memory and returned without setting it's parameters.

Also, this revealed that `Mapgen*::generateBiomes` and `checkobject`
should be de-duplicated, although that's left for a future commit.
