### PR TITLE
Make plantlike drawtype more fun.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -578,6 +578,22 @@ node definition:
     ^ The rotation of this node is stored in param2. Plants are rotated this way.
       Values range 0 - 179. The value stored in param2 is multiplied by two to
       get the actual rotation of the node.
+    paramtype2 == "meshoptions"
+    ^ Only valid for "plantlike". The value of param2 becomes a bitfield which can
+      be used to change how the client draws plantlike nodes. Bits 0, 1 and 2 form
+      a mesh selector. Currently the following meshes are choosable:
+        0 = a "x" shaped plant (ordinary plant)
+        1 = a "+" shaped plant (just rotated 45 degrees)
+        2 = a "*" shaped plant with 3 faces instead of 2
+        3 = a "#" shaped plant with 4 faces instead of 2
+        4 = a "#" shaped plant with 4 faces that lean outwards
+        5-7 are unused and reserved for future meshes.
+      Bits 3 through 7 are optional flags that can be combined and give these
+      effects:
+        bit 3 (0x08) - Makes the plant slightly vary placement horizontally
+        bit 4 (0x10) - Makes the plant mesh 1.4x larger
+        bit 5 (0x20) - Moves each face randomly a small bit down (1/8 max)
+        bits 6-7 are reserved for future use.
     collision_box = {
       type = "fixed",
       fixed = {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -136,9 +136,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		backface_culling: backwards compatibility for playing with
 		newer client on pre-27 servers.
 		Add nodedef v3 - connected nodeboxes
+	PROTOCOL_VERSION 28:
+		CPT2_MESHOPTIONS
 */
 
-#define LATEST_PROTOCOL_VERSION 27
+#define LATEST_PROTOCOL_VERSION 28
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -387,7 +387,10 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, post_effect_color.getGreen());
 	writeU8(os, post_effect_color.getBlue());
 	writeU8(os, param_type);
-	writeU8(os, param_type_2);
+	if ((protocol_version < 28) && (param_type_2 == CPT2_MESHOPTIONS))
+		writeU8(os, CPT2_NONE);
+	else
+		writeU8(os, param_type_2);
 	writeU8(os, is_ground_content);
 	writeU8(os, light_propagates);
 	writeU8(os, sunlight_propagates);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -65,6 +65,8 @@ enum ContentParamType2
 	CPT2_LEVELED,
 	// 2D rotation for things like plants
 	CPT2_DEGROTATE,
+	// Mesh options for plants
+	CPT2_MESHOPTIONS
 };
 
 enum LiquidType

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -58,6 +58,7 @@ struct EnumString ScriptApiNode::es_ContentParamType2[] =
 		{CPT2_WALLMOUNTED, "wallmounted"},
 		{CPT2_LEVELED, "leveled"},
 		{CPT2_DEGROTATE, "degrotate"},
+		{CPT2_MESHOPTIONS, "meshoptions"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
Adds several new ways that the plantlike drawtype mesh can be changed.

This requires paramtype2 = "meshoptions" to be set in the node
definition. The drawtype for these nodes should be "plantlike".

These modifications are all done using param2. This field is now
a complex bitfield that allows some or more of the combinations to
be chosen, and the mesh draw code will choose the options based as
needed for each plantlike node.

bit layout:
bits 0, 1 and 2 (values 0x1 through 0x7) are for choosing the plant
mesh shape:
  0 - ordinary plantlike plant ("x" shaped)
  1 - ordinary plant, but rotated 45 degrees ("+" shaped)
  2 - a plant with 3 faces ("*" shaped)
  3 - a plant with 4 faces ("#" shaped)
  4 through 7 are unused and reserved for future mesh shapes.

bit 3 (0x8) causes the plant to be randomly offset in the x,z
plane. The plant should fall within the 1x1x1 nodebox if regularly
sized.

bit 4 (0x10) causes the plant mesh to grow by sqrt(2), and will cause
the plant mesh to fill out 1x1x1, and appear slightly larger. Texture
makers will want to make their plant texture 23x16 pixels to have the
best visual fit in 1x1x1 size.

bit 5 (0x20) through bit 7 (0x80) are unused and reserved for
future use.

!(https://youtu.be/qWuI664krsI)
- [X] - CPT2_MESHOPTIONS
- [X] - don't stretch pixels
- [X] - Reorganize bitfield
- [x] - Docs
