### PR TITLE
Decoration API: Allow rotation of simple decorations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -546,9 +546,10 @@ node definition:
     ^ The rotation of the node is stored in param2. Furnaces and chests are
       rotated this way. Can be made by using minetest.dir_to_facedir().
       Values range 0 - 23
-      facedir modulo 4 = axisdir
+      facedir / 4 = axis direction:
       0 = y+    1 = z+    2 = z-    3 = x+    4 = x-    5 = y-
-      facedir's two less significant bits are rotation around the axis
+      facedir modulo 4 = rotation around that axis
+      facedir 0, 1, 2, 3 = rotations around the +y axis
     paramtype2 == "leveled"
     paramtype2 == "degrotate"
     ^ The rotation of this node is stored in param2. Plants are rotated this way.
@@ -3767,6 +3768,11 @@ Definition tables
         num_spawn_by = 1,
     --  ^ Number of spawn_by nodes that must be surrounding the decoration position to occur.
     --  ^ If absent or -1, decorations occur next to any nodes.
+        rotation = 3,
+    --  ^ Specified rotation is an integer between 0 and 23,
+    --  ^ a value of 24 enables 24-orientation random rotation.
+    --  ^ See 'paramtype2 == "facedir"' in 'Nodes' section above.
+    --  ^ Defaults to 0 if absent.
 
         ----- Schematic-type parameters
         schematic = "foobar.mts",

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -26,12 +26,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 
 FlagDesc flagdesc_deco[] = {
-	{"place_center_x", DECO_PLACE_CENTER_X},
-	{"place_center_y", DECO_PLACE_CENTER_Y},
-	{"place_center_z", DECO_PLACE_CENTER_Z},
+	{"place_center_x",  DECO_PLACE_CENTER_X},
+	{"place_center_y",  DECO_PLACE_CENTER_Y},
+	{"place_center_z",  DECO_PLACE_CENTER_Z},
 	{"force_placement", DECO_FORCE_PLACEMENT},
-	{"liquid_surface", DECO_LIQUID_SURFACE},
-	{NULL,             0}
+	{"liquid_surface",  DECO_LIQUID_SURFACE},
+	{NULL,              0}
 };
 
 
@@ -306,6 +306,8 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 
 	bool force_placement = (flags & DECO_FORCE_PLACEMENT);
 
+	u8 rot = (rotation == 24) ? pr->range(0, 23) : rotation;
+
 	v3s16 em = vm->m_area.getExtent();
 	u32 vi = vm->m_area.index(p);
 	for (int i = 0; i < height; i++) {
@@ -317,6 +319,7 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 			break;
 
 		vm->m_data[vi] = MapNode(c_place);
+		vm->m_data[vi].param2 = rot;
 	}
 
 	return 1;

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -101,6 +101,7 @@ public:
 	s16 deco_height;
 	s16 deco_height_max;
 	s16 nspawnby;
+	s16 rotation;
 };
 
 class DecoSchematic : public Decoration {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -870,6 +870,7 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 	deco->deco_height     = getintfield_default(L, index, "height", 1);
 	deco->deco_height_max = getintfield_default(L, index, "height_max", 0);
 	deco->nspawnby        = getintfield_default(L, index, "num_spawn_by", -1);
+	deco->rotation        = getintfield_default(L, index, "rotation", 0);
 
 	if (deco->deco_height <= 0) {
 		errorstream << "register_decoration: simple decoration height"


### PR DESCRIPTION
Specified or random 24-value rotation
///////////////////////////
```
+        rotation = 3,
+    --  ^ Specified rotation is an integer between 0 and 23,
+    --  ^ a value of 24 enables 24-orientation random rotation.
+    --  ^ See 'paramtype2 == "facedir"' in 'Nodes' section above.
+    --  ^ Defaults to 0 if absent.
```