### PR TITLE
Add syntax fix for torch generation in dungeons (developer feature)

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -44,7 +44,7 @@ DungeonGen::DungeonGen(Mapgen *mapgen, DungeonParams *dparams)
 	this->vm = mapgen->vm;
 
 #ifdef DGEN_USE_TORCHES
-	c_torch  = ndef->getId("default:torch");
+	c_torch  = mg->ndef->getId("default:torch");
 #endif
 
 	if (dparams) {


### PR DESCRIPTION
This corrects the syntax error in order to avoid later headaches/delays.