### PR TITLE
Add client-side translations

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -679,8 +679,8 @@ ChatBackend::~ChatBackend()
 
 void ChatBackend::addMessage(std::wstring name, std::wstring text)
 {
-	name = removeChatEscapes(name);
-	text = removeChatEscapes(text);
+	name = removeEscapes(name);
+	text = removeEscapes(text);
 
 	// Note: A message may consist of multiple lines, for example the MOTD.
 	WStrfnd fnd(text);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3728,7 +3728,7 @@ void Game::handlePointingAtNode(GameRunData *runData,
 	NodeMetadata *meta = map.getNodeMetadata(nodepos);
 
 	if (meta) {
-		infotext = utf8_to_wide(meta->getString("infotext"));
+		infotext = removeEscapes(utf8_to_wide(meta->getString("infotext")));
 	} else {
 		MapNode n = map.getNodeNoEx(nodepos);
 
@@ -3804,13 +3804,13 @@ void Game::handlePointingAtObject(GameRunData *runData,
 		const v3f &player_position,
 		bool show_debug)
 {
-	infotext = utf8_to_wide(runData->selected_object->infoText());
+	infotext = removeEscapes(utf8_to_wide(runData->selected_object->infoText()));
 
 	if (show_debug) {
 		if (infotext != L"") {
 			infotext += L"\n";
 		}
-		infotext += utf8_to_wide(runData->selected_object->debugInfoText());
+		infotext += removeEscapes(utf8_to_wide(runData->selected_object->debugInfoText()));
 	}
 
 	if (input->getLeftState()) {

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -609,8 +609,6 @@ void GUIFormSpecMenu::parseButton(parserData* data,std::string element,
 		if(!data->explicit_size)
 			warningstream<<"invalid use of button without a size[] element"<<std::endl;
 
-		label = unescape_string(label);
-
 		std::wstring wlabel = utf8_to_wide(label);
 
 		FieldSpec spec(
@@ -733,7 +731,6 @@ void GUIFormSpecMenu::parseTable(parserData* data,std::string element)
 		geom.X = stof(v_geom[0]) * (float)spacing.X;
 		geom.Y = stof(v_geom[1]) * (float)spacing.Y;
 
-
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
 		FieldSpec spec(
@@ -746,7 +743,8 @@ void GUIFormSpecMenu::parseTable(parserData* data,std::string element)
 		spec.ftype = f_Table;
 
 		for (unsigned int i = 0; i < items.size(); ++i) {
-			items[i] = unescape_string(items[i]);
+			items[i] = unescape_string(wide_to_utf8(
+				removeEscapes(utf8_to_wide(items[i]))));
 		}
 
 		//now really show table
@@ -818,7 +816,8 @@ void GUIFormSpecMenu::parseTextList(parserData* data,std::string element)
 		spec.ftype = f_Table;
 
 		for (unsigned int i = 0; i < items.size(); ++i) {
-			items[i] = unescape_string(items[i]);
+			items[i] = unescape_string(wide_to_utf8(
+				removeEscapes(utf8_to_wide(items[i]))));
 		}
 
 		//now really show list
@@ -889,7 +888,7 @@ void GUIFormSpecMenu::parseDropDown(parserData* data,std::string element)
 		}
 
 		for (unsigned int i=0; i < items.size(); i++) {
-			e->addItem(utf8_to_wide(items[i]).c_str());
+			e->addItem(unescape_string(removeEscapes(utf8_to_wide(items[i]))).c_str());
 		}
 
 		if (str_initial_selection != "")
@@ -929,8 +928,6 @@ void GUIFormSpecMenu::parsePwdField(parserData* data,std::string element)
 		geom.Y = m_btn_height*2;
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
-
-		label = unescape_string(label);
 
 		std::wstring wlabel = utf8_to_wide(label);
 
@@ -995,8 +992,6 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 	if(m_form_src)
 		default_val = m_form_src->resolveText(default_val);
 
-	default_val = unescape_string(default_val);
-	label = unescape_string(label);
 
 	std::wstring wlabel = utf8_to_wide(label);
 
@@ -1093,9 +1088,6 @@ void GUIFormSpecMenu::parseTextArea(parserData* data,
 	if(m_form_src)
 		default_val = m_form_src->resolveText(default_val);
 
-
-	default_val = unescape_string(default_val);
-	label = unescape_string(label);
 
 	std::wstring wlabel = utf8_to_wide(label);
 
@@ -1197,7 +1189,6 @@ void GUIFormSpecMenu::parseLabel(parserData* data,std::string element)
 		if(!data->explicit_size)
 			warningstream<<"invalid use of label without a size[] element"<<std::endl;
 
-		text = unescape_string(text);
 		std::vector<std::string> lines = split(text, '\n');
 
 		for (unsigned int i = 0; i != lines.size(); i++) {
@@ -1243,7 +1234,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data,std::string element)
 		((parts.size() > 2) && (m_formspec_version > FORMSPEC_API_VERSION)))
 	{
 		std::vector<std::string> v_pos = split(parts[0],',');
-		std::wstring text = utf8_to_wide(unescape_string(parts[1]));
+		std::wstring text = unescape_string(removeEscapes(utf8_to_wide(parts[1])));
 
 		MY_CHECKPOS("vertlabel",1);
 
@@ -1330,7 +1321,6 @@ void GUIFormSpecMenu::parseImageButton(parserData* data,std::string element,
 
 		image_name = unescape_string(image_name);
 		pressed_image_name = unescape_string(pressed_image_name);
-		label = unescape_string(label);
 
 		std::wstring wlabel = utf8_to_wide(label);
 
@@ -1430,7 +1420,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data,std::string element)
 		e->setNotClipped(true);
 
 		for (unsigned int i = 0; i < buttons.size(); i++) {
-			e->addTab(utf8_to_wide(buttons[i]).c_str(), -1);
+			e->addTab(unescape_string(removeEscapes(utf8_to_wide(buttons[i]))).c_str(), -1);
 		}
 
 		if ((tab_index >= 0) &&
@@ -1489,7 +1479,6 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data,std::string element)
 						m_default_tooltip_bgcolor,
 						m_default_tooltip_color);
 
-		label = unescape_string(label);
 		FieldSpec spec(
 			name,
 			utf8_to_wide(label),
@@ -1604,14 +1593,14 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, std::string element)
 	std::vector<std::string> parts = split(element,';');
 	if (parts.size() == 2) {
 		std::string name = parts[0];
-		m_tooltips[name] = TooltipSpec(unescape_string(parts[1]),
+		m_tooltips[name] = TooltipSpec(parts[1],
 			m_default_tooltip_bgcolor, m_default_tooltip_color);
 		return;
 	} else if (parts.size() == 4) {
 		std::string name = parts[0];
 		video::SColor tmp_color1, tmp_color2;
 		if ( parseColorString(parts[2], tmp_color1, false) && parseColorString(parts[3], tmp_color2, false) ) {
-			m_tooltips[name] = TooltipSpec(unescape_string(parts[1]),
+			m_tooltips[name] = TooltipSpec(parts[1],
 				tmp_color1, tmp_color2);
 			return;
 		}
@@ -2243,8 +2232,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 
 			// Draw tooltip
 			std::string tooltip_text = "";
-			if (hovering && !m_selected_item)
+			if (hovering && !m_selected_item) {
 				tooltip_text = item.getDefinition(m_gamedef->idef()).description;
+				tooltip_text = wide_to_utf8(removeEscapes(utf8_to_wide(tooltip_text)));
+			}
 			if (tooltip_text != "") {
 				std::vector<std::string> tt_rows = str_split(tooltip_text, '\n');
 				m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -240,37 +240,6 @@ GUITable* GUIFormSpecMenu::getTable(const std::string &tablename)
 	return 0;
 }
 
-static std::vector<std::string> split(const std::string &s, char delim)
-{
-	std::vector<std::string> tokens;
-
-	std::string current = "";
-	bool last_was_escape = false;
-	for (unsigned int i = 0; i < s.size(); i++) {
-		char si = s.c_str()[i];
-		if (last_was_escape) {
-			current += '\\';
-			current += si;
-			last_was_escape = false;
-		} else {
-			if (si == delim) {
-				tokens.push_back(current);
-				current = "";
-				last_was_escape = false;
-			} else if (si == '\\') {
-				last_was_escape = true;
-			} else {
-				current += si;
-				last_was_escape = false;
-			}
-		}
-	}
-	//push last element
-	tokens.push_back(current);
-
-	return tokens;
-}
-
 void GUIFormSpecMenu::parseSize(parserData* data,std::string element)
 {
 	std::vector<std::string> parts = split(element,',');

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "modalMenu.h"
 #include "guiTable.h"
 #include "network/networkprotocol.h"
+#include "util/string.h"
 
 class IGameDef;
 class InventoryManager;
@@ -199,10 +200,10 @@ class GUIFormSpecMenu : public GUIModalMenu
 		FieldSpec(const std::string &name, const std::wstring &label,
 				const std::wstring &fdeflt, int id) :
 			fname(name),
-			flabel(label),
-			fdefault(fdeflt),
 			fid(id)
 		{
+			flabel = unescape_string(removeEscapes(label));
+			fdefault = unescape_string(removeEscapes(fdeflt));
 			send = false;
 			ftype = f_Unknown;
 			is_exit = false;
@@ -235,10 +236,11 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		TooltipSpec(std::string a_tooltip, irr::video::SColor a_bgcolor,
 				irr::video::SColor a_color):
-			tooltip(a_tooltip),
 			bgcolor(a_bgcolor),
 			color(a_color)
 		{
+			tooltip = unescape_string(wide_to_utf8(
+				removeEscapes(utf8_to_wide(a_tooltip))));
 		}
 		std::string tooltip;
 		irr::video::SColor bgcolor;
@@ -252,18 +254,18 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		StaticTextSpec(const std::wstring &a_text,
 				const core::rect<s32> &a_rect):
-			text(a_text),
 			rect(a_rect),
 			parent_button(NULL)
 		{
+			text = unescape_string(removeEscapes(a_text));
 		}
 		StaticTextSpec(const std::wstring &a_text,
 				const core::rect<s32> &a_rect,
 				gui::IGUIButton *a_parent_button):
-			text(a_text),
 			rect(a_rect),
 			parent_button(a_parent_button)
 		{
+			text = unescape_string(removeEscapes(a_text));
 		}
 		std::wstring text;
 		core::rect<s32> rect;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "hud.h"
 #include "settings.h"
 #include "util/numeric.h"
+#include "util/string.h"
 #include "log.h"
 #include "gamedef.h"
 #include "itemdef.h"
@@ -313,7 +314,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset) {
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
 				core::rect<s32> size(0, 0, e->scale.X, text_height * e->scale.Y);
-				std::wstring text = utf8_to_wide(e->text);
+				std::wstring text = removeEscapes(utf8_to_wide(e->text));
 				core::dimension2d<u32> textsize = font->getDimension(text.c_str());
 				v2s32 offset((e->align.X - 1.0) * (textsize.Width / 2),
 				             (e->align.Y - 1.0) * (textsize.Height / 2));
@@ -348,11 +349,11 @@ void Hud::drawLuaElements(const v3s16 &camera_offset) {
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
-				std::wstring text = utf8_to_wide(e->name);
+				std::wstring text = removeEscapes(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
 				std::ostringstream os;
 				os << distance << e->text;
-				text = utf8_to_wide(os.str());
+				text = removeEscapes(utf8_to_wide(os.str()));
 				pos.Y += text_height;
 				font->draw(text.c_str(), size + pos, color);
 				break; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -465,6 +465,7 @@ static bool init_common(const Settings &cmd_args, int argc, char *argv[])
 
 	init_gettext(porting::path_locale.c_str(),
 		g_settings->get("language"), argc, argv);
+	init_language(gettext("LANG_CODE"));
 
 	return true;
 }

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -729,7 +729,7 @@ static bool parseNamedColorString(const std::string &value, video::SColor &color
 	return true;
 }
 
-std::wstring removeChatEscapes(const std::wstring &s) {
+std::wstring removeEscapes(const std::wstring &s) {
 	std::wstring output;
 	size_t i = 0;
 	while (i < s.length()) {

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -492,6 +492,40 @@ inline std::basic_string<T> unescape_string(const std::basic_string<T> &s)
 	return res;
 }
 
+template <typename T>
+std::vector<std::basic_string<T> >
+  split(const std::basic_string<T> &s, T delim)
+{
+	std::vector<std::basic_string<T> > tokens;
+
+	std::basic_string<T> current;
+	bool last_was_escape = false;
+	for (unsigned int i = 0; i < s.length(); i++) {
+		T si = s[i];
+		if (last_was_escape) {
+			current += '\\';
+			current += si;
+			last_was_escape = false;
+		} else {
+			if (si == delim) {
+				tokens.push_back(current);
+				current = std::basic_string<T>();
+				last_was_escape = false;
+			} else if (si == '\\') {
+				last_was_escape = true;
+			} else {
+				current += si;
+				last_was_escape = false;
+			}
+		}
+	}
+	//push last element
+	tokens.push_back(current);
+
+	return tokens;
+}
+
+void init_language(std::string language);
 
 /**
  * Checks that all characters in \p to_check are a decimal digits.

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -387,12 +387,12 @@ inline void str_replace(std::string &str, const std::string &pattern,
 }
 
 /**
- * Remove all chat escape sequences in \p s.
+ * Remove all escape sequences in \p s.
  *
  * @param s The string in which to remove escape sequences.
  * @return \p s, with escape sequences removed.
  */
-std::wstring removeChatEscapes(const std::wstring &s);
+std::wstring removeEscapes(const std::wstring &s);
 
 /**
  * Replace all occurrences of the character \p from in \p str with \p to.
@@ -476,7 +476,7 @@ inline std::string wrap_rows(const std::string &from,
  * Removes backslashes from an escaped string (FormSpec strings)
  */
 template <typename T>
-inline std::basic_string<T> unescape_string(std::basic_string<T> &s)
+inline std::basic_string<T> unescape_string(const std::basic_string<T> &s)
 {
 	std::basic_string<T> res;
 


### PR DESCRIPTION
Requires #3948 to be merged in a stable release before this is merged.

This adds an escape sequence for translations : for example, the item description "Cobblestone\v(translate;11;fr:Cobble FR;de:Cobble DE)" will show up as "Cobblestone" on clients that don't have this pr (but that have #3948) and on clients whose locale is different from "fr" and "de", and on new clients, it will show up as "Cobble FR" if the client is set to "fr" locale, and "Cobble DE" if locale is "de".

Because locale detection is complicated, and to ensure consistency with gettext locale, the name of the locale is detected by translating the string "LANG_CODE", which should be translated to the corresponding language code in all languages.

This is WIP; still missing are:
- [ ] Documentation
- [ ] Some code that would do the equivalent of what intllib currently does, but producing text for all languages
- [ ] Translating the contents of builtin
- [ ] Maybe find some way to add the translation of "LANG_CODE" to all languages automatically.
