### PR TITLE
Set log level for field exist warning same as warning message

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -740,7 +740,7 @@ void warn_if_field_exists(lua_State *L, int table,
 	if (!lua_isnil(L, -1)) {
 		warningstream << "Field \"" << name << "\": "
 				<< message << std::endl;
-		infostream << script_get_backtrace(L) << std::endl;
+		warningstream << script_get_backtrace(L) << std::endl;
 	}
 	lua_pop(L, 1);
 }


### PR DESCRIPTION
Without this backtrace you would get warnings with no context, leaving you to grep through all your mods for, eg, tile_images.
