### PR TITLE
Clearer explanation of [colorize with alpha

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -361,9 +361,9 @@ Colorize the textures with the given color.
 it is an int, then it specifies how far to interpolate between the
 colors where 0 is only the texture color and 255 is only `<color>`. If
 omitted, the alpha of `<color>` will be used as the ratio.  If it is
-the word "`alpha`", then the alpha of the color will be multiplied with
-the alpha of the texture with the RGB of the color replacing the RGB of
-the texture.
+the word "`alpha`", then each texture pixel will contain the RGB of
+`<color>` and the alpha of `<color>` multiplied by the alpha of the
+texture pixel.
 
 Sounds
 ------


### PR DESCRIPTION
The doc text from 01ae43c48009f816f4649fae2f7f6997452aa6cf could have been clearer, so I tried again.