### PR TITLE
Mgv5: Optimise tunnels, add biome material in entrances

### DIFF
--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -53,7 +53,7 @@ public:
 	BiomeManager *bmgr;
 
 	int ystride;
-	int zstride;
+	int zstride_1d;
 	u32 spflags;
 
 	v3s16 node_min;


### PR DESCRIPTION
Place biome top node on tunnel entrance floor
Instead of doing nothing at node_max.Y + 1 use 1-down
overgeneration for tunnel generation and noisemaps
///////////////////////////////////////

Combination of #3558 and #3959 but for mgv5.
The implementation of 3D noise tunnels is now identical to the other mapgens.
Tested.