### PR TITLE
Add basic_priv property to privileges

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -182,14 +182,16 @@ core.register_chatcommand("grant", {
 		local privs = core.get_player_privs(grantname)
 		local privs_unknown = ""
 		for priv, _ in pairs(grantprivs) do
-			if priv ~= "interact" and priv ~= "shout" and
-					not core.check_player_privs(name, {privs=true}) then
-				return false, "Your privileges are insufficient."
-			end
-			if not core.registered_privileges[priv] then
+			local def = core.registered_privileges[priv]
+			if def then
+				if not def.basic_priv and
+						not core.check_player_privs(name, {privs=true}) then
+					return false, "Your privileges are insufficient."
+				end
+				privs[priv] = true
+			else
 				privs_unknown = privs_unknown .. "Unknown privilege: " .. priv .. "\n"
 			end
-			privs[priv] = true
 		end
 		if privs_unknown ~= "" then
 			return false, privs_unknown
@@ -224,9 +226,12 @@ core.register_chatcommand("revoke", {
 		local revoke_privs = core.string_to_privs(revoke_priv_str)
 		local privs = core.get_player_privs(revoke_name)
 		for priv, _ in pairs(revoke_privs) do
-			if priv ~= "interact" and priv ~= "shout" and
-					not core.check_player_privs(name, {privs=true}) then
-				return false, "Your privileges are insufficient."
+			local def = core.registered_privileges[priv]
+			if def then
+				if not def.basic_priv and
+						not core.check_player_privs(name, {privs=true}) then
+					return false, "Your privileges are insufficient."
+				end
 			end
 		end
 		if revoke_priv_str == "all" then

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -25,7 +25,14 @@ function core.register_privilege(name, param)
 	core.registered_privileges[name] = def
 end
 
-core.register_privilege("interact", "Can interact with things and modify the world")
+core.register_privilege("interact", {
+	description = "Can interact with things and modify the world",
+	basic_priv = true
+})
+core.register_privilege("shout", {
+	description = "Can speak in chat",
+	basic_priv = true
+})
 core.register_privilege("teleport", "Can use /teleport command")
 core.register_privilege("bring", "Can teleport other players")
 core.register_privilege("settime", "Can use /time")
@@ -33,7 +40,6 @@ core.register_privilege("privs", "Can modify privileges")
 core.register_privilege("basic_privs", "Can modify 'shout' and 'interact' privileges")
 core.register_privilege("server", "Can do server maintenance stuff")
 core.register_privilege("protection_bypass", "Can bypass node protection in the world")
-core.register_privilege("shout", "Can speak in chat")
 core.register_privilege("ban", "Can ban and unban players")
 core.register_privilege("kick", "Can kick players")
 core.register_privilege("give", "Can use /give and /giveme")
@@ -51,4 +57,3 @@ core.register_privilege("noclip", {
 	give_to_singleplayer = false,
 })
 core.register_privilege("rollback", "Can use the rollback functionality")
-

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1920,7 +1920,14 @@ Call these functions only at load time!
 * `minetest.register_chatcommand(cmd, chatcommand definition)`
 * `minetest.register_privilege(name, definition)`
     * `definition`: `"description text"`
-    * `definition`: `{ description = "description text", give_to_singleplayer = boolean, -- default: true }`
+    * `definition`:
+
+            {
+                description = "description text",
+                basic_priv = true, -- players with the basic priv can grant/revoke this.
+                give_to_singleplayer = boolean, -- default: true
+            }
+
 * `minetest.register_authentication_handler(handler)`
     * See `minetest.builtin_auth_handler` in `builtin.lua` for reference
 


### PR DESCRIPTION
Privileges players could grant with `basic_privs` was previously hard coded. This change makes it no longer hard coded.

``` Lua
minetest.register_privilege("interact", {
    description = "Can interact with things and modify the world",
    basic_priv = true
})
```
