### PR TITLE
Document hpchange callback ordering thing

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1870,7 +1870,7 @@ Call these functions only at load time!
     * `modifier`: when true, the function should return the actual hp_change.
       Note: modifiers only get a temporary hp_change that can be modified by later modifiers.
       modifiers can return true as a second argument to stop the execution of further functions.
-      Non-modifiers execute only after modifiers have run.
+      Non-modifiers receive the final hp change calculated by the modifiers.
 * `minetest.register_on_respawnplayer(func(ObjectRef))`
      * Called when player is to be respawned
      * Called _before_ repositioning of player occurs

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1870,6 +1870,7 @@ Call these functions only at load time!
     * `modifier`: when true, the function should return the actual hp_change.
       Note: modifiers only get a temporary hp_change that can be modified by later modifiers.
       modifiers can return true as a second argument to stop the execution of further functions.
+      Non-modifiers execute only after modifiers have run.
 * `minetest.register_on_respawnplayer(func(ObjectRef))`
      * Called when player is to be respawned
      * Called _before_ repositioning of player occurs


### PR DESCRIPTION
Callbacks registered by register_on_player_hpchange are ordered so that non-modifiers are called after modifiers are called. Credit to @TeTpaAka who mentioned this previously-undocumented feature in #3799.