### PR TITLE
falling: walk 4 additional diagonally down directions.

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -182,6 +182,10 @@ end
 -- Down first as likely case, but always before self. The same with sides.
 -- Up must come last, so that things above self will also fall all at once.
 local nodeupdate_neighbors = {
+	{x = -1, y = -1, z = 0},
+	{x = 1, y = -1, z = 0},
+	{x = 0, y = -1, z = -1},
+	{x = 0, y = -1, z = 1},
 	{x = 0, y = -1, z = 0},
 	{x = -1, y = 0, z = 0},
 	{x = 1, y = 0, z = 0},
@@ -226,10 +230,10 @@ function nodeupdate(p)
 				n = n - 1
 				-- If there's nothing left on the stack, and no
 				-- more sides to walk to, we're done and can exit
-				if n == 0 and v == 7 then
+				if n == 0 and v == 11 then
 					return
 				end
-			until v < 7
+			until v < 11
 			-- The next round walk the next neighbor in list.
 			v = v + 1
 		else


### PR DESCRIPTION
This seems very little cost and matches the old behavior more
closely. This will cause some more falling nodes to get added
to falling clusters. With the efficiency of the algorithm, this
really doesn't do much damage.