### PR TITLE
mainmenu: Fix protocol check for favorite server list

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -290,7 +290,7 @@ end
 
 --------------------------------------------------------------------------------
 function is_server_protocol_compat(server_proto_min, server_proto_max)
-	return not ((min_supp_proto > (server_proto_max or 24)) or (max_supp_proto < (server_proto_min or 13)))
+	return min_supp_proto <= (server_proto_max or 24) and max_supp_proto >= (server_proto_min or 13)
 end
 --------------------------------------------------------------------------------
 function is_server_protocol_compat_or_error(server_proto_min, server_proto_max)


### PR DESCRIPTION
Connecting to a server with the favorite server list throws this error:
```
Protocol version mismatch. Server enforces protocol version 13. We support protocol versions between version 25 and 27.
```
**How to reproduce**
Disable the setting `send_pre_v25_init (Support older servers)` and connect to any server on your favorite server list.

**Bug source**
This happens when the favorite server list does not know the accepted protocol ranges. Thus, the variables `menudata.favorites[event.row].proto_min` and `.proto_max` will be set to `nil`. In the compatibility checking function `is_server_protocol_compat` they're replaced by a hardcoded protocol version of `24`. 25 as minimal proto version is bigger than 24, thus it will throw this error.

**Diff comment**
The De Morgan's logic conversion (or -> and) was done to make the function easier to understand. Comments please.