### PR TITLE
Mgv7: Combine mountain terrain generation with base terrain generation

### DIFF
--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -59,6 +59,7 @@ public:
 	BiomeManager *bmgr;
 
 	int ystride;
+	int zstride_1u1d;
 	int zstride_1d;
 	u32 spflags;
 
@@ -113,15 +114,11 @@ public:
 
 	void calculateNoise();
 
-	virtual int generateTerrain();
-	void generateBaseTerrain(s16 *stone_surface_min_y, s16 *stone_surface_max_y);
-	int generateMountainTerrain(s16 ymax);
+	int generateTerrain();
 	void generateRidgeTerrain();
 
 	MgStoneType generateBiomes(float *heat_map, float *humidity_map);
 	void dustTopNodes();
-
-	//void addTopNodes();
 
 	void generateCaves(s16 max_stone_y);
 };


### PR DESCRIPTION
Previous mountain terrain generation was by necessity placing
stone in air, this was removing air from any overgenerated
structures such as tunnels, dungeons and large caves
Moving it into the base terrain generation loop ensures that
only 'ignore' is replaced

generateRidgeTerrain: only return if node_max.Y < water_level - 16
Previously, if water level was set a few nodes above a mapchunk
border the river channel was only partially excavated
///////////////////////////////////////////////

Fixes issue #4000 

Mountain generation is still optional, the flag is cached for use in the main generation loop.
Mountain noise calculation is moved back into 'calculateNoise' and enabled with the mountain flag.
Generation is simpler and slightly faster due to 2 loops being combined into 1.
If base terrain stone is placed now there is no unnecessary check to see if mountain stone should be placed, the mountain flag also disables this check.
The former 'generateTerrain' which included base terrain gen, mountain gen and ridge gen, has been removed. Now the main terrain loop and ridge gen are called directly from 'makeChunk'.

Tested.