### PR TITLE
mainmenu: Fix minetest.after timing

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -6,13 +6,13 @@
 
 local jobs = {}
 local time = 0.0
-local last = 0.0
+local last = core.get_us_time() / 1000000
 
 core.register_globalstep(function(dtime)
 	local new = core.get_us_time() / 1000000
 	if new > last then
 		time = time + (new - last)
-	else
+	elseif new < last then
 		-- Overflow, we may lose a little bit of time here but
 		-- only 1 tick max, potentially running timers slightly
 		-- too early.


### PR DESCRIPTION
```
local start_time = os.clock()

minetest.after(10, function()
	print("This function was called after ".. os.clock()-start_time .."s")
end)
```
Returns `This function was called after 7.0620000000001s`,  `This function was called after 0.45299999999997s` or any other value.
This bug was caused by the time calculation of the time `last`, which is initialized to zero. The time `new` instead starts with any value.

Tested this pull and got `This function was called after 10.469s` (some loading delay included).