### PR TITLE
Use system fonts and remove broken on android shaders

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -16,6 +16,7 @@ ROOT = $(shell pwd)
 GAMES_TO_COPY = minetest_game
 MODS_TO_COPY =
 
+ENABLE_SHADERS = 0
 
 VERSION_MAJOR := $(shell cat $(ROOT)/../../CMakeLists.txt | \
 	grep ^set\(VERSION_MAJOR\ | sed 's/)/ /' | cut -f2 -d' ')
@@ -731,7 +732,9 @@ assets : $(ASSETS_TIMESTAMP)
 	cp ${ROOT}/../../README.txt ${ROOT}/assets/Minetest;                       \
 	cp -r ${ROOT}/../../builtin ${ROOT}/assets/Minetest;                       \
 	mkdir ${ROOT}/assets/Minetest/client;                                      \
-#   cp -r ${ROOT}/../../client/shaders ${ROOT}/assets/Minetest/client;         \
+ifeq ($(ENABLE_SHADERS),1)                                                     \
+	cp -r ${ROOT}/../../client/shaders ${ROOT}/assets/Minetest/client;         \
+endif                                                                          \
 	cp ${ROOT}/../../doc/lgpl-2.1.txt ${ROOT}/assets/Minetest/LICENSE.txt;     \
 	mkdir ${ROOT}/assets/Minetest/fonts;                                       \
 	cp -r ${ROOT}/../../fonts/liberationsans ${ROOT}/assets/Minetest/fonts/;   \

--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -731,10 +731,10 @@ assets : $(ASSETS_TIMESTAMP)
 	cp ${ROOT}/../../README.txt ${ROOT}/assets/Minetest;                       \
 	cp -r ${ROOT}/../../builtin ${ROOT}/assets/Minetest;                       \
 	mkdir ${ROOT}/assets/Minetest/client;                                      \
-	cp -r ${ROOT}/../../client/shaders ${ROOT}/assets/Minetest/client;         \
+#   cp -r ${ROOT}/../../client/shaders ${ROOT}/assets/Minetest/client;         \
 	cp ${ROOT}/../../doc/lgpl-2.1.txt ${ROOT}/assets/Minetest/LICENSE.txt;     \
 	mkdir ${ROOT}/assets/Minetest/fonts;                                       \
-	cp -r ${ROOT}/../../fonts/*.ttf ${ROOT}/assets/Minetest/fonts/;            \
+	cp -r ${ROOT}/../../fonts/liberationsans ${ROOT}/assets/Minetest/fonts/;   \
 	mkdir ${ROOT}/assets/Minetest/games;                                       \
 	for game in ${GAMES_TO_COPY}; do                                           \
 	    cp -r ${ROOT}/../../games/$$game ${ROOT}/assets/Minetest/games/;       \

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -363,6 +363,10 @@ void set_default_settings(Settings *settings)
 		settings->setDefault("hud_scaling", "0.7");
 	}
 	settings->setDefault("curl_verify_cert","false");
+	
+	settings->setDefault("mono_font_path", "/system/fonts/DroidSansMono.ttf");
+	settings->setDefault("fallback_font_path", "/system/fonts/DroidSans.ttf");
+	
 #else
 	settings->setDefault("screen_dpi", "72");
 #endif


### PR DESCRIPTION
It works fine in MultiCraft many months.
These fonts are required in ANY version and ROMs. They used Google Apps too.
