### PR TITLE
Fix timer initialization.

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -6,7 +6,7 @@
 
 local jobs = {}
 local time = 0.0
-local last = 0.0
+local last = core.get_us_time() / 1000000
 
 core.register_globalstep(function(dtime)
 	local new = core.get_us_time() / 1000000


### PR DESCRIPTION
This fixes the problem that the first timer tick is an
overrun and causes all timers to expire immediately.

replaces #4003