### PR TITLE
Biomes: Make dust fallback 'ignore' to fix y = 63 lighting

### DIFF
--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -56,7 +56,7 @@ BiomeManager::BiomeManager(IGameDef *gamedef) :
 	b->m_nodenames.push_back("mapgen_water_source");
 	b->m_nodenames.push_back("mapgen_water_source");
 	b->m_nodenames.push_back("mapgen_river_water_source");
-	b->m_nodenames.push_back("air");
+	b->m_nodenames.push_back("ignore");
 	m_ndef->pendNodeResolve(b);
 
 	add(b);
@@ -138,5 +138,5 @@ void Biome::resolveNodeNames()
 	getIdFromNrBacklog(&c_water_top,   "mapgen_water_source",       CONTENT_AIR);
 	getIdFromNrBacklog(&c_water,       "mapgen_water_source",       CONTENT_AIR);
 	getIdFromNrBacklog(&c_river_water, "mapgen_river_water_source", CONTENT_AIR);
-	getIdFromNrBacklog(&c_dust,        "air",                       CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_dust,        "ignore",                    CONTENT_IGNORE);
 }


### PR DESCRIPTION
The shadow bug at y = 63 was caused by dark air being placed as dust,
when the biome dust was unspecified it was falling back to 'air'
In dustTopNodes only dust == 'ignore' will disable dust placement
///////////////////////////////////////////////////////

To fix #2759 
Approved by hmmmm http://irc.minetest.ru/minetest-dev/2016-04-21#i_4589113