### PR TITLE
tile.cpp: Automatically resize overlaying texture to base dimensions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -243,6 +243,7 @@ Example:
     default_dirt.png^default_grass_side.png
 
 `default_grass_side.png` is overlayed over `default_dirt.png`.
+The texture with the lower resolution will be automatically upscaled to the higher resolution texture.
 
 ### Texture grouping
 Textures can be grouped together by enclosing them in `(` and `)`.


### PR DESCRIPTION
Previous:
![screenshot_20160421_220250_](https://cloud.githubusercontent.com/assets/1497498/14722656/ce6808d8-080c-11e6-90fd-10b8bb1e012f.png)
After:
![screenshot_20160421_220224_](https://cloud.githubusercontent.com/assets/1497498/14722655/ce642a10-080c-11e6-9d8e-c5348343c4e0.png)
^ Graphical issue with dirt side was fixed

Issue source: #3987 
This pull resizes the overlay texture to the dimensions of the base texture.
~~Testing of conflicts with the texture modifiers is in progress.~~ :ok: 