### PR TITLE
Fix bug that was leading to oversized tooltips containing multiline text

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2253,7 +2253,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				this->bringToFront(m_tooltip_element);
 				m_tooltip_element->setText(utf8_to_wide(tooltip_text).c_str());
 				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
+				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
 				v2u32 screenSize = driver->getScreenSize();
 				int tooltip_offset_x = m_btn_height;
 				int tooltip_offset_y = m_btn_height;


### PR DESCRIPTION
There is no need to multiply by amount of rows because "m_tooltip_element->getTextHeight()" already returns right height