### PR TITLE
Mapgen: Make 3D noise tunnels' width settable

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -883,6 +883,9 @@ mg_biome_np_humidity_blend (Mapgen biome humidity blend noise parameters) noise_
 
 [***Mapgen v5]
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+mgv5_cave_width (Mapgen v5 cave width) float 0.125
+
 mgv5_np_filler_depth (Mapgen v5 filler depth noise parameters) noise_params 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 mgv5_np_factor (Mapgen v5 factor noise parameters) noise_params 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0
 mgv5_np_height (Mapgen v5 height noise parameters) noise_params 0, 10, (250, 250, 250), 84174, 4, 0.5, 2.0
@@ -937,6 +940,9 @@ mgv6_np_apple_trees (Mapgen v6 apple trees noise parameters) noise_params 0, 1, 
 #    Flags starting with 'no' are used to explicitly disable them.
 mgv7_spflags (Mapgen v7 flags) flags mountains,ridges mountains,ridges,nomountains,noridges
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+mgv7_cave_width (Mapgen v7 cave width) float 0.3
+
 mgv7_np_terrain_base (Mapgen v7 terrain base noise parameters) noise_params 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 mgv7_np_terrain_alt (Mapgen v7 terrain altitude noise parameters) noise_params 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0
 mgv7_np_terrain_persist (Mapgen v7 terrain persistation noise parameters) noise_params 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0
@@ -965,6 +971,9 @@ mgflat_ground_level (Mapgen flat ground level) int 8
 #    Y of upper limit of large pseudorandom caves.
 mgflat_large_cave_depth (Mapgen flat large cave depth) int -33
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+mgflat_cave_width (Mapgen flat cave width) float 0.3
+
 #    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
 #    Adjust towards 0.0 for a larger proportion.
@@ -991,6 +1000,9 @@ mgflat_np_cave1 (Mapgen flat cave1 noise parameters) noise_params 0, 12, (128, 1
 mgflat_np_cave2 (Mapgen flat cave2 noise parameters) noise_params 0, 12, (128, 128, 128), 10325, 4, 0.5, 2.0
 
 [***Mapgen fractal]
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+mgfractal_cave_width (Mapgen fractal cave width) float 0.3
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.
@@ -1071,60 +1083,63 @@ mgfractal_np_cave2 (Mapgen fractal cave2 noise parameters) noise_params 0, 12, (
 mg_valleys_spflags (Valleys C Flags) flags altitude_chill,humid_rivers altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers
 
 # The altitude at which temperature drops by 20C
-mg_valleys_altitude_chill (Altitude Chill) int 90
+mgvalleys_altitude_chill (Altitude Chill) int 90
 
 # Depth below which you'll find large caves.
-mg_valleys_large_cave_depth (Large cave depth) int -33
+mgvalleys_large_cave_depth (Large cave depth) int -33
 
 # Creates unpredictable lava features in caves.
 # These can make mining difficult. Zero disables them. (0-10)
-mg_valleys_lava_features (Lava Features) int 0
+mgvalleys_lava_features (Lava Features) int 0
 
 # Depth below which you'll find massive caves.
-mg_valleys_massive_cave_depth (Massive cave depth) int -256
+mgvalleys_massive_cave_depth (Massive cave depth) int -256
 
 # How deep to make rivers
-mg_valleys_river_depth (River Depth) int 4
+mgvalleys_river_depth (River Depth) int 4
 
 # How wide to make rivers
-mg_valleys_river_size (River Size) int 5
+mgvalleys_river_size (River Size) int 5
 
 # Creates unpredictable water features in caves.
 # These can make mining difficult. Zero disables them. (0-10)
-mg_valleys_water_features (Water Features) int 0
+mgvalleys_water_features (Water Features) int 0
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+mgvalleys_cave_width (Cave width) float 0.3
 
 # Noise parameters
 [****Noises]
 
 # Caves and tunnels form at the intersection of the two noises
-mg_valleys_np_cave1 (Cave noise #1) noise_params 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
+mgvalleys_np_cave1 (Cave noise #1) noise_params 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
 
 # Caves and tunnels form at the intersection of the two noises
-mg_valleys_np_cave2 (Cave noise #2) noise_params 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
+mgvalleys_np_cave2 (Cave noise #2) noise_params 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
 
 # The depth of dirt or other filler
-mg_valleys_np_filler_depth (Filler Depth) noise_params 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0
+mgvalleys_np_filler_depth (Filler Depth) noise_params 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0
 
 # Massive caves form here.
-mg_valleys_np_massive_caves (Massive cave noise) noise_params 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
+mgvalleys_np_massive_caves (Massive cave noise) noise_params 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
 
 # River noise -- rivers occur close to zero
-mg_valleys_np_rivers (River Noise) noise_params 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0
+mgvalleys_np_rivers (River Noise) noise_params 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0
 
 # Base terrain height
-mg_valleys_np_terrain_height (Terrain Height) noise_params -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0
+mgvalleys_np_terrain_height (Terrain Height) noise_params -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0
 
 # Raises terrain to make valleys around the rivers
-mg_valleys_np_valley_depth (Valley Depth) noise_params 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0
+mgvalleys_np_valley_depth (Valley Depth) noise_params 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0
 
 # Slope and fill work together to modify the heights
-mg_valleys_np_inter_valley_fill (Valley Fill) noise_params 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
+mgvalleys_np_inter_valley_fill (Valley Fill) noise_params 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
 
 # Amplifies the valleys
-mg_valleys_np_valley_profile (Valley Profile) noise_params 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0
+mgvalleys_np_valley_profile (Valley Profile) noise_params 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0
 
 # Slope and fill work together to modify the heights
-mg_valleys_np_inter_valley_slope (Valley Slope) noise_params 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0
+mgvalleys_np_inter_valley_slope (Valley Slope) noise_params 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0
 
 [*Security]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1094,6 +1094,10 @@
 
 #### Mapgen v5
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    type: float
+# mgv5_cave_width = 0.125
+
 #    type: noise_params
 # mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 
@@ -1172,6 +1176,10 @@
 #    type: flags possible values: mountains, ridges, nomountains, noridges
 # mgv7_spflags = mountains,ridges
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    type: float
+# mgv7_cave_width = 0.3
+
 #    type: noise_params
 # mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 
@@ -1224,6 +1232,10 @@
 #    type: int
 # mgflat_large_cave_depth = -33
 
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    type: float
+# mgflat_cave_width = 0.3
+
 #    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
 #    Adjust towards 0.0 for a larger proportion.
@@ -1260,6 +1272,10 @@
 # mgflat_np_cave2 = 0, 12, (128, 128, 128), 10325, 4, 0.5, 2.0
 
 #### Mapgen fractal
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    type: float
+# mgfractal_cave_width = 0.3
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.
@@ -1352,79 +1368,83 @@
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers
-# mg_valleys_spflags = altitude_chill,humid_rivers
+# mgvalleys_spflags = altitude_chill,humid_rivers
 
 #    The altitude at which temperature drops by 20C
 #    type: int
-# mg_valleys_altitude_chill = 90
+# mgvalleys_altitude_chill = 90
 
 #    Depth below which you'll find large caves.
 #    type: int
-# mg_valleys_large_cave_depth = -33
+# mgvalleys_large_cave_depth = -33
 
 #    Creates unpredictable lava features in caves.
 #    These can make mining difficult. Zero disables them. (0-10)
 #    type: int
-# mg_valleys_lava_features = 0
+# mgvalleys_lava_features = 0
 
 #    Depth below which you'll find massive caves.
 #    type: int
-# mg_valleys_massive_cave_depth = -256
+# mgvalleys_massive_cave_depth = -256
 
 #    How deep to make rivers
 #    type: int
-# mg_valleys_river_depth = 4
+# mgvalleys_river_depth = 4
 
 #    How wide to make rivers
 #    type: int
-# mg_valleys_river_size = 5
+# mgvalleys_river_size = 5
 
 #    Creates unpredictable water features in caves.
 #    These can make mining difficult. Zero disables them. (0-10)
 #    type: int
-# mg_valleys_water_features = 0
+# mgvalleys_water_features = 0
+
+#    Controls width of tunnels, a smaller value creates wider tunnels.
+#    type: float
+# mgvalleys_cave_width = 0.3
 
 ##### Noises
 
 #    Caves and tunnels form at the intersection of the two noises
 #    type: noise_params
-# mg_valleys_np_cave1 = 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
+# mgvalleys_np_cave1 = 0, 12, (100, 100, 100), 52534, 4, 0.5, 2.0
 
 #    Caves and tunnels form at the intersection of the two noises
 #    type: noise_params
-# mg_valleys_np_cave2 = 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
+# mgvalleys_np_cave2 = 0, 12, (100, 100, 100), 10325, 4, 0.5, 2.0
 
 #    The depth of dirt or other filler
 #    type: noise_params
-# mg_valleys_np_filler_depth = 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0
+# mgvalleys_np_filler_depth = 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0
 
 #    Massive caves form here.
 #    type: noise_params
-# mg_valleys_np_massive_caves = 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
+# mgvalleys_np_massive_caves = 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
 
 #    River noise -- rivers occur close to zero
 #    type: noise_params
-# mg_valleys_np_rivers = 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0
+# mgvalleys_np_rivers = 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0
 
 #    Base terrain height
 #    type: noise_params
-# mg_valleys_np_terrain_height = -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0
+# mgvalleys_np_terrain_height = -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0
 
 #    Raises terrain to make valleys around the rivers
 #    type: noise_params
-# mg_valleys_np_valley_depth = 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0
+# mgvalleys_np_valley_depth = 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0
 
 #    Slope and fill work together to modify the heights
 #    type: noise_params
-# mg_valleys_np_inter_valley_fill = 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
+# mgvalleys_np_inter_valley_fill = 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
 
 #    Amplifies the valleys
 #    type: noise_params
-# mg_valleys_np_valley_profile = 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0
+# mgvalleys_np_valley_profile = 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0
 
 #    Slope and fill work together to modify the heights
 #    type: noise_params
-# mg_valleys_np_inter_valley_slope = 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0
+# mgvalleys_np_inter_valley_slope = 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0
 
 ## Security
 

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -67,14 +67,15 @@ MapgenFlat::MapgenFlat(int mapgenid, MapgenParams *params, EmergeManager *emerge
 	this->humidmap        = NULL;
 
 	MapgenFlatParams *sp = (MapgenFlatParams *)params->sparams;
-	this->spflags = sp->spflags;
 
-	this->ground_level = sp->ground_level;
+	this->spflags          = sp->spflags;
+	this->ground_level     = sp->ground_level;
 	this->large_cave_depth = sp->large_cave_depth;
-	this->lake_threshold = sp->lake_threshold;
-	this->lake_steepness = sp->lake_steepness;
-	this->hill_threshold = sp->hill_threshold;
-	this->hill_steepness = sp->hill_steepness;
+	this->cave_width       = sp->cave_width;
+	this->lake_threshold   = sp->lake_threshold;
+	this->lake_steepness   = sp->lake_steepness;
+	this->hill_threshold   = sp->hill_threshold;
+	this->hill_steepness   = sp->hill_steepness;
 
 	//// 2D noise
 	noise_terrain      = new Noise(&sp->np_terrain,      seed, csize.X, csize.Z);
@@ -139,14 +140,14 @@ MapgenFlat::~MapgenFlat()
 
 MapgenFlatParams::MapgenFlatParams()
 {
-	spflags = 0;
-
-	ground_level = 8;
+	spflags          = 0;
+	ground_level     = 8;
 	large_cave_depth = -33;
-	lake_threshold = -0.45;
-	lake_steepness = 48.0;
-	hill_threshold = 0.45;
-	hill_steepness = 64.0;
+	cave_width       = 0.3;
+	lake_threshold   = -0.45;
+	lake_steepness   = 48.0;
+	hill_threshold   = 0.45;
+	hill_steepness   = 64.0;
 
 	np_terrain      = NoiseParams(0, 1,   v3f(600, 600, 600), 7244,  5, 0.6, 2.0);
 	np_filler_depth = NoiseParams(0, 1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0);
@@ -157,10 +158,10 @@ MapgenFlatParams::MapgenFlatParams()
 
 void MapgenFlatParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgflat_spflags", spflags, flagdesc_mapgen_flat);
-
+	settings->getFlagStrNoEx("mgflat_spflags",      spflags, flagdesc_mapgen_flat);
 	settings->getS16NoEx("mgflat_ground_level",     ground_level);
 	settings->getS16NoEx("mgflat_large_cave_depth", large_cave_depth);
+	settings->getFloatNoEx("mgflat_cave_width",     cave_width);
 	settings->getFloatNoEx("mgflat_lake_threshold", lake_threshold);
 	settings->getFloatNoEx("mgflat_lake_steepness", lake_steepness);
 	settings->getFloatNoEx("mgflat_hill_threshold", hill_threshold);
@@ -175,10 +176,10 @@ void MapgenFlatParams::readParams(const Settings *settings)
 
 void MapgenFlatParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgflat_spflags", spflags, flagdesc_mapgen_flat, U32_MAX);
-
+	settings->setFlagStr("mgflat_spflags",      spflags, flagdesc_mapgen_flat, U32_MAX);
 	settings->setS16("mgflat_ground_level",     ground_level);
 	settings->setS16("mgflat_large_cave_depth", large_cave_depth);
+	settings->setFloat("mgflat_cave_width",     cave_width);
 	settings->setFloat("mgflat_lake_threshold", lake_threshold);
 	settings->setFloat("mgflat_lake_steepness", lake_steepness);
 	settings->setFloat("mgflat_hill_threshold", hill_threshold);
@@ -592,7 +593,7 @@ void MapgenFlat::generateCaves(s16 max_stone_y)
 			float d1 = contour(noise_cave1->result[index3d]);
 			float d2 = contour(noise_cave2->result[index3d]);
 
-			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
+			if (d1 * d2 > cave_width && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
 				is_tunnel = true;

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -34,14 +34,13 @@ extern FlagDesc flagdesc_mapgen_flat[];
 
 struct MapgenFlatParams : public MapgenSpecificParams {
 	u32 spflags;
-
 	s16 ground_level;
 	s16 large_cave_depth;
+	float cave_width;
 	float lake_threshold;
 	float lake_steepness;
 	float hill_threshold;
 	float hill_steepness;
-
 	NoiseParams np_terrain;
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
@@ -61,20 +60,20 @@ public:
 
 	int ystride;
 	int zstride_1d;
-	u32 spflags;
 
 	v3s16 node_min;
 	v3s16 node_max;
 	v3s16 full_node_min;
 	v3s16 full_node_max;
 
+	u32 spflags;
 	s16 ground_level;
 	s16 large_cave_depth;
+	float cave_width;
 	float lake_threshold;
 	float lake_steepness;
 	float hill_threshold;
 	float hill_steepness;
-
 	Noise *noise_terrain;
 	Noise *noise_filler_depth;
 	Noise *noise_cave1;

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -65,21 +65,18 @@ MapgenFractal::MapgenFractal(int mapgenid, MapgenParams *params, EmergeManager *
 	this->humidmap  = NULL;
 
 	MapgenFractalParams *sp = (MapgenFractalParams *)params->sparams;
-	this->spflags = sp->spflags;
 
+	this->spflags    = sp->spflags;
+	this->cave_width = sp->cave_width;
 	this->fractal    = sp->fractal;
 	this->iterations = sp->iterations;
 	this->scale      = sp->scale;
 	this->offset     = sp->offset;
 	this->slice_w    = sp->slice_w;
-
-	this->julia_x = sp->julia_x;
-	this->julia_y = sp->julia_y;
-	this->julia_z = sp->julia_z;
-	this->julia_w = sp->julia_w;
-
-	this->formula = fractal / 2 + fractal % 2;
-	this->julia   = fractal % 2 == 0;
+	this->julia_x    = sp->julia_x;
+	this->julia_y    = sp->julia_y;
+	this->julia_z    = sp->julia_z;
+	this->julia_w    = sp->julia_w;
 
 	//// 2D terrain noise
 	noise_seabed       = new Noise(&sp->np_seabed, seed, csize.X, csize.Z);
@@ -95,6 +92,9 @@ MapgenFractal::MapgenFractal(int mapgenid, MapgenParams *params, EmergeManager *
 	noise_humidity       = new Noise(&params->np_biome_humidity,       seed, csize.X, csize.Z);
 	noise_heat_blend     = new Noise(&params->np_biome_heat_blend,     seed, csize.X, csize.Z);
 	noise_humidity_blend = new Noise(&params->np_biome_humidity_blend, seed, csize.X, csize.Z);
+
+	this->formula = fractal / 2 + fractal % 2;
+	this->julia   = fractal % 2 == 0;
 
 	//// Resolve nodes to be used
 	INodeDefManager *ndef = emerge->ndef;
@@ -144,18 +144,17 @@ MapgenFractal::~MapgenFractal()
 
 MapgenFractalParams::MapgenFractalParams()
 {
-	spflags = 0;
-
-	fractal = 1;
+	spflags    = 0;
+	cave_width = 0.3;
+	fractal    = 1;
 	iterations = 11;
-	scale = v3f(4096.0, 1024.0, 4096.0);
-	offset = v3f(1.79, 0.0, 0.0);
-	slice_w = 0.0;
-
-	julia_x = 0.33;
-	julia_y = 0.33;
-	julia_z = 0.33;
-	julia_w = 0.33;
+	scale      = v3f(4096.0, 1024.0, 4096.0);
+	offset     = v3f(1.79, 0.0, 0.0);
+	slice_w    = 0.0;
+	julia_x    = 0.33;
+	julia_y    = 0.33;
+	julia_z    = 0.33;
+	julia_w    = 0.33;
 
 	np_seabed       = NoiseParams(-14, 9,   v3f(600, 600, 600), 41900, 5, 0.6, 2.0);
 	np_filler_depth = NoiseParams(0,   1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0);
@@ -166,45 +165,43 @@ MapgenFractalParams::MapgenFractalParams()
 
 void MapgenFractalParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgfractal_spflags", spflags, flagdesc_mapgen_fractal);
+	settings->getFlagStrNoEx("mgfractal_spflags",  spflags, flagdesc_mapgen_fractal);
+	settings->getFloatNoEx("mgfractal_cave_width", cave_width);
+	settings->getU16NoEx("mgfractal_fractal",      fractal);
+	settings->getU16NoEx("mgfractal_iterations",   iterations);
+	settings->getV3FNoEx("mgfractal_scale",        scale);
+	settings->getV3FNoEx("mgfractal_offset",       offset);
+	settings->getFloatNoEx("mgfractal_slice_w",    slice_w);
+	settings->getFloatNoEx("mgfractal_julia_x",    julia_x);
+	settings->getFloatNoEx("mgfractal_julia_y",    julia_y);
+	settings->getFloatNoEx("mgfractal_julia_z",    julia_z);
+	settings->getFloatNoEx("mgfractal_julia_w",    julia_w);
 
-	settings->getU16NoEx("mgfractal_fractal", fractal);
-	settings->getU16NoEx("mgfractal_iterations", iterations);
-	settings->getV3FNoEx("mgfractal_scale", scale);
-	settings->getV3FNoEx("mgfractal_offset", offset);
-	settings->getFloatNoEx("mgfractal_slice_w", slice_w);
-
-	settings->getFloatNoEx("mgfractal_julia_x", julia_x);
-	settings->getFloatNoEx("mgfractal_julia_y", julia_y);
-	settings->getFloatNoEx("mgfractal_julia_z", julia_z);
-	settings->getFloatNoEx("mgfractal_julia_w", julia_w);
-
-	settings->getNoiseParams("mgfractal_np_seabed", np_seabed);
+	settings->getNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->getNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
-	settings->getNoiseParams("mgfractal_np_cave1", np_cave1);
-	settings->getNoiseParams("mgfractal_np_cave2", np_cave2);
+	settings->getNoiseParams("mgfractal_np_cave1",        np_cave1);
+	settings->getNoiseParams("mgfractal_np_cave2",        np_cave2);
 }
 
 
 void MapgenFractalParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFlagStr("mgfractal_spflags",  spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFloat("mgfractal_cave_width", cave_width);
+	settings->setU16("mgfractal_fractal",      fractal);
+	settings->setU16("mgfractal_iterations",   iterations);
+	settings->setV3F("mgfractal_scale",        scale);
+	settings->setV3F("mgfractal_offset",       offset);
+	settings->setFloat("mgfractal_slice_w",    slice_w);
+	settings->setFloat("mgfractal_julia_x",    julia_x);
+	settings->setFloat("mgfractal_julia_y",    julia_y);
+	settings->setFloat("mgfractal_julia_z",    julia_z);
+	settings->setFloat("mgfractal_julia_w",    julia_w);
 
-	settings->setU16("mgfractal_fractal", fractal);
-	settings->setU16("mgfractal_iterations", iterations);
-	settings->setV3F("mgfractal_scale", scale);
-	settings->setV3F("mgfractal_offset", offset);
-	settings->setFloat("mgfractal_slice_w", slice_w);
-
-	settings->setFloat("mgfractal_julia_x", julia_x);
-	settings->setFloat("mgfractal_julia_y", julia_y);
-	settings->setFloat("mgfractal_julia_z", julia_z);
-	settings->setFloat("mgfractal_julia_w", julia_w);
-
-	settings->setNoiseParams("mgfractal_np_seabed", np_seabed);
+	settings->setNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->setNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
-	settings->setNoiseParams("mgfractal_np_cave1", np_cave1);
-	settings->setNoiseParams("mgfractal_np_cave2", np_cave2);
+	settings->setNoiseParams("mgfractal_np_cave1",        np_cave1);
+	settings->setNoiseParams("mgfractal_np_cave2",        np_cave2);
 }
 
 
@@ -720,7 +717,7 @@ void MapgenFractal::generateCaves(s16 max_stone_y)
 			float d1 = contour(noise_cave1->result[index3d]);
 			float d2 = contour(noise_cave2->result[index3d]);
 
-			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
+			if (d1 * d2 > cave_width && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
 				is_tunnel = true;

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -35,18 +35,16 @@ extern FlagDesc flagdesc_mapgen_fractal[];
 
 struct MapgenFractalParams : public MapgenSpecificParams {
 	u32 spflags;
-
+	float cave_width;
 	u16 fractal;
 	u16 iterations;
 	v3f scale;
 	v3f offset;
 	float slice_w;
-
 	float julia_x;
 	float julia_y;
 	float julia_z;
 	float julia_w;
-
 	NoiseParams np_seabed;
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
@@ -75,18 +73,16 @@ public:
 	v3s16 full_node_max;
 
 	u32 spflags;
-
+	float cave_width;
 	u16 fractal;
 	u16 iterations;
 	v3f scale;
 	v3f offset;
 	float slice_w;
-
 	float julia_x;
 	float julia_y;
 	float julia_z;
 	float julia_w;
-
 	Noise *noise_seabed;
 	Noise *noise_filler_depth;
 	Noise *noise_cave1;

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -63,7 +63,9 @@ MapgenV5::MapgenV5(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->humidmap  = NULL;
 
 	MapgenV5Params *sp = (MapgenV5Params *)params->sparams;
-	this->spflags      = sp->spflags;
+
+	this->spflags    = sp->spflags;
+	this->cave_width = sp->cave_width;
 
 	// Terrain noise
 	noise_filler_depth = new Noise(&sp->np_filler_depth, seed, csize.X, csize.Z);
@@ -133,7 +135,8 @@ MapgenV5::~MapgenV5()
 
 MapgenV5Params::MapgenV5Params()
 {
-	spflags = 0;
+	spflags    = 0;
+	cave_width = 0.125;
 
 	np_filler_depth = NoiseParams(0, 1,  v3f(150, 150, 150), 261,    4, 0.7,  2.0);
 	np_factor       = NoiseParams(0, 1,  v3f(250, 250, 250), 920381, 3, 0.45, 2.0);
@@ -150,7 +153,8 @@ MapgenV5Params::MapgenV5Params()
 
 void MapgenV5Params::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgv5_spflags", spflags, flagdesc_mapgen_v5);
+	settings->getFlagStrNoEx("mgv5_spflags",  spflags, flagdesc_mapgen_v5);
+	settings->getFloatNoEx("mgv5_cave_width", cave_width);
 
 	settings->getNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->getNoiseParams("mgv5_np_factor",       np_factor);
@@ -163,7 +167,8 @@ void MapgenV5Params::readParams(const Settings *settings)
 
 void MapgenV5Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, U32_MAX);
+	settings->setFlagStr("mgv5_spflags",  spflags, flagdesc_mapgen_v5, U32_MAX);
+	settings->setFloat("mgv5_cave_width", cave_width);
 
 	settings->setNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgv5_np_factor",       np_factor);
@@ -598,7 +603,7 @@ void MapgenV5::generateCaves(int max_stone_y)
 			float d1 = contour(noise_cave1->result[index3d]);
 			float d2 = contour(noise_cave2->result[index3d]);
 
-			if (d1 * d2 > 0.125f && ndef->get(c).is_ground_content) {
+			if (d1 * d2 > cave_width && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
 				is_tunnel = true;

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -32,6 +32,7 @@ extern FlagDesc flagdesc_mapgen_v5[];
 
 struct MapgenV5Params : public MapgenSpecificParams {
 	u32 spflags;
+	float cave_width;
 	NoiseParams np_filler_depth;
 	NoiseParams np_factor;
 	NoiseParams np_height;
@@ -54,13 +55,14 @@ public:
 
 	int ystride;
 	int zstride_1d;
-	u32 spflags;
 
 	v3s16 node_min;
 	v3s16 node_max;
 	v3s16 full_node_min;
 	v3s16 full_node_max;
 
+	u32 spflags;
+	float cave_width;
 	Noise *noise_filler_depth;
 	Noise *noise_factor;
 	Noise *noise_height;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -71,7 +71,9 @@ MapgenV7::MapgenV7(int mapgenid, MapgenParams *params, EmergeManager *emerge)
 	this->ridge_heightmap = new s16[csize.X * csize.Z];
 
 	MapgenV7Params *sp = (MapgenV7Params *)params->sparams;
-	this->spflags = sp->spflags;
+
+	this->spflags    = sp->spflags;
+	this->cave_width = sp->cave_width;
 
 	//// Terrain noise
 	noise_terrain_base    = new Noise(&sp->np_terrain_base,    seed, csize.X, csize.Z);
@@ -152,7 +154,8 @@ MapgenV7::~MapgenV7()
 
 MapgenV7Params::MapgenV7Params()
 {
-	spflags = MGV7_MOUNTAINS | MGV7_RIDGES;
+	spflags    = MGV7_MOUNTAINS | MGV7_RIDGES;
+	cave_width = 0.3;
 
 	np_terrain_base    = NoiseParams(4,    70,  v3f(600,  600,  600),  82341, 5, 0.6,  2.0);
 	np_terrain_alt     = NoiseParams(4,    25,  v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
@@ -170,7 +173,8 @@ MapgenV7Params::MapgenV7Params()
 
 void MapgenV7Params::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgv7_spflags", spflags, flagdesc_mapgen_v7);
+	settings->getFlagStrNoEx("mgv7_spflags",  spflags, flagdesc_mapgen_v7);
+	settings->getFloatNoEx("mgv7_cave_width", cave_width);
 
 	settings->getNoiseParams("mgv7_np_terrain_base",    np_terrain_base);
 	settings->getNoiseParams("mgv7_np_terrain_alt",     np_terrain_alt);
@@ -188,7 +192,8 @@ void MapgenV7Params::readParams(const Settings *settings)
 
 void MapgenV7Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7, U32_MAX);
+	settings->setFlagStr("mgv7_spflags",  spflags, flagdesc_mapgen_v7, U32_MAX);
+	settings->setFloat("mgv7_cave_width", cave_width);
 
 	settings->setNoiseParams("mgv7_np_terrain_base",    np_terrain_base);
 	settings->setNoiseParams("mgv7_np_terrain_alt",     np_terrain_alt);
@@ -735,7 +740,7 @@ void MapgenV7::generateCaves(s16 max_stone_y)
 			float d1 = contour(noise_cave1->result[index3d]);
 			float d2 = contour(noise_cave2->result[index3d]);
 
-			if (d1 * d2 > 0.3f && ndef->get(c).is_ground_content) {
+			if (d1 * d2 > cave_width && ndef->get(c).is_ground_content) {
 				// In tunnel and ground content, excavate
 				vm->m_data[vi] = MapNode(CONTENT_AIR);
 				is_tunnel = true;

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -34,6 +34,7 @@ extern FlagDesc flagdesc_mapgen_v7[];
 
 struct MapgenV7Params : public MapgenSpecificParams {
 	u32 spflags;
+	float cave_width;
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_alt;
 	NoiseParams np_terrain_persist;
@@ -61,7 +62,6 @@ public:
 	int ystride;
 	int zstride_1u1d;
 	int zstride_1d;
-	u32 spflags;
 
 	v3s16 node_min;
 	v3s16 node_max;
@@ -70,6 +70,8 @@ public:
 
 	s16 *ridge_heightmap;
 
+	u32 spflags;
+	float cave_width;
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
 	Noise *noise_terrain_persist;

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -47,7 +47,6 @@ class BiomeManager;
 
 struct MapgenValleysParams : public MapgenSpecificParams {
 	u32 spflags;
-
 	s16 large_cave_depth;
 	s16 massive_cave_depth;
 	u16 altitude_chill;
@@ -55,11 +54,7 @@ struct MapgenValleysParams : public MapgenSpecificParams {
 	u16 river_depth;
 	u16 river_size;
 	u16 water_features;
-
-	NoiseParams np_biome_heat;
-	NoiseParams np_biome_heat_blend;
-	NoiseParams np_biome_humidity;
-	NoiseParams np_biome_humidity_blend;
+	float cave_width;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_filler_depth;
@@ -110,23 +105,29 @@ private:
 
 	float map_gen_limit;
 
-	u32 spflags;
 	bool humid_rivers;
 	bool use_altitude_chill;
+	float humidity_adjust;
+	s16 cave_water_max_height;
+	s16 lava_max_height;
 
 	v3s16 node_min;
 	v3s16 node_max;
 	v3s16 full_node_min;
 	v3s16 full_node_max;
 
+	u32 spflags;
+	float altitude_chill;
+	s16 lava_features_lim;
+	s16 massive_cave_depth;
+	float river_depth_bed;
+	float river_size_factor;
+	float *tcave_cache;
+	s16 water_features_lim;
+	float cave_width;
 	Noise *noise_filler_depth;
-
 	Noise *noise_cave1;
 	Noise *noise_cave2;
-	Noise *noise_heat;
-	Noise *noise_heat_blend;
-	Noise *noise_humidity;
-	Noise *noise_humidity_blend;
 	Noise *noise_inter_valley_fill;
 	Noise *noise_inter_valley_slope;
 	Noise *noise_rivers;
@@ -135,16 +136,10 @@ private:
 	Noise *noise_valley_depth;
 	Noise *noise_valley_profile;
 
-	float altitude_chill;
-	s16 cave_water_max_height;
-	float humidity_adjust;
-	s16 lava_features_lim;
-	s16 lava_max_height;
-	s16 massive_cave_depth;
-	float river_depth_bed;
-	float river_size_factor;
-	float *tcave_cache;
-	s16 water_features_lim;
+	Noise *noise_heat;
+	Noise *noise_heat_blend;
+	Noise *noise_humidity;
+	Noise *noise_humidity_blend;
 
 	content_t c_cobble;
 	content_t c_desert_stone;


### PR DESCRIPTION
Correct parameter names mg_valleys to mgvalleys
Remove biome NoiseParams from MapgenValleysParams
Improve format of parameter code
/////////////////////////////////////

Found some errors in mgvalleys, so lucky i worked on this.
Custom cave noise parameters are almost useless unless tunnel width is settable too.
This PR puts that right for the 3 new mapgens before they are released in stable MT.
Also adds the feature to mgv5 and mgv7.