### PR TITLE
Adding minetest.clear_craft(recipe) to Lua modding API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1817,6 +1817,14 @@ Call these functions only at load time!
 * `minetest.register_craftitem(name, item definition)`
 * `minetest.register_alias(name, convert_to)`
 * `minetest.register_craft(recipe)`
+    * Check recipe table syntax for different types below.
+* `minetest.clear_craft(recipe)`
+    * Will erase existing craft based either on output item or on input recipe.
+    * Use a same recipe table syntax as for `minetest.register_craft(recipe)`, 
+      but specify either output or input only. If you specify both, input will be ignored.
+    * If there is no erase candidate founded, Lua exception will be thrown.
+    * Warning! Type field ("shaped","cooking" or any other) will be ignored if recipe 
+      contain output. Will be erased all possible crafting recipe independent from crafting method.
 * `minetest.register_ore(ore definition)`
 * `minetest.register_decoration(decoration definition)`
 * `minetest.override_item(name, redefinition)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1820,8 +1820,8 @@ Call these functions only at load time!
     * Check recipe table syntax for different types below.
 * `minetest.clear_craft(recipe)`
     * Will erase existing craft based either on output item or on input recipe.
-    * Use a same recipe table syntax as for `minetest.register_craft(recipe)`, 
-      but specify either output or input only. If you specify both, input will be ignored.
+    * Specify either output or input only. If you specify both, input will be ignored. For input use a same recipe table
+      syntax as for `minetest.register_craft(recipe)`. For output specify only item, but not a quantity.
     * If there is no erase candidate founded, Lua exception will be thrown.
     * Warning! Type field ("shaped","cooking" or any other) will be ignored if recipe 
       contain output. Will be erased all possible crafting recipe independent from crafting method.

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -961,7 +961,7 @@ public:
 		return recipes;
 	}
 
-	virtual bool clearCraftRecipesByOutput(CraftOutput &output, IGameDef *gamedef)
+	virtual bool clearCraftRecipesByOutput(const CraftOutput &output, IGameDef *gamedef)
 	{
 		std::map<std::string, std::vector<CraftDefinition*> >::iterator vec_iter = m_output_craft_definitions.find(output.item);
 
@@ -974,10 +974,10 @@ public:
 			CraftDefinition *def = *i;
 			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
 			std::vector<CraftDefinition*> new_vec_by_input;
+			new_vec_by_input.reserve(unhashed_inputs_vec.size());
 			for (std::vector<CraftDefinition*>::iterator i2 = unhashed_inputs_vec.begin();
 				i2 != unhashed_inputs_vec.end(); ++i2) {
-				if(def != *i2)
-				{
+				if (def != *i2) {
 					new_vec_by_input.push_back(*i2);
 				}
 			}
@@ -991,7 +991,7 @@ public:
 	{
 		bool all_empty = true;
 		for (std::vector<std::string>::size_type i = 0;
-			i < recipe.size(); i++) {
+				i < recipe.size(); i++) {
 			if (!recipe[i].empty()) {
 				all_empty = false;
 				break;
@@ -1008,12 +1008,12 @@ public:
 		for (std::vector<CraftDefinition*>::size_type
 			i = unhashed_inputs_vec.size(); i > 0; i--) {
 			CraftDefinition *def = unhashed_inputs_vec[i - 1];
-			CraftOutput output = def->getOutput(input, gamedef); // What first argument for?
-			//If check are not passed, skip 'CraftDefinition' and add element to a new vector.
+			// If the input doesn't match the recipe definition, this recipe definition later will be added back in source map.
 			if (!def->check(input, gamedef)){
 				new_vec_by_input.push_back(def);
 				continue;
 			}
+			CraftOutput output = def->getOutput(input, gamedef);
 			got_hit = true;
 			std::map<std::string, std::vector<CraftDefinition*> >::iterator 
 				vec_iter = m_output_craft_definitions.find(output.item);
@@ -1021,15 +1021,16 @@ public:
 				continue;
 			std::vector<CraftDefinition*> &vec = vec_iter->second;
 			std::vector<CraftDefinition*> new_vec_by_output;
+			new_vec_by_output.reserve(vec.size());
 			for (std::vector<CraftDefinition*>::iterator i = vec.begin();
 				i != vec.end(); ++i) {
-				if(def != *i){ // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
+				if(def != *i) { // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
 					new_vec_by_output.push_back(*i); // Adding dereferenced iterator value (which are 'CraftDefinition' reference) to a new vector.
 				}
 			}
 			m_output_craft_definitions[output.item].swap(new_vec_by_output); // Swaps assigned to current key value with new vector for output map.
 		}
-		if(got_hit)
+		if (got_hit)
 			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input); // Swaps value with new vector for input map.
 
 		return got_hit;

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -963,20 +963,24 @@ public:
 
 	virtual bool clearCraftRecipesByOutput(const CraftOutput &output, IGameDef *gamedef)
 	{
-		std::map<std::string, std::vector<CraftDefinition*> >::iterator vec_iter = m_output_craft_definitions.find(output.item);
+		std::map<std::string, std::vector<CraftDefinition*> >::iterator vec_iter = 
+			m_output_craft_definitions.find(output.item);
 
 		if (vec_iter == m_output_craft_definitions.end())
 			return false;
 
 		std::vector<CraftDefinition*> &vec = vec_iter->second;
 		for (std::vector<CraftDefinition*>::iterator i = vec.begin();
-			i != vec.end(); ++i) {
+				i != vec.end(); ++i) {
 			CraftDefinition *def = *i;
-			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
+			// Recipes are not yet hashed at this point
+			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; 
 			std::vector<CraftDefinition*> new_vec_by_input;
-			new_vec_by_input.reserve(unhashed_inputs_vec.size()); // We will preallocate necessary memory addresses, so we don't need to reallocate them later. This would save us some performance.
+			/* We will preallocate necessary memory addresses, so we don't need to reallocate them later. 
+				This would save us some performance. */
+			new_vec_by_input.reserve(unhashed_inputs_vec.size()); 
 			for (std::vector<CraftDefinition*>::iterator i2 = unhashed_inputs_vec.begin();
-				i2 != unhashed_inputs_vec.end(); ++i2) {
+					i2 != unhashed_inputs_vec.end(); ++i2) {
 				if (def != *i2) {
 					new_vec_by_input.push_back(*i2);
 				}
@@ -987,7 +991,8 @@ public:
 		return true;
 	}
 
-	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, unsigned int craft_grid_width, const std::vector<std::string> &recipe, IGameDef *gamedef)
+	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, unsigned int craft_grid_width, 
+		const std::vector<std::string> &recipe, IGameDef *gamedef)
 	{
 		bool all_empty = true;
 		for (std::vector<std::string>::size_type i = 0;
@@ -1001,14 +1006,15 @@ public:
 			return false;
 
 		CraftInput input(craft_method, craft_grid_width, craftGetItems(recipe, gamedef));
-
-		std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
+		// Recipes are not yet hashed at this point
+		std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
 		std::vector<CraftDefinition*> new_vec_by_input;
 		bool got_hit = false;
 		for (std::vector<CraftDefinition*>::size_type
-			i = unhashed_inputs_vec.size(); i > 0; i--) {
+				i = unhashed_inputs_vec.size(); i > 0; i--) {
 			CraftDefinition *def = unhashed_inputs_vec[i - 1];
-			// If the input doesn't match the recipe definition, this recipe definition later will be added back in source map.
+			/* If the input doesn't match the recipe definition, this recipe definition later 
+				will be added back in source map. */
 			if (!def->check(input, gamedef)) {
 				new_vec_by_input.push_back(def);
 				continue;
@@ -1021,17 +1027,25 @@ public:
 				continue;
 			std::vector<CraftDefinition*> &vec = vec_iter->second;
 			std::vector<CraftDefinition*> new_vec_by_output;
-			new_vec_by_output.reserve(vec.size()); // We will preallocate necessary memory addresses, so we don't need to reallocate them later. This would save us some performance.
+			/* We will preallocate necessary memory addresses, so we don't need 
+				to reallocate them later. This would save us some performance. */
+			new_vec_by_output.reserve(vec.size()); 
 			for (std::vector<CraftDefinition*>::iterator i = vec.begin();
-				i != vec.end(); ++i) {
-				if (def != *i) { // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
-					new_vec_by_output.push_back(*i); // Adding dereferenced iterator value (which are 'CraftDefinition' reference) to a new vector.
+					i != vec.end(); ++i) {
+				/* If pointers from map by input and output are not same, 
+					we will add 'CraftDefinition*' to a new vector. */
+				if (def != *i) { 
+					/* Adding dereferenced iterator value (which are 
+						'CraftDefinition' reference) to a new vector. */
+					new_vec_by_output.push_back(*i);
 				}
 			}
-			m_output_craft_definitions[output.item].swap(new_vec_by_output); // Swaps assigned to current key value with new vector for output map.
+			// Swaps assigned to current key value with new vector for output map.
+			m_output_craft_definitions[output.item].swap(new_vec_by_output);
 		}
 		if (got_hit)
-			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input); // Swaps value with new vector for input map.
+			// Swaps value with new vector for input map.
+			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input); 
 
 		return got_hit;
 	}

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -974,7 +974,7 @@ public:
 			CraftDefinition *def = *i;
 			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
 			std::vector<CraftDefinition*> new_vec_by_input;
-			new_vec_by_input.reserve(unhashed_inputs_vec.size());
+			new_vec_by_input.reserve(unhashed_inputs_vec.size()); // We will preallocate necessary memory addresses, so we don't need to reallocate them later. This would save us some performance.
 			for (std::vector<CraftDefinition*>::iterator i2 = unhashed_inputs_vec.begin();
 				i2 != unhashed_inputs_vec.end(); ++i2) {
 				if (def != *i2) {
@@ -1009,7 +1009,7 @@ public:
 			i = unhashed_inputs_vec.size(); i > 0; i--) {
 			CraftDefinition *def = unhashed_inputs_vec[i - 1];
 			// If the input doesn't match the recipe definition, this recipe definition later will be added back in source map.
-			if (!def->check(input, gamedef)){
+			if (!def->check(input, gamedef)) {
 				new_vec_by_input.push_back(def);
 				continue;
 			}
@@ -1021,10 +1021,10 @@ public:
 				continue;
 			std::vector<CraftDefinition*> &vec = vec_iter->second;
 			std::vector<CraftDefinition*> new_vec_by_output;
-			new_vec_by_output.reserve(vec.size());
+			new_vec_by_output.reserve(vec.size()); // We will preallocate necessary memory addresses, so we don't need to reallocate them later. This would save us some performance.
 			for (std::vector<CraftDefinition*>::iterator i = vec.begin();
 				i != vec.end(); ++i) {
-				if(def != *i) { // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
+				if (def != *i) { // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
 					new_vec_by_output.push_back(*i); // Adding dereferenced iterator value (which are 'CraftDefinition' reference) to a new vector.
 				}
 			}

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -960,6 +960,81 @@ public:
 
 		return recipes;
 	}
+
+	virtual bool clearCraftRecipesByOutput(CraftOutput &output, IGameDef *gamedef)
+	{
+		std::map<std::string, std::vector<CraftDefinition*> >::iterator vec_iter = m_output_craft_definitions.find(output.item);
+
+		if (vec_iter == m_output_craft_definitions.end())
+			return false;
+
+		std::vector<CraftDefinition*> &vec = vec_iter->second;
+		for (std::vector<CraftDefinition*>::iterator i = vec.begin();
+			i != vec.end(); ++i) {
+			CraftDefinition *def = *i;
+			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
+			std::vector<CraftDefinition*> new_vec_by_input;
+			for (std::vector<CraftDefinition*>::iterator i2 = unhashed_inputs_vec.begin();
+				i2 != unhashed_inputs_vec.end(); ++i2) {
+				if(def != *i2)
+				{
+					new_vec_by_input.push_back(*i2);
+				}
+			}
+			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input);
+		}
+		m_output_craft_definitions.erase(output.item);
+		return true;
+	}
+
+	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, unsigned int craft_grid_width, const std::vector<std::string> &recipe, IGameDef *gamedef)
+	{
+		bool all_empty = true;
+		for (std::vector<std::string>::size_type i = 0;
+			i < recipe.size(); i++) {
+			if (!recipe[i].empty()) {
+				all_empty = false;
+				break;
+			}
+		}
+		if (all_empty)
+			return false;
+
+		CraftInput input(craft_method, craft_grid_width, craftGetItems(recipe, gamedef));
+
+		std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0]; // Recipes are not yet hashed at this point
+		std::vector<CraftDefinition*> new_vec_by_input;
+		bool got_hit = false;
+		for (std::vector<CraftDefinition*>::size_type
+			i = unhashed_inputs_vec.size(); i > 0; i--) {
+			CraftDefinition *def = unhashed_inputs_vec[i - 1];
+			CraftOutput output = def->getOutput(input, gamedef); // What first argument for?
+			//If check are not passed, skip 'CraftDefinition' and add element to a new vector.
+			if (!def->check(input, gamedef)){
+				new_vec_by_input.push_back(def);
+				continue;
+			}
+			got_hit = true;
+			std::map<std::string, std::vector<CraftDefinition*> >::iterator 
+				vec_iter = m_output_craft_definitions.find(output.item);
+			if (vec_iter == m_output_craft_definitions.end())
+				continue;
+			std::vector<CraftDefinition*> &vec = vec_iter->second;
+			std::vector<CraftDefinition*> new_vec_by_output;
+			for (std::vector<CraftDefinition*>::iterator i = vec.begin();
+				i != vec.end(); ++i) {
+				if(def != *i){ // If pointers from map by input and output are not same, we will add 'CraftDefinition*' to a new vector.
+					new_vec_by_output.push_back(*i); // Adding dereferenced iterator value (which are 'CraftDefinition' reference) to a new vector.
+				}
+			}
+			m_output_craft_definitions[output.item].swap(new_vec_by_output); // Swaps assigned to current key value with new vector for output map.
+		}
+		if(got_hit)
+			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input); // Swaps value with new vector for input map.
+
+		return got_hit;
+	}
+
 	virtual std::string dump() const
 	{
 		std::ostringstream os(std::ios::binary);

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -426,6 +426,9 @@ public:
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 
+	virtual bool clearCraftRecipesByOutput(CraftOutput &output, IGameDef *gamedef) = 0;
+	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, unsigned int craft_grid_width, const std::vector<std::string> &recipe, IGameDef *gamedef) = 0;
+
 	// Print crafting recipes for debugging
 	virtual std::string dump() const=0;
 

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -426,8 +426,9 @@ public:
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 
-	virtual bool clearCraftRecipesByOutput(CraftOutput &output, IGameDef *gamedef) = 0;
-	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, unsigned int craft_grid_width, const std::vector<std::string> &recipe, IGameDef *gamedef) = 0;
+	virtual bool clearCraftRecipesByOutput(const CraftOutput &output, IGameDef *gamedef) = 0;
+	virtual bool clearCraftRecipesByInput(CraftMethod craft_method, 
+			unsigned int craft_grid_width, const std::vector<std::string> &recipe, IGameDef *gamedef) = 0;
 
 	// Print crafting recipes for debugging
 	virtual std::string dump() const=0;

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -338,10 +338,10 @@ int ModApiCraft::l_clear_craft(lua_State *L)
 	/*
 		CraftDefinitionFuel
 	*/
-	else if(type == "fuel") {
+	else if (type == "fuel") {
 		method = CRAFT_METHOD_FUEL;
 		std::string rec = getstringfield_default(L, table, "recipe", "");
-		if(rec == "")
+		if (rec == "")
 			throw LuaError("Crafting definition (fuel)"
 					" is missing a recipe");
 		recipe.push_back(rec);

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -294,43 +294,43 @@ int ModApiCraft::l_clear_craft(lua_State *L)
 	std::string output = getstringfield_default(L, table, "output", "");
 	std::string type = getstringfield_default(L, table, "type", "shaped");
 	CraftOutput c_output(output, 0);
-	if(output != ""){
-		if(craftdef->clearCraftRecipesByOutput(c_output, getServer(L)))
+	if (output != "") {
+		if (craftdef->clearCraftRecipesByOutput(c_output, getServer(L)))
 			return 0;
 		else
 			throw LuaError("No crafting specified for output"
 					" (output=\"" + output + "\")");	
 	}
 	std::vector<std::string> recipe;
-	int width =0;
+	int width = 0;
 	CraftMethod method = CRAFT_METHOD_NORMAL;
 	/*
 		CraftDefinitionShaped
 	*/
-	if(type == "shaped"){
+	if (type == "shaped") {
 		lua_getfield(L, table, "recipe");
-		if(lua_isnil(L, -1))
+		if (lua_isnil(L, -1))
 			throw LuaError("Either output or recipe should be defined");
-		if(!readCraftRecipeShaped(L, -1, width, recipe))
+		if (!readCraftRecipeShaped(L, -1, width, recipe))
 			throw LuaError("Invalid crafting recipe");
 	}
 	/*
 		CraftDefinitionShapeless
 	*/
-	else if(type == "shapeless"){
+	else if (type == "shapeless") {
 		lua_getfield(L, table, "recipe");
-		if(lua_isnil(L, -1))
+		if (lua_isnil(L, -1))
 			throw LuaError("Either output or recipe should be defined");
-		if(!readCraftRecipeShapeless(L, -1, recipe))
+		if (!readCraftRecipeShapeless(L, -1, recipe))
 			throw LuaError("Invalid crafting recipe");
 	}
 	/*
 		CraftDefinitionCooking
 	*/
-	else if(type == "cooking"){
+	else if (type == "cooking") {
 		method = CRAFT_METHOD_COOKING;
 		std::string rec = getstringfield_default(L, table, "recipe", "");
-		if(rec == "")
+		if (rec == "")
 			throw LuaError("Crafting definition (cooking)"
 					" is missing a recipe");
 		recipe.push_back(rec);
@@ -338,7 +338,7 @@ int ModApiCraft::l_clear_craft(lua_State *L)
 	/*
 		CraftDefinitionFuel
 	*/
-	else if(type == "fuel"){
+	else if(type == "fuel") {
 		method = CRAFT_METHOD_FUEL;
 		std::string rec = getstringfield_default(L, table, "recipe", "");
 		if(rec == "")
@@ -350,7 +350,7 @@ int ModApiCraft::l_clear_craft(lua_State *L)
 	{
 		throw LuaError("Unknown crafting definition type: \"" + type + "\"");
 	}
-	if(!craftdef->clearCraftRecipesByInput(method, width, recipe, getServer(L)))
+	if (!craftdef->clearCraftRecipesByInput(method, width, recipe, getServer(L)))
 		throw LuaError("No crafting specified for input");	
 	lua_pop(L, 1);
 	return 0;

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -34,7 +34,6 @@ struct EnumString ModApiCraft::es_CraftMethod[] =
 	{0, NULL},
 };
 
-
 // helper for register_craft
 bool ModApiCraft::readCraftRecipeShaped(lua_State *L, int index,
 		int &width, std::vector<std::string> &recipe)
@@ -281,6 +280,82 @@ int ModApiCraft::l_register_craft(lua_State *L)
 	return 0; /* number of results */
 }
 
+// clear_craft({[output=item], [recipe={{item00,item10},{item01,item11}}])
+int ModApiCraft::l_clear_craft(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	luaL_checktype(L, 1, LUA_TTABLE);
+	int table = 1;
+
+	// Get the writable craft definition manager from the server
+	IWritableCraftDefManager *craftdef =
+			getServer(L)->getWritableCraftDefManager();
+
+	std::string output = getstringfield_default(L, table, "output", "");
+	std::string type = getstringfield_default(L, table, "type", "shaped");
+	CraftOutput c_output(output, 0);
+	if(output != ""){
+		if(craftdef->clearCraftRecipesByOutput(c_output, getServer(L)))
+			return 0;
+		else
+			throw LuaError("No crafting specified for output"
+					" (output=\"" + output + "\")");	
+	}
+	std::vector<std::string> recipe;
+	int width =0;
+	CraftMethod method = CRAFT_METHOD_NORMAL;
+	/*
+		CraftDefinitionShaped
+	*/
+	if(type == "shaped"){
+		lua_getfield(L, table, "recipe");
+		if(lua_isnil(L, -1))
+			throw LuaError("Either output or recipe should be defined");
+		if(!readCraftRecipeShaped(L, -1, width, recipe))
+			throw LuaError("Invalid crafting recipe");
+	}
+	/*
+		CraftDefinitionShapeless
+	*/
+	else if(type == "shapeless"){
+		lua_getfield(L, table, "recipe");
+		if(lua_isnil(L, -1))
+			throw LuaError("Either output or recipe should be defined");
+		if(!readCraftRecipeShapeless(L, -1, recipe))
+			throw LuaError("Invalid crafting recipe");
+	}
+	/*
+		CraftDefinitionCooking
+	*/
+	else if(type == "cooking"){
+		method = CRAFT_METHOD_COOKING;
+		std::string rec = getstringfield_default(L, table, "recipe", "");
+		if(rec == "")
+			throw LuaError("Crafting definition (cooking)"
+					" is missing a recipe");
+		recipe.push_back(rec);
+	}
+	/*
+		CraftDefinitionFuel
+	*/
+	else if(type == "fuel"){
+		method = CRAFT_METHOD_FUEL;
+		std::string rec = getstringfield_default(L, table, "recipe", "");
+		if(rec == "")
+			throw LuaError("Crafting definition (fuel)"
+					" is missing a recipe");
+		recipe.push_back(rec);
+	}
+	else
+	{
+		throw LuaError("Unknown crafting definition type: \"" + type + "\"");
+	}
+	if(!craftdef->clearCraftRecipesByInput(method, width, recipe, getServer(L)))
+		throw LuaError("No crafting specified for input");	
+	lua_pop(L, 1);
+	return 0;
+}
+
 // get_craft_result(input)
 int ModApiCraft::l_get_craft_result(lua_State *L)
 {
@@ -431,4 +506,5 @@ void ModApiCraft::Initialize(lua_State *L, int top)
 	API_FCT(get_craft_recipe);
 	API_FCT(get_craft_result);
 	API_FCT(register_craft);
+	API_FCT(clear_craft);
 }

--- a/src/script/lua_api/l_craft.h
+++ b/src/script/lua_api/l_craft.h
@@ -33,6 +33,7 @@ private:
 	static int l_get_craft_recipe(lua_State *L);
 	static int l_get_all_craft_recipes(lua_State *L);
 	static int l_get_craft_result(lua_State *L);
+	static int l_clear_craft(lua_State *L);
 
 	static bool readCraftReplacements(lua_State *L, int index,
 			CraftReplacements &replacements);


### PR DESCRIPTION
This function allow modders remove previously registered recipes either by output or by input and type (including "fuel" and "cooking"). Plus, removed recipes no longer visible via crafting guides, because they eliminated from registry.