### PR TITLE
Map boundary check for /teleport

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -348,7 +348,8 @@ core.register_chatcommand("teleport", {
 		p.x = tonumber(p.x)
 		p.y = tonumber(p.y)
 		p.z = tonumber(p.z)
-		if p.x < -31000 or p.x > 31000 or p.y < -31000 or p.y > 31000 or p.z < -31000 or p.z > 31000 then
+		local limit = minetest.setting_get("map_generation_limit") or 31000
+		if p.x < -limit or p.x > limit or p.y < -limit or p.y > limit or p.z < -limit or p.z > limit then
 			return false, "Cannot teleport out of map bounds!"
 		end
 		teleportee = core.get_player_by_name(name)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -348,14 +348,16 @@ core.register_chatcommand("teleport", {
 		p.x = tonumber(p.x)
 		p.y = tonumber(p.y)
 		p.z = tonumber(p.z)
-		local lm = tonumber(minetest.setting_get("map_generation_limit") or 31000)
-		if p.x and (p.x < -lm or p.x > lm or p.y < -lm or p.y > lm or p.z < -lm or p.z > lm) then
-			return false, "Cannot teleport out of map bounds!"
-		end
-		teleportee = core.get_player_by_name(name)
-		if teleportee and p.x and p.y and p.z then
-			teleportee:setpos(p)
-			return true, "Teleporting to "..core.pos_to_string(p)
+		if p.x and p.y and p.z then
+			local lm = tonumber(minetest.setting_get("map_generation_limit") or 31000)
+			if p.x < -lm or p.x > lm or p.y < -lm or p.y > lm or p.z < -lm or p.z > lm then
+				return false, "Cannot teleport out of map bounds!"
+			end
+			teleportee = core.get_player_by_name(name)
+			if teleportee then
+				teleportee:setpos(p)
+				return true, "Teleporting to "..core.pos_to_string(p)
+			end
 		end
 
 		local teleportee = nil

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -348,8 +348,8 @@ core.register_chatcommand("teleport", {
 		p.x = tonumber(p.x)
 		p.y = tonumber(p.y)
 		p.z = tonumber(p.z)
-		local limit = tonumber(minetest.setting_get("map_generation_limit") or 31000)
-		if p.x < -limit or p.x > limit or p.y < -limit or p.y > limit or p.z < -limit or p.z > limit then
+		local lm = tonumber(minetest.setting_get("map_generation_limit") or 31000)
+		if p.x and (p.x < -lm or p.x > lm or p.y < -lm or p.y > lm or p.z < -lm or p.z > lm) then
 			return false, "Cannot teleport out of map bounds!"
 		end
 		teleportee = core.get_player_by_name(name)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -348,7 +348,7 @@ core.register_chatcommand("teleport", {
 		p.x = tonumber(p.x)
 		p.y = tonumber(p.y)
 		p.z = tonumber(p.z)
-		local limit = minetest.setting_get("map_generation_limit") or 31000
+		local limit = tonumber(minetest.setting_get("map_generation_limit") or 31000)
 		if p.x < -limit or p.x > limit or p.y < -limit or p.y > limit or p.z < -limit or p.z > limit then
 			return false, "Cannot teleport out of map bounds!"
 		end

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -348,6 +348,9 @@ core.register_chatcommand("teleport", {
 		p.x = tonumber(p.x)
 		p.y = tonumber(p.y)
 		p.z = tonumber(p.z)
+		if p.x < -31000 or p.x > 31000 or p.y < -31000 or p.y > 31000 or p.z < -31000 or p.z > 31000 then
+			return false, "Cannot teleport out of map bounds!"
+		end
 		teleportee = core.get_player_by_name(name)
 		if teleportee and p.x and p.y and p.z then
 			teleportee:setpos(p)


### PR DESCRIPTION
I've added a few lines to check if player is trying to /teleport across map boundary and stop serialize.h errors crashing client/server if they go too far.