### PR TITLE
FileSelectMenu: Fix formspec parsing broken by Irrlicht file-chooser

### DIFF
--- a/src/guiFileSelectMenu.cpp
+++ b/src/guiFileSelectMenu.cpp
@@ -36,6 +36,7 @@ GUIModalMenu(env, parent, id, menumgr)
 GUIFileSelectMenu::~GUIFileSelectMenu()
 {
 	removeChildren();
+	setlocale(LC_NUMERIC, "C");
 }
 
 void GUIFileSelectMenu::removeChildren()


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/4044.
Also see discussion at https://github.com/minetest/minetest/pull/3258#issuecomment-148756395.

Patch by @kahrl. Tested and works perfectly.