### PR TITLE
Add secondary viewing range

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -406,6 +406,10 @@ pause_fps_max (FPS in pause menu) int 20
 #    Min = 20
 viewing_range (Viewing range) int 100
 
+#    Secondary view distance in nodes.
+#    Hold aux1 and toggle full vrange to switch.
+viewing_range_secondary (Initial secondary viewing range) int 1000
+
 #    Width component of the initial window size.
 screenW (Screen width) int 800
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -92,6 +92,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
+	settings->setDefault("viewing_range_secondary", "1000");
 	settings->setDefault("map_generation_limit", "31000");
 	settings->setDefault("screenW", "800");
 	settings->setDefault("screenH", "600");
@@ -180,7 +181,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("enable_vbo", "true");
-	
+
 	settings->setDefault("enable_minimap", "true");
 	settings->setDefault("minimap_shape_round", "true");
 	settings->setDefault("minimap_double_scan_height", "true");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1585,7 +1585,7 @@ protected:
 
 	void increaseViewRange(float *statustext_time);
 	void decreaseViewRange(float *statustext_time);
-	void toggleFullViewRange(float *statustext_time, bool second);
+	void toggleViewRange(float *statustext_time, bool second);
 
 	void updateCameraDirection(CameraOrientation *cam, VolatileRunFlags *flags);
 	void updateCameraOrientation(CameraOrientation *cam,
@@ -2746,7 +2746,7 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_DECREASE_VIEWING_RANGE])) {
 		decreaseViewRange(statustext_time);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_RANGESELECT])) {
-		toggleFullViewRange(statustext_time, input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]));
+		toggleViewRange(statustext_time, input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]));
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_QUICKTUNE_NEXT])) {
 		quicktune->next();
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_QUICKTUNE_PREV])) {
@@ -3118,7 +3118,7 @@ void Game::decreaseViewRange(float *statustext_time)
 }
 
 
-void Game::toggleFullViewRange(float *statustext_time, bool second)
+void Game::toggleViewRange(float *statustext_time, bool second)
 {
 	static const wchar_t *msg[] = {
 		L"Disabled full viewing range",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1585,7 +1585,7 @@ protected:
 
 	void increaseViewRange(float *statustext_time);
 	void decreaseViewRange(float *statustext_time);
-	void toggleFullViewRange(float *statustext_time);
+	void toggleFullViewRange(float *statustext_time, bool second);
 
 	void updateCameraDirection(CameraOrientation *cam, VolatileRunFlags *flags);
 	void updateCameraOrientation(CameraOrientation *cam,
@@ -2746,7 +2746,7 @@ void Game::processKeyboardInput(VolatileRunFlags *flags,
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_DECREASE_VIEWING_RANGE])) {
 		decreaseViewRange(statustext_time);
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_RANGESELECT])) {
-		toggleFullViewRange(statustext_time);
+		toggleFullViewRange(statustext_time, input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_SPECIAL1]));
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_QUICKTUNE_NEXT])) {
 		quicktune->next();
 	} else if (input->wasKeyDown(keycache.key[KeyCache::KEYMAP_ID_QUICKTUNE_PREV])) {
@@ -3118,16 +3118,28 @@ void Game::decreaseViewRange(float *statustext_time)
 }
 
 
-void Game::toggleFullViewRange(float *statustext_time)
+void Game::toggleFullViewRange(float *statustext_time, bool second)
 {
 	static const wchar_t *msg[] = {
 		L"Disabled full viewing range",
 		L"Enabled full viewing range"
 	};
+	static s16 other_range = g_settings->getS16("viewing_range_secondary");
 
-	draw_control->range_all = !draw_control->range_all;
-	infostream << msg[draw_control->range_all] << std::endl;
-	statustext = msg[draw_control->range_all];
+	if (second) {
+		// Switch to secondary vrange
+		s16 range_new = other_range;
+		other_range = g_settings->getS16("viewing_range");
+
+		g_settings->set("viewing_range", itos(range_new));
+		statustext = utf8_to_wide("Viewing range changed to "
+				+ itos(range_new));
+	} else {
+		// Toggle full view range
+		draw_control->range_all = !draw_control->range_all;
+		infostream << msg[draw_control->range_all] << std::endl;
+		statustext = msg[draw_control->range_all];
+	}
 	*statustext_time = 0;
 }
 


### PR DESCRIPTION
people can temporary and simply switch to a second value,
so if they want to see further but not necessarily everything, they do not have to suffer extremely low fps if a lot map is loaded

hit r holding aux1 to switch

sorry for my bad English