### PR TITLE
Generate index mth

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -538,6 +538,23 @@ endif()
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin")
 
 
+add_executable(generate_index_mth generate_index.mth.cpp clientmedia.cpp
+								  httpfetch.cpp log.cpp debug.cpp noise.cpp
+								  util/string.cpp
+								  util/numeric.cpp
+								  util/serialize.cpp
+								  filesys.cpp
+								  porting.cpp
+								  settings.cpp
+								  version.cpp
+								  filecache.cpp
+								  	${JTHREAD_SRCS})
+target_link_libraries(generate_index_mth 
+										 ${PLATFORM_LIBS}
+			${CURL_LIBRARY})
+set_target_properties(generate_index_mth PROPERTIES
+			COMPILE_DEFINITIONS "SERVER")
+
 if(BUILD_CLIENT)
 	add_executable(${PROJECT_NAME} ${client_SRCS})
 	add_dependencies(${PROJECT_NAME} GenerateVersion)

--- a/src/clientmedia.cpp
+++ b/src/clientmedia.cpp
@@ -19,7 +19,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "clientmedia.h"
 #include "httpfetch.h"
+#ifndef SERVER
 #include "client.h"
+#endif
 #include "filecache.h"
 #include "filesys.h"
 #include "debug.h"
@@ -483,7 +485,10 @@ void ClientMediaDownloader::startRemoteMediaTransfers()
 
 void ClientMediaDownloader::startConventionalTransfers(Client *client)
 {
-	assert(m_httpfetch_active == 0);	// pre-condition
+#ifdef SERVER
+  throw "fail";
+#else
+  assert(m_httpfetch_active == 0);	// pre-condition
 
 	if (m_uncached_received_count != m_uncached_count) {
 		// Some media files have not been received yet, use the
@@ -499,6 +504,7 @@ void ClientMediaDownloader::startConventionalTransfers(Client *client)
 				m_uncached_count - m_uncached_received_count);
 		client->request_media(file_requests);
 	}
+#endif
 }
 
 void ClientMediaDownloader::conventionalTransferDone(
@@ -542,6 +548,9 @@ bool ClientMediaDownloader::checkAndLoad(
 		const std::string &name, const std::string &sha1,
 		const std::string &data, bool is_from_cache, Client *client)
 {
+#ifdef SERVER
+  throw "fail";
+#else
 	const char *cached_or_received = is_from_cache ? "cached" : "received";
 	const char *cached_or_received_uc = is_from_cache ? "Cached" : "Received";
 	std::string sha1_hex = hex_encode(sha1);
@@ -587,6 +596,7 @@ bool ClientMediaDownloader::checkAndLoad(
 		m_media_cache.update(sha1_hex, data);
 
 	return true;
+#endif
 }
 
 

--- a/src/clientmedia.h
+++ b/src/clientmedia.h
@@ -107,6 +107,7 @@ private:
 			const std::string &data, bool is_from_cache,
 			Client *client);
 
+	public:
 	std::string serializeRequiredHashSet();
 	static void deSerializeHashSet(const std::string &data,
 			std::set<std::string> &result);

--- a/src/generate_index.mth.cpp
+++ b/src/generate_index.mth.cpp
@@ -1,0 +1,27 @@
+#include "clientmedia.h"
+
+#include <iostream>
+#include <string>
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+  string hhash;
+  ClientMediaDownloader store;
+  while(!cin.eof()) {
+	getline(cin,hhash);
+	cout << "ummm " << hhash << endl;
+	if(hhash.size()<=41) {
+	  cerr << " error " << hhash << endl;
+	  return 23;
+	}
+	char hash[20];
+	for(int i=0;i<20;++i) {
+	  hex_digit_decode(hhash[2*i],hash+i);
+	}
+	store.addFile(hash,hash);
+  }
+  cout << store.serializeRequiredHashSet();
+  return 0;
+}
+

--- a/src/generate_index.mth.cpp
+++ b/src/generate_index.mth.cpp
@@ -1,4 +1,5 @@
 #include "clientmedia.h"
+#include "util/hex.h"
 
 #include <iostream>
 #include <string>
@@ -10,16 +11,17 @@ int main(int argc, char *argv[])
   ClientMediaDownloader store;
   while(!cin.eof()) {
 	getline(cin,hhash);
-	cout << "ummm " << hhash << endl;
-	if(hhash.size()<=41) {
-	  cerr << " error " << hhash << endl;
-	  return 23;
+	if(hhash.size()==0) continue;
+	if(hhash.size()<40) {
+	  cerr << " ummm " << hhash.size() << endl;
+	  continue;
 	}
-	char hash[20];
+	unsigned char hash[20];
 	for(int i=0;i<20;++i) {
-	  hex_digit_decode(hhash[2*i],hash+i);
+	  hex_digit_decode(hhash[2*i],hash[i]);
 	}
-	store.addFile(hash,hash);
+	string bhash((const char*)hash,20);
+	store.addFile(hhash,bhash);
   }
   cout << store.serializeRequiredHashSet();
   return 0;


### PR DESCRIPTION
Minetest's "remote media" stuff is a neat idea, and it lets you name the files after their sha1 hash, rather than use "content_dirt.png" or whatnot. That way you can update what dirt looks like, without clients keeping the old texture cached. 

But you cannot do that, without an index.mth file in the media directory. There doesn't seem any way to generate index.mth. Like... at all. Anywhere. 

I'm a terrible hack, but I thought there should at least be _some_ way to do it. I noticed the client generates a file of the _format_ index.mth is in, but only sends "files we don't have" to the server, rather than keeping a list of files we do have. So I wrote a quick little C++ program that uses the serialization algorithm in clientmedia.cpp to generate an index.mth from a list of hex encoded hashes on stdin. 

The idea is you'd clear your cache, connect to your own server without remote media enabled, then 

``` sh
ls cache/media | ./bin/generate_index_mth > cache/media/index.mth
```

Then you can symlink that directory from your web server's docroot, and provide the URL to that as a remote_media URL.

A better solution might be for clients to just store and update an index.mth when they download a bunch of stuff to the cache. I didn't want to take a list of "content_dirt.png" files as input, or walk the tree looking for textures/ sounds/ stuff/ etc, because hashing hundreds of files is expensive, and it's easier to just copy cache/media/ which already stores them by their hashed name. Ideally, you'd track which "content_dirt.png" filename corresponds to which hash, and when that file is newer than the hashed file, you delete the hashed file, and re-hash the named file.

...but `ls cache/media | ./bin/generate_index_mth > cache/media/index.mth` is easier.
