### PR TITLE
Add on_punchnode callback to falling.lua

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -258,3 +258,8 @@ function on_dignode(p, node)
 	nodeupdate(p)
 end
 core.register_on_dignode(on_dignode)
+
+function on_punchnode(p, node)
+	nodeupdate(p)
+end
+core.register_on_punchnode(on_punchnode)


### PR DESCRIPTION
It seems to me that if falling nodes are so unstable as to be disturbed when placing something next to them, surely punching them should cause them to fall as well.