### PR TITLE
Fix use of uninitialised variable in class Event

### DIFF
--- a/src/threading/event.cpp
+++ b/src/threading/event.cpp
@@ -25,17 +25,20 @@ DEALINGS IN THE SOFTWARE.
 
 #include "threading/event.h"
 
-#if __cplusplus < 201103L
 Event::Event()
+    : notified(false)
 {
-#ifdef _WIN32
+#if __cplusplus < 201103L
+#	ifdef _WIN32
 	event = CreateEvent(NULL, false, false, NULL);
-#else
+#	else
 	pthread_cond_init(&cv, NULL);
 	pthread_mutex_init(&mutex, NULL);
+#	endif
 #endif
 }
 
+#if __cplusplus < 201103L
 Event::~Event()
 {
 #ifdef _WIN32

--- a/src/threading/event.h
+++ b/src/threading/event.h
@@ -48,8 +48,8 @@ DEALINGS IN THE SOFTWARE.
  */
 class Event {
 public:
-#if __cplusplus < 201103L
 	Event();
+#if __cplusplus < 201103L
 	~Event();
 #endif
 	void wait();


### PR DESCRIPTION
Event::notified was not being initialised to false (relying on undefined behaviour)