### PR TITLE
Fix #4057 (weird Shift behavior)

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -611,7 +611,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			prompt.nickCompletion(names, backwards);
 			return true;
 		}
-		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)
+		else if(isprint(event.KeyInput.Char) && !event.KeyInput.Control)
 		{
 			#if (defined(linux) || defined(__linux))
 				wchar_t wc = L'_';


### PR DESCRIPTION
I don't know if this internally more Irrlicht's problem, but I find nothing bad in using `isprint` instead of `!= 0`.

What about special symbols in the console: it definitely Irrlicht's issue and I've created [patch request](https://sourceforge.net/p/irrlicht/patches/313/) for it. Hope it will be merged soon.
