### PR TITLE
[Proof of concept] Re-enable mod store and use a forum parser based DB

### DIFF
--- a/builtin/mainmenu/tab_mods.lua
+++ b/builtin/mainmenu/tab_mods.lua
@@ -36,10 +36,7 @@ local function get_formspec(tabview, name, tabdata)
 --		"label[0.8,4.2;" .. fgettext("Add mod:") .. "]" ..
 --		TODO Disabled due to upcoming release 0.4.8 and irrlicht messing up localization
 --		"button[0.75,4.85;1.8,0.5;btn_mod_mgr_install_local;".. fgettext("Local install") .. "]" ..
-
---		TODO Disabled due to service being offline, and not likely to come online again, in this form
---		"button[0,4.85;5.25,0.5;btn_modstore;".. fgettext("Online mod repository") .. "]"
-		""
+		"button[0,4.85;5.25,0.5;btn_modstore;".. fgettext("Online mod repository") .. "]"
 
 	local selected_mod = nil
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -180,7 +180,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("enable_vbo", "true");
-	
+
 	settings->setDefault("enable_minimap", "true");
 	settings->setDefault("minimap_shape_round", "true");
 	settings->setDefault("minimap_double_scan_height", "true");
@@ -328,9 +328,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("main_menu_path", "");
 	settings->setDefault("main_menu_mod_mgr", "1");
 	settings->setDefault("main_menu_game_mgr", "0");
-	settings->setDefault("modstore_download_url", "https://forum.minetest.net/media/");
-	settings->setDefault("modstore_listmods_url", "https://forum.minetest.net/mmdb/mods/");
-	settings->setDefault("modstore_details_url", "https://forum.minetest.net/mmdb/mod/*/");
+	settings->setDefault("modstore_download_url", "http://app-mtmm.rubenwardy.com/");
+	settings->setDefault("modstore_listmods_url", "http://app-mtmm.rubenwardy.com/mods/");
+	settings->setDefault("modstore_details_url", "http://app-mtmm.rubenwardy.com/mod/*/");
 
 	settings->setDefault("high_precision_fpu", "true");
 

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -247,7 +247,7 @@ HTTPFetchOngoing::HTTPFetchOngoing(HTTPFetchRequest request_, CurlHandlePool *po
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 1);
+	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3);
 
 	std::string bind_address = g_settings->get("bind_address");
 	if (!bind_address.empty()) {


### PR DESCRIPTION
https://github.com/rubenwardy/mtmods4android_server

The server gets a list from Krock's mod search, and then validates it and improves it. This includes:
- Checking modname, authorname, download url.
- Checks that the download doesn't 404, but goes to a zip file.
- Fetches description.txt and depends.txt from Github based repos
- Download link points to the latest known commit. The commit hash is given and should be used to verify contents (if possible).

Not ready to be used due to:
- Needs to get a hash of the download to check for malicious modification
- Non-github downloads are still listed, but will be insecure due to no way to point to a commit
- When updating the commit the download link points to, the download should be virus scanned
- No category support yet
- No rating support yet
- No way for a mod owner to log into the db and correct things.
- MMDB uses modname as a primary key, where as my DB uses modname and author as a composite primary key. The ingame mod store needs to be changed to reflect this - my database supports multiple mods with the same name (eg: tenplus1/mobs vs pilzadam/mobs), whereas mmdb didn't

This is a proof of concept pr that shows that it is possible for a forum based parser to work well.

TL;DR: It all works, except it lacks features and security.
