### PR TITLE
Add [scale texture modifier

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -279,6 +279,13 @@ Example:
 
     [combine:16x32:0,0=default_cobble.png:0,16=default_wood.png
 
+#### `[resize:<w>x<h>`
+Resizes the texture to the given dimensions.
+
+Example:
+
+    default_sandstone.png^[resize:16x16
+
 #### `[brighten`
 Brightens the texture.
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1352,7 +1352,6 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			u32 r1 = stoi(sf.next(","));
 			u32 g1 = stoi(sf.next(","));
 			u32 b1 = stoi(sf.next(""));
-			std::string filename = sf.next("");
 
 			core::dimension2d<u32> dim = baseimg->getDimension();
 
@@ -1710,6 +1709,31 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 					baseimg = newimg;
 				}
 			}
+		}
+		/*
+			[resize:WxH
+			Resizes the base image to the given dimensions
+		*/
+		else if (str_starts_with(part_of_name, "[resize"))
+		{
+			if (baseimg == NULL) {
+				errorstream << "generateImagePart(): baseimg == NULL "
+						<< "for part_of_name=\""<< part_of_name
+						<< "\", cancelling." << std::endl;
+				return false;
+			}
+
+			Strfnd sf(part_of_name);
+			sf.next(":");
+			u32 width = stoi(sf.next("x"));
+			u32 height = stoi(sf.next(""));
+			core::dimension2d<u32> dim(width, height);
+
+			video::IImage* image = m_device->getVideoDriver()->
+				createImage(video::ECF_A8R8G8B8, dim);
+			baseimg->copyToScaling(image);
+			baseimg->drop();
+			baseimg = image;
 		}
 		else
 		{


### PR DESCRIPTION
Scales the texture to the given dimensions.
Partly fixes #4081

Without `^[scale` modifier:
![screenshot_20160503_203646_](https://cloud.githubusercontent.com/assets/1497498/14994192/d13a479a-116e-11e6-97f2-31819bc13d63.png)


With `^[scale`modifier:
![screenshot_20160503_203540_](https://cloud.githubusercontent.com/assets/1497498/14994172/b928c3a2-116e-11e6-96f6-ae1a98719ac2.png)