### PR TITLE
Defaultsettings/Android: Increase 'max block generate distance' to 3

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -349,7 +349,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_simultaneous_block_sends_per_client", "3");
 	settings->setDefault("emergequeue_limit_diskonly", "8");
 	settings->setDefault("emergequeue_limit_generate", "8");
-	settings->setDefault("max_block_generate_distance", "2");
+	settings->setDefault("max_block_generate_distance", "3");
 	settings->setDefault("enable_3d_clouds", "false");
 	settings->setDefault("fps_max", "30");
 	settings->setDefault("pause_fps_max", "10");


### PR DESCRIPTION
A recent commit set this to 2. ```settings->setDefault("max_block_generate_distance", "3");``` Will not have much impact on performance, it ensures neighbouring chunks are reliably generated (because chunks are 3 blocks across) so that if a larger view range is used, landscape looks better instead of stopping 32 nodes away, which is too close.
client_mapblock_limit = 500 allows the world to be shown up to 50 nodes distance, so world should be generated this far too.

Because players mostly wander around, chunks that are generated earlier will then not have to be generated later as the player wanders around back into those neighbouring areas. So this does not increase the total number of chunks generated by much, just makes them generate earlier, while improving the view of the world.

The worst case is a player travelling along a long path, depending on their position within chunks the strip of world generated may be 3 chunks across instead of 2.