### PR TITLE
Android: enable parallelism for main target too

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -752,7 +752,7 @@ clean_assets :
 apk: local.properties assets $(ICONV_LIB) $(IRRLICHT_LIB) $(CURL_LIB) $(GMP_LIB) $(LEVELDB_TARGET)       \
 	$(OPENAL_LIB) $(OGG_LIB) prep_srcdir $(ANDR_ROOT)/jni/src/android_version.h    \
 	$(ANDR_ROOT)/jni/src/android_version_githash.h sqlite3_download
-	@${ANDROID_NDK}/ndk-build NDK_MODULE_PATH=${NDK_MODULE_PATH}               \
+	+ @${ANDROID_NDK}/ndk-build NDK_MODULE_PATH=${NDK_MODULE_PATH}             \
 		GPROF=${GPROF} APP_ABI=${TARGET_ABI} HAVE_LEVELDB=${HAVE_LEVELDB}      \
 		APP_PLATFORM=${APP_PLATFORM}                                           \
 		TARGET_LIBDIR=${TARGET_LIBDIR}                                         \


### PR DESCRIPTION
Little build speedup for the android build if parallelism is enabled.

Just made a PR so that the change doesn't get forgotten, because now it can't be pushed due to the freeze for 0.4.14.