### PR TITLE
Implement a PostgreSQL backend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -189,6 +189,30 @@ if(ENABLE_CURSES)
 	endif()
 endif(ENABLE_CURSES)
 
+option(ENABLE_POSTGRESQL "Enable PostgreSQL backend" TRUE)
+set(USE_POSTGRESQL FALSE)
+
+if(ENABLE_POSTGRESQL)
+	find_program(PG_CONFIG_EXECUTABLE pg_config DOC "pg_config")
+	find_library(PG_LIBRARY pq)
+	if(PG_CONFIG_EXECUTABLE)
+		execute_process(COMMAND ${PG_CONFIG_EXECUTABLE} --includedir-server
+			OUTPUT_VARIABLE PostgreSQL_SERVER_INCLUDE_DIRS
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		set(PostgreSQL_ADDITIONAL_SEARCH_PATHS ${PostgreSQL_SERVER_INCLUDE_DIRS})
+	endif()
+
+	find_package("PostgreSQL")
+
+	if(PG_LIBRARY AND PG_CONFIG_EXECUTABLE)
+		set(USE_POSTGRESQL TRUE)
+		message(STATUS "PostgreSQL backend enabled")
+		include_directories(${PostgreSQL_INCLUDE_DIR})
+	else()
+		message(STATUS "PostgreSQL not found!")
+	endif()
+endif(ENABLE_POSTGRESQL)
+
 option(ENABLE_LEVELDB "Enable LevelDB backend" TRUE)
 set(USE_LEVELDB FALSE)
 
@@ -361,6 +385,7 @@ set(common_SRCS
 	craftdef.cpp
 	database-dummy.cpp
 	database-leveldb.cpp
+	database-postgresql.cpp
 	database-redis.cpp
 	database-sqlite3.cpp
 	database.cpp
@@ -592,6 +617,9 @@ if(BUILD_CLIENT)
 	if (USE_CURSES)
 		target_link_libraries(${PROJECT_NAME} ${CURSES_LIBRARIES})
 	endif()
+	if (USE_POSTGRESQL)
+		target_link_libraries(${PROJECT_NAME} ${PG_LIBRARY})
+	endif()
 	if (USE_LEVELDB)
 		target_link_libraries(${PROJECT_NAME} ${LEVELDB_LIBRARY})
 	endif()
@@ -621,6 +649,9 @@ if(BUILD_SERVER)
 			COMPILE_DEFINITIONS "SERVER")
 	if (USE_CURSES)
 		target_link_libraries(${PROJECT_NAME}server ${CURSES_LIBRARIES})
+	endif()
+	if (USE_POSTGRESQL)
+		target_link_libraries(${PROJECT_NAME}server ${PG_LIBRARY})
 	endif()
 	if (USE_LEVELDB)
 		target_link_libraries(${PROJECT_NAME}server ${LEVELDB_LIBRARY})

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -22,6 +22,7 @@
 #cmakedefine01 USE_CURSES
 #cmakedefine01 USE_LEVELDB
 #cmakedefine01 USE_LUAJIT
+#cmakedefine01 USE_POSTGRESQL
 #cmakedefine01 USE_SPATIAL
 #cmakedefine01 USE_SYSTEM_GMP
 #cmakedefine01 USE_REDIS

--- a/src/database-postgresql.cpp
+++ b/src/database-postgresql.cpp
@@ -1,0 +1,266 @@
+/*
+Copyright (C) 2016 Loic Blot <loic.blot@unix-experience.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "config.h"
+
+#if USE_POSTGRESQL
+
+#include "database-postgresql.h"
+
+#include "log.h"
+#include "exceptions.h"
+#include "settings.h"
+
+/*
+ * IMPORTANT NOTICE
+ * Every conversion from non string to const char* values
+ * should be done by using an intermediate std::string
+ * buffer.
+ * If you don't use this intermediate, the conversion
+ * to std::string followed by conversion to const char*
+ * could have bad issues, refering to bad memory areas.
+ */
+
+Database_PostgreSQL::Database_PostgreSQL(const Settings &conf):
+	m_connect_string(""), m_conn(NULL), m_pgversion(0)
+{
+	try {
+		m_connect_string = conf.get("pgsql_connection");
+	} catch (SettingNotFoundException) {
+		throw SettingNotFoundException("Set pgsql_connection string in world.mt to "
+			"use the postgresql backend\n"
+			"Notes:\n"
+			"pgsql_connection has the following form: \n"
+			"\tpgsql_connection = host=127.0.0.1 port=5432 user=mt_user password=mt_password dbname=minetest_amazingworld\n"
+			"mt_user should have CREATE TABLE, INSERT, SELECT, UPDATE and DELETE rights on the database.\n"
+			"Don't create mt_user as a SUPERUSER!");
+	}
+
+	connectToDatabase();
+}
+
+Database_PostgreSQL::~Database_PostgreSQL()
+{
+	PQfinish(m_conn);
+}
+
+void Database_PostgreSQL::connectToDatabase()
+{
+	m_conn = PQconnectdb(m_connect_string.c_str());
+
+	if (PQstatus(m_conn) != CONNECTION_OK) {
+		throw DatabaseException(std::string(
+			"PostgreSQL database error: ") +
+			PQerrorMessage(m_conn));
+	}
+
+	m_pgversion = PQserverVersion(m_conn);
+
+	if (m_pgversion < 90500) {
+		throw DatabaseException("PostgreSQL database error: "
+			"Server version 9.5 or greater required.");
+	}
+
+	infostream << "PostgreSQL Database: Version " << m_pgversion << " Connection made." << std::endl;
+}
+
+void Database_PostgreSQL::verifyDatabase()
+{
+	if (PQstatus(m_conn) == CONNECTION_OK)
+		return;
+
+	PQreset(m_conn);
+	ping();
+}
+
+bool Database_PostgreSQL::ping()
+{
+	if (PQping(m_connect_string.c_str()) != PQPING_OK) {
+		throw DatabaseException(std::string(
+			"PostgreSQL database error: ") +
+			PQerrorMessage(m_conn));
+	}
+	return true;
+}
+
+bool Database_PostgreSQL::initialized() const
+{
+	return (PQstatus(m_conn) == CONNECTION_OK);
+}
+
+void Database_PostgreSQL::initStatements()
+{
+	prepareStatement("read_block",
+			"SELECT block_data FROM blocks "
+					"WHERE posX = $1::int AND posY = $2::int AND posZ = $3::int");
+
+	prepareStatement("write_block",
+			"INSERT INTO blocks (posX, posY, posZ, block_data) VALUES "
+					"($1::int, $2::int, $3::int, $4::bytea) "
+					"ON CONFLICT ON CONSTRAINT blocks_pkey DO UPDATE SET block_data = $4::bytea");
+
+	prepareStatement("delete_block", "DELETE FROM blocks WHERE posX = $1::int, posY = $2::int, posZ = $3::int");
+
+	prepareStatement("list_all_loadable_blocks", "SELECT posX, posY, posZ FROM blocks");
+}
+
+void Database_PostgreSQL::prepareStatement(const std::string &name, const std::string &sql)
+{
+	resultsCheck(PQprepare(m_conn, name.c_str(), sql.c_str(), 0, NULL));
+}
+
+PGresult* Database_PostgreSQL::resultsCheck(PGresult* result, bool clear /*= true*/)
+{
+	ExecStatusType statusType = PQresultStatus(result);
+
+	if ((statusType != PGRES_COMMAND_OK && statusType != PGRES_TUPLES_OK) ||
+		statusType == PGRES_FATAL_ERROR) {
+		throw DatabaseException(std::string(
+			"PostgreSQL database error: ") +
+			PQresultErrorMessage(result));
+	}
+
+	if (clear)
+		PQclear(result);
+
+	return result;
+}
+
+void Database_PostgreSQL::createDatabase()
+{
+	PGresult *result = resultsCheck(PQexec(m_conn,
+		"SELECT relname FROM pg_class WHERE relname='blocks';"),
+		false);
+
+	// If table doesn't exist, create it
+	if (!PQntuples(result)) {
+		const std::string dbcreate_sql = "CREATE TABLE blocks ("
+			"posX INT NOT NULL,"
+			"posY INT NOT NULL,"
+			"posZ INT NOT NULL,"
+			"block_data BYTEA,"
+			"PRIMARY KEY (posX,posY,posZ)"
+		");";
+		resultsCheck(PQexec(m_conn, dbcreate_sql.c_str()));
+	}
+
+	PQclear(result);
+
+	infostream << "PostgreSQL: Game Database was inited." << std::endl;
+}
+
+
+/**
+ * @brief Database_PostgreSQL::beginSave
+ *
+ * Start a write transaction
+ */
+void Database_PostgreSQL::beginSave()
+{
+	verifyDatabase();
+	resultsCheck(PQexec(m_conn, "BEGIN;"));
+}
+
+/**
+ * @brief Database_PostgreSQL::endSave
+ *
+ * Commit current transaction to DB
+ */
+void Database_PostgreSQL::endSave()
+{
+	resultsCheck(PQexec(m_conn, "COMMIT;"));
+}
+
+/**
+ * @brief Database_PostgreSQL::saveBlock
+ * @param pos
+ * @param data
+ * @return always true
+ *
+ * Save a block to the database
+ */
+bool Database_PostgreSQL::saveBlock(const v3s16 &pos, const std::string &data)
+{
+	verifyDatabase();
+
+	// This case is manually handled because we manipulate blob datas
+	std::string x = itos(pos.X), y = itos(pos.Y), z = itos(pos.Z);
+	const char *values[] = {x.c_str(), y.c_str(), z.c_str(), data.c_str()};
+	const int valLen[] = {sizeof(int), sizeof(int), sizeof(int), (int)data.size()};
+	const int valFormats[] = { 0, 0, 0, 1 };
+
+	resultsCheck(PQexecPrepared(m_conn, "write_block", 4,
+				values, valLen, valFormats, 1), true);
+	return true;
+}
+
+/**
+ * @brief Database_PostgreSQL::loadBlock
+ * @param pos
+ * @return block datas
+ */
+std::string Database_PostgreSQL::loadBlock(const v3s16 &pos)
+{
+	verifyDatabase();
+
+	std::string x = itos(pos.X), y = itos(pos.Y), z = itos(pos.Z);
+	const char *values[] = {x.c_str(), y.c_str(), z.c_str()};
+
+	PGresult *results = execPrepared("read_block", 3, values, false, false);
+
+	std::string data = "";
+
+	if (PQntuples(results)) {
+		size_t rd_s;
+		unsigned char* rd = PQunescapeBytea((unsigned char*)PQgetvalue(results, 0, 0), &rd_s);
+		data = std::string((char*)rd, rd_s);
+		PQfreemem(rd);
+	}
+
+	PQclear(results);
+
+	return data;
+}
+
+bool Database_PostgreSQL::deleteBlock(const v3s16 &pos)
+{
+	verifyDatabase();
+
+	std::string x = itos(pos.X), y = itos(pos.Y), z = itos(pos.Z);
+	const char *values[] = {x.c_str(), y.c_str(), z.c_str()};
+
+	execPrepared("read_block", 3, values);
+
+	return true;
+}
+
+void Database_PostgreSQL::listAllLoadableBlocks(std::vector<v3s16> &dst)
+{
+	verifyDatabase();
+
+	PGresult *results = execPrepared("list_all_loadable_blocks", 0, NULL, false, false);
+	int numrows = PQntuples(results);
+
+	for (int row = 0; row < numrows; ++row) {
+		dst.push_back(pg_to_v3s16(results, 0, 0));
+	}
+
+	PQclear(results);
+}
+
+#endif // USE_POSTGRESQL

--- a/src/database-postgresql.h
+++ b/src/database-postgresql.h
@@ -1,0 +1,85 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef DATABASE_POSTGRESQL_HEADER
+#define DATABASE_POSTGRESQL_HEADER
+
+#include "database.h"
+#include <string>
+#include <libpq-fe.h>
+
+class Settings;
+
+class Database_PostgreSQL : public Database
+{
+public:
+	Database_PostgreSQL(const Settings &conf);
+	~Database_PostgreSQL();
+
+	void beginSave();
+	void endSave();
+
+	bool saveBlock(const v3s16 &pos, const std::string &data);
+	std::string loadBlock(const v3s16 &pos);
+	bool deleteBlock(const v3s16 &pos);
+	void listAllLoadableBlocks(std::vector<v3s16> &dst);
+	bool initialized() const;
+
+private:
+	// Database initialization
+	void connectToDatabase();
+	void initStatements();
+	void createDatabase();
+	void prepareStatement(const std::string &name, const std::string &sql);
+
+	// Database connectivity checks
+	bool ping();
+	void verifyDatabase();
+
+	// Database usage
+	PGresult* resultsCheck(PGresult* res, bool clear = true);
+
+	inline PGresult* execPrepared(const char* stmtName, const int nbParams,
+			const char** params, bool clear = true, bool nobinary = true)
+	{
+		return resultsCheck(PQexecPrepared(m_conn, stmtName, nbParams,
+			params, NULL, NULL, nobinary ? 1 : 0), clear);
+	}
+
+	// Conversion helpers
+	inline const int pg_to_int(PGresult *res, int row, int col) {
+		return atoi(PQgetvalue(res, row, col));
+	}
+
+	inline const v3s16 pg_to_v3s16(PGresult *res, int row, int col) {
+		return v3s16(
+			pg_to_int(res, row, col),
+			pg_to_int(res, row, col + 1),
+			pg_to_int(res, row, col + 2)
+		);
+	}
+
+	// Attributes
+	std::string m_connect_string;
+	PGconn* m_conn;
+	int m_pgversion;
+};
+
+#endif
+

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -47,7 +47,7 @@ SQLite format specification:
 
 #define SQLRES(s, r, m) \
 	if ((s) != (r)) { \
-		throw FileNotGoodException(std::string(m) + ": " +\
+		throw DatabaseException(std::string(m) + ": " +\
 				sqlite3_errmsg(m_database)); \
 	}
 #define SQLOK(s, m) SQLRES(s, SQLITE_OK, m)

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -65,6 +65,11 @@ public:
 	FileNotGoodException(const std::string &s): BaseException(s) {}
 };
 
+class DatabaseException : public BaseException {
+public:
+	DatabaseException(const std::string &s): BaseException(s) {}
+};
+
 class SerializationError : public BaseException {
 public:
 	SerializationError(const std::string &s): BaseException(s) {}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -50,6 +50,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_REDIS
 #include "database-redis.h"
 #endif
+#if USE_POSTGRESQL
+#include "database-postgresql.h"
+#endif
 
 #define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
 
@@ -3239,6 +3242,10 @@ Database *ServerMap::createDatabase(
 	#if USE_REDIS
 	else if (name == "redis")
 		return new Database_Redis(conf);
+	#endif
+	#if USE_POSTGRESQL
+	else if (name == "postgresql")
+		return new Database_PostgreSQL(conf);
 	#endif
 	else
 		throw BaseException(std::string("Database backend ") + name + " not supported.");


### PR DESCRIPTION
PostgreSQL is better than redis for huge maps because redis will use many memory and for maps > server memory redis cannot handle it properly (in recent versions, since redis 3) because redis will load all in memory.
I use postgresql on my fork (epixel) since 1 year with a very larger backend (not also map but all players and many content) and it works very well.

I decided to backport it to MT for next release