### PR TITLE
Avoid calling DiePlayer more than once

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1101,8 +1101,9 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 				<< (int)damage << " hp at " << PP(player->getPosition() / BS)
 				<< std::endl;
 
-		playersao->setHP(playersao->getHP() - damage);
-		SendPlayerHPOrDie(playersao);
+		u8 oldhp = playersao->getHP();
+		playersao->setHP(oldhp - damage);
+		SendPlayerHPOrDie(playersao, oldhp);
 	}
 }
 
@@ -1464,12 +1465,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			// If the object is a player and its HP changed
 			if (src_original_hp != pointed_object->getHP() &&
 					pointed_object->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-				SendPlayerHPOrDie((PlayerSAO *)pointed_object);
+				SendPlayerHPOrDie((PlayerSAO *)pointed_object, src_original_hp);
 			}
 
 			// If the puncher is a player and its HP changed
 			if (dst_origin_hp != playersao->getHP())
-				SendPlayerHPOrDie(playersao);
+				SendPlayerHPOrDie(playersao, dst_origin_hp);
 		}
 
 	} // action == 0

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -230,13 +230,13 @@ int ObjectRef::l_punch(lua_State *L)
 	// If the punched is a player, and its HP changed
 	if (src_original_hp != co->getHP() &&
 			co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co);
+		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co, src_original_hp);
 	}
 
 	// If the puncher is a player, and its HP changed
 	if (dst_origin_hp != puncher->getHP() &&
 			puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher);
+		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher, dst_origin_hp);
 	}
 	return 0;
 }
@@ -270,9 +270,10 @@ int ObjectRef::l_set_hp(lua_State *L)
 	/*infostream<<"ObjectRef::l_set_hp(): id="<<co->getId()
 			<<" hp="<<hp<<std::endl;*/
 	// Do it
+	s16 oldhp = co->getHP();
 	co->setHP(hp);
 	if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER)
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co);
+		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co, oldhp);
 
 	// Return
 	return 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1105,7 +1105,7 @@ PlayerSAO* Server::StageTwoClientInit(u16 peer_id)
 	SendInventory(playersao);
 
 	// Send HP
-	SendPlayerHPOrDie(playersao);
+	SendPlayerHPOrDie(playersao, playersao->getHP());
 
 	// Send Breath
 	SendPlayerBreath(peer_id);
@@ -1497,7 +1497,7 @@ void Server::SendMovement(u16 peer_id)
 	Send(&pkt);
 }
 
-void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
+void Server::SendPlayerHPOrDie(PlayerSAO *playersao, s16 oldhp)
 {
 	if (!g_settings->getBool("enable_damage"))
 		return;
@@ -1505,10 +1505,12 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 	u16 peer_id   = playersao->getPeerID();
 	bool is_alive = playersao->getHP() > 0;
 
-	if (is_alive)
-		SendPlayerHP(peer_id);
-	else
+	// Make sure that the player only dies once.
+	if (playersao->getHP() < oldhp && !is_alive) {
 		DiePlayer(peer_id);
+	} else {
+		SendPlayerHP(peer_id);
+	}
 }
 
 void Server::SendHP(u16 peer_id, u8 hp)

--- a/src/server.h
+++ b/src/server.h
@@ -376,7 +376,7 @@ public:
 
 	void printToConsoleOnly(const std::string &text);
 
-	void SendPlayerHPOrDie(PlayerSAO *player);
+	void SendPlayerHPOrDie(PlayerSAO *player, s16 oldhp);
 	void SendPlayerBreath(u16 peer_id);
 	void SendInventory(PlayerSAO* playerSAO);
 	void SendMovePlayer(u16 peer_id);


### PR DESCRIPTION
Fixes #3565 by making sure that `DiePlayer` is not called unless the player went from having positive health to 0 health and is not already dead.
