### PR TITLE
Allow flooding to cause item drops

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -294,7 +294,8 @@ public:
 	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
 	virtual void PrintInfo(std::ostream &out);
 
-	void transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks);
+	void transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks,
+						  ServerEnvironment& env);
 
 	/*
 		Node metadata

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -42,7 +42,11 @@ bool ScriptApiItem::item_OnDrop(ItemStack &item,
 
 	// Call function
 	LuaItemStack::create(L, item);
-	objectrefGetOrCreate(L, dropper);
+	if(dropper == NULL) {
+	  lua_pushnil(L);
+	} else {
+	  objectrefGetOrCreate(L, dropper);
+	}
 	pushFloatPos(L, pos);
 	PCALL_RES(lua_pcall(L, 3, 1, error_handler));
 	if (!lua_isnil(L, -1)) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -612,7 +612,7 @@ void Server::AsyncRunStep(bool initial_step)
 		ScopeProfiler sp(g_profiler, "Server: liquid transform");
 
 		std::map<v3s16, MapBlock*> modified_blocks;
-		m_env->getMap().transformLiquids(modified_blocks);
+		m_env->getMap().transformLiquids(modified_blocks, *m_env);
 #if 0
 		/*
 			Update lighting


### PR DESCRIPTION
Non-air nodes can be defined as floodable, and now they'll drop their contents rather than just being replaced with air.