### PR TITLE
allow mods to change the velocity of players

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2644,6 +2644,7 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_look_yaw()`: yaw in radians (wraps around pretty randomly as of now)
 * `set_look_pitch(radians)`: sets look pitch
 * `set_look_yaw(radians)`: sets look yaw
+* `set_player_velocity({x=num, y=num, z=num}, relative=false)`: changes the velocity of the player
 * `get_breath()`: returns players breath
 * `set_breath(value)`: sets players breath
      * values:

--- a/src/client.h
+++ b/src/client.h
@@ -369,6 +369,7 @@ public:
 	void handleCommand_HP(NetworkPacket* pkt);
 	void handleCommand_Breath(NetworkPacket* pkt);
 	void handleCommand_MovePlayer(NetworkPacket* pkt);
+	void handleCommand_VelocityPlayer(NetworkPacket* pkt);
 	void handleCommand_PlayerItem(NetworkPacket* pkt);
 	void handleCommand_DeathScreen(NetworkPacket* pkt);
 	void handleCommand_AnnounceMedia(NetworkPacket* pkt);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1063,6 +1063,15 @@ void PlayerSAO::setPitch(float pitch)
 	((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
 }
 
+void PlayerSAO::setVelocity(v3f vel, bool relative)
+{
+	if(isAttached())
+		return;
+	m_player->vel_change = vel;
+	m_player->vel_change_relative = relative;
+	((Server*)m_env->getGameDef())->SendVelocityPlayer(m_peer_id);
+}
+
 int PlayerSAO::punch(v3f dir,
 	const ToolCapabilities *toolcap,
 	ServerActiveObject *puncher,

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -185,6 +185,7 @@ public:
 	void moveTo(v3f pos, bool continuous);
 	void setYaw(float);
 	void setPitch(float);
+	void setVelocity(v3f vel, bool relative);
 
 	/*
 		Interaction interface

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -71,7 +71,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,
-	null_command_handler,
+	{ "TOCLIENT_VELOCITY_PLAYER",          TOCLIENT_STATE_CONNECTED, &Client::handleCommand_VelocityPlayer }, // 0x2f
 	{ "TOCLIENT_CHAT_MESSAGE",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatMessage }, // 0x30
 	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectRemoveAdd }, // 0x31
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectMessages }, // 0x32

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -578,6 +578,27 @@ void Client::handleCommand_MovePlayer(NetworkPacket* pkt)
 	m_ignore_damage_timer = 3.0;
 }
 
+void Client::handleCommand_VelocityPlayer(NetworkPacket* pkt)
+{
+	Player *player = m_env.getLocalPlayer();
+	assert(player != NULL);
+
+	v3f vel;
+	bool relative;
+
+	*pkt >> vel >> relative;
+
+	if (relative)
+		vel += player->getSpeed();
+
+	player->setSpeed(vel);
+
+	infostream << "Client got TOCLIENT_VELOCITY_PLAYER"
+			<< " pos=(" << vel.X << "," << vel.Y << "," << vel.Z << ")"
+			<< " relative=" << relative
+			<< std::endl;
+}
+
 void Client::handleCommand_PlayerItem(NetworkPacket* pkt)
 {
 	warningstream << "Client: Ignoring TOCLIENT_PLAYERITEM" << std::endl;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -283,6 +283,12 @@ enum ToClientCommand
 
 	// (oops, there is some gap here)
 
+	TOCLIENT_VELOCITY_PLAYER = 0x2f,
+	/*
+		v3f1000 player velocity
+		u8 bool relative
+	*/
+
 	TOCLIENT_CHAT_MESSAGE = 0x30,
 	/*
 		u16 length

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -160,7 +160,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,
-	null_command_factory,
+	{ "TOCLIENT_VELOCITY_PLAYER",          0, true }, // 0x2f
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x30
 	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", 0, true }, // 0x31
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   0, true }, // 0x32 Special packet, sent by 0 (rel) and 1 (unrel) channel

--- a/src/player.h
+++ b/src/player.h
@@ -332,6 +332,9 @@ public:
 	v3f eye_offset_first;
 	v3f eye_offset_third;
 
+	v3f vel_change;
+	bool vel_change_relative;
+
 	Inventory inventory;
 
 	f32 movement_acceleration_default;
@@ -432,6 +435,7 @@ public:
 	void setPlayerSAO(PlayerSAO *sao)
 	{ m_sao = sao; }
 	void setPosition(const v3f &position);
+	void setVelocity(const v3f &vel, const bool relative);
 
 private:
 	PlayerSAO *m_sao;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1073,6 +1073,20 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 	return 1;
 }
 
+// set_player_velocity(self, velocity, relative)
+int ObjectRef::l_set_player_velocity(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
+	v3f vel = checkFloatPos(L, 2);
+	bool relative = lua_toboolean(L, 3);
+	// Do it
+	co->setVelocity(vel, relative);
+	return 0;
+}
+
 // set_breath(self, breath)
 int ObjectRef::l_set_breath(lua_State *L)
 {
@@ -1756,6 +1770,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_look_yaw),
 	luamethod(ObjectRef, set_look_yaw),
 	luamethod(ObjectRef, set_look_pitch),
+	luamethod(ObjectRef, set_player_velocity),
 	luamethod(ObjectRef, get_breath),
 	luamethod(ObjectRef, set_breath),
 	luamethod(ObjectRef, set_inventory_formspec),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -201,6 +201,9 @@ private:
 	// set_look_yaw(self, radians)
 	static int l_set_look_yaw(lua_State *L);
 
+	// set_player_velocity(self, velocity, relative)
+	static int l_set_player_velocity(lua_State *L);
+
 	// set_breath(self, breath)
 	static int l_set_breath(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1098,6 +1098,8 @@ PlayerSAO* Server::StageTwoClientInit(u16 peer_id)
 	*/
 	SendMovePlayer(peer_id);
 
+	SendVelocityPlayer(peer_id);
+
 	// Send privileges
 	SendPlayerPrivileges(peer_id);
 
@@ -1887,6 +1889,27 @@ void Server::SendMovePlayer(u16 peer_id)
 				<< " pos=(" << pos.X << "," << pos.Y << "," << pos.Z << ")"
 				<< " pitch=" << pitch
 				<< " yaw=" << yaw
+				<< std::endl;
+	}
+
+	Send(&pkt);
+}
+
+void Server::SendVelocityPlayer(u16 peer_id)
+{
+	DSTACK(FUNCTION_NAME);
+	Player *player = m_env->getPlayer(peer_id);
+	assert(player);
+
+	NetworkPacket pkt(TOCLIENT_VELOCITY_PLAYER, sizeof(v3f) + sizeof(bool), peer_id);
+	pkt << player->vel_change << player->vel_change_relative;
+
+	{
+		v3f vel = player->vel_change;
+		bool relative = player->vel_change_relative;
+		verbosestream << "Server: Sending TOCLIENT_VELOCITY_PLAYER"
+				<< " pos=(" << vel.X << "," << vel.Y << "," << vel.Z << ")"
+				<< " relative=" << relative
 				<< std::endl;
 	}
 

--- a/src/server.h
+++ b/src/server.h
@@ -378,6 +378,7 @@ public:
 	void SendPlayerBreath(u16 peer_id);
 	void SendInventory(PlayerSAO* playerSAO);
 	void SendMovePlayer(u16 peer_id);
+	void SendVelocityPlayer(u16 peer_id);
 
 	// Bind address
 	Address m_bind_addr;


### PR DESCRIPTION
it can optionally be set relatively to perform pushes

@sofar this can be used to make tnt push players

l added the set_player_velocity instead of making set_velocity work for players because of compatibility to #1489.