### PR TITLE
 Item entities: Don't show description as infotext

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -31,7 +31,6 @@ core.register_entity(":__builtin:item", {
 		spritediv = {x = 1, y = 1},
 		initial_sprite_basepos = {x = 0, y = 0},
 		is_visible = false,
-		infotext = "",
 	},
 
 	itemstring = '',
@@ -51,7 +50,6 @@ core.register_entity(":__builtin:item", {
 		local c = s
 		local itemtable = stack:to_table()
 		local itemname = nil
-		local description = ""
 		if itemtable then
 			itemname = stack:to_table().name
 		end
@@ -60,7 +58,6 @@ core.register_entity(":__builtin:item", {
 		if core.registered_items[itemname] then
 			item_texture = core.registered_items[itemname].inventory_image
 			item_type = core.registered_items[itemname].type
-			description = core.registered_items[itemname].description
 		end
 		local prop = {
 			is_visible = true,
@@ -69,7 +66,6 @@ core.register_entity(":__builtin:item", {
 			visual_size = {x = s, y = s},
 			collisionbox = {-c, -c, -c, c, c, c},
 			automatic_rotate = math.pi * 0.5,
-			infotext = description,
 		}
 		self.object:set_properties(prop)
 	end,


### PR DESCRIPTION
 Partially reverts #3547
Infotext remains optional for objects, empty by default
//////////////////////////////////////////
Modifies #3547 
See issue #4131 

Screenshots show behaviour with this commit.
Item entity description is no longer shown as infotext in HUD with or without F5.

![screenshot_20160519_024742](https://cloud.githubusercontent.com/assets/3686677/15380546/484813ba-1d6f-11e6-9e81-9e3c12a88a7c.png)

![screenshot_20160519_024747](https://cloud.githubusercontent.com/assets/3686677/15380550/4cd3435a-1d6f-11e6-9420-3b05582200e4.png)

^ F5

Below i have added infotext to the boat object to show it is still optional and shows in HUD with or without F5.

![screenshot_20160519_025522](https://cloud.githubusercontent.com/assets/3686677/15380554/51021582-1d6f-11e6-8392-1aab1edff49e.png)

![screenshot_20160519_025528](https://cloud.githubusercontent.com/assets/3686677/15380555/55212c52-1d6f-11e6-97fa-48ab3c010d82.png)

^ F5