### PR TITLE
Add arbitrary player metadata storage API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2650,6 +2650,8 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `0`: player is drowning,
         * `1`-`10`: remaining number of bubbles
         * `11`: bubbles bar is not shown
+* `get_metadata()`: Returns metadata (a string attached to an player object).
+* `set_metadata(metadata)`: Returns true.
 * `set_inventory_formspec(formspec)`
     * Redefine player's inventory form
     * Should usually be called in on_joinplayer

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1179,6 +1179,16 @@ void PlayerSAO::setBreath(u16 breath)
 	m_player->setBreath(breath);
 }
 
+std::string PlayerSAO::getMetadata() const
+{
+	return m_player->getMetadata();
+}
+
+void PlayerSAO::setMetadata(const std::string &metadata)
+{
+	m_player->setMetadata(metadata);
+}
+
 void PlayerSAO::setArmorGroups(const ItemGroupList &armor_groups)
 {
 	m_armor_groups = armor_groups;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -200,6 +200,8 @@ public:
 	s16 readDamage();
 	u16 getBreath() const;
 	void setBreath(u16 breath);
+	std::string getMetadata() const;
+	void setMetadata(const std::string &metadata);
 	void setArmorGroups(const ItemGroupList &armor_groups);
 	ItemGroupList getArmorGroups();
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop);

--- a/src/player.h
+++ b/src/player.h
@@ -180,6 +180,18 @@ public:
 		m_breath = breath;
 	}
 
+	std::string getMetadata()
+	{
+		return m_metadata;
+	}
+
+	virtual void setMetadata(const std::string &metadata)
+	{
+		if (metadata != m_metadata)
+			m_dirty = true;
+		m_metadata = metadata;
+	}
+
 	f32 getRadPitch()
 	{
 		return -1.0 * m_pitch * core::DEGTORAD;
@@ -397,6 +409,8 @@ protected:
 	v3f m_speed;
 	v3f m_position;
 	aabb3f m_collisionbox;
+
+	std::string m_metadata;
 
 	bool m_dirty;
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1104,6 +1104,33 @@ int ObjectRef::l_get_breath(lua_State *L)
 	return 1;
 }
 
+// set_metadata(self)
+int ObjectRef::l_set_metadata(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *co = getplayersao(ref);
+	if (!co)
+		return 0;
+	// Do it
+	std::string metadata = luaL_checkstring(L, 2);
+	co->setMetadata(metadata);
+	return 1;
+}
+
+// get_metadata(self)
+int ObjectRef::l_get_metadata(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *co = getplayersao(ref);
+	if (!co)
+		return 0;
+	// Do it
+	lua_pushstring(L, co->getMetadata().c_str());
+	return 1;
+}
+
 // set_inventory_formspec(self, formspec)
 int ObjectRef::l_set_inventory_formspec(lua_State *L)
 {
@@ -1758,6 +1785,8 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_look_pitch),
 	luamethod(ObjectRef, get_breath),
 	luamethod(ObjectRef, set_breath),
+	luamethod(ObjectRef, set_metadata),
+	luamethod(ObjectRef, get_metadata),
 	luamethod(ObjectRef, set_inventory_formspec),
 	luamethod(ObjectRef, get_inventory_formspec),
 	luamethod(ObjectRef, get_player_control),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -207,6 +207,12 @@ private:
 	// get_breath(self, breath)
 	static int l_get_breath(lua_State *L);
 
+	// set_metadata(self, metadata)
+	static int l_set_metadata(lua_State *L);
+
+	// get_metadata(self)
+	static int l_get_metadata(lua_State *L);
+
 	// set_inventory_formspec(self, formspec)
 	static int l_set_inventory_formspec(lua_State *L);
 


### PR DESCRIPTION
This API is very similar to the ItemStack metadata, and a complete rip
off from #3388. Instead of making a new specialized stat field for one
value, we create a generic and engine-opaque metadata store for mods.

Mods can store any data in here that they wish, but probably want to
push their data through minetest.write_json() or minetest.serialize()
before storing.

This allows mods to store persistent per-player data without creating
files on disk. Mods *should* probably use a coherent data access
method namespace separation method so that the data store can be
shared throughout several mods without collisions, and without erasing
content of other mods. I intend to fork and change `datastorage`
to do this arbitration and offer it as part of `minetest_game` as a
default data store and retrieval interface.

I tested this code with the following code:

```
minetest.register_on_joinplayer(function(player)
	local metadata = player:get_metadata()
	local meta = minetest.parse_json(metadata)
	print(dump(meta))
	metadata = minetest.write_json({stuff = "there is now stuff here!"})
	player:set_metadata(metadata)
end)

```

Thanks to @blockmen for a fantastic idea, it just needed to go 1
inch further.