### PR TITLE
Tolerate packet reordering in the early init process

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -2167,12 +2167,12 @@ void ConnectionReceiveThread::receive()
 				throw InvalidIncomingDataException("Channel doesn't exist");
 			}
 
-			/* preserve original peer_id for later usage */
-			u16 packet_peer_id   = peer_id;
-
 			/* Try to identify peer by sender address (may happen on join) */
 			if (peer_id == PEER_ID_INEXISTENT) {
 				peer_id = m_connection->lookupPeer(sender);
+				// We do not have to remind the peer of its
+				// peer id as the CONTROLTYPE_SET_PEER_ID
+				// command was sent reliably.
 			}
 
 			/* The peer was not found in our lists. Add it. */
@@ -2213,11 +2213,6 @@ void ConnectionReceiveThread::receive()
 					continue;
 				}
 			}
-
-
-			/* mark peer as seen with id */
-			if (!(packet_peer_id == PEER_ID_INEXISTENT))
-				peer->setSentWithID();
 
 			peer->ResetTimeout();
 
@@ -2756,7 +2751,7 @@ u16 Connection::lookupPeer(Address& sender)
 	for(; j != m_peers.end(); ++j)
 	{
 		Peer *peer = j->second;
-		if (peer->isActive())
+		if (peer->isPendingDeletion())
 			continue;
 
 		Address tocheck;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -663,8 +663,7 @@ class Peer {
 			m_last_rtt(-1.0),
 			m_usage(0),
 			m_timeout_counter(0.0),
-			m_last_timeout_check(porting::getTimeMs()),
-			m_has_sent_with_id(false)
+			m_last_timeout_check(porting::getTimeMs())
 		{
 			m_rtt.avg_rtt = -1.0;
 			m_rtt.jitter_avg = -1.0;
@@ -687,20 +686,15 @@ class Peer {
 		virtual void PutReliableSendCommand(ConnectionCommand &c,
 						unsigned int max_packet_size) {};
 
-		virtual bool isActive() { return false; };
-
 		virtual bool getAddress(MTProtocols type, Address& toset) = 0;
+
+		bool isPendingDeletion()
+		{ MutexAutoLock lock(m_exclusive_access_mutex); return m_pending_deletion; };
 
 		void ResetTimeout()
 			{MutexAutoLock lock(m_exclusive_access_mutex); m_timeout_counter=0.0; };
 
 		bool isTimedOut(float timeout);
-
-		void setSentWithID()
-		{ MutexAutoLock lock(m_exclusive_access_mutex); m_has_sent_with_id = true; };
-
-		bool hasSentWithID()
-		{ MutexAutoLock lock(m_exclusive_access_mutex); return m_has_sent_with_id; };
 
 		unsigned int m_increment_packets_remaining;
 		unsigned int m_increment_bytes_remaining;
@@ -776,8 +770,6 @@ class Peer {
 		float m_timeout_counter;
 
 		u32 m_last_timeout_check;
-
-		bool m_has_sent_with_id;
 };
 
 class UDPPeer : public Peer
@@ -794,9 +786,6 @@ public:
 
 	void PutReliableSendCommand(ConnectionCommand &c,
 							unsigned int max_packet_size);
-
-	bool isActive()
-	{ return ((hasSentWithID()) && (!m_pending_deletion)); };
 
 	bool getAddress(MTProtocols type, Address& toset);
 


### PR DESCRIPTION
Fixes a bug where packet reordering made the server give the
client two peer ids instead of one. This in turn confused
reliable packet sending and made connecting to the server fail.

For my detailed theory how this happens and further discussion see the commit msg.

However, marked WIP, as I still don't know 100% what exactly happens, I just know how it can be made to not reproduce anymore. Perhaps there was more buggy behaviour causing the actual failure, it would be better to fix that as well.