### PR TITLE
update .gitignore: ignore ninja files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 tags
 !tags/
 gtags.files
+.idea/*
 
 ## Files related to minetest development cycle
 /*.patch

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ locale/
 *.layout
 *.o
 *.a
+*.ninja
+.ninja*
 
 ## Android build files
 build/android/src/main/assets


### PR DESCRIPTION
l used ninja instead of make to compile minetest successfully. But git didn't ignore these files yet:
```
On branch master
Your branch is up-to-date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.ninja_deps
	.ninja_log
	build.ninja
	rules.ninja

nothing added to commit but untracked files present (use "git add" to track)
```
l found out about ninja there:
https://github.com/Secretchronicles/TSC/issues/540#issuecomment-217260177