### PR TITLE
override table.insert to work faster

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -595,6 +595,15 @@ function table.copy(t, seen)
 	return n
 end
 --------------------------------------------------------------------------------
+-- make table.insert work faster
+local tinsert = table.insert
+function table.insert(t, v, n)
+	if n then
+		return tinsert(t, v, n)
+	end
+	t[#t+1] = v
+end
+--------------------------------------------------------------------------------
 -- mainmenu only functions
 --------------------------------------------------------------------------------
 if INIT == "mainmenu" then


### PR DESCRIPTION
l read a comment about simply overriding table.insert to make it use table[#table+1] if the third param is omitted, if l remember correctly it's from Rui.

If people begin to optimize their mods (see #3448) and then in the future some change in lua or somewhere else happens which makes table.insert work faster, those optimizations will be for the cat or even worse.
So this change does the optimization by overriding table.insert, i.e. mods don't use the optimization, so if table.insert later works faster for any reason, there wouldn't be lots of code change which needs to be undone.