### PR TITLE
Implement player attribute backend

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2899,6 +2899,8 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `0`: player is drowning,
         * `1`-`10`: remaining number of bubbles
         * `11`: bubbles bar is not shown
+* `set_attribute(attribute, value)`: sets an extra attribute with value on player
+* `get_attribute(attribute)`: returns value for extra attribute. Returns nil if no attribute found.
 * `set_inventory_formspec(formspec)`
     * Redefine player's inventory form
     * Should usually be called in on_joinplayer

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -791,6 +791,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_pitch(0),
 	m_fov(0),
 	m_wanted_range(0),
+	m_extended_attributes_modified(false),
 	// public
 	m_physics_override_speed(1),
 	m_physics_override_jump(1),

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -180,6 +180,7 @@ public:
 	}
 };
 
+typedef UNORDERED_MAP<std::string, std::string> PlayerAttributes;
 class RemotePlayer;
 
 class PlayerSAO : public UnitSAO
@@ -248,6 +249,39 @@ public:
 	bool setWieldedItem(const ItemStack &item);
 	int getWieldIndex() const;
 	void setWieldIndex(int i);
+
+	/*
+		Modding interface
+	*/
+	inline void setExtendedAttribute(const std::string &attr, const std::string &value)
+	{
+		m_extra_attributes[attr] = value;
+		m_extended_attributes_modified = true;
+	}
+
+	inline bool getExtendedAttribute(const std::string &attr, std::string *value)
+	{
+		if (m_extra_attributes.find(attr) == m_extra_attributes.end())
+			return false;
+
+		*value = m_extra_attributes[attr];
+		return true;
+	}
+
+	inline const PlayerAttributes &getExtendedAttributes()
+	{
+		return m_extra_attributes;
+	}
+
+	inline bool extendedAttributesModified() const
+	{
+		return m_extended_attributes_modified;
+	}
+
+	inline void setExtendedAttributeModified(bool v)
+	{
+		m_extended_attributes_modified = v;
+	}
 
 	/*
 		PlayerSAO-specific
@@ -343,6 +377,9 @@ private:
 	f32 m_pitch;
 	f32 m_fov;
 	s16 m_wanted_range;
+
+	PlayerAttributes m_extra_attributes;
+	bool m_extended_attributes_modified;
 public:
 	float m_physics_override_speed;
 	float m_physics_override_jump;

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -25,11 +25,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class PlayerSAO;
 
-enum RemotePlayerChatResult {
+enum RemotePlayerChatResult
+{
 	RPLAYER_CHATRESULT_OK,
 	RPLAYER_CHATRESULT_FLOODING,
 	RPLAYER_CHATRESULT_KICK,
 };
+
 /*
 	Player on the server
 */
@@ -135,6 +137,7 @@ private:
 		deSerialize stops reading exactly at the right point.
 	*/
 	void serialize(std::ostream &os);
+	void serializeExtraAttributes(std::string &output);
 
 	PlayerSAO *m_sao;
 	bool m_dirty;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1181,6 +1181,45 @@ int ObjectRef::l_get_breath(lua_State *L)
 	return 1;
 }
 
+// set_attribute(self, attribute, value)
+int ObjectRef::l_set_attribute(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) {
+		return 0;
+	}
+
+	std::string attr = luaL_checkstring(L, 2);
+	std::string value = luaL_checkstring(L, 3);
+
+	if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+		co->setExtendedAttribute(attr, value);
+	}
+	return 1;
+}
+
+// get_attribute(self, attribute)
+int ObjectRef::l_get_attribute(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) {
+		return 0;
+	}
+
+	std::string attr = luaL_checkstring(L, 2);
+
+	std::string value = "";
+	if (co->getExtendedAttribute(attr, &value)) {
+		lua_pushstring(L, value.c_str());
+		return 1;
+	}
+
+	return 0;
+}
+
+
 // set_inventory_formspec(self, formspec)
 int ObjectRef::l_set_inventory_formspec(lua_State *L)
 {
@@ -1839,6 +1878,8 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_look_pitch),
 	luamethod(ObjectRef, get_breath),
 	luamethod(ObjectRef, set_breath),
+	luamethod(ObjectRef, get_attribute),
+	luamethod(ObjectRef, set_attribute),
 	luamethod(ObjectRef, set_inventory_formspec),
 	luamethod(ObjectRef, get_inventory_formspec),
 	luamethod(ObjectRef, get_player_control),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -226,6 +226,12 @@ private:
 	// get_breath(self, breath)
 	static int l_get_breath(lua_State *L);
 
+	// set_attribute(self, attribute, value)
+	static int l_set_attribute(lua_State *L);
+
+	// get_attribute(self, attribute)
+	static int l_get_attribute(lua_State *L);
+
 	// set_inventory_formspec(self, formspec)
 	static int l_set_inventory_formspec(lua_State *L);
 

--- a/src/server.h
+++ b/src/server.h
@@ -576,7 +576,6 @@ private:
 	float m_time_of_day_send_timer;
 	// Uptime of server in seconds
 	MutexedVariable<double> m_uptime;
-
 	/*
 	 Client interface
 	 */

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -500,7 +500,8 @@ void ServerEnvironment::saveLoadedPlayers()
 	for (std::vector<RemotePlayer *>::iterator it = m_players.begin();
 		it != m_players.end();
 		++it) {
-		if ((*it)->checkModified()) {
+		if ((*it)->checkModified() ||
+			((*it)->getPlayerSAO() && (*it)->getPlayerSAO()->extendedAttributesModified())) {
 			(*it)->save(players_path, m_server);
 		}
 	}


### PR DESCRIPTION
This backend permit mods to store extra players attributes to a common interface.
- Add the obj:set_attribute(attr, value) Lua call
- Add the obj:get_attribute(attr) Lua call

Examples:
- player:set_attribute("home:home", "{'x': 10, 'y': 25, z:'-78'")
- player:get_attribute("default:mana")

Attributes are saved as a json in the players file using the extended_attributes key.

They are saved only if a modification on the attributes occurs and loaded
when emergePlayer is called (they are attached to PlayerSAO).

Note: the dedicated json is intended for outside minetest used, like python, ruby, perl, etc manipulation programs
