### PR TITLE
Sky: Darker, bluer sky and improved horizon haze at night

### DIFF
--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -510,11 +510,15 @@ void Sky::update(float time_of_day, float time_brightness,
 	//video::SColorf bgcolor_bright_dawn_f(0.666*1.2,0.549*1.0,0.220*1.2,1.0);
 	video::SColorf bgcolor_bright_dawn_f
 			(155./255*1.2,193./255,240./255, 1.0);
+	video::SColorf bgcolor_bright_night_f
+			(64./255, 144./255, 255./255, 1.0);
 
 	video::SColorf skycolor_bright_normal_f =
 			video::SColor(255, 140, 186, 250);
 	video::SColorf skycolor_bright_dawn_f =
 			video::SColor(255, 180, 186, 250);
+	video::SColorf skycolor_bright_night_f =
+			video::SColor(255, 0, 107, 255);
 	
 	video::SColorf cloudcolor_bright_normal_f =
 			video::SColor(255, 240,240,255);
@@ -550,10 +554,18 @@ void Sky::update(float time_of_day, float time_brightness,
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
 					cloudcolor_bright_dawn_f, color_change_fraction);
 		} else {
-			m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-					bgcolor_bright_normal_f, color_change_fraction);
-			m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-					skycolor_bright_normal_f, color_change_fraction);
+			if (time_brightness < 0.07) {  // Night sky
+				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
+						bgcolor_bright_night_f, color_change_fraction);
+				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
+						skycolor_bright_night_f, color_change_fraction);
+			} else {  // Daytime sky
+				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
+						bgcolor_bright_normal_f, color_change_fraction);
+				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
+						skycolor_bright_normal_f, color_change_fraction);
+			}
+
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
 					cloudcolor_bright_normal_f, color_change_fraction);
 		}


### PR DESCRIPTION
Add new colours 'skycolour_bright_night', 'bgcolour_bright_night'
and enable these between sunset end and sunrise start
Night sky has same hue as day sky but is darker and more saturated
Night horizon haze (bgcolour) is slightly less saturated and
slightly brighter than night sky, to be consistent with daytime
horizon haze
////////////////////////////////

v Twilight with this PR (time 19500 and 4500)

![screenshot_pr_twilight](https://cloud.githubusercontent.com/assets/3686677/15647445/81ed5d74-265b-11e6-91a5-cf74e27fa947.png)

v Midnight with this PR

![screenshot_pr_midnight](https://cloud.githubusercontent.com/assets/3686677/15647447/86bd5f20-265b-11e6-9864-a0d296485766.png)

![screenshot_current](https://cloud.githubusercontent.com/assets/3686677/15634119/54d27c5e-25b4-11e6-9d50-21a6ace8e949.png)

^ Current midnight

v Current midday (unchanged, here to show horizon is consistent)

![screenshot_middaysky](https://cloud.githubusercontent.com/assets/3686677/15634127/6abe081c-25b4-11e6-9798-d1a615af9045.png)

Sky colour and horizon colour (background colour / bgcolour) each have two versions: one for dawn and one for day and night. The day/night colours are tuned for daytime and look grey and smoggy at night. This commit adds a third sky colour and a third horizon colour and enables these between sunset end and sunrise start.

The night sky has the same hue as the daytime sky but is darker and more saturated, it looks suitable for a sky lit up by a full moon.
Night horizon was chosen to have a very similar relationship to night sky as daytime horizon has to daytime sky: subtly brighter and less saturated.

The times of colour switch are the exact time of the last change in world light level at sunset (time 19500), and the exact time of the first change in world light level at sunrise (time 4500).

```if (time_brightness < 0.07) {  // Night sky```
This is used because 'time_brightness' is the value used to control which colours are used, it's the value that determines when dawn is, see https://github.com/minetest/minetest/blob/master/src/sky.cpp#L502 and https://github.com/minetest/minetest/blob/master/src/sky.cpp#L545

The existing code is a mess but i might clean it up in a later commit or PR.