### PR TITLE
Remove libXxf86vm usage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,11 +339,6 @@ else()
 		set(PLATFORM_LIBS -lrt ${PLATFORM_LIBS})
 	endif(APPLE)
 
-	# This way Xxf86vm is found on OpenBSD too
-	find_library(XXF86VM_LIBRARY Xxf86vm)
-	mark_as_advanced(XXF86VM_LIBRARY)
-	set(CLIENT_PLATFORM_LIBS ${CLIENT_PLATFORM_LIBS} ${XXF86VM_LIBRARY})
-
 	# Prefer local iconv if installed
 	find_library(ICONV_LIBRARY iconv)
 	mark_as_advanced(ICONV_LIBRARY)


### PR DESCRIPTION
This library does not seem to be used anywhere, e.g. there are no XF86VidMode* calls at all