### PR TITLE
do not grant protection_bypass priv automaticly

### DIFF
--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -32,7 +32,10 @@ core.register_privilege("settime", "Can use /time")
 core.register_privilege("privs", "Can modify privileges")
 core.register_privilege("basic_privs", "Can modify 'shout' and 'interact' privileges")
 core.register_privilege("server", "Can do server maintenance stuff")
-core.register_privilege("protection_bypass", "Can bypass node protection in the world")
+core.register_privilege("protection_bypass", {
+	description = "Can bypass node protection in the world",
+	give_to_singleplayer = false,
+})
 core.register_privilege("shout", "Can speak in chat")
 core.register_privilege("ban", "Can ban and unban players")
 core.register_privilege("kick", "Can kick players")


### PR DESCRIPTION
There are situations when it is not at all desirable to be able to override protection without even noticing. For once, it makes testing of protection mods tricky. And then you might want to give the player a world which poses some kind of challenge by *not* allowing the player to modify all parts of the world automaticly. This becomes impossible if the priv cannot even be revoked.
With this pull request, the priv can still be granted manually if needed.