### PR TITLE
Sapier's fix for the RESEND RELIABLE problem

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -71,6 +71,9 @@ static inline float CALC_DTIME(unsigned int lasttime, unsigned int curtime) {
 
 #define PING_TIMEOUT 5.0
 
+/* maximum number of retries for reliable packets */
+#define MAX_RELIABLE_RETRY 5
+
 static u16 readPeerId(u8 *packetdata)
 {
 	return readU16(&packetdata[4]);
@@ -1399,6 +1402,7 @@ void ConnectionSendThread::runTimeouts(float dtime)
 		}
 
 		float resend_timeout = dynamic_cast<UDPPeer*>(&peer)->getResendTimeout();
+		bool retry_count_exceeded = false;
 		for(u16 i=0; i<CHANNEL_COUNT; i++)
 		{
 			std::list<BufferedPacket> timed_outs;
@@ -1438,6 +1442,13 @@ void ConnectionSendThread::runTimeouts(float dtime)
 				channel->UpdateBytesLost(k->data.getSize());
 				k->resend_count++;
 
+				if (k-> resend_count > MAX_RELIABLE_RETRY) {
+					retry_count_exceeded = true;
+					timeouted_peers.push_back(peer->id);
+					/* no need to check additional packets if a single one did timeout*/
+					break;
+				}
+
 				LOG(derr_con<<m_connection->getDesc()
 						<<"RE-SENDING timed-out RELIABLE to "
 						<< k->address.serializeString()
@@ -1452,8 +1463,17 @@ void ConnectionSendThread::runTimeouts(float dtime)
 				// do not handle rtt here as we can't decide if this packet was
 				// lost or really takes more time to transmit
 			}
+
+			if (retry_count_exceeded) {
+				break; /* no need to check other channels if we already did timeout */
+			}
+
 			channel->UpdateTimers(dtime,dynamic_cast<UDPPeer*>(&peer)->getLegacyPeer());
 		}
+
+		/* skip to next peer if we did timeout */
+		if (retry_count_exceeded)
+			continue;
 
 		/* send ping if necessary */
 		if (dynamic_cast<UDPPeer*>(&peer)->Ping(dtime,data)) {


### PR DESCRIPTION
This is Sapier's fix for the RESEND RELIABLE problem, a network issue that has affected MT worlds for at least 1.5 years. The fix is relatively simple and is believed to be correct.

I've used the fix myself for over a year to keep a dozen worlds up and running; for me, MT wouldn't be possible without it. The fix has been tested, recently, in other worlds and seems to improve performance even in problematic cases such as residential hosting.
