### PR TITLE
Mgv7: Always carve river channels in mountain terrain

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -206,13 +206,15 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	blockseed = getBlockSeed2(full_node_min, seed);
 
-	// Generate terrain and ridges with initial heightmaps
+	// Generate base and mountain terrain
+	// An initial heightmap is no longer created here for use in generateRidgeTerrain()
 	s16 stone_surface_max_y = generateTerrain();
 
+	// Generate rivers
 	if (spflags & MGV7_RIDGES)
 		generateRidgeTerrain();
 
-	// Update heightmap to include mountain terrain
+	// Create heightmap
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
@@ -331,7 +333,6 @@ int MapgenV7::generateTerrain()
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index2d++) {
 		s16 surface_y = baseTerrainLevelFromMap(index2d);
-		heightmap[index2d] = surface_y;  // Create base terrain heightmap
 
 		if (surface_y > stone_surface_max_y)
 			stone_surface_max_y = surface_y;
@@ -381,9 +382,6 @@ void MapgenV7::generateRidgeTerrain()
 		u32 vi = vm->m_area.index(node_min.X, y, z);
 		for (s16 x = node_min.X; x <= node_max.X; x++, index++, vi++) {
 			int j = (z - node_min.Z) * csize.X + (x - node_min.X);
-
-			if (heightmap[j] < water_level - 16)  // Use base terrain heightmap
-				continue;
 
 			float uwatern = noise_ridge_uwater->result[j] * 2;
 			if (fabs(uwatern) > width)


### PR DESCRIPTION
Previously, rivers were sometimes blocked by vertical walls
of mountain terrain due to river carving being disabled
when base terrain height was below water_level - 16
Remove now unused base terrain heightmap
///////////////////////////////////////////

v Current blocked river, a strange triple wall here

![screenshot_20160530_133449](https://cloud.githubusercontent.com/assets/3686677/15650807/289f332e-2673-11e6-8842-a24c0761daf2.png)

v This PR, same location as screenshot above

![screenshot_20160530_134138](https://cloud.githubusercontent.com/assets/3686677/15650813/30ed8bb6-2673-11e6-9214-c0b45f5c33aa.png)

Only change to mapgen is that rivers now pass through mountains in deep water, or, pass completely through instead of being blocked at points.