### PR TITLE
Add `place_param2` nodedef field.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -250,7 +250,9 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 	local newnode = {name = def.name, param1 = 0, param2 = param2}
 
 	-- Calculate direction for wall mounted stuff like torches and signs
-	if def.paramtype2 == 'wallmounted' and not param2 then
+	if def.place_param2 ~= nil then
+		newnode.param2 = def.place_param2
+	elseif def.paramtype2 == 'wallmounted' and not param2 then
 		local dir = {
 			x = under.x - above.x,
 			y = under.y - above.y,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3485,6 +3485,7 @@ Definition tables
         ^ paramtype = "light" allows light to propagate from or through the node with light value
         ^ falling by 1 per node. This line is essential for a light source node to spread its light. ]]
         paramtype2 = "none", -- See "Nodes"
+        place_param2 = nil, -- Force value for param2 when player places node
         is_ground_content = true, -- If false, the cave generator will not carve through this
         sunlight_propagates = false, -- If true, sunlight will go infinitely through this
         walkable = true, -- If true, objects collide with node


### PR DESCRIPTION
This allows a nodedef to specify a fixed value for param2 to be
used for all normal placements.

There are several uses for this:

- nodes that require param2 to be set to a non-zero value for
  internal mod use. E.g. leafdecay could use this to detect that
  leaves are played by players.
- force wallmounted or facedir value at placement at placement

This overrides any player look direction or other on-the-fly
param2 setting during placement.