### PR TITLE
Do not generate dummy images for normalmaps

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1208,17 +1208,17 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 #endif
 		if (image == NULL) {
 			if (part_of_name != "") {
-				if (part_of_name.find("_normal.png") == std::string::npos){
-					errorstream<<"generateImage(): Could not load image \""
-						<<part_of_name<<"\""<<" while building texture"<<std::endl;
-					errorstream<<"generateImage(): Creating a dummy"
-						<<" image for \""<<part_of_name<<"\""<<std::endl;
-				} else {
-					infostream<<"generateImage(): Could not load normal map \""
-						<<part_of_name<<"\""<<std::endl;
-					infostream<<"generateImage(): Creating a dummy"
-						<<" normal map for \""<<part_of_name<<"\""<<std::endl;
+
+				// Do not create normalmap dummies
+				if (part_of_name.find("_normal.png") != std::string::npos) {
+					warningstream << "generateImage(): Could not load normal map \""
+						<< part_of_name << "\"" << std::endl;
+					return true;
 				}
+
+				errorstream << "generateImage(): Could not load image \""
+					<< part_of_name << "\" while building texture; "
+					"Creating a dummy image" << std::endl;
 			}
 
 			// Just create a dummy image


### PR DESCRIPTION
Before the change dummies for normalmaps fuck up the result image:
![screenshot_20160531_183225](https://cloud.githubusercontent.com/assets/3192173/15683375/4b34d408-2762-11e6-99e8-09e0772bc9f8.png)

After the change for normalmaps no dummies are generated, so the normalmap of the base texture is used.
