### PR TITLE
Sky: Fix sunrisebg texture motion

### DIFF
--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -239,7 +239,7 @@ void Sky::render()
 			float a = easeCurve(MYMAX(0, MYMIN(1, a_)));
 			//std::cerr<<"a_="<<a_<<" a="<<a<<std::endl;
 			video::SColor c(255,255,255,255);
-			float y = -(1.0 - a) * 0.2;
+			float y = -(1.0 - a) * 0.22;
 			vertices[0] = video::S3DVertex(-1,-0.05+y,-1, 0,0,1, c, t, t);
 			vertices[1] = video::S3DVertex( 1,-0.05+y,-1, 0,0,1, c, o, t);
 			vertices[2] = video::S3DVertex( 1, 0.2+y,-1, 0,0,1, c, o, o);


### PR DESCRIPTION
Top of texture no longer shows above horizon during night and day

Fix for #4194 
Confirmed by Zeno- as being the solution https://github.com/minetest/minetest/issues/4194#issuecomment-224157828
@Zeno- please can you +1?