### PR TITLE
Move unknown node message when applying texture overrides to infostream

### DIFF
--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1107,7 +1107,7 @@ void CNodeDefManager::applyTextureOverrides(const std::string &override_filepath
 
 		content_t id;
 		if (!getId(splitted[0], id)) {
-			errorstream << override_filepath
+			infostream << override_filepath
 				<< ":" << line_c << " Could not apply texture override \""
 				<< line << "\": Unknown node \""
 				<< splitted[0] << "\"" << std::endl;


### PR DESCRIPTION
Texture packs have no way to know what nodes are available, so this shouldn't be a error message.