### PR TITLE
Fixes #2658 (Bad get_look_yaw/get_look_pitch)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2679,10 +2679,20 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_player_velocity()`: returns `nil` if is not a player, otherwise a
   table {x, y, z} representing the player's instantaneous velocity in nodes/s
 * `get_look_dir()`: get camera direction as a unit vector
-* `get_look_pitch()`: pitch in radians
-* `get_look_yaw()`: yaw in radians (wraps around pretty randomly as of now)
-* `set_look_pitch(radians)`: sets look pitch
-* `set_look_yaw(radians)`: sets look yaw
+* `get_look_vertical()`: pitch in radians
+     * Angle ranges between -pi/2 and pi/2, which are straight up and down respectively.
+* `get_look_horizontal()`: yaw in radians
+     * Angle is counter-clockwise from the +z direction.
+* `set_look_vertical(radians)`: sets look pitch
+     * radians - Angle from looking forward, where positive is downwards.
+* `set_look_horizontal(radians)`: sets look yaw
+     * radians - Angle from the +z direction, where positive is counter-clockwise.
+* `get_look_pitch()`: pitch in radians - Deprecated as broken. Use get_look_vertical.
+     * Angle ranges between -pi/2 and pi/2, which are straight down and up respectively.
+* `get_look_yaw()`: yaw in radians - Deprecated as broken. Use get_look_horizontal.
+     * Angle is counter-clockwise from the +x direction.
+* `set_look_pitch(radians)`: sets look pitch - Deprecated. Use set_look_vertical.
+* `set_look_yaw(radians)`: sets look yaw - Deprecated. Use set_look_horizontal.
 * `get_breath()`: returns players breath
 * `set_breath(value)`: sets players breath
      * values:

--- a/src/player.h
+++ b/src/player.h
@@ -188,14 +188,26 @@ public:
 		m_breath = breath;
 	}
 
-	f32 getRadPitch()
+	// Deprecated
+	f32 getRadPitchDep()
 	{
 		return -1.0 * m_pitch * core::DEGTORAD;
 	}
 
-	f32 getRadYaw()
+	// Deprecated
+	f32 getRadYawDep()
 	{
 		return (m_yaw + 90.) * core::DEGTORAD;
+	}
+
+	f32 getRadPitch()
+	{
+		return m_pitch * core::DEGTORAD;
+	}
+
+	f32 getRadYaw()
+	{
+		return m_yaw * core::DEGTORAD;
 	}
 
 	const char *getName() const

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1016,15 +1016,49 @@ int ObjectRef::l_get_look_dir(lua_State *L)
 	Player *player = getplayer(ref);
 	if (player == NULL) return 0;
 	// Do it
-	float pitch = player->getRadPitch();
-	float yaw = player->getRadYaw();
+	float pitch = player->getRadPitchDep();
+	float yaw = player->getRadYawDep();
 	v3f v(cos(pitch)*cos(yaw), sin(pitch), cos(pitch)*sin(yaw));
 	push_v3f(L, v);
 	return 1;
 }
 
+// DEPRECATED
 // get_look_pitch(self)
 int ObjectRef::l_get_look_pitch(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	log_deprecated(L,
+		"Deprecated call to get_look_pitch, use get_look_vertical instead");
+
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL) return 0;
+	// Do it
+	lua_pushnumber(L, player->getRadPitchDep());
+	return 1;
+}
+
+// DEPRECATED
+// get_look_yaw(self)
+int ObjectRef::l_get_look_yaw(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	log_deprecated(L,
+		"Deprecated call to get_look_yaw, use get_look_horizontal instead");
+
+	ObjectRef *ref = checkobject(L, 1);
+	Player *player = getplayer(ref);
+	if (player == NULL) return 0;
+	// Do it
+	lua_pushnumber(L, player->getRadYawDep());
+	return 1;
+}
+
+// get_look_pitch2(self)
+int ObjectRef::l_get_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
@@ -1035,8 +1069,8 @@ int ObjectRef::l_get_look_pitch(lua_State *L)
 	return 1;
 }
 
-// get_look_yaw(self)
-int ObjectRef::l_get_look_yaw(lua_State *L)
+// get_look_yaw2(self)
+int ObjectRef::l_get_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
@@ -1047,8 +1081,8 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 	return 1;
 }
 
-// set_look_pitch(self, radians)
-int ObjectRef::l_set_look_pitch(lua_State *L)
+// set_look_vertical(self, radians)
+int ObjectRef::l_set_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
@@ -1060,10 +1094,46 @@ int ObjectRef::l_set_look_pitch(lua_State *L)
 	return 1;
 }
 
+// set_look_horizontal(self, radians)
+int ObjectRef::l_set_look_horizontal(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
+	float yaw = luaL_checknumber(L, 2) * core::RADTODEG;
+	// Do it
+	co->setYaw(yaw);
+	return 1;
+}
+
+// DEPRECATED
+// set_look_pitch(self, radians)
+int ObjectRef::l_set_look_pitch(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	log_deprecated(L,
+		"Deprecated call to set_look_pitch, use set_look_vertical instead.");
+
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
+	float pitch = luaL_checknumber(L, 2) * core::RADTODEG;
+	// Do it
+	co->setPitch(pitch);
+	return 1;
+}
+
+// DEPRECATED
 // set_look_yaw(self, radians)
 int ObjectRef::l_set_look_yaw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
+
+	log_deprecated(L,
+		"Deprecated call to set_look_yaw, use set_look_horizontal instead.");
+
 	ObjectRef *ref = checkobject(L, 1);
 	PlayerSAO* co = getplayersao(ref);
 	if (co == NULL) return 0;
@@ -1754,6 +1824,10 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, get_look_dir),
 	luamethod(ObjectRef, get_look_pitch),
 	luamethod(ObjectRef, get_look_yaw),
+	luamethod(ObjectRef, get_look_vertical),
+	luamethod(ObjectRef, get_look_horizontal),
+	luamethod(ObjectRef, set_look_horizontal),
+	luamethod(ObjectRef, set_look_vertical),
 	luamethod(ObjectRef, set_look_yaw),
 	luamethod(ObjectRef, set_look_pitch),
 	luamethod(ObjectRef, get_breath),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -189,15 +189,31 @@ private:
 	// get_look_dir(self)
 	static int l_get_look_dir(lua_State *L);
 
+	// DEPRECATED
 	// get_look_pitch(self)
 	static int l_get_look_pitch(lua_State *L);
 
+	// DEPRECATED
 	// get_look_yaw(self)
 	static int l_get_look_yaw(lua_State *L);
 
+	// get_look_pitch2(self)
+	static int l_get_look_vertical(lua_State *L);
+
+	// get_look_yaw2(self)
+	static int l_get_look_horizontal(lua_State *L);
+
+	// set_look_vertical(self, radians)
+	static int l_set_look_vertical(lua_State *L);
+
+	// set_look_horizontal(self, radians)
+	static int l_set_look_horizontal(lua_State *L);
+
+	// DEPRECATED
 	// set_look_pitch(self, radians)
 	static int l_set_look_pitch(lua_State *L);
 
+	// DEPRECATED
 	// set_look_yaw(self, radians)
 	static int l_set_look_yaw(lua_State *L);
 


### PR DESCRIPTION
Deprecates get_look_yaw and get_look_pitch, and introduces get_look_yaw2 and get_look_pitch2.

I tested both the deprecation message and the new methods, and they appear to work. I tested it with the following mod code:
```
minetest.register_on_chat_message(function(name, message)
	local p = minetest.get_player_by_name(name)
        p:set_look_yaw(p:get_look_yaw())
        p:set_look_pitch(p:get_look_pitch())
end)
```
I added a "2" past the getter functions to test the new methods, and removed it to make sure the deprecation message appears (and still has the unintuitive functionality).