### PR TITLE
Only allow strings to be passed to minetest.global_exists

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -5,6 +5,9 @@ local WARN_INIT = false
 
 
 function core.global_exists(name)
+	if type(name) ~= "string" then
+		error("core.global_exists: " .. tostring(name) .. " is not a string")
+	end
 	return rawget(_G, name) ~= nil
 end
 


### PR DESCRIPTION
Sometimes you accidentally forget the quotes when using global_exists, this makes minetest abort if you did so.