### PR TITLE
Abort if static_spawnpoint is an invalid setting instead of just giving an error log

### DIFF
--- a/builtin/game/static_spawn.lua
+++ b/builtin/game/static_spawn.lua
@@ -1,14 +1,12 @@
 -- Minetest: builtin/static_spawn.lua
 
-local function warn_invalid_static_spawnpoint()
-	if core.settings:get("static_spawnpoint") and
-			not core.setting_get_pos("static_spawnpoint") then
-		core.log("error", "The static_spawnpoint setting is invalid: \""..
-				core.settings:get("static_spawnpoint").."\"")
-	end
+local static_spawnpoint_string = core.settings:get("static_spawnpoint")
+if static_spawnpoint_string and
+		static_spawnpoint_string ~= "" and
+		not core.setting_get_pos("static_spawnpoint") then
+	error('The static_spawnpoint setting is invalid: "' ..
+			static_spawnpoint_string .. '"')
 end
-
-warn_invalid_static_spawnpoint()
 
 local function put_player_in_spawn(player_obj)
 	local static_spawnpoint = core.setting_get_pos("static_spawnpoint")


### PR DESCRIPTION
it forces admins to take care of their minetest setting(s)
and if you set static_spawnpoint, l guess you want to join the server to test it, so if it aborts instead of giving a log, you can faster fix it because you don't need to wait until you pressed esc and got back to the menu
