### PR TITLE
	Removed minetest version number from top left corner

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4349,7 +4349,6 @@ void Game::updateGui(float *statustext_time, const RunStats &stats,
 		guitext->setVisible(true);
 	} else if (flags.show_hud || flags.show_chat) {
 		std::ostringstream os(std::ios_base::binary);
-		os << PROJECT_NAME_C " " << g_version_hash;
 		setStaticText(guitext, utf8_to_wide(os.str()).c_str());
 		guitext->setVisible(true);
 	} else {


### PR DESCRIPTION
Removed the minetest version number from top left corner as requested in issue #4209 
It remains in f5