### PR TITLE
Fix & make linux conditionals uniform

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -630,7 +630,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)
 		{
-			#if (defined(linux) || defined(__linux))
+			#if (defined(__linux__))
 				wchar_t wc = L'_';
 				mbtowc( &wc, (char *) &event.KeyInput.Char, sizeof(event.KeyInput.Char) );
 				prompt.input(wc);

--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -271,7 +271,7 @@ bool intlGUIEditBox::OnEvent(const SEvent& event)
 			break;
 		case EET_KEY_INPUT_EVENT:
         {
-#if (defined(linux) || defined(__linux) || defined(__FreeBSD__))
+#if (defined(__linux__) || defined(__FreeBSD__))
             // ################################################################
 			// ValkaTR:
             // This part is the difference from the original intlGUIEditBox

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -258,7 +258,7 @@ bool getCurrentExecPath(char *buf, size_t len)
 
 
 //// Linux
-#elif defined(linux) || defined(__linux) || defined(__linux__)
+#elif defined(__linux__)
 
 bool getCurrentExecPath(char *buf, size_t len)
 {
@@ -374,7 +374,7 @@ bool setSystemPaths()
 
 
 //// Linux
-#elif defined(linux) || defined(__linux)
+#elif defined(__linux__)
 
 bool setSystemPaths()
 {

--- a/src/porting.h
+++ b/src/porting.h
@@ -60,7 +60,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <unistd.h>
 	#include <stdint.h> //for uintptr_t
 
-	#if (defined(linux) || defined(__linux) || defined(__GNU__)) && !defined(_GNU_SOURCE)
+	// Use standard Posix macro for Linux
+	#if (defined(linux) || defined(__linux)) && !defined(__linux__)
+		#define __linux__ 
+	#endif
+	#if (defined(__linux__) || defined(__GNU__)) && !defined(_GNU_SOURCE)
 		#define _GNU_SOURCE
 	#endif
 
@@ -321,7 +325,7 @@ inline const char *getPlatformName()
 	return
 #if defined(ANDROID)
 	"Android"
-#elif defined(linux) || defined(__linux) || defined(__linux__)
+#elif defined(__linux__)
 	"Linux"
 #elif defined(_WIN32) || defined(_WIN64)
 	"Windows"

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -54,7 +54,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 // for setName
-#if defined(linux) || defined(__linux)
+#if defined(__linux__)
 	#include <sys/prctl.h>
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 	#include <pthread_np.h>
@@ -70,7 +70,7 @@ DEALINGS IN THE SOFTWARE.
 // for bindToProcessor
 #if __FreeBSD_version >= 702106
 	typedef cpuset_t cpu_set_t;
-#elif defined(__linux) || defined(linux)
+#elif defined(__linux__)
 	#include <sched.h>
 #elif defined(__sun) || defined(sun)
 	#include <sys/types.h>
@@ -261,7 +261,7 @@ DWORD WINAPI Thread::threadProc(LPVOID param)
 
 void Thread::setName(const std::string &name)
 {
-#if defined(linux) || defined(__linux)
+#if defined(__linux__)
 
 	// It would be cleaner to do this with pthread_setname_np,
 	// which was added to glibc in version 2.12, but some major
@@ -363,7 +363,7 @@ bool Thread::bindToProcessor(unsigned int proc_number)
 
 	return SetThreadAffinityMask(getThreadHandle(), 1 << proc_number);
 
-#elif __FreeBSD_version >= 702106 || defined(__linux) || defined(linux)
+#elif __FreeBSD_version >= 702106 || defined(__linux__)
 
 	cpu_set_t cpuset;
 


### PR DESCRIPTION
The source used a hodge-podge of different combinations of different
macros to check for linux: `linux`, `__linux`, `__linux__`.

As `__linux__` is standard (Posix), and the others are not, the source
now uniformly uses `__linux__`. If either `linux` or `__linux` are defined,
it is made sure that `__linux__` is defined as well.