### PR TITLE
Use the standard to_string() functions for C++11

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -820,7 +820,7 @@ void Client::initLocalMapSaving(const Address &address,
 	const std::string world_path = porting::path_user
 		+ DIR_DELIM + "worlds"
 		+ DIR_DELIM + "server_"
-		+ hostname + "_" + to_string(address.getPort());
+		+ hostname + "_" + std::to_string(address.getPort());
 
 	fs::CreateAllDirs(world_path);
 


### PR DESCRIPTION
If compiling according to a C++ version before C++11, then define
std::to_string ourselves.

Add a to_wstring version as well