### PR TITLE
Travis: Skip installation and compilation for non-C++  related changes

### DIFF
--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -e
+echo "Preparing for $TRAVIS_COMMIT_RANGE"
+. util/travis/common.sh
+
+needs_compile || exit 0
 
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
 	sudo apt-get update

--- a/util/travis/common.sh
+++ b/util/travis/common.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# Relative to git-repository root:
+TRIGGER_COMPILE_PATHS="src/|CMakeLists.txt|cmake/Modules/|util/travis/|util/buildbot/"
+
+needs_compile() {
+	git diff --name-only $TRAVIS_COMMIT_RANGE | egrep -q "^($TRIGGER_COMPILE_PATHS)"
+}

--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+. util/travis/common.sh
+
+needs_compile || exit 0
 
 if [[ $PLATFORM == "Unix" ]]; then
 	mkdir -p travisbuild


### PR DESCRIPTION
This makes travis-ci skip builds, when changes in a pullrequest do not affect `src/` or `CMakeLists.txt`.

PR's that only contain changes to e.g. doc/ or builtin/ will finish after 20-40s instead of 6-8minutes.