### PR TITLE
Builtin: Fix check for a player object in core.check_player_privs

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -48,11 +48,13 @@ function core.after(after, func, ...)
 	}
 end
 
-function core.check_player_privs(player_or_name, ...)
-	local name = player_or_name
-	-- Check if we have been provided with a Player object.
-	if type(name) ~= "string" then
+function core.check_player_privs(name, ...)
+	local arg_type = type(name)
+	if (arg_type == "userdata" or arg_type == "table") and
+			name.get_player_name then -- If it quacks like a Player...
 		name = name:get_player_name()
+	elseif arg_type ~= "string" then
+		error("Invalid core.check_player_privs argument type: " .. arg_type, 2)
 	end
 	
 	local requested_privs = {...}


### PR DESCRIPTION
`core.check_player_privs` accepts as first argument a name or player object, but just tested for a string. This caused crashes inside builtin, when being passed any unexpected types.

This provides a better (duck-typing like) test and better error reporting.