### PR TITLE
Add custom wield item animation using linear keyframes (WIP)

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -70,6 +70,8 @@ Camera::Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
 
 	m_wield_change_timer(0.125),
 	m_wield_item_next(),
+	m_wieldnode_keyframe(0),
+	m_wieldnode_keyframe_duration(0),
 
 	m_camera_mode(CAMERA_MODE_FIRST)
 {
@@ -149,8 +151,13 @@ void Camera::step(f32 dtime)
 	bool was_under_zero = m_wield_change_timer < 0;
 	m_wield_change_timer = MYMIN(m_wield_change_timer + dtime, 0.125);
 
-	if (m_wield_change_timer >= 0 && was_under_zero)
+	if (m_wield_change_timer >= 0 && was_under_zero) {
+		const ItemDefinition &def = m_gamedef->idef()->get(m_wield_item_next.name);
+		m_wieldnode_keyframes = def.keyframes;
+		m_wieldnode_keyframe = 0;
+		m_wieldnode_keyframe_duration = 0;
 		m_wieldnode->setItem(m_wield_item_next, m_gamedef);
+	}
 
 	if (m_view_bobbing_state != 0)
 	{
@@ -195,13 +202,23 @@ void Camera::step(f32 dtime)
 
 	if (m_digging_button != -1)
 	{
-		f32 offset = dtime * 3.5;
+		f32 offset = dtime;
+		if (m_wieldnode_keyframe_duration > 0) {
+			offset /= m_wieldnode_keyframe_duration;
+		} else {
+			offset *= 3.5;
+		}
 		float m_digging_anim_was = m_digging_anim;
 		m_digging_anim += offset;
 		if (m_digging_anim >= 1)
 		{
 			m_digging_anim = 0;
-			m_digging_button = -1;
+			m_wieldnode_keyframe++;
+			if (m_wieldnode_keyframe < m_wieldnode_keyframes.size()) {
+				m_wieldnode_keyframe_duration = m_wieldnode_keyframes[m_wieldnode_keyframe].duration;
+			} else {
+				m_digging_button = -1;
+			}
 		}
 		float lim = 0.15;
 		if(m_digging_anim_was < lim && m_digging_anim >= lim)
@@ -407,8 +424,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	//v3f wield_rotation = v3f(-100, 120, -100);
 	v3f wield_rotation = v3f(-100, 120, -100);
 	wield_position.Y += fabs(m_wield_change_timer)*320 - 40;
-	if(m_digging_anim < 0.05 || m_digging_anim > 0.5)
-	{
+	if(m_digging_anim < 0.05 || m_digging_anim > 0.5) {
 		f32 frac = 1.0;
 		if(m_digging_anim > 0.5)
 			frac = 2.0 * (m_digging_anim - 0.5);
@@ -423,20 +439,33 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 		//wield_rotation.X -= frac * 15.0 * pow(ratiothing2, 1.4f);
 		//wield_rotation.Z += frac * 15.0 * pow(ratiothing2, 1.0f);
 	}
-	if (m_digging_button != -1)
-	{
-		f32 digfrac = m_digging_anim;
-		wield_position.X -= 50 * sin(pow(digfrac, 0.8f) * M_PI);
-		wield_position.Y += 24 * sin(digfrac * 1.8 * M_PI);
-		wield_position.Z += 25 * 0.5;
 
-		// Euler angles are PURE EVIL, so why not use quaternions?
-		core::quaternion quat_begin(wield_rotation * core::DEGTORAD);
-		core::quaternion quat_end(v3f(80, 30, 100) * core::DEGTORAD);
-		core::quaternion quat_slerp;
-		quat_slerp.slerp(quat_begin, quat_end, sin(digfrac * M_PI));
-		quat_slerp.toEuler(wield_rotation);
-		wield_rotation *= core::RADTODEG;
+	if (m_digging_button != -1)	{
+		errorstream << "Digging anim! " << m_digging_anim << " ft " << frametime << std::endl;
+		f32 digfrac = m_digging_anim;
+
+		if (m_wieldnode_keyframes.empty()) {
+			wield_position.X -= 50 * sin(pow(digfrac, 0.8f) * M_PI);
+			wield_position.Y += 24 * sin(digfrac * 1.8 * M_PI);
+			wield_position.Z += 25 * 0.5;
+
+			// Euler angles are PURE EVIL, so why not use quaternions?
+			core::quaternion quat_begin(wield_rotation * core::DEGTORAD);
+			core::quaternion quat_end(v3f(80, 30, 100) * core::DEGTORAD);
+			core::quaternion quat_slerp;
+			quat_slerp.slerp(quat_begin, quat_end, sin(digfrac * M_PI));
+			quat_slerp.toEuler(wield_rotation);
+			wield_rotation *= core::RADTODEG;
+		} else {
+			v3f last = wield_position;
+			if (m_wieldnode_keyframe > 0) {
+				last = m_wieldnode_keyframes[m_wieldnode_keyframe - 1].position;
+			}
+
+			v3f delta = m_wieldnode_keyframes[m_wieldnode_keyframe].position;
+			delta -= last;
+			wield_position = last + delta * m_digging_anim;
+		}
 	} else {
 		f32 bobfrac = my_modf(m_view_bobbing_anim);
 		wield_position.X -= sin(bobfrac*M_PI*2.0) * 3.0;
@@ -490,8 +519,16 @@ void Camera::updateViewingRange()
 
 void Camera::setDigging(s32 button)
 {
-	if (m_digging_button == -1)
+	if (m_digging_button == -1) {
 		m_digging_button = button;
+
+		if (!m_wieldnode_keyframes.empty()) {
+			m_wieldnode_keyframe = 0;
+			m_wieldnode_keyframe_duration = m_wieldnode_keyframes[0].duration;
+		}
+
+		errorstream << "Set digging" << std::endl;
+	}
 }
 
 void Camera::wield(const ItemStack &item)

--- a/src/camera.h
+++ b/src/camera.h
@@ -185,6 +185,9 @@ private:
 
 	scene::ISceneManager* m_wieldmgr;
 	WieldMeshSceneNode* m_wieldnode;
+	std::vector<WieldKeyframe> m_wieldnode_keyframes;
+	int m_wieldnode_keyframe;
+	f32 m_wieldnode_keyframe_duration;
 
 	// draw control
 	MapDrawControl& m_draw_control;

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -82,6 +82,10 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	sound_place = def.sound_place;
 	sound_place_failed = def.sound_place_failed;
 	range = def.range;
+	for (size_t i = 0; i < def.keyframes.size(); i++) {
+		WieldKeyframe frame = def.keyframes[i];
+		keyframes.push_back(WieldKeyframe(frame.position, frame.duration));
+	}
 	return *this;
 }
 
@@ -117,6 +121,7 @@ void ItemDefinition::reset()
 	sound_place = SimpleSoundSpec();
 	sound_place_failed = SimpleSoundSpec();
 	range = -1;
+	keyframes.clear();
 
 	node_placement_prediction = "";
 }
@@ -152,7 +157,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 		writeS16(os, i->second);
 	}
 	os<<serializeString(node_placement_prediction);
-	if(protocol_version > 17){
+	if(protocol_version > 17) {
 		//serializeSimpleSoundSpec(sound_place, os);
 		os<<serializeString(sound_place.name);
 		writeF1000(os, sound_place.gain);
@@ -161,6 +166,13 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 		writeF1000(os, range);
 		os << serializeString(sound_place_failed.name);
 		writeF1000(os, sound_place_failed.gain);
+
+		writeU16(os, (u16)keyframes.size());
+		for (int i = 0; i < keyframes.size(); i++) {
+			WieldKeyframe frame = keyframes[i];
+			writeV3F1000(os, frame.position);
+			writeF1000(os, frame.duration);
+		}
 	}
 }
 
@@ -218,6 +230,13 @@ void ItemDefinition::deSerialize(std::istream &is)
 	try {
 		sound_place_failed.name = deSerializeString(is);
 		sound_place_failed.gain = readF1000(is);
+
+		u16 frames = readU16(is);
+		for (int i = 0; i < frames; i++) {
+			v3f pos = readV3F1000(is);
+			f32 duration = readF1000(is);
+			keyframes.push_back(WieldKeyframe(pos, duration));
+		}
 	} catch(SerializationError &e) {};
 }
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <iostream>
 #include <set>
+#include <vector>
 #include "itemgroup.h"
 #include "sound.h"
 class IGameDef;
@@ -42,6 +43,17 @@ enum ItemType
 	ITEM_TOOL,
 };
 
+struct WieldKeyframe
+{
+	WieldKeyframe(v3f position, f32 duration):
+		position(position),
+		duration(duration)
+	{}
+
+	v3f position;
+	f32 duration;
+};
+
 struct ItemDefinition
 {
 	/*
@@ -57,6 +69,9 @@ struct ItemDefinition
 	std::string inventory_image; // Optional for nodes, mandatory for tools/craftitems
 	std::string wield_image; // If empty, inventory_image or mesh (only nodes) is used
 	v3f wield_scale;
+
+
+	std::vector<WieldKeyframe> keyframes;
 
 	/*
 		Item stack and interaction properties

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -60,8 +60,14 @@ ItemDefinition read_item_definition(lua_State* L,int index,
 	getstringfield(L, index, "wield_image", def.wield_image);
 
 	lua_getfield(L, index, "wield_scale");
-	if(lua_istable(L, -1)){
+	if (lua_istable(L, -1)) {
 		def.wield_scale = check_v3f(L, -1);
+	}
+	lua_pop(L, 1);
+
+	lua_getfield(L, index, "wield_keyframes");
+	if (lua_istable(L, -1)) {
+		read_wield_keyframes(L, -1, def.keyframes);
 	}
 	lua_pop(L, 1);
 
@@ -115,6 +121,31 @@ ItemDefinition read_item_definition(lua_State* L,int index,
 			def.node_placement_prediction);
 
 	return def;
+}
+
+/******************************************************************************/
+void read_wield_keyframes(lua_State *L, int table, std::vector<WieldKeyframe> &keyframes)
+{
+	errorstream << "Reading keyframes..." << std::endl;
+	int table2 = lua_gettop(L);
+	lua_pushnil(L);
+	while (lua_next(L, table2) != 0){
+		// key at index -2 and value at index -1
+		if (lua_istable(L, -1)) {
+			errorstream << "is table" << std::endl;
+			float x, y, z, duration=1;
+			getfloatfield(L, -1, "x", x);
+			getfloatfield(L, -1, "y", y);
+			getfloatfield(L, -1, "z", z);
+			getfloatfield(L, -1, "duration", duration);
+			keyframes.push_back(WieldKeyframe(v3f(x, y, z), duration));
+			errorstream << "Key: " << x << ", " << y << ", " << z << " for " << duration << std::endl;
+		} else {
+			errorstream << "Found non table!" << std::endl;
+		}
+		// removes value, keeps key for next iteration
+		lua_pop(L, 1);
+	}
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -46,6 +46,7 @@ class INodeDefManager;
 struct PointedThing;
 struct ItemStack;
 struct ItemDefinition;
+struct WieldKeyframe;
 struct ToolCapabilities;
 struct ObjectProperties;
 struct SimpleSoundSpec;
@@ -86,6 +87,8 @@ void               push_tool_capabilities    (lua_State *L,
 
 ItemDefinition     read_item_definition      (lua_State *L, int index,
                                               ItemDefinition default_def);
+void               read_wield_keyframes     (lua_State *L, int table,
+                                            std::vector<WieldKeyframe> &keyframes);
 void               read_object_properties    (lua_State *L, int index,
                                               ObjectProperties *prop);
 void               push_object_properties    (lua_State *L,

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -44,6 +44,8 @@ public:
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
 	void setItem(const ItemStack &item, IGameDef *gamedef);
 
+	ItemStack getItem();
+
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false
 	void setColor(video::SColor color);


### PR DESCRIPTION
``` lua
minetest.register_node("default:apple", {
    --
    wield_keyframes = {
        {
            x = 0,
            y = 0,
            z = 20,
            duration = 5
        }
    },
    --
})
```

Todo:
- rotation in key frames
- remove logging
- more than linear (bezier curves / splines)
- particles etc
- documentation
