### PR TITLE
Treegen: Improve use of signed vs. unsigned integers

### DIFF
--- a/src/treegen.cpp
+++ b/src/treegen.cpp
@@ -770,9 +770,9 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, s32 seed)
 	MapNode snownode(c_snow);
 
 	PseudoRandom pr(seed);
-	s16 trunk_h = pr.range(9, 13);
+	u16 trunk_h = pr.range(9, 13);
 	v3s16 p1 = p0;
-	for (s16 ii = 0; ii < trunk_h; ii++) {
+	for (u16 ii = 0; ii < trunk_h; ii++) {
 		if (vmanip.m_area.contains(p1)) {
 			u32 vi = vmanip.m_area.index(p1);
 			vmanip.m_data[vi] = treenode;
@@ -790,7 +790,7 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, s32 seed)
 		leaves_d[i] = 0;
 
 	// Upper branches
-	s16 dev = 3;
+	u16 dev = 3;
 	for (s16 yy = -1; yy <= 1; yy++) {
 		for (s16 zz = -dev; zz <= dev; zz++) {
 			u32 i = leaves_a.index(v3s16(-dev, yy, zz));


### PR DESCRIPTION
To fix GCC 6.1.1 compilation warning:
'assuming signed overflow does not occur when assuming
that (X - c) > X is always false'
/////////////////////////

Hopefully a fix for #4300 