### PR TITLE
Prevent falling nodes from getting stuck

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -105,6 +105,12 @@ core.register_entity(":__builtin:falling_node", {
 			local npos = self.object:getpos()
 			self.object:setpos(vector.round(npos))
 		end
+		-- Timer to stop falling nodes getting stuck
+		self.timer = (self.timer or 0) + dtime
+		if self.timer > 10 then
+			core.add_item(pos, ItemStack(self.node.name))
+			self.object:remove()
+		end
 	end
 })
 


### PR DESCRIPTION
This prevents falling nodes from getting stuck by adding a 10 second timer, if it still hasn't landed by that time the node itself drops as an item.