### PR TITLE
Add optional delay for use action on items

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1149,6 +1149,8 @@ Another example: Make red wool from white wool and red dye:
 * `soil`: saplings will grow on nodes in this group
 * `connect_to_raillike`: makes nodes of raillike drawtype with same group value
   connect to each other
+* `delayed_use`: usable items with this group will only be used after a delay of
+  `value * 0.1` seconds. Releasing the button earlier will abort the use.
 
 ### Known damage and digging time defining groups
 * `crumbly`: dirt, sand

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1430,6 +1430,7 @@ struct GameRunData {
 	float repeat_rightclick_timer;
 	float object_hit_delay_timer;
 	float time_from_last_punch;
+	float item_use_timer;
 	ClientActiveObject *selected_object;
 
 	float jump_timer;
@@ -3743,8 +3744,22 @@ void Game::processPlayerInteraction(GameRunData *runData,
 		runData->repeat_rightclick_timer = 0;
 
 	if (playeritem_def.usable && isLeftPressed()) {
-		if (getLeftClicked())
+		if (getLeftClicked()) {
+			runData->item_use_timer = 0.0;
+		} else {
+			runData->item_use_timer += dtime;
+		}
+		// item_use_timer is well-defined while using an object.
+		// Any residual value after using something has no effect,
+		// since we always reinitialize at the start of using.
+
+		// Items in group "delayed_use" have a delay before triggering
+		// the "use" effect, default 0 (from itemgroup_get).
+		float use_delay = itemgroup_get(playeritem_def.groups, "delayed_use") * 0.1;
+		// See if we reached the delay *this frame*.
+		if (runData->item_use_timer >= use_delay && runData->item_use_timer - dtime < use_delay ) {
 			client->interact(4, pointed);
+		}
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		ToolCapabilities playeritem_toolcap =
 				playeritem.getToolCapabilities(itemdef_manager);


### PR DESCRIPTION
Add the "lazy_use" group on an item to delay the "use" action by value * 0.1 seconds.

An example would be to slightly delay eating food, to reduce accidental wasting of items.