### PR TITLE
Shaders: Disable by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -335,9 +335,9 @@ fsaa (FSAA) enum 0 0,1,2,4,8,16
 
 [***Shaders]
 
-#    Shaders allow advanced visul effects and may increase performance on some video cards.
-#    Thy only work with the OpenGL video backend.
-enable_shaders (Shaders) bool true
+#    Shaders allow advanced visual effects.
+#    They only work with the OpenGL video backend.
+enable_shaders (Shaders) bool false
 
 [****Tone Mapping]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -369,10 +369,10 @@
 
 #### Shaders
 
-#    Shaders allow advanced visul effects and may increase performance on some video cards.
-#    Thy only work with the OpenGL video backend.
+#    Shaders allow advanced visual effects.
+#    They only work with the OpenGL video backend.
 #    type: bool
-# enable_shaders = true
+# enable_shaders = false
 
 ##### Tone Mapping
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -178,7 +178,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("ambient_occlusion_gamma", "2.2");
-	settings->setDefault("enable_shaders", "true");
+	settings->setDefault("enable_shaders", "false");
 	settings->setDefault("repeat_rightclick_time", "0.25");
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("enable_mesh_cache", "false");


### PR DESCRIPTION
The recent addition of tangent space, used when shaders are enabled,
severely reduces FPS. The visual difference when the basic nodes shader is
disabled is very subtle, and in some situations this almost doubles FPS.

Remove description that stated that shaders increase performance, this
may have been true for certain video cards but only with particular aspects
of graphics. The statement may also no longer apply since tangent space
was added.
///////////////////////////////////////////////////////////

See #4335 for comparison screenshots and FPS gains.
#3530
#3654
Discussion http://irc.minetest.ru/minetest-dev/2016-07-18#i_4653391

20:25 hmmmmmm    it's really hard to decouple now
20:26 hmmmmmm    the old code used to calculate tangents from a big set of if statements
20:26 hmmmmmm    now i think it actually calculates it using the mathy calculating way
20:27 hmmmmmm    you need to basically revert part of his normal mapping commit
20:28 paramat    mtgame no longer uses normalmaps but custom texture packs and subgames do
20:28 hmmmmmm    i'm sure we can fix it, it just takes some effort
20:28 hmmmmmm    everybody's busy though :/

Ideally tangent space should only be used when a shader effect that requires it is enabled, such as normalmaps. However currently tangent space is used even with the basic node shader which doesn't require it.
The result is a huge unnecessary reduction in FPS in the default setup of basic nodes shader enabled. In some cases, for example in built-up areas of servers, FPS has halved, no wonder players complain of low FPS.
The basic nodes shader only makes very subtle changes to colouring and contrast (see screenshots in issue) and may affect the smoothness of day/night transition.
Eventually, once we only enable tangent space when it's needed, we can re-enable the basic nodes shader.