### PR TITLE
Mgvalleys / cavegen: Place riverbed nodes under river water

### DIFF
--- a/src/cavegen.cpp
+++ b/src/cavegen.cpp
@@ -79,6 +79,7 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 	for (s16 z = nmin.Z; z <= nmax.Z; z++)
 	for (s16 x = nmin.X; x <= nmax.X; x++, index2d++) {
 		bool column_is_open = false;  // Is column open to overground
+		bool is_under_river = false;  // Is column under river water
 		bool is_tunnel = false;  // Is tunnel or tunnel floor
 		u32 vi = vm->m_area.index(x, nmax.Y, z);
 		u32 index3d = (z - nmin.Z) * m_zstride_1d + m_csize.Y * m_ystride +
@@ -99,6 +100,10 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 					c == biome->c_water) {
 				column_is_open = true;
 				continue;
+			} else if (c == biome->c_river_water) {
+				column_is_open = true;
+				is_under_river = true;
+				continue;
 			}
 			// Ground
 			float d1 = contour(noise_cave1->result[index3d]);
@@ -111,9 +116,13 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 			} else {
 				// Not in tunnel or not ground content
 				if (is_tunnel && column_is_open &&
-						(c == biome->c_filler || c == biome->c_stone))
+						(c == biome->c_filler || c == biome->c_stone)) {
 					// Tunnel entrance floor
-					vm->m_data[vi] = MapNode(biome->c_top);
+					if (is_under_river)
+						vm->m_data[vi] = MapNode(biome->c_riverbed);
+					else
+						vm->m_data[vi] = MapNode(biome->c_top);
+				}
 
 				column_is_open = false;
 				is_tunnel = false;


### PR DESCRIPTION
When a CavesNoiseIntersection tunnel intersects a river place biome
'riverbed' nodes in tunnel entrance instead of biome 'top' nodes.
//////////////////////////////////////////////////////

![screenshot_20160721_012711](https://cloud.githubusercontent.com/assets/3686677/17007755/136c2654-4ee3-11e6-97a5-a302a34326bb.png)

![screenshot_20160721_012925](https://cloud.githubusercontent.com/assets/3686677/17007758/19ebf7b6-4ee3-11e6-9c09-58c613af8838.png)

In mgvalleys i noticed biome top nodes, such as grass and snow, under default:river_water_source when a tunnel intersects a river.
The cavegen code is not reacting correctly to rivers.
CavesNoiseIntersection in 'mapgen basic' is also updated to prepare for future river mapgens.

Tested.