### PR TITLE
Profiler: Better structures, count calls, measure relative usage

### DIFF
--- a/builtin/profiler/data.lua
+++ b/builtin/profiler/data.lua
@@ -21,6 +21,10 @@ local setmetatable, rawset, rawget = setmetatable, rawset, rawget
 local type, tostring = type, tostring
 local huge, pairs = math.huge, pairs
 
+--
+-- Localized table ref to profiler.data.ins_total
+-- the total statistics over all instruments of the current profile session
+local ins_total
 --------------------------------------------------------------------------------
 
 ---
@@ -28,6 +32,10 @@ local huge, pairs = math.huge, pairs
 local Stats = {
 	get_mean = function(self, key)
 		return self[key] and self[key] / self.samples
+	end,
+
+	get_use = function(self)
+		return self.samples / ins_total.samples
 	end,
 
 	---
@@ -76,12 +84,10 @@ DataSet.__index = function(table, ins)
 	local new = setmetatable({
 		instrument = ins,
 		samples = 0,
+		call_all = 0,
 		time_min = huge,
 		time_max = 0,
 		time_all = 0,
-		part_min = 100,
-		part_max = 0,
-		part_all = 0,
 	}, Stats)
 	rawset(table, ins, new)
 
@@ -130,10 +136,9 @@ function Data.reset()
 			time_min = huge,
 			time_max = 0,
 			time_all = 0,
-			part_min = 100,
-			part_max = 100
 		}, Stats),
 	}, Data)
+	ins_total = profiler.data.ins_total
 
 	return old_data
 end

--- a/builtin/profiler/data.lua
+++ b/builtin/profiler/data.lua
@@ -1,0 +1,141 @@
+--Minetest
+--Copyright (C) 2016-2018 T4im
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+local profiler = ...
+
+local setmetatable, rawset, rawget = setmetatable, rawset, rawget
+local type, tostring = type, tostring
+local huge, pairs = math.huge, pairs
+
+--------------------------------------------------------------------------------
+
+---
+-- a collection of statistics gained through instrument sampling
+local Stats = {
+	get_mean = function(self, key)
+		return self[key] and self[key] / self.samples
+	end,
+
+	---
+	-- @return a serializable table copy
+	export = function(self)
+		local copy = {}
+		for key, value in pairs(self) do
+			-- Stats of mod-instruments can contain additional indexed "sub stats" references
+			if type(key) == "number" then
+				copy.includes = copy.includes or {}
+				copy.includes[key] = tostring(value.instrument)
+			else
+				copy[key] = value
+			end
+		end
+		if copy.instrument then
+			-- the instrument can contain a reference to the instrumented function
+			-- which cannot be serialized by json
+			copy.instrument = tostring(copy.instrument)
+		end
+		return copy
+	end
+}
+Stats.__index = Stats
+
+--------------------------------------------------------------------------------
+
+local Data = {}
+Data.__index = Data
+
+---
+-- A set of Stats.
+--
+-- This is not a class, but a special purpose table in the structure of
+-- dataset_instance = { [instrument] = stats }
+-- With stats being automatically initialized on demand
+--
+-- By not using any methods in this object we can make assumptions and
+-- skip some tests in __index for performance
+local DataSet = {}
+
+---
+-- Return a requested Stats table.
+-- Initialize if it doesn't exist yet.
+DataSet.__index = function(table, ins)
+	local new = setmetatable({
+		instrument = ins,
+		samples = 0,
+		time_min = huge,
+		time_max = 0,
+		time_all = 0,
+		part_min = 100,
+		part_max = 0,
+		part_all = 0,
+	}, Stats)
+	rawset(table, ins, new)
+
+	local mod = rawget(ins, "mod")
+	if mod then
+		-- No rawget here, since we want it initialized.
+		local mod_stat = table[mod]
+		-- Then add to the mod's array.
+		mod_stat[#mod_stat + 1] = new
+	end
+	return new
+end
+
+---
+-- @return a serializable table copy of the entire data state, optionally filtered
+function Data:export(filter)
+	local dataset = {}
+	for instrument, stats in pairs(self.ins_stats) do
+		local name = tostring(instrument)
+		if not filter or name:match(filter) then
+			dataset[name] = stats:export()
+		end
+	end
+
+	return {
+		dataset = dataset,
+		stats_total = self.ins_total:export()
+	}
+end
+
+function Data.reset()
+	local old_data = profiler.data
+
+	if old_data then
+		for instrument in pairs(old_data.ins_stats) do
+			-- Instruments are recycled.
+			instrument:reset()
+		end
+	end
+
+	profiler.data = setmetatable({
+		ins_stats = setmetatable({}, DataSet),
+		-- Current stats over all mods.
+		ins_total = setmetatable({
+			samples = 0,
+			time_min = huge,
+			time_max = 0,
+			time_all = 0,
+			part_min = 100,
+			part_max = 100
+		}, Stats),
+	}, Data)
+
+	return old_data
+end
+
+return Data

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -15,27 +15,30 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-local function get_bool_default(name, default)
-	local val = core.settings:get_bool(name)
-	if val == nil then
-		return default
-	end
-	return val
-end
-
 local profiler_path = core.get_builtin_path().."profiler"..DIR_DELIM
 local profiler = {}
+assert(loadfile(profiler_path .. "data.lua"))(profiler).reset()
+
 local sampler = assert(loadfile(profiler_path .. "sampling.lua"))(profiler)
-local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler, get_bool_default)
+local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler)
 local reporter = dofile(profiler_path .. "reporter.lua")
 profiler.instrument = instrumentation.instrument
+profiler.registered_instruments = instrumentation.registered_instruments
+
+function profiler.reset()
+	profiler.data.reset()
+	sampler.reset()
+end
 
 ---
 -- Delayed registration of the /profiler chat command
--- Is called later, after `core.register_chatcommand` was set up.
+-- Is called after `core.register_chatcommand` was set up.
 --
 function profiler.init_chatcommand()
-	local instrument_profiler = get_bool_default("instrument.profiler", false)
+	-- instrument chatcommands before or after we register /profile
+	-- depending on whether or not we configured the profiler to profile itself.
+	-- self-profiling includes but is not limited to this
+	local instrument_profiler = core.settings:get_bool("instrument.profiler")
 	if instrument_profiler then
 		instrumentation.init_chatcommand()
 	end
@@ -50,14 +53,14 @@ function profiler.init_chatcommand()
 			local args = arg0 and string.split(arg0, " ")
 
 			if command == "dump" then
-				core.log("action", reporter.print(sampler.profile, arg0))
+				core.log("action", reporter.print(profiler.data, arg0))
 				return true, "Statistics written to action log"
 			elseif command == "print" then
-				return true, reporter.print(sampler.profile, arg0)
+				return true, reporter.print(profiler.data, arg0)
 			elseif command == "save" then
-				return reporter.save(sampler.profile, args[1] or "txt", args[2])
+				return reporter.save(profiler.data, args[1] or "txt", args[2])
 			elseif command == "reset" then
-				sampler.reset()
+				profiler.reset()
 				return true, "Statistics were reset"
 			end
 
@@ -69,6 +72,7 @@ function profiler.init_chatcommand()
 		end
 	})
 
+	-- no self-profiling, so instrument after registration instead
 	if not instrument_profiler then
 		instrumentation.init_chatcommand()
 	end

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -89,6 +89,7 @@ local Instrument = {
 	-- set all measured quantities to 0 that were logged for this instrument
 	reset = function(self)
 		self.logged_time = 0
+		self.logged_calls = 0
 		return self
 	end,
 
@@ -117,8 +118,9 @@ local get_time = core.get_us_time
 local logged_instruments = sampler.logged_instruments
 local function measure(ins, time_diff, ...)
 	time_diff = get_time() - time_diff
-	if time_diff > 0 then
+	if time_diff >= 0 then
 		ins.logged_time = ins.logged_time + time_diff
+		ins.logged_calls = ins.logged_calls + 1
 		logged_instruments[ins] = true
 	end
 	return ...


### PR DESCRIPTION
Follow-up of #4245

#### Changes
The first commit refactors the code for better extensibility and improved performance.
- Allow to log more types of measurement without having to add new lookup tables.
- Improve sampling and measurement performance.
- Have Stats initialize automatically.
- Make labeling and its reporting more flexible.
- Isolate data storing/handling from sampling.
- Some aesthetically changes, like dynamic first column width
- pass along return values from callback registration functions for increased future-safety

The second commit changes the measurements taken to avoid misleading results from profiling sessions.
- Count how often a function is called and report an average call per active sample in txt (total in csv)
- Replace "relative time spend per server step" with "relative usage".
  > Because we already measure absolute time, the relative time did not provide additional useful information. "relative usage" shows how often an instrument was sampled relative to all samples (csv provides absolute numbers). That way you know if an instrument is often idle or frequently used, which makes a difference for other measures.
- Don't discard 0-time measurements anymore, only negative measurements
  > Instrumentalized functions that return early should not unnecessarily be penalized as being more heavyweight just because we skip their 0-time measurments.

#### Example console dump

| instrumentation | calls | use % | avg µs | min µs | max µs |
| --- | --- | --- | --- | --- | --- |
| pipeworks: | 8.2 | 100.0 | 186 | 1 | 11680 |
| \- globalstep[1] | 2.0 | 100.0 | 9 | 1 | 378 |
| \- ABM: Vacuum tubes | 12.6 | 4.8 | 114 | 72 | 215 |