### PR TITLE
Improved getPointedThing()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -447,6 +447,7 @@ set(common_SRCS
 	quicktune.cpp
 	reflowscan.cpp
 	remoteplayer.cpp
+	raycast.cpp
 	rollback.cpp
 	rollback_interface.cpp
 	serialization.cpp

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1501,64 +1501,6 @@ void Client::inventoryAction(InventoryAction *a)
 	delete a;
 }
 
-ClientActiveObject * Client::getSelectedActiveObject(
-	const core::line3d<f32> &shootline_on_map, v3f *intersection_point,
-	v3s16 *intersection_normal)
-{
-	std::vector<DistanceSortedActiveObject> objects;
-	m_env.getActiveObjects(shootline_on_map.start,
-		shootline_on_map.getLength() + 3, objects);
-	const v3f line_vector = shootline_on_map.getVector();
-
-	// Sort them.
-	// After this, the closest object is the first in the array.
-	std::sort(objects.begin(), objects.end());
-
-	/* Because objects can have different nodebox sizes,
-	 * the object whose center is the nearest isn't necessarily
-	 * the closest one. If an object is found, don't stop
-	 * immediately. */
-
-	f32 d_min = shootline_on_map.getLength();
-	ClientActiveObject *nearest_obj = NULL;
-	for (u32 i = 0; i < objects.size(); i++) {
-		ClientActiveObject *obj = objects[i].obj;
-
-		aabb3f *selection_box = obj->getSelectionBox();
-		if (selection_box == NULL)
-			continue;
-
-		v3f pos = obj->getPosition();
-
-		aabb3f offsetted_box(selection_box->MinEdge + pos,
-			selection_box->MaxEdge + pos);
-
-		if (offsetted_box.getCenter().getDistanceFrom(
-				shootline_on_map.start) > d_min + 9.6f*BS) {
-			// Probably there is no active object that has bigger nodebox than
-			// (-5.5,-5.5,-5.5,5.5,5.5,5.5)
-			// 9.6 > 5.5*sqrt(3)
-			break;
-		}
-
-		v3f current_intersection;
-		v3s16 current_normal;
-		if (boxLineCollision(offsetted_box, shootline_on_map.start, line_vector,
-				&current_intersection, &current_normal)) {
-			f32 d_current = current_intersection.getDistanceFrom(
-				shootline_on_map.start);
-			if (d_current <= d_min) {
-				d_min = d_current;
-				nearest_obj = obj;
-				*intersection_point = current_intersection;
-				*intersection_normal = current_normal;
-			}
-		}
-	}
-
-	return nearest_obj;
-}
-
 float Client::getAnimationTime()
 {
 	return m_animation_time;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -53,6 +53,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database-sqlite3.h"
 #include "serialization.h"
 #include "guiscalingfilter.h"
+#include "raycast.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -1501,41 +1502,61 @@ void Client::inventoryAction(InventoryAction *a)
 }
 
 ClientActiveObject * Client::getSelectedActiveObject(
-		f32 max_d,
-		v3f from_pos_f_on_map,
-		core::line3d<f32> shootline_on_map
-	)
+	const core::line3d<f32> &shootline_on_map, v3f *intersection_point,
+	v3s16 *intersection_normal)
 {
 	std::vector<DistanceSortedActiveObject> objects;
-
-	m_env.getActiveObjects(from_pos_f_on_map, max_d, objects);
+	m_env.getActiveObjects(shootline_on_map.start,
+		shootline_on_map.getLength() + 3, objects);
+	const v3f line_vector = shootline_on_map.getVector();
 
 	// Sort them.
 	// After this, the closest object is the first in the array.
 	std::sort(objects.begin(), objects.end());
 
-	for(unsigned int i=0; i<objects.size(); i++)
-	{
+	/* Because objects can have different nodebox sizes,
+	 * the object whose center is the nearest isn't necessarily
+	 * the closest one. If an object is found, don't stop
+	 * immediately. */
+
+	f32 d_min = shootline_on_map.getLength();
+	ClientActiveObject *nearest_obj = NULL;
+	for (u32 i = 0; i < objects.size(); i++) {
 		ClientActiveObject *obj = objects[i].obj;
 
 		aabb3f *selection_box = obj->getSelectionBox();
-		if(selection_box == NULL)
+		if (selection_box == NULL)
 			continue;
 
 		v3f pos = obj->getPosition();
 
-		aabb3f offsetted_box(
-				selection_box->MinEdge + pos,
-				selection_box->MaxEdge + pos
-		);
+		aabb3f offsetted_box(selection_box->MinEdge + pos,
+			selection_box->MaxEdge + pos);
 
-		if(offsetted_box.intersectsWithLine(shootline_on_map))
-		{
-			return obj;
+		if (offsetted_box.getCenter().getDistanceFrom(
+				shootline_on_map.start) > d_min + 9.6f*BS) {
+			// Probably there is no active object that has bigger nodebox than
+			// (-5.5,-5.5,-5.5,5.5,5.5,5.5)
+			// 9.6 > 5.5*sqrt(3)
+			break;
+		}
+
+		v3f current_intersection;
+		v3s16 current_normal;
+		if (boxLineCollision(offsetted_box, shootline_on_map.start, line_vector,
+				&current_intersection, &current_normal)) {
+			f32 d_current = current_intersection.getDistanceFrom(
+				shootline_on_map.start);
+			if (d_current <= d_min) {
+				d_min = d_current;
+				nearest_obj = obj;
+				*intersection_point = current_intersection;
+				*intersection_normal = current_normal;
+			}
 		}
 	}
 
-	return NULL;
+	return nearest_obj;
 }
 
 float Client::getAnimationTime()

--- a/src/client.h
+++ b/src/client.h
@@ -445,12 +445,25 @@ public:
 	Inventory* getInventory(const InventoryLocation &loc);
 	void inventoryAction(InventoryAction *a);
 
-	// Gets closest object pointed by the shootline
-	// Returns NULL if not found
+	/*!
+	 * Gets closest object pointed by the shootline.
+	 * Returns NULL if not found.
+	 * @param[in]  shootline_on_map    the shootline for
+	 * the test in world coordinates
+	 *
+	 * @param[out] intersection_point  the first point where
+	 * the shootline meets the object. Valid only if
+	 * not NULL is returned.
+	 *
+	 * @param[out] intersection_normal the normal vector of
+	 * the intersection, pointing outwards. Zero vector if
+	 * the shootline starts in an active object.
+	 * Valid only if not NULL is returned.
+	 */
 	ClientActiveObject * getSelectedActiveObject(
-			f32 max_d,
-			v3f from_pos_f_on_map,
-			core::line3d<f32> shootline_on_map
+		const core::line3d<f32> &shootline_on_map,
+		v3f *intersection_point,
+		v3s16 *intersection_normal
 	);
 
 	const std::list<std::string> &getConnectedPlayerNames()

--- a/src/client.h
+++ b/src/client.h
@@ -445,27 +445,6 @@ public:
 	Inventory* getInventory(const InventoryLocation &loc);
 	void inventoryAction(InventoryAction *a);
 
-	/*!
-	 * Gets closest object pointed by the shootline.
-	 * Returns NULL if not found.
-	 * @param[in]  shootline_on_map    the shootline for
-	 * the test in world coordinates
-	 *
-	 * @param[out] intersection_point  the first point where
-	 * the shootline meets the object. Valid only if
-	 * not NULL is returned.
-	 *
-	 * @param[out] intersection_normal the normal vector of
-	 * the intersection, pointing outwards. Zero vector if
-	 * the shootline starts in an active object.
-	 * Valid only if not NULL is returned.
-	 */
-	ClientActiveObject * getSelectedActiveObject(
-		const core::line3d<f32> &shootline_on_map,
-		v3f *intersection_point,
-		v3s16 *intersection_normal
-	);
-
 	const std::list<std::string> &getConnectedPlayerNames()
 	{
 		return m_env.getPlayerNames();

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -172,8 +172,6 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 	ScopeProfiler sp(g_profiler, "CM::updateDrawList()", SPT_AVG);
 	g_profiler->add("CM::updateDrawList() count", 1);
 
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	for (std::map<v3s16, MapBlock*>::iterator i = m_drawlist.begin();
 			i != m_drawlist.end(); ++i) {
 		MapBlock *block = i->second;
@@ -219,7 +217,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 	if (g_settings->getBool("free_move")) {
 		MapNode n = getNodeNoEx(cam_pos_nodes);
 		if (n.getContent() == CONTENT_IGNORE ||
-				nodemgr->get(n).solidness == 2)
+				m_nodedef->get(n).solidness == 2)
 			occlusion_culling_enabled = false;
 	}
 
@@ -297,23 +295,23 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			if (occlusion_culling_enabled &&
 					// For the central point of the mapblock 'endoff' can be halved
 					isOccluded(this, spn, cpn,
-						step, stepfac, startoff, endoff / 2.0f, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff / 2.0f, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,bs2,bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,bs2,-bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,-bs2,bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,-bs2,-bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(-bs2,bs2,bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(-bs2,bs2,-bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff, needed_count, m_nodedef) &&
 					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,-bs2),
-						step, stepfac, startoff, endoff, needed_count, nodemgr)) {
+						step, stepfac, startoff, endoff, needed_count, m_nodedef)) {
 				blocks_occlusion_culled++;
 				continue;
 			}
@@ -656,7 +654,6 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 		int oldvalue, bool *sunlight_seen_result)
 {
 	const bool debugprint = false;
-	INodeDefManager *ndef = m_gamedef->ndef();
 	static v3f z_directions[50] = {
 		v3f(-100, 0, 0)
 	};
@@ -694,7 +691,7 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 		float off = step * z_offsets[i];
 		bool sunlight_seen_now = false;
 		bool ok = getVisibleBrightness(this, m_camera_position, dir,
-				step, 1.0, max_d*0.6+off, max_d, ndef, daylight_factor,
+				step, 1.0, max_d*0.6+off, max_d, m_nodedef, daylight_factor,
 				sunlight_min_d,
 				&br, &sunlight_seen_now);
 		if(sunlight_seen_now)
@@ -734,8 +731,8 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 	int ret = 0;
 	if(brightness_count == 0){
 		MapNode n = getNodeNoEx(floatToInt(m_camera_position, BS));
-		if(ndef->get(n).param_type == CPT_LIGHT){
-			ret = decode_light(n.getLightBlend(daylight_factor, ndef));
+		if(m_nodedef->get(n).param_type == CPT_LIGHT){
+			ret = decode_light(n.getLightBlend(daylight_factor, m_nodedef));
 		} else {
 			ret = oldvalue;
 		}
@@ -758,8 +755,6 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 
 void ClientMap::renderPostFx(CameraMode cam_mode)
 {
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	// Sadly ISceneManager has no "post effects" render pass, in that case we
 	// could just register for that and handle it in renderMap().
 
@@ -768,7 +763,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	// - If the player is in a solid node, make everything black.
 	// - If the player is in liquid, draw a semi-transparent overlay.
 	// - Do not if player is in third person mode
-	const ContentFeatures& features = nodemgr->get(n);
+	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
 	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
 			m_gamedef->checkLocalPrivilege("noclip")) &&

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -43,8 +43,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "daynightratio.h"
 #include "map.h"
 #include "emerge.h"
+#include "raycast.h"
+#include "voxelalgorithms.h"
 #include "util/serialize.h"
 #include "util/basic_macros.h"
+#include "util/pointedthing.h"
 #include "threading/mutex_auto_lock.h"
 
 #define LBM_NAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_:"
@@ -2846,6 +2849,244 @@ ClientEnvEvent ClientEnvironment::getClientEvent()
 		m_client_event_queue.pop();
 	}
 	return event;
+}
+
+ClientActiveObject * ClientEnvironment::getSelectedActiveObject(
+	const core::line3d<f32> &shootline_on_map, v3f *intersection_point,
+	v3s16 *intersection_normal)
+{
+	std::vector<DistanceSortedActiveObject> objects;
+	getActiveObjects(shootline_on_map.start,
+		shootline_on_map.getLength() + 3, objects);
+	const v3f line_vector = shootline_on_map.getVector();
+
+	// Sort them.
+	// After this, the closest object is the first in the array.
+	std::sort(objects.begin(), objects.end());
+
+	/* Because objects can have different nodebox sizes,
+	 * the object whose center is the nearest isn't necessarily
+	 * the closest one. If an object is found, don't stop
+	 * immediately. */
+
+	f32 d_min = shootline_on_map.getLength();
+	ClientActiveObject *nearest_obj = NULL;
+	for (u32 i = 0; i < objects.size(); i++) {
+		ClientActiveObject *obj = objects[i].obj;
+
+		aabb3f *selection_box = obj->getSelectionBox();
+		if (selection_box == NULL)
+			continue;
+
+		v3f pos = obj->getPosition();
+
+		aabb3f offsetted_box(selection_box->MinEdge + pos,
+			selection_box->MaxEdge + pos);
+
+		if (offsetted_box.getCenter().getDistanceFrom(
+				shootline_on_map.start) > d_min + 9.6f*BS) {
+			// Probably there is no active object that has bigger nodebox than
+			// (-5.5,-5.5,-5.5,5.5,5.5,5.5)
+			// 9.6 > 5.5*sqrt(3)
+			break;
+		}
+
+		v3f current_intersection;
+		v3s16 current_normal;
+		if (boxLineCollision(offsetted_box, shootline_on_map.start, line_vector,
+				&current_intersection, &current_normal)) {
+			f32 d_current = current_intersection.getDistanceFrom(
+				shootline_on_map.start);
+			if (d_current <= d_min) {
+				d_min = d_current;
+				nearest_obj = obj;
+				*intersection_point = current_intersection;
+				*intersection_normal = current_normal;
+			}
+		}
+	}
+
+	return nearest_obj;
+}
+
+/*
+	Check if a node is pointable
+*/
+static inline bool isPointableNode(const MapNode &n,
+	INodeDefManager *ndef, bool liquids_pointable)
+{
+	const ContentFeatures &features = ndef->get(n);
+	return features.pointable ||
+	       (liquids_pointable && features.isLiquid());
+}
+
+PointedThing ClientEnvironment::getPointedThing(
+	core::line3d<f32> shootline,
+	bool liquids_pointable,
+	bool look_for_object)
+{
+	PointedThing result;
+
+	INodeDefManager *nodedef = m_map->getNodeDefManager();
+
+	core::aabbox3d<s16> maximal_exceed = nodedef->getSelectionBoxIntUnion();
+	// The code needs to search these nodes
+	core::aabbox3d<s16> search_range(-maximal_exceed.MaxEdge,
+		-maximal_exceed.MinEdge);
+	// If a node is found, there might be a larger node behind.
+	// To find it, we have to go further.
+	s16 maximal_overcheck =
+		  std::max(abs(search_range.MinEdge.X), abs(search_range.MaxEdge.X))
+		+ std::max(abs(search_range.MinEdge.Y), abs(search_range.MaxEdge.Y))
+		+ std::max(abs(search_range.MinEdge.Z), abs(search_range.MaxEdge.Z));
+
+	const v3f original_vector = shootline.getVector();
+	const f32 original_length = original_vector.getLength();
+
+	f32 min_distance = original_length;
+
+	// First try to find an active object
+	if (look_for_object) {
+		ClientActiveObject *selected_object = getSelectedActiveObject(
+			shootline, &result.intersection_point,
+			&result.intersection_normal);
+
+		if (selected_object != NULL) {
+			min_distance =
+				(result.intersection_point - shootline.start).getLength();
+
+			result.type = POINTEDTHING_OBJECT;
+			result.object_id = selected_object->getId();
+		}
+	}
+
+	// Reduce shootline
+	if (original_length > 0) {
+		shootline.end = shootline.start
+			+ shootline.getVector() / original_length * min_distance;
+	}
+
+	// Try to find a node that is closer than the selected active
+	// object (if it exists).
+
+	voxalgo::VoxelLineIterator iterator(shootline.start / BS,
+		shootline.getVector() / BS);
+	v3s16 oldnode = iterator.m_current_node_pos;
+	// Indicates that a node was found.
+	bool is_node_found = false;
+	// If a node is found, it is possible that there's a node
+	// behind it with a large nodebox, so continue the search.
+	u16 node_foundcounter = 0;
+	// If a node is found, this is the center of the
+	// first nodebox the shootline meets.
+	v3f found_boxcenter(0, 0, 0);
+	// The untested nodes are in this range.
+	core::aabbox3d<s16> new_nodes;
+	while (true) {
+		// Test the nodes around the current node in search_range.
+		new_nodes = search_range;
+		new_nodes.MinEdge += iterator.m_current_node_pos;
+		new_nodes.MaxEdge += iterator.m_current_node_pos;
+
+		// Only check new nodes
+		v3s16 delta = iterator.m_current_node_pos - oldnode;
+		if (delta.X > 0)
+			new_nodes.MinEdge.X = new_nodes.MaxEdge.X;
+		else if (delta.X < 0)
+			new_nodes.MaxEdge.X = new_nodes.MinEdge.X;
+		else if (delta.Y > 0)
+			new_nodes.MinEdge.Y = new_nodes.MaxEdge.Y;
+		else if (delta.Y < 0)
+			new_nodes.MaxEdge.Y = new_nodes.MinEdge.Y;
+		else if (delta.Z > 0)
+			new_nodes.MinEdge.Z = new_nodes.MaxEdge.Z;
+		else if (delta.Z < 0)
+			new_nodes.MaxEdge.Z = new_nodes.MinEdge.Z;
+
+		// For each untested node
+		for (s16 x = new_nodes.MinEdge.X; x <= new_nodes.MaxEdge.X; x++) {
+		for (s16 y = new_nodes.MinEdge.Y; y <= new_nodes.MaxEdge.Y; y++) {
+		for (s16 z = new_nodes.MinEdge.Z; z <= new_nodes.MaxEdge.Z; z++) {
+		MapNode n;
+		v3s16 np(x, y, z);
+		bool is_valid_position;
+
+		n = m_map->getNodeNoEx(np, &is_valid_position);
+		if (!(is_valid_position &&
+				isPointableNode(n, nodedef, liquids_pointable))) {
+			continue;
+		}
+		std::vector<aabb3f> boxes;
+		n.getSelectionBoxes(nodedef, &boxes,
+			n.getNeighbors(np, m_map));
+
+		v3f npf = intToFloat(np, BS);
+		for (std::vector<aabb3f>::const_iterator i = boxes.begin();
+			i != boxes.end(); ++i) {
+			aabb3f box = *i;
+			box.MinEdge += npf;
+			box.MaxEdge += npf;
+			v3f intersection_point;
+			v3s16 intersection_normal;
+			if (!boxLineCollision(box, shootline.start, shootline.getVector(),
+					&intersection_point, &intersection_normal)) {
+				continue;
+			}
+			f32 distance = (intersection_point - shootline.start).getLength();
+			if (distance >= min_distance) {
+				continue;
+			}
+			result.type = POINTEDTHING_NODE;
+			result.node_undersurface = np;
+			result.intersection_point = intersection_point;
+			result.intersection_normal = intersection_normal;
+			found_boxcenter = box.getCenter();
+			min_distance = distance;
+			is_node_found = true;
+		}
+		}
+		}
+		}
+		if (is_node_found) {
+			node_foundcounter++;
+			if (node_foundcounter > maximal_overcheck) {
+				break;
+			}
+		}
+		// Next node
+		if (iterator.hasNext()) {
+			oldnode = iterator.m_current_node_pos;
+			iterator.next();
+		} else {
+			break;
+		}
+	}
+
+	if (is_node_found) {
+		// Set undersurface and abovesurface nodes
+		f32 d = 0.002 * BS;
+		v3f fake_intersection = result.intersection_point;
+		// Move intersection towards its source block.
+		if (fake_intersection.X < found_boxcenter.X)
+			fake_intersection.X += d;
+		else
+			fake_intersection.X -= d;
+
+		if (fake_intersection.Y < found_boxcenter.Y)
+			fake_intersection.Y += d;
+		else
+			fake_intersection.Y -= d;
+
+		if (fake_intersection.Z < found_boxcenter.Z)
+			fake_intersection.Z += d;
+		else
+			fake_intersection.Z -= d;
+
+		result.node_real_undersurface = floatToInt(fake_intersection, BS);
+		result.node_abovesurface = result.node_real_undersurface
+			+ result.intersection_normal;
+	}
+	return result;
 }
 
 #endif // #ifndef SERVER

--- a/src/environment.h
+++ b/src/environment.h
@@ -55,6 +55,7 @@ class GameScripting;
 class Player;
 class RemotePlayer;
 class PlayerSAO;
+class PointedThing;
 
 class Environment
 {
@@ -626,6 +627,41 @@ public:
 
 	// Get event from queue. CEE_NONE is returned if queue is empty.
 	ClientEnvEvent getClientEvent();
+
+	/*!
+	 * Gets closest object pointed by the shootline.
+	 * Returns NULL if not found.
+	 *
+	 * \param[in]  shootline_on_map    the shootline for
+	 * the test in world coordinates
+	 * \param[out] intersection_point  the first point where
+	 * the shootline meets the object. Valid only if
+	 * not NULL is returned.
+	 * \param[out] intersection_normal the normal vector of
+	 * the intersection, pointing outwards. Zero vector if
+	 * the shootline starts in an active object.
+	 * Valid only if not NULL is returned.
+	 */
+	ClientActiveObject * getSelectedActiveObject(
+		const core::line3d<f32> &shootline_on_map,
+		v3f *intersection_point,
+		v3s16 *intersection_normal
+	);
+
+	/*!
+	 * Performs a raycast on the world.
+	 * Returns the first thing the shootline meets.
+	 *
+	 * @param[in]  shootline         the shootline, starting from
+	 * the camera position. This also gives the maximal distance
+	 * of the search.
+	 * @param[in]  liquids_pointable if false, liquids are ignored
+	 * @param[in]  look_for_object   if false, objects are ignored
+	 */
+	PointedThing getPointedThing(
+		core::line3d<f32> shootline,
+		bool liquids_pointable,
+		bool look_for_object);
 
 	u16 attachement_parent_ids[USHRT_MAX + 1];
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -66,6 +66,7 @@ Map::Map(std::ostream &dout, IGameDef *gamedef):
 	m_dout(dout),
 	m_gamedef(gamedef),
 	m_sector_cache(NULL),
+	m_nodedef(gamedef->ndef()),
 	m_transforming_liquid_loop_count_multiplier(1.0f),
 	m_unprocessed_count(0),
 	m_inc_trending_up_start_time(0),
@@ -227,7 +228,7 @@ void Map::setNode(v3s16 p, MapNode & n)
 		bool temp_bool;
 		errorstream<<"Map::setNode(): Not allowing to place CONTENT_IGNORE"
 				<<" while trying to replace \""
-				<<m_gamedef->ndef()->get(block->getNodeNoCheck(relpos, &temp_bool)).name
+				<<m_nodedef->get(block->getNodeNoCheck(relpos, &temp_bool)).name
 				<<"\" at "<<PP(p)<<" (block "<<PP(blockpos)<<")"<<std::endl;
 		debug_stacks_print_to(infostream);
 		return;
@@ -257,8 +258,6 @@ void Map::unspreadLight(enum LightBank bank,
 		std::set<v3s16> & light_sources,
 		std::map<v3s16, MapBlock*>  & modified_blocks)
 {
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	v3s16 dirs[6] = {
 		v3s16(0,0,1), // back
 		v3s16(0,1,0), // top
@@ -353,20 +352,20 @@ void Map::unspreadLight(enum LightBank bank,
 				If the neighbor is dimmer than what was specified
 				as oldlight (the light of the previous node)
 			*/
-			if(n2.getLight(bank, nodemgr) < oldlight)
+			if(n2.getLight(bank, m_nodedef) < oldlight)
 			{
 				/*
 					And the neighbor is transparent and it has some light
 				*/
-				if(nodemgr->get(n2).light_propagates
-						&& n2.getLight(bank, nodemgr) != 0)
+				if(m_nodedef->get(n2).light_propagates
+						&& n2.getLight(bank, m_nodedef) != 0)
 				{
 					/*
 						Set light to 0 and add to queue
 					*/
 
-					u8 current_light = n2.getLight(bank, nodemgr);
-					n2.setLight(bank, 0, nodemgr);
+					u8 current_light = n2.getLight(bank, m_nodedef);
+					n2.setLight(bank, 0, m_nodedef);
 					block->setNode(relpos, n2);
 
 					unlighted_nodes[n2pos] = current_light;
@@ -421,8 +420,6 @@ void Map::spreadLight(enum LightBank bank,
 		std::set<v3s16> & from_nodes,
 		std::map<v3s16, MapBlock*> & modified_blocks)
 {
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	const v3s16 dirs[6] = {
 		v3s16(0,0,1), // back
 		v3s16(0,1,0), // top
@@ -476,7 +473,7 @@ void Map::spreadLight(enum LightBank bank,
 		bool is_valid_position;
 		MapNode n = block->getNode(relpos, &is_valid_position);
 
-		u8 oldlight = is_valid_position ? n.getLight(bank, nodemgr) : 0;
+		u8 oldlight = is_valid_position ? n.getLight(bank, m_nodedef) : 0;
 		u8 newlight = diminish_light(oldlight);
 
 		// Loop through 6 neighbors
@@ -512,7 +509,7 @@ void Map::spreadLight(enum LightBank bank,
 				If the neighbor is brighter than the current node,
 				add to list (it will light up this node on its turn)
 			*/
-			if(n2.getLight(bank, nodemgr) > undiminish_light(oldlight))
+			if(n2.getLight(bank, m_nodedef) > undiminish_light(oldlight))
 			{
 				lighted_nodes.insert(n2pos);
 				changed = true;
@@ -521,11 +518,11 @@ void Map::spreadLight(enum LightBank bank,
 				If the neighbor is dimmer than how much light this node
 				would spread on it, add to list
 			*/
-			if(n2.getLight(bank, nodemgr) < newlight)
+			if(n2.getLight(bank, m_nodedef) < newlight)
 			{
-				if(nodemgr->get(n2).light_propagates)
+				if(m_nodedef->get(n2).light_propagates)
 				{
-					n2.setLight(bank, newlight, nodemgr);
+					n2.setLight(bank, newlight, m_nodedef);
 					block->setNode(relpos, n2);
 					lighted_nodes.insert(n2pos);
 					changed = true;
@@ -558,8 +555,6 @@ void Map::updateLighting(enum LightBank bank,
 		std::map<v3s16, MapBlock*> & a_blocks,
 		std::map<v3s16, MapBlock*> & modified_blocks)
 {
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	/*m_dout<<"Map::updateLighting(): "
 			<<a_blocks.size()<<" blocks."<<std::endl;*/
 
@@ -614,12 +609,12 @@ void Map::updateLighting(enum LightBank bank,
 							<<std::endl;
 					continue;
 				}
-				u8 oldlight = n.getLight(bank, nodemgr);
-				n.setLight(bank, 0, nodemgr);
+				u8 oldlight = n.getLight(bank, m_nodedef);
+				n.setLight(bank, 0, m_nodedef);
 				block->setNode(p, n);
 
 				// If node sources light, add to list
-				u8 source = nodemgr->get(n).light_source;
+				u8 source = m_nodedef->get(n).light_source;
 				if(source != 0)
 					light_sources.insert(p + posnodes);
 
@@ -810,8 +805,6 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 		std::map<v3s16, MapBlock*> &modified_blocks,
 		bool remove_metadata)
 {
-	INodeDefManager *ndef = m_gamedef->ndef();
-
 	// Collect old node for rollback
 	RollbackNode rollback_oldnode(this, p, m_gamedef);
 
@@ -825,14 +818,14 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 
 	// Set the node on the map
 	// Ignore light (because calling voxalgo::update_lighting_nodes)
-	n.setLight(LIGHTBANK_DAY, 0, ndef);
-	n.setLight(LIGHTBANK_NIGHT, 0, ndef);
+	n.setLight(LIGHTBANK_DAY, 0, m_nodedef);
+	n.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
 	setNode(p, n);
 
 	// Update lighting
 	std::vector<std::pair<v3s16, MapNode> > oldnodes;
 	oldnodes.push_back(std::pair<v3s16, MapNode>(p, oldnode));
-	voxalgo::update_lighting_nodes(this, ndef, oldnodes, modified_blocks);
+	voxalgo::update_lighting_nodes(this, m_nodedef, oldnodes, modified_blocks);
 
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = modified_blocks.begin();
@@ -869,11 +862,10 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 
 		bool is_valid_position;
 		MapNode n2 = getNodeNoEx(p2, &is_valid_position);
-		if(is_valid_position
-				&& (ndef->get(n2).isLiquid() || n2.getContent() == CONTENT_AIR))
-		{
+		if(is_valid_position &&
+				(m_nodedef->get(n2).isLiquid() ||
+				n2.getContent() == CONTENT_AIR))
 			m_transforming_liquid.push_back(p2);
-		}
 	}
 }
 
@@ -1213,9 +1205,6 @@ s32 Map::transforming_liquid_size() {
 
 void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 {
-
-	INodeDefManager *nodemgr = m_gamedef->ndef();
-
 	DSTACK(FUNCTION_NAME);
 	//TimeTaker timer("transformLiquids()");
 
@@ -1275,12 +1264,12 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 		// The node which will be placed there if liquid
 		// can't flow into this node.
 		content_t floodable_node = CONTENT_AIR;
-		const ContentFeatures &cf = nodemgr->get(n0);
+		const ContentFeatures &cf = m_nodedef->get(n0);
 		LiquidType liquid_type = cf.liquid_type;
 		switch (liquid_type) {
 			case LIQUID_SOURCE:
 				liquid_level = LIQUID_LEVEL_SOURCE;
-				liquid_kind = nodemgr->getId(cf.liquid_alternative_flowing);
+				liquid_kind = m_nodedef->getId(cf.liquid_alternative_flowing);
 				break;
 			case LIQUID_FLOWING:
 				liquid_level = (n0.param2 & LIQUID_LEVEL_MASK);
@@ -1322,8 +1311,8 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 			}
 			v3s16 npos = p0 + dirs[i];
 			NodeNeighbor nb(getNodeNoEx(npos), nt, npos);
-			const ContentFeatures &cfnb = nodemgr->get(nb.n);
-			switch (nodemgr->get(nb.n.getContent()).liquid_type) {
+			const ContentFeatures &cfnb = m_nodedef->get(nb.n);
+			switch (m_nodedef->get(nb.n.getContent()).liquid_type) {
 				case LIQUID_NONE:
 					if (cfnb.floodable) {
 						airs[num_airs++] = nb;
@@ -1351,8 +1340,8 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 				case LIQUID_SOURCE:
 					// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
 					if (liquid_kind == CONTENT_AIR)
-						liquid_kind = nodemgr->getId(cfnb.liquid_alternative_flowing);
-					if (nodemgr->getId(cfnb.liquid_alternative_flowing) != liquid_kind) {
+						liquid_kind = m_nodedef->getId(cfnb.liquid_alternative_flowing);
+					if (m_nodedef->getId(cfnb.liquid_alternative_flowing) != liquid_kind) {
 						neutrals[num_neutrals++] = nb;
 					} else {
 						// Do not count bottom source, it will screw things up
@@ -1363,8 +1352,8 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 				case LIQUID_FLOWING:
 					// if this node is not (yet) of a liquid type, choose the first liquid type we encounter
 					if (liquid_kind == CONTENT_AIR)
-						liquid_kind = nodemgr->getId(cfnb.liquid_alternative_flowing);
-					if (nodemgr->getId(cfnb.liquid_alternative_flowing) != liquid_kind) {
+						liquid_kind = m_nodedef->getId(cfnb.liquid_alternative_flowing);
+					if (m_nodedef->getId(cfnb.liquid_alternative_flowing) != liquid_kind) {
 						neutrals[num_neutrals++] = nb;
 					} else {
 						flows[num_flows++] = nb;
@@ -1382,15 +1371,15 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 		s8 new_node_level = -1;
 		s8 max_node_level = -1;
 
-		u8 range = nodemgr->get(liquid_kind).liquid_range;
+		u8 range = m_nodedef->get(liquid_kind).liquid_range;
 		if (range > LIQUID_LEVEL_MAX + 1)
 			range = LIQUID_LEVEL_MAX + 1;
 
-		if ((num_sources >= 2 && nodemgr->get(liquid_kind).liquid_renewable) || liquid_type == LIQUID_SOURCE) {
+		if ((num_sources >= 2 && m_nodedef->get(liquid_kind).liquid_renewable) || liquid_type == LIQUID_SOURCE) {
 			// liquid_kind will be set to either the flowing alternative of the node (if it's a liquid)
 			// or the flowing alternative of the first of the surrounding sources (if it's air), so
 			// it's perfectly safe to use liquid_kind here to determine the new node content.
-			new_node_content = nodemgr->getId(nodemgr->get(liquid_kind).liquid_alternative_source);
+			new_node_content = m_nodedef->getId(m_nodedef->get(liquid_kind).liquid_alternative_source);
 		} else if (num_sources >= 1 && sources[0].t != NEIGHBOR_LOWER) {
 			// liquid_kind is set properly, see above
 			max_node_level = new_node_level = LIQUID_LEVEL_MAX;
@@ -1427,7 +1416,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 				}
 			}
 
-			u8 viscosity = nodemgr->get(liquid_kind).liquid_viscosity;
+			u8 viscosity = m_nodedef->get(liquid_kind).liquid_viscosity;
 			if (viscosity > 1 && max_node_level != liquid_level) {
 				// amount to gain, limited by viscosity
 				// must be at least 1 in absolute value
@@ -1455,7 +1444,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 			check if anything has changed. if not, just continue with the next node.
 		 */
 		if (new_node_content == n0.getContent() &&
-				(nodemgr->get(n0.getContent()).liquid_type != LIQUID_FLOWING ||
+				(m_nodedef->get(n0.getContent()).liquid_type != LIQUID_FLOWING ||
 				((n0.param2 & LIQUID_LEVEL_MASK) == (u8)new_node_level &&
 				((n0.param2 & LIQUID_FLOW_DOWN_MASK) == LIQUID_FLOW_DOWN_MASK)
 				== flowing_down)))
@@ -1467,7 +1456,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 		 */
 		MapNode n00 = n0;
 		//bool flow_down_enabled = (flowing_down && ((n0.param2 & LIQUID_FLOW_DOWN_MASK) != LIQUID_FLOW_DOWN_MASK));
-		if (nodemgr->get(new_node_content).liquid_type == LIQUID_FLOWING) {
+		if (m_nodedef->get(new_node_content).liquid_type == LIQUID_FLOWING) {
 			// set level to last 3 bits, flowing down bit to 4th bit
 			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);
 		} else {
@@ -1477,8 +1466,8 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 		n0.setContent(new_node_content);
 
 		// Ignore light (because calling voxalgo::update_lighting_nodes)
-		n0.setLight(LIGHTBANK_DAY, 0, nodemgr);
-		n0.setLight(LIGHTBANK_NIGHT, 0, nodemgr);
+		n0.setLight(LIGHTBANK_DAY, 0, m_nodedef);
+		n0.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
 
 		// Find out whether there is a suspect for this action
 		std::string suspect;
@@ -1512,7 +1501,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 		/*
 			enqueue neighbors for update if neccessary
 		 */
-		switch (nodemgr->get(n0.getContent()).liquid_type) {
+		switch (m_nodedef->get(n0.getContent()).liquid_type) {
 			case LIQUID_SOURCE:
 			case LIQUID_FLOWING:
 				// make sure source flows into all neighboring nodes
@@ -1535,7 +1524,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 	for (std::deque<v3s16>::iterator iter = must_reflow.begin(); iter != must_reflow.end(); ++iter)
 		m_transforming_liquid.push_back(*iter);
 
-	voxalgo::update_lighting_nodes(this, nodemgr, changed_nodes, modified_blocks);
+	voxalgo::update_lighting_nodes(this, m_nodedef, changed_nodes, modified_blocks);
 
 
 	/* ----------------------------------------------------------------------
@@ -1900,7 +1889,7 @@ bool ServerMap::initBlockMake(v3s16 blockpos, BlockMakeData *data)
 	data->blockpos_min = bpmin;
 	data->blockpos_max = bpmax;
 	data->blockpos_requested = blockpos;
-	data->nodedef = m_gamedef->ndef();
+	data->nodedef = m_nodedef;
 
 	/*
 		Create the whole area of this and the neighboring blocks

--- a/src/map.h
+++ b/src/map.h
@@ -193,6 +193,8 @@ public:
 	virtual MapBlock * emergeBlock(v3s16 p, bool create_blank=true)
 	{ return getBlockNoCreateNoEx(p); }
 
+	inline INodeDefManager * getNodeDefManager() { return m_nodedef; }
+
 	// Returns InvalidPositionException if not found
 	bool isNodeUnderground(v3s16 p);
 
@@ -345,6 +347,9 @@ protected:
 
 	// Queued transforming water nodes
 	UniqueQueue<v3s16> m_transforming_liquid;
+
+	// This stores the properties of the nodes on the map.
+	INodeDefManager *m_nodedef;
 
 private:
 	f32 m_transforming_liquid_loop_count_multiplier;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 
 class INodeDefManager;
+class Map;
 
 /*
 	Naming scheme:
@@ -245,6 +246,13 @@ struct MapNode
 	v3s16 getWallMountedDir(INodeDefManager *nodemgr) const;
 
 	void rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot);
+
+	/*!
+	 * Checks which neighbors does this node connect to.
+	 *
+	 * \param p coordinates of the node
+	 */
+	u8 getNeighbors(v3s16 p, Map *map);
 
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -790,9 +790,18 @@ public:
 	virtual void resetNodeResolveState();
 	virtual void mapNodeboxConnections();
 	virtual bool nodeboxConnects(MapNode from, MapNode to, u8 connect_face);
+	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const
+	{
+		return m_selection_box_int_union;
+	}
 
 private:
 	void addNameIdMapping(content_t i, std::string name);
+	/*!
+	 * Recalculates m_selection_box_int_union based on
+	 * m_selection_box_union.
+	 */
+	void fixSelectionBoxIntUnion();
 
 	// Features indexed by id
 	std::vector<ContentFeatures> m_content_features;
@@ -819,6 +828,14 @@ private:
 
 	// True when all nodes have been registered
 	bool m_node_registration_complete;
+
+	//! The union of all nodes' selection boxes.
+	aabb3f m_selection_box_union;
+	/*!
+	 * The smallest box in node coordinates that
+	 * contains all nodes' selection boxes.
+	 */
+	core::aabbox3d<s16> m_selection_box_int_union;
 };
 
 
@@ -849,6 +866,8 @@ void CNodeDefManager::clear()
 	m_name_id_mapping_with_aliases.clear();
 	m_group_to_items.clear();
 	m_next_id = 0;
+	m_selection_box_union.reset(0,0,0);
+	m_selection_box_int_union.reset(0,0,0);
 
 	resetNodeResolveState();
 
@@ -1007,6 +1026,127 @@ content_t CNodeDefManager::allocateId()
 }
 
 
+/*!
+ * Returns the smallest box that contains all boxes
+ * in the vector. Box_union is expanded.
+ * @param[in]      boxes     the vector containing the boxes
+ * @param[in, out] box_union the union of the arguments
+ */
+void boxVectorUnion(const std::vector<aabb3f> &boxes, aabb3f *box_union)
+{
+	for (std::vector<aabb3f>::const_iterator it = boxes.begin();
+			it != boxes.end(); ++it) {
+		box_union->addInternalBox(*it);
+	}
+}
+
+
+/*!
+ * Returns a box that contains the nodebox in every case.
+ * The argument node_union is expanded.
+ * @param[in]      nodebox  the nodebox to be measured
+ * @param[in]      features  used to decide whether the nodebox
+ * can be rotated
+ * @param[in, out] box_union the union of the arguments
+ */
+void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
+	aabb3f *box_union)
+{
+	switch(nodebox.type) {
+	case NODEBOX_FIXED:
+	case NODEBOX_LEVELED:
+	{
+		// Raw union
+		aabb3f half_processed(0, 0, 0, 0, 0, 0);
+		boxVectorUnion(nodebox.fixed, &half_processed);
+		// Set leveled boxes to maximal
+		if (nodebox.type == NODEBOX_LEVELED) {
+			half_processed.MaxEdge.Y = +BS / 2;
+		}
+		if (features.param_type_2 == CPT2_FACEDIR) {
+			// Get maximal coordinate
+			f32 coords[] = {
+				fabsf(half_processed.MinEdge.X),
+				fabsf(half_processed.MinEdge.Y),
+				fabsf(half_processed.MinEdge.Z),
+				fabsf(half_processed.MaxEdge.X),
+				fabsf(half_processed.MaxEdge.Y),
+				fabsf(half_processed.MaxEdge.Z) };
+			f32 max = 0;
+			for (int i = 0; i < 6; i++) {
+				if (max < coords[i]) {
+					max = coords[i];
+				}
+			}
+			// Add the union of all possible rotated boxes
+			box_union->addInternalPoint(-max, -max, -max);
+			box_union->addInternalPoint(+max, +max, +max);
+		} else {
+			box_union->addInternalBox(half_processed);
+		}
+	}
+	break;
+	case NODEBOX_WALLMOUNTED:
+	{
+		// Add fix boxes
+		box_union->addInternalBox(nodebox.wall_top);
+		box_union->addInternalBox(nodebox.wall_bottom);
+		// Find maximal coordinate in the X-Z plane
+		f32 coords[] = {
+			fabsf(nodebox.wall_side.MinEdge.X),
+			fabsf(nodebox.wall_side.MinEdge.Z),
+			fabsf(nodebox.wall_side.MaxEdge.X),
+			fabsf(nodebox.wall_side.MaxEdge.Z) };
+		f32 max = 0;
+		for (int i = 0; i < 4; i++) {
+			if (max < coords[i]) {
+				max = coords[i];
+			}
+		}
+		// Add the union of all possible rotated boxes
+		box_union->addInternalPoint(-max, nodebox.wall_side.MinEdge.Y, -max);
+		box_union->addInternalPoint(max, nodebox.wall_side.MaxEdge.Y, max);
+	}
+	break;
+	case NODEBOX_CONNECTED:
+	{
+		// Add all possible connected boxes
+		boxVectorUnion(nodebox.fixed,          box_union);
+		boxVectorUnion(nodebox.connect_top,    box_union);
+		boxVectorUnion(nodebox.connect_bottom, box_union);
+		boxVectorUnion(nodebox.connect_front,  box_union);
+		boxVectorUnion(nodebox.connect_left,   box_union);
+		boxVectorUnion(nodebox.connect_back,   box_union);
+		boxVectorUnion(nodebox.connect_right,  box_union);
+	}
+	break;
+	default:
+	{
+		// NODEBOX_REGULAR
+		box_union->addInternalPoint(-BS / 2, -BS / 2, -BS / 2);
+		box_union->addInternalPoint(+BS / 2, +BS / 2, +BS / 2);
+	}
+	}
+}
+
+
+inline void CNodeDefManager::fixSelectionBoxIntUnion()
+{
+	m_selection_box_int_union.MinEdge.X = floorf(
+		m_selection_box_union.MinEdge.X / BS + 0.5f);
+	m_selection_box_int_union.MinEdge.Y = floorf(
+		m_selection_box_union.MinEdge.Y / BS + 0.5f);
+	m_selection_box_int_union.MinEdge.Z = floorf(
+		m_selection_box_union.MinEdge.Z / BS + 0.5f);
+	m_selection_box_int_union.MaxEdge.X = ceilf(
+		m_selection_box_union.MaxEdge.X / BS - 0.5f);
+	m_selection_box_int_union.MaxEdge.Y = ceilf(
+		m_selection_box_union.MaxEdge.Y / BS - 0.5f);
+	m_selection_box_int_union.MaxEdge.Z = ceilf(
+		m_selection_box_union.MaxEdge.Z / BS - 0.5f);
+}
+
+
 // IWritableNodeDefManager
 content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &def)
 {
@@ -1037,6 +1177,8 @@ content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &d
 	verbosestream << "NodeDefManager: registering content id \"" << id
 		<< "\": name=\"" << def.name << "\""<<std::endl;
 
+	getNodeBoxUnion(def.selection_box, def, &m_selection_box_union);
+	fixSelectionBoxIntUnion();
 	// Add this content to the list of all groups it belongs to
 	// FIXME: This should remove a node from groups it no longer
 	// belongs to when a node is re-registered
@@ -1266,6 +1408,9 @@ void CNodeDefManager::deSerialize(std::istream &is)
 		m_content_features[i] = f;
 		addNameIdMapping(i, f.name);
 		verbosestream << "deserialized " << f.name << std::endl;
+
+		getNodeBoxUnion(f.selection_box, f, &m_selection_box_union);
+		fixSelectionBoxIntUnion();
 	}
 }
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -349,6 +349,11 @@ public:
 	virtual void pendNodeResolve(NodeResolver *nr)=0;
 	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
 	virtual bool nodeboxConnects(const MapNode from, const MapNode to, u8 connect_face)=0;
+	/*!
+	 * Returns the smallest box in node coordinates that
+	 * contains all nodes' selection boxes.
+	 */
+	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
 };
 
 class IWritableNodeDefManager : public INodeDefManager {
@@ -406,6 +411,7 @@ public:
 	virtual void runNodeResolveCallbacks()=0;
 	virtual void resetNodeResolveState()=0;
 	virtual void mapNodeboxConnections()=0;
+	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
 };
 
 IWritableNodeDefManager *createNodeDefManager();

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -1,0 +1,86 @@
+/*
+Minetest
+Copyright (C) 2016 juhdanad, Daniel Juhasz <juhdanad@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "irr_v3d.h"
+#include "irr_aabb3d.h"
+
+bool boxLineCollision(const aabb3f &box, const v3f &start,
+		const v3f &dir, v3f *collision_point, v3s16 *collision_normal) {
+	if (box.isPointInside(start)) {
+		*collision_point = start;
+		collision_normal->set(0, 0, 0);
+		return true;
+	}
+	float m = 0;
+	//Test X collision
+	if (dir.X != 0) {
+		if (dir.X > 0) {
+			m = (box.MinEdge.X - start.X) / dir.X;
+		} else {
+			m = (box.MaxEdge.X - start.X) / dir.X;
+		}
+		if (m >= 0 && m <= 1) {
+			*collision_point = start + dir * m;
+			if ((collision_point->Y >= box.MinEdge.Y)
+					&& (collision_point->Y <= box.MaxEdge.Y)
+					&& (collision_point->Z >= box.MinEdge.Z)
+					&& (collision_point->Z <= box.MaxEdge.Z)) {
+				collision_normal->set((dir.X > 0) ? -1 : 1, 0, 0);
+				return true;
+			}
+		}
+	}
+	//Test Y collision
+	if (dir.Y != 0) {
+		if (dir.Y > 0) {
+			m = (box.MinEdge.Y - start.Y) / dir.Y;
+		} else {
+			m = (box.MaxEdge.Y - start.Y) / dir.Y;
+		}
+		if (m >= 0 && m <= 1) {
+			*collision_point = start + dir * m;
+			if ((collision_point->X >= box.MinEdge.X)
+					&& (collision_point->X <= box.MaxEdge.X)
+					&& (collision_point->Z >= box.MinEdge.Z)
+					&& (collision_point->Z <= box.MaxEdge.Z)) {
+				collision_normal->set(0, (dir.Y > 0) ? -1 : 1, 0);
+				return true;
+			}
+		}
+	}
+	//Test Z collision
+	if (dir.Z != 0) {
+		if (dir.Z > 0) {
+			m = (box.MinEdge.Z - start.Z) / dir.Z;
+		} else {
+			m = (box.MaxEdge.Z - start.Z) / dir.Z;
+		}
+		if (m >= 0 && m <= 1) {
+			*collision_point = start + dir * m;
+			if ((collision_point->X >= box.MinEdge.X)
+					&& (collision_point->X <= box.MaxEdge.X)
+					&& (collision_point->Y >= box.MinEdge.Y)
+					&& (collision_point->Y <= box.MaxEdge.Y)) {
+				collision_normal->set(0, 0, (dir.Z > 0) ? -1 : 1);
+				return true;
+			}
+		}
+	}
+	return false;
+}

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -28,13 +28,14 @@ bool boxLineCollision(const aabb3f &box, const v3f &start,
 		return true;
 	}
 	float m = 0;
-	//Test X collision
+
+	// Test X collision
 	if (dir.X != 0) {
-		if (dir.X > 0) {
+		if (dir.X > 0)
 			m = (box.MinEdge.X - start.X) / dir.X;
-		} else {
+		else
 			m = (box.MaxEdge.X - start.X) / dir.X;
-		}
+
 		if (m >= 0 && m <= 1) {
 			*collision_point = start + dir * m;
 			if ((collision_point->Y >= box.MinEdge.Y)
@@ -46,13 +47,14 @@ bool boxLineCollision(const aabb3f &box, const v3f &start,
 			}
 		}
 	}
-	//Test Y collision
+
+	// Test Y collision
 	if (dir.Y != 0) {
-		if (dir.Y > 0) {
+		if (dir.Y > 0)
 			m = (box.MinEdge.Y - start.Y) / dir.Y;
-		} else {
+		else
 			m = (box.MaxEdge.Y - start.Y) / dir.Y;
-		}
+
 		if (m >= 0 && m <= 1) {
 			*collision_point = start + dir * m;
 			if ((collision_point->X >= box.MinEdge.X)
@@ -64,13 +66,14 @@ bool boxLineCollision(const aabb3f &box, const v3f &start,
 			}
 		}
 	}
-	//Test Z collision
+
+	// Test Z collision
 	if (dir.Z != 0) {
-		if (dir.Z > 0) {
+		if (dir.Z > 0)
 			m = (box.MinEdge.Z - start.Z) / dir.Z;
-		} else {
+		else
 			m = (box.MaxEdge.Z - start.Z) / dir.Z;
-		}
+
 		if (m >= 0 && m <= 1) {
 			*collision_point = start + dir * m;
 			if ((collision_point->X >= box.MinEdge.X)

--- a/src/raycast.h
+++ b/src/raycast.h
@@ -1,0 +1,38 @@
+/*
+Minetest
+Copyright (C) 2016 juhdanad, Daniel Juhasz <juhdanad@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef SRC_RAYCAST_H_
+#define SRC_RAYCAST_H_
+
+
+/*!
+ * Checks if a line and a box intersects.
+ * @param[in]  box              box to test collision
+ * @param[in]  start            starting point of the line
+ * @param[in]  dir              direction and length of the line
+ * @param[out] collision_point  first point of the collision
+ * @param[out] collision_normal normal vector at the collision, points
+ * outwards of the surface. If start is in the box, zero vector.
+ * @returns true if a collision point was found
+ */
+bool boxLineCollision(const aabb3f &box, const v3f &start, const v3f &dir,
+	v3f *collision_point, v3s16 *collision_normal);
+
+
+#endif /* SRC_RAYCAST_H_ */

--- a/src/unittest/test_voxelalgorithms.cpp
+++ b/src/unittest/test_voxelalgorithms.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "gamedef.h"
 #include "voxelalgorithms.h"
+#include "util/numeric.h"
 
 class TestVoxelAlgorithms : public TestBase {
 public:
@@ -31,6 +32,7 @@ public:
 
 	void testPropogateSunlight(INodeDefManager *ndef);
 	void testClearLightAndCollectSources(INodeDefManager *ndef);
+	void testVoxelLineIterator(INodeDefManager *ndef);
 };
 
 static TestVoxelAlgorithms g_test_instance;
@@ -41,6 +43,7 @@ void TestVoxelAlgorithms::runTests(IGameDef *gamedef)
 
 	TEST(testPropogateSunlight, ndef);
 	TEST(testClearLightAndCollectSources, ndef);
+	TEST(testVoxelLineIterator, ndef);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -200,5 +203,61 @@ void TestVoxelAlgorithms::testClearLightAndCollectSources(INodeDefManager *ndef)
 		UASSERT(light_sources.size() == 1);
 		UASSERT(unlight_from.find(v3s16(1,1,2)) != unlight_from.end());
 		UASSERT(unlight_from.size() == 1);
+	}
+}
+
+void TestVoxelAlgorithms::testVoxelLineIterator(INodeDefManager *ndef)
+{
+	// Test some lines
+	// Do not test lines that start or end on the border of
+	// two voxels as rounding errors can make the test fail!
+	std::vector<core::line3d<f32> > lines;
+	for (f32 x = -9.1; x < 9; x += 3.124) {
+	for (f32 y = -9.2; y < 9; y += 3.123) {
+	for (f32 z = -9.3; z < 9; z += 3.122) {
+		lines.push_back(core::line3d<f32>(-x, -y, -z, x, y, z));
+	}
+	}
+	}
+	lines.push_back(core::line3d<f32>(0, 0, 0, 0, 0, 0));
+	// Test every line
+	std::vector<core::line3d<f32> >::iterator it = lines.begin();
+	for (; it < lines.end(); it++) {
+		core::line3d<f32> l = *it;
+
+		// Initialize test
+		voxalgo::VoxelLineIterator iterator(l.start, l.getVector());
+
+		//Test the first voxel
+		v3s16 start_voxel = floatToInt(l.start, 1);
+		UASSERT(iterator.m_current_node_pos == start_voxel);
+
+		// Values for testing
+		v3s16 end_voxel = floatToInt(l.end, 1);
+		v3s16 voxel_vector = end_voxel - start_voxel;
+		int nodecount = abs(voxel_vector.X) + abs(voxel_vector.Y)
+			+ abs(voxel_vector.Z);
+		int actual_nodecount = 0;
+		v3s16 old_voxel = iterator.m_current_node_pos;
+
+		while (iterator.hasNext()) {
+			iterator.next();
+			actual_nodecount++;
+			v3s16 new_voxel = iterator.m_current_node_pos;
+			// This must be a neighbor of the old voxel
+			UASSERTEQ(f32, (new_voxel - old_voxel).getLengthSQ(), 1);
+			// The line must intersect with the voxel
+			v3f voxel_center = intToFloat(iterator.m_current_node_pos, 1);
+			aabb3f box(voxel_center - v3f(0.5, 0.5, 0.5),
+				voxel_center + v3f(0.5, 0.5, 0.5));
+			UASSERT(box.intersectsWithLine(l));
+			// Update old voxel
+			old_voxel = new_voxel;
+		}
+
+		// Test last node
+		UASSERT(iterator.m_current_node_pos == end_voxel);
+		// Test node count
+		UASSERTEQ(int, actual_nodecount, nodecount);
 	}
 }

--- a/src/util/pointedthing.cpp
+++ b/src/util/pointedthing.cpp
@@ -27,29 +27,25 @@ PointedThing::PointedThing():
 	type(POINTEDTHING_NOTHING),
 	node_undersurface(0,0,0),
 	node_abovesurface(0,0,0),
+	node_real_undersurface(0,0,0),
+	intersection_point(0,0,0),
+	intersection_normal(0,0,0),
 	object_id(-1)
 {}
 
 std::string PointedThing::dump() const
 {
 	std::ostringstream os(std::ios::binary);
-	if(type == POINTEDTHING_NOTHING)
-	{
+	if (type == POINTEDTHING_NOTHING) {
 		os<<"[nothing]";
-	}
-	else if(type == POINTEDTHING_NODE)
-	{
+	} else if (type == POINTEDTHING_NODE) {
 		const v3s16 &u = node_undersurface;
 		const v3s16 &a = node_abovesurface;
 		os<<"[node under="<<u.X<<","<<u.Y<<","<<u.Z
 			<< " above="<<a.X<<","<<a.Y<<","<<a.Z<<"]";
-	}
-	else if(type == POINTEDTHING_OBJECT)
-	{
+	} else if (type == POINTEDTHING_OBJECT) {
 		os<<"[object "<<object_id<<"]";
-	}
-	else
-	{
+	} else {
 		os<<"[unknown PointedThing]";
 	}
 	return os.str();
@@ -59,61 +55,56 @@ void PointedThing::serialize(std::ostream &os) const
 {
 	writeU8(os, 0); // version
 	writeU8(os, (u8)type);
-	if(type == POINTEDTHING_NOTHING)
-	{
-		// nothing
-	}
-	else if(type == POINTEDTHING_NODE)
-	{
+	switch (type) {
+	case POINTEDTHING_NOTHING:
+		break;
+	case POINTEDTHING_NODE:
 		writeV3S16(os, node_undersurface);
 		writeV3S16(os, node_abovesurface);
-	}
-	else if(type == POINTEDTHING_OBJECT)
-	{
+		break;
+	case POINTEDTHING_OBJECT:
 		writeS16(os, object_id);
+		break;
 	}
 }
 
 void PointedThing::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if(version != 0) throw SerializationError(
+	if (version != 0) throw SerializationError(
 			"unsupported PointedThing version");
 	type = (PointedThingType) readU8(is);
-	if(type == POINTEDTHING_NOTHING)
-	{
-		// nothing
-	}
-	else if(type == POINTEDTHING_NODE)
-	{
+	switch (type) {
+	case POINTEDTHING_NOTHING:
+		break;
+	case POINTEDTHING_NODE:
 		node_undersurface = readV3S16(is);
 		node_abovesurface = readV3S16(is);
-	}
-	else if(type == POINTEDTHING_OBJECT)
-	{
+		break;
+	case POINTEDTHING_OBJECT:
 		object_id = readS16(is);
-	}
-	else
-	{
-		throw SerializationError(
-			"unsupported PointedThingType");
+		break;
+	default:
+		throw SerializationError("unsupported PointedThingType");
 	}
 }
 
 bool PointedThing::operator==(const PointedThing &pt2) const
 {
-	if(type != pt2.type)
-		return false;
-	if(type == POINTEDTHING_NODE)
+	if (type != pt2.type)
 	{
-		if(node_undersurface != pt2.node_undersurface)
-			return false;
-		if(node_abovesurface != pt2.node_abovesurface)
+		return false;
+	}
+	if (type == POINTEDTHING_NODE)
+	{
+		if ((node_undersurface != pt2.node_undersurface)
+				|| (node_abovesurface != pt2.node_abovesurface)
+				|| (node_real_undersurface != pt2.node_real_undersurface))
 			return false;
 	}
-	else if(type == POINTEDTHING_OBJECT)
+	else if (type == POINTEDTHING_OBJECT)
 	{
-		if(object_id != pt2.object_id)
+		if (object_id != pt2.object_id)
 			return false;
 	}
 	return true;

--- a/src/util/pointedthing.h
+++ b/src/util/pointedthing.h
@@ -32,17 +32,57 @@ enum PointedThingType
 	POINTEDTHING_OBJECT
 };
 
+//! An active object or node which is selected by a ray on the map.
 struct PointedThing
 {
+	//! The type of the pointed object.
 	PointedThingType type;
+	/*!
+	 * Only valid if type is POINTEDTHING_NODE.
+	 * The coordinates of the node which owns the
+	 * nodebox that the ray hits first.
+	 * This may differ from node_real_undersurface if
+	 * a nodebox exceeds the limits of its node.
+	 */
 	v3s16 node_undersurface;
+	/*!
+	 * Only valid if type is POINTEDTHING_NODE.
+	 * The coordinates of the last node the ray intersects
+	 * before node_undersurface. Same as node_undersurface
+	 * if the ray starts in a nodebox.
+	 */
 	v3s16 node_abovesurface;
+	/*!
+	 * Only valid if type is POINTEDTHING_NODE.
+	 * The coordinates of the node which contains the
+	 * point of the collision and the nodebox of the node.
+	 */
+	v3s16 node_real_undersurface;
+	/*!
+	 * Only valid if type isn't POINTEDTHING_NONE.
+	 * First intersection point of the ray and the nodebox.
+	 */
+	v3f intersection_point;
+	/*!
+	 * Only valid if type isn't POINTEDTHING_NONE.
+	 * Normal vector of the intersection.
+	 * This is perpendicular to the face the ray hits,
+	 * points outside of the box and it's length is 1.
+	 */
+	v3s16 intersection_normal;
+	/*!
+	 * Only valid if type is POINTEDTHING_OBJECT.
+	 * The ID of the object the ray hit.
+	 */
 	s16 object_id;
 
 	PointedThing();
 	std::string dump() const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
+	/*!
+	 * This function ignores the intersection point and normal.
+	 */
 	bool operator==(const PointedThing &pt2) const;
 	bool operator!=(const PointedThing &pt2) const;
 };

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -747,5 +747,73 @@ void update_lighting_nodes(Map *map, INodeDefManager *ndef,
 	}
 }
 
+VoxelLineIterator::VoxelLineIterator(
+	const v3f &start_position,
+	const v3f &line_vector) :
+	m_start_position(start_position),
+	m_line_vector(line_vector),
+	m_next_intersection_multi(10000.0f, 10000.0f, 10000.0f),
+	m_intersection_multi_inc(10000.0f, 10000.0f, 10000.0f),
+	m_step_directions(1.0f, 1.0f, 1.0f)
+{
+	m_current_node_pos = floatToInt(m_start_position, 1);
+
+	if (m_line_vector.X > 0) {
+		m_next_intersection_multi.X = (floorf(m_start_position.X - 0.5) + 1.5
+			- m_start_position.X) / m_line_vector.X;
+		m_intersection_multi_inc.X = 1 / m_line_vector.X;
+	} else if (m_line_vector.X < 0) {
+		m_next_intersection_multi.X = (floorf(m_start_position.X - 0.5)
+			- m_start_position.X + 0.5) / m_line_vector.X;
+		m_intersection_multi_inc.X = -1 / m_line_vector.X;
+		m_step_directions.X = -1;
+	}
+
+	if (m_line_vector.Y > 0) {
+		m_next_intersection_multi.Y = (floorf(m_start_position.Y - 0.5) + 1.5
+			- m_start_position.Y) / m_line_vector.Y;
+		m_intersection_multi_inc.Y = 1 / m_line_vector.Y;
+	} else if (m_line_vector.Y < 0) {
+		m_next_intersection_multi.Y = (floorf(m_start_position.Y - 0.5)
+			- m_start_position.Y + 0.5) / m_line_vector.Y;
+		m_intersection_multi_inc.Y = -1 / m_line_vector.Y;
+		m_step_directions.Y = -1;
+	}
+
+	if (m_line_vector.Z > 0) {
+		m_next_intersection_multi.Z = (floorf(m_start_position.Z - 0.5) + 1.5
+			- m_start_position.Z) / m_line_vector.Z;
+		m_intersection_multi_inc.Z = 1 / m_line_vector.Z;
+	} else if (m_line_vector.Z < 0) {
+		m_next_intersection_multi.Z = (floorf(m_start_position.Z - 0.5)
+			- m_start_position.Z + 0.5) / m_line_vector.Z;
+		m_intersection_multi_inc.Z = -1 / m_line_vector.Z;
+		m_step_directions.Z = -1;
+	}
+
+	m_has_next = (m_next_intersection_multi.X <= 1)
+		|| (m_next_intersection_multi.Y <= 1)
+		|| (m_next_intersection_multi.Z <= 1);
+}
+
+void VoxelLineIterator::next()
+{
+	if ((m_next_intersection_multi.X < m_next_intersection_multi.Y)
+			&& (m_next_intersection_multi.X < m_next_intersection_multi.Z)) {
+		m_next_intersection_multi.X += m_intersection_multi_inc.X;
+		m_current_node_pos.X += m_step_directions.X;
+	} else if ((m_next_intersection_multi.Y < m_next_intersection_multi.Z)) {
+		m_next_intersection_multi.Y += m_intersection_multi_inc.Y;
+		m_current_node_pos.Y += m_step_directions.Y;
+	} else {
+		m_next_intersection_multi.Z += m_intersection_multi_inc.Z;
+		m_current_node_pos.Z += m_step_directions.Z;
+	}
+
+	m_has_next = (m_next_intersection_multi.X <= 1)
+			|| (m_next_intersection_multi.Y <= 1)
+			|| (m_next_intersection_multi.Z <= 1);
+}
+
 } // namespace voxalgo
 

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -73,7 +73,68 @@ void update_lighting_nodes(
 	std::vector<std::pair<v3s16, MapNode> > &oldnodes,
 	std::map<v3s16, MapBlock*> &modified_blocks);
 
+/*!
+ * This class iterates trough voxels that intersect with
+ * a line. The collision detection does not see nodeboxes,
+ * every voxel is a cube and is returned.
+ * This iterator steps to all nodes exactly once.
+ */
+struct VoxelLineIterator
+{
+public:
+	//! Starting position of the line in world coordinates.
+	v3f m_start_position;
+	//! Direction and length of the line in world coordinates.
+	v3f m_line_vector;
+	/*!
+	 * Each component stores the next smallest positive number, by
+	 * which multiplying the line's vector gives a vector that ends
+	 * on the intersection of two nodes.
+	 */
+	v3f m_next_intersection_multi;
+	/*!
+	 * Each component stores the smallest positive number, by which
+	 * m_next_intersection_multi's components can be increased.
+	 */
+	v3f m_intersection_multi_inc;
+	/*!
+	 * Direction of the line. Each component can be -1 or 1 (if a
+	 * component of the line's vector is 0, then there will be 1).
+	 */
+	v3s16 m_step_directions;
+	//! Position of the current node.
+	v3s16 m_current_node_pos;
+	//! If true, the next node will intersect the line, too.
+	bool m_has_next;
+
+	/*!
+	 * Creates a voxel line iterator with the given line.
+	 * @param start_position starting point of the line
+	 * in voxel coordinates
+	 * @param line_vector    length and direction of the
+	 * line in voxel coordinates. start_position+line_vector
+	 * is the end of the line
+	 */
+	VoxelLineIterator(const v3f &start_position,const v3f &line_vector);
+
+	/*!
+	 * Steps to the next voxel.
+	 * Updates m_current_node_pos and
+	 * m_previous_node_pos.
+	 * Note that it works even if hasNext() is false,
+	 * continuing the line as a ray.
+	 */
+	void next();
+
+	/*!
+	 * Returns true if the next voxel intersects the given line.
+	 */
+	inline bool hasNext() const { return m_has_next; }
+};
+
 } // namespace voxalgo
+
+
 
 #endif
 


### PR DESCRIPTION
The new algorithm checks every node exactly once.
In game.cpp I define MAXIMAL_NODEBOX_EXCEED=2. This tells how big can
a nodebox be. (the absolute value of its coordinates must not be greater than MAXIMAL_NODEBOX_EXCEED+0.5)
The function checks at the most sqrt(3)_d_5+20 nodes, where d is the
length of the shootline, so the running time is linear.
Now the point and normal vector of the collision is also returned in the
PointedThing (currently they are not used outside of the function).

I create voxalgo::VoxelLineIterator to iterate trough voxels (in
voxelalgorithms.h).

raycast.h is a new file which contains the code of the improved box-line
collision detection.

Fixes #4973.

Edit by Zeno: See also #4421
