### PR TITLE
buildbot script: retrieve short commit hash properly

### DIFF
--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -81,7 +81,7 @@ else
 	[ -d minetest ] && (cd minetest && git pull) || (git clone https://github.com/minetest/minetest)
 fi
 cd minetest
-git_hash=`git show | head -c14 | tail -c7`
+git_hash=$(git rev-parse --short HEAD)
 
 # Get minetest_game
 cd games

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -76,7 +76,7 @@ else
 	[ -d minetest ] && (cd minetest && git pull) || (git clone https://github.com/minetest/minetest)
 fi
 cd minetest
-git_hash=`git show | head -c14 | tail -c7`
+git_hash=$(git rev-parse --short HEAD)
 
 # Get minetest_game
 cd games


### PR DESCRIPTION
Instead of trying to manually parse the output of 'git show' which can be different across different git configurations, properly use the 'git rev-parse' command that is intended for this purpose.

I was trying to cross compile the Mingw-w64 build from Linux and encountered a problem because the way git_hash was retrieved in the script was messed up due to my custom "git show" output.


I also changed the line to use $() instead of backticks `` ...which was inconsistently used in the script (as $() is used before), and backticks is also typically the less recommended form anyway.