### PR TITLE
Increase android versionCode

### DIFF
--- a/build/android/build.gradle
+++ b/build/android/build.gradle
@@ -14,7 +14,7 @@ android {
 	buildToolsVersion "23.0.3"
 
 	defaultConfig {
-		versionCode 14
+		versionCode 15
 		versionName "${System.env.VERSION_STR}.${versionCode}"
 		minSdkVersion 9
 		targetSdkVersion 9


### PR DESCRIPTION
This little update is due to a packaging problem when uploading on play store. They don't permit to re upload an APK with same version code.
This case was a fail on openssl packaged version which was old and rejected by Google but they don't remove the APK then i should increase the version code to permit having it on play store