### PR TITLE
Add emergechunks chat command + some related fixes and improvements

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -501,8 +501,7 @@ end
 
 core.register_chatcommand("emergeblocks", {
 	params = "(here [radius]) | (<pos1> [<pos2>])",
-	description = "starts loading (or generating, if inexistent) map blocks "
-		.. "contained in area pos1 to pos2",
+	description = "start loading/generating map blocks contained in area pos1 to pos2",
 	privs = {server=true},
 	func = function(name, param)
 		local p1, p2 = parse_range_str(name, param)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -58,7 +58,13 @@ local function parse_range_str(player_name, str)
 	else
 		p1, p2 = core.string_to_area(str)
 		if p1 == nil then
-			return false, "Incorrect area format. Expected: (x1,y1,z1) (x2,y2,z2)"
+			p1 = core.string_to_pos(str)
+			if p1 ~= nil then
+				p2 = {x=p1.x, y=p1.y, z=p1.z}
+			end
+		end
+		if p1 == nil then
+			return false, "Incorrect area format. Expected: (x1,y1,z1) [(x2,y2,z2)]"
 		end
 	end
 
@@ -477,7 +483,7 @@ local function emergeblocks_progress_update(ctx)
 end
 
 core.register_chatcommand("emergeblocks", {
-	params = "(here [radius]) | (<pos1> <pos2>)",
+	params = "(here [radius]) | (<pos1> [<pos2>])",
 	description = "starts loading (or generating, if inexistent) map blocks "
 		.. "contained in area pos1 to pos2",
 	privs = {server=true},
@@ -503,7 +509,7 @@ core.register_chatcommand("emergeblocks", {
 })
 
 core.register_chatcommand("deleteblocks", {
-	params = "(here [radius]) | (<pos1> <pos2>)",
+	params = "(here [radius]) | (<pos1> [<pos2>])",
 	description = "delete map blocks contained in area pos1 to pos2",
 	privs = {server=true},
 	func = function(name, param)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -567,6 +567,19 @@ core.register_chatcommand("emergeblocks", {
 	end,
 })
 
+core.register_chatcommand("emergechunks", {
+	params = "(here [radius]) | (<pos1> [<pos2>])",
+	description = "start loading/generating map chunks contained in area pos1 to pos2",
+	privs = {server=true},
+	func = function(name, param)
+		local p1, p2 = parse_range_str(name, param)
+		if p1 == false then
+			return false, p2
+		end
+		return emerge(name, p1, p2, "chunk")
+	end,
+})
+
 core.register_chatcommand("deleteblocks", {
 	params = "(here [radius]) | (<pos1> [<pos2>])",
 	description = "delete map blocks contained in area pos1 to pos2",

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -639,10 +639,13 @@ local function delete_area(name, p1, p2, unit)
 		max.y - min.y + 1,
 		max.z - min.z + 1,
 		total_count, unit)
-	if core.delete_area(p1, p2) then
-		return true, "Successfully cleared " .. msg_detail
+	local success, total_count, failed_count = core.delete_area(p1, p2)
+	if success then
+		return true, string.format("Successfully cleared %d/%d blocks in %s",
+			total_count - failed_count, total_count, msg_detail)
 	else
-		return false, "Failed to clear one or more blocks in " .. msg_detail
+		return false, string.format("Failed to clear %d/%d blocks in %s",
+			failed_count, total_count, msg_detail)
 	end
 end
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -495,7 +495,7 @@ local function emerge_progress_update(ctx)
 			(ctx.current_count / ctx.total_count) * 100,
 			ctx.current_count / ((ctx.cur_time - ctx.start_time) / 1000000)))
 
-		core.after(2, emerge_progress_update, ctx)
+		core.after(10, emerge_progress_update, ctx)
 	end
 end
 
@@ -541,7 +541,7 @@ core.register_chatcommand("emergeblocks", {
 
 
 		core.emerge_area(p1, p2, emerge_callback, context)
-		core.after(2, emerge_progress_update, context)
+		core.after(10, emerge_progress_update, context)
 
 		return true, string.format("Started emerge of area ranging from %s to %s (%d x %d x %d = %d blocks)",
 			core.pos_to_string(p1, 0), core.pos_to_string(p2, 0),

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -623,6 +623,29 @@ core.register_chatcommand("emergechunks", {
 	end,
 })
 
+local function delete_area(name, p1, p2, unit)
+	-- Sanitize and adjust boundaries
+	-- This is not required when unit is 'block'. It *is* required
+	-- when unit is 'chunk', as core.delete_area() is block-oriented.
+	-- In any case, thus improves user feedback by reporting the exact
+	-- area that has been deleted.
+	local min, max
+	local total_count
+	p1, p2, min, max, total_count = sanitize_area(p1, p2, unit)
+
+	local msg_detail = string.format("area ranging from %s to %s (%d x %d x %d = %d %ss)",
+		core.pos_to_string(p1, 0), core.pos_to_string(p2, 0),
+		max.x - min.x + 1,
+		max.y - min.y + 1,
+		max.z - min.z + 1,
+		total_count, unit)
+	if core.delete_area(p1, p2) then
+		return true, "Successfully cleared " .. msg_detail
+	else
+		return false, "Failed to clear one or more blocks in " .. msg_detail
+	end
+end
+
 core.register_chatcommand("deleteblocks", {
 	params = "(here [distance [nodes|blocks|chunks]]) | (<pos1> [<pos2>])",
 	description = "delete map blocks contained in area pos1 to pos2",
@@ -632,13 +655,7 @@ core.register_chatcommand("deleteblocks", {
 		if p1 == false then
 			return false, p2
 		end
-
-		if core.delete_area(p1, p2) then
-			return true, "Successfully cleared area ranging from " ..
-				core.pos_to_string(p1, 1) .. " to " .. core.pos_to_string(p2, 1)
-		else
-			return false, "Failed to clear one or more blocks in area"
-		end
+		return delete_area(name, p1, p2, "block")
 	end,
 })
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -659,6 +659,19 @@ core.register_chatcommand("deleteblocks", {
 	end,
 })
 
+core.register_chatcommand("deletechunks", {
+	params = "(here [distance [nodes|blocks|chunks]]) | (<pos1> [<pos2>])",
+	description = "delete map chunks contained in area pos1 to pos2",
+	privs = {server=true},
+	func = function(name, param)
+		local p1, p2 = parse_range_str(name, param)
+		if p1 == false then
+			return false, p2
+		end
+		return delete_area(name, p1, p2, "chunk")
+	end,
+})
+
 core.register_chatcommand("mods", {
 	params = "",
 	description = "List mods installed on the server",

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -457,7 +457,7 @@ core.register_chatcommand("set", {
 	end,
 })
 
-local function emergeblocks_callback(pos, action, num_calls_remaining, ctx)
+local function emerge_callback(pos, action, num_calls_remaining, ctx)
 	if ctx.total_blocks == 0 then
 		ctx.total_blocks   = num_calls_remaining + 1
 		ctx.current_blocks = 0
@@ -471,14 +471,14 @@ local function emergeblocks_callback(pos, action, num_calls_remaining, ctx)
 	end
 end
 
-local function emergeblocks_progress_update(ctx)
+local function emerge_progress_update(ctx)
 	if ctx.current_blocks ~= ctx.total_blocks then
 		core.chat_send_player(ctx.requestor_name,
 			string.format("emergeblocks update: %d/%d blocks emerged (%.1f%%)",
 			ctx.current_blocks, ctx.total_blocks,
 			(ctx.current_blocks / ctx.total_blocks) * 100))
 
-		core.after(2, emergeblocks_progress_update, ctx)
+		core.after(2, emerge_progress_update, ctx)
 	end
 end
 
@@ -500,8 +500,8 @@ core.register_chatcommand("emergeblocks", {
 			requestor_name = name
 		}
 
-		core.emerge_area(p1, p2, emergeblocks_callback, context)
-		core.after(2, emergeblocks_progress_update, context)
+		core.emerge_area(p1, p2, emerge_callback, context)
+		core.after(2, emerge_progress_update, context)
 
 		return true, "Started emerge of area ranging from " ..
 			core.pos_to_string(p1, 1) .. " to " .. core.pos_to_string(p2, 1)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -458,25 +458,25 @@ core.register_chatcommand("set", {
 })
 
 local function emerge_callback(pos, action, num_calls_remaining, ctx)
-	if ctx.total_blocks == 0 then
-		ctx.total_blocks   = num_calls_remaining + 1
-		ctx.current_blocks = 0
+	if ctx.total_count == 0 then
+		ctx.total_count   = num_calls_remaining + 1
+		ctx.current_count = 0
 	end
-	ctx.current_blocks = ctx.current_blocks + 1
+	ctx.current_count = ctx.current_count + 1
 
-	if ctx.current_blocks == ctx.total_blocks then
+	if ctx.current_count == ctx.total_count then
 		core.chat_send_player(ctx.requestor_name,
 			string.format("Finished emerging %d blocks in %.2fms.",
-			ctx.total_blocks, (os.clock() - ctx.start_time) * 1000))
+			ctx.total_count, (os.clock() - ctx.start_time) * 1000))
 	end
 end
 
 local function emerge_progress_update(ctx)
-	if ctx.current_blocks ~= ctx.total_blocks then
+	if ctx.current_count ~= ctx.total_count then
 		core.chat_send_player(ctx.requestor_name,
 			string.format("emergeblocks update: %d/%d blocks emerged (%.1f%%)",
-			ctx.current_blocks, ctx.total_blocks,
-			(ctx.current_blocks / ctx.total_blocks) * 100))
+			ctx.current_count, ctx.total_count,
+			(ctx.current_count / ctx.total_count) * 100))
 
 		core.after(2, emerge_progress_update, ctx)
 	end
@@ -494,8 +494,8 @@ core.register_chatcommand("emergeblocks", {
 		end
 
 		local context = {
-			current_blocks = 0,
-			total_blocks   = 0,
+			current_count  = 0,
+			total_count    = 0,
 			start_time     = os.clock(),
 			requestor_name = name
 		}

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -888,8 +888,8 @@ int ModApiEnvMod::l_emerge_area(lua_State *L)
 	// Adding emerge_unit/2 causes the center block of a chunk to be requested
 	// (this should not make a difference in practise)
 	for (s16 z = bpmin.Z + emerge_unit / 2; z <= bpmax.Z; z += emerge_unit)
-	for (s16 y = bpmin.Y + emerge_unit / 2; y <= bpmax.Y; y += emerge_unit)
-	for (s16 x = bpmin.X + emerge_unit / 2; x <= bpmax.X; x += emerge_unit) {
+	for (s16 x = bpmin.X + emerge_unit / 2; x <= bpmax.X; x += emerge_unit)
+	for (s16 y = bpmin.Y + emerge_unit / 2; y <= bpmax.Y; y += emerge_unit) {
 		num_blocks--;
 		emerge->enqueueBlockEmergeEx(v3s16(x, y, z), PEER_ID_INEXISTENT,
 			BLOCK_EMERGE_ALLOW_GEN | BLOCK_EMERGE_FORCE_QUEUE, callback, state);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -826,8 +826,9 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L)
 	return 1;
 }
 
-// emerge_area(p1, p2, [callback, context])
+// emerge_area(p1, p2, [callback, context], [unit])
 // emerge mapblocks in area p1..p2, calls callback with context upon completion
+// unit is "chunk" or "block"
 int ModApiEnvMod::l_emerge_area(lua_State *L)
 {
 	GET_ENV_PTR;
@@ -841,32 +842,60 @@ int ModApiEnvMod::l_emerge_area(lua_State *L)
 	v3s16 bpmax = getNodeBlockPos(read_v3s16(L, 2));
 	sortBoxVerticies(bpmin, bpmax);
 
-	size_t num_blocks = VoxelArea(bpmin, bpmax).getVolume();
-	assert(num_blocks != 0);
-
-	if (lua_isfunction(L, 3)) {
+	int param = 3;
+	if (lua_isfunction(L, param)) {
 		callback = LuaEmergeAreaCallback;
 
-		lua_pushvalue(L, 3);
+		lua_pushvalue(L, param);
 		int callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
-		lua_pushvalue(L, 4);
+		lua_pushvalue(L, param + 1);
 		int args_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 		state = new ScriptCallbackState;
 		state->script       = getServer(L)->getScriptIface();
 		state->callback_ref = callback_ref;
 		state->args_ref     = args_ref;
-		state->refcount     = num_blocks;
+		state->refcount     = -1;
 		state->origin       = getScriptApiBase(L)->getOrigin();
+		param += 2;
 	}
 
-	for (s16 z = bpmin.Z; z <= bpmax.Z; z++)
-	for (s16 y = bpmin.Y; y <= bpmax.Y; y++)
-	for (s16 x = bpmin.X; x <= bpmax.X; x++) {
+	std::string emerge_unit_name = "block";
+	s16 emerge_unit = 1;
+	if (!lua_isnoneornil(L, param)) {
+		emerge_unit_name = "--INVALID--";
+		if (lua_isstring(L, param))
+			emerge_unit_name = lua_tostring(L, param);
+		if (emerge_unit_name != "chunk" && emerge_unit_name != "block") {
+			luaL_error(L, "emerge_area(): invalid unit. Expected 'block' or 'chunk'");
+			return 1;
+		}
+	}
+	if (emerge_unit_name == "chunk") {
+		emerge_unit = emerge->mgparams->chunksize;
+		bpmin = emerge->getContainingChunk(bpmin);
+		bpmax = emerge->getContainingChunk(bpmax);
+		bpmax += emerge_unit - 1;
+	}
+
+	size_t num_blocks = VoxelArea(bpmin, bpmax).getVolume();
+	num_blocks = num_blocks / emerge_unit / emerge_unit / emerge_unit;
+	assert(num_blocks != 0);
+	if (state)
+		state->refcount = num_blocks;
+
+	// Adding emerge_unit/2 causes the center block of a chunk to be requested
+	// (this should not make a difference in practise)
+	for (s16 z = bpmin.Z + emerge_unit / 2; z <= bpmax.Z; z += emerge_unit)
+	for (s16 y = bpmin.Y + emerge_unit / 2; y <= bpmax.Y; y += emerge_unit)
+	for (s16 x = bpmin.X + emerge_unit / 2; x <= bpmax.X; x += emerge_unit) {
+		num_blocks--;
 		emerge->enqueueBlockEmergeEx(v3s16(x, y, z), PEER_ID_INEXISTENT,
 			BLOCK_EMERGE_ALLOW_GEN | BLOCK_EMERGE_FORCE_QUEUE, callback, state);
 	}
+	// Catch error here, instead of having a crash later
+	assert(num_blocks == 0);
 
 	return 0;
 }


### PR DESCRIPTION
The major change of this patch set is the addition of the chat command `emergechunks`. In addition, it includes a few other changes that are not necessarily required, but still related to emergeblocks/emergechunks.

On my system, emergechunks is about 100% faster than emergeblocks...
(i.e. the rate of map generation doubles approximately)

Edit: added a `deletechunks` command as well, and some more minor changes
