### PR TITLE
Call FATAL_ERROR() on lua panic, instead of exit().

### DIFF
--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -40,6 +40,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <cstdarg>
+#include <sstream>
 
 
 class ModNameStorer
@@ -76,6 +77,8 @@ ScriptApiBase::ScriptApiBase() :
 
 	m_luastack = luaL_newstate();
 	FATAL_ERROR_IF(!m_luastack, "luaL_newstate() failed");
+
+	lua_atpanic(m_luastack, &luaPanic);
 
 	luaL_openlibs(m_luastack);
 
@@ -118,6 +121,16 @@ ScriptApiBase::ScriptApiBase() :
 ScriptApiBase::~ScriptApiBase()
 {
 	lua_close(m_luastack);
+}
+
+int ScriptApiBase::luaPanic(lua_State *L)
+{
+	std::ostringstream oss;
+	oss << "LUA PANIC: unprotected error in call to Lua API ("
+		<< lua_tostring(L, -1) << ")";
+	FATAL_ERROR(oss.str().c_str());
+	// NOTREACHED
+	return 0;
 }
 
 void ScriptApiBase::loadMod(const std::string &script_path,

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -118,6 +118,8 @@ protected:
 #endif
 
 private:
+	static int luaPanic(lua_State *L);
+
 	lua_State*      m_luastack;
 
 	Server*         m_server;


### PR DESCRIPTION
I'd like to propose this debugging feature, which I used / needed for diagnosing #4352.

Currently, minetest always does a graceful shutdown on lua panic,
which can make the problem very hard to debug. Calling abort() instead
may cause some data loss (hopefully not too much), but allows using
a debugger to analyze the situation.

Update: the lua panic function now calls FATAL_ERROR().
