### PR TITLE
Remove empty default of on_secondary_use.

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -343,10 +343,6 @@ function core.item_place(itemstack, placer, pointed_thing, param2)
 	return itemstack
 end
 
-function core.item_secondary_use(itemstack, placer)
-	return itemstack
-end
-
 function core.item_drop(itemstack, dropper, pos)
 	if dropper and dropper:is_player() then
 		local v = dropper:get_look_dir()
@@ -607,8 +603,8 @@ core.craftitemdef_default = {
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
 	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
 	on_use = nil,
+	on_secondary_use = nil,
 }
 
 core.tooldef_default = {
@@ -625,9 +621,9 @@ core.tooldef_default = {
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
 	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
 	on_use = nil,
+	on_secondary_use = nil,
 }
 
 core.noneitemdef_default = {  -- This is used for the hand and unknown items
@@ -644,7 +640,7 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'),
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
 	on_drop = nil,
 	on_use = nil,
+	on_secondary_use = nil,
 }

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -280,7 +280,6 @@ core.register_item(":unknown", {
 	description = "Unknown Item",
 	inventory_image = "unknown_item.png",
 	on_place = core.item_place,
-	on_secondary_use = core.item_secondary_use,
 	on_drop = core.item_drop,
 	groups = {not_in_creative_inventory=1},
 	diggable = true,


### PR DESCRIPTION
`on_secondary_use` sets a NOP function by default, that serves no purpose.
The [C-code already assumes `nil` as a lack of it](https://github.com/minetest/minetest/commit/97908cc65670d3f6cf2e286390bfea10f653aaa8#diff-fa972960897c9e4bc3a67e650231e6a8R119), so setting this to `nil` works fine with the engine.
Mods only assign to it and override the default, so for them this should make no difference.

Having this `nil` will allow to differentiate between a node that has a `secondary_use` and one that has not and reduces unused code and calls

---

A full [github search](https://github.com/search?l=lua&q=item_secondary_use+OR+on_secondary_use&ref=searchresults&type=Code&utf8=%E2%9C%93) has been conducted to find any usages that might contradict these assumptions. None were found for `on_secondary_use` and `core.item_secondary_use`

Additionally there are no api guarantees made about a default, so in the unlikely case a mod calls `on_secondary_use` itself (and why would it?), it would have to check for it being set anyway.
