### PR TITLE
Fix l_request_insecure_environment not ignoring all whitespace

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -446,8 +446,9 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 	// Check secure.trusted_mods
 	const char *mod_name = lua_tostring(L, -1);
 	std::string trusted_mods = g_settings->get("secure.trusted_mods");
-	trusted_mods.erase(std::remove(trusted_mods.begin(),
-			trusted_mods.end(), ' '), trusted_mods.end());
+	trusted_mods.erase(std::remove_if(trusted_mods.begin(),
+			trusted_mods.end(), static_cast<int(*)(int)>(&std::isspace)),
+			trusted_mods.end());
 	std::vector<std::string> mod_list = str_split(trusted_mods, ',');
 	if (std::find(mod_list.begin(), mod_list.end(), mod_name) ==
 			mod_list.end()) {


### PR DESCRIPTION
`l_request_insecure_environment` didn't ignore all whitespace in the `secure.trusted_mods` config option.

Replaces `std::remove` with `std::remove_if` and the `isspace` function.
Also ignores anything beyond a '#' comment marker.