### PR TITLE
Decorations: Fix decoration height check errors

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -145,7 +145,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				y < y_min  || y > y_max)
 				continue;
 
-			if (y + getHeight() >= mg->vm->m_area.MaxEdge.Y) {
+			if (y + getHeight() > mg->vm->m_area.MaxEdge.Y) {
 				continue;
 #if 0
 				printf("Decoration at (%d %d %d) cut off\n", x, y, z);
@@ -370,5 +370,9 @@ size_t DecoSchematic::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 
 int DecoSchematic::getHeight()
 {
-	return schematic->size.Y;
+	// Account for a schematic being sunk into the ground by flag.
+	// When placed normally account for how a schematic is placed
+	// sunk 1 node into the ground.
+	return (flags & DECO_PLACE_CENTER_Y) ?
+		(schematic->size.Y - 1) / 2 : schematic->size.Y - 1;
 }


### PR DESCRIPTION
Fix height check comparison from '>=' to '>'.
Fix getHeight() for schematic decorations to account for
'deco place center y' flag and for how normal placement
sinks schematic 1 node into the ground.

Jungletrees were not being placed at y = 46, y = 47 despite
having an acceptable 16 nodes of height above ground surface.
////////////////////////////////////////////////////

Fix for #4401 
Tested.