### PR TITLE
Lua->C getintfield() use lua_tointeger

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -391,7 +391,7 @@ bool getintfield(lua_State *L, int table,
 	lua_getfield(L, table, fieldname);
 	bool got = false;
 	if(lua_isnumber(L, -1)){
-		result = lua_tonumber(L, -1);
+		result = lua_tointeger(L, -1);
 		got = true;
 	}
 	lua_pop(L, 1);
@@ -404,7 +404,7 @@ bool getintfield(lua_State *L, int table,
 	lua_getfield(L, table, fieldname);
 	bool got = false;
 	if(lua_isnumber(L, -1)){
-		result = lua_tonumber(L, -1);
+		result = lua_tointeger(L, -1);
 		got = true;
 	}
 	lua_pop(L, 1);
@@ -417,7 +417,7 @@ bool getintfield(lua_State *L, int table,
 	lua_getfield(L, table, fieldname);
 	bool got = false;
 	if(lua_isnumber(L, -1)){
-		result = lua_tonumber(L, -1);
+		result = lua_tointeger(L, -1);
 		got = true;
 	}
 	lua_pop(L, 1);
@@ -430,7 +430,7 @@ bool getintfield(lua_State *L, int table,
 	lua_getfield(L, table, fieldname);
 	bool got = false;
 	if(lua_isnumber(L, -1)){
-		result = lua_tonumber(L, -1);
+		result = lua_tointeger(L, -1);
 		got = true;
 	}
 	lua_pop(L, 1);


### PR DESCRIPTION
previously function used lua_tonumber which returned float
this caused errors in large numbers and resulted in
obj-def-handlers being invalid when retrived from lua tables in c
replaced with tointeger, this way at least the bits stay same