### PR TITLE
Formspecs: Fix background elements from interferring with each other

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -636,17 +636,17 @@ void GUIFormSpecMenu::parseBackground(parserData* data,std::string element)
 		geom.X = stof(v_geom[0]) * (float)spacing.X;
 		geom.Y = stof(v_geom[1]) * (float)spacing.Y;
 
-		if (parts.size() == 4) {
-			m_clipbackground = is_yes(parts[3]);
-			if (m_clipbackground) {
-				pos.X = stoi(v_pos[0]); //acts as offset
-				pos.Y = stoi(v_pos[1]); //acts as offset
-			}
-		}
-
-		if(!data->explicit_size)
+		if (!data->explicit_size)
 			warningstream<<"invalid use of background without a size[] element"<<std::endl;
-		m_backgrounds.push_back(ImageDrawSpec(name, pos, geom));
+
+		bool clip = false;
+		if (parts.size() == 4 && is_yes(parts[3])) {
+			pos.X = stoi(v_pos[0]); //acts as offset
+			pos.Y = stoi(v_pos[1]); //acts as offset
+			clip = true;
+		}
+		m_backgrounds.push_back(ImageDrawSpec(name, pos, geom, clip));
+
 		return;
 	}
 	errorstream<< "Invalid background element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -1877,7 +1877,6 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_slotbordercolor = video::SColor(200,0,0,0);
 	m_slotborder = false;
 
-	m_clipbackground = false;
 	// Add tooltip
 	{
 		assert(m_tooltip_element == NULL);
@@ -2329,7 +2328,7 @@ void GUIFormSpecMenu::drawMenu()
 			// Image rectangle on screen
 			core::rect<s32> rect = imgrect + spec.pos;
 
-			if (m_clipbackground) {
+			if (spec.clip) {
 				core::dimension2d<s32> absrec_size = AbsoluteRect.getSize();
 				rect = core::rect<s32>(AbsoluteRect.UpperLeftCorner.X - spec.pos.X,
 									AbsoluteRect.UpperLeftCorner.Y - spec.pos.Y,
@@ -2343,8 +2342,7 @@ void GUIFormSpecMenu::drawMenu()
 				core::rect<s32>(core::position2d<s32>(0,0),
 						core::dimension2di(texture->getOriginalSize())),
 				NULL/*&AbsoluteClippingRect*/, colors, true);
-		}
-		else {
+		} else {
 			errorstream << "GUIFormSpecMenu::drawMenu() Draw backgrounds unable to load texture:" << std::endl;
 			errorstream << "\t" << spec.name << std::endl;
 		}

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -143,9 +143,10 @@ class GUIFormSpecMenu : public GUIModalMenu
 	struct ImageDrawSpec
 	{
 		ImageDrawSpec():
-			parent_button(NULL)
-		{
-		}
+			parent_button(NULL),
+			clip(false)
+		{}
+
 		ImageDrawSpec(const std::string &a_name,
 				const std::string &a_item_name,
 				gui::IGUIButton *a_parent_button,
@@ -155,9 +156,10 @@ class GUIFormSpecMenu : public GUIModalMenu
 			parent_button(a_parent_button),
 			pos(a_pos),
 			geom(a_geom),
-			scale(true)
-		{
-		}
+			scale(true),
+			clip(false)
+		{}
+
 		ImageDrawSpec(const std::string &a_name,
 				const std::string &a_item_name,
 				const v2s32 &a_pos, const v2s32 &a_geom):
@@ -166,32 +168,36 @@ class GUIFormSpecMenu : public GUIModalMenu
 			parent_button(NULL),
 			pos(a_pos),
 			geom(a_geom),
-			scale(true)
-		{
-		}
+			scale(true),
+			clip(false)
+		{}
+
 		ImageDrawSpec(const std::string &a_name,
-				const v2s32 &a_pos, const v2s32 &a_geom):
+				const v2s32 &a_pos, const v2s32 &a_geom, bool clip=false):
 			name(a_name),
 			parent_button(NULL),
 			pos(a_pos),
 			geom(a_geom),
-			scale(true)
-		{
-		}
+			scale(true),
+			clip(clip)
+		{}
+
 		ImageDrawSpec(const std::string &a_name,
 				const v2s32 &a_pos):
 			name(a_name),
 			parent_button(NULL),
 			pos(a_pos),
-			scale(false)
-		{
-		}
+			scale(false),
+			clip(false)
+		{}
+
 		std::string name;
 		std::string item_name;
 		gui::IGUIButton *parent_button;
 		v2s32 pos;
 		v2s32 geom;
 		bool scale;
+		bool clip;
 	};
 
 	struct FieldSpec
@@ -426,7 +432,6 @@ protected:
 
 	bool m_bgfullscreen;
 	bool m_slotborder;
-	bool m_clipbackground;
 	video::SColor m_bgcolor;
 	video::SColor m_slotbg_n;
 	video::SColor m_slotbg_h;
@@ -557,4 +562,3 @@ public:
 };
 
 #endif
-


### PR DESCRIPTION
Background are defined using `background[x,y;w,h;image;clip]`
It turns out that clip was stored globally for all backgrounds (as a class member variable) rather than being specific for a particular background.

**Before this PR**

```
background[x,y;w,h;image;false]
background[x,y;w,h;image]
background[x,y;w,h;image;true]
background[x,y;w,h;image]
```

is the same as

```
background[x,y;w,h;image;true]
background[x,y;w,h;image;true]
background[x,y;w,h;image;true]
background[x,y;w,h;image;true]
```

as the last background to specify clipping sets the clipping of all the others.

**What should've happened**


```
background[x,y;w,h;image;false]
background[x,y;w,h;image;false]
background[x,y;w,h;image;true]
background[x,y;w,h;image;false]
```

**After this PR**

the clip only applies to the background it's defined on
