### PR TITLE
Sqlite3 database concurrent use & possible speed improvement

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1210,7 +1210,7 @@ sqlite_synchronous (Default SQLite3 synchronous level) enum -1 -1,0,1,2,3
 
 #    Set the journal mode for sqlite3.
 #    See https://www.sqlite.org/pragma.html#pragma_journal_mode
-#    The default journal mode that sqlite3 uses is DELETE.
+#    The default journal mode that sqlite3 uses is DELETE. Minetest uses WAL by default
 #    See https://www.sqlite.org/wal.html
 #
 #    Some advantages of WAL mode over DELETE mode:
@@ -1240,7 +1240,7 @@ sqlite_synchronous (Default SQLite3 synchronous level) enum -1 -1,0,1,2,3
 #    in the file world.mt in the local database's directory.
 #
 #    Sqlite3 journal modes 'memory' and 'off' are not supported.
-sqlite_journal_mode (Default SQLite3 Journal mode) enum delete delete,truncate,persist,wal
+sqlite_journal_mode (Default SQLite3 Journal mode) enum wal delete,truncate,persist,wal
 
 #    Set the checkpoint interval for the sqlite WAL journal.
 #    See https://www.sqlite.org/wal.html

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1193,8 +1193,66 @@ secure.http_mods (HTTP Mods) string
 
 [*Database]
 
+#    Set the synchronous level for sqlite.
 #    See http://www.sqlite.org/pragma.html#pragma_synchronous
-sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
+#    Besides the sqlite3 supported values (0..3), the value -1 is accepted, which
+#    makes minetest choose the level depending on the journal mode.
+#    (which is 1 for wal, and 2 for other journal modes)
+#
+#    The value in minetest.conf is used for newly-created worlds only. When a
+#    world is created, the level is written to world.mt. To change the synchronous
+#    level for an existing database, modify the value in world.mt.
+#
+#    For locally saved maps (enable_local_map_saving = true), the value from
+#    minetest.conf is always used unless the user configures a different value
+#    in the file world.mt in the local database's directory.
+sqlite_synchronous (Default SQLite3 synchronous level) enum -1 -1,0,1,2,3
+
+#    Set the journal mode for sqlite3.
+#    See https://www.sqlite.org/pragma.html#pragma_journal_mode
+#    The default journal mode that sqlite3 uses is DELETE.
+#    See https://www.sqlite.org/wal.html
+#
+#    Some advantages of WAL mode over DELETE mode:
+#    - setting sqlite_synchronous to normal (1) will never cause database corruption.
+#      (it may still cause data loss though, but not significantly more than the
+#       data loss due to unsaved blocks following a minetest crash).
+#	See: https://www.sqlite.org/pragma.html#pragma_synchronous.
+#    - minetestmapper or other applications *reading* the database will never
+#      interfere with minetest's use of the database.
+#    - WAL mode with a separate checkpoint thread (which is what minetest uses) is
+#      *much* faster. In particular: it significantly reduces IO delays in the server.
+#    Disadvantages:
+#    - WAL mode may not be supported on all file systems
+#    - WAL mode does not work over a network file system
+#    - Write access is needed to the wal file when opening the database, even
+#      in read-only mode.
+#    - The additional wal file, if it still exists, contains important data, and must
+#      be included in any backups. In practise, after a clean minetest shutdown, minetest
+#      will usually have managed to checkpoint and remove the file altogether.
+#
+#    The value set in minetest.conf is used for newly-created worlds only. When a
+#    world is created, the mode is written to world.mt. To change the journal mode
+#    for an existing database, modify the value in world.mt.
+#
+#    For locally saved maps (enable_local_map_saving = true), the value from
+#    minetest.conf is always used unless the user configures a different value
+#    in the file world.mt in the local database's directory.
+#
+#    Sqlite3 journal modes 'memory' and 'off' are not supported.
+sqlite_journal_mode (Default SQLite3 Journal mode) enum delete delete,truncate,persist,wal
+
+#    Set the checkpoint interval for the sqlite WAL journal.
+#    See https://www.sqlite.org/wal.html
+#    This is the interval in seconds with which minetest will checkpoint the WAL
+#    (i.e. transfer committed transactions from the WAL to the database).
+#    Note that checkpointing is just database-internal housekeeping. It does not
+#    in any way affect the safety and persistence of already-saved mapblocks.
+#
+#    Setting this sufficiently high will allow disk IO to be combined in larger
+#    batches, thus reducing the IO load on the database.
+#    Setting this too high may increase mapblock read delays.
+sqlite_wal_checkpoint_interval (SQLite WAL checkpoint interval) int 10 1
 
 [*Advanced]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -819,9 +819,6 @@ server_unload_unused_data_timeout (Unload unused server data) int 29
 #    Maximum number of statically stored objects in a block.
 max_objects_per_block (Maximum objects per block) int 64
 
-#    See http://www.sqlite.org/pragma.html#pragma_synchronous
-sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
-
 #    Length of a server tick and the interval at which objects are generally updated over network.
 dedicated_server_step (Dedicated server step) float 0.1
 
@@ -1193,6 +1190,11 @@ secure.trusted_mods (Trusted mods) string
 #	Comma-separated list of mods that are allowed to access HTTP APIs, which
 #	allow them to upload and download data to/from the internet.
 secure.http_mods (HTTP Mods) string
+
+[*Database]
+
+#    See http://www.sqlite.org/pragma.html#pragma_synchronous
+sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 
 [*Advanced]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1550,9 +1550,70 @@
 
 ## Database
 
+#    Set the synchronous level for sqlite.
 #    See http://www.sqlite.org/pragma.html#pragma_synchronous
-#    type: enum values: 0, 1, 2
-# sqlite_synchronous = 2
+#    Besides the sqlite3 supported values (0..3), the value -1 is accepted, which
+#    makes minetest choose the level depending on the journal mode.
+#    (which is 1 for wal, and 2 for other journal modes)
+#
+#    The value in minetest.conf is used for newly-created worlds only. When a
+#    world is created, the level is written to world.mt. To change the synchronous
+#    level for an existing database, modify the value in world.mt.
+#
+#    For locally saved maps (enable_local_map_saving = true), the value from
+#    minetest.conf is always used unless the user configures a different value
+#    in the file world.mt in the local database's directory.
+#
+#    type: enum values: -1, 0, 1, 2, 3
+# sqlite_synchronous = -1
+
+#    Set the journal mode for sqlite3.
+#    See https://www.sqlite.org/pragma.html#pragma_journal_mode
+#    The default journal mode that sqlite3 uses is DELETE.
+#    See https://www.sqlite.org/wal.html
+#
+#    Some advantages of WAL mode over DELETE mode:
+#    - setting sqlite_synchronous to normal (1) will never cause database corruption.
+#      (it may still cause data loss though, but not significantly more than the
+#       data loss due to unsaved blocks following a minetest crash).
+#	See: https://www.sqlite.org/pragma.html#pragma_synchronous.
+#    - minetestmapper or other applications *reading* the database will never
+#      interfere with minetest's use of the database.
+#    - WAL mode with a separate checkpoint thread (which is what minetest uses) is
+#      *much* faster. In particular: it significantly reduces IO delays in the server.
+#    Disadvantages:
+#    - WAL mode may not be supported on all file systems
+#    - WAL mode does not work over a network file system
+#    - Write access is needed to the wal file when opening the database, even
+#      in read-only mode.
+#    - The additional wal file, if it still exists, contains important data, and must
+#      be included in any backups. In practise, after a clean minetest shutdown, minetest
+#      will usually have managed to checkpoint and remove the file altogether.
+#
+#    The value set in minetest.conf is used for newly-created worlds only. When a
+#    world is created, the mode is written to world.mt. To change the journal mode
+#    for an existing database, modify the value in world.mt.
+#
+#    For locally saved maps (enable_local_map_saving = true), the value from
+#    minetest.conf is always used unless the user configures a different value
+#    in the file world.mt in the local database's directory.
+#
+#    Sqlite3 journal modes 'memory' and 'off' are not supported.
+#    type: enum values: delete, truncate, persist, wal
+# sqlite_journal_mode = delete
+
+#    Set the checkpoint interval for the sqlite WAL journal.
+#    See https://www.sqlite.org/wal.html
+#    This is the interval in seconds with which minetest will checkpoint the WAL
+#    (i.e. transfer committed transactions from the WAL to the database).
+#    Note that checkpointing is just database-internal housekeeping. It does not
+#    in any way affect the safety and persistence of already-saved mapblocks.
+#
+#    Setting this sufficiently high will allow disk IO to be combined in larger
+#    batches, thus reducing the IO load on the database.
+#    Setting this too high may increase mapblock read delays.
+#    type: int
+# sqlite_wal_checkpoint_interval = 10
 
 ## Advanced
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1569,7 +1569,7 @@
 
 #    Set the journal mode for sqlite3.
 #    See https://www.sqlite.org/pragma.html#pragma_journal_mode
-#    The default journal mode that sqlite3 uses is DELETE.
+#    The default journal mode that sqlite3 uses is DELETE. Minetest uses WAL by default
 #    See https://www.sqlite.org/wal.html
 #
 #    Some advantages of WAL mode over DELETE mode:
@@ -1600,7 +1600,7 @@
 #
 #    Sqlite3 journal modes 'memory' and 'off' are not supported.
 #    type: enum values: delete, truncate, persist, wal
-# sqlite_journal_mode = delete
+# sqlite_journal_mode = wal
 
 #    Set the checkpoint interval for the sqlite WAL journal.
 #    See https://www.sqlite.org/wal.html

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1018,10 +1018,6 @@
 #    type: int
 # max_objects_per_block = 64
 
-#    See http://www.sqlite.org/pragma.html#pragma_synchronous
-#    type: enum values: 0, 1, 2
-# sqlite_synchronous = 2
-
 #    Length of a server tick and the interval at which objects are generally updated over network.
 #    type: float
 # dedicated_server_step = 0.1
@@ -1551,6 +1547,12 @@
 #    allow them to upload and download data to/from the internet.
 #    type: string
 # secure.http_mods =
+
+## Database
+
+#    See http://www.sqlite.org/pragma.html#pragma_synchronous
+#    type: enum values: 0, 1, 2
+# sqlite_synchronous = 2
 
 ## Advanced
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -277,6 +277,8 @@ void Client::Stop()
 	if (m_localdb) {
 		infostream << "Local map saving ended." << std::endl;
 		m_localdb->endSave();
+		delete m_localdb;
+		m_localdb = NULL;
 	}
 }
 
@@ -821,7 +823,16 @@ void Client::initLocalMapSaving(const Address &address,
 
 	fs::CreateAllDirs(world_path);
 
-	m_localdb = new Database_SQLite3(world_path);
+	Settings conf;
+	std::string conf_path = world_path + DIR_DELIM + "world.mt";
+	// It's OK if this fails. The file may not even exist...
+	(void) conf.readConfigFile(conf_path.c_str());
+	m_localdb = new Database_SQLite3(world_path, conf);
+	// Don't save world-specific settings for local-map-save databases. Leave that
+	// to the user: unless the user has wilfully configured or changed database-
+	// specific settings (i.e. created or edited world.mt), always use the default
+	// values from minetest.conf
+
 	m_localdb->beginSave();
 	actionstream << "Local map saving started, map will be saved at '" << world_path << "'" << std::endl;
 }

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -41,8 +41,8 @@ SQLite format specification:
 #define BUSY_INFO_TRESHOLD	100	// Print first informational message after 100ms.
 #define BUSY_WARNING_TRESHOLD	250	// Print warning message after 250ms. Lag is increased.
 #define BUSY_ERROR_TRESHOLD	1000	// Print error message after 1000ms. Significant lag.
-#define BUSY_FATAL_TRESHOLD	3000	// Allow SQLITE_BUSY to be returned, which will cause a minetest crash.
-#define BUSY_ERROR_INTERVAL	10000	// Safety net: report again every 10 seconds
+#define BUSY_FATAL_TRESHOLD	10000	// Allow SQLITE_BUSY to be returned, which will cause a minetest crash.
+#define BUSY_ERROR_INTERVAL	2000	// Report again regularly while the situation lasts
 
 
 #define SQLRES(s, r, m) \

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -96,7 +96,7 @@ SQLite3::SQLite3(const std::string &db_path, Settings &conf) :
 	m_database(NULL),
 	m_database_path(db_path),
 	m_synchronous(2),
-	m_journal_mode("delete"),
+	m_journal_mode("wal"),
 	m_last_wal_backlog(0),
 	m_stmt_begin(NULL),
 	m_stmt_commit(NULL),

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -290,7 +290,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");
 	settings->setDefault("chat_message_limit_trigger_kick", "50");
 	settings->setDefault("sqlite_synchronous", "-1");
-	settings->setDefault("sqlite_journal_mode", "delete");
+	settings->setDefault("sqlite_journal_mode", "wal");
 	settings->setDefault("sqlite_wal_checkpoint_interval", "10");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.1");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -289,7 +289,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chat_message_max_size", "500");
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");
 	settings->setDefault("chat_message_limit_trigger_kick", "50");
-	settings->setDefault("sqlite_synchronous", "2");
+	settings->setDefault("sqlite_synchronous", "-1");
+	settings->setDefault("sqlite_journal_mode", "delete");
+	settings->setDefault("sqlite_wal_checkpoint_interval", "10");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
 	settings->setDefault("dedicated_server_step", "0.1");
 	settings->setDefault("active_block_mgmt_interval", "2.0");

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2785,7 +2785,7 @@ Database *ServerMap::createDatabase(
 	Settings &conf)
 {
 	if (name == "sqlite3")
-		return new Database_SQLite3(savedir);
+		return new Database_SQLite3(savedir, conf);
 	if (name == "dummy")
 		return new Database_Dummy();
 	#if USE_LEVELDB


### PR DESCRIPTION
I have created these patches to improve concurrent use of minetest with an external application reading the database. E.g. minetestmapper. One patch can also improve the speed or reduce the risk of corruption.

Major changes:
- Add support for Sqlite3 WAL mode. See https://www.sqlite.org/wal.html.
- Increase abort delay if an external application is accessing (reading) the database.

As there are tradeoffs to enabling WAL mode by default, I put it in a separate patch, which can be merged independently, or not.

The possible speed improvement comes from the fact that WAL mode is safer, thus allowing `sqlite_synchronous` to be set to `normal` (1) instead of `full` (2) without increasing the risk of a corrupt database after an OS crash or power failure. [Quote](https://www.sqlite.org/pragma.html#pragma_synchronous):

> With synchronous=FULL in WAL mode, an additional sync operation of the WAL file happens after each transaction commit. The extra WAL sync following each transaction help ensure that transactions are durable across a power loss, but they do not aid in preserving consistency. If durability is not a concern, then synchronous=NORMAL is normally all one needs in WAL mode.

I.e. in WAL mode with `synchronous = normal`, the risk of minor data loss is a little bit higher, but the loss will still not be significant, and an OS crash results in loss of unsaved blocks anyway. Losing a few more because some OS buffers of the WAL file were not completely written out to disk will not be a significant problem to most server administrators if the benefit is better performance.
