### PR TITLE
Expose getPointedThing() as Raycast

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2557,6 +2557,12 @@ and `minetest.auth_reload` call the authetification handler.
     * `pos2`: Second position
     * `stepsize`: smaller gives more accurate results but requires more computing
       time. Default is `1`.
+* `minetest.raycast(pos1, pos2, objects, liquids)`: returns `Raycast`
+    * Creates a `Raycast` object.
+    * `pos1`: start of the ray
+    * `pos2`: end of the ray
+    * `objects` : if false, only nodes will be returned. Default is `true`.
+    * `liquids' : if false, liquid nodes won't be returned. Default is `false`.
 * `minetest.find_path(pos1,pos2,searchdistance,max_jump,max_drop,algorithm)`
     * returns table containing path
     * returns a table of 3D points representing a path from `pos1` to `pos2` or `nil`
@@ -3754,6 +3760,26 @@ It can be created via `Settings(filename)`.
 * `write()`: returns a boolean (`true` for success)
     * Writes changes to file.
 * `to_table()`: returns `{[key1]=value1,...}`
+
+### `Raycast`
+A raycast on the map. It works with selection boxes.
+Can be used as an iterator in a for loop.
+
+The map is loaded as the ray advances. If the
+map is modified after the `Raycast` is created,
+the changes may or may not have an effect on
+the object.
+
+It can be created via `Raycast(pos1, pos2, objects, liquids)` or
+`minetest.raycast(pos1, pos2, objects, liquids)` where:
+    * `pos1`: start of the ray
+    * `pos2`: end of the ray
+    * `objects` : if false, only nodes will be returned. Default is true.
+    * `liquids' : if false, liquid nodes won't be returned. Default is false.
+
+#### Methods
+* `next()`: returns a `pointed_thing`
+    * Returns the next thing pointed by the ray or nil.
 
 Mapgen objects
 --------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -428,9 +428,9 @@ set(common_SRCS
 	porting.cpp
 	profiler.cpp
 	quicktune.cpp
+	raycast.cpp
 	reflowscan.cpp
 	remoteplayer.cpp
-	raycast.cpp
 	rollback.cpp
 	rollback_interface.cpp
 	serialization.cpp

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -65,7 +65,7 @@ public:
 	{
 	}
 
-	u16 getId()
+	u16 getId() const
 	{
 		return m_id;
 	}
@@ -76,7 +76,28 @@ public:
 	}
 
 	virtual ActiveObjectType getType() const = 0;
+
+
+	/*!
+	 * Returns the collision box of the object.
+	 * This box is translated by the object's
+	 * location.
+	 * The box's coordinates are world coordinates.
+	 * @returns true if the object has a collision box.
+	 */
 	virtual bool getCollisionBox(aabb3f *toset) const = 0;
+
+
+	/*!
+	 * Returns the selection box of the object.
+	 * This box is not translated when the
+	 * object moves.
+	 * The box's coordinates are world coordinates.
+	 * @returns true if the object has a selection box.
+	 */
+	virtual bool getSelectionBox(aabb3f *toset) const = 0;
+
+
 	virtual bool collideWithObjects() const = 0;
 protected:
 	u16 m_id; // 0 is invalid, "no id"

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -30,7 +30,6 @@ class ClientScripting;
 class ClientActiveObject;
 class GenericCAO;
 class LocalPlayer;
-struct PointedThing;
 
 /*
 	The client-side environment.
@@ -125,43 +124,14 @@ public:
 		std::vector<DistanceSortedActiveObject> &dest);
 
 	bool hasClientEnvEvents() const { return !m_client_event_queue.empty(); }
+
 	// Get event from queue. If queue is empty, it triggers an assertion failure.
 	ClientEnvEvent getClientEnvEvent();
 
-	/*!
-	 * Gets closest object pointed by the shootline.
-	 * Returns NULL if not found.
-	 *
-	 * \param[in]  shootline_on_map    the shootline for
-	 * the test in world coordinates
-	 * \param[out] intersection_point  the first point where
-	 * the shootline meets the object. Valid only if
-	 * not NULL is returned.
-	 * \param[out] intersection_normal the normal vector of
-	 * the intersection, pointing outwards. Zero vector if
-	 * the shootline starts in an active object.
-	 * Valid only if not NULL is returned.
-	 */
-	ClientActiveObject * getSelectedActiveObject(
+	virtual void getSelectedActiveObjects(
 		const core::line3d<f32> &shootline_on_map,
-		v3f *intersection_point,
-		v3s16 *intersection_normal
+		std::vector<PointedThing> &objects
 	);
-
-	/*!
-	 * Performs a raycast on the world.
-	 * Returns the first thing the shootline meets.
-	 *
-	 * @param[in]  shootline         the shootline, starting from
-	 * the camera position. This also gives the maximal distance
-	 * of the search.
-	 * @param[in]  liquids_pointable if false, liquids are ignored
-	 * @param[in]  look_for_object   if false, objects are ignored
-	 */
-	PointedThing getPointedThing(
-		core::line3d<f32> shootline,
-		bool liquids_pointable,
-		bool look_for_object);
 
 	u16 attachement_parent_ids[USHRT_MAX + 1];
 

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -44,8 +44,8 @@ public:
 	virtual void updateLight(u8 light_at_pos){}
 	virtual void updateLightNoCheck(u8 light_at_pos){}
 	virtual v3s16 getLightPosition(){return v3s16(0,0,0);}
-	virtual aabb3f *getSelectionBox() { return NULL; }
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
+	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
 	virtual bool collideWithObjects() const { return false; }
 	virtual v3f getPosition(){ return v3f(0,0,0); }
 	virtual float getYaw() const { return 0; }

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -283,8 +283,14 @@ public:
 
 	void initialize(const std::string &data);
 
-	aabb3f *getSelectionBox()
-		{return &m_selection_box;}
+
+	virtual bool getSelectionBox(aabb3f *toset) const
+	{
+		*toset = m_selection_box;
+		return true;
+	}
+
+
 	v3f getPosition()
 		{return m_position;}
 	inline float getYaw() const
@@ -605,11 +611,14 @@ GenericCAO::~GenericCAO()
 	removeFromScene(true);
 }
 
-aabb3f *GenericCAO::getSelectionBox()
+bool GenericCAO::getSelectionBox(aabb3f *toset) const
 {
-	if(!m_prop.is_visible || !m_is_visible || m_is_local_player || getParent() != NULL)
-		return NULL;
-	return &m_selection_box;
+	if (!m_prop.is_visible || !m_is_visible || m_is_local_player
+			|| getParent() != NULL){
+		return false;
+	}
+	*toset = m_selection_box;
+	return true;
 }
 
 v3f GenericCAO::getPosition()
@@ -658,7 +667,7 @@ void GenericCAO::setAttachments()
 	updateAttachments();
 }
 
-ClientActiveObject* GenericCAO::getParent()
+ClientActiveObject* GenericCAO::getParent() const
 {
 	ClientActiveObject *obj = NULL;
 

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -129,13 +129,13 @@ public:
 
 	void processInitData(const std::string &data);
 
-	ClientActiveObject *getParent();
+	ClientActiveObject *getParent() const;
 
 	bool getCollisionBox(aabb3f *toset) const;
 
 	bool collideWithObjects() const;
 
-	aabb3f *getSelectionBox();
+	virtual bool getSelectionBox(aabb3f *toset) const;
 
 	v3f getPosition();
 	inline float getYaw() const

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -91,6 +91,9 @@ public:
 	}
 
 	bool getCollisionBox(aabb3f *toset) const { return false; }
+
+	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
+
 	bool collideWithObjects() const { return false; }
 
 private:
@@ -744,6 +747,18 @@ bool LuaEntitySAO::getCollisionBox(aabb3f *toset) const
 	}
 
 	return false;
+}
+
+bool LuaEntitySAO::getSelectionBox(aabb3f *toset) const
+{
+	if (!m_prop.is_visible) {
+		return false;
+	}
+
+	toset->MinEdge = m_prop.collisionbox.MinEdge * BS;
+	toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS;
+
+	return true;
 }
 
 bool LuaEntitySAO::collideWithObjects() const
@@ -1403,5 +1418,16 @@ bool PlayerSAO::getCollisionBox(aabb3f *toset) const
 
 	toset->MinEdge += m_base_position;
 	toset->MaxEdge += m_base_position;
+	return true;
+}
+
+bool PlayerSAO::getSelectionBox(aabb3f *toset) const
+{
+	if (!m_prop.is_visible) {
+		return false;
+	}
+
+	getCollisionBox(toset);
+
 	return true;
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -127,6 +127,7 @@ public:
 			bool select_horiz_by_yawpitch);
 	std::string getName();
 	bool getCollisionBox(aabb3f *toset) const;
+	bool getSelectionBox(aabb3f *toset) const;
 	bool collideWithObjects() const;
 private:
 	std::string getPropertyPacket();
@@ -357,6 +358,7 @@ public:
 	}
 
 	bool getCollisionBox(aabb3f *toset) const;
+	bool getSelectionBox(aabb3f *toset) const;
 	bool collideWithObjects() const { return true; }
 
 	void finalize(RemotePlayer *player, const std::set<std::string> &privs);

--- a/src/environment.h
+++ b/src/environment.h
@@ -42,6 +42,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class IGameDef;
 class Map;
+struct PointedThing;
+class RaycastState;
 
 class Environment
 {
@@ -75,6 +77,26 @@ public:
 	void setDayNightRatioOverride(bool enable, u32 value);
 
 	u32 getDayCount();
+
+	/*!
+	 * Gets the objects pointed by the shootline as
+	 * pointed things.
+	 * If this is a client environment, the local player
+	 * won't be returned.
+	 * @param[in]  shootline_on_map the shootline for
+	 * the test in world coordinates
+	 *
+	 * @param[out] objects          found objects
+	 */
+	virtual void getSelectedActiveObjects(const core::line3d<f32> &shootline_on_map,
+			std::vector<PointedThing> &objects) = 0;
+
+	/*!
+	 * Returns the next node or object the shootline meets.
+	 * @param state current state of the raycast
+	 * @result output, will contain the next pointed thing
+	 */
+	void continueRaycast(RaycastState *state, PointedThing *result);
 
 	// counter used internally when triggering ABMs
 	u32 m_added_objects;

--- a/src/raycast.h
+++ b/src/raycast.h
@@ -20,6 +20,49 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SRC_RAYCAST_H_
 #define SRC_RAYCAST_H_
 
+#include "voxelalgorithms.h"
+#include "util/pointedthing.h"
+
+//! Sorts PointedThings based on their distance.
+struct RaycastSort
+{
+	bool operator() (const PointedThing &pt1, const PointedThing &pt2) const;
+};
+
+//! Describes the state of a raycast.
+class RaycastState
+{
+public:
+	/*!
+	 * Creates a raycast.
+	 * @param objects_pointable if false, only nodes will be found
+	 * @param liquids pointable if false, liquid nodes won't be found
+	 */
+	RaycastState(const core::line3d<f32> &shootline, bool objects_pointable,
+		bool liquids_pointable);
+
+	//! Shootline of the raycast.
+	core::line3d<f32> m_shootline;
+	//! Iterator to store the progress of the raycast.
+	voxalgo::VoxelLineIterator m_iterator;
+	//! Previous tested node during the raycast.
+	v3s16 m_previous_node;
+
+	/*!
+	 * This priority queue stores the found pointed things
+	 * waiting to be returned.
+	 */
+	std::priority_queue<PointedThing, std::vector<PointedThing>, RaycastSort> m_found;
+
+	bool m_objects_pointable;
+	bool m_liquids_pointable;
+
+	//! The code needs to search these nodes around the center node.
+	core::aabbox3d<s16> m_search_range { 0, 0, 0, 0, 0, 0 };
+
+	//! If true, the Environment will initialize this state.
+	bool m_initialization_needed = true;
+};
 
 /*!
  * Checks if a line and a box intersects.

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -52,6 +52,7 @@ public:
 protected:
 	friend class LuaItemStack;
 	friend class ModApiItemMod;
+	friend class LuaRaycast;
 
 	bool getItemCallback(const char *name, const char *callbackname);
 	void pushPointedThing(const PointedThing& pointed);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -92,6 +92,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaPerlinNoiseMap::Register(L);
 	LuaPseudoRandom::Register(L);
 	LuaPcgRandom::Register(L);
+	LuaRaycast::Register(L);
 	LuaSecureRandom::Register(L);
 	LuaVoxelManip::Register(L);
 	NodeMetaRef::Register(L);

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -284,6 +284,11 @@ public:
 	*/
 	ActiveObjectMessage getActiveObjectMessage();
 
+	virtual void getSelectedActiveObjects(
+		const core::line3d<f32> &shootline_on_map,
+		std::vector<PointedThing> &objects
+	);
+
 	/*
 		Activate objects and dynamically modify for the dtime determined
 		from timestamp and additional_dtime

--- a/src/util/pointedthing.cpp
+++ b/src/util/pointedthing.cpp
@@ -23,20 +23,47 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../exceptions.h"
 #include <sstream>
 
+PointedThing::PointedThing(const v3s16 &under, const v3s16 &above,
+	const v3s16 &real_under, const v3f &point, const v3s16 &normal,
+	f32 distSq):
+	type(POINTEDTHING_NODE),
+	node_undersurface(under),
+	node_abovesurface(above),
+	node_real_undersurface(real_under),
+	intersection_point(point),
+	intersection_normal(normal),
+	distanceSq(distSq)
+{}
+
+PointedThing::PointedThing(s16 id, const v3f &point, const v3s16 &normal,
+	f32 distSq) :
+	type(POINTEDTHING_OBJECT),
+	object_id(id),
+	intersection_point(point),
+	intersection_normal(normal),
+	distanceSq(distSq)
+{}
+
 std::string PointedThing::dump() const
 {
 	std::ostringstream os(std::ios::binary);
-	if (type == POINTEDTHING_NOTHING) {
-		os<<"[nothing]";
-	} else if (type == POINTEDTHING_NODE) {
+	switch (type) {
+	case POINTEDTHING_NOTHING:
+		os << "[nothing]";
+		break;
+	case POINTEDTHING_NODE:
+	{
 		const v3s16 &u = node_undersurface;
 		const v3s16 &a = node_abovesurface;
-		os<<"[node under="<<u.X<<","<<u.Y<<","<<u.Z
-			<< " above="<<a.X<<","<<a.Y<<","<<a.Z<<"]";
-	} else if (type == POINTEDTHING_OBJECT) {
-		os<<"[object "<<object_id<<"]";
-	} else {
-		os<<"[unknown PointedThing]";
+		os << "[node under=" << u.X << "," << u.Y << "," << u.Z << " above="
+			<< a.X << "," << a.Y << "," << a.Z << "]";
+	}
+		break;
+	case POINTEDTHING_OBJECT:
+		os << "[object " << object_id << "]";
+		break;
+	default:
+		os << "[unknown PointedThing]";
 	}
 	return os.str();
 }
@@ -104,4 +131,3 @@ bool PointedThing::operator!=(const PointedThing &pt2) const
 {
 	return !(*this == pt2);
 }
-

--- a/src/util/pointedthing.h
+++ b/src/util/pointedthing.h
@@ -59,6 +59,11 @@ struct PointedThing
 	 */
 	v3s16 node_real_undersurface;
 	/*!
+	 * Only valid if type is POINTEDTHING_OBJECT.
+	 * The ID of the object the ray hit.
+	 */
+	s16 object_id = -1;
+	/*!
 	 * Only valid if type isn't POINTEDTHING_NONE.
 	 * First intersection point of the ray and the nodebox.
 	 */
@@ -71,12 +76,19 @@ struct PointedThing
 	 */
 	v3s16 intersection_normal;
 	/*!
-	 * Only valid if type is POINTEDTHING_OBJECT.
-	 * The ID of the object the ray hit.
+	 * Square of the distance between the pointing
+	 * ray's start point and the intersection point.
 	 */
-	s16 object_id = -1;
+	f32 distanceSq = 0;
 
+	//! Constructor for POINTEDTHING_NOTHING
 	PointedThing() {};
+	//! Constructor for POINTEDTHING_NODE
+	PointedThing(const v3s16 &under, const v3s16 &above,
+		const v3s16 &real_under, const v3f &point, const v3s16 &normal,
+		f32 distSq);
+	//! Constructor for POINTEDTHING_OBJECT
+	PointedThing(s16 id, const v3f &point, const v3s16 &normal, f32 distSq);
 	std::string dump() const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -1407,6 +1407,8 @@ VoxelLineIterator::VoxelLineIterator(const v3f &start_position, const v3f &line_
 	m_line_vector(line_vector)
 {
 	m_current_node_pos = floatToInt(m_start_position, 1);
+	m_start_node_pos = m_current_node_pos;
+	m_last_index = getIndex(floatToInt(start_position + line_vector, 1));
 
 	if (m_line_vector.X > 0) {
 		m_next_intersection_multi.X = (floorf(m_start_position.X - 0.5) + 1.5
@@ -1440,14 +1442,11 @@ VoxelLineIterator::VoxelLineIterator(const v3f &start_position, const v3f &line_
 		m_intersection_multi_inc.Z = -1 / m_line_vector.Z;
 		m_step_directions.Z = -1;
 	}
-
-	m_has_next = (m_next_intersection_multi.X <= 1)
-		|| (m_next_intersection_multi.Y <= 1)
-		|| (m_next_intersection_multi.Z <= 1);
 }
 
 void VoxelLineIterator::next()
 {
+	m_current_index++;
 	if ((m_next_intersection_multi.X < m_next_intersection_multi.Y)
 			&& (m_next_intersection_multi.X < m_next_intersection_multi.Z)) {
 		m_next_intersection_multi.X += m_intersection_multi_inc.X;
@@ -1459,10 +1458,13 @@ void VoxelLineIterator::next()
 		m_next_intersection_multi.Z += m_intersection_multi_inc.Z;
 		m_current_node_pos.Z += m_step_directions.Z;
 	}
+}
 
-	m_has_next = (m_next_intersection_multi.X <= 1)
-			|| (m_next_intersection_multi.Y <= 1)
-			|| (m_next_intersection_multi.Z <= 1);
+s16 VoxelLineIterator::getIndex(v3s16 voxel){
+	return
+		abs(voxel.X - m_start_node_pos.X) +
+		abs(voxel.Y - m_start_node_pos.Y) +
+		abs(voxel.Z - m_start_node_pos.Z);
 }
 
 } // namespace voxalgo

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -123,21 +123,25 @@ public:
 	 * which multiplying the line's vector gives a vector that ends
 	 * on the intersection of two nodes.
 	 */
-	v3f m_next_intersection_multi = v3f(10000.0f, 10000.0f, 10000.0f);
+	v3f m_next_intersection_multi { 10000.0f, 10000.0f, 10000.0f };
 	/*!
 	 * Each component stores the smallest positive number, by which
 	 * m_next_intersection_multi's components can be increased.
 	 */
-	v3f m_intersection_multi_inc = v3f(10000.0f, 10000.0f, 10000.0f);
+	v3f m_intersection_multi_inc { 10000.0f, 10000.0f, 10000.0f };
 	/*!
 	 * Direction of the line. Each component can be -1 or 1 (if a
 	 * component of the line's vector is 0, then there will be 1).
 	 */
-	v3s16 m_step_directions = v3s16(1, 1, 1);
+	v3s16 m_step_directions { 1, 1, 1 };
 	//! Position of the current node.
 	v3s16 m_current_node_pos;
-	//! If true, the next node will intersect the line, too.
-	bool m_has_next;
+	//! Index of the current node
+	s16 m_current_index = 0;
+	//! Position of the start node.
+	v3s16 m_start_node_pos;
+	//! Index of the last node
+	s16 m_last_index;
 
 	/*!
 	 * Creates a voxel line iterator with the given line.
@@ -161,7 +165,18 @@ public:
 	/*!
 	 * Returns true if the next voxel intersects the given line.
 	 */
-	inline bool hasNext() const { return m_has_next; }
+	inline bool hasNext() const
+	{
+		return m_current_index < m_last_index;
+	}
+
+	/*!
+	 * Returns how many times next() must be called until
+	 * voxel==m_current_node_pos.
+	 * If voxel does not intersect with the line,
+	 * the result is undefined.
+	 */
+	s16 getIndex(v3s16 voxel);
 };
 
 } // namespace voxalgo


### PR DESCRIPTION
I have created a new (server-side) function, which is similar to line_of_sight, but it is based on selection boxes.

raycast(pos1, pos2, objects_pointable) -> pointed_thing
pos1, pos2: vectors, the start and end of the shootline
objects_pointable: optional boolean, if false, only nodes are returned

~This code is based on #4346, so merging it will also include that PR.~
Edit:merged.

Things to finish:
- [x] ~~Add option to exclude an object/node from the search. Now the player is returned when giving the player's shootline, since it starts in the player.~~
- [x] Document changes.

A small mod for testing - it places dirt, when there is dirt in your hand.
[init.txt](https://github.com/minetest/minetest/files/405772/init.txt)

Edit by Zeno: I edited the comment to make the #4346 comment more conspicuous; I've changed nothing else.
