### PR TITLE
Assertion failure: sanitize some values obtained from mods (yaw, velocity, etc.)

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -168,6 +168,18 @@ function core.setting_get_pos(name)
 	return core.string_to_pos(value)
 end
 
+function core.get_world_limits()
+	local absolute_limit = 31000
+	local value = core.setting_get("map_generation_limit")
+	local v
+	if not value or value > absolute_limit then
+		v = vector.new(absolute_limit, absolute_limit, absolute_limit)
+	else
+		v = vector.new(value, value, value)
+	end
+	return vector.subtract(0, v), v
+end
+
 -- To be overriden by protection mods
 function core.is_protected(pos, name)
 	return false

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2800,14 +2800,21 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_animation()`: returns range, frame_speed, frame_blend and frame_loop
 * `set_attach(parent, bone, position, rotation)`
     * `bone`: string
-    * `position`: `{x=num, y=num, z=num}` (relative)
-    * `rotation`: `{x=num, y=num, z=num}`
+    * `position`: `{x=num, y=num, z=num}` (relative, multiplied by 10)
+    * `rotation`: `{x=pitch, y=yaw, z=roll}`
 * `get_attach()`: returns parent, bone, position, rotation or nil if it isn't attached
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
     * `bone`: string
-    * `position`: `{x=num, y=num, z=num}` (relative)
-    * `rotation`: `{x=num, y=num, z=num}`
+	E.g. (for player model):
+        * Head
+        * Arm_Left
+        * Arm_Right
+        * Leg_Left
+        * Leg_Right
+        * Body
+    * `position`: `{x=num, y=num, z=num}` (relative, multiplied by 10)
+    * `rotation`: `{x=pitch, y=yaw, z=roll}`
 * `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2089,6 +2089,7 @@ Call these functions only at load time!
 * `minetest.setting_getbool(name)`: returns boolean or `nil`
 * `minetest.setting_get_pos(name)`: returns position or nil
 * `minetest.setting_save()`, returns `nil`, save all settings to config file
+* `minetest.get_world_limits()`: returns the min and max coordinate of the world (pos, pos)
 
 ### Authentication
 * `minetest.notify_authentication_modified(name)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2782,7 +2782,11 @@ This is basically a reference to a C++ `ServerActiveObject`
     * Note: Doesn't work on players, use minetest.kick_player instead
 * `getpos()`: returns `{x=num, y=num, z=num}`
 * `setpos(pos)`; `pos`=`{x=num, y=num, z=num}`
+    * positions that are outside of the map are not accepted.
+      The world limits can be obtained using minetest.get_world_limits()
 * `moveto(pos, continuous=false)`: interpolated move
+    * positions that are outside of the map are not accepted.
+      The world limits can be obtained using minetest.get_world_limits()
 * `punch(puncher, time_from_last_punch, tool_capabilities, direction)`
     * `puncher` = another `ObjectRef`,
     * `time_from_last_punch` = time since last punch action of the puncher
@@ -2803,6 +2807,8 @@ This is basically a reference to a C++ `ServerActiveObject`
     * `bone`: string
     * `position`: `{x=num, y=num, z=num}` (relative, multiplied by 10)
     * `rotation`: `{x=pitch, y=yaw, z=roll}`
+	* Angles are in degrees, and should be between -360 and 360
+	* Angles between -720 and 720 are silently accepted and adjusted
 * `get_attach()`: returns parent, bone, position, rotation or nil if it isn't attached
 * `set_detach()`
 * `set_bone_position(bone, position, rotation)`
@@ -2816,6 +2822,8 @@ This is basically a reference to a C++ `ServerActiveObject`
         * Body
     * `position`: `{x=num, y=num, z=num}` (relative, multiplied by 10)
     * `rotation`: `{x=pitch, y=yaw, z=roll}`
+	* Angles are in degrees, and should be between -360 and 360
+	* Angles between -720 and 720 are silently accepted and adjusted
 * `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table
@@ -2836,10 +2844,15 @@ This is basically a reference to a C++ `ServerActiveObject`
 
 ##### LuaEntitySAO-only (no-op for other objects)
 * `setvelocity({x=num, y=num, z=num})`
+    * The maximum velocity is approximately 210000, however, due to
+      a bug, the core currently limits the velocity to 500 in each direction.
 * `getvelocity()`: returns `{x=num, y=num, z=num}`
 * `setacceleration({x=num, y=num, z=num})`
+    * The maximum acceleration is approximately 210000.
 * `getacceleration()`: returns `{x=num, y=num, z=num}`
 * `setyaw(radians)`
+    * The yaw should be between 0 and 2*pi.
+    * Angles between -4*pi and 4*pi are silently accepted and adjusted
 * `getyaw()`: returns number in radians
 * `settexturemod(mod)`
 * `setsprite(p={x=0,y=0}, num_frames=1, framelength=0.2,
@@ -2860,14 +2873,20 @@ This is basically a reference to a C++ `ServerActiveObject`
      * Angle is counter-clockwise from the +z direction.
 * `set_look_vertical(radians)`: sets look pitch
      * radians - Angle from looking forward, where positive is downwards.
+     * The angle should be between -pi/2 and pi/2
 * `set_look_horizontal(radians)`: sets look yaw
      * radians - Angle from the +z direction, where positive is counter-clockwise.
+     * The angle should be between 0 and 2*pi.
+     * Angles between -4*pi and 4*pi are silently accepted and adjusted
 * `get_look_pitch()`: pitch in radians - Deprecated as broken. Use get_look_vertical.
      * Angle ranges between -pi/2 and pi/2, which are straight down and up respectively.
 * `get_look_yaw()`: yaw in radians - Deprecated as broken. Use get_look_horizontal.
      * Angle is counter-clockwise from the +x direction.
 * `set_look_pitch(radians)`: sets look pitch - Deprecated. Use set_look_vertical.
+     * The angle should be between -pi/2 and pi/2
 * `set_look_yaw(radians)`: sets look yaw - Deprecated. Use set_look_horizontal.
+     * The angle should be between 0 and 2*pi.
+     * Angles between -4*pi and 4*pi are silently accepted and adjusted
 * `get_breath()`: returns players breath
 * `set_breath(value)`: sets players breath
      * values:

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -246,9 +246,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		return result;
 
 	// Limit speed for avoiding hangs
-	speed_f->Y = rangelim(speed_f->Y, -5000, 5000);
-	speed_f->X = rangelim(speed_f->X, -5000, 5000);
-	speed_f->Z = rangelim(speed_f->Z, -5000, 5000);
+	*speed_f = rangelim_v3f(*speed_f, v3f(-1,-1,-1) * OBJECT_MAX_SPEED * BS,
+		v3f(1,1,1) * OBJECT_MAX_SPEED * BS);
 
 	/*
 		Collect node boxes in movement range

--- a/src/constants.h
+++ b/src/constants.h
@@ -104,6 +104,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // the file attempting to ensure a unique filename
 #define SCREENSHOT_MAX_SERIAL_TRIES 1000
 
+// Currently, the max speed is limited. Setting it 'too high' will cause
+// excessive CPU and memory consumption in the collision detection code.
+#define OBJECT_MAX_SPEED 500
+
 /*
     GUI related things
 */

--- a/src/constants.h
+++ b/src/constants.h
@@ -20,6 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef CONSTANTS_HEADER
 #define CONSTANTS_HEADER
 
+#include "util/serialize.h"
+
 /*
 	All kinds of constants.
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1185,8 +1185,15 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			pos_translator.translate(dtime);
 			updateNodePos();
 		} else {
-			m_position += dtime * m_velocity + 0.5 * dtime * dtime * m_acceleration;
-			m_velocity += dtime * m_acceleration;
+			v3f new_velocity = m_velocity + dtime * m_acceleration;
+			// Limit speed. A value higher than F1000_MAX will cause a crash.
+			// (due to serialization error)
+			new_velocity = rangelim_v3f(new_velocity, v3f(-1,-1,-1) * OBJECT_MAX_SPEED * BS,
+				v3f(1,1,1) * OBJECT_MAX_SPEED * BS);
+			v3f real_acceleration = (new_velocity - m_velocity) / dtime;
+
+			m_position += dtime * m_velocity + 0.5 * dtime * dtime * real_acceleration;
+			m_velocity = new_velocity;
 			pos_translator.update(m_position, pos_translator.aim_is_end,
 					pos_translator.anim_time);
 			pos_translator.translate(dtime);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -282,9 +282,16 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			m_velocity = p_velocity;
 			m_acceleration = p_acceleration;
 		} else {
+			v3f new_velocity = m_velocity + dtime * m_acceleration;
+			// Limit speed. A value higher than F1000_MAX will cause a crash.
+			// (due to serialization error)
+			new_velocity = rangelim_v3f(new_velocity, v3f(-1,-1,-1) * OBJECT_MAX_SPEED * BS,
+				v3f(1,1,1) * OBJECT_MAX_SPEED * BS);
+			v3f real_acceleration = (new_velocity - m_velocity) / dtime;
+
 			m_base_position += dtime * m_velocity + 0.5 * dtime
-					* dtime * m_acceleration;
-			m_velocity += dtime * m_acceleration;
+					* dtime * real_acceleration;
+			m_velocity = new_velocity;
 		}
 
 		if((m_prop.automatic_face_movement_dir) &&

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include "lauxlib.h"
 }
 
+#include "log.h"
 #include "util/numeric.h"
 #include "util/serialize.h"
 #include "util/string.h"
@@ -38,16 +39,19 @@ extern "C" {
 		} \
 	} while(0)
 #define CHECK_POS_COORD(name) CHECK_TYPE(-1, "position coordinate '" name "'", LUA_TNUMBER)
-#define CHECK_FLOAT_RANGE(value, name) \
-if (value < F1000_MIN || value > F1000_MAX) { \
-	std::ostringstream error_text; \
-	error_text << "Invalid float vector dimension range '" name "' " << \
-	"(expected " << F1000_MIN << " < " name " < " << F1000_MAX << \
-	" got " << value << ")." << std::endl; \
-	throw LuaError(error_text.str()); \
-}
 #define CHECK_POS_TAB(index) CHECK_TYPE(index, "position", LUA_TTABLE)
 
+void check_range_f(lua_State *L, float f,
+		float min, float max, float rmin, float rmax,
+		const char *what)
+{
+	if (isnan(f))
+		luaL_error(L, "invalid value: %s = %f",
+			(what ? what : "value"), f);
+	if (f < min || f > max)
+		luaL_error(L, "range error: %s = %f; must be between %f and %f",
+			(what ? what : "value"), f, rmin, rmax);
+}
 
 void push_v3f(lua_State *L, v3f p)
 {
@@ -141,7 +145,7 @@ v2f read_v2f(lua_State *L, int index)
 	return p;
 }
 
-v2f check_v2f(lua_State *L, int index)
+v2f check_v2f(lua_State *L, int index, float range_factor)
 {
 	v2f p;
 	CHECK_POS_TAB(index);
@@ -152,6 +156,7 @@ v2f check_v2f(lua_State *L, int index)
 	lua_getfield(L, index, "y");
 	CHECK_POS_COORD("y");
 	p.Y = lua_tonumber(L, -1);
+	check_range_v2f(L, p / range_factor, F1000_MIN / range_factor, F1000_MAX / range_factor);
 	lua_pop(L, 1);
 	return p;
 }
@@ -172,24 +177,22 @@ v3f read_v3f(lua_State *L, int index)
 	return pos;
 }
 
-v3f check_v3f(lua_State *L, int index)
+v3f check_v3f(lua_State *L, int index, float range_factor)
 {
 	v3f pos;
 	CHECK_POS_TAB(index);
 	lua_getfield(L, index, "x");
 	CHECK_POS_COORD("x");
 	pos.X = lua_tonumber(L, -1);
-	CHECK_FLOAT_RANGE(pos.X, "x")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "y");
 	CHECK_POS_COORD("y");
 	pos.Y = lua_tonumber(L, -1);
-	CHECK_FLOAT_RANGE(pos.Y, "y")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "z");
 	CHECK_POS_COORD("z");
 	pos.Z = lua_tonumber(L, -1);
-	CHECK_FLOAT_RANGE(pos.Z, "z")
+	check_range_v3f(L, pos / range_factor, F1000_MIN / range_factor, F1000_MAX / range_factor);
 	lua_pop(L, 1);
 	return pos;
 }
@@ -215,7 +218,7 @@ void pushFloatPos(lua_State *L, v3f p)
 
 v3f checkFloatPos(lua_State *L, int index)
 {
-	return check_v3f(L, index) * BS;
+	return check_v3f(L, index, BS) * BS;
 }
 
 void push_v3s16(lua_State *L, v3s16 p)

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -32,6 +32,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes_bloated.h"
 #include "common/c_types.h"
+#include "util/numeric.h"
+#include "util/serialize.h"
 
 extern "C" {
 #include <lua.h>
@@ -79,10 +81,49 @@ void               setboolfield(lua_State *L, int table,
                              const char *fieldname, bool value);
 
 v3f                 checkFloatPos       (lua_State *L, int index);
-v2f                 check_v2f           (lua_State *L, int index);
+v2f                 check_v2f           (lua_State *L, int index, float range_factor = 1);
 v2s16               check_v2s16         (lua_State *L, int index);
-v3f                 check_v3f           (lua_State *L, int index);
+v3f                 check_v3f           (lua_State *L, int index, float range_factor = 1);
 v3s16               check_v3s16         (lua_State *L, int index);
+
+void                check_range_f (lua_State *L, float f,
+				float min, float max, float rmin, float rmax,
+				const char *what = NULL);
+
+inline void         check_range_f (lua_State *L, float f, float min, float max,
+				const char *what = NULL)
+			{ check_range_f(L, f, min, max, min, max, what); }
+
+inline void         check_range_v2f (lua_State *L, v2f p,
+				float min, float max, float rmin, float rmax)
+			{
+				check_range_f(L, p.X, min, max, rmin, rmax, "x");
+				check_range_f(L, p.Y, min, max, rmin, rmax, "y");
+			}
+
+inline void         check_range_v2f (lua_State *L, v2f p, float min, float max)
+			{ check_range_v2f(L, p, min, max, min, max); }
+
+inline void         check_range_v3f (lua_State *L, v3f p,
+				float min, float max, float rmin, float rmax)
+			{
+				check_range_f(L, p.X, min, max, rmin, rmax, "x");
+				check_range_f(L, p.Y, min, max, rmin, rmax, "y");
+				check_range_f(L, p.Z, min, max, rmin, rmax, "z");
+			}
+
+inline void         check_range_v3f (lua_State *L, v3f p, float min, float max)
+			{ check_range_v3f(L, p, min, max, min, max); }
+
+// Set pitch and yaw to 0 if abs. value larger than 1e5, so that limiting the
+//     range does not suffer from floating point precision issues.
+//     The value shouldn't be (much) larger than 360 anyway...
+inline float        sanitize_yaw (float yaw)
+			{ return (fabs(yaw) > 1e5 || fabs(yaw) < 1e-3) ? 0
+				: (yaw - trunc(yaw / 360) * 360 + (yaw < 0 ? 360 : 0)); }
+inline float        sanitize_pitch (float pitch)
+			{ return (fabs(pitch) > 1e5 || fabs(pitch) < 1e-3) ? 0
+				: pitch - trunc(pitch / 90) * 90; }
 
 v3f                 read_v3f            (lua_State *L, int index);
 v2f                 read_v2f            (lua_State *L, int index);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -608,6 +608,10 @@ int ObjectRef::l_set_bone_position(lua_State *L)
 	v3f position = v3f(0, 0, 0);
 	if (!lua_isnil(L, 3))
 		position = check_v3f(L, 3);
+	// When this method was created, position should have been multiplied
+	// by BS, but it wasn't. Make sure that if BS changes, the factor
+	// 10 remains (for backward compatibility).
+	position = position / 10 * BS;
 	v3f rotation = v3f(0, 0, 0);
 	if (!lua_isnil(L, 4))
 		rotation = check_v3f(L, 4);
@@ -631,6 +635,8 @@ int ObjectRef::l_get_bone_position(lua_State *L)
 	v3f position = v3f(0, 0, 0);
 	v3f rotation = v3f(0, 0, 0);
 	co->getBonePosition(bone, &position, &rotation);
+	// See comment in l_set_bone_position
+	position = position / BS * 10;
 
 	push_v3f(L, position);
 	push_v3f(L, rotation);
@@ -667,6 +673,8 @@ int ObjectRef::l_set_attach(lua_State *L)
 	position = v3f(0, 0, 0);
 	if (!lua_isnil(L, 4))
 		position = read_v3f(L, 4);
+	// See comment in l_set_bone_position
+	position = position / 10 * BS;
 	rotation = v3f(0, 0, 0);
 	if (!lua_isnil(L, 5))
 		rotation = read_v3f(L, 5);
@@ -694,6 +702,8 @@ int ObjectRef::l_get_attach(lua_State *L)
 	if (!parent_id)
 		return 0;
 	ServerActiveObject *parent = env->getActiveObject(parent_id);
+	// See comment in l_set_bone_position
+	position = position / BS * 10;
 
 	getScriptApiBase(L)->objectrefGetOrCreate(L, parent);
 	lua_pushlstring(L, bone.c_str(), bone.size());

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -131,6 +131,13 @@ inline bool isInArea(v3s16 p, v3s16 d)
 }
 
 #define rangelim(d, min, max) ((d) < (min) ? (min) : ((d)>(max)?(max):(d)))
+#define rangelim_v2f(d, min, max)                     \
+	v2f(rangelim((d).X, (min).X, (max).X),        \
+		rangelim((d).Y, (min).Y, (max).Y))
+#define rangelim_v3f(d, min, max)                     \
+	v3f(rangelim((d).X, (min).X, (max).X),        \
+		rangelim((d).Y, (min).Y, (max).Y),    \
+		rangelim((d).Z, (min).Z, (max).Z))
 #define myfloor(x) ((x) > 0.0 ? (int)(x) : (int)(x) - 1)
 
 // The naive swap performs better than the xor version

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -138,6 +138,21 @@ inline bool isInArea(v3s16 p, v3s16 d)
 	v3f(rangelim((d).X, (min).X, (max).X),        \
 		rangelim((d).Y, (min).Y, (max).Y),    \
 		rangelim((d).Z, (min).Z, (max).Z))
+// Set to 0 if abs. value is larger than 1e5, to avoid floating point
+// precision issues:
+//    (float(9876543210) - 360 * trunc(float(9876543210) / 360)
+// is not equal to:
+//    (double(9876543210) - 360 * trunc(double(9876543210) / 360)
+// Result for float(9876543210):	-352
+// Result for double(9876543210):	90
+// Mathematical result:			90
+// (and anybody using an angle much larger than 360 should fix their code anyway...)
+#define anglelim(d, limit)                            \
+	((d) > 1e5 ? 0 : (d) - (limit) * trunc((d) / (limit)))
+#define anglelim_v3f(d, limit)                        \
+	v3f(anglelim((d).X, (limit).X),               \
+		anglelim((d).Y, (limit).Y),           \
+		anglelim((d).Z, (limit).Z))
 #define myfloor(x) ((x) > 0.0 ? (int)(x) : (int)(x) - 1)
 
 // The naive swap performs better than the xor version


### PR DESCRIPTION
I got the following assertion failure:

```
minetest/src/util/serialize.h:278: void writeF1000(irr::u8*, irr::f32): Assertion `i >= ((float)(s32)((-0x7FFFFFFF - 1) / 1000.0f)) && i <= ((float)(s32)((0x7FFFFFFF) / 1000.0f))' failed.
```

Because a mod (older version of mobs) was setting entity yaw and velocity to `-nan`.

This patch fixes this by sanitizing the float values a mod may set for objects.

Alternatively, minetest could opt to return an error to the mod. However, as such mod bugs will be intermittent, possibly rare, and may be hard to reproduce and fix, I thought it would be better just to accept the invalid values, and sanitize them.

Optionally, I could add code to print a warning message to the log ?
