### PR TITLE
Permit usage of std::unordered_map & std::unorderered_set on c++11 compilers

### DIFF
--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -156,7 +156,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 			}
 
 			if (mg->biomemap) {
-				std::set<u8>::iterator iter;
+				UNORDERED_SET<u8>::iterator iter;
 
 				if (!biomes.empty()) {
 					iter = biomes.find(mg->biomemap[mapindex]);

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef MG_DECORATION_HEADER
 #define MG_DECORATION_HEADER
 
-#include <set>
+#include "util/cpp11_container.h"
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
@@ -83,7 +83,7 @@ public:
 	float fill_ratio;
 	NoiseParams np;
 
-	std::set<u8> biomes;
+	UNORDERED_SET<u8> biomes;
 	//std::list<CutoffData> cutoffs;
 	//Mutex cutoff_mutex;
 };

--- a/src/mg_ore.cpp
+++ b/src/mg_ore.cpp
@@ -148,7 +148,7 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 index = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::set<u8>::iterator it = biomes.find(biomemap[index]);
+			UNORDERED_SET<u8>::iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -202,7 +202,7 @@ void OreSheet::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::set<u8>::iterator it = biomes.find(biomemap[index]);
+			UNORDERED_SET<u8>::iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -270,7 +270,7 @@ void OrePuff::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			continue;
 
 		if (biomemap && !biomes.empty()) {
-			std::set<u8>::iterator it = biomes.find(biomemap[index]);
+			UNORDERED_SET<u8>::iterator it = biomes.find(biomemap[index]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -338,7 +338,7 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z0 - nmin.Z) + (x0 - nmin.X);
-			std::set<u8>::iterator it = biomes.find(biomemap[bmapidx]);
+			UNORDERED_SET<u8>::iterator it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}
@@ -422,7 +422,7 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 
 		if (biomemap && !biomes.empty()) {
 			u32 bmapidx = sizex * (z - nmin.Z) + (x - nmin.X);
-			std::set<u8>::iterator it = biomes.find(biomemap[bmapidx]);
+			UNORDERED_SET<u8>::iterator it = biomes.find(biomemap[bmapidx]);
 			if (it == biomes.end())
 				continue;
 		}

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef MG_ORE_HEADER
 #define MG_ORE_HEADER
 
+#include "util/cpp11_container.h"
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
@@ -64,7 +65,7 @@ public:
 	float nthresh;      // threshold for noise at which an ore is placed
 	NoiseParams np;     // noise for distribution of clusters (NULL for uniform scattering)
 	Noise *noise;
-	std::set<u8> biomes;
+	UNORDERED_SET<u8> biomes;
 
 	Ore();
 	virtual ~Ore();

--- a/src/nameidmapping.cpp
+++ b/src/nameidmapping.cpp
@@ -25,7 +25,7 @@ void NameIdMapping::serialize(std::ostream &os) const
 {
 	writeU8(os, 0); // version
 	writeU16(os, m_id_to_name.size());
-	for(std::map<u16, std::string>::const_iterator
+	for(UNORDERED_MAP<u16, std::string>::const_iterator
 			i = m_id_to_name.begin();
 			i != m_id_to_name.end(); ++i){
 		writeU16(os, i->first);

--- a/src/nameidmapping.h
+++ b/src/nameidmapping.h
@@ -23,15 +23,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <iostream>
 #include <set>
-#include <map>
 #include "irrlichttypes_bloated.h"
+#include "util/cpp11_container.h"
 
 class NameIdMapping
 {
 public:
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
-	
+
 	void clear(){
 		m_id_to_name.clear();
 		m_name_to_id.clear();
@@ -55,7 +55,7 @@ public:
 		m_name_to_id.erase(name);
 	}
 	bool getName(u16 id, std::string &result) const{
-		std::map<u16, std::string>::const_iterator i;
+		UNORDERED_MAP<u16, std::string>::const_iterator i;
 		i = m_id_to_name.find(id);
 		if(i == m_id_to_name.end())
 			return false;
@@ -63,7 +63,7 @@ public:
 		return true;
 	}
 	bool getId(const std::string &name, u16 &result) const{
-		std::map<std::string, u16>::const_iterator i;
+		UNORDERED_MAP<std::string, u16>::const_iterator i;
 		i = m_name_to_id.find(name);
 		if(i == m_name_to_id.end())
 			return false;
@@ -74,8 +74,8 @@ public:
 		return m_id_to_name.size();
 	}
 private:
-	std::map<u16, std::string> m_id_to_name;
-	std::map<std::string, u16> m_name_to_id;
+	UNORDERED_MAP<u16, std::string> m_id_to_name;
+	UNORDERED_MAP<std::string, u16> m_name_to_id;
 };
 
 #endif

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -100,7 +100,7 @@ Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
 Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef);
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::set<u8> *biome_id_list);
+	BiomeManager *biomemgr, UNORDERED_SET<u8> *biome_id_list);
 
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names);
@@ -401,7 +401,7 @@ Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef)
 
 
 size_t get_biome_list(lua_State *L, int index,
-	BiomeManager *biomemgr, std::set<u8> *biome_id_list)
+	BiomeManager *biomemgr, UNORDERED_SET<u8> *biome_id_list)
 {
 	if (index < 0)
 		index = lua_gettop(L) + 1 + index;

--- a/src/util/cpp11_container.h
+++ b/src/util/cpp11_container.h
@@ -1,0 +1,35 @@
+/*
+Minetest
+Copyright (C) 2016 nerzhul, Loic Blot <loic.blot@unix-experience.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef MT_CPP11CONTAINER_HEADER
+#define MT_CPP11CONTAINER_HEADER
+
+#if __cplusplus >= 201103L
+	#include <unordered_map>
+	#include <unordered_set>
+	#define UNORDERED_MAP std::unordered_map
+	#define UNORDERED_SET std::unordered_set
+#else
+	#include <map>
+	#include <set>
+	#define UNORDERED_MAP std::map
+	#define UNORDERED_SET std::set
+#endif
+
+#endif


### PR DESCRIPTION
This fallback to std::map & std::set for older compilers
 Use UNORDERED_SET as an example in decoration and ore biome sets
Use UNORDERED_MAP as an example in nameidmapping
