### PR TITLE
Add infotext containing entity type (e.g. mobs:cow) to unknown entities

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -175,6 +175,8 @@ void LuaEntitySAO::addedToEnvironment(u32 dtime_s)
 		// Activate entity, supplying serialized state
 		m_env->getScriptIface()->
 			luaentity_Activate(m_id, m_init_state.c_str(), dtime_s);
+	} else {
+		m_prop.infotext = m_init_name;
 	}
 }
 


### PR DESCRIPTION
If a mod is disabled, or upgraded without sufficient backward compatibility,
then entities it has put into the world become unknown, and continue moving
around, but are completely unrecognisable.

This change allows the player to see their type, and therefore which mod is
or was responsible.
