### PR TITLE
Refined tab autocompletion

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -283,7 +283,7 @@ function core.autocomplete_word(start, t, iter)
 	end
 
 	if l ~= start_len then
-		return first_cmd:sub(1, l), possible_words
+		return first_word:sub(1, l), possible_words
 	end
 
 	return possible_words

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -288,3 +288,41 @@ function core.autocomplete_word(start, t, iter)
 
 	return possible_words
 end
+
+-- Add playernames autocompletion
+minetest.after(0, core.register_chat_autocompletion,
+	function(message, cursorpos, name, first_invocation)
+		local len = #message
+		local last_space = len - (message:reverse():find(" ") or len + 1)
+
+		local start
+		if last_space + 1 == len then
+			start = ""
+		else
+			start = message:sub(last_space - len + 1)
+		end
+
+		local pnames = core.get_connected_players()
+		for i = 1,#pnames do
+			pnames[i] = pnames[i]:get_player_name()
+		end
+		local replacement, possible_players = core.autocomplete_word(start, pnames)
+
+		if not replacement then
+			return
+		end
+
+		if type(replacement) == "string" then
+			message = message:sub(1, last_space - len) .. replacement
+			if not possible_players then
+				message = message .. " "
+			end
+			return message, #message, true
+		end
+
+		if not first_invocation then
+			core.chat_send_player(name, "Players found: " ..
+					table.concat(replacement, ", "))
+		end
+	end
+)

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -56,11 +56,11 @@ function core.check_player_privs(name, ...)
 	elseif arg_type ~= "string" then
 		error("Invalid core.check_player_privs argument type: " .. arg_type, 2)
 	end
-	
+
 	local requested_privs = {...}
 	local player_privs = core.get_player_privs(name)
 	local missing_privileges = {}
-	
+
 	if type(requested_privs[1]) == "table" then
 		-- We were provided with a table like { privA = true, privB = true }.
 		for priv, value in pairs(requested_privs[1]) do
@@ -76,11 +76,11 @@ function core.check_player_privs(name, ...)
 			end
 		end
 	end
-	
+
 	if #missing_privileges > 0 then
 		return false, missing_privileges
 	end
-	
+
 	return true, ""
 end
 
@@ -239,3 +239,52 @@ else
 
 end
 
+
+local function simple_list_iter(t)
+	local n = 0
+	return function()
+		n = n+1
+		return t[n]
+	end
+end
+
+-- useful to short chat autocompletion code
+function core.autocomplete_word(start, t, iter)
+	if not iter then
+		if t[1] then
+			iter = simple_list_iter
+		else
+			iter = pairs
+		end
+	end
+
+	local start_len = #start
+	local possible_words,n = {},1
+	for word in iter(t) do
+		if word:sub(1, start_len) == start then
+			possible_words[n] = word
+			n = n+1
+		end
+	end
+
+	if n < 3 then
+		return possible_words[1]
+	end
+
+	table.sort(possible_words)
+	local first_word = possible_words[1]
+	local last_word = possible_words[#possible_words]
+	local l = start_len
+	for i = l+1, math.min(#first_word, #last_word) do
+		if first_word:sub(i, i) ~= last_word:sub(i, i) then
+			break
+		end
+		l = l+1
+	end
+
+	if l ~= start_len then
+		return first_cmd:sub(1, l), possible_words
+	end
+
+	return possible_words
+end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4041,6 +4041,10 @@ The Biome API is still in an experimental phase and subject to change.
         privs = {privs=true}, -- Require the "privs" privilege to run
         func = function(name, param), -- Called when command is run.
                                       -- Returns boolean success and text output.
+        autocompletion = func(params, cursorpos, name, first_invocation),
+    --  ^ Called after after someone presses tab in the chat terminal.
+    --  ^ For the return values see register_chat_autocompletion.
+    --  ^ Note that params and cursorpos are relative, same for these two return values.
     }
 
 ### Detached inventory callbacks

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2013,6 +2013,12 @@ Call these functions only at load time!
         * `"finished_unknown_dig"`
         * `dug_unbreakable`
         * `dug_too_fast`
+* `minetest.register_chat_autocompletion(func(message, cursorpos, name, first_inquiry))`
+    * Called when a player tips the tab key in chat
+    * message is the current text in the client's chat prompt
+    * cursorpos is a integer between inclusively 0 and #message
+    * first_inquiry is true if the previous message and cursorpos are not the current ones
+    * return [new_message], [new_cursorpos], [abort]
 * `minetest.register_on_chat_message(func(name, message))`
     * Called always when a player says something
     * Return `true` to mark the message as handled, which means that it will not be sent to other players

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1857,6 +1857,17 @@ Helper functions
     * returns time with microsecond precision. May not return wall time.
 * `table.copy(table)`: returns a table
     * returns a deep copy of `table`
+* `core.autocomplete_word(start, t, [iter])`
+    * `start` is the beginning of the word
+    * `t` is a table containing words which are used for autocompletion
+    * `iter` is an iteration function for the for loop
+      if omitted, either pairs or a list iteration is used depending on `t`
+    * It returns one of following:
+      nil: `t` does not contain a string beginning with `start`
+      found_word: a string, one fitting word was found
+      longer_start, possible_words: a string and a table
+        more fitting word were found and their equal beginning is longer than start
+      possible_words: a table, their equal beginning is as long as start
 
 `minetest` namespace reference
 ------------------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2014,9 +2014,9 @@ Call these functions only at load time!
         * `dug_unbreakable`
         * `dug_too_fast`
 * `minetest.register_chat_autocompletion(func(message, cursorpos, name, first_inquiry))`
-    * Called when a player tips the tab key in chat
-    * message is the current text in the client's chat prompt
-    * cursorpos is a integer between inclusively 0 and #message
+    * Called when the admin tips the tab key in the terminal chat
+    * message is the current text in the chat prompt
+    * cursorpos is an integer between inclusively 0 and #message
     * first_inquiry is true if the previous message and cursorpos are not the current ones
     * return [new_message], [new_cursorpos], [abort]
 * `minetest.register_on_chat_message(func(name, message))`

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -475,6 +475,25 @@ void ChatPrompt::historyNext()
 	}
 }
 
+void ChatPrompt::CompletionSend(u16 &cursorpos, std::wstring &line)
+{
+	cursorpos = m_cursor;
+	line = m_line;
+
+	m_completion_sent_cursor = m_cursor;
+	m_completion_sent_line = line;
+}
+
+void ChatPrompt::CompletionReceive(u16 cursorpos, const std::wstring &message)
+{
+	if ((cursorpos & 2) && (m_line == m_completion_sent_line))
+		m_line = message;
+
+	if ((cursorpos & 1) && (m_cursor == m_completion_sent_cursor)) {
+		m_cursor = MYMIN((u16) m_line.size(), cursorpos >> 2);
+	}
+}
+
 void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwards)
 {
 	// Two cases:

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -395,9 +395,7 @@ ChatPrompt::ChatPrompt(std::wstring prompt, u32 history_limit):
 	m_cols(0),
 	m_view(0),
 	m_cursor(0),
-	m_cursor_len(0),
-	m_nick_completion_start(0),
-	m_nick_completion_end(0)
+	m_cursor_len(0)
 {
 }
 
@@ -410,8 +408,6 @@ void ChatPrompt::input(wchar_t ch)
 	m_line.insert(m_cursor, 1, ch);
 	m_cursor++;
 	clampView();
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
 }
 
 void ChatPrompt::input(const std::wstring &str)
@@ -419,8 +415,6 @@ void ChatPrompt::input(const std::wstring &str)
 	m_line.insert(m_cursor, str);
 	m_cursor += str.size();
 	clampView();
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
 }
 
 void ChatPrompt::addToHistory(std::wstring line)
@@ -437,8 +431,6 @@ void ChatPrompt::clear()
 	m_line.clear();
 	m_view = 0;
 	m_cursor = 0;
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
 }
 
 std::wstring ChatPrompt::replace(std::wstring line)
@@ -447,8 +439,6 @@ std::wstring ChatPrompt::replace(std::wstring line)
 	m_line =  line;
 	m_view = m_cursor = line.size();
 	clampView();
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
 	return old_line;
 }
 
@@ -492,86 +482,6 @@ void ChatPrompt::CompletionReceive(u16 cursorpos, const std::wstring &message)
 	if ((cursorpos & 1) && (m_cursor == m_completion_sent_cursor)) {
 		m_cursor = MYMIN((u16) m_line.size(), cursorpos >> 2);
 	}
-}
-
-void ChatPrompt::nickCompletion(const std::list<std::string>& names, bool backwards)
-{
-	// Two cases:
-	// (a) m_nick_completion_start == m_nick_completion_end == 0
-	//     Then no previous nick completion is active.
-	//     Get the word around the cursor and replace with any nick
-	//     that has that word as a prefix.
-	// (b) else, continue a previous nick completion.
-	//     m_nick_completion_start..m_nick_completion_end are the
-	//     interval where the originally used prefix was. Cycle
-	//     through the list of completions of that prefix.
-	u32 prefix_start = m_nick_completion_start;
-	u32 prefix_end = m_nick_completion_end;
-	bool initial = (prefix_end == 0);
-	if (initial)
-	{
-		// no previous nick completion is active
-		prefix_start = prefix_end = m_cursor;
-		while (prefix_start > 0 && !isspace(m_line[prefix_start-1]))
-			--prefix_start;
-		while (prefix_end < m_line.size() && !isspace(m_line[prefix_end]))
-			++prefix_end;
-		if (prefix_start == prefix_end)
-			return;
-	}
-	std::wstring prefix = m_line.substr(prefix_start, prefix_end - prefix_start);
-
-	// find all names that start with the selected prefix
-	std::vector<std::wstring> completions;
-	for (std::list<std::string>::const_iterator
-			i = names.begin();
-			i != names.end(); ++i)
-	{
-		if (str_starts_with(narrow_to_wide(*i), prefix, true))
-		{
-			std::wstring completion = narrow_to_wide(*i);
-			if (prefix_start == 0)
-				completion += L": ";
-			completions.push_back(completion);
-		}
-	}
-	if (completions.empty())
-		return;
-
-	// find a replacement string and the word that will be replaced
-	u32 word_end = prefix_end;
-	u32 replacement_index = 0;
-	if (!initial)
-	{
-		while (word_end < m_line.size() && !isspace(m_line[word_end]))
-			++word_end;
-		std::wstring word = m_line.substr(prefix_start, word_end - prefix_start);
-
-		// cycle through completions
-		for (u32 i = 0; i < completions.size(); ++i)
-		{
-			if (str_equal(word, completions[i], true))
-			{
-				if (backwards)
-					replacement_index = i + completions.size() - 1;
-				else
-					replacement_index = i + 1;
-				replacement_index %= completions.size();
-				break;
-			}
-		}
-	}
-	std::wstring replacement = completions[replacement_index];
-	if (word_end < m_line.size() && isspace(word_end))
-		++word_end;
-
-	// replace existing word with replacement word,
-	// place the cursor at the end and record the completion prefix
-	m_line.replace(prefix_start, word_end - prefix_start, replacement);
-	m_cursor = prefix_start + replacement.size();
-	clampView();
-	m_nick_completion_start = prefix_start;
-	m_nick_completion_end = prefix_end;
 }
 
 void ChatPrompt::reformat(u32 cols)
@@ -667,9 +577,6 @@ void ChatPrompt::cursorOperation(CursorOp op, CursorOpDir dir, CursorOpScope sco
 	}
 
 	clampView();
-
-	m_nick_completion_start = 0;
-	m_nick_completion_end = 0;
 }
 
 void ChatPrompt::clampView()

--- a/src/chat.h
+++ b/src/chat.h
@@ -180,9 +180,6 @@ public:
 	void CompletionSend(u16 &cursorpos, std::wstring &line);
 	void CompletionReceive(u16 cursorpos, const std::wstring &message);
 
-	// Nick completion
-	void nickCompletion(const std::list<std::string>& names, bool backwards);
-
 	// Update console size and reformat the visible portion of the prompt
 	void reformat(u32 cols);
 	// Get visible portion of the prompt.
@@ -254,11 +251,6 @@ private:
 	// Line and cursor sent by autocomplete
 	std::wstring m_completion_sent_line;
 	s32 m_completion_sent_cursor;
-
-	// Last nick completion start (index into m_line)
-	s32 m_nick_completion_start;
-	// Last nick completion start (index into m_line)
-	s32 m_nick_completion_end;
 };
 
 class ChatBackend

--- a/src/chat.h
+++ b/src/chat.h
@@ -180,6 +180,8 @@ public:
 	void CompletionSend(u16 &cursorpos, std::wstring &line);
 	void CompletionReceive(u16 cursorpos, const std::wstring &message);
 
+	void lnickCompletion(const std::list<std::string> &names);
+
 	// Update console size and reformat the visible portion of the prompt
 	void reformat(u32 cols);
 	// Get visible portion of the prompt.

--- a/src/chat.h
+++ b/src/chat.h
@@ -176,6 +176,10 @@ public:
 	// Select next command from history
 	void historyNext();
 
+	// Tab autocompletion
+	void CompletionSend(u16 &cursorpos, std::wstring &line);
+	void CompletionReceive(u16 cursorpos, const std::wstring &message);
+
 	// Nick completion
 	void nickCompletion(const std::list<std::string>& names, bool backwards);
 
@@ -246,6 +250,10 @@ private:
 	s32 m_cursor;
 	// Cursor length (length of selected portion of line)
 	s32 m_cursor_len;
+
+	// Line and cursor sent by autocomplete
+	std::wstring m_completion_sent_line;
+	s32 m_completion_sent_cursor;
 
 	// Last nick completion start (index into m_line)
 	s32 m_nick_completion_start;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1188,6 +1188,15 @@ void Client::sendChatMessage(const std::wstring &message)
 	Send(&pkt);
 }
 
+void Client::sendChatAutocomplete(u16 cursorpos, const std::wstring &message)
+{
+	NetworkPacket pkt(TOSERVER_CHAT_AUTOCOMPLETE, 2 + sizeof(u16) + message.size() * sizeof(u16));
+
+	pkt << cursorpos << message;
+
+	Send(&pkt);
+}
+
 void Client::sendChangePassword(const std::string &oldpassword,
         const std::string &newpassword)
 {

--- a/src/client.h
+++ b/src/client.h
@@ -34,6 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "localplayer.h"
 #include "hud.h"
 #include "particles.h"
+#include "chat.h"
 #include "network/networkpacket.h"
 
 struct MeshMakeData;
@@ -365,6 +366,7 @@ public:
 	void handleCommand_Inventory(NetworkPacket* pkt);
 	void handleCommand_TimeOfDay(NetworkPacket* pkt);
 	void handleCommand_ChatMessage(NetworkPacket* pkt);
+	void handleCommand_ChatAutocomplete(NetworkPacket* pkt);
 	void handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt);
 	void handleCommand_ActiveObjectMessages(NetworkPacket* pkt);
 	void handleCommand_Movement(NetworkPacket* pkt);
@@ -414,6 +416,7 @@ public:
 		const StringMap &fields);
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
+	void sendChatAutocomplete(u16 cursorpos, const std::wstring &message);
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
 	void sendDamage(u8 damage);
@@ -547,6 +550,8 @@ public:
 	LocalClientState getState() { return m_state; }
 
 	void makeScreenshot(IrrlichtDevice *device);
+
+	ChatPrompt *autocompletion_chatprompt;
 
 private:
 

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -621,11 +621,14 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Key == KEY_TAB)
 		{
-			// Tab or Shift-Tab pressed
-			// Nick completion
-			std::list<std::string> names = m_client->getConnectedPlayerNames();
-			bool backwards = event.KeyInput.Shift;
-			prompt.nickCompletion(names, backwards);
+			// Chat Autocompletion
+			std::wstring line;
+			u16 cursorpos;
+
+			prompt.CompletionSend(cursorpos, line);
+			m_client->autocompletion_chatprompt = &prompt;
+			m_client->sendChatAutocomplete(cursorpos, line);
+
 			return true;
 		}
 		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -621,13 +621,9 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 		else if(event.KeyInput.Key == KEY_TAB)
 		{
-			// Chat Autocompletion
-			std::wstring line;
-			u16 cursorpos;
-
-			prompt.CompletionSend(cursorpos, line);
-			m_client->autocompletion_chatprompt = &prompt;
-			m_client->sendChatAutocomplete(cursorpos, line);
+			// Client side chat autocompletion
+			std::list<std::string> names = m_client->getConnectedPlayerNames();
+			prompt.lnickCompletion(names);
 
 			return true;
 		}

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -71,7 +71,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,
-	null_command_handler,
+	{ "TOCLIENT_CHAT_AUTOCOMPLETE",        TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatAutocomplete }, // 0x2f
 	{ "TOCLIENT_CHAT_MESSAGE",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatMessage }, // 0x30
 	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectRemoveAdd }, // 0x31
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectMessages }, // 0x32
@@ -174,7 +174,7 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_factory, // 0x2c
 	null_command_factory, // 0x2d
 	null_command_factory, // 0x2e
-	null_command_factory, // 0x2f
+	{ "TOSERVER_CHAT_AUTOCOMPLETE",  0, true },// 0x2f
 	{ "TOSERVER_SIGNTEXT",           0, false }, // 0x30
 	{ "TOSERVER_INVENTORY_ACTION",   0, true }, // 0x31
 	{ "TOSERVER_CHAT_MESSAGE",       0, true }, // 0x32

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -413,6 +413,28 @@ void Client::handleCommand_ChatMessage(NetworkPacket* pkt)
 	m_chat_queue.push(message);
 }
 
+void Client::handleCommand_ChatAutocomplete(NetworkPacket* pkt)
+{
+	std::wstring wmessage;
+	u16 cursorpos;
+
+	*pkt >> cursorpos;
+
+	// message is only sent if it is changed
+	if (cursorpos & 2) {
+		u16 len, read_wchar;
+
+		*pkt >> len;
+
+		for (u32 i = 0; i < len; i++) {
+			*pkt >> read_wchar;
+			wmessage += (wchar_t)read_wchar;
+		}
+	}
+
+	(*autocompletion_chatprompt).CompletionReceive(cursorpos, wmessage);
+}
+
 void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 {
 	/*

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -285,6 +285,13 @@ enum ToClientCommand
 
 	// (oops, there is some gap here)
 
+	TOCLIENT_CHAT_AUTOCOMPLETE = 0x2f,
+	/*
+		u16 cursorpos
+		[u16 length
+		wstring message]
+	*/
+
 	TOCLIENT_CHAT_MESSAGE = 0x30,
 	/*
 		u16 length
@@ -713,6 +720,13 @@ enum ToServerCommand
 		s16 id
 		u16 textlen
 		textdata
+	*/
+
+	TOSERVER_CHAT_AUTOCOMPLETE = 0x2f,
+	/*
+		u16 cursorpos
+		u16 length
+		wstring message
 	*/
 
 	TOSERVER_INVENTORY_ACTION = 0x31,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -71,7 +71,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x2c
 	null_command_handler, // 0x2d
 	null_command_handler, // 0x2e
-	null_command_handler, // 0x2f
+	{ "TOSERVER_CHAT_AUTOCOMPLETE",        TOSERVER_STATE_INGAME, &Server::handleCommand_ChatAutocomplete }, // 0x2f
 	{ "TOSERVER_SIGNTEXT",                 TOSERVER_STATE_INGAME, &Server::handleCommand_Deprecated }, // 0x30
 	{ "TOSERVER_INVENTORY_ACTION",         TOSERVER_STATE_INGAME, &Server::handleCommand_InventoryAction }, // 0x31
 	{ "TOSERVER_CHAT_MESSAGE",             TOSERVER_STATE_INGAME, &Server::handleCommand_ChatMessage }, // 0x32
@@ -160,7 +160,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,
-	null_command_factory,
+	{ "TOCLIENT_CHAT_AUTOCOMPLETE",        0, true }, // 0x2f
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x30
 	{ "TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD", 0, true }, // 0x31
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   0, true }, // 0x32 Special packet, sent by 0 (rel) and 1 (unrel) channel

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1073,6 +1073,40 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 	}
 }
 
+void Server::handleCommand_ChatAutocomplete(NetworkPacket* pkt)
+{
+	/*
+		u16 command
+		u16 cursorpos
+		u16 length
+		wstring message
+	*/
+	u16 cursorpos, len;
+	*pkt >> cursorpos >> len;
+
+	std::wstring wmessage;
+	for (u16 i = 0; i < len; i++) {
+		u16 tmp_wchar;
+		*pkt >> tmp_wchar;
+
+		wmessage += (wchar_t)tmp_wchar;
+	}
+
+	std::string message = wide_to_narrow(wmessage);
+
+	// Get id and name of this client
+	u16 peer_id = pkt->getPeerId();
+	std::string name = m_env->getPlayer(peer_id)->getName();
+
+	// If something goes wrong, this player is to blame
+	RollbackScopeActor rollback_scope(m_rollback,
+		std::string("player:") + name);
+
+	// Run script hook and send back if necessary
+	if (m_script->on_chat_autocomplete(name, cursorpos, message))
+		SendChatAutocompletion(peer_id, cursorpos, message);
+}
+
 void Server::handleCommand_Damage(NetworkPacket* pkt)
 {
 	u8 damage;

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -31,6 +31,9 @@ public:
 	// Returns true if script handled message
 	bool on_chat_message(const std::string &name, const std::string &message);
 
+	// Returns true if something needs to be sent back to client
+	bool on_chat_autocomplete(const std::string &name, u16 &cursorpos, std::string &message);
+
 	// Calls on_shutdown handlers
 	void on_shutdown();
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1637,6 +1637,21 @@ void Server::SendChatMessage(u16 peer_id, const std::wstring &message)
 	}
 }
 
+void Server::SendChatAutocompletion(u16 peer_id, u16 cursorpos, const std::string &message)
+{
+	DSTACK(FUNCTION_NAME);
+
+	NetworkPacket pkt(TOCLIENT_CHAT_AUTOCOMPLETE, 0, peer_id);
+
+	pkt << cursorpos;
+
+	// send message only if it is changed
+	if (cursorpos & 2)
+		pkt << narrow_to_wide(message);
+
+	Send(&pkt);
+}
+
 void Server::SendShowFormspecMessage(u16 peer_id, const std::string &formspec,
                                      const std::string &formname)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -180,6 +180,7 @@ public:
 	void handleCommand_DeletedBlocks(NetworkPacket* pkt);
 	void handleCommand_InventoryAction(NetworkPacket* pkt);
 	void handleCommand_ChatMessage(NetworkPacket* pkt);
+	void handleCommand_ChatAutocomplete(NetworkPacket* pkt);
 	void handleCommand_Damage(NetworkPacket* pkt);
 	void handleCommand_Breath(NetworkPacket* pkt);
 	void handleCommand_Password(NetworkPacket* pkt);
@@ -382,6 +383,7 @@ private:
 
 
 	void SendChatMessage(u16 peer_id, const std::wstring &message);
+	void SendChatAutocompletion(u16 peer_id, u16 cursorpos, const std::string &message);
 	void SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed);
 	void SendPlayerHP(u16 peer_id);
 

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -280,8 +280,7 @@ void TerminalChatConsole::handleInput(int ch, bool &complete_redraw_needed)
 			break;
 		case KEY_TAB:
 			// Tab pressed
-			// Nick completion
-			prompt.nickCompletion(m_nicks, false);
+			// How to get here ingame? ~HybridDog
 			break;
 		default:
 			// Add character to the prompt,

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -279,8 +279,16 @@ void TerminalChatConsole::handleInput(int ch, bool &complete_redraw_needed)
 				ChatPrompt::CURSOROP_SCOPE_LINE);
 			break;
 		case KEY_TAB:
-			// Tab pressed
-			// How to get here ingame? ~HybridDog
+			// Chat autocompletion
+			{
+				std::wstring line;
+				u16 cursorpos;
+
+				prompt.CompletionSend(cursorpos, line);
+				//m_client->autocompletion_chatprompt = &prompt;
+				//m_client->sendChatAutocomplete(cursorpos, line);
+			}
+
 			break;
 		default:
 			// Add character to the prompt,

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -287,6 +287,9 @@ void TerminalChatConsole::handleInput(int ch, bool &complete_redraw_needed)
 				prompt.CompletionSend(cursorpos, line);
 				//m_client->autocompletion_chatprompt = &prompt;
 				//m_client->sendChatAutocomplete(cursorpos, line);
+
+				if (m_script->on_chat_autocomplete(m_nick, cursorpos, line))
+					prompt.CompletionReceive(cursorpos, line);
 			}
 
 			break;


### PR DESCRIPTION
- Change client side autocompletion
- Add server side completion
- Add core.autocomplete_word helper function
- Use autocompletion for chatcommands
- Add player name autocompletion, minetest.after is used due to its low autocompleting priority

> It would make more sense to do the autocompletion fully client-side.

l don't think so because
autocompletion happens seldom,
no words list or other complex stuff needs to be sent,
stuff is only sent back to the client if necessary,
mods have a lot more possibilities, see https://github.com/minetest/minetest/issues/2788#issuecomment-229966508,
less, or even no, compatibility problems for autocompletion updates are added and
lag doesn't matter because you usually hardly use chat autocompletion when the server lags a lot.
