### PR TITLE
gettext.h: include <locale> before defining the gettext macro

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -25,6 +25,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if USE_GETTEXT
 	#include <libintl.h>
 #else
+	// In certain environments, some standard headers like <iomanip>
+	// and <locale> include libintl.h. If libintl.h is included after
+	// we define our gettext macro below, this causes a syntax error
+	// at the declaration of the gettext function in libintl.h.
+	// Fix this by including such a header before defining the macro.
+	// See issue #4446.
+	// Note that we can't include libintl.h directly since we're in
+	// the USE_GETTEXT=0 case and can't assume that gettext is installed.
+	#include <locale>
+
 	#define gettext(String) String
 #endif
 


### PR DESCRIPTION
Fixes #4446: a syntax error that happens if something else (such as &lt;iomanip&gt; or &lt;locale&gt; in certain libstdc++ versions) includes <libintl.h> later, which contains a function declaration for gettext that gets mangled by the macro.

See the added comment in gettext.h and the discussion in #4446 for details.