### PR TITLE
Camera: Higher frequency limit for view/hand bobbing and footsteps 

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -472,7 +472,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	{
 		// Start animation
 		m_view_bobbing_state = 1;
-		m_view_bobbing_speed = MYMIN(speed.getLength(), 40);
+		m_view_bobbing_speed = MYMIN(speed.getLength(), 70);
 	}
 	else if (m_view_bobbing_state == 1)
 	{


### PR DESCRIPTION
'm_view_bobbing_speed' controls the frequency of view bobbing,
hand bobbing and footsteps, it was limited to 40 (walking frequency)
so did not increase if player speed was modified by a 'speed buff' or
sprinting mod.
This commit raises the limit to 70 which is suitable for sprinting,
while still being limited prevents excessive frequency when 'fast move'
is used.
//////////////////////////////////////////////////////

Rebased version of #1908 
It seems there is some confusion over this PR, i hope my explanation is clear.
A good way to test this for yourself is to enable 'autorun' then use 'W' to switch between normal walking and 'fast move', because 'fast move' is so fast this will make the bob / footstep frequency hit its limit.

'm_view_bobbing_speed' gets its value from the length of the player speed vector, so is proportional to player speed (of course) but has a limit in place to avoid excessively fast sound events and bobbing when using 'fast move' (20 nodes per second == 45mph). Currently the limit is set (wrongly) at walking speed / frequency (40). 

We have a 'set physics override' API so modifying player speed is common in mods. It is also easily done by modifying player speed in .conf or advanced settings.

'fast move' is not 'Minetest run', it's an unrealstic admin/cheat/superpower, however it does look better when a higher maximum frequency is allowed.