### PR TITLE
Move join and left mesages to lua

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -87,11 +87,19 @@ end
 local player_list = {}
 
 core.register_on_joinplayer(function(player)
-	player_list[player:get_player_name()] = player
+	local player_name = player:get_player_name()
+	player_list[player_name] = player
+	core.chat_send_all("*** " .. player_name .. " joined the game.")
 end)
 
-core.register_on_leaveplayer(function(player)
-	player_list[player:get_player_name()] = nil
+core.register_on_leaveplayer(function(player, timed_out)
+	local player_name = player:get_player_name()
+	player_list[player_name] = nil
+	local announcement = "*** " ..  player_name .. " left the game."
+	if timed_out then
+		announcement = announcement .. " (timed out)"
+	end
+	core.chat_send_all(announcement)
 end)
 
 function core.get_connected_players()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1118,23 +1118,6 @@ PlayerSAO* Server::StageTwoClientInit(u16 peer_id)
 	if(!m_simple_singleplayer_mode) {
 		// Send information about server to player in chat
 		SendChatMessage(peer_id, getStatusString());
-
-		// Send information about joining in chat
-		{
-			std::string name = "unknown";
-			Player *player = m_env->getPlayer(peer_id);
-			if(player != NULL)
-				name = player->getName();
-
-			std::wstring message;
-			message += L"*** ";
-			message += narrow_to_wide(name);
-			message += L" joined the game.";
-			SendChatMessage(PEER_ID_INEXISTENT,message);
-			if (m_admin_chat)
-				m_admin_chat->outgoing_queue.push_back(
-					new ChatEventNick(CET_NICK_ADD, name));
-		}
 	}
 	Address addr = getPeerAddress(player->peer_id);
 	std::string ip_str = addr.serializeString();
@@ -2659,19 +2642,6 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 		}
 
 		Player *player = m_env->getPlayer(peer_id);
-
-		// Collect information about leaving in chat
-		{
-			if(player != NULL && reason != CDR_DENY)
-			{
-				std::wstring name = narrow_to_wide(player->getName());
-				message += L"*** ";
-				message += name;
-				message += L" left the game.";
-				if(reason == CDR_TIMEOUT)
-					message += L" (timed out)";
-			}
-		}
 
 		/* Run scripts and remove from environment */
 		{


### PR DESCRIPTION
When I was reading #4454, I found out that messages that is written when player join and leave the game is defined in cpp. I don't see any reason for that, so I moved it to builtin. Now you can modify it by editing builtin lua.

I'm waiting for suggestion about how to make it customizable by mods(there are several ways). My opinion is that we shouldn't define any default, so if somebody would want those messages, they should be defined in mod.