### PR TITLE
Client: disable pre v25 init sending by default

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -248,14 +248,18 @@ end
 
 --------------------------------------------------------------------------------
 function is_server_protocol_compat(server_proto_min, server_proto_max)
-	return min_supp_proto <= (server_proto_max or 24) and max_supp_proto >= (server_proto_min or 13)
+	if (not server_proto_min) or (not server_proto_max) then
+		-- There is no info. Assume the best and act as if we would be compatible.
+		return true
+	end
+	return min_supp_proto <= server_proto_max and max_supp_proto >= server_proto_min
 end
 --------------------------------------------------------------------------------
 function is_server_protocol_compat_or_error(server_proto_min, server_proto_max)
 	if not is_server_protocol_compat(server_proto_min, server_proto_max) then
 		local server_prot_ver_info, client_prot_ver_info
-		local s_p_min = server_proto_min or 13
-		local s_p_max = server_proto_max or 24
+		local s_p_min = server_proto_min
+		local s_p_max = server_proto_max
 
 		if s_p_min ~= s_p_max then
 			server_prot_ver_info = fgettext_ne("Server supports protocol versions between $1 and $2. ",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -247,7 +247,7 @@ remote_port (Remote port) int 30000 1 65535
 #    Enable if you want to connect to 0.4.12 servers and before.
 #    Servers starting with 0.4.13 will work, 0.4.12-dev servers may work.
 #    Disabling this option will protect your password better.
-send_pre_v25_init (Support older servers) bool true
+send_pre_v25_init (Support older servers) bool false
 
 #    Save the map received by the client on disk.
 enable_local_map_saving (Saving map received from server) bool false

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -261,7 +261,7 @@
 #    Servers starting with 0.4.13 will work, 0.4.12-dev servers may work.
 #    Disabling this option will protect your password better.
 #    type: bool
-# send_pre_v25_init = true
+# send_pre_v25_init = false
 
 #    Save the map received by the client on disk.
 #    type: bool
@@ -1485,7 +1485,7 @@
 # profiler.default_report_format = txt
 
 #    The file path relative to your worldpath in which profiles will be saved to.
-#    
+#
 #    type: string
 # profiler.report_path = ""
 

--- a/src/client.h
+++ b/src/client.h
@@ -499,6 +499,9 @@ public:
 	u8 getProtoVersion()
 	{ return m_proto_ver; }
 
+	bool connectedToServer()
+	{ return m_con.Connected(); }
+
 	float mediaReceiveProgress();
 
 	void afterContentReceived(IrrlichtDevice *device);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -190,7 +190,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("minimap_shape_round", "true");
 	settings->setDefault("minimap_double_scan_height", "true");
 
-	settings->setDefault("send_pre_v25_init", "true");
+	settings->setDefault("send_pre_v25_init", "false");
 
 	settings->setDefault("curl_timeout", "5000");
 	settings->setDefault("curl_parallel_limit", "8");


### PR DESCRIPTION
Disable the ability to connect to old servers by default to
improve password security.

If people still want to connect to old (0.4.12 and earlier)
servers, they can flip the send_pre_v25_init setting.

Add the ability to detect if we've tried to connect
to a server which only supports the pre v25 init protocol,
and show an apropriate error message. Most times the error
will already be catched at the serverlist level, the
detection mechanism only acts as last resort, because the
"Connection timed out" error message that would be shown
otherwise would be very confusing.

Automatic "fixing" of this condition is not desired,
as it would allow for downgrade attacks.

As already 161 of the 167 servers on the serverlist
support the new srp based auth protocol (> 96%),
the breakage should be minimal.