### PR TITLE
Selection box with alpha

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -536,7 +536,7 @@ void Hud::drawSelectionMesh()
 					m_selection_mesh_color.getGreen() / 255);
 			u32 b = (selectionbox_argb.getBlue() *
 					m_selection_mesh_color.getBlue() / 255);
-			driver->draw3DBox(box, video::SColor(255, r, g, b));
+			driver->draw3DBox(box, video::SColor(100, r, g, b));
 		}
 		driver->setMaterial(oldmaterial);
 	} else if (m_selection_mesh) {


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/15183857/18051984/81c0cb50-6e00-11e6-89ef-c116240c70e3.png)

After:
![after](https://cloud.githubusercontent.com/assets/15183857/18051990/860d7e24-6e00-11e6-8065-4d49a86175eb.png)

I think selection box with alpha looks better than the solid color