### PR TITLE
Make only sources pointable

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -273,7 +273,7 @@ inline bool isPointableNode(const MapNode &n,
 {
 	const ContentFeatures &features = client->getNodeDefManager()->get(n);
 	return features.pointable ||
-	       (liquids_pointable && features.isLiquid());
+	       (liquids_pointable && features.liquid_type == LIQUID_SOURCE);
 }
 
 static inline void getNeighborConnectingFace(v3s16 p, INodeDefManager *nodedef,


### PR DESCRIPTION
This makes it so that liquid_pointable items will only point at sources. For boats and things like waterlilies, this change is only annoying in a few questionable corner cases. For buckets, this has the effect of letting you manipulate the liquid from below as well as above.