### PR TITLE
Fix "unknown CMake command "check_library_exists"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.6)
 project(minetest)
 
 INCLUDE(CheckIncludeFiles)
+INCLUDE(CheckLibraryExists)
 
 # Add custom SemiDebug build mode
 set(CMAKE_CXX_FLAGS_SEMIDEBUG "-O1 -g -Wall -Wabi" CACHE STRING


### PR DESCRIPTION
Adds CMakeLists.txt include to fix this issue:

```
$ cmake . -DBUILD_SERVER=TRUE -DBUILD_CLIENT=FALSE \
   -DCMAKE_BUILD_TYPE=Release -DENABLE_CURL=TRUE -DENABLE_CURSES=FALSE \
   -DENABLE_FREETYPE=TRUE -DENABLE_GETTEXT=FALSE \
   -DENABLE_POSTGRESQL=FALSE -DENABLE_SOUND=FALSE -DENABLE_LUAJIT=TRUE \
   -DIRRLICHT_SOURCE_DIR=$HOME/irrlicht-1.8.4 -LH
...
CMake Error at src/CMakeLists.txt:339 (check_library_exists):
  Unknown CMake command "check_library_exists".
...
```