### PR TITLE
Decorations: Generalise 'spawn by' to be used by all decoration types 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3897,7 +3897,7 @@ The Biome API is still in an experimental phase and subject to change.
     {
         deco_type = "simple", -- See "Decoration types"
         place_on = "default:dirt_with_grass",
-    --  ^ Node that decoration can be placed on
+    --  ^ Node (or list of nodes) that the decoration can be placed on
         sidelen = 8,
     --  ^ Size of divisions made in the chunk being generated.
     --  ^ If the chunk size is not evenly divisible by sidelen, sidelen is made equal to the chunk size.
@@ -3916,6 +3916,13 @@ The Biome API is still in an experimental phase and subject to change.
     -- ^ Minimum and maximum `y` positions these decorations can be generated at.
     -- ^ This parameter refers to the `y` position of the decoration base, so
     --   the actual maximum height would be `height_max + size.Y`.
+        spawn_by = "default:water",
+    --  ^ Node (or list of nodes) that the decoration only spawns next to.
+    --  ^ Checks two horizontal planes of neighbouring nodes (including diagonal neighbours),
+    --  ^ one plane at Y = surface and one plane at Y = surface = + 1.
+        num_spawn_by = 1,
+    --  ^ Number of spawn_by nodes that must be surrounding the decoration position to occur.
+    --  ^ If absent or -1, decorations occur next to any nodes.
         flags = "liquid_surface, force_placement",
     --  ^ Flags for all decoration types.
     --  ^ "liquid_surface": Instead of placement on the highest solid surface
@@ -3933,13 +3940,6 @@ The Biome API is still in an experimental phase and subject to change.
         height_max = 0,
     --      ^ Number of nodes the decoration can be at maximum.
     --  ^ If absent, the parameter 'height' is used as a constant.
-        spawn_by = "default:water",
-    --  ^ Node that the decoration only spawns next to.
-    --  ^ The neighbours checked are the 8 nodes horizontally surrounding the lowest node of the
-    --  ^ decoration, and the 8 nodes horizontally surrounding the ground node below the decoration.
-        num_spawn_by = 1,
-    --  ^ Number of spawn_by nodes that must be surrounding the decoration position to occur.
-    --  ^ If absent or -1, decorations occur next to any nodes.
 
         ----- Schematic-type parameters
         schematic = "foobar.mts",

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -68,6 +68,7 @@ public:
 
 	virtual void resolveNodeNames();
 
+	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
 	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	//size_t placeCutoffs(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
@@ -82,6 +83,8 @@ public:
 	s16 y_max;
 	float fill_ratio;
 	NoiseParams np;
+	std::vector<content_t> c_spawnby;
+	s16 nspawnby;
 
 	UNORDERED_SET<u8> biomes;
 	//std::list<CutoffData> cutoffs;
@@ -90,17 +93,13 @@ public:
 
 class DecoSimple : public Decoration {
 public:
+	virtual void resolveNodeNames();
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p);
-	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
 	virtual int getHeight();
 
-	virtual void resolveNodeNames();
-
 	std::vector<content_t> c_decos;
-	std::vector<content_t> c_spawnby;
 	s16 deco_height;
 	s16 deco_height_max;
-	s16 nspawnby;
 };
 
 class DecoSchematic : public Decoration {


### PR DESCRIPTION
In lua_api.txt, make clear that 'place on' and 'spawn by' can be lists.
/////////////////////////////////////////////////

Requested in #4463 
Tested.

To keep this simple just the placement point of the schematic is considered for 'spawn by', as this is for use with the flags 'place centre x' 'place centre z' and will usually be used for schematic trees which have a central trunk.