### PR TITLE
Register.lua: Throw error if node 'light_source' > core.LIGHT_MAX 

### DIFF
--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -19,4 +19,9 @@ core.EMERGE_FROM_DISK   = 3
 core.EMERGE_GENERATED   = 4
 
 -- constants.h
+-- Size of mapblocks in nodes
 core.MAP_BLOCKSIZE = 16
+
+-- light.h
+-- Maximum value for node 'light_source' parameter
+core.LIGHT_MAX = 14

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -127,6 +127,9 @@ function core.register_item(name, itemdef)
 				fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
 			}
 		end
+		if itemdef.light_source and itemdef.light_source > core.LIGHT_MAX then
+			error("Unable to register node: 'light_source' exceeds maximum: " .. name)
+		end
 		setmetatable(itemdef, {__index = core.nodedef_default})
 		core.registered_nodes[itemdef.name] = itemdef
 	elseif itemdef.type == "craft" then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3664,7 +3664,10 @@ Definition tables
         ^ Don't forget to use "leveled" type nodebox. ]]
         liquid_range = 8, -- number of flowing nodes around source (max. 8)
         drowning = 0, -- Player will take this amount of damage if no bubbles are left
-        light_source = 0, -- Amount of light emitted by node (max. 14)
+        light_source = 0, --[[
+        ^ Amount of light emitted by node.
+        ^ To set the maximum (currently 14), use the value 'minetest.LIGHT_MAX'.
+        ^ A value outside the range 0 to minetest.LIGHT_MAX causes undefined behavior.]]
         damage_per_second = 0, -- If player is inside node, this damage is caused
         node_box = {type="regular"}, -- See "Node boxes"
         connects_to = nodenames, --[[

--- a/src/light.h
+++ b/src/light.h
@@ -27,8 +27,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 // This directly sets the range of light.
-// Actually this is not the real maximum, and this is not the
-// brightest. The brightest is LIGHT_SUN.
+// Actually this is not the real maximum, and this is not the brightest, the
+// brightest is LIGHT_SUN.
+// If changed, this constant as defined in builtin/game/constants.lua must
+// also be changed.
 #define LIGHT_MAX 14
 // Light is stored as 4 bits, thus 15 is the maximum.
 // This brightness is reserved for sunlight


### PR DESCRIPTION
Add 'core.LIGHT_MAX = 14' to builtin/game/constants.lua with the intention
to replace misplaced 'default.LIGHT_MAX = 14' in Minetest Game.
Add comment in light.h requiring the constant be changed in both places.
Add lighting bug warning to note in lua_api.txt.
There are hundreds of mod uses of 15 which causes a lighting bug.
///////////////////////////////////////////////////

More thorough fix for #3964 than #4519 
See https://github.com/minetest/minetest/issues/3964#issuecomment-246115736
An error halts the game and notifies which node caused the error.