### PR TITLE
Clouds api

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3080,8 +3080,8 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_clouds(settings)`: set cloud parameters
 	* `settings` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
-		* `color`: cloud color component affected by daylight (default `#fff0f0`)
-		* `ambient`: daylight-independent cloud color component, "glow at night" effect (default `#000000`)
+		* `color`: basic cloud color (default `#fff0f0`)
+		* `ambient`: cloud color lower bound, use for a "glow at night" effect (default `#000000`)
 		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
 		* `thickness`: cloud thickness in nodes (default `16`)
 		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, y=-2}`)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3080,7 +3080,7 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_clouds(parameters)`: set cloud parameters
 	* `parameters` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
-		* `color`: basic cloud color (default `#fff0f0`)
+		* `color`: basic cloud color, with alpha channel (default `#fff0f0e5`)
 		* `ambient`: cloud color lower bound, use for a "glow at night" effect (default `#000000`)
 		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
 		* `thickness`: cloud thickness in nodes (default `16`)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3077,6 +3077,11 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
 * `get_sky()`: returns bgcolor, type and a table with the textures
+* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec})`: set cloud parameters
+	* `density`: from `0` (no clouds) to `1` (full clouds)
+	* `color`: cloud color during daylight
+	* `ambient`: this will be added to cloud color regardless of light, "glow at night" effect
+* `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount
     * `nil`: Disables override, defaulting to sunlight based on day-night cycle

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3077,15 +3077,15 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
 * `get_sky()`: returns bgcolor, type and a table with the textures
-* `set_clouds(settings)`: set cloud parameters
-	* `settings` is a table with the following optional fields:
+* `set_clouds(parameters)`: set cloud parameters
+	* `parameters` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
 		* `color`: basic cloud color (default `#fff0f0`)
 		* `ambient`: cloud color lower bound, use for a "glow at night" effect (default `#000000`)
 		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
 		* `thickness`: cloud thickness in nodes (default `16`)
 		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, y=-2}`)
-* `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
+* `get_clouds()`: returns a table with the current cloud parameters as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount
     * `nil`: Disables override, defaulting to sunlight based on day-night cycle

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3077,11 +3077,12 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
 * `get_sky()`: returns bgcolor, type and a table with the textures
-* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec, height=number})`: set cloud parameters
+* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec, height=number, speed={x=0,y=-2}})`: set cloud parameters
 	* `density`: from `0` (no clouds) to `1` (full clouds)
 	* `color`: cloud color during daylight
 	* `ambient`: this will be added to cloud color regardless of light, "glow at night" effect
 	* `height`: cloud height
+	* `speed`: 2D cloud speed + direction in blocks per second
 * `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3080,11 +3080,11 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_clouds(settings)`: set cloud parameters
 	* `settings` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
-		* `color`: cloud color during daylight (default `#fff0f0`)
-		* `ambient`: light-independent cloud color component, "glow at night" effect (default `#000000`)
-		* `height`: cloud height in blocks (default per conf, usually `120`)
-		* `thickness`: cloud thickness in blocks (default `16`)
-		* `speed`: 2D cloud speed + direction in blocks per second (default `{x=0, y=-2}`)
+		* `color`: cloud color component affected by daylight (default `#fff0f0`)
+		* `ambient`: daylight-independent cloud color component, "glow at night" effect (default `#000000`)
+		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
+		* `thickness`: cloud thickness in nodes (default `16`)
+		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, y=-2}`)
 * `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3077,12 +3077,14 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
 * `get_sky()`: returns bgcolor, type and a table with the textures
-* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec, height=number, speed={x=0,y=-2}})`: set cloud parameters
-	* `density`: from `0` (no clouds) to `1` (full clouds)
-	* `color`: cloud color during daylight
-	* `ambient`: this will be added to cloud color regardless of light, "glow at night" effect
-	* `height`: cloud height
-	* `speed`: 2D cloud speed + direction in blocks per second
+* `set_clouds(settings)`: set cloud parameters
+	* `settings` is a table with the following optional fields:
+		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
+		* `color`: cloud color during daylight (default `#fff0f0`)
+		* `ambient`: light-independent cloud color component, "glow at night" effect (default `#000000`)
+		* `height`: cloud height in blocks (default per conf, usually `120`)
+		* `thickness`: cloud thickness in blocks (default `16`)
+		* `speed`: 2D cloud speed + direction in blocks per second (default `{x=0, y=-2}`)
 * `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3077,10 +3077,11 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
 * `get_sky()`: returns bgcolor, type and a table with the textures
-* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec})`: set cloud parameters
+* `set_clouds({density=number, color=ColorSpec, ambient=ColorSpec, height=number})`: set cloud parameters
 	* `density`: from `0` (no clouds) to `1` (full clouds)
 	* `color`: cloud color during daylight
 	* `ambient`: this will be added to cloud color regardless of light, "glow at night" effect
+	* `height`: cloud height
 * `get_clouds()`: returns a table with the current cloud settings as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount

--- a/src/client.h
+++ b/src/client.h
@@ -180,12 +180,13 @@ struct ClientEvent
 			float ratio_f;
 		} override_day_night_ratio;
 		struct {
-			float density;
-			video::SColor *color_bright;
-			video::SColor *color_ambient;
-			float height;
-			float thickness;
-			v2f *speed;
+			f32 density;
+			u32 color_bright;
+			u32 color_ambient;
+			f32 height;
+			f32 thickness;
+			f32 speed_x;
+			f32 speed_y;
 		} clouds_params;
 	};
 };

--- a/src/client.h
+++ b/src/client.h
@@ -183,6 +183,7 @@ struct ClientEvent
 			float density;
 			video::SColor *color_bright;
 			video::SColor *color_ambient;
+			float height;
 		} set_clouds;
 	};
 };

--- a/src/client.h
+++ b/src/client.h
@@ -184,6 +184,7 @@ struct ClientEvent
 			video::SColor *color_bright;
 			video::SColor *color_ambient;
 			float height;
+			v2f *speed;
 		} set_clouds;
 	};
 };

--- a/src/client.h
+++ b/src/client.h
@@ -77,7 +77,7 @@ enum ClientEventType
 	CE_HUDCHANGE,
 	CE_SET_SKY,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
-	CE_SET_CLOUDS,
+	CE_CLOUDS_PARAMS,
 };
 
 struct ClientEvent
@@ -179,14 +179,14 @@ struct ClientEvent
 			bool do_override;
 			float ratio_f;
 		} override_day_night_ratio;
-		struct{
+		struct {
 			float density;
 			video::SColor *color_bright;
 			video::SColor *color_ambient;
 			float height;
 			float thickness;
 			v2f *speed;
-		} set_clouds;
+		} clouds_params;
 	};
 };
 
@@ -340,7 +340,7 @@ public:
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
-	void handleCommand_HudSetClouds(NetworkPacket* pkt);
+	void handleCommand_CloudsParams(NetworkPacket* pkt);
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);

--- a/src/client.h
+++ b/src/client.h
@@ -77,7 +77,7 @@ enum ClientEventType
 	CE_HUDCHANGE,
 	CE_SET_SKY,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
-	CE_CLOUD_PARAMETERS,
+	CE_CLOUD_PARAMS,
 };
 
 struct ClientEvent
@@ -187,7 +187,7 @@ struct ClientEvent
 			f32 thickness;
 			f32 speed_x;
 			f32 speed_y;
-		} cloud_parameters;
+		} cloud_params;
 	};
 };
 
@@ -341,7 +341,7 @@ public:
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
-	void handleCommand_CloudParameters(NetworkPacket* pkt);
+	void handleCommand_CloudParams(NetworkPacket* pkt);
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);

--- a/src/client.h
+++ b/src/client.h
@@ -77,6 +77,7 @@ enum ClientEventType
 	CE_HUDCHANGE,
 	CE_SET_SKY,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
+	CE_SET_CLOUDS,
 };
 
 struct ClientEvent
@@ -178,6 +179,11 @@ struct ClientEvent
 			bool do_override;
 			float ratio_f;
 		} override_day_night_ratio;
+		struct{
+			float density;
+			video::SColor *color_bright;
+			video::SColor *color_ambient;
+		} set_clouds;
 	};
 };
 
@@ -331,6 +337,7 @@ public:
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
+	void handleCommand_HudSetClouds(NetworkPacket* pkt);
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);

--- a/src/client.h
+++ b/src/client.h
@@ -77,7 +77,7 @@ enum ClientEventType
 	CE_HUDCHANGE,
 	CE_SET_SKY,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
-	CE_CLOUDS_PARAMS,
+	CE_CLOUD_PARAMETERS,
 };
 
 struct ClientEvent
@@ -187,7 +187,7 @@ struct ClientEvent
 			f32 thickness;
 			f32 speed_x;
 			f32 speed_y;
-		} clouds_params;
+		} cloud_parameters;
 	};
 };
 
@@ -341,7 +341,7 @@ public:
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);
-	void handleCommand_CloudsParams(NetworkPacket* pkt);
+	void handleCommand_CloudParameters(NetworkPacket* pkt);
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);

--- a/src/client.h
+++ b/src/client.h
@@ -184,6 +184,7 @@ struct ClientEvent
 			video::SColor *color_bright;
 			video::SColor *color_ambient;
 			float height;
+			float thickness;
 			v2f *speed;
 		} set_clouds;
 	};

--- a/src/cloudparameters.h
+++ b/src/cloudparameters.h
@@ -1,0 +1,33 @@
+/*
+Minetest
+Copyright (C) 2017 bendeutsch, Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef CLOUDPARAMETERS_HEADER
+#define CLOUDPARAMETERS_HEADER
+
+struct CloudParameters
+{
+	float density;
+	video::SColor color_bright;
+	video::SColor color_ambient;
+	float thickness;
+	float height;
+	v2f speed;
+};
+
+#endif

--- a/src/cloudparams.h
+++ b/src/cloudparams.h
@@ -17,10 +17,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLOUDPARAMETERS_HEADER
-#define CLOUDPARAMETERS_HEADER
+#ifndef CLOUDPARAMS_HEADER
+#define CLOUDPARAMS_HEADER
 
-struct CloudParameters
+struct CloudParams
 {
 	float density;
 	video::SColor color_bright;

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -50,6 +50,7 @@ Clouds::Clouds(
 	m_speed(0, -2),
 	m_camera_offset(0,0,0),
 	m_density(0.4),
+	m_thickness(16 * BS),
 	m_color(1.0, 1.0, 1.0, 1.0),
 	m_color_bright(255.0/255.0, 240.0/255.0, 240.0/255.0, 1.0),
 	m_color_ambient(0.0, 0.0, 0.0, 1.0)
@@ -240,8 +241,9 @@ void Clouds::render()
 			v[3].Color.setBlue(255);
 		}*/
 
-		f32 rx = cloud_size/2;
-		f32 ry = 8 * BS;
+		f32 rx = cloud_size / 2;
+		// if clouds are flat, the top layer should be at the given height
+		f32 ry = m_enable_3d ? m_thickness : 0;
 		f32 rz = cloud_size / 2;
 
 		for(int i=0; i<num_faces_to_draw; i++)
@@ -269,8 +271,8 @@ void Clouds::render()
 				}
 				v[0].Pos.set(-rx, ry,-rz);
 				v[1].Pos.set( rx, ry,-rz);
-				v[2].Pos.set( rx,-ry,-rz);
-				v[3].Pos.set(-rx,-ry,-rz);
+				v[2].Pos.set( rx,  0,-rz);
+				v[3].Pos.set(-rx,  0,-rz);
 				break;
 			case 2: //right
 				if (INAREA(xi + 1, zi, m_cloud_radius_i)) {
@@ -284,8 +286,8 @@ void Clouds::render()
 				}
 				v[0].Pos.set( rx, ry,-rz);
 				v[1].Pos.set( rx, ry, rz);
-				v[2].Pos.set( rx,-ry, rz);
-				v[3].Pos.set( rx,-ry,-rz);
+				v[2].Pos.set( rx,  0, rz);
+				v[3].Pos.set( rx,  0,-rz);
 				break;
 			case 3: // front
 				if (INAREA(xi, zi + 1, m_cloud_radius_i)) {
@@ -299,8 +301,8 @@ void Clouds::render()
 				}
 				v[0].Pos.set( rx, ry, rz);
 				v[1].Pos.set(-rx, ry, rz);
-				v[2].Pos.set(-rx,-ry, rz);
-				v[3].Pos.set( rx,-ry, rz);
+				v[2].Pos.set(-rx,  0, rz);
+				v[3].Pos.set( rx,  0, rz);
 				break;
 			case 4: // left
 				if (INAREA(xi-1, zi, m_cloud_radius_i)) {
@@ -314,18 +316,18 @@ void Clouds::render()
 				}
 				v[0].Pos.set(-rx, ry, rz);
 				v[1].Pos.set(-rx, ry,-rz);
-				v[2].Pos.set(-rx,-ry,-rz);
-				v[3].Pos.set(-rx,-ry, rz);
+				v[2].Pos.set(-rx,  0,-rz);
+				v[3].Pos.set(-rx,  0, rz);
 				break;
 			case 5: // bottom
 				for(int j=0;j<4;j++){
 					v[j].Color = c_bottom;
 					v[j].Normal.set(0,-1,0);
 				}
-				v[0].Pos.set( rx,-ry, rz);
-				v[1].Pos.set(-rx,-ry, rz);
-				v[2].Pos.set(-rx,-ry,-rz);
-				v[3].Pos.set( rx,-ry,-rz);
+				v[0].Pos.set( rx,  0, rz);
+				v[1].Pos.set(-rx,  0, rz);
+				v[2].Pos.set(-rx,  0,-rz);
+				v[3].Pos.set( rx,  0,-rz);
 				break;
 			}
 

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -361,9 +361,9 @@ void Clouds::step(float dtime)
 void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 {
 	m_camera_pos = camera_p;
-	m_color.r = MYMIN(color_diffuse.r * m_color_bright.r + m_color_ambient.r, 1.0);
-	m_color.g = MYMIN(color_diffuse.g * m_color_bright.g + m_color_ambient.g, 1.0);
-	m_color.b = MYMIN(color_diffuse.b * m_color_bright.b + m_color_ambient.b, 1.0);
+	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_color_bright.r, m_color_ambient.r), 1.0);
+	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_color_bright.g, m_color_ambient.g), 1.0);
+	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_color_bright.b, m_color_ambient.b), 1.0);
 	m_color.a = 1.0;
 }
 

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -47,13 +47,8 @@ Clouds::Clouds(
 	m_seed(seed),
 	m_camera_pos(0.0f, 0.0f),
 	m_origin(0.0f, 0.0f),
-	m_speed(0.0f, -2.0f),
 	m_camera_offset(0.0f, 0.0f, 0.0f),
-	m_density(0.4f),
-	m_thickness(16.0f * BS),
-	m_color(1.0f, 1.0f, 1.0f, 1.0f),
-	m_color_bright(255.0f/255.0f, 240.0f/255.0f, 240.0f/255.0f, 1.0f),
-	m_color_ambient(0.0f, 0.0f, 0.0f, 1.0f)
+	m_color(1.0f, 1.0f, 1.0f, 1.0f)
 {
 	m_material.setFlag(video::EMF_LIGHTING, false);
 	//m_material.setFlag(video::EMF_BACK_FACE_CULLING, false);
@@ -63,6 +58,12 @@ Clouds::Clouds(
 	m_material.setFlag(video::EMF_ANTI_ALIASING, true);
 	//m_material.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+
+	m_parameters.density       = 0.4f;
+	m_parameters.thickness     = 16.0f;
+	m_parameters.color_bright  = video::SColor(255, 255, 240, 240);
+	m_parameters.color_ambient = video::SColor(255, 0, 0, 0);
+	m_parameters.speed         = v2f(0.0f, -2.0f);
 
 	m_passed_cloud_y = cloudheight;
 	readSettings();
@@ -94,7 +95,7 @@ void Clouds::OnRegisterSceneNode()
 void Clouds::render()
 {
 
-	if (m_density <= 0.0f)
+	if (m_parameters.density <= 0.0f)
 		return; // no need to do anything
 
 	video::IVideoDriver* driver = SceneManager->getVideoDriver();
@@ -200,7 +201,7 @@ void Clouds::render()
 			// normalize to 0..1 (given 3 octaves)
 			static const float noise_bound = 1.0f + 0.5f + 0.25f;
 			float density = noise / noise_bound * 0.5f + 0.5f;
-			grid[i] = (density < m_density);
+			grid[i] = (density < m_parameters.density);
 		}
 	}
 
@@ -247,7 +248,7 @@ void Clouds::render()
 
 		f32 rx = cloud_size / 2.0f;
 		// if clouds are flat, the top layer should be at the given height
-		f32 ry = m_enable_3d ? m_thickness : 0.0f;
+		f32 ry = m_enable_3d ? m_parameters.thickness * BS : 0.0f;
 		f32 rz = cloud_size / 2;
 
 		for(int i=0; i<num_faces_to_draw; i++)
@@ -335,7 +336,7 @@ void Clouds::render()
 				break;
 			}
 
-			v3f pos(p0.X, m_cloud_y, p0.Y);
+			v3f pos(p0.X, m_parameters.height * BS, p0.Y);
 			pos -= intToFloat(m_camera_offset, BS);
 
 			for(u16 i=0; i<4; i++)
@@ -355,21 +356,21 @@ void Clouds::render()
 
 void Clouds::step(float dtime)
 {
-	m_origin = m_origin + dtime * BS * m_speed;
+	m_origin = m_origin + dtime * BS * m_parameters.speed;
 }
 
 void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 {
 	m_camera_pos = camera_p;
-	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_color_bright.r, m_color_ambient.r), 1.0f);
-	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_color_bright.g, m_color_ambient.g), 1.0f);
-	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_color_bright.b, m_color_ambient.b), 1.0f);
+	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_parameters.color_bright.getRed(), m_parameters.color_ambient.getRed()), 255) / 255.0f;
+	m_color.g = MYMIN(MYMAX(color_diffuse.r * m_parameters.color_bright.getGreen(), m_parameters.color_ambient.getGreen()), 255) / 255.0f;
+	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_parameters.color_bright.getBlue(), m_parameters.color_ambient.getBlue()), 255) / 255.0f;
 	m_color.a = 1.0f;
 }
 
 void Clouds::readSettings()
 {
-	m_cloud_y = BS * (m_passed_cloud_y ? m_passed_cloud_y :
+	m_parameters.height = (m_passed_cloud_y ? m_passed_cloud_y :
 		g_settings->getS16("cloud_height"));
 	m_cloud_radius_i = g_settings->getU16("cloud_radius");
 	m_enable_3d = g_settings->getBool("enable_3d_clouds");

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -93,6 +93,10 @@ void Clouds::OnRegisterSceneNode()
 
 void Clouds::render()
 {
+
+	if (m_density <= 0.0)
+		return; // no need to do anything
+
 	video::IVideoDriver* driver = SceneManager->getVideoDriver();
 
 	if(SceneManager->getSceneNodeRenderPass() != scene::ESNRP_TRANSPARENT)
@@ -189,13 +193,13 @@ void Clouds::render()
 				zi + center_of_drawing_in_noise_i.Y
 			);
 
-			double noise = noise2d_perlin(
+			float noise = noise2d_perlin(
 					(float)p_in_noise_i.X * cloud_size_noise,
 					(float)p_in_noise_i.Y * cloud_size_noise,
 					m_seed, 3, 0.5);
 			// normalize to 0..1 (given 3 octaves)
-			double noise_bound = 1.0 + 0.5 + 0.25;
-			double density = noise / noise_bound * 0.5 + 0.5;
+			float noise_bound = 1.0 + 0.5 + 0.25;
+			float density = noise / noise_bound * 0.5 + 0.5;
 			grid[i] = (density < m_density);
 		}
 	}

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -61,7 +61,7 @@ Clouds::Clouds(
 
 	m_params.density       = 0.4f;
 	m_params.thickness     = 16.0f;
-	m_params.color_bright  = video::SColor(255, 255, 240, 240);
+	m_params.color_bright  = video::SColor(229, 255, 240, 240);
 	m_params.color_ambient = video::SColor(255, 0, 0, 0);
 	m_params.speed         = v2f(0.0f, -2.0f);
 
@@ -153,10 +153,6 @@ void Clouds::render()
 	c_bottom_f.r *= 0.80;
 	c_bottom_f.g *= 0.80;
 	c_bottom_f.b *= 0.80;
-	c_top_f.a = 0.9;
-	c_side_1_f.a = 0.9;
-	c_side_2_f.a = 0.9;
-	c_bottom_f.a = 0.9;
 	video::SColor c_top = c_top_f.toSColor();
 	video::SColor c_side_1 = c_side_1_f.toSColor();
 	video::SColor c_side_2 = c_side_2_f.toSColor();
@@ -365,7 +361,7 @@ void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getRed(), m_params.color_ambient.getRed()), 255) / 255.0f;
 	m_color.g = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getGreen(), m_params.color_ambient.getGreen()), 255) / 255.0f;
 	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_params.color_bright.getBlue(), m_params.color_ambient.getBlue()), 255) / 255.0f;
-	m_color.a = 1.0f;
+	m_color.a = m_params.color_bright.getAlpha() / 255.0f;
 }
 
 void Clouds::readSettings()

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -46,7 +46,11 @@ Clouds::Clouds(
 	m_seed(seed),
 	m_camera_pos(0,0),
 	m_time(0),
-	m_camera_offset(0,0,0)
+	m_camera_offset(0,0,0),
+	m_density(0.4),
+	m_color(1.0, 1.0, 1.0, 1.0),
+	m_color_bright(255.0/255.0, 240.0/255.0, 240.0/255.0, 1.0),
+	m_color_ambient(0.0, 0.0, 0.0, 1.0)
 {
 	m_material.setFlag(video::EMF_LIGHTING, false);
 	//m_material.setFlag(video::EMF_BACK_FACE_CULLING, false);
@@ -191,7 +195,10 @@ void Clouds::render()
 					(float)p_in_noise_i.X * cloud_size_noise,
 					(float)p_in_noise_i.Y * cloud_size_noise,
 					m_seed, 3, 0.5);
-			grid[i] = (noise >= 0.4);
+			// normalize to 0..1 (given 3 octaves)
+			double noise_bound = 1.0 + 0.5 + 0.25;
+			double density = noise / noise_bound * 0.5 + 0.5;
+			grid[i] = (density < m_density);
 		}
 	}
 
@@ -348,12 +355,13 @@ void Clouds::step(float dtime)
 	m_time += dtime;
 }
 
-void Clouds::update(v2f camera_p, video::SColorf color)
+void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 {
 	m_camera_pos = camera_p;
-	m_color = color;
-	//m_brightness = brightness;
-	//dstream<<"m_brightness="<<m_brightness<<std::endl;
+	m_color.r = MYMIN(color_diffuse.r * m_color_bright.r + m_color_ambient.r, 1.0);
+	m_color.g = MYMIN(color_diffuse.g * m_color_bright.g + m_color_ambient.g, 1.0);
+	m_color.b = MYMIN(color_diffuse.b * m_color_bright.b + m_color_ambient.b, 1.0);
+	m_color.a = 1.0;
 }
 
 void Clouds::readSettings()

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -46,7 +46,8 @@ Clouds::Clouds(
 	scene::ISceneNode(parent, mgr, id),
 	m_seed(seed),
 	m_camera_pos(0,0),
-	m_time(0),
+	m_origin(0, 0),
+	m_speed(0, -2),
 	m_camera_offset(0,0,0),
 	m_density(0.4),
 	m_color(1.0, 1.0, 1.0, 1.0),
@@ -111,14 +112,11 @@ void Clouds::render()
 	*/
 
 	const float cloud_size = BS * 64;
-	const v2f cloud_speed(0, -BS * 2);
 	
 	const float cloud_full_radius = cloud_size * m_cloud_radius_i;
 	
-	// Position of cloud noise origin in world coordinates
-	v2f world_cloud_origin_pos_f = m_time * cloud_speed;
 	// Position of cloud noise origin from the camera
-	v2f cloud_origin_from_camera_f = world_cloud_origin_pos_f - m_camera_pos;
+	v2f cloud_origin_from_camera_f = m_origin - m_camera_pos;
 	// The center point of drawing in the noise
 	v2f center_of_drawing_in_noise_f = -cloud_origin_from_camera_f;
 	// The integer center point of drawing in the noise
@@ -130,7 +128,7 @@ void Clouds::render()
 	v2f world_center_of_drawing_in_noise_f = v2f(
 		center_of_drawing_in_noise_i.X * cloud_size,
 		center_of_drawing_in_noise_i.Y * cloud_size
-	) + world_cloud_origin_pos_f;
+	) + m_origin;
 
 	/*video::SColor c_top(128,b*240,b*240,b*255);
 	video::SColor c_side_1(128,b*230,b*230,b*255);
@@ -351,7 +349,7 @@ void Clouds::render()
 
 void Clouds::step(float dtime)
 {
-	m_time += dtime;
+	m_origin = m_origin + dtime * BS * m_speed;
 }
 
 void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
@@ -370,4 +368,3 @@ void Clouds::readSettings()
 	m_cloud_radius_i = g_settings->getU16("cloud_radius");
 	m_enable_3d = g_settings->getBool("enable_3d_clouds");
 }
-

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -59,11 +59,11 @@ Clouds::Clouds(
 	//m_material.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
-	m_parameters.density       = 0.4f;
-	m_parameters.thickness     = 16.0f;
-	m_parameters.color_bright  = video::SColor(255, 255, 240, 240);
-	m_parameters.color_ambient = video::SColor(255, 0, 0, 0);
-	m_parameters.speed         = v2f(0.0f, -2.0f);
+	m_params.density       = 0.4f;
+	m_params.thickness     = 16.0f;
+	m_params.color_bright  = video::SColor(255, 255, 240, 240);
+	m_params.color_ambient = video::SColor(255, 0, 0, 0);
+	m_params.speed         = v2f(0.0f, -2.0f);
 
 	m_passed_cloud_y = cloudheight;
 	readSettings();
@@ -95,7 +95,7 @@ void Clouds::OnRegisterSceneNode()
 void Clouds::render()
 {
 
-	if (m_parameters.density <= 0.0f)
+	if (m_params.density <= 0.0f)
 		return; // no need to do anything
 
 	video::IVideoDriver* driver = SceneManager->getVideoDriver();
@@ -201,7 +201,7 @@ void Clouds::render()
 			// normalize to 0..1 (given 3 octaves)
 			static const float noise_bound = 1.0f + 0.5f + 0.25f;
 			float density = noise / noise_bound * 0.5f + 0.5f;
-			grid[i] = (density < m_parameters.density);
+			grid[i] = (density < m_params.density);
 		}
 	}
 
@@ -248,7 +248,7 @@ void Clouds::render()
 
 		f32 rx = cloud_size / 2.0f;
 		// if clouds are flat, the top layer should be at the given height
-		f32 ry = m_enable_3d ? m_parameters.thickness * BS : 0.0f;
+		f32 ry = m_enable_3d ? m_params.thickness * BS : 0.0f;
 		f32 rz = cloud_size / 2;
 
 		for(int i=0; i<num_faces_to_draw; i++)
@@ -336,7 +336,7 @@ void Clouds::render()
 				break;
 			}
 
-			v3f pos(p0.X, m_parameters.height * BS, p0.Y);
+			v3f pos(p0.X, m_params.height * BS, p0.Y);
 			pos -= intToFloat(m_camera_offset, BS);
 
 			for(u16 i=0; i<4; i++)
@@ -356,21 +356,21 @@ void Clouds::render()
 
 void Clouds::step(float dtime)
 {
-	m_origin = m_origin + dtime * BS * m_parameters.speed;
+	m_origin = m_origin + dtime * BS * m_params.speed;
 }
 
 void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 {
 	m_camera_pos = camera_p;
-	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_parameters.color_bright.getRed(), m_parameters.color_ambient.getRed()), 255) / 255.0f;
-	m_color.g = MYMIN(MYMAX(color_diffuse.r * m_parameters.color_bright.getGreen(), m_parameters.color_ambient.getGreen()), 255) / 255.0f;
-	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_parameters.color_bright.getBlue(), m_parameters.color_ambient.getBlue()), 255) / 255.0f;
+	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getRed(), m_params.color_ambient.getRed()), 255) / 255.0f;
+	m_color.g = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getGreen(), m_params.color_ambient.getGreen()), 255) / 255.0f;
+	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_params.color_bright.getBlue(), m_params.color_ambient.getBlue()), 255) / 255.0f;
 	m_color.a = 1.0f;
 }
 
 void Clouds::readSettings()
 {
-	m_parameters.height = (m_passed_cloud_y ? m_passed_cloud_y :
+	m_params.height = (m_passed_cloud_y ? m_passed_cloud_y :
 		g_settings->getS16("cloud_height"));
 	m_cloud_radius_i = g_settings->getU16("cloud_radius");
 	m_enable_3d = g_settings->getBool("enable_3d_clouds");

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -116,7 +116,7 @@ void Clouds::render()
 		Clouds move from Z+ towards Z-
 	*/
 
-	const float cloud_size = BS * 64.0f;
+	static const float cloud_size = BS * 64.0f;
 	
 	const float cloud_full_radius = cloud_size * m_cloud_radius_i;
 	
@@ -198,7 +198,7 @@ void Clouds::render()
 					(float)p_in_noise_i.Y * cloud_size_noise,
 					m_seed, 3, 0.5);
 			// normalize to 0..1 (given 3 octaves)
-			float noise_bound = 1.0f + 0.5f + 0.25f;
+			static const float noise_bound = 1.0f + 0.5f + 0.25f;
 			float density = noise / noise_bound * 0.5f + 0.5f;
 			grid[i] = (density < m_density);
 		}

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -32,6 +32,7 @@ irr::scene::ISceneManager *g_menucloudsmgr = NULL;
 
 static void cloud_3d_setting_changed(const std::string &settingname, void *data)
 {
+	// TODO: only re-read cloud settings, not height or radius
 	((Clouds *)data)->readSettings();
 }
 
@@ -66,9 +67,7 @@ Clouds::Clouds(
 	g_settings->registerChangedCallback("enable_3d_clouds",
 		&cloud_3d_setting_changed, this);
 
-	m_box = aabb3f(-BS*1000000,m_cloud_y-BS,-BS*1000000,
-			BS*1000000,m_cloud_y+BS,BS*1000000);
-
+	updateBox();
 }
 
 Clouds::~Clouds()

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -45,15 +45,15 @@ Clouds::Clouds(
 ):
 	scene::ISceneNode(parent, mgr, id),
 	m_seed(seed),
-	m_camera_pos(0,0),
-	m_origin(0, 0),
-	m_speed(0, -2),
-	m_camera_offset(0,0,0),
-	m_density(0.4),
-	m_thickness(16 * BS),
-	m_color(1.0, 1.0, 1.0, 1.0),
-	m_color_bright(255.0/255.0, 240.0/255.0, 240.0/255.0, 1.0),
-	m_color_ambient(0.0, 0.0, 0.0, 1.0)
+	m_camera_pos(0.0f, 0.0f),
+	m_origin(0.0f, 0.0f),
+	m_speed(0.0f, -2.0f),
+	m_camera_offset(0.0f, 0.0f, 0.0f),
+	m_density(0.4f),
+	m_thickness(16.0f * BS),
+	m_color(1.0f, 1.0f, 1.0f, 1.0f),
+	m_color_bright(255.0f/255.0f, 240.0f/255.0f, 240.0f/255.0f, 1.0f),
+	m_color_ambient(0.0f, 0.0f, 0.0f, 1.0f)
 {
 	m_material.setFlag(video::EMF_LIGHTING, false);
 	//m_material.setFlag(video::EMF_BACK_FACE_CULLING, false);
@@ -94,7 +94,7 @@ void Clouds::OnRegisterSceneNode()
 void Clouds::render()
 {
 
-	if (m_density <= 0.0)
+	if (m_density <= 0.0f)
 		return; // no need to do anything
 
 	video::IVideoDriver* driver = SceneManager->getVideoDriver();
@@ -116,7 +116,7 @@ void Clouds::render()
 		Clouds move from Z+ towards Z-
 	*/
 
-	const float cloud_size = BS * 64;
+	const float cloud_size = BS * 64.0f;
 	
 	const float cloud_full_radius = cloud_size * m_cloud_radius_i;
 	
@@ -198,8 +198,8 @@ void Clouds::render()
 					(float)p_in_noise_i.Y * cloud_size_noise,
 					m_seed, 3, 0.5);
 			// normalize to 0..1 (given 3 octaves)
-			float noise_bound = 1.0 + 0.5 + 0.25;
-			float density = noise / noise_bound * 0.5 + 0.5;
+			float noise_bound = 1.0f + 0.5f + 0.25f;
+			float density = noise / noise_bound * 0.5f + 0.5f;
 			grid[i] = (density < m_density);
 		}
 	}
@@ -245,9 +245,9 @@ void Clouds::render()
 			v[3].Color.setBlue(255);
 		}*/
 
-		f32 rx = cloud_size / 2;
+		f32 rx = cloud_size / 2.0f;
 		// if clouds are flat, the top layer should be at the given height
-		f32 ry = m_enable_3d ? m_thickness : 0;
+		f32 ry = m_enable_3d ? m_thickness : 0.0f;
 		f32 rz = cloud_size / 2;
 
 		for(int i=0; i<num_faces_to_draw; i++)
@@ -361,10 +361,10 @@ void Clouds::step(float dtime)
 void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 {
 	m_camera_pos = camera_p;
-	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_color_bright.r, m_color_ambient.r), 1.0);
-	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_color_bright.g, m_color_ambient.g), 1.0);
-	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_color_bright.b, m_color_ambient.b), 1.0);
-	m_color.a = 1.0;
+	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_color_bright.r, m_color_ambient.r), 1.0f);
+	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_color_bright.g, m_color_ambient.g), 1.0f);
+	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_color_bright.b, m_color_ambient.b), 1.0f);
+	m_color.a = 1.0f;
 }
 
 void Clouds::readSettings()

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <iostream>
 #include "constants.h"
+#include "cloudparameters.h"
 
 // Menu clouds
 class Clouds;

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -117,8 +117,8 @@ public:
 private:
 	void updateBox()
 	{
-		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000,
-				BS * 1000000, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000);
+		m_box = aabb3f(-BS * 1000000.0f, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000.0f,
+				BS * 1000000.0f, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000.0f);
 	}
 
 	video::SMaterial m_material;

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -87,45 +87,49 @@ public:
 
 	void setDensity(float density)
 	{
-		m_density = density;
+		m_parameters.density = density;
 		// currently does not need bounding
 	}
 
 	void setColorBright(const video::SColor &color_bright)
 	{
-		m_color_bright = color_bright;
+		m_parameters.color_bright = color_bright;
 	}
 
 	void setColorAmbient(const video::SColor &color_ambient)
 	{
-		m_color_ambient = color_ambient;
+		m_parameters.color_ambient = color_ambient;
 	}
 
 	void setHeight(float height)
 	{
-		m_cloud_y = BS * height; // add bounding when necessary
+		m_parameters.height = height; // add bounding when necessary
 		updateBox();
 	}
 
-	void setSpeed(v2f speed) { m_speed = speed; }
+	void setSpeed(v2f speed)
+	{
+		m_parameters.speed = speed;
+	}
 
 	void setThickness(float thickness)
 	{
-		m_thickness = BS * thickness;
+		m_parameters.thickness = thickness;
 		updateBox();
 	}
 
 private:
 	void updateBox()
 	{
-		m_box = aabb3f(-BS * 1000000.0f, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000.0f,
-				BS * 1000000.0f, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000.0f);
+		float height_bs    = m_parameters.height    * BS;
+		float thickness_bs = m_parameters.thickness * BS;
+		m_box = aabb3f(-BS * 1000000.0f, height_bs - BS * m_camera_offset.Y, -BS * 1000000.0f,
+				BS * 1000000.0f, height_bs + thickness_bs - BS * m_camera_offset.Y, BS * 1000000.0f);
 	}
 
 	video::SMaterial m_material;
 	aabb3f m_box;
 	s16 m_passed_cloud_y;
-	float m_cloud_y;
 	u16 m_cloud_radius_i;
 	bool m_enable_3d;
 	u32 m_seed;
@@ -133,11 +137,8 @@ private:
 	v2f m_origin;
 	v2f m_speed;
 	v3s16 m_camera_offset;
-	float m_density;
-	float m_thickness;
 	video::SColorf m_color;
-	video::SColorf m_color_bright;
-	video::SColorf m_color_ambient;
+	CloudParameters m_parameters;
 
 };
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -108,6 +108,12 @@ public:
 
 	void setSpeed(v2f speed) { m_speed = speed; }
 
+	void setThickness(float thickness)
+	{
+		m_thickness = BS * thickness;
+		updateBox();
+	}
+
 private:
 	video::SMaterial m_material;
 	aabb3f m_box;
@@ -121,6 +127,7 @@ private:
 	v2f m_speed;
 	v3s16 m_camera_offset;
 	float m_density;
+	float m_thickness;
 	video::SColorf m_color;
 	video::SColorf m_color_bright;
 	video::SColorf m_color_ambient;
@@ -128,8 +135,8 @@ private:
 	// called in several places
 	void updateBox()
 	{
-		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS - BS * m_camera_offset.Y, -BS * 1000000,
-				BS * 1000000, m_cloud_y + BS - BS * m_camera_offset.Y, BS * 1000000);
+		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000,
+				BS * 1000000, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000);
 	}
 };
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -115,6 +115,12 @@ public:
 	}
 
 private:
+	void updateBox()
+	{
+		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000,
+				BS * 1000000, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000);
+	}
+
 	video::SMaterial m_material;
 	aabb3f m_box;
 	s16 m_passed_cloud_y;
@@ -132,12 +138,6 @@ private:
 	video::SColorf m_color_bright;
 	video::SColorf m_color_ambient;
 
-	// called in several places
-	void updateBox()
-	{
-		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS * m_camera_offset.Y, -BS * 1000000,
-				BS * 1000000, m_cloud_y + m_thickness - BS * m_camera_offset.Y, BS * 1000000);
-	}
 };
 
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -85,6 +85,22 @@ public:
 
 	void readSettings();
 
+	void setDensity(float density)
+	{
+		m_density = density;
+		// currently does not need bounding
+	}
+
+	void setColorBright(const video::SColor &color_bright)
+	{
+		m_color_bright = color_bright;
+	}
+
+	void setColorAmbient(const video::SColor &color_ambient)
+	{
+		m_color_ambient = color_ambient;
+	}
+
 private:
 	video::SMaterial m_material;
 	aabb3f m_box;
@@ -92,11 +108,14 @@ private:
 	float m_cloud_y;
 	u16 m_cloud_radius_i;
 	bool m_enable_3d;
-	video::SColorf m_color;
 	u32 m_seed;
 	v2f m_camera_pos;
 	float m_time;
 	v3s16 m_camera_offset;
+	float m_density;
+	video::SColorf m_color;
+	video::SColorf m_color_bright;
+	video::SColorf m_color_ambient;
 };
 
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include <iostream>
 #include "constants.h"
-#include "cloudparameters.h"
+#include "cloudparams.h"
 
 // Menu clouds
 class Clouds;
@@ -87,42 +87,42 @@ public:
 
 	void setDensity(float density)
 	{
-		m_parameters.density = density;
+		m_params.density = density;
 		// currently does not need bounding
 	}
 
 	void setColorBright(const video::SColor &color_bright)
 	{
-		m_parameters.color_bright = color_bright;
+		m_params.color_bright = color_bright;
 	}
 
 	void setColorAmbient(const video::SColor &color_ambient)
 	{
-		m_parameters.color_ambient = color_ambient;
+		m_params.color_ambient = color_ambient;
 	}
 
 	void setHeight(float height)
 	{
-		m_parameters.height = height; // add bounding when necessary
+		m_params.height = height; // add bounding when necessary
 		updateBox();
 	}
 
 	void setSpeed(v2f speed)
 	{
-		m_parameters.speed = speed;
+		m_params.speed = speed;
 	}
 
 	void setThickness(float thickness)
 	{
-		m_parameters.thickness = thickness;
+		m_params.thickness = thickness;
 		updateBox();
 	}
 
 private:
 	void updateBox()
 	{
-		float height_bs    = m_parameters.height    * BS;
-		float thickness_bs = m_parameters.thickness * BS;
+		float height_bs    = m_params.height    * BS;
+		float thickness_bs = m_params.thickness * BS;
 		m_box = aabb3f(-BS * 1000000.0f, height_bs - BS * m_camera_offset.Y, -BS * 1000000.0f,
 				BS * 1000000.0f, height_bs + thickness_bs - BS * m_camera_offset.Y, BS * 1000000.0f);
 	}
@@ -138,7 +138,7 @@ private:
 	v2f m_speed;
 	v3s16 m_camera_offset;
 	video::SColorf m_color;
-	CloudParameters m_parameters;
+	CloudParams m_params;
 
 };
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -79,8 +79,7 @@ public:
 	void updateCameraOffset(v3s16 camera_offset)
 	{
 		m_camera_offset = camera_offset;
-		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS - BS * camera_offset.Y, -BS * 1000000,
-			BS * 1000000, m_cloud_y + BS - BS * camera_offset.Y, BS * 1000000);
+		updateBox();
 	}
 
 	void readSettings();
@@ -101,6 +100,13 @@ public:
 		m_color_ambient = color_ambient;
 	}
 
+	void setHeight(float height)
+	{
+		m_cloud_y = BS * height; // add bounding when necessary
+		updateBox();
+	}
+
+
 private:
 	video::SMaterial m_material;
 	aabb3f m_box;
@@ -116,6 +122,13 @@ private:
 	video::SColorf m_color;
 	video::SColorf m_color_bright;
 	video::SColorf m_color_ambient;
+
+	// called in several places
+	void updateBox()
+	{
+		m_box = aabb3f(-BS * 1000000, m_cloud_y - BS - BS * m_camera_offset.Y, -BS * 1000000,
+				BS * 1000000, m_cloud_y + BS - BS * m_camera_offset.Y, BS * 1000000);
+	}
 };
 
 

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -106,6 +106,7 @@ public:
 		updateBox();
 	}
 
+	void setSpeed(v2f speed) { m_speed = speed; }
 
 private:
 	video::SMaterial m_material;
@@ -116,7 +117,8 @@ private:
 	bool m_enable_3d;
 	u32 m_seed;
 	v2f m_camera_pos;
-	float m_time;
+	v2f m_origin;
+	v2f m_speed;
 	v3s16 m_camera_offset;
 	float m_density;
 	video::SColorf m_color;
@@ -134,4 +136,3 @@ private:
 
 
 #endif
-

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3296,6 +3296,16 @@ void Game::processClientEvents(CameraOrientation *cam)
 					event.override_day_night_ratio.ratio_f * 1000);
 			break;
 
+		case CE_SET_CLOUDS:
+			if (clouds) {
+				clouds->setDensity(event.set_clouds.density);
+				clouds->setColorBright(*event.set_clouds.color_bright);
+				delete event.set_clouds.color_bright;
+				clouds->setColorAmbient(*event.set_clouds.color_ambient);
+				delete event.set_clouds.color_ambient;
+			}
+			break;
+
 		default:
 			// unknown or unhandled type
 			break;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3299,14 +3299,13 @@ void Game::processClientEvents(CameraOrientation *cam)
 		case CE_CLOUDS_PARAMS:
 			if (clouds) {
 				clouds->setDensity(event.clouds_params.density);
-				clouds->setColorBright(*event.clouds_params.color_bright);
-				delete event.clouds_params.color_bright;
-				clouds->setColorAmbient(*event.clouds_params.color_ambient);
-				delete event.clouds_params.color_ambient;
+				clouds->setColorBright(video::SColor(event.clouds_params.color_bright));
+				clouds->setColorAmbient(video::SColor(event.clouds_params.color_ambient));
 				clouds->setHeight(event.clouds_params.height);
 				clouds->setThickness(event.clouds_params.thickness);
-				clouds->setSpeed(*event.clouds_params.speed);
-				delete event.clouds_params.speed;
+				clouds->setSpeed(v2f(
+						event.clouds_params.speed_x,
+						event.clouds_params.speed_y));
 			}
 			break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3304,6 +3304,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 				clouds->setColorAmbient(*event.set_clouds.color_ambient);
 				delete event.set_clouds.color_ambient;
 				clouds->setHeight(event.set_clouds.height);
+				clouds->setThickness(event.set_clouds.thickness);
 				clouds->setSpeed(*event.set_clouds.speed);
 				delete event.set_clouds.speed;
 			}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3296,16 +3296,16 @@ void Game::processClientEvents(CameraOrientation *cam)
 					event.override_day_night_ratio.ratio_f * 1000);
 			break;
 
-		case CE_CLOUD_PARAMETERS:
+		case CE_CLOUD_PARAMS:
 			if (clouds) {
-				clouds->setDensity(event.cloud_parameters.density);
-				clouds->setColorBright(video::SColor(event.cloud_parameters.color_bright));
-				clouds->setColorAmbient(video::SColor(event.cloud_parameters.color_ambient));
-				clouds->setHeight(event.cloud_parameters.height);
-				clouds->setThickness(event.cloud_parameters.thickness);
+				clouds->setDensity(event.cloud_params.density);
+				clouds->setColorBright(video::SColor(event.cloud_params.color_bright));
+				clouds->setColorAmbient(video::SColor(event.cloud_params.color_ambient));
+				clouds->setHeight(event.cloud_params.height);
+				clouds->setThickness(event.cloud_params.thickness);
 				clouds->setSpeed(v2f(
-						event.cloud_parameters.speed_x,
-						event.cloud_parameters.speed_y));
+						event.cloud_params.speed_x,
+						event.cloud_params.speed_y));
 			}
 			break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3296,16 +3296,16 @@ void Game::processClientEvents(CameraOrientation *cam)
 					event.override_day_night_ratio.ratio_f * 1000);
 			break;
 
-		case CE_CLOUDS_PARAMS:
+		case CE_CLOUD_PARAMETERS:
 			if (clouds) {
-				clouds->setDensity(event.clouds_params.density);
-				clouds->setColorBright(video::SColor(event.clouds_params.color_bright));
-				clouds->setColorAmbient(video::SColor(event.clouds_params.color_ambient));
-				clouds->setHeight(event.clouds_params.height);
-				clouds->setThickness(event.clouds_params.thickness);
+				clouds->setDensity(event.cloud_parameters.density);
+				clouds->setColorBright(video::SColor(event.cloud_parameters.color_bright));
+				clouds->setColorAmbient(video::SColor(event.cloud_parameters.color_ambient));
+				clouds->setHeight(event.cloud_parameters.height);
+				clouds->setThickness(event.cloud_parameters.thickness);
 				clouds->setSpeed(v2f(
-						event.clouds_params.speed_x,
-						event.clouds_params.speed_y));
+						event.cloud_parameters.speed_x,
+						event.cloud_parameters.speed_y));
 			}
 			break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3304,6 +3304,8 @@ void Game::processClientEvents(CameraOrientation *cam)
 				clouds->setColorAmbient(*event.set_clouds.color_ambient);
 				delete event.set_clouds.color_ambient;
 				clouds->setHeight(event.set_clouds.height);
+				clouds->setSpeed(*event.set_clouds.speed);
+				delete event.set_clouds.speed;
 			}
 			break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3296,17 +3296,17 @@ void Game::processClientEvents(CameraOrientation *cam)
 					event.override_day_night_ratio.ratio_f * 1000);
 			break;
 
-		case CE_SET_CLOUDS:
+		case CE_CLOUDS_PARAMS:
 			if (clouds) {
-				clouds->setDensity(event.set_clouds.density);
-				clouds->setColorBright(*event.set_clouds.color_bright);
-				delete event.set_clouds.color_bright;
-				clouds->setColorAmbient(*event.set_clouds.color_ambient);
-				delete event.set_clouds.color_ambient;
-				clouds->setHeight(event.set_clouds.height);
-				clouds->setThickness(event.set_clouds.thickness);
-				clouds->setSpeed(*event.set_clouds.speed);
-				delete event.set_clouds.speed;
+				clouds->setDensity(event.clouds_params.density);
+				clouds->setColorBright(*event.clouds_params.color_bright);
+				delete event.clouds_params.color_bright;
+				clouds->setColorAmbient(*event.clouds_params.color_ambient);
+				delete event.clouds_params.color_ambient;
+				clouds->setHeight(event.clouds_params.height);
+				clouds->setThickness(event.clouds_params.thickness);
+				clouds->setSpeed(*event.clouds_params.speed);
+				delete event.clouds_params.speed;
 			}
 			break;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3303,6 +3303,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 				delete event.set_clouds.color_bright;
 				clouds->setColorAmbient(*event.set_clouds.color_ambient);
 				delete event.set_clouds.color_ambient;
+				clouds->setHeight(event.set_clouds.height);
 			}
 			break;
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_SET_CLOUDS",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetClouds }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	{ "TOCLIENT_SET_CLOUDS",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetClouds }, // 0x54
+	{ "TOCLIENT_CLOUDS_PARAMS",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudsParams }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	{ "TOCLIENT_CLOUDS_PARAMS",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudsParams }, // 0x54
+	{ "TOCLIENT_CLOUD_PARAMETERS",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParameters }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	{ "TOCLIENT_CLOUD_PARAMETERS",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParameters }, // 0x54
+	{ "TOCLIENT_CLOUD_PARAMS",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParams }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1168,7 +1168,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
+void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 {
 	std::string datastring(pkt->getString(0), pkt->getSize());
 	std::istringstream is(datastring, std::ios_base::binary);
@@ -1181,13 +1181,13 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	v2f *speed                     = new v2f(readV2F1000(is));
 
 	ClientEvent event;
-	event.type                     = CE_SET_CLOUDS;
-	event.set_clouds.density       = density / 65535.0;
-	event.set_clouds.color_bright  = color_bright;
-	event.set_clouds.color_ambient = color_ambient;
-	event.set_clouds.height        = height;
-	event.set_clouds.thickness     = thickness;
-	event.set_clouds.speed         = speed;
+	event.type                        = CE_CLOUDS_PARAMS;
+	event.clouds_params.density       = density / 65535.0;
+	event.clouds_params.color_bright  = color_bright;
+	event.clouds_params.color_ambient = color_ambient;
+	event.clouds_params.height        = height;
+	event.clouds_params.thickness     = thickness;
+	event.clouds_params.speed         = speed;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1177,6 +1177,7 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	video::SColor *color_bright    = new video::SColor(readARGB8(is));
 	video::SColor *color_ambient   = new video::SColor(readARGB8(is));
 	f32 height                     = readF1000(is);
+	v2f *speed                     = new v2f(readV2F1000(is));
 
 	ClientEvent event;
 	event.type                     = CE_SET_CLOUDS;
@@ -1184,6 +1185,7 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	event.set_clouds.color_bright  = color_bright;
 	event.set_clouds.color_ambient = color_ambient;
 	event.set_clouds.height        = height;
+	event.set_clouds.speed         = speed;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1177,6 +1177,7 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	video::SColor *color_bright    = new video::SColor(readARGB8(is));
 	video::SColor *color_ambient   = new video::SColor(readARGB8(is));
 	f32 height                     = readF1000(is);
+	f32 thickness                  = readF1000(is);
 	v2f *speed                     = new v2f(readV2F1000(is));
 
 	ClientEvent event;
@@ -1185,6 +1186,7 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	event.set_clouds.color_bright  = color_bright;
 	event.set_clouds.color_ambient = color_ambient;
 	event.set_clouds.height        = height;
+	event.set_clouds.thickness     = thickness;
 	event.set_clouds.speed         = speed;
 	m_client_event_queue.push(event);
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1170,16 +1170,6 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 
 void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 {
-	//std::string datastring(pkt->getString(0), pkt->getSize());
-	//std::istringstream is(datastring, std::ios_base::binary);
-
-	//u16 density                    = readU16(is);
-	//video::SColor *color_bright    = new video::SColor(readARGB8(is));
-	//video::SColor *color_ambient   = new video::SColor(readARGB8(is));
-	//f32 height                     = readF1000(is);
-	//f32 thickness                  = readF1000(is);
-	//v2f *speed                     = new v2f(readV2F1000(is));
-
 	u16 density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
@@ -1192,7 +1182,7 @@ void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 
 	ClientEvent event;
 	event.type                        = CE_CLOUDS_PARAMS;
-	event.clouds_params.density       = density / 65535.0;
+	event.clouds_params.density       = density / 65535.0f;
 	// use the underlying u32 representation, because we can't
 	// use struct members with constructors here, and this way
 	// we avoid using new() and delete() for no good reason

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1170,24 +1170,39 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 
 void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 {
-	std::string datastring(pkt->getString(0), pkt->getSize());
-	std::istringstream is(datastring, std::ios_base::binary);
+	//std::string datastring(pkt->getString(0), pkt->getSize());
+	//std::istringstream is(datastring, std::ios_base::binary);
 
-	u16 density                    = readU16(is);
-	video::SColor *color_bright    = new video::SColor(readARGB8(is));
-	video::SColor *color_ambient   = new video::SColor(readARGB8(is));
-	f32 height                     = readF1000(is);
-	f32 thickness                  = readF1000(is);
-	v2f *speed                     = new v2f(readV2F1000(is));
+	//u16 density                    = readU16(is);
+	//video::SColor *color_bright    = new video::SColor(readARGB8(is));
+	//video::SColor *color_ambient   = new video::SColor(readARGB8(is));
+	//f32 height                     = readF1000(is);
+	//f32 thickness                  = readF1000(is);
+	//v2f *speed                     = new v2f(readV2F1000(is));
+
+	u16 density;
+	video::SColor color_bright;
+	video::SColor color_ambient;
+	f32 height;
+	f32 thickness;
+	v2f speed;
+
+	*pkt >> density >> color_bright >> color_ambient
+			>> height >> thickness >> speed;
 
 	ClientEvent event;
 	event.type                        = CE_CLOUDS_PARAMS;
 	event.clouds_params.density       = density / 65535.0;
-	event.clouds_params.color_bright  = color_bright;
-	event.clouds_params.color_ambient = color_ambient;
+	// use the underlying u32 representation, because we can't
+	// use struct members with constructors here, and this way
+	// we avoid using new() and delete() for no good reason
+	event.clouds_params.color_bright  = color_bright.color;
+	event.clouds_params.color_ambient = color_ambient.color;
 	event.clouds_params.height        = height;
 	event.clouds_params.thickness     = thickness;
-	event.clouds_params.speed         = speed;
+	// same here: deconstruct to skip constructor
+	event.clouds_params.speed_x       = speed.X;
+	event.clouds_params.speed_y       = speed.Y;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1170,7 +1170,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 
 void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 {
-	u16 density;
+	f32 density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
 	f32 height;
@@ -1182,7 +1182,7 @@ void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 
 	ClientEvent event;
 	event.type                        = CE_CLOUDS_PARAMS;
-	event.clouds_params.density       = density / 65535.0f;
+	event.clouds_params.density       = density;
 	// use the underlying u32 representation, because we can't
 	// use struct members with constructors here, and this way
 	// we avoid using new() and delete() for no good reason

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1168,7 +1168,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_CloudParameters(NetworkPacket* pkt)
+void Client::handleCommand_CloudParams(NetworkPacket* pkt)
 {
 	f32 density;
 	video::SColor color_bright;
@@ -1181,18 +1181,18 @@ void Client::handleCommand_CloudParameters(NetworkPacket* pkt)
 			>> height >> thickness >> speed;
 
 	ClientEvent event;
-	event.type                        = CE_CLOUD_PARAMETERS;
-	event.cloud_parameters.density       = density;
+	event.type                           = CE_CLOUD_PARAMS;
+	event.cloud_params.density       = density;
 	// use the underlying u32 representation, because we can't
 	// use struct members with constructors here, and this way
 	// we avoid using new() and delete() for no good reason
-	event.cloud_parameters.color_bright  = color_bright.color;
-	event.cloud_parameters.color_ambient = color_ambient.color;
-	event.cloud_parameters.height        = height;
-	event.cloud_parameters.thickness     = thickness;
+	event.cloud_params.color_bright  = color_bright.color;
+	event.cloud_params.color_ambient = color_ambient.color;
+	event.cloud_params.height        = height;
+	event.cloud_params.thickness     = thickness;
 	// same here: deconstruct to skip constructor
-	event.cloud_parameters.speed_x       = speed.X;
-	event.cloud_parameters.speed_y       = speed.Y;
+	event.cloud_params.speed_x       = speed.X;
+	event.cloud_params.speed_y       = speed.Y;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1168,7 +1168,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
+void Client::handleCommand_CloudParameters(NetworkPacket* pkt)
 {
 	f32 density;
 	video::SColor color_bright;
@@ -1181,18 +1181,18 @@ void Client::handleCommand_CloudsParams(NetworkPacket* pkt)
 			>> height >> thickness >> speed;
 
 	ClientEvent event;
-	event.type                        = CE_CLOUDS_PARAMS;
-	event.clouds_params.density       = density;
+	event.type                        = CE_CLOUD_PARAMETERS;
+	event.cloud_parameters.density       = density;
 	// use the underlying u32 representation, because we can't
 	// use struct members with constructors here, and this way
 	// we avoid using new() and delete() for no good reason
-	event.clouds_params.color_bright  = color_bright.color;
-	event.clouds_params.color_ambient = color_ambient.color;
-	event.clouds_params.height        = height;
-	event.clouds_params.thickness     = thickness;
+	event.cloud_parameters.color_bright  = color_bright.color;
+	event.cloud_parameters.color_ambient = color_ambient.color;
+	event.cloud_parameters.height        = height;
+	event.cloud_parameters.thickness     = thickness;
 	// same here: deconstruct to skip constructor
-	event.clouds_params.speed_x       = speed.X;
-	event.clouds_params.speed_y       = speed.Y;
+	event.cloud_parameters.speed_x       = speed.X;
+	event.cloud_parameters.speed_y       = speed.Y;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1176,12 +1176,14 @@ void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
 	u16 density                    = readU16(is);
 	video::SColor *color_bright    = new video::SColor(readARGB8(is));
 	video::SColor *color_ambient   = new video::SColor(readARGB8(is));
+	f32 height                     = readF1000(is);
 
 	ClientEvent event;
 	event.type                     = CE_SET_CLOUDS;
 	event.set_clouds.density       = density / 65535.0;
 	event.set_clouds.color_bright  = color_bright;
 	event.set_clouds.color_ambient = color_ambient;
+	event.set_clouds.height        = height;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1168,6 +1168,23 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
+void Client::handleCommand_HudSetClouds(NetworkPacket* pkt)
+{
+	std::string datastring(pkt->getString(0), pkt->getSize());
+	std::istringstream is(datastring, std::ios_base::binary);
+
+	u16 density                    = readU16(is);
+	video::SColor *color_bright    = new video::SColor(readARGB8(is));
+	video::SColor *color_ambient   = new video::SColor(readARGB8(is));
+
+	ClientEvent event;
+	event.type                     = CE_SET_CLOUDS;
+	event.set_clouds.density       = density / 65535.0;
+	event.set_clouds.color_bright  = color_bright;
+	event.set_clouds.color_ambient = color_ambient;
+	m_client_event_queue.push(event);
+}
+
 void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
 {
 	bool do_override;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -616,6 +616,7 @@ enum ToClientCommand
 		u8[4] color_diffuse (ARGB)
 		u8[4] color_ambient (ARGB)
 		f1000 height
+		v2f1000 speed
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -610,7 +610,7 @@ enum ToClientCommand
 		u32 id
 	*/
 
-	TOCLIENT_CLOUDS_PARAMS = 0x54,
+	TOCLIENT_CLOUD_PARAMETERS = 0x54,
 	/*
 		f1000 density
 		u8[4] color_diffuse (ARGB)

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -610,7 +610,7 @@ enum ToClientCommand
 		u32 id
 	*/
 
-	TOCLIENT_SET_CLOUDS = 0x54,
+	TOCLIENT_CLOUDS_PARAMS = 0x54,
 	/*
 		u16 density
 		u8[4] color_diffuse (ARGB)

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -615,6 +615,7 @@ enum ToClientCommand
 		u16 density
 		u8[4] color_diffuse (ARGB)
 		u8[4] color_ambient (ARGB)
+		f1000 height
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -610,6 +610,13 @@ enum ToClientCommand
 		u32 id
 	*/
 
+	TOCLIENT_SET_CLOUDS = 0x54,
+	/*
+		u16 density
+		u8[4] color_diffuse (ARGB)
+		u8[4] color_ambient (ARGB)
+	*/
+
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
 		Belonging to AUTH_MECHANISM_LEGACY_PASSWORD and AUTH_MECHANISM_SRP.

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -616,6 +616,7 @@ enum ToClientCommand
 		u8[4] color_diffuse (ARGB)
 		u8[4] color_ambient (ARGB)
 		f1000 height
+		f1000 thickness
 		v2f1000 speed
 	*/
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -612,7 +612,7 @@ enum ToClientCommand
 
 	TOCLIENT_CLOUDS_PARAMS = 0x54,
 	/*
-		u16 density
+		f1000 density
 		u8[4] color_diffuse (ARGB)
 		u8[4] color_ambient (ARGB)
 		f1000 height

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -610,7 +610,7 @@ enum ToClientCommand
 		u32 id
 	*/
 
-	TOCLIENT_CLOUD_PARAMETERS = 0x54,
+	TOCLIENT_CLOUD_PARAMS = 0x54,
 	/*
 		f1000 density
 		u8[4] color_diffuse (ARGB)

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_SET_CLOUDS",               0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	{ "TOCLIENT_SET_CLOUDS",               0, true }, // 0x54
+	{ "TOCLIENT_CLOUDS_PARAMS",            0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	{ "TOCLIENT_CLOUDS_PARAMS",            0, true }, // 0x54
+	{ "TOCLIENT_CLOUD_PARAMETERS",         0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	{ "TOCLIENT_CLOUD_PARAMETERS",         0, true }, // 0x54
+	{ "TOCLIENT_CLOUD_PARAMS",             0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -67,12 +67,12 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
 
 	// copy defaults
-	m_cloud_settings.density = 0.4;
+	m_cloud_settings.density = 0.4f;
 	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
 	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
-	m_cloud_settings.height = 120.0;
-	m_cloud_settings.thickness = 16.0;
-	m_cloud_settings.speed = v2f(0, -2);
+	m_cloud_settings.height = 120.0f;
+	m_cloud_settings.thickness = 16.0f;
+	m_cloud_settings.speed = v2f(0.0f, -2.0f);
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -65,6 +65,11 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	movement_liquid_fluidity_smooth = g_settings->getFloat("movement_liquid_fluidity_smooth") * BS;
 	movement_liquid_sink            = g_settings->getFloat("movement_liquid_sink")            * BS;
 	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
+
+	// copy defaults
+	m_cloud_settings.density = 0.4;
+	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
+	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -70,6 +70,7 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	m_cloud_settings.density = 0.4;
 	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
 	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
+	m_cloud_settings.height = 120.0;
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -71,6 +71,7 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
 	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
 	m_cloud_settings.height = 120.0;
+	m_cloud_settings.speed = v2f(0, -2);
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -71,6 +71,7 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
 	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
 	m_cloud_settings.height = 120.0;
+	m_cloud_settings.thickness = 16.0;
 	m_cloud_settings.speed = v2f(0, -2);
 }
 

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -67,12 +67,12 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
 
 	// copy defaults
-	m_cloud_parameters.density = 0.4f;
-	m_cloud_parameters.color_bright = video::SColor(255, 255, 240, 240);
-	m_cloud_parameters.color_ambient = video::SColor(255, 0, 0, 0);
-	m_cloud_parameters.height = 120.0f;
-	m_cloud_parameters.thickness = 16.0f;
-	m_cloud_parameters.speed = v2f(0.0f, -2.0f);
+	m_cloud_params.density = 0.4f;
+	m_cloud_params.color_bright = video::SColor(255, 255, 240, 240);
+	m_cloud_params.color_ambient = video::SColor(255, 0, 0, 0);
+	m_cloud_params.height = 120.0f;
+	m_cloud_params.thickness = 16.0f;
+	m_cloud_params.speed = v2f(0.0f, -2.0f);
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -67,12 +67,12 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
 
 	// copy defaults
-	m_cloud_settings.density = 0.4f;
-	m_cloud_settings.color_bright = video::SColor(255, 255, 240, 240);
-	m_cloud_settings.color_ambient = video::SColor(255, 0, 0, 0);
-	m_cloud_settings.height = 120.0f;
-	m_cloud_settings.thickness = 16.0f;
-	m_cloud_settings.speed = v2f(0.0f, -2.0f);
+	m_cloud_parameters.density = 0.4f;
+	m_cloud_parameters.color_bright = video::SColor(255, 255, 240, 240);
+	m_cloud_parameters.color_ambient = video::SColor(255, 0, 0, 0);
+	m_cloud_parameters.height = 120.0f;
+	m_cloud_parameters.thickness = 16.0f;
+	m_cloud_parameters.speed = v2f(0.0f, -2.0f);
 }
 
 void RemotePlayer::serializeExtraAttributes(std::string &output)

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -32,6 +32,13 @@ enum RemotePlayerChatResult
 	RPLAYER_CHATRESULT_KICK,
 };
 
+struct CloudSettings
+{
+	float density;
+	video::SColor color_bright;
+	video::SColor color_ambient;
+};
+
 /*
 	Player on the server
 */
@@ -99,6 +106,16 @@ public:
 		*params = m_sky_params;
 	}
 
+	void setCloudSettings(const CloudSettings &cloud_settings)
+	{
+		m_cloud_settings = cloud_settings;
+	}
+
+	CloudSettings getCloudSettings() const
+	{
+		return m_cloud_settings;
+	}
+
 	bool checkModified() const { return m_dirty || inventory.checkModified(); }
 
 	void setModified(const bool x)
@@ -154,6 +171,7 @@ private:
 	std::string m_sky_type;
 	video::SColor m_sky_bgcolor;
 	std::vector<std::string> m_sky_params;
+	CloudSettings m_cloud_settings;
 };
 
 #endif

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define REMOTEPLAYER_HEADER
 
 #include "player.h"
+#include "cloudparameters.h"
 
 class PlayerSAO;
 
@@ -30,16 +31,6 @@ enum RemotePlayerChatResult
 	RPLAYER_CHATRESULT_OK,
 	RPLAYER_CHATRESULT_FLOODING,
 	RPLAYER_CHATRESULT_KICK,
-};
-
-struct CloudSettings
-{
-	float density;
-	video::SColor color_bright;
-	video::SColor color_ambient;
-	float thickness;
-	float height;
-	v2f speed;
 };
 
 /*
@@ -109,14 +100,14 @@ public:
 		*params = m_sky_params;
 	}
 
-	void setCloudSettings(const CloudSettings &cloud_settings)
+	void setCloudParameters(const CloudParameters &cloud_parameters)
 	{
-		m_cloud_settings = cloud_settings;
+		m_cloud_parameters = cloud_parameters;
 	}
 
-	const CloudSettings &getCloudSettings() const
+	const CloudParameters &getCloudParameters() const
 	{
-		return m_cloud_settings;
+		return m_cloud_parameters;
 	}
 
 	bool checkModified() const { return m_dirty || inventory.checkModified(); }
@@ -174,7 +165,7 @@ private:
 	std::string m_sky_type;
 	video::SColor m_sky_bgcolor;
 	std::vector<std::string> m_sky_params;
-	CloudSettings m_cloud_settings;
+	CloudParameters m_cloud_parameters;
 };
 
 #endif

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -37,6 +37,7 @@ struct CloudSettings
 	float density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
+	float height;
 };
 
 /*

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -38,6 +38,7 @@ struct CloudSettings
 	video::SColor color_bright;
 	video::SColor color_ambient;
 	float height;
+	v2f speed;
 };
 
 /*

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define REMOTEPLAYER_HEADER
 
 #include "player.h"
-#include "cloudparameters.h"
+#include "cloudparams.h"
 
 class PlayerSAO;
 
@@ -100,14 +100,14 @@ public:
 		*params = m_sky_params;
 	}
 
-	void setCloudParameters(const CloudParameters &cloud_parameters)
+	void setCloudParams(const CloudParams &cloud_params)
 	{
-		m_cloud_parameters = cloud_parameters;
+		m_cloud_params = cloud_params;
 	}
 
-	const CloudParameters &getCloudParameters() const
+	const CloudParams &getCloudParams() const
 	{
-		return m_cloud_parameters;
+		return m_cloud_params;
 	}
 
 	bool checkModified() const { return m_dirty || inventory.checkModified(); }
@@ -165,7 +165,7 @@ private:
 	std::string m_sky_type;
 	video::SColor m_sky_bgcolor;
 	std::vector<std::string> m_sky_params;
-	CloudParameters m_cloud_parameters;
+	CloudParams m_cloud_params;
 };
 
 #endif

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -114,7 +114,7 @@ public:
 		m_cloud_settings = cloud_settings;
 	}
 
-	CloudSettings getCloudSettings() const
+	const CloudSettings &getCloudSettings() const
 	{
 		return m_cloud_settings;
 	}

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -37,6 +37,7 @@ struct CloudSettings
 	float density;
 	video::SColor color_bright;
 	video::SColor color_ambient;
+	float thickness;
 	float height;
 	v2f speed;
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1727,7 +1727,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 	return 3;
 }
 
-// set_clouds(self, {density=, color=, ambient=, height=})
+// set_clouds(self, {density=, color=, ambient=, height=, thickness=, speed=})
 int ObjectRef::l_set_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1750,7 +1750,8 @@ int ObjectRef::l_set_clouds(lua_State *L)
 			read_color(L, -1, &cloud_settings.color_ambient);
 		lua_pop(L, 1);
 
-		cloud_settings.height = getfloatfield_default(L, 2, "height", cloud_settings.height);
+		cloud_settings.height    = getfloatfield_default(L, 2, "height",    cloud_settings.height   );
+		cloud_settings.thickness = getfloatfield_default(L, 2, "thickness", cloud_settings.thickness);
 
 		lua_getfield(L, 2, "speed");
 		if (lua_istable(L, -1))
@@ -1767,7 +1768,8 @@ int ObjectRef::l_set_clouds(lua_State *L)
 
 	if (!getServer(L)->setClouds(player, cloud_settings.density,
 			cloud_settings.color_bright, cloud_settings.color_ambient,
-			cloud_settings.height, cloud_settings.speed))
+			cloud_settings.height, cloud_settings.thickness,
+			cloud_settings.speed))
 		return 0;
 
 	player->setCloudSettings(cloud_settings);
@@ -1794,6 +1796,8 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	lua_setfield(L, -2, "ambient");
 	lua_pushnumber(L, cloud_settings.height);
 	lua_setfield(L, -2, "height");
+	lua_pushnumber(L, cloud_settings.thickness);
+	lua_setfield(L, -2, "thickness");
 	lua_newtable(L);
 	lua_pushnumber(L, cloud_settings.speed.X);
 	lua_setfield(L, -2, "x");

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1738,38 +1738,38 @@ int ObjectRef::l_set_clouds(lua_State *L)
 	if (!lua_istable(L, 2))
 		return 0;
 
-	CloudSettings cloud_settings = player->getCloudSettings();
+	CloudParameters cloud_parameters = player->getCloudParameters();
 
-	cloud_settings.density = getfloatfield_default(L, 2, "density", cloud_settings.density);
+	cloud_parameters.density = getfloatfield_default(L, 2, "density", cloud_parameters.density);
 
 	lua_getfield(L, 2, "color");
 	if (!lua_isnil(L, -1))
-		read_color(L, -1, &cloud_settings.color_bright);
+		read_color(L, -1, &cloud_parameters.color_bright);
 	lua_pop(L, 1);
 	lua_getfield(L, 2, "ambient");
 	if (!lua_isnil(L, -1))
-		read_color(L, -1, &cloud_settings.color_ambient);
+		read_color(L, -1, &cloud_parameters.color_ambient);
 	lua_pop(L, 1);
 
-	cloud_settings.height    = getfloatfield_default(L, 2, "height",    cloud_settings.height   );
-	cloud_settings.thickness = getfloatfield_default(L, 2, "thickness", cloud_settings.thickness);
+	cloud_parameters.height    = getfloatfield_default(L, 2, "height",    cloud_parameters.height   );
+	cloud_parameters.thickness = getfloatfield_default(L, 2, "thickness", cloud_parameters.thickness);
 
 	lua_getfield(L, 2, "speed");
 	if (lua_istable(L, -1)) {
 		v2f new_speed;
 		new_speed.X = getfloatfield_default(L, -1, "x", 0);
 		new_speed.Y = getfloatfield_default(L, -1, "y", 0);
-		cloud_settings.speed = new_speed;
+		cloud_parameters.speed = new_speed;
 	}
 	lua_pop(L, 1);
 
-	if (!getServer(L)->setClouds(player, cloud_settings.density,
-			cloud_settings.color_bright, cloud_settings.color_ambient,
-			cloud_settings.height, cloud_settings.thickness,
-			cloud_settings.speed))
+	if (!getServer(L)->setClouds(player, cloud_parameters.density,
+			cloud_parameters.color_bright, cloud_parameters.color_ambient,
+			cloud_parameters.height, cloud_parameters.thickness,
+			cloud_parameters.speed))
 		return 0;
 
-	player->setCloudSettings(cloud_settings);
+	player->setCloudParameters(cloud_parameters);
 
 	lua_pushboolean(L, true);
 	return 1;
@@ -1782,23 +1782,23 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	RemotePlayer *player = getplayer(ref);
 	if (!player)
 		return 0;
-	CloudSettings cloud_settings = player->getCloudSettings();
+	const CloudParameters &cloud_parameters = player->getCloudParameters();
 
 	lua_newtable(L);
-	lua_pushnumber(L, cloud_settings.density);
+	lua_pushnumber(L, cloud_parameters.density);
 	lua_setfield(L, -2, "density");
-	push_ARGB8(L, cloud_settings.color_bright);
+	push_ARGB8(L, cloud_parameters.color_bright);
 	lua_setfield(L, -2, "color");
-	push_ARGB8(L, cloud_settings.color_ambient);
+	push_ARGB8(L, cloud_parameters.color_ambient);
 	lua_setfield(L, -2, "ambient");
-	lua_pushnumber(L, cloud_settings.height);
+	lua_pushnumber(L, cloud_parameters.height);
 	lua_setfield(L, -2, "height");
-	lua_pushnumber(L, cloud_settings.thickness);
+	lua_pushnumber(L, cloud_parameters.thickness);
 	lua_setfield(L, -2, "thickness");
 	lua_newtable(L);
-	lua_pushnumber(L, cloud_settings.speed.X);
+	lua_pushnumber(L, cloud_parameters.speed.X);
 	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, cloud_settings.speed.Y);
+	lua_pushnumber(L, cloud_parameters.speed.Y);
 	lua_setfield(L, -2, "y");
 	lua_setfield(L, -2, "speed");
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1738,38 +1738,38 @@ int ObjectRef::l_set_clouds(lua_State *L)
 	if (!lua_istable(L, 2))
 		return 0;
 
-	CloudParameters cloud_parameters = player->getCloudParameters();
+	CloudParams cloud_params = player->getCloudParams();
 
-	cloud_parameters.density = getfloatfield_default(L, 2, "density", cloud_parameters.density);
+	cloud_params.density = getfloatfield_default(L, 2, "density", cloud_params.density);
 
 	lua_getfield(L, 2, "color");
 	if (!lua_isnil(L, -1))
-		read_color(L, -1, &cloud_parameters.color_bright);
+		read_color(L, -1, &cloud_params.color_bright);
 	lua_pop(L, 1);
 	lua_getfield(L, 2, "ambient");
 	if (!lua_isnil(L, -1))
-		read_color(L, -1, &cloud_parameters.color_ambient);
+		read_color(L, -1, &cloud_params.color_ambient);
 	lua_pop(L, 1);
 
-	cloud_parameters.height    = getfloatfield_default(L, 2, "height",    cloud_parameters.height   );
-	cloud_parameters.thickness = getfloatfield_default(L, 2, "thickness", cloud_parameters.thickness);
+	cloud_params.height    = getfloatfield_default(L, 2, "height",    cloud_params.height   );
+	cloud_params.thickness = getfloatfield_default(L, 2, "thickness", cloud_params.thickness);
 
 	lua_getfield(L, 2, "speed");
 	if (lua_istable(L, -1)) {
 		v2f new_speed;
 		new_speed.X = getfloatfield_default(L, -1, "x", 0);
 		new_speed.Y = getfloatfield_default(L, -1, "y", 0);
-		cloud_parameters.speed = new_speed;
+		cloud_params.speed = new_speed;
 	}
 	lua_pop(L, 1);
 
-	if (!getServer(L)->setClouds(player, cloud_parameters.density,
-			cloud_parameters.color_bright, cloud_parameters.color_ambient,
-			cloud_parameters.height, cloud_parameters.thickness,
-			cloud_parameters.speed))
+	if (!getServer(L)->setClouds(player, cloud_params.density,
+			cloud_params.color_bright, cloud_params.color_ambient,
+			cloud_params.height, cloud_params.thickness,
+			cloud_params.speed))
 		return 0;
 
-	player->setCloudParameters(cloud_parameters);
+	player->setCloudParams(cloud_params);
 
 	lua_pushboolean(L, true);
 	return 1;
@@ -1782,23 +1782,23 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	RemotePlayer *player = getplayer(ref);
 	if (!player)
 		return 0;
-	const CloudParameters &cloud_parameters = player->getCloudParameters();
+	const CloudParams &cloud_params = player->getCloudParams();
 
 	lua_newtable(L);
-	lua_pushnumber(L, cloud_parameters.density);
+	lua_pushnumber(L, cloud_params.density);
 	lua_setfield(L, -2, "density");
-	push_ARGB8(L, cloud_parameters.color_bright);
+	push_ARGB8(L, cloud_params.color_bright);
 	lua_setfield(L, -2, "color");
-	push_ARGB8(L, cloud_parameters.color_ambient);
+	push_ARGB8(L, cloud_params.color_ambient);
 	lua_setfield(L, -2, "ambient");
-	lua_pushnumber(L, cloud_parameters.height);
+	lua_pushnumber(L, cloud_params.height);
 	lua_setfield(L, -2, "height");
-	lua_pushnumber(L, cloud_parameters.thickness);
+	lua_pushnumber(L, cloud_params.thickness);
 	lua_setfield(L, -2, "thickness");
 	lua_newtable(L);
-	lua_pushnumber(L, cloud_parameters.speed.X);
+	lua_pushnumber(L, cloud_params.speed.X);
 	lua_setfield(L, -2, "x");
-	lua_pushnumber(L, cloud_parameters.speed.Y);
+	lua_pushnumber(L, cloud_params.speed.Y);
 	lua_setfield(L, -2, "y");
 	lua_setfield(L, -2, "speed");
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1727,13 +1727,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 	return 3;
 }
 
-#if 0
-static void _out_color(std::string name, video::SColorf color) {
-	dstream << name << ": (" << color.r << ", " << color.g << ", " << color.b << ")" << std::endl; 
-}
-#endif
-
-// set_clouds(self, {density=, color=, ambient=})
+// set_clouds(self, {density=, color=, ambient=, height=})
 int ObjectRef::l_set_clouds(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1755,11 +1749,14 @@ int ObjectRef::l_set_clouds(lua_State *L)
 		if (!lua_isnil(L, -1))
 			read_color(L, -1, &cloud_settings.color_ambient);
 		lua_pop(L, 1);
+
+		cloud_settings.height = getfloatfield_default(L, 2, "height", cloud_settings.height);
 	}
 
 
 	if (!getServer(L)->setClouds(player, cloud_settings.density,
-			cloud_settings.color_bright, cloud_settings.color_ambient))
+			cloud_settings.color_bright, cloud_settings.color_ambient,
+			cloud_settings.height))
 		return 0;
 
 	player->setCloudSettings(cloud_settings);
@@ -1784,6 +1781,8 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	lua_setfield(L, -2, "color");
 	push_ARGB8(L, cloud_settings.color_ambient);
 	lua_setfield(L, -2, "ambient");
+	lua_pushnumber(L, cloud_settings.height);
+	lua_setfield(L, -2, "height");
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1751,12 +1751,23 @@ int ObjectRef::l_set_clouds(lua_State *L)
 		lua_pop(L, 1);
 
 		cloud_settings.height = getfloatfield_default(L, 2, "height", cloud_settings.height);
+
+		lua_getfield(L, 2, "speed");
+		if (lua_istable(L, -1))
+		{
+			v2f new_speed;
+			new_speed.X = getfloatfield_default(L, -1, "x", 0);
+			new_speed.Y = getfloatfield_default(L, -1, "y", 0);
+			cloud_settings.speed = new_speed;
+		}
+		lua_pop(L, 1);
+
 	}
 
 
 	if (!getServer(L)->setClouds(player, cloud_settings.density,
 			cloud_settings.color_bright, cloud_settings.color_ambient,
-			cloud_settings.height))
+			cloud_settings.height, cloud_settings.speed))
 		return 0;
 
 	player->setCloudSettings(cloud_settings);
@@ -1783,6 +1794,12 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	lua_setfield(L, -2, "ambient");
 	lua_pushnumber(L, cloud_settings.height);
 	lua_setfield(L, -2, "height");
+	lua_newtable(L);
+	lua_pushnumber(L, cloud_settings.speed.X);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, cloud_settings.speed.Y);
+	lua_setfield(L, -2, "y");
+	lua_setfield(L, -2, "speed");
 
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1735,36 +1735,33 @@ int ObjectRef::l_set_clouds(lua_State *L)
 	RemotePlayer *player = getplayer(ref);
 	if (!player)
 		return 0;
+	if (!lua_istable(L, 2))
+		return 0;
+
 	CloudSettings cloud_settings = player->getCloudSettings();
 
-	if (lua_istable(L, 2)) {
+	cloud_settings.density = getfloatfield_default(L, 2, "density", cloud_settings.density);
 
-		cloud_settings.density = getfloatfield_default(L, 2, "density", cloud_settings.density);
+	lua_getfield(L, 2, "color");
+	if (!lua_isnil(L, -1))
+		read_color(L, -1, &cloud_settings.color_bright);
+	lua_pop(L, 1);
+	lua_getfield(L, 2, "ambient");
+	if (!lua_isnil(L, -1))
+		read_color(L, -1, &cloud_settings.color_ambient);
+	lua_pop(L, 1);
 
-		lua_getfield(L, 2, "color");
-		if (!lua_isnil(L, -1))
-			read_color(L, -1, &cloud_settings.color_bright);
-		lua_pop(L, 1);
-		lua_getfield(L, 2, "ambient");
-		if (!lua_isnil(L, -1))
-			read_color(L, -1, &cloud_settings.color_ambient);
-		lua_pop(L, 1);
+	cloud_settings.height    = getfloatfield_default(L, 2, "height",    cloud_settings.height   );
+	cloud_settings.thickness = getfloatfield_default(L, 2, "thickness", cloud_settings.thickness);
 
-		cloud_settings.height    = getfloatfield_default(L, 2, "height",    cloud_settings.height   );
-		cloud_settings.thickness = getfloatfield_default(L, 2, "thickness", cloud_settings.thickness);
-
-		lua_getfield(L, 2, "speed");
-		if (lua_istable(L, -1))
-		{
-			v2f new_speed;
-			new_speed.X = getfloatfield_default(L, -1, "x", 0);
-			new_speed.Y = getfloatfield_default(L, -1, "y", 0);
-			cloud_settings.speed = new_speed;
-		}
-		lua_pop(L, 1);
-
+	lua_getfield(L, 2, "speed");
+	if (lua_istable(L, -1)) {
+		v2f new_speed;
+		new_speed.X = getfloatfield_default(L, -1, "x", 0);
+		new_speed.Y = getfloatfield_default(L, -1, "y", 0);
+		cloud_settings.speed = new_speed;
 	}
-
+	lua_pop(L, 1);
 
 	if (!getServer(L)->setClouds(player, cloud_settings.density,
 			cloud_settings.color_bright, cloud_settings.color_ambient,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1783,7 +1783,7 @@ int ObjectRef::l_get_clouds(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == NULL)
+	if (!player)
 		return 0;
 	CloudSettings cloud_settings = player->getCloudSettings();
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -289,7 +289,7 @@ private:
 	// get_sky(self, type, list)
 	static int l_get_sky(lua_State *L);
 
-	// set_clouds(self, {density=, color=, ambient=, height=})
+	// set_clouds(self, {density=, color=, ambient=, height=, thickness=, speed=})
 	static int l_set_clouds(lua_State *L);
 
 	// get_clouds(self)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -289,6 +289,12 @@ private:
 	// get_sky(self, type, list)
 	static int l_get_sky(lua_State *L);
 
+	// set_clouds(self, {density=, color=, ambient=})
+	static int l_set_clouds(lua_State *L);
+
+	// get_clouds(self)
+	static int l_get_clouds(lua_State *L);
+
 	// override_day_night_ratio(self, type)
 	static int l_override_day_night_ratio(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -289,7 +289,7 @@ private:
 	// get_sky(self, type, list)
 	static int l_get_sky(lua_State *L);
 
-	// set_clouds(self, {density=, color=, ambient=})
+	// set_clouds(self, {density=, color=, ambient=, height=})
 	static int l_set_clouds(lua_State *L);
 
 	// get_clouds(self)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1884,10 +1884,11 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 
 void Server::SendSetClouds(u16 peer_id, const float density,
 		const video::SColor &color_bright,
-		const video::SColor &color_ambient)
+		const video::SColor &color_ambient,
+		const float height)
 {
 	NetworkPacket pkt(TOCLIENT_SET_CLOUDS, 0, peer_id);
-	pkt << (u16) (density  * 65535 ) << color_bright << color_ambient;
+	pkt << (u16) (density  * 65535 ) << color_bright << color_ambient << height;
 
 	Send(&pkt);
 }
@@ -3208,12 +3209,14 @@ bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
 
 bool Server::setClouds(RemotePlayer *player, const float density,
 	const video::SColor &color_bright,
-	const video::SColor &color_ambient)
+	const video::SColor &color_ambient,
+	const float height)
 {
 	if (!player)
 		return false;
 
-	SendSetClouds(player->peer_id, density, color_bright, color_ambient);
+	SendSetClouds(player->peer_id, density,
+			color_bright, color_ambient, height);
 	return true;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1882,15 +1882,15 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendCloudsParams(u16 peer_id, const float density,
+void Server::SendCloudsParams(u16 peer_id, float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
-		const float height,
-		const float thickness,
-		const v2f speed)
+		float height,
+		float thickness,
+		const v2f &speed)
 {
 	NetworkPacket pkt(TOCLIENT_CLOUDS_PARAMS, 0, peer_id);
-	pkt << (u16) (density  * 65535) << color_bright << color_ambient
+	pkt << density << color_bright << color_ambient
 			<< height << thickness << speed;
 
 	Send(&pkt);
@@ -3210,12 +3210,12 @@ bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
 	return true;
 }
 
-bool Server::setClouds(RemotePlayer *player, const float density,
+bool Server::setClouds(RemotePlayer *player, float density,
 	const video::SColor &color_bright,
 	const video::SColor &color_ambient,
-	const float height,
-	const float thickness,
-	const v2f speed)
+	float height,
+	float thickness,
+	const v2f &speed)
 {
 	if (!player)
 		return false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1886,11 +1886,12 @@ void Server::SendSetClouds(u16 peer_id, const float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		const float height,
+		const float thickness,
 		const v2f speed)
 {
 	NetworkPacket pkt(TOCLIENT_SET_CLOUDS, 0, peer_id);
 	pkt << (u16) (density  * 65535) << color_bright << color_ambient
-			<< height << speed;
+			<< height << thickness << speed;
 
 	Send(&pkt);
 }
@@ -3213,13 +3214,15 @@ bool Server::setClouds(RemotePlayer *player, const float density,
 	const video::SColor &color_bright,
 	const video::SColor &color_ambient,
 	const float height,
+	const float thickness,
 	const v2f speed)
 {
 	if (!player)
 		return false;
 
 	SendSetClouds(player->peer_id, density,
-			color_bright, color_ambient, height, speed);
+			color_bright, color_ambient, height,
+			thickness, speed);
 	return true;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1882,14 +1882,14 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendSetClouds(u16 peer_id, const float density,
+void Server::SendCloudsParams(u16 peer_id, const float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		const float height,
 		const float thickness,
 		const v2f speed)
 {
-	NetworkPacket pkt(TOCLIENT_SET_CLOUDS, 0, peer_id);
+	NetworkPacket pkt(TOCLIENT_CLOUDS_PARAMS, 0, peer_id);
 	pkt << (u16) (density  * 65535) << color_bright << color_ambient
 			<< height << thickness << speed;
 
@@ -3220,7 +3220,7 @@ bool Server::setClouds(RemotePlayer *player, const float density,
 	if (!player)
 		return false;
 
-	SendSetClouds(player->peer_id, density,
+	SendCloudsParams(player->peer_id, density,
 			color_bright, color_ambient, height,
 			thickness, speed);
 	return true;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1882,6 +1882,16 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
+void Server::SendSetClouds(u16 peer_id, const float density,
+		const video::SColor &color_bright,
+		const video::SColor &color_ambient)
+{
+	NetworkPacket pkt(TOCLIENT_SET_CLOUDS, 0, peer_id);
+	pkt << (u16) (density  * 65535 ) << color_bright << color_ambient;
+
+	Send(&pkt);
+}
+
 void Server::SendOverrideDayNightRatio(u16 peer_id, bool do_override,
 		float ratio)
 {
@@ -3193,6 +3203,17 @@ bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
 
 	player->setSky(bgcolor, type, params);
 	SendSetSky(player->peer_id, bgcolor, type, params);
+	return true;
+}
+
+bool Server::setClouds(RemotePlayer *player, const float density,
+	const video::SColor &color_bright,
+	const video::SColor &color_ambient)
+{
+	if (!player)
+		return false;
+
+	SendSetClouds(player->peer_id, density, color_bright, color_ambient);
 	return true;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1882,14 +1882,14 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendCloudsParams(u16 peer_id, float density,
+void Server::SendCloudParameters(u16 peer_id, float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		float height,
 		float thickness,
 		const v2f &speed)
 {
-	NetworkPacket pkt(TOCLIENT_CLOUDS_PARAMS, 0, peer_id);
+	NetworkPacket pkt(TOCLIENT_CLOUD_PARAMETERS, 0, peer_id);
 	pkt << density << color_bright << color_ambient
 			<< height << thickness << speed;
 
@@ -3220,7 +3220,7 @@ bool Server::setClouds(RemotePlayer *player, float density,
 	if (!player)
 		return false;
 
-	SendCloudsParams(player->peer_id, density,
+	SendCloudParameters(player->peer_id, density,
 			color_bright, color_ambient, height,
 			thickness, speed);
 	return true;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1885,10 +1885,12 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 void Server::SendSetClouds(u16 peer_id, const float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
-		const float height)
+		const float height,
+		const v2f speed)
 {
 	NetworkPacket pkt(TOCLIENT_SET_CLOUDS, 0, peer_id);
-	pkt << (u16) (density  * 65535 ) << color_bright << color_ambient << height;
+	pkt << (u16) (density  * 65535) << color_bright << color_ambient
+			<< height << speed;
 
 	Send(&pkt);
 }
@@ -3210,13 +3212,14 @@ bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
 bool Server::setClouds(RemotePlayer *player, const float density,
 	const video::SColor &color_bright,
 	const video::SColor &color_ambient,
-	const float height)
+	const float height,
+	const v2f speed)
 {
 	if (!player)
 		return false;
 
 	SendSetClouds(player->peer_id, density,
-			color_bright, color_ambient, height);
+			color_bright, color_ambient, height, speed);
 	return true;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1882,14 +1882,14 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendCloudParameters(u16 peer_id, float density,
+void Server::SendCloudParams(u16 peer_id, float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		float height,
 		float thickness,
 		const v2f &speed)
 {
-	NetworkPacket pkt(TOCLIENT_CLOUD_PARAMETERS, 0, peer_id);
+	NetworkPacket pkt(TOCLIENT_CLOUD_PARAMS, 0, peer_id);
 	pkt << density << color_bright << color_ambient
 			<< height << thickness << speed;
 
@@ -3220,7 +3220,7 @@ bool Server::setClouds(RemotePlayer *player, float density,
 	if (!player)
 		return false;
 
-	SendCloudParameters(player->peer_id, density,
+	SendCloudParams(player->peer_id, density,
 			color_bright, color_ambient, height,
 			thickness, speed);
 	return true;

--- a/src/server.h
+++ b/src/server.h
@@ -407,7 +407,7 @@ private:
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
-	void SendCloudsParams(u16 peer_id, float density,
+	void SendCloudParameters(u16 peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			float height,

--- a/src/server.h
+++ b/src/server.h
@@ -332,12 +332,12 @@ public:
 
 	bool setSky(RemotePlayer *player, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
-	bool setClouds(RemotePlayer *player, const float density,
+	bool setClouds(RemotePlayer *player, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
-			const float height,
-			const float thickness,
-			const v2f speed);
+			float height,
+			float thickness,
+			const v2f &speed);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
@@ -407,12 +407,12 @@ private:
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
-	void SendCloudsParams(u16 peer_id, const float density,
+	void SendCloudsParams(u16 peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
-			const float height,
-			const float thickness,
-			const v2f speed);
+			float height,
+			float thickness,
+			const v2f &speed);
 	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
 
 	/*

--- a/src/server.h
+++ b/src/server.h
@@ -336,6 +336,7 @@ public:
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			const float height,
+			const float thickness,
 			const v2f speed);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
@@ -410,6 +411,7 @@ private:
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			const float height,
+			const float thickness,
 			const v2f speed);
 	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
 

--- a/src/server.h
+++ b/src/server.h
@@ -334,7 +334,8 @@ public:
 			const std::string &type, const std::vector<std::string> &params);
 	bool setClouds(RemotePlayer *player, const float density,
 			const video::SColor &color_bright,
-			const video::SColor &color_ambient);
+			const video::SColor &color_ambient,
+			const float height);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
@@ -406,7 +407,8 @@ private:
 			const std::string &type, const std::vector<std::string> &params);
 	void SendSetClouds(u16 peer_id, const float density,
 			const video::SColor &color_bright,
-			const video::SColor &color_ambient);
+			const video::SColor &color_ambient,
+			const float height);
 	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
 
 	/*

--- a/src/server.h
+++ b/src/server.h
@@ -335,7 +335,8 @@ public:
 	bool setClouds(RemotePlayer *player, const float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
-			const float height);
+			const float height,
+			const v2f speed);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
@@ -408,7 +409,8 @@ private:
 	void SendSetClouds(u16 peer_id, const float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
-			const float height);
+			const float height,
+			const v2f speed);
 	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
 
 	/*

--- a/src/server.h
+++ b/src/server.h
@@ -407,7 +407,7 @@ private:
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
-	void SendSetClouds(u16 peer_id, const float density,
+	void SendCloudsParams(u16 peer_id, const float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			const float height,

--- a/src/server.h
+++ b/src/server.h
@@ -407,7 +407,7 @@ private:
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
-	void SendCloudParameters(u16 peer_id, float density,
+	void SendCloudParams(u16 peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			float height,

--- a/src/server.h
+++ b/src/server.h
@@ -332,6 +332,9 @@ public:
 
 	bool setSky(RemotePlayer *player, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
+	bool setClouds(RemotePlayer *player, const float density,
+			const video::SColor &color_bright,
+			const video::SColor &color_ambient);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);
 
@@ -401,6 +404,9 @@ private:
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
+	void SendSetClouds(u16 peer_id, const float density,
+			const video::SColor &color_bright,
+			const video::SColor &color_ambient);
 	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
 
 	/*

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -537,9 +537,9 @@ void Sky::update(float time_of_day, float time_brightness,
 	// pure white: becomes "diffuse light component" for clouds
 	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 255, 255, 255);
 	video::SColorf cloudcolor_bright_dawn_f = cloudcolor_bright_normal_f;
-	cloudcolor_bright_dawn_f.r *= 255.0/240.0;
-	cloudcolor_bright_dawn_f.g *= 223.0/240.0;
-	cloudcolor_bright_dawn_f.b *= 191.0/255.0;
+	cloudcolor_bright_dawn_f.r *= 255.0f/240.0f;
+	cloudcolor_bright_dawn_f.g *= 223.0f/240.0f;
+	cloudcolor_bright_dawn_f.b *= 191.0f/255.0f;
 
 	float cloud_color_change_fraction = 0.95;
 	if (sunlight_seen) {

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -534,8 +534,12 @@ void Sky::update(float time_of_day, float time_brightness,
 	video::SColorf skycolor_bright_dawn_f = video::SColor(255, 180, 186, 250);
 	video::SColorf skycolor_bright_night_f = video::SColor(255, 0, 107, 255);
 	
-	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 240, 240, 255);
-	video::SColorf cloudcolor_bright_dawn_f = video::SColor(255, 255, 223, 191);
+	// pure white: becomes "diffuse light component" for clouds
+	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 255, 255, 255);
+	video::SColorf cloudcolor_bright_dawn_f = cloudcolor_bright_normal_f;
+	cloudcolor_bright_dawn_f.r *= 255.0/240.0;
+	cloudcolor_bright_dawn_f.g *= 223.0/240.0;
+	cloudcolor_bright_dawn_f.b *= 191.0/255.0;
 
 	float cloud_color_change_fraction = 0.95;
 	if (sunlight_seen) {

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -536,10 +536,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	
 	// pure white: becomes "diffuse light component" for clouds
 	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 255, 255, 255);
-	video::SColorf cloudcolor_bright_dawn_f = cloudcolor_bright_normal_f;
-	cloudcolor_bright_dawn_f.r *= 255.0f/240.0f;
-	cloudcolor_bright_dawn_f.g *= 223.0f/240.0f;
-	cloudcolor_bright_dawn_f.b *= 191.0f/255.0f;
+	// dawn-factoring version of pure white (note: R is above 1.0)
+	video::SColorf cloudcolor_bright_dawn_f(255.0f/240.0f, 223.0f/240.0f, 191.0f/255.0f);
 
 	float cloud_color_change_fraction = 0.95;
 	if (sunlight_seen) {


### PR DESCRIPTION
This is a first attempt at a cloud API for mods, allowing them to set the cloud density (between 0.0 and 1.0), the cloud color, and a cloud "glow", i.e. a minimal brightness, even at night.

Includes a Lua player method for setting all parameters (at once), a new network package type and some accessors on the Clouds and Sky classes.

At the time of writing, this is very much a work in progress. There is no way for mods to get the current settings, or to change just one aspect of clouds. The network protocol is also quite rigid and assumes a fixed set of fields, which could be a problem for forward compatibility.

I'd also like to eventually rearrange the sky and cloud code a bit; at the moment, the Sky class holds the cloud color, because it's the only one that knows about dawn and transition times.

Comments welcome!
