### PR TITLE
Mgv7: Add optional floatlands

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -963,13 +963,27 @@ mgv6_np_apple_trees (Mapgen v6 apple trees noise parameters) noise_params 0, 1, 
 [***Mapgen v7]
 
 #    Map generation attributes specific to Mapgen v7.
-#    The 'ridges' flag controls the rivers.
+#    The 'ridges' flag enables the rivers.
+#    Floatlands are currently experimental and subject to change.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-mgv7_spflags (Mapgen v7 flags) flags mountains,ridges mountains,ridges,nomountains,noridges
+mgv7_spflags (Mapgen v7 flags) flags mountains,ridges mountains,ridges,floatlands,nomountains,noridges,nofloatlands
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Mapgen v7 cave width) float 0.2
+
+#    Controls the density of floatland mountain terrain.
+#    Is an offset added to the 'np_mountain' noise value.
+mgv7_float_mount_density (Mapgen v7 floatland mountain density) float 0.6
+
+#    Typical maximum height, above and below midpoint, of floatland mountain terrain.
+mgv7_float_mount_height (Mapgen v7 floatland mountain height) float 128.0
+
+#    Y-level of floatland midpoint and lake surface.
+mgv7_floatland_level (Mapgen v7 floatland level) int 1280
+
+#    Y-level to which floatland shadows extend.
+mgv7_shadow_limit (Mapgen v7 shadow limit) int 1024
 
 mgv7_np_terrain_base (Mapgen v7 terrain base noise parameters) noise_params 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 mgv7_np_terrain_alt (Mapgen v7 terrain altitude noise parameters) noise_params 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0
@@ -977,9 +991,11 @@ mgv7_np_terrain_persist (Mapgen v7 terrain persistation noise parameters) noise_
 mgv7_np_height_select (Mapgen v7 height select noise parameters) noise_params -8, 16, (500, 500, 500), 4213, 6, 0.7, 2.0
 mgv7_np_filler_depth (Mapgen v7 filler depth noise parameters) noise_params 0, 1.2, (150, 150, 150), 261, 3, 0.7, 2.0
 mgv7_np_mount_height (Mapgen v7 mount height noise parameters) noise_params 256, 112, (1000, 1000, 1000), 72449, 3, 0.6, 2.0
-mgv7_np_ridge_uwater (Mapgen v7 ridge water noise parameters) noise_params 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0
+mgv7_np_ridge_uwater (Mapgen v7 river course noise parameters) noise_params 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0
+mgv7_np_floatland_base (Mapgen v7 floatland base terrain noise parameters) noise_params -0.6, 1.5, (600, 600, 600), 114, 5, 0.6, 2.0
+mgv7_np_float_base_height (Mapgen v7 floatland base terrain height noise parameters) noise_params 48, 24, (300, 300, 300), 907, 4, 0.7, 2.0
 mgv7_np_mountain (Mapgen v7 mountain noise parameters) noise_params -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0
-mgv7_np_ridge (Mapgen v7 ridge noise parameters) noise_params 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+mgv7_np_ridge (Mapgen v7 river channel wall noise parameters) noise_params 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
 mgv7_np_cave1 (Mapgen v7 cave1 noise parameters) noise_params 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 mgv7_np_cave2 (Mapgen v7 cave2 noise parameters) noise_params 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1239,15 +1239,34 @@
 #### Mapgen v7
 
 #    Map generation attributes specific to Mapgen v7.
-#    The 'ridges' flag controls the rivers.
+#    The 'ridges' flag enables the rivers.
+#    Floatlands are currently experimental and subject to change.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-#    type: flags possible values: mountains, ridges, nomountains, noridges
+#    type: flags possible values: mountains, ridges, floatlands,
+#    nomountains, noridges, nofloatlands
 # mgv7_spflags = mountains,ridges
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
 # mgv7_cave_width = 0.2
+
+#    Controls the density of floatland mountain terrain.
+#    Is an offset added to the 'np_mountain' noise value.
+#    type: float
+# mgv7_float_mount_density = 0.6
+
+#    Typical maximum height, above and below midpoint, of floatland mountain terrain.
+#    type: float
+# mgv7_float_mount_height = 128.0
+
+#    Y-level of floatland midpoint and lake surface.
+#    type: int
+# mgv7_floatland_level = 1280
+
+#    Y-level to which floatland shadows extend.
+#    type: int
+# mgv7_shadow_limit = 1024
 
 #    type: noise_params
 # mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
@@ -1269,6 +1288,12 @@
 
 #    type: noise_params
 # mgv7_np_ridge_uwater = 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0
+
+#    type: noise_params
+# mgv7_np_floatland_base = -0.6, 1.5, (600, 600, 600), 114, 5, 0.6, 2.0
+
+#    type: noise_params
+# mgv7_np_float_base_height = 48, 24, (300, 300, 300), 907, 4, 0.7, 2.0
 
 #    type: noise_params
 # mgv7_np_mountain = -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -23,9 +23,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-/////////////////// Mapgen V7 flags
-#define MGV7_MOUNTAINS   0x01
-#define MGV7_RIDGES      0x02
+////////////// Mapgen V7 flags
+#define MGV7_MOUNTAINS    0x01
+#define MGV7_RIDGES       0x02
+#define MGV7_FLOATLANDS   0x04
 
 class BiomeManager;
 
@@ -35,6 +36,11 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	u32 spflags;
 	float cave_width;
+	float float_mount_density;
+	float float_mount_height;
+	s16 floatland_level;
+	s16 shadow_limit;
+
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_alt;
 	NoiseParams np_terrain_persist;
@@ -42,6 +48,8 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_filler_depth;
 	NoiseParams np_mount_height;
 	NoiseParams np_ridge_uwater;
+	NoiseParams np_floatland_base;
+	NoiseParams np_float_base_height;
 	NoiseParams np_mountain;
 	NoiseParams np_ridge;
 	NoiseParams np_cave1;
@@ -68,16 +76,26 @@ public:
 	float baseTerrainLevelFromMap(int index);
 	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
 	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
+	bool getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y);
+	void floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max, int idx_xz);
+
 	int generateTerrain();
 	void generateRidgeTerrain();
 
 private:
+	float float_mount_density;
+	float float_mount_height;
+	s16 floatland_level;
+	s16 shadow_limit;
+
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
 	Noise *noise_terrain_persist;
 	Noise *noise_height_select;
 	Noise *noise_mount_height;
 	Noise *noise_ridge_uwater;
+	Noise *noise_floatland_base;
+	Noise *noise_float_base_height;
 	Noise *noise_mountain;
 	Noise *noise_ridge;
 };


### PR DESCRIPTION
![screenshot_20160918_082058](https://cloud.githubusercontent.com/assets/3686677/18613882/90bfdc38-7d7b-11e6-91e8-0f6add9c3f70.png)

^ The sharp ridges around the water have been smoothed out now using the 'smoothstep function'.

![screenshot_20160924_210747](https://cloud.githubusercontent.com/assets/3686677/18853454/272a5dca-843d-11e6-8651-f36eaa7a7afc.png)

Consists of 3D noise 'floatland mountains' and smooth 2D noise water basins containing default:water_source. Both are shaped for a 'double-pyramid' form (stereotypical flying island form) mirrored around the centre y value. The centre y value is intended to suggest a 'sea level' but here the sea being the blue of sky below. The floatlands are intended to suggest islands floating in the blue sea of sky. To reinforce this analogy the floatland water is also at this centre y value.

At the centre y value floatlands cover roughly half of the area. Not too far apart for bridge building or so far apart that other islands remain unseen, not too dense that everything is connected and bridges are never needed.

To test teleport to y = 1280 with fly and noclip enabled. Note that biomes will be a mess at the floatlands with trees underwater, we will need dedicated floatland biomes in MTGame.
Currently in this branch floatlands are enabled by default, they will be disabled by default if/when merged.
Docs will be updated closer to merge to avoid conflicts..

Mgv7 mountain noise is used to create the main floatlands (the rougher, higher structures), avoiding the need for another 3D noise.
2 2D noises (inherenty lightweight) are added to create the smoother, lower land and lakes. Because river noises (1 2D and 1 3D) are not calculated for floatlands performance actually increases.
Floatland ores are enabled above y = 1024 so the floatlands are very ore-rich, to compensate for the lack of mass.

There are additional parameters for:
- Floatland level, by default y = 1280.
- Y at which shadows do not propagate, and above which rivers are not cut, by default y = 1024.
- Density of the rough floatlands (as an offset added to mgv7 mountain noise).
- Vertical scale of the rough floatlands.

The 'way to get up there' will be left to mods, possibly a mod in MTGame. I have an idea for a 'structure / tower' created by schematic units, appearing at certain places in the world.
Code will be added to MTGame to detect the floatland mapgen flag and register suitable biomes (probably a simplified set of biomes at first, later maybe some special biomes).
Floatland terrain and floatland biomes will not be stable for 0.4.15. The floatlands will be disabled by default.
