### PR TITLE
Do not serialize empty NodeMetadata

### DIFF
--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -47,6 +47,7 @@ public:
 	void deSerialize(std::istream &is);
 
 	void clear();
+	bool empty() const;
 
 	// Generic key/value store
 	std::string getString(const std::string &name, unsigned short recursion = 0) const;
@@ -94,6 +95,8 @@ public:
 	void clear();
 
 private:
+	int countNonEmpty() const;
+
 	std::map<v3s16, NodeMetadata *> m_data;
 };
 


### PR DESCRIPTION
This commit fixes #4516, though note that this will gradually fix MapBlocks
as they are used/modified and thus re-serialized.

(I tested this and verified that it fixes the problem, obviously.)