### PR TITLE
Builtin: Change error to warning for light_source > 14

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -128,7 +128,9 @@ function core.register_item(name, itemdef)
 			}
 		end
 		if itemdef.light_source and itemdef.light_source > core.LIGHT_MAX then
-			error("Unable to register node: 'light_source' exceeds maximum: " .. name)
+			itemdef.light_source = core.LIGHT_MAX
+			core.log("warning", "Node 'light_source' value exceeds maximum," ..
+				" limiting to maximum: " ..name)
 		end
 		setmetatable(itemdef, {__index = core.nodedef_default})
 		core.registered_nodes[itemdef.name] = itemdef


### PR DESCRIPTION
As requested https://github.com/minetest/minetest/commit/3aefa5d3ceaaa9299f42cc10921dec65fa53c5e0#commitcomment-19105454
The light source value of 15 is widespread and likely to persist for months, some players may not know how to edit the value.