### PR TITLE
Conf.example: Re-add deleted noise parameter documentation

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -659,5 +659,12 @@ function create_adv_settings_dlg()
 				return dlg
 end
 
--- generate minetest.conf.example and settings_translation_file.cpp:
+-- Generate minetest.conf.example and settings_translation_file.cpp
+
+-- *** Please note ***
+-- There is text in minetest.conf.example that will not be generated from
+-- settingtypes.txt but must be preserved:
+-- The documentation of mapgen noise parameter formats (title plus 16 lines)
+-- Noise parameter 'mgv5_np_ground' in group format (13 lines)
+
 --assert(loadfile(core.get_mainmenu_path()..DIR_DELIM.."generate_from_settingtypes.lua"))(parse_config_file(true, false))

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1099,6 +1099,25 @@
 #    type: int
 # num_emerge_threads = 1
 
+#### Noise parameters and formats
+
+#    Noise parameters can be specified as a set of positional values, for example:
+#    Offset, scale, (spread factors), seed offset, number of octaves, persistence, lacunarity
+# mgv6_np_terrain_base = -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0
+#    Or the group format can be used instead, for example:
+# mgv6_np_terrain_base = {
+#    offset      = -4,
+#    scale       = 20,
+#    spread      = (250, 250, 250),
+#    seed        = 82341,
+#    octaves     = 5,
+#    persistence = 0.6,
+#    lacunarity  = 2.0,
+#    flags       = "defaults"
+# }
+#    Only the group format supports noise flags which are needed for eased noise.
+#    Mgv5 uses eased noise for np_ground so this is shown in group format below.
+
 #    Noise parameters for biome API temperature, humidity and biome blend.
 #    type: noise_params
 # mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
@@ -1132,6 +1151,20 @@
 
 #    type: noise_params
 # mgv5_np_cave2 = 0, 12, (50, 50, 50), 10325, 4, 0.5, 2.0
+
+#    Noise parameters in group format, unsupported by advanced settings
+#    menu but settable in minetest.conf.
+#    See documentation of noise parameter formats above.
+# mgv5_np_ground = {
+#    offset      = 0,
+#    scale       = 40,
+#    spread      = (80, 80, 80),
+#    seed        = 983240,
+#    octaves     = 4,
+#    persistence = 0.55,
+#    lacunarity  = 2.0,
+#    flags       = "eased"
+# }
 
 #### Mapgen v6
 


### PR DESCRIPTION
Re-add documentation of noise parameter formats.
Re-add 'mgv5_np_ground' noise parameters in group format.
Both these were deleted through auto-generation of conf.example.
Add note to builtin/mainmenu/dlg_settings_advanced.lua that this
documentation must be preserved.
///////////////////////////////////////////////

See #4390 
Addresses part of #4390 