### PR TITLE
Add coloured logs

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1160,6 +1160,13 @@ language (Language) enum   ,be,ca,cs,da,de,en,eo,es,et,fr,he,hu,id,it,ja,jbo,ko,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
+#    ANSI colored logs: red error log, yellow warning and grey info and verbose logs
+#    Note that it doesn't work on Windows
+#    "yes" always enables it,
+#    "detect" enables it when printing to terminal and
+#    "no" disables it
+log_color (Colored logs) enum detect yes,detect,no
+
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -351,6 +351,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
+	settings->setDefault("log_color", "detect");
 	settings->setDefault("emergequeue_limit_total", "256");
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");


### PR DESCRIPTION
error is red, warning is yellow, info is grey and verbose is darker grey
![colg](https://cloud.githubusercontent.com/assets/3192173/18831341/7c348136-83e5-11e6-87cc-d9ff292e5287.png)
