### PR TITLE
Fix backwards compatibility issue introduced by close_on_enter

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1542,7 +1542,7 @@ examples.
 * If `true` the background is clipped to formspec size
   (`x` and `y` are used as offset values, `w` and `h` are ignored)
 
-#### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>;<close_on_enter>]`
+#### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>]`
 * Textual password style field; will be sent to server when a button is clicked
 * When enter is pressed in field, fields.key_enter_field will be sent with the name
   of this field.
@@ -1552,10 +1552,9 @@ examples.
 * Position and size units are inventory slots
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
-* `close_on_enter` (optional) is whether the form should accept and close when enter is
-  pressed in this field. Defaults to true.
+* See field_close_on_enter to stop enter closing the formspec
 
-#### `field[<X>,<Y>;<W>,<H>;<name>;<label>;<default>;<close_on_enter>]`
+#### `field[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 * Textual field; will be sent to server when a button is clicked
 * When enter is pressed in field, fields.key_enter_field will be sent with the name
   of this field.
@@ -1569,18 +1568,21 @@ examples.
     * `default` may contain variable references such as `${text}'` which
       will fill the value from the metadata value `text`
     * **Note**: no extra text or more than a single variable is supported ATM.
-* `close_on_enter` (optional) is whether the form should accept and close when enter is
-  pressed in this field. Defaults to true.
+* See field_close_on_enter to stop enter closing the formspec
 
-#### `field[<name>;<label>;<default>;<close_on_enter>]`
+#### `field[<name>;<label>;<default>]`
 * As above, but without position/size units
 * When enter is pressed in field, fields.key_enter_field will be sent with the name
   of this field.
 * Special field for creating simple forms, such as sign text input
 * Must be used without a `size[]` element
 * A "Proceed" button will be added automatically
-* `close_on_enter` (optional) is whether the form should accept and close when enter is
-  pressed in this field. Defaults to true.
+* See field_close_on_enter to stop enter closing the formspec
+
+#### `field_close_on_enter[<name>;<close_on_enter>]`
+* <name> is the name of the field
+* if <close_on_enter> is false, pressing enter in the field will submit the form but not close it
+* defaults to true when not specified (ie: no tag for a field)
 
 #### `textarea[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 * Same as fields above, but with multi-line input

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -212,7 +212,6 @@ class GUIFormSpecMenu : public GUIModalMenu
 			flabel(label),
 			fid(id),
 			send(false),
-			close_on_enter(false),
 			ftype(f_Unknown),
 			is_exit(false)
 		{
@@ -224,7 +223,6 @@ class GUIFormSpecMenu : public GUIModalMenu
 		std::wstring fdefault;
 		int fid;
 		bool send;
-		bool close_on_enter; // used by text fields
 		FormspecFieldType ftype;
 		bool is_exit;
 		core::rect<s32> rect;
@@ -400,6 +398,7 @@ protected:
 	std::vector<ImageDrawSpec> m_images;
 	std::vector<ImageDrawSpec> m_itemimages;
 	std::vector<BoxDrawSpec> m_boxes;
+	UNORDERED_MAP<std::string, bool> field_close_on_enter;
 	std::vector<FieldSpec> m_fields;
 	std::vector<StaticTextSpec> m_static_texts;
 	std::vector<std::pair<FieldSpec,GUITable*> > m_tables;
@@ -492,6 +491,7 @@ private:
 	void parseTable(parserData* data,std::string element);
 	void parseTextList(parserData* data,std::string element);
 	void parseDropDown(parserData* data,std::string element);
+	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
 	void parsePwdField(parserData* data,std::string element);
 	void parseField(parserData* data,std::string element,std::string type);
 	void parseSimpleField(parserData* data,std::vector<std::string> &parts);


### PR DESCRIPTION
e10fee00011f6c1ef8ee5b884adb11013954a1c9 (#4417) added a new parameter to the `field[]` element, which caused problems with older clients rejecting elements with too many parameters. This caused fields which disable close on enter to disappear

# Solutions

* Increase formspec version:
    * This makes old clients simply ignore additional parameters and render the field as before.
    * However, this has never been done before
* Depreciate the new parameter and add `field_close_on_enter[name, bool]`. I chose this because:
    * increasing the version doesn't help if the server is also old as well. Additionally, the version has never been increased which is a little iffy
    * it's more readable

This PR adds a map (`std::map<std::string, bool>`) to store whether a field closes on enter. This was done for simplicity reasons - modders can add the field_close_on_enter tag before or after the field tag, and there's no need to search for the field and then change its spec