### PR TITLE
Damage flash: Reduce maximum alpha. Avoid fade overload 

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3374,12 +3374,12 @@ void Game::processClientEvents(CameraOrientation *cam, float *damage_flash)
 			//u16 damage = event.player_damage.amount;
 			//infostream<<"Player damage: "<<damage<<std::endl;
 
-			*damage_flash += 100.0;
-			*damage_flash += 8.0 * event.player_damage.amount;
+			*damage_flash += 95.0 + 3.2 * event.player_damage.amount;
+			*damage_flash = MYMIN(*damage_flash, 127.0);
 
 			player->hurt_tilt_timer = 1.5;
-			player->hurt_tilt_strength = event.player_damage.amount / 4;
-			player->hurt_tilt_strength = rangelim(player->hurt_tilt_strength, 1.0, 4.0);
+			player->hurt_tilt_strength =
+				rangelim(event.player_damage.amount / 4, 1.0, 4.0);
 
 			MtEvent *e = new SimpleTriggerEvent("PlayerDamage");
 			gamedef->event()->put(e);
@@ -4285,10 +4285,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats,
 		Damage flash
 	*/
 	if (runData->damage_flash > 0.0) {
-		video::SColor color(std::min(runData->damage_flash, 180.0f),
-				180,
-				0,
-				0);
+		video::SColor color(runData->damage_flash, 180, 0, 0);
 		driver->draw2DRectangle(color,
 					core::rect<s32>(0, 0, screensize.X, screensize.Y),
 					NULL);


### PR DESCRIPTION
Flash alpha maximum is reduced from 180 to 127 to avoid player blindness
in combat. Flash alpha minimum is unchanged.
The 'damage_flash' value is now limited to max alpha, to avoid multiple
hits creating a huge value that causes flash to stay at maximum alpha
for a long period. Now alpha always starts to fade immediately after
taking damage.
Both problems can be seen in Minetest let's play videos.
Simplify and optimise some code.
///////////////////////////////////////////////////

![screenshot_20161006_232053](https://cloud.githubusercontent.com/assets/3686677/19172793/a6c263e4-8c1b-11e6-9530-45eabcdc1d8c.png)

![screenshot_20161005_033030](https://cloud.githubusercontent.com/assets/3686677/19099215/38bb1a28-8aac-11e6-967c-423ee2830d2c.png)

^ This is what the new maximum alpha of 127 looks like, half-obscured vision instead of 2/3rds obscured, not enough to blind in dark areas.

![screenshot_20161005_011730](https://cloud.githubusercontent.com/assets/3686677/19097219/cc6e560c-8a9a-11e6-9e7d-aa1f3ea2dad6.png)

^ Test structure for fall damage. 6 nodes takes 1HP, 15 nodes takes 10HP.

See #3429 #3691 

Updated: I have now left flash fade time unchanged, this PR simply deals with the problems of player blindness due to excessive alpha (180 is 2/3rds obscured vision), and deals with alpha overload on multple hits. This PR adds no settings.
Updated to not reduce flash alpha minimum, only maximum. Taking small amounts of damage will now be as before.
Video of 20s flash overload and current max alpha https://www.youtube.com/watch?v=4UosiB94A1w&feature=youtu.be&t=1105