### PR TITLE
Replace various std::map with UNORDERED_MAP + various cleanups

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -303,7 +303,7 @@ Client::~Client()
 	delete m_inventory_from_server;
 
 	// Delete detached inventories
-	for (std::map<std::string, Inventory*>::iterator
+	for (UNORDERED_MAP<std::string, Inventory*>::iterator
 			i = m_detached_inventories.begin();
 			i != m_detached_inventories.end(); ++i) {
 		delete i->second;
@@ -1437,7 +1437,7 @@ Inventory* Client::getInventory(const InventoryLocation &loc)
 	break;
 	case InventoryLocation::DETACHED:
 	{
-		if(m_detached_inventories.count(loc.name) == 0)
+		if (m_detached_inventories.count(loc.name) == 0)
 			return NULL;
 		return m_detached_inventories[loc.name];
 	}

--- a/src/client.h
+++ b/src/client.h
@@ -462,7 +462,7 @@ public:
 	u16 getHP();
 	u16 getBreath();
 
-	bool checkPrivilege(const std::string &priv)
+	bool checkPrivilege(const std::string &priv) const
 	{ return (m_privileges.count(priv) != 0); }
 
 	bool getChatMessage(std::wstring &message);
@@ -670,11 +670,11 @@ private:
 	std::map<int, u16> m_sounds_to_objects;
 
 	// Privileges
-	std::set<std::string> m_privileges;
+	UNORDERED_SET<std::string> m_privileges;
 
 	// Detached inventories
 	// key = name
-	std::map<std::string, Inventory*> m_detached_inventories;
+	UNORDERED_MAP<std::string, Inventory*> m_detached_inventories;
 
 	// Storage for mesh data for creating multiple instances of the same mesh
 	StringMap m_mesh_data;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -605,11 +605,8 @@ ClientInterface::~ClientInterface()
 	{
 		MutexAutoLock clientslock(m_clients_mutex);
 
-		for(std::map<u16, RemoteClient*>::iterator
-			i = m_clients.begin();
-			i != m_clients.end(); ++i)
-		{
-
+		for (UNORDERED_MAP<u16, RemoteClient*>::iterator i = m_clients.begin();
+			i != m_clients.end(); ++i) {
 			// Delete client
 			delete i->second;
 		}
@@ -621,10 +618,8 @@ std::vector<u16> ClientInterface::getClientIDs(ClientState min_state)
 	std::vector<u16> reply;
 	MutexAutoLock clientslock(m_clients_mutex);
 
-	for(std::map<u16, RemoteClient*>::iterator
-		i = m_clients.begin();
-		i != m_clients.end(); ++i)
-	{
+	for(UNORDERED_MAP<u16, RemoteClient*>::iterator i = m_clients.begin();
+		i != m_clients.end(); ++i) {
 		if (i->second->getState() >= min_state)
 			reply.push_back(i->second->peer_id);
 	}
@@ -691,8 +686,7 @@ void ClientInterface::sendToAll(u16 channelnum,
 		NetworkPacket* pkt, bool reliable)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
-	for(std::map<u16, RemoteClient*>::iterator
-		i = m_clients.begin();
+	for(UNORDERED_MAP<u16, RemoteClient*>::iterator i = m_clients.begin();
 		i != m_clients.end(); ++i) {
 		RemoteClient *client = i->second;
 
@@ -705,11 +699,10 @@ void ClientInterface::sendToAll(u16 channelnum,
 RemoteClient* ClientInterface::getClientNoEx(u16 peer_id, ClientState state_min)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
-	if(n == m_clients.end())
+	if (n == m_clients.end())
 		return NULL;
 
 	if (n->second->getState() >= state_min)
@@ -720,11 +713,10 @@ RemoteClient* ClientInterface::getClientNoEx(u16 peer_id, ClientState state_min)
 
 RemoteClient* ClientInterface::lockedGetClientNoEx(u16 peer_id, ClientState state_min)
 {
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
-	if(n == m_clients.end())
+	if (n == m_clients.end())
 		return NULL;
 
 	if (n->second->getState() >= state_min)
@@ -736,11 +728,10 @@ RemoteClient* ClientInterface::lockedGetClientNoEx(u16 peer_id, ClientState stat
 ClientState ClientInterface::getClientState(u16 peer_id)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
-	if(n == m_clients.end())
+	if (n == m_clients.end())
 		return CS_Invalid;
 
 	return n->second->getState();
@@ -749,11 +740,10 @@ ClientState ClientInterface::getClientState(u16 peer_id)
 void ClientInterface::setPlayerName(u16 peer_id,std::string name)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
-	if(n != m_clients.end())
+	if (n != m_clients.end())
 		n->second->setName(name);
 }
 
@@ -762,11 +752,10 @@ void ClientInterface::DeleteClient(u16 peer_id)
 	MutexAutoLock conlock(m_clients_mutex);
 
 	// Error check
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
-	if(n == m_clients.end())
+	if (n == m_clients.end())
 		return;
 
 	/*
@@ -797,10 +786,9 @@ void ClientInterface::CreateClient(u16 peer_id)
 	MutexAutoLock conlock(m_clients_mutex);
 
 	// Error check
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 	// The client shouldn't already exist
-	if(n != m_clients.end()) return;
+	if (n != m_clients.end()) return;
 
 	// Create client
 	RemoteClient *client = new RemoteClient();
@@ -814,8 +802,7 @@ void ClientInterface::event(u16 peer_id, ClientStateEvent event)
 		MutexAutoLock clientlock(m_clients_mutex);
 
 		// Error check
-		std::map<u16, RemoteClient*>::iterator n;
-		n = m_clients.find(peer_id);
+		UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 
 		// No client to deliver event
 		if (n == m_clients.end())
@@ -836,8 +823,7 @@ u16 ClientInterface::getProtocolVersion(u16 peer_id)
 	MutexAutoLock conlock(m_clients_mutex);
 
 	// Error check
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 
 	// No client to get version
 	if (n == m_clients.end())
@@ -851,8 +837,7 @@ void ClientInterface::setClientVersion(u16 peer_id, u8 major, u8 minor, u8 patch
 	MutexAutoLock conlock(m_clients_mutex);
 
 	// Error check
-	std::map<u16, RemoteClient*>::iterator n;
-	n = m_clients.find(peer_id);
+	UNORDERED_MAP<u16, RemoteClient*>::iterator n = m_clients.find(peer_id);
 
 	// No client to set versions
 	if (n == m_clients.end())

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -25,10 +25,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serialization.h"             // for SER_FMT_VER_INVALID
 #include "threading/mutex.h"
 #include "network/networkpacket.h"
+#include "util/cpp11_container.h"
 
 #include <list>
 #include <vector>
-#include <map>
 #include <set>
 
 class MapBlock;
@@ -502,8 +502,7 @@ protected:
 	void lock() { m_clients_mutex.lock(); }
 	void unlock() { m_clients_mutex.unlock(); }
 
-	std::map<u16, RemoteClient*>& getClientList()
-		{ return m_clients; }
+	UNORDERED_MAP<u16, RemoteClient*>& getClientList() { return m_clients; }
 
 private:
 	/* update internal player list */
@@ -513,7 +512,7 @@ private:
 	con::Connection* m_con;
 	Mutex m_clients_mutex;
 	// Connected clients (behind the con mutex)
-	std::map<u16, RemoteClient*> m_clients;
+	UNORDERED_MAP<u16, RemoteClient*> m_clients;
 	std::vector<std::string> m_clients_names; //for announcing masterserver
 
 	// Environment

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1505,10 +1505,8 @@ void GenericCAO::updateBonePosition()
 		return;
 
 	m_animated_meshnode->setJointMode(irr::scene::EJUOR_CONTROL); // To write positions to the mesh on render
-	for(std::map<std::string,
-			core::vector2d<v3f> >::const_iterator ii = m_bone_position.begin();
-			ii != m_bone_position.end(); ++ii)
-	{
+	for(UNORDERED_MAP<std::string, core::vector2d<v3f> >::const_iterator
+			ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii) {
 		std::string bone_name = (*ii).first;
 		v3f bone_pos = (*ii).second.X;
 		v3f bone_rot = (*ii).second.Y;

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -90,7 +90,7 @@ private:
 	int m_animation_speed;
 	int m_animation_blend;
 	bool m_animation_loop;
-	std::map<std::string, core::vector2d<v3f> > m_bone_position; // stores position and rotation for each bone name
+	UNORDERED_MAP<std::string, core::vector2d<v3f> > m_bone_position; // stores position and rotation for each bone name
 	std::string m_attachment_bone;
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -369,12 +369,10 @@ bool EmergeManager::pushBlockEmergeData(
 }
 
 
-bool EmergeManager::popBlockEmergeData(
-	v3s16 pos,
-	BlockEmergeData *bedata)
+bool EmergeManager::popBlockEmergeData(v3s16 pos, BlockEmergeData *bedata)
 {
 	std::map<v3s16, BlockEmergeData>::iterator it;
-	std::map<u16, u16>::iterator it2;
+	UNORDERED_MAP<u16, u16>::iterator it2;
 
 	it = m_blocks_enqueued.find(pos);
 	if (it == m_blocks_enqueued.end())

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -156,7 +156,7 @@ private:
 
 	Mutex m_queue_mutex;
 	std::map<v3s16, BlockEmergeData> m_blocks_enqueued;
-	std::map<u16, u16> m_peer_queue_count;
+	UNORDERED_MAP<u16, u16> m_peer_queue_count;
 
 	u16 m_qlimit_total;
 	u16 m_qlimit_diskonly;

--- a/src/environment.h
+++ b/src/environment.h
@@ -300,6 +300,8 @@ enum ClearObjectsMode {
 	This is not thread-safe. Server uses an environment mutex.
 */
 
+typedef UNORDERED_MAP<u16, ServerActiveObject *> ActiveObjectMap;
+
 class ServerEnvironment : public Environment
 {
 public:
@@ -338,7 +340,7 @@ public:
 	void loadDefaultMeta();
 
 	u32 addParticleSpawner(float exptime);
-	void deleteParticleSpawner(u32 id);
+	void deleteParticleSpawner(u32 id) { m_particle_spawners.erase(id); }
 
 	/*
 		External ActiveObject interface
@@ -491,7 +493,7 @@ private:
 	// World path
 	const std::string m_path_world;
 	// Active object list
-	std::map<u16, ServerActiveObject*> m_active_objects;
+	ActiveObjectMap m_active_objects;
 	// Outgoing network message buffer for active objects
 	std::queue<ActiveObjectMessage> m_active_object_messages;
 	// Some timers
@@ -522,7 +524,7 @@ private:
 
 	// Particles
 	IntervalLimiter m_particle_management_interval;
-	std::map<u32, float> m_particle_spawners;
+	UNORDERED_MAP<u32, float> m_particle_spawners;
 };
 
 #ifndef SERVER

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -605,7 +605,7 @@ public:
 	void draw(s32 x_left, s32 y_bottom, video::IVideoDriver *driver,
 		  gui::IGUIFont *font) const
 	{
-		std::map<std::string, Meta> m_meta;
+		UNORDERED_MAP<std::string, Meta> m_meta;
 
 		for (std::deque<Piece>::const_iterator k = m_log.begin();
 				k != m_log.end(); ++k) {
@@ -615,8 +615,7 @@ public:
 					i != piece.values.end(); ++i) {
 				const std::string &id = i->first;
 				const float &value = i->second;
-				std::map<std::string, Meta>::iterator j =
-					m_meta.find(id);
+				UNORDERED_MAP<std::string, Meta>::iterator j = m_meta.find(id);
 
 				if (j == m_meta.end()) {
 					m_meta[id] = Meta(value);
@@ -643,7 +642,7 @@ public:
 			sizeof(usable_colors) / sizeof(*usable_colors);
 		u32 next_color_i = 0;
 
-		for (std::map<std::string, Meta>::iterator i = m_meta.begin();
+		for (UNORDERED_MAP<std::string, Meta>::iterator i = m_meta.begin();
 				i != m_meta.end(); ++i) {
 			Meta &meta = i->second;
 			video::SColor color(255, 200, 200, 200);
@@ -659,7 +658,7 @@ public:
 		s32 textx2 = textx + 200 - 15;
 		s32 meta_i = 0;
 
-		for (std::map<std::string, Meta>::const_iterator i = m_meta.begin();
+		for (UNORDERED_MAP<std::string, Meta>::const_iterator i = m_meta.begin();
 				i != m_meta.end(); ++i) {
 			const std::string &id = i->first;
 			const Meta &meta = i->second;

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -146,9 +146,9 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	}
 	os<<serializeString(tool_capabilities_s);
 	writeU16(os, groups.size());
-	for(std::map<std::string, int>::const_iterator
+	for (ItemGroupList::const_iterator
 			i = groups.begin(); i != groups.end(); ++i){
-		os<<serializeString(i->first);
+		os << serializeString(i->first);
 		writeS16(os, i->second);
 	}
 	os<<serializeString(node_placement_prediction);

--- a/src/itemgroup.h
+++ b/src/itemgroup.h
@@ -21,14 +21,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define ITEMGROUP_HEADER
 
 #include <string>
-#include <map>
+#include "util/cpp11_container.h"
 
-typedef std::map<std::string, int> ItemGroupList;
+typedef UNORDERED_MAP<std::string, int> ItemGroupList;
 
 static inline int itemgroup_get(const ItemGroupList &groups,
 		const std::string &name)
 {
-	std::map<std::string, int>::const_iterator i = groups.find(name);
+	ItemGroupList::const_iterator i = groups.find(name);
 	if(i == groups.end())
 		return 0;
 	return i->second;

--- a/src/mapsector.cpp
+++ b/src/mapsector.cpp
@@ -42,9 +42,8 @@ void MapSector::deleteBlocks()
 	m_block_cache = NULL;
 
 	// Delete all
-	for(std::map<s16, MapBlock*>::iterator i = m_blocks.begin();
-		i != m_blocks.end(); ++i)
-	{
+	for (UNORDERED_MAP<s16, MapBlock*>::iterator i = m_blocks.begin();
+		 	i != m_blocks.end(); ++i) {
 		delete i->second;
 	}
 
@@ -56,20 +55,13 @@ MapBlock * MapSector::getBlockBuffered(s16 y)
 {
 	MapBlock *block;
 
-	if(m_block_cache != NULL && y == m_block_cache_y){
+	if (m_block_cache != NULL && y == m_block_cache_y) {
 		return m_block_cache;
 	}
 
 	// If block doesn't exist, return NULL
-	std::map<s16, MapBlock*>::iterator n = m_blocks.find(y);
-	if(n == m_blocks.end())
-	{
-		block = NULL;
-	}
-	// If block exists, return it
-	else{
-		block = n->second;
-	}
+	UNORDERED_MAP<s16, MapBlock*>::iterator n = m_blocks.find(y);
+	block = (n != m_blocks.end() ? n->second : NULL);
 
 	// Cache the last result
 	m_block_cache_y = y;
@@ -135,16 +127,10 @@ void MapSector::deleteBlock(MapBlock *block)
 
 void MapSector::getBlocks(MapBlockVect &dest)
 {
-	for(std::map<s16, MapBlock*>::iterator bi = m_blocks.begin();
-		bi != m_blocks.end(); ++bi)
-	{
+	for (UNORDERED_MAP<s16, MapBlock*>::iterator bi = m_blocks.begin();
+		bi != m_blocks.end(); ++bi) {
 		dest.push_back(bi->second);
 	}
-}
-
-bool MapSector::empty()
-{
-	return m_blocks.empty();
 }
 
 /*

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -63,7 +63,7 @@ public:
 
 	void getBlocks(MapBlockVect &dest);
 
-	bool empty();
+	bool empty() const { return m_blocks.empty(); }
 
 	// Always false at the moment, because sector contains no metadata.
 	bool differs_from_disk;
@@ -71,7 +71,7 @@ public:
 protected:
 
 	// The pile of MapBlocks
-	std::map<s16, MapBlock*> m_blocks;
+	UNORDERED_MAP<s16, MapBlock*> m_blocks;
 
 	Map *m_parent;
 	// Position on parent (in MapBlock widths)

--- a/src/mg_schematic.cpp
+++ b/src/mg_schematic.cpp
@@ -564,14 +564,14 @@ void Schematic::applyProbabilities(v3s16 p0,
 void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,
 	std::vector<std::string> *usednodes, INodeDefManager *ndef)
 {
-	std::map<content_t, content_t> nodeidmap;
+	UNORDERED_MAP<content_t, content_t> nodeidmap;
 	content_t numids = 0;
 
 	for (size_t i = 0; i != nodecount; i++) {
 		content_t id;
 		content_t c = nodes[i].getContent();
 
-		std::map<content_t, content_t>::const_iterator it = nodeidmap.find(c);
+		UNORDERED_MAP<content_t, content_t>::const_iterator it = nodeidmap.find(c);
 		if (it == nodeidmap.end()) {
 			id = numids;
 			numids++;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1063,8 +1063,7 @@ void push_flags_string(lua_State *L, FlagDesc *flagdesc, u32 flags, u32 flagmask
 /******************************************************************************/
 
 /******************************************************************************/
-void read_groups(lua_State *L, int index,
-		std::map<std::string, int> &result)
+void read_groups(lua_State *L, int index, ItemGroupList &result)
 {
 	if (!lua_istable(L,index))
 		return;
@@ -1083,11 +1082,10 @@ void read_groups(lua_State *L, int index,
 }
 
 /******************************************************************************/
-void push_groups(lua_State *L, const std::map<std::string, int> &groups)
+void push_groups(lua_State *L, const ItemGroupList &groups)
 {
 	lua_newtable(L);
-	std::map<std::string, int>::const_iterator it;
-	for (it = groups.begin(); it != groups.end(); ++it) {
+	for (ItemGroupList::const_iterator it = groups.begin(); it != groups.end(); ++it) {
 		lua_pushnumber(L, it->second);
 		lua_setfield(L, -2, it->first.c_str());
 	}

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -33,11 +33,11 @@ extern "C" {
 }
 
 #include <iostream>
-#include <map>
 #include <vector>
 
 #include "irrlichttypes_bloated.h"
 #include "util/string.h"
+#include "itemgroup.h"
 
 namespace Json { class Value; }
 
@@ -106,10 +106,10 @@ void               pushnode                  (lua_State *L, const MapNode &n,
 NodeBox            read_nodebox              (lua_State *L, int index);
 
 void               read_groups               (lua_State *L, int index,
-                                              std::map<std::string, int> &result);
+                                              ItemGroupList &result);
 
 void               push_groups               (lua_State *L,
-                                              const std::map<std::string, int> &groups);
+                                              const ItemGroupList &groups);
 
 //TODO rename to "read_enum_field"
 int                getenumfield              (lua_State *L, int table,

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -28,7 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define C_CONVERTER_H_
 
 #include <vector>
-#include <map>
+#include "util/cpp11_container.h"
 
 #include "irrlichttypes_bloated.h"
 #include "common/c_types.h"
@@ -60,7 +60,7 @@ bool               getintfield(lua_State *L, int table,
 bool               getintfield(lua_State *L, int table,
                              const char *fieldname, u32 &result);
 void               read_groups(lua_State *L, int index,
-                             std::map<std::string, int> &result);
+                             UNORDERED_MAP<std::string, int> &result);
 bool               getboolfield(lua_State *L, int table,
                              const char *fieldname, bool &result);
 bool               getfloatfield(lua_State *L, int table,

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -220,7 +220,7 @@ int ModApiUtil::l_write_json(lua_State *L)
 int ModApiUtil::l_get_dig_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	std::map<std::string, int> groups;
+	ItemGroupList groups;
 	read_groups(L, 1, groups);
 	ToolCapabilities tp = read_tool_capabilities(L, 2);
 	if(lua_isnoneornil(L, 3))
@@ -235,7 +235,7 @@ int ModApiUtil::l_get_dig_params(lua_State *L)
 int ModApiUtil::l_get_hit_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	std::map<std::string, int> groups;
+	UNORDERED_MAP<std::string, int> groups;
 	read_groups(L, 1, groups);
 	ToolCapabilities tp = read_tool_capabilities(L, 2);
 	if(lua_isnoneornil(L, 3))

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -669,7 +669,7 @@ void Server::AsyncRunStep(bool initial_step)
 		MutexAutoLock envlock(m_env_mutex);
 
 		m_clients.lock();
-		std::map<u16, RemoteClient*> clients = m_clients.getClientList();
+		UNORDERED_MAP<u16, RemoteClient*> clients = m_clients.getClientList();
 		ScopeProfiler sp(g_profiler, "Server: checking added and deleted objs");
 
 		// Radius inside which objects are active
@@ -685,8 +685,7 @@ void Server::AsyncRunStep(bool initial_step)
 		if (player_radius == 0 && is_transfer_limited)
 			player_radius = radius;
 
-		for (std::map<u16, RemoteClient*>::iterator
-			i = clients.begin();
+		for (UNORDERED_MAP<u16, RemoteClient*>::iterator i = clients.begin();
 			i != clients.end(); ++i) {
 			RemoteClient *client = i->second;
 
@@ -696,7 +695,7 @@ void Server::AsyncRunStep(bool initial_step)
 				continue;
 
 			Player *player = m_env->getPlayer(client->peer_id);
-			if(player == NULL) {
+			if (player == NULL) {
 				// This can happen if the client timeouts somehow
 				/*warningstream<<FUNCTION_NAME<<": Client "
 						<<client->peer_id
@@ -817,10 +816,9 @@ void Server::AsyncRunStep(bool initial_step)
 		}
 
 		m_clients.lock();
-		std::map<u16, RemoteClient*> clients = m_clients.getClientList();
+		UNORDERED_MAP<u16, RemoteClient*> clients = m_clients.getClientList();
 		// Route data to every client
-		for (std::map<u16, RemoteClient*>::iterator
-			i = clients.begin();
+		for (UNORDERED_MAP<u16, RemoteClient*>::iterator i = clients.begin();
 			i != clients.end(); ++i) {
 			RemoteClient *client = i->second;
 			std::string reliable_data;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -196,9 +196,8 @@ void Settings::writeLines(std::ostream &os, u32 tab_depth) const
 {
 	MutexAutoLock lock(m_mutex);
 
-	for (std::map<std::string, SettingsEntry>::const_iterator
-			it = m_settings.begin();
-			it != m_settings.end(); ++it)
+	for (SettingEntries::const_iterator it = m_settings.begin();
+		 	it != m_settings.end(); ++it)
 		printEntry(os, it->first, it->second, tab_depth);
 }
 
@@ -231,7 +230,7 @@ void Settings::printEntry(std::ostream &os, const std::string &name,
 bool Settings::updateConfigObject(std::istream &is, std::ostream &os,
 	const std::string &end, u32 tab_depth)
 {
-	std::map<std::string, SettingsEntry>::const_iterator it;
+	SettingEntries::const_iterator it;
 	std::set<std::string> present_entries;
 	std::string line, name, value;
 	bool was_modified = false;
@@ -381,7 +380,7 @@ const SettingsEntry &Settings::getEntry(const std::string &name) const
 {
 	MutexAutoLock lock(m_mutex);
 
-	std::map<std::string, SettingsEntry>::const_iterator n;
+	SettingEntries::const_iterator n;
 	if ((n = m_settings.find(name)) == m_settings.end()) {
 		if ((n = m_defaults.find(name)) == m_defaults.end())
 			throw SettingNotFoundException("Setting [" + name + "] not found.");
@@ -572,9 +571,8 @@ bool Settings::exists(const std::string &name) const
 std::vector<std::string> Settings::getNames() const
 {
 	std::vector<std::string> names;
-	for (std::map<std::string, SettingsEntry>::const_iterator
-			i = m_settings.begin();
-			i != m_settings.end(); ++i) {
+	for (SettingEntries::const_iterator i = m_settings.begin();
+		 	i != m_settings.end(); ++i) {
 		names.push_back(i->first);
 	}
 	return names;
@@ -880,7 +878,7 @@ bool Settings::remove(const std::string &name)
 {
 	MutexAutoLock lock(m_mutex);
 
-	std::map<std::string, SettingsEntry>::iterator it = m_settings.find(name);
+	SettingEntries::iterator it = m_settings.find(name);
 	if (it != m_settings.end()) {
 		delete it->second.group;
 		m_settings.erase(it);
@@ -912,7 +910,6 @@ void Settings::updateValue(const Settings &other, const std::string &name)
 
 	try {
 		std::string val = other.get(name);
-
 		m_settings[name] = val;
 	} catch (SettingNotFoundException &e) {
 	}
@@ -968,8 +965,9 @@ void Settings::updateNoLock(const Settings &other)
 
 void Settings::clearNoLock()
 {
-	std::map<std::string, SettingsEntry>::const_iterator it;
-	for (it = m_settings.begin(); it != m_settings.end(); ++it)
+
+	for (SettingEntries::const_iterator it = m_settings.begin();
+			it != m_settings.end(); ++it)
 		delete it->second.group;
 	m_settings.clear();
 
@@ -978,8 +976,8 @@ void Settings::clearNoLock()
 
 void Settings::clearDefaultsNoLock()
 {
-	std::map<std::string, SettingsEntry>::const_iterator it;
-	for (it = m_defaults.begin(); it != m_defaults.end(); ++it)
+	for (SettingEntries::const_iterator it = m_defaults.begin();
+			it != m_defaults.end(); ++it)
 		delete it->second.group;
 	m_defaults.clear();
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -98,6 +98,8 @@ struct SettingsEntry {
 	bool is_group;
 };
 
+typedef UNORDERED_MAP<std::string, SettingsEntry> SettingEntries;
+
 class Settings {
 public:
 	Settings() {}
@@ -231,8 +233,8 @@ private:
 
 	void doCallbacks(const std::string &name) const;
 
-	std::map<std::string, SettingsEntry> m_settings;
-	std::map<std::string, SettingsEntry> m_defaults;
+	SettingEntries m_settings;
+	SettingEntries m_defaults;
 
 	SettingsCallbackMap m_callbacks;
 


### PR DESCRIPTION
This is part 2 for 5f084cd98d7b3326b51320455364337539710efd

Other improvements:

* Use the defined ItemGroupList when used
* make Client::checkPrivilege const
* inline some trivial functions
* Add ActiveObjectMap typedef to maintain easily this map