### PR TITLE
Infrastructure for sending server parameters to clients, overriding settings on the client

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -245,6 +245,7 @@ Client::Client(
 	m_auth_data(NULL),
 	m_access_denied(false),
 	m_access_denied_reconnect(false),
+	m_settings_received(false),
 	m_itemdef_received(false),
 	m_nodedef_received(false),
 	m_media_downloader(new ClientMediaDownloader()),

--- a/src/client.h
+++ b/src/client.h
@@ -379,6 +379,7 @@ public:
 	void handleCommand_NodeDef(NetworkPacket* pkt);
 	void handleCommand_CraftItemDef(NetworkPacket* pkt);
 	void handleCommand_ItemDef(NetworkPacket* pkt);
+	void handleCommand_Settings(NetworkPacket* pkt);
 	void handleCommand_PlaySound(NetworkPacket* pkt);
 	void handleCommand_StopSound(NetworkPacket* pkt);
 	void handleCommand_Privileges(NetworkPacket* pkt);
@@ -650,6 +651,7 @@ private:
 	bool m_access_denied_reconnect;
 	std::string m_access_denied_reason;
 	std::queue<ClientEvent> m_client_event_queue;
+	bool m_settings_received;
 	bool m_itemdef_received;
 	bool m_nodedef_received;
 	ClientMediaDownloader *m_media_downloader;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -193,6 +193,9 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 			L" [" + text + L"]").c_str());
 		delete[] text;
 
+		g_settings_managed_by_server = false;
+		g_settings->clearServerProvided();
+
 		try {	// This is used for catching disconnects
 
 			guienv->clear();

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -674,14 +674,17 @@ void ClientInterface::send(u16 peer_id, u8 channelnum,
 }
 
 void ClientInterface::sendToAll(u16 channelnum,
-		NetworkPacket* pkt, bool reliable)
+		NetworkPacket* pkt, bool reliable,
+		int min_protocol_version, int max_protocol_version)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	for(UNORDERED_MAP<u16, RemoteClient*>::iterator i = m_clients.begin();
 		i != m_clients.end(); ++i) {
 		RemoteClient *client = i->second;
 
-		if (client->net_proto_version != 0) {
+		if (client->net_proto_version != 0
+				&& client->net_proto_version >= min_protocol_version
+				&& client->net_proto_version <= max_protocol_version) {
 			m_con->Send(client->peer_id, channelnum, pkt, reliable);
 		}
 	}

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -459,7 +459,8 @@ public:
 	void send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
 
 	/* send to all clients */
-	void sendToAll(u16 channelnum, NetworkPacket* pkt, bool reliable);
+	void sendToAll(u16 channelnum, NetworkPacket* pkt, bool reliable,
+		int min_protocol_version = 0, int max_protocol_version = INT_MAX);
 
 	/* delete a client */
 	void DeleteClient(u16 peer_id);

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -86,6 +86,7 @@ class EmergeManager;
 +-----------------------------+   ---------------------                                |
 |OUT:                         |                                                        |
 | TOCLIENT_MOVEMENT           |                                                        |
+| TOCLIENT_SETTINGS           |                                                        |
 | TOCLIENT_ITEMDEF            |                                                        |
 | TOCLIENT_NODEDEF            |                                                        |
 | TOCLIENT_ANNOUNCE_MEDIA     |                                                        |

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -86,7 +86,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_CRAFTITEMDEF",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CraftItemDef }, // 0x3b
 	{ "TOCLIENT_ANNOUNCE_MEDIA",           TOCLIENT_STATE_CONNECTED, &Client::handleCommand_AnnounceMedia }, // 0x3c
 	{ "TOCLIENT_ITEMDEF",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ItemDef }, // 0x3d
-	null_command_handler,
+	{ "TOCLIENT_SETTINGS",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Settings }, // 0x3e
 	{ "TOCLIENT_PLAY_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlaySound }, // 0x3f
 	{ "TOCLIENT_STOP_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_StopSound }, // 0x40
 	{ "TOCLIENT_PRIVILEGES",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Privileges }, // 0x41

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -764,6 +764,32 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 	m_itemdef_received = true;
 }
 
+
+void Client::handleCommand_Settings(NetworkPacket* pkt)
+{
+	infostream << "Client: Received settings: packet size: "
+			<< pkt->getSize() << std::endl;
+
+	u8 type;
+	u8 flags;
+	(*pkt) >> type;
+	assert(type == 0);
+	(*pkt) >> flags;
+	bool complete_set = (flags & 0x01) != 0;
+	if (complete_set)
+		m_settings_received = true;
+
+	// If managed by server, the settings have already been applied.
+	// No need to override (or actually: overriding is harmful)
+	if (g_settings_managed_by_server)
+		return;
+
+	// Deserialize settings
+	std::istringstream is(pkt->readLongString(), std::ios_base::binary);
+	g_settings->deSerialize(is, complete_set);
+}
+
+
 void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 {
 	s32 server_id;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -138,9 +138,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add nodedef v3 - connected nodeboxes
 	PROTOCOL_VERSION 28:
 		CPT2_MESHOPTIONS
+	PROTOCOL_VERSION 29:
+		Add TOCLIENT_SETTINGS
 */
 
-#define LATEST_PROTOCOL_VERSION 28
+#define LATEST_PROTOCOL_VERSION 29
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13
@@ -399,6 +401,14 @@ enum ToClientCommand
 	/*
 		u32 length of next item
 		serialized ItemDefManager
+	*/
+
+	TOCLIENT_SETTINGS = 0x3e,
+	/*
+		u8 type (0)
+		u8 flags (0x01=complete-set)
+		u32 length of next item
+		serialized Settings
 	*/
 
 	TOCLIENT_PLAY_SOUND = 0x3f,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -175,7 +175,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_CRAFTITEMDEF",             0, false }, // 0x3b obsolete
 	{ "TOCLIENT_ANNOUNCE_MEDIA",           0, true }, // 0x3c
 	{ "TOCLIENT_ITEMDEF",                  0, true }, // 0x3d
-	null_command_factory,
+	{ "TOCLIENT_SETTINGS",                 0, true }, // 0x3e
 	{ "TOCLIENT_PLAY_SOUND",               0, true }, // 0x3f
 	{ "TOCLIENT_STOP_SOUND",               0, true }, // 0x40
 	{ "TOCLIENT_PRIVILEGES",               0, true }, // 0x41

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -643,6 +643,9 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	// Send node definitions
 	SendNodeDef(pkt->getPeerId(), m_nodedef, protocol_version);
 
+	// Send client settings
+	SendClientSettings(pkt->getPeerId(), protocol_version);
+
 	m_clients.event(pkt->getPeerId(), CSE_SetDefinitionsSent);
 
 	// Send media announcement

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1457,6 +1457,17 @@ void Server::Send(NetworkPacket* pkt)
 		clientCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
+
+void Server::Broadcast(NetworkPacket* pkt, int min_protocol_version, int max_protocol_version)
+{
+	m_clients.sendToAll(
+		clientCommandFactoryTable[pkt->getCommand()].channel,
+		pkt,
+		clientCommandFactoryTable[pkt->getCommand()].reliable,
+		min_protocol_version, max_protocol_version);
+}
+
+
 void Server::SendMovement(u16 peer_id)
 {
 	DSTACK(FUNCTION_NAME);

--- a/src/server.h
+++ b/src/server.h
@@ -161,6 +161,8 @@ public:
 	void Receive();
 	PlayerSAO* StageTwoClientInit(u16 peer_id);
 
+	static void ClientSettingChangedCallback(const std::string &name, void *data);
+
 	/*
 	 * Command Handlers
 	 */
@@ -376,6 +378,8 @@ private:
 		const std::string &custom_reason, bool reconnect = false);
 	void SendAccessDenied_Legacy(u16 peer_id, const std::wstring &reason);
 	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
+	void SendClientSettings(u16 peer_id, u16 protocol_version);
+	void BroadcastSingleClientSetting(const std::string &name, const SettingsEntry &entry);
 	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
 	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);
 

--- a/src/server.h
+++ b/src/server.h
@@ -196,6 +196,8 @@ public:
 	void ProcessData(NetworkPacket *pkt);
 
 	void Send(NetworkPacket* pkt);
+	void Broadcast(NetworkPacket* pkt,
+		int min_protocol_version = 0, int max_protocol_version = INT_MAX);
 
 	// Both setter and getter need no envlock,
 	// can be called freely from threads

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include "debug.h"
 #include "log.h"
-#include "util/serialize.h"
+#include "util/hex.h"
 #include "filesys.h"
 #include "noise.h"
 #include <cctype>
@@ -769,8 +769,10 @@ bool Settings::set(const std::string &name, const std::string &value)
 }
 
 
-bool Settings::setDefault(const std::string &name, const std::string &value)
+bool Settings::setDefault(const std::string &name, const std::string &value, Flags flags)
 {
+	if (flags)
+		m_flags[name] = flags;
 	return setEntry(name, &value, false, true);
 }
 
@@ -781,8 +783,10 @@ bool Settings::setGroup(const std::string &name, Settings *group)
 }
 
 
-bool Settings::setGroupDefault(const std::string &name, Settings *group)
+bool Settings::setGroupDefault(const std::string &name, Settings *group, Flags flags)
 {
+	if (flags)
+		m_flags[name] = flags;
 	return setEntry(name, &group, true, true);
 }
 
@@ -969,6 +973,7 @@ SettingsParseEvent Settings::parseConfigObject(const std::string &line,
 
 void Settings::updateNoLock(const Settings &other)
 {
+	m_flags.insert(other.m_flags.begin(), other.m_flags.end());
 	m_server_enforced.insert(other.m_server_enforced.begin(), other.m_server_enforced.end());
 	m_settings.insert(other.m_settings.begin(), other.m_settings.end());
 	m_server_suggested.insert(other.m_server_suggested.begin(), other.m_server_suggested.end());
@@ -990,6 +995,7 @@ void Settings::clearNoLock()
 	clearNoLock(&m_settings);
 	clearNoLock(&m_server_suggested);
 	clearNoLock(&m_defaults);
+	m_flags.clear();
 }
 
 
@@ -1027,4 +1033,260 @@ void Settings::doCallbacks(const std::string &name) const
 		for (it = it_cbks->second.begin(); it != it_cbks->second.end(); ++it)
 			(it->first)(name, it->second);
 	}
+}
+
+
+// Returns true if anything was serialized
+// If flags is set to SUGGEST_CLIENT or ENFORCE_CLIENT, serialize only the settings
+// with those flags set. Else serialize all settings.
+// If a group has a flag set, that flag applies to all its members. ATM, it is assumed
+// that members don't have different flags than the group they are in.
+// Must be entered with lock (m_mutex) held
+bool Settings::serializeSettings(const SettingEntries &settings, std::ostream &os, Flags flags) const
+{
+	bool empty = true;
+	SettingEntries::const_iterator i;
+	for (i = settings.begin(); i != settings.end(); i++) {
+		const std::string &name = i->first;
+		const SettingsEntry &entry = i->second;
+		if (flags == FLAGS_NONE || (getEntryFlags(name) & flags)) {
+			os << serializeString(name);
+			if (entry.is_group) {
+				writeU8(os, SERIALIZATION_VALUETYPE_GROUP);
+				entry.group->serializeGroup(os, FLAGS_NONE);
+			} else {
+				writeU8(os, SERIALIZATION_VALUETYPE_STRING);
+				os << serializeString(entry.value);
+			}
+			empty = false;
+		}
+	}
+
+	return !empty;
+}
+
+
+// Serialize a sentinel.
+// The tag can be used for error checking. Currently, only the tag in
+// the group-sentinel is checked by the deserialisation code.
+void Settings::serializeSentinel(std::ostream &os, const std::string &tag) const
+{
+	os << serializeString("");
+	writeU8(os, SERIALIZATION_VALUETYPE_SENTINEL);
+	if (tag.empty())
+		os << serializeString("--END--");
+	else
+		os << serializeString("--END-" + tag + "--");
+}
+
+
+// Returns true if anything was serialized
+// Must be entered with lock (m_mutex) held
+bool Settings::serializeCategory(std::ostream &os, SettingsCategoryType category, Flags flags) const
+{
+	bool empty = true;
+
+	if ((category & SETTINGS_DEFAULT))
+		empty = !serializeSettings(m_defaults, os, flags) && empty;
+
+	if ((category & SETTINGS_SUGGESTED))
+		empty = !serializeSettings(m_server_suggested, os, flags) && empty;
+
+	if ((category & SETTINGS_CUSTOMIZED))
+		empty = !serializeSettings(m_settings, os, flags) && empty;
+
+	if ((category & SETTINGS_ENFORCED))
+		empty = !serializeSettings(m_server_enforced, os, flags) && empty;
+
+	return !empty;
+}
+
+
+// Serialization of a group's contents: aggregate all settings into category 'customized'
+// Returns true if anything was serialized
+bool Settings::serializeGroup(std::ostream &os, Flags flags) const
+{
+	MutexAutoLock lock(m_mutex);
+	bool empty = true;
+
+	writeU8(os,SETTINGS_CUSTOMIZED);
+	empty = !serializeCategory(os, SETTINGS_CATEGORY_ALL, flags) && empty;
+	serializeSentinel(os, "CUSTOMIZED");
+
+	writeU8(os,SETTINGS_CATEGORY_NONE);
+	serializeSentinel(os, "GROUP");
+
+	return !empty;
+}
+
+
+// Regular serialization: serialize exactly what we've got.
+// Returns true if anything was serialized
+//
+// Serialization format (same as the format of a group):
+//	u8			category
+//	<string,u8,string>*	list of name, value-type, value
+//	<string,u8,string>	sentinel
+//	(repeat the 3 above as often as necessary)
+//	u8			category (SETTINGS_CATEGORY_NONE)
+//	<string,u8,string>	group sentinel
+// A value can itself be a group
+// ATM groups are assumed to consist of a single category only.
+bool Settings::serialize(std::ostream &os) const
+{
+	MutexAutoLock lock(m_mutex);
+	bool empty = true;
+
+	// Categories are terminated by a sentinel. Identified by name == "" and U8 == SERIALIZATION_VALUETYPE_SENTINEL
+	// Groups are also terminated by a group sentinel
+
+	writeU8(os,SETTINGS_DEFAULT);
+	empty = !serializeCategory(os, SETTINGS_DEFAULT, FLAGS_NONE) && empty;
+	serializeSentinel(os, "DEFAULT");
+
+	writeU8(os,SETTINGS_SUGGESTED);
+	empty = !serializeCategory(os, SETTINGS_SUGGESTED, FLAGS_NONE) && empty;
+	serializeSentinel(os, "SUGGESTED");
+
+	writeU8(os,SETTINGS_CUSTOMIZED);
+	empty = !serializeCategory(os, SETTINGS_CUSTOMIZED, FLAGS_NONE) && empty;
+	serializeSentinel(os, "CUSTOMIZED");
+
+	writeU8(os,SETTINGS_ENFORCED);
+	empty = !serializeCategory(os, SETTINGS_ENFORCED, FLAGS_NONE) && empty;
+	serializeSentinel(os, "ENFORCED");
+
+	writeU8(os,SETTINGS_CATEGORY_NONE);
+	serializeSentinel(os, "GROUP");
+
+	return !empty;
+}
+
+
+// For client; category depends on flags instead of on server category
+// Returns true if anything was serialized
+bool Settings::serializeForClient(std::ostream &os) const
+{
+	MutexAutoLock lock(m_mutex);
+	bool empty = true;
+
+	// Categories are terminated by a sentinel. Identified by name == "" and U8 == SERIALIZATION_VALUETYPE_SENTINEL
+
+	writeU8(os,SETTINGS_SUGGESTED);
+	empty = !serializeCategory(os, SETTINGS_CATEGORY_ALL, SUGGEST_TO_CLIENT) && empty;
+	serializeSentinel(os, "SUGGESTED");
+
+	writeU8(os,SETTINGS_ENFORCED);
+	empty = !serializeCategory(os, SETTINGS_CATEGORY_ALL, ENFORCE_ON_CLIENT) && empty;
+	serializeSentinel(os, "ENFORCED");
+
+	writeU8(os,SETTINGS_CATEGORY_NONE);
+	serializeSentinel(os, "GROUP");
+
+	return !empty;
+}
+
+
+// Must be entered with lock (m_mutex) held
+void Settings::deSerializeSettings(std::istream &is, SettingEntries *settings)
+{
+	for (;;) {
+		std::string name = deSerializeString(is);
+		SerializationValueType type = static_cast<SerializationValueType>(readU8(is));
+		switch (type) {
+			case SERIALIZATION_VALUETYPE_SENTINEL :
+				// deserialized string should be '--END--' or
+				// '--END-<tag>--' (see serialization code)
+				(void) deSerializeString(is);
+				return;
+			case SERIALIZATION_VALUETYPE_STRING : {
+				SettingsEntry &entry = (*settings)[name];
+				entry.value    = deSerializeString(is);
+				entry.group    = NULL;
+				entry.is_group = false;
+				break;
+			}
+			case SERIALIZATION_VALUETYPE_GROUP : {
+				SettingsEntry &entry = (*settings)[name];
+				entry.value    = "";
+				entry.is_group = true;
+				if (!entry.group)
+					entry.group = new Settings();
+				entry.group->deSerialize(is, false);
+				break;
+			}
+			default: {
+				std::ostringstream msg;
+				msg << "Settings deserialisation error: unrecognised SerializationValueType: " << type;
+				throw SerializationError(msg.str());
+				break;
+			}
+		}
+	}
+}
+
+
+void Settings::deSerializeGroupSentinel(std::istream &is) const
+{
+	std::string sentinel_name = deSerializeString(is);
+	SerializationValueType sentinel_type = static_cast<SerializationValueType>(readU8(is));
+	std::string sentinel_value = deSerializeString(is);
+	if (sentinel_name != "" || sentinel_type != SERIALIZATION_VALUETYPE_SENTINEL || sentinel_value != "--END-GROUP--") {
+#define DUMP_LENGTH 16
+		if (sentinel_value.size() > DUMP_LENGTH + 5) {
+			sentinel_value.resize(DUMP_LENGTH);
+			sentinel_value.append("[...]");
+		}
+		for (unsigned i = 0; i < sentinel_value.size(); i++) {
+			if (!isprint(sentinel_value[i])) {
+				std::string hex = hex_encode(sentinel_value.substr(i,1));
+				hex.insert(0, "\\x");
+				sentinel_value.replace(i, 1, hex);
+				i += hex.length() - 1;
+			}
+		}
+		std::ostringstream msg;
+		msg << "Settings deserialisation error: group is not terminated by sentinel."
+			<< " Got: '" << sentinel_name << "' =  '" << sentinel_value << "';"
+			<< " SerializationValueType is: " << sentinel_type << std::endl;
+		throw SerializationError(msg.str());
+#undef DUMP_LENGTH
+	}
+}
+
+
+void Settings::deSerialize(std::istream &is, bool replace)
+{
+	MutexAutoLock lock(m_mutex);
+	SettingEntries *entries;
+	for (;;) {
+		SettingsCategoryType category = static_cast<SettingsCategoryType>(readU8(is));
+		switch (category) {
+			case SETTINGS_CATEGORY_NONE:
+				deSerializeGroupSentinel(is);
+				return;
+			case SETTINGS_DEFAULT:
+				entries = &m_defaults;
+				break;
+			case SETTINGS_SUGGESTED:
+				entries = &m_server_suggested;
+				break;
+			case SETTINGS_CUSTOMIZED:
+				entries = &m_settings;
+				break;
+			case SETTINGS_ENFORCED:
+				entries = &m_server_enforced;
+				break;
+			default: {
+				std::ostringstream msg;
+				msg << "Settings deserialisation error: unrecognised SettingsCategoryType: " << category;
+				throw SerializationError(msg.str());
+				break;
+			}
+		}
+		if (replace)
+			clearNoLock(entries);
+		deSerializeSettings(is, entries);
+	}
+	// NOTREACHED
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -218,6 +218,7 @@ public:
 	bool remove(const std::string &name);
 	void clear();
 	void clearDefaults();
+	void clearServerProvided();
 	void updateValue(const Settings &other, const std::string &name);
 	void update(const Settings &other);
 
@@ -228,12 +229,16 @@ public:
 
 private:
 	void updateNoLock(const Settings &other);
+	void clearNoLock(SettingEntries *settings);
 	void clearNoLock();
-	void clearDefaultsNoLock();
+	void clearDefaultsNoLock() { clearNoLock(&m_defaults); }
+	void clearServerProvidedNoLock() { clearNoLock(&m_server_suggested); clearNoLock(&m_server_enforced); }
 
 	void doCallbacks(const std::string &name) const;
 
+	SettingEntries m_server_enforced;
 	SettingEntries m_settings;
+	SettingEntries m_server_suggested;
 	SettingEntries m_defaults;
 
 	SettingsCallbackMap m_callbacks;

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,6 +36,10 @@ struct NoiseParams;
 extern Settings *g_settings;
 extern std::string g_settings_path;
 
+// This is used to avoid the client setting override-type settings
+// when the server is using the same settings object.
+extern bool g_settings_managed_by_server;
+
 // Type for a settings changed callback function
 typedef void (*SettingsChangedCallback)(const std::string &name, void *data);
 
@@ -203,6 +207,7 @@ public:
 
 	// N.B. Groups not allocated with new must be set to NULL in the settings
 	// tree before object destruction.
+	bool setEntry(const std::string &name, const SettingsEntry &entry, bool set_default);
 	bool setEntry(const std::string &name, const void *entry,
 		bool set_group, bool set_default);
 	Flags setEntryFlags(const std::string &name, Flags flags, Flags mask = static_cast<Flags>(~0x00))
@@ -235,6 +240,10 @@ public:
 	void updateValue(const Settings &other, const std::string &name);
 	void update(const Settings &other);
 
+	void registerSendToClientCallbacks(
+		SettingsChangedCallback cbf, void *userdata = NULL);
+	void deregisterSendToClientCallbacks(
+		SettingsChangedCallback cbf, void *userdata = NULL);
 	void registerChangedCallback(const std::string &name,
 		SettingsChangedCallback cbf, void *userdata = NULL);
 	void deregisterChangedCallback(const std::string &name,

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -61,6 +61,26 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define LONG_STRING_MAX_LEN (64 * 1024 * 1024)
 
 
+// Value types for serializing a key-value store
+// (used for settings)
+enum SerializationValueType
+{
+	SERIALIZATION_VALUETYPE_SENTINEL = 0,
+	SERIALIZATION_VALUETYPE_STRING   = 1,
+	SERIALIZATION_VALUETYPE_GROUP    = 2,
+};
+
+// Categories for serialisation of settings
+// (SERIALIZATION_CATEGORY_ALL should not be used on the wire)
+enum SettingsCategoryType {
+	SETTINGS_CATEGORY_NONE        = 0x00,
+	SETTINGS_DEFAULT    = 0x01,
+	SETTINGS_SUGGESTED  = 0x02,
+	SETTINGS_CUSTOMIZED = 0x04,
+	SETTINGS_ENFORCED   = 0x08,
+	SETTINGS_CATEGORY_ALL         = 0x0f,
+};
+
 #if HAVE_ENDIAN_H
 // use machine native byte swapping routines
 // Note: memcpy below is optimized out by modern compilers


### PR DESCRIPTION
This set of commits allows selected options to be marked for sending to the client. They will be sent at client initialisation after a new connection has been established. The client will integrate them into its own settings such that they override values that the client may have set, or will set later. If the option is ever changed on the server, the new value will also be broadcast to all connected clients.

This feature can be used with client-side autopickup (#4427) for example, to allow the server to enforce autopickup privilege checking (on unmodified clients :-) See my branch [autopickup-with-client-config](https://github.com/Rogier-5/minetest/tree/autopickup-with-client-config) for the implementation.

Possible extensions:
- ~~Currently, the server-provided settings always override clients' settings. Another category of settings could have the status of suggestion, overriding default values on the client, but not the values the client has configured explicitly~~. (done)
- Lua interface to allow such settings to be created from mods (currently of little use; probably useful, when client-side scripting gets merged).
