### PR TITLE
Player/LocalPlayer/RemotePlayer inheritance cleanup (part 2 of X)

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1418,7 +1418,7 @@ Inventory* Client::getInventory(const InventoryLocation &loc)
 	break;
 	case InventoryLocation::PLAYER:
 	{
-		Player *player = m_env.getPlayer(loc.name.c_str());
+		LocalPlayer *player = m_env.getPlayer(loc.name.c_str());
 		if(!player)
 			return NULL;
 		return &player->inventory;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -127,65 +127,6 @@ Player * Environment::getPlayer(const char *name)
 	return NULL;
 }
 
-Player * Environment::getRandomConnectedPlayer()
-{
-	std::vector<Player*> connected_players = getPlayers(true);
-	u32 chosen_one = myrand() % connected_players.size();
-	u32 j = 0;
-	for(std::vector<Player*>::iterator
-			i = connected_players.begin();
-			i != connected_players.end(); ++i) {
-		if(j == chosen_one) {
-			Player *player = *i;
-			return player;
-		}
-		j++;
-	}
-	return NULL;
-}
-
-Player * Environment::getNearestConnectedPlayer(v3f pos)
-{
-	std::vector<Player*> connected_players = getPlayers(true);
-	f32 nearest_d = 0;
-	Player *nearest_player = NULL;
-	for(std::vector<Player*>::iterator
-			i = connected_players.begin();
-			i != connected_players.end(); ++i) {
-		Player *player = *i;
-		f32 d = player->getPosition().getDistanceFrom(pos);
-		if(d < nearest_d || nearest_player == NULL) {
-			nearest_d = d;
-			nearest_player = player;
-		}
-	}
-	return nearest_player;
-}
-
-std::vector<Player*> Environment::getPlayers()
-{
-	return m_players;
-}
-
-std::vector<Player*> Environment::getPlayers(bool ignore_disconnected)
-{
-	std::vector<Player*> newlist;
-	for(std::vector<Player*>::iterator
-			i = m_players.begin();
-			i != m_players.end(); ++i) {
-		Player *player = *i;
-
-		if(ignore_disconnected) {
-			// Ignore disconnected players
-			if(player->peer_id == 0)
-				continue;
-		}
-
-		newlist.push_back(player);
-	}
-	return newlist;
-}
-
 u32 Environment::getDayNightRatio()
 {
 	MutexAutoLock lock(this->m_time_lock);
@@ -197,11 +138,6 @@ u32 Environment::getDayNightRatio()
 void Environment::setTimeOfDaySpeed(float speed)
 {
 	m_time_of_day_speed = speed;
-}
-
-float Environment::getTimeOfDaySpeed()
-{
-	return m_time_of_day_speed;
 }
 
 void Environment::setDayNightRatioOverride(bool enable, u32 value)
@@ -623,6 +559,16 @@ Map & ServerEnvironment::getMap()
 ServerMap & ServerEnvironment::getServerMap()
 {
 	return *m_map;
+}
+
+RemotePlayer *ServerEnvironment::getPlayer(const u16 peer_id)
+{
+	return dynamic_cast<RemotePlayer *>(Environment::getPlayer(peer_id));
+}
+
+RemotePlayer *ServerEnvironment::getPlayer(const char* name)
+{
+	return dynamic_cast<RemotePlayer *>(Environment::getPlayer(name));
 }
 
 bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 *p)
@@ -2347,6 +2293,16 @@ Map & ClientEnvironment::getMap()
 ClientMap & ClientEnvironment::getClientMap()
 {
 	return *m_map;
+}
+
+LocalPlayer *ClientEnvironment::getPlayer(const u16 peer_id)
+{
+	return dynamic_cast<LocalPlayer *>(Environment::getPlayer(peer_id));
+}
+
+LocalPlayer *ClientEnvironment::getPlayer(const char* name)
+{
+	return dynamic_cast<LocalPlayer *>(Environment::getPlayer(name));
 }
 
 void ClientEnvironment::addPlayer(Player *player)

--- a/src/environment.h
+++ b/src/environment.h
@@ -74,12 +74,6 @@ public:
 
 	virtual void addPlayer(Player *player);
 	void removePlayer(Player *player);
-	Player * getPlayer(u16 peer_id);
-	Player * getPlayer(const char *name);
-	Player * getRandomConnectedPlayer();
-	Player * getNearestConnectedPlayer(v3f pos);
-	std::vector<Player*> getPlayers();
-	std::vector<Player*> getPlayers(bool ignore_disconnected);
 
 	u32 getDayNightRatio();
 
@@ -91,7 +85,6 @@ public:
 	void stepTimeOfDay(float dtime);
 
 	void setTimeOfDaySpeed(float speed);
-	float getTimeOfDaySpeed();
 
 	void setDayNightRatioOverride(bool enable, u32 value);
 
@@ -101,6 +94,9 @@ public:
 	u32 m_added_objects;
 
 protected:
+	Player * getPlayer(u16 peer_id);
+	Player * getPlayer(const char *name);
+
 	// peer_ids in here should be unique, except that there may be many 0s
 	std::vector<Player*> m_players;
 
@@ -440,6 +436,8 @@ public:
 	void setStaticForActiveObjectsInBlock(v3s16 blockpos,
 		bool static_exists, v3s16 static_block=v3s16(0,0,0));
 
+	RemotePlayer *getPlayer(const u16 peer_id);
+	RemotePlayer *getPlayer(const char* name);
 private:
 
 	/*
@@ -640,8 +638,10 @@ public:
 	{ m_player_names.remove(name); }
 	void updateCameraOffset(v3s16 camera_offset)
 	{ m_camera_offset = camera_offset; }
-	v3s16 getCameraOffset()
-	{ return m_camera_offset; }
+	v3s16 getCameraOffset() const { return m_camera_offset; }
+
+	LocalPlayer *getPlayer(const u16 peer_id);
+	LocalPlayer *getPlayer(const char* name);
 
 private:
 	ClientMap *m_map;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -800,8 +800,7 @@ void Server::handleCommand_PlayerPos(NetworkPacket* pkt)
 	pitch = modulo360f(pitch);
 	yaw = modulo360f(yaw);
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
 				"No player for peer_id=" << pkt->getPeerId()
@@ -880,8 +879,7 @@ void Server::handleCommand_DeletedBlocks(NetworkPacket* pkt)
 
 void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 {
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1081,8 +1079,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 
 	*pkt >> damage;
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1117,8 +1114,7 @@ void Server::handleCommand_Breath(NetworkPacket* pkt)
 
 	*pkt >> breath;
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1231,8 +1227,7 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 	if (pkt->getSize() < 2)
 		return;
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1308,8 +1303,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 	verbosestream << "TOSERVER_INTERACT: action=" << (int)action << ", item="
 			<< item_i << ", pointed=" << pointed.dump() << std::endl;
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1730,8 +1724,7 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 		fields[fieldname] = pkt->readLongString();
 	}
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "
@@ -1782,8 +1775,7 @@ void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
 		fields[fieldname] = pkt->readLongString();
 	}
 
-	RemotePlayer *player =
-		dynamic_cast<RemotePlayer *>(m_env->getPlayer(pkt->getPeerId()));
+	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
 	if (player == NULL) {
 		errorstream << "Server::ProcessData(): Canceling: "

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -420,7 +420,7 @@ void InvRef::create(lua_State *L, const InventoryLocation &loc)
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
 }
-void InvRef::createPlayer(lua_State *L, Player *player)
+void InvRef::createPlayer(lua_State *L, RemotePlayer *player)
 {
 	NO_MAP_LOCK_REQUIRED;
 	InventoryLocation loc;

--- a/src/script/lua_api/l_inventory.h
+++ b/src/script/lua_api/l_inventory.h
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventory.h"
 #include "inventorymanager.h"
 
-class Player;
+class RemotePlayer;
 
 /*
 	InvRef
@@ -112,7 +112,7 @@ public:
 	// Creates an InvRef and leaves it on top of stack
 	// Not callable from Lua; all references are created on the C side.
 	static void create(lua_State *L, const InventoryLocation &loc);
-	static void createPlayer(lua_State *L, Player *player);
+	static void createPlayer(lua_State *L, RemotePlayer *player);
 	static void createNodeMeta(lua_State *L, v3s16 p);
 	static void Register(lua_State *L);
 };
@@ -122,11 +122,6 @@ private:
 	static int l_create_detached_inventory_raw(lua_State *L);
 
 	static int l_get_inventory(lua_State *L);
-
-	static void inventory_set_list_from_lua(Inventory *inv, const char *name,
-			lua_State *L, int tableindex, int forcesize);
-	static void inventory_get_list_to_lua(Inventory *inv, const char *name,
-			lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -508,7 +508,7 @@ int ObjectRef::l_set_local_animation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 	// Do it
@@ -554,7 +554,7 @@ int ObjectRef::l_set_eye_offset(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 	// Do it
@@ -1256,7 +1256,7 @@ int ObjectRef::l_hud_add(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1319,7 +1319,7 @@ int ObjectRef::l_hud_remove(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1339,7 +1339,7 @@ int ObjectRef::l_hud_change(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1552,7 +1552,7 @@ int ObjectRef::l_hud_set_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1567,7 +1567,7 @@ int ObjectRef::l_hud_get_hotbar_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1581,7 +1581,7 @@ int ObjectRef::l_hud_set_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1596,7 +1596,7 @@ int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 
@@ -1610,7 +1610,7 @@ int ObjectRef::l_set_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	Player *player = getplayer(ref);
+	RemotePlayer *player = getplayer(ref);
 	if (player == NULL)
 		return 0;
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -26,7 +26,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class ServerActiveObject;
 class LuaEntitySAO;
 class PlayerSAO;
-class Player;
 class RemotePlayer;
 
 /*

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -106,7 +106,7 @@ int ModApiServer::l_get_player_ip(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char * name = luaL_checkstring(L, 1);
-	Player *player = getEnv(L)->getPlayer(name);
+	RemotePlayer *player = dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name);
 	if(player == NULL)
 	{
 		lua_pushnil(L); // no such player
@@ -133,9 +133,8 @@ int ModApiServer::l_get_player_information(lua_State *L)
 
 	NO_MAP_LOCK_REQUIRED;
 	const char * name = luaL_checkstring(L, 1);
-	Player *player = getEnv(L)->getPlayer(name);
-	if(player == NULL)
-	{
+	RemotePlayer *player = dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name);
+	if (player == NULL) {
 		lua_pushnil(L); // no such player
 		return 1;
 	}
@@ -278,15 +277,15 @@ int ModApiServer::l_ban_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char * name = luaL_checkstring(L, 1);
-	Player *player = getEnv(L)->getPlayer(name);
-	if(player == NULL)
-	{
+	RemotePlayer *player = dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name);
+	if (player == NULL) {
 		lua_pushboolean(L, false); // no such player
 		return 1;
 	}
 	try
 	{
-		Address addr = getServer(L)->getPeerAddress(getEnv(L)->getPlayer(name)->peer_id);
+		Address addr = getServer(L)->getPeerAddress(
+			dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name)->peer_id);
 		std::string ip_str = addr.serializeString();
 		getServer(L)->setIpBanned(ip_str, name);
 	}
@@ -314,9 +313,9 @@ int ModApiServer::l_kick_player(lua_State *L)
 	{
 		message = "Kicked.";
 	}
-	Player *player = getEnv(L)->getPlayer(name);
-	if (player == NULL)
-	{
+
+	RemotePlayer *player = dynamic_cast<ServerEnvironment *>(getEnv(L))->getPlayer(name);
+	if (player == NULL) {
 		lua_pushboolean(L, false); // No such player
 		return 1;
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2638,7 +2638,7 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 				++i;
 		}
 
-		RemotePlayer *player = dynamic_cast<RemotePlayer *>(m_env->getPlayer(peer_id));
+		RemotePlayer *player = m_env->getPlayer(peer_id);
 
 		/* Run scripts and remove from environment */
 		if(player != NULL) {
@@ -2850,7 +2850,7 @@ std::string Server::getPlayerName(u16 peer_id)
 
 PlayerSAO* Server::getPlayerSAO(u16 peer_id)
 {
-	RemotePlayer *player = dynamic_cast<RemotePlayer *>(m_env->getPlayer(peer_id));
+	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (player == NULL)
 		return NULL;
 	return player->getPlayerSAO();
@@ -2989,7 +2989,7 @@ bool Server::showFormspec(const char *playername, const std::string &formspec,
 	return true;
 }
 
-u32 Server::hudAdd(Player *player, HudElement *form)
+u32 Server::hudAdd(RemotePlayer *player, HudElement *form)
 {
 	if (!player)
 		return -1;
@@ -3001,7 +3001,7 @@ u32 Server::hudAdd(Player *player, HudElement *form)
 	return id;
 }
 
-bool Server::hudRemove(Player *player, u32 id) {
+bool Server::hudRemove(RemotePlayer *player, u32 id) {
 	if (!player)
 		return false;
 
@@ -3016,7 +3016,7 @@ bool Server::hudRemove(Player *player, u32 id) {
 	return true;
 }
 
-bool Server::hudChange(Player *player, u32 id, HudElementStat stat, void *data)
+bool Server::hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *data)
 {
 	if (!player)
 		return false;
@@ -3058,7 +3058,7 @@ bool Server::hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount)
 	return true;
 }
 
-void Server::hudSetHotbarImage(Player *player, std::string name)
+void Server::hudSetHotbarImage(RemotePlayer *player, std::string name)
 {
 	if (!player)
 		return;
@@ -3067,14 +3067,14 @@ void Server::hudSetHotbarImage(Player *player, std::string name)
 	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_IMAGE, name);
 }
 
-std::string Server::hudGetHotbarImage(Player *player)
+std::string Server::hudGetHotbarImage(RemotePlayer *player)
 {
 	if (!player)
 		return "";
 	return player->getHotbarImage();
 }
 
-void Server::hudSetHotbarSelectedImage(Player *player, std::string name)
+void Server::hudSetHotbarSelectedImage(RemotePlayer *player, std::string name)
 {
 	if (!player)
 		return;
@@ -3083,7 +3083,7 @@ void Server::hudSetHotbarSelectedImage(Player *player, std::string name)
 	SendHUDSetParam(player->peer_id, HUD_PARAM_HOTBAR_SELECTED_IMAGE, name);
 }
 
-std::string Server::hudGetHotbarSelectedImage(Player *player)
+std::string Server::hudGetHotbarSelectedImage(RemotePlayer *player)
 {
 	if (!player)
 		return "";
@@ -3091,8 +3091,8 @@ std::string Server::hudGetHotbarSelectedImage(Player *player)
 	return player->getHotbarSelectedImage();
 }
 
-bool Server::setLocalPlayerAnimations(Player *player,
-	v2s32 animation_frames[4], f32 frame_speed)
+bool Server::setLocalPlayerAnimations(RemotePlayer *player,
+		v2s32 animation_frames[4], f32 frame_speed)
 {
 	if (!player)
 		return false;
@@ -3102,7 +3102,7 @@ bool Server::setLocalPlayerAnimations(Player *player,
 	return true;
 }
 
-bool Server::setPlayerEyeOffset(Player *player, v3f first, v3f third)
+bool Server::setPlayerEyeOffset(RemotePlayer *player, v3f first, v3f third)
 {
 	if (!player)
 		return false;
@@ -3113,7 +3113,7 @@ bool Server::setPlayerEyeOffset(Player *player, v3f first, v3f third)
 	return true;
 }
 
-bool Server::setSky(Player *player, const video::SColor &bgcolor,
+bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
 	const std::string &type, const std::vector<std::string> &params)
 {
 	if (!player)

--- a/src/server.h
+++ b/src/server.h
@@ -307,25 +307,26 @@ public:
 	Map & getMap() { return m_env->getMap(); }
 	ServerEnvironment & getEnv() { return *m_env; }
 
-	u32 hudAdd(Player *player, HudElement *element);
-	bool hudRemove(Player *player, u32 id);
-	bool hudChange(Player *player, u32 id, HudElementStat stat, void *value);
+	u32 hudAdd(RemotePlayer *player, HudElement *element);
+	bool hudRemove(RemotePlayer *player, u32 id);
+	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount);
 	s32 hudGetHotbarItemcount(RemotePlayer *player) const
 			{ return player->getHotbarItemcount(); }
-	void hudSetHotbarImage(Player *player, std::string name);
-	std::string hudGetHotbarImage(Player *player);
-	void hudSetHotbarSelectedImage(Player *player, std::string name);
-	std::string hudGetHotbarSelectedImage(Player *player);
+	void hudSetHotbarImage(RemotePlayer *player, std::string name);
+	std::string hudGetHotbarImage(RemotePlayer *player);
+	void hudSetHotbarSelectedImage(RemotePlayer *player, std::string name);
+	std::string hudGetHotbarSelectedImage(RemotePlayer *player);
 
 	inline Address getPeerAddress(u16 peer_id)
 			{ return m_con.GetPeerAddress(peer_id); }
 
-	bool setLocalPlayerAnimations(Player *player, v2s32 animation_frames[4], f32 frame_speed);
-	bool setPlayerEyeOffset(Player *player, v3f first, v3f third);
+	bool setLocalPlayerAnimations(RemotePlayer *player, v2s32 animation_frames[4],
+			f32 frame_speed);
+	bool setPlayerEyeOffset(RemotePlayer *player, v3f first, v3f third);
 
-	bool setSky(Player *player, const video::SColor &bgcolor,
+	bool setSky(RemotePlayer *player, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params);
 
 	bool overrideDayNightRatio(RemotePlayer *player, bool do_override, float brightness);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -44,7 +44,6 @@ Some planning
 
 class ServerEnvironment;
 struct ItemStack;
-class Player;
 struct ToolCapabilities;
 struct ObjectProperties;
 
@@ -69,23 +68,23 @@ public:
 	// environment
 	virtual bool environmentDeletes() const
 	{ return true; }
-	
+
 	// Create a certain type of ServerActiveObject
 	static ServerActiveObject* create(ActiveObjectType type,
 			ServerEnvironment *env, u16 id, v3f pos,
 			const std::string &data);
-	
+
 	/*
 		Some simple getters/setters
 	*/
 	v3f getBasePosition(){ return m_base_position; }
 	void setBasePosition(v3f pos){ m_base_position = pos; }
 	ServerEnvironment* getEnv(){ return m_env; }
-	
+
 	/*
 		Some more dynamic interface
 	*/
-	
+
 	virtual void setPos(v3f pos)
 		{ setBasePosition(pos); }
 	// continuous: if true, object does not stop immediately at pos
@@ -96,7 +95,7 @@ public:
 	virtual float getMinimumSavedMovement();
 
 	virtual std::string getDescription(){return "SAO";}
-	
+
 	/*
 		Step object in time.
 		Messages added to messages are sent to client over network.
@@ -108,13 +107,13 @@ public:
 			packet.
 	*/
 	virtual void step(float dtime, bool send_recommended){}
-	
+
 	/*
 		The return value of this is passed to the client-side object
 		when it is created
 	*/
 	virtual std::string getClientInitializationData(u16 protocol_version){return "";}
-	
+
 	/*
 		The return value of this is passed to the server-side object
 		when it is created (converted from static to active - actually
@@ -131,7 +130,7 @@ public:
 	*/
 	virtual bool isStaticAllowed() const
 	{return true;}
-	
+
 	// Returns tool wear
 	virtual int punch(v3f dir,
 			const ToolCapabilities *toolcap=NULL,
@@ -207,7 +206,7 @@ public:
 		- This can be set to true by anything else too.
 	*/
 	bool m_removed;
-	
+
 	/*
 		This is set to true when an object should be removed from the active
 		object list but couldn't be removed because the id has to be
@@ -218,7 +217,7 @@ public:
 		list.
 	*/
 	bool m_pending_deactivation;
-	
+
 	/*
 		Whether the object's static data has been stored to a block
 	*/
@@ -228,12 +227,12 @@ public:
 		a copy of the static data resides.
 	*/
 	v3s16 m_static_block;
-	
+
 	/*
 		Queue of messages to be sent to the client
 	*/
 	std::queue<ActiveObjectMessage> m_messages_out;
-	
+
 protected:
 	// Used for creating objects based on type
 	typedef ServerActiveObject* (*Factory)


### PR DESCRIPTION
* Server/Client Environments now have an helper to cast Player object in the right type to use it
* Server: use RemotePlayer everywhere and remove previous added casts
* Client: use LocalPlayer where needed
* Environment: remove unused functions (getPlayers(), getRandomConnectedPlayer(), getNearestConnectedPlayer())