### PR TITLE
Ensure std::unordered_ be used on MSVC 2010 too

### DIFF
--- a/src/util/cpp11_container.h
+++ b/src/util/cpp11_container.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define USE_UNORDERED_CONTAINERS
 #endif
 
-#if _MSC_VER >= 1800
+#if _MSC_VER >= 1600
 #define USE_UNORDERED_CONTAINERS
 #endif
 


### PR DESCRIPTION
Addition for #4597 
Known issue with std::move http://stackoverflow.com/questions/12787229/vc10-unordered-set-map-move-constructor-bug (only used once in cguittfont)