### PR TITLE
Environment cleanup

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -257,7 +257,7 @@ Client::Client(
 	m_localdb(NULL)
 {
 	// Add local player
-	m_env.addPlayer(new LocalPlayer(this, playername));
+	m_env.setLocalPlayer(new LocalPlayer(this, playername));
 
 	m_mapper = new Mapper(device, this);
 	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
@@ -1418,8 +1418,9 @@ Inventory* Client::getInventory(const InventoryLocation &loc)
 	break;
 	case InventoryLocation::PLAYER:
 	{
-		LocalPlayer *player = m_env.getPlayer(loc.name.c_str());
-		if(!player)
+		// Check if we are working with local player inventory
+		LocalPlayer *player = m_env.getLocalPlayer();
+		if (!player || strcmp(player->getName(), loc.name.c_str()) != 0)
 			return NULL;
 		return &player->inventory;
 	}
@@ -1498,11 +1499,6 @@ ClientActiveObject * Client::getSelectedActiveObject(
 	}
 
 	return NULL;
-}
-
-std::list<std::string> Client::getConnectedPlayerNames()
-{
-	return m_env.getPlayerNames();
 }
 
 float Client::getAnimationTime()
@@ -1664,7 +1660,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 ClientEvent Client::getClientEvent()
 {
 	ClientEvent event;
-	if(m_client_event_queue.size() == 0) {
+	if (m_client_event_queue.empty()) {
 		event.type = CE_NONE;
 	}
 	else {

--- a/src/client.h
+++ b/src/client.h
@@ -452,7 +452,10 @@ public:
 			core::line3d<f32> shootline_on_map
 	);
 
-	std::list<std::string> getConnectedPlayerNames();
+	const std::list<std::string> &getConnectedPlayerNames()
+	{
+		return m_env.getPlayerNames();
+	}
 
 	float getAnimationTime();
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -653,10 +653,10 @@ void GenericCAO::initialize(const std::string &data)
 	pos_translator.init(m_position);
 	updateNodePos();
 
-	if(m_is_player)
-	{
-		LocalPlayer *player = m_env->getPlayer(m_name.c_str());
-		if (player && player->isLocal()) {
+	if (m_is_player) {
+		// Check if it's the current player
+		LocalPlayer *player = m_env->getLocalPlayer();
+		if (player && strcmp(player->getName(), m_name.c_str()) == 0) {
 			m_is_local_player = true;
 			m_is_visible = false;
 			LocalPlayer* localplayer = player;

--- a/src/environment.h
+++ b/src/environment.h
@@ -72,9 +72,6 @@ public:
 
 	virtual Map & getMap() = 0;
 
-	virtual void addPlayer(Player *player);
-	void removePlayer(Player *player);
-
 	u32 getDayNightRatio();
 
 	// 0-23999
@@ -94,12 +91,6 @@ public:
 	u32 m_added_objects;
 
 protected:
-	Player *getPlayer(u16 peer_id);
-	Player *getPlayer(const char *name);
-
-	// peer_ids in here should be unique, except that there may be many 0s
-	std::vector<Player*> m_players;
-
 	GenericAtomic<float> m_time_of_day_speed;
 
 	/*
@@ -325,6 +316,8 @@ public:
 	void saveLoadedPlayers();
 	void savePlayer(RemotePlayer *player);
 	RemotePlayer *loadPlayer(const std::string &playername);
+	void addPlayer(RemotePlayer *player);
+	void removePlayer(RemotePlayer *player);
 
 	/*
 		Save and load time of day and game timer
@@ -520,6 +513,9 @@ private:
 	// Can raise to high values like 15s with eg. map generation mods.
 	float m_max_lag_estimate;
 
+	// peer_ids in here should be unique, except that there may be many 0s
+	std::vector<RemotePlayer*> m_players;
+
 	// Particles
 	IntervalLimiter m_particle_management_interval;
 	UNORDERED_MAP<u32, float> m_particle_spawners;
@@ -579,8 +575,8 @@ public:
 
 	void step(f32 dtime);
 
-	virtual void addPlayer(LocalPlayer *player);
-	LocalPlayer * getLocalPlayer();
+	virtual void setLocalPlayer(LocalPlayer *player);
+	LocalPlayer *getLocalPlayer() { return m_local_player; }
 
 	/*
 		ClientSimpleObjects
@@ -630,21 +626,15 @@ public:
 
 	u16 attachement_parent_ids[USHRT_MAX + 1];
 
-	std::list<std::string> getPlayerNames()
-	{ return m_player_names; }
-	void addPlayerName(std::string name)
-	{ m_player_names.push_back(name); }
-	void removePlayerName(std::string name)
-	{ m_player_names.remove(name); }
+	const std::list<std::string> &getPlayerNames() { return m_player_names; }
+	void addPlayerName(const std::string &name) { m_player_names.push_back(name); }
+	void removePlayerName(const std::string &name) { m_player_names.remove(name); }
 	void updateCameraOffset(v3s16 camera_offset)
 	{ m_camera_offset = camera_offset; }
 	v3s16 getCameraOffset() const { return m_camera_offset; }
-
-	LocalPlayer *getPlayer(const u16 peer_id);
-	LocalPlayer *getPlayer(const char* name);
-
 private:
 	ClientMap *m_map;
+	LocalPlayer *m_local_player;
 	scene::ISceneManager *m_smgr;
 	ITextureSource *m_texturesource;
 	IGameDef *m_gamedef;

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -38,11 +38,6 @@ public:
 	LocalPlayer(Client *gamedef, const char *name);
 	virtual ~LocalPlayer();
 
-	bool isLocal() const
-	{
-		return true;
-	}
-
 	ClientActiveObject *parent;
 
 	bool got_teleported;

--- a/src/player.h
+++ b/src/player.h
@@ -183,22 +183,6 @@ public:
 		return size;
 	}
 
-	void setLocalAnimations(v2s32 frames[4], float frame_speed)
-	{
-		for (int i = 0; i < 4; i++)
-			local_animations[i] = frames[i];
-		local_animation_speed = frame_speed;
-	}
-
-	void getLocalAnimations(v2s32 *frames, float *frame_speed)
-	{
-		for (int i = 0; i < 4; i++)
-			frames[i] = local_animations[i];
-		*frame_speed = local_animation_speed;
-	}
-
-	virtual bool isLocal() const { return false; }
-
 	bool camera_barely_in_ceiling;
 	v3f eye_offset_first;
 	v3f eye_offset_third;

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -142,6 +142,20 @@ public:
 		Player::setYaw(yaw);
 	}
 
+	void setLocalAnimations(v2s32 frames[4], float frame_speed)
+	{
+		for (int i = 0; i < 4; i++)
+			local_animations[i] = frames[i];
+		local_animation_speed = frame_speed;
+	}
+
+	void getLocalAnimations(v2s32 *frames, float *frame_speed)
+	{
+		for (int i = 0; i < 4; i++)
+			frames[i] = local_animations[i];
+		*frame_speed = local_animation_speed;
+	}
+
 	u16 protocol_version;
 private:
 	/*


### PR DESCRIPTION
* Move client list to ServerEnvironment and use RemotePlayer members instead of Player
* ClientEnvironment only use setLocalPlayer to specify the current player
* Remove ClientEnvironment dead code on player list (in fact other players are CAO not Player objects)
* Drop LocalPlayer::getPlayer(xxx) functions which aren't used.
* Improve a little bit performance by using const ref list for ClientEnvironment::getPlayerNames() & Client::getConnectedPlayerNames()
* Drop isLocal() function from (Local)Player which is not needed anymore because of previous changes

This change permits to cleanup shared client list which is very old code.
ClientEnvironment doesn't use player list anymore, it only contains the local player, as addPlayer is only called from Client constructor client side.
Clients are only CAO on client side, this cleanup permit to remove confusion about player list.