### PR TITLE
Fix crash on attaching player to entity

### DIFF
--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -125,6 +125,8 @@ public:
 
 	void initialize(const std::string &data);
 
+	void processInitData(const std::string &data);
+
 	ClientActiveObject *getParent();
 
 	bool getCollisionBox(aabb3f *toset);


### PR DESCRIPTION
Fix crash caused by attaching player to entity by using another new function on child client objects.

For details check https://github.com/minetest/minetest/issues/4610