### PR TITLE
Player class cleanup / PlayerSAO - LocalPlayer ownership

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "environment.h"
 #include "map.h"
 #include "emerge.h"
-#include "serverobject.h"              // TODO this is used for cleanup of only
+#include "content_sao.h"              // TODO this is used for cleanup of only
 #include "log.h"
 #include "util/srp.h"
 
@@ -82,6 +82,10 @@ void RemoteClient::GetNextBlocks (
 	if (player == NULL)
 		return;
 
+	PlayerSAO *sao = player->getPlayerSAO();
+	if (sao == NULL)
+		return;
+
 	// Won't send anything if already sending
 	if(m_blocks_sending.size() >= g_settings->getU16
 			("max_simultaneous_block_sends_per_client"))
@@ -90,7 +94,7 @@ void RemoteClient::GetNextBlocks (
 		return;
 	}
 
-	v3f playerpos = player->getPosition();
+	v3f playerpos = sao->getBasePosition();
 	v3f playerspeed = player->getSpeed();
 	v3f playerspeeddir(0,0,0);
 	if(playerspeed.getLength() > 1.0*BS)
@@ -103,10 +107,10 @@ void RemoteClient::GetNextBlocks (
 	v3s16 center = getNodeBlockPos(center_nodepos);
 
 	// Camera position and direction
-	v3f camera_pos = player->getEyePosition();
+	v3f camera_pos = sao->getEyePosition();
 	v3f camera_dir = v3f(0,0,1);
-	camera_dir.rotateYZBy(player->getPitch());
-	camera_dir.rotateXZBy(player->getYaw());
+	camera_dir.rotateYZBy(sao->getPitch());
+	camera_dir.rotateXZBy(sao->getYaw());
 
 	/*infostream<<"camera_dir=("<<camera_dir.X<<","<<camera_dir.Y<<","
 			<<camera_dir.Z<<")"<<std::endl;*/

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -367,7 +367,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 #endif
 		{
 			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
-			if (s_env != 0) {
+			if (s_env != NULL) {
 				f32 distance = speed_f->getLength();
 				std::vector<u16> s_objects;
 				s_env->getObjectsInsideRadius(s_objects, *pos_f, distance * 1.5);

--- a/src/environment.h
+++ b/src/environment.h
@@ -54,6 +54,7 @@ class ClientMap;
 class GameScripting;
 class Player;
 class RemotePlayer;
+class PlayerSAO;
 
 class Environment
 {
@@ -315,7 +316,7 @@ public:
 	// Save players
 	void saveLoadedPlayers();
 	void savePlayer(RemotePlayer *player);
-	RemotePlayer *loadPlayer(const std::string &playername);
+	RemotePlayer *loadPlayer(const std::string &playername, PlayerSAO *sao);
 	void addPlayer(RemotePlayer *player);
 	void removePlayer(RemotePlayer *player);
 
@@ -362,7 +363,7 @@ public:
 		Find out what new objects have been added to
 		inside a radius around a position
 	*/
-	void getAddedActiveObjects(RemotePlayer *player, s16 radius,
+	void getAddedActiveObjects(PlayerSAO *playersao, s16 radius,
 			s16 player_radius,
 			std::set<u16> &current_objects,
 			std::queue<u16> &added_objects);
@@ -371,7 +372,7 @@ public:
 		Find out what new objects have been removed from
 		inside a radius around a position
 	*/
-	void getRemovedActiveObjects(RemotePlayer *player, s16 radius,
+	void getRemovedActiveObjects(PlayerSAO *playersao, s16 radius,
 			s16 player_radius,
 			std::set<u16> &current_objects,
 			std::queue<u16> &removed_objects);

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 LocalPlayer::LocalPlayer(Client *gamedef, const char *name):
 	Player(name, gamedef->idef()),
 	parent(0),
+	hp(PLAYER_MAX_HP),
 	got_teleported(false),
 	isAttached(false),
 	touching_ground(false),
@@ -62,6 +63,7 @@ LocalPlayer::LocalPlayer(Client *gamedef, const char *name):
 	light_color(255,255,255,255),
 	hurt_tilt_timer(0.0f),
 	hurt_tilt_strength(0.0f),
+	m_position(0,0,0),
 	m_sneak_node(32767,32767,32767),
 	m_sneak_node_exists(false),
 	m_need_to_get_new_sneak_node(true),
@@ -69,6 +71,11 @@ LocalPlayer::LocalPlayer(Client *gamedef, const char *name):
 	m_old_node_below(32767,32767,32767),
 	m_old_node_below_type("air"),
 	m_can_jump(false),
+	m_breath(PLAYER_MAX_BREATH),
+	m_yaw(0),
+	m_pitch(0),
+	camera_barely_in_ceiling(false),
+	m_collisionbox(-BS * 0.30, 0.0, -BS * 0.30, BS * 0.30, BS * 1.75, BS * 0.30),
 	m_cao(NULL),
 	m_gamedef(gamedef)
 {

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -40,6 +40,7 @@ public:
 
 	ClientActiveObject *parent;
 
+	u16 hp;
 	bool got_teleported;
 	bool isAttached;
 	bool touching_ground;
@@ -99,10 +100,45 @@ public:
 
 	u32 maxHudId() const { return hud.size(); }
 
+	u16 getBreath() const { return m_breath; }
+	void setBreath(u16 breath) { m_breath = breath; }
+
+	v3s16 getLightPosition() const
+	{
+		return floatToInt(m_position + v3f(0,BS+BS/2,0), BS);
+	}
+
+	void setYaw(f32 yaw)
+	{
+		m_yaw = yaw;
+	}
+
+	f32 getYaw() const { return m_yaw; }
+
+	void setPitch(f32 pitch)
+	{
+		m_pitch = pitch;
+	}
+
+	f32 getPitch() const { return m_pitch; }
+
+	void setPosition(const v3f &position)
+	{
+		m_position = position;
+	}
+
+	v3f getPosition() const { return m_position; }
+	v3f getEyePosition() const { return m_position + getEyeOffset(); }
+	v3f getEyeOffset() const
+	{
+		float eye_height = camera_barely_in_ceiling ? 1.5f : 1.625f;
+		return v3f(0, BS * eye_height, 0);
+	}
 private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);
 
+	v3f m_position;
 	// This is used for determining the sneaking range
 	v3s16 m_sneak_node;
 	// Whether the player is allowed to sneak
@@ -117,6 +153,11 @@ private:
 	v3s16 m_old_node_below;
 	std::string m_old_node_below_type;
 	bool m_can_jump;
+	u16 m_breath;
+	f32 m_yaw;
+	f32 m_pitch;
+	bool camera_barely_in_ceiling;
+	aabb3f m_collisionbox;
 
 	GenericCAO* m_cao;
 	Client *m_gamedef;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -634,7 +634,6 @@ void Client::handleCommand_AnnounceMedia(NetworkPacket* pkt)
 		m_media_downloader->addFile(name, sha1_raw);
 	}
 
-	std::vector<std::string> remote_media;
 	try {
 		std::string str;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -30,18 +30,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 Player::Player(const char *name, IItemDefManager *idef):
-	camera_barely_in_ceiling(false),
 	inventory(idef),
-	hp(PLAYER_MAX_HP),
 	peer_id(PEER_ID_INEXISTENT),
 	keyPressed(0),
 // protected
-	m_breath(PLAYER_MAX_BREATH),
-	m_pitch(0),
-	m_yaw(0),
-	m_speed(0,0,0),
-	m_position(0,0,0),
-	m_collisionbox(-BS*0.30,0.0,-BS*0.30,BS*0.30,BS*1.75,BS*0.30)
+	m_speed(0,0,0)
 {
 	strlcpy(m_name, name, PLAYERNAME_SIZE);
 
@@ -88,11 +81,6 @@ Player::Player(const char *name, IItemDefManager *idef):
 Player::~Player()
 {
 	clearHud();
-}
-
-v3s16 Player::getLightPosition() const
-{
-	return floatToInt(m_position + v3f(0,BS+BS/2,0), BS);
 }
 
 u32 Player::addHud(HudElement *toadd)

--- a/src/player.h
+++ b/src/player.h
@@ -129,49 +129,7 @@ public:
 		m_speed = speed;
 	}
 
-	v3f getPosition()
-	{
-		return m_position;
-	}
-
-	v3s16 getLightPosition() const;
-
-	v3f getEyeOffset()
-	{
-		float eye_height = camera_barely_in_ceiling ? 1.5f : 1.625f;
-		return v3f(0, BS * eye_height, 0);
-	}
-
-	v3f getEyePosition()
-	{
-		return m_position + getEyeOffset();
-	}
-
-	virtual void setPosition(const v3f &position)
-	{
-		m_position = position;
-	}
-
-	virtual void setPitch(f32 pitch)
-	{
-		m_pitch = pitch;
-	}
-
-	virtual void setYaw(f32 yaw)
-	{
-		m_yaw = yaw;
-	}
-
-	f32 getPitch() const { return m_pitch; }
-	f32 getYaw() const { return m_yaw; }
-	u16 getBreath() const { return m_breath; }
-
-	virtual void setBreath(u16 breath) { m_breath = breath; }
-
-	f32 getRadPitch() const { return m_pitch * core::DEGTORAD; }
-	f32 getRadYaw() const { return m_yaw * core::DEGTORAD; }
 	const char *getName() const { return m_name; }
-	aabb3f getCollisionbox() const { return m_collisionbox; }
 
 	u32 getFreeHudID()
 	{
@@ -183,7 +141,6 @@ public:
 		return size;
 	}
 
-	bool camera_barely_in_ceiling;
 	v3f eye_offset_first;
 	v3f eye_offset_third;
 
@@ -205,8 +162,6 @@ public:
 	v2s32 local_animations[4];
 	float local_animation_speed;
 
-	u16 hp;
-
 	u16 peer_id;
 
 	std::string inventory_formspec;
@@ -225,12 +180,7 @@ public:
 	s32 hud_hotbar_itemcount;
 protected:
 	char m_name[PLAYERNAME_SIZE];
-	u16 m_breath;
-	f32 m_pitch;
-	f32 m_yaw;
 	v3f m_speed;
-	v3f m_position;
-	aabb3f m_collisionbox;
 
 	std::vector<HudElement *> hud;
 private:

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -40,11 +40,10 @@ public:
 	virtual ~RemotePlayer() {}
 
 	void save(std::string savedir, IGameDef *gamedef);
-	void deSerialize(std::istream &is, const std::string &playername);
+	void deSerialize(std::istream &is, const std::string &playername, PlayerSAO *sao);
 
 	PlayerSAO *getPlayerSAO() { return m_sao; }
 	void setPlayerSAO(PlayerSAO *sao) { m_sao = sao; }
-	void setPosition(const v3f &position);
 
 	const RemotePlayerChatResult canSendChatMessage();
 
@@ -67,9 +66,6 @@ public:
 		*ratio = m_day_night_ratio;
 	}
 
-	// Use a function, if isDead can be defined by other conditions
-	bool isDead() const { return hp == 0; }
-
 	void setHotbarImage(const std::string &name)
 	{
 		hud_hotbar_image = name;
@@ -89,12 +85,6 @@ public:
 	{
 		return hud_hotbar_selected_image;
 	}
-
-	// Deprecated
-	f32 getRadPitchDep() const { return -1.0 * m_pitch * core::DEGTORAD; }
-
-	// Deprecated
-	f32 getRadYawDep() const { return (m_yaw + 90.) * core::DEGTORAD; }
 
 	void setSky(const video::SColor &bgcolor, const std::string &type,
 				const std::vector<std::string> &params)
@@ -121,27 +111,6 @@ public:
 			inventory.setModified(x);
 	}
 
-	virtual void setBreath(u16 breath)
-	{
-		if (breath != m_breath)
-			m_dirty = true;
-		Player::setBreath(breath);
-	}
-
-	virtual void setPitch(f32 pitch)
-	{
-		if (pitch != m_pitch)
-			m_dirty = true;
-		Player::setPitch(pitch);
-	}
-
-	virtual void setYaw(f32 yaw)
-	{
-		if (yaw != m_yaw)
-			m_dirty = true;
-		Player::setYaw(yaw);
-	}
-
 	void setLocalAnimations(v2s32 frames[4], float frame_speed)
 	{
 		for (int i = 0; i < 4; i++)
@@ -155,6 +124,8 @@ public:
 			frames[i] = local_animations[i];
 		*frame_speed = local_animation_speed;
 	}
+
+	void setDirty(bool dirty) { m_dirty = true; }
 
 	u16 protocol_version;
 private:

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1013,11 +1013,11 @@ int ObjectRef::l_get_look_dir(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
 	// Do it
-	float pitch = player->getRadPitchDep();
-	float yaw = player->getRadYawDep();
+	float pitch = co->getRadPitchDep();
+	float yaw = co->getRadYawDep();
 	v3f v(cos(pitch)*cos(yaw), sin(pitch), cos(pitch)*sin(yaw));
 	push_v3f(L, v);
 	return 1;
@@ -1033,10 +1033,10 @@ int ObjectRef::l_get_look_pitch(lua_State *L)
 		"Deprecated call to get_look_pitch, use get_look_vertical instead");
 
 	ObjectRef *ref = checkobject(L, 1);
-	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
 	// Do it
-	lua_pushnumber(L, player->getRadPitchDep());
+	lua_pushnumber(L, co->getRadPitchDep());
 	return 1;
 }
 
@@ -1050,10 +1050,10 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 		"Deprecated call to get_look_yaw, use get_look_horizontal instead");
 
 	ObjectRef *ref = checkobject(L, 1);
-	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
 	// Do it
-	lua_pushnumber(L, player->getRadYawDep());
+	lua_pushnumber(L, co->getRadYawDep());
 	return 1;
 }
 
@@ -1062,10 +1062,10 @@ int ObjectRef::l_get_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
 	// Do it
-	lua_pushnumber(L, player->getRadPitch());
+	lua_pushnumber(L, co->getRadPitch());
 	return 1;
 }
 
@@ -1074,10 +1074,10 @@ int ObjectRef::l_get_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	PlayerSAO* co = getplayersao(ref);
+	if (co == NULL) return 0;
 	// Do it
-	lua_pushnumber(L, player->getRadYaw());
+	lua_pushnumber(L, co->getRadYaw());
 	return 1;
 }
 

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -85,7 +85,7 @@ public:
 		Some more dynamic interface
 	*/
 
-	virtual void setPos(v3f pos)
+	virtual void setPos(const v3f &pos)
 		{ setBasePosition(pos); }
 	// continuous: if true, object does not stop immediately at pos
 	virtual void moveTo(v3f pos, bool continuous)

--- a/src/unittest/test_player.cpp
+++ b/src/unittest/test_player.cpp
@@ -46,11 +46,14 @@ void TestPlayer::runTests(IGameDef *gamedef)
 void TestPlayer::testSave(IGameDef *gamedef)
 {
 	RemotePlayer rplayer("testplayer_save", gamedef->idef());
-	rplayer.setBreath(10);
-	rplayer.hp = 8;
-	rplayer.setYaw(0.1f);
-	rplayer.setPitch(0.6f);
-	rplayer.setPosition(v3f(450.2f, -15.7f, 68.1f));
+	PlayerSAO sao(NULL, 1, false);
+	sao.initialize(&rplayer, std::set<std::string>());
+	rplayer.setPlayerSAO(&sao);
+	sao.setBreath(10);
+	sao.setHP(8, true);
+	sao.setYaw(0.1f, false);
+	sao.setPitch(0.6f, false);
+	sao.setBasePosition(v3f(450.2f, -15.7f, 68.1f));
 	rplayer.save(".", gamedef);
 	UASSERT(fs::PathExists("testplayer_save"));
 }
@@ -58,24 +61,28 @@ void TestPlayer::testSave(IGameDef *gamedef)
 void TestPlayer::testLoad(IGameDef *gamedef)
 {
 	RemotePlayer rplayer("testplayer_load", gamedef->idef());
-	rplayer.setBreath(10);
-	rplayer.hp = 8;
-	rplayer.setYaw(0.1f);
-	rplayer.setPitch(0.6f);
-	rplayer.setPosition(v3f(450.2f, -15.7f, 68.1f));
+	PlayerSAO sao(NULL, 1, false);
+	sao.initialize(&rplayer, std::set<std::string>());
+	rplayer.setPlayerSAO(&sao);
+	sao.setBreath(10);
+	sao.setHP(8, true);
+	sao.setYaw(0.1f, false);
+	sao.setPitch(0.6f, false);
+	sao.setBasePosition(v3f(450.2f, -15.7f, 68.1f));
 	rplayer.save(".", gamedef);
 	UASSERT(fs::PathExists("testplayer_load"));
 
 	RemotePlayer rplayer_load("testplayer_load", gamedef->idef());
+	PlayerSAO sao_load(NULL, 2, false);
 	std::ifstream is("testplayer_load", std::ios_base::binary);
 	UASSERT(is.good());
-	rplayer_load.deSerialize(is, "testplayer_load");
+	rplayer_load.deSerialize(is, "testplayer_load", &sao_load);
 	is.close();
 
 	UASSERT(strcmp(rplayer_load.getName(), "testplayer_load") == 0);
-	UASSERT(rplayer.getBreath() == 10);
-	UASSERT(rplayer.hp == 8);
-	UASSERT(rplayer.getYaw() == 0.1f);
-	UASSERT(rplayer.getPitch() == 0.6f);
-	UASSERT(rplayer.getPosition() == v3f(450.2f, -15.7f, 68.1f));
+	UASSERT(sao_load.getBreath() == 10);
+	UASSERT(sao_load.getHP() == 8);
+	UASSERT(sao_load.getYaw() == 0.1f);
+	UASSERT(sao_load.getPitch() == 0.6f);
+	UASSERT(sao_load.getBasePosition() == v3f(450.2f, -15.7f, 68.1f));
 }


### PR DESCRIPTION
Many attributes are SAO attributes, not really player object attribute (server side)
RemotePlayer is a pseudo session & player object, but SAO is the real ingame object. 
It make sense to migrate attributes from Player base class to PlayerSAO (server) & LocalPlayer (client)
As RemotePlayer is never removed from server, it also permit to reduce memory usage from server when player was disconnected because PlayerSAO is properly cleaned.

This change require to change some old parts to permit cross usage of PlayerSAO & RemotePlayer objects server side. I don't know if this PR will really move all attributes to PlayerSAO but i don't think i will have time to do everything, but we can do it in multiple parts.

With this PR PlayerSAO is inited in two phases because of the cross dep between RemotePlayer & PlayerSAO.