### PR TITLE
Enable mod security by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1148,7 +1148,7 @@ mgvalleys_np_inter_valley_slope (Valley Slope) noise_params 0.5, 0.5, (128, 128,
 [*Security]
 
 #    Prevent mods from doing insecure things like running shell commands.
-secure.enable_security (Enable mod security) bool false
+secure.enable_security (Enable mod security) bool true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure
 #    functions even when mod security is on (via request_insecure_environment()).

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1457,7 +1457,7 @@
 
 #    Prevent mods from doing insecure things like running shell commands.
 #    type: bool
-# secure.enable_security = false
+# secure.enable_security = true
 
 #    Comma-separated list of trusted mods that are allowed to access insecure
 #    functions even when mod security is on (via request_insecure_environment()).

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -298,7 +298,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");
 	settings->setDefault("num_emerge_threads", "1");
-	settings->setDefault("secure.enable_security", "false");
+	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");
 	settings->setDefault("secure.http_mods", "");
 


### PR DESCRIPTION
This was left disabled by default at first to avoid breaking anything and I just didn't get around to enabling it until now.

The only major mod that I know of that this breaks now is player_textures, [but there's a PR to fix it](https://github.com/PilzAdam/player_textures/pull/2), it just hasn't been merged yet (_ahem_ @PilzAdam).
