### PR TITLE
Enforce only one punch each full_punch_interval

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1398,8 +1398,6 @@ void KeyCache::populate()
 
  ****************************************************************************/
 
-const float object_hit_delay = 0.2;
-
 struct FpsControl {
 	u32 last_time, busy_time, sleep_time;
 };
@@ -3917,7 +3915,9 @@ void Game::handlePointingAtObject(GameRunData *runData,
 		if (runData->object_hit_delay_timer <= 0.0) {
 			do_punch = true;
 			do_punch_damage = true;
-			runData->object_hit_delay_timer = object_hit_delay;
+			runData->object_hit_delay_timer =
+				playeritem.getToolCapabilities(itemdef_manager)
+				.full_punch_interval;
 		}
 
 		if (getLeftClicked())


### PR DESCRIPTION
Punching with e.g. the 'hand' tool only deals damage if you wait 1 second from the last one. This PR allows you to spam-click, previously spam-clicking would deal zero damage as there never is a 1.0 sec pause.
