### PR TITLE
Builtin/../falling.lua: Do not call nodeupdate() on node punch

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -262,8 +262,3 @@ function on_dignode(p, node)
 	nodeupdate(p)
 end
 core.register_on_dignode(on_dignode)
-
-function on_punchnode(p, node)
-	nodeupdate(p)
-end
-core.register_on_punchnode(on_punchnode)


### PR DESCRIPTION
Originally part of a pull request by tenplus1.
Calling nodeupdate() on node punch was added for 0.4.14 stable.
Each tool or hand punch was triggering nodeupdate_single() for neighbour
nodes and a possible chain-reaction of nodeupdates through connected
falling nodes.
Now only nodeupdate() on place or dig node.
/////////////////////////////////////////////////////

Originally part of tenplus1's PR #4620 this has been split off into a seperate PR due to controversy and the need for more opinions.
See #4620 for the arguments for and against.
To be clear i approve this change.
@sfan5 do you still approve?