### PR TITLE
Client camera position not respecting attachment position offset

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -227,7 +227,10 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	v3f old_player_position = m_playernode->getPosition();
 	v3f player_position = player->getPosition();
 	if (player->isAttached && player->parent)
-		player_position = player->parent->getPosition();
+	{
+		v3f* attach_offset = &player->getCAO()->m_attachment_position;
+		player_position = player->parent->getPosition() - v3f(attach_offset->X, 0, attach_offset->Z);
+	}
 	//if(player->touching_ground && player_position.Y > old_player_position.Y)
 	if(player->touching_ground &&
 			player_position.Y > old_player_position.Y)

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -58,6 +58,8 @@ struct SmoothTranslator
 
 class GenericCAO : public ClientActiveObject
 {
+public:
+	v3f m_attachment_position;
 private:
 	// Only set at initialization
 	std::string m_name;
@@ -92,7 +94,7 @@ private:
 	bool m_animation_loop;
 	UNORDERED_MAP<std::string, core::vector2d<v3f> > m_bone_position; // stores position and rotation for each bone name
 	std::string m_attachment_bone;
-	v3f m_attachment_position;
+
 	v3f m_attachment_rotation;
 	bool m_attached_to_local;
 	int m_anim_frame;


### PR DESCRIPTION
When attaching the player to an object and specifying a positional offset, the camera does not respect this positional offset and is just set 1.8 units above the parent's base position
This very simple fix works only for objects not attached to a bone. a better solution would be to attach the player scene node directly to the one of the CAO, but my limited knowledge about c++ and irrlicht does not allow me to do so.
I would need this fix for my advtrains mod to work properly. Before merging or reimplementing this, it should be considered if it would break other existing mods.
before:
![screenshot_20161016_171425](https://cloud.githubusercontent.com/assets/13201701/19418437/236a562c-93c4-11e6-9838-57fd6ce14b17.png)
after:
![screenshot_20161016_171500](https://cloud.githubusercontent.com/assets/13201701/19418442/326e1550-93c4-11e6-9b81-c6e375f807cd.png)