### PR TITLE
Allow the join/leave message to be overridden by mods.

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -42,22 +42,30 @@ end
 
 local player_list = {}
 
-core.register_on_joinplayer(function(player)
-	local player_name = player:get_player_name()
-	player_list[player_name] = player
+function core.send_join_message(player_name)
 	if not minetest.is_singleplayer() then
 		core.chat_send_all("*** " .. player_name .. " joined the game.")
 	end
-end)
+end
 
-core.register_on_leaveplayer(function(player, timed_out)
-	local player_name = player:get_player_name()
-	player_list[player_name] = nil
+function core.send_leave_message(player_name, timed_out)
 	local announcement = "*** " ..  player_name .. " left the game."
 	if timed_out then
 		announcement = announcement .. " (timed out)"
 	end
 	core.chat_send_all(announcement)
+end
+
+core.register_on_joinplayer(function(player)
+	local player_name = player:get_player_name()
+	player_list[player_name] = player
+	core.send_join_message(player_name)
+end)
+
+core.register_on_leaveplayer(function(player, timed_out)
+	local player_name = player:get_player_name()
+	player_list[player_name] = nil
+	core.send_leave_message(player_name, timed_out)
 end)
 
 function core.get_connected_players()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2711,6 +2711,10 @@ These functions return the leftover itemstack.
     * Replaces definition of a builtin hud element
     * `name`: `"breath"` or `"health"`
     * `hud_definition`: definition to replace builtin definition
+* `minetest.send_join_message(player_name)`
+    * Can be overridden by mods to change the join message
+* `minetest.send_leave_message(player_name, timed_out)`
+    * Can be overridden by mods to change the leave message
 * `minetest.hash_node_position({x=,y=,z=})`: returns an 48-bit integer
     * Gives a unique hash number for a node position (16+16+16=48bit)
 * `minetest.get_position_from_hash(hash)`: returns a position


### PR DESCRIPTION
Requested in #4227. this allows modifying join/leave messages without modifying builtin, making it possible to do in a mod.
