### PR TITLE
Don't use day light sky unless noclip and free_move are enabled

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1845,6 +1845,10 @@ Game::~Game()
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("repeat_rightclick_time",
 		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("noclip",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("free_move",
+		&settingChangedCallback, this);
 }
 
 bool Game::startup(bool *kill,
@@ -2965,14 +2969,12 @@ void Game::toggleFreeMove(float *statustext_time)
 	static const wchar_t *msg[] = { L"free_move disabled", L"free_move enabled" };
 
 	bool free_move = !g_settings->getBool("free_move");
+	g_settings->set("free_move", bool_to_cstr(free_move));
 
 	*statustext_time = 0;
 	statustext = msg[free_move];
-	if (free_move && !client->checkPrivilege("fly")) {
+	if (free_move && !client->checkPrivilege("fly"))
 		statustext += L" (note: no 'fly' privilege)";
-	} else {
-		g_settings->set("free_move", bool_to_cstr(free_move));
-	}
 }
 
 
@@ -3007,15 +3009,13 @@ void Game::toggleNoClip(float *statustext_time)
 {
 	static const wchar_t *msg[] = { L"noclip disabled", L"noclip enabled" };
 	bool noclip = !g_settings->getBool("noclip");
+	g_settings->set("noclip", bool_to_cstr(noclip));
 
 	*statustext_time = 0;
 	statustext = msg[noclip];
 
-	if (noclip && !client->checkPrivilege("noclip")) {
+	if (noclip && !client->checkPrivilege("noclip"))
 		statustext += L" (note: no 'noclip' privilege)";
-	} else {
-		g_settings->set("noclip", bool_to_cstr(noclip));
-	}
 }
 
 void Game::toggleCinematic(float *statustext_time)


### PR DESCRIPTION
How about this as sky color fox? Avoids getting settings in updateFrame, and only shows the sky when noclip and free_move are enabled.

Fixes #4640 and #4187, replaces #4643 (which I botched :( )

- Doesn't allow enabling free_move unless the fly privilege is given
- Doesn't allow enabling noclip unless the noclip privilege is given
- Caches the noclip and free_move settings, to avoid retrieving those in updateFrame
- Only renders the sky background when both noclip and free_move are enabled

This should make the behavior more predictable for users; perpetuates the local caching in the class Game, though.
