### PR TITLE
Changes to static object storage limit and error message 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -817,7 +817,7 @@ max_clearobjects_extra_loaded_blocks (Max. clearobjects extra blocks) int 4096
 server_unload_unused_data_timeout (Unload unused server data) int 29
 
 #    Maximum number of statically stored objects in a block.
-max_objects_per_block (Maximum objects per block) int 49
+max_objects_per_block (Maximum objects per block) int 64
 
 #    See http://www.sqlite.org/pragma.html#pragma_synchronous
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1008,7 +1008,7 @@
 
 #    Maximum number of statically stored objects in a block.
 #    type: int
-# max_objects_per_block = 49
+# max_objects_per_block = 64
 
 #    See http://www.sqlite.org/pragma.html#pragma_synchronous
 #    type: enum values: 0, 1, 2

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -283,7 +283,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("time_send_interval", "5");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");
-	settings->setDefault("max_objects_per_block", "49");
+	settings->setDefault("max_objects_per_block", "64");
 	settings->setDefault("server_map_save_interval", "5.3");
 	settings->setDefault("chat_message_max_size", "500");
 	settings->setDefault("chat_message_limit_per_10sec", "8.0");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2175,13 +2175,13 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 
 			if(block)
 			{
-				if(block->m_static_objects.m_stored.size() >= g_settings->getU16("max_objects_per_block")){
-					errorstream<<"ServerEnv: Trying to store id="<<obj->getId()
-							<<" statically but block "<<PP(blockpos)
-							<<" already contains "
-							<<block->m_static_objects.m_stored.size()
-							<<" objects."
-							<<" Forcing delete."<<std::endl;
+				if (block->m_static_objects.m_stored.size() >= g_settings->getU16("max_objects_per_block")) {
+					warningstream << "ServerEnv: Trying to store id = " << obj->getId()
+							<< " statically but block " << PP(blockpos)
+							<< " already contains "
+							<< block->m_static_objects.m_stored.size()
+							<< " objects."
+							<< " Forcing delete." << std::endl;
 					force_delete = true;
 				} else {
 					// If static counterpart already exists in target block,


### PR DESCRIPTION
Move static object storage force-delete message from errorstream to
warningstream.
Increase 'max objects per block' setting to 64.
Add missing spaces in warning code.
/////////////////////////////////

Addresses #4648 