### PR TITLE
Use same fog calculation in Shaders and Irrlicht

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -197,14 +197,14 @@ void main(void)
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(length(eyeVec) / fogDistance * 1.5 - 0.6, 1.0));
-		alpha = mix(alpha, 0.0, d);
+		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
+		alpha = mix(0.0, alpha, d);
 	}
 	col = vec4(col.rgb, alpha);
 #else
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(length(eyeVec) / fogDistance * 1.5 - 0.6, 1.0));
-		col = mix(col, skyBgColor, d);
+		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
+		col = mix(skyBgColor, col, d);
 	}
 	col = vec4(col.rgb, base.a);
 #endif

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -153,14 +153,14 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(length(eyeVec) / fogDistance * 1.5 - 0.6, 1.0));
-		alpha = mix(alpha, 0.0, d);
+		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
+		alpha = mix(0.0, alpha, d);
 	}
 	col = vec4(col.rgb, alpha);
 #else
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(length(eyeVec) / fogDistance * 1.5 - 0.6, 1.0));
-		col = mix(col, skyBgColor, d);
+		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
+		col = mix(skyBgColor, col, d);
 	}
 	col = vec4(col.rgb, base.a);
 #endif

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -107,8 +107,8 @@ void main(void)
 	vec4 col = vec4(color.rgb, base.a);
 	col *= gl_Color;
 	if (fogDistance != 0.0) {
-		float d = max(0.0, min(length(eyeVec) / fogDistance * 1.5 - 0.6, 1.0));
-		col = mix(col, skyBgColor, d);
+		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
+		col = mix(skyBgColor, col, d);
 	}
 	gl_FragColor = vec4(col.rgb, base.a);
 }


### PR DESCRIPTION
This PR contains two commits:

1. change fog calculation from `d/fogDistance * 1.5 - 0.6`, which tries to find the right linear slope to match what Irrlich is doing with `(fogDistance - d)/(fogDistance*0.6)`, which has the right slope automatically, also use `clamp(..., 0.0, 1.0)` instead of max(0.0, min(..., 1.0))
Irrlicht had a slightly shorter range than the shaders because of the slope not being 100% matched, this is now fixed (i.e. the shaders now show a slightly smaller range, that matches what Irrlicht does).

2. Currently fog is shown in last 60% of the visible range, fogging a large area unnecessarily (IMHO). Only doing that in that furthest 20% gives a "sharp" view closeby, while still hiding the edges in the fog. (that also seems more like Mindcraft renders its fog, but that's immaterial). 
Even fogged areas need to be rendered unless completely hidden, so this has no impact on performance (if anything what is rendered is better visible), the view range has not changed.

Have a look. I can attach screenshots as well.
