### PR TITLE
Windows: dont link to libraries that are already linked by cmake

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,15 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifdef _MSC_VER
-	#ifndef SERVER // Dedicated server isn't linked with Irrlicht
-		#pragma comment(lib, "Irrlicht.lib")
-		// This would get rid of the console window
-		//#pragma comment(linker, "/subsystem:windows /ENTRY:mainCRTStartup")
-	#endif
-	#pragma comment(lib, "zlibwapi.lib")
-	#pragma comment(lib, "Shell32.lib")
-#endif
+// This would get rid of the console window
+//#pragma comment(linker, "/subsystem:windows /ENTRY:mainCRTStartup")
 
 #include "irrlicht.h" // createDevice
 


### PR DESCRIPTION
This solves some problem whith building where build fails if the libraries have different names eg. zlib is named zlib.lib or zlib-static.lib and not zlibwapi.lib

They get already linked by the cmake script:
IRRLICHT_LIBRARY
ZLIB_LIBRARIES