### PR TITLE
Damage sounds: Balance gain levels

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -831,13 +831,13 @@ public:
 	static void playerDamage(MtEvent *e, void *data)
 	{
 		SoundMaker *sm = (SoundMaker *)data;
-		sm->m_sound->playSound(SimpleSoundSpec("player_damage", 0.5), false);
+		sm->m_sound->playSound(SimpleSoundSpec("player_damage", 0.6), false);
 	}
 
 	static void playerFallingDamage(MtEvent *e, void *data)
 	{
 		SoundMaker *sm = (SoundMaker *)data;
-		sm->m_sound->playSound(SimpleSoundSpec("player_falling_damage", 0.5), false);
+		sm->m_sound->playSound(SimpleSoundSpec("player_falling_damage", 0.3), false);
 	}
 
 	void registerReceiver(MtEventManager *mgr)


### PR DESCRIPTION
Damage sounds have been added to MTGame, but the gains are set in the engine, this balances the volume levels.