### PR TITLE
Shaders: Apply tone mapping before fog calculation.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -194,6 +194,10 @@ void main(void)
 
 	vec4 col = vec4(color.rgb * gl_Color.rgb, 1.0); 
 	
+#ifdef ENABLE_TONE_MAPPING
+	col = applyToneMapping(col);
+#endif
+
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
@@ -209,9 +213,5 @@ void main(void)
 	col = vec4(col.rgb, base.a);
 #endif
 
-#ifdef ENABLE_TONE_MAPPING
-	gl_FragColor = applyToneMapping(col);
-#else
 	gl_FragColor = col;
-#endif
 }

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -150,6 +150,10 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 
 	vec4 col = vec4(color.rgb * gl_Color.rgb, 1.0); 
 
+#ifdef ENABLE_TONE_MAPPING
+	col = applyToneMapping(col);
+#endif
+
 #if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE
 	float alpha = gl_Color.a;
 	if (fogDistance != 0.0) {
@@ -165,9 +169,5 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 	col = vec4(col.rgb, base.a);
 #endif
 
-#ifdef ENABLE_TONE_MAPPING
-	gl_FragColor = applyToneMapping(col);
-#else
 	gl_FragColor = col;
-#endif
 }


### PR DESCRIPTION
The tone mapping defeats the smooth fog, especially in a distance, leading to jaggy edges.
