### PR TITLE
Implement delayed server shutdown with cancelation

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -763,14 +763,20 @@ core.register_chatcommand("days", {
 
 core.register_chatcommand("shutdown", {
 	description = "Shutdown server",
-	params = "[reconnect] [message]",
+	params = "[delay_in_seconds(0..inf) or -1 for cancel] [reconnect] [message]",
 	privs = {server=true},
 	func = function(name, param)
-		core.log("action", name .. " shuts down server")
-		core.chat_send_all("*** Server shutting down (operator request).")
-		local reconnect, message = param:match("([^ ]+)(.*)")
+		local delay, reconnect, message = param:match("([^ ][-]?[0-9]+)([^ ]+)(.*)")
 		message = message or ""
-		core.request_shutdown(message:trim(), core.is_yes(reconnect))
+
+		if delay ~= "" then
+			delay = tonumber(param) or 0
+		else
+			delay = 0
+			core.log("action", name .. " shuts down server")
+			core.chat_send_all("*** Server shutting down (operator request).")
+		end
+		core.request_shutdown(message:trim(), core.is_yes(reconnect), delay)
 	end,
 })
 

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -173,3 +173,8 @@ end
 function core.close_formspec(player_name, formname)
 	return minetest.show_formspec(player_name, formname, "")
 end
+
+function core.cancel_shutdown_requests()
+	core.request_shutdown("", false, -1)
+end
+

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2576,8 +2576,12 @@ These functions return the leftover itemstack.
     * Optional: Variable number of arguments that are passed to `func`
 
 ### Server
-* `minetest.request_shutdown([message],[reconnect])`: request for server shutdown. Will display `message` to clients,
-    and `reconnect` == true displays a reconnect button.
+* `minetest.request_shutdown([message],[reconnect],[delay])`: request for server shutdown. Will display `message` to clients,
+    `reconnect` == true displays a reconnect button,
+    `delay` adds an optional delay (in seconds) before shutdown
+        negative delay cancels the current active shutdown
+        zero delay triggers an immediate shutdown.
+* `minetest.cancel_shutdown_requests()`: cancel current delayed shutdown
 * `minetest.get_server_status()`: returns server status string
 * `minetest.get_server_uptime()`: returns the server uptime in seconds
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -722,6 +722,13 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 
 	m_clients.event(peer_id, CSE_SetClientReady);
 	m_script->on_joinplayer(playersao);
+	// Send shutdown timer if shutdown has been scheduled
+	if (m_shutdown_timer > 0.0f) {
+		std::wstringstream ws;
+		ws << L"*** Server shutting down in "
+				<< duration_to_string(round(m_shutdown_timer)).c_str() << ".";
+		SendChatMessage(pkt->getPeerId(), ws.str());
+	}
 }
 
 void Server::handleCommand_GotBlocks(NetworkPacket* pkt)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -33,7 +33,8 @@ int ModApiServer::l_request_shutdown(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	const char *msg = lua_tolstring(L, 1, NULL);
 	bool reconnect = lua_toboolean(L, 2);
-	getServer(L)->requestShutdown(msg ? msg : "", reconnect);
+	float seconds_before_shutdown = lua_tonumber(L, 3);
+	getServer(L)->requestShutdown(msg ? msg : "", reconnect, seconds_before_shutdown);
 	return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -226,12 +226,7 @@ public:
 	inline bool getShutdownRequested() const { return m_shutdown_requested; }
 
 	// request server to shutdown
-	void requestShutdown(const std::string &msg, bool reconnect)
-	{
-		m_shutdown_requested = true;
-		m_shutdown_msg = msg;
-		m_shutdown_ask_reconnect = reconnect;
-	}
+	void requestShutdown(const std::string &msg, bool reconnect, float delay = 0.0f);
 
 	// Returns -1 if failed, sound handle on success
 	// Envlock
@@ -602,6 +597,7 @@ private:
 	bool m_shutdown_requested;
 	std::string m_shutdown_msg;
 	bool m_shutdown_ask_reconnect;
+	float m_shutdown_timer;
 
 	ChatInterface *m_admin_chat;
 	std::string m_admin_nick;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -614,4 +614,28 @@ inline const char *bool_to_cstr(bool val)
 	return val ? "true" : "false";
 }
 
+inline const std::string duration_to_string(int sec)
+{
+	int min = floor(sec / 60);
+	sec %= 60;
+	int hour = floor(min / 60);
+	min %= 60;
+
+	std::stringstream ss;
+	if (hour > 0) {
+		ss << hour << "h ";
+	}
+
+	if (min > 0) {
+		ss << min << "m ";
+	}
+
+	if (sec > 0) {
+		ss << sec << "s ";
+	}
+
+	return ss.str();
+}
+
+
 #endif


### PR DESCRIPTION
Add delayed server shutdown with periodic messages.

It's backported partially from epixel fork. It needs some improvements
- [x] Correct cancellation handling (wrong message)
- [x] Send the shutdown delay when a client connects
