### PR TITLE
"Document" item use callbacks' "user" parameter

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3593,15 +3593,18 @@ Definition tables
         on_place = func(itemstack, placer, pointed_thing),
         --[[
         ^ Shall place item and return the leftover itemstack
+        ^ The placer may be any ObjectRef or nil.
         ^ default: minetest.item_place ]]
         on_secondary_use = func(itemstack, user, pointed_thing),
         --[[
         ^ Same as on_place but called when pointing at nothing.
+        ^ The user may be any ObjectRef or nil.
         ^ pointed_thing : always { type = "nothing" }
         ]]
         on_drop = func(itemstack, dropper, pos),
         --[[
         ^ Shall drop item and return the leftover itemstack
+        ^ The dropper may be any ObjectRef or nil.
         ^ default: minetest.item_drop ]]
         on_use = func(itemstack, user, pointed_thing),
         --[[
@@ -3610,6 +3613,7 @@ Definition tables
           inventory, or an itemstack to replace the original itemstack.
             e.g. itemstack:take_item(); return itemstack
         ^ Otherwise, the function is free to do what it wants.
+        ^ The user may be any ObjectRef or nil.
         ^ The default functions handle regular use cases.
         ]]
         after_use = func(itemstack, user, node, digparams),
@@ -3622,6 +3626,7 @@ Definition tables
               itemstack:add_wear(digparams.wear)
               return itemstack
             end
+        ^ The user may be any ObjectRef or nil.
         ]]
     }
 


### PR DESCRIPTION
The "user", "placer" etc. parameters in item callbacks were never documented. Nobody said anything in #4488 about what those parameters really should be, so I took the opportunity to make a decision in the direction that I prefer.

This PR clarifies that those parameters may be either nil, or any valid (not dangling) ObjectRef.

What this means for modding:
 - Mods defining items need to check if the user is the right kind of thing, if the item's operation depends on something specific to players or requiring a non-nil object. I am guessing that in many cases items will only act on the pointed_thing so won't need these checks.
 - Mods can have entities, nodes, etc. use items without hacky "fake player" tables.