### PR TITLE
Make player send control information before interacts

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -953,6 +953,9 @@ void Client::interact(u8 action, const PointedThing& pointed)
 		5: perform secondary action of item
 	*/
 
+	// Give the server up-to-date control information for mod use
+	sendPlayerPos();
+
 	NetworkPacket pkt(TOSERVER_INTERACT, 1 + 2 + 0);
 
 	pkt << action;

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -162,7 +162,7 @@ const ServerCommandFactory serverCommandFactoryTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_factory, // 0x20
 	null_command_factory, // 0x21
 	null_command_factory, // 0x22
-	{ "TOSERVER_PLAYERPOS",          0, false }, // 0x23
+	{ "TOSERVER_PLAYERPOS",          0, true }, // 0x23
 	{ "TOSERVER_GOTBLOCKS",          2, true }, // 0x24
 	{ "TOSERVER_DELETEDBLOCKS",      2, true }, // 0x25
 	null_command_factory, // 0x26


### PR DESCRIPTION
If you have experienced control lag with items that do something special when you click while holding down shift, this PR tries to fix it. It should also fix the issue where player look direction might not be up-to-date on item use callbacks (#4627).