### PR TITLE
Shaders: Remove special handling for liquids.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -198,20 +198,11 @@ void main(void)
 	col = applyToneMapping(col);
 #endif
 
-#if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT
-	float alpha = gl_Color.a;
-	if (fogDistance != 0.0) {
-		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
-		alpha = mix(0.0, alpha, d);
-	}
-	col = vec4(col.rgb, alpha);
-#else
 	if (fogDistance != 0.0) {
 		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
 		col = mix(skyBgColor, col, d);
 	}
 	col = vec4(col.rgb, base.a);
-#endif
 
 	gl_FragColor = col;
 }

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -154,20 +154,11 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 	col = applyToneMapping(col);
 #endif
 
-#if MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_OPAQUE
-	float alpha = gl_Color.a;
-	if (fogDistance != 0.0) {
-		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
-		alpha = mix(0.0, alpha, d);
-	}
-	col = vec4(col.rgb, alpha);
-#else
 	if (fogDistance != 0.0) {
 		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
 		col = mix(skyBgColor, col, d);
 	}
 	col = vec4(col.rgb, base.a);
-#endif
 
 	gl_FragColor = col;
 }


### PR DESCRIPTION
I do have another small, tactical change...

I was experimenting making water less transparent in the distance, when I realized the entire code is weird.
Currently we make water _more_ transparent in the distance. At the max distance it is 100% transparent (presumably so that it is no longer visible). That's a hack, IMHO.

Instead we should just subject the water to the regular fog calculation, not only is the code slightly simpler, it also makes the water look more real.

Screenshots...

With patch:
![screenshot_20161025_212440](https://cloud.githubusercontent.com/assets/446130/19713237/30d5401a-9af9-11e6-93d0-c64a192ec725.png)

Without (note how the water is more transparent in the distance):
![screenshot_20161025_212400](https://cloud.githubusercontent.com/assets/446130/19713236/30d1b0bc-9af9-11e6-9994-152dee944374.png)

Have a look.