### PR TITLE
Make empty formspec strings close the formspec

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -61,6 +61,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "version.h"
 #include "minimap.h"
 #include "mapblock_mesh.h"
+//for FORMSPEC_VERSION_STRING
+#include "network/networkprotocol.h"
 
 #include "sound.h"
 
@@ -1113,24 +1115,31 @@ static inline void create_formspec_menu(GUIFormSpecMenu **cur_formspec,
 		JoystickController *joystick,
 		IFormSource *fs_src, TextDest *txt_dest, Client *client)
 {
-
-	if (*cur_formspec == 0) {
-		*cur_formspec = new GUIFormSpecMenu(device, joystick,
-			guiroot, -1, &g_menumgr, invmgr, gamedef, tsrc,
-			fs_src, txt_dest, client);
-		(*cur_formspec)->doPause = false;
-
-		/*
-			Caution: do not call (*cur_formspec)->drop() here --
-			the reference might outlive the menu, so we will
-			periodically check if *cur_formspec is the only
-			remaining reference (i.e. the menu was removed)
-			and delete it in that case.
-		*/
-
+	verbosestream << "Init GuiFormSpec:" << fs_src->getForm() << std::endl;
+	if (fs_src->getForm() == FORMSPEC_VERSION_STRING && *cur_formspec != 0) {
+		infostream << "Formspec QuitMenu" << std::endl;
+		(*cur_formspec)->quitMenu();
 	} else {
-		(*cur_formspec)->setFormSource(fs_src);
-		(*cur_formspec)->setTextDest(txt_dest);
+		if (*cur_formspec == 0) {
+			infostream << "GuiFormSpecMenu: creating new instance" << std::endl;
+			*cur_formspec = new GUIFormSpecMenu(device, joystick,
+				guiroot, -1, &g_menumgr, invmgr, gamedef, tsrc,
+				fs_src, txt_dest, client);
+			(*cur_formspec)->doPause = false;
+
+			/*
+				Caution: do not call (*cur_formspec)->drop() here --
+				the reference might outlive the menu, so we will
+				periodically check if *cur_formspec is the only
+				remaining reference (i.e. the menu was removed)
+				and delete it in that case.
+			*/
+
+		} else {
+			infostream << "GuiFormSpecMenu: updating existing instance" << std::endl;
+			(*cur_formspec)->setFormSource(fs_src);
+			(*cur_formspec)->setTextDest(txt_dest);
+		}
 	}
 }
 

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -3788,3 +3788,16 @@ std::wstring GUIFormSpecMenu::getLabelByID(s32 id)
 	}
 	return L"";
 }
+
+void GUIFormSpecMenu::setFormSpec(const std::string &formspec_string,
+			InventoryLocation current_inventory_location)
+{
+	verbosestream << "SetFormSpec:" << std::endl << formspec_string << std::endl;
+	if (formspec_string == "") {
+		quitMenu();
+	} else {
+		m_formspec_string = formspec_string;
+		m_current_inventory_location = current_inventory_location;
+		regenerateGui(m_screensize_old);
+	}
+}

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -300,12 +300,7 @@ public:
 	~GUIFormSpecMenu();
 
 	void setFormSpec(const std::string &formspec_string,
-			InventoryLocation current_inventory_location)
-	{
-		m_formspec_string = formspec_string;
-		m_current_inventory_location = current_inventory_location;
-		regenerateGui(m_screensize_old);
-	}
+			InventoryLocation current_inventory_location);
 
 	// form_src is deleted by this GUIFormSpecMenu
 	void setFormSource(IFormSource *form_src)


### PR DESCRIPTION
Warning! The Formspec system is more complex than I thought. The game is messing around with non-garbage-collected resources, and I don't know if they are closed properly. Although quitMenu() shouldn't destroy the GUIFormSpec object, some calls coming after create_formspec_menu() could fail, although I see no reason for that. It would be good if someone could review it before considering a merge (or just ignore it entirely).

This PR causes formspecs to close when an empty formspec string is supplied instead of displaying an empty form with default size. This is the way mod developers have tried to close formspecs ever since, but it never actually worked. By handling the check client-side, no protocol changes are needed.
