### PR TITLE
Fix water flooding onto lava

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -284,12 +284,6 @@ void RemoteClient::GetNextBlocks (
 					surely_not_found_on_disk = true;
 				}
 
-				// Block is valid if lighting is up-to-date and data exists
-				if(block->isValid() == false)
-				{
-					block_is_invalid = true;
-				}
-
 				if(block->isGenerated() == false)
 					block_is_invalid = true;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -825,7 +825,7 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 	// Update lighting
 	std::vector<std::pair<v3s16, MapNode> > oldnodes;
 	oldnodes.push_back(std::pair<v3s16, MapNode>(p, oldnode));
-	voxalgo::update_lighting_nodes(this, m_nodedef, oldnodes, modified_blocks);
+	voxalgo::update_lighting_nodes(this, oldnodes, modified_blocks);
 
 	for(std::map<v3s16, MapBlock*>::iterator
 			i = modified_blocks.begin();
@@ -1524,7 +1524,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks)
 	for (std::deque<v3s16>::iterator iter = must_reflow.begin(); iter != must_reflow.end(); ++iter)
 		m_transforming_liquid.push_back(*iter);
 
-	voxalgo::update_lighting_nodes(this, m_nodedef, changed_nodes, modified_blocks);
+	voxalgo::update_lighting_nodes(this, changed_nodes, modified_blocks);
 
 
 	/* ----------------------------------------------------------------------
@@ -1956,26 +1956,9 @@ void ServerMap::finishBlockMake(BlockMakeData *data,
 	v3s16 bpmax = data->blockpos_max;
 
 	v3s16 extra_borders(1, 1, 1);
-	v3s16 full_bpmin = bpmin - extra_borders;
-	v3s16 full_bpmax = bpmax + extra_borders;
 
 	bool enable_mapgen_debug_info = m_emerge->enable_mapgen_debug_info;
 	EMERGE_DBG_OUT("finishBlockMake(): " PP(bpmin) " - " PP(bpmax));
-
-	/*
-		Set lighting to non-expired state in all of them.
-		This is cheating, but it is not fast enough if all of them
-		would actually be updated.
-	*/
-	for (s16 x = full_bpmin.X; x <= full_bpmax.X; x++)
-	for (s16 z = full_bpmin.Z; z <= full_bpmax.Z; z++)
-	for (s16 y = full_bpmin.Y; y <= full_bpmax.Y; y++) {
-		MapBlock *block = emergeBlock(v3s16(x, y, z), false);
-		if (!block)
-			continue;
-
-		block->setLightingExpired(false);
-	}
 
 	/*
 		Blit generated stuff to map
@@ -2981,7 +2964,6 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 
 		// We just loaded it from, so it's up-to-date.
 		block->resetModified();
-
 	}
 	catch(SerializationError &e)
 	{
@@ -3005,71 +2987,80 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 {
 	DSTACK(FUNCTION_NAME);
 
+	bool created_new = (getBlockNoCreateNoEx(blockpos) == NULL);
+
 	v2s16 p2d(blockpos.X, blockpos.Z);
 
 	std::string ret;
 	dbase->loadBlock(blockpos, &ret);
 	if (ret != "") {
 		loadBlock(&ret, blockpos, createSector(p2d), false);
-		return getBlockNoCreateNoEx(blockpos);
-	}
-	// Not found in database, try the files
+	} else {
+		// Not found in database, try the files
 
-	// The directory layout we're going to load from.
-	//  1 - original sectors/xxxxzzzz/
-	//  2 - new sectors2/xxx/zzz/
-	//  If we load from anything but the latest structure, we will
-	//  immediately save to the new one, and remove the old.
-	int loadlayout = 1;
-	std::string sectordir1 = getSectorDir(p2d, 1);
-	std::string sectordir;
-	if(fs::PathExists(sectordir1))
-	{
-		sectordir = sectordir1;
-	}
-	else
-	{
-		loadlayout = 2;
-		sectordir = getSectorDir(p2d, 2);
-	}
+		// The directory layout we're going to load from.
+		//  1 - original sectors/xxxxzzzz/
+		//  2 - new sectors2/xxx/zzz/
+		//  If we load from anything but the latest structure, we will
+		//  immediately save to the new one, and remove the old.
+		int loadlayout = 1;
+		std::string sectordir1 = getSectorDir(p2d, 1);
+		std::string sectordir;
+		if (fs::PathExists(sectordir1)) {
+			sectordir = sectordir1;
+		} else {
+			loadlayout = 2;
+			sectordir = getSectorDir(p2d, 2);
+		}
 
-	/*
+		/*
 		Make sure sector is loaded
-	*/
+		 */
 
-	MapSector *sector = getSectorNoGenerateNoEx(p2d);
-	if(sector == NULL)
-	{
-		try{
-			sector = loadSectorMeta(sectordir, loadlayout != 2);
+		MapSector *sector = getSectorNoGenerateNoEx(p2d);
+		if (sector == NULL) {
+			try {
+				sector = loadSectorMeta(sectordir, loadlayout != 2);
+			} catch(InvalidFilenameException &e) {
+				return NULL;
+			} catch(FileNotGoodException &e) {
+				return NULL;
+			} catch(std::exception &e) {
+				return NULL;
+			}
 		}
-		catch(InvalidFilenameException &e)
-		{
+
+
+		/*
+		Make sure file exists
+		 */
+
+		std::string blockfilename = getBlockFilename(blockpos);
+		if (fs::PathExists(sectordir + DIR_DELIM + blockfilename) == false)
 			return NULL;
-		}
-		catch(FileNotGoodException &e)
-		{
-			return NULL;
-		}
-		catch(std::exception &e)
-		{
-			return NULL;
+
+		/*
+		Load block and save it to the database
+		 */
+		loadBlock(sectordir, blockfilename, sector, true);
+	}
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (created_new && (block != NULL)) {
+		std::map<v3s16, MapBlock*> modified_blocks;
+		// Fix lighting if necessary
+		voxalgo::update_block_border_lighting(this, block, modified_blocks);
+		if (!modified_blocks.empty()) {
+			//Modified lighting, send event
+			MapEditEvent event;
+			event.type = MEET_OTHER;
+			std::map<v3s16, MapBlock *>::iterator it;
+			for (it = modified_blocks.begin();
+					it != modified_blocks.end(); ++it)
+				event.modified_blocks.insert(it->first);
+			dispatchEvent(&event);
 		}
 	}
-
-	/*
-		Make sure file exists
-	*/
-
-	std::string blockfilename = getBlockFilename(blockpos);
-	if(fs::PathExists(sectordir + DIR_DELIM + blockfilename) == false)
-		return NULL;
-
-	/*
-		Load block and save it to the database
-	*/
-	loadBlock(sectordir, blockfilename, sector, true);
-	return getBlockNoCreateNoEx(blockpos);
+	return block;
 }
 
 bool ServerMap::deleteBlock(v3s16 blockpos)

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -62,13 +62,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	24: 16-bit node ids and node timers (never released as stable)
 	25: Improved node timer format
 	26: Never written; read the same as 25
+	27: Added light spreading flags to blocks
 */
 // This represents an uninitialized or invalid format
 #define SER_FMT_VER_INVALID 255
 // Highest supported serialization version
-#define SER_FMT_VER_HIGHEST_READ 26
+#define SER_FMT_VER_HIGHEST_READ 27
 // Saved on disk version
-#define SER_FMT_VER_HIGHEST_WRITE 25
+#define SER_FMT_VER_HIGHEST_WRITE 27
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST_READ 0
 // Lowest serialization version for writing

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -22,8 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "voxel.h"
 #include "mapnode.h"
-#include <set>
-#include <map>
+#include "util/container.h"
+#include "util/cpp11_container.h"
 
 class Map;
 class MapBlock;
@@ -69,8 +69,19 @@ SunlightPropagateResult propagateSunlight(VoxelManipulator &v, VoxelArea a,
  */
 void update_lighting_nodes(
 	Map *map,
-	INodeDefManager *ndef,
 	std::vector<std::pair<v3s16, MapNode> > &oldnodes,
+	std::map<v3s16, MapBlock*> &modified_blocks);
+
+/*!
+ * Updates borders of the given mapblock.
+ * Only updates if the block was marked with incomplete
+ * lighting and the neighbor is also loaded.
+ *
+ * \param block the block to update
+ * \param modified_blocks output, contains all map blocks that
+ * the function modified
+ */
+void update_block_border_lighting(Map *map, MapBlock *block,
 	std::map<v3s16, MapBlock*> &modified_blocks);
 
 /*!


### PR DESCRIPTION
Lava cooled by water now clears its light.
Fixes the bug introduced by #4655.
Sorry about that bug...

(EDIT by paramat, author's comment below copied up to here)

A little help to reviewers: `MapBlock::getLightingExpired()` and `MapBlock::isGenerated()` always returned the same value, so I removed the former.
Instead I introduced `MapBlock::getLightingIncomplete()`, which returns 16 bits (`u16`). Each bit indicates if in a direction in a particular light bank light propagation/removal was not finished, because the neighbor block was unloaded.
When the server loads a block, it checks these flags and corrects lighting if necessary.

To introduce the new flags I had to increase the map block serialization version, this is why you can not play on your maps on other versions of Minetest after you opened them in this version.
Of course old clients still can play, just the server has to be new to be able to read the map.