### PR TITLE
Add control information to player interacts

### DIFF
--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -40,6 +40,7 @@ public:
 		u32 getSize() { return m_datasize; }
 		u16 getPeerId() { return m_peer_id; }
 		u16 getCommand() { return m_command; }
+		const u32 getRemainingBytes() const { return m_datasize - m_read_offset; }
 
 		// Returns a c-string without copying.
 		// A better name for this would be getRawString()

--- a/src/server.h
+++ b/src/server.h
@@ -197,6 +197,10 @@ public:
 
 	void Send(NetworkPacket* pkt);
 
+	// Helper for handleCommand_PlayerPos and handleCommand_Interact
+	void process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
+		NetworkPacket *pkt);
+
 	// Both setter and getter need no envlock,
 	// can be called freely from threads
 	void setTimeOfDay(u32 time);


### PR DESCRIPTION
This adds control (keys pressed, look direction, etc.) information to player interact messages sent to the server. This solves some issues with items that change use behavior when the player is holding sneak. Normally, the player's position and controls are only updated every so often, to reduce network pressure. This means that in the usage callbacks of items, the player's control information might not be up to date. So if a player presses sneak right before clicking, the item might register it as an ordinary usage without holding sneak. By appending control information to interact messages, the server has the info to update player controls before invoking the item's callbacks.
