### PR TITLE
Remove optimization that causes underwater and cave rendering glitches.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -849,6 +849,13 @@ liquid_queue_purge_time (Liquid queue purge time) int 0
 #    Liquid update interval in seconds.
 liquid_update (Liquid update tick) float 1.0
 
+#    At this distance the server will aggressively optimize which blocks are sent to clients.
+#    Small values potentially improve performance a lot, at the expense of visible rendering glitches.
+#    (some blocks will not be rendered under water and in caves, as well as sometimes on land)
+#    Setting this to a value greater than max_block_send_distance disables this optimization.
+#    Stated in mapblocks (16 nodes)
+block_send_optimize_distance (block send optimize distance) int 4 2
+
 [*Mapgen]
 
 #    Name of map generator to be used when creating a new world.

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -170,6 +170,8 @@ void RemoteClient::GetNextBlocks (
 	s32 new_nearest_unsent_d = -1;
 
 	const s16 full_d_max = g_settings->getS16("max_block_send_distance");
+	const s16 d_opt = g_settings->getS16("block_send_optimize_distance");
+
 	s16 d_max = full_d_max;
 	s16 d_max_gen = g_settings->getS16("max_block_generate_distance");
 
@@ -296,7 +298,7 @@ void RemoteClient::GetNextBlocks (
 					Block is near ground level if night-time mesh
 					differs from day-time mesh.
 				*/
-				if(d >= 4)
+				if(d >= d_opt)
 				{
 					if(block->getDayNightDiff() == false)
 						continue;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -279,6 +279,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_simultaneous_block_sends_server_total", "40");
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("max_block_generate_distance", "7");
+	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_send_interval", "5");
 	settings->setDefault("time_speed", "72");


### PR DESCRIPTION
This is slight optimization, but it causes under water terrain and especially caves to not be rendered correctly (blocks are not sent)

Fixes #4678
