### PR TITLE
Lua voxelmanip: Add optional buffer param for 'get param2 data'

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3263,7 +3263,9 @@ will place the schematic inside of the VoxelManip.
 * `set_light_data(light_data)`: Sets the `param1` (light) contents of each node
   in the `VoxelManip`
     * expects lighting data in the same format that `get_light_data()` returns
-* `get_param2_data()`: Gets the raw `param2` data read into the `VoxelManip` object
+* `get_param2_data([buffer])`: Gets the raw `param2` data read into the `VoxelManip` object
+    * Returns an array (indices 1 to volume) of integers ranging from `0` to `255`
+    * If the param `buffer` is present, this table will be used to store the result instead
 * `set_param2_data(param2_data)`: Sets the `param2` contents of each node in the `VoxelManip`
 * `calc_lighting([p1, p2], [propagate_shadow])`:  Calculate lighting within the `VoxelManip`
     * To be used only by a `VoxelManip` object from `minetest.get_mapgen_object`

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -277,11 +277,17 @@ int LuaVoxelManip::l_get_param2_data(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaVoxelManip *o = checkobject(L, 1);
+	bool use_buffer  = lua_istable(L, 2);
+
 	MMVManip *vm = o->vm;
 
 	u32 volume = vm->m_area.getVolume();
 
-	lua_newtable(L);
+	if (use_buffer)
+		lua_pushvalue(L, 2);
+	else
+		lua_newtable(L);
+
 	for (u32 i = 0; i != volume; i++) {
 		lua_Integer param2 = vm->m_data[i].param2;
 		lua_pushinteger(L, param2);


### PR DESCRIPTION
'get data' already has a buffer param, enabling reduction of memory use, since 'get param2 data' is often used add the feature to that too. This will help with OOM errors when lua mapgens are used.
Documentation will be added later after initial reviews.

Based on kwolekr's commit https://github.com/minetest/minetest/commit/3ffb5f5761a83773037869d6f6179353c46a650a

Tested.