### PR TITLE
Rename “Use” key to “Special”

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -51,6 +51,7 @@ Default controls
 - -: Decrease view range
 - K: Enable/disable fly mode (needs fly privilege)
 - J: Enable/disable fast mode (needs fast privilege)
+- E: Move fast in fast mode
 - H: Enable/disable noclip mode (needs noclip privilege)
 
 - F1:  Hide/show HUD

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -65,7 +65,7 @@ enable_build_where_you_stand (Build inside player) bool false
 #    This requires the "fly" privilege on the server.
 free_move (Flying) bool false
 
-#    Fast movement (via use key).
+#    Fast movement (via the "special" key).
 #    This requires the "fast" privilege on the server.
 fast_move (Fast movement) bool false
 
@@ -89,13 +89,13 @@ invert_mouse (Invert mouse) bool false
 #    Mouse sensitivity multiplier.
 mouse_sensitivity (Mouse sensitivity) float 0.2
 
-#    If enabled, "use" key instead of "sneak" key is used for climbing down and descending.
-aux1_descends (Key use for climbing/descending) bool false
+#    If enabled, "special" key instead of "sneak" key is used for climbing down and descending.
+aux1_descends (Special key for climbing/descending) bool false
 
 #    Double-tapping the jump key toggles fly mode.
 doubletap_jump (Double tap jump for fly) bool false
 
-#    If disabled "use" key is used to fly fast if both fly and fast mode are enabled.
+#    If disabled, "special" key is used to fly fast if both fly and fast mode are enabled.
 always_fly_fast (Always fly and fast) bool true
 
 #    The time in seconds it takes between repeated right clicks when holding the right mouse button.
@@ -155,7 +155,7 @@ keymap_inventory (Inventory key) key KEY_KEY_I
 
 #    Key for moving fast in fast mode.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_special1 (Use key) key KEY_KEY_E
+keymap_special1 (Special key) key KEY_KEY_E
 
 #    Key for opening the chat window.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -28,7 +28,7 @@
 #    type: bool
 # free_move = false
 
-#    Fast movement (via use key).
+#    Fast movement (via special key).
 #    This requires the "fast" privilege on the server.
 #    type: bool
 # fast_move = false
@@ -59,7 +59,7 @@
 #    type: float
 # mouse_sensitivity = 0.2
 
-#    If enabled, "use" key instead of "sneak" key is used for climbing down and descending.
+#    If enabled, "special" key instead of "sneak" key is used for climbing down and descending.
 #    type: bool
 # aux1_descends = false
 
@@ -67,7 +67,7 @@
 #    type: bool
 # doubletap_jump = false
 
-#    If disabled "use" key is used to fly fast if both fly and fast mode are enabled.
+#    If disabled, "special" key is used to fly fast if both fly and fast mode are enabled.
 #    type: bool
 # always_fly_fast = true
 
@@ -141,7 +141,7 @@
 #    type: key
 # keymap_inventory = KEY_KEY_I
 
-#    Key for moving fast in fast mode.
+#    Key for moving fast in fast mode (known as "special").
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
 # keymap_special1 = KEY_KEY_E

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -168,7 +168,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect<s32> rect(0, 0, option_w, 30);
 			rect += topleft + v2s32(option_x, option_y);
-			const wchar_t *text = wgettext("\"Use\" = climb down");
+			const wchar_t *text = wgettext("\"Special\" = climb down");
 			Environment->addCheckBox(g_settings->getBool("aux1_descends"), rect, this,
 					GUI_ID_CB_AUX1_DESCENDS, text);
 			delete[] text;
@@ -406,7 +406,7 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_BACKWARD_BUTTON,  wgettext("Backward"),         "keymap_backward");
 	this->add_key(GUI_ID_KEY_LEFT_BUTTON,      wgettext("Left"),             "keymap_left");
 	this->add_key(GUI_ID_KEY_RIGHT_BUTTON,     wgettext("Right"),            "keymap_right");
-	this->add_key(GUI_ID_KEY_USE_BUTTON,       wgettext("Use"),              "keymap_special1");
+	this->add_key(GUI_ID_KEY_USE_BUTTON,       wgettext("Special"),          "keymap_special1");
 	this->add_key(GUI_ID_KEY_JUMP_BUTTON,      wgettext("Jump"),             "keymap_jump");
 	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,     wgettext("Sneak"),            "keymap_sneak");
 	this->add_key(GUI_ID_KEY_DROP_BUTTON,      wgettext("Drop"),             "keymap_drop");


### PR DESCRIPTION
This PR renames the “Use” key ([E], also known as “aux1”, cofigured with `keymap_special1`) to “Special”.
I hope I have catched all occourences of the name “Use”. If not, please complain here or even directly edit my branch (Yes, GitHub allows this).

Rationale:
The name “Use” is pretty awkward and confusing, it has very little to do with using. It's primary (!) use is moving faster in fast mode. Arguably, this key has a few other uses, but the going fast use is clearly the dominant one. Another problem is that the term “use” is already used for rightclicking a special node (e.g. Chest. If you rightclick a chest, the rightclick is generally known as “using” in this context).


EDIT: This issue was previously about renaming the key to “Turbo” but this name was rejected.