### PR TITLE
(1) add "debug" priv, (2) allow player to display the scene as wire-frame.

### DIFF
--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -58,4 +58,7 @@ core.register_privilege("zoom", {
 	description = "Can zoom the camera",
 	give_to_singleplayer = false,
 })
-
+core.register_privilege("debug", {
+	description = "Allows enabling various debug options that may affect gameplay",
+	give_to_singleplayer = false,
+})

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -521,6 +521,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, m_cache_trilinear_filter);
 				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, m_cache_bilinear_filter);
 				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, m_cache_anistropic_filter);
+				buf->getMaterial().setFlag(video::EMF_WIREFRAME, m_control.show_wireframe);
 
 				const video::SMaterial& material = buf->getMaterial();
 				video::IMaterialRenderer* rnd =

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -32,6 +32,7 @@ struct MapDrawControl
 		range_all(false),
 		wanted_range(0),
 		wanted_max_blocks(0),
+		show_wireframe(false),
 		blocks_drawn(0),
 		blocks_would_have_drawn(0),
 		farthest_drawn(0)
@@ -43,6 +44,8 @@ struct MapDrawControl
 	float wanted_range;
 	// Maximum number of blocks to draw
 	u32 wanted_max_blocks;
+	// show a wire frame for debugging
+	bool show_wireframe;
 	// Number of blocks rendered is written here by the renderer
 	u32 blocks_drawn;
 	// Number of blocks that would have been drawn in wanted_range


### PR DESCRIPTION
Addresses #4708

For players with the "debug" priv this adds another cycle to the F5 key, which then shows the entire scene rendered as a wire frame.

Note on the issue there was discussion about whether this should be a priv or a compile time option.

I already had a patch with a "debug" priv, so using that first. Happy to change that to compile time option (once I understand cmake).
