### PR TITLE
Allow non-tools to use wear to display a bar

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -685,7 +685,7 @@ void drawItemStack(video::IVideoDriver *driver,
 		driver->setViewPort(oldViewPort);
 	}
 
-	if(def.type == ITEM_TOOL && item.wear != 0)
+	if(item.wear != 0)
 	{
 		// Draw a progressbar
 		float barheight = rect.getHeight()/16;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -122,20 +122,13 @@ struct ItemStack
 	// Returns true if the item is (was) a tool
 	bool addWear(s32 amount, IItemDefManager *itemdef)
 	{
-		if(getDefinition(itemdef).type == ITEM_TOOL)
-		{
-			if(amount > 65535 - wear)
-				clear();
-			else if(amount < -wear)
-				wear = 0;
-			else
-				wear += amount;
-			return true;
-		}
+		if(amount > 65535 - wear && getDefinition(itemdef).type == ITEM_TOOL)
+			clear();
+		else if(amount < -wear)
+			wear = 0;
 		else
-		{
-			return false;
-		}
+			wear += amount;
+		return true;
 	}
 
 	// If possible, adds newitem to this item.


### PR DESCRIPTION
Do note that destroying items due to damage only occurs on tools.

This change is compatible, even if you load a "damaged" craftitem on an older version.

EDIT: Addresses #6448 