### PR TITLE
Separate optional from required mod dependencies in main menu

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -47,13 +47,18 @@ local function get_formspec(data)
 	if mod == nil then
 		mod = {name=""}
 	end
+
+	local hard_deps, soft_deps = modmgr.get_dependencies(mod.path)
 	
 	retval = retval ..
 		"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
 		"label[0.75,0.7;" .. mod.name .. "]" ..
-		"label[0,1.25;" .. fgettext("Depends:") .. "]" ..
-		"textlist[0,1.75;5,4.25;world_config_depends;" ..
-		modmgr.get_dependencies(mod.path) .. ";0]" ..
+		"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
+		"textlist[0,1.75;5,2.125;world_config_depends;" ..
+		hard_deps .. ";0]" ..
+		"label[0,3.875;" .. fgettext("Optional dependencies:") .. "]" ..
+		"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
+		soft_deps .. ";0]" ..
 		"button[3.25,7;2.5,0.5;btn_config_world_save;" .. fgettext("Save") .. "]" ..
 		"button[5.75,7;2.5,0.5;btn_config_world_cancel;" .. fgettext("Cancel") .. "]"
 
@@ -86,11 +91,11 @@ local function get_formspec(data)
 	if enabled_all then 
 		retval = retval ..
 			"button[8.75,0.125;2.5,0.5;btn_disable_all_mods;" .. fgettext("Disable all") .. "]" ..
-			"textlist[5.5,0.75;5.75,5.25;world_config_modlist;"
+			"textlist[5.5,0.75;5.75,5.4;world_config_modlist;"
 	else
 		retval = retval ..
 			"button[8.75,0.125;2.5,0.5;btn_enable_all_mods;" .. fgettext("Enable all") .. "]" ..
-			"textlist[5.5,0.75;5.75,5.25;world_config_modlist;"
+			"textlist[5.5,0.75;5.75,5.4;world_config_modlist;"
 	end
 	retval = retval .. modmgr.render_modlist(data.list)
 	retval = retval .. ";" .. data.selected_mod .."]"

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -305,18 +305,8 @@ function modmgr.get_dependencies(modfolder)
 			end
 			dependencyfile:close()
 		end
-		for i=1, #hard_dependencies do
-			if toadd_hard ~= "" then
-				toadd_hard = toadd_hard .. ","
-			end
-			toadd_hard = toadd_hard .. hard_dependencies[i]
-		end
-		for i=1, #soft_dependencies do
-			if toadd_soft ~= "" then
-				toadd_soft = toadd_soft .. ","
-			end
-			toadd_soft = toadd_soft .. soft_dependencies[i]
-		end
+		toadd_hard = table.concat(hard_dependencies, ",")
+		toadd_soft = table.concat(soft_dependencies, ",")
 	end
 
 	return toadd_hard, toadd_soft

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -284,27 +284,42 @@ end
 
 --------------------------------------------------------------------------------
 function modmgr.get_dependencies(modfolder)
-	local toadd = ""
+	local toadd_hard = ""
+	local toadd_soft = ""
 	if modfolder ~= nil then
 		local filename = modfolder ..
 					DIR_DELIM .. "depends.txt"
 
+		local hard_dependencies = {}
+		local soft_dependencies = {}
 		local dependencyfile = io.open(filename,"r")
-
 		if dependencyfile then
 			local dependency = dependencyfile:read("*l")
 			while dependency do
-				if toadd ~= "" then
-					toadd = toadd .. ","
+				if string.sub(dependency, -1, -1) == "?" then
+					table.insert(soft_dependencies, string.sub(dependency, 1, -2))
+				else
+					table.insert(hard_dependencies, dependency)
 				end
-				toadd = toadd .. dependency
 				dependency = dependencyfile:read()
 			end
 			dependencyfile:close()
 		end
+		for i=1, #hard_dependencies do
+			if toadd_hard ~= "" then
+				toadd_hard = toadd_hard .. ","
+			end
+			toadd_hard = toadd_hard .. hard_dependencies[i]
+		end
+		for i=1, #soft_dependencies do
+			if toadd_soft ~= "" then
+				toadd_soft = toadd_soft .. ","
+			end
+			toadd_soft = toadd_soft .. soft_dependencies[i]
+		end
 	end
 
-	return toadd
+	return toadd_hard, toadd_soft
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/tab_mods.lua
+++ b/builtin/mainmenu/tab_mods.lua
@@ -98,12 +98,24 @@ local function get_formspec(tabview, name, tabdata)
 				.. fgettext("Uninstall selected modpack") .. "]"
 		else
 			--show dependencies
+			local toadd_hard, toadd_soft = modmgr.get_dependencies(selected_mod.path)
+			if toadd_hard == "" and toadd_soft == "" then
+				retval = retval .. "," .. fgettext("No dependencies.")
+			else
+				if toadd_hard ~= "" then
+					retval = retval .. "," .. fgettext("Dependencies:") .. ","
+					retval = retval .. toadd_hard
+				end
+				if toadd_soft ~= "" then
+					if toadd_hard ~= "" then
+						retval = retval .. ","
+					end
+					retval = retval .. "," .. fgettext("Optional dependencies:") .. ","
+					retval = retval .. toadd_soft
+				end
+			end
 
-			retval = retval .. "," .. fgettext("Depends:") .. ","
-
-			local toadd = modmgr.get_dependencies(selected_mod.path)
-
-			retval = retval .. toadd .. ";0]"
+			retval = retval .. ";0]"
 
 			retval = retval .. "button[5.5,4.85;4.5,0.5;btn_mod_mgr_delete_mod;"
 				.. fgettext("Uninstall selected mod") .. "]"


### PR DESCRIPTION
This PR tweaks the main menu. The listed mod dependencies are now separated in required and optional dependencies. The current approach is basically just just blindly pasting `depends.txt` (including the question marks). The the main menu “Mods” tab,, if a mod has no dependencies, the string “No dependencies.” is shown.

Screenshots:

![Screenshot of tweaked mod selection list](https://i.imgur.com/TvFrDId.png)
![Screenshot of tweaked mod tab in main menu](https://i.imgur.com/Hj13VQa.png)