### PR TITLE
Improve number of blocks sent and occlusion culling.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -175,6 +175,7 @@ void RemoteClient::GetNextBlocks (
 
 	const s16 full_d_max = g_settings->getS16("max_block_send_distance");
 	const s16 d_opt = g_settings->getS16("block_send_optimize_distance");
+	const s16 d_blocks_in_sight = (full_d_max + 1) * BS * MAP_BLOCKSIZE;
 
 	s16 d_max = full_d_max;
 	s16 d_max_gen = g_settings->getS16("max_block_generate_distance");
@@ -252,7 +253,7 @@ void RemoteClient::GetNextBlocks (
 			*/
 
 			float camera_fov = (72.0*M_PI/180) * 4./3.;
-			if(isBlockInSight(p, camera_pos, camera_dir, camera_fov, 10000*BS) == false)
+			if(isBlockInSight(p, camera_pos, camera_dir, camera_fov, d_blocks_in_sight) == false)
 			{
 				continue;
 			}

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -293,13 +293,14 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			float step = BS * 1;
 			float stepfac = 1.1;
 			float startoff = BS * 1;
-			float endoff = -BS*MAP_BLOCKSIZE * 1.42 * 1.42;
+			// - Length of the diagonal of a mapblock.
+			float endoff = -BS * MAP_BLOCKSIZE * 1.732050807569;
 			v3s16 spn = cam_pos_nodes + v3s16(0, 0, 0);
 			s16 bs2 = MAP_BLOCKSIZE / 2 + 1;
 			u32 needed_count = 1;
 			if (occlusion_culling_enabled &&
 					isOccluded(this, spn, cpn + v3s16(0, 0, 0),
-						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+						step, stepfac, startoff, endoff / 2, needed_count, nodemgr) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,bs2,bs2),
 						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
 					isOccluded(this, spn, cpn + v3s16(bs2,bs2,-bs2),


### PR DESCRIPTION
This should be an interesting one.

(1) When blocks are retrieved from the server we retrieve a square (or a cube rather). We should retrieve a circle instead (or a sphere specifically).
It does not add to the visual experience to retrieve the corners of the cube, those blocks are mostly useless. As I was looking into improving this I noticed that isBlockInSight already checks the distance, we just need to pass in the correct range.
With this we're retrieving blocks up to the same distance in all directions - and no extra blocks in the corners of the cube. No extra comparison or work, fewer blocks shipped to the server, slightly better experience if the fog is set too far (the distance will still look rounded).

(2) I think we were too conservative in the occlusion culling. The margin of error is MAP_BLOCKSIZE/2*SQRT(2)*SQRT(2) (= MAP_BLOCKSIZE) rather then MAP_BLOCKSIZE*SQRT(2)*SQRT(2) (= MAP_BLOCKSIZE * 2) as we have it now.
This change allows us to consider slightly more blocks and hence a higher chance to consider a block occluded. I've been playing with this for a while (ground, air, under water, caves, etc) with no rendering problems so far.

I assume #2 will illicit some more discussion, #1 should be fairly uncontroversial.

[EDIT by paramat: see #4722 for details and discussion]
[EDIT by paramat: (2) above has been changed to correct the 'endoff' value, see discussion below]