### PR TITLE
Add short description for disabled texture packs

### DIFF
--- a/builtin/mainmenu/tab_texturepacks.lua
+++ b/builtin/mainmenu/tab_texturepacks.lua
@@ -63,7 +63,10 @@ local function get_formspec(tabview, name, tabdata)
 	if current_texture_path == "" then
 		retval = retval ..
 			render_texture_pack_list(list) ..
-			";" .. index .. "]"
+			";" .. index .. "]" ..
+			"textarea[0.6,2.85;3.7,1.5;;" ..
+			fgettext("Default textures will be used.") ..
+			";]"
 		return retval
 	end
 


### PR DESCRIPTION
In the texture packs tab of the main menu, a short label is included for the “None” selection, as a simple reminder/explanation to the user:

> Default textures will be used.

![Screenshot of the change](https://i.imgur.com/e1nx1LU.png)