### PR TITLE
Add minetest.close_formspec() to close formspecs from the server side

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -239,3 +239,7 @@ else
 
 end
 
+function core.close_formspec(player_name, formname)
+	return minetest.show_formspec(player_name, formname, "")
+end
+

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2312,6 +2312,13 @@ and `minetest.auth_reload` call the authetification handler.
     * `formname`: name passed to `on_player_receive_fields` callbacks.
       It should follow the `"modname:<whatever>"` naming convention
     * `formspec`: formspec to display
+* `minetest.close_formspec(playername, formname)`
+    * `playername`: name of player to close formspec
+    * `formname`: has to exactly match the one given in show_formspec, or the formspec will
+       not close.
+    * calling show_formspec(playername, formname, "") is equal to this expression
+    * to close a formspec regardless of the formname, call 
+      minetest.close_formspec(playername, ""). USE THIS ONLY WHEN ABSOLUTELY NECESSARY!
 * `minetest.formspec_escape(string)`: returns a string
     * escapes the characters "[", "]", "\", "," and ";", which can not be used in formspecs
 * `minetest.explode_table_event(string)`: returns a table

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1132,6 +1132,7 @@ static inline void create_formspec_menu(GUIFormSpecMenu **cur_formspec,
 		(*cur_formspec)->setFormSource(fs_src);
 		(*cur_formspec)->setTextDest(txt_dest);
 	}
+	
 }
 
 #ifdef __ANDROID__
@@ -1680,6 +1681,8 @@ private:
 	ChatBackend *chat_backend;
 
 	GUIFormSpecMenu *current_formspec;
+	//default: "". If other than "", empty show_formspec packets will only close the formspec when the formname matches
+	std::string cur_formname;
 
 	EventManager *eventmgr;
 	QuicktuneShortcutter *quicktune;
@@ -1765,6 +1768,7 @@ Game::Game() :
 	soundmaker(NULL),
 	chat_backend(NULL),
 	current_formspec(NULL),
+	cur_formname(""),
 	eventmgr(NULL),
 	quicktune(NULL),
 	gui_chat_console(NULL),
@@ -2931,6 +2935,7 @@ void Game::openInventory()
 
 	create_formspec_menu(&current_formspec, client, gamedef, texture_src,
 			device, &input->joystick, fs_src, txt_dst, client);
+	cur_formname = "";
 
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
@@ -3410,14 +3415,21 @@ void Game::processClientEvents(CameraOrientation *cam, float *damage_flash)
 			player->hurt_tilt_strength = 0;
 
 		} else if (event.type == CE_SHOW_FORMSPEC) {
-			FormspecFormSource *fs_src =
-				new FormspecFormSource(*(event.show_formspec.formspec));
-			TextDestPlayerInventory *txt_dst =
-				new TextDestPlayerInventory(client, *(event.show_formspec.formname));
+			if (*(event.show_formspec.formspec) == "") {
+				if (current_formspec && ( *(event.show_formspec.formname) == "" || *(event.show_formspec.formname) == cur_formname) ){
+					current_formspec->quitMenu();
+				}
+			} else {
+				FormspecFormSource *fs_src =
+					new FormspecFormSource(*(event.show_formspec.formspec));
+				TextDestPlayerInventory *txt_dst =
+					new TextDestPlayerInventory(client, *(event.show_formspec.formname));
 
-			create_formspec_menu(&current_formspec, client, gamedef,
-				texture_src, device, &input->joystick,
-				fs_src, txt_dst, client);
+				create_formspec_menu(&current_formspec, client, gamedef,
+					texture_src, device, &input->joystick,
+					fs_src, txt_dst, client);
+				cur_formname = *(event.show_formspec.formname);
+			}
 
 			delete(event.show_formspec.formspec);
 			delete(event.show_formspec.formname);
@@ -3881,6 +3893,7 @@ void Game::handlePointingAtNode(GameRunData *runData,
 
 			create_formspec_menu(&current_formspec, client, gamedef,
 				texture_src, device, &input->joystick, fs_src, txt_dst, client);
+			cur_formname = "";
 
 			current_formspec->setFormSpec(meta->getString("formspec"), inventoryloc);
 		} else {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1647,8 +1647,12 @@ void Server::SendShowFormspecMessage(u16 peer_id, const std::string &formspec,
 	DSTACK(FUNCTION_NAME);
 
 	NetworkPacket pkt(TOCLIENT_SHOW_FORMSPEC, 0 , peer_id);
-
-	pkt.putLongString(FORMSPEC_VERSION_STRING + formspec);
+	if (formspec == "" ){
+		//the client should close the formspec
+		pkt.putLongString("");
+	} else {
+		pkt.putLongString(FORMSPEC_VERSION_STRING + formspec);
+	}
 	pkt << formname;
 
 	Send(&pkt);


### PR DESCRIPTION
new implementation of #4675
When an empty formspec string is supplied to show_formspec, and the formname matches the one of the formspec currently open on the client, it will close.
when supplying empty formspec and empty formname, it will close the client's formspec regardless of the open form's name.

For more info, see #4675
Has been documented in init.lua

Has been tested, test code:
```
minetest.register_node("test:disapp", {
	description = "Disappears",
	tiles = {"default_dirt.png"},
	groups = {crumbly = 3, soil = 1},
	on_construct=function(pos)
		minetest.get_meta(pos):set_string("formspec", "size[2,2]")
	end,
})
minetest.register_node("test:set", {
	description = "Sets form empty",
	tiles = {"default_dirt.png"},
	groups = {crumbly = 3, soil = 1},
	on_construct=function(pos)
		minetest.get_meta(pos):set_string("formspec", "size[2,2]")
	end,
})
minetest.register_node("test:form", {
	description = "show_formspec and close",
	tiles = {"default_dirt.png"},
	groups = {crumbly = 3, soil = 1},
	on_construct=function(pos)
		minetest.show_formspec("moflo", "test", "size[2,4]")
	end,
})
minetest.register_node("test:form2", {
	description = "show_formspec and close with different formname",
	tiles = {"default_dirt.png"},
	groups = {crumbly = 3, soil = 1},
	on_construct=function(pos)
		minetest.show_formspec("moflo", "test2", "size[2,4]")
	end,
})
minetest.register_node("test:form3", {
	description = "show_formspec and close wit formname empty",
	tiles = {"default_dirt.png"},
	groups = {crumbly = 3, soil = 1},
	on_construct=function(pos)
		minetest.show_formspec("moflo", "test2", "size[4,2]")
	end,
})
minetest.register_abm({
	nodenames = {"test:disapp"},
	interval = 10, -- Operation interval in seconds
	chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
	action = function(pos, node, active_object_count, active_object_count_wider) minetest.set_node(pos, {name="air"}) end,
})
minetest.register_abm({
	nodenames = {"test:form"},
	interval = 10, -- Operation interval in seconds
	chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
	action = function(pos, node, active_object_count, active_object_count_wider) minetest.set_node(pos, {name="air"}) minetest.close_formspec("moflo", "test") end,
})
minetest.register_abm({
	nodenames = {"test:form2"},
	interval = 10, -- Operation interval in seconds
	chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
	action = function(pos, node, active_object_count, active_object_count_wider) minetest.set_node(pos, {name="air"}) minetest.close_formspec("moflo", "testblablubb") end,
})
minetest.register_abm({
	nodenames = {"test:form3"},
	interval = 10, -- Operation interval in seconds
	chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
	action = function(pos, node, active_object_count, active_object_count_wider) minetest.set_node(pos, {name="air"}) minetest.close_formspec("moflo", "") end,
})
minetest.register_abm({
	nodenames = {"test:set"},
	interval = 10, -- Operation interval in seconds
	chance = 1, -- Chance of trigger per-node per-interval is 1.0 / this
	action = function(pos, node, active_object_count, active_object_count_wider) minetest.get_meta(pos):set_string("formspec", "") end,
})
```