### PR TITLE
Fix crash when attached object no longer exists

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -140,8 +140,9 @@ int ObjectRef::l_remove(lua_State *L)
 	UNORDERED_SET<int> child_ids = co->getAttachmentChildIds();
 	UNORDERED_SET<int>::iterator it;
 	for (it = child_ids.begin(); it != child_ids.end(); ++it) {
-		ServerActiveObject *child = env->getActiveObject(*it);
-		child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
+		// Child can be NULL if it was deleted earlier
+		if (ServerActiveObject *child = env->getActiveObject(*it))
+			child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
 	}
 
 	verbosestream<<"ObjectRef::l_remove(): id="<<co->getId()<<std::endl;


### PR DESCRIPTION
Active objects that are attached to other objects are not safe
from deletion. As a result, the parent object may have a reference
to an id of a child's that no longer exists.

If at some point an attempt is made to manipulate the child,
enviromment->getActiveObject(child-id) returns NULL. Using the
NULL pointer causes the crash...