### PR TITLE
Digging crack animation: Make crack animation optional 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -490,6 +490,10 @@ selectionbox_color (Selection box color) string (0,0,0)
 #    Width of the selectionbox's lines around nodes.
 selectionbox_width (Selection box width) int 2 1 5
 
+#    Enable crack animation on nodes to show digging progress.
+#    If disabled, reduces the number of mapblock mesh updates when digging.
+dig_crack_animation (Digging crack animation) bool true
+
 #    Crosshair color (R,G,B).
 crosshair_color (Crosshair color) string (255,255,255)
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -565,6 +565,11 @@
 #    type: int min: 1 max: 5
 # selectionbox_width = 2
 
+#    Enable crack animation on nodes to show digging progress.
+#    If disabled, reduces the number of mapblock mesh updates when digging.
+#    type: bool
+# dig_crack_animation = true
+
 #    Crosshair color (R,G,B).
 #    type: string
 # crosshair_color = (255,255,255)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -267,6 +267,7 @@ Client::Client(
 	m_cache_use_tangent_vertices = m_cache_enable_shaders && (
 		g_settings->getBool("enable_bumpmapping") ||
 		g_settings->getBool("enable_parallax_occlusion"));
+	m_cache_dig_crack_animation = g_settings->getBool("dig_crack_animation");
 }
 
 void Client::Stop()
@@ -1533,15 +1534,15 @@ void Client::setCrack(int level, v3s16 pos)
 	m_crack_level = level;
 	m_crack_pos = pos;
 
-	if(old_crack_level >= 0 && (level < 0 || pos != old_crack_pos))
-	{
-		// remove old crack
-		addUpdateMeshTaskForNode(old_crack_pos, false, true);
-	}
-	if(level >= 0 && (old_crack_level < 0 || pos != old_crack_pos))
-	{
-		// add new crack
-		addUpdateMeshTaskForNode(pos, false, true);
+	if (m_cache_dig_crack_animation) {
+		if (old_crack_level >= 0 && (level < 0 || pos != old_crack_pos)) {
+			// remove old crack
+			addUpdateMeshTaskForNode(old_crack_pos, false, true);
+		}
+		if (level >= 0 && (old_crack_level < 0 || pos != old_crack_pos)) {
+			// add new crack
+			addUpdateMeshTaskForNode(pos, false, true);
+		}
 	}
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -624,6 +624,7 @@ private:
 	PacketCounter m_packetcounter;
 	// Block mesh animation parameters
 	float m_animation_time;
+	bool m_cache_dig_crack_animation;
 	int m_crack_level;
 	v3s16 m_crack_pos;
 	// 0 <= m_daynight_i < DAYNIGHT_CACHE_COUNT

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -143,6 +143,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("selectionbox_width", "2");
 	settings->setDefault("inventory_items_animations", "false");
 	settings->setDefault("node_highlighting", "box");
+	settings->setDefault("dig_crack_animation", "true");
 	settings->setDefault("crosshair_color", "(255,255,255)");
 	settings->setDefault("crosshair_alpha", "255");
 	settings->setDefault("hud_scaling", "1.0");

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1033,6 +1033,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 	m_enable_shaders = data->m_use_shaders;
 	m_use_tangent_vertices = data->m_use_tangent_vertices;
 	m_enable_vbo = g_settings->getBool("enable_vbo");
+	m_dig_crack_animation = g_settings->getBool("dig_crack_animation");
 
 	if (g_settings->getBool("enable_minimap")) {
 		m_minimap_mapblock = new MinimapMapblock;
@@ -1116,8 +1117,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 
 		// Generate animation data
 		// - Cracks
-		if(p.tile.material_flags & MATERIAL_FLAG_CRACK)
-		{
+		if (m_dig_crack_animation && (p.tile.material_flags & MATERIAL_FLAG_CRACK)) {
 			// Find the texture name plus ^[crack:N:
 			std::ostringstream os(std::ios::binary);
 			os<<m_tsrc->getTextureName(p.tile.texture_id)<<"^[crack";

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -136,6 +136,7 @@ private:
 	bool m_enable_shaders;
 	bool m_use_tangent_vertices;
 	bool m_enable_vbo;
+	bool m_dig_crack_animation;
 
 	// Must animate() be called before rendering?
 	bool m_has_animation;


### PR DESCRIPTION
Part of an unmerged commit by RealBadAngel.
Each frame of the crack animation causes a mesh update.
Particles and sounds provide an alternative dig feedback.
///////////////////////////////////////////

Original PR by RealBadAngel #1685 
This PR applies only the optional crack animation and avoids the other unpopular parts of that PR.
Much of this is copied from the original, there may be improvements needed.

Crack animation is enabled by default in this PR.

Changes to RBA's code are:
Better setting and bool variable names.
Additional brackets to the conditional that uses both && and &.

Tested.