### PR TITLE
Fix unexplained shader issue (glsl compiler bug??)

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -19,6 +19,8 @@ bool normalTexturePresent = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
+const float fogStart = 0.4;
+const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 #ifdef ENABLE_TONE_MAPPING
 
@@ -199,8 +201,18 @@ void main(void)
 #endif
 
 	if (fogDistance != 0.0) {
-		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
-		col = mix(skyBgColor, col, d);
+		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+		// the fog will only be rendered correctly if the last operation before the
+		// clamp() is an addition. Else, the clamp() seems to be ignored.
+		// E.g. the following won't work:
+		//      float clarity = clamp(fogShadingParameter
+		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+		// As additions usually come for free following a multiplication, the new formula
+		// should be more efficient as well.
+		// Note: clarity = (1 - fogginess)
+		float clarity = clamp(fogShadingParameter
+			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+		col = mix(skyBgColor, col, clarity);
 	}
 	col = vec4(col.rgb, base.a);
 

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -21,6 +21,8 @@ bool texSeamless = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
+const float fogStart = 0.4;
+const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 #ifdef ENABLE_TONE_MAPPING
 
@@ -155,8 +157,18 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 #endif
 
 	if (fogDistance != 0.0) {
-		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
-		col = mix(skyBgColor, col, d);
+		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+		// the fog will only be rendered correctly if the last operation before the
+		// clamp() is an addition. Else, the clamp() seems to be ignored.
+		// E.g. the following won't work:
+		//      float clarity = clamp(fogShadingParameter
+		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+		// As additions usually come for free following a multiplication, the new formula
+		// should be more efficient as well.
+		// Note: clarity = (1 - fogginess)
+		float clarity = clamp(fogShadingParameter
+			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+		col = mix(skyBgColor, col, clarity);
 	}
 	col = vec4(col.rgb, base.a);
 

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -19,6 +19,8 @@ bool texSeamless = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
+const float fogStart = 0.4;
+const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 void get_texture_flags()
 {
@@ -107,8 +109,18 @@ void main(void)
 	vec4 col = vec4(color.rgb, base.a);
 	col *= gl_Color;
 	if (fogDistance != 0.0) {
-		float d = clamp((fogDistance - length(eyeVec)) / (fogDistance * 0.6), 0.0, 1.0);
-		col = mix(skyBgColor, col, d);
+		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+		// the fog will only be rendered correctly if the last operation before the
+		// clamp() is an addition. Else, the clamp() seems to be ignored.
+		// E.g. the following won't work:
+		//      float clarity = clamp(fogShadingParameter
+		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+		// As additions usually come for free following a multiplication, the new formula
+		// should be more efficient as well.
+		// Note: clarity = (1 - fogginess)
+		float clarity = clamp(fogShadingParameter
+			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+		col = mix(skyBgColor, col, clarity);
 	}
 	gl_FragColor = vec4(col.rgb, base.a);
 }


### PR DESCRIPTION
For some reason, in the original code, the clamp() operations seem
to be ignored on my system (e.g. erroneously optimized away by the
glsl compiler ? driver bug ?)

The changed code, which _should_ be 100% equivalent, does not suffer
from the problem.

It is not known if more than one person is affected, or if this issue
is already fixed in a more recent version of the software (driver,
glsl compiler ... ?)

See also the discussion in https://github.com/minetest/minetest/issues/4691

Screenshots without and with this patch:

![screenshot_20161108_234729](https://cloud.githubusercontent.com/assets/6202053/20120654/f68a3706-a60d-11e6-9642-e03dcbe04bb3.png)
![screenshot_20161108_233431](https://cloud.githubusercontent.com/assets/6202053/20120398/f212db0c-a60c-11e6-87f9-6f800bf1d261.png)

**Note**: as so far I'm the only one experiencing this problem, I don't expect
this to be merged soon. However, this PR may be of use if and when other
people report this problem as well.
