### PR TITLE
Fix incorrect distance computation for visible blocks

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -175,7 +175,7 @@ void RemoteClient::GetNextBlocks (
 
 	const s16 full_d_max = g_settings->getS16("max_block_send_distance");
 	const s16 d_opt = g_settings->getS16("block_send_optimize_distance");
-	const s16 d_blocks_in_sight = (full_d_max + 1) * BS * MAP_BLOCKSIZE;
+	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 
 	s16 d_max = full_d_max;
 	s16 d_max_gen = g_settings->getS16("max_block_generate_distance");

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -188,14 +188,19 @@ u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed)
 }
 
 /*
-	blockpos: position of block in block coordinates
+	blockpos_b: position of block in block coordinates
 	camera_pos: position of camera in nodes
 	camera_dir: an unit vector pointing to camera direction
 	range: viewing range
+	distance_ptr: return location for distance from the camera
 */
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr)
 {
+	// Maximum radius of a block.  The magic number is
+	// sqrt(3.0) / 2.0 in literal form.
+	const f32 block_max_radius = 0.866025403784 * MAP_BLOCKSIZE * BS;
+
 	v3s16 blockpos_nodes = blockpos_b * MAP_BLOCKSIZE;
 
 	// Block center position
@@ -209,7 +214,7 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	v3f blockpos_relative = blockpos - camera_pos;
 
 	// Total distance
-	f32 d = blockpos_relative.getLength();
+	f32 d = MYMAX(0, blockpos_relative.getLength() - block_max_radius);
 
 	if(distance_ptr)
 		*distance_ptr = d;
@@ -218,13 +223,9 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	if(d > range)
 		return false;
 
-	// Maximum radius of a block.  The magic number is
-	// sqrt(3.0) / 2.0 in literal form.
-	f32 block_max_radius = 0.866025403784 * MAP_BLOCKSIZE * BS;
-
 	// If block is (nearly) touching the camera, don't
 	// bother validating further (that is, render it anyway)
-	if(d < block_max_radius)
+	if(d == 0)
 		return true;
 
 	// Adjust camera position, for purposes of computing the angle,


### PR DESCRIPTION
The client would not compute the distance from the camera to
to a mapblock correctly. The result was that blocks that were in
view (i.e. not beyond the fog limit) would not be rendered.

See issue #4763 for a discussion and screenshots