### PR TITLE
Fixed tooltips not resizing with \n

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2314,7 +2314,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				this->bringToFront(m_tooltip_element);
 				setStaticText(m_tooltip_element, tooltip_text.c_str());
 				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 4 && USE_FREETYPE == 1
+#if (IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION < 2) || USE_FREETYPE == 1
 				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
 #else
 				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2314,7 +2314,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				this->bringToFront(m_tooltip_element);
 				setStaticText(m_tooltip_element, tooltip_text.c_str());
 				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION < 2
+#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 3
 				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
 #else
 				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2314,7 +2314,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				this->bringToFront(m_tooltip_element);
 				setStaticText(m_tooltip_element, tooltip_text.c_str());
 				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 4
+#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 4 && USE_FREETYPE == 1
 				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
 #else
 				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2314,7 +2314,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				this->bringToFront(m_tooltip_element);
 				setStaticText(m_tooltip_element, tooltip_text.c_str());
 				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 3
+#if IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION <= 4
 				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
 #else
 				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;


### PR DESCRIPTION
I've got Irrlicht version 1.8.3, and, apparently, Minetest isn't resizing the tooltip on this code:
```
minetest.register_craftitem("test_newline:test", {
        description = "Test\nNew\nLines",
        inventory_image = "default_cobble.png",
})
```
With this commit, it is resizing it. This is my first code edit (I think) so please have mercy on my soul.