### PR TITLE
Rename nodeupdate and nodeupdate_single and make them part of the official API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2286,6 +2286,15 @@ and `minetest.auth_reload` call the authetification handler.
     * increase level of leveled node by level, default `level` equals `1`
     * if `totallevel > maxlevel`, returns rest (`total-max`)
     * can be negative for decreasing
+* `core.check_single_for_falling(pos)`
+    * causes an unsupported `group:falling_node` node to fall and causes an
+      unattached `group:attached_node` node to fall.
+    * does not spread these updates to neighbours.
+* `core.check_for_falling(pos)`
+    * causes an unsupported `group:falling_node` node to fall and causes an
+      unattached `group:attached_node` node to fall.
+    * spread these updates to neighbours and can cause a cascade
+      of nodes to fall.
 
 ### Inventory
 `minetest.get_inventory(location)`: returns an `InvRef`


### PR DESCRIPTION
Now, the renamed forms of nodeupdate and nodeupdate_single are part of the official API.

As nodeupdate has been used by Minetest Game and in mods despite of not
being part of the official API, we ease the transition by still supporting
it for the 0.4.15 release. After the release, the two functions can be removed.

The removal will not violate the stability promise, as that promise only
includes the official and documented API.

Also, make some formerly global functions local. They most likely haven't
been used by mods, therefore they won't get stubs with deprecation warnings,
hard erroring directly.

See issue #4733 and PR #4753.