### PR TITLE
[WIP] Hide map generators, warn about discouraged map generators and seed in world creation by subgame request

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -57,6 +57,17 @@ FlagDesc flagdesc_mapgen[] = {
 	{NULL,       0}
 };
 
+FlagDesc flagdesc_mapgen_type[] = {
+	{"v5",		MAPGEN_TYPE_V5},
+	{"v6",		MAPGEN_TYPE_V6},
+	{"v7",		MAPGEN_TYPE_V7},
+	{"flat",	MAPGEN_TYPE_FLAT},
+	{"fractal",	MAPGEN_TYPE_FRACTAL},
+	{"valleys",	MAPGEN_TYPE_VALLEYS},
+	{"singlenode",	MAPGEN_TYPE_SINGLENODE},
+	{NULL,    0}
+};
+
 FlagDesc flagdesc_gennotify[] = {
 	{"dungeon",          1 << GENNOTIFY_DUNGEON},
 	{"temple",           1 << GENNOTIFY_TEMPLE},
@@ -84,7 +95,7 @@ static MapgenDesc g_reg_mapgens[] = {
 	{"flat",       true},
 	{"fractal",    true},
 	{"valleys",    true},
-	{"singlenode", false},
+	{"singlenode", true},
 };
 
 STATIC_ASSERT(

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -37,6 +37,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MG_LIGHT       0x10
 #define MG_DECORATIONS 0x20
 
+/////////////////// Mapgen type flags
+#define MAPGEN_TYPE_V5 0x01
+#define MAPGEN_TYPE_V6 0x02
+#define MAPGEN_TYPE_V7 0x04
+#define MAPGEN_TYPE_FLAT 0x08
+#define MAPGEN_TYPE_FRACTAL 0x10
+#define MAPGEN_TYPE_VALLEYS 0x20
+#define MAPGEN_TYPE_SINGLENODE 0x40
+
 typedef u8 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class Settings;
@@ -45,6 +54,7 @@ class INodeDefManager;
 
 extern FlagDesc flagdesc_mapgen[];
 extern FlagDesc flagdesc_gennotify[];
+extern FlagDesc flagdesc_mapgen_type[];
 
 class Biome;
 class BiomeGen;

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -290,6 +290,10 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 		lua_pushstring(L,games[i].name.c_str());
 		lua_settable(L, top_lvl2);
 
+		lua_pushstring(L,"mapgen_seed_used");
+		lua_pushboolean(L,games[i].mapgen_seed_used);
+		lua_settable(L, top_lvl2);
+
 		lua_pushstring(L,"menuicon_path");
 		lua_pushstring(L,games[i].menuicon_path.c_str());
 		lua_settable(L, top_lvl2);
@@ -306,6 +310,33 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 			internal_index++;
 		}
 		lua_settable(L, top_lvl2);
+
+		lua_pushstring(L,"available_mapgens");
+		lua_newtable(L);
+		int table3 = lua_gettop(L);
+		internal_index=1;
+		for (std::set<std::string>::iterator iter = games[i].available_mapgens.begin();
+				iter != games[i].available_mapgens.end(); iter++) {
+			lua_pushstring(L,(*iter).c_str());
+			lua_pushboolean(L,true);
+			lua_settable(L, table3);
+			internal_index++;
+		}
+		lua_settable(L, top_lvl2);
+
+		lua_pushstring(L,"discouraged_mapgens");
+		lua_newtable(L);
+		int table4 = lua_gettop(L);
+		internal_index=1;
+		for (std::set<std::string>::iterator iter = games[i].discouraged_mapgens.begin();
+				iter != games[i].discouraged_mapgens.end(); iter++) {
+			lua_pushstring(L,(*iter).c_str());
+			lua_pushboolean(L,true);
+			lua_settable(L, table4);
+			internal_index++;
+		}
+		lua_settable(L, top_lvl2);
+
 		lua_settable(L, top);
 		index++;
 	}

--- a/src/subgame.h
+++ b/src/subgame.h
@@ -35,6 +35,9 @@ struct SubgameSpec
 	std::string gamemods_path; //path to mods of the game
 	std::set<std::string> addon_mods_paths; //paths to addon mods for this game
 	std::string name;
+	std::set<std::string> available_mapgens; // List of selectable mapgens in main menu
+	std::set<std::string> discouraged_mapgens; // List of mapgens which are don't perform well with this subgame while not being completely useless
+	bool mapgen_seed_used; // If true, setting the seed influences the result of the mapgen. If false, seed is ignored
 	std::string menuicon_path;
 
 	SubgameSpec(const std::string &id_="",
@@ -42,12 +45,18 @@ struct SubgameSpec
 			const std::string &gamemods_path_="",
 			const std::set<std::string> &addon_mods_paths_=std::set<std::string>(),
 			const std::string &name_="",
+			const std::set<std::string> &available_mapgens_=std::set<std::string>(),
+			const std::set<std::string> &discouraged_mapgens_=std::set<std::string>(),
+			const bool &mapgen_seed_used_=true,
 			const std::string &menuicon_path_=""):
 		id(id_),
 		path(path_),
 		gamemods_path(gamemods_path_),		
 		addon_mods_paths(addon_mods_paths_),
 		name(name_),
+		available_mapgens(available_mapgens_),
+		discouraged_mapgens(discouraged_mapgens_),
+		mapgen_seed_used(mapgen_seed_used_),
 		menuicon_path(menuicon_path_)
 	{}
 
@@ -63,6 +72,9 @@ bool getGameMinetestConfig(const std::string &game_path, Settings &conf);
 bool getGameConfig(const std::string &game_path, Settings &conf);
 
 std::string getGameName(const std::string &game_path);
+std::set<std::string> getAvailableMapgens(const std::string &game_path);
+std::set<std::string> getDiscouragedMapgens(const std::string &game_path);
+bool isMapgenSeedUsedByGame(const std::string &game_path);
 
 SubgameSpec findSubgame(const std::string &id);
 SubgameSpec findWorldSubgame(const std::string &world_path);


### PR DESCRIPTION
**This is a work in progress! Do not merge yet.**

See: https://github.com/minetest/minetest/issues/4768

The subgame's game.conf now supports 3 optional new settings:
- available_mapgens: List of mapgens which are available for this subgame. Useful to filter out unused or broken (for the subgame) mapgens.
- discouraged_mapgens: List of mapgens which don't work very well with the subgame but are not completely useless.
- mapgen_seed_used: If false, subgame does not need the seed.

These settings currently affect the world creation window. Unavailable mapgens will be hidden, discouraged mapgens show a warning when selected and the seed input field is hidden if it is not needed by the subgame.

TODO:
- Update widgets when user selects new subgame in this window.
- Update widgets when user selects new mapgen
- Update docs