### PR TITLE
Make attached particle spawners respect the parent's yaw (rebased)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4140,7 +4140,8 @@ The Biome API is still in an experimental phase and subject to change.
     --  ^ collision_removal: if true then particle is removed when it collides,
     --  ^ requires collisiondetection = true to have any effect
         attached = ObjectRef,
-    --  ^ attached: if defined, makes particle positions relative to this object.
+    --  ^ attached: if defined, particle positions, velocities and accelerations
+    --  ^ are relative to this object's position and yaw.
         vertical = false,
     --  ^ vertical: if true faces player using y axis only
         texture = "image.png",

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -61,6 +61,7 @@ public:
 	virtual bool getCollisionBox(aabb3f *toset){return false;}
 	virtual bool collideWithObjects(){return false;}
 	virtual v3f getPosition(){return v3f(0,0,0);}
+	virtual float getYaw() const {return 0;}
 	virtual scene::ISceneNode *getSceneNode(){return NULL;}
 	virtual scene::IMeshSceneNode *getMeshSceneNode(){return NULL;}
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode(){return NULL;}

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -313,7 +313,8 @@ public:
 		{return &m_selection_box;}
 	v3f getPosition()
 		{return m_position;}
-
+	inline float getYaw() const
+		{return 0;}
 	std::string infoText()
 		{return m_infotext;}
 

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -136,6 +136,10 @@ public:
 	aabb3f *getSelectionBox();
 
 	v3f getPosition();
+	inline float getYaw() const
+	{
+		return m_yaw;
+	}
 
 	scene::ISceneNode *getSceneNode();
 

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -253,12 +253,17 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 	m_time += dtime;
 
 	bool unloaded = false;
-	v3f attached_offset = v3f(0,0,0);
+	bool is_attached = false;
+	v3f attached_pos = v3f(0,0,0);
+	float attached_yaw = 0;
 	if (m_attached_id != 0) {
-		if (ClientActiveObject *attached = env->getActiveObject(m_attached_id))
-			attached_offset = attached->getPosition() / BS;
-		else
+		if (ClientActiveObject *attached = env->getActiveObject(m_attached_id)) {
+			attached_pos = attached->getPosition() / BS;
+			attached_yaw = attached->getYaw();
+			is_attached = true;
+		} else {
 			unloaded = true;
+		}
 	}
 
 	if (m_spawntime != 0) // Spawner exists for a predefined timespan
@@ -277,8 +282,15 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 					v3f pos = random_v3f(m_minpos, m_maxpos);
 					v3f vel = random_v3f(m_minvel, m_maxvel);
 					v3f acc = random_v3f(m_minacc, m_maxacc);
-					// Make relative to offest
-					pos += attached_offset;
+
+					if (is_attached) {
+						// Apply attachment yaw and position
+						pos.rotateXZBy(attached_yaw);
+						pos += attached_pos;
+						vel.rotateXZBy(attached_yaw);
+						acc.rotateXZBy(attached_yaw);
+					}
+
 					float exptime = rand()/(float)RAND_MAX
 							*(m_maxexptime-m_minexptime)
 							+m_minexptime;
@@ -321,10 +333,18 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 		{
 			if (rand()/(float)RAND_MAX < dtime)
 			{
-				v3f pos = random_v3f(m_minpos, m_maxpos)
-						+ attached_offset;
+				v3f pos = random_v3f(m_minpos, m_maxpos);
 				v3f vel = random_v3f(m_minvel, m_maxvel);
 				v3f acc = random_v3f(m_minacc, m_maxacc);
+
+				if (is_attached) {
+					// Apply attachment yaw and position
+					pos.rotateXZBy(attached_yaw);
+					pos += attached_pos;
+					vel.rotateXZBy(attached_yaw);
+					acc.rotateXZBy(attached_yaw);
+				}
+
 				float exptime = rand()/(float)RAND_MAX
 						*(m_maxexptime-m_minexptime)
 						+m_minexptime;


### PR DESCRIPTION
See #4663. Seems like I screwed everything up.

The position values of attached particle spawners are added to the parent's position absolutely. This is no problem for particles spawned equally around the parent's position, but as soon as you want to spawn particles in front or behind of objects, you run into problems.
Example: you want smoke coming out of a steam engine, but every time the engine's yaw changes you need to reinitialize the particle spawner.
With this PR, position, velocity and acceleration vectors are rotated by the yaw of the parent object so that they are truly relative to it.