### PR TITLE
Tool break: Reduce gain of break sounds

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -475,7 +475,7 @@ function core.node_dig(pos, node, digger)
 		if not core.setting_getbool("creative_mode") then
 			wielded:add_wear(dp.wear)
 			if wielded:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-				core.sound_play(wdef.sound.breaks, {pos = pos, gain = 1.0})
+				core.sound_play(wdef.sound.breaks, {pos = pos, gain = 0.5})
 			end
 		end
 	end


### PR DESCRIPTION
Gain is set in the engine, once tool break sounds were added in MTGame later they were tested and found to be far too loud.