### PR TITLE
Distinct between 'walkable' and 'solid'

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -144,7 +144,7 @@ function builtin_shared.check_attached_node(p, n)
 	local p2 = vector.add(p, d)
 	local nn = core.get_node(p2).name
 	local def2 = core.registered_nodes[nn]
-	if def2 and not def2.walkable then
+	if def2 and not def2.solid then
 		return false
 	end
 	return true
@@ -170,7 +170,7 @@ function core.check_single_for_falling(p)
 				core.get_node_level(p_bottom) <
 				core.get_node_max_level(p_bottom))) and
 
-				(not d_bottom.walkable or d_bottom.buildable_to) then
+				(not d_bottom.solid or d_bottom.buildable_to) then
 			n.level = core.get_node_level(p)
 			core.remove_node(p)
 			spawn_falling_node(p, n)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -132,11 +132,11 @@ function core.register_item(name, itemdef)
 			core.log("warning", "Node 'light_source' value exceeds maximum," ..
 				" limiting to maximum: " ..name)
 		end
+		setmetatable(itemdef, {__index = core.nodedef_default})
 		--if 'solid' is not explicitly set, default to the value of 'walkable'
 		if itemdef.solid == nil then
 			itemdef.solid = itemdef.walkable
 		end
-		setmetatable(itemdef, {__index = core.nodedef_default})
 		core.registered_nodes[itemdef.name] = itemdef
 	elseif itemdef.type == "craft" then
 		setmetatable(itemdef, {__index = core.craftitemdef_default})

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -132,6 +132,10 @@ function core.register_item(name, itemdef)
 			core.log("warning", "Node 'light_source' value exceeds maximum," ..
 				" limiting to maximum: " ..name)
 		end
+		--if 'solid' is not explicitly set, default to the value of 'walkable'
+		if itemdef.solid == nil then
+			itemdef.solid = itemdef.walkable
+		end
 		setmetatable(itemdef, {__index = core.nodedef_default})
 		core.registered_nodes[itemdef.name] = itemdef
 	elseif itemdef.type == "craft" then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1199,8 +1199,8 @@ Another example: Make red wool from white wool and red dye:
 * `disable_jump`: Player (and possibly other things) cannot jump from node
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `bouncy`: value is bounce speed in percent
-* `falling_node`: if there is no walkable block under the node it will fall
-* `attached_node`: if the node under it is not a walkable block the node will be
+* `falling_node`: if there is no 'solid' block under the node it will fall
+* `attached_node`: if the node under it is not a 'solid' block the node will be
   dropped as an item. If the node is wallmounted the wallmounted direction is
   checked.
 * `soil`: saplings will grow on nodes in this group
@@ -3700,6 +3700,8 @@ Definition tables
         is_ground_content = true, -- If false, the cave generator will not carve through this
         sunlight_propagates = false, -- If true, sunlight will go infinitely through this
         walkable = true, -- If true, objects collide with node
+        solid = <value of 'walkable'>, -- If true, attached and falling nodes will stick to this node
+	^ Note: has to be explicitly set to false if node is walkable but not solid
         pointable = true, -- If true, can be pointed at
         diggable = true, -- If false, can never be dug
         climbable = false, -- If true, can be climbed on (ladder)


### PR DESCRIPTION
Collisions and 'attached nodes stick to' are 2 different things IMO.
I ran into this problem with my rails: I want them to be walkable (so you can walk them up like slopes) but don't want torches attached to them.
This adds the 'solid' definition key.
walkable: objects collide (only)
solid: attached (and falling) nodes stick to this node
the value of 'solid' defaults to the value of 'walkable'