### PR TITLE
Don't clear excess entities on mapblock save (possible fix for #4067, #1425, etc.)

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2180,39 +2180,29 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 
 			if(block)
 			{
-				if (block->m_static_objects.m_stored.size() >= g_settings->getU16("max_objects_per_block")) {
-					warningstream << "ServerEnv: Trying to store id = " << obj->getId()
-							<< " statically but block " << PP(blockpos)
-							<< " already contains "
-							<< block->m_static_objects.m_stored.size()
-							<< " objects."
-							<< " Forcing delete." << std::endl;
-					force_delete = true;
-				} else {
-					// If static counterpart already exists in target block,
-					// remove it first.
-					// This shouldn't happen because the object is removed from
-					// the previous block before this according to
-					// obj->m_static_block, but happens rarely for some unknown
-					// reason. Unsuccessful attempts have been made to find
-					// said reason.
-					if(id && block->m_static_objects.m_active.find(id) != block->m_static_objects.m_active.end()){
-						warningstream<<"ServerEnv: Performing hack #83274"
-								<<std::endl;
-						block->m_static_objects.remove(id);
-					}
-					// Store static data
-					u16 store_id = pending_delete ? id : 0;
-					block->m_static_objects.insert(store_id, s_obj);
-
-					// Only mark block as modified if data changed considerably
-					if(shall_be_written)
-						block->raiseModified(MOD_STATE_WRITE_NEEDED,
-							MOD_REASON_STATIC_DATA_CHANGED);
-
-					obj->m_static_exists = true;
-					obj->m_static_block = block->getPos();
+				// If static counterpart already exists in target block,
+				// remove it first.
+				// This shouldn't happen because the object is removed from
+				// the previous block before this according to
+				// obj->m_static_block, but happens rarely for some unknown
+				// reason. Unsuccessful attempts have been made to find
+				// said reason.
+				if(id && block->m_static_objects.m_active.find(id) != block->m_static_objects.m_active.end()){
+					warningstream<<"ServerEnv: Performing hack #83274"
+							<<std::endl;
+					block->m_static_objects.remove(id);
 				}
+				// Store static data
+				u16 store_id = pending_delete ? id : 0;
+				block->m_static_objects.insert(store_id, s_obj);
+
+				// Only mark block as modified if data changed considerably
+				if(shall_be_written)
+					block->raiseModified(MOD_STATE_WRITE_NEEDED,
+						MOD_REASON_STATIC_DATA_CHANGED);
+
+				obj->m_static_exists = true;
+				obj->m_static_block = block->getPos();
 			}
 			else{
 				if(!force_delete){

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2187,7 +2187,8 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 				// obj->m_static_block, but happens rarely for some unknown
 				// reason. Unsuccessful attempts have been made to find
 				// said reason.
-				if(id && block->m_static_objects.m_active.find(id) != block->m_static_objects.m_active.end()){
+				if (id && block->m_static_objects.m_active.find(id) !=
+						block->m_static_objects.m_active.end()) {
 					warningstream<<"ServerEnv: Performing hack #83274"
 							<<std::endl;
 					block->m_static_objects.remove(id);
@@ -2197,7 +2198,7 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 				block->m_static_objects.insert(store_id, s_obj);
 
 				// Only mark block as modified if data changed considerably
-				if(shall_be_written)
+				if (shall_be_written)
 					block->raiseModified(MOD_STATE_WRITE_NEEDED,
 						MOD_REASON_STATIC_DATA_CHANGED);
 


### PR DESCRIPTION
This *probably* shouldn't be merged as-is, at least not without some extensive testing.

Some servers have been experiencing a bug recently where the server notices there are too many entities in a mapblock, and clears them all, wiping out players too. Seeing as how nobody seems to be able to fix the offending code (it's been over a year now), I figured I'd just remove it and see what happens.

As far as I can tell, this *did* fix the issue, and even more surprisingly, didn't seem to cause any other issues. It would appear that any excess entities are just deleted the next time the mapblock is loaded anyway, and as such, it hasn't caused any issues in my singleplayer testing, while at the same time fixing these issues:
* Difficulty connecting (client dropped during connection, aka the "gray screen" bug)
* Random disconnections (client dropped while playing, bug #4067 )
* Flickering rgblightstone (entities being deleted almost immediately after creation)

If somebody comes up with a better solution, that would be much preferred to this. On the other hand, in the meantime, I would like to see some testing of this (aside from my own) to see if it's a legitimate fix or if it causes other issues.