### PR TITLE
Allow restricting detached inventories to one player

### DIFF
--- a/builtin/game/detached_inventory.lua
+++ b/builtin/game/detached_inventory.lua
@@ -2,7 +2,7 @@
 
 core.detached_inventories = {}
 
-function core.create_detached_inventory(name, callbacks)
+function core.create_detached_inventory(name, callbacks, player_name)
 	local stuff = {}
 	stuff.name = name
 	if callbacks then
@@ -15,6 +15,6 @@ function core.create_detached_inventory(name, callbacks)
 	end
 	stuff.mod_origin = core.get_current_modname() or "??"
 	core.detached_inventories[name] = stuff
-	return core.create_detached_inventory_raw(name)
+	return core.create_detached_inventory_raw(name, player_name)
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2310,8 +2310,11 @@ and `minetest.auth_reload` call the authetification handler.
     * `{type="player", name="celeron55"}`
     * `{type="node", pos={x=, y=, z=}}`
     * `{type="detached", name="creative"}`
-* `minetest.create_detached_inventory(name, callbacks)`: returns an `InvRef`
+* `minetest.create_detached_inventory(name, callbacks, [player_name])`: returns an `InvRef`
     * callbacks: See "Detached inventory callbacks"
+    * player_name: Make detached inventory available to one player exclusively,
+      by default they will be sent to every player (even if not used).
+      Note that this parameter is mostly just a workaround and will be removed in future releases.
     * Creates a detached inventory. If it already exists, it is cleared.
 * `minetest.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)`:
    returns left over ItemStack

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -520,16 +520,17 @@ int ModApiInventory::l_get_inventory(lua_State *L)
 	}
 }
 
-// create_detached_inventory_raw(name)
+// create_detached_inventory_raw(name, [player_name])
 int ModApiInventory::l_create_detached_inventory_raw(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
-	if(getServer(L)->createDetachedInventory(name) != NULL){
+	const char *player = lua_isstring(L, 2) ? lua_tostring(L, 2) : "";
+	if (getServer(L)->createDetachedInventory(name, player) != NULL) {
 		InventoryLocation loc;
 		loc.setDetached(name);
 		InvRef::create(L, loc);
-	}else{
+	} else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/server.h
+++ b/src/server.h
@@ -270,7 +270,7 @@ public:
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
 	// Creates or resets inventory
-	Inventory* createDetachedInventory(const std::string &name);
+	Inventory* createDetachedInventory(const std::string &name, const std::string &player="");
 
 	// Envlock and conlock should be locked when using scriptapi
 	GameScripting *getScriptIface(){ return m_script; }
@@ -647,6 +647,8 @@ private:
 	*/
 	// key = name
 	std::map<std::string, Inventory*> m_detached_inventories;
+	// value = "" (visible to all players) or player name
+	std::map<std::string, std::string> m_detached_inventories_player;
 
 	DISABLE_CLASS_COPY(Server);
 };


### PR DESCRIPTION
should fix #4403

please note that **mods need to utilize this feature in order to fix the problems**

in the future when someone decides to allow player-attached invs from the script api (which is clearly the better solution to this) this mechanism can be deprecated [-> #4813]