### PR TITLE
Limit light_source in the engine

### DIFF
--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -482,6 +482,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 	liquid_viscosity = readU8(is);
 	liquid_renewable = readU8(is);
 	light_source = readU8(is);
+	light_source = MYMIN(light_source, LIGHT_MAX);
 	damage_per_second = readU32(is);
 	node_box.deSerialize(is);
 	selection_box.deSerialize(is);
@@ -1442,6 +1443,7 @@ void ContentFeatures::deSerializeOld(std::istream &is, int version)
 		liquid_alternative_source = deSerializeString(is);
 		liquid_viscosity = readU8(is);
 		light_source = readU8(is);
+		light_source = MYMIN(light_source, LIGHT_MAX);
 		damage_per_second = readU32(is);
 		node_box.deSerialize(is);
 		selection_box.deSerialize(is);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -526,6 +526,12 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	// Amount of light the node emits
 	f.light_source = getintfield_default(L, index,
 			"light_source", f.light_source);
+	if (f.light_source > LIGHT_MAX) {
+		warningstream << "Node " << f.name.c_str()
+			<< " had greater light_source than " << LIGHT_MAX
+			<< ", it was reduced." << std::endl;
+		f.light_source = LIGHT_MAX;
+	}
 	f.damage_per_second = getintfield_default(L, index,
 			"damage_per_second", f.damage_per_second);
 

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -264,6 +264,7 @@ struct LightQueue {
 		const mapblock_v3 &block_pos, MapBlock *block,
 		direction source_dir)
 	{
+		assert(light <= LIGHT_SUN);
 		lights[light].push_back(
 			ChangingLight(rel_pos, block_pos, block, source_dir));
 	}


### PR DESCRIPTION
Fixes #4807.
This commit limits nodes' light_source to 14.
Some old servers send nodes with light_source>15.