### PR TITLE
Mgv7 floatlands: Various improvements 

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -346,8 +346,11 @@ bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y)
 
 bool MapgenV7::getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y)
 {
-	float density_gradient =
-		-pow(fabs((float)(y - floatland_level) / float_mount_height), 0.8f);
+	// Make rim 2 nodes thick to match floatland base terrain
+	float density_gradient = (y >= floatland_level) ?
+		-pow((float)(y - floatland_level) / float_mount_height, 0.75f) :
+		-pow((float)(floatland_level - 1 - y) / float_mount_height, 0.75f);
+
 	float floatn = noise_mountain->result[idx_xyz] + float_mount_density;
 
 	return floatn + density_gradient >= 0.0f;
@@ -362,11 +365,10 @@ void MapgenV7::floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max, 
 
 	float n_base = noise_floatland_base->result[idx_xz];
 	if (n_base > 0.0f) {
-		float n_base_height =
-			MYMAX(noise_float_base_height->result[idx_xz], 0.0f);
+		float n_base_height = noise_float_base_height->result[idx_xz];
 		float amp = n_base * n_base_height;
 		float ridge = n_base_height / 3.0f;
-		base_min = floatland_level - amp / 2.0f;
+		base_min = floatland_level - amp / 1.5f;
 
 		if (amp > ridge * 2.0f) {
 			// Lake bed


### PR DESCRIPTION
Floatland base terrain underside was too thin, causing excessive water
leakage through tunnels under lakes, now make it thicker.
Floatland mountain terrain had a rim 1 node thick which made it bare
stone, now make it 2 nodes thick to merge with the floatland base
terrain rim and to have a layer of biome material.
Make mountain terrain more exponentially shaped by altering the
exponent.
Remove unnecessary and potentially ugly MYMAX() applied to
n_base_height.
///////////////////////////////////////////////////

![screenshot_20161129_040446](https://cloud.githubusercontent.com/assets/3686677/20696479/77231f90-b5ea-11e6-969c-cf2f75ef8e1d.png)

^ Left: 2D noise base terrain. Right: 3D noise mountain terrain. Flanges merge seamlessly.