### PR TITLE
Optimize block sent: Fix rendering issue

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -951,7 +951,7 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 		[12+12] s32 pitch*100
 		[12+12+4] s32 yaw*100
 		[12+12+4+4] u32 keyPressed
-		[12+12+4+4+1] u8 fov*80
+		[12+12+4+4+4] u8 fov*80
 		[12+12+4+4+4+1] u8 wanted_range / MAP_BLOCKSIZE
 	*/
 	*pkt << position << speed << pitch << yaw << keyPressed;
@@ -1338,7 +1338,7 @@ void Client::sendPlayerPos()
 
 	assert(myplayer->peer_id == our_peer_id);
 
-	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4);
+	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1);
 
 	writePlayerPos(myplayer, &map, &pkt);
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -357,7 +357,7 @@ queue_full_break:
 	} else if(nearest_emergefull_d != -1){
 		new_nearest_unsent_d = nearest_emergefull_d;
 	} else {
-		if(d > g_settings->getS16("max_block_send_distance")){
+		if(d > full_d_max){
 			new_nearest_unsent_d = 0;
 			m_nothing_to_send_pause_timer = 2.0;
 		} else {

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -794,7 +794,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	u32 keyPressed = 0;
 
 	// default behavior (in case an old client doesn't send these)
-	f32 fov = (72.0*M_PI/180) * 4./3.;
+	f32 fov = 0;
 	u8 wanted_range = 0;
 
 	if (pkt->getRemainingBytes() >= 4)


### PR DESCRIPTION
This fixes a rendering issue, with delayed (m_nothing_to_send_pause_timer). Should use the reduce distance calculated before. You can reproduce this when your view range is less than max_block_send_distance * 16, and you turn around. Some block will take 20 seconds or more to render.

Also includes some cosmetic fixes.