### PR TITLE
Improved line_of_sight

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2551,12 +2551,14 @@ and `minetest.auth_reload` call the authetification handler.
 * `minetest.delete_area(pos1, pos2)`
     * delete all mapblocks in the area from pos1 to pos2, inclusive
 * `minetest.line_of_sight(pos1, pos2, stepsize)`: returns `boolean, pos`
-    * Check if there is a direct line of sight between `pos1` and `pos2`
+    * Checks if there is anything other than air between pos1 and pos2.
+    * Returns false if something is blocking the sight.
     * Returns the position of the blocking node when `false`
     * `pos1`: First position
     * `pos2`: Second position
-    * `stepsize`: smaller gives more accurate results but requires more computing
-      time. Default is `1`.
+    * `stepsize`: Kept for compatibility, the starting point of the
+      line is translated towards the end by stepsize. Set to 0 for
+      accurate results.
 * `minetest.raycast(pos1, pos2, objects, liquids)`: returns `Raycast`
     * Creates a `Raycast` object.
     * `pos1`: start of the ray

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2550,15 +2550,12 @@ and `minetest.auth_reload` call the authetification handler.
     *   parameter was absent)
 * `minetest.delete_area(pos1, pos2)`
     * delete all mapblocks in the area from pos1 to pos2, inclusive
-* `minetest.line_of_sight(pos1, pos2, stepsize)`: returns `boolean, pos`
+* `minetest.line_of_sight(pos1, pos2)`: returns `boolean, pos`
     * Checks if there is anything other than air between pos1 and pos2.
     * Returns false if something is blocking the sight.
     * Returns the position of the blocking node when `false`
     * `pos1`: First position
     * `pos2`: Second position
-    * `stepsize`: Kept for compatibility, the starting point of the
-      line is translated towards the end by stepsize. Set to 0 for
-      accurate results.
 * `minetest.raycast(pos1, pos2, objects, liquids)`: returns `Raycast`
     * Creates a `Raycast` object.
     * `pos1`: start of the ray

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -947,24 +947,19 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 	return 0;
 }
 
-// line_of_sight(pos1, pos2, stepsize) -> true/false, pos
+// line_of_sight(pos1, pos2) -> true/false, pos
 int ModApiEnvMod::l_line_of_sight(lua_State *L)
 {
-	float stepsize = 1.0;
-
 	GET_ENV_PTR;
 
 	// read position 1 from lua
 	v3f pos1 = checkFloatPos(L, 1);
 	// read position 2 from lua
 	v3f pos2 = checkFloatPos(L, 2);
-	//read step size from lua
-	if (lua_isnumber(L, 3)) {
-		stepsize = lua_tonumber(L, 3);
-	}
 
 	v3s16 p;
-	bool success = env->line_of_sight(pos1, pos2, stepsize, &p);
+
+	bool success = env->line_of_sight(pos1, pos2, &p);
 	lua_pushboolean(L, success);
 	if (!success) {
 		push_v3s16(L, p);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -157,7 +157,7 @@ private:
 	// spawn_tree(pos, treedef)
 	static int l_spawn_tree(lua_State *L);
 
-	// line_of_sight(pos1, pos2, stepsize) -> true/false
+	// line_of_sight(pos1, pos2) -> true/false
 	static int l_line_of_sight(lua_State *L);
 
 	// raycast(pos1, pos2, objects, liquids) -> Raycast

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -481,15 +481,8 @@ bool ServerEnvironment::removePlayerFromDatabase(const std::string &name)
 	return m_player_database->removePlayer(name);
 }
 
-bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 *p)
+bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, v3s16 *p)
 {
-	float distance = pos1.getDistanceFrom(pos2);
-	// For compatibility, reduce the length of the line
-	// by stepsize, keeping the end's position
-	if (distance < stepsize) {
-		return true;
-	}
-	pos1 += (pos2 - pos1) * (stepsize / distance);
 	// Iterate trough nodes on the line
 	voxalgo::VoxelLineIterator iterator(pos1 / BS, (pos2 - pos1) / BS);
 	do {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -484,27 +484,25 @@ bool ServerEnvironment::removePlayerFromDatabase(const std::string &name)
 bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 *p)
 {
 	float distance = pos1.getDistanceFrom(pos2);
+	// For compatibility, reduce the length of the line
+	// by stepsize, keeping the end's position
+	if (distance < stepsize) {
+		return true;
+	}
+	pos1 += (pos2 - pos1) * (stepsize / distance);
+	// Iterate trough nodes on the line
+	voxalgo::VoxelLineIterator iterator(pos1 / BS, (pos2 - pos1) / BS);
+	do {
+		MapNode n = getMap().getNodeNoEx(iterator.m_current_node_pos);
 
-	//calculate normalized direction vector
-	v3f normalized_vector = v3f((pos2.X - pos1.X)/distance,
-		(pos2.Y - pos1.Y)/distance,
-		(pos2.Z - pos1.Z)/distance);
-
-	//find out if there's a node on path between pos1 and pos2
-	for (float i = 1; i < distance; i += stepsize) {
-		v3s16 pos = floatToInt(v3f(normalized_vector.X * i,
-			normalized_vector.Y * i,
-			normalized_vector.Z * i) +pos1,BS);
-
-		MapNode n = getMap().getNodeNoEx(pos);
-
-		if(n.param0 != CONTENT_AIR) {
-			if (p) {
-				*p = pos;
-			}
+		// Return non-air
+		if (n.param0 != CONTENT_AIR) {
+			if (p)
+				*p = iterator.m_current_node_pos;
 			return false;
 		}
-	}
+		iterator.next();
+	} while (iterator.m_current_index <= iterator.m_last_index);
 	return true;
 }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -323,16 +323,14 @@ public:
 	void step(f32 dtime);
 
 	/*!
-	 * Returns true if the given line intersects with a
-	 * non-air node.
+	 * Returns false if the given line intersects with a
+	 * non-air node, true otherwise.
 	 * \param pos1 start of the line
 	 * \param pos2 end of the line
-	 * \param stepsize kept for compatibility. The starting point of the
-	 * line is translated by stepsize towards the end.
 	 * \param p output, position of the first non-air node
 	 * the line intersects
 	 */
-	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, v3s16 *p=NULL);
+	bool line_of_sight(v3f pos1, v3f pos2, v3s16 *p = NULL);
 
 	u32 getGameTime() const { return m_game_time; }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -322,7 +322,16 @@ public:
 	// This makes stuff happen
 	void step(f32 dtime);
 
-	//check if there's a line of sight between two positions
+	/*!
+	 * Returns true if the given line intersects with a
+	 * non-air node.
+	 * \param pos1 start of the line
+	 * \param pos2 end of the line
+	 * \param stepsize kept for compatibility. The starting point of the
+	 * line is translated by stepsize towards the end.
+	 * \param p output, position of the first non-air node
+	 * the line intersects
+	 */
 	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, v3s16 *p=NULL);
 
 	u32 getGameTime() const { return m_game_time; }


### PR DESCRIPTION
Sorry for creating long pull request chains, but the feature freeze is close and I thought it might worth merging.
This PR is based on #4421, please do not merge this before that.

I rewrote line_of_sight to use vector computations (`VoxelLineIterator`) rather than just stepping forward.
Parameter 'stepsize' is kept for compatibility.

With this, line_of_sight will be accurate and won't step trough nodes' edges. The running time also becomes independent of the stepsize.
Comparsion when the line is 40 nodes long and only meets air:
```
Running time of line_of_sight:
old, stepsize 10 (node-sized step): 8 microseconds
old, stepsize 1: 24 microseconds
old, stepsize 0.1: 155 microseconds
new: always 9 microseconds
```