### PR TITLE
Mapgen: Make mgv7 the default mapgen for 0.4.15

### DIFF
--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -26,8 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/container.h"
 
-#define MAPGEN_DEFAULT MAPGEN_V6
-#define MAPGEN_DEFAULT_NAME "v6"
+#define MAPGEN_DEFAULT MAPGEN_V7
+#define MAPGEN_DEFAULT_NAME "v7"
 
 /////////////////// Mapgen flags
 #define MG_TREES       0x01  // Deprecated. Moved into mgv6 flags


### PR DESCRIPTION
Addresses #3655 
The biome system has been much improved for release, but is not officially stable (it may never be).
Mgv7 terrain is now stable, apart from the experimental floatlands which are disabled by default.

Anyone who has used Minetest for a while has tried the mapgens and knows which to use, the only way the default is important is concerning those new to the game and reviewers.
I make a daily check on all new Minetest videos on Youtube and all of those new to the game use the default mgv6. I guess when faced with the choice of mapgens they don't know what to do so just use the default, perhaps assuming the default has been set as being the mapgen most representative and most developed, our best work.

Obviously mgv6 is none of these:

It has hardcoded biomes and some hardcoded decorations and doesn't use the biome API.
It has 6 biomes instead of 12 plus iceberg, sand dune and swamp sub-biomes.
It lacks aspen, temperate pine and acacia trees, dry grasses, logs, large cacti, bushes and coral reefs.
It has no sandstone.
Hills don't pass y = 47 and there are no mountains or overhangs.
There are no rivers.
The terrain and biomes become repetitve on a smaller scale, travel 500 nodes and you've seen everything.

It drives me nuts to see all these people missing our best work and not getting the best impression, and making videos that others watch.
So, even if you have no personal preference please support to give a better impression of Minetest.