### PR TITLE
Biomes: Increase heat and humidity noise spread to 1000

### DIFF
--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -134,8 +134,8 @@ protected:
 
 struct BiomeParamsOriginal : public BiomeParams {
 	BiomeParamsOriginal() :
-		np_heat(50, 50, v3f(750.0, 750.0, 750.0), 5349, 3, 0.5, 2.0),
-		np_humidity(50, 50, v3f(750.0, 750.0, 750.0), 842, 3, 0.5, 2.0),
+		np_heat(50, 50, v3f(1000.0, 1000.0, 1000.0), 5349, 3, 0.5, 2.0),
+		np_humidity(50, 50, v3f(1000.0, 1000.0, 1000.0), 842, 3, 0.5, 2.0),
 		np_heat_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0),
 		np_humidity_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 90003, 2, 1.0, 2.0)
 	{


### PR DESCRIPTION
To avoid smaller biomes when extra biomes are added to MTGame.
The addition of bushes in MTGame grasslands makes wood resources easier
to find and less distant, so slightly larger biomes are now acceptable,
but also desirable to encourage travel and create more sense of adventure.
////////////////////////////////////////////////////////

To be merged with https://github.com/minetest/minetest_game/pull/1432