### PR TITLE
configurable fog start

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -529,8 +529,8 @@ ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
 #    Enables animation of inventory items.
 inventory_items_animations (Inventory items animations) bool false
 
-#    Percent of the visible distance at which fog starts to be rendered
-fog_start_pct (Fog Start in Percent) int 40 0 99
+#    Fraction of the visible distance at which fog starts to be rendered
+fog_start (Fog Start) float 0.4 0.0 0.99
 
 [**Menus]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -529,6 +529,9 @@ ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
 #    Enables animation of inventory items.
 inventory_items_animations (Inventory items animations) bool false
 
+#    Percent of the visible distance at which fog starts to be rendered
+fog_start_pct (Fog Start in Percent) int 40 0 99
+
 [**Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -19,7 +19,7 @@ bool normalTexturePresent = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
-const float fogStart = 0.4;
+const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 #ifdef ENABLE_TONE_MAPPING

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -21,7 +21,7 @@ bool texSeamless = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
-const float fogStart = 0.4;
+const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 #ifdef ENABLE_TONE_MAPPING

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -19,7 +19,7 @@ bool texSeamless = false;
 
 const float e = 2.718281828459;
 const float BS = 10.0;
-const float fogStart = 0.4;
+const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
 void get_texture_flags()

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -615,6 +615,9 @@
 #    type: bool
 # inventory_items_animations = false
 
+#    Percent of the visible distance at which fog starts to be rendered
+# fog_start_pct = 40
+
 ### Menus
 
 #    Use a cloud animation for the main menu background.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -615,8 +615,9 @@
 #    type: bool
 # inventory_items_animations = false
 
-#    Percent of the visible distance at which fog starts to be rendered
-# fog_start_pct = 40
+#    Fraction of the visible distance at which fog starts to be rendered
+#    Range 0 - 0.99
+# fog_start = 0.4
 
 ### Menus
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -106,6 +106,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("client_unload_unused_data_timeout", "600");
 	settings->setDefault("client_mapblock_limit", "5000");
 	settings->setDefault("enable_fog", "true");
+	settings->setDefault("fog_start_pct", "40");
 	settings->setDefault("fov", "72");
 	settings->setDefault("view_bobbing", "true");
 	settings->setDefault("leaves_style", "fancy");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -106,7 +106,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("client_unload_unused_data_timeout", "600");
 	settings->setDefault("client_mapblock_limit", "5000");
 	settings->setDefault("enable_fog", "true");
-	settings->setDefault("fog_start_pct", "40");
+	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("fov", "72");
 	settings->setDefault("view_bobbing", "true");
 	settings->setDefault("leaves_style", "fancy");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1825,6 +1825,8 @@ private:
 	f32  m_cache_mouse_sensitivity;
 	f32  m_cache_joystick_frustum_sensitivity;
 	f32  m_repeat_right_click_time;
+	f32  m_cache_cam_smoothing;
+	f32  m_cache_fog_start;
 
 #ifdef __ANDROID__
 	bool m_cache_hold_aux1;
@@ -1875,6 +1877,12 @@ Game::Game() :
 	g_settings->registerChangedCallback("noclip",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("free_move",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("cinematic",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("cinematic_camera_smoothing",
+		&settingChangedCallback, this);
+	g_settings->registerChangedCallback("camera_smoothing",
 		&settingChangedCallback, this);
 
 	readSettings();
@@ -1928,6 +1936,12 @@ Game::~Game()
 	g_settings->deregisterChangedCallback("noclip",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("free_move",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("cinematic",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("cinematic_camera_smoothing",
+		&settingChangedCallback, this);
+	g_settings->deregisterChangedCallback("camera_smoothing",
 		&settingChangedCallback, this);
 }
 
@@ -2034,16 +2048,10 @@ void Game::run()
 		processUserInput(&flags, &runData, dtime);
 		// Update camera before player movement to avoid camera lag of one frame
 		updateCameraDirection(&cam_view_target, &flags, dtime);
-		float cam_smoothing = 0;
-		if (g_settings->getBool("cinematic"))
-			cam_smoothing = 1 - g_settings->getFloat("cinematic_camera_smoothing");
-		else
-			cam_smoothing = 1 - g_settings->getFloat("camera_smoothing");
-		cam_smoothing = rangelim(cam_smoothing, 0.01f, 1.0f);
 		cam_view.camera_yaw += (cam_view_target.camera_yaw -
-				cam_view.camera_yaw) * cam_smoothing;
+				cam_view.camera_yaw) * m_cache_cam_smoothing;
 		cam_view.camera_pitch += (cam_view_target.camera_pitch -
-				cam_view.camera_pitch) * cam_smoothing;
+				cam_view.camera_pitch) * m_cache_cam_smoothing;
 		updatePlayerControl(cam_view);
 		step(&dtime);
 		processClientEvents(&cam_view_target, &runData.damage_flash);
@@ -4284,7 +4292,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats,
 		driver->setFog(
 				sky->getBgColor(),
 				video::EFT_FOG_LINEAR,
-				runData->fog_range * 0.4,
+				runData->fog_range * m_cache_fog_start,
 				runData->fog_range * 1.0,
 				0.01,
 				false, // pixel fog
@@ -4660,7 +4668,18 @@ void Game::readSettings()
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");
 
+	m_cache_fog_start                    = g_settings->getFloat("fog_start_pct")/100.0;
+
+	m_cache_cam_smoothing = 0;
+	if (g_settings->getBool("cinematic"))
+		m_cache_cam_smoothing = 1 - g_settings->getFloat("cinematic_camera_smoothing");
+	else
+		m_cache_cam_smoothing = 1 - g_settings->getFloat("camera_smoothing");
+
+	m_cache_fog_start = rangelim(m_cache_fog_start, 0.0f, 0.99f);
+	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
+
 }
 
 /****************************************************************************/

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4668,7 +4668,7 @@ void Game::readSettings()
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");
 
-	m_cache_fog_start                    = g_settings->getFloat("fog_start_pct")/100.0;
+	m_cache_fog_start                    = g_settings->getFloat("fog_start");
 
 	m_cache_cam_smoothing = 0;
 	if (g_settings->getBool("cinematic"))

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -751,6 +751,10 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 	if (g_settings->getBool("tone_mapping"))
 		shaders_header += "#define ENABLE_TONE_MAPPING\n";
 
+	shaders_header += "#define FOG_START ";
+	shaders_header += ftos(g_settings->getFloat("fog_start_pct")/100.0);
+	shaders_header += "\n";
+
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
 	const c8* vertex_program_ptr = 0;
 	const c8* pixel_program_ptr = 0;

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -752,7 +752,7 @@ ShaderInfo generate_shader(std::string name, u8 material_type, u8 drawtype,
 		shaders_header += "#define ENABLE_TONE_MAPPING\n";
 
 	shaders_header += "#define FOG_START ";
-	shaders_header += ftos(g_settings->getFloat("fog_start_pct")/100.0);
+	shaders_header += ftos(rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f));
 	shaders_header += "\n";
 
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()


### PR DESCRIPTION
Allows to make the start of the fog configurable (in percent of the visible range). Default it 40% as before.

While I was add it I also fixed us retrieving at two global settings in the main game loop (for the camera smoothing).

Related to #4836 but doesn't end up fixing the issue presented there, since the visible range is not increased (much).

This does _not_ include changing the fog distance factor from 0.9 to 0.95 as I found that detriment to the visual experience and not increasing visible range much (5% as the far range is only noticeable when "edges of the world" are visible).

Have a look. Not sure we actually want to merge this.
(except for maybe the camera smoothing, because that was stupid)