### PR TITLE
Fix unnecessary block loading and duplicating objects

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -508,13 +508,15 @@ EmergeAction EmergeThread::getBlockOrStartGen(
 
 	// 1). Attempt to fetch block from memory
 	*block = m_map->getBlockNoCreateNoEx(pos);
-	if (*block && !(*block)->isDummy() && (*block)->isGenerated())
-		return EMERGE_FROM_MEMORY;
-
-	// 2). Attempt to load block from disk
-	*block = m_map->loadBlock(pos);
-	if (*block && (*block)->isGenerated())
-		return EMERGE_FROM_DISK;
+	if (*block && !(*block)->isDummy()) {
+		if ((*block)->isGenerated())
+			return EMERGE_FROM_MEMORY;
+	} else {
+		// 2). Attempt to load block from disk if it was not in the memory
+		*block = m_map->loadBlock(pos);
+		if (*block && (*block)->isGenerated())
+			return EMERGE_FROM_DISK;
+	}
 
 	// 3). Attempt to start generation
 	if (allow_gen && m_map->initBlockMake(pos, bmdata))


### PR DESCRIPTION
This commit makes the game load blocks only if they are not in the memory.
Previously far blocks that had been only partially generated were continuously loaded from the disk.
This is because they are marked as not generated, and the code did not accept them as valid blocks.