### PR TITLE
Simple deco: allow param2 value for placement.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4040,8 +4040,10 @@ The Biome API is still in an experimental phase and subject to change.
     --  ^ Number of nodes high the decoration is made.
     --  ^ If height_max is not 0, this is the lower bound of the randomly selected height.
         height_max = 0,
-    --      ^ Number of nodes the decoration can be at maximum.
+    --  ^ Number of nodes the decoration can be at maximum.
     --  ^ If absent, the parameter 'height' is used as a constant.
+        param2 = 0,
+    --  ^ Param2 value of placed decoration node.
 
         ----- Schematic-type parameters
         schematic = "foobar.mts",

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -315,7 +315,7 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 				!force_placement)
 			break;
 
-		vm->m_data[vi] = MapNode(c_place);
+		vm->m_data[vi] = MapNode(c_place, 0, deco_param2);
 	}
 
 	return 1;

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -100,6 +100,7 @@ public:
 	std::vector<content_t> c_decos;
 	s16 deco_height;
 	s16 deco_height_max;
+	u8 deco_param2;
 };
 
 class DecoSchematic : public Decoration {

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -975,6 +975,7 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 
 	deco->deco_height     = getintfield_default(L, index, "height", 1);
 	deco->deco_height_max = getintfield_default(L, index, "height_max", 0);
+	deco->deco_param2     = getintfield_default(L, index, "param2", 0);
 
 	if (deco->deco_height <= 0) {
 		errorstream << "register_decoration: simple decoration height"
@@ -987,6 +988,12 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 	if (nnames == 0) {
 		errorstream << "register_decoration: no decoration nodes "
 			"defined" << std::endl;
+		return false;
+	}
+
+	if ((deco->deco_param2 < 0) || (deco->deco_param2 > 255)) {
+		errorstream << "register_decoration: param2 out of bounds (0-255)"
+			<< std::endl;
 		return false;
 	}
 


### PR DESCRIPTION
Schematics can already be placed with a param2 value, but not
simple 1-node plant decorations of the simple type.

This adds a `param2` field to the simple deco type that is
checked to be between 0 and 255, and put to the placed node
at mapgen.

This can be used to put a degrotate value in, or e.g. a fill
value for leveltype nodes, or a place_param2 value at mapgen
placement, or vary the shape of meshoptions plantlike drawtype.