### PR TITLE
Fix range check for simple deco->deco_param2

### DIFF
--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -972,10 +972,10 @@ int ModApiMapgen::l_register_decoration(lua_State *L)
 bool read_deco_simple(lua_State *L, DecoSimple *deco)
 {
 	int index = 1;
+	int param2;
 
 	deco->deco_height     = getintfield_default(L, index, "height", 1);
 	deco->deco_height_max = getintfield_default(L, index, "height_max", 0);
-	deco->deco_param2     = getintfield_default(L, index, "param2", 0);
 
 	if (deco->deco_height <= 0) {
 		errorstream << "register_decoration: simple decoration height"
@@ -991,11 +991,13 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 		return false;
 	}
 
-	if ((deco->deco_param2 < 0) || (deco->deco_param2 > 255)) {
+	param2 = getintfield_default(L, index, "param2", 0);
+	if ((param2 < 0) || (param2 > 255)) {
 		errorstream << "register_decoration: param2 out of bounds (0-255)"
 			<< std::endl;
 		return false;
 	}
+	deco->deco_param2 = (u8)param2;
 
 	return true;
 }


### PR DESCRIPTION
Allow any int value, and properly range check it before casting.