### PR TITLE
Remove unnecessary shader if-statements.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -163,7 +163,8 @@ void main(void)
 	}
 #endif
 
-	if (GENERATE_NORMALMAPS == 1 && normalTexturePresent == false) {
+#if GENERATE_NORMALMAPS == 1
+	if (normalTexturePresent == false) {
 		float tl = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y + SAMPLE_STEP));
 		float t  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y - SAMPLE_STEP));
 		float tr = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y + SAMPLE_STEP));
@@ -177,7 +178,7 @@ void main(void)
 		bump = vec4(normalize(vec3 (dX, dY, NORMALMAPS_STRENGTH)), 1.0);
 		use_normalmap = true;
 	}
-
+#endif
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
 #ifdef ENABLE_BUMPMAPPING
@@ -200,20 +201,18 @@ void main(void)
 	col = applyToneMapping(col);
 #endif
 
-	if (fogDistance != 0.0) {
-		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
-		// the fog will only be rendered correctly if the last operation before the
-		// clamp() is an addition. Else, the clamp() seems to be ignored.
-		// E.g. the following won't work:
-		//      float clarity = clamp(fogShadingParameter
-		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
-		// As additions usually come for free following a multiplication, the new formula
-		// should be more efficient as well.
-		// Note: clarity = (1 - fogginess)
-		float clarity = clamp(fogShadingParameter
-			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
-		col = mix(skyBgColor, col, clarity);
-	}
+	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+	// the fog will only be rendered correctly if the last operation before the
+	// clamp() is an addition. Else, the clamp() seems to be ignored.
+	// E.g. the following won't work:
+	//      float clarity = clamp(fogShadingParameter
+	//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+	// As additions usually come for free following a multiplication, the new formula
+	// should be more efficient as well.
+	// Note: clarity = (1 - fogginess)
+	float clarity = clamp(fogShadingParameter
+		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+	col = mix(skyBgColor, col, clarity);
 	col = vec4(col.rgb, base.a);
 
 	gl_FragColor = col;

--- a/client/shaders/water_surface_shader/opengl_fragment.glsl
+++ b/client/shaders/water_surface_shader/opengl_fragment.glsl
@@ -114,7 +114,8 @@ void main(void)
 	} 
 #endif
 
-	if (GENERATE_NORMALMAPS == 1 && use_normalmap == false) {
+#if GENERATE_NORMALMAPS == 1
+	if (use_normalmap == false) {
 		float tl = get_rgb_height (vec2(uv.x-SAMPLE_STEP,uv.y+SAMPLE_STEP));
 		float t  = get_rgb_height (vec2(uv.x-SAMPLE_STEP,uv.y-SAMPLE_STEP));
 		float tr = get_rgb_height (vec2(uv.x+SAMPLE_STEP,uv.y+SAMPLE_STEP));
@@ -128,6 +129,7 @@ void main(void)
 		bump = vec4 (normalize(vec3 (dX, -dY, NORMALMAPS_STRENGTH)),1.0);
 		use_normalmap = true;
 	}
+#endif
 
 vec4 base = texture2D(baseTexture, uv).rgba;
 
@@ -156,20 +158,18 @@ vec4 base = texture2D(baseTexture, uv).rgba;
 	col = applyToneMapping(col);
 #endif
 
-	if (fogDistance != 0.0) {
-		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
-		// the fog will only be rendered correctly if the last operation before the
-		// clamp() is an addition. Else, the clamp() seems to be ignored.
-		// E.g. the following won't work:
-		//      float clarity = clamp(fogShadingParameter
-		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
-		// As additions usually come for free following a multiplication, the new formula
-		// should be more efficient as well.
-		// Note: clarity = (1 - fogginess)
-		float clarity = clamp(fogShadingParameter
-			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
-		col = mix(skyBgColor, col, clarity);
-	}
+	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+	// the fog will only be rendered correctly if the last operation before the
+	// clamp() is an addition. Else, the clamp() seems to be ignored.
+	// E.g. the following won't work:
+	//      float clarity = clamp(fogShadingParameter
+	//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+	// As additions usually come for free following a multiplication, the new formula
+	// should be more efficient as well.
+	// Note: clarity = (1 - fogginess)
+	float clarity = clamp(fogShadingParameter
+		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+	col = mix(skyBgColor, col, clarity);
 	col = vec4(col.rgb, base.a);
 
 	gl_FragColor = col;

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -75,7 +75,8 @@ void main(void)
 	}
 #endif
 
-	if (GENERATE_NORMALMAPS == 1 && normalTexturePresent == false) {
+#if GENERATE_NORMALMAPS == 1
+	if (normalTexturePresent == false) {
 		float tl = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y + SAMPLE_STEP));
 		float t  = get_rgb_height(vec2(uv.x - SAMPLE_STEP, uv.y - SAMPLE_STEP));
 		float tr = get_rgb_height(vec2(uv.x + SAMPLE_STEP, uv.y + SAMPLE_STEP));
@@ -89,6 +90,7 @@ void main(void)
 		bump = vec4(normalize(vec3 (dX, dY, NORMALMAPS_STRENGTH)), 1.0);
 		use_normalmap = true;
 	}
+#endif
 
 	vec4 base = texture2D(baseTexture, uv).rgba;
 
@@ -108,19 +110,18 @@ void main(void)
 
 	vec4 col = vec4(color.rgb, base.a);
 	col *= gl_Color;
-	if (fogDistance != 0.0) {
-		// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
-		// the fog will only be rendered correctly if the last operation before the
-		// clamp() is an addition. Else, the clamp() seems to be ignored.
-		// E.g. the following won't work:
-		//      float clarity = clamp(fogShadingParameter
-		//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
-		// As additions usually come for free following a multiplication, the new formula
-		// should be more efficient as well.
-		// Note: clarity = (1 - fogginess)
-		float clarity = clamp(fogShadingParameter
-			- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
-		col = mix(skyBgColor, col, clarity);
-	}
+	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
+	// the fog will only be rendered correctly if the last operation before the
+	// clamp() is an addition. Else, the clamp() seems to be ignored.
+	// E.g. the following won't work:
+	//      float clarity = clamp(fogShadingParameter
+	//		* (fogDistance - length(eyeVec)) / fogDistance), 0.0, 1.0);
+	// As additions usually come for free following a multiplication, the new formula
+	// should be more efficient as well.
+	// Note: clarity = (1 - fogginess)
+	float clarity = clamp(fogShadingParameter
+		- fogShadingParameter * length(eyeVec) / fogDistance, 0.0, 1.0);
+	col = mix(skyBgColor, col, clarity);
+
 	gl_FragColor = vec4(col.rgb, base.a);
 }


### PR DESCRIPTION
This PR pulls `if GENERATE_NORMALMAPS == 1` into the template avoiding evaluating it for each fragment.

It also removes `if (fogDistance != 0.0)`. That condition is already not handled for shader-less rendering with no ill-effects when view range is set to 0.
I also tried with manually setting view range to 0 and shader enabled, no shader errors seen (both NVidia GPU and Intel HD)

If conditions are bad in shaders for performance. The difference depends on the platform. In my setup it made difference actually, so it's probably a minor fix.
