### PR TITLE
Use the outgoing split sequence number for every outgoing packet

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1237,7 +1237,7 @@ void UDPPeer::RunCommandQueues(
 u16 UDPPeer::getNextSplitSequenceNumber(u8 channel)
 {
 	assert(channel < CHANNEL_COUNT); // Pre-condition
-	return channels[channel].readNextIncomingSeqNum();
+	return channels[channel].readNextSplitSeqNum();
 }
 
 void UDPPeer::setNextSplitSequenceNumber(u8 channel, u16 seqnum)


### PR DESCRIPTION
(instead of the last incoming sequence number...)

Fixes #4848

For outgoing packets, the last *incoming* sequence number was used. This
caused different unreliable split packets to be sent using with the same sequence
number. As a result, the connection code would mix up chunks from different
packets.

Example packet trace:
```
No.     Time        Length Protocol 
   4212 36.889518   556    Minetest Server: Split message 65504 chunk 0/20 (Unrel)
   4213 36.889555   556    Minetest Server: Split message 65504 chunk 1/20 (Unrel)
   4214 36.889589   556    Minetest Server: Split message 65504 chunk 2/20 (Unrel)
   4215 36.889620   556    Minetest Server: Split message 65504 chunk 3/20 (Unrel)
   4216 36.889654   556    Minetest Server: Split message 65504 chunk 4/20 (Unrel)
   4217 36.889684   556    Minetest Server: Split message 65504 chunk 5/20 (Unrel)
   4218 36.889728   556    Minetest Server: Split message 65504 chunk 6/20 (Unrel)
   4219 36.889760   556    Minetest Server: Split message 65504 chunk 7/20 (Unrel)
   4220 36.889794   556    Minetest Server: Split message 65504 chunk 8/20 (Unrel)
   4221 36.889825   556    Minetest Server: Split message 65504 chunk 9/20 (Unrel)
   4222 36.889859   556    Minetest Server: Split message 65504 chunk 10/20 (Unrel)
   4223 36.889891   556    Minetest Server: Split message 65504 chunk 11/20 (Unrel)
   4224 36.889925   556    Minetest Server: Split message 65504 chunk 12/20 (Unrel)
   4225 36.889957   556    Minetest Server: Split message 65504 chunk 13/20 (Unrel)
   4226 36.890001   556    Minetest Server: Split message 65504 chunk 14/20 (Unrel)
   4227 36.890035   556    Minetest Server: Split message 65504 chunk 15/20 (Unrel)
   4228 36.890069   556    Minetest Server: Split message 65504 chunk 16/20 (Unrel)
   4229 36.890099   556    Minetest Server: Split message 65504 chunk 17/20 (Unrel)
   4230 36.890130   556    Minetest Server: Split message 65504 chunk 18/20 (Unrel)
   4231 36.890160   186    Minetest Server: Split message 65504 chunk 19/20 (Unrel)
   4232 36.895174   445    Minetest Server: BLOCKDATA (Seq=26)
   4233 36.895449   55     Minetest Ack 26 (Unrel)
   4234 36.896664   556    Minetest Server: Split message 65521 chunk 0/2 (Seq=27)
   4235 36.896750   337    Minetest Server: Split message 65521 chunk 1/2 (Seq=28)
   4236 36.897105   55     Minetest Ack 27 (Unrel)
   4237 36.897130   55     Minetest Ack 28 (Unrel)
   4238 36.897655   63     Minetest Server: TIME_OF_DAY (Seq=1321)
   4239 36.897896   55     Minetest Ack 1321 (Unrel)
   4240 37.175046   64     Minetest Client: GOTBLOCKS * 1 (Seq=2)
   4241 37.175303   55     Minetest Ack 2 (Unrel)
   4242 37.419237   64     Minetest Client: GOTBLOCKS * 1 (Seq=3)
   4243 37.419490   55     Minetest Ack 3 (Unrel)
   4244 37.664217   135    Minetest Server: Unknown command (Seq=1)
   4245 37.664258   144    Minetest Server: Unknown command (Seq=2)
   4246 37.664288   61     Minetest Server: Unknown command (Seq=3)
   4247 37.664646   55     Minetest Ack 1 (Unrel)
   4248 37.664671   55     Minetest Ack 2 (Unrel)
   4249 37.664693   55     Minetest Ack 3 (Unrel)
   4250 38.028016   307    Minetest Server: ACTIVE_OBJECT_REMOVE_ADD * 1 (Seq=1322)
   4251 38.028298   55     Minetest Ack 1322 (Unrel)
   4252 38.031185   556    Minetest Server: Split message 65523 chunk 0/4 (Seq=1323)
   4253 38.031222   556    Minetest Server: Split message 65523 chunk 1/4 (Seq=1324)
   4254 38.031252   556    Minetest Server: Split message 65523 chunk 2/4 (Seq=1325)
   4255 38.031281   118    Minetest Server: Split message 65523 chunk 3/4 (Seq=1326)
   4256 38.031915   55     Minetest Ack 1323 (Unrel)
   4257 38.031942   55     Minetest Ack 1324 (Unrel)
   4258 38.031964   55     Minetest Ack 1325 (Unrel)
   4259 38.031987   55     Minetest Ack 1326 (Unrel)
   4260 38.032584   556    Minetest Server: Split message 65504 chunk 0/19 (Unrel)
   4261 38.032611   556    Minetest Server: Split message 65504 chunk 1/19 (Unrel)
   4262 38.032635   556    Minetest Server: Split message 65504 chunk 2/19 (Unrel)
   4263 38.032659   556    Minetest Server: Split message 65504 chunk 3/19 (Unrel)
   4264 38.032683   556    Minetest Server: Split message 65504 chunk 4/19 (Unrel)
   4265 38.032707   556    Minetest Server: Split message 65504 chunk 5/19 (Unrel)
   4266 38.032731   556    Minetest Server: Split message 65504 chunk 6/19 (Unrel)
   4267 38.032754   556    Minetest Server: Split message 65504 chunk 7/19 (Unrel)
   4268 38.032778   556    Minetest Server: Split message 65504 chunk 8/19 (Unrel)
   4269 38.032802   556    Minetest Server: Split message 65504 chunk 9/19 (Unrel)
   4270 38.032826   556    Minetest Server: Split message 65504 chunk 10/19 (Unrel)
   4271 38.032850   556    Minetest Server: Split message 65504 chunk 11/19 (Unrel)
   4272 38.032874   556    Minetest Server: Split message 65504 chunk 12/19 (Unrel)
   4273 38.032898   556    Minetest Server: Split message 65504 chunk 13/19 (Unrel)
   4274 38.032921   556    Minetest Server: Split message 65504 chunk 14/19 (Unrel)
   4275 38.032945   556    Minetest Server: Split message 65504 chunk 15/19 (Unrel)
   4276 38.032968   556    Minetest Server: Split message 65504 chunk 16/19 (Unrel)
   4277 38.032991   556    Minetest Server: Split message 65504 chunk 17/19 (Unrel)
   4278 38.033014   480    Minetest Server: Split message 65504 chunk 18/19 (Unrel)
   4279 38.122617   556    Minetest Server: Split message 65522 chunk 0/2 (Seq=29)
   4280 38.122658   113    Minetest Server: Split message 65522 chunk 1/2 (Seq=30)
   4281 38.123098   55     Minetest Ack 29 (Unrel)
   4282 38.123124   55     Minetest Ack 30 (Unrel)
   4283 38.127377   135    Minetest Server: Unknown command (Seq=4)
   4284 38.127643   55     Minetest Ack 4 (Unrel)
   4285 38.127993   144    Minetest Server: Unknown command (Seq=5)
   4286 38.128208   55     Minetest Ack 5 (Unrel)
   4287 38.128511   61     Minetest Server: Unknown command (Seq=6)
   4288 38.128719   55     Minetest Ack 6 (Unrel)
   4289 38.256402   64     Minetest Client: GOTBLOCKS * 1 (Seq=4)
   4290 38.256655   55     Minetest Ack 4 (Unrel)
   4291 38.438722   556    Minetest Server: Split message 65524 chunk 0/2 (Seq=1327)
   4292 38.438764   314    Minetest Server: Split message 65524 chunk 1/2 (Seq=1328)
   4293 38.439142   55     Minetest Ack 1327 (Unrel)
   4294 38.439421   55     Minetest Ack 1328 (Unrel)
   4295 38.444300   556    Minetest Server: Split message 65525 chunk 0/3 (Seq=1329)
   4296 38.444340   556    Minetest Server: Split message 65525 chunk 1/3 (Seq=1330)
   4297 38.444371   349    Minetest Server: Split message 65525 chunk 2/3 (Seq=1331)
   4298 38.444422   556    Minetest Server: Split message 65504 chunk 0/20 (Unrel)
   4299 38.444446   556    Minetest Server: Split message 65504 chunk 1/20 (Unrel)
   4300 38.444469   556    Minetest Server: Split message 65504 chunk 2/20 (Unrel)
   4301 38.444492   556    Minetest Server: Split message 65504 chunk 3/20 (Unrel)
   4302 38.444520   556    Minetest Server: Split message 65504 chunk 4/20 (Unrel)
   4303 38.444687   556    Minetest Server: Split message 65504 chunk 5/20 (Unrel)
   4304 38.444712   556    Minetest Server: Split message 65504 chunk 6/20 (Unrel)
   4305 38.444735   556    Minetest Server: Split message 65504 chunk 7/20 (Unrel)
   4306 38.444758   556    Minetest Server: Split message 65504 chunk 8/20 (Unrel)
   4307 38.444781   556    Minetest Server: Split message 65504 chunk 9/20 (Unrel)
   4308 38.444804   556    Minetest Server: Split message 65504 chunk 10/20 (Unrel)
   4309 38.444827   556    Minetest Server: Split message 65504 chunk 11/20 (Unrel)
   4310 38.444850   556    Minetest Server: Split message 65504 chunk 12/20 (Unrel)
   4311 38.444872   556    Minetest Server: Split message 65504 chunk 13/20 (Unrel)
   4312 38.444895   556    Minetest Server: Split message 65504 chunk 14/20 (Unrel)
   4313 38.444918   556    Minetest Server: Split message 65504 chunk 15/20 (Unrel)
   4314 38.444940   556    Minetest Server: Split message 65504 chunk 16/20 (Unrel)
   4315 38.444963   556    Minetest Server: Split message 65504 chunk 17/20 (Unrel)
   4316 38.444985   556    Minetest Server: Split message 65504 chunk 18/20 (Unrel)
   4317 38.445009   186    Minetest Server: Split message 65504 chunk 19/20 (Unrel)
   4318 38.446746   55     Minetest Ack 1329 (Unrel)
   4319 38.446771   55     Minetest Ack 1330 (Unrel)
   4320 38.446793   55     Minetest Ack 1331 (Unrel)
   4321 38.447145   556    Minetest Server: Split message 65523 chunk 0/2 (Seq=31)
   4322 38.447176   178    Minetest Server: Split message 65523 chunk 1/2 (Seq=32)
   4323 38.447503   55     Minetest Ack 31 (Unrel)
   4324 38.447527   55     Minetest Ack 32 (Unrel)
   4325 38.568958   64     Minetest Client: GOTBLOCKS * 1 (Seq=5)
   4326 38.569262   55     Minetest Ack 5 (Unrel)
   4327 38.695139   311    Minetest Server: ACTIVE_OBJECT_REMOVE_ADD * 3 (Seq=1332)
   4328 38.695449   55     Minetest Ack 1332 (Unrel)
   4329 38.697917   556    Minetest Server: Split message 65504 chunk 0/19 (Unrel)
   4330 38.697947   556    Minetest Server: Split message 65504 chunk 1/19 (Unrel)
   4331 38.697971   556    Minetest Server: Split message 65504 chunk 2/19 (Unrel)
   4332 38.697995   556    Minetest Server: Split message 65504 chunk 3/19 (Unrel)
   4333 38.698284   556    Minetest Server: Split message 65504 chunk 4/19 (Unrel)
   4334 38.698315   556    Minetest Server: Split message 65504 chunk 5/19 (Unrel)
   4335 38.698339   556    Minetest Server: Split message 65504 chunk 6/19 (Unrel)
   4336 38.698362   556    Minetest Server: Split message 65504 chunk 7/19 (Unrel)
   4337 38.698387   556    Minetest Server: Split message 65504 chunk 8/19 (Unrel)
   4338 38.698418   556    Minetest Server: Split message 65504 chunk 9/19 (Unrel)
   4339 38.698448   556    Minetest Server: Split message 65504 chunk 10/19 (Unrel)
   4340 38.698477   556    Minetest Server: Split message 65504 chunk 11/19 (Unrel)
   4341 38.698506   556    Minetest Server: Split message 65504 chunk 12/19 (Unrel)
   4342 38.698533   556    Minetest Server: Split message 65504 chunk 13/19 (Unrel)
   4343 38.698592   556    Minetest Server: Split message 65504 chunk 14/19 (Unrel)
   4344 38.698616   556    Minetest Server: Split message 65504 chunk 15/19 (Unrel)
   4345 38.698639   556    Minetest Server: Split message 65504 chunk 16/19 (Unrel)
   4346 38.698665   556    Minetest Server: Split message 65504 chunk 17/19 (Unrel)
   4347 38.698693   123    Minetest Server: Split message 65504 chunk 18/19 (Unrel)
   4348 38.700803   130    Minetest Server: BLOCKDATA (Seq=33)
   4349 38.701042   55     Minetest Ack 33 (Unrel)
   4350 38.823107   64     Minetest Client: GOTBLOCKS * 1 (Seq=6)
   4351 38.823348   55     Minetest Ack 6 (Unrel)
   4352 38.955988   556    Minetest Server: Split message 65504 chunk 0/18 (Unrel)
   4353 38.956024   556    Minetest Server: Split message 65504 chunk 1/18 (Unrel)
   4354 38.956049   556    Minetest Server: Split message 65504 chunk 2/18 (Unrel)
   4355 38.956072   556    Minetest Server: Split message 65504 chunk 3/18 (Unrel)
   4356 38.956100   556    Minetest Server: Split message 65504 chunk 4/18 (Unrel)
   4357 38.956125   556    Minetest Server: Split message 65504 chunk 5/18 (Unrel)
   4358 38.956149   556    Minetest Server: Split message 65504 chunk 6/18 (Unrel)
   4359 38.956172   556    Minetest Server: Split message 65504 chunk 7/18 (Unrel)
   4360 38.956195   556    Minetest Server: Split message 65504 chunk 8/18 (Unrel)
   4361 38.956218   556    Minetest Server: Split message 65504 chunk 9/18 (Unrel)
   4362 38.956241   556    Minetest Server: Split message 65504 chunk 10/18 (Unrel)
   4363 38.956264   556    Minetest Server: Split message 65504 chunk 11/18 (Unrel)
   4364 38.956286   556    Minetest Server: Split message 65504 chunk 12/18 (Unrel)
   4365 38.956310   556    Minetest Server: Split message 65504 chunk 13/18 (Unrel)
   4366 38.956333   556    Minetest Server: Split message 65504 chunk 14/18 (Unrel)
   4367 38.956356   556    Minetest Server: Split message 65504 chunk 15/18 (Unrel)
   4368 38.956380   556    Minetest Server: Split message 65504 chunk 16/18 (Unrel)
   4369 38.956402   162    Minetest Server: Split message 65504 chunk 17/18 (Unrel)
   4370 39.156521   553    Minetest Server: ACTIVE_OBJECT_REMOVE_ADD * 2 (Seq=1333)
   4371 39.156792   55     Minetest Ack 1333 (Unrel)
   4372 39.158797   556    Minetest Server: Split message 65504 chunk 0/16 (Unrel)
   4373 39.158828   556    Minetest Server: Split message 65504 chunk 1/16 (Unrel)
   4374 39.158852   556    Minetest Server: Split message 65504 chunk 2/16 (Unrel)
   4375 39.158875   556    Minetest Server: Split message 65504 chunk 3/16 (Unrel)
   4376 39.158898   556    Minetest Server: Split message 65504 chunk 4/16 (Unrel)
   4377 39.158922   556    Minetest Server: Split message 65504 chunk 5/16 (Unrel)
   4378 39.158945   556    Minetest Server: Split message 65504 chunk 6/16 (Unrel)
   4379 39.158968   556    Minetest Server: Split message 65504 chunk 7/16 (Unrel)
   4380 39.159543   556    Minetest Server: Split message 65504 chunk 8/16 (Unrel)
   4381 39.159568   556    Minetest Server: Split message 65504 chunk 9/16 (Unrel)
   4382 39.159591   556    Minetest Server: Split message 65504 chunk 10/16 (Unrel)
   4383 39.159613   556    Minetest Server: Split message 65504 chunk 11/16 (Unrel)
   4384 39.159635   556    Minetest Server: Split message 65504 chunk 12/16 (Unrel)
   4385 39.159658   556    Minetest Server: Split message 65504 chunk 13/16 (Unrel)
   4386 39.159680   556    Minetest Server: Split message 65504 chunk 14/16 (Unrel)
   4387 39.159702   291    Minetest Server: Split message 65504 chunk 15/16 (Unrel)
   4388 39.997172   307    Minetest Server: ACTIVE_OBJECT_REMOVE_ADD * 1 (Seq=1334)
   4389 39.997455   55     Minetest Ack 1334 (Unrel)
   4390 40.001964   556    Minetest Server: Split message 65526 chunk 0/3 (Seq=1335)
   4391 40.002008   556    Minetest Server: Split message 65526 chunk 1/3 (Seq=1336)
   4392 40.002038   129    Minetest Server: Split message 65526 chunk 2/3 (Seq=1337)
   4393 40.002584   55     Minetest Ack 1335 (Unrel)
   4394 40.002611   55     Minetest Ack 1336 (Unrel)
   4395 40.002633   55     Minetest Ack 1337 (Unrel)
```