### PR TITLE
Increase network packet size to for IPv6 and for loopback

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -226,7 +226,7 @@ Client::Client(
 		tsrc, this, device
 	),
 	m_particle_manager(&m_env),
-	m_con(PROTOCOL_ID, 512, CONNECTION_TIMEOUT, ipv6, this),
+	m_con(PROTOCOL_ID, CONNECTION_TIMEOUT, ipv6, this),
 	m_device(device),
 	m_camera(NULL),
 	m_minimap_disabled_by_server(false),

--- a/src/constants.h
+++ b/src/constants.h
@@ -42,7 +42,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define INTERNET_SIMULATOR_PACKET_LOSS 10 // 10 = easy, 4 = hard
 
 // Max packet size that can be received.
-#define MAX_RECV_PACKET_SIZE 1500
+#define MAX_RECV_PACKET_SIZE 65536
 // Max packet-size to use for transmission
 // Theoretical maximum for UDP is 65507, but that may be too large
 // for the network stack.
@@ -56,6 +56,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // The minimum packet size that can always be transmitted without
 // fragmentation is 1280, including headers of at least 48 bytes.
 #define MAX_SEND_PACKET_SIZE_IPV6 1200
+// For local packets, use the same maximum for IPv4 and IPv6.
+// Not too close to the theoretical maximum.
+#define MAX_SEND_PACKET_SIZE_LOCAL 65000
 #define MAX_SEND_PACKET_SIZE_INITIAL MAX_SEND_PACKET_SIZE_IPV4
 
 #define CONNECTION_TIMEOUT 30

--- a/src/constants.h
+++ b/src/constants.h
@@ -48,8 +48,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // for the network stack.
 // The smallest value that must always be supported by the network
 // (IPv4) is 548 (576 - 28 for the UDP/IP headers)
-#define MAX_SEND_PACKET_SIZE 512
-#define MAX_SEND_PACKET_SIZE_INITIAL MAX_SEND_PACKET_SIZE
+#define MAX_SEND_PACKET_SIZE_IPV4 512
+// Theoretical maximum for UDP/IPv6: 65487, but the presence of
+// additional options in the header would lower that limit.
+// The smallest value that must always be supported for IPv6 is 1500
+// including headers. Such packets may end up being fragmented.
+// The minimum packet size that can always be transmitted without
+// fragmentation is 1280, including headers of at least 48 bytes.
+#define MAX_SEND_PACKET_SIZE_IPV6 1200
+#define MAX_SEND_PACKET_SIZE_INITIAL MAX_SEND_PACKET_SIZE_IPV4
 
 #define CONNECTION_TIMEOUT 30
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -41,6 +41,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define INTERNET_SIMULATOR 0
 #define INTERNET_SIMULATOR_PACKET_LOSS 10 // 10 = easy, 4 = hard
 
+// Max packet size that can be received.
+#define MAX_RECV_PACKET_SIZE 1500
+// Max packet-size to use for transmission
+// Theoretical maximum for UDP is 65507, but that may be too large
+// for the network stack.
+// The smallest value that must always be supported by the network
+// (IPv4) is 548 (576 - 28 for the UDP/IP headers)
+#define MAX_SEND_PACKET_SIZE 512
+#define MAX_SEND_PACKET_SIZE_INITIAL MAX_SEND_PACKET_SIZE
+
 #define CONNECTION_TIMEOUT 30
 
 #define RESEND_TIMEOUT_MIN 0.1

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -72,6 +72,13 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 	m_server_ser_ver = serialization_ver;
 	m_proto_ver = proto_ver;
 
+	// Protocol version 29 and up can receive larger packet sizes
+	if (proto_ver >= 29) {
+		Address address = m_con.GetPeerAddress(pkt->getPeerId());
+		if (!INTERNET_SIMULATOR && address.isLoopback())
+			m_con.setMaxPacketSize(pkt->getPeerId(), MAX_SEND_PACKET_SIZE_LOCAL);
+	}
+
 	//TODO verify that username_legacy matches sent username, only
 	// differs in casing (make both uppercase and compare)
 	// This is only neccessary though when we actually want to add casing support

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1072,8 +1072,7 @@ bool UDPPeer::Ping(float dtime,SharedBuffer<u8>& data)
 	return false;
 }
 
-void UDPPeer::PutReliableSendCommand(ConnectionCommand &c,
-		unsigned int max_packet_size)
+void UDPPeer::PutReliableSendCommand(ConnectionCommand &c)
 {
 	if (m_pending_disconnect)
 		return;
@@ -1085,7 +1084,7 @@ void UDPPeer::PutReliableSendCommand(ConnectionCommand &c,
 		LOG(dout_con<<m_connection->getDesc()
 				<<" processing reliable command for peer id: " << c.peer_id
 				<<" data size: " << c.data.getSize() << std::endl);
-		if (!processReliableSendCommand(c,max_packet_size)) {
+		if (!processReliableSendCommand(c)) {
 			channels[c.channelnum].queued_commands.push_back(c);
 		}
 	}
@@ -1097,16 +1096,14 @@ void UDPPeer::PutReliableSendCommand(ConnectionCommand &c,
 	}
 }
 
-bool UDPPeer::processReliableSendCommand(
-				ConnectionCommand &c,
-				unsigned int max_packet_size)
+bool UDPPeer::processReliableSendCommand(ConnectionCommand &c)
 {
 	if (m_pending_disconnect)
 		return true;
 
-	u32 chunksize_max = max_packet_size
-							- BASE_HEADER_SIZE
-							- RELIABLE_HEADER_SIZE;
+	u32 chunksize_max = getMaxPacketSize()
+			    - BASE_HEADER_SIZE
+			    - RELIABLE_HEADER_SIZE;
 
 	sanity_check(c.data.getSize() < MAX_RELIABLE_WINDOW_SIZE*512);
 
@@ -1199,10 +1196,8 @@ bool UDPPeer::processReliableSendCommand(
 	}
 }
 
-void UDPPeer::RunCommandQueues(
-							unsigned int max_packet_size,
-							unsigned int maxcommands,
-							unsigned int maxtransfer)
+void UDPPeer::RunCommandQueues(unsigned int maxcommands,
+				unsigned int maxtransfer)
 {
 
 	for (unsigned int i = 0; i < CHANNEL_COUNT; i++) {
@@ -1218,7 +1213,7 @@ void UDPPeer::RunCommandQueues(
 						<< " processing queued reliable command " << std::endl);
 
 				// Packet is processed, remove it from queue
-				if (processReliableSendCommand(c,max_packet_size)) {
+				if (processReliableSendCommand(c)) {
 					channels[i].queued_commands.pop_front();
 				} else {
 					LOG(dout_con << m_connection->getDesc()
@@ -1258,11 +1253,9 @@ SharedBuffer<u8> UDPPeer::addSpiltPacket(u8 channel,
 /* Connection Threads                                                         */
 /******************************************************************************/
 
-ConnectionSendThread::ConnectionSendThread(unsigned int max_packet_size,
-		float timeout) :
+ConnectionSendThread::ConnectionSendThread(float timeout) :
 	Thread("ConnectionSend"),
 	m_connection(NULL),
-	m_max_packet_size(max_packet_size),
 	m_timeout(timeout),
 	m_max_commands_per_iteration(1),
 	m_max_data_packets_per_iteration(g_settings->getU16("max_packets_per_iteration")),
@@ -1488,8 +1481,7 @@ void ConnectionSendThread::runTimeouts(float dtime)
 			}
 		}
 
-		dynamic_cast<UDPPeer*>(&peer)->RunCommandQueues(m_max_packet_size,
-								m_max_commands_per_iteration,
+		dynamic_cast<UDPPeer*>(&peer)->RunCommandQueues(m_max_commands_per_iteration,
 								m_max_packets_requeued);
 	}
 
@@ -1661,6 +1653,7 @@ void ConnectionSendThread::processReliableCommand(ConnectionCommand &c)
 	case CONNCMD_CONNECT:
 	case CONNCMD_DISCONNECT:
 	case CONCMD_ACK:
+	case CONCMD_SET_MAX_PACKET_SIZE:
 		FATAL_ERROR("Got command that shouldn't be reliable as reliable command");
 	default:
 		LOG(dout_con<<m_connection->getDesc()
@@ -1713,6 +1706,12 @@ void ConnectionSendThread::processNonReliableCommand(ConnectionCommand &c)
 		LOG(dout_con<<m_connection->getDesc()
 				<<" UDP processing CONCMD_ACK"<<std::endl);
 		sendAsPacket(c.peer_id,c.channelnum,c.data,true);
+		return;
+	case CONCMD_SET_MAX_PACKET_SIZE:
+		LOG(dout_con << m_connection->getDesc()
+				<< " UDP processing CONCMD_SET_MAX_PACKET_SIZE: "
+				<< c.param << std::endl);
+		m_connection->setMaxPacketSizeCommand(c.peer_id, c.param);
 		return;
 	case CONCMD_CREATE_PEER:
 		FATAL_ERROR("Got command that should be reliable as unreliable command");
@@ -1830,7 +1829,7 @@ void ConnectionSendThread::send(u16 peer_id, u8 channelnum,
 
 	u16 split_sequence_number = peer->getNextSplitSequenceNumber(channelnum);
 
-	u32 chunksize_max = m_max_packet_size - BASE_HEADER_SIZE;
+	u32 chunksize_max = peer->getMaxPacketSize() - BASE_HEADER_SIZE;
 	std::list<SharedBuffer<u8> > originals;
 
 	originals = makeAutoSplitPacket(data, chunksize_max,split_sequence_number);
@@ -1851,7 +1850,7 @@ void ConnectionSendThread::sendReliable(ConnectionCommand &c)
 	if (!peer)
 		return;
 
-	peer->PutReliableSendCommand(c,m_max_packet_size);
+	peer->PutReliableSendCommand(c);
 }
 
 void ConnectionSendThread::sendToAll(u8 channelnum, SharedBuffer<u8> data)
@@ -1879,7 +1878,7 @@ void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 		if (!peer)
 			continue;
 
-		peer->PutReliableSendCommand(c,m_max_packet_size);
+		peer->PutReliableSendCommand(c);
 	}
 }
 
@@ -2030,7 +2029,7 @@ void ConnectionSendThread::sendAsPacket(u16 peer_id, u8 channelnum,
 	m_outgoing_queue.push(packet);
 }
 
-ConnectionReceiveThread::ConnectionReceiveThread(unsigned int max_packet_size) :
+ConnectionReceiveThread::ConnectionReceiveThread() :
 	Thread("ConnectionReceive"),
 	m_connection(NULL)
 {
@@ -2127,10 +2126,7 @@ void * ConnectionReceiveThread::run()
 // Receive packets from the network and buffers and create ConnectionEvents
 void ConnectionReceiveThread::receive()
 {
-	// use IPv6 minimum allowed MTU as receive buffer size as this is
-	// theoretical reliable upper boundary of a udp packet for all IPv6 enabled
-	// infrastructure
-	unsigned int packet_maxsize = 1500;
+	unsigned int packet_maxsize = MAX_RECV_PACKET_SIZE;
 	SharedBuffer<u8> packetdata(packet_maxsize);
 
 	bool packet_queued = true;
@@ -2673,15 +2669,15 @@ SharedBuffer<u8> ConnectionReceiveThread::processPacket(Channel *channel,
 	Connection
 */
 
-Connection::Connection(u32 protocol_id, u32 max_packet_size, float timeout,
+Connection::Connection(u32 protocol_id, float timeout,
 		bool ipv6, PeerHandler *peerhandler) :
 	m_udpSocket(ipv6),
 	m_command_queue(),
 	m_event_queue(),
 	m_peer_id(0),
 	m_protocol_id(protocol_id),
-	m_sendThread(max_packet_size, timeout),
-	m_receiveThread(max_packet_size),
+	m_sendThread(timeout),
+	m_receiveThread(),
 	m_info_mutex(),
 	m_bc_peerhandler(peerhandler),
 	m_bc_receive_timeout(0),
@@ -3107,6 +3103,20 @@ UDPPeer* Connection::createServerPeer(Address& address)
 	}
 
 	return peer;
+}
+
+void Connection::setMaxPacketSize(u16 peer_id, u32 max_packet_size)
+{
+	ConnectionCommand c;
+	c.setMaxPacketSize(peer_id, max_packet_size);
+	putCommand(c);
+}
+
+void Connection::setMaxPacketSizeCommand(u16 peer_id, u32 max_packet_size)
+{
+	PeerHelper peer = getPeerNoEx(peer_id);
+	if (!peer) return;
+	peer->setMaxPacketSize(max_packet_size);
 }
 
 } // namespace

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -1019,6 +1019,10 @@ UDPPeer::UDPPeer(u16 a_id, Address a_address, Connection* connection) :
 	resend_timeout(0.5),
 	m_legacy_peer(true)
 {
+	if (a_address.isIPv6() && !a_address.isIPv4MappedIPv6())
+		setMaxPacketSize(MAX_SEND_PACKET_SIZE_IPV6);
+	else
+		setMaxPacketSize(MAX_SEND_PACKET_SIZE_IPV4);
 }
 
 bool UDPPeer::getAddress(MTProtocols type,Address& toset)

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -138,9 +138,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add nodedef v3 - connected nodeboxes
 	PROTOCOL_VERSION 28:
 		CPT2_MESHOPTIONS
+	PROTOCOL_VERSION 29:
+		Increase max receivable packet size to 65536 (was 1500).
 */
 
-#define LATEST_PROTOCOL_VERSION 28
+#define LATEST_PROTOCOL_VERSION 29
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 13

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -159,6 +159,13 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 		}
 	}
 
+	// Protocol version 29 and up can receive larger packet sizes
+	if (net_proto_version >= 29) {
+		Address address = m_con.GetPeerAddress(pkt->getPeerId());
+		if (!INTERNET_SIMULATOR && address.isLoopback())
+			m_con.setMaxPacketSize(pkt->getPeerId(), MAX_SEND_PACKET_SIZE_LOCAL);
+	}
+
 	/*
 		Validate player name
 	*/

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -157,7 +157,6 @@ Server::Server(
 	m_async_fatal_error(""),
 	m_env(NULL),
 	m_con(PROTOCOL_ID,
-			512,
 			CONNECTION_TIMEOUT,
 			ipv6,
 			this),

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -255,6 +255,17 @@ int Address::getFamily() const
 	return m_addr_family;
 }
 
+bool Address::isIPv4MappedIPv6() const
+{
+	static const in6_addr ipv4_mapped_prefix = {{
+		   0,    0,    0,    0,
+		   0,    0,    0,    0,
+		   0,    0, 0xff, 0xff,
+		   0,    0,    0,    0
+	}};
+	return 0 == memcmp(m_address.ipv6.sin6_addr.s6_addr, ipv4_mapped_prefix.s6_addr, 12);
+}
+
 bool Address::isIPv6() const
 {
 	return m_addr_family == AF_INET6;

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -283,6 +283,24 @@ bool Address::isZero() const
 	return false;
 }
 
+bool Address::isLoopback() const
+{
+	if (isIPv6() && isIPv4MappedIPv6()) {
+		static const in6_addr ipv4_mapped_loopback = {{
+			   0,    0,    0,    0,
+			   0,    0,    0,    0,
+			   0,    0, 0xff, 0xff,
+			0x7f,    0,    0,    0
+		}};
+		return 0 == memcmp(m_address.ipv6.sin6_addr.s6_addr, ipv4_mapped_loopback.s6_addr, 13);
+	} else if (isIPv6()) {
+		return 0 == memcmp(m_address.ipv6.sin6_addr.s6_addr, in6addr_loopback.s6_addr, 16);
+	} else {
+		u32 addr = ntohl(m_address.ipv4.sin_addr.s_addr);
+		return (addr & 0xff000000) == 0x7f000000;
+	}
+}
+
 void Address::setAddress(u32 address)
 {
 	m_addr_family = AF_INET;

--- a/src/socket.h
+++ b/src/socket.h
@@ -98,6 +98,7 @@ public:
 	struct sockaddr_in6 getAddress6() const;
 	int getFamily() const;
 	bool isIPv6() const;
+	bool isIPv4MappedIPv6() const;
 	bool isZero() const;
 	void setPort(unsigned short port);
 	void print(std::ostream *s) const;

--- a/src/socket.h
+++ b/src/socket.h
@@ -100,6 +100,7 @@ public:
 	bool isIPv6() const;
 	bool isIPv4MappedIPv6() const;
 	bool isZero() const;
+	bool isLoopback() const;
 	void setPort(unsigned short port);
 	void print(std::ostream *s) const;
 	std::string serializeString() const;

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -157,11 +157,11 @@ void TestConnection::testConnectSendReceive()
 	}
 
 	infostream << "** Creating server Connection" << std::endl;
-	con::Connection server(proto_id, 512, 5.0, false, &hand_server);
+	con::Connection server(proto_id, 5.0, false, &hand_server);
 	server.Serve(address);
 
 	infostream << "** Creating client Connection" << std::endl;
-	con::Connection client(proto_id, 512, 5.0, false, &hand_client);
+	con::Connection client(proto_id, 5.0, false, &hand_client);
 
 	UASSERT(hand_server.count == 0);
 	UASSERT(hand_client.count == 0);


### PR DESCRIPTION
Edit: These patches now change the network packet size for IPv6 and loopback only.
They may be increased for other cases as well, but it remains to be seen how that
can best be done.

------------------------------------------------------------------------

A size of 512 is way too small for normal operation, and will make
inefficient use of CPU, network bandwidth and network processing power.

The value of 4000 significantly reduces the overhead, makes one UDP packet
fit in 3 ethernet packets even if the MTU is a bit less than 1500, and it
is not too large, so that the impact of packet loss is still limited.

For peers that don't support protocol v29, the maximum supported packet
size is 1500, so the chosen maximum is set a bit lower in case
some kind of encapsulation is used.

I tested all combinations of old & new client and server, and they
work fine.