### PR TITLE
Fix sqlite databases being read-only on 64bit Android by patching sqlite

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -665,7 +665,9 @@ deps/${SQLITE3_FOLDER}/sqlite3.c :
 	cd deps;                                                                    \
 	wget ${SQLITE3_URL};                                                        \
 	unzip ${SQLITE3_FOLDER}.zip;                                                \
-	ln -s ${SQLITE3_FOLDER} sqlite
+	ln -s ${SQLITE3_FOLDER} sqlite;                                             \
+	cd ${SQLITE3_FOLDER};                                                       \
+	patch sqlite3.c < ${ANDR_ROOT}/patches/sqlite3-readonly-fix.patch
 
 clean_sqlite3:
 	cd deps && $(RM) -rf ${SQLITE3_FOLDER} && $(RM) -f ${SQLITE3_FOLDER}.zip && \
@@ -831,4 +833,3 @@ $(ANDR_ROOT)/jni/src/android_version.h : prep_srcdir
 	fi
 
 clean : clean_apk clean_assets
-

--- a/build/android/patches/sqlite3-readonly-fix.patch
+++ b/build/android/patches/sqlite3-readonly-fix.patch
@@ -1,0 +1,17 @@
+--- sqlite3.c	2016-11-29 02:29:24.000000000 +0000
++++ sqlite3.c	2016-12-08 22:54:54.206465377 +0000
+@@ -30445,7 +30445,14 @@
+ #if OS_VXWORKS
+   struct vxworksFileId *pId;  /* Unique file ID for vxworks. */
+ #else
+-  ino_t ino;                  /* Inode number */
++  #ifdef ANDROID
++    // Bionic's struct stat has a 64 bit st_ino on both 32 and
++    // 64 bit architectures. ino_t remains 32 bits wide on 32 bit
++    // architectures and can lead to inode truncation.
++    unsigned long long ino;     /* Inode number */
++  #else
++    ino_t ino;     /* Inode number */
++  #endif
+ #endif
+ };


### PR DESCRIPTION
On 64bit Android, the length of the ono datatype is not long enough to hold the unixFileId inodes, causing the database to be opened in readonly mode.

This [backports a patch from Android's sqlite](https://android-review.googlesource.com/#/c/115351/) to our sqlite

Fixes #4121