### PR TITLE
Limit Active Block Range to what player can see. Retrieve a spherical volume.

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -405,8 +405,8 @@ void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 	}
 }
 
-void ActiveBlockList::update(std::vector<v3s16> &active_positions,
-		std::vector<s16> &ranges,
+void ActiveBlockList::update(const std::vector<v3s16> &active_positions,
+		const std::vector<s16> &ranges,
 		std::set<v3s16> &blocks_removed,
 		std::set<v3s16> &blocks_added)
 {
@@ -414,8 +414,8 @@ void ActiveBlockList::update(std::vector<v3s16> &active_positions,
 		Create the new list
 	*/
 	std::set<v3s16> newlist = m_forceloaded_list;
-	std::vector<s16>::iterator j = ranges.begin();
-	for(std::vector<v3s16>::iterator i = active_positions.begin();
+	std::vector<s16>::const_iterator j = ranges.begin();
+	for(std::vector<v3s16>::const_iterator i = active_positions.begin();
 	    i != active_positions.end(); ++i, ++j)
 	{
 		fillRadiusBlock(*i, *j, newlist);
@@ -1274,7 +1274,8 @@ void ServerEnvironment::step(float dtime)
 		*/
 		std::vector<v3s16> players_blockpos;
 		std::vector<s16> players_range;
-		static const s16 active_block_range = g_settings->getS16("active_block_range");
+		const s16 active_block_range = g_settings->getS16("active_block_range");
+
 		for (std::vector<RemotePlayer *>::iterator i = m_players.begin();
 				i != m_players.end(); ++i) {
 			RemotePlayer *player = dynamic_cast<RemotePlayer *>(*i);
@@ -1291,7 +1292,8 @@ void ServerEnvironment::step(float dtime)
 					floatToInt(playersao->getBasePosition(), BS));
 			players_blockpos.push_back(blockpos);
 			s16 range = MYMIN(playersao->getWantedRange(), active_block_range);
-			if (range <= 0) range = active_block_range;
+			if (range <= 0)
+				range = active_block_range;
 			players_range.push_back(range);
 		}
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -397,13 +397,16 @@ void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 	for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
 	for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
 	{
-		// Set in list
-		list.insert(p);
+		// limit to a sphere
+		if ((p-p0).getLength() <= r) {
+			// Set in list
+			list.insert(p);
+		}
 	}
 }
 
 void ActiveBlockList::update(std::vector<v3s16> &active_positions,
-		s16 radius,
+		std::vector<s16> &ranges,
 		std::set<v3s16> &blocks_removed,
 		std::set<v3s16> &blocks_added)
 {
@@ -411,10 +414,11 @@ void ActiveBlockList::update(std::vector<v3s16> &active_positions,
 		Create the new list
 	*/
 	std::set<v3s16> newlist = m_forceloaded_list;
+	std::vector<s16>::iterator j = ranges.begin();
 	for(std::vector<v3s16>::iterator i = active_positions.begin();
-			i != active_positions.end(); ++i)
+	    i != active_positions.end(); ++i, ++j)
 	{
-		fillRadiusBlock(*i, radius, newlist);
+		fillRadiusBlock(*i, *j, newlist);
 	}
 
 	/*
@@ -1269,6 +1273,8 @@ void ServerEnvironment::step(float dtime)
 			Get player block positions
 		*/
 		std::vector<v3s16> players_blockpos;
+		std::vector<s16> players_range;
+		static const s16 active_block_range = g_settings->getS16("active_block_range");
 		for (std::vector<RemotePlayer *>::iterator i = m_players.begin();
 				i != m_players.end(); ++i) {
 			RemotePlayer *player = dynamic_cast<RemotePlayer *>(*i);
@@ -1284,15 +1290,17 @@ void ServerEnvironment::step(float dtime)
 			v3s16 blockpos = getNodeBlockPos(
 					floatToInt(playersao->getBasePosition(), BS));
 			players_blockpos.push_back(blockpos);
+			s16 range = MYMIN(playersao->getWantedRange(), active_block_range);
+			if (range <= 0) range = active_block_range;
+			players_range.push_back(range);
 		}
 
 		/*
 			Update list of active blocks, collecting changes
 		*/
-		static const s16 active_block_range = g_settings->getS16("active_block_range");
 		std::set<v3s16> blocks_removed;
 		std::set<v3s16> blocks_added;
-		m_active_blocks.update(players_blockpos, active_block_range,
+		m_active_blocks.update(players_blockpos, players_range,
 				blocks_removed, blocks_added);
 
 		/*

--- a/src/environment.h
+++ b/src/environment.h
@@ -251,8 +251,8 @@ private:
 class ActiveBlockList
 {
 public:
-	void update(std::vector<v3s16> &active_positions,
-			std::vector<s16> &ranges,
+	void update(const std::vector<v3s16> &active_positions,
+			const std::vector<s16> &ranges,
 			std::set<v3s16> &blocks_removed,
 			std::set<v3s16> &blocks_added);
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -252,7 +252,7 @@ class ActiveBlockList
 {
 public:
 	void update(std::vector<v3s16> &active_positions,
-			s16 radius,
+			std::vector<s16> &ranges,
 			std::set<v3s16> &blocks_removed,
 			std::set<v3s16> &blocks_added);
 


### PR DESCRIPTION
I changed my mind on this one. We should also limit the active_block_range to what a player can see. That way it is possible to increase this on a server a bit and get a better active block and active object experience.
The default of 2 is very limiting. You're just barely 40 blocks away and active objects vanish and active blocks are no longer active.

@paramat Had a comment on this in #4811 , but it turns out that active_block_range also determines the radius in which active _objects_ operate (not just blocks), so in order to take full advantage of #4811 you'd want to increase `active_block_range` as well. And in that case you'd wanna limit that by the client can see... and definitely do a sphere only (or you get different ranges based on whether an object/block is in the corner of a cube or on the flat side).

In any case. Have a look. As expected with larger values for active_block_range, this has big implications.