### PR TITLE
Process ABMs in a spherical volume instead of a cuboid

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -759,7 +759,7 @@ active_object_send_range_blocks (Active object send range) int 3
 
 #    How large area of blocks are subject to the active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
-active_block_range (Active block range) int 3
+active_block_range (Active block range) int 2
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
 max_block_send_distance (Max block send distance) int 10

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -759,7 +759,7 @@ active_object_send_range_blocks (Active object send range) int 3
 
 #    How large area of blocks are subject to the active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
-active_block_range (Active block range) int 2
+active_block_range (Active block range) int 3
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
 max_block_send_distance (Max block send distance) int 10

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -914,7 +914,7 @@
 #    How large area of blocks are subject to the active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
 #    type: int
-# active_block_range = 2
+# active_block_range = 3
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
 #    type: int

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -914,7 +914,7 @@
 #    How large area of blocks are subject to the active block stuff, stated in mapblocks (16 nodes).
 #    In active blocks objects are loaded and ABMs run.
 #    type: int
-# active_block_range = 3
+# active_block_range = 2
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
 #    type: int

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -273,7 +273,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("profiler_print_interval", "0");
 	settings->setDefault("enable_mapgen_debug_info", "false");
 	settings->setDefault("active_object_send_range_blocks", "3");
-	settings->setDefault("active_block_range", "2");
+	settings->setDefault("active_block_range", "3");
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -273,7 +273,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("profiler_print_interval", "0");
 	settings->setDefault("enable_mapgen_debug_info", "false");
 	settings->setDefault("active_object_send_range_blocks", "3");
-	settings->setDefault("active_block_range", "3");
+	settings->setDefault("active_block_range", "2");
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1272,7 +1272,6 @@ void ServerEnvironment::step(float dtime)
 			Get player block positions
 		*/
 		std::vector<v3s16> players_blockpos;
-
 		for (std::vector<RemotePlayer *>::iterator i = m_players.begin();
 				i != m_players.end(); ++i) {
 			RemotePlayer *player = dynamic_cast<RemotePlayer *>(*i);
@@ -1293,7 +1292,7 @@ void ServerEnvironment::step(float dtime)
 		/*
 			Update list of active blocks, collecting changes
 		*/
-		const s16 active_block_range = g_settings->getS16("active_block_range");
+		static const s16 active_block_range = g_settings->getS16("active_block_range");
 		std::set<v3s16> blocks_removed;
 		std::set<v3s16> blocks_added;
 		m_active_blocks.update(players_blockpos, active_block_range,

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -397,8 +397,11 @@ void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 	for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
 	for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
 	{
-		// Set in list
-		list.insert(p);
+		// limit to a sphere
+		if (p.getDistanceFrom(p0) <= r) {
+			// Set in list
+			list.insert(p);
+		}
 	}
 }
 
@@ -1269,6 +1272,7 @@ void ServerEnvironment::step(float dtime)
 			Get player block positions
 		*/
 		std::vector<v3s16> players_blockpos;
+
 		for (std::vector<RemotePlayer *>::iterator i = m_players.begin();
 				i != m_players.end(); ++i) {
 			RemotePlayer *player = dynamic_cast<RemotePlayer *>(*i);
@@ -1289,7 +1293,7 @@ void ServerEnvironment::step(float dtime)
 		/*
 			Update list of active blocks, collecting changes
 		*/
-		static const s16 active_block_range = g_settings->getS16("active_block_range");
+		const s16 active_block_range = g_settings->getS16("active_block_range");
 		std::set<v3s16> blocks_removed;
 		std::set<v3s16> blocks_added;
 		m_active_blocks.update(players_blockpos, active_block_range,


### PR DESCRIPTION
1. Process ABMs in a spherical volume
2. Increase active_block_range default to 3 a map block radius

A 5x5x5 cube (range = 2) has 125 map blocks. The corresponding sphere 93 (I measured the actual blocks).
A 7x7x7 cube (range = 3) has 343 map block. The sphere has 251.

So for just 2x the active block processing we can increase the default active_block_range to 3 - as a cuboid it'd cause almost 3x the processing.

Makes for a better experience.