### PR TITLE
Set maximum viewing range to 4000

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -418,8 +418,7 @@ fps_max (Maximum FPS) int 60
 pause_fps_max (FPS in pause menu) int 20
 
 #    View distance in nodes.
-#    Min = 20
-viewing_range (Viewing range) int 100
+viewing_range (Viewing range) int 100 20 4000
 
 #    Width component of the initial window size.
 screenW (Screen width) int 800

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -473,8 +473,7 @@
 # pause_fps_max = 20
 
 #    View distance in nodes.
-#    Min = 20
-#    type: int
+#    type: int min: 20 max: 4000
 # viewing_range = 100
 
 #    Width component of the initial window size.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -940,7 +940,8 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	u32 keyPressed   = myplayer->keyPressed;
 	// scaled by 80, so that pi can fit into a u8
 	u8 fov           = clientMap->getCameraFov() * 80;
-	u8 wanted_range  = std::ceil(clientMap->getControl().wanted_range / MAP_BLOCKSIZE);
+	u8 wanted_range  = MYMIN(255,
+			std::ceil(clientMap->getControl().wanted_range / MAP_BLOCKSIZE));
 
 	v3s32 position(pf.X, pf.Y, pf.Z);
 	v3s32 speed(sf.X, sf.Y, sf.Z);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3277,9 +3277,16 @@ void Game::increaseViewRange(float *statustext_time)
 {
 	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range + 10;
+
+	if (range_new > 4000) {
+		range_new = 4000;
+		statustext = utf8_to_wide("Viewing range is at maximum: "
+				+ itos(range_new));
+	} else {
+		statustext = utf8_to_wide("Viewing range changed to "
+				+ itos(range_new));
+	}
 	g_settings->set("viewing_range", itos(range_new));
-	statustext = utf8_to_wide("Viewing range changed to "
-			+ itos(range_new));
 	*statustext_time = 0;
 }
 
@@ -3289,12 +3296,15 @@ void Game::decreaseViewRange(float *statustext_time)
 	s16 range = g_settings->getS16("viewing_range");
 	s16 range_new = range - 10;
 
-	if (range_new < 20)
+	if (range_new < 20) {
 		range_new = 20;
-
+		statustext = utf8_to_wide("Viewing range is at minimum: "
+				+ itos(range_new));
+	} else {
+		statustext = utf8_to_wide("Viewing range changed to "
+				+ itos(range_new));
+	}
 	g_settings->set("viewing_range", itos(range_new));
-	statustext = utf8_to_wide("Viewing range changed to "
-			+ itos(range_new));
 	*statustext_time = 0;
 }
 


### PR DESCRIPTION
Edit: changed PR: limit viewing range to 4000 max, as that is about the maximum the network protocol supports.

------------------------------------------------------------------------

Using u8 will cause the wanted_range to wrap around if the player
selects a viewing range of 4096 or higher.

I realize this change makes yesterday's clients incompatible with
today's servers, and vice versa. However, people using development
versions might be expected to experience breakage now and then ?

This change is based on PR #4882.