### PR TITLE
Handle multiple deserialization of a block's entities

### DIFF
--- a/src/staticobject.cpp
+++ b/src/staticobject.cpp
@@ -75,6 +75,15 @@ void StaticObjectList::serialize(std::ostream &os)
 }
 void StaticObjectList::deSerialize(std::istream &is)
 {
+	if (m_active.size()) {
+		errorstream << "StaticObjectList::deSerialize(): "
+			<< "deserializing objects while " << m_active.size()
+			<< " active objects already exist (not cleared). "
+			<< m_stored.size() << " stored objects _were_ cleared"
+			<< std::endl;
+	}
+	m_stored.clear();
+
 	// version
 	u8 version = readU8(is);
 	// count


### PR DESCRIPTION
This fix consists of two parts:
- Clear the list of stored entities. This has no side-effects.
- Catch the case where active entities exist and print a message.
  Clearing the active entitiy list has side-effects that should
  be handled. (those entities are known to the environment and
  to clients).

  As avoiding those side-effects is more complex, and as this
  problem is not expected to occur (with PR #4847 merged), there
  is no real incentive to implement this ATM.

This issue was a contributing factor to bug #4217. With the other
contributing factor removed (PR #4847), this commit makes sure this
factor does not go unnoticed if it ever happens again.

See also comment https://github.com/minetest/minetest/pull/4847#issuecomment-266241393

(This PR should be merged after PR #4847 has been merged!)