### PR TITLE
Fix camera jumping on Android when panning past 0/360 mark

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1205,7 +1205,7 @@ static inline void create_formspec_menu(GUIFormSpecMenu **cur_formspec,
 		(*cur_formspec)->setFormSource(fs_src);
 		(*cur_formspec)->setTextDest(txt_dest);
 	}
-	
+
 }
 
 #ifdef __ANDROID__
@@ -3362,8 +3362,8 @@ void Game::updateCameraOrientation(CameraOrientation *cam,
 {
 #ifdef HAVE_TOUCHSCREENGUI
 	if (g_touchscreengui) {
-		cam->camera_yaw   = g_touchscreengui->getYaw();
-		cam->camera_pitch = g_touchscreengui->getPitch();
+		cam->camera_yaw   += g_touchscreengui->getYawChange();
+		cam->camera_pitch  = g_touchscreengui->getPitch();
 	} else {
 #endif
 

--- a/src/touchscreengui.cpp
+++ b/src/touchscreengui.cpp
@@ -414,7 +414,7 @@ void AutoHideButtonBar::show()
 TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver* receiver):
 	m_device(device),
 	m_guienv(device->getGUIEnvironment()),
-	m_camera_yaw(0.0),
+	m_camera_yaw_change(0.0),
 	m_camera_pitch(0.0),
 	m_visible(false),
 	m_move_id(-1),
@@ -835,17 +835,11 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 
 					/* adapt to similar behaviour as pc screen */
 					double d         = g_settings->getFloat("mouse_sensitivity") *4;
-					double old_yaw   = m_camera_yaw;
+					double old_yaw   = m_camera_yaw_change;
 					double old_pitch = m_camera_pitch;
 
-					m_camera_yaw   -= dx * d;
-					m_camera_pitch  = MYMIN(MYMAX( m_camera_pitch + (dy * d),-180),180);
-
-					while (m_camera_yaw < 0)
-						m_camera_yaw += 360;
-
-					while (m_camera_yaw > 360)
-						m_camera_yaw -= 360;
+					m_camera_yaw_change -= dx * d;
+					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dy * d), -180), 180);
 
 					// update shootline
 					m_shootline = m_device

--- a/src/touchscreengui.h
+++ b/src/touchscreengui.h
@@ -147,8 +147,14 @@ public:
 
 	void init(ISimpleTextureSource* tsrc);
 
-	double getYaw() { return m_camera_yaw; }
+	double getYawChange() {
+		double res = m_camera_yaw_change;
+		m_camera_yaw_change = 0;
+		return res;
+	}
+
 	double getPitch() { return m_camera_pitch; }
+
 	line3d<f32> getShootline() { return m_shootline; }
 
 	void step(float dtime);
@@ -170,7 +176,7 @@ private:
 	bool                    m_visible; // is the gui visible
 
 	/* value in degree */
-	double                  m_camera_yaw;
+	double                  m_camera_yaw_change;
 	double                  m_camera_pitch;
 
 	line3d<f32>             m_shootline;


### PR DESCRIPTION
Fixes #2599 

Note that it's fine not to limit yaw to 0-360, as the main desktop version doesn't either