### PR TITLE
Use std::vector instead of std::map in class ABMHandler

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -762,7 +762,7 @@ class ABMHandler
 {
 private:
 	ServerEnvironment *m_env;
-	std::map<content_t, std::vector<ActiveABM> > m_aabms;
+	std::vector<std::vector<ActiveABM> *> m_aabms;
 public:
 	ABMHandler(std::vector<ABMWithState> &abms,
 			float dtime_s, ServerEnvironment *env,
@@ -821,18 +821,22 @@ public:
 						k != ids.end(); ++k)
 				{
 					content_t c = *k;
-					std::map<content_t, std::vector<ActiveABM> >::iterator j;
-					j = m_aabms.find(c);
-					if(j == m_aabms.end()){
-						std::vector<ActiveABM> aabmlist;
-						m_aabms[c] = aabmlist;
-						j = m_aabms.find(c);
-					}
-					j->second.push_back(aabm);
+					if (c >= m_aabms.size())
+						m_aabms.resize(c + 256, (std::vector<ActiveABM> *) NULL);
+					if (!m_aabms[c])
+						m_aabms[c] = new std::vector<ActiveABM>;
+					m_aabms[c]->push_back(aabm);
 				}
 			}
 		}
 	}
+
+	~ABMHandler()
+	{
+		for (size_t i = 0; i < m_aabms.size(); i++)
+			delete m_aabms[i];
+	}
+
 	// Find out how many objects the given block and its neighbours contain.
 	// Returns the number of objects in the block, and also in 'wider' the
 	// number of objects in the block and all its neighbours. The latter
@@ -881,13 +885,11 @@ public:
 			content_t c = n.getContent();
 			v3s16 p = p0 + block->getPosRelative();
 
-			std::map<content_t, std::vector<ActiveABM> >::iterator j;
-			j = m_aabms.find(c);
-			if(j == m_aabms.end())
+			if (!m_aabms[c])
 				continue;
 
 			for(std::vector<ActiveABM>::iterator
-					i = j->second.begin(); i != j->second.end(); ++i) {
+					i = m_aabms[c]->begin(); i != m_aabms[c]->end(); ++i) {
 				if(myrand() % i->chance != 0)
 					continue;
 


### PR DESCRIPTION
This improves performance *significantly*.

Using a minimal subgame, doing nothing, 75% of server time was spent
processing ABMs, while 57% of that time was spent in std::map::find().

With this patch, ABM processing time goes to 45%, while no significant
time is spent in std::vector::find()

(data collected with executables instrumented for profiling)

I also tried to use std::unordered_map instead, but the performance
improvement was disappointingly small.

Sample warnings from minetest using std::map<> (with profiling):
2016-12-11 23:06:10: WARNING[Server]: active block modifiers took 2668ms (longer than 200ms)
2016-12-11 23:06:24: WARNING[Server]: active block modifiers took 2581ms (longer than 200ms)
2016-12-11 23:06:37: WARNING[Server]: active block modifiers took 1878ms (longer than 200ms)
2016-12-11 23:06:50: WARNING[Server]: active block modifiers took 3362ms (longer than 200ms)
2016-12-11 23:07:07: WARNING[Server]: active block modifiers took 2893ms (longer than 200ms)
2016-12-11 23:07:24: WARNING[Server]: active block modifiers took 3076ms (longer than 200ms)
2016-12-11 23:07:40: WARNING[Server]: active block modifiers took 2231ms (longer than 200ms)
2016-12-11 23:07:54: WARNING[Server]: active block modifiers took 3527ms (longer than 200ms)

Sample warnings from minetest using std::vector<> (with profiling)
2016-12-12 00:09:21: WARNING[Server]: active block modifiers took 269ms (longer than 200ms)
2016-12-12 00:09:25: WARNING[Server]: active block modifiers took 317ms (longer than 200ms)
2016-12-12 00:09:28: WARNING[Server]: active block modifiers took 430ms (longer than 200ms)
2016-12-12 00:09:32: WARNING[Server]: active block modifiers took 514ms (longer than 200ms)
2016-12-12 00:09:36: WARNING[Server]: active block modifiers took 372ms (longer than 200ms)
2016-12-12 00:09:39: WARNING[Server]: active block modifiers took 399ms (longer than 200ms)
2016-12-12 00:09:41: WARNING[Server]: active block modifiers took 310ms (longer than 200ms)
2016-12-12 00:09:45: WARNING[Server]: active block modifiers took 461ms (longer than 200ms)
