### PR TITLE
Should have platform-independent line breaking

### DIFF
--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -296,6 +296,7 @@ function modmgr.get_dependencies(modfolder)
 		if dependencyfile then
 			local dependency = dependencyfile:read("*l")
 			while dependency do
+				dependency = dependency:gsub("\r", "")
 				if string.sub(dependency, -1, -1) == "?" then
 					table.insert(soft_dependencies, string.sub(dependency, 1, -2))
 				else


### PR DESCRIPTION
This fixes a bug existing in modmgr.lua as reported by @Wuzzy2 which
caused the mod dependency list to glitch if input was using a line
terminator different than the OS default.

Also fixed the corresponding C++ code, which worked based on widen('\n')
and now works with all of '\r', '\r\n', and '\n', everywhere.

Taken into account the size of the depends.txt files used, this should
not introduce a noticeable performance regression.

Fixes #4720