### PR TITLE
Mgv7: Change default cave width to 0.09

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -972,7 +972,7 @@ mgv6_np_apple_trees (Mapgen v6 apple trees noise parameters) noise_params 0, 1, 
 mgv7_spflags (Mapgen v7 flags) flags mountains,ridges mountains,ridges,floatlands,nomountains,noridges,nofloatlands
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
-mgv7_cave_width (Mapgen v7 cave width) float 0.2
+mgv7_cave_width (Mapgen v7 cave width) float 0.09
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1252,7 +1252,7 @@
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
-# mgv7_cave_width = 0.2
+# mgv7_cave_width = 0.09
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -101,7 +101,7 @@ MapgenV7::~MapgenV7()
 MapgenV7Params::MapgenV7Params()
 {
 	spflags             = MGV7_MOUNTAINS | MGV7_RIDGES;
-	cave_width          = 0.2;
+	cave_width          = 0.09;
 	float_mount_density = 0.6;
 	float_mount_height  = 128.0;
 	floatland_level     = 1280;


### PR DESCRIPTION
this isn't a bugfix, but a "fix" for the too narrow caves concern I had in the discussion of #4829 

Bonus screenshot:
![screenshot_20161212_170111](https://cloud.githubusercontent.com/assets/1042418/21107270/71bc7388-c091-11e6-8937-18d9943754df.png)
