### PR TITLE
Cavegen: Wider tunnels in mgflat, mgfractal, mgvalleys

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1016,7 +1016,7 @@ mgflat_ground_level (Mapgen flat ground level) int 8
 mgflat_large_cave_depth (Mapgen flat large cave depth) int -33
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
-mgflat_cave_width (Mapgen flat cave width) float 0.2
+mgflat_cave_width (Mapgen flat cave width) float 0.09
 
 #    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
@@ -1046,7 +1046,7 @@ mgflat_np_cave2 (Mapgen flat cave2 noise parameters) noise_params 0, 12, (67, 67
 [***Mapgen fractal]
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
-mgfractal_cave_width (Mapgen fractal cave width) float 0.2
+mgfractal_cave_width (Mapgen fractal cave width) float 0.09
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.
@@ -1148,7 +1148,7 @@ mgvalleys_river_size (River Size) int 5
 mgvalleys_water_features (Water Features) int 0
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
-mgvalleys_cave_width (Cave width) float 0.2
+mgvalleys_cave_width (Cave width) float 0.09
 
 # Noise parameters
 [****Noises]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1329,7 +1329,7 @@
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
-# mgflat_cave_width = 0.2
+# mgflat_cave_width = 0.09
 
 #    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
@@ -1370,7 +1370,7 @@
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
-# mgfractal_cave_width = 0.2
+# mgfractal_cave_width = 0.09
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.
@@ -1495,7 +1495,7 @@
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
-# mgvalleys_cave_width = 0.2
+# mgvalleys_cave_width = 0.09
 
 ##### Noises
 

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -82,7 +82,7 @@ MapgenFlatParams::MapgenFlatParams()
 	spflags          = 0;
 	ground_level     = 8;
 	large_cave_depth = -33;
-	cave_width       = 0.2;
+	cave_width       = 0.09;
 	lake_threshold   = -0.45;
 	lake_steepness   = 48.0;
 	hill_threshold   = 0.45;

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -84,7 +84,7 @@ MapgenFractal::~MapgenFractal()
 MapgenFractalParams::MapgenFractalParams()
 {
 	spflags    = 0;
-	cave_width = 0.2;
+	cave_width = 0.09;
 	fractal    = 1;
 	iterations = 11;
 	scale      = v3f(4096.0, 1024.0, 4096.0);

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -143,7 +143,7 @@ MapgenValleysParams::MapgenValleysParams()
 	river_depth        = 4;  // How deep to carve river channels.
 	river_size         = 5;  // How wide to make rivers.
 	water_features     = 0;  // How often water will occur in caves.
-	cave_width         = 0.2;
+	cave_width         = 0.09;
 
 	np_cave1              = NoiseParams(0,     12,   v3f(61,   61,   61),   52534, 3, 0.5,   2.0);
 	np_cave2              = NoiseParams(0,     12,   v3f(67,   67,   67),   10325, 3, 0.5,   2.0);


### PR DESCRIPTION
As mgv7 is now the default mapgen i re-checked its tunnel width on request,
discovered they needed to be wider, and have made this change.
This commit widens the identical 3D noise tunnels in the other mapgens in
exactly the same way.
////////////////////////////////////////////////////////////

@sfan5 The 3D noise tunnels in mgv7, mgflat, mgfractal and mgvalleys are identical and have identical parameters so these need tuning too for release.
Tested.