### PR TITLE
Provide more information when warning about deprecated lua field names

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -74,7 +74,7 @@ ItemDefinition read_item_definition(lua_State* L,int index,
 
 	getboolfield(L, index, "liquids_pointable", def.liquids_pointable);
 
-	warn_if_field_exists(L, index, "tool_digging_properties",
+	log_deprecated_field(L, index, "", def.name.c_str(), "tool_digging_properties",
 			"Deprecated; use tool_capabilities");
 
 	lua_getfield(L, index, "tool_capabilities");
@@ -396,7 +396,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	// If nil, try the deprecated name "tile_images" instead
 	if(lua_isnil(L, -1)){
 		lua_pop(L, 1);
-		warn_if_field_exists(L, index, "tile_images",
+		log_deprecated_field(L, index, "", f.name.c_str(), "tile_images",
 				"Deprecated; new name is \"tiles\".");
 		lua_getfield(L, index, "tile_images");
 	}
@@ -431,7 +431,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	// If nil, try the deprecated name "special_materials" instead
 	if(lua_isnil(L, -1)){
 		lua_pop(L, 1);
-		warn_if_field_exists(L, index, "special_materials",
+		log_deprecated_field(L, index, "", f.name.c_str(), "special_materials",
 				"Deprecated; new name is \"special_tiles\".");
 		lua_getfield(L, index, "special_materials");
 	}
@@ -472,17 +472,17 @@ ContentFeatures read_content_features(lua_State *L, int index)
 			ScriptApiNode::es_ContentParamType2, CPT2_NONE);
 
 	// Warn about some deprecated fields
-	warn_if_field_exists(L, index, "wall_mounted",
+	log_deprecated_field(L, index, "", f.name.c_str(), "wall_mounted",
 			"Deprecated; use paramtype2 = 'wallmounted'");
-	warn_if_field_exists(L, index, "light_propagates",
+	log_deprecated_field(L, index, "", f.name.c_str(), "light_propagates",
 			"Deprecated; determined from paramtype");
-	warn_if_field_exists(L, index, "dug_item",
+	log_deprecated_field(L, index, "", f.name.c_str(), "dug_item",
 			"Deprecated; use 'drop' field");
-	warn_if_field_exists(L, index, "extra_dug_item",
+	log_deprecated_field(L, index, "", f.name.c_str(), "extra_dug_item",
 			"Deprecated; use 'drop' field");
-	warn_if_field_exists(L, index, "extra_dug_item_rarity",
+	log_deprecated_field(L, index, "", f.name.c_str(), "extra_dug_item_rarity",
 			"Deprecated; use 'drop' field");
-	warn_if_field_exists(L, index, "metadata_name",
+	log_deprecated_field(L, index, "", f.name.c_str(), "metadata_name",
 			"Deprecated; use on_add and metadata callbacks");
 
 	// True for all ground-like things like stone and mud, false for eg. trees
@@ -735,19 +735,6 @@ void pushnode(lua_State *L, const MapNode &n, INodeDefManager *ndef)
 	lua_setfield(L, -2, "param1");
 	lua_pushnumber(L, n.getParam2());
 	lua_setfield(L, -2, "param2");
-}
-
-/******************************************************************************/
-void warn_if_field_exists(lua_State *L, int table,
-		const char *name, const std::string &message)
-{
-	lua_getfield(L, table, name);
-	if (!lua_isnil(L, -1)) {
-		warningstream << "Field \"" << name << "\": "
-				<< message << std::endl;
-		infostream << script_get_backtrace(L) << std::endl;
-	}
-	lua_pop(L, 1);
 }
 
 /******************************************************************************/

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -107,10 +107,6 @@ void                pushFloatPos        (lua_State *L, v3f p);
 void                push_v3f            (lua_State *L, v3f p);
 void                push_v2f            (lua_State *L, v2f p);
 
-void                warn_if_field_exists(lua_State *L, int table,
-                                         const char *fieldname,
-                                         const std::string &message);
-
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,
 	v3u16 data_size, v3u16 slice_offset, v3u16 slice_size);
 size_t write_array_slice_u16(lua_State *L, int table_index, u16 *data,

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -190,3 +190,18 @@ void log_deprecated(lua_State *L, const std::string &message)
 	}
 }
 
+void log_deprecated_field(lua_State *L, int table, const char *function,
+		const char *name, const char *field_name, const std::string &message)
+{
+	lua_getfield(L, table, field_name);
+	if (!lua_isnil(L, -1)) {
+		std::ostringstream msg;
+		msg << function << (*function ? ": " : "")
+			<< name << (*name ? ": " : "")
+			<< "field \"" << field_name << "\": "
+			<< message << std::endl;
+		log_deprecated(L, msg.str());
+	}
+	lua_pop(L, 1);
+}
+

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -106,5 +106,9 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 void script_run_callbacks_f(lua_State *L, int nargs,
 	RunCallbacksMode mode, const char *fxn);
 void log_deprecated(lua_State *L, const std::string &message);
+void log_deprecated_field(lua_State *L, int table,
+	const char *function, const char *name,
+	const char *field_name, const std::string &message);
+
 
 #endif /* C_INTERNAL_H_ */

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -668,7 +668,7 @@ int ModApiMapgen::l_set_mapgen_params(lua_State *L)
 	if (lua_isnumber(L, -1))
 		settingsmgr->setMapSetting("chunksize", lua_tostring(L, -1), true);
 
-	warn_if_field_exists(L, 1, "flagmask",
+	log_deprecated_field(L, 1, "set_mapgen_params", "", "flagmask",
 		"Deprecated: flags field now includes unset flags.");
 
 	lua_getfield(L, 1, "flags");
@@ -1054,7 +1054,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->flags          = 0;
 
 	//// Get noise_threshold
-	warn_if_field_exists(L, index, "noise_threshhold",
+	log_deprecated_field(L, index, "register_ore", ore->name.c_str(), "noise_threshhold",
 		"Deprecated: new name is \"noise_threshold\".");
 
 	float nthresh;
@@ -1064,9 +1064,9 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->nthresh = nthresh;
 
 	//// Get y_min/y_max
-	warn_if_field_exists(L, index, "height_min",
+	log_deprecated_field(L, index, "register_ore", ore->name.c_str(), "height_min",
 		"Deprecated: new name is \"y_min\".");
-	warn_if_field_exists(L, index, "height_max",
+	log_deprecated_field(L, index, "register_ore", ore->name.c_str(), "height_max",
 		"Deprecated: new name is \"y_max\".");
 
 	int ymin, ymax;


### PR DESCRIPTION
The information was rather terse, which made it difficult to identify
the offending mod.