### PR TITLE
Use field 'tiles' instead of 'tile_images' in minimal game

### DIFF
--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -28,7 +28,7 @@ minetest.after(1.0, switch_player_visual)
 ]]
 
 minetest.register_node("experimental:soundblock", {
-	tile_images = {"unknown_node.png", "default_tnt_bottom.png",
+	tiles = {"unknown_node.png", "default_tnt_bottom.png",
 			"default_tnt_side.png", "default_tnt_side.png",
 			"default_tnt_side.png", "default_tnt_side.png"},
 	inventory_image = minetest.inventorycube("unknown_node.png",
@@ -120,7 +120,7 @@ minetest.register_craft({
 })
 
 minetest.register_node("experimental:tnt", {
-	tile_images = {"default_tnt_top.png", "default_tnt_bottom.png",
+	tiles = {"default_tnt_top.png", "default_tnt_bottom.png",
 			"default_tnt_side.png", "default_tnt_side.png",
 			"default_tnt_side.png", "default_tnt_side.png"},
 	inventory_image = minetest.inventorycube("default_tnt_top.png",
@@ -453,7 +453,7 @@ minetest.register_abm({
 
 minetest.register_node("experimental:tester_node_1", {
 	description = "Tester Node 1 (construct/destruct/timer)",
-	tile_images = {"wieldhand.png"},
+	tiles = {"wieldhand.png"},
 	groups = {oddly_breakable_by_hand=2},
 	sounds = default.node_sound_wood_defaults(),
 	-- This was known to cause a bug in minetest.item_place_node() when used

--- a/games/minimal/mods/stairs/init.lua
+++ b/games/minimal/mods/stairs/init.lua
@@ -5,7 +5,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description)
 	minetest.register_node("stairs:stair_" .. subname, {
 		description = description,
 		drawtype = "nodebox",
-		tile_images = images,
+		tiles = images,
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = true,
@@ -34,7 +34,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description)
 	minetest.register_node("stairs:slab_" .. subname, {
 		description = description,
 		drawtype = "nodebox",
-		tile_images = images,
+		tiles = images,
 		paramtype = "light",
 		is_ground_content = true,
 		groups = groups,


### PR DESCRIPTION
tile_images is deprecated.