### PR TITLE
Fix occlusing culling counting

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -132,9 +132,9 @@ static bool isOccluded(Map *map, v3s16 p0, v3s16 p1, float step, float stepfac,
 		else
 			is_transparent = (f.solidness != 2);
 		if(!is_transparent){
-			if(count == needed_count)
-				return true;
 			count++;
+			if(count >= needed_count)
+				return true;
 		}
 		step *= stepfac;
 	}


### PR DESCRIPTION
I finally found one reason why occlusion culling seemed to be less effected than I had expected.
Due to - what appears to be a - mistake in counting we require `needed_count` +1 non-transparent block before considered block occluded (so that's currently 2 instead of 1). Looks like this was not indented.

So far I have not seen anything rendered incorrectly, and this marks many more blocks as occluded (at least 30% in all my tests).
