### PR TITLE
Fix block drawing glitch at block boundaries

### DIFF
--- a/src/util/cpp11_container.h
+++ b/src/util/cpp11_container.h
@@ -31,8 +31,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifdef USE_UNORDERED_CONTAINERS
 	#include <unordered_map>
 	#include <unordered_set>
+	#include <functional>
+	#include <irr_v3d.h>
 	#define UNORDERED_MAP std::unordered_map
 	#define UNORDERED_SET std::unordered_set
+
+// Avoid some circular dependencies; declare hash function here
+u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed);
+
+// A hash class is required for c++11 unordered containers
+
+namespace std {
+	template<>
+	struct hash<v3s16> {
+		u64 operator()(const v3s16 &pos) const
+		{
+			s16 data[3] = { pos.X, pos.Y, pos.Z };
+			return murmur_hash_64_ua(data, sizeof(data), 0x6543210f);
+		}
+	};
+}
+
 #else
 	#include <map>
 	#include <set>


### PR DESCRIPTION

![screenshot_20161218_151631](https://cloud.githubusercontent.com/assets/6202053/21294520/c9da36c0-c53e-11e6-9541-d748d373efe1.png)


Sometimes, part of the surface of a mapblock is not rendered, while
all surrounding blocks are. This can be caused by the following:

1) Blocks that are at some distance from the player, and that consist
  of only air will not be sent to the client.
2) If the air/non-air transition is at the block's boundary, then the
  client will not render the boundary until it gets the air block too.
  Which it won't.

This patch fixes this, by using some of the leftover bandwidth to send
air-only blocks that are adjacent to non-air-only blocks. Thus, eventually,
the client will get the air-only blocks it requires, and draw the
block boundary of the adjacent block too.
