### PR TITLE
Cache information about blocks not found in database

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -277,12 +277,8 @@ void RemoteClient::GetNextBlocks (
 				// Reset usage timer, this block will be of use in the future.
 				block->resetUsageTimer();
 
-				// Block is dummy if data doesn't exist.
-				// It means it has been not found from disk and not generated
-				if(block->isDummy())
-				{
+				if (env->getMap().blockNotInDatabase(p))
 					surely_not_found_on_disk = true;
-				}
 
 				// Block is valid if lighting is up-to-date and data exists
 				if(block->isValid() == false)
@@ -308,7 +304,7 @@ void RemoteClient::GetNextBlocks (
 			}
 
 			/*
-				If block has been marked to not exist on disk (dummy)
+				If block is known to not exist on disk
 				and generating new ones is not wanted, skip block.
 			*/
 			if(generate == false && surely_not_found_on_disk == true)

--- a/src/database-dummy.cpp
+++ b/src/database-dummy.cpp
@@ -24,13 +24,13 @@ Dummy database class
 #include "database-dummy.h"
 
 
-bool Database_Dummy::saveBlock(const v3s16 &pos, const std::string &data)
+bool Database_Dummy::saveBlockToDatabase(const v3s16 &pos, const std::string &data)
 {
 	m_database[getBlockAsInteger(pos)] = data;
 	return true;
 }
 
-void Database_Dummy::loadBlock(const v3s16 &pos, std::string *block)
+void Database_Dummy::loadBlockFromDatabase(const v3s16 &pos, std::string *block)
 {
 	s64 i = getBlockAsInteger(pos);
 	std::map<s64, std::string>::iterator it = m_database.find(i);
@@ -42,7 +42,7 @@ void Database_Dummy::loadBlock(const v3s16 &pos, std::string *block)
 	*block = it->second;
 }
 
-bool Database_Dummy::deleteBlock(const v3s16 &pos)
+bool Database_Dummy::deleteBlockFromDatabase(const v3s16 &pos)
 {
 	m_database.erase(getBlockAsInteger(pos));
 	return true;

--- a/src/database-dummy.h
+++ b/src/database-dummy.h
@@ -28,10 +28,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class Database_Dummy : public Database
 {
 public:
-	bool saveBlock(const v3s16 &pos, const std::string &data);
-	void loadBlock(const v3s16 &pos, std::string *block);
-	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
+
+protected:
+	bool saveBlockToDatabase(const v3s16 &pos, const std::string &data);
+	void loadBlockFromDatabase(const v3s16 &pos, std::string *block);
+	bool deleteBlockFromDatabase(const v3s16 &pos);
 
 private:
 	std::map<s64, std::string> m_database;

--- a/src/database-leveldb.cpp
+++ b/src/database-leveldb.cpp
@@ -52,12 +52,12 @@ Database_LevelDB::~Database_LevelDB()
 	delete m_database;
 }
 
-bool Database_LevelDB::saveBlock(const v3s16 &pos, const std::string &data)
+bool Database_LevelDB::saveBlockToDatabase(const v3s16 &pos, const std::string &data)
 {
 	leveldb::Status status = m_database->Put(leveldb::WriteOptions(),
 			i64tos(getBlockAsInteger(pos)), data);
 	if (!status.ok()) {
-		warningstream << "saveBlock: LevelDB error saving block "
+		warningstream << "saveBlockToDatabase: LevelDB error saving block "
 			<< PP(pos) << ": " << status.ToString() << std::endl;
 		return false;
 	}
@@ -65,7 +65,7 @@ bool Database_LevelDB::saveBlock(const v3s16 &pos, const std::string &data)
 	return true;
 }
 
-void Database_LevelDB::loadBlock(const v3s16 &pos, std::string *block)
+void Database_LevelDB::loadBlockFromDatabase(const v3s16 &pos, std::string *block)
 {
 	std::string datastr;
 	leveldb::Status status = m_database->Get(leveldb::ReadOptions(),
@@ -74,12 +74,12 @@ void Database_LevelDB::loadBlock(const v3s16 &pos, std::string *block)
 	*block = (status.ok()) ? datastr : "";
 }
 
-bool Database_LevelDB::deleteBlock(const v3s16 &pos)
+bool Database_LevelDB::deleteBlockFromDatabase(const v3s16 &pos)
 {
 	leveldb::Status status = m_database->Delete(leveldb::WriteOptions(),
 			i64tos(getBlockAsInteger(pos)));
 	if (!status.ok()) {
-		warningstream << "deleteBlock: LevelDB error deleting block "
+		warningstream << "deleteBlockFromDatabase: LevelDB error deleting block "
 			<< PP(pos) << ": " << status.ToString() << std::endl;
 		return false;
 	}

--- a/src/database-leveldb.h
+++ b/src/database-leveldb.h
@@ -34,10 +34,12 @@ public:
 	Database_LevelDB(const std::string &savedir);
 	~Database_LevelDB();
 
-	bool saveBlock(const v3s16 &pos, const std::string &data);
-	void loadBlock(const v3s16 &pos, std::string *block);
-	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
+
+protected:
+	bool saveBlockToDatabase(const v3s16 &pos, const std::string &data);
+	void loadBlockFromDatabase(const v3s16 &pos, std::string *block);
+	bool deleteBlockFromDatabase(const v3s16 &pos);
 
 private:
 	leveldb::DB *m_database;

--- a/src/database-postgresql.cpp
+++ b/src/database-postgresql.cpp
@@ -194,12 +194,12 @@ void Database_PostgreSQL::endSave()
 	checkResults(PQexec(m_conn, "COMMIT;"));
 }
 
-bool Database_PostgreSQL::saveBlock(const v3s16 &pos,
+bool Database_PostgreSQL::saveBlockToDatabase(const v3s16 &pos,
 		const std::string &data)
 {
 	// Verify if we don't overflow the platform integer with the mapblock size
 	if (data.size() > INT_MAX) {
-		errorstream << "Database_PostgreSQL::saveBlock: Data truncation! "
+		errorstream << "Database_PostgreSQL::saveBlockToDatabase: Data truncation! "
 				<< "data.size() over 0xFFFF (== " << data.size()
 				<< ")" << std::endl;
 		return false;
@@ -222,7 +222,7 @@ bool Database_PostgreSQL::saveBlock(const v3s16 &pos,
 	return true;
 }
 
-void Database_PostgreSQL::loadBlock(const v3s16 &pos,
+void Database_PostgreSQL::loadBlockFromDatabase(const v3s16 &pos,
 		std::string *block)
 {
 	verifyDatabase();
@@ -249,7 +249,7 @@ void Database_PostgreSQL::loadBlock(const v3s16 &pos,
 	PQclear(results);
 }
 
-bool Database_PostgreSQL::deleteBlock(const v3s16 &pos)
+bool Database_PostgreSQL::deleteBlockFromDatabase(const v3s16 &pos)
 {
 	verifyDatabase();
 

--- a/src/database-postgresql.h
+++ b/src/database-postgresql.h
@@ -36,11 +36,13 @@ public:
 	void beginSave();
 	void endSave();
 
-	bool saveBlock(const v3s16 &pos, const std::string &data);
-	void loadBlock(const v3s16 &pos, std::string *block);
-	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
 	bool initialized() const;
+
+protected:
+	bool saveBlockToDatabase(const v3s16 &pos, const std::string &data);
+	void loadBlockFromDatabase(const v3s16 &pos, std::string *block);
+	bool deleteBlockFromDatabase(const v3s16 &pos);
 
 private:
 	// Database initialization

--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -77,21 +77,21 @@ void Database_Redis::endSave() {
 	freeReplyObject(reply);
 }
 
-bool Database_Redis::saveBlock(const v3s16 &pos, const std::string &data)
+bool Database_Redis::saveBlockToDatabase(const v3s16 &pos, const std::string &data)
 {
 	std::string tmp = i64tos(getBlockAsInteger(pos));
 
 	redisReply *reply = static_cast<redisReply *>(redisCommand(ctx, "HSET %s %s %b",
 			hash.c_str(), tmp.c_str(), data.c_str(), data.size()));
 	if (!reply) {
-		warningstream << "saveBlock: redis command 'HSET' failed on "
+		warningstream << "saveBlockToDatabase: redis command 'HSET' failed on "
 			"block " << PP(pos) << ": " << ctx->errstr << std::endl;
 		freeReplyObject(reply);
 		return false;
 	}
 
 	if (reply->type == REDIS_REPLY_ERROR) {
-		warningstream << "saveBlock: saving block " << PP(pos)
+		warningstream << "saveBlockToDatabase: saving block " << PP(pos)
 			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;
@@ -101,7 +101,7 @@ bool Database_Redis::saveBlock(const v3s16 &pos, const std::string &data)
 	return true;
 }
 
-void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
+void Database_Redis::loadBlockFromDatabase(const v3s16 &pos, std::string *block)
 {
 	std::string tmp = i64tos(getBlockAsInteger(pos));
 	redisReply *reply = static_cast<redisReply *>(redisCommand(ctx,
@@ -122,7 +122,7 @@ void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
 	case REDIS_REPLY_ERROR: {
 		std::string errstr(reply->str, reply->len);
 		freeReplyObject(reply);
-		errorstream << "loadBlock: loading block " << PP(pos)
+		errorstream << "loadBlockFromDatabase: loading block " << PP(pos)
 			<< " failed: " << errstr << std::endl;
 		throw DatabaseException(std::string(
 			"Redis command 'HGET %s %s' errored: ") + errstr);
@@ -135,7 +135,7 @@ void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
 	}
 	}
 
-	errorstream << "loadBlock: loading block " << PP(pos)
+	errorstream << "loadBlockFromDatabase: loading block " << PP(pos)
 		<< " returned invalid reply type " << reply->type
 		<< ": " << std::string(reply->str, reply->len) << std::endl;
 	freeReplyObject(reply);
@@ -143,7 +143,7 @@ void Database_Redis::loadBlock(const v3s16 &pos, std::string *block)
 		"Redis command 'HGET %s %s' gave invalid reply."));
 }
 
-bool Database_Redis::deleteBlock(const v3s16 &pos)
+bool Database_Redis::deleteBlockFromDatabase(const v3s16 &pos)
 {
 	std::string tmp = i64tos(getBlockAsInteger(pos));
 
@@ -153,7 +153,7 @@ bool Database_Redis::deleteBlock(const v3s16 &pos)
 		throw DatabaseException(std::string(
 			"Redis command 'HDEL %s %s' failed: ") + ctx->errstr);
 	} else if (reply->type == REDIS_REPLY_ERROR) {
-		warningstream << "deleteBlock: deleting block " << PP(pos)
+		warningstream << "deleteBlockFromDatabase: deleting block " << PP(pos)
 			<< " failed: " << std::string(reply->str, reply->len) << std::endl;
 		freeReplyObject(reply);
 		return false;

--- a/src/database-redis.h
+++ b/src/database-redis.h
@@ -39,10 +39,12 @@ public:
 	void beginSave();
 	void endSave();
 
-	bool saveBlock(const v3s16 &pos, const std::string &data);
-	void loadBlock(const v3s16 &pos, std::string *block);
-	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
+
+protected:
+	bool saveBlockToDatabase(const v3s16 &pos, const std::string &data);
+	void loadBlockFromDatabase(const v3s16 &pos, std::string *block);
+	bool deleteBlockFromDatabase(const v3s16 &pos);
 
 private:
 	redisContext *ctx;

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -200,7 +200,7 @@ inline void Database_SQLite3::bindPos(sqlite3_stmt *stmt, const v3s16 &pos, int 
 		"Internal error: failed to bind query at " __FILE__ ":" TOSTRING(__LINE__));
 }
 
-bool Database_SQLite3::deleteBlock(const v3s16 &pos)
+bool Database_SQLite3::deleteBlockFromDatabase(const v3s16 &pos)
 {
 	verifyDatabase();
 
@@ -210,13 +210,13 @@ bool Database_SQLite3::deleteBlock(const v3s16 &pos)
 	sqlite3_reset(m_stmt_delete);
 
 	if (!good) {
-		warningstream << "deleteBlock: Block failed to delete "
+		warningstream << "deleteBlockFromDatabase: Block failed to delete "
 			<< PP(pos) << ": " << sqlite3_errmsg(m_database) << std::endl;
 	}
 	return good;
 }
 
-bool Database_SQLite3::saveBlock(const v3s16 &pos, const std::string &data)
+bool Database_SQLite3::saveBlockToDatabase(const v3s16 &pos, const std::string &data)
 {
 	verifyDatabase();
 
@@ -228,7 +228,7 @@ bool Database_SQLite3::saveBlock(const v3s16 &pos, const std::string &data)
 	bindPos(m_stmt_read, pos);
 
 	if (sqlite3_step(m_stmt_read) == SQLITE_ROW) {
-		deleteBlock(pos);
+		deleteBlockFromDatabase(pos);
 	}
 	sqlite3_reset(m_stmt_read);
 #endif
@@ -243,7 +243,7 @@ bool Database_SQLite3::saveBlock(const v3s16 &pos, const std::string &data)
 	return true;
 }
 
-void Database_SQLite3::loadBlock(const v3s16 &pos, std::string *block)
+void Database_SQLite3::loadBlockFromDatabase(const v3s16 &pos, std::string *block)
 {
 	verifyDatabase();
 

--- a/src/database-sqlite3.h
+++ b/src/database-sqlite3.h
@@ -36,11 +36,13 @@ public:
 	void beginSave();
 	void endSave();
 
-	bool saveBlock(const v3s16 &pos, const std::string &data);
-	void loadBlock(const v3s16 &pos, std::string *block);
-	bool deleteBlock(const v3s16 &pos);
 	void listAllLoadableBlocks(std::vector<v3s16> &dst);
 	bool initialized() const { return m_initialized; }
+
+protected:
+	bool saveBlockToDatabase(const v3s16 &pos, const std::string &data);
+	void loadBlockFromDatabase(const v3s16 &pos, std::string *block);
+	bool deleteBlockFromDatabase(const v3s16 &pos);
 
 private:
 	// Open the database

--- a/src/database.h
+++ b/src/database.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include "irr_v3d.h"
 #include "irrlichttypes.h"
+#include "util/cpp11_container.h"
 
 #ifndef PP
 	#define PP(x) "("<<(x).X<<","<<(x).Y<<","<<(x).Z<<")"
@@ -37,9 +38,31 @@ public:
 	virtual void beginSave() {}
 	virtual void endSave() {}
 
-	virtual bool saveBlock(const v3s16 &pos, const std::string &data) = 0;
-	virtual void loadBlock(const v3s16 &pos, std::string *block) = 0;
-	virtual bool deleteBlock(const v3s16 &pos) = 0;
+	bool saveBlock(const v3s16 &pos, const std::string &data)
+	{
+		m_blocks_not_found.erase(pos);
+		return saveBlockToDatabase(pos, data);
+	}
+	void loadBlock(const v3s16 &pos, std::string *block)
+	{
+		if (m_blocks_not_found.count(pos)) {
+			block->clear();
+		} else {
+			loadBlockFromDatabase(pos, block);
+			if (!block->length())
+				m_blocks_not_found.insert(pos);
+		}
+	}
+	bool deleteBlock(const v3s16 &pos)
+	{
+		bool deleted = deleteBlockFromDatabase(pos);
+		if (deleted)
+			m_blocks_not_found.insert(pos);
+		return deleted;
+	}
+	bool blockNotFound(const v3s16 &pos) const
+		{ return m_blocks_not_found.count(pos); }
+	void forgetBlocksNotFound() { m_blocks_not_found.clear(); }
 
 	static s64 getBlockAsInteger(const v3s16 &pos);
 	static v3s16 getIntegerAsBlock(s64 i);
@@ -47,6 +70,14 @@ public:
 	virtual void listAllLoadableBlocks(std::vector<v3s16> &dst) = 0;
 
 	virtual bool initialized() const { return true; }
+
+protected:
+	virtual bool saveBlockToDatabase(const v3s16 &pos, const std::string &data) = 0;
+	virtual void loadBlockFromDatabase(const v3s16 &pos, std::string *block) = 0;
+	virtual bool deleteBlockFromDatabase(const v3s16 &pos) = 0;
+
+private:
+	UNORDERED_SET<v3s16> m_blocks_not_found;
 };
 
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -34,10 +34,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/container.h"
 #include "util/cpp11_container.h"
 #include "nodetimer.h"
+#include "database.h"
 #include "map_settings_manager.h"
 
 class Settings;
-class Database;
 class ClientMap;
 class MapSector;
 class ServerMapSector;
@@ -188,6 +188,13 @@ public:
 	MapBlock * getBlockNoCreate(v3s16 p);
 	// Returns NULL if not found
 	MapBlock * getBlockNoCreateNoEx(v3s16 p);
+
+	// Overridden by server
+	virtual bool blockNotInDatabase(const v3s16 &pos)
+	{
+		assert(!"Map::blockNotInDatabase: this method should not ever be invoked");
+		return false;
+	}
 
 	/* Server overrides */
 	virtual MapBlock * emergeBlock(v3s16 p, bool create_blank=true)
@@ -478,6 +485,9 @@ public:
 	MapBlock* loadBlock(v3s16 p);
 	// Database version
 	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
+	// Check whether block is *known* to not be in the database.
+	// If true, the block is not in the database, if false, then the block may or may not be in the database.
+	bool blockNotInDatabase(const v3s16 &pos) { return dbase->blockNotFound(pos); }
 
 	bool deleteBlock(v3s16 blockpos);
 

--- a/src/util/cpp11_container.h
+++ b/src/util/cpp11_container.h
@@ -31,8 +31,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifdef USE_UNORDERED_CONTAINERS
 	#include <unordered_map>
 	#include <unordered_set>
+	#include <functional>
+	#include <irr_v3d.h>
 	#define UNORDERED_MAP std::unordered_map
 	#define UNORDERED_SET std::unordered_set
+
+// Avoid some circular dependencies; declare hash function here
+u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed);
+
+// A hash class is required for c++11 unordered containers
+
+namespace std {
+	template<>
+	struct hash<v3s16> {
+		u64 operator()(const v3s16 &pos) const
+		{
+			s16 data[3] = { pos.X, pos.Y, pos.Z };
+			return murmur_hash_64_ua(data, sizeof(data), 0x6543210f);
+		}
+	};
+}
+
 #else
 	#include <map>
 	#include <set>


### PR DESCRIPTION
Minetest did not remember this information, and would
repeatedly (incessantly) query the database for the same
non-existant blocks.

Now, the information about blocks not found in the database
is cached, so that the database is not queried needlessly.