### PR TITLE
Improve occlusion culling accuracy.

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -292,9 +292,6 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			cpn += v3s16(MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2);
 			float step = BS * 1;
 			float stepfac = 1.1;
-			// avoid the extreme angles close to camera
-			// to prevent occlusion errors
-			// why 4? no idea, tested fine
 			float startoff = BS * 4;
 			// The occlusion search of 'isOccluded()' must stop short of the target
 			// point by distance 'endoff' (end offset) to not enter the target mapblock.
@@ -304,6 +301,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			float endoff = -BS * MAP_BLOCKSIZE * 1.732050807569;
 			v3s16 spn = cam_pos_nodes;
 			s16 bs2 = MAP_BLOCKSIZE / 2 + 1;
+			s16 bs4 = MAP_BLOCKSIZE / 4 + 1;
 			u32 needed_count = 1;
 			if (occlusion_culling_enabled &&
 					// For the central point of the mapblock 'endoff' can be halved
@@ -324,6 +322,24 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,bs2),
 						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
 					isOccluded(this, spn, cpn + v3s16(-bs2,-bs2,-bs2),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					// also try 1/2 the distance to the corners of the MapBlock for
+					// for better accuracy in tunnels, etc.
+					isOccluded(this, spn, cpn + v3s16(bs4,bs4,bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs4,bs4,-bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs4,-bs4,bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(bs4,-bs4,-bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs4,bs4,bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs4,bs4,-bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs4,-bs4,bs4),
+						step, stepfac, startoff, endoff, needed_count, nodemgr) &&
+					isOccluded(this, spn, cpn + v3s16(-bs4,-bs4,-bs4),
 						step, stepfac, startoff, endoff, needed_count, nodemgr)) {
 				blocks_occlusion_culled++;
 				continue;

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -313,9 +313,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			cpn += v3s16(MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2);
 			float step = BS * 1;
 			float stepfac = 1.1;
-			// BS * 4 avoids sharp angles close to the camera
-			// for better accuracy
-			float startoff = BS * 4;
+			float startoff = BS * 1;
 			// The occlusion search of 'isOccluded()' must stop short of the target
 			// point by distance 'endoff' (end offset) to not enter the target mapblock.
 			// For the 8 mapblock corners 'endoff' must therefore be the maximum diagonal
@@ -323,7 +321,10 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			// sqrt(1^2 + 1^2 + 1^2) = 1.732
 			float endoff = -BS * MAP_BLOCKSIZE * 1.732050807569;
 			v3s16 spn = cam_pos_nodes;
-			u32 needed_count = 1;
+			// to reduce the likelihood of falsely occluded blocks
+			// require at least two solid blocks
+			// this is a HACK, we should think of a more precise algorithm
+			u32 needed_count = 2;
 			if (occlusion_culling_enabled &&
 					// First see if the block's center is occluded
 					// (for the central point of the mapblock 'endoff' can be halved)

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -292,7 +292,10 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			cpn += v3s16(MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2, MAP_BLOCKSIZE / 2);
 			float step = BS * 1;
 			float stepfac = 1.1;
-			float startoff = BS * 1;
+			// avoid the extreme angles close to camera
+			// to prevent occlusion errors
+			// why 4? no idea, tested fine
+			float startoff = BS * 4;
 			// The occlusion search of 'isOccluded()' must stop short of the target
 			// point by distance 'endoff' (end offset) to not enter the target mapblock.
 			// For the 8 mapblock corners 'endoff' must therefore be the maximum diagonal
@@ -301,10 +304,7 @@ void ClientMap::updateDrawList(video::IVideoDriver* driver)
 			float endoff = -BS * MAP_BLOCKSIZE * 1.732050807569;
 			v3s16 spn = cam_pos_nodes;
 			s16 bs2 = MAP_BLOCKSIZE / 2 + 1;
-			// to reduce the likelihood of falsely occluded blocks
-			// require at least two solid blocks
-			// this is a HACK, we should think of a more precise algorithm
-			u32 needed_count = 2;
+			u32 needed_count = 1;
 			if (occlusion_culling_enabled &&
 					// For the central point of the mapblock 'endoff' can be halved
 					isOccluded(this, spn, cpn,


### PR DESCRIPTION
Update: This is now improved accuracy of occlusion culling. If a block is visible it usually determined pretty quickly. If the block is a block is occluded, however, an extra set of 8 rays is sent out to improve accuracy, especially in tunnels and other "tight" scenarios. 
All performance improvements are removed.

Was:

Thinking about all this it occurred to me that the falsely occluded block probably have to with the extreme angles close to the camera. Indeed if that search just starts BS * 4 away from the camera I was not able to see any wrongly occluded blocks in all the scenarios I could find.

@Fixer-007 , @paramat any chance that you could repeat your tests with this?