### PR TITLE
Builtin/../falling.lua: Avoid crash when object pos over limit

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -113,7 +113,9 @@ core.register_entity(":__builtin:falling_node", {
 
 local function spawn_falling_node(p, node)
 	local obj = core.add_entity(p, "__builtin:falling_node")
-	obj:get_luaentity():set_node(node)
+	if obj then
+		obj:get_luaentity():set_node(node)
+	end
 end
 
 local function drop_attached_node(p)


### PR DESCRIPTION
If the object pos is over limit, 'add entity' will not add an entity,
causing 'obj' to be nil.
////////////////////////////////////////////////

Avoids crashes due to buggy map gen limit code.
Discussion in #4923 
Tested by placing falling nodes over-limit, error is printed to screen, entity is removed but no crash.