### PR TITLE
Add player:hud_set_above()

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -146,6 +146,7 @@ enum ClientEventType
 	CE_HUDADD,
 	CE_HUDRM,
 	CE_HUDCHANGE,
+        CE_HUD_SET_ABOVE,
 	CE_SET_SKY,
 	CE_OVERRIDE_DAY_NIGHT_RATIO,
 };
@@ -236,6 +237,10 @@ struct ClientEvent
 			v3f *v3fdata;
 			v2s32 * v2s32data;
 		} hudchange;
+		struct {
+			u32 bottom;
+			u32 top;
+		} hud_set_above;
 		struct{
 			video::SColor *bgcolor;
 			std::string *type;
@@ -392,6 +397,7 @@ public:
 	void handleCommand_HudAdd(NetworkPacket* pkt);
 	void handleCommand_HudRemove(NetworkPacket* pkt);
 	void handleCommand_HudChange(NetworkPacket* pkt);
+	void handleCommand_HudSetAbove(NetworkPacket* pkt);
 	void handleCommand_HudSetFlags(NetworkPacket* pkt);
 	void handleCommand_HudSetParam(NetworkPacket* pkt);
 	void handleCommand_HudSetSky(NetworkPacket* pkt);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3641,6 +3641,8 @@ void Game::processClientEvents(CameraOrientation *cam, float *damage_flash)
 			delete event.hudchange.v2fdata;
 			delete event.hudchange.sdata;
 			delete event.hudchange.v2s32data;
+		} else if (event.type == CE_HUD_SET_ABOVE) {
+			player->setHudAbove(event.hud_set_above.bottom, event.hud_set_above.top);
 		} else if (event.type == CE_SET_SKY) {
 			sky->setVisible(false);
 

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -285,8 +285,10 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 {
 	u32 text_height = g_fontengine->getTextHeight();
 	irr::gui::IGUIFont* font = g_fontengine->getFont();
-	for (size_t i = 0; i != player->maxHudId(); i++) {
-		HudElement *e = player->getHud(i);
+	std::list<u32> hud_stack = player->getHudStack();
+	for (std::list<u32>::iterator it = hud_stack.begin();
+			it != hud_stack.end(); ++it) {
+		HudElement *e = player->getHud(*it);
 		if (!e)
 			continue;
 
@@ -366,7 +368,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				break; }
 			default:
 				infostream << "Hud::drawLuaElements: ignoring drawform " << e->type <<
-					" of hud element ID " << i << " due to unrecognized type" << std::endl;
+					" of hud element ID " << *it << " due to unrecognized type" << std::endl;
 		}
 	}
 }

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -100,8 +100,6 @@ public:
 		m_cao = toset;
 	}
 
-	u32 maxHudId() const { return hud.size(); }
-
 	u16 getBreath() const { return m_breath; }
 	void setBreath(u16 breath) { m_breath = breath; }
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -108,7 +108,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerAnimations }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_EyeOffset }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
-	null_command_handler,
+	{ "TOCLIENT_HUD_SET_ABOVE",            TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetAbove }, // 0x54
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1094,6 +1094,20 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
+void Client::handleCommand_HudSetAbove(NetworkPacket* pkt)
+{
+	u32 bottom;
+	u32 top;
+
+	*pkt >> bottom >> top;
+
+	ClientEvent event;
+	event.type                 = CE_HUD_SET_ABOVE;
+	event.hud_set_above.bottom = bottom;
+	event.hud_set_above.top    = top;
+	m_client_event_queue.push(event);
+}
+
 void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
 {
 	u32 flags, mask;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -595,6 +595,12 @@ enum ToClientCommand
 		u32 id
 	*/
 
+	TOCLIENT_HUD_SET_ABOVE = 0x54,
+	/*
+		u32 bottom
+		u32 top
+	*/
+
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
 		Belonging to AUTH_MECHANISM_LEGACY_PASSWORD and AUTH_MECHANISM_SRP.

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -197,7 +197,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_LOCAL_PLAYER_ANIMATIONS",  0, true }, // 0x51
 	{ "TOCLIENT_EYE_OFFSET",               0, true }, // 0x52
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
-	null_command_factory,
+	{ "TOCLIENT_HUD_SET_ABOVE",            0, true }, // 0x54
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -95,6 +95,7 @@ u32 Player::addHud(HudElement *toadd)
 	else
 		hud.push_back(toadd);
 
+	hud_stack.push_back(id);
 	return id;
 }
 
@@ -117,7 +118,37 @@ HudElement* Player::removeHud(u32 id)
 		retval = hud[id];
 		hud[id] = NULL;
 	}
+	for (std::list<u32>::iterator it = hud_stack.begin();
+			it != hud_stack.end(); ++it) {
+		if (*it == id) {
+			hud_stack.erase(it);
+			// there should never be multiple entries, so we can skip
+			break;
+		}
+	}
 	return retval;
+}
+
+void Player::setHudAbove(u32 bottom, u32 top)
+{
+	if (bottom == top || getHud(bottom) == NULL || getHud(top) == NULL)
+		return;
+
+	bool found = false;
+	for (std::list<u32>::iterator it = hud_stack.begin();
+			it != hud_stack.end(); ) {
+		if (*it == bottom) {
+			if (found) {
+				hud_stack.insert(++it, top);
+			}
+			break;
+		} else if (*it == top) {
+			found = true;
+			it = hud_stack.erase(it);
+		} else {
+			++it;
+		}
+	}
 }
 
 void Player::clearHud()

--- a/src/player.h
+++ b/src/player.h
@@ -140,6 +140,7 @@ public:
 		}
 		return size;
 	}
+	void setHudAbove(u32 bottom, u32 top);
 
 	v3f eye_offset_first;
 	v3f eye_offset_third;
@@ -175,6 +176,7 @@ public:
 	u32         addHud(HudElement* hud);
 	HudElement* removeHud(u32 id);
 	void        clearHud();
+	std::list<u32> getHudStack() const { return hud_stack; }
 
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;
@@ -183,6 +185,8 @@ protected:
 	v3f m_speed;
 
 	std::vector<HudElement *> hud;
+	// Hud stack to determine the draw order
+	std::list<u32> hud_stack;
 private:
 	// Protect some critical areas
 	// hud for example can be modified by EmergeThread

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1412,6 +1412,27 @@ int ObjectRef::l_hud_change(lua_State *L)
 	return 1;
 }
 
+// hud_set_above(self, bottom, top)
+int ObjectRef::l_hud_set_above(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == NULL)
+		return 0;
+
+	u32 bottom = lua_isnumber(L, 2) ? lua_tonumber(L, 2) : -1;
+	u32 top = lua_isnumber(L, 3) ? lua_tonumber(L, 3) : -1;
+	if (bottom == top)
+		return 0;
+
+	if (!getServer(L)->hudSetAbove(player, bottom, top))
+		return 0;
+
+	lua_pushboolean(L, true);
+	return 1;
+}
+
 // hud_get(self, id)
 int ObjectRef::l_hud_get(lua_State *L)
 {
@@ -1842,6 +1863,7 @@ const luaL_reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, hud_add),
 	luamethod(ObjectRef, hud_remove),
 	luamethod(ObjectRef, hud_change),
+	luamethod(ObjectRef, hud_set_above),
 	luamethod(ObjectRef, hud_get),
 	luamethod(ObjectRef, hud_set_flags),
 	luamethod(ObjectRef, hud_get_flags),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -244,6 +244,9 @@ private:
 	// hud_change(self, id, stat, data)
 	static int l_hud_change(lua_State *L);
 
+	// hud_set_above(self, bottom, top)
+	static int l_hud_set_above(lua_State *L);
+
 	// hud_get_next_id(self)
 	static u32 hud_get_next_id(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1783,6 +1783,13 @@ void Server::SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value
 	Send(&pkt);
 }
 
+void Server::SendHUDSetAbove(u16 peer_id, u32 bottom, u32 top)
+{
+	NetworkPacket pkt(TOCLIENT_HUD_SET_ABOVE, 8, peer_id);
+	pkt << bottom << top;
+	Send(&pkt);
+}
+
 void Server::SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask)
 {
 	NetworkPacket pkt(TOCLIENT_HUD_SET_FLAGS, 4 + 4, peer_id);
@@ -3046,6 +3053,20 @@ bool Server::hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *
 		return false;
 
 	SendHUDChange(player->peer_id, id, stat, data);
+	return true;
+}
+
+bool Server::hudSetAbove(RemotePlayer *player, u32 bottom, u32 top) {
+	if (!player)
+		return false;
+
+	HudElement *e_bottom = player->getHud(bottom);
+	HudElement *e_top = player->getHud(top);
+
+	if (e_bottom == NULL || e_top == NULL)
+		return false;
+
+	SendHUDSetAbove(player->peer_id, bottom, top);
 	return true;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -317,6 +317,7 @@ public:
 	u32 hudAdd(RemotePlayer *player, HudElement *element);
 	bool hudRemove(RemotePlayer *player, u32 id);
 	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
+	bool hudSetAbove(RemotePlayer *player, u32 bottom, u32 top);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount);
 	s32 hudGetHotbarItemcount(RemotePlayer *player) const
@@ -400,6 +401,7 @@ private:
 	void SendHUDAdd(u16 peer_id, u32 id, HudElement *form);
 	void SendHUDRemove(u16 peer_id, u32 id);
 	void SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value);
+	void SendHUDSetAbove(u16 peer_id, u32 bottom, u32 top);
 	void SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask);
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,


### PR DESCRIPTION
Allows changing the draw order of HudElements.

This addresses the issue, that the draw order of HudElements is pretty random: When a hudElement is added, the first available id is used, so later HudElements can be behind previous ones. Now, you can explicitly state that one element should be in front of another.

The main problem this should solve in the long run, is overlaying of the default hud. This is still not possible since the user doesn't have access to the ids of the health and breath bar and the hotbar isn't a lua generated HudElement. Furthermore, the breath bar doesn't have a fixed id since it gets deleted and readded when needed.