### PR TITLE
Meshes: Make object mesh face shading consistent 

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -186,17 +186,14 @@ void shadeMeshFaces(scene::IMesh *mesh)
 		for (u32 i = 0; i < vertex_count; i++) {
 			video::S3DVertex *vertex = (video::S3DVertex *)(vertices + i * stride);
 			video::SColor &vc = vertex->Color;
-			if (vertex->Normal.Y < -0.5) {
-				applyFacesShading (vc, 0.447213);
-			} else if (vertex->Normal.Z > 0.5) {
-				applyFacesShading (vc, 0.670820);
-			} else if (vertex->Normal.Z < -0.5) {
-				applyFacesShading (vc, 0.670820);
-			} else if (vertex->Normal.X > 0.5) {
-				applyFacesShading (vc, 0.836660);
-			} else if (vertex->Normal.X < -0.5) {
-				applyFacesShading (vc, 0.836660);
-			}
+			// Many special drawtypes have normals set to 0,0,0 and this
+			// must result in maximum brightness (no face shadng).
+			if (vertex->Normal.Y < -0.5f)
+				applyFacesShading (vc, 0.447213f);
+			else if (vertex->Normal.X > 0.5f || vertex->Normal.X < -0.5f)
+				applyFacesShading (vc, 0.670820f);
+			else if (vertex->Normal.Z > 0.5f || vertex->Normal.Z < -0.5f)
+				applyFacesShading (vc, 0.836660f);
 		}
 	}
 }


### PR DESCRIPTION
Previously, object meshes had their North and South faces darker than
East and West faces, the opposite of nodes and meshnodes. This commit
corrects this.
State constants as float-literals not double-literals.
Simplify logic.
Add comment.
///////////////////////////////////////////////////////

Examples are falling sand node entities.
Shaders off, all visual filters off.
Code now matches https://github.com/minetest/minetest/blob/master/src/mapblock_mesh.cpp#L1169

![screenshot_20161224_051945](https://cloud.githubusercontent.com/assets/3686677/21465656/5630a15e-c9a4-11e6-82fd-f681185d64d1.png)

^ Current. Shading of mesh is darker on N and S faces, the opposite of nodes

![screenshot_20161224_063734](https://cloud.githubusercontent.com/assets/3686677/21465670/842aaff0-c9a4-11e6-90e1-d9999453b550.png)

![screenshot_20161224_063752](https://cloud.githubusercontent.com/assets/3686677/21465672/8edc70b4-c9a4-11e6-814e-21cbb5a40d1b.png)

^ This commit

![screenshot_20161225_080640](https://cloud.githubusercontent.com/assets/3686677/21470287/621fc15e-ca79-11e6-836b-33b88018bddb.png)

^ Current

![screenshot_20161225_080532](https://cloud.githubusercontent.com/assets/3686677/21470285/533df0ca-ca79-11e6-987c-c2a737e176e0.png)

^ This commit. Shading of extruded entities is improved as the larger faces become brighter than the edges.