### PR TITLE
Fix retrieving blocks in 3rd front camera view.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -879,6 +879,10 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	u8 wanted_range  = MYMIN(255,
 			std::ceil(clientMap->getControl().wanted_range / MAP_BLOCKSIZE));
 
+	if (clientMap->getCameraFrontView()) {
+		yaw += 180 * 100;
+		pitch = -pitch;
+	}
 	v3s32 position(pf.X, pf.Y, pf.Z);
 	v3s32 speed(sf.X, sf.Y, sf.Z);
 
@@ -1271,12 +1275,18 @@ void Client::sendPlayerPos()
 
 	u8 camera_fov    = map.getCameraFov();
 	u8 wanted_range  = map.getControl().wanted_range;
+	float pitch = myplayer->getPitch();
+	float yaw = myplayer->getYaw();
+	if (map.getCameraFrontView()) {
+		yaw += 180;
+		pitch = -pitch;
+	}
 
 	// Save bandwidth by only updating position when something changed
 	if(myplayer->last_position        == myplayer->getPosition() &&
 			myplayer->last_speed        == myplayer->getSpeed()    &&
-			myplayer->last_pitch        == myplayer->getPitch()    &&
-			myplayer->last_yaw          == myplayer->getYaw()      &&
+			myplayer->last_pitch        == pitch                   &&
+			myplayer->last_yaw          == yaw                     &&
 			myplayer->last_keyPressed   == myplayer->keyPressed    &&
 			myplayer->last_camera_fov   == camera_fov              &&
 			myplayer->last_wanted_range == wanted_range)
@@ -1284,8 +1294,8 @@ void Client::sendPlayerPos()
 
 	myplayer->last_position     = myplayer->getPosition();
 	myplayer->last_speed        = myplayer->getSpeed();
-	myplayer->last_pitch        = myplayer->getPitch();
-	myplayer->last_yaw          = myplayer->getYaw();
+	myplayer->last_pitch        = pitch;
+	myplayer->last_yaw          = yaw;
 	myplayer->last_keyPressed   = myplayer->keyPressed;
 	myplayer->last_camera_fov   = camera_fov;
 	myplayer->last_wanted_range = wanted_range;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -105,8 +105,14 @@ void RemoteClient::GetNextBlocks (
 	// Camera position and direction
 	v3f camera_pos = sao->getEyePosition();
 	v3f camera_dir = v3f(0,0,1);
-	camera_dir.rotateYZBy(sao->getPitch());
-	camera_dir.rotateXZBy(sao->getYaw());
+	float pitch = sao->getPitch();
+	float yaw = sao->getYaw();
+	if (sao->getCameraInverted()) {
+		yaw += 180;
+		pitch = -pitch;
+	}
+	camera_dir.rotateYZBy(pitch);
+	camera_dir.rotateXZBy(yaw);
 
 	/*infostream<<"camera_dir=("<<camera_dir.X<<","<<camera_dir.Y<<","
 			<<camera_dir.Z<<")"<<std::endl;*/

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -67,12 +67,13 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset, const bool front_view)
 	{
 		m_camera_position = pos;
 		m_camera_direction = dir;
 		m_camera_fov = fov;
 		m_camera_offset = offset;
+		m_camera_front_view = front_view;
 	}
 
 	/*
@@ -115,6 +116,7 @@ public:
 
 	const MapDrawControl & getControl() const { return m_control; }
 	f32 getCameraFov() const { return m_camera_fov; }
+	bool getCameraFrontView() const { return m_camera_front_view; }
 private:
 	Client *m_client;
 
@@ -127,6 +129,7 @@ private:
 	v3f m_camera_direction = v3f(0,0,1);
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
+	bool m_camera_front_view;
 
 	std::map<v3s16, MapBlock*> m_drawlist;
 

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -67,13 +67,13 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset, const bool front_view)
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset, bool inverted_view)
 	{
 		m_camera_position = pos;
 		m_camera_direction = dir;
 		m_camera_fov = fov;
 		m_camera_offset = offset;
-		m_camera_front_view = front_view;
+		m_camera_inverted = inverted_view;
 	}
 
 	/*
@@ -116,7 +116,7 @@ public:
 
 	const MapDrawControl & getControl() const { return m_control; }
 	f32 getCameraFov() const { return m_camera_fov; }
-	bool getCameraFrontView() const { return m_camera_front_view; }
+	bool getCameraInverted() const { return m_camera_inverted; }
 private:
 	Client *m_client;
 
@@ -129,7 +129,7 @@ private:
 	v3f m_camera_direction = v3f(0,0,1);
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
-	bool m_camera_front_view;
+	bool m_camera_inverted;
 
 	std::map<v3s16, MapBlock*> m_drawlist;
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1145,6 +1145,14 @@ void PlayerSAO::setFov(const float fov)
 	m_fov = fov;
 }
 
+void PlayerSAO::setCameraInverted(const bool camera_inverted)
+{
+	if (m_player && camera_inverted != m_camera_inverted)
+		m_player->setDirty(true);
+
+	m_camera_inverted = camera_inverted;
+}
+
 void PlayerSAO::setWantedRange(const s16 range)
 {
 	if (m_player && range != m_wanted_range)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -232,6 +232,9 @@ public:
 	void setWantedRange(const s16 range);
 	s16 getWantedRange() const { return m_wanted_range; }
 
+	void setCameraInverted(const bool camera_inverted);
+	bool getCameraInverted() const { return m_camera_inverted; }
+
 	/*
 		Interaction interface
 	*/
@@ -401,6 +404,7 @@ private:
 	f32 m_pitch = 0.0f;
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
+	bool m_camera_inverted = false;
 
 	PlayerAttributes m_extra_attributes;
 	bool m_extended_attributes_modified = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3536,7 +3536,10 @@ void Game::updateCamera(u32 busy_time, f32 dtime)
 
 	if (!flags.disable_camera_update) {
 		client->getEnv().getClientMap().updateCamera(camera_position,
-				camera_direction, camera_fov, camera_offset);
+				camera_direction,
+				camera_fov,
+				camera_offset,
+				camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT);
 
 		if (m_camera_offset_changed) {
 			client->updateCameraOffset(camera_offset);

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -92,6 +92,7 @@ public:
 	unsigned int last_keyPressed = 0;
 	u8 last_camera_fov = 0;
 	u8 last_wanted_range = 0;
+	u8 last_camera_inverted = 0;
 
 	float camera_impact = 0.0f;
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -784,6 +784,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	// default behavior (in case an old client doesn't send these)
 	f32 fov = 0;
 	u8 wanted_range = 0;
+	bool camera_inverted = false;
 
 	if (pkt->getRemainingBytes() >= 4)
 		*pkt >> keyPressed;
@@ -793,6 +794,9 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	}
 	if (pkt->getRemainingBytes() >= 1)
 		*pkt >> wanted_range;
+
+	if (pkt->getRemainingBytes() >= 1)
+		*pkt >> camera_inverted;
 
 	v3f position((f32)ps.X / 100.0f, (f32)ps.Y / 100.0f, (f32)ps.Z / 100.0f);
 	v3f speed((f32)ss.X / 100.0f, (f32)ss.Y / 100.0f, (f32)ss.Z / 100.0f);
@@ -806,6 +810,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	playersao->setYaw(yaw);
 	playersao->setFov(fov);
 	playersao->setWantedRange(wanted_range);
+	playersao->setCameraInverted(camera_inverted);
 	player->keyPressed = keyPressed;
 	player->control.up = (keyPressed & 1);
 	player->control.down = (keyPressed & 2);


### PR DESCRIPTION
Not sure it's even worth the effort, but I noticed that in 3rd front camera view the visible blocks are not correctly loaded, since the camera pitch and yaw sent to the server are not adjusted accordingly. This fixes that.