### PR TITLE
Mapblock mesh shading: Improve simple slope face shading 

### DIFF
--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1161,19 +1161,38 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 				Normal = &p.vertices[j].Normal;
 			}
 			// Note applyFacesShading second parameter is precalculated sqrt
-			// value for speed improvement
-			// Skip it for lightsources and top faces.
+			// value for speed improvement.
+			// Skip shading for lightsources and top faces.
+			// Note many special drawtypes have normals set to 0,0,0 and this
+			// must result in maximum brightness.
 			if (!vc->getBlue()) {
-				if (Normal->Y < -0.5) {
-					applyFacesShading(*vc, 0.447213);
-				} else if (Normal->X > 0.5) {
-					applyFacesShading(*vc, 0.670820);
-				} else if (Normal->X < -0.5) {
-					applyFacesShading(*vc, 0.670820);
-				} else if (Normal->Z > 0.5) {
-					applyFacesShading(*vc, 0.836660);
-				} else if (Normal->Z < -0.5) {
-					applyFacesShading(*vc, 0.836660);
+				if (Normal->Y > 0.924f) {
+					// Top faces, pitch > 67.5 deg, max brightness, no shading
+				} else if (fabs(Normal->Y) < 0.383f) {
+					// Mid faces, pitch -22.5 to 22.5 deg
+					if (fabs(Normal->Z) > 0.5f) {
+						applyFacesShading(*vc, 0.836660f);
+					// Check X to keep a normal of 0,0,0 max brightness
+					} else if (Normal->X != 0.0f) {
+						applyFacesShading(*vc, 0.670820f);
+					}
+				} else if (Normal->Y < -0.924f) {
+					// Base faces, pitch < -67.5 deg
+					applyFacesShading(*vc, 0.447213f);
+				} else if (Normal->Y > 0.0f) {
+					// Upper-mid faces, pitch 22.5 to 67.5 deg
+					if (fabs(Normal->Z) > 0.5f) {
+						applyFacesShading(*vc, 0.921954f);
+					} else {
+						applyFacesShading(*vc, 0.836660f);
+					}
+				} else {
+					// Lower-mid faces, pitch -22.5 to -67.5 deg
+					if (fabs(Normal->X) > 0.5f) {
+						applyFacesShading(*vc, 0.570088f);
+					} else {
+						applyFacesShading(*vc, 0.670820f);
+					}
 				}
 			}
 			if (!m_enable_shaders) {


### PR DESCRIPTION
Fix the very dark upward-facing slopes.
Preserve the visual definition of terrain created with simple slopes,
neighbouring orthogonal slopes and node tops have differing shading
to be distinguishable.
Neighbouring upward tilted faces, vertical faces and downward tilted
faces have differing shading to be distinguishable.
Preserve the behaviour that more Northward/Southward faces tend to be
brighter than more Eastward/Westward faces.

Add 2 new shading levels to do the above, new levels bisect existing
levels.
Preserve the existing shading of the basic cube faces.
Preserve maximum brightness for special drawtypes that have normals
set to 0,0,0.
Order logic to deal with the most common orientations (top, sides)
first and slopes last.
Add comments.
////////////////////////////////////////////////////

Related to #4953 and addresses #4809 
After the method here is decided, the same or similar method should be applied to object meshes in PR #4953 

![screenshot_20161226_124405](https://cloud.githubusercontent.com/assets/3686677/21482239/244bd7fa-cb69-11e6-82ce-87ce5b783eba.png)

^ To test the code i have 2 slopey structures made using the simplyslopes mod, smooth lighting off.
The priority is the simple slopes of the left structure, of lower priority is acceptable shading for the more complex corner slopes in the right structure.

![screenshot_20161226_124837](https://cloud.githubusercontent.com/assets/3686677/21482283/d657cfe4-cb69-11e6-98f7-109037bfe980.png)

^ From the side, there is always a change of shading from top to middle to base nodes, including corner slopes. As you can see structures using 45 degree slopes and corner slopes are now beautifully shaded.

![screenshot_20161226_124909](https://cloud.githubusercontent.com/assets/3686677/21482284/da1882c2-cb69-11e6-9c1d-02fb896d4a43.png)

^ From the top, neighbouring top and simple slopes (not the corner slopes) have differing shading so are distinguishable from each other.

![screenshot_20161226_124923](https://cloud.githubusercontent.com/assets/3686677/21482285/dd0f2b7a-cb69-11e6-9d42-972c05f27214.png)

^ From underneath, neighbouring base and simple slopes (not the corner slopes) have differing shading so are distinguishable from each other.

![screenshot_20161226_084129](https://cloud.githubusercontent.com/assets/3686677/21482450/1416f678-cb6c-11e6-967d-76e14ddcfd27.png)

^ Current code makes some sloping faces too dark.

![screenshot_20161227_150241](https://cloud.githubusercontent.com/assets/3686677/21502143/a82ea55c-cc45-11e6-8ec9-10bfe1a6bc96.png)

![screenshot_20161227_150254](https://cloud.githubusercontent.com/assets/3686677/21502148/ad1a9620-cc45-11e6-9640-6284262697a3.png)

^ Test structures with current code.