### PR TITLE
Map generation limit: Fix checks for block/sector over-limit 

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2064,15 +2064,26 @@ ServerMapSector *ServerMap::createSector(v2s16 p2d)
 		return sector;
 	}
 #endif
+
 	/*
-		Do not create over-limit
+		Do not create over-limit.
+		We are checking for any nodes of the mapblocks of the sector being beyond the limit.
+		A sector is a vertical column of mapblocks, so sectorpos is like a 2D blockpos.
+
+		At the negative limit we are checking for
+			block minimum nodepos < -mapgenlimit.
+		At the positive limit we are checking for
+			block maximum nodepos > mapgenlimit.
+
+		Block minimum nodepos = blockpos * mapblocksize.
+		Block maximum nodepos = (blockpos + 1) * mapblocksize - 1.
 	*/
 	const static u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit"));
-	if(p2d.X < -map_gen_limit / MAP_BLOCKSIZE
-			|| p2d.X >  map_gen_limit / MAP_BLOCKSIZE
-			|| p2d.Y < -map_gen_limit / MAP_BLOCKSIZE
-			|| p2d.Y >  map_gen_limit / MAP_BLOCKSIZE)
+	if (p2d.X * MAP_BLOCKSIZE < -map_gen_limit
+			|| (p2d.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
+			|| p2d.Y * MAP_BLOCKSIZE < -map_gen_limit
+			|| (p2d.Y + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit)
 		throw InvalidPositionException("createSector(): pos. over limit");
 
 	/*

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2078,7 +2078,7 @@ ServerMapSector *ServerMap::createSector(v2s16 p2d)
 		Block minimum nodepos = blockpos * mapblocksize.
 		Block maximum nodepos = (blockpos + 1) * mapblocksize - 1.
 	*/
-	const static u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
+	const u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit"));
 	if (p2d.X * MAP_BLOCKSIZE < -map_gen_limit
 			|| (p2d.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -653,7 +653,7 @@ typedef std::vector<MapBlock*> MapBlockVect;
 
 inline bool objectpos_over_limit(v3f p)
 {
-	const static float map_gen_limit_bs = MYMIN(MAX_MAP_GENERATION_LIMIT,
+	const float map_gen_limit_bs = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit")) * BS;
 	return (p.X < -map_gen_limit_bs
 		|| p.X > map_gen_limit_bs
@@ -676,7 +676,7 @@ inline bool objectpos_over_limit(v3f p)
 */
 inline bool blockpos_over_limit(v3s16 p)
 {
-	const static u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
+	const u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit"));
 	return (p.X * MAP_BLOCKSIZE < -map_gen_limit 
 		|| (p.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -656,23 +656,34 @@ inline bool objectpos_over_limit(v3f p)
 	const static float map_gen_limit_bs = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit")) * BS;
 	return (p.X < -map_gen_limit_bs
-		|| p.X >  map_gen_limit_bs
+		|| p.X > map_gen_limit_bs
 		|| p.Y < -map_gen_limit_bs
-		|| p.Y >  map_gen_limit_bs
+		|| p.Y > map_gen_limit_bs
 		|| p.Z < -map_gen_limit_bs
-		|| p.Z >  map_gen_limit_bs);
+		|| p.Z > map_gen_limit_bs);
 }
 
+/*
+	We are checking for any node of the mapblock being beyond the limit.
+
+	At the negative limit we are checking for
+		block minimum nodepos < -mapgenlimit.
+	At the positive limit we are checking for
+		block maximum nodepos > mapgenlimit.
+
+	Block minimum nodepos = blockpos * mapblocksize.
+	Block maximum nodepos = (blockpos + 1) * mapblocksize - 1.
+*/
 inline bool blockpos_over_limit(v3s16 p)
 {
 	const static u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit"));
-	return (p.X < -map_gen_limit / MAP_BLOCKSIZE
-			|| p.X >  map_gen_limit / MAP_BLOCKSIZE
-			|| p.Y < -map_gen_limit / MAP_BLOCKSIZE
-			|| p.Y >  map_gen_limit / MAP_BLOCKSIZE
-			|| p.Z < -map_gen_limit / MAP_BLOCKSIZE
-			|| p.Z >  map_gen_limit / MAP_BLOCKSIZE);
+	return (p.X * MAP_BLOCKSIZE < -map_gen_limit 
+		|| (p.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
+		|| p.Y * MAP_BLOCKSIZE < -map_gen_limit 
+		|| (p.Y + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
+		|| p.Z * MAP_BLOCKSIZE < -map_gen_limit 
+		|| (p.Z + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit);
 }
 
 /*


### PR DESCRIPTION
Fix the maths that check if any part of a mapblock or sector is over the
set map_generation_limit.
Therefore avoid the loading of any over-limit blocks that were previously
generated when map_generation_limit was larger. The set limit can vary
for a world because it is not yet a per-world mapgen parameter, even when
it is sometimes it will be changed deliberately.
Therefore avoid a player being returned to world centre if they re-enter
a world while being over-limit.

Fix the createSector() crash caused by a mob spawning over-limit in an
over-limit mapblock
/////////////////////////////////////////////////////////
Map generation limit: Cache as 'const' not 'const static' 
//////////////////////////////////////

Addresses #4923 
See https://github.com/minetest/minetest/issues/4923#issuecomment-268429613 and onwards for an explanation of the bugs. 2 of the bugs have now been fixed in Lua.

This commit fixes the loading of over-limit mapblocks that were generated before a reduction in `map_generation_limit`. The maths of `blockpos_over_limit()` were wrong in the positive direction.

This commit also fixes the `*ServerMap::createSector()` crash caused by mobs spawning over-limit, this has the same maths error and is fixed in the same way.

//////////////////////////////

Mapblock minp is at n * 16, maxp is at n * 16 + 15 since mapblock zero is from 0 to 15.

In the positive direction we are checking for
mapblockmaxp > limit
n * 16 + 15 > limit
which is
p.X * blocksize + blocksize - 1 > limit
(p.X + 1) * blocksize - 1 > limit

In the negative direction we are checking for
mapblockminp < -limit
n * 16 < -limit
which is
p.X * blocksize < -limit

All variables are integers so If we work in units of nodes we can avoid division float rounding errors.

Sectors are vertical columns of mapblocks, so we can use the same maths for sector over limit.

//////////////////////////////

Tested.
The mapgen limit should probably not be 'static' but i will fix these in following PR.