### PR TITLE
Update Gettext version in Buildbot

### DIFF
--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -17,7 +17,7 @@ irrlicht_version=1.8.4
 ogg_version=1.3.2
 vorbis_version=1.3.5
 curl_version=7.50.3
-gettext_version=0.14.4
+gettext_version=0.19.8.1
 freetype_version=2.7
 sqlite3_version=3.14.2
 luajit_version=2.1.0-beta2
@@ -40,7 +40,7 @@ cd $builddir
 	-c -O $packagedir/libvorbis-$vorbis_version.zip
 [ -e $packagedir/curl-$curl_version.zip ] || wget http://minetest.kitsunemimi.pw/curl-$curl_version-win32.zip \
 	-c -O $packagedir/curl-$curl_version.zip
-[ -e $packagedir/gettext-$gettext_version.zip ] || wget http://minetest.kitsunemimi.pw/gettext-$gettext_version.zip \
+[ -e $packagedir/gettext-$gettext_version.zip ] || wget http://minetest.kitsunemimi.pw/gettext-$gettext_version-win32.zip \
 	-c -O $packagedir/gettext-$gettext_version.zip
 [ -e $packagedir/freetype2-$freetype_version.zip ] || wget http://minetest.kitsunemimi.pw/freetype2-$freetype_version-win32.zip \
 	-c -O $packagedir/freetype2-$freetype_version.zip
@@ -130,10 +130,9 @@ cmake .. \
 	-DCURL_INCLUDE_DIR=$libdir/libcurl/include \
 	-DCURL_LIBRARY=$libdir/libcurl/lib/libcurl.dll.a \
 	\
-	-DCUSTOM_GETTEXT_PATH=$libdir/gettext \
 	-DGETTEXT_MSGFMT=`which msgfmt` \
-	-DGETTEXT_DLL=$libdir/gettext/bin/libintl3.dll \
-	-DGETTEXT_ICONV_DLL=$libdir/gettext/bin/libiconv2.dll \
+	-DGETTEXT_DLL=$libdir/gettext/bin/libintl-8.dll \
+	-DGETTEXT_ICONV_DLL=$libdir/gettext/bin/libiconv-2.dll \
 	-DGETTEXT_INCLUDE_DIR=$libdir/gettext/include \
 	-DGETTEXT_LIBRARY=$libdir/gettext/lib/libintl.dll.a \
 	\

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -17,7 +17,7 @@ irrlicht_version=1.8.4
 ogg_version=1.3.2
 vorbis_version=1.3.5
 curl_version=7.50.3
-gettext_version=0.18.2
+gettext_version=0.19.8.1
 freetype_version=2.7
 sqlite3_version=3.14.2
 luajit_version=2.1.0-beta2
@@ -131,7 +131,6 @@ cmake .. \
 	-DCURL_INCLUDE_DIR=$libdir/libcurl/include \
 	-DCURL_LIBRARY=$libdir/libcurl/lib/libcurl.dll.a \
 	\
-	-DCUSTOM_GETTEXT_PATH=$libdir/gettext \
 	-DGETTEXT_MSGFMT=`which msgfmt` \
 	-DGETTEXT_DLL=$libdir/gettext/bin/libintl-8.dll \
 	-DGETTEXT_ICONV_DLL=$libdir/gettext/bin/libiconv-2.dll \


### PR DESCRIPTION
the gettext used for 32-bit builds was from 2005...