### PR TITLE
from_table: Fix crash for missing inventory or field

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2747,8 +2747,9 @@ Can be gotten via `minetest.get_meta(pos)`.
 * `get_inventory()`: returns `InvRef`
 * `to_table()`: returns `nil` or `{fields = {...}, inventory = {list1 = {}, ...}}`
 * `from_table(nil or {})`
-    * to clear metadata, use from_table(nil)
+    * Any non-table value will clear the metadata
     * See "Node Metadata"
+    * returns `true` on success
 
 ### `NodeTimerRef`
 Node Timers: a high resolution persistent per-node timer.

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -254,7 +254,7 @@ int NodeMetaRef::l_from_table(lua_State *L)
 	// clear old metadata first
 	ref->m_env->getMap().removeNodeMetadata(ref->m_p);
 
-	if(lua_isnil(L, base)){
+	if (!lua_istable(L, base)) {
 		// No metadata
 		lua_pushboolean(L, true);
 		return 1;
@@ -262,34 +262,42 @@ int NodeMetaRef::l_from_table(lua_State *L)
 
 	// Create new metadata
 	NodeMetadata *meta = getmeta(ref, true);
-	if(meta == NULL){
+	if (meta == NULL) {
 		lua_pushboolean(L, false);
 		return 1;
 	}
+
 	// Set fields
 	lua_getfield(L, base, "fields");
-	int fieldstable = lua_gettop(L);
-	lua_pushnil(L);
-	while(lua_next(L, fieldstable) != 0){
-		// key at index -2 and value at index -1
-		std::string name = lua_tostring(L, -2);
-		size_t cl;
-		const char *cs = lua_tolstring(L, -1, &cl);
-		std::string value(cs, cl);
-		meta->setString(name, value);
-		lua_pop(L, 1); // removes value, keeps key for next iteration
+	if (lua_istable(L, -1)) {
+		int fieldstable = lua_gettop(L);
+		lua_pushnil(L);
+		while (lua_next(L, fieldstable) != 0) {
+			// key at index -2 and value at index -1
+			std::string name = lua_tostring(L, -2);
+			size_t cl;
+			const char *cs = lua_tolstring(L, -1, &cl);
+			meta->setString(name, std::string(cs, cl));
+			lua_pop(L, 1); // Remove value, keep key for next iteration
+		}
+		lua_pop(L, 1);
 	}
+
 	// Set inventory
 	Inventory *inv = meta->getInventory();
 	lua_getfield(L, base, "inventory");
-	int inventorytable = lua_gettop(L);
-	lua_pushnil(L);
-	while(lua_next(L, inventorytable) != 0){
-		// key at index -2 and value at index -1
-		std::string name = lua_tostring(L, -2);
-		read_inventory_list(L, -1, inv, name.c_str(), getServer(L));
-		lua_pop(L, 1); // removes value, keeps key for next iteration
+	if (lua_istable(L, -1)) {
+		int inventorytable = lua_gettop(L);
+		lua_pushnil(L);
+		while (lua_next(L, inventorytable) != 0) {
+			// key at index -2 and value at index -1
+			std::string name = lua_tostring(L, -2);
+			read_inventory_list(L, -1, inv, name.c_str(), getServer(L));
+			lua_pop(L, 1); // Remove value, keep key for next iteration
+		}
+		lua_pop(L, 1);
 	}
+
 	reportMetadataChange(ref);
 	lua_pushboolean(L, true);
 	return 1;


### PR DESCRIPTION
Also changes the behaviour of `meta:from_table()`: Any non-table value will clear the metadata *and the function will return true*.

Fixes: #4960