### PR TITLE
Environment & IGameDef code refactoring

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -117,6 +117,7 @@ LOCAL_SRC_FILES := \
 		jni/src/cavegen.cpp                       \
 		jni/src/chat.cpp                          \
 		jni/src/client.cpp                        \
+		jni/src/clientenvironment.cpp             \
 		jni/src/clientiface.cpp                   \
 		jni/src/clientmap.cpp                     \
 		jni/src/clientmedia.cpp                   \
@@ -210,6 +211,7 @@ LOCAL_SRC_FILES := \
 		jni/src/rollback_interface.cpp            \
 		jni/src/serialization.cpp                 \
 		jni/src/server.cpp                        \
+		jni/src/serverenvironment.cpp             \
 		jni/src/serverlist.cpp                    \
 		jni/src/serverobject.cpp                  \
 		jni/src/shader.cpp                        \

--- a/src/camera.h
+++ b/src/camera.h
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class LocalPlayer;
 struct MapDrawControl;
-class IGameDef;
+class Client;
 class WieldMeshSceneNode;
 
 struct Nametag {
@@ -61,7 +61,7 @@ class Camera
 {
 public:
 	Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
-			IGameDef *gamedef);
+			Client *client);
 	~Camera();
 
 	// Get player scene node.
@@ -189,7 +189,7 @@ private:
 	// draw control
 	MapDrawControl& m_draw_control;
 
-	IGameDef *m_gamedef;
+	Client *m_client;
 	video::IVideoDriver *m_driver;
 
 	// Absolute camera position

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -221,7 +221,7 @@ Client::Client(
 	m_event(event),
 	m_mesh_update_thread(),
 	m_env(
-		new ClientMap(this, this, control,
+		new ClientMap(this, control,
 			device->getSceneManager()->getRootSceneNode(),
 			device->getSceneManager(), 666),
 		device->getSceneManager(),

--- a/src/client.h
+++ b/src/client.h
@@ -402,9 +402,6 @@ public:
 
 	void ProcessData(NetworkPacket *pkt);
 
-	// Returns true if something was received
-	bool AsyncProcessPacket();
-	bool AsyncProcessData();
 	void Send(NetworkPacket* pkt);
 
 	void interact(u8 action, const PointedThing& pointed);
@@ -422,8 +419,9 @@ public:
 	void sendRespawn();
 	void sendReady();
 
-	ClientEnvironment& getEnv()
-	{ return m_env; }
+	ClientEnvironment& getEnv() { return m_env; }
+	ITextureSource   *tsrc()     { return getTextureSource(); }
+	ISoundManager    *sound()    { return getSoundManager(); }
 
 	// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
 	void removeNode(v3s16 p);
@@ -521,14 +519,15 @@ public:
 	virtual IItemDefManager* getItemDefManager();
 	virtual INodeDefManager* getNodeDefManager();
 	virtual ICraftDefManager* getCraftDefManager();
-	virtual ITextureSource* getTextureSource();
+	ITextureSource* getTextureSource();
 	virtual IShaderSource* getShaderSource();
-	virtual scene::ISceneManager* getSceneManager();
+	IShaderSource    *shsrc()    { return getShaderSource(); }
+	scene::ISceneManager* getSceneManager();
 	virtual u16 allocateUnknownNodeId(const std::string &name);
 	virtual ISoundManager* getSoundManager();
 	virtual MtEventManager* getEventManager();
 	virtual ParticleManager* getParticleManager();
-	virtual bool checkLocalPrivilege(const std::string &priv)
+	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
 	virtual scene::IAnimatedMesh* getMesh(const std::string &filename);
 

--- a/src/client.h
+++ b/src/client.h
@@ -34,7 +34,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "localplayer.h"
 #include "hud.h"
 #include "particles.h"
-#include "network/networkpacket.h"
 
 struct MeshMakeData;
 class MapBlockMesh;
@@ -51,6 +50,7 @@ class Database;
 class Mapper;
 struct MinimapMapblock;
 class Camera;
+class NetworkPacket;
 
 struct QueuedMeshUpdate
 {
@@ -420,8 +420,8 @@ public:
 	void sendReady();
 
 	ClientEnvironment& getEnv() { return m_env; }
-	ITextureSource   *tsrc()     { return getTextureSource(); }
-	ISoundManager    *sound()    { return getSoundManager(); }
+	ITextureSource *tsrc() { return getTextureSource(); }
+	ISoundManager *sound() { return getSoundManager(); }
 
 	// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
 	void removeNode(v3s16 p);
@@ -521,7 +521,7 @@ public:
 	virtual ICraftDefManager* getCraftDefManager();
 	ITextureSource* getTextureSource();
 	virtual IShaderSource* getShaderSource();
-	IShaderSource    *shsrc()    { return getShaderSource(); }
+	IShaderSource *shsrc() { return getShaderSource(); }
 	scene::ISceneManager* getSceneManager();
 	virtual u16 allocateUnknownNodeId(const std::string &name);
 	virtual ISoundManager* getSoundManager();

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -30,7 +30,7 @@ class ClientMap;
 class ClientActiveObject;
 class GenericCAO;
 class LocalPlayer;
-class PointedThing;
+struct PointedThing;
 
 /*
 	The client-side environment.

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -30,6 +30,7 @@ class ClientMap;
 class ClientActiveObject;
 class GenericCAO;
 class LocalPlayer;
+class PointedThing;
 
 /*
 	The client-side environment.
@@ -66,15 +67,14 @@ class ClientEnvironment : public Environment
 {
 public:
 	ClientEnvironment(ClientMap *map, scene::ISceneManager *smgr,
-		ITextureSource *texturesource, IGameDef *gamedef,
+		ITextureSource *texturesource, Client *client,
 		IrrlichtDevice *device);
 	~ClientEnvironment();
 
 	Map & getMap();
 	ClientMap & getClientMap();
 
-	IGameDef *getGameDef()
-	{ return m_gamedef; }
+	Client *getGameDef() { return m_client; }
 
 	void step(f32 dtime);
 
@@ -175,7 +175,7 @@ private:
 	LocalPlayer *m_local_player;
 	scene::ISceneManager *m_smgr;
 	ITextureSource *m_texturesource;
-	IGameDef *m_gamedef;
+	Client *m_client;
 	IrrlichtDevice *m_irr;
 	UNORDERED_MAP<u16, ClientActiveObject*> m_active_objects;
 	std::vector<ClientSimpleObject*> m_simple_objects;

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -35,13 +35,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 ClientMap::ClientMap(
 		Client *client,
-		IGameDef *gamedef,
 		MapDrawControl &control,
 		scene::ISceneNode* parent,
 		scene::ISceneManager* mgr,
 		s32 id
 ):
-	Map(dout_client, gamedef),
+	Map(dout_client, client),
 	scene::ISceneNode(parent, mgr, id),
 	m_client(client),
 	m_control(control),
@@ -766,7 +765,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
 	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
-			((Client *) m_gamedef)->checkLocalPrivilege("noclip")) &&
+			m_client->checkLocalPrivilege("noclip")) &&
 			cam_mode == CAMERA_MODE_FIRST)
 	{
 		post_effect_color = video::SColor(255, 0, 0, 0);

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -140,7 +140,7 @@ static bool isOccluded(Map *map, v3s16 p0, v3s16 p1, float step, float stepfac,
 	return false;
 }
 
-void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes, 
+void ClientMap::getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max)
 {
 	v3s16 box_nodes_d = m_control.wanted_range * v3s16(1, 1, 1);
@@ -766,7 +766,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	const ContentFeatures& features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
 	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
-			m_gamedef->checkLocalPrivilege("noclip")) &&
+			((Client *) m_gamedef)->checkLocalPrivilege("noclip")) &&
 			cam_mode == CAMERA_MODE_FIRST)
 	{
 		post_effect_color = video::SColor(255, 0, 0, 0);

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -59,7 +59,7 @@ class ITextureSource;
 
 /*
 	ClientMap
-	
+
 	This is the only map class that is able to render itself on screen.
 */
 
@@ -68,7 +68,6 @@ class ClientMap : public Map, public scene::ISceneNode
 public:
 	ClientMap(
 			Client *client,
-			IGameDef *gamedef,
 			MapDrawControl &control,
 			scene::ISceneNode* parent,
 			scene::ISceneManager* mgr,
@@ -114,13 +113,13 @@ public:
 		driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
 		renderMap(driver, SceneManager->getSceneNodeRenderPass());
 	}
-	
+
 	virtual const aabb3f &getBoundingBox() const
 	{
 		return m_box;
 	}
-	
-	void getBlocksInViewRange(v3s16 cam_pos_nodes, 
+
+	void getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
 	void updateDrawList(video::IVideoDriver* driver);
 	void renderMap(video::IVideoDriver* driver, s32 pass);
@@ -132,20 +131,14 @@ public:
 
 	// For debug printing
 	virtual void PrintInfo(std::ostream &out);
-	
-	// Check if sector was drawn on last render()
-	bool sectorWasDrawn(v2s16 p)
-	{
-		return (m_last_drawn_sectors.find(p) != m_last_drawn_sectors.end());
-	}
 
 	const MapDrawControl & getControl() const { return m_control; }
 	f32 getCameraFov() const { return m_camera_fov; }
 private:
 	Client *m_client;
-	
+
 	aabb3f m_box;
-	
+
 	MapDrawControl &m_control;
 
 	v3f m_camera_position;
@@ -154,7 +147,7 @@ private:
 	v3s16 m_camera_offset;
 
 	std::map<v3s16, MapBlock*> m_drawlist;
-	
+
 	std::set<v2s16> m_last_drawn_sectors;
 
 	bool m_cache_trilinear_filter;

--- a/src/clientobject.cpp
+++ b/src/clientobject.cpp
@@ -20,16 +20,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "clientobject.h"
 #include "debug.h"
 #include "porting.h"
-#include "constants.h"
 
 /*
 	ClientActiveObject
 */
 
-ClientActiveObject::ClientActiveObject(u16 id, IGameDef *gamedef,
+ClientActiveObject::ClientActiveObject(u16 id, Client *client,
 		ClientEnvironment *env):
 	ActiveObject(id),
-	m_gamedef(gamedef),
+	m_client(client),
 	m_env(env)
 {
 }
@@ -40,7 +39,7 @@ ClientActiveObject::~ClientActiveObject()
 }
 
 ClientActiveObject* ClientActiveObject::create(ActiveObjectType type,
-		IGameDef *gamedef, ClientEnvironment *env)
+		Client *client, ClientEnvironment *env)
 {
 	// Find factory function
 	UNORDERED_MAP<u16, Factory>::iterator n = m_types.find(type);
@@ -52,7 +51,7 @@ ClientActiveObject* ClientActiveObject::create(ActiveObjectType type,
 	}
 
 	Factory f = n->second;
-	ClientActiveObject *object = (*f)(gamedef, env);
+	ClientActiveObject *object = (*f)(client, env);
 	return object;
 }
 

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -25,20 +25,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include "util/cpp11_container.h"
 
-/*
-
-Some planning
--------------
-
-* Client receives a network packet with information of added objects
-  in it
-* Client supplies the information to its ClientEnvironment
-* The environment adds the specified objects to itself
-
-*/
-
 class ClientEnvironment;
 class ITextureSource;
+class Client;
 class IGameDef;
 class LocalPlayer;
 struct ItemStack;
@@ -47,7 +36,7 @@ class WieldMeshSceneNode;
 class ClientActiveObject : public ActiveObject
 {
 public:
-	ClientActiveObject(u16 id, IGameDef *gamedef, ClientEnvironment *env);
+	ClientActiveObject(u16 id, Client *client, ClientEnvironment *env);
 	virtual ~ClientActiveObject();
 
 	virtual void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
@@ -89,7 +78,7 @@ public:
 	virtual void initialize(const std::string &data){}
 
 	// Create a certain type of ClientActiveObject
-	static ClientActiveObject* create(ActiveObjectType type, IGameDef *gamedef,
+	static ClientActiveObject* create(ActiveObjectType type, Client *client,
 			ClientEnvironment *env);
 
 	// If returns true, punch will not be sent to the server
@@ -99,9 +88,9 @@ public:
 
 protected:
 	// Used for creating objects based on type
-	typedef ClientActiveObject* (*Factory)(IGameDef *gamedef, ClientEnvironment *env);
+	typedef ClientActiveObject* (*Factory)(Client *client, ClientEnvironment *env);
 	static void registerType(u16 type, Factory f);
-	IGameDef *m_gamedef;
+	Client *m_client;
 	ClientEnvironment *m_env;
 private:
 	// Used for creating objects based on type

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -22,9 +22,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "nodedef.h"
 #include "gamedef.h"
+#ifndef SERVER
 #include "clientenvironment.h"
+#endif
 #include "serverenvironment.h"
 #include "serverobject.h"
+#include "util/timetaker.h"
 #include "profiler.h"
 
 // float error is 10 - 9.96875 = 0.03125

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "itemgroup.h"
 
 class Camera;
+class Client;
 struct Nametag;
 
 /*
@@ -68,7 +69,7 @@ private:
 	//
 	scene::ISceneManager *m_smgr;
 	IrrlichtDevice *m_irr;
-	IGameDef *m_gamedef;
+	Client *m_client;
 	aabb3f m_selection_box;
 	scene::IMeshSceneNode *m_meshnode;
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode;
@@ -109,13 +110,13 @@ private:
 	std::vector<u16> m_children;
 
 public:
-	GenericCAO(IGameDef *gamedef, ClientEnvironment *env);
+	GenericCAO(Client *client, ClientEnvironment *env);
 
 	~GenericCAO();
 
-	static ClientActiveObject* create(IGameDef *gamedef, ClientEnvironment *env)
+	static ClientActiveObject* create(Client *client, ClientEnvironment *env)
 	{
-		return new GenericCAO(gamedef, env);
+		return new GenericCAO(client, env);
 	}
 
 	inline ActiveObjectType getType() const

--- a/src/content_cso.cpp
+++ b/src/content_cso.cpp
@@ -21,19 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IBillboardSceneNode.h>
 #include "client/tile.h"
 #include "clientenvironment.h"
-#include "gamedef.h"
+#include "client.h"
 #include "map.h"
-
-/*
-static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
-		float txs, float tys, int col, int row)
-{
-	video::SMaterial& material = bill->getMaterial(0);
-	core::matrix4& matrix = material.getTextureMatrix(0);
-	matrix.setTextureTranslate(txs*col, tys*row);
-	matrix.setTextureScale(txs, tys);
-}
-*/
 
 class SmokePuffCSO: public ClientSimpleObject
 {

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/tile.h"
 #include "mesh.h"
 #include <IMeshManipulator.h>
-#include "gamedef.h"
+#include "client.h"
 #include "log.h"
 #include "noise.h"
 
@@ -188,8 +188,8 @@ static inline int NeighborToIndex(const v3s16 &pos)
 void mapblock_mesh_generate_special(MeshMakeData *data,
 		MeshCollector &collector)
 {
-	INodeDefManager *nodedef = data->m_gamedef->ndef();
-	scene::ISceneManager* smgr = data->m_gamedef->getSceneManager();
+	INodeDefManager *nodedef = data->m_client->ndef();
+	scene::ISceneManager* smgr = data->m_client->getSceneManager();
 	scene::IMeshManipulator* meshmanip = smgr->getMeshManipulator();
 
 	// 0ms

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -273,7 +273,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			v3f p_pos = m_base_position;
 			v3f p_velocity = m_velocity;
 			v3f p_acceleration = m_acceleration;
-			moveresult = collisionMoveSimple(m_env,m_env->getGameDef(),
+			moveresult = collisionMoveSimple(m_env, m_env->getGameDef(),
 					pos_max_d, box, m_prop.stepheight, dtime,
 					&p_pos, &p_velocity, p_acceleration,
 					this, m_prop.collideWithObjects);
@@ -945,7 +945,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// get head position
 		v3s16 p = floatToInt(m_base_position + v3f(0, BS * 1.6, 0), BS);
 		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = ((Server*) m_env->getGameDef())->ndef()->get(n);
+		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
 		// If node generates drown
 		if (c.drowning > 0) {
 			if (m_hp > 0 && m_breath > 0)
@@ -954,7 +954,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			// No more breath, damage player
 			if (m_breath == 0) {
 				setHP(m_hp - c.drowning);
-				((Server*) m_env->getGameDef())->SendPlayerHPOrDie(this);
+				m_env->getGameDef()->SendPlayerHPOrDie(this);
 			}
 		}
 	}
@@ -963,7 +963,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// get head position
 		v3s16 p = floatToInt(m_base_position + v3f(0, BS * 1.6, 0), BS);
 		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = ((Server*) m_env->getGameDef())->ndef()->get(n);
+		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
 		// If player is alive & no drowning, breath
 		if (m_hp > 0 && c.drowning == 0)
 			setBreath(m_breath + 1);
@@ -985,7 +985,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		m_attachment_position = v3f(0,0,0);
 		m_attachment_rotation = v3f(0,0,0);
 		setBasePosition(m_last_good_position);
-		((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
+		m_env->getGameDef()->SendMovePlayer(m_peer_id);
 	}
 
 	//dstream<<"PlayerSAO::step: dtime: "<<dtime<<std::endl;
@@ -1107,7 +1107,7 @@ void PlayerSAO::setPos(const v3f &pos)
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
 	m_last_good_position = pos;
-	((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
+	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
 void PlayerSAO::moveTo(v3f pos, bool continuous)
@@ -1118,7 +1118,7 @@ void PlayerSAO::moveTo(v3f pos, bool continuous)
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
 	m_last_good_position = pos;
-	((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
+	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
 void PlayerSAO::setYaw(const float yaw)
@@ -1148,7 +1148,7 @@ void PlayerSAO::setWantedRange(const s16 range)
 void PlayerSAO::setYawAndSend(const float yaw)
 {
 	setYaw(yaw);
-	((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
+	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
 void PlayerSAO::setPitch(const float pitch)
@@ -1162,7 +1162,7 @@ void PlayerSAO::setPitch(const float pitch)
 void PlayerSAO::setPitchAndSend(const float pitch)
 {
 	setPitch(pitch);
-	((Server*)m_env->getGameDef())->SendMovePlayer(m_peer_id);
+	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
 int PlayerSAO::punch(v3f dir,
@@ -1273,7 +1273,7 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 	m_breath = MYMIN(breath, PLAYER_MAX_BREATH);
 
 	if (send)
-		((Server *) m_env->getGameDef())->SendPlayerBreath(this);
+		m_env->getGameDef()->SendPlayerBreath(this);
 }
 
 void PlayerSAO::setArmorGroups(const ItemGroupList &armor_groups)

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -89,13 +89,13 @@ private:
 //// EmergeManager
 ////
 
-EmergeManager::EmergeManager(IGameDef *gamedef)
+EmergeManager::EmergeManager(Server *server)
 {
-	this->ndef      = gamedef->getNodeDefManager();
-	this->biomemgr  = new BiomeManager(gamedef);
-	this->oremgr    = new OreManager(gamedef);
-	this->decomgr   = new DecorationManager(gamedef);
-	this->schemmgr  = new SchematicManager(gamedef);
+	this->ndef      = server->getNodeDefManager();
+	this->biomemgr  = new BiomeManager(server);
+	this->oremgr    = new OreManager(server);
+	this->decomgr   = new DecorationManager(server);
+	this->schemmgr  = new SchematicManager(server);
 	this->gen_notify_on = 0;
 
 	// Note that accesses to this variable are not synchronized.
@@ -128,7 +128,7 @@ EmergeManager::EmergeManager(IGameDef *gamedef)
 		m_qlimit_generate = 1;
 
 	for (s16 i = 0; i < nthreads; i++)
-		m_threads.push_back(new EmergeThread((Server *)gamedef, i));
+		m_threads.push_back(new EmergeThread(server, i));
 
 	infostream << "EmergeManager: using " << nthreads << " threads" << std::endl;
 }

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -42,6 +42,7 @@ class BiomeManager;
 class OreManager;
 class DecorationManager;
 class SchematicManager;
+class Server;
 
 // Structure containing inputs/outputs for chunk generation
 struct BlockMakeData {
@@ -115,7 +116,7 @@ public:
 	SchematicManager *schemmgr;
 
 	// Methods
-	EmergeManager(IGameDef *gamedef);
+	EmergeManager(Server *server);
 	~EmergeManager();
 
 	bool initMapgens(MapgenParams *mgparams);

--- a/src/environment.h
+++ b/src/environment.h
@@ -42,13 +42,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "threading/atomic.h"
 #include "network/networkprotocol.h" // for AccessDeniedCode
 
-class ITextureSource;
-class IGameDef;
-class Map;
-class GameScripting;
-class Player;
-class PointedThing;
-
 class Environment
 {
 public:

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -53,47 +53,22 @@ public:
 	virtual INodeDefManager* getNodeDefManager()=0;
 	virtual ICraftDefManager* getCraftDefManager()=0;
 
-	// This is always thread-safe, but referencing the irrlicht texture
-	// pointers in other threads than main thread will make things explode.
-	virtual ITextureSource* getTextureSource()=0;
-
-	virtual IShaderSource* getShaderSource()=0;
-
 	// Used for keeping track of names/ids of unknown nodes
 	virtual u16 allocateUnknownNodeId(const std::string &name)=0;
 
-	// Only usable on the client
-	virtual ISoundManager* getSoundManager()=0;
 	virtual MtEventManager* getEventManager()=0;
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename)
-	{ return NULL; }
-	virtual scene::ISceneManager* getSceneManager()=0;
-
-	virtual Camera* getCamera()
-	{ return NULL; }
-	virtual void setCamera(Camera *camera) {}
 
 	// Only usable on the server, and NOT thread-safe. It is usable from the
 	// environment thread.
-	virtual IRollbackManager* getRollbackManager(){return NULL;}
-
-	// Only usable on the server. Thread safe if not written while running threads.
-	virtual EmergeManager *getEmergeManager() { return NULL; }
-
-	// Used on the client
-	virtual bool checkLocalPrivilege(const std::string &priv)
-	{ return false; }
+	virtual IRollbackManager* getRollbackManager() { return NULL; }
 
 	// Shorthands
 	IItemDefManager  *idef()     { return getItemDefManager(); }
 	INodeDefManager  *ndef()     { return getNodeDefManager(); }
 	ICraftDefManager *cdef()     { return getCraftDefManager(); }
-	ITextureSource   *tsrc()     { return getTextureSource(); }
-	ISoundManager    *sound()    { return getSoundManager(); }
-	IShaderSource    *shsrc()    { return getShaderSource(); }
+
 	MtEventManager   *event()    { return getEventManager(); }
 	IRollbackManager *rollback() { return getRollbackManager();}
-	EmergeManager    *emerge()   { return getEmergeManager(); }
 };
 
 #endif

--- a/src/guiEngine.cpp
+++ b/src/guiEngine.cpp
@@ -194,11 +194,9 @@ GUIEngine::GUIEngine(	irr::IrrlichtDevice* dev,
 			-1,
 			m_menumanager,
 			NULL /* &client */,
-			NULL /* gamedef */,
 			m_texture_source,
 			m_formspecgui,
 			m_buttonhandler,
-			NULL,
 			false);
 
 	m_menu->allowClose(false);

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -34,7 +34,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/enriched_string.h"
 
-class IGameDef;
 class InventoryManager;
 class ISimpleTextureSource;
 class Client;
@@ -289,12 +288,10 @@ public:
 			JoystickController *joystick,
 			gui::IGUIElement* parent, s32 id,
 			IMenuManager *menumgr,
-			InventoryManager *invmgr,
-			IGameDef *gamedef,
+			Client *client,
 			ISimpleTextureSource *tsrc,
 			IFormSource* fs_src,
 			TextDest* txt_dst,
-			Client* client,
 			bool remap_dbl_click = true);
 
 	~GUIFormSpecMenu();
@@ -384,7 +381,6 @@ protected:
 
 	irr::IrrlichtDevice* m_device;
 	InventoryManager *m_invmgr;
-	IGameDef *m_gamedef;
 	ISimpleTextureSource *m_tsrc;
 	Client *m_client;
 

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -22,10 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "hud.h"
 #include "settings.h"
 #include "util/numeric.h"
-#include "util/string.h"
 #include "log.h"
-#include "gamedef.h"
-#include "itemdef.h"
+#include "client.h"
 #include "inventory.h"
 #include "client/tile.h"
 #include "localplayer.h"
@@ -41,13 +39,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
-		gui::IGUIEnvironment* guienv, IGameDef *gamedef, LocalPlayer *player,
+		gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory)
 {
 	this->driver      = driver;
 	this->smgr        = smgr;
 	this->guienv      = guienv;
-	this->gamedef     = gamedef;
+	this->client      = client;
 	this->player      = player;
 	this->inventory   = inventory;
 
@@ -61,7 +59,7 @@ Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
 	for (unsigned int i = 0; i < 4; i++)
 		hbar_colors[i] = video::SColor(255, 255, 255, 255);
 
-	tsrc = gamedef->getTextureSource();
+	tsrc = client->getTextureSource();
 
 	v3f crosshair_color = g_settings->getV3F("crosshair_color");
 	u32 cross_r = rangelim(myround(crosshair_color.X), 0, 255);
@@ -92,7 +90,7 @@ Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
 	m_selection_material.Lighting = false;
 
 	if (g_settings->getBool("enable_shaders")) {
-		IShaderSource *shdrsrc = gamedef->getShaderSource();
+		IShaderSource *shdrsrc = client->getShaderSource();
 		u16 shader_id = shdrsrc->getShader(
 			mode == "halo" ? "selection_shader" : "default_shader", 1, 1);
 		m_selection_material.MaterialType = shdrsrc->getShaderInfo(shader_id).material;
@@ -193,7 +191,7 @@ void Hud::drawItem(const ItemStack &item, const core::rect<s32>& rect,
 		if (!use_hotbar_image)
 			driver->draw2DRectangle(bgcolor2, rect, NULL);
 		drawItemStack(driver, g_fontengine->getFont(), item, rect, NULL,
-			gamedef, selected ? IT_ROT_SELECTED : IT_ROT_NONE);
+			client, selected ? IT_ROT_SELECTED : IT_ROT_NONE);
 	}
 
 //NOTE: selectitem = 0 -> no selected; selectitem 1-based
@@ -629,7 +627,7 @@ void drawItemStack(video::IVideoDriver *driver,
 		const ItemStack &item,
 		const core::rect<s32> &rect,
 		const core::rect<s32> *clip,
-		IGameDef *gamedef,
+		Client *client,
 		ItemRotationKind rotation_kind)
 {
 	static MeshTimeInfo rotation_time_infos[IT_ROT_NONE];
@@ -643,8 +641,8 @@ void drawItemStack(video::IVideoDriver *driver,
 		return;
 	}
 
-	const ItemDefinition &def = item.getDefinition(gamedef->idef());
-	scene::IMesh* mesh = gamedef->idef()->getWieldMesh(def.name, gamedef);
+	const ItemDefinition &def = item.getDefinition(client->idef());
+	scene::IMesh* mesh = client->idef()->getWieldMesh(def.name, client);
 
 	if (mesh) {
 		driver->clearZBuffer();

--- a/src/hud.h
+++ b/src/hud.h
@@ -95,7 +95,7 @@ struct HudElement {
 #include <IGUIFont.h>
 #include "irr_aabb3d.h"
 
-class IGameDef;
+class Client;
 class ITextureSource;
 class Inventory;
 class InventoryList;
@@ -107,7 +107,7 @@ public:
 	video::IVideoDriver *driver;
 	scene::ISceneManager* smgr;
 	gui::IGUIEnvironment *guienv;
-	IGameDef *gamedef;
+	Client *client;
 	LocalPlayer *player;
 	Inventory *inventory;
 	ITextureSource *tsrc;
@@ -121,7 +121,7 @@ public:
 	bool use_hotbar_selected_image;
 
 	Hud(video::IVideoDriver *driver,scene::ISceneManager* smgr,
-		gui::IGUIEnvironment* guienv, IGameDef *gamedef, LocalPlayer *player,
+		gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory);
 	~Hud();
 
@@ -190,7 +190,7 @@ void drawItemStack(video::IVideoDriver *driver,
 		const ItemStack &item,
 		const core::rect<s32> &rect,
 		const core::rect<s32> *clip,
-		IGameDef *gamedef,
+		Client *client,
 		ItemRotationKind rotation_kind);
 
 #endif

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "itemdef.h"
 
-#include "gamedef.h"
 #include "nodedef.h"
 #include "tool.h"
 #include "inventory.h"
@@ -29,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mesh.h"
 #include "wieldmesh.h"
 #include "client/tile.h"
+#include "client.h"
 #endif
 #include "log.h"
 #include "settings.h"
@@ -317,7 +317,7 @@ public:
 #ifndef SERVER
 public:
 	ClientCached* createClientCachedDirect(const std::string &name,
-			IGameDef *gamedef) const
+			Client *client) const
 	{
 		infostream<<"Lazily creating item texture and mesh for \""
 				<<name<<"\""<<std::endl;
@@ -331,7 +331,7 @@ public:
 		if(cc)
 			return cc;
 
-		ITextureSource *tsrc = gamedef->getTextureSource();
+		ITextureSource *tsrc = client->getTextureSource();
 		const ItemDefinition &def = get(name);
 
 		// Create new ClientCached
@@ -345,7 +345,7 @@ public:
 		ItemStack item = ItemStack();
 		item.name = def.name;
 
-		scene::IMesh *mesh = getItemMesh(gamedef, item);
+		scene::IMesh *mesh = getItemMesh(client, item);
 		cc->wield_mesh = mesh;
 
 		// Put in cache
@@ -354,7 +354,7 @@ public:
 		return cc;
 	}
 	ClientCached* getClientCached(const std::string &name,
-			IGameDef *gamedef) const
+			Client *client) const
 	{
 		ClientCached *cc = NULL;
 		m_clientcached.get(name, &cc);
@@ -363,7 +363,7 @@ public:
 
 		if(thr_is_current_thread(m_main_thread))
 		{
-			return createClientCachedDirect(name, gamedef);
+			return createClientCachedDirect(name, client);
 		}
 		else
 		{
@@ -392,18 +392,18 @@ public:
 	}
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			IGameDef *gamedef) const
+			Client *client) const
 	{
-		ClientCached *cc = getClientCached(name, gamedef);
+		ClientCached *cc = getClientCached(name, client);
 		if(!cc)
 			return NULL;
 		return cc->inventory_texture;
 	}
 	// Get item wield mesh
 	virtual scene::IMesh* getWieldMesh(const std::string &name,
-			IGameDef *gamedef) const
+			Client *client) const
 	{
-		ClientCached *cc = getClientCached(name, gamedef);
+		ClientCached *cc = getClientCached(name, client);
 		if(!cc)
 			return NULL;
 		return cc->wield_mesh;
@@ -543,7 +543,7 @@ public:
 					request = m_get_clientcached_queue.pop();
 
 			m_get_clientcached_queue.pushResult(request,
-					createClientCachedDirect(request.key, gamedef));
+					createClientCachedDirect(request.key, (Client *)gamedef));
 		}
 #endif
 	}

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "itemgroup.h"
 #include "sound.h"
 class IGameDef;
+class Client;
 struct ToolCapabilities;
 
 /*
@@ -107,10 +108,10 @@ public:
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			IGameDef *gamedef) const=0;
+			Client *client) const=0;
 	// Get item wield mesh
 	virtual scene::IMesh* getWieldMesh(const std::string &name,
-		IGameDef *gamedef) const=0;
+		Client *client) const=0;
 #endif
 
 	virtual void serialize(std::ostream &os, u16 protocol_version)=0;
@@ -133,10 +134,10 @@ public:
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			IGameDef *gamedef) const=0;
+			Client *client) const=0;
 	// Get item wield mesh
 	virtual scene::IMesh* getWieldMesh(const std::string &name,
-		IGameDef *gamedef) const=0;
+		Client *client) const=0;
 #endif
 
 	// Remove all registered item and node definitions and aliases

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -35,7 +35,7 @@ enum LocalPlayerAnimations {NO_ANIM, WALK_ANIM, DIG_ANIM, WD_ANIM};  // no local
 class LocalPlayer : public Player
 {
 public:
-	LocalPlayer(Client *gamedef, const char *name);
+	LocalPlayer(Client *client, const char *name);
 	virtual ~LocalPlayer();
 
 	ClientActiveObject *parent;
@@ -162,7 +162,7 @@ private:
 	aabb3f m_collisionbox;
 
 	GenericCAO* m_cao;
-	Client *m_gamedef;
+	Client *m_client;
 };
 
 #endif

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/cpp11_container.h"
 #include <map>
 
-class IGameDef;
+class Client;
 class IShaderSource;
 
 /*
@@ -45,11 +45,11 @@ struct MeshMakeData
 	bool m_smooth_lighting;
 	bool m_show_hud;
 
-	IGameDef *m_gamedef;
+	Client *m_client;
 	bool m_use_shaders;
 	bool m_use_tangent_vertices;
 
-	MeshMakeData(IGameDef *gamedef, bool use_shaders,
+	MeshMakeData(Client *client, bool use_shaders,
 			bool use_tangent_vertices = false);
 
 	/*
@@ -128,7 +128,7 @@ public:
 private:
 	scene::IMesh *m_mesh;
 	MinimapMapblock *m_minimap_mapblock;
-	IGameDef *m_gamedef;
+	Client *m_client;
 	video::IVideoDriver *m_driver;
 	ITextureSource *m_tsrc;
 	IShaderSource *m_shdrsrc;

--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -20,10 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mg_biome.h"
 #include "mg_decoration.h"
 #include "emerge.h"
-#include "gamedef.h"
+#include "server.h"
 #include "nodedef.h"
 #include "map.h" //for MMVManip
-#include "log.h"
 #include "util/numeric.h"
 #include "util/mathconstants.h"
 #include "porting.h"
@@ -33,10 +32,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 ///////////////////////////////////////////////////////////////////////////////
 
 
-BiomeManager::BiomeManager(IGameDef *gamedef) :
-	ObjDefManager(gamedef, OBJDEF_BIOME)
+BiomeManager::BiomeManager(Server *server) :
+	ObjDefManager(server, OBJDEF_BIOME)
 {
-	m_gamedef = gamedef;
+	m_server = server;
 
 	// Create default biome to be used in case none exist
 	Biome *b = new Biome;
@@ -73,7 +72,7 @@ BiomeManager::~BiomeManager()
 
 void BiomeManager::clear()
 {
-	EmergeManager *emerge = m_gamedef->getEmergeManager();
+	EmergeManager *emerge = m_server->getEmergeManager();
 
 	// Remove all dangling references in Decorations
 	DecorationManager *decomgr = emerge->decomgr;

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "noise.h"
 
+class Server;
 class Settings;
 class BiomeManager;
 
@@ -186,7 +187,7 @@ private:
 
 class BiomeManager : public ObjDefManager {
 public:
-	BiomeManager(IGameDef *gamedef);
+	BiomeManager(Server *server);
 	virtual ~BiomeManager();
 
 	const char *getObjectTitle() const
@@ -223,7 +224,7 @@ public:
 	virtual void clear();
 
 private:
-	IGameDef *m_gamedef;
+	Server *m_server;
 
 };
 

--- a/src/mg_schematic.cpp
+++ b/src/mg_schematic.cpp
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <fstream>
 #include <typeinfo>
 #include "mg_schematic.h"
-#include "gamedef.h"
+#include "server.h"
 #include "mapgen.h"
 #include "emerge.h"
 #include "map.h"
@@ -34,16 +34,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 ///////////////////////////////////////////////////////////////////////////////
 
 
-SchematicManager::SchematicManager(IGameDef *gamedef) :
-	ObjDefManager(gamedef, OBJDEF_SCHEMATIC)
+SchematicManager::SchematicManager(Server *server) :
+	ObjDefManager(server, OBJDEF_SCHEMATIC)
 {
-	m_gamedef = gamedef;
+	m_server = server;
 }
 
 
 void SchematicManager::clear()
 {
-	EmergeManager *emerge = m_gamedef->getEmergeManager();
+	EmergeManager *emerge = m_server->getEmergeManager();
 
 	// Remove all dangling references in Decorations
 	DecorationManager *decomgr = emerge->decomgr;

--- a/src/mg_schematic.h
+++ b/src/mg_schematic.h
@@ -29,7 +29,7 @@ class Mapgen;
 class MMVManip;
 class PseudoRandom;
 class NodeResolver;
-class IGameDef;
+class Server;
 
 /*
 	Minetest Schematic File Format
@@ -123,7 +123,7 @@ public:
 
 class SchematicManager : public ObjDefManager {
 public:
-	SchematicManager(IGameDef *gamedef);
+	SchematicManager(Server *server);
 	virtual ~SchematicManager() {}
 
 	virtual void clear();
@@ -139,7 +139,7 @@ public:
 	}
 
 private:
-	IGameDef *m_gamedef;
+	Server *m_server;
 };
 
 void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERVER
 #include "client/tile.h"
 #include "mesh.h"
+#include "client.h"
 #include <IMeshManipulator.h>
 #endif
 #include "log.h"
@@ -572,8 +573,7 @@ void ContentFeatures::fillTileAttribs(ITextureSource *tsrc, TileSpec *tile,
 
 #ifndef SERVER
 void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc,
-	scene::ISceneManager *smgr, scene::IMeshManipulator *meshmanip,
-	IGameDef *gamedef, const TextureSettings &tsettings)
+	scene::IMeshManipulator *meshmanip, Client *client, const TextureSettings &tsettings)
 {
 	// minimap pixel color - the average color of a texture
 	if (tsettings.enable_minimap && tiledef[0].name != "")
@@ -709,7 +709,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	if ((drawtype == NDT_MESH) && (mesh != "")) {
 		// Meshnode drawtype
 		// Read the mesh and apply scale
-		mesh_ptr[0] = gamedef->getMesh(mesh);
+		mesh_ptr[0] = client->getMesh(mesh);
 		if (mesh_ptr[0]){
 			v3f scale = v3f(1.0, 1.0, 1.0) * BS * visual_scale;
 			scaleMesh(mesh_ptr[0], scale);
@@ -1316,9 +1316,11 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 #ifndef SERVER
 	infostream << "CNodeDefManager::updateTextures(): Updating "
 		"textures in node definitions" << std::endl;
-	ITextureSource *tsrc = gamedef->tsrc();
-	IShaderSource *shdsrc = gamedef->getShaderSource();
-	scene::ISceneManager* smgr = gamedef->getSceneManager();
+
+	Client *client = (Client *)gamedef;
+	ITextureSource *tsrc = client->tsrc();
+	IShaderSource *shdsrc = client->getShaderSource();
+	scene::ISceneManager* smgr = client->getSceneManager();
 	scene::IMeshManipulator* meshmanip = smgr->getMeshManipulator();
 	TextureSettings tsettings;
 	tsettings.readSettings();
@@ -1326,7 +1328,7 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 	u32 size = m_content_features.size();
 
 	for (u32 i = 0; i < size; i++) {
-		m_content_features[i].updateTextures(tsrc, shdsrc, smgr, meshmanip, gamedef, tsettings);
+		m_content_features[i].updateTextures(tsrc, shdsrc, meshmanip, client, tsettings);
 		progress_callback(progress_callback_args, i, size);
 	}
 #endif

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERVER
 #include "client/tile.h"
 #include "shader.h"
+class Client;
 #endif
 #include "itemgroup.h"
 #include "sound.h" // SimpleSoundSpec
@@ -322,8 +323,7 @@ struct ContentFeatures
 		u32 shader_id, bool use_normal_texture, bool backface_culling,
 		u8 alpha, u8 material_type);
 	void updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc,
-		scene::ISceneManager *smgr, scene::IMeshManipulator *meshmanip,
-		IGameDef *gamedef, const TextureSettings &tsettings);
+		scene::IMeshManipulator *meshmanip, Client *client, const TextureSettings &tsettings);
 #endif
 };
 

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -18,11 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "particles.h"
-#include "constants.h"
-#include "debug.h"
-#include "settings.h"
-#include "client/tile.h"
-#include "gamedef.h"
+#include "client.h"
 #include "collision.h"
 #include <stdlib.h>
 #include "util/numeric.h"
@@ -452,7 +448,7 @@ void ParticleManager::clearAll ()
 	}
 }
 
-void ParticleManager::handleParticleEvent(ClientEvent *event, IGameDef *gamedef,
+void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 		scene::ISceneManager* smgr, LocalPlayer *player)
 {
 	switch (event->type) {
@@ -477,9 +473,9 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, IGameDef *gamedef,
 			}
 
 			video::ITexture *texture =
-				gamedef->tsrc()->getTextureForMesh(*(event->add_particlespawner.texture));
+				client->tsrc()->getTextureForMesh(*(event->add_particlespawner.texture));
 
-			ParticleSpawner* toadd = new ParticleSpawner(gamedef, smgr, player,
+			ParticleSpawner* toadd = new ParticleSpawner(client, smgr, player,
 					event->add_particlespawner.amount,
 					event->add_particlespawner.spawntime,
 					*event->add_particlespawner.minpos,
@@ -520,9 +516,9 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, IGameDef *gamedef,
 		}
 		case CE_SPAWN_PARTICLE: {
 			video::ITexture *texture =
-				gamedef->tsrc()->getTextureForMesh(*(event->spawn_particle.texture));
+				client->tsrc()->getTextureForMesh(*(event->spawn_particle.texture));
 
-			Particle* toadd = new Particle(gamedef, smgr, player, m_env,
+			Particle* toadd = new Particle(client, smgr, player, m_env,
 					*event->spawn_particle.pos,
 					*event->spawn_particle.vel,
 					*event->spawn_particle.acc,

--- a/src/particles.h
+++ b/src/particles.h
@@ -170,7 +170,7 @@ public:
 
 	void step (float dtime);
 
-	void handleParticleEvent(ClientEvent *event,IGameDef *gamedef,
+	void handleParticleEvent(ClientEvent *event, Client *client,
 			scene::ISceneManager* smgr, LocalPlayer *player);
 
 	void addDiggingParticles(IGameDef* gamedef, scene::ISceneManager* smgr,

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -24,12 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "pathfinder.h"
 #include "serverenvironment.h"
-#include "gamedef.h"
+#include "server.h"
 #include "nodedef.h"
-#include "map.h"
-#include "log.h"
-#include "irr_aabb3d.h"
-#include "util/basic_macros.h"
 
 //#define PATHFINDER_DEBUG
 //#define PATHFINDER_CALC_TIME

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -20,14 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_nodemeta.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_inventory.h"
-#include "common/c_converter.h"
 #include "common/c_content.h"
 #include "serverenvironment.h"
 #include "map.h"
-#include "gamedef.h"
-#include "nodemetadata.h"
-
-
+#include "server.h"
 
 /*
 	NodeMetaRef

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -50,7 +50,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content_abm.h"
 #include "content_sao.h"
 #include "mods.h"
-#include "sound.h" // dummySoundManager
 #include "event_manager.h"
 #include "serverlist.h"
 #include "util/string.h"
@@ -3310,27 +3309,10 @@ ICraftDefManager *Server::getCraftDefManager()
 {
 	return m_craftdef;
 }
-ITextureSource *Server::getTextureSource()
-{
-	return NULL;
-}
-IShaderSource *Server::getShaderSource()
-{
-	return NULL;
-}
-scene::ISceneManager *Server::getSceneManager()
-{
-	return NULL;
-}
 
 u16 Server::allocateUnknownNodeId(const std::string &name)
 {
 	return m_nodedef->allocateDummy(name);
-}
-
-ISoundManager *Server::getSoundManager()
-{
-	return &dummySoundManager;
 }
 
 MtEventManager *Server::getEventManager()

--- a/src/server.h
+++ b/src/server.h
@@ -283,13 +283,9 @@ public:
 	virtual IItemDefManager* getItemDefManager();
 	virtual INodeDefManager* getNodeDefManager();
 	virtual ICraftDefManager* getCraftDefManager();
-	virtual ITextureSource* getTextureSource();
-	virtual IShaderSource* getShaderSource();
 	virtual u16 allocateUnknownNodeId(const std::string &name);
-	virtual ISoundManager* getSoundManager();
 	virtual MtEventManager* getEventManager();
-	virtual scene::ISceneManager* getSceneManager();
-	virtual IRollbackManager *getRollbackManager() { return m_rollback; }
+	IRollbackManager *getRollbackManager() { return m_rollback; }
 	virtual EmergeManager *getEmergeManager() { return m_emerge; }
 
 	IWritableItemDefManager* getWritableItemDefManager();

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -29,6 +29,8 @@ class PlayerSAO;
 class ServerEnvironment;
 class ActiveBlockModifier;
 class ServerActiveObject;
+class Server;
+class GameScripting;
 
 /*
 	{Active, Loading} block modifier interface.
@@ -190,7 +192,7 @@ class ServerEnvironment : public Environment
 {
 public:
 	ServerEnvironment(ServerMap *map, GameScripting *scriptIface,
-		IGameDef *gamedef, const std::string &path_world);
+		Server *server, const std::string &path_world);
 	~ServerEnvironment();
 
 	Map & getMap();
@@ -201,8 +203,8 @@ public:
 	GameScripting* getScriptIface()
 	{ return m_script; }
 
-	IGameDef *getGameDef()
-	{ return m_gamedef; }
+	Server *getGameDef()
+	{ return m_server; }
 
 	float getSendRecommendedInterval()
 	{ return m_recommended_send_interval; }
@@ -377,8 +379,8 @@ private:
 	ServerMap *m_map;
 	// Lua state
 	GameScripting* m_script;
-	// Game definition
-	IGameDef *m_gamedef;
+	// Server definition
+	Server *m_server;
 	// World path
 	const std::string m_path_world;
 	// Active object list

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "wieldmesh.h"
 #include "inventory.h"
-#include "gamedef.h"
+#include "client.h"
 #include "itemdef.h"
 #include "nodedef.h"
 #include "mesh.h"
@@ -283,7 +283,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 	video::SMaterial &material = m_meshnode->getMaterial(0);
 	material.setTexture(0, tsrc->getTextureForMesh(imagename));
 	material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-	material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE; 
+	material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
 	material.MaterialType = m_material_type;
 	material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 	// Enable bi/trilinear filtering only for high resolution textures
@@ -304,12 +304,12 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 	}
 }
 
-void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
+void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 {
-	ITextureSource *tsrc = gamedef->getTextureSource();
-	IItemDefManager *idef = gamedef->getItemDefManager();
-	IShaderSource *shdrsrc = gamedef->getShaderSource();
-	INodeDefManager *ndef = gamedef->getNodeDefManager();
+	ITextureSource *tsrc = client->getTextureSource();
+	IItemDefManager *idef = client->getItemDefManager();
+	IShaderSource *shdrsrc = client->getShaderSource();
+	INodeDefManager *ndef = client->getNodeDefManager();
 	const ItemDefinition &def = item.getDefinition(idef);
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);
@@ -341,7 +341,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, IGameDef *gamedef)
 		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES) {
 			setCube(f.tiles, def.wield_scale, tsrc);
 		} else {
-			MeshMakeData mesh_make_data(gamedef, false);
+			MeshMakeData mesh_make_data(client, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);
 			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
@@ -435,11 +435,11 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 	m_meshnode->setVisible(true);
 }
 
-scene::IMesh *getItemMesh(IGameDef *gamedef, const ItemStack &item)
+scene::IMesh *getItemMesh(Client *client, const ItemStack &item)
 {
-	ITextureSource *tsrc = gamedef->getTextureSource();
-	IItemDefManager *idef = gamedef->getItemDefManager();
-	INodeDefManager *ndef = gamedef->getNodeDefManager();
+	ITextureSource *tsrc = client->getTextureSource();
+	IItemDefManager *idef = client->getItemDefManager();
+	INodeDefManager *ndef = client->getNodeDefManager();
 	const ItemDefinition &def = item.getDefinition(idef);
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);
@@ -470,7 +470,7 @@ scene::IMesh *getItemMesh(IGameDef *gamedef, const ItemStack &item)
 			mesh = cloneMesh(g_extrusion_mesh_cache->createCube());
 			scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
 		} else {
-			MeshMakeData mesh_make_data(gamedef, false);
+			MeshMakeData mesh_make_data(client, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);
 			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 
 struct ItemStack;
-class IGameDef;
+class Client;
 class ITextureSource;
 struct TileSpec;
 
@@ -42,7 +42,7 @@ public:
 			v3f wield_scale, ITextureSource *tsrc);
 	void setExtruded(const std::string &imagename,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
-	void setItem(const ItemStack &item, IGameDef *gamedef);
+	void setItem(const ItemStack &item, Client *client);
 
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false
@@ -77,7 +77,7 @@ private:
 	aabb3f m_bounding_box;
 };
 
-scene::IMesh *getItemMesh(IGameDef *gamedef, const ItemStack &item);
+scene::IMesh *getItemMesh(Client *client, const ItemStack &item);
 
 scene::IMesh *getExtrudedMesh(ITextureSource *tsrc,
 		const std::string &imagename);


### PR DESCRIPTION
# Commit 1
* Split ClientEnvironment & ServerEnvironment from environment.h (better code separation & more friendly with IDE because those files are very huge)
* environment.cpp/h now only contains common environment interface
* Cleanup includes & class declarations in client & server environment to improve build speed
* ServerEnvironment::m_gamedef is now a pointer to Server instead of IGameDef, permitting to cleanup many casts.

# Commit 2

Move ITextureSource* IGameDef::getTextureSource() to Client only.
* Also move ITextureSource *IGameDef::tsrc() helper
    
This needs a huge code refactor to use Client* instead of IGameDef* client side to use the right object type everywhere
    
This permits to remove some irrlicht implicit dependency server side

# Commit 3

IGameDef cleanup & misc cleanups
    
* drop getShaderSource, getSceneManager, getSoundManager & getCamera abstract call
* drop unused emerge() call
* cleanup server unused functions (mentionned before)
* Drop one unused parameter from ContentFeatures::updateTextures

# Commit 4
 Rename all Server *gamedef & Client *gamedef

Server *game => Server *server
Client *gamedef => Client *client

This also shows that game.cpp sent sometimes Client + InventoryManager + IGameDef in same functions but it's the same objects

# Commit 5
Remove duplicate Client pointer in GUIFormSpecMenu::GUIFormSpecMenu 

# Commit 6

* move checkLocalPrivilege to Client
* Remove some unnecessary casts
* create_formspec_menu: remove IWritableTextureSource pointer, as client already knows it
* Fix some comments
