### PR TITLE
Use std::vector instead of std::map in class ABMHandler, original by Rogier-5

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -824,7 +824,7 @@ public:
 				{
 					content_t c = *k;
 					if (c >= m_aabms.size())
-						m_aabms.resize(c + 256, (std::vector<ActiveABM> *) NULL);
+						m_aabms.resize(c + 256, NULL);
 					if (!m_aabms[c])
 						m_aabms[c] = new std::vector<ActiveABM>;
 					m_aabms[c]->push_back(aabm);
@@ -869,7 +869,7 @@ public:
 	}
 	void apply(MapBlock *block)
 	{
-		if(m_aabms.empty())
+		if(m_aabms.empty() || block->isDummy())
 			return;
 
 		ServerMap *map = &m_env->getServerMap();
@@ -883,13 +883,13 @@ public:
 		for(p0.Y=0; p0.Y<MAP_BLOCKSIZE; p0.Y++)
 		for(p0.Z=0; p0.Z<MAP_BLOCKSIZE; p0.Z++)
 		{
-			MapNode n = block->getNodeNoEx(p0);
+			const MapNode &n = block->getNodeUnsafe(p0);
 			content_t c = n.getContent();
-			v3s16 p = p0 + block->getPosRelative();
 
-			if (!m_aabms[c])
+			if (c >= m_aabms.size() || !m_aabms[c])
 				continue;
 
+			v3s16 p = p0 + block->getPosRelative();
 			for(std::vector<ActiveABM>::iterator
 					i = m_aabms[c]->begin(); i != m_aabms[c]->end(); ++i) {
 				if(myrand() % i->chance != 0)

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -764,7 +764,7 @@ class ABMHandler
 {
 private:
 	ServerEnvironment *m_env;
-	std::map<content_t, std::vector<ActiveABM> > m_aabms;
+	std::vector<std::vector<ActiveABM> *> m_aabms;
 public:
 	ABMHandler(std::vector<ABMWithState> &abms,
 			float dtime_s, ServerEnvironment *env,
@@ -823,18 +823,22 @@ public:
 						k != ids.end(); ++k)
 				{
 					content_t c = *k;
-					std::map<content_t, std::vector<ActiveABM> >::iterator j;
-					j = m_aabms.find(c);
-					if(j == m_aabms.end()){
-						std::vector<ActiveABM> aabmlist;
-						m_aabms[c] = aabmlist;
-						j = m_aabms.find(c);
-					}
-					j->second.push_back(aabm);
+					if (c >= m_aabms.size())
+						m_aabms.resize(c + 256, (std::vector<ActiveABM> *) NULL);
+					if (!m_aabms[c])
+						m_aabms[c] = new std::vector<ActiveABM>;
+					m_aabms[c]->push_back(aabm);
 				}
 			}
 		}
 	}
+
+	~ABMHandler()
+	{
+		for (size_t i = 0; i < m_aabms.size(); i++)
+			delete m_aabms[i];
+	}
+
 	// Find out how many objects the given block and its neighbours contain.
 	// Returns the number of objects in the block, and also in 'wider' the
 	// number of objects in the block and all its neighbours. The latter
@@ -883,13 +887,11 @@ public:
 			content_t c = n.getContent();
 			v3s16 p = p0 + block->getPosRelative();
 
-			std::map<content_t, std::vector<ActiveABM> >::iterator j;
-			j = m_aabms.find(c);
-			if(j == m_aabms.end())
+			if (!m_aabms[c])
 				continue;
 
 			for(std::vector<ActiveABM>::iterator
-					i = j->second.begin(); i != j->second.end(); ++i) {
+					i = m_aabms[c]->begin(); i != m_aabms[c]->end(); ++i) {
 				if(myrand() % i->chance != 0)
 					continue;
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -305,8 +305,7 @@ public:
 	inline MapNode getNodeNoEx(v3s16 p)
 	{
 		bool is_valid;
-		MapNode node = getNode(p.X, p.Y, p.Z, &is_valid);
-		return is_valid ? node : MapNode(CONTENT_IGNORE);
+		return getNode(p.X, p.Y, p.Z, &is_valid);
 	}
 
 	inline void setNode(s16 x, s16 y, s16 z, MapNode & n)
@@ -339,6 +338,22 @@ public:
 	inline MapNode getNodeNoCheck(v3s16 p, bool *valid_position)
 	{
 		return getNodeNoCheck(p.X, p.Y, p.Z, valid_position);
+	}
+
+	////
+	//// Non-checking, unsafe variants of the above
+	//// MapBlock must be loaded by another function in the same scope/function
+	//// Caller must ensure that this is not a dummy block (by calling isDummy())
+	////
+
+	inline const MapNode &getNodeUnsafe(s16 x, s16 y, s16 z)
+	{
+		return data[z * zstride + y * ystride + x];
+	}
+
+	inline const MapNode &getNodeUnsafe(v3s16 &p)
+	{
+		return getNodeUnsafe(p.X, p.Y, p.Z);
 	}
 
 	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode & n)
@@ -512,7 +527,6 @@ public:
 
 	void serializeNetworkSpecific(std::ostream &os, u16 net_proto_version);
 	void deSerializeNetworkSpecific(std::istream &is);
-
 private:
 	/*
 		Private methods

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -142,11 +142,6 @@ struct MapNode
 	MapNode()
 	{ }
 
-	MapNode(const MapNode & n)
-	{
-		*this = n;
-	}
-
 	MapNode(content_t content, u8 a_param1=0, u8 a_param2=0)
 		: param0(content),
 		  param1(a_param1),


### PR DESCRIPTION
Adopting #4895. Done with three commits, the first with @Rogier-5 's original change, a second with my changes on top, to make it clear what I changed. The 3rd commit improves this further, with some suggestions from @gregorycu.

* added the overflow check, avoiding a core dump
* remove the unnecessary in resize
* removed the custom copy constructor for MapNode (now uses the trivial default constructor)
* removed unnecessary logic from MapBlock::getNodeNoEx (check it out it really does exactly the same)
* avoid initializing the vector for the MapNode until needed
* retrieve a MapNode reference directly, a avoid the validity check (thanks @gregorycu)

This help a lot on my system. Would be nice if someone else could verify.
