### PR TITLE
Travis: Build server too for UNIX

### DIFF
--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -21,6 +21,7 @@ if [[ $PLATFORM == "Unix" ]]; then
 	cmake -DCMAKE_BUILD_TYPE=Debug \
 		-DRUN_IN_PLACE=TRUE \
 		-DENABLE_GETTEXT=TRUE \
+		-DBUILD_SERVER=TRUE \
 		$CMAKE_FLAGS ..
 	make -j2
 	echo "Running unit tests."


### PR DESCRIPTION
Travis doesn't build server, only client embedding server. There are some code parts which are enabled or disabled depending on minetestserver which can sometimes break, let travis show this