### PR TITLE
lua_api.txt: Add registered_chatcommands to global tables

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2729,6 +2729,8 @@ These functions return the leftover itemstack.
     * Map of object references, indexed by active object id
 * `minetest.luaentities`
     * Map of Lua entities, indexed by active object id
+* `minetest.registered_chatcommands`
+    * Map of registered chat command definitions, indexed by name
 * `minetest.registered_ores`
     * List of registered ore definitions.
 * `minetest.registered_biomes`


### PR DESCRIPTION
It seems so somebody has forgotten to add it there..