### PR TITLE
Get neighbor from same map block if possible in ABMHandler

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -902,14 +902,23 @@ public:
 				if(!i->required_neighbors.empty())
 				{
 					v3s16 p1;
-					for(p1.X = p.X-1; p1.X <= p.X+1; p1.X++)
-					for(p1.Y = p.Y-1; p1.Y <= p.Y+1; p1.Y++)
-					for(p1.Z = p.Z-1; p1.Z <= p.Z+1; p1.Z++)
+					for(p1.X = p0.X-1; p1.X <= p0.X+1; p1.X++)
+					for(p1.Y = p0.Y-1; p1.Y <= p0.Y+1; p1.Y++)
+					for(p1.Z = p0.Z-1; p1.Z <= p0.Z+1; p1.Z++)
 					{
-						if(p1 == p)
+						if(p1 == p0)
 							continue;
-						MapNode n = map->getNodeNoEx(p1);
-						content_t c = n.getContent();
+						content_t c;
+						if (block->isValidPosition(p1)) {
+							// if the neighbor is found on the same map block
+							// get it straight from there
+							const MapNode &n = block->getNodeUnsafe(p1);
+							c = n.getContent();
+						} else {
+							// otherwise consult the map
+							MapNode n = map->getNodeNoEx(p1 + block->getPosRelative());
+							c = n.getContent();
+						}
 						std::set<content_t>::const_iterator k;
 						k = i->required_neighbors.find(c);
 						if(k != i->required_neighbors.end()){


### PR DESCRIPTION
I noticed that when I use the Technic mod and a larg'ish `active_block_range` - 7 or 8 in my case - I see messages like these:
`2017-01-05 21:55:04: WARNING[Server]: active block modifiers took 623ms (longer than 200ms)`

Without actually doing anything. Turns out that the time is spent in the required neighbor check.
Looking at the code one can observe that the majority of the neighbors of the nodes are actually found in the very map block that we already have a reference to; so use that one to get the neighorhing map node instead of going back to getting the mapnode via map->sector->mapblock->mapnode.

That brought the max down from 623ms to to 223ms. And the average from about 490ms to 210ms.
