### PR TITLE
Make column alignment consistent in advanced settings

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -544,7 +544,7 @@ end
 
 local function create_settings_formspec(tabview, name, tabdata)
 	local formspec = "size[12,6.5;true]" ..
-			"tablecolumns[color;tree;text;text]" ..
+			"tablecolumns[color;tree;text,width=32;text]" ..
 			"tableoptions[background=#00000000;border=false]" ..
 			"table[0,0;12,5.5;list_settings;"
 


### PR DESCRIPTION
Switching from default names to technical names in Advanced Settings using the 'Show technical names checkbox' causes the position of the second column to shift to the left. (And the reverse when you deselect it). This change would prevent the movement and keep column alignment consistent. 