### PR TITLE
Add staticdata parameter to add_entity

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -9,6 +9,7 @@ core.features = {
 	no_legacy_abms = true,
 	texture_names_parens = true,
 	area_store_custom_ids = true,
+	add_entity_with_staticdata = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2173,7 +2173,7 @@ and `minetest.auth_reload` call the authetification handler.
 * `minetest.get_node_timer(pos)`
     * Get `NodeTimerRef`
 
-* `minetest.add_entity(pos, name)`: Spawn Lua-defined entity at position
+* `minetest.add_entity(pos, name, [staticdata])`: Spawn Lua-defined entity at position
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -440,7 +440,7 @@ int ModApiEnvMod::l_get_node_timer(lua_State *L)
 	return 1;
 }
 
-// add_entity(pos, entityname) -> ObjectRef or nil
+// add_entity(pos, entityname, [staticdata]) -> ObjectRef or nil
 // pos = {x=num, y=num, z=num}
 int ModApiEnvMod::l_add_entity(lua_State *L)
 {
@@ -450,8 +450,10 @@ int ModApiEnvMod::l_add_entity(lua_State *L)
 	v3f pos = checkFloatPos(L, 1);
 	// content
 	const char *name = luaL_checkstring(L, 2);
+	// staticdata
+	const char *staticdata = luaL_optstring(L, 3, "");
 	// Do it
-	ServerActiveObject *obj = new LuaEntitySAO(env, pos, name, "");
+	ServerActiveObject *obj = new LuaEntitySAO(env, pos, name, staticdata);
 	int objectid = env->addActiveObject(obj);
 	// If failed to add, return nothing (reads as nil)
 	if(objectid == 0)


### PR DESCRIPTION
Squashed version of #5008 

This parameter is optional.
You need call on_activate twice no longer.