### PR TITLE
Sky: Do not darken in dark places when above water_level

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -749,7 +749,10 @@ int ClientMap::getBackgroundBrightness(float max_d, u32 daylight_factor,
 	if(debugprint)
 		std::cerr<<"Result: "<<ret<<" sunlight_seen_count="
 				<<sunlight_seen_count<<std::endl;
-	*sunlight_seen_result = (sunlight_seen_count > 0);
+	// Don't darken sky when above water_level
+	const s16 water_level = g_settings->getS16("water_level");
+	s16 cam_pos_y = m_camera_position.Y / BS;
+	*sunlight_seen_result = sunlight_seen_count > 0 || cam_pos_y > water_level;
 	return ret;
 }
 


### PR DESCRIPTION
![screenshot_20170108_232805](https://cloud.githubusercontent.com/assets/3686677/21754600/582b4a32-d5fb-11e6-9153-ce0e641cfcd6.png)

![screenshot_20170108_232810](https://cloud.githubusercontent.com/assets/3686677/21754601/5c5d1eb4-d5fb-11e6-8ff6-e1e5490d5458.png)

^ Tested by moving across water_level (y = 1) with a very short view range (20) the brightness will not be this extreme with longer view distances

Issue #5006
Addresses #3577 
Not sure if this is the optimum way to access water_level.

This will cause very subtle light in distant parts of tunnels when above sea level, however in all mapgens when you are above sea level you are no more than 100 nodes from the outside world, so this light can be considered distant daylight filtering through tunnels to where you are. It will be quite a nice indicator that you are approaching the surface.