### PR TITLE
Make nametag removable with set_nametag_attributes

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -790,8 +790,7 @@ int ObjectRef::l_set_nametag_attributes(lua_State *L)
 	lua_pop(L, 1);
 
 	std::string nametag = getstringfield_default(L, 2, "text", "");
-	if (nametag != "")
-		prop->nametag = nametag;
+	prop->nametag = nametag;
 
 	co->notifyObjectPropertiesModified();
 	lua_pushboolean(L, true);


### PR DESCRIPTION
ObjectRef only.
You can remove nametag with empty string.
```lua
-- before
object:set_properties({nametag = ""})

-- after
object:set_nametag_attributes({text = ""})
```