### PR TITLE
Mgv7 floatlands: Reduce skybox darkening on underside 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -984,8 +984,13 @@ mgv7_float_mount_height (Mapgen v7 floatland mountain height) float 128.0
 #    Y-level of floatland midpoint and lake surface.
 mgv7_floatland_level (Mapgen v7 floatland level) int 1280
 
-#    Y-level to which floatland shadows extend.
-mgv7_shadow_limit (Mapgen v7 shadow limit) int 1024
+#    Y-level of floatland biome and lighting transition.
+#    Set this to the Y of the lowest possible floatland stone, typically
+#    2 * float_mount_height below floatland_level.
+#    Above this level floatland biomes take effect.
+#    Between this and floatland_level shadow propagation is disabled to
+#    illuminate the floatland underside.
+mgv7_floatland_limit (Mapgen v7 floatland limit) int 1024
 
 mgv7_np_terrain_base (Mapgen v7 terrain base noise parameters) noise_params 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 mgv7_np_terrain_alt (Mapgen v7 terrain altitude noise parameters) noise_params 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1254,9 +1254,14 @@
 #    type: int
 # mgv7_floatland_level = 1280
 
-#    Y-level to which floatland shadows extend.
+#    Y-level of floatland biome and lighting transition.
+#    Set this to the Y of the lowest possible floatland stone, typically
+#    2 * float_mount_height below floatland_level.
+#    Above this level floatland biomes take effect.
+#    Between this and floatland_level shadow propagation is disabled to
+#    illuminate the floatland underside.
 #    type: int
-# mgv7_shadow_limit = 1024
+# mgv7_floatland_limit = 1024
 
 #    type: noise_params
 # mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -59,7 +59,7 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	this->float_mount_density = params->float_mount_density;
 	this->float_mount_height  = params->float_mount_height;
 	this->floatland_level     = params->floatland_level;
-	this->shadow_limit        = params->shadow_limit;
+	this->floatland_limit     = params->floatland_limit;
 
 	//// Terrain noise
 	noise_terrain_base      = new Noise(&params->np_terrain_base,      seed, csize.X, csize.Z);
@@ -105,7 +105,7 @@ MapgenV7Params::MapgenV7Params()
 	float_mount_density = 0.6;
 	float_mount_height  = 128.0;
 	floatland_level     = 1280;
-	shadow_limit        = 1024;
+	floatland_limit     = 1024;
 
 	np_terrain_base      = NoiseParams(4,    70,   v3f(600,  600,  600),  82341, 5, 0.6,  2.0);
 	np_terrain_alt       = NoiseParams(4,    25,   v3f(600,  600,  600),  5934,  5, 0.6,  2.0);
@@ -130,7 +130,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgv7_float_mount_density", float_mount_density);
 	settings->getFloatNoEx("mgv7_float_mount_height",  float_mount_height);
 	settings->getS16NoEx("mgv7_floatland_level",       floatland_level);
-	settings->getS16NoEx("mgv7_shadow_limit",          shadow_limit);
+	settings->getS16NoEx("mgv7_floatland_limit",       floatland_limit);
 
 	settings->getNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
 	settings->getNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
@@ -155,7 +155,7 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setFloat("mgv7_float_mount_density", float_mount_density);
 	settings->setFloat("mgv7_float_mount_height",  float_mount_height);
 	settings->setS16("mgv7_floatland_level",       floatland_level);
-	settings->setS16("mgv7_shadow_limit",          shadow_limit);
+	settings->setS16("mgv7_floatland_limit",       floatland_limit);
 
 	settings->setNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
 	settings->setNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
@@ -278,7 +278,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Limit floatland shadow
 	bool propagate_shadow = !((spflags & MGV7_FLOATLANDS) &&
-		node_min.Y <= shadow_limit && node_max.Y >= shadow_limit);
+		node_max.Y >= floatland_limit && node_max.Y <= floatland_level);
 
 	if (flags & MG_LIGHT)
 		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
@@ -469,7 +469,7 @@ int MapgenV7::generateTerrain()
 
 void MapgenV7::generateRidgeTerrain()
 {
-	if ((node_max.Y < water_level - 16) || (node_max.Y > shadow_limit))
+	if ((node_max.Y < water_level - 16) || (node_max.Y > floatland_limit))
 		return;
 
 	noise_ridge->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -39,7 +39,7 @@ struct MapgenV7Params : public MapgenParams {
 	float float_mount_density;
 	float float_mount_height;
 	s16 floatland_level;
-	s16 shadow_limit;
+	s16 floatland_limit;
 
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_alt;
@@ -86,7 +86,7 @@ private:
 	float float_mount_density;
 	float float_mount_height;
 	s16 floatland_level;
-	s16 shadow_limit;
+	s16 floatland_limit;
 
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;


### PR DESCRIPTION
Disable shadow propagation between floatland_limit and
floatland_level to partially illuminate the underside. This helps to
avoid the skybox going dark due to detection of large volumes of dark air.
Rename shadow_limit parameter to floatland_limit.
Update documentation.
////////////////////////////////////////

Partly addresses #3577 
Related #5006 #5014 

![screenshot_20170113_041354](https://cloud.githubusercontent.com/assets/3686677/21918282/d0d000c8-d947-11e6-882e-59d204573fa5.png)

^ The shadow propagation bool is now set to false for the entire volume from floatland_level down to shadow_limit 256 nodes below

![screenshot_20170113_041609](https://cloud.githubusercontent.com/assets/3686677/21918284/d6ae2f88-d947-11e6-990a-3f931a13b4a2.png)

^ When exploring the underside of floatlands this view would previously result in a dark skybox with no blue sky or clouds visible

![screenshot_20170113_042529](https://cloud.githubusercontent.com/assets/3686677/21918355/5fb6211e-d948-11e6-9a74-2987ee9a5d9f.png)

^ At night clouds and stars are visible below

Although i thought it might be a problem, having light under the floatlands seems rather reasonable, it can be considered lighting from below and from the side. The transition from dark to light is gradual over 16 nodes.
Before this commit the underside would be black. Makes for a better view too.
Note that this partially-lit appearence happens already when you approach floatlands from the underneath because chunks above have not been generated yet so mapgen assumes light from above. It's a common lighting bug caused by generating world upwards. This PR therefore forces that behaviour to happen all the time.