### PR TITLE
Improved texture modifier handling to be more usefull for mods

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2843,6 +2843,7 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_yaw(radians)`
 * `get_yaw()`: returns number in radians
 * `set_texture_mod(mod)`
+* `get_texture_mod()` returns current texture modifier
 * `set_sprite(p={x=0,y=0}, num_frames=1, framelength=0.2,
   select_horiz_by_yawpitch=false)`
     * Select sprite from spritesheet with optional animation and DM-style

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -575,6 +575,8 @@ GenericCAO::GenericCAO(Client *client, ClientEnvironment *env):
 		m_anim_framelength(0.2),
 		m_anim_timer(0),
 		m_reset_textures_timer(-1),
+		m_previous_texture_modifier(""),
+		m_current_texture_modifier(""),
 		m_visuals_expired(false),
 		m_step_distance_counter(0),
 		m_last_light(255),
@@ -953,7 +955,10 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr,
 		infostream<<"GenericCAO::addToScene(): \""<<m_prop.visual
 				<<"\" not supported"<<std::endl;
 	}
-	updateTextures("");
+
+	/* don't update while punch texture modifier is active */
+	if (m_reset_textures_timer < 0)
+		updateTextures(m_current_texture_modifier);
 
 	scene::ISceneNode *node = getSceneNode();
 	if (node && m_prop.nametag != "" && !m_is_local_player) {
@@ -1222,9 +1227,9 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 	if(m_reset_textures_timer >= 0)
 	{
 		m_reset_textures_timer -= dtime;
-		if(m_reset_textures_timer <= 0){
+		if(m_reset_textures_timer <= 0) {
 			m_reset_textures_timer = -1;
-			updateTextures("");
+			updateTextures(m_previous_texture_modifier);
 		}
 	}
 	if(getParent() == NULL && fabs(m_prop.automatic_rotate) > 0.001)
@@ -1302,13 +1307,16 @@ void GenericCAO::updateTexturePos()
 	}
 }
 
-void GenericCAO::updateTextures(const std::string &mod)
+void GenericCAO::updateTextures(const std::string mod)
 {
 	ITextureSource *tsrc = m_client->tsrc();
 
 	bool use_trilinear_filter = g_settings->getBool("trilinear_filter");
 	bool use_bilinear_filter = g_settings->getBool("bilinear_filter");
 	bool use_anisotropic_filter = g_settings->getBool("anisotropic_filter");
+
+	m_previous_texture_modifier = m_current_texture_modifier;
+	m_current_texture_modifier = mod;
 
 	if(m_spritenode)
 	{
@@ -1612,6 +1620,12 @@ void GenericCAO::processMessage(const std::string &data)
 		updateNodePos();
 	} else if (cmd == GENERIC_CMD_SET_TEXTURE_MOD) {
 		std::string mod = deSerializeString(is);
+
+		// immediatly reset a engine issued texture modifier if a mod sends a different one
+		if (m_reset_textures_timer > 0) {
+			m_reset_textures_timer = -1;
+			updateTextures(m_previous_texture_modifier);
+		}
 		updateTextures(mod);
 	} else if (cmd == GENERIC_CMD_SET_SPRITE) {
 		v2s16 p = readV2S16(is);
@@ -1735,7 +1749,7 @@ void GenericCAO::processMessage(const std::string &data)
 				m_reset_textures_timer = 0.05;
 				if(damage >= 2)
 					m_reset_textures_timer += 0.05 * damage;
-				updateTextures("^[brighten");
+				updateTextures(m_current_texture_modifier + "^[brighten");
 			}
 		}
 	} else if (cmd == GENERIC_CMD_UPDATE_ARMOR_GROUPS) {
@@ -1803,7 +1817,7 @@ bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
 		m_reset_textures_timer = 0.05;
 		if(result.damage >= 2)
 			m_reset_textures_timer += 0.05 * result.damage;
-		updateTextures("^[brighten");
+		updateTextures(m_current_texture_modifier + "^[brighten");
 	}
 
 	return false;

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -102,6 +102,8 @@ private:
 	float m_anim_timer;
 	ItemGroupList m_armor_groups;
 	float m_reset_textures_timer;
+	std::string m_previous_texture_modifier; // stores texture modifier before punch update
+	std::string m_current_texture_modifier;  // last applied texture modifier
 	bool m_visuals_expired;
 	float m_step_distance_counter;
 	u8 m_last_light;
@@ -198,7 +200,7 @@ public:
 
 	void updateTexturePos();
 
-	void updateTextures(const std::string &mod);
+	void updateTextures(const std::string mod);
 
 	void updateAnimation();
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -687,7 +687,7 @@ void LuaEntitySAO::setTextureMod(const std::string &mod)
 	m_messages_out.push(aom);
 }
 
-std::string LuaEntitySAO::getTextureMod()
+std::string LuaEntitySAO::getTextureMod() const
 {
 	return m_current_texture_modifier;
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -247,7 +247,8 @@ LuaEntitySAO::LuaEntitySAO(ServerEnvironment *env, v3f pos,
 	m_last_sent_position(0,0,0),
 	m_last_sent_velocity(0,0,0),
 	m_last_sent_position_timer(0),
-	m_last_sent_move_precision(0)
+	m_last_sent_move_precision(0),
+	m_current_texture_modifier("")
 {
 	// Only register type if no environment supplied
 	if(env == NULL){
@@ -501,6 +502,9 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 			}
 		}
 
+		msg_os << serializeLongString(gob_cmd_set_texture_mod(m_current_texture_modifier));
+		message_count++;
+
 		writeU8(os, message_count);
 		os.write(msg_os.str().c_str(), msg_os.str().size());
 	}
@@ -677,9 +681,15 @@ v3f LuaEntitySAO::getAcceleration()
 void LuaEntitySAO::setTextureMod(const std::string &mod)
 {
 	std::string str = gob_cmd_set_texture_mod(mod);
+	m_current_texture_modifier = mod;
 	// create message and add to list
 	ActiveObjectMessage aom(getId(), true, str);
 	m_messages_out.push(aom);
+}
+
+std::string LuaEntitySAO::getTextureMod()
+{
+	return m_current_texture_modifier;
 }
 
 void LuaEntitySAO::setSprite(v2s16 p, int num_frames, float framelength,

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -121,6 +121,7 @@ public:
 	v3f getAcceleration();
 
 	void setTextureMod(const std::string &mod);
+	std::string getTextureMod();
 	void setSprite(v2s16 p, int num_frames, float framelength,
 			bool select_horiz_by_yawpitch);
 	std::string getName();
@@ -142,6 +143,7 @@ private:
 	v3f m_last_sent_velocity;
 	float m_last_sent_position_timer;
 	float m_last_sent_move_precision;
+	std::string m_current_texture_modifier;
 };
 
 /*

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -121,7 +121,7 @@ public:
 	v3f getAcceleration();
 
 	void setTextureMod(const std::string &mod);
-	std::string getTextureMod();
+	std::string getTextureMod() const;
 	void setSprite(v2s16 p, int num_frames, float framelength,
 			bool select_horiz_by_yawpitch);
 	std::string getName();

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -913,6 +913,19 @@ int ObjectRef::l_set_texture_mod(lua_State *L)
 	return 0;
 }
 
+// get_texture_mod(self)
+int ObjectRef::l_get_texture_mod(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	LuaEntitySAO *co = getluaobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	std::string mod = co->getTextureMod();
+	lua_pushstring(L, mod.c_str());
+	return 1;
+}
+
 // set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
 //           select_horiz_by_yawpitch=false)
 int ObjectRef::l_set_sprite(lua_State *L)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -164,6 +164,9 @@ private:
 	// set_texture_mod(self, mod)
 	static int l_set_texture_mod(lua_State *L);
 
+	// l_get_texture_mod(self)
+	static int l_get_texture_mod(lua_State *L);
+
 	// set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
 	//           select_horiz_by_yawpitch=false)
 	static int l_set_sprite(lua_State *L);


### PR DESCRIPTION
At the moment a texture modifier is quite incomplete, a mod can set a texture modifier which is active for undefined time.

BUT:
1) A texture modifier set is not sent to client connecting later.
2) If the texture is modified from somewhere else,  e.g. punching, add to scene the modifier is lost.
==> behaviour is quite inconsistent

Additionaly there's no way for a mod to check if any other texture modifiers are already applied.

This commit fixes the behavior the following way:

1) temporary engine issued modifiers e.g. punch restore the previous texture modifier
2) client's connecting are told about current active texture modifiers
3) lua api can read the current texture modifier