### PR TITLE
Add color names from web page referenced in luaapi doc

### DIFF
--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -561,6 +561,7 @@ ColorContainer::ColorContainer()
 	colors["darkgoldenrod"]          = 0xb8860b;
 	colors["darkgray"]               = 0xa9a9a9;
 	colors["darkgreen"]              = 0x006400;
+	colors["darkgrey"]               = 0xa9a9a9;
 	colors["darkkhaki"]              = 0xbdb76b;
 	colors["darkmagenta"]            = 0x8b008b;
 	colors["darkolivegreen"]         = 0x556b2f;
@@ -571,11 +572,13 @@ ColorContainer::ColorContainer()
 	colors["darkseagreen"]           = 0x8fbc8f;
 	colors["darkslateblue"]          = 0x483d8b;
 	colors["darkslategray"]          = 0x2f4f4f;
+	colors["darkslategrey"]          = 0x2f4f4f;
 	colors["darkturquoise"]          = 0x00ced1;
 	colors["darkviolet"]             = 0x9400d3;
 	colors["deeppink"]               = 0xff1493;
 	colors["deepskyblue"]            = 0x00bfff;
 	colors["dimgray"]                = 0x696969;
+	colors["dimgrey"]                = 0x696969;
 	colors["dodgerblue"]             = 0x1e90ff;
 	colors["firebrick"]              = 0xb22222;
 	colors["floralwhite"]            = 0xfffaf0;
@@ -588,6 +591,7 @@ ColorContainer::ColorContainer()
 	colors["gray"]                   = 0x808080;
 	colors["green"]                  = 0x008000;
 	colors["greenyellow"]            = 0xadff2f;
+	colors["grey"]                   = 0x808080;
 	colors["honeydew"]               = 0xf0fff0;
 	colors["hotpink"]                = 0xff69b4;
 	colors["indianred"]              = 0xcd5c5c;
@@ -604,11 +608,13 @@ ColorContainer::ColorContainer()
 	colors["lightgoldenrodyellow"]   = 0xfafad2;
 	colors["lightgray"]              = 0xd3d3d3;
 	colors["lightgreen"]             = 0x90ee90;
+	colors["lightgrey"]              = 0xd3d3d3;
 	colors["lightpink"]              = 0xffb6c1;
 	colors["lightsalmon"]            = 0xffa07a;
 	colors["lightseagreen"]          = 0x20b2aa;
 	colors["lightskyblue"]           = 0x87cefa;
 	colors["lightslategray"]         = 0x778899;
+	colors["lightslategrey"]         = 0x778899;
 	colors["lightsteelblue"]         = 0xb0c4de;
 	colors["lightyellow"]            = 0xffffe0;
 	colors["lime"]                   = 0x00ff00;
@@ -661,6 +667,7 @@ ColorContainer::ColorContainer()
 	colors["skyblue"]                = 0x87ceeb;
 	colors["slateblue"]              = 0x6a5acd;
 	colors["slategray"]              = 0x708090;
+	colors["slategrey"]              = 0x708090;
 	colors["snow"]                   = 0xfffafa;
 	colors["springgreen"]            = 0x00ff7f;
 	colors["steelblue"]              = 0x4682b4;


### PR DESCRIPTION
https://drafts.csswg.org/css-color/#named-colors

mentiones the grey/gray synonyms which are missing in current minetest code