### PR TITLE
Add "multiply" texture modifier which uses multiplication method for colorizing textures

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -419,6 +419,13 @@ the word "`alpha`", then each texture pixel will contain the RGB of
 `<color>` and the alpha of `<color>` multiplied by the alpha of the
 texture pixel.
 
+#### `[multiply:<color>`
+Multiplies texture colors with the given color.
+`<color>` is specified as a `ColorString`.
+Result is more like what you'd expect if you put a color on top of another
+color. Meaning white surfaces get a lot of your new color while black parts don't
+change very much.
+
 Sounds
 ------
 Only Ogg Vorbis files are supported.

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -555,7 +555,11 @@ static void blit_with_alpha_overlay(video::IImage *src, video::IImage *dst,
 // color alpha with the destination alpha.
 // Otherwise, any pixels that are not fully transparent get the color alpha.
 static void apply_colorize(video::IImage *dst, v2u32 dst_pos, v2u32 size,
-		video::SColor color, int ratio, bool keep_alpha);
+		const video::SColor &color, int ratio, bool keep_alpha);
+
+// paint a texture using the given color
+static void apply_multiplication(video::IImage *dst, v2u32 dst_pos, v2u32 size,
+		const video::SColor &color);
 
 // Apply a mask to an image
 static void apply_mask(video::IImage *mask, video::IImage *dst,
@@ -1657,6 +1661,30 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 			}
 		}
 		/*
+		[multiply:color
+			multiplys a given color to any pixel of an image
+			color = color as ColorString
+		*/
+		else if (str_starts_with(part_of_name, "[multiply:")) {
+			Strfnd sf(part_of_name);
+			sf.next(":");
+			std::string color_str = sf.next(":");
+
+			if (baseimg == NULL) {
+				errorstream << "generateImagePart(): baseimg != NULL "
+						<< "for part_of_name=\"" << part_of_name
+						<< "\", cancelling." << std::endl;
+				return false;
+			}
+
+			video::SColor color;
+
+			if (!parseColorString(color_str, color, false))
+				return false;
+
+			apply_multiplication(baseimg, v2u32(0, 0), baseimg->getDimension(), color);
+		}
+		/*
 			[colorize:color
 			Overlays image with given color
 			color = color as ColorString
@@ -1960,7 +1988,7 @@ static void blit_with_interpolate_overlay(video::IImage *src, video::IImage *dst
 	Apply color to destination
 */
 static void apply_colorize(video::IImage *dst, v2u32 dst_pos, v2u32 size,
-		video::SColor color, int ratio, bool keep_alpha)
+		const video::SColor &color, int ratio, bool keep_alpha)
 {
 	u32 alpha = color.getAlpha();
 	video::SColor dst_c;
@@ -1991,6 +2019,27 @@ static void apply_colorize(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 				dst->setPixel(x, y, dst_c);
 			}
 		}
+	}
+}
+
+/*
+	Apply color to destination
+*/
+static void apply_multiplication(video::IImage *dst, v2u32 dst_pos, v2u32 size,
+		const video::SColor &color)
+{
+	video::SColor dst_c;
+
+	for (u32 y = dst_pos.Y; y < dst_pos.Y + size.Y; y++)
+	for (u32 x = dst_pos.X; x < dst_pos.X + size.X; x++) {
+		dst_c = dst->getPixel(x, y);
+		dst_c.set(
+				dst_c.getAlpha(),
+				(dst_c.getRed() * color.getRed())/255,
+				(dst_c.getGreen() * color.getGreen())/255,
+				(dst_c.getBlue() * color.getBlue())/255
+				);
+		dst->setPixel(x, y, dst_c);
 	}
 }
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2035,9 +2035,9 @@ static void apply_multiplication(video::IImage *dst, v2u32 dst_pos, v2u32 size,
 		dst_c = dst->getPixel(x, y);
 		dst_c.set(
 				dst_c.getAlpha(),
-				(dst_c.getRed() * color.getRed())/255,
-				(dst_c.getGreen() * color.getGreen())/255,
-				(dst_c.getBlue() * color.getBlue())/255
+				(dst_c.getRed() * color.getRed()) / 255,
+				(dst_c.getGreen() * color.getGreen()) / 255,
+				(dst_c.getBlue() * color.getBlue()) / 255
 				);
 		dst->setPixel(x, y, dst_c);
 	}


### PR DESCRIPTION
Just a quick & dirty example what can be done with it.
I know the colors aren't exactly identical I didn't spend any time to "adjust" them. I just wanted to show how easy you can create different colored nodes using one single black/white texture and apply this modifier.

(Important) changes in wool mod:

-tiles = {"wool_" .. name ..  ".png"},

+tiles = {"wool_white.png^[paint:" .. colorname},

http://imgur.com/a/h0rwx