### PR TITLE
Documentation: Correct biome heat / humidity noise parameters

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -910,9 +910,9 @@ emergequeue_limit_generate (Limit of emerge queues to generate) int 32
 num_emerge_threads (Number of emerge threads) int 1
 
 #    Noise parameters for biome API temperature, humidity and biome blend.
-mg_biome_np_heat (Mapgen biome heat noise parameters) noise_params 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
+mg_biome_np_heat (Mapgen biome heat noise parameters) noise_params 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0
 mg_biome_np_heat_blend (Mapgen heat blend noise parameters) noise_params 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
-mg_biome_np_humidity (Mapgen biome humidity noise parameters) noise_params 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
+mg_biome_np_humidity (Mapgen biome humidity noise parameters) noise_params 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0
 mg_biome_np_humidity_blend (Mapgen biome humidity blend noise parameters) noise_params 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0
 
 [***Mapgen v5]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1131,13 +1131,13 @@
 
 #    Noise parameters for biome API temperature, humidity and biome blend.
 #    type: noise_params
-# mg_biome_np_heat = 50, 50, (750, 750, 750), 5349, 3, 0.5, 2.0
+# mg_biome_np_heat = 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0
 
 #    type: noise_params
 # mg_biome_np_heat_blend = 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
 
 #    type: noise_params
-# mg_biome_np_humidity = 50, 50, (750, 750, 750), 842, 3, 0.5, 2.0
+# mg_biome_np_humidity = 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0
 
 #    type: noise_params
 # mg_biome_np_humidity_blend = 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0


### PR DESCRIPTION
When the new set of biomes was added in MTGame the 'spread' for heat
and humidity noise parameters was increased to 1000, i forgot to update
settingtypes.txt and minetest.conf.