### PR TITLE
Limit per round MapBlockMeshes created in MeshUpdateThread

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -113,9 +113,9 @@ void MeshUpdateQueue::addBlock(v3s16 p, MeshMakeData *data, bool ack_block_to_se
 		Find if block is already in queue.
 		If it is, update the data and quit.
 	*/
-	for(std::vector<QueuedMeshUpdate*>::iterator
-			i = m_queue.begin();
-			i != m_queue.end(); ++i)
+	for(std::vector<QueuedMeshUpdate*>::reverse_iterator
+			i = m_queue.rbegin();
+			i != m_queue.rend(); ++i)
 	{
 		QueuedMeshUpdate *q = *i;
 		if(q->p == p)
@@ -174,8 +174,9 @@ void MeshUpdateThread::enqueueUpdate(v3s16 p, MeshMakeData *data,
 void MeshUpdateThread::doUpdate()
 {
 	QueuedMeshUpdate *q;
-	while ((q = m_queue_in.pop())) {
-
+	int i=0;
+	while (i < 40 && (q = m_queue_in.pop())) {
+		i++;
 		ScopeProfiler sp(g_profiler, "Client: Mesh making");
 
 		MapBlockMesh *mesh_new = new MapBlockMesh(q->data, m_camera_offset);


### PR DESCRIPTION
This should be considered experimental. In order to reduce jitter when moving around with blocks loading, limit the number of MapBlockMeshes created per call MeshUpdateThread::doUpdate.

Where does the 40 come from. No idea, it tested well... Would be nice to derive a good default from the minetest settings. Perhaps this should be around the servers `max_simultaneous_block_sends_per_client` setting.

I also observer that it is slightly more likely that block that are updated again are found towards the end of the incoming queue, so there's a slight improvement to have by looking from the end of the queue (std::vector).

If somebody could test whether this reduces jitter with their setup... @Fixer-007 hint, hint :) That'd be great.