### PR TITLE
Remove client-side chat prediction.

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -10,6 +10,7 @@ core.features = {
 	texture_names_parens = true,
 	area_store_custom_ids = true,
 	add_entity_with_staticdata = true,
+	no_chat_message_prediction = true,
 }
 
 function core.has_feature(arg)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1563,10 +1563,13 @@ void Client::typeChatMessage(const std::wstring &message)
 	}
 	else
 	{
-		LocalPlayer *player = m_env.getLocalPlayer();
-		assert(player != NULL);
-		std::wstring name = narrow_to_wide(player->getName());
-		m_chat_queue.push((std::wstring)L"<" + name + L"> " + message);
+		// compatibility code
+		if (m_proto_ver < 29) {
+			LocalPlayer *player = m_env.getLocalPlayer();
+			assert(player != NULL);
+			std::wstring name = narrow_to_wide(player->getName());
+			m_chat_queue.push((std::wstring)L"<" + name + L"> " + message);
+		}
 	}
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -142,6 +142,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Server doesn't accept TOSERVER_BREATH anymore
 		serialization of TileAnimation params changed
 		TAT_SHEET_2D
+		Removed client-sided chat perdiction
 */
 
 #define LATEST_PROTOCOL_VERSION 29

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2826,7 +2826,15 @@ std::wstring Server::handleChat(const std::string &name, const std::wstring &wna
 
 		std::vector<u16> clients = m_clients.getClientIDs();
 
+		/*
+			Send the message back to the inital sender
+			if they are using protocol version >= 29
+		*/
+
 		u16 peer_id_to_avoid_sending = (player ? player->peer_id : PEER_ID_INEXISTENT);
+		if (player->protocol_version >= 29)
+			peer_id_to_avoid_sending = PEER_ID_INEXISTENT;
+
 		for (u16 i = 0; i < clients.size(); i++) {
 			u16 cid = clients[i];
 			if (cid != peer_id_to_avoid_sending)


### PR DESCRIPTION
Network lag isn't really a big issue with chat and chat prediction makes writing mods harder. See #4976.