### PR TITLE
Undersampling

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -340,7 +340,7 @@ texture_min_size (Minimum texture size for filters) int 64
 #    when set to higher number than 0.
 fsaa (FSAA) enum 0 0,1,2,4,8,16
 
-#    Undersampling is similat to using lower scrren resolution, but it applies
+#    Undersampling is similar to using lower screen resolution, but it applies
 #    to the game world only, keeping the GUI intact.
 #    It should give significant performance boost at the cost of less detailed image.
 undersampling (Undersampling) enum 0 0,2,3,4

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -340,6 +340,11 @@ texture_min_size (Minimum texture size for filters) int 64
 #    when set to higher number than 0.
 fsaa (FSAA) enum 0 0,1,2,4,8,16
 
+#    Undersampling is similat to using lower scrren resolution, but it applies
+#    to the game world only, keeping the GUI intact.
+#    It should give significant performance boost at the cost of less detailed image.
+undersampling (Undersampling) enum 0 0,2,3,4
+
 [***Shaders]
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -377,6 +377,12 @@ enable_client_modding (Client modding) bool false
 #    type: enum values: 0, 1, 2, 4, 8, 16
 # fsaa = 0
 
+#    Undersampling is similar to using lower screen resolution, but it applies
+#    to the game world only, keeping the GUI intact.
+#    It should give significant performance boost at the cost of less detailed image.
+#    type: enum values: 0, 2, 3, 4
+# undersampling = 0
+
 #### Shaders
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -106,6 +106,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("show_debug", "true");
 #endif
 	settings->setDefault("fsaa", "0");
+	settings->setDefault("undersampling", "0");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -459,6 +459,7 @@ void draw_pageflip_3d_mode(Camera& camera, bool show_hud,
 #endif
 }
 
+// returns (size / coef), rounded upwards
 inline int scaledown(int coef, int size)
 {
 	return (size + coef - 1) / coef;
@@ -470,13 +471,13 @@ void draw_plain(Camera &camera, bool show_hud,
 		bool draw_wield_tool, Client &client, gui::IGUIEnvironment *guienv,
 		video::SColor skycolor)
 {
-// Undersampling-specific stuff
+	// Undersampling-specific stuff
 	static video::ITexture *image = NULL;
 	static v2u32 last_pixelated_size = v2u32(0, 0);
 	int undersampling = g_settings->getU16("undersampling");
 	v2u32 pixelated_size;
 	v2u32 dest_size;
-	if (undersampling) {
+	if (undersampling > 0) {
 		pixelated_size = v2u32(scaledown(undersampling, screensize.X),
 				scaledown(undersampling, screensize.Y));
 		dest_size = v2u32(undersampling * pixelated_size.X, undersampling * pixelated_size.Y);
@@ -487,7 +488,7 @@ void draw_plain(Camera &camera, bool show_hud,
 		driver->setRenderTarget(image, true, true, skycolor);
 	}
 
-// Render
+	// Render
 	smgr->drawAll();
 	driver->setTransform(video::ETS_WORLD, core::IdentityMatrix);
 	if (show_hud) {
@@ -497,8 +498,8 @@ void draw_plain(Camera &camera, bool show_hud,
 		}
 	}
 
-// Upscale lowres render
-	if (undersampling) {
+	// Upscale lowres render
+	if (undersampling > 0) {
 		driver->setRenderTarget(0, true, true);
 		driver->draw2DImage(image,
 				irr::core::rect<s32>(0, 0, dest_size.X, dest_size.Y),

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -464,21 +464,21 @@ inline int scaledown(int coef, int size)
 	return (size + coef - 1) / coef;
 }
 
-void draw_plain(Camera& camera, bool show_hud,
-		Hud& hud, video::IVideoDriver* driver,
-		scene::ISceneManager* smgr, const v2u32& screensize,
-		bool draw_wield_tool, Client& client, gui::IGUIEnvironment* guienv,
+void draw_plain(Camera &camera, bool show_hud,
+		Hud &hud, video::IVideoDriver *driver,
+		scene::ISceneManager *smgr, const v2u32 &screensize,
+		bool draw_wield_tool, Client &client, gui::IGUIEnvironment *guienv,
 		video::SColor skycolor)
 {
 // Undersampling-specific stuff
-	static video::ITexture* image = NULL;
+	static video::ITexture *image = NULL;
 	static v2u32 last_pixelated_size = v2u32(0, 0);
 	int undersampling = g_settings->getU16("undersampling");
 	v2u32 pixelated_size;
 	v2u32 dest_size;
-	if(undersampling)
-	{
-		pixelated_size = v2u32(scaledown(undersampling, screensize.X), scaledown(undersampling, screensize.Y));
+	if (undersampling) {
+		pixelated_size = v2u32(scaledown(undersampling, screensize.X),
+				scaledown(undersampling, screensize.Y));
 		dest_size = v2u32(undersampling * pixelated_size.X, undersampling * pixelated_size.Y);
 		if (pixelated_size != last_pixelated_size) {
 			init_texture(driver, pixelated_size, &image, "mt_drawimage_img1");
@@ -498,8 +498,7 @@ void draw_plain(Camera& camera, bool show_hud,
 	}
 
 // Upscale lowres render
-	if(undersampling)
-	{
+	if (undersampling) {
 		driver->setRenderTarget(0, true, true);
 		driver->draw2DImage(image,
 				irr::core::rect<s32>(0, 0, dest_size.X, dest_size.Y),
@@ -508,7 +507,7 @@ void draw_plain(Camera& camera, bool show_hud,
 }
 
 void draw_scene(video::IVideoDriver *driver, scene::ISceneManager *smgr,
-		Camera &camera, Client& client, LocalPlayer *player, Hud &hud,
+		Camera &camera, Client &client, LocalPlayer *player, Hud &hud,
 		Minimap &mapper, gui::IGUIEnvironment *guienv,
 		const v2u32 &screensize, const video::SColor &skycolor,
 		bool show_hud, bool show_minimap)

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -152,6 +152,8 @@ fake_function() {
 	gettext("When using bilinear/trilinear/anisotropic filters, low-resolution textures\ncan be blurred, so automatically upscale them with nearest-neighbor\ninterpolation to preserve crisp pixels.  This sets the minimum texture size\nfor the upscaled textures; higher values look sharper, but require more\nmemory.  Powers of 2 are recommended.  Setting this higher than 1 may not\nhave a visible effect unless bilinear/trilinear/anisotropic filtering is\nenabled.");
 	gettext("FSAA");
 	gettext("Experimental option, might cause visible spaces between blocks\nwhen set to higher number than 0.");
+	gettext("Undersampling");
+	gettext("Undersampling is similar to using lower screen resolution, but it applies\nto the game world only, keeping the GUI intact.\nIt should give significant performance boost at the cost of less detailed image.");
 	gettext("Shaders");
 	gettext("Shaders");
 	gettext("Shaders allow advanced visual effects and may increase performance on some video cards.\nThy only work with the OpenGL video backend.");


### PR DESCRIPTION
This simple patch adds support of undersampling to improve performance on low-end GPUs. That’s better than changing screen resolution as it keeps GUI (and other programs) intact and may even be used in windowed mode.
Just compare the screenshots:

Fast | Nice | New
-- | -- | --
(1) [![serie1_place2.png](https://s20.postimg.org/m4y8czp5l/serie1_place2.png)](https://s20.postimg.org/8o19u4eu5/serie1_place2.png) | (3) [![serie3-place2.png](https://s20.postimg.org/lkelwk6jd/serie3_place2.png)](https://s20.postimg.org/6og2oyv4t/serie3_place2.png) | (8) [![serie8-place2.png](https://s20.postimg.org/k3yi0oe8p/serie8_place2.png)](https://s20.postimg.org/toi4nk3kt/serie8_place2.png)
(4) [![serie4_place3.png](https://s20.postimg.org/pqzgbw655/serie4_place3.png)](https://s20.postimg.org/bxb3mudjx/serie4_place3.png) | (5) [![series7-place3.png](https://s20.postimg.org/xv7kgmsk9/serie5_place3.png)](https://s20.postimg.org/5v3gwcp3x/serie5_place3.png) | (7) [![series7-place3.png](https://s20.postimg.org/mb2qoljix/serie7_place3.png)](https://s20.postimg.org/dstak9d0d/serie7_place3.png)

IMO small lose of details is acceptable; it looks better than with hardware resolution change anyway.

Different configurations [and screenshots](https://postimg.org/gallery/1vr0sxq2y/):

Series | Filtering | Tone mapping | Textures | US | Look | Performance
-- | -- | -- | -- | -- | -- | --
1 | none | off | 16px | off | grayish | normal
2 | full | off | 16/64px (upscale) | off | grayish | normal
3 | none | on | 16px | off | nice | low
4 | none | off | 64px | off | grayish | acceptable
5 | none | on | 64px | off | acceptable | low
6 | none | on | 64px | 2x | noisy | normal
7 | full | on | 64px | 2x | nice | normal
8 | none | off | 16px | 2x | nice | normal