### PR TITLE
Fix MSVC build

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "content_sao.h"
+#include "util/mathconstants.h"
 #include "util/serialize.h"
 #include "collision.h"
 #include "environment.h"

--- a/src/treegen.cpp
+++ b/src/treegen.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stack>
 #include "util/pointer.h"
 #include "util/numeric.h"
+#include "util/mathconstants.h"
 #include "map.h"
 #include "serverenvironment.h"
 #include "nodedef.h"


### PR DESCRIPTION
Build broken by 98e36d7

The compiler complained about the missing `M_PI`.