### PR TITLE
Remove `mathconstants.h` and use the correct way to get `M_PI` in MSVC.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,6 +284,8 @@ if(WIN32)
 		set(PLATFORM_LIBS dbghelp.lib ${PLATFORM_LIBS})
 		# Surpress some useless warnings
 		add_definitions ( /D "_CRT_SECURE_NO_DEPRECATE" /W1 )
+		# Get M_PI to work
+		add_definitions(/D "_USE_MATH_DEFINES")
 	else() # Probably MinGW = GCC
 		set(PLATFORM_LIBS "")
 	endif()

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -31,7 +31,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "event.h"
 #include "profiler.h"
 #include "util/numeric.h"
-#include "util/mathconstants.h"
 #include "constants.h"
 #include "fontengine.h"
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "clientiface.h"
 #include "util/numeric.h"
-#include "util/mathconstants.h"
 #include "remoteplayer.h"
 #include "settings.h"
 #include "mapblock.h"

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -29,7 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "profiler.h"
 #include "settings.h"
 #include "camera.h"               // CameraModes
-#include "util/mathconstants.h"
 #include "util/basic_macros.h"
 #include <algorithm>
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -26,7 +26,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content_cao.h"
 #include "util/numeric.h" // For IntervalLimiter
 #include "util/serialize.h"
-#include "util/mathconstants.h"
 #include "util/basic_macros.h"
 #include "client/tile.h"
 #include "environment.h"

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -18,7 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "content_sao.h"
-#include "util/mathconstants.h"
 #include "util/serialize.h"
 #include "collision.h"
 #include "environment.h"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -32,7 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "gamedef.h"
 #include "util/directiontables.h"
-#include "util/mathconstants.h"
 #include "util/basic_macros.h"
 #include "rollback_interface.h"
 #include "environment.h"

--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "map.h" //for MMVManip
 #include "util/numeric.h"
-#include "util/mathconstants.h"
 #include "porting.h"
 #include "settings.h"
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -53,7 +53,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "event_manager.h"
 #include "serverlist.h"
 #include "util/string.h"
-#include "util/mathconstants.h"
 #include "rollback.h"
 #include "util/serialize.h"
 #include "util/thread.h"

--- a/src/treegen.cpp
+++ b/src/treegen.cpp
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stack>
 #include "util/pointer.h"
 #include "util/numeric.h"
-#include "util/mathconstants.h"
 #include "map.h"
 #include "serverenvironment.h"
 #include "nodedef.h"

--- a/src/util/mathconstants.h
+++ b/src/util/mathconstants.h
@@ -1,7 +1,0 @@
-#include <math.h>
-
-// MSVC doesn't seem to define this
-#ifndef M_PI
-	#define M_PI 3.1415926535
-#endif
-

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -18,7 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "numeric.h"
-#include "mathconstants.h"
 
 #include "log.h"
 #include "../constants.h" // BS, MAP_BLOCKSIZE


### PR DESCRIPTION
See https://msdn.microsoft.com/en-us/library/4hwaceh6(v=vs.120).aspx