### PR TITLE
Add `clear_chat` chat command.

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -940,3 +940,12 @@ core.register_chatcommand("last-login", {
 		return false, "Last login time is unknown"
 	end,
 })
+
+core.register_chatcommand("clear_chat", {
+	description = "Clear the recent chat",
+	func = function(name, param)
+		for _ = 1, 10 do
+			core.chat_send_player(name, " ")
+		end
+	end,
+})


### PR DESCRIPTION
The chat often obscures coordinate in the F5 debug data. Fixes  #5067.