### PR TITLE
Add chatcommand unregister and override API

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -15,6 +15,24 @@ function core.register_chatcommand(cmd, def)
 	core.registered_chatcommands[cmd] = def
 end
 
+function core.unregister_chatcommand(name)
+	if core.registered_chatcommands[name] then
+		core.registered_chatcommands[name] = nil
+	else
+		core.log("warning", "Not unregistering chatcommand " ..name..
+			" because it doesn't exist.")
+	end
+end
+
+function core.override_chatcommand(name, redefinition)
+	local chatcommand = core.registered_chatcommands[name]
+	assert(chatcommand, "Attempt to override non-existent chatcommand "..name)
+	for k, v in pairs(redefinition) do
+		rawset(chatcommand, k, v)
+	end
+	core.registered_chatcommands[name] = chatcommand
+end
+
 core.register_on_chat_message(function(name, message)
 	local cmd, param = string.match(message, "^/([^ ]+) *(.*)")
 	if not param then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2077,6 +2077,10 @@ Call these functions only at load time!
 ### Other registration functions
 * `minetest.register_chatcommand(cmd, chatcommand definition)`
     * Adds definition to minetest.registered_chatcommands
+* `minetest.override_chatcommand(name, redefinition)`
+    * Overrides fields of a chatcommand registered with register_chatcommand.
+* `minetest.unregister_chatcommand(name)`
+    * Unregisters a chatcommands registered with register_chatcommand.
 * `minetest.register_privilege(name, definition)`
     * `definition`: `"description text"`
     * `definition`: `{ description = "description text", give_to_singleplayer = boolean}`


### PR DESCRIPTION
Introduces two functions to unregister and override chatcommands.

```lua
minetest.unregister_chatcommand("<name>")
minetest.override_chatcommand("<name>", {<redifinition>})
```

Examples:
```lua
minetest.unregister_chatcommand("teleport")

minetest.override_chatcommand("teleport", {
    description = "Overridden teleport Command",
    params = "<none>",
    privs = { shout = true },
    func = function()
        return false, "teleport command has been overriden."
    end,
})
```