### PR TITLE
Dungeons: Support nodebox stairs wider than 1 node 

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -437,14 +437,22 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 					// rotate face 180 deg if
 					// making stairs backwards
 					int facedir = dir_to_facedir(dir * make_stairs);
+					v3s16 ps = p;
+					u16 stair_width = (dir.Z != 0) ? dp.holesize.X : dp.holesize.Z;
+					// Stair width direction vector
+					v3s16 swv = (dir.Z != 0) ? v3s16(1, 0, 0) : v3s16(0, 0, 1);
 
-					u32 vi = vm->m_area.index(p.X - dir.X, p.Y - 1, p.Z - dir.Z);
-					if (vm->m_data[vi].getContent() == dp.c_wall)
-						vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
+					for (u16 st = 0; st < stair_width; st++) {
+						u32 vi = vm->m_area.index(ps.X - dir.X, ps.Y - 1, ps.Z - dir.Z);
+						if (vm->m_data[vi].getContent() == dp.c_wall)
+							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
 
-					vi = vm->m_area.index(p.X, p.Y, p.Z);
-					if (vm->m_data[vi].getContent() == dp.c_wall)
-						vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
+						vi = vm->m_area.index(ps.X, ps.Y, ps.Z);
+						if (vm->m_data[vi].getContent() == dp.c_wall)
+							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
+
+						ps += swv;
+					}
 				}
 			} else {
 				makeFill(p + v3s16(-1, -1, -1),


### PR DESCRIPTION
Previously, code did not support stair nodeboxes in corridors wider
than 1 node.
Make stair nodeboxes full width even in corridors with different
widths in X and Z directions.
/////////////////////////////////////////////////

![screenshot_20170121_063529](https://cloud.githubusercontent.com/assets/3686677/22172635/98afcaa8-dfa4-11e6-9c1d-d85ce960d3b6.png)

^ 3 wide.

Don't know if anyone's noticed but, if you set the dungeon parameter dp.holesize to create corridors / stairs wider than 1 node the nodebox stairs are only placed 1 node wide, The code only supports nodebox stairs 1 node wide. This commit 'fixes' that, although stair nodeboxes often fail to generate as they did before (there's a comment in the code about this long running bug that is hard to fix).

Nodebox stairs only work when they go upwards in South or West directions, and then not always, but in testing i have discovered this is the case currently too, so this is not caused by my commit.

Desert dungeons have diagonal corridors so nodebox stairs are auto-disabled. Cobble dungeons have always had 1 node wide corridors / stairs. It is only when i added sandstone dungeons with 2 wide corridors / stairs that i discovered this bug.

![screenshot_20170122_091923](https://cloud.githubusercontent.com/assets/3686677/22181535/78ef0ab6-e086-11e6-9bcc-f2a13f38596b.png)

^ Current behaviour with 2-wide corridors / stairs