### PR TITLE
Warning fix for 2ea60156437962d7d29d20606bf5d9189059f76b

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2086,7 +2086,9 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 
 			if(block)
 			{
-				if (block->m_static_objects.m_stored.size() >= g_settings->getU16("max_objects_per_block")) {
+				// Force delete object if mapblock is full, but ignore players
+				if (obj->getType() != ACTIVEOBJECT_TYPE_PLAYER &&
+					block->m_static_objects.m_stored.size() >= g_settings->getU16("max_objects_per_block")) {
 					warningstream << "ServerEnv: Trying to store id = " << obj->getId()
 						<< " statically but block " << PP(blockpos)
 						<< " already contains "
@@ -2143,12 +2145,6 @@ void ServerEnvironment::deactivateFarObjects(bool force_delete)
 				<<"; not deleting yet"<<std::endl;
 
 			obj->m_pending_deactivation = true;
-			continue;
-		}
-
-		// If it's a forced delete, there are too many objects in mapblock
-		// Ignore players, they should not be removed on force delete
-		if (force_delete && obj->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
 			continue;
 		}
 


### PR DESCRIPTION
Neither flag as force delete nor show the warning when mapblock is full and object is a player