### PR TITLE
Make entity on_punch same signature and behaviour as player on_punch

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1379,7 +1379,7 @@ a non-tool item, so that it can do something else than take damage.
 
 On the Lua side, every punch calls:
 
-    entity:on_punch(puncher, time_from_last_punch, tool_capabilities, direction)
+    entity:on_punch(puncher, time_from_last_punch, tool_capabilities, direction, damage)
 
 This should never be called directly, because damage is usually not handled by
 the entity itself.
@@ -1390,6 +1390,9 @@ the entity itself.
 * `tool_capabilities` can be `nil`.
 * `direction` is a unit vector, pointing from the source of the punch to
    the punched object.
+* `damage` damage that will be done to entity
+Return value of this function will determin if damage is done by this function 
+(retval true) or shall be done by engine (retval false)
 
 To punch an entity/object in Lua, call:
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -574,28 +574,32 @@ int LuaEntitySAO::punch(v3f dir,
 			punchitem,
 			time_from_last_punch);
 
-	if (result.did_punch) {
-		setHP(getHP() - result.damage);
+	bool damage_handled = m_env->getScriptIface()->luaentity_Punch(m_id, puncher,
+			time_from_last_punch, toolcap, dir, result.did_punch ? result.damage : 0);
 
-		if (result.damage > 0) {
-			std::string punchername = puncher ? puncher->getDescription() : "nil";
+	if (!damage_handled) {
+		if (result.did_punch) {
+			setHP(getHP() - result.damage);
 
-			actionstream << getDescription() << " punched by "
-					<< punchername << ", damage " << result.damage
-					<< " hp, health now " << getHP() << " hp" << std::endl;
+			if (result.damage > 0) {
+				std::string punchername = puncher ? puncher->getDescription() : "nil";
+
+				actionstream << getDescription() << " punched by "
+						<< punchername << ", damage " << result.damage
+						<< " hp, health now " << getHP() << " hp" << std::endl;
+			}
+
+			std::string str = gob_cmd_punched(result.damage, getHP());
+			// create message and add to list
+			ActiveObjectMessage aom(getId(), true, str);
+			m_messages_out.push(aom);
 		}
-
-		std::string str = gob_cmd_punched(result.damage, getHP());
-		// create message and add to list
-		ActiveObjectMessage aom(getId(), true, str);
-		m_messages_out.push(aom);
 	}
 
 	if (getHP() == 0)
 		m_removed = true;
 
-	m_env->getScriptIface()->luaentity_Punch(m_id, puncher,
-			time_from_last_punch, toolcap, dir);
+
 
 	return result.wear;
 }

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -224,10 +224,10 @@ void ScriptApiEntity::luaentity_Step(u16 id, float dtime)
 }
 
 // Calls entity:on_punch(ObjectRef puncher, time_from_last_punch,
-//                       tool_capabilities, direction)
-void ScriptApiEntity::luaentity_Punch(u16 id,
+//                       tool_capabilities, direction, damage)
+bool ScriptApiEntity::luaentity_Punch(u16 id,
 		ServerActiveObject *puncher, float time_from_last_punch,
-		const ToolCapabilities *toolcap, v3f dir)
+		const ToolCapabilities *toolcap, v3f dir, s16 damage)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -242,8 +242,8 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 	// Get function
 	lua_getfield(L, -1, "on_punch");
 	if (lua_isnil(L, -1)) {
-		lua_pop(L, 2); // Pop on_punch and entitu
-		return;
+		lua_pop(L, 2); // Pop on_punch and entity
+		return false;
 	}
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_pushvalue(L, object);  // self
@@ -251,11 +251,14 @@ void ScriptApiEntity::luaentity_Punch(u16 id,
 	lua_pushnumber(L, time_from_last_punch);
 	push_tool_capabilities(L, *toolcap);
 	push_v3f(L, dir);
+	lua_pushnumber(L, damage);
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 5, 0, error_handler));
+	PCALL_RES(lua_pcall(L, 6, 0, error_handler));
 
+	bool retval = lua_toboolean(L, -1);
 	lua_pop(L, 2); // Pop object and error handler
+	return retval;
 }
 
 // Calls entity:on_rightclick(ObjectRef clicker)

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -38,9 +38,9 @@ public:
 	void luaentity_GetProperties(u16 id,
 			ObjectProperties *prop);
 	void luaentity_Step(u16 id, float dtime);
-	void luaentity_Punch(u16 id,
+	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,
-			const ToolCapabilities *toolcap, v3f dir);
+			const ToolCapabilities *toolcap, v3f dir, s16 damage);
 	void luaentity_Rightclick(u16 id,
 			ServerActiveObject *clicker);
 };


### PR DESCRIPTION
Current situation (retval bool specifies if damage handling is already done in lua):
**player:**
bool on_punch(puncher, time_from_last_punch, tool_capabilities, direction, damage)

**entity:**
void on_punch(puncher, time_from_last_punch, tool_capabilities, direction)

**New for both:**
bool on_punch(puncher, time_from_last_punch, tool_capabilities, direction, damage)

Usecase:
No-Damage handling e.g. for "punching" mobs with special tools