### PR TITLE
ModSecurity: os.exit should not be used by Lua API

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -99,7 +99,6 @@ void ScriptApiSecurity::initializeSecurity()
 		"clock",
 		"date",
 		"difftime",
-		"exit",
 		"getenv",
 		"setlocale",
 		"time",


### PR DESCRIPTION
os.exit will exit not using proper resource liberation paths. Mods should call the proper exit call from our API