### PR TITLE
Zoom FOV: Reduce minimum zoom FOV to 7 degrees 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -440,7 +440,7 @@ fov (Field of view) int 72 30 160
 
 #    Field of view while zooming in degrees.
 #    This requires the "zoom" privilege on the server.
-zoom_fov (Field of view for zoom) int 15 15 160
+zoom_fov (Field of view for zoom) int 15 7 160
 
 #    Adjust the gamma encoding for the light tables. Higher numbers are brighter.
 #    This setting is for the client only and is ignored by the server.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -502,7 +502,7 @@
 
 #    Field of view while zooming in degrees.
 #    This requires the "zoom" privilege on the server.
-#    type: int min: 15 max: 160
+#    type: int min: 7 max: 160
 # zoom_fov = 15
 
 #    Adjust the gamma encoding for the light tables. Higher numbers are brighter.

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -393,8 +393,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	} else {
 		fov_degrees = m_cache_fov;
 	}
-	fov_degrees = MYMAX(fov_degrees, 10.0);
-	fov_degrees = MYMIN(fov_degrees, 170.0);
+	fov_degrees = rangelim(fov_degrees, 7.0, 160.0);
 
 	// FOV and aspect ratio
 	m_aspect = (f32) porting::getWindowSize().X / (f32) porting::getWindowSize().Y;


### PR DESCRIPTION
The default of 15 is unchanged.
7 degrees is x10 magnification which is common for binoculars.
Alter hardcoded limits in camera.cpp:
Minimum 7 degrees.
Maximum 160 degrees to match upper limits in advanced settings.
////////////////////////////////////////////////////

Addresses #4887 by reducing the minimum zoom FOV, the current minimum of 15 degrees (x5 magnification) is underpowered and is too high for a minimum.
7 degrees (x10 magnification) seems reasonable for old-technology portable telescope items.

![screenshot_20170122_041205_z7_d160](https://cloud.githubusercontent.com/assets/3686677/22180448/8e373524-e068-11e6-88d8-efa62108ce1a.png)

![screenshot_20170122_041209_z7_d160](https://cloud.githubusercontent.com/assets/3686677/22180449/91a6d4bc-e068-11e6-9735-2d00ab52a110.png)

^ 7 degree FOV zoom at 160 nodes distance