### PR TITLE
Dungeons: Add nodebox stairs to desert and sandstone dungeons 

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -604,6 +604,7 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emer
 	c_cobble               = ndef->getId("mapgen_cobble");
 	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
 	c_mossycobble          = ndef->getId("mapgen_mossycobble");
+	c_stair_desert_stone   = ndef->getId("mapgen_stair_desert_stone");
 	c_sandstonebrick       = ndef->getId("mapgen_sandstonebrick");
 	c_stair_sandstonebrick = ndef->getId("mapgen_stair_sandstonebrick");
 
@@ -867,7 +868,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y, MgStoneType stone_type)
 	case MGSTONE_DESERT_STONE:
 		dp.c_wall     = c_desert_stone;
 		dp.c_alt_wall = CONTENT_IGNORE;
-		dp.c_stair    = c_desert_stone;
+		dp.c_stair    = c_stair_desert_stone;
 
 		dp.diagonal_dirs = true;
 		dp.holesize      = v3s16(2, 3, 2);
@@ -877,7 +878,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y, MgStoneType stone_type)
 	case MGSTONE_SANDSTONE:
 		dp.c_wall     = c_sandstonebrick;
 		dp.c_alt_wall = CONTENT_IGNORE;
-		dp.c_stair    = c_sandstonebrick;
+		dp.c_stair    = c_stair_sandstonebrick;
 
 		dp.diagonal_dirs = false;
 		dp.holesize      = v3s16(2, 2, 2);

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -266,6 +266,7 @@ protected:
 	content_t c_cobble;
 	content_t c_stair_cobble;
 	content_t c_mossycobble;
+	content_t c_stair_desert_stone;
 	content_t c_sandstonebrick;
 	content_t c_stair_sandstonebrick;
 


### PR DESCRIPTION
Desert and sandstone dungeons have 2 node wide corridors. Previously,
nodebox stairs were disabled because dungeon generation code did not
support nodebox stairs wider than 1 node, now it does.

Add 'stair desert stone' content id to MappgenBasic.

Requires 'mapgen stair desert stone' to be added to Minetest Game.
/////////////////////////////////////////////////////////////

![screenshot_20170126_182608](https://cloud.githubusercontent.com/assets/3686677/22344754/34f558c0-e3f5-11e6-83ab-19723193e46e.png)

![screenshot_20170123_081904](https://cloud.githubusercontent.com/assets/3686677/22196362/ccf6b88e-e144-11e6-84d1-b543e1a1f01b.png)

Tested.