### PR TITLE
Wrap player yaw to positive degree values

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -811,7 +811,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	v3f speed((f32)ss.X / 100.0, (f32)ss.Y / 100.0, (f32)ss.Z / 100.0);
 
 	pitch = modulo360f(pitch);
-	yaw = modulo360f(yaw);
+	yaw = wrapDegrees_0_360(yaw);
 
 	playersao->setBasePosition(position);
 	player->setSpeed(speed);


### PR DESCRIPTION
Player yaw is currently stored and represented as values between -360 and 360, which leads to some redundancy. This PR changes it so that it is represented as a value between 0 and 360.