### PR TITLE
OpenAL sound: Use a simpler distance model

### DIFF
--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -317,7 +317,7 @@ public:
 			return;
 		}
 
-		alDistanceModel(AL_EXPONENT_DISTANCE);
+		alDistanceModel(AL_INVERSE_DISTANCE);
 
 		infostream<<"Audio: Initialized: OpenAL "<<alGetString(AL_VERSION)
 				<<", using "<<alcGetString(m_device, ALC_DEVICE_SPECIFIER)
@@ -409,7 +409,6 @@ public:
 		alSourcei(sound->source_id, AL_SOURCE_RELATIVE, false);
 		alSource3f(sound->source_id, AL_POSITION, pos.X, pos.Y, pos.Z);
 		alSource3f(sound->source_id, AL_VELOCITY, 0, 0, 0);
-		//alSourcef(sound->source_id, AL_ROLLOFF_FACTOR, 0.7);
 		alSourcef(sound->source_id, AL_REFERENCE_DISTANCE, 30.0);
 		alSourcei(sound->source_id, AL_LOOPING, loop ? AL_TRUE : AL_FALSE);
 		volume = MYMAX(0.0, volume);


### PR DESCRIPTION
In createPlayingSoundAt(), AL_ROLLOFF_FACTOR is not set, so it has
the default value of 1.0, this makes the equation of the currently
used AL_EXPONENT_DISTANCE distance model identical to the equation
of the simpler AL_INVERSE_DISTANCE distance model.

Using AL_INVERSE_DISTANCE means an exponent is not processed,
exponents are quite intensive to process.
There is no change in sound attenuation behaviour.

The commented-out AL_ROLLOFF_FACTOR value is removed as it would
now have a different effect if used.
/////////////////////////////////////////////////////////

![screenshot_20170124_123440](https://cloud.githubusercontent.com/assets/3686677/22247587/80161a5c-e232-11e6-811c-9db2d82dd2b1.png)

^ My test setup for silent footsteps (wool) and repeatable distances from fire (walking into the corners)
^ Final position is head in fire for maximum volume.

In testing i cannot, by listening with headphones, hear any change in sound volumes between current code and this commit.
I tested fire as as shown above, carts (riding and standing beside a circular track as cart passes) and general node dig/dug/place/footstep sounds.

///////////////////////////////////////////////////////

OpenAL has various 'distance models' usable, page 87 here https://www.openal.org/documentation/OpenAL_Programmers_Guide.pdf
Here the distance model is set to 'AL_EXPONENT_DISTANCE' https://github.com/minetest/minetest/blob/master/src/sound_openal.cpp#L320
The distance model equation is:
```
gain = (distance / AL_REFERENCE_DISTANCE) ^ (- AL_ROLLOFF_FACTOR)
```
Here is 'createPlayingSoundAt()' https://github.com/minetest/minetest/blob/master/src/sound_openal.cpp#L398
With the relevant parameters:
```
		//alSourcef(sound->source_id, AL_ROLLOFF_FACTOR, 0.7);
		alSourcef(sound->source_id, AL_REFERENCE_DISTANCE, 30.0);
```
The default for AL_ROLLOFF_FACTOR is 1.0, see pdf page 13.
Since AL_ROLLOFF_FACTOR is the default 1.0 (the value of 0.7 is commented out), the exponential equation becomes (because x ^ -1 = 1 / x):
```
gain = (AL_REFERENCE_DISTANCE / distance)
```
which is the simple inverse distance model, so we can change to AL_INVERSE_DISTANCE to avoid the unnecessary processing of exponents, which are intensive to process.

The equation for AL_INVERSE_DISTANCE is:
```
gain = AL_REFERENCE_DISTANCE / (AL_REFERENCE_DISTANCE +
AL_ROLLOFF_FACTOR * (distance – AL_REFERENCE_DISTANCE))
```
Because AL_ROLLOFF_FACTOR is 1.0 this becomes:
```
gain = (AL_REFERENCE_DISTANCE / distance)
```
So, the exponential model was being used when celeron55 was experimenting with non -1.0 exponents, but he eventually decided not to use an exponent and left it unset, therefore taking the default value of -1.0,