### PR TITLE
Add static_save property to luaentites to not save them statically.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4160,9 +4160,10 @@ Definition tables
         nametag = "", -- by default empty, for players their name is shown if empty
         nametag_color = <color>, -- sets color of nametag as ColorSpec
         infotext = "", -- by default empty, text to be shown when pointed at object
-        no_static_save = false,
-    --  ^ If true, never save this object statically. It will simply be deleted when the block gets unloaded.
-    --  ^ The get_staticdata() callback is never called
+        static_save = true,
+    --  ^ If false, never save this object statically. It will simply be deleted when the block gets unloaded.
+    --  ^ The get_staticdata() callback is never called then.
+    --  ^ Defaults to 'true'
     }
 
 ### Entity definition (`register_entity`)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4160,6 +4160,9 @@ Definition tables
         nametag = "", -- by default empty, for players their name is shown if empty
         nametag_color = <color>, -- sets color of nametag as ColorSpec
         infotext = "", -- by default empty, text to be shown when pointed at object
+        no_static_save = false,
+    --  ^ If true, never save this object statically. It will simply be deleted when the block gets unloaded.
+    --  ^ The get_staticdata() callback is never called
     }
 
 ### Entity definition (`register_entity`)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -105,7 +105,7 @@ public:
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
 	bool isStaticAllowed() const
-	{ return !m_prop.no_static_save; }
+	{ return m_prop.static_save; }
 	void getStaticData(std::string *result) const;
 	int punch(v3f dir,
 			const ToolCapabilities *toolcap=NULL,

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -104,6 +104,8 @@ public:
 			const std::string &data);
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
+	bool isStaticAllowed() const
+	{ return !m_prop.no_static_save; }
 	void getStaticData(std::string *result) const;
 	int punch(v3f dir,
 			const ToolCapabilities *toolcap=NULL,

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -66,6 +66,7 @@ std::string ObjectProperties::dump()
 	os << ", selectionbox=" << PP(selectionbox.MinEdge) << "," << PP(selectionbox.MaxEdge);
 	os << ", pointable=" << pointable;
 	os << ", can_zoom=" << can_zoom;
+	os << ", static_save=" << static_save;
 	return os.str();
 }
 

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -58,7 +58,7 @@ struct ObjectProperties
 	std::string infotext;
 	//! For dropped items, this contains item information.
 	std::string wield_item;
-	bool no_static_save = false;
+	bool static_save = true;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -58,6 +58,7 @@ struct ObjectProperties
 	std::string infotext;
 	//! For dropped items, this contains item information.
 	std::string wield_item;
+	bool no_static_save = false;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -294,7 +294,10 @@ void read_object_properties(lua_State *L, int index,
 		prop->automatic_face_movement_max_rotation_per_sec = luaL_checknumber(L, -1);
 	}
 	lua_pop(L, 1);
+
 	getstringfield(L, -1, "infotext", prop->infotext);
+	getboolfield(L, -1, "no_static_save", prop->no_static_save);
+
 	lua_getfield(L, -1, "wield_item");
 	if (!lua_isnil(L, -1))
 		prop->wield_item = read_item(L, -1, idef).getItemString();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -379,6 +379,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "automatic_face_movement_max_rotation_per_sec");
 	lua_pushlstring(L, prop->infotext.c_str(), prop->infotext.size());
 	lua_setfield(L, -2, "infotext");
+	lua_pushboolean(L, prop->static_save);
+	lua_setfield(L, -2, "static_save");
 	lua_pushlstring(L, prop->wield_item.c_str(), prop->wield_item.size());
 	lua_setfield(L, -2, "wield_item");
 }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -296,9 +296,7 @@ void read_object_properties(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	getstringfield(L, -1, "infotext", prop->infotext);
-	bool no_static_save;
-	getboolfield(L, -1, "no_static_save", no_static_save);
-	prop->static_save=!no_static_save;
+	getboolfield(L, -1, "static_save", prop->static_save);
 
 	lua_getfield(L, -1, "wield_item");
 	if (!lua_isnil(L, -1))

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -296,7 +296,9 @@ void read_object_properties(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	getstringfield(L, -1, "infotext", prop->infotext);
-	getboolfield(L, -1, "no_static_save", prop->no_static_save);
+	bool no_static_save;
+	getboolfield(L, -1, "no_static_save", no_static_save);
+	prop->static_save=!no_static_save;
 
 	lua_getfield(L, -1, "wield_item");
 	if (!lua_isnil(L, -1))


### PR DESCRIPTION
Introduces an object property "no_static_save".
Causes Minetest to not save these objects statically.
This allows for temporary objects that would get deleted anyway as soon as they are loaded again without the static saving overhead.
Examples:
- WorldEdit Position indicators
- My trains (advtrains) (after travelling through unloaded terrain, wagon entities are automatically re_spawned, so static blocks can become cluttered with duplicate wagon entities)