### PR TITLE
Plantlike: Fix visual_scale being applied squared

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1602,8 +1602,6 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				}
 
 				for (int i = 0; i < 4; i++) {
-					vertices[i].Pos *= f.visual_scale;
-					vertices[i].Pos.Y += BS/2 * (f.visual_scale - 1);
 					if (data->m_smooth_lighting)
 						vertices[i].Color = blendLight(frame, vertices[i].Pos, tile.color);
 					vertices[i].Pos += intToFloat(p, BS);


### PR DESCRIPTION
Visual_scale was applied twice to plantlike by accident sometime between
2011 and 2013, squaring the requested scale value. Visual_scale is
correctly applied once in it's other uses in signlike and torchlike.

Two lines of code are removed, they also had no effect for the vast
majority of nodes with the default visual_scale of 1.0.
The texture continues to have it's base at ground level.
/////////////////////////////////////////////////////

New PR replacing #5070 

Below, papyrus with 'visual_scale = 2.0'

![screenshot_20170119_030331](https://cloud.githubusercontent.com/assets/3686677/22092221/160676c6-ddf4-11e6-8527-da1d3822fc1b.png)

^ Currently

![screenshot_20170119_030207](https://cloud.githubusercontent.com/assets/3686677/22092223/1e896114-ddf4-11e6-9a90-27b2cd9e7134.png)

^ This commit

See discussion in issue #5069

When added by celeron55 visual_scale was applied once https://github.com/minetest/minetest/commit/eed727c61b51f46f6d172c56ecd26a3b1752d449 here https://github.com/minetest/minetest/blob/eed727c61b51f46f6d172c56ecd26a3b1752d449/src/content_mapblock.cpp#L825
Since then it was accidently applied a second time in S3DVertex.
Looks like it was broken during the many changes meant to keep the texture base at ground level, and no-one noticed the double application.

If approved i will make a post in the forum news section detailing the necessary adjustment to visual_scale, we are early in a release cycle so plenty of time for modders to make the quick edit.

If you are concerned about the mod breakage consider this: overall this will actually save modders time and frustration.
Currently a modder will want a texture, for example, 1.5 times larger, they use 1.5 and get something much bigger. Because they don't know the engine code responsible they won't know it has been squared, so they have to spend a few minutes using trial-and-error to get the texture exactly 1.5 nodes high, with associated small amounts of confusion and frustration.

This experience has happened to me more than once.
This benefit more than compensates for having to update a mod.

This will also make it easier to add new plantlike meshoptions in future, as the second application of visual_scale makes things complex. For example when i experimented with a plantlike meshoption that is fixed to ceilings and expands downwards with visual_scale it was difficult to get it to scale properly, i had to add code to undo the second application of visual_scale.

It was suggested that this transition could be done by introducing a new, correct, API with an alternative name like "visualscale" and deprecating the old one. This is a method sometimes done to avoid mod breakage, but in this case i consider this too messy and disruptive to be worth doing. It would need another node property added for nodes, extra code for handling old and new versions, and the new name would not match with the 'visual_scale' used for other drawtypes.

So, a little bit of pain but we can get this cleanly and simply sorted out.