### PR TITLE
Dungeongen: Fix out-of-voxelmanip access segfault

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -415,8 +415,8 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 		if (partcount != 0)
 			p.Y += make_stairs;
 
-		if (vm->m_area.contains(p) && vm->m_area.contains(p + v3s16(0, 1, 0)) &&
-				vm->m_area.contains(v3s16(p.X - dir.X, p.Y - 1, p.Z - dir.Z))) {
+		// Check segment of minimum size corridor is in voxelmanip
+		if (vm->m_area.contains(p) && vm->m_area.contains(p + v3s16(0, 1, 0))) {
 			if (make_stairs) {
 				makeFill(p + v3s16(-1, -1, -1),
 					dp.holesize + v3s16(2, 3, 2),
@@ -444,11 +444,13 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 
 					for (u16 st = 0; st < stair_width; st++) {
 						u32 vi = vm->m_area.index(ps.X - dir.X, ps.Y - 1, ps.Z - dir.Z);
-						if (vm->m_data[vi].getContent() == dp.c_wall)
+						if (vm->m_area.contains(ps + v3s16(-dir.X, -1, -dir.Z)) &&
+								vm->m_data[vi].getContent() == dp.c_wall)
 							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
 
 						vi = vm->m_area.index(ps.X, ps.Y, ps.Z);
-						if (vm->m_data[vi].getContent() == dp.c_wall)
+						if (vm->m_area.contains(ps) &&
+								vm->m_data[vi].getContent() == dp.c_wall)
 							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
 
 						ps += swv;


### PR DESCRIPTION
My recent dungeon commit allowed stairs to be placed across the full
width of corridors, but some of the new node positions accessed were
missing checks for being within the voxelmanip, causing occasional
segfaults near dungeons with corridors wider than 1 node.

Add 'vm->m_area.contains(pos)' checks just before stair position
voxelmanip access. This allows an earlier check to be removed as it
is now redundant.
///////////////////////////////////////////////////////

My recent commit https://github.com/minetest/minetest/commit/d413dfe87c326385be4259afc2830e3e1638bf3c allowed stairs to be placed in a larger volume, but was missing checks for these new node positions being inside the voxelmanip. This causes rare segfaults when sandstone dungeons are generated, because they have 2-wide corridors.

Very similar bug and fix to https://github.com/minetest/minetest/commit/57b429574ef92c62d202955535896b36845b88db but now done properly by moving the 'contains' checks to just before getting content and placing the stairs.