### PR TITLE
Dungeongen: Fix selection of diagonal corridors

### DIFF
--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -622,7 +622,7 @@ v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs)
 			dir.Z = random.next() % 3 - 1;
 			dir.Y = 0;
 			dir.X = random.next() % 3 - 1;
-		} while ((dir.X == 0 && dir.Z == 0) && trycount < 10);
+		} while ((dir.X == 0 || dir.Z == 0) && trycount < 10);
 
 		return dir;
 	} else {


### PR DESCRIPTION
The do .. while loop is waiting for both dir.X and dir.Z to be non-zero,
so should continue to loop if either dir.X or dir.Z are zero. The brackets
present suggest this was intended to be OR not AND.
///////////////////////////////////////////////////