### PR TITLE
Fix synchronization issue at thread start

### DIFF
--- a/src/threading/mutex.cpp
+++ b/src/threading/mutex.cpp
@@ -88,6 +88,15 @@ void Mutex::lock()
 #endif
 }
 
+bool Mutex::try_lock()
+{
+#if USE_WIN_MUTEX
+	return TryEnterCriticalSection(&mutex) != 0;
+#else
+	return pthread_mutex_trylock(&mutex) == 0;
+#endif
+}
+
 void Mutex::unlock()
 {
 #if USE_WIN_MUTEX

--- a/src/threading/mutex.h
+++ b/src/threading/mutex.h
@@ -56,6 +56,8 @@ public:
 	void lock();
 	void unlock();
 
+	bool try_lock();
+
 protected:
 	Mutex(bool recursive);
 	void init_mutex(bool recursive);

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -252,7 +252,7 @@ DWORD WINAPI Thread::threadProc(LPVOID param)
 	Thread *thr = (Thread *)param;
 
 #ifdef _AIX
-	m_kernel_thread_id = thread_self();
+	thr->m_kernel_thread_id = thread_self();
 #endif
 
 	thr->setName(thr->m_name);

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -153,6 +153,7 @@ private:
 	Atomic<bool> m_request_stop;
 	Atomic<bool> m_running;
 	Mutex m_mutex;
+	Mutex m_start_finished_mutex;
 
 #if USE_CPP11_THREADS
 	std::thread *m_thread_obj;

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -39,9 +39,7 @@ static TestThreading g_test_instance;
 
 void TestThreading::runTests(IGameDef *gamedef)
 {
-#if !(defined(__MACH__) && defined(__APPLE__))
 	TEST(testStartStopWait);
-#endif
 	TEST(testThreadKill);
 	TEST(testAtomicSemaphoreThread);
 }


### PR DESCRIPTION
If a newly spawned thread called getThreadId or getThreadHandle before the spawning thread finished saving the thread handle, then the handle/id would be used uninitialized.  This would cause the threading tests to fail since isCurrentThread would return false, and if Minetest is built with C++11 the std::thread object pointer would be dereferenced while uninitialized, causing a segmentation fault.

This fixes the issue by using a mutex to force the spawned thread to wait for the spawning thread to finish initializing the thread object.

An alternative way to handle this would be to also set the thread handle/id in the started thread but this wouldn't work for C++11 builds because there's no way to get the partially constructed object.

Fixes #4911 and #3786.