### PR TITLE
Plantlike visual scale: Send sqrt(visual_scale) to old clients 

### DIFF
--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -146,6 +146,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 30:
 		New ContentFeatures serialization version
 		Add node and tile color and palette
+		Fix plantlike visual_scale being applied squared and add compatibility
+			with pre-30 clients by sending sqrt(visual_scale)
 */
 
 #define LATEST_PROTOCOL_VERSION 30

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1611,6 +1611,10 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			compatible_param_type_2 = CPT2_WALLMOUNTED;
 	}
 
+	float compatible_visual_scale = visual_scale;
+	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
+		compatible_visual_scale = sqrt(visual_scale);
+
 	if (protocol_version == 13)
 	{
 		writeU8(os, 5); // version
@@ -1622,7 +1626,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);
@@ -1670,7 +1674,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);
@@ -1724,7 +1728,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);


### PR DESCRIPTION
Keep compatibility with protocol < 30 clients now that visual_scale
is no longer applied twice to plantlike drawtype and mods are being
updated to a new value.
////////////////////////////////////////////////

See https://github.com/minetest/minetest/pull/5115#issuecomment-275843758 onwards for details.
New territory for me so there may be mistakes.
@rubenwardy 

Below, in MTGame on the server papyrus visual_scale is set to 2.0.

![screenshot_20170130_105737](https://cloud.githubusercontent.com/assets/3686677/22420609/22bb6760-e6db-11e6-9536-13b85c8478d6.png)

^ Server with latest dev and this commit

![screenshot_20170130_105657](https://cloud.githubusercontent.com/assets/3686677/22420622/3464dd84-e6db-11e6-8511-db0b77a7020c.png)

^ 0.4.15 stable client connected to the server