### PR TITLE
Rename height to scale for openConsole()

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1372,7 +1372,7 @@ protected:
 
 	void dropSelectedItem();
 	void openInventory();
-	void openConsole(float height, const wchar_t *line=NULL);
+	void openConsole(float scale, const wchar_t *line=NULL);
 	void toggleFreeMove(float *statustext_time);
 	void toggleFreeMoveAlt(float *statustext_time, float *jump_timer);
 	void toggleFast(float *statustext_time);
@@ -2779,15 +2779,17 @@ void Game::openInventory()
 }
 
 
-void Game::openConsole(float height, const wchar_t *line)
+void Game::openConsole(float scale, const wchar_t *line)
 {
+	assert(scale > 0.0f && scale <= 1.0f);
+
 #ifdef __ANDROID__
 	porting::showInputDialog(gettext("ok"), "", "", 2);
 	m_android_chat_open = true;
 #else
 	if (gui_chat_console->isOpenInhibited())
 		return;
-	gui_chat_console->openConsole(height);
+	gui_chat_console->openConsole(scale);
 	if (line) {
 		gui_chat_console->setCloseOnEnter(true);
 		gui_chat_console->replaceAndAddToHistory(line);

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -116,11 +116,13 @@ GUIChatConsole::~GUIChatConsole()
 		m_font->drop();
 }
 
-void GUIChatConsole::openConsole(f32 height)
+void GUIChatConsole::openConsole(f32 scale)
 {
+	assert(scale > 0.0f && scale <= 1.0f);
+
 	m_open = true;
-	m_desired_height_fraction = height;
-	m_desired_height = height * m_screensize.Y;
+	m_desired_height_fraction = scale;
+	m_desired_height = scale * m_screensize.Y;
 	reformatConsole();
 	m_animate_time_old = getTimeMs();
 	IGUIElement::setVisible(true);

--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -41,7 +41,7 @@ public:
 	// Open the console (height = desired fraction of screen size)
 	// This doesn't open immediately but initiates an animation.
 	// You should call isOpenInhibited() before this.
-	void openConsole(f32 height);
+	void openConsole(f32 scale);
 
 	bool isOpen() const;
 


### PR DESCRIPTION
For Game::openConsole() and GUIChatConsole::openConsole() the parameter name 'height' is misleading because it's actually a percentage of the screen/window height.