### PR TITLE
Fix anticheat resetting client position after the client is teleported.

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -781,6 +781,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_inventory(NULL),
 	m_damage(0),
 	m_last_good_position(0,0,0),
+	m_time_from_last_teleport(0),
 	m_time_from_last_punch(0),
 	m_nocheat_dig_pos(32767, 32767, 32767),
 	m_nocheat_dig_time(0),
@@ -995,6 +996,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	// Increment cheat prevention timers
 	m_dig_pool.add(dtime);
 	m_move_pool.add(dtime);
+	m_time_from_last_teleport += dtime;
 	m_time_from_last_punch += dtime;
 	m_nocheat_dig_time += dtime;
 
@@ -1102,6 +1104,7 @@ void PlayerSAO::setPos(const v3f &pos)
 	// Movement caused by this command is always valid
 	m_last_good_position = pos;
 	m_move_pool.empty();
+	m_time_from_last_teleport = 0.0;
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
@@ -1113,6 +1116,8 @@ void PlayerSAO::moveTo(v3f pos, bool continuous)
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
 	m_last_good_position = pos;
+	m_move_pool.empty();
+	m_time_from_last_teleport = 0.0;
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
@@ -1401,11 +1406,17 @@ bool PlayerSAO::checkMovementCheat()
 	if (m_move_pool.grab(required_time)) {
 		m_last_good_position = m_base_position;
 	} else {
-		actionstream << "Player " << m_player->getName()
-				<< " moved too fast; resetting position"
-				<< std::endl;
+		const float LAG_POOL_MIN = 5.0;
+		float lag_pool_max = m_env->getMaxLagEstimate() * 2.0;
+		if(lag_pool_max < LAG_POOL_MIN)
+			lag_pool_max = LAG_POOL_MIN;
+		if (m_time_from_last_teleport > lag_pool_max) {
+			actionstream << "Player " << m_player->getName()
+					<< " moved too fast; resetting position"
+					<< std::endl;
+			cheated = true;
+		}
 		setBasePosition(m_last_good_position);
-		cheated = true;
 	}
 	return cheated;
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1101,6 +1101,7 @@ void PlayerSAO::setPos(const v3f &pos)
 	setBasePosition(pos);
 	// Movement caused by this command is always valid
 	m_last_good_position = pos;
+	m_move_pool.empty();
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1408,8 +1408,7 @@ bool PlayerSAO::checkMovementCheat()
 	} else {
 		const float LAG_POOL_MIN = 5.0;
 		float lag_pool_max = m_env->getMaxLagEstimate() * 2.0;
-		if(lag_pool_max < LAG_POOL_MIN)
-			lag_pool_max = LAG_POOL_MIN;
+		lag_pool_max = MYMAX(lag_pool_max, LAG_POOL_MIN);
 		if (m_time_from_last_teleport > lag_pool_max) {
 			actionstream << "Player " << m_player->getName()
 					<< " moved too fast; resetting position"

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -157,22 +157,26 @@ class LagPool
 public:
 	LagPool(): m_pool(15), m_max(15)
 	{}
+
 	void setMax(float new_max)
 	{
 		m_max = new_max;
 		if(m_pool > new_max)
 			m_pool = new_max;
 	}
+
 	void add(float dtime)
 	{
 		m_pool -= dtime;
 		if(m_pool < 0)
 			m_pool = 0;
 	}
+
 	void empty()
 	{
 		m_pool = m_max;
 	}
+
 	bool grab(float dtime)
 	{
 		if(dtime <= 0)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -332,6 +332,7 @@ private:
 	LagPool m_dig_pool;
 	LagPool m_move_pool;
 	v3f m_last_good_position;
+	float m_time_from_last_teleport;
 	float m_time_from_last_punch;
 	v3s16 m_nocheat_dig_pos;
 	float m_nocheat_dig_time;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -169,6 +169,10 @@ public:
 		if(m_pool < 0)
 			m_pool = 0;
 	}
+	void empty()
+	{
+		m_pool = m_max;
+	}
 	bool grab(float dtime)
 	{
 		if(dtime <= 0)


### PR DESCRIPTION
Previously, m_move_pool could accomodate the client moving from the new
position to the old one, and the server accepted the client to go back
to its old position. However, it couldn't then accomodate the client
moving from its old to its new position, and therefore would reset position
to the old position. Thus, by emptying m_move_pool after a teleport, the
server no longer accepts the client to go back to its old position. A
drawback is however that a laggy client *will* trigger a few
"moved_too_fast" anticheats before being told about its new position.

Fixes #5118.

To test, add a connexion delay to localhost (see https://daniel.haxx.se/blog/2010/12/14/add-latency-to-localhost/ for example).