### PR TITLE
Tell on_punch to expect a return value

### DIFF
--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -254,7 +254,7 @@ bool ScriptApiEntity::luaentity_Punch(u16 id,
 	lua_pushnumber(L, damage);
 
 	setOriginFromTable(object);
-	PCALL_RES(lua_pcall(L, 6, 0, error_handler));
+	PCALL_RES(lua_pcall(L, 6, 1, error_handler));
 
 	bool retval = lua_toboolean(L, -1);
 	lua_pop(L, 2); // Pop object and error handler


### PR DESCRIPTION
At the moment, no value is returned. The return value should be interpreted as a boolean saying whether the lua on_punch function handled damage or the system needs to.

As it is, the system never gets called to handle damage, even if you want it to.