### PR TITLE
Add ItemStack key-value meta storage and per-stack descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ locale/
 *.a
 *.ninja
 .ninja*
+*.gch
 
 ## Android build files
 build/android/src/main/assets
@@ -86,4 +87,3 @@ build/android/obj
 build/android/local.properties
 build/android/.gradle
 timestamp
-

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -307,6 +307,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_item.cpp         \
 		jni/src/script/lua_api/l_mainmenu.cpp     \
 		jni/src/script/lua_api/l_mapgen.cpp       \
+		jni/src/script/lua_api/l_metadata.cpp     \
 		jni/src/script/lua_api/l_nodemeta.cpp     \
 		jni/src/script/lua_api/l_nodetimer.cpp    \
 		jni/src/script/lua_api/l_noise.cpp        \

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -164,6 +164,7 @@ LOCAL_SRC_FILES := \
 		jni/src/inventory.cpp                     \
 		jni/src/inventorymanager.cpp              \
 		jni/src/itemdef.cpp                       \
+		jni/src/itemstackmetadata.cpp             \
 		jni/src/keycode.cpp                       \
 		jni/src/light.cpp                         \
 		jni/src/localplayer.cpp                   \
@@ -305,6 +306,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_env.cpp          \
 		jni/src/script/lua_api/l_inventory.cpp    \
 		jni/src/script/lua_api/l_item.cpp         \
+		jni/src/script/lua_api/l_itemstackmeta.cpp\
 		jni/src/script/lua_api/l_mainmenu.cpp     \
 		jni/src/script/lua_api/l_mapgen.cpp       \
 		jni/src/script/lua_api/l_metadata.cpp     \

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -184,6 +184,7 @@ LOCAL_SRC_FILES := \
 		jni/src/mapnode.cpp                       \
 		jni/src/mapsector.cpp                     \
 		jni/src/mesh.cpp                          \
+		jni/src/metadata.cpp                      \
 		jni/src/mg_biome.cpp                      \
 		jni/src/mg_decoration.cpp                 \
 		jni/src/mg_ore.cpp                        \
@@ -384,4 +385,3 @@ ifdef GPROF
 $(call import-module,android-ndk-profiler)
 endif
 $(call import-module,android/native_app_glue)
-

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1473,6 +1473,10 @@ Item stacks can store metadata too. See `ItemStackMetaRef`.
 
 Item metadata only contains a key-value store.
 
+Some of the values in the key-value store are handled specially:
+
+* `description`: Set the itemstack's description. Defaults to idef.description
+
 Example stuff:
 
     local meta = stack:get_meta()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1411,7 +1411,7 @@ the entity itself.
 * `direction` is a unit vector, pointing from the source of the punch to
    the punched object.
 * `damage` damage that will be done to entity
-Return value of this function will determin if damage is done by this function 
+Return value of this function will determin if damage is done by this function
 (retval true) or shall be done by engine (retval false)
 
 To punch an entity/object in Lua, call:
@@ -1427,9 +1427,9 @@ Node Metadata
 -------------
 The instance of a node in the world normally only contains the three values
 mentioned in "Nodes". However, it is possible to insert extra data into a
-node. It is called "node metadata"; See "`NodeMetaRef`".
+node. It is called "node metadata"; See `NodeMetaRef`.
 
-Metadata contains two things:
+Node metadata contains two things:
 
 * A key-value store
 * An inventory
@@ -1466,6 +1466,18 @@ Example stuff:
             infotext = "Chest"
         }
     })
+
+Item Metadata
+-------------
+Item stacks can store metadata too. See `ItemStackMetaRef`.
+
+Item metadata only contains a key-value store.
+
+Example stuff:
+
+    local meta = stack:get_meta()
+    meta:set_string("key", "value")
+    print(dump(meta:to_table()))
 
 Formspec
 --------
@@ -2774,9 +2786,8 @@ These functions return the leftover itemstack.
 Class reference
 ---------------
 
-### `NodeMetaRef`
-Node metadata: reference extra data and functionality stored in a node.
-Can be gotten via `minetest.get_meta(pos)`.
+### `MetaDataRef`
+See `NodeMetaRef` and `ItemStackMetaRef`.
 
 #### Methods
 * `set_string(name, value)`
@@ -2785,12 +2796,28 @@ Can be gotten via `minetest.get_meta(pos)`.
 * `get_int(name)`
 * `set_float(name, value)`
 * `get_float(name)`
-* `get_inventory()`: returns `InvRef`
-* `to_table()`: returns `nil` or `{fields = {...}, inventory = {list1 = {}, ...}}`
+* `to_table()`: returns `nil` or a table with keys:
+    * `fields`: key-value storage
+    * `inventory`: `{list1 = {}, ...}}` (NodeMetaRef only)
 * `from_table(nil or {})`
     * Any non-table value will clear the metadata
-    * See "Node Metadata"
+    * See "Node Metadata" for an example
     * returns `true` on success
+
+### `NodeMetaRef`
+Node metadata: reference extra data and functionality stored in a node.
+Can be gotten via `minetest.get_meta(pos)`.
+
+#### Methods
+* All methods in MetaDataRef
+* `get_inventory()`: returns `InvRef`
+
+### `ItemStackMetaRef`
+ItemStack metadata: reference extra data and functionality stored in a stack.
+Can be gotten via `item:get_meta()`.
+
+#### Methods
+* All methods in MetaDataRef
 
 ### `NodeTimerRef`
 Node Timers: a high resolution persistent per-node timer.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,6 +415,7 @@ set(common_SRCS
 	inventory.cpp
 	inventorymanager.cpp
 	itemdef.cpp
+	itemstackmetadata.cpp
 	light.cpp
 	log.cpp
 	map.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -430,6 +430,7 @@ set(common_SRCS
 	mapgen_valleys.cpp
 	mapnode.cpp
 	mapsector.cpp
+	metadata.cpp
 	mg_biome.cpp
 	mg_decoration.cpp
 	mg_ore.cpp
@@ -893,4 +894,3 @@ endif()
 if (BUILD_CLIENT AND USE_FREETYPE)
 	add_subdirectory(cguittfont)
 endif()
-

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -938,7 +938,7 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr,
 		if(m_prop.textures.size() >= 1){
 			infostream<<"textures[0]: "<<m_prop.textures[0]<<std::endl;
 			IItemDefManager *idef = m_client->idef();
-			ItemStack item(m_prop.textures[0], 1, 0, "", idef);
+			ItemStack item(m_prop.textures[0], 1, 0, idef);
 
 			m_wield_meshnode = new WieldMeshSceneNode(
 					smgr->getRootSceneNode(), smgr, -1);

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -139,7 +139,7 @@ static std::vector<ItemStack> craftGetItems(
 	for (std::vector<std::string>::size_type i = 0;
 			i < items.size(); i++) {
 		result.push_back(ItemStack(std::string(items[i]), (u16)1,
-			(u16)0, "", gamedef->getItemDefManager()));
+			(u16)0, gamedef->getItemDefManager()));
 	}
 	return result;
 }
@@ -1126,4 +1126,3 @@ IWritableCraftDefManager* createCraftDefManager()
 {
 	return new CCraftDefManager();
 }
-

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2303,7 +2303,12 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 			// Draw tooltip
 			std::wstring tooltip_text = L"";
 			if (hovering && !m_selected_item) {
-				tooltip_text = utf8_to_wide(item.getDefinition(m_client->idef()).description);
+				const std::string &desc = item.metadata.getString("description");
+				if (desc.empty())
+					tooltip_text =
+						utf8_to_wide(item.getDefinition(m_client->idef()).description);
+				else
+					tooltip_text = utf8_to_wide(desc);
 			}
 			if (tooltip_text != L"") {
 				std::vector<std::wstring> tt_rows = str_split(tooltip_text, L'\n');

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -45,82 +45,16 @@ static content_t content_translate_from_19_to_internal(content_t c_from)
 	return c_from;
 }
 
-// If the string contains spaces, quotes or control characters, encodes as JSON.
-// Else returns the string unmodified.
-static std::string serializeJsonStringIfNeeded(const std::string &s)
-{
-	for(size_t i = 0; i < s.size(); ++i)
-	{
-		if(s[i] <= 0x1f || s[i] >= 0x7f || s[i] == ' ' || s[i] == '\"')
-			return serializeJsonString(s);
-	}
-	return s;
-}
-
-// Parses a string serialized by serializeJsonStringIfNeeded.
-static std::string deSerializeJsonStringIfNeeded(std::istream &is)
-{
-	std::ostringstream tmp_os;
-	bool expect_initial_quote = true;
-	bool is_json = false;
-	bool was_backslash = false;
-	for(;;)
-	{
-		char c = is.get();
-		if(is.eof())
-			break;
-		if(expect_initial_quote && c == '"')
-		{
-			tmp_os << c;
-			is_json = true;
-		}
-		else if(is_json)
-		{
-			tmp_os << c;
-			if(was_backslash)
-				was_backslash = false;
-			else if(c == '\\')
-				was_backslash = true;
-			else if(c == '"')
-				break; // Found end of string
-		}
-		else
-		{
-			if(c == ' ')
-			{
-				// Found end of word
-				is.unget();
-				break;
-			}
-			else
-			{
-				tmp_os << c;
-			}
-		}
-		expect_initial_quote = false;
-	}
-	if(is_json)
-	{
-		std::istringstream tmp_is(tmp_os.str(), std::ios::binary);
-		return deSerializeJsonString(tmp_is);
-	}
-	else
-		return tmp_os.str();
-}
-
-
-ItemStack::ItemStack(std::string name_, u16 count_,
-		u16 wear_, std::string metadata_,
-		IItemDefManager *itemdef)
+ItemStack::ItemStack(const std::string &name_, u16 count_,
+		u16 wear_, IItemDefManager *itemdef)
 {
 	name = itemdef->getAlias(name_);
 	count = count_;
 	wear = wear_;
-	metadata = metadata_;
 
-	if(name.empty() || count == 0)
+	if (name.empty() || count == 0)
 		clear();
-	else if(itemdef->get(name).type == ITEM_TOOL)
+	else if (itemdef->get(name).type == ITEM_TOOL)
 		count = 1;
 }
 
@@ -137,7 +71,7 @@ void ItemStack::serialize(std::ostream &os) const
 		parts = 2;
 	if(wear != 0)
 		parts = 3;
-	if(metadata != "")
+	if (!metadata.empty())
 		parts = 4;
 
 	os<<serializeJsonStringIfNeeded(name);
@@ -145,8 +79,10 @@ void ItemStack::serialize(std::ostream &os) const
 		os<<" "<<count;
 	if(parts >= 3)
 		os<<" "<<wear;
-	if(parts >= 4)
-		os<<" "<<serializeJsonStringIfNeeded(metadata);
+	if (parts >= 4) {
+		os << " ";
+		metadata.serialize(os);
+	}
 }
 
 void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
@@ -289,7 +225,7 @@ void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
 				wear = stoi(wear_str);
 
 			// Read metadata
-			metadata = deSerializeJsonStringIfNeeded(is);
+			metadata.deSerialize(is);
 
 			// In case fields are added after metadata, skip space here:
 			//std::getline(is, tmp, ' ');
@@ -335,7 +271,7 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 		*this = newitem;
 		newitem.clear();
 	}
-	// If item name or metadata differs, bail out 
+	// If item name or metadata differs, bail out
 	else if (name != newitem.name
 		|| metadata != newitem.metadata)
 	{
@@ -375,7 +311,7 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 	{
 		newitem.clear();
 	}
-	// If item name or metadata differs, bail out 
+	// If item name or metadata differs, bail out
 	else if (name != newitem.name
 		|| metadata != newitem.metadata)
 	{

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "debug.h"
 #include "itemdef.h"
 #include "irrlichttypes.h"
+#include "itemstackmetadata.h"
 #include <istream>
 #include <ostream>
 #include <string>
@@ -32,10 +33,10 @@ struct ToolCapabilities;
 
 struct ItemStack
 {
-	ItemStack(): name(""), count(0), wear(0), metadata("") {}
-	ItemStack(std::string name_, u16 count_,
-			u16 wear, std::string metadata_,
-			IItemDefManager *itemdef);
+	ItemStack(): name(""), count(0), wear(0) {}
+	ItemStack(const std::string &name_, u16 count_,
+			u16 wear, IItemDefManager *itemdef);
+
 	~ItemStack() {}
 
 	// Serialization
@@ -61,7 +62,7 @@ struct ItemStack
 		name = "";
 		count = 0;
 		wear = 0;
-		metadata = "";
+		metadata.clear();
 	}
 
 	void add(u16 n)
@@ -166,7 +167,7 @@ struct ItemStack
 	std::string name;
 	u16 count;
 	u16 wear;
-	std::string metadata;
+	ItemStackMetadata metadata;
 };
 
 class InventoryList
@@ -313,4 +314,3 @@ private:
 };
 
 #endif
-

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -1,0 +1,43 @@
+#include "itemstackmetadata.h"
+#include "util/serialize.h"
+#include "util/strfnd.h"
+
+#define DESERIALIZE_START '\x01'
+#define DESERIALIZE_KV_DELIM '\x02'
+#define DESERIALIZE_PAIR_DELIM '\x03'
+#define DESERIALIZE_START_STR "\x01"
+#define DESERIALIZE_KV_DELIM_STR "\x02"
+#define DESERIALIZE_PAIR_DELIM_STR "\x03"
+
+void ItemStackMetadata::serialize(std::ostream &os) const
+{
+	std::ostringstream os2;
+	os2 << DESERIALIZE_START;
+	for (StringMap::const_iterator
+			it = m_stringvars.begin();
+			it != m_stringvars.end(); ++it) {
+		os2 << it->first << DESERIALIZE_KV_DELIM
+		    << it->second << DESERIALIZE_PAIR_DELIM;
+	}
+	os << serializeJsonStringIfNeeded(os2.str());
+}
+
+void ItemStackMetadata::deSerialize(std::istream &is)
+{
+	std::string in = deSerializeJsonStringIfNeeded(is);
+
+	m_stringvars.clear();
+
+	if (!in.empty() && in[0] == DESERIALIZE_START) {
+		Strfnd fnd(in);
+		fnd.to(1);
+		while (!fnd.at_end()) {
+			std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
+			std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
+			m_stringvars[name] = var;
+		}
+	} else {
+		// BACKWARDS COMPATIBILITY
+		m_stringvars[""] = in;
+	}
+}

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -1,0 +1,35 @@
+/*
+Minetest
+Copyright (C) 2010-2013 rubenwardy <rubenwardy@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef ITEMSTACKMETADATA_HEADER
+#define ITEMSTACKMETADATA_HEADER
+
+#include "metadata.h"
+
+class Inventory;
+class IItemDefManager;
+
+class ItemStackMetadata : public Metadata
+{
+public:
+	void serialize(std::ostream &os) const;
+	void deSerialize(std::istream &is);
+};
+
+#endif

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gamedef.h"
 #include "log.h"
 #include <sstream>
+#include "constants.h" // MAP_BLOCKSIZE
+#include <sstream>
 
 /*
 	Metadata

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,0 +1,69 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "metadata.h"
+#include "exceptions.h"
+#include "gamedef.h"
+#include "log.h"
+#include <sstream>
+
+/*
+	Metadata
+*/
+
+void Metadata::clear()
+{
+	m_stringvars.clear();
+}
+
+bool Metadata::empty() const
+{
+	return m_stringvars.size() == 0;
+}
+
+std::string Metadata::getString(const std::string &name,
+	u16 recursion) const
+{
+	StringMap::const_iterator it = m_stringvars.find(name);
+	if (it == m_stringvars.end())
+		return "";
+
+	return resolveString(it->second, recursion);
+}
+
+void Metadata::setString(const std::string &name, const std::string &var)
+{
+	if (var.empty()) {
+		m_stringvars.erase(name);
+	} else {
+		m_stringvars[name] = var;
+	}
+}
+
+std::string Metadata::resolveString(const std::string &str,
+	u16 recursion) const
+{
+	if (recursion > 1) {
+		return str;
+	}
+	if (str.substr(0, 2) == "${" && str[str.length() - 1] == '}') {
+		return getString(str.substr(2, str.length() - 3), recursion + 1);
+	}
+	return str;
+}

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -17,10 +17,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NODEMETADATA_HEADER
-#define NODEMETADATA_HEADER
+#ifndef METADATA_HEADER
+#define METADATA_HEADER
 
-#include "metadata.h"
+#include "irr_v3d.h"
+#include <iostream>
+#include <vector>
+#include "util/string.h"
 
 /*
 	NodeMetadata stores arbitary amounts of data for special blocks.
@@ -34,56 +37,23 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class Inventory;
 class IItemDefManager;
 
-class NodeMetadata : public Metadata
+class Metadata
 {
 public:
-	NodeMetadata(IItemDefManager *item_def_mgr);
-	~NodeMetadata();
-
-	void serialize(std::ostream &os) const;
-	void deSerialize(std::istream &is);
-
 	void clear();
 	bool empty() const;
 
-	// The inventory
-	Inventory *getInventory()
+	// Generic key/value store
+	std::string getString(const std::string &name, u16 recursion = 0) const;
+	void setString(const std::string &name, const std::string &var);
+	// Support variable names in values
+	std::string resolveString(const std::string &str, u16 recursion = 0) const;
+	const StringMap &getStrings() const
 	{
-		return m_inventory;
+		return m_stringvars;
 	}
-
 private:
-	Inventory *m_inventory;
-};
-
-
-/*
-	List of metadata of all the nodes of a block
-*/
-
-class NodeMetadataList
-{
-public:
-	~NodeMetadataList();
-
-	void serialize(std::ostream &os) const;
-	void deSerialize(std::istream &is, IItemDefManager *item_def_mgr);
-
-	// Add all keys in this list to the vector keys
-	std::vector<v3s16> getAllKeys();
-	// Get pointer to data
-	NodeMetadata *get(v3s16 p);
-	// Deletes data
-	void remove(v3s16 p);
-	// Deletes old data and sets a new one
-	void set(v3s16 p, NodeMetadata *d);
-	// Deletes all
-	void clear();
-
-private:
-	int countNonEmpty() const;
-
-	std::map<v3s16, NodeMetadata *> m_data;
+	StringMap m_stringvars;
 };
 
 #endif

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -44,10 +44,10 @@ public:
 	bool empty() const;
 
 	// Generic key/value store
-	std::string getString(const std::string &name, u16 recursion = 0) const;
+	const std::string &getString(const std::string &name, u16 recursion = 0) const;
 	void setString(const std::string &name, const std::string &var);
 	// Support variable names in values
-	std::string resolveString(const std::string &str, u16 recursion = 0) const;
+	const std::string &resolveString(const std::string &str, u16 recursion = 0) const;
 	const StringMap &getStrings() const
 	{
 		return m_stringvars;

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -25,35 +25,37 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include "util/string.h"
 
-/*
-	NodeMetadata stores arbitary amounts of data for special blocks.
-	Used for furnaces, chests and signs.
-
-	There are two interaction methods: inventory menu and text input.
-	Only one can be used for a single metadata, thus only inventory OR
-	text input should exist in a metadata.
-*/
-
-class Inventory;
-class IItemDefManager;
-
 class Metadata
 {
 public:
-	void clear();
-	bool empty() const;
+	virtual ~Metadata() {}
 
-	// Generic key/value store
+	virtual void clear();
+	virtual bool empty() const;
+
+	bool operator==(const Metadata &other) const;
+	inline bool operator!=(const Metadata &other) const
+	{
+		return !(*this == other);
+	}
+
+	//
+	// Key-value related
+	//
+
+	size_t size() const;
+	bool contains(const std::string &name) const;
 	const std::string &getString(const std::string &name, u16 recursion = 0) const;
 	void setString(const std::string &name, const std::string &var);
-	// Support variable names in values
-	const std::string &resolveString(const std::string &str, u16 recursion = 0) const;
 	const StringMap &getStrings() const
 	{
 		return m_stringvars;
 	}
-private:
+	// Add support for variable names in values
+	const std::string &resolveString(const std::string &str, u16 recursion = 0) const;
+protected:
 	StringMap m_stringvars;
+
 };
 
 #endif

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -31,10 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 NodeMetadata::NodeMetadata(IItemDefManager *item_def_mgr):
-	m_stringvars(),
 	m_inventory(new Inventory(item_def_mgr))
-{
-}
+{}
 
 NodeMetadata::~NodeMetadata()
 {
@@ -70,13 +68,13 @@ void NodeMetadata::deSerialize(std::istream &is)
 
 void NodeMetadata::clear()
 {
-	m_stringvars.clear();
+	Metadata::clear();
 	m_inventory->clear();
 }
 
 bool NodeMetadata::empty() const
 {
-	return m_stringvars.size() == 0 && m_inventory->getLists().size() == 0;
+	return Metadata::empty() && m_inventory->getLists().size() == 0;
 }
 
 /*
@@ -216,35 +214,3 @@ int NodeMetadataList::countNonEmpty() const
 	}
 	return n;
 }
-
-std::string NodeMetadata::getString(const std::string &name,
-	unsigned short recursion) const
-{
-	StringMap::const_iterator it = m_stringvars.find(name);
-	if (it == m_stringvars.end())
-		return "";
-
-	return resolveString(it->second, recursion);
-}
-
-void NodeMetadata::setString(const std::string &name, const std::string &var)
-{
-	if (var.empty()) {
-		m_stringvars.erase(name);
-	} else {
-		m_stringvars[name] = var;
-	}
-}
-
-std::string NodeMetadata::resolveString(const std::string &str,
-	unsigned short recursion) const
-{
-	if (recursion > 1) {
-		return str;
-	}
-	if (str.substr(0, 2) == "${" && str[str.length() - 1] == '}') {
-		return getString(str.substr(2, str.length() - 3), recursion + 1);
-	}
-	return str;
-}
-

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -824,11 +824,32 @@ ItemStack read_item(lua_State* L, int index,Server* srv)
 		std::string name = getstringfield_default(L, index, "name", "");
 		int count = getintfield_default(L, index, "count", 1);
 		int wear = getintfield_default(L, index, "wear", 0);
-		std::string metadata = getstringfield_default(L, index, "metadata", "");
-		return ItemStack(name, count, wear, metadata, idef);
-	}
-	else
-	{
+
+		ItemStack istack(name, count, wear, idef);
+
+		lua_getfield(L, index, "metadata");
+
+		// Support old metadata format by checking type
+		int fieldstable = lua_gettop(L);
+		if (lua_istable(L, fieldstable)) {
+			lua_pushnil(L);
+			while (lua_next(L, fieldstable) != 0) {
+				// key at index -2 and value at index -1
+				std::string key = lua_tostring(L, -2);
+				size_t value_len;
+				const char *value_cs = lua_tolstring(L, -1, &value_len);
+				std::string value(value_cs, value_len);
+				istack.metadata.setString(name, value);
+				lua_pop(L, 1); // removes value, keeps key for next iteration
+			}
+		} else {
+			// BACKWARDS COMPATIBLITY
+			std::string value = getstringfield_default(L, index, "metadata", "");
+			istack.metadata.setString("", value);
+		}
+
+		return istack;
+	} else {
 		throw LuaError("Expecting itemstack, itemstring, table or nil");
 	}
 }

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -6,6 +6,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_item.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_mapgen.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_metadata.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_nodemeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_nodetimer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_noise.cpp
@@ -22,4 +23,3 @@ set(common_SCRIPT_LUA_API_SRCS
 set(client_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_mainmenu.cpp
 	PARENT_SCOPE)
-

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -5,6 +5,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_env.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_item.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_itemstackmeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_mapgen.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_metadata.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_nodemeta.cpp

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -284,7 +284,7 @@ int ModApiEnvMod::l_place_node(lua_State *L)
 		return 1;
 	}
 	// Create item to place
-	ItemStack item(ndef->get(n).name, 1, 0, "", idef);
+	ItemStack item(ndef->get(n).name, 1, 0, idef);
 	// Make pointed position
 	PointedThing pointed;
 	pointed.type = POINTEDTHING_NODE;

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -56,9 +56,14 @@ private:
 	// set_wear(self, number)
 	static int l_set_wear(lua_State *L);
 
+	// get_meta(self) -> string
+	static int l_get_meta(lua_State *L);
+
+	// DEPRECATED
 	// get_metadata(self) -> string
 	static int l_get_metadata(lua_State *L);
 
+	// DEPRECATED
 	// set_metadata(self, string)
 	static int l_set_metadata(lua_State *L);
 

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -1,0 +1,115 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_itemstackmeta.h"
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+
+/*
+	NodeMetaRef
+*/
+ItemStackMetaRef* ItemStackMetaRef::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata(L, narg, className);
+	if (!ud)
+		luaL_typerror(L, narg, className);
+
+	return *(ItemStackMetaRef**)ud;  // unbox pointer
+}
+
+Metadata* ItemStackMetaRef::getmeta(bool auto_create)
+{
+	return &istack->metadata;
+}
+
+void ItemStackMetaRef::clearMeta()
+{
+	istack->metadata.clear();
+}
+
+void ItemStackMetaRef::reportMetadataChange()
+{
+	// TODO
+}
+
+// Exported functions
+
+// garbage collector
+int ItemStackMetaRef::gc_object(lua_State *L) {
+	ItemStackMetaRef *o = *(ItemStackMetaRef **)(lua_touserdata(L, 1));
+	delete o;
+	return 0;
+}
+
+// Creates an NodeMetaRef and leaves it on top of stack
+// Not callable from Lua; all references are created on the C side.
+void ItemStackMetaRef::create(lua_State *L, ItemStack *istack)
+{
+	ItemStackMetaRef *o = new ItemStackMetaRef(istack);
+	//infostream<<"NodeMetaRef::create: o="<<o<<std::endl;
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+void ItemStackMetaRef::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, className);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "metadata_class");
+	lua_pushlstring(L, className, strlen(className));
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);  // drop metatable
+
+	luaL_openlib(L, 0, methods, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+
+	// Cannot be created from Lua
+	//lua_register(L, className, create_object);
+}
+
+const char ItemStackMetaRef::className[] = "ItemStackMetaRef";
+const luaL_reg ItemStackMetaRef::methods[] = {
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, set_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, set_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, to_table),
+	luamethod(MetaDataRef, from_table),
+	{0,0}
+};

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -1,0 +1,59 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef L_ITEMSTACKMETA_H_
+#define L_ITEMSTACKMETA_H_
+
+#include "lua_api/l_base.h"
+#include "lua_api/l_metadata.h"
+#include "irrlichttypes_bloated.h"
+#include "inventory.h"
+
+class ItemStackMetaRef : public MetaDataRef
+{
+private:
+	ItemStack *istack;
+
+	static const char className[];
+	static const luaL_reg methods[];
+
+	static ItemStackMetaRef *checkobject(lua_State *L, int narg);
+
+	virtual Metadata* getmeta(bool auto_create);
+
+	virtual void clearMeta();
+
+	virtual void reportMetadataChange();
+
+	// Exported functions
+
+	// garbage collector
+	static int gc_object(lua_State *L);
+public:
+	ItemStackMetaRef(ItemStack *istack): istack(istack) {}
+	~ItemStackMetaRef() {}
+
+	// Creates an ItemStackMetaRef and leaves it on top of stack
+	// Not callable from Lua; all references are created on the C side.
+	static void create(lua_State *L, ItemStack *istack);
+
+	static void Register(lua_State *L);
+};
+
+#endif

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -1,0 +1,252 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_metadata.h"
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+#include "serverenvironment.h"
+#include "map.h"
+#include "server.h"
+
+// LUALIB_API
+void *luaL_checkudata_is_metadataref(lua_State *L, int ud) {
+	void *p = lua_touserdata(L, ud);
+	if (p != NULL &&  // value is a userdata?
+			lua_getmetatable(L, ud)) {  // does it have a metatable?
+		lua_getfield(L, -1, "metadata_class");
+		if (lua_type(L, -1) == LUA_TSTRING) { // does it have a metadata_class field?
+			return p;
+		}
+	}
+	luaL_typerror(L, ud, "MetaDataRef");
+	return NULL;
+}
+
+MetaDataRef* MetaDataRef::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata_is_metadataref(L, narg);
+	if (!ud)
+		luaL_typerror(L, narg, "MetaDataRef");
+
+	return *(MetaDataRef**)ud;  // unbox pointer
+}
+
+// Exported functions
+
+// get_string(self, name)
+int MetaDataRef::l_get_string(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = luaL_checkstring(L, 2);
+
+	Metadata *meta = ref->getmeta(false);
+	if (meta == NULL) {
+		lua_pushlstring(L, "", 0);
+		return 1;
+	}
+
+	const std::string &str = meta->getString(name);
+	lua_pushlstring(L, str.c_str(), str.size());
+	return 1;
+}
+
+// set_string(self, name, var)
+int MetaDataRef::l_set_string(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = luaL_checkstring(L, 2);
+	size_t len = 0;
+	const char *s = lua_tolstring(L, 3, &len);
+	std::string str(s, len);
+
+	Metadata *meta = ref->getmeta(!str.empty());
+	if (meta == NULL || str == meta->getString(name))
+		return 0;
+
+	meta->setString(name, str);
+	ref->reportMetadataChange();
+	return 0;
+}
+
+// get_int(self, name)
+int MetaDataRef::l_get_int(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = lua_tostring(L, 2);
+
+	Metadata *meta = ref->getmeta(false);
+	if (meta == NULL) {
+		lua_pushnumber(L, 0);
+		return 1;
+	}
+
+	const std::string &str = meta->getString(name);
+	lua_pushnumber(L, stoi(str));
+	return 1;
+}
+
+// set_int(self, name, var)
+int MetaDataRef::l_set_int(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = lua_tostring(L, 2);
+	int a = lua_tointeger(L, 3);
+	std::string str = itos(a);
+
+	Metadata *meta = ref->getmeta(true);
+	if (meta == NULL || str == meta->getString(name))
+		return 0;
+
+	meta->setString(name, str);
+	ref->reportMetadataChange();
+	return 0;
+}
+
+// get_float(self, name)
+int MetaDataRef::l_get_float(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = lua_tostring(L, 2);
+
+	Metadata *meta = ref->getmeta(false);
+	if (meta == NULL) {
+		lua_pushnumber(L, 0);
+		return 1;
+	}
+
+	const std::string &str = meta->getString(name);
+	lua_pushnumber(L, stof(str));
+	return 1;
+}
+
+// set_float(self, name, var)
+int MetaDataRef::l_set_float(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	std::string name = lua_tostring(L, 2);
+	float a = lua_tonumber(L, 3);
+	std::string str = ftos(a);
+
+	Metadata *meta = ref->getmeta(true);
+	if (meta == NULL || str == meta->getString(name))
+		return 0;
+
+	meta->setString(name, str);
+	ref->reportMetadataChange();
+	return 0;
+}
+
+// to_table(self)
+int MetaDataRef::l_to_table(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+
+	Metadata *meta = ref->getmeta(true);
+	if (meta == NULL) {
+		lua_pushnil(L);
+		return 1;
+	}
+	lua_newtable(L);
+
+	ref->handleToTable(L, meta);
+
+	return 1;
+}
+
+// from_table(self, table)
+int MetaDataRef::l_from_table(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	MetaDataRef *ref = checkobject(L, 1);
+	int base = 2;
+
+	ref->clearMeta();
+
+	if (!lua_istable(L, base)) {
+		// No metadata
+		lua_pushboolean(L, true);
+		return 1;
+	}
+
+	// Create new metadata
+	Metadata *meta = ref->getmeta(true);
+	if (meta == NULL) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	bool was_successful = ref->handleFromTable(L, base, meta);
+	ref->reportMetadataChange();
+	lua_pushboolean(L, was_successful);
+	return 1;
+}
+
+void MetaDataRef::handleToTable(lua_State *L, Metadata *meta)
+{
+	lua_newtable(L);
+	{
+		const StringMap &fields = meta->getStrings();
+		for (StringMap::const_iterator
+				it = fields.begin(); it != fields.end(); ++it) {
+			const std::string &name = it->first;
+			const std::string &value = it->second;
+			lua_pushlstring(L, name.c_str(), name.size());
+			lua_pushlstring(L, value.c_str(), value.size());
+			lua_settable(L, -3);
+		}
+	}
+	lua_setfield(L, -2, "fields");
+}
+
+bool MetaDataRef::handleFromTable(lua_State *L, int table, Metadata *meta)
+{
+	// Set fields
+	lua_getfield(L, table, "fields");
+	if (lua_istable(L, -1)) {
+		int fieldstable = lua_gettop(L);
+		lua_pushnil(L);
+		while (lua_next(L, fieldstable) != 0) {
+			// key at index -2 and value at index -1
+			std::string name = lua_tostring(L, -2);
+			size_t cl;
+			const char *cs = lua_tolstring(L, -1, &cl);
+			meta->setString(name, std::string(cs, cl));
+			lua_pop(L, 1); // Remove value, keep key for next iteration
+		}
+		lua_pop(L, 1);
+	}
+
+	return true;
+}

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -1,0 +1,71 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+#ifndef L_METADATA_H_
+#define L_METADATA_H_
+
+#include "lua_api/l_base.h"
+#include "irrlichttypes_bloated.h"
+
+class Metadata;
+
+/*
+	NodeMetaRef
+*/
+
+class MetaDataRef : public ModApiBase {
+public:
+	virtual ~MetaDataRef() {}
+protected:
+	static MetaDataRef *checkobject(lua_State *L, int narg);
+
+	virtual void reportMetadataChange() {}
+	virtual Metadata* getmeta(bool auto_create) = 0;
+	virtual void clearMeta() = 0;
+
+	virtual void handleToTable(lua_State *L, Metadata *meta);
+	virtual bool handleFromTable(lua_State *L, int table, Metadata *meta);
+
+	// Exported functions
+
+	// get_string(self, name)
+	static int l_get_string(lua_State *L);
+
+	// set_string(self, name, var)
+	static int l_set_string(lua_State *L);
+
+	// get_int(self, name)
+	static int l_get_int(lua_State *L);
+
+	// set_int(self, name, var)
+	static int l_set_int(lua_State *L);
+
+	// get_float(self, name)
+	static int l_get_float(lua_State *L);
+
+	// set_float(self, name, var)
+	static int l_set_float(lua_State *L);
+
+	// to_table(self)
+	static int l_to_table(lua_State *L);
+
+	// from_table(self, table)
+	static int l_from_table(lua_State *L);
+};
+
+#endif /* L_NODEMETA_H_ */

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -36,12 +36,12 @@ NodeMetaRef* NodeMetaRef::checkobject(lua_State *L, int narg)
 	return *(NodeMetaRef**)ud;  // unbox pointer
 }
 
-NodeMetadata* NodeMetaRef::getmeta(NodeMetaRef *ref, bool auto_create)
+NodeMetadata* NodeMetaRef::getmeta(bool auto_create)
 {
-	NodeMetadata *meta = ref->m_env->getMap().getNodeMetadata(ref->m_p);
-	if(meta == NULL && auto_create)	{
-		meta = new NodeMetadata(ref->m_env->getGameDef()->idef());
-		if(!ref->m_env->getMap().setNodeMetadata(ref->m_p, meta)) {
+	NodeMetadata *meta = m_env->getMap().getNodeMetadata(m_p);
+	if (meta == NULL && auto_create) {
+		meta = new NodeMetadata(m_env->getGameDef()->idef());
+		if (!m_env->getMap().setNodeMetadata(m_p, meta)) {
 			delete meta;
 			return NULL;
 		}
@@ -83,7 +83,7 @@ int NodeMetaRef::l_get_string(lua_State *L)
 	NodeMetaRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 
-	NodeMetadata *meta = getmeta(ref, false);
+	NodeMetadata *meta = ref->getmeta(false);
 	if(meta == NULL){
 		lua_pushlstring(L, "", 0);
 		return 1;
@@ -104,7 +104,7 @@ int NodeMetaRef::l_set_string(lua_State *L)
 	const char *s = lua_tolstring(L, 3, &len);
 	std::string str(s, len);
 
-	NodeMetadata *meta = getmeta(ref, !str.empty());
+	NodeMetadata *meta = ref->getmeta(!str.empty());
 	if(meta == NULL || str == meta->getString(name))
 		return 0;
 	meta->setString(name, str);
@@ -120,7 +120,7 @@ int NodeMetaRef::l_get_int(lua_State *L)
 	NodeMetaRef *ref = checkobject(L, 1);
 	std::string name = lua_tostring(L, 2);
 
-	NodeMetadata *meta = getmeta(ref, false);
+	NodeMetadata *meta = ref->getmeta(false);
 	if(meta == NULL){
 		lua_pushnumber(L, 0);
 		return 1;
@@ -140,7 +140,7 @@ int NodeMetaRef::l_set_int(lua_State *L)
 	int a = lua_tointeger(L, 3);
 	std::string str = itos(a);
 
-	NodeMetadata *meta = getmeta(ref, true);
+	NodeMetadata *meta = ref->getmeta(true);
 	if(meta == NULL || str == meta->getString(name))
 		return 0;
 	meta->setString(name, str);
@@ -156,7 +156,7 @@ int NodeMetaRef::l_get_float(lua_State *L)
 	NodeMetaRef *ref = checkobject(L, 1);
 	std::string name = lua_tostring(L, 2);
 
-	NodeMetadata *meta = getmeta(ref, false);
+	NodeMetadata *meta = ref->getmeta(false);
 	if(meta == NULL){
 		lua_pushnumber(L, 0);
 		return 1;
@@ -176,7 +176,7 @@ int NodeMetaRef::l_set_float(lua_State *L)
 	float a = lua_tonumber(L, 3);
 	std::string str = ftos(a);
 
-	NodeMetadata *meta = getmeta(ref, true);
+	NodeMetadata *meta = ref->getmeta(true);
 	if(meta == NULL || str == meta->getString(name))
 		return 0;
 	meta->setString(name, str);
@@ -190,7 +190,7 @@ int NodeMetaRef::l_get_inventory(lua_State *L)
 	MAP_LOCK_REQUIRED;
 
 	NodeMetaRef *ref = checkobject(L, 1);
-	getmeta(ref, true);  // try to ensure the metadata exists
+	ref->getmeta(true);  // try to ensure the metadata exists
 	InvRef::createNodeMeta(L, ref->m_p);
 	return 1;
 }
@@ -202,7 +202,7 @@ int NodeMetaRef::l_to_table(lua_State *L)
 
 	NodeMetaRef *ref = checkobject(L, 1);
 
-	NodeMetadata *meta = getmeta(ref, true);
+	NodeMetadata *meta = ref->getmeta(true);
 	if (meta == NULL) {
 		lua_pushnil(L);
 		return 1;
@@ -257,7 +257,7 @@ int NodeMetaRef::l_from_table(lua_State *L)
 	}
 
 	// Create new metadata
-	NodeMetadata *meta = getmeta(ref, true);
+	NodeMetadata *meta = ref->getmeta(true);
 	if (meta == NULL) {
 		lua_pushboolean(L, false);
 		return 1;

--- a/src/script/lua_api/l_nodemeta.h
+++ b/src/script/lua_api/l_nodemeta.h
@@ -52,7 +52,7 @@ private:
 	 * @param auto_create when true, try to create metadata information for the node if it has none.
 	 * @return pointer to a @c NodeMetadata object or @c NULL in case of error.
 	 */
-	static NodeMetadata* getmeta(NodeMetaRef *ref, bool auto_create);
+	virtual NodeMetadata* getmeta(bool auto_create);
 
 	static void reportMetadataChange(NodeMetaRef *ref);
 

--- a/src/script/lua_api/l_nodemeta.h
+++ b/src/script/lua_api/l_nodemeta.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define L_NODEMETA_H_
 
 #include "lua_api/l_base.h"
+#include "lua_api/l_metadata.h"
 #include "irrlichttypes_bloated.h"
 
 class ServerEnvironment;
@@ -29,7 +30,7 @@ class NodeMetadata;
 	NodeMetaRef
 */
 
-class NodeMetaRef : public ModApiBase {
+class NodeMetaRef : public MetaDataRef {
 private:
 	v3s16 m_p;
 	ServerEnvironment *m_env;
@@ -52,41 +53,21 @@ private:
 	 * @param auto_create when true, try to create metadata information for the node if it has none.
 	 * @return pointer to a @c NodeMetadata object or @c NULL in case of error.
 	 */
-	virtual NodeMetadata* getmeta(bool auto_create);
+	virtual Metadata* getmeta(bool auto_create);
+	virtual void clearMeta();
 
-	static void reportMetadataChange(NodeMetaRef *ref);
+	virtual void reportMetadataChange();
+
+	virtual void handleToTable(lua_State *L, Metadata *_meta);
+	virtual bool handleFromTable(lua_State *L, int table, Metadata *_meta);
 
 	// Exported functions
 
 	// garbage collector
 	static int gc_object(lua_State *L);
 
-	// get_string(self, name)
-	static int l_get_string(lua_State *L);
-
-	// set_string(self, name, var)
-	static int l_set_string(lua_State *L);
-
-	// get_int(self, name)
-	static int l_get_int(lua_State *L);
-
-	// set_int(self, name, var)
-	static int l_set_int(lua_State *L);
-
-	// get_float(self, name)
-	static int l_get_float(lua_State *L);
-
-	// set_float(self, name, var)
-	static int l_set_float(lua_State *L);
-
 	// get_inventory(self)
 	static int l_get_inventory(lua_State *L);
-
-	// to_table(self)
-	static int l_to_table(lua_State *L);
-
-	// from_table(self, table)
-	static int l_from_table(lua_State *L);
 
 public:
 	NodeMetaRef(v3s16 p, ServerEnvironment *env);

--- a/src/script/scripting_game.cpp
+++ b/src/script/scripting_game.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_env.h"
 #include "lua_api/l_inventory.h"
 #include "lua_api/l_item.h"
+#include "lua_api/l_itemstackmeta.h"
 #include "lua_api/l_mapgen.h"
 #include "lua_api/l_nodemeta.h"
 #include "lua_api/l_nodetimer.h"
@@ -94,6 +95,7 @@ void GameScripting::InitializeModApi(lua_State *L, int top)
 
 	// Register reference classes (userdata)
 	InvRef::Register(L);
+	ItemStackMetaRef::Register(L);
 	LuaAreaStore::Register(L);
 	LuaItemStack::Register(L);
 	LuaPerlinNoise::Register(L);

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -405,6 +405,13 @@ std::string serializeJsonString(const std::string &plain);
 // Reads a string encoded in JSON format
 std::string deSerializeJsonString(std::istream &is);
 
+// If the string contains spaces, quotes or control characters, encodes as JSON.
+// Else returns the string unmodified.
+std::string serializeJsonStringIfNeeded(const std::string &s);
+
+// Parses a string serialized by serializeJsonStringIfNeeded.
+std::string deSerializeJsonStringIfNeeded(std::istream &is);
+
 // Creates a string consisting of the hexadecimal representation of `data`
 std::string serializeHexString(const std::string &data, bool insert_spaces=false);
 


### PR DESCRIPTION
Adds ItemStackMetadata, sharing code with NodeMetadata.
Backwards compatible.

- [x] Fix issues with MetaDataRef::checkobject()
- [x] Actually run and test
- [x] Fix polymorphic destructor warning
- [x] Add docs
- [x] Make getString const ref
- [x] Perstack description
- [x] Fix duplicated l_from_table and l_to_table
- [x] Add ItemStackMetaData to move item serialize from Metadata?
- [ ] Test from_table