### PR TITLE
Objectpos over limit: Avoid error caused by sector over limit

### DIFF
--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -653,14 +653,18 @@ typedef std::vector<MapBlock*> MapBlockVect;
 
 inline bool objectpos_over_limit(v3f p)
 {
-	const float map_gen_limit_bs = MYMIN(MAX_MAP_GENERATION_LIMIT,
-		g_settings->getU16("map_generation_limit")) * BS;
-	return (p.X < -map_gen_limit_bs
-		|| p.X > map_gen_limit_bs
-		|| p.Y < -map_gen_limit_bs
-		|| p.Y > map_gen_limit_bs
-		|| p.Z < -map_gen_limit_bs
-		|| p.Z > map_gen_limit_bs);
+	// MAP_BLOCKSIZE must be subtracted to avoid an object being spawned just
+	// within the map generation limit but in a block / sector that extends
+	// beyond the map generation limit.
+	// This avoids errors caused by sector over limit in createSector().
+	const float object_limit = (MYMIN(MAX_MAP_GENERATION_LIMIT,
+		g_settings->getU16("map_generation_limit")) - MAP_BLOCKSIZE) * BS;
+	return (p.X < -object_limit
+		|| p.X > object_limit
+		|| p.Y < -object_limit
+		|| p.Y > object_limit
+		|| p.Z < -object_limit
+		|| p.Z > object_limit);
 }
 
 /*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1667,7 +1667,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 
 	if (objectpos_over_limit(object->getBasePosition())) {
 		v3f p = object->getBasePosition();
-		errorstream << "ServerEnvironment::addActiveObjectRaw(): "
+		warningstream << "ServerEnvironment::addActiveObjectRaw(): "
 			<< "object position (" << p.X << "," << p.Y << "," << p.Z
 			<< ") outside maximum range" << std::endl;
 		if (object->environmentDeletes())


### PR DESCRIPTION
Reduce the object limit by mapblock size, to avoid objects being
added just inside the map generation limit but in a block / sector
that extends beyond the map generation limit.

Change notification of 'objectpos over limit' from red in-chat ERROR
to in-terminal only WARNING, since this will happen often using mob
mods near the world's edge.
////////////////////////////////////////////////////

Addresses #4923 specifically see https://github.com/minetest/minetest/issues/4923#issuecomment-275946037 onwards.
Crashes are happening when objects are added close to the map gen limit, such that they are within the limit, but the block and therefore sector (vertical stack of blocks) they are in extends beyond the limit, which is not allowed and halts the game.

////////////////////////////////////////////////////

`addActiveObjectRaw` is here https://github.com/minetest/minetest/blob/master/src/serverenvironment.cpp#L1639 and contains a check for object pos over limit, if within the limit it then calls `emergeBlock` https://github.com/minetest/minetest/blob/master/src/map.cpp#L2280 which calls `createSector` https://github.com/minetest/minetest/blob/master/src/map.cpp#L2033

An object may be spawned near the map generation limit (4500):
>  Spawned Sheep at (4496, 6,-4420)

This passes the test for being within limit, then the sector is created and there is a check here https://github.com/minetest/minetest/blob/master/src/map.cpp#L2068 for any part of the sector being over-limit.
The object is within the limit but the sector the object is in extends past the limit, causing the crash.