### PR TITLE
MapgenBasic node resolver: Various fixes

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -587,23 +587,23 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emer
 
 	//// Look up some commonly used content
 	c_stone              = ndef->getId("mapgen_stone");
-	c_water_source       = ndef->getId("mapgen_water_source");
 	c_desert_stone       = ndef->getId("mapgen_desert_stone");
 	c_sandstone          = ndef->getId("mapgen_sandstone");
+	c_water_source       = ndef->getId("mapgen_water_source");
 	c_river_water_source = ndef->getId("mapgen_river_water_source");
 
 	// Fall back to more basic content if not defined
+	// river_water_source cannot fallback to water_source because river water
+	// needs to be non-renewable and have a short flow range.
 	if (c_desert_stone == CONTENT_IGNORE)
 		c_desert_stone = c_stone;
 	if (c_sandstone == CONTENT_IGNORE)
 		c_sandstone = c_stone;
-	if (c_river_water_source == CONTENT_IGNORE)
-		c_river_water_source = c_water_source;
 
 	//// Content used for dungeon generation
 	c_cobble               = ndef->getId("mapgen_cobble");
-	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
 	c_mossycobble          = ndef->getId("mapgen_mossycobble");
+	c_stair_cobble         = ndef->getId("mapgen_stair_cobble");
 	c_stair_desert_stone   = ndef->getId("mapgen_stair_desert_stone");
 	c_sandstonebrick       = ndef->getId("mapgen_sandstonebrick");
 	c_stair_sandstonebrick = ndef->getId("mapgen_stair_sandstonebrick");
@@ -613,10 +613,12 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emer
 		c_mossycobble = c_cobble;
 	if (c_stair_cobble == CONTENT_IGNORE)
 		c_stair_cobble = c_cobble;
+	if (c_stair_desert_stone == CONTENT_IGNORE)
+		c_stair_desert_stone = c_desert_stone;
 	if (c_sandstonebrick == CONTENT_IGNORE)
 		c_sandstonebrick = c_sandstone;
 	if (c_stair_sandstonebrick == CONTENT_IGNORE)
-		c_stair_sandstonebrick = c_sandstone;
+		c_stair_sandstonebrick = c_sandstonebrick;
 }
 
 


### PR DESCRIPTION
Add a fallback node for stair_desert_stone to avoid ignore placed
in Minimal subgame desert dungeons.
Don't allow river_water_source to fallback to water_source as river
water needs to be non-renewable and have a short flow range.
Make stair_sandstonebrick fall back to sandstonebrick instead of
sandstone.

Re-order some lines.
Add a comment.
//////////////////////////////////////////////

Addresses #5163 plus other fixes and improvements.