### PR TITLE
Use JSON serialize to store ItemStack Metadata

### DIFF
--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -30,6 +30,7 @@ void ItemStackMetadata::serialize(std::ostream &os) const
 	}
 
 	Json::StreamWriterBuilder writerBuilder;
+	writerBuilder.settings_["indentation"] = "";
 	os << SERIALIZATION_VERSION_IDENTIFIER
 	   << Json::writeString(writerBuilder, root);
 }

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -1,13 +1,9 @@
 #include "itemstackmetadata.h"
 #include "util/serialize.h"
 #include "util/strfnd.h"
+#include <json/json.h>
 
-#define DESERIALIZE_START '\x01'
-#define DESERIALIZE_KV_DELIM '\x02'
-#define DESERIALIZE_PAIR_DELIM '\x03'
-#define DESERIALIZE_START_STR "\x01"
-#define DESERIALIZE_KV_DELIM_STR "\x02"
-#define DESERIALIZE_PAIR_DELIM_STR "\x03"
+#define SERIALIZATION_VERSION_IDENTIFIER '\x02'
 
 #define TOOLCAP_KEY "tool_capabilities"
 
@@ -27,15 +23,21 @@ bool ItemStackMetadata::setString(const std::string &name, const std::string &va
 
 void ItemStackMetadata::serialize(std::ostream &os) const
 {
-	std::ostringstream os2;
-	os2 << DESERIALIZE_START;
+	Json::Value root(Json::objectValue);
 	for (const auto &stringvar : m_stringvars) {
 		if (!stringvar.first.empty() || !stringvar.second.empty())
-			os2 << stringvar.first << DESERIALIZE_KV_DELIM
-				<< stringvar.second << DESERIALIZE_PAIR_DELIM;
+			root[stringvar.first] = stringvar.second;
 	}
-	os << serializeJsonStringIfNeeded(os2.str());
+	os << serializeJsonStringIfNeeded((char)SERIALIZATION_VERSION_IDENTIFIER +
+			Json::FastWriter().write(root));
 }
+
+#define DESERIALIZE_START '\x01'
+#define DESERIALIZE_KV_DELIM '\x02'
+#define DESERIALIZE_PAIR_DELIM '\x03'
+#define DESERIALIZE_START_STR "\x01"
+#define DESERIALIZE_KV_DELIM_STR "\x02"
+#define DESERIALIZE_PAIR_DELIM_STR "\x03"
 
 void ItemStackMetadata::deSerialize(std::istream &is)
 {
@@ -43,19 +45,36 @@ void ItemStackMetadata::deSerialize(std::istream &is)
 
 	m_stringvars.clear();
 
-	if (!in.empty()) {
-		if (in[0] == DESERIALIZE_START) {
-			Strfnd fnd(in);
-			fnd.to(1);
-			while (!fnd.at_end()) {
-				std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
-				std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
-				m_stringvars[name] = var;
+	if (in.empty())
+		return;
+
+	if (in[0] == SERIALIZATION_VERSION_IDENTIFIER) {
+		in.erase(0, 1);
+
+		Json::Reader reader;
+		Json::Value attr_root;
+		if (reader.parse(in, attr_root) && attr_root.type() == Json::objectValue) {
+			const Json::Value::Members attr_list = attr_root.getMemberNames();
+			for (Json::Value::Members::const_iterator it = attr_list.begin();
+					it != attr_list.end(); ++it) {
+				m_stringvars[*it] = attr_root[*it].asString();
 			}
 		} else {
-			// BACKWARDS COMPATIBILITY
-			m_stringvars[""] = in;
+			errorstream << "ItemStackMetadata::deSerialize():"
+				<< " expected JSON data, but failed to parse. Ignoring." << std::endl;
 		}
+	} else if (in[0] == DESERIALIZE_START) {
+		// BACKWARDS COMPATIBILITY
+		Strfnd fnd(in);
+		fnd.to(1);
+		while (!fnd.at_end()) {
+			std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
+			std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
+			m_stringvars[name] = var;
+		}
+	} else {
+		// BACKWARDS COMPATIBILITY
+		m_stringvars[""] = in;
 	}
 	updateToolCapabilities();
 }

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -223,12 +223,18 @@ void TestInventory::testSerializeDeserializeItemMetadata() {
 	metadata.setString("one", "two");
 	metadata.setString("foo", "{\"\"sn4##434#sas#34eds#}");
 	metadata.setString("bar", "\x01\x02\x03\x02\x03\x01");
+	metadata.setString("boo", "{\"\"snsdfb sdf  sdfsdf {} sdjkffb sdf9347sdf \n sdfjjbsdf \t\r\n skdfjjkgbsdfjlgb \n");
 	metadata.setString("\x01", "asasasas");
+
 
 	std::ostringstream os;
 	metadata.serialize(os);
 
-	std::istringstream is(os.str());
+	std::string serialisedString = os.str();
+
+	UASSERT(serialisedString.find('\n') == std::string::npos);
+
+	std::istringstream is(serialisedString);
 	ItemStackMetadata metadata2;
 	metadata2.deSerialize(is);
 

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "gamedef.h"
 #include "inventory.h"
+#include "itemstackmetadata.h"
 
 class TestInventory : public TestBase {
 public:
@@ -32,6 +33,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testSerializeDeserialize(IItemDefManager *idef);
+	void testDeSerializeItemStackMetadata();
 
 	static const char *serialized_inventory;
 	static const char *serialized_inventory_2;
@@ -42,6 +44,7 @@ static TestInventory g_test_instance;
 void TestInventory::runTests(IGameDef *gamedef)
 {
 	TEST(testSerializeDeserialize, gamedef->getItemDefManager());
+	TEST(testDeSerializeItemStackMetadata);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,3 +144,74 @@ const char *TestInventory::serialized_inventory_2 =
 	"Empty\n"
 	"EndInventoryList\n"
 	"EndInventory\n";
+
+#include "util/serialize.h"
+
+#define DESERIALIZE_START '\x01'
+#define DESERIALIZE_KV_DELIM '\x02'
+#define DESERIALIZE_PAIR_DELIM '\x03'
+#define DESERIALIZE_START_STR "\x01"
+#define DESERIALIZE_KV_DELIM_STR "\x02"
+#define DESERIALIZE_PAIR_DELIM_STR "\x03"
+#define SERIALIZATION_VERSION_IDENTIFIER '\x02'
+
+void TestInventory::testDeSerializeItemStackMetadata() {
+	{
+		std::istringstream is(serializeJsonString("some meta\nasdkmskdmsds\nasasasas"));
+
+		ItemStackMetadata metadata;
+		metadata.deSerialize(is);
+
+		UASSERT(metadata.size() == 1);
+		UASSERT(metadata.getString("") == "some meta\nasdkmskdmsds\nasasasas");
+	}
+
+	{
+		std::ostringstream is;
+		is << DESERIALIZE_START
+		   << "foo"
+		   << DESERIALIZE_KV_DELIM
+		   << "bar"
+		   << DESERIALIZE_PAIR_DELIM
+		   << "description"
+		   << DESERIALIZE_KV_DELIM
+		   << "A foo bar thing\nbleh"
+		   << DESERIALIZE_PAIR_DELIM;
+
+		std::istringstream is2(serializeJsonString(is.str()));
+
+		ItemStackMetadata metadata;
+		metadata.deSerialize(is2);
+
+		UASSERT(metadata.size() == 2);
+		UASSERT(metadata.getString("foo") == "bar");
+		UASSERT(metadata.getString("description") == "A foo bar thing\nbleh");
+	}
+
+	{
+		std::ostringstream is;
+		is << SERIALIZATION_VERSION_IDENTIFIER
+		   << "{ \"foo\": \"bar\", \"description\": \"this is a JSON string!\\nHow exciting!\"}";
+
+		std::istringstream is2(serializeJsonString(is.str()));
+
+		ItemStackMetadata metadata;
+		metadata.deSerialize(is2);
+
+		UASSERT(metadata.size() == 2);
+		UASSERT(metadata.getString("foo") == "bar");
+		UASSERT(metadata.getString("description") == "this is a JSON string!\nHow exciting!");
+	}
+
+	{
+		const std::string test = "{ \"foo\": \"bar\", \"description\": \"this is a JSON string!\\nHow exciting!\"}";
+
+		std::istringstream is2(serializeJsonString(test));
+
+		ItemStackMetadata metadata;
+		metadata.deSerialize(is2);
+
+		UASSERT(metadata.size() == 1);
+		UASSERT(metadata.getString("") == test);
+	}
+}

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -34,6 +34,7 @@ public:
 
 	void testSerializeDeserialize(IItemDefManager *idef);
 	void testDeSerializeItemStackMetadata();
+	void testSerializeDeserializeItemMetadata();
 
 	static const char *serialized_inventory;
 	static const char *serialized_inventory_2;
@@ -45,6 +46,7 @@ void TestInventory::runTests(IGameDef *gamedef)
 {
 	TEST(testSerializeDeserialize, gamedef->getItemDefManager());
 	TEST(testDeSerializeItemStackMetadata);
+	TEST(testSerializeDeserializeItemMetadata);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -193,7 +195,7 @@ void TestInventory::testDeSerializeItemStackMetadata() {
 		is << SERIALIZATION_VERSION_IDENTIFIER
 		   << "{ \"foo\": \"bar\", \"description\": \"this is a JSON string!\\nHow exciting!\"}";
 
-		std::istringstream is2(serializeJsonString(is.str()));
+		std::istringstream is2(is.str());
 
 		ItemStackMetadata metadata;
 		metadata.deSerialize(is2);
@@ -214,4 +216,21 @@ void TestInventory::testDeSerializeItemStackMetadata() {
 		UASSERT(metadata.size() == 1);
 		UASSERT(metadata.getString("") == test);
 	}
+}
+
+void TestInventory::testSerializeDeserializeItemMetadata() {
+	ItemStackMetadata metadata;
+	metadata.setString("one", "two");
+	metadata.setString("foo", "{\"\"sn4##434#sas#34eds#}");
+	metadata.setString("bar", "\x01\x02\x03\x02\x03\x01");
+	metadata.setString("\x01", "asasasas");
+
+	std::ostringstream os;
+	metadata.serialize(os);
+
+	std::istringstream is(os.str());
+	ItemStackMetadata metadata2;
+	metadata2.deSerialize(is);
+
+	UASSERT(metadata2 == metadata);
 }


### PR DESCRIPTION
- [x] Fix memory leak caused by repeated serialization
- [x] Testing
- [x] Remove unnecessary serializeJsonString
- [x] Don't write new lines
- [ ] Don't write invalid characters (eg: control characters)