### PR TITLE
Perform mesh animation only once per frame.

### DIFF
--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -470,7 +470,7 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			continue;
 
 		// Mesh animation
-		{
+		if (pass == scene::ESNRP_SOLID) {
 			//MutexAutoLock lock(block->mesh_mutex);
 			MapBlockMesh *mapBlockMesh = block->mesh;
 			assert(mapBlockMesh);


### PR DESCRIPTION
ClientMap::renderMap is called twice per frame (once for solid and once for transparent meshes). We unnecessarily animate all meshes in both calls.