### PR TITLE
Prevent SIGFPE on entity tile loading issue.

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1741,6 +1741,12 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 				 * equal to the target minimum.  If e.g. this is a vertical frames
 				 * animation, the short dimension will be the real size.
 				 */
+				if ((dim.Width == 0) || (dim.Height == 0)) {
+					errorstream << "generateImagePart(): Illegal 0 dimension "
+						<< "for part_of_name=\""<< part_of_name
+						<< "\", cancelling." << std::endl;
+					return false;
+				}
 				u32 xscale = scaleto / dim.Width;
 				u32 yscale = scaleto / dim.Height;
 				u32 scale = (xscale > yscale) ? xscale : yscale;


### PR DESCRIPTION
While experimenting with entities I ran into this unresolvable
error where the server is sending some texture that the client
crashes on. The crash prevents the client from ever reconnecting,
resulting in a server that has to use clearobjects.

We shouldn't crash but just ignore the object and move on.

```
0x00000000004dc0de in TextureSource::generateImagePart (this=this@entry=0x7118eb0, part_of_name="[applyfiltersformesh",
    baseimg=@0x7fffffffbe98: 0x9f1b010) at /home/sofar/git/minetest/src/client/tile.cpp:1744
    1744					u32 xscale = scaleto / dim.Width;
    (gdb) bt
    #0  0x00000000004dc0de in TextureSource::generateImagePart (this=this@entry=0x7118eb0, part_of_name="[applyfiltersformesh",
        baseimg=@0x7fffffffbe98: 0x9f1b010) at /home/sofar/git/minetest/src/client/tile.cpp:1744
```

After reconnecting, the client now can connect without issues
and displays an error message:

```
ERROR[Main]: generateImagePart(): Illegal 0 dimension for part_of_name="[applyfiltersformesh", cancelling.
ERROR[Main]: generateImage(): Failed to generate "[applyfiltersformesh"
ERROR[Main]: Irrlicht: Invalid size of image for OpenGL Texture.
```