### PR TITLE
Add support for unix socket connection to redis

### DIFF
--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -44,7 +44,8 @@ Database_Redis::Database_Redis(Settings &conf)
 	}
 	const char *addr = tmp.c_str();
 	int port = conf.exists("redis_port") ? conf.getU16("redis_port") : 6379;
-	ctx = redisConnect(addr, port);
+	// if redis_address contains '/' assume unix socket, else hostname/ip
+	ctx = tmp.find('/') != std::string::npos ? redisConnectUnix(addr) : redisConnect(addr, port);
 	if (!ctx) {
 		throw DatabaseException("Cannot allocate redis context");
 	} else if (ctx->err) {


### PR DESCRIPTION
This is a very simple change, it doesn't even add a configuration option.  It simply re-uses redis_address and if it contains a '/', which a hostname/ip cannot, but a unix socket must, assume it's a unix socket and connect that way, otherwise connect the old way.

I also tested the server running both connected to a host/ip and a unix socket and everything works as expected.