### PR TITLE
Map gen limit: Avoid adding structures that pass the limit

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2066,23 +2066,18 @@ ServerMapSector *ServerMap::createSector(v2s16 p2d)
 
 	/*
 		Do not create over-limit.
-		We are checking for any nodes of the mapblocks of the sector being beyond the limit.
-		A sector is a vertical column of mapblocks, so sectorpos is like a 2D blockpos.
-
-		At the negative limit we are checking for
-			block minimum nodepos < -mapgenlimit.
-		At the positive limit we are checking for
-			block maximum nodepos > mapgenlimit.
-
-		Block minimum nodepos = blockpos * mapblocksize.
-		Block maximum nodepos = (blockpos + 1) * mapblocksize - 1.
+		Allow saplings growing near the limit to become trees that partly
+		extend beyond it. Allow sectors containing nodes that are up to
+		1 mapblock beyond the limit.
+		Sector minimum nodepos = sectorpos * mapblocksize.
+		Sector maximum nodepos = (sectorpos + 1) * mapblocksize - 1.
 	*/
-	const u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
-		g_settings->getU16("map_generation_limit"));
-	if (p2d.X * MAP_BLOCKSIZE < -map_gen_limit
-			|| (p2d.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
-			|| p2d.Y * MAP_BLOCKSIZE < -map_gen_limit
-			|| (p2d.Y + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit)
+	const u16 sector_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
+		g_settings->getU16("map_generation_limit")) + MAP_BLOCKSIZE;
+	if ((p2d.X + 1) * MAP_BLOCKSIZE - 1 < -sector_limit
+			|| p2d.X * MAP_BLOCKSIZE > sector_limit
+			|| (p2d.Y + 1) * MAP_BLOCKSIZE - 1 < -sector_limit
+			|| p2d.Y * MAP_BLOCKSIZE > sector_limit)
 		throw InvalidPositionException("createSector(): pos. over limit");
 
 	/*


### PR DESCRIPTION
Addresses #4923 

WIP as there are issues to consider.

See https://github.com/minetest/minetest/issues/4923#issuecomment-277562783
Here map_gen_limit is 4500. The loaded world stops at 4495 which is the maxpos of a mapblock.
A sapling grew at 4495 and therefore became a tree with leaves extending beyond 4495 into the next block and sector out, this causes the crash because that next block and sector out extends beyond map_gen_limit.

We could allow sectors beyond map_gen_limit, but then the map gen limit is no longer the world limit.
We need to disallow any structure that would pass the mapblock border just inside the set map gen limit.