### PR TITLE
Soft node overlay

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3908,6 +3908,12 @@ Definition tables
         tiles = {tile definition 1, def2, def3, def4, def5, def6}, --[[
         ^ Textures of node; +Y, -Y, +X, -X, +Z, -Z (old field name: tile_images)
         ^ List can be shortened to needed length ]]
+        overlay_tiles = {tile definition 1, def2, def3, def4, def5, def6}, --[[
+        ^ Same as `tiles`, but these textures are drawn on top of the
+        ^ base tiles. You can use this to colorize only specific parts of
+        ^ your texture. If the texture name is an empty string, that
+        ^ overlay is not drawn. Since such tiles are drawn twice, it
+        ^ is not recommended to use overlays on very common nodes.
         special_tiles = {tile definition 1, Tile definition 2}, --[[
         ^ Special textures of node; used rarely (old field name: special_materials)
         ^ List can be shortened to needed length ]]

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -487,13 +487,17 @@ void Client::step(float dtime)
 					minimap_mapblock = r.mesh->moveMinimapMapblock();
 					if (minimap_mapblock == NULL)
 						do_mapper_update = false;
-				}
 
-				if (r.mesh && r.mesh->getMesh()->getMeshBufferCount() == 0) {
-					delete r.mesh;
-				} else {
-					// Replace with the new mesh
-					block->mesh = r.mesh;
+					bool is_empty = true;
+					for (int l = 0; l < MAX_TILE_LAYERS; l++)
+						if (r.mesh->getMesh(l)->getMeshBufferCount() != 0)
+							is_empty = false;
+
+					if (is_empty)
+						delete r.mesh;
+					else
+						// Replace with the new mesh
+						block->mesh = r.mesh;
 				}
 			} else {
 				delete r.mesh;

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -60,8 +60,8 @@ public:
 // lighting
 	void getSmoothLightFrame();
 	u16 blendLight(const v3f &vertex_pos);
-	video::SColor blendLight(const v3f &vertex_pos, video::SColor tile_color);
-	video::SColor blendLight(const v3f &vertex_pos, const v3f &vertex_normal, video::SColor tile_color);
+	video::SColor blendLightColor(const v3f &vertex_pos);
+	video::SColor blendLightColor(const v3f &vertex_pos, const v3f &vertex_normal);
 
 	void useTile(int index, bool disable_backface_culling);
 	void useDefaultTile(bool set_color = true);

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -687,8 +687,9 @@ void drawItemStack(video::IVideoDriver *driver,
 			assert(buf->getHardwareMappingHint_Vertex() == scene::EHM_NEVER);
 			video::SColor c = basecolor;
 			if (imesh->buffer_colors.size() > j) {
-				std::pair<bool, video::SColor> p = imesh->buffer_colors[j];
-				c = p.first ? p.second : basecolor;
+				ItemPartColor *p = &imesh->buffer_colors[j];
+				if (p->override_base)
+					c = p->color;
 			}
 			colorizeMeshBuffer(buf, &c);
 			video::SMaterial &material = buf->getMaterial();

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -108,7 +108,12 @@ public:
 
 	scene::IMesh *getMesh()
 	{
-		return m_mesh;
+		return m_mesh[0];
+	}
+
+	scene::IMesh *getMesh(u8 layer)
+	{
+		return m_mesh[layer];
 	}
 
 	MinimapMapblock *moveMinimapMapblock()
@@ -132,7 +137,7 @@ public:
 	void updateCameraOffset(v3s16 camera_offset);
 
 private:
-	scene::IMesh *m_mesh;
+	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	MinimapMapblock *m_minimap_mapblock;
 	Client *m_client;
 	video::IVideoDriver *m_driver;
@@ -150,20 +155,23 @@ private:
 	// Animation info: cracks
 	// Last crack value passed to animate()
 	int m_last_crack;
-	// Maps mesh buffer (i.e. material) indices to base texture names
-	UNORDERED_MAP<u32, std::string> m_crack_materials;
+	// Maps mesh and mesh buffer (i.e. material) indices to base texture names
+	std::map<std::pair<u8, u32>, std::string> m_crack_materials;
 
 	// Animation info: texture animationi
-	// Maps meshbuffers to TileSpecs
-	UNORDERED_MAP<u32, TileSpec> m_animation_tiles;
-	UNORDERED_MAP<u32, int> m_animation_frames; // last animation frame
-	UNORDERED_MAP<u32, int> m_animation_frame_offsets;
+	// Maps mesh and mesh buffer indices to TileSpecs
+	// Keys are pairs of (mesh index, buffer index in the mesh)
+	std::map<std::pair<u8, u32>, TileLayer> m_animation_tiles;
+	std::map<std::pair<u8, u32>, int> m_animation_frames; // last animation frame
+	std::map<std::pair<u8, u32>, int> m_animation_frame_offsets;
 
 	// Animation info: day/night transitions
 	// Last daynight_ratio value passed to animate()
 	u32 m_last_daynight_ratio;
-	// For each meshbuffer, stores pre-baked colors of sunlit vertices
-	std::map<u32, std::map<u32, video::SColor > > m_daynight_diffs;
+	// For each mesh and mesh buffer, stores pre-baked colors
+	// of sunlit vertices
+	// Keys are pairs of (mesh index, buffer index in the mesh)
+	std::map<std::pair<u8, u32>, std::map<u32, video::SColor > > m_daynight_diffs;
 
 	// Camera offset info -> do we have to translate the mesh?
 	v3s16 m_camera_offset;
@@ -176,7 +184,7 @@ private:
 */
 struct PreMeshBuffer
 {
-	TileSpec tile;
+	TileLayer layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
 	std::vector<video::S3DVertexTangents> tangent_vertices;
@@ -184,7 +192,7 @@ struct PreMeshBuffer
 
 struct MeshCollector
 {
-	std::vector<PreMeshBuffer> prebuffers;
+	std::vector<PreMeshBuffer> prebuffers[MAX_TILE_LAYERS];
 	bool m_use_tangent_vertices;
 
 	MeshCollector(bool use_tangent_vertices):
@@ -193,27 +201,38 @@ struct MeshCollector
 	}
 
 	void append(const TileSpec &material,
+				const video::S3DVertex *vertices, u32 numVertices,
+				const u16 *indices, u32 numIndices);
+	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices);
+			const u16 *indices, u32 numIndices, u8 layernum);
 	void append(const TileSpec &material,
+				const video::S3DVertex *vertices, u32 numVertices,
+				const u16 *indices, u32 numIndices, v3f pos,
+				video::SColor c, u8 light_source);
+	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source);
+			const u16 *indices, u32 numIndices, v3f pos,
+			video::SColor c, u8 light_source, u8 layernum);
+	/*!
+	 * Colorizes all vertices in the collector.
+	 */
+	void applyTileColors();
 };
 
 /*!
- * Encodes light and color of a node.
+ * Encodes light of a node.
  * The result is not the final color, but a
  * half-baked vertex color.
+ * You have to multiply the resulting color
+ * with the node's color.
  *
  * \param light the first 8 bits are day light,
  * the last 8 bits are night light
- * \param color the node's color
  * \param emissive_light amount of light the surface emits,
  * from 0 to LIGHT_SUN.
  */
-video::SColor encode_light_and_color(u16 light, const video::SColor &color,
-	u8 emissive_light);
+video::SColor encode_light(u16 light, u8 emissive_light);
 
 // Compute light at node
 u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -385,48 +385,50 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 	src_mesh->setBoundingBox(bbox);
 }
 
-scene::IMesh* cloneMesh(scene::IMesh *src_mesh)
+scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
+{
+	scene::IMeshBuffer *clone = NULL;
+	switch (mesh_buffer->getVertexType()) {
+	case video::EVT_STANDARD: {
+		video::S3DVertex *v = (video::S3DVertex *) mesh_buffer->getVertices();
+		u16 *indices = (u16*) mesh_buffer->getIndices();
+		scene::SMeshBuffer *temp_buf = new scene::SMeshBuffer();
+		temp_buf->append(v, mesh_buffer->getVertexCount(), indices,
+			mesh_buffer->getIndexCount());
+		return temp_buf;
+		break;
+	}
+	case video::EVT_2TCOORDS: {
+		video::S3DVertex2TCoords *v =
+			(video::S3DVertex2TCoords *) mesh_buffer->getVertices();
+		u16 *indices = (u16*) mesh_buffer->getIndices();
+		scene::SMeshBufferTangents *temp_buf = new scene::SMeshBufferTangents();
+		temp_buf->append(v, mesh_buffer->getVertexCount(), indices,
+			mesh_buffer->getIndexCount());
+		break;
+	}
+	case video::EVT_TANGENTS: {
+		video::S3DVertexTangents *v =
+			(video::S3DVertexTangents *) mesh_buffer->getVertices();
+		u16 *indices = (u16*) mesh_buffer->getIndices();
+		scene::SMeshBufferTangents *temp_buf = new scene::SMeshBufferTangents();
+		temp_buf->append(v, mesh_buffer->getVertexCount(), indices,
+			mesh_buffer->getIndexCount());
+		break;
+	}
+	}
+	return clone;
+}
+
+scene::SMesh* cloneMesh(scene::IMesh *src_mesh)
 {
 	scene::SMesh* dst_mesh = new scene::SMesh();
 	for (u16 j = 0; j < src_mesh->getMeshBufferCount(); j++) {
-		scene::IMeshBuffer *buf = src_mesh->getMeshBuffer(j);
-		switch (buf->getVertexType()) {
-			case video::EVT_STANDARD: {
-				video::S3DVertex *v =
-					(video::S3DVertex *) buf->getVertices();
-				u16 *indices = (u16*)buf->getIndices();
-				scene::SMeshBuffer *temp_buf = new scene::SMeshBuffer();
-				temp_buf->append(v, buf->getVertexCount(),
-					indices, buf->getIndexCount());
-				dst_mesh->addMeshBuffer(temp_buf);
-				temp_buf->drop();
-				break;
-			}
-			case video::EVT_2TCOORDS: {
-				video::S3DVertex2TCoords *v =
-					(video::S3DVertex2TCoords *) buf->getVertices();
-				u16 *indices = (u16*)buf->getIndices();
-				scene::SMeshBufferTangents *temp_buf =
-					new scene::SMeshBufferTangents();
-				temp_buf->append(v, buf->getVertexCount(),
-					indices, buf->getIndexCount());
-				dst_mesh->addMeshBuffer(temp_buf);
-				temp_buf->drop();
-				break;
-			}
-			case video::EVT_TANGENTS: {
-				video::S3DVertexTangents *v =
-					(video::S3DVertexTangents *) buf->getVertices();
-				u16 *indices = (u16*)buf->getIndices();
-				scene::SMeshBufferTangents *temp_buf =
-					new scene::SMeshBufferTangents();
-				temp_buf->append(v, buf->getVertexCount(),
-					indices, buf->getIndexCount());
-				dst_mesh->addMeshBuffer(temp_buf);
-				temp_buf->drop();
-				break;
-			}
-		}
+		scene::IMeshBuffer *temp_buf = cloneMeshBuffer(
+			src_mesh->getMeshBuffer(j));
+		dst_mesh->addMeshBuffer(temp_buf);
+		temp_buf->drop();
+
 	}
 	return dst_mesh;
 }

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -82,11 +82,16 @@ void rotateMeshBy6dFacedir(scene::IMesh *mesh, int facedir);
 void rotateMeshXYby (scene::IMesh *mesh, f64 degrees);
 void rotateMeshXZby (scene::IMesh *mesh, f64 degrees);
 void rotateMeshYZby (scene::IMesh *mesh, f64 degrees); 
+
+/*
+ *  Clone the mesh buffer.
+ */
+scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer);
  
 /*
 	Clone the mesh.
 */
-scene::IMesh* cloneMesh(scene::IMesh *src_mesh);
+scene::SMesh* cloneMesh(scene::IMesh *src_mesh);
 
 /*
 	Convert nodeboxes to mesh. Each tile goes into a different buffer.

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -148,9 +148,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add node and tile color and palette
 		Fix plantlike visual_scale being applied squared and add compatibility
 			with pre-30 clients by sending sqrt(visual_scale)
+	PROTOCOL VERSION 31:
+		Add tile overlay
 */
 
-#define LATEST_PROTOCOL_VERSION 30
+#define LATEST_PROTOCOL_VERSION 31
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 24

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -378,13 +378,13 @@ void ContentFeatures::reset()
 
 void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version < 30) {
+	if (protocol_version < 31) {
 		serializeOld(os, protocol_version);
 		return;
 	}
 
 	// version
-	writeU8(os, 9);
+	writeU8(os, 10);
 
 	// general
 	os << serializeString(name);
@@ -404,6 +404,8 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, 6);
 	for (u32 i = 0; i < 6; i++)
 		tiledef[i].serialize(os, protocol_version);
+	for (u32 i = 0; i < 6; i++)
+		tiledef_overlay[i].serialize(os, protocol_version);
 	writeU8(os, CF_SPECIAL_COUNT);
 	for (u32 i = 0; i < CF_SPECIAL_COUNT; i++) {
 		tiledef_special[i].serialize(os, protocol_version);
@@ -492,7 +494,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 	if (version < 9) {
 		deSerializeOld(is, version);
 		return;
-	} else if (version > 9) {
+	} else if (version > 10) {
 		throw SerializationError("unsupported ContentFeatures version");
 	}
 
@@ -516,6 +518,9 @@ void ContentFeatures::deSerialize(std::istream &is)
 		throw SerializationError("unsupported tile count");
 	for (u32 i = 0; i < 6; i++)
 		tiledef[i].deSerialize(is, version, drawtype);
+	if (version >= 10)
+		for (u32 i = 0; i < 6; i++)
+			tiledef_overlay[i].deSerialize(is, version, drawtype);
 	if (readU8(is) != CF_SPECIAL_COUNT)
 		throw SerializationError("unsupported CF_SPECIAL_COUNT");
 	for (u32 i = 0; i < CF_SPECIAL_COUNT; i++)
@@ -581,7 +586,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 }
 
 #ifndef SERVER
-void ContentFeatures::fillTileAttribs(ITextureSource *tsrc, TileSpec *tile,
+void ContentFeatures::fillTileAttribs(ITextureSource *tsrc, TileLayer *tile,
 		TileDef *tiledef, u32 shader_id, bool use_normal_texture,
 		bool backface_culling, u8 material_type)
 {
@@ -774,14 +779,18 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
-		fillTileAttribs(tsrc, &tiles[j], &tdef[j], tile_shader[j],
+		fillTileAttribs(tsrc, &tiles[j].layers[0], &tdef[j], tile_shader[j],
 			tsettings.use_normal_texture,
 			tiledef[j].backface_culling, material_type);
+		if (tiledef_overlay[j].name!="")
+			fillTileAttribs(tsrc, &tiles[j].layers[1], &tiledef_overlay[j],
+				tile_shader[j], tsettings.use_normal_texture,
+				tiledef[j].backface_culling, material_type);
 	}
 
 	// Special tiles (fill in f->special_tiles[])
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++) {
-		fillTileAttribs(tsrc, &special_tiles[j], &tiledef_special[j],
+		fillTileAttribs(tsrc, &special_tiles[j].layers[0], &tiledef_special[j],
 			tile_shader[j], tsettings.use_normal_texture,
 			tiledef_special[j].backface_culling, material_type);
 	}
@@ -1538,8 +1547,19 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
 		compatible_visual_scale = sqrt(visual_scale);
 
+	TileDef compatible_tiles[6];
+	for (u8 i = 0; i < 6; i++) {
+		compatible_tiles[i] = tiledef[i];
+		if (tiledef_overlay[i].name != "") {
+			std::stringstream s;
+			s << "(" << tiledef[i].name << ")^(" << tiledef_overlay[i].name
+				<< ")";
+			compatible_tiles[i].name = s.str();
+		}
+	}
+
 	// Protocol >= 24
-	if (protocol_version < 30) {
+	if (protocol_version < 31) {
 		writeU8(os, protocol_version < 27 ? 7 : 8);
 
 		os << serializeString(name);
@@ -1553,7 +1573,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
-			tiledef[i].serialize(os, protocol_version);
+			compatible_tiles[i].serialize(os, protocol_version);
 		writeU8(os, CF_SPECIAL_COUNT);
 		for (u32 i = 0; i < CF_SPECIAL_COUNT; i++)
 			tiledef_special[i].serialize(os, protocol_version);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -280,6 +280,8 @@ struct ContentFeatures
 #endif
 	float visual_scale; // Misc. scale parameter
 	TileDef tiledef[6];
+	// These will be drawn over the base tiles.
+	TileDef tiledef_overlay[6];
 	TileDef tiledef_special[CF_SPECIAL_COUNT]; // eg. flowing liquid
 	// If 255, the node is opaque.
 	// Otherwise it uses texture alpha.
@@ -405,7 +407,7 @@ struct ContentFeatures
 	}
 
 #ifndef SERVER
-	void fillTileAttribs(ITextureSource *tsrc, TileSpec *tile, TileDef *tiledef,
+	void fillTileAttribs(ITextureSource *tsrc, TileLayer *tile, TileDef *tiledef,
 		u32 shader_id, bool use_normal_texture, bool backface_culling,
 		u8 material_type);
 	void updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc,

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -620,7 +620,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 {
 	// Texture
 	u8 texid = myrand_range(0, 5);
-	const TileSpec &tile = f.tiles[texid];
+	const TileLayer &tile = f.tiles[texid].layers[0];
 	video::ITexture *texture;
 	struct TileAnimationParams anim;
 	anim.type = TAT_NONE;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -426,6 +426,34 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	}
 	lua_pop(L, 1);
 
+	// overlay_tiles = {}
+	lua_getfield(L, index, "overlay_tiles");
+	if (lua_istable(L, -1)) {
+		int table = lua_gettop(L);
+		lua_pushnil(L);
+		int i = 0;
+		while (lua_next(L, table) != 0) {
+			// Read tiledef from value
+			f.tiledef_overlay[i] = read_tiledef(L, -1, f.drawtype);
+			// removes value, keeps key for next iteration
+			lua_pop(L, 1);
+			i++;
+			if (i == 6) {
+				lua_pop(L, 1);
+				break;
+			}
+		}
+		// Copy last value to all remaining textures
+		if (i >= 1) {
+			TileDef lasttile = f.tiledef_overlay[i - 1];
+			while (i < 6) {
+				f.tiledef_overlay[i] = lasttile;
+				i++;
+			}
+		}
+	}
+	lua_pop(L, 1);
+
 	// special_tiles = {}
 	lua_getfield(L, index, "special_tiles");
 	// If nil, try the deprecated name "special_materials" instead

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -235,27 +235,16 @@ WieldMeshSceneNode::~WieldMeshSceneNode()
 		g_extrusion_mesh_cache = NULL;
 }
 
-void WieldMeshSceneNode::setCube(const TileSpec tiles[6],
+void WieldMeshSceneNode::setCube(const ContentFeatures &f,
 			v3f wield_scale, ITextureSource *tsrc)
 {
 	scene::IMesh *cubemesh = g_extrusion_mesh_cache->createCube();
-	changeToMesh(cubemesh);
+	scene::SMesh *copy = cloneMesh(cubemesh);
 	cubemesh->drop();
-
+	postProcessNodeMesh(copy, f, false, true, &m_material_type, &m_colors);
+	changeToMesh(copy);
+	copy->drop();
 	m_meshnode->setScale(wield_scale * WIELD_SCALE_FACTOR);
-
-	// Customize materials
-	for (u32 i = 0; i < m_meshnode->getMaterialCount(); ++i) {
-		assert(i < 6);
-		video::SMaterial &material = m_meshnode->getMaterial(i);
-		if (tiles[i].animation_frame_count == 1) {
-			material.setTexture(0, tiles[i].texture);
-		} else {
-			FrameSpec animation_frame = tiles[i].frames[0];
-			material.setTexture(0, animation_frame.texture);
-		}
-		tiles[i].applyMaterialOptions(material);
-	}
 }
 
 void WieldMeshSceneNode::setExtruded(const std::string &imagename,
@@ -274,8 +263,10 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		dim = core::dimension2d<u32>(dim.Width, frame_height);
 	}
 	scene::IMesh *mesh = g_extrusion_mesh_cache->create(dim);
-	changeToMesh(mesh);
+	scene::SMesh *copy = cloneMesh(mesh);
 	mesh->drop();
+	changeToMesh(copy);
+	copy->drop();
 
 	m_meshnode->setScale(wield_scale * WIELD_SCALE_FACTOR_EXTRUDED);
 
@@ -321,12 +312,12 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 
 	// Color-related
 	m_colors.clear();
-	video::SColor basecolor = idef->getItemstackColor(item, client);
+	m_base_color = idef->getItemstackColor(item, client);
 
 	// If wield_image is defined, it overrides everything else
 	if (def.wield_image != "") {
 		setExtruded(def.wield_image, def.wield_scale, tsrc, 1);
-		m_colors.push_back(basecolor);
+		m_colors.push_back(ItemPartColor());
 		return;
 	}
 	// Handle nodes
@@ -334,66 +325,50 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 	else if (def.type == ITEM_NODE) {
 		if (f.mesh_ptr[0]) {
 			// e.g. mesh nodes and nodeboxes
-			changeToMesh(f.mesh_ptr[0]);
-			// mesh_ptr[0] is pre-scaled by BS * f->visual_scale
+			scene::SMesh *mesh = cloneMesh(f.mesh_ptr[0]);
+			postProcessNodeMesh(mesh, f, m_enable_shaders, true,
+				&m_material_type, &m_colors);
+			changeToMesh(mesh);
+			mesh->drop();
+			// mesh is pre-scaled by BS * f->visual_scale
 			m_meshnode->setScale(
 					def.wield_scale * WIELD_SCALE_FACTOR
 					/ (BS * f.visual_scale));
 		} else if (f.drawtype == NDT_AIRLIKE) {
 			changeToMesh(NULL);
 		} else if (f.drawtype == NDT_PLANTLIKE) {
-			setExtruded(tsrc->getTextureName(f.tiles[0].texture_id), def.wield_scale, tsrc, f.tiles[0].animation_frame_count);
+			setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
+				def.wield_scale, tsrc,
+				f.tiles[0].layers[0].animation_frame_count);
 		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES) {
-			setCube(f.tiles, def.wield_scale, tsrc);
+			setCube(f, def.wield_scale, tsrc);
 		} else {
 			MeshMakeData mesh_make_data(client, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);
 			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
-			changeToMesh(mapblock_mesh.getMesh());
-			translateMesh(m_meshnode->getMesh(), v3f(-BS, -BS, -BS));
+			scene::SMesh *mesh = cloneMesh(mapblock_mesh.getMesh());
+			translateMesh(mesh, v3f(-BS, -BS, -BS));
+			postProcessNodeMesh(mesh, f, m_enable_shaders, true,
+				&m_material_type, &m_colors);
+			changeToMesh(mesh);
+			mesh->drop();
 			m_meshnode->setScale(
 					def.wield_scale * WIELD_SCALE_FACTOR
 					/ (BS * f.visual_scale));
 		}
 		u32 material_count = m_meshnode->getMaterialCount();
-		if (material_count > 6) {
-			errorstream << "WieldMeshSceneNode::setItem: Invalid material "
-				"count " << material_count << ", truncating to 6" << std::endl;
-			material_count = 6;
-		}
 		for (u32 i = 0; i < material_count; ++i) {
-			const TileSpec *tile = &(f.tiles[i]);
 			video::SMaterial &material = m_meshnode->getMaterial(i);
 			material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 			material.setFlag(video::EMF_BILINEAR_FILTER, m_bilinear_filter);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, m_trilinear_filter);
-			bool animated = (tile->animation_frame_count > 1);
-			if (animated) {
-				FrameSpec animation_frame = tile->frames[0];
-				material.setTexture(0, animation_frame.texture);
-			} else {
-				material.setTexture(0, tile->texture);
-			}
-			m_colors.push_back(tile->has_color ? tile->color : basecolor);
-			material.MaterialType = m_material_type;
-			if (m_enable_shaders) {
-				if (tile->normal_texture) {
-					if (animated) {
-						FrameSpec animation_frame = tile->frames[0];
-						material.setTexture(1, animation_frame.normal_texture);
-					} else {
-						material.setTexture(1, tile->normal_texture);
-					}
-				}
-				material.setTexture(2, tile->flags_texture);
-			}
 		}
 		return;
 	}
 	else if (def.inventory_image != "") {
 		setExtruded(def.inventory_image, def.wield_scale, tsrc, 1);
-		m_colors.push_back(basecolor);
+		m_colors.push_back(ItemPartColor());
 		return;
 	}
 
@@ -413,9 +388,9 @@ void WieldMeshSceneNode::setColor(video::SColor c)
 	u8 blue = c.getBlue();
 	u32 mc = mesh->getMeshBufferCount();
 	for (u32 j = 0; j < mc; j++) {
-		video::SColor bc(0xFFFFFFFF);
-		if (m_colors.size() > j)
-			bc = m_colors[j];
+		video::SColor bc(m_base_color);
+		if ((m_colors.size() > j) && (m_colors[j].override_base))
+			bc = m_colors[j].color;
 		video::SColor buffercolor(255,
 			bc.getRed() * red / 255,
 			bc.getGreen() * green / 255,
@@ -439,19 +414,7 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 		m_meshnode->setMesh(dummymesh);
 		dummymesh->drop();  // m_meshnode grabbed it
 	} else {
-		if (m_lighting) {
-			m_meshnode->setMesh(mesh);
-		} else {
-			/*
-				Lighting is disabled, this means the caller can (and probably will)
-				call setColor later. We therefore need to clone the mesh so that
-				setColor will only modify this scene node's mesh, not others'.
-			*/
-			scene::IMeshManipulator *meshmanip = SceneManager->getMeshManipulator();
-			scene::IMesh *new_mesh = meshmanip->createMeshCopy(mesh);
-			m_meshnode->setMesh(new_mesh);
-			new_mesh->drop();  // m_meshnode grabbed it
-		}
+		m_meshnode->setMesh(mesh);
 	}
 
 	m_meshnode->setMaterialFlag(video::EMF_LIGHTING, m_lighting);
@@ -475,24 +438,24 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		g_extrusion_mesh_cache->grab();
 	}
 
-	scene::IMesh *mesh;
+	scene::SMesh *mesh;
 
 	// If inventory_image is defined, it overrides everything else
 	if (def.inventory_image != "") {
 		mesh = getExtrudedMesh(tsrc, def.inventory_image);
-		result->mesh = mesh;
-		result->buffer_colors.push_back(
-			std::pair<bool, video::SColor>(false, video::SColor(0xFFFFFFFF)));
+		result->buffer_colors.push_back(ItemPartColor());
 	} else if (def.type == ITEM_NODE) {
 		if (f.mesh_ptr[0]) {
 			mesh = cloneMesh(f.mesh_ptr[0]);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
 		} else if (f.drawtype == NDT_PLANTLIKE) {
 			mesh = getExtrudedMesh(tsrc,
-				tsrc->getTextureName(f.tiles[0].texture_id));
+				tsrc->getTextureName(f.tiles[0].layers[0].texture_id));
 		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES
 			|| f.drawtype == NDT_LIQUID || f.drawtype == NDT_FLOWINGLIQUID) {
-			mesh = cloneMesh(g_extrusion_mesh_cache->createCube());
+			scene::IMesh *cube = g_extrusion_mesh_cache->createCube();
+			mesh = cloneMesh(cube);
+			cube->drop();
 			scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
 		} else {
 			MeshMakeData mesh_make_data(client, false);
@@ -519,32 +482,27 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 
 		u32 mc = mesh->getMeshBufferCount();
 		for (u32 i = 0; i < mc; ++i) {
-			const TileSpec *tile = &(f.tiles[i]);
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
-			result->buffer_colors.push_back(
-				std::pair<bool, video::SColor>(tile->has_color, tile->color));
-			colorizeMeshBuffer(buf, &tile->color);
 			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 			material.setFlag(video::EMF_BILINEAR_FILTER, false);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, false);
 			material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 			material.setFlag(video::EMF_LIGHTING, false);
-			if (tile->animation_frame_count > 1) {
-				FrameSpec animation_frame = tile->frames[0];
-				material.setTexture(0, animation_frame.texture);
-			} else {
-				material.setTexture(0, tile->texture);
-			}
 		}
 
 		rotateMeshXZby(mesh, -45);
 		rotateMeshYZby(mesh, -30);
-		result->mesh = mesh;
+
+		postProcessNodeMesh(mesh, f, false, false, NULL,
+			&result->buffer_colors);
 	}
+	result->mesh = mesh;
 }
 
-scene::IMesh * getExtrudedMesh(ITextureSource *tsrc,
+
+
+scene::SMesh * getExtrudedMesh(ITextureSource *tsrc,
 		const std::string &imagename)
 {
 	video::ITexture *texture = tsrc->getTextureForMesh(imagename);
@@ -553,7 +511,9 @@ scene::IMesh * getExtrudedMesh(ITextureSource *tsrc,
 	}
 
 	core::dimension2d<u32> dim = texture->getSize();
-	scene::IMesh *mesh = cloneMesh(g_extrusion_mesh_cache->create(dim));
+	scene::IMesh *original = g_extrusion_mesh_cache->create(dim);
+	scene::SMesh *mesh = cloneMesh(original);
+	original->drop();
 
 	// Customize material
 	video::SMaterial &material = mesh->getMeshBuffer(0)->getMaterial();
@@ -568,4 +528,58 @@ scene::IMesh * getExtrudedMesh(ITextureSource *tsrc,
 	scaleMesh(mesh, v3f(2.0, 2.0, 2.0));
 
 	return mesh;
+}
+
+void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
+	bool use_shaders, bool set_material, video::E_MATERIAL_TYPE *mattype,
+	std::vector<ItemPartColor> *colors)
+{
+	u32 mc = mesh->getMeshBufferCount();
+	// Allocate colors for existing buffers
+	colors->clear();
+	for (u32 i = 0; i < mc; ++i)
+		colors->push_back(ItemPartColor());
+
+	for (u32 i = 0; i < mc; ++i) {
+		const TileSpec *tile = &(f.tiles[i]);
+		scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
+		for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
+			const TileLayer *layer = &tile->layers[layernum];
+			if (layer->texture_id == 0)
+				continue;
+			if (layernum != 0) {
+				scene::IMeshBuffer *copy = cloneMeshBuffer(buf);
+				copy->getMaterial() = buf->getMaterial();
+				mesh->addMeshBuffer(copy);
+				copy->drop();
+				buf = copy;
+				colors->push_back(
+					ItemPartColor(layer->has_color, layer->color));
+			} else {
+				(*colors)[i] = ItemPartColor(layer->has_color, layer->color);
+			}
+			video::SMaterial &material = buf->getMaterial();
+			if (set_material)
+				layer->applyMaterialOptions(material);
+			if (mattype) {
+				material.MaterialType = *mattype;
+			}
+			if (layer->animation_frame_count > 1) {
+				FrameSpec animation_frame = layer->frames[0];
+				material.setTexture(0, animation_frame.texture);
+			} else {
+				material.setTexture(0, layer->texture);
+			}
+			if (use_shaders) {
+				if (layer->normal_texture) {
+					if (layer->animation_frame_count > 1) {
+						FrameSpec animation_frame = layer->frames[0];
+						material.setTexture(1, animation_frame.normal_texture);
+					} else
+						material.setTexture(1, layer->normal_texture);
+				}
+				material.setTexture(2, layer->flags_texture);
+			}
+		}
+	}
 }


### PR DESCRIPTION
This commit adds soft node overlays, which are tiles that are drawn on top of other tiles.

Advantages:
You can colorize specific parts of your textures
Unlike texture overlays, this method does not create new textures in the video memory, so mods which use repetitive texture parts (like the Streets Mod) can decrease their texture memory usage
For old clients these overlays are converted into regular texture overlays (without colorization).

Disadvantages:
These overlays are actual geometry. They consume mesh memory and they need to be separately rendered. This is why it is not recommended to use such overlays for very common nodes with difficult geometry.
If you dig a node, the created particles do not contain the overlay texture.
On the minimap overlays are ignored.

How to use:
An example node:
```lua
minetest.register_node("default:dirt_with_grass", {
	description = "Dirt with Grass",
	-- Regular tiles, as usual
	tiles = {{name="default_grass.png"}, 
		{name="default_dirt.png", color="white"}},
	-- Overlay tiles: define them in the same style
	overlay_tiles = {"", "", -- The top and bottom does not have overlay
			{name = "default_grass_side.png", tileable_vertical = false}},
	-- Color in inventory
	color="green",
	-- Palette in the world
	paramtype2="color",
	palette="default_foilage.png",
})
```

And the result:
![grass_side](https://cloud.githubusercontent.com/assets/20600448/22669223/f707bf12-ecc3-11e6-9fbc-372212ead773.png)
