### PR TITLE
Change default nodetimer_interval to 0.2s.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -840,7 +840,7 @@ active_block_mgmt_interval (Active Block Management interval) float 2.0
 abm_interval (Active Block Modifier interval) float 1.0
 
 #    Length of time between NodeTimer execution cycles
-nodetimer_interval (NodeTimer interval) float 1.0
+nodetimer_interval (NodeTimer interval) float 0.2
 
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1027,7 +1027,7 @@
 
 #    Length of time between NodeTimer execution cycles
 #    type: float
-# nodetimer_interval = 1.0
+# nodetimer_interval = 0.2
 
 #    If enabled, invalid world data won't cause the server to shut down.
 #    Only enable this if you know what you are doing.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -295,7 +295,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("dedicated_server_step", "0.1");
 	settings->setDefault("active_block_mgmt_interval", "2.0");
 	settings->setDefault("abm_interval", "1.0");
-	settings->setDefault("nodetimer_interval", "1.0");
+	settings->setDefault("nodetimer_interval", "0.2");
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");


### PR DESCRIPTION
We want to reduce the chance that we get lots and lots of node
timers all happening once a second, because we're better off doing
small bits of work as they are available.

Reducing this to 0.2 seconds will greatly reduce the total amount
of nodetimers that elapse at the same instance, while not effecting
total work load. This results in a far better chance of the server
keeping up with work loads.