### PR TITLE
Footsteps: Fix offset footstep and shallow water sound bugs 

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3530,7 +3530,7 @@ void Game::updateSound(f32 dtime)
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
 	ClientMap &map = client->getEnv().getClientMap();
-	MapNode n = map.getNodeNoEx(player->getStandingNodePos());
+	MapNode n = map.getNodeNoEx(player->getFootstepNodePos());
 	soundmaker->m_player_step_sound = nodedef_manager->get(n).sound_footstep;
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -655,6 +655,18 @@ v3s16 LocalPlayer::getStandingNodePos()
 	return floatToInt(getPosition() - v3f(0, BS, 0), BS);
 }
 
+v3s16 LocalPlayer::getFootstepNodePos()
+{
+	if (touching_ground)
+		// BS * 0.05 below the player's feet ensures a 1/16th height
+		// nodebox is detected instead of the node below it.
+		return floatToInt(getPosition() - v3f(0, BS * 0.05f, 0), BS);
+	// A larger distance below is necessary for a footstep sound
+	// when landing after a jump or fall. BS * 0.5 ensures water
+	// sounds when swimming in 1 node deep water.
+	return floatToInt(getPosition() - v3f(0, BS * 0.5f, 0), BS);
+}
+
 v3s16 LocalPlayer::getLightPosition() const
 {
 	return floatToInt(m_position + v3f(0,BS+BS/2,0), BS);

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -68,6 +68,7 @@ public:
 	void applyControl(float dtime);
 
 	v3s16 getStandingNodePos();
+	v3s16 getFootstepNodePos();
 
 	// Used to check if anything changed and prevent sending packets if not
 	v3f last_position;


### PR DESCRIPTION
Fix footstep sounds coming from nodes to either side when walking on a
1 node wide row of nodebox slabs such as default:snow.
Fix sand footsteps when swimming in 1 node deep water.

Use a new function 'getFootstepNodePos()' instead of 'getStandingNodePos()'
to avoid using a horizontally-offset 'sneak node' for sounds.

Sound is selected from the node BS * 0.05 below the player's feet, so
that 1/16th slabs will play the slab sound but 1/32nd slabs will not.
If the player is not 'touching ground' the node detection position is
changed to BS * 0.5 below to preserve footstep sounds when landing after
a jump or fall.
///////////////////////////////////////////////////////////

Addresses #5121 see detailed discussion there.

Tested to make sure 1/16th slabs still play the slab sound.
Also fixes sand footsteps being played when swimming in 1 node deep water. If swimming water sounds are played, if walking on the lakebed sand footsteps are played.

Note footsteps are no longer played if the player is hanging off the edge of a node as shown below, this seems a reasonable price to pay. The previous code used horizontally-offset 'sneak nodes' to play sounds when hanging off the edge but this is exactly what causes the bug.

![screenshot_20170209_221533](https://cloud.githubusercontent.com/assets/3686677/22805723/d997f01e-ef16-11e6-8ed4-3030e0145a40.png)