### PR TITLE
Plantlike: Fix visual_scale being applied squared

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1602,8 +1602,6 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				}
 
 				for (int i = 0; i < 4; i++) {
-					vertices[i].Pos *= f.visual_scale;
-					vertices[i].Pos.Y += BS/2 * (f.visual_scale - 1);
 					if (data->m_smooth_lighting)
 						vertices[i].Color = blendLight(frame, vertices[i].Pos, tile.color);
 					vertices[i].Pos += intToFloat(p, BS);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -146,6 +146,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 30:
 		New ContentFeatures serialization version
 		Add node and tile color and palette
+		Fix plantlike visual_scale being applied squared and add compatibility
+			with pre-30 clients by sending sqrt(visual_scale)
 */
 
 #define LATEST_PROTOCOL_VERSION 30

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1611,6 +1611,10 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			compatible_param_type_2 = CPT2_WALLMOUNTED;
 	}
 
+	float compatible_visual_scale = visual_scale;
+	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
+		compatible_visual_scale = sqrt(visual_scale);
+
 	if (protocol_version == 13)
 	{
 		writeU8(os, 5); // version
@@ -1622,7 +1626,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);
@@ -1670,7 +1674,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);
@@ -1724,7 +1728,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 			writeS16(os, i->second);
 		}
 		writeU8(os, drawtype);
-		writeF1000(os, visual_scale);
+		writeF1000(os, compatible_visual_scale);
 		writeU8(os, 6);
 		for (u32 i = 0; i < 6; i++)
 			tiledef[i].serialize(os, protocol_version);


### PR DESCRIPTION
This re-applies 2 commits that were reverted.

Visual_scale was applied twice to plantlike by accident sometime between
2011 and 2013, squaring the requested scale value. Visual_scale is
correctly applied once in it's other uses in signlike and torchlike.

Two lines of code are removed, they also had no effect for the vast
majority of nodes with the default visual_scale of 1.0.
The texture continues to have it's base at ground level.

Send sqrt(visual_scale) to old clients.

Keep compatibility with protocol < 30 clients now that visual_scale
is no longer applied twice to plantlike drawtype and mods are being
updated to a new value.
////////////////////////////////////////////////////

Re-applies #5115 #5138 
Discussion http://irc.minetest.net/minetest-dev/2017-02-10#i_4807131