### PR TITLE
Make colourized mainmenu text more readable

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -16,9 +16,9 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 mt_color_grey  = "#AAAAAA"
-mt_color_blue  = "#0000DD"
-mt_color_green = "#00DD00"
-mt_color_dark_green = "#003300"
+mt_color_blue  = "#6389FF"
+mt_color_green = "#72FF63"
+mt_color_dark_green = "#25C191"
 
 --for all other colors ask sfan5 to complete his work!
 


### PR DESCRIPTION
Before:
![2017-02-11-114127_1920x1080_scrot](https://cloud.githubusercontent.com/assets/3192173/22853173/5fececee-f04f-11e6-9611-49d6c9dbbc02.png)

After:
![2017-02-11-114054_1920x1080_scrot](https://cloud.githubusercontent.com/assets/3192173/22853174/6574c5f6-f04f-11e6-80a3-a86d39f33f0c.png)
