### PR TITLE
Firelike drawtype: Fix visual_scale being applied squared

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3817,9 +3817,10 @@ Definition tables
 
         drawtype = "normal", -- See "Node drawtypes"
         visual_scale = 1.0, --[[
-        ^ Supported for drawtypes "plantlike", "signlike", "torchlike", "mesh".
-        ^ For plantlike, the image will start at the bottom of the node; for the
-        ^ other drawtypes, the image will be centered on the node.
+        ^ Supported for drawtypes "plantlike", "signlike", "torchlike",
+        ^ "firelike", "mesh".
+        ^ For plantlike and firelike, the image will start at the bottom of the
+        ^ node, for the other drawtypes the image will be centered on the node.
         ^ Note that positioning for "torchlike" may still change. ]]
         tiles = {tile definition 1, def2, def3, def4, def5, def6}, --[[
         ^ Textures of node; +Y, -Y, +X, -X, +Z, -Z (old field name: tile_images)

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1755,7 +1755,6 @@ void mapblock_mesh_generate_special(MeshMakeData *data,
 				}
 
 				for (int i = 0; i < 4; i++) {
-					vertices[i].Pos *= f.visual_scale;
 					if (data->m_smooth_lighting)
 						vertices[i].Color = blendLight(frame, vertices[i].Pos, tile.color);
 					vertices[i].Pos += intToFloat(p, BS);


### PR DESCRIPTION
Visual_scale was applied twice to firelike by copying plantlike code,
squaring the desired scale value. Visual_scale is correctly applied
once in it's other uses in plantlike, signlike and torchlike.

Update lua_api.txt to document that 'visual scale' is usable with
firelike drawtype.

Since this use of 'visual scale' was undocumented, since it's use with
firelike is unlikely, and since the nature of the texture offsets and
rotations means that identical backwards compatibility is not possible
by sending sqrt(visual scale) to old clients, do not attempt backwards
compatibility.
///////////////////////////////////////////////////

To be rebased and merged after the refactor of content_mapblock.cpp.

Similar to #5115 #5138 but for firelike drawtype and without backwards compatibility with old clients (because that is not possible).

Below, firelike with 'visual scale = 2':

![screenshot_20170211_190252](https://cloud.githubusercontent.com/assets/3686677/22857165/d0a60cde-f097-11e6-9e2e-78d497eeb135.png)

^ Current code, result is 4 times larger and texture bases do not align with coal block top

![screenshot_20170211_194838](https://cloud.githubusercontent.com/assets/3686677/22857171/eeb21c72-f097-11e6-8e62-a3650d1dc0af.png)

^ This commit