### PR TITLE
Objectpos over limit: Avoid crash caused by sector over limit

### DIFF
--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -653,14 +653,18 @@ typedef std::vector<MapBlock*> MapBlockVect;
 
 inline bool objectpos_over_limit(v3f p)
 {
-	const float map_gen_limit_bs = MYMIN(MAX_MAP_GENERATION_LIMIT,
-		g_settings->getU16("map_generation_limit")) * BS;
-	return (p.X < -map_gen_limit_bs
-		|| p.X > map_gen_limit_bs
-		|| p.Y < -map_gen_limit_bs
-		|| p.Y > map_gen_limit_bs
-		|| p.Z < -map_gen_limit_bs
-		|| p.Z > map_gen_limit_bs);
+	// MAP_BLOCKSIZE must be subtracted to avoid an object being spawned just
+	// within the map generation limit but in a block and sector that extend
+	// beyond the map generation limit.
+	// This avoids crashes caused by sector over limit in createSector().
+	const float object_limit = (MYMIN(MAX_MAP_GENERATION_LIMIT,
+		g_settings->getU16("map_generation_limit")) - MAP_BLOCKSIZE) * BS;
+	return (p.X < -object_limit
+		|| p.X > object_limit
+		|| p.Y < -object_limit
+		|| p.Y > object_limit
+		|| p.Z < -object_limit
+		|| p.Z > object_limit);
 }
 
 /*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1667,7 +1667,7 @@ u16 ServerEnvironment::addActiveObjectRaw(ServerActiveObject *object,
 
 	if (objectpos_over_limit(object->getBasePosition())) {
 		v3f p = object->getBasePosition();
-		errorstream << "ServerEnvironment::addActiveObjectRaw(): "
+		warningstream << "ServerEnvironment::addActiveObjectRaw(): "
 			<< "object position (" << p.X << "," << p.Y << "," << p.Z
 			<< ") outside maximum range" << std::endl;
 		if (object->environmentDeletes())


### PR DESCRIPTION
Reduce the object limit by mapblock size, to avoid objects being
added just inside the map generation limit but in a block and sector
that extend beyond the map generation limit.

Change notification of 'objectpos over limit' from red in-chat ERROR
to in-terminal only WARNING, since this will happen often using mob
mods near the world's edge.
///////////////////////////////////////////////////

#5157 back from the dead, we do need it after all.
Addresses parts of #4923 
Note: a sector is a vertical column of mapblocks.
Tested.

The existing 'objectpos over limit' checks against 'map gen limit', but an object can be inside 'map gen limit' but also be in a block and sector that extends beyond 'map gen limit' which is not allowed and causes a crash. The simplest solution is to just reduce the object limit by 'mapblock size'.

///////////////////////////////////////////////////

Testing with mobs redo and farm animals, with bunny set to spawn 1 per second.
I generated world beyond x = 4500 then set map gen limit to 4500, restarted world and stood at world's edge.
There were many error messages of objects failing to be placed but no crash:
```
2017-02-02 16:24:38: ERROR[Server]: ServerEnvironment::addActiveObjectRaw():
object position (44950,105,140) outside maximum range
[mobs] mobs_animal:bunny failed to spawn at (4495,10.5,14)	2
2017-02-02 16:24:38: ERROR[Server]: ServerEnvironment::addActiveObjectRaw():
object position (44950,105,150) outside maximum range
[mobs] mobs_animal:bunny failed to spawn at (4495,10.5,15)	2
Unknown chunk found in mesh base - skipping
Loaded mesh: mobs_sheep.b3d
Loaded mesh: mobs_bunny.b3d
Loaded mesh: mobs_bunny.b3d
Loaded mesh: mobs_bunny.b3d
2017-02-02 16:25:49: ERROR[Server]: ServerEnvironment::addActiveObjectRaw():
object position (44843.3,14.0751,-344.585) outside maximum range
2017-02-02 16:26:32: ERROR[Server]: ServerEnvironment::addActiveObjectRaw():
object position (44888.9,40,380.244) outside maximum range
```
Note mob spawns are being prevented at x = 4484 which is 16 nodes within the map gen limit, as expected.
These errors were shown in red in chat which seems unnecessary, so i moved them to warningstream.