### PR TITLE
Only add direct neighbors for each MapBlock loaded on the client.

### DIFF
--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -83,9 +83,8 @@ void MeshMakeData::fill(MapBlock *block)
 		// Get map
 		Map *map = block->getParent();
 
-		for(u16 i=0; i<26; i++)
-		{
-			const v3s16 &dir = g_26dirs[i];
+		for (u16 i=0; i<6; i++) {
+			const v3s16 &dir = g_6dirs[i];
 			v3s16 bp = m_blockpos + dir;
 			MapBlock *b = map->getBlockNoCreateNoEx(bp);
 			if(b)

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -83,8 +83,9 @@ void MeshMakeData::fill(MapBlock *block)
 		// Get map
 		Map *map = block->getParent();
 
-		for (u16 i=0; i<6; i++) {
-			const v3s16 &dir = g_6dirs[i];
+		for(u16 i=0; i<26; i++)
+		{
+			const v3s16 &dir = g_26dirs[i];
 			v3s16 bp = m_blockpos + dir;
 			MapBlock *b = map->getBlockNoCreateNoEx(bp);
 			if(b)

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -83,9 +83,8 @@ void MeshMakeData::fill(MapBlock *block)
 		// Get map
 		Map *map = block->getParent();
 
-		for(u16 i=0; i<26; i++)
-		{
-			const v3s16 &dir = g_26dirs[i];
+		for(u16 i = 0; i < 18; i++) {
+			const v3s16 &dir = g_18dirs[i];
 			v3s16 bp = m_blockpos + dir;
 			MapBlock *b = map->getBlockNoCreateNoEx(bp);
 			if(b)

--- a/src/util/directiontables.cpp
+++ b/src/util/directiontables.cpp
@@ -30,6 +30,31 @@ const v3s16 g_6dirs[6] =
 	v3s16(-1, 0, 0) // left
 };
 
+const v3s16 g_18dirs[18] =
+{
+	// +right, +top, +back
+	v3s16( 0, 0, 1), // back
+	v3s16( 0, 1, 0), // top
+	v3s16( 1, 0, 0), // right
+	v3s16( 0, 0,-1), // front
+	v3s16( 0,-1, 0), // bottom
+	v3s16(-1, 0, 0), // left
+	// 6
+	v3s16(-1, 1, 0), // top left
+	v3s16( 1, 1, 0), // top right
+	v3s16( 0, 1, 1), // top back
+	v3s16( 0, 1,-1), // top front
+	v3s16(-1, 0, 1), // back left
+	v3s16( 1, 0, 1), // back right
+	v3s16(-1, 0,-1), // front left
+	v3s16( 1, 0,-1), // front right
+	v3s16(-1,-1, 0), // bottom left
+	v3s16( 1,-1, 0), // bottom right
+	v3s16( 0,-1, 1), // bottom back
+	v3s16( 0,-1,-1), // bottom front
+	// 18
+};
+
 const v3s16 g_26dirs[26] =
 {
 	// +right, +top, +back

--- a/src/util/directiontables.h
+++ b/src/util/directiontables.h
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 extern const v3s16 g_6dirs[6];
 
+extern const v3s16 g_18dirs[18];
+
 extern const v3s16 g_26dirs[26];
 
 // 26th is (0,0,0)


### PR DESCRIPTION
While profiling only on the main Minetest thread (the one that also renders the view) I noticed that when I move around on the map VoxelManipulator::copyFrom and memcpy/memset called from it are using a large percentage of the CPU as blocks are loaded into the client.

I eventually tracked it down to MeshMakeData::fill. If I understand the intention of the code correctly the goal is to make sure all border meshes are rendered eventually by making sure all neighboring blocks are loaded.

In order to achieve that it is not necessary to also (re-)add all 26 neighbors to the VoxelManipulator but only the 6 that actually share a "surface".

(To verify when I remove that part altogether I noticed many missing surfaces. When I change the code as suggested in this PR there are no rendering problems even after prolonged checking with many scenarios)

This cut down the the time spent in copyFrom from > 17% to < 5%.