### PR TITLE
Clarify loading of minetest.conf in Readme.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -102,6 +102,8 @@ Configuration file:
 - It is created by Minetest when it is ran the first time.
 - A specific file can be specified on the command line:
 	--config <path-to-file>
+- A run-in-place build will look for the configuration file in 
+        $location_of_exe/../minetest.conf and also $location_of_exe/../../minetest.conf
 
 Command-line options:
 ---------------------


### PR DESCRIPTION
Clarify in doc/README.txt: 
```
- A run-in-place build will look for the configuration file in 
        $location_of_exe/../minetest.conf and also $location_of_exe/../../minetest.conf
```

Addresses https://github.com/minetest/minetest/issues/5245:

>[23:33:23] celeron55: a run-in-place will look for the configuration file from $location_of_exe/../minetest.conf and also $location_of_exe/../../minetest.conf
>[23:33:31] celeron55: a run-in-place build*
>[23:34:24] celeron55: useful for eg. visual studio builds that append another directory before bin
>[23:35:58] celeron55: or for collections of different minetests that still should use the same configuration

Yay, my first pull request.