### PR TITLE
Multiplayer menu: fix attempt to open nonexistant image.

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -54,7 +54,8 @@ end
 function image_column(tooltip, flagname)
 	return "image,tooltip=" .. core.formspec_escape(tooltip) .. "," ..
 		"0=" .. core.formspec_escape(defaulttexturedir .. "blank.png") .. "," ..
-		"1=" .. core.formspec_escape(defaulttexturedir .. "server_flags_" .. flagname .. ".png") .. "," ..
+		"1=" .. core.formspec_escape(defaulttexturedir ..
+			(flagname and "server_flags_" .. flagname .. ".png" or "blank.png")) .. "," ..
 		"2=" .. core.formspec_escape(defaulttexturedir .. "server_ping_4.png") .. "," ..
 		"3=" .. core.formspec_escape(defaulttexturedir .. "server_ping_3.png") .. "," ..
 		"4=" .. core.formspec_escape(defaulttexturedir .. "server_ping_2.png") .. "," ..

--- a/builtin/mainmenu/tab_multiplayer.lua
+++ b/builtin/mainmenu/tab_multiplayer.lua
@@ -69,7 +69,7 @@ local function get_formspec(tabview, name, tabdata)
 	--favourites
 	retval = retval .. "tablecolumns[" ..
 		image_column(fgettext("Favorite"), "favorite") .. ";" ..
-		image_column(fgettext("Ping"), "") .. ",padding=0.25;" ..
+		image_column(fgettext("Ping")) .. ",padding=0.25;" ..
 		"color,span=3;" ..
 		"text,align=right;" ..                -- clients
 		"text,align=center,padding=0.25;" ..  -- "/"


### PR DESCRIPTION
Since local servers and local favorites have no ping value (these
are only provided by the server) we shouldn't load a broken
image filename.

Fixes #5238

```
Could not open file of texture: /usr/local/share/minetest/textures/base/pack/server_flags_.png
```