### PR TITLE
Voxelmanip: Do not emerge or blit to blocks over map gen limit

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3170,7 +3170,7 @@ void MMVManip::initialEmerge(v3s16 blockpos_min, v3s16 blockpos_max,
 		if(block_data_inexistent)
 		{
 
-			if (load_if_inexistent) {
+			if (load_if_inexistent && !blockpos_over_limit(p)) {
 				ServerMap *svrmap = (ServerMap *)m_map;
 				block = svrmap->emergeBlock(p, false);
 				if (block == NULL)


### PR DESCRIPTION
Placing a structure that extends into mapblocks that extend past
map_gen_limit causes a crash. For example a sapling growing at the
world edge which adds leaves beyond the edge, or placing a structure
using the lua voxelmanip, or placing a schematic or l-system tree.

Do not run the 'load_if_inexistent' block of code if the mapblock
is over limit, this also marks the mapblock with the flag
VMANIP_BLOCK_DATA_INEXIST which later prevents blitting back those
mapblocks.

This fix therefore uses existing functionality by having the same
effect as the 'load_if_inexistent' bool being false.
///////////////////////////////////////////////////////////

Addresses remaining issues of #4923 specifically https://github.com/minetest/minetest/issues/4923#issuecomment-277562783
Replaces #5184 
Tested by growing a sapling at world edge, and by adding a large cobble structure at world edge.
Mapblocks that are over-limit are simply not processed, meaning only the parts of the structures within the limit appear.

![screenshot_20170217_172330](https://cloud.githubusercontent.com/assets/3686677/23077009/abce09aa-f53a-11e6-9850-0abc09982712.png)

![screenshot_20170217_172452](https://cloud.githubusercontent.com/assets/3686677/23077016/b0991bbe-f53a-11e6-80e6-2f6f345055e5.png)