### PR TITLE
[Testing] Mesh updates: Add setting to limit updates per-frame

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -269,6 +269,8 @@ Client::Client(
 	m_cache_use_tangent_vertices = m_cache_enable_shaders && (
 		g_settings->getBool("enable_bumpmapping") ||
 		g_settings->getBool("enable_parallax_occlusion"));
+	m_cache_max_processed_meshes_per_frame =
+		g_settings->getU16("max_processed_meshes_per_frame");
 }
 
 void Client::Stop()
@@ -537,7 +539,8 @@ void Client::step(float dtime)
 	*/
 	{
 		int num_processed_meshes = 0;
-		while (!m_mesh_update_thread.m_queue_out.empty())
+		while (!m_mesh_update_thread.m_queue_out.empty() &&
+			num_processed_meshes < m_cache_max_processed_meshes_per_frame)
 		{
 			num_processed_meshes++;
 

--- a/src/client.h
+++ b/src/client.h
@@ -692,6 +692,8 @@ private:
 	bool m_cache_enable_shaders;
 	bool m_cache_use_tangent_vertices;
 
+	u16 m_cache_max_processed_meshes_per_frame;
+
 	DISABLE_CLASS_COPY(Client);
 };
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -54,6 +54,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("curl_file_download_timeout", "300000");
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
+	settings->setDefault("max_processed_meshes_per_frame", "5");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");


### PR DESCRIPTION
Not necessarily to be merged, more for testing to see if this helps with FPS jitter.
Try altering the value for meshes processed per frame.
Discussion http://irc.minetest.net/minetest-dev/2017-02-17#i_4814183 onwards.