### PR TITLE
Lua API Documentation Cleanups

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -199,8 +199,11 @@ Mods can be put in a subdirectory, if the parent directory, which otherwise
 should be a mod, contains a file named `modpack.txt`. This file shall be
 empty, except for lines starting with `#`, which are comments.
 
-Naming convention for registered textual names
-----------------------------------------------
+Registered identifiers / textual names
+--------------------------------------
+
+### Naming convention for registered textual names
+
 Registered names should generally be in this format:
 
     "modname:<whatever>" (<whatever> can have characters a-zA-Z0-9_)
@@ -208,38 +211,37 @@ Registered names should generally be in this format:
 This is to prevent conflicting names from corrupting maps and is
 enforced by the mod loader.
 
-### Example
-In the mod `experimental`, there is the ideal item/node/entity name `tnt`.
+For example, in the mod `experimental`, there is the ideal item/node/entity name `tnt`.
 So the name should be `experimental:tnt`.
 
-Enforcement can be overridden by prefixing the name with `:`. This can
-be used for overriding the registrations of some other mod.
+If you try to register a name which doesn't match `modname:<whatever>`, Minetest
+will throw an error. It is possible to disable this enforcement by using the
+override character `:`. This can be used for overriding the registrations of some
+other mod.
 
-Example: Any mod can redefine `experimental:tnt` by using the name
+For example: Any mod can redefine `experimental:tnt` by using the name
 
     :experimental:tnt
 
-when registering it.
+when registering it. Note that the first `:` is not part of the name, but is
+just used to disable the enforcement.
 (also that mod is required to have `experimental` as a dependency)
 
 The `:` prefix can also be used for maintaining backwards compatibility.
 
 ### Aliases
 Aliases can be added by using `minetest.register_alias(name, convert_to)` or
-`minetest.register_alias_force(name, convert_to).
+`minetest.register_alias_force(name, convert_to)`.
+Items called `name` will be converted to an item called `convert_to`.
 
-This will make Minetest to convert things called name to things called
-`convert_to`.
+If `name` is a valid registered item, then `minetest.register_alias` won't
+register the alias, whereas `minetest.register_alias_force` will
+delete `name` and register the alias. The force version should be avoided and
+not used unless required.
 
-The only difference between `minetest.register_alias` and
-`minetest.register_alias_force` is that if an item called `name` exists,
-`minetest.register_alias` will do nothing while
-`minetest.register_alias_force` will unregister it.
-
-This can be used for maintaining backwards compatibility.
-
-This can be also used for setting quick access names for things, e.g. if
-you have an item called `epiclylongmodname:stuff`, you could do
+Aliases can be used for maintaining backwards compatibility, or for setting
+quick access names for things with long names,
+e.g. if you have an item called `epiclylongmodname:stuff`, you could do
 
     minetest.register_alias("stuff", "epiclylongmodname:stuff")
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -294,154 +294,89 @@ on top of `cobble.png`.
 
 ### Advanced texture modifiers
 
-#### `[crack:<n>:<p>`
-* `<n>` = animation frame count
-* `<p>` = current animation frame
-
-Draw a step of the crack animation on the texture.
-
-Example:
-
-    default_cobble.png^[crack:10:1
-
-#### `[combine:<w>x<h>:<x1>,<y1>=<file1>:<x2>,<y2>=<file2>:...`
-* `<w>` = width
-* `<h>` = height
-* `<x>` = x position
-* `<y>` = y position
-* `<file>` = texture to combine
-
-Creates a texture of size `<w>` times `<h>` and blits the listed files to their
-specified coordinates.
-
-Example:
-
-    [combine:16x32:0,0=default_cobble.png:0,16=default_wood.png
-
-#### `[resize:<w>x<h>`
-Resizes the texture to the given dimensions.
-
-Example:
-
-    default_sandstone.png^[resize:16x16
-
-#### `[opacity:<r>`
-    Makes the base image transparent according to the given ratio.
-    r must be between 0 and 255.
-    0 means totally transparent.
-    255 means totally opaque.
-
-Example:
-
-    default_sandstone.png^[opacity:127
-
-#### `[invert:<mode>`
-Inverts the given channels of the base image.
-Mode may contain the characters "r", "g", "b", "a".
-Only the channels that are mentioned in the mode string will be inverted.
-
-Example:
-
-	default_apple.png^[invert:rgb
-
-#### `[brighten`
-Brightens the texture.
-
-Example:
-
-    tnt_tnt_side.png^[brighten
-
-#### `[noalpha`
-Makes the texture completely opaque.
-
-Example:
-
-    default_leaves.png^[noalpha
-
-#### `[makealpha:<r>,<g>,<b>`
-Convert one color to transparency.
-
-Example:
-
-    default_cobble.png^[makealpha:128,128,128
-
-#### `[transform<t>`
-* `<t>` = transformation(s) to apply
-
-Rotates and/or flips the image.
-
-`<t>` can be a number (between 0 and 7) or a transform name.
-Rotations are counter-clockwise.
-
-    0  I      identity
-    1  R90    rotate by 90 degrees
-    2  R180   rotate by 180 degrees
-    3  R270   rotate by 270 degrees
-    4  FX     flip X
-    5  FXR90  flip X then rotate by 90 degrees
-    6  FY     flip Y
-    7  FYR90  flip Y then rotate by 90 degrees
-
-Example:
-
-    default_stone.png^[transformFXR90
-
-#### `[inventorycube{<top>{<left>{<right>`
-Escaping does not apply here and `^` is replaced by `&` in texture names instead.
-
-Create an inventory cube texture using the side textures.
-
-Example:
-
-    [inventorycube{grass.png{dirt.png&grass_side.png{dirt.png&grass_side.png
-
-Creates an inventorycube with `grass.png`, `dirt.png^grass_side.png` and
-`dirt.png^grass_side.png` textures
-
-#### `[lowpart:<percent>:<file>`
-Blit the lower `<percent>`% part of `<file>` on the texture.
-
-Example:
-
-    base.png^[lowpart:25:overlay.png
-
-#### `[verticalframe:<t>:<n>`
-* `<t>` = animation frame count
-* `<n>` = current animation frame
-
-Crops the texture to a frame of a vertical animation.
-
-Example:
-
-    default_torch_animated.png^[verticalframe:16:8
-
-#### `[mask:<file>`
-Apply a mask to the base image.
-
-The mask is applied using binary AND.
-
-#### `[sheet:<w>x<h>:<x>,<y>`
-Retrieves a tile at position x,y from the base image
-which it assumes to be a tilesheet with dimensions w,h.
-
-
-#### `[colorize:<color>:<ratio>`
-Colorize the textures with the given color.
-`<color>` is specified as a `ColorString`.
-`<ratio>` is an int ranging from 0 to 255 or the word "`alpha`".  If
-it is an int, then it specifies how far to interpolate between the
-colors where 0 is only the texture color and 255 is only `<color>`. If
-omitted, the alpha of `<color>` will be used as the ratio.  If it is
-the word "`alpha`", then each texture pixel will contain the RGB of
-`<color>` and the alpha of `<color>` multiplied by the alpha of the
-texture pixel.
-
-#### `[multiply:<color>`
-Multiplies texture colors with the given color.
-`<color>` is specified as a `ColorString`.
-Result is more like what you'd expect if you put a color on top of another
-color. Meaning white surfaces get a lot of your new color while black parts don't
-change very much.
+* `[crack:<n>:<p>`
+    * Draw a step of the crack animation on the texture
+    * `<n>` = animation frame count
+    * `<p>` = current animation frame
+    * Example: `default_cobble.png^[crack:10:1`
+* `[combine:<w>x<h>:<x1>,<y1>=<file1>:<x2>,<y2>=<file2>:...`
+    * Creates a texture of size `<w>` times `<h>` and blits the listed files
+      to their specified coordinates.
+    * `<w>` = width
+    * `<h>` = height
+    * `<x>` = x position
+    * `<y>` = y position
+    * `<file>` = texture to combine
+    * Example: `[combine:16x32:0,0=default_cobble.png:0,16=default_wood.png`
+* `[resize:<w>x<h>`
+    * Resizes the texture to the given dimensions.
+    * Example: `default_sandstone.png^[resize:16x16`
+* `[opacity:<ratio>`
+    * Makes the base image transparent according to the given ratio.
+    * `ratio` - between 0 and 255, where 0 is transparent and 255 is opaque
+    * Example: `default_sandstone.png^[opacity:127`
+* `[invert:<mode>`
+    * Inverts the given channels of the base image.
+    * Mode may contain the characters "r", "g", "b", "a".
+    * Only the channels that are mentioned in the mode string will be inverted.
+    * Example: `default_apple.png^[invert:rgb`
+* `[brighten`
+    * Brightens the texture.
+    * Example: `tnt_tnt_side.png^[brighten`
+* `[noalpha`
+    * Makes the texture completely opaque.
+    * Example: `default_leaves.png^[noalpha`
+* `[makealpha:<r>,<g>,<b>`
+    * Convert one color to transparency.
+    * Example: `default_cobble.png^[makealpha:128,128,128`
+* `[transform<t>`
+    * Rotates and/or flips the image.
+    * `<t>` = transformation(s) to apply
+      `<t>` can be a number (between 0 and 7) or a transform name.
+        * Rotations are counter-clockwise.
+        * 0  I      identity
+        * 1  R90    rotate by 90 degrees
+        * 2  R180   rotate by 180 degrees
+        * 3  R270   rotate by 270 degrees
+        * 4  FX     flip X
+        * 5  FXR90  flip X then rotate by 90 degrees
+        * 6  FY     flip Y
+        * 7  FYR90  flip Y then rotate by 90 degrees
+    * Example: `default_stone.png^[transformFXR90`
+* `[inventorycube{<top>{<left>{<right>`
+    * Create an inventory cube texture using the side textures.
+    * Escaping does not apply here and `^` is replaced by `&` in texture names
+      instead.
+    * Example: `[inventorycube{grass.png{dirt.png&grass_side.png{dirt.png&grass_side.png`
+      Creates an inventorycube with `grass.png`, `dirt.png^grass_side.png` and
+      `dirt.png^grass_side.png` textures
+* `[lowpart:<percent>:<file>`
+    * Blit the lower `<percent>`% part of `<file>` on the texture.
+    * Example: `base.png^[lowpart:25:overlay.png`
+* `[verticalframe:<t>:<n>`
+    * Crops the texture to a frame of a vertical animation.
+    * `<t>` = animation frame count
+    * `<n>` = current animation frame
+    * Example: `default_torch_animated.png^[verticalframe:16:8`
+* `[mask:<file>`
+    * Apply a mask to the base image.
+    * The mask is applied using binary AND.
+* `[colorize:<color>:<ratio>`
+    * Colorize the textures with the given color.
+    * `<color>` is specified as a `ColorString`.
+    * `<ratio>` is an int ranging from 0 to 255 or the word "`alpha`".
+        * If it is an int, then it specifies how far to interpolate between the
+          colors where 0 is only the texture color and 255 is only `<color>`.
+        * If it is the word "`alpha`", then each texture pixel will contain the
+          RGB of `<color>` and the alpha of `<color>` multiplied by the alpha
+          of the texture pixel.
+        * If omitted, the alpha of `<color>` will be used as the ratio.
+* `[multiply:<color>`
+    * Multiplies texture colors with the given color.
+    * `<color>` is specified as a `ColorString`.
+    * Result is more like what you'd expect if you put a color on top of another
+      color. Meaning white surfaces get a lot of your new color while black parts don't
+      change very much.
 
 Sounds
 ------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -23,53 +23,66 @@ Programming in Lua
 If you have any difficulty in understanding this, please read
 [Programming in Lua](http://www.lua.org/pil/).
 
-Startup
--------
-Mods are loaded during server startup from the mod load paths by running
-the `init.lua` scripts in a shared environment.
-
 Paths
 -----
-* `RUN_IN_PLACE=1` (Windows release, local build)
+* `$HOME`: user home directory, eg: `/home/username/`
+* `RUN_IN_PLACE=1`: (Windows release, local build)
     *  `$path_user`:
         * Linux: `<build directory>`
         * Windows: `<build directory>`
     * `$path_share`
         * Linux: `<build directory>`
         * Windows:  `<build directory>`
-* `RUN_IN_PLACE=0`: (Linux release)
+* `RUN_IN_PLACE=0`: (Linux only currently)
     * `$path_share`
         * Linux: `/usr/share/minetest`
-        * Windows: `<install directory>/minetest-0.4.x`
     * `$path_user`:
-        * Linux: `$HOME/.minetest`
-        * Windows: `C:/users/<user>/AppData/minetest` (maybe)
+        * Linux: `$HOME/.minetest` (note: this is a hidden dir)
 
 Games
 -----
-Games are looked up from:
+A game is a collection of mods.
 
-* `$path_share/games/gameid/`
-* `$path_user/games/gameid/`
+### Game load paths
 
-where `gameid` is unique to each game.
+Games are discovered in:
 
+* `$path_share/games/`
+* `$path_user/games/`
+
+### Game directory structure
+
+    games
+    |-- gameid
+    |   |-- game.conf
+    |   |-- minetest.conf
+    |   |-- mods
+    |   |   |-- mod1
+    |   |   `-- <more mods>
+    |   `-- menu
+    |       |-- overlay.png
+    |       |-- background.png
+    |       |-- footer.png
+    |       `-- header.png
+    `-- another
+
+#### game.conf
 The game directory contains the file `game.conf`, which contains these fields:
 
     name = <Human-readable full name of the game>
 
 e.g.
 
-    name = Minetest
+    name = Minetest Game
 
+#### minetest.conf
 The game directory can contain the file minetest.conf, which will be used
 to set default settings when running the particular game.
 It can also contain a settingtypes.txt in the same format as the one in builtin.
 This settingtypes.txt will be parsed by the menu and the settings will be displayed
 in the "Games" category in the settings tab.
 
-### Menu images
-
+#### Menu images
 Games can provide custom main menu images. They are put inside a `menu` directory
 inside the game directory.
 
@@ -79,9 +92,15 @@ If you want to specify multiple images for one identifier, add additional images
 like `$identifier.$n.png`, with an ascending number $n starting with 1, and a random
 image will be chosen from the provided ones.
 
+Mods
+----
 
-Mod load path
--------------
+The `init.lua` of all enabled mods are executed during server start up.
+The mods share an environment so any globals declared will be accessible from
+other mods.
+
+### Mod load path
+
 Generic:
 
 * `$path_share/games/gameid/mods/`
@@ -102,8 +121,8 @@ On an installed version on Linux:
 * `$HOME/.minetest/mods/` (User-installed mods)
 * `$HOME/.minetest/worlds/worldname/worldmods`
 
-Mod load path for world-specific games
---------------------------------------
+### Mod load path for world-specific games
+
 It is possible to include a game in a world; in this case, no mods or
 games are loaded or checked from anywhere else.
 
@@ -117,14 +136,7 @@ Mods should be then be placed in:
 
     $world/game/mods/
 
-Modpack support
-----------------
-Mods can be put in a subdirectory, if the parent directory, which otherwise
-should be a mod, contains a file named `modpack.txt`. This file shall be
-empty, except for lines starting with `#`, which are comments.
-
-Mod directory structure
-------------------------
+### Mod directory structure
 
     mods
     |-- modname
@@ -140,14 +152,13 @@ Mod directory structure
     |   |-- sounds
     |   |-- media
     |   `-- <custom data>
-    `-- another
+    `-- another`
 
-
-### modname
+#### modname
 The location of this directory can be fetched by using
 `minetest.get_modpath(modname)`.
 
-### `depends.txt`
+#### depends.txt
 List of mods that have to be loaded before loading this mod.
 
 A single line contains a single modname.
@@ -156,18 +167,18 @@ Optional dependencies can be defined by appending a question mark
 to a single modname. Their meaning is that if the specified mod
 is missing, that does not prevent this mod from being loaded.
 
-### `screenshot.png`
+#### screenshot.png
 A screenshot shown in the mod manager within the main menu. It should
 have an aspect ratio of 3:2 and a minimum size of 300×200 pixels.
 
-### `description.txt`
+#### description.txt
 A File containing description to be shown within mainmenu.
 
-### `settingtypes.txt`
+#### settingtypes.txt
 A file in the same format as the one in builtin. It will be parsed by the
 settings menu and the settings will be displayed in the "Mods" category.
 
-### `init.lua`
+#### init.lua
 The main Lua script. Running this script should register everything it
 wants to register. Subsequent execution depends on minetest calling the
 registered callbacks.
@@ -175,12 +186,18 @@ registered callbacks.
 `minetest.setting_get(name)` and `minetest.setting_getbool(name)` can be used
 to read custom or existing settings at load time, if necessary.
 
-### `models`
+#### models
 Models for entities or meshnodes.
 
-### `textures`, `sounds`, `media`
+#### textures, sounds, media
 Media files (textures, sounds, whatever) that will be transferred to the
 client and will be available for use by the mod.
+
+Modpacks
+--------
+Mods can be put in a subdirectory, if the parent directory, which otherwise
+should be a mod, contains a file named `modpack.txt`. This file shall be
+empty, except for lines starting with `#`, which are comments.
 
 Naming convention for registered textual names
 ----------------------------------------------


### PR DESCRIPTION
The aim of the PR is to increase the readability of lua_api.txt, and to place everything into nicer sections

- [x] Add game dir structure docs
- [x] Put all mod and game info into their relevant sections
- [x] Remove incorrect mod location info
- [x] For registered id section, make main heading match contents (ie: aliases makes sense in a reg.id. section, but not in a naming conventions for reg.id. section)
- [x] Use list rather than headings for texture modifiers - increases readability imo, and is also more consistent
- [ ] Put simple sound spec into definitions of simple things
- [ ] Clean up nodes, paramtype, and draw type sections