### PR TITLE
Extend is_yes()

### DIFF
--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -147,6 +147,8 @@ void TestUtilities::testIsYes()
 	UASSERT(is_yes("0") == false);
 	UASSERT(is_yes("1") == true);
 	UASSERT(is_yes("2") == true);
+	UASSERT(is_yes("on") == true);
+	UASSERT(is_yes("off") == false);
 }
 
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -272,7 +272,7 @@ inline bool is_yes(const std::string &str)
 {
 	std::string s2 = lowercase(trim(str));
 
-	return s2 == "y" || s2 == "yes" || s2 == "true" || atoi(s2.c_str()) != 0;
+	return s2 == "y" || s2 == "yes" || s2 == "true" || s2 == "on" || atoi(s2.c_str()) != 0;
 }
 
 


### PR DESCRIPTION
This is used by `Settings::getBool` so it would make sense for it to return true when passed on.