### PR TITLE
Fix wrong meta key in item meta on ItemStack construction

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -827,9 +827,12 @@ ItemStack read_item(lua_State* L, int index,Server* srv)
 
 		ItemStack istack(name, count, wear, idef);
 
-		lua_getfield(L, index, "metadata");
+		// BACKWARDS COMPATIBLITY
+		std::string value = getstringfield_default(L, index, "metadata", "");
+		istack.metadata.setString("", value);
 
-		// Support old metadata format by checking type
+		// Get meta
+		lua_getfield(L, index, "meta");
 		int fieldstable = lua_gettop(L);
 		if (lua_istable(L, fieldstable)) {
 			lua_pushnil(L);
@@ -839,26 +842,7 @@ ItemStack read_item(lua_State* L, int index,Server* srv)
 				size_t value_len;
 				const char *value_cs = lua_tolstring(L, -1, &value_len);
 				std::string value(value_cs, value_len);
-				istack.metadata.setString(name, value);
-				lua_pop(L, 1); // removes value, keeps key for next iteration
-			}
-		} else {
-			// BACKWARDS COMPATIBLITY
-			std::string value = getstringfield_default(L, index, "metadata", "");
-			istack.metadata.setString("", value);
-		}
-
-		lua_getfield(L, index, "meta");
-		fieldstable = lua_gettop(L);
-		if (lua_istable(L, fieldstable)) {
-			lua_pushnil(L);
-			while (lua_next(L, fieldstable) != 0) {
-				// key at index -2 and value at index -1
-				std::string key = lua_tostring(L, -2);
-				size_t value_len;
-				const char *value_cs = lua_tolstring(L, -1, &value_len);
-				std::string value(value_cs, value_len);
-				istack.metadata.setString(name, value);
+				istack.metadata.setString(key, value);
 				lua_pop(L, 1); // removes value, keeps key for next iteration
 			}
 		}


### PR DESCRIPTION
Feel free to suggest a better commit name.

The issue is `name` instead of `key`

```cpp
istack.metadata.setString(name, value);
// should be
istack.metadata.setString(key, value);
```