### PR TITLE
FormSpec: Add position and anchor elements

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1522,6 +1522,16 @@ examples.
 * `fixed_size`: `true`/`false` (optional)
 * deprecated: `invsize[<W>,<H>;]`
 
+#### `position[<X>,<Y>]`
+* Define the position of the formspec
+* A value between 0.0 and 1.0 represents a position inside the screen
+* The default value is the center of the screen (0.5, 0.5)
+
+#### `anchor[<X>,<Y>]`
+* Define the anchor of the formspec
+* A value between 0.0 and 1.0 represents an anchor inside the formspec
+* The default value is the center of the formspec (0.5, 0.5)
+
 #### `container[<X>,<Y>]`
 * Start of a container block, moves all physical elements in the container by (X, Y)
 * Must have matching container_end

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -447,6 +447,8 @@ private:
 		bool explicit_size;
 		v2f invsize;
 		v2s32 size;
+		v2f32 offset;
+		v2f32 anchor;
 		core::rect<s32> rect;
 		v2s32 basepos;
 		v2u32 screensize;
@@ -502,6 +504,10 @@ private:
 	bool parseVersionDirect(std::string data);
 	bool parseSizeDirect(parserData* data, std::string element);
 	void parseScrollBar(parserData* data, std::string element);
+	bool parsePositionDirect(parserData *data, const std::string &element);
+	void parsePosition(parserData *data, const std::string &element);
+	bool parseAnchorDirect(parserData *data, const std::string &element);
+	void parseAnchor(parserData *data, const std::string &element);
 
 	void tryClose();
 


### PR DESCRIPTION
**Description :** 
- `position` element can be used after `size` element
- `anchor` element can be used after `position` element or `size` element (if `position` element is not used)

**Usage :**
- `position` element sets the position of the Form Spec on the screen
- `position[0,5, 0.5]` sets the position on the center of the screen (the default value if not used)
- `position[0,0, 0.0]` sets the position to the Top Left of the screen
- `position[1,0, 0.0]` sets the position to the Top Right of the screen
- `position[0,0, 1.0]` sets the position to the Bottom Left of the screen
- `position[1,0, 1.0]` sets the position to the Bottom Right of the screen

- `anchor` element sets the anchor of the Form Spec
- `anchor[0,5, 0.5]` sets the anchor in the center of the Form Spec (the default value if not used)
- `anchor[0,0, 0.0]` sets the anchor in the Top Left of the Form Spec
- `anchor[1,0, 0.0]` sets the anchor in the Top Right of the Form Spec
- `anchor[0,0, 1.0]` sets the anchor in the Bottom Left of the Form Spec
- `anchor[1,0, 1.0]` sets the anchor in the Bottom Right of the Form Spec

**Examples :**
- `size[6,4]position[0.5,0.5]anchor[0.5,0.5]` set the position of the Form Spec on the center of the screen
- `size[6,4]position[1.0,1.0]anchor[1.0,1.0]` set the position of the Form Spec on the Bottom Right of the screen