### PR TITLE
Add damage from falling nodes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -904,6 +904,9 @@ enable_damage (Damage) bool false
 #    Enable creative mode for new created maps.
 creative_mode (Creative) bool false
 
+#    Enable falling node damage
+node_fall_hurt (Falling node damage) bool true
+
 #    A chosen map seed for a new map, leave empty for random.
 #    Will be overridden when creating a new world in the main menu.
 fixed_map_seed (Fixed map seed) string

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1460,6 +1460,7 @@ Another example: Make red wool from white wool and red dye:
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `bouncy`: value is bounce speed in percent
 * `falling_node`: if there is no walkable block under the node it will fall
+* `falling_node_damage`: number of hp points inflicted on player or entity
 * `attached_node`: if the node under it is not a walkable block the node will be
   dropped as an item. If the node is wallmounted the wallmounted direction is
   checked.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1095,6 +1095,10 @@
 #    type: bool
 # creative_mode = false
 
+#    Enable falling nodes to damage player/entity below
+#    type: bool
+# node_fall_hurt = true
+
 #    A chosen map seed for a new map, leave empty for random.
 #    Will be overridden when creating a new world in the main menu.
 #    type: string


### PR DESCRIPTION
This pull has falling nodes hurt players and entities caught below them when the {falling_node_damage} group has a value higher than zero.