### PR TITLE
Show itemstring as item tooltip if item description is missing

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2309,6 +2309,9 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 						utf8_to_wide(item.getDefinition(m_client->idef()).description);
 				else
 					tooltip_text = utf8_to_wide(desc);
+				// Show itemstring as fallback for easier debugging
+				if (!item.name.empty() && tooltip_text.empty())
+					tooltip_text = utf8_to_wide(item.name);
 			}
 			if (tooltip_text != L"") {
 				std::vector<std::wstring> tt_rows = str_split(tooltip_text, L'\n');


### PR DESCRIPTION
Currently, if you hover an item in your player inventory which happens to have no `description` set, or it is an empty string, nothing is displayed. This is VERY irritating and also makes it a bit hard to debug.

This PR will add a simple fallback: If `description` is empty, the itemstring is instead used as the tooltip. 
Still not pretty, but at least it's debuggable. It also make it easier to distinguish between obscure items gotten with `/giveme`.

**Example:**
Do `/giveme farming:wheat_1`, `/giveme farming:wheat_2`, etc. and hover these items in your inventory.
Currently: Hovering these items does not display anything, you don't know which is which.
After this PR: Hovering this item displays “farming:wheat_1”, “farming:wheat_2”, etc.