### PR TITLE
Fix multiple death messages (#3565)

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -784,6 +784,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_peer_id(peer_id_),
 	m_inventory(NULL),
 	m_damage(0),
+	m_dead(false),
 	m_last_good_position(0,0,0),
 	m_time_from_last_teleport(0),
 	m_time_from_last_punch(0),
@@ -1088,6 +1089,10 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);
 	}
+}
+
+void PlayerSAO::setDeadStatus(const bool dead) {
+	m_dead = dead;
 }
 
 void PlayerSAO::setBasePosition(const v3f &position)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -784,7 +784,6 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_peer_id(peer_id_),
 	m_inventory(NULL),
 	m_damage(0),
-	m_dead(false),
 	m_last_good_position(0,0,0),
 	m_time_from_last_teleport(0),
 	m_time_from_last_punch(0),
@@ -948,8 +947,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		MapNode n = m_env->getMap().getNodeNoEx(p);
 		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
 		// If node generates drown
-		if (c.drowning > 0) {
-			if (m_hp > 0 && m_breath > 0)
+		if (c.drowning > 0 && m_hp > 0) {
+			if (m_breath > 0)
 				setBreath(m_breath - 1);
 
 			// No more breath, damage player
@@ -1089,11 +1088,6 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);
 	}
-}
-
-void PlayerSAO::setDeadStatus(bool dead)
-{
-	m_dead = dead;
 }
 
 void PlayerSAO::setBasePosition(const v3f &position)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1091,7 +1091,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	}
 }
 
-void PlayerSAO::setDeadStatus(const bool dead) {
+void PlayerSAO::setDeadStatus(bool dead)
+{
 	m_dead = dead;
 }
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -244,6 +244,8 @@ public:
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
+	void setDeadStatus(const bool dead);
+	bool getDeadStatus() const { return m_dead; }
 
 	/*
 		Inventory interface
@@ -361,7 +363,8 @@ private:
 	u16 m_peer_id;
 	Inventory *m_inventory;
 	s16 m_damage;
-
+	bool m_dead;
+	
 	// Cheat prevention
 	LagPool m_dig_pool;
 	LagPool m_move_pool;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -244,9 +244,6 @@ public:
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
-	// m_dead is set to true when the deathscreen is displayed to the client.
-	void setDeadStatus(bool dead);
-	bool getDeadStatus() const { return m_dead; }
 
 	/*
 		Inventory interface
@@ -364,7 +361,6 @@ private:
 	u16 m_peer_id;
 	Inventory *m_inventory;
 	s16 m_damage;
-	bool m_dead;
 
 	// Cheat prevention
 	LagPool m_dig_pool;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -244,7 +244,8 @@ public:
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
-	void setDeadStatus(const bool dead);
+	// m_dead is set to true when the deathscreen is displayed to the client.
+	void setDeadStatus(bool dead);
 	bool getDeadStatus() const { return m_dead; }
 
 	/*
@@ -364,7 +365,7 @@ private:
 	Inventory *m_inventory;
 	s16 m_damage;
 	bool m_dead;
-	
+
 	// Cheat prevention
 	LagPool m_dig_pool;
 	LagPool m_move_pool;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1127,7 +1127,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage")) {
+	if (g_settings->getBool("enable_damage") && !playersao->getDeadStatus()) {
 		actionstream << player->getName() << " damaged by "
 				<< (int)damage << " hp at " << PP(playersao->getBasePosition() / BS)
 				<< std::endl;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1127,7 +1127,14 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage") && playersao->getHP() > 0) {
+	if (g_settings->getBool("enable_damage")) {
+		if (playerSAO->isDead()) {
+			verbosestream << "Server::ProcessData(): Info: "
+				"Ignoring damage as player " << player->getName()
+				<< " is already dead." << std::endl;
+			return;
+		}
+
 		actionstream << player->getName() << " damaged by "
 				<< (int)damage << " hp at " << PP(playersao->getBasePosition() / BS)
 				<< std::endl;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1127,7 +1127,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage") && !playersao->getDeadStatus()) {
+	if (g_settings->getBool("enable_damage") && playersao->getHP() > 0) {
 		actionstream << player->getName() << " damaged by "
 				<< (int)damage << " hp at " << PP(playersao->getBasePosition() / BS)
 				<< std::endl;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1119,15 +1119,14 @@ PlayerSAO* Server::StageTwoClientInit(u16 peer_id)
 	// Send inventory
 	SendInventory(playersao);
 
-	// Send HP
-	SendPlayerHPOrDie(playersao);
+	// Send HP or death screen
+	if (playersao->isDead())
+		SendDeathscreen(peer_id, false, v3f(0,0,0));
+	else
+		SendPlayerHPOrDie(playersao);
 
 	// Send Breath
 	SendPlayerBreath(playersao);
-
-	// Show death screen if necessary
-	if (playersao->isDead())
-		SendDeathscreen(peer_id, false, v3f(0,0,0));
 
 	// Note things in chat if not in simple singleplayer mode
 	if (!m_simple_singleplayer_mode && g_settings->getBool("show_statusline_on_connect")) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1503,9 +1503,9 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 		return;
 
 	u16 peer_id   = playersao->getPeerID();
-	bool is_alive_or_died = playersao->getHP() > 0 || playersao->getDeadStatus();
+	bool is_alive = playersao->getHP() > 0;
 
-	if (is_alive_or_died)
+	if (is_alive)
 		SendPlayerHP(peer_id);
 	else
 		DiePlayer(peer_id);
@@ -2575,8 +2575,7 @@ void Server::DiePlayer(u16 peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " dies" << std::endl;
 
-	playersao->setHP(0); // NOTE: might not be necessary
-	playersao->setDeadStatus(true);
+	playersao->setHP(0);
 
 	// Trigger scripted stuff
 	m_script->on_dieplayer(playersao);
@@ -2596,7 +2595,6 @@ void Server::RespawnPlayer(u16 peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " respawns" << std::endl;
 
-	playersao->setDeadStatus(false);
 	playersao->setHP(PLAYER_MAX_HP);
 	playersao->setBreath(PLAYER_MAX_BREATH);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1504,9 +1504,9 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 		return;
 
 	u16 peer_id   = playersao->getPeerID();
-	bool is_alive = playersao->getHP() > 0;
+	bool is_alive_or_died = playersao->getHP() > 0 || playersao->getDeadStatus();
 
-	if (is_alive)
+	if (is_alive_or_died)
 		SendPlayerHP(peer_id);
 	else
 		DiePlayer(peer_id);
@@ -2576,7 +2576,8 @@ void Server::DiePlayer(u16 peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " dies" << std::endl;
 
-	playersao->setHP(0);
+	playersao->setHP(0); // NOTE: might not be necessary
+	playersao->setDeadStatus(true);
 
 	// Trigger scripted stuff
 	m_script->on_dieplayer(playersao);
@@ -2596,6 +2597,7 @@ void Server::RespawnPlayer(u16 peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " respawns" << std::endl;
 
+	playersao->setDeadStatus(false);
 	playersao->setHP(PLAYER_MAX_HP);
 	playersao->setBreath(PLAYER_MAX_BREATH);
 


### PR DESCRIPTION
Fixes #3565, problem was to do with the fact that there was nothing in place to know whether or not the player was actually dead, so dying happened every damage update.