### PR TITLE
Formspec: Add options to set background color and opacity

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -486,6 +486,12 @@ console_color (Console color) string (0,0,0)
 #    In-game chat console background alpha (opaqueness, between 0 and 255).
 console_alpha (Console alpha) int 200 0 255
 
+#    Formspec full-screen background opacity (between 0 and 255).
+formspec_fullscreen_bg_opacity (Formspec Full-Screen Background Opacity) int 140 0 255
+
+#    Formspec full-screen background color (R,G,B).
+formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0,0)
+
 #    Selection box border color (R,G,B).
 selectionbox_color (Selection box color) string (0,0,0)
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -560,6 +560,14 @@
 #    type: int min: 0 max: 255
 # console_alpha = 200
 
+#    Formspec full-screen background opacity (between 0 and 255).
+#    type: int
+# formspec_fullscreen_bg_opacity = 140
+
+#    Formspec full-screen background color (R,G,B).
+#    type: string
+# formspec_fullscreen_bg_color = (0,0,0)
+
 #    Selection box border color (R,G,B).
 #    type: string
 # selectionbox_color = (0,0,0)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -141,6 +141,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("console_height", "1.0");
 	settings->setDefault("console_color", "(0,0,0)");
 	settings->setDefault("console_alpha", "200");
+	settings->setDefault("formspec_fullscreen_bg_color", "(0,0,0)");
+	settings->setDefault("formspec_fullscreen_bg_opacity", "140");
 	settings->setDefault("selectionbox_color", "(0,0,0)");
 	settings->setDefault("selectionbox_width", "2");
 	settings->setDefault("node_highlighting", "box");

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -78,6 +78,11 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 	return font->getDimension(L"Ay").Height + font->getKerningHeight();
 }
 
+inline u32 clamp_u8(s32 value)
+{
+	return (u32) MYMIN(MYMAX(value, 0), 255);
+}
+
 GUIFormSpecMenu::GUIFormSpecMenu(irr::IrrlichtDevice* dev,
 		JoystickController *joystick,
 		gui::IGUIElement* parent, s32 id, IMenuManager *menumgr,
@@ -2390,11 +2395,20 @@ void GUIFormSpecMenu::drawMenu()
 	video::IVideoDriver* driver = Environment->getVideoDriver();
 
 	v2u32 screenSize = driver->getScreenSize();
-	core::rect<s32> allbg(0, 0, screenSize.X ,	screenSize.Y);
-	if (m_bgfullscreen)
+	core::rect<s32> allbg(0, 0, screenSize.X, screenSize.Y);
+
+	if (m_bgfullscreen) {
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
+		m_bgcolor = video::SColor(
+			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
 		driver->draw2DRectangle(m_bgcolor, allbg, &allbg);
-	else
+	} else {
 		driver->draw2DRectangle(m_bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+	}
 
 	m_tooltip_element->setVisible(false);
 


### PR DESCRIPTION
By default, when a formspec shows up, the fullscreen background is semi-opaque black. This is problematic when your formspec is set at e.g. the bottom-right of your screen to do not hinder the view of the scene you're seeing.

This PR allows to change the color and the opacity of the background when a formspec shows up. You can even hide the background by setting `0` for the opacity.

This PR is particularly useful along with https://github.com/minetest/minetest/pull/5284

On a small note, this patch is high-priority for my professional workflow (as well as the aforementioned PR). 