### PR TITLE
Declarative block sending optimization setting.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -857,12 +857,14 @@ liquid_queue_purge_time (Liquid queue purge time) int 0
 #    Liquid update interval in seconds.
 liquid_update (Liquid update tick) float 1.0
 
-#    At this distance the server will aggressively optimize which blocks are sent to clients.
-#    Small values potentially improve performance a lot, at the expense of visible rendering glitches.
-#    (some blocks will not be rendered under water and in caves, as well as sometimes on land)
-#    Setting this to a value greater than max_block_send_distance disables this optimization.
-#    Stated in mapblocks (16 nodes)
-block_send_optimize_distance (block send optimize distance) int 4 2
+#    How agressively the server will optimize which blocks are sent to clients.
+#    The more aggressive the optimization the better the performance, at the expense
+#    of rendering glitches due to missing blocks.
+#    0 = no optimization
+#    1-9 = medium optimization
+#    10 = aggressive optimization
+#    Default: 10
+block_send_optimization (block send optimization) int 10 0 10
 
 [*Mapgen]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -864,6 +864,11 @@ liquid_update (Liquid update tick) float 1.0
 #    Stated in mapblocks (16 nodes)
 block_send_optimize_distance (block send optimize distance) int 4 2
 
+#    Optimize sending under ground blocks to the client.
+#    This significantly reduces the number of blocks sent, but
+#    may lead to rendering glitches around the ocean floor and in caves.
+block_send_optimize_underground (Optimize sending underground blocks) bool true
+
 [*Mapgen]
 
 #    Name of map generator to be used when creating a new world.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -857,14 +857,12 @@ liquid_queue_purge_time (Liquid queue purge time) int 0
 #    Liquid update interval in seconds.
 liquid_update (Liquid update tick) float 1.0
 
-#    How agressively the server will optimize which blocks are sent to clients.
-#    The more aggressive the optimization the better the performance, at the expense
-#    of rendering glitches due to missing blocks.
-#    0 = no optimization
-#    1-9 = medium optimization
-#    10 = aggressive optimization
-#    Default: 10
-block_send_optimization (block send optimization) int 10 0 10
+#    At this distance the server will aggressively optimize which blocks are sent to clients.
+#    Small values potentially improve performance a lot, at the expense of visible rendering glitches.
+#    (some blocks will not be rendered under water and in caves, as well as sometimes on land)
+#    Setting this to a value greater than max_block_send_distance disables this optimization.
+#    Stated in mapblocks (16 nodes)
+block_send_optimize_distance (block send optimize distance) int 4 2
 
 [*Mapgen]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -864,9 +864,9 @@ liquid_update (Liquid update tick) float 1.0
 #    Stated in mapblocks (16 nodes)
 block_send_optimize_distance (block send optimize distance) int 4 2
 
-#    Optimize sending under ground blocks to the client.
-#    This significantly reduces the number of blocks sent, but
-#    may lead to rendering glitches around the ocean floor and in caves.
+#    Optimize sending under ground (below the water line) blocks to the client.
+#    This reduces the number of blocks sent, but may lead to rendering glitches
+#    around the ocean floor and in caves beyond the block send optimize distance.
 block_send_optimize_underground (Optimize sending underground blocks) bool true
 
 [*Mapgen]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1048,13 +1048,13 @@
 #    type: float
 # liquid_update = 1.0
 
-#    How agressively the server will optimize which blocks are sent to clients.
-#    The more aggressive the optimization the better the performance, at the expense
-#    of rendering glitches due to missing blocks.
-#    0 = no optimization
-#    1-9 = medium optimization
-#    10 = aggressive optimization
-# block_send_optimization = 10
+#    At this distance the server will aggressively optimize which blocks are sent to clients.
+#    Small values potentially improve performance a lot, at the expense of visible rendering glitches.
+#    (some blocks will not be rendered under water and in caves, as well as sometimes on land)
+#    Setting this to a value greater than max_block_send_distance disables this optimization.
+#    Stated in mapblocks (16 nodes)
+#    type: int min: 2
+# block_send_optimize_distance = 4
 
 ## Mapgen
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1048,13 +1048,13 @@
 #    type: float
 # liquid_update = 1.0
 
-#    At this distance the server will aggressively optimize which blocks are sent to clients.
-#    Small values potentially improve performance a lot, at the expense of visible rendering glitches.
-#    (some blocks will not be rendered under water and in caves, as well as sometimes on land)
-#    Setting this to a value greater than max_block_send_distance disables this optimization.
-#    Stated in mapblocks (16 nodes)
-#    type: int min: 2
-# block_send_optimize_distance = 4
+#    How agressively the server will optimize which blocks are sent to clients.
+#    The more aggressive the optimization the better the performance, at the expense
+#    of rendering glitches due to missing blocks.
+#    0 = no optimization
+#    1-9 = medium optimization
+#    10 = aggressive optimization
+# block_send_optimization = 10
 
 ## Mapgen
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1057,8 +1057,8 @@
 # block_send_optimize_distance = 4
 
 #    Optimize sending under ground (below the water line) blocks to the client.
-#    This significantly reduces the number of blocks sent, but
-#    may lead to rendering glitches around the ocean floor and in caves.
+#    This reduces the number of blocks sent, but may lead to rendering glitches
+#    around the ocean floor and in caves beyond the block send optimize distance.
 block_send_optimize_underground = true
 
 ## Mapgen

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1056,6 +1056,11 @@
 #    type: int min: 2
 # block_send_optimize_distance = 4
 
+#    Optimize sending under ground (below the water line) blocks to the client.
+#    This significantly reduces the number of blocks sent, but
+#    may lead to rendering glitches around the ocean floor and in caves.
+block_send_optimize_underground = true
+
 ## Mapgen
 
 #    Name of map generator to be used when creating a new world.

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -180,7 +180,7 @@ void RemoteClient::GetNextBlocks (
 	if (camera_fov <= 0) camera_fov = (72.0*M_PI/180) * 4./3.;
 
 	const s16 full_d_max = MYMIN(g_settings->getS16("max_block_send_distance"), wanted_range);
-	const s16 d_opt = g_settings->getS16("block_send_optimization");
+	const s16 d_opt = MYMIN(g_settings->getS16("block_send_optimize_distance"), wanted_range);
 	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 	//infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
 
@@ -287,20 +287,16 @@ void RemoteClient::GetNextBlocks (
 					block_is_invalid = true;
 
 				/*
-					If send optimization was requests and
-					if block is not close, don't send it unless it is near
+					If block is not close, don't send it unless it is near
 					ground level.
 
 					Block is near ground level if night-time mesh
 					differs from day-time mesh.
-
-					For medium optimization only optimize for blocks above ground.
 				*/
-				if((d_opt > 0 && d >= 4) &&
-					(d_opt > 9 || !block->getIsUnderground()) &&
-					!block->getDayNightDiff())
-			        {
-					continue;
+				if(d >= d_opt)
+				{
+					if(block->getDayNightDiff() == false)
+						continue;
 				}
 			}
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -182,6 +182,7 @@ void RemoteClient::GetNextBlocks (
 	const s16 full_d_max = MYMIN(g_settings->getS16("max_block_send_distance"), wanted_range);
 	const s16 d_opt = MYMIN(g_settings->getS16("block_send_optimize_distance"), wanted_range);
 	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
+	const bool optimize_underground = g_settings->getBool("block_send_optimize_underground");
 	//infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
 
 	s16 d_max = full_d_max;
@@ -283,7 +284,7 @@ void RemoteClient::GetNextBlocks (
 					surely_not_found_on_disk = true;
 				}
 
-				if(block->isGenerated() == false)
+				if(!block->isGenerated())
 					block_is_invalid = true;
 
 				/*
@@ -295,7 +296,8 @@ void RemoteClient::GetNextBlocks (
 				*/
 				if(d >= d_opt)
 				{
-					if(block->getDayNightDiff() == false)
+					if((optimize_underground || !block->getIsUnderground()) &&
+						!block->getDayNightDiff())
 						continue;
 				}
 			}

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -180,7 +180,7 @@ void RemoteClient::GetNextBlocks (
 	if (camera_fov <= 0) camera_fov = (72.0*M_PI/180) * 4./3.;
 
 	const s16 full_d_max = MYMIN(g_settings->getS16("max_block_send_distance"), wanted_range);
-	const s16 d_opt = MYMIN(g_settings->getS16("block_send_optimize_distance"), wanted_range);
+	const s16 d_opt = g_settings->getS16("block_send_optimization");
 	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 	//infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
 
@@ -287,16 +287,20 @@ void RemoteClient::GetNextBlocks (
 					block_is_invalid = true;
 
 				/*
-					If block is not close, don't send it unless it is near
+					If send optimization was requests and
+					if block is not close, don't send it unless it is near
 					ground level.
 
 					Block is near ground level if night-time mesh
 					differs from day-time mesh.
+
+					For medium optimization only optimize for blocks above ground.
 				*/
-				if(d >= d_opt)
-				{
-					if(block->getDayNightDiff() == false)
-						continue;
+				if((d_opt > 0 && d >= 4) &&
+					(d_opt > 9 || !block->getIsUnderground()) &&
+					!block->getDayNightDiff())
+			        {
+					continue;
 				}
 			}
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -282,6 +282,7 @@ void set_default_settings(Settings *settings)
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
+	settings->setDefault("block_send_optimize_underground", "true");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -281,7 +281,7 @@ void set_default_settings(Settings *settings)
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_block_send_distance", "9");
-	settings->setDefault("block_send_optimize_distance", "4");
+	settings->setDefault("block_send_optimization", "10");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -281,7 +281,7 @@ void set_default_settings(Settings *settings)
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_block_send_distance", "9");
-	settings->setDefault("block_send_optimize_distance", "4");
+	settings->setDefault("block_send_optimize_distance", "6");
 	settings->setDefault("block_send_optimize_underground", "true");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
@@ -372,6 +372,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chunksize", "3");
 
 	settings->setDefault("viewing_range", "25");
+	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("inventory_image_hack", "false");
 
 	// Check for a device with a small screen

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -281,7 +281,7 @@ void set_default_settings(Settings *settings)
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
 	settings->setDefault("max_block_send_distance", "9");
-	settings->setDefault("block_send_optimization", "10");
+	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");


### PR DESCRIPTION
Related to #4811

Add a new config option to disable the block send optimization on the server when the block is known to be underground.
The block send optimization relies on the propagation of daylight, which fails in areas of the map where no daylight reaches.

Together this block_send_optimize_distance this allows for fairly fine grained control over how the server optimizes sending blocks.

------- Old description --------

1. Streamline the optimization setting. Instead of providing the optimize distance, just specify the an abstract optimization level. (I doubt anyone would set the old distance setting to anything but the default, or equal to the max distance - to turn the optimization off. Now it's an easier choice)
2. Add another level. Where we check whether the block is underground (below water level) if so avoid the optimization. This is a kind of a middle ground. In many cases the blocks would not need to be sent, and still deep ocean and - underground - caves would render correctly)
3. Restore the optimize distance of 4 (which is how is was before #4811)
4. Adds optimization levels from 0-10, so that we could potentially add more levels later (right now it's 0, 1-9, and 10)