### PR TITLE
Biomes: Add heat and humidity vertical gradient parameters 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -915,11 +915,18 @@ emergequeue_limit_generate (Limit of emerge queues to generate) int 32
 #    at the cost of slightly buggy caves.
 num_emerge_threads (Number of emerge threads) int 1
 
-#    Noise parameters for biome API temperature, humidity and biome blend.
+[***Biome parameters]
+
 mg_biome_np_heat (Mapgen biome heat noise parameters) noise_params 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0
-mg_biome_np_heat_blend (Mapgen heat blend noise parameters) noise_params 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
+mg_biome_np_heat_blend (Mapgen biome heat blend noise parameters) noise_params 0, 1.5, (8, 8, 8), 13, 2, 1.0, 2.0
 mg_biome_np_humidity (Mapgen biome humidity noise parameters) noise_params 50, 50, (1000, 1000, 1000), 842, 3, 0.5, 2.0
 mg_biome_np_humidity_blend (Mapgen biome humidity blend noise parameters) noise_params 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0
+
+#    Biome vertical heat gradient in change per node from y = 0.
+mg_biome_heat_gradient (Mapgen biome heat gradient) float 0.0
+
+#    Biome vertical humidity gradient in change per node from y = 0.
+mg_biome_humidity_gradient (Mapgen biome humidity gradient) float 0.0
 
 [***Mapgen v5]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1137,7 +1137,8 @@
 #    Only the group format supports noise flags which are needed for eased noise.
 #    Mgv5 uses eased noise for np_ground so this is shown in group format below.
 
-#    Noise parameters for biome API temperature, humidity and biome blend.
+#### Biome parameters
+
 #    type: noise_params
 # mg_biome_np_heat = 50, 50, (1000, 1000, 1000), 5349, 3, 0.5, 2.0
 
@@ -1149,6 +1150,14 @@
 
 #    type: noise_params
 # mg_biome_np_humidity_blend = 0, 1.5, (8, 8, 8), 90003, 2, 1.0, 2.0
+
+#    Biome vertical heat gradient in change per node from y = 0.
+#    type: float
+# mg_biome_heat_gradient = 0.0
+
+#    Biome vertical humidity gradient in change per node from y = 0.
+#    type: float
+# mg_biome_humidity_gradient = 0.0
 
 #### Mapgen v5
 

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -189,7 +189,7 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoiseWithGradient(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -205,7 +205,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoiseWithGradient(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -187,7 +187,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoiseWithGradient(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	// Generate caves

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -253,7 +253,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoiseWithGradient(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -101,7 +101,13 @@ public:
 	// Computes any intermediate results needed for biome generation.  Must be
 	// called before using any of: getBiomes, getBiomeAtPoint, or getBiomeAtIndex.
 	// Calling this invalidates the previous results stored in biomemap.
+	// Does not include heat/humidity gradient calculations.
 	virtual void calcBiomeNoise(v3s16 pmin) = 0;
+
+	// Computes any intermediate results needed for biome generation.  Must be
+	// called before using any of: getBiomes, getBiomeAtPoint, or getBiomeAtIndex.
+	// Calling this invalidates the previous results stored in biomemap.
+	virtual void calcBiomeNoiseWithGradient(v3s16 pmin, s16 *heightmap) = 0;
 
 	// Gets all biomes in current chunk using each corresponding element of
 	// heightmap as the y position, then stores the results by biome index in
@@ -140,6 +146,8 @@ struct BiomeParamsOriginal : public BiomeParams {
 		np_heat_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0),
 		np_humidity_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 90003, 2, 1.0, 2.0)
 	{
+		heat_gradient     = 0.0;
+		humidity_gradient = 0.0;
 	}
 
 	virtual void readParams(const Settings *settings);
@@ -149,6 +157,8 @@ struct BiomeParamsOriginal : public BiomeParams {
 	NoiseParams np_humidity;
 	NoiseParams np_heat_blend;
 	NoiseParams np_humidity_blend;
+	float heat_gradient;
+	float humidity_gradient;
 };
 
 class BiomeGenOriginal : public BiomeGen {
@@ -161,6 +171,7 @@ public:
 
 	Biome *calcBiomeAtPoint(v3s16 pos) const;
 	void calcBiomeNoise(v3s16 pmin);
+	void calcBiomeNoiseWithGradient(v3s16 pmin, s16 *heightmap);
 
 	biome_t *getBiomes(s16 *heightmap);
 	Biome *getBiomeAtPoint(v3s16 pos) const;
@@ -178,6 +189,8 @@ private:
 	Noise *noise_humidity;
 	Noise *noise_heat_blend;
 	Noise *noise_humidity_blend;
+	float heat_gradient;
+	float humidity_gradient;
 };
 
 


### PR DESCRIPTION
New biome parameters grouped with heat and humidity noises.
Measured from y = 0, the values are change per node so would usually
be set negative.
By default set to 0.0 to not break existing worlds.
To avoid extreme values caused by world height, heat and humidity
values are now limited to a range of -50 to 150 (50 +/- 100).

Add 'calcBiomeNoiseWithGradient()' that includes gradient
calculations.
Mgvalleys has it's own heat gradient code so uses the existing
'calcBiomeNoise()'.

Add a new sub-section to advanced settings menu: 'Biome parameters'.
//////////////////////////////////////////////

![screenshot_20170228_022000](https://cloud.githubusercontent.com/assets/3686677/23388928/d8c4e5da-fd5c-11e6-85c4-f5d9b07e5b70.png)

^ With both heat and humidity gradients set to -0.4. Biome changes from temperate coniferous forest to snowy grassland to tundra at the summit.

![screenshot from 2017-03-03 04-04-46](https://cloud.githubusercontent.com/assets/3686677/23537874/edc51786-ffc6-11e6-840c-f8e2a578fde8.png)

^ Biome parameters deserve their own titled sub section, so added one

Replaces #5316 
New biome parameters for vertical heat and humidity gradients, by default set to zero to not break existing worlds.
Since these gradients are calculated from y = 0 they will bias biomes towards cold and dry, the 'offset' noise parameters for heat and humidity can be adjusted to compensate for this.

Thoroughly tested.