### PR TITLE
Make world config dialog and advanced settings dialog support nested modpacks

### DIFF
--- a/builtin/common/filterlist.lua
+++ b/builtin/common/filterlist.lua
@@ -294,27 +294,13 @@ function sort_mod_list(self)
 			end
 			return b.typ == "game_mod"
 		end
-		-- If in same or no modpack, sort by name
-		if a.modpack == b.modpack then
-			if a.name:lower() == b.name:lower() then
-				return a.name < b.name
-			end
-			return a.name:lower() < b.name:lower()
-		-- Else compare name to modpack name
-		else
-			-- Always show modpack pseudo-mod on top of modpack mod list
-			if a.name == b.modpack then
-				return true
-			elseif b.name == a.modpack then
-				return false
-			end
-			
-			local name_a = a.modpack or a.name
-			local name_b = b.modpack or b.name
-			if name_a:lower() == name_b:lower() then
-				return  name_a < name_b
-			end
-			return name_a:lower() < name_b:lower()
+		-- full_name contains the modpack/mod path, so sorting by this does not require any modpack checks
+		-- see also modmgr.lua
+		local name_a = a.full_name
+		local name_b = b.full_name
+		if name_a:lower() == name_b:lower() then
+			return  name_a < name_b
 		end
+		return name_a:lower() < name_b:lower()
 	end)
 end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -51,15 +51,7 @@ local function get_formspec(data)
 
 	if mod and mod.name ~= "" and not mod.is_game_content then
 		if mod.is_modpack then
-			local rawlist = data.list:get_raw_list()
-
-			local all_enabled = true
-			for j = 1, #rawlist, 1 do
-				if rawlist[j].modpack == mod.name and not rawlist[j].enabled then
-					all_enabled = false
-					break
-				end
-			end
+			local all_enabled = modmgr.check_modpack_enabled(data.list, mod.full_name)
 
 			if all_enabled then
 				retval = retval .. "button[5.5,0.125;2.5,0.5;btn_mp_disable;" ..
@@ -106,15 +98,7 @@ local function enable_mod(this, toset)
 			mod.enabled = toset
 		end
 	else
-		local list = this.data.list:get_raw_list()
-		for i=1,#list,1 do
-			if list[i].modpack == mod.name then
-				if toset == nil then
-					toset = not list[i].enabled
-				end
-				list[i].enabled = toset
-			end
-		end
+		modmgr.set_modpack_enabled(this.data.list, mod.full_name, toset)
 	end
 end
 

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -461,7 +461,8 @@ function modmgr.preparemodlist(data)
 		retval[#retval + 1] = {
 			typ = "game",
 			is_game_content = true,
-			name = fgettext("Subgame Mods")
+			name = fgettext("Subgame Mods"),
+			mp_level = -1,
 		}
 	end
 


### PR DESCRIPTION
The engine is able to handle nested modpack structures, while the menu was not.
The entry format of mod entries from get_mods was changed, see the comment on top of modmgr.lua for details