### PR TITLE
Add support to show LUA mapgen mods in world creation dialog

### DIFF
--- a/builtin/common/filterlist.lua
+++ b/builtin/common/filterlist.lua
@@ -294,27 +294,13 @@ function sort_mod_list(self)
 			end
 			return b.typ == "game_mod"
 		end
-		-- If in same or no modpack, sort by name
-		if a.modpack == b.modpack then
-			if a.name:lower() == b.name:lower() then
-				return a.name < b.name
-			end
-			return a.name:lower() < b.name:lower()
-		-- Else compare name to modpack name
-		else
-			-- Always show modpack pseudo-mod on top of modpack mod list
-			if a.name == b.modpack then
-				return true
-			elseif b.name == a.modpack then
-				return false
-			end
-			
-			local name_a = a.modpack or a.name
-			local name_b = b.modpack or b.name
-			if name_a:lower() == name_b:lower() then
-				return  name_a < name_b
-			end
-			return name_a:lower() < name_b:lower()
+		-- full_name contains the modpack/mod path, so sorting by this does not require any modpack checks
+		-- see also modmgr.lua
+		local name_a = a.full_name
+		local name_b = b.full_name
+		if name_a:lower() == name_b:lower() then
+			return  name_a < name_b
 		end
+		return name_a:lower() < name_b:lower()
 	end)
 end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -51,15 +51,7 @@ local function get_formspec(data)
 
 	if mod and mod.name ~= "" and not mod.is_game_content then
 		if mod.is_modpack then
-			local rawlist = data.list:get_raw_list()
-
-			local all_enabled = true
-			for j = 1, #rawlist, 1 do
-				if rawlist[j].modpack == mod.name and not rawlist[j].enabled then
-					all_enabled = false
-					break
-				end
-			end
+			local all_enabled = modmgr.check_modpack_enabled(data.list, mod.full_name)
 
 			if all_enabled then
 				retval = retval .. "button[5.5,0.125;2.5,0.5;btn_mp_disable;" ..
@@ -106,15 +98,7 @@ local function enable_mod(this, toset)
 			mod.enabled = toset
 		end
 	else
-		local list = this.data.list:get_raw_list()
-		for i=1,#list,1 do
-			if list[i].modpack == mod.name then
-				if toset == nil then
-					toset = not list[i].enabled
-				end
-				list[i].enabled = toset
-			end
-		end
+		modmgr.set_modpack_enabled(this.data.list, mod.full_name, toset)
 	end
 end
 

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -31,6 +31,11 @@
     mp_level = 1
        Intendation level where this mod(pack) should be drawn in a tree.
        0 is top layer (modpack "")
+    is_standalone_mapgen = nil,
+       Whether this mod is a standalone mapgen that should be shown in the world creation dialog.
+       If a world was created using this feature, the selected mapgen mod is saved in the 'mapgen_mod'
+       field in world.mt for future handling.
+       See lua_api.txt ### mod.conf for more info
  }
 ]]--
 
@@ -63,6 +68,9 @@ function get_mods(path, retval, modpack_p, mp_level_p)
 				modpackfile:close()
 				toadd.is_modpack = true
 				get_mods(prefix, retval, toadd.full_name, mp_level+1)
+			end
+			if core.is_yes(mod_conf.is_standalone_mapgen) and not toadd.is_modpack then
+				toadd.is_standalone_mapgen = true
 			end
 		end
 	end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -132,6 +132,7 @@ Mod directory structure
     |   |-- screenshot.png
     |   |-- description.txt
     |   |-- settingtypes.txt
+    |   |-- mod.conf
     |   |-- init.lua
     |   |-- models
     |   |-- textures
@@ -166,6 +167,31 @@ A File containing description to be shown within mainmenu.
 ### `settingtypes.txt`
 A file in the same format as the one in builtin. It will be parsed by the
 settings menu and the settings will be displayed in the "Mods" category.
+
+### `mod.conf`
+File that contains additional mod information. It has the same format as
+minetest.conf.
+Adding a mod.conf is not necessary in most cases.
+The following options are recognized:
+  name = foo
+  ^-- The name of the mod.
+  ^-- If this option is not specified, defaults to the directory name
+  is_standalone_mapgen = false
+  ^-- This mod is a LUA mapgen. It will generate all terrain itself,
+      without being backed by a builtin mapgen.
+  ^-- When this option is specified, users can select this mod as world mapgen
+      when creating a world. Internally, singlenode is chosen as mapgen and the
+      selected mapgen mod gets enabled.
+  ^-- Note: You should only use this option when the scenario matches exactly
+      Don't set it if your mod just adds biomes or decorations and therefore requires
+      a core mapgen to run.
+  ^-- As a general rule of thumb, this option should only be set when your mod code
+      contains something like:
+        ```
+        minetest.register_on_mapgen_init(function(mgparams)
+            minetest.set_mapgen_params({mgname = "singlenode"})
+        end)
+        ```
 
 ### `init.lua`
 The main Lua script. Running this script should register everything it


### PR DESCRIPTION
This PR includes #5329.
If the option is_standalone_mapgen is specified in mod.conf, a mod is listed as mapgen option in the world creation dialog.
For more info see the documentation these commits add.