### PR TITLE
Biomes: Add vertical heat/humidity gradient biome parameters

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -189,7 +189,7 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoise(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -205,7 +205,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoise(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -187,7 +187,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoise(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	// Generate caves

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -253,7 +253,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
-	biomegen->calcBiomeNoise(node_min);
+	biomegen->calcBiomeNoise(node_min, heightmap);
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -241,7 +241,10 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	// Generate biome noises.  Note this must be executed strictly before
 	// generateTerrain, because generateTerrain depends on intermediate
 	// biome-related noises.
-	m_bgen->calcBiomeNoise(node_min);
+	// mgvalleys calls calcBiomeNoise() before it creates the heightmap,
+	// so it passes 0 for the heightmap argument to set y = 0 in
+	// calcBiomeNoise() and avoid it accessing a NULL heightmap.
+	m_bgen->calcBiomeNoise(node_min, 0);
 
 	// Generate noise maps and base terrain height.
 	// Modify heat and humidity maps.

--- a/src/mg_biome.cpp
+++ b/src/mg_biome.cpp
@@ -96,6 +96,8 @@ void BiomeParamsOriginal::readParams(const Settings *settings)
 	settings->getNoiseParams("mg_biome_np_heat_blend",     np_heat_blend);
 	settings->getNoiseParams("mg_biome_np_humidity",       np_humidity);
 	settings->getNoiseParams("mg_biome_np_humidity_blend", np_humidity_blend);
+	settings->getFloatNoEx("mg_biome_heat_gradient",       heat_gradient);
+	settings->getFloatNoEx("mg_biome_humidity_gradient",   humidity_gradient);
 }
 
 
@@ -105,6 +107,8 @@ void BiomeParamsOriginal::writeParams(Settings *settings) const
 	settings->setNoiseParams("mg_biome_np_heat_blend",     np_heat_blend);
 	settings->setNoiseParams("mg_biome_np_humidity",       np_humidity);
 	settings->setNoiseParams("mg_biome_np_humidity_blend", np_humidity_blend);
+	settings->setFloat("mg_biome_heat_gradient",           heat_gradient);
+	settings->setFloat("mg_biome_humidity_gradient",       humidity_gradient);
 }
 
 
@@ -125,6 +129,8 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 									params->seed, m_csize.X, m_csize.Z);
 	noise_humidity_blend = new Noise(&params->np_humidity_blend,
 									params->seed, m_csize.X, m_csize.Z);
+	this->heat_gradient     = params->heat_gradient;
+	this->humidity_gradient = params->humidity_gradient;
 
 	heatmap  = noise_heat->result;
 	humidmap = noise_humidity->result;
@@ -144,18 +150,23 @@ BiomeGenOriginal::~BiomeGenOriginal()
 
 Biome *BiomeGenOriginal::calcBiomeAtPoint(v3s16 pos) const
 {
-	float heat =
+	float heat = rangelim(
 		NoisePerlin2D(&m_params->np_heat,       pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed);
-	float humidity =
+		NoisePerlin2D(&m_params->np_heat_blend, pos.X, pos.Z, m_params->seed) +
+		pos.Y * heat_gradient,
+		-50.0f, 150.0f);
+	// Humidity gradient is disabled underground.
+	float humidity = rangelim(
 		NoisePerlin2D(&m_params->np_humidity,       pos.X, pos.Z, m_params->seed) +
-		NoisePerlin2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed);
+		NoisePerlin2D(&m_params->np_humidity_blend, pos.X, pos.Z, m_params->seed) +
+		MYMAX(pos.Y, 0) * humidity_gradient,
+		-50.0f, 150.0f);
 
 	return calcBiomeFromNoise(heat, humidity, pos.Y);
 }
 
 
-void BiomeGenOriginal::calcBiomeNoise(v3s16 pmin)
+void BiomeGenOriginal::calcBiomeNoise(v3s16 pmin, s16 *heightmap)
 {
 	m_pmin = pmin;
 
@@ -165,8 +176,22 @@ void BiomeGenOriginal::calcBiomeNoise(v3s16 pmin)
 	noise_humidity_blend->perlinMap2D(pmin.X, pmin.Z);
 
 	for (s32 i = 0; i < m_csize.X * m_csize.Z; i++) {
-		noise_heat->result[i]     += noise_heat_blend->result[i];
-		noise_humidity->result[i] += noise_humidity_blend->result[i];
+		// mgvalleys calls calcBiomeNoise() before it creates the heightmap,
+		// so it passes 0 for the heightmap argument to set y = 0 and avoid
+		// accessing a NULL heightmap.
+		// y is limited to a minimum of mapchunk minp.Y due to the heightmap
+		// containing -MAX_MAP_GENERATION_LIMIT if no terrain is found in a
+		// mapchunk node column.
+		s16 y = (!heightmap) ? 0 : MYMAX(heightmap[i], pmin.Y);
+		noise_heat->result[i] = rangelim(
+			noise_heat->result[i] + noise_heat_blend->result[i] +
+			y * heat_gradient,
+			-50.0f, 150.0f);
+		// Humidity gradient is disabled underground.
+		noise_humidity->result[i] = rangelim(
+			noise_humidity->result[i] + noise_humidity_blend->result[i] +
+			MYMAX(y, 0) * humidity_gradient,
+			-50.0f, 150.0f);
 	}
 }
 

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -101,7 +101,7 @@ public:
 	// Computes any intermediate results needed for biome generation.  Must be
 	// called before using any of: getBiomes, getBiomeAtPoint, or getBiomeAtIndex.
 	// Calling this invalidates the previous results stored in biomemap.
-	virtual void calcBiomeNoise(v3s16 pmin) = 0;
+	virtual void calcBiomeNoise(v3s16 pmin, s16 *heightmap) = 0;
 
 	// Gets all biomes in current chunk using each corresponding element of
 	// heightmap as the y position, then stores the results by biome index in
@@ -140,6 +140,8 @@ struct BiomeParamsOriginal : public BiomeParams {
 		np_heat_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 13, 2, 1.0, 2.0),
 		np_humidity_blend(0, 1.5, v3f(8.0, 8.0, 8.0), 90003, 2, 1.0, 2.0)
 	{
+		heat_gradient     = 0.0;
+		humidity_gradient = 0.0;
 	}
 
 	virtual void readParams(const Settings *settings);
@@ -149,6 +151,8 @@ struct BiomeParamsOriginal : public BiomeParams {
 	NoiseParams np_humidity;
 	NoiseParams np_heat_blend;
 	NoiseParams np_humidity_blend;
+	float heat_gradient;
+	float humidity_gradient;
 };
 
 class BiomeGenOriginal : public BiomeGen {
@@ -160,7 +164,7 @@ public:
 	BiomeGenType getType() const { return BIOMEGEN_ORIGINAL; }
 
 	Biome *calcBiomeAtPoint(v3s16 pos) const;
-	void calcBiomeNoise(v3s16 pmin);
+	void calcBiomeNoise(v3s16 pmin, s16 *heightmap);
 
 	biome_t *getBiomes(s16 *heightmap);
 	Biome *getBiomeAtPoint(v3s16 pos) const;
@@ -178,6 +182,8 @@ private:
 	Noise *noise_humidity;
 	Noise *noise_heat_blend;
 	Noise *noise_humidity_blend;
+	float heat_gradient;
+	float humidity_gradient;
 };
 
 


### PR DESCRIPTION
New biome parameters grouped with heat and humidity noises.
Measured from y = 0, the values are change per node so would usually
be set negative.
Humidity gradient is disabled for negative y.
By default set to 0.0 to not break existing worlds.
To avoid extreme values caused by world height, heat and humidity
values are now limited to a range of -50 to 150 (50 +/- 100).

Mgvalleys calls calcBiomeNoise() before it creates the heightmap, so
it passes 0 for the heightmap argument to set y = 0 in calcBiomeNoise()
and avoid it accessing a NULL heightmap. This disables these gradients,
it has it's own modifications of heat and humidity.

Add a new sub-section to advanced settings menu: 'Biome parameters'.
////////////////////////////////////////////////////////


![screenshot_20170228_022000](https://cloud.githubusercontent.com/assets/3686677/23388928/d8c4e5da-fd5c-11e6-85c4-f5d9b07e5b70.png)

^ With both heat and humidity gradients set to -0.4. Biome changes from temperate coniferous forest to snowy grassland to tundra at the summit.

Replaces #5319 
Addresses #4205 #5278 
New biome parameters for vertical heat and humidity gradients, by default set to zero to not break existing worlds.
Since these gradients are calculated from y = 0 they will bias biomes towards cold and dry, the 'offset' noise parameters for heat and humidity can be adjusted to compensate for this.

WIP changes to conf.example and settingtypes.txt still needed.