### PR TITLE
Climb speed: Increase default setting from 2 to 3

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -799,7 +799,7 @@ movement_acceleration_fast (Fast mode acceleration) float 10
 movement_speed_walk (Walking speed) float 4
 movement_speed_crouch (Crouch speed) float 1.35
 movement_speed_fast (Fast mode speed) float 20
-movement_speed_climb (Climbing speed) float 2
+movement_speed_climb (Climbing speed) float 3
 movement_speed_jump (Jumping speed) float 6.5
 movement_speed_descend (Descending speed) float 6
 movement_liquid_fluidity (Liquid fluidity) float 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -965,7 +965,7 @@
 # movement_speed_fast = 20
 
 #    type: float
-# movement_speed_climb = 2
+# movement_speed_climb = 3
 
 #    type: float
 # movement_speed_jump = 6.5

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -314,7 +314,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("movement_speed_walk", "4");
 	settings->setDefault("movement_speed_crouch", "1.35");
 	settings->setDefault("movement_speed_fast", "20");
-	settings->setDefault("movement_speed_climb", "2");
+	settings->setDefault("movement_speed_climb", "3");
 	settings->setDefault("movement_speed_jump", "6.5");
 	settings->setDefault("movement_liquid_fluidity", "1");
 	settings->setDefault("movement_liquid_fluidity_smooth", "0.5");


### PR DESCRIPTION
You can test this easily by adding `movement_speed_climb = 3` to mineteest.conf.

Partly as compensation if sneak ladder is removed, but also because 2 feels slow and MT is very vertical. It is possible to walk up stairs with a vertical velocity of 4 n/s.
I tried climb speed 4 but it felt too fast, 3 is still a significant increase.

Similar to https://github.com/minetest/minetest_game/pull/1605 in making ladder travel easier and faster.