### PR TITLE
CI: Add memleak checking using valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
     - env: PLATFORM=Unix COMPILER=clang
       compiler: clang
       os: linux
+    - env: PLATFORM=Unix COMPILER=clang VALGRIND=1
+      compiler: clang
+      os: linux
+      dist: trusty
     - env: PLATFORM=Unix COMPILER=g++-6
       compiler: gcc
       os: linux

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -18,6 +18,9 @@ if [[ $PLATFORM == "Unix" ]]; then
 		# Linking to LevelDB is broken, use a custom build
 		wget http://minetest.kitsunemimi.pw/libleveldb-1.18-ubuntu12.04.7z
 		sudo 7z x -o/usr libleveldb-1.18-ubuntu12.04.7z
+		if [[ "$VALGRIND" == "1" ]]; then
+			sudo apt-get install valgrind
+		fi
 	else
 		brew update
 		brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit

--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -24,8 +24,15 @@ if [[ $PLATFORM == "Unix" ]]; then
 		-DBUILD_SERVER=TRUE \
 		$CMAKE_FLAGS ..
 	make -j2
+
 	echo "Running unit tests."
-	../bin/minetest --run-unittests && exit 0
+	CMD="../bin/minetest --run-unittests"
+	if [[ "$VALGRIND" == "1" ]]; then
+		valgrind --leak-check=full --leak-check-heuristics=all --undef-value-errors=no --error-exitcode=9 ${CMD} && exit 0
+	else
+		${CMD} && exit 0
+	fi
+
 elif [[ $PLATFORM == Win* ]]; then
 	[[ $CC == "clang" ]] && exit 1 # Not supposed to happen
 	# We need to have our build directory outside of the minetest directory because


### PR DESCRIPTION
Our unittests doesn't cover the whole code, but using valgrind on existing and future unittests can be good to ensure we don't add any memleak on covered path