### PR TITLE
Add the possibility to skip light update and fix light later

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2373,7 +2373,13 @@ and `minetest.auth_reload` call the authetification handler.
     * `pos1` is the corner of the cuboid with the least coordinates
       (in node coordinates), inclusive.
     * `pos2` is the opposite corner of the cuboid, inclusive.
-    * The actual updated cuboid might be larger than the specified one.
+    * The actual updated cuboid might be larger than the specified one,
+      because only whole map blocks can be updated.
+      The actual updated area consists of those map blocks that intersect
+      with the given cuboid.
+    * However, the neighborhood of the updated area might change
+      as well, as light can spread out of the cuboid, also light
+      might be removed.
     * returns `false` if the area is not fully generated,
       `true` otherwise
 * `core.check_single_for_falling(pos)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2366,11 +2366,15 @@ and `minetest.auth_reload` call the authetification handler.
     * increase level of leveled node by level, default `level` equals `1`
     * if `totallevel > maxlevel`, returns rest (`total-max`)
     * can be negative for decreasing
-* `minetest.fix_light(pos)`: returns `true`/`false`
-    * resets the light of a map block and removes lighting bugs.
-    * Loads the block if it is not loaded.
-    * `pos` is the position of the block (in block coordinates)
-    * returns `false` if the block is not generated (so nothing changed),
+* `minetest.fix_light(pos1, pos2)`: returns `true`/`false`
+    * resets the light in a cuboid-shaped part of
+      the map and removes lighting bugs.
+    * Loads the area if it is not loaded.
+    * `pos1` is the corner of the cuboid with the least coordinates
+      (in node coordinates), inclusive.
+    * `pos2` is the opposite corner of the cuboid, inclusive.
+    * The actual updated cuboid might be larger than the specified one.
+    * returns `false` if the area is not fully generated,
       `true` otherwise
 * `core.check_single_for_falling(pos)`
     * causes an unsupported `group:falling_node` node to fall and causes an

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2366,6 +2366,12 @@ and `minetest.auth_reload` call the authetification handler.
     * increase level of leveled node by level, default `level` equals `1`
     * if `totallevel > maxlevel`, returns rest (`total-max`)
     * can be negative for decreasing
+* `minetest.fix_light(pos)`: returns `true`/`false`
+    * resets the light of a map block and removes lighting bugs.
+    * Loads the block if it is not loaded.
+    * `pos` is the position of the block (in block coordinates)
+    * returns `false` if the block is not generated (so nothing changed),
+      `true` otherwise
 * `core.check_single_for_falling(pos)`
     * causes an unsupported `group:falling_node` node to fall and causes an
       unattached `group:attached_node` node to fall.
@@ -3379,8 +3385,14 @@ will place the schematic inside of the VoxelManip.
 * `read_from_map(p1, p2)`:  Loads a chunk of map into the VoxelManip object containing
   the region formed by `p1` and `p2`.
     * returns actual emerged `pmin`, actual emerged `pmax`
-* `write_to_map()`: Writes the data loaded from the `VoxelManip` back to the map.
+* `write_to_map([light])`: Writes the data loaded from the `VoxelManip` back to the map.
     * **important**: data must be set using `VoxelManip:set_data()` before calling this
+    * if `light` is true, then lighting is automatically recalculated.
+      The default value is true.
+      If `light` is false, no light calculations happen, and you should correct
+      all modified blocks with `minetest.fix_light()` as soon as possible.
+      Keep in mind that modifying the map where light is incorrect can cause
+      more lighting bugs. 
 * `get_node_at(pos)`: Returns a `MapNode` table of the node currently loaded in
   the `VoxelManip` at that position
 * `set_node_at(pos, node)`: Sets a specific `MapNode` in the `VoxelManip` at that position

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2530,6 +2530,16 @@ void ServerMap::PrintInfo(std::ostream &out)
 	out<<"ServerMap: ";
 }
 
+bool ServerMap::repairBlockLight(v3s16 blockpos,
+	std::map<v3s16, MapBlock *> *modified_blocks)
+{
+	MapBlock *block = emergeBlock(blockpos, false);
+	if (!block || !block->isGenerated())
+		return false;
+	voxalgo::repair_block_light(this, block, modified_blocks);
+	return true;
+}
+
 MMVManip::MMVManip(Map *map):
 		VoxelManipulator(),
 		m_is_dirty(false),

--- a/src/map.h
+++ b/src/map.h
@@ -480,6 +480,16 @@ public:
 	u64 getSeed();
 	s16 getWaterLevel();
 
+	/*!
+	 * Fixes lighting in one map block.
+	 * May modify other blocks as well, as light can spread
+	 * out of the specified block.
+	 * Returns false if the block is not generated (so nothing
+	 * changed), true otherwise.
+	 */
+	bool repairBlockLight(v3s16 blockpos,
+		std::map<v3s16, MapBlock *> *modified_blocks);
+
 	MapSettingsManager settings_mgr;
 
 private:

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -845,7 +845,7 @@ int ModApiEnvMod::l_fix_light(lua_State *L)
 		MapEditEvent event;
 		event.type = MEET_OTHER;
 		for (std::map<v3s16, MapBlock *>::iterator it = modified_blocks.begin();
-			it != modified_blocks.end(); ++it)
+				it != modified_blocks.end(); ++it)
 			event.modified_blocks.insert(it->first);
 
 		map.dispatchEvent(&event);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -832,16 +832,26 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L)
 	return 1;
 }
 
-// fix_light(p)
+// fix_light(p1, p2)
 int ModApiEnvMod::l_fix_light(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	v3s16 blockpos = read_v3s16(L, 1);
+	v3s16 blockpos1 = getContainerPos(read_v3s16(L, 1), MAP_BLOCKSIZE);
+	v3s16 blockpos2 = getContainerPos(read_v3s16(L, 2), MAP_BLOCKSIZE);
 	ServerMap &map = env->getServerMap();
 	std::map<v3s16, MapBlock *> modified_blocks;
-	bool success = map.repairBlockLight(blockpos, &modified_blocks);
-	if (success) {
+	bool success = true;
+	v3s16 blockpos;
+	for (blockpos.X = blockpos1.X; blockpos.X <= blockpos2.X;
+			blockpos.X++)
+		for (blockpos.Y = blockpos1.Y; blockpos.Y <= blockpos2.Y;
+				blockpos.Y++)
+			for (blockpos.Z = blockpos1.Z; blockpos.Z <= blockpos2.Z;
+					blockpos.Z++)
+				success = success
+					& map.repairBlockLight(blockpos, &modified_blocks);
+	if (modified_blocks.size() > 0) {
 		MapEditEvent event;
 		event.type = MEET_OTHER;
 		for (std::map<v3s16, MapBlock *>::iterator it = modified_blocks.begin();

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -128,6 +128,9 @@ private:
 	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
 	static int l_find_nodes_in_area_under_air(lua_State *L);
 
+	// fix_light(p) -> true/false
+	static int l_fix_light(lua_State *L);
+
 	// emerge_area(p1, p2)
 	static int l_emerge_area(lua_State *L);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -128,7 +128,7 @@ private:
 	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
 	static int l_find_nodes_in_area_under_air(lua_State *L);
 
-	// fix_light(p) -> true/false
+	// fix_light(p1, p2) -> true/false
 	static int l_fix_light(lua_State *L);
 
 	// emerge_area(p1, p2)

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -110,9 +110,10 @@ int LuaVoxelManip::l_write_to_map(lua_State *L)
 	MAP_LOCK_REQUIRED;
 
 	LuaVoxelManip *o = checkobject(L, 1);
+	bool update_light = lua_isboolean(L, 2) ? lua_toboolean(L, 2) : true;
 	GET_ENV_PTR;
 	ServerMap *map = &(env->getServerMap());
-	if (o->is_mapgen_vm) {
+	if (o->is_mapgen_vm || !update_light) {
 		o->vm->blitBackAll(&(o->modified_blocks));
 	} else {
 		voxalgo::blit_back_with_light(map, o->vm,

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -1136,7 +1136,7 @@ void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 	for (s16 b_x = minblock.X; b_x <= maxblock.X; b_x++)
 	for (s16 b_y = minblock.Y; b_y <= maxblock.Y; b_y++)
 	for (s16 b_z = minblock.Z; b_z <= maxblock.Z; b_z++) {
-		v3s16 blockpos(b_x, b_y, b_z);
+		const v3s16 blockpos(b_x, b_y, b_z);
 		MapBlock *block = map->getBlockNoCreateNoEx(blockpos);
 		if (!block || block->isDummy())
 			// Skip not existing blocks
@@ -1311,9 +1311,10 @@ void fill_with_sunlight(MapBlock *block, INodeDefManager *ndef,
 			if (n.getContent() == CONTENT_IGNORE)
 				continue;
 			const ContentFeatures &f = ndef->get(n.getContent());
-			if (lig && !f.sunlight_propagates)
+			if (lig && !f.sunlight_propagates) {
 				// Sunlight is stopped.
 				lig = false;
+			}
 			// Reset light
 			n.setLight(LIGHTBANK_DAY, lig ? 15 : 0, f);
 			n.setLight(LIGHTBANK_NIGHT, 0, f);

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -1282,6 +1282,124 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
 		modified_blocks);
 }
 
+/*!
+ * Resets the lighting of the given map block to
+ * complete darkness and full sunlight.
+ *
+ * \param light incoming sunlight, light[x][z] is true if there
+ * is sunlight above the map block at the given x-z coordinates.
+ * The array's indices are relative node coordinates in the block.
+ * After the procedure returns, this contains outgoing light at
+ * the bottom of the map block.
+ */
+void fill_with_sunlight(MapBlock *block, INodeDefManager *ndef,
+	bool light[MAP_BLOCKSIZE][MAP_BLOCKSIZE])
+{
+	if (block->isDummy())
+		return;
+	// dummy boolean
+	bool is_valid;
+	// For each column of nodes:
+	for (s16 z = 0; z < MAP_BLOCKSIZE; z++)
+	for (s16 x = 0; x < MAP_BLOCKSIZE; x++) {
+		// True if the current node has sunlight.
+		bool lig = light[z][x];
+		// For each node, downwards:
+		for (s16 y = MAP_BLOCKSIZE - 1; y >= 0; y--) {
+			MapNode n = block->getNodeNoCheck(x, y, z, &is_valid);
+			// Ignore IGNORE nodes, these are not generated yet.
+			if (n.getContent() == CONTENT_IGNORE)
+				continue;
+			const ContentFeatures &f = ndef->get(n.getContent());
+			if (lig && !f.sunlight_propagates)
+				// Sunlight is stopped.
+				lig = false;
+			// Reset light
+			n.setLight(LIGHTBANK_DAY, lig ? 15 : 0, f);
+			n.setLight(LIGHTBANK_NIGHT, 0, f);
+			block->setNodeNoCheck(x, y, z, n);
+		}
+		// Output outgoing light.
+		light[z][x] = lig;
+	}
+}
+
+void repair_block_light(ServerMap *map, MapBlock *block,
+	std::map<v3s16, MapBlock*> *modified_blocks)
+{
+	if (!block || block->isDummy())
+		return;
+	INodeDefManager *ndef = map->getNodeDefManager();
+	// First queue is for day light, second is for night light.
+	UnlightQueue unlight[] = { UnlightQueue(256), UnlightQueue(256) };
+	ReLightQueue relight[] = { ReLightQueue(256), ReLightQueue(256) };
+	// Will hold sunlight data.
+	bool lights[MAP_BLOCKSIZE][MAP_BLOCKSIZE];
+	SunlightPropagationData data;
+	// Dummy boolean.
+	bool is_valid;
+
+	// --- STEP 1: reset everything to sunlight
+
+	mapblock_v3 blockpos = block->getPos();
+	(*modified_blocks)[blockpos] = block;
+	// For each map block:
+	// Extract sunlight above.
+	is_sunlight_above_block(map, blockpos, ndef, lights);
+	// Reset the voxel manipulator.
+	fill_with_sunlight(block, ndef, lights);
+	// Copy sunlight data
+	data.target_block = v3s16(blockpos.X, blockpos.Y - 1, blockpos.Z);
+	for (s16 z = 0; z < MAP_BLOCKSIZE; z++)
+	for (s16 x = 0; x < MAP_BLOCKSIZE; x++)
+		data.data.push_back(
+			SunlightPropagationUnit(v2s16(x, z), lights[z][x]));
+	// Propagate sunlight and shadow below the voxel manipulator.
+	while (!data.data.empty()) {
+		if (propagate_block_sunlight(map, ndef, &data, &unlight[0],
+				&relight[0]))
+			(*modified_blocks)[data.target_block] =
+				map->getBlockNoCreateNoEx(data.target_block);
+		// Step downwards.
+		data.target_block.Y--;
+	}
+
+	// --- STEP 2: Get nodes from borders to unlight
+
+	// For each border of the block:
+	for (direction d = 0; d < 6; d++) {
+		VoxelArea a = block_pad[d];
+		// For each node of the border:
+		for (s32 x = a.MinEdge.X; x <= a.MaxEdge.X; x++)
+		for (s32 z = a.MinEdge.Z; z <= a.MaxEdge.Z; z++)
+		for (s32 y = a.MinEdge.Y; y <= a.MaxEdge.Y; y++) {
+			v3s16 relpos(x, y, z);
+			// Get node
+			MapNode node = block->getNodeNoCheck(x, y, z, &is_valid);
+			const ContentFeatures &f = ndef->get(node);
+			// For each light bank
+			for (size_t b = 0; b < 2; b++) {
+				LightBank bank = banks[b];
+				u8 light = f.param_type == CPT_LIGHT ?
+					node.getLightNoChecks(bank, &f):
+					f.light_source;
+				// If the new node is dimmer than sunlight, unlight.
+				// (if it has maximal light, it is pointless to remove
+				// surrounding light, as it can only become brighter)
+				if (LIGHT_SUN > light) {
+					unlight[b].push(
+						LIGHT_SUN, relpos, blockpos, block, 6);
+				}
+			} // end of banks
+		} // end of nodes
+	} // end of borders
+
+	// STEP 3: Remove and spread light
+
+	finish_bulk_light_update(map, blockpos, blockpos, unlight, relight,
+		modified_blocks);
+}
+
 VoxelLineIterator::VoxelLineIterator(
 	const v3f &start_position,
 	const v3f &line_vector) :

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -98,6 +98,15 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
 	std::map<v3s16, MapBlock*> *modified_blocks);
 
 /*!
+ * Corrects the light in a map block.
+ * For server use only.
+ *
+ * \param block the block to update
+ */
+void repair_block_light(ServerMap *map, MapBlock *block,
+	std::map<v3s16, MapBlock*> *modified_blocks);
+
+/*!
  * This class iterates trough voxels that intersect with
  * a line. The collision detection does not see nodeboxes,
  * every voxel is a cube and is returned.


### PR DESCRIPTION
For the request of @HybridDog this patch adds the possibility to skip light update when writing voxel manipulators to the map.

`write_to_map([do_light_update])` got a boolean parameter: if it is false, light is not checked. You might want to do this if your voxel manipulator is huge and you want to split the light calculation into smaller parts, or if you modify the same area twice (like the TNT mod in MTG) and you want to skip the first, unnecessary light calculation.

If you want to fix the lighting later (or you find a lighting bug which you want to correct), call `minetest.fix_light(pos)`. This method corrects the lighting in one map block (without copying the data into a new voxel manipulator).