### PR TITLE
Pathfinder: Send errors to `warningstream`.

### DIFF
--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -55,7 +55,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define DEBUG_OUT(a)     while(0)
 #define INFO_TARGET      infostream << "Pathfinder: "
 #define VERBOSE_TARGET   verbosestream << "Pathfinder: "
-#define ERROR_TARGET     errorstream << "Pathfinder: "
+#define ERROR_TARGET     warningstream << "Pathfinder: "
 #endif
 
 /******************************************************************************/


### PR DESCRIPTION
Avoids spamming the chat about several errors.