### PR TITLE
Use distance as block sending priority

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -252,8 +252,8 @@ void RemoteClient::GetNextBlocks (
 				FOV setting. The default of 72 degrees is fine.
 			*/
 
-			if(isBlockInSight(p, camera_pos, camera_dir, camera_fov, d_blocks_in_sight) == false)
-			{
+			f32 dist;
+			if (!isBlockInSight(p, camera_pos, camera_dir, camera_fov, d_blocks_in_sight, &dist)) {
 				continue;
 			}
 
@@ -342,7 +342,7 @@ void RemoteClient::GetNextBlocks (
 			/*
 				Add block to send queue
 			*/
-			PrioritySortedBlockTransfer q((float)d, p, peer_id);
+			PrioritySortedBlockTransfer q((float)dist, p, peer_id);
 
 			dest.push_back(q);
 


### PR DESCRIPTION
In ClientIface use the real distance of a block from a player for it's priority to be sent to the client.
This leads to slightly better behavior in the order in which blocks are rendered at the client.