### PR TITLE
Cavegen/Mgv5/Mgv7: Add optional giant caverns 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -943,12 +943,25 @@ mg_biome_np_humidity_blend (Mapgen biome humidity blend noise parameters) noise_
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv5_cave_width (Mapgen v5 cave width) float 0.125
 
+#    Y-level of cavern upper limit.
+mgv5_cavern_limit (Mapgen v5 cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgv5_cavern_taper (Mapgen v5 cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgv5_cavern_threshold (Mapgen v5 cavern threshold) float 0.7
+
 mgv5_np_filler_depth (Mapgen v5 filler depth noise parameters) noise_params 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 mgv5_np_factor (Mapgen v5 factor noise parameters) noise_params 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0
 mgv5_np_height (Mapgen v5 height noise parameters) noise_params 0, 10, (250, 250, 250), 84174, 4, 0.5, 2.0
 mgv5_np_cave1 (Mapgen v5 cave1 noise parameters) noise_params 0, 12, (50, 50, 50), 52534, 4, 0.5, 2.0
 mgv5_np_cave2 (Mapgen v5 cave2 noise parameters) noise_params 0, 12, (50, 50, 50), 10325, 4, 0.5, 2.0
+mgv5_np_cavern (Mapgen v5 cavern noise parameters) noise_params 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 #    TODO
+#    Noise parameters in group format, unsupported by advanced settings
+#    menu but settable in minetest.conf.
+#    See documentation of noise parameter formats in minetest.conf.example.
 #mgv5_np_ground = {
 #    offset      = 0
 #    scale       = 40
@@ -1010,6 +1023,15 @@ mgv7_floatland_level (Mapgen v7 floatland level) int 1280
 #    Y-level to which floatland shadows extend.
 mgv7_shadow_limit (Mapgen v7 shadow limit) int 1024
 
+#    Y-level of cavern upper limit.
+mgv7_cavern_limit (Mapgen v7 cavern limit) int -256
+
+#    Y-distance over which caverns expand to full size.
+mgv7_cavern_taper (Mapgen v7 cavern taper) int 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+mgv7_cavern_threshold (Mapgen v7 cavern threshold) float 0.7
+
 mgv7_np_terrain_base (Mapgen v7 terrain base noise parameters) noise_params 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 mgv7_np_terrain_alt (Mapgen v7 terrain altitude noise parameters) noise_params 4, 25, (600, 600, 600), 5934, 5, 0.6, 2.0
 mgv7_np_terrain_persist (Mapgen v7 terrain persistation noise parameters) noise_params 0.6, 0.1, (2000, 2000, 2000), 539, 3, 0.6, 2.0
@@ -1021,6 +1043,7 @@ mgv7_np_floatland_base (Mapgen v7 floatland base terrain noise parameters) noise
 mgv7_np_float_base_height (Mapgen v7 floatland base terrain height noise parameters) noise_params 48, 24, (300, 300, 300), 907, 4, 0.7, 2.0
 mgv7_np_mountain (Mapgen v7 mountain noise parameters) noise_params -0.6, 1, (250, 350, 250), 5333, 5, 0.63, 2.0
 mgv7_np_ridge (Mapgen v7 river channel wall noise parameters) noise_params 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+mgv7_np_cavern (Mapgen v7 cavern noise parameters) noise_params 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 mgv7_np_cave1 (Mapgen v7 cave1 noise parameters) noise_params 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 mgv7_np_cave2 (Mapgen v7 cave2 noise parameters) noise_params 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1177,6 +1177,18 @@ server_side_occlusion_culling = true
 #    type: float
 # mgv5_cave_width = 0.125
 
+#    Y-level of cavern upper limit.
+#    type: int
+# mgv5_cavern_limit = -256
+
+#    Y-distance over which caverns expand to full size.
+#    type: int
+# mgv5_cavern_taper = 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+#    type: float
+# mgv5_cavern_threshold = 0.7
+
 #    type: noise_params
 # mgv5_np_filler_depth = 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 
@@ -1191,6 +1203,9 @@ server_side_occlusion_culling = true
 
 #    type: noise_params
 # mgv5_np_cave2 = 0, 12, (50, 50, 50), 10325, 4, 0.5, 2.0
+
+#    type: noise_params
+# mgv5_np_cavern = 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    Noise parameters in group format, unsupported by advanced settings
 #    menu but settable in minetest.conf.
@@ -1287,6 +1302,18 @@ server_side_occlusion_culling = true
 #    type: int
 # mgv7_shadow_limit = 1024
 
+#    Y-level of cavern upper limit.
+#    type: int
+# mgv7_cavern_limit = -256
+
+#    Y-distance over which caverns expand to full size.
+#    type: int
+# mgv7_cavern_taper = 256
+
+#    Defines full size of caverns, smaller values create larger caverns.
+#    type: float
+# mgv7_cavern_threshold = 0.7
+
 #    type: noise_params
 # mgv7_np_terrain_base = 4, 70, (600, 600, 600), 82341, 5, 0.6, 2.0
 
@@ -1319,6 +1346,9 @@ server_side_occlusion_culling = true
 
 #    type: noise_params
 # mgv7_np_ridge = 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+
+#    type: noise_params
+# mgv7_np_cavern = 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
 #    type: noise_params
 # mgv7_np_cave1 = 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0

--- a/src/cavegen.cpp
+++ b/src/cavegen.cpp
@@ -151,6 +151,101 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 
 
 ////
+//// CavernsNoise
+////
+
+CavernsNoise::CavernsNoise(
+	INodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
+	s32 seed, float cavern_limit, float cavern_taper, float cavern_threshold)
+{
+	assert(nodedef);
+
+	m_ndef = nodedef;
+
+	m_csize = chunksize;
+	m_cavern_limit     = cavern_limit;
+	m_cavern_taper     = cavern_taper;
+	m_cavern_threshold = cavern_threshold;
+
+	m_ystride = m_csize.X;
+	m_zstride_1d = m_csize.X * (m_csize.Y + 1);
+
+	// Noise is created using 1-down overgeneration
+	// A Nx-by-1-by-Nz-sized plane is at the bottom of the desired for
+	// re-carving the solid overtop placed for blocking sunlight
+	noise_cavern = new Noise(np_cavern, seed, m_csize.X, m_csize.Y + 1, m_csize.Z);
+
+	c_water_source = m_ndef->getId("mapgen_water_source");
+	if (c_water_source == CONTENT_IGNORE)
+		c_water_source = CONTENT_AIR;
+
+	c_lava_source = m_ndef->getId("mapgen_lava_source");
+	if (c_lava_source == CONTENT_IGNORE)
+		c_lava_source = CONTENT_AIR;
+}
+
+
+CavernsNoise::~CavernsNoise()
+{
+	delete noise_cavern;
+}
+
+
+bool CavernsNoise::generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax)
+{
+	assert(vm);
+
+	// Calculate noise
+	noise_cavern->perlinMap3D(nmin.X, nmin.Y - 1, nmin.Z);
+
+	// Cache cavern_amp values
+	float cavern_amp[m_csize.Y + 1];
+	u8 cavern_amp_index = 0;  // Index zero at column top
+	for (s16 y = nmax.Y; y >= nmin.Y - 1; y--, cavern_amp_index++) {
+		cavern_amp[cavern_amp_index] =
+			MYMIN((m_cavern_limit - y) / (float)m_cavern_taper, 1.0f);
+	}
+
+	//// Place nodes
+	bool has_cavern = false;
+	v3s16 em = vm->m_area.getExtent();
+	u32 index2d = 0;
+
+	for (s16 z = nmin.Z; z <= nmax.Z; z++)
+	for (s16 x = nmin.X; x <= nmax.X; x++, index2d++) {
+		// Reset cave_amp index to column top
+		cavern_amp_index = 0;
+		// Initial voxelmanip index at column top
+		u32 vi = vm->m_area.index(x, nmax.Y, z);
+		// Initial 3D noise index at column top
+		u32 index3d = (z - nmin.Z) * m_zstride_1d + m_csize.Y * m_ystride +
+			(x - nmin.X);
+		// Don't excavate the overgenerated stone at node_max.Y + 1,
+		// this creates a 'roof' over the cavern, preventing light in
+		// caverns at mapchunk borders when generating mapchunks upwards.
+		// This 'roof' is excavated when the mapchunk above is generated.
+		for (s16 y = nmax.Y; y >= nmin.Y - 1; y--,
+				index3d -= m_ystride,
+				vm->m_area.add_y(em, vi, -1),
+				cavern_amp_index++) {			
+			content_t c = vm->m_data[vi].getContent();
+			float nabs_cavern = fabs(noise_cavern->result[index3d]);
+			// Caverns generate first but still remove lava and water in case
+			// of overgenerated classic caves.
+			if (nabs_cavern * cavern_amp[cavern_amp_index] > m_cavern_threshold &&
+					(m_ndef->get(c).is_ground_content ||
+					c == c_lava_source || c == c_water_source)) {
+				vm->m_data[vi] = MapNode(CONTENT_AIR);
+				has_cavern = true;
+			}
+		}
+	}
+
+	return has_cavern;
+}
+
+
+////
 //// CavesRandomWalk
 ////
 

--- a/src/cavegen.h
+++ b/src/cavegen.h
@@ -63,6 +63,36 @@ private:
 };
 
 /*
+	CavernsNoise is a cave digging algorithm
+*/
+class CavernsNoise {
+public:
+	CavernsNoise(INodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
+	s32 seed, float cavern_limit, float cavern_taper, float cavern_threshold);
+	~CavernsNoise();
+
+	bool generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax);
+
+private:
+	INodeDefManager *m_ndef;
+
+	// configurable parameters
+	v3s16 m_csize;
+	float m_cavern_limit;
+	float m_cavern_taper;
+	float m_cavern_threshold;
+
+	// intermediate state variables
+	u16 m_ystride;
+	u16 m_zstride_1d;
+
+	Noise *noise_cavern;
+
+	content_t c_water_source;
+	content_t c_lava_source;
+};
+
+/*
 	CavesRandomWalk is an implementation of a cave-digging algorithm that
 	operates on the principle of a "random walk" to approximate the stochiastic
 	activity of cavern development.

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -838,6 +838,18 @@ void MapgenBasic::generateCaves(s16 max_stone_y, s16 large_cave_depth)
 }
 
 
+bool MapgenBasic::generateCaverns(s16 max_stone_y)
+{
+	if (node_min.Y > max_stone_y || node_min.Y > cavern_limit)
+		return false;
+
+	CavernsNoise caverns_noise(ndef, csize, &np_cavern,
+		seed, cavern_limit, cavern_taper, cavern_threshold);
+
+	return caverns_noise.generateCaverns(vm, node_min, node_max);
+}
+
+
 void MapgenBasic::generateDungeons(s16 max_stone_y, MgStoneType stone_type)
 {
 	if (max_stone_y < node_min.Y)

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -240,6 +240,7 @@ public:
 	virtual ~MapgenBasic();
 
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
+	virtual bool generateCaverns(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y, MgStoneType stone_type);
 	virtual MgStoneType generateBiomes();
 	virtual void dustTopNodes();
@@ -279,7 +280,11 @@ protected:
 
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
+	NoiseParams np_cavern;
 	float cave_width;
+	float cavern_limit;
+	float cavern_taper;
+	float cavern_threshold;
 };
 
 #endif

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -25,6 +25,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MGV5_LARGE_CAVE_DEPTH -256
 
+///////// Mapgen V5 flags
+#define MGV5_CAVERNS 0x01
+
 class BiomeManager;
 
 extern FlagDesc flagdesc_mapgen_v5[];
@@ -33,12 +36,17 @@ extern FlagDesc flagdesc_mapgen_v5[];
 struct MapgenV5Params : public MapgenParams {
 	u32 spflags;
 	float cave_width;
+	s16 cavern_limit;
+	s16 cavern_taper;
+	float cavern_threshold;
+
 	NoiseParams np_filler_depth;
 	NoiseParams np_factor;
 	NoiseParams np_height;
+	NoiseParams np_ground;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
-	NoiseParams np_ground;
+	NoiseParams np_cavern;
 
 	MapgenV5Params();
 	~MapgenV5Params() {}

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -23,10 +23,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-////////////// Mapgen V7 flags
-#define MGV7_MOUNTAINS    0x01
-#define MGV7_RIDGES       0x02
-#define MGV7_FLOATLANDS   0x04
+//////////// Mapgen V7 flags
+#define MGV7_MOUNTAINS  0x01
+#define MGV7_RIDGES     0x02
+#define MGV7_FLOATLANDS 0x04
+#define MGV7_CAVERNS    0x08
 
 class BiomeManager;
 
@@ -40,6 +41,9 @@ struct MapgenV7Params : public MapgenParams {
 	float float_mount_height;
 	s16 floatland_level;
 	s16 shadow_limit;
+	s16 cavern_limit;
+	s16 cavern_taper;
+	float cavern_threshold;
 
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_alt;
@@ -52,6 +56,7 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_float_base_height;
 	NoiseParams np_mountain;
 	NoiseParams np_ridge;
+	NoiseParams np_cavern;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 


### PR DESCRIPTION
Add to MapgenBasic for use by multiple mapgens.
Add to mgv5 and mgv7.
Similar to mgvalleys caverns but half the scale.
Parameters for upper y limit, distance caverns taper to full size, and
noise threshold (full cavern size).
As with mgvalleys caverns are generated first and classic caves are
disabled in any mapchunk containing a cavern, to avoid excessive
spreading volumes of liquids.
This also avoids floating blobs of liquid where a large classic cave
has overgenerated out into a neighbouring previously-generated mapchunk.
////////////////////////////////////////////////////////

![screenshot_3524895488](https://cloud.githubusercontent.com/assets/3686677/23869620/88af88ba-081b-11e7-825f-bf88c5caede6.png)

^ Screenshot is from my 'subterrain' mod but structure is identical to this PR

See #5380 
I have noticed that the 3D noise giant caverns in mgvalleys are very popular, this PR adds these to MapgenBasic for use in any mapgen.
In mgv7 there will be no performance problems because the 3D noises for mountains and rivers are not calculated underground, so i can add a cavern 3D noise.

These are scaled smaller than the caverns in mgvalleys, big is good but 768 nodes is just too big for a cavern, the scale has been halved. Otherwise identical.

There are parameters for the upper limit of caverns (default -256), taper distance to full size (default 256) and the noise threshold (size of caverns and what proportion of the underground volume they take up).