### PR TITLE
avoid crashing when accessing mapgen early

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -174,6 +174,9 @@ bool EmergeManager::initMapgens(MapgenParams *params)
 
 Mapgen *EmergeManager::getCurrentMapgen()
 {
+	if (!m_threads_active)
+		return NULL;
+
 	for (u32 i = 0; i != m_threads.size(); i++) {
 		if (m_threads[i]->isCurrentThread())
 			return m_threads[i]->m_mapgen;


### PR DESCRIPTION
Due to the delayed invocation of EmergeManager::startThreads on server startup, EmergeManager::getCurrentMapgen can cause a segmentation fault when being called early (for example from a mod). The committed patch fixes this by checking for thread initialization first.

It may be even better if lua scripts could conditionalize code according to server initialization progress, but in any case, mods should not be able to cause a segmentation fault.