### PR TITLE
FormSpec: support custom colors in dropdown

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -149,7 +149,9 @@ LOCAL_SRC_FILES := \
 		jni/src/genericobject.cpp                 \
 		jni/src/gettext.cpp                       \
 		jni/src/guiChatConsole.cpp                \
+		jni/src/guiComboBox.cpp                   \
 		jni/src/guiEngine.cpp                     \
+		jni/src/guiListBox.cpp                    \
 		jni/src/guiFileSelectMenu.cpp             \
 		jni/src/guiFormSpecMenu.cpp               \
 		jni/src/guiKeyChangeMenu.cpp              \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1728,7 +1728,7 @@ examples.
 * `w` and `h` are the size of box
 * `color` is color specified as a `ColorString`
 
-#### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
+#### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>;<bg_color>;<selected_item_color>]`
 * Show a dropdown field
 * **Important note**: There are two different operation modes:
      1. handle directly on change (only changed dropdown is submitted)
@@ -1738,6 +1738,8 @@ examples.
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
+* `bg_color`is the background color of the dropdown
+* `selected_item_color` is the color of the selected item
 
 #### `checkbox[<X>,<Y>;<name>;<label>;<selected>]`
 * Show a checkbox

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -527,7 +527,9 @@ set(client_SRCS
 	fontengine.cpp
 	game.cpp
 	guiChatConsole.cpp
+	guiComboBox.cpp
 	guiEngine.cpp
+	guiListBox.cpp
 	guiFileSelectMenu.cpp
 	guiFormSpecMenu.cpp
 	guiKeyChangeMenu.cpp

--- a/src/guiComboBox.cpp
+++ b/src/guiComboBox.cpp
@@ -1,0 +1,573 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt, Modified by Mustapha Tachouct
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+
+
+#include "guiComboBox.h"
+
+#include "IGUIEnvironment.h"
+#include "IVideoDriver.h"
+#include "IGUISkin.h"
+#include "IGUIEnvironment.h"
+#include "IGUIFont.h"
+#include "IGUIButton.h"
+#include "guiListBox.h"
+
+using namespace irr;
+using namespace irr::gui;
+using namespace irr::core;
+
+class IGUIButton;
+class IGUIListBox;
+
+//! constructor
+GUIComboBox::GUIComboBox(IGUIEnvironment *environment, IGUIElement *parent,
+	s32 id, core::rect<s32> rectangle)
+	: IGUIComboBox(environment, parent, id, rectangle),
+	m_list_button(NULL), m_selected_text(NULL), m_listbox(NULL), m_last_focus(NULL),
+	m_selected(-1), m_halign(EGUIA_UPPERLEFT), m_valign(EGUIA_CENTER),
+	m_max_selection_rows(5), m_has_focus(false),
+	m_bg_color_used(false), m_bg_color(video::SColor(0)),
+	m_selected_item_color_used(false), m_selected_item_color(video::SColor(0))
+
+{
+#ifdef _DEBUG
+	setDebugName("CGUIComboBox");
+#endif
+
+	IGUISkin* skin = Environment->getSkin();
+
+	s32 width = 15;
+	if (skin)
+		width = skin->getSize(EGDS_WINDOW_BUTTON_WIDTH);
+
+	core::rect<s32> r;
+	r.UpperLeftCorner.X = rectangle.getWidth() - width - 2;
+	r.LowerRightCorner.X = rectangle.getWidth() - 2;
+
+	r.UpperLeftCorner.Y = 2;
+	r.LowerRightCorner.Y = rectangle.getHeight() - 2;
+
+	m_list_button = Environment->addButton(r, this, -1, L"");
+	if (skin && skin->getSpriteBank()) {
+		m_list_button->setSpriteBank(skin->getSpriteBank());
+		m_list_button->setSprite(EGBS_BUTTON_UP,
+			skin->getIcon(EGDI_CURSOR_DOWN),
+			skin->getColor(EGDC_WINDOW_SYMBOL));
+		m_list_button->setSprite(EGBS_BUTTON_DOWN,
+			skin->getIcon(EGDI_CURSOR_DOWN),
+			skin->getColor(EGDC_WINDOW_SYMBOL));
+	}
+	m_list_button->setAlignment(EGUIA_LOWERRIGHT,
+		EGUIA_LOWERRIGHT, EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT);
+	m_list_button->setSubElement(true);
+	m_list_button->setTabStop(false);
+
+	r.UpperLeftCorner.X = 2;
+	r.UpperLeftCorner.Y = 2;
+	r.LowerRightCorner.X = RelativeRect.getWidth() -
+		(m_list_button->getAbsolutePosition().getWidth() + 2);
+	r.LowerRightCorner.Y = RelativeRect.getHeight() - 2;
+
+	m_selected_text = Environment->addStaticText(L"", r, false, false,
+		this, -1, false);
+	m_selected_text->setSubElement(true);
+	m_selected_text->setAlignment(EGUIA_UPPERLEFT,
+		EGUIA_LOWERRIGHT, EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT);
+	m_selected_text->setTextAlignment(EGUIA_UPPERLEFT, EGUIA_CENTER);
+	if (skin)
+		m_selected_text->setOverrideColor(skin->getColor(EGDC_BUTTON_TEXT));
+	m_selected_text->enableOverrideColor(true);
+
+	// this element can be tabbed to
+	setTabStop(true);
+	setTabOrder(-1);
+}
+
+
+void GUIComboBox::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical)
+{
+	m_halign = horizontal;
+	m_valign = vertical;
+	m_selected_text->setTextAlignment(horizontal, vertical);
+}
+
+
+//! Set the maximal number of rows for the selection listbox
+void GUIComboBox::setMaxSelectionRows(u32 max)
+{
+	m_max_selection_rows = max;
+
+	// force recalculation of open listbox
+	if (m_listbox) {
+		openCloseMenu();
+		openCloseMenu();
+	}
+}
+
+//! Get the maximimal number of rows for the selection listbox
+u32 GUIComboBox::getMaxSelectionRows() const
+{
+	return m_max_selection_rows;
+}
+
+
+//! Returns amount of items in box
+u32 GUIComboBox::getItemCount() const
+{
+	return m_items.size();
+}
+
+
+//! returns string of an item. the idx may be a value from 0 to itemCount-1
+const wchar_t* GUIComboBox::getItem(u32 idx) const
+{
+	if (idx >= m_items.size())
+		return 0;
+
+	return m_items[idx].name.c_str();
+}
+
+//! returns string of an item. the idx may be a value from 0 to itemCount-1
+u32 GUIComboBox::getItemData(u32 idx) const
+{
+	if (idx >= m_items.size())
+		return 0;
+
+	return m_items[idx].data;
+}
+
+//! Returns index based on item data
+s32 GUIComboBox::getIndexForItemData(u32 data) const
+{
+	for (u32 i = 0; i < m_items.size(); ++i) {
+		if (m_items[i].data == data)
+			return i;
+	}
+	return -1;
+}
+
+
+//! Removes an item from the combo box.
+void GUIComboBox::removeItem(u32 idx)
+{
+	if (idx >= m_items.size())
+		return;
+
+	if (m_selected == (s32)idx)
+		setSelected(-1);
+
+	m_items.erase(m_items.begin() + idx);
+}
+
+
+//! Returns caption of this element.
+const wchar_t* GUIComboBox::getText() const
+{
+	return getItem(m_selected);
+}
+
+
+//! adds an item and returns the index of it
+u32 GUIComboBox::addItem(const wchar_t* text, u32 data)
+{
+	m_items.push_back(SComboData(text, data));
+
+	if (m_selected == -1)
+		setSelected(0);
+
+	return m_items.size() - 1;
+}
+
+
+//! deletes all items in the combo box
+void GUIComboBox::clear()
+{
+	m_items.clear();
+	setSelected(-1);
+}
+
+
+//! returns id of selected item. returns -1 if no item is selected.
+s32 GUIComboBox::getSelected() const
+{
+	return m_selected;
+}
+
+
+//! sets the selected item. Set this to -1 if no item should be selected
+void GUIComboBox::setSelected(s32 idx)
+{
+	if (idx < -1 || idx >= (s32)m_items.size())
+		return;
+
+	m_selected = idx;
+	if (m_selected == -1)
+		m_selected_text->setText(L"");
+	else
+		m_selected_text->setText(m_items[m_selected].name.c_str());
+}
+
+
+//! called if an event happened.
+bool GUIComboBox::OnEvent(const SEvent& event)
+{
+	if (isEnabled()) {
+		switch (event.EventType) {
+		case EET_KEY_INPUT_EVENT:
+			if (m_listbox && event.KeyInput.PressedDown && event.KeyInput.Key == KEY_ESCAPE) {
+				// hide list box
+				openCloseMenu();
+				return true;
+			}
+			else
+				if (event.KeyInput.Key == KEY_RETURN || event.KeyInput.Key == KEY_SPACE) {
+					if (!event.KeyInput.PressedDown) {
+						openCloseMenu();
+					}
+
+					m_list_button->setPressed(m_listbox == 0);
+
+					return true;
+				}
+				else if (event.KeyInput.PressedDown) {
+					s32 old_selected = m_selected;
+					bool absorb = true;
+					switch (event.KeyInput.Key) {
+					case KEY_DOWN:
+						setSelected(m_selected + 1);
+						break;
+					case KEY_UP:
+						setSelected(m_selected - 1);
+						break;
+					case KEY_HOME:
+					case KEY_PRIOR:
+						setSelected(0);
+						break;
+					case KEY_END:
+					case KEY_NEXT:
+						setSelected((s32)m_items.size() - 1);
+						break;
+					default:
+						absorb = false;
+					}
+
+					if (m_selected < 0)
+						setSelected(0);
+
+					if (m_selected >= (s32)m_items.size())
+						setSelected((s32)m_items.size() - 1);
+
+					if (m_selected != old_selected) {
+						sendSelectionChangedEvent();
+						return true;
+					}
+
+					if (absorb)
+						return true;
+				}
+				break;
+
+		case EET_GUI_EVENT:
+
+			switch (event.GUIEvent.EventType) {
+			case EGET_ELEMENT_FOCUS_LOST:
+				if (m_listbox &&
+					(Environment->hasFocus(m_listbox)
+					|| m_listbox->isMyChild(event.GUIEvent.Caller))	&&
+					event.GUIEvent.Element != this &&
+					!isMyChild(event.GUIEvent.Element) &&
+					!m_listbox->isMyChild(event.GUIEvent.Element)) {
+					openCloseMenu();
+				}
+				break;
+			case EGET_BUTTON_CLICKED:
+				if (event.GUIEvent.Caller == m_list_button) {
+					openCloseMenu();
+					return true;
+				}
+				break;
+			case EGET_LISTBOX_SELECTED_AGAIN:
+			case EGET_LISTBOX_CHANGED:
+				if (event.GUIEvent.Caller == m_listbox) {
+					setSelected(m_listbox->getSelected());
+					if (m_selected < 0 || m_selected >= (s32)m_items.size())
+						setSelected(-1);
+					openCloseMenu();
+
+					sendSelectionChangedEvent();
+				}
+				return true;
+			default:
+				break;
+			}
+			break;
+		case EET_MOUSE_INPUT_EVENT:
+
+			switch (event.MouseInput.Event) {
+			case EMIE_LMOUSE_PRESSED_DOWN:
+			{
+				core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
+
+				// send to list box
+				if (m_listbox && m_listbox->isPointInside(p) && m_listbox->OnEvent(event))
+					return true;
+
+				return true;
+			}
+			case EMIE_LMOUSE_LEFT_UP:
+			{
+				core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
+
+				// send to list box
+				if (!(m_listbox &&
+					m_listbox->getAbsolutePosition().isPointInside(p) &&
+					m_listbox->OnEvent(event)))
+				{
+					openCloseMenu();
+				}
+				return true;
+			}
+			case EMIE_MOUSE_WHEEL:
+			{
+				s32 old_selected = m_selected;
+				s32 mouse_wheel_inc = event.MouseInput.Wheel < 0 ? 1 : -1;
+				setSelected(m_selected + mouse_wheel_inc);
+
+				if (m_selected < 0)
+					setSelected(0);
+
+				if (m_selected >= (s32)m_items.size())
+					setSelected((s32)m_items.size() - 1);
+
+				if (m_selected != old_selected) {
+					sendSelectionChangedEvent();
+					return true;
+				}
+			}
+			default:
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	return IGUIElement::OnEvent(event);
+}
+
+
+void GUIComboBox::sendSelectionChangedEvent()
+{
+	if (Parent) {
+		SEvent event;
+
+		event.EventType = EET_GUI_EVENT;
+		event.GUIEvent.Caller = this;
+		event.GUIEvent.Element = 0;
+		event.GUIEvent.EventType = EGET_COMBO_BOX_CHANGED;
+		Parent->OnEvent(event);
+	}
+}
+
+
+//! draws the element and its children
+void GUIComboBox::draw()
+{
+	if (!IsVisible)
+		return;
+
+	IGUISkin* skin = Environment->getSkin();
+	IGUIElement *currentFocus = Environment->getFocus();
+	if (currentFocus != m_last_focus) {
+		m_has_focus = currentFocus == this || isMyChild(currentFocus);
+		m_last_focus = currentFocus;
+	}
+
+	// set colors each time as skin-colors can be changed
+	m_selected_text->setBackgroundColor(
+		m_selected_item_color_used ?
+		m_selected_item_color : skin->getColor(EGDC_HIGH_LIGHT));
+	if (isEnabled()) {
+		m_selected_text->setDrawBackground(m_has_focus);
+		m_selected_text->setOverrideColor(
+			skin->getColor(m_has_focus ?
+				EGDC_HIGH_LIGHT_TEXT : EGDC_BUTTON_TEXT));
+	}
+	else {
+		m_selected_text->setDrawBackground(false);
+		m_selected_text->setOverrideColor(skin->getColor(EGDC_GRAY_TEXT));
+	}
+	
+	video::SColor enabled_color = skin->getColor(EGDC_WINDOW_SYMBOL);
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8
+	video::SColor disabled_color(240, 100, 100, 100);
+#else
+	video::SColor disabled_color = skin->getColor(EGDC_GRAY_WINDOW_SYMBOL);
+#endif
+
+
+	m_list_button->setSprite(EGBS_BUTTON_UP,
+		skin->getIcon(EGDI_CURSOR_DOWN),
+		isEnabled() ? enabled_color : disabled_color);
+	m_list_button->setSprite(EGBS_BUTTON_DOWN,
+		skin->getIcon(EGDI_CURSOR_DOWN),
+		isEnabled() ? enabled_color : disabled_color);
+
+
+	core::rect<s32> frameRect(AbsoluteRect);
+
+	// draw the border
+
+	skin->draw3DSunkenPane(this,
+		m_bg_color_used ? m_bg_color : skin->getColor(EGDC_3D_HIGH_LIGHT),
+		true, true, frameRect, &AbsoluteClippingRect);
+
+	// draw children
+	IGUIElement::draw();
+}
+
+
+void GUIComboBox::openCloseMenu()
+{
+	if (m_listbox) {
+		// close list box
+		Environment->setFocus(this);
+		m_listbox->remove();
+		m_listbox = 0;
+	}
+	else {
+		if (Parent)
+			Parent->bringToFront(this);
+
+		IGUISkin* skin = Environment->getSkin();
+		u32 h = m_items.size();
+
+		if (h > getMaxSelectionRows())
+			h = getMaxSelectionRows();
+		if (h == 0)
+			h = 1;
+
+		irr::gui::IGUIFont *font = skin->getFont();
+		if (font)
+			h *= (font->getDimension(L"A").Height + 4);
+
+		// open list box
+		core::rect<s32> r(0, AbsoluteRect.getHeight(),
+			AbsoluteRect.getWidth(), AbsoluteRect.getHeight() + h);
+
+		m_listbox = new GUIListBox(Environment, this, -1, r, false, true, true);
+
+		if (m_bg_color_used) {
+			m_listbox->setBackgroundColor(m_bg_color);
+		}
+
+		if (m_bg_color_used) {
+			m_listbox->setSelectedItemColor(m_selected_item_color);
+		}
+
+		m_listbox->setSubElement(true);
+		m_listbox->setNotClipped(true);
+		//ListBox->drop();
+
+
+		// ensure that list box is always completely visible
+		irr::s32 y = m_listbox->getAbsolutePosition().LowerRightCorner.Y;
+		irr::s32 height = Environment->getRootGUIElement()->
+			getAbsolutePosition().getHeight();
+		if (y > height) {
+			core::rect<s32> rect(0,
+				-m_listbox->getAbsolutePosition().getHeight(),
+				AbsoluteRect.getWidth(), 0);
+
+			m_listbox->setRelativePosition(rect);
+		}
+
+		for (s32 i = 0; i < (s32)m_items.size(); ++i)
+			m_listbox->addItem(m_items[i].name.c_str());
+
+		m_listbox->setSelected(m_selected);
+
+		// set focus
+		Environment->setFocus(m_listbox);
+	}
+}
+
+
+//! Change the selected item color
+void GUIComboBox::setSelectedItemColor(const video::SColor &color)
+{
+	m_selected_item_color_used = true;
+	m_selected_item_color = color;
+}
+
+
+//! Change the background color
+void GUIComboBox::setBackgroundColor(const video::SColor &color)
+{
+	m_bg_color_used = true;
+	m_bg_color = color;
+}
+
+
+//! Writes attributes of the element.
+void GUIComboBox::serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options = 0) const
+{
+	IGUIComboBox::serializeAttributes(out, options);
+
+	out->addEnum("HTextAlign", m_halign, GUIAlignmentNames);
+	out->addEnum("VTextAlign", m_valign, GUIAlignmentNames);
+	out->addInt("MaxSelectionRows", (s32)m_max_selection_rows);
+
+	out->addInt("Selected", m_selected);
+
+	out->addBool("BackgroundColorUsed", m_bg_color_used);
+	out->addColor("BackgroundColor", m_bg_color);
+
+	out->addBool("SelectedItemColorUsed", m_selected_item_color_used);
+	out->addColor("SelectedItemColor", m_selected_item_color);
+
+	out->addInt("ItemCount", m_items.size());
+	for (u32 i = 0; i < m_items.size(); ++i) {
+		core::stringc s = "Item";
+		s += i;
+		s += "Text";
+		out->addString(s.c_str(), m_items[i].name.c_str());
+	}
+}
+
+
+//! Reads attributes of the element
+void GUIComboBox::deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options = 0)
+{
+	IGUIComboBox::deserializeAttributes(in, options);
+
+	setTextAlignment(
+		(EGUI_ALIGNMENT)in->getAttributeAsEnumeration("HTextAlign", GUIAlignmentNames),
+		(EGUI_ALIGNMENT)in->getAttributeAsEnumeration("VTextAlign", GUIAlignmentNames));
+	setMaxSelectionRows((u32)(in->getAttributeAsInt("MaxSelectionRows")));
+
+	m_bg_color_used = in->getAttributeAsBool("BackgroundColorUsed");
+	m_bg_color = in->getAttributeAsColor("BackgroundColor");
+
+	m_selected_item_color_used = in->getAttributeAsBool("SelectedItemColorUsed");
+	m_selected_item_color = in->getAttributeAsColor("SelectedItemColor");
+
+	// clear the list
+	clear();
+
+	// get item count
+	u32 c = in->getAttributeAsInt("ItemCount");
+
+	// add items
+	for (u32 i = 0; i < c; ++i) {
+		core::stringc s = "Item";
+		s += i;
+		s += "Text";
+		addItem(in->getAttributeAsStringW(s.c_str()).c_str(), 0);
+	}
+
+	setSelected(in->getAttributeAsInt("Selected"));
+}

--- a/src/guiComboBox.h
+++ b/src/guiComboBox.h
@@ -1,0 +1,123 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt, Modified by Mustapha Tachouct
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#ifndef GUICOMBOBOX_HEADER
+#define GUICOMBOBOX_HEADER
+
+#include "irrlichttypes_extrabloated.h"
+#include <IGUIComboBox.h>
+#include <IGUIStaticText.h>
+#include "guiListBox.h"
+#include <irrString.h>
+#include <irrArray.h>
+
+using namespace irr;
+using namespace irr::gui;
+
+class IGUIButton;
+class GUIListBox;
+
+//! Single line edit box for editing simple text.
+class GUIComboBox : public IGUIComboBox
+{
+public:
+
+	//! constructor
+	GUIComboBox(IGUIEnvironment *environment, IGUIElement *parent,
+		s32 id, core::rect<s32> rectangle);
+
+	//! Returns amount of items in box
+	virtual u32 getItemCount() const;
+
+	//! returns string of an item. the idx may be a value from 0 to itemCount-1
+	virtual const wchar_t* getItem(u32 idx) const;
+
+	//! Returns item data of an item. the idx may be a value from 0 to itemCount-1
+	virtual u32 getItemData(u32 idx) const;
+
+	//! Returns index based on item data
+	virtual s32 getIndexForItemData(u32 data) const;
+
+	//! adds an item and returns the index of it
+	virtual u32 addItem(const wchar_t *text, u32 data = 0);
+
+	//! Removes an item from the combo box.
+	virtual void removeItem(u32 id);
+
+	//! deletes all items in the combo box
+	virtual void clear();
+
+	//! returns the text of the currently selected item
+	virtual const wchar_t* getText() const;
+
+	//! returns id of selected item. returns -1 if no item is selected.
+	virtual s32 getSelected() const;
+
+	//! sets the selected item. Set this to -1 if no item should be selected
+	virtual void setSelected(s32 idx);
+
+	//! sets the text alignment of the text part
+	virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical);
+
+	//! Set the maximal number of rows for the selection listbox
+	virtual void setMaxSelectionRows(u32 max);
+
+	//! Get the maximimal number of rows for the selection listbox
+	virtual u32 getMaxSelectionRows() const;
+
+	//! called if an event happened.
+	virtual bool OnEvent(const SEvent &event);
+
+	//! draws the element and its children
+	virtual void draw();
+
+	//! Change the selected item color
+	virtual void setSelectedItemColor(const video::SColor &color);
+
+	//! Change the background color
+	virtual void setBackgroundColor(const video::SColor &color);
+
+	//! Writes attributes of the element.
+	virtual void serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options) const;
+
+	//! Reads attributes of the element
+	virtual void deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options);
+
+private:
+
+	void openCloseMenu();
+	void sendSelectionChangedEvent();
+
+	irr::gui::IGUIButton *m_list_button;
+	irr::gui::IGUIStaticText *m_selected_text;
+	GUIListBox *m_listbox;
+	irr::gui::IGUIElement *m_last_focus;
+
+
+	struct SComboData
+	{
+		SComboData(const wchar_t *text, u32 _data)
+			: name(text), data(_data) {}
+
+		core::stringw name;
+		u32 data;
+	};
+	std::vector<SComboData> m_items;
+
+	s32 m_selected;
+	EGUI_ALIGNMENT m_halign, m_valign;
+	u32 m_max_selection_rows;
+	bool m_has_focus;
+	
+	bool m_bg_color_used;
+	video::SColor m_bg_color;
+
+	bool m_selected_item_color_used;
+	video::SColor m_selected_item_color;
+};
+
+
+
+#endif // GUICOMBOBOX_HEADER
+

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -35,7 +35,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
 #include <IGUITabControl.h>
-#include <IGUIComboBox.h>
 #include "log.h"
 #include "client/tile.h" // ITextureSource
 #include "hud.h" // drawItemStack
@@ -52,6 +51,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h" // for parseColorString()
 #include "irrlicht_changes/static_text.h"
 #include "guiscalingfilter.h"
+#include "guiComboBox.h"
 
 #if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
 #include "intlGUIEditBox.h"
@@ -853,14 +853,19 @@ void GUIFormSpecMenu::parseDropDown(parserData* data,std::string element)
 {
 	std::vector<std::string> parts = split(element,';');
 
-	if ((parts.size() == 5) ||
-		((parts.size() > 5) && (m_formspec_version > FORMSPEC_API_VERSION)))
+	if ((parts.size() >= 5 && parts.size() <= 7) ||
+		((parts.size() > 7) && (m_formspec_version > FORMSPEC_API_VERSION)))
 	{
 		std::vector<std::string> v_pos = split(parts[0],',');
 		std::string name = parts[2];
 		std::vector<std::string> items = split(parts[3],',');
 		std::string str_initial_selection = "";
 		str_initial_selection = parts[4];
+		video::SColor bg_color;
+		bool has_bg_color = parts.size() > 5 && parseColorString(parts[5], bg_color, false);
+		video::SColor selected_item_color;
+		bool has_selected_item_color = parts.size() > 6 && parseColorString(parts[6], selected_item_color, false);
+				
 
 		MY_CHECKPOS("dropdown",0);
 
@@ -884,7 +889,15 @@ void GUIFormSpecMenu::parseDropDown(parserData* data,std::string element)
 		spec.send = true;
 
 		//now really show list
-		gui::IGUIComboBox *e = Environment->addComboBox(rect, this,spec.fid);
+		GUIComboBox* e = new GUIComboBox(Environment, this, spec.fid, rect);
+
+		if (has_bg_color) {
+			e->setBackgroundColor(bg_color);
+		}
+
+		if (has_selected_item_color) {
+			e->setSelectedItemColor(selected_item_color);
+		}
 
 		if (spec.fname == data->focused_fieldname) {
 			Environment->setFocus(e);

--- a/src/guiListBox.cpp
+++ b/src/guiListBox.cpp
@@ -1,0 +1,927 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt. Modified by Mustapha Tachouct
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#include "guiListBox.h"
+
+#include "IGUISkin.h"
+#include "IGUIEnvironment.h"
+#include "IVideoDriver.h"
+#include "IGUIFont.h"
+#include "IGUISpriteBank.h"
+#include "IGUIScrollBar.h"
+#include "porting.h"
+
+using namespace irr;
+using namespace irr::gui;
+
+
+//! constructor
+GUIListBox::GUIListBox(IGUIEnvironment *environment, IGUIElement *parent,
+	s32 id, core::rect<s32> rectangle, bool clip,
+	bool draw_back, bool move_over_select)
+	: IGUIListBox(environment, parent, id, rectangle), m_selected(-1),
+	m_item_height(0), m_item_height_override(0),
+	m_total_item_height(0), m_items_icon_width(0), m_font(0), m_icon_bank(0),
+	m_scrollbar(0), m_select_time(0), m_last_key_time(0), m_selecting(false), m_draw_back(draw_back),
+	m_move_over_select(move_over_select), m_autoscroll(true), m_highlight_when_not_focused(true),
+	m_bg_color_used(false), m_bg_color(video::SColor(0, 0, 0, 0)),
+	m_selected_item_color_used(false), m_selected_item_color(video::SColor(0, 0, 0, 0))
+{
+#ifdef _DEBUG
+	setDebugName("GUIListBox");
+#endif
+
+	IGUISkin* skin = Environment->getSkin();
+	const s32 s = skin->getSize(EGDS_SCROLLBAR_SIZE);
+
+	core::rect<s32> scrollbar_rect(RelativeRect.getWidth() - s, 0,
+		RelativeRect.getWidth(), RelativeRect.getHeight());
+
+	m_scrollbar = Environment->addScrollBar(false, scrollbar_rect, this, -1);
+	m_scrollbar->setSubElement(true);
+	m_scrollbar->setTabStop(false);
+	m_scrollbar->setAlignment(EGUIA_LOWERRIGHT, EGUIA_LOWERRIGHT,
+		EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT);
+	m_scrollbar->setVisible(false);
+	m_scrollbar->setPos(0);
+
+	setNotClipped(!clip);
+
+	// this element can be tabbed to
+	setTabStop(true);
+	setTabOrder(-1);
+
+	updateAbsolutePosition();
+}
+
+
+//! destructor
+GUIListBox::~GUIListBox()
+{
+	if (m_scrollbar)
+		m_scrollbar->drop();
+
+	if (m_font)
+		m_font->drop();
+
+	if (m_icon_bank)
+		m_icon_bank->drop();
+}
+
+
+//! returns amount of list items
+u32 GUIListBox::getItemCount() const
+{
+	return m_items.size();
+}
+
+
+//! returns string of a list item. the may be a value from 0 to itemCount-1
+const wchar_t* GUIListBox::getListItem(u32 id) const
+{
+	if (id >= m_items.size())
+		return 0;
+
+	return m_items[id].text.c_str();
+}
+
+
+//! Returns the icon of an item
+s32 GUIListBox::getIcon(u32 id) const
+{
+	if (id >= m_items.size())
+		return -1;
+
+	return m_items[id].icon;
+}
+
+
+//! adds a list item, returns id of item
+u32 GUIListBox::addItem(const wchar_t* text)
+{
+	return addItem(text, -1);
+}
+
+
+//! adds a list item, returns id of item
+void GUIListBox::removeItem(u32 id)
+{
+	if (id >= m_items.size())
+		return;
+
+	if ((u32)m_selected == id)
+	{
+		m_selected = -1;
+	}
+	else if ((u32)m_selected > id)
+	{
+		m_selected -= 1;
+		m_select_time = porting::getTimeMs();
+	}
+
+	m_items.erase(m_items.begin() + id);
+
+	recalculateItemHeight();
+}
+
+
+s32 GUIListBox::getItemAt(s32 xpos, s32 ypos) const
+{
+	if (xpos < AbsoluteRect.UpperLeftCorner.X
+		|| xpos >= AbsoluteRect.LowerRightCorner.X
+		|| ypos < AbsoluteRect.UpperLeftCorner.Y
+		|| ypos >= AbsoluteRect.LowerRightCorner.Y
+		)
+		return -1;
+
+	if (m_item_height == 0)
+		return -1;
+
+	s32 item = ((ypos - AbsoluteRect.UpperLeftCorner.Y - 1) + m_scrollbar->getPos())
+		/ m_item_height;
+	if (item < 0 || item >= (s32)m_items.size())
+		return -1;
+
+	return item;
+}
+
+//! clears the list
+void GUIListBox::clear()
+{
+	m_items.clear();
+	m_items_icon_width = 0;
+	m_selected = -1;
+
+	if (m_scrollbar)
+		m_scrollbar->setPos(0);
+
+	recalculateItemHeight();
+}
+
+
+void GUIListBox::recalculateItemHeight()
+{
+	IGUISkin* skin = Environment->getSkin();
+
+	if (m_font != skin->getFont())
+	{
+		if (m_font)
+			m_font->drop();
+
+		m_font = skin->getFont();
+		if (0 == m_item_height_override)
+			m_item_height = 0;
+
+		if (m_font)
+		{
+			if (0 == m_item_height_override)
+				m_item_height = m_font->getDimension(L"A").Height + 4;
+
+			m_font->grab();
+		}
+	}
+
+	m_total_item_height = m_item_height * m_items.size();
+	m_scrollbar->setMax(core::max_(0, m_total_item_height - AbsoluteRect.getHeight()));
+	s32 minItemHeight = m_item_height > 0 ? m_item_height : 1;
+	m_scrollbar->setSmallStep(minItemHeight);
+	m_scrollbar->setLargeStep(2 * minItemHeight);
+
+	if (m_total_item_height <= AbsoluteRect.getHeight())
+		m_scrollbar->setVisible(false);
+	else
+		m_scrollbar->setVisible(true);
+}
+
+
+//! returns id of selected item. returns -1 if no item is selected.
+s32 GUIListBox::getSelected() const
+{
+	return m_selected;
+}
+
+
+//! sets the selected item. Set this to -1 if no item should be selected
+void GUIListBox::setSelected(s32 id)
+{
+	if ((u32)id >= m_items.size())
+		m_selected = -1;
+	else
+		m_selected = id;
+
+	m_select_time = porting::getTimeMs();
+
+	recalculateScrollPos();
+}
+
+//! sets the selected item. Set this to -1 if no item should be selected
+void GUIListBox::setSelected(const wchar_t *item)
+{
+	s32 index = -1;
+
+	if (item)
+	{
+		for (index = 0; index < (s32)m_items.size(); ++index)
+		{
+			if (m_items[index].text == item)
+				break;
+		}
+	}
+	setSelected(index);
+}
+
+//! called if an event happened.
+bool GUIListBox::OnEvent(const SEvent& event)
+{
+	if (isEnabled())
+	{
+		switch (event.EventType)
+		{
+		case EET_KEY_INPUT_EVENT:
+			if (event.KeyInput.PressedDown &&
+				(event.KeyInput.Key == KEY_DOWN ||
+					event.KeyInput.Key == KEY_UP ||
+					event.KeyInput.Key == KEY_HOME ||
+					event.KeyInput.Key == KEY_END ||
+					event.KeyInput.Key == KEY_NEXT ||
+					event.KeyInput.Key == KEY_PRIOR)) {
+				s32 oldSelected = m_selected;
+				switch (event.KeyInput.Key)
+				{
+				case KEY_DOWN:
+					m_selected += 1;
+					break;
+				case KEY_UP:
+					m_selected -= 1;
+					break;
+				case KEY_HOME:
+					m_selected = 0;
+					break;
+				case KEY_END:
+					m_selected = (s32)m_items.size() - 1;
+					break;
+				case KEY_NEXT:
+					m_selected += AbsoluteRect.getHeight() / m_item_height;
+					break;
+				case KEY_PRIOR:
+					m_selected -= AbsoluteRect.getHeight() / m_item_height;
+					break;
+				default:
+					break;
+				}
+				if (m_selected >= (s32)m_items.size())
+					m_selected = m_items.size() - 1;
+				else
+					if (m_selected < 0)
+						m_selected = 0;
+
+				recalculateScrollPos();
+
+				// post the news
+
+				if (oldSelected != m_selected && Parent && !m_selecting && !m_move_over_select) {
+					SEvent e;
+					e.EventType = EET_GUI_EVENT;
+					e.GUIEvent.Caller = this;
+					e.GUIEvent.Element = 0;
+					e.GUIEvent.EventType = EGET_LISTBOX_CHANGED;
+					Parent->OnEvent(e);
+				}
+
+				return true;
+			}
+			else
+				if (!event.KeyInput.PressedDown &&
+					(event.KeyInput.Key == KEY_RETURN
+						|| event.KeyInput.Key == KEY_SPACE)) {
+					if (Parent) {
+						SEvent e;
+						e.EventType = EET_GUI_EVENT;
+						e.GUIEvent.Caller = this;
+						e.GUIEvent.Element = 0;
+						e.GUIEvent.EventType = EGET_LISTBOX_SELECTED_AGAIN;
+						Parent->OnEvent(e);
+					}
+					return true;
+				}
+				else if (event.KeyInput.PressedDown && event.KeyInput.Char) {
+					// change selection based on text as it is typed.
+					u32 now = porting::getTimeMs();
+
+					if (now - m_last_key_time < 500) {
+						// add to key buffer if it isn't a key repeat
+						if (!(m_key_buffer.size() == 1
+							&& m_key_buffer[0] == event.KeyInput.Char)) {
+							m_key_buffer += L" ";
+							m_key_buffer[m_key_buffer.size() - 1] = event.KeyInput.Char;
+						}
+					}
+					else {
+						m_key_buffer = L" ";
+						m_key_buffer[0] = event.KeyInput.Char;
+					}
+					m_last_key_time = now;
+
+					// find the selected item, starting at the current selection
+					s32 start = m_selected;
+					// dont change selection if the key buffer matches the current item
+					if (m_selected > -1 && m_key_buffer.size() > 1) {
+						if (m_items[m_selected].text.size() >= m_key_buffer.size() &&
+							m_key_buffer.equals_ignore_case(
+								m_items[m_selected].text.subString(
+									0, m_key_buffer.size())))
+							return true;
+					}
+
+					s32 current;
+					for (current = start + 1; current < (s32)m_items.size(); ++current) {
+						if (m_items[current].text.size() >= m_key_buffer.size()) {
+							if (m_key_buffer.equals_ignore_case(m_items[current].text.subString(0, m_key_buffer.size()))) {
+								if (Parent && m_selected != current && !m_selecting && !m_move_over_select) {
+									SEvent e;
+									e.EventType = EET_GUI_EVENT;
+									e.GUIEvent.Caller = this;
+									e.GUIEvent.Element = 0;
+									e.GUIEvent.EventType = EGET_LISTBOX_CHANGED;
+									Parent->OnEvent(e);
+								}
+								setSelected(current);
+								return true;
+							}
+						}
+					}
+					for (current = 0; current <= start; ++current) {
+						if (m_items[current].text.size() >= m_key_buffer.size()) {
+							if (m_key_buffer.equals_ignore_case(
+								m_items[current].text.subString(0, m_key_buffer.size()))) {
+								if (Parent && m_selected != current &&
+									!m_selecting && !m_move_over_select) {
+									m_selected = current;
+									SEvent e;
+									e.EventType = EET_GUI_EVENT;
+									e.GUIEvent.Caller = this;
+									e.GUIEvent.Element = 0;
+									e.GUIEvent.EventType = EGET_LISTBOX_CHANGED;
+									Parent->OnEvent(e);
+								}
+								setSelected(current);
+								return true;
+							}
+						}
+					}
+
+					return true;
+				}
+				break;
+
+		case EET_GUI_EVENT:
+			switch (event.GUIEvent.EventType) {
+			case gui::EGET_SCROLL_BAR_CHANGED:
+				if (event.GUIEvent.Caller == m_scrollbar)
+					return true;
+				break;
+			case gui::EGET_ELEMENT_FOCUS_LOST:
+			{
+				if (event.GUIEvent.Caller == this)
+					m_selecting = false;
+			}
+			default:
+				break;
+			}
+			break;
+
+		case EET_MOUSE_INPUT_EVENT:
+		{
+			core::position2d<s32> p(event.MouseInput.X, event.MouseInput.Y);
+
+			switch (event.MouseInput.Event) {
+			case EMIE_MOUSE_WHEEL:
+			{
+				s32 mouse_wheel_inc = event.MouseInput.Wheel < 0 ? -1 : 1;
+				m_scrollbar->setPos(m_scrollbar->getPos()
+					+ mouse_wheel_inc * -m_item_height / 2);
+				return true;
+			}
+
+			case EMIE_LMOUSE_PRESSED_DOWN:
+			{
+				m_selecting = true;
+				return true;
+			}
+
+			case EMIE_LMOUSE_LEFT_UP:
+			{
+				m_selecting = false;
+
+				if (isPointInside(p))
+					selectNew(event.MouseInput.Y);
+
+				return true;
+			}
+
+			case EMIE_MOUSE_MOVED:
+				if (m_selecting || m_move_over_select) {
+					if (isPointInside(p)) {
+						selectNew(event.MouseInput.Y, true);
+						return true;
+					}
+				}
+			default:
+				break;
+			}
+		}
+		break;
+		case EET_LOG_TEXT_EVENT:
+		case EET_USER_EVENT:
+		case EET_JOYSTICK_INPUT_EVENT:
+		case irr::gui::EGUIET_FORCE_32_BIT:
+			break;
+		}
+	}
+
+	return IGUIElement::OnEvent(event);
+}
+
+
+void GUIListBox::selectNew(s32 ypos, bool onlyHover)
+{
+	u32 now = porting::getTimeMs(); //os::Timer::getTime();
+	s32 oldSelected = m_selected;
+
+	m_selected = getItemAt(AbsoluteRect.UpperLeftCorner.X, ypos);
+	if (m_selected < 0 && !m_items.empty())
+		m_selected = 0;
+
+	recalculateScrollPos();
+
+	gui::EGUI_EVENT_TYPE eventType = (m_selected == oldSelected &&
+		now < m_select_time + 500) ?
+			EGET_LISTBOX_SELECTED_AGAIN : EGET_LISTBOX_CHANGED;
+	m_select_time = now;
+	// post the news
+	if (Parent && !onlyHover) {
+		SEvent event;
+		event.EventType = EET_GUI_EVENT;
+		event.GUIEvent.Caller = this;
+		event.GUIEvent.Element = 0;
+		event.GUIEvent.EventType = eventType;
+		Parent->OnEvent(event);
+	}
+}
+
+
+//! Update the position and size of the listbox, and update the scrollbar
+void GUIListBox::updateAbsolutePosition()
+{
+	IGUIElement::updateAbsolutePosition();
+
+	recalculateItemHeight();
+}
+
+
+//! draws the element and its children
+void GUIListBox::draw()
+{
+	if (!IsVisible)
+		return;
+
+	recalculateItemHeight(); // if the font changed
+
+	IGUISkin* skin = Environment->getSkin();
+
+	core::rect<s32>* clipRect = 0;
+
+	// draw background
+	core::rect<s32> frameRect(AbsoluteRect);
+
+	// draw items
+
+	core::rect<s32> clientClip(AbsoluteRect);
+	clientClip.UpperLeftCorner.Y += 1;
+	clientClip.UpperLeftCorner.X += 1;
+	if (m_scrollbar->isVisible())
+		clientClip.LowerRightCorner.X = AbsoluteRect.LowerRightCorner.X
+		- skin->getSize(EGDS_SCROLLBAR_SIZE);
+	clientClip.LowerRightCorner.Y -= 1;
+	clientClip.clipAgainst(AbsoluteClippingRect);
+
+	skin->draw3DSunkenPane(this,
+		m_bg_color_used ? m_bg_color : skin->getColor(EGDC_3D_HIGH_LIGHT),
+		true, m_draw_back, frameRect, &AbsoluteClippingRect);
+
+	if (clipRect)
+		clientClip.clipAgainst(*clipRect);
+
+	frameRect = AbsoluteRect;
+	frameRect.UpperLeftCorner.X += 1;
+	if (m_scrollbar->isVisible())
+		frameRect.LowerRightCorner.X = AbsoluteRect.LowerRightCorner.X
+		- skin->getSize(EGDS_SCROLLBAR_SIZE);
+
+	frameRect.LowerRightCorner.Y = AbsoluteRect.UpperLeftCorner.Y + m_item_height;
+
+	frameRect.UpperLeftCorner.Y -= m_scrollbar->getPos();
+	frameRect.LowerRightCorner.Y -= m_scrollbar->getPos();
+
+	bool hl = m_highlight_when_not_focused ||
+		Environment->hasFocus(this) ||
+		Environment->hasFocus(m_scrollbar);
+
+	for (s32 i = 0; i < (s32)m_items.size(); ++i) {
+		if (frameRect.LowerRightCorner.Y >= AbsoluteRect.UpperLeftCorner.Y &&
+			frameRect.UpperLeftCorner.Y <= AbsoluteRect.LowerRightCorner.Y) {
+			if (i == m_selected && hl)
+				skin->draw2DRectangle(this,
+					m_selected_item_color_used ?
+					m_selected_item_color :
+					skin->getColor(EGDC_HIGH_LIGHT),
+					frameRect, &clientClip);
+
+			core::rect<s32> text_rect = frameRect;
+			text_rect.UpperLeftCorner.X += 3;
+
+			if (m_font)	{
+				if (m_icon_bank && (m_items[i].icon > -1)) {
+					core::position2di iconPos = text_rect.UpperLeftCorner;
+					iconPos.Y += text_rect.getHeight() / 2;
+					iconPos.X += m_items_icon_width / 2;
+
+					if (i == m_selected && hl) {
+						m_icon_bank->draw2DSprite((u32)m_items[i].icon, iconPos,
+							&clientClip,
+							hasItemOverrideColor(i, EGUI_LBC_ICON_HIGHLIGHT) ?
+							getItemOverrideColor(i, EGUI_LBC_ICON_HIGHLIGHT) :
+							getItemDefaultColor(EGUI_LBC_ICON_HIGHLIGHT),
+							m_select_time, porting::getTimeMs(), false, true);
+					} else {
+						m_icon_bank->draw2DSprite((u32)m_items[i].icon, iconPos,
+							&clientClip,
+							hasItemOverrideColor(i, EGUI_LBC_ICON) ?
+							getItemOverrideColor(i, EGUI_LBC_ICON) :
+							getItemDefaultColor(EGUI_LBC_ICON),
+							0, (i == m_selected) ? porting::getTimeMs() : 0, false, true);
+					}
+				}
+
+				text_rect.UpperLeftCorner.X += m_items_icon_width + 3;
+
+				if (i == m_selected && hl) {
+					m_font->draw(m_items[i].text.c_str(), text_rect,
+						hasItemOverrideColor(i, EGUI_LBC_TEXT_HIGHLIGHT) ?
+						getItemOverrideColor(i, EGUI_LBC_TEXT_HIGHLIGHT) :
+						getItemDefaultColor(EGUI_LBC_TEXT_HIGHLIGHT),
+						false, true, &clientClip);
+				} else {
+					m_font->draw(m_items[i].text.c_str(), text_rect,
+						hasItemOverrideColor(i, EGUI_LBC_TEXT) ?
+						getItemOverrideColor(i, EGUI_LBC_TEXT) :
+						getItemDefaultColor(EGUI_LBC_TEXT),
+						false, true, &clientClip);
+				}
+
+				text_rect.UpperLeftCorner.X -= m_items_icon_width + 3;
+			}
+		}
+
+		frameRect.UpperLeftCorner.Y += m_item_height;
+		frameRect.LowerRightCorner.Y += m_item_height;
+	}
+
+	IGUIElement::draw();
+}
+
+
+//! adds an list item with an icon
+u32 GUIListBox::addItem(const wchar_t* text, s32 icon)
+{
+	ListItem i;
+	i.text = text;
+	i.icon = icon;
+
+	m_items.push_back(i);
+	recalculateItemHeight();
+	recalculateItemWidth(icon);
+
+	return m_items.size() - 1;
+}
+
+
+void GUIListBox::setSpriteBank(IGUISpriteBank* bank)
+{
+	if (bank == m_icon_bank)
+		return;
+	if (m_icon_bank)
+		m_icon_bank->drop();
+
+	m_icon_bank = bank;
+	if (m_icon_bank)
+		m_icon_bank->grab();
+}
+
+
+void GUIListBox::recalculateScrollPos()
+{
+	if (!m_autoscroll)
+		return;
+
+	s32 height = m_selected == -1 ? m_total_item_height : m_selected * m_item_height;
+	const s32 selPos = height - m_scrollbar->getPos();
+
+	if (selPos < 0) {
+		m_scrollbar->setPos(m_scrollbar->getPos() + selPos);
+	} else if (selPos > AbsoluteRect.getHeight() - m_item_height){
+		m_scrollbar->setPos(m_scrollbar->getPos() +
+			selPos - AbsoluteRect.getHeight() + m_item_height);
+	}
+}
+
+
+void GUIListBox::setAutoScrollEnabled(bool scroll)
+{
+	m_autoscroll = scroll;
+}
+
+
+bool GUIListBox::isAutoScrollEnabled() const
+{
+	_IRR_IMPLEMENT_MANAGED_MARSHALLING_BUGFIX;
+	return m_autoscroll;
+}
+
+
+bool GUIListBox::getSerializationLabels(EGUI_LISTBOX_COLOR colorType, core::stringc & useColorLabel, core::stringc & colorLabel) const
+{
+	switch (colorType)
+	{
+	case EGUI_LBC_TEXT:
+		useColorLabel = "UseColText";
+		colorLabel = "ColText";
+		break;
+	case EGUI_LBC_TEXT_HIGHLIGHT:
+		useColorLabel = "UseColTextHl";
+		colorLabel = "ColTextHl";
+		break;
+	case EGUI_LBC_ICON:
+		useColorLabel = "UseColIcon";
+		colorLabel = "ColIcon";
+		break;
+	case EGUI_LBC_ICON_HIGHLIGHT:
+		useColorLabel = "UseColIconHl";
+		colorLabel = "ColIconHl";
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+
+//! Writes attributes of the element.
+void GUIListBox::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options = 0) const
+{
+	IGUIListBox::serializeAttributes(out, options);
+
+	// todo: out->addString	("IconBank",		IconBank->getName?);
+	out->addBool("DrawBack", m_draw_back);
+	out->addBool("MoveOverSelect", m_move_over_select);
+	out->addBool("AutoScroll", m_autoscroll);
+
+	out->addInt("ItemCount", m_items.size());
+	for (u32 i = 0; i < m_items.size(); ++i)
+	{
+		core::stringc label("text");
+		label += i;
+		out->addString(label.c_str(), m_items[i].text.c_str());
+
+		for (s32 c = 0; c < (s32)EGUI_LBC_COUNT; ++c)
+		{
+			core::stringc useColorLabel, colorLabel;
+			if (!getSerializationLabels((EGUI_LISTBOX_COLOR)c, useColorLabel, colorLabel))
+				return;
+			label = useColorLabel; label += i;
+			if (m_items[i].override_colors[c].use)
+			{
+				out->addBool(label.c_str(), true);
+				label = colorLabel; label += i;
+				out->addColor(label.c_str(), m_items[i].override_colors[c].color);
+			}
+			else
+			{
+				out->addBool(label.c_str(), false);
+			}
+		}
+	}
+}
+
+
+//! Reads attributes of the element
+void GUIListBox::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options = 0)
+{
+	clear();
+
+	m_draw_back = in->getAttributeAsBool("DrawBack");
+	m_move_over_select = in->getAttributeAsBool("MoveOverSelect");
+	m_autoscroll = in->getAttributeAsBool("AutoScroll");
+
+	IGUIListBox::deserializeAttributes(in, options);
+
+	const s32 count = in->getAttributeAsInt("ItemCount");
+	for (s32 i = 0; i < count; ++i)
+	{
+		core::stringc label("text");
+		ListItem item;
+
+		label += i;
+		item.text = in->getAttributeAsStringW(label.c_str());
+
+		addItem(item.text.c_str(), item.icon);
+
+		for (u32 c = 0; c < EGUI_LBC_COUNT; ++c)
+		{
+			core::stringc useColorLabel, colorLabel;
+			if (!getSerializationLabels((EGUI_LISTBOX_COLOR)c, useColorLabel, colorLabel))
+				return;
+			label = useColorLabel; label += i;
+			m_items[i].override_colors[c].use = in->getAttributeAsBool(label.c_str());
+			if (m_items[i].override_colors[c].use)
+			{
+				label = colorLabel; label += i;
+				m_items[i].override_colors[c].color = in->getAttributeAsColor(label.c_str());
+			}
+		}
+	}
+}
+
+
+void GUIListBox::recalculateItemWidth(s32 icon)
+{
+	if (m_icon_bank && icon > -1 &&
+		m_icon_bank->getSprites().size() > (u32)icon &&
+		m_icon_bank->getSprites()[(u32)icon].Frames.size())
+	{
+		u32 rno = m_icon_bank->getSprites()[(u32)icon].Frames[0].rectNumber;
+		if (m_icon_bank->getPositions().size() > rno)
+		{
+			const s32 w = m_icon_bank->getPositions()[rno].getWidth();
+			if (w > m_items_icon_width)
+				m_items_icon_width = w;
+		}
+	}
+}
+
+
+void GUIListBox::setItem(u32 index, const wchar_t* text, s32 icon)
+{
+	if (index >= m_items.size())
+		return;
+
+	m_items[index].text = text;
+	m_items[index].icon = icon;
+
+	recalculateItemHeight();
+	recalculateItemWidth(icon);
+}
+
+
+//! Insert the item at the given index
+//! Return the index on success or -1 on failure.
+s32 GUIListBox::insertItem(u32 index, const wchar_t* text, s32 icon)
+{
+	ListItem i;
+	i.text = text;
+	i.icon = icon;
+
+	m_items.insert(m_items.begin() + index, i);
+	recalculateItemHeight();
+	recalculateItemWidth(icon);
+
+	return index;
+}
+
+
+void GUIListBox::swapItems(u32 index1, u32 index2)
+{
+	if (index1 >= m_items.size() || index2 >= m_items.size())
+		return;
+
+	ListItem dummmy = m_items[index1];
+	m_items[index1] = m_items[index2];
+	m_items[index2] = dummmy;
+}
+
+
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8
+void GUIListBox::setItemOverrideColor(u32 index, const video::SColor &color)
+#else
+void GUIListBox::setItemOverrideColor(u32 index, video::SColor color)
+#endif
+{
+	for (u32 c = 0; c < EGUI_LBC_COUNT; ++c)
+	{
+		m_items[index].override_colors[c].use = true;
+		m_items[index].override_colors[c].color = color;
+	}
+}
+
+
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8
+void GUIListBox::setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, const video::SColor &color)
+#else
+void GUIListBox::setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, video::SColor color)
+#endif
+{
+	if (index >= m_items.size() || colorType < 0 || colorType >= EGUI_LBC_COUNT)
+		return;
+
+	m_items[index].override_colors[colorType].use = true;
+	m_items[index].override_colors[colorType].color = color;
+}
+
+
+void GUIListBox::clearItemOverrideColor(u32 index)
+{
+	for (u32 c = 0; c < (u32)EGUI_LBC_COUNT; ++c)
+	{
+		m_items[index].override_colors[c].use = false;
+	}
+}
+
+
+void GUIListBox::clearItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType)
+{
+	if (index >= m_items.size() || colorType < 0 || colorType >= EGUI_LBC_COUNT)
+		return;
+
+	m_items[index].override_colors[colorType].use = false;
+}
+
+
+bool GUIListBox::hasItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const
+{
+	if (index >= m_items.size() || colorType < 0 || colorType >= EGUI_LBC_COUNT)
+		return false;
+
+	return m_items[index].override_colors[colorType].use;
+}
+
+
+video::SColor GUIListBox::getItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const
+{
+	if ((u32)index >= m_items.size() || colorType < 0 || colorType >= EGUI_LBC_COUNT)
+		return video::SColor();
+
+	return m_items[index].override_colors[colorType].color;
+}
+
+
+video::SColor GUIListBox::getItemDefaultColor(EGUI_LISTBOX_COLOR colorType) const
+{
+	IGUISkin* skin = Environment->getSkin();
+	if (!skin)
+		return video::SColor();
+
+	switch (colorType)
+	{
+	case EGUI_LBC_TEXT:
+		return skin->getColor(EGDC_BUTTON_TEXT);
+	case EGUI_LBC_TEXT_HIGHLIGHT:
+		return skin->getColor(EGDC_HIGH_LIGHT_TEXT);
+	case EGUI_LBC_ICON:
+		return skin->getColor(EGDC_ICON);
+	case EGUI_LBC_ICON_HIGHLIGHT:
+		return skin->getColor(EGDC_ICON_HIGH_LIGHT);
+	default:
+		return video::SColor();
+	}
+}
+
+//! set global itemHeight
+void GUIListBox::setItemHeight(s32 height)
+{
+	m_item_height = height;
+	m_item_height_override = 1;
+}
+
+
+//! Sets whether to draw the background
+void GUIListBox::setDrawBackground(bool draw)
+{
+	m_draw_back = draw;
+}
+
+
+//! Change the selected item color
+void GUIListBox::setSelectedItemColor(const video::SColor &color)
+{
+	m_selected_item_color_used = true;
+	m_selected_item_color = color;
+}
+
+
+//! Change the background color
+void GUIListBox::setBackgroundColor(const video::SColor &color)
+{
+	m_bg_color_used = true;
+	m_bg_color = color;
+}

--- a/src/guiListBox.h
+++ b/src/guiListBox.h
@@ -1,0 +1,201 @@
+// Copyright (C) 2002-2012 Nikolaus Gebhardt. Modified by Mustapha Tachouct
+// This file is part of the "Irrlicht Engine".
+// For conditions of distribution and use, see copyright notice in irrlicht.h
+
+#ifndef GUILISTBOX_HEADER
+#define GUILISTBOX_HEADER
+
+#include "IrrCompileConfig.h"
+
+#include "irrlichttypes_extrabloated.h"
+#include "IGUIListBox.h"
+#include <vector>
+
+using namespace irr;
+using namespace irr::gui;
+
+class IGUIFont;
+class IGUIScrollBar;
+
+class GUIListBox : public IGUIListBox
+{
+public:
+	//! constructor
+	GUIListBox(IGUIEnvironment *environment, IGUIElement *parent,
+		s32 id, core::rect<s32> rectangle, bool clip = true,
+		bool draw_Back = false, bool move_over_select = false);
+
+	//! destructor
+	virtual ~GUIListBox();
+
+	//! returns amount of list items
+	virtual u32 getItemCount() const;
+
+	//! returns string of a list item. the id may be a value from 0 to itemCount-1
+	virtual const wchar_t* getListItem(u32 id) const;
+
+	//! adds an list item, returns id of item
+	virtual u32 addItem(const wchar_t *text);
+
+	//! clears the list
+	virtual void clear();
+
+	//! returns id of selected item. returns -1 if no item is selected.
+	virtual s32 getSelected() const;
+
+	//! sets the selected item. Set this to -1 if no item should be selected
+	virtual void setSelected(s32 id);
+
+	//! sets the selected item. Set this to -1 if no item should be selected
+	virtual void setSelected(const wchar_t *item);
+
+	//! called if an event happened.
+	virtual bool OnEvent(const SEvent &event);
+
+	//! draws the element and its children
+	virtual void draw();
+
+	//! adds an list item with an icon
+	//! \param text Text of list entry
+	//! \param icon Sprite index of the Icon within the current sprite bank. Set it to -1 if you want no icon
+	//! \return
+	//! returns the id of the new created item
+	virtual u32 addItem(const wchar_t *text, s32 icon);
+
+	//! Returns the icon of an item
+	virtual s32 getIcon(u32 id) const;
+
+	//! removes an item from the list
+	virtual void removeItem(u32 id);
+
+	//! get the the id of the item at the given absolute coordinates
+	virtual s32 getItemAt(s32 xpos, s32 ypos) const;
+
+	//! Sets the sprite bank which should be used to draw list icons. This font is set to the sprite bank of
+	//! the built-in-font by default. A sprite can be displayed in front of every list item.
+	//! An icon is an index within the icon sprite bank. Several default icons are available in the
+	//! skin through getIcon
+	virtual void setSpriteBank(IGUISpriteBank *bank);
+
+	//! set whether the listbox should scroll to newly selected items
+	virtual void setAutoScrollEnabled(bool scroll);
+
+	//! returns true if automatic scrolling is enabled, false if not.
+	virtual bool isAutoScrollEnabled() const;
+
+	//! Update the position and size of the listbox, and update the scrollbar
+	virtual void updateAbsolutePosition();
+
+	//! Writes attributes of the element.
+	virtual void serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options) const;
+
+	//! Reads attributes of the element
+	virtual void deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options);
+
+#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8
+	//! set all item colors at given index to color
+	virtual void setItemOverrideColor(u32 index, const video::SColor &color);
+
+	//! set all item colors of specified type at given index to color
+	virtual void setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, const video::SColor &color);
+#else 
+	//! set all item colors at given index to color
+	virtual void setItemOverrideColor(u32 index, video::SColor color);
+
+	//! set all item colors of specified type at given index to color
+	virtual void setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, video::SColor color);
+#endif
+
+	//! clear all item colors at index
+	virtual void clearItemOverrideColor(u32 index);
+
+	//! clear item color at index for given colortype
+	virtual void clearItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType);
+
+	//! has the item at index its color overwritten?
+	virtual bool hasItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const;
+
+	//! return the overwrite color at given item index.
+	virtual video::SColor getItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const;
+
+	//! return the default color which is used for the given colorType
+	virtual video::SColor getItemDefaultColor(EGUI_LISTBOX_COLOR colorType) const;
+
+	//! set the item at the given index
+	virtual void setItem(u32 index, const wchar_t *text, s32 icon);
+
+	//! Insert the item at the given index
+	//! Return the index on success or -1 on failure.
+	virtual s32 insertItem(u32 index, const wchar_t *text, s32 icon);
+
+	//! Swap the items at the given indices
+	virtual void swapItems(u32 index1, u32 index2);
+	
+	//! set global itemHeight
+	virtual void setItemHeight(s32 height);
+
+	//! Sets whether to draw the background
+	virtual void setDrawBackground(bool draw);
+
+	//! Change the selected item color
+	virtual void setSelectedItemColor(const video::SColor &color);
+
+	//! Change the background color
+	virtual void setBackgroundColor(const video::SColor &color);
+	
+private:
+
+	struct ListItem
+	{
+		ListItem() : icon(-1)
+		{}
+
+		core::stringw text;
+		s32 icon;
+
+		// A multicolor extension
+		struct ListItemOverrideColor
+		{
+			ListItemOverrideColor() : use(false) {}
+			bool use;
+			video::SColor color;
+		};
+		ListItemOverrideColor override_colors[EGUI_LBC_COUNT];
+	};
+
+	void recalculateItemHeight();
+	void selectNew(s32 ypos, bool onlyHover = false);
+	void recalculateScrollPos();
+
+	// extracted that function to avoid copy&paste code
+	void recalculateItemWidth(s32 icon);
+
+	// get labels used for serialization
+	bool getSerializationLabels(EGUI_LISTBOX_COLOR colorType, core::stringc  &useColorLabel, core::stringc &colorLabel) const;
+
+	std::vector<ListItem> m_items;
+	s32 m_selected;
+	s32 m_item_height;
+	s32 m_item_height_override;
+	s32 m_total_item_height;
+	s32 m_items_icon_width;
+	gui::IGUIFont *m_font;
+	gui::IGUISpriteBank *m_icon_bank;
+	gui::IGUIScrollBar *m_scrollbar;
+	u32 m_select_time;
+	u32 m_last_key_time;
+	core::stringw m_key_buffer;
+	bool m_selecting;
+	bool m_draw_back;
+	bool m_move_over_select;
+	bool m_autoscroll;
+	bool m_highlight_when_not_focused;
+
+	bool m_selected_item_color_used;
+	video::SColor m_selected_item_color;
+
+	bool m_bg_color_used;
+	video::SColor m_bg_color;
+};
+
+#endif


### PR DESCRIPTION
#### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>;<bg_color>;<selected_item_color>]`
* Show a dropdown field
* **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
* `x` and `y` position of dropdown
* Width of dropdown
* Fieldname data is transferred to Lua
* Items to be shown in dropdown
* Index of currently selected dropdown item
* `bg_color`is the background color of the dropdown
* `selected_item_color` is the color of the selected item