### PR TITLE
Get biome list: Downgrade missing biome message to infostream

### DIFF
--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -419,7 +419,7 @@ size_t get_biome_list(lua_State *L, int index,
 	if (is_single) {
 		Biome *biome = get_or_load_biome(L, index, biomemgr);
 		if (!biome) {
-			errorstream << "get_biome_list: failed to get biome '"
+			infostream << "get_biome_list: failed to get biome '"
 				<< (lua_isstring(L, index) ? lua_tostring(L, index) : "")
 				<< "'." << std::endl;
 			return 1;
@@ -438,7 +438,7 @@ size_t get_biome_list(lua_State *L, int index,
 		Biome *biome = get_or_load_biome(L, -1, biomemgr);
 		if (!biome) {
 			fail_count++;
-			errorstream << "get_biome_list: failed to get biome '"
+			infostream << "get_biome_list: failed to get biome '"
 				<< (lua_isstring(L, -1) ? lua_tostring(L, -1) : "")
 				<< "'" << std::endl;
 			continue;
@@ -927,7 +927,7 @@ int ModApiMapgen::l_register_decoration(lua_State *L)
 	//// Get biomes associated with this decoration (if any)
 	lua_getfield(L, index, "biomes");
 	if (get_biome_list(L, -1, biomemgr, &deco->biomes))
-		errorstream << "register_decoration: couldn't get all biomes " << std::endl;
+		infostream << "register_decoration: couldn't get all biomes " << std::endl;
 	lua_pop(L, 1);
 
 	//// Get node name(s) to 'spawn by'
@@ -1092,7 +1092,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	//// Get biomes associated with this decoration (if any)
 	lua_getfield(L, index, "biomes");
 	if (get_biome_list(L, -1, bmgr, &ore->biomes))
-		errorstream << "register_ore: couldn't get all biomes " << std::endl;
+		infostream << "register_ore: couldn't get all biomes " << std::endl;
 	lua_pop(L, 1);
 
 	//// Get noise parameters if needed


### PR DESCRIPTION
It is harmless for a biome listed in an ore or decoration registration
to be missing.
Now that we are registering certain biomes or not based on options
(such as floatland biomes), the biome lists in ore and decoration
registrations trigger these error messages, avoiding these error
messages would need a large amount of duplication of ore and decoration
registrations.
/////////////////////////////////////////////////////

Needed for https://github.com/minetest/minetest_game/pull/1624
Why this is needed https://github.com/minetest/minetest_game/pull/1624#issuecomment-286086328 and following comment.
This is needed to avoid large amounts of code duplication due to floatland biomes being optional.
It will also greatly simplify use of the Biome API in future, for devs, modders and subgame creators.

An example of an ore registration with a list of biomes the ore spawns in:
```
	-- Silver sand

	minetest.register_ore({
		ore_type        = "blob",
		ore             = "default:silver_sand",
		wherein         = {"default:stone"},
		clust_scarcity  = 16 * 16 * 16,
		clust_size      = 5,
		y_min           = -31000,
		y_max           = 31000,
		noise_threshold = 0.0,
		noise_params    = {
			offset = 0.5,
			scale = 0.2,
			spread = {x = 5, y = 5, z = 5},
			seed = 2316,
			octaves = 1,
			persist = 0.0
		},
		biomes = {"icesheet_ocean", "tundra", "tundra_beach", "tundra_ocean",
			"taiga", "taiga_ocean", "snowy_grassland", "snowy_grassland_ocean",
			"grassland", "grassland_dunes", "grassland_ocean", "coniferous_forest",
			"coniferous_forest_dunes", "coniferous_forest_ocean", "deciduous_forest",
			"deciduous_forest_shore", "deciduous_forest_ocean", "cold_desert",
			"cold_desert_ocean", "savanna", "savanna_shore", "savanna_ocean",
			"rainforest", "rainforest_swamp", "rainforest_ocean", "underground"}
})
```
If an ore or a decoration has a certain biome in it's list, but that biome is not registered, this is no problem, the missing biome is recorded as 'NULL' in the list of biomes used by ore or decoration generation. When the biome for a point is being matched to the biome list there will simply be no match, which is harmless.

The error was shown in terminal as a hint to modders that they may have made a mistake, but now a missing biome registration is acceptable and desired usage to avoid duplication of, for exmple, the registration shown above.

This will also reduce error messages printed due to certain mods or subgames redefining biomes in certain acceptable ways.