### PR TITLE
Map gen limit: Rewrite

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -238,9 +238,9 @@ void RemoteClient::GetNextBlocks (
 				continue;
 
 			/*
-				Do not go over-limit
+				Do not go over max mapgen limit
 			*/
-			if (blockpos_over_limit(p))
+			if (blockpos_over_max_limit(p))
 				continue;
 
 			// If this is true, inexistent block will be made from scratch

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -606,7 +606,7 @@ void *EmergeThread::run()
 			continue;
 		}
 
-		if (blockpos_over_limit(pos))
+		if (blockpos_over_max_limit(pos))
 			continue;
 
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -669,41 +669,37 @@ typedef std::vector<MapBlock*> MapBlockVect;
 
 inline bool objectpos_over_limit(v3f p)
 {
-	// MAP_BLOCKSIZE must be subtracted to avoid an object being spawned just
-	// within the map generation limit but in a block and sector that extend
-	// beyond the map generation limit.
-	// This avoids crashes caused by sector over limit in createSector().
-	const float object_limit = (MYMIN(MAX_MAP_GENERATION_LIMIT,
-		g_settings->getU16("map_generation_limit")) - MAP_BLOCKSIZE) * BS;
-	return (p.X < -object_limit
-		|| p.X > object_limit
-		|| p.Y < -object_limit
-		|| p.Y > object_limit
-		|| p.Z < -object_limit
-		|| p.Z > object_limit);
+	const float max_limit_bs = MAX_MAP_GENERATION_LIMIT * BS;
+	return p.X < -max_limit_bs ||
+		p.X >  max_limit_bs ||
+		p.Y < -max_limit_bs ||
+		p.Y >  max_limit_bs ||
+		p.Z < -max_limit_bs ||
+		p.Z >  max_limit_bs;
 }
 
-/*
-	We are checking for any node of the mapblock being beyond the limit.
-
-	At the negative limit we are checking for
-		block minimum nodepos < -mapgenlimit.
-	At the positive limit we are checking for
-		block maximum nodepos > mapgenlimit.
-
-	Block minimum nodepos = blockpos * mapblocksize.
-	Block maximum nodepos = (blockpos + 1) * mapblocksize - 1.
-*/
-inline bool blockpos_over_limit(v3s16 p)
+inline bool blockpos_over_max_limit(v3s16 p)
 {
-	const u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
-		g_settings->getU16("map_generation_limit"));
-	return (p.X * MAP_BLOCKSIZE < -map_gen_limit
-		|| (p.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
-		|| p.Y * MAP_BLOCKSIZE < -map_gen_limit
-		|| (p.Y + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
-		|| p.Z * MAP_BLOCKSIZE < -map_gen_limit
-		|| (p.Z + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit);
+	const s16 max_limit_bp = MAX_MAP_GENERATION_LIMIT / MAP_BLOCKSIZE;
+	return p.X < -max_limit_bp ||
+		p.X >  max_limit_bp ||
+		p.Y < -max_limit_bp ||
+		p.Y >  max_limit_bp ||
+		p.Z < -max_limit_bp ||
+		p.Z >  max_limit_bp;
+}
+
+inline bool blockpos_over_mapgen_limit(v3s16 p)
+{
+	const s16 mapgen_limit_bp = rangelim(
+		g_settings->getS16("map_generation_limit"), 0, MAX_MAP_GENERATION_LIMIT) /
+		MAP_BLOCKSIZE;
+	return p.X < -mapgen_limit_bp ||
+		p.X >  mapgen_limit_bp ||
+		p.Y < -mapgen_limit_bp ||
+		p.Y >  mapgen_limit_bp ||
+		p.Z < -mapgen_limit_bp ||
+		p.Z >  mapgen_limit_bp;
 }
 
 /*


### PR DESCRIPTION
See #4338 and comment https://github.com/minetest/minetest/pull/4338#issuecomment-233799823
"IRC discussion http://irc.minetest.ru/minetest-dev/2016-07-19#i_4653842
It looks likely the original implementation of map gen limit will be reworked and improved. I suggest waiting to see what happens."

Linked IRC discussion
20:02 hmmmm map_generation_limit is implemented in a crummy manner to begin with
20:03 hmmmm why is it so far overreaching?
20:03 hmmmm the map_generation_limit should limit map generation. not everything else in the entire universe.
20:04 hmmmm instead what the guy did who implemented it first added a parameter to a fundamental function that just about everything uses to make sure objects or positions are not out-of-bounds and will cause bugs or errors
20:04 hmmmm when in reality it should simply... limit the map generation

I have been fixing bugs caused by the current implementation and so now understand what hmmmm is referring too and agree with his opinion. Hmmmm is inactive and i was inspired to rework map gen limit.

First i reverted the commit https://github.com/minetest/minetest/commit/ec796b8e814864b433aea75119c307f44b2b33e8
Then renamed 'blockpos over limit' to 'blockpos over max limit' to be clear this is referring to MAX MAP GENERATION LIMIT (31000).
Then added a new function in 'mapblock.h' called 'blockpos over mapgen limit' that refers to the setting 'map generation limit'. I then only call this from one place, from where the mapgen code decides whether to generate a mapchunk or not (see next comment).

I also changed 'objectpos over limit' to use MAX MAP GENERATION LIMIT. Related commits https://github.com/minetest/minetest/commit/f61f817b9c170942a5b3ce3591125c2191645cd0 https://github.com/minetest/minetest/commit/6c81be51ffd26ec7dee1ecb887a8743a8b6a6ce4 There is no reason to limit objects to within 'map generation limit'.