### PR TITLE
FormSpec: support custom size and spacing for slots in list

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1547,6 +1547,17 @@ examples.
 #### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 * Show an inventory list
 
+#### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>;<spacing factor width>,<spacing factor height>;<img factor size>]`
+* Show an inventory list
+* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
+  example 1 : (0.0,0.0) for spacing means that there are no space between slots
+  example 2 : (1.0,1.0) for spacing means that default space between slots is used
+  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
+* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
+  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
+  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
+  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
+
 #### `listring[<inventory location>;<list name>]`
 * Allows to create a ring of inventory lists
 * Shift-clicking on items in one element of the ring

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -84,11 +84,18 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i)
+				s32 a_i,
+				const v2s32 &a_imgsize,
+				const v2s32 &a_spacing,
+				s32 a_border
+		)
 		{
 			inventoryloc = a_inventoryloc;
 			listname = a_listname;
 			i = a_i;
+			imgsize = a_imgsize;
+			spacing = a_spacing;
+			border = a_border;
 		}
 		bool isValid() const
 		{
@@ -98,6 +105,9 @@ class GUIFormSpecMenu : public GUIModalMenu
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i;
+		v2s32 imgsize;
+		v2s32 spacing;
+		s32 border;
 	};
 
 	struct ListDrawSpec
@@ -107,12 +117,16 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				v2s32 a_imgsize, v2s32 a_spacing, s32 a_border):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			imgsize(a_imgsize),
+			spacing(a_spacing),
+			border(a_border)
 		{
 		}
 
@@ -121,6 +135,9 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+		v2s32 imgsize;
+		v2s32 spacing;
+		s32 border;
 	};
 
 	struct ListRingSpec

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -169,7 +169,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PASSWORD_SIZE 28       // Maximum password length. Allows for
                                // base64-encoded SHA-1 (27+\0).
 
-#define FORMSPEC_API_VERSION 1
+#define FORMSPEC_API_VERSION 2
 #define FORMSPEC_VERSION_STRING "formspec_version[" TOSTRING(FORMSPEC_API_VERSION) "]"
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"


### PR DESCRIPTION
#### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>;<spacing factor width>,<spacing factor height>;<img factor size>]`
* Show an inventory list
* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
  example 1 : (0.0,0.0) for spacing means that there are no space between slots
  example 2 : (1.0,1.0) for spacing means that default space between slots is used
  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot