### PR TITLE
Update server min protocol version to v24

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -470,56 +470,42 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 {
 	std::ostringstream os(std::ios::binary);
 
-	if(protocol_version >= 14)
-	{
-		writeU8(os, 1); // version
-		os<<serializeString(""); // name
-		writeU8(os, 0); // is_player
-		writeS16(os, getId()); //id
-		writeV3F1000(os, m_base_position);
-		writeF1000(os, m_yaw);
-		writeS16(os, m_hp);
+	// protocol >= 14
+	writeU8(os, 1); // version
+	os << serializeString(""); // name
+	writeU8(os, 0); // is_player
+	writeS16(os, getId()); //id
+	writeV3F1000(os, m_base_position);
+	writeF1000(os, m_yaw);
+	writeS16(os, m_hp);
 
-		std::ostringstream msg_os(std::ios::binary);
-		msg_os << serializeLongString(getPropertyPacket()); // message 1
-		msg_os << serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
-		msg_os << serializeLongString(gob_cmd_update_animation(
-			m_animation_range, m_animation_speed, m_animation_blend, m_animation_loop)); // 3
-		for (UNORDERED_MAP<std::string, core::vector2d<v3f> >::const_iterator
-				ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii) {
-			msg_os << serializeLongString(gob_cmd_update_bone_position((*ii).first,
-					(*ii).second.X, (*ii).second.Y)); // m_bone_position.size
-		}
-		msg_os << serializeLongString(gob_cmd_update_attachment(m_attachment_parent_id,
-			m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
-		int message_count = 4 + m_bone_position.size();
-		for (UNORDERED_SET<int>::const_iterator ii = m_attachment_child_ids.begin();
-				(ii != m_attachment_child_ids.end()); ++ii) {
-			if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
-				message_count++;
-				msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
-					obj->getClientInitializationData(protocol_version)));
-			}
-		}
-
-		msg_os << serializeLongString(gob_cmd_set_texture_mod(m_current_texture_modifier));
-		message_count++;
-
-		writeU8(os, message_count);
-		os.write(msg_os.str().c_str(), msg_os.str().size());
+	std::ostringstream msg_os(std::ios::binary);
+	msg_os << serializeLongString(getPropertyPacket()); // message 1
+	msg_os << serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
+	msg_os << serializeLongString(gob_cmd_update_animation(
+		m_animation_range, m_animation_speed, m_animation_blend, m_animation_loop)); // 3
+	for (UNORDERED_MAP<std::string, core::vector2d<v3f> >::const_iterator
+			ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii) {
+		msg_os << serializeLongString(gob_cmd_update_bone_position((*ii).first,
+				(*ii).second.X, (*ii).second.Y)); // m_bone_position.size
 	}
-	else
-	{
-		writeU8(os, 0); // version
-		os<<serializeString(""); // name
-		writeU8(os, 0); // is_player
-		writeV3F1000(os, m_base_position);
-		writeF1000(os, m_yaw);
-		writeS16(os, m_hp);
-		writeU8(os, 2); // number of messages stuffed in here
-		os<<serializeLongString(getPropertyPacket()); // message 1
-		os<<serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
+	msg_os << serializeLongString(gob_cmd_update_attachment(m_attachment_parent_id,
+		m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
+	int message_count = 4 + m_bone_position.size();
+	for (UNORDERED_SET<int>::const_iterator ii = m_attachment_child_ids.begin();
+			(ii != m_attachment_child_ids.end()); ++ii) {
+		if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
+			message_count++;
+			msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
+				obj->getClientInitializationData(protocol_version)));
+		}
 	}
+
+	msg_os << serializeLongString(gob_cmd_set_texture_mod(m_current_texture_modifier));
+	message_count++;
+
+	writeU8(os, message_count);
+	os.write(msg_os.str().c_str(), msg_os.str().size());
 
 	// return result
 	return os.str();
@@ -877,58 +863,44 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 {
 	std::ostringstream os(std::ios::binary);
 
-	if(protocol_version >= 15)
-	{
-		writeU8(os, 1); // version
-		os<<serializeString(m_player->getName()); // name
-		writeU8(os, 1); // is_player
-		writeS16(os, getId()); //id
-		writeV3F1000(os, m_base_position + v3f(0,BS*1,0));
-		writeF1000(os, m_yaw);
-		writeS16(os, getHP());
+	// Protocol >= 15
+	writeU8(os, 1); // version
+	os << serializeString(m_player->getName()); // name
+	writeU8(os, 1); // is_player
+	writeS16(os, getId()); //id
+	writeV3F1000(os, m_base_position + v3f(0,BS*1,0));
+	writeF1000(os, m_yaw);
+	writeS16(os, getHP());
 
-		std::ostringstream msg_os(std::ios::binary);
-		msg_os << serializeLongString(getPropertyPacket()); // message 1
-		msg_os << serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
-		msg_os << serializeLongString(gob_cmd_update_animation(
-			m_animation_range, m_animation_speed, m_animation_blend, m_animation_loop)); // 3
-		for (UNORDERED_MAP<std::string, core::vector2d<v3f> >::const_iterator
-				ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii) {
-			msg_os << serializeLongString(gob_cmd_update_bone_position((*ii).first,
-				(*ii).second.X, (*ii).second.Y)); // m_bone_position.size
+	std::ostringstream msg_os(std::ios::binary);
+	msg_os << serializeLongString(getPropertyPacket()); // message 1
+	msg_os << serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
+	msg_os << serializeLongString(gob_cmd_update_animation(
+		m_animation_range, m_animation_speed, m_animation_blend, m_animation_loop)); // 3
+	for (UNORDERED_MAP<std::string, core::vector2d<v3f> >::const_iterator
+			ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii) {
+		msg_os << serializeLongString(gob_cmd_update_bone_position((*ii).first,
+			(*ii).second.X, (*ii).second.Y)); // m_bone_position.size
+	}
+	msg_os << serializeLongString(gob_cmd_update_attachment(m_attachment_parent_id,
+		m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
+	msg_os << serializeLongString(gob_cmd_update_physics_override(m_physics_override_speed,
+			m_physics_override_jump, m_physics_override_gravity, m_physics_override_sneak,
+			m_physics_override_sneak_glitch)); // 5
+	// (GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) : Deprecated, for backwards compatibility only.
+	msg_os << serializeLongString(gob_cmd_update_nametag_attributes(m_prop.nametag_color)); // 6
+	int message_count = 6 + m_bone_position.size();
+	for (UNORDERED_SET<int>::const_iterator ii = m_attachment_child_ids.begin();
+			ii != m_attachment_child_ids.end(); ++ii) {
+		if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
+			message_count++;
+			msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
+				obj->getClientInitializationData(protocol_version)));
 		}
-		msg_os << serializeLongString(gob_cmd_update_attachment(m_attachment_parent_id,
-			m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
-		msg_os << serializeLongString(gob_cmd_update_physics_override(m_physics_override_speed,
-				m_physics_override_jump, m_physics_override_gravity, m_physics_override_sneak,
-				m_physics_override_sneak_glitch)); // 5
-		// (GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) : Deprecated, for backwards compatibility only.
-		msg_os << serializeLongString(gob_cmd_update_nametag_attributes(m_prop.nametag_color)); // 6
-		int message_count = 6 + m_bone_position.size();
-		for (UNORDERED_SET<int>::const_iterator ii = m_attachment_child_ids.begin();
-				ii != m_attachment_child_ids.end(); ++ii) {
-			if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
-				message_count++;
-				msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
-					obj->getClientInitializationData(protocol_version)));
-			}
-		}
+	}
 
-		writeU8(os, message_count);
-		os.write(msg_os.str().c_str(), msg_os.str().size());
-	}
-	else
-	{
-		writeU8(os, 0); // version
-		os<<serializeString(m_player->getName()); // name
-		writeU8(os, 1); // is_player
-		writeV3F1000(os, m_base_position + v3f(0,BS*1,0));
-		writeF1000(os, m_yaw);
-		writeS16(os, getHP());
-		writeU8(os, 2); // number of messages stuffed in here
-		os<<serializeLongString(getPropertyPacket()); // message 1
-		os<<serializeLongString(gob_cmd_update_armor_groups(m_armor_groups)); // 2
-	}
+	writeU8(os, message_count);
+	os.write(msg_os.str().c_str(), msg_os.str().size());
 
 	// return result
 	return os.str();

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -123,17 +123,13 @@ void ItemDefinition::reset()
 
 void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if(protocol_version <= 17)
-		writeU8(os, 1); // version
-	else if(protocol_version <= 20)
-		writeU8(os, 2); // version
-	else
-		writeU8(os, 3); // version
+
+	writeU8(os, 3); // version (proto > 20)
 	writeU8(os, type);
-	os<<serializeString(name);
-	os<<serializeString(description);
-	os<<serializeString(inventory_image);
-	os<<serializeString(wield_image);
+	os << serializeString(name);
+	os << serializeString(description);
+	os << serializeString(inventory_image);
+	os << serializeString(wield_image);
 	writeV3F1000(os, wield_scale);
 	writeS16(os, stack_max);
 	writeU8(os, usable);
@@ -144,24 +140,19 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 		tool_capabilities->serialize(tmp_os, protocol_version);
 		tool_capabilities_s = tmp_os.str();
 	}
-	os<<serializeString(tool_capabilities_s);
+	os << serializeString(tool_capabilities_s);
 	writeU16(os, groups.size());
 	for (ItemGroupList::const_iterator
 			i = groups.begin(); i != groups.end(); ++i){
 		os << serializeString(i->first);
 		writeS16(os, i->second);
 	}
-	os<<serializeString(node_placement_prediction);
-	if(protocol_version > 17){
-		//serializeSimpleSoundSpec(sound_place, os);
-		os<<serializeString(sound_place.name);
-		writeF1000(os, sound_place.gain);
-	}
-	if (protocol_version > 20) {
-		writeF1000(os, range);
-		os << serializeString(sound_place_failed.name);
-		writeF1000(os, sound_place_failed.gain);
-	}
+	os << serializeString(node_placement_prediction);
+	os << serializeString(sound_place.name);
+	writeF1000(os, sound_place.gain);
+	writeF1000(os, range);
+	os << serializeString(sound_place_failed.name);
+	writeF1000(os, sound_place_failed.gain);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2438,13 +2438,6 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 			throw SerializationError("ServerMap::loadBlock(): Failed"
 					" to read MapBlock version");
 
-		/*u32 block_size = MapBlock::serializedLength(version);
-		SharedBuffer<u8> data(block_size);
-		is.read((char*)*data, block_size);*/
-
-		// This will always return a sector because we're the server
-		//MapSector *sector = emergeSector(p2d);
-
 		MapBlock *block = NULL;
 		bool created_new = false;
 		block = sector->getBlockNoCreateNoEx(p3d.Y);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -640,19 +640,15 @@ void MapBlock::serialize(std::ostream &os, u8 version, bool disk)
 	}
 }
 
-void MapBlock::serializeNetworkSpecific(std::ostream &os, u16 net_proto_version)
+void MapBlock::serializeNetworkSpecific(std::ostream &os)
 {
-	if(data == NULL)
-	{
+	if (!data) {
 		throw SerializationError("ERROR: Not writing dummy block.");
 	}
 
-	if(net_proto_version >= 21){
-		int version = 1;
-		writeU8(os, version);
-		writeF1000(os, 0); // deprecated heat
-		writeF1000(os, 0); // deprecated humidity
-	}
+	writeU8(os, 1); // version
+	writeF1000(os, 0); // deprecated heat
+	writeF1000(os, 0); // deprecated humidity
 }
 
 void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -541,7 +541,7 @@ public:
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);
 
-	void serializeNetworkSpecific(std::ostream &os, u16 net_proto_version);
+	void serializeNetworkSpecific(std::ostream &os);
 	void deSerializeNetworkSpecific(std::istream &is);
 private:
 	/*
@@ -698,11 +698,11 @@ inline bool blockpos_over_limit(v3s16 p)
 {
 	const u16 map_gen_limit = MYMIN(MAX_MAP_GENERATION_LIMIT,
 		g_settings->getU16("map_generation_limit"));
-	return (p.X * MAP_BLOCKSIZE < -map_gen_limit 
+	return (p.X * MAP_BLOCKSIZE < -map_gen_limit
 		|| (p.X + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
-		|| p.Y * MAP_BLOCKSIZE < -map_gen_limit 
+		|| p.Y * MAP_BLOCKSIZE < -map_gen_limit
 		|| (p.Y + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit
-		|| p.Z * MAP_BLOCKSIZE < -map_gen_limit 
+		|| p.Z * MAP_BLOCKSIZE < -map_gen_limit
 		|| (p.Z + 1) * MAP_BLOCKSIZE - 1 > map_gen_limit);
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -153,14 +153,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define LATEST_PROTOCOL_VERSION 30
 
 // Server's supported network protocol range
-#define SERVER_PROTOCOL_VERSION_MIN 13
+#define SERVER_PROTOCOL_VERSION_MIN 24
 #define SERVER_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Client's supported network protocol range
 // The minimal version depends on whether
 // send_pre_v25_init is enabled or not
 #define CLIENT_PROTOCOL_VERSION_MIN 25
-#define CLIENT_PROTOCOL_VERSION_MIN_LEGACY 13
+#define CLIENT_PROTOCOL_VERSION_MIN_LEGACY 24
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Constant that differentiates the protocol from random data and other protocols

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -614,20 +614,6 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	u16 protocol_version = m_clients.getProtocolVersion(pkt->getPeerId());
 
 
-	///// begin compatibility code
-	PlayerSAO* playersao = NULL;
-	if (protocol_version <= 22) {
-		playersao = StageTwoClientInit(pkt->getPeerId());
-
-		if (playersao == NULL) {
-			actionstream
-				<< "TOSERVER_INIT2 stage 2 client init failed for peer "
-				<< pkt->getPeerId() << std::endl;
-			return;
-		}
-	}
-	///// end compatibility code
-
 	/*
 		Send some initialization data
 	*/
@@ -656,13 +642,6 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	u16 time = m_env->getTimeOfDay();
 	float time_speed = g_settings->getFloat("time_speed");
 	SendTimeOfDay(pkt->getPeerId(), time, time_speed);
-
-	///// begin compatibility code
-	if (protocol_version <= 22) {
-		m_clients.event(pkt->getPeerId(), CSE_SetClientReady);
-		m_script->on_joinplayer(playersao);
-	}
-	///// end compatibility code
 
 	// Warnings about protocol version can be issued here
 	if (getClient(pkt->getPeerId())->net_proto_version < LATEST_PROTOCOL_VERSION) {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -61,11 +61,10 @@ void NodeBox::reset()
 
 void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 {
-	int version = 1;
+	// Protocol >= 21
+	int version = 2;
 	if (protocol_version >= 27)
 		version = 3;
-	else if (protocol_version >= 21)
-		version = 2;
 	writeU8(os, version);
 
 	switch (type) {
@@ -195,14 +194,12 @@ void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 		writeU8(os, 3);
 	else if (protocol_version >= 26)
 		writeU8(os, 2);
-	else if (protocol_version >= 17)
-		writeU8(os, 1);
 	else
-		writeU8(os, 0);
-	os<<serializeString(name);
+		writeU8(os, 1);
+
+	os << serializeString(name);
 	animation.serialize(os, protocol_version);
-	if (protocol_version >= 17)
-		writeU8(os, backface_culling);
+	writeU8(os, backface_culling);
 	if (protocol_version >= 26) {
 		writeU8(os, tileable_horizontal);
 		writeU8(os, tileable_vertical);
@@ -1615,109 +1612,8 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
 		compatible_visual_scale = sqrt(visual_scale);
 
-	if (protocol_version == 13)
-	{
-		writeU8(os, 5); // version
-		os<<serializeString(name);
-		writeU16(os, groups.size());
-		for (ItemGroupList::const_iterator
-				i = groups.begin(); i != groups.end(); ++i) {
-			os<<serializeString(i->first);
-			writeS16(os, i->second);
-		}
-		writeU8(os, drawtype);
-		writeF1000(os, compatible_visual_scale);
-		writeU8(os, 6);
-		for (u32 i = 0; i < 6; i++)
-			tiledef[i].serialize(os, protocol_version);
-		//CF_SPECIAL_COUNT = 2 before cf ver. 7 and protocol ver. 24
-		writeU8(os, 2);
-		for (u32 i = 0; i < 2; i++)
-			tiledef_special[i].serialize(os, protocol_version);
-		writeU8(os, alpha);
-		writeU8(os, post_effect_color.getAlpha());
-		writeU8(os, post_effect_color.getRed());
-		writeU8(os, post_effect_color.getGreen());
-		writeU8(os, post_effect_color.getBlue());
-		writeU8(os, param_type);
-		writeU8(os, compatible_param_type_2);
-		writeU8(os, is_ground_content);
-		writeU8(os, light_propagates);
-		writeU8(os, sunlight_propagates);
-		writeU8(os, walkable);
-		writeU8(os, pointable);
-		writeU8(os, diggable);
-		writeU8(os, climbable);
-		writeU8(os, buildable_to);
-		os<<serializeString(""); // legacy: used to be metadata_name
-		writeU8(os, liquid_type);
-		os<<serializeString(liquid_alternative_flowing);
-		os<<serializeString(liquid_alternative_source);
-		writeU8(os, liquid_viscosity);
-		writeU8(os, light_source);
-		writeU32(os, damage_per_second);
-		node_box.serialize(os, protocol_version);
-		selection_box.serialize(os, protocol_version);
-		writeU8(os, legacy_facedir_simple);
-		writeU8(os, legacy_wallmounted);
-		serializeSimpleSoundSpec(sound_footstep, os);
-		serializeSimpleSoundSpec(sound_dig, os);
-		serializeSimpleSoundSpec(sound_dug, os);
-	}
-	else if (protocol_version > 13 && protocol_version < 24) {
-		writeU8(os, 6); // version
-		os<<serializeString(name);
-		writeU16(os, groups.size());
-		for (ItemGroupList::const_iterator
-				i = groups.begin(); i != groups.end(); ++i) {
-			os<<serializeString(i->first);
-			writeS16(os, i->second);
-		}
-		writeU8(os, drawtype);
-		writeF1000(os, compatible_visual_scale);
-		writeU8(os, 6);
-		for (u32 i = 0; i < 6; i++)
-			tiledef[i].serialize(os, protocol_version);
-		//CF_SPECIAL_COUNT = 2 before cf ver. 7 and protocol ver. 24
-		writeU8(os, 2);
-		for (u32 i = 0; i < 2; i++)
-			tiledef_special[i].serialize(os, protocol_version);
-		writeU8(os, alpha);
-		writeU8(os, post_effect_color.getAlpha());
-		writeU8(os, post_effect_color.getRed());
-		writeU8(os, post_effect_color.getGreen());
-		writeU8(os, post_effect_color.getBlue());
-		writeU8(os, param_type);
-		writeU8(os, compatible_param_type_2);
-		writeU8(os, is_ground_content);
-		writeU8(os, light_propagates);
-		writeU8(os, sunlight_propagates);
-		writeU8(os, walkable);
-		writeU8(os, pointable);
-		writeU8(os, diggable);
-		writeU8(os, climbable);
-		writeU8(os, buildable_to);
-		os<<serializeString(""); // legacy: used to be metadata_name
-		writeU8(os, liquid_type);
-		os<<serializeString(liquid_alternative_flowing);
-		os<<serializeString(liquid_alternative_source);
-		writeU8(os, liquid_viscosity);
-		writeU8(os, liquid_renewable);
-		writeU8(os, light_source);
-		writeU32(os, damage_per_second);
-		node_box.serialize(os, protocol_version);
-		selection_box.serialize(os, protocol_version);
-		writeU8(os, legacy_facedir_simple);
-		writeU8(os, legacy_wallmounted);
-		serializeSimpleSoundSpec(sound_footstep, os);
-		serializeSimpleSoundSpec(sound_dig, os);
-		serializeSimpleSoundSpec(sound_dug, os);
-		writeU8(os, rightclickable);
-		writeU8(os, drowning);
-		writeU8(os, leveled);
-		writeU8(os, liquid_range);
-	}
-	else if(protocol_version >= 24 && protocol_version < 30) {
+	// Protocol >= 24
+	if (protocol_version < 30) {
 		writeU8(os, protocol_version < 27 ? 7 : 8);
 
 		os << serializeString(name);
@@ -1778,9 +1674,10 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 				i != connects_to_ids.end(); ++i)
 			writeU16(os, *i);
 		writeU8(os, connect_sides);
-	} else
+	} else {
 		throw SerializationError("ContentFeatures::serialize(): "
 			"Unsupported version requested");
+	}
 }
 
 void ContentFeatures::deSerializeOld(std::istream &is, int version)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2144,14 +2144,6 @@ void Server::sendAddNode(v3s16 p, MapNode n, u16 ignore_id,
 		if (client != 0) {
 			pkt << p << n.param0 << n.param1 << n.param2
 					<< (u8) (remove_metadata ? 0 : 1);
-
-			if (!remove_metadata) {
-				if (client->net_proto_version <= 21) {
-					// Old clients always clear metadata; fix it
-					// by sending the full block again.
-					client->SetBlockNotSent(getNodeBlockPos(p));
-				}
-			}
 		}
 		m_clients.unlock();
 
@@ -2185,7 +2177,7 @@ void Server::SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto
 
 	std::ostringstream os(std::ios_base::binary);
 	block->serialize(os, ver, false);
-	block->serializeNetworkSpecific(os, net_proto_version);
+	block->serializeNetworkSpecific(os);
 	std::string s = os.str();
 
 	NetworkPacket pkt(TOCLIENT_BLOCKDATA, 2 + 2 + 2 + 2 + s.size(), peer_id);

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -27,33 +27,30 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if(protocol_version <= 17)
-		writeU8(os, 1); // version
-	else
-		writeU8(os, 2); // version
+	writeU8(os, 2); // version (protocol >= 18)
 	writeF1000(os, full_punch_interval);
 	writeS16(os, max_drop_level);
 	writeU32(os, groupcaps.size());
 	for (ToolGCMap::const_iterator i = groupcaps.begin(); i != groupcaps.end(); ++i) {
 		const std::string *name = &i->first;
 		const ToolGroupCap *cap = &i->second;
-		os<<serializeString(*name);
+		os << serializeString(*name);
 		writeS16(os, cap->uses);
 		writeS16(os, cap->maxlevel);
 		writeU32(os, cap->times.size());
 		for (UNORDERED_MAP<int, float>::const_iterator
-				i = cap->times.begin(); i != cap->times.end(); ++i) {
-			writeS16(os, i->first);
-			writeF1000(os, i->second);
+				j = cap->times.begin(); j != cap->times.end(); ++j) {
+			writeS16(os, j->first);
+			writeF1000(os, j->second);
 		}
 	}
-	if(protocol_version > 17){
-		writeU32(os, damageGroups.size());
-		for (DamageGroup::const_iterator i = damageGroups.begin();
-			 	i != damageGroups.end(); ++i) {
-			os<<serializeString(i->first);
-			writeS16(os, i->second);
-		}
+
+	writeU32(os, damageGroups.size());
+
+	for (DamageGroup::const_iterator i = damageGroups.begin();
+			i != damageGroups.end(); ++i) {
+		os << serializeString(i->first);
+		writeS16(os, i->second);
 	}
 }
 


### PR DESCRIPTION
It's based on @sfan5 stats. See https://kitsunemimi.pw/tmp/serverlist_stats_2017-03-17.txt

v24 was bumped 25/08/14 and 0.4.11 was released 25/12/14

It's important to keep a contract support with our users. As @sofar requested 2 years old is sufficient. 0.4.11 is the last version 2 years ago, but maybe we should update to 0.4.13 as 0.4.11 is only 2.8% users.

When all agree i will drop support into engine on minimum chosen version.

As you know, we are implementing CSM, which is a huge interesting change and will need to be enhanced version after version. Here is the changes added between v13 and v24, which means better user experience

Here are a set of added features which are important for user experience, maybe essential as it's very used by server owners
* GENERIC_CMD_SET_ANIMATION
* GENERIC_CMD_SET_BONE_POSITION
* GENERIC_CMD_SET_ATTACHMENT
* TOCLIENT_SHOW_FORMSPEC
* TOCLIENT_SPAWN_PARTICLE
* TOCLIENT_ADD_PARTICLESPAWNER
* TOCLIENT_DELETE_PARTICLESPAWNER
* backface_culling flag in TileDef
* rightclickable field in nodedef
* damageGroups added to ToolCapabilities
* sound_place added to ItemDefinition
* custom HUD
* player breath
* range added to ItemDefinition
* drowning, leveled and liquid_range added to ContentFeatures
* stepheight and collideWithObjects added to object properties
* version, heat and humidity transfer in MapBock
* automatic_face_movement_dir and automatic_face_movement_dir_offset added to object properties
* add swap_node

If we choose to bump to 0.4.13, protocol interesting changes are:
* TOCLIENT_ACCESS_DENIED for refusing player with standard or custom messages
* secure SRP authentication
* TileDef tileable_horizontal, tileable_vertical flags

Please vote for a minimum version (0.4.11 or 0.4.13). @minetest/team-minetest 

* 0.4.11 (5 votes)
* 0.4.13 (0 votes)