### PR TITLE
Climb speed: Increase to 3.5n/s

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -802,7 +802,7 @@ movement_acceleration_fast (Fast mode acceleration) float 10
 movement_speed_walk (Walking speed) float 4
 movement_speed_crouch (Crouch speed) float 1.35
 movement_speed_fast (Fast mode speed) float 20
-movement_speed_climb (Climbing speed) float 3
+movement_speed_climb (Climbing speed) float 3.5
 movement_speed_jump (Jumping speed) float 6.5
 movement_speed_descend (Descending speed) float 6
 movement_liquid_fluidity (Liquid fluidity) float 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -970,7 +970,7 @@ enable_client_modding (Client modding) bool false
 # movement_speed_fast = 20
 
 #    type: float
-# movement_speed_climb = 3
+# movement_speed_climb = 3.5
 
 #    type: float
 # movement_speed_jump = 6.5

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -316,7 +316,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("movement_speed_walk", "4");
 	settings->setDefault("movement_speed_crouch", "1.35");
 	settings->setDefault("movement_speed_fast", "20");
-	settings->setDefault("movement_speed_climb", "3");
+	settings->setDefault("movement_speed_climb", "3.5");
 	settings->setDefault("movement_speed_jump", "6.5");
 	settings->setDefault("movement_liquid_fluidity", "1");
 	settings->setDefault("movement_liquid_fluidity_smooth", "0.5");


### PR DESCRIPTION
As partial compensation for the loss of the sneak ladder which had a high
movement speed. Mods are being used to create replacements for the sneak
ladder and these will often be using climbable nodes.
3.5n/s feels the highest reasonable speed for climbing, and means that
stairs still have a slight speed advantage (4n/s vertical movement)
as reward for being harder to build.
Minetest is very (and increasingly) vertical, this helps by making
ladders and other climbable nodes no longer significantly slower than
stairs.
///////////////////////////////////////////////////////

When testing, the current 3 is very reasonable, doesn't feel slow but also doesn't feel fast.
4 seems just too fast, even for our hyperactive character.
You can easily test this by using this line in .conf:
movement_speed_climb = 3.5