### PR TITLE
Add clang format & skip build if no source file modified

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false

--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ UseTab: Always
 BreakBeforeBraces: Linux
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
+AccessModifierOffset: -8

--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,8 @@ BreakBeforeBraces: Linux
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
 AccessModifierOffset: -8
+IncludeCategories:
+  - Regex:           '^".*'
+    Priority:        2
+  - Regex:           '^<.*'
+    Priority:        1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       compiler: clang
       os: linux
       dist: trusty
-    - env: PLATFORM=Unix COMPILER=clang CC=none LINT=1
+    - env: COMPILER=none LINT=1
       compiler: clang
       os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
       compiler: clang
       os: linux
       dist: trusty
+    - env: PLATFORM=Unix COMPILER=clang CC=none LINT=1
+      compiler: clang
+      os: linux
+      dist: trusty
     - env: PLATFORM=Unix COMPILER=g++-6
       compiler: gcc
       os: linux

--- a/src/nameidmapping.h
+++ b/src/nameidmapping.h
@@ -32,10 +32,12 @@ public:
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
 
-	void clear(){
+	void clear()
+	{
 		m_id_to_name.clear();
 		m_name_to_id.clear();
 	}
+
 	void set(u16 id, const std::string &name){
 		m_id_to_name[id] = name;
 		m_name_to_id[name] = id;

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -e
 echo "Preparing for $TRAVIS_COMMIT_RANGE"
-. util/travis/common.sh
 
+if [[ "$LINT" == "1" ]]; then
+	curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+	sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
+	sudo apt-get -yq update
+	sudo apt-get install clang-format-3.9
+	exit 0
+fi
+
+. util/travis/common.sh
 needs_compile || exit 0
 
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
@@ -11,6 +19,7 @@ fi
 
 if [[ $PLATFORM == "Unix" ]]; then
 	if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+		sudo apt-get update
 		sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
 			libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
 			libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
@@ -21,12 +30,7 @@ if [[ $PLATFORM == "Unix" ]]; then
 		if [[ "$VALGRIND" == "1" ]]; then
 			sudo apt-get install valgrind
 		fi
-		if [[ "$LINT" == "1" ]]; then
-			curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-			sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-			sudo apt-get -yq update
-			sudo apt-get install clang-format-3.9
-		fi
+
 	else
 		brew update
 		brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -21,6 +21,12 @@ if [[ $PLATFORM == "Unix" ]]; then
 		if [[ "$VALGRIND" == "1" ]]; then
 			sudo apt-get install valgrind
 		fi
+		if [[ "$LINT" == "1" ]]; then
+			curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+			sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
+			sudo apt-get -yq update
+			sudo apt-get install clang-format-3.9
+		fi
 	else
 		brew update
 		brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit

--- a/util/travis/common.sh
+++ b/util/travis/common.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
 # Relative to git-repository root:
-TRIGGER_COMPILE_PATHS="src/|CMakeLists.txt|cmake/Modules/|util/travis/|util/buildbot/"
+TRIGGER_COMPILE_PATHS="src/.*\.(c|cpp|h)|CMakeLists.txt|cmake/Modules/|util/travis/|util/buildbot/"
 
 needs_compile() {
 	git diff --name-only $TRAVIS_COMMIT_RANGE | egrep -q "^($TRIGGER_COMPILE_PATHS)"
 }
+

--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -34,13 +34,14 @@ if [ $(git diff --name-only --diff-filter=ACMRTUXB $TRAVIS_COMMIT_RANGE | grep -
 	exit 0
 fi
 
+if [[ "$LINT" == "1" ]]; then
+	# Lint with exit CI
+	perform_lint
+fi
+
 if [[ $PLATFORM == "Unix" ]]; then
 	mkdir -p travisbuild
 	cd travisbuild || exit 1
-	if [[ "$LINT" == "1" ]]; then
-		# Lint with exit CI
-		perform_lint
-	fi
 
 	CMAKE_FLAGS=''
 	if [[ $COMPILER == "g++-6" ]]; then


### PR DESCRIPTION
Warning: it check the whole modified file, not the diff part, it's why it's lazy. Please also look if rules are perfect, i take the Linux codestyle from LLVM site

Fix issue #5415 
ping @sfan5 

I also skip build if we didn't modified any CPP file as there is nothing to test