### PR TITLE
[CSM] Add function to get player names in range

### DIFF
--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -102,7 +102,7 @@ core.register_on_punchnode(function(pos, node)
 	print(dump(itemstack:get_count()))
 	print(dump(itemstack:get_wear()))
 	print(dump(itemstack:get_meta()))
-	print(dump(itemstack:get_metadata()))
+	print(dump(itemstack:get_metadata()
 	print(dump(itemstack:is_known()))
 	--print(dump(itemstack:get_definition()))
 	print(dump(itemstack:get_tool_capabilities()))
@@ -120,3 +120,10 @@ core.register_on_punchnode(function(pos, node)
 	print("node:" .. dump(node))
 	return false
 end)
+
+-- This is an example function to ensure it's working properly, should be removed before merge
+core.register_chatcommand("list_players", {
+	func = function(param)
+		core.display_chat_message(dump(core.get_player_names()))
+	end
+})

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -737,6 +737,10 @@ Call these functions only at load time!
 * `minetest.get_wielded_item()`
     * Returns the itemstack the local player is holding
 
+### Client Environment
+* `minetest.get_names_in_range()`
+    * Returns list of player names on server in range
+
 ### Misc.
 * `minetest.parse_json(string[, nullvalue])`: returns something
     * Convert a string containing JSON data into the Lua equivalent

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -738,7 +738,7 @@ Call these functions only at load time!
     * Returns the itemstack the local player is holding
 
 ### Client Environment
-* `minetest.get_names_in_range()`
+* `minetest.get_player_names_in_range()`
     * Returns list of player names on server in range
 
 ### Misc.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -739,7 +739,7 @@ Call these functions only at load time!
 
 ### Client Environment
 * `minetest.get_player_names()`
-    * Returns list of player names on server in range
+    * Returns list of player names on server
 
 ### Misc.
 * `minetest.parse_json(string[, nullvalue])`: returns something

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -738,7 +738,7 @@ Call these functions only at load time!
     * Returns the itemstack the local player is holding
 
 ### Client Environment
-* `minetest.get_player_names_in_range()`
+* `minetest.get_player_names()`
     * Returns list of player names on server in range
 
 ### Misc.

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -69,8 +69,8 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
-// get_player_names_in_range()
-int ModApiClient::l_get_player_names_in_range(lua_State *L)
+// get_player_names()
+int ModApiClient::l_get_player_names(lua_State *L)
 {
 	const std::list<std::string> &plist = getClient(L)->getConnectedPlayerNames();
 	lua_createtable(L, plist.size(), 0);
@@ -170,7 +170,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
 	API_FCT(display_chat_message);
-	API_FCT(get_player_names_in_range);
+	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);
 	API_FCT(show_formspec);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -69,6 +69,23 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
+// get_names_in_range()
+int ModApiClient::l_get_names_in_range(lua_State *L)
+{
+	const std::list<std::string> plist = getClient(L)->getConnectedPlayerNames();
+	lua_createtable(L, plist.size(), 0);
+	int newTable = lua_gettop(L);
+	int index = 1;
+	std::list<std::string>::const_iterator iter = plist.begin();
+	while(iter != plist.end()) {
+		lua_pushstring(L, (*iter).c_str());
+		lua_rawseti(L, newTable, index);
+		++iter;
+		++index;
+	}
+	return 1; 
+}
+
 // show_formspec(formspec)
 int ModApiClient::l_show_formspec(lua_State *L)
 {
@@ -154,6 +171,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
 	API_FCT(display_chat_message);
+	API_FCT(get_names_in_range);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);
 	API_FCT(show_formspec);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -69,21 +69,20 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
-// get_names_in_range()
-int ModApiClient::l_get_names_in_range(lua_State *L)
+// get_player_names_in_range()
+int ModApiClient::l_get_player_names_in_range(lua_State *L)
 {
-	const std::list<std::string> plist = getClient(L)->getConnectedPlayerNames();
+	const std::list<std::string> &plist = getClient(L)->getConnectedPlayerNames();
 	lua_createtable(L, plist.size(), 0);
 	int newTable = lua_gettop(L);
 	int index = 1;
-	std::list<std::string>::const_iterator iter = plist.begin();
-	while(iter != plist.end()) {
+	std::list<std::string>::const_iterator iter;
+	for (iter = plist.begin(); iter != plist.end(); iter++) {
 		lua_pushstring(L, (*iter).c_str());
 		lua_rawseti(L, newTable, index);
-		++iter;
-		++index;
+		index++;
 	}
-	return 1; 
+	return 1;
 }
 
 // show_formspec(formspec)
@@ -171,7 +170,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
 	API_FCT(display_chat_message);
-	API_FCT(get_names_in_range);
+	API_FCT(get_player_names_in_range);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);
 	API_FCT(show_formspec);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -32,8 +32,8 @@ private:
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 	
-	// get_names_in_range()
-	static int l_get_names_in_range(lua_State *L);
+	// get_player_names_in_range()
+	static int l_get_player_names_in_range(lua_State *L);
 
 	// show_formspec(name, fornspec)
 	static int l_show_formspec(lua_State *L);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -31,6 +31,9 @@ private:
 
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
+	
+	// get_names_in_range()
+	static int l_get_names_in_range(lua_State *L);
 
 	// show_formspec(name, fornspec)
 	static int l_show_formspec(lua_State *L);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -32,8 +32,8 @@ private:
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 	
-	// get_player_names_in_range()
-	static int l_get_player_names_in_range(lua_State *L);
+	// get_player_names()
+	static int l_get_player_names(lua_State *L);
 
 	// show_formspec(name, fornspec)
 	static int l_show_formspec(lua_State *L);


### PR DESCRIPTION
This function called `get_names_in_range()` returns a list of strings of player names sent to the client.