### PR TITLE
[CSM] Change command prefix to "." and add "help" command.

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -2,27 +2,35 @@
 
 
 core.register_on_sending_chat_messages(function(message)
-	if not (message:sub(1,1) == "/") then
+	local first_char = message:sub(1,1)
+	if first_char == "/" or first_char == "." then
+		core.display_chat_message("issued command: " .. message)
+	end
+
+	if first_char ~= "." then
 		return false
 	end
 
-	core.display_chat_message("issued command: " .. message)
-
-	local cmd, param = string.match(message, "^/([^ ]+) *(.*)")
+	local cmd, param = string.match(message, "^%.([^ ]+) *(.*)")
 	if not param then
 		param = ""
 	end
 
-	local cmd_def = core.registered_chatcommands[cmd]
+	if not cmd then
+		core.display_chat_message("-!- Empty command")
+		return true
+	end
 
+	local cmd_def = core.registered_chatcommands[cmd]
 	if cmd_def then
 		core.set_last_run_mod(cmd_def.mod_origin)
 		local _, message = cmd_def.func(param)
 		if message then
 			core.display_chat_message(message)
 		end
-		return true
+	else
+		core.display_chat_message("-!- Invalid command: " .. cmd)
 	end
 
-	return false
+	return true
 end)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -82,61 +82,6 @@ core.register_chatcommand("admin", {
 	end,
 })
 
-core.register_chatcommand("help", {
-	privs = {},
-	params = "[all/privs/<cmd>]",
-	description = "Get help for commands or list privileges",
-	func = function(name, param)
-		local function format_help_line(cmd, def)
-			local msg = core.colorize("#00ffff", "/"..cmd)
-			if def.params and def.params ~= "" then
-				msg = msg .. " " .. def.params
-			end
-			if def.description and def.description ~= "" then
-				msg = msg .. ": " .. def.description
-			end
-			return msg
-		end
-		if param == "" then
-			local msg = ""
-			local cmds = {}
-			for cmd, def in pairs(core.registered_chatcommands) do
-				if core.check_player_privs(name, def.privs) then
-					cmds[#cmds + 1] = cmd
-				end
-			end
-			table.sort(cmds)
-			return true, "Available commands: " .. table.concat(cmds, " ") .. "\n"
-					.. "Use '/help <cmd>' to get more information,"
-					.. " or '/help all' to list everything."
-		elseif param == "all" then
-			local cmds = {}
-			for cmd, def in pairs(core.registered_chatcommands) do
-				if core.check_player_privs(name, def.privs) then
-					cmds[#cmds + 1] = format_help_line(cmd, def)
-				end
-			end
-			table.sort(cmds)
-			return true, "Available commands:\n"..table.concat(cmds, "\n")
-		elseif param == "privs" then
-			local privs = {}
-			for priv, def in pairs(core.registered_privileges) do
-				privs[#privs + 1] = priv .. ": " .. def.description
-			end
-			table.sort(privs)
-			return true, "Available privileges:\n"..table.concat(privs, "\n")
-		else
-			local cmd = param
-			local def = core.registered_chatcommands[cmd]
-			if not def then
-				return false, "Command not available: "..cmd
-			else
-				return true, format_help_line(cmd, def)
-			end
-		end
-	end,
-})
-
 core.register_chatcommand("privs", {
 	params = "<name>",
 	description = "Print privileges of player",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -156,6 +156,10 @@ keymap_chat (Chat key) key KEY_KEY_T
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_cmd (Command key) key /
 
+#    Key for opening the chat window to type local commands.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+keymap_cmd_local (Command key) key .
+
 #    Key for opening the chat console.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keyman_console (Console key) key KEY_F10

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -148,6 +148,11 @@
 #    type: key
 # keymap_cmd = /
 
+#    Key for opening the chat window to type local commands.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#    type: key
+# keymap_cmd_local = .
+
 #    Key for opening the chat console.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -42,6 +42,7 @@ public:
 		INVENTORY,
 		CHAT,
 		CMD,
+		CMD_LOCAL,
 		CONSOLE,
 		MINIMAP,
 		FREEMOVE,

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -71,6 +71,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_special1", "KEY_KEY_E");
 	settings->setDefault("keymap_chat", "KEY_KEY_T");
 	settings->setDefault("keymap_cmd", "/");
+	settings->setDefault("keymap_cmd_local", ".");
 	settings->setDefault("keymap_minimap", "KEY_F9");
 	settings->setDefault("keymap_console", "KEY_F10");
 	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1034,6 +1034,7 @@ void KeyCache::populate()
 	key[KeyType::INVENTORY]    = getKeySetting("keymap_inventory");
 	key[KeyType::CHAT]         = getKeySetting("keymap_chat");
 	key[KeyType::CMD]          = getKeySetting("keymap_cmd");
+	key[KeyType::CMD_LOCAL]    = getKeySetting("keymap_cmd_local");
 	key[KeyType::CONSOLE]      = getKeySetting("keymap_console");
 	key[KeyType::MINIMAP]      = getKeySetting("keymap_minimap");
 	key[KeyType::FREEMOVE]     = getKeySetting("keymap_freemove");
@@ -2449,6 +2450,8 @@ void Game::processKeyInput()
 		openConsole(0.2, L"");
 	} else if (wasKeyDown(KeyType::CMD)) {
 		openConsole(0.2, L"/");
+	} else if (wasKeyDown(KeyType::CMD_LOCAL)) {
+		openConsole(0.2, L".");
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
 		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -53,6 +53,7 @@ enum
 	GUI_ID_KEY_CINEMATIC_BUTTON,
 	GUI_ID_KEY_CHAT_BUTTON,
 	GUI_ID_KEY_CMD_BUTTON,
+	GUI_ID_KEY_CMD_LOCAL_BUTTON,
 	GUI_ID_KEY_CONSOLE_BUTTON,
 	GUI_ID_KEY_SNEAK_BUTTON,
 	GUI_ID_KEY_DROP_BUTTON,
@@ -408,6 +409,7 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON, wgettext("Inventory"),        "keymap_inventory");
 	this->add_key(GUI_ID_KEY_CHAT_BUTTON,      wgettext("Chat"),             "keymap_chat");
 	this->add_key(GUI_ID_KEY_CMD_BUTTON,       wgettext("Command"),          "keymap_cmd");
+	this->add_key(GUI_ID_KEY_CMD_LOCAL_BUTTON, wgettext("Local command"),    "keymap_cmd_local");
 	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,   wgettext("Console"),          "keymap_console");
 	this->add_key(GUI_ID_KEY_FLY_BUTTON,       wgettext("Toggle fly"),       "keymap_freemove");
 	this->add_key(GUI_ID_KEY_FAST_BUTTON,      wgettext("Toggle fast"),      "keymap_fastmove");


### PR DESCRIPTION
Setting the prefix to "/" makes writing client-sided mods harder because you risk blocking access to server-sided commands. It also makes it harder to add a "help" command as a different name has to be used.