### PR TITLE
lua API for deregistering single biomes

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -496,15 +496,12 @@ end
 
 local function make_wrap_deregistration(reg_fn, clear_fn, list)
 	local unregister = function (unregistered_key)
-		local temporary_list = {}
-		for k, v in pairs(list) do
-			if unregistered_key ~= k then
-				temporary_list[k] = v
-			end
-		end
+		local temporary_list = table.copy(list)
 		clear_fn()
 		for k,v in pairs(temporary_list) do
-			reg_fn(v)
+			if unregistered_key ~= k then
+				reg_fn(v)
+			end
 		end
 	end
 	return unregister

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -494,6 +494,22 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 	return list
 end
 
+local function make_wrap_deregistration(reg_fn, clear_fn, list)
+	local unregister = function (unregistered_key)
+		local temporary_list = {}
+		for k, v in pairs(list) do
+			if unregistered_key ~= k then
+				temporary_list[k] = v
+			end
+		end
+		clear_fn()
+		for k,v in pairs(temporary_list) do
+			reg_fn(v)
+		end
+	end
+	return unregister
+end
+
 core.registered_on_player_hpchanges = { modifiers = { }, loggers = { } }
 
 function core.registered_on_player_hpchange(player, hp_change)
@@ -531,6 +547,8 @@ end
 core.registered_biomes      = make_registration_wrap("register_biome",      "clear_registered_biomes")
 core.registered_ores        = make_registration_wrap("register_ore",        "clear_registered_ores")
 core.registered_decorations = make_registration_wrap("register_decoration", "clear_registered_decorations")
+
+core.unregister_biome = make_wrap_deregistration(core.register_biome, core.clear_registered_biomes, core.registered_biomes)
 
 core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
 core.registered_globalsteps, core.register_globalstep = make_registration()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -520,6 +520,10 @@ the global `minetest.registered_*` tables.
     * added to `minetest.registered_biome` with the key of `biome.name`
     * if `biome.name` is nil, the key is the returned ID
 
+* `minetest.unregister_biome(name)`
+    * Unregisters the biome name from engine, and deletes the entry with key
+    * `name` from `minetest.registered_biome`
+
 * `minetest.register_ore(ore definition)`
     * returns an integer uniquely identifying the registered ore
     * added to `minetest.registered_ores` with the key of `ore.name`


### PR DESCRIPTION
Instead of implementing a mgv6-like "nojungles" (https://github.com/minetest/minetest_game/pull/1661) setting, deregistering the unwanted biomes from a mod seems like the right approach. However, there doesn't seem to be an API function that allows doing so without having to bother with biome registration internals (having to re-register all the biomes not meant to be removed).