### PR TITLE
Fix upside down textures

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -850,10 +850,10 @@ void MapblockMeshGenerator::drawPlantlikeQuad(float rotation, float quad_offset,
 		PseudoRandom yrng(face_num++ | p.X << 16 | p.Z << 8 | p.Y << 24);
 		offset.Y = BS * ((yrng.next() % 16 / 16.0) * 0.125);
 	}
-	int offset_first_index = offset_top_only ? 2 : 0;
+	int offset_first_count = offset_top_only ? 2 : 4;
+	for (int i = 0; i < offset_first_count; i++)
+		vertices[i].Z += quad_offset;
 	for (int i = 0; i < 4; i++) {
-		if (i >= offset_first_index)
-			vertices[i].Z += quad_offset;
 		vertices[i].rotateXZBy(rotation + rotate_degree);
 		vertices[i] += offset;
 	}

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -97,7 +97,7 @@ TileSpec MapblockMeshGenerator::getTile(const v3s16& direction)
 
 void MapblockMeshGenerator::drawQuad(v3f *coords, const v3s16 &normal)
 {
-	static const v2f tcoords[4] = {v2f(0, 1), v2f(1, 1), v2f(1, 0), v2f(0, 0)};
+	static const v2f tcoords[4] = {v2f(0, 0), v2f(1, 0), v2f(1, 1), v2f(0, 1)};
 	video::S3DVertex vertices[4];
 	bool shade_face = !f->light_source && (normal != v3s16(0, 0, 0));
 	v3f normal2(normal.X, normal.Y, normal.Z);
@@ -630,22 +630,22 @@ void MapblockMeshGenerator::drawGlasslikeNode()
 		// Don't make face if neighbor is of same type
 		if (neighbor.getContent() == n.getContent())
 			continue;
+		// Face at Z-
 		v3f vertices[4] = {
-			v3f(-BS / 2, -BS / 2, BS / 2),
-			v3f( BS / 2, -BS / 2, BS / 2),
-			v3f( BS / 2,  BS / 2, BS / 2),
-			v3f(-BS / 2,  BS / 2, BS / 2),
+			v3f(-BS / 2,  BS / 2, -BS / 2),
+			v3f( BS / 2,  BS / 2, -BS / 2),
+			v3f( BS / 2, -BS / 2, -BS / 2),
+			v3f(-BS / 2, -BS / 2, -BS / 2),
 		};
 		for (int i = 0; i < 4; i++) {
-			// Rotations in the g_6dirs format
 			switch (face) {
-				case 0: vertices[i].rotateXZBy(  0); break; // Z+
-				case 1: vertices[i].rotateYZBy(-90); break; // Y+
-				case 2: vertices[i].rotateXZBy(-90); break; // X+
-				case 3: vertices[i].rotateXZBy(180); break; // Z-
-				case 4: vertices[i].rotateYZBy( 90); break; // Y-
-				case 5: vertices[i].rotateXZBy( 90); break; // X-
-			};
+				case D6D_ZP: vertices[i].rotateXZBy(180); break;
+				case D6D_YP: vertices[i].rotateYZBy( 90); break;
+				case D6D_XP: vertices[i].rotateXZBy( 90); break;
+				case D6D_ZN: vertices[i].rotateXZBy(  0); break;
+				case D6D_YN: vertices[i].rotateYZBy(-90); break;
+				case D6D_XN: vertices[i].rotateXZBy(-90); break;
+			}
 		}
 		drawQuad(vertices, dir);
 	}
@@ -793,10 +793,10 @@ void MapblockMeshGenerator::drawTorchlikeNode()
 
 	float size = BS / 2 * f->visual_scale;
 	v3f vertices[4] = {
-		v3f(-size, -size, 0),
-		v3f( size, -size, 0),
-		v3f( size,  size, 0),
 		v3f(-size,  size, 0),
+		v3f( size,  size, 0),
+		v3f( size, -size, 0),
+		v3f(-size, -size, 0),
 	};
 	for (int i = 0; i < 4; i++) {
 		switch (wall) {
@@ -841,10 +841,10 @@ void MapblockMeshGenerator::drawPlantlikeQuad(float rotation, float quad_offset,
 	bool offset_top_only)
 {
 	v3f vertices[4] = {
-		v3f(-scale, -BS / 2, 0),
-		v3f( scale, -BS / 2, 0),
-		v3f( scale, -BS / 2 + scale * 2, 0),
 		v3f(-scale, -BS / 2 + scale * 2, 0),
+		v3f( scale, -BS / 2 + scale * 2, 0),
+		v3f( scale, -BS / 2, 0),
+		v3f(-scale, -BS / 2, 0),
 	};
 	if (random_offset_Y) {
 		PseudoRandom yrng(face_num++ | p.X << 16 | p.Z << 8 | p.Y << 24);
@@ -929,10 +929,10 @@ void MapblockMeshGenerator::drawFirelikeQuad(float rotation, float opening_angle
 	float offset_h, float offset_v)
 {
 	v3f vertices[4] = {
-		v3f(-scale, -BS / 2, 0),
-		v3f( scale, -BS / 2, 0),
-		v3f( scale, -BS / 2 + scale * 2, 0),
 		v3f(-scale, -BS / 2 + scale * 2, 0),
+		v3f( scale, -BS / 2 + scale * 2, 0),
+		v3f( scale, -BS / 2, 0),
+		v3f(-scale, -BS / 2, 0),
 	};
 	for (int i = 0; i < 4; i++) {
 		vertices[i].rotateYZBy(opening_angle);
@@ -1147,10 +1147,10 @@ void MapblockMeshGenerator::drawRaillikeNode()
 	static const float size   = BS / 2;
 	float y2 = sloped ? size : -size;
 	v3f vertices[4] = {
-		v3f(-size, -size + offset, -size),
-		v3f( size, -size + offset, -size),
-		v3f( size,    y2 + offset,  size),
 		v3f(-size,    y2 + offset,  size),
+		v3f( size,    y2 + offset,  size),
+		v3f( size, -size + offset, -size),
+		v3f(-size, -size + offset, -size),
 	};
 	if (angle)
 		for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Fixes for `signlike` and `glasslike`. Doesn’t break `torchlike` or `raillike`. May break `plantlike` and `firelike` with backface culling (which is disabled by default).

It’s difficult to catch such errors in casual testing as default nodes have no visual orientation. This is how I tested this patch (notice signs near the crosshair):
![screenshot_20170325_212123](https://cloud.githubusercontent.com/assets/7352626/24324944/feb92502-11a8-11e7-909d-d20b36138306.png)
