### PR TITLE
Sneak: Set 'sneak glitch' physics override default to 'false' 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3000,7 +3000,8 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
-        * `sneak_glitch`: whether player can use the sneak glitch (default: `true`)
+        * `sneak_glitch`: whether player can use the 'sneak glitch'
+          and sneak ladder (default: `false`)
 * `get_physics_override()`: returns the table given to set_physics_override
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -788,7 +788,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_physics_override_jump(1),
 	m_physics_override_gravity(1),
 	m_physics_override_sneak(true),
-	m_physics_override_sneak_glitch(true),
+	m_physics_override_sneak_glitch(false),
 	m_physics_override_sent(false)
 {
 	assert(m_peer_id != 0);	// pre-condition

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -48,7 +48,7 @@ LocalPlayer::LocalPlayer(Client *client, const char *name):
 	physics_override_jump(1.0f),
 	physics_override_gravity(1.0f),
 	physics_override_sneak(true),
-	physics_override_sneak_glitch(true),
+	physics_override_sneak_glitch(false),
 	overridePosition(v3f(0,0,0)),
 	last_position(v3f(0,0,0)),
 	last_speed(v3f(0,0,0)),


### PR DESCRIPTION
The 'sneak glitch' physics override now enables the new sneak ladder
code, so should be disabled by default as the new sneak ladder cannot
be a default in a game engine.
The new sneak ladder is not affected by the 'climbable' node property
which should decide the ability to climb, or the 'movement_speed_climb'
setting which should decide the speed of climbing, the speed of climb
is also unreasonably fast.
////////////////////////////////////////////////////////

This can probably wait until closer to release.
Tested.
@rubenwardy @Ekdohibs @sofar @sfan5 