### PR TITLE
Add CPP11 header to define nullptr & constexpr

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client.h"
 #include "log.h"
 #include "noise.h"
+#include "util/cpp11.h"
 
 // Distance of light extrapolation (for oversized nodes)
 // After this distance, it gives up and considers light level constant
@@ -42,7 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Corresponding offsets are listed in g_27dirs
 #define FRAMED_NEIGHBOR_COUNT 18
 
-static const v3s16 light_dirs[8] = {
+static constexpr v3s16 light_dirs[8] = {
 	v3s16(-1, -1, -1),
 	v3s16(-1, -1,  1),
 	v3s16(-1,  1, -1),
@@ -54,7 +55,7 @@ static const v3s16 light_dirs[8] = {
 };
 
 // Standard index set to make a quad on 4 vertices
-static const u16 quad_indices[] = {0, 1, 2, 2, 3, 0};
+static constexpr u16 quad_indices[] = {0, 1, 2, 2, 3, 0};
 
 const std::string MapblockMeshGenerator::raillike_groupname = "connect_to_raillike";
 

--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -22,12 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapblock.h"
 #include "nodedef.h"
 #include "util/timetaker.h"
+#include "util/cpp11.h"
 
 
 ReflowScan::ReflowScan(Map *map, INodeDefManager *ndef) :
 	m_map(map),
 	m_ndef(ndef),
-	m_liquid_queue(NULL)
+	m_liquid_queue(nullptr)
 {
 }
 
@@ -41,7 +42,7 @@ void ReflowScan::scan(MapBlock *block, UniqueQueue<v3s16> *liquid_queue)
 	// scanned block. Blocks are only added to the lookup if they are really
 	// needed. The lookup is indexed manually to use the same index in a
 	// bit-array (of uint32 type) which stores for unloaded blocks that they
-	// were already fetched from Map but were actually NULL.
+	// were already fetched from Map but were actually nullptr.
 	memset(m_lookup, 0, sizeof(m_lookup));
 	int block_idx = 1 + (1 * 9) + (1 * 3);
 	m_lookup[block_idx] = block;

--- a/src/util/cpp11.h
+++ b/src/util/cpp11.h
@@ -1,0 +1,32 @@
+/*
+Minetest
+Copyright (C) 2016 nerzhul, Loic Blot <loic.blot@unix-experience.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef MT_CPP11_HEADER
+#define MT_CPP11_HEADER
+
+#if __cplusplus < 201103L || _MSC_VER < 1600
+#define USE_CPP11_FAKE_KEYWORD
+#endif
+
+#ifdef USE_CPP11_FAKE_KEYWORD
+#define constexpr const
+#define nullptr NULL
+#endif
+
+#endif


### PR DESCRIPTION
This header permit to use nullptr & constexpr keywords in portable code segments and benefit from nullptr & constexpr when using C++11 and greater

i setted it in two places, now we should look at CI :)