### PR TITLE
Sneak glitch option: Add ability to climb onto a 2 node high ledge

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -125,6 +125,16 @@ static bool detectSneakLadder(Map *map, INodeDefManager *nodemgr, v3s16 pos)
 	for (u16 i = 0; i < ARRLEN(vecs); i++) {
 		const v2s16 vec = vecs[i];
 
+		// Detect ledge for 2-node pull-up
+		node = GETNODE(map, pos, vec, 1, &is_valid_position);
+		if (is_valid_position && nodemgr->get(node).walkable) {
+			// Ledge exists
+			node = GETNODE(map, pos, vec, 2, &is_valid_position);
+			if (is_valid_position && !nodemgr->get(node).walkable)
+				// Space above ledge exists
+				return true;
+		}
+
 		// walkability of bottom & top node should differ
 		node = GETNODE(map, pos, vec, 0, &is_valid_position);
 		if (!is_valid_position)


### PR DESCRIPTION
The 'sneak_glitch' physics override enables the new sneak ladder option.
Add into this option the old sneak-plus-jump ability to climb onto a
2 node high ledge.
//////////////////////////////////////////////////////

Works but needs testing in various other situations to check for problem behaviour.
Replaces #5460 

![screenshot_20170325_012257](https://cloud.githubusercontent.com/assets/3686677/24318223/a4fc6772-10f9-11e7-9c5f-dd9a882a39e7.png)

The code i add here in the 'detect sneak ladder' loop is actually all that is needed to make the corner sneak ladder (on the left) work, the existing code becomes a back up that makes the centre ladder work too. The simple sneak ladder, a single column of alternating nodes, still does not work (it didn't before).