### PR TITLE
Paramtype2: Add missing type CPT2_GLASSLIKE_LIQUID_LEVEL

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -658,6 +658,10 @@ node definition:
       The first five bits of `param2` tells which color
       is picked from the palette.
       The palette should have 32 pixels.
+    paramtype2 == "glasslikeliquidlevel"
+    ^ Only valid for "glasslike_framed" or "glasslike_framed_optional" drawtypes.
+      param2 defines 64 levels of internal liquid.
+      Liquid texture is defined using `special_tiles = {"modname_tilename.png"},`
     collision_box = {
       type = "fixed",
       fixed = {

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -759,8 +759,11 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 		drawAutoLightedCuboid(glass_faces[face]);
 	}
 
-	if (param2 > 0 && f->special_tiles[0].texture) {
-		// Interior volume level is in range 0 .. 63,
+	// Optionally render internal liquid level defined by param2
+	// Liquid is textured with 1 tile defined in nodedef 'special_tiles'
+	if (param2 > 0 && f->param_type_2 == CPT2_GLASSLIKE_LIQUID_LEVEL &&
+			f->special_tiles[0].texture) {
+		// Internal liquid level has param2 range 0 .. 63,
 		// convert it to -0.5 .. 0.5
 		float vlev = (param2 / 63.0) * 2.0 - 1.0;
 		tile = getSpecialTile(*f, n, 0);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -74,7 +74,9 @@ enum ContentParamType2
 	// 3 bits of palette index, then facedir
 	CPT2_COLORED_FACEDIR,
 	// 5 bits of palette index, then wallmounted
-	CPT2_COLORED_WALLMOUNTED
+	CPT2_COLORED_WALLMOUNTED,
+	// Glasslike framed drawtype internal liquid level, param2 values 0 to 63
+	CPT2_GLASSLIKE_LIQUID_LEVEL,
 };
 
 enum LiquidType
@@ -144,26 +146,46 @@ public:
 
 enum NodeDrawType
 {
-	NDT_NORMAL, // A basic solid block
-	NDT_AIRLIKE, // Nothing is drawn
-	NDT_LIQUID, // Do not draw face towards same kind of flowing/source liquid
-	NDT_FLOWINGLIQUID, // A very special kind of thing
-	NDT_GLASSLIKE, // Glass-like, don't draw faces towards other glass
-	NDT_ALLFACES, // Leaves-like, draw all faces no matter what
-	NDT_ALLFACES_OPTIONAL, // Fancy -> allfaces, fast -> normal
+	// A basic solid block
+	NDT_NORMAL,
+	// Nothing is drawn
+	NDT_AIRLIKE,
+	// Do not draw face towards same kind of flowing/source liquid
+	NDT_LIQUID,
+	// A very special kind of thing
+	NDT_FLOWINGLIQUID,
+	// Glass-like, don't draw faces towards other glass
+	NDT_GLASSLIKE,
+	// Leaves-like, draw all faces no matter what
+	NDT_ALLFACES,
+	// Enabled -> ndt_allfaces, disabled -> ndt_normal
+	NDT_ALLFACES_OPTIONAL,
+	// Single plane perpendicular to a surface
 	NDT_TORCHLIKE,
+	// Single plane parallel to a surface
 	NDT_SIGNLIKE,
+	// 2 vertical planes in a 'X' shape diagonal to XZ axes.
+	// paramtype2 = "meshoptions" allows various forms, sizes and
+	// vertical and horizontal random offsets.
 	NDT_PLANTLIKE,
+	// Fenceposts that connect to neighbouring fenceposts with horizontal bars
 	NDT_FENCELIKE,
+	// Selects appropriate junction texture to connect like rails to
+	// neighbouring raillikes.
 	NDT_RAILLIKE,
+	// Custom Lua-definable structure of multiple cuboids
 	NDT_NODEBOX,
-	NDT_GLASSLIKE_FRAMED, // Glass-like, draw connected frames and all all
-	                      // visible faces
-						  // uses 2 textures, one for frames, second for faces
-	NDT_FIRELIKE, // Draw faces slightly rotated and only on connecting nodes,
-	NDT_GLASSLIKE_FRAMED_OPTIONAL,	// enabled -> connected, disabled -> Glass-like
-									// uses 2 textures, one for frames, second for faces
-	NDT_MESH, // Uses static meshes
+	// Glass-like, draw connected frames and all visible faces.
+	// param2 > 0 defines 64 levels of internal liquid
+	// Uses 3 textures, one for frames, second for faces,
+	// optional third is a 'special tile' for the liquid.
+	NDT_GLASSLIKE_FRAMED,
+	// Draw faces slightly rotated and only on neighbouring nodes
+	NDT_FIRELIKE,
+	// Enabled -> ndt_glasslike_framed, disabled -> ndt_glasslike
+	NDT_GLASSLIKE_FRAMED_OPTIONAL,
+	// Uses static meshes
+	NDT_MESH,
 };
 
 // Mesh options for NDT_PLANTLIKE with CPT2_MESHOPTIONS

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -62,6 +62,7 @@ struct EnumString ScriptApiNode::es_ContentParamType2[] =
 		{CPT2_COLOR, "color"},
 		{CPT2_COLORED_FACEDIR, "colorfacedir"},
 		{CPT2_COLORED_WALLMOUNTED, "colorwallmounted"},
+		{CPT2_GLASSLIKE_LIQUID_LEVEL, "glasslikeliquidlevel"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
Add the missing paramtype2 for param2 controlling the liquid level
inside the glasslike_framed drawtype.
Add missing documentation of the feature to lua_api.txt.
Update and improve comments for drawtype enumerations in nodedef.h.
/////////////////////////////////////////////////////

![screenshot_20170329_050909](https://cloud.githubusercontent.com/assets/3686677/24438257/fca1c2aa-143d-11e7-8a89-55903d425c2f.png)

^ Tested

The glass liquid tank feature is completely undocumented and doesn't even have a paramtype2 defined.
To be merged with https://github.com/minetest/minetest_game/pull/1673