### PR TITLE
Formspec: Add options to set background color and opacity (fullscreen mode + default mode)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -649,6 +649,12 @@ console_color (Console color) string (0,0,0)
 #    In-game chat console background alpha (opaqueness, between 0 and 255).
 console_alpha (Console alpha) int 200 0 255
 
+#    Formspec full-screen background opacity (between 0 and 255).
+formspec_fullscreen_bg_opacity (Formspec Full-Screen Background Opacity) int 140 0 255
+
+#    Formspec full-screen background color (R,G,B).
+formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0,0)
+
 #    Selection box border color (R,G,B).
 selectionbox_color (Selection box color) string (0,0,0)
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -655,6 +655,12 @@ formspec_fullscreen_bg_opacity (Formspec Full-Screen Background Opacity) int 140
 #    Formspec full-screen background color (R,G,B).
 formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0,0)
 
+#    Formspec default background opacity (between 0 and 255).
+formspec_default_bg_opacity (Formspec Default Background Opacity) int 140 0 255
+
+#    Formspec default background color (R,G,B).
+formspec_default_bg_color (Formspec Default Background Color) string (0,0,0)
+
 #    Selection box border color (R,G,B).
 selectionbox_color (Selection box color) string (0,0,0)
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -762,6 +762,14 @@
 #    type: int min: 0 max: 255
 # console_alpha = 200
 
+#    Formspec full-screen background opacity (between 0 and 255).
+#    type: int
+# formspec_fullscreen_bg_opacity = 140
+
+#    Formspec full-screen background color (R,G,B).
+#    type: string
+# formspec_fullscreen_bg_color = (0,0,0)
+
 #    Selection box border color (R,G,B).
 #    type: string
 # selectionbox_color = (0,0,0)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -770,6 +770,14 @@
 #    type: string
 # formspec_fullscreen_bg_color = (0,0,0)
 
+#    Formspec default background opacity (between 0 and 255).
+#    type: int
+# formspec_default_bg_opacity = 140
+
+#    Formspec default background color (R,G,B).
+#    type: string
+# formspec_default_bg_color = (0,0,0)
+
 #    Selection box border color (R,G,B).
 #    type: string
 # selectionbox_color = (0,0,0)

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -189,6 +189,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("console_alpha", "200");
 	settings->setDefault("formspec_fullscreen_bg_color", "(0,0,0)");
 	settings->setDefault("formspec_fullscreen_bg_opacity", "140");
+	settings->setDefault("formspec_default_bg_color", "(0,0,0)");
+	settings->setDefault("formspec_default_bg_opacity", "140");
 	settings->setDefault("selectionbox_color", "(0,0,0)");
 	settings->setDefault("selectionbox_width", "2");
 	settings->setDefault("node_highlighting", "box");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -187,6 +187,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("console_height", "1.0");
 	settings->setDefault("console_color", "(0,0,0)");
 	settings->setDefault("console_alpha", "200");
+	settings->setDefault("formspec_fullscreen_bg_color", "(0,0,0)");
+	settings->setDefault("formspec_fullscreen_bg_opacity", "140");
 	settings->setDefault("selectionbox_color", "(0,0,0)");
 	settings->setDefault("selectionbox_width", "2");
 	settings->setDefault("node_highlighting", "box");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -184,6 +184,7 @@ struct LocalFormspecHandler : public TextDest
 
 /* Form update callback */
 
+static const std::string empty_string = "";
 class NodeMetadataFormSource: public IFormSource
 {
 public:
@@ -192,12 +193,12 @@ public:
 		m_p(p)
 	{
 	}
-	std::string getForm()
+	const std::string &getForm() const
 	{
 		NodeMetadata *meta = m_map->getNodeMetadata(m_p);
 
 		if (!meta)
-			return "";
+			return empty_string;
 
 		return meta->getString("formspec");
 	}
@@ -223,7 +224,8 @@ public:
 		m_client(client)
 	{
 	}
-	std::string getForm()
+
+	const std::string &getForm() const
 	{
 		LocalPlayer *player = m_client->getEnv().getLocalPlayer();
 		return player->inventory_formspec;

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -1572,17 +1572,19 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &
 	std::vector<std::string> parts = split(element,';');
 
 	if (((parts.size() == 1) || (parts.size() == 2)) ||
-		((parts.size() > 2) && (m_formspec_version > FORMSPEC_API_VERSION)))
-	{
-		parseColorString(parts[0],m_bgcolor,false);
+			((parts.size() > 2) && (m_formspec_version > FORMSPEC_API_VERSION))) {
+		parseColorString(parts[0], m_bgcolor, false);
 
 		if (parts.size() == 2) {
 			std::string fullscreen = parts[1];
 			m_bgfullscreen = is_yes(fullscreen);
 		}
+
 		return;
 	}
-	errorstream<< "Invalid bgcolor element(" << parts.size() << "): '" << element << "'"  << std::endl;
+
+	errorstream << "Invalid bgcolor element(" << parts.size() << "): '" << element << "'"
+			<< std::endl;
 }
 
 void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &element)
@@ -1913,9 +1915,8 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 	}
 
 	// Ignore others
-	infostream
-		<< "Unknown DrawSpec: type="<<type<<", data=\""<<description<<"\""
-		<<std::endl;
+	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
+			<< std::endl;
 }
 
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
@@ -1983,9 +1984,28 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_static_texts.clear();
 	m_dropdowns.clear();
 
-	// Set default values (fits old formspec values)
-	m_bgcolor = video::SColor(140,0,0,0);
 	m_bgfullscreen = false;
+
+	{
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
+		m_bgcolor = video::SColor(
+			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
+	}
+
+	{
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
+		m_fullscreen_bgcolor = video::SColor(
+			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
+	}
+
 
 	m_slotbg_n = video::SColor(255,128,128,128);
 	m_slotbg_h = video::SColor(255,192,192,192);
@@ -2406,9 +2426,9 @@ void GUIFormSpecMenu::drawSelectedItem()
 
 void GUIFormSpecMenu::drawMenu()
 {
-	if(m_form_src){
-		std::string newform = m_form_src->getForm();
-		if(newform != m_formspec_string){
+	if (m_form_src) {
+		const std::string &newform = m_form_src->getForm();
+		if (newform != m_formspec_string) {
 			m_formspec_string = newform;
 			regenerateGui(m_screensize_old);
 		}
@@ -2426,18 +2446,10 @@ void GUIFormSpecMenu::drawMenu()
 	v2u32 screenSize = driver->getScreenSize();
 	core::rect<s32> allbg(0, 0, screenSize.X, screenSize.Y);
 
-	if (m_bgfullscreen) {
-		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
-		m_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
-		);
-		driver->draw2DRectangle(m_bgcolor, allbg, &allbg);
-	} else {
+	if (m_bgfullscreen)
+		driver->draw2DRectangle(m_fullscreen_bgcolor, allbg, &allbg);
+	else
 		driver->draw2DRectangle(m_bgcolor, AbsoluteRect, &AbsoluteClippingRect);
-	}
 
 	m_tooltip_element->setVisible(false);
 

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -79,6 +79,11 @@ static unsigned int font_line_height(gui::IGUIFont *font)
 	return font->getDimension(L"Ay").Height + font->getKerningHeight();
 }
 
+inline u32 clamp_u8(s32 value)
+{
+	return (u32) MYMIN(MYMAX(value, 0), 255);
+}
+
 GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		Client *client, ISimpleTextureSource *tsrc, IFormSource *fsrc, TextDest *tdst,
@@ -2419,11 +2424,20 @@ void GUIFormSpecMenu::drawMenu()
 	video::IVideoDriver* driver = Environment->getVideoDriver();
 
 	v2u32 screenSize = driver->getScreenSize();
-	core::rect<s32> allbg(0, 0, screenSize.X ,	screenSize.Y);
-	if (m_bgfullscreen)
+	core::rect<s32> allbg(0, 0, screenSize.X, screenSize.Y);
+
+	if (m_bgfullscreen) {
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
+		m_bgcolor = video::SColor(
+			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
+		);
 		driver->draw2DRectangle(m_bgcolor, allbg, &allbg);
-	else
+	} else {
 		driver->draw2DRectangle(m_bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+	}
 
 	m_tooltip_element->setVisible(false);
 

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -66,7 +66,7 @@ class IFormSource
 {
 public:
 	virtual ~IFormSource() = default;
-	virtual std::string getForm() = 0;
+	virtual const std::string &getForm() const = 0;
 	// Fill in variables in field text
 	virtual std::string resolveText(const std::string &str) { return str; }
 };
@@ -419,6 +419,7 @@ protected:
 	bool m_bgfullscreen;
 	bool m_slotborder;
 	video::SColor m_bgcolor;
+	video::SColor m_fullscreen_bgcolor;
 	video::SColor m_slotbg_n;
 	video::SColor m_slotbg_h;
 	video::SColor m_slotbordercolor;
@@ -554,7 +555,10 @@ public:
 		m_formspec = FORMSPEC_VERSION_STRING + formspec;
 	}
 
-	std::string getForm() { return m_formspec; }
+	const std::string &getForm() const
+	{
+		return m_formspec;
+	}
 
 	std::string m_formspec;
 };


### PR DESCRIPTION
Re-opened PR #5306 
i separated fullscreen default color from default color permitting to override in the two cases
I also added a little performance optimisation on formspec getters by removing some string copies (which are expensive for formspecs)