### PR TITLE
Fix 'alpha' property for liquid nodes

### DIFF
--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -382,13 +382,13 @@ struct ContentFeatures
 	void serializeOld(std::ostream &os, u16 protocol_version) const;
 	void deSerializeOld(std::istream &is, int version);
 	/*!
-	 * Since vertex alpha is no lnger supported, this method
-	 * adds instructions to the texture names to blend alpha there.
+	 * Since vertex alpha is no longer supported, this method
+	 * adds opacity directly to the texture pixels.
 	 *
-	 * tiledef, tiledef_special and alpha must be initialized
-	 * before calling this.
+	 * \param tiles array of the tile definitions.
+	 * \param length length of tiles
 	 */
-	void correctAlpha();
+	void correctAlpha(TileDef *tiles, int length);
 
 	/*
 		Some handy methods


### PR DESCRIPTION
Since #4986 the `alpha` property of liquids did not work correctly. This commit restores the old behavior: `alpha` overrides texture translucency.

Related: #5461.

EDIT by paramat: Fixes #5769 