### PR TITLE
Add missing source to android build

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -312,6 +312,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_mainmenu.cpp     \
 		jni/src/script/lua_api/l_mapgen.cpp       \
 		jni/src/script/lua_api/l_metadata.cpp     \
+		jni/src/script/lua_api/l_minimap.cpp      \
 		jni/src/script/lua_api/l_nodemeta.cpp     \
 		jni/src/script/lua_api/l_nodetimer.cpp    \
 		jni/src/script/lua_api/l_noise.cpp        \


### PR DESCRIPTION
`l_minimap.cpp` was missing from the android buildfile resulting in this linker errors:

```
jni/../jni/src/script/clientscripting.cpp:51: error: undefined reference to 'LuaMinimap::create(lua_State*, Minimap*)'
jni/../jni/src/script/clientscripting.cpp:51: error: undefined reference to 'LuaMinimap::create(lua_State*, Minimap*)'
jni/../jni/src/script/clientscripting.cpp:70: error: undefined reference to 'LuaMinimap::Register(lua_State*)'
```