### PR TITLE
Show media download progress in percent on progress screen

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2192,8 +2192,10 @@ bool Game::getServerContent(bool *aborted)
 			delete[] text;
 		} else {
 			std::stringstream message;
-			message.precision(3);
-			message << gettext("Media...");
+			std::fixed(message);
+			message.precision(0);
+			message << gettext("Media...") << " " << (client->mediaReceiveProgress()*100) << "%";
+			message.precision(2);
 
 			if ((USE_CURL == 0) ||
 					(!g_settings->getBool("enable_remote_media_server"))) {


### PR DESCRIPTION
This changes the progress output of "Media..." to "Media... nn%".
This enables users to track the status of the media downloads, rather than waiting and not knowing how much still has to be downloaded.

I decided not to mess with the translation files.