### PR TITLE
core.after(): simplify further, pause in singleplayer

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -1,18 +1,8 @@
 local jobs = {}
 local time = 0.0
-local last = core.get_us_time() / 1000000
 
 core.register_globalstep(function(dtime)
-	local new = core.get_us_time() / 1000000
-	if new > last then
-		time = time + (new - last)
-	else
-		-- Overflow, we may lose a little bit of time here but
-		-- only 1 tick max, potentially running timers slightly
-		-- too early.
-		time = time + new
-	end
-	last = new
+	time = time + dtime
 
 	if #jobs < 1 then
 		return


### PR DESCRIPTION
Using the `dtime` value entirely, this will stop the clock
if the game is paused in singleplayer. Since most of the
clocks were fixed a long time ago, this should again be
safe to use.