### PR TITLE
Set Irrlichts loglevel to Minetests loglevel

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -17,6 +17,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#ifndef SERVER
+#include <ILogger.h>
+#endif // !SERVER
+
 #include "mainmenumanager.h"
 #include "debug.h"
 #include "clouds.h"
@@ -95,6 +99,36 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 		errorstream << "Could not initialize game engine." << std::endl;
 		return false;
 	}
+
+#ifndef SERVER
+	// Set Irrlicht LogLevel
+	switch (Logger::stringToLevel(g_settings->get("debug_log_level"))) {
+	case LL_NONE:
+		device->getLogger()->setLogLevel(irr::ELL_NONE);
+		break;
+	case LL_ERROR:
+		device->getLogger()->setLogLevel(irr::ELL_ERROR);
+		break;
+	case LL_WARNING:
+		device->getLogger()->setLogLevel(irr::ELL_WARNING);
+		break;
+	case LL_ACTION:
+	case LL_INFO:
+		device->getLogger()->setLogLevel(irr::ELL_INFORMATION);
+		break;
+	case LL_VERBOSE:
+	case LL_MAX:
+		// irr::ELL_DEBUG was added in irrlicht 1.8
+#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
+		device->getLogger()->setLogLevel(irr::ELL_INFORMATION);
+#else
+		device->getLogger()->setLogLevel(irr::ELL_DEBUG);
+#endif	
+		break;
+	default:
+		break;
+	}
+#endif // !SERVER
 
 	// Create time getter
 	g_timegetter = new IrrlichtTimeGetter(device);


### PR DESCRIPTION
with debug_log_level set to warning:

before:
```
2017-04-02 10:13:35: WARNING[Main]: Couldn't find a locale directory!
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/menu_header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/overlay.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/icon.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/minetest_game/menu/icon.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/minimal/menu/icon.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/minetest_game/menu/header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/overlay.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/minimal/menu/background.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/minetest_game/menu/header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/overlay.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/header.png
Ignoring resize operation to (0 0)
Resizing window (1000 750)
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/menu_header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/blank.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_flags_favorite.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_ping_4.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_ping_3.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_ping_2.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_ping_1.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_flags_creative.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_flags_damage.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/server_flags_pvp.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/overlay.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/games/king_arthurs_game/menu/header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/menu_header.png
Loaded texture: D:/Users/Doll/Documents/Projects/Minetest/textures/base/pack/no_screenshot.png
```
after:
` 2017-04-02 10:26:14: WARNING[Main]: Couldn't find a locale directory!`

this would solve: https://github.com/minetest/minetest/issues/4255
a little bit related: https://github.com/minetest/minetest/pull/5416

I created a separate PR, because this is independent of https://github.com/minetest/minetest/pull/5416 and may be merged faster.