### PR TITLE
Mapgen on emerge: Do not generate over set mapgen_limit

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -613,7 +613,8 @@ void *EmergeThread::run()
 		EMERGE_DBG_OUT("pos=" PP(pos) " allow_gen=" << allow_gen);
 
 		action = getBlockOrStartGen(pos, allow_gen, &block, &bmdata);
-		if (action == EMERGE_GENERATED) {
+		if (action == EMERGE_GENERATED &&
+				!m_map->blockpos_over_mapgen_limit(pos)) {
 			{
 				ScopeProfiler sp(g_profiler,
 					"EmergeThread: Mapgen::makeChunk", SPT_AVG);


### PR DESCRIPTION
Intended to fix a reported bug where mapgen is happening outside the set mapgen_limit when '/deleteblocks () ()' is used.
```
00:40 Out`Of`Control hi
00:40 Out`Of`Control anyone could give me example of '/deleteblocks (x1, y1, z1) (x2, y2, z2)'
00:40 Out`Of`Control as i get error
00:41 VanessaE       I only know `/deleteblocks here`  (and I think you can put a radius after it)
00:42 Out`Of`Control uhm
00:42 Out`Of`Control VanessaE: thanks
00:44 Out`Of`Control ok i delete blocks but they are still there
00:44 VanessaE       they probably re-generated.
00:45 Out`Of`Control its outside mapgen limit
00:46 Out`Of`Control area near does not regenerate
00:46 VanessaE       maybe the mapgen limit also trims the "delete" coords
00:46 Out`Of`Control so i need disable limit delete then enable?
00:47 Out`Of`Control its just one area far away
```
Still need to test.