### PR TITLE
MapgenBasic: Add lava source as commonly used content

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -593,6 +593,7 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emer
 	c_sandstone          = ndef->getId("mapgen_sandstone");
 	c_water_source       = ndef->getId("mapgen_water_source");
 	c_river_water_source = ndef->getId("mapgen_river_water_source");
+	c_lava_source        = ndef->getId("mapgen_lava_source");
 
 	// Fall back to more basic content if not defined
 	// river_water_source cannot fallback to water_source because river water

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -261,10 +261,11 @@ protected:
 
 	// Content required for generateBiomes
 	content_t c_stone;
-	content_t c_water_source;
-	content_t c_river_water_source;
 	content_t c_desert_stone;
 	content_t c_sandstone;
+	content_t c_water_source;
+	content_t c_river_water_source;
+	content_t c_lava_source;
 
 	// Content required for generateDungeons
 	content_t c_cobble;

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -107,9 +107,6 @@ MapgenValleys::MapgenValleys(int mapgenid, MapgenValleysParams *params, EmergeMa
 	this->lava_max_height       = water_level + MYMAX(0, lava_features_lim - 4) * 50;
 
 	tcave_cache = new float[csize.Y + 2];
-
-	// Resolve content to be used
-	c_lava_source = ndef->getId("mapgen_lava_source");
 }
 
 

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -124,8 +124,6 @@ private:
 	Noise *noise_valley_depth;
 	Noise *noise_valley_profile;
 
-	content_t c_lava_source;
-
 	float terrainLevelAtPoint(s16 x, s16 z);
 
 	void calculateNoise();


### PR DESCRIPTION
Future mapgens are likely to use this for magma and volcanos.
Remove the getting of lava source content id in mgvalleys.
/////////////////////////////////////////////

Tested.