### PR TITLE
Mapgen: Remove '#include treegen.h' from non-mgv6 mapgens

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -33,7 +33,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "dungeongen.h"
 #include "cavegen.h"
-#include "treegen.h"
 #include "mg_biome.h"
 #include "mg_ore.h"
 #include "mg_decoration.h"

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -33,7 +33,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "dungeongen.h"
 #include "cavegen.h"
-#include "treegen.h"
 #include "mg_biome.h"
 #include "mg_ore.h"
 #include "mg_decoration.h"

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -33,7 +33,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "dungeongen.h"
 #include "cavegen.h"
-#include "treegen.h"
 #include "mg_biome.h"
 #include "mg_ore.h"
 #include "mg_decoration.h"

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -33,7 +33,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 #include "dungeongen.h"
 #include "cavegen.h"
-#include "treegen.h"
 #include "mg_biome.h"
 #include "mg_ore.h"
 #include "mg_decoration.h"

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -37,7 +37,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h" // For g_settings
 #include "emerge.h"
 #include "dungeongen.h"
-#include "treegen.h"
 #include "mg_biome.h"
 #include "mg_ore.h"
 #include "mg_decoration.h"


### PR DESCRIPTION
Only mgv6 uses the tree functions from treegen.cpp.
////////////////////////////////////////

Tested.