### PR TITLE
Sneak: Add option for old move code 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3021,7 +3021,11 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `jump`: multiplier to default jump value (default: `1`)
         * `gravity`: multiplier to default gravity value (default: `1`)
         * `sneak`: whether player can sneak (default: `true`)
-        * `sneak_glitch`: whether player can use the sneak glitch (default: `true`)
+        * `sneak_glitch`: whether player can use the new move code replications
+          of the old sneak side-effects: sneak ladders and 2 node sneak jump
+          when next to a ledge 2 nodes up (default: `true`)
+        * `new_move`: use new move/sneak code. When `false` the exact old code
+          is used for the specific old sneak behaviour (default: `true`)
 * `get_physics_override()`: returns the table given to set_physics_override
 * `hud_add(hud definition)`: add a HUD element described by HUD def, returns ID
    number on success

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1652,6 +1652,7 @@ void GenericCAO::processMessage(const std::string &data)
 		// these are sent inverted so we get true when the server sends nothing
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
+		bool new_move = !readU8(is);
 
 
 		if(m_is_local_player)
@@ -1662,6 +1663,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->physics_override_gravity = override_gravity;
 			player->physics_override_sneak = sneak;
 			player->physics_override_sneak_glitch = sneak_glitch;
+			player->physics_override_new_move = new_move;
 		}
 	} else if (cmd == GENERIC_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -789,6 +789,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_physics_override_gravity(1),
 	m_physics_override_sneak(true),
 	m_physics_override_sneak_glitch(true),
+	m_physics_override_new_move(true),
 	m_physics_override_sent(false)
 {
 	assert(m_peer_id != 0);	// pre-condition
@@ -886,7 +887,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 		m_attachment_bone, m_attachment_position, m_attachment_rotation)); // 4
 	msg_os << serializeLongString(gob_cmd_update_physics_override(m_physics_override_speed,
 			m_physics_override_jump, m_physics_override_gravity, m_physics_override_sneak,
-			m_physics_override_sneak_glitch)); // 5
+			m_physics_override_sneak_glitch, m_physics_override_new_move)); // 5
 	// (GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) : Deprecated, for backwards compatibility only.
 	msg_os << serializeLongString(gob_cmd_update_nametag_attributes(m_prop.nametag_color)); // 6
 	int message_count = 6 + m_bone_position.size();
@@ -1049,7 +1050,8 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		m_physics_override_sent = true;
 		std::string str = gob_cmd_update_physics_override(m_physics_override_speed,
 				m_physics_override_jump, m_physics_override_gravity,
-				m_physics_override_sneak, m_physics_override_sneak_glitch);
+				m_physics_override_sneak, m_physics_override_sneak_glitch,
+				m_physics_override_new_move);
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -397,6 +397,7 @@ public:
 	float m_physics_override_gravity;
 	bool m_physics_override_sneak;
 	bool m_physics_override_sneak_glitch;
+	bool m_physics_override_new_move;
 	bool m_physics_override_sent;
 };
 

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -118,7 +118,7 @@ std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups)
 }
 
 std::string gob_cmd_update_physics_override(float physics_override_speed, float physics_override_jump,
-		float physics_override_gravity, bool sneak, bool sneak_glitch)
+		float physics_override_gravity, bool sneak, bool sneak_glitch, bool new_move)
 {
 	std::ostringstream os(std::ios::binary);
 	// command 
@@ -130,6 +130,7 @@ std::string gob_cmd_update_physics_override(float physics_override_speed, float 
 	// these are sent inverted so we get true when the server sends nothing
 	writeU8(os, !sneak);
 	writeU8(os, !sneak_glitch);
+	writeU8(os, !new_move);
 	return os.str();
 }
 

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -68,7 +68,8 @@ std::string gob_cmd_punched(s16 damage, s16 result_hp);
 std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups);
 
 std::string gob_cmd_update_physics_override(float physics_override_speed,
-		float physics_override_jump, float physics_override_gravity, bool sneak, bool sneak_glitch);
+		float physics_override_jump, float physics_override_gravity,
+		bool sneak, bool sneak_glitch, bool new_move);
 
 std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_blend, bool frame_loop);
 

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -58,11 +58,16 @@ public:
 	float physics_override_gravity;
 	bool physics_override_sneak;
 	bool physics_override_sneak_glitch;
+	// Temporary option for old move code
+	bool physics_override_new_move;
 
 	v3f overridePosition;
 
 	void move(f32 dtime, Environment *env, f32 pos_max_d);
 	void move(f32 dtime, Environment *env, f32 pos_max_d,
+			std::vector<CollisionInfo> *collision_info);
+	// Temporary option for old move code
+	void old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			std::vector<CollisionInfo> *collision_info);
 
 	void applyControl(float dtime);
@@ -137,6 +142,9 @@ private:
 	v3f m_position;
 
 	v3s16 m_sneak_node;
+	// Stores the max player uplift by m_sneak_node
+	// To support temporary option for old move code
+	f32 m_sneak_node_bb_ymax;
 	// Stores the top bounding box of m_sneak_node
 	aabb3f m_sneak_node_bb_top;
 	// Whether the player is allowed to sneak

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -401,7 +401,7 @@ int ObjectRef::l_get_armor_groups(lua_State *L)
 }
 
 // set_physics_override(self, physics_override_speed, physics_override_jump,
-//                      physics_override_gravity, sneak, sneak_glitch)
+//                      physics_override_gravity, sneak, sneak_glitch, new_move)
 int ObjectRef::l_set_physics_override(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -410,11 +410,18 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	if (co == NULL) return 0;
 	// Do it
 	if (lua_istable(L, 2)) {
-		co->m_physics_override_speed = getfloatfield_default(L, 2, "speed", co->m_physics_override_speed);
-		co->m_physics_override_jump = getfloatfield_default(L, 2, "jump", co->m_physics_override_jump);
-		co->m_physics_override_gravity = getfloatfield_default(L, 2, "gravity", co->m_physics_override_gravity);
-		co->m_physics_override_sneak = getboolfield_default(L, 2, "sneak", co->m_physics_override_sneak);
-		co->m_physics_override_sneak_glitch = getboolfield_default(L, 2, "sneak_glitch", co->m_physics_override_sneak_glitch);
+		co->m_physics_override_speed = getfloatfield_default(
+				L, 2, "speed", co->m_physics_override_speed);
+		co->m_physics_override_jump = getfloatfield_default(
+				L, 2, "jump", co->m_physics_override_jump);
+		co->m_physics_override_gravity = getfloatfield_default(
+				L, 2, "gravity", co->m_physics_override_gravity);
+		co->m_physics_override_sneak = getboolfield_default(
+				L, 2, "sneak", co->m_physics_override_sneak);
+		co->m_physics_override_sneak_glitch = getboolfield_default(
+				L, 2, "sneak_glitch", co->m_physics_override_sneak_glitch);
+		co->m_physics_override_new_move = getboolfield_default(
+				L, 2, "new_move", co->m_physics_override_new_move);
 		co->m_physics_override_sent = false;
 	} else {
 		// old, non-table format
@@ -454,6 +461,8 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	lua_setfield(L, -2, "sneak");
 	lua_pushboolean(L, co->m_physics_override_sneak_glitch);
 	lua_setfield(L, -2, "sneak_glitch");
+	lua_pushboolean(L, co->m_physics_override_new_move);
+	lua_setfield(L, -2, "new_move");
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -105,7 +105,7 @@ private:
 	static int l_get_armor_groups(lua_State *L);
 
 	// set_physics_override(self, physics_override_speed, physics_override_jump,
-	//                      physics_override_gravity, sneak, sneak_glitch)
+	//                      physics_override_gravity, sneak, sneak_glitch, new_move)
 	static int l_set_physics_override(lua_State *L);
 
 	// get_physics_override(self)


### PR DESCRIPTION
Temporary option for classic sneak behaviour.
Enabled by setting the added 'new move' physics override to false.
By default 'new move' is true.
///////////////////////////////////////

Tested.

Temporary (until 0.5 or the end of next release) option that enables the old move code (exactly as it was before new sneak). Keeps players happy while we continue to improve the new move code.

New sneak works differently and so does new sneak ladder and any 2-node jump we might code. Sneak behaviour identical to before is very unlikely, however, worlds have been built that depend on the specific previous behaviour. So i realised that although new sneak is improving, players will not be happy (in the short-term future) with anything other than old move code exactly as it was.

I and others would of course not be happy with old move code being kept for the long-term future.
This PR would give us 6+ months to improve new sneak code, hopefully having the new code available will help players get used to it.
MT then 0.5 gives us a good excuse to remove the old move code and break some parkour worlds.

It seems making the setting a physics override is best, as this gives server admin the choice of either choosing the setting for a world, or allowing players to choose through a chat command.
This would also be consistent with the related 'sneak glitch' override.