### PR TITLE
Sneak glitch: Detect ledge for 2-node climb-up 

### DIFF
--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -146,6 +146,9 @@ private:
 	// Whether a "sneak ladder" structure is detected at the players pos
 	// see detectSneakLadder() in the .cpp for more info (always false if disabled)
 	bool m_sneak_ladder_detected;
+	// Whether a 2-node-up ledge is detected at the players pos,
+	// see detectLedge() in the .cpp for more info (always false if disabled).
+	bool m_ledge_detected;
 
 	// Node below player, used to determine whether it has been removed,
 	// and its old type


### PR DESCRIPTION
Re-creates the old sneak-jump behaviour in new code.
Enabled by the 'sneak glitch' physics override.
When a ledge is detected the jump speed modifier is set to the larger
of 'physics override jump' and 1.3 to allow a 2-node climb-up.

An unexpected side-effect is the simple sneak ladder working smoothly.
////////////////////////////////////////////

![screenshot_20170406_191207](https://cloud.githubusercontent.com/assets/3686677/24769069/ff0dd6b2-1afc-11e7-8280-6bf0064555b6.png)

^ On the right: simple sneak ladder.

New PR for adding 2-node pull-up to 'sneak_glitch' option.
Much smoother than my first attempt, still has a small 'teleport' effect near the top of the sneak-jump but this was present with old move code also.