### PR TITLE
Store legacy metadata separate from new item meta data

### DIFF
--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -19,6 +19,10 @@ void ItemStackMetadata::serialize(std::ostream &os) const
 		os2 << it->first << DESERIALIZE_KV_DELIM
 		    << it->second << DESERIALIZE_PAIR_DELIM;
 	}
+
+	if (!legacy_metadata.empty())
+		os2 << DESERIALIZE_KV_DELIM << legacy_metadata << DESERIALIZE_PAIR_DELIM;
+
 	os << serializeJsonStringIfNeeded(os2.str());
 }
 
@@ -29,15 +33,21 @@ void ItemStackMetadata::deSerialize(std::istream &is)
 	m_stringvars.clear();
 
 	if (!in.empty() && in[0] == DESERIALIZE_START) {
+		legacy_metadata = "";
+
 		Strfnd fnd(in);
 		fnd.to(1);
 		while (!fnd.at_end()) {
 			std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
 			std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
-			m_stringvars[name] = var;
+			if (name == "") {
+				legacy_metadata = var;
+			} else {
+				m_stringvars[name] = var;
+			}
 		}
 	} else {
 		// BACKWARDS COMPATIBILITY
-		m_stringvars[""] = in;
+		legacy_metadata = in;
 	}
 }

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -30,6 +30,8 @@ class ItemStackMetadata : public Metadata
 public:
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
+
+	std::string legacy_metadata;
 };
 
 #endif

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -826,7 +826,7 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 
 		// BACKWARDS COMPATIBLITY
 		std::string value = getstringfield_default(L, index, "metadata", "");
-		istack.metadata.setString("", value);
+		istack.metadata.legacy_metadata = value;
 
 		// Get meta
 		lua_getfield(L, index, "meta");

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -154,7 +154,7 @@ int LuaItemStack::l_get_metadata(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	LuaItemStack *o = checkobject(L, 1);
 	ItemStack &item = o->m_stack;
-	const std::string &value = item.metadata.getString("");
+	const std::string &value = item.metadata.legacy_metadata;
 	lua_pushlstring(L, value.c_str(), value.size());
 	return 1;
 }
@@ -169,7 +169,7 @@ int LuaItemStack::l_set_metadata(lua_State *L)
 
 	size_t len = 0;
 	const char *ptr = luaL_checklstring(L, 2, &len);
-	item.metadata.setString("", std::string(ptr, len));
+	item.metadata.legacy_metadata = std::string(ptr, len);
 
 	lua_pushboolean(L, true);
 	return 1;
@@ -225,7 +225,7 @@ int LuaItemStack::l_to_table(lua_State *L)
 		lua_pushinteger(L, item.wear);
 		lua_setfield(L, -2, "wear");
 
-		const std::string &metadata_str = item.metadata.getString("");
+		const std::string &metadata_str = item.metadata.legacy_metadata;
 		lua_pushlstring(L, metadata_str.c_str(), metadata_str.size());
 		lua_setfield(L, -2, "metadata");
 


### PR DESCRIPTION
Removes need for empty key in metadata storage. Also fixes a bug
where "" in meta overrides the value of metadata

Tested using this code:

```lua
local stack = ItemStack("default:stone")
stack:set_metadata("hello!")
stack:get_meta():set_string("foo", "bar")
stack:get_meta():set_string("description", "Hello everyone!")

do
	local meta = stack:get_meta()
	local data = meta:to_table()
	data.fields.bleg = "sldmslmdsd"
	meta:from_table(data)
	print(dump(stack:get_meta():to_table()))
end

local function count_keys(v)
	local c = 0
	for key, value in pairs(v) do
		c = c + 1
	end
	print("keys = " .. c .. " for " .. dump(v))
	return c
end

do
	local stack2 = ItemStack(stack:to_table())
	assert(stack2:get_name() == stack:get_name())
	assert(stack2:get_metadata() == stack:get_metadata())
	assert(stack2:get_meta():get_string("foo") == stack:get_meta():get_string("foo"))
	assert(count_keys(stack2:get_meta():to_table().fields) == 3)
end

do
	local data = stack:to_table()
	data.name = "foo:bar"
	data.metadata = "abd"
	local stack2 = ItemStack(data)
	assert(stack2:get_name() == "foo:bar")
	assert(stack2:get_metadata() == "abd")
	assert(stack2:get_meta():get_string("foo") == stack:get_meta():get_string("foo"))
	assert(count_keys(stack2:get_meta():to_table().fields) == 3)
end

print("all good!")
```