### PR TITLE
Settings: Update documentation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -206,6 +206,10 @@ keymap_screenshot (Screenshot) key KEY_F12
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_drop (Drop item key) key KEY_KEY_Q
 
+#    Key to use view zoom when possible.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+keymap_zoom (View zoom key) key KEY_KEY_Z
+
 #    Key for toggling the display of the HUD.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_toggle_hud (HUD toggle key) key KEY_F1
@@ -213,6 +217,10 @@ keymap_toggle_hud (HUD toggle key) key KEY_F1
 #    Key for toggling the display of the chat.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_toggle_chat (Chat toggle key) key KEY_F2
+
+#    Key for toggling the display of the large chat console.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+keymap_console (Large chat console key) key KEY_F10
 
 #    Key for toggling the display of the fog.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -275,6 +283,7 @@ show_entity_selectionbox (Show entity selection boxes) bool true
 enable_remote_media_server (Connect to external media server) bool true
 
 #    Enable Lua modding support on client.
+#    This support is experimental and API can change.
 enable_client_modding (Client modding) bool false
 
 #    URL to the server list displayed in the Multiplayer Tab.
@@ -317,6 +326,9 @@ enable_3d_clouds (3D clouds) bool true
 #    Method used to highlight selected object.
 node_highlighting (Node highlighting) enum box box,halo
 
+#    Adds particles when digging a node.
+enable_particles (Digging particles) bool true
+
 [***Filtering]
 
 #    Use mip mapping to scale textures. May slightly increase performance.
@@ -353,8 +365,11 @@ fsaa (FSAA) enum 0 0,1,2,4,8,16
 [***Shaders]
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.
-#    Thy only work with the OpenGL video backend.
+#    This only works with the OpenGL video backend.
 enable_shaders (Shaders) bool true
+
+#    Path to shader directory. If no path is defined, default location will be used.
+shader_path (Shader path) path
 
 [****Tone Mapping]
 
@@ -390,7 +405,7 @@ enable_parallax_occlusion (Parallax occlusion) bool false
 parallax_occlusion_mode (Parallax occlusion mode) int 1 0 1
 
 #    Strength of parallax.
-3d_parallax_strength (Parallax occlusion strength) float 0.025
+3d_paralax_strength (Parallax occlusion strength) float 0.025
 
 #    Number of parallax occlusion iterations.
 parallax_occlusion_iterations (Parallax occlusion iterations) int 4
@@ -472,13 +487,16 @@ cloud_height (Cloud height) int 120
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
 cloud_radius (Cloud radius) int 12
 
+#    Enables view bobbing when walking.
+view_bobbing (Enable view bobbing) bool true
+
 #    Multiplier for view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-view_bobbing_amount (View bobbing) float 1.0
+view_bobbing_amount (View bobbing factor) float 1.0
 
 #    Multiplier for fall bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-fall_bobbing_amount (Fall bobbing) float 0.0
+fall_bobbing_amount (Fall bobbing factor) float 0.0
 
 #    3D support.
 #    Currently supported:
@@ -518,6 +536,9 @@ desynchronize_mapblock_texture_animation (Desynchronize block animation) bool tr
 #    Useful if there's something to be displayed right or left of hotbar.
 hud_hotbar_max_width (Maximum hotbar width) float 1.0
 
+#    Modifies the size of the hudbar elements.
+hud_scaling (HUD scale factor) float 1.0
+
 #    Enables caching of facedir rotated meshes.
 enable_mesh_cache (Mesh cache) bool false
 
@@ -548,8 +569,15 @@ ambient_occlusion_gamma (Ambient occlusion gamma) float 2.2 0.25 4.0
 #    Enables animation of inventory items.
 inventory_items_animations (Inventory items animations) bool false
 
+#    Android systems only: Tries to create inventory textures from meshes
+#    when no supported render was found.
+inventory_image_hack (Inventory image hack) bool false
+
 #    Fraction of the visible distance at which fog starts to be rendered
 fog_start (Fog Start) float 0.4 0.0 0.99
+
+#    Makes all liquids opaque
+opaque_water (Opaque liquids) bool false
 
 [**Menus]
 
@@ -616,6 +644,10 @@ screenshot_quality (Screenshot quality) int 0 0 100
 
 #    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
 screen_dpi (DPI) int 72
+
+#    Windows systems only: Start Minetest with the command line window in the background.
+#    Contains the same information as the file debug.txt (default name).
+enable_console (Enable console window) bool false
 
 [*Sound]
 
@@ -728,6 +760,9 @@ show_statusline_on_connect (Status message on connection) bool true
 
 #    Enable players getting damage and dying.
 enable_damage (Damage) bool false
+
+#    Enable creative mode for new created maps.
+creative_mode (Creative) bool false
 
 #    A chosen map seed for a new map, leave empty for random.
 #    Will be overridden when creating a new world in the main menu.
@@ -972,6 +1007,7 @@ mgv5_cavern_threshold (Cavern threshold) float 0.7
 mgv5_np_filler_depth (Filler depth noise) noise_params 0, 1, (150, 150, 150), 261, 4, 0.7, 2.0
 
 #    Variation of terrain vertical scale.
+#    When noise is < -0.55 terrain is near-flat.
 mgv5_np_factor (Factor noise) noise_params 0, 1, (250, 250, 250), 920381, 3, 0.45, 2.0
 
 #    Y-level of average terrain surface.
@@ -1059,7 +1095,7 @@ mgv6_np_apple_trees (Apple trees noise) noise_params 0, 1, (100, 100, 100), 3429
 #    Floatlands are currently experimental and subject to change.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
+mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Cave width) float 0.09
@@ -1137,7 +1173,7 @@ mgv7_np_cave2 (Cave2 noise) noise_params 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 #    Occasional lakes and hills can be added to the flat world.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-mgflat_spflags (Mapgen flat specific flags) flags  lakes,hills,,nolakes,nohills
+mgflat_spflags (Mapgen flat specific flags) flags nolakes,nohills lakes,hills,nolakes,nohills
 
 #    Y of flat ground.
 mgflat_ground_level (Ground level) int 8
@@ -1349,7 +1385,6 @@ profiler.load (Load the game profiler) bool false
 profiler.default_report_format (Default report format) enum txt txt,csv,lua,json,json_pretty
 
 #    The file path relative to your worldpath in which profiles will be saved to.
-#
 profiler.report_path (Report path) string ""
 
 [***Instrumentation]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -211,6 +211,11 @@
 #    type: key
 # keymap_drop = KEY_KEY_Q
 
+#    Key to use view zoom when possible.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#    type: key
+# keymap_zoom = KEY_KEY_Z
+
 #    Key for toggling the display of the HUD.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
@@ -220,6 +225,11 @@
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
 # keymap_toggle_chat = KEY_F2
+
+#    Key for toggling the display of the large chat console.
+#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
+#    type: key
+# keymap_console = KEY_F10
 
 #    Key for toggling the display of the fog.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -298,7 +308,7 @@
 #    Enable Lua modding support on client.
 #    This support is experimental and API can change.
 #    type: bool
-enable_client_modding (Client modding) bool false
+# enable_client_modding = false
 
 #    URL to the server list displayed in the Multiplayer Tab.
 #    type: string
@@ -350,6 +360,10 @@ enable_client_modding (Client modding) bool false
 #    type: enum values: box, halo
 # node_highlighting = box
 
+#    Adds particles when digging a node.
+#    type: bool
+# enable_particles = true
+
 #### Filtering
 
 #    Use mip mapping to scale textures. May slightly increase performance.
@@ -393,9 +407,13 @@ enable_client_modding (Client modding) bool false
 #### Shaders
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.
-#    Thy only work with the OpenGL video backend.
+#    This only works with the OpenGL video backend.
 #    type: bool
 # enable_shaders = true
+
+#    Path to shader directory. If no path is defined, default location will be used.
+#    type: path
+# shader_path =
 
 ##### Tone Mapping
 
@@ -439,7 +457,7 @@ enable_client_modding (Client modding) bool false
 
 #    Strength of parallax.
 #    type: float
-# 3d_parallax_strength = 0.025
+# 3d_paralax_strength = 0.025
 
 #    Number of parallax occlusion iterations.
 #    type: int
@@ -545,6 +563,10 @@ enable_client_modding (Client modding) bool false
 #    type: int
 # cloud_radius = 12
 
+#    Enables view bobbing when walking.
+#    type: bool
+# view_bobbing = true
+
 #    Multiplier for view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 #    type: float
@@ -567,7 +589,7 @@ enable_client_modding (Client modding) bool false
 # 3d_mode = none
 
 #    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
-#    type: float
+#    type: float min: 0.1 max: 1
 # console_height = 1.0
 
 #    In-game chat console background color (R,G,B).
@@ -602,6 +624,10 @@ enable_client_modding (Client modding) bool false
 #    Useful if there's something to be displayed right or left of hotbar.
 #    type: float
 # hud_hotbar_max_width = 1.0
+
+#    Modifies the size of the hudbar elements.
+#    type: float
+# hud_scaling = 1.0
 
 #    Enables caching of facedir rotated meshes.
 #    type: bool
@@ -641,9 +667,18 @@ enable_client_modding (Client modding) bool false
 #    type: bool
 # inventory_items_animations = false
 
+#    Android systems only: Tries to create inventory textures from meshes
+#    when no supported render was found.
+#    type: bool
+# inventory_image_hack = false
+
 #    Fraction of the visible distance at which fog starts to be rendered
 #    type: float min: 0 max: 0.99
 # fog_start = 0.4
+
+#    Makes all liquids opaque
+#    type: bool
+# opaque_water = false
 
 ### Menus
 
@@ -733,6 +768,11 @@ enable_client_modding (Client modding) bool false
 #    Adjust dpi configuration to your screen (non X11/Android only) e.g. for 4k screens.
 #    type: int
 # screen_dpi = 72
+
+#    Windows systems only: Start Minetest with the command line window in the background.
+#    Contains the same information as the file debug.txt (default name).
+#    type: bool
+# enable_console = false
 
 ## Sound
 
@@ -875,6 +915,10 @@ enable_client_modding (Client modding) bool false
 #    Enable players getting damage and dying.
 #    type: bool
 # enable_damage = false
+
+#    Enable creative mode for new created maps.
+#    type: bool
+# creative_mode = false
 
 #    A chosen map seed for a new map, leave empty for random.
 #    Will be overridden when creating a new world in the main menu.
@@ -1083,7 +1127,8 @@ enable_client_modding (Client modding) bool false
 #    on the eye position of the player. This can reduce the number of blocks
 #    sent to the client 50-80%. The client will not longer receive most invisible
 #    so that the utility of noclip mode is reduced.
-server_side_occlusion_culling = true
+#    type: bool
+# server_side_occlusion_culling = true
 
 ## Mapgen
 
@@ -1433,7 +1478,7 @@ server_side_occlusion_culling = true
 #    type: float
 # mgflat_cave_width = 0.09
 
-#    Terrain noise threshold for optional lakes.
+#    Terrain noise threshold for lakes.
 #    Controls proportion of world area covered by lakes.
 #    Adjust towards 0.0 for a larger proportion.
 #    type: float
@@ -1443,7 +1488,7 @@ server_side_occlusion_culling = true
 #    type: float
 # mgflat_lake_steepness = 48.0
 
-#    Terrain noise threshold for optional hills.
+#    Terrain noise threshold for hills.
 #    Controls proportion of world area covered by hills.
 #    Adjust towards 0.0 for a larger proportion.
 #    type: float
@@ -1678,7 +1723,6 @@ server_side_occlusion_culling = true
 # profiler.default_report_format = txt
 
 #    The file path relative to your worldpath in which profiles will be saved to.
-#
 #    type: string
 # profiler.report_path = ""
 
@@ -1794,3 +1838,4 @@ server_side_occlusion_culling = true
 #    Print the engine's profiling data in regular intervals (in seconds). 0 = disable. Useful for developers.
 #    type: int
 # profiler_print_interval = 0
+

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -263,7 +263,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("creative_mode", "false");
 	settings->setDefault("show_statusline_on_connect", "true");
 	settings->setDefault("enable_damage", "true");
-	settings->setDefault("give_initial_stuff", "false");
 	settings->setDefault("default_password", "");
 	settings->setDefault("default_privs", "interact, shout");
 	settings->setDefault("enable_pvp", "true");


### PR DESCRIPTION
Now documented (sorted a-z):
- enable_console
- enable_particles
- creative_mode
- hud_scaling
- inventory_image_hack
- keymap_console
- keymap_zoom
- shader_path
- view_bobbing

Setting `give_initial_stuff` is subgame-specific and just garbage in our settings.
File `minetest.conf.example` synced with `settingtypes.txt` using `generate_from_settingtypes.lua`