### PR TITLE
Modify minetest.write_json to match the documentation.

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1385,10 +1385,8 @@ void read_json_value(lua_State *L, Json::Value &root, int index, u8 recursion)
 				throw SerializationError("Lua key to convert to JSON is not a string or number");
 			}
 		}
-	} else if (type == LUA_TNIL) {
-		root = Json::nullValue;
 	} else {
-		throw SerializationError("Can only store booleans, numbers, strings, objects, arrays, and null in JSON");
+		root = Json::nullValue;
 	}
 	lua_pop(L, 1); // Pop value
 }


### PR DESCRIPTION
The documentation in lua_api.txt specifies that "unserializable things" like functions or userdata
are saved as null. Previously they caused an error, but this commit changes it so
that they are serialized as null.

An alternative solution would be to modify the documentation to say that unserializable things cause an error.

This is an alternative to #5539, so don't merge both.