### PR TITLE
Fix inability to change metadata using stack:to_table()

### DIFF
--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -234,10 +234,14 @@ int LuaItemStack::l_to_table(lua_State *L)
 		for (StringMap::const_iterator it = fields.begin();
 				it != fields.end(); ++it) {
 			const std::string &name = it->first;
-			const std::string &value = it->second;
-			lua_pushlstring(L, name.c_str(), name.size());
-			lua_pushlstring(L, value.c_str(), value.size());
-			lua_settable(L, -3);
+
+			// don't export legacy meta, as it causes problems in ItemStack()
+			if (name != "") {
+				const std::string &value = it->second;
+				lua_pushlstring(L, name.c_str(), name.size());
+				lua_pushlstring(L, value.c_str(), value.size());
+				lua_settable(L, -3);
+			}
 		}
 		lua_setfield(L, -2, "meta");
 	}


### PR DESCRIPTION
Alternative to #5531 

Passes test:

```lua
local stack = ItemStack("default:stone")
stack:set_metadata("hello!")
stack:get_meta():set_string("foo", "bar")
stack:get_meta():set_string("description", "Hello everyone!")

do
	local meta = stack:get_meta()
	local data = meta:to_table()
	data.fields.bleg = "sldmslmdsd"
	meta:from_table(data)
	print(dump(stack:get_meta():to_table()))
end

local function count_keys(v)
	local c = 0
	for key, value in pairs(v) do
		c = c + 1
	end
	print("keys = " .. c .. " for " .. dump(v))
	return c
end

do
	local stack2 = ItemStack(stack:to_table())
	assert(stack2:get_name() == stack:get_name())
	assert(stack2:get_metadata() == stack:get_metadata())
	assert(stack2:get_meta():get_string("foo") == stack:get_meta():get_string("foo"))
	assert(count_keys(stack2:get_meta():to_table().fields) == 4)
end

do
	local data = stack:to_table()
	data.name = "foo:bar"
	data.metadata = "abd"
	local stack2 = ItemStack(data)
	assert(stack2:get_name() == "foo:bar")
	assert(stack2:get_metadata() == "abd")
	assert(stack2:get_meta():get_string("foo") == stack:get_meta():get_string("foo"))
	assert(count_keys(stack2:get_meta():to_table().fields) == 4)
end

print("all good!")
```