### PR TITLE
Damage: Remove damage ignore timer

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -264,13 +264,8 @@ void Client::connect(Address address, bool is_local_server)
 void Client::step(float dtime)
 {
 	// Limit a bit
-	if(dtime > 2.0)
+	if (dtime > 2.0)
 		dtime = 2.0;
-
-	if(m_ignore_damage_timer > dtime)
-		m_ignore_damage_timer -= dtime;
-	else
-		m_ignore_damage_timer = 0.0;
 
 	m_animation_time += dtime;
 	if(m_animation_time > 60.0)
@@ -394,18 +389,16 @@ void Client::step(float dtime)
 		ClientEnvEvent envEvent = m_env.getClientEnvEvent();
 
 		if (envEvent.type == CEE_PLAYER_DAMAGE) {
-			if (m_ignore_damage_timer <= 0) {
-				u8 damage = envEvent.player_damage.amount;
+			u8 damage = envEvent.player_damage.amount;
 
-				if (envEvent.player_damage.send_to_server)
-					sendDamage(damage);
+			if (envEvent.player_damage.send_to_server)
+				sendDamage(damage);
 
-				// Add to ClientEvent queue
-				ClientEvent *event = new ClientEvent();
-				event->type = CE_PLAYER_DAMAGE;
-				event->player_damage.amount = damage;
-				m_client_event_queue.push(event);
-			}
+			// Add to ClientEvent queue
+			ClientEvent *event = new ClientEvent();
+			event->type = CE_PLAYER_DAMAGE;
+			event->player_damage.amount = damage;
+			m_client_event_queue.push(event);
 		}
 	}
 

--- a/src/client.h
+++ b/src/client.h
@@ -469,7 +469,6 @@ private:
 	float m_connection_reinit_timer = 0.1f;
 	float m_avg_rtt_timer = 0.0f;
 	float m_playerpos_send_timer = 0.0f;
-	float m_ignore_damage_timer = 0.0f; // Used after server moves player
 	IntervalLimiter m_map_timer_and_unload_interval;
 
 	IWritableTextureSource *m_tsrc;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -573,10 +573,6 @@ void Client::handleCommand_MovePlayer(NetworkPacket* pkt)
 	event->player_force_move.pitch = pitch;
 	event->player_force_move.yaw = yaw;
 	m_client_event_queue.push(event);
-
-	// Ignore damage for a few seconds, so that the player doesn't
-	// get damage from falling on ground
-	m_ignore_damage_timer = 3.0;
 }
 
 void Client::handleCommand_DeathScreen(NetworkPacket* pkt)


### PR DESCRIPTION
Remove `m_ignore_damage_timer`
-> Allowed for 3.0s after teleport to evade damage (It's the next mean guy after sneak glitch gets fixed)
Remove `send_to_server`, unused variable in ClientEnvEvent
Move player damage handling from `ClientEnvironment` to `Client`