### PR TITLE
getDigParams: Fix selecting the lowest digging time

### DIFF
--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -156,18 +156,14 @@ int ModApiUtil::l_write_json(lua_State *L)
 	return 1;
 }
 
-// get_dig_params(groups, tool_capabilities[, time_from_last_punch])
+// get_dig_params(groups, tool_capabilities)
 int ModApiUtil::l_get_dig_params(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ItemGroupList groups;
 	read_groups(L, 1, groups);
 	ToolCapabilities tp = read_tool_capabilities(L, 2);
-	if(lua_isnoneornil(L, 3))
-		push_dig_params(L, getDigParams(groups, &tp));
-	else
-		push_dig_params(L, getDigParams(groups, &tp,
-					luaL_checknumber(L, 3)));
+	push_dig_params(L, getDigParams(groups, &tp));
 	return 1;
 }
 

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -115,11 +115,12 @@ DigParams getDigParams(const ItemGroupList &groups,
 		int rating = itemgroup_get(groups, name);
 		float time = 0;
 		bool time_exists = cap.getTime(rating, &time);
+		int leveldiff = cap.maxlevel - level;
+		time /= MYMAX(1, leveldiff);
 		if(!result_diggable || time < result_time){
 			if(cap.maxlevel >= level && time_exists){
 				result_diggable = true;
-				int leveldiff = cap.maxlevel - level;
-				result_time = time / MYMAX(1, leveldiff);
+				result_time = time;
 				if(cap.uses != 0)
 					result_wear = 1.0 / cap.uses / pow(3.0, (double)leveldiff);
 				else

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -85,7 +85,7 @@ void ToolCapabilities::deSerialize(std::istream &is)
 }
 
 DigParams getDigParams(const ItemGroupList &groups,
-		const ToolCapabilities *tp, float time_from_last_punch)
+		const ToolCapabilities *tp)
 {
 	// Group dig_immediate has fixed time and no wear
 	switch (itemgroup_get(groups, "dig_immediate")) {
@@ -131,20 +131,8 @@ DigParams getDigParams(const ItemGroupList &groups,
 		}
 	}
 
-	if (time_from_last_punch < tp->full_punch_interval) {
-		float f = tp->full_punch_interval / time_from_last_punch;
-		result_time *= f;
-		result_wear *= f;
-	}
-
 	u16 wear_i = U16_MAX * result_wear;
 	return DigParams(result_diggable, result_time, wear_i, result_main_group);
-}
-
-DigParams getDigParams(const ItemGroupList &groups,
-		const ToolCapabilities *tp)
-{
-	return getDigParams(groups, tp, 1000000);
 }
 
 HitParams getHitParams(const ItemGroupList &armor_groups,

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -87,14 +87,11 @@ void ToolCapabilities::deSerialize(std::istream &is)
 DigParams getDigParams(const ItemGroupList &groups,
 		const ToolCapabilities *tp, float time_from_last_punch)
 {
-	//infostream<<"getDigParams"<<std::endl;
-	/* Check group dig_immediate */
-	switch(itemgroup_get(groups, "dig_immediate")){
+	// Group dig_immediate has fixed time and no wear
+	switch (itemgroup_get(groups, "dig_immediate")) {
 	case 2:
-		//infostream<<"dig_immediate=2"<<std::endl;
 		return DigParams(true, 0.5, 0, "dig_immediate");
 	case 3:
-		//infostream<<"dig_immediate=3"<<std::endl;
 		return DigParams(true, 0, 0, "dig_immediate");
 	default:
 		break;
@@ -107,40 +104,40 @@ DigParams getDigParams(const ItemGroupList &groups,
 	std::string result_main_group;
 
 	int level = itemgroup_get(groups, "level");
-	//infostream<<"level="<<level<<std::endl;
 	for (const auto &groupcap : tp->groupcaps) {
-		const std::string &name = groupcap.first;
-		//infostream<<"group="<<name<<std::endl;
 		const ToolGroupCap &cap = groupcap.second;
-		int rating = itemgroup_get(groups, name);
-		float time = 0;
-		bool time_exists = cap.getTime(rating, &time);
+
 		int leveldiff = cap.maxlevel - level;
-		time /= MYMAX(1, leveldiff);
-		if(!result_diggable || time < result_time){
-			if(cap.maxlevel >= level && time_exists){
-				result_diggable = true;
-				result_time = time;
-				if(cap.uses != 0)
-					result_wear = 1.0 / cap.uses / pow(3.0, (double)leveldiff);
-				else
-					result_wear = 0;
-				result_main_group = name;
-			}
+		if (leveldiff < 0)
+			continue;
+
+		const std::string &groupname = groupcap.first;
+		float time = 0;
+		int rating = itemgroup_get(groups, groupname);
+		bool time_exists = cap.getTime(rating, &time);
+		if (!time_exists)
+			continue;
+
+		if (leveldiff > 1)
+			time /= leveldiff;
+		if (!result_diggable || time < result_time) {
+			result_time = time;
+			result_diggable = true;
+			if (cap.uses != 0)
+				result_wear = 1.0 / cap.uses / pow(3.0, leveldiff);
+			else
+				result_wear = 0;
+			result_main_group = groupname;
 		}
 	}
-	//infostream<<"result_diggable="<<result_diggable<<std::endl;
-	//infostream<<"result_time="<<result_time<<std::endl;
-	//infostream<<"result_wear="<<result_wear<<std::endl;
 
-	if(time_from_last_punch < tp->full_punch_interval){
-		float f = time_from_last_punch / tp->full_punch_interval;
-		//infostream<<"f="<<f<<std::endl;
-		result_time /= f;
-		result_wear /= f;
+	if (time_from_last_punch < tp->full_punch_interval) {
+		float f = tp->full_punch_interval / time_from_last_punch;
+		result_time *= f;
+		result_wear *= f;
 	}
 
-	u16 wear_i = 65535.*result_wear;
+	u16 wear_i = U16_MAX * result_wear;
 	return DigParams(result_diggable, result_time, wear_i, result_main_group);
 }
 

--- a/src/tool.h
+++ b/src/tool.h
@@ -90,9 +90,6 @@ struct DigParams
 };
 
 DigParams getDigParams(const ItemGroupList &groups,
-		const ToolCapabilities *tp, float time_from_last_punch);
-
-DigParams getDigParams(const ItemGroupList &groups,
 		const ToolCapabilities *tp);
 
 struct HitParams


### PR DESCRIPTION
* Tidy up code
* Fix selecting the best fitting time: time was compared with result_time before dividing it by the level difference
* Remove dead code (time from last punch)