### PR TITLE
Fix tool digging speed limit

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1231,9 +1231,8 @@ Another example: Make red wool from white wool and red dye:
      * `0` is something that is directly accessible at the start of gameplay
      * There is no upper limit
 * `dig_immediate`: (player can always pick up node without tool wear)
-    * `2`: node is removed without tool wear after 0.5 seconds or so
-      (rail, sign)
-    * `3`: node is removed without tool wear immediately (torch)
+    * `2`: node is removed without tool wear after 0.5 seconds (rail, sign)
+    * `3`: node is removed without tool wear after 0.15 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `bouncy`: value is bounce speed in percent

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3883,13 +3883,6 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		if (runData.nodig_delay_timer > 0.3)
 			runData.nodig_delay_timer = 0.3;
 
-		// We want a slight delay to very little
-		// time consuming nodes
-		const float mindelay = 0.15;
-
-		if (runData.nodig_delay_timer < mindelay)
-			runData.nodig_delay_timer = mindelay;
-
 		bool is_valid_position;
 		MapNode wasnode = map.getNodeNoEx(nodepos, &is_valid_position);
 		if (is_valid_position) {

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -98,7 +98,7 @@ DigParams getDigParams(const ItemGroupList &groups,
 		return DigParams(true, 0.5, 0, "dig_immediate");
 	case 3:
 		//infostream<<"dig_immediate=3"<<std::endl;
-		return DigParams(true, 0.0, 0, "dig_immediate");
+		return DigParams(true, 0.15, 0, "dig_immediate");
 	default:
 		break;
 	}


### PR DESCRIPTION
To make it possible to dig only one torch when another one is behind it (pointed after digging), the digging speed must not be too small.
Before the change any digging time is set to 0.15 if it's bigger than this value.
After the change only the dig_immediate=3 nodes (e.g. torch) have the 0.15 digging time.