### PR TITLE
Add builtin groups for each drawtype

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -133,6 +133,7 @@ function core.register_item(name, itemdef)
 				" limiting to maximum: " ..name)
 		end
 		setmetatable(itemdef, {__index = core.nodedef_default})
+		itemdef.groups["__builtin_drawtype_" .. itemdef.drawtype] = 1
 		core.registered_nodes[itemdef.name] = itemdef
 	elseif itemdef.type == "craft" then
 		setmetatable(itemdef, {__index = core.craftitemdef_default})


### PR DESCRIPTION
Useful e.g. for the connects_to field

The group for a `normal` drawtype would be: `__builtin_drawtype_normal`