### PR TITLE
Accommodate duplicate and empty world names automatically

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -15,115 +15,135 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-local function create_world_formspec(dialogdata)
-	local mapgens = core.get_mapgen_names()
+local function create_world_formspec(dialog_data)
+	local values = {
+		seed = core.settings:get("fixed_map_seed") or "",
 
-	local current_seed = core.settings:get("fixed_map_seed") or ""
-	local current_mg   = core.settings:get("mg_name")
+		-- The ID which is also the name
+		map_generator = core.settings:get("mg_name"),
 
-	local mglist = ""
-	local selindex = 1
-	local i = 1
-	for k,v in pairs(mapgens) do
-		if current_mg == v then
-			selindex = i
+		-- The ID
+		game = core.settings:get("menu_last_game")
+	}
+
+	local map_generator_textlist = {}
+	local map_generator_index = 1
+	for i, name in ipairs(core.get_mapgen_names()) do
+		if name == values.map_generator then
+			map_generator_index = i
 		end
-		i = i + 1
-		mglist = mglist .. v .. ","
-	end
-	mglist = mglist:sub(1, -2)
-	
-	local gameid = core.settings:get("menu_last_game")
-	
-	local game, gameidx = nil , 0
-	if gameid ~= nil then
-		game, gameidx = gamemgr.find_by_gameid(gameid)
-		
-		if gameidx == nil then
-			gameidx = 0
-		end
+		table.insert(map_generator_textlist, core.formspec_escape(name))
 	end
 
-	current_seed = core.formspec_escape(current_seed)
-	local retval =
+	-- Cannot use gamemgr.gamelist() as it doesn't escape game names
+	local game_dropdown = {}
+	local game_index = 1
+	for i, game in ipairs(gamemgr.games) do
+		if game.id == values.game then
+			game_index = i
+		end
+		table.insert(game_dropdown, core.formspec_escape(game.name))
+	end
+
+	local formspec =
 		"size[11.5,6.5,true]" ..
-		"label[2,0;" .. fgettext("World name") .. "]"..
-		"field[4.5,0.4;6,0.5;te_world_name;;]" ..
 
-		"label[2,1;" .. fgettext("Seed") .. "]"..
-		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
+		"label[2,0;" .. fgettext("World name") .. "]" ..
+		"field[4.5,0.4;6,0.5;name;;]" ..
 
-		"label[2,2;" .. fgettext("Mapgen") .. "]"..
-		"dropdown[4.2,2;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]" ..
+		"label[2,1;" .. fgettext("Seed") .. "]" ..
+		"field[4.5,1.4;6,0.5;seed;;".. core.formspec_escape(values.seed) .. "]" ..
 
-		"label[2,3;" .. fgettext("Game") .. "]"..
-		"textlist[4.2,3;5.8,2.3;games;" .. gamemgr.gamelist() ..
-		";" .. gameidx .. ";true]" ..
+		"label[2,2;" .. fgettext("Mapgen") .. "]" ..
+		"dropdown[4.2,2;6.3;map_generator;" ..
+		table.concat(map_generator_textlist, ",") .. ";" ..
+		map_generator_index .. "]" ..
 
-		"button[3.25,6;2.5,0.5;world_create_confirm;" .. fgettext("Create") .. "]" ..
-		"button[5.75,6;2.5,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]"
+		"label[2,3;" .. fgettext("Game") .. "]" ..
+		"textlist[4.2,3;5.8,2.3;game;" ..
+		table.concat(game_dropdown, ",") .. ";" ..
+		game_index .. ";true]" ..
+
+		"button[3.25,6;2.5,0.5;create;" .. fgettext("Create") .. "]" ..
+		"button[5.75,6;2.5,0.5;cancel;" .. fgettext("Cancel") .. "]"
 		
 	if #gamemgr.games == 0 then
-		retval = retval .. "box[2,4;8,1;#ff8800]label[2.25,4;" ..
-				fgettext("You have no subgames installed.") .. "]label[2.25,4.4;" ..
-				fgettext("Download one from minetest.net") .. "]"
+		formspec = formspec ..
+			"box[2,4;8,1;#ff8800]" ..
+
+			"label[2.25,4;" ..
+			fgettext("You have no subgames installed.") .. "]" ..
+
+			"label[2.25,4.4;" ..
+			fgettext("Download one from minetest.net") .. "]"
 	elseif #gamemgr.games == 1 and gamemgr.games[1].id == "minimal" then
-		retval = retval .. "box[1.75,4;8.7,1;#ff8800]label[2,4;" ..
-				fgettext("Warning: The minimal development test is meant for developers.") .. "]label[2,4.4;" ..
-				fgettext("Download a subgame, such as minetest_game, from minetest.net") .. "]"
+		formspec = formspec ..
+			"box[1.75,4;8.7,1;#ff8800]" ..
+
+			"label[2,4;" ..
+			fgettext("Warning: The minimal development test is meant for developers.") .. "]" ..
+
+			"label[2,4.4;" ..
+			fgettext("Download a subgame, such as minetest_game, from minetest.net") .. "]"
 	end
-
-	return retval
-
+	return formspec
 end
 
-local function create_world_buttonhandler(this, fields)
 
-	if fields["world_create_confirm"] or
-		fields["key_enter"] then
+local function create_world_button_handler(this, fields)
+	local buttons = {
+		create = fields["create"] or fields["key_enter"],
+		cancel = fields["cancel"]
+	}
+	local values = {
+		name = fields["name"],
+		game_index = core.get_textlist_index("game"),
+		seed = fields["seed"],
+		map_generator = fields["map_generator"]
+	}
 
-		local worldname = fields["te_world_name"]
-		local gameindex = core.get_textlist_index("games")
-
-		if gameindex ~= nil and
-			worldname ~= "" then
-
-			local message = nil
-
-			core.settings:set("fixed_map_seed", fields["te_seed"])
-
-			if not menudata.worldlist:uid_exists_raw(worldname) then
-				core.settings:set("mg_name",fields["dd_mapgen"])
-				message = core.create_world(worldname,gameindex)
-			else
-				message = fgettext("A world named \"$1\" already exists", worldname)
-			end
-
-			if message ~= nil then
-				gamedata.errormessage = message
-			else
-				core.settings:set("menu_last_game",gamemgr.games[gameindex].id)
-				if this.data.update_worldlist_filter then
-					menudata.worldlist:set_filtercriteria(gamemgr.games[gameindex].id)
-					mm_texture.update("singleplayer", gamemgr.games[gameindex].id)
-				end
-				menudata.worldlist:refresh()
-				core.settings:set("mainmenu_last_selected_world",
-									menudata.worldlist:raw_index_by_uid(worldname))
-			end
-		else
+	if buttons.create then
+		if values.name == "" or values.game_index == nil then
 			gamedata.errormessage =
 				fgettext("No worldname given or no game selected")
+			return true
 		end
+
+		core.settings:set("fixed_map_seed", values.seed)
+		if menudata.worldlist:uid_exists_raw(values.name) then
+			gamedata.errormessage =
+				fgettext("A world named \"$1\" already exists", worldname)
+			return true
+		end
+
+		core.settings:set("mg_name", values.map_generator)
+		local create_world_error =
+			core.create_world(values.name, values.game_index)
+		if create_world_error ~= nil then
+			gamedata.errormessage = create_world_error
+			return true
+		end
+
+		local game_id = gamemgr.games[values.game_index].id
+		core.settings:set("menu_last_game", game_id)
+		if this.data.update_worldlist_filter then
+			menudata.worldlist:set_filtercriteria(game_id)
+			mm_texture.update("singleplayer", game_id)
+		end
+		menudata.worldlist:refresh()
+		core.settings:set(
+			"mainmenu_last_selected_world",
+			menudata.worldlist:raw_index_by_uid(values.name)
+		)
 		this:delete()
 		return true
 	end
 
-	if fields["games"] then
+	if values.game then
 		return true
 	end
 	
-	if fields["world_create_cancel"] then
+	if buttons.cancel then
 		this:delete()
 		return true
 	end
@@ -132,12 +152,13 @@ local function create_world_buttonhandler(this, fields)
 end
 
 
-function create_create_world_dlg(update_worldlistfilter)
-	local retval = dialog_create("sp_create_world",
-					create_world_formspec,
-					create_world_buttonhandler,
-					nil)
-	retval.update_worldlist_filter = update_worldlistfilter
-	
-	return retval
+function create_create_world_dlg(update_worldlist_filter)
+	local dialog = dialog_create(
+		"sp_create_world",
+		create_world_formspec,
+		create_world_button_handler,
+		nil
+	)
+	dialog.update_worldlist_filter = update_worldlist_filter
+	return dialog
 end


### PR DESCRIPTION
When the create button is pressed and the name is empty it becomes "Unnamed" and if duplicate a number is added or increased.

Commit list:

- ~~Start world after creation~~
- Accommodate world name automatically
- Refactor and fix no escaping in dlg_create_world 
  - Fix game names and map generators not being escaped
  - Fix variable name inconsistencies within file
  - Use table concatenation to build comma separated lists
  - Use tables for form values