### PR TITLE
Allow "drawtype:<lua drawtype name>" in getIds()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2757,15 +2757,15 @@ and `minetest.auth_reload` call the authentication handler.
     * accounting for time changes.
 * `minetest.find_node_near(pos, radius, nodenames, [search_center])`: returns pos or `nil`
     * `radius`: using a maximum metric
-    * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
+    * `nodenames`: e.g. `{"ignore", "group:tree", "drawtype:normal"}` or `"default:dirt"`
     * `search_center` is an optional boolean (default: `false`)
       If true `pos` is also checked for the nodes
 * `minetest.find_nodes_in_area(pos1, pos2, nodenames)`: returns a list of positions
-    * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
+    * `nodenames`: e.g. `{"ignore", "group:tree", "drawtype:normal"}` or `"default:dirt"`
     * First return value: Table with all node positions
     * Second return value: Table with the count of each node with the node name as index
 * `minetest.find_nodes_in_area_under_air(pos1, pos2, nodenames)`: returns a list of positions
-    * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
+    * `nodenames`: e.g. `{"ignore", "group:tree", "drawtype:normal"}` or `"default:dirt"`
     * Return value: Table with all node positions with a node air above
 * `minetest.get_perlin(noiseparams)`
 * `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
@@ -4393,7 +4393,7 @@ Definition tables
         label = "Lava cooling",
     --  ^ Descriptive label for profiling purposes (optional).
     --    Definitions with identical labels will be listed as one.
-    --  In the following two fields, also group:groupname will work.
+    --  In the following two fields, also group:groupname and drawtype:drawtype_name will work.
         nodenames = {"default:lava_source"},
         neighbors = {"default:water_source", "default:water_flowing"}, -- Any of these --[[
         ^ If left out or empty, any neighbor will do ]]
@@ -4416,7 +4416,7 @@ Definition tables
         nodenames = {"default:lava_source"},
     --  ^ List of node names to trigger the LBM on.
     --    Also non-registered nodes will work.
-    --    Groups (as of group:groupname) will work as well.
+    --    Groups (as of group:groupname) and drawtypes (drawtype:drawtype_name) will work as well.
         run_at_every_load = false,
     --  ^ Whether to run the LBM's action every time a block gets loaded,
     --    and not just for blocks that were saved last time before LBMs were
@@ -4651,7 +4651,7 @@ Definition tables
         connects_to = nodenames, --[[
         * Used for nodebox nodes with the type == "connected"
         * Specifies to what neighboring nodes connections will be drawn
-        * e.g. `{"group:fence", "default:wood"}` or `"default:stone"` ]]
+        * e.g. `{"group:fence", "default:wood", "drawtype:normal"}` or `"default:stone"` ]]
         connect_sides = { "top", "bottom", "front", "left", "back", "right" }, --[[
         ^ Tells connected nodebox nodes to connect only to these sides of this node. ]]
         mesh = "model",

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -33,6 +33,7 @@ class Client;
 #include "sound.h" // SimpleSoundSpec
 #include "constants.h" // BS
 #include "tileanimation.h"
+#include "script/common/c_types.h"
 
 class INodeDefManager;
 class IItemDefManager;
@@ -440,7 +441,7 @@ public:
 	virtual const ContentFeatures &get(const MapNode &n) const=0;
 	virtual bool getId(const std::string &name, content_t &result) const=0;
 	virtual content_t getId(const std::string &name) const=0;
-	// Allows "group:name" in addition to regular node names
+	// Allows "group:name" and "drawtype:name" in addition to regular node names
 	// returns false if node name not found, true otherwise
 	virtual bool getIds(const std::string &name, std::vector<content_t> &result)
 			const=0;
@@ -456,6 +457,8 @@ public:
 	 * contains all nodes' selection boxes.
 	 */
 	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
+	static struct EnumString DrawTypes[];
+	bool stringToEnum(const EnumString *spec, int &result, const std::string &drawtype) const;
 };
 
 class IWritableNodeDefManager : public INodeDefManager {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -491,7 +491,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	/* Visual definition */
 
 	f.drawtype = (NodeDrawType)getenumfield(L, index, "drawtype",
-			ScriptApiNode::es_DrawType,NDT_NORMAL);
+			INodeDefManager::DrawTypes, NDT_NORMAL);
 	getfloatfield(L, index, "visual_scale", f.visual_scale);
 
 	/* Meshnode model filename */
@@ -772,7 +772,7 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 {
 	std::string paramtype(ScriptApiNode::es_ContentParamType[(int)c.param_type].str);
 	std::string paramtype2(ScriptApiNode::es_ContentParamType2[(int)c.param_type_2].str);
-	std::string drawtype(ScriptApiNode::es_DrawType[(int)c.drawtype].str);
+	std::string drawtype(INodeDefManager::DrawTypes[(int)c.drawtype].str);
 	std::string liquid_type(ScriptApiNode::es_LiquidType[(int)c.liquid_type].str);
 
 	/* Missing "tiles" because I don't see a usecase (at least not yet). */

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -27,29 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 
 
-// Should be ordered exactly like enum NodeDrawType in nodedef.h
-struct EnumString ScriptApiNode::es_DrawType[] =
-	{
-		{NDT_NORMAL, "normal"},
-		{NDT_AIRLIKE, "airlike"},
-		{NDT_LIQUID, "liquid"},
-		{NDT_FLOWINGLIQUID, "flowingliquid"},
-		{NDT_GLASSLIKE, "glasslike"},
-		{NDT_ALLFACES, "allfaces"},
-		{NDT_ALLFACES_OPTIONAL, "allfaces_optional"},
-		{NDT_TORCHLIKE, "torchlike"},
-		{NDT_SIGNLIKE, "signlike"},
-		{NDT_PLANTLIKE, "plantlike"},
-		{NDT_FENCELIKE, "fencelike"},
-		{NDT_RAILLIKE, "raillike"},
-		{NDT_NODEBOX, "nodebox"},
-		{NDT_GLASSLIKE_FRAMED, "glasslike_framed"},
-		{NDT_FIRELIKE, "firelike"},
-		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
-		{NDT_MESH, "mesh"},
-		{NDT_PLANTLIKE_ROOTED, "plantlike_rooted"},
-		{0, NULL},
-	};
 
 struct EnumString ScriptApiNode::es_ContentParamType2[] =
 	{

--- a/src/script/cpp_api/s_node.h
+++ b/src/script/cpp_api/s_node.h
@@ -49,7 +49,6 @@ public:
 			const StringMap &fields,
 			ServerActiveObject *sender);
 public:
-	static struct EnumString es_DrawType[];
 	static struct EnumString es_ContentParamType[];
 	static struct EnumString es_ContentParamType2[];
 	static struct EnumString es_LiquidType[];


### PR DESCRIPTION
Thanks to @SmallJoker for the help.

Useful e.g. for connected nodeboxes.

ToDo:

- [x] Add documentation
- [x] Further testing
- [x] (Don't copy-paste `EnumString INodeDefManager::DrawTypes[]`from `s_node.cpp`. ~~I tried to do this, but I failed. This needs to be done by someone else later.~~ _Thanks to Krock's help, I managed to fix this._)

Replaces #5579.

@paramat Better? :wink: