### PR TITLE
Don't make TAB exit game if bound to inventory.

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -3296,8 +3296,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 {
 	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
-		if (event.KeyInput.PressedDown && ( (kp == EscapeKey) ||
-				(kp == getKeySetting("keymap_inventory")) || (kp == CancelKey))) {
+		if (event.KeyInput.PressedDown && (
+				(kp == EscapeKey) || (kp == CancelKey) ||
+				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {
 			tryClose();
 			return true;
 		} else if (m_client != NULL && event.KeyInput.PressedDown &&


### PR DESCRIPTION
I play with the TAB key bound to the inventory. However, the
code here assumes that `inventory key` means "close formspec" in all contexts,
including the main menu. This causes my game to exit when I attempt
to TAB in between USERNAME and PASSWORD fields.

We know when m_client != NULL that the game is a client game and
not in the main menu, and then it's OK to use the INVENTORY bound
key to exit the formspec, since it's not the main menu.

Fixes #5593 