### PR TITLE
Cache MapBlock data in the mesh generator thread for less stutter

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -185,6 +185,7 @@ LOCAL_SRC_FILES := \
 		jni/src/mapnode.cpp                       \
 		jni/src/mapsector.cpp                     \
 		jni/src/mesh.cpp                          \
+		jni/src/mesh_generator_thread.cpp         \
 		jni/src/metadata.cpp                      \
 		jni/src/mg_biome.cpp                      \
 		jni/src/mg_decoration.cpp                 \

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -551,6 +551,11 @@ enable_mesh_cache (Mesh cache) bool false
 #    down the rate of mesh updates, thus reducing jitter on slower clients.
 mesh_generation_interval (Mapblock mesh generation delay) int 0 0 50
 
+#    Size of the MapBlock cache of the mesh generator. Increasing this will
+#    increase the cache hit %, reducing the data being copied from the main
+#    thread, thus reducing jitter.
+meshgen_block_cache_size (Mapblock mesh generator's MapBlock cache size MB) int 20 0 1000
+
 #    Enables minimap.
 enable_minimap (Minimap) bool true
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -644,6 +644,12 @@
 #    type: int min: 0 max: 50
 # mesh_generation_interval = 0
 
+#    Size of the MapBlock cache of the mesh generator. Increasing this will
+#    increase the cache hit %, reducing the data being copied from the main
+#    thread, thus reducing jitter.
+#    type: int min: 0 max: 1000
+# meshgen_block_cache_size = 20
+
 #    Enables minimap.
 #    type: bool
 # enable_minimap = true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -522,6 +522,7 @@ set(client_SRCS
 	main.cpp
 	mapblock_mesh.cpp
 	mesh.cpp
+	mesh_generator_thread.cpp
 	minimap.cpp
 	particles.cpp
 	shader.cpp

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -39,6 +39,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("sound_volume", "0.8");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
+	settings->setDefault("meshgen_block_cache_size", "20");
 	settings->setDefault("enable_vbo", "true");
 	settings->setDefault("free_move", "false");
 	settings->setDefault("fast_move", "false");

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -154,6 +154,11 @@ public:
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_REALLOCATE);
 	}
 
+	MapNode* getData()
+	{
+		return data;
+	}
+
 	////
 	//// Modification tracking methods
 	////

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -53,6 +53,12 @@ struct MeshMakeData
 			bool use_tangent_vertices = false);
 
 	/*
+		Copy block data manually (to allow optimizations by the caller)
+	*/
+	void fillBlockDataBegin(const v3s16 &blockpos);
+	void fillBlockData(const v3s16 &block_offset, MapNode *data);
+
+	/*
 		Copy central data directly from block, and other data from
 		parent of block.
 	*/

--- a/src/mesh_generator_thread.cpp
+++ b/src/mesh_generator_thread.cpp
@@ -1,0 +1,329 @@
+/*
+Minetest
+Copyright (C) 2013, 2017 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "mesh_generator_thread.h"
+#include "settings.h"
+#include "profiler.h"
+#include "client.h"
+#include "mapblock.h"
+#include "map.h"
+
+/*
+	CachedMapBlockData
+*/
+
+CachedMapBlockData::CachedMapBlockData():
+	p(-1337,-1337,-1337),
+	data(NULL),
+	refcount_from_queue(0),
+	last_used_timestamp(time(0))
+{
+}
+
+CachedMapBlockData::~CachedMapBlockData()
+{
+	assert(refcount_from_queue == 0);
+
+	if (data)
+		delete[] data;
+}
+
+/*
+	QueuedMeshUpdate
+*/
+
+QueuedMeshUpdate::QueuedMeshUpdate():
+	p(-1337,-1337,-1337),
+	ack_block_to_server(false),
+	urgent(false),
+	crack_level(-1),
+	crack_pos(0,0,0),
+	data(NULL)
+{
+}
+
+QueuedMeshUpdate::~QueuedMeshUpdate()
+{
+	if (data)
+		delete data;
+}
+
+/*
+	MeshUpdateQueue
+*/
+
+MeshUpdateQueue::MeshUpdateQueue(Client *client):
+	m_client(client)
+{
+	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
+	m_cache_use_tangent_vertices = m_cache_enable_shaders && (
+		g_settings->getBool("enable_bumpmapping") ||
+		g_settings->getBool("enable_parallax_occlusion"));
+	m_cache_smooth_lighting = g_settings->getBool("smooth_lighting");
+	m_meshgen_block_cache_size = g_settings->getS32("meshgen_block_cache_size");
+}
+
+MeshUpdateQueue::~MeshUpdateQueue()
+{
+	MutexAutoLock lock(m_mutex);
+
+	for (std::vector<QueuedMeshUpdate*>::iterator i = m_queue.begin();
+			i != m_queue.end(); ++i) {
+		QueuedMeshUpdate *q = *i;
+		delete q;
+	}
+}
+
+void MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent)
+{
+	DSTACK(FUNCTION_NAME);
+
+	MutexAutoLock lock(m_mutex);
+
+	cleanupCache();
+
+	/*
+		Cache the block data (force-update the center block, don't update the
+		neighbors but get them if they aren't already cached)
+	*/
+	std::vector<CachedMapBlockData*> cached_blocks;
+	size_t cache_hit_counter = 0;
+	cached_blocks.reserve(3*3*3);
+	v3s16 dp;
+	for (dp.X = -1; dp.X <= 1; dp.X++)
+	for (dp.Y = -1; dp.Y <= 1; dp.Y++)
+	for (dp.Z = -1; dp.Z <= 1; dp.Z++) {
+		v3s16 p1 = p + dp;
+		CachedMapBlockData *cached_block;
+		if (dp == v3s16(0, 0, 0))
+			cached_block = cacheBlock(map, p1, FORCE_UPDATE);
+		else
+			cached_block = cacheBlock(map, p1, SKIP_UPDATE_IF_ALREADY_CACHED,
+					&cache_hit_counter);
+		cached_blocks.push_back(cached_block);
+	}
+	g_profiler->avg("MeshUpdateQueue MapBlock cache hit %",
+			100.0f * cache_hit_counter / cached_blocks.size());
+
+	/*
+		Mark the block as urgent if requested
+	*/
+	if (urgent)
+		m_urgents.insert(p);
+
+	/*
+		Find if block is already in queue.
+		If it is, update the data and quit.
+	*/
+	for (std::vector<QueuedMeshUpdate*>::iterator i = m_queue.begin();
+			i != m_queue.end(); ++i) {
+		QueuedMeshUpdate *q = *i;
+		if (q->p == p) {
+			// NOTE: We are not adding a new position to the queue, thus
+			//       refcount_from_queue stays the same.
+			if(ack_block_to_server)
+				q->ack_block_to_server = true;
+			q->crack_level = m_client->getCrackLevel();
+			q->crack_pos = m_client->getCrackPos();
+			return;
+		}
+	}
+
+	/*
+		Add the block
+	*/
+	QueuedMeshUpdate *q = new QueuedMeshUpdate;
+	q->p = p;
+	q->ack_block_to_server = ack_block_to_server;
+	q->crack_level = m_client->getCrackLevel();
+	q->crack_pos = m_client->getCrackPos();
+	m_queue.push_back(q);
+
+	// This queue entry is a new reference to the cached blocks
+	for (size_t i=0; i<cached_blocks.size(); i++) {
+		cached_blocks[i]->refcount_from_queue++;
+	}
+}
+
+// Returned pointer must be deleted
+// Returns NULL if queue is empty
+QueuedMeshUpdate *MeshUpdateQueue::pop()
+{
+	MutexAutoLock lock(m_mutex);
+
+	bool must_be_urgent = !m_urgents.empty();
+	for (std::vector<QueuedMeshUpdate*>::iterator i = m_queue.begin();
+			i != m_queue.end(); ++i) {
+		QueuedMeshUpdate *q = *i;
+		if(must_be_urgent && m_urgents.count(q->p) == 0)
+			continue;
+		m_queue.erase(i);
+		m_urgents.erase(q->p);
+		fillDataFromMapBlockCache(q);
+		return q;
+	}
+	return NULL;
+}
+
+CachedMapBlockData* MeshUpdateQueue::cacheBlock(Map *map, v3s16 p, UpdateMode mode,
+			size_t *cache_hit_counter)
+{
+	std::map<v3s16, CachedMapBlockData*>::iterator it =
+			m_cache.find(p);
+	if (it != m_cache.end()) {
+		// Already in cache
+		CachedMapBlockData *cached_block = it->second;
+		if (mode == SKIP_UPDATE_IF_ALREADY_CACHED) {
+			if (cache_hit_counter)
+				(*cache_hit_counter)++;
+			return cached_block;
+		}
+		MapBlock *b = map->getBlockNoCreateNoEx(p);
+		if (b) {
+			if (cached_block->data == NULL)
+				cached_block->data =
+						new MapNode[MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE];
+			memcpy(cached_block->data, b->getData(),
+					MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE * sizeof(MapNode));
+		} else {
+			delete[] cached_block->data;
+			cached_block->data = NULL;
+		}
+		return cached_block;
+	} else {
+		// Not yet in cache
+		CachedMapBlockData *cached_block = new CachedMapBlockData();
+		m_cache[p] = cached_block;
+		MapBlock *b = map->getBlockNoCreateNoEx(p);
+		if (b) {
+			cached_block->data =
+					new MapNode[MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE];
+			memcpy(cached_block->data, b->getData(),
+					MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE * sizeof(MapNode));
+		}
+		return cached_block;
+	}
+}
+
+CachedMapBlockData* MeshUpdateQueue::getCachedBlock(const v3s16 &p)
+{
+	std::map<v3s16, CachedMapBlockData*>::iterator it = m_cache.find(p);
+	if (it != m_cache.end()) {
+		return it->second;
+	}
+	return NULL;
+}
+
+void MeshUpdateQueue::fillDataFromMapBlockCache(QueuedMeshUpdate *q)
+{
+	MeshMakeData *data = new MeshMakeData(m_client, m_cache_enable_shaders,
+			m_cache_use_tangent_vertices);
+	q->data = data;
+
+	data->fillBlockDataBegin(q->p);
+
+	int t_now = time(0);
+
+	// Collect data for 3*3*3 blocks from cache
+	v3s16 dp;
+	for (dp.X = -1; dp.X <= 1; dp.X++)
+	for (dp.Y = -1; dp.Y <= 1; dp.Y++)
+	for (dp.Z = -1; dp.Z <= 1; dp.Z++) {
+		v3s16 p = q->p + dp;
+		CachedMapBlockData *cached_block = getCachedBlock(p);
+		if (cached_block) {
+			cached_block->refcount_from_queue--;
+			cached_block->last_used_timestamp = t_now;
+			if (cached_block->data)
+				data->fillBlockData(dp, cached_block->data);
+		}
+	}
+
+	data->setCrack(q->crack_level, q->crack_pos);
+	data->setSmoothLighting(m_cache_smooth_lighting);
+}
+
+void MeshUpdateQueue::cleanupCache()
+{
+	const int mapblock_kB = MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE *
+			sizeof(MapNode) / 1000;
+	g_profiler->avg("MeshUpdateQueue MapBlock cache size kB",
+			mapblock_kB * m_cache.size());
+
+	// The cache size is kept roughly below cache_soft_max_size, not letting
+	// anything get older than cache_seconds_max or deleted before 2 seconds.
+	const int cache_seconds_max = 10;
+	const int cache_soft_max_size = m_meshgen_block_cache_size * 1000 / mapblock_kB;
+	int cache_seconds = MYMAX(2, cache_seconds_max -
+			m_cache.size() / (cache_soft_max_size / cache_seconds_max));
+
+	int t_now = time(0);
+
+	for (std::map<v3s16, CachedMapBlockData*>::iterator it = m_cache.begin();
+			it != m_cache.end(); ) {
+		CachedMapBlockData *cached_block = it->second;
+		if (cached_block->refcount_from_queue == 0 &&
+				cached_block->last_used_timestamp < t_now - cache_seconds) {
+			m_cache.erase(it++);
+		} else {
+			++it;
+		}
+	}
+}
+
+/*
+	MeshUpdateThread
+*/
+
+MeshUpdateThread::MeshUpdateThread(Client *client):
+	UpdateThread("Mesh"),
+	m_queue_in(client)
+{
+	m_generation_interval = g_settings->getU16("mesh_generation_interval");
+	m_generation_interval = rangelim(m_generation_interval, 0, 50);
+}
+
+void MeshUpdateThread::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
+		bool urgent)
+{
+	// Allow the MeshUpdateQueue to do whatever it wants
+	m_queue_in.addBlock(map, p, ack_block_to_server, urgent);
+	deferUpdate();
+}
+
+void MeshUpdateThread::doUpdate()
+{
+	QueuedMeshUpdate *q;
+	while ((q = m_queue_in.pop())) {
+		if (m_generation_interval)
+			sleep_ms(m_generation_interval);
+		ScopeProfiler sp(g_profiler, "Client: Mesh making");
+
+		MapBlockMesh *mesh_new = new MapBlockMesh(q->data, m_camera_offset);
+
+		MeshUpdateResult r;
+		r.p = q->p;
+		r.mesh = mesh_new;
+		r.ack_block_to_server = q->ack_block_to_server;
+
+		m_queue_out.push_back(r);
+
+		delete q;
+	}
+}

--- a/src/mesh_generator_thread.h
+++ b/src/mesh_generator_thread.h
@@ -1,0 +1,135 @@
+/*
+Minetest
+Copyright (C) 2013, 2017 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef MESH_GENERATOR_THREAD_HEADER
+#define MESH_GENERATOR_THREAD_HEADER
+
+#include "mapblock_mesh.h"
+#include "threading/mutex_auto_lock.h"
+#include "util/thread.h"
+
+struct CachedMapBlockData
+{
+	v3s16 p;
+	MapNode *data; // A copy of the MapBlock's data member
+	int refcount_from_queue;
+	int last_used_timestamp;
+
+	CachedMapBlockData();
+	~CachedMapBlockData();
+};
+
+struct QueuedMeshUpdate
+{
+	v3s16 p;
+	bool ack_block_to_server;
+	bool urgent;
+	int crack_level;
+	v3s16 crack_pos;
+	MeshMakeData *data; // This is generated in MeshUpdateQueue::pop()
+
+	QueuedMeshUpdate();
+	~QueuedMeshUpdate();
+};
+
+/*
+	A thread-safe queue of mesh update tasks and a cache of MapBlock data
+*/
+class MeshUpdateQueue
+{
+	enum UpdateMode {
+		FORCE_UPDATE,
+		SKIP_UPDATE_IF_ALREADY_CACHED,
+	};
+public:
+	MeshUpdateQueue(Client *client);
+
+	~MeshUpdateQueue();
+
+	// Caches the block at p and its neighbors (if needed) and queues a mesh
+	// update for the block at p
+	void addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent);
+
+	// Returned pointer must be deleted
+	// Returns NULL if queue is empty
+	QueuedMeshUpdate * pop();
+
+	u32 size()
+	{
+		MutexAutoLock lock(m_mutex);
+		return m_queue.size();
+	}
+
+private:
+	Client *m_client;
+	std::vector<QueuedMeshUpdate*> m_queue;
+	std::set<v3s16> m_urgents;
+	std::map<v3s16, CachedMapBlockData*> m_cache;
+	Mutex m_mutex;
+
+	// TODO: Add callback to update these when g_settings changes
+	bool m_cache_enable_shaders;
+	bool m_cache_use_tangent_vertices;
+	bool m_cache_smooth_lighting;
+	int m_meshgen_block_cache_size;
+
+	CachedMapBlockData* cacheBlock(Map *map, v3s16 p, UpdateMode mode,
+			size_t *cache_hit_counter=NULL);
+	CachedMapBlockData* getCachedBlock(const v3s16 &p);
+	void fillDataFromMapBlockCache(QueuedMeshUpdate *q);
+	void cleanupCache();
+};
+
+struct MeshUpdateResult
+{
+	v3s16 p;
+	MapBlockMesh *mesh;
+	bool ack_block_to_server;
+
+	MeshUpdateResult():
+		p(-1338,-1338,-1338),
+		mesh(NULL),
+		ack_block_to_server(false)
+	{
+	}
+};
+
+class MeshUpdateThread : public UpdateThread
+{
+public:
+	MeshUpdateThread(Client *client);
+
+	// Caches the block at p and its neighbors (if needed) and queues a mesh
+	// update for the block at p
+	void updateBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent);
+
+	v3s16 m_camera_offset;
+	MutexedQueue<MeshUpdateResult> m_queue_out;
+
+private:
+	MeshUpdateQueue m_queue_in;
+
+	// TODO: Add callback to update these when g_settings changes
+	int m_generation_interval;
+
+protected:
+	virtual void doUpdate();
+};
+
+#endif

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../threading/mutex_auto_lock.h"
 #include "porting.h"
 #include "log.h"
+#include "container.h"
 
 template<typename T>
 class MutexedVariable {


### PR DESCRIPTION
Adds a MapBlock cache in MeshUpdateThread's MeshUpdateQueue. This way only changed MapBlocks need to be copied from the main thread, plus ones that have timed out from the cache.

Neighboring MapBlocks are often received and updated in close succession to each other, which leads to huge amounts of MapBlocks being fetched from the cache.

This removes the MeshMakeData::fill stutter that is seen on the client when large amounts of received MapBlocks are being handled. There are multiple other unknown sources of stutter left, which can make noticing the difference difficult.

A version with some extra instrumentation can be found at https://github.com/celeron55/minetest/tree/mesh_update_block_cache.

Relates slightly to #5239.