### PR TITLE
Disable android leveldb by default

### DIFF
--- a/build/android/Makefile
+++ b/build/android/Makefile
@@ -35,7 +35,7 @@ TARGET_CXXFLAGS_ADDON = $(TARGET_CFLAGS_ADDON)
 TARGET_ARCH = armv7
 CROSS_PREFIX = arm-linux-androideabi-
 COMPILER_VERSION = 4.9
-HAVE_LEVELDB = 1
+HAVE_LEVELDB = 0
 
 ################################################################################
 # toolchain config for little endian mips
@@ -59,7 +59,7 @@ HAVE_LEVELDB = 1
 #CROSS_PREFIX = i686-linux-android-
 #TARGET_ARCH = x86
 #COMPILER_VERSION = 4.9
-#HAVE_LEVELDB = 1
+#HAVE_LEVELDB = 0
 
 ################################################################################
 ASSETS_TIMESTAMP = deps/assets_timestamp
@@ -352,7 +352,7 @@ leveldb_download :
 	fi
 
 leveldb : $(LEVELDB_LIB)
-
+ifeq ($(HAVE_LEVELDB),1)
 $(LEVELDB_LIB): $(LEVELDB_TIMESTAMP)
 	@REFRESH=0;                                                                \
 	if [ ! -e ${LEVELDB_TIMESTAMP_INT} ] ; then                                \
@@ -384,6 +384,7 @@ $(LEVELDB_LIB): $(LEVELDB_TIMESTAMP)
 	else                                                                       \
 		echo "nothing to be done for leveldb";                                 \
 	fi
+endif
 
 clean_leveldb :
 	$(RM) -rf deps/leveldb


### PR DESCRIPTION
This is a rebased version of #3651.
Completely untested however as this only concerns the android building process -- volunteers for testing?