### PR TITLE
Conf.example: Move some lines to minetest.conf.example.extra

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -769,10 +769,4 @@ end
 
 -- Generate minetest.conf.example and settings_translation_file.cpp
 
--- *** Please note ***
--- There is text in minetest.conf.example that will not be generated from
--- settingtypes.txt but must be preserved:
--- The documentation of mapgen noise parameter formats (title plus 16 lines)
--- Noise parameter 'mgv5_np_ground' in group format (13 lines)
-
 --assert(loadfile(core.get_builtin_path()..DIR_DELIM.."mainmenu"..DIR_DELIM.."generate_from_settingtypes.lua"))(parse_config_file(true, false))

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -92,7 +92,7 @@
 # joystick_id = 0
 
 #    The type of joystick
-#    type: enum values: auto,generic,xbox
+#    type: enum values: auto, generic, xbox
 # joystick_type = auto
 
 #    The time in seconds it takes between repeated events
@@ -1195,25 +1195,6 @@
 #    type: int
 # num_emerge_threads = 1
 
-#### Noise parameters and formats
-
-#    Noise parameters can be specified as a set of positional values, for example:
-#    Offset, scale, (spread factors), seed offset, number of octaves, persistence, lacunarity
-# mgv6_np_terrain_base = -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0
-#    Or the group format can be used instead, for example:
-# mgv6_np_terrain_base = {
-#    offset      = -4,
-#    scale       = 20,
-#    spread      = (250, 250, 250),
-#    seed        = 82341,
-#    octaves     = 5,
-#    persistence = 0.6,
-#    lacunarity  = 2.0,
-#    flags       = "defaults"
-# }
-#    Only the group format supports noise flags which are needed for eased noise.
-#    Mgv5 uses eased noise for np_ground so this is shown in group format below.
-
 #### Biome API temperature and humidity noise parameters
 
 #    Temperature variation for biomes.
@@ -1280,22 +1261,6 @@
 #    3D noise defining giant caverns.
 #    type: noise_params
 # mgv5_np_cavern = 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
-
-#    Noise parameter in group format, unsupported by advanced settings
-#    menu but settable in minetest.conf.
-#    See documentation of noise parameter formats above.
-#    3D noise defining terrain.
-#    type: noise_params
-# mgv5_np_ground = {
-#    offset      = 0,
-#    scale       = 40,
-#    spread      = (80, 80, 80),
-#    seed        = 983240,
-#    octaves     = 4,
-#    persistence = 0.55,
-#    lacunarity  = 2.0,
-#    flags       = "eased"
-# }
 
 #### Mapgen v6
 

--- a/minetest.conf.example.extra
+++ b/minetest.conf.example.extra
@@ -1,0 +1,63 @@
+#    This file contains information (some of which was previously stored in
+#    minetest.conf.example) that cannot be automatically generated from
+#    builtin/settingtypes.txt.
+#    This file contains a list of settings and their default value for minetest.conf
+
+#    By default, all the settings are commented and not functional.
+#    Uncomment settings by removing the preceding #.
+
+#    minetest.conf is read by default from:
+#    ../minetest.conf
+#    ../../minetest.conf
+#    Any other path can be chosen by passing the path as a parameter
+#    to the program, eg. "minetest.exe --config ../minetest.conf.example".
+
+#    Further documentation:
+#    http://wiki.minetest.net/
+
+
+# Mapgen
+
+# Noise parameters and formats
+
+#    Noise parameters can be specified as a set of positional values, for example:
+#
+#    Offset, scale, (x, y, z spread factors), seed offset, octaves, persistence, lacunarity
+# mgv6_np_terrain_base = -4, 20, (250, 250, 250), 82341, 5, 0.6, 2.0
+#
+#    Or the group format can be used instead, for example:
+#
+# mgv6_np_terrain_base = {
+#    offset      = -4,
+#    scale       = 20,
+#    spread      = (250, 250, 250),
+#    seed        = 82341,
+#    octaves     = 5,
+#    persistence = 0.6,
+#    lacunarity  = 2.0,
+#    flags       = "defaults"
+# }
+#
+#    The advanced settings menu does not yet support the group format.
+#    Only the group format supports noise flags which are needed for eased noise.
+#    Mgv5 uses eased noise for np_ground so this is shown in group format below
+#    and is not present in the advanced settings menu.
+
+# Mapgen v5
+
+#    Noise parameter in group format, unsupported by advanced settings menu but
+#    settable in minetest.conf.
+#    See documentation of noise parameter formats above.
+#
+#    3D noise defining terrain.
+#    type: noise_params
+# mgv5_np_ground = {
+#    offset      = 0,
+#    scale       = 40,
+#    spread      = (80, 80, 80),
+#    seed        = 983240,
+#    octaves     = 4,
+#    persistence = 0.55,
+#    lacunarity  = 2.0,
+#    flags       = "eased"
+# }


### PR DESCRIPTION
Some information in conf.example cannot be generated from
settingtypes.txt, moving it to a new file makes generating
conf.example while preserving that information easier.

Regenerate conf.example from settingtypes.txt.
///////////////////////////////////////////
I also removed my comment about preserving code from builtin/mainmenu/dlg_settings_advanced.lua

As discussed http://irc.minetest.net/minetest-dev/2017-04-16#i_4877699
http://irc.minetest.net/minetest-dev/2017-04-17#i_4879865