### PR TITLE
Allow overriding tool capabilities through itemstack metadata

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3267,8 +3267,9 @@ Can be obtained via `item:get_meta()`.
 
 #### Methods
 * All methods in MetaDataRef
-* `set_tool_capabilities([tool_capabilities])`: overrides the item's tool
-  capabilities to those provided, or unoverrides it if nil.
+* `set_tool_capabilities([tool_capabilities])`
+    * overrides the item's tool capabilities
+    * a nil value will clear the override data and restore the original behavior
 
 ### `StorageRef`
 Mod metadata: per mod metadata, saved automatically.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3267,6 +3267,8 @@ Can be obtained via `item:get_meta()`.
 
 #### Methods
 * All methods in MetaDataRef
+* `set_tool_capabilities([tool_capabilities])`: overrides the item's tool
+  capabilities to those provided, or unoverrides it if nil.
 
 ### `StorageRef`
 Mod metadata: per mod metadata, saved automatically.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3713,8 +3713,13 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		ToolCapabilities playeritem_toolcap =
 				playeritem.getToolCapabilities(itemdef_manager);
-		if (playeritem.name.empty() && hand_def.tool_capabilities != NULL) {
-			playeritem_toolcap = *hand_def.tool_capabilities;
+		if (playeritem.name.empty()) {
+			const ToolCapabilities *handToolcap = hlist
+				? &hlist->getItem(0).getToolCapabilities(itemdef_manager)
+				: itemdef_manager->get("").tool_capabilities;
+
+			if (handToolcap != nullptr)
+				playeritem_toolcap = *handToolcap;
 		}
 		handlePointingAtNode(pointed, playeritem_def, playeritem,
 			playeritem_toolcap, dtime);
@@ -4016,9 +4021,9 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	// If can't dig, try hand
 	if (!params.diggable) {
 		InventoryList *hlist = local_inventory->getList("hand");
-		const ItemDefinition &hand =
-			hlist ? hlist->getItem(0).getDefinition(itemdef_manager) : itemdef_manager->get("");
-		const ToolCapabilities *tp = hand.tool_capabilities;
+		const ToolCapabilities *tp = hlist
+			? &hlist->getItem(0).getToolCapabilities(itemdef_manager)
+			: itemdef_manager->get("").tool_capabilities;
 
 		if (tp)
 			params = getDigParams(nodedef_manager->get(n).groups, tp);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -111,12 +111,15 @@ struct ItemStack
 	const ToolCapabilities& getToolCapabilities(
 			IItemDefManager *itemdef) const
 	{
-		ToolCapabilities *cap;
-		cap = itemdef->get(name).tool_capabilities;
-		if(cap == NULL)
-			cap = itemdef->get("").tool_capabilities;
-		assert(cap != NULL);
-		return *cap;
+		const ToolCapabilities *item_cap =
+			itemdef->get(name).tool_capabilities;
+
+		if (item_cap == NULL)
+			// Fall back to the hand's tool capabilities
+			item_cap = itemdef->get("").tool_capabilities;
+
+		assert(item_cap != NULL);
+		return metadata.getToolCapabilities(*item_cap); // Check for override
 	}
 
 	// Wear out (only tools)

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -9,6 +9,22 @@
 #define DESERIALIZE_KV_DELIM_STR "\x02"
 #define DESERIALIZE_PAIR_DELIM_STR "\x03"
 
+#define TOOLCAP_KEY "tool_capabilities"
+
+void ItemStackMetadata::clear()
+{
+	Metadata::clear();
+	updateToolCapabilities();
+}
+
+bool ItemStackMetadata::setString(const std::string &name, const std::string &var)
+{
+	bool result = Metadata::setString(name, var);
+	if (name == TOOLCAP_KEY)
+		updateToolCapabilities();
+	return result;
+}
+
 void ItemStackMetadata::serialize(std::ostream &os) const
 {
 	std::ostringstream os2;
@@ -40,4 +56,29 @@ void ItemStackMetadata::deSerialize(std::istream &is)
 			m_stringvars[""] = in;
 		}
 	}
+	updateToolCapabilities();
+}
+
+void ItemStackMetadata::updateToolCapabilities()
+{
+	if (contains(TOOLCAP_KEY)) {
+		toolcaps_overridden = true;
+		toolcaps_override = ToolCapabilities();
+		std::istringstream is(getString(TOOLCAP_KEY));
+		toolcaps_override.deserializeJson(is);
+	} else {
+		toolcaps_overridden = false;
+	}
+}
+
+void ItemStackMetadata::setToolCapabilities(const ToolCapabilities &caps)
+{
+	std::ostringstream os;
+	caps.serializeJson(os);
+	setString(TOOLCAP_KEY, os.str());
+}
+
+void ItemStackMetadata::clearToolCapabilities()
+{
+	setString(TOOLCAP_KEY, "");
 }

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "metadata.h"
+#include "tool.h"
 
 class Inventory;
 class IItemDefManager;
@@ -27,6 +28,27 @@ class IItemDefManager;
 class ItemStackMetadata : public Metadata
 {
 public:
+	ItemStackMetadata() : toolcaps_overridden(false) {}
+
+	// Overrides
+	void clear() override;
+	bool setString(const std::string &name, const std::string &var) override;
+
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
+
+	const ToolCapabilities &getToolCapabilities(
+			const ToolCapabilities &default_caps) const
+	{
+		return toolcaps_overridden ? toolcaps_override : default_caps;
+	}
+
+	void setToolCapabilities(const ToolCapabilities &caps);
+	void clearToolCapabilities();
+
+private:
+	void updateToolCapabilities();
+
+	bool toolcaps_overridden;
+	ToolCapabilities toolcaps_override;
 };

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1536,9 +1536,10 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 				// If can't dig, try hand
 				if (!params.diggable) {
 					InventoryList *hlist = playersao->getInventory()->getList("hand");
-					const ItemDefinition &hand =
-						hlist ? hlist->getItem(0).getDefinition(m_itemdef) : m_itemdef->get("");
-					const ToolCapabilities *tp = hand.tool_capabilities;
+					const ToolCapabilities *tp = hlist
+						? &hlist->getItem(0).getToolCapabilities(m_itemdef)
+						: m_itemdef->get("").tool_capabilities;
+
 					if (tp)
 						params = getDigParams(m_nodedef->get(n).groups, tp);
 				}

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -50,6 +50,20 @@ void ItemStackMetaRef::reportMetadataChange()
 }
 
 // Exported functions
+int ItemStackMetaRef::l_set_tool_capabilities(lua_State *L)
+{
+	ItemStackMetaRef *metaref = checkobject(L, 1);
+	if (lua_isnoneornil(L, 2)) {
+		metaref->clearToolCapabilities();
+	} else if (lua_istable(L, 2)) {
+		ToolCapabilities caps = read_tool_capabilities(L, 2);
+		metaref->setToolCapabilities(caps);
+	} else {
+		luaL_typerror(L, 2, "table or nil");
+	}
+
+	return 0;
+}
 
 // garbage collector
 int ItemStackMetaRef::gc_object(lua_State *L) {
@@ -116,5 +130,6 @@ const luaL_Reg ItemStackMetaRef::methods[] = {
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
 	luamethod(MetaDataRef, equals),
+	luamethod(ItemStackMetaRef, set_tool_capabilities),
 	{0,0}
 };

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -40,7 +40,18 @@ private:
 
 	virtual void reportMetadataChange();
 
+	void setToolCapabilities(const ToolCapabilities &caps)
+	{
+		istack->metadata.setToolCapabilities(caps);
+	}
+
+	void clearToolCapabilities()
+	{
+		istack->metadata.clearToolCapabilities();
+	}
+
 	// Exported functions
+	static int l_set_tool_capabilities(lua_State *L);
 
 	// garbage collector
 	static int gc_object(lua_State *L);

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -25,6 +25,34 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "util/numeric.h"
 
+void ToolGroupCap::toJson(Json::Value &object) const
+{
+	object["maxlevel"] = maxlevel;
+	object["uses"] = uses;
+
+	Json::Value times_object;
+	for (auto time : times)
+		times_object[time.first] = time.second;
+	object["times"] = times_object;
+}
+
+void ToolGroupCap::fromJson(const Json::Value &json)
+{
+	if (json.isObject()) {
+		if (json["maxlevel"].isInt())
+			maxlevel = json["maxlevel"].asInt();
+		if (json["uses"].isInt())
+			uses = json["uses"].asInt();
+		const Json::Value &times_object = json["times"];
+		if (times_object.isArray()) {
+			Json::ArrayIndex size = times_object.size();
+			for (Json::ArrayIndex i = 0; i < size; ++i)
+				if (times_object[i].isDouble())
+					times[i] = times_object[i].asFloat();
+		}
+	}
+}
+
 void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 {
 	writeU8(os, 3); // protocol_version >= 36
@@ -81,6 +109,63 @@ void ToolCapabilities::deSerialize(std::istream &is)
 		std::string name = deSerializeString(is);
 		s16 rating = readS16(is);
 		damageGroups[name] = rating;
+	}
+}
+
+void ToolCapabilities::serializeJson(std::ostream &os) const
+{
+	Json::Value root;
+	root["full_punch_interval"] = full_punch_interval;
+	root["max_drop_level"] = max_drop_level;
+
+	Json::Value groupcaps_object;
+	for (auto groupcap : groupcaps) {
+		groupcap.second.toJson(groupcaps_object[groupcap.first]);
+	}
+	root["groupcaps"] = groupcaps_object;
+
+	Json::Value damage_groups_object;
+	DamageGroup::const_iterator dgiter;
+	for (dgiter = damageGroups.begin(); dgiter != damageGroups.end(); ++dgiter) {
+		damage_groups_object[dgiter->first] = dgiter->second;
+	}
+	root["damage_groups"] = damage_groups_object;
+
+	os << root;
+}
+
+void ToolCapabilities::deserializeJson(std::istream &is)
+{
+	Json::Value root;
+	is >> root;
+	if (root.isObject()) {
+		if (root["full_punch_interval"].isDouble())
+			full_punch_interval = root["full_punch_interval"].asFloat();
+		if (root["max_drop_level"].isInt())
+			max_drop_level = root["max_drop_level"].asInt();
+
+		Json::Value &groupcaps_object = root["groupcaps"];
+		if (groupcaps_object.isObject()) {
+			Json::ValueIterator gciter;
+			for (gciter = groupcaps_object.begin();
+					gciter != groupcaps_object.end(); ++gciter) {
+				ToolGroupCap groupcap;
+				groupcap.fromJson(*gciter);
+				groupcaps[gciter.key().asString()] = groupcap;
+			}
+		}
+
+		Json::Value &damage_groups_object = root["damage_groups"];
+		if (damage_groups_object.isObject()) {
+			Json::ValueIterator dgiter;
+			for (dgiter = damage_groups_object.begin();
+					dgiter != damage_groups_object.end(); ++dgiter) {
+				Json::Value &value = *dgiter;
+				if (value.isInt())
+					damageGroups[dgiter.key().asString()] =
+						value.asInt();
+			}
+		}
 	}
 }
 

--- a/src/tool.h
+++ b/src/tool.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <iostream>
 #include "itemgroup.h"
+#include <json/json.h>
 
 struct ToolGroupCap
 {
@@ -42,6 +43,9 @@ struct ToolGroupCap
 		*time = i->second;
 		return true;
 	}
+
+	void toJson(Json::Value &object) const;
+	void fromJson(const Json::Value &json);
 };
 
 
@@ -69,6 +73,8 @@ struct ToolCapabilities
 
 	void serialize(std::ostream &os, u16 version) const;
 	void deSerialize(std::istream &is);
+	void serializeJson(std::ostream &os) const;
+	void deserializeJson(std::istream &is);
 };
 
 struct DigParams


### PR DESCRIPTION
This implements tool capability overriding for itemstacks, relevant to #36.

Some suggestions for review things that I am unsure of:
 - I used `__tool_capabilities` as an "internal" meta field to transmit/store tool capability overrides. The modder does not need to set this manually, tool capabilities are overridden with a separate itemstack metadata method.

The impact on mods is that the get_tool_capabilities lua API method on itemstacks is no longer equivalent to getting the tool capabilities from the item definition.