### PR TITLE
Fix #5617 - respect message and reconnect parameters when shutting down immediately

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3479,9 +3479,16 @@ v3f Server::findSpawnPos()
 
 void Server::requestShutdown(const std::string &msg, bool reconnect, float delay)
 {
+	m_shutdown_timer = delay;
+	m_shutdown_msg = msg;
+	m_shutdown_ask_reconnect = reconnect;
+
 	if (delay == 0.0f) {
 	// No delay, shutdown immediately
 		m_shutdown_requested = true;
+		// only print to the infostream, a chat message saying 
+		// "Server Shutting Down" is sent when the server destructs.
+		infostream << "*** Immediate Server shutdown requested." << std::endl;
 	} else if (delay < 0.0f && m_shutdown_timer > 0.0f) {
 	// Negative delay, cancel shutdown if requested
 		m_shutdown_timer = 0.0f;
@@ -3495,10 +3502,7 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 		infostream << wide_to_utf8(ws.str()).c_str() << std::endl;
 		SendChatMessage(PEER_ID_INEXISTENT, ws.str());
 	} else if (delay > 0.0f) {
-	// Positive delay, delay the shutdown
-		m_shutdown_timer = delay;
-		m_shutdown_msg = msg;
-		m_shutdown_ask_reconnect = reconnect;
+	// Positive delay, tell the clients when the server will shut down
 		std::wstringstream ws;
 
 		ws << L"*** Server shutting down in "


### PR DESCRIPTION
This fixes issue #5617.
This fix is UNTESTED, please test.
EDIT: it works for BluebirdGreycoat.