### PR TITLE
fix set_detach visual slide issue

### DIFF
--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -730,7 +730,7 @@ int ObjectRef::l_set_detach(lua_State *L)
 		parent = env->getActiveObject(parent_id);
 
 	// Do it
-	co->setAttachment(0, "", v3f(0,0,0), v3f(0,0,0));
+	co->setAttachment(parent->getId(), bone, position, rotation);
 	if (parent != NULL)
 		parent->removeAttachmentChild(co->getId());
 	return 0;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -722,15 +722,17 @@ int ObjectRef::l_set_detach(lua_State *L)
 
 	int parent_id = 0;
 	std::string bone = "";
-	v3f position = v3f(0, 0, 0);
-	v3f rotation = v3f(0, 0, 0);
+	v3f position;
+	v3f rotation;
 	co->getAttachment(&parent_id, &bone, &position, &rotation);
 	ServerActiveObject *parent = NULL;
-	if (parent_id)
+	if (parent_id) {
 		parent = env->getActiveObject(parent_id);
-
+		co->setAttachment(0, "", position, rotation);
+	} else {
+		co->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
+	}
 	// Do it
-	co->setAttachment(0, "", position, rotation);
 	if (parent != NULL)
 		parent->removeAttachmentChild(co->getId());
 	return 0;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -728,10 +728,10 @@ int ObjectRef::l_set_detach(lua_State *L)
 	ServerActiveObject *parent = NULL;
 	if (parent_id)
 		parent = env->getActiveObject(parent_id);
-	
+
 	// Do it
 	co->setAttachment(0, "", position, rotation);
-	if (parent != NULL) 
+	if (parent != NULL)
 		parent->removeAttachmentChild(co->getId());
 	return 0;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -722,18 +722,17 @@ int ObjectRef::l_set_detach(lua_State *L)
 
 	int parent_id = 0;
 	std::string bone = "";
-	v3f position;
-	v3f rotation;
+	v3f position = v3f(0, 0, 0);
+	v3f rotation = v3f(0, 0, 0);
 	co->getAttachment(&parent_id, &bone, &position, &rotation);
 	ServerActiveObject *parent = NULL;
 	if (parent_id)
 		parent = env->getActiveObject(parent_id);
-
-	if (parent != NULL) {
-		// Do it
-		co->setAttachment(parent->getId(), bone, position, rotation);
+	
+	// Do it
+	co->setAttachment(0, "", position, rotation);
+	if (parent != NULL) 
 		parent->removeAttachmentChild(co->getId());
-	}
 	return 0;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -729,10 +729,11 @@ int ObjectRef::l_set_detach(lua_State *L)
 	if (parent_id)
 		parent = env->getActiveObject(parent_id);
 
-	// Do it
-	co->setAttachment(parent->getId(), bone, position, rotation);
-	if (parent != NULL)
+	if (parent != NULL) {
+		// Do it
+		co->setAttachment(parent->getId(), bone, position, rotation);
 		parent->removeAttachmentChild(co->getId());
+	}
 	return 0;
 }
 


### PR DESCRIPTION
pass correct parameters when detaching from an entity.
This fixes the visual aspect of a player detaching from an entity, as the move is currently interpolated from 0,0,0 when a player detaches they disappear and slide back to the correct vector 

issue: https://github.com/minetest/minetest/issues/5620