### PR TITLE
Sneak glitch: Set default to false

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3022,7 +3022,7 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `sneak`: whether player can sneak (default: `true`)
         * `sneak_glitch`: whether player can use the new move code replications
           of the old sneak side-effects: sneak ladders and 2 node sneak jump
-          when next to a ledge 2 nodes up (default: `true`)
+          (default: `false`)
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
 * `get_physics_override()`: returns the table given to set_physics_override

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -788,7 +788,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, u16 peer_id_, bool is_singleplayer
 	m_physics_override_jump(1),
 	m_physics_override_gravity(1),
 	m_physics_override_sneak(true),
-	m_physics_override_sneak_glitch(true),
+	m_physics_override_sneak_glitch(false),
 	m_physics_override_new_move(true),
 	m_physics_override_sent(false)
 {

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -48,7 +48,7 @@ LocalPlayer::LocalPlayer(Client *client, const char *name):
 	physics_override_jump(1.0f),
 	physics_override_gravity(1.0f),
 	physics_override_sneak(true),
-	physics_override_sneak_glitch(true),
+	physics_override_sneak_glitch(false),
 	physics_override_new_move(true),  // Temporary option for old move code
 	overridePosition(v3f(0,0,0)),
 	last_position(v3f(0,0,0)),


### PR DESCRIPTION
The 'sneak glitch' physics override now controls whether a player can
use the new move code replications of the old sneak side-effects:
sneak ladders and 2 node sneak jump. This completes our intention to
replicate the old sneak side-effects in new code and provide them as
an option that is disabled by default.
//////////////////////////////////////////////////////

Tested.