### PR TITLE
vector.direction fix and new methods

### DIFF
--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -4,13 +4,13 @@ vector = {}
 function vector.new(a, b, c)
 	if type(a) == "table" then
 		assert(a.x and a.y and a.z, "Invalid vector passed to vector.new()")
-		return {x=a.x, y=a.y, z=a.z}
+		return {x = a.x, y = a.y, z = a.z}
 	elseif a and b and c then
-		return {x=a, y=b, z=c}
+		return {x = a, y = b, z = c}
 	elseif a then
-		return {x=a, y=a, z=a}
+		return {x = a, y = a, z = a}
 	end
-	return {x=0, y=0, z=0}
+	return {x = 0, y = 0, z = 0}
 end
 
 function vector.equals(a, b)
@@ -31,11 +31,11 @@ end
 
 function vector.normalize(v)
 	if vector.is_nil(v) then return v end
-	local inv_len = 1/vector.length(v)
+	local inv_len = 1 / vector.length(v)
 	return {
-		x = v.x*inv_len,
-		y = v.y*inv_len,
-		z = v.z*inv_len,
+		x = v.x * inv_len,
+		y = v.y * inv_len,
+		z = v.z * inv_len,
 	}
 end
 
@@ -82,7 +82,7 @@ function vector.direction(pos1, pos2)
 	return vector.normalize({
 		x = pos2.x - pos1.x,
 		y = pos2.y - pos1.y,
-		z = pos2.z - pos1.z
+		z = pos2.z - pos1.z,
 	})
 end
 
@@ -152,7 +152,7 @@ function vector.divide(a, b)
 end
 
 function vector.sum(vs)
-	local V = {x=0, y=0, z=0}
+	local V = {x = 0, y = 0, z = 0}
 	for _, v in ipairs(vs) do
 		V.x = V.x + v.x
 		V.y = V.y + v.y

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -69,24 +69,10 @@ function vector.direction(pos1, pos2)
 	local x_abs = math.abs(x_raw)
 	local y_abs = math.abs(y_raw)
 	local z_abs = math.abs(z_raw)
-	if x_abs >= y_abs and
-	   x_abs >= z_abs then
-		y_raw = y_raw * (1 / x_abs)
-		z_raw = z_raw * (1 / x_abs)
-		x_raw = x_raw / x_abs
-	end
-	if y_abs >= x_abs and
-	   y_abs >= z_abs then
-		x_raw = x_raw * (1 / y_abs)
-		z_raw = z_raw * (1 / y_abs)
-		y_raw = y_raw / y_abs
-	end
-	if z_abs >= y_abs and
-	   z_abs >= x_abs then
-		x_raw = x_raw * (1 / z_abs)
-		y_raw = y_raw * (1 / z_abs)
-		z_raw = z_raw / z_abs
-	end
+	local inv_max_length = 1/math.max(x_abs, y_abs, z_abs)
+	y_raw = y_raw*inv_max_length
+	z_raw = z_raw*inv_max_length
+	x_raw = x_raw*inv_max_length
 	return {x=x_raw, y=y_raw, z=z_raw}
 end
 

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -5,9 +5,10 @@ function vector.new(a, b, c)
 	if type(a) == "table" then
 		assert(a.x and a.y and a.z, "Invalid vector passed to vector.new()")
 		return {x=a.x, y=a.y, z=a.z}
-	elseif a then
-		assert(b and c, "Invalid arguments for vector.new()")
+	elseif a and b and c then
 		return {x=a, y=b, z=c}
+	elseif a then
+		return {x=a, y=a, z=a}
 	end
 	return {x=0, y=0, z=0}
 end
@@ -18,24 +19,39 @@ function vector.equals(a, b)
 	       a.z == b.z
 end
 
+function vector.is_nil(a)
+	return a.x == 0 and
+	       a.y == 0 and
+	       a.z == 0
+end
+
 function vector.length(v)
 	return math.hypot(v.x, math.hypot(v.y, v.z))
 end
 
 function vector.normalize(v)
-	local len = vector.length(v)
-	if len == 0 then
-		return {x=0, y=0, z=0}
-	else
-		return vector.divide(v, len)
-	end
+	if vector.is_nil(v) then return v end
+	local inv_len = 1/vector.length(v)
+	return {
+		x = v.x*inv_len,
+		y = v.y*inv_len,
+		z = v.z*inv_len,
+	}
+end
+
+function vector.ceil(v)
+	return {
+		x = math.ceil(v.x),
+		y = math.ceil(v.y),
+		z = math.ceil(v.z),
+	}
 end
 
 function vector.floor(v)
 	return {
 		x = math.floor(v.x),
 		y = math.floor(v.y),
-		z = math.floor(v.z)
+		z = math.floor(v.z),
 	}
 end
 
@@ -43,7 +59,7 @@ function vector.round(v)
 	return {
 		x = math.floor(v.x + 0.5),
 		y = math.floor(v.y + 0.5),
-		z = math.floor(v.z + 0.5)
+		z = math.floor(v.z + 0.5),
 	}
 end
 
@@ -51,7 +67,7 @@ function vector.apply(v, func)
 	return {
 		x = func(v.x),
 		y = func(v.y),
-		z = func(v.z)
+		z = func(v.z),
 	}
 end
 
@@ -63,69 +79,96 @@ function vector.distance(a, b)
 end
 
 function vector.direction(pos1, pos2)
-	local x_raw = pos2.x - pos1.x
-	local y_raw = pos2.y - pos1.y
-	local z_raw = pos2.z - pos1.z
-	local x_abs = math.abs(x_raw)
-	local y_abs = math.abs(y_raw)
-	local z_abs = math.abs(z_raw)
-	local inv_max_length = 1/math.max(x_abs, y_abs, z_abs)
-	y_raw = y_raw*inv_max_length
-	z_raw = z_raw*inv_max_length
-	x_raw = x_raw*inv_max_length
-	return {x=x_raw, y=y_raw, z=z_raw}
+	return vector.normalize({
+		x = pos2.x - pos1.x,
+		y = pos2.y - pos1.y,
+		z = pos2.z - pos1.z
+	})
 end
 
 
 function vector.add(a, b)
 	if type(b) == "table" then
-		return {x = a.x + b.x,
+		return {
+			x = a.x + b.x,
 			y = a.y + b.y,
-			z = a.z + b.z}
+			z = a.z + b.z,
+		}
 	else
-		return {x = a.x + b,
+		return {
+			x = a.x + b,
 			y = a.y + b,
-			z = a.z + b}
+			z = a.z + b,
+		}
 	end
 end
 
 function vector.subtract(a, b)
 	if type(b) == "table" then
-		return {x = a.x - b.x,
+		return {
+			x = a.x - b.x,
 			y = a.y - b.y,
-			z = a.z - b.z}
+			z = a.z - b.z,
+		}
 	else
-		return {x = a.x - b,
+		return {
+			x = a.x - b,
 			y = a.y - b,
-			z = a.z - b}
+			z = a.z - b,
+		}
 	end
 end
 
 function vector.multiply(a, b)
 	if type(b) == "table" then
-		return {x = a.x * b.x,
+		return {
+			x = a.x * b.x,
 			y = a.y * b.y,
-			z = a.z * b.z}
+			z = a.z * b.z,
+		}
 	else
-		return {x = a.x * b,
+		return {
+			x = a.x * b,
 			y = a.y * b,
-			z = a.z * b}
+			z = a.z * b,
+		}
 	end
 end
 
 function vector.divide(a, b)
 	if type(b) == "table" then
-		return {x = a.x / b.x,
+		return {
+			x = a.x / b.x,
 			y = a.y / b.y,
-			z = a.z / b.z}
+			z = a.z / b.z,
+		}
 	else
-		return {x = a.x / b,
+		return {
+			x = a.x / b,
 			y = a.y / b,
-			z = a.z / b}
+			z = a.z / b,
+		}
 	end
 end
 
+function vector.sum(vs)
+	local V = {x=0, y=0, z=0}
+	for _, v in ipairs(vs) do
+		V.x = V.x + v.x
+		V.y = V.y + v.y
+		V.z = V.z + v.z
+	end
+	return V
+end
+
 function vector.sort(a, b)
-	return {x = math.min(a.x, b.x), y = math.min(a.y, b.y), z = math.min(a.z, b.z)},
-		{x = math.max(a.x, b.x), y = math.max(a.y, b.y), z = math.max(a.z, b.z)}
+	return {
+		x = math.min(a.x, b.x),
+		y = math.min(a.y, b.y),
+		z = math.min(a.z, b.z),
+	}, {
+		x = math.max(a.x, b.x),
+		y = math.max(a.y, b.y),
+		z = math.max(a.z, b.z),
+	}
 end

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -19,7 +19,7 @@ function vector.equals(a, b)
 	       a.z == b.z
 end
 
-function vector.is_nil(a)
+function vector.is_zero(a)
 	return a.x == 0 and
 	       a.y == 0 and
 	       a.z == 0

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1890,6 +1890,7 @@ Spatial Vectors
 * `vector.new(a[, b, c])`: returns a vector:
     * A copy of `a` if `a` is a vector.
     * `{x = a, y = b, z = c}`, if all `a, b, c` are defined
+    * `{x = a, y = a, z = a}`, if `a` is a number, `b, c` are not defined
 * `vector.direction(p1, p2)`: returns a vector
 * `vector.distance(p1, p2)`: returns a number
 * `vector.length(v)`: returns a number
@@ -1898,7 +1899,9 @@ Spatial Vectors
 * `vector.round(v)`: returns a vector, each dimension rounded to nearest int
 * `vector.apply(v, func)`: returns a vector
 * `vector.equals(v1, v2)`: returns a boolean
+* `vector.is_zero(v)`: equivalent to `vector.equals(v, {x = 0, y = 0, z = 0})`
 * `vector.sort(v1, v2)`: returns minp, maxp vectors of the cuboid defined by v1 and v2
+* `vector.sum({v1, v2, ...})`: returns a vector
 
 For the following functions `x` can be either a vector or a number:
 


### PR DESCRIPTION
```vector.direction({x=0, y=0, z=0}, {x=0.5, y=0.5, z=0.5})```
return {x=4, y=4, z=4};
```vector.direction({x=-1, y=-1, z=-1}, {x=1, y=1, z=1})```
return {x=0.25, y=0.25, z=0.25}...

So it should be?
If not, then maybe it's better like this: