### PR TITLE
Mgflat, Mgv7: Only create noise objects if needed

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -60,10 +60,12 @@ MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *em
 	this->hill_threshold   = params->hill_threshold;
 	this->hill_steepness   = params->hill_steepness;
 
-	//// 2D noise
-	noise_terrain      = new Noise(&params->np_terrain,      seed, csize.X, csize.Z);
+	// 2D noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
 
+	if ((spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS))
+		noise_terrain = new Noise(&params->np_terrain, seed, csize.X, csize.Z);
+	// 3D noise
 	MapgenBasic::np_cave1 = params->np_cave1;
 	MapgenBasic::np_cave2 = params->np_cave2;
 }
@@ -136,7 +138,9 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 int MapgenFlat::getSpawnLevelAtPoint(v2s16 p)
 {
 	s16 level_at_point = ground_level;
-	float n_terrain = NoisePerlin2D(&noise_terrain->np, p.X, p.Y, seed);
+	float n_terrain = 0.0f;
+	if ((spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS))
+		n_terrain = NoisePerlin2D(&noise_terrain->np, p.X, p.Y, seed);
 
 	if ((spflags & MGFLAT_LAKES) && n_terrain < lake_threshold) {
 		level_at_point = ground_level -

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -64,22 +64,30 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	this->cavern_taper        = params->cavern_taper;
 	this->cavern_threshold    = params->cavern_threshold;
 
-	//// Terrain noise
-	noise_terrain_base      = new Noise(&params->np_terrain_base,      seed, csize.X, csize.Z);
-	noise_terrain_alt       = new Noise(&params->np_terrain_alt,       seed, csize.X, csize.Z);
-	noise_terrain_persist   = new Noise(&params->np_terrain_persist,   seed, csize.X, csize.Z);
-	noise_height_select     = new Noise(&params->np_height_select,     seed, csize.X, csize.Z);
-	noise_filler_depth      = new Noise(&params->np_filler_depth,      seed, csize.X, csize.Z);
-	noise_mount_height      = new Noise(&params->np_mount_height,      seed, csize.X, csize.Z);
-	noise_ridge_uwater      = new Noise(&params->np_ridge_uwater,      seed, csize.X, csize.Z);
-	noise_floatland_base    = new Noise(&params->np_floatland_base,    seed, csize.X, csize.Z);
-	noise_float_base_height = new Noise(&params->np_float_base_height, seed, csize.X, csize.Z);
+	// 2D noise
+	noise_terrain_base    = new Noise(&params->np_terrain_base,    seed, csize.X, csize.Z);
+	noise_terrain_alt     = new Noise(&params->np_terrain_alt,     seed, csize.X, csize.Z);
+	noise_terrain_persist = new Noise(&params->np_terrain_persist, seed, csize.X, csize.Z);
+	noise_height_select   = new Noise(&params->np_height_select,   seed, csize.X, csize.Z);
+	noise_filler_depth    = new Noise(&params->np_filler_depth,    seed, csize.X, csize.Z);
 
-	//// 3d terrain noise
-	// 1-up 1-down overgeneration
-	noise_mountain = new Noise(&params->np_mountain, seed, csize.X, csize.Y + 2, csize.Z);
-	noise_ridge    = new Noise(&params->np_ridge,    seed, csize.X, csize.Y + 2, csize.Z);
-	// 1 down overgeneration
+	if (spflags & MGV7_MOUNTAINS)
+		noise_mount_height = new Noise(&params->np_mount_height, seed, csize.X, csize.Z);
+
+	if (spflags & MGV7_FLOATLANDS) {
+		noise_floatland_base    = new Noise(&params->np_floatland_base,    seed, csize.X, csize.Z);
+		noise_float_base_height = new Noise(&params->np_float_base_height, seed, csize.X, csize.Z);
+	}
+
+	if (spflags & MGV7_RIDGES) {
+		noise_ridge_uwater = new Noise(&params->np_ridge_uwater, seed, csize.X, csize.Z);
+	// 3D noise, 1-up 1-down overgeneration
+		noise_ridge = new Noise(&params->np_ridge, seed, csize.X, csize.Y + 2, csize.Z);
+	}
+	// 3D noise, 1 up, 1 down overgeneration
+	if ((spflags & MGV7_MOUNTAINS) || (spflags & MGV7_FLOATLANDS))
+		noise_mountain = new Noise(&params->np_mountain, seed, csize.X, csize.Y + 2, csize.Z);
+	// 3D noise, 1 down overgeneration
 	MapgenBasic::np_cave1  = params->np_cave1;
 	MapgenBasic::np_cave2  = params->np_cave2;
 	MapgenBasic::np_cavern = params->np_cavern;


### PR DESCRIPTION
As requested by @Zeno- 
Creates noise objects only if mapgen options require them.