### PR TITLE
Menu: Add install mod button

### DIFF
--- a/builtin/mainmenu/dlg_install_mod.lua
+++ b/builtin/mainmenu/dlg_install_mod.lua
@@ -1,0 +1,49 @@
+--Minetest
+--Copyright (C) 2017 octacian
+--
+--This program is free software; you can redistribute it and/or modify
+--it under the terms of the GNU Lesser General Public License as published by
+--the Free Software Foundation; either version 2.1 of the License, or
+--(at your option) any later version.
+--
+--This program is distributed in the hope that it will be useful,
+--but WITHOUT ANY WARRANTY; without even the implied warranty of
+--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--GNU Lesser General Public License for more details.
+--
+--You should have received a copy of the GNU Lesser General Public License along
+--with this program; if not, write to the Free Software Foundation, Inc.,
+--51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+--------------------------------------------------------------------------------
+
+local function install_mod_formspec(dialogdata)
+	local retval =
+		"size[11.5,4.5,true]" ..
+		"label[2,2;" ..
+		fgettext(dialogdata.text) .. "]"..
+		"button[4.5,3.5;2.5,0.5;dlg_install_mod_close;" .. fgettext("OK") .. "]"
+
+	return retval
+end
+
+--------------------------------------------------------------------------------
+local function install_mod_buttonhandler(this, fields)
+	if fields["dlg_install_mod_close"] then
+		this:delete()
+		return true
+	end
+
+	return false
+end
+
+--------------------------------------------------------------------------------
+function create_install_mod_dlg(text)
+
+	local retval = dialog_create("dlg_install_mod",
+					install_mod_formspec,
+					install_mod_buttonhandler,
+					nil)
+	retval.data.text = text
+	return retval
+end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -46,6 +46,7 @@ if PLATFORM ~= "Android" then
 	dofile(menupath .. DIR_DELIM .. "dlg_delete_mod.lua")
 	dofile(menupath .. DIR_DELIM .. "dlg_delete_world.lua")
 	dofile(menupath .. DIR_DELIM .. "dlg_rename_modpack.lua")
+	dofile(menupath .. DIR_DELIM .. "dlg_install_mod.lua")
 end
 
 local tabs = {}

--- a/builtin/mainmenu/modmgr.lua
+++ b/builtin/mainmenu/modmgr.lua
@@ -395,6 +395,7 @@ function modmgr.installmod(modfilename,basename)
 
 	modmgr.refresh_globals()
 
+	return basefolder.type ~= "invalid"
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Add install mod button in mods tab on the main menu. Allows installing a mod from ZIP on the local filesystem. Uses built-in file picker and adds a dialog to display whether the installation was successful (will be unsuccessful if the selected file is either not a ZIP file or not a mod).

As you can see from the first screenshot, the Install Mod button is placed beneath the Installed Mods list and the Uninstall selected mod button is moved so as to be placed beside the new button. Due to the size of the resulting buttons, tooltips are used to display more in-depth information. However, if no mod is selected (and therefore the uninstall button is not shown), the install mod button takes full width (seen at bottom of first screenshot).

__Todo:__
- [ ] Support modpacks
- [ ] Improve formspecs
  - [x] Mods tab formspec
  - [ ] Result formspec
- [ ] Support installing from folders

__Screenshots:__ (cropped)
![mt_install_both](https://cloud.githubusercontent.com/assets/15371866/25298015/716d39dc-26a6-11e7-9a5f-05ac848d1e39.png)
![mt_install_filepicker](https://cloud.githubusercontent.com/assets/15371866/25260411/d49522f0-2600-11e7-990d-b137d1fdbde1.png)
![mt_install_success](https://cloud.githubusercontent.com/assets/15371866/25260412/d6229a12-2600-11e7-9a2c-c8e93f3d75b4.png)


