### PR TITLE
Mgflat, Mgv7: Fix noise crash on world exit.

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -73,8 +73,10 @@ MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *em
 
 MapgenFlat::~MapgenFlat()
 {
-	delete noise_terrain;
 	delete noise_filler_depth;
+
+	if ((spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS))
+		delete noise_terrain;
 }
 
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -97,16 +97,26 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 MapgenV7::~MapgenV7()
 {
 	delete noise_terrain_base;
+	delete noise_terrain_alt;
 	delete noise_terrain_persist;
 	delete noise_height_select;
-	delete noise_terrain_alt;
 	delete noise_filler_depth;
-	delete noise_mount_height;
-	delete noise_ridge_uwater;
-	delete noise_floatland_base;
-	delete noise_float_base_height;
-	delete noise_mountain;
-	delete noise_ridge;
+
+	if (spflags & MGV7_MOUNTAINS)
+		delete noise_mount_height;
+
+	if (spflags & MGV7_FLOATLANDS) {
+		delete noise_floatland_base;
+		delete noise_float_base_height;
+	}
+
+	if (spflags & MGV7_RIDGES) {
+		delete noise_ridge_uwater;
+		delete noise_ridge;
+	}
+
+	if ((spflags & MGV7_MOUNTAINS) || (spflags & MGV7_FLOATLANDS))
+		delete noise_mountain;
 }
 
 


### PR DESCRIPTION
Fix crash caused by destructor 'delete' on noise objects that are not
created due to mapgen options.
Crash was caused by commit 57eaf62c697cec91890d9cb28d10385d293d2d3f
////////////////////////////////////////////////////////

Tested.