### PR TITLE
Automatic item and node colorization

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -93,7 +93,7 @@ core.register_entity(":__builtin:falling_node", {
 				core.remove_node(np)
 				if nd and nd.buildable_to == false then
 					-- Add dropped items
-					local drops = core.get_node_drops(n2.name, "")
+					local drops = core.get_node_drops(n2, "")
 					for _, dropped_item in pairs(drops) do
 						core.add_item(np, dropped_item)
 					end
@@ -145,9 +145,9 @@ function core.spawn_falling_node(pos)
 end
 
 local function drop_attached_node(p)
-	local nn = core.get_node(p).name
+	local n = core.get_node(p)
 	core.remove_node(p)
-	for _, item in pairs(core.get_node_drops(nn, "")) do
+	for _, item in pairs(core.get_node_drops(n, "")) do
 		local pos = {
 			x = p.x + math.random()/2 - 0.25,
 			y = p.y + math.random()/2 - 0.25,

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -155,12 +155,27 @@ function core.yaw_to_dir(yaw)
 	return {x = -math.sin(yaw), y = 0, z = math.cos(yaw)}
 end
 
-function core.get_node_drops(nodename, toolname)
-	local def = core.registered_nodes[nodename]
+function core.get_node_drops(node, toolname)
+	local def = core.registered_nodes[node.name]
 	local drop = def and def.drop
 	if drop == nil then
 		-- default drop
-		return {nodename}
+		local stack = ItemStack(node.name)
+		if def then
+			local type = def.paramtype2
+			if (type == "color") or (type == "colorfacedir") or
+					(type == "colorwallmounted") then
+				local meta = stack:get_meta()
+				local color_part = node.param2
+				if (type == "colorfacedir") then
+					color_part = math.floor(color_part / 32) * 32;
+				elseif (type == "colorwallmounted") then
+					color_part = math.floor(color_part / 8) * 8;
+				end
+				meta:set_int("palette_index", color_part)
+			end
+		end
+		return {stack:to_string()}
 	elseif type(drop) == "string" then
 		-- itemstring drop
 		return {drop}
@@ -258,7 +273,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		.. def.name .. " at " .. core.pos_to_string(place_to))
 
 	local oldnode = core.get_node(place_to)
-	local newnode = {name = def.name, param1 = 0, param2 = param2}
+	local newnode = {name = def.name, param1 = 0, param2 = param2 or 0}
 
 	-- Calculate direction for wall mounted stuff like torches and signs
 	if def.place_param2 ~= nil then
@@ -283,6 +298,25 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 			}
 			newnode.param2 = core.dir_to_facedir(dir)
 			core.log("action", "facedir: " .. newnode.param2)
+		end
+	end
+
+	local metatable = itemstack:get_meta():to_table().fields
+
+	-- Transfer color information
+	if metatable.palette_index and not def.place_param2 then
+		local color_divisor = 0
+		if def.paramtype2 == "color" then
+			color_divisor = 1
+		elseif def.paramtype2 == "colorwallmounted" then
+			color_divisor = 8
+		elseif def.paramtype2 == "colorfacedir" then
+			color_divisor = 32
+		end
+		if color_divisor > 0 then
+			local color = math.floor(metatable.palette_index / color_divisor)
+			local other = newnode.param2 % color_divisor
+			newnode.param2 = color * color_divisor + other
 		end
 	end
 
@@ -474,7 +508,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger:get_wielded_item()
-	local drops = core.get_node_drops(node.name, wielded:get_name())
+	local drops = core.get_node_drops(node, wielded:get_name())
 
 	local wdef = wielded:get_definition()
 	local tp = wielded:get_tool_capabilities()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -156,17 +156,25 @@ function core.yaw_to_dir(yaw)
 end
 
 function core.get_node_drops(node, toolname)
-	local def = core.registered_nodes[node.name]
+	-- Compatibility, if node is string
+	local nodename = node
+	local param2 = 0
+	-- New format, if node is table
+	if(type(node) == "table") then
+		nodename = node.name
+		param2 = node.param2
+	end
+	local def = core.registered_nodes[nodename]
 	local drop = def and def.drop
 	if drop == nil then
 		-- default drop
-		local stack = ItemStack(node.name)
+		local stack = ItemStack(nodename)
 		if def then
 			local type = def.paramtype2
 			if (type == "color") or (type == "colorfacedir") or
 					(type == "colorwallmounted") then
 				local meta = stack:get_meta()
-				local color_part = node.param2
+				local color_part = param2
 				if (type == "colorfacedir") then
 					color_part = math.floor(color_part / 32) * 32;
 				elseif (type == "colorwallmounted") then

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -160,7 +160,7 @@ function core.get_node_drops(node, toolname)
 	local nodename = node
 	local param2 = 0
 	-- New format, if node is table
-	if(type(node) == "table") then
+	if (type(node) == "table") then
 		nodename = node.name
 		param2 = node.param2
 	end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -313,7 +313,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 
 	-- Transfer color information
 	if metatable.palette_index and not def.place_param2 then
-		local color_divisor = 0
+		local color_divisor = nil
 		if def.paramtype2 == "color" then
 			color_divisor = 1
 		elseif def.paramtype2 == "colorwallmounted" then
@@ -321,7 +321,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		elseif def.paramtype2 == "colorfacedir" then
 			color_divisor = 32
 		end
-		if color_divisor > 0 then
+		if color_divisor then
 			local color = math.floor(metatable.palette_index / color_divisor)
 			local other = newnode.param2 % color_divisor
 			newnode.param2 = color * color_divisor + other

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3327,8 +3327,7 @@ An `InvRef` is a reference to an inventory.
   can be fully added to the list
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
-  If `match_meta` is false, only the items' names are compared.
-  The default is false.
+  If `match_meta` is false, only the items' names are compared (default: `false`).
 * `remove_item(listname, stack)`: take as many items as specified from the list,
   returns the items that were actually removed (as an `ItemStack`) -- note that
   any item metadata is ignored, so attempting to remove a specific unique

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -531,9 +531,11 @@ for conversion.
 If the `ItemStack`'s metadata contains the `color` field, it will be
 lost on placement, because nodes on the map can only use palettes.
 
-If the `ItemStack`'s metadata contains the `palette_index` field, you
-currently must manually convert between it and the node's `param2` with
-custom `on_place` and `on_dig` callbacks.
+If the `ItemStack`'s metadata contains the `palette_index` field, it is
+automatically transferred between node and item forms by the engine,
+when a player digs or places a colored node.
+You can disable this feature by setting the `drop` field of the node
+to itself (without metadata).
 
 ### Colored items in craft recipes
 Craft recipes only support item strings, but fortunately item strings

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3325,8 +3325,10 @@ An `InvRef` is a reference to an inventory.
 * `add_item(listname, stack)`: add item somewhere in list, returns leftover `ItemStack`
 * `room_for_item(listname, stack):` returns `true` if the stack of items
   can be fully added to the list
-* `contains_item(listname, stack)`: returns `true` if the stack of items
-  can be fully taken from the list
+* `contains_item(listname, stack, [match_meta])`: returns `true` if
+  the stack of items can be fully taken from the list.
+  If `match_meta` is false, only the items' names are compared.
+  The default is false.
 * `remove_item(listname, stack)`: take as many items as specified from the list,
   returns the items that were actually removed (as an `ItemStack`) -- note that
   any item metadata is ignored, so attempting to remove a specific unique

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -658,7 +658,7 @@ bool InventoryList::roomForItem(const ItemStack &item_) const
 	return false;
 }
 
-bool InventoryList::containsItem(const ItemStack &item) const
+bool InventoryList::containsItem(const ItemStack &item, bool match_meta) const
 {
 	u32 count = item.count;
 	if(count == 0)
@@ -669,9 +669,9 @@ bool InventoryList::containsItem(const ItemStack &item) const
 	{
 		if(count == 0)
 			break;
-		if(i->name == item.name)
-		{
-			if(i->count >= count)
+		if (i->name == item.name
+				&& (!match_meta || (i->metadata == item.metadata))) {
+			if (i->count >= count)
 				return true;
 			else
 				count -= i->count;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -223,9 +223,10 @@ public:
 	// Checks whether there is room for a given item
 	bool roomForItem(const ItemStack &item) const;
 
-	// Checks whether the given count of the given item name
+	// Checks whether the given count of the given item
 	// exists in this inventory list.
-	bool containsItem(const ItemStack &item) const;
+	// If match_meta is false, only the items' names are compared.
+	bool containsItem(const ItemStack &item, bool match_meta) const;
 
 	// Removes the given count of the given item name from
 	// this inventory list. Walks the list in reverse order.

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -325,8 +325,8 @@ int InvRef::l_room_for_item(lua_State *L)
 	return 1;
 }
 
-// contains_item(self, listname, itemstack or itemstring or table or nil) -> true/false
-// Returns true if the list contains the given count of the given item name
+// contains_item(self, listname, itemstack or itemstring or table or nil, [match_meta]) -> true/false
+// Returns true if the list contains the given count of the given item
 int InvRef::l_contains_item(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -334,8 +334,11 @@ int InvRef::l_contains_item(lua_State *L)
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
+	bool match_meta = false;
+	if (lua_isboolean(L, 4))
+		match_meta = lua_toboolean(L, 4);
 	if(list){
-		lua_pushboolean(L, list->containsItem(item));
+		lua_pushboolean(L, list->containsItem(item, match_meta));
 	} else {
 		lua_pushboolean(L, false);
 	}

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -337,7 +337,7 @@ int InvRef::l_contains_item(lua_State *L)
 	bool match_meta = false;
 	if (lua_isboolean(L, 4))
 		match_meta = lua_toboolean(L, 4);
-	if(list){
+	if (list) {
 		lua_pushboolean(L, list->containsItem(item, match_meta));
 	} else {
 		lua_pushboolean(L, false);

--- a/src/script/lua_api/l_inventory.h
+++ b/src/script/lua_api/l_inventory.h
@@ -93,7 +93,7 @@ private:
 	// Returns true if the item completely fits into the list
 	static int l_room_for_item(lua_State *L);
 
-	// contains_item(self, listname, itemstack or itemstring or table or nil) -> true/false
+	// contains_item(self, listname, itemstack or itemstring or table or nil, [match_meta]) -> true/false
 	// Returns true if the list contains the given count of the given item name
 	static int l_contains_item(lua_State *L);
 


### PR DESCRIPTION
Now nodes with a palette yield colored item stacks, and colored items place colored nodes by default.

The client also predicts the colorization, so players will immediately see the placed node in the correct color.