### PR TITLE
Connected Nodeboxes: Add `disconnected` boxes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1022,6 +1022,17 @@ A nodebox is defined as any of:
         connect_left = box OR {box1, box2, ...}
         connect_back = box OR {box1, box2, ...}
         connect_right = box OR {box1, box2, ...}
+        -- The following `disconnected_*` boxes are the opposites of the
+        -- `connect_*` ones above, i.e. when a node has no suitable neighbour
+        -- on the respective side, the corresponding disconnected box is drawn.
+        disconnected_top = box OR {box1, box2, ...}
+        disconnected_bottom = box OR {box1, box2, ...}
+        disconnected_front = box OR {box1, box2, ...}
+        disconnected_left = box OR {box1, box2, ...}
+        disconnected_back = box OR {box1, box2, ...}
+        disconnected_right = box OR {box1, box2, ...}
+        disconnected = box OR {box1, box2, ...} -- when there is *no* neighbour
+        disconnected_sides = box OR {box1, box2, ...} -- when there are *no* neighbours to the sides
     }
 
 A `box` is defined as:

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -422,16 +422,40 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 		boxes_size += nodebox.fixed.size();
 		if (neighbors & 1)
 			boxes_size += nodebox.connect_top.size();
+		else
+			boxes_size += nodebox.disconnected_top.size();
+
 		if (neighbors & 2)
 			boxes_size += nodebox.connect_bottom.size();
+		else
+			boxes_size += nodebox.disconnected_bottom.size();
+
 		if (neighbors & 4)
 			boxes_size += nodebox.connect_front.size();
+		else
+			boxes_size += nodebox.disconnected_front.size();
+
 		if (neighbors & 8)
 			boxes_size += nodebox.connect_left.size();
+		else
+			boxes_size += nodebox.disconnected_left.size();
+
 		if (neighbors & 16)
 			boxes_size += nodebox.connect_back.size();
+		else
+			boxes_size += nodebox.disconnected_back.size();
+
 		if (neighbors & 32)
 			boxes_size += nodebox.connect_right.size();
+		else
+			boxes_size += nodebox.disconnected_right.size();
+
+		if (neighbors == 0)
+			boxes_size += nodebox.disconnected.size();
+
+		if (neighbors < 4)
+			boxes_size += nodebox.disconnected_sides.size();
+
 		boxes.reserve(boxes_size);
 
 #define BOXESPUSHBACK(c) \
@@ -442,18 +466,50 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 
 		BOXESPUSHBACK(nodebox.fixed);
 
-		if (neighbors & 1)
+		if (neighbors & 1) {
 			BOXESPUSHBACK(nodebox.connect_top);
-		if (neighbors & 2)
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_top);
+		}
+
+		if (neighbors & 2) {
 			BOXESPUSHBACK(nodebox.connect_bottom);
-		if (neighbors & 4)
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_bottom);
+		}
+
+		if (neighbors & 4) {
 			BOXESPUSHBACK(nodebox.connect_front);
-		if (neighbors & 8)
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_front);
+		}
+
+		if (neighbors & 8) {
 			BOXESPUSHBACK(nodebox.connect_left);
-		if (neighbors & 16)
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_left);
+		}
+
+		if (neighbors & 16) {
 			BOXESPUSHBACK(nodebox.connect_back);
-		if (neighbors & 32)
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_back);
+		}
+
+		if (neighbors & 32) {
 			BOXESPUSHBACK(nodebox.connect_right);
+		} else {
+			BOXESPUSHBACK(nodebox.disconnected_right);
+		}
+
+		if (neighbors == 0) {
+			BOXESPUSHBACK(nodebox.disconnected);
+		}
+
+		if (neighbors < 4) {
+			BOXESPUSHBACK(nodebox.disconnected_sides);
+		}
+
 	}
 	else // NODEBOX_REGULAR
 	{

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -185,6 +185,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Mod channels
 		Raise ObjectProperties version to 3 for removing 'can_zoom' and adding
 			'zoom_fov'.
+		Nodebox version 5
+		Add disconnected nodeboxes
 */
 
 #define LATEST_PROTOCOL_VERSION 36

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -61,12 +61,20 @@ void NodeBox::reset()
 	connect_left.clear();
 	connect_back.clear();
 	connect_right.clear();
+	disconnected_top.clear();
+	disconnected_bottom.clear();
+	disconnected_front.clear();
+	disconnected_left.clear();
+	disconnected_back.clear();
+	disconnected_right.clear();
+	disconnected.clear();
+	disconnected_sides.clear();
 }
 
 void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 {
 	// Protocol >= 36
-	int version = 4;
+	int version = 5;
 	writeU8(os, version);
 
 	switch (type) {
@@ -107,6 +115,14 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 		WRITEBOX(connect_left);
 		WRITEBOX(connect_back);
 		WRITEBOX(connect_right);
+		WRITEBOX(disconnected_top);
+		WRITEBOX(disconnected_bottom);
+		WRITEBOX(disconnected_front);
+		WRITEBOX(disconnected_left);
+		WRITEBOX(disconnected_back);
+		WRITEBOX(disconnected_right);
+		WRITEBOX(disconnected);
+		WRITEBOX(disconnected_sides);
 		break;
 	default:
 		writeU8(os, type);
@@ -163,6 +179,16 @@ void NodeBox::deSerialize(std::istream &is)
 		READBOXES(connect_left);
 		READBOXES(connect_back);
 		READBOXES(connect_right);
+		if (version >= 5) {
+			READBOXES(disconnected_top);
+			READBOXES(disconnected_bottom);
+			READBOXES(disconnected_front);
+			READBOXES(disconnected_left);
+			READBOXES(disconnected_back);
+			READBOXES(disconnected_right);
+			READBOXES(disconnected);
+			READBOXES(disconnected_sides);
+		}
 	}
 }
 
@@ -1245,13 +1271,21 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 		}
 		case NODEBOX_CONNECTED: {
 			// Add all possible connected boxes
-			boxVectorUnion(nodebox.fixed,          box_union);
-			boxVectorUnion(nodebox.connect_top,    box_union);
-			boxVectorUnion(nodebox.connect_bottom, box_union);
-			boxVectorUnion(nodebox.connect_front,  box_union);
-			boxVectorUnion(nodebox.connect_left,   box_union);
-			boxVectorUnion(nodebox.connect_back,   box_union);
-			boxVectorUnion(nodebox.connect_right,  box_union);
+			boxVectorUnion(nodebox.fixed,               box_union);
+			boxVectorUnion(nodebox.connect_top,         box_union);
+			boxVectorUnion(nodebox.connect_bottom,      box_union);
+			boxVectorUnion(nodebox.connect_front,       box_union);
+			boxVectorUnion(nodebox.connect_left,        box_union);
+			boxVectorUnion(nodebox.connect_back,        box_union);
+			boxVectorUnion(nodebox.connect_right,       box_union);
+			boxVectorUnion(nodebox.disconnected_top,    box_union);
+			boxVectorUnion(nodebox.disconnected_bottom, box_union);
+			boxVectorUnion(nodebox.disconnected_front,  box_union);
+			boxVectorUnion(nodebox.disconnected_left,   box_union);
+			boxVectorUnion(nodebox.disconnected_back,   box_union);
+			boxVectorUnion(nodebox.disconnected_right,  box_union);
+			boxVectorUnion(nodebox.disconnected,        box_union);
+			boxVectorUnion(nodebox.disconnected_sides,  box_union);
 			break;
 		}
 		default: {

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -107,6 +107,14 @@ struct NodeBox
 	std::vector<aabb3f> connect_left;
 	std::vector<aabb3f> connect_back;
 	std::vector<aabb3f> connect_right;
+	std::vector<aabb3f> disconnected_top;
+	std::vector<aabb3f> disconnected_bottom;
+	std::vector<aabb3f> disconnected_front;
+	std::vector<aabb3f> disconnected_left;
+	std::vector<aabb3f> disconnected_back;
+	std::vector<aabb3f> disconnected_right;
+	std::vector<aabb3f> disconnected;
+	std::vector<aabb3f> disconnected_sides;
 
 	NodeBox()
 	{ reset(); }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1062,6 +1062,14 @@ NodeBox read_nodebox(lua_State *L, int index)
 		NODEBOXREADVEC(nodebox.connect_left, "connect_left");
 		NODEBOXREADVEC(nodebox.connect_back, "connect_back");
 		NODEBOXREADVEC(nodebox.connect_right, "connect_right");
+		NODEBOXREADVEC(nodebox.disconnected_top, "disconnected_top");
+		NODEBOXREADVEC(nodebox.disconnected_bottom, "disconnected_bottom");
+		NODEBOXREADVEC(nodebox.disconnected_front, "disconnected_front");
+		NODEBOXREADVEC(nodebox.disconnected_left, "disconnected_left");
+		NODEBOXREADVEC(nodebox.disconnected_back, "disconnected_back");
+		NODEBOXREADVEC(nodebox.disconnected_right, "disconnected_right");
+		NODEBOXREADVEC(nodebox.disconnected, "disconnected");
+		NODEBOXREADVEC(nodebox.disconnected_sides, "disconnected_sides");
 	}
 	return nodebox;
 }


### PR DESCRIPTION
* disconnected_top
* disconnected_bottom
* disconnected_front
* disconnected_left
* disconnected_back
* disconnected_right
* disconnected (when there is *no* neighbor)
* disconnected_sides (when there are *no* neighbors to the sides)

Useful e.g. when you want a bridge node to show a handrail when there is no bridge node next to it.

~~The `disconnected` field _could_ be used to restore the old behavior of disconnected xpanes.~~ You ~would~ need `disconnected_sides` for this. ~Working at this atm.~ _Done._