### PR TITLE
Remove view_bobbing bool in settings

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -492,9 +492,6 @@ cloud_height (Cloud height) int 120
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
 cloud_radius (Cloud radius) int 12
 
-#    Enables view bobbing when walking.
-view_bobbing (Enable view bobbing) bool true
-
 #    Multiplier for view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 view_bobbing_amount (View bobbing factor) float 1.0

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -569,10 +569,6 @@
 #    type: int
 # cloud_radius = 12
 
-#    Enables view bobbing when walking.
-#    type: bool
-# view_bobbing = true
-
 #    Multiplier for view bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 #    type: float
@@ -1815,4 +1811,3 @@
 #    Print the engine's profiling data in regular intervals (in seconds). 0 = disable. Useful for developers.
 #    type: int
 # profiler_print_interval = 0
-

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -102,7 +102,6 @@ Camera::Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
 	m_cache_view_bobbing_amount = g_settings->getFloat("view_bobbing_amount");
 	m_cache_fov                 = g_settings->getFloat("fov");
 	m_cache_zoom_fov            = g_settings->getFloat("zoom_fov");
-	m_cache_view_bobbing        = g_settings->getBool("view_bobbing");
 	m_nametags.clear();
 }
 
@@ -467,7 +466,6 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime,
 	const bool swimming = (movement_XZ || player->swimming_vertical) && player->in_liquid;
 	const bool climbing = movement_Y && player->is_climbing;
 	if ((walking || swimming || climbing) &&
-			m_cache_view_bobbing &&
 			(!g_settings->getBool("free_move") || !m_client->checkLocalPrivilege("fly")))
 	{
 		// Start animation

--- a/src/camera.h
+++ b/src/camera.h
@@ -231,7 +231,6 @@ private:
 	f32 m_cache_view_bobbing_amount;
 	f32 m_cache_fov;
 	f32 m_cache_zoom_fov;
-	bool m_cache_view_bobbing;
 
 	std::list<Nametag *> m_nametags;
 };

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -171,7 +171,6 @@ void set_default_settings(Settings *settings)
 
 	// Effects
 	settings->setDefault("directional_colored_fog", "true");
-	settings->setDefault("view_bobbing", "true");
 	settings->setDefault("inventory_items_animations", "false");
 	settings->setDefault("mip_map", "false");
 	settings->setDefault("anisotropic_filter", "false");


### PR DESCRIPTION
This PR fixes bug #5602 by removing the view_bobbing bool in settings. This is a very simple PR and it only removes a few lines of code. Everything compiles and runs, but it is very possible I have screwed something up as this is my first time doing a pull request! Any and all feedback is welcome, and I am definitely willing to put a little more work in to get this in a decent state :)