### PR TITLE
Allow scripts to get the client protocol version in non-debug builds.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1992,11 +1992,11 @@ Helper functions
             max_jitter = 0.5,          -- maximum packet time jitter
             avg_jitter = 0.03,         -- average packet time jitter
             connection_uptime = 200,   -- seconds since client connected
+            prot_vers = 31,            -- protocol version used by client
 
             -- following information is available on debug build only!!!
             -- DO NOT USE IN MODS
             --ser_vers = 26,             -- serialization version used by client
-            --prot_vers = 23,            -- protocol version used by client
             --major = 0,                 -- major version number
             --minor = 4,                 -- minor version number
             --patch = 10,                -- patch version number

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -137,7 +137,7 @@ int ModApiServer::l_get_player_ip(lua_State *L)
 	}
 }
 
-// get_player_information()
+// get_player_information(name)
 int ModApiServer::l_get_player_information(lua_State *L)
 {
 
@@ -231,13 +231,13 @@ int ModApiServer::l_get_player_information(lua_State *L)
 	lua_pushnumber(L, uptime);
 	lua_settable(L, table);
 
+	lua_pushstring(L,"protocol_version");
+	lua_pushnumber(L, prot_vers);
+	lua_settable(L, table);
+	
 #ifndef NDEBUG
 	lua_pushstring(L,"serialization_version");
 	lua_pushnumber(L, ser_vers);
-	lua_settable(L, table);
-
-	lua_pushstring(L,"protocol_version");
-	lua_pushnumber(L, prot_vers);
 	lua_settable(L, table);
 
 	lua_pushstring(L,"major");

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -74,7 +74,7 @@ private:
 	// get_player_ip()
 	static int l_get_player_ip(lua_State *L);
 
-	// get_player_information()
+	// get_player_information(name)
 	static int l_get_player_information(lua_State *L);
 
 	// get_ban_list()


### PR DESCRIPTION
example usecase: it could be used by a mod that manipulates the chat to check if the client will display the chat message to the client before sending it to the server.