### PR TITLE
Make torch digging instant again

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1230,9 +1230,9 @@ Another example: Make red wool from white wool and red dye:
        from destroyed nodes.
      * `0` is something that is directly accessible at the start of gameplay
      * There is no upper limit
-* `dig_immediate`: (player can always pick up node without tool wear)
-    * `2`: node is removed without tool wear after 0.5 seconds (rail, sign)
-    * `3`: node is removed without tool wear after 0.15 seconds (torch)
+* `dig_immediate`: (player can always pick up node without reducing tool wear)
+    * `2`: the node always gets the digging time 0.5 seconds (rail, sign)
+    * `3`: the node always gets the digging time 0 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `bouncy`: value is bounce speed in percent
@@ -1332,6 +1332,10 @@ For example, as a Lua table, `times={2=2.00, 3=0.70}`. This would
 result in the tool to be able to dig nodes that have a rating of `2` or `3`
 for this group, and unable to dig the rating `1`, which is the toughest.
 Unless there is a matching group that enables digging otherwise.
+
+If the result digging time is 0, a delay of 0.15 seconds is added between
+digging nodes; If the player releases LMB after digging, this delay is set to 0,
+i.e. players can more quickly click the nodes away instead of holding LMB.
 
 #### Damage groups
 List of damage for groups of entities. See "Entity damage mechanism".
@@ -3446,7 +3450,7 @@ will place the schematic inside of the VoxelManip.
       If `light` is false, no light calculations happen, and you should correct
       all modified blocks with `minetest.fix_light()` as soon as possible.
       Keep in mind that modifying the map where light is incorrect can cause
-      more lighting bugs. 
+      more lighting bugs.
 * `get_node_at(pos)`: Returns a `MapNode` table of the node currently loaded in
   the `VoxelManip` at that position
 * `set_node_at(pos, node)`: Sets a specific `MapNode` in the `VoxelManip` at that position

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1108,6 +1108,7 @@ struct GameRunData {
 	PointedThing pointed_old;
 	bool digging;
 	bool ldown_for_dig;
+	bool dig_instantly;
 	bool left_punch;
 	bool update_wielded_item_trigger;
 	bool reset_jump_timer;
@@ -3486,6 +3487,10 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 			client->setCrack(-1, v3s16(0, 0, 0));
 			runData.dig_time = 0.0;
 		}
+	} else if (runData.dig_instantly && getLeftReleased()) {
+		// Remove e.g. torches faster when clicking instead of holding LMB
+		runData.nodig_delay_timer = 0;
+		runData.dig_instantly = false;
 	}
 
 	if (!runData.digging && runData.ldown_for_dig && !isLeftPressed()) {
@@ -3798,15 +3803,6 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	ClientMap &map = client->getEnv().getClientMap();
 	MapNode n = client->getEnv().getClientMap().getNodeNoEx(nodepos);
 
-	if (!runData.digging) {
-		infostream << "Started digging" << std::endl;
-		if (client->moddingEnabled() && client->getScript()->on_punchnode(nodepos, n))
-			return;
-		client->interact(0, pointed);
-		runData.digging = true;
-		runData.ldown_for_dig = true;
-	}
-
 	// NOTE: Similar piece of code exists on the server side for
 	// cheat detection.
 	// Get digging parameters
@@ -3824,6 +3820,16 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 			params = getDigParams(nodedef_manager->get(n).groups, tp);
 	}
 
+	if (!runData.digging) {
+		infostream << "Started digging" << std::endl;
+		runData.dig_instantly = params.time == 0;
+		if (client->moddingEnabled() && client->getScript()->on_punchnode(nodepos, n))
+			return;
+		client->interact(0, pointed);
+		runData.digging = true;
+		runData.ldown_for_dig = true;
+	}
+
 	if (!params.diggable) {
 		// I guess nobody will wait for this long
 		runData.dig_time_complete = 10000000.0;
@@ -3838,12 +3844,12 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		}
 	}
 
-	if (runData.dig_time_complete >= 0.001) {
+	if (!runData.dig_instantly) {
 		runData.dig_index = (float)crack_animation_length
 				* runData.dig_time
 				/ runData.dig_time_complete;
 	} else {
-		// This is for torches
+		// This is for e.g. torches
 		runData.dig_index = crack_animation_length;
 	}
 
@@ -3878,10 +3884,12 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.nodig_delay_timer =
 				runData.dig_time_complete / (float)crack_animation_length;
 
-		// We don't want a corresponding delay to
-		// very time consuming nodes
+		// We don't want a corresponding delay to very time consuming nodes
+		// and nodes without digging time (e.g. torches) get a fixed delay.
 		if (runData.nodig_delay_timer > 0.3)
 			runData.nodig_delay_timer = 0.3;
+		else if (runData.dig_instantly)
+			runData.nodig_delay_timer = 0.15;
 
 		bool is_valid_position;
 		MapNode wasnode = map.getNodeNoEx(nodepos, &is_valid_position);

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -98,7 +98,7 @@ DigParams getDigParams(const ItemGroupList &groups,
 		return DigParams(true, 0.5, 0, "dig_immediate");
 	case 3:
 		//infostream<<"dig_immediate=3"<<std::endl;
-		return DigParams(true, 0.15, 0, "dig_immediate");
+		return DigParams(true, 0, 0, "dig_immediate");
 	default:
 		break;
 	}


### PR DESCRIPTION
* @Fixer-007 fixes https://github.com/minetest/minetest_game/issues/1706 (torch instant mining)
* When the digging time is 0, a delay of 0.15 seconds is added between digging nodes. If the left mouse button is released, the delay is set to 0, thus quick click-digging.

