### PR TITLE
Add 'once_per_session' to the LBM definition. Default is 'false'.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3756,6 +3756,12 @@ Definition tables
     --  ^ Whether to run the LBM's action every time a block gets loaded,
     --    and not just for blocks that were saved last time before LBMs were
     --    introduced to the world.
+        once_per_session = false,
+    --  ^ A modification on the previous parameter, which takes effect ONLY if
+          the previous parameter `run_at_every_load` is false (the default).
+          If this parameter is set, then the LBM's introducement time is discarded
+          at shutdown, which will cause the LBM's action to be executed during
+          the next session.
         action = func(pos, node),
     }
 

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -200,8 +200,11 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 		bool run_at_every_load = getboolfield_default(L, current_lbm,
 			"run_at_every_load", false);
 
+		bool once_per_session = getboolfield_default(L, current_lbm,
+			"once_per_session", false);
+
 		LuaLBM *lbm = new LuaLBM(L, id, trigger_contents, name,
-			run_at_every_load);
+			run_at_every_load, once_per_session);
 
 		env->addLoadingBlockModifierDef(lbm);
 

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -235,10 +235,11 @@ public:
 	LuaLBM(lua_State *L, int id,
 			const std::set<std::string> &trigger_contents,
 			const std::string &name,
-			bool run_at_every_load):
+			bool run_at_every_load, bool once_per_session):
 		m_id(id)
 	{
 		this->run_at_every_load = run_at_every_load;
+		this->once_per_session = once_per_session;
 		this->trigger_contents = trigger_contents;
 		this->name = name;
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -246,6 +246,14 @@ std::string LBMManager::createIntroductionTimesString()
 			// and doesn't need to be stored
 			if ((*iit)->run_at_every_load)
 				continue;
+			// Don't add if the LBM is marked as running once per session.
+			// This requires `run_at_every_load` to be false to have a real effect.
+			// The reasoning is simple: if `run_at_every_load` is false, then
+			// introducement times will take effect. But if `once_per_session` is set,
+			// then introducement time is discarded at shutdown, which causes the
+			// LBM to be executed again during the next session.
+			if ((*iit)->once_per_session)
+				continue;
 			oss << (*iit)->name << "~" << time << ";";
 		}
 	}

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -82,6 +82,7 @@ struct LoadingBlockModifierDef
 	std::set<std::string> trigger_contents;
 	std::string name;
 	bool run_at_every_load;
+	bool once_per_session;
 
 	virtual ~LoadingBlockModifierDef() {}
 	virtual void trigger(ServerEnvironment *env, v3s16 p, MapNode n){};


### PR DESCRIPTION
This allows modders to specify that an LBM's introducement times should be discarded at shutdown, so that the same LBM will be executed again the next time the server restarts.

Not to be confused with `run_at_every_load`; the behavior is subtly different.

This takes care of #5650.

I have tested this myself, and it works. If others could test that would be great.

Here is the test code. Swap the run_at_every_load/once_per_session flags in various different combinations to observe results.

```

minetest.register_lbm({
	name = "testmod:test_lbm",
	label = "Test LBM",
	nodenames = {
		"default:chest",
	},
	--run_at_every_load = true,
	once_per_session = true,

	action = function(pos)
		minetest.chat_send_all("LBM executing!")
	end,
})
```