### PR TITLE
Fix various points reported by cppcheck

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -202,15 +202,6 @@ public:
 
 		return meta->getString("formspec");
 	}
-	std::string resolveText(std::string str)
-	{
-		NodeMetadata *meta = m_map->getNodeMetadata(m_p);
-
-		if (!meta)
-			return str;
-
-		return meta->resolveString(str);
-	}
 
 	ClientMap *m_map;
 	v3s16 m_p;

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -69,7 +69,7 @@ public:
 	virtual ~IFormSource(){}
 	virtual std::string getForm() = 0;
 	// Fill in variables in field text
-	virtual std::string resolveText(std::string str){ return str; }
+	virtual std::string resolveText(const std::string &str) { return str; }
 };
 
 class GUIFormSpecMenu : public GUIModalMenu

--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -25,14 +25,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "map_settings_manager.h"
 
-MapSettingsManager::MapSettingsManager(
-	Settings *user_settings, const std::string &map_meta_path)
+MapSettingsManager::MapSettingsManager(Settings *user_settings,
+		const std::string &map_meta_path):
+	mapgen_params(NULL),
+	m_map_meta_path(map_meta_path),
+	m_map_settings(new Settings()),
+	m_user_settings(user_settings)
 {
-	m_map_meta_path = map_meta_path;
-	m_user_settings = user_settings;
-	m_map_settings  = new Settings;
-	mapgen_params   = NULL;
-
 	assert(m_user_settings != NULL);
 }
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1318,22 +1318,21 @@ void CNodeDefManager::removeNode(const std::string &name)
 
 	// Erase node content from all groups it belongs to
 	for (UNORDERED_MAP<std::string, GroupItems>::iterator iter_groups =
-			m_group_to_items.begin();
-			iter_groups != m_group_to_items.end();) {
+			m_group_to_items.begin(); iter_groups != m_group_to_items.end();) {
 		GroupItems &items = iter_groups->second;
 		for (GroupItems::iterator iter_groupitems = items.begin();
 				iter_groupitems != items.end();) {
 			if (iter_groupitems->first == id)
 				items.erase(iter_groupitems++);
 			else
-				iter_groupitems++;
+				++iter_groupitems;
 		}
 
 		// Check if group is empty
 		if (items.size() == 0)
 			m_group_to_items.erase(iter_groups++);
 		else
-			iter_groups++;
+			++iter_groups;
 	}
 }
 

--- a/src/script/cpp_api/s_async.cpp
+++ b/src/script/cpp_api/s_async.cpp
@@ -46,26 +46,26 @@ AsyncEngine::~AsyncEngine()
 
 	// Request all threads to stop
 	for (std::vector<AsyncWorkerThread *>::iterator it = workerThreads.begin();
-			it != workerThreads.end(); it++) {
+			it != workerThreads.end(); ++it) {
 		(*it)->stop();
 	}
 
 
 	// Wake up all threads
 	for (std::vector<AsyncWorkerThread *>::iterator it = workerThreads.begin();
-			it != workerThreads.end(); it++) {
+			it != workerThreads.end(); ++it) {
 		jobQueueCounter.post();
 	}
 
 	// Wait for threads to finish
 	for (std::vector<AsyncWorkerThread *>::iterator it = workerThreads.begin();
-			it != workerThreads.end(); it++) {
+			it != workerThreads.end(); ++it) {
 		(*it)->wait();
 	}
 
 	// Force kill all threads
 	for (std::vector<AsyncWorkerThread *>::iterator it = workerThreads.begin();
-			it != workerThreads.end(); it++) {
+			it != workerThreads.end(); ++it) {
 		delete *it;
 	}
 
@@ -205,7 +205,7 @@ void AsyncEngine::pushFinishedJobs(lua_State* L) {
 void AsyncEngine::prepareEnvironment(lua_State* L, int top)
 {
 	for (UNORDERED_MAP<std::string, lua_CFunction>::iterator it = functionList.begin();
-			it != functionList.end(); it++) {
+			it != functionList.end(); ++it) {
 		lua_pushstring(L, it->first.c_str());
 		lua_pushcfunction(L, it->second);
 		lua_settable(L, top);

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -263,7 +263,7 @@ void ScriptApiNode::node_on_receive_fields(v3s16 p,
 	lua_pushstring(L, formname.c_str()); // formname
 	lua_newtable(L);                     // fields
 	StringMap::const_iterator it;
-	for (it = fields.begin(); it != fields.end(); it++) {
+	for (it = fields.begin(); it != fields.end(); ++it) {
 		const std::string &name = it->first;
 		const std::string &value = it->second;
 		lua_pushstring(L, name.c_str());

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -83,7 +83,7 @@ int ModApiClient::l_get_player_names(lua_State *L)
 	int newTable = lua_gettop(L);
 	int index = 1;
 	std::list<std::string>::const_iterator iter;
-	for (iter = plist.begin(); iter != plist.end(); iter++) {
+	for (iter = plist.begin(); iter != plist.end(); ++iter) {
 		lua_pushstring(L, (*iter).c_str());
 		lua_rawseti(L, newTable, index);
 		index++;

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -414,7 +414,7 @@ static void push_craft_recipe(lua_State *L, IGameDef *gdef,
 
 	lua_newtable(L); // items
 	std::vector<ItemStack>::const_iterator iter = input.items.begin();
-	for (u16 j = 1; iter != input.items.end(); iter++, j++) {
+	for (u16 j = 1; iter != input.items.end(); ++iter, j++) {
 		if (iter->empty())
 			continue;
 		lua_pushstring(L, iter->name.c_str());

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -534,7 +534,7 @@ int ModApiEnvMod::l_get_objects_inside_radius(lua_State *L)
 	ScriptApiBase *script = getScriptApiBase(L);
 	lua_createtable(L, ids.size(), 0);
 	std::vector<u16>::const_iterator iter = ids.begin();
-	for(u32 i = 0; iter != ids.end(); iter++) {
+	for(u32 i = 0; iter != ids.end(); ++iter) {
 		ServerActiveObject *obj = env->getActiveObject(*iter);
 		// Insert object reference into table
 		script->objectrefGetOrCreate(L, obj);
@@ -985,8 +985,7 @@ int ModApiEnvMod::l_find_path(lua_State *L)
 		lua_newtable(L);
 		int top = lua_gettop(L);
 		unsigned int index = 1;
-		for (std::vector<v3s16>::iterator i = path.begin(); i != path.end();i++)
-		{
+		for (std::vector<v3s16>::iterator i = path.begin(); i != path.end(); ++i) {
 			lua_pushnumber(L,index);
 			push_v3s16(L, *i);
 			lua_settable(L, top);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -297,7 +297,7 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 		int table2 = lua_gettop(L);
 		int internal_index=1;
 		for (std::set<std::string>::iterator iter = games[i].addon_mods_paths.begin();
-				iter != games[i].addon_mods_paths.end(); iter++) {
+				iter != games[i].addon_mods_paths.end(); ++iter) {
 			lua_pushnumber(L,internal_index);
 			lua_pushstring(L,(*iter).c_str());
 			lua_settable(L, table2);

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -107,7 +107,7 @@ void NodeMetaRef::handleToTable(lua_State *L, Metadata *_meta)
 	if (inv) {
 		std::vector<const InventoryList *> lists = inv->getLists();
 		for(std::vector<const InventoryList *>::const_iterator
-				i = lists.begin(); i != lists.end(); i++) {
+				i = lists.begin(); i != lists.end(); ++i) {
 			push_inventory_list(L, inv, (*i)->getName().c_str());
 			lua_setfield(L, -2, (*i)->getName().c_str());
 		}

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -103,7 +103,7 @@ int ModApiServer::l_get_player_privs(lua_State *L)
 	int table = lua_gettop(L);
 	std::set<std::string> privs_s = server->getPlayerEffectivePrivs(name);
 	for(std::set<std::string>::const_iterator
-			i = privs_s.begin(); i != privs_s.end(); i++){
+			i = privs_s.begin(); i != privs_s.end(); ++i){
 		lua_pushboolean(L, true);
 		lua_setfield(L, table, i->c_str());
 	}
@@ -417,7 +417,7 @@ int ModApiServer::l_get_modnames(lua_State *L)
 	// Package them up for Lua
 	lua_createtable(L, modlist.size(), 0);
 	std::vector<std::string>::iterator iter = modlist.begin();
-	for (u16 i = 0; iter != modlist.end(); iter++) {
+	for (u16 i = 0; iter != modlist.end(); ++iter) {
 		lua_pushstring(L, iter->c_str());
 		lua_rawseti(L, -2, ++i);
 	}

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -83,8 +83,8 @@ public:
 	GetRequest() {}
 	~GetRequest() {}
 
-	GetRequest(Key a_key) {
-		key = a_key;
+	GetRequest(const Key &a_key): key(a_key)
+	{
 	}
 
 	Key key;
@@ -106,7 +106,7 @@ public:
 		return m_queue.empty();
 	}
 
-	void add(Key key, Caller caller, CallerData callerdata,
+	void add(const Key &key, Caller caller, CallerData callerdata,
 		ResultQueue<Key, T, Caller, CallerData> *dest)
 	{
 		typename std::deque<GetRequest<Key, T, Caller, CallerData> >::iterator i;


### PR DESCRIPTION
* Fix various iterator increment 
* remove unused NodeMetadataFormSource::resolveText
* Fix 2 copy value => const ref
* Fix 1 constructor

Here is cppcheck output after first commit (sorry i don't have it before)

```
[src/gettext.h:59]: (performance) Returning the result of c_str() in a function that returns std::string is slow and redundant.
[src/content_cao.cpp:1316]: (performance) Function parameter 'mod' should be passed by reference.
[src/convert_json.cpp:121]: (error) Uninitialized struct member: toadd.id
[src/convert_json.cpp:121]: (error) Uninitialized struct member: toadd.author
[src/convert_json.cpp:121]: (error) Uninitialized struct member: toadd.rating
[src/util/thread.h:87]: (performance) Variable 'key' is assigned in constructor body. Consider performing initialization in initialization list.
[src/util/thread.h:109]: (performance) Function parameter 'key' should be passed by reference.
[src/util/thread.h:86]: (performance) Function parameter 'a_key' should be passed by reference.
[src/map_settings_manager.cpp:31]: (performance) Variable 'm_map_meta_path' is assigned in constructor body. Consider performing initialization in initialization list.
[src/mapgen_flat.cpp:94]: (performance) Variable 'np_terrain' is assigned in constructor body. Consider performing initialization in initialization list.
[src/mapgen_v5.cpp:89]: (performance) Variable 'np_filler_depth' is assigned in constructor body. Consider performing initialization in initialization list.
[src/mapgen_v6.cpp:154]: (performance) Variable 'np_terrain_base' is assigned in constructor body. Consider performing initialization in initialization list.
[src/mapgen_v7.cpp:135]: (performance) Variable 'np_terrain_base' is assigned in constructor body. Consider performing initialization in initialization list.
[src/mapgen_valleys.cpp:141]: (performance) Variable 'np_cave1' is assigned in constructor body. Consider performing initialization in initialization list.
[src/nodedef.cpp:1329]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/nodedef.cpp:1336]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/particles.cpp:280]: (performance) Variable 'm_animation' is assigned in constructor body. Consider performing initialization in initialization list.
[src/rollback.cpp:102]: (performance) Variable 'database_path' is assigned in constructor body. Consider performing initialization in initialization list.
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.id
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.index
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.add
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.stack
[src/rollback.cpp:499]: (error) Uninitialized struct member: row.nodeMeta
[src/rollback.cpp:521]: (error) Uninitialized struct member: row.nodeMeta
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.nodeMeta
[src/rollback.cpp:523]: (error) Uninitialized struct member: row.x
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.x
[src/rollback.cpp:525]: (error) Uninitialized struct member: row.y
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.y
[src/rollback.cpp:527]: (error) Uninitialized struct member: row.z
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.z
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.oldNode
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.oldParam1
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.oldParam2
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.newNode
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.newParam1
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.newParam2
[src/rollback.cpp:532]: (error) Uninitialized struct member: row.guessed
[src/rollback.cpp:771]: (error) Uninitialized struct member: row.index
[src/rollback.cpp:771]: (error) Uninitialized struct member: row.add
[src/rollback.cpp:771]: (error) Uninitialized struct member: row.stack
[src/rollback.cpp:771]: (error) Uninitialized struct member: row.nodeMeta
[src/script/cpp_api/s_async.cpp:49]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_async.cpp:56]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_async.cpp:62]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_async.cpp:68]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_async.cpp:208]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_node.cpp:266]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/cpp_api/s_security.cpp:454]: (error) Resource leak: fp
[src/script/lua_api/l_client.cpp:86]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_craft.cpp:417]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_env.cpp:537]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_env.cpp:988]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_inventory.cpp:256]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_mainmenu.cpp:300]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_nodemeta.cpp:110]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_server.cpp:106]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/script/lua_api/l_server.cpp:420]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/settings_translation_file.cpp:5]: (error) syntax error
[src/unittest/test_map_settings_manager.cpp:86]: (error) Resource leak: f
[src/unittest/test_map_settings_manager.cpp:117]: (error) Resource leak: f
[src/unittest/test_utilities.cpp:316]: (error) Signed integer overflow for expression '(1<<exponent)+1'.
[src/unittest/test_voxelalgorithms.cpp:225]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[src/util/string.h:348]: (error) Uninitialized variable: t
[src/util/string.h:349]: (error) Uninitialized variable: t
[src/util/string.h:363]: (error) Uninitialized variable: oss
[src/util/string.h:364]: (error) Uninitialized variable: oss
[src/util/string.h:403]: (error) Uninitialized variable: oss
[src/util/string.h:404]: (error) Uninitialized variable: oss
[src/util/string.h:626]: (error) Uninitialized variable: ss
[src/util/string.h:630]: (error) Uninitialized variable: ss
[src/util/string.h:634]: (error) Uninitialized variable: ss
[src/util/string.h:637]: (error) Uninitialized variable: ss
```