### PR TITLE
Fix`TOSERVER_RECEIVED_MEDIA` handling.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -526,7 +526,6 @@ void Client::step(float dtime)
 	if (m_media_downloader && m_media_downloader->isStarted()) {
 		m_media_downloader->step(this);
 		if (m_media_downloader->isDone()) {
-			received_media();
 			delete m_media_downloader;
 			m_media_downloader = NULL;
 		}
@@ -745,14 +744,6 @@ void Client::request_media(const std::vector<std::string> &file_requests)
 
 	infostream << "Client: Sending media request list to server ("
 			<< file_requests.size() << " files. packet size)" << std::endl;
-}
-
-void Client::received_media()
-{
-	NetworkPacket pkt(TOSERVER_RECEIVED_MEDIA, 0);
-	Send(&pkt);
-	infostream << "Client: Notifying server that we received all media"
-			<< std::endl;
 }
 
 void Client::initLocalMapSaving(const Address &address,

--- a/src/client.h
+++ b/src/client.h
@@ -484,8 +484,6 @@ public:
 	bool loadMedia(const std::string &data, const std::string &filename);
 	// Send a request for conventional media transfer
 	void request_media(const std::vector<std::string> &file_requests);
-	// Send a notification that no conventional media transfer is needed
-	void received_media();
 
 	LocalClientState getState() { return m_state; }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -106,7 +106,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		add swap_node
 	PROTOCOL_VERSION 23:
 		Obsolete TOSERVER_RECEIVED_MEDIA
-		Add TOSERVER_CLIENT_READY
+		Server: Stop using TOSERVER_CLIENT_READY
 	PROTOCOL_VERSION 24:
 		ContentFeatures version 7
 		ContentFeatures: change number of special tiles to 6 (CF_SPECIAL_COUNT)
@@ -152,6 +152,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			with pre-30 clients by sending sqrt(visual_scale)
 	PROTOCOL VERSION 31:
 		Add tile overlay
+		Stop sending TOSERVER_CLIENT_READY
 */
 
 #define LATEST_PROTOCOL_VERSION 31

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -89,7 +89,7 @@ const ToServerCommandHandler toServerCommandTable[TOSERVER_NUM_MSG_TYPES] =
 	null_command_handler, // 0x3e
 	null_command_handler, // 0x3f
 	{ "TOSERVER_REQUEST_MEDIA",            TOSERVER_STATE_STARTUP, &Server::handleCommand_RequestMedia }, // 0x40
-	null_command_handler, // 0x41
+	{ "TOSERVER_RECEIVED_MEDIA",           TOSERVER_STATE_STARTUP, &Server::handleCommand_Deprecated }, // 0x41 not used by the server since protocol version 23
 	{ "TOSERVER_BREATH",                   TOSERVER_STATE_INGAME, &Server::handleCommand_Deprecated }, // 0x42 Old breath model which is now deprecated for anticheating
 	{ "TOSERVER_CLIENT_READY",             TOSERVER_STATE_STARTUP, &Server::handleCommand_ClientReady }, // 0x43
 	null_command_handler, // 0x44


### PR DESCRIPTION
Client: Don't send `TOSERVER_RECEIVED_MEDIA` since it's not used anymore
Server: Handle `TOSERVER_RECEIVED_MEDIA` using `Server::handleCommand_Deprecated`