### PR TITLE
Tiny documentation fix.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1919,8 +1919,7 @@ Helper functions
 * `math.sign(x, tolerance)`
     * Get the sign of a number.
       Optional: Also returns `0` when the absolute value is within the tolerance (default: `0`)
-* `string.split(str, separator=",", include_empty=false, max_splits=-1,
-* sep_is_pattern=false)`
+* `string.split(str, separator=",", include_empty=false, max_splits=-1, sep_is_pattern=false)`
     * If `max_splits` is negative, do not limit splits.
     * `sep_is_pattern` specifies if separator is a plain string or a pattern (regex).
     * e.g. `string:split("a,b", ",") == {"a","b"}`


### PR DESCRIPTION
Splitting the function declaration across two lines, and marking the second line with a star, seems inconsistent and can be momentarily confusing.