### PR TITLE
Always show clouds.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3986,14 +3986,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	*/
 	if (clouds) {
 		v3f player_position = player->getPosition();
-		if (sky->getCloudsVisible()) {
-			clouds->setVisible(true);
-			clouds->step(dtime);
-			clouds->update(v2f(player_position.X, player_position.Z),
-				       sky->getCloudColor());
-		} else {
-			clouds->setVisible(false);
-		}
+		clouds->setVisible(true);
+		clouds->step(dtime);
+		clouds->update(v2f(player_position.X, player_position.Z),
+			       sky->getCloudColor());
 	}
 
 	/*


### PR DESCRIPTION
With the new cloud API, we can always enable clouds and refer to
`density = 0.0` as a method to disable or hide the cloud layer. This
produces clouds that can be used in combination with sky box textures,
which is a nice visual.

https://www.youtube.com/watch?v=aiGSZR-q6AM

![](http://i.imgur.com/3fNlcFo.jpg)