### PR TITLE
Set sky API: Add bool for clouds in front of custom skybox 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3070,13 +3070,15 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `hud_set_hotbar_selected_image(texturename)`
     * sets image for selected item of hotbar
 * `hud_get_hotbar_selected_image`: returns texturename
-* `set_sky(bgcolor, type, {texture names})`
+* `set_sky(bgcolor, type, {texture names}, clouds)`
     * `bgcolor`: ColorSpec, defaults to white
-    * Available types:
+    * `type`: Available types:
         * `"regular"`: Uses 0 textures, `bgcolor` ignored
         * `"skybox"`: Uses 6 textures, `bgcolor` used
         * `"plain"`: Uses 0 textures, `bgcolor` used
-* `get_sky()`: returns bgcolor, type and a table with the textures
+    * `clouds`: Boolean for whether clouds appear in front of `"skybox"` or
+      `"plain"` custom skyboxes (default: `true`)
+* `get_sky()`: returns bgcolor, type, table of textures, clouds
 * `set_clouds(parameters)`: set cloud parameters
 	* `parameters` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)

--- a/src/client.h
+++ b/src/client.h
@@ -174,6 +174,7 @@ struct ClientEvent
 			video::SColor *bgcolor;
 			std::string *type;
 			std::vector<std::string> *params;
+			bool clouds;
 		} set_sky;
 		struct{
 			bool do_override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3255,6 +3255,8 @@ void Game::processClientEvents(CameraOrientation *cam)
 
 		case CE_SET_SKY:
 			sky->setVisible(false);
+			// Whether clouds are visible in front of a custom skybox
+			sky->setCloudsEnabled(event.set_sky.clouds);
 
 			if (skybox) {
 				skybox->remove();
@@ -3264,6 +3266,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 			// Handle according to type
 			if (*event.set_sky.type == "regular") {
 				sky->setVisible(true);
+				sky->setCloudsEnabled(true);
 			} else if (*event.set_sky.type == "skybox" &&
 					event.set_sky.params->size() == 6) {
 				sky->setFallbackBgColor(*event.set_sky.bgcolor);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1160,11 +1160,17 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	for (size_t i = 0; i < count; i++)
 		params->push_back(deSerializeString(is));
 
+	bool clouds = true;
+	try {
+		clouds = readU8(is);
+	} catch (...) {}
+
 	ClientEvent event;
 	event.type            = CE_SET_SKY;
 	event.set_sky.bgcolor = bgcolor;
 	event.set_sky.type    = type;
 	event.set_sky.params  = params;
+	event.set_sky.clouds  = clouds;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -582,6 +582,7 @@ enum ToClientCommand
 		foreach count:
 			u8 len
 			u8[len] param
+		u8 clouds (boolean)
 	*/
 
 	TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO = 0x50,

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -85,19 +85,21 @@ public:
 	}
 
 	void setSky(const video::SColor &bgcolor, const std::string &type,
-			const std::vector<std::string> &params)
+			const std::vector<std::string> &params, bool &clouds)
 	{
 		m_sky_bgcolor = bgcolor;
 		m_sky_type = type;
 		m_sky_params = params;
+		m_sky_clouds = clouds;
 	}
 
 	void getSky(video::SColor *bgcolor, std::string *type,
-			std::vector<std::string> *params)
+			std::vector<std::string> *params, bool *clouds)
 	{
 		*bgcolor = m_sky_bgcolor;
 		*type = m_sky_type;
 		*params = m_sky_params;
+		*clouds = m_sky_clouds;
 	}
 
 	void setCloudParams(const CloudParams &cloud_params)
@@ -165,6 +167,8 @@ private:
 	std::string m_sky_type;
 	video::SColor m_sky_bgcolor;
 	std::vector<std::string> m_sky_params;
+	bool m_sky_clouds;
+
 	CloudParams m_cloud_params;
 };
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1662,7 +1662,7 @@ int ObjectRef::l_hud_get_hotbar_selected_image(lua_State *L)
 	return 1;
 }
 
-// set_sky(self, bgcolor, type, list)
+// set_sky(self, bgcolor, type, list, clouds = true)
 int ObjectRef::l_set_sky(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1678,9 +1678,8 @@ int ObjectRef::l_set_sky(lua_State *L)
 
 	std::vector<std::string> params;
 	if (lua_istable(L, 4)) {
-		int table = lua_gettop(L);
 		lua_pushnil(L);
-		while (lua_next(L, table) != 0) {
+		while (lua_next(L, 4) != 0) {
 			// key at index -2 and value at index -1
 			if (lua_isstring(L, -1))
 				params.push_back(lua_tostring(L, -1));
@@ -1694,7 +1693,11 @@ int ObjectRef::l_set_sky(lua_State *L)
 	if (type == "skybox" && params.size() != 6)
 		throw LuaError("skybox expects 6 textures");
 
-	if (!getServer(L)->setSky(player, bgcolor, type, params))
+	bool clouds = true;
+	if (lua_isboolean(L, 5))
+		clouds = lua_toboolean(L, 5);
+
+	if (!getServer(L)->setSky(player, bgcolor, type, params, clouds))
 		return 0;
 
 	lua_pushboolean(L, true);
@@ -1712,8 +1715,9 @@ int ObjectRef::l_get_sky(lua_State *L)
 	video::SColor bgcolor(255, 255, 255, 255);
 	std::string type;
 	std::vector<std::string> params;
+	bool clouds;
 
-	player->getSky(&bgcolor, &type, &params);
+	player->getSky(&bgcolor, &type, &params, &clouds);
 	type = type == "" ? "regular" : type;
 
 	push_ARGB8(L, bgcolor);
@@ -1726,6 +1730,7 @@ int ObjectRef::l_get_sky(lua_State *L)
 		lua_rawseti(L, -2, i);
 		i++;
 	}
+	lua_pushboolean(L, clouds);
 	return 3;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -283,10 +283,10 @@ private:
 	// hud_get_hotbar_selected_image(self)
 	static int l_hud_get_hotbar_selected_image(lua_State *L);
 
-	// set_sky(self, type, list)
+	// set_sky(self, bgcolor, type, list, clouds = true)
 	static int l_set_sky(lua_State *L);
 
-	// get_sky(self, type, list)
+	// get_sky(self)
 	static int l_get_sky(lua_State *L);
 
 	// set_clouds(self, {density=, color=, ambient=, height=, thickness=, speed=})

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1871,13 +1871,16 @@ void Server::SendHUDSetParam(u16 peer_id, u16 param, const std::string &value)
 }
 
 void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
-		const std::string &type, const std::vector<std::string> &params)
+		const std::string &type, const std::vector<std::string> &params,
+		bool &clouds)
 {
 	NetworkPacket pkt(TOCLIENT_SET_SKY, 0, peer_id);
 	pkt << bgcolor << type << (u16) params.size();
 
 	for(size_t i=0; i<params.size(); i++)
 		pkt << params[i];
+
+	pkt << clouds;
 
 	Send(&pkt);
 }
@@ -3200,13 +3203,14 @@ bool Server::setPlayerEyeOffset(RemotePlayer *player, v3f first, v3f third)
 }
 
 bool Server::setSky(RemotePlayer *player, const video::SColor &bgcolor,
-	const std::string &type, const std::vector<std::string> &params)
+	const std::string &type, const std::vector<std::string> &params,
+	bool &clouds)
 {
 	if (!player)
 		return false;
 
-	player->setSky(bgcolor, type, params);
-	SendSetSky(player->peer_id, bgcolor, type, params);
+	player->setSky(bgcolor, type, params, clouds);
+	SendSetSky(player->peer_id, bgcolor, type, params, clouds);
 	return true;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -331,7 +331,8 @@ public:
 	bool setPlayerEyeOffset(RemotePlayer *player, v3f first, v3f third);
 
 	bool setSky(RemotePlayer *player, const video::SColor &bgcolor,
-			const std::string &type, const std::vector<std::string> &params);
+			const std::string &type, const std::vector<std::string> &params,
+			bool &clouds);
 	bool setClouds(RemotePlayer *player, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
@@ -406,7 +407,8 @@ private:
 	void SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask);
 	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
 	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
-			const std::string &type, const std::vector<std::string> &params);
+			const std::string &type, const std::vector<std::string> &params,
+			bool &clouds);
 	void SendCloudParams(u16 peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -85,6 +85,8 @@ Sky::Sky(scene::ISceneNode* parent, scene::ISceneManager* mgr, s32 id,
 	}
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
+
+	m_clouds_enabled = true;
 }
 
 

--- a/src/sky.h
+++ b/src/sky.h
@@ -65,10 +65,12 @@ public:
 		return m_visible ? m_skycolor : m_fallback_bg_color;
 	}
 
-	bool getCloudsVisible() { return m_clouds_visible && m_visible; }
+	bool getCloudsVisible() { return m_clouds_visible && m_clouds_enabled; }
 	const video::SColorf &getCloudColor() { return m_cloudcolor_f; }
 
 	void setVisible(bool visible) { m_visible = visible; }
+	// Set only from set_sky API
+	void setCloudsEnabled(bool clouds_enabled) { m_clouds_enabled = clouds_enabled; }
 	void setFallbackBgColor(const video::SColor &fallback_bg_color)
 	{
 		m_fallback_bg_color = fallback_bg_color;
@@ -123,7 +125,8 @@ private:
 	bool m_sunlight_seen;
 	float m_brightness;
 	float m_cloud_brightness;
-	bool m_clouds_visible;
+	bool m_clouds_visible;  // Whether clouds are disabled due to player underground
+	bool m_clouds_enabled;  // Initialised to true, reset only by set_sky API
 	bool m_directional_colored_fog;
 	video::SColorf m_bgcolor_bright_f;
 	video::SColorf m_skycolor_bright_f;


### PR DESCRIPTION
Default true.
Add 'm_clouds_enabled' bool to sky.h, set from new bool in 'set sky' API.
Make 'getCloudsVisible()' depend on 'm_clouds_enabled' instead of
'm_visible' (whether normal sky is visible).
///////////////////

![screenshot_20170428_024946](https://cloud.githubusercontent.com/assets/3686677/25511231/76c8e28e-2bbd-11e7-8d0c-867e1bac9db6.png)

PR for issue #5669