### PR TITLE
Game::processClientEvents don't create factice events

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -414,7 +414,8 @@ public:
 	void updateCameraOffset(v3s16 camera_offset)
 	{ m_mesh_update_thread.m_camera_offset = camera_offset; }
 
-	// Get event from queue. CE_NONE is returned if queue is empty.
+	bool hasClientEvents() const { return !m_client_event_queue.empty(); }
+	// Get event from queue. If queue is empty, it triggers an assertion failure.
 	ClientEvent getClientEvent();
 
 	bool accessDenied() const { return m_access_denied; }

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -598,15 +598,13 @@ void ClientEnvironment::getActiveObjects(v3f origin, f32 max_d,
 	}
 }
 
-ClientEnvEvent ClientEnvironment::getClientEvent()
+ClientEnvEvent ClientEnvironment::getClientEnvEvent()
 {
-	ClientEnvEvent event;
-	if(m_client_event_queue.empty())
-		event.type = CEE_NONE;
-	else {
-		event = m_client_event_queue.front();
-		m_client_event_queue.pop();
-	}
+	FATAL_ERROR_IF(m_client_event_queue.empty(),
+			"ClientEnvironment::getClientEnvEvent(): queue is empty");
+
+	ClientEnvEvent event = m_client_event_queue.front();
+	m_client_event_queue.pop();
 	return event;
 }
 

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -126,8 +126,9 @@ public:
 	void getActiveObjects(v3f origin, f32 max_d,
 		std::vector<DistanceSortedActiveObject> &dest);
 
-	// Get event from queue. CEE_NONE is returned if queue is empty.
-	ClientEnvEvent getClientEvent();
+	bool hasClientEnvEvents() const { return !m_client_event_queue.empty(); }
+	// Get event from queue. If queue is empty, it triggers an assertion failure.
+	ClientEnvEvent getClientEnvEvent();
 
 	/*!
 	 * Gets closest object pointed by the shootline.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3055,11 +3055,10 @@ inline void Game::step(f32 *dtime)
 
 void Game::processClientEvents(CameraOrientation *cam)
 {
-	ClientEvent event = client->getClientEvent();
-
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-	for ( ; event.type != CE_NONE; event = client->getClientEvent()) {
+	while (client->hasClientEvents()) {
+		ClientEvent event = client->getClientEvent();
 
 		switch (event.type) {
 		case CE_PLAYER_DAMAGE:


### PR DESCRIPTION
Instead of create factice events on the stack on each loop call (Game::run), verify is queue is empty or not and handle event directly if there is.

This prevents factice ClientEvent creation & memory allocations