### PR TITLE
Artificial bank

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3468,14 +3468,14 @@ will place the schematic inside of the VoxelManip.
 * `set_data(data)`: Sets the data contents of the `VoxelManip` object
 * `update_map()`: Does nothing, kept for compatibility.
 * `set_lighting(light, [p1, p2])`: Set the lighting within the `VoxelManip` to a uniform value
-    * `light` is a table, `{day=<0...15>, night=<0...15>}`
+    * `light` is a table, `{sun=<0...15>, artificial=<0...15>}`
     * To be used only by a `VoxelManip` object from `minetest.get_mapgen_object`
     * (`p1`, `p2`) is the area in which lighting is set;
       defaults to the whole area if left out
 * `get_light_data()`: Gets the light data read into the `VoxelManip` object
     * Returns an array (indices 1 to volume) of integers ranging from `0` to `255`
-    * Each value is the bitwise combination of day and night light values (`0` to `15` each)
-    * `light = day + (night * 16)`
+    * Each value is the bitwise combination of sun and artificial light values (`0` to `15` each)
+    * `light = sun + (artificial * 16)`
 * `set_light_data(light_data)`: Sets the `param1` (light) contents of each node
   in the `VoxelManip`
     * expects lighting data in the same format that `get_light_data()` returns

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -320,9 +320,10 @@ struct TileLayer
 struct TileSpec
 {
 	TileSpec():
-		rotation(0),
-		emissive_light(0)
+		rotation(0)
 	{
+		for (int bank = 0; bank < 2; bank++)
+			emissive_light[bank] = 0;
 		for (int layer = 0; layer < MAX_TILE_LAYERS; layer++)
 			layers[layer] = TileLayer();
 	}
@@ -344,7 +345,8 @@ struct TileSpec
 
 	u8 rotation;
 	//! This much light does the tile emit.
-	u8 emissive_light;
+	//! The first element is sunlight, the second is artificial light.
+	u8 emissive_light[2];
 	//! The first is base texture, the second is overlay.
 	TileLayer layers[MAX_TILE_LAYERS];
 };

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -583,7 +583,7 @@ static bool getVisibleBrightness(Map *map, v3f p0, v3f dir, float step,
 		}
 		if(distance >= sunlight_min_d && *sunlight_seen == false
 				&& nonlight_seen == false)
-			if(n.getLight(LIGHTBANK_DAY, ndef) == LIGHT_SUN)
+			if(n.getLight(LIGHTBANK_SUN, ndef) == LIGHT_SUN)
 				*sunlight_seen = true;
 		noncount = 0;
 		brightness_sum += decode_light(n.getLightBlend(daylight_factor, ndef));

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -78,7 +78,7 @@ void MapblockMeshGenerator::useTile(int index, bool disable_backface_culling)
 {
 	getNodeTileN(n, p, index, data, tile);
 	if (!data->m_smooth_lighting)
-		color = encode_light(light, f->light_source);
+		color = encode_light(light, f->light_source[LIGHTBANK_ARTIFICIAL]);
 	for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
 		tile.layers[layer].material_flags |= MATERIAL_FLAG_CRACK_OVERLAY;
 		if (disable_backface_culling)
@@ -90,7 +90,7 @@ void MapblockMeshGenerator::useDefaultTile(bool set_color)
 {
 	getNodeTile(n, p, v3s16(0, 0, 0), data, tile);
 	if (set_color && !data->m_smooth_lighting)
-		color = encode_light(light, f->light_source);
+		color = encode_light(light, f->light_source[LIGHTBANK_ARTIFICIAL]);
 }
 
 void MapblockMeshGenerator::getTile(const v3s16& direction, TileSpec &tile)
@@ -102,7 +102,8 @@ void MapblockMeshGenerator::drawQuad(v3f *coords, const v3s16 &normal)
 {
 	static const v2f tcoords[4] = {v2f(0, 0), v2f(1, 0), v2f(1, 1), v2f(0, 1)};
 	video::S3DVertex vertices[4];
-	bool shade_face = !f->light_source && (normal != v3s16(0, 0, 0));
+	bool shade_face = !f->light_source[LIGHTBANK_ARTIFICIAL] &&
+		(normal != v3s16(0, 0, 0));
 	v3f normal2(normal.X, normal.Y, normal.Z);
 	for (int j = 0; j < 4; j++) {
 		vertices[j].Pos = coords[j] + origin;
@@ -139,9 +140,10 @@ void MapblockMeshGenerator::drawCuboid(const aabb3f &box,
 	video::SColor colors[6];
 	if (!data->m_smooth_lighting) {
 		for (int face = 0; face != 6; ++face) {
-			colors[face] = encode_light(light, f->light_source);
+			colors[face] = encode_light(light,
+				f->light_source[LIGHTBANK_ARTIFICIAL]);
 		}
-		if (!f->light_source) {
+		if (!f->light_source[LIGHTBANK_ARTIFICIAL]) {
 			applyFacesShading(colors[0], v3f(0, 1, 0));
 			applyFacesShading(colors[1], v3f(0, -1, 0));
 			applyFacesShading(colors[2], v3f(1, 0, 0));
@@ -242,8 +244,8 @@ void MapblockMeshGenerator::drawCuboid(const aabb3f &box,
 	if (data->m_smooth_lighting) {
 		for (int j = 0; j < 24; ++j) {
 			vertices[j].Color = encode_light(lights[light_indices[j]],
-				f->light_source);
-			if (!f->light_source)
+				f->light_source[LIGHTBANK_ARTIFICIAL]);
+			if (!f->light_source[LIGHTBANK_ARTIFICIAL])
 				applyFacesShading(vertices[j].Color, vertices[j].Normal);
 		}
 	}
@@ -292,14 +294,14 @@ u16 MapblockMeshGenerator::blendLight(const v3f &vertex_pos)
 video::SColor MapblockMeshGenerator::blendLightColor(const v3f &vertex_pos)
 {
 	u16 light = blendLight(vertex_pos);
-	return encode_light(light, f->light_source);
+	return encode_light(light, f->light_source[LIGHTBANK_ARTIFICIAL]);
 }
 
 video::SColor MapblockMeshGenerator::blendLightColor(const v3f &vertex_pos,
 	const v3f &vertex_normal)
 {
 	video::SColor color = blendLightColor(vertex_pos);
-	if (!f->light_source)
+	if (!f->light_source[LIGHTBANK_ARTIFICIAL])
 		applyFacesShading(color, vertex_normal);
 	return color;
 }
@@ -389,18 +391,19 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing(bool flowing)
 	if (data->m_smooth_lighting)
 		return; // don't need to pre-compute anything in this case
 
-	if (f->light_source != 0) {
+	if (f->light_source[LIGHTBANK_ARTIFICIAL] != 0) {
 		// If this liquid emits light and doesn't contain light, draw
 		// it at what it emits, for an increased effect
-		light = decode_light(f->light_source);
+		light = decode_light(f->light_source[LIGHTBANK_ARTIFICIAL]);
 		light = light | (light << 8);
 	} else if (nodedef->get(ntop).param_type == CPT_LIGHT) {
 		// Otherwise, use the light of the node on top if possible
 		light = getInteriorLight(ntop, 0, nodedef);
 	}
 
-	color_liquid_top = encode_light(light, f->light_source);
-	color = encode_light(light, f->light_source);
+	color_liquid_top = encode_light(light,
+		f->light_source[LIGHTBANK_ARTIFICIAL]);
+	color = encode_light(light, f->light_source[LIGHTBANK_ARTIFICIAL]);
 }
 
 void MapblockMeshGenerator::getLiquidNeighborhood(bool flowing)
@@ -1270,7 +1273,7 @@ void MapblockMeshGenerator::drawMeshNode()
 			// Instead, let the collector process colors, etc.
 			collector->append(tile, vertices, vertex_count,
 				buf->getIndices(), buf->getIndexCount(), origin,
-				color, f->light_source);
+				color, f->light_source[LIGHTBANK_ARTIFICIAL]);
 		}
 	}
 	if (private_mesh)

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -51,6 +51,7 @@ public:
 	v3f origin;
 	MapNode n;
 	const ContentFeatures *f;
+	bool need_shading;
 	u16 light;
 	LightFrame frame;
 	video::SColor color;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2360,10 +2360,13 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db)
 	return ret;
 }
 
-void ServerMap::loadBlock(const std::string &sectordir, const std::string &blockfile,
-		MapSector *sector, bool save_after_load)
+void ServerMap::loadBlock(const std::string &sectordir,
+	const std::string &blockfile, MapSector *sector, u8 *version,
+	bool save_after_load)
 {
 	DSTACK(FUNCTION_NAME);
+
+	*version = SER_FMT_VER_INVALID;
 
 	std::string fullpath = sectordir + DIR_DELIM + blockfile;
 	try {
@@ -2376,31 +2379,28 @@ void ServerMap::loadBlock(const std::string &sectordir, const std::string &block
 
 		assert(sector->getPos() == p2d);
 
-		u8 version = SER_FMT_VER_INVALID;
-		is.read((char*)&version, 1);
+		is.read((char*) version, 1);
 
-		if(is.fail())
+		if (is.fail())
 			throw SerializationError("ServerMap::loadBlock(): Failed"
-					" to read MapBlock version");
+				" to read MapBlock version");
 
 		/*u32 block_size = MapBlock::serializedLength(version);
-		SharedBuffer<u8> data(block_size);
-		is.read((char*)*data, block_size);*/
+		 SharedBuffer<u8> data(block_size);
+		 is.read((char*)*data, block_size);*/
 
 		// This will always return a sector because we're the server
 		//MapSector *sector = emergeSector(p2d);
-
 		MapBlock *block = NULL;
 		bool created_new = false;
 		block = sector->getBlockNoCreateNoEx(p3d.Y);
-		if(block == NULL)
-		{
+		if (block == NULL) {
 			block = sector->createBlankBlockNoInsert(p3d.Y);
 			created_new = true;
 		}
 
 		// Read basic data
-		block->deSerialize(is, version, true);
+		block->deSerialize(is, *version, true);
 
 		// If it's a new block, insert it to the map
 		if (created_new) {
@@ -2410,11 +2410,10 @@ void ServerMap::loadBlock(const std::string &sectordir, const std::string &block
 		}
 
 		/*
-			Save blocks loaded in old format in new format
-		*/
+		 Save blocks loaded in old format in new format
+		 */
 
-		if(version < SER_FMT_VER_HIGHEST_WRITE || save_after_load)
-		{
+		if (*version < SER_FMT_VER_HIGHEST_WRITE || save_after_load) {
 			saveBlock(block);
 
 			// Should be in database now, so delete the old file
@@ -2424,46 +2423,43 @@ void ServerMap::loadBlock(const std::string &sectordir, const std::string &block
 		// We just loaded it from the disk, so it's up-to-date.
 		block->resetModified();
 
-	}
-	catch(SerializationError &e)
-	{
-		warningstream<<"Invalid block data on disk "
-				<<"fullpath="<<fullpath
-				<<" (SerializationError). "
-				<<"what()="<<e.what()
-				<<std::endl;
-				// Ignoring. A new one will be generated.
+	} catch (SerializationError &e) {
+		warningstream << "Invalid block data on disk " << "fullpath="
+			<< fullpath << " (SerializationError). " << "what()=" << e.what()
+			<< std::endl;
+		// Ignoring. A new one will be generated.
 		abort();
 
 		// TODO: Backup file; name is in fullpath.
 	}
 }
 
-void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load)
+void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector,
+	u8 *version, bool save_after_load)
 {
 	DSTACK(FUNCTION_NAME);
+
+	*version = SER_FMT_VER_INVALID;
 
 	try {
 		std::istringstream is(*blob, std::ios_base::binary);
 
-		u8 version = SER_FMT_VER_INVALID;
-		is.read((char*)&version, 1);
+		is.read((char*) version, 1);
 
-		if(is.fail())
+		if (is.fail())
 			throw SerializationError("ServerMap::loadBlock(): Failed"
-					" to read MapBlock version");
+				" to read MapBlock version");
 
 		MapBlock *block = NULL;
 		bool created_new = false;
 		block = sector->getBlockNoCreateNoEx(p3d.Y);
-		if(block == NULL)
-		{
+		if (block == NULL) {
 			block = sector->createBlankBlockNoInsert(p3d.Y);
 			created_new = true;
 		}
 
 		// Read basic data
-		block->deSerialize(is, version, true);
+		block->deSerialize(is, *version, true);
 
 		// If it's a new block, insert it to the map
 		if (created_new) {
@@ -2473,29 +2469,27 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 		}
 
 		/*
-			Save blocks loaded in old format in new format
-		*/
+		 Save blocks loaded in old format in new format
+		 */
 
 		//if(version < SER_FMT_VER_HIGHEST_READ || save_after_load)
 		// Only save if asked to; no need to update version
-		if(save_after_load)
+		if (save_after_load)
 			saveBlock(block);
 
 		// We just loaded it from, so it's up-to-date.
 		block->resetModified();
-	}
-	catch(SerializationError &e)
-	{
-		errorstream<<"Invalid block data in database"
-				<<" ("<<p3d.X<<","<<p3d.Y<<","<<p3d.Z<<")"
-				<<" (SerializationError): "<<e.what()<<std::endl;
+	} catch (SerializationError &e) {
+		errorstream << "Invalid block data in database" << " (" << p3d.X << ","
+			<< p3d.Y << "," << p3d.Z << ")" << " (SerializationError): "
+			<< e.what() << std::endl;
 
 		// TODO: Block should be marked as invalid in memory so that it is
 		// not touched but the game can run
 
-		if(g_settings->getBool("ignore_world_load_errors")){
-			errorstream<<"Ignoring block load error. Duck and cover! "
-					<<"(ignore_world_load_errors)"<<std::endl;
+		if (g_settings->getBool("ignore_world_load_errors")) {
+			errorstream << "Ignoring block load error. Duck and cover! "
+				<< "(ignore_world_load_errors)" << std::endl;
 		} else {
 			throw SerializationError("Invalid block data in database");
 		}
@@ -2510,10 +2504,11 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 
 	v2s16 p2d(blockpos.X, blockpos.Z);
 
+	u8 version = SER_FMT_VER_INVALID;
 	std::string ret;
 	dbase->loadBlock(blockpos, &ret);
 	if (ret != "") {
-		loadBlock(&ret, blockpos, createSector(p2d), false);
+		loadBlock(&ret, blockpos, createSector(p2d), &version, false);
 	} else {
 		// Not found in database, try the files
 
@@ -2561,11 +2556,13 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 		/*
 		Load block and save it to the database
 		 */
-		loadBlock(sectordir, blockfilename, sector, true);
+		loadBlock(sectordir, blockfilename, sector, &version, true);
 	}
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if (created_new && (block != NULL)) {
 		std::map<v3s16, MapBlock*> modified_blocks;
+		if(version < 28)
+			voxalgo::repair_block_light(this, block, false, &modified_blocks);
 		// Fix lighting if necessary
 		voxalgo::update_block_border_lighting(this, block, modified_blocks);
 		if (!modified_blocks.empty()) {
@@ -2610,7 +2607,7 @@ bool ServerMap::repairBlockLight(v3s16 blockpos,
 	MapBlock *block = emergeBlock(blockpos, false);
 	if (!block || !block->isGenerated())
 		return false;
-	voxalgo::repair_block_light(this, block, modified_blocks);
+	voxalgo::repair_block_light(this, block, true, modified_blocks);
 	return true;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -253,8 +253,8 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 
 	// Set the node on the map
 	// Ignore light (because calling voxalgo::update_lighting_nodes)
-	n.setLight(LIGHTBANK_DAY, 0, m_nodedef);
-	n.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
+	n.setLight(LIGHTBANK_SUN, 0, m_nodedef);
+	n.setLight(LIGHTBANK_ARTIFICIAL, 0, m_nodedef);
 	setNode(p, n);
 
 	// Update lighting
@@ -910,8 +910,8 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 		}
 
 		// Ignore light (because calling voxalgo::update_lighting_nodes)
-		n0.setLight(LIGHTBANK_DAY, 0, m_nodedef);
-		n0.setLight(LIGHTBANK_NIGHT, 0, m_nodedef);
+		n0.setLight(LIGHTBANK_SUN, 0, m_nodedef);
+		n0.setLight(LIGHTBANK_ARTIFICIAL, 0, m_nodedef);
 
 		// Find out whether there is a suspect for this action
 		std::string suspect;

--- a/src/map.h
+++ b/src/map.h
@@ -461,10 +461,11 @@ public:
 	static bool saveBlock(MapBlock *block, MapDatabase *db);
 	// This will generate a sector with getSector if not found.
 	void loadBlock(const std::string &sectordir, const std::string &blockfile,
-			MapSector *sector, bool save_after_load=false);
+		MapSector *sector, u8 *version, bool save_after_load = false);
 	MapBlock* loadBlock(v3s16 p);
 	// Database version
-	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
+	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector,
+		u8 *version, bool save_after_load = false);
 
 	bool deleteBlock(v3s16 blockpos);
 

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -205,7 +205,7 @@ bool MapBlock::propagateSunlight(std::set<v3s16> & light_sources,
 					// Trust heuristics
 					no_sunlight = is_underground;
 				}
-				else if(n.getLight(LIGHTBANK_DAY, m_gamedef->ndef()) != LIGHT_SUN)
+				else if(n.getLight(LIGHTBANK_SUN, m_gamedef->ndef()) != LIGHT_SUN)
 				{
 					no_sunlight = true;
 				}
@@ -239,7 +239,7 @@ bool MapBlock::propagateSunlight(std::set<v3s16> & light_sources,
 			// Check if node above block has sunlight
 			try{
 				MapNode n = getNodeParent(v3s16(x, MAP_BLOCKSIZE, z));
-				if(n.getLight(LIGHTBANK_DAY) == LIGHT_SUN)
+				if(n.getLight(LIGHTBANK_SUN) == LIGHT_SUN)
 				{
 					no_sunlight = false;
 				}
@@ -290,11 +290,11 @@ bool MapBlock::propagateSunlight(std::set<v3s16> & light_sources,
 					current_light = diminish_light(current_light);
 				}
 
-				u8 old_light = n.getLight(LIGHTBANK_DAY, nodemgr);
+				u8 old_light = n.getLight(LIGHTBANK_SUN, nodemgr);
 
 				if(current_light > old_light || remove_light)
 				{
-					n.setLight(LIGHTBANK_DAY, current_light, nodemgr);
+					n.setLight(LIGHTBANK_SUN, current_light, nodemgr);
 				}
 
 				if(diminish_light(current_light) != 0)
@@ -329,10 +329,10 @@ bool MapBlock::propagateSunlight(std::set<v3s16> & light_sources,
 				if (is_valid_position) {
 					if(nodemgr->get(n).light_propagates)
 					{
-						if(n.getLight(LIGHTBANK_DAY, nodemgr) == LIGHT_SUN
+						if(n.getLight(LIGHTBANK_SUN, nodemgr) == LIGHT_SUN
 								&& sunlight_should_go_down == false)
 							block_below_is_valid = false;
-						else if(n.getLight(LIGHTBANK_DAY, nodemgr) != LIGHT_SUN
+						else if(n.getLight(LIGHTBANK_SUN, nodemgr) != LIGHT_SUN
 								&& sunlight_should_go_down == true)
 							block_below_is_valid = false;
 					}

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -236,7 +236,7 @@ public:
 		bool is_complete)
 	{
 		assert(direction >= 0 && direction <= 5);
-		if (bank == LIGHTBANK_NIGHT) {
+		if (bank == LIGHTBANK_ARTIFICIAL) {
 			direction += 6;
 		}
 		u16 newflags = m_lighting_complete;
@@ -251,7 +251,7 @@ public:
 	inline bool isLightingComplete(LightBank bank, u8 direction)
 	{
 		assert(direction >= 0 && direction <= 5);
-		if (bank == LIGHTBANK_NIGHT) {
+		if (bank == LIGHTBANK_ARTIFICIAL) {
 			direction += 6;
 		}
 		return (m_lighting_complete & (1 << direction)) != 0;

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -184,8 +184,8 @@ static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
 		light = l2;
 
 	// Boost light level for light sources
-	u8 light_source = MYMAX(ndef->get(n).light_source,
-			ndef->get(n2).light_source);
+	u8 light_source = MYMAX(ndef->get(n).light_source[LIGHTBANK_ARTIFICIAL],
+			ndef->get(n2).light_source[LIGHTBANK_ARTIFICIAL]);
 	if(light_source > light)
 		light = light_source;
 
@@ -238,8 +238,8 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 		}
 
 		const ContentFeatures &f = ndef->get(n);
-		if (f.light_source > light_source_max)
-			light_source_max = f.light_source;
+		if (f.light_source[LIGHTBANK_ARTIFICIAL] > light_source_max)
+			light_source_max = f.light_source[LIGHTBANK_ARTIFICIAL];
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
 			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_SUN, &f));
@@ -829,7 +829,7 @@ static void getTileInfo(
 
 	getNodeTile(n, p_corrected, face_dir_corrected, data, tile);
 	const ContentFeatures &f = ndef->get(n);
-	tile.emissive_light = f.light_source;
+	tile.emissive_light = f.light_source[LIGHTBANK_ARTIFICIAL];
 
 	// eg. water and glass
 	if (equivalent) {

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -163,8 +163,8 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 */
 u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef)
 {
-	u16 day = getInteriorLight(LIGHTBANK_DAY, n, increment, ndef);
-	u16 night = getInteriorLight(LIGHTBANK_NIGHT, n, increment, ndef);
+	u16 day = getInteriorLight(LIGHTBANK_SUN, n, increment, ndef);
+	u16 night = getInteriorLight(LIGHTBANK_ARTIFICIAL, n, increment, ndef);
 	return day | (night << 8);
 }
 
@@ -198,8 +198,8 @@ static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
 */
 u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef)
 {
-	u16 day = getFaceLight(LIGHTBANK_DAY, n, n2, face_dir, ndef);
-	u16 night = getFaceLight(LIGHTBANK_NIGHT, n, n2, face_dir, ndef);
+	u16 day = getFaceLight(LIGHTBANK_SUN, n, n2, face_dir, ndef);
+	u16 night = getFaceLight(LIGHTBANK_ARTIFICIAL, n, n2, face_dir, ndef);
 	return day | (night << 8);
 }
 
@@ -242,8 +242,8 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 			light_source_max = f.light_source;
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
-			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_DAY, &f));
-			light_night += decode_light(n.getLightNoChecks(LIGHTBANK_NIGHT, &f));
+			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_SUN, &f));
+			light_night += decode_light(n.getLightNoChecks(LIGHTBANK_ARTIFICIAL, &f));
 			light_count++;
 		} else {
 			ambient_occlusion++;

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -184,8 +184,8 @@ static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
 		light = l2;
 
 	// Boost light level for light sources
-	u8 light_source = MYMAX(ndef->get(n).light_source[LIGHTBANK_ARTIFICIAL],
-			ndef->get(n2).light_source[LIGHTBANK_ARTIFICIAL]);
+	u8 light_source = MYMAX(ndef->get(n).light_source[bank],
+			ndef->get(n2).light_source[bank]);
 	if(light_source > light)
 		light = light_source;
 
@@ -224,7 +224,8 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 
 	u16 ambient_occlusion = 0;
 	u16 light_count = 0;
-	u8 light_source_max = 0;
+	u8 light_source_sun_max = 0;
+	u8 light_source_artificial_max = 0;
 	u16 light_day = 0;
 	u16 light_night = 0;
 
@@ -238,8 +239,10 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 		}
 
 		const ContentFeatures &f = ndef->get(n);
-		if (f.light_source[LIGHTBANK_ARTIFICIAL] > light_source_max)
-			light_source_max = f.light_source[LIGHTBANK_ARTIFICIAL];
+		if (f.light_source[LIGHTBANK_SUN] > light_source_sun_max)
+			light_source_sun_max = f.light_source[LIGHTBANK_SUN];
+		if (f.light_source[LIGHTBANK_ARTIFICIAL] > light_source_artificial_max)
+			light_source_artificial_max = f.light_source[LIGHTBANK_ARTIFICIAL];
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
 			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_SUN, &f));
@@ -258,14 +261,14 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 
 	// Boost brightness around light sources
 	bool skip_ambient_occlusion_day = false;
-	if(decode_light(light_source_max) >= light_day) {
-		light_day = decode_light(light_source_max);
+	if(decode_light(light_source_sun_max) >= light_day) {
+		light_day = decode_light(light_source_sun_max);
 		skip_ambient_occlusion_day = true;
 	}
 
 	bool skip_ambient_occlusion_night = false;
-	if(decode_light(light_source_max) >= light_night) {
-		light_night = decode_light(light_source_max);
+	if(decode_light(light_source_artificial_max) >= light_night) {
+		light_night = decode_light(light_source_artificial_max);
 		skip_ambient_occlusion_night = true;
 	}
 
@@ -322,8 +325,9 @@ void final_color_blend(video::SColor *result,
 {
 	video::SColorf dayLight;
 	get_sunlight_color(&dayLight, daynight_ratio);
+	const static u8 nolight[2] = { 0, 0 };
 	final_color_blend(result,
-		encode_light(light, 0), dayLight);
+		encode_light(light, nolight), dayLight);
 }
 
 void final_color_blend(video::SColor *result,
@@ -829,7 +833,9 @@ static void getTileInfo(
 
 	getNodeTile(n, p_corrected, face_dir_corrected, data, tile);
 	const ContentFeatures &f = ndef->get(n);
-	tile.emissive_light = f.light_source[LIGHTBANK_ARTIFICIAL];
+	tile.emissive_light[LIGHTBANK_SUN] = f.light_source[LIGHTBANK_SUN];
+	tile.emissive_light[LIGHTBANK_ARTIFICIAL] =
+		f.light_source[LIGHTBANK_ARTIFICIAL];
 
 	// eg. water and glass
 	if (equivalent) {
@@ -1457,21 +1463,21 @@ void MeshCollector::append(const TileLayer &layer,
 void MeshCollector::append(const TileSpec &tile,
 		const video::S3DVertex *vertices, u32 numVertices,
 		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source)
+		v3f pos, video::SColor c, bool apply_shading)
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
 		const TileLayer *layer = &tile.layers[layernum];
 		if (layer->texture_id == 0)
 			continue;
 		append(*layer, vertices, numVertices, indices, numIndices, pos,
-			c, light_source, layernum);
+			c, apply_shading, layernum);
 	}
 }
 
 void MeshCollector::append(const TileLayer &layer,
 		const video::S3DVertex *vertices, u32 numVertices,
 		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source, u8 layernum)
+		v3f pos, video::SColor c, bool apply_shading, u8 layernum)
 {
 	if (numIndices > 65535) {
 		dstream<<"FIXME: MeshCollector::append() called with numIndices="<<numIndices<<" (limit 65535)"<<std::endl;
@@ -1503,7 +1509,7 @@ void MeshCollector::append(const TileLayer &layer,
 	if (m_use_tangent_vertices) {
 		vertex_count = p->tangent_vertices.size();
 		for (u32 i = 0; i < numVertices; i++) {
-			if (!light_source) {
+			if (apply_shading) {
 				c = original_c;
 				applyFacesShading(c, vertices[i].Normal);
 			}
@@ -1514,7 +1520,7 @@ void MeshCollector::append(const TileLayer &layer,
 	} else {
 		vertex_count = p->vertices.size();
 		for (u32 i = 0; i < numVertices; i++) {
-			if (!light_source) {
+			if (apply_shading) {
 				c = original_c;
 				applyFacesShading(c, vertices[i].Normal);
 			}
@@ -1566,22 +1572,19 @@ void MeshCollector::applyTileColors()
 		}
 }
 
-video::SColor encode_light(u16 light, u8 emissive_light)
+video::SColor encode_light(u16 light, const u8 *emissive_light)
 {
 	// Get components
 	u32 day = (light & 0xff);
 	u32 night = (light >> 8);
 	// Add emissive light
-	night += emissive_light * 2.5f;
+	day += emissive_light[LIGHTBANK_SUN] * 2.5f;
+	night += emissive_light[LIGHTBANK_ARTIFICIAL] * 2.5f;
+	if (day > 255)
+		day = 255;
 	if (night > 255)
 		night = 255;
-	// Since we don't know if the day light is sunlight or
-	// artificial light, assume it is artificial when the night
-	// light bank is also lit.
-	if (day < night)
-		day = 0;
-	else
-		day = day - night;
+
 	u32 sum = day + night;
 	// Ratio of sunlight:
 	u32 r;
@@ -1593,3 +1596,4 @@ video::SColor encode_light(u16 light, u8 emissive_light)
 	float b = (day + night) / 2;
 	return video::SColor(r, b, b, b);
 }
+

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -209,11 +209,11 @@ struct MeshCollector
 	void append(const TileSpec &material,
 				const video::S3DVertex *vertices, u32 numVertices,
 				const u16 *indices, u32 numIndices, v3f pos,
-				video::SColor c, u8 light_source);
+				video::SColor c, bool apply_shading);
 	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices, v3f pos,
-			video::SColor c, u8 light_source, u8 layernum);
+			video::SColor c, bool apply_shading, u8 layernum);
 	/*!
 	 * Colorizes all vertices in the collector.
 	 */
@@ -229,10 +229,11 @@ struct MeshCollector
  *
  * \param light the first 8 bits are day light,
  * the last 8 bits are night light
- * \param emissive_light amount of light the surface emits,
- * from 0 to LIGHT_SUN.
+ * \param emissive_light amount of light the surface emits
+ * in both light banks, from 0 to LIGHT_SUN.
+ * emissive_light[0] is sunlight and emissive_light[1] is artificial light.
  */
-video::SColor encode_light(u16 light, u8 emissive_light);
+video::SColor encode_light(u16 light, const u8 *emissive_light);
 
 // Compute light at node
 u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef);

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -529,11 +529,13 @@ void Mapgen::spreadLight(v3s16 nmin, v3s16 nmax)
 				// TODO(hmmmmm): Abstract away direct param1 accesses with a
 				// wrapper, but something lighter than MapNode::get/setLight
 
-				u8 light_produced = cf.light_source;
-				if (light_produced)
-					n.param1 = light_produced | (light_produced << 4);
+				u8 light_sun = MYMAX(n.param1 & 0x0f,
+					cf.light_source[LIGHTBANK_SUN]);
+				// There is no artificial light there yet.
+				u8 light = light_sun
+					| (cf.light_source[LIGHTBANK_ARTIFICIAL] << 4);
 
-				u8 light = n.param1;
+				n.param1 = light;
 				if (light) {
 					lightSpread(a, v3s16(x,     y,     z + 1), light);
 					lightSpread(a, v3s16(x,     y + 1, z    ), light);

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -69,12 +69,12 @@ void MapNode::setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f
 	// If node doesn't contain light data, ignore this
 	if(f.param_type != CPT_LIGHT)
 		return;
-	if(bank == LIGHTBANK_DAY)
+	if(bank == LIGHTBANK_SUN)
 	{
 		param1 &= 0xf0;
 		param1 |= a_light & 0x0f;
 	}
-	else if(bank == LIGHTBANK_NIGHT)
+	else if(bank == LIGHTBANK_ARTIFICIAL)
 	{
 		param1 &= 0x0f;
 		param1 |= (a_light & 0x0f)<<4;
@@ -111,7 +111,7 @@ u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
 
 	u8 light;
 	if(f.param_type == CPT_LIGHT)
-		light = bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f;
+		light = bank == LIGHTBANK_SUN ? param1 & 0x0f : (param1 >> 4) & 0x0f;
 	else
 		light = 0;
 
@@ -121,14 +121,14 @@ u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
 u8 MapNode::getLightRaw(enum LightBank bank, const ContentFeatures &f) const
 {
 	if(f.param_type == CPT_LIGHT)
-		return bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f;
+		return bank == LIGHTBANK_SUN ? param1 & 0x0f : (param1 >> 4) & 0x0f;
 	return 0;
 }
 
 u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f) const
 {
 	return MYMAX(f->light_source,
-	             bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f);
+	             bank == LIGHTBANK_SUN ? param1 & 0x0f : (param1 >> 4) & 0x0f);
 }
 
 bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -73,8 +73,8 @@ typedef u16 content_t;
 
 enum LightBank
 {
-	LIGHTBANK_DAY,
-	LIGHTBANK_NIGHT
+	LIGHTBANK_SUN,
+	LIGHTBANK_ARTIFICIAL
 };
 
 /*

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -71,10 +71,12 @@ typedef u16 content_t;
 */
 #define CONTENT_IGNORE 127
 
+#define LIGHTBANK_COUNT 2
+
 enum LightBank
 {
-	LIGHTBANK_SUN,
-	LIGHTBANK_ARTIFICIAL
+	LIGHTBANK_SUN = 0,
+	LIGHTBANK_ARTIFICIAL = 1
 };
 
 /*
@@ -230,7 +232,8 @@ struct MapNode
 	 */
 	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f) const;
 
-	bool getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const;
+	void getLightBanks(u8 &lightsun, u8 &lightartificial,
+		INodeDefManager *nodemgr) const;
 
 	// 0 <= daylight_factor <= 1000
 	// 0 <= return value <= LIGHT_SUN

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -357,7 +357,8 @@ void ContentFeatures::reset()
 	liquid_renewable = true;
 	liquid_range = LIQUID_LEVEL_MAX+1;
 	drowning = 0;
-	light_source = 0;
+	for (int bank = 0; bank < LIGHTBANK_COUNT; ++bank)
+		light_source[bank] = 0;
 	damage_per_second = 0;
 	node_box = NodeBox();
 	selection_box = NodeBox();
@@ -430,7 +431,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	// lighting
 	writeU8(os, light_propagates);
 	writeU8(os, sunlight_propagates);
-	writeU8(os, light_source);
+	writeU8(os, light_source[LIGHTBANK_ARTIFICIAL]);
 
 	// map generation
 	writeU8(os, is_ground_content);
@@ -545,8 +546,9 @@ void ContentFeatures::deSerialize(std::istream &is)
 	// lighting-related
 	light_propagates = readU8(is);
 	sunlight_propagates = readU8(is);
-	light_source = readU8(is);
-	light_source = MYMIN(light_source, LIGHT_MAX);
+	light_source[LIGHTBANK_ARTIFICIAL] = readU8(is);
+	light_source[LIGHTBANK_ARTIFICIAL] = MYMIN(
+		light_source[LIGHTBANK_ARTIFICIAL], LIGHT_MAX);
 
 	// map generation
 	is_ground_content = readU8(is);
@@ -1601,7 +1603,7 @@ void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
 		os << serializeString(liquid_alternative_source);
 		writeU8(os, liquid_viscosity);
 		writeU8(os, liquid_renewable);
-		writeU8(os, light_source);
+		writeU8(os, light_source[LIGHTBANK_ARTIFICIAL]);
 		writeU32(os, damage_per_second);
 		node_box.serialize(os, protocol_version);
 		selection_box.serialize(os, protocol_version);
@@ -1672,8 +1674,9 @@ void ContentFeatures::deSerializeOld(std::istream &is, int version)
 		liquid_alternative_flowing = deSerializeString(is);
 		liquid_alternative_source = deSerializeString(is);
 		liquid_viscosity = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
+		light_source[LIGHTBANK_ARTIFICIAL] = readU8(is);
+		light_source[LIGHTBANK_ARTIFICIAL] = MYMIN(
+			light_source[LIGHTBANK_ARTIFICIAL], LIGHT_MAX);
 		damage_per_second = readU32(is);
 		node_box.deSerialize(is);
 		selection_box.deSerialize(is);
@@ -1723,7 +1726,9 @@ void ContentFeatures::deSerializeOld(std::istream &is, int version)
 		liquid_alternative_source = deSerializeString(is);
 		liquid_viscosity = readU8(is);
 		liquid_renewable = readU8(is);
-		light_source = readU8(is);
+		light_source[LIGHTBANK_ARTIFICIAL] = readU8(is);
+		light_source[LIGHTBANK_ARTIFICIAL] = MYMIN(
+			light_source[LIGHTBANK_ARTIFICIAL], LIGHT_MAX);
 		damage_per_second = readU32(is);
 		node_box.deSerialize(is);
 		selection_box.deSerialize(is);
@@ -1777,8 +1782,9 @@ void ContentFeatures::deSerializeOld(std::istream &is, int version)
 		liquid_alternative_source = deSerializeString(is);
 		liquid_viscosity = readU8(is);
 		liquid_renewable = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
+		light_source[LIGHTBANK_ARTIFICIAL] = readU8(is);
+		light_source[LIGHTBANK_ARTIFICIAL] = MYMIN(
+			light_source[LIGHTBANK_ARTIFICIAL], LIGHT_MAX);
 		damage_per_second = readU32(is);
 		node_box.deSerialize(is);
 		selection_box.deSerialize(is);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -305,8 +305,8 @@ struct ContentFeatures
 
 	bool light_propagates;
 	bool sunlight_propagates;
-	// Amount of light the node emits
-	u8 light_source;
+	// Amount of light the node emits in each light bank
+	u8 light_source[LIGHTBANK_COUNT];
 
 	// --- MAP GENERATION ---
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -577,13 +577,13 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	f.drowning = getintfield_default(L, index,
 			"drowning", f.drowning);
 	// Amount of light the node emits
-	f.light_source = getintfield_default(L, index,
-			"light_source", f.light_source);
-	if (f.light_source > LIGHT_MAX) {
+	f.light_source[LIGHTBANK_ARTIFICIAL] = getintfield_default(L, index,
+		"light_source", f.light_source[LIGHTBANK_ARTIFICIAL]);
+	if (f.light_source[LIGHTBANK_ARTIFICIAL] > LIGHT_MAX) {
 		warningstream << "Node " << f.name.c_str()
 			<< " had greater light_source than " << LIGHT_MAX
 			<< ", it was reduced." << std::endl;
-		f.light_source = LIGHT_MAX;
+		f.light_source[LIGHTBANK_ARTIFICIAL] = LIGHT_MAX;
 	}
 	f.damage_per_second = getintfield_default(L, index,
 			"damage_per_second", f.damage_per_second);

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -225,8 +225,15 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 		return 0;
 
 	u8 light;
-	light  = (getintfield_default(L, 2, "day",   0) & 0x0F);
-	light |= (getintfield_default(L, 2, "night", 0) & 0x0F) << 4;
+	u8 sun;
+	u8 artificial;
+	if (!(getintfield(L, 2, "sun", sun)
+			&& getintfield(L, 2, "artificial", artificial))) {
+		// Backwards compatibility
+		sun = (getintfield_default(L, 2, "day", 0) & 0x0F);
+		artificial = (getintfield_default(L, 2, "night", 0) & 0x0F);
+	}
+	light = (sun & 0x0F) | ((artificial & 0x0F) << 4);
 
 	MMVManip *vm = o->vm;
 

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -63,13 +63,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	25: Improved node timer format
 	26: Never written; read the same as 25
 	27: Added light spreading flags to blocks
+	28: Change light banks: sunlight and artificial light
 */
 // This represents an uninitialized or invalid format
 #define SER_FMT_VER_INVALID 255
 // Highest supported serialization version
-#define SER_FMT_VER_HIGHEST_READ 27
+#define SER_FMT_VER_HIGHEST_READ 28
 // Saved on disk version
-#define SER_FMT_VER_HIGHEST_WRITE 27
+#define SER_FMT_VER_HIGHEST_WRITE 28
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST_READ 0
 // Lowest serialization version for writing

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -154,7 +154,7 @@ void TestGameDef::defineSomeNodes()
 	f.param_type = CPT_LIGHT;
 	f.light_propagates = true;
 	f.sunlight_propagates = true;
-	f.light_source = LIGHT_MAX-1;
+	f.light_source[LIGHTBANK_ARTIFICIAL] = LIGHT_MAX-1;
 	idef->registerItem(itemdef);
 	t_CONTENT_TORCH = ndef->set(f.name, f);
 
@@ -193,7 +193,7 @@ void TestGameDef::defineSomeNodes()
 	f.alpha = 128;
 	f.liquid_type = LIQUID_SOURCE;
 	f.liquid_viscosity = 7;
-	f.light_source = LIGHT_MAX-1;
+	f.light_source[LIGHTBANK_ARTIFICIAL] = LIGHT_MAX-1;
 	f.is_ground_content = true;
 	f.groups["liquids"] = 3;
 	for(int i = 0; i < 6; i++)

--- a/src/unittest/test_mapnode.cpp
+++ b/src/unittest/test_mapnode.cpp
@@ -48,8 +48,8 @@ void TestMapNode::testNodeProperties(INodeDefManager *nodedef)
 	MapNode n(CONTENT_AIR);
 
 	UASSERT(n.getContent() == CONTENT_AIR);
-	UASSERT(n.getLight(LIGHTBANK_DAY, nodedef) == 0);
-	UASSERT(n.getLight(LIGHTBANK_NIGHT, nodedef) == 0);
+	UASSERT(n.getLight(LIGHTBANK_SUN, nodedef) == 0);
+	UASSERT(n.getLight(LIGHTBANK_ARTIFICIAL, nodedef) == 0);
 
 	// Transparency
 	n.setContent(CONTENT_AIR);

--- a/src/unittest/test_voxelalgorithms.cpp
+++ b/src/unittest/test_voxelalgorithms.cpp
@@ -68,7 +68,7 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 				v, a, true, light_sources, ndef);
 		//v.print(dstream, ndef, VOXELPRINT_LIGHT_DAY);
 		UASSERT(res.bottom_sunlight_valid == true);
-		UASSERT(v.getNode(v3s16(1,1,1)).getLight(LIGHTBANK_DAY, ndef)
+		UASSERT(v.getNode(v3s16(1,1,1)).getLight(LIGHTBANK_SUN, ndef)
 				== LIGHT_SUN);
 	}
 
@@ -80,7 +80,7 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 		voxalgo::SunlightPropagateResult res = voxalgo::propagateSunlight(
 				v, a, true, light_sources, ndef);
 		UASSERT(res.bottom_sunlight_valid == true);
-		UASSERT(v.getNode(v3s16(1,1,1)).getLight(LIGHTBANK_DAY, ndef)
+		UASSERT(v.getNode(v3s16(1,1,1)).getLight(LIGHTBANK_SUN, ndef)
 				== LIGHT_SUN);
 	}
 
@@ -90,7 +90,7 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 		voxalgo::SunlightPropagateResult res = voxalgo::propagateSunlight(
 				v, a, false, light_sources, ndef);
 		UASSERT(res.bottom_sunlight_valid == true);
-		UASSERT(v.getNode(v3s16(2,0,2)).getLight(LIGHTBANK_DAY, ndef)
+		UASSERT(v.getNode(v3s16(2,0,2)).getLight(LIGHTBANK_SUN, ndef)
 				== 0);
 	}
 
@@ -102,7 +102,7 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 		voxalgo::SunlightPropagateResult res = voxalgo::propagateSunlight(
 				v, a, true, light_sources, ndef);
 		UASSERT(res.bottom_sunlight_valid == true);
-		UASSERT(v.getNode(v3s16(1,1,2)).getLight(LIGHTBANK_DAY, ndef)
+		UASSERT(v.getNode(v3s16(1,1,2)).getLight(LIGHTBANK_SUN, ndef)
 				== 0);
 	}
 
@@ -112,13 +112,13 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 		voxalgo::SunlightPropagateResult res = voxalgo::propagateSunlight(
 				v, a, false, light_sources, ndef);
 		UASSERT(res.bottom_sunlight_valid == true);
-		UASSERT(v.getNode(v3s16(1,0,2)).getLight(LIGHTBANK_DAY, ndef)
+		UASSERT(v.getNode(v3s16(1,0,2)).getLight(LIGHTBANK_SUN, ndef)
 				== 0);
 	}
 
 	{
 		MapNode n(CONTENT_AIR);
-		n.setLight(LIGHTBANK_DAY, 10, ndef);
+		n.setLight(LIGHTBANK_SUN, 10, ndef);
 		v.setNodeNoRef(v3s16(1,-1,2), n);
 	}
 
@@ -140,7 +140,7 @@ void TestVoxelAlgorithms::testPropogateSunlight(INodeDefManager *ndef)
 
 	{
 		MapNode n(CONTENT_AIR);
-		n.setLight(LIGHTBANK_DAY, LIGHT_SUN, ndef);
+		n.setLight(LIGHTBANK_SUN, LIGHT_SUN, ndef);
 		v.setNodeNoRef(v3s16(1,-1,2), n);
 	}
 
@@ -188,17 +188,17 @@ void TestVoxelAlgorithms::testClearLightAndCollectSources(INodeDefManager *ndef)
 
 	{
 		MapNode n(CONTENT_AIR);
-		n.setLight(LIGHTBANK_DAY, 1, ndef);
+		n.setLight(LIGHTBANK_SUN, 1, ndef);
 		v.setNode(v3s16(1,1,2), n);
 	}
 
 	{
 		std::set<v3s16> light_sources;
 		std::map<v3s16, u8> unlight_from;
-		voxalgo::clearLightAndCollectSources(v, a, LIGHTBANK_DAY,
+		voxalgo::clearLightAndCollectSources(v, a, LIGHTBANK_SUN,
 				ndef, light_sources, unlight_from);
 		//v.print(dstream, ndef, VOXELPRINT_LIGHT_DAY);
-		UASSERT(v.getNode(v3s16(0,1,1)).getLight(LIGHTBANK_DAY, ndef) == 0);
+		UASSERT(v.getNode(v3s16(0,1,1)).getLight(LIGHTBANK_SUN, ndef) == 0);
 		UASSERT(light_sources.find(v3s16(1,1,1)) != light_sources.end());
 		UASSERT(light_sources.size() == 1);
 		UASSERT(unlight_from.find(v3s16(1,1,2)) != unlight_from.end());

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -114,17 +114,19 @@ void VoxelManipulator::print(std::ostream &o, INodeDefManager *ndef,
 					}
 					else if(mode == VOXELPRINT_LIGHT_DAY)
 					{
-						if(ndef->get(m).light_source != 0)
+						const ContentFeatures &cf=ndef->get(m);
+						if ((cf.light_source[LIGHTBANK_SUN] != 0)
+							|| (cf.light_source[LIGHTBANK_ARTIFICIAL] != 0))
 							c = 'S';
-						else if(ndef->get(m).light_propagates == false)
+						else if (ndef->get(m).light_propagates == false)
 							c = 'X';
-						else
-						{
-							u8 light = n.getLight(LIGHTBANK_SUN, ndef);
-							if(light < 10)
+						else {
+							u8 light = MYMAX(n.getLight(LIGHTBANK_SUN, ndef),
+								n.getLight(LIGHTBANK_ARTIFICIAL, ndef));
+							if (light < 10)
 								c = '0' + light;
 							else
-								c = 'a' + (light-10);
+								c = 'a' + (light - 10);
 						}
 					}
 				}

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -120,7 +120,7 @@ void VoxelManipulator::print(std::ostream &o, INodeDefManager *ndef,
 							c = 'X';
 						else
 						{
-							u8 light = n.getLight(LIGHTBANK_DAY, ndef);
+							u8 light = n.getLight(LIGHTBANK_SUN, ndef);
 							if(light < 10)
 								c = '0' + light;
 							else

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -60,7 +60,7 @@ void clearLightAndCollectSources(VoxelManipulator &v, VoxelArea a,
 		n.setLight(bank, 0, ndef);
 
 		// If node sources light, add to list
-		u8 source = ndef->get(n).light_source;
+		u8 source = ndef->get(n).light_source[LIGHTBANK_ARTIFICIAL];
 		if(source != 0)
 			light_sources.insert(p);
 
@@ -407,7 +407,7 @@ void unspread_light(Map *map, INodeDefManager *nodemgr, LightBank bank,
 		const ContentFeatures &f = nodemgr->get(node);
 		// If the node emits light, it behaves like it had a
 		// brighter neighbor.
-		u8 brightest_neighbor_light = f.light_source + 1;
+		u8 brightest_neighbor_light = f.light_source[bank] + 1;
 		for (direction i = 0; i < 6; i++) {
 			//For each neighbor
 
@@ -453,8 +453,8 @@ void unspread_light(Map *map, INodeDefManager *nodemgr, LightBank bank,
 				}
 			} else {
 				// The neighbor can light up this node.
-				if (neighbor_light < neighbor_f.light_source) {
-					neighbor_light = neighbor_f.light_source;
+				if (neighbor_light < neighbor_f.light_source[bank]) {
+					neighbor_light = neighbor_f.light_source[bank];
 				}
 				if (brightest_neighbor_light < neighbor_light) {
 					brightest_neighbor_light = neighbor_light;
@@ -662,7 +662,7 @@ void update_lighting_nodes(Map *map,
 					&& is_sunlight_above(map, p, ndef)) {
 					new_light = LIGHT_SUN;
 				} else {
-					new_light = ndef->get(n).light_source;
+					new_light = ndef->get(n).light_source[bank];
 					for (int i = 0; i < 6; i++) {
 						v3s16 p2 = p + neighbor_dirs[i];
 						bool is_valid;
@@ -679,7 +679,7 @@ void update_lighting_nodes(Map *map,
 				}
 			} else {
 				// If this is an opaque node, it still can emit light.
-				new_light = ndef->get(n).light_source;
+				new_light = ndef->get(n).light_source[bank];
 			}
 
 			if (new_light > 0) {
@@ -811,8 +811,8 @@ bool is_light_locally_correct(Map *map, INodeDefManager *ndef, LightBank bank,
 		return true;
 	}
 	u8 light = n.getLightNoChecks(bank, &f);
-	assert(f.light_source <= LIGHT_MAX);
-	u8 brightest_neighbor = f.light_source + 1;
+	assert(f.light_source[bank] <= LIGHT_MAX);
+	u8 brightest_neighbor = f.light_source[bank] + 1;
 	for (direction d = 0; d < 6; ++d) {
 		MapNode n2 = map->getNodeNoEx(pos + neighbor_dirs[d],
 			&is_valid_position);
@@ -1153,7 +1153,7 @@ void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 				LightBank bank = banks[b];
 				u8 light = f.param_type == CPT_LIGHT ?
 					node.getLightNoChecks(bank, &f):
-					f.light_source;
+					f.light_source[bank];
 				if (light > 1)
 					relight[b].push(light, relpos, blockpos, block, 6);
 			} // end of banks
@@ -1261,7 +1261,7 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
 						LIGHT_SUN; // no light information, force unlighting
 					u8 newlight = newf.param_type == CPT_LIGHT ?
 						newnode.getLightNoChecks(bank, &newf):
-						newf.light_source;
+						newf.light_source[bank];
 					// If the new node is dimmer, unlight.
 					if (oldlight > newlight) {
 						unlight[b].push(
@@ -1384,7 +1384,7 @@ void repair_block_light(ServerMap *map, MapBlock *block,
 				LightBank bank = banks[b];
 				u8 light = f.param_type == CPT_LIGHT ?
 					node.getLightNoChecks(bank, &f):
-					f.light_source;
+					f.light_source[bank];
 				// If the new node is dimmer than sunlight, unlight.
 				// (if it has maximal light, it is pointless to remove
 				// surrounding light, as it can only become brighter)

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -102,9 +102,11 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
  * For server use only.
  *
  * \param block the block to update
+ * \param load_top if true, the block above the corrected
+ * block is also loaded, to prevent the need of sunlight prediction.
  */
 void repair_block_light(ServerMap *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> *modified_blocks);
+	bool load_top, std::map<v3s16, MapBlock*> *modified_blocks);
 
 /*!
  * This class iterates trough voxels that intersect with


### PR DESCRIPTION
**WARNING: if you open your world with this version, it gets converted and you won't be able to open it with other versions anymore!**

The goal is this PR to change the light banks' meaning to sunlight + artificial light.

The request is still WIP, because the conversion sometimes causes dark blocks, and I don't know yet why.

What will change:
- the map format increases
- old server - new server: when first loaded, the world is automatically converted to the new format, erasing the old light information. This might slow down the map loading, but once the conversion is done, no more processing is required.
- old client - new server: the blocks get converted back when they are sent to the clients. Old clients should see no change in the lighting. Currently all `param1` values are converted, even if they contain no light information. I hope this won't cause any side effects.
- new client - old server: the client has to guess the amount of sunlight. The current implementation works well with artificial sources if they are either in direct sunlight or in darkness. But there is an ugly jump in brightness if the artificial light and sunlight meet each other, while the artificial source is in darkness. Again, currently all `param1` values are converted, even if they contain no light information. I hope this won't cause any side effects.
![light_edge](https://cloud.githubusercontent.com/assets/20600448/25577668/444455e8-2e68-11e7-8c86-2be9b9b2f2e8.png)
- `sunlight_source` for nodes was introduced to make light calculations uniform. This property is not exposed to Lua yet.
- graphics: now artificial light sources are brighter if they are in sunlight. Since the light sources produce maximal brightness without sunlight, in sunlight their brightness is clamped.
![light_clamp](https://cloud.githubusercontent.com/assets/20600448/25577661/396eb942-2e68-11e7-9fe0-d06576f2ffda.png)

I hope I did not forget anything. Please let me know what you think, how should this pull change!