### PR TITLE
Clouds: Fix reddish clouds. Add missing alpha update 

### DIFF
--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -61,7 +61,7 @@ Clouds::Clouds(
 
 	m_params.density       = 0.4f;
 	m_params.thickness     = 16.0f;
-	m_params.color_bright  = video::SColor(229, 255, 240, 240);
+	m_params.color_bright  = video::SColor(229, 240, 240, 255);
 	m_params.color_ambient = video::SColor(255, 0, 0, 0);
 	m_params.speed         = v2f(0.0f, -2.0f);
 

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -68,7 +68,7 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 
 	// copy defaults
 	m_cloud_params.density = 0.4f;
-	m_cloud_params.color_bright = video::SColor(255, 255, 240, 240);
+	m_cloud_params.color_bright = video::SColor(229, 240, 240, 255);
 	m_cloud_params.color_ambient = video::SColor(255, 0, 0, 0);
 	m_cloud_params.height = 120.0f;
 	m_cloud_params.thickness = 16.0f;

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -609,7 +609,7 @@ void Sky::update(float time_of_day, float time_brightness,
 	);
 
 	// Horizon coloring based on sun and moon direction during sunset and sunrise
-	video::SColor pointcolor = video::SColor(255, 255, 255, m_bgcolor.getAlpha());
+	video::SColor pointcolor = video::SColor(m_bgcolor.getAlpha(), 255, 255, 255);
 	if (m_directional_colored_fog) {
 		if (m_horizon_blend() != 0) {
 			// Calculate hemisphere value from yaw, (inverted in third person front view)


### PR DESCRIPTION
Fix accidental swap of red and blue components that caused reddish clouds
Add missing update of alpha in remoteplayer.cpp
//////////////////////////////////////////////////////////
2nd commit:
Directional coloured fog: Fix order of SColor components
'video::SColor pointcolor' was initialised with order RGBA instead of ARGB.
No change in behaviour as 'm_bgcolor' has alpha 255.
/////////////////////////////////////////////////

![screenshot_20170502_015417](https://cloud.githubusercontent.com/assets/3686677/25600206/705f184e-2eda-11e7-8bbf-a6827c3ff82e.png)

^ This PR

Addresses #5692 
WIP as the alpha component may need to be 229 instead of 255, the 2 sets of values do not match @bendeutsch is this the case or is it intended?
Also should test dawn/dusk colours.

Initial test on screenshot above:
Underside:
H 229 S 11 V 82
N,S:
H 227 S 10 V 95
E,W:
H 227 S 10 V 91

Compare to old clouds:
Underside:
H 229 S 10 V 82
N,S:
H 227 S 10 V 95
E,W:
H 227 S 10 V 91

Seems good.