### PR TITLE
Add keys as alternatives to mouse movement

### DIFF
--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -49,6 +49,8 @@ public:
 					keyIsDown.set(keyCode);
 					keyWasDown.set(keyCode);
 				} else {
+					if (keyIsDown.get(keyCode))
+						keyWasReleased.set(keyCode);
 					keyIsDown.unset(keyCode);
 				}
 				return true;
@@ -129,6 +131,15 @@ public:
 		return b;
 	}
 
+	// Checks whether a key was released and resets the state
+	bool WasKeyReleased(const KeyPress &keyCode)
+	{
+		bool b = keyWasReleased[keyCode];
+		if (b)
+			keyWasReleased.unset(keyCode);
+		return b;
+	}
+
 	void listenForKey(const KeyPress &keyCode)
 	{
 		keysListenedFor.set(keyCode);
@@ -192,6 +203,8 @@ private:
 	KeyList keyIsDown;
 	// Whether a key has been pressed or not
 	KeyList keyWasDown;
+	// Wether a key has been released or not
+	KeyList keyWasReleased;
 	// List of keys we listen for
 	// TODO perhaps the type of this is not really
 	// performant as KeyList is designed for few but
@@ -222,6 +235,10 @@ public:
 	virtual bool wasKeyDown(const KeyPress &keyCode)
 	{
 		return m_receiver->WasKeyDown(keyCode);
+	}
+	virtual bool wasKeyReleased(const KeyPress &keyCode)
+	{
+		return m_receiver->WasKeyReleased(keyCode);
 	}
 	virtual void listenForKey(const KeyPress &keyCode)
 	{
@@ -327,6 +344,10 @@ public:
 		return keydown[keyCode];
 	}
 	virtual bool wasKeyDown(const KeyPress &keyCode)
+	{
+		return false;
+	}
+	virtual bool wasKeyReleased(const KeyPress &keyCode)
 	{
 		return false;
 	}

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -77,6 +77,16 @@ public:
 		SCROLL_UP,
 		SCROLL_DOWN,
 
+		// Mouse move alternatives
+		ROTATE_UP,
+		ROTATE_DOWN,
+		ROTATE_LEFT,
+		ROTATE_RIGHT,
+
+		//Mouse button alternatives
+		MOUSE_BUTTON_ALT_LEFT,
+		MOUSE_BUTTON_ALT_RIGHT,
+
 		// Fake keycode for array size and internal checks
 		INTERNAL_ENUM_COUNT
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -84,6 +84,12 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_toggle_hud", "KEY_F1");
 	settings->setDefault("keymap_toggle_chat", "KEY_F2");
 	settings->setDefault("keymap_toggle_force_fog_off", "KEY_F3");
+	settings->setDefault("keymap_rotate_up", "KEY_UP");
+	settings->setDefault("keymap_rotate_down", "KEY_DOWN");
+	settings->setDefault("keymap_rotate_left", "KEY_LEFT");
+	settings->setDefault("keymap_rotate_right", "KEY_RIGHT");
+	settings->setDefault("keymap_mouse_button_alt_left", "KEY_BACK");
+	settings->setDefault("keymap_mouse_button_alt_right", "KEY_RETURN");
 #if DEBUG
 	settings->setDefault("keymap_toggle_update_camera", "KEY_F4");
 #else

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1068,6 +1068,14 @@ void KeyCache::populate()
 			= getKeySetting("keymap_rangeselect");
 	key[KeyType::ZOOM] = getKeySetting("keymap_zoom");
 
+	key[KeyType::ROTATE_UP]    = getKeySetting("keymap_rotate_up");
+	key[KeyType::ROTATE_DOWN]  = getKeySetting("keymap_rotate_down");
+	key[KeyType::ROTATE_LEFT]  = getKeySetting("keymap_rotate_left");
+	key[KeyType::ROTATE_RIGHT] = getKeySetting("keymap_rotate_right");
+
+	key[KeyType::MOUSE_BUTTON_ALT_LEFT]  = getKeySetting("keymap_mouse_button_alt_left");
+	key[KeyType::MOUSE_BUTTON_ALT_RIGHT] = getKeySetting("keymap_mouse_button_alt_right");
+
 	key[KeyType::QUICKTUNE_NEXT] = getKeySetting("keymap_quicktune_next");
 	key[KeyType::QUICKTUNE_PREV] = getKeySetting("keymap_quicktune_prev");
 	key[KeyType::QUICKTUNE_INC]  = getKeySetting("keymap_quicktune_inc");
@@ -1296,27 +1304,32 @@ protected:
 	inline bool getLeftClicked()
 	{
 		return input->getLeftClicked() ||
-			input->joystick.getWasKeyDown(KeyType::MOUSE_L);
+			input->joystick.getWasKeyDown(KeyType::MOUSE_L) ||
+			wasKeyDown(KeyType::MOUSE_BUTTON_ALT_LEFT);
 	}
 	inline bool getRightClicked()
 	{
 		return input->getRightClicked() ||
-			input->joystick.getWasKeyDown(KeyType::MOUSE_R);
+			input->joystick.getWasKeyDown(KeyType::MOUSE_R) ||
+			wasKeyDown(KeyType::MOUSE_BUTTON_ALT_RIGHT);
 	}
 	inline bool isLeftPressed()
 	{
 		return input->getLeftState() ||
-			input->joystick.isKeyDown(KeyType::MOUSE_L);
+			input->joystick.isKeyDown(KeyType::MOUSE_L) ||
+			isKeyDown(KeyType::MOUSE_BUTTON_ALT_LEFT);
 	}
 	inline bool isRightPressed()
 	{
 		return input->getRightState() ||
-			input->joystick.isKeyDown(KeyType::MOUSE_R);
+			input->joystick.isKeyDown(KeyType::MOUSE_R) ||
+			isKeyDown(KeyType::MOUSE_BUTTON_ALT_RIGHT);
 	}
 	inline bool getLeftReleased()
 	{
 		return input->getLeftReleased() ||
-			input->joystick.wasKeyReleased(KeyType::MOUSE_L);
+			input->joystick.wasKeyReleased(KeyType::MOUSE_L) ||
+			wasKeyReleased(KeyType::MOUSE_BUTTON_ALT_LEFT);
 	}
 
 	inline bool isKeyDown(GameKeyType k)
@@ -1326,6 +1339,10 @@ protected:
 	inline bool wasKeyDown(GameKeyType k)
 	{
 		return input->wasKeyDown(keycache.key[k]) || input->joystick.wasKeyDown(k);
+	}
+	inline bool wasKeyReleased(GameKeyType k)
+	{
+		return input->wasKeyReleased(keycache.key[k]) || input->joystick.wasKeyReleased(k);
 	}
 
 #ifdef __ANDROID__
@@ -2959,6 +2976,15 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 		if (m_invert_mouse || camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT) {
 			dy = -dy;
 		}
+
+		if (isKeyDown(KeyType::ROTATE_UP))
+			dy -= 7;
+		if (isKeyDown(KeyType::ROTATE_DOWN))
+			dy += 7;
+		if (isKeyDown(KeyType::ROTATE_LEFT))
+			dx -= 7;
+		if (isKeyDown(KeyType::ROTATE_RIGHT))
+			dx += 7;
 
 		cam->camera_yaw   -= dx * m_cache_mouse_sensitivity;
 		cam->camera_pitch += dy * m_cache_mouse_sensitivity;

--- a/src/game.h
+++ b/src/game.h
@@ -69,6 +69,14 @@ public:
 		super::clear();
 	}
 
+	bool get(const KeyPress &key)
+	{
+		if (find(key) == end())
+			return false;
+		else
+			return true;
+	}
+
 	void set(const KeyPress &key)
 	{
 		if (find(key) == end())
@@ -111,6 +119,7 @@ public:
 
 	virtual bool isKeyDown(const KeyPress &keyCode) = 0;
 	virtual bool wasKeyDown(const KeyPress &keyCode) = 0;
+	virtual bool wasKeyReleased(const KeyPress &keyCode) = 0;
 
 	virtual void listenForKey(const KeyPress &keyCode) {}
 	virtual void dontListenForKeys() {}


### PR DESCRIPTION
Arrow keys by default for rotation
Enter and backspace by default for placing/digging

See #5696 

This will probably need further improvement. It is mainly thought as a Proof of Concept. However, I think it already works quite well during normal gameplay.

Note: This only affects the camera movements, not the mouse movements in forms etc.

- [x] Add alternatives for clicking on the mouse
- [ ] Add documentation
- [ ] When placing many nodes by pressing and holding enter, this seems to be much to fast. If someone could provide a good patch, this would be very nice.