### PR TITLE
Clouds API: Fix yellow clouds at dawn and dusk

### DIFF
--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -360,7 +360,7 @@ void Clouds::update(v2f camera_p, video::SColorf color_diffuse)
 	m_camera_pos = camera_p;
 	m_color.r = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getRed(),
 			m_params.color_ambient.getRed()), 255) / 255.0f;
-	m_color.g = MYMIN(MYMAX(color_diffuse.r * m_params.color_bright.getGreen(),
+	m_color.g = MYMIN(MYMAX(color_diffuse.g * m_params.color_bright.getGreen(),
 			m_params.color_ambient.getGreen()), 255) / 255.0f;
 	m_color.b = MYMIN(MYMAX(color_diffuse.b * m_params.color_bright.getBlue(),
 			m_params.color_ambient.getBlue()), 255) / 255.0f;


### PR DESCRIPTION
![screenshot_20170505_200655](https://cloud.githubusercontent.com/assets/3686677/25760547/29949644-31cf-11e7-82ef-7ecd81e6991b.png)

^ This PR with directional coloured fog disabled.

![screenshot_20170505_200743](https://cloud.githubusercontent.com/assets/3686677/25760565/447c8cc8-31cf-11e7-87f2-9158aa0e58d3.png)

^ This PR with directional coloured fog enabled.

Fixes #5701 
See https://github.com/minetest/minetest/issues/5701#issuecomment-299376517 it was a single character typo. Explains everything i experienced.