### PR TITLE
Rework escape/pause menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4551,7 +4551,7 @@ void Game::showPauseMenu()
 
 #endif
 
-	float ypos = simple_singleplayer_mode ? 0.7 : 0.1;
+	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
 	std::ostringstream os;
 
 	os << FORMSPEC_VERSION_STRING  << SIZE_TAG
@@ -4562,7 +4562,7 @@ void Game::showPauseMenu()
 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_change_password;"
 			<< strgettext("Change Password") << "]";
 	} else {
-		os << "textarea[4.95,0.16;3.5,6;;" << strgettext("Game Paused") << ";]";
+		os << "textarea[4.95,0;3.5,6;;" << strgettext("Game Paused") << ";]";
 	}
 
 
@@ -4580,23 +4580,23 @@ void Game::showPauseMenu()
 		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
 		<< "\n"
 		<<  strgettext("Game info:") << "\n";
-	std::string address = client->getAddressName();
-	const static std::string mode = strgettext("- Mode: ");
+	const std::string &address = client->getAddressName();
+	static const std::string mode = strgettext("- Mode: ");
 	if (!simple_singleplayer_mode) {
 		Address serverAddress = client->getServerAddress();
-		if(address != "") {
+		if (address != "") {
 			os << mode << strgettext("Remote server") << "\n"
 					<< strgettext("- Address: ") << address;
 		} else {
-			os << mode << strgettext("Hosting Server");
+			os << mode << strgettext("Hosting server");
 		}
 		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
 	} else {
 		os << mode << strgettext("Singleplayer") << "\n";
 	}
 	if (simple_singleplayer_mode || address == "") {
-		const static std::string on = strgettext("On");
-		const static std::string off = strgettext("Off");
+		static const std::string on = strgettext("On");
+		static const std::string off = strgettext("Off");
 		std::string damage = g_settings->getBool("enable_damage") ? on : off;
 		std::string creative = g_settings->getBool("creative_mode") ? on : off;
 		std::string announced = g_settings->getBool("server_announce") ? on : off;
@@ -4607,8 +4607,8 @@ void Game::showPauseMenu()
 			os << strgettext("- PvP: ") << pvp << "\n"
 					<< strgettext("- Public: ") << announced << "\n";
 			std::string server_name = g_settings->get("server_name");
-			if(announced == on && server_name != "")
-				os << strgettext("- Server Name: ") <<  server_name;
+			if (announced == on && server_name != "")
+				os << strgettext("- Server Name: ") << server_name;
 
 		}
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4535,9 +4535,9 @@ void Game::showPauseMenu()
 		"- %s: chat\n"
 	);
 
-	 char control_text[500];
+	 char control_text_buf[500];
 
-	 snprintf(control_text, 500, control_text_template.c_str(),
+	 snprintf(control_text_buf, 500, control_text_template.c_str(),
 			 GET_KEY_NAME(keymap_forward),
 	 	 	 GET_KEY_NAME(keymap_left),
 			 GET_KEY_NAME(keymap_backward),
@@ -4551,6 +4551,8 @@ void Game::showPauseMenu()
 
 #endif
 
+	std::string control_text = std::string(control_text_buf);
+	str_formspec_escape(control_text);
 	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
 	std::ostringstream os;
 
@@ -4564,7 +4566,6 @@ void Game::showPauseMenu()
 	} else {
 		os << "field[4.95,0;5,1.5;;" << strgettext("Game Paused") << ";]";
 	}
-
 
 #ifndef __ANDROID__
 	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_sound;"
@@ -4606,7 +4607,8 @@ void Game::showPauseMenu()
 			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
 			os << strgettext("- PvP: ") << pvp << "\n"
 					<< strgettext("- Public: ") << announced << "\n";
-			const std::string &server_name = g_settings->get("server_name");
+			std::string server_name = g_settings->get("server_name");
+			str_formspec_escape(server_name);
 			if (announced == on && server_name != "")
 				os << strgettext("- Server Name: ") << server_name;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -54,6 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "sky.h"
 #include "subgame.h"
 #include "tool.h"
+#include "util/basic_macros.h"
 #include "util/directiontables.h"
 #include "util/pointedthing.h"
 #include "irrlicht_changes/static_text.h"
@@ -4537,7 +4538,7 @@ void Game::showPauseMenu()
 
 	 char control_text_buf[500];
 
-	 snprintf(control_text_buf, 500, control_text_template.c_str(),
+	 snprintf(control_text_buf, ARRLEN(control_text_buf), control_text_template.c_str(),
 			 GET_KEY_NAME(keymap_forward),
 	 	 	 GET_KEY_NAME(keymap_left),
 			 GET_KEY_NAME(keymap_backward),

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4562,7 +4562,7 @@ void Game::showPauseMenu()
 		os << "button_exit[4," << (ypos++) << ";3,0.5;btn_change_password;"
 			<< strgettext("Change Password") << "]";
 	} else {
-		os << "textarea[4.95,0;3.5,6;;" << strgettext("Game Paused") << ";]";
+		os << "field[4.95,0;5,1.5;;" << strgettext("Game Paused") << ";]";
 	}
 
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4597,16 +4597,16 @@ void Game::showPauseMenu()
 	if (simple_singleplayer_mode || address == "") {
 		static const std::string on = strgettext("On");
 		static const std::string off = strgettext("Off");
-		std::string damage = g_settings->getBool("enable_damage") ? on : off;
-		std::string creative = g_settings->getBool("creative_mode") ? on : off;
-		std::string announced = g_settings->getBool("server_announce") ? on : off;
+		const std::string &damage = g_settings->getBool("enable_damage") ? on : off;
+		const std::string &creative = g_settings->getBool("creative_mode") ? on : off;
+		const std::string &announced = g_settings->getBool("server_announce") ? on : off;
 		os << strgettext("- Damage: ") << damage << "\n"
 				<< strgettext("- Creative mode: ") << creative << "\n";
 		if (!simple_singleplayer_mode) {
-			std::string pvp = g_settings->getBool("enable_pvp") ? on : off;
+			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
 			os << strgettext("- PvP: ") << pvp << "\n"
 					<< strgettext("- Public: ") << announced << "\n";
-			std::string server_name = g_settings->get("server_name");
+			const std::string &server_name = g_settings->get("server_name");
 			if (announced == on && server_name != "")
 				os << strgettext("- Server Name: ") << server_name;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4581,31 +4581,35 @@ void Game::showPauseMenu()
 		<< "\n"
 		<<  strgettext("Game info:") << "\n";
 	std::string address = client->getAddressName();
+	const static std::string mode = strgettext("- Mode: ");
 	if (!simple_singleplayer_mode) {
 		Address serverAddress = client->getServerAddress();
 		if(address != "") {
-			os << strgettext("- Connected to remote server.") << "\n"
+			os << mode << strgettext("Remote server") << "\n"
 					<< strgettext("- Address: ") << address;
 		} else {
-			os << strgettext("- Hosting Server.");
+			os << mode << strgettext("Hosting Server");
 		}
 		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
 	} else {
-		os << strgettext("- Playing in singleplayer mode.") << "\n";
+		os << mode << strgettext("Singleplayer") << "\n";
 	}
 	if (simple_singleplayer_mode || address == "") {
 		const static std::string on = strgettext("On");
 		const static std::string off = strgettext("Off");
 		std::string damage = g_settings->getBool("enable_damage") ? on : off;
 		std::string creative = g_settings->getBool("creative_mode") ? on : off;
-
+		std::string announced = g_settings->getBool("server_announce") ? on : off;
 		os << strgettext("- Damage: ") << damage << "\n"
 				<< strgettext("- Creative mode: ") << creative << "\n";
 		if (!simple_singleplayer_mode) {
 			std::string pvp = g_settings->getBool("enable_pvp") ? on : off;
-			os << strgettext("- PvP: ") << pvp << "\n";
-			if (g_settings->getBool("server_announce"))
-				os << strgettext("- Announced to public server list");
+			os << strgettext("- PvP: ") << pvp << "\n"
+					<< strgettext("- Public: ") << announced << "\n";
+			std::string server_name = g_settings->get("server_name");
+			if(announced == on && server_name != "")
+				os << strgettext("- Server Name: ") <<  server_name;
+
 		}
 	}
 	os << ";]";

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -423,6 +423,18 @@ inline void str_replace(std::string &str, const std::string &pattern,
 }
 
 /**
+ * Escapes characters [ ] \ , ; that can not be used in formspecs
+ */
+inline void str_formspec_escape(std::string &str)
+{
+	str_replace(str, "\\", "\\\\");
+	str_replace(str, "]", "\\]");
+	str_replace(str, "[", "\\[");
+	str_replace(str, ";", "\\;");
+	str_replace(str, ",", "\\,");
+}
+
+/**
  * Replace all occurrences of the character \p from in \p str with \p to.
  *
  * @param str The string to (potentially) modify.


### PR DESCRIPTION
# Changes
- Remove build information
- Use current controls instead of default controls
- Add information about the current server in place of the build information
- Add text saying the game is paused to if in singleplayer mode.
rework pause/escape menu

see also #3845
# Screenshots
Hosting server
![screenshot_20170507_172346](https://cloud.githubusercontent.com/assets/12450071/25782416/a8079f98-3342-11e7-8d56-da7f38fdf971.png)
Singleplayer
![screenshot_20170507_172420](https://cloud.githubusercontent.com/assets/12450071/25782418/b72630d4-3342-11e7-8194-c4fec80d2f61.png)
Connected to server
![screenshot_20170507_172502](https://cloud.githubusercontent.com/assets/12450071/25782420/c0ee56be-3342-11e7-8580-8888298de601.png)


