### PR TITLE
Custom step height: Fix implementation

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -344,13 +344,11 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	}
 
-	float player_stepheight = (m_cao == 0) ? 0.0 :
-				(touching_ground ?
-				(m_cao->getStepheight() * BS) :
-				(m_cao->getStepheight() -0.4 * BS));
+	float player_stepheight = (m_cao == 0) ? 0.0f :
+			((touching_ground) ? m_cao->getStepheight() : (0.2f * BS));
 
 #ifdef __ANDROID__
-	player_stepheight += (0.6 * BS);
+	player_stepheight += (0.6f * BS);
 #endif
 
 	v3f accel_f = v3f(0,0,0);


### PR DESCRIPTION


Recent commit 45ab62d had a coding error that
made climbing out of water difficult due to an incorrect value of the step height
when not 'touching ground'.
It also incorrectly multiplied the custom stepheight by BS, resulting in being
able to step-up 2 nodes if set to the default of 0.6, or even 0.3.
Also the implementation was wrong because it customised the step height when
not 'touching ground', this step height is for a slight rise when catching the
edge of a node during a jump, and should always remain at 0.2 * BS.
/////////////////////////////////////

Fixes #5718 
Tested with custom stepheight values from 0.3 to 2.1.

Examples of problems with previous implementation:

If custom step height is set to 1.1 to climb full nodes, step height in a jump will be 0.7, meaning a big upwards teleport when colliding 0.7 nodes below a ledge.

If custom step height is set to 0.3 to only climb quarter-slabs, then step height during a jump is -0.1, meaning jumping up onto a ledge is stopped even if the player is 0.1 nodes above the ledge.