### PR TITLE
Revert custom player collision box and step height commits

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3705,9 +3705,6 @@ Definition tables
         collide_with_objects = true, -- collide with other objects if physical = true
         weight = 5,
         collisionbox = {-0.5, 0.0, -0.5, 0.5, 1.0, 0.5},
-    --  ^ For players (0, -1, 0) is at object base level,
-    --    for all other objects (0, 0, 0) is at object base level.
-    --    For example, Minetest Game player box is (-0.3, -1.0, -0.3, 0.3, 0.75, 0.3).
         visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem",
         visual_size = {x = 1, y = 1},
         mesh = "model",

--- a/src/constants.h
+++ b/src/constants.h
@@ -90,12 +90,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Maximum hit points of a player
 #define PLAYER_MAX_HP 20
 
-// Player weight
-#define PLAYER_DEFAULT_WEIGHT 75
-
-// Player step height
-#define PLAYER_DEFAULT_STEPHEIGHT 0.6f
-
 // Maximal breath of a player
 #define PLAYER_MAX_BREATH 11
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1586,13 +1586,7 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 		if (m_is_local_player) {
 			LocalPlayer *player = m_env->getLocalPlayer();
-
 			player->makes_footstep_sound = m_prop.makes_footstep_sound;
-
-			aabb3f collisionbox = m_selection_box;
-			collisionbox.MinEdge += v3f(0, BS, 0);
-			collisionbox.MaxEdge += v3f(0, BS, 0);
-			player->setCollisionbox(collisionbox);
 		}
 
 		if ((m_is_player && !m_is_local_player) && m_prop.nametag == "")

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -154,12 +154,6 @@ public:
 
 	scene::IBillboardSceneNode *getSpriteSceneNode();
 
-
-	inline f32 getStepheight() const
-	{
-		return m_prop.stepheight;
-	}
-
 	inline bool isPlayer() const
 	{
 		return m_is_player;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -797,7 +797,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 
 	m_prop.hp_max = PLAYER_MAX_HP;
 	m_prop.physical = false;
-	m_prop.weight = PLAYER_DEFAULT_WEIGHT;
+	m_prop.weight = 75;
 	m_prop.collisionbox = aabb3f(-0.3f, -1.0f, -0.3f, 0.3f, 0.75f, 0.3f);
 	// start of default appearance, this should be overwritten by LUA
 	m_prop.visual = "upright_sprite";
@@ -811,7 +811,6 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 	// end of default appearance
 	m_prop.is_visible = true;
 	m_prop.makes_footstep_sound = true;
-	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT;
 	m_hp = PLAYER_MAX_HP;
 }
 
@@ -1429,9 +1428,7 @@ bool PlayerSAO::checkMovementCheat()
 
 bool PlayerSAO::getCollisionBox(aabb3f *toset) const
 {
-	//update collision box
-	toset->MinEdge = m_prop.collisionbox.MinEdge * BS + v3f(0, BS, 0);
-	toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS + v3f(0, BS, 0);
+	*toset = aabb3f(-0.3f * BS, 0.0f, -0.3f * BS, 0.3f * BS, 1.75f * BS, 0.3f * BS);
 
 	toset->MinEdge += m_base_position;
 	toset->MaxEdge += m_base_position;

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -344,8 +344,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	}
 
-	float player_stepheight = (m_cao == 0) ? 0.0f :
-			((touching_ground) ? m_cao->getStepheight() : (0.2f * BS));
+	// TODO: this shouldn't be hardcoded but transmitted from server
+	float player_stepheight = (touching_ground) ? (BS * 0.6f) : (BS * 0.2f);
 
 #ifdef __ANDROID__
 	player_stepheight += (0.6f * BS);

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -137,8 +137,6 @@ public:
 	v3f getEyePosition() const { return m_position + getEyeOffset(); }
 	v3f getEyeOffset() const;
 
-	void setCollisionbox(aabb3f box) { m_collisionbox = box; }
-
 private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);


### PR DESCRIPTION
These caused inability to pass through 2 node high spaces or step up onto slabs
or steps when a new client connected to an older server.
//////////////////////////////

Fixes #5713 #5727 
Reverts 45ab62d6a3d90ab3b97aec88251a766cb5dd1899 b6f4a9c7e1a4f0bac66fd6f6ff844425ac775975 5e04f1a3357a618bed6d36b6a7439279b758fc8e
Tested.