### PR TITLE
Caverns: Remove unnecessary liquid excavation

### DIFF
--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -204,12 +204,12 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
-		bool has_cavern = false;
+		bool near_cavern = false;
 		// Generate caverns
 		if (spflags & MGV5_CAVERNS)
-			has_cavern = generateCaverns(stone_surface_max_y);
+			near_cavern = generateCaverns(stone_surface_max_y);
 		// Generate tunnels and classic caves
-		if (has_cavern)
+		if (near_cavern)
 			// Disable classic caves in this mapchunk by setting
 			// 'large cave depth' to world base. Avoids excessive liquid in
 			// large caverns and floating blobs of overgenerated liquid.

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -292,12 +292,12 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
-		bool has_cavern = false;
+		bool near_cavern = false;
 		// Generate caverns
 		if (spflags & MGV7_CAVERNS)
-			has_cavern = generateCaverns(stone_surface_max_y);
+			near_cavern = generateCaverns(stone_surface_max_y);
 		// Generate tunnels and classic caves
-		if (has_cavern)
+		if (near_cavern)
 			// Disable classic caves in this mapchunk by setting
 			// 'large cave depth' to world base. Avoids excessive liquid in
 			// large caverns and floating blobs of overgenerated liquid.


### PR DESCRIPTION
Also disable CavesRandomWalk at a safer distance from caverns.

Excavating liquids in cavern code is unnecessary as in practice we are already
successfully disabling the generation of liquid caves that could intersect
with caverns and cause excessive amounts of spreading liquids in caverns.

However to be safer this commit now disables liquid caves at a larger distance
from caverns, to compensate for liquid caves being able to generate up to a
mapblock beyond a mapchunk border.

Not excavating liquids in cavern code also allows a feature i am working on in
experimental new core mapgens, but also allows for more flexibility in future.
////////////////////////////////

Tested.
By 'larger distance from caverns' i mean only 16 nodes or so, no more than the rough distance between liquid caves.

Previously the code decided that a cavern was in a mapchunk if a node was excavated, now this is decided by the noise value being within 0.1 of the cavern noise threshold. So the volume where liquid caves are disabled is now not the cavern volume but a very slightly larger volume.
This is necessary because liquid caves can extend up to 1 mapblock beyond their mapchunk of creation.

In extensive testing 0.1 is only just enough of a safe margin, i found a liquid cave separated from a cavern by only 4-8 nodes. So there is no worry about an unnecessarily large volume being without liquid caves.