### PR TITLE
[CSM] Add send_chat_message and run_server_chatcommand API functions

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -51,3 +51,7 @@ core.register_chatcommand("disconnect", {
 		core.disconnect()
 	end,
 })
+
+function core.run_server_chatcommand(cmd, param)
+	core.send_chat_message("/" .. cmd .. " " .. param)
+end

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -52,6 +52,14 @@ core.register_chatcommand("disconnect", {
 	end,
 })
 
+core.register_chatcommand("clear_chat_queue", {
+	description = core.gettext("Clear the out chat queue"),
+	func = function(param)
+		core.clear_out_chat_queue()
+		return true, core.gettext("The out chat queue is now empty")
+	end,
+})
+
 function core.run_server_chatcommand(cmd, param)
 	core.send_chat_message("/" .. cmd .. " " .. param)
 end

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -312,6 +312,9 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 #    File in client/serverlist/ that contains your favorite servers displayed in the Multiplayer Tab.
 serverlist_file (Serverlist file) string favoriteservers.txt
 
+#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size illimited
+max_out_chat_queue_size (Maximum size of the out chat queue) int 50
+
 [*Graphics]
 
 [**In-Game]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -312,8 +312,8 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 #    File in client/serverlist/ that contains your favorite servers displayed in the Multiplayer Tab.
 serverlist_file (Serverlist file) string favoriteservers.txt
 
-#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size illimited
-max_out_chat_queue_size (Maximum size of the out chat queue) int 50
+#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
+max_out_chat_queue_size (Maximum size of the out chat queue) int 20
 
 [*Graphics]
 

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -701,6 +701,8 @@ Call these functions only at load time!
     * Act as if `message` was typed by the player into the terminal.
 * `minetest.run_server_chatcommand(cmd, param)`
     * Alias for `minetest.send_chat_message("/" .. cmd .. " " .. param)`
+* `minetest.clear_out_chat_queue()`
+    * Clears the out chat queue
 * `minetest.localplayer`
     * Reference to the LocalPlayer object. See [`LocalPlayer`](#localplayer) class reference for methods.
 

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -697,6 +697,10 @@ Call these functions only at load time!
 ### Player
 * `minetest.get_wielded_item()`
     * Returns the itemstack the local player is holding
+* `minetest.send_chat_message(message)`
+    * Act as if `message` was typed by the player into the terminal.
+* `minetest.run_server_chatcommand(cmd, param)`
+    * Alias for `minetest.send_chat_message("/" .. cmd .. " " .. param)`
 * `minetest.localplayer`
     * Reference to the LocalPlayer object. See [`LocalPlayer`](#localplayer) class reference for methods.
 
@@ -802,7 +806,7 @@ Please do not try to access the reference until the camera is initialized, other
     * Returns with same syntax as above
 * `get_fov()`
     * Returns:
-    
+
 ```lua
      {
          x = number,
@@ -811,7 +815,7 @@ Please do not try to access the reference until the camera is initialized, other
          actual = number
      }
 ```
-    
+
 * `get_pos()`
     * Returns position of camera with view bobbing
 * `get_offset()`

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -343,6 +343,10 @@
 #    type: string
 # serverlist_file = favoriteservers.txt
 
+#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
+#    type: int min: -1
+max_out_chat_queue_size = 20
+
 ## Graphics
 
 ### In-Game

--- a/po/fr/minetest.po
+++ b/po/fr/minetest.po
@@ -19,14 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.10-dev\n"
 
-#: builtin/client/chatcommands.lua
-msgid "Clear the out chat queue"
-msgstr "Nettoie la file d'attente de discussion en sortie"
-
-#: builtin/client/chatcommands.lua
-msgid "The out chat queue is now empty"
-msgstr "La file d'attente de discussion en sortie a été nettoyée"
-
 #: builtin/fstk/ui.lua
 msgid "An error occured in a Lua script, such as a mod:"
 msgstr "Une erreur est survenue dans un script Lua, il peut s'agir d'un mod :"

--- a/po/fr/minetest.po
+++ b/po/fr/minetest.po
@@ -19,6 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.10-dev\n"
 
+#: builtin/client/chatcommands.lua
+msgid "Clear the out chat queue"
+msgstr "Nettoie la file d'attente de discussion en sortie"
+
+#: builtin/client/chatcommands.lua
+msgid "The out chat queue is now empty"
+msgstr "La file d'attente de discussion en sortie a été nettoyée"
+
 #: builtin/fstk/ui.lua
 msgid "An error occured in a Lua script, such as a mod:"
 msgstr "Une erreur est survenue dans un script Lua, il peut s'agir d'un mod :"

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1180,6 +1180,7 @@ bool Client::canSendChatMessage() const
 
 void Client::sendChatMessage(const std::wstring &message)
 {
+	const s16 max_queue_size = g_settings->getS16("max_out_chat_queue_size");
 	if (canSendChatMessage()) {
 		u32 now = time(NULL);
 		float time_passed = now - m_last_chat_message_sent;
@@ -1196,8 +1197,11 @@ void Client::sendChatMessage(const std::wstring &message)
 		pkt << message;
 
 		Send(&pkt);
-	} else {
+	} else if (m_out_chat_queue.size() < (u16) max_queue_size || max_queue_size == -1) {
 		m_out_chat_queue.push(message);
+	} else {
+		infostream << "Coulnd't queue chat message because maximum out chat queue size ("
+				<< max_queue_size << ") is reached." << std::endl;
 	}
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1205,6 +1205,11 @@ void Client::sendChatMessage(const std::wstring &message)
 	}
 }
 
+void Client::clearOutChatQueue()
+{
+	m_out_chat_queue = std::queue<std::wstring>();
+}
+
 void Client::sendChangePassword(const std::string &oldpassword,
         const std::string &newpassword)
 {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1170,7 +1170,8 @@ bool Client::canSendChatMessage() const
 	u32 now = time(NULL);
 	float time_passed = now - m_last_chat_message_sent;
 
-	float virt_chat_message_allowance = m_chat_message_allowance + time_passed * (CLIENT_CHAT_MESSAGE_LIMIT_PER_10S / 8.0f);
+	float virt_chat_message_allowance = m_chat_message_allowance + time_passed *
+			(CLIENT_CHAT_MESSAGE_LIMIT_PER_10S / 8.0f);
 
 	if (virt_chat_message_allowance < 1.0f)
 		return false;
@@ -1200,7 +1201,7 @@ void Client::sendChatMessage(const std::wstring &message)
 	} else if (m_out_chat_queue.size() < (u16) max_queue_size || max_queue_size == -1) {
 		m_out_chat_queue.push(message);
 	} else {
-		infostream << "Coulnd't queue chat message because maximum out chat queue size ("
+		infostream << "Could not queue chat message because maximum out chat queue size ("
 				<< max_queue_size << ") is reached." << std::endl;
 	}
 }

--- a/src/client.h
+++ b/src/client.h
@@ -362,6 +362,7 @@ public:
 		const StringMap &fields);
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
+	void clearOutChatQueue();
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
 	void sendDamage(u8 damage);

--- a/src/client.h
+++ b/src/client.h
@@ -38,6 +38,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "mesh_generator_thread.h"
 
+#define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
+
 struct MeshMakeData;
 class MapBlockMesh;
 class IWritableTextureSource;
@@ -566,6 +568,8 @@ private:
 	inline std::string getPlayerName()
 	{ return m_env.getLocalPlayer()->getName(); }
 
+	bool canSendChatMessage() const;
+
 	float m_packetcounter_timer;
 	float m_connection_reinit_timer;
 	float m_avg_rtt_timer;
@@ -613,6 +617,9 @@ private:
 	//s32 m_daynight_i;
 	//u32 m_daynight_ratio;
 	std::queue<std::wstring> m_chat_queue;
+	std::queue<std::wstring> m_out_chat_queue;
+	u32 m_last_chat_message_sent;
+	float m_chat_message_allowance;
 
 	// The authentication methods we can use to enter sudo mode (=change password)
 	u32 m_sudo_auth_methods;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -57,7 +57,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
-	settings->setDefault("max_out_chat_queue_size", "50");
+	settings->setDefault("max_out_chat_queue_size", "20");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -57,6 +57,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
+	settings->setDefault("max_out_chat_queue_size", "50");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -82,16 +82,14 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 		return 0;
 	std::string message = luaL_checkstring(L, 1);
 	getClient(L)->sendChatMessage(utf8_to_wide(message));
-	lua_pushboolean(L, true);
-	return 1;
+	return 0;
 }
 
 // clear_out_chat_queue()
 int ModApiClient::l_clear_out_chat_queue(lua_State *L)
 {
 	getClient(L)->clearOutChatQueue();
-	lua_pushboolean(L, true);
-	return 1;
+	return 0;
 }
 
 // get_player_names()

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -75,6 +75,17 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
+// send_chat_message(message)
+int ModApiClient::l_send_chat_message(lua_State *L)
+{
+	if (!lua_isstring(L,1))
+		return 0;
+	std::string message = luaL_checkstring(L, 1);
+	getClient(L)->sendChatMessage(utf8_to_wide(message));
+	lua_pushboolean(L, true);
+	return 1;
+}
+
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
@@ -262,6 +273,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
 	API_FCT(display_chat_message);
+	API_FCT(send_chat_message);
 	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -86,6 +86,14 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 	return 1;
 }
 
+// clear_out_chat_queue()
+int ModApiClient::l_clear_out_chat_queue(lua_State *L)
+{
+	getClient(L)->clearOutChatQueue();
+	lua_pushboolean(L, true);
+	return 1;
+}
+
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
@@ -274,6 +282,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_current_modname);
 	API_FCT(display_chat_message);
 	API_FCT(send_chat_message);
+	API_FCT(clear_out_chat_queue);
 	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -32,6 +32,9 @@ private:
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 
+	// send_chat_message(message)
+	static int l_send_chat_message(lua_State *L);
+
 	// get_player_names()
 	static int l_get_player_names(lua_State *L);
 

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -35,6 +35,9 @@ private:
 	// send_chat_message(message)
 	static int l_send_chat_message(lua_State *L);
 
+	// clear_out_chat_queue()
+	static int l_clear_out_chat_queue(lua_State *L);
+
 	// get_player_names()
 	static int l_get_player_names(lua_State *L);
 


### PR DESCRIPTION
This is basically a copy of https://github.com/minetest/minetest/pull/5452, I don't understand why this PR has been closed. For convenience, and to avoid adding legacy stuff in case sending server chat commands gets a bit more complicated, I added a `minetest.run_server_chatcommand` alias.

Possibly needed changes:
* Adding type checks for `minetest.run_server_chatcommand` params