### PR TITLE
Underwater plantlike drawtype

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -860,6 +860,7 @@ Look for examples in `games/minimal` or `games/minetest_game`.
 * `raillike`
 * `nodebox` -- See below. (**Experimental!**)
 * `mesh` -- use models for nodes
+* `plantlike_rooted`
 
 `*_optional` drawtypes need less rendering time if deactivated (always client side).
 

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -922,7 +922,7 @@ void MapblockMeshGenerator::drawPlantlikeNode()
 	drawPlantlike();
 }
 
-void MapblockMeshGenerator::drawPlantlikeWaterNode()
+void MapblockMeshGenerator::drawPlantlikeRootedNode()
 {
 	useTile(0, MATERIAL_FLAG_CRACK_OVERLAY, 0, true);
 	origin += v3f(0.0, BS, 0.0);
@@ -1295,7 +1295,7 @@ void MapblockMeshGenerator::drawNode()
 		case NDT_TORCHLIKE:         drawTorchlikeNode(); break;
 		case NDT_SIGNLIKE:          drawSignlikeNode(); break;
 		case NDT_PLANTLIKE:         drawPlantlikeNode(); break;
-		case NDT_PLANTLIKE_WATER:   drawPlantlikeWaterNode(); break;
+		case NDT_PLANTLIKE_ROOTED:  drawPlantlikeRootedNode(); break;
 		case NDT_FIRELIKE:          drawFirelikeNode(); break;
 		case NDT_FENCELIKE:         drawFencelikeNode(); break;
 		case NDT_RAILLIKE:          drawRaillikeNode(); break;

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -926,6 +926,13 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 {
 	useTile(0, MATERIAL_FLAG_CRACK_OVERLAY, 0, true);
 	origin += v3f(0.0, BS, 0.0);
+	p.Y++;
+	if (data->m_smooth_lighting) {
+		getSmoothLightFrame();
+	} else {
+		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + p);
+		light = getInteriorLight(ntop, 1, nodedef);
+	}
 	drawPlantlike();
 }
 

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -934,6 +934,7 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 		light = getInteriorLight(ntop, 1, nodedef);
 	}
 	drawPlantlike();
+	p.Y--;
 }
 
 void MapblockMeshGenerator::drawFirelikeQuad(float rotation, float opening_angle,

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -73,7 +73,7 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 	blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
 }
 
-void MapblockMeshGenerator::useTile(int index, int set_flags, int reset_flags, bool special)
+void MapblockMeshGenerator::useTile(int index, u8 set_flags, u8 reset_flags, bool special)
 {
 	if (special)
 		getSpecialTile(index, &tile, p == data->m_crack_pos_relative);
@@ -87,7 +87,7 @@ void MapblockMeshGenerator::useTile(int index, int set_flags, int reset_flags, b
 	}
 }
 
-void MapblockMeshGenerator::getTile(const v3s16& direction, TileSpec *tile)
+void MapblockMeshGenerator::getTile(v3s16 direction, TileSpec *tile)
 {
 	getNodeTile(n, p, direction, data, *tile);
 }

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -131,7 +131,7 @@ public:
 	void drawTorchlikeNode();
 	void drawSignlikeNode();
 	void drawPlantlikeNode();
-	void drawPlantlikeWaterNode();
+	void drawPlantlikeRootedNode();
 	void drawFirelikeNode();
 	void drawFencelikeNode();
 	void drawRaillikeNode();

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -62,9 +62,10 @@ public:
 	video::SColor blendLightColor(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos, const v3f &vertex_normal);
 
-	void useTile(int index, bool disable_backface_culling);
-	void useDefaultTile(bool set_color = true);
-	void getTile(const v3s16 &direction, TileSpec &tile);
+	void useTile(int index = 0, int set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
+		int reset_flags = 0, bool special = false);
+	void getTile(const v3s16 &direction, TileSpec *tile);
+	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
 
 // face drawing
 	void drawQuad(v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0));

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -68,7 +68,8 @@ public:
 	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
 
 // face drawing
-	void drawQuad(v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0));
+	void drawQuad(v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0),
+		float vertical_tiling = 1.0);
 
 // cuboid drawing!
 	void drawCuboid(const aabb3f &box, TileSpec *tiles, int tilecount,
@@ -112,9 +113,11 @@ public:
 	int rotate_degree;
 	bool random_offset_Y;
 	int face_num;
+	float plant_height;
 
 	void drawPlantlikeQuad(float rotation, float quad_offset = 0,
 		bool offset_top_only = false);
+	void drawPlantlike();
 
 // firelike-specific
 	void drawFirelikeQuad(float rotation, float opening_angle,
@@ -128,6 +131,7 @@ public:
 	void drawTorchlikeNode();
 	void drawSignlikeNode();
 	void drawPlantlikeNode();
+	void drawPlantlikeWaterNode();
 	void drawFirelikeNode();
 	void drawFencelikeNode();
 	void drawRaillikeNode();

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -62,9 +62,9 @@ public:
 	video::SColor blendLightColor(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos, const v3f &vertex_normal);
 
-	void useTile(int index = 0, int set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
-		int reset_flags = 0, bool special = false);
-	void getTile(const v3s16 &direction, TileSpec *tile);
+	void useTile(int index = 0, u8 set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
+		u8 reset_flags = 0, bool special = false);
+	void getTile(v3s16 direction, TileSpec *tile);
 	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
 
 // face drawing

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -786,45 +786,41 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			TILE_MATERIAL_LIQUID_OPAQUE : TILE_MATERIAL_LIQUID_TRANSPARENT;
 	}
 
-	u32 tile_shader[6];
-	for (u16 j = 0; j < 6; j++) {
-		tile_shader[j] = shdsrc->getShader("nodes_shader",
-			material_type, drawtype);
-	}
+	u32 tile_shader = shdsrc->getShader("nodes_shader", material_type, drawtype);
+
 	u8 overlay_material = material_type;
 	if (overlay_material == TILE_MATERIAL_OPAQUE)
 		overlay_material = TILE_MATERIAL_BASIC;
 	else if (overlay_material == TILE_MATERIAL_LIQUID_OPAQUE)
 		overlay_material = TILE_MATERIAL_LIQUID_TRANSPARENT;
-	u32 overlay_shader[6];
-	for (u16 j = 0; j < 6; j++) {
-		overlay_shader[j] = shdsrc->getShader("nodes_shader",
-			overlay_material, drawtype);
-	}
+
+	u32 overlay_shader = shdsrc->getShader("nodes_shader", overlay_material, drawtype);
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
-		fillTileAttribs(tsrc, &tiles[j].layers[0], &tdef[j], tile_shader[j],
+		fillTileAttribs(tsrc, &tiles[j].layers[0], &tdef[j], tile_shader,
 			tsettings.use_normal_texture,
 			tdef[j].backface_culling, material_type);
 		if (tdef_overlay[j].name != "")
 			fillTileAttribs(tsrc, &tiles[j].layers[1], &tdef_overlay[j],
-				overlay_shader[j], tsettings.use_normal_texture,
+				overlay_shader, tsettings.use_normal_texture,
 				tdef[j].backface_culling, overlay_material);
 	}
 
+	u8 special_material = material_type;
 	if (drawtype == NDT_PLANTLIKE_ROOTED) {
 		if (waving == 1)
-			material_type = TILE_MATERIAL_WAVING_PLANTS;
+			special_material = TILE_MATERIAL_WAVING_PLANTS;
 		else if (waving == 2)
-			material_type = TILE_MATERIAL_WAVING_LEAVES;
+			special_material = TILE_MATERIAL_WAVING_LEAVES;
 	}
+	u32 special_shader = shdsrc->getShader("nodes_shader", special_material, drawtype);
 
 	// Special tiles (fill in f->special_tiles[])
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++) {
 		fillTileAttribs(tsrc, &special_tiles[j].layers[0], &tdef_spec[j],
-			tile_shader[j], tsettings.use_normal_texture,
-			tdef_spec[j].backface_culling, material_type);
+			special_shader, tsettings.use_normal_texture,
+			tdef_spec[j].backface_culling, special_material);
 	}
 
 	if (param_type_2 == CPT2_COLOR ||

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -813,11 +813,12 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				tdef[j].backface_culling, overlay_material);
 	}
 
-	if (drawtype == NDT_PLANTLIKE_ROOTED)
+	if (drawtype == NDT_PLANTLIKE_ROOTED) {
 		if (waving == 1)
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		else if (waving == 2)
 			material_type = TILE_MATERIAL_WAVING_LEAVES;
+	}
 
 	// Special tiles (fill in f->special_tiles[])
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++) {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -772,6 +772,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	case NDT_RAILLIKE:
 		solidness = 0;
 		break;
+	case NDT_PLANTLIKE_WATER:
+		solidness = 2;
+		break;
 	}
 
 	if (is_liquid) {
@@ -809,6 +812,12 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				overlay_shader[j], tsettings.use_normal_texture,
 				tdef[j].backface_culling, overlay_material);
 	}
+
+	if (drawtype == NDT_PLANTLIKE_WATER)
+		if (waving == 1)
+			material_type = TILE_MATERIAL_WAVING_PLANTS;
+		else if (waving == 2)
+			material_type = TILE_MATERIAL_WAVING_LEAVES;
 
 	// Special tiles (fill in f->special_tiles[])
 	for (u16 j = 0; j < CF_SPECIAL_COUNT; j++) {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -772,7 +772,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	case NDT_RAILLIKE:
 		solidness = 0;
 		break;
-	case NDT_PLANTLIKE_WATER:
+	case NDT_PLANTLIKE_ROOTED:
 		solidness = 2;
 		break;
 	}
@@ -813,7 +813,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				tdef[j].backface_culling, overlay_material);
 	}
 
-	if (drawtype == NDT_PLANTLIKE_WATER)
+	if (drawtype == NDT_PLANTLIKE_ROOTED)
 		if (waving == 1)
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		else if (waving == 2)

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -188,7 +188,7 @@ enum NodeDrawType
 	// Uses static meshes
 	NDT_MESH,
 	// Combined plantlike-on-solid
-	NDT_PLANTLIKE_WATER,
+	NDT_PLANTLIKE_ROOTED,
 };
 
 // Mesh options for NDT_PLANTLIKE with CPT2_MESHOPTIONS

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -187,6 +187,8 @@ enum NodeDrawType
 	NDT_GLASSLIKE_FRAMED_OPTIONAL,
 	// Uses static meshes
 	NDT_MESH,
+	// Combined plantlike-on-solid
+	NDT_PLANTLIKE_WATER,
 };
 
 // Mesh options for NDT_PLANTLIKE with CPT2_MESHOPTIONS

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -362,6 +362,7 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 	bool default_culling = true;
 	switch (drawtype) {
 		case NDT_PLANTLIKE:
+		case NDT_PLANTLIKE_WATER:
 		case NDT_FIRELIKE:
 			default_tiling = false;
 			// "break" is omitted here intentionaly, as PLANTLIKE

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -362,7 +362,7 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 	bool default_culling = true;
 	switch (drawtype) {
 		case NDT_PLANTLIKE:
-		case NDT_PLANTLIKE_WATER:
+		case NDT_PLANTLIKE_ROOTED:
 		case NDT_FIRELIKE:
 			default_tiling = false;
 			// "break" is omitted here intentionaly, as PLANTLIKE

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -47,7 +47,7 @@ struct EnumString ScriptApiNode::es_DrawType[] =
 		{NDT_FIRELIKE, "firelike"},
 		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
 		{NDT_MESH, "mesh"},
-		{NDT_PLANTLIKE_WATER, "plantlike_water"},
+		{NDT_PLANTLIKE_ROOTED, "plantlike_rooted"},
 		{0, NULL},
 	};
 

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -47,6 +47,7 @@ struct EnumString ScriptApiNode::es_DrawType[] =
 		{NDT_FIRELIKE, "firelike"},
 		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
 		{NDT_MESH, "mesh"},
+		{NDT_PLANTLIKE_WATER, "plantlike_water"},
 		{0, NULL},
 	};
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -618,7 +618,8 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		"NDT_NODEBOX",
 		"NDT_GLASSLIKE_FRAMED",
 		"NDT_FIRELIKE",
-		"NDT_GLASSLIKE_FRAMED_OPTIONAL"
+		"NDT_GLASSLIKE_FRAMED_OPTIONAL",
+		"NDT_PLANTLIKE_WATER",
 	};
 
 	for (int i = 0; i < 14; i++){

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -619,7 +619,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		"NDT_GLASSLIKE_FRAMED",
 		"NDT_FIRELIKE",
 		"NDT_GLASSLIKE_FRAMED_OPTIONAL",
-		"NDT_PLANTLIKE_WATER",
+		"NDT_PLANTLIKE_ROOTED",
 	};
 
 	for (int i = 0; i < 14; i++){

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -327,42 +327,45 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 			m_meshnode->setScale(
 					def.wield_scale * WIELD_SCALE_FACTOR
 					/ (BS * f.visual_scale));
-		} else switch (f.drawtype) {
-		case NDT_AIRLIKE:
-			changeToMesh(nullptr);
-			break;
-
-		case NDT_PLANTLIKE:
-			setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
-				def.wield_scale, tsrc,
-				f.tiles[0].layers[0].animation_frame_count);
-			break;
-
-		case NDT_PLANTLIKE_ROOTED:
-			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
-				def.wield_scale, tsrc,
-				f.special_tiles[0].layers[0].animation_frame_count);
-			break;
-
-		case NDT_NORMAL:
-		case NDT_ALLFACES:
-			setCube(f, def.wield_scale);
-			break;
-
-		default:
-			MeshMakeData mesh_make_data(client, false);
-			MapNode mesh_make_node(id, 255, 0);
-			mesh_make_data.fillSingleNode(&mesh_make_node);
-			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
-			scene::SMesh *mesh = cloneMesh(mapblock_mesh.getMesh());
-			translateMesh(mesh, v3f(-BS, -BS, -BS));
-			postProcessNodeMesh(mesh, f, m_enable_shaders, true,
-				&m_material_type, &m_colors);
-			changeToMesh(mesh);
-			mesh->drop();
-			m_meshnode->setScale(
-					def.wield_scale * WIELD_SCALE_FACTOR
-					/ (BS * f.visual_scale));
+		} else {
+			switch (f.drawtype) {
+				case NDT_AIRLIKE: {
+					changeToMesh(nullptr);
+					break;
+				}
+				case NDT_PLANTLIKE: {
+					setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
+						def.wield_scale, tsrc,
+						f.tiles[0].layers[0].animation_frame_count);
+					break;
+				}
+				case NDT_PLANTLIKE_ROOTED: {
+					setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
+						def.wield_scale, tsrc,
+						f.special_tiles[0].layers[0].animation_frame_count);
+					break;
+				}
+				case NDT_NORMAL:
+				case NDT_ALLFACES: {
+					setCube(f, def.wield_scale);
+					break;
+				}
+				default: {
+					MeshMakeData mesh_make_data(client, false);
+					MapNode mesh_make_node(id, 255, 0);
+					mesh_make_data.fillSingleNode(&mesh_make_node);
+					MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
+					scene::SMesh *mesh = cloneMesh(mapblock_mesh.getMesh());
+					translateMesh(mesh, v3f(-BS, -BS, -BS));
+					postProcessNodeMesh(mesh, f, m_enable_shaders, true,
+						&m_material_type, &m_colors);
+					changeToMesh(mesh);
+					mesh->drop();
+					m_meshnode->setScale(
+							def.wield_scale * WIELD_SCALE_FACTOR
+							/ (BS * f.visual_scale));
+				}
+			}
 		}
 		u32 material_count = m_meshnode->getMaterialCount();
 		for (u32 i = 0; i < material_count; ++i) {
@@ -460,47 +463,50 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		if (f.mesh_ptr[0]) {
 			mesh = cloneMesh(f.mesh_ptr[0]);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
-		} else switch (f.drawtype) {
-		case NDT_PLANTLIKE:
-			mesh = getExtrudedMesh(tsrc,
-				tsrc->getTextureName(f.tiles[0].layers[0].texture_id));
-			break;
+		} else {
+			switch (f.drawtype) {
+				case NDT_PLANTLIKE: {
+					mesh = getExtrudedMesh(tsrc,
+						tsrc->getTextureName(f.tiles[0].layers[0].texture_id));
+					break;
+				}
+				case NDT_PLANTLIKE_ROOTED: {
+					mesh = getExtrudedMesh(tsrc,
+						tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id));
+					break;
+				}
+				case NDT_NORMAL:
+				case NDT_ALLFACES:
+				case NDT_LIQUID:
+				case NDT_FLOWINGLIQUID: {
+					scene::IMesh *cube = g_extrusion_mesh_cache->createCube();
+					mesh = cloneMesh(cube);
+					cube->drop();
+					scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
+					break;
+				}
+				default: {
+					MeshMakeData mesh_make_data(client, false);
+					MapNode mesh_make_node(id, 255, 0);
+					mesh_make_data.fillSingleNode(&mesh_make_node);
+					MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
+					mesh = cloneMesh(mapblock_mesh.getMesh());
+					translateMesh(mesh, v3f(-BS, -BS, -BS));
+					scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
 
-		case NDT_PLANTLIKE_ROOTED:
-			mesh = getExtrudedMesh(tsrc,
-				tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id));
-			break;
-
-		case NDT_NORMAL:
-		case NDT_ALLFACES:
-		case NDT_LIQUID:
-		case NDT_FLOWINGLIQUID:
-			scene::IMesh *cube = g_extrusion_mesh_cache->createCube();
-			mesh = cloneMesh(cube);
-			cube->drop();
-			scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
-			break;
-
-		default:
-			MeshMakeData mesh_make_data(client, false);
-			MapNode mesh_make_node(id, 255, 0);
-			mesh_make_data.fillSingleNode(&mesh_make_node);
-			MapBlockMesh mapblock_mesh(&mesh_make_data, v3s16(0, 0, 0));
-			mesh = cloneMesh(mapblock_mesh.getMesh());
-			translateMesh(mesh, v3f(-BS, -BS, -BS));
-			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
-
-			u32 mc = mesh->getMeshBufferCount();
-			for (u32 i = 0; i < mc; ++i) {
-				video::SMaterial &material1 =
-					mesh->getMeshBuffer(i)->getMaterial();
-				video::SMaterial &material2 =
-					mapblock_mesh.getMesh()->getMeshBuffer(i)->getMaterial();
-				material1.setTexture(0, material2.getTexture(0));
-				material1.setTexture(1, material2.getTexture(1));
-				material1.setTexture(2, material2.getTexture(2));
-				material1.setTexture(3, material2.getTexture(3));
-				material1.MaterialType = material2.MaterialType;
+					u32 mc = mesh->getMeshBufferCount();
+					for (u32 i = 0; i < mc; ++i) {
+						video::SMaterial &material1 =
+							mesh->getMeshBuffer(i)->getMaterial();
+						video::SMaterial &material2 =
+							mapblock_mesh.getMesh()->getMeshBuffer(i)->getMaterial();
+						material1.setTexture(0, material2.getTexture(0));
+						material1.setTexture(1, material2.getTexture(1));
+						material1.setTexture(2, material2.getTexture(2));
+						material1.setTexture(3, material2.getTexture(3));
+						material1.MaterialType = material2.MaterialType;
+					}
+				}
 			}
 		}
 

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -333,6 +333,10 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 			setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
 				def.wield_scale, tsrc,
 				f.tiles[0].layers[0].animation_frame_count);
+		} else if (f.drawtype == NDT_PLANTLIKE_WATER) {
+			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
+				def.wield_scale, tsrc,
+				f.special_tiles[0].layers[0].animation_frame_count);
 		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES) {
 			setCube(f, def.wield_scale);
 		} else {

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -460,16 +460,28 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 		if (f.mesh_ptr[0]) {
 			mesh = cloneMesh(f.mesh_ptr[0]);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
-		} else if (f.drawtype == NDT_PLANTLIKE) {
+		} else switch (f.drawtype) {
+		case NDT_PLANTLIKE:
 			mesh = getExtrudedMesh(tsrc,
 				tsrc->getTextureName(f.tiles[0].layers[0].texture_id));
-		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES
-			|| f.drawtype == NDT_LIQUID || f.drawtype == NDT_FLOWINGLIQUID) {
+			break;
+
+		case NDT_PLANTLIKE_ROOTED:
+			mesh = getExtrudedMesh(tsrc,
+				tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id));
+			break;
+
+		case NDT_NORMAL:
+		case NDT_ALLFACES:
+		case NDT_LIQUID:
+		case NDT_FLOWINGLIQUID:
 			scene::IMesh *cube = g_extrusion_mesh_cache->createCube();
 			mesh = cloneMesh(cube);
 			cube->drop();
 			scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
-		} else {
+			break;
+
+		default:
 			MeshMakeData mesh_make_data(client, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -333,7 +333,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 			setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
 				def.wield_scale, tsrc,
 				f.tiles[0].layers[0].animation_frame_count);
-		} else if (f.drawtype == NDT_PLANTLIKE_WATER) {
+		} else if (f.drawtype == NDT_PLANTLIKE_ROOTED) {
 			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
 				def.wield_scale, tsrc,
 				f.special_tiles[0].layers[0].animation_frame_count);

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -327,19 +327,29 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 			m_meshnode->setScale(
 					def.wield_scale * WIELD_SCALE_FACTOR
 					/ (BS * f.visual_scale));
-		} else if (f.drawtype == NDT_AIRLIKE) {
+		} else switch (f.drawtype) {
+		case NDT_AIRLIKE:
 			changeToMesh(nullptr);
-		} else if (f.drawtype == NDT_PLANTLIKE) {
+			break;
+
+		case NDT_PLANTLIKE:
 			setExtruded(tsrc->getTextureName(f.tiles[0].layers[0].texture_id),
 				def.wield_scale, tsrc,
 				f.tiles[0].layers[0].animation_frame_count);
-		} else if (f.drawtype == NDT_PLANTLIKE_ROOTED) {
+			break;
+
+		case NDT_PLANTLIKE_ROOTED:
 			setExtruded(tsrc->getTextureName(f.special_tiles[0].layers[0].texture_id),
 				def.wield_scale, tsrc,
 				f.special_tiles[0].layers[0].animation_frame_count);
-		} else if (f.drawtype == NDT_NORMAL || f.drawtype == NDT_ALLFACES) {
+			break;
+
+		case NDT_NORMAL:
+		case NDT_ALLFACES:
 			setCube(f, def.wield_scale);
-		} else {
+			break;
+
+		default:
 			MeshMakeData mesh_make_data(client, false);
 			MapNode mesh_make_node(id, 255, 0);
 			mesh_make_data.fillSingleNode(&mesh_make_node);


### PR DESCRIPTION
See #5381. In this implementation, plant height is `param2 / 16.0` nodes.
![screenshot_20170512_001303](https://cloud.githubusercontent.com/assets/7352626/25972751/4dd59778-36b2-11e7-852b-9e670fae7b1f.png)
Note: collision and selection boxes aren’t implemented yet. But unlike older version, this one draws the cube as a conventional solid node, thus using less faces.
@paramat
