### PR TITLE
Improve password change menu

### DIFF
--- a/src/guiPasswordChange.h
+++ b/src/guiPasswordChange.h
@@ -39,12 +39,17 @@ public:
 
 	void drawMenu();
 
-	bool acceptInput();
+	void acceptInput();
+
+	bool processInput();
 
 	bool OnEvent(const SEvent &event);
 
 private:
 	Client *m_client;
+	std::wstring m_oldpass;
+	std::wstring m_newpass;
+	std::wstring m_newpass_confirm;
 };
 
 #endif


### PR DESCRIPTION
- Fix the GUI getting messed up when resizing (#2835)
- Save the input when resizing (works around an issue related to #3732)

The code that is used for resizing is copied from the key change menu.