### PR TITLE
Add option to use neither node highlighting nor outlining

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -25,7 +25,8 @@ local labels = {
 	},
 	node_highlighting = {
 		fgettext("Node Outlining"),
-		fgettext("Node Highlighting")
+		fgettext("Node Highlighting"),
+		fgettext("None")
 	},
 	filters = {
 		fgettext("No Filter"),
@@ -52,7 +53,7 @@ local dd_options = {
 	},
 	node_highlighting = {
 		table.concat(labels.node_highlighting, ","),
-		{"box", "halo"}
+		{"box", "halo", "none"}
 	},
 	filters = {
 		table.concat(labels.filters, ","),

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -344,7 +344,7 @@ enable_clouds (Clouds) bool true
 enable_3d_clouds (3D clouds) bool true
 
 #    Method used to highlight selected object.
-node_highlighting (Node highlighting) enum box box,halo
+node_highlighting (Node highlighting) enum box box,halo,none
 
 #    Adds particles when digging a node.
 enable_particles (Digging particles) bool true

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -382,7 +382,7 @@
 # enable_3d_clouds = true
 
 #    Method used to highlight selected object.
-#    type: enum values: box, halo
+#    type: enum values: box, halo, none
 # node_highlighting = box
 
 #    Adds particles when digging a node.

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -91,10 +91,10 @@ Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
 
 	if (mode_setting == "halo") {
 		m_mode = HIGHLIGHT_HALO;
-	} else if (mode_setting == "box") {
-		m_mode = HIGHLIGHT_BOX;
-	} else {
+	} else if (mode_setting == "none") {
 		m_mode = HIGHLIGHT_NONE;
+	} else {
+		m_mode = HIGHLIGHT_BOX;
 	}
 
 	m_selection_material.Lighting = false;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -545,7 +545,7 @@ void Hud::drawSelectionMesh()
 			driver->draw3DBox(box, video::SColor(255, r, g, b));
 		}
 		driver->setMaterial(oldmaterial);
-	} else if (m_selection_mesh) {
+	} else if (m_mode == HIGHLIGHT_HALO && m_selection_mesh) {
 		// Draw selection mesh
 		video::SMaterial oldmaterial = driver->getMaterial2D();
 		driver->setMaterial(m_selection_material);

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -87,24 +87,31 @@ Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
 	m_halo_boxes.clear();
 
 	m_selection_pos = v3f(0.0, 0.0, 0.0);
-	std::string mode = g_settings->get("node_highlighting");
+	std::string mode_setting = g_settings->get("node_highlighting");
+
+	if (mode_setting == "halo") {
+		m_mode = HIGHLIGHT_HALO;
+	} else if (mode_setting == "box") {
+		m_mode = HIGHLIGHT_BOX;
+	} else {
+		m_mode = HIGHLIGHT_NONE;
+	}
+
 	m_selection_material.Lighting = false;
 
 	if (g_settings->getBool("enable_shaders")) {
 		IShaderSource *shdrsrc = client->getShaderSource();
 		u16 shader_id = shdrsrc->getShader(
-			mode == "halo" ? "selection_shader" : "default_shader", 1, 1);
+			m_mode == HIGHLIGHT_HALO ? "selection_shader" : "default_shader", 1, 1);
 		m_selection_material.MaterialType = shdrsrc->getShaderInfo(shader_id).material;
 	} else {
 		m_selection_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 	}
 
-	if (mode == "box") {
-		m_use_selection_mesh = false;
+	if (m_mode == HIGHLIGHT_BOX) {
 		m_selection_material.Thickness =
 			rangelim(g_settings->getS16("selectionbox_width"), 1, 5);
-	} else if (mode == "halo") {
-		m_use_selection_mesh = true;
+	} else if (m_mode == HIGHLIGHT_HALO) {
 		m_selection_material.setTexture(0, tsrc->getTextureForMesh("halo.png"));
 		m_selection_material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 	} else {
@@ -518,7 +525,7 @@ void Hud::setSelectionPos(const v3f &pos, const v3s16 &camera_offset)
 
 void Hud::drawSelectionMesh()
 {
-	if (!m_use_selection_mesh) {
+	if (m_mode == HIGHLIGHT_BOX) {
 		// Draw 3D selection boxes
 		video::SMaterial oldmaterial = driver->getMaterial2D();
 		driver->setMaterial(m_selection_material);
@@ -564,7 +571,7 @@ void Hud::drawSelectionMesh()
 void Hud::updateSelectionMesh(const v3s16 &camera_offset)
 {
 	m_camera_offset = camera_offset;
-	if (!m_use_selection_mesh)
+	if (m_mode != HIGHLIGHT_HALO)
 		return;
 
 	if (m_selection_mesh) {

--- a/src/hud.h
+++ b/src/hud.h
@@ -175,7 +175,11 @@ private:
 	v3f m_selected_face_normal;
 
 	video::SMaterial m_selection_material;
-	bool m_use_selection_mesh;
+	
+	enum { 
+		HIGHLIGHT_BOX, 
+		HIGHLIGHT_HALO, 
+		HIGHLIGHT_NONE } m_mode;
 };
 
 enum ItemRotationKind {


### PR DESCRIPTION
Adds an extra option to the node highlighting drop-down on settings so you can have neither highlighting nor outlining, and play by use of crosshair alone if you so choose.