### PR TITLE
line_of_sight upgrade

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2710,13 +2710,14 @@ and `minetest.auth_reload` call the authetification handler.
     *   parameter was absent)
 * `minetest.delete_area(pos1, pos2)`
     * delete all mapblocks in the area from pos1 to pos2, inclusive
-* `minetest.line_of_sight(pos1, pos2, stepsize)`: returns `boolean, pos`
+* `minetest.line_of_sight(pos1, pos2, stepsize, nobuild)`: returns `boolean, pos`
     * Check if there is a direct line of sight between `pos1` and `pos2`
     * Returns the position of the blocking node when `false`
     * `pos1`: First position
     * `pos2`: Second position
     * `stepsize`: smaller gives more accurate results but requires more computing
       time. Default is `1`.
+    * `nobuild` : when true buildable_to nodes will be ignored (water, snow, plants)
 * `minetest.raycast(pos1, pos2, objects, liquids)`: returns `Raycast`
     * Creates a `Raycast` object.
     * `pos1`: start of the ray

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2710,14 +2710,14 @@ and `minetest.auth_reload` call the authetification handler.
     *   parameter was absent)
 * `minetest.delete_area(pos1, pos2)`
     * delete all mapblocks in the area from pos1 to pos2, inclusive
-* `minetest.line_of_sight(pos1, pos2, stepsize, nobuild)`: returns `boolean, pos`
+* `minetest.line_of_sight(pos1, pos2, stepsize, ignore_buildable_to)`: returns `boolean, pos`
     * Check if there is a direct line of sight between `pos1` and `pos2`
     * Returns the position of the blocking node when `false`
     * `pos1`: First position
     * `pos2`: Second position
     * `stepsize`: smaller gives more accurate results but requires more computing
       time. Default is `1`.
-    * `nobuild` : when true buildable_to nodes will be ignored (water, snow, plants)
+    * `ignore_buildable_to`: buildable_to nodes will be ignored (water, snow, plants)
 * `minetest.raycast(pos1, pos2, objects, liquids)`: returns `Raycast`
     * Creates a `Raycast` object.
     * `pos1`: start of the ray

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -982,7 +982,7 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L)
 		stepsize = lua_tonumber(L, 3);
 	}
 	//read ignore buildable_to from lua
-	bool nobuild = lua_toboolean(L, 4)
+	bool nobuild = lua_toboolean(L, 4);
 
 	v3s16 p;
 	bool success = env->line_of_sight(pos1, pos2, stepsize, nobuild, &p);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -966,7 +966,7 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 	return 0;
 }
 
-// line_of_sight(pos1, pos2, stepsize, nobuild) -> true/false, pos
+// line_of_sight(pos1, pos2, stepsize, ignore_buildable_to) -> true/false, pos
 int ModApiEnvMod::l_line_of_sight(lua_State *L)
 {
 	float stepsize = 1.0;
@@ -977,15 +977,15 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L)
 	v3f pos1 = checkFloatPos(L, 1);
 	// read position 2 from lua
 	v3f pos2 = checkFloatPos(L, 2);
-	//read step size from lua
+	// read step size from lua
 	if (lua_isnumber(L, 3)) {
 		stepsize = lua_tonumber(L, 3);
 	}
-	//read ignore buildable_to from lua
-	bool nobuild = lua_toboolean(L, 4);
+
+	bool ignore_buildable_to = lua_toboolean(L, 4);
 
 	v3s16 p;
-	bool success = env->line_of_sight(pos1, pos2, stepsize, nobuild, &p);
+	bool success = env->line_of_sight(pos1, pos2, stepsize, ignore_buildable_to, &p);
 	lua_pushboolean(L, success);
 	if (!success) {
 		push_v3s16(L, p);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -966,7 +966,7 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 	return 0;
 }
 
-// line_of_sight(pos1, pos2, stepsize) -> true/false, pos
+// line_of_sight(pos1, pos2, stepsize, nobuild) -> true/false, pos
 int ModApiEnvMod::l_line_of_sight(lua_State *L)
 {
 	float stepsize = 1.0;
@@ -981,9 +981,11 @@ int ModApiEnvMod::l_line_of_sight(lua_State *L)
 	if (lua_isnumber(L, 3)) {
 		stepsize = lua_tonumber(L, 3);
 	}
+	//read ignore buildable_to from lua
+	bool nobuild = lua_toboolean(L, 4)
 
 	v3s16 p;
-	bool success = env->line_of_sight(pos1, pos2, stepsize, &p);
+	bool success = env->line_of_sight(pos1, pos2, stepsize, nobuild, &p);
 	lua_pushboolean(L, success);
 	if (!success) {
 		push_v3s16(L, p);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -156,7 +156,7 @@ private:
 	// spawn_tree(pos, treedef)
 	static int l_spawn_tree(lua_State *L);
 
-	// line_of_sight(pos1, pos2, stepsize) -> true/false
+	// line_of_sight(pos1, pos2, stepsize, nobuild) -> true/false
 	static int l_line_of_sight(lua_State *L);
 
 	// raycast(pos1, pos2, objects, liquids) -> Raycast

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -474,9 +474,9 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, bool n
 
 		MapNode n = getMap().getNodeNoEx(pos);
 
-		if(n.drawtype != NDT_AIRLIKE) {
-			if(nobuild == true) {
-				if(n.buildable_to == false) {
+		if (n.drawtype != NDT_AIRLIKE) {
+			if (nobuild) {
+				if (n.buildable_to == false) {
 					if (p) {
 						*p = pos;
 					}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -456,7 +456,7 @@ bool ServerEnvironment::removePlayerFromDatabase(const std::string &name)
 	return m_player_database->removePlayer(name);
 }
 
-bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 *p)
+bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, bool nobuild, v3s16 *p)
 {
 	float distance = pos1.getDistanceFrom(pos2);
 
@@ -466,6 +466,7 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 
 		(pos2.Z - pos1.Z)/distance);
 
 	//find out if there's a node on path between pos1 and pos2
+	//when nobuild is true then buildable_to nodes are ignored
 	for (float i = 1; i < distance; i += stepsize) {
 		v3s16 pos = floatToInt(v3f(normalized_vector.X * i,
 			normalized_vector.Y * i,
@@ -473,11 +474,22 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, v3s16 
 
 		MapNode n = getMap().getNodeNoEx(pos);
 
-		if(n.param0 != CONTENT_AIR) {
-			if (p) {
-				*p = pos;
+		if(n.drawtype != NDT_AIRLIKE) {
+			if(nobuild == true) {
+				if(n.buildable_to == false) {
+					if (p) {
+						*p = pos;
+					}
+					return false;
+				}
 			}
-			return false;
+			else
+			{
+				if (p) {
+					*p = pos;
+				}
+				return false;
+			}
 		}
 	}
 	return true;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -474,9 +474,9 @@ bool ServerEnvironment::line_of_sight(v3f pos1, v3f pos2, float stepsize, bool n
 
 		MapNode n = getMap().getNodeNoEx(pos);
 
-		if (n.drawtype != NDT_AIRLIKE) {
+		if (m_gamedef->ndef()->get(n).drawtype != NDT_AIRLIKE) {
 			if (nobuild) {
-				if (n.buildable_to == false) {
+				if (m_gamedef->ndef()->get(n).buildable_to == false) {
 					if (p) {
 						*p = pos;
 					}

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -327,7 +327,8 @@ public:
 	void step(f32 dtime);
 
 	//check if there's a line of sight between two positions
-	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, bool nobuild=false, v3s16 *p=NULL);
+	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0,
+		bool ignore_buildable_to=false, v3s16 *p=NULL);
 
 	u32 getGameTime() const { return m_game_time; }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -327,7 +327,7 @@ public:
 	void step(f32 dtime);
 
 	//check if there's a line of sight between two positions
-	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, v3s16 *p=NULL);
+	bool line_of_sight(v3f pos1, v3f pos2, float stepsize=1.0, bool nobuild=false, v3s16 *p=NULL);
 
 	u32 getGameTime() const { return m_game_time; }
 


### PR DESCRIPTION
This pull has line_of_sight function working with 'airlike' nodes instead of simply 'air' (for moon realms and such) and adds a bool which allows buildable_to nodes to be ignored (snow, water, plants) which will be handy for mobs.