### PR TITLE
Make addItem for empty ItemStacks respect max stack size

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -268,7 +268,18 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	else if(empty())
 	{
 		*this = newitem;
-		newitem.clear();
+
+		// If item is oversized, take maximum
+		if (count > getStackMax(itemdef))
+		{
+			count = getStackMax(itemdef);
+			newitem.remove(count);
+		}
+		// Else item fits fully, delete it
+		else
+		{
+			newitem.clear();
+		}
 	}
 	// If item name or metadata differs, bail out
 	else if (name != newitem.name
@@ -308,7 +319,16 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		newitem.clear();
+		// If item is oversize, remove maximum
+		if (newitem.count > getStackMax(itemdef))
+		{
+			newitem.remove(getStackMax(itemdef));
+		}
+		// Else item fits fully, delete it
+		else
+		{
+			newitem.clear();
+		}
 	}
 	// If item name or metadata differs, bail out
 	else if (name != newitem.name

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -267,13 +267,15 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
+		const u16 stackMax = getStackMax(itemdef);
+
 		*this = newitem;
 
 		// If the item fits fully, delete it
-		if (count <= getStackMax(itemdef)) {
+		if (count <= stackMax) {
 			newitem.clear();
 		} else { // Else the item does not fit fully. Return the rest.
-			count = getStackMax(itemdef);
+			count = stackMax;
 			newitem.remove(count);
 		}
 	}
@@ -315,11 +317,13 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
+		const u16 stackMax = getStackMax(itemdef);
+
 		// If the item fits fully, delete it
-		if (newitem.count <= getStackMax(itemdef)) {
+		if (newitem.count <= stackMax) {
 			newitem.clear();
 		} else { // Else the item does not fit fully. Return the rest.
-			newitem.remove(getStackMax(itemdef));
+			newitem.remove(stackMax);
 		}
 	}
 	// If item name or metadata differs, bail out

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -269,16 +269,12 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	{
 		*this = newitem;
 
-		// If item is oversized, take maximum
-		if (count > getStackMax(itemdef))
-		{
+		// If the item fits fully, delete it
+		if (count <= getStackMax(itemdef)) {
+			newitem.clear();
+		} else { // Else the item does not fit fully. Return the rest.
 			count = getStackMax(itemdef);
 			newitem.remove(count);
-		}
-		// Else item fits fully, delete it
-		else
-		{
-			newitem.clear();
 		}
 	}
 	// If item name or metadata differs, bail out
@@ -319,15 +315,11 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		// If item is oversize, remove maximum
-		if (newitem.count > getStackMax(itemdef))
-		{
-			newitem.remove(getStackMax(itemdef));
-		}
-		// Else item fits fully, delete it
-		else
-		{
+		// If the item fits fully, delete it
+		if (newitem.count <= getStackMax(itemdef)) {
 			newitem.clear();
+		} else { // Else the item does not fit fully. Return the rest.
+			newitem.remove(getStackMax(itemdef));
 		}
 	}
 	// If item name or metadata differs, bail out
@@ -342,7 +334,6 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 		newitem.clear();
 	}
 	// Else the item does not fit fully. Return the rest.
-	// the rest.
 	else
 	{
 		u16 freespace = freeSpace(itemdef);


### PR DESCRIPTION
When adding items to an empty ```ItemStack```, limit the number of items taken based on the maximum stack size in the item description.

Likewise, when checking whether items will fit into an empty ```ItemStack```, only absorb as many items as are allowed in a single stack and return the rest.

Fixes minetest/minetest#5773.