### PR TITLE
Fix shift key producing space in console

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -661,3 +661,4 @@ void GUIChatConsole::setVisible(bool visible)
 		recalculateConsolePosition();
 	}
 }
+

--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -628,7 +628,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			prompt.nickCompletion(names, backwards);
 			return true;
 		}
-		else if(event.KeyInput.Char != 0 && !event.KeyInput.Control)
+		else if(isprint(event.KeyInput.Char) && !event.KeyInput.Control)
 		{
 			#if defined(__linux__) && (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9)
 				wchar_t wc = L'_';
@@ -661,4 +661,3 @@ void GUIChatConsole::setVisible(bool visible)
 		recalculateConsolePosition();
 	}
 }
-


### PR DESCRIPTION
This fixes the problem where the shift key would produce a space in the console on macOS.

Special characters in the console are a problem with Irrlicht (which is fixed in latest version).

Second attempt at the PR by @neoascetic https://github.com/minetest/minetest/pull/4074

Related: https://github.com/minetest/minetest/issues/4531 https://github.com/minetest/minetest/issues/4057 https://github.com/minetest/minetest/issues/5700

Tested on latest -dev on macOS.