### PR TITLE
Fix CSM crash

### DIFF
--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -202,7 +202,7 @@ For helper functions see "Vector helpers".
 ### pointed_thing
 * `{type="nothing"}`
 * `{type="node", under=pos, above=pos}`
-* `{type="object", ref=ObjectRef}`
+* `{type="object", id=ObjectID}`
 
 Flag Specifier Format
 ---------------------

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1441,7 +1441,7 @@ void read_json_value(lua_State *L, Json::Value &root, int index, u8 recursion)
 	lua_pop(L, 1); // Pop value
 }
 
-void push_pointed_thing(lua_State *L, const PointedThing &pointed)
+void push_pointed_thing(lua_State *L, const PointedThing &pointed, bool csm)
 {
 	lua_newtable(L);
 	if (pointed.type == POINTEDTHING_NODE) {
@@ -1454,8 +1454,14 @@ void push_pointed_thing(lua_State *L, const PointedThing &pointed)
 	} else if (pointed.type == POINTEDTHING_OBJECT) {
 		lua_pushstring(L, "object");
 		lua_setfield(L, -2, "type");
-		push_objectRef(L, pointed.object_id);
-		lua_setfield(L, -2, "ref");
+
+		if (csm) {
+			lua_pushinteger(L, pointed.object_id);
+			lua_setfield(L, -2, "id");
+		} else {
+			push_objectRef(L, pointed.object_id);
+			lua_setfield(L, -2, "ref");
+		}
 	} else {
 		lua_pushstring(L, "nothing");
 		lua_setfield(L, -2, "type");

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -164,7 +164,7 @@ bool               push_json_value           (lua_State *L,
 void               read_json_value           (lua_State *L, Json::Value &root,
                                               int index, u8 recursion = 0);
 
-void               push_pointed_thing        (lua_State *L, const PointedThing &pointed);
+void               push_pointed_thing        (lua_State *L, const PointedThing &pointed, bool csm = false);
 
 void               push_objectRef            (lua_State *L, const u16 id);
 

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -199,7 +199,7 @@ bool ScriptApiClient::on_placenode(const PointedThing &pointed, const ItemDefini
 	lua_getfield(L, -1, "registered_on_placenode");
 
 	// Push data
-	push_pointed_thing(L, pointed);
+	push_pointed_thing(L, pointed, true);
 	push_item_definition(L, item);
 
 	// Call functions
@@ -217,7 +217,7 @@ bool ScriptApiClient::on_item_use(const ItemStack &item, const PointedThing &poi
 
 	// Push data
 	LuaItemStack::create(L, item);
-	push_pointed_thing(L, pointed);
+	push_pointed_thing(L, pointed, true);
 
 	// Call functions
 	runCallbacks(2, RUN_CALLBACKS_MODE_OR);


### PR DESCRIPTION
Caused by dc5bc6c and them made worse by 5ebf8f9

> \<red-001> the client has no objectref
> \<nerzhul> yeah, it's just a typo .? because server side we said it's ref whereas it's an id, exact ?
> \<red-001> so trying to return one crashes minetest