### PR TITLE
[CSM] Correct the log destination of print()

### DIFF
--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -63,6 +63,15 @@ int ModApiClient::l_set_last_run_mod(lua_State *L)
 	return 1;
 }
 
+// print(text)
+int ModApiClient::l_print(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	std::string text = luaL_checkstring(L, 1);
+	rawstream << text << std::endl;
+	return 0;
+}
+
 // display_chat_message(message)
 int ModApiClient::l_display_chat_message(lua_State *L)
 {
@@ -261,6 +270,7 @@ int ModApiClient::l_take_screenshot(lua_State *L)
 void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
+	API_FCT(print);
 	API_FCT(display_chat_message);
 	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -29,6 +29,9 @@ private:
 	// get_current_modname()
 	static int l_get_current_modname(lua_State *L);
 
+	// print(text)
+	static int l_print(lua_State *L);
+
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 


### PR DESCRIPTION
This makes the Lua function `print(text)` in CSM consistent with SSM. Whenever the function is called, the message is directly sent to the raw output stream. Thanks to `builtin/init.lua`, which overwrites the by Lua shipped `print` function, when `core.print` was found.

It seems to be a Windows-only issue, given that the console window is used/activated.
Successfully tested.