### PR TITLE
Mgv6 mudflow: Remove decoration if 'dirt with grass' below flows away

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -836,13 +836,17 @@ void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 					v3s16(-1, 0, 0), // left
 				};
 
-				// Check that upper is air or doesn't exist.
-				// Cancel dropping if upper keeps it in place
+				// Check that upper is walkable. Cancel
+				// dropping if upper keeps it in place.
 				u32 i3 = i;
 				vm->m_area.add_y(em, i3, 1);
-				if (vm->m_area.contains(i3) == true &&
-						ndef->get(vm->m_data[i3]).walkable)
-					continue;
+				MapNode *n3 = NULL;
+
+				if (vm->m_area.contains(i3)) {
+					n3 = &vm->m_data[i3];
+					if (ndef->get(*n3).walkable)
+						continue;
+				}
 
 				// Drop mud on side
 				for (u32 di = 0; di < 4; di++) {
@@ -885,10 +889,18 @@ void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 					if (!dropped_to_unknown) {
 						*n2 = *n;
 						// Set old place to be air (or water)
-						if (old_is_water)
+						if (old_is_water) {
 							*n = MapNode(c_water_source);
-						else
+						} else {
 							*n = MapNode(CONTENT_AIR);
+							// Upper (n3) is not walkable or is NULL. If it is
+							// not NULL and not air and not water it is a
+							// decoration that needs removing, to avoid
+							// unsupported decorations.
+							if (n3 && n3->getContent() != CONTENT_AIR &&
+									n3->getContent() != c_water_source)
+								*n3 = MapNode(CONTENT_AIR);
+						}
 					}
 
 					// Done


### PR DESCRIPTION
Mudflow of a neighbouring mapchunk extends into a mapchunk's edge, and could
remove 'dirt with grass' from under a decoration, creating unsupported
decorations.

Remove any decoration above if a 'dirt with grass' node is removed by mudflow.
//////////////////////////////////////

Fixes #5796 
Tested.

![screenshot_20170522_121603](https://cloud.githubusercontent.com/assets/3686677/26305909/1f5136e8-3ee9-11e7-9bda-24d36433ef4f.png)

^ Same hill as shown on issue, no floating grasses.

The 'node above' the removed 'dirt with grass' node is the newly-added 'Mapnode *n3'. The PR gets 'n3' at low cost, at a place in the code where 'node above' is already being tested. Then 'n3' is used later.