### PR TITLE
Read meta after node digging to ensure it is correct

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3744,6 +3744,13 @@ void Game::handlePointingAtNode(const PointedThing &pointed, const ItemDefinitio
 	*/
 
 	ClientMap &map = client->getEnv().getClientMap();
+
+	if (runData.nodig_delay_timer <= 0.0 && isLeftPressed()
+			&& client->checkPrivilege("interact")) {
+		handleDigging(pointed, nodepos, playeritem_toolcap, dtime);
+	}
+
+	// This should be done after digging handling
 	NodeMetadata *meta = map.getNodeMetadata(nodepos);
 
 	if (meta) {
@@ -3755,11 +3762,6 @@ void Game::handlePointingAtNode(const PointedThing &pointed, const ItemDefinitio
 			infotext = L"Unknown node: ";
 			infotext += utf8_to_wide(nodedef_manager->get(n).name);
 		}
-	}
-
-	if (runData.nodig_delay_timer <= 0.0 && isLeftPressed()
-			&& client->checkPrivilege("interact")) {
-		handleDigging(pointed, nodepos, playeritem_toolcap, dtime);
 	}
 
 	if ((getRightClicked() ||
@@ -3977,10 +3979,9 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		bool is_valid_position;
 		MapNode wasnode = map.getNodeNoEx(nodepos, &is_valid_position);
 		if (is_valid_position) {
-			if (client->moddingEnabled()) {
-				if (client->getScript()->on_dignode(nodepos, wasnode)) {
-					return;
-				}
+			if (client->moddingEnabled() && 
+			    		client->getScript()->on_dignode(nodepos, wasnode)) {
+				return;
 			}
 			client->removeNode(nodepos);
 		}


### PR DESCRIPTION
Fixes a crash caused in MTGame by breaking and right-clicking a chest.
//////////////////////////

Rewritten version of #5300 
Fixes https://github.com/minetest/minetest_game/issues/1462
@Fixer-007 