### PR TITLE
Revert 1469424 and fix wrong char position when doing mouse selection on intlGUIEditBox

### DIFF
--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -1099,21 +1099,21 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 
 	core::stringw *txtLine = NULL;
 	s32 startPos = 0;
-	u32 cur_line_idx = 0;
+	u32 curr_line_idx = 0;
 	x += 3;
 
-	for (; cur_line_idx < lineCount; ++cur_line_idx) {
-		setTextRect(cur_line_idx);
-		if (cur_line_idx == 0 && y < CurrentTextRect.UpperLeftCorner.Y)
+	for (; curr_line_idx < lineCount; ++curr_line_idx) {
+		setTextRect(curr_line_idx);
+		if (curr_line_idx == 0 && y < CurrentTextRect.UpperLeftCorner.Y)
 			y = CurrentTextRect.UpperLeftCorner.Y;
-		if (cur_line_idx == lineCount - 1 && y > CurrentTextRect.LowerRightCorner.Y)
+		if (curr_line_idx == lineCount - 1 && y > CurrentTextRect.LowerRightCorner.Y)
 			y = CurrentTextRect.LowerRightCorner.Y;
 
 		// is it inside this region?
 		if (y >= CurrentTextRect.UpperLeftCorner.Y && y <= CurrentTextRect.LowerRightCorner.Y) {
 			// we've found the clicked line
-			txtLine = (WordWrap || MultiLine) ? &BrokenText[cur_line_idx] : &Text;
-			startPos = (WordWrap || MultiLine) ? BrokenTextPositions[cur_line_idx] : 0;
+			txtLine = (WordWrap || MultiLine) ? &BrokenText[curr_line_idx] : &Text;
+			startPos = (WordWrap || MultiLine) ? BrokenTextPositions[curr_line_idx] : 0;
 			break;
 		}
 	}
@@ -1126,7 +1126,7 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 	s32 idx = font->getCharacterFromPos(txtLine->c_str(), x - CurrentTextRect.UpperLeftCorner.X);
 	// Special handling for last line, if we are on limits, add 1 extra shift because idx
 	// will be the last char, not null char of the wstring
-	if (cur_line_idx == lineCount - 1 && x == CurrentTextRect.LowerRightCorner.X)
+	if (curr_line_idx == lineCount - 1 && x == CurrentTextRect.LowerRightCorner.X)
 		idx++;
 
 	return rangelim(idx + startPos, 0, S32_MAX);

--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -1097,7 +1097,7 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 
 	const u32 lineCount = (WordWrap || MultiLine) ? BrokenText.size() : 1;
 
-	core::stringw *txtLine = 0;
+	core::stringw *txtLine = NULL;
 	s32 startPos = 0;
 	u32 cur_line_idx = 0;
 	x += 3;

--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -1096,41 +1096,37 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 
 	const u32 lineCount = (WordWrap || MultiLine) ? BrokenText.size() : 1;
 
-	core::stringw *txtLine=0;
-	s32 startPos=0;
-	x+=3;
+	core::stringw *txtLine = 0;
+	s32 startPos = 0;
+	u32 cur_line_idx = 0;
+	x += 3;
 
-	for (u32 i=0; i < lineCount; ++i)
-	{
-		setTextRect(i);
-		if (i == 0 && y < CurrentTextRect.UpperLeftCorner.Y)
+	for (; cur_line_idx < lineCount; ++cur_line_idx) {
+		setTextRect(cur_line_idx);
+		if (cur_line_idx == 0 && y < CurrentTextRect.UpperLeftCorner.Y)
 			y = CurrentTextRect.UpperLeftCorner.Y;
-		if (i == lineCount - 1 && y > CurrentTextRect.LowerRightCorner.Y )
+		if (cur_line_idx == lineCount - 1 && y > CurrentTextRect.LowerRightCorner.Y)
 			y = CurrentTextRect.LowerRightCorner.Y;
 
 		// is it inside this region?
-		if (y >= CurrentTextRect.UpperLeftCorner.Y && y <= CurrentTextRect.LowerRightCorner.Y)
-		{
+		if (y >= CurrentTextRect.UpperLeftCorner.Y && y <= CurrentTextRect.LowerRightCorner.Y) {
 			// we've found the clicked line
-			txtLine = (WordWrap || MultiLine) ? &BrokenText[i] : &Text;
-			startPos = (WordWrap || MultiLine) ? BrokenTextPositions[i] : 0;
+			txtLine = (WordWrap || MultiLine) ? &BrokenText[cur_line_idx] : &Text;
+			startPos = (WordWrap || MultiLine) ? BrokenTextPositions[cur_line_idx] : 0;
 			break;
 		}
 	}
 
 	if (x < CurrentTextRect.UpperLeftCorner.X)
 		x = CurrentTextRect.UpperLeftCorner.X;
-	else if (x > CurrentTextRect.LowerRightCorner.X + 1)
-		x = CurrentTextRect.LowerRightCorner.X + 1;
+	else if (x > CurrentTextRect.LowerRightCorner.X)
+		x = CurrentTextRect.LowerRightCorner.X;
 
-	s32 idx = font->getCharacterFromPos(Text.c_str(), x - CurrentTextRect.UpperLeftCorner.X);
+	s32 idx = font->getCharacterFromPos(txtLine->c_str(), x - CurrentTextRect.UpperLeftCorner.X);
 
-	// click was on or left of the line
-	if (idx != -1)
-		return idx + startPos;
-
-	// click was off the right edge of the last line, go to end.
-	return txtLine->size() + startPos;
+	// On last line we should shift 1 char (due to the null string delimiter \0)
+	u8 shift_last_char = (cur_line_idx == lineCount - 1) ? 1 : 0;
+	return idx + startPos + shift_last_char;
 }
 
 

--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -29,6 +29,7 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
+#include <util/numeric.h>
 #include "intlGUIEditBox.h"
 
 #if defined(_IRR_COMPILE_WITH_GUI_) && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
@@ -1123,10 +1124,13 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 		x = CurrentTextRect.LowerRightCorner.X;
 
 	s32 idx = font->getCharacterFromPos(txtLine->c_str(), x - CurrentTextRect.UpperLeftCorner.X);
+	// Special handling for last line, if we are on limits, add 1 extra shift because idx
+	// will be the last char, not null char of the wstring
+	if (cur_line_idx == lineCount - 1 && x == CurrentTextRect.LowerRightCorner.X)
+		idx++;
 
 	// On last line we should shift 1 char (due to the null string delimiter \0)
-	u8 shift_last_char = (cur_line_idx == lineCount - 1) ? 1 : 0;
-	return idx + startPos + shift_last_char;
+	return rangelim(idx + startPos, 0, S32_MAX);
 }
 
 

--- a/src/intlGUIEditBox.cpp
+++ b/src/intlGUIEditBox.cpp
@@ -1129,7 +1129,6 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 	if (cur_line_idx == lineCount - 1 && x == CurrentTextRect.LowerRightCorner.X)
 		idx++;
 
-	// On last line we should shift 1 char (due to the null string delimiter \0)
 	return rangelim(idx + startPos, 0, S32_MAX);
 }
 


### PR DESCRIPTION
We shift one char when we are selecting the right to last char of the last line because \0 is not handled like \n by font->getCharacterFromPos 

poke @Fixer-007 

fixed #5805 and #5804 