### PR TITLE
Minetest for C++11 (CMakeLists + Travis)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ BasedOnStyle: LLVM
 IndentWidth: 8
 UseTab: Always
 BreakBeforeBraces: Custom
-Standard: Cpp03
+Standard: Cpp11
 BraceWrapping:
   AfterClass: true
   AfterControlStatement: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 before_install: ./util/travis/before_install.sh
 script: ./util/travis/script.sh
 sudo: required
+dist: trusty
 notifications:
   email: false
 matrix:
@@ -10,30 +11,81 @@ matrix:
     - env: PLATFORM=Win32
       compiler: gcc
       os: linux
+      addons:
+        apt:
+          packages: ['gcc-mingw-w64-i686', 'g++-mingw-w64-i686', 'binutils-mingw-w64-i686']
+          sources: &sources
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb http://mirrors.kernel.org/ubuntu xenial main universe'
+
     - env: PLATFORM=Win64
       compiler: gcc
       os: linux
-    - env: PLATFORM=Unix COMPILER=clang
+      addons:
+        apt:
+          packages: ['gcc-mingw-w64-x86-64', 'g++-mingw-w64-x86-64', 'binutils-mingw-w64-x86-64']
+          sources: &sources
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb http://mirrors.kernel.org/ubuntu xenial main universe'
+
+    - env: PLATFORM=Unix
       compiler: clang
       os: osx
-    - env: PLATFORM=Unix COMPILER=g++
+      osx_image: xcode8
+
+    - env: PLATFORM=Unix COMPILER=gcc-6
       compiler: gcc
       os: linux
-    - env: PLATFORM=Unix COMPILER=clang
-      compiler: clang
-      os: linux
-    - env: PLATFORM=Unix COMPILER=clang VALGRIND=1
-      compiler: clang
-      os: linux
-      dist: trusty
-    - env: COMPILER=none LINT=1
-      compiler: clang
-      os: linux
-      dist: trusty
-    - env: PLATFORM=Unix COMPILER=g++-6
+      addons:
+        apt:
+          packages: ['gcc-6', 'g++-6']
+          sources: &sources
+            - ubuntu-toolchain-r-test
+
+    - env: PLATFORM=Unix COMPILER=gcc-7
       compiler: gcc
       os: linux
-addons:
-  apt:
-    sources: &sources
-      - ubuntu-toolchain-r-test
+      addons:
+        apt:
+          packages: ['gcc-7', 'g++-7']
+          sources: &sources
+            - ubuntu-toolchain-r-test
+
+    - env: PLATFORM=Unix COMPILER=clang-3.6
+      compiler: clang
+      os: linux
+      addons:
+        apt:
+          packages: ['clang-3.6', 'clang++-3.6']
+          sources: &sources
+            - llvm-toolchain-trusty-3.6
+
+    - env: PLATFORM=Unix COMPILER=clang-4.0
+      compiler: clang
+      os: linux
+      addons:
+        apt:
+          packages: ['clang-4.0', 'clang++-4.0']
+          sources: &sources
+            - llvm-toolchain-trusty-4.0
+
+    - env: PLATFORM=Unix COMPILER=clang-4.0 VALGRIND=1
+      compiler: clang
+      os: linux
+      addons:
+        apt:
+          packages: ['valgrind', 'clang-4.0', 'clang++-4.0']
+          sources: &sources
+            - llvm-toolchain-trusty-4.0
+
+    - env: LINT=1
+      compiler: clang
+      os: linux
+      addons:
+        apt:
+          packages: ['clang-format-4.0']
+          sources: &sources
+            - llvm-toolchain-trusty-4.0
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 project(minetest)
 set(PROJECT_NAME_CAPITALIZED "Minetest")
 
+# Works only for cmake 3.1 and greater
+set(CMAKE_CXX_STANDARD 11)
 
 # Also remember to set PROTOCOL_VERSION in network/networkprotocol.h when releasing
 set(VERSION_MAJOR 0)

--- a/lib/jsoncpp/json/json.h
+++ b/lib/jsoncpp/json/json.h
@@ -6,28 +6,28 @@
 // //////////////////////////////////////////////////////////////////////
 
 /*
-The JsonCpp library's source code, including accompanying documentation,
+The JsonCpp library's source code, including accompanying documentation, 
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all
-jurisdictions which recognize such a disclaimer. In such jurisdictions,
+The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
+jurisdictions which recognize such a disclaimer. In such jurisdictions, 
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
 2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
 released under the terms of the MIT License (see below).
 
-In jurisdictions which recognize Public Domain property, the user of this
-software may choose to accept it either as 1) Public Domain, 2) under the
-conditions of the MIT License (see below), or 3) under the terms of dual
+In jurisdictions which recognize Public Domain property, the user of this 
+software may choose to accept it either as 1) Public Domain, 2) under the 
+conditions of the MIT License (see below), or 3) under the terms of dual 
 Public Domain/MIT License conditions described here, as they choose.
 
 The MIT License is about as close to Public Domain as a license can get, and is
 described in clear, concise terms at:
 
    http://en.wikipedia.org/wiki/MIT_License
-
+   
 The full text of the MIT License follows:
 
 ========================================================================
@@ -77,7 +77,7 @@ license you like.
 /// If defined, indicates that the source file is amalgated
 /// to prevent private header inclusion.
 #define JSON_IS_AMALGAMATION
-#define JSONCPP_STRING
+
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: include/json/version.h
 // //////////////////////////////////////////////////////////////////////
@@ -87,12 +87,19 @@ license you like.
 #ifndef JSON_VERSION_H_INCLUDED
 # define JSON_VERSION_H_INCLUDED
 
-# define JSONCPP_VERSION_STRING "0.10.6"
-# define JSONCPP_VERSION_MAJOR 0
-# define JSONCPP_VERSION_MINOR 10
-# define JSONCPP_VERSION_PATCH 6
+# define JSONCPP_VERSION_STRING "1.8.0"
+# define JSONCPP_VERSION_MAJOR 1
+# define JSONCPP_VERSION_MINOR 8
+# define JSONCPP_VERSION_PATCH 0
 # define JSONCPP_VERSION_QUALIFIER
 # define JSONCPP_VERSION_HEXA ((JSONCPP_VERSION_MAJOR << 24) | (JSONCPP_VERSION_MINOR << 16) | (JSONCPP_VERSION_PATCH << 8))
+
+#ifdef JSONCPP_USING_SECURE_MEMORY
+#undef JSONCPP_USING_SECURE_MEMORY
+#endif
+#define JSONCPP_USING_SECURE_MEMORY 0
+// If non-zero, the library zeroes any memory that it has allocated before
+// it frees its memory.
 
 #endif // JSON_VERSION_H_INCLUDED
 
@@ -116,6 +123,9 @@ license you like.
 
 #ifndef JSON_CONFIG_H_INCLUDED
 #define JSON_CONFIG_H_INCLUDED
+#include <stddef.h>
+#include <string> //typedef String
+#include <stdint.h> //typedef int64_t, uint64_t
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1
@@ -148,12 +158,12 @@ license you like.
 #ifdef JSON_IN_CPPTL
 #define JSON_API CPPTL_API
 #elif defined(JSON_DLL_BUILD)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define JSON_API __declspec(dllexport)
 #define JSONCPP_DISABLE_DLL_INTERFACE_WARNING
 #endif // if defined(_MSC_VER)
 #elif defined(JSON_DLL)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define JSON_API __declspec(dllimport)
 #define JSONCPP_DISABLE_DLL_INTERFACE_WARNING
 #endif // if defined(_MSC_VER)
@@ -167,33 +177,92 @@ license you like.
 // Storages, and 64 bits integer support is disabled.
 // #define JSON_NO_INT64 1
 
-#if defined(_MSC_VER) && _MSC_VER <= 1200 // MSVC 6
-// Microsoft Visual Studio 6 only support conversion from __int64 to double
-// (no conversion from unsigned __int64).
-#define JSON_USE_INT64_DOUBLE_CONVERSION 1
-// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
-// characters in the debug information)
-// All projects I've ever seen with VS6 were using this globally (not bothering
-// with pragma push/pop).
-#pragma warning(disable : 4786)
-#endif // if defined(_MSC_VER)  &&  _MSC_VER < 1200 // MSVC 6
+#if defined(_MSC_VER) // MSVC
+#  if _MSC_VER <= 1200 // MSVC 6
+    // Microsoft Visual Studio 6 only support conversion from __int64 to double
+    // (no conversion from unsigned __int64).
+#    define JSON_USE_INT64_DOUBLE_CONVERSION 1
+    // Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
+    // characters in the debug information)
+    // All projects I've ever seen with VS6 were using this globally (not bothering
+    // with pragma push/pop).
+#    pragma warning(disable : 4786)
+#  endif // MSVC 6
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500 // MSVC 2008
-/// Indicates that the following function is deprecated.
-#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
-#elif defined(__clang__) && defined(__has_feature)
-#if __has_feature(attribute_deprecated_with_message)
-#define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
+#  if _MSC_VER >= 1500 // MSVC 2008
+    /// Indicates that the following function is deprecated.
+#    define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+#  endif
+
+#endif // defined(_MSC_VER)
+
+// In c++11 the override keyword allows you to explicity define that a function
+// is intended to override the base-class version.  This makes the code more
+// managable and fixes a set of common hard-to-find bugs.
+#if __cplusplus >= 201103L
+# define JSONCPP_OVERRIDE override
+# define JSONCPP_NOEXCEPT noexcept
+#elif defined(_MSC_VER) && _MSC_VER > 1600 && _MSC_VER < 1900
+# define JSONCPP_OVERRIDE override
+# define JSONCPP_NOEXCEPT throw()
+#elif defined(_MSC_VER) && _MSC_VER >= 1900
+# define JSONCPP_OVERRIDE override
+# define JSONCPP_NOEXCEPT noexcept
+#else
+# define JSONCPP_OVERRIDE
+# define JSONCPP_NOEXCEPT throw()
 #endif
-#elif defined(__GNUC__) &&  (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
-#define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
-#elif defined(__GNUC__) &&  (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
-#define JSONCPP_DEPRECATED(message)  __attribute__((__deprecated__))
+
+#ifndef JSON_HAS_RVALUE_REFERENCES
+
+#if defined(_MSC_VER) && _MSC_VER >= 1600 // MSVC >= 2010
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif // MSVC >= 2010
+
+#ifdef __clang__
+#if __has_feature(cxx_rvalue_references)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif  // has_feature
+
+#elif defined __GNUC__ // not clang (gcc comes later since clang emulates gcc)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif  // GXX_EXPERIMENTAL
+
+#endif // __clang__ || __GNUC__
+
+#endif // not defined JSON_HAS_RVALUE_REFERENCES
+
+#ifndef JSON_HAS_RVALUE_REFERENCES
+#define JSON_HAS_RVALUE_REFERENCES 0
 #endif
+
+#ifdef __clang__
+#elif defined __GNUC__ // not clang (gcc comes later since clang emulates gcc)
+#  if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+#    define JSONCPP_DEPRECATED(message)  __attribute__ ((deprecated(message)))
+#  elif (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
+#    define JSONCPP_DEPRECATED(message)  __attribute__((__deprecated__))
+#  endif  // GNUC version
+#endif // __clang__ || __GNUC__
 
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)
 #endif // if !defined(JSONCPP_DEPRECATED)
+
+#if __GNUC__ >= 6
+#  define JSON_USE_INT64_DOUBLE_CONVERSION 1
+#endif
+
+#if !defined(JSON_IS_AMALGAMATION)
+
+# include "version.h"
+
+# if JSONCPP_USING_SECURE_MEMORY
+#  include "allocator.h" //typedef Allocator
+# endif
+
+#endif // if !defined(JSON_IS_AMALGAMATION)
 
 namespace Json {
 typedef int Int;
@@ -208,13 +277,26 @@ typedef unsigned int LargestUInt;
 typedef __int64 Int64;
 typedef unsigned __int64 UInt64;
 #else                 // if defined(_MSC_VER) // Other platforms, use long long
-typedef long long int Int64;
-typedef unsigned long long int UInt64;
+typedef int64_t Int64;
+typedef uint64_t UInt64;
 #endif // if defined(_MSC_VER)
 typedef Int64 LargestInt;
 typedef UInt64 LargestUInt;
 #define JSON_HAS_INT64
 #endif // if defined(JSON_NO_INT64)
+#if JSONCPP_USING_SECURE_MEMORY
+#define JSONCPP_STRING        std::basic_string<char, std::char_traits<char>, Json::SecureAllocator<char> >
+#define JSONCPP_OSTRINGSTREAM std::basic_ostringstream<char, std::char_traits<char>, Json::SecureAllocator<char> >
+#define JSONCPP_OSTREAM       std::basic_ostream<char, std::char_traits<char>>
+#define JSONCPP_ISTRINGSTREAM std::basic_istringstream<char, std::char_traits<char>, Json::SecureAllocator<char> >
+#define JSONCPP_ISTREAM       std::istream
+#else
+#define JSONCPP_STRING        std::string
+#define JSONCPP_OSTRINGSTREAM std::ostringstream
+#define JSONCPP_OSTREAM       std::ostream
+#define JSONCPP_ISTRINGSTREAM std::istringstream
+#define JSONCPP_ISTREAM       std::istream
+#endif // if JSONCPP_USING_SECURE_MEMORY
 } // end namespace Json
 
 #endif // JSON_CONFIG_H_INCLUDED
@@ -295,6 +377,8 @@ class ValueConstIterator;
 #include "forwards.h"
 #endif // if !defined(JSON_IS_AMALGAMATION)
 
+#pragma pack(push, 8)
+
 namespace Json {
 
 /** \brief Configuration passed to reader and writer.
@@ -329,9 +413,17 @@ public:
   /// \c true if root must be either an array or an object value. Default: \c
   /// false.
   bool strictRoot_;
+
+  /// \c true if dropped null placeholders are allowed. Default: \c false.
+  bool allowDroppedNullPlaceholders_;
+
+  /// \c true if numeric object key are allowed. Default: \c false.
+  bool allowNumericKeys_;
 };
 
 } // namespace Json
+
+#pragma pack(pop)
 
 #endif // CPPTL_JSON_FEATURES_H_INCLUDED
 
@@ -372,15 +464,8 @@ public:
 #include <cpptl/forwards.h>
 #endif
 
-// Disable warning C4251: <data member>: <type> needs to have dll-interface to
-// be used by...
-#if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
-
 //Conditional NORETURN attribute on the throw functions would:
-// a) suppress false positives from static code analysis
+// a) suppress false positives from static code analysis 
 // b) possibly improve optimization opportunities.
 #if !defined(JSONCPP_NORETURN)
 #  if defined(_MSC_VER)
@@ -392,6 +477,15 @@ public:
 #  endif
 #endif
 
+// Disable warning C4251: <data member>: <type> needs to have dll-interface to
+// be used by...
+#if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
+
+#pragma pack(push, 8)
+
 /** \brief JSON (JavaScript Object Notation).
  */
 namespace Json {
@@ -402,39 +496,39 @@ namespace Json {
  */
 class JSON_API Exception : public std::exception {
 public:
-  Exception(std::string const& msg);
-  virtual ~Exception() throw();
-  virtual char const* what() const throw();
+  Exception(JSONCPP_STRING const& msg);
+  ~Exception() JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
+  char const* what() const JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
 protected:
-  std::string const msg_;
+  JSONCPP_STRING msg_;
 };
 
 /** Exceptions which the user cannot easily avoid.
  *
  * E.g. out-of-memory (when we use malloc), stack-overflow, malicious input
- *
+ * 
  * \remark derived from Json::Exception
  */
 class JSON_API RuntimeError : public Exception {
 public:
-  RuntimeError(std::string const& msg);
+  RuntimeError(JSONCPP_STRING const& msg);
 };
 
 /** Exceptions thrown by JSON_ASSERT/JSON_FAIL macros.
  *
  * These are precondition-violations (user bugs) and internal errors (our bugs).
- *
+ * 
  * \remark derived from Json::Exception
  */
 class JSON_API LogicError : public Exception {
 public:
-  LogicError(std::string const& msg);
+  LogicError(JSONCPP_STRING const& msg);
 };
 
 /// used internally
-JSONCPP_NORETURN void throwRuntimeError(std::string const& msg);
+JSONCPP_NORETURN void throwRuntimeError(JSONCPP_STRING const& msg);
 /// used internally
-JSONCPP_NORETURN void throwLogicError(std::string const& msg);
+JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg);
 
 /** \brief Type of the value held by a Value object.
  */
@@ -525,7 +619,7 @@ private:
 class JSON_API Value {
   friend class ValueIteratorBase;
 public:
-  typedef std::vector<std::string> Members;
+  typedef std::vector<JSONCPP_STRING> Members;
   typedef ValueIterator iterator;
   typedef ValueConstIterator const_iterator;
   typedef Json::UInt UInt;
@@ -538,11 +632,10 @@ public:
   typedef Json::LargestUInt LargestUInt;
   typedef Json::ArrayIndex ArrayIndex;
 
-  static const Value& nullRef;
-#if !defined(__ARMEL__)
-  /// \deprecated This exists for binary compatibility only. Use nullRef.
-  static const Value null;
-#endif
+  static const Value& null;  ///< We regret this reference to a global instance; prefer the simpler Value().
+  static const Value& nullRef;  ///< just a kludge for binary-compatibility; same as null
+  static Value const& nullSingleton(); ///< Prefer this to null or nullRef.
+
   /// Minimum signed integer value that can be stored in a Json::Value.
   static const LargestInt minLargestInt;
   /// Maximum signed integer value that can be stored in a Json::Value.
@@ -578,6 +671,9 @@ private:
     CZString(ArrayIndex index);
     CZString(char const* str, unsigned length, DuplicationPolicy allocate);
     CZString(CZString const& other);
+#if JSON_HAS_RVALUE_REFERENCES
+    CZString(CZString&& other);
+#endif
     ~CZString();
     CZString& operator=(CZString other);
     bool operator<(CZString const& other) const;
@@ -653,18 +749,22 @@ Json::Value obj_value(Json::objectValue); // {}
    * \endcode
    */
   Value(const StaticString& value);
-  Value(const std::string& value); ///< Copy data() til size(). Embedded zeroes too.
+  Value(const JSONCPP_STRING& value); ///< Copy data() til size(). Embedded zeroes too.
 #ifdef JSON_USE_CPPTL
   Value(const CppTL::ConstString& value);
 #endif
   Value(bool value);
   /// Deep copy.
   Value(const Value& other);
+#if JSON_HAS_RVALUE_REFERENCES
+  /// Move constructor
+  Value(Value&& other);
+#endif
   ~Value();
 
   /// Deep copy, then swap(other).
   /// \note Over-write existing comments. To preserve comments, use #swapPayload().
-  Value &operator=(const Value &other);
+  Value& operator=(Value other);
   /// Swap everything.
   void swap(Value& other);
   /// Swap values but leave comments and source offsets in place.
@@ -682,7 +782,10 @@ Json::Value obj_value(Json::objectValue); // {}
   int compare(const Value& other) const;
 
   const char* asCString() const; ///< Embedded zeroes could cause you trouble!
-  std::string asString() const; ///< Embedded zeroes are possible.
+#if JSONCPP_USING_SECURE_MEMORY
+  unsigned getCStringLength() const; //Allows you to understand the length of the CString
+#endif
+  JSONCPP_STRING asString() const; ///< Embedded zeroes are possible.
   /** Get raw char* of string-value.
    *  \return false if !string. (Seg-fault if str or end are NULL.)
    */
@@ -786,11 +889,11 @@ Json::Value obj_value(Json::objectValue); // {}
   const Value& operator[](const char* key) const;
   /// Access an object value by name, create a null member if it does not exist.
   /// \param key may contain embedded nulls.
-  Value& operator[](const std::string& key);
+  Value& operator[](const JSONCPP_STRING& key);
   /// Access an object value by name, returns null if there is no member with
   /// that name.
   /// \param key may contain embedded nulls.
-  const Value& operator[](const std::string& key) const;
+  const Value& operator[](const JSONCPP_STRING& key) const;
   /** \brief Access an object value by name, create a null member if it does not
    exist.
 
@@ -821,7 +924,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Return the member named key if it exist, defaultValue otherwise.
   /// \note deep copy
   /// \param key may contain embedded nulls.
-  Value get(const std::string& key, const Value& defaultValue) const;
+  Value get(const JSONCPP_STRING& key, const Value& defaultValue) const;
 #ifdef JSON_USE_CPPTL
   /// Return the member named key if it exist, defaultValue otherwise.
   /// \note deep copy
@@ -846,7 +949,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Same as removeMember(const char*)
   /// \param key may contain embedded nulls.
   /// \deprecated
-  Value removeMember(const std::string& key);
+  Value removeMember(const JSONCPP_STRING& key);
   /// Same as removeMember(const char* begin, const char* end, Value* removed),
   /// but 'key' is null-terminated.
   bool removeMember(const char* key, Value* removed);
@@ -856,8 +959,8 @@ Json::Value obj_value(Json::objectValue); // {}
       \param key may contain embedded nulls.
       \return true iff removed (no exceptions)
   */
-  bool removeMember(std::string const& key, Value* removed);
-  /// Same as removeMember(std::string const& key, Value* removed)
+  bool removeMember(JSONCPP_STRING const& key, Value* removed);
+  /// Same as removeMember(JSONCPP_STRING const& key, Value* removed)
   bool removeMember(const char* begin, const char* end, Value* removed);
   /** \brief Remove the indexed array element.
 
@@ -872,8 +975,8 @@ Json::Value obj_value(Json::objectValue); // {}
   bool isMember(const char* key) const;
   /// Return true if the object has a member named key.
   /// \param key may contain embedded nulls.
-  bool isMember(const std::string& key) const;
-  /// Same as isMember(std::string const& key)const
+  bool isMember(const JSONCPP_STRING& key) const;
+  /// Same as isMember(JSONCPP_STRING const& key)const
   bool isMember(const char* begin, const char* end) const;
 #ifdef JSON_USE_CPPTL
   /// Return true if the object has a member named key.
@@ -893,23 +996,30 @@ Json::Value obj_value(Json::objectValue); // {}
   //# endif
 
   /// \deprecated Always pass len.
-  JSONCPP_DEPRECATED("Use setComment(std::string const&) instead.")
+  JSONCPP_DEPRECATED("Use setComment(JSONCPP_STRING const&) instead.")
   void setComment(const char* comment, CommentPlacement placement);
   /// Comments must be //... or /* ... */
   void setComment(const char* comment, size_t len, CommentPlacement placement);
   /// Comments must be //... or /* ... */
-  void setComment(const std::string& comment, CommentPlacement placement);
+  void setComment(const JSONCPP_STRING& comment, CommentPlacement placement);
   bool hasComment(CommentPlacement placement) const;
   /// Include delimiters and embedded newlines.
-  std::string getComment(CommentPlacement placement) const;
+  JSONCPP_STRING getComment(CommentPlacement placement) const;
 
-  std::string toStyledString() const;
+  JSONCPP_STRING toStyledString() const;
 
   const_iterator begin() const;
   const_iterator end() const;
 
   iterator begin();
   iterator end();
+
+  // Accessors for the [start, limit) range of bytes within the JSON text from
+  // which this value was parsed, if any.
+  void setOffsetStart(ptrdiff_t start);
+  void setOffsetLimit(ptrdiff_t limit);
+  ptrdiff_t getOffsetStart() const;
+  ptrdiff_t getOffsetLimit() const;
 
 private:
   void initBasic(ValueType type, bool allocated = false);
@@ -947,6 +1057,11 @@ private:
   unsigned int allocated_ : 1; // Notes: if declared as bool, bitfield is useless.
                                // If not allocated_, string_ must be null-terminated.
   CommentInfo* comments_;
+
+  // [start, limit) byte offsets in the source JSON text from which this Value
+  // was extracted.
+  ptrdiff_t start_;
+  ptrdiff_t limit_;
 };
 
 /** \brief Experimental and untested: represents an element of the "path" to
@@ -959,7 +1074,7 @@ public:
   PathArgument();
   PathArgument(ArrayIndex index);
   PathArgument(const char* key);
-  PathArgument(const std::string& key);
+  PathArgument(const JSONCPP_STRING& key);
 
 private:
   enum Kind {
@@ -967,7 +1082,7 @@ private:
     kindIndex,
     kindKey
   };
-  std::string key_;
+  JSONCPP_STRING key_;
   ArrayIndex index_;
   Kind kind_;
 };
@@ -985,7 +1100,7 @@ private:
  */
 class JSON_API Path {
 public:
-  Path(const std::string& path,
+  Path(const JSONCPP_STRING& path,
        const PathArgument& a1 = PathArgument(),
        const PathArgument& a2 = PathArgument(),
        const PathArgument& a3 = PathArgument(),
@@ -1002,12 +1117,12 @@ private:
   typedef std::vector<const PathArgument*> InArgs;
   typedef std::vector<PathArgument> Args;
 
-  void makePath(const std::string& path, const InArgs& in);
-  void addPathInArg(const std::string& path,
+  void makePath(const JSONCPP_STRING& path, const InArgs& in);
+  void addPathInArg(const JSONCPP_STRING& path,
                     const InArgs& in,
                     InArgs::const_iterator& itInArg,
                     PathArgument::Kind kind);
-  void invalidPath(const std::string& path, int location);
+  void invalidPath(const JSONCPP_STRING& path, int location);
 
   Args args_;
 };
@@ -1040,7 +1155,7 @@ public:
   /// Return the member name of the referenced Value, or "" if it is not an
   /// objectValue.
   /// \note Avoid `c_str()` on result, as embedded zeroes are possible.
-  std::string name() const;
+  JSONCPP_STRING name() const;
 
   /// Return the member name of the referenced Value. "" if it is not an
   /// objectValue.
@@ -1092,6 +1207,7 @@ public:
   typedef ValueConstIterator SelfType;
 
   ValueConstIterator();
+  ValueConstIterator(ValueIterator const& other);
 
 private:
 /*! \internal Use by Value to create an iterator.
@@ -1141,7 +1257,7 @@ public:
   typedef ValueIterator SelfType;
 
   ValueIterator();
-  ValueIterator(const ValueConstIterator& other);
+  explicit ValueIterator(const ValueConstIterator& other);
   ValueIterator(const ValueIterator& other);
 
 private:
@@ -1187,6 +1303,7 @@ template<>
 inline void swap(Json::Value& a, Json::Value& b) { a.swap(b); }
 }
 
+#pragma pack(pop)
 
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 #pragma warning(pop)
@@ -1232,6 +1349,8 @@ inline void swap(Json::Value& a, Json::Value& b) { a.swap(b); }
 #pragma warning(disable : 4251)
 #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 
+#pragma pack(push, 8)
+
 namespace Json {
 
 /** \brief Unserialize a <a HREF="http://www.json.org">JSON</a> document into a
@@ -1243,6 +1362,18 @@ class JSON_API Reader {
 public:
   typedef char Char;
   typedef const Char* Location;
+
+  /** \brief An error tagged with where in the JSON text it was encountered.
+   *
+   * The offsets give the [start, limit) range of bytes within the text. Note
+   * that this is bytes, not codepoints.
+   *
+   */
+  struct StructuredError {
+    ptrdiff_t offset_start;
+    ptrdiff_t offset_limit;
+    JSONCPP_STRING message;
+  };
 
   /** \brief Constructs a Reader allowing all features
    * for parsing.
@@ -1296,7 +1427,7 @@ public:
 
   /// \brief Parse from input stream.
   /// \see Json::operator>>(std::istream&, Json::Value&).
-  bool parse(std::istream& is, Value& root, bool collectComments = true);
+  bool parse(JSONCPP_ISTREAM& is, Value& root, bool collectComments = true);
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -1308,7 +1439,7 @@ public:
    * \deprecated Use getFormattedErrorMessages() instead (typo fix).
    */
   JSONCPP_DEPRECATED("Use getFormattedErrorMessages() instead.")
-  std::string getFormatedErrorMessages() const;
+  JSONCPP_STRING getFormatedErrorMessages() const;
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -1318,7 +1449,39 @@ public:
    * occurred
    *         during parsing.
    */
-  std::string getFormattedErrorMessages() const;
+  JSONCPP_STRING getFormattedErrorMessages() const;
+
+  /** \brief Returns a vector of structured erros encounted while parsing.
+   * \return A (possibly empty) vector of StructuredError objects. Currently
+   *         only one error can be returned, but the caller should tolerate
+   * multiple
+   *         errors.  This can occur if the parser recovers from a non-fatal
+   *         parse error and then encounters additional errors.
+   */
+  std::vector<StructuredError> getStructuredErrors() const;
+
+  /** \brief Add a semantic error message.
+   * \param value JSON Value location associated with the error
+   * \param message The error message.
+   * \return \c true if the error was successfully added, \c false if the
+   * Value offset exceeds the document size.
+   */
+  bool pushError(const Value& value, const JSONCPP_STRING& message);
+
+  /** \brief Add a semantic error message with extra context.
+   * \param value JSON Value location associated with the error
+   * \param message The error message.
+   * \param extra Additional JSON Value location to contextualize the error
+   * \return \c true if the error was successfully added, \c false if either
+   * Value offset exceeds the document size.
+   */
+  bool pushError(const Value& value, const JSONCPP_STRING& message, const Value& extra);
+
+  /** \brief Return whether there are any errors.
+   * \return \c true if there are no errors to report \c false if
+   * errors have occurred.
+   */
+  bool good() const;
 
 private:
   enum TokenType {
@@ -1348,7 +1511,7 @@ private:
   class ErrorInfo {
   public:
     Token token_;
-    std::string message_;
+    JSONCPP_STRING message_;
     Location extra_;
   };
 
@@ -1368,7 +1531,7 @@ private:
   bool decodeNumber(Token& token);
   bool decodeNumber(Token& token, Value& decoded);
   bool decodeString(Token& token);
-  bool decodeString(Token& token, std::string& decoded);
+  bool decodeString(Token& token, JSONCPP_STRING& decoded);
   bool decodeDouble(Token& token);
   bool decodeDouble(Token& token, Value& decoded);
   bool decodeUnicodeCodePoint(Token& token,
@@ -1379,9 +1542,9 @@ private:
                                    Location& current,
                                    Location end,
                                    unsigned int& unicode);
-  bool addError(const std::string& message, Token& token, Location extra = 0);
+  bool addError(const JSONCPP_STRING& message, Token& token, Location extra = 0);
   bool recoverFromError(TokenType skipUntilToken);
-  bool addErrorAndRecover(const std::string& message,
+  bool addErrorAndRecover(const JSONCPP_STRING& message,
                           Token& token,
                           TokenType skipUntilToken);
   void skipUntilSpace();
@@ -1389,20 +1552,20 @@ private:
   Char getNextChar();
   void
   getLocationLineAndColumn(Location location, int& line, int& column) const;
-  std::string getLocationLineAndColumn(Location location) const;
+  JSONCPP_STRING getLocationLineAndColumn(Location location) const;
   void addComment(Location begin, Location end, CommentPlacement placement);
   void skipCommentTokens(Token& token);
 
   typedef std::stack<Value*> Nodes;
   Nodes nodes_;
   Errors errors_;
-  std::string document_;
+  JSONCPP_STRING document_;
   Location begin_;
   Location end_;
   Location current_;
   Location lastValueEnd_;
   Value* lastValue_;
-  std::string commentsBefore_;
+  JSONCPP_STRING commentsBefore_;
   Features features_;
   bool collectComments_;
 };  // Reader
@@ -1431,9 +1594,9 @@ public:
    */
   virtual bool parse(
       char const* beginDoc, char const* endDoc,
-      Value* root, std::string* errs) = 0;
+      Value* root, JSONCPP_STRING* errs) = 0;
 
-  class Factory {
+  class JSON_API Factory {
   public:
     virtual ~Factory() {}
     /** \brief Allocate a CharReader via operator new().
@@ -1451,7 +1614,7 @@ Usage:
   CharReaderBuilder builder;
   builder["collectComments"] = false;
   Value value;
-  std::string errs;
+  JSONCPP_STRING errs;
   bool ok = parseFromStream(builder, std::cin, &value, &errs);
 \endcode
 */
@@ -1487,7 +1650,7 @@ public:
     - `"rejectDupKeys": false or true`
       - If true, `parse()` returns false when a key is duplicated within an object.
     - `"allowSpecialFloats": false or true`
-      - If true, special float values (NaNs and infinities) are allowed
+      - If true, special float values (NaNs and infinities) are allowed 
         and their values are lossfree restorable.
 
     You can examine 'settings_` yourself
@@ -1498,9 +1661,9 @@ public:
   Json::Value settings_;
 
   CharReaderBuilder();
-  virtual ~CharReaderBuilder();
+  ~CharReaderBuilder() JSONCPP_OVERRIDE;
 
-  virtual CharReader* newCharReader() const;
+  CharReader* newCharReader() const JSONCPP_OVERRIDE;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
@@ -1509,7 +1672,7 @@ public:
 
   /** A simple way to update a specific setting.
    */
-  Value& operator[](std::string key);
+  Value& operator[](JSONCPP_STRING key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
@@ -1531,7 +1694,7 @@ public:
   */
 bool JSON_API parseFromStream(
     CharReader::Factory const&,
-    std::istream&,
+    JSONCPP_ISTREAM&,
     Value* root, std::string* errs);
 
 /** \brief Read from 'sin' into 'root'.
@@ -1558,9 +1721,11 @@ bool JSON_API parseFromStream(
  \throw std::exception on parse error.
  \see Json::operator<<()
 */
-JSON_API std::istream& operator>>(std::istream&, Value&);
+JSON_API JSONCPP_ISTREAM& operator>>(JSONCPP_ISTREAM&, Value&);
 
 } // namespace Json
+
+#pragma pack(pop)
 
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 #pragma warning(pop)
@@ -1603,6 +1768,8 @@ JSON_API std::istream& operator>>(std::istream&, Value&);
 #pragma warning(disable : 4251)
 #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 
+#pragma pack(push, 8)
+
 namespace Json {
 
 class Value;
@@ -1622,7 +1789,7 @@ Usage:
 */
 class JSON_API StreamWriter {
 protected:
-  std::ostream* sout_;  // not owned; will not delete
+  JSONCPP_OSTREAM* sout_;  // not owned; will not delete
 public:
   StreamWriter();
   virtual ~StreamWriter();
@@ -1632,7 +1799,7 @@ public:
       \return zero on success (For now, we always return zero, so check the stream instead.)
       \throw std::exception possibly, depending on configuration
    */
-  virtual int write(Value const& root, std::ostream* sout) = 0;
+  virtual int write(Value const& root, JSONCPP_OSTREAM* sout) = 0;
 
   /** \brief A simple abstract factory.
    */
@@ -1649,7 +1816,7 @@ public:
 /** \brief Write into stringstream, then return string, for convenience.
  * A StreamWriter will be created from the factory, used, and then deleted.
  */
-std::string JSON_API writeString(StreamWriter::Factory const& factory, Value const& root);
+JSONCPP_STRING JSON_API writeString(StreamWriter::Factory const& factory, Value const& root);
 
 
 /** \brief Build a StreamWriter implementation.
@@ -1695,12 +1862,12 @@ public:
   Json::Value settings_;
 
   StreamWriterBuilder();
-  virtual ~StreamWriterBuilder();
+  ~StreamWriterBuilder() JSONCPP_OVERRIDE;
 
   /**
    * \throw std::exception if something goes wrong (e.g. invalid settings)
    */
-  virtual StreamWriter* newStreamWriter() const;
+  StreamWriter* newStreamWriter() const JSONCPP_OVERRIDE;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
@@ -1708,7 +1875,7 @@ public:
   bool validate(Json::Value* invalid) const;
   /** A simple way to update a specific setting.
    */
-  Value& operator[](std::string key);
+  Value& operator[](JSONCPP_STRING key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
@@ -1725,7 +1892,7 @@ class JSON_API Writer {
 public:
   virtual ~Writer();
 
-  virtual std::string write(const Value& root) = 0;
+  virtual JSONCPP_STRING write(const Value& root) = 0;
 };
 
 /** \brief Outputs a Value in <a HREF="http://www.json.org">JSON</a> format
@@ -1741,18 +1908,29 @@ class JSON_API FastWriter : public Writer {
 
 public:
   FastWriter();
-  virtual ~FastWriter() {}
+  ~FastWriter() JSONCPP_OVERRIDE {}
 
   void enableYAMLCompatibility();
 
+  /** \brief Drop the "null" string from the writer's output for nullValues.
+   * Strictly speaking, this is not valid JSON. But when the output is being
+   * fed to a browser's Javascript, it makes for smaller output and the
+   * browser can handle the output just fine.
+   */
+  void dropNullPlaceholders();
+
+  void omitEndingLineFeed();
+
 public: // overridden from Writer
-  virtual std::string write(const Value& root);
+  JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
 private:
   void writeValue(const Value& value);
 
-  std::string document_;
+  JSONCPP_STRING document_;
   bool yamlCompatiblityEnabled_;
+  bool dropNullPlaceholders_;
+  bool omitEndingLineFeed_;
 };
 
 /** \brief Writes a Value in <a HREF="http://www.json.org">JSON</a> format in a
@@ -1782,36 +1960,36 @@ private:
 class JSON_API StyledWriter : public Writer {
 public:
   StyledWriter();
-  virtual ~StyledWriter() {}
+  ~StyledWriter() JSONCPP_OVERRIDE {}
 
 public: // overridden from Writer
   /** \brief Serialize a Value in <a HREF="http://www.json.org">JSON</a> format.
    * \param root Value to serialize.
    * \return String containing the JSON document that represents the root value.
    */
-  virtual std::string write(const Value& root);
+  JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
   bool isMultineArray(const Value& value);
-  void pushValue(const std::string& value);
+  void pushValue(const JSONCPP_STRING& value);
   void writeIndent();
-  void writeWithIndent(const std::string& value);
+  void writeWithIndent(const JSONCPP_STRING& value);
   void indent();
   void unindent();
   void writeCommentBeforeValue(const Value& root);
   void writeCommentAfterValueOnSameLine(const Value& root);
   bool hasCommentForValue(const Value& value);
-  static std::string normalizeEOL(const std::string& text);
+  static JSONCPP_STRING normalizeEOL(const JSONCPP_STRING& text);
 
-  typedef std::vector<std::string> ChildValues;
+  typedef std::vector<JSONCPP_STRING> ChildValues;
 
   ChildValues childValues_;
-  std::string document_;
-  std::string indentString_;
-  int rightMargin_;
-  int indentSize_;
+  JSONCPP_STRING document_;
+  JSONCPP_STRING indentString_;
+  unsigned int rightMargin_;
+  unsigned int indentSize_;
   bool addChildValues_;
 };
 
@@ -1843,7 +2021,7 @@ private:
  */
 class JSON_API StyledStreamWriter {
 public:
-  StyledStreamWriter(std::string indentation = "\t");
+  StyledStreamWriter(JSONCPP_STRING indentation = "\t");
   ~StyledStreamWriter() {}
 
 public:
@@ -1853,48 +2031,50 @@ public:
    * \note There is no point in deriving from Writer, since write() should not
    * return a value.
    */
-  void write(std::ostream& out, const Value& root);
+  void write(JSONCPP_OSTREAM& out, const Value& root);
 
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
   bool isMultineArray(const Value& value);
-  void pushValue(const std::string& value);
+  void pushValue(const JSONCPP_STRING& value);
   void writeIndent();
-  void writeWithIndent(const std::string& value);
+  void writeWithIndent(const JSONCPP_STRING& value);
   void indent();
   void unindent();
   void writeCommentBeforeValue(const Value& root);
   void writeCommentAfterValueOnSameLine(const Value& root);
   bool hasCommentForValue(const Value& value);
-  static std::string normalizeEOL(const std::string& text);
+  static JSONCPP_STRING normalizeEOL(const JSONCPP_STRING& text);
 
-  typedef std::vector<std::string> ChildValues;
+  typedef std::vector<JSONCPP_STRING> ChildValues;
 
   ChildValues childValues_;
-  std::ostream* document_;
-  std::string indentString_;
-  int rightMargin_;
-  std::string indentation_;
+  JSONCPP_OSTREAM* document_;
+  JSONCPP_STRING indentString_;
+  unsigned int rightMargin_;
+  JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
 };
 
 #if defined(JSON_HAS_INT64)
-std::string JSON_API valueToString(Int value);
-std::string JSON_API valueToString(UInt value);
+JSONCPP_STRING JSON_API valueToString(Int value);
+JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
-std::string JSON_API valueToString(LargestInt value);
-std::string JSON_API valueToString(LargestUInt value);
-std::string JSON_API valueToString(double value);
-std::string JSON_API valueToString(bool value);
-std::string JSON_API valueToQuotedString(const char* value);
+JSONCPP_STRING JSON_API valueToString(LargestInt value);
+JSONCPP_STRING JSON_API valueToString(LargestUInt value);
+JSONCPP_STRING JSON_API valueToString(double value);
+JSONCPP_STRING JSON_API valueToString(bool value);
+JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 
 /// \brief Output using the StyledStreamWriter.
 /// \see Json::operator>>()
-JSON_API std::ostream& operator<<(std::ostream&, const Value& root);
+JSON_API JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM&, const Value& root);
 
 } // namespace Json
+
+#pragma pack(pop)
 
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 #pragma warning(pop)
@@ -1942,7 +2122,7 @@ JSON_API std::ostream& operator<<(std::ostream&, const Value& root);
 
 # define JSON_FAIL_MESSAGE(message)                                            \
   {                                                                            \
-    std::ostringstream oss; oss << message;                                    \
+    JSONCPP_OSTRINGSTREAM oss; oss << message;                                    \
     Json::throwLogicError(oss.str());                                          \
     abort();                                                                   \
   }
@@ -1955,7 +2135,7 @@ JSON_API std::ostream& operator<<(std::ostream&, const Value& root);
 // release builds we abort, for a core-dump or debugger.
 # define JSON_FAIL_MESSAGE(message)                                            \
   {                                                                            \
-    std::ostringstream oss; oss << message;                                    \
+    JSONCPP_OSTRINGSTREAM oss; oss << message;                                    \
     assert(false && oss.str().c_str());                                        \
     abort();                                                                   \
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -708,7 +708,7 @@ include(CheckCXXCompilerFlag)
 
 if(MSVC)
 	# Visual Studio
-
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11")
 	# EHa enables SEH exceptions (used for catching segfaults)
 	set(CMAKE_CXX_FLAGS_RELEASE "/EHa /Ox /GL /FD /MT /GS- /Zi /arch:SSE /fp:fast /D NDEBUG /D _HAS_ITERATOR_DEBUGGING=0 /TP")
 	#set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/LTCG /NODEFAULTLIB:\"libcmtd.lib\" /NODEFAULTLIB:\"libcmt.lib\"")
@@ -728,9 +728,10 @@ if(MSVC)
 	# /MT = Link statically with standard library stuff
 	set(CMAKE_C_FLAGS_RELEASE "/O2 /Ob2 /MT")
 else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 	# Probably GCC
 	if(APPLE)
-		SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000" )
+		SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000" )
 	endif()
 	if(WARN_ALL)
 		set(RELEASE_WARNING_FLAGS "-Wall")

--- a/src/database-dummy.h
+++ b/src/database-dummy.h
@@ -40,6 +40,7 @@ public:
 
 	void beginSave() {}
 	void endSave() {}
+
 private:
 	std::map<s64, std::string> m_database;
 };

--- a/src/database-leveldb.h
+++ b/src/database-leveldb.h
@@ -41,6 +41,7 @@ public:
 
 	void beginSave() {}
 	void endSave() {}
+
 private:
 	leveldb::DB *m_database;
 };

--- a/src/environment.h
+++ b/src/environment.h
@@ -79,6 +79,7 @@ public:
 	u32 m_added_objects;
 
 	IGameDef *getGameDef() { return m_gamedef; }
+
 protected:
 	GenericAtomic<float> m_time_of_day_speed;
 

--- a/src/nameidmapping.h
+++ b/src/nameidmapping.h
@@ -80,6 +80,7 @@ public:
 		return true;
 	}
 	u16 size() const { return m_id_to_name.size(); }
+
 private:
 	UNORDERED_MAP<u16, std::string> m_id_to_name;
 	UNORDERED_MAP<std::string, u16> m_name_to_id;

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -32,6 +32,7 @@ class MetaDataRef : public ModApiBase
 {
 public:
 	virtual ~MetaDataRef() {}
+
 protected:
 	static MetaDataRef *checkobject(lua_State *L, int narg);
 

--- a/src/touchscreengui.h
+++ b/src/touchscreengui.h
@@ -172,7 +172,7 @@ private:
 	IEventReceiver *m_receiver;
 	ISimpleTextureSource *m_texturesource;
 	v2u32 m_screensize;
-	std::map<int, rect<s32> > m_hud_rects;
+	std::map<int, rect<s32>> m_hud_rects;
 	std::map<int, irr::EKEY_CODE> m_hud_ids;
 	bool m_visible; // is the gui visible
 

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -16,13 +16,13 @@ toolchain_file=$dir/toolchain_mingw.cmake
 irrlicht_version=1.8.4
 ogg_version=1.3.2
 vorbis_version=1.3.5
-curl_version=7.50.3
+curl_version=7.54.0
 gettext_version=0.19.8.1
-freetype_version=2.7
-sqlite3_version=3.14.2
-luajit_version=2.1.0-beta2
-leveldb_version=1.18
-zlib_version=1.2.8
+freetype_version=2.8
+sqlite3_version=3.19.2
+luajit_version=2.1.0-beta3
+leveldb_version=1.19
+zlib_version=1.2.11
 
 mkdir -p $packagedir
 mkdir -p $libdir

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -16,13 +16,13 @@ toolchain_file=$dir/toolchain_mingw64.cmake
 irrlicht_version=1.8.4
 ogg_version=1.3.2
 vorbis_version=1.3.5
-curl_version=7.50.3
+curl_version=7.54.0
 gettext_version=0.19.8.1
-freetype_version=2.7
-sqlite3_version=3.14.2
-luajit_version=2.1.0-beta2
-leveldb_version=1.18
-zlib_version=1.2.8
+freetype_version=2.8
+sqlite3_version=3.19.2
+luajit_version=2.1.0-beta3
+leveldb_version=1.19
+zlib_version=1.2.11
 
 mkdir -p $packagedir
 mkdir -p $libdir

--- a/util/travis/before_install.sh
+++ b/util/travis/before_install.sh
@@ -1,49 +1,33 @@
 #!/bin/bash -e
+
 echo "Preparing for $TRAVIS_COMMIT_RANGE"
 
-if [[ "$LINT" == "1" ]]; then
-	curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-	sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-	sudo apt-get -yq update
-	sudo apt-get install clang-format-3.9
+. util/travis/common.sh
+
+if [[ "${LINT}" == "1" ]]; then
 	exit 0
 fi
 
-. util/travis/common.sh
 needs_compile || exit 0
-
-if [[ $TRAVIS_OS_NAME == "linux" ]]; then
-	sudo apt-get update
-	sudo apt-get install p7zip-full $COMPILER
-fi
 
 if [[ $PLATFORM == "Unix" ]]; then
 	if [[ $TRAVIS_OS_NAME == "linux" ]]; then
-		sudo apt-get update
-		sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
-			libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
-			libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
-			gettext libpq-dev postgresql-server-dev-all
-		# Linking to LevelDB is broken, use a custom build
-		wget http://minetest.kitsunemimi.pw/libleveldb-1.18-ubuntu12.04.7z
-		sudo 7z x -o/usr libleveldb-1.18-ubuntu12.04.7z
-		if [[ "$VALGRIND" == "1" ]]; then
-			sudo apt-get install valgrind
-		fi
-
+		install_linux_deps
 	else
-		brew update
-		brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit
-		#brew upgrade postgresql
+		install_macosx_deps
 	fi
 elif [[ $PLATFORM == "Win32" ]]; then
-	wget http://minetest.kitsunemimi.pw/mingw_w64_i686_ubuntu12.04_4.9.1.7z -O mingw.7z
+	sudo apt-get update
+	sudo apt-get install p7zip-full
+	wget http://minetest.kitsunemimi.pw/mingw-w64-i686_7.1.1_ubuntu14.04.7z -O mingw.7z
 	sed -e "s|%PREFIX%|i686-w64-mingw32|" \
 		-e "s|%ROOTPATH%|/usr/i686-w64-mingw32|" \
 		< util/travis/toolchain_mingw.cmake.in > util/buildbot/toolchain_mingw.cmake
 	sudo 7z x -y -o/usr mingw.7z
 elif [[ $PLATFORM == "Win64" ]]; then
-	wget http://minetest.kitsunemimi.pw/mingw_w64_x86_64_ubuntu12.04_4.9.1.7z -O mingw.7z
+	sudo apt-get update
+	sudo apt-get install p7zip-full
+	wget http://minetest.kitsunemimi.pw/mingw-w64-x86_64_7.1.1_ubuntu14.04.7z -O mingw.7z
 	sed -e "s|%PREFIX%|x86_64-w64-mingw32|" \
 		-e "s|%ROOTPATH%|/usr/x86_64-w64-mingw32|" \
 		< util/travis/toolchain_mingw.cmake.in > util/buildbot/toolchain_mingw64.cmake

--- a/util/travis/common.sh
+++ b/util/travis/common.sh
@@ -1,5 +1,40 @@
 #!/bin/bash -e
 
+set_linux_compiler_env() {
+	if [[ "${COMPILER}" == "gcc-5.1" ]]; then
+		export CC=gcc-5.1
+		export CXX=g++-5.1
+	elif [[ "${COMPILER}" == "gcc-6" ]]; then
+		export CC=gcc-6
+		export CXX=g++-6
+	elif [[ "${COMPILER}" == "gcc-7" ]]; then
+		export CC=gcc-7
+		export CXX=g++-7
+	elif [[ "${COMPILER}" == "clang-3.6" ]]; then
+		export CC=clang-3.6
+		export CXX=clang++-3.6
+	elif [[ "${COMPILER}" == "clang-4.0" ]]; then
+		export CC=clang-4.0
+		export CXX=clang++-4.0
+	fi
+}
+
+# Linux build only
+install_linux_deps() {
+	sudo apt-get update
+	sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
+		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
+		libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
+		gettext libpq-dev libleveldb-dev
+}
+
+# Mac OSX build only
+install_macosx_deps() {
+	brew update
+	brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit
+	#brew upgrade postgresql
+}
+
 # Relative to git-repository root:
 TRIGGER_COMPILE_PATHS="src/.*\.(c|cpp|h)|CMakeLists.txt|cmake/Modules/|util/travis/|util/buildbot/"
 

--- a/util/travis/lint.sh
+++ b/util/travis/lint.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 function perform_lint() {
 	echo "Performing LINT..."
-	if hash clang-format-3.9 2>/dev/null; then
-		CLANG_FORMAT=clang-format-3.9
+	if hash clang-format-4.0 2>/dev/null; then
+		CLANG_FORMAT=clang-format-4.0
 	else
 		CLANG_FORMAT=clang-format
 	fi

--- a/util/travis/script.sh
+++ b/util/travis/script.sh
@@ -10,22 +10,15 @@ if [[ "$LINT" == "1" ]]; then
 	exit 0
 fi
 
-if [[ $PLATFORM == "Unix" ]]; then
+set_linux_compiler_env
+
+if [[ ${PLATFORM} == "Unix" ]]; then
 	mkdir -p travisbuild
 	cd travisbuild || exit 1
 
 	CMAKE_FLAGS=''
-	if [[ $COMPILER == "g++-6" ]]; then
-		export CC=gcc-6
-		export CXX=g++-6
-	fi
 
-	# Clang builds with FreeType fail on Travis
-	if [[ $CC == "clang" ]]; then
-		CMAKE_FLAGS+=' -DENABLE_FREETYPE=FALSE'
-	fi
-
-	if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+	if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
 		CMAKE_FLAGS+=' -DCUSTOM_GETTEXT_PATH=/usr/local/opt/gettext'
 	fi
 
@@ -33,12 +26,12 @@ if [[ $PLATFORM == "Unix" ]]; then
 		-DRUN_IN_PLACE=TRUE \
 		-DENABLE_GETTEXT=TRUE \
 		-DBUILD_SERVER=TRUE \
-		$CMAKE_FLAGS ..
+		${CMAKE_FLAGS} ..
 	make -j2
 
 	echo "Running unit tests."
 	CMD="../bin/minetest --run-unittests"
-	if [[ "$VALGRIND" == "1" ]]; then
+	if [[ "${VALGRIND}" == "1" ]]; then
 		valgrind --leak-check=full --leak-check-heuristics=all --undef-value-errors=no --error-exitcode=9 ${CMD} && exit 0
 	else
 		${CMD} && exit 0


### PR DESCRIPTION
* Move GCC to GCC 6 & GCC 7
* Move Clang to Clang 3.6 & Clang 4.0
* LINT moves from Clang 3.9 to Clang 4.0
* Move XCode 7.3 to 8.0
* Use more travis tricks to install compilers instead of adding complexity to our build script
* Clang format fixes on checked files (compat Cpp11 instead of Cpp03)
* JsonCPP update from 0.10.6 to 1.8.0
* Mingw GCC update from 4.8.4 to 5.3 (Ubuntu Xenial)
* Drop mingw cmake generated files and add them to gitignore
* Use new version scheme for development: version-dev -> version -> version+1-dev -> version+1