### PR TITLE
Enhance ABM performance a little bit by removing two std::set copy

### DIFF
--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -203,11 +203,11 @@ public:
 		m_simple_catch_up(simple_catch_up)
 	{
 	}
-	virtual std::set<std::string> getTriggerContents()
+	virtual const std::set<std::string> &getTriggerContents() const
 	{
 		return m_trigger_contents;
 	}
-	virtual std::set<std::string> getRequiredNeighbors()
+	virtual const std::set<std::string> &getRequiredNeighbors() const
 	{
 		return m_required_neighbors;
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -721,7 +721,7 @@ public:
 				chance = 1;
 			ActiveABM aabm;
 			aabm.abm = abm;
-			if(abm->getSimpleCatchUp()) {
+			if (abm->getSimpleCatchUp()) {
 				float intervals = actual_interval / trigger_interval;
 				if(intervals == 0)
 					continue;
@@ -731,25 +731,23 @@ public:
 			} else {
 				aabm.chance = chance;
 			}
+
 			// Trigger neighbors
-			std::set<std::string> required_neighbors_s
-				= abm->getRequiredNeighbors();
-			for(std::set<std::string>::iterator
-				i = required_neighbors_s.begin();
-				i != required_neighbors_s.end(); ++i)
-			{
-				ndef->getIds(*i, aabm.required_neighbors);
+			const std::set<std::string> &required_neighbors_s =
+				abm->getRequiredNeighbors();
+			for (std::set<std::string>::iterator rn = required_neighbors_s.begin();
+					rn != required_neighbors_s.end(); ++rn) {
+				ndef->getIds(*rn, aabm.required_neighbors);
 			}
+
 			// Trigger contents
-			std::set<std::string> contents_s = abm->getTriggerContents();
-			for(std::set<std::string>::iterator
-				i = contents_s.begin(); i != contents_s.end(); ++i)
-			{
+			const std::set<std::string> &contents_s = abm->getTriggerContents();
+			for (std::set<std::string>::iterator cs = contents_s.begin();
+					cs != contents_s.end(); ++cs) {
 				std::set<content_t> ids;
-				ndef->getIds(*i, ids);
-				for(std::set<content_t>::const_iterator k = ids.begin();
-					k != ids.end(); ++k)
-				{
+				ndef->getIds(*cs, ids);
+				for (std::set<content_t>::const_iterator k = ids.begin();
+					k != ids.end(); ++k) {
 					content_t c = *k;
 					if (c >= m_aabms.size())
 						m_aabms.resize(c + 256, NULL);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -747,7 +747,7 @@ public:
 				std::set<content_t> ids;
 				ndef->getIds(*cs, ids);
 				for (std::set<content_t>::const_iterator k = ids.begin();
-					k != ids.end(); ++k) {
+						k != ids.end(); ++k) {
 					content_t c = *k;
 					if (c >= m_aabms.size())
 						m_aabms.resize(c + 256, NULL);

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -51,11 +51,10 @@ public:
 	virtual ~ActiveBlockModifier(){};
 
 	// Set of contents to trigger on
-	virtual std::set<std::string> getTriggerContents()=0;
+	virtual const std::set<std::string> &getTriggerContents() const = 0;
 	// Set of required neighbors (trigger doesn't happen if none are found)
 	// Empty = do not check neighbors
-	virtual std::set<std::string> getRequiredNeighbors()
-	{ return std::set<std::string>(); }
+	virtual const std::set<std::string> &getRequiredNeighbors() const = 0;
 	// Trigger interval in seconds
 	virtual float getTriggerInterval() = 0;
 	// Random chance of (1 / return value), 0 is disallowed


### PR DESCRIPTION
* ActiveBlockModifier::getTriggerContents now returns a const ref
* ActiveBlockModifier::getRequiredNeighbors now returns a const ref
* ActiveBlockModifier::getRequiredNeighbors is now purely virtual