### PR TITLE
Menu: Do not use textlist for shaders in settings tab

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -247,17 +247,20 @@ local function formspec(tabview, name, tabdata)
 					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
 	else
 		tab_string = tab_string ..
-			"tablecolumns[color;text]" ..
-			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
-			"table[8.33,0.7;3.5,4;shaders;" ..
-				"#888888," .. fgettext("Bump Mapping") .. "," ..
-				"#888888," .. fgettext("Tone Mapping") .. "," ..
-				"#888888," .. fgettext("Normal Mapping") .. "," ..
-				"#888888," .. fgettext("Parallax Occlusion") .. "," ..
-				"#888888," .. fgettext("Waving Water") .. "," ..
-				"#888888," .. fgettext("Waving Leaves") .. "," ..
-				"#888888," .. fgettext("Waving Plants") .. "," ..
-				";1]"
+			"label[8.38,0.7;" .. core.colorize("#888888",
+					fgettext("Bump Mapping")) .. "]" ..
+			"label[8.38,1.2;" .. core.colorize("#888888",
+					fgettext("Tone Mapping")) .. "]" ..
+			"label[8.38,1.7;" .. core.colorize("#888888",
+					fgettext("Normal Mapping")) .. "]" ..
+			"label[8.38,2.2;" .. core.colorize("#888888",
+					fgettext("Parallax Occlusion")) .. "]" ..
+			"label[8.38,2.7;" .. core.colorize("#888888",
+					fgettext("Waving Water")) .. "]" ..
+			"label[8.38,3.2;" .. core.colorize("#888888",
+					fgettext("Waving Leaves")) .. "]" ..
+			"label[8.38,3.7;" .. core.colorize("#888888",
+					fgettext("Waving Plants")) .. "]"
 	end
 
 	return tab_string


### PR DESCRIPTION
![settings shaders transition](https://cloud.githubusercontent.com/assets/15371866/26476740/8242fa8c-4175-11e7-896c-702a98ed5bf1.png)

Replace the textlist used if the shaders checkbox is unchecked in the settings tab of the main menu with labels. This makes the formspec feel more consistent as the items do not move when shaders are unchecked but only change colour and the checkboxes beside them disappear.

The only possible disadvantage to this is that it results in 7 extra labels rather than 1 textlist with 7 rows, however, as mentioned and shown in the screenshot, it feels much more consistent. And performance wise, 7 extra labels isn't going to hurt anything. **Note:** The screenshot is cropped to include only the important areas.