### PR TITLE
Mapgen v6: Use snow blocks in tundra and remove them from taiga

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -1008,8 +1008,7 @@ void MapgenV6::placeTreesAndJungleGrass()
 				content_t c = vm->m_data[i].getContent();
 				if (c != c_dirt &&
 						c != c_dirt_with_grass &&
-						c != c_dirt_with_snow &&
-						c != c_snowblock)
+						c != c_dirt_with_snow)
 					continue;
 			}
 			p.Y++;
@@ -1064,15 +1063,13 @@ void MapgenV6::growGrass() // Add surface nodes
 		content_t c = vm->m_data[i].getContent();
 		if (surface_y >= water_level - 20) {
 			if (bt == BT_TAIGA && c == c_dirt) {
-				vm->m_data[i] = n_snowblock;
-				vm->m_area.add_y(em, i, -1);
 				vm->m_data[i] = n_dirt_with_snow;
 			} else if (bt == BT_TUNDRA) {
 				if (c == c_dirt) {
 					vm->m_data[i] = n_dirt_with_snow;
 				} else if (c == c_stone && surface_y < node_max.Y) {
 					vm->m_area.add_y(em, i, 1);
-					vm->m_data[i] = n_snow;
+					vm->m_data[i] = n_snowblock;
 				}
 			} else if (c == c_dirt) {
 				vm->m_data[i] = n_dirt_with_grass;

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -1002,7 +1002,7 @@ void MapgenV6::placeTreesAndJungleGrass()
 				continue;
 
 			v3s16 p(x, y, z);
-			// Trees grow only on mud and grass and snowblock
+			// Trees grow only on mud and grass
 			{
 				u32 i = vm->m_area.index(p);
 				content_t c = vm->m_data[i].getContent();
@@ -1066,6 +1066,8 @@ void MapgenV6::growGrass() // Add surface nodes
 				vm->m_data[i] = n_dirt_with_snow;
 			} else if (bt == BT_TUNDRA) {
 				if (c == c_dirt) {
+					vm->m_data[i] = n_snowblock;
+					vm->m_area.add_y(em, i, -1);
 					vm->m_data[i] = n_dirt_with_snow;
 				} else if (c == c_stone && surface_y < node_max.Y) {
 					vm->m_area.add_y(em, i, 1);


### PR DESCRIPTION
Screenshots:
[Before](http://screenshot.ru/upload/images/2017/05/27/screenshot_20170527_03380263e55.png)
[After](http://screenshot.ru/upload/images/2017/05/27/screenshot_20170527_171529f801f.png)

I always found it to be strange that conifer trees grew on snowblocks, and that the snowy forest was covered in snow blocks while mountains (with stone) had only a thin layer of normal snow.

This PR basically swaps the top nodes of taiga and tundra.