### PR TITLE
Change default maxlevel to zero

### DIFF
--- a/src/tool.h
+++ b/src/tool.h
@@ -33,7 +33,7 @@ struct ToolGroupCap
 	int uses;
 
 	ToolGroupCap():
-		maxlevel(1),
+		maxlevel(0),
 		uses(20)
 	{}
 


### PR DESCRIPTION
When tool group caps omit to define maxlevel they now use the defined value.
Therefor allow not to use the maxlevel feature. Before they where multiplied by a factor because of maxlevel = 1.

Previous issue was #5682
///////////
EDIT by paramat: See issue for more explanation.