### PR TITLE
guiVolumeChange: prevent wrong value position by using 1 label instead of 2

### DIFF
--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -30,10 +30,9 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "gettext.h"
 
-const int ID_soundText1 = 263;
-const int ID_soundText2 = 264;
-const int ID_soundExitButton = 265;
-const int ID_soundSlider = 266;
+const int ID_soundText = 263;
+const int ID_soundExitButton = 264;
+const int ID_soundSlider = 265;
 
 GUIVolumeChange::GUIVolumeChange(gui::IGUIEnvironment* env,
 		gui::IGUIElement* parent, s32 id,
@@ -50,10 +49,7 @@ GUIVolumeChange::~GUIVolumeChange()
 
 void GUIVolumeChange::removeChildren()
 {
-	if (gui::IGUIElement *e = getElementFromId(ID_soundText1))
-		e->remove();
-
-	if (gui::IGUIElement *e = getElementFromId(ID_soundText2))
+	if (gui::IGUIElement *e = getElementFromId(ID_soundText))
 		e->remove();
 
 	if (gui::IGUIElement *e = getElementFromId(ID_soundExitButton))
@@ -73,34 +69,31 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	core::rect<s32> rect(
-			screensize.X/2 - 380/2,
-			screensize.Y/2 - 200/2,
-			screensize.X/2 + 380/2,
-			screensize.Y/2 + 200/2
+	DesiredRect = core::rect<s32>(
+		screensize.X/2 - 380/2,
+		screensize.Y/2 - 200/2,
+		screensize.X/2 + 380/2,
+		screensize.Y/2 + 200/2
 	);
-
-	DesiredRect = rect;
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = rect.getSize();
-	int volume = (int)(g_settings->getFloat("sound_volume")*100);
+	v2s32 size = DesiredRect.getSize();
+	int volume = (int)(g_settings->getFloat("sound_volume") * 100);
+
 	/*
 		Add stuff
 	*/
 	{
-		core::rect<s32> rect(0, 0, 120, 20);
-		rect = rect + v2s32(size.X/2-60, size.Y/2-35);
+		core::rect<s32> rect(0, 0, 160, 20);
+		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 35);
+
 		const wchar_t *text = wgettext("Sound Volume: ");
-		Environment->addStaticText(text, rect, false,
-				true, this, ID_soundText1);
-		delete[] text;
-	}
-	{
-		core::rect<s32> rect(0, 0, 30, 20);
-		rect = rect + v2s32(size.X/2+40, size.Y/2-35);
-		Environment->addStaticText(core::stringw(volume).c_str(), rect, false,
-				true, this, ID_soundText2);
+		core::stringw volume_text = text;
+		delete [] text;
+
+		volume_text += core::stringw(volume) + core::stringw("%");
+		Environment->addStaticText(volume_text.c_str(), rect, false,
+				true, this, ID_soundText);
 	}
 	{
 		core::rect<s32> rect(0, 0, 80, 30);
@@ -155,10 +148,15 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 	if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 		if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
 			s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
-			g_settings->setFloat("sound_volume", (float)pos/100);
+			g_settings->setFloat("sound_volume", (float) pos / 100);
 
-			gui::IGUIElement *e = getElementFromId(ID_soundText2);
-			e->setText(core::stringw(pos).c_str());
+			gui::IGUIElement *e = getElementFromId(ID_soundText);
+			const wchar_t *text = wgettext("Sound Volume: ");
+			core::stringw volume_text = text;
+			delete [] text;
+
+			volume_text += core::stringw(pos) + core::stringw("%");
+			e->setText(volume_text.c_str());
 			return true;
 		}
 	}


### PR DESCRIPTION

![capture d ecran de 2017-05-28 13-11-01](https://cloud.githubusercontent.com/assets/119752/26528232/212fbf8a-43a7-11e7-9ae4-6bc57c48611e.png)

* Use only one label instead of two for the soundText, this permit to ensure both label & values are aligned
* Add '%' character too, to reflect it's a percentage volume
* Remove rect on regenerateGui (upper part) which shadows outer part and which is not needed outside of the DesiredRect affectation

Fix issue #5837