### PR TITLE
fix dropdown menu selection

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2005,6 +2005,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_tooltips.clear();
 	m_inventory_rings.clear();
 	m_static_texts.clear();
+	m_dropdowns.clear();
 
 	// Set default values (fits old formspec values)
 	m_bgcolor = video::SColor(140,0,0,0);


### PR DESCRIPTION
This fixes a bug that occurred when the selection list of a drop down menu was changed but the name was still the same. see #5834 for an example of what could cause this.

The issue was that the C++ stored the drop down list along with the dropdown menu name in a vector and used the name of the dropdown element to find the correct list. However when more then one drop down menu used the same name it would find the list for the one that was created first, instead of the latest one. 

This fixes that by clearing the dropdown list every time the formspec is regenerated.