### PR TITLE
Tooltips: Unify the tooltip[] and list[] description tooltip display functions

### DIFF
--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2399,36 +2399,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 					tooltip_text = utf8_to_wide(item.name);
 			}
 			if (tooltip_text != L"") {
-				std::vector<std::wstring> tt_rows = str_split(tooltip_text, L'\n');
-				m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
-				m_tooltip_element->setOverrideColor(m_default_tooltip_color);
-				m_tooltip_element->setVisible(true);
-				this->bringToFront(m_tooltip_element);
-				setStaticText(m_tooltip_element, tooltip_text.c_str());
-				s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if (IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION < 2) || USE_FREETYPE == 1
-				s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
-#else
-				s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
-#endif
-				v2u32 screenSize = driver->getScreenSize();
-				int tooltip_offset_x = m_btn_height;
-				int tooltip_offset_y = m_btn_height;
-#ifdef __ANDROID__
-				tooltip_offset_x *= 3;
-				tooltip_offset_y  = 0;
-				if (m_pointer.X > (s32)screenSize.X / 2)
-					tooltip_offset_x = (tooltip_offset_x + tooltip_width) * -1;
-#endif
-				s32 tooltip_x = m_pointer.X + tooltip_offset_x;
-				s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
-				if (tooltip_x + tooltip_width > (s32)screenSize.X)
-					tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
-				if (tooltip_y + tooltip_height > (s32)screenSize.Y)
-					tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
-				m_tooltip_element->setRelativePosition(core::rect<s32>(
-						core::position2d<s32>(tooltip_x, tooltip_y),
-						core::dimension2d<s32>(tooltip_width, tooltip_height)));
+				this->showTooltip(tooltip_text, m_default_tooltip_color,
+					m_default_tooltip_bgcolor);
 			}
 		}
 	}
@@ -2671,40 +2643,20 @@ void GUIFormSpecMenu::drawMenu()
 			}
 		}
 
+		// Find and update the current tooltip
 		if (id != -1 && delta >= m_tooltip_show_delay) {
-			for(std::vector<FieldSpec>::iterator iter =  m_fields.begin();
+			for (std::vector<FieldSpec>::iterator iter = m_fields.begin();
 					iter != m_fields.end(); ++iter) {
-				if (iter->fid == id && m_tooltips[iter->fname].tooltip != L"") {
-					if (m_old_tooltip != m_tooltips[iter->fname].tooltip) {
-						m_tooltip_element->setBackgroundColor(m_tooltips[iter->fname].bgcolor);
-						m_tooltip_element->setOverrideColor(m_tooltips[iter->fname].color);
-						m_old_tooltip = m_tooltips[iter->fname].tooltip;
-						setStaticText(m_tooltip_element, m_tooltips[iter->fname].tooltip.c_str());
-						std::vector<std::wstring> tt_rows = str_split(m_tooltips[iter->fname].tooltip, L'\n');
-						s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-						s32 tooltip_height = m_tooltip_element->getTextHeight() * tt_rows.size() + 5;
-						int tooltip_offset_x = m_btn_height;
-						int tooltip_offset_y = m_btn_height;
-#ifdef __ANDROID__
-						tooltip_offset_x *= 3;
-						tooltip_offset_y  = 0;
-						if (m_pointer.X > (s32)screenSize.X / 2)
-							tooltip_offset_x = (tooltip_offset_x + tooltip_width) * -1;
-#endif
-						s32 tooltip_x = m_pointer.X + tooltip_offset_x;
-						s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
-						if (tooltip_x + tooltip_width > (s32)screenSize.X)
-							tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
-						if (tooltip_y + tooltip_height > (s32)screenSize.Y)
-							tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
-						m_tooltip_element->setRelativePosition(core::rect<s32>(
-						core::position2d<s32>(tooltip_x, tooltip_y),
-						core::dimension2d<s32>(tooltip_width, tooltip_height)));
-					}
-					m_tooltip_element->setVisible(true);
-					this->bringToFront(m_tooltip_element);
-					break;
-				}
+
+				if (iter->fid != id)
+					continue;
+
+				const std::wstring &text = m_tooltips[iter->fname].tooltip;
+				if (text != L"")
+					this->showTooltip(text, m_tooltips[iter->fname].color,
+						m_tooltips[iter->fname].bgcolor);
+
+				break;
 			}
 		}
 	}
@@ -2717,6 +2669,53 @@ void GUIFormSpecMenu::drawMenu()
 	drawSelectedItem();
 
 	skin->setFont(old_font);
+}
+
+
+void GUIFormSpecMenu::showTooltip(const std::wstring &text,
+	const irr::video::SColor &color, const irr::video::SColor &bgcolor)
+{
+	m_tooltip_element->setOverrideColor(color);
+	m_tooltip_element->setBackgroundColor(bgcolor);
+	m_old_tooltip = text;
+	setStaticText(m_tooltip_element, text.c_str());
+
+	// Tooltip size and offset
+	s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
+#if (IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION < 2) || USE_FREETYPE == 1
+	std::vector<std::wstring> text_rows = str_split(text, L'\n');
+	s32 tooltip_height = m_tooltip_element->getTextHeight() * text_rows.size() + 5;
+#else
+	s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
+#endif
+	v2u32 screenSize = Environment->getVideoDriver()->getScreenSize();
+	int tooltip_offset_x = m_btn_height;
+	int tooltip_offset_y = m_btn_height;
+#ifdef __ANDROID__
+	tooltip_offset_x *= 3;
+	tooltip_offset_y  = 0;
+	if (m_pointer.X > (s32)screenSize.X / 2)
+		tooltip_offset_x = -(tooltip_offset_x + tooltip_width);
+#endif
+
+	// Calculate and set the tooltip position
+	s32 tooltip_x = m_pointer.X + tooltip_offset_x;
+	s32 tooltip_y = m_pointer.Y + tooltip_offset_y;
+	if (tooltip_x + tooltip_width > (s32)screenSize.X)
+		tooltip_x = (s32)screenSize.X - tooltip_width  - m_btn_height;
+	if (tooltip_y + tooltip_height > (s32)screenSize.Y)
+		tooltip_y = (s32)screenSize.Y - tooltip_height - m_btn_height;
+
+	m_tooltip_element->setRelativePosition(
+		core::rect<s32>(
+			core::position2d<s32>(tooltip_x, tooltip_y),
+			core::dimension2d<s32>(tooltip_width, tooltip_height)
+		)
+	);
+
+	// Display the tooltip
+	m_tooltip_element->setVisible(true);
+	this->bringToFront(m_tooltip_element);
 }
 
 void GUIFormSpecMenu::updateSelectedItem()

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2398,8 +2398,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				if (!item.name.empty() && tooltip_text.empty())
 					tooltip_text = utf8_to_wide(item.name);
 			}
-			if (tooltip_text != L"") {
-				this->showTooltip(tooltip_text, m_default_tooltip_color,
+			if (!tooltip_text.empty()) {
+				showTooltip(tooltip_text, m_default_tooltip_color,
 					m_default_tooltip_bgcolor);
 			}
 		}
@@ -2652,8 +2652,8 @@ void GUIFormSpecMenu::drawMenu()
 					continue;
 
 				const std::wstring &text = m_tooltips[iter->fname].tooltip;
-				if (text != L"")
-					this->showTooltip(text, m_tooltips[iter->fname].color,
+				if (!text.empty())
+					showTooltip(text, m_tooltips[iter->fname].color,
 						m_tooltips[iter->fname].bgcolor);
 
 				break;
@@ -2715,7 +2715,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 
 	// Display the tooltip
 	m_tooltip_element->setVisible(true);
-	this->bringToFront(m_tooltip_element);
+	bringToFront(m_tooltip_element);
 }
 
 void GUIFormSpecMenu::updateSelectedItem()

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -517,6 +517,9 @@ private:
 
 	void tryClose();
 
+	void showTooltip(const std::wstring &text, const irr::video::SColor &color,
+		const irr::video::SColor &bgcolor);
+
 	/**
 	 * check if event is part of a double click
 	 * @param event event to evaluate


### PR DESCRIPTION
This PR moves the tooltip setter functionality to `GUIFormSpecMenu::showTooltip` including code style cleanups and solves the unneccessary code duplicate.

Fixes #4592 (tested)

![grafik](https://cloud.githubusercontent.com/assets/1497498/26596950/b693ddca-4570-11e7-8dc5-5b36674818fe.png)
Apart from fixing that issue, there were no functional changes and they're still shown as before ^