### PR TITLE
Improve the path select GUI

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -152,7 +152,7 @@ LOCAL_SRC_FILES := \
 		jni/src/gettext.cpp                       \
 		jni/src/guiChatConsole.cpp                \
 		jni/src/guiEngine.cpp                     \
-		jni/src/guiFileSelectMenu.cpp             \
+		jni/src/guiPathSelectMenu.cpp             \
 		jni/src/guiFormSpecMenu.cpp               \
 		jni/src/guiKeyChangeMenu.cpp              \
 		jni/src/guiPasswordChange.cpp             \

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -196,7 +196,7 @@ local function parse_setting_line(settings, line, read_all, base_level, allow_se
 		return
 	end
 
-	if setting_type == "path" then
+	if setting_type == "path" or setting_type == "filepath" then
 		local default = remaining_line:match("^(.*)$")
 
 		if not default then
@@ -206,7 +206,7 @@ local function parse_setting_line(settings, line, read_all, base_level, allow_se
 		table.insert(settings, {
 			name = name,
 			readable_name = readable_name,
-			type = "path",
+			type = setting_type,
 			default = default,
 			comment = current_comment,
 		})
@@ -504,14 +504,14 @@ local function create_change_setting_formspec(dialogdata)
 		end
 		formspec = formspec .. ";" .. selected_index .. "]"
 
-	elseif setting.type == "path" then
+	elseif setting.type == "path" or setting.type == "filepath" then
 		local current_value = dialogdata.selected_path
 		if not current_value then
 			current_value = get_current_value(setting)
 		end
 		formspec = formspec .. "field[0.5,4;7.5,1;te_setting_value;;"
 				.. core.formspec_escape(current_value) .. "]"
-				.. "button[8,3.75;2,1;btn_browser_path;" .. fgettext("Browse") .. "]"
+				.. "button[8,3.75;2,1;btn_browser_" .. setting.type .. ";" .. fgettext("Browse") .. "]"
 
 	else
 		-- TODO: fancy input for float, int, flags, noise_params, v3f
@@ -606,7 +606,13 @@ local function handle_change_setting_buttons(this, fields)
 	end
 
 	if fields["btn_browser_path"] then
-		core.show_file_open_dialog("dlg_browse_path", fgettext_ne("Select path"))
+		core.show_path_select_dialog("dlg_browse_path",
+			fgettext_ne("Select directory"), false)
+	end
+
+	if fields["btn_browser_filepath"] then
+		core.show_path_select_dialog("dlg_browse_path",
+			fgettext_ne("Select file"), true)
 	end
 
 	if fields["dlg_browse_path_accepted"] then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -12,6 +12,7 @@
 #    - float
 #    - enum
 #    - path
+#    - filepath
 #    - key (will be ignored in GUI, since a special key change dialog exists)
 #    - flags
 #    - noise_params
@@ -30,6 +31,8 @@
 #   * enum:
 #            - default value1,value2,...
 #   * path:
+#            - default (if default is not specified then "" is set)
+#   * filepath:
 #            - default (if default is not specified then "" is set)
 #   * key:
 #            - default
@@ -642,7 +645,7 @@ tooltip_show_delay (Tooltip delay) int 400
 freetype (Freetype fonts) bool true
 
 #    Path to TrueTypeFont or bitmap.
-font_path (Font path) path fonts/liberationsans.ttf
+font_path (Font path) filepath fonts/liberationsans.ttf
 
 font_size (Font size) int 16
 
@@ -652,12 +655,12 @@ font_shadow (Font shadow) int 1
 #    Font shadow alpha (opaqueness, between 0 and 255).
 font_shadow_alpha (Font shadow alpha) int 127 0 255
 
-mono_font_path (Monospace font path) path fonts/liberationmono.ttf
+mono_font_path (Monospace font path) filepath fonts/liberationmono.ttf
 
 mono_font_size (Monospace font size) int 15
 
 #    This font will be used for certain languages.
-fallback_font_path (Fallback font) path fonts/DroidSansFallbackFull.ttf
+fallback_font_path (Fallback font) filepath fonts/DroidSansFallbackFull.ttf
 fallback_font_size (Fallback font size) int 15
 fallback_font_shadow (Fallback font shadow) int 1
 fallback_font_shadow_alpha (Fallback font shadow alpha) int 128 0 255

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -344,8 +344,8 @@
 # serverlist_file = favoriteservers.txt
 
 #    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
-#    type: int min: -1
-max_out_chat_queue_size = 20
+#    type: int
+# max_out_chat_queue_size = 20
 
 ## Graphics
 
@@ -555,7 +555,7 @@ max_out_chat_queue_size = 20
 #    type: int
 # screen_h = 600
 
-#    Save the window size automatically when modified.
+#    Save window size automatically when modified.
 #    type: bool
 # autosave_screensize = true
 
@@ -757,7 +757,7 @@ max_out_chat_queue_size = 20
 # freetype = true
 
 #    Path to TrueTypeFont or bitmap.
-#    type: path
+#    type: filepath
 # font_path = fonts/liberationsans.ttf
 
 #    type: int
@@ -771,14 +771,14 @@ max_out_chat_queue_size = 20
 #    type: int min: 0 max: 255
 # font_shadow_alpha = 127
 
-#    type: path
+#    type: filepath
 # mono_font_path = fonts/liberationmono.ttf
 
 #    type: int
 # mono_font_size = 15
 
 #    This font will be used for certain languages.
-#    type: path
+#    type: filepath
 # fallback_font_path = fonts/DroidSansFallbackFull.ttf
 
 #    type: int
@@ -1841,3 +1841,4 @@ max_out_chat_queue_size = 20
 #    Print the engine's profiling data in regular intervals (in seconds). 0 = disable. Useful for developers.
 #    type: int
 # profiler_print_interval = 0
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -509,7 +509,7 @@ set(client_SRCS
 	game.cpp
 	guiChatConsole.cpp
 	guiEngine.cpp
-	guiFileSelectMenu.cpp
+	guiPathSelectMenu.cpp
 	guiFormSpecMenu.cpp
 	guiKeyChangeMenu.cpp
 	guiPasswordChange.cpp

--- a/src/guiPathSelectMenu.h
+++ b/src/guiPathSelectMenu.h
@@ -31,10 +31,8 @@ class GUIFileSelectMenu : public GUIModalMenu
 public:
 	GUIFileSelectMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 			IMenuManager *menumgr, const std::string &title,
-			const std::string &formid);
+			const std::string &formid, bool is_file_select);
 	~GUIFileSelectMenu();
-
-	void removeChildren();
 
 	/*
 	 Remove and re-add (or reposition) stuff
@@ -58,6 +56,7 @@ private:
 	TextDest *m_text_dst;
 
 	std::string m_formname;
+	bool m_file_select_dialog;
 };
 
 #endif /* GUIFILESELECTMENU_H_ */

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "guiEngine.h"
 #include "guiMainMenu.h"
 #include "guiKeyChangeMenu.h"
-#include "guiFileSelectMenu.h"
+#include "guiPathSelectMenu.h"
 #include "subgame.h"
 #include "version.h"
 #include "porting.h"
@@ -950,13 +950,14 @@ bool ModApiMainMenu::isMinetestPath(std::string path)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_show_file_open_dialog(lua_State *L)
+int ModApiMainMenu::l_show_path_select_dialog(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	const char *formname= luaL_checkstring(L, 1);
 	const char *title	= luaL_checkstring(L, 2);
+	bool is_file_select = lua_toboolean(L, 3);
 
 	GUIFileSelectMenu* fileOpenMenu =
 		new GUIFileSelectMenu(engine->m_device->getGUIEnvironment(),
@@ -964,7 +965,8 @@ int ModApiMainMenu::l_show_file_open_dialog(lua_State *L)
 								-1,
 								engine->m_menumanager,
 								title,
-								formname);
+								formname,
+								is_file_select);
 	fileOpenMenu->setTextDest(engine->m_buttonhandler);
 	fileOpenMenu->drop();
 	return 0;
@@ -1138,7 +1140,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(copy_dir);
 	API_FCT(extract_zip);
 	API_FCT(get_mainmenu_path);
-	API_FCT(show_file_open_dialog);
+	API_FCT(show_path_select_dialog);
 	API_FCT(download_file);
 	API_FCT(get_modstore_details);
 	API_FCT(get_modstore_list);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -86,7 +86,7 @@ private:
 
 	static int l_show_keys_menu(lua_State *L);
 
-	static int l_show_file_open_dialog(lua_State *L);
+	static int l_show_path_select_dialog(lua_State *L);
 
 	static int l_set_topleft_text(lua_State *L);
 

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -89,7 +89,8 @@ src/guiChatConsole.cpp
 src/guiChatConsole.h
 src/guiEngine.cpp
 src/guiEngine.h
-src/guiFileSelectMenu.cpp
+src/guiPathSelectMenu.cpp
+src/guiPathSelectMenu.h
 src/guiFormSpecMenu.cpp
 src/guiFormSpecMenu.h
 src/guiKeyChangeMenu.cpp


### PR DESCRIPTION
- Allow lua to chose whatever directories or files can be selected
- Fix selecting directories
- Rename dialog to `guiPathSelectMenu` from `guiFileSelectMenu`
- Rename lua function for opening the menu from `show_file_open_dialog` to `show_path_select_dialog`
- Remove duplicate code and fix code style.

This fixes #5833