### PR TITLE
Do not shade inventory items with textures

### DIFF
--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -698,7 +698,10 @@ void drawItemStack(video::IVideoDriver *driver,
 				if (p->override_base)
 					c = p->color;
 			}
-			colorizeMeshBuffer(buf, &c);
+			if (imesh->needs_shading)
+				colorizeMeshBuffer(buf, &c);
+			else
+				setMeshBufferColor(buf, c);
 			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 			material.Lighting = false;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -175,6 +175,14 @@ void translateMesh(scene::IMesh *mesh, v3f vec)
 	mesh->setBoundingBox(bbox);
 }
 
+void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color)
+{
+	const u32 stride = getVertexPitchFromType(buf->getVertexType());
+	u32 vertex_count = buf->getVertexCount();
+	u8 *vertices = (u8 *) buf->getVertices();
+	for (u32 i = 0; i < vertex_count; i++)
+		((video::S3DVertex *) (vertices + i * stride))->Color = color;
+}
 
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 {
@@ -182,14 +190,8 @@ void setMeshColor(scene::IMesh *mesh, const video::SColor &color)
 		return;
 
 	u32 mc = mesh->getMeshBufferCount();
-	for (u32 j = 0; j < mc; j++) {
-		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
-		const u32 stride = getVertexPitchFromType(buf->getVertexType());
-		u32 vertex_count = buf->getVertexCount();
-		u8 *vertices = (u8 *)buf->getVertices();
-		for (u32 i = 0; i < vertex_count; i++)
-			((video::S3DVertex *)(vertices + i * stride))->Color = color;
-	}
+	for (u32 j = 0; j < mc; j++)
+		setMeshBufferColor(mesh->getMeshBuffer(j), color);
 }
 
 void colorizeMeshBuffer(scene::IMeshBuffer *buf, const video::SColor *buffercolor)

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -49,11 +49,20 @@ void scaleMesh(scene::IMesh *mesh, v3f scale);
 */
 void translateMesh(scene::IMesh *mesh, v3f vec);
 
+/*!
+ * Sets a constant color for all vertices in the mesh buffer.
+ */
+void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color);
+
 /*
 	Set a constant color for all vertices in the mesh
 */
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color);
 
+/*!
+ * Overwrites the color of a mesh buffer.
+ * The color is darkened based on the normal vector of the vertices.
+ */
 void colorizeMeshBuffer(scene::IMeshBuffer *buf, const video::SColor *buffercolor);
 
 /*

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -440,10 +440,15 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 
 	scene::SMesh *mesh = NULL;
 
+	// Shading is on by default
+	result->needs_shading = true;
+
 	// If inventory_image is defined, it overrides everything else
 	if (def.inventory_image != "") {
 		mesh = getExtrudedMesh(tsrc, def.inventory_image);
 		result->buffer_colors.push_back(ItemPartColor());
+		// Items with inventory images do not need shading
+		result->needs_shading = false;
 	} else if (def.type == ITEM_NODE) {
 		if (f.mesh_ptr[0]) {
 			mesh = cloneMesh(f.mesh_ptr[0]);

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -59,8 +59,13 @@ struct ItemMesh
 	 * Stores the color of each mesh buffer.
 	 */
 	std::vector<ItemPartColor> buffer_colors;
+	/*!
+	 * If false, all faces of the item should have the same brightness.
+	 * Disables shading based on normal vectors.
+	 */
+	bool needs_shading;
 
-	ItemMesh() : mesh(NULL), buffer_colors() {}
+	ItemMesh() : mesh(NULL), buffer_colors(), needs_shading(true) {}
 };
 
 /*


### PR DESCRIPTION
This commit restores the old behavior: if an inventory item has an own
inventory texture, it will not be shaded.

Fixes #5866.