### PR TITLE
Helper methods for hardware colorization

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -530,6 +530,18 @@ function core.node_dig(pos, node, digger)
 	end
 end
 
+function core.itemstring_with_palette(item, palette_index)
+	local stack = ItemStack(item) -- convert to ItemStack
+	stack:get_meta():set_int("palette_index", palette_index)
+	return stack:to_string()
+end
+
+function core.itemstring_with_color(item, colorstring)
+	local stack = ItemStack(item) -- convert to ItemStack
+	stack:get_meta():set_string("color", colorstring)
+	return stack:to_string()
+end
+
 -- This is used to allow mods to redefine core.item_place and so on
 -- NOTE: This is not the preferred way. Preferred way is to provide enough
 --       callbacks to not require redefining global functions. -celeron55

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -539,16 +539,16 @@ custom `on_place` and `on_dig` callbacks.
 Craft recipes only support item strings, but fortunately item strings
 can also contain metadata. Example craft recipe registration:
 
-    local stack = ItemStack("wool:block")
-    dyed:get_meta():set_int("palette_index", 3) -- add index
     minetest.register_craft({
-        output = dyed:to_string(), -- convert to string
+        output = minetest.itemstring_with_palette("wool:block", 3),
         type = "shapeless",
         recipe = {
             "wool:block",
             "dye:red",
         },
     })
+
+To set the `color` field, you can use `minetest.itemstring_with_color`.
 
 Metadata field filtering in the `recipe` field are not supported yet,
 so the craft output is independent of the color of the ingredients.
@@ -2725,6 +2725,21 @@ and `minetest.auth_reload` call the authetification handler.
       digger's inventory
     * Can be overridden to get different functionality (e.g. dropping items on
       ground)
+* `minetest.itemstring_with_palette(item, palette_index)`: returns an item string
+    * Creates an item string which contains palette index information
+      for hardware colorization. You can use the returned string
+      as an output in a craft recipe.
+    * `item`: the item stack which becomes colored. Can be in string,
+      table and native form.
+    * `palette_index`: this index is added to the item stack
+* `minetest.itemstring_with_color(item, colorstring)`: returns an item string
+    * Creates an item string which contains static color information
+      for hardware colorization. Use this method if you wish to colorize
+      an item that does not own a palette. You can use the returned string
+      as an output in a craft recipe.
+    * `item`: the item stack which becomes colored. Can be in string,
+      table and native form.
+    * `colorstring`: the new color of the item stack
 
 ### Rollback
 * `minetest.rollback_get_node_actions(pos, range, seconds, limit)`:


### PR DESCRIPTION
This pull request adds two helper methods for modders, which make creating colored craft recipes easier, so  it will be easier for beginner modders to understand hardware colorization.

Current complexity:
```lua
local dyed = ItemStack("wool:block")
dyed:get_meta():set_int("palette_index", 3)
minetest.register_craft({
	output = dyed:to_string(),
	type = "shapeless",
	recipe = {
		"wool:block",
		"dye:red",
	},
})
```

New complexity:
```lua
minetest.register_craft({
	output = minetest.itemstring_with_palette("wool:block", 3),
	type = "shapeless",
	recipe = {
		"wool:block",
		"dye:red",
	},
})
```