### PR TITLE
Biome generation: Allow mapgens to alter biome zero level

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -633,7 +633,7 @@ MapgenBasic::~MapgenBasic()
 }
 
 
-MgStoneType MapgenBasic::generateBiomes()
+MgStoneType MapgenBasic::generateBiomes(s16 biome_zero_y)
 {
 	// can't generate biomes without a biome generator!
 	assert(biomegen);
@@ -685,7 +685,9 @@ MgStoneType MapgenBasic::generateBiomes()
 				(air_above || !biome);
 
 			if (is_stone_surface || is_water_surface) {
-				biome = biomegen->getBiomeAtIndex(index, y);
+				s32 relative_y = rangelim((s32)y - (s32)biome_zero_y,
+						S16_MIN, S16_MAX);
+				biome = biomegen->getBiomeAtIndex(index, relative_y);
 
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
 					biomemap[index] = biome->index;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -247,7 +247,7 @@ public:
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
 	virtual bool generateCaverns(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y, MgStoneType stone_type);
-	virtual MgStoneType generateBiomes();
+	virtual MgStoneType generateBiomes(s16 biome_zero_y);
 	virtual void dustTopNodes();
 
 protected:

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -195,7 +195,7 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes();
+	MgStoneType stone_type = generateBiomes(0);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -205,7 +205,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes();
+	MgStoneType stone_type = generateBiomes(0);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, MGFRACTAL_LARGE_CAVE_DEPTH);

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -200,7 +200,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes();
+	MgStoneType stone_type = generateBiomes(0);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -288,7 +288,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes();
+	MgStoneType stone_type = generateBiomes(0);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -246,7 +246,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Place biome-specific nodes and build biomemap
-	MgStoneType stone_type = generateBiomes();
+	MgStoneType stone_type = generateBiomes(0);
 
 	// Cave creation.
 	if (flags & MG_CAVES)


### PR DESCRIPTION
WIP still need to test.

Allows mapgens to raise or lower the entire set of registered biomes per-mapchunk by setting the 'biome zero level' instead of that level always being y = 0.
This will allow the option of repeating the registered set of biomes in mgv7 floatlands without needing to register a duplicate set of biomes just for floatlands.
Will also allow future mapgens to create a world of multiple stacked realms without needing to register a set of biomes for every realm.
Will probably allow further interesting possibilites for future mapgens.
(I am currently experimenting with new core mapgens that can make use of this PR).

Also intended in other PRs: The same feature for registered ores and decorations.