### PR TITLE
Fix issue Minetest crash when custom font path is not exist

### DIFF
--- a/src/fontengine.cpp
+++ b/src/fontengine.cpp
@@ -340,7 +340,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 		}
 
 		if (font_config_prefix == "mono_") {
-			const std::string & mono_font_path = m_settings->getDefault("mono_font_path");
+			const std::string &mono_font_path = m_settings->getDefault("mono_font_path");
 
 			if (font_path != mono_font_path) {
 				// try original mono font
@@ -373,7 +373,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 				return;
 			}
 
-			const std::string & fallback_font_path = m_settings->getDefault("fallback_font_path");
+			const std::string &fallback_font_path = m_settings->getDefault("fallback_font_path");
 
 			if (font_path != fallback_font_path) {
 				// try original fallback font

--- a/src/fontengine.cpp
+++ b/src/fontengine.cpp
@@ -339,19 +339,63 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 			return;
 		}
 
-		// try fallback font
-		errorstream << "FontEngine: failed to load: " << font_path << ", trying to fall back "
-				"to fallback font" << std::endl;
+		if (font_config_prefix == "mono_") {
+#if USE_FREETYPE
+			std::string mono_font_path = porting::getDataPath("fonts" DIR_DELIM "Cousine-Regular.ttf");
+#else
+			std::string mono_font_path = porting::getDataPath("fonts" DIR_DELIM "mono_dejavu_sans");
+#endif
 
-		font_path = g_settings->get(font_config_prefix + "fallback_font_path");
+			if (font_path != mono_font_path) {
+				// try original mono font
+				errorstream << "FontEngine: failed to load custom mono font: " << font_path << ", "
+						"trying to fall back to original mono font" << std::endl;
 
-		font = gui::CGUITTFont::createTTFont(m_env,
-			font_path.c_str(), size, true, true, font_shadow,
-			font_shadow_alpha);
+				font = gui::CGUITTFont::createTTFont(m_env,
+					mono_font_path.c_str(), size, true, true,
+					font_shadow, font_shadow_alpha);
 
-		if (font != NULL) {
-			m_font_cache[mode][basesize] = font;
-			return;
+				if (font != NULL) {
+					m_font_cache[mode][basesize] = font;
+					return;
+				}
+			}
+		} else {
+			// try fallback font
+			errorstream << "FontEngine: failed to load: " << font_path << ", trying to fall back "
+					"to fallback font" << std::endl;
+
+			font_path = g_settings->get(font_config_prefix + "fallback_font_path");
+
+			font = gui::CGUITTFont::createTTFont(m_env,
+				font_path.c_str(), size, true, true, font_shadow,
+				font_shadow_alpha);
+
+			if (font != NULL) {
+				m_font_cache[mode][basesize] = font;
+				return;
+			}
+
+#if USE_FREETYPE
+			std::string fallback_font_path = porting::getDataPath("fonts" DIR_DELIM "DroidSansFallbackFull.ttf");
+#else
+			std::string fallback_font_path = porting::getDataPath("fonts" DIR_DELIM "mono_dejavu_sans");
+#endif
+
+			if (font_path != fallback_font_path) {
+				// try original fallback font
+				errorstream << "FontEngine: failed to load custom fallback font: " << font_path << ", "
+						"trying to fall back to original fallback font" << std::endl;
+
+				font = gui::CGUITTFont::createTTFont(m_env,
+					fallback_font_path.c_str(), size, true, true,
+					font_shadow, font_shadow_alpha);
+
+				if (font != NULL) {
+					m_font_cache[mode][basesize] = font;
+					return;
+				}
+			}
 		}
 
 		// give up

--- a/src/fontengine.cpp
+++ b/src/fontengine.cpp
@@ -344,8 +344,9 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 
 			if (font_path != mono_font_path) {
 				// try original mono font
-				errorstream << "FontEngine: failed to load custom mono font: " << font_path << ", "
-						"trying to fall back to original mono font" << std::endl;
+				errorstream << "FontEngine: failed to load custom mono "
+						"font: " << font_path << ", trying to fall back to "
+						"original mono font" << std::endl;
 
 				font = gui::CGUITTFont::createTTFont(m_env,
 					mono_font_path.c_str(), size, true, true,
@@ -358,8 +359,8 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 			}
 		} else {
 			// try fallback font
-			errorstream << "FontEngine: failed to load: " << font_path << ", trying to fall back "
-					"to fallback font" << std::endl;
+			errorstream << "FontEngine: failed to load: " << font_path <<
+					", trying to fall back to fallback font" << std::endl;
 
 			font_path = g_settings->get(font_config_prefix + "fallback_font_path");
 
@@ -376,8 +377,9 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 
 			if (font_path != fallback_font_path) {
 				// try original fallback font
-				errorstream << "FontEngine: failed to load custom fallback font: " << font_path << ", "
-						"trying to fall back to original fallback font" << std::endl;
+				errorstream << "FontEngine: failed to load custom fallback "
+						"font: " << font_path << ", trying to fall back to "
+						"original fallback font" << std::endl;
 
 				font = gui::CGUITTFont::createTTFont(m_env,
 					fallback_font_path.c_str(), size, true, true,
@@ -393,9 +395,9 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 		// give up
 		errorstream << "FontEngine: failed to load freetype font: "
 				<< font_path << std::endl;
-		errorstream << "minetest can not continue without a valid font. Please correct "
-				"the 'font_path' setting or install the font file in the proper "
-				"location" << std::endl;
+		errorstream << "minetest can not continue without a valid font. "
+				"Please correct the 'font_path' setting or install the font "
+				"file in the proper location" << std::endl;
 		abort();
 	}
 #endif

--- a/src/fontengine.cpp
+++ b/src/fontengine.cpp
@@ -334,13 +334,13 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 				font_path.c_str(), size, true, true, font_shadow,
 				font_shadow_alpha);
 
-		if (font != NULL) {
+		if (font) {
 			m_font_cache[mode][basesize] = font;
 			return;
 		}
 
 		if (font_config_prefix == "mono_") {
-			std::string mono_font_path = m_settings->getDefault("mono_font_path");
+			const std::string & mono_font_path = m_settings->getDefault("mono_font_path");
 
 			if (font_path != mono_font_path) {
 				// try original mono font
@@ -351,7 +351,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 					mono_font_path.c_str(), size, true, true,
 					font_shadow, font_shadow_alpha);
 
-				if (font != NULL) {
+				if (font) {
 					m_font_cache[mode][basesize] = font;
 					return;
 				}
@@ -367,12 +367,12 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 				font_path.c_str(), size, true, true, font_shadow,
 				font_shadow_alpha);
 
-			if (font != NULL) {
+			if (font) {
 				m_font_cache[mode][basesize] = font;
 				return;
 			}
 
-			std::string fallback_font_path = m_settings->getDefault("fallback_font_path");
+			const std::string & fallback_font_path = m_settings->getDefault("fallback_font_path");
 
 			if (font_path != fallback_font_path) {
 				// try original fallback font
@@ -383,7 +383,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 					fallback_font_path.c_str(), size, true, true,
 					font_shadow, font_shadow_alpha);
 
-				if (font != NULL) {
+				if (font) {
 					m_font_cache[mode][basesize] = font;
 					return;
 				}
@@ -497,7 +497,7 @@ void FontEngine::initSimpleFont(unsigned int basesize, FontMode mode)
 		}
 	}
 
-	if (font != NULL) {
+	if (font) {
 		font->grab();
 		m_font_cache[mode][basesize] = font;
 	}

--- a/src/fontengine.cpp
+++ b/src/fontengine.cpp
@@ -340,11 +340,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 		}
 
 		if (font_config_prefix == "mono_") {
-#if USE_FREETYPE
-			std::string mono_font_path = porting::getDataPath("fonts" DIR_DELIM "Cousine-Regular.ttf");
-#else
-			std::string mono_font_path = porting::getDataPath("fonts" DIR_DELIM "mono_dejavu_sans");
-#endif
+			std::string mono_font_path = m_settings->getDefault("mono_font_path");
 
 			if (font_path != mono_font_path) {
 				// try original mono font
@@ -376,11 +372,7 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 				return;
 			}
 
-#if USE_FREETYPE
-			std::string fallback_font_path = porting::getDataPath("fonts" DIR_DELIM "DroidSansFallbackFull.ttf");
-#else
-			std::string fallback_font_path = porting::getDataPath("fonts" DIR_DELIM "mono_dejavu_sans");
-#endif
+			std::string fallback_font_path = m_settings->getDefault("fallback_font_path");
 
 			if (font_path != fallback_font_path) {
 				// try original fallback font

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -362,6 +362,18 @@ const SettingsEntry &Settings::getEntry(const std::string &name) const
 }
 
 
+const SettingsEntry &Settings::getEntryDefault(const std::string &name) const
+{
+	MutexAutoLock lock(m_mutex);
+
+	SettingEntries::const_iterator n;
+	if ((n = m_defaults.find(name)) == m_defaults.end()) {
+		throw SettingNotFoundException("Setting [" + name + "] not found.");
+	}
+	return n->second;
+}
+
+
 Settings *Settings::getGroup(const std::string &name) const
 {
 	const SettingsEntry &entry = getEntry(name);
@@ -374,6 +386,15 @@ Settings *Settings::getGroup(const std::string &name) const
 const std::string &Settings::get(const std::string &name) const
 {
 	const SettingsEntry &entry = getEntry(name);
+	if (entry.is_group)
+		throw SettingNotFoundException("Setting [" + name + "] is a group.");
+	return entry.value;
+}
+
+
+const std::string &Settings::getDefault(const std::string &name) const
+{
+	const SettingsEntry &entry = getEntryDefault(name);
 	if (entry.is_group)
 		throw SettingNotFoundException("Setting [" + name + "] is a group.");
 	return entry.value;
@@ -568,6 +589,17 @@ bool Settings::getEntryNoEx(const std::string &name, SettingsEntry &val) const
 }
 
 
+bool Settings::getEntryDefaultNoEx(const std::string &name, SettingsEntry &val) const
+{
+	try {
+		val = getEntryDefault(name);
+		return true;
+	} catch (SettingNotFoundException &e) {
+		return false;
+	}
+}
+
+
 bool Settings::getGroupNoEx(const std::string &name, Settings *&val) const
 {
 	try {
@@ -583,6 +615,17 @@ bool Settings::getNoEx(const std::string &name, std::string &val) const
 {
 	try {
 		val = get(name);
+		return true;
+	} catch (SettingNotFoundException &e) {
+		return false;
+	}
+}
+
+
+bool Settings::getDefaultNoEx(const std::string &name, std::string &val) const
+{
+	try {
+		val = getDefault(name);
 		return true;
 	} catch (SettingNotFoundException &e) {
 		return false;

--- a/src/settings.h
+++ b/src/settings.h
@@ -129,8 +129,10 @@ public:
 	 ***********/
 
 	const SettingsEntry &getEntry(const std::string &name) const;
+	const SettingsEntry &getEntryDefault(const std::string &name) const;
 	Settings *getGroup(const std::string &name) const;
 	const std::string &get(const std::string &name) const;
+	const std::string &getDefault(const std::string &name) const;
 	bool getBool(const std::string &name) const;
 	u16 getU16(const std::string &name) const;
 	s16 getS16(const std::string &name) const;
@@ -159,8 +161,10 @@ public:
 	 ***************************************/
 
 	bool getEntryNoEx(const std::string &name, SettingsEntry &val) const;
+	bool getEntryDefaultNoEx(const std::string &name, SettingsEntry &val) const;
 	bool getGroupNoEx(const std::string &name, Settings *&val) const;
 	bool getNoEx(const std::string &name, std::string &val) const;
+	bool getDefaultNoEx(const std::string &name, std::string &val) const;
 	bool getFlag(const std::string &name) const;
 	bool getU16NoEx(const std::string &name, u16 &val) const;
 	bool getS16NoEx(const std::string &name, s16 &val) const;


### PR DESCRIPTION
We try to use default fallback for both mono and main font when custom font path is not exist. This way, if Minetest is not corrupted, we could avoid crash.

~Idea:~
- ~Put a dialog to tell the player. (?)~

(Not for now. Probably in another PR.)