### PR TITLE
Remove unimplemented setting `movement_speed_descend`

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -886,7 +886,6 @@ movement_speed_crouch (Crouch speed) float 1.35
 movement_speed_fast (Fast mode speed) float 20
 movement_speed_climb (Climbing speed) float 3
 movement_speed_jump (Jumping speed) float 6.5
-movement_speed_descend (Descending speed) float 6
 movement_liquid_fluidity (Liquid fluidity) float 1
 movement_liquid_fluidity_smooth (Liquid fluidity smoothing) float 0.5
 movement_liquid_sink (Liquid sink) float 10

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1079,9 +1079,6 @@ max_out_chat_queue_size = 20
 # movement_speed_jump = 6.5
 
 #    type: float
-# movement_speed_descend = 6
-
-#    type: float
 # movement_liquid_fluidity = 1
 
 #    type: float


### PR DESCRIPTION
This setting seems to have been first documented in df3c925b3ccae3bdba125e6dc3ecc740739baeab but it was never implemented.