### PR TITLE
(Re)spawn players within 'mapgen_limit' 

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1053,12 +1053,13 @@ void MapgenParams::writeParams(Settings *settings) const
 // 'mapgen_limit'), and corresponding exact limits for SAO entities.
 void MapgenParams::calcMapgenEdges()
 {
+	if (m_mapgen_edges_calculated)
+		return;
+	
 	// Central chunk offset, in blocks
 	s16 ccoff_b = -chunksize / 2;
-
 	// Chunksize, in nodes
 	s32 csize_n = chunksize * MAP_BLOCKSIZE;
-
 	// Minp/maxp of central chunk, in nodes
 	s16 ccmin = ccoff_b * MAP_BLOCKSIZE;
 	s16 ccmax = ccmin + csize_n - 1;
@@ -1077,25 +1078,33 @@ void MapgenParams::calcMapgenEdges()
 	s16 numcmin = MYMAX((ccfmin - mapgen_limit_min) / csize_n, 0);
 	s16 numcmax = MYMAX((mapgen_limit_max - ccfmax) / csize_n, 0);
 	// Mapgen edges, in nodes
-	// These values may be useful later as additional class members
-	s16 mapgen_edge_min = ccmin - numcmin * csize_n;
-	s16 mapgen_edge_max = ccmax + numcmax * csize_n;
+	mapgen_edge_min = ccmin - numcmin * csize_n;
+	mapgen_edge_max = ccmax + numcmax * csize_n;
 	// SAO position limits, in Irrlicht units
 	m_sao_limit_min = mapgen_edge_min * BS - 3.0f;
 	m_sao_limit_max = mapgen_edge_max * BS + 3.0f;
+	
+	m_mapgen_edges_calculated = true;
 }
 
 
 bool MapgenParams::saoPosOverLimit(const v3f &p)
 {
-	if (!m_sao_limit_calculated) {
+	if (!m_mapgen_edges_calculated)
 		calcMapgenEdges();
-		m_sao_limit_calculated = true;
-	}
+
 	return p.X < m_sao_limit_min ||
 		p.X > m_sao_limit_max ||
 		p.Y < m_sao_limit_min ||
 		p.Y > m_sao_limit_max ||
 		p.Z < m_sao_limit_min ||
 		p.Z > m_sao_limit_max;
+}
+
+
+s32 MapgenParams::getSpawnRangeMax()
+{
+	calcMapgenEdges();
+
+	return MYMIN(-mapgen_edge_min, mapgen_edge_max);
 }

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -131,6 +131,9 @@ struct MapgenParams {
 
 	BiomeParams *bparams;
 
+	s16 mapgen_edge_min;
+	s16 mapgen_edge_max;
+
 	MapgenParams() :
 		mgtype(MAPGEN_DEFAULT),
 		chunksize(5),
@@ -139,9 +142,12 @@ struct MapgenParams {
 		mapgen_limit(MAX_MAP_GENERATION_LIMIT),
 		flags(MG_CAVES | MG_LIGHT | MG_DECORATIONS),
 		bparams(NULL),
-		m_sao_limit_min(MAX_MAP_GENERATION_LIMIT * BS),
+
+		mapgen_edge_min(-MAX_MAP_GENERATION_LIMIT),
+		mapgen_edge_max(MAX_MAP_GENERATION_LIMIT),
+		m_sao_limit_min(-MAX_MAP_GENERATION_LIMIT * BS),
 		m_sao_limit_max(MAX_MAP_GENERATION_LIMIT * BS),
-		m_sao_limit_calculated(false)
+		m_mapgen_edges_calculated(false)
 	{
 	}
 
@@ -151,12 +157,14 @@ struct MapgenParams {
 	virtual void writeParams(Settings *settings) const;
 
 	bool saoPosOverLimit(const v3f &p);
+	s32 getSpawnRangeMax();
+
 private:
 	void calcMapgenEdges();
 
 	float m_sao_limit_min;
 	float m_sao_limit_max;
-	bool m_sao_limit_calculated;
+	bool m_mapgen_edges_calculated;
 };
 
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3510,10 +3510,12 @@ v3f Server::findSpawnPos()
 	}
 
 	bool is_good = false;
+	// Limit spawn range to mapgen edges (determined by 'mapgen_limit')
+	s32 range_max = map.getMapgenParams()->getSpawnRangeMax();
 
 	// Try to find a good place a few times
 	for(s32 i = 0; i < 4000 && !is_good; i++) {
-		s32 range = 1 + i;
+		s32 range = MYMIN(1 + i, range_max);
 		// We're going to try to throw the player to this position
 		v2s16 nodepos2d = v2s16(
 			-range + (myrand() % (range * 2)),

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -579,7 +579,8 @@ PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, bool *new_player,
 		// If the player exists, ensure that they respawn inside legal bounds
 		// This fixes an assert crash when the player can't be added
 		// to the environment
-		if (objectpos_over_limit(playersao->getBasePosition())) {
+		ServerMap &map = getServerMap();
+		if (map.getMapgenParams()->saoPosOverLimit(playersao->getBasePosition())) {
 			actionstream << "Respawn position for player \""
 				<< player->getName() << "\" outside limits, resetting" << std::endl;
 			playersao->setBasePosition(m_server->findSpawnPos());


### PR DESCRIPTION
Previously, findSpawnPos() did not take the 'mapgen_limit' setting into account,
a small limit often resulted in a spawn out in the void.
Use the recently added 'calcMapgenEdges()' to get max spawn range through a new
mapgenParams function 'getSpawnRangeMax()'.

Previously, when a player respawned into a world, 'objectpos_over_limit()' was
used as a check, which was inaccurate.
Use the recently added 'saoPosOverLimit()' to get exact mapgen edges.

Also fix default value of 'm_sao_limit_min'.
///////////////////

Tested.