### PR TITLE
Error when compiling from source fix.

### DIFF
--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -26,6 +26,8 @@
  *
  */
 
+#include <cstddef>
+
 // clang-format off
 #ifdef WIN32
 	#include <windows.h>


### PR DESCRIPTION
There is an error when compiling from source and this fix will stop it from happening. The fix comes from here https://stackoverflow.com/questions/35110786/how-to-fix-the-error-max-align-t

The error occurred on Linux Ubuntu 14.04