### PR TITLE
Main Menu: Add get_clientmodpath API

### DIFF
--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -35,6 +35,8 @@ core.get_builtin_path()
 ^ returns path to builtin root
 core.get_modpath() (possible in async calls)
 ^ returns path to global modpath
+core.get_clientmodpath() (possible in async calls)
+^ returns path to global client-side modpath
 core.get_modstore_details(modid) (possible in async calls)
 ^ modid numeric id of mod in modstore
 ^ returns {
@@ -234,7 +236,7 @@ Limitations of Async operations
  -Limited set of available functions
 	e.g. No access to functions modifying menu like core.start,core.close,
 	core.file_open_dialog
-			
+
 
 Class reference
 ----------------

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -735,6 +735,15 @@ int ModApiMainMenu::l_get_modpath(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_get_clientmodpath(lua_State *L)
+{
+	std::string modpath = fs::RemoveRelativePathComponents(
+		porting::path_user + DIR_DELIM + "clientmods" + DIR_DELIM);
+	lua_pushstring(L, modpath.c_str());
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_get_gamepath(lua_State *L)
 {
 	std::string gamepath = fs::RemoveRelativePathComponents(
@@ -1120,6 +1129,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(set_topleft_text);
 	API_FCT(get_mapgen_names);
 	API_FCT(get_modpath);
+	API_FCT(get_clientmodpath);
 	API_FCT(get_gamepath);
 	API_FCT(get_texturepath);
 	API_FCT(get_texturepath_share);
@@ -1150,6 +1160,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(get_favorites);
 	API_FCT(get_mapgen_names);
 	API_FCT(get_modpath);
+	API_FCT(get_clientmodpath);
 	API_FCT(get_gamepath);
 	API_FCT(get_texturepath);
 	API_FCT(get_texturepath_share);
@@ -1162,4 +1173,3 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(get_modstore_list);
 	//API_FCT(gettext); (gettext lib isn't threadsafe)
 }
-

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -108,6 +108,8 @@ private:
 
 	static int l_get_modpath(lua_State *L);
 
+	static int l_get_clientmodpath(lua_State *L);
+
 	static int l_get_gamepath(lua_State *L);
 
 	static int l_get_texturepath(lua_State *L);


### PR DESCRIPTION
Add `core.get_clientmodpath` to main menu API (also possible in async calls).

Though not required, this is important to allow a proper way for my WIP `modmgr` rewrite to manage client side mods. And yes, I am now aware of the fact that the client loading CSMs wasn't originally planned, however, I personally think it is very important. A mod like the new [who_plus](https://forum.minetest.net/viewtopic.php?f=53&t=17800) wouldn't be inserted as a CSM by the server, it just doesn't make since. It would be optionally installed by the client.