### PR TITLE
Postprocessing

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -391,6 +391,7 @@ fsaa (FSAA) enum 0 0,1,2,4,8,16
 undersampling (Undersampling) enum 0 0,2,3,4
 
 #    Whether to use filter with undersampling.
+#    Requires shaders to be enabled.
 undersampling_filter (Smoother undersampling) bool false
 
 [***Shaders]
@@ -403,6 +404,7 @@ enable_shaders (Shaders) bool true
 shader_path (Shader path) path
 
 #    This option allows to use certain full-screen effects.
+#    Requires shaders to be enabled.
 postprocessing (Postprocessing) bool true
 
 [****Tone Mapping]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -390,6 +390,9 @@ fsaa (FSAA) enum 0 0,1,2,4,8,16
 #    It should give significant performance boost at the cost of less detailed image.
 undersampling (Undersampling) enum 0 0,2,3,4
 
+#    Whether to use filter with undersampling.
+undersampling_filter (Smoother undersampling) bool false
+
 [***Shaders]
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.
@@ -398,6 +401,9 @@ enable_shaders (Shaders) bool true
 
 #    Path to shader directory. If no path is defined, default location will be used.
 shader_path (Shader path) path
+
+#    This option allows to use certain full-screen effects.
+postprocessing (Postprocessing) bool true
 
 [****Tone Mapping]
 

--- a/client/shaders/merging/opengl_fragment.glsl
+++ b/client/shaders/merging/opengl_fragment.glsl
@@ -1,0 +1,7 @@
+uniform sampler2D baseTexture;
+
+void main(void)
+{
+	vec2 uv = gl_TexCoord[0].st;
+	gl_FragColor = texture2D(baseTexture, uv).rgba;
+}

--- a/client/shaders/merging/opengl_vertex.glsl
+++ b/client/shaders/merging/opengl_vertex.glsl
@@ -1,0 +1,5 @@
+void main(void)
+{
+	gl_TexCoord[0] = gl_MultiTexCoord0;
+	gl_Position = gl_Vertex;
+}

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -22,7 +22,7 @@ const float BS = 10.0;
 const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
-#ifdef ENABLE_TONE_MAPPING
+#if ENABLE_TONE_MAPPING && !POSTPROCESSING_ENABLED
 
 /* Hable's UC2 Tone mapping parameters
 	A = 0.22;
@@ -46,7 +46,7 @@ vec4 applyToneMapping(vec4 color)
 	const float gamma = 1.6;
 	const float exposureBias = 5.5;
 	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
-	// Precalculated white_scale from 
+	// Precalculated white_scale from
 	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
 	vec3 whiteScale = vec3(1.036015346);
 	color.rgb *= whiteScale;
@@ -197,7 +197,7 @@ void main(void)
 
 	vec4 col = vec4(color.rgb * gl_Color.rgb, 1.0); 
 	
-#ifdef ENABLE_TONE_MAPPING
+#if ENABLE_TONE_MAPPING && !POSTPROCESSING_ENABLED
 	col = applyToneMapping(col);
 #endif
 

--- a/client/shaders/postprocessing/opengl_fragment.glsl
+++ b/client/shaders/postprocessing/opengl_fragment.glsl
@@ -1,0 +1,8 @@
+uniform sampler2D baseTexture;
+
+void main(void)
+{
+	vec2 uv = gl_TexCoord[0].st;
+	vec4 color = texture2D(baseTexture, uv).rgba;
+	gl_FragColor = color;
+}

--- a/client/shaders/postprocessing/opengl_fragment.glsl
+++ b/client/shaders/postprocessing/opengl_fragment.glsl
@@ -1,8 +1,41 @@
 uniform sampler2D baseTexture;
 
+#if ENABLE_TONE_MAPPING
+
+/* Hable's UC2 Tone mapping parameters
+	A = 0.22;
+	B = 0.30;
+	C = 0.10;
+	D = 0.20;
+	E = 0.01;
+	F = 0.30;
+	W = 11.2;
+	equation used:  ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F
+*/
+
+vec3 uncharted2Tonemap(vec3 x) {
+	return ((x * (0.22 * x + 0.03) + 0.002) / (x * (0.22 * x + 0.3) + 0.06)) - 0.03333;
+}
+
+vec4 applyToneMapping(vec4 color) {
+	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
+	const float gamma = 1.6;
+	const float exposureBias = 5.5;
+	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
+	// Precalculated white_scale from
+	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
+	vec3 whiteScale = vec3(1.036015346);
+	color.rgb *= whiteScale;
+	return vec4(pow(color.rgb, vec3(1.0 / gamma)), color.a);
+}
+#endif
+
 void main(void)
 {
 	vec2 uv = gl_TexCoord[0].st;
 	vec4 color = texture2D(baseTexture, uv).rgba;
+#if ENABLE_TONE_MAPPING
+	color = applyToneMapping(color);
+#endif
 	gl_FragColor = color;
 }

--- a/client/shaders/postprocessing/opengl_vertex.glsl
+++ b/client/shaders/postprocessing/opengl_vertex.glsl
@@ -1,0 +1,9 @@
+uniform mat4 mWorldViewProj;
+
+void main(void)
+{
+	gl_TexCoord[0] = gl_MultiTexCoord0;
+	gl_Position = gl_Vertex;
+
+	gl_FrontColor = gl_BackColor = gl_Color;
+}

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -439,6 +439,10 @@ max_out_chat_queue_size = 20
 #    type: enum values: 0, 2, 3, 4
 # undersampling = 0
 
+#    Whether to use filter with undersampling.
+#    type: bool
+# undersampling_filter = false
+
 #### Shaders
 
 #    Shaders allow advanced visual effects and may increase performance on some video cards.
@@ -449,6 +453,10 @@ max_out_chat_queue_size = 20
 #    Path to shader directory. If no path is defined, default location will be used.
 #    type: path
 # shader_path =
+
+#    This option allows to use certain full-screen effects.
+#    type: bool
+# postprocessing = true
 
 ##### Tone Mapping
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -440,6 +440,7 @@ max_out_chat_queue_size = 20
 # undersampling = 0
 
 #    Whether to use filter with undersampling.
+#    Requires shaders to be enabled.
 #    type: bool
 # undersampling_filter = false
 
@@ -455,6 +456,7 @@ max_out_chat_queue_size = 20
 # shader_path =
 
 #    This option allows to use certain full-screen effects.
+#    Requires shaders to be enabled.
 #    type: bool
 # postprocessing = true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -116,6 +116,8 @@ void set_default_settings(Settings *settings)
 #endif
 	settings->setDefault("fsaa", "0");
 	settings->setDefault("undersampling", "0");
+	settings->setDefault("undersampling_filter", "false");
+	settings->setDefault("postprocessing", "true");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -509,13 +509,13 @@ void draw_plain(Camera &camera, bool show_hud,
 	// Post-process
 	if (undersampling || postprocessing) {
 		driver->setRenderTarget(0, false, false);
-		static video::S3DVertex vertices[4] = {
+		static const video::S3DVertex vertices[4] = {
 			video::S3DVertex(1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 0, 255, 255), 1.0, 0.0),
 			video::S3DVertex(-1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 0, 255), 0.0, 0.0),
 			video::S3DVertex(-1.0, 1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 255, 0), 0.0, 1.0),
 			video::S3DVertex(1.0, 1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 255, 255), 1.0, 1.0),
 		};
-		static u16 indices[6] = { 0, 1, 2, 2, 3, 0 };
+		static const u16 indices[6] = { 0, 1, 2, 2, 3, 0 };
 		IShaderSource *s = client.getShaderSource();
 		video::SMaterial mat;
 		mat.UseMipMaps = false;

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -477,7 +477,8 @@ void draw_plain(Camera &camera, bool show_hud,
 	static v2u32 last_pixelated_size = v2u32(0, 0);
 	int pixel_size = g_settings->getU16("undersampling");
 	bool undersampling = pixel_size > 1;
-	bool postprocessing = g_settings->getBool("postprocessing");
+	bool enable_shaders = g_settings->getBool("enable_shaders");
+	bool postprocessing = enable_shaders && g_settings->getBool("postprocessing");
 	bool filter = g_settings->getBool("undersampling_filter");
 	v2u32 pixelated_size;
 	v2u32 dest_size;
@@ -509,6 +510,12 @@ void draw_plain(Camera &camera, bool show_hud,
 	// Post-process
 	if (undersampling || postprocessing) {
 		driver->setRenderTarget(0, false, false);
+		if (!enable_shaders) {
+			driver->draw2DImage(image,
+					irr::core::rect<s32>(0, 0, dest_size.X, dest_size.Y),
+					irr::core::rect<s32>(0, 0, pixelated_size.X, pixelated_size.Y));
+			return;
+		}
 		static const video::S3DVertex vertices[4] = {
 			video::S3DVertex(1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 0, 255, 255), 1.0, 0.0),
 			video::S3DVertex(-1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 0, 255), 0.0, 0.0),

--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -473,16 +473,24 @@ void draw_plain(Camera &camera, bool show_hud,
 {
 	// Undersampling-specific stuff
 	static video::ITexture *image = NULL;
+	static video::ITexture *image2 = NULL;
 	static v2u32 last_pixelated_size = v2u32(0, 0);
-	int undersampling = g_settings->getU16("undersampling");
+	int pixel_size = g_settings->getU16("undersampling");
+	bool undersampling = pixel_size > 1;
+	bool postprocessing = g_settings->getBool("postprocessing");
+	bool filter = g_settings->getBool("undersampling_filter");
 	v2u32 pixelated_size;
 	v2u32 dest_size;
-	if (undersampling > 0) {
-		pixelated_size = v2u32(scaledown(undersampling, screensize.X),
-				scaledown(undersampling, screensize.Y));
-		dest_size = v2u32(undersampling * pixelated_size.X, undersampling * pixelated_size.Y);
+	if (!undersampling)
+		pixel_size = 1;
+	if (undersampling || postprocessing) {
+		pixelated_size = v2u32(scaledown(pixel_size, screensize.X),
+				scaledown(pixel_size, screensize.Y));
+		dest_size = v2u32(pixel_size * pixelated_size.X, pixel_size * pixelated_size.Y);
 		if (pixelated_size != last_pixelated_size) {
 			init_texture(driver, pixelated_size, &image, "mt_drawimage_img1");
+			if (undersampling && postprocessing)
+				init_texture(driver, pixelated_size, &image2, "mt_drawimage_img2");
 			last_pixelated_size = pixelated_size;
 		}
 		driver->setRenderTarget(image, true, true, skycolor);
@@ -498,12 +506,45 @@ void draw_plain(Camera &camera, bool show_hud,
 		}
 	}
 
-	// Upscale lowres render
-	if (undersampling > 0) {
-		driver->setRenderTarget(0, true, true);
-		driver->draw2DImage(image,
-				irr::core::rect<s32>(0, 0, dest_size.X, dest_size.Y),
-				irr::core::rect<s32>(0, 0, pixelated_size.X, pixelated_size.Y));
+	// Post-process
+	if (undersampling || postprocessing) {
+		driver->setRenderTarget(0, false, false);
+		static video::S3DVertex vertices[4] = {
+			video::S3DVertex(1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 0, 255, 255), 1.0, 0.0),
+			video::S3DVertex(-1.0, -1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 0, 255), 0.0, 0.0),
+			video::S3DVertex(-1.0, 1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 255, 0), 0.0, 1.0),
+			video::S3DVertex(1.0, 1.0, 0.0, 0.0, 0.0, -1.0, video::SColor(255, 255, 255, 255), 1.0, 1.0),
+		};
+		static u16 indices[6] = { 0, 1, 2, 2, 3, 0 };
+		IShaderSource *s = client.getShaderSource();
+		video::SMaterial mat;
+		mat.UseMipMaps = false;
+		mat.ZBuffer = false;
+		mat.ZWriteEnable = false;
+		mat.TextureLayer[0].AnisotropicFilter = false;
+		mat.TextureLayer[0].TrilinearFilter = false;
+		mat.TextureLayer[0].TextureWrapU = irr::video::ETC_CLAMP_TO_EDGE;
+		mat.TextureLayer[0].TextureWrapV = irr::video::ETC_CLAMP_TO_EDGE;
+		if (postprocessing) {
+			u32 shader = s->getShader("postprocessing", TILE_MATERIAL_BASIC, 0);
+			mat.MaterialType = s->getShaderInfo(shader).material;
+			mat.TextureLayer[0].BilinearFilter = false;
+			mat.TextureLayer[0].Texture = image;
+			if (undersampling)
+				driver->setRenderTarget(image2, false, false);
+			driver->setMaterial(mat);
+			driver->drawVertexPrimitiveList(&vertices, 4, &indices, 2);
+			if (undersampling)
+				driver->setRenderTarget(0, false, false);
+		}
+		if (undersampling) {
+			u32 shader = s->getShader("merging", TILE_MATERIAL_BASIC, 0);
+			mat.MaterialType = s->getShaderInfo(shader).material;
+			mat.TextureLayer[0].BilinearFilter = filter;
+			mat.TextureLayer[0].Texture = postprocessing ? image2 : image;
+			driver->setMaterial(mat);
+			driver->drawVertexPrimitiveList(&vertices, 4, &indices, 2);
+		}
 	}
 }
 

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -178,11 +178,15 @@ fake_function() {
 	gettext("Experimental option, might cause visible spaces between blocks\nwhen set to higher number than 0.");
 	gettext("Undersampling");
 	gettext("Undersampling is similar to using lower screen resolution, but it applies\nto the game world only, keeping the GUI intact.\nIt should give significant performance boost at the cost of less detailed image.");
+	gettext("Smoother undersampling");
+	gettext("Whether to use filter with undersampling.");
 	gettext("Shaders");
 	gettext("Shaders");
 	gettext("Shaders allow advanced visual effects and may increase performance on some video cards.\nThis only works with the OpenGL video backend.");
 	gettext("Shader path");
 	gettext("Path to shader directory. If no path is defined, default location will be used.");
+	gettext("Postprocessing");
+	gettext("This option allows to use certain full-screen effects.");
 	gettext("Tone Mapping");
 	gettext("Filmic tone mapping");
 	gettext("Enables filmic tone mapping");

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -179,14 +179,14 @@ fake_function() {
 	gettext("Undersampling");
 	gettext("Undersampling is similar to using lower screen resolution, but it applies\nto the game world only, keeping the GUI intact.\nIt should give significant performance boost at the cost of less detailed image.");
 	gettext("Smoother undersampling");
-	gettext("Whether to use filter with undersampling.");
+	gettext("Whether to use filter with undersampling.\nRequires shaders to be enabled.");
 	gettext("Shaders");
 	gettext("Shaders");
 	gettext("Shaders allow advanced visual effects and may increase performance on some video cards.\nThis only works with the OpenGL video backend.");
 	gettext("Shader path");
 	gettext("Path to shader directory. If no path is defined, default location will be used.");
 	gettext("Postprocessing");
-	gettext("This option allows to use certain full-screen effects.");
+	gettext("This option allows to use certain full-screen effects.\nRequires shaders to be enabled.");
 	gettext("Tone Mapping");
 	gettext("Filmic tone mapping");
 	gettext("Enables filmic tone mapping");

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -737,19 +737,16 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	}
 
 	shaders_header += "#define ENABLE_WAVING_LEAVES ";
-	if (g_settings->getBool("enable_waving_leaves"))
-		shaders_header += "1\n";
-	else
-		shaders_header += "0\n";
+	shaders_header += g_settings->getBool("enable_waving_leaves") ? "1\n" : "0\n";
 
 	shaders_header += "#define ENABLE_WAVING_PLANTS ";
-	if (g_settings->getBool("enable_waving_plants"))
-		shaders_header += "1\n";
-	else
-		shaders_header += "0\n";
+	shaders_header += g_settings->getBool("enable_waving_plants") ? "1\n" : "0\n";
 
-	if (g_settings->getBool("tone_mapping"))
-		shaders_header += "#define ENABLE_TONE_MAPPING\n";
+	shaders_header += "#define POSTPROCESSING_ENABLED ";
+	shaders_header += g_settings->getBool("postprocessing") ? "1\n" : "0\n";
+
+	shaders_header += "#define ENABLE_TONE_MAPPING ";
+	shaders_header += g_settings->getBool("tone_mapping") ? "1\n" : "0\n";
 
 	shaders_header += "#define FOG_START ";
 	shaders_header += ftos(rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f));


### PR DESCRIPTION
The post-processing shader is very simple currently, but that’s only the beginning. And even that simple shader may improve performance greatly sometimes:

**Standard tone mapping:**
![plain](https://cloud.githubusercontent.com/assets/7352626/26766274/dceb7e22-4996-11e7-8b76-5ed1fb651f5c.png)

**Tone mapping at post-processing:**
![postprocessing](https://cloud.githubusercontent.com/assets/7352626/26766275/dceffb50-4996-11e7-8a2f-2bcee6cc56fb.png)

The reason here seems to be that there are TONS of `plantlike` leaves, so usual shader gets called way more often than necessary. The performance difference is smaller when undersampling is in effect, however. Also, there is a side effect: sky color is affected too now. But that’s just an optin anyway.