### PR TITLE
[WIP] Meta-set nodedef: Part 4

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -373,32 +373,31 @@ if INIT == "game" then
 				infinitestacks, orient_flags)
 		orient_flags = orient_flags or {}
 
-		local unode = core.get_node_or_nil(pointed_thing.under)
-		if not unode then
-			return
-		end
-		local undef = core.registered_nodes[unode.name]
-		if undef and undef.on_rightclick then
-			undef.on_rightclick(pointed_thing.under, unode, placer,
-					itemstack, pointed_thing)
-			return
-		end
-		local fdir = core.dir_to_facedir(placer:get_look_dir())
-		local wield_name = itemstack:get_name()
-
 		local above = pointed_thing.above
 		local under = pointed_thing.under
+
+		local unode = core.get_node_or_nil(under)
+		if not unode then
+			return
+	end
+		local undef = core.get_nodedef(under)
+		if undef and undef.on_rightclick then
+			undef.on_rightclick(under, unode, placer, itemstack, pointed_thing)
+			return
+	end
+		local fdir = core.dir_to_facedir(placer:get_look_dir())
+		local wield_name = itemstack:get_name()
 		local iswall = (above.y == under.y)
 		local isceiling = not iswall and (above.y < under.y)
 		local anode = core.get_node_or_nil(above)
 		if not anode then
 			return
 		end
-		local pos = pointed_thing.above
+		local pos = above
 		local node = anode
 
 		if undef and undef.buildable_to then
-			pos = pointed_thing.under
+			pos = under
 			node = unode
 			iswall = false
 		end
@@ -409,7 +408,7 @@ if INIT == "game" then
 			return
 		end
 
-		local ndef = core.registered_nodes[node.name]
+		local ndef = core.get_nodedef(pos)
 		if not ndef or not ndef.buildable_to then
 			return
 		end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -62,7 +62,7 @@ core.register_entity(":__builtin:falling_node", {
 		local bcp = {x = pos.x, y = pos.y - 0.7, z = pos.z}
 		-- Avoid bugs caused by an unloaded node below
 		local bcn = core.get_node_or_nil(bcp)
-		local bcd = bcn and core.registered_nodes[bcn.name]
+		local bcd = bcn and core.get_nodedef(bcp)
 		if bcn and
 				(not bcd or bcd.walkable or
 				(core.get_item_group(self.node.name, "float") ~= 0 and
@@ -86,7 +86,7 @@ core.register_entity(":__builtin:falling_node", {
 			local np = {x = bcp.x, y = bcp.y + 1, z = bcp.z}
 			-- Check what's here
 			local n2 = core.get_node(np)
-			local nd = core.registered_nodes[n2.name]
+			local nd = core.get_nodedef(np)
 			-- If it's not air or liquid, remove node and replace it with
 			-- it's drops
 			if n2.name ~= "air" and (not nd or nd.liquidtype == "none") then
@@ -189,7 +189,7 @@ function core.check_single_for_falling(p)
 		local p_bottom = {x = p.x, y = p.y - 1, z = p.z}
 		-- Only spawn falling node if node below is loaded
 		local n_bottom = core.get_node_or_nil(p_bottom)
-		local d_bottom = n_bottom and core.registered_nodes[n_bottom.name]
+		local d_bottom = n_bottom and core.get_nodedef(p_bottom)
 		if d_bottom and
 
 				(core.get_item_group(n.name, "float") == 0 or

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -223,9 +223,9 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		return itemstack, false
 	end
 
-	local olddef_under = core.registered_nodes[oldnode_under.name]
+	local olddef_under = core.get_nodedef(under)
 	olddef_under = olddef_under or core.nodedef_default
-	local olddef_above = core.registered_nodes[oldnode_above.name]
+	local olddef_above = core.get_nodedef(above)
 	olddef_above = olddef_above or core.nodedef_default
 
 	if not olddef_above.buildable_to and not olddef_under.buildable_to then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -421,6 +421,7 @@ set(common_SRCS
 	nodedef.cpp
 	nodemetadata.cpp
 	nodetimer.cpp
+	node_with_def.cpp
 	noise.cpp
 	objdef.cpp
 	object_properties.cpp

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -259,22 +259,29 @@ void ClientEnvironment::step(float dtime)
 
 			// Feet, middle and head
 			v3s16 p1 = floatToInt(pf + v3f(0, BS * 0.1, 0), BS);
-			MapNode n1 = m_map->getNodeNoEx(p1);
 			v3s16 p2 = floatToInt(pf + v3f(0, BS * 0.8, 0), BS);
-			MapNode n2 = m_map->getNodeNoEx(p2);
 			v3s16 p3 = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
-			MapNode n3 = m_map->getNodeNoEx(p3);
+			bool is_valid_position_1;
+			bool is_valid_position_2;
+			bool is_valid_position_3;
+			HybridPtr<const ContentFeatures> f_ptr1 = m_map->getNodeDefNoEx(p1, &is_valid_position_1);
+			HybridPtr<const ContentFeatures> f_ptr2 = m_map->getNodeDefNoEx(p2, &is_valid_position_2);
+			HybridPtr<const ContentFeatures> f_ptr3 = m_map->getNodeDefNoEx(p3, &is_valid_position_3);
 
-			u32 damage_per_second = 0;
-			damage_per_second = MYMAX(damage_per_second,
-				m_client->ndef()->get(n1).damage_per_second);
-			damage_per_second = MYMAX(damage_per_second,
-				m_client->ndef()->get(n2).damage_per_second);
-			damage_per_second = MYMAX(damage_per_second,
-				m_client->ndef()->get(n3).damage_per_second);
+			if (is_valid_position_1 && is_valid_position_2 && is_valid_position_3) {
+				const ContentFeatures &f1 = *f_ptr1;
+				const ContentFeatures &f2 = *f_ptr2;
+				const ContentFeatures &f3 = *f_ptr3;
 
-			if (damage_per_second != 0)
-				damageLocalPlayer(damage_per_second, true);
+
+				u32 damage_per_second = 0;
+				damage_per_second = MYMAX(damage_per_second, f1.damage_per_second);
+				damage_per_second = MYMAX(damage_per_second, f2.damage_per_second);
+				damage_per_second = MYMAX(damage_per_second, f3.damage_per_second);
+
+				if (damage_per_second != 0)
+					damageLocalPlayer(damage_per_second, true);
+			}
 		}
 
 		/*
@@ -285,9 +292,9 @@ void ClientEnvironment::step(float dtime)
 
 			// head
 			v3s16 p = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
-			MapNode n = m_map->getNodeNoEx(p);
-			ContentFeatures c = m_client->ndef()->get(n);
-			u8 drowning_damage = c.drowning;
+			HybridPtr<const ContentFeatures> f_ptr = m_map->getNodeDefNoEx(p);
+			const ContentFeatures &f = *f_ptr;
+			u8 drowning_damage = f.drowning;
 			if (drowning_damage > 0 && lplayer->hp > 0) {
 				u16 breath = lplayer->getBreath();
 				if (breath > 10) {
@@ -309,11 +316,11 @@ void ClientEnvironment::step(float dtime)
 
 			// head
 			v3s16 p = floatToInt(pf + v3f(0, BS * 1.6, 0), BS);
-			MapNode n = m_map->getNodeNoEx(p);
-			ContentFeatures c = m_client->ndef()->get(n);
+			HybridPtr<const ContentFeatures> f_ptr = m_map->getNodeDefNoEx(p);
+			const ContentFeatures &f = *f_ptr;
 			if (!lplayer->hp) {
 				lplayer->setBreath(11);
-			} else if (c.drowning == 0) {
+			} else if (f.drowning == 0) {
 				u16 breath = lplayer->getBreath();
 				if (breath <= 10) {
 					breath += 1;
@@ -669,12 +676,10 @@ ClientActiveObject * ClientEnvironment::getSelectedActiveObject(
 /*
 	Check if a node is pointable
 */
-static inline bool isPointableNode(const MapNode &n,
+static inline bool isPointableNode(const ContentFeatures &f,
 	INodeDefManager *ndef, bool liquids_pointable)
 {
-	const ContentFeatures &features = ndef->get(n);
-	return features.pointable ||
-		(liquids_pointable && features.isLiquid());
+	return f.pointable || (liquids_pointable && f.isLiquid());
 }
 
 PointedThing ClientEnvironment::getPointedThing(
@@ -769,12 +774,14 @@ PointedThing ClientEnvironment::getPointedThing(
 					bool is_valid_position;
 
 					n = m_map->getNodeNoEx(np, &is_valid_position);
+					HybridPtr<const ContentFeatures> f_ptr = m_map->getNodeDefNoEx(np);
+					const ContentFeatures &f = *f_ptr;
 					if (!(is_valid_position &&
-						isPointableNode(n, nodedef, liquids_pointable))) {
+						isPointableNode(f, nodedef, liquids_pointable))) {
 						continue;
 					}
 					std::vector<aabb3f> boxes;
-					n.getSelectionBoxes(nodedef, &boxes,
+					n.getSelectionBoxes(f, &boxes,
 						n.getNeighbors(np, m_map));
 
 					v3f npf = intToFloat(np, BS);

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -706,14 +706,29 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	// Sadly ISceneManager has no "post effects" render pass, in that case we
 	// could just register for that and handle it in renderMap().
 
-	MapNode n = getNodeNoEx(floatToInt(m_camera_position, BS));
-
 	// - If the player is in a solid node, make everything black.
 	// - If the player is in liquid, draw a semi-transparent overlay.
 	// - Do not if player is in third person mode
-	const ContentFeatures& features = m_nodedef->get(n);
-	video::SColor post_effect_color = features.post_effect_color;
-	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
+	v3s16 p = floatToInt(m_camera_position, BS);
+	bool is_valid_position;
+	HybridPtr<const ContentFeatures> f_ptr = getNodeDefNoEx(p, &is_valid_position);
+	if (!is_valid_position)
+		return;
+	const ContentFeatures &def = *f_ptr;
+
+	ContentFeatures f = def;
+
+	ITextureSource *tsrc = m_client->tsrc();
+    IShaderSource *shdsrc = m_client->getShaderSource();
+    scene::ISceneManager* smgr = m_client->getSceneManager();
+    scene::IMeshManipulator* meshmanip = smgr->getMeshManipulator();
+    TextureSettings tsettings;
+    tsettings.readSettings();
+
+	f.updateTextures(tsrc, shdsrc, meshmanip, m_client, tsettings);
+
+	video::SColor post_effect_color = f.post_effect_color;
+	if(f.solidness == 2 && !(g_settings->getBool("noclip") &&
 			m_client->checkLocalPrivilege("noclip")) &&
 			cam_mode == CAMERA_MODE_FIRST)
 	{

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -283,7 +283,8 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 			any_position_valid = true;
 			INodeDefManager *nodedef = gamedef->getNodeDefManager();
-			const ContentFeatures &f = nodedef->get(n);
+			HybridPtr<const ContentFeatures> f_ptr = map->getNodeDefNoEx(p);
+			const ContentFeatures &f = *f_ptr;
 			if(f.walkable == false)
 				continue;
 			int n_bouncy_value = itemgroup_get(f.groups, "bouncy");
@@ -316,7 +317,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				getNeighborConnectingFace(p2, nodedef, map, n, 32, &neighbors);
 			}
 			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
+			n.getCollisionBoxes(f, &nodeboxes, neighbors);
 			for(std::vector<aabb3f>::iterator
 					i = nodeboxes.begin();
 					i != nodeboxes.end(); ++i)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -932,16 +932,16 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	if (m_drowning_interval.step(dtime, 2.0)) {
 		// get head position
 		v3s16 p = floatToInt(m_base_position + v3f(0, BS * 1.6, 0), BS);
-		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
+		HybridPtr<const ContentFeatures> f_ptr = m_env->getMap().getNodeDefNoEx(p);
+		const ContentFeatures &f = *f_ptr;
 		// If node generates drown
-		if (c.drowning > 0 && m_hp > 0) {
+		if (f.drowning > 0 && m_hp > 0) {
 			if (m_breath > 0)
 				setBreath(m_breath - 1);
 
 			// No more breath, damage player
 			if (m_breath == 0) {
-				setHP(m_hp - c.drowning);
+				setHP(m_hp - f.drowning);
 				m_env->getGameDef()->SendPlayerHPOrDie(this);
 			}
 		}
@@ -950,34 +950,40 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 	if (m_breathing_interval.step(dtime, 0.5)) {
 		// get head position
 		v3s16 p = floatToInt(m_base_position + v3f(0, BS * 1.6, 0), BS);
-		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
+		HybridPtr<const ContentFeatures> f_ptr = m_env->getMap().getNodeDefNoEx(p);
+		const ContentFeatures &f = *f_ptr;
 		// If player is alive & no drowning, breath
-		if (m_hp > 0 && m_breath < PLAYER_MAX_BREATH && c.drowning == 0)
+		if (m_hp > 0 && m_breath < PLAYER_MAX_BREATH && f.drowning == 0)
 			setBreath(m_breath + 1);
 	}
 
 	if (m_node_hurt_interval.step(dtime, 1.0)) {
 		// Feet, middle and head
 		v3s16 p1 = floatToInt(m_base_position + v3f(0, BS*0.1, 0), BS);
-		MapNode n1 = m_env->getMap().getNodeNoEx(p1);
 		v3s16 p2 = floatToInt(m_base_position + v3f(0, BS*0.8, 0), BS);
-		MapNode n2 = m_env->getMap().getNodeNoEx(p2);
 		v3s16 p3 = floatToInt(m_base_position + v3f(0, BS*1.6, 0), BS);
-		MapNode n3 = m_env->getMap().getNodeNoEx(p3);
+		bool is_valid_position_1;
+		bool is_valid_position_2;
+		bool is_valid_position_3;
+		HybridPtr<const ContentFeatures> f_ptr1 = m_env->getMap().getNodeDefNoEx(p1, &is_valid_position_1);
+		HybridPtr<const ContentFeatures> f_ptr2 = m_env->getMap().getNodeDefNoEx(p2, &is_valid_position_2);
+		HybridPtr<const ContentFeatures> f_ptr3 = m_env->getMap().getNodeDefNoEx(p3, &is_valid_position_3);
 
-		u32 damage_per_second = 0;
-		damage_per_second = MYMAX(damage_per_second,
-			m_env->getGameDef()->ndef()->get(n1).damage_per_second);
-		damage_per_second = MYMAX(damage_per_second,
-			m_env->getGameDef()->ndef()->get(n2).damage_per_second);
-		damage_per_second = MYMAX(damage_per_second,
-			m_env->getGameDef()->ndef()->get(n3).damage_per_second);
+		if (is_valid_position_1 && is_valid_position_2 && is_valid_position_3) {
+			const ContentFeatures &f1 = *f_ptr1;
+			const ContentFeatures &f2 = *f_ptr2;
+			const ContentFeatures &f3 = *f_ptr3;
 
-		if (damage_per_second != 0 && m_hp > 0) {
-			s16 newhp = ((s32) damage_per_second > m_hp ? 0 : m_hp - damage_per_second);
-			setHP(newhp);
-			m_env->getGameDef()->SendPlayerHPOrDie(this);
+			u32 damage_per_second = 0;
+			damage_per_second = MYMAX(damage_per_second, f1.damage_per_second);
+			damage_per_second = MYMAX(damage_per_second, f2.damage_per_second);
+			damage_per_second = MYMAX(damage_per_second, f3.damage_per_second);
+
+			if (damage_per_second != 0 && m_hp > 0) {
+				s16 newhp = ((s32) damage_per_second > m_hp ? 0 : m_hp - damage_per_second);
+				setHP(newhp);
+				m_env->getGameDef()->SendPlayerHPOrDie(this);
+			}
 		}
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -794,14 +794,17 @@ bool nodePlacementPrediction(Client &client,
 		v3s16 p = neighbourpos;
 
 		// Place inside node itself if buildable_to
-		MapNode n_under = map.getNodeNoEx(nodepos, &is_valid_position);
+		HybridPtr<const ContentFeatures> f_ptr = map.getNodeDefNoEx(nodepos, &is_valid_position);
+		const ContentFeatures &f = *f_ptr;
 		if (is_valid_position)
 		{
-			if (nodedef->get(n_under).buildable_to)
+			if (f.buildable_to)
 				p = nodepos;
 			else {
 				node = map.getNodeNoEx(p, &is_valid_position);
-				if (is_valid_position &&!nodedef->get(node).buildable_to)
+				HybridPtr<const ContentFeatures> f_ptr2 = map.getNodeDefNoEx(p, &is_valid_position);
+				const ContentFeatures &f2 = *f_ptr2;
+				if (is_valid_position &&!f2.buildable_to)
 					return false;
 			}
 		}
@@ -3668,8 +3671,10 @@ PointedThing Game::updatePointedThing(
 	} else if (result.type == POINTEDTHING_NODE) {
 		// Update selection boxes
 		MapNode n = map.getNodeNoEx(result.node_undersurface);
+		HybridPtr<const ContentFeatures> f_ptr = map.getNodeDefNoEx(result.node_undersurface);
+		const ContentFeatures &f = *f_ptr;
 		std::vector<aabb3f> boxes;
-		n.getSelectionBoxes(nodedef, &boxes,
+		n.getSelectionBoxes(f, &boxes,
 			n.getNeighbors(result.node_undersurface, &map));
 
 		f32 d = 0.002 * BS;

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -270,13 +270,15 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	v3s16 pp2 = floatToInt(position + v3f(0,-0.2*BS,0), BS);
 	node = map->getNodeNoEx(pp, &is_valid_position);
 	bool is_valid_position2;
-	MapNode node2 = map->getNodeNoEx(pp2, &is_valid_position2);
+	HybridPtr<const ContentFeatures> f_ptr = map->getNodeDefNoEx(pp);
+	HybridPtr<const ContentFeatures> f_ptr2 = map->getNodeDefNoEx(pp2, &is_valid_position2);
 
 	if (!(is_valid_position && is_valid_position2)) {
 		is_climbing = false;
 	} else {
-		is_climbing = (nodemgr->get(node.getContent()).climbable
-				|| nodemgr->get(node2.getContent()).climbable) && !free_move;
+		const ContentFeatures &f = *f_ptr;
+		const ContentFeatures &f2 = *f_ptr2;
+		is_climbing = (f.climbable || f2.climbable) && !free_move;
 	}
 
 
@@ -445,8 +447,10 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		if (sneak_node_found) {
 			// Update saved top bounding box of sneak node
 			MapNode n = map->getNodeNoEx(m_sneak_node);
+			HybridPtr<const ContentFeatures> f_ptr = map->getNodeDefNoEx(m_sneak_node);
+			const ContentFeatures &f = *f_ptr;
 			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(nodemgr, &nodeboxes);
+			n.getCollisionBoxes(f, &nodeboxes);
 			m_sneak_node_bb_top = getTopBoundingBox(nodeboxes);
 
 			m_sneak_ladder_detected = physics_override_sneak_glitch &&
@@ -908,13 +912,16 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	v3s16 pp2 = floatToInt(position + v3f(0, -0.2 * BS, 0), BS);
 	node = map->getNodeNoEx(pp, &is_valid_position);
 	bool is_valid_position2;
-	MapNode node2 = map->getNodeNoEx(pp2, &is_valid_position2);
+	HybridPtr<const ContentFeatures> f_ptr = map->getNodeDefNoEx(pp);
+	HybridPtr<const ContentFeatures> f_ptr2 = map->getNodeDefNoEx(pp2, &is_valid_position2);
 
-	if (!(is_valid_position && is_valid_position2))
+	if (!(is_valid_position && is_valid_position2)) {
 		is_climbing = false;
-	else
-		is_climbing = (nodemgr->get(node.getContent()).climbable ||
-				nodemgr->get(node2.getContent()).climbable) && !free_move;
+	} else {
+    	const ContentFeatures &f = *f_ptr;
+    	const ContentFeatures &f2 = *f_ptr2;
+		is_climbing = (f.climbable || f2.climbable) && !free_move;
+	}
 
 	/*
 		Collision uncertainty radius
@@ -1049,8 +1056,10 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		if (sneak_node_found) {
 			f32 cb_max = 0;
 			MapNode n = map->getNodeNoEx(m_sneak_node);
+			HybridPtr<const ContentFeatures> f_ptr = map->getNodeDefNoEx(m_sneak_node);
+            const ContentFeatures &f = *f_ptr;
 			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(nodemgr, &nodeboxes);
+			n.getCollisionBoxes(f, &nodeboxes);
 			for (std::vector<aabb3f>::iterator it = nodeboxes.begin();
 					it != nodeboxes.end(); ++it) {
 				aabb3f box = *it;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -236,6 +236,67 @@ void Map::setNode(v3s16 p, MapNode & n)
 	block->setNodeNoCheck(relpos, n);
 }
 
+// Returns a NULL pointer if not found
+HybridPtr<const ContentFeatures> Map::getNodeDefNoEx(v3s16 p, bool *is_valid_position)
+{
+	v3s16 blockpos = getNodeBlockPos(p);
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if(block == NULL) {
+		if (is_valid_position != NULL)
+			*is_valid_position = false;
+		return NULL;
+	}
+	v3s16 relpos = p - blockpos*MAP_BLOCKSIZE;
+	bool is_valid_p;
+	HybridPtr<const ContentFeatures> f = block->getNodeDefNoCheck(relpos, &is_valid_p);
+	if (is_valid_position != NULL)
+		*is_valid_position = is_valid_p;
+	return f;
+}
+
+NodeWithDef Map::getNodeWithDefNoEx(v3s16 p, bool *is_valid_position)
+{
+	v3s16 blockpos = getNodeBlockPos(p);
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if(block == NULL) {
+		if (is_valid_position != NULL)
+			*is_valid_position = false;
+		return NodeWithDef(MapNode(CONTENT_IGNORE), m_gamedef->ndef());
+	}
+	v3s16 relpos = p - blockpos*MAP_BLOCKSIZE;
+	bool is_valid_p;
+	NodeWithDef node = block->getNodeWithDefNoCheck(relpos, &is_valid_p);
+	if (is_valid_position != NULL)
+		*is_valid_position = is_valid_p;
+	return node;
+}
+
+void Map::setNode(v3s16 p, const NodeWithDef &nd)
+{
+	v3s16 blockpos = getNodeBlockPos(p);
+	MapBlock *block = getBlockNoCreate(blockpos);
+	v3s16 relpos = p - blockpos*MAP_BLOCKSIZE;
+	// Never allow placing CONTENT_IGNORE, it fucks up stuff
+	if(nd.getContent() == CONTENT_IGNORE){
+		bool is_valid_position;
+		errorstream<<"Map::setNode(): Not allowing to place CONTENT_IGNORE"
+				<<" while trying to replace \""
+				<<m_gamedef->ndef()->get(block->getNodeNoCheck(relpos, &is_valid_position)).name
+				<<"\" at "<<PP(p)<<" (block "<<PP(blockpos)<<")"<<std::endl;
+		debug_stacks_print_to(infostream);
+		return;
+	}
+	block->setNodeNoCheck(relpos, nd);
+}
+
+void Map::setNodeDef(v3s16 p, const ContentFeatures *def)
+{
+	v3s16 blockpos = getNodeBlockPos(p);
+	MapBlock *block = getBlockNoCreate(blockpos);
+	v3s16 relpos = p - blockpos*MAP_BLOCKSIZE;
+	block->setNodeDefNoCheck(relpos, def);
+}
+
 void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 		std::map<v3s16, MapBlock*> &modified_blocks,
 		bool remove_metadata)

--- a/src/map.h
+++ b/src/map.h
@@ -34,6 +34,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/container.h"
 #include "nodetimer.h"
 #include "map_settings_manager.h"
+#include "nodedef.h" // For ContentFeatures
+#include "util/pointer.h" // HybridPtr
+#include "node_with_def.h"
 
 class Settings;
 class MapDatabase;
@@ -206,6 +209,16 @@ public:
 	// If is_valid_position is not NULL then this will be set to true if the
 	// position is valid, otherwise false
 	MapNode getNodeNoEx(v3s16 p, bool *is_valid_position = NULL);
+
+	// Same as getNodeNoEx, but returns NULL if node is not found
+    HybridPtr<const ContentFeatures> getNodeDefNoEx(v3s16 p, bool *is_valid_position = NULL);
+
+    // Same as getNodeNoEx
+    NodeWithDef getNodeWithDefNoEx(v3s16 p, bool *is_valid_position = NULL);
+
+    void setNode(v3s16 p, const NodeWithDef &nd);
+
+    void setNodeDef(v3s16 p, const ContentFeatures *def);
 
 	/*
 		These handle lighting but not faces.

--- a/src/map.h
+++ b/src/map.h
@@ -223,6 +223,9 @@ public:
 	/*
 		These handle lighting but not faces.
 	*/
+	void addNodeAndUpdate(v3s16 p, NodeWithDef nd,
+			std::map<v3s16, MapBlock*> &modified_blocks,
+			bool remove_metadata = true);
 	void addNodeAndUpdate(v3s16 p, MapNode n,
 			std::map<v3s16, MapBlock*> &modified_blocks,
 			bool remove_metadata = true);
@@ -234,6 +237,7 @@ public:
 		These emit events.
 		Return true if succeeded, false if not.
 	*/
+	bool addNodeWithEvent(v3s16 p, NodeWithDef nd, bool remove_metadata = true);
 	bool addNodeWithEvent(v3s16 p, MapNode n, bool remove_metadata = true);
 	bool removeNodeWithEvent(v3s16 p);
 

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "nameidmapping.h"
 #include "content_nodemeta.h" // For legacy deserialization
+#include "network/networkprotocol.h"
 #include "serialization.h"
 #ifndef SERVER
 #include "mapblock_mesh.h"
@@ -106,6 +107,72 @@ MapBlock::~MapBlock()
 
 	if(data)
 		delete[] data;
+}
+
+NodeWithDef MapBlock::getNodeWithDefNoEx(v3s16 p)
+{
+	if(!isValidPosition(p))
+		return NodeWithDef(MapNode(CONTENT_IGNORE), m_gamedef->ndef());
+	return getNodeWithDefNoCheck(p, NULL);
+}
+
+HybridPtr<const ContentFeatures> MapBlock::getNodeDefNoCheck(v3s16 p, bool *valid_position)
+{
+	*valid_position = isValidPosition(p);
+	if(!valid_position) {
+		return NULL;
+	}
+	// If special definition exists, return a shared pointer to a copy of it
+	if(m_special_nodedefs.count(p))
+		return new ContentFeatures(m_special_nodedefs[p]);
+	// Otherwise look up from node definition manager
+	MapNode n = getNodeNoCheck(p, valid_position);
+	const ContentFeatures &c = m_gamedef->ndef()->get(n);
+	// Return a reference that won't be deleted
+	HybridPtr<const ContentFeatures> ptr(&c);
+	ptr.setNeverDelete(true);
+	return ptr;
+}
+
+NodeWithDef MapBlock::getNodeWithDefNoCheck(v3s16 p, bool *valid_position)
+{
+	return NodeWithDef(getNodeNoCheck(p, valid_position), getNodeDefNoCheck(p, valid_position));
+}
+
+void MapBlock::setNodeNoCheck(v3s16 p, const NodeWithDef &nd)
+{
+	setNodeNoCheck(p, nd.node());
+	// If nd's definition is global, it should not have __nodedef
+	if(nd.def_is_global())
+		setNodeDefNoCheck(p, NULL);
+	// If nd's definition is local, it should have __nodedef
+	else
+		setNodeDefNoCheck(p, nd.def());
+}
+
+// def=NULL resets to global definition
+void MapBlock::setNodeDefNoCheck(v3s16 p, const ContentFeatures *def)
+{
+	if(def == NULL){
+		NodeMetadata *meta = m_node_metadata.get(p);
+		if(meta != NULL && meta->getString("__nodedef") != "")
+			meta->setString("__nodedef", "");
+		m_special_nodedefs.erase(p);
+	}
+	else{
+		std::ostringstream os(std::ios::binary);
+		def->serialize(os, LATEST_PROTOCOL_VERSION);
+		const std::string &str = os.str();
+
+		NodeMetadata *meta = m_node_metadata.get(p);
+		if(meta == NULL){
+			meta = new NodeMetadata(m_gamedef->idef());
+			m_node_metadata.set(p, meta);
+		}
+		if(str != meta->getString("__nodedef"))
+			meta->setString("__nodedef", str);
+		m_special_nodedefs[p] = *def;
+	}
 }
 
 bool MapBlock::isValidPositionParent(v3s16 p)
@@ -709,6 +776,32 @@ void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)
 				<<" while deserializing node metadata at ("
 				<<PP(getPos())<<": "<<e.what()<<std::endl;
 	}
+
+	/* Read special node definitions from metadata */
+    TRACESTREAM(<<"MapBlock::deSerialize "<<PP(getPos())
+    		<<": Special node definitions"<<std::endl);
+    m_special_nodedefs.clear();
+    std::map<v3s16, NodeMetadata*> *metamap = m_node_metadata.getAll();
+    for (std::map<v3s16, NodeMetadata*>::iterator i = metamap->begin();
+    		i != metamap->end(); i++)
+    {
+    	const v3s16 &p = i->first;
+    	try{
+    		NodeMetadata *m = i->second;
+    		std::string def_s = m->getString("__nodedef");
+    		if (def_s.empty())
+    			continue;
+    		std::istringstream is(def_s, std::ios::binary);
+    		ContentFeatures def;
+    		def.deSerialize(is);
+    		m_special_nodedefs[p] = def;
+    	}
+    	catch(SerializationError &e){
+    		errorstream<<"WARNING: MapBlock::deSerialize(): Ignoring an error"
+    				<<" while deserializing nodedef from metadata at ("
+    				<<PP(getPos())<<": "<<e.what()<<std::endl;
+    	}
+    }
 
 	/*
 		Data that is only on disk

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -33,6 +33,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h" // getContainerPos
 #include "settings.h"
 #include "mapgen.h"
+#include "nodedef.h" // For ContentFeatures for getNodeDef*()
+#include "util/pointer.h" // HybridPtr
+#include "node_with_def.h"
 
 class Map;
 class NodeMetadataList;
@@ -344,6 +347,15 @@ public:
 		setNode(p.X, p.Y, p.Z, n);
 	}
 
+	NodeWithDef getNodeWithDefNoEx(v3s16 p);
+
+	void setNode(v3s16 p, const NodeWithDef &nd)
+    {
+    	if (!isValidPosition(p))
+    		throw InvalidPositionException();
+    	setNodeNoCheck(p, nd);
+    }
+
 	////
 	//// Non-checking variants of the above
 	////
@@ -378,7 +390,7 @@ public:
 		return getNodeUnsafe(p.X, p.Y, p.Z);
 	}
 
-	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode & n)
+	inline void setNodeNoCheck(s16 x, s16 y, s16 z, const MapNode & n)
 	{
 		if (data == NULL)
 			throw InvalidPositionException();
@@ -387,10 +399,16 @@ public:
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE_NO_CHECK);
 	}
 
-	inline void setNodeNoCheck(v3s16 p, MapNode & n)
+	inline void setNodeNoCheck(v3s16 p, const MapNode & n)
 	{
 		setNodeNoCheck(p.X, p.Y, p.Z, n);
 	}
+
+	HybridPtr<const ContentFeatures> getNodeDefNoCheck(v3s16 p, bool *valid_position);
+    NodeWithDef getNodeWithDefNoCheck(v3s16 p, bool *valid_position);
+	void setNodeNoCheck(v3s16 p, const NodeWithDef &nd);
+	// def=NULL resets to global definition
+	void setNodeDefNoCheck(v3s16 p, const ContentFeatures *def);
 
 	// These functions consult the parent container if the position
 	// is not valid on this MapBlock.
@@ -585,6 +603,8 @@ public:
 	NodeMetadataList m_node_metadata;
 	NodeTimerList m_node_timers;
 	StaticObjectList m_static_objects;
+
+	std::map<v3s16, ContentFeatures> m_special_nodedefs;
 
 	static const u32 ystride = MAP_BLOCKSIZE;
 	static const u32 zstride = MAP_BLOCKSIZE * MAP_BLOCKSIZE;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -84,12 +84,12 @@ void MapNode::setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f
 
 void MapNode::setLight(enum LightBank bank, u8 a_light, INodeDefManager *nodemgr)
 {
-	setLight(bank, a_light, nodemgr->get(*this));
+	const ContentFeatures &f = nodemgr->get(*this);
+	setLight(bank, a_light, f);
 }
 
-bool MapNode::isLightDayNightEq(INodeDefManager *nodemgr) const
+bool MapNode::isLightDayNightEq(const ContentFeatures &f) const
 {
-	const ContentFeatures &f = nodemgr->get(*this);
 	bool isEqual;
 
 	if (f.param_type == CPT_LIGHT) {
@@ -103,11 +103,15 @@ bool MapNode::isLightDayNightEq(INodeDefManager *nodemgr) const
 	return isEqual;
 }
 
-u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
+bool MapNode::isLightDayNightEq(INodeDefManager *nodemgr) const
+{
+	const ContentFeatures &f = nodemgr->get(*this);
+	return isLightDayNightEq(f);
+}
+
+u8 MapNode::getLight(enum LightBank bank, const ContentFeatures &f) const
 {
 	// Select the brightest of [light source, propagated light]
-	const ContentFeatures &f = nodemgr->get(*this);
-
 	u8 light;
 	if(f.param_type == CPT_LIGHT)
 		light = bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f;
@@ -115,6 +119,12 @@ u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
 		light = 0;
 
 	return MYMAX(f.light_source, light);
+}
+
+u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
+{
+	const ContentFeatures &f = nodemgr->get(*this);
+	return getLight(bank, f);
 }
 
 u8 MapNode::getLightRaw(enum LightBank bank, const ContentFeatures &f) const
@@ -130,10 +140,9 @@ u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f) cons
 	             bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f);
 }
 
-bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const
+bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, const ContentFeatures &f) const
 {
 	// Select the brightest of [light source, propagated light]
-	const ContentFeatures &f = nodemgr->get(*this);
 	if(f.param_type == CPT_LIGHT)
 	{
 		lightday = param1 & 0x0f;
@@ -151,27 +160,43 @@ bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodem
 	return f.param_type == CPT_LIGHT || f.light_source != 0;
 }
 
-u8 MapNode::getFaceDir(INodeDefManager *nodemgr) const
+bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
+	return getLightBanks(lightday, lightnight, f);
+}
+
+u8 MapNode::getFaceDir(const ContentFeatures &f) const
+{
 	if (f.param_type_2 == CPT2_FACEDIR ||
 			f.param_type_2 == CPT2_COLORED_FACEDIR)
 		return (getParam2() & 0x1F) % 24;
 	return 0;
 }
 
-u8 MapNode::getWallMounted(INodeDefManager *nodemgr) const
+u8 MapNode::getFaceDir(INodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
+	return getFaceDir(f);
+}
+
+u8 MapNode::getWallMounted(const ContentFeatures &f) const
+{
 	if (f.param_type_2 == CPT2_WALLMOUNTED ||
 			f.param_type_2 == CPT2_COLORED_WALLMOUNTED)
 		return getParam2() & 0x07;
 	return 0;
 }
 
-v3s16 MapNode::getWallMountedDir(INodeDefManager *nodemgr) const
+u8 MapNode::getWallMounted(INodeDefManager *nodemgr) const
 {
-	switch(getWallMounted(nodemgr))
+	const ContentFeatures &f = nodemgr->get(*this);
+	return getWallMounted(f);
+}
+
+v3s16 MapNode::getWallMountedDir(const ContentFeatures &f) const
+{
+	switch(getWallMounted(f))
 	{
 	case 0: default: return v3s16(0,1,0);
 	case 1: return v3s16(0,-1,0);
@@ -182,8 +207,7 @@ v3s16 MapNode::getWallMountedDir(INodeDefManager *nodemgr) const
 	}
 }
 
-void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
-{
+void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot) {
 	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
 
 	if (cpt2 == CPT2_FACEDIR || cpt2 == CPT2_COLORED_FACEDIR) {
@@ -239,13 +263,13 @@ void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
 }
 
 void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
-		INodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes, u8 neighbors = 0)
+		const ContentFeatures &f, std::vector<aabb3f> *p_boxes, u8 neighbors = 0)
 {
 	std::vector<aabb3f> &boxes = *p_boxes;
 
 	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
 		const std::vector<aabb3f> &fixed = nodebox.fixed;
-		int facedir = n.getFaceDir(nodemgr);
+		int facedir = n.getFaceDir(f);
 		u8 axisdir = facedir>>2;
 		facedir&=0x03;
 		for(std::vector<aabb3f>::const_iterator
@@ -255,7 +279,7 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 			aabb3f box = *i;
 
 			if (nodebox.type == NODEBOX_LEVELED) {
-				box.MaxEdge.Y = -BS/2 + BS*((float)1/LEVELED_MAX) * n.getLevel(nodemgr);
+				box.MaxEdge.Y = -BS/2 + BS*((float)1/LEVELED_MAX) * n.getLevel(f);
 			}
 
 			switch (axisdir)
@@ -381,7 +405,7 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	}
 	else if(nodebox.type == NODEBOX_WALLMOUNTED)
 	{
-		v3s16 dir = n.getWallMountedDir(nodemgr);
+		v3s16 dir = n.getWallMountedDir(f);
 
 		// top
 		if(dir == v3s16(0,1,0))
@@ -510,30 +534,44 @@ u8 MapNode::getNeighbors(v3s16 p, Map *map)
 	return neighbors;
 }
 
+void MapNode::getNodeBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	transformNodeBox(*this, f.node_box, f, boxes, neighbors);
+}
+
 void MapNode::getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	transformNodeBox(*this, f.node_box, nodemgr, boxes, neighbors);
+	getNodeBoxes(f, boxes, neighbors);
+}
+
+void MapNode::getCollisionBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	if (f.collision_box.fixed.empty())
+		transformNodeBox(*this, f.node_box, f, boxes, neighbors);
+	else
+		transformNodeBox(*this, f.collision_box, f, boxes, neighbors);
 }
 
 void MapNode::getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	if (f.collision_box.fixed.empty())
-		transformNodeBox(*this, f.node_box, nodemgr, boxes, neighbors);
-	else
-		transformNodeBox(*this, f.collision_box, nodemgr, boxes, neighbors);
+	getCollisionBoxes(f, boxes, neighbors);
+}
+
+void MapNode::getSelectionBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	transformNodeBox(*this, f.selection_box, f, boxes, neighbors);
 }
 
 void MapNode::getSelectionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
-	transformNodeBox(*this, f.selection_box, nodemgr, boxes, neighbors);
+	getSelectionBoxes(f, boxes, neighbors);
 }
 
-u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const
+u8 MapNode::getMaxLevel(const ContentFeatures &f) const
 {
-	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
 	if( f.liquid_type == LIQUID_FLOWING || f.param_type_2 == CPT2_FLOWINGLIQUID)
 		return LIQUID_LEVEL_MAX;
@@ -542,9 +580,14 @@ u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const
 	return 0;
 }
 
-u8 MapNode::getLevel(INodeDefManager *nodemgr) const
+u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
+	return getMaxLevel(f);
+}
+
+u8 MapNode::getLevel(const ContentFeatures &f) const
+{
 	// todo: after update in all games leave only if (f.param_type_2 ==
 	if(f.liquid_type == LIQUID_SOURCE)
 		return LIQUID_LEVEL_SOURCE;
@@ -561,6 +604,12 @@ u8 MapNode::getLevel(INodeDefManager *nodemgr) const
 		 return f.leveled; //default
 	}
 	return 0;
+}
+
+u8 MapNode::getLevel(INodeDefManager *nodemgr) const
+{
+	const ContentFeatures &f = nodemgr->get(*this);
+	return getLevel(f);
 }
 
 u8 MapNode::setLevel(INodeDefManager *nodemgr, s8 level)

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -141,6 +141,11 @@ struct MapNode
 	MapNode()
 	{ }
 
+	MapNode(const MapNode & n)
+	{
+		*this = n;
+	}
+
 	MapNode(content_t content, u8 a_param1=0, u8 a_param2=0)
 		: param0(content),
 		  param1(a_param1),
@@ -202,7 +207,11 @@ struct MapNode
 	 *
 	 * @return If the light values are equal, returns true; otherwise false
 	 */
+	bool isLightDayNightEq(const ContentFeatures &f) const;
+
 	bool isLightDayNightEq(INodeDefManager *nodemgr) const;
+
+	u8 getLight(enum LightBank bank, const ContentFeatures &f) const;
 
 	u8 getLight(enum LightBank bank, INodeDefManager *nodemgr) const;
 
@@ -230,10 +239,20 @@ struct MapNode
 	 */
 	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f) const;
 
+	bool getLightBanks(u8 &lightday, u8 &lightnight, const ContentFeatures &f) const;
+
 	bool getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const;
 
 	// 0 <= daylight_factor <= 1000
 	// 0 <= return value <= LIGHT_SUN
+	u8 getLightBlend(u32 daylight_factor, const ContentFeatures &f) const
+	{
+		u8 lightday = 0;
+		u8 lightnight = 0;
+		getLightBanks(lightday, lightnight, f);
+		return blend_light(daylight_factor, lightday, lightnight);
+	}
+
 	u8 getLightBlend(u32 daylight_factor, INodeDefManager *nodemgr) const
 	{
 		u8 lightday = 0;
@@ -242,8 +261,11 @@ struct MapNode
 		return blend_light(daylight_factor, lightday, lightnight);
 	}
 
+	u8 getFaceDir(const ContentFeatures &f) const;
 	u8 getFaceDir(INodeDefManager *nodemgr) const;
+	u8 getWallMounted(const ContentFeatures &f) const;
 	u8 getWallMounted(INodeDefManager *nodemgr) const;
+	v3s16 getWallMountedDir(const ContentFeatures &f) const;
 	v3s16 getWallMountedDir(INodeDefManager *nodemgr) const;
 
 	void rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot);
@@ -258,24 +280,34 @@ struct MapNode
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))
 	*/
+	void getNodeBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+
 	void getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Gets list of selection boxes
 	*/
+	void getSelectionBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+
 	void getSelectionBoxes(INodeDefManager *nodemg, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Gets list of collision boxes
 	*/
+	void getCollisionBoxes(const ContentFeatures &f, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+
 	void getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Liquid helpers
 	*/
+	u8 getMaxLevel(const ContentFeatures &f) const;
 	u8 getMaxLevel(INodeDefManager *nodemgr) const;
+	u8 getLevel(const ContentFeatures &f) const;
 	u8 getLevel(INodeDefManager *nodemgr) const;
+	u8 setLevel(const ContentFeatures &f, s8 level = 1);
 	u8 setLevel(INodeDefManager *nodemgr, s8 level = 1);
+	u8 addLevel(const ContentFeatures &f, s8 add = 1);
 	u8 addLevel(INodeDefManager *nodemgr, s8 add = 1);
 
 	/*

--- a/src/node_with_def.cpp
+++ b/src/node_with_def.cpp
@@ -1,0 +1,97 @@
+/*
+Minetest
+Copyright (C) 2017 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "node_with_def.h"
+
+#include "nodedef.h"
+
+NodeWithDef::NodeWithDef()
+{
+}
+NodeWithDef::NodeWithDef(const MapNode &n, const INodeDefManager *ndef)
+	: MapNode(n), m_def(NULL)
+{
+	m_def = &ndef->get(n);
+	m_def.setNeverDelete(true);
+}
+NodeWithDef::NodeWithDef(const MapNode &n, const HybridPtr<const ContentFeatures> &def)
+	: MapNode(n), m_def(def)
+{
+}
+
+void NodeWithDef::setLight(enum LightBank bank, u8 a_light)
+{
+	const ContentFeatures &f = *m_def;
+	MapNode::setLight(bank, a_light, f);
+}
+
+u8 NodeWithDef::getLight(enum LightBank bank) const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getLight(bank, f);
+}
+
+bool NodeWithDef::getLightBanks(u8 &lightday, u8 &lightnight) const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getLightBanks(lightday, lightnight, f);
+}
+
+u8 NodeWithDef::getLightBlend(u32 daylight_factor) const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getLightBlend(daylight_factor, f);
+}
+
+u8 NodeWithDef::getFaceDir() const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getFaceDir(f);
+}
+
+u8 NodeWithDef::getWallMounted() const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getWallMounted(f);
+}
+
+v3s16 NodeWithDef::getWallMountedDir() const
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getWallMountedDir(f);
+}
+
+void NodeWithDef::getNodeBoxes(std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getNodeBoxes(f, boxes, neighbors);
+}
+
+void NodeWithDef::getCollisionBoxes(std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getCollisionBoxes(f, boxes, neighbors);
+}
+
+void NodeWithDef::getSelectionBoxes(std::vector<aabb3f> *boxes, u8 neighbors)
+{
+	const ContentFeatures &f = *m_def;
+	return MapNode::getSelectionBoxes(f, boxes, neighbors);
+}
+

--- a/src/node_with_def.h
+++ b/src/node_with_def.h
@@ -1,0 +1,74 @@
+/*
+Minetest
+Copyright (C) 2017 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef NODE_WITH_DEF_HEADER
+#define NODE_WITH_DEF_HEADER
+
+#include "mapnode.h"
+#include "util/pointer.h"
+
+struct ContentFeatures;
+class INodeDefManager;
+
+class NodeWithDef : public MapNode
+{
+	MapNode m_n;
+	HybridPtr<const ContentFeatures> m_def;
+
+public:
+	NodeWithDef();
+	NodeWithDef(const MapNode &n, const INodeDefManager *ndef);
+	NodeWithDef(const MapNode &n, const HybridPtr<const ContentFeatures> &def);
+
+	const MapNode & node() const { return *this; }
+	const ContentFeatures * def() const { return m_def.get(); }
+	bool def_is_global() const { return m_def.getNeverDelete();	}
+
+	void setNode(const MapNode &n)
+	{
+		param0 = n.param0;
+		param1 = n.param1;
+		param2 = n.param2;
+	}
+
+	void setLight(enum LightBank bank, u8 a_light);
+	u8 getLight(enum LightBank bank) const;
+	bool getLightBanks(u8 &lightday, u8 &lightnight) const;
+
+	// 0 <= daylight_factor <= 1000
+	// 0 <= return value <= LIGHT_SUN
+	u8 getLightBlend(u32 daylight_factor) const;
+
+	u8 getFaceDir() const;
+	u8 getWallMounted() const;
+	v3s16 getWallMountedDir() const;
+
+	// Get list of node boxes
+	void getNodeBoxes(std::vector<aabb3f> *boxes, u8 neighbors);
+
+	// Get list of collision boxes
+	void getCollisionBoxes(std::vector<aabb3f> *boxes, u8 neighbors);
+
+	// Get list of selection boxes
+	void getSelectionBoxes(std::vector<aabb3f> *boxes, u8 neighbors);
+};
+
+
+
+#endif

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -215,6 +215,11 @@ NodeMetadata *NodeMetadataList::get(v3s16 p)
 	return n->second;
 }
 
+std::map<v3s16, NodeMetadata*>* NodeMetadataList::getAll()
+{
+	return &m_data;
+}
+
 void NodeMetadataList::remove(v3s16 p)
 {
 	NodeMetadata *olddata = get(p);

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -83,6 +83,8 @@ public:
 	std::vector<v3s16> getAllKeys();
 	// Get pointer to data
 	NodeMetadata *get(v3s16 p);
+	// Get pointer to all data
+	std::map<v3s16, NodeMetadata*>* getAll();
 	// Deletes data
 	void remove(v3s16 p);
 	// Deletes old data and sets a new one

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -409,12 +409,12 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 }
 
 /******************************************************************************/
-ContentFeatures read_content_features(lua_State *L, int index)
+ContentFeatures read_content_features(lua_State *L, int index, ContentFeatures f_base)
 {
 	if(index < 0)
 		index = lua_gettop(L) + 1 + index;
 
-	ContentFeatures f;
+	ContentFeatures f = f_base;
 
 	/* Cache existence of some callbacks */
 	lua_getfield(L, index, "on_construct");
@@ -442,7 +442,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	/* Visual definition */
 
 	f.drawtype = (NodeDrawType)getenumfield(L, index, "drawtype",
-			ScriptApiNode::es_DrawType,NDT_NORMAL);
+			ScriptApiNode::es_DrawType, f.drawtype);
 	getfloatfield(L, index, "visual_scale", f.visual_scale);
 
 	/* Meshnode model filename */
@@ -538,10 +538,14 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	}
 	lua_pop(L, 1);
 
-	f.alpha = getintfield_default(L, index, "alpha", 255);
+	bool usealpha_default = false;
+	if (f.alpha == 0)
+		usealpha_default = true;
+
+	f.alpha = getintfield_default(L, index, "alpha", f.alpha);
 
 	bool usealpha = getboolfield_default(L, index,
-			"use_texture_alpha", false);
+			"use_texture_alpha", usealpha_default);
 	if (usealpha)
 		f.alpha = 0;
 
@@ -559,9 +563,9 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	lua_pop(L, 1);
 
 	f.param_type = (ContentParamType)getenumfield(L, index, "paramtype",
-			ScriptApiNode::es_ContentParamType, CPT_NONE);
+			ScriptApiNode::es_ContentParamType, f.param_type);
 	f.param_type_2 = (ContentParamType2)getenumfield(L, index, "paramtype2",
-			ScriptApiNode::es_ContentParamType2, CPT2_NONE);
+			ScriptApiNode::es_ContentParamType2, f.param_type_2);
 
 	if (f.palette_name != "" &&
 			!(f.param_type_2 == CPT2_COLOR ||
@@ -603,7 +607,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	getboolfield(L, index, "floodable", f.floodable);
 	// Whether the node is non-liquid, source liquid or flowing liquid
 	f.liquid_type = (LiquidType)getenumfield(L, index, "liquidtype",
-			ScriptApiNode::es_LiquidType, LIQUID_NONE);
+			ScriptApiNode::es_LiquidType, f.liquid_type);
 	// If the content is liquid, this is the flowing version of the liquid.
 	getstringfield(L, index, "liquid_alternative_flowing",
 			f.liquid_alternative_flowing);
@@ -715,127 +719,162 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	return f;
 }
 
-void push_content_features(lua_State *L, const ContentFeatures &c)
+void push_tiledef(lua_State *L, const TileDef &tiledef)
 {
-	std::string paramtype(ScriptApiNode::es_ContentParamType[(int)c.param_type].str);
-	std::string paramtype2(ScriptApiNode::es_ContentParamType2[(int)c.param_type_2].str);
-	std::string drawtype(ScriptApiNode::es_DrawType[(int)c.drawtype].str);
-	std::string liquid_type(ScriptApiNode::es_LiquidType[(int)c.liquid_type].str);
+	lua_createtable(L, 0, 3);
 
-	/* Missing "tiles" because I don't see a usecase (at least not yet). */
-
-	lua_newtable(L);
-	lua_pushboolean(L, c.has_on_construct);
-	lua_setfield(L, -2, "has_on_construct");
-	lua_pushboolean(L, c.has_on_destruct);
-	lua_setfield(L, -2, "has_on_destruct");
-	lua_pushboolean(L, c.has_after_destruct);
-	lua_setfield(L, -2, "has_after_destruct");
-	lua_pushstring(L, c.name.c_str());
+	lua_pushstring(L, tiledef.name.c_str());
 	lua_setfield(L, -2, "name");
-	push_groups(L, c.groups);
+	setboolfield(L, -1, "backface_culling", tiledef.backface_culling);
+
+	lua_createtable(L, 0, 3);
+
+	std::string type(es_TileAnimationType[(int)tiledef.animation.type].str);
+    setenumfield(L, -1, "type", es_TileAnimationType, tiledef.animation.type);
+
+	lua_createtable(L, 0, 3);
+	setintfield(L, -1, "aspect_w", tiledef.animation.vertical_frames.aspect_w);
+	setintfield(L, -1, "aspect_h", tiledef.animation.vertical_frames.aspect_h);
+	setfloatfield(L, -1, "length", tiledef.animation.vertical_frames.length);
+	lua_setfield(L, -2, "vertical_frames");
+
+	lua_createtable(L, 0, 3);
+	setintfield(L, -1, "frames_w", tiledef.animation.sheet_2d.frames_w);
+	setintfield(L, -1, "frames_h", tiledef.animation.sheet_2d.frames_h);
+	setfloatfield(L, -1, "frame_length", tiledef.animation.sheet_2d.frame_length);
+	lua_setfield(L, -2, "sheet_2d");
+
+	lua_setfield(L, -2, "animation");
+}
+
+void push_content_features(lua_State *L, const ContentFeatures &f)
+{
+	lua_newtable(L);
+	lua_pushboolean(L, f.has_on_construct);
+	lua_setfield(L, -2, "has_on_construct");
+	lua_pushboolean(L, f.has_on_destruct);
+	lua_setfield(L, -2, "has_on_destruct");
+	lua_pushboolean(L, f.has_after_destruct);
+	lua_setfield(L, -2, "has_after_destruct");
+	lua_pushstring(L, f.name.c_str());
+	lua_setfield(L, -2, "name");
+	push_groups(L, f.groups);
 	lua_setfield(L, -2, "groups");
-	lua_pushstring(L, paramtype.c_str());
-	lua_setfield(L, -2, "paramtype");
-	lua_pushstring(L, paramtype2.c_str());
-	lua_setfield(L, -2, "paramtype2");
-	lua_pushstring(L, drawtype.c_str());
-	lua_setfield(L, -2, "drawtype");
-	if (!c.mesh.empty()) {
-		lua_pushstring(L, c.mesh.c_str());
+	setenumfield(L, -1, "paramtype", ScriptApiNode::es_ContentParamType, f.param_type);
+	setenumfield(L, -1, "paramtype2", ScriptApiNode::es_ContentParamType2, f.param_type_2);
+	setenumfield(L, -1, "drawtype", ScriptApiNode::es_DrawType, f.drawtype);
+	if (!f.mesh.empty()) {
+		lua_pushstring(L, f.mesh.c_str());
 		lua_setfield(L, -2, "mesh");
 	}
 #ifndef SERVER
-	push_ARGB8(L, c.minimap_color);       // I know this is not set-able w/ register_node,
+	push_ARGB8(L, f.minimap_color);       // I know this is not set-able w/ register_node,
 	lua_setfield(L, -2, "minimap_color"); // but the people need to know!
 #endif
-	lua_pushnumber(L, c.visual_scale);
+	lua_pushnumber(L, f.visual_scale);
 	lua_setfield(L, -2, "visual_scale");
-	lua_pushnumber(L, c.alpha);
+	lua_pushnumber(L, f.alpha);
 	lua_setfield(L, -2, "alpha");
-	if (!c.palette_name.empty()) {
-		push_ARGB8(L, c.color);
+	lua_createtable(L, 6, 0);
+    for (int i=0; i<6; i++){
+    	lua_pushinteger(L, i+1);
+    	push_tiledef(L, f.tiledef[i]);
+    	lua_settable(L, -3);
+    }
+    lua_setfield(L, -2, "tiles");
+
+    lua_createtable(L, CF_SPECIAL_COUNT, 0);
+    for (int i=0; i<CF_SPECIAL_COUNT; i++){
+    	lua_pushinteger(L, i+1);
+    	push_tiledef(L, f.tiledef[i]);
+    	lua_settable(L, -3);
+    }
+    lua_setfield(L, -2, "special_tiles");
+
+	if (!f.palette_name.empty()) {
+		push_ARGB8(L, f.color);
 		lua_setfield(L, -2, "color");
 
-		lua_pushstring(L, c.palette_name.c_str());
+		lua_pushstring(L, f.palette_name.c_str());
 		lua_setfield(L, -2, "palette_name");
 
-		push_palette(L, c.palette);
+		push_palette(L, f.palette);
 		lua_setfield(L, -2, "palette");
 	}
-	lua_pushnumber(L, c.waving);
+	lua_pushnumber(L, f.waving);
 	lua_setfield(L, -2, "waving");
-	lua_pushnumber(L, c.connect_sides);
+	lua_pushnumber(L, f.connect_sides);
 	lua_setfield(L, -2, "connect_sides");
 
 	lua_newtable(L);
 	u16 i = 1;
-	for (std::vector<std::string>::const_iterator it = c.connects_to.begin();
-			it != c.connects_to.end(); ++it) {
+	for (std::vector<std::string>::const_iterator it = f.connects_to.begin();
+			it != f.connects_to.end(); ++it) {
 		lua_pushlstring(L, it->c_str(), it->size());
 		lua_rawseti(L, -2, i);
 	}
 	lua_setfield(L, -2, "connects_to");
 
-	push_ARGB8(L, c.post_effect_color);
+	push_ARGB8(L, f.post_effect_color);
 	lua_setfield(L, -2, "post_effect_color");
-	lua_pushnumber(L, c.leveled);
+	lua_pushnumber(L, f.leveled);
 	lua_setfield(L, -2, "leveled");
-	lua_pushboolean(L, c.sunlight_propagates);
+	lua_pushboolean(L, f.sunlight_propagates);
 	lua_setfield(L, -2, "sunlight_propagates");
-	lua_pushnumber(L, c.light_source);
+	lua_pushnumber(L, f.light_source);
 	lua_setfield(L, -2, "light_source");
-	lua_pushboolean(L, c.is_ground_content);
+	lua_pushboolean(L, f.is_ground_content);
 	lua_setfield(L, -2, "is_ground_content");
-	lua_pushboolean(L, c.walkable);
+	lua_pushboolean(L, f.walkable);
 	lua_setfield(L, -2, "walkable");
-	lua_pushboolean(L, c.pointable);
+	lua_pushboolean(L, f.pointable);
 	lua_setfield(L, -2, "pointable");
-	lua_pushboolean(L, c.diggable);
+	lua_pushboolean(L, f.diggable);
 	lua_setfield(L, -2, "diggable");
-	lua_pushboolean(L, c.climbable);
+	lua_pushboolean(L, f.climbable);
 	lua_setfield(L, -2, "climbable");
-	lua_pushboolean(L, c.buildable_to);
+	lua_pushboolean(L, f.buildable_to);
 	lua_setfield(L, -2, "buildable_to");
-	lua_pushboolean(L, c.rightclickable);
+	lua_pushboolean(L, f.rightclickable);
 	lua_setfield(L, -2, "rightclickable");
-	lua_pushnumber(L, c.damage_per_second);
+	lua_pushnumber(L, f.damage_per_second);
 	lua_setfield(L, -2, "damage_per_second");
-	if (c.isLiquid()) {
-		lua_pushstring(L, liquid_type.c_str());
-		lua_setfield(L, -2, "liquid_type");
-		lua_pushstring(L, c.liquid_alternative_flowing.c_str());
+	push_groups(L, f.groups);
+	lua_setfield(L, -2, "groups");
+	if (f.isLiquid()) {
+		setenumfield(L, -1, "liquid_type", ScriptApiNode::es_LiquidType, f.liquid_type);
+		lua_pushstring(L, f.liquid_alternative_flowing.c_str());
 		lua_setfield(L, -2, "liquid_alternative_flowing");
-		lua_pushstring(L, c.liquid_alternative_source.c_str());
+		lua_pushstring(L, f.liquid_alternative_source.c_str());
 		lua_setfield(L, -2, "liquid_alternative_source");
-		lua_pushnumber(L, c.liquid_viscosity);
+		lua_pushnumber(L, f.liquid_viscosity);
 		lua_setfield(L, -2, "liquid_viscosity");
-		lua_pushboolean(L, c.liquid_renewable);
+		lua_pushboolean(L, f.liquid_renewable);
 		lua_setfield(L, -2, "liquid_renewable");
-		lua_pushnumber(L, c.liquid_range);
+		lua_pushnumber(L, f.liquid_range);
 		lua_setfield(L, -2, "liquid_range");
 	}
-	lua_pushnumber(L, c.drowning);
+	lua_pushnumber(L, f.drowning);
 	lua_setfield(L, -2, "drowning");
-	lua_pushboolean(L, c.floodable);
+	lua_pushboolean(L, f.floodable);
 	lua_setfield(L, -2, "floodable");
-	push_nodebox(L, c.node_box);
+	push_nodebox(L, f.node_box);
 	lua_setfield(L, -2, "node_box");
-	push_nodebox(L, c.selection_box);
+	push_nodebox(L, f.selection_box);
 	lua_setfield(L, -2, "selection_box");
-	push_nodebox(L, c.collision_box);
+	push_nodebox(L, f.collision_box);
 	lua_setfield(L, -2, "collision_box");
 	lua_newtable(L);
-	push_soundspec(L, c.sound_footstep);
+	push_soundspec(L, f.sound_footstep);
 	lua_setfield(L, -2, "sound_footstep");
-	push_soundspec(L, c.sound_dig);
+	push_soundspec(L, f.sound_dig);
 	lua_setfield(L, -2, "sound_dig");
-	push_soundspec(L, c.sound_dug);
+	push_soundspec(L, f.sound_dug);
 	lua_setfield(L, -2, "sound_dug");
 	lua_setfield(L, -2, "sounds");
-	lua_pushboolean(L, c.legacy_facedir_simple);
+	lua_pushboolean(L, f.legacy_facedir_simple);
 	lua_setfield(L, -2, "legacy_facedir_simple");
-	lua_pushboolean(L, c.legacy_wallmounted);
+	lua_pushboolean(L, f.legacy_wallmounted);
 	lua_setfield(L, -2, "legacy_wallmounted");
 }
 
@@ -896,6 +935,17 @@ void push_box(lua_State *L, const std::vector<aabb3f> &box)
 	                it != box.end(); ++it) {
 		push_aabb3f(L, (*it));
 		lua_rawseti(L, -2, i);
+	}
+}
+
+/******************************************************************************/
+void push_groups(lua_State *L, std::map<std::string, int> groups)
+{
+	lua_createtable(L, 0, groups.size());
+	for(std::map<std::string, int>::iterator i = groups.begin();
+			i != groups.end(); i++)
+	{
+		setintfield(L, -1, i->first.c_str(), i->second);
 	}
 }
 
@@ -1038,7 +1088,7 @@ MapNode readnode(lua_State *L, int index, INodeDefManager *ndef)
 /******************************************************************************/
 void pushnode(lua_State *L, const MapNode &n, INodeDefManager *ndef)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	lua_pushstring(L, ndef->get(n).name.c_str());
 	lua_setfield(L, -2, "name");
 	lua_pushnumber(L, n.getParam1());
@@ -1070,6 +1120,15 @@ int getenumfield(lua_State *L, int table,
 	return result;
 }
 
+void setenumfield(lua_State *L, int table,
+		const char *fieldname, const EnumString *spec, int num)
+{
+	lua_pushstring(L, enum_to_string(spec, num));
+	if(table < 0)
+		table -= 1;
+	lua_setfield(L, table, fieldname);
+}
+
 /******************************************************************************/
 bool string_to_enum(const EnumString *spec, int &result,
 		const std::string &str)
@@ -1083,6 +1142,18 @@ bool string_to_enum(const EnumString *spec, int &result,
 		esp++;
 	}
 	return false;
+}
+
+const char* enum_to_string(const EnumString *spec, const int num)
+{
+	const EnumString *esp = spec;
+	while(esp->str){
+		if(num == esp->num){
+			return esp->str;
+		}
+		esp++;
+	}
+	return "";
 }
 
 /******************************************************************************/
@@ -1157,46 +1228,46 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 void push_tool_capabilities(lua_State *L,
 		const ToolCapabilities &toolcap)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 4);
 	setfloatfield(L, -1, "full_punch_interval", toolcap.full_punch_interval);
-		setintfield(L, -1, "max_drop_level", toolcap.max_drop_level);
-		// Create groupcaps table
-		lua_newtable(L);
-		// For each groupcap
-		for (ToolGCMap::const_iterator i = toolcap.groupcaps.begin();
-			i != toolcap.groupcaps.end(); ++i) {
-			// Create groupcap table
-			lua_newtable(L);
-			const std::string &name = i->first;
-			const ToolGroupCap &groupcap = i->second;
-			// Create subtable "times"
-			lua_newtable(L);
-			for (std::unordered_map<int, float>::const_iterator
-					i = groupcap.times.begin(); i != groupcap.times.end(); ++i) {
-				lua_pushinteger(L, i->first);
-				lua_pushnumber(L, i->second);
-				lua_settable(L, -3);
-			}
-			// Set subtable "times"
-			lua_setfield(L, -2, "times");
-			// Set simple parameters
-			setintfield(L, -1, "maxlevel", groupcap.maxlevel);
-			setintfield(L, -1, "uses", groupcap.uses);
-			// Insert groupcap table into groupcaps table
-			lua_setfield(L, -2, name.c_str());
+	setintfield(L, -1, "max_drop_level", toolcap.max_drop_level);
+	// Create groupcaps table
+	lua_createtable(L, 0, toolcap.groupcaps.size());
+	// For each groupcap
+	for (ToolGCMap::const_iterator i = toolcap.groupcaps.begin();
+		i != toolcap.groupcaps.end(); ++i) {
+		// Create groupcap table
+		lua_createtable(L, 0, 3);
+		const std::string &name = i->first;
+		const ToolGroupCap &groupcap = i->second;
+		// Create subtable "times"
+		lua_createtable(L, groupcap.times.size(), 0);
+		for (std::unordered_map<int, float>::const_iterator
+				i = groupcap.times.begin(); i != groupcap.times.end(); ++i) {
+			lua_pushinteger(L, i->first);
+			lua_pushnumber(L, i->second);
+			lua_settable(L, -3);
 		}
-		// Set groupcaps table
-		lua_setfield(L, -2, "groupcaps");
-		//Create damage_groups table
-		lua_newtable(L);
-		// For each damage group
-		for (DamageGroup::const_iterator i = toolcap.damageGroups.begin();
-			i != toolcap.damageGroups.end(); ++i) {
-			// Create damage group table
-			lua_pushinteger(L, i->second);
-			lua_setfield(L, -2, i->first.c_str());
-		}
-		lua_setfield(L, -2, "damage_groups");
+		// Set subtable "times"
+		lua_setfield(L, -2, "times");
+		// Set simple parameters
+		setintfield(L, -1, "maxlevel", groupcap.maxlevel);
+		setintfield(L, -1, "uses", groupcap.uses);
+		// Insert groupcap table into groupcaps table
+		lua_setfield(L, -2, name.c_str());
+	}
+	// Set groupcaps table
+	lua_setfield(L, -2, "groupcaps");
+	//Create damage_groups table
+	lua_createtable(L, 0, toolcap.damageGroups.size());
+	// For each damage group
+	for (DamageGroup::const_iterator i = toolcap.damageGroups.begin();
+		i != toolcap.damageGroups.end(); ++i) {
+		// Create damage group table
+		lua_pushinteger(L, i->second);
+		lua_setfield(L, -2, i->first.c_str());
+	}
+	lua_setfield(L, -2, "damage_groups");
 }
 
 /******************************************************************************/
@@ -1353,7 +1424,7 @@ ToolCapabilities read_tool_capabilities(
 /******************************************************************************/
 void push_dig_params(lua_State *L,const DigParams &params)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 3);
 	setboolfield(L, -1, "diggable", params.diggable);
 	setfloatfield(L, -1, "time", params.time);
 	setintfield(L, -1, "wear", params.wear);
@@ -1362,7 +1433,7 @@ void push_dig_params(lua_State *L,const DigParams &params)
 /******************************************************************************/
 void push_hit_params(lua_State *L,const HitParams &params)
 {
-	lua_newtable(L);
+	lua_createtable(L, 0, 2);
 	setintfield(L, -1, "hp", params.hp);
 	setintfield(L, -1, "wear", params.wear);
 }

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "util/string.h"
 #include "itemgroup.h"
 #include "itemdef.h"
+#include "nodedef.h"
 #include "c_types.h"
 
 namespace Json { class Value; }
@@ -54,7 +55,6 @@ struct SimpleSoundSpec;
 struct ServerSoundParams;
 class Inventory;
 struct NodeBox;
-struct ContentFeatures;
 struct TileDef;
 class Server;
 struct DigParams;
@@ -64,7 +64,7 @@ struct NoiseParams;
 class Schematic;
 
 
-ContentFeatures    read_content_features     (lua_State *L, int index);
+ContentFeatures    read_content_features     (lua_State *L, int index, ContentFeatures f_base = ContentFeatures());
 void               push_content_features     (lua_State *L,
                                               const ContentFeatures &c);
 
@@ -138,6 +138,12 @@ int                getenumfield              (lua_State *L, int table,
                                               const EnumString *spec,
                                               int default_);
 
+void               setenumfield              (lua_State *L,
+                                              int table,
+                                              const char *fieldname,
+                                              const EnumString *spec,
+                                              int num);
+
 bool               getflagsfield             (lua_State *L, int table,
                                               const char *fieldname,
                                               FlagDesc *flagdesc,
@@ -169,6 +175,9 @@ void               push_soundspec            (lua_State *L,
 bool               string_to_enum            (const EnumString *spec,
                                               int &result,
                                               const std::string &str);
+
+const char*        enum_to_string            (const EnumString *spec,
+                                              const int num);
 
 bool               read_noiseparams          (lua_State *L, int index,
                                               NoiseParams *np);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -203,6 +203,51 @@ int ModApiEnvMod::l_swap_node(lua_State *L)
 	return 1;
 }
 
+// set_def(pos, adddef)
+// pos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_set_def(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	INodeDefManager *ndef = env->getGameDef()->ndef();
+	// parameters
+	v3s16 pos = read_v3s16(L, 1);
+	MapNode n = env->getMap().getNodeNoEx(pos);
+	luaL_checktype(L, 2, LUA_TTABLE);
+	ContentFeatures def = read_content_features(L, 2, ndef->get(n));
+	bool succeeded = env->setNode(pos, n, def);
+	// Do it
+	lua_pushboolean(L, succeeded);
+	return 1;
+}
+
+// get_nodedef(pos)
+// pos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_get_nodedef(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// Do it
+	v3s16 p = read_v3s16(L, 1);
+	MapNode n = env->getMap().getNodeNoEx(p);
+	HybridPtr<const ContentFeatures> f_ptr = env->getMap().getNodeDefNoEx(p);
+	INodeDefManager *ndef = env->getGameDef()->ndef();
+	const ContentFeatures *f_current = f_ptr.get();
+	const ContentFeatures *f_orig = &ndef->get(n);
+	// If exact pointers, return from registered_nodes table
+	if(f_current == f_orig){
+		lua_getglobal(L, "minetest");
+		lua_getfield(L, -1, "registered_nodes");
+		lua_getfield(L, -1, f_current->name.c_str());
+		return 1;
+	}
+	// Otherwise convert f_current to lua table
+	else{
+		push_content_features(L, *f_current);
+		return 1;
+	}
+}
+
 // get_node(pos)
 // pos = {x=num, y=num, z=num}
 int ModApiEnvMod::l_get_node(lua_State *L)
@@ -1094,6 +1139,8 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(set_node);
 	API_FCT(add_node);
 	API_FCT(swap_node);
+	API_FCT(set_def);
+	API_FCT(get_nodedef);
 	API_FCT(add_item);
 	API_FCT(remove_node);
 	API_FCT(get_node);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -39,6 +39,14 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_swap_node(lua_State *L);
 
+	// minetest.set_def(pos, adddef)
+	// pos = {x=num, y=num, z=num}
+	static int l_set_def(lua_State *L);
+
+    // minetest.get_nodedef(pos)
+    // pos = {x=num, y=num, z=num}
+    static int l_get_nodedef(lua_State *L);
+
 	// get_node(pos)
 	// pos = {x=num, y=num, z=num}
 	static int l_get_node(lua_State *L);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "nodedef.h"
 #include "nodemetadata.h"
+#include "node_with_def.h"
 #include "gamedef.h"
 #include "map.h"
 #include "profiler.h"
@@ -958,6 +959,35 @@ bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 
 	// Call constructor
 	if (ndef->get(n).has_on_construct)
+		m_script->node_on_construct(p, n);
+
+	return true;
+}
+
+bool ServerEnvironment::setNode(v3s16 p, const MapNode &n, ContentFeatures &def)
+{
+	INodeDefManager *ndef = m_server->ndef();
+	MapNode n_old = m_map->getNodeNoEx(p);
+
+	// Call destructor
+	if (ndef->get(n_old).has_on_destruct)
+		m_script->node_on_destruct(p, n_old);
+
+	// Replace node
+	HybridPtr<const ContentFeatures> def_ptr(new ContentFeatures(def));
+	NodeWithDef nd(n, def_ptr);
+	if (!m_map->addNodeWithEvent(p, nd))
+		return false;
+
+	// Update active VoxelManipulator if a mapgen thread
+	m_map->updateVManip(p);
+
+	// Call post-destructor
+	if (ndef->get(n_old).has_after_destruct)
+		m_script->node_after_destruct(p, n_old);
+
+	// Call constructor
+	if(ndef->get(n).has_on_construct)
 		m_script->node_on_construct(p, n);
 
 	return true;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -308,6 +308,7 @@ public:
 
 	// Script-aware node setters
 	bool setNode(v3s16 p, const MapNode &n);
+	bool setNode(v3s16 p, const MapNode &n, ContentFeatures &def);
 	bool removeNode(v3s16 p);
 	bool swapNode(v3s16 p, const MapNode &n);
 

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -25,6 +25,96 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cstring>
 
 template <typename T>
+class HybridPtr
+{
+public:
+	HybridPtr(T *t=NULL)
+	{
+		refcount = new int;
+		*refcount = 1;
+		ptr = t;
+		never_delete = false;
+	}
+	HybridPtr(const HybridPtr<T> &t)
+	{
+		refcount = t.refcount;
+		(*refcount)++;
+		ptr = t.ptr;
+		never_delete = t.never_delete;
+	}
+	~HybridPtr()
+	{
+		drop();
+	}
+	HybridPtr<T> & operator=(T *t)
+	{
+		drop();
+		refcount = new int;
+		*refcount = 1;
+		ptr = t;
+		never_delete = false;
+		return *this;
+	}
+	HybridPtr<T> & operator=(const HybridPtr<T> &t)
+	{
+		drop();
+		refcount = t.refcount;
+		(*refcount)++;
+		ptr = t.ptr;
+		never_delete = t.never_delete;
+		return *this;
+	}
+	T* get() const
+	{
+		return ptr;
+	}
+	T* operator->() const
+	{
+		return ptr;
+	}
+	T & operator*() const
+	{
+		return *ptr;
+	}
+	bool operator!=(T *t) const
+	{
+		return ptr != t;
+	}
+	bool operator==(T *t) const
+	{
+		return ptr == t;
+	}
+	T & operator[](unsigned int i) const
+	{
+		return ptr[i];
+	}
+	// Can be used for transparently passing references to global things
+	void setNeverDelete(bool a_never_delete)
+	{
+		never_delete = a_never_delete;
+	}
+	bool getNeverDelete() const
+	{
+		return never_delete;
+	}
+private:
+	void drop()
+	{
+		assert((*refcount) > 0);
+		(*refcount)--;
+		if(*refcount == 0)
+		{
+			delete refcount;
+			if(ptr != NULL && !never_delete)
+				delete ptr;
+		}
+	}
+	T *ptr;
+	int *refcount;
+	bool never_delete;
+};
+
+template <typename T>
 class Buffer
 {
 public:
@@ -106,7 +196,6 @@ private:
 
 /************************************************
  *           !!!  W A R N I N G  !!!            *
- *           !!!  A C H T U N G  !!!            *
  *                                              *
  * This smart pointer class is NOT thread safe. *
  * ONLY use in a single-threaded context!       *

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -182,6 +182,8 @@ src/nodemetadata.cpp
 src/nodemetadata.h
 src/nodetimer.cpp
 src/nodetimer.h
+src/node_with_def.cpp
+src/node_with_def.h
 src/noise.cpp
 src/noise.h
 src/objdef.cpp


### PR DESCRIPTION
See #5895 for part 1
See #5902 for part 2
See #5903 for part 3

Part 1-3 are the base for actual meta-set nodedef.

Real meta-set nodedef arrives here in part 4.

Until now the following is possible:

- [ ] `on_construct`
- [ ] `on_destruct`
- [ ] `after_destruct`
- [ ] `on_rightclick`
- [ ] `groups`
- [ ] `drawtype`
- [ ] `visual_scale`
- [ ] `mesh`
- [ ] `tiles`
- [ ] `overlay_tiles`
- [ ] `special_tiles`
- [ ] `alpha`
- [ ] `use_texture_alpha`
- [ ] `color`
- [ ] `palette`
- [x] **`post_effect_color`**
- [ ] `paramtype`
- [ ] `paramtype2`
- [ ] `is_ground_content` _(possibly senseless)_
- [ ] `sunlight_propagates`
- [ ] `walkable`
- [x] **`pointable`**
- [ ] `diggable`
- [x] **`climbable`**
- [x] **`buildable_to`**
- [ ] `floodable`
- [ ] `liquidtype`
- [ ] `liquid_alternative_flowing`
- [ ] `liquid_alternative_source`
- [ ] `liquid_viscosity`
- [ ] `liquid_range`
- [ ] `leveled`
- [ ] `liquidrenewable`
- [x] **`drowning`**
- [ ] `light_source`
- [x] **`damage_per_second`**
- [ ] `node_box`
- [ ] `connects_to`
- [ ] `connect_sides`
- [x] **`selection_box`**
- [x] **`collision_box`**
- [ ] `waving`
- [ ] `sounds`