### PR TITLE
Have the server send the player list to the client

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -349,6 +349,7 @@ public:
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);
+	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
 
 	void ProcessData(NetworkPacket *pkt);

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -624,7 +624,8 @@ void GenericCAO::initialize(const std::string &data)
 			m_is_visible = false;
 			player->setCAO(this);
 		}
-		m_env->addPlayerName(m_name.c_str());
+		if (m_client->getProtoVersion() < 33)
+			m_env->addPlayerName(m_name.c_str());
 	}
 }
 
@@ -667,7 +668,7 @@ void GenericCAO::processInitData(const std::string &data)
 
 GenericCAO::~GenericCAO()
 {
-	if (m_is_player) {
+	if (m_is_player && m_client->getProtoVersion() < 33) {
 		m_env->removePlayerName(m_name.c_str());
 	}
 	removeFromScene(true);

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -110,7 +110,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeleteParticleSpawner }, // 0x53
 	{ "TOCLIENT_CLOUD_PARAMS",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CloudParams }, // 0x54
 	{ "TOCLIENT_FADE_SOUND",               TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FadeSound }, // 0x55
-	null_command_handler,
+	{ "TOCLIENT_UPDATE_PLAYER_LIST",       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_UpdatePlayerList }, // 0x56
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1270,6 +1270,28 @@ void Client::handleCommand_EyeOffset(NetworkPacket* pkt)
 	*pkt >> player->eye_offset_first >> player->eye_offset_third;
 }
 
+void Client::handleCommand_UpdatePlayerList(NetworkPacket* pkt)
+{
+	u16 num_players;
+	*pkt >> num_players;
+
+	for (u8 i = 0; i < num_players; i++) {
+		u8 type;
+		std::string name;
+		*pkt >> type >> name;
+		PlayerListModifer notice_type = (PlayerListModifer) type;
+		switch (notice_type) {
+		case PLAYER_ADD_INIT:
+		case PLAYER_ADD:
+			m_env.addPlayerName(name);
+			continue;
+		case PLAYER_REMOVE:
+			m_env.removePlayerName(name);
+			continue;
+		}
+	}
+}
+
 void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 {
 	if ((m_chosen_auth_mech != AUTH_MECHANISM_LEGACY_PASSWORD)

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1272,20 +1272,20 @@ void Client::handleCommand_EyeOffset(NetworkPacket* pkt)
 
 void Client::handleCommand_UpdatePlayerList(NetworkPacket* pkt)
 {
+	u8 type;
 	u16 num_players;
-	*pkt >> num_players;
+	*pkt >> type >> num_players;
+	PlayerListModifer notice_type = (PlayerListModifer) type;
 
-	for (u8 i = 0; i < num_players; i++) {
-		u8 type;
+	for (u16 i = 0; i < num_players; i++) {
 		std::string name;
-		*pkt >> type >> name;
-		PlayerListModifer notice_type = (PlayerListModifer) type;
+		*pkt >> name;
 		switch (notice_type) {
-		case PLAYER_ADD_INIT:
-		case PLAYER_ADD:
+		case PLAYER_LIST_INIT:
+		case PLAYER_LIST_ADD:
 			m_env.addPlayerName(name);
 			continue;
-		case PLAYER_REMOVE:
+		case PLAYER_LIST_REMOVE:
 			m_env.removePlayerName(name);
 			continue;
 		}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -155,9 +155,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Stop sending TOSERVER_CLIENT_READY
 	PROTOCOL VERSION 32:
 		Add fading sounds
+	PROTOCOL VERSION 33:
+		Add TOCLIENT_UPDATE_PLAYER_LIST and send the player list to the client,
+			instead of guessing based on the active object list.
+
 */
 
-#define LATEST_PROTOCOL_VERSION 32
+#define LATEST_PROTOCOL_VERSION 33
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 24
@@ -629,6 +633,11 @@ enum ToClientCommand
 		float step
 		float gain
 	*/
+	TOCLIENT_UPDATE_PLAYER_LIST = 0x56,
+	/*
+	 	 enum type;
+	 	 std::string name;
+	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
@@ -964,5 +973,13 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"Server shutting down.",
 	"This server has experienced an internal error. You will now be disconnected."
 };
+
+enum PlayerListModifer: u8
+{
+	PLAYER_ADD_INIT,
+	PLAYER_ADD,
+	PLAYER_REMOVE,
+};
+
 
 #endif

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -976,9 +976,9 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 
 enum PlayerListModifer: u8
 {
-	PLAYER_ADD_INIT,
-	PLAYER_ADD,
-	PLAYER_REMOVE,
+	PLAYER_LIST_INIT,
+	PLAYER_LIST_ADD,
+	PLAYER_LIST_REMOVE,
 };
 
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -635,8 +635,11 @@ enum ToClientCommand
 	*/
 	TOCLIENT_UPDATE_PLAYER_LIST = 0x56,
 	/*
-	 	 enum type;
-	 	 std::string name;
+	 	u8 type
+	 	u16 number of players
+		for each player
+			u16 len
+			u8[len] player name
 	*/
 
 	TOCLIENT_SRP_BYTES_S_B = 0x60,

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -199,7 +199,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_DELETE_PARTICLESPAWNER",   0, true }, // 0x53
 	{ "TOCLIENT_CLOUD_PARAMS",             0, true }, // 0x54
 	{ "TOCLIENT_FADE_SOUND",               0, true }, // 0x55
-	null_command_factory,
+	{ "TOCLIENT_UPDATE_PLAYER_LIST",       0, true }, // 0x56
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -716,6 +716,18 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 			peer_id, major_ver, minor_ver, patch_ver,
 			full_ver);
 
+	std::vector<std::string> players = m_clients.getPlayerNames();
+	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
+	list_pkt << (u16) players.size();
+	for (const std::string &player: players) {
+		list_pkt << (u8) PLAYER_ADD_INIT <<  player;
+	}
+	m_clients.send(peer_id, 0, &list_pkt, true);
+
+	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
+	notice_pkt << (u16) 1 << (u8) PLAYER_ADD << std::string(playersao->getPlayer()->getName());
+	m_clients.sendToAll(&notice_pkt);
+
 	m_clients.event(peer_id, CSE_SetClientReady);
 	m_script->on_joinplayer(playersao);
 	// Send shutdown timer if shutdown has been scheduled

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -716,7 +716,7 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 			peer_id, major_ver, minor_ver, patch_ver,
 			full_ver);
 
-	std::vector<std::string> players = m_clients.getPlayerNames();
+	const std::vector<std::string> &players = m_clients.getPlayerNames();
 	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
 	list_pkt << (u8) PLAYER_LIST_INIT << (u16) players.size();
 	for (const std::string &player: players) {
@@ -725,6 +725,7 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	m_clients.send(peer_id, 0, &list_pkt, true);
 
 	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
+	// (u16) 1 + std::string represents a pseudo vector serialization representation
 	notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(playersao->getPlayer()->getName());
 	m_clients.sendToAll(&notice_pkt);
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -718,14 +718,14 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 
 	std::vector<std::string> players = m_clients.getPlayerNames();
 	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
-	list_pkt << (u16) players.size();
+	list_pkt << (u8) PLAYER_LIST_INIT << (u16) players.size();
 	for (const std::string &player: players) {
-		list_pkt << (u8) PLAYER_ADD_INIT <<  player;
+		list_pkt <<  player;
 	}
 	m_clients.send(peer_id, 0, &list_pkt, true);
 
 	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
-	notice_pkt << (u16) 1 << (u8) PLAYER_ADD << std::string(playersao->getPlayer()->getName());
+	notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(playersao->getPlayer()->getName());
 	m_clients.sendToAll(&notice_pkt);
 
 	m_clients.event(peer_id, CSE_SetClientReady);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2786,6 +2786,11 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 			PlayerSAO *playersao = player->getPlayerSAO();
 			assert(playersao);
 
+			// inform connected clients
+			NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
+			notice << (u16) 1 << (u8) PLAYER_REMOVE << std::string(playersao->getPlayer()->getName());
+			m_clients.sendToAll(&notice);
+			// run scripts
 			m_script->on_leaveplayer(playersao, reason == CDR_TIMEOUT);
 
 			playersao->disconnected();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2788,7 +2788,7 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 
 			// inform connected clients
 			NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
-			notice << (u16) 1 << (u8) PLAYER_REMOVE << std::string(playersao->getPlayer()->getName());
+			notice << (u8) PLAYER_LIST_REMOVE  << (u16) 1 << std::string(playersao->getPlayer()->getName());
 			m_clients.sendToAll(&notice);
 			// run scripts
 			m_script->on_leaveplayer(playersao, reason == CDR_TIMEOUT);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2788,6 +2788,7 @@ void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
 
 			// inform connected clients
 			NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
+			// (u16) 1 + std::string represents a vector serialization representation
 			notice << (u8) PLAYER_LIST_REMOVE  << (u16) 1 << std::string(playersao->getPlayer()->getName());
 			m_clients.sendToAll(&notice);
 			// run scripts


### PR DESCRIPTION
Currently the client generates the player list based on the Client active object list, the issue with this is that we can't be sure all player active objects will be sent to the client, so this could result in players showing up when someone run `/status` but auto complete not working with their nick and CSM not being aware of the player