### PR TITLE
Autorun: Change to 'autoforward'

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -101,7 +101,7 @@ repeat_rightclick_time (Rightclick repetition interval) float 0.25
 #    Enable random user input (only used for testing).
 random_input (Random input) bool false
 
-#    Continuous forward movement (only used for testing).
+#    Continuous forward movement, toggled by autoforward key.
 continuous_forward (Continuous forward) bool false
 
 #    Enable Joysticks
@@ -206,9 +206,9 @@ keymap_increase_volume (Inc. volume key) key
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_decrease_volume (Dec. volume key) key
 
-#    Key for toggling autorun.
+#    Key for toggling autoforward.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_autorun (Autorun key) key
+keymap_autoforward (Automatic forwards key) key
 
 #    Key for toggling cinematic mode.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -79,7 +79,7 @@
 #    type: bool
 # random_input = false
 
-#    Continuous forward movement (only used for testing).
+#    Continuous forward movement, toggled by autoforward key.
 #    type: bool
 # continuous_forward = false
 
@@ -211,10 +211,10 @@
 #    type: key
 # keymap_decrease_volume =
 
-#    Key for toggling autorun.
+#    Key for toggling autoforward.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
-# keymap_autorun =
+# keymap_autoforward =
 
 #    Key for toggling cinematic mode.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -35,7 +35,7 @@ public:
 		JUMP,
 		SPECIAL1,
 		SNEAK,
-		AUTORUN,
+		AUTOFORWARD,
 
 		ESC,
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -62,7 +62,7 @@ void set_default_settings(Settings *settings)
 	// Keymap
 	settings->setDefault("remote_port", "30000");
 	settings->setDefault("keymap_forward", "KEY_KEY_W");
-	settings->setDefault("keymap_autorun", "");
+	settings->setDefault("keymap_autoforward", "");
 	settings->setDefault("keymap_backward", "KEY_KEY_S");
 	settings->setDefault("keymap_left", "KEY_KEY_A");
 	settings->setDefault("keymap_right", "KEY_KEY_D");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1033,7 +1033,7 @@ void KeyCache::populate()
 	key[KeyType::SPECIAL1]     = getKeySetting("keymap_special1");
 	key[KeyType::SNEAK]        = getKeySetting("keymap_sneak");
 
-	key[KeyType::AUTORUN]      = getKeySetting("keymap_autorun");
+	key[KeyType::AUTOFORWARD]  = getKeySetting("keymap_autoforward");
 
 	key[KeyType::DROP]         = getKeySetting("keymap_drop");
 	key[KeyType::INVENTORY]    = getKeySetting("keymap_inventory");
@@ -1238,7 +1238,7 @@ protected:
 	void toggleFast();
 	void toggleNoClip();
 	void toggleCinematic();
-	void toggleAutorun();
+	void toggleAutoforward();
 
 	void toggleChat();
 	void toggleHud();
@@ -2473,8 +2473,8 @@ void Game::processKeyInput()
 {
 	if (wasKeyDown(KeyType::DROP)) {
 		dropSelectedItem();
-	} else if (wasKeyDown(KeyType::AUTORUN)) {
-		toggleAutorun();
+	} else if (wasKeyDown(KeyType::AUTOFORWARD)) {
+		toggleAutoforward();
 	} else if (wasKeyDown(KeyType::INVENTORY)) {
 		openInventory();
 	} else if (wasKeyDown(KeyType::ESC) || input->wasKeyDown(CancelKey)) {
@@ -2755,15 +2755,15 @@ void Game::toggleCinematic()
 	m_statustext = msg[cinematic];
 }
 
-// Add WoW-style autorun by toggling continuous forward.
-void Game::toggleAutorun()
+// Autoforward by toggling continuous forward.
+void Game::toggleAutoforward()
 {
-	static const wchar_t *msg[] = { L"autorun disabled", L"autorun enabled" };
-	bool autorun_enabled = !g_settings->getBool("continuous_forward");
-	g_settings->set("continuous_forward", bool_to_cstr(autorun_enabled));
+	static const wchar_t *msg[] = { L"autoforward disabled", L"autoforward enabled" };
+	bool autoforward_enabled = !g_settings->getBool("continuous_forward");
+	g_settings->set("continuous_forward", bool_to_cstr(autoforward_enabled));
 
 	runData.statustext_time = 0;
-	m_statustext = msg[autorun_enabled ? 1 : 0];
+	m_statustext = msg[autoforward_enabled ? 1 : 0];
 }
 
 void Game::toggleChat()

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -34,7 +34,7 @@ fake_function() {
 	gettext("Random input");
 	gettext("Enable random user input (only used for testing).");
 	gettext("Continuous forward");
-	gettext("Continuous forward movement (only used for testing).");
+	gettext("Continuous forward movement, toggled by autoforward key.");
 	gettext("Enable Joysticks");
 	gettext("Enable Joysticks");
 	gettext("Joystick ID");
@@ -87,8 +87,8 @@ fake_function() {
 	gettext("Key for increasing the volume.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Dec. volume key");
 	gettext("Key for decreasing the volume.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
-	gettext("Autorun key");
-	gettext("Key for toggling autorun.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
+	gettext("Autoforward key");
+	gettext("Key for toggling autoforward.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Cinematic mode key");
 	gettext("Key for toggling cinematic mode.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Minimap key");


### PR DESCRIPTION
Minetest does not have 'run'.
Automatic forwards is very often used while flying or swimming, so a general
word is more suitable.
////////////////

Tested.
Seeing 'autorun' on the screen has been irritating me for a long time.
Also improved the documentation of 'continuous forward'.