### PR TITLE
[CSM] Add flavour limits controlled by server

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -968,7 +968,7 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    type: int
-csm_flavour_limits (Client side modding flavour limits) int 0
+csm_flavour_limits (Client side modding flavour limits) int 3
 
 #    If CSM flavour for node range is enabled, sets the client range limit for get_node
 #    to this limit. The default limit (8) is reasonable to know nodes very near player.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -969,8 +969,8 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    type: int
 csm_flavour_limits (Client side modding flavour limits) int 3
 
-#    If CSM flavour for node range is enabled, sets the client range limit for get_node
-#    to this limit. The default limit (8) is reasonable to know nodes very near player.
+#   If the CSM flavour for node range is enabled, get_node is limited to
+#   this many nodes from the player.
 csm_flavour_noderange_limit (Client side noderange flavour limit) int 8
 
 [*Mapgen]

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -960,9 +960,8 @@ block_send_optimize_distance (block send optimize distance) int 4 2
 #    so that the utility of noclip mode is reduced.
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
-#    Limits some features on client
-#    It's a byteflag, you should add value for every feature you want to limit
-#    Here is the possible values to combine:
+#    Restricts the access of certain client-side functions on servers
+#    Combine these byteflags below to restrict more client-side features:
 #    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -960,6 +960,20 @@ block_send_optimize_distance (block send optimize distance) int 4 2
 #    so that the utility of noclip mode is reduced.
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
+#    Limits some features on client
+#    It's a byteflag, you should add value for every feature you want to limit
+#    Here is the possible values to combine:
+#    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
+#    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
+#    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
+#    READ_NODEDEFS: 8 (disable get_node_def call client-side)
+#    type: int
+csm_flavour_limits (Client side modding flavour limits) int 0
+
+#    If CSM flavour for node range is enabled, sets the client range limit for get_node
+#    to this limit. The default limit (8) is reasonable to know nodes very near player.
+csm_flavour_noderange_limit (Client side noderange flavour limit) int 8
+
 [*Mapgen]
 
 #    Name of map generator to be used when creating a new world.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -700,7 +700,7 @@ Call these functions only at load time!
     * Returns the time of day: `0` for midnight, `0.5` for midday
 
 ### Map
-* `minetest.get_node(pos)`
+* `minetest.get_node_or_nil(pos)`
     * Returns the node at the given position as table in the format
       `{name="node_name", param1=0, param2=0}`, returns `nil`
       for unloaded areas or flavour limited areas.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -702,10 +702,8 @@ Call these functions only at load time!
 ### Map
 * `minetest.get_node(pos)`
     * Returns the node at the given position as table in the format
-      `{name="node_name", param1=0, param2=0}`, returns `{name="ignore", param1=0, param2=0}`
-      for unloaded areas.
-* `minetest.get_node_or_nil(pos)`
-    * Same as `get_node` but returns `nil` for unloaded areas.
+      `{name="node_name", param1=0, param2=0}`, returns `nil`
+      for unloaded areas or flavour limited areas.
 * `minetest.find_node_near(pos, radius, nodenames, [search_center])`: returns pos or `nil`
     * `radius`: using a maximum metric
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1172,9 +1172,8 @@
 #    type: bool
 # server_side_occlusion_culling = true
 
-#    Limits some features on client
-#    It's a byteflag, you should add value for every feature you want to limit
-#    Here is the possible values to combine:
+#    Restricts the access of certain client-side functions on servers
+#    Combine these byteflags below to restrict more client-side features:
 #    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1180,7 +1180,7 @@
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    type: int
-# csm_flavour_limits = 0
+# csm_flavour_limits = 3
 
 #    If CSM flavour for node range is enabled, sets the client range limit for get_node
 #    to this limit. The default limit (8) is reasonable to know nodes very near player.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1181,8 +1181,8 @@
 #    type: int
 # csm_flavour_limits = 3
 
-#    If CSM flavour for node range is enabled, sets the client range limit for get_node
-#    to this limit. The default limit (8) is reasonable to know nodes very near player.
+#   If the CSM flavour for node range is enabled, get_node is limited to
+#   this many nodes from the player.
 # csm_flavour_noderange_limit 8
 
 ## Mapgen

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1172,6 +1172,20 @@
 #    type: bool
 # server_side_occlusion_culling = true
 
+#    Blacklists or greylist some features on client
+#    It's a byteflag, you should add value for every feature you want to limit
+#    Here is the possible values to combine:
+#    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
+#    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
+#    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
+#    READ_NODEDEFS: 8 (disable get_node_def call client-side)
+#    type: int
+# csm_flavour_blacklist = 0
+
+#    If CSM flavour for node range is enabled, sets the client range limit for get_node
+#    to this limit. The default limit (8) is reasonable to know nodes very near player.
+# csm_flavour_noderange_limit 8
+
 ## Mapgen
 
 #    Name of map generator to be used when creating a new world.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1172,7 +1172,7 @@
 #    type: bool
 # server_side_occlusion_culling = true
 
-#    Blacklists or greylist some features on client
+#    Limits some features on client
 #    It's a byteflag, you should add value for every feature you want to limit
 #    Here is the possible values to combine:
 #    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
@@ -1180,7 +1180,7 @@
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    type: int
-# csm_flavour_blacklist = 0
+# csm_flavour_limits = 0
 
 #    If CSM flavour for node range is enabled, sets the client range limit for get_node
 #    to this limit. The default limit (8) is reasonable to know nodes very near player.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1372,7 +1372,7 @@ MapNode Client::getNode(v3s16 p, bool *is_valid_position)
 {
 	if (getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		v3s16 ppos = floatToInt(m_env.getLocalPlayer()->getPosition(), BS);
-		if (ppos.getDistanceFrom(p) > CSM_FL_LOOKUP_NODES_LIMIT) {
+		if ((u32) std::abs(ppos.getDistanceFrom(p)) > m_csm_noderange_limit) {
 			*is_valid_position = false;
 			return MapNode();
 		}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1361,8 +1361,22 @@ void Client::removeNode(v3s16 p)
 	}
 }
 
+/**
+ * Helper function for Client Side Modding
+ * Flavour is applied there, this should not be used for core engine
+ * @param p
+ * @param is_valid_position
+ * @return
+ */
 MapNode Client::getNode(v3s16 p, bool *is_valid_position)
 {
+	if (getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
+		v3s16 ppos = floatToInt(m_env.getLocalPlayer()->getPosition(), BS);
+		if (ppos.getDistanceFrom(p) > CSM_FL_LOOKUP_NODES_LIMIT) {
+			*is_valid_position = false;
+			return MapNode();
+		}
+	}
 	return m_env.getMap().getNodeNoEx(p, is_valid_position);
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1370,7 +1370,7 @@ void Client::removeNode(v3s16 p)
  */
 MapNode Client::getNode(v3s16 p, bool *is_valid_position)
 {
-	if (getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
+	if (checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_LOOKUP_NODES)) {
 		v3s16 ppos = floatToInt(m_env.getLocalPlayer()->getPosition(), BS);
 		if ((u32) ppos.getDistanceFrom(p) > m_csm_noderange_limit) {
 			*is_valid_position = false;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1372,7 +1372,7 @@ MapNode Client::getNode(v3s16 p, bool *is_valid_position)
 {
 	if (getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		v3s16 ppos = floatToInt(m_env.getLocalPlayer()->getPosition(), BS);
-		if ((u32) std::abs(ppos.getDistanceFrom(p)) > m_csm_noderange_limit) {
+		if ((u32) ppos.getDistanceFrom(p) > m_csm_noderange_limit) {
 			*is_valid_position = false;
 			return MapNode();
 		}

--- a/src/client.h
+++ b/src/client.h
@@ -566,6 +566,11 @@ public:
 		return m_csm_flavour_limits;
 	}
 
+	u32 getCSMNodeRangeLimit() const
+	{
+		return m_csm_noderange_limit;
+	}
+
 private:
 
 	// Virtual methods from con::PeerHandler
@@ -722,6 +727,7 @@ private:
 
 	// CSM flavour limits byteflag
 	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FL_NONE;
+	u32 m_csm_noderange_limit = 8;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/client.h
+++ b/src/client.h
@@ -397,6 +397,14 @@ public:
 
 	// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
 	void removeNode(v3s16 p);
+
+	/**
+	 * Helper function for Client Side Modding
+	 * Flavour is applied there, this should not be used for core engine
+	 * @param p
+	 * @param is_valid_position
+	 * @return
+	 */
 	MapNode getNode(v3s16 p, bool *is_valid_position);
 	void addNode(v3s16 p, MapNode n, bool remove_metadata = true);
 

--- a/src/client.h
+++ b/src/client.h
@@ -561,9 +561,9 @@ public:
 		return m_address_name;
 	}
 
-	u64 getCSMFlavourLimits() const
+	inline bool checkCSMFlavourLimit(CSMFlavourLimit flag) const
 	{
-		return m_csm_flavour_limits;
+		return m_csm_flavour_limits & flag;
 	}
 
 	u32 getCSMNodeRangeLimit() const

--- a/src/client.h
+++ b/src/client.h
@@ -364,6 +364,7 @@ public:
 	void handleCommand_EyeOffset(NetworkPacket* pkt);
 	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
+	void handleCommand_CSMFlavourLimits(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -552,6 +553,11 @@ public:
 		return m_address_name;
 	}
 
+	u64 getCSMFlavourLimits() const
+	{
+		return m_csm_flavour_limits;
+	}
+
 private:
 
 	// Virtual methods from con::PeerHandler
@@ -705,6 +711,9 @@ private:
 	GameUIFlags *m_game_ui_flags;
 
 	bool m_shutdown = false;
+
+	// CSM flavour limits byteflag
+	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FBL_NONE;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/client.h
+++ b/src/client.h
@@ -713,7 +713,7 @@ private:
 	bool m_shutdown = false;
 
 	// CSM flavour limits byteflag
-	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FBL_NONE;
+	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FL_NONE;
 };
 
 #endif // !CLIENT_HEADER

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -294,6 +294,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
+	settings->setDefault("csm_flavour_blacklist", "0");
+	settings->setDefault("csm_flavour_noderange_limit", "8");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("server_unload_unused_data_timeout", "29");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -294,7 +294,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_flavour_limits", "0");
+	settings->setDefault("csm_flavour_limits", "3");
 	settings->setDefault("csm_flavour_noderange_limit", "8");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -294,7 +294,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_flavour_blacklist", "0");
+	settings->setDefault("csm_flavour_limits", "0");
 	settings->setDefault("csm_flavour_noderange_limit", "8");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -66,7 +66,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_INVENTORY",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Inventory }, // 0x27
 	null_command_handler,
 	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay }, // 0x29
-	null_command_handler,
+	{ "TOCLIENT_CSM_FLAVOUR_LIMITS",       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CSMFlavourLimits }, // 0x2A
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1379,5 +1379,5 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 
 void Client::handleCommand_CSMFlavourLimits(NetworkPacket *pkt)
 {
-	*pkt >> m_csm_flavour_limits;
+	*pkt >> m_csm_flavour_limits >> m_csm_noderange_limit;
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1376,3 +1376,8 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 	resp_pkt << std::string(bytes_M, len_M);
 	Send(&resp_pkt);
 }
+
+void Client::handleCommand_CSMFlavourLimits(NetworkPacket *pkt)
+{
+	*pkt >> m_csm_flavour_limits;
+}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -168,6 +168,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  			* sender
  			* type (RAW, NORMAL, ANNOUNCE, SYSTEM)
  			* content
+ 		Add TOCLIENT_CSM_FLAVOUR_LIMITS to define which CSM flavour should be limited
 */
 
 #define LATEST_PROTOCOL_VERSION 35

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1008,8 +1008,6 @@ enum PlayerListModifer: u8
 	PLAYER_LIST_REMOVE,
 };
 
-#define CSM_FL_LOOKUP_NODES_LIMIT 8
-
 enum CSMFlavourLimit : u64 {
 	CSM_FL_NONE = 0x00000000,
 	CSM_FL_LOOKUP_NODES = 0x00000001, // Limit node lookups

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -17,8 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NETWORKPROTOCOL_HEADER
-#define NETWORKPROTOCOL_HEADER
+#pragma once
+
 #include "util/string.h"
 
 /*
@@ -312,6 +312,11 @@ enum ToClientCommand
 		Added in a later version:
 		f1000 time_speed
 	*/
+
+	TOCLIENT_CSM_FLAVOUR_LIMITS = 0x2A,
+	/*
+		u32 CSMFlavourLimits byteflag
+	 */
 
 	// (oops, there is some gap here)
 
@@ -1003,5 +1008,10 @@ enum PlayerListModifer: u8
 	PLAYER_LIST_REMOVE,
 };
 
+enum CSMFlavourLimit : u64 {
+	CSM_FBL_NONE = 0x00000000,
+	CSM_FBL_LOOKUP_NODES = 0x00000001, // Limit node lookups
+	CSM_FBL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
+	CSM_FBL_ALL = 0xFFFFFFFF,
+};
 
-#endif

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1009,9 +1009,11 @@ enum PlayerListModifer: u8
 };
 
 enum CSMFlavourLimit : u64 {
-	CSM_FBL_NONE = 0x00000000,
-	CSM_FBL_LOOKUP_NODES = 0x00000001, // Limit node lookups
-	CSM_FBL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
-	CSM_FBL_ALL = 0xFFFFFFFF,
+	CSM_FL_NONE = 0x00000000,
+	CSM_FL_LOOKUP_NODES = 0x00000001, // Limit node lookups
+	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
+	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
+	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
+	CSM_FL_ALL = 0xFFFFFFFF,
 };
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1008,6 +1008,8 @@ enum PlayerListModifer: u8
 	PLAYER_LIST_REMOVE,
 };
 
+#define CSM_FL_LOOKUP_NODES_LIMIT 8
+
 enum CSMFlavourLimit : u64 {
 	CSM_FL_NONE = 0x00000000,
 	CSM_FL_LOOKUP_NODES = 0x00000001, // Limit node lookups

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -155,7 +155,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_INVENTORY",                0, true }, // 0x27
 	null_command_factory,
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
-	null_command_factory,
+	{ "TOCLIENT_CSM_FLAVOUR_LIMITS",       0, true }, // 0x2A
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -643,6 +643,8 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	float time_speed = g_settings->getFloat("time_speed");
 	SendTimeOfDay(pkt->getPeerId(), time, time_speed);
 
+	SendCSMFlavourLimits(pkt->getPeerId());
+
 	// Warnings about protocol version can be issued here
 	if (getClient(pkt->getPeerId())->net_proto_version < LATEST_PROTOCOL_VERSION) {
 		SendChatMessage(pkt->getPeerId(), ChatMessage(CHATMESSAGE_TYPE_SYSTEM,

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -93,7 +93,7 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 		return 0;
 
 	// If server disabled this API, discard
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_CHAT_MESSAGES)
+	if (getClient(L)->checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_CHAT_MESSAGES))
 		return 0;
 
 	std::string message = luaL_checkstring(L, 1);
@@ -171,7 +171,7 @@ int ModApiClient::l_gettext(lua_State *L)
 
 // get_node(pos)
 // pos = {x=num, y=num, z=num}
-int ModApiClient::l_get_node(lua_State *L)
+int ModApiClient::l_get_node_or_nil(lua_State *L)
 {
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
@@ -282,9 +282,8 @@ int ModApiClient::l_get_item_def(lua_State *L)
 	IItemDefManager *idef = gdef->idef();
 	assert(idef);
 
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_READ_ITEMDEFS) {
+	if (getClient(L)->checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_READ_ITEMDEFS))
 		return 0;
-	}
 
 	if (!lua_isstring(L, 1))
 		return 0;
@@ -311,9 +310,8 @@ int ModApiClient::l_get_node_def(lua_State *L)
 	if (!lua_isstring(L, 1))
 		return 0;
 
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_READ_NODEDEFS) {
+	if (getClient(L)->checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_READ_NODEDEFS))
 		return 0;
-	}
 
 	const std::string &name = lua_tostring(L, 1);
 	const ContentFeatures &cf = ndef->get(ndef->getId(name));
@@ -363,7 +361,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(show_formspec);
 	API_FCT(send_respawn);
 	API_FCT(gettext);
-	API_FCT(get_node);
+	API_FCT(get_node_or_nil);
 	API_FCT(get_wielded_item);
 	API_FCT(disconnect);
 	API_FCT(get_meta);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -176,25 +176,6 @@ int ModApiClient::l_get_node(lua_State *L)
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
 
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
-		// TODO
-	}
-
-	// Do it
-	bool pos_ok;
-	MapNode n = getClient(L)->getNode(pos, &pos_ok);
-	// Return node
-	pushnode(L, n, getClient(L)->ndef());
-	return 1;
-}
-
-// get_node_or_nil(pos)
-// pos = {x=num, y=num, z=num}
-int ModApiClient::l_get_node_or_nil(lua_State *L)
-{
-	// pos
-	v3s16 pos = read_v3s16(L, 1);
-
 	// Do it
 	bool pos_ok;
 	MapNode n = getClient(L)->getNode(pos, &pos_ok);
@@ -383,7 +364,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(send_respawn);
 	API_FCT(gettext);
 	API_FCT(get_node);
-	API_FCT(get_node_or_nil);
 	API_FCT(get_wielded_item);
 	API_FCT(disconnect);
 	API_FCT(get_meta);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -93,7 +93,7 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 		return 0;
 
 	// If server disable this API, discard
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_CHAT_MESSAGES)
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_CHAT_MESSAGES)
 		return 0;
 
 	std::string message = luaL_checkstring(L, 1);
@@ -176,7 +176,7 @@ int ModApiClient::l_get_node(lua_State *L)
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
 
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		// TODO
 	}
 
@@ -194,7 +194,7 @@ int ModApiClient::l_get_node_or_nil(lua_State *L)
 {
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		// TODO
 	}
 
@@ -304,6 +304,10 @@ int ModApiClient::l_get_item_def(lua_State *L)
 	IItemDefManager *idef = gdef->idef();
 	assert(idef);
 
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_READ_ITEMDEFS) {
+		return 0;
+	}
+
 	if (!lua_isstring(L, 1))
 		return 0;
 
@@ -328,6 +332,10 @@ int ModApiClient::l_get_node_def(lua_State *L)
 
 	if (!lua_isstring(L, 1))
 		return 0;
+
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_READ_NODEDEFS) {
+		return 0;
+	}
 
 	const std::string &name = lua_tostring(L, 1);
 	const ContentFeatures &cf = ndef->get(ndef->getId(name));

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -194,9 +194,6 @@ int ModApiClient::l_get_node_or_nil(lua_State *L)
 {
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
-	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
-		// TODO
-	}
 
 	// Do it
 	bool pos_ok;

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -91,6 +91,11 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 {
 	if (!lua_isstring(L, 1))
 		return 0;
+
+	// If server disable this API, discard
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_CHAT_MESSAGES)
+		return 0;
+
 	std::string message = luaL_checkstring(L, 1);
 	getClient(L)->sendChatMessage(utf8_to_wide(message));
 	return 0;
@@ -170,6 +175,11 @@ int ModApiClient::l_get_node(lua_State *L)
 {
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
+
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+		// TODO
+	}
+
 	// Do it
 	bool pos_ok;
 	MapNode n = getClient(L)->getNode(pos, &pos_ok);
@@ -184,6 +194,10 @@ int ModApiClient::l_get_node_or_nil(lua_State *L)
 {
 	// pos
 	v3s16 pos = read_v3s16(L, 1);
+	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+		// TODO
+	}
+
 	// Do it
 	bool pos_ok;
 	MapNode n = getClient(L)->getNode(pos, &pos_ok);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -92,7 +92,7 @@ int ModApiClient::l_send_chat_message(lua_State *L)
 	if (!lua_isstring(L, 1))
 		return 0;
 
-	// If server disable this API, discard
+	// If server disabled this API, discard
 	if (getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_CHAT_MESSAGES)
 		return 0;
 

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -65,7 +65,7 @@ private:
 	static int l_set_last_run_mod(lua_State *L);
 
 	// get_node(pos)
-	static int l_get_node(lua_State *L);
+	static int l_get_node_or_nil(lua_State *L);
 
 	// get_wielded_item()
 	static int l_get_wielded_item(lua_State *L);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -67,9 +67,6 @@ private:
 	// get_node(pos)
 	static int l_get_node(lua_State *L);
 
-	// get_node_or_nil(pos)
-	static int l_get_node_or_nil(lua_State *L);
-
 	// get_wielded_item()
 	static int l_get_wielded_item(lua_State *L);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -710,7 +710,7 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 
 	// Client API limitations
 	if (getClient(L) &&
-			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		// TODO
 	}
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_vmanip.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include <algorithm>
 #include "scripting_server.h"
 #include "environment.h"
 #include "server.h"
@@ -730,7 +731,7 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 	// Client API limitations
 	if (getClient(L) &&
 		getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
-		radius = std::max(radius, CSM_FL_LOOKUP_NODES_LIMIT);
+		radius = std::max<int>(radius, getClient(L)->getCSMNodeRangeLimit());
 	}
 
 	for (int d = start_radius; d <= radius; d++) {

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -708,12 +708,6 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 		return 0;
 	}
 
-	// Client API limitations
-	if (getClient(L) &&
-			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
-		// TODO
-	}
-
 	INodeDefManager *ndef = getGameDef(L)->ndef();
 	v3s16 pos = read_v3s16(L, 1);
 	int radius = luaL_checkinteger(L, 2);
@@ -732,6 +726,13 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 	}
 
 	int start_radius = (lua_toboolean(L, 4)) ? 0 : 1;
+
+	// Client API limitations
+	if (getClient(L) &&
+		getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
+		radius = std::max(radius, CSM_FL_LOOKUP_NODES_LIMIT);
+	}
+
 	for (int d = start_radius; d <= radius; d++) {
 		std::vector<v3s16> list = FacePositionCache::getFacePositions(d);
 		for (std::vector<v3s16>::iterator i = list.begin();

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -731,7 +731,7 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 #ifndef SERVER
 	// Client API limitations
 	if (getClient(L) &&
-			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
+			getClient(L)->checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_LOOKUP_NODES)) {
 		radius = std::max<int>(radius, getClient(L)->getCSMNodeRangeLimit());
 	}
 #endif

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -708,6 +708,12 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 		return 0;
 	}
 
+	// Client API limitations
+	if (getClient(L) &&
+			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FBL_LOOKUP_NODES) {
+		// TODO
+	}
+
 	INodeDefManager *ndef = getGameDef(L)->ndef();
 	v3s16 pos = read_v3s16(L, 1);
 	int radius = luaL_checkinteger(L, 2);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -728,11 +728,13 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 
 	int start_radius = (lua_toboolean(L, 4)) ? 0 : 1;
 
+#ifndef SERVER
 	// Client API limitations
 	if (getClient(L) &&
 		getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		radius = std::max<int>(radius, getClient(L)->getCSMNodeRangeLimit());
 	}
+#endif
 
 	for (int d = start_radius; d <= radius; d++) {
 		std::vector<v3s16> list = FacePositionCache::getFacePositions(d);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -731,7 +731,7 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 #ifndef SERVER
 	// Client API limitations
 	if (getClient(L) &&
-		getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
+			getClient(L)->getCSMFlavourLimits() & CSMFlavourLimit::CSM_FL_LOOKUP_NODES) {
 		radius = std::max<int>(radius, getClient(L)->getCSMNodeRangeLimit());
 	}
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -298,7 +298,7 @@ Server::Server(
 
 	m_liquid_transform_every = g_settings->getFloat("liquid_update");
 	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
-	m_csm_flavour_limits = g_settings->getU64("csm_flavour_blacklist");
+	m_csm_flavour_limits = g_settings->getU64("csm_flavour_limits");
 	m_csm_noderange_limit = (u32) g_settings->getS32("csm_flavour_noderange_limit");
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -298,6 +298,8 @@ Server::Server(
 
 	m_liquid_transform_every = g_settings->getFloat("liquid_update");
 	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
+	m_csm_flavour_limits = g_settings->getU64("csm_flavour_blacklist");
+	m_csm_noderange_limit = (u32) g_settings->getS32("csm_flavour_noderange_limit");
 }
 
 Server::~Server()
@@ -2021,8 +2023,9 @@ void Server::SendActiveObjectMessages(u16 peer_id, const std::string &datas, boo
 
 void Server::SendCSMFlavourLimits(u16 peer_id)
 {
-	NetworkPacket pkt(TOCLIENT_CSM_FLAVOUR_LIMITS, sizeof(m_csm_flavour_limits), peer_id);
-	pkt << m_csm_flavour_limits;
+	NetworkPacket pkt(TOCLIENT_CSM_FLAVOUR_LIMITS,
+		sizeof(m_csm_flavour_limits) + sizeof(m_csm_noderange_limit), peer_id);
+	pkt << m_csm_flavour_limits << m_csm_noderange_limit;
 	Send(&pkt);
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -299,7 +299,7 @@ Server::Server(
 	m_liquid_transform_every = g_settings->getFloat("liquid_update");
 	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
 	m_csm_flavour_limits = g_settings->getU64("csm_flavour_limits");
-	m_csm_noderange_limit = (u32) g_settings->getS32("csm_flavour_noderange_limit");
+	m_csm_noderange_limit = g_settings->getU32("csm_flavour_noderange_limit");
 }
 
 Server::~Server()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2017,7 +2017,13 @@ void Server::SendActiveObjectMessages(u16 peer_id, const std::string &datas, boo
 	m_clients.send(pkt.getPeerId(),
 			reliable ? clientCommandFactoryTable[pkt.getCommand()].channel : 1,
 			&pkt, reliable);
+}
 
+void Server::SendCSMFlavourLimits(u16 peer_id)
+{
+	NetworkPacket pkt(TOCLIENT_CSM_FLAVOUR_LIMITS, sizeof(m_csm_flavour_limits), peer_id);
+	pkt << m_csm_flavour_limits;
+	Send(&pkt);
 }
 
 s32 Server::playSound(const SimpleSoundSpec &spec,

--- a/src/server.h
+++ b/src/server.h
@@ -466,6 +466,8 @@ private:
 
 	u32 SendActiveObjectRemoveAdd(u16 peer_id, const std::string &datas);
 	void SendActiveObjectMessages(u16 peer_id, const std::string &datas, bool reliable = true);
+	void SendCSMFlavourLimits(u16 peer_id);
+
 	/*
 		Something random
 	*/
@@ -664,6 +666,9 @@ private:
 
 	std::unordered_map<std::string, ModMetadata *> m_mod_storages;
 	float m_mod_storage_save_timer = 10.0f;
+
+	// CSM flavour limits byteflag
+	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FBL_NONE;
 };
 
 /*
@@ -674,4 +679,3 @@ private:
 void dedicated_server_loop(Server &server, bool &kill);
 
 #endif
-

--- a/src/server.h
+++ b/src/server.h
@@ -668,7 +668,7 @@ private:
 	float m_mod_storage_save_timer = 10.0f;
 
 	// CSM flavour limits byteflag
-	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FBL_NONE;
+	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FL_NONE;
 };
 
 /*

--- a/src/server.h
+++ b/src/server.h
@@ -669,6 +669,7 @@ private:
 
 	// CSM flavour limits byteflag
 	u64 m_csm_flavour_limits = CSMFlavourLimit::CSM_FL_NONE;
+	u32 m_csm_noderange_limit = 8;
 };
 
 /*

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -398,6 +398,11 @@ s16 Settings::getS16(const std::string &name) const
 }
 
 
+u32 Settings::getU32(const std::string &name) const
+{
+	return (u32) stoi(get(name));
+}
+
 s32 Settings::getS32(const std::string &name) const
 {
 	return stoi(get(name));

--- a/src/settings.h
+++ b/src/settings.h
@@ -134,6 +134,7 @@ public:
 	bool getBool(const std::string &name) const;
 	u16 getU16(const std::string &name) const;
 	s16 getS16(const std::string &name) const;
+	u32 getU32(const std::string &name) const;
 	s32 getS32(const std::string &name) const;
 	u64 getU64(const std::string &name) const;
 	float getFloat(const std::string &name) const;


### PR DESCRIPTION
Server send flavour limits to client permitting to disable or limit some Lua calls

* CSM_FL_LOOKUP_NODES: Limit node lookups for 8 nodes in player range
* CSM_FL_CHAT_MESSAGES: Disable chat message sending from CSM
* CSM_FL_READ_ITEMDEFS: Disable itemdef lookups
* CSM_FL_READ_NODEDEFS: Disable nodedef lookups

Remove get_node_or_nil, get_node now have the get_node_or_nil behaviour

Add a parameter (server-side) to set node lookup limit (default 8) when enable LOOKUP_NODE Flavour