### PR TITLE
Use opaque textures for basic materials

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -156,7 +156,8 @@ enum MaterialType{
 	TILE_MATERIAL_LIQUID_TRANSPARENT,
 	TILE_MATERIAL_LIQUID_OPAQUE,
 	TILE_MATERIAL_WAVING_LEAVES,
-	TILE_MATERIAL_WAVING_PLANTS
+	TILE_MATERIAL_WAVING_PLANTS,
+	TILE_MATERIAL_OPAQUE
 };
 
 // Material flags
@@ -216,6 +217,10 @@ struct TileLayer
 	void applyMaterialOptions(video::SMaterial &material) const
 	{
 		switch (material_type) {
+		case TILE_MATERIAL_OPAQUE:
+		case TILE_MATERIAL_LIQUID_OPAQUE:
+			material.MaterialType = video::EMT_SOLID;
+			break;
 		case TILE_MATERIAL_BASIC:
 		case TILE_MATERIAL_WAVING_LEAVES:
 		case TILE_MATERIAL_WAVING_PLANTS:
@@ -224,9 +229,6 @@ struct TileLayer
 		case TILE_MATERIAL_ALPHA:
 		case TILE_MATERIAL_LIQUID_TRANSPARENT:
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-			break;
-		case TILE_MATERIAL_LIQUID_OPAQUE:
-			material.MaterialType = video::EMT_SOLID;
 			break;
 		}
 		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -690,6 +690,8 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	switch (drawtype) {
 	default:
 	case NDT_NORMAL:
+		material_type = (alpha == 255) ?
+			TILE_MATERIAL_OPAQUE : TILE_MATERIAL_ALPHA;
 		solidness = 2;
 		break;
 	case NDT_AIRLIKE:
@@ -786,6 +788,16 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 		tile_shader[j] = shdsrc->getShader("nodes_shader",
 			material_type, drawtype);
 	}
+	u8 overlay_material = material_type;
+	if (overlay_material == TILE_MATERIAL_OPAQUE)
+		overlay_material = TILE_MATERIAL_BASIC;
+	else if (overlay_material == TILE_MATERIAL_LIQUID_OPAQUE)
+		overlay_material = TILE_MATERIAL_LIQUID_TRANSPARENT;
+	u32 overlay_shader[6];
+	for (u16 j = 0; j < 6; j++) {
+		overlay_shader[j] = shdsrc->getShader("nodes_shader",
+			overlay_material, drawtype);
+	}
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
@@ -794,8 +806,8 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			tdef[j].backface_culling, material_type);
 		if (tdef_overlay[j].name != "")
 			fillTileAttribs(tsrc, &tiles[j].layers[1], &tdef_overlay[j],
-				tile_shader[j], tsettings.use_normal_texture,
-				tdef[j].backface_culling, material_type);
+				overlay_shader[j], tsettings.use_normal_texture,
+				tdef[j].backface_culling, overlay_material);
 	}
 
 	// Special tiles (fill in f->special_tiles[])

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -531,26 +531,19 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	shaderinfo.drawtype = drawtype;
 	shaderinfo.material = video::EMT_SOLID;
 	switch (material_type) {
-		case TILE_MATERIAL_BASIC:
-			shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-			break;
-		case TILE_MATERIAL_ALPHA:
-			shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-			break;
-		case TILE_MATERIAL_LIQUID_TRANSPARENT:
-			shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-			break;
-		case TILE_MATERIAL_LIQUID_OPAQUE:
-			shaderinfo.base_material = video::EMT_SOLID;
-			break;
-		case TILE_MATERIAL_WAVING_LEAVES:
-			shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-			break;
-		case TILE_MATERIAL_WAVING_PLANTS:
-			shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-			break;
-		default:
-			break;
+	case TILE_MATERIAL_OPAQUE:
+	case TILE_MATERIAL_LIQUID_OPAQUE:
+		shaderinfo.base_material = video::EMT_SOLID;
+		break;
+	case TILE_MATERIAL_ALPHA:
+	case TILE_MATERIAL_LIQUID_TRANSPARENT:
+		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		break;
+	case TILE_MATERIAL_BASIC:
+	case TILE_MATERIAL_WAVING_LEAVES:
+	case TILE_MATERIAL_WAVING_PLANTS:
+		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		break;
 	}
 
 	bool enable_shaders = g_settings->getBool("enable_shaders");
@@ -642,7 +635,8 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		"TILE_MATERIAL_LIQUID_TRANSPARENT",
 		"TILE_MATERIAL_LIQUID_OPAQUE",
 		"TILE_MATERIAL_WAVING_LEAVES",
-		"TILE_MATERIAL_WAVING_PLANTS"
+		"TILE_MATERIAL_WAVING_PLANTS",
+		"TILE_MATERIAL_OPAQUE"
 	};
 
 	for (int i = 0; i < 6; i++){


### PR DESCRIPTION
This is an attempt to fix the x-ray effect when rendering transparent textures on nodes that do not support alpha channel `TILE_MATERIAL_BASIC`

This PR introduces a new material type flag `TILE_MATERIAL_OPAQUE` to be used for nodes that do not explicitly allow transparent textures. Theoretically, using opaque materials for what amounts to most of the generated landscape, could offer a slight increase in performance. However, I have yet to see any concrete evidence of that, it certainly should not have any adverse effect in that respect.

This should, however, prevent the use of x-ray texture packs to see through solid nodes. I have tested this with and without basic shaders enabled and have not found any problems.

Related: #5939

Possibly fixes:  #5842 ?

No-clip viewer mod with patch applied:
![screenshot_20170607_190853](https://user-images.githubusercontent.com/3710749/26893943-d5000258-4bb4-11e7-98b7-fcea717d7368.png)