### PR TITLE
Clang-Format: constructor initializer rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ IndentWidth: 8
 UseTab: Always
 BreakBeforeBraces: Custom
 Standard: Cpp11
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 BraceWrapping:
   AfterClass: true
   AfterControlStatement: false

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -78,14 +78,22 @@ struct HTTPFetchResult
 	unsigned long request_id;
 
 	HTTPFetchResult()
-	    : succeeded(false), timeout(false), response_code(0), data(""),
-	      caller(HTTPFETCH_DISCARD), request_id(0)
+	    : succeeded(false),
+	      timeout(false),
+	      response_code(0),
+	      data(""),
+	      caller(HTTPFETCH_DISCARD),
+	      request_id(0)
 	{
 	}
 
 	HTTPFetchResult(const HTTPFetchRequest &fetch_request)
-	    : succeeded(false), timeout(false), response_code(0), data(""),
-	      caller(fetch_request.caller), request_id(fetch_request.request_id)
+	    : succeeded(false),
+	      timeout(false),
+	      response_code(0),
+	      data(""),
+	      caller(fetch_request.caller),
+	      request_id(fetch_request.request_id)
 	{
 	}
 };


### PR DESCRIPTION
Add ConstructorInitializerAllOnOneLineOrOnePerLine option and set to true
If initializers fits on one line, let them on one line, else set them on multiple lines