### PR TITLE
C++11 patchset 6: forbid object copy using assigment/copy function delete

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -272,6 +272,7 @@ public:
 	);
 
 	~Client();
+	DISABLE_CLASS_COPY(Client);
 
 	void initMods();
 
@@ -691,7 +692,6 @@ private:
 	GameUIFlags *m_game_ui_flags;
 
 	bool m_shutdown;
-	DISABLE_CLASS_COPY(Client);
 };
 
 #endif // !CLIENT_HEADER

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -119,6 +119,7 @@ public:
 	// Methods
 	EmergeManager(Server *server);
 	~EmergeManager();
+	DISABLE_CLASS_COPY(EmergeManager);
 
 	bool initMapgens(MapgenParams *mgparams);
 
@@ -144,7 +145,6 @@ public:
 	Mapgen *getCurrentMapgen();
 
 	// Mapgen helpers methods
-	Biome *getBiomeAtPoint(v3s16 p);
 	int getSpawnLevelAtPoint(v2s16 p);
 	int getGroundLevelAtPoint(v2s16 p);
 	bool isBlockUnderground(v3s16 blockpos);
@@ -178,8 +178,6 @@ private:
 	bool popBlockEmergeData(v3s16 pos, BlockEmergeData *bedata);
 
 	friend class EmergeThread;
-
-	DISABLE_CLASS_COPY(EmergeManager);
 };
 
 #endif

--- a/src/environment.h
+++ b/src/environment.h
@@ -49,6 +49,7 @@ public:
 	// Environment will delete the map passed to the constructor
 	Environment(IGameDef *gamedef);
 	virtual ~Environment();
+	DISABLE_CLASS_COPY(Environment);
 
 	/*
 		Step everything in environment.
@@ -121,8 +122,6 @@ protected:
 
 private:
 	std::mutex m_time_lock;
-
-	DISABLE_CLASS_COPY(Environment);
 };
 
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -142,11 +142,7 @@ public:
 
 	Map(std::ostream &dout, IGameDef *gamedef);
 	virtual ~Map();
-
-	/*virtual u16 nodeContainerId() const
-	{
-		return NODECONTAINER_ID_MAP;
-	}*/
+	DISABLE_CLASS_COPY(Map);
 
 	virtual s32 mapType() const
 	{
@@ -344,8 +340,6 @@ private:
 	u32 m_unprocessed_count;
 	u64 m_inc_trending_up_start_time; // milliseconds
 	bool m_queue_size_timer_started;
-
-	DISABLE_CLASS_COPY(Map);
 };
 
 /*

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -192,6 +192,7 @@ public:
 	Mapgen();
 	Mapgen(int mapgenid, MapgenParams *params, EmergeManager *emerge);
 	virtual ~Mapgen();
+	DISABLE_CLASS_COPY(Mapgen);
 
 	virtual MapgenType getType() const { return MAPGEN_INVALID; }
 
@@ -233,7 +234,6 @@ private:
 	// that checks whether there are floodable nodes without liquid beneath
 	// the node at index vi.
 	inline bool isLiquidHorizontallyFlowable(u32 vi, v3s16 em);
-	DISABLE_CLASS_COPY(Mapgen);
 };
 
 /*

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -59,6 +59,7 @@ class ObjDefManager {
 public:
 	ObjDefManager(IGameDef *gamedef, ObjDefType type);
 	virtual ~ObjDefManager();
+	DISABLE_CLASS_COPY(ObjDefManager);
 
 	virtual const char *getObjectTitle() const { return "ObjDef"; }
 
@@ -91,9 +92,6 @@ protected:
 	INodeDefManager *m_ndef;
 	std::vector<ObjDef *> m_objects;
 	ObjDefType m_objtype;
-
-private:
-	DISABLE_CLASS_COPY(ObjDefManager);
 };
 
 #endif

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <iostream>
 #include <string>
+#include "util/basic_macros.h"
 
 extern "C" {
 #include <lua.h>
@@ -66,6 +67,7 @@ class ScriptApiBase {
 public:
 	ScriptApiBase();
 	virtual ~ScriptApiBase();
+	DISABLE_CLASS_COPY(ScriptApiBase);
 
 	// These throw a ModError on failure
 	void loadMod(const std::string &script_path, const std::string &mod_name);

--- a/src/script/scripting_client.h
+++ b/src/script/scripting_client.h
@@ -24,7 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_client.h"
 #include "cpp_api/s_security.h"
-#include "util/basic_macros.h"
 
 class Client;
 class LocalPlayer;
@@ -41,6 +40,5 @@ public:
 
 private:
 	virtual void InitializeModApi(lua_State *L, int top);
-	DISABLE_CLASS_COPY(ClientScripting);
 };
 #endif

--- a/src/script/scripting_mainmenu.h
+++ b/src/script/scripting_mainmenu.h
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_mainmenu.h"
 #include "cpp_api/s_async.h"
-#include "util/basic_macros.h"
 
 /*****************************************************************************/
 /* Scripting <-> Main Menu Interface                                         */
@@ -47,7 +46,6 @@ private:
 	static void registerLuaClasses(lua_State *L, int top);
 
 	AsyncEngine asyncEngine;
-	DISABLE_CLASS_COPY(MainMenuScripting);
 };
 
 

--- a/src/script/scripting_server.h
+++ b/src/script/scripting_server.h
@@ -28,7 +28,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_server.h"
 #include "cpp_api/s_security.h"
-#include "util/basic_macros.h"
 
 /*****************************************************************************/
 /* Scripting <-> Server Game Interface                                       */
@@ -51,7 +50,6 @@ public:
 
 private:
 	void InitializeModApi(lua_State *L, int top);
-	DISABLE_CLASS_COPY(ServerScripting);
 };
 
 void log_deprecated(const std::string &message);

--- a/src/server.h
+++ b/src/server.h
@@ -155,6 +155,8 @@ public:
 		ChatInterface *iface = NULL
 	);
 	~Server();
+	DISABLE_CLASS_COPY(Server);
+
 	void start(Address bind_addr);
 	void stop();
 	// This is mainly a way to pass the time to the server.
@@ -671,8 +673,6 @@ private:
 
 	std::unordered_map<std::string, ModMetadata *> m_mod_storages;
 	float m_mod_storage_save_timer;
-
-	DISABLE_CLASS_COPY(Server);
 };
 
 /*

--- a/src/util/basic_macros.h
+++ b/src/util/basic_macros.h
@@ -33,9 +33,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // 'Foobar', add the macro DISABLE_CLASS_COPY(Foobar) as a private member.
 // Note this also disables copying for any classes derived from 'Foobar' as well
 // as classes having a 'Foobar' member.
-#define DISABLE_CLASS_COPY(C) \
-	C(const C &);             \
-	C &operator=(const C &)
+#define DISABLE_CLASS_COPY(C)        \
+	C(const C &) = delete;           \
+	C &operator=(const C &) = delete;
 
 #ifndef _MSC_VER
 	#define UNUSED_ATTRIBUTE __attribute__ ((unused))


### PR DESCRIPTION
C++11 implement function deleting, it's generally used to prevent some object copy
Remove DISABLE_CLASS_COPY (which needs to be private in C++03) and use proper C++11 copy/assignment function removal
In script API use this function removal on ScriptApiBase instead of ScriptApiClient/Server/MainMenu, this affect all ScriptApis