### PR TITLE
Order es_DrawType exactly like enum NodeDrawType in nodedef.h

### DIFF
--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 
 
+// Should be ordered exactly like enum NodeDrawType in nodedef.h
 struct EnumString ScriptApiNode::es_DrawType[] =
 	{
 		{NDT_NORMAL, "normal"},
@@ -34,17 +35,17 @@ struct EnumString ScriptApiNode::es_DrawType[] =
 		{NDT_LIQUID, "liquid"},
 		{NDT_FLOWINGLIQUID, "flowingliquid"},
 		{NDT_GLASSLIKE, "glasslike"},
-		{NDT_GLASSLIKE_FRAMED, "glasslike_framed"},
-		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
 		{NDT_ALLFACES, "allfaces"},
 		{NDT_ALLFACES_OPTIONAL, "allfaces_optional"},
 		{NDT_TORCHLIKE, "torchlike"},
 		{NDT_SIGNLIKE, "signlike"},
 		{NDT_PLANTLIKE, "plantlike"},
-		{NDT_FIRELIKE, "firelike"},
 		{NDT_FENCELIKE, "fencelike"},
 		{NDT_RAILLIKE, "raillike"},
 		{NDT_NODEBOX, "nodebox"},
+		{NDT_GLASSLIKE_FRAMED, "glasslike_framed"},
+		{NDT_FIRELIKE, "firelike"},
+		{NDT_GLASSLIKE_FRAMED_OPTIONAL, "glasslike_framed_optional"},
 		{NDT_MESH, "mesh"},
 		{0, NULL},
 	};


### PR DESCRIPTION
This will help to avoid some strange bugs.

Update: nerzhul asked me to give a more detailed description here:

In c_content.cpp the following line is used:
`std::string drawtype(ScriptApiNode::es_DrawType[(int)f.drawtype].str);`

But this only works, if es_DrawType is ordered in the same way as the enum NodeDrawType in nodedef.h

Another thing to consider is, that all other similiar things are also both equally ordered:

`enum ContentParamType` is ordered exactly like `EnumString ScriptApiNode::es_ContentParamType[]`
`enum ContentParamType2` is ordered exactly like `EnumString ScriptApiNode::es_ContentParamType2[]`
`enum LiquidType` is ordered exactly like `EnumString ScriptApiNode::es_LiquidType[]`
`enum NodeBoxType` is ordered exactly like `EnumString ScriptApiNode::es_NodeBoxType[]`
`enum NodeDrawType` is **not** ordered like `EnumString ScriptApiNode::es_NodeDrawType[]`

Until now, this mainly affects the CSM `get_node_def` function.