### PR TITLE
C++11 patchset 7: Use thread_local with static for some settings

### DIFF
--- a/src/drawscene.cpp
+++ b/src/drawscene.cpp
@@ -474,7 +474,7 @@ void draw_plain(Camera &camera, bool show_hud,
 	// Undersampling-specific stuff
 	static video::ITexture *image = NULL;
 	static v2u32 last_pixelated_size = v2u32(0, 0);
-	int undersampling = g_settings->getU16("undersampling");
+	static thread_local int undersampling = g_settings->getU16("undersampling");
 	v2u32 pixelated_size;
 	v2u32 dest_size;
 	if (undersampling > 0) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3638,7 +3638,7 @@ PointedThing Game::updatePointedThing(
 	std::vector<aabb3f> *selectionboxes = hud->getSelectionBoxes();
 	selectionboxes->clear();
 	hud->setSelectedFaceNormal(v3f(0.0, 0.0, 0.0));
-	static const bool show_entity_selectionbox = g_settings->getBool(
+	static thread_local const bool show_entity_selectionbox = g_settings->getBool(
 		"show_entity_selectionbox");
 
 	ClientMap &map = client->getEnv().getClientMap();
@@ -3981,7 +3981,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		bool is_valid_position;
 		MapNode wasnode = map.getNodeNoEx(nodepos, &is_valid_position);
 		if (is_valid_position) {
-			if (client->moddingEnabled() && 
+			if (client->moddingEnabled() &&
 			    		client->getScript()->on_dignode(nodepos, wasnode)) {
 				return;
 			}

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -639,7 +639,7 @@ void drawItemStack(video::IVideoDriver *driver,
 		ItemRotationKind rotation_kind)
 {
 	static MeshTimeInfo rotation_time_infos[IT_ROT_NONE];
-	static bool enable_animations =
+	static thread_local bool enable_animations =
 		g_settings->getBool("inventory_items_animations");
 
 	if (item.empty()) {

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -271,7 +271,7 @@ static u16 getSmoothLightCombined(v3s16 p, MeshMakeData *data)
 
 	if (ambient_occlusion > 4)
 	{
-		static const float ao_gamma = rangelim(
+		static thread_local const float ao_gamma = rangelim(
 			g_settings->getFloat("ambient_occlusion_gamma"), 0.25, 4.0);
 
 		// Table of gamma space multiply factors.

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1380,7 +1380,9 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		Check that target is reasonably close
 		(only when digging or placing things)
 	*/
-	static const bool enable_anticheat = !g_settings->getBool("disable_anticheat");
+	static thread_local const bool enable_anticheat =
+			!g_settings->getBool("disable_anticheat");
+
 	if ((action == 0 || action == 2 || action == 3 || action == 4) &&
 			(enable_anticheat && !isSingleplayer())) {
 		float d = player_pos.getDistanceFrom(pointed_pos_under);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -294,7 +294,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 {
 	m_time += dtime;
 
-	static const float radius =
+	static thread_local const float radius =
 			g_settings->getS16("max_block_send_distance") * MAP_BLOCKSIZE;
 
 	bool unloaded = false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -638,14 +638,15 @@ void Server::AsyncRunStep(bool initial_step)
 		ScopeProfiler sp(g_profiler, "Server: checking added and deleted objs");
 
 		// Radius inside which objects are active
-		static const s16 radius =
+		static thread_local const s16 radius =
 			g_settings->getS16("active_object_send_range_blocks") * MAP_BLOCKSIZE;
 
 		// Radius inside which players are active
-		static const bool is_transfer_limited =
+		static thread_local const bool is_transfer_limited =
 			g_settings->exists("unlimited_player_transfer_distance") &&
 			!g_settings->getBool("unlimited_player_transfer_distance");
-		static const s16 player_transfer_dist = g_settings->getS16("player_transfer_distance") * MAP_BLOCKSIZE;
+		static thread_local const s16 player_transfer_dist =
+			g_settings->getS16("player_transfer_distance") * MAP_BLOCKSIZE;
 		s16 player_radius = player_transfer_dist;
 		if (player_radius == 0 && is_transfer_limited)
 			player_radius = radius;
@@ -982,7 +983,7 @@ void Server::AsyncRunStep(bool initial_step)
 	{
 		float &counter = m_savemap_timer;
 		counter += dtime;
-		static const float save_interval =
+		static thread_local const float save_interval =
 			g_settings->getFloat("server_map_save_interval");
 		if (counter >= save_interval) {
 			counter = 0.0;
@@ -1684,7 +1685,7 @@ void Server::SendSpawnParticle(u16 peer_id, u16 protocol_version,
 				const struct TileAnimationParams &animation, u8 glow)
 {
 	DSTACK(FUNCTION_NAME);
-	static const float radius =
+	static thread_local const float radius =
 			g_settings->getS16("max_block_send_distance") * MAP_BLOCKSIZE * BS;
 
 	if (peer_id == PEER_ID_INEXISTENT) {
@@ -3674,8 +3675,9 @@ void dedicated_server_loop(Server &server, bool &kill)
 
 	IntervalLimiter m_profiler_interval;
 
-	static const float steplen = g_settings->getFloat("dedicated_server_step");
-	static const float profiler_print_interval =
+	static thread_local const float steplen =
+			g_settings->getFloat("dedicated_server_step");
+	static thread_local const float profiler_print_interval =
 			g_settings->getFloat("profiler_print_interval");
 
 	for(;;) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1168,7 +1168,8 @@ void ServerEnvironment::step(float dtime)
 	// Update this one
 	// NOTE: This is kind of funny on a singleplayer game, but doesn't
 	// really matter that much.
-	static const float server_step = g_settings->getFloat("dedicated_server_step");
+	static thread_local const float server_step =
+			g_settings->getFloat("dedicated_server_step");
 	m_recommended_send_interval = server_step;
 
 	/*
@@ -1229,7 +1230,8 @@ void ServerEnvironment::step(float dtime)
 		/*
 			Update list of active blocks, collecting changes
 		*/
-		static const s16 active_block_range = g_settings->getS16("active_block_range");
+		static thread_local const s16 active_block_range =
+				g_settings->getS16("active_block_range");
 		std::set<v3s16> blocks_removed;
 		std::set<v3s16> blocks_added;
 		m_active_blocks.update(players_blockpos, active_block_range,


### PR DESCRIPTION
thread_local is a "static for thread lifetime" to schematize. Use it on each setting place which uses static to cache variable result. This permits to keep the same performance level & reconfigure server from MT gui in those various variables places.

Add thread_local to undersampling calculation too.