### PR TITLE
C++11 patchset 8: C++11 random generators

### DIFF
--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -20,26 +20,23 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "socket.h" // for select()
 #include "porting.h" // for sleep_ms(), get_sysinfo(), secure_rand_fill_buf()
 #include "httpfetch.h"
-#include <iostream>
-#include <sstream>
 #include <list>
 #include <map>
 #include <errno.h>
 #include <mutex>
+#include <random>
 #include "threading/event.h"
 #include "config.h"
-#include "exceptions.h"
 #include "debug.h"
 #include "log.h"
 #include "util/container.h"
 #include "util/thread.h"
 #include "version.h"
 #include "settings.h"
-#include "noise.h"
 
 std::mutex g_httpfetch_mutex;
 std::map<unsigned long, std::queue<HTTPFetchResult> > g_httpfetch_results;
-PcgRandom g_callerid_randomness;
+std::mt19937 g_callerid_randomness(std::time(NULL));
 
 HTTPFetchRequest::HTTPFetchRequest() :
 	url(""),
@@ -97,8 +94,8 @@ unsigned long httpfetch_caller_alloc_secure()
 	unsigned long caller;
 
 	do {
-		caller = (((u64) g_callerid_randomness.next()) << 32) |
-				g_callerid_randomness.next();
+		caller = (((u64) g_callerid_randomness()) << 32) |
+				g_callerid_randomness();
 
 		if (--tries < 1) {
 			FATAL_ERROR("httpfetch_caller_alloc_secure: ran out of caller IDs");
@@ -743,9 +740,7 @@ void httpfetch_init(int parallel_limit)
 	g_httpfetch_thread = new CurlFetchThread(parallel_limit);
 
 	// Initialize g_callerid_randomness for httpfetch_caller_alloc_secure
-	u64 randbuf[2];
-	porting::secure_rand_fill_buf(randbuf, sizeof(u64) * 2);
-	g_callerid_randomness = PcgRandom(randbuf[0], randbuf[1]);
+	g_callerid_randomness = std::mt19937(time(0));
 }
 
 void httpfetch_cleanup()

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1011,8 +1011,9 @@ void MapgenParams::readParams(const Settings *settings)
 	if (settings->getNoEx(seed_name, seed_str)) {
 		if (!seed_str.empty())
 			seed = read_seed(seed_str.c_str());
-		else
-			myrand_bytes(&seed, sizeof(seed));
+		else {
+			seed = myrand() | (myrand() << sizeof(s32));
+		}
 	}
 
 	std::string mg_name;

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -238,7 +238,8 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	// Generate noise maps and base terrain height.
 	// Modify heat and humidity maps.
 	calculateNoise();
-
+std::mt19937 gen;
+	gen();
 	// Generate base terrain with initial heightmaps
 	s16 stone_surface_max_y = generateTerrain();
 

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -22,13 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MG_DECORATION_HEADER
 
 #include <unordered_set>
+#include <random>
 #include "objdef.h"
 #include "noise.h"
 #include "nodedef.h"
 
 class Mapgen;
 class MMVManip;
-class PcgRandom;
 class Schematic;
 
 enum DecorationType {
@@ -46,22 +46,6 @@ enum DecorationType {
 
 extern FlagDesc flagdesc_deco[];
 
-
-#if 0
-struct CutoffData {
-	VoxelArea a;
-	Decoration *deco;
-	//v3s16 p;
-	//v3s16 size;
-	//s16 height;
-
-	CutoffData(s16 x, s16 y, s16 z, s16 h) {
-		p = v3s16(x, y, z);
-		height = h;
-	}
-};
-#endif
-
 class Decoration : public ObjDef, public NodeResolver {
 public:
 	Decoration();
@@ -73,7 +57,7 @@ public:
 	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	//size_t placeCutoffs(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p) = 0;
+	virtual size_t generate(MMVManip *vm, std::mt19937 &pr, v3s16 p) = 0;
 	virtual int getHeight() = 0;
 
 	u32 flags;
@@ -93,7 +77,7 @@ public:
 class DecoSimple : public Decoration {
 public:
 	virtual void resolveNodeNames();
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p);
+	virtual size_t generate(MMVManip *vm, std::mt19937 &pr, v3s16 p);
 	virtual int getHeight();
 
 	std::vector<content_t> c_decos;
@@ -106,7 +90,7 @@ class DecoSchematic : public Decoration {
 public:
 	DecoSchematic();
 
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p);
+	virtual size_t generate(MMVManip *vm, std::mt19937 &pr, v3s16 p);
 	virtual int getHeight();
 
 	Rotation rotation;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -134,27 +134,6 @@ s32 PcgRandom::range(s32 min, s32 max)
 	return range(bound) + min;
 }
 
-
-void PcgRandom::bytes(void *out, size_t len)
-{
-	u8 *outb = (u8 *)out;
-	int bytes_left = 0;
-	u32 r;
-
-	while (len--) {
-		if (bytes_left == 0) {
-			bytes_left = sizeof(u32);
-			r = next();
-		}
-
-		*outb = r & 0xFF;
-		outb++;
-		bytes_left--;
-		r >>= CHAR_BIT;
-	}
-}
-
-
 s32 PcgRandom::randNormalDist(s32 min, s32 max, int num_trials)
 {
 	s32 accum = 0;

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -60,90 +60,6 @@ FlagDesc flagdesc_noiseparams[] = {
 	{NULL,          0}
 };
 
-///////////////////////////////////////////////////////////////////////////////
-
-PcgRandom::PcgRandom(u64 state, u64 seq)
-{
-	seed(state, seq);
-}
-
-void PcgRandom::seed(u64 state, u64 seq)
-{
-	m_state = 0U;
-	m_inc = (seq << 1u) | 1u;
-	next();
-	m_state += state;
-	next();
-}
-
-
-u32 PcgRandom::next()
-{
-	u64 oldstate = m_state;
-	m_state = oldstate * 6364136223846793005ULL + m_inc;
-
-	u32 xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
-	u32 rot = oldstate >> 59u;
-	return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
-}
-
-
-u32 PcgRandom::range(u32 bound)
-{
-	// If the bound is 0, we cover the whole RNG's range
-	if (bound == 0)
-		return next();
-
-	/*
-		This is an optimization of the expression:
-		  0x100000000ull % bound
-		since 64-bit modulo operations typically much slower than 32.
-	*/
-	u32 threshold = -bound % bound;
-	u32 r;
-
-	/*
-		If the bound is not a multiple of the RNG's range, it may cause bias,
-		e.g. a RNG has a range from 0 to 3 and we take want a number 0 to 2.
-		Using rand() % 3, the number 0 would be twice as likely to appear.
-		With a very large RNG range, the effect becomes less prevalent but
-		still present.
-
-		This can be solved by modifying the range of the RNG to become a
-		multiple of bound by dropping values above the a threshold.
-
-		In our example, threshold == 4 % 3 == 1, so reject values < 1
-		(that is, 0), thus making the range == 3 with no bias.
-
-		This loop may look dangerous, but will always terminate due to the
-		RNG's property of uniformity.
-	*/
-	while ((r = next()) < threshold)
-		;
-
-	return r % bound;
-}
-
-
-s32 PcgRandom::range(s32 min, s32 max)
-{
-	if (max < min)
-		throw PrngException("Invalid range (max < min)");
-
-	u32 bound = max - min + 1;
-	return range(bound) + min;
-}
-
-s32 PcgRandom::randNormalDist(s32 min, s32 max, int num_trials)
-{
-	s32 accum = 0;
-	for (int i = 0; i != num_trials; i++)
-		accum += range(min, max);
-	return myround((float)accum / num_trials);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
 float noise2d(int x, int y, s32 seed)
 {
 	unsigned int n = (NOISE_MAGIC_X * x + NOISE_MAGIC_Y * y
@@ -162,13 +78,6 @@ float noise3d(int x, int y, int z, s32 seed)
 	n = (n * (n * n * 60493 + 19990303) + 1376312589) & 0x7fffffff;
 	return 1.f - (float)(int)n / 0x40000000;
 }
-
-
-inline float dotProduct(float vx, float vy, float wx, float wy)
-{
-	return vx * wx + vy * wy;
-}
-
 
 inline float linearInterpolation(float v0, float v1, float t)
 {

--- a/src/noise.h
+++ b/src/noise.h
@@ -74,24 +74,6 @@ private:
 	int m_next;
 };
 
-class PcgRandom {
-public:
-	const static s32 RANDOM_MIN   = -0x7fffffff - 1;
-	const static s32 RANDOM_MAX   = 0x7fffffff;
-	const static u32 RANDOM_RANGE = 0xffffffff;
-
-	PcgRandom(u64 state=0x853c49e6748fea9bULL, u64 seq=0xda3e39cb94b95bdbULL);
-	void seed(u64 state, u64 seq=0xda3e39cb94b95bdbULL);
-	u32 next();
-	u32 range(u32 bound);
-	s32 range(s32 min, s32 max);
-	s32 randNormalDist(s32 min, s32 max, int num_trials=6);
-
-private:
-	u64 m_state;
-	u64 m_inc;
-};
-
 #define NOISE_FLAG_DEFAULTS    0x01
 #define NOISE_FLAG_EASED       0x02
 #define NOISE_FLAG_ABSVALUE    0x04

--- a/src/noise.h
+++ b/src/noise.h
@@ -85,7 +85,6 @@ public:
 	u32 next();
 	u32 range(u32 bound);
 	s32 range(s32 min, s32 max);
-	void bytes(void *out, size_t len);
 	s32 randNormalDist(s32 min, s32 max, int num_trials=6);
 
 private:

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -513,10 +513,11 @@ int LuaPcgRandom::l_next(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaPcgRandom *o = checkobject(L, 1);
-	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
-	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
+	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.min();
+	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.max();
 
-	lua_pushinteger(L, o->m_rnd.range(min, max));
+	std::uniform_int_distribution<u32> rndRange(min, max);
+	lua_pushinteger(L, rndRange(o->m_rnd));
 	return 1;
 }
 
@@ -526,11 +527,18 @@ int LuaPcgRandom::l_rand_normal_dist(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaPcgRandom *o = checkobject(L, 1);
-	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.RANDOM_MIN;
-	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.RANDOM_MAX;
+	u32 min = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : o->m_rnd.min();
+	u32 max = lua_isnumber(L, 3) ? lua_tointeger(L, 3) : o->m_rnd.max();
 	int num_trials = lua_isnumber(L, 4) ? lua_tointeger(L, 4) : 6;
 
-	lua_pushinteger(L, o->m_rnd.randNormalDist(min, max, num_trials));
+	std::uniform_int_distribution<u32> rndRange(min, max);
+	u32 result = 0;
+	do {
+		result = rndRange(o->m_rnd);
+	}
+	while (num_trials-- > 0);
+
+	lua_pushinteger(L, result);
 	return 1;
 }
 

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef L_NOISE_H_
 #define L_NOISE_H_
 
+#include <random>
 #include "irr_v3d.h"
 #include "lua_api/l_base.h"
 #include "noise.h"
@@ -131,7 +132,7 @@ public:
 class LuaPcgRandom : public ModApiBase
 {
 private:
-	PcgRandom m_rnd;
+	std::mt19937 m_rnd;
 
 	static const char className[];
 	static const luaL_Reg methods[];
@@ -150,7 +151,8 @@ private:
 
 public:
 	LuaPcgRandom(u64 seed) : m_rnd(seed) {}
-	LuaPcgRandom(u64 seed, u64 seq) : m_rnd(seed, seq) {}
+	// @TODO: set seq
+	LuaPcgRandom(u64 seed, u64 seq) : m_rnd(seed) {}
 
 	// LuaPcgRandom(seed)
 	// Creates an LuaPcgRandom and leaves it on top of stack

--- a/src/unittest/test_areastore.cpp
+++ b/src/unittest/test_areastore.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 
+#include <sstream>
 #include "util/areastore.h"
 
 class TestAreaStore : public TestBase {

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -34,7 +34,6 @@ public:
 	void testPseudoRandomRange();
 	void testPcgRandom();
 	void testPcgRandomRange();
-	void testPcgRandomBytes();
 	void testPcgRandomNormalDist();
 
 	static const int expected_pseudorandom_results[256];
@@ -51,7 +50,6 @@ void TestRandom::runTests(IGameDef *gamedef)
 	TEST(testPseudoRandomRange);
 	TEST(testPcgRandom);
 	TEST(testPcgRandomRange);
-	TEST(testPcgRandomBytes);
 	TEST(testPcgRandomNormalDist);
 }
 
@@ -114,23 +112,6 @@ void TestRandom::testPcgRandomRange()
 		UASSERT(randval >= min);
 		UASSERT(randval <= max);
 	}
-}
-
-
-void TestRandom::testPcgRandomBytes()
-{
-	char buf[32];
-	PcgRandom r(1538, 877);
-
-	memset(buf, 0, sizeof(buf));
-	r.bytes(buf + 5, 23);
-	UASSERT(memcmp(buf + 5, expected_pcgrandom_bytes_result,
-		sizeof(expected_pcgrandom_bytes_result)) == 0);
-
-	memset(buf, 0, sizeof(buf));
-	r.bytes(buf, 17);
-	UASSERT(memcmp(buf, expected_pcgrandom_bytes_result2,
-		sizeof(expected_pcgrandom_bytes_result2)) == 0);
 }
 
 

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -32,14 +32,8 @@ public:
 
 	void testPseudoRandom();
 	void testPseudoRandomRange();
-	void testPcgRandom();
-	void testPcgRandomRange();
-	void testPcgRandomNormalDist();
 
 	static const int expected_pseudorandom_results[256];
-	static const u32 expected_pcgrandom_results[256];
-	static const u8 expected_pcgrandom_bytes_result[24];
-	static const u8 expected_pcgrandom_bytes_result2[24];
 };
 
 static TestRandom g_test_instance;
@@ -48,9 +42,6 @@ void TestRandom::runTests(IGameDef *gamedef)
 {
 	TEST(testPseudoRandom);
 	TEST(testPseudoRandomRange);
-	TEST(testPcgRandom);
-	TEST(testPcgRandomRange);
-	TEST(testPcgRandomNormalDist);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,89 +74,6 @@ void TestRandom::testPseudoRandomRange()
 	}
 }
 
-
-void TestRandom::testPcgRandom()
-{
-	PcgRandom pr(814538, 998877);
-
-	for (u32 i = 0; i != 256; i++)
-		UASSERTEQ(u32, pr.next(), expected_pcgrandom_results[i]);
-}
-
-
-void TestRandom::testPcgRandomRange()
-{
-	PcgRandom pr((int)time(NULL));
-
-	EXCEPTION_CHECK(PrngException, pr.range(5, 1));
-
-	// Regression test for bug 3027
-	pr.range(pr.RANDOM_MIN, pr.RANDOM_MAX);
-
-	for (u32 i = 0; i != 32768; i++) {
-		int min = (pr.next() % 3000) - 500;
-		int max = (pr.next() % 3000) - 500;
-		if (min > max)
-			SWAP(int, min, max);
-
-		int randval = pr.range(min, max);
-		UASSERT(randval >= min);
-		UASSERT(randval <= max);
-	}
-}
-
-
-void TestRandom::testPcgRandomNormalDist()
-{
-	static const int max = 120;
-	static const int min = -120;
-	static const int num_trials = 20;
-	static const u32 num_samples = 61000;
-	s32 bins[max - min + 1];
-	memset(bins, 0, sizeof(bins));
-
-	PcgRandom r(486179 + (int)time(NULL));
-
-	for (u32 i = 0; i != num_samples; i++) {
-		s32 randval = r.randNormalDist(min, max, num_trials);
-		UASSERT(randval <= max);
-		UASSERT(randval >= min);
-		bins[randval - min]++;
-	}
-
-	// Note that here we divide variance by the number of trials;
-	// this is because variance is a biased estimator.
-	int range      = (max - min + 1);
-	float mean     = (max + min) / 2;
-	float variance = ((range * range - 1) / 12) / num_trials;
-	float stddev   = sqrt(variance);
-
-	static const float prediction_intervals[] = {
-		0.68269f, // 1.0
-		0.86639f, // 1.5
-		0.95450f, // 2.0
-		0.98758f, // 2.5
-		0.99730f, // 3.0
-	};
-
-	//// Simple normality test using the 68-95-99.7% rule
-	for (u32 i = 0; i != ARRLEN(prediction_intervals); i++) {
-		float deviations = i / 2.f + 1.f;
-		int lbound = myround(mean - deviations * stddev);
-		int ubound = myround(mean + deviations * stddev);
-		UASSERT(lbound >= min);
-		UASSERT(ubound <= max);
-
-		int accum = 0;
-		for (int j = lbound; j != ubound; j++)
-			accum += bins[j - min];
-
-		float actual = (float)accum / num_samples;
-		UASSERT(fabs(actual - prediction_intervals[i]) < 0.02);
-	}
-}
-
-
 const int TestRandom::expected_pseudorandom_results[256] = {
 	0x02fa, 0x60d5, 0x6c10, 0x606b, 0x098b, 0x5f1e, 0x4f56, 0x3fbd, 0x77af,
 	0x4fe9, 0x419a, 0x6fe1, 0x177b, 0x6858, 0x36f8, 0x6d83, 0x14fc, 0x2d62,
@@ -196,60 +104,4 @@ const int TestRandom::expected_pseudorandom_results[256] = {
 	0x140e, 0x613d, 0x1193, 0x268d, 0x1e2f, 0x3123, 0x6d61, 0x4e0b, 0x51ce,
 	0x13bf, 0x58d4, 0x4f43, 0x05c6, 0x4d6a, 0x7eb5, 0x2921, 0x2c36, 0x1c89,
 	0x63b9, 0x1555, 0x1f41, 0x2d9f,
-};
-
-const u32 TestRandom::expected_pcgrandom_results[256] = {
-	0x48c593f8, 0x054f59f5, 0x0d062dc1, 0x23852a23, 0x7fbbc97b, 0x1f9f141e,
-	0x364e6ed8, 0x995bba58, 0xc9307dc0, 0x73fb34c4, 0xcd8de88d, 0x52e8ce08,
-	0x1c4a78e4, 0x25c0882e, 0x8a82e2e0, 0xe3bc3311, 0xb8068d42, 0x73186110,
-	0x19988df4, 0x69bd970b, 0x7214728c, 0x0aee320c, 0x2a5a536c, 0xaf48d715,
-	0x00bce504, 0xd2b8f548, 0x520df366, 0x96d8fff5, 0xa1bb510b, 0x63477049,
-	0xb85990b7, 0x7e090689, 0x275fb468, 0x50206257, 0x8bab4f8a, 0x0d6823db,
-	0x63faeaac, 0x2d92deeb, 0x2ba78024, 0x0d30f631, 0x338923a0, 0xd07248d8,
-	0xa5db62d3, 0xddba8af6, 0x0ad454e9, 0x6f0fd13a, 0xbbfde2bf, 0x91188009,
-	0x966b394d, 0xbb9d2012, 0x7e6926cb, 0x95183860, 0x5ff4c59b, 0x035f628a,
-	0xb67085ef, 0x33867e23, 0x68d1b887, 0x2e3298d7, 0x84fd0650, 0x8bc91141,
-	0x6fcb0452, 0x2836fee9, 0x2e83c0a3, 0xf1bafdc5, 0x9ff77777, 0xfdfbba87,
-	0x527aebeb, 0x423e5248, 0xd1756490, 0xe41148fa, 0x3361f7b4, 0xa2824f23,
-	0xf4e08072, 0xc50442be, 0x35adcc21, 0x36be153c, 0xc7709012, 0xf0eeb9f2,
-	0x3d73114e, 0x1c1574ee, 0x92095b9c, 0x1503d01c, 0xd6ce0677, 0x026a8ec1,
-	0x76d0084d, 0x86c23633, 0x36f75ce6, 0x08fa7bbe, 0x35f6ff2a, 0x31cc9525,
-	0x2c1a35e6, 0x8effcd62, 0xc782fa07, 0x8a86e248, 0x8fdb7a9b, 0x77246626,
-	0x5767723f, 0x3a78b699, 0xe548ce1c, 0x5820f37d, 0x148ed9b8, 0xf6796254,
-	0x32232c20, 0x392bf3a2, 0xe9af6625, 0xd40b0d88, 0x636cfa23, 0x6a5de514,
-	0xc4a69183, 0xc785c853, 0xab0de901, 0x16ae7e44, 0x376f13b5, 0x070f7f31,
-	0x34cbc93b, 0xe6184345, 0x1b7f911f, 0x631fbe4b, 0x86d6e023, 0xc689b518,
-	0x88ef4f7c, 0xddf06b45, 0xc97f18d4, 0x2aaee94b, 0x45694723, 0x6db111d2,
-	0x91974fce, 0xe33e29e2, 0xc5e99494, 0x8017e02b, 0x3ebd8143, 0x471ffb80,
-	0xc0d7ca1b, 0x4954c860, 0x48935d6a, 0xf2d27999, 0xb93d608d, 0x40696e90,
-	0x60b18162, 0x1a156998, 0x09b8bbab, 0xc80a79b6, 0x8adbcfbc, 0xc375248c,
-	0xa584e2ea, 0x5b46fe11, 0x58e84680, 0x8a8bc456, 0xd668b94f, 0x8b9035be,
-	0x278509d4, 0x6663a140, 0x81a9817a, 0xd4f9d3cf, 0x6dc5f607, 0x6ae04450,
-	0x694f22a4, 0x1d061788, 0x2e39ad8b, 0x748f4db2, 0xee569b52, 0xd157166d,
-	0xdabc161e, 0xc8d50176, 0x7e3110e5, 0x9f7d033b, 0x128df67f, 0xb0078583,
-	0xa3a75d26, 0xc1ad8011, 0x07dd89ec, 0xef04f456, 0x91bf866c, 0x6aac5306,
-	0xdd5a1573, 0xf73ff97a, 0x4e1186ad, 0xb9680680, 0xc8894515, 0xdc95a08e,
-	0xc894fd8e, 0xf84ade15, 0xd787f8c1, 0x40dcecca, 0x1b24743e, 0x1ce6ab23,
-	0x72321653, 0xb80fbaf7, 0x1bcf099b, 0x1ff26805, 0x78f66c8e, 0xf93bf51a,
-	0xfb0c06fe, 0xe50d48cf, 0x310947e0, 0x1b78804a, 0xe73e2c14, 0x8deb8381,
-	0xe576122a, 0xe5a8df39, 0x42397c5e, 0xf5503f3c, 0xbe3dbf8d, 0x1b360e5c,
-	0x9254caaf, 0x7a9f6744, 0x6d4144fa, 0xd77c65fe, 0x44ca7b12, 0xf58a4c00,
-	0x159500d0, 0x92769857, 0x7134fdd4, 0xa3fea693, 0xbd044831, 0xeded39a1,
-	0xe4570204, 0xaea37f2f, 0x9a302971, 0x620f8402, 0x1d2f3e5e, 0xf9c2f49c,
-	0x738e813a, 0xb3c92251, 0x7ecba63b, 0xbe7eebc7, 0xf800267c, 0x3fdeb760,
-	0xf12d5e7d, 0x5a18dce1, 0xb35a539c, 0xe565f057, 0x2babf38c, 0xae5800ad,
-	0x421004dd, 0x6715acb6, 0xff529b64, 0xd520d207, 0x7cb193e7, 0xe9b18e4c,
-	0xfd2a8a59, 0x47826ae3, 0x56ba43f8, 0x453b3d99, 0x8ae1675f, 0xf66f5c34,
-	0x057a6ac1, 0x010769e4, 0xa8324158, 0x410379a5, 0x5dfc8c97, 0x72848afe,
-	0x59f169e5, 0xe32acb78, 0x5dfaa9c4, 0x51bb956a,
-};
-
-const u8 TestRandom::expected_pcgrandom_bytes_result[24] = {
-	0xf3, 0x79, 0x8f, 0x31, 0xac, 0xd9, 0x34, 0xf8, 0x3c, 0x6e, 0x82, 0x37,
-	0x6b, 0x4b, 0x77, 0xe3, 0xbd, 0x0a, 0xee, 0x22, 0x79, 0x6e, 0x40, 0x00,
-};
-
-const u8 TestRandom::expected_pcgrandom_bytes_result2[24] = {
-	0x47, 0x9e, 0x08, 0x3e, 0xd4, 0x21, 0x2d, 0xf6, 0xb4, 0xb1, 0x9d, 0x7a,
-	0x60, 0x02, 0x5a, 0xb2, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };

--- a/src/util/areastore.h
+++ b/src/util/areastore.h
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define AREA_STORE_H_
 
 #include "irr_v3d.h"
-#include "noise.h" // for PcgRandom
 #include <map>
 #include <list>
 #include <vector>

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -20,8 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "numeric.h"
 
 #include <random>
+#include <ctime>
+#include <cstring>
 #include "../constants.h" // BS, MAP_BLOCKSIZE
-#include "../noise.h" // PseudoRandom, PcgRandom
 
 
 // myrand

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -19,35 +19,29 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "numeric.h"
 
-#include "log.h"
+#include <random>
 #include "../constants.h" // BS, MAP_BLOCKSIZE
 #include "../noise.h" // PseudoRandom, PcgRandom
-#include "../threading/mutex_auto_lock.h"
-#include <string.h>
 
 
 // myrand
 
-PcgRandom g_pcgrand;
+std::mt19937 g_random(std::time(NULL));
 
 u32 myrand()
 {
-	return g_pcgrand.next();
+	return g_random();
 }
 
 void mysrand(unsigned int seed)
 {
-	g_pcgrand.seed(seed);
-}
-
-void myrand_bytes(void *out, size_t len)
-{
-	g_pcgrand.bytes(out, len);
+	g_random.seed(seed);
 }
 
 int myrand_range(int min, int max)
 {
-	return g_pcgrand.range(min, max);
+	std::uniform_int_distribution<int> rnd(min, max);
+	return rnd(g_random);
 }
 
 


### PR DESCRIPTION
C++11 offer very nice randomness interfaces which are better than our legacy code in terms of randomness entropy.

Replace PcgRandom with C++11 mt15537 + std::uniform_int_distribution/std::uniform_random_distribution in all our code

Also removed 3 years old disabled placecutoff code