### PR TITLE
Mgv6 mudflow: Avoid floating stacked decorations

### DIFF
--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -886,35 +886,43 @@ void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 					vm->m_area.add_y(em, i2, 1);
 					n2 = &vm->m_data[i2];
 
-					// Move mud to new place
-					if (!dropped_to_unknown) {
-						*n2 = *n;
-						// Set old place to be air (or water)
-						*n = MapNode(CONTENT_AIR);
-						// Upper (n3) is not walkable or is NULL. If it is
-						// not NULL and not air it is a decoration that
-						// needs removing, to avoid unsupported decorations.
-						// This only happens outside the mapchunk.
-						if ((p2d.X > node_max.X || p2d.X < node_min.X ||
-								p2d.Y > node_max.Z || p2d.Y < node_min.Z) &&
-								n3 && n3->getContent() != CONTENT_AIR) {
-							*n3 = MapNode(CONTENT_AIR);
-							// Check above for a stacked decoration
-							u32 i4 = i3;
-							vm->m_area.add_y(em, i4, 1);
-							while (vm->m_area.contains(i4) &&
-									vm->m_data[i4].getContent() != CONTENT_AIR) {
-								vm->m_data[i4] = MapNode(CONTENT_AIR);
-								vm->m_area.add_y(em, i4, 1);
-							}
-						}
-					}
+					// Move mud to new place. Outside mapchunk
+					// remove any decorations above removed mud.
+					if (!dropped_to_unknown)
+						moveMud(n, n2, n3, p2d, i3, em);
 
 					// Done
 					break;
 				}
 			}
 			}
+		}
+	}
+}
+
+
+void MapgenV6::moveMud(MapNode *n, MapNode *n2, MapNode *n3,
+	v2s16 p2d, u32 i3, v3s16 em)
+{
+	// Move mud to new place
+	*n2 = *n;
+	// Set old place to be air
+	*n = MapNode(CONTENT_AIR);
+	// Upper (n3) is not walkable or is NULL. If it is
+	// not NULL and not air it is a decoration that
+	// needs removing to avoid unsupported decorations.
+	// This only happens outside the mapchunk.
+	if ((p2d.X > node_max.X || p2d.X < node_min.X ||
+			p2d.Y > node_max.Z || p2d.Y < node_min.Z) &&
+			n3 && n3->getContent() != CONTENT_AIR) {
+		*n3 = MapNode(CONTENT_AIR);
+		// Check above for a stacked decoration and remove nodes
+		u32 i4 = i3;
+		vm->m_area.add_y(em, i4, 1);
+		while (vm->m_area.contains(i4) &&
+				vm->m_data[i4].getContent() != CONTENT_AIR) {
+			vm->m_data[i4] = MapNode(CONTENT_AIR);
+			vm->m_area.add_y(em, i4, 1);
 		}
 	}
 }

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -886,22 +886,27 @@ void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 					vm->m_area.add_y(em, i2, 1);
 					n2 = &vm->m_data[i2];
 
-					bool old_is_water = (n->getContent() == c_water_source);
 					// Move mud to new place
 					if (!dropped_to_unknown) {
 						*n2 = *n;
 						// Set old place to be air (or water)
-						if (old_is_water) {
-							*n = MapNode(c_water_source);
-						} else {
-							*n = MapNode(CONTENT_AIR);
-							// Upper (n3) is not walkable or is NULL. If it is
-							// not NULL and not air and not water it is a
-							// decoration that needs removing, to avoid
-							// unsupported decorations.
-							if (n3 && n3->getContent() != CONTENT_AIR &&
-									n3->getContent() != c_water_source)
-								*n3 = MapNode(CONTENT_AIR);
+						*n = MapNode(CONTENT_AIR);
+						// Upper (n3) is not walkable or is NULL. If it is
+						// not NULL and not air it is a decoration that
+						// needs removing, to avoid unsupported decorations.
+						// This only happens outside the mapchunk.
+						if ((p2d.X > node_max.X || p2d.X < node_min.X ||
+								p2d.Y > node_max.Z || p2d.Y < node_min.Z) &&
+								n3 && n3->getContent() != CONTENT_AIR) {
+							*n3 = MapNode(CONTENT_AIR);
+							// Check above for a stacked decoration
+							u32 i4 = i3;
+							vm->m_area.add_y(em, i4, 1);
+							while (vm->m_area.contains(i4) &&
+									vm->m_data[i4].getContent() != CONTENT_AIR) {
+								vm->m_data[i4] = MapNode(CONTENT_AIR);
+								vm->m_area.add_y(em, i4, 1);
+							}
 						}
 					}
 

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -162,6 +162,8 @@ public:
 	int generateGround();
 	void addMud();
 	void flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos);
+	void moveMud(MapNode *n, MapNode *n2, MapNode *n3,
+			v2s16 p2d, u32 i3, v3s16 em);
 	void growGrass();
 	void placeTreesAndJungleGrass();
 	virtual void generateCaves(int max_stone_y);

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -162,8 +162,8 @@ public:
 	int generateGround();
 	void addMud();
 	void flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos);
-	void moveMud(MapNode *n, MapNode *n2, MapNode *n3,
-			v2s16 p2d, u32 i3, v3s16 em);
+	void moveMud(u32 remove_index, u32 place_index,
+		u32 above_remove_index, v2s16 pos, v3s16 em);
 	void growGrass();
 	void placeTreesAndJungleGrass();
 	virtual void generateCaves(int max_stone_y);


### PR DESCRIPTION
Recently we started to remove decorations if the dirt below was flowed away,
but this did not check for stacked decorations, causing them to have only
their lowest node removed.

Remove nodes above a removed decoration until air is found.

Also remove 'old_is_water' bool which on testing is never true.
///////////////
Mgv6 mudflow: Add function to reduce indentation 
//////////////
 Mgv6 mudflow: Remove stacked decorations half-buried in placed mud.
Improve 'moveMud()' code and use index arguments instead of pointers.
//////////////

Fixes #5952 
Tested.

Since removing decorations above flowed and placed mud is only needed outside the mapchunk i have added conditions to only check outside, improving performace and so compensating for the checks for tall decorations.
'old_is_water' was a coding mistake, that bool is never true, so removed that check and action.

Mudflow comparison with master, to check unchanged behaviour:

![68747470733a2f2f692e696d6775722e636f6d2f5759726a5053662e6a7067](https://user-images.githubusercontent.com/3686677/27110133-04859562-509f-11e7-99c8-fb9e0ba0f979.jpeg)

^ Master

![screenshot_20170614_011325](https://user-images.githubusercontent.com/3686677/27110150-1cfca82e-509f-11e7-8264-7ff86941b6ac.png)

^ This PR