### PR TITLE
LuaEntity: Depend collision on entity size

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -88,10 +88,6 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
 		}
-		else if(relbox.MinEdge.X > xsize)
-		{
-			return -1;
-		}
 	}
 	else if(speed.X < 0) // Check for collision with X+ plane
 	{
@@ -102,10 +98,6 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
-		}
-		else if(relbox.MaxEdge.X < 0)
-		{
-			return -1;
 		}
 	}
 
@@ -121,10 +113,6 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
 		}
-		else if(relbox.MinEdge.Y > ysize)
-		{
-			return -1;
-		}
 	}
 	else if(speed.Y < 0) // Check for collision with Y+ plane
 	{
@@ -135,10 +123,6 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
-		}
-		else if(relbox.MaxEdge.Y < 0)
-		{
-			return -1;
 		}
 	}
 
@@ -154,10 +138,6 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
-		//else if(relbox.MinEdge.Z > zsize)
-		//{
-		//	return -1;
-		//}
 	}
 	else if(speed.Z < 0) // Check for collision with Z+ plane
 	{
@@ -169,10 +149,6 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
-		//else if(relbox.MaxEdge.Z < 0)
-		//{
-		//	return -1;
-		//}
 	}
 
 	return -1;

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1153,22 +1153,21 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 	} else {
 		v3f lastpos = pos_translator.vect_show;
 
-		if(m_prop.physical)
-		{
+		if (m_prop.physical) {
 			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
+
+			v3f extent = box.getExtent();
+			// Calculate the maximum distance per iteration, apply limits
+			f32 pos_max_d = MYMIN(extent.X, MYMIN(extent.Y, extent.Z));
+			pos_max_d = rangelim(pos_max_d / 2, 0.05 * BS, 0.25 * BS);
+
 			collisionMoveResult moveresult;
-			f32 pos_max_d = BS*0.125; // Distance per iteration
-			v3f p_pos = m_position;
-			v3f p_velocity = m_velocity;
-			moveresult = collisionMoveSimple(env,env->getGameDef(),
+			moveresult = collisionMoveSimple(env, env->getGameDef(),
 					pos_max_d, box, m_prop.stepheight, dtime,
-					&p_pos, &p_velocity, m_acceleration,
+					&m_position, &m_velocity, m_acceleration,
 					this, m_prop.collideWithObjects);
-			// Apply results
-			m_position = p_pos;
-			m_velocity = p_velocity;
 
 			bool is_end_position = moveresult.collides;
 			pos_translator.update(m_position, is_end_position, dtime);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -360,24 +360,21 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	}
 	else
 	{
-		if(m_prop.physical){
+		if (m_prop.physical) {
 			aabb3f box = m_prop.collisionbox;
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
+
+			v3f extent = box.getExtent();
+			// Calculate the maximum distance per iteration, apply limits
+			f32 pos_max_d = MYMIN(extent.X, MYMIN(extent.Y, extent.Z));
+			pos_max_d = rangelim(pos_max_d / 2, 0.05 * BS, 0.25 * BS);
+
 			collisionMoveResult moveresult;
-			f32 pos_max_d = BS*0.25; // Distance per iteration
-			v3f p_pos = m_base_position;
-			v3f p_velocity = m_velocity;
-			v3f p_acceleration = m_acceleration;
 			moveresult = collisionMoveSimple(m_env, m_env->getGameDef(),
 					pos_max_d, box, m_prop.stepheight, dtime,
-					&p_pos, &p_velocity, p_acceleration,
+					&m_base_position, &m_velocity, m_acceleration,
 					this, m_prop.collideWithObjects);
-
-			// Apply results
-			m_base_position = p_pos;
-			m_velocity = p_velocity;
-			m_acceleration = p_acceleration;
 		} else {
 			m_base_position += dtime * m_velocity + 0.5 * dtime
 					* dtime * m_acceleration;


### PR DESCRIPTION
This PR is an attempt to prevent small LuaEntities from glitching into nodes, see #5966 and #5482.
It could be that TNT itself already places the entities into solid nodes.

EDIT: This PR does not prevent item entities from glitching into nodes (like with TNT), as they switch to `physical=false` once they're on solid ground to prevent superfluous collision detections.