### PR TITLE
Properly shut down and return 2 when receiving SIGUSR1 on POSIX systems

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,9 +209,9 @@ int main(int argc, char *argv[])
 
 #ifndef SERVER
 	ClientLauncher launcher;
-	retval = launcher.run(game_params, cmd_args) ? 0 : 1;
+	retval = launcher.run(game_params, cmd_args) ? porting::ret_val : 1;
 #else
-	retval = 0;
+	retval = porting::ret_val;
 #endif
 
 	// Update configuration file

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -66,6 +66,7 @@ namespace porting
 */
 
 bool g_killed = false;
+int ret_val = 0;
 
 bool * signal_handler_killstatus(void)
 {
@@ -84,6 +85,10 @@ void signal_handler(int sig)
 		} else if (sig == SIGTERM) {
 			dstream << "INFO: signal_handler(): "
 				<< "got SIGTERM, shutting down." << std::endl;
+		} else if (sig == SIGUSR1) {
+			dstream << "INFO: signal_handler(): "
+				<< "got SIGUSR1, shutting down with return code 2." << std::endl;
+			ret_val = 2;
 		}
 
 		// Comment out for less clutter when testing scripts
@@ -101,6 +106,7 @@ void signal_handler_init(void)
 {
 	(void)signal(SIGINT, signal_handler);
 	(void)signal(SIGTERM, signal_handler);
+	(void)signal(SIGUSR1, signal_handler);
 }
 
 #else // _WIN32

--- a/src/porting.h
+++ b/src/porting.h
@@ -61,7 +61,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 	// Use standard Posix macro for Linux
 	#if (defined(linux) || defined(__linux)) && !defined(__linux__)
-		#define __linux__ 
+		#define __linux__
 	#endif
 	#if (defined(__linux__) || defined(__GNU__)) && !defined(_GNU_SOURCE)
 		#define _GNU_SOURCE
@@ -131,6 +131,8 @@ void signal_handler_init(void);
 // Returns a pointer to a bool.
 // When the bool is true, program should quit.
 bool * signal_handler_killstatus(void);
+// Suggested program return value.
+extern int ret_val;
 
 /*
 	Path of static data directory.


### PR DESCRIPTION
As a server administrator, and as most server administrators do, I'm using a script that runs the minetestserver in a loop so it is restarted when it crashes. The script checks the process return code to know whether it should be restarted or not (crash or intentional shut down).
Most of the time this is enough. However, sometimes, it is useful to be able to restart the minetestserver on demand. This commit makes it possible by sending `SIGUSR1` to the process, which makes it shut down as if it was killed by `SIGTERM`, but with a different return code.

So this (trivial) PR only serves to make server maintenance easier on POSIX systems.