### PR TITLE
Improve anticheat flexibility.

### DIFF
--- a/builtin/game/anticheat.lua
+++ b/builtin/game/anticheat.lua
@@ -1,0 +1,288 @@
+core.registered_anticheat_objects = {}
+
+local current_anticheat_objects = {}
+
+function core.register_anticheat_object(name, def)
+	if core.registered_anticheat_objects[name] then
+		core.log("warning", "Couldn't register anticheat object "..name..": anticheat object with same name already exists.")
+	end
+
+	if def.enable then
+		core.log("warning", "Anticheat object "..name.." definition contains an enable method. Use on_enable instead. Overwriting.")
+	end
+	def.enable = function(self)
+		if self.on_enable then
+			if self:on_enable() ~= false then
+				self.enabled = true
+			end
+		else
+			self.enabled = true
+		end
+	end
+
+	if def.disable then
+		core.log("warning", "Anticheat object "..name.." definition contains a disable method. Use on_disable instead. Overwriting.")
+	end
+	def.disable = function(self)
+		if self.on_disable then
+			if self:on_disable() ~= false then
+				self.enabled = false
+			end
+		else
+			self.enabled = false
+		end
+	end
+
+	core.registered_anticheat_objects[name] = def
+end
+
+function core.get_anticheat_object(player, type)
+	if type(player) == "string" then
+		player = minetest.get_player_by_name(player)
+	end
+
+	local player_name = player:get_player_name()
+	if not current_anticheat_objects[player_name] then
+		current_anticheat_objects[player_name] = {}
+	end
+	if not current_anticheat_objects[player_name][type] then
+		if not core.registered_anticheat_objects[type] then
+			return nil
+		end
+
+		-- Create anticheat object
+		local obj = {}
+		setmetatable(obj, {__index = core.registered_anticheat_objects[type]})
+		obj.player = player
+		--obj.enabled = core.settings:get_bool("enable_anticheat") and not core.is_singleplayer()
+		-- DEBUG:
+		obj.enabled = core.settings:get_bool("enable_anticheat")
+		if obj.init then
+			obj:init()
+		end
+		current_anticheat_objects[player_name][type] = obj
+	end
+
+	return current_anticheat_objects[player_name][type]
+end
+
+function core.run_anticheat_callbacks(player, type, params)
+	assert(core.registered_anticheat_objects[type])
+	if not params then
+		params = {}
+	end
+	params.type = type
+	return core.run_callbacks(core.registered_on_cheats, 0, player, params)
+end
+
+core.register_on_leaveplayer(function(player)
+	local player_name = player:get_player_name()
+	if not current_anticheat_objects[player_name] then
+		return
+	end
+	for type, obj in pairs(current_anticheat_objects[player_name]) do
+		if obj.deinit then
+			obj:deinit()
+		end
+	end
+	current_anticheat_objects[player_name] = nil
+end)
+
+-- Builtin anticheat definitions. These anticheat objects are called from the C++ engine
+
+core.register_anticheat_object("interacted_too_far", {
+	check = function(self, node_pos)
+		if not self.enabled then
+			return false
+		end
+
+		local distance = vector.distance(self.player:get_pos(), node_pos)
+		local max_distance = self:get_max_distance()
+
+		if distance > max_distance then
+			core.log("action", "Player " .. self.player:get_player_name()
+						.. " tried to access " .. core.pos_to_string(node_pos)
+						.. " from too far: "
+						.. "d=" .. distance .. ", max_d=" .. max_distance
+						.. ". ignoring.")
+			core.run_anticheat_callbacks(self.player, "interacted_too_far", {node_pos = node_pos, distance = distance, max_distance = max_distance})
+			return true
+		else
+			return false
+		end
+	end,
+
+	set_max_distance = function(self, max_distance)
+		self.max_distance = max_distance
+	end,
+
+	get_max_distance = function(self)
+		if self.max_distance then
+			return self.max_distance
+		end
+
+		local item_range = minetest.registered_items[self.player:get_wielded_item():get_name()].range or 4.0
+		if item_range >= 0 then
+			return item_range
+		end
+
+		local hand_range = minetest.registered_items[":"].range or 4.0
+		if hand_range >= 0 then
+			return hand_range
+		end
+
+		return 4.0
+	end
+})
+
+core.register_anticheat_object("finished_unknown_dig", {
+	check = function(self, started_pos, completed_pos)
+		if not self.enabled then
+			return false
+		end
+
+		if not vector.equals(started_pos, completed_pos) then
+			core.log("info", "Server: NoCheat: " .. self.player:get_player_name()
+					.. " started digging "
+					.. core.pos_to_string(started_pos) .. " and completed digging "
+					.. core.pos_to_string(completed_pos) .. "; not digging.")
+			core.run_anticheat_callbacks(self.player, "finished_unknown_dig", {started_pos = started_pos, completed_pos = completed_pos})
+			return true
+		else
+			return false
+		end
+	end
+})
+
+core.register_anticheat_object("dug_unbreakable", {
+	check = function(self, node_pos)
+		if not self.enabled then
+			return false
+		end
+
+		local groups = core.registered_items[core.get_node(node_pos).name].groups
+		local tool_capabilities = self.player:get_wielded_item():get_tool_capabilities()
+
+		if not core.get_dig_params(groups, tool_capabilities).diggable then
+			-- Not diggable? Try hand
+			tool_capabilities = core.registered_items[":"].tool_capabilities
+			if not core.get_dig_params(groups, tool_capabilities).diggable then
+				-- Ignore dig
+				core.log("info", "Server: NoCheat: " .. self.player:get_player_name()
+						.. " completed digging " .. core.pos_to_string(node_pos)
+						.. "; which is not diggable with tool. not digging.")
+				core.run_anticheat_callbacks(self.player, "dug_unbreakable", {node_pos = node_pos, groups = groups})
+				return true
+			end
+		end
+
+		return false
+	end
+})
+
+core.register_anticheat_object("dug_too_fast", {
+	check = function(self, node_pos, nocheat_time, grab_lag_pool)
+		if not self.enabled then
+			return false
+		end
+
+		local groups = core.registered_items[core.get_node(node_pos).name].groups
+		local tool_capabilities = self.player:get_wielded_item():get_tool_capabilities()
+		local dtime = core.get_dig_params(groups, tool_capabilities).time
+
+		if dtime > 2.0 and nocheat_time * 1.2 > dtime then
+			-- All is good, but grab time from pool; don't care if
+			-- it's actually available
+			grab_lag_pool(dtime, self.player:get_player_name(), "dig")
+			return false
+		elseif grab_lag_pool(dtime, self.player:get_player_name(), "dig") then
+			return false
+		else
+			core.log("info", "Server: NoCheat: " .. self.player:get_player_name()
+							.. " completed digging " .. core.pos_to_string(node_pos)
+							.. "too fast; not digging.")
+			core.run_anticheat_callbacks(self.player, "dug_too_fast", {node_pos = node_pos,
+				dtime = dtime, nocheat_time = nocheat_time})
+			return true
+		end
+	end
+})
+
+core.register_anticheat_object("moved_too_fast", {
+	check = function(self, pos, max_lag_estimate, time_from_last_teleport, last_good_position, grab_lag_pool)
+		if not self.enabled or self.player:get_attach() then
+			return false
+		end
+
+		--[[
+			Check player movements
+
+			NOTE: Actually the server should handle player physics like the
+			client does and compare player's position to what is calculated
+			on our side. This is required when eg. players fly due to an
+			explosion. Altough a node-based alternative might be possible
+			too, and much more lightweight.
+		]]
+
+		local player_max_speed = self:get_max_speed()
+		-- Tolerance. The lag pool does this a bit.
+		--player_max_speed = player_max_speed * 2.5
+
+		local diff = vector.subtract(pos, last_good_position)
+		local d_vert = diff.y
+		diff.y = 0
+		local d_horiz = vector.length(diff)
+		local required_time = d_horiz / player_max_speed
+
+		if d_vert > 0 and d_vert / player_max_speed > required_time then
+			required_time = d_vert / player_max_speed -- Moving upwards
+		end
+
+		if grab_lag_pool(required_time, self.player:get_player_name(), "move") then
+			return false
+		else
+			local LAG_POOL_MIN = 5.0
+			local lag_pool_max = math.max(max_lag_estimate * 2.0, LAG_POOL_MIN)
+			if time_from_last_teleport > lag_pool_max then
+				minetest.log("action", "Player " .. self.player:get_player_name()
+						.. " moved too fast; resetting position")
+				core.run_anticheat_callbacks(self.player, "moved_too_fast", {player_pos = pos,
+					player_max_speed = player_max_speed})
+				return true
+			end
+		end
+	end,
+
+	set_max_speed = function(self, max_speed)
+		self.max_speed = max_speed
+	end,
+
+	get_max_speed = function(self)
+		if self.max_speed then
+			return self.max_speed
+		end
+
+		if core.check_player_privs(self.player, "fast") then
+			return core.settings:get("movement_speed_fast") * self.player:get_physics_override().speed
+		else
+			return core.settings:get("movement_speed_walk") * self.player:get_physics_override().speed
+		end
+	end
+})
+
+core.register_anticheat_object("interacted_while_dead", {
+	check = function(self)
+		if not self.enabled then
+			return false
+		end
+
+		if self.player:get_hp() == 0 then
+			minetest.log("action", "Server: NoCheat: " .. self.player:get_player_name()
+					.. " tried to interact while dead; ignoring.")
+			core.run_anticheat_callbacks(self.player, "interacted_while_dead", {})
+			return true
+		else
+			return false
+		end
+	end
+})

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -32,5 +32,6 @@ dofile(gamepath.."features.lua")
 dofile(gamepath.."voxelarea.lua")
 dofile(gamepath.."forceloading.lua")
 dofile(gamepath.."statbars.lua")
+dofile(gamepath.."anticheat.lua")
 
 profiler = nil

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -578,7 +578,7 @@ Example (colored grass block):
         description = "Dirt with Grass",
         -- Regular tiles, as usual
         -- The dirt tile disables palette coloring
-        tiles = {{name = "default_grass.png"}, 
+        tiles = {{name = "default_grass.png"},
             {name = "default_dirt.png", color = "white"}},
         -- Overlay tiles: define them in the same style
         -- The top and bottom tile does not have overlay
@@ -719,6 +719,20 @@ the global `minetest.registered_*` tables.
 
 * `minetest.clear_registered_schematics()`
     * clears all schematics currently registered
+
+* `minetest.register_anticheat_object(name, def)`
+    * registers an anticheat object (see `AnticheatObject`)
+    * `name`: name of the object (cheat type)
+    * `def`: table containing the object methods. This table *must not* contain
+      methods named `enable` and `disable`.
+    * Special methods (optional):
+      * `on_enable()`: called when enabling the object. Should return `false`
+        to indicate that the object cannot be enabled.
+      * `on_disable()`: called when disabling the object. Should return `false`
+        to indicate that the object cannot be disabled.
+      * `init()`: called when the object is created (= accessed for the first time).
+      * `deinit()`: called when the object is destroyed (= when its attached player
+        leaves the game).
 
 Note that in some cases you will stumble upon things that are not contained
 in these tables (e.g. when a mod has been removed). Always check for
@@ -2252,6 +2266,7 @@ Call these functions only at load time!
 * `minetest.clear_registered_ores()`
 * `minetest.clear_registered_biomes()`
 * `minetest.clear_registered_decorations()`
+* `minetest.register_anticheat_object(name, def)`
 
 ### Global callback registration functions
 Call these functions only at load time!
@@ -2313,13 +2328,21 @@ Call these functions only at load time!
     * `timed_out`: True for timeout, false for other reasons.
 * `minetest.register_on_cheat(func(ObjectRef, cheat))`
     * Called when a player cheats
-    * `cheat`: `{type=<cheat_type>}`, where `<cheat_type>` is one of:
+    * `cheat`: `{type=<cheat_type>}`. Built-in cheat types:
         * `moved_too_fast`
         * `interacted_too_far`
         * `interacted_while_dead`
         * `finished_unknown_dig`
         * `dug_unbreakable`
         * `dug_too_fast`
+   * Additional parameters can be passed in the cheat table, depending on the
+     cheat type.
+   * For non-built-in anticheat objects, the callbacks must be manually run
+     using `minetest.run_anticheat_callbacks(player, cheat_type, params)` where:
+     * `player`: an `ObjectRef`
+     * `cheat_type`: the name of the `AnticheatObject`
+     * `params`: an optional table of additional parameters. It must not
+       contain a key named `type`.
 * `minetest.register_on_chat_message(func(name, message))`
     * Called always when a player says something
     * Return `true` to mark the message as handled, which means that it will not be sent to other players
@@ -3736,6 +3759,32 @@ It can be created via `Settings(filename)`.
 * `write()`: returns a boolean (`true` for success)
     * Writes changes to file.
 * `to_table()`: returns `{[key1]=value1,...}`
+
+### `AnticheatObject`
+An interface to the anticheat mechanisms.
+It can be created and accessed via `minetest.get_anticheat_object(player, type)`.
+
+#### Methods
+* `disable()`: disables the anticheat object
+* `enable()`: enables the anticheat object
+Other methods specific to the type can be registered.
+
+#### Attributes
+* `player`: `ObjectRef` to which the `AnticheatObject` is attached
+* `enabled`: whether the `AnticheatObject` is enabled.
+Other attributes specific to the type can be registered.
+
+#### Built-in type-specific methods
+
+##### `"interacted_too_far"`
+* `set_max_distance(max_distance)`: sets the maximum interaction distance.
+  If `max_distance` is nil, sets back to default value.
+* `get_max_distance()`: returns the maximum interaction distance
+
+##### `"moved_too_fast"`
+* `set_max_speed(max_speed)`: sets the maximum speed.
+  If `max_distance` is nil, sets back to default value.
+* `get_max_distance()`: returns the maximum speed
 
 Mapgen objects
 --------------

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -317,6 +317,10 @@ public:
 	{
 		return m_last_good_position;
 	}
+	void resetLastGoodPosition()
+	{
+		m_last_good_position = m_base_position;
+	}
 	float resetTimeFromLastPunch()
 	{
 		float r = m_time_from_last_punch;
@@ -344,8 +348,14 @@ public:
 	{
 		return m_dig_pool;
 	}
-	// Returns true if cheated
-	bool checkMovementCheat();
+	LagPool& getMovePool()
+	{
+		return m_move_pool;
+	}
+	float getTimeFromLastTeleport()
+	{
+		return m_time_from_last_teleport;
+	}
 
 	// Other
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -814,10 +814,11 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	player->control.LMB = (keyPressed & 128);
 	player->control.RMB = (keyPressed & 256);
 
-	if (playersao->checkMovementCheat()) {
-		// Call callbacks
-		m_script->on_cheat(playersao, "moved_too_fast");
+	if (m_script->anticheat_check_moved_too_fast(player, playersao)) {
+		playersao->setBasePosition(playersao->getLastGoodPosition());
 		SendMovePlayer(pkt->getPeerId());
+	} else {
+		playersao->resetLastGoodPosition();
 	}
 }
 
@@ -1306,23 +1307,19 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		return;
 	}
 
-	if (playersao->isDead()) {
-		actionstream << "Server: NoCheat: " << player->getName()
-				<< " tried to interact while dead; ignoring." << std::endl;
+	if (m_script->anticheat_check_interacted_while_dead(playersao)) {
 		if (pointed.type == POINTEDTHING_NODE) {
 			// Re-send block to revert change on client-side
 			RemoteClient *client = getClient(pkt->getPeerId());
 			v3s16 blockpos = getNodeBlockPos(pointed.node_undersurface);
 			client->SetBlockNotSent(blockpos);
 		}
-		// Call callbacks
-		m_script->on_cheat(playersao, "interacted_while_dead");
 		return;
 	}
 
 	process_PlayerPos(player, playersao, pkt);
 
-	v3f player_pos = playersao->getLastGoodPosition();
+	v3f player_pos = playersao->getBasePosition();
 
 	// Update wielded item
 	playersao->setWieldIndex(item_i);
@@ -1380,36 +1377,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		Check that target is reasonably close
 		(only when digging or placing things)
 	*/
-	static thread_local const bool enable_anticheat =
-			!g_settings->getBool("disable_anticheat");
-
-	if ((action == 0 || action == 2 || action == 3 || action == 4) &&
-			(enable_anticheat && !isSingleplayer())) {
-		float d = player_pos.getDistanceFrom(pointed_pos_under);
-		const ItemDefinition &playeritem_def =
-			playersao->getWieldedItem().getDefinition(m_itemdef);
-		float max_d = BS * playeritem_def.range;
-		InventoryList *hlist = playersao->getInventory()->getList("hand");
-		const ItemDefinition &hand_def =
-			hlist ? (hlist->getItem(0).getDefinition(m_itemdef)) : (m_itemdef->get(""));
-		float max_d_hand = BS * hand_def.range;
-		if (max_d < 0 && max_d_hand >= 0)
-			max_d = max_d_hand;
-		else if (max_d < 0)
-			max_d = BS * 4.0;
-		// cube diagonal: sqrt(3) = 1.73
-		if (d > max_d * 1.73) {
-			actionstream << "Player " << player->getName()
-					<< " tried to access " << pointed.dump()
-					<< " from too far: "
-					<< "d=" << d <<", max_d=" << max_d
-					<< ". ignoring." << std::endl;
+	if (action == 0 || action == 2 || action == 3 || action == 4) {
+		if (m_script->anticheat_check_interacted_too_far(playersao, floatToInt(pointed_pos_under, BS))) {
 			// Re-send block to revert change on client-side
 			RemoteClient *client = getClient(pkt->getPeerId());
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_under, BS));
 			client->SetBlockNotSent(blockpos);
-			// Call callbacks
-			m_script->on_cheat(playersao, "interacted_too_far");
 			// Do nothing else
 			return;
 		}
@@ -1505,72 +1478,26 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 
 			/* Cheat prevention */
 			bool is_valid_dig = true;
-			if (enable_anticheat && !isSingleplayer()) {
-				v3s16 nocheat_p = playersao->getNoCheatDigPos();
-				float nocheat_t = playersao->getNoCheatDigTime();
-				playersao->noCheatDigEnd();
-				// If player didn't start digging this, ignore dig
-				if (nocheat_p != p_under) {
-					infostream << "Server: NoCheat: " << player->getName()
-							<< " started digging "
-							<< PP(nocheat_p) << " and completed digging "
-							<< PP(p_under) << "; not digging." << std::endl;
+
+			v3s16 nocheat_p = playersao->getNoCheatDigPos();
+			float nocheat_t = playersao->getNoCheatDigTime();
+			playersao->noCheatDigEnd();
+
+			// If player didn't start digging this, ignore dig
+			if (m_script->anticheat_check_finished_unknown_dig(playersao, nocheat_p, p_under))
+				is_valid_dig = false;
+
+			// Check if node is diggable with tool
+			if (m_script->anticheat_check_dug_unbreakable(playersao, p_under))
+				is_valid_dig = false;
+
+			// Check digging time
+			// If already invalidated, we don't have to
+			if (is_valid_dig) {
+				if (m_script->anticheat_check_dug_too_fast(playersao, p_under, nocheat_t))
 					is_valid_dig = false;
-					// Call callbacks
-					m_script->on_cheat(playersao, "finished_unknown_dig");
-				}
-				// Get player's wielded item
-				ItemStack playeritem = playersao->getWieldedItemOrHand();
-				ToolCapabilities playeritem_toolcap =
-						playeritem.getToolCapabilities(m_itemdef);
-				// Get diggability and expected digging time
-				DigParams params = getDigParams(m_nodedef->get(n).groups,
-						&playeritem_toolcap);
-				// If can't dig, try hand
-				if (!params.diggable) {
-					InventoryList *hlist = playersao->getInventory()->getList("hand");
-					const ItemDefinition &hand =
-						hlist ? hlist->getItem(0).getDefinition(m_itemdef) : m_itemdef->get("");
-					const ToolCapabilities *tp = hand.tool_capabilities;
-					if (tp)
-						params = getDigParams(m_nodedef->get(n).groups, tp);
-				}
-				// If can't dig, ignore dig
-				if (!params.diggable) {
-					infostream << "Server: NoCheat: " << player->getName()
-							<< " completed digging " << PP(p_under)
-							<< ", which is not diggable with tool. not digging."
-							<< std::endl;
-					is_valid_dig = false;
-					// Call callbacks
-					m_script->on_cheat(playersao, "dug_unbreakable");
-				}
-				// Check digging time
-				// If already invalidated, we don't have to
-				if (!is_valid_dig) {
-					// Well not our problem then
-				}
-				// Clean and long dig
-				else if (params.time > 2.0 && nocheat_t * 1.2 > params.time) {
-					// All is good, but grab time from pool; don't care if
-					// it's actually available
-					playersao->getDigPool().grab(params.time);
-				}
-				// Short or laggy dig
-				// Try getting the time from pool
-				else if (playersao->getDigPool().grab(params.time)) {
-					// All is good
-				}
-				// Dig not possible
-				else {
-					infostream << "Server: NoCheat: " << player->getName()
-							<< " completed digging " << PP(p_under)
-							<< "too fast; not digging." << std::endl;
-					is_valid_dig = false;
-					// Call callbacks
-					m_script->on_cheat(playersao, "dug_too_fast");
-				}
 			}
+
 
 			/* Actually dig node */
 

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -25,15 +25,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "content_sao.h"
 
- #define ANTICHEAT_CHECK_HEADER(type)                             \
- 	int error_handler;                                                 \
+#define ANTICHEAT_CHECK_HEADER(type)                                                     \
+	int error_handler;                                                               \
 	prepare_anticheat_check(player, (type), error_handler);
 
-#define ANTICHEAT_CHECK_FOOTER(nb_params)                         \
-	/* Add 1 to nb_params for the self parameter */           \
-	PCALL_RES(lua_pcall(L, (nb_params)+1, 1, error_handler)); \
-	bool ret = (lua_toboolean(L, -1) != 0);                   \
-	lua_pop(L, 2); /* Pop error handler and return value */   \
+#define ANTICHEAT_CHECK_FOOTER(nb_params)                                                \
+	/* Add 1 to nb_params for the self parameter */                                  \
+	PCALL_RES(lua_pcall(L, (nb_params) + 1, 1, error_handler));                      \
+	bool ret = (lua_toboolean(L, -1) != 0);                                          \
+	lua_pop(L, 2); /* Pop error handler and return value */                          \
 	return ret;
 
 struct ToolCapabilities;
@@ -50,14 +50,16 @@ public:
 			std::string *reason);
 	void on_joinplayer(ServerActiveObject *player);
 	void on_leaveplayer(ServerActiveObject *player, bool timeout);
-	bool anticheat_check_interacted_too_far(ServerActiveObject *player, v3s16 node_pos);
+	bool anticheat_check_interacted_too_far(
+			ServerActiveObject *player, v3s16 node_pos);
 	bool anticheat_check_finished_unknown_dig(ServerActiveObject *player,
 			v3s16 started_pos, v3s16 completed_pos);
 	bool anticheat_check_dug_unbreakable(ServerActiveObject *player, v3s16 node_pos);
 	bool anticheat_check_interacted_while_dead(ServerActiveObject *player);
-	bool anticheat_check_dug_too_fast(ServerActiveObject *player,
-			v3s16 node_pos, float nocheat_time);
-	bool anticheat_check_moved_too_fast(RemotePlayer *remote_player, ServerActiveObject *player);
+	bool anticheat_check_dug_too_fast(
+			ServerActiveObject *player, v3s16 node_pos, float nocheat_time);
+	bool anticheat_check_moved_too_fast(
+			RemotePlayer *remote_player, ServerActiveObject *player);
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);
@@ -67,7 +69,7 @@ public:
 
 private:
 	inline void prepare_anticheat_check(ServerActiveObject *player,
-		const std::string &cheat_type, int &error_handler);
+			const std::string &cheat_type, int &error_handler);
 };
 
 #endif /* S_PLAYER_H_ */

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -23,6 +23,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "irr_v3d.h"
 #include "util/string.h"
+#include "content_sao.h"
+
+ #define ANTICHEAT_CHECK_HEADER(type)                             \
+ 	int error_handler;                                                 \
+	prepare_anticheat_check(player, (type), error_handler);
+
+#define ANTICHEAT_CHECK_FOOTER(nb_params)                         \
+	/* Add 1 to nb_params for the self parameter */           \
+	PCALL_RES(lua_pcall(L, (nb_params)+1, 1, error_handler)); \
+	bool ret = (lua_toboolean(L, -1) != 0);                   \
+	lua_pop(L, 2); /* Pop error handler and return value */   \
+	return ret;
 
 struct ToolCapabilities;
 
@@ -38,13 +50,24 @@ public:
 			std::string *reason);
 	void on_joinplayer(ServerActiveObject *player);
 	void on_leaveplayer(ServerActiveObject *player, bool timeout);
-	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
+	bool anticheat_check_interacted_too_far(ServerActiveObject *player, v3s16 node_pos);
+	bool anticheat_check_finished_unknown_dig(ServerActiveObject *player,
+			v3s16 started_pos, v3s16 completed_pos);
+	bool anticheat_check_dug_unbreakable(ServerActiveObject *player, v3s16 node_pos);
+	bool anticheat_check_interacted_while_dead(ServerActiveObject *player);
+	bool anticheat_check_dug_too_fast(ServerActiveObject *player,
+			v3s16 node_pos, float nocheat_time);
+	bool anticheat_check_moved_too_fast(RemotePlayer *remote_player, ServerActiveObject *player);
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);
 	s16 on_player_hpchange(ServerActiveObject *player, s16 hp_change);
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
+
+private:
+	inline void prepare_anticheat_check(ServerActiveObject *player,
+		const std::string &cheat_type, int &error_handler);
 };
 
 #endif /* S_PLAYER_H_ */


### PR DESCRIPTION
* The anticheat functionality can now be extended by external mods.
* Specific parts of the anticheat may be disabled for specific players only.
* Additional parameters are transferred to `registered_on_cheat` callbacks.
* External mods may dynamically change anticheat settings (maximum interaction distance for `interacted_too_far` and maximum speed for `moved_too_fast`).

This needs to be tested! It compiles fine, but I didn't test it with a cheated client.