### PR TITLE
Mgv7: Do not limit river generation if no floatlands

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -519,7 +519,8 @@ int MapgenV7::generateTerrain()
 
 void MapgenV7::generateRidgeTerrain()
 {
-	if ((node_max.Y < water_level - 16) || (node_max.Y > shadow_limit))
+	if (node_max.Y < water_level - 16 ||
+			((spflags & MGV7_FLOATLANDS) && node_max.Y > shadow_limit))
 		return;
 
 	noise_ridge->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);


### PR DESCRIPTION
Previously, the carving of rivers was disabled above 'shadow_limit' even if
floatlands were disabled. This caused rivers to be unnecessarily disabled if
mapgen was customised to have surface level above y = 1024.
////////////

![screenshot_20170618_012142](https://user-images.githubusercontent.com/3686677/27257383-5f772514-53cc-11e7-9f2d-9235cd51a94f.png)

^ The bug near y = 1024

Tested.