### PR TITLE
Remove IrrlichtDevice unused pointer from ClientActiveObject class & childs

### DIFF
--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -458,7 +458,7 @@ u16 ClientEnvironment::addActiveObject(ClientActiveObject *object)
 	infostream<<"ClientEnvironment::addActiveObject(): "
 		<<"added (id="<<object->getId()<<")"<<std::endl;
 	m_active_objects[object->getId()] = object;
-	object->addToScene(m_smgr, m_texturesource, m_irr);
+	object->addToScene(m_smgr, m_texturesource);
 	{ // Update lighting immediately
 		u8 light = 0;
 		bool pos_ok;

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -39,9 +39,8 @@ public:
 	ClientActiveObject(u16 id, Client *client, ClientEnvironment *env);
 	virtual ~ClientActiveObject();
 
-	virtual void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr){}
-	virtual void removeFromScene(bool permanent){}
+	virtual void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc) {};
+	virtual void removeFromScene(bool permanent) {}
 	// 0 <= light_at_pos <= LIGHT_SUN
 	virtual void updateLight(u8 light_at_pos){}
 	virtual void updateLightNoCheck(u8 light_at_pos){}

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -128,8 +128,7 @@ public:
 
 	static ClientActiveObject* create(Client *client, ClientEnvironment *env);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr);
+	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
 	void updateLight(u8 light_at_pos);
 	v3s16 getLightPosition();
@@ -165,8 +164,7 @@ ClientActiveObject* TestCAO::create(Client *client, ClientEnvironment *env)
 	return new TestCAO(client, env);
 }
 
-void TestCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr)
+void TestCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 {
 	if(m_node != NULL)
 		return;
@@ -272,8 +270,7 @@ public:
 
 	static ClientActiveObject* create(Client *client, ClientEnvironment *env);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr);
+	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
 	void updateLight(u8 light_at_pos);
 	v3s16 getLightPosition();
@@ -329,8 +326,7 @@ ClientActiveObject* ItemCAO::create(Client *client, ClientEnvironment *env)
 	return new ItemCAO(client, env);
 }
 
-void ItemCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr)
+void ItemCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 {
 	if(m_node != NULL)
 		return;
@@ -721,11 +717,9 @@ void GenericCAO::removeFromScene(bool permanent)
 	}
 }
 
-void GenericCAO::addToScene(scene::ISceneManager *smgr,
-		ITextureSource *tsrc, IrrlichtDevice *irr)
+void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 {
 	m_smgr = smgr;
-	m_irr = irr;
 
 	if (getSceneNode() != NULL) {
 		return;
@@ -1034,7 +1028,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		}
 	}
 
-	if(m_visuals_expired && m_smgr && m_irr){
+	if (m_visuals_expired && m_smgr) {
 		m_visuals_expired = false;
 
 		// Attachments, part 1: All attached objects must be unparented first,
@@ -1056,7 +1050,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		}
 
 		removeFromScene(false);
-		addToScene(m_smgr, m_client->tsrc(), m_irr);
+		addToScene(m_smgr, m_client->tsrc());
 
 		// Attachments, part 2: Now that the parent has been refreshed, put its attachments back
 		for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -65,7 +65,6 @@ private:
 	ObjectProperties m_prop;
 	//
 	scene::ISceneManager *m_smgr = nullptr;
-	IrrlichtDevice *m_irr = nullptr;
 	Client *m_client = nullptr;
 	aabb3f m_selection_box = aabb3f(-BS/3.,-BS/3.,-BS/3., BS/3.,BS/3.,BS/3.);
 	scene::IMeshSceneNode *m_meshnode = nullptr;
@@ -169,8 +168,7 @@ public:
 
 	void removeFromScene(bool permanent);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc,
-			IrrlichtDevice *irr);
+	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
 
 	inline void expireVisuals()
 	{


### PR DESCRIPTION
At the beginning of minetest IrrlichtDevice was exposed to ClientActiveObject, it's not the case anymore