### PR TITLE
Mgv5/v7/fractal: Add 'large_cave_depth' parameter to replace fixed value

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1028,6 +1028,9 @@ mgv5_spflags (Mapgen v5 specific flags) flags caverns caverns,nocaverns
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv5_cave_width (Cave width) float 0.125
 
+#    Y of upper limit of large pseudorandom caves.
+mgv5_large_cave_depth (Large cave depth) int -256
+
 #    Y-level of cavern upper limit.
 mgv5_cavern_limit (Cavern limit) int -256
 
@@ -1133,6 +1136,9 @@ mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,cave
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large pseudorandom caves.
+mgv7_large_cave_depth (Large cave depth) int -33
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.
@@ -1250,6 +1256,9 @@ mgflat_np_cave2 (Cave2 noise) noise_params 0, 12, (67, 67, 67), 10325, 3, 0.5, 2
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgfractal_cave_width (Cave width) float 0.09
+
+#    Y of upper limit of large pseudorandom caves.
+mgfractal_large_cave_depth (Large cave depth) int -33
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1256,6 +1256,10 @@
 #    type: float
 # mgv5_cave_width = 0.125
 
+#    Y of upper limit of large pseudorandom caves.
+#    type: int
+# mgv5_large_cave_depth = -256
+
 #    Y-level of cavern upper limit.
 #    type: int
 # mgv5_cavern_limit = -256
@@ -1370,6 +1374,10 @@
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
 # mgv7_cave_width = 0.09
+
+#    Y of upper limit of large pseudorandom caves.
+#    type: int
+# mgv7_large_cave_depth = -33
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.
@@ -1521,6 +1529,10 @@
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
 # mgfractal_cave_width = 0.09
+
+#    Y of upper limit of large pseudorandom caves.
+#    type: int
+# mgfractal_large_cave_depth = -33
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -49,17 +49,18 @@ FlagDesc flagdesc_mapgen_fractal[] = {
 MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
-	this->spflags    = params->spflags;
-	this->cave_width = params->cave_width;
-	this->fractal    = params->fractal;
-	this->iterations = params->iterations;
-	this->scale      = params->scale;
-	this->offset     = params->offset;
-	this->slice_w    = params->slice_w;
-	this->julia_x    = params->julia_x;
-	this->julia_y    = params->julia_y;
-	this->julia_z    = params->julia_z;
-	this->julia_w    = params->julia_w;
+	this->spflags          = params->spflags;
+	this->cave_width       = params->cave_width;
+	this->large_cave_depth = params->large_cave_depth;
+	this->fractal          = params->fractal;
+	this->iterations       = params->iterations;
+	this->scale            = params->scale;
+	this->offset           = params->offset;
+	this->slice_w          = params->slice_w;
+	this->julia_x          = params->julia_x;
+	this->julia_y          = params->julia_y;
+	this->julia_z          = params->julia_z;
+	this->julia_w          = params->julia_w;
 
 	//// 2D terrain noise
 	noise_seabed       = new Noise(&params->np_seabed, seed, csize.X, csize.Z);
@@ -91,17 +92,18 @@ MapgenFractalParams::MapgenFractalParams()
 
 void MapgenFractalParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgfractal_spflags",  spflags, flagdesc_mapgen_fractal);
-	settings->getFloatNoEx("mgfractal_cave_width", cave_width);
-	settings->getU16NoEx("mgfractal_fractal",      fractal);
-	settings->getU16NoEx("mgfractal_iterations",   iterations);
-	settings->getV3FNoEx("mgfractal_scale",        scale);
-	settings->getV3FNoEx("mgfractal_offset",       offset);
-	settings->getFloatNoEx("mgfractal_slice_w",    slice_w);
-	settings->getFloatNoEx("mgfractal_julia_x",    julia_x);
-	settings->getFloatNoEx("mgfractal_julia_y",    julia_y);
-	settings->getFloatNoEx("mgfractal_julia_z",    julia_z);
-	settings->getFloatNoEx("mgfractal_julia_w",    julia_w);
+	settings->getFlagStrNoEx("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal);
+	settings->getFloatNoEx("mgfractal_cave_width",     cave_width);
+	settings->getS16NoEx("mgfractal_large_cave_depth", large_cave_depth);
+	settings->getU16NoEx("mgfractal_fractal",          fractal);
+	settings->getU16NoEx("mgfractal_iterations",       iterations);
+	settings->getV3FNoEx("mgfractal_scale",            scale);
+	settings->getV3FNoEx("mgfractal_offset",           offset);
+	settings->getFloatNoEx("mgfractal_slice_w",        slice_w);
+	settings->getFloatNoEx("mgfractal_julia_x",        julia_x);
+	settings->getFloatNoEx("mgfractal_julia_y",        julia_y);
+	settings->getFloatNoEx("mgfractal_julia_z",        julia_z);
+	settings->getFloatNoEx("mgfractal_julia_w",        julia_w);
 
 	settings->getNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->getNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
@@ -112,17 +114,18 @@ void MapgenFractalParams::readParams(const Settings *settings)
 
 void MapgenFractalParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgfractal_spflags",  spflags, flagdesc_mapgen_fractal, U32_MAX);
-	settings->setFloat("mgfractal_cave_width", cave_width);
-	settings->setU16("mgfractal_fractal",      fractal);
-	settings->setU16("mgfractal_iterations",   iterations);
-	settings->setV3F("mgfractal_scale",        scale);
-	settings->setV3F("mgfractal_offset",       offset);
-	settings->setFloat("mgfractal_slice_w",    slice_w);
-	settings->setFloat("mgfractal_julia_x",    julia_x);
-	settings->setFloat("mgfractal_julia_y",    julia_y);
-	settings->setFloat("mgfractal_julia_z",    julia_z);
-	settings->setFloat("mgfractal_julia_w",    julia_w);
+	settings->setFlagStr("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFloat("mgfractal_cave_width",     cave_width);
+	settings->setS16("mgfractal_large_cave_depth", large_cave_depth);
+	settings->setU16("mgfractal_fractal",          fractal);
+	settings->setU16("mgfractal_iterations",       iterations);
+	settings->setV3F("mgfractal_scale",            scale);
+	settings->setV3F("mgfractal_offset",           offset);
+	settings->setFloat("mgfractal_slice_w",        slice_w);
+	settings->setFloat("mgfractal_julia_x",        julia_x);
+	settings->setFloat("mgfractal_julia_y",        julia_y);
+	settings->setFloat("mgfractal_julia_z",        julia_z);
+	settings->setFloat("mgfractal_julia_w",        julia_w);
 
 	settings->setNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->setNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
@@ -196,7 +199,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	MgStoneType stone_type = generateBiomes();
 
 	if (flags & MG_CAVES)
-		generateCaves(stone_surface_max_y, MGFRACTAL_LARGE_CAVE_DEPTH);
+		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if (flags & MG_DUNGEONS)
 		generateDungeons(stone_surface_max_y, stone_type);

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -26,8 +26,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-#define MGFRACTAL_LARGE_CAVE_DEPTH -33
-
 class BiomeManager;
 
 extern FlagDesc flagdesc_mapgen_fractal[];
@@ -36,6 +34,7 @@ struct MapgenFractalParams : public MapgenParams
 {
 	u32 spflags = 0;
 	float cave_width = 0.09f;
+	s16 large_cave_depth = -33;
 	u16 fractal = 1;
 	u16 iterations = 11;
 	v3f scale = v3f(4096.0, 1024.0, 4096.0);
@@ -74,6 +73,7 @@ private:
 	u16 formula;
 	bool julia;
 
+	s16 large_cave_depth;
 	u16 fractal;
 	u16 iterations;
 	v3f scale;

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -50,6 +50,7 @@ MapgenV5::MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge)
 {
 	this->spflags          = params->spflags;
 	this->cave_width       = params->cave_width;
+	this->large_cave_depth = params->large_cave_depth;
 	this->cavern_limit     = params->cavern_limit;
 	this->cavern_taper     = params->cavern_taper;
 	this->cavern_threshold = params->cavern_threshold;
@@ -94,6 +95,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 {
 	settings->getFlagStrNoEx("mgv5_spflags",        spflags, flagdesc_mapgen_v5);
 	settings->getFloatNoEx("mgv5_cave_width",       cave_width);
+	settings->getS16NoEx("mgv5_large_cave_depth",   large_cave_depth);
 	settings->getS16NoEx("mgv5_cavern_limit",       cavern_limit);
 	settings->getS16NoEx("mgv5_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgv5_cavern_threshold", cavern_threshold);
@@ -112,6 +114,7 @@ void MapgenV5Params::writeParams(Settings *settings) const
 {
 	settings->setFlagStr("mgv5_spflags",        spflags, flagdesc_mapgen_v5, U32_MAX);
 	settings->setFloat("mgv5_cave_width",       cave_width);
+	settings->setS16("mgv5_large_cave_depth",   large_cave_depth);
 	settings->setS16("mgv5_cavern_limit",       cavern_limit);
 	settings->setS16("mgv5_cavern_taper",       cavern_taper);
 	settings->setFloat("mgv5_cavern_threshold", cavern_threshold);
@@ -209,7 +212,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 			// large caverns and floating blobs of overgenerated liquid.
 			generateCaves(stone_surface_max_y, -MAX_MAP_GENERATION_LIMIT);
 		else
-			generateCaves(stone_surface_max_y, MGV5_LARGE_CAVE_DEPTH);
+			generateCaves(stone_surface_max_y, large_cave_depth);
 	}
 
 	// Generate dungeons and desert temples

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -23,8 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-#define MGV5_LARGE_CAVE_DEPTH -256
-
 ///////// Mapgen V5 flags
 #define MGV5_CAVERNS 0x01
 
@@ -36,6 +34,7 @@ struct MapgenV5Params : public MapgenParams
 {
 	u32 spflags = MGV5_CAVERNS;
 	float cave_width = 0.125f;
+	s16 large_cave_depth = -256;
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;
@@ -68,6 +67,7 @@ public:
 	int generateBaseTerrain();
 
 private:
+	s16 large_cave_depth;
 	Noise *noise_factor;
 	Noise *noise_height;
 	Noise *noise_ground;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -56,6 +56,7 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 {
 	this->spflags             = params->spflags;
 	this->cave_width          = params->cave_width;
+	this->large_cave_depth    = params->large_cave_depth;
 	this->float_mount_density = params->float_mount_density;
 	this->float_mount_height  = params->float_mount_height;
 	this->floatland_level     = params->floatland_level;
@@ -143,6 +144,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 {
 	settings->getFlagStrNoEx("mgv7_spflags",           spflags, flagdesc_mapgen_v7);
 	settings->getFloatNoEx("mgv7_cave_width",          cave_width);
+	settings->getS16NoEx("mgv7_large_cave_depth",      large_cave_depth);
 	settings->getFloatNoEx("mgv7_float_mount_density", float_mount_density);
 	settings->getFloatNoEx("mgv7_float_mount_height",  float_mount_height);
 	settings->getS16NoEx("mgv7_floatland_level",       floatland_level);
@@ -172,6 +174,7 @@ void MapgenV7Params::writeParams(Settings *settings) const
 {
 	settings->setFlagStr("mgv7_spflags",           spflags, flagdesc_mapgen_v7, U32_MAX);
 	settings->setFloat("mgv7_cave_width",          cave_width);
+	settings->setS16("mgv7_large_cave_depth",      large_cave_depth);
 	settings->setFloat("mgv7_float_mount_density", float_mount_density);
 	settings->setFloat("mgv7_float_mount_height",  float_mount_height);
 	settings->setS16("mgv7_floatland_level",       floatland_level);
@@ -303,7 +306,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 			// large caverns and floating blobs of overgenerated liquid.
 			generateCaves(stone_surface_max_y, -MAX_MAP_GENERATION_LIMIT);
 		else
-			generateCaves(stone_surface_max_y, water_level);
+			generateCaves(stone_surface_max_y, large_cave_depth);
 	}
 
 	// Generate dungeons

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -37,6 +37,7 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	float cave_width = 0.09f;
+	s16 large_cave_depth = -33;
 	float float_mount_density = 0.6f;
 	float float_mount_height = 128.0f;
 	s16 floatland_level = 1280;
@@ -88,6 +89,7 @@ public:
 	void generateRidgeTerrain();
 
 private:
+	s16 large_cave_depth;
 	float float_mount_density;
 	float float_mount_height;
 	s16 floatland_level;


### PR DESCRIPTION
Large caves need to be a certain distance below the surface in these mapgens. We are able to shift the terrain up and down but the large cave depth is currently a fixed y, it needs to be variable.
So move this to a new parameter to be like mgflat and mgvalleys which both have a parameter for large cave depth.

Fairly trivial as is essentially a bugfix and is consistent with other mapgens. Once tested perhaps you can allow me to merge on my own approval?