### PR TITLE
Fix console not being properly resized after window size changed

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -213,6 +213,7 @@ void GUIChatConsole::reformatConsole()
 	s32 rows = m_desired_height / m_fontsize.Y - 1; // make room for the input prompt
 	if (cols <= 0 || rows <= 0)
 		cols = rows = 0;
+	recalculateConsolePosition();
 	m_chat_backend->reformat(cols, rows);
 }
 


### PR DESCRIPTION
Before this patch resizing the width of the window would cause the chat console to be clipped inappropriately because the clipping rectangle was not updated. E.g. if making the game window wider the chat console would not extend to fill the entire width of the window

Before patch (after widening window)
![snapshot137](https://user-images.githubusercontent.com/5899883/27317043-3f34b7b0-55c7-11e7-8d9d-8ffe9bb348a7.png)

After path: The darkened background extends to fill the entire width of the window