### PR TITLE
Fix console resize issue when maximising game window

### DIFF
--- a/src/guiChatConsole.cpp
+++ b/src/guiChatConsole.cpp
@@ -186,8 +186,8 @@ void GUIChatConsole::draw()
 		// scale current console height to new window size
 		if (m_screensize.Y != 0)
 			m_height = m_height * screensize.Y / m_screensize.Y;
-		m_desired_height = m_desired_height_fraction * m_screensize.Y;
 		m_screensize = screensize;
+		m_desired_height = m_desired_height_fraction * m_screensize.Y;
 		reformatConsole();
 	}
 


### PR DESCRIPTION
Currently maximising the game window while the console is open leaves the console incorrectly positioned. This should fix that issue and seems to be the piece that was missing from #6020. (Thanks to Zeno for helping with these resize issues.)

I've only been able to test on Linux; however, from my experiments with current stable client the bug is slightly different on Windows. On Windows adjusting only the window height by dragging the bottom of the window (without changing the width) also triggers the same effect. I'm hoping this also fixes that issue, but would need someone else to verify. 