### PR TITLE
CavesRandomWalk: Make 'lava_depth' a mapgen parameter

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1028,8 +1028,11 @@ mgv5_spflags (Mapgen v5 specific flags) flags caverns caverns,nocaverns
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv5_cave_width (Cave width) float 0.125
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 mgv5_large_cave_depth (Large cave depth) int -256
+
+#    Y of upper limit of lava in large caves.
+mgv5_lava_depth (Lava depth) int -256
 
 #    Y-level of cavern upper limit.
 mgv5_cavern_limit (Cavern limit) int -256
@@ -1137,8 +1140,11 @@ mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,cave
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Cave width) float 0.09
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 mgv7_large_cave_depth (Large cave depth) int -33
+
+#    Y of upper limit of lava in large caves.
+mgv7_lava_depth (Lava depth) int -256
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.
@@ -1218,8 +1224,11 @@ mgflat_spflags (Mapgen flat specific flags) flags nolakes,nohills lakes,hills,no
 #    Y of flat ground.
 mgflat_ground_level (Ground level) int 8
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 mgflat_large_cave_depth (Large cave depth) int -33
+
+#    Y of upper limit of lava in large caves.
+mgflat_lava_depth (Lava depth) int -256
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgflat_cave_width (Cave width) float 0.09
@@ -1257,8 +1266,11 @@ mgflat_np_cave2 (Cave2 noise) noise_params 0, 12, (67, 67, 67), 10325, 3, 0.5, 2
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgfractal_cave_width (Cave width) float 0.09
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 mgfractal_large_cave_depth (Large cave depth) int -33
+
+#    Y of upper limit of lava in large caves.
+mgfractal_lava_depth (Lava depth) int -256
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1256,9 +1256,13 @@
 #    type: float
 # mgv5_cave_width = 0.125
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 #    type: int
 # mgv5_large_cave_depth = -256
+
+#    Y of upper limit of lava in large caves.
+#    type: int
+# mgv5_lava_depth = -256
 
 #    Y-level of cavern upper limit.
 #    type: int
@@ -1375,9 +1379,13 @@
 #    type: float
 # mgv7_cave_width = 0.09
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 #    type: int
 # mgv7_large_cave_depth = -33
+
+#    Y of upper limit of lava in large caves.
+#    type: int
+# mgv7_lava_depth = -256
 
 #    Controls the density of floatland mountain terrain.
 #    Is an offset added to the 'np_mountain' noise value.
@@ -1480,9 +1488,13 @@
 #    type: int
 # mgflat_ground_level = 8
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 #    type: int
 # mgflat_large_cave_depth = -33
+
+#    Y of upper limit of lava in large caves.
+#    type: int
+# mgflat_lava_depth = -256
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
@@ -1530,9 +1542,13 @@
 #    type: float
 # mgfractal_cave_width = 0.09
 
-#    Y of upper limit of large pseudorandom caves.
+#    Y of upper limit of large caves.
 #    type: int
 # mgfractal_large_cave_depth = -33
+
+#    Y of upper limit of lava in large caves.
+#    type: int
+# mgfractal_lava_depth = -256
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.

--- a/src/cavegen.cpp
+++ b/src/cavegen.cpp
@@ -258,7 +258,8 @@ CavesRandomWalk::CavesRandomWalk(
 	s32 seed,
 	int water_level,
 	content_t water_source,
-	content_t lava_source)
+	content_t lava_source,
+	int lava_depth)
 {
 	assert(ndef);
 
@@ -267,7 +268,7 @@ CavesRandomWalk::CavesRandomWalk(
 	this->seed           = seed;
 	this->water_level    = water_level;
 	this->np_caveliquids = &nparams_caveliquids;
-	this->lava_depth     = DEFAULT_LAVA_DEPTH;
+	this->lava_depth     = lava_depth;
 
 	c_water_source = water_source;
 	if (c_water_source == CONTENT_IGNORE)

--- a/src/cavegen.h
+++ b/src/cavegen.h
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define CAVEGEN_HEADER
 
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
-#define DEFAULT_LAVA_DEPTH (-256)
 
 class GenerateNotifier;
 
@@ -157,7 +156,8 @@ public:
 	CavesRandomWalk(INodeDefManager *ndef, GenerateNotifier *gennotify = NULL,
 			s32 seed = 0, int water_level = 1,
 			content_t water_source = CONTENT_IGNORE,
-			content_t lava_source = CONTENT_IGNORE);
+			content_t lava_source = CONTENT_IGNORE,
+			int lava_depth = -256);
 
 	// vm and ps are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -817,7 +817,7 @@ void MapgenBasic::generateCaves(s16 max_stone_y, s16 large_cave_depth)
 	u32 bruises_count = ps.range(0, 2);
 	for (u32 i = 0; i < bruises_count; i++) {
 		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
-			c_water_source, CONTENT_IGNORE);
+			c_water_source, CONTENT_IGNORE, lava_depth);
 
 		cave.makeCave(vm, node_min, node_max, &ps, true, max_stone_y, heightmap);
 	}

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -294,6 +294,7 @@ protected:
 	float cavern_limit;
 	float cavern_taper;
 	float cavern_threshold;
+	int lava_depth;
 };
 
 #endif

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -54,6 +54,7 @@ MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *em
 	this->spflags          = params->spflags;
 	this->ground_level     = params->ground_level;
 	this->large_cave_depth = params->large_cave_depth;
+	this->lava_depth       = params->lava_depth;
 	this->cave_width       = params->cave_width;
 	this->lake_threshold   = params->lake_threshold;
 	this->lake_steepness   = params->lake_steepness;
@@ -94,6 +95,7 @@ void MapgenFlatParams::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgflat_spflags",      spflags, flagdesc_mapgen_flat);
 	settings->getS16NoEx("mgflat_ground_level",     ground_level);
 	settings->getS16NoEx("mgflat_large_cave_depth", large_cave_depth);
+	settings->getS16NoEx("mgflat_lava_depth",       lava_depth);
 	settings->getFloatNoEx("mgflat_cave_width",     cave_width);
 	settings->getFloatNoEx("mgflat_lake_threshold", lake_threshold);
 	settings->getFloatNoEx("mgflat_lake_steepness", lake_steepness);
@@ -112,6 +114,7 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setFlagStr("mgflat_spflags",      spflags, flagdesc_mapgen_flat, U32_MAX);
 	settings->setS16("mgflat_ground_level",     ground_level);
 	settings->setS16("mgflat_large_cave_depth", large_cave_depth);
+	settings->setS16("mgflat_lava_depth",       lava_depth);
 	settings->setFloat("mgflat_cave_width",     cave_width);
 	settings->setFloat("mgflat_lake_threshold", lake_threshold);
 	settings->setFloat("mgflat_lake_steepness", lake_steepness);

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -36,6 +36,7 @@ struct MapgenFlatParams : public MapgenParams
 	u32 spflags = 0;
 	s16 ground_level = 8;
 	s16 large_cave_depth = -33;
+	s16 lava_depth = -256;
 	float cave_width = 0.09f;
 	float lake_threshold = -0.45f;
 	float lake_steepness = 48.0f;

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -52,6 +52,7 @@ MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeMa
 	this->spflags          = params->spflags;
 	this->cave_width       = params->cave_width;
 	this->large_cave_depth = params->large_cave_depth;
+	this->lava_depth       = params->lava_depth;
 	this->fractal          = params->fractal;
 	this->iterations       = params->iterations;
 	this->scale            = params->scale;
@@ -95,6 +96,7 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal);
 	settings->getFloatNoEx("mgfractal_cave_width",     cave_width);
 	settings->getS16NoEx("mgfractal_large_cave_depth", large_cave_depth);
+	settings->getS16NoEx("mgfractal_lava_depth",       lava_depth);
 	settings->getU16NoEx("mgfractal_fractal",          fractal);
 	settings->getU16NoEx("mgfractal_iterations",       iterations);
 	settings->getV3FNoEx("mgfractal_scale",            scale);
@@ -117,6 +119,7 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setFlagStr("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal, U32_MAX);
 	settings->setFloat("mgfractal_cave_width",     cave_width);
 	settings->setS16("mgfractal_large_cave_depth", large_cave_depth);
+	settings->setS16("mgfractal_lava_depth",       lava_depth);
 	settings->setU16("mgfractal_fractal",          fractal);
 	settings->setU16("mgfractal_iterations",       iterations);
 	settings->setV3F("mgfractal_scale",            scale);

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -35,6 +35,7 @@ struct MapgenFractalParams : public MapgenParams
 	u32 spflags = 0;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
+	s16 lava_depth = -256;
 	u16 fractal = 1;
 	u16 iterations = 11;
 	v3f scale = v3f(4096.0, 1024.0, 4096.0);

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -51,6 +51,7 @@ MapgenV5::MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge)
 	this->spflags          = params->spflags;
 	this->cave_width       = params->cave_width;
 	this->large_cave_depth = params->large_cave_depth;
+	this->lava_depth       = params->lava_depth;
 	this->cavern_limit     = params->cavern_limit;
 	this->cavern_taper     = params->cavern_taper;
 	this->cavern_threshold = params->cavern_threshold;
@@ -96,6 +97,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgv5_spflags",        spflags, flagdesc_mapgen_v5);
 	settings->getFloatNoEx("mgv5_cave_width",       cave_width);
 	settings->getS16NoEx("mgv5_large_cave_depth",   large_cave_depth);
+	settings->getS16NoEx("mgv5_lava_depth",         lava_depth);
 	settings->getS16NoEx("mgv5_cavern_limit",       cavern_limit);
 	settings->getS16NoEx("mgv5_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgv5_cavern_threshold", cavern_threshold);
@@ -115,6 +117,7 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setFlagStr("mgv5_spflags",        spflags, flagdesc_mapgen_v5, U32_MAX);
 	settings->setFloat("mgv5_cave_width",       cave_width);
 	settings->setS16("mgv5_large_cave_depth",   large_cave_depth);
+	settings->setS16("mgv5_lava_depth",         lava_depth);
 	settings->setS16("mgv5_cavern_limit",       cavern_limit);
 	settings->setS16("mgv5_cavern_taper",       cavern_taper);
 	settings->setFloat("mgv5_cavern_threshold", cavern_threshold);

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -35,6 +35,7 @@ struct MapgenV5Params : public MapgenParams
 	u32 spflags = MGV5_CAVERNS;
 	float cave_width = 0.125f;
 	s16 large_cave_depth = -256;
+	s16 lava_depth = -256;
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -57,6 +57,7 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	this->spflags             = params->spflags;
 	this->cave_width          = params->cave_width;
 	this->large_cave_depth    = params->large_cave_depth;
+	this->lava_depth          = params->lava_depth;
 	this->float_mount_density = params->float_mount_density;
 	this->float_mount_height  = params->float_mount_height;
 	this->floatland_level     = params->floatland_level;
@@ -145,6 +146,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgv7_spflags",           spflags, flagdesc_mapgen_v7);
 	settings->getFloatNoEx("mgv7_cave_width",          cave_width);
 	settings->getS16NoEx("mgv7_large_cave_depth",      large_cave_depth);
+	settings->getS16NoEx("mgv7_lava_depth",            lava_depth);
 	settings->getFloatNoEx("mgv7_float_mount_density", float_mount_density);
 	settings->getFloatNoEx("mgv7_float_mount_height",  float_mount_height);
 	settings->getS16NoEx("mgv7_floatland_level",       floatland_level);
@@ -175,6 +177,7 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setFlagStr("mgv7_spflags",           spflags, flagdesc_mapgen_v7, U32_MAX);
 	settings->setFloat("mgv7_cave_width",          cave_width);
 	settings->setS16("mgv7_large_cave_depth",      large_cave_depth);
+	settings->setS16("mgv7_lava_depth",            lava_depth);
 	settings->setFloat("mgv7_float_mount_density", float_mount_density);
 	settings->setFloat("mgv7_float_mount_height",  float_mount_height);
 	settings->setS16("mgv7_floatland_level",       floatland_level);

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -38,6 +38,7 @@ struct MapgenV7Params : public MapgenParams {
 	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
+	s16 lava_depth = -256;
 	float float_mount_density = 0.6f;
 	float float_mount_height = 128.0f;
 	s16 floatland_level = 1280;


### PR DESCRIPTION
As with 'large_cave_depth', lava depth was previously a fixed y value and
therefore incompatible with the ability to shift terrain vertically.

Add 'lava_depth' mapgen parameter to mgflat, mgfractal, mgv5, mgv7.
/////////////

A settable lava depth has been requested by 1 or 2 people.
No change to the value so no breakage of worlds.
Partially a bugfix and no change in mapgen behaviour, so fairly trivial, and is code i understand well, so will merge on my own approval.