### PR TITLE
Ores: Make 'absheight' flag non-functional

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1076,12 +1076,7 @@ Ore attributes
 See section "Flag Specifier Format".
 
 Currently supported flags:
-`absheight`, `puff_cliffs`, `puff_additive_composition`.
-
-### `absheight`
-Also produce this same ore between the height range of `-y_max` and `-y_min`.
-
-Useful for having ore in sky realms without having to duplicate ore entries.
+`puff_cliffs`, `puff_additive_composition`.
 
 ### `puff_cliffs`
 If set, puff ore generation will not taper down large differences in displacement

--- a/src/mg_ore.cpp
+++ b/src/mg_ore.cpp
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 FlagDesc flagdesc_ore[] = {
-	{"absheight",                 OREFLAG_ABSHEIGHT},
+	{"absheight",                 OREFLAG_ABSHEIGHT}, // Non-functional
 	{"puff_cliffs",               OREFLAG_PUFF_CLIFFS},
 	{"puff_additive_composition", OREFLAG_PUFF_ADDITIVE},
 	{NULL,                        0}
@@ -87,22 +87,11 @@ void Ore::resolveNodeNames()
 
 size_t Ore::placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
-	int in_range = 0;
-
-	in_range |= (nmin.Y <= y_max && nmax.Y >= y_min);
-	if (flags & OREFLAG_ABSHEIGHT)
-		in_range |= (nmin.Y >= -y_max && nmax.Y <= -y_min) << 1;
-	if (!in_range)
+	if (!(nmin.Y <= y_max && nmax.Y >= y_min))
 		return 0;
 
-	int actual_ymin, actual_ymax;
-	if (in_range & ORE_RANGE_MIRROR) {
-		actual_ymin = MYMAX(nmin.Y, -y_max);
-		actual_ymax = MYMIN(nmax.Y, -y_min);
-	} else {
-		actual_ymin = MYMAX(nmin.Y, y_min);
-		actual_ymax = MYMIN(nmax.Y, y_max);
-	}
+	int actual_ymin = MYMAX(nmin.Y, y_min);
+	int actual_ymax = MYMIN(nmax.Y, y_max);
 	if (clust_size >= actual_ymax - actual_ymin + 1)
 		return 0;
 

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -32,13 +32,10 @@ class MMVManip;
 
 /////////////////// Ore generation flags
 
-#define OREFLAG_ABSHEIGHT     0x01
+#define OREFLAG_ABSHEIGHT     0x01 // Non-functional but kept to not break flags
 #define OREFLAG_PUFF_CLIFFS   0x02
 #define OREFLAG_PUFF_ADDITIVE 0x04
 #define OREFLAG_USE_NOISE     0x08
-
-#define ORE_RANGE_ACTUAL 1
-#define ORE_RANGE_MIRROR 2
 
 enum OreType {
 	ORE_SCATTER,


### PR DESCRIPTION
The 'absheight' flag was added years ago for the floatlands of 'indev'
mapgen (now deleted). The feature mirrored all ore placement around y = 0
to place ores in floatlands.

In MTG we now use dedicated ore registrations for floatlands.

The feature is crude, inflexible, problematic and very rarely used, it
also makes ore vertical range code more complex.
Minetest 0.5 is a good chance to remove the feature.

The flag itself remains to not break flag values.
/////////////////

Tested.