### PR TITLE
Mgv7: Avoid divide-by-zero errors

### DIFF
--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -106,6 +106,8 @@ private:
 	Noise *noise_float_base_height;
 	Noise *noise_mountain;
 	Noise *noise_ridge;
+
+	float float_mount_height_lim;
 };
 
 #endif


### PR DESCRIPTION
Some settings of paramters can cause mgv7 variables to be -inf, nan or -nan.
This can cause massive vertical columns of water to appear above sea level.
///////////////////

Tested.