### PR TITLE
Inventory: Fix wrong stack size behaviour and item loss

### DIFF
--- a/src/database-postgresql.cpp
+++ b/src/database-postgresql.cpp
@@ -584,7 +584,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 			if (itemStr.length() > 0) {
 				ItemStack stack;
 				stack.deSerialize(itemStr);
-				invList->addItem(pg_to_uint(results2, row2, 0), stack);
+				invList->changeItem(pg_to_uint(results2, row2, 0), stack);
 			}
 		}
 		PQclear(results2);

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -565,7 +565,7 @@ bool PlayerDatabaseSQLite3::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 			if (itemStr.length() > 0) {
 				ItemStack stack;
 				stack.deSerialize(itemStr);
-				invList->addItem(sqlite_to_uint(m_stmt_player_load_inventory_items, 0), stack);
+				invList->changeItem(sqlite_to_uint(m_stmt_player_load_inventory_items, 0), stack);
 			}
 		}
 		sqlite3_reset(m_stmt_player_load_inventory_items);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -267,7 +267,7 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		const u16 stackMax = getStackMax(itemdef);
+		const u16 stackMax = newitem_.getStackMax(itemdef);
 
 		*this = newitem;
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -254,11 +254,8 @@ std::string ItemStack::getItemString() const
 }
 
 
-ItemStack ItemStack::addItem(const ItemStack &newitem_,
-		IItemDefManager *itemdef)
+ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)
 {
-	ItemStack newitem = newitem_;
-
 	// If the item is empty or the position invalid, bail out
 	if(newitem.empty())
 	{
@@ -267,7 +264,7 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		const u16 stackMax = newitem_.getStackMax(itemdef);
+		const u16 stackMax = newitem.getStackMax(itemdef);
 
 		*this = newitem;
 
@@ -303,11 +300,10 @@ ItemStack ItemStack::addItem(const ItemStack &newitem_,
 	return newitem;
 }
 
-bool ItemStack::itemFits(const ItemStack &newitem_,
+bool ItemStack::itemFits(ItemStack newitem,
 		ItemStack *restitem,
 		IItemDefManager *itemdef) const
 {
-	ItemStack newitem = newitem_;
 
 	// If the item is empty or the position invalid, bail out
 	if(newitem.empty())
@@ -317,7 +313,7 @@ bool ItemStack::itemFits(const ItemStack &newitem_,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		const u16 stackMax = getStackMax(itemdef);
+		const u16 stackMax = newitem.getStackMax(itemdef);
 
 		// If the item fits fully, delete it
 		if (newitem.count <= stackMax) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -143,13 +143,12 @@ struct ItemStack
 	// If cannot be added at all, returns the item back.
 	// If can be added partly, decremented item is returned back.
 	// If can be added fully, empty item is returned.
-	ItemStack addItem(const ItemStack &newitem,
-			IItemDefManager *itemdef);
+	ItemStack addItem(ItemStack newitem, IItemDefManager *itemdef);
 
 	// Checks whether newitem could be added.
 	// If restitem is non-NULL, it receives the part of newitem that
 	// would be left over after adding.
-	bool itemFits(const ItemStack &newitem,
+	bool itemFits(ItemStack newitem,
 			ItemStack *restitem,  // may be NULL
 			IItemDefManager *itemdef) const;
 


### PR DESCRIPTION
Fix for #6038, where items are lost and moving large stacks results in weird behaviour.