### PR TITLE
Make dropped items colorable

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -155,6 +155,24 @@ function core.yaw_to_dir(yaw)
 	return {x = -math.sin(yaw), y = 0, z = math.cos(yaw)}
 end
 
+function core.is_colored_paramtype(ptype)
+	return (ptype == "color") or (ptype == "colorfacedir") or
+		(ptype == "colorwallmounted")
+end
+
+function core.strip_param2_color(param2, paramtype2)
+	if (not core.is_colored_paramtype(paramtype2)) then
+		return nil
+	end
+	if (paramtype2 == "colorfacedir") then
+		param2 = math.floor(param2 / 32) * 32;
+	elseif (paramtype2 == "colorwallmounted") then
+		param2 = math.floor(param2 / 8) * 8;
+	end
+	-- paramtype2 == "color" requires no modification.
+	return param2
+end
+
 function core.get_node_drops(node, toolname)
 	-- Compatibility, if node is string
 	local nodename = node
@@ -166,24 +184,17 @@ function core.get_node_drops(node, toolname)
 	end
 	local def = core.registered_nodes[nodename]
 	local drop = def and def.drop
+	local ptype = def and def.paramtype2
+	-- get color, if there is color (otherwise nil)
+	local palette_index = core.strip_param2_color(param2, ptype)
 	if drop == nil then
 		-- default drop
-		local stack = ItemStack(nodename)
-		if def then
-			local type = def.paramtype2
-			if (type == "color") or (type == "colorfacedir") or
-					(type == "colorwallmounted") then
-				local meta = stack:get_meta()
-				local color_part = param2
-				if (type == "colorfacedir") then
-					color_part = math.floor(color_part / 32) * 32;
-				elseif (type == "colorwallmounted") then
-					color_part = math.floor(color_part / 8) * 8;
-				end
-				meta:set_int("palette_index", color_part)
-			end
+		if palette_index then
+			local stack = ItemStack(nodename)
+			stack:get_meta():set_int("palette_index", palette_index)
+			return {stack:to_string()}
 		end
-		return {stack:to_string()}
+		return {nodename}
 	elseif type(drop) == "string" then
 		-- itemstring drop
 		return {drop}
@@ -218,6 +229,12 @@ function core.get_node_drops(node, toolname)
 		if good_rarity and good_tool then
 			got_count = got_count + 1
 			for _, add_item in ipairs(item.items) do
+				-- add color, if necessary
+				if item.inherit_color and palette_index then
+					local stack = ItemStack(add_item)
+					stack:get_meta():set_int("palette_index", palette_index)
+					add_item = stack:to_string()
+				end
 				got_items[#got_items+1] = add_item
 			end
 			if drop.max_items ~= nil and got_count == drop.max_items then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -536,6 +536,21 @@ automatically transferred between node and item forms by the engine,
 when a player digs or places a colored node.
 You can disable this feature by setting the `drop` field of the node
 to itself (without metadata).
+To transfer the color to a special drop, you need a drop table.
+Example:
+
+    minetest.register_node("mod:stone", {
+        description = "Stone",
+        tiles = {"default_stone.png"},
+        paramtype2 = "color",
+        palette = "palette.png",
+        drop = {
+            items = {
+                -- assume that mod:cobblestone also has the same palette
+                {items = {"mod:cobblestone"}, inherit_color = true },
+            }
+        }
+    })
 
 ### Colored items in craft recipes
 Craft recipes only support item strings, but fortunately item strings
@@ -2682,6 +2697,14 @@ and `minetest.auth_reload` call the authetification handler.
     * Convert a vector into a yaw (angle)
 * `minetest.yaw_to_dir(yaw)`
     * Convert yaw (angle) to a vector
+* `minetest.is_colored_paramtype(ptype)`
+    * returns if the given `paramtype2` is `color`,
+      `colorwallmounted` or `colorfacedir`.
+* `minetest.strip_param2_color(param2, paramtype2)`
+    * Removes everything but the color information from the
+      given `param2` value.
+    * Returns `nil` if the given `paramtype2` does not hold color information,
+      or the stripped `param2` value otherwise.
 * `minetest.get_node_drops(nodename, toolname)`
     * Returns list of item names.
     * **Note**: This will be removed or modified in a future version.
@@ -4223,6 +4246,7 @@ Definition tables
                 {
                     items = {"foo:bar", "baz:frob"},  -- Items to drop.
                     rarity = 1,  -- Probability of dropping is 1 / rarity.
+                    inherit_color = true, -- To inherit palette color from the node
                 },
             },
         },


### PR DESCRIPTION
This request extends automatic drop colorization, so custom drops can also inherit color.
Example usage: when a colored stone drops colored cobblestone.