### PR TITLE
Dungeons: Add setting to prevent projecting dungeons 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -984,6 +984,9 @@ mapgen_limit (Map generation limit) int 31000 0 31000
 #    Flags starting with 'no' are used to explicitly disable them.
 mg_flags (Mapgen flags) flags caves,dungeons,light,decorations caves,dungeons,light,decorations,nocaves,nodungeons,nolight,nodecorations
 
+#    Whether dungeons occasionally project from the terrain.
+projecting_dungeons (Projecting dungeons) bool true
+
 [**Advanced]
 
 #    Size of chunks to be generated at once by mapgen, stated in mapblocks (16 nodes).

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1201,6 +1201,10 @@
 #    type: flags possible values: caves, dungeons, light, decorations, nocaves, nodungeons, nolight, nodecorations
 # mg_flags = caves,dungeons,light,decorations
 
+#    Whether dungeons occasionally project from the terrain.
+#    type: bool
+# projecting_dungeons = true
+
 ### Advanced
 
 #    Size of chunks to be generated at once by mapgen, stated in mapblocks (16 nodes).

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -349,6 +349,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mg_flags", "dungeons");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "7");
+	settings->setDefault("projecting_dungeons", "true");
 	settings->setDefault("enable_mapgen_debug_info", "false");
 
 	// Server list announcing

--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -97,6 +97,8 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	if (nval_density < 1.0f)
 		return;
 
+	static const bool preserve_ignore = !g_settings->getBool("projecting_dungeons");
+
 	this->vm = vm;
 	this->blockseed = bseed;
 	random.seed(bseed + 2);
@@ -105,14 +107,16 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	vm->clearFlag(VMANIP_FLAG_DUNGEON_INSIDE | VMANIP_FLAG_DUNGEON_PRESERVE);
 
 	if (dp.only_in_ground) {
-		// Set all air and water to be untouchable
-		// to make dungeons open to caves and open air
+		// Set all air and water to be untouchable to make dungeons open to
+		// caves and open air. Optionally set ignore to be untouchable to
+		// prevent protruding dungeons. 
 		for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 			for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 				u32 i = vm->m_area.index(nmin.X, y, z);
 				for (s16 x = nmin.X; x <= nmax.X; x++) {
 					content_t c = vm->m_data[i].getContent();
 					if (c == CONTENT_AIR || c == dp.c_water ||
+							(preserve_ignore && c == CONTENT_IGNORE) ||
 							c == dp.c_river_water)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;


### PR DESCRIPTION
Prevents dungeons generating into ignore nodes in ungenerated mapchunks,
which can occasionally result in a dungeon projecting from the terrain.
////////////////

Addresses #5204 
Requested by several players and nerzhul.
Tested.
Set to true by default because that is my preference.
Screenshots of projecting dungens are here https://github.com/minetest/minetest/issues/5204#issuecomment-310954892

WIth this PR i have to, and i'm sorry i have to, insist that the default is true.
This is my favourite feature of MT mapgen and has been for years.
These are not common and create interesting structures in the landscape that inspire conversion into player bases or homes.