### PR TITLE
Fix for empty key/value when reading item string with wear but no metadata

### DIFF
--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -28,16 +28,18 @@ void ItemStackMetadata::deSerialize(std::istream &is)
 
 	m_stringvars.clear();
 
-	if (!in.empty() && in[0] == DESERIALIZE_START) {
-		Strfnd fnd(in);
-		fnd.to(1);
-		while (!fnd.at_end()) {
-			std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
-			std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
-			m_stringvars[name] = var;
+	if (!in.empty()) {
+		if (in[0] == DESERIALIZE_START) {
+			Strfnd fnd(in);
+			fnd.to(1);
+			while (!fnd.at_end()) {
+				std::string name = fnd.next(DESERIALIZE_KV_DELIM_STR);
+				std::string var  = fnd.next(DESERIALIZE_PAIR_DELIM_STR);
+				m_stringvars[name] = var;
+			}
+		} else {
+			// BACKWARDS COMPATIBILITY
+			m_stringvars[""] = in;
 		}
-	} else {
-		// BACKWARDS COMPATIBILITY
-		m_stringvars[""] = in;
 	}
 }


### PR DESCRIPTION
When deserializing item stack metadata, don't create the "backward compatibility" key unless there is actually some metadata present.

Fixes minetest/minetest#6057.