### PR TITLE
Move the code for taking and saving a screenshot to `RenderingEngine`

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1734,12 +1734,6 @@ float Client::getCurRate()
 
 void Client::makeScreenshot()
 {
-	irr::video::IVideoDriver *driver = RenderingEngine::get_video_driver();
-	irr::video::IImage* const raw_image = driver->createScreenShot();
-
-	if (!raw_image)
-		return;
-
 	time_t t = time(NULL);
 	struct tm *tm = localtime(&t);
 
@@ -1770,25 +1764,17 @@ void Client::makeScreenshot()
 	if (serial == SCREENSHOT_MAX_SERIAL_TRIES) {
 		infostream << "Could not find suitable filename for screenshot" << std::endl;
 	} else {
-		irr::video::IImage* const image =
-				driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
+		std::string message;
+		if (RenderingEngine::take_screenshot(filename))
+			message = strgettext("Saved screenshot to '%s'");
+		else
+			message = strgettext("Failed to take/save screenshot '%s'");
 
-		if (image) {
-			raw_image->copyTo(image);
-
-			std::ostringstream sstr;
-			if (driver->writeImageToFile(image, filename.c_str(), quality)) {
-				sstr << "Saved screenshot to '" << filename << "'";
-			} else {
-				sstr << "Failed to save screenshot '" << filename << "'";
-			}
-			pushToChatQueue(narrow_to_wide(sstr.str()));
-			infostream << sstr.str() << std::endl;
-			image->drop();
-		}
+		char message_buf[200];
+		snprintf(message_buf, sizeof(message_buf), message.c_str(), filename.c_str());
+		pushToChatQueue(narrow_to_wide(std::string(message_buf)));
+		infostream << message_buf << std::endl;
 	}
-
-	raw_image->drop();
 }
 
 bool Client::shouldShowMinimap() const

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -1013,6 +1013,30 @@ const char *RenderingEngine::getVideoDriverFriendlyName(irr::video::E_DRIVER_TYP
 	return driver_names[type];
 }
 
+bool RenderingEngine::take_screenshot(const std::string &filename)
+{
+	video::IVideoDriver *driver = get_video_driver();
+	irr::video::IImage *const raw_image = driver->createScreenShot();
+
+	if (!raw_image)
+		return false;
+
+	u32 quality = (u32)g_settings->getS32("screenshot_quality");
+	quality = MYMIN(MYMAX(quality, 0), 100) / 100.0 * 255;
+	irr::video::IImage *const image =
+			driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
+
+	bool succeed = false;
+	if (image) {
+		raw_image->copyTo(image);
+		succeed = driver->writeImageToFile(image, filename.c_str(), quality);
+		image->drop();
+	}
+
+	raw_image->drop();
+	return succeed;
+}
+
 #ifndef __ANDROID__
 #ifdef XORG_USED
 

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -125,6 +125,8 @@ public:
 	static std::vector<core::vector3d<u32>> getSupportedVideoModes();
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
 
+	static bool take_screenshot(const std::string &filename);
+
 private:
 	enum parallax_sign
 	{


### PR DESCRIPTION
This PR also fixes the screenshot status messages being untranslatable.