### PR TITLE
Mgv7: Fix undefined 'float_mount_height'

### DIFF
--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -68,6 +68,7 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	// This is to avoid a divide-by-zero.
 	// Parameter will be saved to map_meta.txt in limited form.
 	params->float_mount_height = MYMAX(params->float_mount_height, 1.0f);
+	this->float_mount_height   = params->float_mount_height;
 
 	// 2D noise
 	noise_terrain_base    = new Noise(&params->np_terrain_base,    seed, csize.X, csize.Z);


### PR DESCRIPTION
Commit cad10ce3b747b721fd63784915e05f12bc488128 altered the parameter
'float_mount_height' but was missing the necessary line in the constructor
to get the altered value from 'params'.

Fixes 3D floatland terrain generating everywhere.
////////////////

Tested.
Silly mistake, sorry for that.