### PR TITLE
Mapgen: Remove unnecessary 'this->' from constructors

### DIFF
--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -51,15 +51,15 @@ FlagDesc flagdesc_mapgen_flat[] = {
 MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
-	this->spflags          = params->spflags;
-	this->ground_level     = params->ground_level;
-	this->large_cave_depth = params->large_cave_depth;
-	this->lava_depth       = params->lava_depth;
-	this->cave_width       = params->cave_width;
-	this->lake_threshold   = params->lake_threshold;
-	this->lake_steepness   = params->lake_steepness;
-	this->hill_threshold   = params->hill_threshold;
-	this->hill_steepness   = params->hill_steepness;
+	spflags          = params->spflags;
+	ground_level     = params->ground_level;
+	large_cave_depth = params->large_cave_depth;
+	lava_depth       = params->lava_depth;
+	cave_width       = params->cave_width;
+	lake_threshold   = params->lake_threshold;
+	lake_steepness   = params->lake_steepness;
+	hill_threshold   = params->hill_threshold;
+	hill_steepness   = params->hill_steepness;
 
 	// 2D noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -49,19 +49,19 @@ FlagDesc flagdesc_mapgen_fractal[] = {
 MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
-	this->spflags          = params->spflags;
-	this->cave_width       = params->cave_width;
-	this->large_cave_depth = params->large_cave_depth;
-	this->lava_depth       = params->lava_depth;
-	this->fractal          = params->fractal;
-	this->iterations       = params->iterations;
-	this->scale            = params->scale;
-	this->offset           = params->offset;
-	this->slice_w          = params->slice_w;
-	this->julia_x          = params->julia_x;
-	this->julia_y          = params->julia_y;
-	this->julia_z          = params->julia_z;
-	this->julia_w          = params->julia_w;
+	spflags          = params->spflags;
+	cave_width       = params->cave_width;
+	large_cave_depth = params->large_cave_depth;
+	lava_depth       = params->lava_depth;
+	fractal          = params->fractal;
+	iterations       = params->iterations;
+	scale            = params->scale;
+	offset           = params->offset;
+	slice_w          = params->slice_w;
+	julia_x          = params->julia_x;
+	julia_y          = params->julia_y;
+	julia_z          = params->julia_z;
+	julia_w          = params->julia_w;
 
 	//// 2D terrain noise
 	noise_seabed       = new Noise(&params->np_seabed, seed, csize.X, csize.Z);
@@ -70,8 +70,8 @@ MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeMa
 	MapgenBasic::np_cave1 = params->np_cave1;
 	MapgenBasic::np_cave2 = params->np_cave2;
 
-	this->formula = fractal / 2 + fractal % 2;
-	this->julia   = fractal % 2 == 0;
+	formula = fractal / 2 + fractal % 2;
+	julia   = fractal % 2 == 0;
 }
 
 

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -48,13 +48,13 @@ FlagDesc flagdesc_mapgen_v5[] = {
 MapgenV5::MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
-	this->spflags          = params->spflags;
-	this->cave_width       = params->cave_width;
-	this->large_cave_depth = params->large_cave_depth;
-	this->lava_depth       = params->lava_depth;
-	this->cavern_limit     = params->cavern_limit;
-	this->cavern_taper     = params->cavern_taper;
-	this->cavern_threshold = params->cavern_threshold;
+	spflags          = params->spflags;
+	cave_width       = params->cave_width;
+	large_cave_depth = params->large_cave_depth;
+	lava_depth       = params->lava_depth;
+	cavern_limit     = params->cavern_limit;
+	cavern_taper     = params->cavern_taper;
+	cavern_threshold = params->cavern_threshold;
 
 	// Terrain noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -58,14 +58,14 @@ FlagDesc flagdesc_mapgen_v6[] = {
 MapgenV6::MapgenV6(int mapgenid, MapgenV6Params *params, EmergeManager *emerge)
 	: Mapgen(mapgenid, params, emerge)
 {
-	this->m_emerge = emerge;
-	this->ystride = csize.X; //////fix this
+	m_emerge = emerge;
+	ystride = csize.X; //////fix this
 
-	this->heightmap = new s16[csize.X * csize.Z];
+	heightmap = new s16[csize.X * csize.Z];
 
-	this->spflags     = params->spflags;
-	this->freq_desert = params->freq_desert;
-	this->freq_beach  = params->freq_beach;
+	spflags     = params->spflags;
+	freq_desert = params->freq_desert;
+	freq_beach  = params->freq_beach;
 
 	np_cave        = &params->np_cave;
 	np_humidity    = &params->np_humidity;

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -54,21 +54,21 @@ FlagDesc flagdesc_mapgen_v7[] = {
 MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
-	this->spflags             = params->spflags;
-	this->cave_width          = params->cave_width;
-	this->large_cave_depth    = params->large_cave_depth;
-	this->lava_depth          = params->lava_depth;
-	this->float_mount_density = params->float_mount_density;
-	this->floatland_level     = params->floatland_level;
-	this->shadow_limit        = params->shadow_limit;
-	this->cavern_limit        = params->cavern_limit;
-	this->cavern_taper        = params->cavern_taper;
-	this->cavern_threshold    = params->cavern_threshold;
+	spflags             = params->spflags;
+	cave_width          = params->cave_width;
+	large_cave_depth    = params->large_cave_depth;
+	lava_depth          = params->lava_depth;
+	float_mount_density = params->float_mount_density;
+	floatland_level     = params->floatland_level;
+	shadow_limit        = params->shadow_limit;
+	cavern_limit        = params->cavern_limit;
+	cavern_taper        = params->cavern_taper;
+	cavern_threshold    = params->cavern_threshold;
 
 	// This is to avoid a divide-by-zero.
 	// Parameter will be saved to map_meta.txt in limited form.
 	params->float_mount_height = MYMAX(params->float_mount_height, 1.0f);
-	this->float_mount_height   = params->float_mount_height;
+	float_mount_height   = params->float_mount_height;
 
 	// 2D noise
 	noise_terrain_base    = new Noise(&params->np_terrain_base,    seed, csize.X, csize.Z);

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -66,19 +66,19 @@ MapgenValleys::MapgenValleys(int mapgenid, MapgenValleysParams *params, EmergeMa
 	: MapgenBasic(mapgenid, params, emerge)
 {
 	// NOTE: MapgenValleys has a hard dependency on BiomeGenOriginal
-	this->m_bgen = (BiomeGenOriginal *)biomegen;
+	m_bgen = (BiomeGenOriginal *)biomegen;
 
 	BiomeParamsOriginal *bp = (BiomeParamsOriginal *)params->bparams;
 
-	this->spflags            = params->spflags;
-	this->altitude_chill     = params->altitude_chill;
-	this->large_cave_depth   = params->large_cave_depth;
-	this->lava_features_lim  = rangelim(params->lava_features, 0, 10);
-	this->massive_cave_depth = params->massive_cave_depth;
-	this->river_depth_bed    = params->river_depth + 1.f;
-	this->river_size_factor  = params->river_size / 100.f;
-	this->water_features_lim = rangelim(params->water_features, 0, 10);
-	this->cave_width         = params->cave_width;
+	spflags            = params->spflags;
+	altitude_chill     = params->altitude_chill;
+	large_cave_depth   = params->large_cave_depth;
+	lava_features_lim  = rangelim(params->lava_features, 0, 10);
+	massive_cave_depth = params->massive_cave_depth;
+	river_depth_bed    = params->river_depth + 1.f;
+	river_size_factor  = params->river_size / 100.f;
+	water_features_lim = rangelim(params->water_features, 0, 10);
+	cave_width         = params->cave_width;
 
 	//// 2D Terrain noise
 	noise_filler_depth       = new Noise(&params->np_filler_depth,       seed, csize.X, csize.Z);
@@ -96,13 +96,13 @@ MapgenValleys::MapgenValleys(int mapgenid, MapgenValleysParams *params, EmergeMa
 	noise_cave2             = new Noise(&params->np_cave2,             seed, csize.X, csize.Y + 1, csize.Z);
 	noise_massive_caves     = new Noise(&params->np_massive_caves,     seed, csize.X, csize.Y + 1, csize.Z);
 
-	this->humid_rivers       = (spflags & MGVALLEYS_HUMID_RIVERS);
-	this->use_altitude_chill = (spflags & MGVALLEYS_ALT_CHILL);
-	this->humidity_adjust    = bp->np_humidity.offset - 50.f;
+	humid_rivers       = (spflags & MGVALLEYS_HUMID_RIVERS);
+	use_altitude_chill = (spflags & MGVALLEYS_ALT_CHILL);
+	humidity_adjust    = bp->np_humidity.offset - 50.f;
 
 	// a small chance of overflows if the settings are very high
-	this->cave_water_max_height = water_level + MYMAX(0, water_features_lim - 4) * 50;
-	this->lava_max_height       = water_level + MYMAX(0, lava_features_lim - 4) * 50;
+	cave_water_max_height = water_level + MYMAX(0, water_features_lim - 4) * 50;
+	lava_max_height       = water_level + MYMAX(0, lava_features_lim - 4) * 50;
 
 	tcave_cache = new float[csize.Y + 2];
 }


### PR DESCRIPTION
As requested by @nerzhul 
I quickly ran each mapgen and they seem to generate ok at spawn.