### PR TITLE
World-aligned textures

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4126,12 +4126,15 @@ Definition tables
 * `"image.png"`
 * `{name="image.png", animation={Tile Animation definition}}`
 * `{name="image.png", backface_culling=bool, tileable_vertical=bool,
-    tileable_horizontal=bool}`
+    tileable_horizontal=bool, world_aligned=bool}`
     * backface culling enabled by default for most nodes
     * tileable flags are info for shaders, how they should treat texture
 	  when displacement mapping is used
 	  Directions are from the point of view of the tile texture,
 	  not the node it's on
+    * world-aligned textures are not rotated with the node. Used to make
+          various semiblocks look consistent with surrounding nodes.
+          Supported by solid nodes and nodeboxes only.
 * `{name="image.png", color=ColorSpec}`
     * the texture's color will be multiplied with this color.
     * the tile's color overrides the owning node's color in all cases.

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -318,6 +318,9 @@ struct TileSpec
 			&& emissive_light == other.emissive_light;
 	}
 
+	//! If true, the tile rotation is ignored.
+	bool world_aligned = false;
+	//! Tile rotation.
 	u8 rotation = 0;
 	//! This much light does the tile emit.
 	u8 emissive_light = 0;

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -1200,8 +1200,7 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	TileSpec tiles[6];
 	for (int face = 0; face < 6; face++) {
 		// Handles facedir rotation for textures
-		getTile(face, &tiles[face]);
-// 		getTile(tile_dirs[face], &tiles[face]);
+		getTile(tile_dirs[face], &tiles[face]);
 	}
 
 	// locate possible neighboring nodes to connect to

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -78,7 +78,7 @@ void MapblockMeshGenerator::useTile(int index, u8 set_flags, u8 reset_flags, boo
 	if (special)
 		getSpecialTile(index, &tile, p == data->m_crack_pos_relative);
 	else
-		getNodeTileN(n, p, index, data, tile);
+		getTile(index, &tile);
 	if (!data->m_smooth_lighting)
 		color = encode_light(light, f->light_source);
 	for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
@@ -87,14 +87,19 @@ void MapblockMeshGenerator::useTile(int index, u8 set_flags, u8 reset_flags, boo
 	}
 }
 
+// Returns a tile, ready for use, non-rotated.
+void MapblockMeshGenerator::getTile(int index, TileSpec *tile)
+{
+	getNodeTileN(n, p, index, data, *tile);
+}
+
+// Returns a tile, ready for use, rotated according to the node facedir.
 void MapblockMeshGenerator::getTile(v3s16 direction, TileSpec *tile)
 {
 	getNodeTile(n, p, direction, data, *tile);
 }
 
-/*!
- * Returns the i-th special tile for a map node.
- */
+// Returns a special tile, ready for use, non-rotated.
 void MapblockMeshGenerator::getSpecialTile(int index, TileSpec *tile, bool apply_crack)
 {
 	*tile = f->special_tiles[index];
@@ -1195,7 +1200,8 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	TileSpec tiles[6];
 	for (int face = 0; face < 6; face++) {
 		// Handles facedir rotation for textures
-		getTile(tile_dirs[face], &tiles[face]);
+		getTile(face, &tiles[face]);
+// 		getTile(tile_dirs[face], &tiles[face]);
 	}
 
 	// locate possible neighboring nodes to connect to

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -64,6 +64,7 @@ public:
 
 	void useTile(int index = 0, u8 set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
 		u8 reset_flags = 0, bool special = false);
+	void getTile(int index, TileSpec *tile);
 	void getTile(v3s16 direction, TileSpec *tile);
 	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
 

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -764,7 +764,7 @@ void getNodeTile(MapNode mn, v3s16 p, v3s16 dir, MeshMakeData *data, TileSpec &t
 	};
 	u16 tile_index=facedir*16 + dir_i;
 	getNodeTileN(mn, p, dir_to_tile[tile_index], data, tile);
-	tile.rotation = dir_to_tile[tile_index + 1];
+	tile.rotation = tile.world_aligned ? 0 : dir_to_tile[tile_index + 1];
 }
 
 static void getTileInfo(

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -160,9 +160,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			instead of guessing based on the active object list.
 	PROTOCOL VERSION 34:
 		Add sound pitch
+	PROTOCOL VERSION 35:
+		Change TileDef serialization format.
+		Add world-aligned tiles.
 */
 
-#define LATEST_PROTOCOL_VERSION 34
+#define LATEST_PROTOCOL_VERSION 35
 
 // Server's supported network protocol range
 #define SERVER_PROTOCOL_VERSION_MIN 24

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -844,12 +844,12 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			(!node_box.fixed.empty())) {
 		//Convert regular nodebox nodes to meshnodes
 		//Change the drawtype and apply scale
-		drawtype = NDT_MESH;
-		mesh_ptr[0] = convertNodeboxesToMesh(node_box.fixed);
-		v3f scale = v3f(1.0, 1.0, 1.0) * visual_scale;
-		scaleMesh(mesh_ptr[0], scale);
-		recalculateBoundingBox(mesh_ptr[0]);
-		meshmanip->recalculateNormals(mesh_ptr[0], true, false);
+// 		drawtype = NDT_MESH;
+// 		mesh_ptr[0] = convertNodeboxesToMesh(node_box.fixed);
+// 		v3f scale = v3f(1.0, 1.0, 1.0) * visual_scale;
+// 		scaleMesh(mesh_ptr[0], scale);
+// 		recalculateBoundingBox(mesh_ptr[0]);
+// 		meshmanip->recalculateNormals(mesh_ptr[0], true, false);
 	}
 
 	//Cache 6dfacedir and wallmounted rotated clones of meshes

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -881,18 +881,6 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 			recalculateBoundingBox(mesh_ptr[0]);
 			meshmanip->recalculateNormals(mesh_ptr[0], true, false);
 		}
-	} else if ((drawtype == NDT_NODEBOX) &&
-			((node_box.type == NODEBOX_REGULAR) ||
-			(node_box.type == NODEBOX_FIXED)) &&
-			(!node_box.fixed.empty())) {
-		//Convert regular nodebox nodes to meshnodes
-		//Change the drawtype and apply scale
-// 		drawtype = NDT_MESH;
-// 		mesh_ptr[0] = convertNodeboxesToMesh(node_box.fixed);
-// 		v3f scale = v3f(1.0, 1.0, 1.0) * visual_scale;
-// 		scaleMesh(mesh_ptr[0], scale);
-// 		recalculateBoundingBox(mesh_ptr[0]);
-// 		meshmanip->recalculateNormals(mesh_ptr[0], true, false);
 	}
 
 	//Cache 6dfacedir and wallmounted rotated clones of meshes

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -187,9 +187,17 @@ void NodeBox::deSerialize(std::istream &is)
 	TileDef
 */
 
+#define TILE_FLAG_BACKFACE_CULLING 0x0001
+#define TILE_FLAG_TILEABLE_HORIZONTAL 0x0002
+#define TILE_FLAG_TILEABLE_VERTICAL 0x0004
+#define TILE_FLAG_HAS_COLOR 0x0008
+#define TILE_FLAG_WORLD_ALIGNED 0x0010
+
 void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version >= 30)
+	if (protocol_version >= 35)
+		writeU8(os, 5);
+	else if (protocol_version >= 30)
 		writeU8(os, 4);
 	else if (protocol_version >= 29)
 		writeU8(os, 3);
@@ -200,6 +208,26 @@ void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 
 	os << serializeString(name);
 	animation.serialize(os, protocol_version);
+	if (protocol_version >= 35) {
+		u16 flags = 0;
+		if (backface_culling)
+			flags |= TILE_FLAG_BACKFACE_CULLING;
+		if (tileable_horizontal)
+			flags |= TILE_FLAG_TILEABLE_HORIZONTAL;
+		if (tileable_vertical)
+			flags |= TILE_FLAG_TILEABLE_VERTICAL;
+		if (has_color)
+			flags |= TILE_FLAG_HAS_COLOR;
+		if (world_aligned)
+			flags |= TILE_FLAG_WORLD_ALIGNED;
+		writeU16(os, flags);
+		if (has_color) {
+			writeU8(os, color.getRed());
+			writeU8(os, color.getGreen());
+			writeU8(os, color.getBlue());
+		}
+		return;
+	}
 	writeU8(os, backface_culling);
 	if (protocol_version >= 26) {
 		writeU8(os, tileable_horizontal);
@@ -220,6 +248,20 @@ void TileDef::deSerialize(std::istream &is, const u8 contenfeatures_version, con
 	int version = readU8(is);
 	name = deSerializeString(is);
 	animation.deSerialize(is, version >= 3 ? 29 : 26);
+	if (version >= 5) {
+		u16 flags = readU16(is);
+		backface_culling = flags & TILE_FLAG_BACKFACE_CULLING;
+		tileable_horizontal = flags & TILE_FLAG_TILEABLE_HORIZONTAL;
+		tileable_vertical = flags & TILE_FLAG_TILEABLE_VERTICAL;
+		has_color = flags & TILE_FLAG_HAS_COLOR;
+		world_aligned = flags & TILE_FLAG_WORLD_ALIGNED;
+		if (has_color) {
+			color.setRed(readU8(is));
+			color.setGreen(readU8(is));
+			color.setBlue(readU8(is));
+		}
+		return;
+	}
 	if (version >= 1)
 		backface_culling = readU8(is);
 	if (version >= 2) {
@@ -798,6 +840,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
+		tiles[j].world_aligned = tdef[j].world_aligned;
 		fillTileAttribs(tsrc, &tiles[j].layers[0], &tdef[j], tile_shader,
 			tsettings.use_normal_texture,
 			tdef[j].backface_culling, material_type);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -218,6 +218,7 @@ struct TileDef
 	bool has_color = false;
 	//! The color of the tile.
 	video::SColor color = video::SColor(0xFFFFFFFF);
+	bool world_aligned = false;
 
 	struct TileAnimationParams animation;
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -396,6 +396,8 @@ TileDef read_tiledef(lua_State *L, int index, u8 drawtype)
 			L, index, "tileable_horizontal", default_tiling);
 		tiledef.tileable_vertical = getboolfield_default(
 			L, index, "tileable_vertical", default_tiling);
+		tiledef.world_aligned = getboolfield_default(
+			L, index, "world_aligned", false);
 		// color = ...
 		lua_getfield(L, index, "color");
 		tiledef.has_color = read_color(L, -1, &tiledef.color);


### PR DESCRIPTION
#5993 
***UPD: Superseded by #6105 (merged)***
~~Right now, it fixes #5222; but now it acts unconditionally, that should be changed. IMO there should be new tile properties for that, smth like `world_align` (bool) and `scale` (float).~~
***UPD:** Fixes #5222 adding new `world_align` tile property. `scale` will be added in another PR.*
![screenshot_20170702_234954](https://user-images.githubusercontent.com/7352626/27773439-5a271012-5f82-11e7-8efd-7d53a586ddf9.png)
*Old screenshots:*

**Before**
![screenshot_20170629_021008](https://user-images.githubusercontent.com/7352626/27664764-15c75174-5c72-11e7-8d9d-d8efde57226a.png)

**After**
![screenshot_20170629_020901](https://user-images.githubusercontent.com/7352626/27664773-215448bc-5c72-11e7-960b-13e306ab6297.png)

Right now it works for nodeboxes *and solid nodes* only; for meshes that’s not that trivial, but correct rotation is achievable, at least. *But that seems to be out of scope of this PR.*

P.S. You may find first two commits in some other my PR...