### PR TITLE
Irrlicht cleanup: cleanup various object to use RenderingEngine

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -54,7 +54,7 @@ Camera::Camera(MapDrawControl &draw_control, Client *client):
 	// all other 3D scene nodes and before the GUI.
 	m_wieldmgr = smgr->createNewSceneManager();
 	m_wieldmgr->addCameraSceneNode();
-	m_wieldnode = new WieldMeshSceneNode(m_wieldmgr->getRootSceneNode(), m_wieldmgr, -1, false);
+	m_wieldnode = new WieldMeshSceneNode(m_wieldmgr, -1, false);
 	m_wieldnode->setItem(ItemStack(), m_client);
 	m_wieldnode->drop(); // m_wieldmgr grabbed it
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -38,16 +38,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define CAMERA_OFFSET_STEP 200
 
-#include "nodedef.h"
-
-Camera::Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
-		Client *client):
+Camera::Camera(MapDrawControl& draw_control, Client *client):
 	m_draw_control(draw_control),
 	m_client(client)
 {
-	//dstream<<FUNCTION_NAME<<std::endl;
-
-	m_driver = smgr->getVideoDriver();
+	scene::ISceneManager *smgr = RenderingEngine::get_scene_manager();
 	// note: making the camera node a child of the player node
 	// would lead to unexpected behaviour, so we don't do that.
 	m_playernode = smgr->addEmptySceneNode(smgr->getRootSceneNode());
@@ -624,7 +619,7 @@ void Camera::drawNametags()
 				utf8_to_wide(nametag_colorless).c_str());
 			f32 zDiv = transformed_pos[3] == 0.0f ? 1.0f :
 				core::reciprocal(transformed_pos[3]);
-			v2u32 screensize = m_driver->getScreenSize();
+			v2u32 screensize = RenderingEngine::get_video_driver()->getScreenSize();
 			v2s32 screen_pos;
 			screen_pos.X = screensize.X *
 				(0.5 * transformed_pos[0] * zDiv + 0.5) - textsize.Width / 2;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -38,7 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define CAMERA_OFFSET_STEP 200
 
-Camera::Camera(MapDrawControl& draw_control, Client *client):
+Camera::Camera(MapDrawControl &draw_control, Client *client):
 	m_draw_control(draw_control),
 	m_client(client)
 {

--- a/src/camera.h
+++ b/src/camera.h
@@ -60,8 +60,7 @@ enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};
 class Camera
 {
 public:
-	Camera(scene::ISceneManager* smgr, MapDrawControl& draw_control,
-			Client *client);
+	Camera(MapDrawControl& draw_control, Client *client);
 	~Camera();
 
 	// Get camera scene node.
@@ -181,7 +180,6 @@ private:
 	MapDrawControl& m_draw_control;
 
 	Client *m_client;
-	video::IVideoDriver *m_driver;
 
 	// Absolute camera position
 	v3f m_camera_position;

--- a/src/camera.h
+++ b/src/camera.h
@@ -60,7 +60,7 @@ enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};
 class Camera
 {
 public:
-	Camera(MapDrawControl& draw_control, Client *client);
+	Camera(MapDrawControl &draw_control, Client *client);
 	~Camera();
 
 	// Get camera scene node.

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -23,9 +23,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "irr_v3d.h"
 #include <ITexture.h>
-#include <IrrlichtDevice.h>
 #include <string>
 #include <vector>
+#include <SMaterial.h>
 #include "util/numeric.h"
 
 class IGameDef;

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -456,7 +456,7 @@ u16 ClientEnvironment::addActiveObject(ClientActiveObject *object)
 	infostream<<"ClientEnvironment::addActiveObject(): "
 		<<"added (id="<<object->getId()<<")"<<std::endl;
 	m_active_objects[object->getId()] = object;
-	object->addToScene(RenderingEngine::get_scene_manager(), m_texturesource);
+	object->addToScene(m_texturesource);
 	{ // Update lighting immediately
 		u8 light = 0;
 		bool pos_ok;

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes_extrabloated.h"
 #include "activeobject.h"
-#include <map>
 #include <unordered_map>
 
 class ClientEnvironment;
@@ -39,7 +38,7 @@ public:
 	ClientActiveObject(u16 id, Client *client, ClientEnvironment *env);
 	virtual ~ClientActiveObject();
 
-	virtual void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc) {};
+	virtual void addToScene(ITextureSource *tsrc) {};
 	virtual void removeFromScene(bool permanent) {}
 	// 0 <= light_at_pos <= LIGHT_SUN
 	virtual void updateLight(u8 light_at_pos){}

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -866,7 +866,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 			item.deSerialize(m_prop.wield_item, m_client->idef());
 		}
 		m_wield_meshnode = new WieldMeshSceneNode(
-			RenderingEngine::get_scene_manager()->getRootSceneNode(),
 			RenderingEngine::get_scene_manager(), -1);
 		m_wield_meshnode->setItem(item, m_client);
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -22,7 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IBillboardSceneNode.h>
 #include <IMeshManipulator.h>
 #include <IAnimatedMeshSceneNode.h>
-#include <IBoneSceneNode.h>
 #include "content_cao.h"
 #include "util/numeric.h" // For IntervalLimiter
 #include "util/serialize.h"
@@ -43,8 +42,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "camera.h" // CameraModes
 #include "wieldmesh.h"
-#include "log.h"
 #include <algorithm>
+#include "client/renderingengine.h"
 
 class Settings;
 struct ToolCapabilities;
@@ -128,7 +127,7 @@ public:
 
 	static ClientActiveObject* create(Client *client, ClientEnvironment *env);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
+	void addToScene(ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
 	void updateLight(u8 light_at_pos);
 	v3s16 getLightPosition();
@@ -164,7 +163,7 @@ ClientActiveObject* TestCAO::create(Client *client, ClientEnvironment *env)
 	return new TestCAO(client, env);
 }
 
-void TestCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
+void TestCAO::addToScene(ITextureSource *tsrc)
 {
 	if(m_node != NULL)
 		return;
@@ -193,7 +192,7 @@ void TestCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 	// Add to mesh
 	mesh->addMeshBuffer(buf);
 	buf->drop();
-	m_node = smgr->addMeshSceneNode(mesh, NULL);
+	m_node = RenderingEngine::get_scene_manager()->addMeshSceneNode(mesh, NULL);
 	mesh->drop();
 	updateNodePos();
 }
@@ -270,7 +269,7 @@ public:
 
 	static ClientActiveObject* create(Client *client, ClientEnvironment *env);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
+	void addToScene(ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
 	void updateLight(u8 light_at_pos);
 	v3s16 getLightPosition();
@@ -326,7 +325,7 @@ ClientActiveObject* ItemCAO::create(Client *client, ClientEnvironment *env)
 	return new ItemCAO(client, env);
 }
 
-void ItemCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
+void ItemCAO::addToScene(ITextureSource *tsrc)
 {
 	if(m_node != NULL)
 		return;
@@ -360,7 +359,7 @@ void ItemCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 	// Add to mesh
 	mesh->addMeshBuffer(buf);
 	buf->drop();
-	m_node = smgr->addMeshSceneNode(mesh, NULL);
+	m_node = RenderingEngine::get_scene_manager()->addMeshSceneNode(mesh, NULL);
 	mesh->drop();
 	updateNodePos();
 
@@ -717,9 +716,9 @@ void GenericCAO::removeFromScene(bool permanent)
 	}
 }
 
-void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
+void GenericCAO::addToScene(ITextureSource *tsrc)
 {
-	m_smgr = smgr;
+	m_smgr = RenderingEngine::get_scene_manager();
 
 	if (getSceneNode() != NULL) {
 		return;
@@ -733,7 +732,7 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 
 	if (m_prop.visual == "sprite") {
 		infostream<<"GenericCAO::addToScene(): single_sprite"<<std::endl;
-		m_spritenode = smgr->addBillboardSceneNode(
+		m_spritenode = RenderingEngine::get_scene_manager()->addBillboardSceneNode(
 				NULL, v2f(1, 1), v3f(0,0,0), -1);
 		m_spritenode->grab();
 		m_spritenode->setMaterialTexture(0,
@@ -796,7 +795,7 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 			mesh->addMeshBuffer(buf);
 			buf->drop();
 		}
-		m_meshnode = smgr->addMeshSceneNode(mesh, NULL);
+		m_meshnode = RenderingEngine::get_scene_manager()->addMeshSceneNode(mesh, NULL);
 		m_meshnode->grab();
 		mesh->drop();
 		// Set it to use the materials of the meshbuffers directly.
@@ -806,7 +805,7 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 	else if(m_prop.visual == "cube") {
 		infostream<<"GenericCAO::addToScene(): cube"<<std::endl;
 		scene::IMesh *mesh = createCubeMesh(v3f(BS,BS,BS));
-		m_meshnode = smgr->addMeshSceneNode(mesh, NULL);
+		m_meshnode = RenderingEngine::get_scene_manager()->addMeshSceneNode(mesh, NULL);
 		m_meshnode->grab();
 		mesh->drop();
 
@@ -826,7 +825,8 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh);
 		if(mesh)
 		{
-			m_animated_meshnode = smgr->addAnimatedMeshSceneNode(mesh, NULL);
+			m_animated_meshnode = RenderingEngine::get_scene_manager()->
+				addAnimatedMeshSceneNode(mesh, NULL);
 			m_animated_meshnode->grab();
 			mesh->drop(); // The scene node took hold of it
 			m_animated_meshnode->animateJoints(); // Needed for some animations
@@ -865,8 +865,9 @@ void GenericCAO::addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc)
 			infostream << "serialized form: " << m_prop.wield_item << std::endl;
 			item.deSerialize(m_prop.wield_item, m_client->idef());
 		}
-		m_wield_meshnode = new WieldMeshSceneNode(smgr->getRootSceneNode(),
-			smgr, -1);
+		m_wield_meshnode = new WieldMeshSceneNode(
+			RenderingEngine::get_scene_manager()->getRootSceneNode(),
+			RenderingEngine::get_scene_manager(), -1);
 		m_wield_meshnode->setItem(item, m_client);
 
 		m_wield_meshnode->setScale(
@@ -1050,7 +1051,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		}
 
 		removeFromScene(false);
-		addToScene(m_smgr, m_client->tsrc());
+		addToScene(m_client->tsrc());
 
 		// Attachments, part 2: Now that the parent has been refreshed, put its attachments back
 		for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -168,7 +168,7 @@ public:
 
 	void removeFromScene(bool permanent);
 
-	void addToScene(scene::ISceneManager *smgr, ITextureSource *tsrc);
+	void addToScene(ITextureSource *tsrc);
 
 	inline void expireVisuals()
 	{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1914,7 +1914,7 @@ bool Game::createClient(const std::string &playername,
 
 	/* Camera
 	 */
-	camera = new Camera(smgr, *draw_control, client);
+	camera = new Camera(*draw_control, client);
 	if (!camera || !camera->successfullyCreated(*error_message))
 		return false;
 	client->setCamera(camera);
@@ -1971,7 +1971,7 @@ bool Game::createClient(const std::string &playername,
 	player->hurt_tilt_timer = 0;
 	player->hurt_tilt_strength = 0;
 
-	hud = new Hud(driver, smgr, guienv, client, player, local_inventory);
+	hud = new Hud(guienv, client, player, local_inventory);
 
 	if (!hud) {
 		*error_message = "Memory error: could not create HUD";

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -40,10 +40,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "touchscreengui.h"
 #endif
 
-Hud::Hud(gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
+Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory)
 {
-	driver      = RenderingEngine::get_video_driver();
+	driver            = RenderingEngine::get_video_driver();
 	this->guienv      = guienv;
 	this->client      = client;
 	this->player      = player;

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -40,12 +40,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "touchscreengui.h"
 #endif
 
-Hud::Hud(video::IVideoDriver *driver, scene::ISceneManager* smgr,
-		gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
+Hud::Hud(gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory)
 {
-	this->driver      = driver;
-	this->smgr        = smgr;
+	driver      = RenderingEngine::get_video_driver();
 	this->guienv      = guienv;
 	this->client      = client;
 	this->player      = player;
@@ -339,7 +337,8 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				v3f p_pos = player->getPosition() / BS;
 				v3f w_pos = e->world_pos * BS;
 				float distance = floor(10 * p_pos.getDistanceFrom(e->world_pos)) / 10;
-				scene::ICameraSceneNode* camera = smgr->getActiveCamera();
+				scene::ICameraSceneNode* camera =
+					RenderingEngine::get_scene_manager()->getActiveCamera();
 				w_pos -= intToFloat(camera_offset, BS);
 				core::matrix4 trans = camera->getProjectionMatrix();
 				trans *= camera->getViewMatrix();

--- a/src/hud.h
+++ b/src/hud.h
@@ -120,8 +120,7 @@ public:
 	std::string hotbar_selected_image = "";
 	bool use_hotbar_selected_image = false;
 
-	Hud(video::IVideoDriver *driver,scene::ISceneManager* smgr,
-		gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
+	Hud(gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory);
 	~Hud();
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -120,7 +120,7 @@ public:
 	std::string hotbar_selected_image = "";
 	bool use_hotbar_selected_image = false;
 
-	Hud(gui::IGUIEnvironment* guienv, Client *client, LocalPlayer *player,
+	Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory);
 	~Hud();
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef SERVER
 #include "client/tile.h"
 #include "shader.h"
+#include <IMeshManipulator.h>
 class Client;
 #endif
 #include "itemgroup.h"

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -192,13 +192,8 @@ private:
 ExtrusionMeshCache *g_extrusion_mesh_cache = NULL;
 
 
-WieldMeshSceneNode::WieldMeshSceneNode(
-		scene::ISceneNode *parent,
-		scene::ISceneManager *mgr,
-		s32 id,
-		bool lighting
-):
-	scene::ISceneNode(parent, mgr, id),
+WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id, bool lighting):
+	scene::ISceneNode(mgr->getRootSceneNode(), mgr, id),
 	m_material_type(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF),
 	m_lighting(lighting)
 {

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -74,8 +74,7 @@ struct ItemMesh
 class WieldMeshSceneNode : public scene::ISceneNode
 {
 public:
-	WieldMeshSceneNode(scene::ISceneNode *parent, scene::ISceneManager *mgr,
-			s32 id = -1, bool lighting = false);
+	WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id = -1, bool lighting = false);
 	virtual ~WieldMeshSceneNode();
 
 	void setCube(const ContentFeatures &f, v3f wield_scale);


### PR DESCRIPTION
* CAO doesn't need scenemanager in addToScene
* Camera doesn't need VideoDriver pointer or SceneManager in constructor
* Hud doesn't need driver & scene manager in constructor
* Hud doesn't need scenemanager pointer
* Tile.h doesn't need IrrlichtDevice header (just SMaterial)