### PR TITLE
Revert "[CSM] Add send_chat_message and run_server_chatcommand"

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -51,15 +51,3 @@ core.register_chatcommand("disconnect", {
 		core.disconnect()
 	end,
 })
-
-core.register_chatcommand("clear_chat_queue", {
-	description = core.gettext("Clear the out chat queue"),
-	func = function(param)
-		core.clear_out_chat_queue()
-		return true, core.gettext("The out chat queue is now empty")
-	end,
-})
-
-function core.run_server_chatcommand(cmd, param)
-	core.send_chat_message("/" .. cmd .. " " .. param)
-end

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -315,9 +315,6 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 #    File in client/serverlist/ that contains your favorite servers displayed in the Multiplayer Tab.
 serverlist_file (Serverlist file) string favoriteservers.txt
 
-#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
-max_out_chat_queue_size (Maximum size of the out chat queue) int 20
-
 [*Graphics]
 
 [**In-Game]

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -721,12 +721,6 @@ Call these functions only at load time!
 ### Player
 * `minetest.get_wielded_item()`
     * Returns the itemstack the local player is holding
-* `minetest.send_chat_message(message)`
-    * Act as if `message` was typed by the player into the terminal.
-* `minetest.run_server_chatcommand(cmd, param)`
-    * Alias for `minetest.send_chat_message("/" .. cmd .. " " .. param)`
-* `minetest.clear_out_chat_queue()`
-    * Clears the out chat queue
 * `minetest.localplayer`
     * Reference to the LocalPlayer object. See [`LocalPlayer`](#localplayer) class reference for methods.
 
@@ -853,7 +847,7 @@ Please do not try to access the reference until the camera is initialized, other
     * Returns with same syntax as above
 * `get_fov()`
     * Returns:
-
+    
 ```lua
      {
          x = number,
@@ -862,7 +856,7 @@ Please do not try to access the reference until the camera is initialized, other
          actual = number
      }
 ```
-
+    
 * `get_pos()`
     * Returns position of camera with view bobbing
 * `get_offset()`

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -343,10 +343,6 @@
 #    type: string
 # serverlist_file = favoriteservers.txt
 
-#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
-#    type: int
-# max_out_chat_queue_size = 20
-
 ## Graphics
 
 ### In-Game
@@ -1877,4 +1873,3 @@
 #    Print the engine's profiling data in regular intervals (in seconds). 0 = disable. Useful for developers.
 #    type: int
 # profiler_print_interval = 0
-

--- a/src/client.h
+++ b/src/client.h
@@ -40,8 +40,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <fstream>
 #include "filesys.h"
 
-#define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
-
 struct MeshMakeData;
 class MapBlockMesh;
 class IWritableTextureSource;
@@ -375,7 +373,6 @@ public:
 		const StringMap &fields);
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
-	void clearOutChatQueue();
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
 	void sendDamage(u8 damage);
@@ -582,8 +579,6 @@ private:
 	inline std::string getPlayerName()
 	{ return m_env.getLocalPlayer()->getName(); }
 
-	bool canSendChatMessage() const;
-
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;
 	float m_avg_rtt_timer = 0.0f;
@@ -630,9 +625,6 @@ private:
 	//s32 m_daynight_i;
 	//u32 m_daynight_ratio;
 	std::queue<std::wstring> m_chat_queue;
-	std::queue<std::wstring> m_out_chat_queue;
-	u32 m_last_chat_message_sent;
-	float m_chat_message_allowance = 5.0f;
 
 	// The authentication methods we can use to enter sudo mode (=change password)
 	u32 m_sudo_auth_methods;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -57,7 +57,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
-	settings->setDefault("max_out_chat_queue_size", "20");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -85,23 +85,6 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
-// send_chat_message(message)
-int ModApiClient::l_send_chat_message(lua_State *L)
-{
-	if (!lua_isstring(L, 1))
-		return 0;
-	std::string message = luaL_checkstring(L, 1);
-	getClient(L)->sendChatMessage(utf8_to_wide(message));
-	return 0;
-}
-
-// clear_out_chat_queue()
-int ModApiClient::l_clear_out_chat_queue(lua_State *L)
-{
-	getClient(L)->clearOutChatQueue();
-	return 0;
-}
-
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
@@ -354,8 +337,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_current_modname);
 	API_FCT(print);
 	API_FCT(display_chat_message);
-	API_FCT(send_chat_message);
-	API_FCT(clear_out_chat_queue);
 	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -37,12 +37,6 @@ private:
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 
-	// send_chat_message(message)
-	static int l_send_chat_message(lua_State *L);
-
-	// clear_out_chat_queue()
-	static int l_clear_out_chat_queue(lua_State *L);
-
 	// get_player_names()
 	static int l_get_player_names(lua_State *L);
 


### PR DESCRIPTION
These functions have no good usecase, and are very abusable. The usecase of sending commands to the server should be done with mod communication channels, which the server needs to choose to use.

Original PR: #5747

This reverts commit 39f4a2f607d44738d60db84eba4b30e3d7450204.

Related #5915 