### PR TITLE
Main Menu: Allow copying directories from non-Minetest locations

### DIFF
--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -814,8 +814,7 @@ int ModApiMainMenu::l_copy_dir(lua_State *L)
 	std::string absolute_destination = fs::RemoveRelativePathComponents(destination);
 	std::string absolute_source = fs::RemoveRelativePathComponents(source);
 
-	if ((ModApiMainMenu::isMinetestPath(absolute_source)) &&
-			(ModApiMainMenu::isMinetestPath(absolute_destination))) {
+	if ((ModApiMainMenu::isMinetestPath(absolute_destination))) {
 		bool retval = fs::CopyDir(absolute_source,absolute_destination);
 
 		if (retval && (!keep_source)) {


### PR DESCRIPTION
Allow `core.copy_dir` (main menu API) to copy directories from a non-Minetest location. The check to disallow copying to non-Minetest locations is retained.

This is important as without the ability to copy *from* (note: not *to*) non-Minetest locations via the `core.copy_dir` Lua API my `modmgr` rewrite would be unable to install mods from raw directories and would be limited only to ZIP files.