### PR TITLE
Lua API: Add get_nodes_in_area()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2469,6 +2469,8 @@ and `minetest.auth_reload` call the authetification handler.
 * `minetest.find_nodes_in_area_under_air(pos1, pos2, nodenames)`: returns a list of positions
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
     * Return value: Table with all node positions with a node air above
+* `minetest.get_nodes_in_area(pos1, pos2)`: returns a list of nodenames and positions
+    * Return value: Table with all node names and their positions
 * `minetest.get_perlin(noiseparams)`
 * `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
     * Return world-specific perlin noise (`int(worldseed)+seeddiff`)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -129,6 +129,9 @@ private:
 	// nodenames: eg. {"ignore", "group:tree"} or "default:dirt"
 	static int l_find_nodes_in_area_under_air(lua_State *L);
 
+	// get_nodes_in_area(minp, maxp, nodenames) -> list of nodenames and positions
+	static int l_get_nodes_in_area(lua_State *L);
+
 	// fix_light(p1, p2) -> true/false
 	static int l_fix_light(lua_State *L);
 


### PR DESCRIPTION
```Lua
minetest.get_nodes_in_area(pos1, pos2)
```
----------------------------------------------------------

Possible usecases:

- Comparing several areas.
- Reseting an area to its previous state(s).
- Etc.

Returns a table like that:

```Lua
{
	{
		name = "default:sand",
		pos = {
			y = 1,
			x = 4,
			z = 3
		}
	},

	[...]

	{
		name = "default:copperblock",
		pos = {
			y = 1,
			x = 4,
			z = 4
		}
	},
}
```