### PR TITLE
Advanced settings: Reformat noise parameter format example

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -466,8 +466,9 @@ local function create_change_setting_formspec(dialogdata)
 				.. core.formspec_escape(setting.possible:gsub(",", ", ")) .. ","
 	elseif setting.type == "noise_params" then
 		formspec = formspec .. ",,"
-				.. "," .. fgettext("Format: <offset>, <scale>, (<spreadX>, <spreadY>, <spreadZ>), <seed>, <octaves>, <persistence>") .. ","
-				.. "," .. fgettext("Optionally the lacunarity can be appended with a leading comma.") .. ","
+				.. "," .. fgettext("Format:") .. ","
+				.. "," .. fgettext("<offset>, <scale>, (<spreadX>, <spreadY>, <spreadZ>),") .. ","
+				.. "," .. fgettext("<seed>, <octaves>, <persistence>, <lacunarity>") .. ","
 	elseif setting.type == "v3f" then
 		formspec = formspec .. ",,"
 				.. "," .. fgettext_ne("Format is 3 numbers separated by commas and inside brackets.") .. ","


### PR DESCRIPTION
Previously the example ran off the edge of the formspec.
Also include 'lacunarity' in the format instead of treating it as an option.
////////////////

![screenshot from 2017-07-09 21-06-53](https://user-images.githubusercontent.com/3686677/27997216-6ce8c60a-64eb-11e7-990b-fdaa5cea7636.png)

^ This PR.