### PR TITLE
Improve inside cloud fog

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4124,7 +4124,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 						.getInterpolated(video::SColor(255, 0, 0, 0), 0.9);
 				sky->overrideColors(clouds_dark, clouds->getColor());
 				sky->setBodiesVisible(false);
-				runData.fog_range = 20.0f * BS;
+				runData.fog_range = MYMIN(runData.fog_range * 0.5f, 32.0f * BS);
 				// do not draw clouds after all
 				clouds->setVisible(false);
 			}


### PR DESCRIPTION
Trivial change for #6115. Takes fog_range into account instead of hardcoding a range of 20 when inside a cloud. 20 looks unrealistic when fog_range is larger - in that case one can look through a cloud, but when inside a cloud the range is shorter, which is weird.