### PR TITLE
Add `rmdir` and `cpdir` filesystem APIs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2194,6 +2194,15 @@ Helper functions
 * `minetest.mkdir(path)`: returns success.
     * Creates a directory specified by `path`, creating parent directories
       if they don't exist.
+* `minetest.rmdir(path, recursive)`: returns success.
+    * Removes a directory specified by `path`.
+    * If `recursive` is set to `true`, the directory is recursively removed.
+      Otherwise, the directory will only be removed if it is empty.
+* `minetest.cpdir(source, destination, remove_source)`: returns success.
+    * Copies a directory specified by `path` to `destination`, `destination` is
+      overwritten if it already exists.
+    * If `remove_source` is set to `true`, the `source` directory is removed
+      after copying to the `destination`.
 * `minetest.get_dir_list(path, [is_dir])`: returns list of entry names
     * is_dir is one of:
       * nil: return all entries,

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -329,6 +329,51 @@ int ModApiUtil::l_mkdir(lua_State *L)
 	return 1;
 }
 
+// rmdir(path, recursive)
+int ModApiUtil::l_rmdir(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	const char *path = luaL_checkstring(L, 1);
+	CHECK_SECURE_PATH(L, path, true);
+
+	bool recursive = false;
+
+	if (!lua_isnil(L, 2)) {
+		recursive = lua_toboolean(L, 2);
+	}
+
+	if (recursive) {
+		lua_pushboolean(L, fs::RecursiveDelete(path));
+	} else {
+		lua_pushboolean(L, fs::DeleteSingleFileOrEmptyDirectory(path));
+	}
+	return 1;
+}
+
+// cpdir(source, destination, remove_source)
+int ModApiUtil::l_cpdir(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	const char *source = luaL_checkstring(L, 1);
+	const char *destination = luaL_checkstring(L, 2);
+	CHECK_SECURE_PATH(L, destination, true);
+
+	bool remove_source = false;
+
+	if (!lua_isnil(L, 3)) {
+		remove_source = lua_toboolean(L, 3);
+	}
+
+	bool retval = fs::CopyDir(source, destination);
+
+	if (retval && (remove_source)) {
+		CHECK_SECURE_PATH(L, source, true);
+		retval &= fs::RecursiveDelete(source);
+	}
+	lua_pushboolean(L, retval);
+	return 1;
+}
+
 // get_dir_list(path, is_dir)
 int ModApiUtil::l_get_dir_list(lua_State *L)
 {
@@ -446,6 +491,8 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(decompress);
 
 	API_FCT(mkdir);
+	API_FCT(rmdir);
+	API_FCT(cpdir);
 	API_FCT(get_dir_list);
 
 	API_FCT(request_insecure_environment);
@@ -496,6 +543,8 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	API_FCT(decompress);
 
 	API_FCT(mkdir);
+	API_FCT(rmdir);
+	API_FCT(cpdir);
 	API_FCT(get_dir_list);
 
 	API_FCT(encode_base64);
@@ -506,4 +555,3 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	LuaSettings::create(L, g_settings, g_settings_path);
 	lua_setfield(L, top, "settings");
 }
-

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -78,6 +78,12 @@ private:
 	// mkdir(path)
 	static int l_mkdir(lua_State *L);
 
+	// rmdir(path, recursive)
+	static int l_rmdir(lua_State *L);
+
+	// cpdir(source, destination, remove_source)
+	static int l_cpdir(lua_State *L);
+
 	// get_dir_list(path, is_dir)
 	static int l_get_dir_list(lua_State *L);
 


### PR DESCRIPTION
Complements `mkdir`, complies with mod security.
* `rmdir`: Remove a directory at the path specified
* `cpdir`: Copy a directory to another location, and remove the source directory if the third parameter is set to `true`

This would be useful in mods as there is no way to properly remove directories in Windows (`os.remove` doesn't work on directories, and `os.execute` doesn't work at all). Not only that, but both `rmdir` and `cpdir` code (`rmdir` in particular) is incredibly complex (and likely less efficient) to implement via Lua.

An example of the complexity to implementing `rmdir` in Lua: https://github.com/octacian/digicompute/blob/master/builtin.lua#L79.