### PR TITLE
Default window size: Increase to 1024x576, aspect ratio 16:9 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -484,10 +484,10 @@ pause_fps_max (FPS in pause menu) int 20
 viewing_range (Viewing range) int 100 20 4000
 
 #    Width component of the initial window size.
-screen_w (Screen width) int 800
+screen_w (Screen width) int 1024
 
 #    Height component of the initial window size.
-screen_h (Screen height) int 600
+screen_h (Screen height) int 576
 
 #    Save window size automatically when modified.
 autosave_screensize (Autosave Screen Size) bool true

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -554,11 +554,11 @@
 
 #    Width component of the initial window size.
 #    type: int
-# screen_w = 800
+# screen_w = 1024
 
 #    Height component of the initial window size.
 #    type: int
-# screen_h = 600
+# screen_h = 576
 
 #    Save window size automatically when modified.
 #    type: bool

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -125,8 +125,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
-	settings->setDefault("screen_w", "800");
-	settings->setDefault("screen_h", "600");
+	settings->setDefault("screen_w", "1024");
+	settings->setDefault("screen_h", "576");
 	settings->setDefault("autosave_screensize", "true");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("fullscreen_bpp", "24");


### PR DESCRIPTION
A more reasonable minimum with a more modern and landscape-suitable 16:9 aspect ratio.
Also makes all debug information fit on the screen, see #6125 
See https://pacoup.com/2011/06/12/list-of-true-169-resolutions/
800x600 always looked pathetic to me and an old-fashioned aspect ratio not suited to Minetest landscapes.