### PR TITLE
Safe digging and placing

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -101,6 +101,10 @@ always_fly_fast (Always fly and fast) bool true
 #    The time in seconds it takes between repeated right clicks when holding the right mouse button.
 repeat_rightclick_time (Rightclick repetition interval) float 0.25
 
+#    Prevent digging and placing from repeating when holding the mouse buttons.
+#    Enable this when you dig or place too often by accident.
+safe_dig_and_place (Safe digging and placing) bool false
+
 #    Enable random user input (only used for testing).
 random_input (Random input) bool false
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -75,6 +75,11 @@
 #    type: float
 # repeat_rightclick_time = 0.25
 
+#    Prevent digging and placing from repeating when holding the mouse buttons.
+#    Enable this when you dig or place too often by accident.
+#    type: bool
+# safe_dig_and_place = false
+
 #    Enable random user input (only used for testing).
 #    type: bool
 # random_input = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -206,6 +206,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("invert_mouse", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
 	settings->setDefault("repeat_rightclick_time", "0.25");
+	settings->setDefault("safe_dig_and_place", "false");
 	settings->setDefault("random_input", "false");
 	settings->setDefault("aux1_descends", "false");
 	settings->setDefault("doubletap_jump", "false");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1158,7 +1158,6 @@ struct GameRunData {
 	float dig_time;
 	float dig_time_complete;
 	float repeat_rightclick_timer;
-	bool rightclick_blocked;
 	float object_hit_delay_timer;
 	float time_from_last_punch;
 	ClientActiveObject *selected_object;
@@ -3625,12 +3624,11 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 
 	soundmaker->m_player_leftpunch_sound.name = "";
 
-	if (isRightPressed())
+	// Prepare for repeating, unless we're not supposed to
+	if (isRightPressed() && !g_settings->getBool("safe_dig_and_place"))
 		runData.repeat_rightclick_timer += dtime;
-	else {
+	else
 		runData.repeat_rightclick_timer = 0;
-		runData.rightclick_blocked = false;
-	}
 
 	if (playeritem_def.usable && isLeftPressed()) {
 		if (getLeftClicked() && (!client->moddingEnabled()
@@ -3807,7 +3805,6 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 
 	if ((getRightClicked() ||
 			runData.repeat_rightclick_timer >= m_repeat_right_click_time) &&
-			!runData.rightclick_blocked &&
 			client->checkPrivilege("interact")) {
 		runData.repeat_rightclick_timer = 0;
 		infostream << "Ground right-clicked" << std::endl;
@@ -3861,9 +3858,6 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 				}
 			}
 		}
-		// we right clicked, now block it from repeating if we want to be safe
-		if (g_settings->getBool("safe_dig_and_place"))
-			runData.rightclick_blocked = true;
 	}
 }
 


### PR DESCRIPTION
I recently saw small children have trouble with creative mode, since digging and placing nodes auto-repeat quite fast by default. There is a setting for the right click delay, but nothing for left click (i.e. digging) that I could find.

This PR adds a new setting `safe_dig_and_place` (default off) under "controls". If enabled, a successful dig or place (or any right click, actually) blocks the corresponding action until its key is released again. This makes digging and placing much safer for inexperienced players.