### PR TITLE
Dont search for locale folders if gettext is disabled

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -556,7 +556,7 @@ void initializePaths()
 	infostream << "Detected user path: " << path_user << std::endl;
 	infostream << "Detected cache path: " << path_cache << std::endl;
 
-#ifdef USE_GETTEXT
+#if USE_GETTEXT
 	bool found_localedir = false;
 #  ifdef STATIC_LOCALEDIR
 	if (STATIC_LOCALEDIR[0] && fs::PathExists(STATIC_LOCALEDIR)) {


### PR DESCRIPTION
This really trivial PR fixes an issue where it searches for locale folders, that cannot be found. If gettext is disabled, it is defined as 0 by CMake