### PR TITLE
Mgv7: Add option to repeat biomes in floatlands

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1138,11 +1138,11 @@ mgv6_np_apple_trees (Apple trees noise) noise_params 0, 1, (100, 100, 100), 3429
 [***Mapgen v7]
 
 #    Map generation attributes specific to Mapgen v7.
-#    The 'ridges' flag enables the rivers.
-#    Floatlands are currently experimental and subject to change.
+#    'ridges' enables the rivers.
+#    'biomerepeat' causes surface biomes to repeat in the floatlands.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
+mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,caverns,biomerepeat mountains,ridges,floatlands,caverns,biomerepeat,nomountains,noridges,nofloatlands,nocaverns,nobiomerepeat
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Cave width) float 0.09

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1377,12 +1377,12 @@
 #### Mapgen v7
 
 #    Map generation attributes specific to Mapgen v7.
-#    The 'ridges' flag enables the rivers.
-#    Floatlands are currently experimental and subject to change.
+#    'ridges' enables the rivers.
+#    'biomerepeat' causes surface biomes to repeat in the floatlands.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-#    type: flags possible values: mountains, ridges, floatlands, caverns, nomountains, noridges, nofloatlands, nocaverns
-# mgv7_spflags = mountains,ridges,nofloatlands,caverns
+#    type: flags possible values: mountains, ridges, floatlands, caverns, biomerepeat, nomountains, noridges, nofloatlands, nocaverns, nobiomerepeat
+# mgv7_spflags = mountains,ridges,nofloatlands,caverns,biomerepeat
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -23,11 +23,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-//////////// Mapgen V7 flags
-#define MGV7_MOUNTAINS  0x01
-#define MGV7_RIDGES     0x02
-#define MGV7_FLOATLANDS 0x04
-#define MGV7_CAVERNS    0x08
+/////////////// Mapgen V7 flags
+#define MGV7_MOUNTAINS   0x01
+#define MGV7_RIDGES      0x02
+#define MGV7_FLOATLANDS  0x04
+#define MGV7_CAVERNS     0x08
+#define MGV7_BIOMEREPEAT 0x10
 
 class BiomeManager;
 
@@ -35,7 +36,8 @@ extern FlagDesc flagdesc_mapgen_v7[];
 
 
 struct MapgenV7Params : public MapgenParams {
-	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
+	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES |
+		MGV7_CAVERNS | MGV7_BIOMEREPEAT;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;


### PR DESCRIPTION
Tested.

Now i have added per-mapchunk setting of the 'zero level' of biomes i can add an option to mgv7 to repeat the normal surface biomes in the floatlands, as an alternative to registering a second set of biomes for the floatlands.

The default of the new mapgen flag is true. So when floatlands are enabled players experience a repeat of surface biomes, so experience a rich and complete set of biomes instead of a placeholder.

This will require some changes to MTG, and the mgv7 parameters 'floatland_level' and 'shadow_limit' will need to be made global in MTG and available to mods that wish to register biomes for floatlands.

MTG PR https://github.com/minetest/minetest_game/pull/1828 should be merged with this.