### PR TITLE
Chat: Move chat text down to not overlap 3rd line of debug text

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -995,7 +995,7 @@ static void updateChat(Client &client, f32 dtime, bool show_debug,
 	s32 chat_y = 5;
 
 	if (show_debug)
-		chat_y += 2 * line_height;
+		chat_y += 3 * line_height;
 
 	// first pass to calculate height of text to be set
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();


### PR DESCRIPTION
Fixes #6141 

![screenshot_20170717_123035](https://user-images.githubusercontent.com/3686677/28266431-b99158a8-6aec-11e7-9ef2-ad7230161376.png)

![screenshot_20170717_123102](https://user-images.githubusercontent.com/3686677/28266433-befe10f6-6aec-11e7-9502-8d4444c68beb.png)

^ Note if debug is shown and no node is pointed at there will be an empty line, however this makes debug and chat more readable and the gap makes the top area of the screen less obscured.

![screenshot_20170717_124904_1](https://user-images.githubusercontent.com/3686677/28266724-604f7872-6aee-11e7-8f79-023e9e2d1e3f.png)