### PR TITLE
Mgfractal: Improve spawning behaviour

### DIFF
--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -156,7 +156,8 @@ int MapgenFractal::getSpawnLevelAtPoint(v2s16 p)
 			air_count = 0;
 		} else if (solid_below) {  // Air above solid node
 			air_count++;
-			if (air_count == 2)
+			// 3 to account for snowblock dust
+			if (air_count == 3)
 				return y - 2;
 		}
 	}

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -39,12 +39,12 @@ struct MapgenFractalParams : public MapgenParams
 	u16 fractal = 1;
 	u16 iterations = 11;
 	v3f scale = v3f(4096.0, 1024.0, 4096.0);
-	v3f offset = v3f(1.79, 0.0, 0.0);
+	v3f offset = v3f(1.52, 0.0, 0.0);
 	float slice_w = 0.0f;
-	float julia_x = 0.33f;
-	float julia_y = 0.33f;
-	float julia_z = 0.33f;
-	float julia_w = 0.33f;
+	float julia_x = 0.267f;
+	float julia_y = 0.2f;
+	float julia_z = 0.133f;
+	float julia_w = 0.067f;
 	NoiseParams np_seabed;
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;


### PR DESCRIPTION
Spawn player 1 node higher to avoid spawning waist-deep in a possible
biome 'dust' node, such as tundra snowblock.
Tune default offset to spawn players in a more interesting location on the
mandelbrot sets, on a raised area that looks like a spawn platform.
Tune julia parameters to help avoid spawn search failing, especially for
fractal 6.