### PR TITLE
Window size: use 1024x600 to avoid a smaller UI 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -487,7 +487,7 @@ viewing_range (Viewing range) int 100 20 4000
 screen_w (Screen width) int 1024
 
 #    Height component of the initial window size.
-screen_h (Screen height) int 576
+screen_h (Screen height) int 600
 
 #    Save window size automatically when modified.
 autosave_screensize (Autosave Screen Size) bool true

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -558,7 +558,7 @@
 
 #    Height component of the initial window size.
 #    type: int
-# screen_h = 576
+# screen_h = 600
 
 #    Save window size automatically when modified.
 #    type: bool

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -126,7 +126,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
 	settings->setDefault("screen_w", "1024");
-	settings->setDefault("screen_h", "576");
+	settings->setDefault("screen_h", "600");
 	settings->setDefault("autosave_screensize", "true");
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("fullscreen_bpp", "24");


### PR DESCRIPTION
The change from 800x600 to 1024x576 (16:9) was a reduction in height which caused
user interface to become smaller.
Continue to use width 1024 as it is a common small screen width.