### PR TITLE
Fix header guard naming (#4616)

### DIFF
--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ACTIVEOBJECT_HEADER
-#define ACTIVEOBJECT_HEADER
+#pragma once
 
 #include "irr_aabb3d.h"
 #include <string>
@@ -102,6 +101,4 @@ public:
 protected:
 	u16 m_id; // 0 is invalid, "no id"
 };
-
-#endif
 

--- a/src/ban.h
+++ b/src/ban.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef BAN_HEADER
-#define BAN_HEADER
+#pragma once
 
 #include "util/string.h"
 #include "threading/thread.h"
@@ -49,4 +48,3 @@ private:
 	bool m_modified = false;
 };
 
-#endif

--- a/src/camera.h
+++ b/src/camera.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CAMERA_HEADER
-#define CAMERA_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "inventory.h"
@@ -232,4 +231,3 @@ private:
 	std::list<Nametag *> m_nametags;
 };
 
-#endif

--- a/src/cavegen.h
+++ b/src/cavegen.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CAVEGEN_HEADER
-#define CAVEGEN_HEADER
+#pragma once
 
 #define VMANIP_FLAG_CAVE VOXELFLAG_CHECKED1
 
@@ -242,4 +241,3 @@ private:
 	inline s16 getSurfaceFromHeightmap(v3s16 p);
 };
 
-#endif

--- a/src/chat.h
+++ b/src/chat.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CHAT_HEADER
-#define CHAT_HEADER
+#pragma once
 
 #include <string>
 #include <vector>
@@ -287,6 +286,4 @@ private:
 	ChatBuffer m_recent_buffer;
 	ChatPrompt m_prompt;
 };
-
-#endif
 

--- a/src/chat_interface.h
+++ b/src/chat_interface.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CHAT_INTERFACE_H
-#define CHAT_INTERFACE_H
+#pragma once
 
 #include "util/container.h"
 #include <string>
@@ -79,4 +78,3 @@ struct ChatInterface {
 	MutexedQueue<ChatEvent *> outgoing_queue; // server --> chat backend
 };
 
-#endif

--- a/src/chatmessage.h
+++ b/src/chatmessage.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MT_CHATMESSAGE_H
-#define MT_CHATMESSAGE_H
+#pragma once
 
 #include <string>
 #include <ctime>
@@ -48,4 +47,3 @@ struct ChatMessage
 	std::time_t timestamp = std::time(0);
 };
 
-#endif

--- a/src/client.h
+++ b/src/client.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENT_HEADER
-#define CLIENT_HEADER
+#pragma once
 
 #include "network/connection.h"
 #include "clientenvironment.h"
@@ -730,4 +729,3 @@ private:
 	u32 m_csm_noderange_limit = 8;
 };
 
-#endif // !CLIENT_HEADER

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -17,8 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef __CLIENT_LAUNCHER_H__
-#define __CLIENT_LAUNCHER_H__
+#ifndef CLIENT_LAUNCHER_H
+#define CLIENT_LAUNCHER_H
 
 #include "irrlichttypes_extrabloated.h"
 #include "client/inputhandler.h"

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENT_ENVIRONMENT_HEADER
-#define CLIENT_ENVIRONMENT_HEADER
+#pragma once
 
 #include <ISceneManager.h>
 #include "environment.h"
@@ -158,4 +157,3 @@ private:
 	v3s16 m_camera_offset;
 };
 
-#endif

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -16,8 +16,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef CLIENTIFACE_H
-#define CLIENTIFACE_H
+#pragma once
 
 #include "irr_v3d.h"                   // for irrlicht datatypes
 
@@ -499,4 +498,3 @@ private:
 	static const char *statenames[];
 };
 
-#endif

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -16,8 +16,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef _CLIENTIFACE_H_
-#define _CLIENTIFACE_H_
+#ifndef CLIENTIFACE_H
+#define CLIENTIFACE_H
 
 #include "irr_v3d.h"                   // for irrlicht datatypes
 

--- a/src/clientmap.h
+++ b/src/clientmap.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENTMAP_HEADER
-#define CLIENTMAP_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "map.h"
@@ -143,6 +142,4 @@ private:
 	bool m_cache_bilinear_filter;
 	bool m_cache_anistropic_filter;
 };
-
-#endif
 

--- a/src/clientmedia.h
+++ b/src/clientmedia.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENTMEDIA_HEADER
-#define CLIENTMEDIA_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include "filecache.h"
@@ -148,4 +147,3 @@ private:
 
 };
 
-#endif // !CLIENTMEDIA_HEADER

--- a/src/clientobject.h
+++ b/src/clientobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENTOBJECT_HEADER
-#define CLIENTOBJECT_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "activeobject.h"
@@ -107,4 +106,3 @@ struct DistanceSortedActiveObject
 	}
 };
 
-#endif

--- a/src/clientsimpleobject.h
+++ b/src/clientsimpleobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLIENTSIMPLEOBJECT_HEADER
-#define CLIENTSIMPLEOBJECT_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 class ClientEnvironment;
@@ -34,4 +33,3 @@ public:
 	virtual void step(float dtime) {}
 };
 
-#endif

--- a/src/cloudparams.h
+++ b/src/cloudparams.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLOUDPARAMS_HEADER
-#define CLOUDPARAMS_HEADER
+#pragma once
 
 struct CloudParams
 {
@@ -30,4 +29,3 @@ struct CloudParams
 	v2f speed;
 };
 
-#endif

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CLOUDS_HEADER
-#define CLOUDS_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include <iostream>
@@ -146,6 +145,3 @@ private:
 
 };
 
-
-
-#endif

--- a/src/collision.h
+++ b/src/collision.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef COLLISION_HEADER
-#define COLLISION_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include <vector>
@@ -74,7 +73,4 @@ bool wouldCollideWithCeiling(
 		const std::vector<aabb3f> &staticboxes,
 		const aabb3f &movingbox,
 		f32 y_increase, f32 d);
-
-
-#endif
 

--- a/src/config.h
+++ b/src/config.h
@@ -3,8 +3,7 @@
 	Otherwise use default values
 */
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 #define STRINGIFY(x) #x
 #define STR(x) STRINGIFY(x)
@@ -39,4 +38,3 @@
 		" USE_LUAJIT=" STR(USE_LUAJIT) \
 		" STATIC_SHAREDIR=" STR(STATIC_SHAREDIR)
 
-#endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONSTANTS_HEADER
-#define CONSTANTS_HEADER
+#pragma once
 
 /*
 	All kinds of constants.
@@ -116,4 +115,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 #define DEFAULT_FONT_SIZE (10)
 
-#endif

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_CAO_HEADER
-#define CONTENT_CAO_HEADER
+#pragma once
 
 #include <map>
 #include "irrlichttypes_extrabloated.h"
@@ -210,5 +209,3 @@ public:
 	}
 };
 
-
-#endif

--- a/src/content_cso.h
+++ b/src/content_cso.h
@@ -17,14 +17,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_CSO_HEADER
-#define CONTENT_CSO_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "clientsimpleobject.h"
 
 ClientSimpleObject* createSmokePuff(scene::ISceneManager *smgr,
 		ClientEnvironment *env, v3f pos, v2f size);
-
-#endif
 

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_MAPBLOCK_HEADER
-#define CONTENT_MAPBLOCK_HEADER
+#pragma once
 #include "util/numeric.h"
 #include "nodedef.h"
 #include <IMeshManipulator.h>
@@ -147,4 +146,3 @@ public:
 	void generate();
 };
 
-#endif

--- a/src/content_mapnode.h
+++ b/src/content_mapnode.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_MAPNODE_HEADER
-#define CONTENT_MAPNODE_HEADER
+#pragma once
 
 #include "mapnode.h"
 
@@ -34,4 +33,3 @@ MapNode mapnode_translate_to_internal(MapNode n_from, u8 version);
 class NameIdMapping;
 void content_mapnode_get_name_id_mapping(NameIdMapping *nimap);
 
-#endif

--- a/src/content_nodemeta.h
+++ b/src/content_nodemeta.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_NODEMETA_HEADER
-#define CONTENT_NODEMETA_HEADER
+#pragma once
 
 #include <iostream>
 
@@ -33,6 +32,4 @@ class IItemDefManager;
 void content_nodemeta_deserialize_legacy(std::istream &is,
 		NodeMetadataList *meta, NodeTimerList *timers,
 		IItemDefManager *item_def_mgr);
-
-#endif
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONTENT_SAO_HEADER
-#define CONTENT_SAO_HEADER
+#pragma once
 
 #include <util/numeric.h>
 #include "serverobject.h"
@@ -413,4 +412,3 @@ public:
 	bool m_physics_override_sent = false;
 };
 
-#endif

--- a/src/convert_json.h
+++ b/src/convert_json.h
@@ -17,12 +17,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CONVERT_JSON_H
-#define CONVERT_JSON_H
+#pragma once
 
 #include <json/json.h>
 
 Json::Value                 fetchJsonValue(const std::string &url,
                                            std::vector<std::string> *extra_headers);
 
-#endif

--- a/src/convert_json.h
+++ b/src/convert_json.h
@@ -17,8 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef __CONVERT_JSON_H__
-#define __CONVERT_JSON_H__
+#ifndef CONVERT_JSON_H
+#define CONVERT_JSON_H
 
 #include <json/json.h>
 

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef CRAFTDEF_HEADER
-#define CRAFTDEF_HEADER
+#pragma once
 
 #include <string>
 #include <iostream>
@@ -446,6 +445,4 @@ public:
 };
 
 IWritableCraftDefManager* createCraftDefManager();
-
-#endif
 

--- a/src/database-dummy.h
+++ b/src/database-dummy.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_DUMMY_HEADER
-#define DATABASE_DUMMY_HEADER
+#pragma once
 
 #include <map>
 #include <string>
@@ -45,4 +44,3 @@ private:
 	std::map<s64, std::string> m_database;
 };
 
-#endif

--- a/src/database-files.h
+++ b/src/database-files.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_FILES_HEADER
-#define DATABASE_FILES_HEADER
+#pragma once
 
 // !!! WARNING !!!
 // This backend is intended to be used on Minetest 0.4.16 only for the transition backend
@@ -43,4 +42,3 @@ private:
 	std::string m_savedir;
 };
 
-#endif

--- a/src/database-leveldb.h
+++ b/src/database-leveldb.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_LEVELDB_HEADER
-#define DATABASE_LEVELDB_HEADER
+#pragma once
 
 #include "config.h"
 
@@ -48,4 +47,3 @@ private:
 
 #endif // USE_LEVELDB
 
-#endif

--- a/src/database-postgresql.h
+++ b/src/database-postgresql.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_POSTGRESQL_HEADER
-#define DATABASE_POSTGRESQL_HEADER
+#pragma once
 
 #include <string>
 #include <libpq-fe.h>
@@ -145,6 +144,4 @@ protected:
 private:
 	bool playerDataExists(const std::string &playername);
 };
-
-#endif
 

--- a/src/database-redis.h
+++ b/src/database-redis.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_REDIS_HEADER
-#define DATABASE_REDIS_HEADER
+#pragma once
 
 #include "config.h"
 
@@ -51,4 +50,3 @@ private:
 
 #endif // USE_REDIS
 
-#endif

--- a/src/database-sqlite3.h
+++ b/src/database-sqlite3.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_SQLITE3_HEADER
-#define DATABASE_SQLITE3_HEADER
+#pragma once
 
 #include <cstring>
 #include <string>
@@ -193,4 +192,3 @@ private:
 	sqlite3_stmt *m_stmt_player_metadata_add = nullptr;
 };
 
-#endif

--- a/src/database.h
+++ b/src/database.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DATABASE_HEADER
-#define DATABASE_HEADER
+#pragma once
 
 #include <string>
 #include <vector>
@@ -62,4 +61,3 @@ public:
 	virtual void listPlayers(std::vector<std::string> &res) = 0;
 };
 
-#endif

--- a/src/daynightratio.h
+++ b/src/daynightratio.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DAYNIGHTRATIO_HEADER
-#define DAYNIGHTRATIO_HEADER
+#pragma once
 
 inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 {
@@ -64,6 +63,4 @@ inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 		return 1000;
 	}
 }
-
-#endif
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DEBUG_HEADER
-#define DEBUG_HEADER
+#pragma once
 
 #include <iostream>
 #include <exception>
@@ -131,7 +130,4 @@ private:
 	#define BEGIN_DEBUG_EXCEPTION_HANDLER
 	#define END_DEBUG_EXCEPTION_HANDLER
 #endif
-
-#endif // DEBUG_HEADER
-
 

--- a/src/defaultsettings.h
+++ b/src/defaultsettings.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DEFAULTSETTINGS_HEADER
-#define DEFAULTSETTINGS_HEADER
+#pragma once
 
 class Settings;
 
@@ -35,4 +34,3 @@ void set_default_settings(Settings *settings);
  */
 void override_default_settings(Settings *settings, Settings *from);
 
-#endif

--- a/src/dungeongen.h
+++ b/src/dungeongen.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef DUNGEONGEN_HEADER
-#define DUNGEONGEN_HEADER
+#pragma once
 
 #include "voxel.h"
 #include "noise.h"
@@ -110,4 +109,3 @@ public:
 extern NoiseParams nparams_dungeon_density;
 extern NoiseParams nparams_dungeon_alt_wall;
 
-#endif

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef EMERGE_HEADER
-#define EMERGE_HEADER
+#pragma once
 
 #include <map>
 #include <mutex>
@@ -175,4 +174,3 @@ private:
 	friend class EmergeThread;
 };
 
-#endif

--- a/src/environment.h
+++ b/src/environment.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ENVIRONMENT_HEADER
-#define ENVIRONMENT_HEADER
+#pragma once
 
 /*
 	This class is the game's environment.
@@ -146,4 +145,3 @@ private:
 	std::mutex m_time_lock;
 };
 
-#endif

--- a/src/event.h
+++ b/src/event.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef EVENT_HEADER
-#define EVENT_HEADER
+#pragma once
 
 class MtEvent
 {
@@ -67,6 +66,4 @@ public:
 	virtual void reg(MtEventReceiver *r, const char *type) = 0;
 	virtual void dereg(MtEventReceiver *r, const char *type) = 0;
 };
-
-#endif
 

--- a/src/event_manager.h
+++ b/src/event_manager.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef EVENT_MANAGER_HEADER
-#define EVENT_MANAGER_HEADER
+#pragma once
 
 #include "event.h"
 #include <list>
@@ -110,6 +109,4 @@ public:
 		dereg(type, EventManager::receiverReceive, r);
 	}
 };
-
-#endif
 

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef EXCEPTIONS_HEADER
-#define EXCEPTIONS_HEADER
+#pragma once
 
 #include <exception>
 #include <string>
@@ -129,6 +128,4 @@ public:
 		BaseException(s)
 	{}
 };
-
-#endif
 

--- a/src/face_position_cache.h
+++ b/src/face_position_cache.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FACE_POSITION_CACHE_HEADER
-#define FACE_POSITION_CACHE_HEADER
+#pragma once
 
 #include "irr_v3d.h"
 
@@ -41,4 +40,3 @@ private:
 	static std::mutex cache_mutex;
 };
 
-#endif

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FILECACHE_HEADER
-#define FILECACHE_HEADER
+#pragma once
 
 #include <iostream>
 #include <string>
@@ -42,4 +41,3 @@ private:
 	bool updateByPath(const std::string &path, const std::string &data);
 };
 
-#endif

--- a/src/filesys.h
+++ b/src/filesys.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef FILESYS_HEADER
-#define FILESYS_HEADER
+#pragma once
 
 #include <string>
 #include <vector>
@@ -118,6 +117,4 @@ bool safeWriteToFile(const std::string &path, const std::string &content);
 bool Rename(const std::string &from, const std::string &to);
 
 } // namespace fs
-
-#endif
 

--- a/src/fontengine.h
+++ b/src/fontengine.h
@@ -16,8 +16,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef __FONTENGINE_H__
-#define __FONTENGINE_H__
+#ifndef FONTENGINE_H
+#define FONTENGINE_H
 
 #include <map>
 #include <vector>

--- a/src/fontengine.h
+++ b/src/fontengine.h
@@ -16,8 +16,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef FONTENGINE_H
-#define FONTENGINE_H
+#pragma once
 
 #include <map>
 #include <vector>
@@ -136,4 +135,3 @@ private:
 /** interface to access main font engine*/
 extern FontEngine* g_fontengine;
 
-#endif

--- a/src/game.h
+++ b/src/game.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GAME_HEADER
-#define GAME_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include <string>
@@ -53,4 +52,3 @@ void the_game(bool *kill,
 		const SubgameSpec &gamespec, // Used for local game
 		bool simple_singleplayer_mode);
 
-#endif

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GAMEDEF_HEADER
-#define GAMEDEF_HEADER
+#pragma once
 
 #include <string>
 #include <vector>
@@ -80,6 +79,4 @@ public:
 	virtual bool registerModStorage(ModMetadata *storage) = 0;
 	virtual void unregisterModStorage(const std::string &name) = 0;
 };
-
-#endif
 

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GAME_PARAMS_H
-#define GAME_PARAMS_H
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -32,4 +31,3 @@ struct GameParams
 	bool is_dedicated_server;
 };
 
-#endif

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GENERICOBJECT_HEADER
-#define GENERICOBJECT_HEADER
+#pragma once
 
 #include <string>
 #include "irrlichttypes_bloated.h"
@@ -83,6 +82,4 @@ std::string gob_cmd_update_nametag_attributes(video::SColor color);
 
 std::string gob_cmd_update_infant(u16 id, u8 type,
 		const std::string &client_initialization_data);
-
-#endif
 

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GETTEXT_HEADER
-#define GETTEXT_HEADER
+#pragma once
 
 #include "config.h" // for USE_GETTEXT
 
@@ -59,4 +58,3 @@ inline std::string strgettext(const std::string &text)
 	return gettext(text.c_str());
 }
 
-#endif

--- a/src/gettime.h
+++ b/src/gettime.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GETTIME_HEADER
-#define GETTIME_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include <time.h>
@@ -43,4 +42,3 @@ inline std::string getTimestamp()
 	return cs;
 }
 
-#endif

--- a/src/guiChatConsole.h
+++ b/src/guiChatConsole.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GUICHATCONSOLE_HEADER
-#define GUICHATCONSOLE_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "modalMenu.h"
@@ -132,7 +131,4 @@ private:
 	gui::IGUIFont *m_font = nullptr;
 	v2u32 m_fontsize;
 };
-
-
-#endif
 

--- a/src/guiEngine.h
+++ b/src/guiEngine.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GUI_ENGINE_H_
-#define GUI_ENGINE_H_
+#pragma once
 
 /******************************************************************************/
 /* Includes                                                                   */
@@ -304,4 +303,3 @@ private:
 
 };
 
-#endif /* GUI_ENGINE_H_ */

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 
-#ifndef GUIINVENTORYMENU_HEADER
-#define GUIINVENTORYMENU_HEADER
+#pragma once
 
 #include <utility>
 #include <stack>
@@ -568,4 +567,3 @@ public:
 	std::string m_formspec;
 };
 
-#endif

--- a/src/guiKeyChangeMenu.h
+++ b/src/guiKeyChangeMenu.h
@@ -19,8 +19,7 @@
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef GUIKEYCHANGEMENU_HEADER
-#define GUIKEYCHANGEMENU_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "modalMenu.h"
@@ -73,4 +72,3 @@ private:
 	std::vector<key_setting *> key_settings;
 };
 
-#endif

--- a/src/guiMainMenu.h
+++ b/src/guiMainMenu.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef GUIMAINMENU_HEADER
-#define GUIMAINMENU_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "modalMenu.h"
@@ -54,6 +53,4 @@ struct MainMenuData {
 
 	MainMenuData() {}
 };
-
-#endif
 

--- a/src/guiPasswordChange.h
+++ b/src/guiPasswordChange.h
@@ -16,8 +16,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#ifndef GUIPASSWORDCHANGE_HEADER
-#define GUIPASSWORDCHANGE_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "modalMenu.h"
@@ -52,4 +51,3 @@ private:
 	std::wstring m_newpass_confirm = L"";
 };
 
-#endif

--- a/src/guiPathSelectMenu.h
+++ b/src/guiPathSelectMenu.h
@@ -17,8 +17,7 @@
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef GUIFILESELECTMENU_H_
-#define GUIFILESELECTMENU_H_
+#pragma once
 
 #include <string>
 
@@ -59,4 +58,3 @@ private:
 	bool m_file_select_dialog;
 };
 
-#endif /* GUIFILESELECTMENU_H_ */

--- a/src/guiTable.h
+++ b/src/guiTable.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 
-#ifndef GUITABLE_HEADER
-#define GUITABLE_HEADER
+#pragma once
 
 #include <map>
 #include <set>
@@ -256,6 +255,4 @@ protected:
 	static void alignContent(Cell *cell, s32 xmax, s32 content_width,
 			s32 align);
 };
-
-#endif
 

--- a/src/guiVolumeChange.h
+++ b/src/guiVolumeChange.h
@@ -17,8 +17,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#ifndef GUIVOLUMECHANGE_HEADER
-#define GUIVOLUMECHANGE_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "modalMenu.h"
@@ -45,6 +44,4 @@ public:
 	
 	bool pausesGame() { return true; }
 };
-
-#endif
 

--- a/src/guiscalingfilter.h
+++ b/src/guiscalingfilter.h
@@ -15,8 +15,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef _GUI_SCALING_FILTER_H_
-#define _GUI_SCALING_FILTER_H_
+#ifndef GUI_SCALING_FILTER_H
+#define GUI_SCALING_FILTER_H
 
 #include "irrlichttypes_extrabloated.h"
 

--- a/src/guiscalingfilter.h
+++ b/src/guiscalingfilter.h
@@ -15,8 +15,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef GUI_SCALING_FILTER_H
-#define GUI_SCALING_FILTER_H
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 
@@ -49,4 +48,3 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 		const core::rect<s32> *cliprect = 0, const video::SColor *const colors = 0,
 		bool usealpha = false);
 
-#endif

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef HTTPFETCH_HEADER
-#define HTTPFETCH_HEADER
+#pragma once
 
 #include <vector>
 #include "util/string.h"
@@ -114,4 +113,3 @@ void httpfetch_caller_free(unsigned long caller);
 // only be used from background threads.
 void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);
 
-#endif // !HTTPFETCH_HEADER

--- a/src/hud.h
+++ b/src/hud.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef HUD_HEADER
-#define HUD_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include <string>
@@ -198,4 +197,3 @@ void drawItemStack(video::IVideoDriver *driver,
 
 #endif
 
-#endif

--- a/src/imagefilters.h
+++ b/src/imagefilters.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IMAGE_FILTERS_H
-#define IMAGE_FILTERS_H
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 
@@ -43,4 +42,3 @@ void imageCleanTransparent(video::IImage *src, u32 threshold);
  */
 void imageScaleNNAA(video::IImage *src, const core::rect<s32> &srcrect, video::IImage *dest);
 
-#endif

--- a/src/imagefilters.h
+++ b/src/imagefilters.h
@@ -16,8 +16,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef _IMAGE_FILTERS_H_
-#define _IMAGE_FILTERS_H_
+#ifndef IMAGE_FILTERS_H
+#define IMAGE_FILTERS_H
 
 #include "irrlichttypes_extrabloated.h"
 

--- a/src/intlGUIEditBox.h
+++ b/src/intlGUIEditBox.h
@@ -2,8 +2,7 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
-#ifndef __C_INTL_GUI_EDIT_BOX_H_INCLUDED__
-#define __C_INTL_GUI_EDIT_BOX_H_INCLUDED__
+#pragma once
 
 #include "IrrCompileConfig.h"
 //#ifdef _IRR_COMPILE_WITH_GUI_
@@ -182,4 +181,3 @@ namespace gui
 } // end namespace irr
 
 //#endif // _IRR_COMPILE_WITH_GUI_
-#endif // __C_GUI_EDIT_BOX_H_INCLUDED__

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef INVENTORY_HEADER
-#define INVENTORY_HEADER
+#pragma once
 
 #include "debug.h"
 #include "itemdef.h"
@@ -311,4 +310,3 @@ private:
 	bool m_dirty = false;
 };
 
-#endif

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef INVENTORYMANAGER_HEADER
-#define INVENTORYMANAGER_HEADER
+#pragma once
 
 #include "inventory.h"
 #include <iostream>
@@ -244,6 +243,4 @@ struct ICraftAction : public InventoryAction
 bool getCraftingResult(Inventory *inv, ItemStack &result,
 		std::vector<ItemStack> &output_replacements,
 		bool decrementInput, IGameDef *gamedef);
-
-#endif
 

--- a/src/irr_aabb3d.h
+++ b/src/irr_aabb3d.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRR_AABB3D_HEADER
-#define IRR_AABB3D_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -26,4 +25,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 typedef core::aabbox3d<f32> aabb3f;
 
-#endif

--- a/src/irr_v2d.h
+++ b/src/irr_v2d.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRR_V2D_HEADER
-#define IRR_V2D_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -30,4 +29,3 @@ typedef core::vector2d<s32> v2s32;
 typedef core::vector2d<u32> v2u32;
 typedef core::vector2d<f32> v2f32;
 
-#endif

--- a/src/irr_v3d.h
+++ b/src/irr_v3d.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRR_V3D_HEADER
-#define IRR_V3D_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -29,4 +28,3 @@ typedef core::vector3d<s16> v3s16;
 typedef core::vector3d<u16> v3u16;
 typedef core::vector3d<s32> v3s32;
 
-#endif

--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRRLICHTTYPES_HEADER
-#define IRRLICHTTYPES_HEADER
+#pragma once
 
 /* Ensure that <stdint.h> is included before <irrTypes.h>, unless building on
  * MSVC, to address an irrlicht issue: https://sourceforge.net/p/irrlicht/bugs/433/
@@ -63,4 +62,3 @@ using namespace irr;
 #define U32_MAX 0xFFFFFFFF
 #define U64_MAX 0xFFFFFFFFFFFFFFFF
 
-#endif

--- a/src/irrlichttypes_bloated.h
+++ b/src/irrlichttypes_bloated.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRRLICHTTYPES_BLOATED_HEADER
-#define IRRLICHTTYPES_BLOATED_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -28,4 +27,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <SColor.h>
 
-#endif

--- a/src/irrlichttypes_extrabloated.h
+++ b/src/irrlichttypes_extrabloated.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef IRRLICHTTYPES_EXTRABLOATED_HEADER
-#define IRRLICHTTYPES_EXTRABLOATED_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 
@@ -35,4 +34,3 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIEnvironment.h>
 #endif
 
-#endif

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ITEMDEF_HEADER
-#define ITEMDEF_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include <string>
@@ -175,4 +174,3 @@ public:
 
 IWritableItemDefManager* createItemDefManager();
 
-#endif

--- a/src/itemgroup.h
+++ b/src/itemgroup.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ITEMGROUP_HEADER
-#define ITEMGROUP_HEADER
+#pragma once
 
 #include <string>
 #include <unordered_map>
@@ -33,4 +32,3 @@ static inline int itemgroup_get(const ItemGroupList &groups, const std::string &
 	return i->second;
 }
 
-#endif

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ITEMSTACKMETADATA_HEADER
-#define ITEMSTACKMETADATA_HEADER
+#pragma once
 
 #include "metadata.h"
 
@@ -32,4 +31,3 @@ public:
 	void deSerialize(std::istream &is);
 };
 
-#endif

--- a/src/keycode.h
+++ b/src/keycode.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef KEYCODE_HEADER
-#define KEYCODE_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include "Keycodes.h"
@@ -67,4 +66,3 @@ void clearKeyCache();
 
 irr::EKEY_CODE keyname_to_keycode(const char *name);
 
-#endif

--- a/src/light.h
+++ b/src/light.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef LIGHT_HEADER
-#define LIGHT_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 
@@ -125,4 +124,3 @@ inline u8 blend_light(u32 daylight_factor, u8 lightday, u8 lightnight)
 	return l;
 }
 
-#endif

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef LOCALPLAYER_HEADER
-#define LOCALPLAYER_HEADER
+#pragma once
 
 #include "player.h"
 #include "environment.h"
@@ -181,4 +180,3 @@ private:
 	Client *m_client;
 };
 
-#endif

--- a/src/log.h
+++ b/src/log.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef LOG_HEADER
-#define LOG_HEADER
+#pragma once
 
 #include <map>
 #include <queue>
@@ -213,5 +212,3 @@ extern std::ostream dstream;
 	#define derr_client (*derr_client_ptr)
 #endif
 
-
-#endif

--- a/src/mainmenumanager.h
+++ b/src/mainmenumanager.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAINMENUMANAGER_HEADER
-#define MAINMENUMANAGER_HEADER
+#pragma once
 
 /*
 	All kinds of stuff that needs to be exposed from main.cpp
@@ -168,6 +167,4 @@ public:
 };
 
 extern MainGameCallback *g_gamecallback;
-
-#endif
 

--- a/src/map.h
+++ b/src/map.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAP_HEADER
-#define MAP_HEADER
+#pragma once
 
 #include <iostream>
 #include <sstream>
@@ -535,4 +534,3 @@ protected:
 	std::map<v3s16, u8> m_loaded_blocks;
 };
 
-#endif

--- a/src/map_settings_manager.h
+++ b/src/map_settings_manager.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAP_SETTINGS_MANAGER_HEADER
-#define MAP_SETTINGS_MANAGER_HEADER
+#pragma once
 
 #include <string>
 
@@ -76,4 +75,3 @@ private:
 	Settings *m_user_settings;
 };
 
-#endif

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPBLOCK_HEADER
-#define MAPBLOCK_HEADER
+#pragma once
 
 #include <set>
 #include "debug.h"
@@ -672,4 +671,3 @@ inline void getNodeSectorPosWithOffset(const v2s16 &p, v2s16 &block, v2s16 &offs
 */
 std::string analyze_block(MapBlock *block);
 
-#endif

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPBLOCK_MESH_HEADER
-#define MAPBLOCK_MESH_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "client/tile.h"
@@ -267,6 +266,4 @@ void final_color_blend(video::SColor *result,
 // TileFrame vector copy cost very much to client
 void getNodeTileN(MapNode mn, v3s16 p, u8 tileindex, MeshMakeData *data, TileSpec &tile);
 void getNodeTile(MapNode mn, v3s16 p, v3s16 dir, MeshMakeData *data, TileSpec &tile);
-
-#endif
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -19,8 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_HEADER
-#define MAPGEN_HEADER
+#pragma once
 
 #include "noise.h"
 #include "nodedef.h"
@@ -298,4 +297,3 @@ protected:
 	int lava_depth;
 };
 
-#endif

--- a/src/mapgen_carpathian.h
+++ b/src/mapgen_carpathian.h
@@ -19,8 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_CARPATHIAN_HEADER
-#define MAPGEN_CARPATHIAN_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -102,4 +101,3 @@ private:
 	int generateTerrain();
 };
 
-#endif

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_FLAT_HEADER
-#define MAPGEN_FLAT_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -76,4 +75,3 @@ private:
 	Noise *noise_terrain;
 };
 
-#endif

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -21,8 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_FRACTAL_HEADER
-#define MAPGEN_FRACTAL_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -87,4 +86,3 @@ private:
 	Noise *noise_seabed;
 };
 
-#endif

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -19,8 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_SINGLENODE_HEADER
-#define MAPGEN_SINGLENODE_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -49,4 +48,3 @@ public:
 	int getSpawnLevelAtPoint(v2s16 p);
 };
 
-#endif

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_V5_HEADER
-#define MAPGEN_V5_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -74,4 +73,3 @@ private:
 	Noise *noise_ground;
 };
 
-#endif

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -19,8 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGENV6_HEADER
-#define MAPGENV6_HEADER
+#pragma once
 
 #include "mapgen.h"
 #include "noise.h"
@@ -170,4 +169,3 @@ public:
 	virtual void generateCaves(int max_stone_y);
 };
 
-#endif

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_V7_HEADER
-#define MAPGEN_V7_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -110,4 +109,3 @@ private:
 	Noise *noise_ridge;
 };
 
-#endif

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -24,8 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPGEN_VALLEYS_HEADER
-#define MAPGEN_VALLEYS_HEADER
+#pragma once
 
 #include "mapgen.h"
 
@@ -134,4 +133,3 @@ private:
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
 };
 
-#endif

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPNODE_HEADER
-#define MAPNODE_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include "light.h"
@@ -304,6 +303,4 @@ private:
 	// Deprecated serialization methods
 	void deSerialize_pre22(u8 *source, u8 version);
 };
-
-#endif
 

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MAPSECTOR_HEADER
-#define MAPSECTOR_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include "irr_v2d.h"
@@ -134,7 +133,5 @@ public:
 
 private:
 };
-#endif
-
 #endif
 

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MESH_HEADER
-#define MESH_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "nodedef.h"
@@ -124,4 +123,3 @@ void recalculateBoundingBox(scene::IMesh *src_mesh);
 */
 scene::IMesh* createForsythOptimizedMesh(const scene::IMesh *mesh);
 
-#endif

--- a/src/mesh_generator_thread.h
+++ b/src/mesh_generator_thread.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MESH_GENERATOR_THREAD_HEADER
-#define MESH_GENERATOR_THREAD_HEADER
+#pragma once
 
 #include <ctime>
 #include <mutex>
@@ -131,4 +130,3 @@ protected:
 	virtual void doUpdate();
 };
 
-#endif

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef METADATA_HEADER
-#define METADATA_HEADER
+#pragma once
 
 #include "irr_v3d.h"
 #include <iostream>
@@ -58,4 +57,3 @@ protected:
 
 };
 
-#endif

--- a/src/mg_biome.h
+++ b/src/mg_biome.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MG_BIOME_HEADER
-#define MG_BIOME_HEADER
+#pragma once
 
 #include "objdef.h"
 #include "nodedef.h"
@@ -229,5 +228,3 @@ private:
 
 };
 
-
-#endif

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MG_DECORATION_HEADER
-#define MG_DECORATION_HEADER
+#pragma once
 
 #include <unordered_set>
 #include "objdef.h"
@@ -150,4 +149,3 @@ public:
 		v3s16 nmin, v3s16 nmax, s16 deco_zero_level = 0);
 };
 
-#endif

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MG_ORE_HEADER
-#define MG_ORE_HEADER
+#pragma once
 
 #include <unordered_set>
 #include "objdef.h"
@@ -168,4 +167,3 @@ public:
 		v3s16 nmin, v3s16 nmax, s16 ore_zero_level = 0);
 };
 
-#endif

--- a/src/mg_schematic.h
+++ b/src/mg_schematic.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MG_SCHEMATIC_HEADER
-#define MG_SCHEMATIC_HEADER
+#pragma once
 
 #include <map>
 #include "mg_decoration.h"
@@ -147,4 +146,3 @@ private:
 void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,
 	std::vector<std::string> *usednodes, INodeDefManager *ndef);
 
-#endif

--- a/src/minimap.h
+++ b/src/minimap.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MINIMAP_HEADER
-#define MINIMAP_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #include "client.h"
@@ -162,4 +161,3 @@ private:
 	std::list<v2f> m_active_markers;
 };
 
-#endif

--- a/src/modalMenu.h
+++ b/src/modalMenu.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MODALMENU_HEADER
-#define MODALMENU_HEADER
+#pragma once
 
 #include "irrlichttypes_extrabloated.h"
 #ifdef HAVE_TOUCHSCREENGUI
@@ -140,7 +139,4 @@ private:
 	// wants to launch other menus
 	bool m_allow_focus_removal = false;
 };
-
-
-#endif
 

--- a/src/modifiedstate.h
+++ b/src/modifiedstate.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MODIFIEDSTATE_HEADER
-#define MODIFIEDSTATE_HEADER
+#pragma once
 
 enum ModifiedState
 {
@@ -33,4 +32,3 @@ enum ModifiedState
 	MOD_RESERVED5 = 5,
 };
 
-#endif

--- a/src/mods.h
+++ b/src/mods.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef MODS_HEADER
-#define MODS_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include <list>
@@ -172,4 +171,3 @@ private:
 	bool m_modified = false;
 };
 
-#endif

--- a/src/nameidmapping.h
+++ b/src/nameidmapping.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NAMEIDMAPPING_HEADER
-#define NAMEIDMAPPING_HEADER
+#pragma once
 
 #include <string>
 #include <iostream>
@@ -91,4 +90,3 @@ private:
 	NameToIdMap m_name_to_id;
 };
 
-#endif

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NODEDEF_HEADER
-#define NODEDEF_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include <string>
@@ -519,4 +518,3 @@ public:
 	bool m_resolve_done = false;
 };
 
-#endif

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NODEMETADATA_HEADER
-#define NODEMETADATA_HEADER
+#pragma once
 
 #include <unordered_set>
 #include "metadata.h"
@@ -96,4 +95,3 @@ private:
 	std::map<v3s16, NodeMetadata *> m_data;
 };
 
-#endif

--- a/src/nodetimer.h
+++ b/src/nodetimer.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef NODETIMER_HEADER
-#define NODETIMER_HEADER
+#pragma once
 
 #include "irr_v3d.h"
 #include <iostream>
@@ -131,6 +130,4 @@ private:
 	double m_next_trigger_time = -1.0;
 	double m_time = 0.0;
 };
-
-#endif
 

--- a/src/noise.h
+++ b/src/noise.h
@@ -23,8 +23,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef NOISE_HEADER
-#define NOISE_HEADER
+#pragma once
 
 #include "irr_v3d.h"
 #include "exceptions.h"
@@ -232,6 +231,4 @@ inline float easeCurve(float t)
 }
 
 float contour(float v);
-
-#endif
 

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef OBJDEF_HEADER
-#define OBJDEF_HEADER
+#pragma once
 
 #include "util/basic_macros.h"
 #include "porting.h"
@@ -94,4 +93,3 @@ protected:
 	ObjDefType m_objtype;
 };
 
-#endif

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef OBJECT_PROPERTIES_HEADER
-#define OBJECT_PROPERTIES_HEADER
+#pragma once
 
 #include <string>
 #include "irrlichttypes_bloated.h"
@@ -61,4 +60,3 @@ struct ObjectProperties
 	void deSerialize(std::istream &is);
 };
 
-#endif

--- a/src/particles.h
+++ b/src/particles.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PARTICLES_HEADER
-#define PARTICLES_HEADER
+#pragma once
 
 #include <iostream>
 #include "irrlichttypes_extrabloated.h"
@@ -211,4 +210,3 @@ private:
 	std::mutex m_spawner_list_lock;
 };
 
-#endif

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PATHFINDER_H_
-#define PATHFINDER_H_
+#pragma once
 
 /******************************************************************************/
 /* Includes                                                                   */
@@ -63,4 +62,3 @@ std::vector<v3s16> get_path(ServerEnvironment *env,
 							unsigned int max_drop,
 							PathAlgorithm algo);
 
-#endif /* PATHFINDER_H_ */

--- a/src/player.h
+++ b/src/player.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PLAYER_HEADER
-#define PLAYER_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
@@ -174,6 +173,4 @@ private:
 	// and ServerThread
 	std::mutex m_mutex;
 };
-
-#endif
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -21,8 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	Random portability stuff
 */
 
-#ifndef PORTING_HEADER
-#define PORTING_HEADER
+#pragma once
 
 #ifdef _WIN32
 	#ifdef _WIN32_WINNT
@@ -332,6 +331,4 @@ void attachOrCreateConsole(void);
 #ifdef __ANDROID__
 #include "porting_android.h"
 #endif
-
-#endif // PORTING_HEADER
 

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -16,8 +16,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef PORTING_ANDROID_H
-#define PORTING_ANDROID_H
+#pragma once
 
 #ifndef __ANDROID__
 #error this include has to be included on android port only!
@@ -78,4 +77,3 @@ std::string getInputDialogValue();
 
 }
 
-#endif

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -16,8 +16,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-#ifndef __PORTING_ANDROID_H__
-#define __PORTING_ANDROID_H__
+#ifndef PORTING_ANDROID_H
+#define PORTING_ANDROID_H
 
 #ifndef __ANDROID__
 #error this include has to be included on android port only!

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef PROFILER_HEADER
-#define PROFILER_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include <string>
@@ -198,6 +197,4 @@ private:
 	TimeTaker *m_timer = nullptr;
 	enum ScopeProfilerType m_type;
 };
-
-#endif
 

--- a/src/quicktune.h
+++ b/src/quicktune.h
@@ -46,8 +46,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	The QUICKTUNE macros shouldn't generally be left in committed code.
 */
 
-#ifndef QUICKTUNE_HEADER
-#define QUICKTUNE_HEADER
+#pragma once
 
 #include <string>
 #include <map>
@@ -99,6 +98,4 @@ void updateQuicktuneValue(const std::string &name, QuicktuneValue &val);
 
 #define QUICKTUNE_AUTONAME(type_, var, min_, max_)\
 	QUICKTUNE(type_, var, min_, max_, #var)
-
-#endif
 

--- a/src/quicktune_shortcutter.h
+++ b/src/quicktune_shortcutter.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef QVT_SHORTCUTTER_HEADER
-#define QVT_SHORTCUTTER_HEADER
+#pragma once
 
 #include "quicktune.h"
 
@@ -83,6 +82,4 @@ public:
 		setQuicktuneValue(getSelectedName(), val);
 	}
 };
-
-#endif
 

--- a/src/raycast.h
+++ b/src/raycast.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SRC_RAYCAST_H_
-#define SRC_RAYCAST_H_
+#pragma once
 
 #include "voxelalgorithms.h"
 #include "util/pointedthing.h"
@@ -77,5 +76,3 @@ public:
 bool boxLineCollision(const aabb3f &box, const v3f &start, const v3f &dir,
 	v3f *collision_point, v3s16 *collision_normal);
 
-
-#endif /* SRC_RAYCAST_H_ */

--- a/src/reflowscan.h
+++ b/src/reflowscan.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef REFLOWSCAN_H
-#define REFLOWSCAN_H
+#pragma once
 
 #include "util/container.h"
 #include "irrlichttypes_bloated.h"
@@ -47,4 +46,3 @@ private:
 	u32 m_lookup_state_bitset;
 };
 
-#endif // REFLOWSCAN_H

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef REMOTEPLAYER_HEADER
-#define REMOTEPLAYER_HEADER
+#pragma once
 
 #include "player.h"
 #include "cloudparams.h"
@@ -169,4 +168,3 @@ private:
 	CloudParams m_cloud_params;
 };
 
-#endif

--- a/src/rollback.h
+++ b/src/rollback.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ROLLBACK_HEADER
-#define ROLLBACK_HEADER
+#pragma once
 
 #include <string>
 #include "irr_v3d.h"
@@ -104,4 +103,3 @@ private:
 	std::vector<Entity> knownNodes;
 };
 
-#endif

--- a/src/rollback_interface.h
+++ b/src/rollback_interface.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef ROLLBACK_INTERFACE_HEADER
-#define ROLLBACK_INTERFACE_HEADER
+#pragma once
 
 #include "irr_v3d.h"
 #include <string>
@@ -160,4 +159,3 @@ private:
 	bool old_actor_guess;
 };
 
-#endif

--- a/src/script/lua_api/l_storage.h
+++ b/src/script/lua_api/l_storage.h
@@ -18,8 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef __L_STORAGE_H__
-#define __L_STORAGE_H__
+#ifndef L_STORAGE_H
+#define L_STORAGE_H
 
 #include "l_metadata.h"
 #include "lua_api/l_base.h"
@@ -60,4 +60,4 @@ public:
 	static ModMetadata *getobject(StorageRef *ref);
 };
 
-#endif /* __L_STORAGE_H__ */
+#endif /* L_STORAGE_H */

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SERIALIZATION_HEADER
-#define SERIALIZATION_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include "exceptions.h"
@@ -94,6 +93,4 @@ void decompressZlib(std::istream &is, std::ostream &os);
 void compress(SharedBuffer<u8> data, std::ostream &os, u8 version);
 //void compress(const std::string &data, std::ostream &os, u8 version);
 void decompress(std::istream &is, std::ostream &os, u8 version);
-
-#endif
 

--- a/src/server.h
+++ b/src/server.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SERVER_HEADER
-#define SERVER_HEADER
+#pragma once
 
 #include "network/connection.h"
 #include "irr_v3d.h"
@@ -679,4 +678,3 @@ private:
 */
 void dedicated_server_loop(Server &server, bool &kill);
 
-#endif

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SERVER_ENVIRONMENT_HEADER
-#define SERVER_ENVIRONMENT_HEADER
+#pragma once
 
 #include "environment.h"
 #include "mapnode.h"
@@ -437,4 +436,3 @@ private:
 	std::unordered_map<u32, u16> m_particle_spawner_attachments;
 };
 
-#endif

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -22,8 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mods.h"
 #include <json/json.h>
 
-#ifndef SERVERLIST_HEADER
-#define SERVERLIST_HEADER
+#pragma once
 
 typedef Json::Value ServerListSpec;
 
@@ -52,4 +51,3 @@ void sendAnnounce(AnnounceAction, u16 port,
 
 } // namespace ServerList
 
-#endif

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SERVEROBJECT_HEADER
-#define SERVEROBJECT_HEADER
+#pragma once
 
 #include <unordered_set>
 #include "irrlichttypes_bloated.h"
@@ -258,6 +257,4 @@ private:
 	// Used for creating objects based on type
 	static std::map<u16, Factory> m_types;
 };
-
-#endif
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SETTINGS_HEADER
-#define SETTINGS_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include "util/string.h"
@@ -234,6 +233,4 @@ private:
 	mutable std::mutex m_mutex;
 
 };
-
-#endif
 

--- a/src/shader.h
+++ b/src/shader.h
@@ -18,8 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SHADER_HEADER
-#define SHADER_HEADER
+#pragma once
 
 #include <IMaterialRendererServices.h>
 #include "irrlichttypes_bloated.h"
@@ -154,4 +153,3 @@ IWritableShaderSource *createShaderSource();
 void dumpShaderProgram(std::ostream &output_stream,
 	const std::string &program_type, const std::string &program);
 
-#endif

--- a/src/sky.h
+++ b/src/sky.h
@@ -21,8 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "camera.h"
 #include "irrlichttypes_extrabloated.h"
 
-#ifndef SKY_HEADER
-#define SKY_HEADER
+#pragma once
 
 #define SKY_MATERIAL_COUNT 5
 #define SKY_STAR_COUNT 200
@@ -148,4 +147,3 @@ private:
 	video::ITexture *m_moon_tonemap;
 };
 
-#endif

--- a/src/socket.h
+++ b/src/socket.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SOCKET_HEADER
-#define SOCKET_HEADER
+#pragma once
 
 #ifdef _WIN32
 #ifndef _WIN32_WINNT
@@ -133,6 +132,4 @@ private:
 	int m_timeout_ms;
 	int m_addr_family;
 };
-
-#endif
 

--- a/src/sound.h
+++ b/src/sound.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SOUND_HEADER
-#define SOUND_HEADER
+#pragma once
 
 #include <set>
 #include <string>
@@ -122,4 +121,3 @@ public:
 // Global DummySoundManager singleton
 extern DummySoundManager dummySoundManager;
 
-#endif

--- a/src/sound_openal.h
+++ b/src/sound_openal.h
@@ -17,12 +17,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SOUND_OPENAL_HEADER
-#define SOUND_OPENAL_HEADER
+#pragma once
 
 #include "sound.h"
 
 ISoundManager *createOpenALSoundManager(OnDemandSoundFetcher *fetcher);
-
-#endif
 

--- a/src/staticobject.h
+++ b/src/staticobject.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef STATICOBJECT_HEADER
-#define STATICOBJECT_HEADER
+#pragma once
 
 #include "irrlichttypes_bloated.h"
 #include <string>
@@ -95,6 +94,4 @@ public:
 
 private:
 };
-
-#endif
 

--- a/src/subgame.h
+++ b/src/subgame.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef SUBGAME_HEADER
-#define SUBGAME_HEADER
+#pragma once
 
 #include <string>
 #include <set>
@@ -99,6 +98,4 @@ std::vector<WorldSpec> getAvailableWorlds();
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
 bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamespec);
-
-#endif
 

--- a/src/terminal_chat_console.h
+++ b/src/terminal_chat_console.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TERMINAL_CHAT_CONSOLE_H
-#define TERMINAL_CHAT_CONSOLE_H
+#pragma once
 
 #include "chat.h"
 #include "threading/thread.h"
@@ -122,4 +121,3 @@ private:
 
 extern TerminalChatConsole g_term_console;
 
-#endif

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TILEANIMATION_HEADER
-#define TILEANIMATION_HEADER
+#pragma once
 
 #include <iostream>
 #include "irrlichttypes_bloated.h"
@@ -59,4 +58,3 @@ struct TileAnimationParams
 	v2f getTextureCoords(v2u32 texture_size, int frame) const;
 };
 
-#endif

--- a/src/tool.h
+++ b/src/tool.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TOOL_HEADER
-#define TOOL_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include <string>
@@ -130,6 +129,4 @@ PunchDamageResult getPunchDamage(
 		const ItemStack *punchitem,
 		float time_from_last_punch
 );
-
-#endif
 

--- a/src/touchscreengui.h
+++ b/src/touchscreengui.h
@@ -16,8 +16,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TOUCHSCREENGUI_HEADER
-#define TOUCHSCREENGUI_HEADER
+#pragma once
 
 #include <IEventReceiver.h>
 #include <IGUIButton.h>
@@ -252,4 +251,3 @@ private:
 	AutoHideButtonBar m_rarecontrolsbar;
 };
 extern TouchScreenGUI *g_touchscreengui;
-#endif

--- a/src/treegen.h
+++ b/src/treegen.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef TREEGEN_HEADER
-#define TREEGEN_HEADER
+#pragma once
 
 #include <matrix4.h>
 #include "noise.h"
@@ -91,4 +90,3 @@ namespace treegen {
 	v3f transposeMatrix(irr::core::matrix4 M ,v3f v);
 
 }; // namespace treegen
-#endif

--- a/src/version.h
+++ b/src/version.h
@@ -17,12 +17,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef VERSION_HEADER
-#define VERSION_HEADER
+#pragma once
 
 extern const char *g_version_string;
 extern const char *g_version_hash;
 extern const char *g_build_info;
-
-#endif
 

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef VOXEL_HEADER
-#define VOXEL_HEADER
+#pragma once
 
 #include "irrlichttypes.h"
 #include "irr_v3d.h"
@@ -579,6 +578,4 @@ public:
 
 	static const MapNode ContentIgnoreNode;
 };
-
-#endif
 

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef VOXELALGORITHMS_HEADER
-#define VOXELALGORITHMS_HEADER
+#pragma once
 
 #include "voxel.h"
 #include "mapnode.h"
@@ -180,8 +179,4 @@ public:
 };
 
 } // namespace voxalgo
-
-
-
-#endif
 

--- a/src/wieldmesh.h
+++ b/src/wieldmesh.h
@@ -17,8 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#ifndef WIELDMESH_HEADER
-#define WIELDMESH_HEADER
+#pragma once
 
 #include <string>
 #include "irrlichttypes_extrabloated.h"
@@ -137,4 +136,3 @@ scene::SMesh *getExtrudedMesh(ITextureSource *tsrc, const std::string &imagename
 void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f, bool use_shaders,
 		bool set_material, video::E_MATERIAL_TYPE *mattype,
 		std::vector<ItemPartColor> *colors);
-#endif


### PR DESCRIPTION
To find the problematic header guards per the issue:
`find src -type f -exec grep "define _[_|A-Z]" {} /dev/null \;`
(the /dev/null is to abuse grep to output the filename as well [as found on SO](https://stackoverflow.com/a/15432718/978509) )

This only changes headerguards. There were other macros that came up, but most of them appeared to be engine or platform specific (`_WIN32_WINNT`, `__BYTE_ORDER`, `__IRR_USTRING_H_INCLUDED__`, etc)