### PR TITLE
Clouds API: change speed from 'y' to 'z', ColorSpecs in Lua docs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3306,11 +3306,12 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `set_clouds(parameters)`: set cloud parameters
 	* `parameters` is a table with the following optional fields:
 		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
-		* `color`: basic cloud color, with alpha channel (default `#fff0f0e5`)
-		* `ambient`: cloud color lower bound, use for a "glow at night" effect (default `#000000`)
+		* `color`: basic cloud color with alpha channel, ColorSpec (default `#fff0f0e5`)
+		* `ambient`: cloud color lower bound, use for a "glow at night" effect.
+		  ColorSpec (alpha ignored, default `#000000`)
 		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
 		* `thickness`: cloud thickness in nodes (default `16`)
-		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, y=-2}`)
+		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, z=-2}`)
 * `get_clouds()`: returns a table with the current cloud parameters as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1766,7 +1766,7 @@ int ObjectRef::l_set_clouds(lua_State *L)
 	if (lua_istable(L, -1)) {
 		v2f new_speed;
 		new_speed.X = getfloatfield_default(L, -1, "x", 0);
-		new_speed.Y = getfloatfield_default(L, -1, "y", 0);
+		new_speed.Y = getfloatfield_default(L, -1, "z", 0);
 		cloud_params.speed = new_speed;
 	}
 	lua_pop(L, 1);


### PR DESCRIPTION
Fixes issue #6163 .

This will break mods that use `y` as the second speed parameter, if such mods already exist.

As to the color documentation: the colors are all `ColorSpec`s, i.e. strings, tables, numbers, what have you. I've also noted that the alpha channel is ignored for the "ambient" color, but `ColorSpec`s allow one to be specified, and they won't break anything.