### PR TITLE
More helpful server connect error messages

### DIFF
--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -987,12 +987,12 @@ enum NetProtoCompressionMode {
 };
 
 const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
-	"Invalid password",
+	"The password is invalid.",
 	"Your client sent something the server didn't expect.  Try reconnecting or updating your client",
 	"The server is running in simple singleplayer mode.  You cannot connect.",
 	"Your client's version is not supported.\nPlease contact server administrator.",
-	"Player name contains disallowed characters.",
-	"Player name not allowed.",
+	"This player name contains disallowed characters.  Allowed are a-z, A-Z, 0-9, hyphen and underscore.",
+	"This player name is reserved and can not be used.  Please use a different player name.",
 	"Too many users.",
 	"Empty passwords are disallowed.  Set a password and try again.",
 	"Another client is connected with this name.  If your client closed unexpectedly, try again in a minute.",


### PR DESCRIPTION
This tiny PR slightly rewrites a few of the error messages you can get when you failed to connect to a server to make them a bit more helpful.
Click on “Files changed” above.