### PR TITLE
Mgv7: Add 'mount_zero_level' parameter

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1157,6 +1157,9 @@ mgv6_np_apple_trees (Apple trees noise) noise_params 0, 1, (100, 100, 100), 3429
 #    Flags starting with 'no' are used to explicitly disable them.
 mgv7_spflags (Mapgen v7 specific flags) flags mountains,ridges,nofloatlands,caverns,biomerepeat mountains,ridges,floatlands,caverns,biomerepeat,nomountains,noridges,nofloatlands,nocaverns,nobiomerepeat
 
+#    Y of mountain density gradient zero level. Used to shift mountains vertically.
+mgv7_mount_zero_level (Mountain zero level) int 0
+
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgv7_cave_width (Cave width) float 0.09
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1397,6 +1397,10 @@
 #    type: flags possible values: mountains, ridges, floatlands, caverns, biomerepeat, nomountains, noridges, nofloatlands, nocaverns, nobiomerepeat
 # mgv7_spflags = mountains,ridges,nofloatlands,caverns,biomerepeat
 
+#    Y of mountain density gradient zero level. Used to shift mountains vertically.
+#    type: int
+# mgv7_mount_zero_level = 0
+
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    type: float
 # mgv7_cave_width = 0.09

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -56,6 +56,7 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	: MapgenBasic(mapgenid, params, emerge)
 {
 	spflags             = params->spflags;
+	mount_zero_level    = params->mount_zero_level;
 	cave_width          = params->cave_width;
 	large_cave_depth    = params->large_cave_depth;
 	lava_depth          = params->lava_depth;
@@ -149,6 +150,7 @@ MapgenV7Params::MapgenV7Params()
 void MapgenV7Params::readParams(const Settings *settings)
 {
 	settings->getFlagStrNoEx("mgv7_spflags",           spflags, flagdesc_mapgen_v7);
+	settings->getS16NoEx("mgv7_mount_zero_level",      mount_zero_level);
 	settings->getFloatNoEx("mgv7_cave_width",          cave_width);
 	settings->getS16NoEx("mgv7_large_cave_depth",      large_cave_depth);
 	settings->getS16NoEx("mgv7_lava_depth",            lava_depth);
@@ -180,6 +182,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 void MapgenV7Params::writeParams(Settings *settings) const
 {
 	settings->setFlagStr("mgv7_spflags",           spflags, flagdesc_mapgen_v7, U32_MAX);
+	settings->setS16("mgv7_mount_zero_level",      mount_zero_level);
 	settings->setFloat("mgv7_cave_width",          cave_width);
 	settings->setS16("mgv7_large_cave_depth",      large_cave_depth);
 	settings->setS16("mgv7_lava_depth",            lava_depth);
@@ -397,7 +400,7 @@ bool MapgenV7::getMountainTerrainAtPoint(s16 x, s16 y, s16 z)
 {
 	float mnt_h_n =
 			MYMAX(NoisePerlin2D(&noise_mount_height->np, x, z, seed), 1.0f);
-	float density_gradient = -((float)y / mnt_h_n);
+	float density_gradient = -((float)(y - mount_zero_level) / mnt_h_n);
 	float mnt_n = NoisePerlin3D(&noise_mountain->np, x, y, z, seed);
 
 	return mnt_n + density_gradient >= 0.0;
@@ -407,7 +410,7 @@ bool MapgenV7::getMountainTerrainAtPoint(s16 x, s16 y, s16 z)
 bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y)
 {
 	float mounthn = MYMAX(noise_mount_height->result[idx_xz], 1.0f);
-	float density_gradient = -((float)y / mounthn);
+	float density_gradient = -((float)(y - mount_zero_level) / mounthn);
 	float mountn = noise_mountain->result[idx_xyz];
 
 	return mountn + density_gradient >= 0.0;

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -38,6 +38,7 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES |
 		MGV7_CAVERNS | MGV7_BIOMEREPEAT;
+	s16 mount_zero_level = 0;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
@@ -92,6 +93,7 @@ public:
 	void generateRidgeTerrain();
 
 private:
+	s16 mount_zero_level;
 	s16 large_cave_depth;
 	float float_mount_density;
 	float float_mount_height;


### PR DESCRIPTION
Allows setting of the mountain 'zero level' (y where density gradient is zero).

It is easy to vertically shift smooth terrain by editing noise parameter 'offset',
but vertically shifting mountain terrain was complex and imprecise, involving
making a calculation based on an average of the mountain height parameter.
/////////////////

Tested.
I once helped someone shift mgv7 terrain downwards in their world to make space for stacked Lua mapgen realms, and discovered there is no easy way to shift mountain terrain by a desired number of nodes.