### PR TITLE
TileLayer: use shared_ptr for FrameSpec vector

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <vector>
 #include <SMaterial.h>
+#include <memory>
 #include "util/numeric.h"
 
 class IGameDef;
@@ -284,7 +285,7 @@ struct TileLayer
 	//! If true, the tile has its own color.
 	bool has_color = false;
 
-	std::vector<FrameSpec> frames;
+	std::shared_ptr<std::vector<FrameSpec>> frames = nullptr;
 
 	/*!
 	 * The color of the tile, or if the tile does not own

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mesh.h"
 #include "minimap.h"
 #include "content_mapblock.h"
+#include "util/directiontables.h"
 #include "client/renderingengine.h"
 
 /*

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1126,7 +1126,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 					m_animation_frame_offsets[std::pair<u8, u32>(layer, i)] = 0;
 				}
 				// Replace tile texture with the first animation frame
-				p.layer.texture = p.layer.frames[0].texture;
+				p.layer.texture = (*p.layer.frames)[0].texture;
 			}
 
 			if (!m_enable_shaders) {
@@ -1314,7 +1314,7 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack, u32 daynight_rat
 		scene::IMeshBuffer *buf = m_mesh[i->first.first]->
 			getMeshBuffer(i->first.second);
 
-		const FrameSpec &animation_frame = tile.frames[frame];
+		const FrameSpec &animation_frame = (*tile.frames)[frame];
 		buf->getMaterial().setTexture(0, animation_frame.texture);
 		if (m_enable_shaders) {
 			if (animation_frame.normal_texture) {

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -18,18 +18,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "mapblock_mesh.h"
-#include "light.h"
 #include "mapblock.h"
 #include "map.h"
 #include "profiler.h"
-#include "nodedef.h"
 #include "mesh.h"
 #include "minimap.h"
 #include "content_mapblock.h"
-#include "noise.h"
-#include "shader.h"
-#include "settings.h"
-#include "util/directiontables.h"
 #include "client/renderingengine.h"
 
 /*
@@ -602,7 +596,8 @@ static void makeFastFace(const TileSpec &tile, u16 li0, u16 li1, u16 li2, u16 li
 		if (layer->texture_id == 0)
 			continue;
 
-		dest.push_back(FastFace());
+		// equivalent to dest.push_back(FastFace()) but faster
+		dest.emplace_back();
 		FastFace& face = *dest.rbegin();
 
 		for (u8 i = 0; i < 4; i++) {

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -637,7 +637,10 @@ void ContentFeatures::fillTileAttribs(ITextureSource *tsrc, TileLayer *tile,
 		tile->material_flags &= ~MATERIAL_FLAG_ANIMATION;
 	} else {
 		std::ostringstream os(std::ios::binary);
-		tile->frames.resize(frame_count);
+		if (!tile->frames) {
+			tile->frames = std::make_shared<std::vector<FrameSpec>>();
+		}
+		tile->frames->resize(frame_count);
 
 		for (int i = 0; i < frame_count; i++) {
 
@@ -652,7 +655,7 @@ void ContentFeatures::fillTileAttribs(ITextureSource *tsrc, TileLayer *tile,
 			if (tile->normal_texture)
 				frame.normal_texture = tsrc->getNormalTexture(os.str());
 			frame.flags_texture = tile->flags_texture;
-			tile->frames[i] = frame;
+			(*tile->frames)[i] = frame;
 		}
 	}
 }

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -631,7 +631,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 
 	// Only use first frame of animated texture
 	if (tile.material_flags & MATERIAL_FLAG_ANIMATION)
-		texture = tile.frames[0].texture;
+		texture = (*tile.frames)[0].texture;
 	else
 		texture = tile.texture;
 

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -593,7 +593,7 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				material.MaterialType = *mattype;
 			}
 			if (layer->animation_frame_count > 1) {
-				FrameSpec animation_frame = layer->frames[0];
+				const FrameSpec &animation_frame = (*layer->frames)[0];
 				material.setTexture(0, animation_frame.texture);
 			} else {
 				material.setTexture(0, layer->texture);
@@ -601,7 +601,7 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 			if (use_shaders) {
 				if (layer->normal_texture) {
 					if (layer->animation_frame_count > 1) {
-						FrameSpec animation_frame = layer->frames[0];
+						const FrameSpec &animation_frame = (*layer->frames)[0];
 						material.setTexture(1, animation_frame.normal_texture);
 					} else
 						material.setTexture(1, layer->normal_texture);


### PR DESCRIPTION
This reduce memory copy of TileLayer from (4 to 16) * FrameSpec where FrameSpec = (sizeof(int) + 3 * sizeof(ptr)) to int + sizeof(ptr)

Callgrind difference:

Before: ![capture d ecran de 2017-07-25 19-14-55](https://user-images.githubusercontent.com/119752/28589947-8f37dcfe-7180-11e7-9698-0d880686240a.png)

After: ![capture d ecran de 2017-07-25 21-01-30](https://user-images.githubusercontent.com/119752/28589948-8f4d3d56-7180-11e7-8890-1e4086e0b3f3.png)

we reduce ten times the copy load on the UpdateThread

Just for note: this permits to rebalance the client part from ~65% load on MT part to ~45% MT ~55% irrlicht part
Another side effect, i now have 4 FPS instead of 1 under callgrind :o