### PR TITLE
GenericCAO: Fix dark model below y = 0

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -943,7 +943,7 @@ void GenericCAO::updateLightNoCheck(u8 light_at_pos)
 
 v3s16 GenericCAO::getLightPosition()
 {
-	return floatToInt(m_position, BS);
+	return floatToInt(m_position + v3f(0, 0.5 * BS, 0), BS);
 }
 
 void GenericCAO::updateNodePos()


### PR DESCRIPTION
Move point at which light is sampled up to 0.5 nodes above foot level,
to avoid that point sometimes passing into the node below causing the
model to go dark.
/////////////

![screenshot_20170726_200018](https://user-images.githubusercontent.com/3686677/28638573-29d954f6-723d-11e7-9401-925db953de2f.png)

Fixes #6174 
Tested in a local server, i also adjusted the position downwards to double check this line is the cause.
0.5 nodes up is chosen to cope with 1-node high players or mobs, and is halfway up a node so is optimum.