### PR TITLE
Massive performance improvement on correctBlockNodeIds + various performance fixes

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -502,7 +502,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	std::unordered_set<content_t> unnamed_contents;
 	std::unordered_set<std::string> unallocatable_contents;
 
-	bool previous_was_found = false;
+	bool previous_exists = false;
 	content_t previous_local_id = CONTENT_IGNORE;
 	content_t previous_global_id = CONTENT_IGNORE;
 
@@ -512,7 +512,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 		// apply directly previous resolved id
 		// This permits to massively improve loading performance when nodes are similar
 		// example: default:air, default:stone are massively present
-		if (previous_was_found && local_id == previous_local_id) {
+		if (previous_exists && local_id == previous_local_id) {
 			nodes[i].setContent(previous_global_id);
 			continue;
 		}
@@ -520,7 +520,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 		std::string name;
 		if (!nimap->getName(local_id, name)) {
 			unnamed_contents.insert(local_id);
-			previous_was_found = false;
+			previous_exists = false;
 			continue;
 		}
 
@@ -529,7 +529,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 			global_id = gamedef->allocateUnknownNodeId(name);
 			if (global_id == CONTENT_IGNORE) {
 				unallocatable_contents.insert(name);
-				previous_was_found = false;
+				previous_exists = false;
 				continue;
 			}
 		}
@@ -538,7 +538,7 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 		// Save previous node local_id & global_id result
 		previous_local_id = local_id;
 		previous_global_id = global_id;
-		previous_was_found = true;
+		previous_exists = true;
 	}
 
 	for (const content_t c: unnamed_contents) {

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -494,22 +494,44 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	// correct ids.
 	std::unordered_set<content_t> unnamed_contents;
 	std::unordered_set<std::string> unallocatable_contents;
+
+	bool previous_was_found = false;
+	content_t previous_local_id = CONTENT_IGNORE;
+	content_t previous_global_id = CONTENT_IGNORE;
+
 	for (u32 i = 0; i < MapBlock::nodecount; i++) {
 		content_t local_id = nodes[i].getContent();
+		// If previous node local_id was found and same than before, don't lookup maps
+		// apply directly previous resolved id
+		// This permits to massively improve loading performance when nodes are similar
+		// example: default:air, default:stone are massively present
+		if (previous_was_found && local_id == previous_local_id) {
+			nodes[i].setContent(previous_global_id);
+			continue;
+		}
+
 		std::string name;
 		if (!nimap->getName(local_id, name)) {
 			unnamed_contents.insert(local_id);
+			previous_was_found = false;
 			continue;
 		}
+
 		content_t global_id;
 		if (!nodedef->getId(name, global_id)) {
 			global_id = gamedef->allocateUnknownNodeId(name);
-			if(global_id == CONTENT_IGNORE){
+			if (global_id == CONTENT_IGNORE) {
 				unallocatable_contents.insert(name);
+				previous_was_found = false;
 				continue;
 			}
 		}
 		nodes[i].setContent(global_id);
+
+		// Save previous node local_id & global_id result
+		previous_local_id = local_id;
+		previous_global_id = global_id;
+		previous_was_found = true;
 	}
 
 	for (const content_t c: unnamed_contents) {

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -366,12 +366,19 @@ void MapBlock::actuallyUpdateDayNightDiff()
 	/*
 		Check if any lighting value differs
 	*/
+
+	MapNode previous_n;
 	for (u32 i = 0; i < nodecount; i++) {
-		MapNode &n = data[i];
+		MapNode n = data[i];
+
+		// If node is identical to previous node, don't verify if it differs
+		if (n == previous_n)
+			continue;
 
 		differs = !n.isLightDayNightEq(nodemgr);
 		if (differs)
 			break;
+		previous_n = n;
 	}
 
 	/*

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -86,12 +86,12 @@ inline bool ser_ver_supported(s32 v) {
 	Misc. serialization functions
 */
 
-void compressZlib(SharedBuffer<u8> data, std::ostream &os, int level = -1);
+void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level = -1);
 void compressZlib(const std::string &data, std::ostream &os, int level = -1);
 void decompressZlib(std::istream &is, std::ostream &os);
 
 // These choose between zlib and a self-made one according to version
-void compress(SharedBuffer<u8> data, std::ostream &os, u8 version);
+void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version);
 //void compress(const std::string &data, std::ostream &os, u8 version);
 void decompress(std::istream &is, std::ostream &os, u8 version);
 


### PR DESCRIPTION
# 1st commit

correctBlockNodeIds does 2 lookups for each loaded node, one to translate DB ID to name and a second to translate name to real ID. Name to real ID is very consumming if done on every node. As mapblocks are in most cases composed of many identical adjacent nodes, cache previous source and destination id and use them on the next node to prevent any lookup on those maps.

This reduce the function load from 15% of my CPU usage to ~0.7%, on the test, calls was reduced from 2.5M lookups to 42k lookups (ratio 1.39 applied on deserialize function call), it's a huge performance gain

Before:
![capture d ecran de 2017-07-26 22-43-41](https://user-images.githubusercontent.com/119752/28643265-8eabe9da-7255-11e7-90a3-a45e80fb07ba.png)

After:
![capture d ecran de 2017-07-26 22-47-39](https://user-images.githubusercontent.com/119752/28643266-8eb03684-7255-11e7-9e0b-792fd68b8408.png)

# 2nd commit

compressZlib: don't use a SharedBuffer but a raw u8 * pointer

Remove usage of the SharedBuffer in zlib compression which has two problems:
* We copied the whole memory block to compress it (not good with mapblocks)
* We copied sometimes strings to SharedBuffer to SharedBuffer (2nd time)

Use this method in MapNode::serializeBulk + optimize serialization but merging 3 identical loops in a single loop

# 3rd commit

MapBlock::actuallyUpdateDayNightDiff(): little performance optimization

don't check isLightDayNightEq if checked on previous node

# Extra note

don't squash those commits