### PR TITLE
Dungeons: Use biome 'node_stone' if normal stone types not detected 

### DIFF
--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -79,11 +79,11 @@ enum GenNotifyType {
 	NUM_GENNOTIFY_TYPES
 };
 
-// TODO(hmmmm/paramat): make stone type selection dynamic
 enum MgStoneType {
 	MGSTONE_STONE,
 	MGSTONE_DESERT_STONE,
 	MGSTONE_SANDSTONE,
+	MGSTONE_OTHER,
 };
 
 struct GenNotifyEvent {
@@ -250,8 +250,10 @@ public:
 
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
 	virtual bool generateCaverns(s16 max_stone_y);
-	virtual void generateDungeons(s16 max_stone_y, MgStoneType stone_type);
-	virtual MgStoneType generateBiomes(s16 biome_zero_level = 0);
+	virtual void generateDungeons(s16 max_stone_y,
+		MgStoneType stone_type, content_t biome_stone);
+	virtual void generateBiomes(MgStoneType *mgstone_type,
+		content_t *biome_stone, s16 biome_zero_level);
 	virtual void dustTopNodes();
 
 protected:

--- a/src/mapgen_carpathian.cpp
+++ b/src/mapgen_carpathian.cpp
@@ -242,7 +242,10 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes(water_level - 1);
+
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -262,7 +265,7 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -189,13 +189,16 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes(water_level - 1);
+
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -200,13 +200,16 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes(water_level - 1);
+
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -200,7 +200,10 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes(water_level - 1);
+
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -220,7 +223,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons and desert temples
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -308,7 +308,10 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-	MgStoneType stone_type = generateBiomes(biome_zero_level);
+
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -328,7 +331,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -236,7 +236,9 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Place biome-specific nodes and build biomemap
-	MgStoneType stone_type = generateBiomes(water_level - 1);
+	MgStoneType mgstone_type;
+	content_t biome_stone;
+	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
 
 	// Cave creation.
 	if (flags & MG_CAVES)
@@ -244,7 +246,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 
 	// Dungeon creation
 	if ((flags & MG_DUNGEONS) && node_max.Y < 50)
-		generateDungeons(stone_surface_max_y, stone_type);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)


### PR DESCRIPTION
Construct dungeons from the node defined as biome 'node_stone' if
'mapgen_stone', 'mapgen_desert_stone' and 'mapgen_sandstone' are not
detected.
Feature long-intended by kwolekr/hmmmm and present in code as a TODO.
//////////////

![screenshot_20170729_014326](https://user-images.githubusercontent.com/3686677/28740705-2761bd02-7400-11e7-945c-2006894834a7.png)

^ Ice dungeon, previously this would have been a cobble dungeon

Tested.
Long-intended feature
https://github.com/minetest/minetest/blob/master/src/mapgen.h#L82
```
// TODO(hmmmm/paramat): make stone type selection dynamic
```
that has been requested, if a biome does not contain stone, desert stone or sandstone, construct dungeons from the defined biome 'node stone'.
Produces ice dungeons in icesheet biome.
In subgames that use unusual nodes for biome 'node stone' the dungeons will use that node.