### PR TITLE
Allow 'default' parameter in 'settings:get_bool' function

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4111,7 +4111,9 @@ It can be created via `Settings(filename)`.
 
 #### Methods
 * `get(key)`: returns a value
-* `get_bool(key)`: returns a boolean
+* `get_bool(key, [default])`: returns a boolean
+    * `default` is the value returned if `key` is not found.
+    * Returns `nil` if `key` is not found and `default` not specified.
 * `get_np_group(key)`: returns a NoiseParams table
 * `set(key, value)`
     * Setting names can't contain whitespace or any of `="{}#`.

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -100,7 +100,11 @@ int LuaSettings::l_get_bool(lua_State* L)
 		bool value = o->m_settings->getBool(key);
 		lua_pushboolean(L, value);
 	} else {
-		lua_pushnil(L);
+		// Push default value
+		if (lua_isboolean(L, 3))
+			lua_pushboolean(L, lua_toboolean(L, 3));
+		else
+			lua_pushnil(L);
 	}
 
 	return 1;


### PR DESCRIPTION
Default value is an optional parameter & used when the setting key is not found in the config
file.

Example: ```core.settings:get_bool("enable_debug_mods", false)```

**NOTE:** Defaults to ***nil*** if key not found in config file for compatibility.