### PR TITLE
Fix crash when using --go in command line, when user name is defined via command line or minetest.conf

### DIFF
--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -60,7 +60,7 @@ protected:
 	gui::IGUIFont *font = nullptr;
 	SubgameSpec gamespec;
 	WorldSpec worldspec;
-	bool simple_singleplayer_mode;
+	bool simple_singleplayer_mode = false;
 
 	// These are set up based on the menu and other things
 	// TODO: Are these required since there's already playername, password, etc


### PR DESCRIPTION
Fix a crash while using --go command line parameter (e.g. when user name is defined). I found that if in clientlauncher.h, _bool simple_singleplayer_mode_ in  class ClientLauncher _had no value_ and when game run, the variable **skip_main_menu** were _true_, in the function **launch_game** (clientlauncher.cpp) game would skip the entire block `if (!skip_main_menu) {` and then **simple_singleplayer_mode** variable would **remain undefined** (at least in debug build) and cause an upcoming crash in block `if (simple_singleplayer_mode) {` where `assert(skip_main_menu == false);` is defined.