### PR TITLE
Remove cloud_height setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -610,9 +610,6 @@ texture_path (Texture path) path
 #    The rendering back-end for Irrlicht.
 video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl
 
-#    Height on which clouds are appearing.
-cloud_height (Cloud height) int 120
-
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
 cloud_radius (Cloud radius) int 12

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -598,10 +598,6 @@
 #    type: enum values: null, software, burningsvideo, direct3d8, direct3d9, opengl
 # video_driver = opengl
 
-#    Height on which clouds are appearing.
-#    type: int
-# cloud_height = 120
-
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.
 #    type: int

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -128,7 +128,8 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	if (!g_menucloudsmgr)
 		g_menucloudsmgr = RenderingEngine::get_scene_manager()->createNewSceneManager();
 	if (!g_menuclouds)
-		g_menuclouds = new Clouds(g_menucloudsmgr, -1, rand(), 100);
+		g_menuclouds = new Clouds(g_menucloudsmgr, -1, rand());
+	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 200, 200, 255));
 	scene::ICameraSceneNode* camera;
 	camera = g_menucloudsmgr->addCameraSceneNode(0,

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -42,8 +42,7 @@ static void cloud_3d_setting_changed(const std::string &settingname, void *data)
 
 Clouds::Clouds(scene::ISceneManager* mgr,
 		s32 id,
-		u32 seed,
-		s16 cloudheight
+		u32 seed
 ):
 	scene::ISceneNode(mgr->getRootSceneNode(), mgr, id),
 	m_seed(seed)
@@ -57,7 +56,7 @@ Clouds::Clouds(scene::ISceneManager* mgr,
 	//m_material.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
-	m_params.height        = cloudheight ? cloudheight : 120;
+	m_params.height        = 120;
 	m_params.density       = 0.4f;
 	m_params.thickness     = 16.0f;
 	m_params.color_bright  = video::SColor(229, 240, 240, 255);

--- a/src/clouds.cpp
+++ b/src/clouds.cpp
@@ -37,7 +37,6 @@ static constexpr const float cloud_size = BS * 64.0f;
 
 static void cloud_3d_setting_changed(const std::string &settingname, void *data)
 {
-	// TODO: only re-read cloud settings, not height or radius
 	((Clouds *)data)->readSettings();
 }
 
@@ -58,13 +57,13 @@ Clouds::Clouds(scene::ISceneManager* mgr,
 	//m_material.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
+	m_params.height        = cloudheight ? cloudheight : 120;
 	m_params.density       = 0.4f;
 	m_params.thickness     = 16.0f;
 	m_params.color_bright  = video::SColor(229, 240, 240, 255);
 	m_params.color_ambient = video::SColor(255, 0, 0, 0);
 	m_params.speed         = v2f(0.0f, -2.0f);
 
-	m_passed_cloud_y = cloudheight;
 	readSettings();
 	g_settings->registerChangedCallback("enable_3d_clouds",
 		&cloud_3d_setting_changed, this);
@@ -370,8 +369,6 @@ void Clouds::update(const v3f &camera_p, const video::SColorf &color_diffuse)
 
 void Clouds::readSettings()
 {
-	m_params.height = (m_passed_cloud_y ? m_passed_cloud_y :
-		g_settings->getS16("cloud_height"));
 	m_cloud_radius_i = g_settings->getU16("cloud_radius");
 	m_enable_3d = g_settings->getBool("enable_3d_clouds");
 }

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -133,7 +133,6 @@ private:
 
 	video::SMaterial m_material;
 	aabb3f m_box;
-	s16 m_passed_cloud_y;
 	u16 m_cloud_radius_i;
 	bool m_enable_3d;
 	u32 m_seed;

--- a/src/clouds.h
+++ b/src/clouds.h
@@ -38,8 +38,7 @@ class Clouds : public scene::ISceneNode
 public:
 	Clouds(scene::ISceneManager* mgr,
 			s32 id,
-			u32 seed,
-			s16 cloudheight=0
+			u32 seed
 	);
 
 	~Clouds();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -179,7 +179,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("view_bobbing_amount", "1.0");
 	settings->setDefault("fall_bobbing_amount", "0.0");
 	settings->setDefault("enable_3d_clouds", "true");
-	settings->setDefault("cloud_height", "120");
 	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");
 	settings->setDefault("opaque_water", "false");

--- a/src/guiEngine.cpp
+++ b/src/guiEngine.cpp
@@ -313,7 +313,8 @@ GUIEngine::~GUIEngine()
 /******************************************************************************/
 void GUIEngine::cloudInit()
 {
-	m_cloud.clouds = new Clouds(m_smgr, -1, rand(), 100);
+	m_cloud.clouds = new Clouds(m_smgr, -1, rand());
+	m_cloud.clouds->setHeight(100.0f);
 	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,200,200,255));
 
 	m_cloud.camera = m_smgr->addCameraSceneNode(0,


### PR DESCRIPTION
With the cloud API, the cloud_height setting has become obsolete
and replaceable by a mod. It, and supporting code, can be
removed.

Closes issue #5873.