### PR TITLE
Start off newly generated worlds early at sunrise, 5:15am

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -110,9 +110,9 @@ protected:
 	 * Below: values managed by m_time_lock
 	*/
 	// Time of day in milli-hours (0-23999); determines day and night
-	u32 m_time_of_day = 9000;
-	// Time of day in 0...1
-	float m_time_of_day_f = 9000.0f / 24000.0f;
+	u32 m_time_of_day = 5250;
+	// Time of day in 0...1; start 5:15am unless overridden by game
+	float m_time_of_day_f = 5250.0f / 24000.0f;
 	// Stores the skew created by the float -> u32 conversion
 	// to be applied at next conversion, so that there is no real skew.
 	float m_time_conversion_skew = 0.0f;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -633,8 +633,8 @@ void ServerEnvironment::loadMeta()
 	}
 
 	setTimeOfDay(args.exists("time_of_day") ?
-		// set day to morning by default
-		args.getU64("time_of_day") : 9000);
+		// set day to early morning by default
+		args.getU64("time_of_day") : 5250);
 
 	m_last_clear_objects_time = args.exists("last_clear_objects_time") ?
 		// If missing, do as if clearObjects was never called


### PR DESCRIPTION
Gives starting singleplayer games this subtle "dawn of a new world" feel.
I would have set it even earlier (up to 4:45am), but I was worried that in
some pre-existing games the player could be overwhelmed by hostile
mobs right at the start, seriously changing gameplay.

It's just the default, individual games should be able to override it, and
for public servers it's irrelevant anyway, because only the first player to
set foot in the world will notice, and that's usually the server admin.