### PR TITLE
Fix no user name error not shown in console when the name is blank

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -401,8 +401,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 
 	if (menudata.name == "" && !simple_singleplayer_mode) {
 		error_message = gettext("Please choose a name!");
-		if (skip_main_menu) 
-			errorstream << error_message << std::endl;
+		errorstream << error_message << std::endl;
 		return false;
 	}
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -401,6 +401,8 @@ bool ClientLauncher::launch_game(std::string &error_message,
 
 	if (menudata.name == "" && !simple_singleplayer_mode) {
 		error_message = gettext("Please choose a name!");
+		if (skip_main_menu) 
+			errorstream << error_message << std::endl;
 		return false;
 	}
 


### PR DESCRIPTION
**(updated x2)** If a blank name or nothing were provided while running minetest, the game would not show any error in console, and exit if menu were skipped using --go parameter in command line. The line that was missing were added to display the error message in the console, extra check removed.