### PR TITLE
Serialize: replace spaces with LFs to make merging with git possible

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2960,9 +2960,10 @@ These functions return the leftover itemstack.
         2. You can not mix string and integer keys.
            This is due to the fact that JSON has two distinct array and object values.
     * Example: `write_json({10, {a = false}})`, returns `"[10, {\"a\": false}]"`
-* `minetest.serialize(table)`: returns a string
+* `minetest.serialize(table, use_newlines)`: returns a string
     * Convert a table containing tables, strings, numbers, booleans and `nil`s
-      into string form readable by `minetest.deserialize`
+      into string form readable by `minetest.deserialize`. use_newlines=true uses
+      line feeds instead of spaces to separate top level items.
     * Example: `serialize({foo='bar'})`, returns `'return { ["foo"] = "bar" }'`
 * `minetest.deserialize(string)`: returns a table
     * Convert a string returned by `minetest.deserialize` into a table


### PR DESCRIPTION
Minetest games are often developed in git, but serialized WorldEdit schems
used for predefined structures consist of one single looooong line, making
git diffs worthless.

Try to amend this by putting line feeds in the top level table description,
thus adding structure to the serial data. The line feed replaces a space,
and both are whitespace, so neither size nor meaning of the data changes.
This means the code remains compatible in both directions.

The builtin serialize.lua prints the structures recursively. To replace
spaces with LF on the top level only we must keep track of the current
recursion level ("iter" parameter). Otherwise, if we replaced every space,
we'd just get a huuuuuge column of tokens, which isn't better than before.