### PR TITLE
 Step height: Add as a player object property

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -80,6 +80,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // the main loop (related to TempMods and day/night)
 //#define MAP_BLOCKSIZE 32
 
+// Player step height in nodes
+#define PLAYER_DEFAULT_STEPHEIGHT 0.6f
+
 /*
     Old stuff that shouldn't be hardcoded
 */

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -147,6 +147,11 @@ public:
 
 	scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode();
 
+	inline f32 getStepHeight() const
+	{
+		return m_prop.stepheight;
+	}
+
 	inline bool isLocalPlayer() const
 	{
 		return m_is_local_player;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -799,6 +799,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 	// end of default appearance
 	m_prop.is_visible = true;
 	m_prop.makes_footstep_sound = true;
+	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
 	m_hp = PLAYER_MAX_HP;
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -279,9 +279,15 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// This should always apply, otherwise there are glitches
 	sanity_check(d > pos_max_d);
 
-	// TODO: this shouldn't be hardcoded but transmitted from server
-	float player_stepheight = (touching_ground) ? (BS * 0.6f) : (BS * 0.2f);
+	// Player object property step height is multiplied by BS in
+	// /src/script/common/c_content.cpp and /src/content_sao.cpp
+	float player_stepheight = (m_cao == nullptr) ? 0.0f :
+		(touching_ground ? m_cao->getStepHeight() : (0.2f * BS));
 
+	// TODO this is a problematic hack.
+	// Use a better implementation for autojump, or apply a custom stepheight
+	// to all players, as this currently creates unintended special movement
+	// abilities and advantages for Android players on a server.
 #ifdef __ANDROID__
 	player_stepheight += (0.6f * BS);
 #endif

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -174,6 +174,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add settable player collisionbox. Breaks compatibility with older
 			clients as a 1-node vertical offset has been removed from player's
 			position
+		Add settable player stepheight using existing object property.
+			Breaks compatibility with older clients.
 */
 
 #define LATEST_PROTOCOL_VERSION 35


### PR DESCRIPTION
Add settable player step height using the existing object property.
Breaks compatibility with old clients, add to protocol version 35.
/////////////////////

Tested with and without MTGame PR.
To be merged with https://github.com/minetest/minetest_game/pull/1867
Re-application of #5710 https://github.com/minetest/minetest/commit/45ab62d6a3d90ab3b97aec88251a766cb5dd1899 that was reverted due to lack of compatibility with older clients, this can now be part of 0.5.0 breakage.
Includes my fixes for the implementation #5724 and https://github.com/minetest/minetest/issues/5727#issuecomment-300019524