### PR TITLE
New world start time: Make this 5751, time of earliest full brightness 

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -110,9 +110,9 @@ protected:
 	 * Below: values managed by m_time_lock
 	*/
 	// Time of day in milli-hours (0-23999); determines day and night
-	u32 m_time_of_day = 5250;
-	// Time of day in 0...1; start 5:15am unless overridden by game
-	float m_time_of_day_f = 5250.0f / 24000.0f;
+	u32 m_time_of_day = 5751;
+	// Time of day in 0...1
+	float m_time_of_day_f = 5751.0f / 24000.0f;
 	// Stores the skew created by the float -> u32 conversion
 	// to be applied at next conversion, so that there is no real skew.
 	float m_time_conversion_skew = 0.0f;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -633,8 +633,8 @@ void ServerEnvironment::loadMeta()
 	}
 
 	setTimeOfDay(args.exists("time_of_day") ?
-		// set day to early morning by default
-		args.getU64("time_of_day") : 5250);
+		// Set default to morning at earliest full brightness
+		args.getU64("time_of_day") : 5751);
 
 	m_last_clear_objects_time = args.exists("last_clear_objects_time") ?
 		// If missing, do as if clearObjects was never called


### PR DESCRIPTION
![screenshot_20170807_032748](https://user-images.githubusercontent.com/3686677/29010209-8ba6804a-7b21-11e7-82b9-b9c842fe52f1.png)

Tunes recent commit #6211 

Subgames or mods may have events or mobs triggered as soon as light starts to fade in the evening, these would now happen when entering a new world.

During development work i often need to rapidly start new worlds, now when i do this they are in semi-darkness, which is beautiful but not good for development work, i need full day brightness.

So i feel it is best for both players and developers to start the day at the exact earliest moment that full brightness occurs. 