### PR TITLE
Rearrange F5 'debug' lines for convenient use in normal game play

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -801,6 +801,10 @@ client_unload_unused_data_timeout (Mapblock unload timeout) int 600
 #    Set to -1 for unlimited amount.
 client_mapblock_limit (Mapblock limit) int 5000
 
+#    Whether to show some basic status (can disabled by hitting F5).
+#    Contains current position, direction and node you're pointing at.
+show_status (Show basic status) bool false
+
 #    Whether to show the client debug info (has the same effect as hitting F5).
 show_debug (Show debug info) bool false
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -961,6 +961,11 @@
 #    type: int
 # client_mapblock_limit = 5000
 
+#    Whether to show some basic status (can disabled by hitting F5).
+#    Contains current position, direction and node you're pointing at.
+#    type: bool
+# show_status = false
+
 #    Whether to show the client debug info (has the same effect as hitting F5).
 #    type: bool
 # show_debug = false

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1895,6 +1895,11 @@ void Client::showGameDebug(const bool show)
 	m_game_ui_flags->show_debug = show;
 }
 
+void Client::showGameStatus(const bool show)
+{
+	m_game_ui_flags->show_status = show;
+}
+
 // IGameDef interface
 // Under envlock
 IItemDefManager* Client::getItemDefManager()

--- a/src/client.h
+++ b/src/client.h
@@ -541,6 +541,7 @@ public:
 	void showProfiler(bool show = true);
 	void showGameFog(bool show = true);
 	void showGameDebug(bool show = true);
+	void showGameStatus(bool show = true);
 
 	const Address getServerAddress();
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -143,8 +143,10 @@ void set_default_settings(Settings *settings)
 
 	// Visuals
 #ifdef NDEBUG
+	settings->setDefault("show_status", "false");
 	settings->setDefault("show_debug", "false");
 #else
+	settings->setDefault("show_status", "true");
 	settings->setDefault("show_debug", "true");
 #endif
 	settings->setDefault("fsaa", "0");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2004,7 +2004,8 @@ bool Game::initGui()
 	// Object infos are shown in this
 	guitext_info = addStaticText(guienv,
 			L"",
-			core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5) + v2s32(100, 200),
+			core::rect<s32>(0, 0, 400, g_fontengine->getTextHeight() * 5 + 5)
+				+ v2s32(100, 5 + g_fontengine->getTextHeight() * (3 + 6)), //debug+chat
 			false, true, guiroot);
 
 	// Status text (displays info when showing and hiding GUI stuff, etc.)

--- a/src/game.h
+++ b/src/game.h
@@ -33,6 +33,7 @@ struct GameUIFlags
 	bool show_hud;
 	bool show_minimap;
 	bool force_fog_off;
+	bool show_status;
 	bool show_debug;
 	bool show_profiler_graph;
 	bool disable_camera_update;


### PR DESCRIPTION
During normal game play some of the 'debug' output is actually often
indispensable:
- current coordinates (Where are my friends? Where are my bones?)
- current direction
- node pointed at (What's this funny plant? Is that silver, tin or mithril?)

But to see this you have to enable 3 lines of stuff most of which a normal
player doesn't care about (e.g. map seed). Together with a busy chat it can
make quite a mess of text.

Solution: the 3 essential things listed above easily fit in 1 (one!) line,
together with the MT version (we do want to see it if someone sends bug
reports with screenshots).

The compass direction knows about NW, NE, SW, SE now, the angle is rounded
to full integers. The X/Y/Z coordinates, too, unless show_debug is enabled.
The reason for that: if you build a house and make one wall up to X=10.4
and the other up to X=10.6 your walls will have different lenghts, because
you should have rounded 10.6 to 11 in your head. Now MT does this for you.

The rest is mostly performance related (FPS, drawtime, dtime_jitter, RTT)
and fits all in the 2nd line, which is now only enabled if F5 is pressed
one more time. The map seed isn't performance, but I put it in line 2
anyway. To accomodate all I merged range_all into view_range (and dropped
the decimal place). The selected node's param2 stayed with the node type,
but is only shown if line 2 is visible, normal players don't need it.

To address @paramat's concerns, if the screen width appears too small the
MT version, map seed and pointed node's param2 (i.e. the non performance-
related items) get 'wrapped' to an additional middle line, enlarging the
debug info from 2 to 3 lines again on smaller screens. (Of course the chat
moves to follow suit.)

If only the status is enabled (for normal players) then it's still only 1
single line, which is shortened by hiding the MT version string.

The info text ("Furnace out of fuel") is (permanently) moved down so it can
no longer overlap with the bottom-most chat line (as it could before this
patch series).