### PR TITLE
Travis-ci build: fix osx jpeg installation failure, git ambiguous argument error (caused by merging commits) and add a workaround for travis commit range bug

### DIFF
--- a/util/travis/common.sh
+++ b/util/travis/common.sh
@@ -32,11 +32,10 @@ install_linux_deps() {
 install_macosx_deps() {
 	brew update
 	brew install freetype gettext hiredis irrlicht leveldb libogg libvorbis luajit
-	if [[ "$(brew ls | grep jpeg)" == *"jpeg"* ]]; then
-		brew upgrade jpeg #if jpeg exists upgrade, *"somestring"* = string includes string
-		# "somestring" in it, the asterisks (*) should always be outside of the quotes
+	if brew ls | grep -q jpeg; then
+		brew upgrade jpeg
 	else
-		brew install jpeg #otherwise install
+		brew install jpeg
 	fi
 	#brew upgrade postgresql
 }

--- a/util/travis/common.sh
+++ b/util/travis/common.sh
@@ -31,7 +31,13 @@ install_linux_deps() {
 # Mac OSX build only
 install_macosx_deps() {
 	brew update
-	brew install freetype gettext hiredis irrlicht jpeg leveldb libogg libvorbis luajit
+	brew install freetype gettext hiredis irrlicht leveldb libogg libvorbis luajit
+	if [[ "$(brew ls | grep jpeg)" == *"jpeg"* ]]; then
+		brew upgrade jpeg #if jpeg exists upgrade, *"somestring"* = string includes string
+		# "somestring" in it, the asterisks (*) should always be outside of the quotes
+	else
+		brew install jpeg #otherwise install
+	fi
 	#brew upgrade postgresql
 }
 
@@ -39,6 +45,11 @@ install_macosx_deps() {
 TRIGGER_COMPILE_PATHS="src/.*\.(c|cpp|h)|CMakeLists.txt|cmake/Modules/|util/travis/|util/buildbot/"
 
 needs_compile() {
-	git diff --name-only $TRAVIS_COMMIT_RANGE | egrep -q "^($TRIGGER_COMPILE_PATHS)"
+	RANGE="$TRAVIS_COMMIT_RANGE"
+	if [[ "$(git diff --name-only $RANGE -- 2>/dev/null)" == "" ]]; then 
+		RANGE="$TRAVIS_COMMIT^...$TRAVIS_COMMIT"
+		echo "Fixed range: $RANGE"
+	fi
+	git diff --name-only $RANGE -- | egrep -q "^($TRIGGER_COMPILE_PATHS)"
 }
 


### PR DESCRIPTION
This code fix many travis build bugs. 

1. osx build job (xcode8) fails when installing jpeg, since jpeg is already installed (#6224). Fixed by checking if not already installed, it detected then by changing installation to upgrading.
2. Sometimes build job might fail with ambiguous argument error on git (caused by merged commits or other error). Fix - add a two dashes (**--**) right after commit range
3. `$TRAVIS_COMMIT_RANGE` might some times be empty (such as on new branches) **or** invalid (e.g. when commits are merged and force-pushed to github, if ambiguous argument error were fixed). workaround - check if commit range is valid (using git diff, with two dashes at the end of command). If it's bad or empty (diff returns an empty string) - set it like **[commit hash]^...[commit hash]**

Fixing all problems above, build still fails with Undefined symbols errors in osx, fix now split into #6289 