### PR TITLE
Add slippery group for nodes (players/items slide) (take 3)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1424,6 +1424,9 @@ Another example: Make red wool from white wool and red dye:
 * `soil`: saplings will grow on nodes in this group
 * `connect_to_raillike`: makes nodes of raillike drawtype with same group value
   connect to each other
+* `slippery`: Players and items will slide on the node.
+  Only use `slippery = 3` for now to ensure forwards compatibility.
+
 
 ### Known damage and digging time defining groups
 * `crumbly`: dirt, sand

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -403,7 +403,7 @@ void Client::step(float dtime)
 	// Control local player (0ms)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player);
-	player->applyControl(dtime);
+	player->applyControl(dtime, &m_env);
 
 	// Step environment
 	m_env.step(dtime);

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -29,6 +29,7 @@ class Client;
 class Environment;
 class GenericCAO;
 class ClientActiveObject;
+class ClientEnvironment;
 class IGameDef;
 
 enum LocalPlayerAnimations
@@ -78,7 +79,7 @@ public:
 	void old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			std::vector<CollisionInfo> *collision_info);
 
-	void applyControl(float dtime);
+	void applyControl(float dtime, ClientEnvironment *env);
 
 	v3s16 getStandingNodePos();
 	v3s16 getFootstepNodePos();
@@ -143,7 +144,8 @@ public:
 	void setCollisionbox(const aabb3f &box) { m_collisionbox = box; }
 
 private:
-	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
+	void accelerateHorizontal(const v3f &target_speed,
+		const f32 max_increase, bool slippery);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);
 


### PR DESCRIPTION
Adds the node group “slippery”. Nodes with the group “slippery” set to any value besides 0 will become slippery. Players and item entities will slide on it.

This is an attempt to revive #817 by Zeg9. I had to make a few changes to make the code workable. The new slippery commit is based on Minetest commit bb1c71158613c1f17c57e53ad489b076a11e3828 which I just pulled today.

This is 3rd attempt to add slippery nodes into Minetest.

@paramat @rubenwardy @Fixer-007 