### PR TITLE
Do not add base position to player selection box

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1431,7 +1431,8 @@ bool PlayerSAO::getSelectionBox(aabb3f *toset) const
 		return false;
 	}
 
-	getCollisionBox(toset);
+	toset->MinEdge = m_prop.collisionbox.MinEdge * BS;
+	toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS;
 
 	return true;
 }


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/6157

The base position offset is added by `ServerEnvironment::getSelectedActiveObjects` here: https://github.com/minetest/minetest/blob/master/src/serverenvironment.cpp#L1630

Previously it just called `PlayerSAO::getCollisionBox` which also adds the base position for whatever reason https://github.com/minetest/minetest/blob/master/src/content_sao.cpp#L1424 I felt this should be left intact.

Needs more testing in case it breaks something else but everything seems to be fine up to now. I have since learned that these selection box getters were added as part of the ray-casting PR #4421 so this was likely just an oversight.

Test script available in the related issue.