### PR TITLE
Remove redundant minetest.register_node arguments

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -146,6 +146,25 @@ function core.register_item(name, itemdef)
 			and not itemdef.paramtype then
 				itemdef.paramtype = "light"
 			end
+			-- Fix inventory_image and wield_image for specific drawtypes
+			if not itemdef.inventory_image and itemdef.tiles and
+					type(itemdef.tiles[1]) == "string" then
+				if itemdef.drawtype == "plantlike" or
+						itemdef.drawtype == "raillike" or
+						itemdef.drawtype == "signlike" or
+						itemdef.drawtype == "torchlike" or
+						itemdef.drawtype == "firelike" then
+					itemdef.inventory_image = itemdef.tiles[1]
+				end
+				-- torch,
+				if not itemdef.wield_image then
+					if itemdef.drawtype == "raillike" or
+							itemdef.drawtype == "signlike" or
+							itemdef.drawtype == "torchlike" then
+						itemdef.wield_image = itemdef.inventory_image
+					end
+				end
+			end
 		end
 		if itemdef.light_source and itemdef.light_source > core.LIGHT_MAX then
 			itemdef.light_source = core.LIGHT_MAX

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -65,14 +65,14 @@ local function check_modname_prefix(name)
 			error("Name " .. name .. " does not follow naming conventions: " ..
 				"\"" .. expected_prefix .. "\" or \":\" prefix required")
 		end
-		
+
 		-- Enforce that the name only contains letters, numbers and underscores.
 		local subname = name:sub(#expected_prefix+1)
 		if subname:find("[^%w_]") then
 			error("Name " .. name .. " does not follow naming conventions: " ..
 				"contains unallowed characters")
 		end
-		
+
 		return name
 	end
 end
@@ -105,6 +105,17 @@ function core.register_entity(name, prototype)
 	prototype.mod_origin = core.get_current_modname() or "??"
 end
 
+local param1light_drawtypes = {
+	allfaces = true,
+	allfaces_optional = true,
+	torchlike = true,
+	signlike = true,
+	plantlike = true,
+	raillike = true,
+	firelike = true,
+	nodebox = true,
+	mesh = true,
+}
 function core.register_item(name, itemdef)
 	-- Check name
 	if name == nil then
@@ -118,14 +129,23 @@ function core.register_item(name, itemdef)
 
 	-- Apply defaults and add to registered_* table
 	if itemdef.type == "node" then
-		-- Use the nodebox as selection box if it's not set manually
-		if itemdef.drawtype == "nodebox" and not itemdef.selection_box then
-			itemdef.selection_box = itemdef.node_box
-		elseif itemdef.drawtype == "fencelike" and not itemdef.selection_box then
-			itemdef.selection_box = {
-				type = "fixed",
-				fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
-			}
+		if itemdef.drawtype then
+			-- Use the nodebox as selection box if it's not set manually
+			if not itemdef.selection_box then
+				if itemdef.drawtype == "nodebox" then
+					itemdef.selection_box = itemdef.node_box
+				elseif itemdef.drawtype == "fencelike" then
+					itemdef.selection_box = {
+						type = "fixed",
+						fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
+					}
+				end
+			end
+			-- Set paramtype to "light" if necessary
+			if param1light_drawtypes[itemdef.drawtype]
+			and not itemdef.paramtype then
+				itemdef.paramtype = "light"
+			end
 		end
 		if itemdef.light_source and itemdef.light_source > core.LIGHT_MAX then
 			itemdef.light_source = core.LIGHT_MAX

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4053,7 +4053,20 @@ Definition tables
                             {bendy = 2, snappy = 1},
                             {hard = 1, metal = 1, spikes = 1}
         inventory_image = "default_tool_steelaxe.png",
+        --[[
+        ^ The icon of an item which is shown in the inventory
+        ^ For nodes with drawtype plantlike, raillike, signlike, torchlike or
+        ^ firelike it becomes set automatically to the first tile image if
+        ^ omitted.
+        ]]
         wield_image = "",
+         --[[
+        ^ The image of an item which is shown in the hud or dropped, if
+        ^ specified, the texture becomes extruded to look more
+        ^ three-dimensional.
+        ^ For nodes with drawtype raillike, signlike or torchlike it becomes set
+        ^ automatically to the first tile image if omitted.
+        ]]
         palette = "",
         --[[
         ^ An image file containing the palette of a node.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -777,6 +777,12 @@ node definition:
       respectively. Allows light to propagate from or through the node with
       light value falling by 1 per node. This is essential for a light source
       node to spread its light.
+      Nodes with drawtype allfaces, allfaces_optional, torchlike, signlike,
+      plantlike, raillike, firelike, nodebox and mesh have paramtype set to
+      "light" if omitted because they require this paramtype to be displayed
+      correctly.
+      If the node doesn't have paramtype "light", you can use param1 to store
+      custom 8 Bit values for your own purposes.
 
 `param2` is reserved for the engine when any of these are used:
 


### PR DESCRIPTION
Currently modders have to set paramtype to "light" manually when registering plants, else they become dark (nobody wants this). They also have to manually specify inventory_image and wield_image for specific drawtypes to avoid the unsightly default inventory item exhibition.
This PR makes setting those redundant, so registering plants, rails etc. becomes more convenient. You can still set paramtype to "none" manually for any reason.
The affected node drawtypes are documented in lua_api.txt that people still know when they e.g. can use param1 to store custom numbers.  