### PR TITLE
Hud function cleanups

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3216,7 +3216,8 @@ void Game::processClientEvents(CameraOrientation *cam)
 
 				HudElement *e = player->getHud(id);
 
-				if (e != NULL) {
+				// If there is already a hud, ignore event
+				if (e) {
 					delete event.hudadd.pos;
 					delete event.hudadd.name;
 					delete event.hudadd.scale;
@@ -3258,11 +3259,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 			break;
 
 		case CE_HUDRM:
-			{
-				HudElement *e = player->removeHud(event.hudrm.id);
-
-				delete e;
-			}
+			player->removeHud(event.hudrm.id);
 			break;
 
 		case CE_HUDCHANGE:
@@ -3270,7 +3267,8 @@ void Game::processClientEvents(CameraOrientation *cam)
 				u32 id = event.hudchange.id;
 				HudElement *e = player->getHud(id);
 
-				if (e == NULL) {
+				// If hud isn't registered, ignore event
+				if (!e) {
 					delete event.hudchange.v3fdata;
 					delete event.hudchange.v2fdata;
 					delete event.hudchange.sdata;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -84,13 +84,17 @@ u32 Player::addHud(HudElement *toadd)
 {
 	MutexAutoLock lock(m_mutex);
 
-	u32 id = getFreeHudID();
+	// Try to find a free slot in current list
+	for (u32 id = 0; id != hud.size(); id++) {
+		if (!hud[id]) {
+			hud[id] = toadd;
+			return id;
+		}
+	}
 
-	if (id < hud.size())
-		hud[id] = toadd;
-	else
-		hud.push_back(toadd);
-
+	// No slot was found, add hud to end of the list
+	u32 id = hud.size();
+	hud.push_back(toadd);
 	return id;
 }
 
@@ -101,19 +105,17 @@ HudElement* Player::getHud(u32 id)
 	if (id < hud.size())
 		return hud[id];
 
-	return NULL;
+	return nullptr;
 }
 
-HudElement* Player::removeHud(u32 id)
+void Player::removeHud(u32 id)
 {
 	MutexAutoLock lock(m_mutex);
 
-	HudElement* retval = NULL;
 	if (id < hud.size()) {
-		retval = hud[id];
-		hud[id] = NULL;
+		delete hud[id];
+		hud[id] = nullptr;
 	}
-	return retval;
 }
 
 void Player::clearHud()

--- a/src/player.h
+++ b/src/player.h
@@ -109,22 +109,12 @@ public:
 		return m_speed;
 	}
 
-	void setSpeed(v3f speed)
+	void setSpeed(const v3f &speed)
 	{
 		m_speed = speed;
 	}
 
 	const char *getName() const { return m_name; }
-
-	u32 getFreeHudID()
-	{
-		size_t size = hud.size();
-		for (size_t i = 0; i != size; i++) {
-			if (!hud[i])
-				return i;
-		}
-		return size;
-	}
 
 	v3f eye_offset_first;
 	v3f eye_offset_third;
@@ -158,7 +148,7 @@ public:
 
 	HudElement* getHud(u32 id);
 	u32         addHud(HudElement* hud);
-	HudElement* removeHud(u32 id);
+	void removeHud(u32 id);
 	void        clearHud();
 
 	u32 hud_flags;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1362,8 +1362,8 @@ int ObjectRef::l_hud_add(lua_State *L)
 		log_deprecated(L,"Deprecated usage of statbar without size!");
 	}
 
-	u32 id = getServer(L)->hudAdd(player, elem);
-	if (id == U32_MAX) {
+	s32 id = getServer(L)->hudAdd(player, elem);
+	if (id == -1) {
 		delete elem;
 		return 0;
 	}
@@ -1381,11 +1381,11 @@ int ObjectRef::l_hud_remove(lua_State *L)
 	if (player == NULL)
 		return 0;
 
-	u32 id = -1;
+	s32 id = -1;
 	if (!lua_isnil(L, 2))
 		id = lua_tonumber(L, 2);
 
-	if (!getServer(L)->hudRemove(player, id))
+	if (id < 0 || !getServer(L)->hudRemove(player, id))
 		return 0;
 
 	lua_pushboolean(L, true);
@@ -1398,7 +1398,7 @@ int ObjectRef::l_hud_change(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == NULL)
+	if (!player)
 		return 0;
 
 	u32 id = lua_isnumber(L, 2) ? lua_tonumber(L, 2) : -1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3072,7 +3072,7 @@ bool Server::showFormspec(const char *playername, const std::string &formspec,
 	return true;
 }
 
-u32 Server::hudAdd(RemotePlayer *player, HudElement *form)
+s32 Server::hudAdd(RemotePlayer *player, HudElement *form)
 {
 	if (!player)
 		return -1;
@@ -3088,12 +3088,7 @@ bool Server::hudRemove(RemotePlayer *player, u32 id) {
 	if (!player)
 		return false;
 
-	HudElement* todel = player->removeHud(id);
-
-	if (!todel)
-		return false;
-
-	delete todel;
+	player->removeHud(id);
 
 	SendHUDRemove(player->peer_id, id);
 	return true;

--- a/src/server.h
+++ b/src/server.h
@@ -280,7 +280,7 @@ public:
 	ServerEnvironment & getEnv() { return *m_env; }
 	v3f findSpawnPos();
 
-	u32 hudAdd(RemotePlayer *player, HudElement *element);
+	s32 hudAdd(RemotePlayer *player, HudElement *element);
 	bool hudRemove(RemotePlayer *player, u32 id);
 	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);


### PR DESCRIPTION
* Properly use s32 when using negative ids
* Player::removeHud removed Hud instead of caller function
* Optimize a little bit addHud function by removing getFreeHudID function