### PR TITLE
Reduce dedicated server step to 0.09

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1010,7 +1010,7 @@ max_objects_per_block (Maximum objects per block) int 64
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 
 #    Length of a server tick and the interval at which objects are generally updated over network.
-dedicated_server_step (Dedicated server step) float 0.1
+dedicated_server_step (Dedicated server step) float 0.09
 
 #    Time in between active block management cycles
 active_block_mgmt_interval (Active Block Management interval) float 2.0

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1235,7 +1235,7 @@
 
 #    Length of a server tick and the interval at which objects are generally updated over network.
 #    type: float
-# dedicated_server_step = 0.1
+# dedicated_server_step = 0.09
 
 #    Time in between active block management cycles
 #    type: float

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -338,7 +338,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chat_message_limit_trigger_kick", "50");
 	settings->setDefault("sqlite_synchronous", "2");
 	settings->setDefault("full_block_send_enable_min_time_from_building", "2.0");
-	settings->setDefault("dedicated_server_step", "0.1");
+	settings->setDefault("dedicated_server_step", "0.09");
 	settings->setDefault("active_block_mgmt_interval", "2.0");
 	settings->setDefault("abm_interval", "1.0");
 	settings->setDefault("nodetimer_interval", "0.2");


### PR DESCRIPTION
Minetest performance improvement has been huge since months, server step reduction will permit to handle client events a little bit faster without too many penalty costs due to core engine

I propose to reduce step from 0.10 to 0.09, it also permits to handle 10% more users packets as it seems we handle 1 packet per loop step (i will open a new PR to fix that an optimize it later)