### PR TITLE
Alternative code for slipping

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -186,8 +186,9 @@ core.register_entity(":__builtin:item", {
 		local nn = node.name
 		-- If node is not registered or node is walkably solid and resting on nodebox
 		local v = self.object:getvelocity()
+		local slippery = core.get_item_group(nn, "slippery")
 		if not core.registered_nodes[nn] or (core.registered_nodes[nn].walkable and
-				core.get_item_group(nn, "slippery") == 0) and v.y == 0 then
+				slippery == 0) and v.y == 0 then
 			if self.physical_state then
 				local own_stack = ItemStack(self.object:get_luaentity().itemstring)
 				-- Merge with close entities of the same item
@@ -211,7 +212,7 @@ core.register_entity(":__builtin:item", {
 				self.object:set_acceleration({x = 0, y = -10, z = 0})
 				self.physical_state = true
 				self.object:set_properties({physical = true})
-			elseif minetest.get_item_group(nn, "slippery") ~= 0 then
+			elseif slippery ~= 0 then
 				if math.abs(v.x) < 0.2 and math.abs(v.z) < 0.2 then
 					self.object:set_velocity({x = 0, y = 0, z = 0})
 					self.object:set_acceleration({x = 0, y = 0, z = 0})
@@ -220,7 +221,8 @@ core.register_entity(":__builtin:item", {
 						physical = false
 					})
 				else
-					self.object:set_acceleration({x = -v.x, y = -10, z = -v.z})
+					local slip_factor = 4.0 / (slippery + 4)
+					self.object:set_acceleration({x = -v.x * slip_factor, y = -10, z = -v.z * slip_factor})
 				end
 			end
 		end

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -186,9 +186,8 @@ core.register_entity(":__builtin:item", {
 		local nn = node.name
 		-- If node is not registered or node is walkably solid and resting on nodebox
 		local v = self.object:getvelocity()
-		local slippery = core.get_item_group(nn, "slippery")
 		if not core.registered_nodes[nn] or (core.registered_nodes[nn].walkable and
-				slippery == 0) and v.y == 0 then
+				core.get_item_group(nn, "slippery") == 0) and v.y == 0 then
 			if self.physical_state then
 				local own_stack = ItemStack(self.object:get_luaentity().itemstring)
 				-- Merge with close entities of the same item
@@ -212,7 +211,7 @@ core.register_entity(":__builtin:item", {
 				self.object:set_acceleration({x = 0, y = -10, z = 0})
 				self.physical_state = true
 				self.object:set_properties({physical = true})
-			elseif slippery ~= 0 then
+			elseif minetest.get_item_group(nn, "slippery") ~= 0 then
 				if math.abs(v.x) < 0.2 and math.abs(v.z) < 0.2 then
 					self.object:set_velocity({x = 0, y = 0, z = 0})
 					self.object:set_acceleration({x = 0, y = 0, z = 0})
@@ -221,8 +220,7 @@ core.register_entity(":__builtin:item", {
 						physical = false
 					})
 				else
-					local slip_factor = 4.0 / (slippery + 4)
-					self.object:set_acceleration({x = -v.x * slip_factor, y = -10, z = -v.z * slip_factor})
+					self.object:set_acceleration({x = -v.x, y = -10, z = -v.z})
 				end
 			end
 		end

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -1049,21 +1049,21 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 		for (int z = 0; z <= 1; z++) {
 			for (int x = 0; x <= 1; x++) {
 				// this should cover all nodes surrounding player position
-				const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(floatToInt(
+				const ContentFeatures &f2 = nodemgr->get(map->getNodeNoEx(floatToInt(
 						getPosition() - v3f((x - 0.5f) * BS,
 										0.05f * BS,
 										(z - 0.5f) * BS),
 						BS)));
-				if (f.walkable) {
+				if (f2.walkable) {
 					// find least slippery node we might be standing on
-					int s = itemgroup_get(f.groups, "slippery");
+					int s = itemgroup_get(f2.groups, "slippery");
 					if (s < slippery)
 						slippery = s;
 				}
 			}
 		}
 		// without any hits, ignore slippery
-		if (slippery >= 2 << 16)
+		if (slippery >= (2 << 16))
 			slippery = 0;
 	}
 	if (slippery >= 1) {

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -1049,11 +1049,9 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 		for (int z = 0; z <= 1; z++) {
 			for (int x = 0; x <= 1; x++) {
 				// this should cover all nodes surrounding player position
-				const ContentFeatures &f2 = nodemgr->get(map->getNodeNoEx(floatToInt(
-						getPosition() - v3f((x - 0.5f) * BS,
-										0.05f * BS,
-										(z - 0.5f) * BS),
-						BS)));
+				v3f offset((x - 0.5f) * BS, 0.05f * BS, (z - 0.5f) * BS);
+				const ContentFeatures &f2 = nodemgr->get(map->getNodeNoEx(
+						floatToInt(getPosition() - offset, BS)));
 				if (f2.walkable) {
 					// find least slippery node we might be standing on
 					int s = itemgroup_get(f2.groups, "slippery");

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -658,7 +658,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// Slip on slippery nodes
 	const INodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
-	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(getStandingNodePos()));
+	const ContentFeatures &f = nodemgr->get(
+			map->getNodeNoEx(floatToInt(getPosition() - v3f(0, 0.05f * BS, 0), BS)));
 	float slip_factor = 1.0f;
 	int slippery = itemgroup_get(f.groups, "slippery");
 	if (slippery >= 1) {
@@ -679,7 +680,7 @@ v3s16 LocalPlayer::getStandingNodePos()
 {
 	if(m_sneak_node_exists)
 		return m_sneak_node;
-	return floatToInt(getPosition() - v3f(0, 0.05f * BS, 0), BS);
+	return floatToInt(getPosition() - v3f(0, BS, 0), BS);
 }
 
 v3s16 LocalPlayer::getFootstepNodePos()

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -27,7 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "client.h"
 #include "content_cao.h"
-#include <cmath>
 
 /*
 	LocalPlayer
@@ -711,19 +710,12 @@ v3f LocalPlayer::getEyeOffset() const
 
 // Horizontal acceleration (X and Z), Y direction is ignored
 void LocalPlayer::accelerateHorizontal(const v3f &target_speed,
-	const f32 max_increase, bool slippery)
+	const f32 max_increase)
 {
         if (max_increase == 0)
                 return;
 
 	v3f d_wanted = target_speed - m_speed;
-	if (slippery) {
-		if (target_speed == v3f())
-			d_wanted = -m_speed * 0.05f;
-		else
-			d_wanted *= 0.1f;
-	}
-
 	d_wanted.Y = 0.0f;
 	f32 dl = d_wanted.getLength();
 	if (dl > max_increase)

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -656,29 +656,22 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	else
 		incH = incV = movement_acceleration_default * BS * dtime;
 
+	// Slip on slippery nodes
 	const INodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
 	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(getStandingNodePos()));
 	float slip_factor = 1.0f;
 	int slippery = itemgroup_get(f.groups, "slippery");
-	// REMOVE: can override via env variable
-	char *slipenv = getenv("SLIPPERY");
-	if (slipenv)
-		slippery = atoi(slipenv);
-	// REMOVE: switch between original and alternative slipping code
-	if (getenv("NEW_SLIP") != NULL) {
-		if (slippery >= 1) {
-			if (speedH == v3f(0.0f)) {
-				slippery = slippery * 2;
-			}
-			slip_factor = core::clamp(1.0f / (slippery + 1), 0.001f, 1.0f);
+	if (slippery >= 1) {
+		if (speedH == v3f(0.0f)) {
+			slippery = slippery * 2;
 		}
-		slippery = 0; // disable flag below
+		slip_factor = core::clamp(1.0f / (slippery + 1), 0.001f, 1.0f);
 	}
 
 	// Accelerate to target speed with maximum increment
 	accelerateHorizontal(speedH * physics_override_speed,
-			incH * physics_override_speed * slip_factor, slippery > 0);
+			incH * physics_override_speed * slip_factor);
 	accelerateVertical(speedV * physics_override_speed,
 			incV * physics_override_speed);
 }
@@ -1054,4 +1047,3 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		m_can_jump = false;
 	}
 }
-

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -1040,9 +1040,11 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 	Map *map = &env->getMap();
 	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(
 			floatToInt(getPosition() - v3f(0, 0.05f * BS, 0), BS)));
-	int slippery = itemgroup_get(f.groups, "slippery");
-	if (!f.walkable) {
-		// leaning over an edge? Check surroundings for slippery nodes
+	int slippery = 0;
+	if (f.walkable) {
+		slippery = itemgroup_get(f.groups, "slippery");
+	} else if (is_slipping) {
+		// slipping over an edge? Check surroundings for slippery nodes
 		slippery = 2 << 16; // guard value, bigger than all realistic ones
 		for (int z = 0; z <= 1; z++) {
 			for (int x = 0; x <= 1; x++) {
@@ -1069,6 +1071,10 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 			slippery = slippery * 2;
 		}
 		slip_factor = core::clamp(1.0f / (slippery + 1), 0.001f, 1.0f);
+		is_slipping = true;
+	} else {
+		// remember this to avoid checking the edge case above too often
+		is_slipping = false;
 	}
 	return slip_factor;
 }

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -679,7 +679,7 @@ v3s16 LocalPlayer::getStandingNodePos()
 {
 	if(m_sneak_node_exists)
 		return m_sneak_node;
-	return floatToInt(getPosition() - v3f(0, BS, 0), BS);
+	return floatToInt(getPosition() - v3f(0, 0.05f * BS, 0), BS);
 }
 
 v3s16 LocalPlayer::getFootstepNodePos()

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -143,9 +143,7 @@ public:
 	void setCollisionbox(const aabb3f &box) { m_collisionbox = box; }
 
 private:
-	// clang-format off
-	void accelerateHorizontal(const v3f &target_speed, f32 max_increase);
-	// clang-format on
+	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);
 

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -144,7 +144,7 @@ public:
 
 private:
 	// clang-format off
-	void accelerateHorizontal(const v3f &target_speed, f32 max_increase, bool slippery);
+	void accelerateHorizontal(const v3f &target_speed, f32 max_increase);
 	// clang-format on
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -146,6 +146,7 @@ private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
 	void accelerateVertical(const v3f &target_speed, const f32 max_increase);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);
+	float getSlipFactor(Environment *env, const v3f &speedH);
 
 	v3f m_position;
 

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -60,6 +60,7 @@ public:
 	u8 liquid_viscosity = 0;
 	bool is_climbing = false;
 	bool swimming_vertical = false;
+	bool is_slipping = false;
 
 	float physics_override_speed = 1.0f;
 	float physics_override_jump = 1.0f;


### PR DESCRIPTION
The recently-merged "slippery" code depends strongly on the frame rate: the player's speed is reduced by 10% per frame. Here is an attempt at an alternative that does not.

Marked as "WIP" because it contains helper code for testing and comparison:

- If you do not have any games or mods which define slippery nodes, simply start minetest with the environment variable `SLIPPERY=3` to give *all* nodes the `slippery` group with the specified number (here: 3).
- To test framerate dependency, you can throttle your max FPS in the Advanced Settings (search for "FPS"). Then run onto a large patch of "ice" and see how far you slide when you let go of the keys.
- Starting minetest with the environment variable `NEW_SLIP=1` (or any value, really) will use a different code path which reduces the horizontal acceleration (max speed change) depending on the slipperiness of the node.

The new code is not affected by frame rate, but currently the feel is a lot different: instead of slowly sliding to a halt it feels like putting on the brakes on a car or bike: a constant deceleration. Attempts to change the deceleration depending on the current player's speed were not successful so far…