### PR TITLE
ClientInterface: add a function to verify (correctly) if user limit was reached

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -622,13 +622,17 @@ std::vector<u16> ClientInterface::getClientIDs(ClientState min_state)
 	std::vector<u16> reply;
 	MutexAutoLock clientslock(m_clients_mutex);
 
-	for (RemoteClientMap::iterator i = m_clients.begin();
-		i != m_clients.end(); ++i) {
-		if (i->second->getState() >= min_state)
-			reply.push_back(i->second->peer_id);
+	for (const auto &m_client : m_clients) {
+		if (m_client.second->getState() >= min_state)
+			reply.push_back(m_client.second->peer_id);
 	}
 
 	return reply;
+}
+
+bool ClientInterface::isUserLimitReached()
+{
+	return getClientIDs(CS_Active).size() >= g_settings->getU16("max_users");
 }
 
 void ClientInterface::step(float dtime)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -630,9 +630,14 @@ std::vector<u16> ClientInterface::getClientIDs(ClientState min_state)
 	return reply;
 }
 
+/**
+ * Verify if user limit was reached.
+ * User limit count all clients from HelloSent state (MT protocol user) to Active state
+ * @return true if user limit was reached
+ */
 bool ClientInterface::isUserLimitReached()
 {
-	return getClientIDs(CS_Active).size() >= g_settings->getU16("max_users");
+	return getClientIDs(CS_HelloSent).size() >= g_settings->getU16("max_users");
 }
 
 void ClientInterface::step(float dtime)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -427,6 +427,9 @@ public:
 	/* get list of active client id's */
 	std::vector<u16> getClientIDs(ClientState min_state=CS_Active);
 
+	/* verify is server user limit was reached */
+	bool isUserLimitReached();
+
 	/* get list of client player names */
 	const std::vector<std::string> &getPlayerNames() const { return m_clients_names; }
 
@@ -472,7 +475,6 @@ public:
 	}
 
 	static std::string state2Name(ClientState state);
-
 protected:
 	//TODO find way to avoid this functions
 	void lock() { m_clients_mutex.lock(); }

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -211,7 +211,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 
 	// Enforce user limit.
 	// Don't enforce for users that have some admin right
-	if (m_clients.getClientIDs(CS_Created).size() >= g_settings->getU16("max_users") &&
+	if (m_clients.isUserLimitReached() &&
 			!checkPriv(playername, "server") &&
 			!checkPriv(playername, "ban") &&
 			!checkPriv(playername, "privs") &&
@@ -520,7 +520,7 @@ void Server::handleCommand_Init_Legacy(NetworkPacket* pkt)
 
 	// Enforce user limit.
 	// Don't enforce for users that have some admin right
-	if (m_clients.getClientIDs(CS_Created).size() >= g_settings->getU16("max_users") &&
+	if (m_clients.isUserLimitReached() >= g_settings->getU16("max_users") &&
 			!checkPriv(playername, "server") &&
 			!checkPriv(playername, "ban") &&
 			!checkPriv(playername, "privs") &&


### PR DESCRIPTION

CS_HelloSent is a better indicator of active slots than CS_Created, which are session objects created after init packet reception

Switch existing checks to ClientInterface::isUserLimitReached()

Use range-based for loop for getClientIds() used function too

This will fix #6254 (not the memory overhead if init is flooded)