### PR TITLE
Modernize src/c* src/d* and src/e* files

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -855,8 +855,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		}
 		else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
-	}
-	else if (m_prop.visual == "wielditem") {
+	} else if (m_prop.visual == "wielditem") {
 		ItemStack item;
 		infostream << "GenericCAO::addToScene(): wielditem" << std::endl;
 		if (m_prop.wield_item.empty()) {
@@ -1340,8 +1339,7 @@ void GenericCAO::updateTextures(std::string mod)
 				m_meshnode->getMaterial(i).setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
 				m_meshnode->getMaterial(i).setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 			}
-		}
-		else if (m_prop.visual == "upright_sprite") {
+		} else if (m_prop.visual == "upright_sprite") {
 			scene::IMesh *mesh = m_meshnode->getMesh();
 			{
 				std::string tname = "unknown_object.png";
@@ -1379,13 +1377,11 @@ void GenericCAO::updateTextures(std::string mod)
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
 				// has directional lighting, it should work automatically.
-				if(m_prop.colors.size() >= 2)
-				{
+				if (m_prop.colors.size() >= 2) {
 					buf->getMaterial().AmbientColor = m_prop.colors[1];
 					buf->getMaterial().DiffuseColor = m_prop.colors[1];
 					buf->getMaterial().SpecularColor = m_prop.colors[1];
-				}
-				else if (!m_prop.colors.empty()) {
+				} else if (!m_prop.colors.empty()) {
 					buf->getMaterial().AmbientColor = m_prop.colors[0];
 					buf->getMaterial().DiffuseColor = m_prop.colors[0];
 					buf->getMaterial().SpecularColor = m_prop.colors[0];

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -119,7 +119,7 @@ class TestCAO : public ClientActiveObject
 {
 public:
 	TestCAO(Client *client, ClientEnvironment *env);
-	virtual ~TestCAO();
+	virtual ~TestCAO() = default;
 
 	ActiveObjectType getType() const
 	{
@@ -153,10 +153,6 @@ TestCAO::TestCAO(Client *client, ClientEnvironment *env):
 	m_position(v3f(0,10*BS,0))
 {
 	ClientActiveObject::registerType(getType(), create);
-}
-
-TestCAO::~TestCAO()
-{
 }
 
 ClientActiveObject* TestCAO::create(Client *client, ClientEnvironment *env)
@@ -261,7 +257,7 @@ class ItemCAO : public ClientActiveObject
 {
 public:
 	ItemCAO(Client *client, ClientEnvironment *env);
-	virtual ~ItemCAO();
+	virtual ~ItemCAO() = default;
 
 	ActiveObjectType getType() const
 	{
@@ -321,10 +317,6 @@ ItemCAO::ItemCAO(Client *client, ClientEnvironment *env):
 	{
 		ClientActiveObject::registerType(getType(), create);
 	}
-}
-
-ItemCAO::~ItemCAO()
-{
 }
 
 ClientActiveObject* ItemCAO::create(Client *client, ClientEnvironment *env)
@@ -563,7 +555,7 @@ void GenericCAO::initialize(const std::string &data)
 			player->setCAO(this);
 		}
 		if (m_client->getProtoVersion() < 33)
-			m_env->addPlayerName(m_name.c_str());
+			m_env->addPlayerName(m_name);
 	}
 }
 
@@ -607,7 +599,7 @@ void GenericCAO::processInitData(const std::string &data)
 GenericCAO::~GenericCAO()
 {
 	if (m_is_player && m_client->getProtoVersion() < 33) {
-		m_env->removePlayerName(m_name.c_str());
+		m_env->removePlayerName(m_name);
 	}
 	removeFromScene(true);
 }
@@ -628,8 +620,8 @@ v3f GenericCAO::getPosition()
 		scene::ISceneNode *node = getSceneNode();
 		if (node)
 			return node->getAbsolutePosition();
-		else
-			return m_position;
+
+		return m_position;
 	}
 	return pos_translator.vect_show;
 }
@@ -638,11 +630,17 @@ scene::ISceneNode* GenericCAO::getSceneNode()
 {
 	if (m_meshnode) {
 		return m_meshnode;
-	} else if (m_animated_meshnode) {
+	}
+
+	if (m_animated_meshnode) {
 		return m_animated_meshnode;
-	} else if (m_wield_meshnode) {
+	}
+
+	if (m_wield_meshnode) {
 		return m_wield_meshnode;
-	} else if (m_spritenode) {
+	}
+
+	if (m_spritenode) {
 		return m_spritenode;
 	}
 	return NULL;
@@ -655,8 +653,8 @@ scene::IAnimatedMeshSceneNode* GenericCAO::getAnimatedMeshSceneNode()
 
 void GenericCAO::setChildrenVisible(bool toset)
 {
-	for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {
-		GenericCAO *obj = m_env->getGenericCAO(m_children[i]);
+	for (u16 cao_id : m_children) {
+		GenericCAO *obj = m_env->getGenericCAO(cao_id);
 		if (obj) {
 			obj->setVisible(toset);
 		}
@@ -686,8 +684,7 @@ void GenericCAO::removeFromScene(bool permanent)
 	// Should be true when removing the object permanently and false when refreshing (eg: updating visuals)
 	if((m_env != NULL) && (permanent))
 	{
-		for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {
-			u16 ci = m_children[i];
+		for (u16 ci : m_children) {
 			if (m_env->attachement_parent_ids[ci] == getId()) {
 				m_env->attachement_parent_ids[ci] = 0;
 			}
@@ -859,13 +856,13 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
 	}
-	else if(m_prop.visual == "wielditem") {
+	else if (m_prop.visual == "wielditem") {
 		ItemStack item;
 		infostream << "GenericCAO::addToScene(): wielditem" << std::endl;
-		if (m_prop.wield_item == "") {
+		if (m_prop.wield_item.empty()) {
 			// Old format, only textures are specified.
 			infostream << "textures: " << m_prop.textures.size() << std::endl;
-			if (m_prop.textures.size() >= 1) {
+			if (!m_prop.textures.empty()) {
 				infostream << "textures[0]: " << m_prop.textures[0]
 					<< std::endl;
 				IItemDefManager *idef = m_client->idef();
@@ -894,7 +891,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		updateTextures(m_current_texture_modifier);
 
 	scene::ISceneNode *node = getSceneNode();
-	if (node && m_prop.nametag != "" && !m_is_local_player) {
+	if (node && !m_prop.nametag.empty() && !m_is_local_player) {
 		// Add nametag
 		v3f pos;
 		pos.Y = m_prop.collisionbox.MaxEdge.Y + 0.3f;
@@ -919,8 +916,8 @@ void GenericCAO::updateLight(u8 light_at_pos)
 	updateLightNoCheck(light_at_pos);
 
 	// Update light of all children
-	for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {
-		ClientActiveObject *obj = m_env->getActiveObject(m_children[i]);
+	for (u16 i : m_children) {
+		ClientActiveObject *obj = m_env->getActiveObject(i);
 		if (obj) {
 			obj->updateLightNoCheck(light_at_pos);
 		}
@@ -1046,9 +1043,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		// Attachments, part 1: All attached objects must be unparented first,
 		// or Irrlicht causes a segmentation fault
-		for(std::vector<u16>::iterator ci = m_children.begin();
-				ci != m_children.end();)
-		{
+		for (auto ci = m_children.begin(); ci != m_children.end();) {
 			if (m_env->attachement_parent_ids[*ci] != getId()) {
 				ci = m_children.erase(ci);
 				continue;
@@ -1066,9 +1061,9 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		addToScene(m_client->tsrc());
 
 		// Attachments, part 2: Now that the parent has been refreshed, put its attachments back
-		for (std::vector<u16>::size_type i = 0; i < m_children.size(); i++) {
+		for (u16 cao_id : m_children) {
 			// Get the object of the child
-			ClientActiveObject *obj = m_env->getActiveObject(m_children[i]);
+			ClientActiveObject *obj = m_env->getActiveObject(cao_id);
 			if (obj)
 				obj->setAttachments();
 		}
@@ -1248,12 +1243,10 @@ void GenericCAO::updateTextures(std::string mod)
 	m_previous_texture_modifier = m_current_texture_modifier;
 	m_current_texture_modifier = mod;
 
-	if(m_spritenode)
-	{
-		if(m_prop.visual == "sprite")
-		{
+	if (m_spritenode) {
+		if (m_prop.visual == "sprite") {
 			std::string texturestring = "unknown_node.png";
-			if(m_prop.textures.size() >= 1)
+			if (!m_prop.textures.empty())
 				texturestring = m_prop.textures[0];
 			texturestring += mod;
 			m_spritenode->setMaterialTexture(0,
@@ -1262,8 +1255,7 @@ void GenericCAO::updateTextures(std::string mod)
 			// This allows setting per-material colors. However, until a real lighting
 			// system is added, the code below will have no effect. Once MineTest
 			// has directional lighting, it should work automatically.
-			if(m_prop.colors.size() >= 1)
-			{
+			if (!m_prop.colors.empty()) {
 				m_spritenode->getMaterial(0).AmbientColor = m_prop.colors[0];
 				m_spritenode->getMaterial(0).DiffuseColor = m_prop.colors[0];
 				m_spritenode->getMaterial(0).SpecularColor = m_prop.colors[0];
@@ -1274,20 +1266,17 @@ void GenericCAO::updateTextures(std::string mod)
 			m_spritenode->getMaterial(0).setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 		}
 	}
-	if(m_animated_meshnode)
-	{
-		if(m_prop.visual == "mesh")
-		{
+
+	if (m_animated_meshnode) {
+		if (m_prop.visual == "mesh") {
 			for (u32 i = 0; i < m_prop.textures.size() &&
-					i < m_animated_meshnode->getMaterialCount(); ++i)
-			{
+					i < m_animated_meshnode->getMaterialCount(); ++i) {
 				std::string texturestring = m_prop.textures[i];
-				if(texturestring == "")
+				if (texturestring.empty())
 					continue; // Empty texture string means don't modify that material
 				texturestring += mod;
 				video::ITexture* texture = tsrc->getTextureForMesh(texturestring);
-				if(!texture)
-				{
+				if (!texture) {
 					errorstream<<"GenericCAO::updateTextures(): Could not load texture "<<texturestring<<std::endl;
 					continue;
 				}
@@ -1352,12 +1341,11 @@ void GenericCAO::updateTextures(std::string mod)
 				m_meshnode->getMaterial(i).setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 			}
 		}
-		else if(m_prop.visual == "upright_sprite")
-		{
+		else if (m_prop.visual == "upright_sprite") {
 			scene::IMesh *mesh = m_meshnode->getMesh();
 			{
 				std::string tname = "unknown_object.png";
-				if(m_prop.textures.size() >= 1)
+				if (!m_prop.textures.empty())
 					tname = m_prop.textures[0];
 				tname += mod;
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(0);
@@ -1367,8 +1355,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// This allows setting per-material colors. However, until a real lighting
 				// system is added, the code below will have no effect. Once MineTest
 				// has directional lighting, it should work automatically.
-				if(m_prop.colors.size() >= 1)
-				{
+				if(!m_prop.colors.empty()) {
 					buf->getMaterial().AmbientColor = m_prop.colors[0];
 					buf->getMaterial().DiffuseColor = m_prop.colors[0];
 					buf->getMaterial().SpecularColor = m_prop.colors[0];
@@ -1380,9 +1367,9 @@ void GenericCAO::updateTextures(std::string mod)
 			}
 			{
 				std::string tname = "unknown_object.png";
-				if(m_prop.textures.size() >= 2)
+				if (m_prop.textures.size() >= 2)
 					tname = m_prop.textures[1];
-				else if(m_prop.textures.size() >= 1)
+				else if (!m_prop.textures.empty())
 					tname = m_prop.textures[0];
 				tname += mod;
 				scene::IMeshBuffer *buf = mesh->getMeshBuffer(1);
@@ -1398,8 +1385,7 @@ void GenericCAO::updateTextures(std::string mod)
 					buf->getMaterial().DiffuseColor = m_prop.colors[1];
 					buf->getMaterial().SpecularColor = m_prop.colors[1];
 				}
-				else if(m_prop.colors.size() >= 1)
-				{
+				else if (!m_prop.colors.empty()) {
 					buf->getMaterial().AmbientColor = m_prop.colors[0];
 					buf->getMaterial().DiffuseColor = m_prop.colors[0];
 					buf->getMaterial().SpecularColor = m_prop.colors[0];
@@ -1476,7 +1462,7 @@ void GenericCAO::updateAttachments()
 		scene::ISceneNode *parent_node = getParent()->getSceneNode();
 		scene::IAnimatedMeshSceneNode *parent_animated_mesh_node =
 				getParent()->getAnimatedMeshSceneNode();
-		if (parent_animated_mesh_node && m_attachment_bone != "") {
+		if (parent_animated_mesh_node && !m_attachment_bone.empty()) {
 			parent_node = parent_animated_mesh_node->getJointNode(m_attachment_bone.c_str());
 		}
 
@@ -1519,7 +1505,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->setCollisionbox(m_selection_box);
 		}
 
-		if ((m_is_player && !m_is_local_player) && m_prop.nametag == "")
+		if ((m_is_player && !m_is_local_player) && m_prop.nametag.empty())
 			m_prop.nametag = m_name;
 
 		expireVisuals();

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -41,11 +41,11 @@ struct SmoothTranslator
 	v3f vect_show;
 	v3f vect_aim;
 	f32 anim_counter = 0;
-	f32 anim_time;
+	f32 anim_time = 0;
 	f32 anim_time_counter = 0;
 	bool aim_is_end = true;
 
-	SmoothTranslator() {};
+	SmoothTranslator() = default;
 
 	void init(v3f vect);
 

--- a/src/content_cso.cpp
+++ b/src/content_cso.cpp
@@ -30,7 +30,7 @@ class SmokePuffCSO: public ClientSimpleObject
 	scene::IBillboardSceneNode *m_spritenode = nullptr;
 public:
 	SmokePuffCSO(scene::ISceneManager *smgr,
-			ClientEnvironment *env, v3f pos, v2f size)
+			ClientEnvironment *env, const v3f &pos, const v2f &size)
 	{
 		infostream<<"SmokePuffCSO: constructing"<<std::endl;
 		m_spritenode = smgr->addBillboardSceneNode(

--- a/src/content_mapnode.cpp
+++ b/src/content_mapnode.cpp
@@ -108,11 +108,9 @@ MapNode mapnode_translate_to_internal(MapNode n_from, u8 version)
 	if(version <= 19)
 	{
 		content_t c_from = n_from.getContent();
-		for(u32 i=0; i<sizeof(trans_table_19)/sizeof(trans_table_19[0]); i++)
-		{
-			if(trans_table_19[i][1] == c_from)
-			{
-				result.setContent(trans_table_19[i][0]);
+		for (const auto &tt_i : trans_table_19) {
+			if (tt_i[1] == c_from) {
+				result.setContent(tt_i[0]);
 				break;
 			}
 		}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -67,7 +67,7 @@ public:
 		if(m_base_position.Y > 8*BS)
 			m_base_position.Y = 2*BS;
 
-		if(send_recommended == false)
+		if (!send_recommended)
 			return;
 
 		m_timer1 -= dtime;
@@ -402,7 +402,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		}
 	}
 
-	if(send_recommended == false)
+	if (!send_recommended)
 		return;
 
 	if(!isAttached())
@@ -423,7 +423,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		}
 	}
 
-	if(m_armor_groups_sent == false){
+	if (!m_armor_groups_sent) {
 		m_armor_groups_sent = true;
 		std::string str = gob_cmd_update_armor_groups(
 				m_armor_groups);
@@ -432,7 +432,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		m_messages_out.push(aom);
 	}
 
-	if(m_animation_sent == false){
+	if (!m_animation_sent) {
 		m_animation_sent = true;
 		std::string str = gob_cmd_update_animation(
 			m_animation_range, m_animation_speed, m_animation_blend, m_animation_loop);
@@ -441,7 +441,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		m_messages_out.push(aom);
 	}
 
-	if(m_bone_position_sent == false){
+	if (!m_bone_position_sent) {
 		m_bone_position_sent = true;
 		for (std::unordered_map<std::string, core::vector2d<v3f>>::const_iterator
 				ii = m_bone_position.begin(); ii != m_bone_position.end(); ++ii){
@@ -453,7 +453,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		}
 	}
 
-	if(m_attachment_sent == false){
+	if (!m_attachment_sent) {
 		m_attachment_sent = true;
 		std::string str = gob_cmd_update_attachment(m_attachment_parent_id, m_attachment_bone, m_attachment_position, m_attachment_rotation);
 		// create message and add to list
@@ -897,7 +897,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 	return os.str();
 }
 
-void PlayerSAO::getStaticData(std::string *result) const
+void PlayerSAO::getStaticData(std::string *) const
 {
 	FATAL_ERROR("Deprecated function");
 }
@@ -1171,7 +1171,7 @@ int PlayerSAO::punch(v3f dir,
 		return 0;
 
 	// No effect if PvP disabled
-	if (g_settings->getBool("enable_pvp") == false) {
+	if (!g_settings->getBool("enable_pvp")) {
 		if (puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
 			std::string str = gob_cmd_punched(0, getHP());
 			// create message and add to list

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -30,7 +30,7 @@ class UnitSAO: public ServerActiveObject
 {
 public:
 	UnitSAO(ServerEnvironment *env, v3f pos);
-	virtual ~UnitSAO() {}
+	virtual ~UnitSAO() = default;
 
 	virtual void setYaw(const float yaw) { m_yaw = yaw; }
 	float getYaw() const { return m_yaw; };
@@ -157,7 +157,7 @@ class LagPool
 	float m_pool = 15.0f;
 	float m_max = 15.0f;
 public:
-	LagPool() {}
+	LagPool() = default;
 
 	void setMax(float new_max)
 	{
@@ -324,7 +324,7 @@ public:
 		m_time_from_last_punch = 0.0;
 		return r;
 	}
-	void noCheatDigStart(v3s16 p)
+	void noCheatDigStart(const v3s16 &p)
 	{
 		m_nocheat_dig_pos = p;
 		m_nocheat_dig_time = 0;

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -50,7 +50,7 @@ static u64 getHashForGrid(CraftHashType type, const std::vector<std::string> &gr
 			std::ostringstream os;
 			bool is_first = true;
 			for (size_t i = 0; i < grid_names.size(); i++) {
-				if (grid_names[i] != "") {
+				if (!grid_names[i].empty()) {
 					os << (is_first ? "" : "\n") << grid_names[i];
 					is_first = false;
 				}
@@ -59,7 +59,7 @@ static u64 getHashForGrid(CraftHashType type, const std::vector<std::string> &gr
 		} case CRAFT_HASH_TYPE_COUNT: {
 			u64 cnt = 0;
 			for (size_t i = 0; i < grid_names.size(); i++)
-				if (grid_names[i] != "")
+				if (!grid_names[i].empty())
 					cnt++;
 			return cnt;
 		} case CRAFT_HASH_TYPE_UNHASHED:
@@ -112,9 +112,8 @@ static std::vector<std::string> craftGetItemNames(
 		const std::vector<std::string> &itemstrings, IGameDef *gamedef)
 {
 	std::vector<std::string> result;
-	for (std::vector<std::string>::size_type i = 0;
-			i < itemstrings.size(); i++) {
-		result.push_back(craftGetItemName(itemstrings[i], gamedef));
+	for (const auto &itemstring : itemstrings) {
+		result.push_back(craftGetItemName(itemstring, gamedef));
 	}
 	return result;
 }
@@ -124,9 +123,8 @@ static std::vector<std::string> craftGetItemNames(
 		const std::vector<ItemStack> &items, IGameDef *gamedef)
 {
 	std::vector<std::string> result;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < items.size(); i++) {
-		result.push_back(items[i].name);
+	for (const auto &item : items) {
+		result.push_back(item.name);
 	}
 	return result;
 }
@@ -136,10 +134,9 @@ static std::vector<ItemStack> craftGetItems(
 		const std::vector<std::string> &items, IGameDef *gamedef)
 {
 	std::vector<ItemStack> result;
-	for (std::vector<std::string>::size_type i = 0;
-			i < items.size(); i++) {
-		result.push_back(ItemStack(std::string(items[i]), (u16)1,
-			(u16)0, gamedef->getItemDefManager()));
+	for (const auto &item : items) {
+		result.emplace_back(std::string(item), (u16)1,
+			(u16)0, gamedef->getItemDefManager());
 	}
 	return result;
 }
@@ -156,7 +153,7 @@ static bool craftGetBounds(const std::vector<std::string> &items, unsigned int w
 	for (std::vector<std::string>::size_type i = 0;
 			i < items.size(); i++) {
 		// Is this an actual item?
-		if (items[i] != "") {
+		if (!items[i].empty()) {
 			if (!success) {
 				// This is the first nonempty item
 				min_x = max_x = x;
@@ -183,10 +180,9 @@ static bool craftGetBounds(const std::vector<std::string> &items, unsigned int w
 // Removes 1 from each item stack
 static void craftDecrementInput(CraftInput &input, IGameDef *gamedef)
 {
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		if (input.items[i].count != 0)
-			input.items[i].remove(1);
+	for (auto &item : input.items) {
+		if (item.count != 0)
+			item.remove(1);
 	}
 }
 
@@ -206,28 +202,25 @@ static void craftDecrementOrReplaceInput(CraftInput &input,
 	// Make a copy of the replacements pair list
 	std::vector<std::pair<std::string, std::string> > pairs = replacements.pairs;
 
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		ItemStack &item = input.items[i];
+	for (auto &item : input.items) {
 		// Find an appropriate replacement
 		bool found_replacement = false;
-		for (std::vector<std::pair<std::string, std::string> >::iterator
-				j = pairs.begin();
-				j != pairs.end(); ++j) {
+		for (auto j = pairs.begin(); j != pairs.end(); ++j) {
 			if (inputItemMatchesRecipe(item.name, j->first, gamedef->idef())) {
 				if (item.count == 1) {
 					item.deSerialize(j->second, gamedef->idef());
 					found_replacement = true;
 					pairs.erase(j);
 					break;
-				} else {
-					ItemStack rep;
-					rep.deSerialize(j->second, gamedef->idef());
-					item.remove(1);
-					found_replacement = true;
-					output_replacements.push_back(rep);
-					break;
 				}
+
+				ItemStack rep;
+				rep.deSerialize(j->second, gamedef->idef());
+				item.remove(1);
+				found_replacement = true;
+				output_replacements.push_back(rep);
+				break;
+
 			}
 		}
 		// No replacement was found, simply decrement count by one
@@ -311,9 +304,7 @@ std::string CraftReplacements::dump() const
 	std::ostringstream os(std::ios::binary);
 	os<<"{";
 	const char *sep = "";
-	for (std::vector<std::pair<std::string, std::string> >::size_type i = 0;
-			i < pairs.size(); i++) {
-		const std::pair<std::string, std::string> &repl_p = pairs[i];
+	for (const auto &repl_p : pairs) {
 		os << sep
 			<< '"' << (repl_p.first)
 			<< "\"=>\"" << (repl_p.second) << '"';
@@ -343,7 +334,7 @@ bool CraftDefinitionShaped::check(const CraftInput &input, IGameDef *gamedef) co
 	if (inp_width == 0)
 		return false;
 	while (inp_names.size() % inp_width != 0)
-		inp_names.push_back("");
+		inp_names.emplace_back("");
 
 	// Get input bounds
 	unsigned int inp_min_x = 0, inp_max_x = 0, inp_min_y = 0, inp_max_y = 0;
@@ -362,7 +353,7 @@ bool CraftDefinitionShaped::check(const CraftInput &input, IGameDef *gamedef) co
 	if (rec_width == 0)
 		return false;
 	while (rec_names.size() % rec_width != 0)
-		rec_names.push_back("");
+		rec_names.emplace_back("");
 
 	// Get recipe bounds
 	unsigned int rec_min_x=0, rec_max_x=0, rec_min_y=0, rec_max_y=0;
@@ -418,16 +409,16 @@ CraftHashType CraftDefinitionShaped::getHashType() const
 {
 	assert(hash_inited); // Pre-condition
 	bool has_group = false;
-	for (size_t i = 0; i < recipe_names.size(); i++) {
-		if (isGroupRecipeStr(recipe_names[i])) {
+	for (const auto &recipe_name : recipe_names) {
+		if (isGroupRecipeStr(recipe_name)) {
 			has_group = true;
 			break;
 		}
 	}
 	if (has_group)
 		return CRAFT_HASH_TYPE_COUNT;
-	else
-		return CRAFT_HASH_TYPE_ITEM_NAMES;
+
+	return CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 u64 CraftDefinitionShaped::getHash(CraftHashType type) const
@@ -474,10 +465,8 @@ bool CraftDefinitionShapeless::check(const CraftInput &input, IGameDef *gamedef)
 
 	// Filter empty items out of input
 	std::vector<std::string> input_filtered;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		const ItemStack &item = input.items[i];
-		if (item.name != "")
+	for (const auto &item : input.items) {
+		if (!item.name.empty())
 			input_filtered.push_back(item.name);
 	}
 
@@ -540,16 +529,16 @@ CraftHashType CraftDefinitionShapeless::getHashType() const
 {
 	assert(hash_inited); // Pre-condition
 	bool has_group = false;
-	for (size_t i = 0; i < recipe_names.size(); i++) {
-		if (isGroupRecipeStr(recipe_names[i])) {
+	for (const auto &recipe_name : recipe_names) {
+		if (isGroupRecipeStr(recipe_name)) {
 			has_group = true;
 			break;
 		}
 	}
 	if (has_group)
 		return CRAFT_HASH_TYPE_COUNT;
-	else
-		return CRAFT_HASH_TYPE_ITEM_NAMES;
+
+	return CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 u64 CraftDefinitionShapeless::getHash(CraftHashType type) const
@@ -622,9 +611,7 @@ bool CraftDefinitionToolRepair::check(const CraftInput &input, IGameDef *gamedef
 
 	ItemStack item1;
 	ItemStack item2;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		const ItemStack &item = input.items[i];
+	for (const auto &item : input.items) {
 		if (!item.empty()) {
 			if (item1.empty())
 				item1 = item;
@@ -642,9 +629,7 @@ CraftOutput CraftDefinitionToolRepair::getOutput(const CraftInput &input, IGameD
 {
 	ItemStack item1;
 	ItemStack item2;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		const ItemStack &item = input.items[i];
+	for (const auto &item : input.items) {
 		if (!item.empty()) {
 			if (item1.empty())
 				item1 = item;
@@ -659,7 +644,7 @@ CraftOutput CraftDefinitionToolRepair::getOutput(const CraftInput &input, IGameD
 CraftInput CraftDefinitionToolRepair::getInput(const CraftOutput &output, IGameDef *gamedef) const
 {
 	std::vector<ItemStack> stack;
-	stack.push_back(ItemStack());
+	stack.emplace_back();
 	return CraftInput(CRAFT_METHOD_COOKING, additional_wear, stack);
 }
 
@@ -692,10 +677,9 @@ bool CraftDefinitionCooking::check(const CraftInput &input, IGameDef *gamedef) c
 
 	// Filter empty items out of input
 	std::vector<std::string> input_filtered;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		const std::string &name = input.items[i].name;
-		if (name != "")
+	for (const auto &item : input.items) {
+		const std::string &name = item.name;
+		if (!name.empty())
 			input_filtered.push_back(name);
 	}
 
@@ -733,15 +717,16 @@ CraftHashType CraftDefinitionCooking::getHashType() const
 {
 	if (isGroupRecipeStr(recipe_name))
 		return CRAFT_HASH_TYPE_COUNT;
-	else
-		return CRAFT_HASH_TYPE_ITEM_NAMES;
+
+	return CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 u64 CraftDefinitionCooking::getHash(CraftHashType type) const
 {
 	if (type == CRAFT_HASH_TYPE_ITEM_NAMES) {
 		return getHashForString(recipe_name);
-	} else if (type == CRAFT_HASH_TYPE_COUNT) {
+	}
+	if (type == CRAFT_HASH_TYPE_COUNT) {
 		return 1;
 	} else {
 		//illegal hash type for this CraftDefinition (pre-condition)
@@ -784,10 +769,9 @@ bool CraftDefinitionFuel::check(const CraftInput &input, IGameDef *gamedef) cons
 
 	// Filter empty items out of input
 	std::vector<std::string> input_filtered;
-	for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-		const std::string &name = input.items[i].name;
-		if (name != "")
+	for (const auto &item : input.items) {
+		const std::string &name = item.name;
+		if (!name.empty())
 			input_filtered.push_back(name);
 	}
 
@@ -825,15 +809,17 @@ CraftHashType CraftDefinitionFuel::getHashType() const
 {
 	if (isGroupRecipeStr(recipe_name))
 		return CRAFT_HASH_TYPE_COUNT;
-	else
-		return CRAFT_HASH_TYPE_ITEM_NAMES;
+
+	return CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 u64 CraftDefinitionFuel::getHash(CraftHashType type) const
 {
 	if (type == CRAFT_HASH_TYPE_ITEM_NAMES) {
 		return getHashForString(recipe_name);
-	} else if (type == CRAFT_HASH_TYPE_COUNT) {
+	}
+
+	if (type == CRAFT_HASH_TYPE_COUNT) {
 		return 1;
 	} else {
 		//illegal hash type for this CraftDefinition (pre-condition)
@@ -884,9 +870,8 @@ public:
 
 		// If all input items are empty, abort.
 		bool all_empty = true;
-		for (std::vector<ItemStack>::size_type i = 0;
-			i < input.items.size(); i++) {
-			if (!input.items[i].empty()) {
+		for (const auto &item : input.items) {
+			if (!item.empty()) {
 				all_empty = false;
 				break;
 			}
@@ -906,8 +891,7 @@ public:
 
 			// We'd like to do "const [...] hash_collisions = m_craft_defs[type][hash];"
 			// but that doesn't compile for some reason. This does.
-			std::map<u64, std::vector<CraftDefinition*> >::const_iterator
-				col_iter = (m_craft_defs[type]).find(hash);
+			auto col_iter = (m_craft_defs[type]).find(hash);
 
 			if (col_iter == (m_craft_defs[type]).end())
 				continue;
@@ -940,8 +924,7 @@ public:
 	{
 		std::vector<CraftDefinition*> recipes;
 
-		std::map<std::string, std::vector<CraftDefinition*> >::const_iterator
-			vec_iter = m_output_craft_definitions.find(output.item);
+		auto vec_iter = m_output_craft_definitions.find(output.item);
 
 		if (vec_iter == m_output_craft_definitions.end())
 			return recipes;
@@ -963,26 +946,22 @@ public:
 
 	virtual bool clearCraftRecipesByOutput(const CraftOutput &output, IGameDef *gamedef)
 	{
-		std::map<std::string, std::vector<CraftDefinition*> >::iterator vec_iter =
-			m_output_craft_definitions.find(output.item);
+		auto vec_iter = m_output_craft_definitions.find(output.item);
 
 		if (vec_iter == m_output_craft_definitions.end())
 			return false;
 
 		std::vector<CraftDefinition*> &vec = vec_iter->second;
-		for (std::vector<CraftDefinition*>::iterator i = vec.begin();
-				i != vec.end(); ++i) {
-			CraftDefinition *def = *i;
+		for (auto def : vec) {
 			// Recipes are not yet hashed at this point
 			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
 			std::vector<CraftDefinition*> new_vec_by_input;
 			/* We will preallocate necessary memory addresses, so we don't need to reallocate them later.
 				This would save us some performance. */
 			new_vec_by_input.reserve(unhashed_inputs_vec.size());
-			for (std::vector<CraftDefinition*>::iterator i2 = unhashed_inputs_vec.begin();
-					i2 != unhashed_inputs_vec.end(); ++i2) {
-				if (def != *i2) {
-					new_vec_by_input.push_back(*i2);
+			for (auto &i2 : unhashed_inputs_vec) {
+				if (def != i2) {
+					new_vec_by_input.push_back(i2);
 				}
 			}
 			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0].swap(new_vec_by_input);
@@ -995,9 +974,8 @@ public:
 		const std::vector<std::string> &recipe, IGameDef *gamedef)
 	{
 		bool all_empty = true;
-		for (std::vector<std::string>::size_type i = 0;
-				i < recipe.size(); i++) {
-			if (!recipe[i].empty()) {
+		for (const auto &i : recipe) {
+			if (!i.empty()) {
 				all_empty = false;
 				break;
 			}
@@ -1021,8 +999,7 @@ public:
 			}
 			CraftOutput output = def->getOutput(input, gamedef);
 			got_hit = true;
-			std::map<std::string, std::vector<CraftDefinition*> >::iterator
-				vec_iter = m_output_craft_definitions.find(output.item);
+			auto vec_iter = m_output_craft_definitions.find(output.item);
 			if (vec_iter == m_output_craft_definitions.end())
 				continue;
 			std::vector<CraftDefinition*> &vec = vec_iter->second;
@@ -1030,14 +1007,13 @@ public:
 			/* We will preallocate necessary memory addresses, so we don't need
 				to reallocate them later. This would save us some performance. */
 			new_vec_by_output.reserve(vec.size());
-			for (std::vector<CraftDefinition*>::iterator i = vec.begin();
-					i != vec.end(); ++i) {
+			for (auto &vec_i : vec) {
 				/* If pointers from map by input and output are not same,
 					we will add 'CraftDefinition*' to a new vector. */
-				if (def != *i) {
+				if (def != vec_i) {
 					/* Adding dereferenced iterator value (which are
 						'CraftDefinition' reference) to a new vector. */
-					new_vec_by_output.push_back(*i);
+					new_vec_by_output.push_back(vec_i);
 				}
 			}
 			// Swaps assigned to current key value with new vector for output map.
@@ -1055,9 +1031,8 @@ public:
 		std::ostringstream os(std::ios::binary);
 		os << "Crafting definitions:\n";
 		for (int type = 0; type <= craft_hash_type_max; ++type) {
-			for (std::map<u64, std::vector<CraftDefinition*> >::const_iterator
-					it = (m_craft_defs[type]).begin();
-					it != (m_craft_defs[type]).end(); ++it) {
+			for (auto it = m_craft_defs[type].begin();
+					it != m_craft_defs[type].end(); ++it) {
 				for (std::vector<CraftDefinition*>::size_type i = 0;
 						i < it->second.size(); i++) {
 					os << "type " << type
@@ -1083,15 +1058,12 @@ public:
 	virtual void clear()
 	{
 		for (int type = 0; type <= craft_hash_type_max; ++type) {
-			for (std::map<u64, std::vector<CraftDefinition*> >::iterator
-					it = m_craft_defs[type].begin();
-					it != m_craft_defs[type].end(); ++it) {
-				for (std::vector<CraftDefinition*>::iterator
-						iit = it->second.begin();
-						iit != it->second.end(); ++iit) {
+			for (auto &it : m_craft_defs[type]) {
+				for (auto iit = it.second.begin();
+						iit != it.second.end(); ++iit) {
 					delete *iit;
 				}
-				it->second.clear();
+				it.second.clear();
 			}
 			m_craft_defs[type].clear();
 		}
@@ -1102,10 +1074,7 @@ public:
 		// Move the CraftDefs from the unhashed layer into layers higher up.
 		std::vector<CraftDefinition *> &unhashed =
 			m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
-		for (std::vector<CraftDefinition*>::size_type i = 0;
-			i < unhashed.size(); i++) {
-			CraftDefinition *def = unhashed[i];
-
+		for (auto def : unhashed) {
 			// Initialize and get the definition's hash
 			def->initHash(gamedef);
 			CraftHashType type = def->getHashType();

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -74,7 +74,7 @@ struct CraftInput
 	unsigned int width = 0;
 	std::vector<ItemStack> items;
 
-	CraftInput() {}
+	CraftInput() = default;
 
 	CraftInput(CraftMethod method_, unsigned int width_,
 			const std::vector<ItemStack> &items_):
@@ -94,7 +94,7 @@ struct CraftOutput
 	// Used for cooking (cook time) and fuel (burn time), seconds
 	float time = 0.0f;
 
-	CraftOutput() {}
+	CraftOutput() = default;
 
 	CraftOutput(const std::string &item_, float time_):
 		item(item_), time(time_)
@@ -120,9 +120,7 @@ struct CraftReplacements
 	// List of replacements
 	std::vector<std::pair<std::string, std::string> > pairs;
 
-	CraftReplacements():
-		pairs()
-	{}
+	CraftReplacements() = default;
 	CraftReplacements(const std::vector<std::pair<std::string, std::string> > &pairs_):
 		pairs(pairs_)
 	{}
@@ -135,8 +133,8 @@ struct CraftReplacements
 class CraftDefinition
 {
 public:
-	CraftDefinition(){}
-	virtual ~CraftDefinition(){}
+	CraftDefinition() = default;
+	virtual ~CraftDefinition() = default;
 
 	// Returns type of crafting definition
 	virtual std::string getName() const=0;
@@ -170,7 +168,7 @@ public:
 class CraftDefinitionShaped: public CraftDefinition
 {
 public:
-	CraftDefinitionShaped() {}
+	CraftDefinitionShaped() = delete;
 
 	CraftDefinitionShaped(
 			const std::string &output_,
@@ -180,7 +178,7 @@ public:
 		output(output_), width(width_), recipe(recipe_),
 		replacements(replacements_)
 	{}
-	virtual ~CraftDefinitionShaped(){}
+	virtual ~CraftDefinitionShaped() = default;
 
 	virtual std::string getName() const;
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const;
@@ -219,17 +217,14 @@ private:
 class CraftDefinitionShapeless: public CraftDefinition
 {
 public:
-	CraftDefinitionShapeless():
-		output(""), recipe(), hash_inited(false), replacements()
-	{}
+	CraftDefinitionShapeless() = delete;
 	CraftDefinitionShapeless(
 			const std::string &output_,
 			const std::vector<std::string> &recipe_,
 			const CraftReplacements &replacements_):
-		output(output_), recipe(recipe_),
-		hash_inited(false), replacements(replacements_)
+		output(output_), recipe(recipe_), replacements(replacements_)
 	{}
-	virtual ~CraftDefinitionShapeless(){}
+	virtual ~CraftDefinitionShapeless() = default;
 
 	virtual std::string getName() const;
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const;
@@ -253,7 +248,7 @@ private:
 	// Recipe list (item names)
 	std::vector<std::string> recipe_names;
 	// bool indicating if initHash has been called already
-	bool hash_inited;
+	bool hash_inited = false;
 	// Replacement items for decrementInput()
 	CraftReplacements replacements;
 };
@@ -267,13 +262,11 @@ private:
 class CraftDefinitionToolRepair: public CraftDefinition
 {
 public:
-	CraftDefinitionToolRepair():
-		additional_wear(0)
-	{}
+	CraftDefinitionToolRepair() = delete;
 	CraftDefinitionToolRepair(float additional_wear_):
 		additional_wear(additional_wear_)
 	{}
-	virtual ~CraftDefinitionToolRepair(){}
+	virtual ~CraftDefinitionToolRepair() = default;
 
 	virtual std::string getName() const;
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const;
@@ -295,7 +288,7 @@ private:
 	// 1 = new tool is completely broken
 	// 0 = simply add remaining uses of both input tools
 	// -1 = new tool is completely pristine
-	float additional_wear;
+	float additional_wear = 0.0f;
 };
 
 /*
@@ -305,18 +298,15 @@ private:
 class CraftDefinitionCooking: public CraftDefinition
 {
 public:
-	CraftDefinitionCooking():
-		output(""), recipe(""), hash_inited(false), cooktime()
-	{}
+	CraftDefinitionCooking() = delete;
 	CraftDefinitionCooking(
 			const std::string &output_,
 			const std::string &recipe_,
 			float cooktime_,
 			const CraftReplacements &replacements_):
-		output(output_), recipe(recipe_), hash_inited(false),
-		cooktime(cooktime_), replacements(replacements_)
+		output(output_), recipe(recipe_), cooktime(cooktime_), replacements(replacements_)
 	{}
-	virtual ~CraftDefinitionCooking(){}
+	virtual ~CraftDefinitionCooking() = default;
 
 	virtual std::string getName() const;
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const;
@@ -340,7 +330,7 @@ private:
 	// Recipe item name
 	std::string recipe_name;
 	// bool indicating if initHash has been called already
-	bool hash_inited;
+	bool hash_inited = false;
 	// Time in seconds
 	float cooktime;
 	// Replacement items for decrementInput()
@@ -354,18 +344,13 @@ private:
 class CraftDefinitionFuel: public CraftDefinition
 {
 public:
-	CraftDefinitionFuel():
-		recipe(""), hash_inited(false), burntime()
-	{}
+	CraftDefinitionFuel() = delete;
 	CraftDefinitionFuel(const std::string &recipe_,
 			float burntime_,
 			const CraftReplacements &replacements_):
-		recipe(recipe_),
-		hash_inited(false),
-		burntime(burntime_),
-		replacements(replacements_)
+		recipe(recipe_), burntime(burntime_), replacements(replacements_)
 	{}
-	virtual ~CraftDefinitionFuel(){}
+	virtual ~CraftDefinitionFuel() = default;
 
 	virtual std::string getName() const;
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const;
@@ -387,7 +372,7 @@ private:
 	// Recipe item name
 	std::string recipe_name;
 	// bool indicating if initHash has been called already
-	bool hash_inited;
+	bool hash_inited = false;
 	// Time in seconds
 	float burntime;
 	// Replacement items for decrementInput()
@@ -400,8 +385,8 @@ private:
 class ICraftDefManager
 {
 public:
-	ICraftDefManager(){}
-	virtual ~ICraftDefManager(){}
+	ICraftDefManager() = default;
+	virtual ~ICraftDefManager() = default;
 
 	// The main crafting function
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
@@ -417,8 +402,8 @@ public:
 class IWritableCraftDefManager : public ICraftDefManager
 {
 public:
-	IWritableCraftDefManager(){}
-	virtual ~IWritableCraftDefManager(){}
+	IWritableCraftDefManager() = default;
+	virtual ~IWritableCraftDefManager() = default;
 
 	// The main crafting function
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,

--- a/src/database-dummy.cpp
+++ b/src/database-dummy.cpp
@@ -33,7 +33,7 @@ bool Database_Dummy::saveBlock(const v3s16 &pos, const std::string &data)
 void Database_Dummy::loadBlock(const v3s16 &pos, std::string *block)
 {
 	s64 i = getBlockAsInteger(pos);
-	std::map<s64, std::string>::iterator it = m_database.find(i);
+	auto it = m_database.find(i);
 	if (it == m_database.end()) {
 		*block = "";
 		return;

--- a/src/database-files.cpp
+++ b/src/database-files.cpp
@@ -44,7 +44,7 @@ void PlayerDatabaseFiles::serialize(std::ostringstream &os, RemotePlayer *player
 	args.setFloat("yaw", player->getPlayerSAO()->getYaw());
 	args.setS32("breath", player->getPlayerSAO()->getBreath());
 
-	std::string extended_attrs = "";
+	std::string extended_attrs;
 	player->serializeExtraAttributes(extended_attrs);
 	args.set("extended_attributes", extended_attrs);
 
@@ -174,6 +174,6 @@ void PlayerDatabaseFiles::listPlayers(std::vector<std::string> &res)
 		player.deSerialize(is, "", &playerSAO);
 		is.close();
 
-		res.push_back(player.getName());
+		res.emplace_back(player.getName());
 	}
 }

--- a/src/database-files.h
+++ b/src/database-files.h
@@ -30,7 +30,7 @@ class PlayerDatabaseFiles : public PlayerDatabase
 {
 public:
 	PlayerDatabaseFiles(const std::string &savedir) : m_savedir(savedir) {}
-	virtual ~PlayerDatabaseFiles() {}
+	virtual ~PlayerDatabaseFiles() = default;
 
 	void savePlayer(RemotePlayer *player);
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);

--- a/src/database-postgresql.cpp
+++ b/src/database-postgresql.cpp
@@ -489,7 +489,8 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	std::vector<const InventoryList*> inventory_lists = sao->getInventory()->getLists();
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
 		const InventoryList* list = inventory_lists[i];
-		std::string name = list->getName(), width = itos(list->getWidth()),
+		const std::string &name = list->getName();
+		std::string width = itos(list->getWidth()),
 			inv_id = itos(i), lsize = itos(list->getSize());
 
 		const char* inv_values[] = {
@@ -518,11 +519,11 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 
 	execPrepared("remove_player_metadata", 1, rmvalues);
 	const PlayerAttributes &attrs = sao->getExtendedAttributes();
-	for (PlayerAttributes::const_iterator it = attrs.begin(); it != attrs.end(); ++it) {
+	for (const auto &attr : attrs) {
 		const char *meta_values[] = {
 			player->getName(),
-			it->first.c_str(),
-			it->second.c_str()
+			attr.first.c_str(),
+			attr.second.c_str()
 		};
 		execPrepared("save_player_metadata", 3, meta_values);
 	}
@@ -622,7 +623,7 @@ void PlayerDatabasePostgreSQL::listPlayers(std::vector<std::string> &res)
 
 	int numrows = PQntuples(results);
 	for (int row = 0; row < numrows; row++)
-		res.push_back(PQgetvalue(results, row, 0));
+		res.emplace_back(PQgetvalue(results, row, 0));
 
 	PQclear(results);
 }

--- a/src/database-postgresql.h
+++ b/src/database-postgresql.h
@@ -112,7 +112,7 @@ class MapDatabasePostgreSQL : private Database_PostgreSQL, public MapDatabase
 {
 public:
 	MapDatabasePostgreSQL(const std::string &connect_string);
-	virtual ~MapDatabasePostgreSQL() {}
+	virtual ~MapDatabasePostgreSQL() = default;
 
 	bool saveBlock(const v3s16 &pos, const std::string &data);
 	void loadBlock(const v3s16 &pos, std::string *block);
@@ -131,7 +131,7 @@ class PlayerDatabasePostgreSQL : private Database_PostgreSQL, public PlayerDatab
 {
 public:
 	PlayerDatabasePostgreSQL(const std::string &connect_string);
-	virtual ~PlayerDatabasePostgreSQL() {}
+	virtual ~PlayerDatabasePostgreSQL() = default;
 
 	void savePlayer(RemotePlayer *player);
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);

--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -38,7 +38,7 @@ Database_Redis::Database_Redis(Settings &conf)
 	try {
 		tmp = conf.get("redis_address");
 		hash = conf.get("redis_hash");
-	} catch (SettingNotFoundException) {
+	} catch (SettingNotFoundException &) {
 		throw SettingNotFoundException("Set redis_address and "
 			"redis_hash in world.mt to use the redis backend");
 	}

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -521,10 +521,10 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_reset(m_stmt_player_metadata_remove);
 
 	const PlayerAttributes &attrs = sao->getExtendedAttributes();
-	for (PlayerAttributes::const_iterator it = attrs.begin(); it != attrs.end(); ++it) {
+	for (const auto &attr : attrs) {
 		str_to_sqlite(m_stmt_player_metadata_add, 1, player->getName());
-		str_to_sqlite(m_stmt_player_metadata_add, 2, it->first);
-		str_to_sqlite(m_stmt_player_metadata_add, 3, it->second);
+		str_to_sqlite(m_stmt_player_metadata_add, 2, attr.first);
+		str_to_sqlite(m_stmt_player_metadata_add, 3, attr.second);
 		sqlite3_vrfy(sqlite3_step(m_stmt_player_metadata_add), SQLITE_DONE);
 		sqlite3_reset(m_stmt_player_metadata_add);
 	}

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -32,9 +32,9 @@ static inline s16 unsigned_to_signed(u16 i, u16 max_positive)
 {
 	if (i < max_positive) {
 		return i;
-	} else {
-		return i - (max_positive * 2);
 	}
+
+	return i - (max_positive * 2);
 }
 
 

--- a/src/database.h
+++ b/src/database.h
@@ -37,7 +37,7 @@ public:
 class MapDatabase : public Database
 {
 public:
-	virtual ~MapDatabase() {}
+	virtual ~MapDatabase() = default;
 
 	virtual bool saveBlock(const v3s16 &pos, const std::string &data) = 0;
 	virtual void loadBlock(const v3s16 &pos, std::string *block) = 0;
@@ -55,7 +55,8 @@ class RemotePlayer;
 class PlayerDatabase
 {
 public:
-	virtual ~PlayerDatabase() {}
+	virtual ~PlayerDatabase() = default;
+
 	virtual void savePlayer(RemotePlayer *player) = 0;
 	virtual bool loadPlayer(RemotePlayer *player, PlayerSAO *sao) = 0;
 	virtual bool removePlayer(const std::string &name) = 0;

--- a/src/daynightratio.h
+++ b/src/daynightratio.h
@@ -53,7 +53,7 @@ inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 		return 1000;
 	}
 
-	for (u32 i=0; i<sizeof(values)/sizeof(*values); i++) {
+	for (u32 i=0; i < sizeof(values) / sizeof(*values); i++) {
 			if (values[i][0] <= t)
 				continue;
 			if (i == 0)

--- a/src/daynightratio.h
+++ b/src/daynightratio.h
@@ -51,18 +51,19 @@ inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 			return values[i][1];
 		}
 		return 1000;
-	} else {
-		for(u32 i=0; i<sizeof(values)/sizeof(*values); i++){
-			if(values[i][0] <= t)
+	}
+
+	for (u32 i=0; i<sizeof(values)/sizeof(*values); i++) {
+			if (values[i][0] <= t)
 				continue;
-			if(i == 0)
+			if (i == 0)
 				return values[i][1];
 			float td0 = values[i][0] - values[i-1][0];
 			float f = (t - values[i-1][0]) / td0;
 			return f * values[i][1] + (1.0 - f) * values[i-1][1];
 		}
 		return 1000;
-	}
+
 }
 
 #endif

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -21,8 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include "debug.h"
 #include "exceptions.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <sstream>
@@ -110,7 +110,7 @@ void DebugStack::print(FILE *file, bool everything)
 		os.str().c_str());
 
 	for (int i = 0; i < stack_max_i; i++) {
-		if (i == stack_i && everything == false)
+		if (i == stack_i && !everything)
 			break;
 
 		if (i < stack_i)
@@ -128,7 +128,7 @@ void DebugStack::print(std::ostream &os, bool everything)
 	os<<"DEBUG STACK FOR THREAD "<<thread_id<<": "<<std::endl;
 
 	for(int i = 0; i < stack_max_i; i++) {
-		if(i == stack_i && everything == false)
+		if(i == stack_i && !everything)
 			break;
 
 		if (i < stack_i)
@@ -193,7 +193,7 @@ DebugStacker::~DebugStacker()
 {
 	MutexAutoLock lock(g_debug_stacks_mutex);
 
-	if (m_overflowed == true)
+	if (m_overflowed)
 		return;
 
 	m_stack->stack_i--;

--- a/src/debug.h
+++ b/src/debug.h
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <iostream>
 #include <exception>
-#include <assert.h>
+#include <cassert>
 #include "gettime.h"
 #include "log.h"
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -440,8 +440,7 @@ void set_default_settings(Settings *settings)
 void override_default_settings(Settings *settings, Settings *from)
 {
 	std::vector<std::string> names = from->getNames();
-	for (size_t i = 0; i < names.size(); i++) {
-		const std::string &name = names[i];
+	for (const auto &name : names) {
 		settings->setDefault(name, from->get(name));
 	}
 }

--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -201,7 +201,7 @@ void DungeonGen::makeDungeon(v3s16 start_padding)
 		}
 	}
 	// No place found
-	if (fits == false)
+	if (!fits)
 		return;
 
 	/*
@@ -564,7 +564,7 @@ bool DungeonGen::findPlaceForRoomDoor(v3s16 roomsize, v3s16 &result_doorplace,
 		v3s16 doorplace;
 		v3s16 doordir;
 		bool r = findPlaceForDoor(doorplace, doordir);
-		if (r == false)
+		if (!r)
 			continue;
 		v3s16 roomplace;
 		// X east, Z north, Y up
@@ -596,7 +596,7 @@ bool DungeonGen::findPlaceForRoomDoor(v3s16 roomsize, v3s16 &result_doorplace,
 				break;
 			}
 		}
-		if (fits == false) {
+		if (!fits) {
 			// Find new place
 			continue;
 		}
@@ -625,12 +625,12 @@ v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs)
 		} while ((dir.X == 0 || dir.Z == 0) && trycount < 10);
 
 		return dir;
-	} else {
-		if (random.next() % 2 == 0)
-			return random.next() % 2 ? v3s16(-1, 0, 0) : v3s16(1, 0, 0);
-		else
-			return random.next() % 2 ? v3s16(0, 0, -1) : v3s16(0, 0, 1);
 	}
+
+	if (random.next() % 2 == 0)
+		return random.next() % 2 ? v3s16(-1, 0, 0) : v3s16(1, 0, 0);
+
+	return random.next() % 2 ? v3s16(0, 0, -1) : v3s16(0, 0, 1);
 }
 
 
@@ -673,6 +673,6 @@ int dir_to_facedir(v3s16 d)
 {
 	if (abs(d.X) > abs(d.Z))
 		return d.X < 0 ? 3 : 1;
-	else
-		return d.Z < 0 ? 2 : 0;
+
+	return d.Z < 0 ? 2 : 0;
 }

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -52,18 +52,18 @@ public:
 	int id;
 
 	EmergeThread(Server *server, int ethreadid);
-	~EmergeThread();
+	~EmergeThread() = default;
 
 	void *run();
 	void signal();
 
 	// Requires queue mutex held
-	bool pushBlock(v3s16 pos);
+	bool pushBlock(const v3s16 &pos);
 
 	void cancelPendingItems();
 
 	static void runCompletionCallbacks(
-		v3s16 pos, EmergeAction action,
+		const v3s16 &pos, EmergeAction action,
 		const EmergeCallbackList &callbacks);
 
 private:
@@ -78,7 +78,7 @@ private:
 	bool popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata);
 
 	EmergeAction getBlockOrStartGen(
-		v3s16 pos, bool allow_gen, MapBlock **block, BlockMakeData *data);
+		const v3s16 &pos, bool allow_gen, MapBlock **block, BlockMakeData *data);
 	MapBlock *finishGen(v3s16 pos, BlockMakeData *bmdata,
 		std::map<v3s16, MapBlock *> *modified_blocks);
 
@@ -181,7 +181,7 @@ EmergeManager::~EmergeManager()
 
 bool EmergeManager::initMapgens(MapgenParams *params)
 {
-	if (m_mapgens.size())
+	if (!m_mapgens.empty())
 		return false;
 
 	this->mgparams = params;
@@ -316,7 +316,7 @@ v3s16 EmergeManager::getContainingChunk(v3s16 blockpos, s16 chunksize)
 
 int EmergeManager::getSpawnLevelAtPoint(v2s16 p)
 {
-	if (m_mapgens.size() == 0 || !m_mapgens[0]) {
+	if (m_mapgens.empty() || !m_mapgens[0]) {
 		errorstream << "EmergeManager: getSpawnLevelAtPoint() called"
 			" before mapgen init" << std::endl;
 		return 0;
@@ -328,7 +328,7 @@ int EmergeManager::getSpawnLevelAtPoint(v2s16 p)
 
 int EmergeManager::getGroundLevelAtPoint(v2s16 p)
 {
-	if (m_mapgens.size() == 0 || !m_mapgens[0]) {
+	if (m_mapgens.empty() || !m_mapgens[0]) {
 		errorstream << "EmergeManager: getGroundLevelAtPoint() called"
 			" before mapgen init" << std::endl;
 		return 0;
@@ -380,7 +380,7 @@ bool EmergeManager::pushBlockEmergeData(
 	*entry_already_exists   = !findres.second;
 
 	if (callback)
-		bedata.callbacks.push_back(std::make_pair(callback, callback_param));
+		bedata.callbacks.emplace_back(callback, callback_param);
 
 	if (*entry_already_exists) {
 		bedata.flags |= flags;
@@ -457,19 +457,13 @@ EmergeThread::EmergeThread(Server *server, int ethreadid) :
 }
 
 
-EmergeThread::~EmergeThread()
-{
-	//cancelPendingItems();
-}
-
-
 void EmergeThread::signal()
 {
 	m_queue_event.signal();
 }
 
 
-bool EmergeThread::pushBlock(v3s16 pos)
+bool EmergeThread::pushBlock(const v3s16 &pos)
 {
 	m_block_queue.push(pos);
 	return true;
@@ -494,9 +488,7 @@ void EmergeThread::cancelPendingItems()
 }
 
 
-void EmergeThread::runCompletionCallbacks(
-	v3s16 pos,
-	EmergeAction action,
+void EmergeThread::runCompletionCallbacks(const v3s16 &pos, EmergeAction action,
 	const EmergeCallbackList &callbacks)
 {
 	for (size_t i = 0; i != callbacks.size(); i++) {
@@ -528,7 +520,7 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 
 
 EmergeAction EmergeThread::getBlockOrStartGen(
-	v3s16 pos, bool allow_gen, MapBlock **block, BlockMakeData *bmdata)
+	const v3s16 &pos, bool allow_gen, MapBlock **block, BlockMakeData *bmdata)
 {
 	MutexAutoLock envlock(m_server->m_env_mutex);
 
@@ -644,7 +636,7 @@ void *EmergeThread::run()
 
 				m_mapgen->makeChunk(&bmdata);
 
-				if (enable_mapgen_debug_info == false)
+				if (!enable_mapgen_debug_info)
 					t.stop(true); // Hide output
 			}
 
@@ -656,7 +648,7 @@ void *EmergeThread::run()
 		if (block)
 			modified_blocks[pos] = block;
 
-		if (modified_blocks.size() > 0)
+		if (!modified_blocks.empty())
 			m_server->SetBlocksNotSent(modified_blocks);
 	}
 	} catch (VersionMismatchException &e) {

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -55,7 +55,8 @@ struct BlockMakeData {
 	UniqueQueue<v3s16> transforming_liquid;
 	INodeDefManager *nodedef = nullptr;
 
-	BlockMakeData() {}
+	BlockMakeData() = default;
+
 	~BlockMakeData() { delete vmanip; }
 };
 


### PR DESCRIPTION
* default operator
* redundant init
* delete default constructors on CraftDefinition childs (never used)
* fix some missing init values
* const ref fix reported by clang-tidy
* ranged-based for loops
* simple conditions & returns
* empty stl function instead of size
* emplace_back stl function instead of push_back + construct temp obj
* auto for some iterators
* code style fixes
* c++ stl headers instead of C stl headers (stdio.h -> cstdio)