### PR TITLE
Add missing ctime include

### DIFF
--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <SColor.h>
+#include <ctime>
 #include "util/pointer.h"
 #include "util/numeric.h"
 


### PR DESCRIPTION
Without that include MSVC will fail, because time_t is not in the namespace std.