### PR TITLE
Banmanager: Move 'creating' message from warningstream to infostream 

### DIFF
--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -33,8 +33,8 @@ BanManager::BanManager(const std::string &banfilepath):
 	try {
 		load();
 	} catch(SerializationError &e) {
-		warningstream<<"BanManager: creating "
-				<<m_banfilepath<<std::endl;
+		infostream << "BanManager: creating "
+				<< m_banfilepath << std::endl;
 	}
 }
 


### PR DESCRIPTION
Warning message shown when entering a world is moved to infostream.
As requested here http://irc.minetest.net/minetest-dev/2017-08-18#i_5047967
Tested.