### PR TITLE
Respect object property hp_max field for players

### DIFF
--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -22,7 +22,7 @@ core.EMERGE_GENERATED   = 4
 -- Size of mapblocks in nodes
 core.MAP_BLOCKSIZE = 16
 -- Default maximal HP of a player
-core.PLAYER_MAX_HP = 20
+core.PLAYER_MAX_HP_DEFAULT = 20
 -- Maximal breath of a player
 core.PLAYER_MAX_BREATH = 11
 

--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -21,6 +21,10 @@ core.EMERGE_GENERATED   = 4
 -- constants.h
 -- Size of mapblocks in nodes
 core.MAP_BLOCKSIZE = 16
+-- Default maximal HP of a player
+core.PLAYER_MAX_HP = 20
+-- Maximal breath of a player
+core.PLAYER_MAX_BREATH = 11
 
 -- light.h
 -- Maximum value for node 'light_source' parameter

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -6,7 +6,7 @@ local health_bar_definition =
 	hud_elem_type = "statbar",
 	position = { x=0.5, y=1 },
 	text = "heart.png",
-	number = core.PLAYER_MAX_HP,
+	number = core.PLAYER_MAX_HP_DEFAULT,
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = { x=(-10*24)-25, y=-(48+24+16)},
@@ -48,11 +48,11 @@ local function initialize_builtin_statbars(player)
 	if player:hud_get_flags().healthbar and enable_damage then
  		if hud.id_healthbar == nil then
  			local hp = player:get_hp()
- 			local max_display_hp = math.max(core.PLAYER_MAX_HP,
+ 			local max_display_hp = math.max(core.PLAYER_MAX_HP_DEFAULT,
  				math.max(player:get_properties().hp_max, hp))
  			-- Limit width of health bar: Scale to the default maximal HP
 			health_bar_definition.number =
-				hp / max_display_hp * core.PLAYER_MAX_HP
+				hp / max_display_hp * core.PLAYER_MAX_HP_DEFAULT
 			hud.id_healthbar  = player:hud_add(health_bar_definition)
 		end
 	else
@@ -108,10 +108,10 @@ local function player_event_handler(player,eventname)
 
 		if hud_ids[name].id_healthbar ~= nil then
  			local hp = player:get_hp()
- 			local max_display_hp = math.max(core.PLAYER_MAX_HP,
+ 			local max_display_hp = math.max(core.PLAYER_MAX_HP_DEFAULT,
  				math.max(player:get_properties().hp_max, hp))
  			-- Limit width of health bar: Scale to the default maximal HP
-			local hp_count = hp / max_display_hp * core.PLAYER_MAX_HP
+			local hp_count = hp / max_display_hp * core.PLAYER_MAX_HP_DEFAULT
 			player:hud_change(hud_ids[name].id_healthbar, "number", hp_count)
 			return true
 		end

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -6,7 +6,7 @@ local health_bar_definition =
 	hud_elem_type = "statbar",
 	position = { x=0.5, y=1 },
 	text = "heart.png",
-	number = 20,
+	number = core.PLAYER_MAX_HP,
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = { x=(-10*24)-25, y=-(48+24+16)},
@@ -37,39 +37,45 @@ local function initialize_builtin_statbars(player)
 		return
 	end
 
-	if (hud_ids[name] == nil) then
+	if not hud_ids[name] then
 		hud_ids[name] = {}
 		-- flags are not transmitted to client on connect, we need to make sure
 		-- our current flags are transmitted by sending them actively
 		player:hud_set_flags(player:hud_get_flags())
 	end
+	local hud = hud_ids[name]
 
 	if player:hud_get_flags().healthbar and enable_damage then
- 		if hud_ids[name].id_healthbar == nil then
-			health_bar_definition.number = player:get_hp()
-			hud_ids[name].id_healthbar  = player:hud_add(health_bar_definition)
+ 		if hud.id_healthbar == nil then
+ 			local hp = player:get_hp()
+ 			local max_display_hp = math.max(core.PLAYER_MAX_HP,
+ 				math.max(player:get_properties().hp_max, hp))
+ 			-- Limit width of health bar: Scale to the default maximal HP
+			health_bar_definition.number =
+				hp / max_display_hp * core.PLAYER_MAX_HP
+			hud.id_healthbar  = player:hud_add(health_bar_definition)
 		end
 	else
-		if hud_ids[name].id_healthbar ~= nil then
-			player:hud_remove(hud_ids[name].id_healthbar)
-			hud_ids[name].id_healthbar = nil
+		if hud.id_healthbar ~= nil then
+			player:hud_remove(hud.id_healthbar)
+			hud.id_healthbar = nil
 		end
 	end
 
-	if (player:get_breath() < 11) then
+	if player:get_breath() < core.PLAYER_MAX_BREATH then
 		if player:hud_get_flags().breathbar and enable_damage then
-			if hud_ids[name].id_breathbar == nil then
-				hud_ids[name].id_breathbar = player:hud_add(breath_bar_definition)
+			if hud.id_breathbar == nil then
+				hud.id_breathbar = player:hud_add(breath_bar_definition)
 			end
 		else
-			if hud_ids[name].id_breathbar ~= nil then
-				player:hud_remove(hud_ids[name].id_breathbar)
-				hud_ids[name].id_breathbar = nil
+			if hud.id_breathbar ~= nil then
+				player:hud_remove(hud.id_breathbar)
+				hud.id_breathbar = nil
 			end
 		end
-	elseif hud_ids[name].id_breathbar ~= nil then
-		player:hud_remove(hud_ids[name].id_breathbar)
-		hud_ids[name].id_breathbar = nil
+	elseif hud.id_breathbar ~= nil then
+		player:hud_remove(hud.id_breathbar)
+		hud.id_breathbar = nil
 	end
 end
 
@@ -101,7 +107,12 @@ local function player_event_handler(player,eventname)
 		initialize_builtin_statbars(player)
 
 		if hud_ids[name].id_healthbar ~= nil then
-			player:hud_change(hud_ids[name].id_healthbar,"number",player:get_hp())
+ 			local hp = player:get_hp()
+ 			local max_display_hp = math.max(core.PLAYER_MAX_HP,
+ 				math.max(player:get_properties().hp_max, hp))
+ 			-- Limit width of health bar: Scale to the default maximal HP
+			local hp_count = hp / max_display_hp * core.PLAYER_MAX_HP
+			player:hud_change(hud_ids[name].id_healthbar, "number", hp_count)
 			return true
 		end
 	end
@@ -110,7 +121,7 @@ local function player_event_handler(player,eventname)
 		initialize_builtin_statbars(player)
 
 		if hud_ids[name].id_breathbar ~= nil then
-			player:hud_change(hud_ids[name].id_breathbar,"number",player:get_breath()*2)
+			player:hud_change(hud_ids[name].id_breathbar, "number", player:get_breath() * 2)
 			return true
 		end
 	end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3276,6 +3276,7 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `0`: player is drowning,
         * `1`-`10`: remaining number of bubbles
         * `11`: bubbles bar is not shown
+        * See constant: `minetest.PLAYER_MAX_BREATH`
 * `set_attribute(attribute, value)`:
     * Sets an extra attribute with value on player.
     * `value` must be a string.
@@ -3977,6 +3978,7 @@ Definition tables
 
     {
         hp_max = 1,
+    --  ^ For players, the maximal HP defaults to `minetest.PLAYER_MAX_HP`
         physical = true,
         collide_with_objects = true, -- collide with other objects if physical = true
         weight = 5,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3978,7 +3978,7 @@ Definition tables
 
     {
         hp_max = 1,
-    --  ^ For players, the maximal HP defaults to `minetest.PLAYER_MAX_HP`
+    --  ^ For players, the maximal HP defaults to `minetest.PLAYER_MAX_HP_DEFAULT`
         physical = true,
         collide_with_objects = true, -- collide with other objects if physical = true
         weight = 5,

--- a/src/constants.h
+++ b/src/constants.h
@@ -90,7 +90,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PLAYER_INVENTORY_SIZE (8 * 4)
 
 // Maximum hit points of a player
-#define PLAYER_MAX_HP 20
+#define PLAYER_MAX_HP_DEFAULT 20
 
 // Maximal breath of a player
 #define PLAYER_MAX_BREATH 11

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -783,7 +783,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 {
 	assert(m_peer_id != 0);	// pre-condition
 
-	m_prop.hp_max = PLAYER_MAX_HP;
+	m_prop.hp_max = PLAYER_MAX_HP_DEFAULT;
 	m_prop.physical = false;
 	m_prop.weight = 75;
 	m_prop.collisionbox = aabb3f(-0.3f, 0.0f, -0.3f, 0.3f, 1.77f, 0.3f);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -800,7 +800,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 	m_prop.is_visible = true;
 	m_prop.makes_footstep_sound = true;
 	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
-	m_hp = PLAYER_MAX_HP;
+	m_hp = m_prop.hp_max;
 }
 
 PlayerSAO::~PlayerSAO()
@@ -1237,8 +1237,8 @@ void PlayerSAO::setHP(s16 hp)
 
 	if (hp < 0)
 		hp = 0;
-	else if (hp > PLAYER_MAX_HP)
-		hp = PLAYER_MAX_HP;
+	else if (hp > m_prop.hp_max)
+		hp = m_prop.hp_max;
 
 	if (hp < oldhp && !g_settings->getBool("enable_damage")) {
 		return;

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -100,7 +100,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 		try {
 			sao->setHPRaw(args.getS32("hp"));
 		} catch(SettingNotFoundException &e) {
-			sao->setHPRaw(PLAYER_MAX_HP);
+			sao->setHPRaw(PLAYER_MAX_HP_DEFAULT);
 		}
 
 		try {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -183,7 +183,9 @@ void read_object_properties(lua_State *L, int index,
 	if(!lua_istable(L, index))
 		return;
 
-	prop->hp_max = getintfield_default(L, -1, "hp_max", 10);
+	int hp_max = 0;
+	if (getintfield(L, -1, "hp_max", hp_max))
+		prop->hp_max = (s16)rangelim(hp_max, 0, S16_MAX);
 
 	getboolfield(L, -1, "physical", prop->physical);
 	getboolfield(L, -1, "collide_with_objects", prop->collideWithObjects);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -750,6 +750,11 @@ int ObjectRef::l_set_properties(lua_State *L)
 	if (!prop)
 		return 0;
 	read_object_properties(L, 2, prop, getServer(L)->idef());
+	if (prop->hp_max < co->getHP()) {
+		co->setHP(prop->hp_max);
+		if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER)
+			getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co);
+	}
 	co->notifyObjectPropertiesModified();
 	return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2588,7 +2588,7 @@ void Server::RespawnPlayer(u16 peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " respawns" << std::endl;
 
-	playersao->setHP(PLAYER_MAX_HP);
+	playersao->setHP(playersao->accessObjectProperties()->hp_max);
 	playersao->setBreath(PLAYER_MAX_BREATH);
 
 	bool repositioned = m_script->on_respawnplayer(playersao);


### PR DESCRIPTION
This allows modders to configure the maximal HP per player.

Apart from #2246 there's surely another request for this around.
```Lua
player:set_properties({
	hp_max = 30
})
```
With too high values, the health bar will go off-screen when fully "recharged".