### PR TITLE
[WIP] Fix build using clang on osx

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "util/srp.h"
 #include "tileanimation.h"
+#include "network/networkpacket.h"
 
 void Client::handleCommand_Deprecated(NetworkPacket* pkt)
 {

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/pointedthing.h"
 #include "util/serialize.h"
 #include "util/srp.h"
+#include "network/networkpacket.h"
 
 void Server::handleCommand_Deprecated(NetworkPacket* pkt)
 {


### PR DESCRIPTION
**Problem:** Since the PR #6227 is merged, the mac build errors like below will show in travis build output.
```
Undefined symbols for architecture x86_64:
  "NetworkPacket::operator<<(unsigned long)", referenced from:
      Server::handleCommand_Init_Legacy(NetworkPacket*) in serverpackethandler.cpp.o
      Server::SendCSMFlavourLimits(unsigned short) in server.cpp.o
      Server::acceptAuth(unsigned short, bool) in server.cpp.o
  "NetworkPacket::operator>>(unsigned long&)", referenced from:
      Client::handleCommand_AuthAccept(NetworkPacket*) in clientpackethandler.cpp.o
      Client::handleCommand_InitLegacy(NetworkPacket*) in clientpackethandler.cpp.o
      Client::handleCommand_CSMFlavourLimits(NetworkPacket*) in clientpackethandler.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [../bin/minetest] Error 1
make[1]: *** [src/CMakeFiles/minetest.dir/all] Error 2
make: *** [all] Error 2
```
**Solution:** none yet.
**Work done so far:** 
- Includes added into clientpackethandler.cpp and serverpackethandler.cpp, as were suggested in old PR (#6227)
- PR #6227 now is merged, commits rebased.
