### PR TITLE
New version scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 # Also remember to set PROTOCOL_VERSION in network/networkprotocol.h when releasing
 set(VERSION_MAJOR 0)
-set(VERSION_MINOR 4)
-set(VERSION_PATCH 16)
+set(VERSION_MINOR 5)
+set(VERSION_PATCH 0)
 set(VERSION_EXTRA "" CACHE STRING "Stuff to append to version string")
 
 # Change to false for releases

--- a/README.md
+++ b/README.md
@@ -415,3 +415,13 @@ This is how we build Windows releases.
     popd
     echo Failed.
     exit /b 1
+
+Version scheme
+--------------
+
+Minetest doesn't follow semver. Instead, we do something roughly similar to 0.major.minor.
+
+Since 0.5.0-dev and 0.4.17-dev, the dev notation refers to the next release, 
+ie: 0.5.0-dev is the development version leading to 0.5.0.
+
+Prior to that, we used oldversion-dev.

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -1,4 +1,4 @@
-Minetest Lua Client Modding API Reference 0.4.16
+Minetest Lua Client Modding API Reference 0.5.0
 ================================================
 * More information at <http://www.minetest.net/>
 * Developer Wiki: <http://dev.minetest.net/>

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1,4 +1,4 @@
-Minetest Lua Modding API Reference 0.4.16
+Minetest Lua Modding API Reference 0.5.0
 =========================================
 * More information at <http://www.minetest.net/>
 * Developer Wiki: <http://dev.minetest.net/>

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -1,4 +1,4 @@
-Minetest Lua Mainmenu API Reference 0.4.16
+Minetest Lua Mainmenu API Reference 0.5.0
 ========================================
 
 Introduction

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -16,7 +16,50 @@ prompt_for_number() {
 	done
 }
 
+# On a release the following actions are performed
+# * DEVELOPMENT_BUILD is set to false
+# * android versionCode is bumped
+# * Commit the changes
+# * Tag with current version
+perform_release() {
+	sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt || die "Failed to unset DEVELOPMENT_BUILD"
 
+	sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle || die "Failed to update Android version code"
+
+	git add -f CMakeLists.txt build/android/build.gradle || die "git add failed"
+
+	git commit -m "Bump version to $RELEASE_VERSION" || die "git commit failed"
+
+	echo "Tagging $RELEASE_VERSION"
+
+	git tag -a "$RELEASE_VERSION" -m "$RELEASE_VERSION" || die 'Adding tag failed'
+}
+
+# After release
+# * Set DEVELOPMENT_BUILD to true
+# * Bump version in CMakeLists and docs
+# * Commit the changes
+back_to_devel() {
+	echo 'Creating "return back to development" commit'
+
+	sed -i -re 's/^set\(DEVELOPMENT_BUILD FALSE\)$/set(DEVELOPMENT_BUILD TRUE)/' CMakeLists.txt || die 'Failed to set DEVELOPMENT_BUILD'
+
+	sed -i -re "s/^set\(VERSION_MAJOR [0-9]+\)$/set(VERSION_MAJOR $NEXT_VERSION_MAJOR)/" CMakeLists.txt || die "Failed to update VERSION_MAJOR"
+
+	sed -i -re "s/^set\(VERSION_MINOR [0-9]+\)$/set(VERSION_MINOR $NEXT_VERSION_MINOR)/" CMakeLists.txt || die "Failed to update VERSION_MINOR"
+
+	sed -i -re "s/^set\(VERSION_PATCH [0-9]+\)$/set(VERSION_PATCH $NEXT_VERSION_PATCH)/" CMakeLists.txt || die "Failed to update VERSION_PATCH"
+
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/lua_api.txt || die "Failed to update doc/lua_api.txt"
+
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/menu_lua_api.txt || die "Failed to update doc/menu_lua_api.txt"
+
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/client_lua_api.md || die "Failed to update doc/client_lua_api.md"
+
+	git add -f CMakeLists.txt doc/lua_api.txt doc/menu_lua_api.txt doc/client_lua_api.md || die 'git add failed'
+
+	git commit -m "Continue with $NEXT_VERSION-dev" || die 'git commit failed'
+}
 ##################################
 # Switch to top minetest directory
 ##################################
@@ -39,85 +82,54 @@ VERSION_MINOR=$(grep -E '^set\(VERSION_MINOR [0-9]+\)$' CMakeLists.txt | tr -dC 
 VERSION_PATCH=$(grep -E '^set\(VERSION_PATCH [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)
 ANDROID_VERSION_CODE=$(grep -E 'versionCode [0-9]+$' build/android/build.gradle | tr -dC 0-9)
 
-echo "Current Minetest version: $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
+RELEASE_VERSION="$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
+
+echo "Current Minetest version: $RELEASE_VERSION"
 echo "Current Android version code: $ANDROID_VERSION_CODE"
-
-
-########################
-# Prompt for new version
-########################
-
-NEW_VERSION_MAJOR=$VERSION_MAJOR
-NEW_VERSION_MINOR=$VERSION_MINOR
-NEW_VERSION_PATCH=$(expr $VERSION_PATCH + 1)
-
-NEW_VERSION_MAJOR=$(prompt_for_number "Set major" $NEW_VERSION_MAJOR)
-
-if [ "$NEW_VERSION_MAJOR" != "$VERSION_MAJOR" ]; then
-	NEW_VERSION_MINOR=0
-	NEW_VERSION_PATCH=0
-fi
-
-NEW_VERSION_MINOR=$(prompt_for_number "Set minor" $NEW_VERSION_MINOR)
-
-if [ "$NEW_VERSION_MINOR" != "$VERSION_MINOR" ]; then
-	NEW_VERSION_PATCH=0
-fi
-
-NEW_VERSION_PATCH=$(prompt_for_number "Set patch" $NEW_VERSION_PATCH)
 
 NEW_ANDROID_VERSION_CODE=$(expr $ANDROID_VERSION_CODE + 1)
 NEW_ANDROID_VERSION_CODE=$(prompt_for_number "Set android version code" $NEW_ANDROID_VERSION_CODE)
 
-NEW_VERSION="$NEW_VERSION_MAJOR.$NEW_VERSION_MINOR.$NEW_VERSION_PATCH"
-
-
 echo
-echo "New version: $NEW_VERSION"
 echo "New android version code: $NEW_ANDROID_VERSION_CODE"
 
+########################
+# Perform release
+########################
 
-#######################################
-# Replace version everywhere and commit
-#######################################
+perform_release
 
-sed -i -re "s/^set\(VERSION_MAJOR [0-9]+\)$/set(VERSION_MAJOR $NEW_VERSION_MAJOR)/" CMakeLists.txt || die "Failed to update VERSION_MAJOR"
+########################
+# Prompt for next version
+########################
 
-sed -i -re "s/^set\(VERSION_MINOR [0-9]+\)$/set(VERSION_MINOR $NEW_VERSION_MINOR)/" CMakeLists.txt || die "Failed to update VERSION_MINOR"
+NEXT_VERSION_MAJOR=$VERSION_MAJOR
+NEXT_VERSION_MINOR=$VERSION_MINOR
+NEXT_VERSION_PATCH=$(expr $VERSION_PATCH + 1)
 
-sed -i -re "s/^set\(VERSION_PATCH [0-9]+\)$/set(VERSION_PATCH $NEW_VERSION_PATCH)/" CMakeLists.txt || die "Failed to update VERSION_PATCH"
+NEXT_VERSION_MAJOR=$(prompt_for_number "Set next major" $NEXT_VERSION_MAJOR)
 
-sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt || die "Failed to unset DEVELOPMENT_BUILD"
+if [ "$NEXT_VERSION_MAJOR" != "$VERSION_MAJOR" ]; then
+	NEXT_VERSION_MINOR=0
+	NEXT_VERSION_PATCH=0
+fi
 
-sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle || die "Failed to update Android version code"
+NEXT_VERSION_MINOR=$(prompt_for_number "Set next minor" $NEXT_VERSION_MINOR)
 
-sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" doc/lua_api.txt || die "Failed to update doc/lua_api.txt"
+if [ "$NEXT_VERSION_MINOR" != "$VERSION_MINOR" ]; then
+	NEXT_VERSION_PATCH=0
+fi
 
-sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" doc/menu_lua_api.txt || die "Failed to update doc/menu_lua_api.txt"
+NEXT_VERSION_PATCH=$(prompt_for_number "Set next patch" $NEXT_VERSION_PATCH)
 
-sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEW_VERSION/g" doc/client_lua_api.md || die "Failed to update doc/client_lua_api.md"
+NEXT_VERSION="$NEXT_VERSION_MAJOR.$NEXT_VERSION_MINOR.$NEXT_VERSION_PATCH"
 
-git add -f CMakeLists.txt build/android/build.gradle doc/lua_api.txt doc/menu_lua_api.txt doc/client_lua_api.md || die "git add failed"
+echo
+echo "New version: $NEXT_VERSION"
 
-git commit -m "Bump version to $NEW_VERSION" || die "git commit failed"
+########################
+# Return back to devel
+########################
 
-############
-# Create tag
-############
-
-echo "Tagging $NEW_VERSION"
-
-git tag -a "$NEW_VERSION" -m "$NEW_VERSION" || die 'Adding tag failed'
-
-######################
-# Create revert commit
-######################
-
-echo 'Creating "revert to development" commit'
-
-sed -i -re 's/^set\(DEVELOPMENT_BUILD FALSE\)$/set(DEVELOPMENT_BUILD TRUE)/' CMakeLists.txt || die 'Failed to set DEVELOPMENT_BUILD'
-
-git add -f CMakeLists.txt || die 'git add failed'
-
-git commit -m "Continue with $NEW_VERSION-dev" || die 'git commit failed'
+back_to_devel
 

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-die() { echo "$@" 1>&2 ; exit 1; }
+#!/bin/bash -e
 
 prompt_for_number() {
 	local prompt_text=$1
@@ -22,17 +20,17 @@ prompt_for_number() {
 # * Commit the changes
 # * Tag with current version
 perform_release() {
-	sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt || die "Failed to unset DEVELOPMENT_BUILD"
+	sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt
 
-	sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle || die "Failed to update Android version code"
+	sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle
 
-	git add -f CMakeLists.txt build/android/build.gradle || die "git add failed"
+	git add -f CMakeLists.txt build/android/build.gradle
 
-	git commit -m "Bump version to $RELEASE_VERSION" || die "git commit failed"
+	git commit -m "Bump version to $RELEASE_VERSION"
 
 	echo "Tagging $RELEASE_VERSION"
 
-	git tag -a "$RELEASE_VERSION" -m "$RELEASE_VERSION" || die 'Adding tag failed'
+	git tag -a "$RELEASE_VERSION" -m "$RELEASE_VERSION"
 }
 
 # After release
@@ -42,23 +40,23 @@ perform_release() {
 back_to_devel() {
 	echo 'Creating "return back to development" commit'
 
-	sed -i -re 's/^set\(DEVELOPMENT_BUILD FALSE\)$/set(DEVELOPMENT_BUILD TRUE)/' CMakeLists.txt || die 'Failed to set DEVELOPMENT_BUILD'
+	sed -i -re 's/^set\(DEVELOPMENT_BUILD FALSE\)$/set(DEVELOPMENT_BUILD TRUE)/' CMakeLists.txt
 
-	sed -i -re "s/^set\(VERSION_MAJOR [0-9]+\)$/set(VERSION_MAJOR $NEXT_VERSION_MAJOR)/" CMakeLists.txt || die "Failed to update VERSION_MAJOR"
+	sed -i -re "s/^set\(VERSION_MAJOR [0-9]+\)$/set(VERSION_MAJOR $NEXT_VERSION_MAJOR)/" CMakeLists.txt
 
-	sed -i -re "s/^set\(VERSION_MINOR [0-9]+\)$/set(VERSION_MINOR $NEXT_VERSION_MINOR)/" CMakeLists.txt || die "Failed to update VERSION_MINOR"
+	sed -i -re "s/^set\(VERSION_MINOR [0-9]+\)$/set(VERSION_MINOR $NEXT_VERSION_MINOR)/" CMakeLists.txt
 
-	sed -i -re "s/^set\(VERSION_PATCH [0-9]+\)$/set(VERSION_PATCH $NEXT_VERSION_PATCH)/" CMakeLists.txt || die "Failed to update VERSION_PATCH"
+	sed -i -re "s/^set\(VERSION_PATCH [0-9]+\)$/set(VERSION_PATCH $NEXT_VERSION_PATCH)/" CMakeLists.txt
 
-	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/lua_api.txt || die "Failed to update doc/lua_api.txt"
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/lua_api.txt
 
-	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/menu_lua_api.txt || die "Failed to update doc/menu_lua_api.txt"
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/menu_lua_api.txt
 
-	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/client_lua_api.md || die "Failed to update doc/client_lua_api.md"
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/client_lua_api.md
 
-	git add -f CMakeLists.txt doc/lua_api.txt doc/menu_lua_api.txt doc/client_lua_api.md || die 'git add failed'
+	git add -f CMakeLists.txt doc/lua_api.txt doc/menu_lua_api.txt doc/client_lua_api.md
 
-	git commit -m "Continue with $NEXT_VERSION-dev" || die 'git commit failed'
+	git commit -m "Continue with $NEXT_VERSION-dev"
 }
 ##################################
 # Switch to top minetest directory
@@ -72,10 +70,10 @@ cd ${0%/*}/..
 #######################
 
 # Make sure all the files we need exist
-grep -q -E '^set\(VERSION_MAJOR [0-9]+\)$' CMakeLists.txt || die "error: Could not find CMakeLists.txt"
-grep -q -E '^set\(VERSION_MINOR [0-9]+\)$' CMakeLists.txt || die "error: Could not find CMakeLists.txt"
-grep -q -E '^set\(VERSION_PATCH [0-9]+\)$' CMakeLists.txt || die "error: Could not find CMakeLists.txt"
-grep -q -E 'versionCode [0-9]+$' build/android/build.gradle || die "error: Could not find Android version code"
+grep -q -E '^set\(VERSION_MAJOR [0-9]+\)$' CMakeLists.txt
+grep -q -E '^set\(VERSION_MINOR [0-9]+\)$' CMakeLists.txt
+grep -q -E '^set\(VERSION_PATCH [0-9]+\)$' CMakeLists.txt
+grep -q -E 'versionCode [0-9]+$' build/android/build.gradle
 
 VERSION_MAJOR=$(grep -E '^set\(VERSION_MAJOR [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)
 VERSION_MINOR=$(grep -E '^set\(VERSION_MINOR [0-9]+\)$' CMakeLists.txt | tr -dC 0-9)


### PR DESCRIPTION
I pushed the two result commits for a release as a proof of concept

Here is the console log

```
> ./util/bump_version.sh 
Current Minetest version: 0.5.0
Current Android version code: 17
Set android version code [18]:

New android version code: 18
[new_version_scheme bac8b86e7] Bump version to 0.5.0
 2 files changed, 2 insertions(+), 2 deletions(-)
Tagging 0.5.0
Set next major [0]:
Set next minor [5]:
Set next patch [1]:

New version: 0.5.1
Creating "return back to development" commit
[new_version_scheme f7ce591c6] Continue with 0.5.1-dev
 4 files changed, 5 insertions(+), 5 deletions(-)
```