### PR TITLE
Fix OSX builds caused by __WORDSIZE again

### DIFF
--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -19,8 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include <ISceneManager.h>
 #include "environment.h"
+#include <ISceneManager.h>
 #include "clientobject.h"
 #include "util/numeric.h"
 


### PR DESCRIPTION
We need to find a better way to do this. But since even Irrlicht developers don't know how to fix it correctly, I don't know what to do.