### PR TITLE
MSVC: Dont define min/max macros in minwindef.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,8 @@ if(WIN32)
 		add_definitions ( /D "_CRT_SECURE_NO_DEPRECATE" /W1 )
 		# Get M_PI to work
 		add_definitions(/D "_USE_MATH_DEFINES")
+		# Dont define min/max macros in minwindef.h
+		add_definitions(/D "NOMINMAX")
 	else() # Probably MinGW = GCC
 		set(PLATFORM_LIBS "")
 	endif()


### PR DESCRIPTION
I cant tell if this was introduced due to the latest Visual Studio update, or if this was caused by the cleanups of @nerzhul .

In minwindef.h (included by Windows.h) are macros defined for `min` and `max` that conflicting with `std::min`/`std::max` since today. Defining `NOMINMAX` disables the definition of them.