### PR TITLE
Add '@n' escape sequences and some documentation on translated strings.

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -704,6 +704,8 @@ function core.translate(textdomain, str, ...)
 			end
 			arg_index = arg_index + 1
 			return ESCAPE_CHAR .. "F" .. arg[a] .. ESCAPE_CHAR .. "E"
+		elseif matched == "n" then
+			return "\n"
 		else
 			return matched
 		end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2195,6 +2195,15 @@ Two functions are provided to translate strings: `minetest.translate` and `minet
 
   this will be displayed as "Laine Rouge" on clients with a French locale.
 
+### Operations on translated strings
+
+The output of `minetest.translate` is a string, with escape sequences adding additional information to that string
+so that it can be translated on the different clients. In particular, you can't expect operations like string.length
+to work on them like you would expect them to, or string.gsub to work in the expected manner. However, string
+concatenation will still work as expected (note that you should only use this for things like formspecs; if you are
+using this to translate sentences by breaking them into parts, then you should use arguments instead), and operations
+such as `minetest.colorize` which are only concatenation under the hood as well.
+
 ### Translation file format
 A translation file has the suffix `.[lang].tr`, where `[lang]` is the language it corresponds to.
 The file should be a text file, with the following format:
@@ -2217,6 +2226,7 @@ Strings that need to be translated can contain several escapes, preceded by `@`.
   files to avoid begin confused with the `=` separating the original from the translation.
 * `@\n` (where the `\n` is a literal newline) acts as a literal newline. As with `@=`, this escape is not required
   in strings given to `minetest.translate`, but is in translation files.
+* `@n` acts as a literal newline as well.
 
 `minetest` namespace reference
 ------------------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2200,9 +2200,9 @@ Two functions are provided to translate strings: `minetest.translate` and `minet
 The output of `minetest.translate` is a string, with escape sequences adding additional information to that string
 so that it can be translated on the different clients. In particular, you can't expect operations like string.length
 to work on them like you would expect them to, or string.gsub to work in the expected manner. However, string
-concatenation will still work as expected (note that you should only use this for things like formspecs; if you are
-using this to translate sentences by breaking them into parts, then you should use arguments instead), and operations
-such as `minetest.colorize` which are only concatenation under the hood as well.
+concatenation will still work as expected (note that you should only use this for things like formspecs; do not
+translate sentences by breaking them into parts; arguments should be used instead), and operations such as
+`minetest.colorize` which are only concatenation under the hood as well.
 
 ### Translation file format
 A translation file has the suffix `.[lang].tr`, where `[lang]` is the language it corresponds to.

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -80,6 +80,8 @@ void Translations::loadTranslation(const std::string &data)
 				if (i + 1 < wline.length()) {
 					if (wline[i + 1] == L'=') {
 						word1.put(L'=');
+					} else if (wline[i + 1] == L'n') {
+						word1.put(L'\n');
 					} else {
 						word1.put(L'@');
 						word1.put(wline[i + 1]);
@@ -113,6 +115,8 @@ void Translations::loadTranslation(const std::string &data)
 				if (i + 1 < wline.length()) {
 					if (wline[i + 1] == L'=') {
 						word2.put(L'=');
+					} else if (wline[i + 1] == L'n') {
+						word2.put(L'\n');
 					} else {
 						word2.put(L'@');
 						word2.put(wline[i + 1]);


### PR DESCRIPTION
This adds `@n` escape sequences that can be used instead of `@<literal newline>` in translation strings,  and clarifies the use of the output values of translated strings.