### PR TITLE
Network breakage: Send real floats

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -300,8 +300,6 @@ void GenericCAO::initialize(const std::string &data)
 			m_is_visible = false;
 			player->setCAO(this);
 		}
-		if (m_client->getProtoVersion() < 33)
-			m_env->addPlayerName(m_name);
 	}
 }
 
@@ -337,9 +335,6 @@ void GenericCAO::processInitData(const std::string &data)
 
 GenericCAO::~GenericCAO()
 {
-	if (m_is_player && m_client->getProtoVersion() < 33) {
-		m_env->removePlayerName(m_name);
-	}
 	removeFromScene(true);
 }
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -316,8 +316,8 @@ void GenericCAO::processInitData(const std::string &data)
 		m_name = deSerializeString(is);
 		m_is_player = readU8(is);
 		m_id = readU16(is);
-		m_position = readV3F1000(is);
-		m_yaw = readF1000(is);
+		m_position = readV3F32(is);
+		m_yaw = readF32(is);
 		m_hp = readS16(is);
 		num_messages = readU8(is);
 	} else {
@@ -1253,16 +1253,16 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == GENERIC_CMD_UPDATE_POSITION) {
 		// Not sent by the server if this object is an attachment.
 		// We might however get here if the server notices the object being detached before the client.
-		m_position = readV3F1000(is);
-		m_velocity = readV3F1000(is);
-		m_acceleration = readV3F1000(is);
+		m_position = readV3F32(is);
+		m_velocity = readV3F32(is);
+		m_acceleration = readV3F32(is);
 		if(fabs(m_prop.automatic_rotate) < 0.001)
-			m_yaw = readF1000(is);
+			m_yaw = readF32(is);
 		else
-			readF1000(is);
+			readF32(is);
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
-		float update_interval = readF1000(is);
+		float update_interval = readF32(is);
 
 		// Place us a bit higher if we're physical, to not sink into
 		// the ground due to sucky collision detection...
@@ -1292,7 +1292,7 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == GENERIC_CMD_SET_SPRITE) {
 		v2s16 p = readV2S16(is);
 		int num_frames = readU16(is);
-		float framelength = readF1000(is);
+		float framelength = readF32(is);
 		bool select_horiz_by_yawpitch = readU8(is);
 
 		m_tx_basepos = p;
@@ -1302,9 +1302,9 @@ void GenericCAO::processMessage(const std::string &data)
 
 		updateTexturePos();
 	} else if (cmd == GENERIC_CMD_SET_PHYSICS_OVERRIDE) {
-		float override_speed = readF1000(is);
-		float override_jump = readF1000(is);
-		float override_gravity = readF1000(is);
+		float override_speed = readF32(is);
+		float override_jump = readF32(is);
+		float override_gravity = readF32(is);
 		// these are sent inverted so we get true when the server sends nothing
 		bool sneak = !readU8(is);
 		bool sneak_glitch = !readU8(is);
@@ -1323,11 +1323,11 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 	} else if (cmd == GENERIC_CMD_SET_ANIMATION) {
 		// TODO: change frames send as v2s32 value
-		v2f range = readV2F1000(is);
+		v2f range = readV2F32(is);
 		if (!m_is_local_player) {
 			m_animation_range = v2s32((s32)range.X, (s32)range.Y);
-			m_animation_speed = readF1000(is);
-			m_animation_blend = readF1000(is);
+			m_animation_speed = readF32(is);
+			m_animation_blend = readF32(is);
 			// these are sent inverted so we get true when the server sends nothing
 			m_animation_loop = !readU8(is);
 			updateAnimation();
@@ -1336,8 +1336,8 @@ void GenericCAO::processMessage(const std::string &data)
 			if(player->last_animation == NO_ANIM)
 			{
 				m_animation_range = v2s32((s32)range.X, (s32)range.Y);
-				m_animation_speed = readF1000(is);
-				m_animation_blend = readF1000(is);
+				m_animation_speed = readF32(is);
+				m_animation_blend = readF32(is);
 				// these are sent inverted so we get true when the server sends nothing
 				m_animation_loop = !readU8(is);
 			}
@@ -1357,8 +1357,8 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 	} else if (cmd == GENERIC_CMD_SET_BONE_POSITION) {
 		std::string bone = deSerializeString(is);
-		v3f position = readV3F1000(is);
-		v3f rotation = readV3F1000(is);
+		v3f position = readV3F32(is);
+		v3f rotation = readV3F32(is);
 		m_bone_position[bone] = core::vector2d<v3f>(position, rotation);
 
 		updateBonePosition();
@@ -1377,8 +1377,8 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 
 		m_attachment_bone = deSerializeString(is);
-		m_attachment_position = readV3F1000(is);
-		m_attachment_rotation = readV3F1000(is);
+		m_attachment_position = readV3F32(is);
+		m_attachment_rotation = readV3F32(is);
 
 		// localplayer itself can't be attached to localplayer
 		if (!m_is_local_player) {

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -293,8 +293,8 @@ ServerActiveObject* LuaEntitySAO::create(ServerEnvironment *env, v3f pos,
 			name = deSerializeString(is);
 			state = deSerializeLongString(is);
 			hp = readS16(is);
-			velocity = readV3F1000(is);
-			yaw = readF1000(is);
+			velocity = readV3F32(is);
+			yaw = readF32(is);
 		}
 	}
 	// create object
@@ -470,8 +470,8 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 	os << serializeString(""); // name
 	writeU8(os, 0); // is_player
 	writeS16(os, getId()); //id
-	writeV3F1000(os, m_base_position);
-	writeF1000(os, m_yaw);
+	writeV3F32(os, m_base_position);
+	writeF32(os, m_yaw);
 	writeS16(os, m_hp);
 
 	std::ostringstream msg_os(std::ios::binary);
@@ -525,9 +525,9 @@ void LuaEntitySAO::getStaticData(std::string *result) const
 	// hp
 	writeS16(os, m_hp);
 	// velocity
-	writeV3F1000(os, m_velocity);
+	writeV3F32(os, m_velocity);
 	// yaw
-	writeF1000(os, m_yaw);
+	writeF32(os, m_yaw);
 	*result = os.str();
 }
 
@@ -859,8 +859,8 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 	os << serializeString(m_player->getName()); // name
 	writeU8(os, 1); // is_player
 	writeS16(os, getId()); //id
-	writeV3F1000(os, m_base_position);
-	writeF1000(os, m_yaw);
+	writeV3F32(os, m_base_position);
+	writeF32(os, m_yaw);
 	writeS16(os, getHP());
 
 	std::ostringstream msg_os(std::ios::binary);

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -49,19 +49,19 @@ std::string gob_cmd_update_position(
 	// command
 	writeU8(os, GENERIC_CMD_UPDATE_POSITION);
 	// pos
-	writeV3F1000(os, position);
+	writeV3F32(os, position);
 	// velocity
-	writeV3F1000(os, velocity);
+	writeV3F32(os, velocity);
 	// acceleration
-	writeV3F1000(os, acceleration);
+	writeV3F32(os, acceleration);
 	// yaw
-	writeF1000(os, yaw);
+	writeF32(os, yaw);
 	// do_interpolate
 	writeU8(os, do_interpolate);
 	// is_end_position (for interpolation)
 	writeU8(os, is_movement_end);
 	// update_interval (for interpolation)
-	writeF1000(os, update_interval);
+	writeF32(os, update_interval);
 	return os.str();
 }
 
@@ -87,7 +87,7 @@ std::string gob_cmd_set_sprite(
 	// parameters
 	writeV2S16(os, p);
 	writeU16(os, num_frames);
-	writeF1000(os, framelength);
+	writeF32(os, framelength);
 	writeU8(os, select_horiz_by_yawpitch);
 	return os.str();
 }
@@ -123,9 +123,9 @@ std::string gob_cmd_update_physics_override(float physics_override_speed, float 
 	// command
 	writeU8(os, GENERIC_CMD_SET_PHYSICS_OVERRIDE);
 	// parameters
-	writeF1000(os, physics_override_speed);
-	writeF1000(os, physics_override_jump);
-	writeF1000(os, physics_override_gravity);
+	writeF32(os, physics_override_speed);
+	writeF32(os, physics_override_jump);
+	writeF32(os, physics_override_gravity);
 	// these are sent inverted so we get true when the server sends nothing
 	writeU8(os, !sneak);
 	writeU8(os, !sneak_glitch);
@@ -139,9 +139,9 @@ std::string gob_cmd_update_animation(v2f frames, float frame_speed, float frame_
 	// command
 	writeU8(os, GENERIC_CMD_SET_ANIMATION);
 	// parameters
-	writeV2F1000(os, frames);
-	writeF1000(os, frame_speed);
-	writeF1000(os, frame_blend);
+	writeV2F32(os, frames);
+	writeF32(os, frame_speed);
+	writeF32(os, frame_blend);
 	// these are sent inverted so we get true when the server sends nothing
 	writeU8(os, !frame_loop);
 	return os.str();
@@ -155,8 +155,8 @@ std::string gob_cmd_update_bone_position(const std::string &bone, v3f position,
 	writeU8(os, GENERIC_CMD_SET_BONE_POSITION);
 	// parameters
 	os<<serializeString(bone);
-	writeV3F1000(os, position);
-	writeV3F1000(os, rotation);
+	writeV3F32(os, position);
+	writeV3F32(os, rotation);
 	return os.str();
 }
 
@@ -169,8 +169,8 @@ std::string gob_cmd_update_attachment(int parent_id, const std::string &bone,
 	// parameters
 	writeS16(os, parent_id);
 	os<<serializeString(bone);
-	writeV3F1000(os, position);
-	writeV3F1000(os, rotation);
+	writeV3F32(os, position);
+	writeV3F32(os, rotation);
 	return os.str();
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -956,11 +956,11 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	std::string datastring(pkt->getString(0), pkt->getSize());
 	std::istringstream is(datastring, std::ios_base::binary);
 
-	v3f pos                 = readV3F1000(is);
-	v3f vel                 = readV3F1000(is);
-	v3f acc                 = readV3F1000(is);
-	float expirationtime    = readF1000(is);
-	float size              = readF1000(is);
+	v3f pos                 = readV3F32(is);
+	v3f vel                 = readV3F32(is);
+	v3f acc                 = readV3F32(is);
+	float expirationtime    = readF32(is);
+	float size              = readF32(is);
 	bool collisiondetection = readU8(is);
 	std::string texture     = deSerializeLongString(is);
 	bool vertical           = false;

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -285,7 +285,7 @@ NetworkPacket& NetworkPacket::operator<<(float src)
 {
 	checkDataSize(4);
 
-	writeF1000(&m_data[m_read_offset], src);
+	writeF32(&m_data[m_read_offset], src);
 
 	m_read_offset += 4;
 	return *this;
@@ -380,7 +380,7 @@ NetworkPacket& NetworkPacket::operator>>(float& dst)
 {
 	checkReadOffset(m_read_offset, 4);
 
-	dst = readF1000(&m_data[m_read_offset]);
+	dst = readF32(&m_data[m_read_offset]);
 
 	m_read_offset += 4;
 	return *this;
@@ -390,7 +390,7 @@ NetworkPacket& NetworkPacket::operator>>(v2f& dst)
 {
 	checkReadOffset(m_read_offset, 8);
 
-	dst = readV2F1000(&m_data[m_read_offset]);
+	dst = readV2F32(&m_data[m_read_offset]);
 
 	m_read_offset += 8;
 	return *this;
@@ -400,7 +400,7 @@ NetworkPacket& NetworkPacket::operator>>(v3f& dst)
 {
 	checkReadOffset(m_read_offset, 12);
 
-	dst = readV3F1000(&m_data[m_read_offset]);
+	dst = readV3F32(&m_data[m_read_offset]);
 
 	m_read_offset += 12;
 	return *this;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -176,18 +176,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			position
 		Add settable player stepheight using existing object property.
 			Breaks compatibility with older clients.
+	PROTOCOL VERSION 36:
+		Send real floats in network packets
+		Backwards compability drop
 */
 
-#define LATEST_PROTOCOL_VERSION 35
+#define LATEST_PROTOCOL_VERSION 36
 
 // Server's supported network protocol range
-#define SERVER_PROTOCOL_VERSION_MIN 24
+#define SERVER_PROTOCOL_VERSION_MIN 36
 #define SERVER_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Client's supported network protocol range
 // The minimal version depends on whether
 // send_pre_v25_init is enabled or not
-#define CLIENT_PROTOCOL_VERSION_MIN 25
+#define CLIENT_PROTOCOL_VERSION_MIN 36
 #define CLIENT_PROTOCOL_VERSION_MIN_LEGACY 24
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -220,7 +220,7 @@ enum ToClientCommand
 
 		v3s16 player's position + v3f(0,BS/2,0) floatToInt'd
 		u64 map seed
-		f1000 recommended send interval
+		f32 recommended send interval
 		u32 : supported auth methods for sudo mode
 		      (where the user can change their password)
 	*/
@@ -241,7 +241,7 @@ enum ToClientCommand
 		[2] u8 deployed version
 		[3] v3s16 player's position + v3f(0,BS/2,0) floatToInt'd
 		[12] u64 map seed (new as of 2011-02-27)
-		[20] f1000 recommended send interval (in seconds) (new as of 14)
+		[20] f32 recommended send interval (in seconds) (new as of 14)
 
 		NOTE: The position in here is deprecated; position is
 		      explicitly sent afterwards
@@ -318,7 +318,7 @@ enum ToClientCommand
 	/*
 		u16 time (0-23999)
 		Added in a later version:
-		f1000 time_speed
+		f32 time_speed
 	*/
 
 	TOCLIENT_CSM_FLAVOUR_LIMITS = 0x2A,
@@ -376,9 +376,9 @@ enum ToClientCommand
 
 	TOCLIENT_MOVE_PLAYER = 0x34,
 	/*
-		v3f1000 player position
-		f1000 player pitch
-		f1000 player yaw
+		v3f32 player position
+		f32 player pitch
+		f32 player yaw
 	*/
 
 	TOCLIENT_ACCESS_DENIED_LEGACY = 0x35,
@@ -400,7 +400,7 @@ enum ToClientCommand
 	TOCLIENT_DEATHSCREEN = 0x37,
 	/*
 		u8 bool set camera point target
-		v3f1000 camera point target (to point the death cause or whatever)
+		v3f32 camera point target (to point the death cause or whatever)
 	*/
 
 	TOCLIENT_MEDIA = 0x38,
@@ -504,27 +504,27 @@ enum ToClientCommand
 
 	TOCLIENT_MOVEMENT = 0x45,
 	/*
-		f1000 movement_acceleration_default
-		f1000 movement_acceleration_air
-		f1000 movement_acceleration_fast
-		f1000 movement_speed_walk
-		f1000 movement_speed_crouch
-		f1000 movement_speed_fast
-		f1000 movement_speed_climb
-		f1000 movement_speed_jump
-		f1000 movement_liquid_fluidity
-		f1000 movement_liquid_fluidity_smooth
-		f1000 movement_liquid_sink
-		f1000 movement_gravity
+		f32 movement_acceleration_default
+		f32 movement_acceleration_air
+		f32 movement_acceleration_fast
+		f32 movement_speed_walk
+		f32 movement_speed_crouch
+		f32 movement_speed_fast
+		f32 movement_speed_climb
+		f32 movement_speed_jump
+		f32 movement_liquid_fluidity
+		f32 movement_liquid_fluidity_smooth
+		f32 movement_liquid_sink
+		f32 movement_gravity
 	*/
 
 	TOCLIENT_SPAWN_PARTICLE = 0x46,
 	/*
-		v3f1000 pos
-		v3f1000 velocity
-		v3f1000 acceleration
-		f1000 expirationtime
-		f1000 size
+		v3f32 pos
+		v3f32 velocity
+		v3f32 acceleration
+		f32 expirationtime
+		f32 size
 		u8 bool collisiondetection
 		u8 bool vertical
 		u32 len
@@ -535,17 +535,17 @@ enum ToClientCommand
 	TOCLIENT_ADD_PARTICLESPAWNER = 0x47,
 	/*
 		u16 amount
-		f1000 spawntime
-		v3f1000 minpos
-		v3f1000 maxpos
-		v3f1000 minvel
-		v3f1000 maxvel
-		v3f1000 minacc
-		v3f1000 maxacc
-		f1000 minexptime
-		f1000 maxexptime
-		f1000 minsize
-		f1000 maxsize
+		f32 spawntime
+		v3f32 minpos
+		v3f32 maxpos
+		v3f32 minvel
+		v3f32 maxvel
+		v3f32 minacc
+		v3f32 maxacc
+		f32 minexptime
+		f32 maxexptime
+		f32 minsize
+		f32 maxsize
 		u8 bool collisiondetection
 		u8 bool vertical
 		u32 len
@@ -563,18 +563,18 @@ enum ToClientCommand
 	/*
 		u32 id
 		u8 type
-		v2f1000 pos
+		v2f32 pos
 		u32 len
 		u8[len] name
-		v2f1000 scale
+		v2f32 scale
 		u32 len2
 		u8[len2] text
 		u32 number
 		u32 item
 		u32 dir
-		v2f1000 align
-		v2f1000 offset
-		v3f1000 world_pos
+		v2f32 align
+		v2f32 offset
+		v3f32 world_pos
 		v2s32 size
 	*/
 
@@ -587,7 +587,7 @@ enum ToClientCommand
 	/*
 		u32 id
 		u8 stat
-		[v2f1000 data |
+		[v2f32 data |
 		 u32 len
 		 u8[len] data |
 		 u32 data]
@@ -635,13 +635,13 @@ enum ToClientCommand
 		v2s32 walk
 		v2s32 dig
 		v2s32 walk+dig
-		f1000 frame_speed
+		f32 frame_speed
 	*/
 
 	TOCLIENT_EYE_OFFSET = 0x52,
 	/*
-		v3f1000 first
-		v3f1000 third
+		v3f32 first
+		v3f32 third
 	*/
 
 	TOCLIENT_DELETE_PARTICLESPAWNER = 0x53,
@@ -651,12 +651,12 @@ enum ToClientCommand
 
 	TOCLIENT_CLOUD_PARAMS = 0x54,
 	/*
-		f1000 density
+		f32 density
 		u8[4] color_diffuse (ARGB)
 		u8[4] color_ambient (ARGB)
-		f1000 height
-		f1000 thickness
-		v2f1000 speed
+		f32 height
+		f32 thickness
+		v2f32 speed
 	*/
 
 	TOCLIENT_FADE_SOUND = 0x55,

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -63,63 +63,48 @@ void NodeBox::reset()
 
 void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 {
-	// Protocol >= 21
-	int version = 2;
-	if (protocol_version >= 27)
-		version = 3;
+	// Protocol >= 36
+	int version = 4;
 	writeU8(os, version);
 
 	switch (type) {
 	case NODEBOX_LEVELED:
 	case NODEBOX_FIXED:
-		if (version == 1)
-			writeU8(os, NODEBOX_FIXED);
-		else
-			writeU8(os, type);
+		writeU8(os, type);
 
 		writeU16(os, fixed.size());
 		for (const aabb3f &nodebox : fixed) {
-			writeV3F1000(os, nodebox.MinEdge);
-			writeV3F1000(os, nodebox.MaxEdge);
+			writeV3F32(os, nodebox.MinEdge);
+			writeV3F32(os, nodebox.MaxEdge);
 		}
 		break;
 	case NODEBOX_WALLMOUNTED:
 		writeU8(os, type);
 
-		writeV3F1000(os, wall_top.MinEdge);
-		writeV3F1000(os, wall_top.MaxEdge);
-		writeV3F1000(os, wall_bottom.MinEdge);
-		writeV3F1000(os, wall_bottom.MaxEdge);
-		writeV3F1000(os, wall_side.MinEdge);
-		writeV3F1000(os, wall_side.MaxEdge);
+		writeV3F32(os, wall_top.MinEdge);
+		writeV3F32(os, wall_top.MaxEdge);
+		writeV3F32(os, wall_bottom.MinEdge);
+		writeV3F32(os, wall_bottom.MaxEdge);
+		writeV3F32(os, wall_side.MinEdge);
+		writeV3F32(os, wall_side.MaxEdge);
 		break;
 	case NODEBOX_CONNECTED:
-		if (version <= 2) {
-			// send old clients nodes that can't be walked through
-			// to prevent abuse
-			writeU8(os, NODEBOX_FIXED);
-
-			writeU16(os, 1);
-			writeV3F1000(os, v3f(-BS/2, -BS/2, -BS/2));
-			writeV3F1000(os, v3f(BS/2, BS/2, BS/2));
-		} else {
-			writeU8(os, type);
+		writeU8(os, type);
 
 #define WRITEBOX(box) \
 		writeU16(os, (box).size()); \
 		for (const aabb3f &i: (box)) { \
-			writeV3F1000(os, i.MinEdge); \
-			writeV3F1000(os, i.MaxEdge); \
+			writeV3F32(os, i.MinEdge); \
+			writeV3F32(os, i.MaxEdge); \
 		};
 
-			WRITEBOX(fixed);
-			WRITEBOX(connect_top);
-			WRITEBOX(connect_bottom);
-			WRITEBOX(connect_front);
-			WRITEBOX(connect_left);
-			WRITEBOX(connect_back);
-			WRITEBOX(connect_right);
-		}
+		WRITEBOX(fixed);
+		WRITEBOX(connect_top);
+		WRITEBOX(connect_bottom);
+		WRITEBOX(connect_front);
+		WRITEBOX(connect_left);
+		WRITEBOX(connect_back);
+		WRITEBOX(connect_right);
 		break;
 	default:
 		writeU8(os, type);
@@ -130,7 +115,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 void NodeBox::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if (version < 1 || version > 3)
+	if (version < 4 || version > 4)
 		throw SerializationError("unsupported NodeBox version");
 
 	reset();
@@ -143,19 +128,19 @@ void NodeBox::deSerialize(std::istream &is)
 		while(fixed_count--)
 		{
 			aabb3f box;
-			box.MinEdge = readV3F1000(is);
-			box.MaxEdge = readV3F1000(is);
+			box.MinEdge = readV3F32(is);
+			box.MaxEdge = readV3F32(is);
 			fixed.push_back(box);
 		}
 	}
 	else if(type == NODEBOX_WALLMOUNTED)
 	{
-		wall_top.MinEdge = readV3F1000(is);
-		wall_top.MaxEdge = readV3F1000(is);
-		wall_bottom.MinEdge = readV3F1000(is);
-		wall_bottom.MaxEdge = readV3F1000(is);
-		wall_side.MinEdge = readV3F1000(is);
-		wall_side.MaxEdge = readV3F1000(is);
+		wall_top.MinEdge = readV3F32(is);
+		wall_top.MaxEdge = readV3F32(is);
+		wall_bottom.MinEdge = readV3F32(is);
+		wall_bottom.MaxEdge = readV3F32(is);
+		wall_side.MinEdge = readV3F32(is);
+		wall_side.MaxEdge = readV3F32(is);
 	}
 	else if (type == NODEBOX_CONNECTED)
 	{
@@ -163,8 +148,8 @@ void NodeBox::deSerialize(std::istream &is)
 		count = readU16(is); \
 		(box).reserve(count); \
 		while (count--) { \
-			v3f min = readV3F1000(is); \
-			v3f max = readV3F1000(is); \
+			v3f min = readV3F32(is); \
+			v3f max = readV3F32(is); \
 			(box).emplace_back(min, max); }; }
 
 		u16 count;
@@ -185,58 +170,38 @@ void NodeBox::deSerialize(std::istream &is)
 
 void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version >= 30)
-		writeU8(os, 4);
-	else if (protocol_version >= 29)
-		writeU8(os, 3);
-	else if (protocol_version >= 26)
-		writeU8(os, 2);
-	else
-		writeU8(os, 1);
+	// protocol_version >= 36
+	u8 version = 5;
+	writeU8(os, version);
 
 	os << serializeString(name);
-	animation.serialize(os, protocol_version);
+	animation.serialize(os, version);
 	writeU8(os, backface_culling);
-	if (protocol_version >= 26) {
-		writeU8(os, tileable_horizontal);
-		writeU8(os, tileable_vertical);
-	}
-	if (protocol_version >= 30) {
-		writeU8(os, has_color);
-		if (has_color) {
-			writeU8(os, color.getRed());
-			writeU8(os, color.getGreen());
-			writeU8(os, color.getBlue());
-		}
+	writeU8(os, tileable_horizontal);
+	writeU8(os, tileable_vertical);
+	writeU8(os, has_color);
+	if (has_color) {
+		writeU8(os, color.getRed());
+		writeU8(os, color.getGreen());
+		writeU8(os, color.getBlue());
 	}
 }
 
-void TileDef::deSerialize(std::istream &is, const u8 contenfeatures_version, const NodeDrawType drawtype)
+void TileDef::deSerialize(std::istream &is,
+	const u8 contentfeatures_version, const NodeDrawType drawtype)
 {
 	int version = readU8(is);
 	name = deSerializeString(is);
-	animation.deSerialize(is, version >= 3 ? 29 : 26);
-	if (version >= 1)
-		backface_culling = readU8(is);
-	if (version >= 2) {
-		tileable_horizontal = readU8(is);
-		tileable_vertical = readU8(is);
+	animation.deSerialize(is, version);
+	backface_culling = readU8(is);
+	tileable_horizontal = readU8(is);
+	tileable_vertical = readU8(is);
+	has_color = readU8(is);
+	if (has_color) {
+		color.setRed(readU8(is));
+		color.setGreen(readU8(is));
+		color.setBlue(readU8(is));
 	}
-	if (version >= 4) {
-		has_color = readU8(is);
-		if (has_color) {
-			color.setRed(readU8(is));
-			color.setGreen(readU8(is));
-			color.setBlue(readU8(is));
-		}
-	}
-
-	if ((contenfeatures_version < 8) &&
-		((drawtype == NDT_MESH) ||
-		 (drawtype == NDT_FIRELIKE) ||
-		 (drawtype == NDT_LIQUID) ||
-		 (drawtype == NDT_PLANTLIKE)))
-		backface_culling = false;
 }
 
 
@@ -248,18 +213,15 @@ static void serializeSimpleSoundSpec(const SimpleSoundSpec &ss,
 		std::ostream &os, u8 version)
 {
 	os<<serializeString(ss.name);
-	writeF1000(os, ss.gain);
-
-	if (version >= 11)
-		writeF1000(os, ss.pitch);
+	writeF32(os, ss.gain);
+	writeF32(os, ss.pitch);
 }
-static void deSerializeSimpleSoundSpec(SimpleSoundSpec &ss, std::istream &is, u8 version)
+static void deSerializeSimpleSoundSpec(SimpleSoundSpec &ss,
+		std::istream &is, u8 version)
 {
 	ss.name = deSerializeString(is);
-	ss.gain = readF1000(is);
-
-	if (version >= 11)
-		ss.pitch = readF1000(is);
+	ss.gain = readF32(is);
+	ss.pitch = readF32(is);
 }
 
 void TextureSettings::readSettings()
@@ -377,13 +339,8 @@ void ContentFeatures::reset()
 
 void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version < 31) {
-		serializeOld(os, protocol_version);
-		return;
-	}
-
-	// version
-	u8 version = (protocol_version >= 34) ? 11 : 10;
+	// protocol_version >= 36
+	u8 version = 12;
 	writeU8(os, version);
 
 	// general
@@ -399,7 +356,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	// visual
 	writeU8(os, drawtype);
 	os << serializeString(mesh);
-	writeF1000(os, visual_scale);
+	writeF32(os, visual_scale);
 	writeU8(os, 6);
 	for (const TileDef &td : tiledef)
 		td.serialize(os, protocol_version);
@@ -486,12 +443,8 @@ void ContentFeatures::deSerialize(std::istream &is)
 {
 	// version detection
 	int version = readU8(is);
-	if (version < 9) {
-		deSerializeOld(is, version);
-		return;
-	}
 
-	if (version > 11) {
+	if (version < 12 || version > 12) {
 		throw SerializationError("unsupported ContentFeatures version");
 	}
 
@@ -510,14 +463,13 @@ void ContentFeatures::deSerialize(std::istream &is)
 	// visual
 	drawtype = (enum NodeDrawType) readU8(is);
 	mesh = deSerializeString(is);
-	visual_scale = readF1000(is);
+	visual_scale = readF32(is);
 	if (readU8(is) != 6)
 		throw SerializationError("unsupported tile count");
 	for (TileDef &td : tiledef)
 		td.deSerialize(is, version, drawtype);
-	if (version >= 10)
-		for (TileDef &td : tiledef_overlay)
-			td.deSerialize(is, version, drawtype);
+	for (TileDef &td : tiledef_overlay)
+		td.deSerialize(is, version, drawtype);
 	if (readU8(is) != CF_SPECIAL_COUNT)
 		throw SerializationError("unsupported CF_SPECIAL_COUNT");
 	for (TileDef &td : tiledef_special)
@@ -1530,282 +1482,6 @@ void CNodeDefManager::addNameIdMapping(content_t i, std::string name)
 IWritableNodeDefManager *createNodeDefManager()
 {
 	return new CNodeDefManager();
-}
-
-
-//// Serialization of old ContentFeatures formats
-void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
-{
-	u8 compatible_param_type_2 = param_type_2;
-	if ((protocol_version < 28)
-			&& (compatible_param_type_2 == CPT2_MESHOPTIONS))
-		compatible_param_type_2 = CPT2_NONE;
-	else if (protocol_version < 30) {
-		if (compatible_param_type_2 == CPT2_COLOR)
-			compatible_param_type_2 = CPT2_NONE;
-		else if (compatible_param_type_2 == CPT2_COLORED_FACEDIR)
-			compatible_param_type_2 = CPT2_FACEDIR;
-		else if (compatible_param_type_2 == CPT2_COLORED_WALLMOUNTED)
-			compatible_param_type_2 = CPT2_WALLMOUNTED;
-	}
-
-	float compatible_visual_scale = visual_scale;
-	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
-		compatible_visual_scale = sqrt(visual_scale);
-
-	TileDef compatible_tiles[6];
-	for (u8 i = 0; i < 6; i++) {
-		compatible_tiles[i] = tiledef[i];
-		if (!tiledef_overlay[i].name.empty()) {
-			std::stringstream s;
-			s << "(" << tiledef[i].name << ")^(" << tiledef_overlay[i].name
-				<< ")";
-			compatible_tiles[i].name = s.str();
-		}
-	}
-
-	// Protocol >= 24
-	if (protocol_version < 31) {
-		writeU8(os, protocol_version < 27 ? 7 : 8);
-
-		os << serializeString(name);
-		writeU16(os, groups.size());
-		for (const auto &group : groups) {
-			os << serializeString(group.first);
-			writeS16(os, group.second);
-		}
-		writeU8(os, drawtype);
-		writeF1000(os, compatible_visual_scale);
-		writeU8(os, 6);
-		for (const auto &compatible_tile : compatible_tiles)
-			compatible_tile.serialize(os, protocol_version);
-		writeU8(os, CF_SPECIAL_COUNT);
-		for (const TileDef &i : tiledef_special)
-			i.serialize(os, protocol_version);
-		writeU8(os, alpha);
-		writeU8(os, post_effect_color.getAlpha());
-		writeU8(os, post_effect_color.getRed());
-		writeU8(os, post_effect_color.getGreen());
-		writeU8(os, post_effect_color.getBlue());
-		writeU8(os, param_type);
-		writeU8(os, compatible_param_type_2);
-		writeU8(os, is_ground_content);
-		writeU8(os, light_propagates);
-		writeU8(os, sunlight_propagates);
-		writeU8(os, walkable);
-		writeU8(os, pointable);
-		writeU8(os, diggable);
-		writeU8(os, climbable);
-		writeU8(os, buildable_to);
-		os << serializeString(""); // legacy: used to be metadata_name
-		writeU8(os, liquid_type);
-		os << serializeString(liquid_alternative_flowing);
-		os << serializeString(liquid_alternative_source);
-		writeU8(os, liquid_viscosity);
-		writeU8(os, liquid_renewable);
-		writeU8(os, light_source);
-		writeU32(os, damage_per_second);
-		node_box.serialize(os, protocol_version);
-		selection_box.serialize(os, protocol_version);
-		writeU8(os, legacy_facedir_simple);
-		writeU8(os, legacy_wallmounted);
-		serializeSimpleSoundSpec(sound_footstep, os, 10);
-		serializeSimpleSoundSpec(sound_dig, os, 10);
-		serializeSimpleSoundSpec(sound_dug, os, 10);
-		writeU8(os, rightclickable);
-		writeU8(os, drowning);
-		writeU8(os, leveled);
-		writeU8(os, liquid_range);
-		writeU8(os, waving);
-		os << serializeString(mesh);
-		collision_box.serialize(os, protocol_version);
-		writeU8(os, floodable);
-		writeU16(os, connects_to_ids.size());
-		for (content_t connects_to_id : connects_to_ids)
-			writeU16(os, connects_to_id);
-		writeU8(os, connect_sides);
-	} else {
-		throw SerializationError("ContentFeatures::serialize(): "
-			"Unsupported version requested");
-	}
-}
-
-void ContentFeatures::deSerializeOld(std::istream &is, int version)
-{
-	if (version == 5) // In PROTOCOL_VERSION 13
-	{
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for(u32 i=0; i<groups_size; i++){
-			std::string name = deSerializeString(is);
-			int value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType)readU8(is);
-
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		if (readU8(is) != CF_SPECIAL_COUNT)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (TileDef &i : tiledef_special)
-			i.deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType)readU8(is);
-		param_type_2 = (enum ContentParamType2)readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType)readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-	} else if (version == 6) {
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for (u32 i = 0; i < groups_size; i++) {
-			std::string name = deSerializeString(is);
-			int	value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType)readU8(is);
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		// CF_SPECIAL_COUNT in version 6 = 2
-		if (readU8(is) != 2)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (u32 i = 0; i < 2; i++)
-			tiledef_special[i].deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType)readU8(is);
-		param_type_2 = (enum ContentParamType2)readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType)readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		liquid_renewable = readU8(is);
-		light_source = readU8(is);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-		rightclickable = readU8(is);
-		drowning = readU8(is);
-		leveled = readU8(is);
-		liquid_range = readU8(is);
-	} else if (version == 7 || version == 8){
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for (u32 i = 0; i < groups_size; i++) {
-			std::string name = deSerializeString(is);
-			int value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType) readU8(is);
-
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		if (readU8(is) != CF_SPECIAL_COUNT)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (TileDef &i : tiledef_special)
-			i.deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType) readU8(is);
-		param_type_2 = (enum ContentParamType2) readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType) readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		liquid_renewable = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-		rightclickable = readU8(is);
-		drowning = readU8(is);
-		leveled = readU8(is);
-		liquid_range = readU8(is);
-		waving = readU8(is);
-		try {
-			mesh = deSerializeString(is);
-			collision_box.deSerialize(is);
-			floodable = readU8(is);
-			u16 connects_to_size = readU16(is);
-			connects_to_ids.clear();
-			for (u16 i = 0; i < connects_to_size; i++)
-				connects_to_ids.insert(readU16(is));
-			connect_sides = readU8(is);
-		} catch (SerializationError &e) {};
-	}else{
-		throw SerializationError("unsupported ContentFeatures version");
-	}
 }
 
 inline void CNodeDefManager::setNodeRegistrationStatus(bool completed)

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -68,14 +68,17 @@ std::string ObjectProperties::dump()
 
 void ObjectProperties::serialize(std::ostream &os) const
 {
-	writeU8(os, 1); // version
+	writeU8(os, 2); // version, protocol_version >= 36
 	writeS16(os, hp_max);
 	writeU8(os, physical);
-	writeF1000(os, weight);
-	writeV3F1000(os, collisionbox.MinEdge);
-	writeV3F1000(os, collisionbox.MaxEdge);
-	os<<serializeString(visual);
-	writeV2F1000(os, visual_size);
+	writeF32(os, weight);
+	writeV3F32(os, collisionbox.MinEdge);
+	writeV3F32(os, collisionbox.MaxEdge);
+	writeV3F32(os, selectionbox.MinEdge);
+	writeV3F32(os, selectionbox.MaxEdge);
+	writeU8(os, pointable);
+	os << serializeString(visual);
+	writeV2F32(os, visual_size);
 	writeU16(os, textures.size());
 	for (const std::string &texture : textures) {
 		os << serializeString(texture);
@@ -84,26 +87,23 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeV2S16(os, initial_sprite_basepos);
 	writeU8(os, is_visible);
 	writeU8(os, makes_footstep_sound);
-	writeF1000(os, automatic_rotate);
+	writeF32(os, automatic_rotate);
 	// Added in protocol version 14
-	os<<serializeString(mesh);
+	os << serializeString(mesh);
 	writeU16(os, colors.size());
 	for (video::SColor color : colors) {
 		writeARGB8(os, color);
 	}
 	writeU8(os, collideWithObjects);
-	writeF1000(os,stepheight);
+	writeF32(os,stepheight);
 	writeU8(os, automatic_face_movement_dir);
-	writeF1000(os, automatic_face_movement_dir_offset);
+	writeF32(os, automatic_face_movement_dir_offset);
 	writeU8(os, backface_culling);
 	os << serializeString(nametag);
 	writeARGB8(os, nametag_color);
-	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
+	writeF32(os, automatic_face_movement_max_rotation_per_sec);
 	os << serializeString(infotext);
 	os << serializeString(wield_item);
-	writeV3F1000(os, selectionbox.MinEdge);
-	writeV3F1000(os, selectionbox.MaxEdge);
-	writeU8(os, pointable);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -112,48 +112,44 @@ void ObjectProperties::serialize(std::ostream &os) const
 void ObjectProperties::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if(version == 1)
-	{
-		try{
-			hp_max = readS16(is);
-			physical = readU8(is);
-			weight = readF1000(is);
-			collisionbox.MinEdge = readV3F1000(is);
-			collisionbox.MaxEdge = readV3F1000(is);
-			visual = deSerializeString(is);
-			visual_size = readV2F1000(is);
-			textures.clear();
-			u32 texture_count = readU16(is);
-			for(u32 i=0; i<texture_count; i++){
-				textures.push_back(deSerializeString(is));
-			}
-			spritediv = readV2S16(is);
-			initial_sprite_basepos = readV2S16(is);
-			is_visible = readU8(is);
-			makes_footstep_sound = readU8(is);
-			automatic_rotate = readF1000(is);
-			mesh = deSerializeString(is);
-			u32 color_count = readU16(is);
-			for(u32 i=0; i<color_count; i++){
-				colors.push_back(readARGB8(is));
-			}
-			collideWithObjects = readU8(is);
-			stepheight = readF1000(is);
-			automatic_face_movement_dir = readU8(is);
-			automatic_face_movement_dir_offset = readF1000(is);
-			backface_culling = readU8(is);
-			nametag = deSerializeString(is);
-			nametag_color = readARGB8(is);
-			automatic_face_movement_max_rotation_per_sec = readF1000(is);
-			infotext = deSerializeString(is);
-			wield_item = deSerializeString(is);
-			selectionbox.MinEdge = readV3F1000(is);
-			selectionbox.MaxEdge = readV3F1000(is);
-			pointable = readU8(is);
-		}catch(SerializationError &e){}
-	}
-	else
-	{
+	if (version != 2)
 		throw SerializationError("unsupported ObjectProperties version");
-	}
+
+	try {
+		hp_max = readS16(is);
+		physical = readU8(is);
+		weight = readF32(is);
+		collisionbox.MinEdge = readV3F32(is);
+		collisionbox.MaxEdge = readV3F32(is);
+		selectionbox.MinEdge = readV3F32(is);
+		selectionbox.MaxEdge = readV3F32(is);
+		pointable = readU8(is);
+		visual = deSerializeString(is);
+		visual_size = readV2F32(is);
+		textures.clear();
+		u32 texture_count = readU16(is);
+		for (u32 i = 0; i < texture_count; i++){
+			textures.push_back(deSerializeString(is));
+		}
+		spritediv = readV2S16(is);
+		initial_sprite_basepos = readV2S16(is);
+		is_visible = readU8(is);
+		makes_footstep_sound = readU8(is);
+		automatic_rotate = readF32(is);
+		mesh = deSerializeString(is);
+		u32 color_count = readU16(is);
+		for (u32 i = 0; i < color_count; i++){
+			colors.push_back(readARGB8(is));
+		}
+		collideWithObjects = readU8(is);
+		stepheight = readF32(is);
+		automatic_face_movement_dir = readU8(is);
+		automatic_face_movement_dir_offset = readF32(is);
+		backface_culling = readU8(is);
+		nametag = deSerializeString(is);
+		nametag_color = readARGB8(is);
+		automatic_face_movement_max_rotation_per_sec = readF32(is);
+		infotext = deSerializeString(is);
+		wield_item = deSerializeString(is);
+	} catch (SerializationError &e) { }
 }

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -40,6 +40,7 @@ extern "C" {
 		} \
 	}
 #define CHECK_POS_COORD(name) CHECK_TYPE(-1, "position coordinate '" name "'", LUA_TNUMBER)
+// TODO: Check for real float limits
 #define CHECK_FLOAT_RANGE(value, name) \
 if (value < F1000_MIN || value > F1000_MAX) { \
 	std::ostringstream error_text; \

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "common/c_converter.h"
 #include "common/c_internal.h"
 #include "constants.h"
+#include <cmath> // for isnan, isinf
 
 
 #define CHECK_TYPE(index, name, type) { \
@@ -40,13 +41,11 @@ extern "C" {
 		} \
 	}
 #define CHECK_POS_COORD(name) CHECK_TYPE(-1, "position coordinate '" name "'", LUA_TNUMBER)
-// TODO: Check for real float limits
 #define CHECK_FLOAT_RANGE(value, name) \
-if (value < F1000_MIN || value > F1000_MAX) { \
+if (std::isnan(value) || std::isinf(value)) { \
 	std::ostringstream error_text; \
 	error_text << "Invalid float vector dimension range '" name "' " << \
-	"(expected " << F1000_MIN << " < " name " < " << F1000_MAX << \
-	" got " << value << ")." << std::endl; \
+	"(got " << value << ")." << std::endl; \
 	throw LuaError(error_text.str()); \
 }
 #define CHECK_POS_TAB(index) CHECK_TYPE(index, "position", LUA_TTABLE)

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -19,53 +19,32 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "util/serialize.h"
 
-void TileAnimationParams::serialize(std::ostream &os, u16 protocol_version) const
+void TileAnimationParams::serialize(std::ostream &os, u8 version) const
 {
-	if (protocol_version < 29) {
-		if (type == TAT_VERTICAL_FRAMES) {
-			writeU8(os, type);
-			writeU16(os, vertical_frames.aspect_w);
-			writeU16(os, vertical_frames.aspect_h);
-			writeF1000(os, vertical_frames.length);
-		} else {
-			writeU8(os, TAT_NONE);
-			writeU16(os, 1);
-			writeU16(os, 1);
-			writeF1000(os, 1.0);
-		}
-		return;
-	}
-
 	writeU8(os, type);
 	if (type == TAT_VERTICAL_FRAMES) {
 		writeU16(os, vertical_frames.aspect_w);
 		writeU16(os, vertical_frames.aspect_h);
-		writeF1000(os, vertical_frames.length);
+		writeF32(os, vertical_frames.length);
 	} else if (type == TAT_SHEET_2D) {
 		writeU8(os, sheet_2d.frames_w);
 		writeU8(os, sheet_2d.frames_h);
-		writeF1000(os, sheet_2d.frame_length);
+		writeF32(os, sheet_2d.frame_length);
 	}
 }
 
-void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_version)
+void TileAnimationParams::deSerialize(std::istream &is, u8 version)
 {
 	type = (TileAnimationType) readU8(is);
-	if (protocol_version < 29) {
-		vertical_frames.aspect_w = readU16(is);
-		vertical_frames.aspect_h = readU16(is);
-		vertical_frames.length = readF1000(is);
-		return;
-	}
 
 	if (type == TAT_VERTICAL_FRAMES) {
 		vertical_frames.aspect_w = readU16(is);
 		vertical_frames.aspect_h = readU16(is);
-		vertical_frames.length = readF1000(is);
+		vertical_frames.length = readF32(is);
 	} else if (type == TAT_SHEET_2D) {
 		sheet_2d.frames_w = readU8(is);
 		sheet_2d.frames_h = readU8(is);
-		sheet_2d.frame_length = readF1000(is);
+		sheet_2d.frame_length = readF32(is);
 	}
 }
 

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -50,8 +50,8 @@ struct TileAnimationParams
 		} sheet_2d;
 	};
 
-	void serialize(std::ostream &os, u16 protocol_version) const;
-	void deSerialize(std::istream &is, u16 protocol_version);
+	void serialize(std::ostream &os, u8 version) const;
+	void deSerialize(std::istream &is, u8 version);
 	void determineParams(v2u32 texture_size, int *frame_count, int *frame_length_ms,
 			v2u32 *frame_size) const;
 	void getTextureModifer(std::ostream &os, v2u32 texture_size, int frame) const;

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -303,11 +303,9 @@ void TestSerialization::testStreamRead()
 	UASSERT(readS64(is) == -43);
 
 	UASSERT(readF1000(is) == 53.534f);
-	UASSERT(readF1000(is) == -300000.32f);
-	UASSERT(readF1000(is) == F1000_MIN);
-	UASSERT(readF1000(is) == F1000_MAX);
-
-	UASSERT(readF32(is) == 60000121.f);
+	UASSERT(readF32(is) == -6000000.32f);
+	UASSERT(readF32(is) == 0.4915f);
+	UASSERT(readF32(is) == 2315.99f);
 
 	UASSERT(deSerializeString(is) == "foobar!");
 
@@ -315,11 +313,11 @@ void TestSerialization::testStreamRead()
 	UASSERT(readV3S16(is) == v3s16(4207, 604, -30));
 	UASSERT(readV2S32(is) == v2s32(1920, 1080));
 	UASSERT(readV3S32(is) == v3s32(-400, 6400054, 290549855));
-	UASSERT(readV2F1000(is) == v2f(500.656f, 350.345f));
+	UASSERT(readV2F32(is) == v2f(500.656f, 350.345f));
 
 	UASSERT(deSerializeWideString(is) == L"\x02~woof~\x5455");
 
-	UASSERT(readV3F1000(is) == v3f(500, 10024.2f, -192.54f));
+	UASSERT(readV3F32(is) == v3f(500, 10024.2f, -192.54f));
 	UASSERT(readARGB8(is) == video::SColor(255, 128, 50, 128));
 
 	UASSERT(deSerializeLongString(is) == "some longer string here");
@@ -346,11 +344,9 @@ void TestSerialization::testStreamWrite()
 	writeS64(os, -43);
 
 	writeF1000(os, 53.53467f);
-	writeF1000(os, -300000.32f);
-	writeF1000(os, F1000_MIN);
-	writeF1000(os, F1000_MAX);
-
-	writeF32(os, 60000121.f);
+	writeF32(os, -6000000.32f);
+	writeF32(os, 0.4915f);
+	writeF32(os, 2315.99f);
 
 	os << serializeString("foobar!");
 
@@ -362,11 +358,11 @@ void TestSerialization::testStreamWrite()
 	writeV3S16(os, v3s16(4207, 604, -30));
 	writeV2S32(os, v2s32(1920, 1080));
 	writeV3S32(os, v3s32(-400, 6400054, 290549855));
-	writeV2F1000(os, v2f(500.65661f, 350.34567f));
+	writeV2F32(os, v2f(500.656f, 350.345f));
 
 	os << serializeWideString(L"\x02~woof~\x5455");
 
-	writeV3F1000(os, v3f(500, 10024.2f, -192.54f));
+	writeV3F32(os, v3f(500, 10024.2f, -192.54f));
 	writeARGB8(os, video::SColor(255, 128, 50, 128));
 
 	os << serializeLongString("some longer string here");
@@ -394,9 +390,9 @@ void TestSerialization::testVecPut()
 	putS64(&buf, -43);
 
 	putF1000(&buf, 53.53467f);
-	putF1000(&buf, -300000.32f);
-	putF1000(&buf, F1000_MIN);
-	putF1000(&buf, F1000_MAX);
+	putF32(&buf, -6000000.32f);
+	putF32(&buf, 0.4915f);
+	putF32(&buf, 2315.99f);
 
 	putString(&buf, "foobar!");
 
@@ -404,11 +400,11 @@ void TestSerialization::testVecPut()
 	putV3S16(&buf, v3s16(4207, 604, -30));
 	putV2S32(&buf, v2s32(1920, 1080));
 	putV3S32(&buf, v3s32(-400, 6400054, 290549855));
-	putV2F1000(&buf, v2f(500.65661f, 350.34567f));
+	putV2F32(&buf, v2f(500.656f, 350.345f));
 
 	putWideString(&buf, L"\x02~woof~\x5455");
 
-	putV3F1000(&buf, v3f(500, 10024.2f, -192.54f));
+	putV3F32(&buf, v3f(500, 10024.2f, -192.54f));
 	putARGB8(&buf, video::SColor(255, 128, 50, 128));
 
 	putLongString(&buf, "some longer string here");
@@ -474,17 +470,17 @@ void TestSerialization::testBufReader()
 	UASSERT(buf.getS32() == -6);
 	UASSERT(buf.getS64() == -43);
 	UASSERT(buf.getF1000() == 53.534f);
-	UASSERT(buf.getF1000() == -300000.32f);
-	UASSERT(buf.getF1000() == F1000_MIN);
-	UASSERT(buf.getF1000() == F1000_MAX);
+	UASSERT(buf.getF32() == -6000000.32f);
+	UASSERT(buf.getF32() == 0.4915f);
+	UASSERT(buf.getF32() == 2315.99f);
 	UASSERT(buf.getString() == "foobar!");
 	UASSERT(buf.getV2S16() == v2s16(500, 500));
 	UASSERT(buf.getV3S16() == v3s16(4207, 604, -30));
 	UASSERT(buf.getV2S32() == v2s32(1920, 1080));
 	UASSERT(buf.getV3S32() == v3s32(-400, 6400054, 290549855));
-	UASSERT(buf.getV2F1000() == v2f(500.656f, 350.345f));
+	UASSERT(buf.getV2F32() == v2f(500.656f, 350.345f));
 	UASSERT(buf.getWideString() == L"\x02~woof~\x5455");
-	UASSERT(buf.getV3F1000() == v3f(500, 10024.2f, -192.54f));
+	UASSERT(buf.getV3F32() == v3f(500, 10024.2f, -192.54f));
 	UASSERT(buf.getARGB8() == video::SColor(255, 128, 50, 128));
 	UASSERT(buf.getLongString() == "some longer string here");
 
@@ -520,6 +516,7 @@ void TestSerialization::testBufReader()
 	EXCEPTION_CHECK(SerializationError, buf.getS32());
 	EXCEPTION_CHECK(SerializationError, buf.getS64());
 
+	EXCEPTION_CHECK(SerializationError, buf.getF32());
 	EXCEPTION_CHECK(SerializationError, buf.getF1000());
 	EXCEPTION_CHECK(SerializationError, buf.getARGB8());
 
@@ -527,8 +524,8 @@ void TestSerialization::testBufReader()
 	EXCEPTION_CHECK(SerializationError, buf.getV3S16());
 	EXCEPTION_CHECK(SerializationError, buf.getV2S32());
 	EXCEPTION_CHECK(SerializationError, buf.getV3S32());
-	EXCEPTION_CHECK(SerializationError, buf.getV2F1000());
-	EXCEPTION_CHECK(SerializationError, buf.getV3F1000());
+	EXCEPTION_CHECK(SerializationError, buf.getV2F32());
+	EXCEPTION_CHECK(SerializationError, buf.getV3F32());
 
 	EXCEPTION_CHECK(SerializationError, buf.getString());
 	EXCEPTION_CHECK(SerializationError, buf.getWideString());
@@ -560,16 +557,16 @@ void TestSerialization::testBufReader()
 	UASSERT(buf.getS64NoEx(&s64_data));
 
 	UASSERT(buf.getF1000NoEx(&f32_data));
-	UASSERT(buf.getF1000NoEx(&f32_data2));
-	UASSERT(buf.getF1000NoEx(&f32_data3));
-	UASSERT(buf.getF1000NoEx(&f32_data4));
+	UASSERT(buf.getF32NoEx(&f32_data2));
+	UASSERT(buf.getF32NoEx(&f32_data3));
+	UASSERT(buf.getF32NoEx(&f32_data4));
 
 	UASSERT(buf.getStringNoEx(&string_data));
 	UASSERT(buf.getV2S16NoEx(&v2s16_data));
 	UASSERT(buf.getV3S16NoEx(&v3s16_data));
 	UASSERT(buf.getV2S32NoEx(&v2s32_data));
 	UASSERT(buf.getV3S32NoEx(&v3s32_data));
-	UASSERT(buf.getV2F1000NoEx(&v2f_data));
+	UASSERT(buf.getV2F32NoEx(&v2f_data));
 	UASSERT(buf.getWideStringNoEx(&widestring_data));
 	UASSERT(buf.getV3F1000NoEx(&v3f_data));
 	UASSERT(buf.getARGB8NoEx(&scolor_data));
@@ -586,9 +583,9 @@ void TestSerialization::testBufReader()
 	UASSERT(s32_data == -6);
 	UASSERT(s64_data == -43);
 	UASSERT(f32_data == 53.534f);
-	UASSERT(f32_data2 == -300000.32f);
-	UASSERT(f32_data3 == F1000_MIN);
-	UASSERT(f32_data4 == F1000_MAX);
+	UASSERT(f32_data2 == -6000000.32f);
+	UASSERT(f32_data3 == 0.4915f);
+	UASSERT(f32_data4 == 2315.99f);
 	UASSERT(string_data == "foobar!");
 	UASSERT(v2s16_data == v2s16(500, 500));
 	UASSERT(v3s16_data == v3s16(4207, 604, -30));
@@ -620,14 +617,15 @@ void TestSerialization::testBufReader()
 	UASSERT(!buf.getS64NoEx(&s64_data));
 
 	UASSERT(!buf.getF1000NoEx(&f32_data));
+	UASSERT(!buf.getF32NoEx(&f32_data2));
 	UASSERT(!buf.getARGB8NoEx(&scolor_data));
 
 	UASSERT(!buf.getV2S16NoEx(&v2s16_data));
 	UASSERT(!buf.getV3S16NoEx(&v3s16_data));
 	UASSERT(!buf.getV2S32NoEx(&v2s32_data));
 	UASSERT(!buf.getV3S32NoEx(&v3s32_data));
-	UASSERT(!buf.getV2F1000NoEx(&v2f_data));
-	UASSERT(!buf.getV3F1000NoEx(&v3f_data));
+	UASSERT(!buf.getV2F32NoEx(&v2f_data));
+	UASSERT(!buf.getV3F32NoEx(&v3f_data));
 
 	UASSERT(!buf.getStringNoEx(&string_data));
 	UASSERT(!buf.getWideStringNoEx(&widestring_data));
@@ -639,15 +637,15 @@ void TestSerialization::testBufReader()
 const u8 TestSerialization::test_serialized_data[12 * 13] = {
 	0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
 	0xdd, 0xee, 0xff, 0x80, 0x75, 0x30, 0xff, 0xff, 0xff, 0xfa, 0xff, 0xff,
-	0xff, 0xff, 0xff, 0xff, 0xff, 0xd5, 0x00, 0x00, 0xd1, 0x1e, 0xee, 0x1e,
-	0x5b, 0xc0, 0x80, 0x00, 0x02, 0x80, 0x7F, 0xFF, 0xFD, 0x80, 0x00, 0x07,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xd5, 0x00, 0x00, 0xd1, 0x1e, 0xca, 0xb7,
+	0x1b, 0x01, 0x3e, 0xfb, 0xa5, 0xe3, 0x45, 0x10, 0xbf, 0x7d, 0x00, 0x07,
 	0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x21, 0x01, 0xf4, 0x01, 0xf4, 0x10,
 	0x6f, 0x02, 0x5c, 0xff, 0xe2, 0x00, 0x00, 0x07, 0x80, 0x00, 0x00, 0x04,
 	0x38, 0xff, 0xff, 0xfe, 0x70, 0x00, 0x61, 0xa8, 0x36, 0x11, 0x51, 0x70,
-	0x5f, 0x00, 0x07, 0xa3, 0xb0, 0x00, 0x05, 0x58, 0x89, 0x00, 0x08, 0x00,
+	0x5f, 0x43, 0xfa, 0x53, 0xf8, 0x43, 0xaf, 0x2c, 0x29, 0x00, 0x08, 0x00,
 	0x02, 0x00, 0x7e, 0x00, 0x77, 0x00, 0x6f, 0x00, 0x6f, 0x00, 0x66, 0x00,
-	0x7e, 0x54, 0x55, 0x00, 0x07, 0xa1, 0x20, 0x00, 0x98, 0xf5, 0x08, 0xff,
-	0xfd, 0x0f, 0xe4, 0xff, 0x80, 0x32, 0x80, 0x00, 0x00, 0x00, 0x17, 0x73,
+	0x7e, 0x54, 0x55, 0x43, 0xfa, 0x00, 0x00, 0x46, 0x1c, 0xa0, 0xcd, 0xc3,
+	0x40, 0x8a, 0x3d, 0xff, 0x80, 0x32, 0x80, 0x00, 0x00, 0x00, 0x17, 0x73,
 	0x6f, 0x6d, 0x65, 0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x65, 0x72, 0x20, 0x73,
 	0x74, 0x72, 0x69, 0x6e, 0x67, 0x20, 0x68, 0x65, 0x72, 0x65, 0xF0, 0x0D,
 };

--- a/src/unittest/test_serialization.cpp
+++ b/src/unittest/test_serialization.cpp
@@ -307,6 +307,8 @@ void TestSerialization::testStreamRead()
 	UASSERT(readF1000(is) == F1000_MIN);
 	UASSERT(readF1000(is) == F1000_MAX);
 
+	UASSERT(readF32(is) == 60000121.f);
+
 	UASSERT(deSerializeString(is) == "foobar!");
 
 	UASSERT(readV2S16(is) == v2s16(500, 500));
@@ -347,6 +349,8 @@ void TestSerialization::testStreamWrite()
 	writeF1000(os, -300000.32f);
 	writeF1000(os, F1000_MIN);
 	writeF1000(os, F1000_MAX);
+
+	writeF32(os, 60000121.f);
 
 	os << serializeString("foobar!");
 

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -191,8 +191,9 @@ inline f32 readF1000(const u8 *data)
 
 inline f32 readF32(const u8 *data)
 {
+	u32 dat = readU32(data);
 	f32 val = 0;
-	memcpy(&val, data, 4);
+	memcpy(&val, &dat, 4);
 	return val;
 }
 
@@ -307,9 +308,10 @@ inline void writeF1000(u8 *data, f32 i)
 inline void writeF32(u8 *data, f32 i)
 {
 	assert(!(i != i)); // NaN check
-	memcpy(data, &i, 4);
+	u32 val = 0;
+	memcpy(&val, &i, 4);
+	writeU32(data, val);
 }
-
 
 inline void writeARGB8(u8 *data, video::SColor p)
 {

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -183,9 +183,17 @@ inline s64 readS64(const u8 *data)
 	return (s64)readU64(data);
 }
 
+// Legacy format
 inline f32 readF1000(const u8 *data)
 {
 	return (f32)readS32(data) / FIXEDPOINT_FACTOR;
+}
+
+inline f32 readF32(const u8 *data)
+{
+	f32 val = 0;
+	memcpy(&val, data, 4);
+	return val;
 }
 
 inline video::SColor readARGB8(const u8 *data)
@@ -245,6 +253,23 @@ inline v3f readV3F1000(const u8 *data)
 	return p;
 }
 
+inline v2f readV2F32(const u8 *data)
+{
+	v2f p;
+	p.X = readF32(&data[0]);
+	p.Y = readF32(&data[4]);
+	return p;
+}
+
+inline v3f readV3F32(const u8 *data)
+{
+	v3f p;
+	p.X = readF32(&data[0]);
+	p.Y = readF32(&data[4]);
+	p.Z = readF32(&data[8]);
+	return p;
+}
+
 /////////////// write routines ////////////////
 
 inline void writeU8(u8 *data, u8 i)
@@ -272,11 +297,19 @@ inline void writeS64(u8 *data, s64 i)
 	writeU64(data, (u64)i);
 }
 
+// Legacy format
 inline void writeF1000(u8 *data, f32 i)
 {
 	assert(i >= F1000_MIN && i <= F1000_MAX);
 	writeS32(data, i * FIXEDPOINT_FACTOR);
 }
+
+inline void writeF32(u8 *data, f32 i)
+{
+	assert(!(i != i)); // NaN check
+	memcpy(data, &i, 4);
+}
+
 
 inline void writeARGB8(u8 *data, video::SColor p)
 {
@@ -322,6 +355,19 @@ inline void writeV3F1000(u8 *data, v3f p)
 	writeF1000(&data[8], p.Z);
 }
 
+inline void writeV2F32(u8 *data, v2f p)
+{
+	writeF32(&data[0], p.X);
+	writeF32(&data[4], p.Y);
+}
+
+inline void writeV3F32(u8 *data, v3f p)
+{
+	writeF32(&data[0], p.X);
+	writeF32(&data[4], p.Y);
+	writeF32(&data[8], p.Z);
+}
+
 ////
 //// Iostream wrapper for data read/write
 ////
@@ -351,12 +397,15 @@ MAKE_STREAM_READ_FXN(s16,   S16,      2);
 MAKE_STREAM_READ_FXN(s32,   S32,      4);
 MAKE_STREAM_READ_FXN(s64,   S64,      8);
 MAKE_STREAM_READ_FXN(f32,   F1000,    4);
+MAKE_STREAM_READ_FXN(f32,   F32,      4);
 MAKE_STREAM_READ_FXN(v2s16, V2S16,    4);
 MAKE_STREAM_READ_FXN(v3s16, V3S16,    6);
 MAKE_STREAM_READ_FXN(v2s32, V2S32,    8);
 MAKE_STREAM_READ_FXN(v3s32, V3S32,   12);
 MAKE_STREAM_READ_FXN(v2f,   V2F1000,  8);
 MAKE_STREAM_READ_FXN(v3f,   V3F1000, 12);
+MAKE_STREAM_READ_FXN(v2f,   V2F32,    8);
+MAKE_STREAM_READ_FXN(v3f,   V3F32,   12);
 MAKE_STREAM_READ_FXN(video::SColor, ARGB8, 4);
 
 MAKE_STREAM_WRITE_FXN(u8,    U8,       1);
@@ -368,12 +417,15 @@ MAKE_STREAM_WRITE_FXN(s16,   S16,      2);
 MAKE_STREAM_WRITE_FXN(s32,   S32,      4);
 MAKE_STREAM_WRITE_FXN(s64,   S64,      8);
 MAKE_STREAM_WRITE_FXN(f32,   F1000,    4);
+MAKE_STREAM_WRITE_FXN(f32,   F32,      4);
 MAKE_STREAM_WRITE_FXN(v2s16, V2S16,    4);
 MAKE_STREAM_WRITE_FXN(v3s16, V3S16,    6);
 MAKE_STREAM_WRITE_FXN(v2s32, V2S32,    8);
 MAKE_STREAM_WRITE_FXN(v3s32, V3S32,   12);
 MAKE_STREAM_WRITE_FXN(v2f,   V2F1000,  8);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F1000, 12);
+MAKE_STREAM_WRITE_FXN(v2f,   V2F32,    8);
+MAKE_STREAM_WRITE_FXN(v3f,   V3F32,   12);
 MAKE_STREAM_WRITE_FXN(video::SColor, ARGB8, 4);
 
 ////


### PR DESCRIPTION
Pilot version tested with Xubuntu client to BSD server.
As of 170825 13:00 UTC, `web.unix-experience.fr 30001` is built on 7551acc but the protocol bump is contained in a56e5b7, so you'll get a message for a version-incompatibility. Thanks to @nerzhul for providing this server.

This PR will make servers send real float values instead of a multiplied value, sent as a regular integer. To prevent any overhead, the backwards compatibility is dropped entirely.
By this PR caused deprecated code segments are removed too.

Fixes #5521 and various runtime errors caused by Lua mods that send values outside the allowed range.