### PR TITLE
Android stepheight: Only increase if 'touching ground'

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -285,7 +285,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// to all players, as this currently creates unintended special movement
 	// abilities and advantages for Android players on a server.
 #ifdef __ANDROID__
-	player_stepheight += (0.6f * BS);
+	if (touching_ground)
+		player_stepheight += (0.6f * BS);
 #endif
 
 	v3f accel_f = v3f(0,0,0);


### PR DESCRIPTION
Addresses https://github.com/minetest/minetest/issues/6200#issuecomment-321215352 and a partal fix for #6183
Untested (i can't). 
This should reduce some of the special abilities of Android players. As with non-Android players the stepheight should depend on whether the player is 'touching ground'. Previously the stepheight was always increased by 0.6 * BS even mid-jump or when climbing out of a river.