### PR TITLE
Bump minimal protocol version to 36

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -300,8 +300,6 @@ void GenericCAO::initialize(const std::string &data)
 			m_is_visible = false;
 			player->setCAO(this);
 		}
-		if (m_client->getProtoVersion() < 33)
-			m_env->addPlayerName(m_name);
 	}
 }
 
@@ -337,9 +335,6 @@ void GenericCAO::processInitData(const std::string &data)
 
 GenericCAO::~GenericCAO()
 {
-	if (m_is_player && m_client->getProtoVersion() < 33) {
-		m_env->removePlayerName(m_name);
-	}
 	removeFromScene(true);
 }
 

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -128,6 +128,7 @@ void ItemDefinition::reset()
 
 void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 {
+	// protocol_version >= 36
 	u8 version = 5;
 	writeU8(os, version);
 	writeU8(os, type);
@@ -173,8 +174,9 @@ void ItemDefinition::deSerialize(std::istream &is)
 
 	// Deserialize
 	int version = readU8(is);
-	if (version < 5 || version > 5)
+	if (version < 5)
 		throw SerializationError("unsupported ItemDefinition version");
+
 	type = (enum ItemType)readU8(is);
 	name = deSerializeString(is);
 	description = deSerializeString(is);

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -128,7 +128,7 @@ void ItemDefinition::reset()
 
 void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 {
-	u8 version = (protocol_version >= 34) ? 4 : 3;
+	u8 version = 5;
 	writeU8(os, version);
 	writeU8(os, type);
 	os << serializeString(name);
@@ -160,12 +160,10 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString(palette_image);
 	writeU32(os, color.color);
 
-	if (version >= 4) {
-		writeF1000(os, sound_place.pitch);
-		writeF1000(os, sound_place_failed.pitch);
-		os << serializeString(inventory_overlay);
-		os << serializeString(wield_overlay);
-	}
+	writeF1000(os, sound_place.pitch);
+	writeF1000(os, sound_place_failed.pitch);
+	os << serializeString(inventory_overlay);
+	os << serializeString(wield_overlay);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)
@@ -175,7 +173,7 @@ void ItemDefinition::deSerialize(std::istream &is)
 
 	// Deserialize
 	int version = readU8(is);
-	if (version < 1 || version > 4)
+	if (version < 5 || version > 5)
 		throw SerializationError("unsupported ItemDefinition version");
 	type = (enum ItemType)readU8(is);
 	name = deSerializeString(is);
@@ -200,38 +198,27 @@ void ItemDefinition::deSerialize(std::istream &is)
 		int value = readS16(is);
 		groups[name] = value;
 	}
-	if(version == 1){
-		// We cant be sure that node_placement_prediction is send in version 1
-		try{
-			node_placement_prediction = deSerializeString(is);
-		}catch(SerializationError &e) {};
-		// Set the old default sound
-		sound_place.name = "default_place_node";
-		sound_place.gain = 0.5;
-	} else if(version >= 2) {
-		node_placement_prediction = deSerializeString(is);
-		//deserializeSimpleSoundSpec(sound_place, is);
-		sound_place.name = deSerializeString(is);
-		sound_place.gain = readF1000(is);
-	}
-	if(version >= 3) {
-		range = readF1000(is);
-	}
+
+	node_placement_prediction = deSerializeString(is);
+	//deserializeSimpleSoundSpec(sound_place, is);
+	sound_place.name = deSerializeString(is);
+	sound_place.gain = readF1000(is);
+	range = readF1000(is);
+
+	sound_place_failed.name = deSerializeString(is);
+	sound_place_failed.gain = readF1000(is);
+	palette_image = deSerializeString(is);
+	color.set(readU32(is));
+
+	sound_place.pitch = readF1000(is);
+	sound_place_failed.pitch = readF1000(is);
+	inventory_overlay = deSerializeString(is);
+	wield_overlay = deSerializeString(is);
+
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.
-	try {
-		sound_place_failed.name = deSerializeString(is);
-		sound_place_failed.gain = readF1000(is);
-		palette_image = deSerializeString(is);
-		color.set(readU32(is));
-
-		if (version >= 4) {
-			sound_place.pitch = readF1000(is);
-			sound_place_failed.pitch = readF1000(is);
-			inventory_overlay = deSerializeString(is);
-			wield_overlay = deSerializeString(is);
-		}
-	} catch(SerializationError &e) {};
+	//try {
+	//} catch(SerializationError &e) {};
 }
 
 /*

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -159,7 +159,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString(sound_place_failed.name);
 	writeF1000(os, sound_place_failed.gain);
 	os << serializeString(palette_image);
-	writeU32(os, color.color);
+	writeARGB8(os, color);
 
 	writeF1000(os, sound_place.pitch);
 	writeF1000(os, sound_place_failed.pitch);
@@ -210,7 +210,7 @@ void ItemDefinition::deSerialize(std::istream &is)
 	sound_place_failed.name = deSerializeString(is);
 	sound_place_failed.gain = readF1000(is);
 	palette_image = deSerializeString(is);
-	color.set(readU32(is));
+	color = readARGB8(is);
 
 	sound_place.pitch = readF1000(is);
 	sound_place_failed.pitch = readF1000(is);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -177,7 +177,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Add settable player stepheight using existing object property.
 			Breaks compatibility with older clients.
 	PROTOCOL VERSION 36:
-		Backwards compability drop
+		Backwards compatibility drop
 */
 
 #define LATEST_PROTOCOL_VERSION 36

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -176,18 +176,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			position
 		Add settable player stepheight using existing object property.
 			Breaks compatibility with older clients.
+	PROTOCOL VERSION 36:
+		Backwards compability drop
 */
 
-#define LATEST_PROTOCOL_VERSION 35
+#define LATEST_PROTOCOL_VERSION 36
 
 // Server's supported network protocol range
-#define SERVER_PROTOCOL_VERSION_MIN 24
+#define SERVER_PROTOCOL_VERSION_MIN 36
 #define SERVER_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Client's supported network protocol range
 // The minimal version depends on whether
 // send_pre_v25_init is enabled or not
-#define CLIENT_PROTOCOL_VERSION_MIN 25
+#define CLIENT_PROTOCOL_VERSION_MIN 36
 #define CLIENT_PROTOCOL_VERSION_MIN_LEGACY 24
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -187,8 +187,8 @@ void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 	}
 }
 
-void TileDef::deSerialize(std::istream &is,
-	const u8 contentfeatures_version, const NodeDrawType drawtype)
+void TileDef::deSerialize(std::istream &is, u8 contentfeatures_version,
+	cNodeDrawType drawtype)
 {
 	int version = readU8(is);
 	name = deSerializeString(is);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -63,19 +63,14 @@ void NodeBox::reset()
 
 void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 {
-	// Protocol >= 21
-	int version = 2;
-	if (protocol_version >= 27)
-		version = 3;
+	// Protocol >= 36
+	int version = 4;
 	writeU8(os, version);
 
 	switch (type) {
 	case NODEBOX_LEVELED:
 	case NODEBOX_FIXED:
-		if (version == 1)
-			writeU8(os, NODEBOX_FIXED);
-		else
-			writeU8(os, type);
+		writeU8(os, type);
 
 		writeU16(os, fixed.size());
 		for (const aabb3f &nodebox : fixed) {
@@ -94,16 +89,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 		writeV3F1000(os, wall_side.MaxEdge);
 		break;
 	case NODEBOX_CONNECTED:
-		if (version <= 2) {
-			// send old clients nodes that can't be walked through
-			// to prevent abuse
-			writeU8(os, NODEBOX_FIXED);
-
-			writeU16(os, 1);
-			writeV3F1000(os, v3f(-BS/2, -BS/2, -BS/2));
-			writeV3F1000(os, v3f(BS/2, BS/2, BS/2));
-		} else {
-			writeU8(os, type);
+		writeU8(os, type);
 
 #define WRITEBOX(box) \
 		writeU16(os, (box).size()); \
@@ -112,14 +98,13 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 			writeV3F1000(os, i.MaxEdge); \
 		};
 
-			WRITEBOX(fixed);
-			WRITEBOX(connect_top);
-			WRITEBOX(connect_bottom);
-			WRITEBOX(connect_front);
-			WRITEBOX(connect_left);
-			WRITEBOX(connect_back);
-			WRITEBOX(connect_right);
-		}
+		WRITEBOX(fixed);
+		WRITEBOX(connect_top);
+		WRITEBOX(connect_bottom);
+		WRITEBOX(connect_front);
+		WRITEBOX(connect_left);
+		WRITEBOX(connect_back);
+		WRITEBOX(connect_right);
 		break;
 	default:
 		writeU8(os, type);
@@ -130,7 +115,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 void NodeBox::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if (version < 1 || version > 3)
+	if (version < 4 || version > 4)
 		throw SerializationError("unsupported NodeBox version");
 
 	reset();
@@ -185,58 +170,38 @@ void NodeBox::deSerialize(std::istream &is)
 
 void TileDef::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version >= 30)
-		writeU8(os, 4);
-	else if (protocol_version >= 29)
-		writeU8(os, 3);
-	else if (protocol_version >= 26)
-		writeU8(os, 2);
-	else
-		writeU8(os, 1);
+	// protocol_version >= 36
+	u8 version = 5;
+	writeU8(os, version);
 
 	os << serializeString(name);
-	animation.serialize(os, protocol_version);
+	animation.serialize(os, version);
 	writeU8(os, backface_culling);
-	if (protocol_version >= 26) {
-		writeU8(os, tileable_horizontal);
-		writeU8(os, tileable_vertical);
-	}
-	if (protocol_version >= 30) {
-		writeU8(os, has_color);
-		if (has_color) {
-			writeU8(os, color.getRed());
-			writeU8(os, color.getGreen());
-			writeU8(os, color.getBlue());
-		}
+	writeU8(os, tileable_horizontal);
+	writeU8(os, tileable_vertical);
+	writeU8(os, has_color);
+	if (has_color) {
+		writeU8(os, color.getRed());
+		writeU8(os, color.getGreen());
+		writeU8(os, color.getBlue());
 	}
 }
 
-void TileDef::deSerialize(std::istream &is, const u8 contenfeatures_version, const NodeDrawType drawtype)
+void TileDef::deSerialize(std::istream &is,
+	const u8 contentfeatures_version, const NodeDrawType drawtype)
 {
 	int version = readU8(is);
 	name = deSerializeString(is);
-	animation.deSerialize(is, version >= 3 ? 29 : 26);
-	if (version >= 1)
-		backface_culling = readU8(is);
-	if (version >= 2) {
-		tileable_horizontal = readU8(is);
-		tileable_vertical = readU8(is);
+	animation.deSerialize(is, version);
+	backface_culling = readU8(is);
+	tileable_horizontal = readU8(is);
+	tileable_vertical = readU8(is);
+	has_color = readU8(is);
+	if (has_color) {
+		color.setRed(readU8(is));
+		color.setGreen(readU8(is));
+		color.setBlue(readU8(is));
 	}
-	if (version >= 4) {
-		has_color = readU8(is);
-		if (has_color) {
-			color.setRed(readU8(is));
-			color.setGreen(readU8(is));
-			color.setBlue(readU8(is));
-		}
-	}
-
-	if ((contenfeatures_version < 8) &&
-		((drawtype == NDT_MESH) ||
-		 (drawtype == NDT_FIRELIKE) ||
-		 (drawtype == NDT_LIQUID) ||
-		 (drawtype == NDT_PLANTLIKE)))
-		backface_culling = false;
 }
 
 
@@ -249,17 +214,14 @@ static void serializeSimpleSoundSpec(const SimpleSoundSpec &ss,
 {
 	os<<serializeString(ss.name);
 	writeF1000(os, ss.gain);
-
-	if (version >= 11)
-		writeF1000(os, ss.pitch);
+	writeF1000(os, ss.pitch);
 }
-static void deSerializeSimpleSoundSpec(SimpleSoundSpec &ss, std::istream &is, u8 version)
+static void deSerializeSimpleSoundSpec(SimpleSoundSpec &ss,
+		std::istream &is, u8 version)
 {
 	ss.name = deSerializeString(is);
 	ss.gain = readF1000(is);
-
-	if (version >= 11)
-		ss.pitch = readF1000(is);
+	ss.pitch = readF1000(is);
 }
 
 void TextureSettings::readSettings()
@@ -377,13 +339,8 @@ void ContentFeatures::reset()
 
 void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 {
-	if (protocol_version < 31) {
-		serializeOld(os, protocol_version);
-		return;
-	}
-
-	// version
-	u8 version = (protocol_version >= 34) ? 11 : 10;
+	// protocol_version >= 36
+	u8 version = 12;
 	writeU8(os, version);
 
 	// general
@@ -486,12 +443,8 @@ void ContentFeatures::deSerialize(std::istream &is)
 {
 	// version detection
 	int version = readU8(is);
-	if (version < 9) {
-		deSerializeOld(is, version);
-		return;
-	}
 
-	if (version > 11) {
+	if (version < 12 || version > 12) {
 		throw SerializationError("unsupported ContentFeatures version");
 	}
 
@@ -515,9 +468,8 @@ void ContentFeatures::deSerialize(std::istream &is)
 		throw SerializationError("unsupported tile count");
 	for (TileDef &td : tiledef)
 		td.deSerialize(is, version, drawtype);
-	if (version >= 10)
-		for (TileDef &td : tiledef_overlay)
-			td.deSerialize(is, version, drawtype);
+	for (TileDef &td : tiledef_overlay)
+		td.deSerialize(is, version, drawtype);
 	if (readU8(is) != CF_SPECIAL_COUNT)
 		throw SerializationError("unsupported CF_SPECIAL_COUNT");
 	for (TileDef &td : tiledef_special)
@@ -1530,282 +1482,6 @@ void CNodeDefManager::addNameIdMapping(content_t i, std::string name)
 IWritableNodeDefManager *createNodeDefManager()
 {
 	return new CNodeDefManager();
-}
-
-
-//// Serialization of old ContentFeatures formats
-void ContentFeatures::serializeOld(std::ostream &os, u16 protocol_version) const
-{
-	u8 compatible_param_type_2 = param_type_2;
-	if ((protocol_version < 28)
-			&& (compatible_param_type_2 == CPT2_MESHOPTIONS))
-		compatible_param_type_2 = CPT2_NONE;
-	else if (protocol_version < 30) {
-		if (compatible_param_type_2 == CPT2_COLOR)
-			compatible_param_type_2 = CPT2_NONE;
-		else if (compatible_param_type_2 == CPT2_COLORED_FACEDIR)
-			compatible_param_type_2 = CPT2_FACEDIR;
-		else if (compatible_param_type_2 == CPT2_COLORED_WALLMOUNTED)
-			compatible_param_type_2 = CPT2_WALLMOUNTED;
-	}
-
-	float compatible_visual_scale = visual_scale;
-	if (protocol_version < 30 && drawtype == NDT_PLANTLIKE)
-		compatible_visual_scale = sqrt(visual_scale);
-
-	TileDef compatible_tiles[6];
-	for (u8 i = 0; i < 6; i++) {
-		compatible_tiles[i] = tiledef[i];
-		if (!tiledef_overlay[i].name.empty()) {
-			std::stringstream s;
-			s << "(" << tiledef[i].name << ")^(" << tiledef_overlay[i].name
-				<< ")";
-			compatible_tiles[i].name = s.str();
-		}
-	}
-
-	// Protocol >= 24
-	if (protocol_version < 31) {
-		writeU8(os, protocol_version < 27 ? 7 : 8);
-
-		os << serializeString(name);
-		writeU16(os, groups.size());
-		for (const auto &group : groups) {
-			os << serializeString(group.first);
-			writeS16(os, group.second);
-		}
-		writeU8(os, drawtype);
-		writeF1000(os, compatible_visual_scale);
-		writeU8(os, 6);
-		for (const auto &compatible_tile : compatible_tiles)
-			compatible_tile.serialize(os, protocol_version);
-		writeU8(os, CF_SPECIAL_COUNT);
-		for (const TileDef &i : tiledef_special)
-			i.serialize(os, protocol_version);
-		writeU8(os, alpha);
-		writeU8(os, post_effect_color.getAlpha());
-		writeU8(os, post_effect_color.getRed());
-		writeU8(os, post_effect_color.getGreen());
-		writeU8(os, post_effect_color.getBlue());
-		writeU8(os, param_type);
-		writeU8(os, compatible_param_type_2);
-		writeU8(os, is_ground_content);
-		writeU8(os, light_propagates);
-		writeU8(os, sunlight_propagates);
-		writeU8(os, walkable);
-		writeU8(os, pointable);
-		writeU8(os, diggable);
-		writeU8(os, climbable);
-		writeU8(os, buildable_to);
-		os << serializeString(""); // legacy: used to be metadata_name
-		writeU8(os, liquid_type);
-		os << serializeString(liquid_alternative_flowing);
-		os << serializeString(liquid_alternative_source);
-		writeU8(os, liquid_viscosity);
-		writeU8(os, liquid_renewable);
-		writeU8(os, light_source);
-		writeU32(os, damage_per_second);
-		node_box.serialize(os, protocol_version);
-		selection_box.serialize(os, protocol_version);
-		writeU8(os, legacy_facedir_simple);
-		writeU8(os, legacy_wallmounted);
-		serializeSimpleSoundSpec(sound_footstep, os, 10);
-		serializeSimpleSoundSpec(sound_dig, os, 10);
-		serializeSimpleSoundSpec(sound_dug, os, 10);
-		writeU8(os, rightclickable);
-		writeU8(os, drowning);
-		writeU8(os, leveled);
-		writeU8(os, liquid_range);
-		writeU8(os, waving);
-		os << serializeString(mesh);
-		collision_box.serialize(os, protocol_version);
-		writeU8(os, floodable);
-		writeU16(os, connects_to_ids.size());
-		for (content_t connects_to_id : connects_to_ids)
-			writeU16(os, connects_to_id);
-		writeU8(os, connect_sides);
-	} else {
-		throw SerializationError("ContentFeatures::serialize(): "
-			"Unsupported version requested");
-	}
-}
-
-void ContentFeatures::deSerializeOld(std::istream &is, int version)
-{
-	if (version == 5) // In PROTOCOL_VERSION 13
-	{
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for(u32 i=0; i<groups_size; i++){
-			std::string name = deSerializeString(is);
-			int value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType)readU8(is);
-
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		if (readU8(is) != CF_SPECIAL_COUNT)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (TileDef &i : tiledef_special)
-			i.deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType)readU8(is);
-		param_type_2 = (enum ContentParamType2)readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType)readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-	} else if (version == 6) {
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for (u32 i = 0; i < groups_size; i++) {
-			std::string name = deSerializeString(is);
-			int	value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType)readU8(is);
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		// CF_SPECIAL_COUNT in version 6 = 2
-		if (readU8(is) != 2)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (u32 i = 0; i < 2; i++)
-			tiledef_special[i].deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType)readU8(is);
-		param_type_2 = (enum ContentParamType2)readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType)readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		liquid_renewable = readU8(is);
-		light_source = readU8(is);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-		rightclickable = readU8(is);
-		drowning = readU8(is);
-		leveled = readU8(is);
-		liquid_range = readU8(is);
-	} else if (version == 7 || version == 8){
-		name = deSerializeString(is);
-		groups.clear();
-		u32 groups_size = readU16(is);
-		for (u32 i = 0; i < groups_size; i++) {
-			std::string name = deSerializeString(is);
-			int value = readS16(is);
-			groups[name] = value;
-		}
-		drawtype = (enum NodeDrawType) readU8(is);
-
-		visual_scale = readF1000(is);
-		if (readU8(is) != 6)
-			throw SerializationError("unsupported tile count");
-		for (TileDef &i : tiledef)
-			i.deSerialize(is, version, drawtype);
-		if (readU8(is) != CF_SPECIAL_COUNT)
-			throw SerializationError("unsupported CF_SPECIAL_COUNT");
-		for (TileDef &i : tiledef_special)
-			i.deSerialize(is, version, drawtype);
-		alpha = readU8(is);
-		post_effect_color.setAlpha(readU8(is));
-		post_effect_color.setRed(readU8(is));
-		post_effect_color.setGreen(readU8(is));
-		post_effect_color.setBlue(readU8(is));
-		param_type = (enum ContentParamType) readU8(is);
-		param_type_2 = (enum ContentParamType2) readU8(is);
-		is_ground_content = readU8(is);
-		light_propagates = readU8(is);
-		sunlight_propagates = readU8(is);
-		walkable = readU8(is);
-		pointable = readU8(is);
-		diggable = readU8(is);
-		climbable = readU8(is);
-		buildable_to = readU8(is);
-		deSerializeString(is); // legacy: used to be metadata_name
-		liquid_type = (enum LiquidType) readU8(is);
-		liquid_alternative_flowing = deSerializeString(is);
-		liquid_alternative_source = deSerializeString(is);
-		liquid_viscosity = readU8(is);
-		liquid_renewable = readU8(is);
-		light_source = readU8(is);
-		light_source = MYMIN(light_source, LIGHT_MAX);
-		damage_per_second = readU32(is);
-		node_box.deSerialize(is);
-		selection_box.deSerialize(is);
-		legacy_facedir_simple = readU8(is);
-		legacy_wallmounted = readU8(is);
-		deSerializeSimpleSoundSpec(sound_footstep, is, version);
-		deSerializeSimpleSoundSpec(sound_dig, is, version);
-		deSerializeSimpleSoundSpec(sound_dug, is, version);
-		rightclickable = readU8(is);
-		drowning = readU8(is);
-		leveled = readU8(is);
-		liquid_range = readU8(is);
-		waving = readU8(is);
-		try {
-			mesh = deSerializeString(is);
-			collision_box.deSerialize(is);
-			floodable = readU8(is);
-			u16 connects_to_size = readU16(is);
-			connects_to_ids.clear();
-			for (u16 i = 0; i < connects_to_size; i++)
-				connects_to_ids.insert(readU16(is));
-			connect_sides = readU8(is);
-		} catch (SerializationError &e) {};
-	}else{
-		throw SerializationError("unsupported ContentFeatures version");
-	}
 }
 
 inline void CNodeDefManager::setNodeRegistrationStatus(bool completed)

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -115,7 +115,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 void NodeBox::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if (version < 4 || version > 4)
+	if (version < 4)
 		throw SerializationError("unsupported NodeBox version");
 
 	reset();
@@ -443,10 +443,8 @@ void ContentFeatures::deSerialize(std::istream &is)
 {
 	// version detection
 	int version = readU8(is);
-
-	if (version < 12 || version > 12) {
+	if (version < 12)
 		throw SerializationError("unsupported ContentFeatures version");
-	}
 
 	// general
 	name = deSerializeString(is);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -224,7 +224,8 @@ struct TileDef
 	}
 
 	void serialize(std::ostream &os, u16 protocol_version) const;
-	void deSerialize(std::istream &is, const u8 contentfeatures_version, const NodeDrawType drawtype);
+	void deSerialize(std::istream &is, u8 contentfeatures_version,
+		NodeDrawType drawtype);
 };
 
 #define CF_SPECIAL_COUNT 6

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -115,41 +115,39 @@ void ObjectProperties::deSerialize(std::istream &is)
 	if (version != 2)
 		throw SerializationError("unsupported ObjectProperties version");
 
-	try {
-		hp_max = readS16(is);
-		physical = readU8(is);
-		weight = readF1000(is);
-		collisionbox.MinEdge = readV3F1000(is);
-		collisionbox.MaxEdge = readV3F1000(is);
-		selectionbox.MinEdge = readV3F1000(is);
-		selectionbox.MaxEdge = readV3F1000(is);
-		pointable = readU8(is);
-		visual = deSerializeString(is);
-		visual_size = readV2F1000(is);
-		textures.clear();
-		u32 texture_count = readU16(is);
-		for (u32 i = 0; i < texture_count; i++){
-			textures.push_back(deSerializeString(is));
-		}
-		spritediv = readV2S16(is);
-		initial_sprite_basepos = readV2S16(is);
-		is_visible = readU8(is);
-		makes_footstep_sound = readU8(is);
-		automatic_rotate = readF1000(is);
-		mesh = deSerializeString(is);
-		u32 color_count = readU16(is);
-		for (u32 i = 0; i < color_count; i++){
-			colors.push_back(readARGB8(is));
-		}
-		collideWithObjects = readU8(is);
-		stepheight = readF1000(is);
-		automatic_face_movement_dir = readU8(is);
-		automatic_face_movement_dir_offset = readF1000(is);
-		backface_culling = readU8(is);
-		nametag = deSerializeString(is);
-		nametag_color = readARGB8(is);
-		automatic_face_movement_max_rotation_per_sec = readF1000(is);
-		infotext = deSerializeString(is);
-		wield_item = deSerializeString(is);
-	} catch (SerializationError &e) { }
+	hp_max = readS16(is);
+	physical = readU8(is);
+	weight = readF1000(is);
+	collisionbox.MinEdge = readV3F1000(is);
+	collisionbox.MaxEdge = readV3F1000(is);
+	selectionbox.MinEdge = readV3F1000(is);
+	selectionbox.MaxEdge = readV3F1000(is);
+	pointable = readU8(is);
+	visual = deSerializeString(is);
+	visual_size = readV2F1000(is);
+	textures.clear();
+	u32 texture_count = readU16(is);
+	for (u32 i = 0; i < texture_count; i++){
+		textures.push_back(deSerializeString(is));
+	}
+	spritediv = readV2S16(is);
+	initial_sprite_basepos = readV2S16(is);
+	is_visible = readU8(is);
+	makes_footstep_sound = readU8(is);
+	automatic_rotate = readF1000(is);
+	mesh = deSerializeString(is);
+	u32 color_count = readU16(is);
+	for (u32 i = 0; i < color_count; i++){
+		colors.push_back(readARGB8(is));
+	}
+	collideWithObjects = readU8(is);
+	stepheight = readF1000(is);
+	automatic_face_movement_dir = readU8(is);
+	automatic_face_movement_dir_offset = readF1000(is);
+	backface_culling = readU8(is);
+	nametag = deSerializeString(is);
+	nametag_color = readARGB8(is);
+	automatic_face_movement_max_rotation_per_sec = readF1000(is);
+	infotext = deSerializeString(is);
+	wield_item = deSerializeString(is);
 }

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -68,13 +68,16 @@ std::string ObjectProperties::dump()
 
 void ObjectProperties::serialize(std::ostream &os) const
 {
-	writeU8(os, 1); // version
+	writeU8(os, 2); // version, protocol_version >= 36
 	writeS16(os, hp_max);
 	writeU8(os, physical);
 	writeF1000(os, weight);
 	writeV3F1000(os, collisionbox.MinEdge);
 	writeV3F1000(os, collisionbox.MaxEdge);
-	os<<serializeString(visual);
+	writeV3F1000(os, selectionbox.MinEdge);
+	writeV3F1000(os, selectionbox.MaxEdge);
+	writeU8(os, pointable);
+	os << serializeString(visual);
 	writeV2F1000(os, visual_size);
 	writeU16(os, textures.size());
 	for (const std::string &texture : textures) {
@@ -86,7 +89,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, makes_footstep_sound);
 	writeF1000(os, automatic_rotate);
 	// Added in protocol version 14
-	os<<serializeString(mesh);
+	os << serializeString(mesh);
 	writeU16(os, colors.size());
 	for (video::SColor color : colors) {
 		writeARGB8(os, color);
@@ -101,9 +104,6 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
 	os << serializeString(infotext);
 	os << serializeString(wield_item);
-	writeV3F1000(os, selectionbox.MinEdge);
-	writeV3F1000(os, selectionbox.MaxEdge);
-	writeU8(os, pointable);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -112,48 +112,44 @@ void ObjectProperties::serialize(std::ostream &os) const
 void ObjectProperties::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if(version == 1)
-	{
-		try{
-			hp_max = readS16(is);
-			physical = readU8(is);
-			weight = readF1000(is);
-			collisionbox.MinEdge = readV3F1000(is);
-			collisionbox.MaxEdge = readV3F1000(is);
-			visual = deSerializeString(is);
-			visual_size = readV2F1000(is);
-			textures.clear();
-			u32 texture_count = readU16(is);
-			for(u32 i=0; i<texture_count; i++){
-				textures.push_back(deSerializeString(is));
-			}
-			spritediv = readV2S16(is);
-			initial_sprite_basepos = readV2S16(is);
-			is_visible = readU8(is);
-			makes_footstep_sound = readU8(is);
-			automatic_rotate = readF1000(is);
-			mesh = deSerializeString(is);
-			u32 color_count = readU16(is);
-			for(u32 i=0; i<color_count; i++){
-				colors.push_back(readARGB8(is));
-			}
-			collideWithObjects = readU8(is);
-			stepheight = readF1000(is);
-			automatic_face_movement_dir = readU8(is);
-			automatic_face_movement_dir_offset = readF1000(is);
-			backface_culling = readU8(is);
-			nametag = deSerializeString(is);
-			nametag_color = readARGB8(is);
-			automatic_face_movement_max_rotation_per_sec = readF1000(is);
-			infotext = deSerializeString(is);
-			wield_item = deSerializeString(is);
-			selectionbox.MinEdge = readV3F1000(is);
-			selectionbox.MaxEdge = readV3F1000(is);
-			pointable = readU8(is);
-		}catch(SerializationError &e){}
-	}
-	else
-	{
+	if (version != 2)
 		throw SerializationError("unsupported ObjectProperties version");
-	}
+
+	try {
+		hp_max = readS16(is);
+		physical = readU8(is);
+		weight = readF1000(is);
+		collisionbox.MinEdge = readV3F1000(is);
+		collisionbox.MaxEdge = readV3F1000(is);
+		selectionbox.MinEdge = readV3F1000(is);
+		selectionbox.MaxEdge = readV3F1000(is);
+		pointable = readU8(is);
+		visual = deSerializeString(is);
+		visual_size = readV2F1000(is);
+		textures.clear();
+		u32 texture_count = readU16(is);
+		for (u32 i = 0; i < texture_count; i++){
+			textures.push_back(deSerializeString(is));
+		}
+		spritediv = readV2S16(is);
+		initial_sprite_basepos = readV2S16(is);
+		is_visible = readU8(is);
+		makes_footstep_sound = readU8(is);
+		automatic_rotate = readF1000(is);
+		mesh = deSerializeString(is);
+		u32 color_count = readU16(is);
+		for (u32 i = 0; i < color_count; i++){
+			colors.push_back(readARGB8(is));
+		}
+		collideWithObjects = readU8(is);
+		stepheight = readF1000(is);
+		automatic_face_movement_dir = readU8(is);
+		automatic_face_movement_dir_offset = readF1000(is);
+		backface_culling = readU8(is);
+		nametag = deSerializeString(is);
+		nametag_color = readARGB8(is);
+		automatic_face_movement_max_rotation_per_sec = readF1000(is);
+		infotext = deSerializeString(is);
+		wield_item = deSerializeString(is);
+	} catch (SerializationError &e) { }
 }

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "util/serialize.h"
 
-void TileAnimationParams::serialize(std::ostream &os, u8 version) const
+void TileAnimationParams::serialize(std::ostream &os, u8 tiledef_version) const
 {
 	writeU8(os, type);
 	if (type == TAT_VERTICAL_FRAMES) {
@@ -33,7 +33,7 @@ void TileAnimationParams::serialize(std::ostream &os, u8 version) const
 	}
 }
 
-void TileAnimationParams::deSerialize(std::istream &is, u8 version)
+void TileAnimationParams::deSerialize(std::istream &is, u8 tiledef_version)
 {
 	type = (TileAnimationType) readU8(is);
 

--- a/src/tileanimation.cpp
+++ b/src/tileanimation.cpp
@@ -19,23 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "util/serialize.h"
 
-void TileAnimationParams::serialize(std::ostream &os, u16 protocol_version) const
+void TileAnimationParams::serialize(std::ostream &os, u8 version) const
 {
-	if (protocol_version < 29) {
-		if (type == TAT_VERTICAL_FRAMES) {
-			writeU8(os, type);
-			writeU16(os, vertical_frames.aspect_w);
-			writeU16(os, vertical_frames.aspect_h);
-			writeF1000(os, vertical_frames.length);
-		} else {
-			writeU8(os, TAT_NONE);
-			writeU16(os, 1);
-			writeU16(os, 1);
-			writeF1000(os, 1.0);
-		}
-		return;
-	}
-
 	writeU8(os, type);
 	if (type == TAT_VERTICAL_FRAMES) {
 		writeU16(os, vertical_frames.aspect_w);
@@ -48,15 +33,9 @@ void TileAnimationParams::serialize(std::ostream &os, u16 protocol_version) cons
 	}
 }
 
-void TileAnimationParams::deSerialize(std::istream &is, u16 protocol_version)
+void TileAnimationParams::deSerialize(std::istream &is, u8 version)
 {
 	type = (TileAnimationType) readU8(is);
-	if (protocol_version < 29) {
-		vertical_frames.aspect_w = readU16(is);
-		vertical_frames.aspect_h = readU16(is);
-		vertical_frames.length = readF1000(is);
-		return;
-	}
 
 	if (type == TAT_VERTICAL_FRAMES) {
 		vertical_frames.aspect_w = readU16(is);

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -50,8 +50,8 @@ struct TileAnimationParams
 		} sheet_2d;
 	};
 
-	void serialize(std::ostream &os, u8 version) const;
-	void deSerialize(std::istream &is, u8 version);
+	void serialize(std::ostream &os, u8 tiledef_version) const;
+	void deSerialize(std::istream &is, u8 tiledef_version);
 	void determineParams(v2u32 texture_size, int *frame_count, int *frame_length_ms,
 			v2u32 *frame_size) const;
 	void getTextureModifer(std::ostream &os, v2u32 texture_size, int frame) const;

--- a/src/tileanimation.h
+++ b/src/tileanimation.h
@@ -50,8 +50,8 @@ struct TileAnimationParams
 		} sheet_2d;
 	};
 
-	void serialize(std::ostream &os, u16 protocol_version) const;
-	void deSerialize(std::istream &is, u16 protocol_version);
+	void serialize(std::ostream &os, u8 version) const;
+	void deSerialize(std::istream &is, u8 version);
 	void determineParams(v2u32 texture_size, int *frame_count, int *frame_length_ms,
 			v2u32 *frame_size) const;
 	void getTextureModifer(std::ostream &os, v2u32 texture_size, int frame) const;

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -55,20 +55,20 @@ void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 void ToolCapabilities::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if (version != 3)
+	if (version < 3)
 		throw SerializationError("unsupported ToolCapabilities version");
 
 	full_punch_interval = readF1000(is);
 	max_drop_level = readS16(is);
 	groupcaps.clear();
 	u32 groupcaps_size = readU32(is);
-	for(u32 i=0; i<groupcaps_size; i++){
+	for (u32 i = 0; i < groupcaps_size; i++) {
 		std::string name = deSerializeString(is);
 		ToolGroupCap cap;
 		cap.uses = readS16(is);
 		cap.maxlevel = readS16(is);
 		u32 times_size = readU32(is);
-		for(u32 i=0; i<times_size; i++){
+		for(u32 i = 0; i < times_size; i++) {
 			int level = readS16(is);
 			float time = readF1000(is);
 			cap.times[level] = time;
@@ -77,7 +77,7 @@ void ToolCapabilities::deSerialize(std::istream &is)
 	}
 
 	u32 damage_groups_size = readU32(is);
-	for(u32 i=0; i<damage_groups_size; i++){
+	for (u32 i = 0; i < damage_groups_size; i++) {
 		std::string name = deSerializeString(is);
 		s16 rating = readS16(is);
 		damageGroups[name] = rating;

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 {
-	writeU8(os, 2); // version (protocol >= 18)
+	writeU8(os, 3); // protocol_version >= 36
 	writeF1000(os, full_punch_interval);
 	writeS16(os, max_drop_level);
 	writeU32(os, groupcaps.size());
@@ -55,8 +55,9 @@ void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 void ToolCapabilities::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if(version != 1 && version != 2) throw SerializationError(
-			"unsupported ToolCapabilities version");
+	if (version != 3)
+		throw SerializationError("unsupported ToolCapabilities version");
+
 	full_punch_interval = readF1000(is);
 	max_drop_level = readS16(is);
 	groupcaps.clear();
@@ -74,14 +75,12 @@ void ToolCapabilities::deSerialize(std::istream &is)
 		}
 		groupcaps[name] = cap;
 	}
-	if(version == 2)
-	{
-		u32 damage_groups_size = readU32(is);
-		for(u32 i=0; i<damage_groups_size; i++){
-			std::string name = deSerializeString(is);
-			s16 rating = readS16(is);
-			damageGroups[name] = rating;
-		}
+
+	u32 damage_groups_size = readU32(is);
+	for(u32 i=0; i<damage_groups_size; i++){
+		std::string name = deSerializeString(is);
+		s16 rating = readS16(is);
+		damageGroups[name] = rating;
 	}
 }
 


### PR DESCRIPTION
Backwards compatibility drop for 0.5.0, including removal of legacy code. This should only be merged with other PRs, which make an use of this breakage to restructure the serialisation code. Requested by nerzhul.