### PR TITLE
MAX_REGISTERED_CONTENT: Move to a setting, default unchanged

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1070,6 +1070,13 @@ csm_flavour_limits (Client side modding flavour limits) int 3
 #   this many nodes from the player.
 csm_flavour_noderange_limit (Client side noderange flavour limit) int 8
 
+#    Maximum number of nodes that can be registered by all mods.
+#    If increased above 32767 there is a small risk of losing some map node
+#    data if a world is used with mods disabled and very many 'unknown' nodes
+#    are loaded into that world.
+#    Needs a program restart to apply the setting, or, add it to minetest.conf.
+max_registered_content (Maximum registered nodes) int 32767 0 65535
+
 [*Security]
 
 #    Prevent mods from doing insecure things like running shell commands.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -354,6 +354,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");
 	settings->setDefault("secure.http_mods", "");
+	settings->setDefault("max_registered_content", "32767");
 
 	// Physics
 	settings->setDefault("movement_acceleration_default", "3");

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -40,8 +40,10 @@ typedef u16 content_t;
 	be significantly lower than the maximum content_t value, so that
 	there is enough room for dummy node IDs, which are created when
 	a MapBlock containing unknown node names is loaded from disk.
+
+	This is now set as a setting, default unchanged at 32767.
+	#define MAX_REGISTERED_CONTENT 0x7fffU
 */
-#define MAX_REGISTERED_CONTENT 0x7fffU
 
 /*
 	A solid walkable node with the texture unknown_node.png.

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "content_sao.h"
 #include "inventory.h"
 #include "log.h"
+#include "settings.h" // For g_settings
 
 
 // garbage collector
@@ -536,13 +537,15 @@ int ModApiItemMod::l_register_item_raw(lua_State *L)
 	idef->registerItem(def);
 
 	// Read the node definition (content features) and register it
-	if(def.type == ITEM_NODE){
+	if (def.type == ITEM_NODE) {
 		ContentFeatures f = read_content_features(L, table);
 		content_t id = ndef->set(f.name, f);
+		static const u16 max_registered_content =
+				g_settings->getU16("max_registered_content");
 
-		if(id > MAX_REGISTERED_CONTENT){
+		if (id > max_registered_content) {
 			throw LuaError("Number of registerable nodes ("
-					+ itos(MAX_REGISTERED_CONTENT+1)
+					+ itos(max_registered_content + 1)
 					+ ") exceeded (" + name + ")");
 		}
 	}


### PR DESCRIPTION
Allows those who use a very large number of nodes to increase the limit
at a small risk of losing map node data in certain situations.
/////////////

Requested in #6101 
Compiles and runs but please check i haven't done something silly.
The value is no longer `#defined` in mapnode.h but is fetched from settings in the 1 place it is used.