### PR TITLE
Add build date to minetest --version and increase readability

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,10 +5,6 @@
 
 #pragma once
 
-#define STRINGIFY(x) #x
-#define STR(x) STRINGIFY(x)
-
-
 #if defined USE_CMAKE_CONFIG_H
 	#include "cmake_config.h"
 #elif defined (__ANDROID__) || defined (ANDROID)
@@ -28,12 +24,3 @@
 		#define BUILD_TYPE "Debug"
 	#endif
 #endif
-
-#define BUILD_INFO "BUILD_TYPE=" BUILD_TYPE \
-		" RUN_IN_PLACE=" STR(RUN_IN_PLACE) \
-		" USE_GETTEXT=" STR(USE_GETTEXT) \
-		" USE_SOUND=" STR(USE_SOUND) \
-		" USE_CURL=" STR(USE_CURL) \
-		" USE_FREETYPE=" STR(USE_FREETYPE) \
-		" USE_LUAJIT=" STR(USE_LUAJIT) \
-		" STATIC_SHAREDIR=" STR(STATIC_SHAREDIR)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,11 +325,11 @@ static void print_allowed_options(const OptionList &allowed_options)
 static void print_version()
 {
 	std::cout << PROJECT_NAME_C " " << g_version_hash
-	          << " (" << porting::getPlatformName() << ")" << std::endl;
+		<< " (" << porting::getPlatformName() << ")" << std::endl;
 #ifndef SERVER
-	std::cout << "Using Irrlicht " << IRRLICHT_SDK_VERSION << std::endl;
+	std::cout << "Using Irrlicht " IRRLICHT_SDK_VERSION << std::endl;
 #endif
-	std::cout << "Build info: " << g_build_info << std::endl;
+	std::cout << g_build_info << std::endl;
 }
 
 static void list_game_ids()

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -31,8 +31,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#define VERSION_GITHASH VERSION_STRING
 #endif
 
+#define STRINGIFY(x) #x
+#define STR(x) STRINGIFY(x)
 
 const char *g_version_string = VERSION_STRING;
 const char *g_version_hash = VERSION_GITHASH;
-const char *g_build_info = "VER=" VERSION_GITHASH " " BUILD_INFO;
-
+const char *g_build_info =
+#ifdef __STDC__
+	"Build date: " __DATE__ " " __TIME__ "\n"
+#endif
+	"BUILD_TYPE=" BUILD_TYPE "\n"
+	"RUN_IN_PLACE=" STR(RUN_IN_PLACE) "\n"
+	"USE_GETTEXT=" STR(USE_GETTEXT) "\n"
+	"USE_SOUND=" STR(USE_SOUND) "\n"
+	"USE_CURL=" STR(USE_CURL) "\n"
+	"USE_FREETYPE=" STR(USE_FREETYPE) "\n"
+	"USE_LUAJIT=" STR(USE_LUAJIT) "\n"
+	"STATIC_SHAREDIR=" STR(STATIC_SHAREDIR);


### PR DESCRIPTION
Before:
```
Minetest 0.5.0-dev-caf61f3b (Linux)
Using Irrlicht 1.8.4
Build info: VER=0.5.0-dev-caf61f3b BUILD_TYPE=Release RUN_IN_PLACE=0 USE_GETTEXT=0 USE_SOUND=1 USE_CURL=1 USE_FREETYPE=1 USE_LUAJIT=1 STATIC_SHAREDIR="/usr/local/share/minetest"
```

After:
```
Minetest 0.5.0-dev-caf61f3b (Linux)
Using Irrlicht 1.8.4
Build date: Aug 28 2017 16:36:55
BUILD_TYPE=Release
RUN_IN_PLACE=0
USE_GETTEXT=0
USE_SOUND=1
USE_CURL=1
USE_FREETYPE=1
USE_LUAJIT=1
STATIC_SHAREDIR="/usr/local/share/minetest"
```
<details>
Out of date
After:
```
Minetest (Linux)
Using Irrlicht 1.8.4
Build Info:
	Version: 0.5.0-dev-caf61f3b
	Date:    Aug 28 2017 13:27:11
	Flags:   BUILD_TYPE=Release RUN_IN_PLACE=0 USE_GETTEXT=0 USE_SOUND=1 USE_CURL=1 USE_FREETYPE=1 USE_LUAJIT=1 STATIC_SHAREDIR="/usr/local/share/minetest"
```
</details>