### PR TITLE
Network proto handlers/container fixes

### DIFF
--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -52,7 +52,7 @@ struct ClientEvent
 		//} none;
 		struct
 		{
-			u8 amount;
+			u16 amount;
 		} player_damage;
 		struct
 		{

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -375,11 +375,11 @@ void Client::handleCommand_TimeOfDay(NetworkPacket* pkt)
 	}
 	else {
 		// Old message; try to approximate speed of time by ourselves
-		float time_of_day_f = (float)time_of_day / 24000.0;
+		float time_of_day_f = (float)time_of_day / 24000.0f;
 		float tod_diff_f = 0;
 
 		if (time_of_day_f < 0.2 && m_last_time_of_day_f > 0.8)
-			tod_diff_f = time_of_day_f - m_last_time_of_day_f + 1.0;
+			tod_diff_f = time_of_day_f - m_last_time_of_day_f + 1.0f;
 		else
 			tod_diff_f = time_of_day_f - m_last_time_of_day_f;
 
@@ -388,7 +388,7 @@ void Client::handleCommand_TimeOfDay(NetworkPacket* pkt)
 		m_time_of_day_update_timer = 0;
 
 		if (m_time_of_day_set) {
-			time_speed = (3600.0 * 24.0) * tod_diff_f / time_diff;
+			time_speed = (3600.0f * 24.0f) * tod_diff_f / time_diff;
 			infostream << "Client: Measured time_of_day speed (old format): "
 					<< time_speed << " tod_diff_f=" << tod_diff_f
 					<< " time_diff=" << time_diff << std::endl;
@@ -565,9 +565,9 @@ void Client::handleCommand_HP(NetworkPacket* pkt)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
 
-	u8 oldhp   = player->hp;
+	u16 oldhp   = player->hp;
 
-	u8 hp;
+	u16 hp;
 	*pkt >> hp;
 
 	player->hp = hp;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -966,7 +966,7 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	std::string texture     = deSerializeLongString(is);
 	bool vertical           = false;
 	bool collision_removal  = false;
-	struct TileAnimationParams animation;
+	TileAnimationParams animation;
 	animation.type = TAT_NONE;
 	u8 glow = 0;
 	try {
@@ -1020,7 +1020,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 
 	bool vertical = false;
 	bool collision_removal = false;
-	struct TileAnimationParams animation;
+	TileAnimationParams animation;
 	animation.type = TAT_NONE;
 	u8 glow = 0;
 	u16 attached_id = 0;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -780,8 +780,8 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	*pkt >> f32pitch;
 	*pkt >> f32yaw;
 
-	f32 pitch = (f32)f32pitch / 100.0;
-	f32 yaw = (f32)f32yaw / 100.0;
+	f32 pitch = (f32)f32pitch / 100.0f;
+	f32 yaw = (f32)f32yaw / 100.0f;
 	u32 keyPressed = 0;
 
 	// default behavior (in case an old client doesn't send these)
@@ -792,13 +792,13 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 		*pkt >> keyPressed;
 	if (pkt->getRemainingBytes() >= 1) {
 		*pkt >> f32fov;
-		fov = (f32)f32fov / 80.0;
+		fov = (f32)f32fov / 80.0f;
 	}
 	if (pkt->getRemainingBytes() >= 1)
 		*pkt >> wanted_range;
 
-	v3f position((f32)ps.X / 100.0, (f32)ps.Y / 100.0, (f32)ps.Z / 100.0);
-	v3f speed((f32)ss.X / 100.0, (f32)ss.Y / 100.0, (f32)ss.Z / 100.0);
+	v3f position((f32)ps.X / 100.0f, (f32)ps.Y / 100.0f, (f32)ps.Z / 100.0f);
+	v3f speed((f32)ss.X / 100.0f, (f32)ss.Y / 100.0f, (f32)ss.Z / 100.0f);
 
 	pitch = modulo360f(pitch);
 	yaw = wrapDegrees_0_360(yaw);
@@ -1406,7 +1406,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		if (max_d < 0 && max_d_hand >= 0)
 			max_d = max_d_hand;
 		else if (max_d < 0)
-			max_d = BS * 4.0;
+			max_d = BS * 4.0f;
 		// cube diagonal: sqrt(3) = 1.73
 		if (d > max_d * 1.73) {
 			actionstream << "Player " << player->getName()

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1431,7 +1431,7 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 		DiePlayer(peer_id);
 }
 
-void Server::SendHP(u16 peer_id, u8 hp)
+void Server::SendHP(u16 peer_id, u16 hp)
 {
 	DSTACK(FUNCTION_NAME);
 

--- a/src/server.h
+++ b/src/server.h
@@ -347,7 +347,7 @@ private:
 	friend class RemoteClient;
 
 	void SendMovement(u16 peer_id);
-	void SendHP(u16 peer_id, u8 hp);
+	void SendHP(u16 peer_id, u16 hp);
 	void SendBreath(u16 peer_id, u16 breath);
 	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -246,7 +246,7 @@ void TestConnection::testConnectSendReceive()
 		NetworkPacket pkt;
 		pkt.putRawPacket((u8*) "Hello World !", 14, 0);
 
-		Buffer<u8> sentdata = pkt.oldForgePacket();
+		SharedBuffer<u8> sentdata = pkt.oldForgePacket();
 
 		infostream<<"** running client.Send()"<<std::endl;
 		client.Send(PEER_ID_SERVER, 0, &pkt, true);
@@ -261,7 +261,7 @@ void TestConnection::testConnectSendReceive()
 				<< ", data=" << (const char*)pkt.getU8Ptr(0)
 				<< std::endl;
 
-		Buffer<u8> recvdata = pkt.oldForgePacket();
+		SharedBuffer<u8> recvdata = pkt.oldForgePacket();
 
 		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
 	}


### PR DESCRIPTION
* Fix overflow with TOCLIENT_HP transmission (hp can no be 0-65535, properly)
* Fix various double -> float
* Remove two useless struct keywords