### PR TITLE
Zoom: Move enabling zoom to a new player object property 

### DIFF
--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -82,10 +82,6 @@ core.register_privilege("rollback", {
 	description = "Can use the rollback functionality",
 	give_to_singleplayer = false,
 })
-core.register_privilege("zoom", {
-	description = "Can zoom the camera",
-	give_to_singleplayer = false,
-})
 core.register_privilege("debug", {
 	description = "Allows enabling various debug options that may affect gameplay",
 	give_to_singleplayer = false,

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -453,7 +453,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Get FOV
 	f32 fov_degrees;
-	if (player->getPlayerControl().zoom && m_client->checkLocalPrivilege("zoom")) {
+	if (player->getPlayerControl().zoom && player->getCanZoom()) {
 		fov_degrees = m_cache_zoom_fov;
 	} else {
 		fov_degrees = m_cache_fov;

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1239,6 +1239,7 @@ void GenericCAO::processMessage(const std::string &data)
 			collision_box.MinEdge *= BS;
 			collision_box.MaxEdge *= BS;
 			player->setCollisionbox(collision_box);
+			player->setCanZoom(m_prop.can_zoom);
 		}
 
 		if ((m_is_player && !m_is_local_player) && m_prop.nametag.empty())

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -801,6 +801,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id
 	m_prop.is_visible = true;
 	m_prop.makes_footstep_sound = true;
 	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
+	m_prop.can_zoom = true;
 	m_hp = m_prop.hp_max;
 }
 

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -124,11 +124,9 @@ public:
 	v3s16 getLightPosition() const;
 
 	void setYaw(f32 yaw) { m_yaw = yaw; }
-
 	f32 getYaw() const { return m_yaw; }
 
 	void setPitch(f32 pitch) { m_pitch = pitch; }
-
 	f32 getPitch() const { return m_pitch; }
 
 	inline void setPosition(const v3f &position)
@@ -142,6 +140,9 @@ public:
 	v3f getEyeOffset() const;
 
 	void setCollisionbox(const aabb3f &box) { m_collisionbox = box; }
+
+	bool getCanZoom() const { return m_can_zoom; }
+	void setCanZoom(bool can_zoom) { m_can_zoom = can_zoom; }
 
 private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
@@ -178,6 +179,7 @@ private:
 	bool camera_barely_in_ceiling = false;
 	aabb3f m_collisionbox = aabb3f(-BS * 0.30f, 0.0f, -BS * 0.30f, BS * 0.30f,
 			BS * 1.75f, BS * 0.30f);
+	bool m_can_zoom = true;
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -63,6 +63,7 @@ std::string ObjectProperties::dump()
 			<< "," << nametag_color.getGreen() << "," << nametag_color.getBlue() << "\" ";
 	os << ", selectionbox=" << PP(selectionbox.MinEdge) << "," << PP(selectionbox.MaxEdge);
 	os << ", pointable=" << pointable;
+	os << ", can_zoom=" << can_zoom;
 	return os.str();
 }
 
@@ -104,6 +105,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
 	os << serializeString(infotext);
 	os << serializeString(wield_item);
+	writeU8(os, can_zoom);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -150,4 +152,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	automatic_face_movement_max_rotation_per_sec = readF1000(is);
 	infotext = deSerializeString(is);
 	wield_item = deSerializeString(is);
+	can_zoom = readU8(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -44,8 +44,9 @@ struct ObjectProperties
 	v2s16 initial_sprite_basepos;
 	bool is_visible = true;
 	bool makes_footstep_sound = false;
-	float automatic_rotate = 0.0f;
 	f32 stepheight = 0.0f;
+	bool can_zoom = true;
+	float automatic_rotate = 0.0f;
 	bool automatic_face_movement_dir = false;
 	f32 automatic_face_movement_dir_offset = 0.0f;
 	bool backface_culling = true;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -260,9 +260,11 @@ void read_object_properties(lua_State *L, int index,
 
 	getboolfield(L, -1, "is_visible", prop->is_visible);
 	getboolfield(L, -1, "makes_footstep_sound", prop->makes_footstep_sound);
-	getfloatfield(L, -1, "automatic_rotate", prop->automatic_rotate);
 	if (getfloatfield(L, -1, "stepheight", prop->stepheight))
 		prop->stepheight *= BS;
+	getboolfield(L, -1, "can_zoom", prop->can_zoom);
+
+	getfloatfield(L, -1, "automatic_rotate", prop->automatic_rotate);
 	lua_getfield(L, -1, "automatic_face_movement_dir");
 	if (lua_isnumber(L, -1)) {
 		prop->automatic_face_movement_dir = true;
@@ -344,10 +346,13 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "is_visible");
 	lua_pushboolean(L, prop->makes_footstep_sound);
 	lua_setfield(L, -2, "makes_footstep_sound");
-	lua_pushnumber(L, prop->automatic_rotate);
-	lua_setfield(L, -2, "automatic_rotate");
 	lua_pushnumber(L, prop->stepheight / BS);
 	lua_setfield(L, -2, "stepheight");
+	lua_pushboolean(L, prop->can_zoom);
+	lua_setfield(L, -2, "can_zoom");
+
+	lua_pushnumber(L, prop->automatic_rotate);
+	lua_setfield(L, -2, "automatic_rotate");
 	if (prop->automatic_face_movement_dir)
 		lua_pushnumber(L, prop->automatic_face_movement_dir_offset);
 	else


### PR DESCRIPTION
Default enabled for no change in default behaviour.
Remove 'zoom' privilege.
///////////////

Implements #4700 as discussed and agreed on.