### PR TITLE
Documentation for 'slippery' node group

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1452,7 +1452,7 @@ Another example: Make red wool from white wool and red dye:
 * `connect_to_raillike`: makes nodes of raillike drawtype with same group value
   connect to each other
 * `slippery`: Players and items will slide on the node.
-  Only use `slippery = 3` for now to ensure forwards compatibility.
+  Slipperiness rises steadily with `slippery` value, starting at 1.
 
 
 ### Known damage and digging time defining groups


### PR DESCRIPTION
Documentation was still missing for `slippery` node group. Wording is open for discussion.

I can't get very specific about the effect of the value, since the formula (1 / (1 + value)) is very robust, but not very intuitive, and since the value is effectively doubled when "standing still".