### PR TITLE
[WIP] Add NPC API

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -651,16 +651,16 @@ core.register_chatcommand("spawn_npc", {
 	description = "Spawn NPC at given (or your) position",
 	privs = {give=true, interact=true},
 	func = function(name, param)
-		local entityname, p = string.match(param, "^([^ ]+) *(.*)$")
-		if not entityname then
-			return false, "EntityName required"
+		local npcname, p = string.match(param, "^([^ ]+) *(.*)$")
+		if not npcname then
+			return false, "NpcName required"
 		end
 
-		if core.registered_npc[entityname] == nil then
-			return false, "No NPC with name " .. entityname .. " registered."
+		if core.registered_npc[npcname] == nil then
+			return false, "No NPC with name " .. npcname .. " registered."
 		end
 
-		core.log("action", ("%s invokes /spawn_npc, npcname=%q"):format(name, entityname))
+		core.log("action", ("%s invokes /spawn_npc, npcname=%q"):format(name, npcname))
 		local player = core.get_player_by_name(name)
 		if player == nil then
 			core.log("error", "Unable to spawn NPC, player is nil")
@@ -675,8 +675,8 @@ core.register_chatcommand("spawn_npc", {
 			end
 		end
 		p.y = p.y + 1
-		core.add_npc(p, entityname)
-		return true, ("%q spawned."):format(entityname)
+		core.add_npc(p, npcname)
+		return true, ("%q spawned."):format(npcname)
 	end,
 })
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -646,6 +646,40 @@ core.register_chatcommand("spawnentity", {
 	end,
 })
 
+core.register_chatcommand("spawn_npc", {
+	params = "<EntityName> [<X>,<Y>,<Z>]",
+	description = "Spawn NPC at given (or your) position",
+	privs = {give=true, interact=true},
+	func = function(name, param)
+		local entityname, p = string.match(param, "^([^ ]+) *(.*)$")
+		if not entityname then
+			return false, "EntityName required"
+		end
+
+		if core.registered_npc[entityname] == nil then
+			return false, "No NPC with name " .. entityname .. " registered."
+		end
+
+		core.log("action", ("%s invokes /spawn_npc, npcname=%q"):format(name, entityname))
+		local player = core.get_player_by_name(name)
+		if player == nil then
+			core.log("error", "Unable to spawn NPC, player is nil")
+			return false, "Unable to spawn NPC, player is nil"
+		end
+		if p == "" then
+			p = player:getpos()
+		else
+			p = core.string_to_pos(p)
+			if p == nil then
+				return false, "Invalid parameters ('" .. param .. "')"
+			end
+		end
+		p.y = p.y + 1
+		core.add_npc(p, entityname)
+		return true, ("%q spawned."):format(entityname)
+	end,
+})
+
 core.register_chatcommand("pulverize", {
 	params = "",
 	description = "Destroy item in hand",

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -20,6 +20,7 @@ core.register_alias_raw = nil
 core.registered_abms = {}
 core.registered_lbms = {}
 core.registered_entities = {}
+core.registered_npc = {}
 core.registered_items = {}
 core.registered_nodes = {}
 core.registered_craftitems = {}
@@ -102,6 +103,21 @@ function core.register_entity(name, prototype)
 
 	-- Add to core.registered_entities
 	core.registered_entities[name] = prototype
+	prototype.mod_origin = core.get_current_modname() or "??"
+end
+
+function core.register_npc(name, prototype)
+	-- Check name
+	if name == nil then
+		error("Unable to register npc: Name is nil")
+	end
+	name = check_modname_prefix(tostring(name))
+
+	prototype.name = name
+	prototype.__index = prototype  -- so that it can be used as a metatable
+
+	-- Add to core.registered_npc
+	core.registered_npc[name] = prototype
 	prototype.mod_origin = core.get_current_modname() or "??"
 end
 

--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -293,7 +293,7 @@ end)
 -- A test entity for testing animated and yaw-modulated sprites
 --
 
-minetest.register_entity("experimental:testentity", {
+minetest.register_npc("experimental:testentity", {
 	-- Static definition
 	physical = true, -- Collides with things
 	-- weight = 5,

--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -4,6 +4,9 @@
 
 -- For testing random stuff
 
+local modpath = minetest.get_modpath("experimental")
+dofile(modpath .. "/npc.lua")
+
 experimental = {}
 
 function experimental.print_to_everything(msg)

--- a/games/minimal/mods/experimental/npc.lua
+++ b/games/minimal/mods/experimental/npc.lua
@@ -1,0 +1,44 @@
+--
+-- NPC stuff
+--
+
+minetest.register_npc("experimental:npc", {
+	initial_properties = {
+		hp_max = 20,
+		physical = false,
+		collisionbox = {-0.4,-0.4,-0.4, 0.4,0.4,0.4},
+		visual = "sprite",
+		visual_size = {x=1, y=1},
+		textures = {"experimental_dummyball.png"},
+		spritediv = {x=1, y=3},
+		initial_sprite_basepos = {x=0, y=0},
+	},
+
+	phase = 0,
+	phasetimer = 0,
+
+	on_activate = function(self, staticdata)
+		minetest.log("Dummyball npc!")
+	end,
+
+	on_step = function(self, dtime)
+		self.phasetimer = self.phasetimer + dtime
+		if self.phasetimer > 2.0 then
+			self.phasetimer = self.phasetimer - 2.0
+			self.phase = self.phase + 1
+			if self.phase >= 3 then
+				self.phase = 0
+			end
+			self.object:setsprite({x=0, y=self.phase})
+			phasearmor = {
+				[0]={cracky=3},
+				[1]={crumbly=3},
+				[2]={fleshy=3}
+			}
+			self.object:set_armor_groups(phasearmor[self.phase])
+		end
+	end,
+
+	on_punch = function(self, hitter)
+	end,
+})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,6 +376,7 @@ set(common_SRCS
 	content_mapnode.cpp
 	content_nodemeta.cpp
 	content_sao.cpp
+	npc_sao.cpp
 	convert_json.cpp
 	craftdef.cpp
 	database-dummy.cpp

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -33,6 +33,7 @@ enum ActiveObjectType {
 	ACTIVEOBJECT_TYPE_MOBV2 = 6,
 // End deprecated stuff
 	ACTIVEOBJECT_TYPE_LUAENTITY = 7,
+	ACTIVEOBJECT_TYPE_NPC = 8,
 // Special type, not stored as a static object
 	ACTIVEOBJECT_TYPE_PLAYER = 100,
 // Special type, only exists as CAO

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -94,7 +94,7 @@ class LuaEntitySAO : public UnitSAO
 public:
 	LuaEntitySAO(ServerEnvironment *env, v3f pos,
 	             const std::string &name, const std::string &state);
-	~LuaEntitySAO();
+	virtual ~LuaEntitySAO();
 	ActiveObjectType getType() const
 	{ return ACTIVEOBJECT_TYPE_LUAENTITY; }
 	ActiveObjectType getSendType() const
@@ -130,7 +130,7 @@ public:
 	bool getCollisionBox(aabb3f *toset) const;
 	bool getSelectionBox(aabb3f *toset) const;
 	bool collideWithObjects() const;
-private:
+protected:
 	std::string getPropertyPacket();
 	void sendPosition(bool do_interpolate, bool is_movement_end);
 

--- a/src/npc_sao.cpp
+++ b/src/npc_sao.cpp
@@ -1,0 +1,75 @@
+#include "npc_sao.h"
+#include "util/serialize.h"
+#include "environment.h"
+#include "server.h"
+#include "scripting_server.h"
+
+// Prototype (registers item for deserialization)
+NpcSAO proto_NpcEntitySAO(NULL, v3f(0,0,0), "_prototype", "");
+
+NpcSAO::NpcSAO(ServerEnvironment *env, v3f pos,
+	const std::string &name, const std::string &state):
+		LuaEntitySAO(env, pos, name, state)
+{
+	if(env == NULL){
+		ServerActiveObject::registerType(getType(), create);
+		return;
+	}
+}
+
+NpcSAO::~NpcSAO()
+{
+
+}
+
+ServerActiveObject* NpcSAO::create(ServerEnvironment *env, v3f pos,
+	const std::string &data)
+{
+	std::string name;
+	std::string state;
+	s16 hp = 1;
+	v3f velocity;
+	float yaw = 0;
+	if (!data.empty()) {
+		std::istringstream is(data, std::ios::binary);
+		// read version
+		u8 version = readU8(is);
+		// check if version is supported
+		if (version == 1) {
+			name = deSerializeString(is);
+			state = deSerializeLongString(is);
+			hp = readS16(is);
+			velocity = readV3F1000(is);
+			yaw = readF1000(is);
+		}
+	}
+	// create object
+	infostream << "NpcSAO::create(name=\"" << name << "\" state=\""
+			   << state << "\")" << std::endl;
+	NpcSAO *sao = new NpcSAO(env, pos, name, state);
+	sao->m_hp = hp;
+	sao->m_velocity = velocity;
+	sao->m_yaw = yaw;
+	return sao;
+}
+
+void NpcSAO::addedToEnvironment(u32 dtime_s)
+{
+	ServerActiveObject::addedToEnvironment(dtime_s);
+
+	// Create entity from name
+	m_registered = m_env->getScriptIface()->luanpc_Add(m_id, m_init_name.c_str());
+
+	if(m_registered){
+		// Get properties
+		m_env->getScriptIface()->
+				luaentity_GetProperties(m_id, &m_prop);
+		// Initialize HP from properties
+		m_hp = m_prop.hp_max;
+		// Activate entity, supplying serialized state
+		m_env->getScriptIface()->
+				luaentity_Activate(m_id, m_init_state, dtime_s);
+	} else {
+		m_prop.infotext = m_init_name;
+	}
+}

--- a/src/npc_sao.cpp
+++ b/src/npc_sao.cpp
@@ -57,18 +57,18 @@ void NpcSAO::addedToEnvironment(u32 dtime_s)
 {
 	ServerActiveObject::addedToEnvironment(dtime_s);
 
-	// Create entity from name
+	// Create npc from name
 	m_registered = m_env->getScriptIface()->luanpc_Add(m_id, m_init_name.c_str());
 
 	if(m_registered){
 		// Get properties
 		m_env->getScriptIface()->
-				luaentity_GetProperties(m_id, &m_prop);
+				luanpc_GetProperties(m_id, &m_prop);
 		// Initialize HP from properties
 		m_hp = m_prop.hp_max;
-		// Activate entity, supplying serialized state
+		// Activate npc, supplying serialized state
 		m_env->getScriptIface()->
-				luaentity_Activate(m_id, m_init_state, dtime_s);
+				luanpc_Activate(m_id, m_init_state, dtime_s);
 	} else {
 		m_prop.infotext = m_init_name;
 	}

--- a/src/npc_sao.h
+++ b/src/npc_sao.h
@@ -1,0 +1,38 @@
+/*
+Minetest
+Copyright (C) 2010-2017 Vincent Glize, Dumbeldor <vincent.glize@live.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+#include "content_sao.h"
+
+class NpcSAO : public LuaEntitySAO
+{
+public:
+	NpcSAO(ServerEnvironment *env, v3f pos,
+				 const std::string &name, const std::string &state);
+	virtual ~NpcSAO();
+	ActiveObjectType getType() const
+	{ return ACTIVEOBJECT_TYPE_NPC; }
+	ActiveObjectType getSendType() const
+	{ return ACTIVEOBJECT_TYPE_GENERIC; }
+	virtual void addedToEnvironment(u32 dtime_s);
+
+	static ServerActiveObject *create(ServerEnvironment *env, v3f pos,
+									  const std::string &data);
+};
+

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1540,6 +1540,19 @@ void luaentity_get(lua_State *L, u16 id)
 }
 
 /******************************************************************************/
+void luanpc_get(lua_State *L, u16 id)
+{
+	// Get luaentities[i]
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "luanpc");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_pushnumber(L, id);
+	lua_gettable(L, -2);
+	lua_remove(L, -2); // Remove luanpc
+	lua_remove(L, -2); // Remove core
+}
+
+/******************************************************************************/
 bool read_noiseparams(lua_State *L, int index, NoiseParams *np)
 {
 	if (index < 0)

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -171,6 +171,8 @@ void               push_noiseparams          (lua_State *L, NoiseParams *np);
 
 void               luaentity_get             (lua_State *L,u16 id);
 
+void               luanpc_get                (lua_State *L,u16 id);
+
 bool               push_json_value           (lua_State *L,
                                               const Json::Value &value,
                                               int nullindex);

--- a/src/script/cpp_api/CMakeLists.txt
+++ b/src/script/cpp_api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(common_SCRIPT_CPP_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/s_async.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_base.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_entity.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/s_npc.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_env.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_inventory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_item.cpp

--- a/src/script/cpp_api/s_npc.cpp
+++ b/src/script/cpp_api/s_npc.cpp
@@ -1,0 +1,76 @@
+/*
+Minetest
+Copyright (C) 2017 Vincent Glize, Dumbeldor <vincent.glize@live.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "cpp_api/s_npc.h"
+#include "cpp_api/s_internal.h"
+#include "log.h"
+#include "object_properties.h"
+#include "common/c_converter.h"
+#include "common/c_content.h"
+#include "server.h"
+
+bool ScriptApiNpc::luanpc_Add(u16 id, const char *name)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	verbosestream<<"scriptapi_luanpc_add: id="<<id<<" name=\""
+				 <<name<<"\""<<std::endl;
+
+	// Get core.registered_entities[name]
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_npc");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_pushstring(L, name);
+	lua_gettable(L, -2);
+	// Should be a table, which we will use as a prototype
+	//luaL_checktype(L, -1, LUA_TTABLE);
+	if (lua_type(L, -1) != LUA_TTABLE){
+		errorstream<<"luanpc name \""<<name<<"\" not defined"<<std::endl;
+		return false;
+	}
+	int prototype_table = lua_gettop(L);
+	//dump2(L, "prototype_table");
+
+	// Create npc object
+	lua_newtable(L);
+	int object = lua_gettop(L);
+
+	// Set object metatable
+	lua_pushvalue(L, prototype_table);
+	lua_setmetatable(L, -2);
+
+	// Add object reference
+	// This should be userdata with metatable ObjectRef
+	push_objectRef(L, id);
+	luaL_checktype(L, -1, LUA_TUSERDATA);
+	if (!luaL_checkudata(L, -1, "ObjectRef"))
+		luaL_typerror(L, -1, "ObjectRef");
+	lua_setfield(L, -2, "object");
+
+	// core.luaentities[id] = object
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "luanpc");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	lua_pushnumber(L, id); // Push id
+	lua_pushvalue(L, object); // Copy object to top of stack
+	lua_settable(L, -3);
+
+	return true;
+}
+

--- a/src/script/cpp_api/s_npc.cpp
+++ b/src/script/cpp_api/s_npc.cpp
@@ -74,3 +74,251 @@ bool ScriptApiNpc::luanpc_Add(u16 id, const char *name)
 	return true;
 }
 
+void ScriptApiNpc::luanpc_Activate(u16 id,
+										 const std::string &staticdata, u32 dtime_s)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	verbosestream << "scriptapi_luanpc_activate: id=" << id << std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+	int object = lua_gettop(L);
+
+	// Get on_activate function
+	lua_getfield(L, -1, "on_activate");
+	if (!lua_isnil(L, -1)) {
+		luaL_checktype(L, -1, LUA_TFUNCTION);
+		lua_pushvalue(L, object); // self
+		lua_pushlstring(L, staticdata.c_str(), staticdata.size());
+		lua_pushinteger(L, dtime_s);
+
+		setOriginFromTable(object);
+		PCALL_RES(lua_pcall(L, 3, 0, error_handler));
+	} else {
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 2); // Pop object and error handler
+}
+
+void ScriptApiNpc::luanpc_Remove(u16 id)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	verbosestream << "scriptapi_luanpc_rm: id=" << id << std::endl;
+
+	// Get core.luaentities table
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "luaentities");
+	luaL_checktype(L, -1, LUA_TTABLE);
+	int objectstable = lua_gettop(L);
+
+	// Set luaentities[id] = nil
+	lua_pushnumber(L, id); // Push id
+	lua_pushnil(L);
+	lua_settable(L, objectstable);
+
+	lua_pop(L, 2); // pop luaentities, core
+}
+
+std::string ScriptApiNpc::luanpc_GetStaticdata(u16 id)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	//infostream<<"scriptapi_luanpc_get_staticdata: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+	int object = lua_gettop(L);
+
+	// Get get_staticdata function
+	lua_getfield(L, -1, "get_staticdata");
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 2); // Pop npc and  get_staticdata
+		return "";
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+	lua_pushvalue(L, object); // self
+
+	setOriginFromTable(object);
+	PCALL_RES(lua_pcall(L, 1, 1, error_handler));
+
+	lua_remove(L, object);
+	lua_remove(L, error_handler);
+
+	size_t len = 0;
+	const char *s = lua_tolstring(L, -1, &len);
+	lua_pop(L, 1); // Pop static data
+	return std::string(s, len);
+}
+
+void ScriptApiNpc::luanpc_GetProperties(u16 id,
+											  ObjectProperties *prop)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	//infostream<<"scriptapi_luanpc_get_properties: id="<<id<<std::endl;
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+
+	// Set default values that differ from ObjectProperties defaults
+	prop->hp_max = 10;
+
+	/* Read stuff */
+
+	//prop->hp_max = getintfield_default(L, -1, "hp_max", 10);
+	prop->hp_max = 20;
+
+	getboolfield(L, -1, "physical", prop->physical);
+	getboolfield(L, -1, "collide_with_objects", prop->collideWithObjects);
+
+	getfloatfield(L, -1, "weight", prop->weight);
+
+	lua_getfield(L, -1, "collisionbox");
+	if (lua_istable(L, -1))
+		prop->collisionbox = read_aabb3f(L, -1, 1.0);
+	lua_pop(L, 1);
+
+	getstringfield(L, -1, "visual", prop->visual);
+
+	getstringfield(L, -1, "mesh", prop->mesh);
+
+	// Deprecated: read object properties directly
+	read_object_properties(L, -1, prop, getServer()->idef());
+
+	// Read initial_properties
+	lua_getfield(L, -1, "initial_properties");
+	read_object_properties(L, -1, prop, getServer()->idef());
+	lua_pop(L, 1);
+}
+
+void ScriptApiNpc::luanpc_Step(u16 id, float dtime)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	//infostream<<"scriptapi_luanpc_step: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+	int object = lua_gettop(L);
+	// State: object is at top of stack
+	// Get step function
+	lua_getfield(L, -1, "on_step");
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 2); // Pop on_step and npc
+		return;
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+	lua_pushvalue(L, object); // self
+	lua_pushnumber(L, dtime); // dtime
+
+	setOriginFromTable(object);
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+
+	lua_pop(L, 2); // Pop object and error handler
+}
+
+// Calls npc:on_punch(ObjectRef puncher, time_from_last_punch,
+//                       tool_capabilities, direction, damage)
+bool ScriptApiNpc::luanpc_Punch(u16 id,
+									  ServerActiveObject *puncher, float time_from_last_punch,
+									  const ToolCapabilities *toolcap, v3f dir, s16 damage)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	//infostream<<"scriptapi_luanpc_step: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L,id);
+	int object = lua_gettop(L);
+	// State: object is at top of stack
+	// Get function
+	lua_getfield(L, -1, "on_punch");
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 2); // Pop on_punch and npc
+		return false;
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+	lua_pushvalue(L, object);  // self
+	objectrefGetOrCreate(L, puncher);  // Clicker reference
+	lua_pushnumber(L, time_from_last_punch);
+	push_tool_capabilities(L, *toolcap);
+	push_v3f(L, dir);
+	lua_pushnumber(L, damage);
+
+	setOriginFromTable(object);
+	PCALL_RES(lua_pcall(L, 6, 1, error_handler));
+
+	bool retval = lua_toboolean(L, -1);
+	lua_pop(L, 2); // Pop object and error handler
+	return retval;
+}
+
+bool ScriptApiNpc::luanpc_on_death(u16 id, ServerActiveObject *killer)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+	int object = lua_gettop(L);
+	// State: object is at top of stack
+	// Get function
+	lua_getfield(L, -1, "on_death");
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 2); // Pop on_death and npc
+		return false;
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+	lua_pushvalue(L, object);  // self
+	objectrefGetOrCreate(L, killer);  // killer reference
+
+	setOriginFromTable(object);
+	PCALL_RES(lua_pcall(L, 2, 1, error_handler));
+
+	bool retval = lua_toboolean(L, -1);
+	lua_pop(L, 2); // Pop object and error handler
+	return retval;
+}
+
+// Calls npc:on_rightclick(ObjectRef clicker)
+void ScriptApiNpc::luanpc_Rightclick(u16 id,
+										   ServerActiveObject *clicker)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	//infostream<<"scriptapi_luanpc_step: id="<<id<<std::endl;
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+
+	// Get core.luaentities[id]
+	luanpc_get(L, id);
+	int object = lua_gettop(L);
+	// State: object is at top of stack
+	// Get function
+	lua_getfield(L, -1, "on_rightclick");
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 2); // Pop on_rightclick and npc
+		return;
+	}
+	luaL_checktype(L, -1, LUA_TFUNCTION);
+	lua_pushvalue(L, object); // self
+	objectrefGetOrCreate(L, clicker); // Clicker reference
+
+	setOriginFromTable(object);
+	PCALL_RES(lua_pcall(L, 2, 0, error_handler));
+
+	lua_pop(L, 2); // Pop object and error handler
+}
+
+

--- a/src/script/cpp_api/s_npc.h
+++ b/src/script/cpp_api/s_npc.h
@@ -22,8 +22,24 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "s_base.h"
 #include "irr_v3d.h"
 
+struct ObjectProperties;
+struct ToolCapabilities;
+
 class ScriptApiNpc : virtual public ScriptApiBase
 {
 public:
 	bool luanpc_Add(u16 id, const char *name);
+	void luanpc_Activate(u16 id,
+							const std::string &staticdata, u32 dtime_s);
+	void luanpc_Remove(u16 id);
+	std::string luanpc_GetStaticdata(u16 id);
+	void luanpc_GetProperties(u16 id,
+								 ObjectProperties *prop);
+	void luanpc_Step(u16 id, float dtime);
+	bool luanpc_Punch(u16 id,
+						 ServerActiveObject *puncher, float time_from_last_punch,
+						 const ToolCapabilities *toolcap, v3f dir, s16 damage);
+	bool luanpc_on_death(u16 id, ServerActiveObject *killer);
+	void luanpc_Rightclick(u16 id,
+							  ServerActiveObject *clicker);
 };

--- a/src/script/cpp_api/s_npc.h
+++ b/src/script/cpp_api/s_npc.h
@@ -1,0 +1,29 @@
+/*
+Minetest
+Copyright (C) 2017 Vincent Glize, Dumbeldor <vincent.glize@live.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "s_base.h"
+#include "irr_v3d.h"
+
+class ScriptApiNpc : virtual public ScriptApiBase
+{
+public:
+	bool luanpc_Add(u16 id, const char *name);
+};

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include <algorithm>
+#include "npc_sao.h"
 #include "scripting_server.h"
 #include "environment.h"
 #include "mapblock.h"
@@ -568,7 +569,30 @@ int ModApiEnvMod::l_add_entity(lua_State *L)
 	ServerActiveObject *obj = new LuaEntitySAO(env, pos, name, staticdata);
 	int objectid = env->addActiveObject(obj);
 	// If failed to add, return nothing (reads as nil)
-	if(objectid == 0)
+	if (objectid == 0)
+		return 0;
+	// Return ObjectRef
+	getScriptApiBase(L)->objectrefGetOrCreate(L, obj);
+	return 1;
+}
+
+// add_entity(pos, entityname, [staticdata]) -> ObjectRef or nil
+// pos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_add_npc(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// pos
+	v3f pos = checkFloatPos(L, 1);
+	// content
+	const char *name = luaL_checkstring(L, 2);
+	// staticdata
+	const char *staticdata = luaL_optstring(L, 3, "");
+	// Do it
+	ServerActiveObject *obj = new NpcSAO(env, pos, name, staticdata);
+	int objectid = env->addActiveObject(obj);
+	// If failed to add, return nothing (reads as nil)
+	if (objectid == 0)
 		return 0;
 	// Return ObjectRef
 	getScriptApiBase(L)->objectrefGetOrCreate(L, obj);
@@ -585,7 +609,7 @@ int ModApiEnvMod::l_add_item(lua_State *L)
 	//v3f pos = checkFloatPos(L, 1);
 	// item
 	ItemStack item = read_item(L, 2,getServer(L)->idef());
-	if(item.empty() || !item.isKnown(getServer(L)->idef()))
+	if (item.empty() || !item.isKnown(getServer(L)->idef()))
 		return 0;
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
@@ -594,7 +618,7 @@ int ModApiEnvMod::l_add_item(lua_State *L)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "spawn_item");
 	lua_remove(L, -2); // Remove core
-	if(lua_isnil(L, -1))
+	if (lua_isnil(L, -1))
 		return 0;
 	lua_pushvalue(L, 1);
 	lua_pushstring(L, item.getItemString().c_str());
@@ -1253,6 +1277,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(set_node_level);
 	API_FCT(add_node_level);
 	API_FCT(add_entity);
+	API_FCT(add_npc);
 	API_FCT(find_nodes_with_meta);
 	API_FCT(get_meta);
 	API_FCT(get_node_timer);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -93,6 +93,10 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_add_entity(lua_State *L);
 
+	// add npc(pos, npcname) -> ObjectRef or nil
+	// pos = {x=num, y=num, z=num}
+	static int l_add_npc(lua_State *L);
+
 	// add_item(pos, itemstack or itemstring or table) -> ObjectRef or nil
 	// pos = {x=num, y=num, z=num}
 	static int l_add_item(lua_State *L);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -75,7 +75,7 @@ struct EnumString es_HudBuiltinElement[] =
 */
 
 
-ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
+ObjectRef *ObjectRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
@@ -83,30 +83,40 @@ ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
 	return *(ObjectRef**)ud;  // unbox pointer
 }
 
-ServerActiveObject* ObjectRef::getobject(ObjectRef *ref)
+ServerActiveObject *ObjectRef::getobject(ObjectRef *ref)
 {
 	ServerActiveObject *co = ref->m_object;
 	return co;
 }
 
-LuaEntitySAO* ObjectRef::getluaobject(ObjectRef *ref)
+LuaEntitySAO *ObjectRef::getluaobject(ObjectRef *ref)
 {
 	ServerActiveObject *obj = getobject(ref);
 	if (obj == NULL)
 		return NULL;
 	if (obj->getType() != ACTIVEOBJECT_TYPE_LUAENTITY)
 		return NULL;
-	return (LuaEntitySAO*)obj;
+	return (LuaEntitySAO *) obj;
 }
 
-PlayerSAO* ObjectRef::getplayersao(ObjectRef *ref)
+NpcSAO *ObjectRef::getnpcobject(ObjectRef *ref)
+{
+	ServerActiveObject *obj = getobject(ref);
+	if (obj == NULL)
+		return NULL;
+	if (obj->getType() != ACTIVEOBJECT_TYPE_NPC)
+		return NULL;
+	return (NpcSAO *) obj;
+}
+
+PlayerSAO *ObjectRef::getplayersao(ObjectRef *ref)
 {
 	ServerActiveObject *obj = getobject(ref);
 	if (obj == NULL)
 		return NULL;
 	if (obj->getType() != ACTIVEOBJECT_TYPE_PLAYER)
 		return NULL;
-	return (PlayerSAO*)obj;
+	return (PlayerSAO *) obj;
 }
 
 RemotePlayer *ObjectRef::getplayer(ObjectRef *ref)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -26,6 +26,7 @@ class ServerActiveObject;
 class LuaEntitySAO;
 class PlayerSAO;
 class RemotePlayer;
+class NpcSAO;
 
 /*
 	ObjectRef
@@ -55,9 +56,11 @@ private:
 	static const luaL_Reg methods[];
 
 
-	static LuaEntitySAO* getluaobject(ObjectRef *ref);
+	static LuaEntitySAO *getluaobject(ObjectRef *ref);
 
-	static PlayerSAO* getplayersao(ObjectRef *ref);
+	static NpcSAO *getnpcobject(ObjectRef *ref);
+
+	static PlayerSAO *getplayersao(ObjectRef *ref);
 
 	static RemotePlayer *getplayer(ObjectRef *ref);
 

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -70,6 +70,9 @@ ServerScripting::ServerScripting(Server* server)
 	lua_newtable(L);
 	lua_setfield(L, -2, "luaentities");
 
+	lua_newtable(L);
+	lua_setfield(L, -2, "luanpc");
+
 	// Initialize our lua_api modules
 	InitializeModApi(L, top);
 	lua_pop(L, 1);

--- a/src/script/scripting_server.h
+++ b/src/script/scripting_server.h
@@ -18,11 +18,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #pragma once
+
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_entity.h"
 #include "cpp_api/s_env.h"
 #include "cpp_api/s_inventory.h"
 #include "cpp_api/s_node.h"
+#include "cpp_api/s_npc.h"
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_server.h"
 #include "cpp_api/s_security.h"
@@ -35,6 +37,7 @@ class ServerScripting:
 		virtual public ScriptApiBase,
 		public ScriptApiDetached,
 		public ScriptApiEntity,
+		public ScriptApiNpc,
 		public ScriptApiEnv,
 		public ScriptApiNode,
 		public ScriptApiPlayer,


### PR DESCRIPTION
The goal of this PR is to lay the foundations for a robust and extensible NPC API by mods, standardizing practices and connecting with the client in a more advanced way for a better user experience.

The first commit is to create a new entity type in the core to specialize a LuaEntitySAO to the NPC role. For the moment it has exactly the same functionality as LuaEntitySAO, but will be allocated more functions in future commits.

The aim of the PR is to open the discussion to a unified API, and to identify the needs of such an API.