### PR TITLE
Ores: Add stratum ore

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1069,7 +1069,6 @@ within the currently generated chunk.
 The vertical top and bottom displacement of each puff are determined by the noise
 parameters `np_puff_top` and `np_puff_bottom`, respectively.
 
-
 ### `blob`
 Creates a deformed sphere of ore according to 3d perlin noise described by
 `noise_params`.  The maximum size of the blob is `clust_size`, and
@@ -1098,6 +1097,22 @@ to small changes.  The following is a decent set of parameters to work from:
 
 **WARNING**: Use this ore type *very* sparingly since it is ~200x more
 computationally expensive than any other ore.
+
+### `stratum`
+Creates a single undulating ore stratum that is continuous across mapchunk
+borders and horizontally spans the world.
+The 2D perlin noise described by `noise_params` varies the Y co-ordinate of the
+stratum midpoint. The 2D perlin noise described by `np_stratum_thickness`
+varies the stratum's vertical thickness (in units of nodes). Due to being
+continuous across mapchunk borders the stratum's vertical thickness is
+unlimited. 
+`y_min` and `y_max` define the limits of the ore generation and for performance
+reasons should be set as close together as possible but without clipping the
+stratum's Y variation.
+Each node in the stratum has a 1-in-`clust_scarcity` chance of being ore, so a
+solid-ore stratum would require a `clust_scarcity` of 1.
+The parameters `clust_num_ores`, `clust_size`, `noise_threshold` and
+`random_factor` are ignored by this ore type.
 
 Ore attributes
 --------------
@@ -4557,6 +4572,8 @@ Definition tables
     {
         ore_type = "scatter", -- See "Ore types"
         ore = "default:stone_with_coal",
+        ore_param2 = 3,
+    --  ^ Facedir rotation. Default is 0 (unchanged rotation)
         wherein = "default:stone",
     --  ^ a list of nodenames is supported too
         clust_scarcity = 8*8*8,

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -42,6 +42,7 @@ enum OreType {
 	ORE_PUFF,
 	ORE_BLOB,
 	ORE_VEIN,
+	ORE_STRATUM,
 };
 
 extern FlagDesc flagdesc_ore[];
@@ -133,6 +134,20 @@ public:
 		v3s16 nmin, v3s16 nmax, u8 *biomemap);
 };
 
+class OreStratum : public Ore {
+public:
+	static const bool NEEDS_NOISE = true;
+
+	NoiseParams np_stratum_thickness;
+	Noise *noise_stratum_thickness = nullptr;
+
+	OreStratum() = default;
+	virtual ~OreStratum();
+
+	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
+		v3s16 nmin, v3s16 nmax, u8 *biomemap);
+};
+
 class OreManager : public ObjDefManager {
 public:
 	OreManager(IGameDef *gamedef);
@@ -156,6 +171,8 @@ public:
 			return new OreBlob;
 		case ORE_VEIN:
 			return new OreVein;
+		case ORE_STRATUM:
+			return new OreStratum;
 		default:
 			return nullptr;
 		}

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -73,6 +73,7 @@ struct EnumString ModApiMapgen::es_OreType[] =
 	{ORE_PUFF,    "puff"},
 	{ORE_BLOB,    "blob"},
 	{ORE_VEIN,    "vein"},
+	{ORE_STRATUM, "stratum"},
 	{0, NULL},
 };
 
@@ -1146,6 +1147,15 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 
 			orevein->random_factor = getfloatfield_default(L, index,
 				"random_factor", 1.f);
+
+			break;
+		}
+		case ORE_STRATUM: {
+			OreStratum *orestratum = (OreStratum *)ore;
+
+			lua_getfield(L, index, "np_stratum_thickness");
+			read_noiseparams(L, -1, &orestratum->np_stratum_thickness);
+			lua_pop(L, 1);
 
 			break;
 		}


### PR DESCRIPTION
Creates a single undulating ore stratum that is continuous across mapchunk
borders and horizontally spans the world.
Due to being continuous is ideal for creating bands of alternative stone
type running through cliffs and mountains, or underground layers.

Add missing documentation of 'ore_param2' parameter.
///////////////

![screenshot_20170831_044256](https://user-images.githubusercontent.com/3686677/29905949-7293df62-8e09-11e7-8490-beb519ac55b0.png)

![screenshot_20170901_190544](https://user-images.githubusercontent.com/3686677/29982359-44007930-8f49-11e7-92ff-954da881c07b.png)

![screenshot_20170901_190748](https://user-images.githubusercontent.com/3686677/29982361-464e3c68-8f49-11e7-8c96-577df4f15541.png)

^ Stratum can be solid or any density according to 'clust_scarcity' parameter

2 2D noises define the Y variation of stratum midpoint and the variation of stratum thickness.

Added to enable adding continuous strata of silver sandstone and desert sandstone to existing biomes in MTGame, as these nodes are currently missing from MTG biomes.

Useful for creating strata of any thickness, any variation, anywhere in a MT world.
All other ore types are discontinuous over mapchunk borders.