### PR TITLE
Mapgen Carpathian: Reduce influence of 3D noise on mountains

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1501,7 +1501,7 @@ mgcarpathian_np_ridge_mnt (Ridged mountain size noise) noise_params 0, 12, (743,
 mgcarpathian_np_step_mnt (Step mountain size noise) noise_params 0, 8, (509, 509, 509), 2590, 6, 0.6, 2.0
 
 #    3D noise for mountain overhangs, cliffs, etc. Usually small variations.
-mgcarpathian_np_mnt_var (Mountain variation noise) noise_params 0, 1, (499, 499, 499), 2490, 5, 0.6, 2.0
+mgcarpathian_np_mnt_var (Mountain variation noise) noise_params 0, 1, (499, 499, 499), 2490, 5, 0.55, 2.0
 
 #    First of 2 3D noises that together define tunnels.
 mgcarpathian_np_cave1 (Cave1 noise) noise_params 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1842,7 +1842,7 @@
 
 #    3D noise for mountain overhangs, cliffs, etc. Usually small variations.
 #    type: noise_params
-# mgcarpathian_np_mnt_var = 0, 1, (499, 499, 499), 2490, 5, 0.6, 2.0
+# mgcarpathian_np_mnt_var = 0, 1, (499, 499, 499), 2490, 5, 0.55, 2.0
 
 #    First of 2 3D noises that together define tunnels.
 #    type: noise_params

--- a/src/mapgen_carpathian.cpp
+++ b/src/mapgen_carpathian.cpp
@@ -120,7 +120,7 @@ MapgenCarpathianParams::MapgenCarpathianParams()
 	np_hills         = NoiseParams(0,  3,  v3f(257,  257,  257),  6604,  6, 0.5,  2.0);
 	np_ridge_mnt     = NoiseParams(0,  12, v3f(743,  743,  743),  5520,  6, 0.7,  2.0);
 	np_step_mnt      = NoiseParams(0,  8,  v3f(509,  509,  509),  2590,  6, 0.6,  2.0);
-	np_mnt_var       = NoiseParams(0,  1,  v3f(499,  499,  499),  2490,  5, 0.6,  2.0);
+	np_mnt_var       = NoiseParams(0,  1,  v3f(499,  499,  499),  2490,  5, 0.55, 2.0);
 	np_cave1         = NoiseParams(0,  12, v3f(61,   61,   61),   52534, 3, 0.5,  2.0);
 	np_cave2         = NoiseParams(0,  12, v3f(67,   67,   67),   10325, 3, 0.5,  2.0);
 	np_cavern        = NoiseParams(0,  1,  v3f(384,  128,  384),  723,   5, 0.63, 2.0);
@@ -195,11 +195,11 @@ inline float MapgenCarpathian::getLerp(float noise1, float noise2, float mod)
 }
 
 // Steps function
-float MapgenCarpathian::getSteps(float noise1, float noise2)
+float MapgenCarpathian::getSteps(float noise)
 {
-	float w = fabs(noise2);
-	float k = floor(noise1 / w);
-	float f = (noise1 - k * w) / w;
+	float w = 0.5f;
+	float k = floor(noise / w);
+	float f = (noise - k * w) / w;
 	float s = std::fmin(2.f * f, 1.f);
 	return (k + s) * w;
 }
@@ -343,7 +343,7 @@ float MapgenCarpathian::terrainLevelAtPoint(s16 x, s16 z)
 		float ridged_mountains = pow(rter, 3.f) * ridge_mnt;
 
 		// Step (terraced) mountains
-		float step_mnt = hilliness * getSteps(n_step_mnt, fabs(mnt_var));
+		float step_mnt = hilliness * getSteps(n_step_mnt);
 		float step_mountains = pow(ster, 3.f) * step_mnt;
 
 		// Final terrain level
@@ -430,7 +430,7 @@ int MapgenCarpathian::generateTerrain()
 				// Step (terraced) mountains
 				float ster = noise_step_terrain->result[index2d];
 				float n_step_mnt = noise_step_mnt->result[index2d];
-				float step_mnt = hilliness * getSteps(n_step_mnt, fabs(mnt_var));
+				float step_mnt = hilliness * getSteps(n_step_mnt);
 				float step_mountains = pow(fabs(ster), 3.f) * step_mnt;
 
 				// Final terrain level

--- a/src/mapgen_carpathian.h
+++ b/src/mapgen_carpathian.h
@@ -74,7 +74,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_CARPATHIAN; }
 
-	float getSteps(float noise1, float noise2);
+	float getSteps(float noise);
 	inline float getLerp(float noise1, float noise2, float mod);
 
 	virtual void makeChunk(BlockMakeData *data);


### PR DESCRIPTION
Addresses issue #6349 

Three minor changes to mountains:
* Remove 3D noise from the GetSteps function
* Hardcode the step width to 0.5 in the getSteps function.
* Lower persistence in the 3D noise variation for all mountains 0.6 -> 0.55 to reduce chance of floating blobs of stone

