### PR TITLE
World start time: Add as setting, default unchanged

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -979,6 +979,9 @@ time_send_interval (Time send interval) int 5
 #    Examples: 72 = 20min, 360 = 4min, 1 = 24hour, 0 = day/night/whatever stays unchanged.
 time_speed (Time speed) int 72
 
+#    Time of day when a new world is started, in millihours (0-23999).
+world_start_time (World start time) int 5250 0 23999
+
 #    Interval of saving important changes in the world, stated in seconds.
 server_map_save_interval (Map save interval) float 5.3
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -336,6 +336,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("csm_flavour_noderange_limit", "8");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
+	settings->setDefault("world_start_time", "5250");
 	settings->setDefault("server_unload_unused_data_timeout", "29");
 	settings->setDefault("max_objects_per_block", "64");
 	settings->setDefault("server_map_save_interval", "5.3");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -37,6 +37,9 @@ Environment::Environment(IGameDef *gamedef):
 	m_cache_active_block_mgmt_interval = g_settings->getFloat("active_block_mgmt_interval");
 	m_cache_abm_interval = g_settings->getFloat("abm_interval");
 	m_cache_nodetimer_interval = g_settings->getFloat("nodetimer_interval");
+
+	m_time_of_day = g_settings->getU32("world_start_time");
+	m_time_of_day_f = (float)m_time_of_day / 24000.0f;
 }
 
 u32 Environment::getDayNightRatio()

--- a/src/environment.h
+++ b/src/environment.h
@@ -107,10 +107,10 @@ protected:
 	/*
 	 * Below: values managed by m_time_lock
 	*/
-	// Time of day in milli-hours (0-23999); determines day and night
-	u32 m_time_of_day = 5250;
-	// Time of day in 0...1; start 5:15am unless overridden by game
-	float m_time_of_day_f = 5250.0f / 24000.0f;
+	// Time of day in milli-hours (0-23999), determines day and night
+	u32 m_time_of_day;
+	// Time of day in 0...1
+	float m_time_of_day_f;
 	// Stores the skew created by the float -> u32 conversion
 	// to be applied at next conversion, so that there is no real skew.
 	float m_time_conversion_skew = 0.0f;


### PR DESCRIPTION
Replaces #6220 
Tested.
conf.example not updated as that will be auto-generated soon as it is not up to date.
Now you can choose when to get up in the morning.