### PR TITLE
Implement minetest.register_can_bypass_userlimit

### DIFF
--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -89,9 +89,5 @@ core.register_privilege("debug", {
 
 core.register_on_userlimit_check(function(name, ip)
 	local privs = core.get_player_privs(name)
-	if privs["server"] or privs["ban"] or privs["privs"] or privs["password"] then
-		return true
-	end
-
-	return false
+	return (privs["server"] or privs["ban"] or privs["privs"] or privs["password"])
 end)

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -89,8 +89,7 @@ core.register_privilege("debug", {
 
 core.register_on_userlimit_check(function(name, ip)
 	local privs = core.get_player_privs(name)
-	if privs["server"] ~= nil or privs["ban"] ~= nil or privs["privs"] ~= nil
-		or privs["password"] ~= nil then
+	if privs["server"] or privs["ban"] or privs["privs"] or privs["password"] then
 		return true
 	end
 

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -87,7 +87,7 @@ core.register_privilege("debug", {
 	give_to_singleplayer = false,
 })
 
-core.register_on_userlimit_check(function(name, ip)
+core.register_can_bypass_userlimit(function(name, ip)
 	local privs = core.get_player_privs(name)
-	return (privs["server"] or privs["ban"] or privs["privs"] or privs["password"])
+	return privs["server"] or privs["ban"] or privs["privs"] or privs["password"]
 end)

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -86,3 +86,13 @@ core.register_privilege("debug", {
 	description = "Allows enabling various debug options that may affect gameplay",
 	give_to_singleplayer = false,
 })
+
+core.register_on_userlimit_check(function(name, ip)
+	local privs = core.get_player_privs(name)
+	if privs["server"] ~= nil or privs["ban"] ~= nil or privs["privs"] ~= nil
+		or privs["password"] ~= nil then
+		return true
+	end
+
+	return false
+end)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -581,7 +581,7 @@ core.registered_on_item_eats, core.register_on_item_eat = make_registration()
 core.registered_on_punchplayers, core.register_on_punchplayer = make_registration()
 core.registered_on_priv_grant, core.register_on_priv_grant = make_registration()
 core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration()
-core.registered_on_userlimit_check, core.register_on_userlimit_check = make_registration()
+core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -581,6 +581,7 @@ core.registered_on_item_eats, core.register_on_item_eat = make_registration()
 core.registered_on_punchplayers, core.register_on_punchplayer = make_registration()
 core.registered_on_priv_grant, core.register_on_priv_grant = make_registration()
 core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration()
+core.registered_on_userlimit_check, core.register_on_userlimit_check = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2455,6 +2455,9 @@ Call these functions only at load time!
     * Called when `revoker` revokes the priv `priv` from `name`.
     * Note that the callback will be called twice if it's done by a player, once with revoker being the player name,
       and again with revoker being nil.
+* `minetest.register_on_userlimit_check(function(name, ip))`
+	* Called when `name` user connects with `ip`.
+	* Return `true` to by pass the player limit
 
 ### Other registration functions
 * `minetest.register_chatcommand(cmd, chatcommand definition)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2456,8 +2456,8 @@ Call these functions only at load time!
     * Note that the callback will be called twice if it's done by a player, once with revoker being the player name,
       and again with revoker being nil.
 * `minetest.register_can_bypass_userlimit(function(name, ip))`
-	* Called when `name` user connects with `ip`.
-	* Return `true` to by pass the player limit
+    * Called when `name` user connects with `ip`.
+    * Return `true` to by pass the player limit
 
 ### Other registration functions
 * `minetest.register_chatcommand(cmd, chatcommand definition)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2455,7 +2455,7 @@ Call these functions only at load time!
     * Called when `revoker` revokes the priv `priv` from `name`.
     * Note that the callback will be called twice if it's done by a player, once with revoker being the player name,
       and again with revoker being nil.
-* `minetest.register_on_userlimit_check(function(name, ip))`
+* `minetest.register_can_bypass_userlimit(function(name, ip))`
 	* Called when `name` user connects with `ip`.
 	* Return `true` to by pass the player limit
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -209,13 +209,10 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 			<< addr_s << " (peer_id=" << pkt->getPeerId() << ")" << std::endl;
 
 	// Enforce user limit.
-	// Don't enforce for users that have some admin right
+	// Don't enforce for users that have some admin right or mod permits it.
 	if (m_clients.isUserLimitReached() &&
-			!checkPriv(playername, "server") &&
-			!checkPriv(playername, "ban") &&
-			!checkPriv(playername, "privs") &&
-			!checkPriv(playername, "password") &&
-			playername != g_settings->get("name")) {
+			playername != g_settings->get("name") &&
+			!m_script->can_bypass_userlimit(playername, addr_s)) {
 		actionstream << "Server: " << playername << " tried to join from "
 				<< addr_s << ", but there" << " are already max_users="
 				<< g_settings->getU16("max_users") << " players." << std::endl;

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
+#include "debug.h"
 #include "util/string.h"
 
 void ScriptApiPlayer::on_newplayer(ServerActiveObject *player)
@@ -121,6 +122,20 @@ bool ScriptApiPlayer::on_prejoinplayer(
 		return true;
 	}
 	return false;
+}
+
+bool ScriptApiPlayer::can_bypass_userlimit(const std::string &name, const std::string &ip)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_prejoinplayers
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_userlimit_check");
+	lua_pushstring(L, name.c_str());
+	lua_pushstring(L, ip.c_str());
+	runCallbacks(2, RUN_CALLBACKS_MODE_OR);
+	FATAL_ERROR_IF(!lua_isboolean(L, -1), "on_user_limitcheck must return a boolean");
+	return lua_toboolean(L, -1);
 }
 
 void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player)

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -130,7 +130,7 @@ bool ScriptApiPlayer::can_bypass_userlimit(const std::string &name, const std::s
 
 	// Get core.registered_on_prejoinplayers
 	lua_getglobal(L, "core");
-	lua_getfield(L, -1, "registered_on_userlimit_check");
+	lua_getfield(L, -1, "registered_can_bypass_userlimit");
 	lua_pushstring(L, name.c_str());
 	lua_pushstring(L, ip.c_str());
 	runCallbacks(2, RUN_CALLBACKS_MODE_OR);

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -35,6 +35,7 @@ public:
 	bool on_respawnplayer(ServerActiveObject *player);
 	bool on_prejoinplayer(const std::string &name, const std::string &ip,
 			std::string *reason);
+	bool can_bypass_userlimit(const std::string &name, const std::string &ip);
 	void on_joinplayer(ServerActiveObject *player);
 	void on_leaveplayer(ServerActiveObject *player, bool timeout);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);


### PR DESCRIPTION
This new callback permits to bypass the max_users parameter with new mods condition, based on player name or IP
Only one mod needs to permit it.

Move core part for builtin privileges checks to builtin