### PR TITLE
Fix dropped item look

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -51,7 +51,7 @@ core.register_entity(":__builtin:item", {
 
 		local max_count = stack:get_stack_max()
 		local count = math.min(stack:get_count(), max_count)
-		local size = 0.2 + 0.1 * (count / max_count)
+		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 
 		self.object:set_properties({
 			is_visible = true,

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -52,13 +52,16 @@ core.register_entity(":__builtin:item", {
 		local max_count = stack:get_stack_max()
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
+		local coll_height = size * 0.75
 
 		self.object:set_properties({
 			is_visible = true,
 			visual = "wielditem",
 			textures = {itemname},
 			visual_size = {x = size, y = size},
-			collisionbox = {-size, -size, -size, size, size, size},
+			collisionbox = {-size, -coll_height, -size,
+				size, coll_height, size},
+			selectionbox = {-size, -size, -size, size, size, size},
 			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,
 		})

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -37,21 +37,21 @@ core.register_entity(":__builtin:item", {
 	slippery_state = false,
 	age = 0,
 
-	set_item = function(self, itemstring)
-		local stack = ItemStack(itemstring or self.itemstring)
+	set_item = function(self, item)
+		local stack = ItemStack(item or self.itemstring)
 		self.itemstring = stack:to_string()
+		if self.itemstring == "" then
+			-- item not yet known
+			return
+		end
 
 		-- Backwards compatibility: old clients use the texture
 		-- to get the type of the item
-		local itemname = stack:get_name()
+		local itemname = stack:is_known() and stack:get_name() or "unknown"
 
 		local max_count = stack:get_stack_max()
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count)
-
-		if not stack:is_known() then
-			itemname = "unknown"
-		end
 
 		self.object:set_properties({
 			is_visible = true,
@@ -62,7 +62,7 @@ core.register_entity(":__builtin:item", {
 			automatic_rotate = math.pi * 0.5,
 			wield_item = self.itemstring,
 		})
-		
+
 	end,
 
 	get_staticdata = function(self)
@@ -154,7 +154,7 @@ core.register_entity(":__builtin:item", {
 			is_slippery = slippery ~= 0
 			if is_slippery then
 				is_physical = true
-	
+
 				-- Horizontal deceleration
 				local slip_factor = 4.0 / (slippery + 4)
 				self.object:set_acceleration({

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -59,7 +59,7 @@ core.register_entity(":__builtin:item", {
 			textures = {itemname},
 			visual_size = {x = size, y = size},
 			collisionbox = {-size, -size, -size, size, size, size},
-			automatic_rotate = math.pi * 0.5,
+			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,
 		})
 


### PR DESCRIPTION
Set size of dropped items non-linearly, the dropped item size should depend on the volume the object represents
Make item rotation speed depend on its size
Make items look like they lie on the ground (multiplying with 0.75 works FIXME)