### PR TITLE
Network protocol documentation: Add 'can_zoom' to version 36

### DIFF
--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -178,6 +178,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			Breaks compatibility with older clients.
 	PROTOCOL VERSION 36:
 		Backwards compatibility drop
+		Add 'can_zoom' to player object properties
 */
 
 #define LATEST_PROTOCOL_VERSION 36


### PR DESCRIPTION
Something that should have been done in 561a01cc2a8ca0b83b37975a048d34dcfd0d41e1