### PR TITLE
Remove DSTACK keybind setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Some can be changes in the key config dialog in the settings tab.
 | Shift + F9                    | Change minimap orientation                                     |
 | F10                           | Show/hide console                                              |
 | F12                           | Take screenshot                                                |
-| P                             | Write stack traces into debug.txt                              |
 
 Paths
 -----

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -367,10 +367,6 @@ keymap_increase_viewing_range_min (View range increase key) key +
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_decrease_viewing_range_min (View range decrease key) key -
 
-#    Key for printing debug stacks. Used for development.
-#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_print_debug_stacks (Print stacks) key KEY_KEY_P
-
 [Graphics]
 
 [*In-Game]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -409,11 +409,6 @@
 #    type: key
 # keymap_decrease_viewing_range_min = -
 
-#    Key for printing debug stacks. Used for development.
-#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-#    type: key
-# keymap_print_debug_stacks = KEY_KEY_P
-
 #
 # Graphics
 #

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -135,7 +135,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("zoom_fov", "15");
 
 	// Some (temporary) keys for debugging
-	settings->setDefault("keymap_print_debug_stacks", "KEY_KEY_P");
 	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
 	settings->setDefault("keymap_quicktune_next", "KEY_END");
 	settings->setDefault("keymap_quicktune_dec", "KEY_NEXT");


### PR DESCRIPTION
#6346
This keybind is unnecessary because DSTACK has been removed.