### PR TITLE
Builtin item: Remove empty (wieldhand) items automatically

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -76,7 +76,7 @@ core.register_entity(":__builtin:item", {
 	on_activate = function(self, staticdata, dtime_s)
 		if string.sub(staticdata, 1, string.len("return")) == "return" then
 			local data = core.deserialize(staticdata)
-			if data and type(data) == "table" then
+			if type(data) == "table" then
 				self.itemstring = data.itemstring
 				self.age = (data.age or 0) + dtime_s
 				self.dropped_by = data.dropped_by
@@ -130,7 +130,8 @@ core.register_entity(":__builtin:item", {
 
 	on_step = function(self, dtime)
 		self.age = self.age + dtime
-		if time_to_live > 0 and self.age > time_to_live then
+		if (time_to_live > 0 and self.age > time_to_live) or
+				self.itemstring == "" then
 			self.itemstring = ""
 			self.object:remove()
 			return


### PR DESCRIPTION
Fixes #6379 by deleting and preventing to merge `""` items, which would reset their age.