### PR TITLE
Prevent /spawnentity from spawning unknown entity

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -629,6 +629,9 @@ core.register_chatcommand("spawnentity", {
 			core.log("error", "Unable to spawn entity, player is nil")
 			return false, "Unable to spawn entity, player is nil"
 		end
+		if not minetest.registered_entities[entityname] then
+			return false, "Cannot spawn an unknown entity"
+		end
 		if p == "" then
 			p = player:getpos()
 		else


### PR DESCRIPTION
`/spawnentity` is able to spawn unknown entities if you provided an invalid entity name.

E.g. `/spawnentity some_invalid_entity_id` does not fail, but spawns an unknown item.

With this PR, nothing is spawned when the entity name is not registered and the command fails with an error message.