### PR TITLE
Server: Calculate maximal total block sends dynamically

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -865,10 +865,9 @@ ipv6_server (IPv6 server) bool false
 [**Advanced]
 
 #    Maximum number of blocks that are simultaneously sent per client.
+#    The maximum total count is calculated dynamically:
+#    max_total = ceil((#clients + max_users) * per_client / 4)
 max_simultaneous_block_sends_per_client (Maximum simultaneous block sends per client) int 10
-
-#   Maximum number of blocks that are simultaneously sent in total.
-max_simultaneous_block_sends_server_total (Maximum simultaneous block sends total) int 40
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1049,12 +1049,10 @@
 ### Advanced
 
 #    Maximum number of blocks that are simultaneously sent per client.
+#    The maximum total count is calculated dynamically:
+#    max_total = ceil((#clients + max_users) * per_client / 4)
 #    type: int
 # max_simultaneous_block_sends_per_client = 10
-
-#    Maximum number of blocks that are simultaneously sent in total.
-#    type: int
-# max_simultaneous_block_sends_server_total = 40
 
 #    To reduce lag, block transfers are slowed down when a player is building something.
 #    This determines how long they are slowed down after placing or removing a node.

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -272,10 +272,7 @@ public:
 	 */
 	void ResendBlockIfOnWire(v3s16 p);
 
-	s32 SendingCount()
-	{
-		return m_blocks_sending.size();
-	}
+	u32 getSendingCount() const { return m_blocks_sending.size(); }
 
 	// Increments timeouts and removes timed-out blocks from list
 	// NOTE: This doesn't fix the server-not-sending-block bug

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -298,7 +298,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("strict_protocol_version_checking", "false");
 	settings->setDefault("player_transfer_distance", "0");
 	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
-	settings->setDefault("max_simultaneous_block_sends_server_total", "40");
 	settings->setDefault("time_send_interval", "5");
 
 	settings->setDefault("default_game", "minetest");

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -342,6 +342,7 @@ public:
 
 	RemotePlayer *getPlayer(const u16 peer_id);
 	RemotePlayer *getPlayer(const char* name);
+	u32 getPlayerCount() const { return m_players.size(); }
 
 	static bool migratePlayersDatabase(const GameParams &game_params,
 			const Settings &cmd_args);


### PR DESCRIPTION
The block sends per client is 1/2 when reaching the maximal player count.
Formula: `max_total = ceil((#clients + max_users) * per_client / 4)`

Settings: 10 simultaneous block sends per client (default) + 30 maximal clients

| #clients | server limit | limit/client |
|----------|--------------|--------------|
| 1        | 77           | 77           |
| 2        | 80           | 40           |
| 10       | 100          | 10           |
| 20       | 125          | 6.25         |
| 30       | 150          | 5            |

Targeted to fix #1127, deprecates the setting `max_simultaneous_block_sends_server_total`.