### PR TITLE
Add setting for near plane distance.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -532,8 +532,11 @@ pause_fps_max (FPS in pause menu) int 20
 #    View distance in nodes.
 viewing_range (Viewing range) int 100 20 4000
 
-#	Near plane distance in nodes.
-near_plane (Near plane) float 0.1 0 1
+#   Camera near plane distance in nodes, between 0 and 0.5
+#   Most users will not need to change this.
+#   Increasing can reduce artifacting on weaker GPUs.
+#   0.1 = Default, 0.25 = Good value for weaker tablets.
+near_plane (Near plane) float 0.1 0 0.5
 
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -532,6 +532,9 @@ pause_fps_max (FPS in pause menu) int 20
 #    View distance in nodes.
 viewing_range (Viewing range) int 100 20 4000
 
+#	Near plane distance in nodes.
+near_plane (Near plane) float 0.1 0 1
+
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -549,7 +549,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 void Camera::updateViewingRange()
 {
 	f32 viewing_range = g_settings->getFloat("viewing_range");
+	f32 near_plane = g_settings->getFloat("near_plane");
 	m_draw_control.wanted_range = viewing_range;
+	m_cameranode->setNearValue(near_plane * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);
 		return;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -551,7 +551,7 @@ void Camera::updateViewingRange()
 	f32 viewing_range = g_settings->getFloat("viewing_range");
 	f32 near_plane = g_settings->getFloat("near_plane");
 	m_draw_control.wanted_range = viewing_range;
-	m_cameranode->setNearValue(near_plane * BS);
+	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);
 		return;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -157,6 +157,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
+	settings->setDefault("near_plane", "0.1");
 	settings->setDefault("screen_w", "1024");
 	settings->setDefault("screen_h", "600");
 	settings->setDefault("autosave_screensize", "true");


### PR DESCRIPTION
One weaker GPUs, such as the ones found in cheap tablets, you can sometimes see z-fighting between entities even when they are 1 node apart at larger distances ~200 nodes.  (Granted I had increased the active_block_range before this happened).  This may be because they are using 16 bit depth buffers, but I'm not sure on the exact cause.

Setting the near plane to 2.5 (0.25 blocks) fixed this for me by pushing out some of the depth buffer accuracy toward farther away objects.  The only down side of this I have found is when in no-clip mode, objects clip a little sooner.