### PR TITLE
Cleanup & document better conversions between block position and integers

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -21,11 +21,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 
 
-/****************
- * Black magic! *
- ****************
- * The position hashing is very messed up.
- * It's a lot more complicated than it looks.
+/* The position hashing is done by the
+ * straightforward function getBlockAsInteger.
+ *
+ * To invert it, we use unsigned_to_signed to get
+ * X, Y, Z in that order, since knowing the low
+ * 12 bits of the hash uniquely determines X, and
+ * the we can iterate to get Y then Z.
  */
 
 static inline s16 unsigned_to_signed(u16 i, u16 max_positive)
@@ -36,17 +38,6 @@ static inline s16 unsigned_to_signed(u16 i, u16 max_positive)
 
 	return i - (max_positive * 2);
 }
-
-
-// Modulo of a negative number does not work consistently in C
-static inline s64 pythonmodulo(s64 i, s16 mod)
-{
-	if (i >= 0) {
-		return i % mod;
-	}
-	return mod - ((-i) % mod);
-}
-
 
 s64 MapDatabase::getBlockAsInteger(const v3s16 &pos)
 {
@@ -59,11 +50,11 @@ s64 MapDatabase::getBlockAsInteger(const v3s16 &pos)
 v3s16 MapDatabase::getIntegerAsBlock(s64 i)
 {
 	v3s16 pos;
-	pos.X = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
+	pos.X = unsigned_to_signed(i & 0xfff, 2048);
 	i = (i - pos.X) / 4096;
-	pos.Y = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
+	pos.Y = unsigned_to_signed(i & 0xfff, 2048);
 	i = (i - pos.Y) / 4096;
-	pos.Z = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
+	pos.Z = unsigned_to_signed(i & 0xfff, 2048);
 	return pos;
 }
 


### PR DESCRIPTION
The hashing algorithm is actually quite simple. Besides, the function `pythonmodulo` was misleading/broken, since for instance, `pythonmodulo(-4096, 4096)` was equal to `4096` and not `0`. Here we use bitwise operators instead (since we are using modulo for a power of two). The only difference is in the case of a negative multiple of the modulo, where we get `0` instead of the modulo, `4096`. Fortunately, since the result is given as first argument to `unsigned_to_signed`, with `2048` as second argument, in both cases we get `0` as the result.