### PR TITLE
Add check to pause game on lost window focus

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -536,6 +536,9 @@ fps_max (Maximum FPS) int 60
 #    Maximum FPS when game is paused.
 pause_fps_max (FPS in pause menu) int 20
 
+#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is open.
+pause_on_lost_focus (Pause on lost window focus) bool false
+
 #    View distance in nodes.
 viewing_range (Viewing range) int 100 20 4000
 
@@ -839,9 +842,6 @@ serverlist_file (Serverlist file) string favoriteservers.txt
 
 #    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
 max_out_chat_queue_size (Maximum size of the out chat queue) int 20
-
-#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is open.
-pause_on_lost_focus (Pause on lost window focus) bool true
 
 [*Advanced]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -840,6 +840,9 @@ serverlist_file (Serverlist file) string favoriteservers.txt
 #    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
 max_out_chat_queue_size (Maximum size of the out chat queue) int 20
 
+#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is open.
+pause_on_lost_focus (Pause on lost window focus) bool true
+
 [*Advanced]
 
 #    Timeout for client to remove unused map data from memory.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -996,7 +996,7 @@
 
 #    Open the pause menu when the window's focus is lost. Does not pause if a formspec is open.
 #    type: bool
-# pause_on_lost_focus = true
+# pause_on_lost_focus = false
 
 ## Advanced
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -994,6 +994,10 @@
 #    type: int
 # max_out_chat_queue_size = 20
 
+#    Open the pause menu when the window's focus is lost. Does not pause if a formspec is open.
+#    type: bool
+# pause_on_lost_focus = true
+
 ## Advanced
 
 #    Timeout for client to remove unused map data from memory.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -58,6 +58,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
 	settings->setDefault("max_out_chat_queue_size", "20");
+	settings->setDefault("pause_on_lost_focus", "true");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -58,7 +58,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
 	settings->setDefault("max_out_chat_queue_size", "20");
-	settings->setDefault("pause_on_lost_focus", "true");
+	settings->setDefault("pause_on_lost_focus", "false");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1487,6 +1487,8 @@ private:
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 
+	bool m_doesLostFocusPauseGame;
+
 #ifdef __ANDROID__
 	bool m_cache_hold_aux1;
 	bool m_android_chat_open;
@@ -1741,6 +1743,10 @@ void Game::run()
 
 		// Update if minimap has been disabled by the server
 		flags.show_minimap &= client->shouldShowMinimap();
+
+		if (m_doesLostFocusPauseGame && !device->isWindowFocused() && !isMenuActive()) {
+			showPauseMenu();
+		}
 	}
 }
 
@@ -4638,6 +4644,7 @@ void Game::readSettings()
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
 
+	m_doesLostFocusPauseGame = g_settings->getBool("pause_on_lost_focus");
 }
 
 /****************************************************************************/

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1487,7 +1487,7 @@ private:
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 
-	bool m_does_lost_focus_pause_game;
+	bool m_does_lost_focus_pause_game = false;
 
 #ifdef __ANDROID__
 	bool m_cache_hold_aux1;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1487,7 +1487,7 @@ private:
 	bool m_first_loop_after_window_activation = false;
 	bool m_camera_offset_changed = false;
 
-	bool m_doesLostFocusPauseGame;
+	bool m_does_lost_focus_pause_game;
 
 #ifdef __ANDROID__
 	bool m_cache_hold_aux1;
@@ -1744,7 +1744,7 @@ void Game::run()
 		// Update if minimap has been disabled by the server
 		flags.show_minimap &= client->shouldShowMinimap();
 
-		if (m_doesLostFocusPauseGame && !device->isWindowFocused() && !isMenuActive()) {
+		if (m_does_lost_focus_pause_game && !device->isWindowFocused() && !isMenuActive()) {
 			showPauseMenu();
 		}
 	}
@@ -4644,7 +4644,7 @@ void Game::readSettings()
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
 
-	m_doesLostFocusPauseGame = g_settings->getBool("pause_on_lost_focus");
+	m_does_lost_focus_pause_game = g_settings->getBool("pause_on_lost_focus");
 }
 
 /****************************************************************************/


### PR DESCRIPTION
This code is quite simple, and increases usability.

This also has the benefit of fixing the mouse cursor still being grabbed by minetest when you switch to another window when using Windows

Fixes #6384 