### PR TITLE
Item drop: Tune to land exactly 2 nodes away with level view

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -426,9 +426,9 @@ function core.item_drop(itemstack, dropper, pos)
 		local item = itemstack:take_item(cnt)
 		local obj = core.add_item(p, item)
 		if obj then
-			dir.x = dir.x * 2
-			dir.y = dir.y * 2 + 2
-			dir.z = dir.z * 2
+			dir.x = dir.x * 2.9
+			dir.y = dir.y * 2.9 + 2
+			dir.z = dir.z * 2.9
 			obj:set_velocity(dir)
 			obj:get_luaentity().dropped_by = dropper:get_player_name()
 			return itemstack


### PR DESCRIPTION
Previously it would land a little over 1 node away.
This makes the landing point reliable and easy to remember, for when you want to drop something somewhere precisely.
For example when you want to drop something on a narrow ledge for another player to pick up, you can be sure it will be 2 nodes away instead of 1.5 or some awkward hard to remember amount.
Side effect is the item is now far enough away to avoid auto-pickup, assuming auto pickup range is set to a practical value like a radius of 1 node. Therefore addresses #2086 in a simple way.