### PR TITLE
Add setting to display the itemstring after the tooltip in the inventory.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -710,8 +710,8 @@ gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 #    Delay showing tooltips, stated in milliseconds.
 tooltip_show_delay (Tooltip delay) int 400
 
-#    Show itemstring after tooltip
-tooltip_show_itemstring (Show itemstring) bool false
+#    Append itemstring to tooltip
+tooltip_append_itemstring (Append itemstring) bool false
 
 #    Whether freetype fonts are used, requires freetype support to be compiled in.
 freetype (Freetype fonts) bool true

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -710,6 +710,9 @@ gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 #    Delay showing tooltips, stated in milliseconds.
 tooltip_show_delay (Tooltip delay) int 400
 
+#    Show itemstring after tooltip
+tooltip_show_itemstring (Show itemstring) bool false
+
 #    Whether freetype fonts are used, requires freetype support to be compiled in.
 freetype (Freetype fonts) bool true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -123,16 +123,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_slot21", "");
 	settings->setDefault("keymap_slot22", "");
 	settings->setDefault("keymap_slot23", "");
-	settings->setDefault("enable_build_where_you_stand", "false" );
-	settings->setDefault("3d_mode", "none");
-	settings->setDefault("3d_paralax_strength", "0.025");
-	settings->setDefault("aux1_descends", "false");
-	settings->setDefault("doubletap_jump", "false");
-	settings->setDefault("always_fly_fast", "true");
-	settings->setDefault("directional_colored_fog", "true");
-	settings->setDefault("tooltip_show_delay", "400");
-	settings->setDefault("tooltip_show_itemstring", "false");
-	settings->setDefault("zoom_fov", "15");
 
 	// Some (temporary) keys for debugging
 	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
@@ -153,7 +143,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("3d_mode", "none");
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("tooltip_show_delay", "400");
-	settings->setDefault("tooltip_show_itemstring", "false");
+	settings->setDefault("tooltip_append_itemstring", "false");
 	settings->setDefault("zoom_fov", "15");
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -131,6 +131,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("always_fly_fast", "true");
 	settings->setDefault("directional_colored_fog", "true");
 	settings->setDefault("tooltip_show_delay", "400");
+	settings->setDefault("tooltip_show_itemstring", "false");
 	settings->setDefault("zoom_fov", "15");
 
 	// Some (temporary) keys for debugging
@@ -152,6 +153,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("3d_mode", "none");
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("tooltip_show_delay", "400");
+	settings->setDefault("tooltip_show_itemstring", "false");
 	settings->setDefault("zoom_fov", "15");
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -112,7 +112,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_doubleclickdetect[1].pos = v2s32(0, 0);
 
 	m_tooltip_show_delay = (u32)g_settings->getS32("tooltip_show_delay");
-	m_tooltip_show_itemstring = g_settings->getBool("tooltip_show_itemstring");
+	m_tooltip_append_itemstring = g_settings->getBool("tooltip_append_itemstring");
 }
 
 GUIFormSpecMenu::~GUIFormSpecMenu()
@@ -2391,12 +2391,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 					tooltip_text = utf8_to_wide(desc);
 
 				if (!item.name.empty()) {
-					//Append itemstring if enabled in settings
 					if (tooltip_text.empty())
 						tooltip_text = utf8_to_wide(item.name);
-					if (m_tooltip_show_itemstring){
+					if (m_tooltip_append_itemstring)
 						tooltip_text += utf8_to_wide(" [" + item.name + "]");
-					}
 				}
 			}
 			if (!tooltip_text.empty()) {

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2390,12 +2390,14 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				else
 					tooltip_text = utf8_to_wide(desc);
 
-				// Show itemstring after tooltip
-				if(!item.name.empty() && m_tooltip_show_itemstring)
-					tooltip_text += utf8_to_wide(" [" + item.name + "]");
-				// Show itemstring as fallback for easier debugging
-				if (!item.name.empty() && tooltip_text.empty())
-					tooltip_text = utf8_to_wide(item.name);
+				if (!item.name.empty()){
+					//Append itemstring if enabled in settings
+					if (m_tooltip_show_itemstring){
+						if (!tooltip_text.empty())
+							tooltip_text.append(1,' ');
+						tooltip_text += utf8_to_wide("[" + item.name + "]");
+					}
+				}
 			}
 			if (!tooltip_text.empty()) {
 				showTooltip(tooltip_text, m_default_tooltip_color,

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -112,6 +112,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_doubleclickdetect[1].pos = v2s32(0, 0);
 
 	m_tooltip_show_delay = (u32)g_settings->getS32("tooltip_show_delay");
+	m_tooltip_show_itemstring = g_settings->getBool("tooltip_show_itemstring");
 }
 
 GUIFormSpecMenu::~GUIFormSpecMenu()
@@ -2388,6 +2389,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 						utf8_to_wide(item.getDefinition(m_client->idef()).description);
 				else
 					tooltip_text = utf8_to_wide(desc);
+
+				// Show itemstring after tooltip
+				if(!item.name.empty() && m_tooltip_show_itemstring)
+					tooltip_text += utf8_to_wide(" [" + item.name + "]");
 				// Show itemstring as fallback for easier debugging
 				if (!item.name.empty() && tooltip_text.empty())
 					tooltip_text = utf8_to_wide(item.name);

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2392,10 +2392,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 
 				if (!item.name.empty()){
 					//Append itemstring if enabled in settings
+					if (tooltip_text.empty())
+						tooltip_text += utf8_to_wide(item.name);
 					if (m_tooltip_show_itemstring){
-						if (!tooltip_text.empty())
-							tooltip_text.append(1,' ');
-						tooltip_text += utf8_to_wide("[" + item.name + "]");
+						tooltip_text += utf8_to_wide(" [" + item.name + "]");
 					}
 				}
 			}

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -2390,10 +2390,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				else
 					tooltip_text = utf8_to_wide(desc);
 
-				if (!item.name.empty()){
+				if (!item.name.empty()) {
 					//Append itemstring if enabled in settings
 					if (tooltip_text.empty())
-						tooltip_text += utf8_to_wide(item.name);
+						tooltip_text = utf8_to_wide(item.name);
 					if (m_tooltip_show_itemstring){
 						tooltip_text += utf8_to_wide(" [" + item.name + "]");
 					}

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -407,7 +407,7 @@ protected:
 	gui::IGUIStaticText *m_tooltip_element = nullptr;
 
 	u64 m_tooltip_show_delay;
-	bool m_tooltip_show_itemstring;
+	bool m_tooltip_append_itemstring;
 	u64 m_hovered_time = 0;
 	s32 m_old_tooltip_id = -1;
 

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -407,6 +407,7 @@ protected:
 	gui::IGUIStaticText *m_tooltip_element = nullptr;
 
 	u64 m_tooltip_show_delay;
+	bool m_tooltip_show_itemstring;
 	u64 m_hovered_time = 0;
 	s32 m_old_tooltip_id = -1;
 


### PR DESCRIPTION
builtin/settingtypes.txt:
	Add boolean setting tooltip_show_itemstring
src/defaultsettings.cpp:
	Set default to false
src/guiFormSpecMenu.h:
	Add option m_tooltip_show_itemstring
src/guiFormSpecMenu.cpp:
	Query setting and append a nonempty itemstring to the tooltip if enabled

Solves issue https://github.com/minetest/minetest/issues/6389.