### PR TITLE
Add mute setting (toggled by the mute key and in the volume menu)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -763,6 +763,8 @@ enable_sound (Sound) bool true
 
 sound_volume (Volume) float 0.7 0.0 1.0
 
+mute_sound (Mute sound) bool false
+
 [Client]
 
 [*Network]

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -37,6 +37,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("address", "");
 	settings->setDefault("enable_sound", "true");
 	settings->setDefault("sound_volume", "0.8");
+	settings->setDefault("mute_sound", "false");
 	settings->setDefault("enable_mesh_cache", "false");
 	settings->setDefault("mesh_generation_interval", "0");
 	settings->setDefault("meshgen_block_cache_size", "20");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2553,14 +2553,12 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::NOCLIP)) {
 		toggleNoClip();
 	} else if (wasKeyDown(KeyType::MUTE)) {
-		float volume = g_settings->getFloat("sound_volume");
-		if (volume < 0.001f) {
-			g_settings->setFloat("sound_volume", 1.0f);
-			showStatusTextSimple("Volume changed to 100%");
-		} else {
-			g_settings->setFloat("sound_volume", 0.0f);
-			showStatusTextSimple("Volume changed to 0%");
-		}
+		bool new_mute_sound = !g_settings->getBool("mute_sound");
+		g_settings->setBool("mute_sound", new_mute_sound);
+		if (new_mute_sound)
+			showStatusTextSimple("Sound muted");
+		else
+			showStatusTextSimple("Sound unmuted");
 		runData.statustext_time = 0;
 	} else if (wasKeyDown(KeyType::INC_VOLUME)) {
 		float new_volume = rangelim(g_settings->getFloat("sound_volume") + 0.1f, 0.0f, 1.0f);
@@ -3558,13 +3556,18 @@ void Game::updateSound(f32 dtime)
 			      camera->getDirection(),
 			      camera->getCameraNode()->getUpVector());
 
-	// Check if volume is in the proper range, else fix it.
-	float old_volume = g_settings->getFloat("sound_volume");
-	float new_volume = rangelim(old_volume, 0.0f, 1.0f);
-	sound->setListenerGain(new_volume);
+	bool mute_sound = g_settings->getBool("mute_sound");
+	if (mute_sound)
+		sound->setListenerGain(0.0f);
+	else {
+		// Check if volume is in the proper range, else fix it.
+		float old_volume = g_settings->getFloat("sound_volume");
+		float new_volume = rangelim(old_volume, 0.0f, 1.0f);
+		sound->setListenerGain(new_volume);
 
-	if (old_volume != new_volume) {
-		g_settings->setFloat("sound_volume", new_volume);
+		if (old_volume != new_volume) {
+			g_settings->setFloat("sound_volume", new_volume);
+		}
 	}
 
 	LocalPlayer *player = client->getEnv().getLocalPlayer();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3557,8 +3557,9 @@ void Game::updateSound(f32 dtime)
 			      camera->getCameraNode()->getUpVector());
 
 	bool mute_sound = g_settings->getBool("mute_sound");
-	if (mute_sound)
+	if (mute_sound) {
 		sound->setListenerGain(0.0f);
+	}
 	else {
 		// Check if volume is in the proper range, else fix it.
 		float old_volume = g_settings->getFloat("sound_volume");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3559,8 +3559,7 @@ void Game::updateSound(f32 dtime)
 	bool mute_sound = g_settings->getBool("mute_sound");
 	if (mute_sound) {
 		sound->setListenerGain(0.0f);
-	}
-	else {
+	} else {
 		// Check if volume is in the proper range, else fix it.
 		float old_volume = g_settings->getFloat("sound_volume");
 		float new_volume = rangelim(old_volume, 0.0f, 1.0f);

--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -144,7 +144,6 @@ bool GUIVolumeChange::acceptInput()
 
 bool GUIVolumeChange::OnEvent(const SEvent& event)
 {
-	std::cout << "EVENT!" << std::endl;
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
 			acceptInput();

--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -33,6 +33,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 const int ID_soundText = 263;
 const int ID_soundExitButton = 264;
 const int ID_soundSlider = 265;
+const int ID_soundMuteButton = 266;
 
 GUIVolumeChange::GUIVolumeChange(gui::IGUIEnvironment* env,
 		gui::IGUIElement* parent, s32 id,
@@ -85,7 +86,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	*/
 	{
 		core::rect<s32> rect(0, 0, 160, 20);
-		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 35);
+		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 70);
 
 		const wchar_t *text = wgettext("Sound Volume: ");
 		core::stringw volume_text = text;
@@ -111,6 +112,14 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		e->setMax(100);
 		e->setPos(volume);
 	}
+	{
+		core::rect<s32> rect(0, 0, 160, 20);
+		rect = rect + v2s32(size.X/2 - 80, size.Y/2 - 35);
+		const wchar_t *text = wgettext("Muted");
+		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
+				ID_soundMuteButton, text);
+		delete[] text;
+	}
 }
 
 void GUIVolumeChange::drawMenu()
@@ -124,41 +133,65 @@ void GUIVolumeChange::drawMenu()
 	gui::IGUIElement::draw();
 }
 
+bool GUIVolumeChange::acceptInput()
+{
+	gui::IGUIElement *e = getElementFromId(ID_soundMuteButton);
+	if (e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
+		g_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
+
+	return true;
+}
+
 bool GUIVolumeChange::OnEvent(const SEvent& event)
 {
+	std::cout << "EVENT!" << std::endl;
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
+			acceptInput();
 			quitMenu();
 			return true;
 		}
 
 		if (event.KeyInput.Key == KEY_RETURN && event.KeyInput.PressedDown) {
+			acceptInput();
 			quitMenu();
 			return true;
 		}
-	}
-
-	if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
-		if (event.GUIEvent.Caller->getID() == ID_soundExitButton) {
-			quitMenu();
-			return true;
+	} else if (event.EventType == EET_GUI_EVENT) {
+		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
+				&& isVisible()) {
+			if (!canTakeFocus(event.GUIEvent.Element)) {
+				dstream << "GUIMainMenu: Not allowing focus change."
+				<< std::endl;
+				// Returning true disables focus change
+				return true;
+			}
 		}
-	}
-
-	if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
-		if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
-			s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
-			g_settings->setFloat("sound_volume", (float) pos / 100);
-
-			gui::IGUIElement *e = getElementFromId(ID_soundText);
-			const wchar_t *text = wgettext("Sound Volume: ");
-			core::stringw volume_text = text;
-			delete [] text;
-
-			volume_text += core::stringw(pos) + core::stringw("%");
-			e->setText(volume_text.c_str());
-			return true;
+		if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
+			if (event.GUIEvent.Caller->getID() == ID_soundExitButton) {
+				acceptInput();
+				quitMenu();
+				return true;
+			}
+			Environment->setFocus(this);
 		}
+
+		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
+			if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
+				s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
+				g_settings->setFloat("sound_volume", (float) pos / 100);
+
+				gui::IGUIElement *e = getElementFromId(ID_soundText);
+				const wchar_t *text = wgettext("Sound Volume: ");
+				core::stringw volume_text = text;
+				delete [] text;
+
+				volume_text += core::stringw(pos) + core::stringw("%");
+				e->setText(volume_text.c_str());
+				return true;
+			}
+		}
+
 	}
 
 	return Parent ? Parent->OnEvent(event) : false;

--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -106,7 +106,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	}
 	{
 		core::rect<s32> rect(0, 0, 300, 20);
-		rect = rect + v2s32(size.X/2-150, size.Y/2);
+		rect = rect + v2s32(size.X / 2 - 150, size.Y / 2);
 		gui::IGUIScrollBar *e = Environment->addScrollBar(true,
 			rect, this, ID_soundSlider);
 		e->setMax(100);
@@ -114,7 +114,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	}
 	{
 		core::rect<s32> rect(0, 0, 160, 20);
-		rect = rect + v2s32(size.X/2 - 80, size.Y/2 - 35);
+		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 35);
 		const wchar_t *text = wgettext("Muted");
 		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
 				ID_soundMuteButton, text);

--- a/src/guiVolumeChange.cpp
+++ b/src/guiVolumeChange.cpp
@@ -133,30 +133,37 @@ void GUIVolumeChange::drawMenu()
 	gui::IGUIElement::draw();
 }
 
-bool GUIVolumeChange::acceptInput()
-{
-	gui::IGUIElement *e = getElementFromId(ID_soundMuteButton);
-	if (e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
-		g_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
-
-	return true;
-}
-
 bool GUIVolumeChange::OnEvent(const SEvent& event)
 {
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
-			acceptInput();
 			quitMenu();
 			return true;
 		}
 
 		if (event.KeyInput.Key == KEY_RETURN && event.KeyInput.PressedDown) {
-			acceptInput();
 			quitMenu();
 			return true;
 		}
 	} else if (event.EventType == EET_GUI_EVENT) {
+		if (event.GUIEvent.EventType == gui::EGET_CHECKBOX_CHANGED) {
+			gui::IGUIElement *e = getElementFromId(ID_soundMuteButton);
+			if (e != NULL && e->getType() == gui::EGUIET_CHECK_BOX) {
+				g_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
+			}
+
+			Environment->setFocus(this);
+			return true;
+		}
+
+		if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
+			if (event.GUIEvent.Caller->getID() == ID_soundExitButton) {
+				quitMenu();
+				return true;
+			}
+			Environment->setFocus(this);
+		}
+
 		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
 				&& isVisible()) {
 			if (!canTakeFocus(event.GUIEvent.Element)) {
@@ -166,15 +173,6 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 				return true;
 			}
 		}
-		if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
-			if (event.GUIEvent.Caller->getID() == ID_soundExitButton) {
-				acceptInput();
-				quitMenu();
-				return true;
-			}
-			Environment->setFocus(this);
-		}
-
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
 				s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();

--- a/src/guiVolumeChange.h
+++ b/src/guiVolumeChange.h
@@ -39,8 +39,6 @@ public:
 
 	void drawMenu();
 
-	bool acceptInput();
-
 	bool OnEvent(const SEvent& event);
 
 	bool pausesGame() { return true; }

--- a/src/guiVolumeChange.h
+++ b/src/guiVolumeChange.h
@@ -39,6 +39,8 @@ public:
 
 	void drawMenu();
 
+	bool acceptInput();
+
 	bool OnEvent(const SEvent& event);
 
 	bool pausesGame() { return true; }


### PR DESCRIPTION
builtin/settingtypes.txt:
    Add setting mute_sound (default false).
src/defaultsettings.cpp:
    Add default to false.
src/game.cpp:
    Instead of setting the volume setting to zero if the mute key is
    pressed, toggle the mute setting, but still apply a volume
    (setListenerGain) of zero to the sound engine.
src/guiVolumeChange.h:
    Add method acceptInput() like in guiKeyChangeMenu.h.
src/guiVolumeChange.cpp:
    Add checkbox ID_soundMuteButton and mimic the behaviour of the
    checkboxes in src/guiKeyChangeMenu.cpp.
    For this, the event checks are restructured and the loss of focus
    when clicking outside the menu is prevented
    On pressing KEY_ESCAPE, the mute setting of the checkbox is applied,
    in contrary to the behaviour of the checkboxes in
    guiKeyChangeMenu.cpp.

Solves issue #6208