### PR TITLE
Rename "itemstring" to "item name" (which is actually used) in tooltip setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -710,8 +710,8 @@ gui_scaling_filter_txr2img (GUI scaling filter txr2img) bool true
 #    Delay showing tooltips, stated in milliseconds.
 tooltip_show_delay (Tooltip delay) int 400
 
-#    Append itemstring to tooltip
-tooltip_append_itemstring (Append itemstring) bool false
+#    Append item name to tooltip.
+tooltip_append_itemname (Append item name) bool false
 
 #    Whether freetype fonts are used, requires freetype support to be compiled in.
 freetype (Freetype fonts) bool true

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -143,7 +143,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("3d_mode", "none");
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("tooltip_show_delay", "400");
-	settings->setDefault("tooltip_append_itemstring", "false");
+	settings->setDefault("tooltip_append_itemname", "false");
 	settings->setDefault("zoom_fov", "15");
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");

--- a/src/guiFormSpecMenu.cpp
+++ b/src/guiFormSpecMenu.cpp
@@ -112,7 +112,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_doubleclickdetect[1].pos = v2s32(0, 0);
 
 	m_tooltip_show_delay = (u32)g_settings->getS32("tooltip_show_delay");
-	m_tooltip_append_itemstring = g_settings->getBool("tooltip_append_itemstring");
+	m_tooltip_append_itemname = g_settings->getBool("tooltip_append_itemname");
 }
 
 GUIFormSpecMenu::~GUIFormSpecMenu()
@@ -2393,7 +2393,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int phase,
 				if (!item.name.empty()) {
 					if (tooltip_text.empty())
 						tooltip_text = utf8_to_wide(item.name);
-					if (m_tooltip_append_itemstring)
+					if (m_tooltip_append_itemname)
 						tooltip_text += utf8_to_wide(" [" + item.name + "]");
 				}
 			}

--- a/src/guiFormSpecMenu.h
+++ b/src/guiFormSpecMenu.h
@@ -407,7 +407,7 @@ protected:
 	gui::IGUIStaticText *m_tooltip_element = nullptr;
 
 	u64 m_tooltip_show_delay;
-	bool m_tooltip_append_itemstring;
+	bool m_tooltip_append_itemname;
 	u64 m_hovered_time = 0;
 	s32 m_old_tooltip_id = -1;
 


### PR DESCRIPTION
Fixes terminology, see #6389