### PR TITLE
Generate biomes: Recalculate biome at biome lower limit 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4623,9 +4623,6 @@ Definition tables
 
 ### Biome definition (`register_biome`)
 
-**Note**
-The Biome API is still in an experimental phase and subject to change.
-
     {
         name = "tundra",
         node_dust = "default:snow",
@@ -4652,13 +4649,6 @@ The Biome API is still in an experimental phase and subject to change.
         y_max = 31000,
     --  ^ Lower and upper limits for biome.
     --  ^ Limits are relative to y = water_level - 1.
-    --  ^ Because biome is not recalculated for every node in a node column
-    --  ^ some biome materials can exceed their limits, especially stone.
-    --  ^ For each node column in a mapchunk, biome is only recalculated at column
-    --  ^ top and at each of these surfaces:
-    --  ^ Ground below air, water below air, ground below water.
-    --  ^ The selected biome then stays in effect for all nodes below until
-    --  ^ column base or the next biome recalculation.
         heat_point = 0,
         humidity_point = 50,
     --  ^ Characteristic average temperature and humidity for the biome.


### PR DESCRIPTION
Prevents biome nodes passing below the defined y_min of that biome.
///////////////

![screenshot_20170916_033410](https://user-images.githubusercontent.com/3686677/30508497-16fe41ea-9a90-11e7-8588-b599e8f73653.png)

^ Biome changes at y = 16 and y = 32 which are not mapchunk borders

Tested.
Issue mentioned by Wuzzy in the forums. I should have done this a long time ago, but have only just realised how simple and lightweight it is @Wuzzy2 

Biome generation works downwards through each node column.

Previously, biome was only calculated at mapchunk borders or an upper surface: solid under air, water under air or solid under water. If a biome limit was not at a mapchunk border then biome would not change, meaning biome nodes would exceed the biome limits (naughty!).

Now for each node column, the 'y_min' of the current active biome is stored and when that lower limit is passed biome is recalculated. So biome is only recalculated when it needs to be: just below a biome lower limit.

Tested to confirm biome calculations are only done 0-3 times per column, also tested biome changes in water and even iceshelf.