### PR TITLE
Biome API: Revert biomes, decos, ores being relative to water level

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1346,10 +1346,9 @@ mgv6_np_apple_trees (Apple trees noise) noise_params 0, 1, (100, 100, 100), 3429
 
 #    Map generation attributes specific to Mapgen v7.
 #    'ridges' enables the rivers.
-#    'biomerepeat' causes surface biomes to repeat in the floatlands.
 #    Flags that are not specified in the flag string are not modified from the default.
 #    Flags starting with 'no' are used to explicitly disable them.
-mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns,biomerepeat mountains,ridges,floatlands,caverns,biomerepeat,nomountains,noridges,nofloatlands,nocaverns,nobiomerepeat
+mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
 mgv7_mount_zero_level (Mountain zero level) int 0

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4609,8 +4609,6 @@ Definition tables
         y_min = -31000,
         y_max = 64,
     --  ^ Lower and upper limits for ore.
-    --  ^ Limits are relative to y = water_level - 1 for core mapgen, or
-    --  ^ relative to y = 0 for minetest.generate_ores().
         flags = "",
     --  ^ Attributes for this ore generation
         noise_threshold = 0.5,
@@ -4655,7 +4653,6 @@ Definition tables
         y_min = 1,
         y_max = 31000,
     --  ^ Lower and upper limits for biome.
-    --  ^ Limits are relative to y = water_level - 1.
         heat_point = 0,
         humidity_point = 50,
     --  ^ Characteristic average temperature and humidity for the biome.
@@ -4692,8 +4689,6 @@ Definition tables
         y_min = -31000
         y_max = 31000
     --  ^ Lower and upper limits for decoration.
-    --  ^ Limits are relative to y = water_level - 1 for core mapgen, or
-    --  ^ relative to y = 0 for minetest.generate_decorations().
     --  ^ This parameter refers to the `y` position of the decoration base, so
     --    the actual maximum height would be `height_max + size.Y`.
         spawn_by = "default:water",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -613,7 +613,7 @@ MapgenBasic::~MapgenBasic()
 
 
 void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
-	content_t *biome_stone, s16 biome_zero_level)
+	content_t *biome_stone)
 {
 	// can't generate biomes without a biome generator!
 	assert(biomegen);
@@ -665,10 +665,7 @@ void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
 
 			if (is_stone_surface || is_water_surface) {
 				// (Re)calculate biome
-				// Limit to +-MAX MAP GENERATION LIMIT to work with biome y_min / y_max.
-				s32 relative_y = rangelim(y - biome_zero_level,
-					-MAX_MAP_GENERATION_LIMIT, MAX_MAP_GENERATION_LIMIT);
-				biome = biomegen->getBiomeAtIndex(index, relative_y);
+				biome = biomegen->getBiomeAtIndex(index, y);
 
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
 					biomemap[index] = biome->index;
@@ -679,8 +676,7 @@ void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
 					noise_filler_depth->result[index], 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
-				biome_y_min = rangelim(biome->y_min + biome_zero_level,
-					-MAX_MAP_GENERATION_LIMIT, MAX_MAP_GENERATION_LIMIT);
+				biome_y_min = biome->y_min;
 
 				// Detect stone type for dungeons during every biome calculation.
 				// If none detected the last selected biome stone is chosen.

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -251,7 +251,7 @@ public:
 	virtual void generateDungeons(s16 max_stone_y,
 		MgStoneType stone_type, content_t biome_stone);
 	virtual void generateBiomes(MgStoneType *mgstone_type,
-		content_t *biome_stone, s16 biome_zero_level);
+		content_t *biome_stone);
 	virtual void dustTopNodes();
 
 protected:

--- a/src/mapgen_carpathian.cpp
+++ b/src/mapgen_carpathian.cpp
@@ -245,7 +245,7 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -269,12 +269,10 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -193,7 +193,7 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
@@ -203,12 +203,10 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -203,7 +203,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
@@ -213,12 +213,10 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -204,7 +204,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -228,12 +228,10 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -615,12 +615,10 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Calculate lighting
 	if (flags & MG_LIGHT)

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -44,7 +44,6 @@ FlagDesc flagdesc_mapgen_v7[] = {
 	{"ridges",      MGV7_RIDGES},
 	{"floatlands",  MGV7_FLOATLANDS},
 	{"caverns",     MGV7_CAVERNS},
-	{"biomerepeat", MGV7_BIOMEREPEAT},
 	{NULL,          0}
 };
 
@@ -290,12 +289,6 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	blockseed = getBlockSeed2(full_node_min, seed);
 
-	// Get zero level for biomes and decorations
-	// Optionally repeat surface biomes in floatlands
-	s16 biome_zero_level = ((spflags & MGV7_FLOATLANDS) &&
-		(spflags & MGV7_BIOMEREPEAT) && node_max.Y >= shadow_limit) ?
-		floatland_level - 1 : water_level - 1;
-
 	// Generate base and mountain terrain
 	// An initial heightmap is no longer created here for use in generateRidgeTerrain()
 	s16 stone_surface_max_y = generateTerrain();
@@ -312,7 +305,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -336,12 +329,10 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, biome_zero_level);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -22,12 +22,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-/////////////// Mapgen V7 flags
+///////////// Mapgen V7 flags
 #define MGV7_MOUNTAINS   0x01
 #define MGV7_RIDGES      0x02
 #define MGV7_FLOATLANDS  0x04
 #define MGV7_CAVERNS     0x08
-#define MGV7_BIOMEREPEAT 0x10
+#define MGV7_BIOMEREPEAT 0x10 // Now unused
 
 class BiomeManager;
 
@@ -35,8 +35,7 @@ extern FlagDesc flagdesc_mapgen_v7[];
 
 
 struct MapgenV7Params : public MapgenParams {
-	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES |
-		MGV7_CAVERNS | MGV7_BIOMEREPEAT;
+	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	s16 mount_zero_level = 0;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -237,7 +237,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	// Place biome-specific nodes and build biomemap
 	MgStoneType mgstone_type;
 	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone, water_level - 1);
+	generateBiomes(&mgstone_type, &biome_stone);
 
 	// Cave creation.
 	if (flags & MG_CAVES)
@@ -249,12 +249,10 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed,
-			node_min, node_max, water_level - 1);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
 
 	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed,
-		node_min, node_max, water_level - 1);
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	dustTopNodes();

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -48,7 +48,7 @@ DecorationManager::DecorationManager(IGameDef *gamedef) :
 
 
 size_t DecorationManager::placeAllDecos(Mapgen *mg, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, s16 deco_zero_level)
+	v3s16 nmin, v3s16 nmax)
 {
 	size_t nplaced = 0;
 
@@ -57,7 +57,7 @@ size_t DecorationManager::placeAllDecos(Mapgen *mg, u32 blockseed,
 		if (!deco)
 			continue;
 
-		nplaced += deco->placeDeco(mg, blockseed, nmin, nmax, deco_zero_level);
+		nplaced += deco->placeDeco(mg, blockseed, nmin, nmax);
 		blockseed++;
 	}
 
@@ -124,18 +124,8 @@ bool Decoration::canPlaceDecoration(MMVManip *vm, v3s16 p)
 }
 
 
-size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, s16 deco_zero_level)
+size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
-	// Decoration y_min / y_max is displaced by deco_zero_level or remains
-	// unchanged. Any decoration with a limit at +-MAX_MAP_GENERATION_LIMIT is
-	// considered to have that limit at +-infinity, so we do not alter that limit.
-	s32 y_min_disp = (y_min <= -MAX_MAP_GENERATION_LIMIT) ?
-		-MAX_MAP_GENERATION_LIMIT : y_min + deco_zero_level;
-
-	s32 y_max_disp = (y_max >= MAX_MAP_GENERATION_LIMIT) ?
-		MAX_MAP_GENERATION_LIMIT : y_max + deco_zero_level;
-
 	PcgRandom ps(blockseed + 53);
 	int carea_size = nmax.X - nmin.X + 1;
 
@@ -190,7 +180,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed,
 			else
 				y = mg->findGroundLevel(v2s16(x, z), nmin.Y, nmax.Y);
 
-			if (y < y_min_disp || y > y_max_disp || y < nmin.Y || y > nmax.Y)
+			if (y < y_min || y > y_max || y < nmin.Y || y > nmax.Y)
 				continue;
 
 			if (y + getHeight() > mg->vm->m_area.MaxEdge.Y)

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -54,8 +54,7 @@ public:
 	virtual void resolveNodeNames();
 
 	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
-	size_t placeDeco(Mapgen *mg, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, s16 deco_zero_level);
+	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p) = 0;
 	virtual int getHeight() = 0;
@@ -133,6 +132,5 @@ public:
 		}
 	}
 
-	size_t placeAllDecos(Mapgen *mg, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, s16 deco_zero_level = 0);
+	size_t placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 };

--- a/src/mg_ore.cpp
+++ b/src/mg_ore.cpp
@@ -44,8 +44,7 @@ OreManager::OreManager(IGameDef *gamedef) :
 }
 
 
-size_t OreManager::placeAllOres(Mapgen *mg, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, s16 ore_zero_level)
+size_t OreManager::placeAllOres(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
 	size_t nplaced = 0;
 
@@ -54,7 +53,7 @@ size_t OreManager::placeAllOres(Mapgen *mg, u32 blockseed,
 		if (!ore)
 			continue;
 
-		nplaced += ore->placeOre(mg, blockseed, nmin, nmax, ore_zero_level);
+		nplaced += ore->placeOre(mg, blockseed, nmin, nmax);
 		blockseed++;
 	}
 
@@ -88,23 +87,13 @@ void Ore::resolveNodeNames()
 }
 
 
-size_t Ore::placeOre(Mapgen *mg, u32 blockseed,
-	v3s16 nmin, v3s16 nmax, s16 ore_zero_level)
+size_t Ore::placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
-	// Ore y_min / y_max is displaced by ore_zero_level or remains unchanged.
-	// Any ore with a limit at +-MAX_MAP_GENERATION_LIMIT is considered to have
-	// that limit at +-infinity, so we do not alter that limit.
-	s32 y_min_disp = (y_min <= -MAX_MAP_GENERATION_LIMIT) ?
-		-MAX_MAP_GENERATION_LIMIT : y_min + ore_zero_level;
-
-	s32 y_max_disp = (y_max >= MAX_MAP_GENERATION_LIMIT) ?
-		MAX_MAP_GENERATION_LIMIT : y_max + ore_zero_level;
-
-	if (nmin.Y > y_max_disp || nmax.Y < y_min_disp)
+	if (nmin.Y > y_max || nmax.Y < y_min)
 		return 0;
 
-	int actual_ymin = MYMAX(nmin.Y, y_min_disp);
-	int actual_ymax = MYMIN(nmax.Y, y_max_disp);
+	int actual_ymin = MYMAX(nmin.Y, y_min);
+	int actual_ymax = MYMIN(nmax.Y, y_max);
 	if (clust_size >= actual_ymax - actual_ymin + 1)
 		return 0;
 

--- a/src/mg_ore.h
+++ b/src/mg_ore.h
@@ -70,8 +70,7 @@ public:
 
 	virtual void resolveNodeNames();
 
-	size_t placeOre(Mapgen *mg, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, s16 ore_zero_level);
+	size_t placeOre(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 	virtual void generate(MMVManip *vm, int mapseed, u32 blockseed,
 		v3s16 nmin, v3s16 nmax, u8 *biomemap) = 0;
 };
@@ -180,6 +179,5 @@ public:
 
 	void clear();
 
-	size_t placeAllOres(Mapgen *mg, u32 blockseed,
-		v3s16 nmin, v3s16 nmax, s16 ore_zero_level = 0);
+	size_t placeAllOres(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 };


### PR DESCRIPTION
Feature is unnecessary and would greatly complicate future development,
it would also make 'get biome at pos' extremely complex.
Mgv7: Revert option to repeat surface biomes in floatlands, which
depended on the above.
///////////////////

Reverts 8299e4b67eff48e0f6e101afea2fae8f0e65c421 and dc9e4517a89c3e67585908c88c01442c4d6e3efa both were added after 0.4.16 release.