### PR TITLE
Biome generation: Fix layers of 'filler' nodes at biome y limits 

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -722,6 +722,7 @@ void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
 					nplaced++;
 				} else {
 					vm->m_data[vi] = MapNode(biome->c_stone);
+					nplaced = U16_MAX;  // Disable top/filler placement
 				}
 
 				air_above = false;


### PR DESCRIPTION
Error was exposed by commit a1389c38658fe69c3bd25c3099bae9a4e51ed401
'nplaced' was not set to U16_MAX when biome 'stone' was placed, so when
biome was recalculated in a column of stone, the 'nplaced' value
caused a few remaining filler nodes to be placed.
Occurs when the lower biome has a deeper depth of 'top' plus 'filler'
than the upper biome.
////////////////

Fix for #6426 
Tested.