### PR TITLE
Fix compile error in openbsd

### DIFF
--- a/src/network/address.h
+++ b/src/network/address.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <ws2tcpip.h>
 #else
 #include <netinet/in.h>
+#include <sys/socket.h>
 #endif
 
 #include <ostream>


### PR DESCRIPTION
Include the header that defines AF_INET and AF_INET6