### PR TITLE
Leveled nodebox: Change levels from 1/63rds to 1/64ths

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -15,8 +15,7 @@ Mods are contained and ran solely on the server side. Definitions and media
 files are automatically transferred to the client.
 
 If you see a deficiency in the API, feel free to attempt to add the
-functionality in the engine and API. You can send such improvements as
-source code patches to <celeron55@gmail.com>.
+functionality in the engine and API.
 
 Programming in Lua
 ------------------
@@ -824,6 +823,16 @@ node definition:
       0 = y+    1 = z+    2 = z-    3 = x+    4 = x-    5 = y-
       facedir modulo 4 = rotation around that axis
     paramtype2 == "leveled"
+    ^ Only valid for "nodebox" with 'type = "leveled"', and "plantlike_rooted".
+      Leveled nodebox:
+        The level of the top face of the nodebox is stored in param2.
+        The other faces are defined by 'fixed = {}' like 'type = "fixed"' nodeboxes.
+        The nodebox height is param2 / 64 nodes.
+        The maximum accepted value of param2 is 127.
+      Rooted plantlike:
+        The height of the 'plantlike' section is stored in param2.
+        The height is param2 / 16 nodes.
+        The maximum accepted value of param2 is 127.
     paramtype2 == "degrotate"
     ^ The rotation of this node is stored in param2. Plants are rotated this way.
       Values range 0 - 179. The value stored in param2 is multiplied by two to
@@ -885,8 +894,8 @@ Look for examples in `games/minimal` or `games/minetest_game`.
 * `firelike`
 * `fencelike`
 * `raillike`
-* `nodebox` -- See below. (**Experimental!**)
-* `mesh` -- use models for nodes
+* `nodebox` -- See below
+* `mesh` -- Use models for nodes
 * `plantlike_rooted`
 
 `*_optional` drawtypes need less rendering time if deactivated (always client side).
@@ -895,12 +904,8 @@ Node boxes
 -----------
 Node selection boxes are defined using "node boxes"
 
-The `nodebox` node drawtype allows defining visual of nodes consisting of
-arbitrary number of boxes. It allows defining stuff like stairs. Only the
-`fixed` and `leveled` box type is supported for these.
-
-Please note that this is still experimental, and may be incompatibly
-changed in the future.
+The `nodebox` node drawtype allows defining nodes consisting of an arbitrary
+number of boxes. It allows defining stuff like stairs and slabs.
 
 A nodebox is defined as any of:
 
@@ -909,8 +914,16 @@ A nodebox is defined as any of:
         type = "regular"
     }
     {
-        -- A fixed box (facedir param2 is used, if applicable)
+        -- A fixed box (or boxes) (facedir param2 is used, if applicable)
         type = "fixed",
+        fixed = box OR {box1, box2, ...}
+    }
+    {
+        -- A variable height box (or boxes) with the top face position defined by
+        -- the node parameter 'leveled = ', or if 'paramtype2 == "leveled"' by
+        -- param2.
+        -- Other faces are defined by 'fixed = {}' as with 'type = "fixed"'.
+        type = "leveled",
         fixed = box OR {box1, box2, ...}
     }
     {
@@ -941,9 +954,6 @@ A `box` is defined as:
 A box of a regular node would look like:
 
     {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
-
-`type = "leveled"` is same as `type = "fixed"`, but `y2` will be automatically
-set to level from `param2`.
 
 
 Meshes
@@ -4400,9 +4410,11 @@ Definition tables
         liquid_viscosity = 0, -- Higher viscosity = slower flow (max. 7)
         liquid_renewable = true, --[[
         ^ If true, a new liquid source can be created by placing two or more sources nearby ]]
-        leveled = 0, --[[
-        ^ Block contains level in param2. Value is default level, used for snow.
-        ^ Don't forget to use "leveled" type nodebox. ]]
+        leveled = 16, --[[
+        ^ Only valid for "nodebox" drawtype with 'type = "leveled"'.
+        ^ Allows defining the nodebox height without using param2.
+        ^ The nodebox height is 'leveled' / 64 nodes.
+        ^ The maximum value of 'leveled' is 127. ]]
         liquid_range = 8, -- number of flowing nodes around source (max. 8)
         drowning = 0, -- Player will take this amount of damage if no bubbles are left
         light_source = 0, --[[

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -250,9 +250,8 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 		u8 axisdir = facedir>>2;
 		facedir&=0x03;
 		for (aabb3f box : fixed) {
-			if (nodebox.type == NODEBOX_LEVELED) {
-				box.MaxEdge.Y = -BS/2 + BS*((float)1/LEVELED_MAX) * n.getLevel(nodemgr);
-			}
+			if (nodebox.type == NODEBOX_LEVELED)
+				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
 
 			switch (axisdir) {
 			case 0:

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -102,8 +102,8 @@ enum Rotation {
 
 #define LIQUID_INFINITY_MASK 0x80 //0b10000000
 
-// mask for param2, now as for liquid
-#define LEVELED_MASK 0x3F
+// mask for leveled nodebox param2
+#define LEVELED_MASK 0x7F
 #define LEVELED_MAX LEVELED_MASK
 
 


### PR DESCRIPTION
 Leveled nodebox: Change levels from 1/63rds to 1/64ths

Add missing documentation of leveled nodebox to lua_api.txt, plus
a little cleaning up nearby.
///////////////

Attends to https://github.com/minetest/minetest/issues/6409#issuecomment-329989042 onwards and #5322 and adds long-missing leveled nodebox documentation.
@numberZero 

Previously 'leveled' nodebox had levels that were 1/63rds node high, meaning they never matched up to 1/16th, 1/8th, quarter or half slabs, or texture pixels.
This was only done because the usable param2 values were chosen to be 0-63 where 63 is a full height node (instead of 64). This was done to use 6 bits for 'leveled' even though the other bits are not used for anything (and likely will not be because 2 bits is not useful).
The original implementation could have used 6 bits and 1/32 levels and matched up to slabs and pixels.
There is no reason or logic for using 0-63.

Here i have allowed param2 to take values 0-127 where 64 is a full node.
The new bitmask is 01111111 and the new max value is the same at 127.
My change only causes a very small (1/64th node maximum) height change for existing defined mod nodeboxes so is not much breakage (the levels of 'leveled nodebox' have never been documented so are not officially 'stable').
My change also adds the ability to define the nodebox to be taller than a full node, see screenshots for 96 and 127 below. This ability could be removed if desired by limiting the value to 64.

![screenshot_20170918_054455](https://user-images.githubusercontent.com/3686677/30529446-79387622-9c35-11e7-8c79-a412fd0dbb06.png)

^ leveled = 1,

![screenshot_20170918_054540](https://user-images.githubusercontent.com/3686677/30529436-666bcd00-9c35-11e7-9fab-a0fc4a37a25e.png)

^ leveled = 16,

![screenshot_20170918_054404](https://user-images.githubusercontent.com/3686677/30529437-6bbe97f6-9c35-11e7-9edd-f49b2aa2efee.png)

^ leveled = 32,

![screenshot_20170918_054315](https://user-images.githubusercontent.com/3686677/30529438-6eef335e-9c35-11e7-9049-a012b3408062.png)

^ leveled = 64,

![screenshot_20170918_054158](https://user-images.githubusercontent.com/3686677/30529441-71e32372-9c35-11e7-9927-46555895ee30.png)

^ leveled = 96, (node plus halfslab)

![screenshot_20170918_055546](https://user-images.githubusercontent.com/3686677/30529514-1eeb77d6-9c36-11e7-8fb5-0ea81379d993.png)

^ leveled = 127. (maximum value, quarter-pixel less than 2 nodes)

Test nodedef when using 'leveled = ':
```
minetest.register_node("default:snow", {
	description = "Snow",
	tiles = {"default_snow.png"},
	inventory_image = "default_snowball.png",
	wield_image = "default_snowball.png",
	paramtype = "light",
	drawtype = "nodebox",
	leveled = 16,
	node_box = {
		type = "leveled",
		fixed = {
			{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		},
	},
	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1, snowy = 1},
	sounds = default.node_sound_dirt_defaults({
		footstep = {name = "default_snow_footstep", gain = 0.15},
		dug = {name = "default_snow_footstep", gain = 0.2},
		dig = {name = "default_snow_footstep", gain = 0.2}
	}),
})
```
and when using param2:
```
minetest.register_node("default:snow", {
	description = "Snow",
	tiles = {"default_snow.png"},
	inventory_image = "default_snowball.png",
	wield_image = "default_snowball.png",
	paramtype = "light",
	paramtype2 = "leveled",
	place_param2 = 32,
	drawtype = "nodebox",
	node_box = {
		type = "leveled",
		fixed = {
			{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		},
	},
	groups = {crumbly = 3, falling_node = 1, puts_out_fire = 1, snowy = 1},
	sounds = default.node_sound_dirt_defaults({
		footstep = {name = "default_snow_footstep", gain = 0.15},
		dug = {name = "default_snow_footstep", gain = 0.2},
		dig = {name = "default_snow_footstep", gain = 0.2}
	}),
})
```