### PR TITLE
CAO footstep sounds: Reduce gain to balance volume

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -862,16 +862,17 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		float moved = lastpos.getDistanceFrom(pos_translator.vect_show);
 		m_step_distance_counter += moved;
-		if(m_step_distance_counter > 1.5*BS)
-		{
-			m_step_distance_counter = 0;
-			if(!m_is_local_player && m_prop.makes_footstep_sound)
-			{
+		if (m_step_distance_counter > 1.5f * BS) {
+			m_step_distance_counter = 0.0f;
+			if (!m_is_local_player && m_prop.makes_footstep_sound) {
 				INodeDefManager *ndef = m_client->ndef();
-				v3s16 p = floatToInt(getPosition() + v3f(0,
-						(m_prop.collisionbox.MinEdge.Y-0.5)*BS, 0), BS);
+				v3s16 p = floatToInt(getPosition() +
+					v3f(0.0f, (m_prop.collisionbox.MinEdge.Y - 0.5f) * BS, 0.0f), BS);
 				MapNode n = m_env->getMap().getNodeNoEx(p);
 				SimpleSoundSpec spec = ndef->get(n).sound_footstep;
+				// Reduce footstep gain, as non-local-player footsteps are
+				// somehow louder.
+				spec.gain *= 0.6f;
 				m_client->sound()->playSoundAt(spec, false, getPosition());
 			}
 		}


### PR DESCRIPTION
Addresses #4361 
Still required even after commit a455297d297c0819a7eff89e51e5f01a5ac731c3

Testing by standing as close as possible to a mob i found that mob footstep volume is somehow louder than the player's, and that a good match is created by multiplying the 'gain' by 0.6f. This has a nice side effect of reducing the effective hear distance which is reported to be a little too large.

No surprise then that footstep sounds are reported to be irritatingly loud on servers.

See below, seems to be a difference somehow caused by using positional sound for one and non-positional sound for the other, cannot find any cause for this so have added a gain multiplier tuned through testing.