### PR TITLE
Prefer loading blocks near predicted future player position

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -101,17 +101,16 @@ void RemoteClient::GetNextBlocks (
 
 	v3f playerpos = sao->getBasePosition();
 	const v3f &playerspeed = player->getSpeed();
-	v3f playerspeeddir(0,0,0);
-	f32 playerspeedlen = playerspeed.getLength();
-	if (playerspeedlen > 1.0f * BS)
-		playerspeeddir = playerspeed / playerspeedlen;
+	v3f playerpos_predicted = playerpos;
 
 	// Predict where player will be soon, load blocks around there first
 	// We use the client-reported speed as an indicator, but do not move the
 	// center point further than 1/2 the visible range away
-	v3f playerpos_predicted = playerpos + playerspeeddir *
-		rangelim(playerspeedlen * BS, MAP_BLOCKSIZE * BS, d_blocks_in_sight * 0.5f);
-
+	f32 playerspeedlen = playerspeed.getLength();
+	if (playerspeedlen > 1.0f * BS) {
+		playerpos_predicted += playerspeed / playerspeedlen *
+			rangelim(playerspeedlen * BS, MAP_BLOCKSIZE * BS, d_blocks_in_sight * 0.5f);
+	}
 	v3s16 center_nodepos = floatToInt(playerpos_predicted, BS);
 
 	v3s16 center = getNodeBlockPos(center_nodepos);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -100,8 +100,8 @@ void RemoteClient::GetNextBlocks (
 	if (camera_fov <= 0.0f)
 		camera_fov = (72.0f * M_PI / 180.0f) * 4.0f / 3.0f;
 
-	const s16 full_d_max = MYMIN(g_settings->getS16("max_block_send_distance"), wanted_range);
-	const s16 d_opt = MYMIN(g_settings->getS16("block_send_optimize_distance"), wanted_range);
+	const s16 full_d_max = std::min(g_settings->getS16("max_block_send_distance"), wanted_range);
+	const s16 d_opt = std::min(g_settings->getS16("block_send_optimize_distance"), wanted_range);
 	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 
 	v3f playerpos = sao->getBasePosition();
@@ -187,7 +187,7 @@ void RemoteClient::GetNextBlocks (
 	s32 new_nearest_unsent_d = -1;
 
 	s16 d_max = full_d_max;
-	s16 d_max_gen = MYMIN(g_settings->getS16("max_block_generate_distance"), wanted_range);
+	s16 d_max_gen = std::min(g_settings->getS16("max_block_generate_distance"), wanted_range);
 
 	// Don't loop very much at a time
 	s16 max_d_increment_at_time = 2;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -93,9 +93,12 @@ void RemoteClient::GetNextBlocks (
 	// get view range and camera fov from the client
 	s16 wanted_range = sao->getWantedRange();
 	float camera_fov = sao->getFov();
+
 	// if FOV, wanted_range are not available (old client), fall back to old default
-	if (wanted_range <= 0) wanted_range = 1000;
-	if (camera_fov <= 0) camera_fov = (72.0*M_PI/180) * 4./3.;
+	if (wanted_range <= 0)
+		wanted_range = 1000;
+	if (camera_fov <= 0.0f)
+		camera_fov = (72.0f * M_PI / 180.0f) * 4.0f / 3.0f;
 
 	const s16 full_d_max = MYMIN(g_settings->getS16("max_block_send_distance"), wanted_range);
 	const s16 d_opt = MYMIN(g_settings->getS16("block_send_optimize_distance"), wanted_range);
@@ -105,12 +108,12 @@ void RemoteClient::GetNextBlocks (
 	const v3f &playerspeed = player->getSpeed();
 	v3f playerspeeddir(0,0,0);
 	f32 playerspeedlen = playerspeed.getLength();
-	if(playerspeedlen > 1.0*BS)
+	if (playerspeedlen > 1.0f * BS)
 		playerspeeddir = playerspeed / playerspeedlen;
 
 	// Predict where player will be soon, load blocks around there first
 	v3f playerpos_predicted = playerpos + playerspeeddir *
-		MYMIN(playerspeedlen * BS, d_blocks_in_sight*0.5f);
+		rangelim(playerspeedlen * BS, MAP_BLOCKSIZE * BS, d_blocks_in_sight * 0.5f);
 
 	v3s16 center_nodepos = floatToInt(playerpos_predicted, BS);
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -18,7 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <sstream>
-#include <cmath>
 #include "clientiface.h"
 #include "network/connection.h"
 #include "network/serveropcodes.h"
@@ -106,10 +105,16 @@ void RemoteClient::GetNextBlocks (
 	// Limit to 0.0f in case player moves backwards.
 	// When a player moves forward but looks down or backwards the adjustment will be 0.
 	// (note that playerspeed is not normalized, that way we save a few vector operations)
-	const f32 adjust = std::max(camera_dir.dotProduct(playerspeed), 0.0f) / BS;
+	f32 adjust = camera_dir.dotProduct(playerspeed) / BS;
 
 	// Predict where player will be soon. Just add the speed. The factor two tested well.
-	v3f playerpos_predicted = playerpos + playerspeed * 2.0f;
+	// if the player moves backwards (adjust < 0), do not adjust the center
+	v3f playerpos_predicted = playerpos;
+	if (adjust > 0.0f) {
+		playerpos_predicted += playerspeed * 2.0f;
+	} else {
+		adjust = 0.0f;
+	}
 
 	v3s16 center_nodepos = floatToInt(playerpos_predicted, BS);
 


### PR DESCRIPTION
Very simple and stupid player position prediction.

When a player is not (or slowly) moving, the logic is unchanged.
But if a player is moving fast (f.e. flying in fast mode) the server will prefer to send block some distance out in the direction the player is traveling.
This effect is capped at 50% of the visible range - that is farthest shift the player will allow.

This makes for a smoother experience. Human players tend to look into the direction they move, and then part will be rendered sooner. Capping it at 50% of the view range avoids rendering faraway "block-islands".

Note: Part of this effect existed already, but it was set to exactly one MAPBLOCK out in the player's moving direction regardless of the player's speed. This makes it speed dependent.
