### PR TITLE
Update version correctly again

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,6 +5,10 @@
 
 #pragma once
 
+#define STRINGIFY(x) #x
+#define STR(x) STRINGIFY(x)
+
+
 #if defined USE_CMAKE_CONFIG_H
 	#include "cmake_config.h"
 #elif defined (__ANDROID__) || defined (ANDROID)
@@ -24,3 +28,14 @@
 		#define BUILD_TYPE "Debug"
 	#endif
 #endif
+
+#define BUILD_INFO \
+	"Build date: " __DATE__ " " __TIME__ "\n" \
+	"BUILD_TYPE=" BUILD_TYPE "\n"             \
+	"RUN_IN_PLACE=" STR(RUN_IN_PLACE) "\n"    \
+	"USE_GETTEXT=" STR(USE_GETTEXT) "\n"      \
+	"USE_SOUND=" STR(USE_SOUND) "\n"          \
+	"USE_CURL=" STR(USE_CURL) "\n"            \
+	"USE_FREETYPE=" STR(USE_FREETYPE) "\n"    \
+	"USE_LUAJIT=" STR(USE_LUAJIT) "\n"        \
+	"STATIC_SHAREDIR=" STR(STATIC_SHAREDIR);

--- a/src/config.h
+++ b/src/config.h
@@ -30,12 +30,11 @@
 #endif
 
 #define BUILD_INFO \
-	"Build date: " __DATE__ " " __TIME__ "\n" \
-	"BUILD_TYPE=" BUILD_TYPE "\n"             \
-	"RUN_IN_PLACE=" STR(RUN_IN_PLACE) "\n"    \
-	"USE_GETTEXT=" STR(USE_GETTEXT) "\n"      \
-	"USE_SOUND=" STR(USE_SOUND) "\n"          \
-	"USE_CURL=" STR(USE_CURL) "\n"            \
-	"USE_FREETYPE=" STR(USE_FREETYPE) "\n"    \
-	"USE_LUAJIT=" STR(USE_LUAJIT) "\n"        \
+	"BUILD_TYPE=" BUILD_TYPE "\n"          \
+	"RUN_IN_PLACE=" STR(RUN_IN_PLACE) "\n" \
+	"USE_GETTEXT=" STR(USE_GETTEXT) "\n"   \
+	"USE_SOUND=" STR(USE_SOUND) "\n"       \
+	"USE_CURL=" STR(USE_CURL) "\n"         \
+	"USE_FREETYPE=" STR(USE_FREETYPE) "\n" \
+	"USE_LUAJIT=" STR(USE_LUAJIT) "\n"     \
 	"STATIC_SHAREDIR=" STR(STATIC_SHAREDIR);

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -31,20 +31,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#define VERSION_GITHASH VERSION_STRING
 #endif
 
-#define STRINGIFY(x) #x
-#define STR(x) STRINGIFY(x)
-
 const char *g_version_string = VERSION_STRING;
 const char *g_version_hash = VERSION_GITHASH;
-const char *g_build_info =
-#ifdef __STDC__
-	"Build date: " __DATE__ " " __TIME__ "\n"
-#endif
-	"BUILD_TYPE=" BUILD_TYPE "\n"
-	"RUN_IN_PLACE=" STR(RUN_IN_PLACE) "\n"
-	"USE_GETTEXT=" STR(USE_GETTEXT) "\n"
-	"USE_SOUND=" STR(USE_SOUND) "\n"
-	"USE_CURL=" STR(USE_CURL) "\n"
-	"USE_FREETYPE=" STR(USE_FREETYPE) "\n"
-	"USE_LUAJIT=" STR(USE_LUAJIT) "\n"
-	"STATIC_SHAREDIR=" STR(STATIC_SHAREDIR);
+const char *g_build_info = BUILD_INFO;


### PR DESCRIPTION
Partial revert of #6331 (moving the code from version.cpp back to config.h)
The newline ~and build date information~ is kept.
Fixes #6461

Output with this PR:
```
$ minetest --version
Minetest 0.5.0-dev-a1d636a-dirty (Linux)
Using Irrlicht 1.8.3
BUILD_TYPE=Release
RUN_IN_PLACE=1
USE_GETTEXT=1
USE_SOUND=1
USE_CURL=1
USE_FREETYPE=1
USE_LUAJIT=1
STATIC_SHAREDIR="."
```
