### PR TITLE
Add session_t typedef + remove unused functions

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1218,7 +1218,7 @@ void Client::sendPlayerPos()
 
 	//infostream << "Sending Player Position information" << std::endl;
 
-	SessionId our_peer_id = m_con->GetPeerID();
+	session_t our_peer_id = m_con->GetPeerID();
 
 	// Set peer id if not set already
 	if(myplayer->peer_id == PEER_ID_INEXISTENT)
@@ -1239,7 +1239,7 @@ void Client::sendPlayerItem(u16 item)
 	if(myplayer == NULL)
 		return;
 
-	SessionId our_peer_id = m_con->GetPeerID();
+	session_t our_peer_id = m_con->GetPeerID();
 
 	// Set peer id if not set already
 	if(myplayer->peer_id == PEER_ID_INEXISTENT)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1218,11 +1218,7 @@ void Client::sendPlayerPos()
 
 	//infostream << "Sending Player Position information" << std::endl;
 
-	u16 our_peer_id;
-	{
-		//MutexAutoLock lock(m_con_mutex); //bulk comment-out
-		our_peer_id = m_con->GetPeerID();
-	}
+	SessionId our_peer_id = m_con->GetPeerID();
 
 	// Set peer id if not set already
 	if(myplayer->peer_id == PEER_ID_INEXISTENT)
@@ -1243,7 +1239,7 @@ void Client::sendPlayerItem(u16 item)
 	if(myplayer == NULL)
 		return;
 
-	u16 our_peer_id = m_con->GetPeerID();
+	SessionId our_peer_id = m_con->GetPeerID();
 
 	// Set peer id if not set already
 	if(myplayer->peer_id == PEER_ID_INEXISTENT)

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -669,7 +669,7 @@ void ClientInterface::UpdatePlayerList()
 	}
 }
 
-void ClientInterface::send(u16 peer_id, u8 channelnum,
+void ClientInterface::send(SessionId peer_id, u8 channelnum,
 		NetworkPacket* pkt, bool reliable)
 {
 	m_con->Send(peer_id, channelnum, pkt, reliable);
@@ -714,7 +714,7 @@ void ClientInterface::sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacyp
 	}
 }
 
-RemoteClient* ClientInterface::getClientNoEx(u16 peer_id, ClientState state_min)
+RemoteClient* ClientInterface::getClientNoEx(SessionId peer_id, ClientState state_min)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
@@ -729,7 +729,7 @@ RemoteClient* ClientInterface::getClientNoEx(u16 peer_id, ClientState state_min)
 	return NULL;
 }
 
-RemoteClient* ClientInterface::lockedGetClientNoEx(u16 peer_id, ClientState state_min)
+RemoteClient* ClientInterface::lockedGetClientNoEx(SessionId peer_id, ClientState state_min)
 {
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
@@ -743,7 +743,7 @@ RemoteClient* ClientInterface::lockedGetClientNoEx(u16 peer_id, ClientState stat
 	return NULL;
 }
 
-ClientState ClientInterface::getClientState(u16 peer_id)
+ClientState ClientInterface::getClientState(SessionId peer_id)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
@@ -755,7 +755,7 @@ ClientState ClientInterface::getClientState(u16 peer_id)
 	return n->second->getState();
 }
 
-void ClientInterface::setPlayerName(u16 peer_id,std::string name)
+void ClientInterface::setPlayerName(SessionId peer_id,std::string name)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::iterator n = m_clients.find(peer_id);
@@ -765,7 +765,7 @@ void ClientInterface::setPlayerName(u16 peer_id,std::string name)
 		n->second->setName(name);
 }
 
-void ClientInterface::DeleteClient(u16 peer_id)
+void ClientInterface::DeleteClient(SessionId peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -795,7 +795,7 @@ void ClientInterface::DeleteClient(u16 peer_id)
 	m_clients.erase(peer_id);
 }
 
-void ClientInterface::CreateClient(u16 peer_id)
+void ClientInterface::CreateClient(SessionId peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -810,7 +810,7 @@ void ClientInterface::CreateClient(u16 peer_id)
 	m_clients[client->peer_id] = client;
 }
 
-void ClientInterface::event(u16 peer_id, ClientStateEvent event)
+void ClientInterface::event(SessionId peer_id, ClientStateEvent event)
 {
 	{
 		MutexAutoLock clientlock(m_clients_mutex);
@@ -832,7 +832,7 @@ void ClientInterface::event(u16 peer_id, ClientStateEvent event)
 	}
 }
 
-u16 ClientInterface::getProtocolVersion(u16 peer_id)
+u16 ClientInterface::getProtocolVersion(SessionId peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -846,7 +846,8 @@ u16 ClientInterface::getProtocolVersion(u16 peer_id)
 	return n->second->net_proto_version;
 }
 
-void ClientInterface::setClientVersion(u16 peer_id, u8 major, u8 minor, u8 patch, std::string full)
+void ClientInterface::setClientVersion(SessionId peer_id, u8 major, u8 minor, u8 patch,
+		const std::string &full)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -857,5 +858,5 @@ void ClientInterface::setClientVersion(u16 peer_id, u8 major, u8 minor, u8 patch
 	if (n == m_clients.end())
 		return;
 
-	n->second->setVersionInfo(major,minor,patch,full);
+	n->second->setVersionInfo(major, minor, patch, full);
 }

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -755,7 +755,7 @@ ClientState ClientInterface::getClientState(session_t peer_id)
 	return n->second->getState();
 }
 
-void ClientInterface::setPlayerName(session_t peer_id,std::string name)
+void ClientInterface::setPlayerName(session_t peer_id, const std::string &name)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::iterator n = m_clients.find(peer_id);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -669,8 +669,8 @@ void ClientInterface::UpdatePlayerList()
 	}
 }
 
-void ClientInterface::send(SessionId peer_id, u8 channelnum,
-		NetworkPacket* pkt, bool reliable)
+void ClientInterface::send(session_t peer_id, u8 channelnum,
+		NetworkPacket *pkt, bool reliable)
 {
 	m_con->Send(peer_id, channelnum, pkt, reliable);
 }
@@ -714,7 +714,7 @@ void ClientInterface::sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacyp
 	}
 }
 
-RemoteClient* ClientInterface::getClientNoEx(SessionId peer_id, ClientState state_min)
+RemoteClient* ClientInterface::getClientNoEx(session_t peer_id, ClientState state_min)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
@@ -729,7 +729,7 @@ RemoteClient* ClientInterface::getClientNoEx(SessionId peer_id, ClientState stat
 	return NULL;
 }
 
-RemoteClient* ClientInterface::lockedGetClientNoEx(SessionId peer_id, ClientState state_min)
+RemoteClient* ClientInterface::lockedGetClientNoEx(session_t peer_id, ClientState state_min)
 {
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
@@ -743,7 +743,7 @@ RemoteClient* ClientInterface::lockedGetClientNoEx(SessionId peer_id, ClientStat
 	return NULL;
 }
 
-ClientState ClientInterface::getClientState(SessionId peer_id)
+ClientState ClientInterface::getClientState(session_t peer_id)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
@@ -755,7 +755,7 @@ ClientState ClientInterface::getClientState(SessionId peer_id)
 	return n->second->getState();
 }
 
-void ClientInterface::setPlayerName(SessionId peer_id,std::string name)
+void ClientInterface::setPlayerName(session_t peer_id,std::string name)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::iterator n = m_clients.find(peer_id);
@@ -765,7 +765,7 @@ void ClientInterface::setPlayerName(SessionId peer_id,std::string name)
 		n->second->setName(name);
 }
 
-void ClientInterface::DeleteClient(SessionId peer_id)
+void ClientInterface::DeleteClient(session_t peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -795,7 +795,7 @@ void ClientInterface::DeleteClient(SessionId peer_id)
 	m_clients.erase(peer_id);
 }
 
-void ClientInterface::CreateClient(SessionId peer_id)
+void ClientInterface::CreateClient(session_t peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -810,7 +810,7 @@ void ClientInterface::CreateClient(SessionId peer_id)
 	m_clients[client->peer_id] = client;
 }
 
-void ClientInterface::event(SessionId peer_id, ClientStateEvent event)
+void ClientInterface::event(session_t peer_id, ClientStateEvent event)
 {
 	{
 		MutexAutoLock clientlock(m_clients_mutex);
@@ -832,7 +832,7 @@ void ClientInterface::event(SessionId peer_id, ClientStateEvent event)
 	}
 }
 
-u16 ClientInterface::getProtocolVersion(SessionId peer_id)
+u16 ClientInterface::getProtocolVersion(session_t peer_id)
 {
 	MutexAutoLock conlock(m_clients_mutex);
 
@@ -846,7 +846,7 @@ u16 ClientInterface::getProtocolVersion(SessionId peer_id)
 	return n->second->net_proto_version;
 }
 
-void ClientInterface::setClientVersion(SessionId peer_id, u8 major, u8 minor, u8 patch,
+void ClientInterface::setClientVersion(session_t peer_id, u8 major, u8 minor, u8 patch,
 		const std::string &full)
 {
 	MutexAutoLock conlock(m_clients_mutex);

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -205,7 +205,7 @@ enum ClientStateEvent
 */
 struct PrioritySortedBlockTransfer
 {
-	PrioritySortedBlockTransfer(float a_priority, const v3s16 &a_pos, SessionId a_peer_id)
+	PrioritySortedBlockTransfer(float a_priority, const v3s16 &a_pos, session_t a_peer_id)
 	{
 		priority = a_priority;
 		pos = a_pos;
@@ -217,7 +217,7 @@ struct PrioritySortedBlockTransfer
 	}
 	float priority;
 	v3s16 pos;
-	SessionId peer_id;
+	session_t peer_id;
 };
 
 class RemoteClient
@@ -227,7 +227,7 @@ public:
 	// NOTE: If client is made allowed to exist while peer doesn't,
 	//       this has to be set to 0 when there is no peer.
 	//       Also, the client must be moved to some other container.
-	SessionId peer_id = PEER_ID_INEXISTENT;
+	session_t peer_id = PEER_ID_INEXISTENT;
 	// The serialization version to use with the client
 	u8 serialization_version = SER_FMT_VER_INVALID;
 	//
@@ -431,39 +431,39 @@ public:
 	const std::vector<std::string> &getPlayerNames() const { return m_clients_names; }
 
 	/* send message to client */
-	void send(SessionId peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
+	void send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable);
 
 	/* send to all clients */
 	void sendToAll(NetworkPacket *pkt);
 	void sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacypkt, u16 min_proto_ver);
 
 	/* delete a client */
-	void DeleteClient(SessionId peer_id);
+	void DeleteClient(session_t peer_id);
 
 	/* create client */
-	void CreateClient(SessionId peer_id);
+	void CreateClient(session_t peer_id);
 
 	/* get a client by peer_id */
-	RemoteClient* getClientNoEx(SessionId peer_id,  ClientState state_min=CS_Active);
+	RemoteClient *getClientNoEx(session_t peer_id,  ClientState state_min = CS_Active);
 
 	/* get client by peer_id (make sure you have list lock before!*/
-	RemoteClient* lockedGetClientNoEx(SessionId peer_id,  ClientState state_min=CS_Active);
+	RemoteClient *lockedGetClientNoEx(session_t peer_id,  ClientState state_min = CS_Active);
 
 	/* get state of client by id*/
-	ClientState getClientState(SessionId peer_id);
+	ClientState getClientState(session_t peer_id);
 
 	/* set client playername */
-	void setPlayerName(SessionId peer_id,std::string name);
+	void setPlayerName(session_t peer_id,std::string name);
 
 	/* get protocol version of client */
-	u16 getProtocolVersion(SessionId peer_id);
+	u16 getProtocolVersion(session_t peer_id);
 
 	/* set client version */
-	void setClientVersion(SessionId peer_id, u8 major, u8 minor, u8 patch,
+	void setClientVersion(session_t peer_id, u8 major, u8 minor, u8 patch,
 			const std::string &full);
 
 	/* event to update client state */
-	void event(SessionId peer_id, ClientStateEvent event);
+	void event(session_t peer_id, ClientStateEvent event);
 
 	/* Set environment. Do not call this function if environment is already set */
 	void setEnv(ServerEnvironment *env)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -205,7 +205,7 @@ enum ClientStateEvent
 */
 struct PrioritySortedBlockTransfer
 {
-	PrioritySortedBlockTransfer(float a_priority, const v3s16 &a_pos, u16 a_peer_id)
+	PrioritySortedBlockTransfer(float a_priority, const v3s16 &a_pos, SessionId a_peer_id)
 	{
 		priority = a_priority;
 		pos = a_pos;
@@ -217,7 +217,7 @@ struct PrioritySortedBlockTransfer
 	}
 	float priority;
 	v3s16 pos;
-	u16 peer_id;
+	SessionId peer_id;
 };
 
 class RemoteClient
@@ -227,7 +227,7 @@ public:
 	// NOTE: If client is made allowed to exist while peer doesn't,
 	//       this has to be set to 0 when there is no peer.
 	//       Also, the client must be moved to some other container.
-	u16 peer_id = PEER_ID_INEXISTENT;
+	SessionId peer_id = PEER_ID_INEXISTENT;
 	// The serialization version to use with the client
 	u8 serialization_version = SER_FMT_VER_INVALID;
 	//
@@ -431,38 +431,39 @@ public:
 	const std::vector<std::string> &getPlayerNames() const { return m_clients_names; }
 
 	/* send message to client */
-	void send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
+	void send(SessionId peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
 
 	/* send to all clients */
 	void sendToAll(NetworkPacket *pkt);
 	void sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacypkt, u16 min_proto_ver);
 
 	/* delete a client */
-	void DeleteClient(u16 peer_id);
+	void DeleteClient(SessionId peer_id);
 
 	/* create client */
-	void CreateClient(u16 peer_id);
+	void CreateClient(SessionId peer_id);
 
 	/* get a client by peer_id */
-	RemoteClient* getClientNoEx(u16 peer_id,  ClientState state_min=CS_Active);
+	RemoteClient* getClientNoEx(SessionId peer_id,  ClientState state_min=CS_Active);
 
 	/* get client by peer_id (make sure you have list lock before!*/
-	RemoteClient* lockedGetClientNoEx(u16 peer_id,  ClientState state_min=CS_Active);
+	RemoteClient* lockedGetClientNoEx(SessionId peer_id,  ClientState state_min=CS_Active);
 
 	/* get state of client by id*/
-	ClientState getClientState(u16 peer_id);
+	ClientState getClientState(SessionId peer_id);
 
 	/* set client playername */
-	void setPlayerName(u16 peer_id,std::string name);
+	void setPlayerName(SessionId peer_id,std::string name);
 
 	/* get protocol version of client */
-	u16 getProtocolVersion(u16 peer_id);
+	u16 getProtocolVersion(SessionId peer_id);
 
 	/* set client version */
-	void setClientVersion(u16 peer_id, u8 major, u8 minor, u8 patch, std::string full);
+	void setClientVersion(SessionId peer_id, u8 major, u8 minor, u8 patch,
+			const std::string &full);
 
 	/* event to update client state */
-	void event(u16 peer_id, ClientStateEvent event);
+	void event(SessionId peer_id, ClientStateEvent event);
 
 	/* Set environment. Do not call this function if environment is already set */
 	void setEnv(ServerEnvironment *env)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -453,7 +453,7 @@ public:
 	ClientState getClientState(session_t peer_id);
 
 	/* set client playername */
-	void setPlayerName(session_t peer_id,std::string name);
+	void setPlayerName(session_t peer_id, const std::string &name);
 
 	/* get protocol version of client */
 	u16 getProtocolVersion(session_t peer_id);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -784,7 +784,7 @@ bool LuaEntitySAO::collideWithObjects() const
 
 // No prototype, PlayerSAO does not need to be deserialized
 
-PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, SessionId peer_id_,
+PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
 		bool is_singleplayer):
 	UnitSAO(env_, v3f(0,0,0)),
 	m_player(player_),

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -784,7 +784,7 @@ bool LuaEntitySAO::collideWithObjects() const
 
 // No prototype, PlayerSAO does not need to be deserialized
 
-PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id_,
+PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, SessionId peer_id_,
 		bool is_singleplayer):
 	UnitSAO(env_, v3f(0,0,0)),
 	m_player(player_),

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -197,7 +197,7 @@ class RemotePlayer;
 class PlayerSAO : public UnitSAO
 {
 public:
-	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, SessionId peer_id_,
+	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
 			bool is_singleplayer);
 	~PlayerSAO();
 	ActiveObjectType getType() const
@@ -313,7 +313,7 @@ public:
 	void disconnected();
 
 	RemotePlayer *getPlayer() { return m_player; }
-	SessionId getPeerID() const { return m_peer_id; }
+	session_t getPeerID() const { return m_peer_id; }
 
 	// Cheat prevention
 
@@ -374,7 +374,7 @@ private:
 	void unlinkPlayerSessionAndSave();
 
 	RemotePlayer *m_player = nullptr;
-	SessionId m_peer_id = 0;
+	session_t m_peer_id = 0;
 	Inventory *m_inventory = nullptr;
 	s16 m_damage = 0;
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -19,7 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
-#include <util/numeric.h>
+#include "network/networkprotocol.h"
+#include "util/numeric.h"
 #include "serverobject.h"
 #include "itemgroup.h"
 #include "object_properties.h"
@@ -196,7 +197,8 @@ class RemotePlayer;
 class PlayerSAO : public UnitSAO
 {
 public:
-	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, u16 peer_id_, bool is_singleplayer);
+	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, SessionId peer_id_,
+			bool is_singleplayer);
 	~PlayerSAO();
 	ActiveObjectType getType() const
 	{ return ACTIVEOBJECT_TYPE_PLAYER; }
@@ -311,7 +313,7 @@ public:
 	void disconnected();
 
 	RemotePlayer *getPlayer() { return m_player; }
-	u16 getPeerID() const { return m_peer_id; }
+	SessionId getPeerID() const { return m_peer_id; }
 
 	// Cheat prevention
 
@@ -372,7 +374,7 @@ private:
 	void unlinkPlayerSessionAndSave();
 
 	RemotePlayer *m_player = nullptr;
-	u16 m_peer_id = 0;
+	SessionId m_peer_id = 0;
 	Inventory *m_inventory = nullptr;
 	s16 m_damage = 0;
 

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -247,7 +247,7 @@ bool EmergeManager::isRunning()
 
 
 bool EmergeManager::enqueueBlockEmerge(
-	u16 peer_id,
+	SessionId peer_id,
 	v3s16 blockpos,
 	bool allow_generate,
 	bool ignore_queue_limits)
@@ -264,7 +264,7 @@ bool EmergeManager::enqueueBlockEmerge(
 
 bool EmergeManager::enqueueBlockEmergeEx(
 	v3s16 blockpos,
-	u16 peer_id,
+	SessionId peer_id,
 	u16 flags,
 	EmergeCompletionCallback callback,
 	void *callback_param)

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -247,7 +247,7 @@ bool EmergeManager::isRunning()
 
 
 bool EmergeManager::enqueueBlockEmerge(
-	SessionId peer_id,
+	session_t peer_id,
 	v3s16 blockpos,
 	bool allow_generate,
 	bool ignore_queue_limits)
@@ -264,7 +264,7 @@ bool EmergeManager::enqueueBlockEmerge(
 
 bool EmergeManager::enqueueBlockEmergeEx(
 	v3s16 blockpos,
-	SessionId peer_id,
+	session_t peer_id,
 	u16 flags,
 	EmergeCompletionCallback callback,
 	void *callback_param)

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <map>
 #include <mutex>
+#include "network/networkprotocol.h"
 #include "irr_v3d.h"
 #include "util/container.h"
 #include "mapgen.h" // for MapgenParams
@@ -123,14 +124,14 @@ public:
 	bool isRunning();
 
 	bool enqueueBlockEmerge(
-		u16 peer_id,
+		SessionId peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
 		bool ignore_queue_limits=false);
 
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,
-		u16 peer_id,
+		SessionId peer_id,
 		u16 flags,
 		EmergeCompletionCallback callback,
 		void *callback_param);

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -124,14 +124,14 @@ public:
 	bool isRunning();
 
 	bool enqueueBlockEmerge(
-		SessionId peer_id,
+		session_t peer_id,
 		v3s16 blockpos,
 		bool allow_generate,
 		bool ignore_queue_limits=false);
 
 	bool enqueueBlockEmergeEx(
 		v3s16 blockpos,
-		SessionId peer_id,
+		session_t peer_id,
 		u16 flags,
 		EmergeCompletionCallback callback,
 		void *callback_param);

--- a/src/modchannels.cpp
+++ b/src/modchannels.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 #include "util/basic_macros.h"
 
-bool ModChannel::registerConsumer(SessionId peer_id)
+bool ModChannel::registerConsumer(session_t peer_id)
 {
 
 	// ignore if peer_id already joined
@@ -33,7 +33,7 @@ bool ModChannel::registerConsumer(SessionId peer_id)
 	return true;
 }
 
-bool ModChannel::removeConsumer(SessionId peer_id)
+bool ModChannel::removeConsumer(session_t peer_id)
 {
 	bool found = false;
 	auto peer_removal_fct = [peer_id, &found](u16 p) {
@@ -112,7 +112,7 @@ bool ModChannelMgr::removeChannel(const std::string &channel)
 	return true;
 }
 
-bool ModChannelMgr::joinChannel(const std::string &channel, SessionId peer_id)
+bool ModChannelMgr::joinChannel(const std::string &channel, session_t peer_id)
 {
 	if (!channelRegistered(channel))
 		registerChannel(channel);
@@ -120,7 +120,7 @@ bool ModChannelMgr::joinChannel(const std::string &channel, SessionId peer_id)
 	return m_registered_channels[channel]->registerConsumer(peer_id);
 }
 
-bool ModChannelMgr::leaveChannel(const std::string &channel, SessionId peer_id)
+bool ModChannelMgr::leaveChannel(const std::string &channel, session_t peer_id)
 {
 	if (!channelRegistered(channel))
 		return false;
@@ -135,7 +135,7 @@ bool ModChannelMgr::leaveChannel(const std::string &channel, SessionId peer_id)
 	return consumerRemoved;
 }
 
-void ModChannelMgr::leaveAllChannels(SessionId peer_id)
+void ModChannelMgr::leaveAllChannels(session_t peer_id)
 {
 	for (auto &channel_it : m_registered_channels)
 		channel_it.second->removeConsumer(peer_id);

--- a/src/modchannels.cpp
+++ b/src/modchannels.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 #include "util/basic_macros.h"
 
-bool ModChannel::registerConsumer(u16 peer_id)
+bool ModChannel::registerConsumer(SessionId peer_id)
 {
 
 	// ignore if peer_id already joined
@@ -33,7 +33,7 @@ bool ModChannel::registerConsumer(u16 peer_id)
 	return true;
 }
 
-bool ModChannel::removeConsumer(u16 peer_id)
+bool ModChannel::removeConsumer(SessionId peer_id)
 {
 	bool found = false;
 	auto peer_removal_fct = [peer_id, &found](u16 p) {
@@ -112,7 +112,7 @@ bool ModChannelMgr::removeChannel(const std::string &channel)
 	return true;
 }
 
-bool ModChannelMgr::joinChannel(const std::string &channel, u16 peer_id)
+bool ModChannelMgr::joinChannel(const std::string &channel, SessionId peer_id)
 {
 	if (!channelRegistered(channel))
 		registerChannel(channel);
@@ -120,7 +120,7 @@ bool ModChannelMgr::joinChannel(const std::string &channel, u16 peer_id)
 	return m_registered_channels[channel]->registerConsumer(peer_id);
 }
 
-bool ModChannelMgr::leaveChannel(const std::string &channel, u16 peer_id)
+bool ModChannelMgr::leaveChannel(const std::string &channel, SessionId peer_id)
 {
 	if (!channelRegistered(channel))
 		return false;
@@ -135,7 +135,7 @@ bool ModChannelMgr::leaveChannel(const std::string &channel, u16 peer_id)
 	return consumerRemoved;
 }
 
-void ModChannelMgr::leaveAllChannels(u16 peer_id)
+void ModChannelMgr::leaveAllChannels(SessionId peer_id)
 {
 	for (auto &channel_it : m_registered_channels)
 		channel_it.second->removeConsumer(peer_id);

--- a/src/modchannels.h
+++ b/src/modchannels.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <vector>
 #include <memory>
+#include "network/networkprotocol.h"
 #include "irrlichttypes.h"
 
 enum ModChannelState : u8
@@ -40,8 +41,8 @@ public:
 	~ModChannel() = default;
 
 	const std::string &getName() const { return m_name; }
-	bool registerConsumer(u16 peer_id);
-	bool removeConsumer(u16 peer_id);
+	bool registerConsumer(SessionId peer_id);
+	bool removeConsumer(SessionId peer_id);
 	const std::vector<u16> &getChannelPeers() const { return m_client_consumers; }
 	bool canWrite() const;
 	void setState(ModChannelState state);
@@ -70,8 +71,8 @@ public:
 
 	void registerChannel(const std::string &channel);
 	bool setChannelState(const std::string &channel, ModChannelState state);
-	bool joinChannel(const std::string &channel, u16 peer_id);
-	bool leaveChannel(const std::string &channel, u16 peer_id);
+	bool joinChannel(const std::string &channel, SessionId peer_id);
+	bool leaveChannel(const std::string &channel, SessionId peer_id);
 	bool channelRegistered(const std::string &channel) const;
 	ModChannel *getModChannel(const std::string &channel);
 	/**
@@ -81,7 +82,7 @@ public:
 	 * @return true if write is allowed
 	 */
 	bool canWriteOnChannel(const std::string &channel) const;
-	void leaveAllChannels(u16 peer_id);
+	void leaveAllChannels(SessionId peer_id);
 	const std::vector<u16> &getChannelPeers(const std::string &channel) const;
 
 private:

--- a/src/modchannels.h
+++ b/src/modchannels.h
@@ -41,8 +41,8 @@ public:
 	~ModChannel() = default;
 
 	const std::string &getName() const { return m_name; }
-	bool registerConsumer(SessionId peer_id);
-	bool removeConsumer(SessionId peer_id);
+	bool registerConsumer(session_t peer_id);
+	bool removeConsumer(session_t peer_id);
 	const std::vector<u16> &getChannelPeers() const { return m_client_consumers; }
 	bool canWrite() const;
 	void setState(ModChannelState state);
@@ -71,8 +71,8 @@ public:
 
 	void registerChannel(const std::string &channel);
 	bool setChannelState(const std::string &channel, ModChannelState state);
-	bool joinChannel(const std::string &channel, SessionId peer_id);
-	bool leaveChannel(const std::string &channel, SessionId peer_id);
+	bool joinChannel(const std::string &channel, session_t peer_id);
+	bool leaveChannel(const std::string &channel, session_t peer_id);
 	bool channelRegistered(const std::string &channel) const;
 	ModChannel *getModChannel(const std::string &channel);
 	/**
@@ -82,7 +82,7 @@ public:
 	 * @return true if write is allowed
 	 */
 	bool canWriteOnChannel(const std::string &channel) const;
-	void leaveAllChannels(SessionId peer_id);
+	void leaveAllChannels(session_t peer_id);
 	const std::vector<u16> &getChannelPeers(const std::string &channel) const;
 
 private:

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -56,7 +56,7 @@ std::mutex log_message_mutex;
 #define PING_TIMEOUT 5.0
 
 BufferedPacket makePacket(Address &address, SharedBuffer<u8> data,
-		u32 protocol_id, u16 sender_peer_id, u8 channel)
+		u32 protocol_id, SessionId sender_peer_id, u8 channel)
 {
 	u32 packet_size = data.getSize() + BASE_HEADER_SIZE;
 	BufferedPacket p(packet_size);
@@ -501,7 +501,7 @@ void IncomingSplitBuffer::removeUnreliableTimedOuts(float dtime, float timeout)
 	ConnectionCommand
  */
 
-void ConnectionCommand::send(u16 peer_id_, u8 channelnum_, NetworkPacket *pkt,
+void ConnectionCommand::send(SessionId peer_id_, u8 channelnum_, NetworkPacket *pkt,
 	bool reliable_)
 {
 	type = CONNCMD_SEND;
@@ -1198,10 +1198,10 @@ void Connection::TriggerSend()
 	m_sendThread->Trigger();
 }
 
-PeerHelper Connection::getPeerNoEx(u16 peer_id)
+PeerHelper Connection::getPeerNoEx(SessionId peer_id)
 {
 	MutexAutoLock peerlock(m_peers_mutex);
-	std::map<u16, Peer*>::iterator node = m_peers.find(peer_id);
+	std::map<SessionId, Peer*>::iterator node = m_peers.find(peer_id);
 
 	if (node == m_peers.end()) {
 		return PeerHelper(NULL);
@@ -1237,17 +1237,7 @@ u16 Connection::lookupPeer(Address& sender)
 	return PEER_ID_INEXISTENT;
 }
 
-std::list<Peer*> Connection::getPeers()
-{
-	std::list<Peer*> list;
-	for (auto &p : m_peers) {
-		Peer *peer = p.second;
-		list.push_back(peer);
-	}
-	return list;
-}
-
-bool Connection::deletePeer(u16 peer_id, bool timeout)
+bool Connection::deletePeer(SessionId peer_id, bool timeout)
 {
 	Peer *peer = 0;
 
@@ -1316,7 +1306,7 @@ bool Connection::Connected()
 	if (m_peers.size() != 1)
 		return false;
 
-	std::map<u16, Peer*>::iterator node = m_peers.find(PEER_ID_SERVER);
+	std::map<SessionId, Peer*>::iterator node = m_peers.find(PEER_ID_SERVER);
 	if (node == m_peers.end())
 		return false;
 
@@ -1371,7 +1361,7 @@ void Connection::Receive(NetworkPacket* pkt)
 	throw NoIncomingDataException("No incoming data");
 }
 
-void Connection::Send(u16 peer_id, u8 channelnum,
+void Connection::Send(SessionId peer_id, u8 channelnum,
 		NetworkPacket* pkt, bool reliable)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
@@ -1382,7 +1372,7 @@ void Connection::Send(u16 peer_id, u8 channelnum,
 	putCommand(c);
 }
 
-Address Connection::GetPeerAddress(u16 peer_id)
+Address Connection::GetPeerAddress(SessionId peer_id)
 {
 	PeerHelper peer = getPeerNoEx(peer_id);
 
@@ -1393,7 +1383,7 @@ Address Connection::GetPeerAddress(u16 peer_id)
 	return peer_address;
 }
 
-float Connection::getPeerStat(u16 peer_id, rtt_stat_type type)
+float Connection::getPeerStat(SessionId peer_id, rtt_stat_type type)
 {
 	PeerHelper peer = getPeerNoEx(peer_id);
 	if (!peer) return -1;
@@ -1440,7 +1430,7 @@ u16 Connection::createPeer(Address& sender, MTProtocols protocol, int fd)
 	// Somebody wants to make a new connection
 
 	// Get a unique peer id (2 or higher)
-	u16 peer_id_new = m_next_remote_peer_id;
+	SessionId peer_id_new = m_next_remote_peer_id;
 	u16 overflow =  MAX_UDP_PEERS;
 
 	/*
@@ -1508,14 +1498,14 @@ const std::string Connection::getDesc()
 			itos(m_udpSocket.GetHandle())+"/"+itos(m_peer_id)+")";
 }
 
-void Connection::DisconnectPeer(u16 peer_id)
+void Connection::DisconnectPeer(SessionId peer_id)
 {
 	ConnectionCommand discon;
 	discon.disconnect_peer(peer_id);
 	putCommand(discon);
 }
 
-void Connection::sendAck(u16 peer_id, u8 channelnum, u16 seqnum)
+void Connection::sendAck(SessionId peer_id, u8 channelnum, u16 seqnum)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/container.h"
 #include "util/thread.h"
 #include "util/numeric.h"
+#include "networkprotocol.h"
 #include <iostream>
 #include <fstream>
 #include <list>
@@ -103,7 +104,7 @@ struct BufferedPacket
 
 // This adds the base headers to the data and makes a packet out of it
 BufferedPacket makePacket(Address &address, SharedBuffer<u8> data,
-		u32 protocol_id, u16 sender_peer_id, u8 channel);
+		u32 protocol_id, SessionId sender_peer_id, u8 channel);
 
 // Depending on size, make a TYPE_ORIGINAL or TYPE_SPLIT packet
 // Increments split_seqnum if a split packet is made
@@ -139,7 +140,7 @@ A packet is sent through a channel to a peer with a basic header:
 TODO: Should we have a receiver_peer_id also?
 	Header (7 bytes):
 	[0] u32 protocol_id
-	[4] u16 sender_peer_id
+	[4] SessionId sender_peer_id
 	[6] u8 channel
 sender_peer_id:
 	Unique to each peer.
@@ -164,7 +165,7 @@ controltype and data description:
 	CONTROLTYPE_ACK
 		[2] u16 seqnum
 	CONTROLTYPE_SET_PEER_ID
-		[2] u16 peer_id_new
+		[2] SessionId peer_id_new
 	CONTROLTYPE_PING
 	- There is no actual reply, but this can be sent in a reliable
 	  packet to get a reply
@@ -289,13 +290,13 @@ private:
 
 struct OutgoingPacket
 {
-	u16 peer_id;
+	SessionId peer_id;
 	u8 channelnum;
 	SharedBuffer<u8> data;
 	bool reliable;
 	bool ack;
 
-	OutgoingPacket(u16 peer_id_, u8 channelnum_, const SharedBuffer<u8> &data_,
+	OutgoingPacket(SessionId peer_id_, u8 channelnum_, const SharedBuffer<u8> &data_,
 			bool reliable_,bool ack_=false):
 		peer_id(peer_id_),
 		channelnum(channelnum_),
@@ -323,7 +324,7 @@ struct ConnectionCommand
 {
 	enum ConnectionCommandType type = CONNCMD_NONE;
 	Address address;
-	u16 peer_id = PEER_ID_INEXISTENT;
+	SessionId peer_id = PEER_ID_INEXISTENT;
 	u8 channelnum = 0;
 	Buffer<u8> data;
 	bool reliable = false;
@@ -357,15 +358,15 @@ struct ConnectionCommand
 	{
 		type = CONNCMD_DISCONNECT;
 	}
-	void disconnect_peer(u16 peer_id_)
+	void disconnect_peer(SessionId peer_id_)
 	{
 		type = CONNCMD_DISCONNECT_PEER;
 		peer_id = peer_id_;
 	}
 
-	void send(u16 peer_id_, u8 channelnum_, NetworkPacket* pkt, bool reliable_);
+	void send(SessionId peer_id_, u8 channelnum_, NetworkPacket* pkt, bool reliable_);
 
-	void ack(u16 peer_id_, u8 channelnum_, const SharedBuffer<u8> &data_)
+	void ack(SessionId peer_id_, u8 channelnum_, const SharedBuffer<u8> &data_)
 	{
 		type = CONCMD_ACK;
 		peer_id = peer_id_;
@@ -374,7 +375,7 @@ struct ConnectionCommand
 		reliable = false;
 	}
 
-	void createPeer(u16 peer_id_, const SharedBuffer<u8> &data_)
+	void createPeer(SessionId peer_id_, const SharedBuffer<u8> &data_)
 	{
 		type = CONCMD_CREATE_PEER;
 		peer_id = peer_id_;
@@ -384,7 +385,7 @@ struct ConnectionCommand
 		raw = true;
 	}
 
-	void disableLegacy(u16 peer_id_, const SharedBuffer<u8> &data_)
+	void disableLegacy(SessionId peer_id_, const SharedBuffer<u8> &data_)
 	{
 		type = CONCMD_DISABLE_LEGACY;
 		peer_id = peer_id_;
@@ -716,7 +717,7 @@ enum ConnectionEventType{
 struct ConnectionEvent
 {
 	enum ConnectionEventType type = CONNEVENT_NONE;
-	u16 peer_id = 0;
+	SessionId peer_id = 0;
 	Buffer<u8> data;
 	bool timeout = false;
 	Address address;
@@ -740,19 +741,19 @@ struct ConnectionEvent
 		return "Invalid ConnectionEvent";
 	}
 
-	void dataReceived(u16 peer_id_, const SharedBuffer<u8> &data_)
+	void dataReceived(SessionId peer_id_, const SharedBuffer<u8> &data_)
 	{
 		type = CONNEVENT_DATA_RECEIVED;
 		peer_id = peer_id_;
 		data = data_;
 	}
-	void peerAdded(u16 peer_id_, Address address_)
+	void peerAdded(SessionId peer_id_, Address address_)
 	{
 		type = CONNEVENT_PEER_ADDED;
 		peer_id = peer_id_;
 		address = address_;
 	}
-	void peerRemoved(u16 peer_id_, bool timeout_, Address address_)
+	void peerRemoved(SessionId peer_id_, bool timeout_, Address address_)
 	{
 		type = CONNEVENT_PEER_REMOVED;
 		peer_id = peer_id_;
@@ -787,30 +788,30 @@ public:
 	bool Connected();
 	void Disconnect();
 	void Receive(NetworkPacket* pkt);
-	void Send(u16 peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
-	u16 GetPeerID() { return m_peer_id; }
-	Address GetPeerAddress(u16 peer_id);
-	float getPeerStat(u16 peer_id, rtt_stat_type type);
+	void Send(SessionId peer_id, u8 channelnum, NetworkPacket* pkt, bool reliable);
+	SessionId GetPeerID() { return m_peer_id; }
+	Address GetPeerAddress(SessionId peer_id);
+	float getPeerStat(SessionId peer_id, rtt_stat_type type);
 	float getLocalStat(rate_stat_type type);
 	const u32 GetProtocolID() const { return m_protocol_id; };
 	const std::string getDesc();
-	void DisconnectPeer(u16 peer_id);
+	void DisconnectPeer(SessionId peer_id);
 
 protected:
-	PeerHelper getPeerNoEx(u16 peer_id);
+	PeerHelper getPeerNoEx(SessionId peer_id);
 	u16   lookupPeer(Address& sender);
 
 	u16 createPeer(Address& sender, MTProtocols protocol, int fd);
 	UDPPeer*  createServerPeer(Address& sender);
-	bool deletePeer(u16 peer_id, bool timeout);
+	bool deletePeer(SessionId peer_id, bool timeout);
 
-	void SetPeerID(u16 id) { m_peer_id = id; }
+	void SetPeerID(SessionId id) { m_peer_id = id; }
 
-	void sendAck(u16 peer_id, u8 channelnum, u16 seqnum);
+	void sendAck(SessionId peer_id, u8 channelnum, u16 seqnum);
 
 	void PrintInfo(std::ostream &out);
 
-	std::list<u16> getPeerIDs()
+	std::list<SessionId> getPeerIDs()
 	{
 		MutexAutoLock peerlock(m_peers_mutex);
 		return m_peer_ids;
@@ -823,15 +824,13 @@ protected:
 
 	void TriggerSend();
 private:
-	std::list<Peer*> getPeers();
-
 	MutexedQueue<ConnectionEvent> m_event_queue;
 
-	u16 m_peer_id = 0;
+	SessionId m_peer_id = 0;
 	u32 m_protocol_id;
 
-	std::map<u16, Peer*> m_peers;
-	std::list<u16> m_peer_ids;
+	std::map<SessionId, Peer*> m_peers;
+	std::list<SessionId> m_peer_ids;
 	std::mutex m_peers_mutex;
 
 	std::unique_ptr<ConnectionSendThread> m_sendThread;
@@ -845,7 +844,7 @@ private:
 
 	bool m_shutting_down = false;
 
-	u16 m_next_remote_peer_id = 2;
+	SessionId m_next_remote_peer_id = 2;
 };
 
 } // namespace

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -53,7 +53,7 @@ std::mutex log_conthread_mutex;
 
 #define WINDOW_SIZE 5
 
-static SessionId readPeerId(u8 *packetdata)
+static session_t readPeerId(u8 *packetdata)
 {
 	return readU16(&packetdata[4]);
 }
@@ -138,12 +138,12 @@ void ConnectionSendThread::Trigger()
 
 bool ConnectionSendThread::packetsQueued()
 {
-	std::list<SessionId> peerIds = m_connection->getPeerIDs();
+	std::list<session_t> peerIds = m_connection->getPeerIDs();
 
 	if (!m_outgoing_queue.empty() && !peerIds.empty())
 		return true;
 
-	for (SessionId peerId : peerIds) {
+	for (session_t peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 
 		if (!peer)
@@ -165,10 +165,10 @@ bool ConnectionSendThread::packetsQueued()
 
 void ConnectionSendThread::runTimeouts(float dtime)
 {
-	std::list<SessionId> timeouted_peers;
-	std::list<SessionId> peerIds = m_connection->getPeerIDs();
+	std::list<session_t> timeouted_peers;
+	std::list<session_t> peerIds = m_connection->getPeerIDs();
 
-	for (SessionId &peerId : peerIds) {
+	for (session_t &peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 
 		if (!peer)
@@ -231,7 +231,7 @@ void ConnectionSendThread::runTimeouts(float dtime)
 
 			for (std::list<BufferedPacket>::iterator k = timed_outs.begin();
 				k != timed_outs.end(); ++k) {
-				SessionId peer_id = readPeerId(*(k->data));
+				session_t peer_id = readPeerId(*(k->data));
 				u8 channelnum = readChannel(*(k->data));
 				u16 seqnum = readU16(&(k->data[BASE_HEADER_SIZE + 1]));
 
@@ -329,7 +329,7 @@ void ConnectionSendThread::sendAsPacketReliable(BufferedPacket &p, Channel *chan
 	rawSend(p);
 }
 
-bool ConnectionSendThread::rawSendAsPacket(SessionId peer_id, u8 channelnum,
+bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
 	SharedBuffer<u8> data, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
@@ -557,14 +557,14 @@ void ConnectionSendThread::disconnect()
 
 
 	// Send to all
-	std::list<SessionId> peerids = m_connection->getPeerIDs();
+	std::list<session_t> peerids = m_connection->getPeerIDs();
 
-	for (SessionId peerid : peerids) {
+	for (session_t peerid : peerids) {
 		sendAsPacket(peerid, 0, data, false);
 	}
 }
 
-void ConnectionSendThread::disconnect_peer(SessionId peer_id)
+void ConnectionSendThread::disconnect_peer(session_t peer_id)
 {
 	LOG(dout_con << m_connection->getDesc() << " disconnecting peer" << std::endl);
 
@@ -586,7 +586,7 @@ void ConnectionSendThread::disconnect_peer(SessionId peer_id)
 	dynamic_cast<UDPPeer *>(&peer)->m_pending_disconnect = true;
 }
 
-void ConnectionSendThread::send(SessionId peer_id, u8 channelnum,
+void ConnectionSendThread::send(session_t peer_id, u8 channelnum,
 	SharedBuffer<u8> data)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
@@ -629,18 +629,18 @@ void ConnectionSendThread::sendReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendToAll(u8 channelnum, SharedBuffer<u8> data)
 {
-	std::list<SessionId> peerids = m_connection->getPeerIDs();
+	std::list<session_t> peerids = m_connection->getPeerIDs();
 
-	for (SessionId peerid : peerids) {
+	for (session_t peerid : peerids) {
 		send(peerid, channelnum, data);
 	}
 }
 
 void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 {
-	std::list<SessionId> peerids = m_connection->getPeerIDs();
+	std::list<session_t> peerids = m_connection->getPeerIDs();
 
-	for (SessionId peerid : peerids) {
+	for (session_t peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);
 
 		if (!peer)
@@ -652,11 +652,11 @@ void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendPackets(float dtime)
 {
-	std::list<SessionId> peerIds = m_connection->getPeerIDs();
-	std::list<SessionId> pendingDisconnect;
-	std::map<SessionId, bool> pending_unreliable;
+	std::list<session_t> peerIds = m_connection->getPeerIDs();
+	std::list<session_t> pendingDisconnect;
+	std::map<session_t, bool> pending_unreliable;
 
-	for (SessionId peerId : peerIds) {
+	for (session_t peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 		//peer may have been removed
 		if (!peer) {
@@ -780,14 +780,14 @@ void ConnectionSendThread::sendPackets(float dtime)
 		}
 	}
 
-	for (SessionId peerId : pendingDisconnect) {
+	for (session_t peerId : pendingDisconnect) {
 		if (!pending_unreliable[peerId]) {
 			m_connection->deletePeer(peerId, false);
 		}
 	}
 }
 
-void ConnectionSendThread::sendAsPacket(SessionId peer_id, u8 channelnum,
+void ConnectionSendThread::sendAsPacket(session_t peer_id, u8 channelnum,
 	SharedBuffer<u8> data, bool ack)
 {
 	OutgoingPacket packet(peer_id, channelnum, data, false, ack);
@@ -835,9 +835,9 @@ void *ConnectionReceiveThread::run()
 		if (debug_print_timer > 20.0) {
 			debug_print_timer -= 20.0;
 
-			std::list<SessionId> peerids = m_connection->getPeerIDs();
+			std::list<session_t> peerids = m_connection->getPeerIDs();
 
-			for (std::list<SessionId>::iterator i = peerids.begin();
+			for (std::list<session_t>::iterator i = peerids.begin();
 					i != peerids.end();
 					i++)
 			{
@@ -910,7 +910,7 @@ void ConnectionReceiveThread::receive()
 		try {
 			if (packet_queued) {
 				bool data_left = true;
-				SessionId peer_id;
+				session_t peer_id;
 				SharedBuffer<u8> resultdata;
 				while (data_left) {
 					try {
@@ -943,7 +943,7 @@ void ConnectionReceiveThread::receive()
 				continue;
 			}
 
-			SessionId peer_id = readPeerId(*packetdata);
+			session_t peer_id = readPeerId(*packetdata);
 			u8 channelnum = readChannel(*packetdata);
 
 			if (channelnum > CHANNEL_COUNT - 1) {
@@ -1044,11 +1044,11 @@ void ConnectionReceiveThread::receive()
 	}
 }
 
-bool ConnectionReceiveThread::getFromBuffers(SessionId &peer_id, SharedBuffer<u8> &dst)
+bool ConnectionReceiveThread::getFromBuffers(session_t &peer_id, SharedBuffer<u8> &dst)
 {
-	std::list<SessionId> peerids = m_connection->getPeerIDs();
+	std::list<session_t> peerids = m_connection->getPeerIDs();
 
-	for (SessionId peerid : peerids) {
+	for (session_t peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);
 		if (!peer)
 			continue;
@@ -1066,7 +1066,7 @@ bool ConnectionReceiveThread::getFromBuffers(SessionId &peer_id, SharedBuffer<u8
 }
 
 bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
-	SessionId &peer_id, SharedBuffer<u8> &dst)
+	session_t &peer_id, SharedBuffer<u8> &dst)
 {
 	u16 firstseqnum = 0;
 	if (channel->incoming_reliables.getFirstSeqnum(firstseqnum)) {
@@ -1098,7 +1098,7 @@ bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::processPacket(Channel *channel,
-	SharedBuffer<u8> packetdata, SessionId peer_id, u8 channelnum, bool reliable)
+	SharedBuffer<u8> packetdata, session_t peer_id, u8 channelnum, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 
@@ -1197,7 +1197,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 		if (packetdata.getSize() < 4)
 			throw InvalidIncomingDataException
 				("packetdata.getSize() < 4 (SET_PEER_ID header size)");
-		SessionId peer_id_new = readU16(&packetdata[2]);
+		session_t peer_id_new = readU16(&packetdata[2]);
 		LOG(dout_con << m_connection->getDesc() << "Got new peer id: " << peer_id_new
 			<< "... " << std::endl);
 

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -53,7 +53,7 @@ std::mutex log_conthread_mutex;
 
 #define WINDOW_SIZE 5
 
-static u16 readPeerId(u8 *packetdata)
+static SessionId readPeerId(u8 *packetdata)
 {
 	return readU16(&packetdata[4]);
 }
@@ -138,12 +138,12 @@ void ConnectionSendThread::Trigger()
 
 bool ConnectionSendThread::packetsQueued()
 {
-	std::list<u16> peerIds = m_connection->getPeerIDs();
+	std::list<SessionId> peerIds = m_connection->getPeerIDs();
 
 	if (!m_outgoing_queue.empty() && !peerIds.empty())
 		return true;
 
-	for (u16 peerId : peerIds) {
+	for (SessionId peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 
 		if (!peer)
@@ -165,10 +165,10 @@ bool ConnectionSendThread::packetsQueued()
 
 void ConnectionSendThread::runTimeouts(float dtime)
 {
-	std::list<u16> timeouted_peers;
-	std::list<u16> peerIds = m_connection->getPeerIDs();
+	std::list<SessionId> timeouted_peers;
+	std::list<SessionId> peerIds = m_connection->getPeerIDs();
 
-	for (u16 &peerId : peerIds) {
+	for (SessionId &peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 
 		if (!peer)
@@ -231,7 +231,7 @@ void ConnectionSendThread::runTimeouts(float dtime)
 
 			for (std::list<BufferedPacket>::iterator k = timed_outs.begin();
 				k != timed_outs.end(); ++k) {
-				u16 peer_id = readPeerId(*(k->data));
+				SessionId peer_id = readPeerId(*(k->data));
 				u8 channelnum = readChannel(*(k->data));
 				u16 seqnum = readU16(&(k->data[BASE_HEADER_SIZE + 1]));
 
@@ -329,7 +329,7 @@ void ConnectionSendThread::sendAsPacketReliable(BufferedPacket &p, Channel *chan
 	rawSend(p);
 }
 
-bool ConnectionSendThread::rawSendAsPacket(u16 peer_id, u8 channelnum,
+bool ConnectionSendThread::rawSendAsPacket(SessionId peer_id, u8 channelnum,
 	SharedBuffer<u8> data, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
@@ -557,14 +557,14 @@ void ConnectionSendThread::disconnect()
 
 
 	// Send to all
-	std::list<u16> peerids = m_connection->getPeerIDs();
+	std::list<SessionId> peerids = m_connection->getPeerIDs();
 
-	for (u16 peerid : peerids) {
+	for (SessionId peerid : peerids) {
 		sendAsPacket(peerid, 0, data, false);
 	}
 }
 
-void ConnectionSendThread::disconnect_peer(u16 peer_id)
+void ConnectionSendThread::disconnect_peer(SessionId peer_id)
 {
 	LOG(dout_con << m_connection->getDesc() << " disconnecting peer" << std::endl);
 
@@ -586,7 +586,7 @@ void ConnectionSendThread::disconnect_peer(u16 peer_id)
 	dynamic_cast<UDPPeer *>(&peer)->m_pending_disconnect = true;
 }
 
-void ConnectionSendThread::send(u16 peer_id, u8 channelnum,
+void ConnectionSendThread::send(SessionId peer_id, u8 channelnum,
 	SharedBuffer<u8> data)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
@@ -629,18 +629,18 @@ void ConnectionSendThread::sendReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendToAll(u8 channelnum, SharedBuffer<u8> data)
 {
-	std::list<u16> peerids = m_connection->getPeerIDs();
+	std::list<SessionId> peerids = m_connection->getPeerIDs();
 
-	for (u16 peerid : peerids) {
+	for (SessionId peerid : peerids) {
 		send(peerid, channelnum, data);
 	}
 }
 
 void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 {
-	std::list<u16> peerids = m_connection->getPeerIDs();
+	std::list<SessionId> peerids = m_connection->getPeerIDs();
 
-	for (u16 peerid : peerids) {
+	for (SessionId peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);
 
 		if (!peer)
@@ -652,11 +652,11 @@ void ConnectionSendThread::sendToAllReliable(ConnectionCommand &c)
 
 void ConnectionSendThread::sendPackets(float dtime)
 {
-	std::list<u16> peerIds = m_connection->getPeerIDs();
-	std::list<u16> pendingDisconnect;
-	std::map<u16, bool> pending_unreliable;
+	std::list<SessionId> peerIds = m_connection->getPeerIDs();
+	std::list<SessionId> pendingDisconnect;
+	std::map<SessionId, bool> pending_unreliable;
 
-	for (u16 peerId : peerIds) {
+	for (SessionId peerId : peerIds) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerId);
 		//peer may have been removed
 		if (!peer) {
@@ -780,14 +780,14 @@ void ConnectionSendThread::sendPackets(float dtime)
 		}
 	}
 
-	for (u16 peerId : pendingDisconnect) {
+	for (SessionId peerId : pendingDisconnect) {
 		if (!pending_unreliable[peerId]) {
 			m_connection->deletePeer(peerId, false);
 		}
 	}
 }
 
-void ConnectionSendThread::sendAsPacket(u16 peer_id, u8 channelnum,
+void ConnectionSendThread::sendAsPacket(SessionId peer_id, u8 channelnum,
 	SharedBuffer<u8> data, bool ack)
 {
 	OutgoingPacket packet(peer_id, channelnum, data, false, ack);
@@ -835,9 +835,9 @@ void *ConnectionReceiveThread::run()
 		if (debug_print_timer > 20.0) {
 			debug_print_timer -= 20.0;
 
-			std::list<u16> peerids = m_connection->getPeerIDs();
+			std::list<SessionId> peerids = m_connection->getPeerIDs();
 
-			for (std::list<u16>::iterator i = peerids.begin();
+			for (std::list<SessionId>::iterator i = peerids.begin();
 					i != peerids.end();
 					i++)
 			{
@@ -910,7 +910,7 @@ void ConnectionReceiveThread::receive()
 		try {
 			if (packet_queued) {
 				bool data_left = true;
-				u16 peer_id;
+				SessionId peer_id;
 				SharedBuffer<u8> resultdata;
 				while (data_left) {
 					try {
@@ -943,7 +943,7 @@ void ConnectionReceiveThread::receive()
 				continue;
 			}
 
-			u16 peer_id = readPeerId(*packetdata);
+			SessionId peer_id = readPeerId(*packetdata);
 			u8 channelnum = readChannel(*packetdata);
 
 			if (channelnum > CHANNEL_COUNT - 1) {
@@ -1044,11 +1044,11 @@ void ConnectionReceiveThread::receive()
 	}
 }
 
-bool ConnectionReceiveThread::getFromBuffers(u16 &peer_id, SharedBuffer<u8> &dst)
+bool ConnectionReceiveThread::getFromBuffers(SessionId &peer_id, SharedBuffer<u8> &dst)
 {
-	std::list<u16> peerids = m_connection->getPeerIDs();
+	std::list<SessionId> peerids = m_connection->getPeerIDs();
 
-	for (u16 peerid : peerids) {
+	for (SessionId peerid : peerids) {
 		PeerHelper peer = m_connection->getPeerNoEx(peerid);
 		if (!peer)
 			continue;
@@ -1066,7 +1066,7 @@ bool ConnectionReceiveThread::getFromBuffers(u16 &peer_id, SharedBuffer<u8> &dst
 }
 
 bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
-	u16 &peer_id, SharedBuffer<u8> &dst)
+	SessionId &peer_id, SharedBuffer<u8> &dst)
 {
 	u16 firstseqnum = 0;
 	if (channel->incoming_reliables.getFirstSeqnum(firstseqnum)) {
@@ -1098,7 +1098,7 @@ bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::processPacket(Channel *channel,
-	SharedBuffer<u8> packetdata, u16 peer_id, u8 channelnum, bool reliable)
+	SharedBuffer<u8> packetdata, SessionId peer_id, u8 channelnum, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 
@@ -1197,7 +1197,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 		if (packetdata.getSize() < 4)
 			throw InvalidIncomingDataException
 				("packetdata.getSize() < 4 (SET_PEER_ID header size)");
-		u16 peer_id_new = readU16(&packetdata[2]);
+		SessionId peer_id_new = readU16(&packetdata[2]);
 		LOG(dout_con << m_connection->getDesc() << "Got new peer id: " << peer_id_new
 			<< "... " << std::endl);
 

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -53,22 +53,22 @@ private:
 	void runTimeouts(float dtime);
 	void rawSend(const BufferedPacket &packet);
 	bool rawSendAsPacket(
-			u16 peer_id, u8 channelnum, SharedBuffer<u8> data, bool reliable);
+		SessionId peer_id, u8 channelnum, SharedBuffer<u8> data, bool reliable);
 
 	void processReliableCommand(ConnectionCommand &c);
 	void processNonReliableCommand(ConnectionCommand &c);
 	void serve(Address bind_address);
 	void connect(Address address);
 	void disconnect();
-	void disconnect_peer(u16 peer_id);
-	void send(u16 peer_id, u8 channelnum, SharedBuffer<u8> data);
+	void disconnect_peer(SessionId peer_id);
+	void send(SessionId peer_id, u8 channelnum, SharedBuffer<u8> data);
 	void sendReliable(ConnectionCommand &c);
 	void sendToAll(u8 channelnum, SharedBuffer<u8> data);
 	void sendToAllReliable(ConnectionCommand &c);
 
 	void sendPackets(float dtime);
 
-	void sendAsPacket(u16 peer_id, u8 channelnum, SharedBuffer<u8> data,
+	void sendAsPacket(SessionId peer_id, u8 channelnum, SharedBuffer<u8> data,
 			bool ack = false);
 
 	void sendAsPacketReliable(BufferedPacket &p, Channel *channel);
@@ -106,9 +106,9 @@ private:
 	// Returns next data from a buffer if possible
 	// If found, returns true; if not, false.
 	// If found, sets peer_id and dst
-	bool getFromBuffers(u16 &peer_id, SharedBuffer<u8> &dst);
+	bool getFromBuffers(SessionId &peer_id, SharedBuffer<u8> &dst);
 
-	bool checkIncomingBuffers(Channel *channel, u16 &peer_id, SharedBuffer<u8> &dst);
+	bool checkIncomingBuffers(Channel *channel, SessionId &peer_id, SharedBuffer<u8> &dst);
 
 	/*
 		Processes a packet with the basic header stripped out.
@@ -119,7 +119,7 @@ private:
 			reliable: true if recursing into a reliable packet
 	*/
 	SharedBuffer<u8> processPacket(Channel *channel, SharedBuffer<u8> packetdata,
-			u16 peer_id, u8 channelnum, bool reliable);
+		SessionId peer_id, u8 channelnum, bool reliable);
 
 	SharedBuffer<u8> handlePacketType_Control(Channel *channel,
 			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -53,22 +53,22 @@ private:
 	void runTimeouts(float dtime);
 	void rawSend(const BufferedPacket &packet);
 	bool rawSendAsPacket(
-		SessionId peer_id, u8 channelnum, SharedBuffer<u8> data, bool reliable);
+		session_t peer_id, u8 channelnum, SharedBuffer<u8> data, bool reliable);
 
 	void processReliableCommand(ConnectionCommand &c);
 	void processNonReliableCommand(ConnectionCommand &c);
 	void serve(Address bind_address);
 	void connect(Address address);
 	void disconnect();
-	void disconnect_peer(SessionId peer_id);
-	void send(SessionId peer_id, u8 channelnum, SharedBuffer<u8> data);
+	void disconnect_peer(session_t peer_id);
+	void send(session_t peer_id, u8 channelnum, SharedBuffer<u8> data);
 	void sendReliable(ConnectionCommand &c);
 	void sendToAll(u8 channelnum, SharedBuffer<u8> data);
 	void sendToAllReliable(ConnectionCommand &c);
 
 	void sendPackets(float dtime);
 
-	void sendAsPacket(SessionId peer_id, u8 channelnum, SharedBuffer<u8> data,
+	void sendAsPacket(session_t peer_id, u8 channelnum, SharedBuffer<u8> data,
 			bool ack = false);
 
 	void sendAsPacketReliable(BufferedPacket &p, Channel *channel);
@@ -106,9 +106,9 @@ private:
 	// Returns next data from a buffer if possible
 	// If found, returns true; if not, false.
 	// If found, sets peer_id and dst
-	bool getFromBuffers(SessionId &peer_id, SharedBuffer<u8> &dst);
+	bool getFromBuffers(session_t &peer_id, SharedBuffer<u8> &dst);
 
-	bool checkIncomingBuffers(Channel *channel, SessionId &peer_id, SharedBuffer<u8> &dst);
+	bool checkIncomingBuffers(Channel *channel, session_t &peer_id, SharedBuffer<u8> &dst);
 
 	/*
 		Processes a packet with the basic header stripped out.
@@ -119,7 +119,7 @@ private:
 			reliable: true if recursing into a reliable packet
 	*/
 	SharedBuffer<u8> processPacket(Channel *channel, SharedBuffer<u8> packetdata,
-		SessionId peer_id, u8 channelnum, bool reliable);
+		session_t peer_id, u8 channelnum, bool reliable);
 
 	SharedBuffer<u8> handlePacketType_Control(Channel *channel,
 			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -21,8 +21,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include "networkexceptions.h"
 #include "util/serialize.h"
+#include "networkprotocol.h"
 
-NetworkPacket::NetworkPacket(u16 command, u32 datasize, u16 peer_id):
+NetworkPacket::NetworkPacket(u16 command, u32 datasize, SessionId peer_id):
 m_datasize(datasize), m_command(command), m_peer_id(peer_id)
 {
 	m_data.resize(m_datasize);
@@ -49,7 +50,7 @@ void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size)
 	}
 }
 
-void NetworkPacket::putRawPacket(u8 *data, u32 datasize, u16 peer_id)
+void NetworkPacket::putRawPacket(u8 *data, u32 datasize, SessionId peer_id)
 {
 	// If a m_command is already set, we are rewriting on same packet
 	// This is not permitted

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "networkprotocol.h"
 
-NetworkPacket::NetworkPacket(u16 command, u32 datasize, SessionId peer_id):
+NetworkPacket::NetworkPacket(u16 command, u32 datasize, session_t peer_id):
 m_datasize(datasize), m_command(command), m_peer_id(peer_id)
 {
 	m_data.resize(m_datasize);
@@ -50,7 +50,7 @@ void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size)
 	}
 }
 
-void NetworkPacket::putRawPacket(u8 *data, u32 datasize, SessionId peer_id)
+void NetworkPacket::putRawPacket(u8 *data, u32 datasize, session_t peer_id)
 {
 	// If a m_command is already set, we are rewriting on same packet
 	// This is not permitted

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -29,17 +29,17 @@ class NetworkPacket
 {
 
 public:
-	NetworkPacket(u16 command, u32 datasize, SessionId peer_id);
+	NetworkPacket(u16 command, u32 datasize, session_t peer_id);
 	NetworkPacket(u16 command, u32 datasize);
 	NetworkPacket() = default;
 
 	~NetworkPacket();
 
-	void putRawPacket(u8 *data, u32 datasize, SessionId peer_id);
+	void putRawPacket(u8 *data, u32 datasize, session_t peer_id);
 
 	// Getters
-	u32 getSize() { return m_datasize; }
-	SessionId getPeerId() { return m_peer_id; }
+	u32 getSize() const { return m_datasize; }
+	session_t getPeerId() const { return m_peer_id; }
 	u16 getCommand() { return m_command; }
 	const u32 getRemainingBytes() const { return m_datasize - m_read_offset; }
 	const char *getRemainingString() { return getString(m_read_offset); }
@@ -136,5 +136,5 @@ private:
 	u32 m_datasize = 0;
 	u32 m_read_offset = 0;
 	u16 m_command = 0;
-	SessionId m_peer_id = 0;
+	session_t m_peer_id = 0;
 };

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -22,23 +22,24 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <ctime>
 #include "util/pointer.h"
 #include "util/numeric.h"
+#include "networkprotocol.h"
 #include <SColor.h>
 
 class NetworkPacket
 {
 
 public:
-	NetworkPacket(u16 command, u32 datasize, u16 peer_id);
+	NetworkPacket(u16 command, u32 datasize, SessionId peer_id);
 	NetworkPacket(u16 command, u32 datasize);
 	NetworkPacket() = default;
 
 	~NetworkPacket();
 
-	void putRawPacket(u8 *data, u32 datasize, u16 peer_id);
+	void putRawPacket(u8 *data, u32 datasize, SessionId peer_id);
 
 	// Getters
 	u32 getSize() { return m_datasize; }
-	u16 getPeerId() { return m_peer_id; }
+	SessionId getPeerId() { return m_peer_id; }
 	u16 getCommand() { return m_command; }
 	const u32 getRemainingBytes() const { return m_datasize - m_read_offset; }
 	const char *getRemainingString() { return getString(m_read_offset); }
@@ -135,5 +136,5 @@ private:
 	u32 m_datasize = 0;
 	u32 m_read_offset = 0;
 	u16 m_command = 0;
-	u16 m_peer_id = 0;
+	SessionId m_peer_id = 0;
 };

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -206,6 +206,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 
+typedef u16 SessionId;
+
 enum ToClientCommand
 {
 	TOCLIENT_HELLO = 0x02,

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -206,7 +206,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 
-typedef u16 SessionId;
+typedef u16 session_t;
 
 enum ToClientCommand
 {

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -19,6 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "networkprotocol.h"
+
 namespace con
 {
 
@@ -53,21 +55,22 @@ public:
 	virtual void deletingPeer(Peer *peer, bool timeout) = 0;
 };
 
-enum PeerChangeType
+enum PeerChangeType: u8
 {
 	PEER_ADDED,
 	PEER_REMOVED
 };
+
 struct PeerChange
 {
-	PeerChange(PeerChangeType t, u16 _peer_id, bool _timeout)
+	PeerChange(PeerChangeType t, SessionId _peer_id, bool _timeout)
 	    : type(t), peer_id(_peer_id), timeout(_timeout)
 	{
 	}
 	PeerChange() = delete;
 
 	PeerChangeType type;
-	u16 peer_id;
+	SessionId peer_id;
 	bool timeout;
 };
 }

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -55,7 +55,7 @@ public:
 	virtual void deletingPeer(Peer *peer, bool timeout) = 0;
 };
 
-enum PeerChangeType: u8
+enum PeerChangeType : u8
 {
 	PEER_ADDED,
 	PEER_REMOVED
@@ -63,14 +63,14 @@ enum PeerChangeType: u8
 
 struct PeerChange
 {
-	PeerChange(PeerChangeType t, SessionId _peer_id, bool _timeout)
+	PeerChange(PeerChangeType t, session_t _peer_id, bool _timeout)
 	    : type(t), peer_id(_peer_id), timeout(_timeout)
 	{
 	}
 	PeerChange() = delete;
 
 	PeerChangeType type;
-	SessionId peer_id;
+	session_t peer_id;
 	bool timeout;
 };
 }

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -356,7 +356,7 @@ void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
 
 void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 {
-	u16 peer_id = pkt->getPeerId();
+	SessionId peer_id = pkt->getPeerId();
 
 	PlayerSAO* playersao = StageTwoClientInit(peer_id);
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -356,7 +356,7 @@ void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
 
 void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 {
-	SessionId peer_id = pkt->getPeerId();
+	session_t peer_id = pkt->getPeerId();
 
 	PlayerSAO* playersao = StageTwoClientInit(peer_id);
 

--- a/src/player.h
+++ b/src/player.h
@@ -147,7 +147,7 @@ public:
 	v2s32 local_animations[4];
 	float local_animation_speed;
 
-	SessionId peer_id = PEER_ID_INEXISTENT;
+	session_t peer_id = PEER_ID_INEXISTENT;
 
 	std::string inventory_formspec;
 

--- a/src/player.h
+++ b/src/player.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
 #include "constants.h"
+#include "network/networkprotocol.h"
 #include "util/basic_macros.h"
 #include <list>
 #include <mutex>
@@ -146,7 +147,7 @@ public:
 	v2s32 local_animations[4];
 	float local_animation_speed;
 
-	u16 peer_id = PEER_ID_INEXISTENT;
+	SessionId peer_id = PEER_ID_INEXISTENT;
 
 	std::string inventory_formspec;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1461,7 +1461,7 @@ void Server::SendAccessDenied_Legacy(session_t peer_id,const std::wstring &reaso
 	Send(&pkt);
 }
 
-void Server::SendDeathscreen(session_t peer_id,bool set_camera_point_target,
+void Server::SendDeathscreen(session_t peer_id, bool set_camera_point_target,
 		v3f camera_point_target)
 {
 	NetworkPacket pkt(TOCLIENT_DEATHSCREEN, 1 + sizeof(v3f), peer_id);
@@ -2844,7 +2844,7 @@ void Server::handleAdminChat(const ChatEventChat *evt)
 	}
 }
 
-RemoteClient* Server::getClient(session_t peer_id, ClientState state_min)
+RemoteClient *Server::getClient(session_t peer_id, ClientState state_min)
 {
 	RemoteClient *client = getClientNoEx(peer_id,state_min);
 	if(!client)
@@ -2852,7 +2852,7 @@ RemoteClient* Server::getClient(session_t peer_id, ClientState state_min)
 
 	return client;
 }
-RemoteClient* Server::getClientNoEx(session_t peer_id, ClientState state_min)
+RemoteClient *Server::getClientNoEx(session_t peer_id, ClientState state_min)
 {
 	return m_clients.getClientNoEx(peer_id, state_min);
 }
@@ -2865,7 +2865,7 @@ std::string Server::getPlayerName(session_t peer_id)
 	return player->getName();
 }
 
-PlayerSAO* Server::getPlayerSAO(session_t peer_id)
+PlayerSAO *Server::getPlayerSAO(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (!player)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -974,7 +974,7 @@ void Server::AsyncRunStep(bool initial_step)
 
 void Server::Receive()
 {
-	SessionId peer_id;
+	session_t peer_id;
 	try {
 		NetworkPacket pkt;
 		m_con->Receive(&pkt);
@@ -995,7 +995,7 @@ void Server::Receive()
 	}
 }
 
-PlayerSAO* Server::StageTwoClientInit(SessionId peer_id)
+PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 {
 	std::string playername;
 	PlayerSAO *playersao = NULL;
@@ -1297,14 +1297,14 @@ void Server::deletingPeer(con::Peer *peer, bool timeout)
 	m_peer_change_queue.push(con::PeerChange(con::PEER_REMOVED, peer->id, timeout));
 }
 
-bool Server::getClientConInfo(SessionId peer_id, con::rtt_stat_type type, float* retval)
+bool Server::getClientConInfo(session_t peer_id, con::rtt_stat_type type, float* retval)
 {
 	*retval = m_con->getPeerStat(peer_id,type);
 	return *retval != -1;
 }
 
 bool Server::getClientInfo(
-		SessionId    peer_id,
+		session_t    peer_id,
 		ClientState* state,
 		u32*         uptime,
 		u8*          ser_vers,
@@ -1381,7 +1381,7 @@ void Server::Send(NetworkPacket *pkt)
 	Send(pkt->getPeerId(), pkt);
 }
 
-void Server::Send(SessionId peer_id, NetworkPacket *pkt)
+void Server::Send(session_t peer_id, NetworkPacket *pkt)
 {
 	m_clients.send(peer_id,
 		clientCommandFactoryTable[pkt->getCommand()].channel,
@@ -1389,7 +1389,7 @@ void Server::Send(SessionId peer_id, NetworkPacket *pkt)
 		clientCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
-void Server::SendMovement(SessionId peer_id)
+void Server::SendMovement(session_t peer_id)
 {
 	std::ostringstream os(std::ios_base::binary);
 
@@ -1416,7 +1416,7 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 	if (!g_settings->getBool("enable_damage"))
 		return;
 
-	SessionId peer_id   = playersao->getPeerID();
+	session_t peer_id   = playersao->getPeerID();
 	bool is_alive = playersao->getHP() > 0;
 
 	if (is_alive)
@@ -1425,21 +1425,21 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 		DiePlayer(peer_id);
 }
 
-void Server::SendHP(SessionId peer_id, u16 hp)
+void Server::SendHP(session_t peer_id, u16 hp)
 {
 	NetworkPacket pkt(TOCLIENT_HP, 1, peer_id);
 	pkt << hp;
 	Send(&pkt);
 }
 
-void Server::SendBreath(SessionId peer_id, u16 breath)
+void Server::SendBreath(session_t peer_id, u16 breath)
 {
 	NetworkPacket pkt(TOCLIENT_BREATH, 2, peer_id);
 	pkt << (u16) breath;
 	Send(&pkt);
 }
 
-void Server::SendAccessDenied(SessionId peer_id, AccessDeniedCode reason,
+void Server::SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect)
 {
 	assert(reason < SERVER_ACCESSDENIED_MAX);
@@ -1454,14 +1454,14 @@ void Server::SendAccessDenied(SessionId peer_id, AccessDeniedCode reason,
 	Send(&pkt);
 }
 
-void Server::SendAccessDenied_Legacy(SessionId peer_id,const std::wstring &reason)
+void Server::SendAccessDenied_Legacy(session_t peer_id,const std::wstring &reason)
 {
 	NetworkPacket pkt(TOCLIENT_ACCESS_DENIED_LEGACY, 0, peer_id);
 	pkt << reason;
 	Send(&pkt);
 }
 
-void Server::SendDeathscreen(SessionId peer_id,bool set_camera_point_target,
+void Server::SendDeathscreen(session_t peer_id,bool set_camera_point_target,
 		v3f camera_point_target)
 {
 	NetworkPacket pkt(TOCLIENT_DEATHSCREEN, 1 + sizeof(v3f), peer_id);
@@ -1469,7 +1469,7 @@ void Server::SendDeathscreen(SessionId peer_id,bool set_camera_point_target,
 	Send(&pkt);
 }
 
-void Server::SendItemDef(SessionId peer_id,
+void Server::SendItemDef(session_t peer_id,
 		IItemDefManager *itemdef, u16 protocol_version)
 {
 	NetworkPacket pkt(TOCLIENT_ITEMDEF, 0, peer_id);
@@ -1492,7 +1492,7 @@ void Server::SendItemDef(SessionId peer_id,
 	Send(&pkt);
 }
 
-void Server::SendNodeDef(SessionId peer_id,
+void Server::SendNodeDef(session_t peer_id,
 		INodeDefManager *nodedef, u16 protocol_version)
 {
 	NetworkPacket pkt(TOCLIENT_NODEDEF, 0, peer_id);
@@ -1539,7 +1539,7 @@ void Server::SendInventory(PlayerSAO* playerSAO)
 	Send(&pkt);
 }
 
-void Server::SendChatMessage(SessionId peer_id, const ChatMessage &message)
+void Server::SendChatMessage(session_t peer_id, const ChatMessage &message)
 {
 	NetworkPacket pkt(TOCLIENT_CHAT_MESSAGE, 0, peer_id);
 	u8 version = 1;
@@ -1557,7 +1557,7 @@ void Server::SendChatMessage(SessionId peer_id, const ChatMessage &message)
 	}
 }
 
-void Server::SendShowFormspecMessage(SessionId peer_id, const std::string &formspec,
+void Server::SendShowFormspecMessage(session_t peer_id, const std::string &formspec,
                                      const std::string &formname)
 {
 	NetworkPacket pkt(TOCLIENT_SHOW_FORMSPEC, 0 , peer_id);
@@ -1573,7 +1573,7 @@ void Server::SendShowFormspecMessage(SessionId peer_id, const std::string &forms
 }
 
 // Spawns a particle on peer with peer_id
-void Server::SendSpawnParticle(SessionId peer_id, u16 protocol_version,
+void Server::SendSpawnParticle(session_t peer_id, u16 protocol_version,
 				v3f pos, v3f velocity, v3f acceleration,
 				float expirationtime, float size, bool collisiondetection,
 				bool collision_removal,
@@ -1624,7 +1624,7 @@ void Server::SendSpawnParticle(SessionId peer_id, u16 protocol_version,
 }
 
 // Adds a ParticleSpawner on peer with peer_id
-void Server::SendAddParticleSpawner(SessionId peer_id, u16 protocol_version,
+void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 	u16 amount, float spawntime, v3f minpos, v3f maxpos,
 	v3f minvel, v3f maxvel, v3f minacc, v3f maxacc, float minexptime, float maxexptime,
 	float minsize, float maxsize, bool collisiondetection, bool collision_removal,
@@ -1667,7 +1667,7 @@ void Server::SendAddParticleSpawner(SessionId peer_id, u16 protocol_version,
 	Send(&pkt);
 }
 
-void Server::SendDeleteParticleSpawner(SessionId peer_id, u32 id)
+void Server::SendDeleteParticleSpawner(session_t peer_id, u32 id)
 {
 	NetworkPacket pkt(TOCLIENT_DELETE_PARTICLESPAWNER, 4, peer_id);
 
@@ -1681,7 +1681,7 @@ void Server::SendDeleteParticleSpawner(SessionId peer_id, u32 id)
 
 }
 
-void Server::SendHUDAdd(SessionId peer_id, u32 id, HudElement *form)
+void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 {
 	NetworkPacket pkt(TOCLIENT_HUDADD, 0 , peer_id);
 
@@ -1692,14 +1692,14 @@ void Server::SendHUDAdd(SessionId peer_id, u32 id, HudElement *form)
 	Send(&pkt);
 }
 
-void Server::SendHUDRemove(SessionId peer_id, u32 id)
+void Server::SendHUDRemove(session_t peer_id, u32 id)
 {
 	NetworkPacket pkt(TOCLIENT_HUDRM, 4, peer_id);
 	pkt << id;
 	Send(&pkt);
 }
 
-void Server::SendHUDChange(SessionId peer_id, u32 id, HudElementStat stat, void *value)
+void Server::SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void *value)
 {
 	NetworkPacket pkt(TOCLIENT_HUDCHANGE, 0, peer_id);
 	pkt << id << (u8) stat;
@@ -1732,7 +1732,7 @@ void Server::SendHUDChange(SessionId peer_id, u32 id, HudElementStat stat, void 
 	Send(&pkt);
 }
 
-void Server::SendHUDSetFlags(SessionId peer_id, u32 flags, u32 mask)
+void Server::SendHUDSetFlags(session_t peer_id, u32 flags, u32 mask)
 {
 	NetworkPacket pkt(TOCLIENT_HUD_SET_FLAGS, 4 + 4, peer_id);
 
@@ -1743,14 +1743,14 @@ void Server::SendHUDSetFlags(SessionId peer_id, u32 flags, u32 mask)
 	Send(&pkt);
 }
 
-void Server::SendHUDSetParam(SessionId peer_id, u16 param, const std::string &value)
+void Server::SendHUDSetParam(session_t peer_id, u16 param, const std::string &value)
 {
 	NetworkPacket pkt(TOCLIENT_HUD_SET_PARAM, 0, peer_id);
 	pkt << param << value;
 	Send(&pkt);
 }
 
-void Server::SendSetSky(SessionId peer_id, const video::SColor &bgcolor,
+void Server::SendSetSky(session_t peer_id, const video::SColor &bgcolor,
 		const std::string &type, const std::vector<std::string> &params,
 		bool &clouds)
 {
@@ -1765,7 +1765,7 @@ void Server::SendSetSky(SessionId peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendCloudParams(SessionId peer_id, float density,
+void Server::SendCloudParams(session_t peer_id, float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		float height,
@@ -1779,7 +1779,7 @@ void Server::SendCloudParams(SessionId peer_id, float density,
 	Send(&pkt);
 }
 
-void Server::SendOverrideDayNightRatio(SessionId peer_id, bool do_override,
+void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 		float ratio)
 {
 	NetworkPacket pkt(TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO,
@@ -1790,7 +1790,7 @@ void Server::SendOverrideDayNightRatio(SessionId peer_id, bool do_override,
 	Send(&pkt);
 }
 
-void Server::SendTimeOfDay(SessionId peer_id, u16 time, f32 time_speed)
+void Server::SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed)
 {
 	NetworkPacket pkt(TOCLIENT_TIME_OF_DAY, 0, peer_id);
 	pkt << time << time_speed;
@@ -1803,7 +1803,7 @@ void Server::SendTimeOfDay(SessionId peer_id, u16 time, f32 time_speed)
 	}
 }
 
-void Server::SendPlayerHP(SessionId peer_id)
+void Server::SendPlayerHP(session_t peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	// In some rare case if the player is disconnected
@@ -1828,7 +1828,7 @@ void Server::SendPlayerBreath(PlayerSAO *sao)
 	SendBreath(sao->getPeerID(), sao->getBreath());
 }
 
-void Server::SendMovePlayer(SessionId peer_id)
+void Server::SendMovePlayer(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1850,7 +1850,7 @@ void Server::SendMovePlayer(SessionId peer_id)
 	Send(&pkt);
 }
 
-void Server::SendLocalPlayerAnimations(SessionId peer_id, v2s32 animation_frames[4],
+void Server::SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed)
 {
 	NetworkPacket pkt(TOCLIENT_LOCAL_PLAYER_ANIMATIONS, 0,
@@ -1862,14 +1862,14 @@ void Server::SendLocalPlayerAnimations(SessionId peer_id, v2s32 animation_frames
 	Send(&pkt);
 }
 
-void Server::SendEyeOffset(SessionId peer_id, v3f first, v3f third)
+void Server::SendEyeOffset(session_t peer_id, v3f first, v3f third)
 {
 	NetworkPacket pkt(TOCLIENT_EYE_OFFSET, 0, peer_id);
 	pkt << first << third;
 	Send(&pkt);
 }
 
-void Server::SendPlayerPrivileges(SessionId peer_id)
+void Server::SendPlayerPrivileges(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1889,7 +1889,7 @@ void Server::SendPlayerPrivileges(SessionId peer_id)
 	Send(&pkt);
 }
 
-void Server::SendPlayerInventoryFormspec(SessionId peer_id)
+void Server::SendPlayerInventoryFormspec(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1901,7 +1901,7 @@ void Server::SendPlayerInventoryFormspec(SessionId peer_id)
 	Send(&pkt);
 }
 
-u32 Server::SendActiveObjectRemoveAdd(SessionId peer_id, const std::string &datas)
+u32 Server::SendActiveObjectRemoveAdd(session_t peer_id, const std::string &datas)
 {
 	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD, datas.size(), peer_id);
 	pkt.putRawString(datas.c_str(), datas.size());
@@ -1909,7 +1909,7 @@ u32 Server::SendActiveObjectRemoveAdd(SessionId peer_id, const std::string &data
 	return pkt.getSize();
 }
 
-void Server::SendActiveObjectMessages(SessionId peer_id, const std::string &datas,
+void Server::SendActiveObjectMessages(session_t peer_id, const std::string &datas,
 		bool reliable)
 {
 	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_MESSAGES,
@@ -1922,7 +1922,7 @@ void Server::SendActiveObjectMessages(SessionId peer_id, const std::string &data
 			&pkt, reliable);
 }
 
-void Server::SendCSMFlavourLimits(SessionId peer_id)
+void Server::SendCSMFlavourLimits(session_t peer_id)
 {
 	NetworkPacket pkt(TOCLIENT_CSM_FLAVOUR_LIMITS,
 		sizeof(m_csm_flavour_limits) + sizeof(m_csm_noderange_limit), peer_id);
@@ -2154,7 +2154,7 @@ void Server::setBlockNotSent(v3s16 p)
 	m_clients.unlock();
 }
 
-void Server::SendBlockNoLock(SessionId peer_id, MapBlock *block, u8 ver,
+void Server::SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver,
 		u16 net_proto_version)
 {
 	v3s16 p = block->getPos();
@@ -2336,7 +2336,7 @@ void Server::fillMediaCache()
 	}
 }
 
-void Server::sendMediaAnnouncement(SessionId peer_id, const std::string &lang_code)
+void Server::sendMediaAnnouncement(session_t peer_id, const std::string &lang_code)
 {
 	verbosestream << "Server: Announcing files to id(" << peer_id << ")"
 		<< std::endl;
@@ -2379,7 +2379,7 @@ struct SendableMedia
 	{}
 };
 
-void Server::sendRequestedMedia(SessionId peer_id,
+void Server::sendRequestedMedia(session_t peer_id,
 		const std::vector<std::string> &tosend)
 {
 	verbosestream<<"Server::sendRequestedMedia(): "
@@ -2478,7 +2478,7 @@ void Server::sendRequestedMedia(SessionId peer_id,
 	}
 }
 
-void Server::sendDetachedInventory(const std::string &name, SessionId peer_id)
+void Server::sendDetachedInventory(const std::string &name, session_t peer_id)
 {
 	if(m_detached_inventories.count(name) == 0) {
 		errorstream<<FUNCTION_NAME<<": \""<<name<<"\" not found"<<std::endl;
@@ -2509,7 +2509,7 @@ void Server::sendDetachedInventory(const std::string &name, SessionId peer_id)
 	}
 }
 
-void Server::sendDetachedInventories(SessionId peer_id)
+void Server::sendDetachedInventories(session_t peer_id)
 {
 	for (const auto &detached_inventory : m_detached_inventories) {
 		const std::string &name = detached_inventory.first;
@@ -2522,7 +2522,7 @@ void Server::sendDetachedInventories(SessionId peer_id)
 	Something random
 */
 
-void Server::DiePlayer(SessionId peer_id)
+void Server::DiePlayer(session_t peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	// In some rare cases this can be NULL -- if the player is disconnected
@@ -2543,7 +2543,7 @@ void Server::DiePlayer(SessionId peer_id)
 	SendDeathscreen(peer_id, false, v3f(0,0,0));
 }
 
-void Server::RespawnPlayer(SessionId peer_id)
+void Server::RespawnPlayer(session_t peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
@@ -2565,14 +2565,14 @@ void Server::RespawnPlayer(SessionId peer_id)
 }
 
 
-void Server::DenySudoAccess(SessionId peer_id)
+void Server::DenySudoAccess(session_t peer_id)
 {
 	NetworkPacket pkt(TOCLIENT_DENY_SUDO_MODE, 0, peer_id);
 	Send(&pkt);
 }
 
 
-void Server::DenyAccessVerCompliant(SessionId peer_id, u16 proto_ver, AccessDeniedCode reason,
+void Server::DenyAccessVerCompliant(session_t peer_id, u16 proto_ver, AccessDeniedCode reason,
 		const std::string &str_reason, bool reconnect)
 {
 	SendAccessDenied(peer_id, reason, str_reason, reconnect);
@@ -2582,7 +2582,7 @@ void Server::DenyAccessVerCompliant(SessionId peer_id, u16 proto_ver, AccessDeni
 }
 
 
-void Server::DenyAccess(SessionId peer_id, AccessDeniedCode reason,
+void Server::DenyAccess(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason)
 {
 	SendAccessDenied(peer_id, reason, custom_reason);
@@ -2592,20 +2592,20 @@ void Server::DenyAccess(SessionId peer_id, AccessDeniedCode reason,
 
 // 13/03/15: remove this function when protocol version 25 will become
 // the minimum version for MT users, maybe in 1 year
-void Server::DenyAccess_Legacy(SessionId peer_id, const std::wstring &reason)
+void Server::DenyAccess_Legacy(session_t peer_id, const std::wstring &reason)
 {
 	SendAccessDenied_Legacy(peer_id, reason);
 	m_clients.event(peer_id, CSE_SetDenied);
 	DisconnectPeer(peer_id);
 }
 
-void Server::DisconnectPeer(SessionId peer_id)
+void Server::DisconnectPeer(session_t peer_id)
 {
 	m_modchannel_mgr->leaveAllChannels(peer_id);
 	m_con->DisconnectPeer(peer_id);
 }
 
-void Server::acceptAuth(SessionId peer_id, bool forSudoMode)
+void Server::acceptAuth(session_t peer_id, bool forSudoMode)
 {
 	if (!forSudoMode) {
 		RemoteClient* client = getClient(peer_id, CS_Invalid);
@@ -2634,7 +2634,7 @@ void Server::acceptAuth(SessionId peer_id, bool forSudoMode)
 	}
 }
 
-void Server::DeleteClient(SessionId peer_id, ClientDeletionReason reason)
+void Server::DeleteClient(session_t peer_id, ClientDeletionReason reason)
 {
 	std::wstring message;
 	{
@@ -2819,7 +2819,7 @@ std::wstring Server::handleChat(const std::string &name, const std::wstring &wna
 		if they are using protocol version >= 29
 	*/
 
-	SessionId peer_id_to_avoid_sending = (player ? player->peer_id : PEER_ID_INEXISTENT);
+	session_t peer_id_to_avoid_sending = (player ? player->peer_id : PEER_ID_INEXISTENT);
 	if (player && player->protocol_version >= 29)
 		peer_id_to_avoid_sending = PEER_ID_INEXISTENT;
 
@@ -2844,7 +2844,7 @@ void Server::handleAdminChat(const ChatEventChat *evt)
 	}
 }
 
-RemoteClient* Server::getClient(SessionId peer_id, ClientState state_min)
+RemoteClient* Server::getClient(session_t peer_id, ClientState state_min)
 {
 	RemoteClient *client = getClientNoEx(peer_id,state_min);
 	if(!client)
@@ -2852,12 +2852,12 @@ RemoteClient* Server::getClient(SessionId peer_id, ClientState state_min)
 
 	return client;
 }
-RemoteClient* Server::getClientNoEx(SessionId peer_id, ClientState state_min)
+RemoteClient* Server::getClientNoEx(session_t peer_id, ClientState state_min)
 {
 	return m_clients.getClientNoEx(peer_id, state_min);
 }
 
-std::string Server::getPlayerName(SessionId peer_id)
+std::string Server::getPlayerName(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (!player)
@@ -2865,7 +2865,7 @@ std::string Server::getPlayerName(SessionId peer_id)
 	return player->getName();
 }
 
-PlayerSAO* Server::getPlayerSAO(SessionId peer_id)
+PlayerSAO* Server::getPlayerSAO(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (!player)
@@ -3109,7 +3109,7 @@ const std::string& Server::hudGetHotbarSelectedImage(RemotePlayer *player) const
 	return player->getHotbarSelectedImage();
 }
 
-Address Server::getPeerAddress(SessionId peer_id)
+Address Server::getPeerAddress(session_t peer_id)
 {
 	return m_con->GetPeerAddress(peer_id);
 }
@@ -3191,7 +3191,7 @@ void Server::spawnParticle(const std::string &playername, v3f pos,
 	if (!m_env)
 		return;
 
-	SessionId peer_id = PEER_ID_INEXISTENT;
+	session_t peer_id = PEER_ID_INEXISTENT;
 	u16 proto_ver = 0;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
@@ -3218,7 +3218,7 @@ u32 Server::addParticleSpawner(u16 amount, float spawntime,
 	if (!m_env)
 		return -1;
 
-	SessionId peer_id = PEER_ID_INEXISTENT;
+	session_t peer_id = PEER_ID_INEXISTENT;
 	u16 proto_ver = 0;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
@@ -3251,7 +3251,7 @@ void Server::deleteParticleSpawner(const std::string &playername, u32 id)
 	if (!m_env)
 		throw ServerError("Can't delete particle spawners during initialisation!");
 
-	SessionId peer_id = PEER_ID_INEXISTENT;
+	session_t peer_id = PEER_ID_INEXISTENT;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
 		if (!player)
@@ -3482,7 +3482,7 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 	}
 }
 
-PlayerSAO* Server::emergePlayer(const char *name, SessionId peer_id, u16 proto_version)
+PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version)
 {
 	/*
 		Try to get an existing player
@@ -3643,7 +3643,7 @@ void Server::broadcastModChannelMessage(const std::string &channel,
 	NetworkPacket resp_pkt(TOCLIENT_MODCHANNEL_MSG,
 			2 + channel.size() + 2 + sender.size() + 2 + message.size());
 	resp_pkt << channel << sender << message;
-	for (SessionId peer_id : peers) {
+	for (session_t peer_id : peers) {
 		// Ignore sender
 		if (peer_id == from_peer)
 			continue;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -974,7 +974,7 @@ void Server::AsyncRunStep(bool initial_step)
 
 void Server::Receive()
 {
-	u16 peer_id;
+	SessionId peer_id;
 	try {
 		NetworkPacket pkt;
 		m_con->Receive(&pkt);
@@ -995,7 +995,7 @@ void Server::Receive()
 	}
 }
 
-PlayerSAO* Server::StageTwoClientInit(u16 peer_id)
+PlayerSAO* Server::StageTwoClientInit(SessionId peer_id)
 {
 	std::string playername;
 	PlayerSAO *playersao = NULL;
@@ -1297,14 +1297,14 @@ void Server::deletingPeer(con::Peer *peer, bool timeout)
 	m_peer_change_queue.push(con::PeerChange(con::PEER_REMOVED, peer->id, timeout));
 }
 
-bool Server::getClientConInfo(u16 peer_id, con::rtt_stat_type type, float* retval)
+bool Server::getClientConInfo(SessionId peer_id, con::rtt_stat_type type, float* retval)
 {
 	*retval = m_con->getPeerStat(peer_id,type);
 	return *retval != -1;
 }
 
 bool Server::getClientInfo(
-		u16          peer_id,
+		SessionId    peer_id,
 		ClientState* state,
 		u32*         uptime,
 		u8*          ser_vers,
@@ -1381,7 +1381,7 @@ void Server::Send(NetworkPacket *pkt)
 	Send(pkt->getPeerId(), pkt);
 }
 
-void Server::Send(u16 peer_id, NetworkPacket *pkt)
+void Server::Send(SessionId peer_id, NetworkPacket *pkt)
 {
 	m_clients.send(peer_id,
 		clientCommandFactoryTable[pkt->getCommand()].channel,
@@ -1389,7 +1389,7 @@ void Server::Send(u16 peer_id, NetworkPacket *pkt)
 		clientCommandFactoryTable[pkt->getCommand()].reliable);
 }
 
-void Server::SendMovement(u16 peer_id)
+void Server::SendMovement(SessionId peer_id)
 {
 	std::ostringstream os(std::ios_base::binary);
 
@@ -1416,7 +1416,7 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 	if (!g_settings->getBool("enable_damage"))
 		return;
 
-	u16 peer_id   = playersao->getPeerID();
+	SessionId peer_id   = playersao->getPeerID();
 	bool is_alive = playersao->getHP() > 0;
 
 	if (is_alive)
@@ -1425,21 +1425,21 @@ void Server::SendPlayerHPOrDie(PlayerSAO *playersao)
 		DiePlayer(peer_id);
 }
 
-void Server::SendHP(u16 peer_id, u16 hp)
+void Server::SendHP(SessionId peer_id, u16 hp)
 {
 	NetworkPacket pkt(TOCLIENT_HP, 1, peer_id);
 	pkt << hp;
 	Send(&pkt);
 }
 
-void Server::SendBreath(u16 peer_id, u16 breath)
+void Server::SendBreath(SessionId peer_id, u16 breath)
 {
 	NetworkPacket pkt(TOCLIENT_BREATH, 2, peer_id);
 	pkt << (u16) breath;
 	Send(&pkt);
 }
 
-void Server::SendAccessDenied(u16 peer_id, AccessDeniedCode reason,
+void Server::SendAccessDenied(SessionId peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect)
 {
 	assert(reason < SERVER_ACCESSDENIED_MAX);
@@ -1454,14 +1454,14 @@ void Server::SendAccessDenied(u16 peer_id, AccessDeniedCode reason,
 	Send(&pkt);
 }
 
-void Server::SendAccessDenied_Legacy(u16 peer_id,const std::wstring &reason)
+void Server::SendAccessDenied_Legacy(SessionId peer_id,const std::wstring &reason)
 {
 	NetworkPacket pkt(TOCLIENT_ACCESS_DENIED_LEGACY, 0, peer_id);
 	pkt << reason;
 	Send(&pkt);
 }
 
-void Server::SendDeathscreen(u16 peer_id,bool set_camera_point_target,
+void Server::SendDeathscreen(SessionId peer_id,bool set_camera_point_target,
 		v3f camera_point_target)
 {
 	NetworkPacket pkt(TOCLIENT_DEATHSCREEN, 1 + sizeof(v3f), peer_id);
@@ -1469,7 +1469,7 @@ void Server::SendDeathscreen(u16 peer_id,bool set_camera_point_target,
 	Send(&pkt);
 }
 
-void Server::SendItemDef(u16 peer_id,
+void Server::SendItemDef(SessionId peer_id,
 		IItemDefManager *itemdef, u16 protocol_version)
 {
 	NetworkPacket pkt(TOCLIENT_ITEMDEF, 0, peer_id);
@@ -1492,7 +1492,7 @@ void Server::SendItemDef(u16 peer_id,
 	Send(&pkt);
 }
 
-void Server::SendNodeDef(u16 peer_id,
+void Server::SendNodeDef(SessionId peer_id,
 		INodeDefManager *nodedef, u16 protocol_version)
 {
 	NetworkPacket pkt(TOCLIENT_NODEDEF, 0, peer_id);
@@ -1539,7 +1539,7 @@ void Server::SendInventory(PlayerSAO* playerSAO)
 	Send(&pkt);
 }
 
-void Server::SendChatMessage(u16 peer_id, const ChatMessage &message)
+void Server::SendChatMessage(SessionId peer_id, const ChatMessage &message)
 {
 	NetworkPacket pkt(TOCLIENT_CHAT_MESSAGE, 0, peer_id);
 	u8 version = 1;
@@ -1557,7 +1557,7 @@ void Server::SendChatMessage(u16 peer_id, const ChatMessage &message)
 	}
 }
 
-void Server::SendShowFormspecMessage(u16 peer_id, const std::string &formspec,
+void Server::SendShowFormspecMessage(SessionId peer_id, const std::string &formspec,
                                      const std::string &formname)
 {
 	NetworkPacket pkt(TOCLIENT_SHOW_FORMSPEC, 0 , peer_id);
@@ -1573,7 +1573,7 @@ void Server::SendShowFormspecMessage(u16 peer_id, const std::string &formspec,
 }
 
 // Spawns a particle on peer with peer_id
-void Server::SendSpawnParticle(u16 peer_id, u16 protocol_version,
+void Server::SendSpawnParticle(SessionId peer_id, u16 protocol_version,
 				v3f pos, v3f velocity, v3f acceleration,
 				float expirationtime, float size, bool collisiondetection,
 				bool collision_removal,
@@ -1624,7 +1624,7 @@ void Server::SendSpawnParticle(u16 peer_id, u16 protocol_version,
 }
 
 // Adds a ParticleSpawner on peer with peer_id
-void Server::SendAddParticleSpawner(u16 peer_id, u16 protocol_version,
+void Server::SendAddParticleSpawner(SessionId peer_id, u16 protocol_version,
 	u16 amount, float spawntime, v3f minpos, v3f maxpos,
 	v3f minvel, v3f maxvel, v3f minacc, v3f maxacc, float minexptime, float maxexptime,
 	float minsize, float maxsize, bool collisiondetection, bool collision_removal,
@@ -1667,7 +1667,7 @@ void Server::SendAddParticleSpawner(u16 peer_id, u16 protocol_version,
 	Send(&pkt);
 }
 
-void Server::SendDeleteParticleSpawner(u16 peer_id, u32 id)
+void Server::SendDeleteParticleSpawner(SessionId peer_id, u32 id)
 {
 	NetworkPacket pkt(TOCLIENT_DELETE_PARTICLESPAWNER, 4, peer_id);
 
@@ -1681,7 +1681,7 @@ void Server::SendDeleteParticleSpawner(u16 peer_id, u32 id)
 
 }
 
-void Server::SendHUDAdd(u16 peer_id, u32 id, HudElement *form)
+void Server::SendHUDAdd(SessionId peer_id, u32 id, HudElement *form)
 {
 	NetworkPacket pkt(TOCLIENT_HUDADD, 0 , peer_id);
 
@@ -1692,14 +1692,14 @@ void Server::SendHUDAdd(u16 peer_id, u32 id, HudElement *form)
 	Send(&pkt);
 }
 
-void Server::SendHUDRemove(u16 peer_id, u32 id)
+void Server::SendHUDRemove(SessionId peer_id, u32 id)
 {
 	NetworkPacket pkt(TOCLIENT_HUDRM, 4, peer_id);
 	pkt << id;
 	Send(&pkt);
 }
 
-void Server::SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value)
+void Server::SendHUDChange(SessionId peer_id, u32 id, HudElementStat stat, void *value)
 {
 	NetworkPacket pkt(TOCLIENT_HUDCHANGE, 0, peer_id);
 	pkt << id << (u8) stat;
@@ -1732,7 +1732,7 @@ void Server::SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value
 	Send(&pkt);
 }
 
-void Server::SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask)
+void Server::SendHUDSetFlags(SessionId peer_id, u32 flags, u32 mask)
 {
 	NetworkPacket pkt(TOCLIENT_HUD_SET_FLAGS, 4 + 4, peer_id);
 
@@ -1743,14 +1743,14 @@ void Server::SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask)
 	Send(&pkt);
 }
 
-void Server::SendHUDSetParam(u16 peer_id, u16 param, const std::string &value)
+void Server::SendHUDSetParam(SessionId peer_id, u16 param, const std::string &value)
 {
 	NetworkPacket pkt(TOCLIENT_HUD_SET_PARAM, 0, peer_id);
 	pkt << param << value;
 	Send(&pkt);
 }
 
-void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
+void Server::SendSetSky(SessionId peer_id, const video::SColor &bgcolor,
 		const std::string &type, const std::vector<std::string> &params,
 		bool &clouds)
 {
@@ -1765,7 +1765,7 @@ void Server::SendSetSky(u16 peer_id, const video::SColor &bgcolor,
 	Send(&pkt);
 }
 
-void Server::SendCloudParams(u16 peer_id, float density,
+void Server::SendCloudParams(SessionId peer_id, float density,
 		const video::SColor &color_bright,
 		const video::SColor &color_ambient,
 		float height,
@@ -1779,7 +1779,7 @@ void Server::SendCloudParams(u16 peer_id, float density,
 	Send(&pkt);
 }
 
-void Server::SendOverrideDayNightRatio(u16 peer_id, bool do_override,
+void Server::SendOverrideDayNightRatio(SessionId peer_id, bool do_override,
 		float ratio)
 {
 	NetworkPacket pkt(TOCLIENT_OVERRIDE_DAY_NIGHT_RATIO,
@@ -1790,7 +1790,7 @@ void Server::SendOverrideDayNightRatio(u16 peer_id, bool do_override,
 	Send(&pkt);
 }
 
-void Server::SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed)
+void Server::SendTimeOfDay(SessionId peer_id, u16 time, f32 time_speed)
 {
 	NetworkPacket pkt(TOCLIENT_TIME_OF_DAY, 0, peer_id);
 	pkt << time << time_speed;
@@ -1803,7 +1803,7 @@ void Server::SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed)
 	}
 }
 
-void Server::SendPlayerHP(u16 peer_id)
+void Server::SendPlayerHP(SessionId peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	// In some rare case if the player is disconnected
@@ -1828,7 +1828,7 @@ void Server::SendPlayerBreath(PlayerSAO *sao)
 	SendBreath(sao->getPeerID(), sao->getBreath());
 }
 
-void Server::SendMovePlayer(u16 peer_id)
+void Server::SendMovePlayer(SessionId peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1850,7 +1850,8 @@ void Server::SendMovePlayer(u16 peer_id)
 	Send(&pkt);
 }
 
-void Server::SendLocalPlayerAnimations(u16 peer_id, v2s32 animation_frames[4], f32 animation_speed)
+void Server::SendLocalPlayerAnimations(SessionId peer_id, v2s32 animation_frames[4],
+		f32 animation_speed)
 {
 	NetworkPacket pkt(TOCLIENT_LOCAL_PLAYER_ANIMATIONS, 0,
 		peer_id);
@@ -1861,13 +1862,14 @@ void Server::SendLocalPlayerAnimations(u16 peer_id, v2s32 animation_frames[4], f
 	Send(&pkt);
 }
 
-void Server::SendEyeOffset(u16 peer_id, v3f first, v3f third)
+void Server::SendEyeOffset(SessionId peer_id, v3f first, v3f third)
 {
 	NetworkPacket pkt(TOCLIENT_EYE_OFFSET, 0, peer_id);
 	pkt << first << third;
 	Send(&pkt);
 }
-void Server::SendPlayerPrivileges(u16 peer_id)
+
+void Server::SendPlayerPrivileges(SessionId peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1887,7 +1889,7 @@ void Server::SendPlayerPrivileges(u16 peer_id)
 	Send(&pkt);
 }
 
-void Server::SendPlayerInventoryFormspec(u16 peer_id)
+void Server::SendPlayerInventoryFormspec(SessionId peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
@@ -1899,7 +1901,7 @@ void Server::SendPlayerInventoryFormspec(u16 peer_id)
 	Send(&pkt);
 }
 
-u32 Server::SendActiveObjectRemoveAdd(u16 peer_id, const std::string &datas)
+u32 Server::SendActiveObjectRemoveAdd(SessionId peer_id, const std::string &datas)
 {
 	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD, datas.size(), peer_id);
 	pkt.putRawString(datas.c_str(), datas.size());
@@ -1907,7 +1909,8 @@ u32 Server::SendActiveObjectRemoveAdd(u16 peer_id, const std::string &datas)
 	return pkt.getSize();
 }
 
-void Server::SendActiveObjectMessages(u16 peer_id, const std::string &datas, bool reliable)
+void Server::SendActiveObjectMessages(SessionId peer_id, const std::string &datas,
+		bool reliable)
 {
 	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_MESSAGES,
 			datas.size(), peer_id);
@@ -1919,7 +1922,7 @@ void Server::SendActiveObjectMessages(u16 peer_id, const std::string &datas, boo
 			&pkt, reliable);
 }
 
-void Server::SendCSMFlavourLimits(u16 peer_id)
+void Server::SendCSMFlavourLimits(SessionId peer_id)
 {
 	NetworkPacket pkt(TOCLIENT_CSM_FLAVOUR_LIMITS,
 		sizeof(m_csm_flavour_limits) + sizeof(m_csm_noderange_limit), peer_id);
@@ -2151,7 +2154,8 @@ void Server::setBlockNotSent(v3s16 p)
 	m_clients.unlock();
 }
 
-void Server::SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto_version)
+void Server::SendBlockNoLock(SessionId peer_id, MapBlock *block, u8 ver,
+		u16 net_proto_version)
 {
 	v3s16 p = block->getPos();
 
@@ -2332,7 +2336,7 @@ void Server::fillMediaCache()
 	}
 }
 
-void Server::sendMediaAnnouncement(u16 peer_id, const std::string &lang_code)
+void Server::sendMediaAnnouncement(SessionId peer_id, const std::string &lang_code)
 {
 	verbosestream << "Server: Announcing files to id(" << peer_id << ")"
 		<< std::endl;
@@ -2375,7 +2379,7 @@ struct SendableMedia
 	{}
 };
 
-void Server::sendRequestedMedia(u16 peer_id,
+void Server::sendRequestedMedia(SessionId peer_id,
 		const std::vector<std::string> &tosend)
 {
 	verbosestream<<"Server::sendRequestedMedia(): "
@@ -2474,7 +2478,7 @@ void Server::sendRequestedMedia(u16 peer_id,
 	}
 }
 
-void Server::sendDetachedInventory(const std::string &name, u16 peer_id)
+void Server::sendDetachedInventory(const std::string &name, SessionId peer_id)
 {
 	if(m_detached_inventories.count(name) == 0) {
 		errorstream<<FUNCTION_NAME<<": \""<<name<<"\" not found"<<std::endl;
@@ -2505,7 +2509,7 @@ void Server::sendDetachedInventory(const std::string &name, u16 peer_id)
 	}
 }
 
-void Server::sendDetachedInventories(u16 peer_id)
+void Server::sendDetachedInventories(SessionId peer_id)
 {
 	for (const auto &detached_inventory : m_detached_inventories) {
 		const std::string &name = detached_inventory.first;
@@ -2518,7 +2522,7 @@ void Server::sendDetachedInventories(u16 peer_id)
 	Something random
 */
 
-void Server::DiePlayer(u16 peer_id)
+void Server::DiePlayer(SessionId peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	// In some rare cases this can be NULL -- if the player is disconnected
@@ -2539,7 +2543,7 @@ void Server::DiePlayer(u16 peer_id)
 	SendDeathscreen(peer_id, false, v3f(0,0,0));
 }
 
-void Server::RespawnPlayer(u16 peer_id)
+void Server::RespawnPlayer(SessionId peer_id)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	assert(playersao);
@@ -2561,14 +2565,14 @@ void Server::RespawnPlayer(u16 peer_id)
 }
 
 
-void Server::DenySudoAccess(u16 peer_id)
+void Server::DenySudoAccess(SessionId peer_id)
 {
 	NetworkPacket pkt(TOCLIENT_DENY_SUDO_MODE, 0, peer_id);
 	Send(&pkt);
 }
 
 
-void Server::DenyAccessVerCompliant(u16 peer_id, u16 proto_ver, AccessDeniedCode reason,
+void Server::DenyAccessVerCompliant(SessionId peer_id, u16 proto_ver, AccessDeniedCode reason,
 		const std::string &str_reason, bool reconnect)
 {
 	SendAccessDenied(peer_id, reason, str_reason, reconnect);
@@ -2578,7 +2582,8 @@ void Server::DenyAccessVerCompliant(u16 peer_id, u16 proto_ver, AccessDeniedCode
 }
 
 
-void Server::DenyAccess(u16 peer_id, AccessDeniedCode reason, const std::string &custom_reason)
+void Server::DenyAccess(SessionId peer_id, AccessDeniedCode reason,
+		const std::string &custom_reason)
 {
 	SendAccessDenied(peer_id, reason, custom_reason);
 	m_clients.event(peer_id, CSE_SetDenied);
@@ -2587,20 +2592,20 @@ void Server::DenyAccess(u16 peer_id, AccessDeniedCode reason, const std::string 
 
 // 13/03/15: remove this function when protocol version 25 will become
 // the minimum version for MT users, maybe in 1 year
-void Server::DenyAccess_Legacy(u16 peer_id, const std::wstring &reason)
+void Server::DenyAccess_Legacy(SessionId peer_id, const std::wstring &reason)
 {
 	SendAccessDenied_Legacy(peer_id, reason);
 	m_clients.event(peer_id, CSE_SetDenied);
 	DisconnectPeer(peer_id);
 }
 
-void Server::DisconnectPeer(u16 peer_id)
+void Server::DisconnectPeer(SessionId peer_id)
 {
 	m_modchannel_mgr->leaveAllChannels(peer_id);
 	m_con->DisconnectPeer(peer_id);
 }
 
-void Server::acceptAuth(u16 peer_id, bool forSudoMode)
+void Server::acceptAuth(SessionId peer_id, bool forSudoMode)
 {
 	if (!forSudoMode) {
 		RemoteClient* client = getClient(peer_id, CS_Invalid);
@@ -2629,7 +2634,7 @@ void Server::acceptAuth(u16 peer_id, bool forSudoMode)
 	}
 }
 
-void Server::DeleteClient(u16 peer_id, ClientDeletionReason reason)
+void Server::DeleteClient(SessionId peer_id, ClientDeletionReason reason)
 {
 	std::wstring message;
 	{
@@ -2814,7 +2819,7 @@ std::wstring Server::handleChat(const std::string &name, const std::wstring &wna
 		if they are using protocol version >= 29
 	*/
 
-	u16 peer_id_to_avoid_sending = (player ? player->peer_id : PEER_ID_INEXISTENT);
+	SessionId peer_id_to_avoid_sending = (player ? player->peer_id : PEER_ID_INEXISTENT);
 	if (player && player->protocol_version >= 29)
 		peer_id_to_avoid_sending = PEER_ID_INEXISTENT;
 
@@ -2839,7 +2844,7 @@ void Server::handleAdminChat(const ChatEventChat *evt)
 	}
 }
 
-RemoteClient* Server::getClient(u16 peer_id, ClientState state_min)
+RemoteClient* Server::getClient(SessionId peer_id, ClientState state_min)
 {
 	RemoteClient *client = getClientNoEx(peer_id,state_min);
 	if(!client)
@@ -2847,12 +2852,12 @@ RemoteClient* Server::getClient(u16 peer_id, ClientState state_min)
 
 	return client;
 }
-RemoteClient* Server::getClientNoEx(u16 peer_id, ClientState state_min)
+RemoteClient* Server::getClientNoEx(SessionId peer_id, ClientState state_min)
 {
 	return m_clients.getClientNoEx(peer_id, state_min);
 }
 
-std::string Server::getPlayerName(u16 peer_id)
+std::string Server::getPlayerName(SessionId peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (!player)
@@ -2860,7 +2865,7 @@ std::string Server::getPlayerName(u16 peer_id)
 	return player->getName();
 }
 
-PlayerSAO* Server::getPlayerSAO(u16 peer_id)
+PlayerSAO* Server::getPlayerSAO(SessionId peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	if (!player)
@@ -3104,7 +3109,7 @@ const std::string& Server::hudGetHotbarSelectedImage(RemotePlayer *player) const
 	return player->getHotbarSelectedImage();
 }
 
-Address Server::getPeerAddress(u16 peer_id)
+Address Server::getPeerAddress(SessionId peer_id)
 {
 	return m_con->GetPeerAddress(peer_id);
 }
@@ -3186,7 +3191,8 @@ void Server::spawnParticle(const std::string &playername, v3f pos,
 	if (!m_env)
 		return;
 
-	u16 peer_id = PEER_ID_INEXISTENT, proto_ver = 0;
+	SessionId peer_id = PEER_ID_INEXISTENT;
+	u16 proto_ver = 0;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
 		if (!player)
@@ -3212,7 +3218,8 @@ u32 Server::addParticleSpawner(u16 amount, float spawntime,
 	if (!m_env)
 		return -1;
 
-	u16 peer_id = PEER_ID_INEXISTENT, proto_ver = 0;
+	SessionId peer_id = PEER_ID_INEXISTENT;
+	u16 proto_ver = 0;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
 		if (!player)
@@ -3244,7 +3251,7 @@ void Server::deleteParticleSpawner(const std::string &playername, u32 id)
 	if (!m_env)
 		throw ServerError("Can't delete particle spawners during initialisation!");
 
-	u16 peer_id = PEER_ID_INEXISTENT;
+	SessionId peer_id = PEER_ID_INEXISTENT;
 	if (!playername.empty()) {
 		RemotePlayer *player = m_env->getPlayer(playername.c_str());
 		if (!player)
@@ -3475,7 +3482,7 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 	}
 }
 
-PlayerSAO* Server::emergePlayer(const char *name, u16 peer_id, u16 proto_version)
+PlayerSAO* Server::emergePlayer(const char *name, SessionId peer_id, u16 proto_version)
 {
 	/*
 		Try to get an existing player
@@ -3636,7 +3643,7 @@ void Server::broadcastModChannelMessage(const std::string &channel,
 	NetworkPacket resp_pkt(TOCLIENT_MODCHANNEL_MSG,
 			2 + channel.size() + 2 + sender.size() + 2 + message.size());
 	resp_pkt << channel << sender << message;
-	for (u16 peer_id : peers) {
+	for (SessionId peer_id : peers) {
 		// Ignore sender
 		if (peer_id == from_peer)
 			continue;

--- a/src/server.h
+++ b/src/server.h
@@ -103,7 +103,7 @@ struct ServerPlayingSound
 {
 	ServerSoundParams params;
 	SimpleSoundSpec spec;
-	std::unordered_set<SessionId> clients; // peer ids
+	std::unordered_set<session_t> clients; // peer ids
 };
 
 class Server : public con::PeerHandler, public MapEventReceiver,
@@ -133,7 +133,7 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
-	PlayerSAO* StageTwoClientInit(SessionId peer_id);
+	PlayerSAO* StageTwoClientInit(session_t peer_id);
 
 	/*
 	 * Command Handlers
@@ -170,7 +170,7 @@ public:
 	void ProcessData(NetworkPacket *pkt);
 
 	void Send(NetworkPacket *pkt);
-	void Send(SessionId peer_id, NetworkPacket *pkt);
+	void Send(session_t peer_id, NetworkPacket *pkt);
 
 	// Helper for handleCommand_PlayerPos and handleCommand_Interact
 	void process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
@@ -296,7 +296,7 @@ public:
 	void hudSetHotbarSelectedImage(RemotePlayer *player, std::string name);
 	const std::string &hudGetHotbarSelectedImage(RemotePlayer *player) const;
 
-	Address getPeerAddress(SessionId peer_id);
+	Address getPeerAddress(session_t peer_id);
 
 	bool setLocalPlayerAnimations(RemotePlayer *player, v2s32 animation_frames[4],
 			f32 frame_speed);
@@ -318,16 +318,16 @@ public:
 	void peerAdded(con::Peer *peer);
 	void deletingPeer(con::Peer *peer, bool timeout);
 
-	void DenySudoAccess(SessionId peer_id);
-	void DenyAccessVerCompliant(SessionId peer_id, u16 proto_ver, AccessDeniedCode reason,
+	void DenySudoAccess(session_t peer_id);
+	void DenyAccessVerCompliant(session_t peer_id, u16 proto_ver, AccessDeniedCode reason,
 		const std::string &str_reason = "", bool reconnect = false);
-	void DenyAccess(SessionId peer_id, AccessDeniedCode reason,
+	void DenyAccess(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason = "");
-	void acceptAuth(SessionId peer_id, bool forSudoMode);
-	void DenyAccess_Legacy(SessionId peer_id, const std::wstring &reason);
-	void DisconnectPeer(SessionId peer_id);
-	bool getClientConInfo(SessionId peer_id, con::rtt_stat_type type, float* retval);
-	bool getClientInfo(SessionId peer_id,ClientState* state, u32* uptime,
+	void acceptAuth(session_t peer_id, bool forSudoMode);
+	void DenyAccess_Legacy(session_t peer_id, const std::wstring &reason);
+	void DisconnectPeer(session_t peer_id);
+	bool getClientConInfo(session_t peer_id, con::rtt_stat_type type, float *retval);
+	bool getClientInfo(session_t peer_id, ClientState *state, u32 *uptime,
 			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
 			std::string* vers_string);
 
@@ -336,7 +336,7 @@ public:
 	void SendPlayerHPOrDie(PlayerSAO *player);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO* playerSAO);
-	void SendMovePlayer(SessionId peer_id);
+	void SendMovePlayer(session_t peer_id);
 
 	virtual bool registerModStorage(ModMetadata *storage);
 	virtual void unregisterModStorage(const std::string &name);
@@ -357,49 +357,49 @@ private:
 	friend class EmergeThread;
 	friend class RemoteClient;
 
-	void SendMovement(SessionId peer_id);
-	void SendHP(SessionId peer_id, u16 hp);
-	void SendBreath(SessionId peer_id, u16 breath);
-	void SendAccessDenied(SessionId peer_id, AccessDeniedCode reason,
+	void SendMovement(session_t peer_id);
+	void SendHP(session_t peer_id, u16 hp);
+	void SendBreath(session_t peer_id, u16 breath);
+	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);
-	void SendAccessDenied_Legacy(SessionId peer_id, const std::wstring &reason);
-	void SendDeathscreen(SessionId peer_id,bool set_camera_point_target,
+	void SendAccessDenied_Legacy(session_t peer_id, const std::wstring &reason);
+	void SendDeathscreen(session_t peer_id,bool set_camera_point_target,
 		v3f camera_point_target);
-	void SendItemDef(SessionId peer_id, IItemDefManager *itemdef, u16 protocol_version);
-	void SendNodeDef(SessionId peer_id, INodeDefManager *nodedef, u16 protocol_version);
+	void SendItemDef(session_t peer_id, IItemDefManager *itemdef, u16 protocol_version);
+	void SendNodeDef(session_t peer_id, INodeDefManager *nodedef, u16 protocol_version);
 
 	/* mark blocks not sent for all clients */
 	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
 
 
-	void SendChatMessage(SessionId peer_id, const ChatMessage &message);
-	void SendTimeOfDay(SessionId peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(SessionId peer_id);
+	void SendChatMessage(session_t peer_id, const ChatMessage &message);
+	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
+	void SendPlayerHP(session_t peer_id);
 
-	void SendLocalPlayerAnimations(SessionId peer_id, v2s32 animation_frames[4],
+	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);
-	void SendEyeOffset(SessionId peer_id, v3f first, v3f third);
-	void SendPlayerPrivileges(SessionId peer_id);
-	void SendPlayerInventoryFormspec(SessionId peer_id);
-	void SendShowFormspecMessage(SessionId peer_id, const std::string &formspec,
+	void SendEyeOffset(session_t peer_id, v3f first, v3f third);
+	void SendPlayerPrivileges(session_t peer_id);
+	void SendPlayerInventoryFormspec(session_t peer_id);
+	void SendShowFormspecMessage(session_t peer_id, const std::string &formspec,
 		const std::string &formname);
-	void SendHUDAdd(SessionId peer_id, u32 id, HudElement *form);
-	void SendHUDRemove(SessionId peer_id, u32 id);
-	void SendHUDChange(SessionId peer_id, u32 id, HudElementStat stat, void *value);
-	void SendHUDSetFlags(SessionId peer_id, u32 flags, u32 mask);
-	void SendHUDSetParam(SessionId peer_id, u16 param, const std::string &value);
-	void SendSetSky(SessionId peer_id, const video::SColor &bgcolor,
+	void SendHUDAdd(session_t peer_id, u32 id, HudElement *form);
+	void SendHUDRemove(session_t peer_id, u32 id);
+	void SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void *value);
+	void SendHUDSetFlags(session_t peer_id, u32 flags, u32 mask);
+	void SendHUDSetParam(session_t peer_id, u16 param, const std::string &value);
+	void SendSetSky(session_t peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params,
 			bool &clouds);
-	void SendCloudParams(SessionId peer_id, float density,
+	void SendCloudParams(session_t peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			float height,
 			float thickness,
 			const v2f &speed);
-	void SendOverrideDayNightRatio(SessionId peer_id, bool do_override, float ratio);
+	void SendOverrideDayNightRatio(session_t peer_id, bool do_override, float ratio);
 	void broadcastModChannelMessage(const std::string &channel,
-			const std::string &message, SessionId from_peer);
+			const std::string &message, session_t from_peer);
 
 	/*
 		Send a node removal/addition event to all clients except ignore_id.
@@ -415,21 +415,21 @@ private:
 	void setBlockNotSent(v3s16 p);
 
 	// Environment and Connection must be locked when called
-	void SendBlockNoLock(SessionId peer_id, MapBlock *block, u8 ver, u16 net_proto_version);
+	void SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver, u16 net_proto_version);
 
 	// Sends blocks to clients (locks env and con on its own)
 	void SendBlocks(float dtime);
 
 	void fillMediaCache();
-	void sendMediaAnnouncement(SessionId peer_id, const std::string &lang_code);
-	void sendRequestedMedia(SessionId peer_id,
+	void sendMediaAnnouncement(session_t peer_id, const std::string &lang_code);
+	void sendRequestedMedia(session_t peer_id,
 			const std::vector<std::string> &tosend);
 
-	void sendDetachedInventory(const std::string &name, SessionId peer_id);
-	void sendDetachedInventories(SessionId peer_id);
+	void sendDetachedInventory(const std::string &name, session_t peer_id);
+	void sendDetachedInventories(session_t peer_id);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
-	void SendAddParticleSpawner(SessionId peer_id, u16 protocol_version,
+	void SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 		u16 amount, float spawntime,
 		v3f minpos, v3f maxpos,
 		v3f minvel, v3f maxvel,
@@ -441,28 +441,28 @@ private:
 		bool vertical, const std::string &texture, u32 id,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	void SendDeleteParticleSpawner(SessionId peer_id, u32 id);
+	void SendDeleteParticleSpawner(session_t peer_id, u32 id);
 
 	// Spawns particle on peer with peer_id (PEER_ID_INEXISTENT == all)
-	void SendSpawnParticle(SessionId peer_id, u16 protocol_version,
+	void SendSpawnParticle(session_t peer_id, u16 protocol_version,
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
 		bool collisiondetection, bool collision_removal,
 		bool vertical, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	u32 SendActiveObjectRemoveAdd(SessionId peer_id, const std::string &datas);
-	void SendActiveObjectMessages(SessionId peer_id, const std::string &datas,
+	u32 SendActiveObjectRemoveAdd(session_t peer_id, const std::string &datas);
+	void SendActiveObjectMessages(session_t peer_id, const std::string &datas,
 		bool reliable = true);
-	void SendCSMFlavourLimits(SessionId peer_id);
+	void SendCSMFlavourLimits(session_t peer_id);
 
 	/*
 		Something random
 	*/
 
-	void DiePlayer(SessionId peer_id);
-	void RespawnPlayer(SessionId peer_id);
-	void DeleteClient(SessionId peer_id, ClientDeletionReason reason);
+	void DiePlayer(session_t peer_id);
+	void RespawnPlayer(session_t peer_id);
+	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
@@ -475,12 +475,12 @@ private:
 	void handleAdminChat(const ChatEventChat *evt);
 
 	// When called, connection mutex should be locked
-	RemoteClient* getClient(SessionId peer_id,ClientState state_min=CS_Active);
-	RemoteClient* getClientNoEx(SessionId peer_id,ClientState state_min=CS_Active);
+	RemoteClient* getClient(session_t peer_id,ClientState state_min = CS_Active);
+	RemoteClient* getClientNoEx(session_t peer_id,ClientState state_min = CS_Active);
 
 	// When called, environment mutex should be locked
-	std::string getPlayerName(SessionId peer_id);
-	PlayerSAO* getPlayerSAO(SessionId peer_id);
+	std::string getPlayerName(session_t peer_id);
+	PlayerSAO* getPlayerSAO(session_t peer_id);
 
 	/*
 		Get a player from memory or creates one.
@@ -489,7 +489,7 @@ private:
 
 		Call with env and con locked.
 	*/
-	PlayerSAO *emergePlayer(const char *name, SessionId peer_id, u16 proto_version);
+	PlayerSAO *emergePlayer(const char *name, session_t peer_id, u16 proto_version);
 
 	void handlePeerChanges();
 
@@ -633,7 +633,7 @@ private:
 		this peed id as the disabled recipient
 		This is behind m_env_mutex
 	*/
-	SessionId m_ignore_map_edit_events_peer_id = 0;
+	session_t m_ignore_map_edit_events_peer_id = 0;
 
 	// media files known to server
 	std::unordered_map<std::string, MediaInfo> m_media;

--- a/src/server.h
+++ b/src/server.h
@@ -103,7 +103,7 @@ struct ServerPlayingSound
 {
 	ServerSoundParams params;
 	SimpleSoundSpec spec;
-	std::unordered_set<u16> clients; // peer ids
+	std::unordered_set<SessionId> clients; // peer ids
 };
 
 class Server : public con::PeerHandler, public MapEventReceiver,
@@ -133,7 +133,7 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
-	PlayerSAO* StageTwoClientInit(u16 peer_id);
+	PlayerSAO* StageTwoClientInit(SessionId peer_id);
 
 	/*
 	 * Command Handlers
@@ -170,7 +170,7 @@ public:
 	void ProcessData(NetworkPacket *pkt);
 
 	void Send(NetworkPacket *pkt);
-	void Send(u16 peer_id, NetworkPacket *pkt);
+	void Send(SessionId peer_id, NetworkPacket *pkt);
 
 	// Helper for handleCommand_PlayerPos and handleCommand_Interact
 	void process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
@@ -296,7 +296,7 @@ public:
 	void hudSetHotbarSelectedImage(RemotePlayer *player, std::string name);
 	const std::string &hudGetHotbarSelectedImage(RemotePlayer *player) const;
 
-	Address getPeerAddress(u16 peer_id);
+	Address getPeerAddress(SessionId peer_id);
 
 	bool setLocalPlayerAnimations(RemotePlayer *player, v2s32 animation_frames[4],
 			f32 frame_speed);
@@ -318,15 +318,16 @@ public:
 	void peerAdded(con::Peer *peer);
 	void deletingPeer(con::Peer *peer, bool timeout);
 
-	void DenySudoAccess(u16 peer_id);
-	void DenyAccessVerCompliant(u16 peer_id, u16 proto_ver, AccessDeniedCode reason,
+	void DenySudoAccess(SessionId peer_id);
+	void DenyAccessVerCompliant(SessionId peer_id, u16 proto_ver, AccessDeniedCode reason,
 		const std::string &str_reason = "", bool reconnect = false);
-	void DenyAccess(u16 peer_id, AccessDeniedCode reason, const std::string &custom_reason="");
-	void acceptAuth(u16 peer_id, bool forSudoMode);
-	void DenyAccess_Legacy(u16 peer_id, const std::wstring &reason);
-	void DisconnectPeer(u16 peer_id);
-	bool getClientConInfo(u16 peer_id, con::rtt_stat_type type, float* retval);
-	bool getClientInfo(u16 peer_id,ClientState* state, u32* uptime,
+	void DenyAccess(SessionId peer_id, AccessDeniedCode reason,
+		const std::string &custom_reason = "");
+	void acceptAuth(SessionId peer_id, bool forSudoMode);
+	void DenyAccess_Legacy(SessionId peer_id, const std::wstring &reason);
+	void DisconnectPeer(SessionId peer_id);
+	bool getClientConInfo(SessionId peer_id, con::rtt_stat_type type, float* retval);
+	bool getClientInfo(SessionId peer_id,ClientState* state, u32* uptime,
 			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
 			std::string* vers_string);
 
@@ -335,7 +336,7 @@ public:
 	void SendPlayerHPOrDie(PlayerSAO *player);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO* playerSAO);
-	void SendMovePlayer(u16 peer_id);
+	void SendMovePlayer(SessionId peer_id);
 
 	virtual bool registerModStorage(ModMetadata *storage);
 	virtual void unregisterModStorage(const std::string &name);
@@ -356,46 +357,49 @@ private:
 	friend class EmergeThread;
 	friend class RemoteClient;
 
-	void SendMovement(u16 peer_id);
-	void SendHP(u16 peer_id, u16 hp);
-	void SendBreath(u16 peer_id, u16 breath);
-	void SendAccessDenied(u16 peer_id, AccessDeniedCode reason,
+	void SendMovement(SessionId peer_id);
+	void SendHP(SessionId peer_id, u16 hp);
+	void SendBreath(SessionId peer_id, u16 breath);
+	void SendAccessDenied(SessionId peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);
-	void SendAccessDenied_Legacy(u16 peer_id, const std::wstring &reason);
-	void SendDeathscreen(u16 peer_id,bool set_camera_point_target, v3f camera_point_target);
-	void SendItemDef(u16 peer_id,IItemDefManager *itemdef, u16 protocol_version);
-	void SendNodeDef(u16 peer_id,INodeDefManager *nodedef, u16 protocol_version);
+	void SendAccessDenied_Legacy(SessionId peer_id, const std::wstring &reason);
+	void SendDeathscreen(SessionId peer_id,bool set_camera_point_target,
+		v3f camera_point_target);
+	void SendItemDef(SessionId peer_id, IItemDefManager *itemdef, u16 protocol_version);
+	void SendNodeDef(SessionId peer_id, INodeDefManager *nodedef, u16 protocol_version);
 
 	/* mark blocks not sent for all clients */
 	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
 
 
-	void SendChatMessage(u16 peer_id, const ChatMessage &message);
-	void SendTimeOfDay(u16 peer_id, u16 time, f32 time_speed);
-	void SendPlayerHP(u16 peer_id);
+	void SendChatMessage(SessionId peer_id, const ChatMessage &message);
+	void SendTimeOfDay(SessionId peer_id, u16 time, f32 time_speed);
+	void SendPlayerHP(SessionId peer_id);
 
-	void SendLocalPlayerAnimations(u16 peer_id, v2s32 animation_frames[4], f32 animation_speed);
-	void SendEyeOffset(u16 peer_id, v3f first, v3f third);
-	void SendPlayerPrivileges(u16 peer_id);
-	void SendPlayerInventoryFormspec(u16 peer_id);
-	void SendShowFormspecMessage(u16 peer_id, const std::string &formspec, const std::string &formname);
-	void SendHUDAdd(u16 peer_id, u32 id, HudElement *form);
-	void SendHUDRemove(u16 peer_id, u32 id);
-	void SendHUDChange(u16 peer_id, u32 id, HudElementStat stat, void *value);
-	void SendHUDSetFlags(u16 peer_id, u32 flags, u32 mask);
-	void SendHUDSetParam(u16 peer_id, u16 param, const std::string &value);
-	void SendSetSky(u16 peer_id, const video::SColor &bgcolor,
+	void SendLocalPlayerAnimations(SessionId peer_id, v2s32 animation_frames[4],
+		f32 animation_speed);
+	void SendEyeOffset(SessionId peer_id, v3f first, v3f third);
+	void SendPlayerPrivileges(SessionId peer_id);
+	void SendPlayerInventoryFormspec(SessionId peer_id);
+	void SendShowFormspecMessage(SessionId peer_id, const std::string &formspec,
+		const std::string &formname);
+	void SendHUDAdd(SessionId peer_id, u32 id, HudElement *form);
+	void SendHUDRemove(SessionId peer_id, u32 id);
+	void SendHUDChange(SessionId peer_id, u32 id, HudElementStat stat, void *value);
+	void SendHUDSetFlags(SessionId peer_id, u32 flags, u32 mask);
+	void SendHUDSetParam(SessionId peer_id, u16 param, const std::string &value);
+	void SendSetSky(SessionId peer_id, const video::SColor &bgcolor,
 			const std::string &type, const std::vector<std::string> &params,
 			bool &clouds);
-	void SendCloudParams(u16 peer_id, float density,
+	void SendCloudParams(SessionId peer_id, float density,
 			const video::SColor &color_bright,
 			const video::SColor &color_ambient,
 			float height,
 			float thickness,
 			const v2f &speed);
-	void SendOverrideDayNightRatio(u16 peer_id, bool do_override, float ratio);
+	void SendOverrideDayNightRatio(SessionId peer_id, bool do_override, float ratio);
 	void broadcastModChannelMessage(const std::string &channel,
-			const std::string &message, u16 from_peer);
+			const std::string &message, SessionId from_peer);
 
 	/*
 		Send a node removal/addition event to all clients except ignore_id.
@@ -411,21 +415,21 @@ private:
 	void setBlockNotSent(v3s16 p);
 
 	// Environment and Connection must be locked when called
-	void SendBlockNoLock(u16 peer_id, MapBlock *block, u8 ver, u16 net_proto_version);
+	void SendBlockNoLock(SessionId peer_id, MapBlock *block, u8 ver, u16 net_proto_version);
 
 	// Sends blocks to clients (locks env and con on its own)
 	void SendBlocks(float dtime);
 
 	void fillMediaCache();
-	void sendMediaAnnouncement(u16 peer_id, const std::string &lang_code);
-	void sendRequestedMedia(u16 peer_id,
+	void sendMediaAnnouncement(SessionId peer_id, const std::string &lang_code);
+	void sendRequestedMedia(SessionId peer_id,
 			const std::vector<std::string> &tosend);
 
-	void sendDetachedInventory(const std::string &name, u16 peer_id);
-	void sendDetachedInventories(u16 peer_id);
+	void sendDetachedInventory(const std::string &name, SessionId peer_id);
+	void sendDetachedInventories(SessionId peer_id);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
-	void SendAddParticleSpawner(u16 peer_id, u16 protocol_version,
+	void SendAddParticleSpawner(SessionId peer_id, u16 protocol_version,
 		u16 amount, float spawntime,
 		v3f minpos, v3f maxpos,
 		v3f minvel, v3f maxvel,
@@ -437,27 +441,28 @@ private:
 		bool vertical, const std::string &texture, u32 id,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	void SendDeleteParticleSpawner(u16 peer_id, u32 id);
+	void SendDeleteParticleSpawner(SessionId peer_id, u32 id);
 
 	// Spawns particle on peer with peer_id (PEER_ID_INEXISTENT == all)
-	void SendSpawnParticle(u16 peer_id, u16 protocol_version,
+	void SendSpawnParticle(SessionId peer_id, u16 protocol_version,
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
 		bool collisiondetection, bool collision_removal,
 		bool vertical, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	u32 SendActiveObjectRemoveAdd(u16 peer_id, const std::string &datas);
-	void SendActiveObjectMessages(u16 peer_id, const std::string &datas, bool reliable = true);
-	void SendCSMFlavourLimits(u16 peer_id);
+	u32 SendActiveObjectRemoveAdd(SessionId peer_id, const std::string &datas);
+	void SendActiveObjectMessages(SessionId peer_id, const std::string &datas,
+		bool reliable = true);
+	void SendCSMFlavourLimits(SessionId peer_id);
 
 	/*
 		Something random
 	*/
 
-	void DiePlayer(u16 peer_id);
-	void RespawnPlayer(u16 peer_id);
-	void DeleteClient(u16 peer_id, ClientDeletionReason reason);
+	void DiePlayer(SessionId peer_id);
+	void RespawnPlayer(SessionId peer_id);
+	void DeleteClient(SessionId peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
@@ -470,12 +475,12 @@ private:
 	void handleAdminChat(const ChatEventChat *evt);
 
 	// When called, connection mutex should be locked
-	RemoteClient* getClient(u16 peer_id,ClientState state_min=CS_Active);
-	RemoteClient* getClientNoEx(u16 peer_id,ClientState state_min=CS_Active);
+	RemoteClient* getClient(SessionId peer_id,ClientState state_min=CS_Active);
+	RemoteClient* getClientNoEx(SessionId peer_id,ClientState state_min=CS_Active);
 
 	// When called, environment mutex should be locked
-	std::string getPlayerName(u16 peer_id);
-	PlayerSAO* getPlayerSAO(u16 peer_id);
+	std::string getPlayerName(SessionId peer_id);
+	PlayerSAO* getPlayerSAO(SessionId peer_id);
 
 	/*
 		Get a player from memory or creates one.
@@ -484,7 +489,7 @@ private:
 
 		Call with env and con locked.
 	*/
-	PlayerSAO *emergePlayer(const char *name, u16 peer_id, u16 proto_version);
+	PlayerSAO *emergePlayer(const char *name, SessionId peer_id, u16 proto_version);
 
 	void handlePeerChanges();
 
@@ -628,7 +633,7 @@ private:
 		this peed id as the disabled recipient
 		This is behind m_env_mutex
 	*/
-	u16 m_ignore_map_edit_events_peer_id = 0;
+	SessionId m_ignore_map_edit_events_peer_id = 0;
 
 	// media files known to server
 	std::unordered_map<std::string, MediaInfo> m_media;

--- a/src/server.h
+++ b/src/server.h
@@ -363,7 +363,7 @@ private:
 	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);
 	void SendAccessDenied_Legacy(session_t peer_id, const std::wstring &reason);
-	void SendDeathscreen(session_t peer_id,bool set_camera_point_target,
+	void SendDeathscreen(session_t peer_id, bool set_camera_point_target,
 		v3f camera_point_target);
 	void SendItemDef(session_t peer_id, IItemDefManager *itemdef, u16 protocol_version);
 	void SendNodeDef(session_t peer_id, INodeDefManager *nodedef, u16 protocol_version);
@@ -475,12 +475,12 @@ private:
 	void handleAdminChat(const ChatEventChat *evt);
 
 	// When called, connection mutex should be locked
-	RemoteClient* getClient(session_t peer_id,ClientState state_min = CS_Active);
-	RemoteClient* getClientNoEx(session_t peer_id,ClientState state_min = CS_Active);
+	RemoteClient* getClient(session_t peer_id, ClientState state_min = CS_Active);
+	RemoteClient* getClientNoEx(session_t peer_id, ClientState state_min = CS_Active);
 
 	// When called, environment mutex should be locked
 	std::string getPlayerName(session_t peer_id);
-	PlayerSAO* getPlayerSAO(session_t peer_id);
+	PlayerSAO *getPlayerSAO(session_t peer_id);
 
 	/*
 		Get a player from memory or creates one.

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -405,7 +405,7 @@ ServerMap & ServerEnvironment::getServerMap()
 	return *m_map;
 }
 
-RemotePlayer *ServerEnvironment::getPlayer(const SessionId peer_id)
+RemotePlayer *ServerEnvironment::getPlayer(const session_t peer_id)
 {
 	for (RemotePlayer *player : m_players) {
 		if (player->peer_id == peer_id)
@@ -523,7 +523,7 @@ void ServerEnvironment::savePlayer(RemotePlayer *player)
 }
 
 PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, bool *new_player,
-	SessionId peer_id, bool is_singleplayer)
+	session_t peer_id, bool is_singleplayer)
 {
 	PlayerSAO *playersao = new PlayerSAO(this, player, peer_id, is_singleplayer);
 	// Create player if it doesn't exist

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -405,7 +405,7 @@ ServerMap & ServerEnvironment::getServerMap()
 	return *m_map;
 }
 
-RemotePlayer *ServerEnvironment::getPlayer(const u16 peer_id)
+RemotePlayer *ServerEnvironment::getPlayer(const SessionId peer_id)
 {
 	for (RemotePlayer *player : m_players) {
 		if (player->peer_id == peer_id)
@@ -523,7 +523,7 @@ void ServerEnvironment::savePlayer(RemotePlayer *player)
 }
 
 PlayerSAO *ServerEnvironment::loadPlayer(RemotePlayer *player, bool *new_player,
-	u16 peer_id, bool is_singleplayer)
+	SessionId peer_id, bool is_singleplayer)
 {
 	PlayerSAO *playersao = new PlayerSAO(this, player, peer_id, is_singleplayer);
 	// Create player if it doesn't exist

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -219,7 +219,7 @@ public:
 	// Save players
 	void saveLoadedPlayers();
 	void savePlayer(RemotePlayer *player);
-	PlayerSAO *loadPlayer(RemotePlayer *player, bool *new_player, u16 peer_id,
+	PlayerSAO *loadPlayer(RemotePlayer *player, bool *new_player, SessionId peer_id,
 		bool is_singleplayer);
 	void addPlayer(RemotePlayer *player);
 	void removePlayer(RemotePlayer *player);
@@ -341,7 +341,7 @@ public:
 	void setStaticForActiveObjectsInBlock(v3s16 blockpos,
 		bool static_exists, v3s16 static_block=v3s16(0,0,0));
 
-	RemotePlayer *getPlayer(const u16 peer_id);
+	RemotePlayer *getPlayer(const SessionId peer_id);
 	RemotePlayer *getPlayer(const char* name);
 	u32 getPlayerCount() const { return m_players.size(); }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -219,7 +219,7 @@ public:
 	// Save players
 	void saveLoadedPlayers();
 	void savePlayer(RemotePlayer *player);
-	PlayerSAO *loadPlayer(RemotePlayer *player, bool *new_player, SessionId peer_id,
+	PlayerSAO *loadPlayer(RemotePlayer *player, bool *new_player, session_t peer_id,
 		bool is_singleplayer);
 	void addPlayer(RemotePlayer *player);
 	void removePlayer(RemotePlayer *player);
@@ -341,7 +341,7 @@ public:
 	void setStaticForActiveObjectsInBlock(v3s16 blockpos,
 		bool static_exists, v3s16 static_block=v3s16(0,0,0));
 
-	RemotePlayer *getPlayer(const SessionId peer_id);
+	RemotePlayer *getPlayer(const session_t peer_id);
 	RemotePlayer *getPlayer(const char* name);
 	u32 getPlayerCount() const { return m_players.size(); }
 

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -81,7 +81,7 @@ void TestConnection::testHelpers()
 {
 	// Some constants for testing
 	u32 proto_id = 0x12345678;
-	u16 peer_id = 123;
+	SessionId peer_id = 123;
 	u8 channel = 2;
 	SharedBuffer<u8> data1(1);
 	data1[0] = 100;
@@ -94,7 +94,7 @@ void TestConnection::testHelpers()
 		We should now have a packet with this data:
 		Header:
 			[0] u32 protocol_id
-			[4] u16 sender_peer_id
+			[4] SessionId sender_peer_id
 			[6] u8 channel
 		Data:
 			[7] u8 data1[0]
@@ -264,7 +264,7 @@ void TestConnection::testConnectSendReceive()
 		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
 	}
 
-	u16 peer_id_client = 2;
+	SessionId peer_id_client = 2;
 	/*
 		Send a large packet
 	*/
@@ -296,7 +296,7 @@ void TestConnection::testConnectSendReceive()
 
 		SharedBuffer<u8> recvdata;
 		infostream << "** running client.Receive()" << std::endl;
-		u16 peer_id = 132;
+		SessionId peer_id = 132;
 		u16 size = 0;
 		bool received = false;
 		u64 timems0 = porting::getTimeMs();

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -81,7 +81,7 @@ void TestConnection::testHelpers()
 {
 	// Some constants for testing
 	u32 proto_id = 0x12345678;
-	SessionId peer_id = 123;
+	session_t peer_id = 123;
 	u8 channel = 2;
 	SharedBuffer<u8> data1(1);
 	data1[0] = 100;
@@ -94,7 +94,7 @@ void TestConnection::testHelpers()
 		We should now have a packet with this data:
 		Header:
 			[0] u32 protocol_id
-			[4] SessionId sender_peer_id
+			[4] session_t sender_peer_id
 			[6] u8 channel
 		Data:
 			[7] u8 data1[0]
@@ -264,7 +264,7 @@ void TestConnection::testConnectSendReceive()
 		UASSERT(memcmp(*sentdata, *recvdata, recvdata.getSize()) == 0);
 	}
 
-	SessionId peer_id_client = 2;
+	session_t peer_id_client = 2;
 	/*
 		Send a large packet
 	*/
@@ -296,7 +296,7 @@ void TestConnection::testConnectSendReceive()
 
 		SharedBuffer<u8> recvdata;
 		infostream << "** running client.Receive()" << std::endl;
-		SessionId peer_id = 132;
+		session_t peer_id = 132;
 		u16 size = 0;
 		bool received = false;
 		u64 timems0 = porting::getTimeMs();


### PR DESCRIPTION
u16 peer_id is used everywhere, to be more consistent and permit some evolutions on this type in the future (i'm working on a PoC to rewrite the whole network stack), uniformize u16 peer_id to session_t peer_id

I know it's a boring PR but it permit to be safer on the peer_id type, such typedef should be used in many places to avoid type errors, when needed.