### PR TITLE
Server: affect bind_addr on constructor instead of start()

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1886,10 +1886,8 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 		return false;
 	}
 
-	server = new Server(map_dir, gamespec, simple_singleplayer_mode,
-			    bind_addr.isIPv6(), false);
-
-	server->start(bind_addr);
+	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr, false);
+	server->start();
 
 	return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -838,13 +838,13 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		try {
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec,
-					false, bind_addr.isIPv6(), true, &iface);
+					false, bind_addr, true, &iface);
 
 			g_term_console.setup(&iface, &kill, admin_nick);
 
 			g_term_console.start();
 
-			server.start(bind_addr);
+			server.start();
 			// Run server
 			dedicated_server_loop(server, kill);
 		} catch (const ModError &e) {
@@ -872,8 +872,8 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		try {
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec, false,
-				bind_addr.isIPv6(), true);
-			server.start(bind_addr);
+				bind_addr, true);
+			server.start();
 
 			// Run server
 			bool &kill = *porting::signal_handler_killstatus();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -149,10 +149,11 @@ Server::Server(
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		bool ipv6,
+		Address bind_addr,
 		bool dedicated,
 		ChatInterface *iface
 	):
+	m_bind_addr(bind_addr),
 	m_path_world(path_world),
 	m_gamespec(gamespec),
 	m_simple_singleplayer_mode(simple_singleplayer_mode),
@@ -161,7 +162,7 @@ Server::Server(
 	m_con(std::make_shared<con::Connection>(PROTOCOL_ID,
 			512,
 			CONNECTION_TIMEOUT,
-			ipv6,
+			m_bind_addr.isIPv6(),
 			this)),
 	m_itemdef(createItemDefManager()),
 	m_nodedef(createNodeDefManager()),
@@ -366,35 +367,33 @@ Server::~Server()
 	}
 }
 
-void Server::start(Address bind_addr)
+void Server::start()
 {
-	m_bind_addr = bind_addr;
-
-	infostream<<"Starting server on "
-			<< bind_addr.serializeString() <<"..."<<std::endl;
+	infostream << "Starting server on " << m_bind_addr.serializeString()
+			<< "..." << std::endl;
 
 	// Stop thread if already running
 	m_thread->stop();
 
 	// Initialize connection
 	m_con->SetTimeoutMs(30);
-	m_con->Serve(bind_addr);
+	m_con->Serve(m_bind_addr);
 
 	// Start thread
 	m_thread->start();
 
 	// ASCII art for the win!
 	actionstream
-	<<"        .__               __                   __   "<<std::endl
-	<<"  _____ |__| ____   _____/  |_  ____   _______/  |_ "<<std::endl
-	<<" /     \\|  |/    \\_/ __ \\   __\\/ __ \\ /  ___/\\   __\\"<<std::endl
-	<<"|  Y Y  \\  |   |  \\  ___/|  | \\  ___/ \\___ \\  |  |  "<<std::endl
-	<<"|__|_|  /__|___|  /\\___  >__|  \\___  >____  > |__|  "<<std::endl
-	<<"      \\/        \\/     \\/          \\/     \\/        "<<std::endl;
-	actionstream<<"World at ["<<m_path_world<<"]"<<std::endl;
-	actionstream<<"Server for gameid=\""<<m_gamespec.id
-			<<"\" listening on "<<bind_addr.serializeString()<<":"
-			<<bind_addr.getPort() << "."<<std::endl;
+		<< "        .__               __                   __   " << std::endl
+		<< "  _____ |__| ____   _____/  |_  ____   _______/  |_ " << std::endl
+		<< " /     \\|  |/    \\_/ __ \\   __\\/ __ \\ /  ___/\\   __\\" << std::endl
+		<< "|  Y Y  \\  |   |  \\  ___/|  | \\  ___/ \\___ \\  |  |  " << std::endl
+		<< "|__|_|  /__|___|  /\\___  >__|  \\___  >____  > |__|  " << std::endl
+		<< "      \\/        \\/     \\/          \\/     \\/        " << std::endl;
+	actionstream << "World at [" << m_path_world << "]" << std::endl;
+	actionstream << "Server for gameid=\"" << m_gamespec.id
+			<< "\" listening on " << m_bind_addr.serializeString() << ":"
+			<< m_bind_addr.getPort() << "." << std::endl;
 }
 
 void Server::stop()

--- a/src/server.h
+++ b/src/server.h
@@ -118,14 +118,14 @@ public:
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		bool ipv6,
+		Address bind_addr,
 		bool dedicated,
 		ChatInterface *iface = nullptr
 	);
 	~Server();
 	DISABLE_CLASS_COPY(Server);
 
-	void start(Address bind_addr);
+	void start();
 	void stop();
 	// This is mainly a way to pass the time to the server.
 	// Actual processing is done in an another thread.


### PR DESCRIPTION
bind_addr is already ready when using constructor as we read is.IPv6 from it, instead pass the whole address

Note: This change is backported from my network poc branch