### PR TITLE
Repositioning formspec item in delete world dialog

### DIFF
--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -30,7 +30,7 @@ end
 local function delete_world_buttonhandler(this, fields)
 	if fields["world_delete_confirm"] then
 		if this.data.delete_index > 0 and
-			this.data.delete_index <= #menudata.worldlist:get_raw_list() then
+				this.data.delete_index <= #menudata.worldlist:get_raw_list() then
 			core.delete_world(this.data.delete_index)
 			menudata.worldlist:refresh()
 			this:delete()

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -21,8 +21,7 @@ local function delete_world_formspec(dialogdata)
 		"size[10,2.5,true]" ..
 		"label[0.5,0.5;" ..
 		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
-		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" ..
-		minetest.colorize("#FFFF00", fgettext("Delete")) .. "]" ..
+		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
 		"button[7.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
 	return retval
 end

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -18,22 +18,11 @@
 
 local function delete_world_formspec(dialogdata)
 	local retval =
-		"size[9,4,true]" ..
+		"size[10,2.5,true]" ..
 		"label[0.5,0.5;" ..
-		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]"
-	if dialogdata.error_message then
-		retval = retval ..
-			"label[0.5,1.0;" ..
-			core.formspec_escape(dialogdata.error_message) .. "]"
-	else
-		retval = retval ..
-			"label[0.5,1.0;" ..
-			fgettext("To confirm, please retype the world's name which will be deleted.") .. "]"
-	end
-	retval = retval ..
-		"field[0.75,2.25;8,1;world_name;;;]" ..
-		"button[0.5,3.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
-		"button[6.0,3.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
+		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
+		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. minetest.colorize("#FFFF00", fgettext("Delete")) .. "]" ..
+		"button[7.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
 	return retval
 end
 
@@ -41,15 +30,9 @@ local function delete_world_buttonhandler(this, fields)
 	if fields["world_delete_confirm"] then
 		if this.data.delete_index > 0 and
 			this.data.delete_index <= #menudata.worldlist:get_raw_list() then
-			if this.data.delete_name == fields["world_name"] then
-				core.delete_world(this.data.delete_index)
-				menudata.worldlist:refresh()
-				this:delete()
-			elseif fields["world_name"] == "" then
-				this.data.error_message = nil
-			else
-				this.data.error_message = fgettext_ne("Wrong world name.")
-			end
+			core.delete_world(this.data.delete_index)
+			menudata.worldlist:refresh()
+			this:delete()
 		end
 		return true
 	end

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -19,11 +19,11 @@
 local function delete_world_formspec(dialogdata)
 
 	local retval =
-		"size[11.5,4.5,true]" ..
-		"label[2,2;" ..
+		"size[8,3,true]" ..
+		"label[0.5,0.5;" ..
 		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
-		"button[3.25,3.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
-		"button[5.75,3.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
+		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
+		"button[5.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
 	return retval
 end
 

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -32,8 +32,8 @@ local function delete_world_buttonhandler(this, fields)
 				this.data.delete_index <= #menudata.worldlist:get_raw_list() then
 			core.delete_world(this.data.delete_index)
 			menudata.worldlist:refresh()
-			this:delete()
 		end
+		this:delete()
 		return true
 	end
 

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -21,7 +21,8 @@ local function delete_world_formspec(dialogdata)
 		"size[10,2.5,true]" ..
 		"label[0.5,0.5;" ..
 		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
-		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. minetest.colorize("#FFFF00", fgettext("Delete")) .. "]" ..
+		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" ..
+		minetest.colorize("#FFFF00", fgettext("Delete")) .. "]" ..
 		"button[7.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
 	return retval
 end

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -17,39 +17,53 @@
 
 
 local function delete_world_formspec(dialogdata)
-
 	local retval =
-		"size[8,3,true]" ..
+		"size[9,4,true]" ..
 		"label[0.5,0.5;" ..
-		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]" ..
-		"button[0.5,1.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
-		"button[5.0,1.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
+		fgettext("Delete World \"$1\"?", dialogdata.delete_name) .. "]"
+	if dialogdata.error_message then
+		retval = retval ..
+			"label[0.5,1.0;" ..
+			core.formspec_escape(dialogdata.error_message) .. "]"
+	else
+		retval = retval ..
+			"label[0.5,1.0;" ..
+			fgettext("To confirm, please retype the world's name which will be deleted.") .. "]"
+	end
+	retval = retval ..
+		"field[0.75,2.25;8,1;world_name;;;]" ..
+		"button[0.5,3.5;2.5,0.5;world_delete_confirm;" .. fgettext("Delete") .. "]" ..
+		"button[6.0,3.5;2.5,0.5;world_delete_cancel;" .. fgettext("Cancel") .. "]"
 	return retval
 end
 
 local function delete_world_buttonhandler(this, fields)
 	if fields["world_delete_confirm"] then
-
 		if this.data.delete_index > 0 and
 			this.data.delete_index <= #menudata.worldlist:get_raw_list() then
-			core.delete_world(this.data.delete_index)
-			menudata.worldlist:refresh()
+			if this.data.delete_name == fields["world_name"] then
+				core.delete_world(this.data.delete_index)
+				menudata.worldlist:refresh()
+				this:delete()
+			elseif fields["world_name"] == "" then
+				this.data.error_message = nil
+			else
+				this.data.error_message = fgettext_ne("Wrong world name.")
+			end
 		end
-		this:delete()
 		return true
 	end
-	
+
 	if fields["world_delete_cancel"] then
 		this:delete()
 		return true
 	end
-	
+
 	return false
 end
 
 
-function create_delete_world_dlg(name_to_del,index_to_del)
-
+function create_delete_world_dlg(name_to_del, index_to_del)
 	assert(name_to_del ~= nil and type(name_to_del) == "string" and name_to_del ~= "")
 	assert(index_to_del ~= nil and type(index_to_del) == "number")
 
@@ -59,6 +73,6 @@ function create_delete_world_dlg(name_to_del,index_to_del)
 					nil)
 	retval.data.delete_name  = name_to_del
 	retval.data.delete_index = index_to_del
-	
+
 	return retval
 end


### PR DESCRIPTION
This is an attempt to fix #3458.

Resize formspec to smaller size.
Move "Delete" button and "Cancel" button so that they are far apart.
The position of the "Delete" button in Local Game tab doesn't intersect with "Delete" button in delete world dialog.
~"Delete" button has yellow text.~
~Need retyping world name to confirm deletion.~

![what it looks like](https://user-images.githubusercontent.com/4017302/35801347-994bca36-0a9e-11e8-97c1-aad020d64532.png)

(Old screenshot) https://user-images.githubusercontent.com/4017302/34338073-7f02dbec-e997-11e7-9591-dd365485e84d.PNG
(Older screenshot) https://user-images.githubusercontent.com/4017302/31133337-582570e2-a889-11e7-9fee-bb484b934e5b.png
(Much older screenshot) https://user-images.githubusercontent.com/4017302/31028927-07965338-a57a-11e7-9fee-a37a02c30c97.png