### PR TITLE
Fix attached particle spawners far from spawn

### DIFF
--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -320,7 +320,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 					// Need to apply this first or the following check
 					// will be wrong for attached spawners
 					if (is_attached)
-					  pos += attached_pos;
+						pos += attached_pos;
 
 					if (pos.getDistanceFrom(ppos) <= radius) {
 						v3f vel = random_v3f(m_minvel, m_maxvel);
@@ -384,7 +384,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 				// Need to apply this first or the following check
 				// will be wrong for attached spawners
 				if (is_attached)
-				  pos += attached_pos;
+					pos += attached_pos;
 
 				if (pos.getDistanceFrom(ppos) <= radius) {
 					v3f vel = random_v3f(m_minvel, m_maxvel);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -317,6 +317,11 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 					v3f ppos = m_player->getPosition() / BS;
 					v3f pos = random_v3f(m_minpos, m_maxpos);
 
+					// Need to apply this first or the following check
+					// will be wrong for attached spawners
+					if (is_attached)
+					  pos += attached_pos;
+
 					if (pos.getDistanceFrom(ppos) <= radius) {
 						v3f vel = random_v3f(m_minvel, m_maxvel);
 						v3f acc = random_v3f(m_minacc, m_maxacc);
@@ -324,7 +329,6 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 						if (is_attached) {
 							// Apply attachment yaw and position
 							pos.rotateXZBy(attached_yaw);
-							pos += attached_pos;
 							vel.rotateXZBy(attached_yaw);
 							acc.rotateXZBy(attached_yaw);
 						}
@@ -377,6 +381,11 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 				v3f ppos = m_player->getPosition() / BS;
 				v3f pos = random_v3f(m_minpos, m_maxpos);
 
+				// Need to apply this first or the following check
+				// will be wrong for attached spawners
+				if (is_attached)
+				  pos += attached_pos;
+
 				if (pos.getDistanceFrom(ppos) <= radius) {
 					v3f vel = random_v3f(m_minvel, m_maxvel);
 					v3f acc = random_v3f(m_minacc, m_maxacc);
@@ -384,7 +393,6 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 					if (is_attached) {
 						// Apply attachment yaw and position
 						pos.rotateXZBy(attached_yaw);
-						pos += attached_pos;
 						vel.rotateXZBy(attached_yaw);
 						acc.rotateXZBy(attached_yaw);
 					}


### PR DESCRIPTION
The performance feature where particle spawners far from the player don't spawn particles introduced a bug in attached particle spawners because the check did not take into account that the particle positions are relative to the object it is attached to.

I'm annoyed that I will have to wait for the 0.5 release for this to be in a stable version, since it seems like something that would have come up in a code review. I was using a particle trail as the visual representation of an entity (which was set up so that it was invisible).