### PR TITLE
Add additional nil checks for placer

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -255,11 +255,13 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 	local oldnode_under = core.get_node_or_nil(under)
 	local above = pointed_thing.above
 	local oldnode_above = core.get_node_or_nil(above)
-	local playername = placer:get_player_name()
+	local playername = placer and placer:get_player_name() or ""
 
 	if not oldnode_under or not oldnode_above then
-		core.log("info", playername .. " tried to place"
-			.. " node in unloaded position " .. core.pos_to_string(above))
+		local message_start = placer and (playername .. " tried to place") or
+			"Command issued to place"
+		core.log("info", message_start .. " node in unloaded position "
+			.. core.pos_to_string(above))
 		return itemstack, false
 	end
 
@@ -284,7 +286,8 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		place_to = {x = under.x, y = under.y, z = under.z}
 	end
 
-	if core.is_protected(place_to, playername) and
+	-- Do not check protection for nil placer
+	if placer and core.is_protected(place_to, playername) and
 			not minetest.check_player_privs(placer, "protection_bypass") then
 		core.log("action", playername
 				.. " tried to place " .. def.name
@@ -312,7 +315,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		}
 		newnode.param2 = core.dir_to_wallmounted(dir)
 	-- Calculate the direction for furnaces and chests and stuff
-	elseif (def.paramtype2 == "facedir" or
+	elseif placer and (def.paramtype2 == "facedir" or
 			def.paramtype2 == "colorfacedir") and not param2 then
 		local placer_pos = placer:getpos()
 		if placer_pos then

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -286,9 +286,8 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2)
 		place_to = {x = under.x, y = under.y, z = under.z}
 	end
 
-	-- Do not check protection for nil placer
-	if placer and core.is_protected(place_to, playername) and
-			not minetest.check_player_privs(placer, "protection_bypass") then
+	if core.is_protected(place_to, playername) and
+			not minetest.check_player_privs(playername, "protection_bypass") then
 		core.log("action", playername
 				.. " tried to place " .. def.name
 				.. " at protected position "

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2421,6 +2421,7 @@ Call these functions only at load time!
 * `minetest.register_on_placenode(func(pos, newnode, placer, oldnode, itemstack, pointed_thing))`
     * Called when a node has been placed
     * If return `true` no item is taken from `itemstack`
+    * `placer` may be nil
     * **Not recommended**; use `on_construct` or `after_place_node` in node definition
       whenever possible
 * `minetest.register_on_dignode(func(pos, oldnode, digger))`
@@ -4582,6 +4583,7 @@ Definition tables
         ^ Called after constructing node when node was placed using
           minetest.item_place_node / minetest.place_node
         ^ If return true no item is taken from itemstack
+    	^ `placer` may be nil
         ^ default: nil ]]
         after_dig_node = func(pos, oldnode, oldmetadata, digger), --[[
         ^ oldmetadata is in table format

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3207,6 +3207,7 @@ These functions return the leftover itemstack.
     * Returns true, if player `name` shouldn't be abled to dig at `pos` or do other
       actions, defineable by mods, due to some mod-defined ownership-like concept.
       Returns false or nil, if the player is allowed to do such actions.
+    * For `minetest.place_node`, `name` is set to `""`.
     * This function should be overridden by protection mods and should be used to
       check if a player can interact at a position.
     * This function should call the old version of itself if the position is not

--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -1270,7 +1270,7 @@ minetest.register_node("default:chest_locked", {
 	sounds = default.node_sound_wood_defaults(),
 	after_place_node = function(pos, placer)
 		local meta = minetest.get_meta(pos)
-		meta:set_string("owner", placer:get_player_name() or "")
+		meta:set_string("owner", placer and placer:get_player_name() or "")
 		meta:set_string("infotext", "Locked Chest (owned by "..
 				meta:get_string("owner")..")")
 	end,


### PR DESCRIPTION
core.item_place_node is called by default if minetest.place_node is called, but since 5a3b8e34b36a1f9b1f38f91483fc25d23b142f21, the placer is nil in this case, which did not check for nil.
Before 5a3b8e34b36a1f9b1f38f91483fc25d23b142f21, a dummy placer was used which had some, but not all methods of a player.
If this behaviour stays this way, minetest_game needs nil checks in several places as well.