### PR TITLE
Replace deprecated WINAPI GetVersionInfoEx

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,7 +268,7 @@ if(WIN32)
 	else() # Probably MinGW = GCC
 		set(PLATFORM_LIBS "")
 	endif()
-	set(PLATFORM_LIBS ws2_32.lib shlwapi.lib ${PLATFORM_LIBS})
+	set(PLATFORM_LIBS ws2_32.lib version.lib shlwapi.lib ${PLATFORM_LIBS})
 
 	# Zlib stuff
 	set(ZLIB_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/../../zlib/zlib-1.2.5"

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -197,11 +197,11 @@ std::string get_sysinfo()
 	#ifdef _WIN64
 	oss << "x86_64";
 	#else
-		BOOL is64 = FALSE;
-		if (IsWow64Process(GetCurrentProcess(), &is64) && is64)
-			oss << "x86_64"; // 32-bit app on 64-bit OS
-		else
-			oss << "x86";
+	BOOL is64 = FALSE;
+	if (IsWow64Process(GetCurrentProcess(), &is64) && is64)
+		oss << "x86_64"; // 32-bit app on 64-bit OS
+	else
+		oss << "x86";
 	#endif
 
 	delete[] lpVersionInfo;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#include <windows.h>
 	#include <wincrypt.h>
 	#include <algorithm>
+	#include <shlwapi.h>
 #endif
 #if !defined(_WIN32)
 	#include <unistd.h>
@@ -173,29 +174,38 @@ bool detectMSVCBuildDir(const std::string &path)
 std::string get_sysinfo()
 {
 #ifdef _WIN32
-	OSVERSIONINFO osvi;
-	std::ostringstream oss;
-	std::string tmp;
-	ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
-	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	GetVersionEx(&osvi);
-	tmp = osvi.szCSDVersion;
-	std::replace(tmp.begin(), tmp.end(), ' ', '_');
 
-	oss << "Windows/" << osvi.dwMajorVersion << "."
-		<< osvi.dwMinorVersion;
-	if (osvi.szCSDVersion[0])
-		oss << "-" << tmp;
-	oss << " ";
+	std::ostringstream oss;
+	LPSTR filePath = new char[MAX_PATH];
+	UINT blockSize;
+	VS_FIXEDFILEINFO *fixedFileInfo;
+
+	GetSystemDirectoryA(filePath, MAX_PATH);
+	PathAppendA(filePath, "kernel32.dll");
+
+	DWORD dwVersionSize = GetFileVersionInfoSizeA(filePath, NULL);
+	LPBYTE lpVersionInfo = new BYTE[dwVersionSize];
+
+	GetFileVersionInfoA(filePath, 0, dwVersionSize, lpVersionInfo);
+	VerQueryValueA(lpVersionInfo, "\\", (LPVOID *)&fixedFileInfo, &blockSize);
+
+	oss << "Windows/"
+		<< HIWORD(fixedFileInfo->dwProductVersionMS) << '.' // Major
+		<< LOWORD(fixedFileInfo->dwProductVersionMS) << '.' // Minor
+		<< HIWORD(fixedFileInfo->dwProductVersionLS) << ' '; // Build
+
 	#ifdef _WIN64
 	oss << "x86_64";
 	#else
-	BOOL is64 = FALSE;
-	if (IsWow64Process(GetCurrentProcess(), &is64) && is64)
-		oss << "x86_64"; // 32-bit app on 64-bit OS
-	else
-		oss << "x86";
+		BOOL is64 = FALSE;
+		if (IsWow64Process(GetCurrentProcess(), &is64) && is64)
+			oss << "x86_64"; // 32-bit app on 64-bit OS
+		else
+			oss << "x86";
 	#endif
+
+	delete[] lpVersionInfo;
+	delete[] filePath;
 
 	return oss.str();
 #else


### PR DESCRIPTION
The winapi [GetVersionInfoEx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx) is deprecated since Windows 8.1 SDK and does only return Windows 8 (6.2) on newer Versions (And prints a warning). One solution would be to manifest the minetest.exe as compatible with the newer Windows versions, but since MinGW builds are not manifested, this would not work there. 
Microsoft recommends to either read the version from kernel32.dll or read it from the Registry.
Since Minetest did never use the Registry, this PR reads the version from kernel32.dll 

[GetVersionInfoEx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx) might never removed in any future windows versions due to compatibility reasons, but it might removed in future SDK's