### PR TITLE
Simple decorations: Add 'param2_max' parameter for random param2

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4840,6 +4840,10 @@ Definition tables
     --  ^ If absent, the parameter 'height' is used as a constant.
         param2 = 0,
     --  ^ Param2 value of placed decoration node.
+    --  ^ If param2_max is not 0, this is the lower bound of the randomly selected param2.
+        param2_max = 0,
+    --  ^ Upper bound of the randomly selected param2.
+    --  ^ If absent, the parameter 'param2' is used as a constant.
 
         ----- Schematic-type parameters
         schematic = "foobar.mts",

--- a/src/mg_decoration.cpp
+++ b/src/mg_decoration.cpp
@@ -227,6 +227,9 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 	s16 height = (deco_height_max > 0) ?
 		pr->range(deco_height, deco_height_max) : deco_height;
 
+	u8 param2 = (deco_param2_max > 0) ?
+		pr->range(deco_param2, deco_param2_max) : deco_param2;
+
 	bool force_placement = (flags & DECO_FORCE_PLACEMENT);
 
 	const v3s16 &em = vm->m_area.getExtent();
@@ -239,7 +242,7 @@ size_t DecoSimple::generate(MMVManip *vm, PcgRandom *pr, v3s16 p)
 				!force_placement)
 			break;
 
-		vm->m_data[vi] = MapNode(c_place, 0, deco_param2);
+		vm->m_data[vi] = MapNode(c_place, 0, param2);
 	}
 
 	return 1;

--- a/src/mg_decoration.h
+++ b/src/mg_decoration.h
@@ -84,6 +84,7 @@ public:
 	s16 deco_height;
 	s16 deco_height_max;
 	u8 deco_param2;
+	u8 deco_param2_max;
 };
 
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -981,6 +981,7 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 {
 	int index = 1;
 	int param2;
+	int param2_max;
 
 	deco->deco_height     = getintfield_default(L, index, "height", 1);
 	deco->deco_height_max = getintfield_default(L, index, "height_max", 0);
@@ -993,6 +994,7 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 
 	size_t nnames = getstringlistfield(L, index, "decoration", &deco->m_nodenames);
 	deco->m_nnlistsizes.push_back(nnames);
+
 	if (nnames == 0) {
 		errorstream << "register_decoration: no decoration nodes "
 			"defined" << std::endl;
@@ -1000,12 +1002,16 @@ bool read_deco_simple(lua_State *L, DecoSimple *deco)
 	}
 
 	param2 = getintfield_default(L, index, "param2", 0);
-	if ((param2 < 0) || (param2 > 255)) {
-		errorstream << "register_decoration: param2 out of bounds (0-255)"
+	param2_max = getintfield_default(L, index, "param2_max", 0);
+
+	if (param2 < 0 || param2 > 255 || param2_max < 0 || param2_max > 255) {
+		errorstream << "register_decoration: param2 or param2_max out of bounds (0-255)"
 			<< std::endl;
 		return false;
 	}
+
 	deco->deco_param2 = (u8)param2;
+	deco->deco_param2_max = (u8)param2_max;
 
 	return true;
 }


### PR DESCRIPTION
If 'param2_max' is not used, parameter 'param2' works as before for
compatibility.
If 'param2_max' is used, 'param2' and 'param2_max' become the lower
and upper bounds of a per-decoration random param2.
////////////////////

![screenshot_20171008_222545](https://user-images.githubusercontent.com/3686677/31321331-7efe2bcc-ac7c-11e7-8161-53c8c2b88be0.png)

![screenshot_20171008_225840](https://user-images.githubusercontent.com/3686677/31321332-8447c70a-ac7c-11e7-8be6-cc1831fbd190.png)

This will allow variable height kelp in MTG but is useful for many things.
Allows random rotation of simple decorations.

Works like the existing 'height' and 'height_max':
If 'param2_max' is not set, 'param2' is used as a fixed value, as before to not break compatibility.
If 'param2_max' > 0 (0 is the default) then 'param2' and 'param2_max' become the lower and upper bounds of the random value.
So 0-3 creates random simple rotation NSEW. 0-23 creates random facedir rotation (24 orientations). 20-23 creates NSEW rotation of an upside down node etc.

For stacked decorations of height > 1 all nodes in the stack have the same param2.