### PR TITLE
Thread: fix a crash on Windows due to data race condition on Thread::m_start_finished_mutex

### DIFF
--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -74,8 +74,8 @@ Thread::~Thread()
 	kill();
 
 	// Make sure start finished mutex is unlocked before it's destroyed
-	m_start_finished_mutex.try_lock();
-	m_start_finished_mutex.unlock();
+	if (m_start_finished_mutex.try_lock())
+		m_start_finished_mutex.unlock();
 
 }
 
@@ -196,6 +196,10 @@ void Thread::threadProc(Thread *thr)
 	thr->m_retval = thr->run();
 
 	thr->m_running = false;
+	// Unlock m_start_finished_mutex to prevent data race condition on Windows.
+	// On Windows with VS2017 build TerminateThread is called and this mutex is not
+	// released. We try to unlock it from caller thread and it's refused by system.
+	thr->m_start_finished_mutex.unlock();
 	g_logger.deregisterThread();
 }
 


### PR DESCRIPTION
m_start_finished_mutex is not unlocked by thread when exiting the thread::run function.
On windows TerminateHandle kill the thread but doesn't release mutexes owned by it, it's a dangerous function.
On VS2017 when calling Thread destructor and trying to unlock, it's refused by system because mutex is not owned by this thread.