### PR TITLE
Make setting files per-world.

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -30,7 +30,7 @@ end
 local dialog_metatable = {
 	eventhandler = dialog_event_handler,
 	get_formspec = function(self)
-				if not self.hidden then return self.formspec(self.data) end
+				if not self.hidden then return self.formspec(self.data, self.name, self) end
 			end,
 	handle_buttons = function(self,fields)
 				if not self.hidden then return self.buttonhandler(self,fields) end

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -303,34 +303,38 @@ function is_server_protocol_compat_or_error(server_proto_min, server_proto_max)
 	return true
 end
 --------------------------------------------------------------------------------
-function menu_worldmt(selected, setting, value)
+function get_world_config(selected)
 	local world = menudata.worldlist:get_list()[selected]
 	if world then
 		local filename = world.path .. DIR_DELIM .. "world.mt"
 		local world_conf = Settings(filename)
-
-		if value then
-			if not world_conf:write() then
-				core.log("error", "Failed to write world config file")
-			end
-			world_conf:set(setting, value)
-			world_conf:write()
-		else
-			return world_conf:get(setting)
-		end
+		return world_conf
 	else
 		return nil
 	end
 end
 
-function menu_worldmt_legacy(selected)
-	local modes_names = {"creative_mode", "enable_damage", "server_announce"}
-	for _, mode_name in pairs(modes_names) do
-		local mode_val = menu_worldmt(selected, mode_name)
-		if mode_val then
-			core.settings:set(mode_name, mode_val)
-		else
-			menu_worldmt(selected, mode_name, core.settings:get(mode_name))
-		end
+function get_world_setting(selected, setting)
+	local world_conf = get_world_config(selected)
+	if not world_conf then return end
+	
+	local value = world_conf:get(setting)
+	if not value then -- return default
+		value = core.settings:get(setting)
+	end
+	return value
+end
+
+function set_world_setting(selected, setting, value)
+	local world_conf = get_world_config(selected)
+	if not world_conf then return end
+	
+	if value then
+		world_conf:set(setting, value)
+	else
+		world_conf:remove(setting)
+	end
+	if not world_conf:write() then
+		core.log("error", "Failed to write world config file")
 	end
 end

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -480,10 +480,13 @@ local search_string = ""
 local settings = full_settings
 local selected_setting = 1
 
-local function get_current_value(setting)
-	local value = core.settings:get(setting.name)
+local function get_current_value(conf, setting)
+	local value = conf:get(setting.name)
 	if value == nil then
-		value = setting.default
+		value = core.settings:get(setting.name)
+		if value == nil then
+			value = setting.default
+		end
 	end
 	return value
 end
@@ -530,7 +533,8 @@ end
 
 local checkboxes = {} -- handle checkboxes events
 
-local function create_change_setting_formspec(dialogdata)
+local function create_change_setting_formspec(dialogdata, name, this)
+	local conf = this.parent.data.settings
 	local setting = settings[selected_setting]
 	local height = 5.2
 	if setting.type == "noise_params_2d" or setting.type == "noise_params_3d" then
@@ -573,7 +577,7 @@ local function create_change_setting_formspec(dialogdata)
 
 	if setting.type == "bool" then
 		local selected_index
-		if core.is_yes(get_current_value(setting)) then
+		if core.is_yes(get_current_value(conf, setting)) then
 			selected_index = 2
 		else
 			selected_index = 1
@@ -589,7 +593,7 @@ local function create_change_setting_formspec(dialogdata)
 			-- translating value is not possible, since it's the value
 			--  that we set the setting to
 			formspec = formspec ..  core.formspec_escape(value) .. ","
-			if get_current_value(setting) == value then
+			if get_current_value(conf, setting) == value then
 				selected_index = index
 			end
 		end
@@ -601,7 +605,7 @@ local function create_change_setting_formspec(dialogdata)
 	elseif setting.type == "path" or setting.type == "filepath" then
 		local current_value = dialogdata.selected_path
 		if not current_value then
-			current_value = get_current_value(setting)
+			current_value = get_current_value(conf, setting)
 		end
 		formspec = formspec .. "field[0.5,4;7.5,1;te_setting_value;;"
 				.. core.formspec_escape(current_value) .. "]"
@@ -693,7 +697,7 @@ local function create_change_setting_formspec(dialogdata)
 	else
 		-- TODO: fancy input for float, int
 		local width = 10
-		local text = get_current_value(setting)
+		local text = get_current_value(conf, setting)
 		if dialogdata.error_message then
 			formspec = formspec .. "tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
@@ -712,15 +716,16 @@ end
 
 local function handle_change_setting_buttons(this, fields)
 	local setting = settings[selected_setting]
+	local conf = this.parent.data.settings
 	if fields["btn_done"] or fields["key_enter"] then
 		if setting.type == "bool" then
 			local new_value = fields["dd_setting_value"]
 			-- Note: new_value is the actual (translated) value shown in the dropdown
-			core.settings:set_bool(setting.name, new_value == fgettext("Enabled"))
+			conf:set_bool(setting.name, new_value == fgettext("Enabled"))
 
 		elseif setting.type == "enum" then
 			local new_value = fields["dd_setting_value"]
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 
 		elseif setting.type == "int" then
 			local new_value = tonumber(fields["te_setting_value"])
@@ -742,7 +747,7 @@ local function handle_change_setting_buttons(this, fields)
 				core.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 
 		elseif setting.type == "float" then
 			local new_value = tonumber(fields["te_setting_value"])
@@ -752,7 +757,7 @@ local function handle_change_setting_buttons(this, fields)
 				core.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 
 		elseif setting.type == "flags" then
 			local values = {}
@@ -765,7 +770,7 @@ local function handle_change_setting_buttons(this, fields)
 			checkboxes = {}
 
 			local new_value = table.concat(values, ", ")
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 
 		elseif setting.type == "noise_params_2d" or setting.type == "noise_params_3d" then
 			local np_flags = {}
@@ -791,20 +796,20 @@ local function handle_change_setting_buttons(this, fields)
 				lacunarity = fields["te_lacun"],
 				flags = table.concat(np_flags, ", ")
 			}
-			core.settings:set_np_group(setting.name, new_value)
+			conf:set_np_group(setting.name, new_value)
 
 		elseif setting.type == "v3f" then
 			local new_value = "("
 					.. fields["te_x"] .. ", "
 					.. fields["te_y"] .. ", "
 					.. fields["te_z"] .. ")"
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 
 		else
 			local new_value = fields["te_setting_value"]
-			core.settings:set(setting.name, new_value)
+			conf:set(setting.name, new_value)
 		end
-		core.settings:write()
+		conf:write()
 		this:delete()
 		return true
 	end
@@ -842,7 +847,28 @@ local function handle_change_setting_buttons(this, fields)
 	return false
 end
 
-local function create_settings_formspec(tabview, name, tabdata)
+local function filter_world_settings()
+	local current_level = 0
+	local settings = {}
+	local ignore_top_level_category = false
+	local world_settings_categories = {"Server / Singleplayer", "Client and Server", "Mapgen", "Games", "Mods"}
+	for _, entry in ipairs(full_settings) do
+		if entry.type == "category" and entry.level == 0 then
+			ignore_top_level_category = true
+			for _, allowed_catergory in ipairs(world_settings_categories) do
+				if entry.name == allowed_catergory then
+					ignore_top_level_category = false
+				end
+			end
+		end
+		if not ignore_top_level_category then
+			settings[#settings + 1] = entry
+		end
+	end
+	return settings
+end
+
+local function create_settings_formspec(tabdata)
 	local formspec = "size[12,6.5;true]" ..
 			"tablecolumns[color;tree;text,width=32;text]" ..
 			"tableoptions[background=#00000000;border=false]" ..
@@ -865,14 +891,14 @@ local function create_settings_formspec(tabview, name, tabdata)
 			formspec = formspec .. "#FFFF00," .. current_level .. "," .. fgettext(name) .. ",,"
 
 		elseif entry.type == "bool" then
-			local value = get_current_value(entry)
+			local value = get_current_value(tabdata.settings, entry)
 			if core.is_yes(value) then
 				value = fgettext("Enabled")
 			else
 				value = fgettext("Disabled")
 			end
 			formspec = formspec .. "," .. (current_level + 1) .. "," .. core.formspec_escape(name) .. ","
-					.. value .. ","
+				.. value .. ","
 
 		elseif entry.type == "key" then
 			-- ignore key settings, since we have a special dialog for them
@@ -883,7 +909,7 @@ local function create_settings_formspec(tabview, name, tabdata)
 
 		else
 			formspec = formspec .. "," .. (current_level + 1) .. "," .. core.formspec_escape(name) .. ","
-					.. core.formspec_escape(get_current_value(entry)) .. ","
+				.. core.formspec_escape(get_current_value(tabdata.settings, entry)) .. ","
 		end
 	end
 
@@ -901,6 +927,7 @@ local function create_settings_formspec(tabview, name, tabdata)
 end
 
 local function handle_settings_buttons(this, fields, tabname, tabdata)
+	local conf = this.data.settings
 	local list_enter = false
 	if fields["list_settings"] then
 		selected_setting = core.get_table_index("list_settings")
@@ -908,9 +935,9 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 			-- Directly toggle booleans
 			local setting = settings[selected_setting]
 			if setting and setting.type == "bool" then
-				local current_value = get_current_value(setting)
-				core.settings:set_bool(setting.name, not core.is_yes(current_value))
-				core.settings:write()
+				local current_value = get_current_value(conf, setting)
+				conf:set_bool(setting.name, not core.is_yes(current_value))
+				conf:write()
 				return true
 			else
 				list_enter = true
@@ -944,7 +971,11 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		else
 			-- Search for setting
 			search_string = fields.search_string
-			settings, selected_setting = filter_settings(full_settings, search_string)
+			local complete_settings = full_settings
+			if this.name == "settings_world" then
+				complete_settings = filter_world_settings()
+			end
+			settings, selected_setting = filter_settings(complete_settings, search_string)
 			core.update_formspec(this:get_formspec())
 		end
 		return true
@@ -967,11 +998,11 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		if setting and setting.type ~= "category" then
 			if setting.type == "noise_params_2d"
 					or setting.type == "noise_params_3d" then
-				core.settings:set_np_group(setting.name, setting.default_table)
+			conf:set(setting.name, setting.default)
 			else
-				core.settings:set(setting.name, setting.default)
+				conf:set(setting.name, setting.default)
 			end
-			core.settings:write()
+			conf:write()
 			core.update_formspec(this:get_formspec())
 		end
 		return true
@@ -993,12 +1024,23 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 end
 
 function create_adv_settings_dlg()
+	settings = full_settings
 	local dlg = dialog_create("settings_advanced",
-				create_settings_formspec,
-				handle_settings_buttons,
-				nil)
+		create_settings_formspec,
+		handle_settings_buttons,
+		nil)
+	dlg.data.settings = core.settings
+	return dlg
+end
 
-				return dlg
+function create_world_settings_dlg()
+	local dlg = dialog_create("settings_world",
+		create_settings_formspec,
+		handle_settings_buttons,
+		nil)
+
+	settings = filter_world_settings()
+	return dlg
 end
 
 -- Uncomment to generate minetest.conf.example and settings_translation_file.cpp

--- a/doc/fst_api.txt
+++ b/doc/fst_api.txt
@@ -95,7 +95,7 @@ dialog_create(name, cbf_formspec, cbf_button_handler, cbf_events)
 ^ create a dialog component
 ^ name: name of component (unique per ui)
 ^ cbf_formspec: function to be called to get formspec
-	function(dialogdata)
+	function(dialogdata, name, dialog)
 ^ cbf_button_handler: function to handle buttons
 	function(dialog, fields)
 ^ cbf_events: function to handle events

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -87,7 +87,8 @@ Client::Client(
 		tsrc, this
 	),
 	m_particle_manager(&m_env),
-	m_con(new con::Connection(PROTOCOL_ID, 512, CONNECTION_TIMEOUT, ipv6, this)),
+	m_con(new con::Connection(PROTOCOL_ID, 512, CONNECTION_TIMEOUT,
+			g_settings->getU16("max_packets_per_iteration"), ipv6, this)),
 	m_address_name(address_name),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
 	m_last_chat_message_sent(time(NULL)),
@@ -735,7 +736,7 @@ void Client::initLocalMapSaving(const Address &address,
 
 	fs::CreateAllDirs(world_path);
 
-	m_localdb = new MapDatabaseSQLite3(world_path);
+	m_localdb = new MapDatabaseSQLite3(world_path, g_settings);
 	m_localdb->beginSave();
 	actionstream << "Local map saving started, map will be saved at '" << world_path << "'" << std::endl;
 }

--- a/src/client.h
+++ b/src/client.h
@@ -38,6 +38,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "network/address.h"
 #include "network/peerhandler.h"
 #include <fstream>
+#include "settings.h"
 
 #define CLIENT_CHAT_MESSAGE_LIMIT_PER_10S 10.0f
 
@@ -431,6 +432,11 @@ public:
 	bool leaveModChannel(const std::string &channel);
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
+
+	Settings *getSettings()
+	{
+		return g_settings;
+	}
 
 private:
 

--- a/src/client.h
+++ b/src/client.h
@@ -115,6 +115,14 @@ private:
 class ClientScripting;
 struct GameUIFlags;
 
+struct ServerInfo {
+	bool enable_damage;
+	bool creative_mode;
+	bool server_announce;
+	bool enable_pvp;
+	std::string server_name;
+};
+
 class Client : public con::PeerHandler, public InventoryManager, public IGameDef
 {
 public:
@@ -230,6 +238,7 @@ public:
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
 	void handleCommand_CSMFlavourLimits(NetworkPacket *pkt);
+	void handleCommand_ServerInfo(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -433,11 +442,9 @@ public:
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
 
-	Settings *getSettings()
-	{
-		return g_settings;
-	}
+	Settings *getSettings() { return g_settings; }
 
+	const ServerInfo *getServerInfo() const { return &m_server_info; }
 private:
 
 	// Virtual methods from con::PeerHandler
@@ -596,4 +603,6 @@ private:
 	u32 m_csm_noderange_limit = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+
+	ServerInfo m_server_info;
 };

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -611,14 +611,13 @@ u64 RemoteClient::uptime() const
 	return porting::getTimeS() - m_connection_time;
 }
 
-ClientInterface::ClientInterface(const std::shared_ptr<con::Connection> & con)
+ClientInterface::ClientInterface()
 :
-	m_con(con),
 	m_env(NULL),
 	m_print_info_timer(0.0f)
 {
-
 }
+
 ClientInterface::~ClientInterface()
 {
 	/*
@@ -632,6 +631,11 @@ ClientInterface::~ClientInterface()
 			delete client_it.second;
 		}
 	}
+}
+
+void ClientInterface::SetConnection(const std::shared_ptr<con::Connection> & con)
+{
+	m_con = con;
 }
 
 std::vector<session_t> ClientInterface::getClientIDs(ClientState min_state)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -422,8 +422,10 @@ public:
 
 	friend class Server;
 
-	ClientInterface(const std::shared_ptr<con::Connection> &con);
+	ClientInterface();
 	~ClientInterface();
+
+	void SetConnection(const std::shared_ptr<con::Connection> &con);
 
 	/* run sync step */
 	void step(float dtime);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1185,7 +1185,7 @@ int PlayerSAO::punch(v3f dir,
 		return 0;
 
 	// No effect if PvP disabled
-	if (!g_settings->getBool("enable_pvp")) {
+	if (!m_env->getGameDef()->getSettings()->getBool("enable_pvp")) {
 		if (puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
 			std::string str = gob_cmd_punched(0, getHP());
 			// create message and add to list
@@ -1254,7 +1254,8 @@ void PlayerSAO::setHP(s16 hp)
 	else if (hp > m_prop.hp_max)
 		hp = m_prop.hp_max;
 
-	if (hp < oldhp && !g_settings->getBool("enable_damage")) {
+	Settings *settings = m_env->getGameDef()->getSettings();
+	if (hp < oldhp && !settings->getBool("enable_damage")) {
 		return;
 	}
 
@@ -1374,7 +1375,7 @@ std::string PlayerSAO::getPropertyPacket()
 bool PlayerSAO::checkMovementCheat()
 {
 	if (isAttached() || m_is_singleplayer ||
-			g_settings->getBool("disable_anticheat")) {
+			m_env->getGameDef()->getSettings()->getBool("disable_anticheat")) {
 		m_last_good_position = m_base_position;
 		return false;
 	}

--- a/src/database-dummy.h
+++ b/src/database-dummy.h
@@ -35,7 +35,7 @@ public:
 	void savePlayer(RemotePlayer *player) {}
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao) { return true; }
 	bool removePlayer(const std::string &name) { return true; }
-	void listPlayers(std::vector<std::string> &res) {}
+	void listPlayers(std::vector<std::string> &res, Settings *settings) {}
 
 	void beginSave() {}
 	void endSave() {}

--- a/src/database-files.cpp
+++ b/src/database-files.cpp
@@ -60,7 +60,7 @@ void PlayerDatabaseFiles::savePlayer(RemotePlayer *player)
 	std::string savedir = m_savedir + DIR_DELIM;
 	std::string path = savedir + player->getName();
 	bool path_found = false;
-	RemotePlayer testplayer("", NULL);
+	RemotePlayer testplayer("", NULL, g_settings);
 
 	for (u32 i = 0; i < PLAYER_FILE_ALTERNATE_TRIES && !path_found; i++) {
 		if (!fs::PathExists(path)) {
@@ -105,7 +105,7 @@ bool PlayerDatabaseFiles::removePlayer(const std::string &name)
 	std::string players_path = m_savedir + DIR_DELIM;
 	std::string path = players_path + name;
 
-	RemotePlayer temp_player("", NULL);
+	RemotePlayer temp_player("", NULL, g_settings);
 	for (u32 i = 0; i < PLAYER_FILE_ALTERNATE_TRIES; i++) {
 		// Open file and deserialize
 		std::ifstream is(path.c_str(), std::ios_base::binary);
@@ -151,7 +151,7 @@ bool PlayerDatabaseFiles::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	return false;
 }
 
-void PlayerDatabaseFiles::listPlayers(std::vector<std::string> &res)
+void PlayerDatabaseFiles::listPlayers(std::vector<std::string> &res, Settings *settings)
 {
 	std::vector<fs::DirListNode> files = fs::GetDirListing(m_savedir);
 	// list files into players directory
@@ -167,7 +167,7 @@ void PlayerDatabaseFiles::listPlayers(std::vector<std::string> &res)
 		if (!is.good())
 			continue;
 
-		RemotePlayer player(filename.c_str(), NULL);
+		RemotePlayer player(filename.c_str(), NULL, settings);
 		// Null env & dummy peer_id
 		PlayerSAO playerSAO(NULL, &player, 15789, false);
 

--- a/src/database-files.h
+++ b/src/database-files.h
@@ -34,7 +34,7 @@ public:
 	void savePlayer(RemotePlayer *player);
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);
 	bool removePlayer(const std::string &name);
-	void listPlayers(std::vector<std::string> &res);
+	void listPlayers(std::vector<std::string> &res, Settings *settings);
 
 private:
 	void serialize(std::ostringstream &os, RemotePlayer *player);

--- a/src/database-postgresql.cpp
+++ b/src/database-postgresql.cpp
@@ -615,7 +615,7 @@ bool PlayerDatabasePostgreSQL::removePlayer(const std::string &name)
 	return true;
 }
 
-void PlayerDatabasePostgreSQL::listPlayers(std::vector<std::string> &res)
+void PlayerDatabasePostgreSQL::listPlayers(std::vector<std::string> &res, Settings *settings)
 {
 	verifyDatabase();
 

--- a/src/database-postgresql.h
+++ b/src/database-postgresql.h
@@ -135,7 +135,7 @@ public:
 	void savePlayer(RemotePlayer *player);
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);
 	bool removePlayer(const std::string &name);
-	void listPlayers(std::vector<std::string> &res);
+	void listPlayers(std::vector<std::string> &res, Settings *settings);
 
 protected:
 	virtual void createDatabase();

--- a/src/database-redis.cpp
+++ b/src/database-redis.cpp
@@ -32,18 +32,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 
 
-Database_Redis::Database_Redis(Settings &conf)
+Database_Redis::Database_Redis(Settings* conf)
 {
 	std::string tmp;
 	try {
-		tmp = conf.get("redis_address");
-		hash = conf.get("redis_hash");
+		tmp = conf->get("redis_address");
+		hash = conf->get("redis_hash");
 	} catch (SettingNotFoundException &) {
 		throw SettingNotFoundException("Set redis_address and "
 			"redis_hash in world.mt to use the redis backend");
 	}
 	const char *addr = tmp.c_str();
-	int port = conf.exists("redis_port") ? conf.getU16("redis_port") : 6379;
+	int port = conf->exists("redis_port") ? conf->getU16("redis_port") : 6379;
 	// if redis_address contains '/' assume unix socket, else hostname/ip
 	ctx = tmp.find('/') != std::string::npos ? redisConnectUnix(addr) : redisConnect(addr, port);
 	if (!ctx) {
@@ -53,8 +53,8 @@ Database_Redis::Database_Redis(Settings &conf)
 		redisFree(ctx);
 		throw DatabaseException(err);
 	}
-	if (conf.exists("redis_password")) {
-		tmp = conf.get("redis_password");
+	if (conf->exists("redis_password")) {
+		tmp = conf->get("redis_password");
 		redisReply *reply = static_cast<redisReply *>(redisCommand(ctx, "AUTH %s", tmp.c_str()));
 		if (!reply)
 			throw DatabaseException("Redis authentication failed");

--- a/src/database-redis.h
+++ b/src/database-redis.h
@@ -32,7 +32,7 @@ class Settings;
 class Database_Redis : public MapDatabase
 {
 public:
-	Database_Redis(Settings &conf);
+	Database_Redis(Settings *conf);
 	~Database_Redis();
 
 	void beginSave();

--- a/src/database-sqlite3.cpp
+++ b/src/database-sqlite3.cpp
@@ -113,9 +113,10 @@ int Database_SQLite3::busyHandler(void *data, int count)
 }
 
 
-Database_SQLite3::Database_SQLite3(const std::string &savedir, const std::string &dbname) :
+Database_SQLite3::Database_SQLite3(const std::string &savedir, const std::string &dbname, Settings *conf) :
 	m_savedir(savedir),
-	m_dbname(dbname)
+	m_dbname(dbname),
+	m_conf(conf)
 {
 }
 
@@ -164,7 +165,7 @@ void Database_SQLite3::openDatabase()
 	}
 
 	std::string query_str = std::string("PRAGMA synchronous = ")
-			 + itos(g_settings->getU16("sqlite_synchronous"));
+			 + itos(m_conf->getU16("sqlite_synchronous"));
 	SQLOK(sqlite3_exec(m_database, query_str.c_str(), NULL, NULL, NULL),
 		"Failed to modify sqlite3 synchronous mode");
 	SQLOK(sqlite3_exec(m_database, "PRAGMA foreign_keys = ON", NULL, NULL, NULL),
@@ -197,8 +198,8 @@ Database_SQLite3::~Database_SQLite3()
  * Map database
  */
 
-MapDatabaseSQLite3::MapDatabaseSQLite3(const std::string &savedir):
-	Database_SQLite3(savedir, "map"),
+MapDatabaseSQLite3::MapDatabaseSQLite3(const std::string &savedir, Settings *conf):
+	Database_SQLite3(savedir, "map", conf),
 	MapDatabase()
 {
 }
@@ -323,8 +324,8 @@ void MapDatabaseSQLite3::listAllLoadableBlocks(std::vector<v3s16> &dst)
  * Player Database
  */
 
-PlayerDatabaseSQLite3::PlayerDatabaseSQLite3(const std::string &savedir):
-	Database_SQLite3(savedir, "players"),
+PlayerDatabaseSQLite3::PlayerDatabaseSQLite3(const std::string &savedir, Settings *conf):
+	Database_SQLite3(savedir, "players", conf),
 	PlayerDatabase()
 {
 }
@@ -595,7 +596,7 @@ bool PlayerDatabaseSQLite3::removePlayer(const std::string &name)
 	return true;
 }
 
-void PlayerDatabaseSQLite3::listPlayers(std::vector<std::string> &res)
+void PlayerDatabaseSQLite3::listPlayers(std::vector<std::string> &res, Settings *settings)
 {
 	verifyDatabase();
 

--- a/src/database-sqlite3.h
+++ b/src/database-sqlite3.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include "database.h"
 #include "exceptions.h"
+#include "settings.h"
 
 extern "C" {
 #include "sqlite3.h"
@@ -38,7 +39,7 @@ public:
 
 	bool initialized() const { return m_initialized; }
 protected:
-	Database_SQLite3(const std::string &savedir, const std::string &dbname);
+	Database_SQLite3(const std::string &savedir, const std::string &dbname, Settings *conf);
 
 	// Open and initialize the database if needed
 	void verifyDatabase();
@@ -125,6 +126,8 @@ private:
 	sqlite3_stmt *m_stmt_begin = nullptr;
 	sqlite3_stmt *m_stmt_end = nullptr;
 
+	Settings *m_conf = nullptr;
+
 	s64 m_busy_handler_data[2];
 
 	static int busyHandler(void *data, int count);
@@ -133,7 +136,7 @@ private:
 class MapDatabaseSQLite3 : private Database_SQLite3, public MapDatabase
 {
 public:
-	MapDatabaseSQLite3(const std::string &savedir);
+	MapDatabaseSQLite3(const std::string &savedir, Settings *conf);
 	virtual ~MapDatabaseSQLite3();
 
 	bool saveBlock(const v3s16 &pos, const std::string &data);
@@ -160,13 +163,13 @@ private:
 class PlayerDatabaseSQLite3 : private Database_SQLite3, public PlayerDatabase
 {
 public:
-	PlayerDatabaseSQLite3(const std::string &savedir);
+	PlayerDatabaseSQLite3(const std::string &savedir, Settings *conf);
 	virtual ~PlayerDatabaseSQLite3();
 
 	void savePlayer(RemotePlayer *player);
 	bool loadPlayer(RemotePlayer *player, PlayerSAO *sao);
 	bool removePlayer(const std::string &name);
-	void listPlayers(std::vector<std::string> &res);
+	void listPlayers(std::vector<std::string> &res, Settings *settings);
 
 protected:
 	virtual void createDatabase();

--- a/src/database.h
+++ b/src/database.h
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Lesser General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-
 #pragma once
 
 #include <string>
@@ -24,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v3d.h"
 #include "irrlichttypes.h"
 #include "util/basic_macros.h"
+#include "settings.h"
 
 class Database
 {
@@ -59,5 +59,5 @@ public:
 	virtual void savePlayer(RemotePlayer *player) = 0;
 	virtual bool loadPlayer(RemotePlayer *player, PlayerSAO *sao) = 0;
 	virtual bool removePlayer(const std::string &name) = 0;
-	virtual void listPlayers(std::vector<std::string> &res) = 0;
+	virtual void listPlayers(std::vector<std::string> &res, Settings *settings) = 0;
 };

--- a/src/dungeongen.cpp
+++ b/src/dungeongen.cpp
@@ -84,7 +84,7 @@ DungeonGen::DungeonGen(INodeDefManager *ndef,
 }
 
 
-void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
+void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax, bool project_dungeons)
 {
 	assert(vm);
 
@@ -95,8 +95,6 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	float nval_density = NoisePerlin3D(&dp.np_density, nmin.X, nmin.Y, nmin.Z, dp.seed);
 	if (nval_density < 1.0f)
 		return;
-
-	static const bool preserve_ignore = !g_settings->getBool("projecting_dungeons");
 
 	this->vm = vm;
 	this->blockseed = bseed;
@@ -115,7 +113,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 				for (s16 x = nmin.X; x <= nmax.X; x++) {
 					content_t c = vm->m_data[i].getContent();
 					if (c == CONTENT_AIR || c == dp.c_water ||
-							(preserve_ignore && c == CONTENT_IGNORE) ||
+							(!project_dungeons && c == CONTENT_IGNORE) ||
 							c == dp.c_river_water)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;

--- a/src/dungeongen.h
+++ b/src/dungeongen.h
@@ -86,7 +86,7 @@ public:
 		GenerateNotifier *gennotify, DungeonParams *dparams);
 
 	void generate(MMVManip *vm, u32 bseed,
-		v3s16 full_node_min, v3s16 full_node_max);
+		v3s16 full_node_min, v3s16 full_node_max, bool project_dungeons);
 
 	void makeDungeon(v3s16 start_padding);
 	void makeRoom(v3s16 roomsize, v3s16 roomplace);

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -126,20 +126,21 @@ EmergeManager::EmergeManager(Server *server)
 	// This is because the *only* thread ever starting or stopping
 	// EmergeThreads should be the ServerThread.
 
-	enable_mapgen_debug_info = g_settings->getBool("enable_mapgen_debug_info");
+	Settings *settings = server->getSettings();
+	enable_mapgen_debug_info = settings->getBool("enable_mapgen_debug_info");
 
 	// If unspecified, leave a proc for the main thread and one for
 	// some other misc thread
 	s16 nthreads = 0;
-	if (!g_settings->getS16NoEx("num_emerge_threads", nthreads))
+	if (!settings->getS16NoEx("num_emerge_threads", nthreads))
 		nthreads = Thread::getNumberOfProcessors() - 2;
 	if (nthreads < 1)
 		nthreads = 1;
 
-	m_qlimit_total = g_settings->getU16("emergequeue_limit_total");
-	if (!g_settings->getU16NoEx("emergequeue_limit_diskonly", m_qlimit_diskonly))
+	m_qlimit_total = settings->getU16("emergequeue_limit_total");
+	if (!settings->getU16NoEx("emergequeue_limit_diskonly", m_qlimit_diskonly))
 		m_qlimit_diskonly = nthreads * 5 + 1;
-	if (!g_settings->getU16NoEx("emergequeue_limit_generate", m_qlimit_generate))
+	if (!settings->getU16NoEx("emergequeue_limit_generate", m_qlimit_generate))
 		m_qlimit_generate = nthreads + 1;
 
 	// don't trust user input for something very important like this
@@ -632,8 +633,7 @@ void *EmergeThread::run()
 				ScopeProfiler sp(g_profiler,
 					"EmergeThread: Mapgen::makeChunk", SPT_AVG);
 				TimeTaker t("mapgen::make_block()");
-
-				m_mapgen->makeChunk(&bmdata);
+				m_mapgen->makeChunk(&bmdata, m_server->getSettings());
 
 				if (!enable_mapgen_debug_info)
 					t.stop(true); // Hide output

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -33,12 +33,13 @@ Environment::Environment(IGameDef *gamedef):
 	m_day_count(0),
 	m_gamedef(gamedef)
 {
-	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
-	m_cache_active_block_mgmt_interval = g_settings->getFloat("active_block_mgmt_interval");
-	m_cache_abm_interval = g_settings->getFloat("abm_interval");
-	m_cache_nodetimer_interval = g_settings->getFloat("nodetimer_interval");
+	Settings *conf = gamedef->getSettings();
+	m_cache_enable_shaders = conf->getBool("enable_shaders");
+	m_cache_active_block_mgmt_interval = conf->getFloat("active_block_mgmt_interval");
+	m_cache_abm_interval = conf->getFloat("abm_interval");
+	m_cache_nodetimer_interval = conf->getFloat("nodetimer_interval");
 
-	m_time_of_day = g_settings->getU32("world_start_time");
+	m_time_of_day = conf->getU32("world_start_time");
 	m_time_of_day_f = (float)m_time_of_day / 24000.0f;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4765,39 +4765,41 @@ void Game::showPauseMenu()
 		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
 		<< "\n"
 		<<  strgettext("Game info:") << "\n";
-	const std::string &address = client->getAddressName();
+	const ServerInfo *server_info = client->getServerInfo();
+
 	static const std::string mode = strgettext("- Mode: ");
+	static const std::string on = strgettext("On");
+	static const std::string off = strgettext("Off");
+
+	const std::string &damage = server_info->enable_damage ? on : off;
+	const std::string &creative = server_info->creative_mode ? on : off;
+	const std::string &announced = server_info->server_announce ? on : off;
+	const std::string &pvp = server_info->enable_pvp ? on : off;
+
+	const std::string &address = client->getAddressName();
+	std::string server_name = server_info->server_name;
+	str_formspec_escape(server_name);
+
+	std::string connection_info = "";
 	if (!simple_singleplayer_mode) {
 		Address serverAddress = client->getServerAddress();
 		if (!address.empty()) {
-			os << mode << strgettext("Remote server") << "\n"
-					<< strgettext("- Address: ") << address;
+			os << mode << strgettext("Remote server") << "\n";
+			connection_info += strgettext("- Address: ") + address + "\n";
 		} else {
-			os << mode << strgettext("Hosting server");
+			os << mode << strgettext("Hosting server") << "\n";
 		}
-		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
+		connection_info += strgettext("- Port: ") + std::to_string(serverAddress.getPort()) + "\n";
 	} else {
 		os << mode << strgettext("Singleplayer") << "\n";
 	}
-	if (simple_singleplayer_mode || address.empty()) {
-		static const std::string on = strgettext("On");
-		static const std::string off = strgettext("Off");
-		const std::string &damage = g_settings->getBool("enable_damage") ? on : off;
-		const std::string &creative = g_settings->getBool("creative_mode") ? on : off;
-		const std::string &announced = g_settings->getBool("server_announce") ? on : off;
-		os << strgettext("- Damage: ") << damage << "\n"
-				<< strgettext("- Creative Mode: ") << creative << "\n";
-		if (!simple_singleplayer_mode) {
-			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
-			os << strgettext("- PvP: ") << pvp << "\n"
-					<< strgettext("- Public: ") << announced << "\n";
-			std::string server_name = g_settings->get("server_name");
-			str_formspec_escape(server_name);
-			if (announced == on && !server_name.empty())
-				os << strgettext("- Server Name: ") << server_name;
 
-		}
-	}
+	if (announced == on && !server_name.empty())
+		os << strgettext("- Server Name: ") << server_name << "\n";
+	os << connection_info << strgettext("- Damage: ") << damage << "\n"
+			<< strgettext("- Creative Mode: ") << creative << "\n";
+	os << strgettext("- PvP: ") << pvp << "\n"
+			<< strgettext("- Public: ") << announced;
 	os << ";]";
 
 	/* Create menu */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -55,6 +55,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "raycast.h"
 #include "server.h"
 #include "settings.h"
+#include "defaultsettings.h"
 #include "shader.h"
 #include "sky.h"
 #include "subgame.h"
@@ -918,7 +919,6 @@ bool nodePlacementPrediction(Client &client, const ItemDefinition &playeritem_de
 				    << ") - Position not loaded" << std::endl;
 		}
 	}
-
 	return false;
 }
 
@@ -1866,22 +1866,28 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 {
 	showOverlayMessage("Creating server...", 0, 5);
 
-	std::string bind_str = g_settings->get("bind_address");
+	Settings conf;
+	set_default_settings(&conf);
+	std::string server_config_filepath = map_dir + DIR_DELIM + "world.mt";
+	conf.readConfigFile(server_config_filepath.c_str());
+	override_default_settings(&conf, g_settings);
+
+	std::string bind_str = conf.get("bind_address");
 	Address bind_addr(0, 0, 0, 0, port);
 
-	if (g_settings->getBool("ipv6_server")) {
+	if (conf.getBool("ipv6_server")) {
 		bind_addr.setAddress((IPv6AddressBytes *) NULL);
 	}
 
 	try {
-		bind_addr.Resolve(bind_str.c_str());
+		bind_addr.Resolve(bind_str.c_str(), conf.getBool("enable_ipv6"));
 	} catch (ResolveError &e) {
 		infostream << "Resolving bind address \"" << bind_str
 			   << "\" failed: " << e.what()
 			   << " -- Listening on all addresses." << std::endl;
 	}
 
-	if (bind_addr.isIPv6() && !g_settings->getBool("enable_ipv6")) {
+	if (bind_addr.isIPv6() && !conf.getBool("enable_ipv6")) {
 		*error_message = "Unable to listen on " +
 				bind_addr.serializeString() +
 				" because IPv6 is disabled";
@@ -2098,7 +2104,7 @@ bool Game::connectToServer(const std::string &playername,
 	Address connect_address(0, 0, 0, 0, port);
 
 	try {
-		connect_address.Resolve(address->c_str());
+		connect_address.Resolve(address->c_str(), g_settings->getBool("enable_ipv6"));
 
 		if (connect_address.isZero()) { // i.e. INADDR_ANY, IN6ADDR_ANY
 			//connect_address.Resolve("localhost");

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -35,6 +35,7 @@ class EmergeManager;
 class Camera;
 class ModChannel;
 class ModMetadata;
+class Settings;
 
 namespace irr { namespace scene {
 	class IAnimatedMesh;
@@ -74,6 +75,7 @@ public:
 	IRollbackManager *rollback() { return getRollbackManager(); }
 
 	virtual const std::vector<ModSpec> &getMods() const = 0;
+	virtual Settings* getSettings() = 0;
 	virtual const ModSpec* getModSpec(const std::string &modname) const = 0;
 	virtual std::string getWorldPath() const { return ""; }
 	virtual std::string getModStoragePath() const = 0;

--- a/src/map.h
+++ b/src/map.h
@@ -403,7 +403,7 @@ public:
 	/*
 		Database functions
 	*/
-	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir, Settings &conf);
+	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir, Settings *conf);
 
 	// Returns true if the database file does not exist
 	bool loadFromFolders();

--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -48,10 +48,6 @@ bool MapSettingsManager::getMapSetting(
 	if (m_map_settings->getNoEx(name, *value_out))
 		return true;
 
-	// Compatibility kludge
-	if (m_user_settings == g_settings && name == "seed")
-		return m_user_settings->getNoEx("fixed_map_seed", *value_out);
-
 	return m_user_settings->getNoEx(name, *value_out);
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -876,7 +876,7 @@ bool MapgenBasic::generateCaverns(s16 max_stone_y)
 
 
 void MapgenBasic::generateDungeons(s16 max_stone_y,
-	MgStoneType stone_type, content_t biome_stone)
+	MgStoneType stone_type, content_t biome_stone, Settings *server_settings)
 {
 	if (max_stone_y < node_min.Y)
 		return;
@@ -955,7 +955,8 @@ void MapgenBasic::generateDungeons(s16 max_stone_y,
 	}
 
 	DungeonGen dgen(ndef, &gennotify, &dp);
-	dgen.generate(vm, blockseed, full_node_min, full_node_max);
+	bool projecting_dungeons = server_settings->getBool("projecting_dungeons");
+	dgen.generate(vm, blockseed, full_node_min, full_node_max, projecting_dungeons);
 }
 
 
@@ -1036,9 +1037,8 @@ MapgenParams::~MapgenParams()
 void MapgenParams::readParams(const Settings *settings)
 {
 	std::string seed_str;
-	const char *seed_name = (settings == g_settings) ? "fixed_map_seed" : "seed";
 
-	if (settings->getNoEx(seed_name, seed_str)) {
+	if (settings->getNoEx("seed", seed_str)) {
 		if (!seed_str.empty())
 			seed = read_seed(seed_str.c_str());
 		else

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -205,7 +205,7 @@ public:
 	void propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow);
 	void spreadLight(v3s16 nmin, v3s16 nmax);
 
-	virtual void makeChunk(BlockMakeData *data) {}
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings) {}
 	virtual int getGroundLevelAtPoint(v2s16 p) { return 0; }
 
 	// getSpawnLevelAtPoint() is a function within each mapgen that returns a
@@ -252,7 +252,7 @@ public:
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
 	virtual bool generateCaverns(s16 max_stone_y);
 	virtual void generateDungeons(s16 max_stone_y,
-		MgStoneType stone_type, content_t biome_stone);
+		MgStoneType stone_type, content_t biome_stone, Settings *server_settings);
 	virtual void generateBiomes(MgStoneType *mgstone_type,
 		content_t *biome_stone);
 	virtual void dustTopNodes();

--- a/src/mapgen_carpathian.cpp
+++ b/src/mapgen_carpathian.cpp
@@ -208,7 +208,7 @@ float MapgenCarpathian::getSteps(float noise)
 ///////////////////////////////////////////////////////////////////////////////
 
 
-void MapgenCarpathian::makeChunk(BlockMakeData *data)
+void MapgenCarpathian::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -265,7 +265,7 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_carpathian.h
+++ b/src/mapgen_carpathian.h
@@ -77,7 +77,7 @@ public:
 	float getSteps(float noise);
 	inline float getLerp(float noise1, float noise2, float mod);
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 
 private:

--- a/src/mapgen_flat.cpp
+++ b/src/mapgen_flat.cpp
@@ -156,7 +156,7 @@ int MapgenFlat::getSpawnLevelAtPoint(v2s16 p)
 }
 
 
-void MapgenFlat::makeChunk(BlockMakeData *data)
+void MapgenFlat::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -199,7 +199,7 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_flat.h
+++ b/src/mapgen_flat.h
@@ -61,7 +61,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_FLAT; }
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 	s16 generateTerrain();
 

--- a/src/mapgen_fractal.cpp
+++ b/src/mapgen_fractal.cpp
@@ -166,7 +166,7 @@ int MapgenFractal::getSpawnLevelAtPoint(v2s16 p)
 }
 
 
-void MapgenFractal::makeChunk(BlockMakeData *data)
+void MapgenFractal::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -209,7 +209,7 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_fractal.h
+++ b/src/mapgen_fractal.h
@@ -64,7 +64,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_FRACTAL; }
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 	bool getFractalAtPoint(s16 x, s16 y, s16 z);
 	s16 generateTerrain();

--- a/src/mapgen_singlenode.cpp
+++ b/src/mapgen_singlenode.cpp
@@ -48,7 +48,7 @@ MapgenSinglenode::MapgenSinglenode(int mapgenid,
 
 //////////////////////// Map generator
 
-void MapgenSinglenode::makeChunk(BlockMakeData *data)
+void MapgenSinglenode::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);

--- a/src/mapgen_singlenode.h
+++ b/src/mapgen_singlenode.h
@@ -44,6 +44,6 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_SINGLENODE; }
 
-	void makeChunk(BlockMakeData *data);
+	void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 };

--- a/src/mapgen_v5.cpp
+++ b/src/mapgen_v5.cpp
@@ -166,7 +166,7 @@ int MapgenV5::getSpawnLevelAtPoint(v2s16 p)
 }
 
 
-void MapgenV5::makeChunk(BlockMakeData *data)
+void MapgenV5::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -224,7 +224,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons and desert temples
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_v5.h
+++ b/src/mapgen_v5.h
@@ -62,7 +62,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_V5; }
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 	int generateBaseTerrain();
 

--- a/src/mapgen_v6.cpp
+++ b/src/mapgen_v6.cpp
@@ -481,7 +481,7 @@ u32 MapgenV6::get_blockseed(u64 seed, v3s16 p)
 
 //////////////////////// Map generator
 
-void MapgenV6::makeChunk(BlockMakeData *data)
+void MapgenV6::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -600,7 +600,7 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 		}
 
 		DungeonGen dgen(ndef, &gennotify, &dp);
-		dgen.generate(vm, blockseed, full_node_min, full_node_max);
+		dgen.generate(vm, blockseed, full_node_min, full_node_max, server_settings);
 	}
 
 	// Add top and bottom side of water to transforming_liquid queue

--- a/src/mapgen_v6.h
+++ b/src/mapgen_v6.h
@@ -131,7 +131,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_V6; }
 
-	void makeChunk(BlockMakeData *data);
+	void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getGroundLevelAtPoint(v2s16 p);
 	int getSpawnLevelAtPoint(v2s16 p);
 

--- a/src/mapgen_v7.cpp
+++ b/src/mapgen_v7.cpp
@@ -263,7 +263,7 @@ int MapgenV7::getSpawnLevelAtPoint(v2s16 p)
 }
 
 
-void MapgenV7::makeChunk(BlockMakeData *data)
+void MapgenV7::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -325,7 +325,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Generate dungeons
 	if (flags & MG_DUNGEONS)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_v7.h
+++ b/src/mapgen_v7.h
@@ -77,7 +77,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_V7; }
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 
 	float baseTerrainLevelAtPoint(s16 x, s16 z);

--- a/src/mapgen_valleys.cpp
+++ b/src/mapgen_valleys.cpp
@@ -192,7 +192,7 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 ///////////////////////////////////////
 
 
-void MapgenValleys::makeChunk(BlockMakeData *data)
+void MapgenValleys::makeChunk(BlockMakeData *data, Settings *server_settings)
 {
 	// Pre-conditions
 	assert(data->vmanip);
@@ -245,7 +245,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 
 	// Dungeon creation
 	if ((flags & MG_DUNGEONS) && node_max.Y < 50)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone, server_settings);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen_valleys.h
+++ b/src/mapgen_valleys.h
@@ -91,7 +91,7 @@ public:
 
 	virtual MapgenType getType() const { return MAPGEN_VALLEYS; }
 
-	virtual void makeChunk(BlockMakeData *data);
+	virtual void makeChunk(BlockMakeData *data, Settings *server_settings);
 	int getSpawnLevelAtPoint(v2s16 p);
 
 	s16 large_cave_depth;

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -111,7 +111,7 @@ bool Address::operator!=(const Address &address)
 	return !(*this == address);
 }
 
-void Address::Resolve(const char *name)
+void Address::Resolve(const char *name, bool is_ipv6)
 {
 	if (!name || name[0] == 0) {
 		if (m_addr_family == AF_INET) {
@@ -129,7 +129,7 @@ void Address::Resolve(const char *name)
 	hints.ai_socktype = 0;
 	hints.ai_protocol = 0;
 	hints.ai_flags = 0;
-	if (g_settings->getBool("enable_ipv6")) {
+	if (is_ipv6) {
 		// AF_UNSPEC allows both IPv6 and IPv4 addresses to be returned
 		hints.ai_family = AF_UNSPEC;
 	} else {

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -53,7 +53,7 @@ public:
 	bool operator==(const Address &address);
 	bool operator!=(const Address &address);
 	// Resolve() may throw ResolveError (address is unchanged in this case)
-	void Resolve(const char *name);
+	void Resolve(const char *name, bool is_ipv6);
 	struct sockaddr_in getAddress() const;
 	unsigned short getPort() const;
 	void setAddress(u32 address);

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -41,7 +41,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler, // 0x0E
 	null_command_handler, // 0x0F
 	null_command_handler, // 0x10
-	null_command_handler,
+	{ "TOCLIENT_SERVER_INFO",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ServerInfo }, // 0x11
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1423,3 +1423,12 @@ void Client::handleCommand_ModChannelSignal(NetworkPacket *pkt)
 	if (valid_signal)
 		m_script->on_modchannel_signal(channel, signal);
 }
+
+void Client::handleCommand_ServerInfo(NetworkPacket *pkt)
+{
+	*pkt >> m_server_info.enable_damage
+		>> m_server_info.creative_mode
+		>> m_server_info.server_announce
+		>> m_server_info.enable_pvp
+		>> m_server_info.server_name;
+}

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -923,12 +923,12 @@ bool UDPPeer::getAddress(MTProtocols type,Address& toset)
 	return false;
 }
 
-void UDPPeer::setNonLegacyPeer()
+void UDPPeer::setNonLegacyPeer(u16 max_packets_per_iteration)
 {
 	m_legacy_peer = false;
 	for(unsigned int i=0; i< CHANNEL_COUNT; i++)
 	{
-		channels->setWindowSize(g_settings->getU16("max_packets_per_iteration"));
+		channels->setWindowSize(max_packets_per_iteration);
 	}
 }
 
@@ -1146,11 +1146,11 @@ SharedBuffer<u8> UDPPeer::addSplitPacket(u8 channel, const BufferedPacket &toadd
 */
 
 Connection::Connection(u32 protocol_id, u32 max_packet_size, float timeout,
-		bool ipv6, PeerHandler *peerhandler) :
+		u16 max_packets, bool ipv6, PeerHandler *peerhandler) :
 	m_udpSocket(ipv6),
 	m_protocol_id(protocol_id),
-	m_sendThread(new ConnectionSendThread(max_packet_size, timeout)),
-	m_receiveThread(new ConnectionReceiveThread(max_packet_size)),
+	m_sendThread(new ConnectionSendThread(max_packet_size, timeout, max_packets)),
+	m_receiveThread(new ConnectionReceiveThread(max_packet_size, max_packets)),
 	m_bc_peerhandler(peerhandler)
 
 {

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -659,7 +659,7 @@ public:
 
 	bool getAddress(MTProtocols type, Address& toset);
 
-	void setNonLegacyPeer();
+	void setNonLegacyPeer(u16 max_packets_per_iteration);
 
 	bool getLegacyPeer()
 	{ return m_legacy_peer; }
@@ -774,8 +774,8 @@ public:
 	friend class ConnectionSendThread;
 	friend class ConnectionReceiveThread;
 
-	Connection(u32 protocol_id, u32 max_packet_size, float timeout, bool ipv6,
-			PeerHandler *peerhandler);
+	Connection(u32 protocol_id, u32 max_packet_size, float timeout,
+			u16 max_packets, bool ipv6, PeerHandler *peerhandler);
 	~Connection();
 
 	/* Interface */

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -35,7 +35,8 @@ class ConnectionSendThread : public Thread
 public:
 	friend class UDPPeer;
 
-	ConnectionSendThread(unsigned int max_packet_size, float timeout);
+	ConnectionSendThread(
+			unsigned int max_packet_size, float timeout, u16 max_packets);
 
 	void *run();
 
@@ -90,7 +91,7 @@ private:
 class ConnectionReceiveThread : public Thread
 {
 public:
-	ConnectionReceiveThread(unsigned int max_packet_size);
+	ConnectionReceiveThread(unsigned int max_packet_size, u16 max_packets);
 
 	void *run();
 
@@ -145,5 +146,6 @@ private:
 	static const PacketTypeHandler packetTypeRouter[PACKET_TYPE_MAX];
 
 	Connection *m_connection = nullptr;
+	u16 m_max_packet_count;
 };
 }

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -249,6 +249,15 @@ enum ToClientCommand
 
 	TOCLIENT_INIT_LEGACY = 0x10, // Obsolete
 
+	TOCLIENT_SERVER_INFO = 0x11,
+	/*
+	 * u8 enable_damage
+	 * u8 creative_mode
+	 * u8 server_announce
+	 * u8 enable_pvp
+	 * std::string server_name
+	 */
+
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
 	TOCLIENT_ADDNODE = 0x21,
 	/*

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -130,7 +130,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x0E
 	null_command_factory, // 0x0F
 	{ "TOCLIENT_INIT",              0, true }, // 0x10
-	null_command_factory,
+	{ "TOCLIENT_SERVER_INFO",       0, true }, // 0x11
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,
@@ -200,8 +200,8 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_CLOUD_PARAMS",             0, true }, // 0x54
 	{ "TOCLIENT_FADE_SOUND",               0, true }, // 0x55
 	{ "TOCLIENT_UPDATE_PLAYER_LIST",       0, true }, // 0x56
-	{ "TOCLIENT_MODCHANNEL_MSG",           0, true}, // 0x57
-	{ "TOCLIENT_MODCHANNEL_SIGNAL",        0, true}, // 0x58
+	{ "TOCLIENT_MODCHANNEL_MSG",           0, true }, // 0x57
+	{ "TOCLIENT_MODCHANNEL_SIGNAL",        0, true }, // 0x58
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -142,7 +142,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 
 	client->net_proto_version = net_proto_version;
 
-	if ((g_settings->getBool("strict_protocol_version_checking") &&
+	if (m_conf.getBool("strict_protocol_version_checking") &&
 			net_proto_version != LATEST_PROTOCOL_VERSION) ||
 			net_proto_version < SERVER_PROTOCOL_VERSION_MIN ||
 			net_proto_version > SERVER_PROTOCOL_VERSION_MAX) {
@@ -203,11 +203,11 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	// Enforce user limit.
 	// Don't enforce for users that have some admin right or mod permits it.
 	if (m_clients.isUserLimitReached() &&
-			playername != g_settings->get("name") &&
+			playername != m_conf.get("name") &&
 			!m_script->can_bypass_userlimit(playername, addr_s)) {
 		actionstream << "Server: " << playername << " tried to join from "
 				<< addr_s << ", but there" << " are already max_users="
-				<< g_settings->getU16("max_users") << " players." << std::endl;
+				<< m_conf.getU16("max_users") << " players." << std::endl;
 		DenyAccess(pkt->getPeerId(), SERVER_ACCESSDENIED_TOO_MANY_USERS);
 		return;
 	}
@@ -245,7 +245,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 			return;
 		}
 	} else {
-		std::string default_password = g_settings->get("default_password");
+		std::string default_password = m_conf.get("default_password");
 		if (default_password.length() == 0) {
 			auth_mechs |= AUTH_MECHANISM_FIRST_SRP;
 		} else {
@@ -317,7 +317,7 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 
 	// Send time of day
 	u16 time = m_env->getTimeOfDay();
-	float time_speed = g_settings->getFloat("time_speed");
+	float time_speed = m_conf.getFloat("time_speed");
 	SendTimeOfDay(pkt->getPeerId(), time, time_speed);
 
 	SendCSMFlavourLimits(pkt->getPeerId());
@@ -788,7 +788,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage")) {
+	if (m_conf.getBool("enable_damage")) {
 		if (playersao->isDead()) {
 			verbosestream << "Server::ProcessData(): Info: "
 				"Ignoring damage as player " << player->getName()
@@ -1062,7 +1062,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		(only when digging or placing things)
 	*/
 	static thread_local const bool enable_anticheat =
-			!g_settings->getBool("disable_anticheat");
+			!m_conf.getBool("disable_anticheat");
 
 	if ((action == 0 || action == 2 || action == 3 || action == 4) &&
 			(enable_anticheat && !isSingleplayer())) {
@@ -1510,7 +1510,7 @@ void Server::handleCommand_FirstSrp(NetworkPacket* pkt)
 		}
 
 		if (!isSingleplayer() &&
-				g_settings->getBool("disallow_empty_password") &&
+				m_conf.getBool("disallow_empty_password") &&
 				is_empty == 1) {
 			actionstream << "Server: " << playername
 					<< " supplied empty password from " << addr_s << std::endl;
@@ -1750,7 +1750,7 @@ void Server::handleCommand_ModChannelJoin(NetworkPacket *pkt)
 		pkt->getPeerId());
 
 	// Send signal to client to notify join succeed or not
-	if (g_settings->getBool("enable_mod_channels") &&
+	if (m_conf.getBool("enable_mod_channels") &&
 			m_modchannel_mgr->joinChannel(channel_name, pkt->getPeerId())) {
 		resp_pkt << (u8) MODCHANNEL_SIGNAL_JOIN_OK;
 		infostream << "Peer " << pkt->getPeerId() << " joined channel " << channel_name
@@ -1774,7 +1774,7 @@ void Server::handleCommand_ModChannelLeave(NetworkPacket *pkt)
 		pkt->getPeerId());
 
 	// Send signal to client to notify join succeed or not
-	if (g_settings->getBool("enable_mod_channels") &&
+	if (m_conf.getBool("enable_mod_channels") &&
 			m_modchannel_mgr->leaveChannel(channel_name, pkt->getPeerId())) {
 		resp_pkt << (u8)MODCHANNEL_SIGNAL_LEAVE_OK;
 		infostream << "Peer " << pkt->getPeerId() << " left channel " << channel_name
@@ -1797,7 +1797,7 @@ void Server::handleCommand_ModChannelMsg(NetworkPacket *pkt)
 			<< " on channel " << channel_name << " message: " << channel_msg << std::endl;
 
 	// If mod channels are not enabled, discard message
-	if (!g_settings->getBool("enable_mod_channels")) {
+	if (!m_conf.getBool("enable_mod_channels")) {
 		return;
 	}
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -142,7 +142,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 
 	client->net_proto_version = net_proto_version;
 
-	if (m_conf.getBool("strict_protocol_version_checking") &&
+	if ((m_conf.getBool("strict_protocol_version_checking") &&
 			net_proto_version != LATEST_PROTOCOL_VERSION) ||
 			net_proto_version < SERVER_PROTOCOL_VERSION_MIN ||
 			net_proto_version > SERVER_PROTOCOL_VERSION_MAX) {

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -394,6 +394,14 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	}
 	m_clients.send(peer_id, 0, &list_pkt, true);
 
+	NetworkPacket server_info(TOCLIENT_SERVER_INFO, 0, peer_id);
+	server_info << m_conf.getBool("enable_damage")
+		<< m_conf.getBool("creative_mode")
+		<< m_conf.getBool("server_announce")
+		<< m_conf.getBool("enable_pvp")
+		<< m_conf.get("server_name");
+	m_clients.send(peer_id, 0, &server_info, true);
+
 	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
 	// (u16) 1 + std::string represents a pseudo vector serialization representation
 	notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(playersao->getPlayer()->getName());

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -36,28 +36,28 @@ bool RemotePlayer::m_setting_cache_loaded = false;
 float RemotePlayer::m_setting_chat_message_limit_per_10sec = 0.0f;
 u16 RemotePlayer::m_setting_chat_message_limit_trigger_kick = 0;
 
-RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
+RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef, Settings *settings):
 	Player(name, idef)
 {
 	if (!RemotePlayer::m_setting_cache_loaded) {
 		RemotePlayer::m_setting_chat_message_limit_per_10sec =
-			g_settings->getFloat("chat_message_limit_per_10sec");
+			settings->getFloat("chat_message_limit_per_10sec");
 		RemotePlayer::m_setting_chat_message_limit_trigger_kick =
-			g_settings->getU16("chat_message_limit_trigger_kick");
+			settings->getU16("chat_message_limit_trigger_kick");
 		RemotePlayer::m_setting_cache_loaded = true;
 	}
-	movement_acceleration_default   = g_settings->getFloat("movement_acceleration_default")   * BS;
-	movement_acceleration_air       = g_settings->getFloat("movement_acceleration_air")       * BS;
-	movement_acceleration_fast      = g_settings->getFloat("movement_acceleration_fast")      * BS;
-	movement_speed_walk             = g_settings->getFloat("movement_speed_walk")             * BS;
-	movement_speed_crouch           = g_settings->getFloat("movement_speed_crouch")           * BS;
-	movement_speed_fast             = g_settings->getFloat("movement_speed_fast")             * BS;
-	movement_speed_climb            = g_settings->getFloat("movement_speed_climb")            * BS;
-	movement_speed_jump             = g_settings->getFloat("movement_speed_jump")             * BS;
-	movement_liquid_fluidity        = g_settings->getFloat("movement_liquid_fluidity")        * BS;
-	movement_liquid_fluidity_smooth = g_settings->getFloat("movement_liquid_fluidity_smooth") * BS;
-	movement_liquid_sink            = g_settings->getFloat("movement_liquid_sink")            * BS;
-	movement_gravity                = g_settings->getFloat("movement_gravity")                * BS;
+	movement_acceleration_default   = settings->getFloat("movement_acceleration_default")   * BS;
+	movement_acceleration_air       = settings->getFloat("movement_acceleration_air")       * BS;
+	movement_acceleration_fast      = settings->getFloat("movement_acceleration_fast")      * BS;
+	movement_speed_walk             = settings->getFloat("movement_speed_walk")             * BS;
+	movement_speed_crouch           = settings->getFloat("movement_speed_crouch")           * BS;
+	movement_speed_fast             = settings->getFloat("movement_speed_fast")             * BS;
+	movement_speed_climb            = settings->getFloat("movement_speed_climb")            * BS;
+	movement_speed_jump             = settings->getFloat("movement_speed_jump")             * BS;
+	movement_liquid_fluidity        = settings->getFloat("movement_liquid_fluidity")        * BS;
+	movement_liquid_fluidity_smooth = settings->getFloat("movement_liquid_fluidity_smooth") * BS;
+	movement_liquid_sink            = settings->getFloat("movement_liquid_sink")            * BS;
+	movement_gravity                = settings->getFloat("movement_gravity")                * BS;
 
 	// copy defaults
 	m_cloud_params.density = 0.4f;

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "player.h"
 #include "cloudparams.h"
+#include "settings.h"
 
 class PlayerSAO;
 
@@ -40,7 +41,7 @@ class RemotePlayer : public Player
 	friend class PlayerDatabaseFiles;
 
 public:
-	RemotePlayer(const char *name, IItemDefManager *idef);
+	RemotePlayer(const char *name, IItemDefManager *idef, Settings *settings);
 	virtual ~RemotePlayer() = default;
 
 	void deSerialize(std::istream &is, const std::string &playername, PlayerSAO *sao);

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -18,6 +18,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "common/c_internal.h"
+#include "cpp_api/s_base.h"
+#include "server.h"
+#include "client.h"
 #include "debug.h"
 #include "log.h"
 #include "settings.h"
@@ -140,7 +143,11 @@ void log_deprecated(lua_State *L, const std::string &message)
 
 	// Only read settings on first call
 	if (!configured) {
-		std::string value = g_settings->get("deprecated_lua_api_handling");
+		lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
+		ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
+		lua_pop(L, 1);
+		Settings *settings = script->getGameDef()->getSettings();
+		std::string value = settings->get("deprecated_lua_api_handling");
 		if (value == "log") {
 			do_log = true;
 		} else if (value == "error") {

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "debug.h"
 #include "log.h"
+#include "server.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -153,13 +154,14 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 	if (!lua_isstring(L, -1)) {
 		return 0;
 	}
+	Settings *settings = getServer(L)->getSettings();
 
 	const char *mod_name = lua_tostring(L, -1);
-	std::string http_mods = g_settings->get("secure.http_mods");
+	std::string http_mods = settings->get("secure.http_mods");
 	http_mods.erase(std::remove(http_mods.begin(), http_mods.end(), ' '), http_mods.end());
 	std::vector<std::string> mod_list_http = str_split(http_mods, ',');
 
-	std::string trusted_mods = g_settings->get("secure.trusted_mods");
+	std::string trusted_mods = settings->get("secure.trusted_mods");
 	trusted_mods.erase(std::remove(trusted_mods.begin(), trusted_mods.end(), ' '), trusted_mods.end());
 	std::vector<std::string> mod_list_trusted = str_split(trusted_mods, ',');
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -789,7 +789,7 @@ int ModApiMapgen::l_set_noiseparams(lua_State *L)
 
 	bool set_default = !lua_isboolean(L, 3) || lua_toboolean(L, 3);
 
-	g_settings->setNoiseParams(name, np, set_default);
+	getServer(L)->getSettings()->setNoiseParams(name, np, set_default);
 
 	return 0;
 }
@@ -803,7 +803,7 @@ int ModApiMapgen::l_get_noiseparams(lua_State *L)
 	std::string name = luaL_checkstring(L, 1);
 
 	NoiseParams np;
-	if (!g_settings->getNoiseParams(name, np))
+	if (!getServer(L)->getSettings()->getNoiseParams(name, np))
 		return 0;
 
 	push_noiseparams(L, &np);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -23,10 +23,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "noise.h"
 #include "log.h"
+#include "server.h"
 
 
 #define SET_SECURITY_CHECK(L, name) \
-	if (o->m_settings == g_settings && ScriptApiSecurity::isSecure(L) && \
+	if ((o->m_settings == g_settings ||(getServer(L) && o->m_settings == getServer(L)->getSettings())) \
+			&& ScriptApiSecurity::isSecure(L) && \
 			name.compare(0, 7, "secure.") == 0) { \
 		throw LuaError("Attempt to set secure setting."); \
 	}

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/hex.h"
 #include "util/sha1.h"
 #include <algorithm>
+#include "server.h"
 
 
 // log([level,] text)
@@ -390,7 +391,7 @@ int ModApiUtil::l_request_insecure_environment(lua_State *L)
 
 	// Check secure.trusted_mods
 	const char *mod_name = lua_tostring(L, -1);
-	std::string trusted_mods = g_settings->get("secure.trusted_mods");
+	std::string trusted_mods = getServer(L)->getSettings()->get("secure.trusted_mods");
 	trusted_mods.erase(std::remove_if(trusted_mods.begin(),
 			trusted_mods.end(), static_cast<int(*)(int)>(&std::isspace)),
 			trusted_mods.end());
@@ -484,6 +485,20 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 
 	API_FCT(get_version);
 	API_FCT(sha1);
+}
+
+void ModApiUtil::InitializeServer(lua_State *L, int top)
+{
+	Initialize(L, top);
+
+	Server *server = getServer(L);
+	LuaSettings::create(L, server->getSettings(), server->getSettingsPath());
+	lua_setfield(L, top, "settings");
+}
+
+void ModApiUtil::InitializeMainMenu(lua_State *L, int top)
+{
+	Initialize(L, top);
 
 	LuaSettings::create(L, g_settings, g_settings_path);
 	lua_setfield(L, top, "settings");

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -97,6 +97,8 @@ private:
 
 public:
 	static void Initialize(lua_State *L, int top);
+	static void InitializeServer(lua_State *L, int top);
+	static void InitializeMainMenu(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
 

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -65,7 +65,7 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 
 	// Initialize mod API modules
 	ModApiMainMenu::Initialize(L, top);
-	ModApiUtil::Initialize(L, top);
+	ModApiUtil::InitializeMainMenu(L, top);
 	ModApiSound::Initialize(L, top);
 
 	asyncEngine.registerStateInitializer(registerLuaClasses);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -58,7 +58,7 @@ ServerScripting::ServerScripting(Server* server)
 
 	SCRIPTAPI_PRECHECKHEADER
 
-	if (g_settings->getBool("secure.enable_security")) {
+	if (server->getSettings()->getBool("secure.enable_security")) {
 		initializeSecurity();
 	}
 
@@ -112,7 +112,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ModApiParticles::Initialize(L, top);
 	ModApiRollback::Initialize(L, top);
 	ModApiServer::Initialize(L, top);
-	ModApiUtil::Initialize(L, top);
+	ModApiUtil::InitializeServer(L, top);
 	ModApiHttp::Initialize(L, top);
 	ModApiStorage::Initialize(L, top);
 	ModApiChannels::Initialize(L, top);

--- a/src/server.h
+++ b/src/server.h
@@ -352,6 +352,9 @@ public:
 	// Environment mutex (envlock)
 	std::mutex m_env_mutex;
 
+	inline Settings *getSettings() { return &m_conf; }
+	inline std::string getSettingsPath() const { return m_settings_path; }
+
 private:
 
 	friend class EmergeThread;
@@ -499,6 +502,9 @@ private:
 
 	// World directory
 	std::string m_path_world;
+	// config file
+	std::string m_settings_path;
+	Settings m_conf;
 	// Subgame specification
 	SubgameSpec m_gamespec;
 	// If true, do not allow multiple players and hide some multiplayer

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -350,7 +350,7 @@ public:
 private:
 
 	static PlayerDatabase *openPlayerDatabase(const std::string &name,
-			const std::string &savedir, const Settings &conf);
+			const std::string &savedir, Settings* conf);
 	/*
 		Internal ActiveObject interface
 		-------------------------------------------

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -193,6 +193,7 @@ const std::string serializeJson(const std::vector<ServerListSpec> &serverlist)
 #if USE_CURL
 void sendAnnounce(AnnounceAction action,
 		const u16 port,
+		Settings *settings,
 		const std::vector<std::string> &clients_names,
 		const double uptime,
 		const u32 game_time,
@@ -206,25 +207,25 @@ void sendAnnounce(AnnounceAction action,
 	Json::Value server;
 	server["action"] = aa_names[action];
 	server["port"] = port;
-	if (g_settings->exists("server_address")) {
-		server["address"] = g_settings->get("server_address");
+	if (settings->exists("server_address")) {
+		server["address"] = settings->get("server_address");
 	}
 	if (action != AA_DELETE) {
-		bool strict_checking = g_settings->getBool("strict_protocol_version_checking");
-		server["name"]         = g_settings->get("server_name");
-		server["description"]  = g_settings->get("server_description");
+		bool strict_checking = settings->getBool("strict_protocol_version_checking");
+		server["name"]         = settings->get("server_name");
+		server["description"]  = settings->get("server_description");
 		server["version"]      = g_version_string;
 		server["proto_min"]    = strict_checking ? LATEST_PROTOCOL_VERSION : SERVER_PROTOCOL_VERSION_MIN;
 		server["proto_max"]    = strict_checking ? LATEST_PROTOCOL_VERSION : SERVER_PROTOCOL_VERSION_MAX;
-		server["url"]          = g_settings->get("server_url");
-		server["creative"]     = g_settings->getBool("creative_mode");
-		server["damage"]       = g_settings->getBool("enable_damage");
-		server["password"]     = g_settings->getBool("disallow_empty_password");
-		server["pvp"]          = g_settings->getBool("enable_pvp");
+		server["url"]          = settings->get("server_url");
+		server["creative"]     = settings->getBool("creative_mode");
+		server["damage"]       = settings->getBool("enable_damage");
+		server["password"]     = settings->getBool("disallow_empty_password");
+		server["pvp"]          = settings->getBool("enable_pvp");
 		server["uptime"]       = (int) uptime;
 		server["game_time"]    = game_time;
 		server["clients"]      = (int) clients_names.size();
-		server["clients_max"]  = g_settings->getU16("max_users");
+		server["clients_max"]  = settings->getU16("max_users");
 		server["clients_list"] = Json::Value(Json::arrayValue);
 		for (const std::string &clients_name : clients_names) {
 			server["clients_list"].append(clients_name);
@@ -235,22 +236,22 @@ void sendAnnounce(AnnounceAction action,
 
 	if (action == AA_START) {
 		server["dedicated"]         = dedicated;
-		server["rollback"]          = g_settings->getBool("enable_rollback_recording");
+		server["rollback"]          = settings->getBool("enable_rollback_recording");
 		server["mapgen"]            = mg_name;
-		server["privs"]             = g_settings->get("default_privs");
-		server["can_see_far_names"] = g_settings->getS16("player_transfer_distance") <= 0;
+		server["privs"]             = settings->get("default_privs");
+		server["can_see_far_names"] = settings->getS16("player_transfer_distance") <= 0;
 		server["mods"]              = Json::Value(Json::arrayValue);
 		for (const ModSpec &mod : mods) {
 			server["mods"].append(mod.name);
 		}
-		actionstream << "Announcing to " << g_settings->get("serverlist_url") << std::endl;
+		actionstream << "Announcing to " << settings->get("serverlist_url") << std::endl;
 	} else if (action == AA_UPDATE) {
 		if (lag)
 			server["lag"] = lag;
 	}
 
 	HTTPFetchRequest fetch_request;
-	fetch_request.url = g_settings->get("serverlist_url") + std::string("/announce");
+	fetch_request.url = settings->get("serverlist_url") + std::string("/announce");
 	fetch_request.post_fields["json"] = fastWriteJson(server);
 	fetch_request.multipart = true;
 	httpfetch_async(fetch_request);

--- a/src/serverlist.h
+++ b/src/serverlist.h
@@ -41,7 +41,7 @@ const std::string serializeJson(const std::vector<ServerListSpec> &serverlist);
 
 #if USE_CURL
 enum AnnounceAction {AA_START, AA_UPDATE, AA_DELETE};
-void sendAnnounce(AnnounceAction, u16 port,
+void sendAnnounce(AnnounceAction, u16 port, Settings *settings,
 		const std::vector<std::string> &clients_names = std::vector<std::string>(),
 		double uptime = 0, u32 game_time = 0, float lag = 0,
 		const std::string &gameid = "", const std::string &mg_name = "",

--- a/src/subgame.cpp
+++ b/src/subgame.cpp
@@ -266,15 +266,9 @@ std::vector<WorldSpec> getAvailableWorlds()
 
 bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamespec)
 {
-	// Override defaults with those provided by the game.
-	// We clear and reload the defaults because the defaults
-	// might have been overridden by other subgame config
-	// files that were loaded before.
-	g_settings->clearDefaults();
-	set_default_settings(g_settings);
-	Settings game_defaults;
-	getGameMinetestConfig(gamespec.path, game_defaults);
-	override_default_settings(g_settings, &game_defaults);
+	Settings conf;
+	set_default_settings(&conf);
+	override_default_settings(&conf, g_settings);
 
 	infostream << "Initializing world at " << path << std::endl;
 
@@ -283,14 +277,11 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 	// Create world.mt if does not already exist
 	std::string worldmt_path = path + DIR_DELIM "world.mt";
 	if (!fs::PathExists(worldmt_path)) {
-		Settings conf;
+		getGameMinetestConfig(gamespec.path, conf);
 
 		conf.set("gameid", gamespec.id);
 		conf.set("backend", "sqlite3");
 		conf.set("player_backend", "sqlite3");
-		conf.setBool("creative_mode", g_settings->getBool("creative_mode"));
-		conf.setBool("enable_damage", g_settings->getBool("enable_damage"));
-
 		if (!conf.updateConfigFile(worldmt_path.c_str()))
 			return false;
 	}
@@ -302,12 +293,12 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 		fs::CreateAllDirs(path);
 		std::ostringstream oss(std::ios_base::binary);
 
-		Settings conf;
+		Settings map_conf;
 		MapgenParams params;
 
-		params.readParams(g_settings);
-		params.writeParams(&conf);
-		conf.writeLines(oss);
+		params.readParams(&conf);
+		params.writeParams(&map_conf);
+		map_conf.writeLines(oss);
 		oss << "[end_of_params]\n";
 
 		fs::safeWriteToFile(map_meta_path, oss.str());

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "modchannels.h"
 #include "mods.h"
 #include "util/numeric.h"
+#include "settings.h"
 
 content_t t_CONTENT_STONE;
 content_t t_CONTENT_GRASS;
@@ -65,6 +66,10 @@ public:
 	{
 		static std::vector<ModSpec> testmodspec;
 		return testmodspec;
+	}
+	virtual Settings* getSettings()
+	{
+		return g_settings;
 	}
 	virtual const ModSpec* getModSpec(const std::string &modname) const { return NULL; }
 	virtual std::string getModStoragePath() const { return "."; }

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -142,7 +142,7 @@ void TestConnection::testConnectSendReceive()
 	 */
 	std::string bind_str = g_settings->get("bind_address");
 	try {
-		bind_addr.Resolve(bind_str.c_str());
+		bind_addr.Resolve(bind_str.c_str(), g_settings->getBool("enable_ipv6"));
 
 		if (!bind_addr.isIPv6()) {
 			address = bind_addr;
@@ -151,11 +151,12 @@ void TestConnection::testConnectSendReceive()
 	}
 
 	infostream << "** Creating server Connection" << std::endl;
-	con::Connection server(proto_id, 512, 5.0, false, &hand_server);
+	u16 max_packets = g_settings->getU16("max_packets_per_iteration");
+	con::Connection server(proto_id, 512, 5.0, max_packets, false, &hand_server);
 	server.Serve(address);
 
 	infostream << "** Creating client Connection" << std::endl;
-	con::Connection client(proto_id, 512, 5.0, false, &hand_client);
+	con::Connection client(proto_id, 512, 5.0, max_packets, false, &hand_client);
 
 	UASSERT(hand_server.count == 0);
 	UASSERT(hand_client.count == 0);

--- a/src/unittest/test_socket.cpp
+++ b/src/unittest/test_socket.cpp
@@ -64,7 +64,7 @@ void TestSocket::testIPv4Socket()
 	 */
 	std::string bind_str = g_settings->get("bind_address");
 	try {
-		bind_addr.Resolve(bind_str.c_str());
+		bind_addr.Resolve(bind_str.c_str(), g_settings->getBool("enable_ipv6"));
 
 		if (!bind_addr.isIPv6()) {
 			address = bind_addr;


### PR DESCRIPTION
This separates out the server and client config files. A separate config file is now saved for every world. The client config/minetest.conf is used as a fallback if a setting isn't set in the server's config.

TODO:

- [x] Finish switching server code to use the new config file.
- [x] Extend the settings menu GUI to support the new config file.
- [x] Fix the pause menu.
- [x] misc main menu fixes.