### PR TITLE
 Profiler: Fix var args not being passed to callback register function

### DIFF
--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -133,7 +133,7 @@ local function instrument_register(func, func_name)
 		return func(instrument {
 			func = callback,
 			func_name = register_name
-		}), ...
+		}, ...)
 	end
 end
 


### PR DESCRIPTION
Fixes #6517