### PR TITLE
Bind mouse buttons

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -105,8 +105,8 @@ doubletap_jump (Double tap jump for fly) bool false
 #    If disabled, "special" key is used to fly fast if both fly and fast mode are enabled.
 always_fly_fast (Always fly and fast) bool true
 
-#    The time in seconds it takes between repeated right clicks when holding the right mouse button.
-repeat_rightclick_time (Rightclick repetition interval) float 0.25
+#    The time in seconds it takes between repeated block placements when holding the place block button.
+repeat_place_time (Rightclick repetition interval) float 0.25
 
 #    Prevent digging and placing from repeating when holding the mouse buttons.
 #    Enable this when you dig or place too often by accident.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -106,7 +106,7 @@ doubletap_jump (Double tap jump for fly) bool false
 always_fly_fast (Always fly and fast) bool true
 
 #    The time in seconds it takes between repeated block placements when holding the place block button.
-repeat_place_time (Rightclick repetition interval) float 0.25
+repeat_place_time (Place repetition interval) float 0.25
 
 #    Prevent digging and placing from repeating when holding the mouse buttons.
 #    Enable this when you dig or place too often by accident.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -69,9 +69,9 @@
 #    type: bool
 # always_fly_fast = true
 
-#    The time in seconds it takes between repeated right clicks when holding the right mouse button.
+#    The time in seconds it takes between repeated block placements when holding the place block button.
 #    type: float
-# repeat_rightclick_time = 0.25
+# repeat_place_time = 0.25
 
 #    Prevent digging and placing from repeating when holding the mouse buttons.
 #    Enable this when you dig or place too often by accident.

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -41,8 +41,15 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		const KeyPress &keyCode = event.KeyInput;
 		if (keysListenedFor[keyCode]) {
 			if (event.KeyInput.PressedDown) {
+				// If the key is being held down then the OS may
+				// send a continuous stream of keydown events.
+				// In this case, we don't want to let this
+				// stream reach the application as it will cause
+				// certain actions to repeat constantly.
+				if (!IsKeyDown(keyCode)) {
+					keyWasDown.set(keyCode);
+				}
 				keyIsDown.set(keyCode);
-				keyWasDown.set(keyCode);
 			} else {
 				keyIsDown.unset(keyCode);
 			}

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -81,6 +81,10 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 				keyWasDown.set("KEY_LBUTTON");
 				leftclicked = true;
 			}
+			if (event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN) {
+				keyIsDown.set("KEY_MBUTTON");
+				keyWasDown.set("KEY_MBUTTON");
+			}
 			if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
 				keyIsDown.set("KEY_RBUTTON");
 				keyWasDown.set("KEY_RBUTTON");
@@ -89,6 +93,9 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
 				keyIsDown.unset("KEY_LBUTTON");
 				leftreleased = true;
+			}
+			if (event.MouseInput.Event == EMIE_MMOUSE_LEFT_UP) {
+				keyIsDown.unset("KEY_MBUTTON");
 			}
 			if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
 				keyIsDown.unset("KEY_RBUTTON");

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -67,19 +67,10 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	}
 	// handle mouse events
 	if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
-		if (isMenuActive()) {
-			left_active = false;
-			middle_active = false;
-			right_active = false;
-		} else {
-			left_active = event.MouseInput.isLeftPressed();
-			middle_active = event.MouseInput.isMiddlePressed();
-			right_active = event.MouseInput.isRightPressed();
-
+		if (!isMenuActive()) {
 			if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
 				keyIsDown.set("KEY_LBUTTON");
 				keyWasDown.set("KEY_LBUTTON");
-				leftclicked = true;
 			}
 			if (event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN) {
 				keyIsDown.set("KEY_MBUTTON");
@@ -88,18 +79,15 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
 				keyIsDown.set("KEY_RBUTTON");
 				keyWasDown.set("KEY_RBUTTON");
-				rightclicked = true;
 			}
 			if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
 				keyIsDown.unset("KEY_LBUTTON");
-				leftreleased = true;
 			}
 			if (event.MouseInput.Event == EMIE_MMOUSE_LEFT_UP) {
 				keyIsDown.unset("KEY_MBUTTON");
 			}
 			if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
 				keyIsDown.unset("KEY_RBUTTON");
-				rightreleased = true;
 			}
 			if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {
 				mouse_wheel += event.MouseInput.Wheel;

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -77,15 +77,21 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			right_active = event.MouseInput.isRightPressed();
 
 			if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+				keyIsDown.set("KEY_LBUTTON");
+				keyWasDown.set("KEY_LBUTTON");
 				leftclicked = true;
 			}
 			if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
+				keyIsDown.set("KEY_RBUTTON");
+				keyWasDown.set("KEY_RBUTTON");
 				rightclicked = true;
 			}
 			if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP) {
+				keyIsDown.unset("KEY_LBUTTON");
 				leftreleased = true;
 			}
 			if (event.MouseInput.Event == EMIE_RMOUSE_LEFT_UP) {
+				keyIsDown.unset("KEY_RBUTTON");
 				rightreleased = true;
 			}
 			if (event.MouseInput.Event == EMIE_MOUSE_WHEEL) {

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -127,15 +127,6 @@ public:
 		keyIsDown.clear();
 		keyWasDown.clear();
 
-		leftclicked = false;
-		rightclicked = false;
-		leftreleased = false;
-		rightreleased = false;
-
-		left_active = false;
-		middle_active = false;
-		right_active = false;
-
 		mouse_wheel = 0;
 	}
 
@@ -145,15 +136,6 @@ public:
 		m_touchscreengui = NULL;
 #endif
 	}
-
-	bool leftclicked = false;
-	bool rightclicked = false;
-	bool leftreleased = false;
-	bool rightreleased = false;
-
-	bool left_active = false;
-	bool middle_active = false;
-	bool right_active = false;
 
 	s32 mouse_wheel = 0;
 
@@ -191,19 +173,6 @@ public:
 
 	virtual v2s32 getMousePos() = 0;
 	virtual void setMousePos(s32 x, s32 y) = 0;
-
-	virtual bool getLeftState() = 0;
-	virtual bool getRightState() = 0;
-
-	virtual bool getLeftClicked() = 0;
-	virtual bool getRightClicked() = 0;
-	virtual void resetLeftClicked() = 0;
-	virtual void resetRightClicked() = 0;
-
-	virtual bool getLeftReleased() = 0;
-	virtual bool getRightReleased() = 0;
-	virtual void resetLeftReleased() = 0;
-	virtual void resetRightReleased() = 0;
 
 	virtual s32 getMouseWheel() = 0;
 
@@ -259,19 +228,6 @@ public:
 		}
 	}
 
-	virtual bool getLeftState() { return m_receiver->left_active; }
-	virtual bool getRightState() { return m_receiver->right_active; }
-
-	virtual bool getLeftClicked() { return m_receiver->leftclicked; }
-	virtual bool getRightClicked() { return m_receiver->rightclicked; }
-	virtual void resetLeftClicked() { m_receiver->leftclicked = false; }
-	virtual void resetRightClicked() { m_receiver->rightclicked = false; }
-
-	virtual bool getLeftReleased() { return m_receiver->leftreleased; }
-	virtual bool getRightReleased() { return m_receiver->rightreleased; }
-	virtual void resetLeftReleased() { m_receiver->leftreleased = false; }
-	virtual void resetRightReleased() { m_receiver->rightreleased = false; }
-
 	virtual s32 getMouseWheel() { return m_receiver->getMouseWheel(); }
 
 	void clear()
@@ -294,19 +250,6 @@ public:
 	virtual bool wasKeyDown(const KeyPress &keyCode) { return false; }
 	virtual v2s32 getMousePos() { return mousepos; }
 	virtual void setMousePos(s32 x, s32 y) { mousepos = v2s32(x, y); }
-
-	virtual bool getLeftState() { return leftdown; }
-	virtual bool getRightState() { return rightdown; }
-
-	virtual bool getLeftClicked() { return leftclicked; }
-	virtual bool getRightClicked() { return rightclicked; }
-	virtual void resetLeftClicked() { leftclicked = false; }
-	virtual void resetRightClicked() { rightclicked = false; }
-
-	virtual bool getLeftReleased() { return leftreleased; }
-	virtual bool getRightReleased() { return rightreleased; }
-	virtual void resetLeftReleased() { leftreleased = false; }
-	virtual void resetRightReleased() { rightreleased = false; }
 
 	virtual s32 getMouseWheel() { return 0; }
 
@@ -357,11 +300,7 @@ public:
 			counter1 -= dtime;
 			if (counter1 < 0.0) {
 				counter1 = 0.1 * Rand(1, 30);
-				leftdown = !leftdown;
-				if (leftdown)
-					leftclicked = true;
-				if (!leftdown)
-					leftreleased = true;
+				keydown.toggle(getKeySetting("keymap_dig"));
 			}
 		}
 		{
@@ -369,11 +308,7 @@ public:
 			counter1 -= dtime;
 			if (counter1 < 0.0) {
 				counter1 = 0.1 * Rand(1, 15);
-				rightdown = !rightdown;
-				if (rightdown)
-					rightclicked = true;
-				if (!rightdown)
-					rightreleased = true;
+				keydown.toggle(getKeySetting("keymap_place"));
 			}
 		}
 		mousepos += mousespeed;
@@ -385,10 +320,4 @@ private:
 	KeyList keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
-	bool leftdown = false;
-	bool rightdown = false;
-	bool leftclicked = false;
-	bool rightclicked = false;
-	bool leftreleased = false;
-	bool rightreleased = false;
 };

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -35,6 +35,8 @@ public:
 		SPECIAL1,
 		SNEAK,
 		AUTOFORWARD,
+		DIG,
+		PLACE,
 
 		ESC,
 

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -745,13 +745,13 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			if (controls.sneak && walking)
 				new_speed /= 2;
 
-			if (walking && (controls.LMB || controls.RMB)) {
+			if (walking && (controls.dig || controls.place)) {
 				new_anim = player->local_animations[3];
 				player->last_animation = WD_ANIM;
 			} else if(walking) {
 				new_anim = player->local_animations[1];
 				player->last_animation = WALK_ANIM;
-			} else if(controls.LMB || controls.RMB) {
+			} else if(controls.dig || controls.place) {
 				new_anim = player->local_animations[2];
 				player->last_animation = DIG_ANIM;
 			}

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -68,6 +68,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_right", "KEY_KEY_D");
 	settings->setDefault("keymap_jump", "KEY_SPACE");
 	settings->setDefault("keymap_sneak", "KEY_LSHIFT");
+	settings->setDefault("keymap_dig", "KEY_LBUTTON");
+	settings->setDefault("keymap_place", "KEY_RBUTTON");
 	settings->setDefault("keymap_drop", "KEY_KEY_Q");
 	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
 	settings->setDefault("keymap_inventory", "KEY_KEY_I");
@@ -240,7 +242,7 @@ void set_default_settings(Settings *settings)
 	// Input
 	settings->setDefault("invert_mouse", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
-	settings->setDefault("repeat_rightclick_time", "0.25");
+	settings->setDefault("repeat_place_time", "0.25");
 	settings->setDefault("safe_dig_and_place", "false");
 	settings->setDefault("random_input", "false");
 	settings->setDefault("aux1_descends", "false");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1331,32 +1331,6 @@ protected:
 	static void settingChangedCallback(const std::string &setting_name, void *data);
 	void readSettings();
 
-	inline bool getLeftClicked()
-	{
-		return input->getLeftClicked() ||
-			input->joystick.getWasKeyDown(KeyType::MOUSE_L);
-	}
-	inline bool getRightClicked()
-	{
-		return input->getRightClicked() ||
-			input->joystick.getWasKeyDown(KeyType::MOUSE_R);
-	}
-	inline bool isLeftPressed()
-	{
-		return input->getLeftState() ||
-			input->joystick.isKeyDown(KeyType::MOUSE_L);
-	}
-	inline bool isRightPressed()
-	{
-		return input->getRightState() ||
-			input->joystick.isKeyDown(KeyType::MOUSE_R);
-	}
-	inline bool getLeftReleased()
-	{
-		return input->getLeftReleased() ||
-			input->joystick.wasKeyReleased(KeyType::MOUSE_L);
-	}
-
 	inline bool isKeyDown(GameKeyType k)
 	{
 		return input->isKeyDown(keycache.key[k]) || input->joystick.isKeyDown(k);
@@ -3733,14 +3707,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	if (runData.punch || isKeyDown(KeyType::DIG))
 		camera->setDigging(0); // dig animation
 
-	input->resetLeftClicked();
-	input->resetRightClicked();
-
 	input->joystick.clearWasKeyDown(KeyType::MOUSE_L);
 	input->joystick.clearWasKeyDown(KeyType::MOUSE_R);
-
-	input->resetLeftReleased();
-	input->resetRightReleased();
 
 	input->joystick.clearWasKeyReleased(KeyType::MOUSE_L);
 	input->joystick.clearWasKeyReleased(KeyType::MOUSE_R);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3677,9 +3677,11 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		runData.repeat_place_timer = 0;
 
 	if (playeritem_def.usable && isKeyDown(KeyType::DIG)) {
-		if (isKeyDown(KeyType::DIG) && (!client->moddingEnabled()
-				|| !client->getScript()->on_item_use(playeritem, pointed)))
+		if (wasKeyDown(KeyType::DIG) && (!client->moddingEnabled()
+				|| !client->getScript()->on_item_use(playeritem, pointed))) {
+
 			client->interact(4, pointed);
+		}
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		ToolCapabilities playeritem_toolcap =
 				playeritem.getToolCapabilities(itemdef_manager);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -786,7 +786,7 @@ bool nodePlacementPrediction(Client &client, const ItemDefinition &playeritem_de
 	if (!is_valid_position)
 		return false;
 
-	if (!prediction.empty() && !nodedef->get(node).rightclickable) {
+	if (!prediction.empty() && !nodedef->get(node).can_place_onto) {
 		verbosestream << "Node placement prediction for "
 			      << playeritem_def.name << " is "
 			      << prediction << std::endl;
@@ -1147,7 +1147,7 @@ struct GameRunData {
 	bool btn_down_for_dig;
 	bool dig_instantly;
 	bool digging_blocked;
-	bool left_punch;
+	bool punch;
 	bool update_wielded_item_trigger;
 	bool reset_jump_timer;
 	float nodig_delay_timer;
@@ -3692,7 +3692,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		runData.btn_down_for_dig = false;
 	}
 
-	runData.left_punch = false;
+	runData.punch = false;
 
 	soundmaker->m_player_leftpunch_sound.name = "";
 
@@ -3723,14 +3723,14 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		handlePointingAtObject(pointed, playeritem, player_position, show_debug);
 	} else if (isKeyDown(KeyType::DIG)) {
 		// When button is held down in air, show continuous animation
-		runData.left_punch = true;
+		runData.punch = true;
 	} else if (wasKeyDown(KeyType::PLACE)) {
 		handlePointingAtNothing(playeritem);
 	}
 
 	runData.pointed_old = pointed;
 
-	if (runData.left_punch || isKeyDown(KeyType::DIG))
+	if (runData.punch || isKeyDown(KeyType::DIG))
 		camera->setDigging(0); // dig animation
 
 	input->resetLeftClicked();
@@ -3889,7 +3889,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 		if (meta && !meta->getString("formspec").empty() && !random_input
 				&& !isKeyDown(KeyType::SNEAK)) {
 			// Report place action to server
-			if (nodedef_manager->get(map.getNodeNoEx(nodepos)).rightclickable) {
+			if (nodedef_manager->get(map.getNodeNoEx(nodepos)).can_place_onto) {
 				client->interact(3, pointed);
 			}
 
@@ -3932,7 +3932,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 						SimpleSoundSpec();
 
 				if (playeritem_def.node_placement_prediction.empty() ||
-						nodedef_manager->get(map.getNodeNoEx(nodepos)).rightclickable) {
+						nodedef_manager->get(map.getNodeNoEx(nodepos)).can_place_onto) {
 					client->interact(3, pointed); // Report to server
 				} else {
 					soundmaker->m_player_rightpunch_sound =
@@ -3971,8 +3971,8 @@ void Game::handlePointingAtObject(const PointedThing &pointed, const ItemStack &
 			do_punch = true;
 
 		if (do_punch) {
-			infostream << "Dug object" << std::endl;
-			runData.left_punch = true;
+			infostream << "Punched object" << std::endl;
+			runData.punch = true;
 		}
 
 		if (do_punch_damage) {
@@ -3995,7 +3995,7 @@ void Game::handlePointingAtObject(const PointedThing &pointed, const ItemStack &
 				client->interact(0, pointed);
 		}
 	} else if (wasKeyDown(KeyType::PLACE)) {
-		infostream << "Dug object" << std::endl;
+		infostream << "Pressed place button while looking at object" << std::endl;
 		client->interact(3, pointed);  // place
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3654,7 +3654,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 
 	/*
 		Stop digging when
-		- releasing left mouse button
+		- releasing dig button
 		- pointing away from node
 	*/
 	if (runData.digging) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3114,8 +3114,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		isKeyDown(KeyType::SPECIAL1),
 		isKeyDown(KeyType::SNEAK),
 		isKeyDown(KeyType::ZOOM),
-		isLeftPressed(),
-		isRightPressed(),
+		isKeyDown(KeyType::DIG),
+		isKeyDown(KeyType::PLACE),
 		cam.camera_pitch,
 		cam.camera_yaw,
 		input->joystick.getAxisWithoutDead(JA_SIDEWARD_MOVE),
@@ -3130,8 +3130,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 			( (u32)(isKeyDown(KeyType::JUMP)                          & 0x1) << 4) |
 			( (u32)(isKeyDown(KeyType::SPECIAL1)                      & 0x1) << 5) |
 			( (u32)(isKeyDown(KeyType::SNEAK)                         & 0x1) << 6) |
-			( (u32)(isLeftPressed()                                   & 0x1) << 7) |
-			( (u32)(isRightPressed()                                  & 0x1) << 8
+			( (u32)(isKeyDown(KeyType::DIG)                           & 0x1) << 7) |
+			( (u32)(isKeyDown(KeyType::PLACE)                         & 0x1) << 8
 		);
 
 #ifdef ANDROID

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -46,6 +46,8 @@ enum
 	GUI_ID_KEY_LEFT_BUTTON,
 	GUI_ID_KEY_RIGHT_BUTTON,
 	GUI_ID_KEY_USE_BUTTON,
+	GUI_ID_KEY_DIG_BUTTON,
+	GUI_ID_KEY_PLACE_BUTTON,
 	GUI_ID_KEY_FLY_BUTTON,
 	GUI_ID_KEY_FAST_BUTTON,
 	GUI_ID_KEY_JUMP_BUTTON,
@@ -274,11 +276,29 @@ bool GUIKeyChangeMenu::resetMenu()
 }
 bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 {
-	if (event.EventType == EET_KEY_INPUT_EVENT && activeKey >= 0
-			&& event.KeyInput.PressedDown) {
+	if (activeKey >= 0 &&
+			((event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown) ||
+			(event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+			(event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN ||
+			event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN)))) {
+
+		// If the desired key comes from the keyboard, the event's
+		// KeyInput can be used. However, if the desired key is a mouse
+		// button then a KeyInput has to be created artificially.
+		irr::SEvent::SKeyInput s;
+		if (event.EventType == irr::EET_MOUSE_INPUT_EVENT) {
+			if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
+				s.Key = KEY_LBUTTON;
+			} else if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
+				s.Key = KEY_RBUTTON;
+			}
+			s.Char = 0;
+		} else {
+			s = event.KeyInput;
+		}
 
 		bool prefer_character = shift_down;
-		KeyPress kp(event.KeyInput, prefer_character);
+		KeyPress kp(s, prefer_character);
 
 		bool shift_went_down = false;
 		if(!shift_down &&
@@ -406,6 +426,8 @@ void GUIKeyChangeMenu::init_keys()
 	this->add_key(GUI_ID_KEY_USE_BUTTON,       wgettext("Special"),          "keymap_special1");
 	this->add_key(GUI_ID_KEY_JUMP_BUTTON,      wgettext("Jump"),             "keymap_jump");
 	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,     wgettext("Sneak"),            "keymap_sneak");
+	this->add_key(GUI_ID_KEY_DIG_BUTTON,       wgettext("Dig"),              "keymap_dig");
+	this->add_key(GUI_ID_KEY_PLACE_BUTTON,     wgettext("Place"),            "keymap_place");
 	this->add_key(GUI_ID_KEY_DROP_BUTTON,      wgettext("Drop"),             "keymap_drop");
 	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON, wgettext("Inventory"),        "keymap_inventory");
 	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,wgettext("Prev. item"),      "keymap_hotbar_previous");

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -274,13 +274,19 @@ bool GUIKeyChangeMenu::resetMenu()
 	}
 	return true;
 }
+
+bool isMouseDownEvent(const SEvent &event)
+{
+	return event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
+		(event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN ||
+		event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN ||
+		event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN);
+}
+
 bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 {
-	if (activeKey >= 0 &&
-			((event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown) ||
-			(event.EventType == irr::EET_MOUSE_INPUT_EVENT &&
-			(event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN ||
-			event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN)))) {
+	if (activeKey >= 0 && (isMouseDownEvent(event) ||
+			(event.EventType == EET_KEY_INPUT_EVENT && event.KeyInput.PressedDown))) {
 
 		// If the desired key comes from the keyboard, the event's
 		// KeyInput can be used. However, if the desired key is a mouse
@@ -291,6 +297,8 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 				s.Key = KEY_LBUTTON;
 			} else if (event.MouseInput.Event == EMIE_RMOUSE_PRESSED_DOWN) {
 				s.Key = KEY_RBUTTON;
+			} else if (event.MouseInput.Event == EMIE_MMOUSE_PRESSED_DOWN) {
+				s.Key = KEY_MBUTTON;
 			}
 			s.Char = 0;
 		} else {

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -65,6 +65,8 @@ private:
 
 	void add_key(int id, const wchar_t *button_name, const std::string &setting_name);
 
+	bool setBinding(const SEvent &event);
+
 	bool shift_down = false;
 	s32 activeKey = -1;
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -488,8 +488,8 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	player->control.jump = (keyPressed & 16);
 	player->control.aux1 = (keyPressed & 32);
 	player->control.sneak = (keyPressed & 64);
-	player->control.LMB = (keyPressed & 128);
-	player->control.RMB = (keyPressed & 256);
+	player->control.dig = (keyPressed & 128);
+	player->control.place = (keyPressed & 256);
 
 	if (playersao->checkMovementCheat()) {
 		// Call callbacks

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -362,7 +362,7 @@ void ContentFeatures::reset()
 	climbable = false;
 	buildable_to = false;
 	floodable = false;
-	rightclickable = true;
+	can_place_onto = true;
 	leveled = 0;
 	liquid_type = LIQUID_NONE;
 	liquid_alternative_flowing = "";
@@ -450,7 +450,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, diggable);
 	writeU8(os, climbable);
 	writeU8(os, buildable_to);
-	writeU8(os, rightclickable);
+	writeU8(os, can_place_onto);
 	writeU32(os, damage_per_second);
 
 	// liquid
@@ -560,7 +560,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 	diggable = readU8(is);
 	climbable = readU8(is);
 	buildable_to = readU8(is);
-	rightclickable = readU8(is);
+	can_place_onto = readU8(is);
 	damage_per_second = readU32(is);
 
 	// liquid

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -343,7 +343,7 @@ struct ContentFeatures
 	// Player can build on these
 	bool buildable_to;
 	// Player cannot build to these (placement prediction disabled)
-	bool rightclickable;
+	bool can_place_onto;
 	u32 damage_per_second;
 	// client dig prediction
 	std::string node_dig_prediction;

--- a/src/player.h
+++ b/src/player.h
@@ -45,8 +45,8 @@ struct PlayerControl
 		bool a_aux1,
 		bool a_sneak,
 		bool a_zoom,
-		bool a_LMB,
-		bool a_RMB,
+		bool a_dig,
+		bool a_place,
 		float a_pitch,
 		float a_yaw,
 		float a_sidew_move_joystick_axis,
@@ -61,8 +61,8 @@ struct PlayerControl
 		aux1 = a_aux1;
 		sneak = a_sneak;
 		zoom = a_zoom;
-		LMB = a_LMB;
-		RMB = a_RMB;
+		dig = a_dig;
+		place = a_place;
 		pitch = a_pitch;
 		yaw = a_yaw;
 		sidew_move_joystick_axis = a_sidew_move_joystick_axis;
@@ -76,8 +76,8 @@ struct PlayerControl
 	bool aux1 = false;
 	bool sneak = false;
 	bool zoom = false;
-	bool LMB = false;
-	bool RMB = false;
+	bool dig = false;
+	bool place = false;
 	float pitch = 0.0f;
 	float yaw = 0.0f;
 	float sidew_move_joystick_axis = 0.0f;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -477,7 +477,7 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	lua_pop(L, 1);
 
 	lua_getfield(L, index, "on_rightclick");
-	f.rightclickable = lua_isfunction(L, -1);
+	f.can_place_onto = lua_isfunction(L, -1);
 	lua_pop(L, 1);
 
 	/* Name */
@@ -849,8 +849,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "climbable");
 	lua_pushboolean(L, c.buildable_to);
 	lua_setfield(L, -2, "buildable_to");
-	lua_pushboolean(L, c.rightclickable);
-	lua_setfield(L, -2, "rightclickable");
+	lua_pushboolean(L, c.can_place_onto);
+	lua_setfield(L, -2, "can_place_onto");
 	lua_pushnumber(L, c.damage_per_second);
 	lua_setfield(L, -2, "damage_per_second");
 	if (c.isLiquid()) {

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1313,10 +1313,10 @@ int ObjectRef::l_get_player_control(lua_State *L)
 	lua_setfield(L, -2, "aux1");
 	lua_pushboolean(L, control.sneak);
 	lua_setfield(L, -2, "sneak");
-	lua_pushboolean(L, control.LMB);
-	lua_setfield(L, -2, "LMB");
-	lua_pushboolean(L, control.RMB);
-	lua_setfield(L, -2, "RMB");
+	lua_pushboolean(L, control.dig);
+	lua_setfield(L, -2, "dig");
+	lua_pushboolean(L, control.place);
+	lua_setfield(L, -2, "place");
 	return 1;
 }
 


### PR DESCRIPTION
These patches accomplish the following:

1. Create two new actions: dig and place, for digging and placing blocks. These actions can be bound to any key just like the other player actions e.g. sneak, jump. This involves removing hardcoded associations between the mouse and these actions from game.cpp.
2. Allow the mouse buttons to be bound to any action in the GUI just like any other button.