### PR TITLE
Allow zoom to actually show more data.

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -550,7 +550,7 @@ void Camera::updateViewingRange()
 {
 	f32 viewing_range = g_settings->getFloat("viewing_range");
 	f32 near_plane = g_settings->getFloat("near_plane");
-	m_draw_control.wanted_range = viewing_range;
+	m_draw_control.wanted_range = viewing_range * sqrt(1.775f / getFovMax());
 	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -551,7 +551,7 @@ void Camera::updateViewingRange()
 	f32 viewing_range = g_settings->getFloat("viewing_range");
 	f32 near_plane = g_settings->getFloat("near_plane");
 
-	m_draw_control.wanted_range = adjustDist(viewing_range, getFovMax());
+	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 4000);
 	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -458,7 +458,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	} else {
 		fov_degrees = m_cache_fov;
 	}
-	fov_degrees = rangelim(fov_degrees, 2.0, 160.0);
+	fov_degrees = rangelim(fov_degrees, 1.0, 160.0);
 
 	// FOV and aspect ratio
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -458,7 +458,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	} else {
 		fov_degrees = m_cache_fov;
 	}
-	fov_degrees = rangelim(fov_degrees, 7.0, 160.0);
+	fov_degrees = rangelim(fov_degrees, 2.0, 160.0);
 
 	// FOV and aspect ratio
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();
@@ -550,7 +550,8 @@ void Camera::updateViewingRange()
 {
 	f32 viewing_range = g_settings->getFloat("viewing_range");
 	f32 near_plane = g_settings->getFloat("near_plane");
-	m_draw_control.wanted_range = viewing_range * sqrt(1.775f / getFovMax());
+
+	m_draw_control.wanted_range = adjustDist(viewing_range, getFovMax());
 	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -206,7 +206,7 @@ void RemoteClient::GetNextBlocks (
 
 	// Don't loop very much at a time, adjust with distance,
 	// do more work per RTT with greater distances.
-	s16 max_d_increment_at_time = full_d_max / 10 + 1;
+	s16 max_d_increment_at_time = full_d_max / 9 + 1;
 	if (d_max > d_start + max_d_increment_at_time)
 		d_max = d_start + max_d_increment_at_time;
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -204,8 +204,9 @@ void RemoteClient::GetNextBlocks (
 	s16 d_max = full_d_max;
 	s16 d_max_gen = std::min(adjustDist(m_max_gen_distance, camera_fov), wanted_range);
 
-	// Don't loop very much at a time
-	s16 max_d_increment_at_time = 2;
+	// Don't loop very much at a time, adjust with distance,
+	// do more work per RTT with greater distances.
+	s16 max_d_increment_at_time = full_d_max / 10 + 1;
 	if (d_max > d_start + max_d_increment_at_time)
 		d_max = d_start + max_d_increment_at_time;
 

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -204,13 +204,15 @@ void RemoteClient::GetNextBlocks (
 	// limit max fov effect to 50%, 60% at 20n/s fly speed
 	camera_fov = camera_fov / (1 + dot / 300.0f);
 
-	const s16 full_d_max = std::min(m_max_send_distance, wanted_range);
-	const s16 d_opt = std::min(m_block_optimize_distance, wanted_range);
+	// 1.775 ~= 72 * PI / 180 * 1.4;
+	s16 magnify_adjust = round(sqrt(1.775f / camera_fov));
+	const s16 full_d_max = std::min((s16)(m_max_send_distance * magnify_adjust), wanted_range);
+	const s16 d_opt = std::min((s16)(m_block_optimize_distance * magnify_adjust), wanted_range);
 	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
 	//infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
 
 	s16 d_max = full_d_max;
-	s16 d_max_gen = std::min(m_max_gen_distance, wanted_range);
+	s16 d_max_gen = std::min((s16)(m_max_gen_distance * magnify_adjust), wanted_range);
 
 	// Don't loop very much at a time
 	s16 max_d_increment_at_time = 2;

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -196,6 +196,19 @@ void RemoteClient::GetNextBlocks (
 	s16 wanted_range = sao->getWantedRange() + 1;
 	float camera_fov = sao->getFov();
 
+	const s16 full_d_max = std::min(adjustDist(m_max_send_distance, camera_fov), wanted_range);
+	const s16 d_opt = std::min(adjustDist(m_block_optimize_distance, camera_fov), wanted_range);
+	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
+	infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
+
+	s16 d_max = full_d_max;
+	s16 d_max_gen = std::min(adjustDist(m_max_gen_distance, camera_fov), wanted_range);
+
+	// Don't loop very much at a time
+	s16 max_d_increment_at_time = 2;
+	if (d_max > d_start + max_d_increment_at_time)
+		d_max = d_start + max_d_increment_at_time;
+
 	// cos(angle between velocity and camera) * |velocity|
 	// Limit to 0.0f in case player moves backwards.
 	f32 dot = rangelim(camera_dir.dotProduct(playerspeed), 0.0f, 300.0f);
@@ -203,21 +216,6 @@ void RemoteClient::GetNextBlocks (
 	// Reduce the field of view when a player moves and looks forward.
 	// limit max fov effect to 50%, 60% at 20n/s fly speed
 	camera_fov = camera_fov / (1 + dot / 300.0f);
-
-	// 1.775 ~= 72 * PI / 180 * 1.4;
-	s16 magnify_adjust = round(sqrt(1.775f / camera_fov));
-	const s16 full_d_max = std::min((s16)(m_max_send_distance * magnify_adjust), wanted_range);
-	const s16 d_opt = std::min((s16)(m_block_optimize_distance * magnify_adjust), wanted_range);
-	const s16 d_blocks_in_sight = full_d_max * BS * MAP_BLOCKSIZE;
-	//infostream << "Fov from client " << camera_fov << " full_d_max " << full_d_max << std::endl;
-
-	s16 d_max = full_d_max;
-	s16 d_max_gen = std::min((s16)(m_max_gen_distance * magnify_adjust), wanted_range);
-
-	// Don't loop very much at a time
-	s16 max_d_increment_at_time = 2;
-	if (d_max > d_start + max_d_increment_at_time)
-		d_max = d_start + max_d_increment_at_time;
 
 	s32 nearest_emerged_d = -1;
 	s32 nearest_emergefull_d = -1;

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -163,24 +163,15 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	return true;
 }
 
-s16 adjustDist(const s16 dist, const float zoomFov)
+s16 adjustDist(s16 dist, float zoomFov)
 {
-	/*
-	 * Here we define a scale starting from a FOV of 10
-	 * and a declared max view distance of 400
-	 * (that's a volume of about 290 mapblocks).
-	 *
-	 * From this starting point we calculate the distance for
-	 * other zooms, by keeping the volume constant.
-	 */
-	const float defaultFov = 1.775f; // ~~ 72 * PI / 180 * aspect
-	const float defaultZoomFov = 0.2875f; // ~~ 10 * PI / 180 * aspect
+	// 1.775 ~= 72 * PI / 180 * 1.4, the default on the client
+	float defaultFov = 1.775f;
 	// heuristic cut-off for zooming
 	if (zoomFov > defaultFov / 2.0f)
 		return dist;
 
-	const s16 zoomDist = 400; // default distance at FOV 10
 	// new_dist = dist * ((1 - cos(FOV / 2)) / (1-cos(zoomFOV /2))) ^ (1/3)
-	return round(zoomDist * cbrt((1.0f - cos(defaultZoomFov / 2.0f)) /
+	return round(dist * cbrt((1.0f - cos(defaultFov / 2.0f)) /
 		(1.0f - cos(zoomFov / 2.0f))));
 }

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -163,15 +163,24 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	return true;
 }
 
-s16 adjustDist(s16 dist, float zoomFov)
+s16 adjustDist(const s16 dist, const float zoomFov)
 {
-	// 1.775 ~= 72 * PI / 180 * 1.4, the default on the client
-	float defaultFov = 1.775f;
+	/*
+	 * Here we define a scale starting from a FOV of 10
+	 * and a declared max view distance of 400
+	 * (that's a volume of about 290 mapblocks).
+	 *
+	 * From this starting point we calculate the distance for
+	 * other zooms, by keeping the volume constant.
+	 */
+	const float defaultFov = 1.775f; // ~~ 72 * PI / 180 * aspect
+	const float defaultZoomFov = 0.2875f; // ~~ 10 * PI / 180 * aspect
 	// heuristic cut-off for zooming
 	if (zoomFov > defaultFov / 2.0f)
 		return dist;
 
+	const s16 zoomDist = 400; // default distance at FOV 10
 	// new_dist = dist * ((1 - cos(FOV / 2)) / (1-cos(zoomFOV /2))) ^ (1/3)
-	return round(dist * cbrt((1.0f - cos(defaultFov / 2.0f)) /
+	return round(zoomDist * cbrt((1.0f - cos(defaultZoomFov / 2.0f)) /
 		(1.0f - cos(zoomFov / 2.0f))));
 }

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -163,15 +163,15 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	return true;
 }
 
-s16 adjustDist(s16 dist, float zoomFov)
+s16 adjustDist(s16 dist, float zoom_fov)
 {
 	// 1.775 ~= 72 * PI / 180 * 1.4, the default on the client
-	float defaultFov = 1.775f;
+	const float default_fov = 1.775f;
 	// heuristic cut-off for zooming
-	if (zoomFov > defaultFov / 2.0f)
+	if (zoom_fov > default_fov / 2.0f)
 		return dist;
 
 	// new_dist = dist * ((1 - cos(FOV / 2)) / (1-cos(zoomFOV /2))) ^ (1/3)
-	return round(dist * cbrt((1.0f - cos(defaultFov / 2.0f)) /
-		(1.0f - cos(zoomFov / 2.0f))));
+	return round(dist * cbrt((1.0f - cos(default_fov / 2.0f)) /
+		(1.0f - cos(zoom_fov / 2.0f))));
 }

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "noise.h" // PseudoRandom, PcgRandom
 #include "threading/mutex_auto_lock.h"
 #include <cstring>
+#include <cmath>
 
 
 // myrand
@@ -160,4 +161,17 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		return false;
 
 	return true;
+}
+
+s16 adjustDist(s16 dist, float zoomFov)
+{
+	// 1.775 ~= 72 * PI / 180 * 1.4, the default on the client
+	float defaultFov = 1.775f;
+	// heuristic cut-off for zooming
+	if (zoomFov > defaultFov / 2.0f)
+		return dist;
+
+	// new_dist = dist * ((1 - cos(FOV / 2)) / (1-cos(zoomFOV /2))) ^ (1/3)
+	return round(dist * cbrt((1.0f - cos(defaultFov / 2.0f)) /
+		(1.0f - cos(zoomFov / 2.0f))));
 }

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -232,7 +232,7 @@ u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed);
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr=NULL);
 
-s16 adjustDist(s16 dist, float fov);
+s16 adjustDist(s16 dist, float zoom_fov);
 
 /*
 	Returns nearest 32-bit integer for given floating point number.

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -232,6 +232,8 @@ u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed);
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr=NULL);
 
+s16 adjustDist(s16 dist, float fov);
+
 /*
 	Returns nearest 32-bit integer for given floating point number.
 	<cmath> and <math.h> in VC++ don't provide round().


### PR DESCRIPTION
This might eventually address #6529 .

Some stuff hardcoded, no boundary testing, no code-style, just so that folks can see roughly what the effect would be.
Things to notice:
- The real zoom needs to all increase the client view range, so it seems we have a fog-piercing zoom.
- The zoom distance itself is interesting. How much more data should one retrieve?
- Currently assumes about 14/10 aspect ratio. Interestingly the server does not currently know the aspect ratio, so it's impossible to calculate the base fov (it's 72, but the actual value depends on the aspect ratio). As long as client and server agree it should be OK.

Again, just have a look. Don't argue about code-style and hardcoded stuff, yet.

@paramat 