### PR TITLE
[WIP] Reimplement particles using the Irrlicht particle system

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5028,6 +5028,7 @@ Definition tables
         maxvel = {x=0, y=0, z=0},
         minacc = {x=0, y=0, z=0},
         maxacc = {x=0, y=0, z=0},
+    --  ^ Is cut off to 0 if the lengths of both minacc and maxacc are smaller than 0.001
         minexptime = 1,
         maxexptime = 1,
         minsize = 1,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4232,11 +4232,6 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	}
 
 	/*
-		Update particles
-	*/
-	client->getParticleManager()->step(dtime);
-
-	/*
 		Fog
 	*/
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4433,7 +4433,9 @@ void Game::updateGui(const RunStats &stats, f32 dtime, const CameraOrientation &
 		   << std::setprecision(1)
 		   << ", view_range = " << draw_control->wanted_range
 		   << std::setprecision(3)
-		   << ", RTT = " << client->getRTT() << " s";
+		   << ", RTT = " << client->getRTT() << " s"
+		   << ", single particles = " << client->getParticleManager()->getSingleParticleNumber()
+		   << ", particle spawners = " << client->getParticleManager()->getParticleSpawnerNumber();
 		setStaticText(guitext, utf8_to_wide(os.str()).c_str());
 		guitext->setVisible(true);
 	} else {

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -119,7 +119,7 @@ public:
 	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
 	{
 		for (u32 i = 0; i < count; ++i) {
-			v3f pos = particlearray[i].pos -
+			v3f pos = particlearray[i].pos +
 				intToFloat(env->getCameraOffset(), BS);
 			color = getParticleLightColor(env, pos / BS,
 				gamedef, glow, base_color);

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -1,3 +1,22 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
 #include "client.h"
 #include "collision.h"
 #include "client/clientevent.h"
@@ -14,16 +33,16 @@
 
 static v3f random_v3f(v3f min, v3f max)
 {
-	return v3f(rand()/(float)RAND_MAX*(max.X-min.X)+min.X,
-		rand()/(float)RAND_MAX*(max.Y-min.Y)+min.Y,
-		rand()/(float)RAND_MAX*(max.Z-min.Z)+min.Z);
+	return v3f(rand() / (float) RAND_MAX * (max.X - min.X) + min.X,
+		rand() / (float) RAND_MAX * (max.Y - min.Y) + min.Y,
+		rand() / (float) RAND_MAX * (max.Z - min.Z) + min.Z);
 }
 
 static irr::core::matrix4 bottomUpTextureMatrix(float scale_x, float scale_y,
 	float coord_x, float coord_y)
 {
 	// Transposed 3x3 2D-transformation matrix padded to 4x4
-	irr::core::matrix4 texture_matrix (irr::core::matrix4::EM4CONST_IDENTITY);
+	irr::core::matrix4 texture_matrix(irr::core::matrix4::EM4CONST_IDENTITY);
 	// Rotation and scaling
 	texture_matrix[0] = -scale_x;
 	texture_matrix[5] = -scale_y;
@@ -50,10 +69,10 @@ public:
 		old_camera_offset = camera_offset;
 	}
 
-        virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-                return irr::scene::EPAT_NONE;
-        }
+		return irr::scene::EPAT_NONE;
+	}
 private:
 	const ClientEnvironment &env;
 	irr::scene::IParticleSystemSceneNode *const ps;
@@ -109,10 +128,10 @@ public:
 		}
 	}
 
-        virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-                return irr::scene::EPAT_NONE;
-        }
+		return irr::scene::EPAT_NONE;
+	}
 private:
 	ClientEnvironment *env;
 	IGameDef *gamedef;
@@ -156,10 +175,10 @@ public:
 		texture_matrix = bottomUpTextureMatrix(framesize_ratio.X, framesize_ratio.Y, texcoord.X, texcoord.Y);
 	}
 
-        virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-                return irr::scene::EPAT_NONE;
-        }
+		return irr::scene::EPAT_NONE;
+	}
 private:
 	const struct TileAnimationParams anim;
 	float animation_time = 0.f;
@@ -211,10 +230,10 @@ public:
 		}
 	}
 
-        virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-                return irr::scene::EPAT_NONE;
-        }
+		return irr::scene::EPAT_NONE;
+	}
 private:
 	ClientEnvironment *env;
 	irr::scene::IParticleSystemSceneNode *const ps;
@@ -250,10 +269,10 @@ public:
 		}
 	}
 
-        virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-                return irr::scene::EPAT_NONE;
-        }
+		return irr::scene::EPAT_NONE;
+	}
 private:
 	v3f acc;
 	bool disabled;
@@ -263,33 +282,33 @@ class CustomEmitter : public irr::scene::IParticleEmitter
 {
 public:
 	// unused pure virtual methods
-        virtual void setDirection( const core::vector3df& newDirection ) {  }
-        virtual void setMinParticlesPerSecond( u32 minPPS ) {  }
-        virtual void setMaxParticlesPerSecond( u32 maxPPS ) {  }
-        virtual void setMinStartColor( const video::SColor& color ) {  }
-        virtual void setMaxStartColor( const video::SColor& color ) {  }
-        virtual void setMaxLifeTime( const u32 t ) {  }
-        virtual void setMinLifeTime( const u32 t ) { }
-        virtual u32 getMaxLifeTime() const { return 1; }
-        virtual u32 getMinLifeTime() const { return 1; }
-        virtual void setMaxAngleDegrees(const s32 t ) {  }
-        virtual s32 getMaxAngleDegrees() const { return 0; }
-        virtual void setMaxStartSize( const core::dimension2df& size ) { }
-        virtual void setMinStartSize( const core::dimension2df& size ) {  }
-        virtual void setCenter( const core::vector3df& center ) {  }
-        virtual void setRadius( f32 radius ) {  }
-        virtual const core::vector3df& getDirection() const { return direction; }
-        virtual u32 getMinParticlesPerSecond() const { return 1; }
-        virtual u32 getMaxParticlesPerSecond() const { return 1; }
-        virtual const video::SColor& getMinStartColor() const { return minStartColor; }
-        virtual const video::SColor& getMaxStartColor() const { return maxStartColor; }
-        virtual const core::dimension2df& getMaxStartSize() const { return max_size; }
-        virtual const core::dimension2df& getMinStartSize() const { return min_size; }
-        virtual const core::vector3df& getCenter() const { return center; }
-        virtual f32 getRadius() const { return 1.; }
-        virtual irr::scene::E_PARTICLE_EMITTER_TYPE getType() const
+	virtual void setDirection(const core::vector3df& newDirection) {}
+	virtual void setMinParticlesPerSecond(u32 minPPS) {}
+	virtual void setMaxParticlesPerSecond(u32 maxPPS) {}
+	virtual void setMinStartColor(const video::SColor& color) {}
+	virtual void setMaxStartColor(const video::SColor& color) {}
+	virtual void setMaxLifeTime(const u32 t) {}
+	virtual void setMinLifeTime(const u32 t) {}
+	virtual u32 getMaxLifeTime() const {return 1;}
+	virtual u32 getMinLifeTime() const {return 1;}
+	virtual void setMaxAngleDegrees(const s32 t) {}
+	virtual s32 getMaxAngleDegrees() const {return 0;}
+	virtual void setMaxStartSize(const core::dimension2df& size) {}
+	virtual void setMinStartSize(const core::dimension2df& size) {}
+	virtual void setCenter(const core::vector3df& center) {}
+	virtual void setRadius(f32 radius) {}
+	virtual const core::vector3df& getDirection() const {return direction;}
+	virtual u32 getMinParticlesPerSecond() const {return 1;}
+	virtual u32 getMaxParticlesPerSecond() const {return 1;}
+	virtual const video::SColor& getMinStartColor() const {return minStartColor;}
+	virtual const video::SColor& getMaxStartColor() const {return maxStartColor;}
+	virtual const core::dimension2df& getMaxStartSize() const {return max_size;}
+	virtual const core::dimension2df& getMinStartSize() const {return min_size;}
+	virtual const core::vector3df& getCenter() const {return center;}
+	virtual f32 getRadius() const {return 1.f;}
+	virtual irr::scene::E_PARTICLE_EMITTER_TYPE getType() const
 	{
-                return irr::scene::EPET_COUNT;
+		return irr::scene::EPET_COUNT;
 	}
 protected:
 	core::dimension2df min_size, max_size;
@@ -306,8 +325,8 @@ public:
 	SingleEmitter(irr::scene::ISceneManager *smgr,
 		irr::scene::IParticleSystemSceneNode *ps, const video::SColor &color, u32 number,
 		f32 expirationtime):
-		smgr(smgr), ps(ps), number(number), deletion_time (0),
-		expirationtime(expirationtime), random_properties (true)
+		smgr(smgr), ps(ps), number(number), deletion_time(0),
+		expirationtime(expirationtime), random_properties(true)
 	{
 		particles.reserve(number);
 	}
@@ -315,7 +334,7 @@ public:
 	SingleEmitter(irr::scene::ISceneManager *smgr,
 		irr::scene::IParticleSystemSceneNode *ps, const video::SColor &color,
 		f32 expirationtime, f32 size, const v3f &pos, const v3f &vel):
-		smgr(smgr), ps(ps), number(1), deletion_time (0),
+		smgr(smgr), ps(ps), number(1), deletion_time(0),
 		expirationtime(expirationtime), size(size), pos(pos), vel(vel),
 		random_properties(false)
 	{

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -499,7 +499,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 		if (node)
 			m_smgr->addToDeletionQueue(node);
 
-
 		scene::IParticleSystemSceneNode *ps =
 			m_smgr->addParticleSystemSceneNode(false,
 				RenderingEngine::get_scene_manager()->getRootSceneNode(),
@@ -510,6 +509,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 		v3f minpos = *event->add_particlespawner.minpos * BS;
 		v3f maxpos = *event->add_particlespawner.maxpos * BS;
 		v3f meanpos = (minpos + maxpos) / 2.f;
+		ps->setPosition(meanpos);
 
 		scene::IParticlePointEmitter *continous_emitter =
 			new ContinuousEmitter(m_smgr, m_env, ps,

--- a/src/particles.h
+++ b/src/particles.h
@@ -30,7 +30,7 @@ class ClientEnvironment;
 struct MapNode;
 struct ContentFeatures;
 /**
- * Class doing particle as well as their spawners handling
+ * Class doing handling of single particles and particle spawners
  */
 class ParticleManager
 {
@@ -50,17 +50,10 @@ public:
 	void addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
 		const MapNode &n, const ContentFeatures &f, u32 number = 1);
 
-protected:
+	u32 getSingleParticleNumber();
+	u32 getParticleSpawnerNumber();
 
 private:
-
-//	void stepParticles (float dtime);
-//	void stepSpawners (float dtime);
-
-//void clearAll ();
-
 	ClientEnvironment* m_env;
 	irr::scene::ISceneManager *m_smgr;
-	//std::mutex m_particle_list_lock;
-	//std::mutex m_spawner_list_lock;
 };

--- a/src/particles.h
+++ b/src/particles.h
@@ -26,151 +26,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 
 struct ClientEvent;
-class ParticleManager;
 class ClientEnvironment;
 struct MapNode;
 struct ContentFeatures;
-
-class Particle : public scene::ISceneNode
-{
-	public:
-	Particle(
-		IGameDef* gamedef,
-		LocalPlayer *player,
-		ClientEnvironment *env,
-		v3f pos,
-		v3f velocity,
-		v3f acceleration,
-		float expirationtime,
-		float size,
-		bool collisiondetection,
-		bool collision_removal,
-		bool vertical,
-		video::ITexture *texture,
-		v2f texpos,
-		v2f texsize,
-		const struct TileAnimationParams &anim,
-		u8 glow,
-		video::SColor color = video::SColor(0xFFFFFFFF)
-	);
-	~Particle() = default;
-
-	virtual const aabb3f &getBoundingBox() const
-	{
-		return m_box;
-	}
-
-	virtual u32 getMaterialCount() const
-	{
-		return 1;
-	}
-
-	virtual video::SMaterial& getMaterial(u32 i)
-	{
-		return m_material;
-	}
-
-	virtual void OnRegisterSceneNode();
-	virtual void render();
-
-	void step(float dtime);
-
-	bool get_expired ()
-	{ return m_expiration < m_time; }
-
-private:
-	void updateLight();
-	void updateVertices();
-
-	video::S3DVertex m_vertices[4];
-	float m_time = 0.0f;
-	float m_expiration;
-
-	ClientEnvironment *m_env;
-	IGameDef *m_gamedef;
-	aabb3f m_box;
-	aabb3f m_collisionbox;
-	video::SMaterial m_material;
-	v2f m_texpos;
-	v2f m_texsize;
-	v3f m_pos;
-	v3f m_velocity;
-	v3f m_acceleration;
-	LocalPlayer *m_player;
-	float m_size;
-	//! Color without lighting
-	video::SColor m_base_color;
-	//! Final rendered color
-	video::SColor m_color;
-	bool m_collisiondetection;
-	bool m_collision_removal;
-	bool m_vertical;
-	v3s16 m_camera_offset;
-	struct TileAnimationParams m_animation;
-	float m_animation_time = 0.0f;
-	int m_animation_frame = 0;
-	u8 m_glow;
-};
-
-class ParticleSpawner
-{
-public:
-	ParticleSpawner(IGameDef* gamedef,
-		LocalPlayer *player,
-		u16 amount,
-		float time,
-		v3f minp, v3f maxp,
-		v3f minvel, v3f maxvel,
-		v3f minacc, v3f maxacc,
-		float minexptime, float maxexptime,
-		float minsize, float maxsize,
-		bool collisiondetection,
-		bool collision_removal,
-		u16 attached_id,
-		bool vertical,
-		video::ITexture *texture,
-		u32 id,
-		const struct TileAnimationParams &anim, u8 glow,
-		ParticleManager* p_manager);
-
-	~ParticleSpawner() = default;
-
-	void step(float dtime, ClientEnvironment *env);
-
-	bool get_expired ()
-	{ return (m_amount <= 0) && m_spawntime != 0; }
-
-private:
-	void spawnParticle(ClientEnvironment *env, float radius,
-			bool is_attached, const v3f &attached_pos,
-			float attached_yaw);
-
-	ParticleManager *m_particlemanager;
-	float m_time;
-	IGameDef *m_gamedef;
-	LocalPlayer *m_player;
-	u16 m_amount;
-	float m_spawntime;
-	v3f m_minpos;
-	v3f m_maxpos;
-	v3f m_minvel;
-	v3f m_maxvel;
-	v3f m_minacc;
-	v3f m_maxacc;
-	float m_minexptime;
-	float m_maxexptime;
-	float m_minsize;
-	float m_maxsize;
-	video::ITexture *m_texture;
-	std::vector<float> m_spawntimes;
-	bool m_collisiondetection;
-	bool m_collision_removal;
-	bool m_vertical;
-	u16 m_attached_id;
-	struct TileAnimationParams m_animation;
-	u8 m_glow;
-};
-
 /**
  * Class doing particle as well as their spawners handling
  */
@@ -181,7 +39,7 @@ public:
 	ParticleManager(ClientEnvironment* env);
 	~ParticleManager();
 
-	void step (float dtime);
+	//void step (float dtime);
 
 	void handleParticleEvent(ClientEvent *event, Client *client,
 			LocalPlayer *player);
@@ -190,22 +48,19 @@ public:
 		const MapNode &n, const ContentFeatures &f);
 
 	void addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
-		const MapNode &n, const ContentFeatures &f);
+		const MapNode &n, const ContentFeatures &f, u32 number = 1);
 
 protected:
-	void addParticle(Particle* toadd);
 
 private:
 
-	void stepParticles (float dtime);
-	void stepSpawners (float dtime);
+//	void stepParticles (float dtime);
+//	void stepSpawners (float dtime);
 
-	void clearAll ();
-
-	std::vector<Particle*> m_particles;
-	std::map<u32, ParticleSpawner*> m_particle_spawners;
+//void clearAll ();
 
 	ClientEnvironment* m_env;
-	std::mutex m_particle_list_lock;
-	std::mutex m_spawner_list_lock;
+	irr::scene::ISceneManager *m_smgr;
+	//std::mutex m_particle_list_lock;
+	//std::mutex m_spawner_list_lock;
 };


### PR DESCRIPTION
Addresses #6523, #1414.
I'd expect it not to be slower than the previous implementation for single particles, but faster for particle spawners with many particles, which only use one scene node.
The textures are rotated by 180°, so that they have the correct orientation when rendered, I'm not sure whether this is a bug in Irrlicht.
TODO:
-scale position, velocity and acceleration properly
-add special collision detection for bouncing particles (#2690)
-measure speed
-remove debug outline
-remove vertical property of CE_ADD_PARTICLESPAWNER and CE_SPAWN_PARTICLE

Mod for testing particlespawners: https://pastebin.com/PBKY7FzP