### PR TITLE
Revert changes in NoiseParams table in lua_api.txt

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1043,13 +1043,13 @@ Accumulates the absolute value of each noise gradient result.
 Noise parameters format example for 2D or 3D perlin noise or perlin noise maps:
 
     np_terrain = {
-        offset = "0",
-        scale = "1",
-        spread = {x="500", y="500", z="500"},
+        offset = 0,
+        scale = 1,
+        spread = {x=500, y=500, z=500},
         seed = 571347,
         octaves = 5,
-        persist = "0.63",
-        lacunarity = "2.0",
+        persist = 0.63,
+        lacunarity = 2.0,
         flags = "defaults, absvalue"
     }
     ^ A single noise parameter table can be used to get 2D or 3D noise,


### PR DESCRIPTION
Revert changes in NoiseParams table in lua_api.txt because it was a mistake.
```
    np_terrain = {
        offset = 0,
        scale = 1,
        spread = {x=500, y=500, z=500},
        seed = 571347,
        octaves = 5,
        persist = 0.63,
        lacunarity = 2.0,
        flags = "defaults, absvalue"
    }
```
(Removing double-quotes.)