### PR TITLE
Allow for getting world name and path separately on the command line

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,12 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+	// List worldpaths if requested
+	if (cmd_args.exists("worldpath") && cmd_args.get("worldpath") == "list") {
+		list_worlds(false, true);
+		return 0;
+	}
+
 	// List worldnames if requested
 	if (cmd_args.exists("worldname") && cmd_args.get("worldname") == "list") {
 		list_worlds(true, false);
@@ -258,6 +264,8 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("map-dir", ValueSpec(VALUETYPE_STRING,
 			_("Same as --world (deprecated)"))));
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,
+			_("Set world path (implies local game) ('list' lists all)"))));
+	allowed_options->insert(std::make_pair("worldpath", ValueSpec(VALUETYPE_STRING,
 			_("Set world path (implies local game) ('list' lists all)"))));
 	allowed_options->insert(std::make_pair("worldname", ValueSpec(VALUETYPE_STRING,
 			_("Set world by name (implies local game) ('list' lists all)"))));
@@ -625,6 +633,8 @@ static bool get_world_from_cmdline(GameParams *game_params, const Settings &cmd_
 
 	if (cmd_args.exists("world"))
 		commanded_world = cmd_args.get("world");
+	else if (cmd_args.exists("worldpath"))
+		commanded_world = cmd_args.get("worldpath");
 	else if (cmd_args.exists("map-dir"))
 		commanded_world = cmd_args.get("map-dir");
 	else if (cmd_args.exists("nonopt0")) // First nameless argument

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,21 +160,15 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
-	// List worlds if requested
-	if (cmd_args.exists("world") && cmd_args.get("world") == "list") {
-		list_worlds(true, true);
-		return 0;
-	}
-
-	// List worldpaths if requested
-	if (cmd_args.exists("worldpath") && cmd_args.get("worldpath") == "list") {
-		list_worlds(false, true);
-		return 0;
-	}
-
-	// List worldnames if requested
-	if (cmd_args.exists("worldname") && cmd_args.get("worldname") == "list") {
-		list_worlds(true, false);
+	// List worlds, world names, and world paths if requested
+	if (cmd_args.exists("worldlist")) {
+		if (cmd_args.get("worldlist") == "name") {
+			list_worlds(true, false);
+		} else if (cmd_args.get("worldlist") == "path") {
+			list_worlds(false, true);
+		} else {
+			list_worlds(true, true);
+		}
 		return 0;
 	}
 
@@ -264,11 +258,11 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("map-dir", ValueSpec(VALUETYPE_STRING,
 			_("Same as --world (deprecated)"))));
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,
-			_("Set world path (implies local game) ('list' lists all)"))));
-	allowed_options->insert(std::make_pair("worldpath", ValueSpec(VALUETYPE_STRING,
-			_("Set world path (implies local game) ('list' lists all paths, no names)"))));
+			_("Set world path (implies local game)"))));
 	allowed_options->insert(std::make_pair("worldname", ValueSpec(VALUETYPE_STRING,
-			_("Set world by name (implies local game) ('list' lists all names, no paths)"))));
+			_("Set world by name (implies local game)"))));
+	allowed_options->insert(std::make_pair("worldlist", ValueSpec(VALUETYPE_STRING,
+			_("Get list of worlds (implies local game) ('path' lists paths, 'name' lists names, 'both' lists both)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
@@ -629,8 +623,6 @@ static bool get_world_from_cmdline(GameParams *game_params, const Settings &cmd_
 
 	if (cmd_args.exists("world"))
 		commanded_world = cmd_args.get("world");
-	else if (cmd_args.exists("worldpath"))
-		commanded_world = cmd_args.get("worldpath");
 	else if (cmd_args.exists("map-dir"))
 		commanded_world = cmd_args.get("map-dir");
 	else if (cmd_args.exists("nonopt0")) // First nameless argument

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,7 +263,7 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Set world by name (implies local game)"))));
 	allowed_options->insert(std::make_pair("worldlist", ValueSpec(VALUETYPE_STRING,
 			_("Get list of worlds (implies local game) ('path' lists paths, "
-					  "'name' lists names, 'both' lists both)"))));
+			"'name' lists names, 'both' lists both)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,9 +266,9 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,
 			_("Set world path (implies local game) ('list' lists all)"))));
 	allowed_options->insert(std::make_pair("worldpath", ValueSpec(VALUETYPE_STRING,
-			_("Set world path (implies local game) ('list' lists all)"))));
+			_("Set world path (implies local game) ('list' lists all paths, no names)"))));
 	allowed_options->insert(std::make_pair("worldname", ValueSpec(VALUETYPE_STRING,
-			_("Set world by name (implies local game) ('list' lists all)"))));
+			_("Set world by name (implies local game) ('list' lists all names, no paths)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
@@ -364,12 +364,14 @@ static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
 		std::string name = worldspec.name;
 		std::string path = worldspec.path;
 		if (print_name && print_path) {
+			os << "\t" << name << "\t\t" << path << std::endl;
+
 			if (name.find(' ') != std::string::npos)
 				name = std::string("'").append(name).append("'");
 			path = std::string("'").append(path).append("'");
 
 			name = padStringRight(name, 14);
-			os << "  " << name << " " << path << std::endl;
+			//os << "  " << name << " " << path << std::endl;
 		} else if (print_name) {
 			os << "  " << name << std::endl;
 		} else if (print_path) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,10 +363,11 @@ static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
 	for (const WorldSpec &worldspec : worldspecs) {
 		std::string name = worldspec.name;
 		std::string path = worldspec.path;
-		if (name.find(' ') != std::string::npos)
-			name = std::string("'").append(name).append("'");
-		path = std::string("'").append(path).append("'");
 		if (print_name && print_path) {
+			if (name.find(' ') != std::string::npos)
+				name = std::string("'").append(name).append("'");
+			path = std::string("'").append(path).append("'");
+
 			name = padStringRight(name, 14);
 			os << "  " << name << " " << path << std::endl;
 		} else if (print_name) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,7 +262,8 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("worldname", ValueSpec(VALUETYPE_STRING,
 			_("Set world by name (implies local game)"))));
 	allowed_options->insert(std::make_pair("worldlist", ValueSpec(VALUETYPE_STRING,
-			_("Get list of worlds (implies local game) ('path' lists paths, 'name' lists names, 'both' lists both)"))));
+			_("Get list of worlds (implies local game) ('path' lists paths, "
+					  "'name' lists names, 'both' lists both)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
@@ -360,9 +361,9 @@ static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
 		if (print_name && print_path) {
 			os << "\t" << name << "\t\t" << path << std::endl;
 		} else if (print_name) {
-			os << "  " << name << std::endl;
+			os << "\t" << name << std::endl;
 		} else if (print_path) {
-			os << "  " << path << std::endl;
+			os << "\t" << path << std::endl;
 		}
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,13 +365,6 @@ static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
 		std::string path = worldspec.path;
 		if (print_name && print_path) {
 			os << "\t" << name << "\t\t" << path << std::endl;
-
-			if (name.find(' ') != std::string::npos)
-				name = std::string("'").append(name).append("'");
-			path = std::string("'").append(path).append("'");
-
-			name = padStringRight(name, 14);
-			//os << "  " << name << " " << path << std::endl;
 		} else if (print_name) {
 			os << "  " << name << std::endl;
 		} else if (print_path) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,11 +74,11 @@ static void print_help(const OptionList &allowed_options);
 static void print_allowed_options(const OptionList &allowed_options);
 static void print_version();
 static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
-							 std::ostream &os);
+	std::ostream &os, bool print_name = true, bool print_path = true);
 static void print_modified_quicktune_values();
 
 static void list_game_ids();
-static void list_worlds();
+static void list_worlds(bool print_name, bool print_path);
 static void setup_log_params(const Settings &cmd_args);
 static bool create_userdata_path();
 static bool init_common(const Settings &cmd_args, int argc, char *argv[]);
@@ -162,7 +162,13 @@ int main(int argc, char *argv[])
 
 	// List worlds if requested
 	if (cmd_args.exists("world") && cmd_args.get("world") == "list") {
-		list_worlds();
+		list_worlds(true, true);
+		return 0;
+	}
+
+	// List worldnames if requested
+	if (cmd_args.exists("worldname") && cmd_args.get("worldname") == "list") {
+		list_worlds(true, false);
 		return 0;
 	}
 
@@ -254,7 +260,7 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,
 			_("Set world path (implies local game) ('list' lists all)"))));
 	allowed_options->insert(std::make_pair("worldname", ValueSpec(VALUETYPE_STRING,
-			_("Set world by name (implies local game)"))));
+			_("Set world by name (implies local game) ('list' lists all)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
@@ -336,15 +342,15 @@ static void list_game_ids()
 		std::cout << gameid <<std::endl;
 }
 
-static void list_worlds()
+static void list_worlds(bool print_name, bool print_path)
 {
 	std::cout << _("Available worlds:") << std::endl;
 	std::vector<WorldSpec> worldspecs = getAvailableWorlds();
-	print_worldspecs(worldspecs, std::cout);
+	print_worldspecs(worldspecs, std::cout, print_name, print_path);
 }
 
 static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
-							 std::ostream &os)
+	std::ostream &os, bool print_name, bool print_path)
 {
 	for (const WorldSpec &worldspec : worldspecs) {
 		std::string name = worldspec.name;
@@ -352,8 +358,14 @@ static void print_worldspecs(const std::vector<WorldSpec> &worldspecs,
 		if (name.find(' ') != std::string::npos)
 			name = std::string("'").append(name).append("'");
 		path = std::string("'").append(path).append("'");
-		name = padStringRight(name, 14);
-		os << "  " << name << " " << path << std::endl;
+		if (print_name && print_path) {
+			name = padStringRight(name, 14);
+			os << "  " << name << " " << path << std::endl;
+		} else if (print_name) {
+			os << "  " << name << std::endl;
+		} else if (print_path) {
+			os << "  " << path << std::endl;
+		}
 	}
 }
 


### PR DESCRIPTION
Adds `--worldpath` option, which works almost the same as `--world`, except when passed `--worldpath list` it gives back paths only without quotes.

 `--worldname list` works the same as `--world list`, but only prints the name.

Inside of `main.c`, `list_worlds` and `print_worldspecs` now take booleans `print_name` and `print_path` (optional in `print_worldspec`, defaults to both) to allow for greater extensible in printing in general. If only path or only name is being printed, it does not use quotes. If both are being printed, it uses the same rules as before.

This implements #6452 

