### PR TITLE
Set vertex color on upright sprites.

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1123,10 +1123,12 @@ void GenericCAO::updateTextures(std::string mod)
 					buf->getMaterial().AmbientColor = m_prop.colors[1];
 					buf->getMaterial().DiffuseColor = m_prop.colors[1];
 					buf->getMaterial().SpecularColor = m_prop.colors[1];
+					setMeshColor(mesh, m_prop.colors[1]);
 				} else if (!m_prop.colors.empty()) {
 					buf->getMaterial().AmbientColor = m_prop.colors[0];
 					buf->getMaterial().DiffuseColor = m_prop.colors[0];
 					buf->getMaterial().SpecularColor = m_prop.colors[0];
+					setMeshColor(mesh, m_prop.colors[0]);
 				}
 
 				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -143,6 +143,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 	makes_footstep_sound = readU8(is);
 	automatic_rotate = readF1000(is);
 	mesh = deSerializeString(is);
+	colors.clear();
 	u32 color_count = readU16(is);
 	for (u32 i = 0; i < color_count; i++){
 		colors.push_back(readARGB8(is));


### PR DESCRIPTION
This sets the vertex color on upright sprites so that they respect the colors object property similar to model.