### PR TITLE
Avoid filtering low-res textures for animated meshes (incl. players)

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1028,6 +1028,13 @@ void GenericCAO::updateTextures(std::string mod)
 				material.setFlag(video::EMF_LIGHTING, false);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 
+				// don't filter low-res textures, makes them look blurry
+				// player models have a res of 64
+				const core::dimension2d<u32> &size = texture->getOriginalSize();
+				const u32 res = std::min(size.Height, size.Width);
+				use_trilinear_filter &= res > 64;
+				use_bilinear_filter &= res > 64;
+
 				m_animated_meshnode->getMaterial(i)
 						.setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
 				m_animated_meshnode->getMaterial(i)


### PR DESCRIPTION
Addressed #6556 
If there's a better way I'd like to know.

This simply does not filter textures for any animated meshes with a resolution of less then or equal to 64. (horizontally or vertically).

This could be configurable, but as long as player textures are fixed the hardcoding of the threshold seemed OK to me.