### PR TITLE
Fix day_night_ratio_do_override not being initialised server-side

### DIFF
--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -159,7 +159,7 @@ private:
 	float m_chat_message_allowance = 5.0f;
 	u16 m_message_rate_overhead = 0;
 
-	bool m_day_night_ratio_do_override;
+	bool m_day_night_ratio_do_override = false;
 	float m_day_night_ratio;
 	std::string hud_hotbar_image = "";
 	std::string hud_hotbar_selected_image = "";


### PR DESCRIPTION
Causes get_day_night_ratio() to return unpredictable results.