### PR TITLE
Allow enter to select items from combobox's list.

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3000,7 +3000,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 			gui::IGUIElement *focused = Environment->getFocus();
 			if (focused && isMyChild(focused) &&
 					(focused->getType() == gui::EGUIET_LIST_BOX ||
-					 focused->getType() == gui::EGUIET_CHECK_BOX)) {
+					 focused->getType() == gui::EGUIET_CHECK_BOX) &&
+					focused->getParent()->getType() != gui::EGUIET_COMBO_BOX) {
 				OnEvent(event);
 				return true;
 			}


### PR DESCRIPTION
Currently if you use the keyboard to search though a combobox and try to select an item with enter, it will close the form without sending the update.