### PR TITLE
Fix Settings tab formspec alignment

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -191,7 +191,7 @@ local function formspec(tabview, name, tabdata)
 				.. getSettingIndex.NodeHighlighting() .. "]" ..
 		"dropdown[0.25,3.6;3.3;dd_leaves_style;" .. dd_options.leaves[1] .. ";"
 				.. getSettingIndex.Leaves() .. "]" ..
-		"box[3.75,0;3.75,4.45;#999999]" ..
+		"box[3.75,0;3.75,4.5;#999999]" ..
 		"label[3.85,0.1;" .. fgettext("Texturing:") .. "]" ..
 		"dropdown[3.85,0.55;3.85;dd_filters;" .. dd_options.filters[1] .. ";"
 				.. getSettingIndex.Filter() .. "]" ..
@@ -203,7 +203,7 @@ local function formspec(tabview, name, tabdata)
 		"label[3.85,3.45;" .. fgettext("Screen:") .. "]" ..
 		"checkbox[3.85,3.6;cb_autosave_screensize;" .. fgettext("Autosave screen size") .. ";"
 				.. dump(core.settings:get_bool("autosave_screensize")) .. "]" ..
-		"box[7.75,0;4,4.4;#999999]" ..
+		"box[7.75,0;4,4.5;#999999]" ..
 		"checkbox[8,0;cb_shaders;" .. fgettext("Shaders") .. ";"
 				.. dump(core.settings:get_bool("enable_shaders")) .. "]"
 


### PR DESCRIPTION
Currently for the three grey backdrops on the Settings tab the tops align but the bottoms don't.  This fixes that by making them the same height. 