### PR TITLE
Preserve node metadata as item metadata.

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -146,8 +146,8 @@ end
 
 local function drop_attached_node(p)
 	local n = core.get_node(p)
-	local node_meta, meta_fields = core.get_meta(p), nil
-	if node_meta then meta_fields = node_meta:to_table().fields end
+	local node_meta = core.get_meta(p)
+	local meta_fields = node_meta and node_meta:to_table().fields end
 	core.remove_node(p)
 	for _, item in pairs(core.get_node_drops(n, "")) do
 		local pos = {
@@ -157,16 +157,16 @@ local function drop_attached_node(p)
 		}
 		-- If it drops itself, preserve its metadata.
 		if item == n and meta_fields then
-			local stack, stack_meta = ItemStack({name=n, count=1}), nil
-			if stack then stack_meta = stack:get_meta() end
+			local stack = ItemStack({name=n, count=1})
+			local stack_meta = stack and stack:get_meta() end
 			if stack_meta then
 				for k,v in pairs(meta_fields) do
 					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
 						stack_meta:set_string(k,v )
 					end
 				end
+				item = stack
 			end
-			item = stack:to_string()
 		end
 		core.add_item(pos, item)
 	end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -146,29 +146,27 @@ end
 
 local function drop_attached_node(p)
 	local n = core.get_node(p)
-	local node_meta = core.get_meta(p)
-	local meta_fields = node_meta and node_meta:to_table().fields
+	local drops = core.get_node_drops(n, "")
+	local def = core.registered_items[n.name]
+	if def and def.preserve_metadata then
+		local oldmeta = core.get_meta(p):to_table().fields
+		-- Copy pos and node because the callback can modify them.
+		local pos_copy = {x=p.x, y=p.y, z=p.z}
+		local node_copy = {name=n.name, param1=n.param1, param2=n.param2}
+		local drop_stacks = {}
+		for k, v in pairs(drops) do
+			drop_stacks[k] = ItemStack(v)
+		end
+		drops = drop_stacks
+		def.preserve_metadata(pos_copy, node_copy, oldmeta, drops)
+	end
 	core.remove_node(p)
-	for _, item in pairs(core.get_node_drops(n, "")) do
+	for _, item in pairs(drops) do
 		local pos = {
 			x = p.x + math.random()/2 - 0.25,
 			y = p.y + math.random()/2 - 0.25,
 			z = p.z + math.random()/2 - 0.25,
 		}
-		-- If it drops itself, preserve its metadata.
-		if meta_fields then
-			-- item is a table in 0.4.16, but a string in 0.5 - handle both.
-			local stack = ItemStack(item)
-			if stack:get_name() == n.name and stack:get_count() == 1 then
-				local stack_meta = stack:get_meta()
-				for k,v in pairs(meta_fields) do
-					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
-						stack_meta:set_string(k, v)
-					end
-				end
-				item = stack
-			end
-		end
 		core.add_item(pos, item)
 	end
 end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -155,18 +155,16 @@ local function drop_attached_node(p)
 			y = p.y + math.random()/2 - 0.25,
 			z = p.z + math.random()/2 - 0.25,
 		}
-		-- If it drops itself, preserve its metadata.
-		if item == n and meta_fields then
-			local stack = ItemStack({name=n, count=1})
+		-- If it drops itself, preserve its metadata.  Assume an air block is never attached.
+		if meta_fields and n.name == item.name then
+			local stack = ItemStack({name=n.name, count=1})
 			local stack_meta = stack and stack:get_meta()
-			if stack_meta then
-				for k,v in pairs(meta_fields) do
-					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
-						stack_meta:set_string(k,v )
-					end
+			for k,v in pairs(meta_fields) do
+				if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
+					stack_meta:set_string(k,v )
 				end
-				item = stack
 			end
+			item = stack
 		end
 		core.add_item(pos, item)
 	end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -155,16 +155,19 @@ local function drop_attached_node(p)
 			y = p.y + math.random()/2 - 0.25,
 			z = p.z + math.random()/2 - 0.25,
 		}
-		-- If it drops itself, preserve its metadata.  Assume an air block is never attached.
-		if meta_fields and n.name == item.name then
-			local stack = ItemStack({name=n.name, count=1})
-			local stack_meta = stack and stack:get_meta()
-			for k,v in pairs(meta_fields) do
-				if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
-					stack_meta:set_string(k,v )
+		-- If it drops itself, preserve its metadata.
+		if meta_fields then
+			-- item is a table in 0.4.16, but a string in 0.5 - handle both.
+			if (type(item) == "table" and n.name == item.name) or (type(item) == "string" and n.name == item) then
+				local stack = ItemStack({name=n.name, count=1})
+				local stack_meta = stack:get_meta()
+				for k,v in pairs(meta_fields) do
+					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
+						stack_meta:set_string(k, v)
+					end
 				end
+				item = stack
 			end
-			item = stack
 		end
 		core.add_item(pos, item)
 	end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -147,7 +147,7 @@ end
 local function drop_attached_node(p)
 	local n = core.get_node(p)
 	local node_meta = core.get_meta(p)
-	local meta_fields = node_meta and node_meta:to_table().fields end
+	local meta_fields = node_meta and node_meta:to_table().fields
 	core.remove_node(p)
 	for _, item in pairs(core.get_node_drops(n, "")) do
 		local pos = {
@@ -158,7 +158,7 @@ local function drop_attached_node(p)
 		-- If it drops itself, preserve its metadata.
 		if item == n and meta_fields then
 			local stack = ItemStack({name=n, count=1})
-			local stack_meta = stack and stack:get_meta() end
+			local stack_meta = stack and stack:get_meta()
 			if stack_meta then
 				for k,v in pairs(meta_fields) do
 					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -146,6 +146,8 @@ end
 
 local function drop_attached_node(p)
 	local n = core.get_node(p)
+	local node_meta, meta_fields = core.get_meta(p), nil
+	if node_meta then meta_fields = node_meta:to_table().fields end
 	core.remove_node(p)
 	for _, item in pairs(core.get_node_drops(n, "")) do
 		local pos = {
@@ -153,6 +155,19 @@ local function drop_attached_node(p)
 			y = p.y + math.random()/2 - 0.25,
 			z = p.z + math.random()/2 - 0.25,
 		}
+		-- If it drops itself, preserve its metadata.
+		if item == n and meta_fields then
+			local stack, stack_meta = ItemStack({name=n, count=1}), nil
+			if stack then stack_meta = stack:get_meta() end
+			if stack_meta then
+				for k,v in pairs(meta_fields) do
+					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
+						stack_meta:set_string(k,v )
+					end
+				end
+			end
+			item = stack:to_string()
+		end
 		core.add_item(pos, item)
 	end
 end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -158,8 +158,8 @@ local function drop_attached_node(p)
 		-- If it drops itself, preserve its metadata.
 		if meta_fields then
 			-- item is a table in 0.4.16, but a string in 0.5 - handle both.
-			if (type(item) == "table" and n.name == item.name) or (type(item) == "string" and n.name == item) then
-				local stack = ItemStack({name=n.name, count=1})
+			local stack = ItemStack(item)
+			if stack:get_name() == n.name and stack:get_count() == 1 then
 				local stack_meta = stack:get_meta()
 				for k,v in pairs(meta_fields) do
 					if k ~= "description" and k ~= "infotext" and k ~= "formspec" then

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -578,12 +578,25 @@ function core.node_dig(pos, node, digger)
 		digger:set_wielded_item(wielded)
 	end
 
-	-- Handle drops
+	-- Handle drops.  If it drops itself, preserve its metadata.
+	local oldmetadata = nil
+	if #drops == 1 then
+		local stack = ItemStack(drops[1])
+		if stack:get_name() == node.name and stack:get_count() == 1 then
+			oldmetadata = core.get_meta(pos):to_table()
+			local stack_meta = stack:get_meta()
+			for k,v in pairs(oldmetadata.fields) do
+				if k ~= "description" and k ~= "infotext" and k ~= "formspec" then
+					stack_meta:set_string(k, v)
+				end
+			end
+			drops[1] = stack
+		end
+	end
 	core.handle_node_drops(pos, drops, digger)
 
-	local oldmetadata = nil
 	if def and def.after_dig_node then
-		oldmetadata = core.get_meta(pos):to_table()
+		oldmetadata = oldmetadata or core.get_meta(pos):to_table()
 	end
 
 	-- Remove node and update

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4624,7 +4624,7 @@ Definition tables
 	  node is deleted from the world or the drops are added.  This is generally
 	  the result of either the node being dug or an attached node becoming detached.
 	^ drops is a table of ItemStacks, so any metadata to be preserved can be
-	added directly to one or more of the dropped items.  See "ItemStackMetaRef".
+	 added directly to one or more of the dropped items.  See "ItemStackMetaRef".
 	^ default: nil ]]
         after_place_node = func(pos, placer, itemstack, pointed_thing) --[[
         ^ Called after constructing node when node was placed using

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4624,7 +4624,7 @@ Definition tables
 	  node is deleted from the world or the drops are added.  This is generally
 	  the result of either the node being dug or an attached node becoming detached.
 	^ drops is a table of ItemStacks, so any metadata to be preserved can be
-	 added directly to one or more of the dropped items.  See "ItemStackMetaRef".
+	  added directly to one or more of the dropped items.  See "ItemStackMetaRef".
 	^ default: nil ]]
         after_place_node = func(pos, placer, itemstack, pointed_thing) --[[
         ^ Called after constructing node when node was placed using

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4619,6 +4619,13 @@ Definition tables
         ^ interval. Default: nil.
         ^ Warning: making a liquid node 'floodable' does not work and may cause problems. ]]
 
+	preserve_metadata = func(pos, oldnode, oldmeta, drops) --[[
+	^ Called when oldnode is about be converted to an item, but before the
+	  node is deleted from the world or the drops are added.  This is generally
+	  the result of either the node being dug or an attached node becoming detached.
+	^ drops is a table of ItemStacks, so any metadata to be preserved can be
+	added directly to one or more of the dropped items.  See "ItemStackMetaRef".
+	^ default: nil ]]
         after_place_node = func(pos, placer, itemstack, pointed_thing) --[[
         ^ Called after constructing node when node was placed using
           minetest.item_place_node / minetest.place_node


### PR DESCRIPTION
If a node with metadata is dug, metadata is lost.  This includes digging up the node under an attached node.

I have a book sitting on a table, when I destroy the table, all the text disappears.

But now that we have item metadata, it makes sense to give the node a chance to save the metadata onto its drops before the node is destroyed.  This will not change the default behaviour - if the node does not implement the callback defined in this pull, the old behaviour continues.