### PR TITLE
Remove incorrect entry from settingtypes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -180,10 +180,6 @@ keymap_cmd (Command key) key /
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_cmd_local (Command key) key .
 
-#    Key for opening the chat console.
-#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keyman_console (Console key) key KEY_F10
-
 #    Key for toggling unlimited view range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_rangeselect (Range select key) key KEY_KEY_R

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -164,11 +164,6 @@
 #    type: key
 # keymap_cmd_local = .
 
-#    Key for opening the chat console.
-#    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-#    type: key
-# keyman_console = KEY_F10
-
 #    Key for toggling unlimited view range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key


### PR DESCRIPTION
It appears opening the chat console was included twice, once with typo.