### PR TITLE
Reuse vmip/noise/param2 table whenever possible

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -925,7 +925,7 @@ int ModApiEnvMod::l_get_perlin_map(lua_State *L)
 	v3s16 size = read_v3s16(L, 2);
 
 	s32 seed = (s32)(env->getServerMap().getSeed());
-	LuaPerlinNoiseMap *n = new LuaPerlinNoiseMap(&np, seed, size);
+	LuaPerlinNoiseMap *n = new LuaPerlinNoiseMap(L, &np, seed, size);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = n;
 	luaL_getmetatable(L, "PerlinNoiseMap");
 	lua_setmetatable(L, -2);

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -62,6 +62,7 @@ class LuaPerlinNoiseMap : public ModApiBase
 	NoiseParams np;
 	Noise *noise;
 	bool m_is3d;
+	int m_table_ref;
 	static const char className[];
 	static const luaL_Reg methods[];
 
@@ -80,6 +81,7 @@ class LuaPerlinNoiseMap : public ModApiBase
 	static int l_getMapSlice(lua_State *L);
 
 public:
+	LuaPerlinNoiseMap(lua_State *L, NoiseParams *params, s32 seed, v3s16 size);
 	LuaPerlinNoiseMap(NoiseParams *np, s32 seed, v3s16 size);
 
 	~LuaPerlinNoiseMap();

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -30,6 +30,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mapgen.h"
 #include "voxelalgorithms.h"
 
+const std::string LuaVoxelManip::mg_vm_data_table_ref = "LuaVoxelManip MG Data";
+const std::string LuaVoxelManip::mg_vm_param2_table_ref = "LuaVoxelManip MG Param2";
+
 // garbage collector
 int LuaVoxelManip::gc_object(lua_State *L)
 {
@@ -69,7 +72,10 @@ int LuaVoxelManip::l_get_data(lua_State *L)
 
 	u32 volume = vm->m_area.getVolume();
 
-	if (use_buffer)
+	if (o->is_mapgen_vm) {
+		lua_pushlightuserdata(L, (void *)&mg_vm_data_table_ref);
+		lua_gettable(L, LUA_REGISTRYINDEX);
+	} else if (use_buffer)
 		lua_pushvalue(L, 2);
 	else
 		lua_newtable(L);
@@ -299,7 +305,10 @@ int LuaVoxelManip::l_get_param2_data(lua_State *L)
 
 	u32 volume = vm->m_area.getVolume();
 
-	if (use_buffer)
+	if (o->is_mapgen_vm) {
+		lua_pushlightuserdata(L, (void *)&mg_vm_param2_table_ref);
+		lua_gettable(L, LUA_REGISTRYINDEX);
+	} else if (use_buffer)
 		lua_pushvalue(L, 2);
 	else
 		lua_newtable(L);
@@ -444,6 +453,14 @@ void LuaVoxelManip::Register(lua_State *L)
 
 	luaL_openlib(L, 0, methods, 0);  // fill methodtable
 	lua_pop(L, 1);  // drop methodtable
+
+	lua_pushlightuserdata(L, (void *)&mg_vm_data_table_ref);
+	lua_newtable(L);
+	lua_settable(L, LUA_REGISTRYINDEX);
+
+	lua_pushlightuserdata(L, (void *)&mg_vm_param2_table_ref);
+	lua_newtable(L);
+	lua_settable(L, LUA_REGISTRYINDEX);
 
 	// Can be created from Lua (VoxelManip())
 	lua_register(L, className, create_object);

--- a/src/script/lua_api/l_vmanip.h
+++ b/src/script/lua_api/l_vmanip.h
@@ -35,6 +35,8 @@ class LuaVoxelManip : public ModApiBase
 private:
 	std::map<v3s16, MapBlock *> modified_blocks;
 	bool is_mapgen_vm = false;
+	static const std::string mg_vm_data_table_ref;
+	static const std::string mg_vm_param2_table_ref;
 
 	static const char className[];
 	static const luaL_Reg methods[];


### PR DESCRIPTION
This patch makes vmip, noise and param2 reuses it's table whenever possible without user requiring to specify a 'buffer'.

Note: This patch assume the number of items will stay the same when it `is_mapgen_vm` for data and param2, I notice some mods using ipairs with the data/param2 table, which is just crazy but it shouldn't not affect it much since the `set` functions uses the volume of the vmip.

As @paramat said: [Many mods still don't use these optimisations and should.](https://github.com/minetest/minetest/issues/2988#issuecomment-342778017)

Using @paramat's riverdiv lua mapgen asl97/riverdev@8cedbdd
Memory usage was a stable around 10000+ instead of ballooning 90000+ per chunk.

Using a random modpack which I found with a lot of data and param2 usage, https://github.com/duane-r/duane_world
Memory usage when down from starting 110000+ plus around 40000(?)+ per chunk growth to a stable 65000+.

Also, using this very bad mod to simulate 11 mods with lua mapgen without 'buffer':
```lua
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
minetest.register_on_generated(function(minp, maxp)
    local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
    local data = vm:get_data()
    print(collectgarbage("count"))
end)
```

Before: memory ballooning:
```
17745.083984375
34129.490234375
50513.896484375
66898.302734375
83282.708984375
99667.115234375
116051.52148438
132435.92773438
148820.33398438
165204.74023438
181589.14648438
197990.58398438
214374.99023438
230759.39648438
247143.80273438
263528.20898438
279912.61523438
296297.02148438
312681.42773438
329065.83398438
345450.24023438
361834.64648438
```
After stable memory usage:
```
18281.240234375
18281.607421875
18281.974609375
18282.341796875
18281.076171875
18276.48828125
18271.3828125
18266.333984375
18259.788085938
18252.221679688
18243.491210938
17734.760742188
17735.127929688
17735.495117188
17735.862304688
17736.229492188
17736.596679688
17736.963867188
17737.331054688
17737.698242188
17738.065429688
17738.432617188
```

Related: #2988
Technique reference: https://www.lua.org/pil/27.3.1.html https://www.lua.org/pil/27.3.2.html