### PR TITLE
Biome dust node: Only place on 'walkable' cubic non-liquid drawtypes

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -831,7 +831,16 @@ void MapgenBasic::dustTopNodes()
 		}
 
 		content_t c = vm->m_data[vi].getContent();
-		if (!ndef->get(c).buildable_to && c != CONTENT_IGNORE && c != biome->c_dust) {
+		NodeDrawType dtype = ndef->get(c).drawtype;
+		// Only place on walkable cubic non-liquid nodes
+		// Dust check needed due to vertical overgeneration
+		if ((dtype == NDT_NORMAL ||
+				dtype == NDT_ALLFACES_OPTIONAL ||
+				dtype == NDT_GLASSLIKE_FRAMED_OPTIONAL ||
+				dtype == NDT_GLASSLIKE ||
+				dtype == NDT_GLASSLIKE_FRAMED ||
+				dtype == NDT_ALLFACES) &&
+				ndef->get(c).walkable && c != biome->c_dust) {
 			vm->m_area.add_y(em, vi, 1);
 			vm->m_data[vi] = MapNode(biome->c_dust);
 		}


### PR DESCRIPTION
No longer decide placement on 'buildable_to' parameter.
Dust nodes only look acceptable placed on cubic nodes.
Modders may not want to make their plantlike decorations 'buildable_to'.
////////////

![screenshot_20171117_004143](https://user-images.githubusercontent.com/3686677/32923575-335d4f2c-cb30-11e7-801e-e7dc1f98308f.png)

^ With dry shrubs 'buiildable_to = false', no snow placed on top

Attends to #6627 
Tested.