### PR TITLE
Minetest dependencies for Linux in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,27 @@ Compiling
 
 ### Compiling on GNU/Linux
 
-Install dependencies. Here's an example for Debian/Ubuntu:
+#### Dependencies
+
+| Dependency | Version | Commentary |
+|------------|---------|------------|
+| GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
+| CMake      | 2.6+    |            |
+| Irrlicht   | 1.8.0+  |            |
+| SQLite3    | 3.8+    |            |
+| Lua        | 5.1.0+  | Bundled Lua is used if not present; can be replaced with LuaJIT 2.0 |
+| GMP        | 6.0.0+  | Bundled mini-GMP is used if not present |
+| JsonCPP    | 1.7.0+  | Bundled JsonCPP is used if not present |
+
+For Debian/Ubuntu:
 
     $ sudo apt-get install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev
 
 For Fedora users:
 
     $ sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl* openal* libvorbis* libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel irrlicht-devel bzip2-libs gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel doxygen spatialindex-devel bzip2-devel
+
+#### Download
 
 You can install git for easily keeping your copy up to date.
 If you don’t want git, read below on how to get the source without git.  
@@ -158,6 +172,8 @@ Download minetest_game, without using git:
     $ tar xf master.tar.gz
     $ mv minetest_game-master minetest_game
     $ cd ..
+
+#### Build
 
 Build a version that runs directly from the source directory:
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Compiling
 | CMake      | 2.6+    |            |
 | Irrlicht   | 1.7.3+  |            |
 | SQLite3    | 3.0+    |            |
-| LuaJIT     | 2.0+    | Bundled Lua is used if not present |
+| LuaJIT     | 2.0+    | Bundled Lua 5.1 is used if not present |
 | GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
 | JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ Compiling
 |------------|---------|------------|
 | GCC        | 4.9+    | Can be replaced with Clang 3.4+ |
 | CMake      | 2.6+    |            |
-| Irrlicht   | 1.8.0+  |            |
-| SQLite3    | 3.8+    |            |
-| Lua        | 5.1.0+  | Bundled Lua is used if not present; can be replaced with LuaJIT 2.0 |
-| GMP        | 6.0.0+  | Bundled mini-GMP is used if not present |
-| JsonCPP    | 1.7.0+  | Bundled JsonCPP is used if not present |
+| Irrlicht   | 1.7.3+  |            |
+| SQLite3    | 3.0+    |            |
+| LuaJIT     | 2.0+    | Bundled Lua is used if not present |
+| GMP        | 5.0.0+  | Bundled mini-GMP is used if not present |
+| JsonCPP    | 1.0.0+  | Bundled JsonCPP is used if not present |
 
 For Debian/Ubuntu:
 


### PR DESCRIPTION
There is a table with needed packages for Unix. I wrote GCC's minimum version 4.9+ because at 4.8 jsoncpp can't be compiled normally (as CMakeLists.txt says).

P.s. JsonCPP 1.0 is also probably usable.