### PR TITLE
Improve mainmenu button alignment

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -93,9 +93,9 @@ local function get_formspec(tabview, name, tabdata)
 				)
 
 	retval = retval ..
-			"button[4,4.15;2.6,0.5;world_delete;".. fgettext("Delete") .. "]" ..
-			"button[6.5,4.15;2.8,0.5;world_create;".. fgettext("New") .. "]" ..
-			"button[9.2,4.15;2.55,0.5;world_configure;".. fgettext("Configure") .. "]" ..
+			"button[4,3.95;2.6,1;world_delete;".. fgettext("Delete") .. "]" ..
+			"button[6.5,3.95.15;2.8,1;world_create;".. fgettext("New") .. "]" ..
+			"button[9.2,3.95;2.5,1;world_configure;".. fgettext("Configure") .. "]" ..
 			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
 			"checkbox[0.25,0.25;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
 			dump(core.settings:get_bool("creative_mode")) .. "]"..
@@ -109,7 +109,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	if core.settings:get_bool("enable_server") then
 		retval = retval ..
-				"button[8.5,5;3.25,0.5;play;".. fgettext("Host Game") .. "]" ..
+				"button[8.5,4.8;3.2,1;play;".. fgettext("Host Game") .. "]" ..
 				"checkbox[0.25,1.6;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]" ..
 				"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
@@ -131,7 +131,7 @@ local function get_formspec(tabview, name, tabdata)
 		end
 	else
 		retval = retval ..
-				"button[8.5,5;3.25,0.5;play;".. fgettext("Play Game") .. "]"
+				"button[8.5,4.8;3.2,1;play;".. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_mods.lua
+++ b/builtin/mainmenu/tab_mods.lua
@@ -84,9 +84,9 @@ local function get_formspec(tabview, name, tabdata)
 
 		if selected_mod.is_modpack then
 			retval = retval .. ";0]" ..
-				"button[10,4.85;2,0.5;btn_mod_mgr_rename_modpack;" ..
+				"button[9.9,4.65;2,1;btn_mod_mgr_rename_modpack;" ..
 				fgettext("Rename") .. "]"
-			retval = retval .. "button[5.5,4.85;4.5,0.5;btn_mod_mgr_delete_mod;"
+			retval = retval .. "button[5.5,4.65;4.5,1;btn_mod_mgr_delete_mod;"
 				.. fgettext("Uninstall Selected Modpack") .. "]"
 		else
 			--show dependencies
@@ -109,7 +109,7 @@ local function get_formspec(tabview, name, tabdata)
 
 			retval = retval .. ";0]"
 
-			retval = retval .. "button[5.5,4.85;4.5,0.5;btn_mod_mgr_delete_mod;"
+			retval = retval .. "button[5.5,4.65;4.5,1;btn_mod_mgr_delete_mod;"
 				.. fgettext("Uninstall Selected Mod") .. "]"
 		end
 	end

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -33,8 +33,8 @@ local function get_formspec(tabview, name, tabdata)
 
 	local retval =
 		-- Search
-		"field[0.15,0.35;6.05,0.27;te_search;;"..core.formspec_escape(tabdata.search_for).."]"..
-		"button[5.8,0.1;2,0.1;btn_mp_search;" .. fgettext("Search") .. "]" ..
+		"field[0.15,0.075;6.05,1;te_search;;"..core.formspec_escape(tabdata.search_for).."]"..
+		"button[5.8,-0.25;2,1;btn_mp_search;" .. fgettext("Search") .. "]" ..
 
 		-- Address / Port
 		"label[7.75,-0.25;" .. fgettext("Address / Port") .. "]" ..
@@ -53,7 +53,7 @@ local function get_formspec(tabview, name, tabdata)
 		"box[7.73,2.25;4.25,2.6;#999999]"..
 
 		-- Connect
-		"button[10.1,5.15;2,0.5;btn_mp_connect;" .. fgettext("Connect") .. "]"
+		"button[10,4.9;2.18,1;btn_mp_connect;" .. fgettext("Connect") .. "]"
 
 	if tabdata.fav_selected and fav_selected then
 		if gamedata.fav then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -53,11 +53,11 @@ local function get_formspec(tabview, name, tabdata)
 		"box[7.73,2.25;4.25,2.6;#999999]"..
 
 		-- Connect
-		"button[10,4.9;2.18,1;btn_mp_connect;" .. fgettext("Connect") .. "]"
+		"button[9.88,4.9;2.3,1;btn_mp_connect;" .. fgettext("Connect") .. "]"
 
 	if tabdata.fav_selected and fav_selected then
 		if gamedata.fav then
-			retval = retval .. "button[7.75,5.15;2.3,0.5;btn_delete_favorite;" ..
+			retval = retval .. "button[7.73,4.9;2.3,1;btn_delete_favorite;" ..
 				fgettext("Del. Favorite") .. "]"
 		end
 		if fav_selected.description then

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -209,16 +209,16 @@ local function formspec(tabview, name, tabdata)
 
 	if PLATFORM == "Android" then
 		tab_string = tab_string ..
-			"button[8,4.75;4.1,1;btn_reset_singleplayer;"
+			"button[8,4.75;3.95,1;btn_reset_singleplayer;"
 			.. fgettext("Reset singleplayer world") .. "]"
 	else
 		tab_string = tab_string ..
-			"button[8,4.75;4,1;btn_change_keys;"
+			"button[8,4.75;3.95,1;btn_change_keys;"
 			.. fgettext("Change Keys") .. "]"
 	end
 
 	tab_string = tab_string ..
-		"button[0,4.75;4,1;btn_advanced_settings;"
+		"button[0,4.75;3.95,1;btn_advanced_settings;"
 		.. fgettext("Advanced Settings") .. "]"
 
 


### PR DESCRIPTION
For the Online tab:
- Keeps the tops of the search field and search button aligned. Currently small window sizes disrupt this and neither the top nor bottom of the button align with the field. See current vs. with this PR:
![ba01](https://user-images.githubusercontent.com/7035183/32970944-02fb8caa-cbe3-11e7-9920-bf2c17e00bba.png)
- Fixes this (right side of the Connect button not aligned with the box above it.):
![ba02](https://user-images.githubusercontent.com/7035183/32970975-1ce6efd8-cbe3-11e7-9163-e24735794873.png)

For the Local tab:
- Aligns right side of Configure and Play/Host Server buttons with Select World box.

For Settings tab:
- Tiny fix for where buttons are too wide when window is maximised.
