### PR TITLE
Light curve: Add and tune mid boost

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -574,9 +574,21 @@ zoom_fov (Field of view for zoom) int 15 7 160
 #    This setting is for the client only and is ignored by the server.
 display_gamma (Gamma) float 1.0 0.5 3.0
 
+#    Gradient of light curve at minimum light level.
 lighting_alpha (Darkness sharpness) float 0.0 0.0 4.0
 
-lighting_beta (Lightness sharpness) float 0.0 0.0 4.0
+#    Gradient of light curve at maximum light level.
+lighting_beta (Lightness sharpness) float 1.5 0.0 4.0
+
+#    Strength of light curve mid-boost.
+lighting_boost (Light curve mid boost) float 0.2 0.0 1.0
+
+#    Center of light curve mid-boost.
+lighting_boost_center (Light curve mid boost center) float 0.5 0.0 1.0
+
+#    Spread of light curve mid-boost.
+#    Standard deviation of the mid-boost gaussian.
+lighting_boost_spread (Light curve mid boost spread) float 0.2 0.0 1.0
 
 #    Path to texture directory. All textures are first searched from here.
 texture_path (Texture path) path

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -163,8 +163,11 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("connected_glass", "false");
 	settings->setDefault("smooth_lighting", "true");
 	settings->setDefault("lighting_alpha", "0.0");
-	settings->setDefault("lighting_beta", "0.0");
+	settings->setDefault("lighting_beta", "1.5");
 	settings->setDefault("display_gamma", "1.0");
+	settings->setDefault("lighting_boost", "0.2");
+	settings->setDefault("lighting_boost_center", "0.5");
+	settings->setDefault("lighting_boost_spread", "0.2");
 	settings->setDefault("texture_path", "");
 	settings->setDefault("shader_path", "");
 	settings->setDefault("video_driver", "opengl");

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -24,38 +24,40 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef SERVER
 
-// Length of LIGHT_MAX+1 means LIGHT_MAX is the last value.
+// Length of LIGHT_MAX + 1 means LIGHT_MAX is the last value.
 // LIGHT_SUN is read as LIGHT_MAX from here.
+u8 light_LUT[LIGHT_MAX + 1];
 
-u8 light_LUT[LIGHT_MAX+1];
-
-// the const ref to light_LUT is what is actually used in the code.
+// The const ref to light_LUT is what is actually used in the code
 const u8 *light_decode_table = light_LUT;
 
-/** Initialize or update the light value tables using the specified \p gamma.
- */
+// Initialize or update the light value tables using the specified gamma
 void set_light_table(float gamma)
 {
-// lighting curve derivatives
+// Lighting curve derivatives
 	const float alpha = g_settings->getFloat("lighting_alpha");
 	const float beta  = g_settings->getFloat("lighting_beta");
-// lighting curve coefficients
-	const float a = alpha + beta - 2;
-	const float b = 3 - 2 * alpha - beta;
+// Lighting curve coefficients
+	const float a = alpha + beta - 2.0f;
+	const float b = 3.0f - 2.0f * alpha - beta;
 	const float c = alpha;
-// gamma correction
-	gamma = rangelim(gamma, 0.5, 3.0);
+// Mid boost
+	const float d = g_settings->getFloat("lighting_boost");
+	const float e = g_settings->getFloat("lighting_boost_center");
+	const float f = g_settings->getFloat("lighting_boost_spread");
+// Gamma correction
+	gamma = rangelim(gamma, 0.5f, 3.0f);
 
 	for (size_t i = 0; i < LIGHT_MAX; i++) {
 		float x = i;
 		x /= LIGHT_MAX;
 		float brightness = a * x * x * x + b * x * x + c * x;
-		brightness = powf(brightness, 1.0 / gamma);
-		light_LUT[i] = rangelim((u32)(255 * brightness), 0, 255);
+		float boost = d * std::exp(-((x - e) * (x - e)) / (2.0f * f * f));
+		brightness = powf(brightness + boost, 1.0f / gamma);
+		light_LUT[i] = rangelim((u32)(255.0f * brightness), 0, 255);
 		if (i > 1 && light_LUT[i] <= light_LUT[i - 1])
 			light_LUT[i] = light_LUT[i - 1] + 1;
 	}
 	light_LUT[LIGHT_MAX] = 255;
 }
 #endif
-


### PR DESCRIPTION
 Light curve: Add and tune mid boost gaussian

Create a closer match to the light curve of 0.4.16 stable.
Results in darker shadows while maintaining the 'brightness' and light
spread.
//////////////

New version of #6620 see that thread for more information.

Adds an adjustable mid range boost (a gaussian function) to the light curve to closer approximate sofar's popular light curve of 0.4.16 stable.
The light curve of MT master has reduced the visibility of subtle shadows under trees, due to beta gradient 0.0. This mid range boost allows us to increase beta gradient while preserving the general brightness of lighting.
Classic MT lighting also had a 'raised middle' probably for the same reason.