### PR TITLE
Fix mousewheel behaviour in textarea

### DIFF
--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -1087,7 +1087,7 @@ bool intlGUIEditBox::processMouse(const SEvent& event)
 		}
 		break;
 	case EMIE_MOUSE_WHEEL:
-		if (m_vscrollbar) {
+		if (m_vscrollbar && m_vscrollbar->isVisible()) {
 			s32 pos = m_vscrollbar->getPos();
 			s32 step = m_vscrollbar->getSmallStep();
 			m_vscrollbar->setPos(pos - event.MouseInput.Wheel * step);


### PR DESCRIPTION
Allowing scrolling with the mousewheel when the vertical scrollbar is
hidden, unnecessarily exposes oversized containers and newlines at the
end of the text. For example try scrolling over the textareas in the
pause menu. This PR addresses the issue by requiring the scrollbar to be
visible before allowing scrolling with the mousewheel.