### PR TITLE
Stratum ore: Add option for a constant thickness stratum

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1206,19 +1206,24 @@ computationally expensive than any other ore.
 Creates a single undulating ore stratum that is continuous across mapchunk
 borders and horizontally spans the world.
 
-The 2D perlin noise described by `noise_params` varies the Y co-ordinate of the
+The 2D perlin noise described by `noise_params` defines the Y co-ordinate of the
 stratum midpoint. The 2D perlin noise described by `np_stratum_thickness`
-varies the stratum's vertical thickness (in units of nodes). Due to being
+defines the stratum's vertical thickness (in units of nodes). Due to being
 continuous across mapchunk borders the stratum's vertical thickness is
 unlimited.
+
+If the noise parameter `noise_params` is omitted the ore will occur from y_min
+to y_max in a simple horizontal stratum.
+
+A parameter `stratum_thickness` can be provided instead of the noise parameter
+`np_stratum_thickness`, to create a constant thickness.
+
+Leaving out one or both noise parameters makes the ore generation less intensive,
+useful when adding multiple strata.
 
 `y_min` and `y_max` define the limits of the ore generation and for performance
 reasons should be set as close together as possible but without clipping the
 stratum's Y variation.
-
-If either of the 2 noise parameters are omitted the ore will occur from y_min
-to y_max in a simple horizontal stratum. As this does not compute noise
-performance improves, and is ideal for placing many layers.
 
 Each node in the stratum has a 1-in-`clust_scarcity` chance of being ore, so a
 solid-ore stratum would require a `clust_scarcity` of 1.
@@ -4880,7 +4885,6 @@ Definition tables
         },
     --  ^ See 'Ore types' section above.
     --  ^ The above 2 parameters are only valid for "puff" ore.
-    --  ^ Additional noise parameters needed for "puff" ore.
         random_factor = 1.0,
     --  ^ See 'Ore types' section above.
     --  ^ Only valid for "vein" ore.
@@ -4892,9 +4896,9 @@ Definition tables
             octaves = 3,
             persist = 0.7
         },
+        stratum_thickness = 8,
     --  ^ See 'Ore types' section above.
-    --  ^ Only valid for "stratum" ore.
-    --  ^ Additional noise parameter needed for "stratum" ore.
+    --  ^ The above 2 parameters are only valid for "stratum" ore.
     }
 
 ### Biome definition (`register_biome`)

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -434,13 +434,20 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	MapNode n_ore(c_ore, 0, ore_param2);
 
 	if (flags & OREFLAG_USE_NOISE) {
-		if (!(noise && noise_stratum_thickness)) {
+		if (!noise) {
 			int sx = nmax.X - nmin.X + 1;
 			int sz = nmax.Z - nmin.Z + 1;
 			noise = new Noise(&np, 0, sx, sz);
-			noise_stratum_thickness = new Noise(&np_stratum_thickness, 0, sx, sz);
 		}
 		noise->perlinMap2D(nmin.X, nmin.Z);
+	}
+
+	if (flags & OREFLAG_USE_NOISE2) {
+		if (!noise_stratum_thickness) {
+			int sx = nmax.X - nmin.X + 1;
+			int sz = nmax.Z - nmin.Z + 1;
+			noise_stratum_thickness = new Noise(&np_stratum_thickness, 0, sx, sz);
+		}
 		noise_stratum_thickness->perlinMap2D(nmin.X, nmin.Z);
 	}
 
@@ -458,11 +465,13 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 		int y1;
 
 		if (flags & OREFLAG_USE_NOISE) {
+			float nhalfthick = ((flags & OREFLAG_USE_NOISE2) ?
+				noise_stratum_thickness->result[index] : (float)stratum_thickness) /
+				2.0f;
 			float nmid = noise->result[index];
-			float nhalfthick = noise_stratum_thickness->result[index] / 2.0f;
-			y0 = MYMAX(nmin.Y, nmid - nhalfthick);
+			y0 = MYMAX(nmin.Y, ceil(nmid - nhalfthick));
 			y1 = MYMIN(nmax.Y, nmid + nhalfthick);
-		} else {
+		} else { // Simple horizontal stratum
 			y0 = nmin.Y;
 			y1 = nmax.Y;
 		}

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -35,6 +35,7 @@ class MMVManip;
 #define OREFLAG_PUFF_CLIFFS   0x02
 #define OREFLAG_PUFF_ADDITIVE 0x04
 #define OREFLAG_USE_NOISE     0x08
+#define OREFLAG_USE_NOISE2    0x10
 
 enum OreType {
 	ORE_SCATTER,
@@ -139,6 +140,7 @@ public:
 
 	NoiseParams np_stratum_thickness;
 	Noise *noise_stratum_thickness = nullptr;
+	u16 stratum_thickness;
 
 	OreStratum() = default;
 	virtual ~OreStratum();

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1116,7 +1116,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 		ore->flags |= OREFLAG_USE_NOISE;
 	} else if (ore->NEEDS_NOISE) {
 		errorstream << "register_ore: specified ore type requires valid "
-			"noise parameters" << std::endl;
+			"'noise_params' parameter" << std::endl;
 		delete ore;
 		return 0;
 	}
@@ -1161,10 +1161,12 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 			OreStratum *orestratum = (OreStratum *)ore;
 
 			lua_getfield(L, index, "np_stratum_thickness");
-			// If thickness noise missing unset 'use noise' flag
-			if (!read_noiseparams(L, -1, &orestratum->np_stratum_thickness))
-				ore->flags &= ~OREFLAG_USE_NOISE;
+			if (read_noiseparams(L, -1, &orestratum->np_stratum_thickness))
+				ore->flags |= OREFLAG_USE_NOISE2;
 			lua_pop(L, 1);
+
+			orestratum->stratum_thickness = getintfield_default(L, index,
+				"stratum_thickness", 8);
 
 			break;
 		}


### PR DESCRIPTION
 Stratum ore: Add option for a constant thickness stratum

Add a 'stratum thickness' integer parameter, as an alternative
to providing a 2nd noise parameter for thickness variation.
//////////////

Tested.