### PR TITLE
Zoom: Set zoom FOV per-player using a player object property

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -566,10 +566,6 @@ vsync (V-Sync) bool false
 #    Field of view in degrees.
 fov (Field of view) int 72 30 160
 
-#    Field of view while zooming in degrees.
-#    Requires to be allowed by server-sided mods.
-zoom_fov (Field of view for zoom) int 15 7 160
-
 #    Adjust the gamma encoding for the light tables. Higher numbers are brighter.
 #    This setting is for the client only and is ignored by the server.
 display_gamma (Gamma) float 1.0 0.5 3.0

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4313,8 +4313,13 @@ Definition tables
     --  ^ For players: Defaults to `minetest.PLAYER_MAX_HP_DEFAULT`
         breath_max = 0,
     --  ^ For players only. Defaults to `minetest.PLAYER_MAX_BREATH_DEFAULT`
-        can_zoom = true,
-    --  ^ For players only. Enables the zoom feature. Defaults to true
+        zoom_fov = 0.0,
+    --  ^ For players only. Zoom FOV in degrees.
+    --    Note that zoom loads and/or generates world beyond the server's maximum
+    --    send and generate distances, so acts like a telescope.
+    --    Smaller zoomFOV values increase the distance loaded and/or generated.
+    --    Defaults to 15 in creative mode, 0 in survival mode.
+    --    zoom_fov = 0 disables zooming for the player.
         eye_height = 1.625,
     --  ^ For players only. Camera height above feet position in nodes. Defaults to 1.625
         physical = true,

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -72,8 +72,7 @@ Camera::Camera(MapDrawControl &draw_control, Client *client):
 	m_cache_fall_bobbing_amount = g_settings->getFloat("fall_bobbing_amount");
 	m_cache_view_bobbing_amount = g_settings->getFloat("view_bobbing_amount");
 	m_cache_fov                 = g_settings->getFloat("fov");
-	m_cache_zoom_fov            = g_settings->getFloat("zoom_fov");
-	m_arm_inertia		    = g_settings->getBool("arm_inertia");
+	m_arm_inertia               = g_settings->getBool("arm_inertia");
 	m_nametags.clear();
 }
 
@@ -453,12 +452,13 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Get FOV
 	f32 fov_degrees;
-	if (player->getPlayerControl().zoom && player->getCanZoom()) {
-		fov_degrees = m_cache_zoom_fov;
+	// Disable zoom with zoom FOV = 0
+	if (player->getPlayerControl().zoom && player->getZoomFOV() > 0.001f) {
+		fov_degrees = player->getZoomFOV();
 	} else {
 		fov_degrees = m_cache_fov;
 	}
-	fov_degrees = rangelim(fov_degrees, 1.0, 160.0);
+	fov_degrees = rangelim(fov_degrees, 1.0f, 160.0f);
 
 	// FOV and aspect ratio
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();

--- a/src/camera.h
+++ b/src/camera.h
@@ -225,7 +225,6 @@ private:
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;
 	f32 m_cache_fov;
-	f32 m_cache_zoom_fov;
 	bool m_arm_inertia;
 
 	std::list<Nametag *> m_nametags;

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1259,8 +1259,8 @@ void GenericCAO::processMessage(const std::string &data)
 			collision_box.MinEdge *= BS;
 			collision_box.MaxEdge *= BS;
 			player->setCollisionbox(collision_box);
-			player->setCanZoom(m_prop.can_zoom);
 			player->setEyeHeight(m_prop.eye_height);
+			player->setZoomFOV(m_prop.zoom_fov);
 		}
 
 		if ((m_is_player && !m_is_local_player) && m_prop.nametag.empty())

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 #include "scripting_server.h"
 #include "genericobject.h"
+#include "settings.h"
 #include <algorithm>
 
 std::map<u16, ServerActiveObject::Factory> ServerActiveObject::m_types;
@@ -801,7 +802,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_prop.collisionbox = aabb3f(-0.3f, 0.0f, -0.3f, 0.3f, 1.77f, 0.3f);
 	m_prop.selectionbox = aabb3f(-0.3f, 0.0f, -0.3f, 0.3f, 1.77f, 0.3f);
 	m_prop.pointable = true;
-	// start of default appearance, this should be overwritten by LUA
+	// Start of default appearance, this should be overwritten by Lua
 	m_prop.visual = "upright_sprite";
 	m_prop.visual_size = v2f(1, 2);
 	m_prop.textures.clear();
@@ -811,13 +812,14 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_prop.colors.emplace_back(255, 255, 255, 255);
 	m_prop.spritediv = v2s16(1,1);
 	m_prop.eye_height = 1.625f;
-	// end of default appearance
+	// End of default appearance
 	m_prop.is_visible = true;
 	m_prop.makes_footstep_sound = true;
 	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
-	m_prop.can_zoom = true;
 	m_hp = m_prop.hp_max;
 	m_breath = m_prop.breath_max;
+	// Disable zoom in survival mode using a value of 0
+	m_prop.zoom_fov = g_settings->getBool("creative_mode") ? 15.0f : 0.0f;
 }
 
 PlayerSAO::~PlayerSAO()

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -147,7 +147,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("3d_paralax_strength", "0.025");
 	settings->setDefault("tooltip_show_delay", "400");
 	settings->setDefault("tooltip_append_itemname", "false");
-	settings->setDefault("zoom_fov", "15");
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");

--- a/src/localplayer.h
+++ b/src/localplayer.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "player.h"
 #include "environment.h"
 #include "constants.h"
+#include "settings.h"
 #include <list>
 
 class Client;
@@ -142,8 +143,8 @@ public:
 
 	void setCollisionbox(const aabb3f &box) { m_collisionbox = box; }
 
-	bool getCanZoom() const { return m_can_zoom; }
-	void setCanZoom(bool can_zoom) { m_can_zoom = can_zoom; }
+	float getZoomFOV() const { return m_zoom_fov; }
+	void setZoomFOV(float zoom_fov) { m_zoom_fov = zoom_fov; }
 
 private:
 	void accelerateHorizontal(const v3f &target_speed, const f32 max_increase);
@@ -181,8 +182,8 @@ private:
 	bool camera_barely_in_ceiling = false;
 	aabb3f m_collisionbox = aabb3f(-BS * 0.30f, 0.0f, -BS * 0.30f, BS * 0.30f,
 			BS * 1.75f, BS * 0.30f);
-	bool m_can_zoom = true;
 	float m_eye_height = 1.625f;
+	float m_zoom_fov = 0.0f;
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -183,6 +183,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Change TileDef serialization format.
 		Add world-aligned tiles.
 		Mod channels
+		Raise ObjectProperties version to 3 for removing 'can_zoom' and adding
+			'zoom_fov'.
 */
 
 #define LATEST_PROTOCOL_VERSION 36

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -65,15 +65,15 @@ std::string ObjectProperties::dump()
 			<< "," << nametag_color.getGreen() << "," << nametag_color.getBlue() << "\" ";
 	os << ", selectionbox=" << PP(selectionbox.MinEdge) << "," << PP(selectionbox.MaxEdge);
 	os << ", pointable=" << pointable;
-	os << ", can_zoom=" << can_zoom;
 	os << ", static_save=" << static_save;
 	os << ", eye_height=" << eye_height;
+	os << ", zoom_fov=" << zoom_fov;
 	return os.str();
 }
 
 void ObjectProperties::serialize(std::ostream &os) const
 {
-	writeU8(os, 2); // version, protocol_version >= 36
+	writeU8(os, 3); // version, protocol_version >= 36
 	writeS16(os, hp_max);
 	writeU8(os, physical);
 	writeF1000(os, weight);
@@ -109,10 +109,10 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
 	os << serializeString(infotext);
 	os << serializeString(wield_item);
-	writeU8(os, can_zoom);
 	writeS8(os, glow);
 	writeU16(os, breath_max);
 	writeF1000(os, eye_height);
+	writeF1000(os, zoom_fov);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -121,7 +121,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 void ObjectProperties::deSerialize(std::istream &is)
 {
 	int version = readU8(is);
-	if (version != 2)
+	if (version != 3)
 		throw SerializationError("unsupported ObjectProperties version");
 
 	hp_max = readS16(is);
@@ -159,11 +159,8 @@ void ObjectProperties::deSerialize(std::istream &is)
 	automatic_face_movement_max_rotation_per_sec = readF1000(is);
 	infotext = deSerializeString(is);
 	wield_item = deSerializeString(is);
-	can_zoom = readU8(is);
-
-	try {
-		glow = readS8(is);
-		breath_max = readU16(is);
-		eye_height = readF1000(is);
-	} catch (SerializationError &e) {}
+	glow = readS8(is);
+	breath_max = readU16(is);
+	eye_height = readF1000(is);
+	zoom_fov = readF1000(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -46,7 +46,6 @@ struct ObjectProperties
 	bool is_visible = true;
 	bool makes_footstep_sound = false;
 	f32 stepheight = 0.0f;
-	bool can_zoom = true;
 	float automatic_rotate = 0.0f;
 	bool automatic_face_movement_dir = false;
 	f32 automatic_face_movement_dir_offset = 0.0f;
@@ -60,6 +59,7 @@ struct ObjectProperties
 	std::string wield_item;
 	bool static_save = true;
 	float eye_height = 1.625f;
+	float zoom_fov = 0.0f;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -265,7 +265,6 @@ void read_object_properties(lua_State *L, int index,
 	getboolfield(L, -1, "makes_footstep_sound", prop->makes_footstep_sound);
 	if (getfloatfield(L, -1, "stepheight", prop->stepheight))
 		prop->stepheight *= BS;
-	getboolfield(L, -1, "can_zoom", prop->can_zoom);
 	getfloatfield(L, -1, "eye_height", prop->eye_height);
 
 	getfloatfield(L, -1, "automatic_rotate", prop->automatic_rotate);
@@ -303,6 +302,8 @@ void read_object_properties(lua_State *L, int index,
 	if (!lua_isnil(L, -1))
 		prop->wield_item = read_item(L, -1, idef).getItemString();
 	lua_pop(L, 1);
+
+	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
 }
 
 /******************************************************************************/
@@ -358,8 +359,6 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "makes_footstep_sound");
 	lua_pushnumber(L, prop->stepheight / BS);
 	lua_setfield(L, -2, "stepheight");
-	lua_pushboolean(L, prop->can_zoom);
-	lua_setfield(L, -2, "can_zoom");
 	lua_pushnumber(L, prop->eye_height);
 	lua_setfield(L, -2, "eye_height");
 	lua_pushnumber(L, prop->automatic_rotate);
@@ -385,6 +384,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "static_save");
 	lua_pushlstring(L, prop->wield_item.c_str(), prop->wield_item.size());
 	lua_setfield(L, -2, "wield_item");
+	lua_pushnumber(L, prop->zoom_fov);
+	lua_setfield(L, -2, "zoom_fov");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
 Zoom: Set zoom FOV per-player using a player object property

Remove player object property 'can zoom'.
Add player object property 'zoom fov'.
Remove clientside setting for 'zoom fov'.
Object property default is 15 degrees in creative mode, zoom disabled
in survival mode.

Needed due to zoom now loading and/or generating distant world
according to zoom FOV.

Update object properties serialisation version to 3.
///////////////

Merge https://github.com/minetest/minetest_game/pull/1956 soon after this.

Together with lhofhansl's recent work this will allow a game to provide an item which enables a particular zoom FOV, which in turn allows a certain distance of world to be loaded in when using zoom.
For example a powerful telescope item that allows a zoom FOV of 1 degree, which is capable of loading (and/or generating) world 2000 nodes away.

A server mod can still disable zooming for a player by setting zoom FOV to 0. So the functionality of the previous 'can zoom' property is kept.