### PR TITLE
Clearobjects: Send progress messages to terminal using actionstream

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -896,10 +896,10 @@ core.register_chatcommand("clearobjects", {
 	privs = {server=true},
 	func = function(name, param)
 		local options = {}
-		if param == "" or param == "full" then
-			options.mode = "full"
-		elseif param == "quick" then
+		if param == "" or param == "quick" then
 			options.mode = "quick"
+		elseif param == "full" then
+			options.mode = "full"
 		else
 			return false, "Invalid usage, see /help clearobjects."
 		end

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -956,7 +956,7 @@ int ModApiEnvMod::l_clear_objects(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	ClearObjectsMode mode = CLEAR_OBJECTS_MODE_FULL;
+	ClearObjectsMode mode = CLEAR_OBJECTS_MODE_QUICK;
 	if (lua_istable(L, 1)) {
 		mode = (ClearObjectsMode)getenumfield(L, 1, "mode",
 			ModApiEnvMod::es_ClearObjectsMode, mode);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1024,7 +1024,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 		loadable_blocks = loaded_blocks;
 	}
 
-	infostream << "ServerEnvironment::clearObjects(): "
+	actionstream << "ServerEnvironment::clearObjects(): "
 		<< "Now clearing objects in " << loadable_blocks.size()
 		<< " blocks" << std::endl;
 
@@ -1070,7 +1070,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 			num_blocks_checked % report_interval == 0) {
 			float percent = 100.0 * (float)num_blocks_checked /
 				loadable_blocks.size();
-			infostream << "ServerEnvironment::clearObjects(): "
+			actionstream << "ServerEnvironment::clearObjects(): "
 				<< "Cleared " << num_objs_cleared << " objects"
 				<< " in " << num_blocks_cleared << " blocks ("
 				<< percent << "%)" << std::endl;
@@ -1090,7 +1090,7 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 
 	m_last_clear_objects_time = m_game_time;
 
-	infostream << "ServerEnvironment::clearObjects(): "
+	actionstream << "ServerEnvironment::clearObjects(): "
 		<< "Finished: Cleared " << num_objs_cleared << " objects"
 		<< " in " << num_blocks_cleared << " blocks" << std::endl;
 }


### PR DESCRIPTION
 Clearobjects: Send progress messages to terminal using actionstream

Change default mode to 'quick' as 'full' can lock up a server for a
long time.
/////////////

Attends to #1620 
Progress messages only being sent to debug.txt via infostream is rather pointless as they can't be viewed in real time, so this sends them to terminal using actionstream.
Terminal messages:
```
2017-11-23 00:50:00: ACTION[Server]: singleplayer clears all objects (quick mode).
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Now clearing objects in 1412 blocks
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (9.98584%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (19.9717%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (29.9575%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (39.9433%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (49.9292%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (59.915%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (69.9008%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (79.8867%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (89.8725%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Cleared 0 objects in 0 blocks (99.8584%)
2017-11-23 00:50:00: ACTION[Server]: ServerEnvironment::clearObjects(): Finished: Cleared 0 objects in 0 blocks
2017-11-23 00:50:00: ACTION[Server]: Object clearing done.
```