### PR TITLE
CSM: Revert "[CSM] Add send_chat_message and run_server_chatcommand"

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -51,15 +51,3 @@ core.register_chatcommand("disconnect", {
 		core.disconnect()
 	end,
 })
-
-core.register_chatcommand("clear_chat_queue", {
-	description = core.gettext("Clear the out chat queue"),
-	func = function(param)
-		core.clear_out_chat_queue()
-		return true, core.gettext("The out chat queue is now empty")
-	end,
-})
-
-function core.run_server_chatcommand(cmd, param)
-	core.send_chat_message("/" .. cmd .. " " .. param)
-end

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -829,9 +829,6 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 #    File in client/serverlist/ that contains your favorite servers displayed in the Multiplayer Tab.
 serverlist_file (Serverlist file) string favoriteservers.txt
 
-#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
-max_out_chat_queue_size (Maximum size of the out chat queue) int 20
-
 [*Advanced]
 
 #    Timeout for client to remove unused map data from memory.
@@ -1105,7 +1102,6 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    Restricts the access of certain client-side functions on servers
 #    Combine these byteflags below to restrict more client-side features:
 #    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
-#    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    type: int

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -743,12 +743,6 @@ Call these functions only at load time!
 ### Player
 * `minetest.get_wielded_item()`
     * Returns the itemstack the local player is holding
-* `minetest.send_chat_message(message)`
-    * Act as if `message` was typed by the player into the terminal.
-* `minetest.run_server_chatcommand(cmd, param)`
-    * Alias for `minetest.send_chat_message("/" .. cmd .. " " .. param)`
-* `minetest.clear_out_chat_queue()`
-    * Clears the out chat queue
 * `minetest.localplayer`
     * Reference to the LocalPlayer object. See [`LocalPlayer`](#localplayer) class reference for methods.
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -990,10 +990,6 @@
 #    type: string
 # serverlist_file = favoriteservers.txt
 
-#    Maximum size of the out chat queue. 0 to disable queueing and -1 to make the queue size unlimited
-#    type: int
-# max_out_chat_queue_size = 20
-
 ## Advanced
 
 #    Timeout for client to remove unused map data from memory.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -91,7 +91,6 @@ Client::Client(
 	m_con(new con::Connection(PROTOCOL_ID, 512, CONNECTION_TIMEOUT, ipv6, this)),
 	m_address_name(address_name),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
-	m_last_chat_message_sent(time(NULL)),
 	m_password(password),
 	m_chosen_auth_mech(AUTH_MECHANISM_NONE),
 	m_media_downloader(new ClientMediaDownloader()),
@@ -365,14 +364,6 @@ void Client::step(float dtime)
 			sendlist.push_back(*i);
 			++i;
 		}
-	}
-
-	/*
-		Send pending messages on out chat queue
-	*/
-	if (!m_out_chat_queue.empty() && canSendChatMessage()) {
-		sendChatMessage(m_out_chat_queue.front());
-		m_out_chat_queue.pop();
 	}
 
 	/*
@@ -1103,50 +1094,13 @@ void Client::sendInventoryAction(InventoryAction *a)
 	Send(&pkt);
 }
 
-bool Client::canSendChatMessage() const
-{
-	u32 now = time(NULL);
-	float time_passed = now - m_last_chat_message_sent;
-
-	float virt_chat_message_allowance = m_chat_message_allowance + time_passed *
-			(CLIENT_CHAT_MESSAGE_LIMIT_PER_10S / 8.0f);
-
-	if (virt_chat_message_allowance < 1.0f)
-		return false;
-
-	return true;
-}
-
 void Client::sendChatMessage(const std::wstring &message)
 {
-	const s16 max_queue_size = g_settings->getS16("max_out_chat_queue_size");
-	if (canSendChatMessage()) {
-		u32 now = time(NULL);
-		float time_passed = now - m_last_chat_message_sent;
-		m_last_chat_message_sent = time(NULL);
+	NetworkPacket pkt(TOSERVER_CHAT_MESSAGE, 2 + message.size() * sizeof(u16));
 
-		m_chat_message_allowance += time_passed * (CLIENT_CHAT_MESSAGE_LIMIT_PER_10S / 8.0f);
-		if (m_chat_message_allowance > CLIENT_CHAT_MESSAGE_LIMIT_PER_10S)
-			m_chat_message_allowance = CLIENT_CHAT_MESSAGE_LIMIT_PER_10S;
+	pkt << message;
 
-		m_chat_message_allowance -= 1.0f;
-
-		NetworkPacket pkt(TOSERVER_CHAT_MESSAGE, 2 + message.size() * sizeof(u16));
-
-		pkt << message;
-
-		Send(&pkt);
-	} else if (m_out_chat_queue.size() < (u16) max_queue_size || max_queue_size == -1) {
-		m_out_chat_queue.push(message);
-	} else {
-		infostream << "Could not queue chat message because maximum out chat queue size ("
-				<< max_queue_size << ") is reached." << std::endl;
-	}
-}
-
-void Client::clearOutChatQueue()
-{
-	m_out_chat_queue = std::queue<std::wstring>();
+	Send(&pkt);
 }
 
 void Client::sendChangePassword(const std::string &oldpassword,

--- a/src/client.h
+++ b/src/client.h
@@ -242,7 +242,6 @@ public:
 		const StringMap &fields);
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
-	void clearOutChatQueue();
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
 	void sendDamage(u8 damage);
@@ -462,8 +461,6 @@ private:
 	// Helper function
 	inline std::string getPlayerName()
 	{ return m_env.getLocalPlayer()->getName(); }
-
-	bool canSendChatMessage() const;
 
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -57,7 +57,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
-	settings->setDefault("max_out_chat_queue_size", "20");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -920,7 +920,6 @@ enum PlayerListModifer: u8
 enum CSMFlavourLimit : u64 {
 	CSM_FL_NONE = 0x00000000,
 	CSM_FL_LOOKUP_NODES = 0x00000001, // Limit node lookups
-	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
 	CSM_FL_ALL = 0xFFFFFFFF,

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -86,28 +86,6 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 	return 1;
 }
 
-// send_chat_message(message)
-int ModApiClient::l_send_chat_message(lua_State *L)
-{
-	if (!lua_isstring(L, 1))
-		return 0;
-
-	// If server disabled this API, discard
-	if (getClient(L)->checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_CHAT_MESSAGES))
-		return 0;
-
-	std::string message = luaL_checkstring(L, 1);
-	getClient(L)->sendChatMessage(utf8_to_wide(message));
-	return 0;
-}
-
-// clear_out_chat_queue()
-int ModApiClient::l_clear_out_chat_queue(lua_State *L)
-{
-	getClient(L)->clearOutChatQueue();
-	return 0;
-}
-
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
@@ -360,8 +338,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_current_modname);
 	API_FCT(print);
 	API_FCT(display_chat_message);
-	API_FCT(send_chat_message);
-	API_FCT(clear_out_chat_queue);
 	API_FCT(get_player_names);
 	API_FCT(set_last_run_mod);
 	API_FCT(get_last_run_mod);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -36,12 +36,6 @@ private:
 	// display_chat_message(message)
 	static int l_display_chat_message(lua_State *L);
 
-	// send_chat_message(message)
-	static int l_send_chat_message(lua_State *L);
-
-	// clear_out_chat_queue()
-	static int l_clear_out_chat_queue(lua_State *L);
-
 	// get_player_names()
 	static int l_get_player_names(lua_State *L);
 


### PR DESCRIPTION
Original PR this is reverting: #5747.
Old revert PR: #6091
This reverts commit 39f4a2f607d44738d60db84eba4b30e3d7450204.

CSM sent chat is completely unwanted, unneeded, and against the aims of what CSM should be for. CSM should be enhancing server mods - allowing them to reduce the effect of latency, perform audio/visual effects without the need to send packet, and create custom GUIs / etc. Not for a free-for-all for client provided modifications.


Self approval given :+1: 