### PR TITLE
Hint at problematic code when logging deprecated calls

### DIFF
--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -150,9 +150,15 @@ void log_deprecated(lua_State *L, const std::string &message)
 	}
 
 	if (do_log) {
-		warningstream << message << std::endl;
-		// L can be NULL if we get called by log_deprecated(const std::string &msg)
-		// from scripting_game.cpp.
+		warningstream << message;
+		if (L) { // L can be NULL if we get called from scripting_game.cpp
+			lua_Debug ar;
+			FATAL_ERROR_IF(!lua_getstack(L, 2, &ar), "lua_getstack() failed");
+			FATAL_ERROR_IF(!lua_getinfo(L, "Sl", &ar), "lua_getinfo() failed");
+			warningstream << " (at " << ar.short_src << ":" << ar.currentline << ")";
+		}
+		warningstream << std::endl;
+
 		if (L) {
 			if (do_error)
 				script_error(L, LUA_ERRRUN, NULL, NULL);


### PR DESCRIPTION
Implements #6654
<pre>
2017-11-23 23:32:36: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at .../minetest/bin/../mods/worldedit-mp/worldedit/init.lua:45)
</pre>