### PR TITLE
CAO/SAO: Nicer velocity-controlled, interpolated rotation

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -904,19 +904,19 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 	}
 
 	if (!getParent() && m_prop.automatic_face_movement_dir &&
-			(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001))
-	{
-		float optimal_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI
+			(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)) {
+
+		float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
 		float max_rotation_delta =
 				dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
+		float delta = wrapDegrees_0_360(target_yaw - m_yaw);
 
-		if ((m_prop.automatic_face_movement_max_rotation_per_sec > 0) &&
-			(fabs(m_yaw - optimal_yaw) > max_rotation_delta)) {
-
-			m_yaw = optimal_yaw < m_yaw ? m_yaw - max_rotation_delta : m_yaw + max_rotation_delta;
+		if (delta > max_rotation_delta && 360 - delta > max_rotation_delta) {
+			m_yaw += (delta < 180) ? max_rotation_delta : -max_rotation_delta;
+			m_yaw = wrapDegrees_0_360(m_yaw);
 		} else {
-			m_yaw = optimal_yaw;
+			m_yaw = target_yaw;
 		}
 		updateNodePos();
 	}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -372,20 +372,20 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			m_velocity += dtime * m_acceleration;
 		}
 
-		if((m_prop.automatic_face_movement_dir) &&
-				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001))
-		{
-			float optimal_yaw = atan2(m_velocity.Z,m_velocity.X) * 180 / M_PI
-					+ m_prop.automatic_face_movement_dir_offset;
+		if (m_prop.automatic_face_movement_dir &&
+				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)) {
+
+			float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
+				+ m_prop.automatic_face_movement_dir_offset;
 			float max_rotation_delta =
 					dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
+			float delta = wrapDegrees_0_360(target_yaw - m_yaw);
 
-			if ((m_prop.automatic_face_movement_max_rotation_per_sec > 0) &&
-				(fabs(m_yaw - optimal_yaw) > max_rotation_delta)) {
-
-				m_yaw = optimal_yaw < m_yaw ? m_yaw - max_rotation_delta : m_yaw + max_rotation_delta;
+			if (delta > max_rotation_delta && 360 - delta > max_rotation_delta) {
+				m_yaw += (delta < 180) ? max_rotation_delta : -max_rotation_delta;
+				m_yaw = wrapDegrees_0_360(m_yaw);
 			} else {
-				m_yaw = optimal_yaw;
+				m_yaw = target_yaw;
 			}
 		}
 	}


### PR DESCRIPTION
Object property: automatic_face_movement_max_rotation_per_sec

This PR will always rotate the entity towards the shorter angle, which results in a nicer animation.
Before: Rotation from 350° to 0° will pass the angles 270°, 180°, 90° and these in between.
After: Rotation from 350° to 0° will pass 355° and reach 0° (or 360°) directly

Demo branch of boost_cart using these rotation properties:
https://github.com/SmallJoker/boost_cart/tree/rotationtest
Instructions: Build a closed-loop railway, go to 2nd or 3rd person view and look out what happens when turning.