### PR TITLE
Custom particle generators for particle spawners

### DIFF
--- a/builtin/common/expression.lua
+++ b/builtin/common/expression.lua
@@ -1,0 +1,418 @@
+local vector_indices = {
+	x = true,
+	y = true,
+	z = true,
+}
+
+expression = {}
+local expr_meta = {}
+function expr_meta.__index(self, idx)
+	if vector_indices[idx] then
+		return expression.index(self, idx)
+	end
+	return expr_meta[idx]
+end
+
+local function with_expr_meta(table)
+	return setmetatable(table, expr_meta)
+end
+
+-- Convert to an expression
+function expression.expression(value)
+	local value_type = type(value)
+	if value_type == "number" then
+		-- Constant scalars
+		return with_expr_meta({
+			expr_type = "constant_scalar",
+			value = value,
+		})
+	elseif value_type == "table" then
+		if getmetatable(value) == expr_meta then
+			-- This is an expression already
+			return value
+		elseif value.x and value.y and value.z then
+			-- Constant (Minetest) vectors
+			return with_expr_meta({
+				expr_type = "vector",
+				x = expression.expression(value.x),
+				y = expression.expression(value.y),
+				z = expression.expression(value.z),
+			})
+		end
+	end
+	error("Value of invalid type used as expression")
+end
+
+local unary_operations = {
+	acos = true,
+	asin = true,
+	atan = true,
+	ceil = true,
+	cos = true,
+	floor = true,
+	log = true,
+	sin = true,
+	tan = true,
+}
+
+function expression.unary_operation(op, arg)
+	assert(unary_operations[op])
+
+	local expr_arg = expression.expression(arg)
+
+	return with_expr_meta({
+		expr_type = "unary_operation",
+		operation = op,
+		arg = expr_arg,
+	})
+end
+
+local binary_operations = {
+	add = true,
+	subtract = true,
+	multiply = true,
+	divide = true,
+	power = true,
+	random = true,
+	lt = true,
+	le = true,
+	atan2 = true,
+}
+
+function expression.binary_operation(op, arg1, arg2)
+	assert(binary_operations[op])
+
+	local expr_arg1 = expression.expression(arg1)
+	local expr_arg2 = expression.expression(arg2)
+
+	return with_expr_meta({
+		expr_type = "binary_operation",
+		operation = op,
+		arg1 = expr_arg1,
+		arg2 = expr_arg2,
+	})
+end
+
+function expression.index(arg, index)
+	assert(vector_indices[index])
+
+	local vec = expression.expression(arg)
+
+	return with_expr_meta({
+		expr_type = "index",
+		vector = vec,
+		index = index,
+	})
+end
+
+function expression.time()
+	return with_expr_meta({
+		expr_type = "time",
+	})
+end
+
+function expression.random(low, high)
+	return expression.binary_operation("random", low or 0, high or 1)
+end
+
+local function binop_fun(op)
+	return function(arg1, arg2)
+		return expression.binary_operation(op, arg1, arg2)
+	end
+end
+
+expr_meta.__add = binop_fun("add")
+expr_meta.__sub = binop_fun("subtract")
+expr_meta.__mul = binop_fun("multiply")
+expr_meta.__div = binop_fun("divide")
+expr_meta.__pow = binop_fun("power")
+expression.lt = binop_fun("lt")
+expression.le = binop_fun("le")
+
+function expression.gt(a, b)
+	return expression.lt(b, a)
+end
+
+function expression.ge(a, b)
+	return expression.le(b, a)
+end
+
+function expr_meta.__unm(arg1)
+	return 0 - arg1
+end
+
+function expr_meta.__newindex()
+	error("Cannot set values in expressions.")
+end
+
+function expr_meta:add_ref_counts(count_table)
+	local old_value = count_table[self] or 0
+	count_table[self] = old_value + 1
+
+	-- Don't double count references to children
+	if old_value > 0 then return end
+	if self.expr_type == "vector" then
+		self.x:add_ref_counts(count_table)
+		self.y:add_ref_counts(count_table)
+		self.z:add_ref_counts(count_table)
+	elseif self.expr_type == "unary_operation" then
+		self.arg:add_ref_counts(count_table)
+	elseif self.expr_type == "binary_operation" then
+		self.arg1:add_ref_counts(count_table)
+		self.arg2:add_ref_counts(count_table)
+	elseif self.expr_type == "index" then
+		self.vector:add_ref_counts(count_table)
+	end
+end
+
+-- Get a table of how many times each expression is referenced
+local function get_ref_counts(expr_list)
+	local count_table = {}
+	for _, expr in ipairs(expr_list) do
+		expr:add_ref_counts(count_table)
+	end
+	return count_table
+end
+
+-- Takes a list of expressions and returns a mapping from expressions to variable
+-- indices. Expressions without a mapping are not stored in a variable.
+local function get_variable_map(expr_list)
+	local count_table = get_ref_counts(expr_list)
+	local variable_map = {}
+	local next_var = 0
+	for expr, count in pairs(count_table) do
+		if count > 1 then
+			variable_map[expr] = next_var
+			next_var = next_var + 1
+		end
+	end
+
+	return variable_map, next_var
+end
+
+-- Prints a trace of what the output bytecode would do.
+function expr_meta:trace(variable_map, visited)
+	local self_index = variable_map[self]
+	if self_index and visited[self] then
+		-- Value already calculated
+		print("Push variable", self_index)
+		return
+	elseif self.expr_type == "constant_scalar" then
+		print("Push constant", self.value)
+	elseif self.expr_type == "vector" then
+		self.x:trace(variable_map, visited)
+		self.y:trace(variable_map, visited)
+		self.z:trace(variable_map, visited)
+		print("Pop 3 scalars and make a vector")
+	elseif self.expr_type == "unary_operation" then
+		self.arg:trace(variable_map, visited)
+		print("Pop a value and do op", self.operation)
+	elseif self.expr_type == "binary_operation" then
+		self.arg1:trace(variable_map, visited)
+		self.arg2:trace(variable_map, visited)
+		print("Pop 2 values and do op", self.operation)
+	elseif self.expr_type == "index" then
+		self.vector:trace(variable_map, visited)
+		print("Pop vector and push index", self.index)
+	elseif self.expr_type == "time" then
+		print("Push time")
+	end
+
+	if self_index then
+		-- Store variable
+		print("Copy top of stack to var", self_index)
+		visited[self] = true
+	end
+end
+
+-- Also update src/particles.h
+local opcodes = {
+	push_constant = 0,
+	push_variable = 1,
+	write_variable = 2,
+	make_vector = 3,
+	index_x = 4,
+	index_y = 5,
+	index_z = 6,
+	push_time = 7,
+	add = 8,
+	subtract = 9,
+	multiply = 10,
+	divide = 11,
+	power = 12,
+	random = 13,
+	lt = 14,
+	le = 15,
+	atan2 = 16,
+	acos = 17,
+	asin = 18,
+	atan = 19,
+	ceil = 20,
+	cos = 21,
+	floor = 22,
+	log = 23,
+	sin = 24,
+	tan = 25,
+}
+
+local indices = {
+	x = opcodes.index_x,
+	y = opcodes.index_y,
+	z = opcodes.index_z,
+}
+
+-- output is a table to append commands to.
+function expr_meta:append_commands(variable_map, visited, output)
+	local self_index = variable_map[self]
+	if self_index and visited[self] then
+		-- Value already calculated
+		table.insert(output, {
+			operation = opcodes.push_variable,
+			self_index,
+		})
+		return
+	elseif self.expr_type == "constant_scalar" then
+		table.insert(output, {
+			operation = opcodes.push_constant,
+			self.value,
+		})
+	elseif self.expr_type == "vector" then
+		self.x:append_commands(variable_map, visited, output)
+		self.y:append_commands(variable_map, visited, output)
+		self.z:append_commands(variable_map, visited, output)
+		table.insert(output, {
+			operation = opcodes.make_vector,
+		})
+	elseif self.expr_type == "unary_operation" then
+		self.arg:append_commands(variable_map, visited, output)
+		table.insert(output, {
+			operation = assert(opcodes[self.operation])
+		})
+	elseif self.expr_type == "binary_operation" then
+		self.arg1:append_commands(variable_map, visited, output)
+		self.arg2:append_commands(variable_map, visited, output)
+		table.insert(output, {
+			operation = assert(opcodes[self.operation]),
+		})
+	elseif self.expr_type == "index" then
+		self.vector:append_commands(variable_map, visited, output)
+		table.insert(output, {
+			operation = assert(indices[self.index]),
+		})
+	elseif self.expr_type == "time" then
+		table.insert(output, {
+			operation = opcodes.push_time,
+		})
+	else
+		error ("Invalid expression type")
+	end
+
+	if self_index then
+		-- Store variable
+		table.insert(output, {
+			operation = opcodes.write_variable,
+			self_index,
+		})
+		visited[self] = true
+	end
+end
+
+local function make_exprs(expr_likes)
+	local exprs = {}
+	for i, expr_like in ipairs(expr_likes) do
+		exprs[i] = expression.expression(expr_like)
+	end
+
+	return exprs
+end
+
+-- Returns both a list of compiled expressions and the number of variables
+-- needed.
+function expression.compile(exprs)
+	local actual_exprs = make_exprs(exprs)
+	local v_map, num_vars = get_variable_map(actual_exprs)
+	local out_codes = {}
+
+	local visited = {}
+	for i, actual_expr in ipairs(actual_exprs) do
+		local out_code = {}
+		actual_expr:append_commands(v_map, visited, out_code)
+		out_codes[i] = out_code
+	end
+
+	return out_codes, num_vars
+end
+
+function expression.trace(exprs)
+	local actual_exprs = make_exprs(exprs)
+	local v_map = get_variable_map(actual_exprs)
+
+	local visited = {}
+	for i, actual_expr in ipairs(actual_exprs) do
+		actual_expr:trace(v_map, visited)
+	end
+end
+
+-- Implementations of things from the math library
+
+local function unop_fun(op)
+	return function(arg)
+		return expression.unary_operation(op, arg)
+	end
+end
+
+function expression.abs(x)
+	pos = expression.gt(x, 0)
+	return pos * x + (1 - pos) * x
+end
+
+expression.acos = unop_fun("acos")
+expression.asin = unop_fun("asin")
+expression.atan = unop_fun("atan")
+expression.atan2 = binop_fun("atan2")
+expression.ceil = unop_fun("ceil")
+expression.cos = unop_fun("cos")
+
+function expression.sinh(x)
+	return 0.5 * (expression.exp(x) + expression.exp(-x))
+end
+
+function expression.exp(x)
+	return math.exp(1)^x
+end
+
+expression.floor = unop_fun("floor")
+expression.log = unop_fun("log")
+
+function expression.max(x, y)
+	xBigger = expression.gt(x, y)
+	return xBigger * x + (1 - xBigger) * y
+end
+
+function expression.min(x, y)
+	xBigger = expression.gt(x, y)
+	return xBigger * y + (1 - xBigger) * x
+end
+
+function expression.pow(x, y)
+	return x^y
+end
+
+expression.sin = unop_fun("sin")
+
+function expression.sinh(x)
+	return 0.5 * (expression.exp(x) - expression.exp(-x))
+end
+
+function expression.sqrt(x)
+	return x^0.5
+end
+
+expression.tan = unop_fun("tan")
+
+function expression.tanh(x)
+	posExp = expression.exp(x)
+	negExp = expression.exp(-x)
+
+	return (posExp - negExp) / (posExp + negExp)
+end

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -33,6 +33,7 @@ local asyncpath = scriptdir .. "async" .. DIR_DELIM
 
 dofile(commonpath .. "strict.lua")
 dofile(commonpath .. "serialize.lua")
+dofile(commonpath .. "expression.lua")
 dofile(commonpath .. "misc_helpers.lua")
 
 if INIT == "game" then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3148,6 +3148,52 @@ These functions return the leftover itemstack.
     * If playername is specified, only deletes on the player's client,
     * otherwise on all clients
 
+### Expressions
+Expressions are descriptions of how to generate a vector or scalar. They are used
+to provide custom generation of particle attributes (position, velocity, etc.)
+from particle spawners.
+
+In addition to the operations listed here, they support the operators
++, -, *, /, ^. They also support indexing with the keys `"x"`, `"y"`, or `"z"`,
+which for vector expressions will return the specified value. The operations
+described in this section can take non-expression scalars and vectors, and will
+automatically "upgrade" them to an expression.
+
+Note: operations between expressions will generally pad the arguments so that
+they are the same size.
+
+Debugging
+=========
+* expression.trace(expressions)
+  * `expressions`: A list of expressions.
+  * Prints to standard output a human-readable rendering of the instructions
+    these expressions would be compiled to.
+
+Operations
+==========
+* `expression.ge(a, b)`, `expression.gt(a, b)`,
+  `expression.le(a, b)`, `expression.lt(a, b)`
+    * `a`: an expression
+    * `b`: an expression
+    * Returns an expression that is the result of comparing a and b pointwise with
+      the given operation, using 1 for true and 0 for false.
+* `expression.random(low, high)`
+    * `low`: an expression
+    * `high`: an expression
+    * Returns an expression that generates a value between the two provided.
+* `expression.time()`
+    * Returns an expression that gets the elapsed particle spawner time.
+
+* `expression.abs`, `expression.acos`, `expression.asin`,
+  `expression.atan`, `expression.atan2`, `expression.ceil`,
+  `expression.cos`, `expression.sinh`, `expression.exp`,
+  `expression.floor`, `expression.log`, `expression.max`,
+  `expression.min`, `expression.pow`, `expression.sin`,
+  `expression.sinh`, `expression.sqrt`, `expression.tan`,
+  `expression.tanh`
+  * Performs the same operation as its counterpart in the `math` library, but
+    works on expressions.
+
 ### Schematics
 * `minetest.create_schematic(p1, p2, probability_list, filename, slice_prob_list)`
     * Create a schematic from the volume of map specified by the box formed by p1 and p2.
@@ -5155,6 +5201,15 @@ Definition tables
     --  ^ The particle's properties are random values in between the bounds:
     --  ^ minpos/maxpos, minvel/maxvel (velocity), minacc/maxacc (acceleration),
     --  ^ minsize/maxsize, minexptime/maxexptime (expirationtime)
+        pos_expression = Expression
+        vel_expression = Expression
+        acc_expression = Expression
+    --  ^ See `Expressions`. These should produce vectors, and are added to a
+    --  ^ particle's initial properties.
+        exptime_expression = Expression
+        size_expression = Expression
+    --  ^ See `Expressions`. These should produce scalars, and are multiplied
+    --  ^ with a particle's initial properties.
         collisiondetection = false,
     --  ^ collisiondetection: if true uses collision detection
         collision_removal = false,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,6 +422,7 @@ set(common_SRCS
 	noise.cpp
 	objdef.cpp
 	object_properties.cpp
+	particleshaders.cpp
 	pathfinder.cpp
 	player.cpp
 	porting.cpp

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -109,6 +109,7 @@ struct ClientEvent
 			u32 id;
 			struct TileAnimationParams animation;
 			u8 glow;
+			std::string *shaders;
 		} add_particlespawner;
 		struct
 		{

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -971,6 +971,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	animation.type = TAT_NONE;
 	u8 glow = 0;
 	u16 attached_id = 0;
+	std::string shaders;
 	try {
 		*pkt >> vertical;
 		*pkt >> collision_removal;
@@ -981,6 +982,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 		std::istringstream is(datastring, std::ios_base::binary);
 		animation.deSerialize(is, m_proto_ver);
 		glow = readU8(is);
+		shaders = deSerializeLongString(is);
 	} catch (...) {}
 
 	ClientEvent *event = new ClientEvent();
@@ -1005,6 +1007,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	event->add_particlespawner.id                 = id;
 	event->add_particlespawner.animation          = animation;
 	event->add_particlespawner.glow               = glow;
+	event->add_particlespawner.shaders            = new std::string(shaders);
 
 	m_client_event_queue.push(event);
 }

--- a/src/particles.h
+++ b/src/particles.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "client/tile.h"
 #include "localplayer.h"
+#include "particleshaders.h"
 #include "tileanimation.h"
 
 struct ClientEvent;
@@ -131,6 +132,7 @@ public:
 		video::ITexture *texture,
 		u32 id,
 		const struct TileAnimationParams &anim, u8 glow,
+		const ParticleShaders &particle_shaders,
 		ParticleManager* p_manager);
 
 	~ParticleSpawner() = default;
@@ -169,6 +171,7 @@ private:
 	u16 m_attached_id;
 	struct TileAnimationParams m_animation;
 	u8 m_glow;
+	ParticleShaders m_shaders;
 };
 
 /**

--- a/src/particleshaders.cpp
+++ b/src/particleshaders.cpp
@@ -1,0 +1,48 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "particleshaders.h"
+#include "util/numeric.h"
+#include "util/serialize.h"
+
+#include <sstream>
+
+/*
+	ParticleShaders
+*/
+
+std::string ParticleShaders::serialize() const
+{
+	std::stringstream output;
+
+	writeU32(output, varCount);
+	output << serializeString(pos) << serializeString(vel) << serializeString(acc)
+		<< serializeString(exptime) << serializeString(size);
+	return output.str();
+}
+
+void ParticleShaders::deSerialize(std::istream &is)
+{
+	varCount = readU32(is);
+	pos = deSerializeString(is);
+	vel = deSerializeString(is);
+	acc = deSerializeString(is);
+	exptime = deSerializeString(is);
+	size = deSerializeString(is);
+}

--- a/src/particleshaders.h
+++ b/src/particleshaders.h
@@ -1,0 +1,100 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <iostream>
+#include "irrlichttypes_extrabloated.h"
+
+/* Operations specification
+If args are not specified, then the operation is argless.
+
+push_constant:
+- Args: F1000 value
+- Description: Pushes the given value onto the stack.
+
+push_variable
+- Args: U32 variable
+- Description: Pushes the specified variable's value onto the stack.
+
+write_variable:
+- Args: U32 variable
+- Description: Copies the value at the top of the stack to the specified
+  variable, without popping.
+
+make_vector:
+- Description: Pops three values, and pushes a vector with those values. The
+  values correspond to z, y, x in order of popping.
+
+index_x, index_y, index_z:
+- Description: Pops a vector and pushes the scalar in the specified index.
+
+push_time:
+- Description: Pushes the time passed since the particle spawner was spawned.
+
+add, subtract, multiply, divide, power, random, lt, le, atan2
+- Description: Pops two values and performs the specified operation between them.
+  Random takes a low and high bound.
+
+acos, asin, atan, ceil, cos, floor, log, sin, tan
+- Description: Pops one value and performs the specified operation on it.
+ */
+struct ParticleShaders
+{
+	// Also update builtin/common/expression.lua
+	enum Opcode : u8
+	{
+		op_push_constant = 0,
+		op_push_variable = 1,
+		op_write_variable = 2,
+		op_make_vector = 3,
+		op_index_x = 4,
+		op_index_y = 5,
+		op_index_z = 6,
+		op_push_time = 7,
+		op_add = 8,
+		op_subtract = 9,
+		op_multiply = 10,
+		op_divide = 11,
+		op_power = 12,
+		op_random = 13,
+		op_lt = 14,
+		op_le = 15,
+		op_atan2 = 16,
+		op_acos = 17,
+		op_asin = 18,
+		op_atan = 19,
+		op_ceil = 20,
+		op_cos = 21,
+		op_floor = 22,
+		op_log = 23,
+		op_sin = 24,
+		op_tan = 25
+	};
+
+	std::string serialize() const;
+	void deSerialize(std::istream &is);
+
+	u32 varCount;
+	std::string pos;
+	std::string vel;
+	std::string acc;
+	std::string exptime;
+	std::string size;
+};

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -65,6 +65,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "chatmessage.h"
 #include "chat_interface.h"
 #include "remoteplayer.h"
+#include "particles.h"
+#include "particleshaders.h"
 
 class ClientNotFoundException : public BaseException
 {
@@ -1627,7 +1629,8 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 	v3f minvel, v3f maxvel, v3f minacc, v3f maxacc, float minexptime, float maxexptime,
 	float minsize, float maxsize, bool collisiondetection, bool collision_removal,
 	u16 attached_id, bool vertical, const std::string &texture, u32 id,
-	const struct TileAnimationParams &animation, u8 glow)
+	const struct TileAnimationParams &animation, u8 glow,
+	const ParticleShaders &shaders)
 {
 	if (peer_id == PEER_ID_INEXISTENT) {
 		// This sucks and should be replaced:
@@ -1640,7 +1643,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 					amount, spawntime, minpos, maxpos,
 					minvel, maxvel, minacc, maxacc, minexptime, maxexptime,
 					minsize, maxsize, collisiondetection, collision_removal,
-					attached_id, vertical, texture, id, animation, glow);
+					attached_id, vertical, texture, id, animation, glow, shaders);
 		}
 		return;
 	}
@@ -1661,6 +1664,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 	animation.serialize(os, protocol_version);
 	pkt.putRawString(os.str());
 	pkt << glow;
+	pkt.putLongString(shaders.serialize());
 
 	Send(&pkt);
 }
@@ -3212,7 +3216,7 @@ u32 Server::addParticleSpawner(u16 amount, float spawntime,
 	bool collisiondetection, bool collision_removal,
 	ServerActiveObject *attached, bool vertical, const std::string &texture,
 	const std::string &playername, const struct TileAnimationParams &animation,
-	u8 glow)
+	u8 glow, const ParticleShaders &shaders)
 {
 	// m_env will be NULL if the server is initializing
 	if (!m_env)
@@ -3240,7 +3244,7 @@ u32 Server::addParticleSpawner(u16 amount, float spawntime,
 		minpos, maxpos, minvel, maxvel, minacc, maxacc,
 		minexptime, maxexptime, minsize, maxsize,
 		collisiondetection, collision_removal, attached_id, vertical,
-		texture, id, animation, glow);
+		texture, id, animation, glow, shaders);
 
 	return id;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -56,6 +56,7 @@ class PlayerSAO;
 class IRollbackManager;
 struct RollbackAction;
 class EmergeManager;
+struct ParticleShaders;
 class ServerScripting;
 class ServerEnvironment;
 struct SimpleSoundSpec;
@@ -238,7 +239,7 @@ public:
 		ServerActiveObject *attached,
 		bool vertical, const std::string &texture,
 		const std::string &playername, const struct TileAnimationParams &animation,
-		u8 glow);
+		u8 glow, const ParticleShaders &shaders);
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
 
@@ -439,7 +440,8 @@ private:
 		bool collisiondetection, bool collision_removal,
 		u16 attached_id,
 		bool vertical, const std::string &texture, u32 id,
-		const struct TileAnimationParams &animation, u8 glow);
+		const struct TileAnimationParams &animation, u8 glow,
+		const ParticleShaders &shaders);
 
 	void SendDeleteParticleSpawner(session_t peer_id, u32 id);
 


### PR DESCRIPTION
This PR adds a DSL for particle spawners to allow more flexibility in particle generation. It allows custom generation of position, velocity, acceleration, exptime, and size, and allows the values to be related to each other by having them use the same random generators. It also gives time as an input, so patterns can change over time.

Example video: https://a.safe.moe/KVBCU.webm
Code for example:
```
local expr = expression

local angle = expr.random(0, 2 * math.pi)
local circle = { x = expr.sin(angle), y = expr.random(0, 0.1), z = expr.cos(angle) }
local upspeed = expr.min(5, 5 * expr.time())
local velocity = { x = 0, y = upspeed, z = 0 }
local gravity = { x = 0, y = -10, z = 0 }

expr.trace({ expr.time() * circle, velocity, 2 * expr.time() })

minetest.override_item("default:stick", {
        on_use = function(stack, user)
                local pos = user:getpos()
                minetest.add_particlespawner({
                                amount = 1000 * 5,
                                time = 5,
                                minpos = pos,
                                maxpos = pos,
                                minacc = gravity,
                                maxacc = gravity,
                                pos_expression = expr.time() * circle,
                                vel_expression = velocity,
                                size_expression = 2 * expr.time(),
                                minexptime=0.5,
                                maxexptime=0.5,
                                texture = "default_lava.png",
                                glow = 15,
                                collisiondetection = true,
                })
        end,
})
```