### PR TITLE
Make possible a way to compare a name against the builtin auth table.

### DIFF
--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -169,6 +169,29 @@ function core.get_auth_handler()
 	return core.registered_auth_handler or core.builtin_auth_handler
 end
 
+function core.compare_name_in_auth(playername, comparelower)
+	local auth = core.auth_table
+	if comparelower then
+		-- Compare name in lowercase.
+		local namelower = playername:lower()
+		for curname, auth2 in pairs(auth) do
+			if curname:lower() == namelower then
+				-- Returning the matched name is useful because otherwise the caller
+				-- would not know what the actual capitalization of the name was.
+				return true, curname
+			end
+		end
+	else
+		-- Compare name, in the original.
+		for curname, auth2 in pairs(auth) do
+			if curname == playername then
+				-- Same as above, just for consistency.
+				return true, curname
+			end
+		end
+	end
+end
+
 local function auth_pass(name)
 	return function(...)
 		local auth_handler = core.get_auth_handler()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2685,6 +2685,11 @@ Call these functions only at load time!
 	* `...` is either a list of strings, e.g. `"priva", "privb"` or
 	  a table, e.g. `{ priva = true, privb = true }`.
 * `minetest.get_player_ip(name)`: returns an IP address string
+* `minetest.compare_name_in_auth(playername, comparelower)`
+	* Searches the builtin auth table for the existence of a name
+	* `playername`: the name to search for
+	* `comparelower`: whether to normalize names to lowercase before comparing, defaults to false
+	* Returns true if a match is found. If true, returns as the second value the actual name that matched.
 
 `minetest.set_player_password`, `minetest_set_player_privs`, `minetest_get_player_privs`
 and `minetest.auth_reload` call the authentication handler.


### PR DESCRIPTION
This functionality is not covered by `minetest.player_exists`.

It would probably be better if a function to iterate through existing names was added to the builtin auth handler itself (and to the documentation for adding a custom auth handler) instead of being a free-standing function, but that's rather complicated and I noticed that other code in the same file assumes that the builtin auth handler is the one that is actually used.

I figure I'll leave it to someone else to actually fix that. Or I can, if I get time -- but in a different PR, not this one.

Code is untested, please test.