### PR TITLE
Fix lua_api.txt indentation issues

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -410,7 +410,7 @@ Only the channels that are mentioned in the mode string will be inverted.
 
 Example:
 
-	default_apple.png^[invert:rgb
+    default_apple.png^[invert:rgb
 
 #### `[brighten`
 Brightens the texture.
@@ -1188,16 +1188,16 @@ by this ore type.
 This ore type is difficult to control since it is sensitive to small changes.
 The following is a decent set of parameters to work from:
 
-	noise_params = {
-	    offset  = 0,
-	    scale   = 3,
-	    spread  = {x=200, y=200, z=200},
-	    seed    = 5390,
-	    octaves = 4,
-	    persist = 0.5,
-	    flags = "eased",
-	},
-	noise_threshold = 1.6
+    noise_params = {
+        offset  = 0,
+        scale   = 3,
+        spread  = {x=200, y=200, z=200},
+        seed    = 5390,
+        octaves = 4,
+        persist = 0.5,
+        flags = "eased",
+    },
+    noise_threshold = 1.6
 
 **WARNING**: Use this ore type *very* sparingly since it is ~200x more
 computationally expensive than any other ore.
@@ -2681,9 +2681,9 @@ Call these functions only at load time!
 * `minetest.auth_reload()`
 * `minetest.check_player_privs(player_or_name, ...)`: returns `bool, missing_privs`
     * A quickhand for checking privileges.
-	* `player_or_name`: Either a Player object or the name of a player.
-	* `...` is either a list of strings, e.g. `"priva", "privb"` or
-	  a table, e.g. `{ priva = true, privb = true }`.
+    * `player_or_name`: Either a Player object or the name of a player.
+    * `...` is either a list of strings, e.g. `"priva", "privb"` or
+      a table, e.g. `{ priva = true, privb = true }`.
 * `minetest.get_player_ip(name)`: returns an IP address string
 
 `minetest.set_player_password`, `minetest_set_player_privs`, `minetest_get_player_privs`
@@ -3659,22 +3659,21 @@ This is basically a reference to a C++ `ServerActiveObject`
       `"plain"` custom skyboxes (default: `true`)
 * `get_sky()`: returns bgcolor, type, table of textures, clouds
 * `set_clouds(parameters)`: set cloud parameters
-	* `parameters` is a table with the following optional fields:
-		* `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
-		* `color`: basic cloud color with alpha channel, ColorSpec (default `#fff0f0e5`)
-		* `ambient`: cloud color lower bound, use for a "glow at night" effect.
-		  ColorSpec (alpha ignored, default `#000000`)
-		* `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
-		* `thickness`: cloud thickness in nodes (default `16`)
-		* `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, z=-2}`)
+    * `parameters` is a table with the following optional fields:
+        * `density`: from `0` (no clouds) to `1` (full clouds) (default `0.4`)
+        * `color`: basic cloud color with alpha channel, ColorSpec (default `#fff0f0e5`)
+        * `ambient`: cloud color lower bound, use for a "glow at night" effect.
+          ColorSpec (alpha ignored, default `#000000`)
+        * `height`: cloud height, i.e. y of cloud base (default per conf, usually `120`)
+        * `thickness`: cloud thickness in nodes (default `16`)
+        * `speed`: 2D cloud speed + direction in nodes per second (default `{x=0, z=-2}`)
 * `get_clouds()`: returns a table with the current cloud parameters as in `set_clouds`
 * `override_day_night_ratio(ratio or nil)`
     * `0`...`1`: Overrides day-night ratio, controlling sunlight to a specific amount
     * `nil`: Disables override, defaulting to sunlight based on day-night cycle
 * `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
-* `set_local_animation(stand/idle, walk, dig, walk+dig, frame_speed=frame_speed)`
-
-	set animation for player model in third person view
+* `set_local_animation(stand/idle, walk, dig, walk+dig, frame_speed=frame_speed)`:
+  set animation for player model in third person view
 
         set_local_animation({x=0, y=79}, -- < stand/idle animation key frames
             {x=168, y=187}, -- < walk animation key frames
@@ -4527,9 +4526,9 @@ Definition tables
     tileable_horizontal=bool, align_style="node"/"world"/"user", scale=int}`
     * backface culling enabled by default for most nodes
     * tileable flags are info for shaders, how they should treat texture
-	  when displacement mapping is used
-	  Directions are from the point of view of the tile texture,
-	  not the node it's on
+      when displacement mapping is used
+      Directions are from the point of view of the tile texture,
+      not the node it's on
     * align style determines whether the texture will be rotated with the node
           or kept aligned with its surroundings. "user" means that client
           setting will be used, similar to `glasslike_framed_optional`.
@@ -4547,25 +4546,25 @@ Definition tables
 
 ### Tile animation definition
 
-	{
-		type = "vertical_frames",
-		aspect_w = 16,
-		-- ^ specify width of a frame in pixels
-		aspect_h = 16,
-		-- ^ specify height of a frame in pixels
-		length = 3.0,
-		-- ^ specify full loop length
-	}
+    {
+        type = "vertical_frames",
+        aspect_w = 16,
+        -- ^ specify width of a frame in pixels
+        aspect_h = 16,
+        -- ^ specify height of a frame in pixels
+        length = 3.0,
+        -- ^ specify full loop length
+    }
 
-	{
-		type = "sheet_2d",
-		frames_w = 5,
-		-- ^ specify width in number of frames
-		frames_h = 3,
-		-- ^ specify height in number of frames
-		frame_length = 0.5,
-		-- ^ specify length of a single frame
-	}
+    {
+        type = "sheet_2d",
+        frames_w = 5,
+        -- ^ specify width in number of frames
+        frames_h = 3,
+        -- ^ specify height in number of frames
+        frame_length = 0.5,
+        -- ^ specify length of a single frame
+    }
 
 ### Node definition (`register_node`)
 
@@ -4700,7 +4699,7 @@ Definition tables
         ^ Called after constructing node when node was placed using
           minetest.item_place_node / minetest.place_node
         ^ If return true no item is taken from itemstack
-	^ `placer` may be any valid ObjectRef or nil
+        ^ `placer` may be any valid ObjectRef or nil
         ^ default: nil ]]
         after_dig_node = func(pos, oldnode, oldmetadata, digger), --[[
         ^ oldmetadata is in table format
@@ -4818,7 +4817,7 @@ Definition tables
 
 ### Ore definition (`register_ore`)
 
-	See 'Ore types' section above for essential information.
+    See 'Ore types' section above for essential information.
 
     {
         ore_type = "scatter",


### PR DESCRIPTION
Fixes random switching between spaces and tabs for indentation in lua_api.txt.

Please note this is a "tidy it up so I can stand to look at it a bit more" type of PR. I hope to try and do more to clean up lua_api.txt and address some of the other issues the document has over time.