### PR TITLE
Completely disable CSM, client-side.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -831,8 +831,9 @@ enable_local_map_saving (Saving map received from server) bool false
 #    when connecting to the server.
 enable_remote_media_server (Connect to external media server) bool true
 
-#    Enable Lua modding support on client.
+#    Enable Lua modding support on client (currently disabled).
 #    This support is experimental and API can change.
+#    Note: value is ignored as modding support on the client is disabled.
 enable_client_modding (Client modding) bool false
 
 #    URL to the server list displayed in the Multiplayer Tab.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -107,7 +107,11 @@ Client::Client(
 	}
 	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
 
-	m_modding_enabled = g_settings->getBool("enable_client_modding");
+
+	// CSM is force disabled, more dev work is needed.
+	//m_modding_enabled = g_settings->getBool("enable_client_modding");
+	m_modding_enabled = false;
+
 	m_script = new ClientScripting(this);
 	m_env.setScript(m_script);
 	m_script->setEnv(&m_env);


### PR DESCRIPTION
Hackers will always be able to get around this, but this should mitigate the current problem.

It is far easier to do it this way, than to require the server to instruct the client to disable modding.

The relative security of either method is the same.