### PR TITLE
CSM flavor limits: Add option to disable mod loading 

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -119,7 +119,8 @@ void Client::loadMods()
 	scanModIntoMemory(BUILTIN_MOD_NAME, getBuiltinLuaPath());
 
 	// If modding is not enabled, don't load mods, just builtin
-	if (!m_modding_enabled) {
+	if (!m_modding_enabled ||
+			checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_MOD_LOADING)) {
 		return;
 	}
 	ClientModConfiguration modconf(getClientModsLuaPath());

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2146,9 +2146,6 @@ bool Game::connectToServer(const std::string &playername,
 
 		fps_control.last_time = RenderingEngine::get_timer_time();
 
-		client->loadMods();
-		client->initMods();
-
 		while (RenderingEngine::run()) {
 
 			limitFps(&fps_control, &dtime);
@@ -2208,6 +2205,9 @@ bool Game::getServerContent(bool *aborted)
 	f32 dtime; // in seconds
 
 	fps_control.last_time = RenderingEngine::get_timer_time();
+
+	client->loadMods();
+	client->initMods();
 
 	while (RenderingEngine::run()) {
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -923,6 +923,7 @@ enum CSMFlavourLimit : u64 {
 	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
+	CSM_FL_MOD_LOADING = 0x80000000, // Disable mod loading
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
 


### PR DESCRIPTION
WIP not tested yet.

Alternative to #6710 . Adds the option for a server to disable loading of client-provided CSMods.
If the new flavour limit 0x80000000 is set, CSMods are not loaded.
The clientside setting remains.
Logic: If either the client or the server disables CSModding, CSMods are not loaded.

Not sure it will work, depends on whether the flavour setting is sent to the client before CSMod loading, i'll soon find out in testing.

If you are a server owner please state your support or otherwise.
@Ezhh @tenplus1 @shivajiva101 @VanessaE @Megaf @ExeterDad