### PR TITLE
[WIP] Add ability to play sound with an offset in seconds.

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -161,17 +161,20 @@ Examples of sound parameter tables:
     -- Play locationless
     {
         gain = 1.0, -- default
+        offset = 0.0, -- default
     }
     -- Play locationless, looped
     {
         gain = 1.0, -- default
         loop = true,
+        offset = 0.0, -- default
     }
     -- Play in a location
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
+        offset = 0.0, -- default
     }
     -- Play connected to an object, looped
     {
@@ -179,9 +182,13 @@ Examples of sound parameter tables:
         gain = 1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
         loop = true,
+        offset = 0.0, -- default
     }
 
 Looped sounds must either be connected to an object or played locationless.
+
+`offset` is the offset in the sound file to start playback, expressed as seconds.
+If you choose an invalid offset you will get unexpected results.
 
 ### SimpleSoundSpec
 * e.g. `""`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -725,6 +725,7 @@ Examples of sound parameter tables:
         gain = 1.0, -- default
         fade = 0.0, -- default, change to a value > 0 to fade the sound in
         pitch = 1.0, -- default
+        offset = 0.0, -- default
     }
     -- Play locationless to one player
     {
@@ -732,18 +733,21 @@ Examples of sound parameter tables:
         gain = 1.0, -- default
         fade = 0.0, -- default, change to a value > 0 to fade the sound in
         pitch = 1.0, -- default
+        offset = 0.0, -- default
     }
     -- Play locationless to one player, looped
     {
         to_player = name,
         gain = 1.0, -- default
         loop = true,
+        offset = 0.0, -- default
     }
     -- Play in a location
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
+        offset = 0.0, -- default
     }
     -- Play connected to an object, looped
     {
@@ -751,10 +755,14 @@ Examples of sound parameter tables:
         gain = 1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
         loop = true,
+        offset = 0.0, -- default
     }
 
 Looped sounds must either be connected to an object or played locationless to
 one player using `to_player = name,`
+
+`offset` is the offset in the sound file to start playback, expressed as seconds.
+If you choose an invalid offset you will get unexpected results.
 
 ### `SimpleSoundSpec`
 * e.g. `""`

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -757,6 +757,7 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 		[25 + len] bool loop
 		[26 + len] f32 fade
 		[30 + len] f32 pitch
+		[34 + len] f32 begin
 	*/
 
 	s32 server_id;
@@ -769,29 +770,31 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 	bool loop;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float begin = 0.0f;
 
 	*pkt >> server_id >> name >> gain >> type >> pos >> object_id >> loop;
 
 	try {
 		*pkt >> fade;
 		*pkt >> pitch;
+		*pkt >> begin;
 	} catch (PacketError &e) {};
 
 	// Start playing
 	int client_id = -1;
 	switch(type) {
 		case 0: // local
-			client_id = m_sound->playSound(name, loop, gain, fade, pitch);
+			client_id = m_sound->playSound(name, loop, gain, fade, pitch, begin);
 			break;
 		case 1: // positional
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, begin);
 			break;
 		case 2:
 		{ // object
 			ClientActiveObject *cao = m_env.getActiveObject(object_id);
 			if (cao)
 				pos = cao->getPosition();
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, begin);
 			// TODO: Set up sound to move with object
 			break;
 		}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -978,6 +978,7 @@ void read_server_sound_params(lua_State *L, int index,
 		getstringfield(L, index, "to_player", params.to_player);
 		getfloatfield(L, index, "fade", params.fade);
 		getfloatfield(L, index, "pitch", params.pitch);
+		getfloatfield(L, index, "offset", params.begin);
 		lua_getfield(L, index, "pos");
 		if(!lua_isnil(L, -1)){
 			v3f p = read_v3f(L, -1)*BS;

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -229,26 +229,29 @@ int ModApiClient::l_sound_play(lua_State *L)
 	read_soundspec(L, 1, spec);
 	float gain = 1.0f;
 	float pitch = 1.0f;
+	float begin = 0.0f;
 	bool looped = false;
 	s32 handle;
 
 	if (lua_istable(L, 2)) {
 		getfloatfield(L, 2, "gain", gain);
 		getfloatfield(L, 2, "pitch", pitch);
+		getfloatfield(L, 2, "offset", begin);
 		getboolfield(L, 2, "loop", looped);
 
 		lua_getfield(L, 2, "pos");
 		if (!lua_isnil(L, -1)) {
 			v3f pos = read_v3f(L, -1) * BS;
 			lua_pop(L, 1);
-			handle = sound->playSoundAt(
-					spec.name, looped, gain * spec.gain, pos, pitch);
+			handle = sound->playSoundAt(spec.name, looped, gain * spec.gain,
+					pos, pitch, begin);
 			lua_pushinteger(L, handle);
 			return 1;
 		}
 	}
 
-	handle = sound->playSound(spec.name, looped, gain * spec.gain, 0.0f, pitch);
+	handle = sound->playSound(
+			spec.name, looped, gain * spec.gain, 0.0f, pitch, begin);
 	lua_pushinteger(L, handle);
 
 	return 1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1989,7 +1989,8 @@ s32 Server::playSound(const SimpleSoundSpec &spec,
 	NetworkPacket pkt(TOCLIENT_PLAY_SOUND, 0);
 	pkt << id << spec.name << gain
 			<< (u8) params.type << pos << params.object
-			<< params.loop << params.fade << params.pitch;
+			<< params.loop << params.fade << params.pitch
+			<< params.begin;
 
 	// Backwards compability
 	bool play_sound = gain > 0;

--- a/src/server.h
+++ b/src/server.h
@@ -90,6 +90,7 @@ struct ServerSoundParams
 	float gain = 1.0f;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float begin = 0.0f;
 	bool loop = false;
 	float max_hear_distance = 32 * BS;
 	v3f pos;

--- a/src/sound.h
+++ b/src/sound.h
@@ -34,9 +34,9 @@ public:
 struct SimpleSoundSpec
 {
 	SimpleSoundSpec(const std::string &name = "", float gain = 1.0f,
-			float fade = 0.0f, float pitch = 1.0f) :
+			float fade = 0.0f, float pitch = 1.0f, float begin = 0.0f) :
 			name(name),
-			gain(gain), fade(fade), pitch(pitch)
+			gain(gain), fade(fade), pitch(pitch), begin(begin)
 	{
 	}
 
@@ -46,6 +46,7 @@ struct SimpleSoundSpec
 	float gain = 1.0f;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float begin = 0.0f;
 };
 
 class ISoundManager
@@ -67,9 +68,9 @@ public:
 	// playSound functions return -1 on failure, otherwise a handle to the
 	// sound. If name=="", call should be ignored without error.
 	virtual int playSound(const std::string &name, bool loop, float volume,
-			float fade = 0.0f, float pitch = 1.0f) = 0;
+			float fade = 0.0f, float pitch = 1.0f, float begin = 0.0f) = 0;
 	virtual int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch = 1.0f) = 0;
+			float pitch = 1.0f, float begin = 0.0f) = 0;
 	virtual void stopSound(int sound) = 0;
 	virtual bool soundExists(int sound) = 0;
 	virtual void updateSoundPosition(int sound, v3f pos) = 0;
@@ -80,11 +81,13 @@ public:
 
 	int playSound(const SimpleSoundSpec &spec, bool loop)
 	{
-		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch);
+		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch,
+				spec.begin);
 	}
 	int playSoundAt(const SimpleSoundSpec &spec, bool loop, const v3f &pos)
 	{
-		return playSoundAt(spec.name, loop, spec.gain, pos, spec.pitch);
+		return playSoundAt(
+				spec.name, loop, spec.gain, pos, spec.pitch, spec.begin);
 	}
 };
 
@@ -102,12 +105,12 @@ public:
 	void updateListener(v3f pos, v3f vel, v3f at, v3f up) {}
 	void setListenerGain(float gain) {}
 	int playSound(const std::string &name, bool loop, float volume, float fade,
-			float pitch)
+			float pitch, float begin)
 	{
 		return 0;
 	}
 	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch)
+			float pitch, float begin)
 	{
 		return 0;
 	}

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -393,7 +393,7 @@ public:
 	}
 
 	PlayingSound* createPlayingSound(SoundBuffer *buf, bool loop,
-			float volume, float pitch)
+			float volume, float pitch, float begin)
 	{
 		infostream<<"OpenALSoundManager: Creating playing sound"<<std::endl;
 		assert(buf);
@@ -409,13 +409,15 @@ public:
 		volume = std::fmax(0.0f, volume);
 		alSourcef(sound->source_id, AL_GAIN, volume);
 		alSourcef(sound->source_id, AL_PITCH, pitch);
+		alSourceRewind(sound->source_id);
+		alSourcef(sound->source_id, AL_SEC_OFFSET, begin);
 		alSourcePlay(sound->source_id);
 		warn_if_error(alGetError(), "createPlayingSound");
 		return sound;
 	}
 
 	PlayingSound* createPlayingSoundAt(SoundBuffer *buf, bool loop,
-			float volume, v3f pos, float pitch)
+			float volume, v3f pos, float pitch, float begin)
 	{
 		infostream<<"OpenALSoundManager: Creating positional playing sound"
 				<<std::endl;
@@ -438,15 +440,17 @@ public:
 		volume = std::fmax(0.0f, volume * 3.0f);
 		alSourcef(sound->source_id, AL_GAIN, volume);
 		alSourcef(sound->source_id, AL_PITCH, pitch);
+		alSourceRewind(sound->source_id);
+		alSourcef(sound->source_id, AL_SEC_OFFSET, begin);
 		alSourcePlay(sound->source_id);
 		warn_if_error(alGetError(), "createPlayingSoundAt");
 		return sound;
 	}
 
-	int playSoundRaw(SoundBuffer *buf, bool loop, float volume, float pitch)
+	int playSoundRaw(SoundBuffer *buf, bool loop, float volume, float pitch, float begin)
 	{
 		assert(buf);
-		PlayingSound *sound = createPlayingSound(buf, loop, volume, pitch);
+		PlayingSound *sound = createPlayingSound(buf, loop, volume, pitch, begin);
 		if(!sound)
 			return -1;
 		int id = m_next_id++;
@@ -455,10 +459,10 @@ public:
 	}
 
 	int playSoundRawAt(SoundBuffer *buf, bool loop, float volume, const v3f &pos,
-			float pitch)
+			float pitch, float begin)
 	{
 		assert(buf);
-		PlayingSound *sound = createPlayingSoundAt(buf, loop, volume, pos, pitch);
+		PlayingSound *sound = createPlayingSoundAt(buf, loop, volume, pos, pitch, begin);
 		if(!sound)
 			return -1;
 		int id = m_next_id++;
@@ -563,7 +567,7 @@ public:
 		alListenerf(AL_GAIN, gain);
 	}
 
-	int playSound(const std::string &name, bool loop, float volume, float fade, float pitch)
+	int playSound(const std::string &name, bool loop, float volume, float fade, float pitch, float begin)
 	{
 		maintain();
 		if (name.empty())
@@ -576,15 +580,15 @@ public:
 		}
 		int handle = -1;
 		if (fade > 0) {
-			handle = playSoundRaw(buf, loop, 0.0f, pitch);
+			handle = playSoundRaw(buf, loop, 0.0f, pitch, begin);
 			fadeSound(handle, fade, volume);
 		} else {
-			handle = playSoundRaw(buf, loop, volume, pitch);
+			handle = playSoundRaw(buf, loop, volume, pitch, begin);
 		}
 		return handle;
 	}
 
-	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos, float pitch)
+	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos, float pitch, float begin)
 	{
 		maintain();
 		if (name.empty())
@@ -595,7 +599,7 @@ public:
 					<<std::endl;
 			return -1;
 		}
-		return playSoundRawAt(buf, loop, volume, pos, pitch);
+		return playSoundRawAt(buf, loop, volume, pos, pitch, begin);
 	}
 
 	void stopSound(int sound)


### PR DESCRIPTION
This PR is not quite finished. Input is wanted.

`alSourceRewind()` probably isn't needed, but I did the testing with it in place.

No sanitizing of values is done. What are the security implications of allowing servers to send offset values to clients that are out of range? How will different implementations of OpenAL handle that?

I (very briefly and non-exhaustively) tested the CSM API and the server API using a music track and with a few different offsets. In singleplayer and multiplayer.

There's probably support (dunno how much) for including an "end point" for sound to stop at, but I couldn't find a function to easily do that in the OpenAL API. If there is one let me know.

This also changes the network protocol by necessity.