### PR TITLE
Limit active object step time budget

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1085,6 +1085,9 @@ active_block_mgmt_interval (Active Block Management interval) float 2.0
 #    Length of time between ABM execution cycles
 abm_interval (Active Block Modifier interval) float 1.0
 
+#    Length of time between active object step cycles
+active_object_interval (Active Object interval) float 0.1
+
 #    Length of time between NodeTimer execution cycles
 nodetimer_interval (NodeTimer interval) float 0.2
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -345,6 +345,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("dedicated_server_step", "0.09");
 	settings->setDefault("active_block_mgmt_interval", "2.0");
 	settings->setDefault("abm_interval", "1.0");
+	settings->setDefault("active_object_interval", "0.1");
 	settings->setDefault("nodetimer_interval", "0.2");
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -36,6 +36,7 @@ Environment::Environment(IGameDef *gamedef):
 	m_cache_enable_shaders = g_settings->getBool("enable_shaders");
 	m_cache_active_block_mgmt_interval = g_settings->getFloat("active_block_mgmt_interval");
 	m_cache_abm_interval = g_settings->getFloat("abm_interval");
+	m_cache_ao_interval = g_settings->getFloat("active_object_interval");
 	m_cache_nodetimer_interval = g_settings->getFloat("nodetimer_interval");
 
 	m_time_of_day = g_settings->getU32("world_start_time");

--- a/src/environment.h
+++ b/src/environment.h
@@ -136,6 +136,7 @@ protected:
 	bool m_cache_enable_shaders;
 	float m_cache_active_block_mgmt_interval;
 	float m_cache_abm_interval;
+	float m_cache_ao_interval;
 	float m_cache_nodetimer_interval;
 
 	IGameDef *m_gamedef;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1234,7 +1234,7 @@ void ServerEnvironment::step(float dtime)
 		Mess around in active blocks
 	*/
 	if (m_active_blocks_nodemetadata_interval.step(dtime, m_cache_nodetimer_interval,
-		&elapsed_time)) {
+			&elapsed_time)) {
 		ScopeProfiler sp(g_profiler, "SEnv: mess in act. blocks avg per interval", SPT_AVG);
 
 		for (const v3s16 &p: m_active_blocks.m_list) {
@@ -1271,7 +1271,7 @@ void ServerEnvironment::step(float dtime)
 	}
 
 	if (m_active_block_modifier_interval.step(dtime,
-		m_cache_abm_interval * m_active_block_interval_overload_skip, &elapsed_time))
+			m_cache_abm_interval * m_active_block_interval_overload_skip, &elapsed_time))
 		do { // breakable
 			ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
 			TimeTaker timer("modify in active blocks per interval");
@@ -1313,7 +1313,7 @@ void ServerEnvironment::step(float dtime)
 		Step active objects
 	*/
 	if (m_active_object_interval.step(dtime,
-		m_cache_ao_interval * m_active_object_interval_overload_skip, &elapsed_time)) {
+			m_cache_ao_interval * m_active_object_interval_overload_skip, &elapsed_time)) {
 
 		ScopeProfiler sp(g_profiler, "SEnv: step act. objs avg", SPT_AVG);
 		TimeTaker timer("Step active objects");

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1268,7 +1268,8 @@ void ServerEnvironment::step(float dtime)
 		}
 	}
 
-	if (m_active_block_modifier_interval.step(dtime, m_cache_abm_interval * m_active_block_interval_overload_skip))
+	if (m_active_block_modifier_interval.step(dtime,
+		m_cache_abm_interval * m_active_block_interval_overload_skip))
 		do { // breakable
 			float elapsed_time = m_cache_abm_interval * m_active_object_interval_overload_skip;
 			ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
@@ -1291,7 +1292,7 @@ void ServerEnvironment::step(float dtime)
 
 			const u32 time_ms = timer.stop(true);
 			// allow up to 10% of the budget interval
-			const u32 max_time_ms = m_cache_abm_interval * 1000 / 10;
+			const u32 max_time_ms = m_cache_abm_interval * 1000.0f / 10.0f;
 			if (time_ms > max_time_ms) {
 				warningstream << "active block modifiers took "
 					<< time_ms << "ms (longer than "
@@ -1310,7 +1311,9 @@ void ServerEnvironment::step(float dtime)
 	/*
 		Step active objects
 	*/
-	if (m_active_object_interval.step(dtime, m_cache_ao_interval * m_active_object_interval_overload_skip)) {
+	if (m_active_object_interval.step(dtime,
+		m_cache_ao_interval * m_active_object_interval_overload_skip)) {
+
 		float elapsed_time = m_cache_ao_interval * m_active_object_interval_overload_skip;
 		ScopeProfiler sp(g_profiler, "SEnv: step act. objs avg", SPT_AVG);
 		TimeTaker timer("Step active objects");
@@ -1343,7 +1346,7 @@ void ServerEnvironment::step(float dtime)
 		// calculate a simple moving average
 		m_avg_ao_time = m_avg_ao_time * 0.9f + timer.stop(true) * 0.1f;
 		// allow up to 10% of the budget interval
-		const float max_time_ms = m_cache_ao_interval * 1000 / 10;
+		const float max_time_ms = m_cache_ao_interval * 1000.0f / 10.0f;
 		if (m_avg_ao_time > max_time_ms) {
 			warningstream << "active objects took "
 				<< m_avg_ao_time << "ms (longer than "

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -422,8 +422,11 @@ private:
 	ActiveBlockList m_active_blocks;
 	IntervalLimiter m_active_blocks_management_interval;
 	IntervalLimiter m_active_block_modifier_interval;
+	IntervalLimiter m_active_object_interval;
 	IntervalLimiter m_active_blocks_nodemetadata_interval;
-	int m_active_block_interval_overload_skip = 0;
+	float m_active_block_interval_overload_skip = 1.0f;
+	float m_active_object_interval_overload_skip = 1.0f;
+	float m_avg_ao_time = 0.0f;
 	// Time from the beginning of the game in seconds.
 	// Incremented in step().
 	u32 m_game_time = 0;

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -230,7 +230,7 @@ inline u32 calc_parity(u32 v)
 u64 murmur_hash_64_ua(const void *key, int len, unsigned int seed);
 
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
-		f32 camera_fov, f32 range, f32 *distance_ptr=NULL);
+		f32 camera_fov, f32 range, f32 *distance_ptr = NULL);
 
 s16 adjustDist(s16 dist, float zoom_fov);
 
@@ -291,18 +291,24 @@ public:
 		return value:
 			true: action should be skipped
 			false: action should be done
+		if passed, the elapsed time since this method last returned true
+		is written to elapsed_ptr
 	*/
-	bool step(float dtime, float wanted_interval)
+	bool step(float dtime, float wanted_interval, float *elapsed_ptr = NULL)
 	{
 		m_accumulator += dtime;
+		if (elapsed_ptr)
+			*elapsed_ptr = m_accumulator - m_last_accumulator;
 		if (m_accumulator < wanted_interval)
 			return false;
 		m_accumulator -= wanted_interval;
+		m_last_accumulator = m_accumulator;
 		return true;
 	}
 
 private:
 	float m_accumulator = 0.0f;
+	float m_last_accumulator = 0.0f;
 };
 
 


### PR DESCRIPTION
Split from #6667 .

Streamlines the time budget for active objects and also introduces a budget for active objects.
This prevent active objects to taking up too much time.

Uses a floating point multiplier now to simply increase the interval instead of skipping an integer number of intervals.

With heavy mobs, this prevent them from suddenly "flying off", or from using so much time that no more blocks are generated - both seen with NSSM.

If/when this is merged, I'll rebase #6667 accordingly.