### PR TITLE
Allow Irrlicht caching of animated meshes

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1855,10 +1855,7 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename)
 
 	scene::IAnimatedMesh *mesh = RenderingEngine::get_scene_manager()->getMesh(rfile);
 	rfile->drop();
-	// NOTE: By playing with Irrlicht refcounts, maybe we could cache a bunch
-	// of uniquely named instances and re-use them
 	mesh->grab();
-	RenderingEngine::get_mesh_cache()->removeMesh(mesh);
 	return mesh;
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1836,7 +1836,7 @@ ParticleManager* Client::getParticleManager()
 	return &m_particle_manager;
 }
 
-scene::IAnimatedMesh* Client::getMesh(const std::string &filename)
+scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
 {
 	StringMap::const_iterator it = m_mesh_data.find(filename);
 	if (it == m_mesh_data.end()) {
@@ -1856,6 +1856,8 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename)
 	scene::IAnimatedMesh *mesh = RenderingEngine::get_scene_manager()->getMesh(rfile);
 	rfile->drop();
 	mesh->grab();
+	if (!cache)
+		RenderingEngine::get_mesh_cache()->removeMesh(mesh);
 	return mesh;
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -376,7 +376,7 @@ public:
 	virtual ParticleManager* getParticleManager();
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename);
+	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
 	const std::string* getModFile(const std::string &filename);
 
 	virtual std::string getModStoragePath() const;

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -563,7 +563,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 	}
 	else if(m_prop.visual == "mesh") {
 		infostream<<"GenericCAO::addToScene(): mesh"<<std::endl;
-		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh);
+		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh, true);
 		if(mesh)
 		{
 			m_animated_meshnode = RenderingEngine::get_scene_manager()->

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -575,13 +575,13 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 					m_prop.visual_size.Y,
 					m_prop.visual_size.X));
 			u8 li = m_last_light;
-			setMeshColor(m_animated_meshnode->getMesh(), video::SColor(255,li,li,li));
+			setAnimatedMeshColor(m_animated_meshnode, video::SColor(255,li,li,li));
 
 			bool backface_culling = m_prop.backface_culling;
 			if (m_is_player)
 				backface_culling = false;
 
-			m_animated_meshnode->setMaterialFlag(video::EMF_LIGHTING, false);
+			m_animated_meshnode->setMaterialFlag(video::EMF_LIGHTING, true);
 			m_animated_meshnode->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
 			m_animated_meshnode->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF);
 			m_animated_meshnode->setMaterialFlag(video::EMF_FOG_ENABLE, true);
@@ -669,7 +669,7 @@ void GenericCAO::updateLightNoCheck(u8 light_at_pos)
 		if (m_meshnode) {
 			setMeshColor(m_meshnode->getMesh(), color);
 		} else if (m_animated_meshnode) {
-			setMeshColor(m_animated_meshnode->getMesh(), color);
+			setAnimatedMeshColor(m_animated_meshnode, color);
 		} else if (m_wield_meshnode) {
 			m_wield_meshnode->setColor(color);
 		} else if (m_spritenode) {
@@ -1025,7 +1025,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial& material = m_animated_meshnode->getMaterial(i);
 				material.TextureLayer[0].Texture = texture;
-				material.setFlag(video::EMF_LIGHTING, false);
+				material.setFlag(video::EMF_LIGHTING, true);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 
 				// don't filter low-res textures, makes them look blurry

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -575,6 +575,10 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 					m_prop.visual_size.Y,
 					m_prop.visual_size.X));
 			u8 li = m_last_light;
+
+			// set vertex colors to ensure alpha is set
+			setMeshColor(m_animated_meshnode->getMesh(), video::SColor(255,li,li,li));
+
 			setAnimatedMeshColor(m_animated_meshnode, video::SColor(255,li,li,li));
 
 			bool backface_culling = m_prop.backface_culling;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iostream>
 #include <IAnimatedMesh.h>
 #include <SAnimatedMesh.h>
+#include <IAnimatedMeshSceneNode.h>
 
 // In Irrlicht 1.8 the signature of ITexture::lock was changed from
 // (bool, u32) to (E_TEXTURE_LOCK_MODE, u32).
@@ -182,6 +183,13 @@ void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color)
 	u8 *vertices = (u8 *) buf->getVertices();
 	for (u32 i = 0; i < vertex_count; i++)
 		((video::S3DVertex *) (vertices + i * stride))->Color = color;
+}
+
+void setAnimatedMeshColor(scene::IAnimatedMeshSceneNode *node, const video::SColor &color)
+{
+	for (u32 i = 0; i < node->getMaterialCount(); ++i) {
+		node->getMaterial(i).EmissiveColor = color;
+	}
 }
 
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color)

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -58,6 +58,11 @@ void setMeshBufferColor(scene::IMeshBuffer *buf, const video::SColor &color);
 */
 void setMeshColor(scene::IMesh *mesh, const video::SColor &color);
 
+/*
+	Set a constant color for an animated mesh
+*/
+void setAnimatedMeshColor(scene::IAnimatedMeshSceneNode *node, const video::SColor &color);
+
 /*!
  * Overwrites the color of a mesh buffer.
  * The color is darkened based on the normal vector of the vertices.


### PR DESCRIPTION
Possible solution for #6676 !

Instead of setting the color of each vertex (which is shared between instances of the same animated mesh), set emissive color instead, which is unique per instance of the mesh.

That way we can use Irrlicht's mesh cache.

This is for testing. Please have a look at this and test it out.