### PR TITLE
CSM fixes: load mods after flavours & add flavour to block mod loading

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1122,6 +1122,7 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
+#    LOAD_CLIENT_MODS: 16 (disable client mods loading)
 #    type: int
 csm_flavour_limits (Client side modding flavour limits) int 3
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1118,13 +1118,13 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 
 #    Restricts the access of certain client-side functions on servers
 #    Combine these byteflags below to restrict more client-side features:
-#    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
+#    LOAD_CLIENT_MODS: 1 (disable client mods loading)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
-#    LOAD_CLIENT_MODS: 16 (disable client mods loading)
+#    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_flavour_noderange_limit)
 #    type: int
-csm_flavour_limits (Client side modding flavour limits) int 3
+csm_flavour_limits (Client side modding flavour limits) int 18
 
 #   If the CSM flavour for node range is enabled, get_node is limited to
 #   this many nodes from the player.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1350,7 +1350,7 @@
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
-#    type: int
+#    LOAD_CLIENT_MODS: 16 (disable client mods loading)
 #    type: int
 # csm_flavour_limits = 3
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1346,13 +1346,13 @@
 
 #    Restricts the access of certain client-side functions on servers
 #    Combine these byteflags below to restrict more client-side features:
-#    LOOKUP_NODES_LIMIT: 1 (limits get_node call client-side to csm_flavour_noderange_limit)
+#    LOAD_CLIENT_MODS: 1 (disable client mods loading)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
-#    LOAD_CLIENT_MODS: 16 (disable client mods loading)
 #    type: int
-# csm_flavour_limits = 3
+#    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_flavour_noderange_limit)
+# csm_flavour_limits = 18
 
 #    If the CSM flavour for node range is enabled, get_node is limited to
 #    this many nodes from the player.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -136,6 +136,10 @@ void Client::loadMods()
 
 	if (checkCSMFlavourLimit(CSMFlavourLimit::CSM_FL_LOAD_CLIENT_MODS)) {
 		warningstream << "Client side mods are disabled by server." << std::endl;
+		// If mods loading is disabled and builtin integrity is wrong, disconnect user.
+		if (!checkBuiltinIntegrity()) {
+			// @TODO disconnect user
+		}
 		return;
 	}
 
@@ -167,6 +171,12 @@ void Client::loadMods()
 		m_script->loadModFromMemory(mod.name);
 
 	m_mods_loaded = true;
+}
+
+bool Client::checkBuiltinIntegrity()
+{
+	// @TODO
+	return true;
 }
 
 void Client::scanModSubfolder(const std::string &mod_name, const std::string &mod_path,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -123,6 +123,11 @@ void Client::loadBuiltin()
 
 void Client::loadMods()
 {
+	// Don't permit to load mods twice
+	if (m_mods_loaded) {
+		return;
+	}
+
 	// If modding is not enabled or flavour disable it, don't load mods, just builtin
 	if (!m_modding_enabled) {
 		warningstream << "Client side mods are disabled by configuration." << std::endl;
@@ -160,6 +165,8 @@ void Client::loadMods()
 	// Load and run "mod" scripts
 	for (const ModSpec &mod : m_mods)
 		m_script->loadModFromMemory(mod.name);
+
+	m_mods_loaded = true;
 }
 
 void Client::scanModSubfolder(const std::string &mod_name, const std::string &mod_path,

--- a/src/client.h
+++ b/src/client.h
@@ -140,16 +140,13 @@ public:
 	DISABLE_CLASS_COPY(Client);
 
 	// Load local mods into memory
-	void loadMods();
+	void loadBuiltin();
 	void scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
 				std::string mod_subpath);
 	inline void scanModIntoMemory(const std::string &mod_name, const std::string &mod_path)
 	{
 		scanModSubfolder(mod_name, mod_path, "");
 	}
-
-	// Initizle the mods
-	void initMods();
 
 	/*
 	 request all threads managed by client to be stopped
@@ -433,6 +430,7 @@ public:
 	ModChannel *getModChannel(const std::string &channel);
 
 private:
+	void loadMods();
 
 	// Virtual methods from con::PeerHandler
 	void peerAdded(con::Peer *peer);

--- a/src/client.h
+++ b/src/client.h
@@ -535,6 +535,7 @@ private:
 	std::queue<ClientEvent *> m_client_event_queue;
 	bool m_itemdef_received = false;
 	bool m_nodedef_received = false;
+	bool m_mods_loaded = false;
 	ClientMediaDownloader *m_media_downloader;
 
 	// time_of_day speed approximation for old protocol

--- a/src/client.h
+++ b/src/client.h
@@ -431,6 +431,7 @@ public:
 
 private:
 	void loadMods();
+	bool checkBuiltinIntegrity();
 
 	// Virtual methods from con::PeerHandler
 	void peerAdded(con::Peer *peer);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -329,7 +329,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_flavour_limits", "3");
+	settings->setDefault("csm_flavour_limits", "18");
 	settings->setDefault("csm_flavour_noderange_limit", "8");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2049,7 +2049,7 @@ bool Game::initGui()
 
 	// Make sure the size of the recent messages buffer is right
 	chat_backend->applySettings();
-    
+
 	// Chat backend and console
 	gui_chat_console = new GUIChatConsole(guienv, guienv->getRootGUIElement(),
 			-1, chat_backend, client, &g_menumgr);
@@ -2146,8 +2146,7 @@ bool Game::connectToServer(const std::string &playername,
 
 		fps_control.last_time = RenderingEngine::get_timer_time();
 
-		client->loadMods();
-		client->initMods();
+		client->loadBuiltin();
 
 		while (RenderingEngine::run()) {
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1330,6 +1330,10 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 void Client::handleCommand_CSMFlavourLimits(NetworkPacket *pkt)
 {
 	*pkt >> m_csm_flavour_limits >> m_csm_noderange_limit;
+
+	// Now we have flavours, load mods if it's enabled
+	// Note: this should be moved after mods receptions from server instead
+	loadMods();
 }
 
 /*

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -925,6 +925,7 @@ enum CSMFlavourLimit : u64 {
 	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
+	CSM_FL_LOAD_CLIENT_MODS = 0x800000000, // Disable mods provided by clients
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -921,11 +921,11 @@ enum PlayerListModifer: u8
 
 enum CSMFlavourLimit : u64 {
 	CSM_FL_NONE = 0x00000000,
-	CSM_FL_LOOKUP_NODES = 0x00000001, // Limit node lookups
+	CSM_FL_LOAD_CLIENT_MODS = 0x00000001, // Disable mods provided by clients
 	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
-	CSM_FL_LOAD_CLIENT_MODS = 0x000000010, // Disable mods provided by clients
+	CSM_FL_LOOKUP_NODES = 0x00000010, // Limit node lookups
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -925,7 +925,7 @@ enum CSMFlavourLimit : u64 {
 	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
-	CSM_FL_LOAD_CLIENT_MODS = 0x00000000F, // Disable mods provided by clients
+	CSM_FL_LOAD_CLIENT_MODS = 0x000000010, // Disable mods provided by clients
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -925,7 +925,7 @@ enum CSMFlavourLimit : u64 {
 	CSM_FL_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_FL_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_FL_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
-	CSM_FL_LOAD_CLIENT_MODS = 0x800000000, // Disable mods provided by clients
+	CSM_FL_LOAD_CLIENT_MODS = 0x00000000F, // Disable mods provided by clients
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
 


### PR DESCRIPTION
This is a WIP i will integrate more features after
It will supersede #6718 

* [x] Load mods after flavour reception
* [x] Split builtin & mods loading
* [x] Add a flavour to disable mod loading
