### PR TITLE
Use std::vector instead of dynamic C-Array

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -301,10 +301,8 @@ void Mapgen::updateHeightmap(v3s16 nmin, v3s16 nmax)
 
 
 void Mapgen::getSurfaces(v2s16 p2d, s16 ymin, s16 ymax,
-	s16 *floors, s16 *ceilings, u16 *num_floors, u16 *num_ceilings)
+	std::vector<s16> &floors, std::vector<s16> &ceilings)
 {
-	u16 floor_i = 0;
-	u16 ceiling_i = 0;
 	const v3s16 &em = vm->m_area.getExtent();
 
 	bool is_walkable = false;
@@ -318,19 +316,14 @@ void Mapgen::getSurfaces(v2s16 p2d, s16 ymin, s16 ymax,
 		is_walkable = ndef->get(mn).walkable;
 
 		if (is_walkable && !walkable_above) {
-			floors[floor_i] = y;
-			floor_i++;
+			floors.push_back(y);
 		} else if (!is_walkable && walkable_above) {
-			ceilings[ceiling_i] = y + 1;
-			ceiling_i++;
+			ceilings.push_back(y + 1);
 		}
 
 		vm->m_area.add_y(em, vi, -1);
 		walkable_above = is_walkable;
 	}
-
-	*num_floors = floor_i;
-	*num_ceilings = ceiling_i;
 }
 
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -194,7 +194,7 @@ public:
 	s16 findLiquidSurface(v2s16 p2d, s16 ymin, s16 ymax);
 	void updateHeightmap(v3s16 nmin, v3s16 nmax);
 	void getSurfaces(v2s16 p2d, s16 ymin, s16 ymax,
-		s16 *floors, s16 *ceilings, u16 *num_floors, u16 *num_ceilings);
+		std::vector<s16> &floors, std::vector<s16> &ceilings);
 
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "util/numeric.h"
 #include <algorithm>
+#include <vector>
 
 
 FlagDesc flagdesc_deco[] = {
@@ -186,18 +187,16 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 
 				// Get all floors and ceilings in node column
 				u16 size = (nmax.Y - nmin.Y + 1) / 2;
-				s16 floors[size];
-				s16 ceilings[size];
-				u16 num_floors = 0;
-				u16 num_ceilings = 0;
+				std::vector<s16> floors;
+				std::vector<s16> ceilings;
+				floors.reserve(size);
+				ceilings.reserve(size);
 
-				mg->getSurfaces(v2s16(x, z), nmin.Y, nmax.Y,
-					floors, ceilings, &num_floors, &num_ceilings);
+				mg->getSurfaces(v2s16(x, z), nmin.Y, nmax.Y, floors, ceilings);
 
-				if ((flags & DECO_ALL_FLOORS) && num_floors > 0) {
+				if (flags & DECO_ALL_FLOORS) {
 					// Floor decorations
-					for (u16 fi = 0; fi < num_floors; fi++) {
-						s16 y = floors[fi];
+					for (const s16 y : floors) {
 						if (y < y_min || y > y_max)
 							continue;
 
@@ -208,10 +207,9 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 					}
 				}
 
-				if ((flags & DECO_ALL_CEILINGS) && num_ceilings > 0) {
+				if (flags & DECO_ALL_CEILINGS) {
 					// Ceiling decorations
-					for (u16 ci = 0; ci < num_ceilings; ci++) {
-						s16 y = ceilings[ci];
+					for (const s16 y : ceilings) {
 						if (y < y_min || y > y_max)
 							continue;
 


### PR DESCRIPTION
Fixes #6740

I'm wondering, if it would possible/better to use a dynamic vector and `floors.size()` instead of `num_floors` and `num_ceilings` and a fixed vector.
But I does not want to break existing code and this PR is only meant to fix the failing build not for doing improvements. 