### PR TITLE
Fix nodes dropping the wrong item

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -499,7 +499,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name())
+	local drops = core.get_node_drops(node.name, wielded and wielded:get_name())
 
 	if wielded then
 		local wdef = wielded:get_definition()


### PR DESCRIPTION
Regression from #5819 when changes to core.get_node_drops() aren't included in 0.4.17.
This caused handle_node_drops to ignore `drops` in a node's definition, always dropping the node instead