### PR TITLE
Minimap: Improve 'disabled' message. Zoom: Add 'disabled' message

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2874,7 +2874,7 @@ void Game::toggleMinimap(bool shift_pressed)
 			if (hud_flags & HUD_FLAG_MINIMAP_VISIBLE)
 				showStatusTextSimple("Minimap hidden");
 			else
-				showStatusTextSimple("Minimap disabled by server");
+				showStatusTextSimple("Minimap currently disabled by game or mod");
 	}
 
 	runData.statustext_time = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1280,6 +1280,7 @@ protected:
 	void increaseViewRange();
 	void decreaseViewRange();
 	void toggleFullViewRange();
+	void checkZoomEnabled();
 
 	void updateCameraDirection(CameraOrientation *cam, float dtime);
 	void updateCameraOrientation(CameraOrientation *cam, float dtime);
@@ -2580,6 +2581,8 @@ void Game::processKeyInput()
 		decreaseViewRange();
 	} else if (wasKeyDown(KeyType::RANGESELECT)) {
 		toggleFullViewRange();
+	} else if (wasKeyDown(KeyType::ZOOM)) {
+		checkZoomEnabled();
 	} else if (wasKeyDown(KeyType::QUICKTUNE_NEXT)) {
 		quicktune->next();
 	} else if (wasKeyDown(KeyType::QUICKTUNE_PREV)) {
@@ -3016,6 +3019,14 @@ void Game::toggleFullViewRange()
 		showStatusTextSimple("Enabled unlimited viewing range");
 	else
 		showStatusTextSimple("Disabled unlimited viewing range");
+}
+
+
+void Game::checkZoomEnabled()
+{
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (player->getZoomFOV() < 0.001f)
+		showStatusTextSimple("Zoom currently disabled by game or mod");
 }
 
 


### PR DESCRIPTION
![screenshot_20171212_093822](https://user-images.githubusercontent.com/3686677/33877965-feb1092a-df21-11e7-9b4f-fa66456a3b46.png)

![screenshot_20171212_093142](https://user-images.githubusercontent.com/3686677/33877976-04691556-df22-11e7-8dd5-ccf284b765c7.png)

Addresses #6767 in a simple way and adds the missing zoom message.

I should have done these when working on minimap and zoom code.
'currently' hints that the minimap/zoom may be enableable by an item (as now happens in MTG).
'mod or game' is clearer than 'server' and helps direct the player to the game or mod to investigate how to enable minimap/zoom.