### PR TITLE
Allow damage for attached objects, add attach/detach callbacks

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4831,6 +4831,13 @@ Registered entities
         * Called when the object dies.
         * `killer`: an `ObjectRef` (can be `nil`)
     * `on_rightclick(self, clicker)`
+    * `on_attach_child(self, child)`
+        * `child`: an `ObjectRef` (can be `nil`) of the child that attaches
+    * `on_detach_child(self, child)`
+        * `child`: an `ObjectRef` (can be `nil`) of the child that detaches
+    * `on_detach(self, parent)`
+        * `parent`: an `ObjectRef` (can be `nil`) from where it got detached
+        * This happens before the parent object is removed from the world
     * `get_staticdata(self)`
         * Should return a string that will be passed to `on_activate` when
           the object is instantiated the next time.

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "clientenvironment.h"
 #include "clientsimpleobject.h"
 #include "clientmap.h"
+#include "content_cao.h"
 #include "scripting_client.h"
 #include "mapblock_mesh.h"
 #include "event.h"

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -23,7 +23,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "clientenvironment.h"
 #include "clientsimpleobject.h"
 #include "clientmap.h"
-#include "content_cao.h"
 #include "scripting_client.h"
 #include "mapblock_mesh.h"
 #include "event.h"

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -342,7 +342,7 @@ GenericCAO::~GenericCAO()
 bool GenericCAO::getSelectionBox(aabb3f *toset) const
 {
 	if (!m_prop.is_visible || !m_is_visible || m_is_local_player
-			|| !m_prop.pointable || getParent() != NULL) {
+			|| !m_prop.pointable) {
 		return false;
 	}
 	*toset = m_selection_box;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -624,9 +624,7 @@ void LuaEntitySAO::rightClick(ServerActiveObject *clicker)
 {
 	if (!m_registered)
 		return;
-	// It's best that attachments cannot be clicked
-	if (isAttached())
-		return;
+
 	m_env->getScriptIface()->luaentity_Rightclick(m_id, clicker);
 }
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -86,6 +86,9 @@ protected:
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
 	bool m_attachment_sent = false;
+private:
+	void onAttach(int parent_id);
+	void onDetach(int parent_id);
 };
 
 /*
@@ -136,9 +139,6 @@ public:
 	bool getSelectionBox(aabb3f *toset) const;
 	bool collideWithObjects() const;
 private:
-	void onAttach(int parent_id);
-	void onDetach(int parent_id);
-
 	std::string getPropertyPacket();
 	void sendPosition(bool do_interpolate, bool is_movement_end);
 
@@ -377,9 +377,6 @@ public:
 	v3f getEyeOffset() const;
 
 private:
-	void onAttach(int parent_id);
-	void onDetach(int parent_id);
-
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -52,6 +52,7 @@ public:
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
 	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void clearAttachments(bool detach_childs);
 	void addAttachmentChild(int child_id);
 	void removeAttachmentChild(int child_id);
 	const std::unordered_set<int> &getAttachmentChildIds();

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -52,7 +52,8 @@ public:
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
 	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
-	void clearAttachments(bool detach_childs);
+	void clearChildAttachments();
+	void clearParentAttachment();
 	void addAttachmentChild(int child_id);
 	void removeAttachmentChild(int child_id);
 	const std::unordered_set<int> &getAttachmentChildIds();
@@ -73,7 +74,7 @@ protected:
 	float m_animation_blend = 0.0f;
 	bool m_animation_loop = true;
 	bool m_animation_sent = false;
-        bool m_animation_speed_sent = false;
+	bool m_animation_speed_sent = false;
 
 	// Stores position and rotation for each bone name
 	std::unordered_map<std::string, core::vector2d<v3f>> m_bone_position;
@@ -135,6 +136,9 @@ public:
 	bool getSelectionBox(aabb3f *toset) const;
 	bool collideWithObjects() const;
 private:
+	void onAttach(int parent_id);
+	void onDetach(int parent_id);
+
 	std::string getPropertyPacket();
 	void sendPosition(bool do_interpolate, bool is_movement_end);
 
@@ -373,6 +377,9 @@ public:
 	v3f getEyeOffset() const;
 
 private:
+	void onAttach(int parent_id);
+	void onDetach(int parent_id);
+
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
 

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -41,6 +41,11 @@ public:
 			ServerActiveObject *puncher, float time_from_last_punch,
 			const ToolCapabilities *toolcap, v3f dir, s16 damage);
 	bool luaentity_on_death(u16 id, ServerActiveObject *killer);
-	void luaentity_Rightclick(u16 id,
-			ServerActiveObject *clicker);
+	void luaentity_Rightclick(u16 id, ServerActiveObject *clicker);
+	void luaentity_on_attach_child(u16 id, ServerActiveObject *child);
+	void luaentity_on_detach_child(u16 id, ServerActiveObject *child);
+	void luaentity_on_detach(u16 id, ServerActiveObject *parent);
+private:
+	bool luaentity_run_simple_callback(u16 id, ServerActiveObject *sao,
+		const char *field);
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -101,7 +101,8 @@ int ObjectRef::l_remove(lua_State *L)
 	if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER)
 		return 0;
 
-	co->clearAttachments(true);
+	co->clearChildAttachments();
+	co->clearParentAttachment();
 
 	verbosestream << "ObjectRef::l_remove(): id=" << co->getId() << std::endl;
 	co->m_pending_removal = true;
@@ -714,7 +715,7 @@ int ObjectRef::l_set_detach(lua_State *L)
 	if (co == NULL)
 		return 0;
 
-	co->clearAttachments(false);
+	co->clearParentAttachment();
 	return 0;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -101,12 +101,7 @@ int ObjectRef::l_remove(lua_State *L)
 	if (co->getType() == ACTIVEOBJECT_TYPE_PLAYER)
 		return 0;
 
-	const std::unordered_set<int> &child_ids = co->getAttachmentChildIds();
-	for (int child_id : child_ids) {
-		// Child can be NULL if it was deleted earlier
-		if (ServerActiveObject *child = env->getActiveObject(child_id))
-			child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
-	}
+	co->clearAttachments(true);
 
 	verbosestream << "ObjectRef::l_remove(): id=" << co->getId() << std::endl;
 	co->m_pending_removal = true;
@@ -719,21 +714,7 @@ int ObjectRef::l_set_detach(lua_State *L)
 	if (co == NULL)
 		return 0;
 
-	int parent_id = 0;
-	std::string bone;
-	v3f position;
-	v3f rotation;
-	co->getAttachment(&parent_id, &bone, &position, &rotation);
-	ServerActiveObject *parent = NULL;
-	if (parent_id) {
-		parent = env->getActiveObject(parent_id);
-		co->setAttachment(0, "", position, rotation);
-	} else {
-		co->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
-	}
-	// Do it
-	if (parent != NULL)
-		parent->removeAttachmentChild(co->getId());
+	co->clearAttachments(false);
 	return 0;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2507,7 +2507,7 @@ void Server::DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason)
 			<< " dies" << std::endl;
 
 	playersao->setHP(0, reason);
-	playersao->clearAttachments(false);
+	playersao->clearParentAttachment();
 
 	// Trigger scripted stuff
 	m_script->on_dieplayer(playersao, reason);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2507,6 +2507,7 @@ void Server::DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason)
 			<< " dies" << std::endl;
 
 	playersao->setHP(0, reason);
+	playersao->clearAttachments(false);
 
 	// Trigger scripted stuff
 	m_script->on_dieplayer(playersao, reason);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -165,8 +165,8 @@ public:
 	{}
 	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation)
 	{}
-	virtual void clearAttachments(bool detach_childs)
-	{}
+	virtual void clearChildAttachments() {}
+	virtual void clearParentAttachment() {}
 	virtual void addAttachmentChild(int child_id)
 	{}
 	virtual void removeAttachmentChild(int child_id)
@@ -252,6 +252,9 @@ public:
 	std::queue<ActiveObjectMessage> m_messages_out;
 
 protected:
+	virtual void onAttach(int parent_id) {}
+	virtual void onDetach(int parent_id) {}
+
 	// Used for creating objects based on type
 	typedef ServerActiveObject* (*Factory)
 			(ServerEnvironment *env, v3f pos,

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -165,6 +165,8 @@ public:
 	{}
 	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation)
 	{}
+	virtual void clearAttachments(bool detach_childs)
+	{}
 	virtual void addAttachmentChild(int child_id)
 	{}
 	virtual void removeAttachmentChild(int child_id)


### PR DESCRIPTION
Addresses #4484
Testing is welcome @Wuzzy2 ;)

This PR allows punching (damaging) players AND Lua entities which are attached to another object. The following will happen:
- dying player: Remove parent attachment
- leaving player: Nothing, like before. Seems to work (?)
- removed or killed object: Remove parent and child attachments

**Mods to test and review this PR:**
- Use [wield3d](https://github.com/stujones11/wield3d) to check whether attached items can be punched
- Code example for carts or boost_cart [in this comment](https://github.com/minetest/minetest/pull/6786#issuecomment-353629316)