### PR TITLE
textarea[], field[]: Unify function, fix wrong fallback text

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1013,13 +1013,13 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		return;
 	}
 
-	if (is_editable)
+	if (is_editable) {
 		spec.send = true;
-
-	// Multiline textareas: swap default and label for backwards compat
-	if (!is_editable && is_multiline &&
-			spec.fdefault.empty() && !spec.flabel.empty())
+	} else if (is_multiline &&
+			spec.fdefault.empty() && !spec.flabel.empty()) {
+		// Multiline textareas: swap default and label for backwards compat
 		spec.flabel.swap(spec.fdefault);
+	}
 
 	gui::IGUIEditBox *e = nullptr;
 	static constexpr bool use_intl_edit_box = USE_FREETYPE &&

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1007,6 +1007,72 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 	errorstream<< "Invalid pwdfield element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
+void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
+	core::rect<s32> &rect, bool is_multiline)
+{
+	bool is_editable = !spec.fname.empty();
+	if (!is_editable && !is_multiline) {
+		// spec field id to 0, this stops submit searching for a value that isn't there
+		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+			this, spec.fid);
+		return;
+	}
+
+	if (is_editable)
+		spec.send = true;
+
+	// Multiline textareas: swap default and label for backwards compat
+	if (!is_editable && is_multiline &&
+			spec.fdefault.empty() && !spec.flabel.empty())
+		spec.flabel.swap(spec.fdefault);
+
+	gui::IGUIEditBox *e = nullptr;
+#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
+	if (g_settings->getBool("freetype")) {
+		e = (gui::IGUIEditBox *) new gui::intlGUIEditBox(spec.fdefault.c_str(),
+			true, Environment, this, spec.fid, rect, is_editable, true);
+		e->drop();
+	} else {
+#else
+	{
+#endif
+		if (is_multiline)
+			e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true,
+				Environment, this, spec.fid, rect, is_editable, true);
+		else if (is_editable)
+			e = Environment->addEditBox(spec.fdefault.c_str(), rect, true,
+				this, spec.fid);
+	}
+
+	if (e != nullptr) {
+		if (is_editable && spec.fname == data->focused_fieldname) 
+			Environment->setFocus(e);
+
+		if (is_multiline) {
+			e->setMultiLine(true);
+			e->setWordWrap(true);
+			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
+		} else {
+			irr::SEvent evt;
+			evt.EventType            = EET_KEY_INPUT_EVENT;
+			evt.KeyInput.Key         = KEY_END;
+			evt.KeyInput.Char        = 0;
+			evt.KeyInput.Control     = 0;
+			evt.KeyInput.Shift       = 0;
+			evt.KeyInput.PressedDown = true;
+			e->OnEvent(evt);
+		}
+	}
+
+	if (!spec.flabel.empty()) {
+		int font_height = g_fontengine->getTextHeight();
+		rect.UpperLeftCorner.Y -= font_height;
+		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
+		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
+			this, 0);
+	}
+}
+
 void GUIFormSpecMenu::parseSimpleField(parserData* data,
 		std::vector<std::string> &parts)
 {
@@ -1040,46 +1106,7 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 		258+m_fields.size()
 	);
 
-	if (name.empty()) {
-		// spec field id to 0, this stops submit searching for a value that isn't there
-		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true, this,
-			spec.fid);
-	} else {
-		spec.send = true;
-		gui::IGUIElement *e;
-#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
-		if (g_settings->getBool("freetype")) {
-			e = (gui::IGUIElement *) new gui::intlGUIEditBox(spec.fdefault.c_str(),
-				true, Environment, this, spec.fid, rect);
-			e->drop();
-		} else {
-#else
-		{
-#endif
-			e = Environment->addEditBox(spec.fdefault.c_str(), rect, true, this, spec.fid);
-		}
-		if (spec.fname == data->focused_fieldname) {
-			Environment->setFocus(e);
-		}
-
-		irr::SEvent evt;
-		evt.EventType            = EET_KEY_INPUT_EVENT;
-		evt.KeyInput.Key         = KEY_END;
-		evt.KeyInput.Char        = 0;
-		evt.KeyInput.Control     = 0;
-		evt.KeyInput.Shift       = 0;
-		evt.KeyInput.PressedDown = true;
-		e->OnEvent(evt);
-
-		if (label.length() >= 1)
-		{
-			int font_height = g_fontengine->getTextHeight();
-			rect.UpperLeftCorner.Y -= font_height;
-			rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-			gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-				this, 0);
-		}
-	}
+	createTextField(data, spec, rect, false);
 
 	if (parts.size() >= 4) {
 		// TODO: remove after 2016-11-03
@@ -1142,56 +1169,7 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 		258+m_fields.size()
 	);
 
-	bool is_editable = !name.empty();
-
-	if (is_editable)
-		spec.send = true;
-
-	gui::IGUIEditBox *e = nullptr;
-	const wchar_t *text = spec.fdefault.empty() ?
-		wlabel.c_str() : spec.fdefault.c_str();
-
-#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
-	if (g_settings->getBool("freetype")) {
-		e = (gui::IGUIEditBox *) new gui::intlGUIEditBox(text,
-			true, Environment, this, spec.fid, rect, is_editable, true);
-		e->drop();
-	} else {
-#else
-	{
-#endif
-		e = new GUIEditBoxWithScrollBar(text, true,
-			Environment, this, spec.fid, rect, is_editable, true);
-	}
-
-	if (is_editable && spec.fname == data->focused_fieldname)
-		Environment->setFocus(e);
-
-	if (e) {
-		if (type == "textarea")
-		{
-			e->setMultiLine(true);
-			e->setWordWrap(true);
-			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
-		} else {
-			irr::SEvent evt;
-			evt.EventType            = EET_KEY_INPUT_EVENT;
-			evt.KeyInput.Key         = KEY_END;
-			evt.KeyInput.Char        = 0;
-			evt.KeyInput.Control     = 0;
-			evt.KeyInput.Shift       = 0;
-			evt.KeyInput.PressedDown = true;
-			e->OnEvent(evt);
-		}
-	}
-
-	if (is_editable && !label.empty()) {
-		int font_height = g_fontengine->getTextHeight();
-		rect.UpperLeftCorner.Y -= font_height;
-		rect.LowerRightCorner.Y = rect.UpperLeftCorner.Y + font_height;
-		gui::StaticText::add(Environment, spec.flabel.c_str(), rect, false, true,
-			this, 0);
-	}
+	createTextField(data, spec, rect, type == "textarea");
 
 	if (parts.size() >= 6) {
 		// TODO: remove after 2016-11-03

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -55,12 +55,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlicht_changes/static_text.h"
 #include "guiscalingfilter.h"
 #include "guiEditBoxWithScrollbar.h"
-
-#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
 #include "intlGUIEditBox.h"
-#include "mainmenumanager.h"
-
-#endif
 
 #define MY_CHECKPOS(a,b)													\
 	if (v_pos.size() != 2) {												\
@@ -1027,15 +1022,14 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 		spec.flabel.swap(spec.fdefault);
 
 	gui::IGUIEditBox *e = nullptr;
-#if USE_FREETYPE && IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9
-	if (g_settings->getBool("freetype")) {
-		e = (gui::IGUIEditBox *) new gui::intlGUIEditBox(spec.fdefault.c_str(),
-			true, Environment, this, spec.fid, rect, is_editable, true);
+	static constexpr bool use_intl_edit_box = USE_FREETYPE &&
+		IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 9;
+
+	if (use_intl_edit_box && g_settings->getBool("freetype")) {
+		e = new gui::intlGUIEditBox(spec.fdefault.c_str(),
+			true, Environment, this, spec.fid, rect, is_editable, is_multiline);
 		e->drop();
 	} else {
-#else
-	{
-#endif
 		if (is_multiline)
 			e = new GUIEditBoxWithScrollBar(spec.fdefault.c_str(), true,
 				Environment, this, spec.fid, rect, is_editable, true);
@@ -1044,7 +1038,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 				this, spec.fid);
 	}
 
-	if (e != nullptr) {
+	if (e) {
 		if (is_editable && spec.fname == data->focused_fieldname) 
 			Environment->setFocus(e);
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -484,6 +484,8 @@ private:
 	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
 	void parsePwdField(parserData* data, const std::string &element);
 	void parseField(parserData* data, const std::string &element, const std::string &type);
+	void createTextField(parserData *data, FieldSpec &spec,
+		core::rect<s32> &rect, bool is_multiline);
 	void parseSimpleField(parserData* data,std::vector<std::string> &parts);
 	void parseTextArea(parserData* data,std::vector<std::string>& parts,
 			const std::string &type);

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -354,8 +354,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 			break;
 		case KEY_KEY_X:
 			// cut to the clipboard
-			if (!PasswordBox && Operator && MarkBegin != MarkEnd)
-			{
+			if (!PasswordBox && Operator && MarkBegin != MarkEnd) {
 				const s32 realmbgn = MarkBegin < MarkEnd ? MarkBegin : MarkEnd;
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
@@ -364,8 +363,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 				sc = Text.subString(realmbgn, realmend - realmbgn).c_str();
 				Operator->copyToClipboard(sc.c_str());
 
-				if (IsEnabled)
-				{
+				if (IsEnabled && m_writable) {
 					// delete
 					core::stringw s;
 					s = Text.subString(0, realmbgn);
@@ -380,7 +378,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 			}
 			break;
 		case KEY_KEY_V:
-			if ( !IsEnabled )
+			if (!IsEnabled || !m_writable)
 				break;
 
 			// paste from the clipboard
@@ -636,7 +634,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 		break;
 
 	case KEY_BACK:
-		if ( !this->IsEnabled )
+		if (!this->IsEnabled || !m_writable)
 			break;
 
 		if (!Text.empty()) {
@@ -675,7 +673,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 		}
 		break;
 	case KEY_DELETE:
-		if ( !this->IsEnabled )
+		if (!this->IsEnabled || !m_writable)
 			break;
 
 		if (!Text.empty()) {
@@ -1351,7 +1349,7 @@ s32 intlGUIEditBox::getLineFromPos(s32 pos)
 
 void intlGUIEditBox::inputChar(wchar_t c)
 {
-	if (!IsEnabled)
+	if (!IsEnabled || !m_writable)
 		return;
 
 	if (c != 0)


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest_game/issues/1978

Corrects the compatibility code after #6510 and the suboptimal fix 6b23cab.
**Instructions:**
Use this test mod. If it shows as expected, it's all ok.
```Lua
core.register_on_joinplayer(function(player)
	core.after(2, function(player_name)
	core.show_formspec(player_name, "lab:testy",
		"size[9,7]"..
		-- Book edit
		"field[0.5,1;3.5,0;title;Title:;" ..
			core.formspec_escape("Taking the hobbits to Isengard") .. "]" ..
		"textarea[0.5,1.5;3.5,4;text;Contents:;" ..
			core.formspec_escape("The hobbits the hobbits\nto Isengard") .. "]" ..
		-- Empty book
		"field[4.5,1;3.5,0;title2;Title:;]" ..
		"textarea[0.5,5.5;3.5,4;text2;Contents:;]" ..
		-- Server description (pre e6e5fa3, 0.4.16 stable)
		"textarea[4,2.3;4.23,2.9;;" ..
[[Blinded by the light
Revved up like a deuce
Another runner in the night
Blinded by the light

Madman drummer bummers
Indians in the summer
With a teenage diplomat
In the dumps with the mumps
As the adolescent pumps]] .. ";]" ..
		-- Readonly textarea with title
		"textarea[4.6,5.85;3.7,1.5;;This is a fancy title" ..
		";Never gonna give you up, never gonna let you down]"
	)
	end, player:get_player_name())
end)
```
**EDIT**
As of 180121 this PR also fixes editing of read-only text fields. (thanks to @red-001 for reporting)