### PR TITLE
Give subgames the ability to disallow specific mapgens

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -551,7 +551,7 @@ end
 --------------------------------------------------------------------------------
 if INIT == "mainmenu" then
 	function core.get_game(index)
-		local games = game.get_games()
+		local games = core.get_games()
 
 		if index > 0 and index <= #games then
 			return games[index]

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -36,11 +36,14 @@ local function create_world_formspec(dialogdata)
 	local gamepath = minetest.get_game(gameidx).path
 	local gameconfig = Settings(gamepath.."/game.conf")
 
-	local disallowed_mapgens = gameconfig:get("disallowed_mapgens")
+	local disallowed_mapgens = (gameconfig:get("disallowed_mapgens") or ""):split()
+	for key, value in pairs(disallowed_mapgens) do
+		disallowed_mapgens[key] = value:trim()
+	end
 
 	if disallowed_mapgens then
 		for i = #mapgens, 1, -1 do
-			if string.find(disallowed_mapgens, mapgens[i]) then
+			if table.indexof(disallowed_mapgens, mapgens[i]) > 0 then
 				table.remove(mapgens, i)
 			end
 		end
@@ -142,7 +145,7 @@ local function create_world_buttonhandler(this, fields)
 		core.settings:set("menu_last_game", gamemgr.games[gameindex].id)
 		return true
 	end
-	
+
 	if fields["world_create_cancel"] then
 		this:delete()
 		return true

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -15,6 +15,8 @@
 --with this program; if not, write to the Free Software Foundation, Inc.,
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+local worldname = ""
+
 local function create_world_formspec(dialogdata)
 	local mapgens = core.get_mapgen_names()
 
@@ -60,7 +62,7 @@ local function create_world_formspec(dialogdata)
 	local retval =
 		"size[11.5,6.5,true]" ..
 		"label[2,0;" .. fgettext("World name") .. "]"..
-		"field[4.5,0.4;6,0.5;te_world_name;;]" ..
+		"field[4.5,0.4;6,0.5;te_world_name;;" .. minetest.formspec_escape(worldname) .. "]" ..
 
 		"label[2,1;" .. fgettext("Seed") .. "]"..
 		"field[4.5,1.4;6,0.5;te_seed;;".. current_seed .. "]" ..
@@ -133,6 +135,8 @@ local function create_world_buttonhandler(this, fields)
 		return true
 	end
 
+	worldname = fields.te_world_name
+
 	if fields["games"] then
 		local gameindex = core.get_textlist_index("games")
 		core.settings:set("menu_last_game", gamemgr.games[gameindex].id)
@@ -149,6 +153,7 @@ end
 
 
 function create_create_world_dlg(update_worldlistfilter)
+	worldname = ""
 	local retval = dialog_create("sp_create_world",
 					create_world_formspec,
 					create_world_buttonhandler,

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -20,6 +20,29 @@ local function create_world_formspec(dialogdata)
 
 	local current_seed = core.settings:get("fixed_map_seed") or ""
 	local current_mg   = core.settings:get("mg_name")
+	local gameid = core.settings:get("menu_last_game")
+
+	local game, gameidx = nil , 0
+	if gameid ~= nil then
+		game, gameidx = gamemgr.find_by_gameid(gameid)
+		
+		if gameidx == nil then
+			gameidx = 0
+		end
+	end
+
+	local gamepath = minetest.get_game(gameidx).path
+	local gameconfig = Settings(gamepath.."/game.conf")
+
+	local disallowed_mapgens = gameconfig:get("disallowed_mapgens")
+
+	if disallowed_mapgens then
+		for i = #mapgens, 1, -1 do
+			if string.find(disallowed_mapgens, mapgens[i]) then
+				table.remove(mapgens, i)
+			end
+		end
+	end
 
 	local mglist = ""
 	local selindex = 1
@@ -32,17 +55,6 @@ local function create_world_formspec(dialogdata)
 		mglist = mglist .. v .. ","
 	end
 	mglist = mglist:sub(1, -2)
-	
-	local gameid = core.settings:get("menu_last_game")
-	
-	local game, gameidx = nil , 0
-	if gameid ~= nil then
-		game, gameidx = gamemgr.find_by_gameid(gameid)
-		
-		if gameidx == nil then
-			gameidx = 0
-		end
-	end
 
 	current_seed = core.formspec_escape(current_seed)
 	local retval =
@@ -122,6 +134,8 @@ local function create_world_buttonhandler(this, fields)
 	end
 
 	if fields["games"] then
+		local gameindex = core.get_textlist_index("games")
+		core.settings:set("menu_last_game", gamemgr.games[gameindex].id)
 		return true
 	end
 	

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -33,7 +33,7 @@ local function create_world_formspec(dialogdata)
 		end
 	end
 
-	local gamepath = minetest.get_game(gameidx).path
+	local gamepath = core.get_game(gameidx).path
 	local gameconfig = Settings(gamepath.."/game.conf")
 
 	local disallowed_mapgens = (gameconfig:get("disallowed_mapgens") or ""):split()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -53,13 +53,23 @@ Games are looked up from:
 
 where `gameid` is unique to each game.
 
-The game directory contains the file `game.conf`, which contains these fields:
+The game directory contains the file `game.conf`, which contains:
 
     name = <Human-readable full name of the game>
 
 e.g.
 
     name = Minetest
+
+Optionally, game.conf can also contain:
+
+    disallowed_mapgens = <comma-separated mapgens>
+
+e.g.
+
+    disallowed_mapgens = v5,v6,flat
+
+These mapgens are removed from the list of mapgens for the game.
 
 The game directory can contain the file minetest.conf, which will be used
 to set default settings when running the particular game.


### PR DESCRIPTION
This allows a subgame to control which mapgens show in the Mapgen dropdown when making a new game/world. 

Mapgens which are not supported or otherwise suitable for a given subgame can be disallowed by adding a setting in game.conf. For example, if you wish to disable v6, flat and fractal mapgens, add: 
disallowed_mapgens = v6,flat,fractal

This results in:
![mapgensleft](https://user-images.githubusercontent.com/7035183/34062224-56306df8-e1e3-11e7-8a0e-14246b1a743d.png)

Fixes  #4768