### PR TITLE
Fix compiler warning

### DIFF
--- a/lib/lua/src/ltablib.c
+++ b/lib/lua/src/ltablib.c
@@ -137,7 +137,7 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
   if (!lua_isstring(L, -1))
     luaL_error(L, "invalid value (%s) at index %d in table for "
                   LUA_QL("concat"), luaL_typename(L, -1), i);
-    luaL_addvalue(b);
+  luaL_addvalue(b);
 }
 
 


### PR DESCRIPTION
After this commit, you'll see the annoying compiler warning for ltablib.c gone.

Before this commit, the warning was:

/home/user/minetest/lib/lua/src/ltablib.c: In function ‘addfield’:
/home/user/minetest/lib/lua/src/ltablib.c:137:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if (!lua_isstring(L, -1))
   ^~
/home/user/minetest/lib/lua/src/ltablib.c:140:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
     luaL_addvalue(b);
    ^~~~~~~~~~~~~
