### PR TITLE
Adjust default console height

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -616,7 +616,7 @@ fall_bobbing_amount (Fall bobbing factor) float 0.0
 3d_mode (3D mode) enum none none,anaglyph,interlaced,topbottom,sidebyside,pageflip
 
 #    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
-console_height (Console height) float 1.0 0.1 1.0
+console_height (Console height) float 0.6 0.1 1.0
 
 #    In-game chat console background color (R,G,B).
 console_color (Console color) string (0,0,0)

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -701,7 +701,7 @@
 
 #    In-game chat console height, between 0.1 (10%) and 1.0 (100%).
 #    type: float min: 0.1 max: 1
-# console_height = 1.0
+# console_height = 0.6
 
 #    In-game chat console background color (R,G,B).
 #    type: string

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -180,7 +180,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");
 	settings->setDefault("opaque_water", "false");
-	settings->setDefault("console_height", "1.0");
+	settings->setDefault("console_height", "0.6");
 	settings->setDefault("console_color", "(0,0,0)");
 	settings->setDefault("console_alpha", "200");
 	settings->setDefault("formspec_fullscreen_bg_color", "(0,0,0)");


### PR DESCRIPTION
The current default console height is very uncomfortable when playing with a larger window size. Now there is an option to set the height, we can safely adjust the default back to the original.