### PR TITLE
Punchwear

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1169,8 +1169,11 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			s16 src_original_hp = pointed_object->getHP();
 			s16 dst_origin_hp = playersao->getHP();
 
-			pointed_object->punch(dir, &toolcap, playersao,
+			s16 wear = pointed_object->punch(dir, &toolcap, playersao,
 					time_from_last_punch);
+			bool result = punchitem.addWear(wear, m_itemdef);
+			if (result && playersao->setWieldedItem(punchitem))
+				SendInventory(playersao);
 
 			// If the object is a player and its HP changed
 			if (src_original_hp != pointed_object->getHP() &&

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -228,6 +228,7 @@ int ObjectRef::l_punch(lua_State *L)
 
 	// Do it
 	co->punch(dir, &toolcap, puncher, time_from_last_punch);
+	//FIXME punch() returns a wear value, we should apply this to a wielditem()
 
 	// If the punched is a player, and its HP changed
 	if (src_original_hp != co->getHP() &&

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -220,8 +220,8 @@ DigParams getDigParams(const ItemGroupList &groups,
 	if(time_from_last_punch < tp->full_punch_interval){
 		float f = time_from_last_punch / tp->full_punch_interval;
 		//infostream<<"f="<<f<<std::endl;
-		result_time /= f;
-		result_wear /= f;
+		result_time *= f;
+		result_wear *= f;
 	}
 
 	u16 wear_i = 65535.*result_wear;

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -238,6 +238,7 @@ HitParams getHitParams(const ItemGroupList &armor_groups,
 		const ToolCapabilities *tp, float time_from_last_punch)
 {
 	s16 damage = 0;
+	float result_wear = 0.0;
 	float full_punch_interval = tp->full_punch_interval;
 
 	for (const auto &damageGroup : tp->damageGroups) {
@@ -247,7 +248,23 @@ HitParams getHitParams(const ItemGroupList &armor_groups,
 				* armor / 100.0;
 	}
 
-	return {damage, 0};
+	for (const auto &groupcap : tp->groupcaps) {
+		const ToolGroupCap &cap = groupcap.second;
+
+		if (cap.uses != 0)
+			result_wear = 1.0 / cap.uses / pow(3.0, (double)(cap.maxlevel - 1.0));
+		else
+			result_wear = 0;
+	}
+
+	if (time_from_last_punch < tp->full_punch_interval) {
+		float f = time_from_last_punch / tp->full_punch_interval;
+		//infostream<<"f="<<f<<std::endl;
+		result_wear *= f;
+	}
+	u16 wear_i = 65535. * result_wear;
+
+	return {damage, wear_i};
 }
 
 HitParams getHitParams(const ItemGroupList &armor_groups,

--- a/src/tool.h
+++ b/src/tool.h
@@ -104,9 +104,9 @@ DigParams getDigParams(const ItemGroupList &groups,
 struct HitParams
 {
 	s16 hp;
-	s16 wear;
+	u16 wear;
 
-	HitParams(s16 hp_=0, s16 wear_=0):
+	HitParams(s16 hp_ = 0, u16 wear_ = 0):
 		hp(hp_),
 		wear(wear_)
 	{}


### PR DESCRIPTION
Replaces #3631 

Sadly, due to me deleting the original tree at one point, I can't rebase and continue the PR in the original thread. This is a rebased and re-tested version of that same code.

============

I'm firmly convinced that swords are meant to be worn out in
core when used by players to hit objects, entities and players.
There are various places here where there is obvious thought of
the wear param, and so this patch isn't too complex to begin
with at all.

getHitParams is the correct place to determine wear. Since
there are no levels for players, we assume a 1 / uses wear
fraction, which then gets scaled to 2^16 just like digging
wear. We propagate the wear to the code from where the punch
happens and apply the wear to the itemstack, and return the
itemstack to the client by updating their inventory.

It's obvious that wear needs to be a u16 and not s16 in the
hitparams, so we correct that.

Entities that hit still need to account for wielded item
wear. I've left a note explaining where this should be handled.

I've tested this code and it correctly wears out and breaks
a sword when hitting a player with a sword. Stone swords
wear out correctly less fast, etc. as well.