### PR TITLE
msvc: Fix condition where an attempt to take the address of zero-th e…

### DIFF
--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -63,7 +63,7 @@ void NetworkPacket::putRawPacket(u8 *data, u32 datasize, session_t peer_id)
 
 	// split command and datas
 	m_command = readU16(&data[0]);
-	memcpy(&m_data[0], &data[2], m_datasize);
+	memcpy(m_data.data(), &data[2], m_datasize);
 }
 
 const char* NetworkPacket::getString(u32 from_offset)


### PR DESCRIPTION
validity of addressing empty container (&a[0] when a.empty()):
  section numbering according to C++11 Working Draft (N3242)
    23.2.3 Table 101: a[n] operational semantics are listed as *(a.begin() + n)
    23.2.1/6: if a is empty then begin()==end()
  a.begin() + n for n=0 therefore equals a.end()
  UB since end() cannot be dereferenced

We can not take &m_data[0] when m_data is empty.
m_data will be empty, if in the line m_data.resize(m_datasize) just above the changed code, m_datasize is zero.
In that case memcpy will be called to copy zero bytes (a no-op).
The call will still take the address of m_data[0] though, which produces undefined behaviour.
This results in error on executable compiled with Visual Studio in Debug mode (iterator debugging support).