### PR TITLE
Tooltip height bugfix: Improve Irrlicht version check

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2673,11 +2673,14 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 
 	// Tooltip size and offset
 	s32 tooltip_width = m_tooltip_element->getTextWidth() + m_btn_height;
-#if (IRRLICHT_VERSION_MAJOR <= 1 && IRRLICHT_VERSION_MINOR <= 8 && IRRLICHT_VERSION_REVISION < 2) || USE_FREETYPE == 1
+	/* Irrlicht version 1.8.2 added counting newlines in the
+	 * calculation for getTextHeight()
+	 */
+#if (IRRLICHT_VERSION_MAJOR >= 1 && IRRLICHT_VERSION_MINOR >= 8 && IRRLICHT_VERSION_REVISION >= 2)
+	s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
+#else
 	std::vector<std::wstring> text_rows = str_split(ntext, L'\n');
 	s32 tooltip_height = m_tooltip_element->getTextHeight() * text_rows.size() + 5;
-#else
-	s32 tooltip_height = m_tooltip_element->getTextHeight() + 5;
 #endif
 	v2u32 screenSize = Environment->getVideoDriver()->getScreenSize();
 	int tooltip_offset_x = m_btn_height;


### PR DESCRIPTION
![screenshot_20171223_010621](https://user-images.githubusercontent.com/3686677/34315802-a44bf896-e77d-11e7-8cd6-ff73ca80aee7.png)

WIP has bug
Replaces #4302 
```
minetest.register_craftitem("binoculars:binoculars", {
	description = "Binoculars\nUse with 'Zoom' key\ngghhhhhhhgg\nuiiiiiuuuu\nooppiiipp",
	inventory_image = "binoculars_binoculars.png",
	stack_max = 1,

	on_use = function(itemstack, user, pointed_thing)
		binoculars.update_player_property(user)
	end,
})
```
```
.../minetest/bin$ ./minetest --version
Minetest 0.5.0-dev-7be7076 (Linux)
Using Irrlicht 1.8.3
```