### PR TITLE
Attempt at #6719 (play sound with an offset)

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -161,6 +161,8 @@ Examples of sound parameter tables:
     -- Play locationless
     {
         gain = 1.0, -- default
+        offset_start = 0.0,  -- default
+        offset_end   = -1.0, -- default
     }
     -- Play locationless, looped
     {
@@ -171,6 +173,8 @@ Examples of sound parameter tables:
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0, -- default
+        offset_start = 0.0,  -- default
+        offset_end   = -1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
     }
     -- Play connected to an object, looped
@@ -181,7 +185,12 @@ Examples of sound parameter tables:
         loop = true,
     }
 
-Looped sounds must either be connected to an object or played locationless.
+Looped sounds must be offsetless and either be connected to an object or played locationless.
+
+`offset_start` is the offset in the named sound to start playback, expressed in seconds.
+`offset_end` is the offset in the named sound to end playback, expressed in seconds.
+Together these offsets are able to specify a range [offset_start, offset_end].
+Specify `offset_end = -1.0` (or no `offset_end` at all) to play until the very end.
 
 ### SimpleSoundSpec
 * e.g. `""`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -732,6 +732,8 @@ Examples of sound parameter tables:
     -- Play locationless on all clients
     {
         gain = 1.0, -- default
+        offset_start = 0.0,  -- default
+        offset_end   = -1.0, -- default
         fade = 0.0, -- default, change to a value > 0 to fade the sound in
         pitch = 1.0, -- default
     }
@@ -739,6 +741,8 @@ Examples of sound parameter tables:
     {
         to_player = name,
         gain = 1.0, -- default
+        offset_start = 0.0,  -- default
+        offset_end   = -1.0, -- default
         fade = 0.0, -- default, change to a value > 0 to fade the sound in
         pitch = 1.0, -- default
     }
@@ -752,6 +756,8 @@ Examples of sound parameter tables:
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0, -- default
+        offset_start = 0.0,  -- default
+        offset_end   = -1.0, -- default
         max_hear_distance = 32, -- default, uses an euclidean metric
     }
     -- Play connected to an object, looped
@@ -765,6 +771,11 @@ Examples of sound parameter tables:
 Looped sounds must either be connected to an object or played locationless to
 one player using `to_player = name,`
 
+`offset_start` is the offset in the named sound to start playback, expressed in seconds.
+`offset_end` is the offset in the named sound to end playback, expressed in seconds.
+Together these offsets are able to specify a range [offset_start, offset_end].
+Specify `offset_end = -1.0` (or no `offset_end` at all) to play until the very end.
+
 ### `SimpleSoundSpec`
 * e.g. `""`
 * e.g. `"default_place_node"`
@@ -772,6 +783,7 @@ one player using `to_player = name,`
 * e.g. `{name = "default_place_node"}`
 * e.g. `{name = "default_place_node", gain = 1.0}`
 * e.g. `{name = "default_place_node", gain = 1.0, pitch = 1.0}`
+* e.g. `{name = "default_place_node", gain = 1.0, pitch = 1.0, offset_start = 1.0, offset_end = 3.5}`
 
 Registered definitions of stuff
 -------------------------------

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -222,6 +222,12 @@ bool GUIEngine::loadMainMenuScript()
 /******************************************************************************/
 void GUIEngine::run()
 {
+	u32 time;
+	u32 last_time;
+	f32 dtime;
+
+	irr::IrrlichtDevice *device = RenderingEngine::get_raw_device();
+
 	// Always create clouds because they may or may not be
 	// needed based on the game selected
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
@@ -232,6 +238,8 @@ void GUIEngine::run()
 
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
+
+	last_time = device->getTimer()->getTime();
 
 	while (RenderingEngine::run() && (!m_startgame) && (!m_kill)) {
 
@@ -277,6 +285,22 @@ void GUIEngine::run()
 			sleep_ms(25);
 
 		m_script->step();
+
+		/* dtime and other time related update.
+		 * This code essentially duplicates the logic in
+		 * Game.cpp Game::connectToServer.
+		 * (RenderingEngine::run() loop calls client->step
+		 *  which in turn calls m_sound->step(dtime))
+		 */
+		device->getTimer()->tick();
+		time = device->getTimer()->getTime();
+		if (time > last_time)
+			dtime = (time - last_time) / 1000.0;
+		else
+			dtime = 0;
+		last_time = time;
+
+		m_sound_manager->step(dtime);
 
 #ifdef __ANDROID__
 		m_menu->getAndroidUIInput();

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -753,6 +753,8 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 		[25 + len] bool loop
 		[26 + len] f32 fade
 		[30 + len] f32 pitch
+		[34 + len] f32 offset_start
+		[38 + len] f32 offset_end
 	*/
 
 	s32 server_id;
@@ -765,29 +767,33 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 	bool loop;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float offset_start = 0.0f;
+	float offset_end = -1.0f;
 
 	*pkt >> server_id >> name >> gain >> type >> pos >> object_id >> loop;
 
 	try {
 		*pkt >> fade;
 		*pkt >> pitch;
+		*pkt >> offset_start;
+		*pkt >> offset_end;
 	} catch (PacketError &e) {};
 
 	// Start playing
 	int client_id = -1;
 	switch(type) {
 		case 0: // local
-			client_id = m_sound->playSound(name, loop, gain, fade, pitch);
+			client_id = m_sound->playSound(name, loop, gain, fade, pitch, offset_start, offset_end);
 			break;
 		case 1: // positional
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, offset_start, offset_end);
 			break;
 		case 2:
 		{ // object
 			ClientActiveObject *cao = m_env.getActiveObject(object_id);
 			if (cao)
 				pos = cao->getPosition();
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, offset_start, offset_end);
 			// TODO: Set up sound to move with object
 			break;
 		}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1013,6 +1013,8 @@ void read_soundspec(lua_State *L, int index, SimpleSoundSpec &spec)
 		getfloatfield(L, index, "gain", spec.gain);
 		getfloatfield(L, index, "fade", spec.fade);
 		getfloatfield(L, index, "pitch", spec.pitch);
+		getfloatfield(L, index, "offset_start", spec.offset_start);
+		getfloatfield(L, index, "offset_end", spec.offset_end);
 	} else if(lua_isstring(L, index)){
 		spec.name = lua_tostring(L, index);
 	}
@@ -1029,6 +1031,10 @@ void push_soundspec(lua_State *L, const SimpleSoundSpec &spec)
 	lua_setfield(L, -2, "fade");
 	lua_pushnumber(L, spec.pitch);
 	lua_setfield(L, -2, "pitch");
+	lua_pushnumber(L, spec.offset_start);
+	lua_setfield(L, -2, "offset_start");
+	lua_pushnumber(L, spec.offset_end);
+	lua_setfield(L, -2, "offset_end");
 }
 
 /******************************************************************************/

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -242,13 +242,16 @@ int ModApiClient::l_sound_play(lua_State *L)
 			v3f pos = read_v3f(L, -1) * BS;
 			lua_pop(L, 1);
 			handle = sound->playSoundAt(
-					spec.name, looped, gain * spec.gain, pos, pitch);
+					spec.name, looped, gain * spec.gain, pos, pitch,
+					spec.offset_start, spec.offset_end);
 			lua_pushinteger(L, handle);
 			return 1;
 		}
 	}
 
-	handle = sound->playSound(spec.name, looped, gain * spec.gain, 0.0f, pitch);
+	handle = sound->playSound(
+			spec.name, looped, gain * spec.gain, 0.0f, pitch,
+			spec.offset_start, spec.offset_end);
 	lua_pushinteger(L, handle);
 
 	return 1;

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -241,16 +241,14 @@ int ModApiClient::l_sound_play(lua_State *L)
 		if (!lua_isnil(L, -1)) {
 			v3f pos = read_v3f(L, -1) * BS;
 			lua_pop(L, 1);
-			handle = sound->playSoundAt(
-					spec.name, looped, gain * spec.gain, pos, pitch,
-					spec.offset_start, spec.offset_end);
+			handle = sound->playSoundAt(spec.name, looped, gain * spec.gain,
+					pos, pitch, spec.offset_start, spec.offset_end);
 			lua_pushinteger(L, handle);
 			return 1;
 		}
 	}
 
-	handle = sound->playSound(
-			spec.name, looped, gain * spec.gain, 0.0f, pitch,
+	handle = sound->playSound(spec.name, looped, gain * spec.gain, 0.0f, pitch,
 			spec.offset_start, spec.offset_end);
 	lua_pushinteger(L, handle);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1996,7 +1996,8 @@ s32 Server::playSound(const SimpleSoundSpec &spec,
 	NetworkPacket pkt(TOCLIENT_PLAY_SOUND, 0);
 	pkt << id << spec.name << gain
 			<< (u8) params.type << pos << params.object
-			<< params.loop << params.fade << params.pitch;
+			<< params.loop << params.fade << params.pitch
+			<< spec.offset_start << spec.offset_end;
 
 	// Backwards compability
 	bool play_sound = gain > 0;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -18,8 +18,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "sound.h"
+#include "util/numeric.h"
 
 // Global DummySoundManager singleton
 DummySoundManager dummySoundManager;
 
-
+unsigned long SimpleSoundSpec::convertOffsetToSampleOffset(
+		unsigned long channels, unsigned long bits_per_sample, unsigned long frequency,
+		unsigned long buffer_size_bytes, double offset)
+{
+	const unsigned long BytesPerSampleFrame = channels * (bits_per_sample / 8);
+	const unsigned long NumBufferSampleFrames = buffer_size_bytes / BytesPerSampleFrame;
+	unsigned long SampleFrameOfOffset = offset * frequency;
+	// remember sample frames range [0, NumBufferSampleFrames)
+	//   therefore last is NumBufferSampleFrames - 1
+	if (offset == -1.0) // special value for 'offset at the very end'
+		SampleFrameOfOffset = NumBufferSampleFrames - 1;
+	return rangelim(SampleFrameOfOffset, 0, NumBufferSampleFrames - 1);
+}

--- a/src/sound.h
+++ b/src/sound.h
@@ -34,9 +34,11 @@ public:
 struct SimpleSoundSpec
 {
 	SimpleSoundSpec(const std::string &name = "", float gain = 1.0f,
-			float fade = 0.0f, float pitch = 1.0f) :
+			float fade = 0.0f, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) :
 			name(name),
-			gain(gain), fade(fade), pitch(pitch)
+			gain(gain), fade(fade), pitch(pitch),
+			offset_start(offset_start), offset_end(offset_end)
 	{
 	}
 
@@ -46,6 +48,12 @@ struct SimpleSoundSpec
 	float gain = 1.0f;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float offset_start = 0.0f;
+	float offset_end   = -1.0f;
+
+	static unsigned long convertOffsetToSampleOffset(
+			unsigned long channels, unsigned long bits_per_sample, unsigned long frequency,
+			unsigned long buffer_size_bytes, double offset);
 };
 
 class ISoundManager
@@ -67,9 +75,11 @@ public:
 	// playSound functions return -1 on failure, otherwise a handle to the
 	// sound. If name=="", call should be ignored without error.
 	virtual int playSound(const std::string &name, bool loop, float volume,
-			float fade = 0.0f, float pitch = 1.0f) = 0;
-	virtual int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch = 1.0f) = 0;
+			float fade = 0.0f, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
+	virtual int playSoundAt(const std::string &name, bool loop, float volume,
+			v3f pos, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
 	virtual void stopSound(int sound) = 0;
 	virtual bool soundExists(int sound) = 0;
 	virtual void updateSoundPosition(int sound, v3f pos) = 0;
@@ -80,7 +90,8 @@ public:
 
 	int playSound(const SimpleSoundSpec &spec, bool loop)
 	{
-		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch);
+		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch,
+				spec.offset_start, spec.offset_end);
 	}
 	int playSoundAt(const SimpleSoundSpec &spec, bool loop, const v3f &pos)
 	{
@@ -101,13 +112,15 @@ public:
 	}
 	void updateListener(v3f pos, v3f vel, v3f at, v3f up) {}
 	void setListenerGain(float gain) {}
-	int playSound(const std::string &name, bool loop, float volume, float fade,
-			float pitch)
+	int playSound(const std::string &name, bool loop, float volume,
+			float fade, float pitch,
+			float offset_start, float offset_end)
 	{
 		return 0;
 	}
-	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch)
+	int playSoundAt(const std::string &name, bool loop, float volume,
+			v3f pos, float pitch,
+			float offset_start, float offset_end)
 	{
 		return 0;
 	}

--- a/src/sound.h
+++ b/src/sound.h
@@ -34,11 +34,11 @@ public:
 struct SimpleSoundSpec
 {
 	SimpleSoundSpec(const std::string &name = "", float gain = 1.0f,
-			float fade = 0.0f, float pitch = 1.0f,
-			float offset_start = 0.0f, float offset_end = -1.0f) :
+			float fade = 0.0f, float pitch = 1.0f, float offset_start = 0.0f,
+			float offset_end = -1.0f) :
 			name(name),
-			gain(gain), fade(fade), pitch(pitch),
-			offset_start(offset_start), offset_end(offset_end)
+			gain(gain), fade(fade), pitch(pitch), offset_start(offset_start),
+			offset_end(offset_end)
 	{
 	}
 
@@ -49,10 +49,10 @@ struct SimpleSoundSpec
 	float fade = 0.0f;
 	float pitch = 1.0f;
 	float offset_start = 0.0f;
-	float offset_end   = -1.0f;
+	float offset_end = -1.0f;
 
-	static unsigned long convertOffsetToSampleOffset(
-			unsigned long channels, unsigned long bits_per_sample, unsigned long frequency,
+	static unsigned long convertOffsetToSampleOffset(unsigned long channels,
+			unsigned long bits_per_sample, unsigned long frequency,
 			unsigned long buffer_size_bytes, double offset);
 };
 
@@ -75,11 +75,11 @@ public:
 	// playSound functions return -1 on failure, otherwise a handle to the
 	// sound. If name=="", call should be ignored without error.
 	virtual int playSound(const std::string &name, bool loop, float volume,
-			float fade = 0.0f, float pitch = 1.0f,
-			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
-	virtual int playSoundAt(const std::string &name, bool loop, float volume,
-			v3f pos, float pitch = 1.0f,
-			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
+			float fade = 0.0f, float pitch = 1.0f, float offset_start = 0.0f,
+			float offset_end = -1.0f) = 0;
+	virtual int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
+			float pitch = 1.0f, float offset_start = 0.0f,
+			float offset_end = -1.0f) = 0;
 	virtual void stopSound(int sound) = 0;
 	virtual bool soundExists(int sound) = 0;
 	virtual void updateSoundPosition(int sound, v3f pos) = 0;
@@ -112,15 +112,13 @@ public:
 	}
 	void updateListener(v3f pos, v3f vel, v3f at, v3f up) {}
 	void setListenerGain(float gain) {}
-	int playSound(const std::string &name, bool loop, float volume,
-			float fade, float pitch,
-			float offset_start, float offset_end)
+	int playSound(const std::string &name, bool loop, float volume, float fade,
+			float pitch, float offset_start, float offset_end)
 	{
 		return 0;
 	}
-	int playSoundAt(const std::string &name, bool loop, float volume,
-			v3f pos, float pitch,
-			float offset_start, float offset_end)
+	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
+			float pitch, float offset_start, float offset_end)
 	{
 		return 0;
 	}


### PR DESCRIPTION
Ability to play a range (defined by start and end offsets) of a sound via the sound_play APIs.
OpenAL, the audio backend used by minetest offers direct support for a start offset but lacks a
good way of implementing an end offset.
End offset support is here implemented by periodically monitoring an ALsource's playback position, stopping the sound once past the end offset position.
Copying the sound range would likely be necessary to implement the range playback behaviour with perfect fidelity.
Copying is not done due to performance concerns (indefinitely many sounds could be made play simultaneously by the lua API).
Nevertheless, once/if these sound range APIs and associated network protocol change are merged, such an alternate implementation could eventually be substituted in.

There are three entrypoints requiring sound range support:
 - ModApiServer::l_sound_play (minetest.sound_play server mod)
 - ModApiClient::l_sound_play (minetest.sound_play CSM)
 - ModApiSound::l_sound_play  (core.sound_play mainmenu scripting)
Storing offsets received from lua API into the SimpleSoundSpec structure
(rather than the ServerSoundParams structure - as seen in some previous PRs)
is the right choice, as SimpleSoundSpec is already used by all three entrypoints.

With respect to network protocol compatibility note how the old code in clientpackethandler.cpp
handles fade and pitch parameters as optional (try { *pkt >> ...; } catch (...) {}).
The new offset parameters are added in the same style.
A new client connected to a old server is able to receive old packets.
An old client connected to a new server is able to receive packets with new parameters,
and somewhat gracefully degrade (the whole sound will be played instead of a range).
Therefore theoretically there may be no need to bump protocol version.

Currently minetest seems to duplicate some rendering loop code for the main game loop and
the menu loop (while (RenderingEngine::run()) { ... }). However the menu loop code is stripped down.
Particularly, it is missing a call to the sound manager step() function. guiEngine.cpp was modified
to introduce such call (and supporting code calculating 'dtime').

A call to the step function is required so that playback positions of currently active sounds can be monitored.
minetest already monitored active sounds for the sound fading support (see use of doFades() by step() in sound_openal.cpp).
Therefore the overhead should be acceptable.

Note the use of AL_SAMPLE_OFFSET (expressed in samples), rather than AL_SEC_OFFSET (expressed in seconds).
Samples are used even though the offset parameters in lua API are expressed in seconds.
Bad API design of OpenAL is to blame. Setting AL_*_OFFSET properties on an ALsource is specified to set an AL_INVALID_VALUE error when the values are out of range. As AL_SEC_OFFSET values are floating point, it is actually nontrivial to ensure minetest and OpenAL 'agree' whether such a value is or is not out of range.
(example: a sound buffer of 32145 samples at 44100 khz. last sample comes 32145/44100 or 0.72891156462585034013605442176871 seconds into the buffer, which has obvious precision problems.).

See especially the following issue transporting float values over the network specific to minetest:
networkpacket.cpp NetworkPacket::operator<<(float src) is used for inserting float values into a NetworkPacket. This function calls writeF1000 which absolutely obliterates precision, converting into a fixed point format.

SimpleSoundSpec::convertOffsetToSampleOffset function converts a floating point offset (expressed seconds) into
an integer offset (expressed in samples and ready for use with AL_SAMPLE_OFFSET).
