### PR TITLE
Add range check for float type in advanced settings

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -752,6 +752,18 @@ local function handle_change_setting_buttons(this, fields)
 				core.update_formspec(this:get_formspec())
 				return true
 			end
+			if setting.min and new_value < setting.min then
+				this.data.error_message = fgettext_ne("The value must be at least $1.", setting.min)
+				this.data.entered_text = fields["te_setting_value"]
+				core.update_formspec(this:get_formspec())
+				return true
+			end
+			if setting.max and new_value > setting.max then
+				this.data.error_message = fgettext_ne("The value must not be larger than $1.", setting.max)
+				this.data.entered_text = fields["te_setting_value"]
+				core.update_formspec(this:get_formspec())
+				return true
+			end
 			core.settings:set(setting.name, new_value)
 
 		elseif setting.type == "flags" then


### PR DESCRIPTION
Add range check for `float` type in advanced settings. Just copied the code from `int` type, it works! Because it is the same algorithm.

Fixes #4268.