### PR TITLE
Fix ambient occlusion and dark lines at mapblock borders

### DIFF
--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -212,6 +212,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			return false;
 		}
 		MapNode n = data->m_vmanip.getNodeNoExNoEmerge(p + dirs[i]);
+		if (n.getContent() == CONTENT_IGNORE)
+			return true;
 		const ContentFeatures &f = ndef->get(n);
 		if (f.light_source > light_source_max)
 			light_source_max = f.light_source;

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -227,14 +227,25 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	bool opaque1 = !add_node(1).light_propagates;
 	bool opaque2 = !add_node(2).light_propagates;
 	bool opaque3 = !add_node(3).light_propagates;
+	bool wrap7 = false;
 	obstructed[0] = opaque1 && opaque2;
 	obstructed[1] = opaque1 && opaque3;
 	obstructed[2] = opaque2 && opaque3;
-	for (int k = 0; k < 4; ++k) {
+	for (int k = 0; k < 3; ++k) {
 		if (obstructed[k])
 			ambient_occlusion++;
 		else if (add_node(k + 4).light_propagates)
 			obstructed[3] = false;
+	}
+	if (obstructed[3])
+		ambient_occlusion++;
+	else
+		wrap7 = add_node(7).light_propagates;
+	for (int k = 0; k < 3; ++k) { // wrap light around nodes
+		if (wrap7 && obstructed[k]) { // re-consider node that appears to be reachable
+			ambient_occlusion--;
+			add_node(k + 4);
+		}
 	}
 
 	if (light_count == 0) {

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -196,7 +196,7 @@ u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef)
 	Both light banks
 */
 static u16 getSmoothLightCombined(const v3s16 &p,
-	const std::array<v3s16,8> &dirs, MeshMakeData *data, bool node_solid)
+	const std::array<v3s16,8> &dirs, MeshMakeData *data)
 {
 	INodeDefManager *ndef = data->m_client->ndef();
 
@@ -222,34 +222,19 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		return f;
 	};
 
-	if (node_solid) {
-		ambient_occlusion = 3;
-		bool corner_obstructed = true;
-		for (int i = 0; i < 2; ++i) {
-			if (add_node(i).light_propagates)
-				corner_obstructed = false;
-		}
-		add_node(2);
-		add_node(3);
-		if (corner_obstructed)
+	std::array<bool, 4> obstructed = {{ 1, 1, 1, 1 }};
+	add_node(0);
+	bool opaque1 = !add_node(1).light_propagates;
+	bool opaque2 = !add_node(2).light_propagates;
+	bool opaque3 = !add_node(3).light_propagates;
+	obstructed[0] = opaque1 && opaque2;
+	obstructed[1] = opaque1 && opaque3;
+	obstructed[2] = opaque2 && opaque3;
+	for (int k = 0; k < 4; ++k) {
+		if (obstructed[k])
 			ambient_occlusion++;
-		else
-			add_node(4);
-	} else {
-		std::array<bool, 4> obstructed = {{ 1, 1, 1, 1 }};
-		add_node(0);
-		bool opaque1 = !add_node(1).light_propagates;
-		bool opaque2 = !add_node(2).light_propagates;
-		bool opaque3 = !add_node(3).light_propagates;
-		obstructed[0] = opaque1 && opaque2;
-		obstructed[1] = opaque1 && opaque3;
-		obstructed[2] = opaque2 && opaque3;
-		for (int k = 0; k < 4; ++k) {
-			if (obstructed[k])
-				ambient_occlusion++;
-			else if (add_node(k + 4).light_propagates)
-				obstructed[3] = false;
-		}
+		else if (add_node(k + 4).light_propagates)
+			obstructed[3] = false;
 	}
 
 	if (light_count == 0) {
@@ -304,43 +289,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 */
 u16 getSmoothLightSolid(const v3s16 &p, const v3s16 &face_dir, const v3s16 &corner, MeshMakeData *data)
 {
-	v3s16 neighbor_offset1, neighbor_offset2;
-
-	/*
-	 * face_dir, neighbor_offset1 and neighbor_offset2 define an
-	 * orthonormal basis which is used to define the offsets of the 8
-	 * surrounding nodes and to differentiate the "distance" (by going only
-	 * along directly neighboring nodes) relative to the node at p.
-	 * Apart from the node at p, only the 4 nodes which contain face_dir
-	 * can contribute light.
-	 */
-	if (face_dir.X != 0) {
-		neighbor_offset1 = v3s16(0, corner.Y, 0);
-		neighbor_offset2 = v3s16(0, 0, corner.Z);
-	} else if (face_dir.Y != 0) {
-		neighbor_offset1 = v3s16(0, 0, corner.Z);
-		neighbor_offset2 = v3s16(corner.X, 0, 0);
-	} else if (face_dir.Z != 0) {
-		neighbor_offset1 = v3s16(corner.X,0,0);
-		neighbor_offset2 = v3s16(0,corner.Y,0);
-	}
-
-	const std::array<v3s16,8> dirs = {{
-		// Always shine light
-		neighbor_offset1 + face_dir,
-		neighbor_offset2 + face_dir,
-		v3s16(0,0,0),
-		face_dir,
-
-		// Can be obstructed
-		neighbor_offset1 + neighbor_offset2 + face_dir,
-
-		// Do not shine light, only for ambient occlusion
-		neighbor_offset1,
-		neighbor_offset2,
-		neighbor_offset1 + neighbor_offset2
-	}};
-	return getSmoothLightCombined(p, dirs, data, true);
+	return getSmoothLightTransparent(p + face_dir, corner - 2 * face_dir, data);
 }
 
 /*
@@ -363,7 +312,7 @@ u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData 
 		v3s16(0,corner.Y,corner.Z),
 		v3s16(corner.X,corner.Y,corner.Z)
 	}};
-	return getSmoothLightCombined(p, dirs, data, false);
+	return getSmoothLightCombined(p, dirs, data);
 }
 
 void get_sunlight_color(video::SColorf *sunlight, u32 daynight_ratio){

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -270,7 +270,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			g_settings->getFloat("ambient_occlusion_gamma"), 0.25, 4.0);
 
 		// Table of gamma space multiply factors.
-		static const float light_amount[3] = {
+		static thread_local const float light_amount[3] = {
 			powf(0.75, 1.0 / ao_gamma),
 			powf(0.5,  1.0 / ao_gamma),
 			powf(0.25, 1.0 / ao_gamma)

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -206,7 +206,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	u16 light_day = 0;
 	u16 light_night = 0;
 
-	auto add_node = [&] (int i, bool obstructed = false) -> bool {
+	auto add_node = [&] (u8 i, bool obstructed = false) -> bool {
 		if (obstructed) {
 			ambient_occlusion++;
 			return false;
@@ -236,12 +236,12 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	obstructed[0] = opaque1 && opaque2;
 	obstructed[1] = opaque1 && opaque3;
 	obstructed[2] = opaque2 && opaque3;
-	for (int k = 0; k < 3; ++k)
+	for (u8 k = 0; k < 3; ++k)
 		if (add_node(k + 4, obstructed[k]))
 			obstructed[3] = false;
 	if (add_node(7, obstructed[3])) { // wrap light around nodes
 		ambient_occlusion -= 3;
-		for (int k = 0; k < 3; ++k)
+		for (u8 k = 0; k < 3; ++k)
 			add_node(k + 4, !obstructed[k]);
 	}
 


### PR DESCRIPTION
Fixes #6578 and #6574 

Mod to test: https://github.com/numberZero/minetest-test_lighting
Say /testlight and it will present all possible solid/transparent combinations (of size 2³), with one transparent node being full-sized nodebox and others being air.

~~UPD: found a case where a bug remains.~~ **Fixed.**
![screenshot_20171226_001225](https://user-images.githubusercontent.com/7352626/34342954-c2dff734-e9d1-11e7-8cd3-0be23de85e77.png)

~~UPD: that affects non-solid nodes per se as well (don’t say my torches are broken, I know that myself):~~ **Fixed.**
![screenshot_20171226_001717](https://user-images.githubusercontent.com/7352626/34342969-5bfb8ce4-e9d2-11e7-84c8-d30584641759.png)
  