### PR TITLE
Add confirmation on new player registration

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -978,7 +978,7 @@ void Client::sendInit(const std::string &playerName)
 	Send(&pkt);
 }
 
-void Client::promptConfirmRegister(AuthMechanism chosen_auth_mechanism)
+void Client::promptConfirmRegistration(AuthMechanism chosen_auth_mechanism)
 {
 	m_chosen_auth_mech = chosen_auth_mechanism;
 	m_is_registration_confirmation_state = true;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -318,6 +318,10 @@ void Client::step(float dtime)
 		initial_step = false;
 	}
 	else if(m_state == LC_Created) {
+		if (m_is_registration_confirmation_state) {
+			// Waiting confirmation
+			return;
+		}
 		float &counter = m_connection_reinit_timer;
 		counter -= dtime;
 		if(counter <= 0.0) {
@@ -972,6 +976,18 @@ void Client::sendInit(const std::string &playerName)
 	pkt << playerName;
 
 	Send(&pkt);
+}
+
+void Client::promptConfirmRegister(AuthMechanism chosen_auth_mechanism)
+{
+	m_chosen_auth_mech = chosen_auth_mechanism;
+	m_is_registration_confirmation_state = true;
+}
+
+void Client::confirmRegistration()
+{
+	m_is_registration_confirmation_state = false;
+	startAuth(m_chosen_auth_mech);
 }
 
 void Client::startAuth(AuthMechanism chosen_auth_mechanism)

--- a/src/client.h
+++ b/src/client.h
@@ -345,6 +345,9 @@ public:
 	{ return m_proto_ver; }
 
 	bool connectedToServer();
+	void confirmRegistration();
+	bool m_is_registration_confirmation_state = false;
+	bool m_simple_singleplayer_mode;
 
 	float mediaReceiveProgress();
 
@@ -448,6 +451,7 @@ private:
 	static AuthMechanism choseAuthMech(const u32 mechs);
 
 	void sendInit(const std::string &playerName);
+	void promptConfirmRegister(AuthMechanism chosen_auth_mechanism);
 	void startAuth(AuthMechanism chosen_auth_mechanism);
 	void sendDeletedBlocks(std::vector<v3s16> &blocks);
 	void sendGotBlocks(v3s16 block);

--- a/src/client.h
+++ b/src/client.h
@@ -451,7 +451,7 @@ private:
 	static AuthMechanism choseAuthMech(const u32 mechs);
 
 	void sendInit(const std::string &playerName);
-	void promptConfirmRegister(AuthMechanism chosen_auth_mechanism);
+	void promptConfirmRegistration(AuthMechanism chosen_auth_mechanism);
 	void startAuth(AuthMechanism chosen_auth_mechanism);
 	void sendDeletedBlocks(std::vector<v3s16> &blocks);
 	void sendGotBlocks(v3s16 block);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -410,6 +410,26 @@ void RenderingEngine::_draw_load_screen(const std::wstring &text,
 	guitext->remove();
 }
 
+/*
+	Draws the menu scene including (optional) cloud background.
+*/
+void RenderingEngine::_draw_menu_scene(gui::IGUIEnvironment *guienv,
+		float dtime, bool clouds)
+{
+	bool cloud_menu_background = clouds && g_settings->getBool("menu_clouds");
+	if (cloud_menu_background) {
+		g_menuclouds->step(dtime * 3);
+		g_menuclouds->render();
+		get_video_driver()->beginScene(
+				true, true, video::SColor(255, 140, 186, 250));
+		g_menucloudsmgr->drawAll();
+	} else
+		get_video_driver()->beginScene(true, true, video::SColor(255, 0, 0, 0));
+
+	guienv->drawAll();
+	get_video_driver()->endScene();
+}
+
 std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 {
 	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -110,6 +110,12 @@ public:
 				text, guienv, tsrc, dtime, percent, clouds);
 	}
 
+	inline static void draw_menu_scene(
+			gui::IGUIEnvironment *guienv, float dtime, bool clouds)
+	{
+		s_singleton->_draw_menu_scene(guienv, dtime, clouds);
+	}
+
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair)
 	{
@@ -136,6 +142,9 @@ public:
 private:
 	void _draw_load_screen(const std::wstring &text, gui::IGUIEnvironment *guienv,
 			ITextureSource *tsrc, float dtime = 0, int percent = 0,
+			bool clouds = true);
+
+	void _draw_menu_scene(gui::IGUIEnvironment *guienv, float dtime = 0,
 			bool clouds = true);
 
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiChatConsole.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiConfirmRegistration.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEditBoxWithScrollbar.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEngine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiFormSpecMenu.cpp

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -88,14 +88,12 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 540, 90);
 		rect += topleft_client + v2s32(30, ypos);
 		static const std::string info_text_template = strgettext(
-				"You are about to join the server (%1$s) with name "
-				"and password, but no player account is registered "
-				"on the name \"%2$s\" yet. If you proceed, a new "
-				"password-protected player account with this name "
-				"will be created on this server.\nIf you want to "
-				"create an account and join this server, please "
-				"enter the previously entered password once again "
-				"to confirm account creation:");
+				"You are about to join this server (%1$s) with the "
+				"name \"%2$s\" the first time. If you proceed, a "
+				"new account using your credentials will be created "
+				"on this server.\n"
+				"Please enter your password once again to confirm "
+				"account creation or cancel to abort.");
 		char info_text_buf[600];
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -83,7 +83,7 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 	s32 ypos = 30;
 	{
 		std::string address = m_address;
-		if (address == "")
+		if (address.empty())
 			address = "localhost";
 		core::rect<s32> rect(0, 0, 540, 90);
 		rect += topleft_client + v2s32(30, ypos);
@@ -92,9 +92,9 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 				"name \"%2$s\" the first time. If you proceed, a "
 				"new account using your credentials will be created "
 				"on this server.\n"
-				"Please enter your password once again to confirm "
+				"Please type your password once again to confirm "
 				"account creation or cancel to abort.");
-		char info_text_buf[600];
+		char info_text_buf[1024];
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());
 		Environment->addStaticText(narrow_to_wide_c(info_text_buf), rect, false,
@@ -206,8 +206,7 @@ bool GUIConfirmRegistration::OnEvent(const SEvent &event)
 			// Returning true disables focus change
 			return true;
 		}
-	}
-	if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
+	} else if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
 		switch (event.GUIEvent.Caller->getID()) {
 		case ID_confirm:
 			acceptInput();
@@ -218,8 +217,7 @@ bool GUIConfirmRegistration::OnEvent(const SEvent &event)
 			closeMenu(false);
 			return true;
 		}
-	}
-	if (event.GUIEvent.EventType == gui::EGET_EDITBOX_ENTER) {
+	} else if (event.GUIEvent.EventType == gui::EGET_EDITBOX_ENTER) {
 		switch (event.GUIEvent.Caller->getID()) {
 		case ID_confirmPassword:
 			acceptInput();

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -1,0 +1,236 @@
+/*
+Minetest
+Copyright (C) 2018 srifqi, Muhammad Rifqi Priyo Susanto
+		<muhammadrifqipriyosusanto@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiConfirmRegistration.h"
+#include "client.h"
+#include <IGUICheckBox.h>
+#include <IGUIEditBox.h>
+#include <IGUIButton.h>
+#include <IGUIStaticText.h>
+#include <IGUIFont.h>
+
+#include "gettext.h"
+
+// Continuing from guiPasswordChange.cpp
+const int ID_confirmPassword = 262;
+const int ID_confirm = 263;
+const int ID_message = 264;
+const int ID_cancel = 265;
+
+GUIConfirmRegistration::GUIConfirmRegistration(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr, Client *client,
+		const std::string &playername, const std::string &password,
+		const std::string &address, bool *aborted) :
+		GUIModalMenu(env, parent, id, menumgr),
+		m_client(client), m_playername(playername), m_password(password),
+		m_address(address), m_aborted(aborted)
+{
+}
+
+GUIConfirmRegistration::~GUIConfirmRegistration()
+{
+	removeChildren();
+}
+
+void GUIConfirmRegistration::removeChildren()
+{
+	const core::list<gui::IGUIElement *> &children = getChildren();
+	core::list<gui::IGUIElement *> children_copy;
+	for (gui::IGUIElement *i : children)
+		children_copy.push_back(i);
+	for (gui::IGUIElement *i : children_copy)
+		i->remove();
+}
+void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
+{
+	acceptInput();
+	removeChildren();
+
+	/*
+		Calculate new sizes and positions
+	*/
+	core::rect<s32> rect(screensize.X / 2 - 600 / 2, screensize.Y / 2 - 300 / 2,
+			screensize.X / 2 + 600 / 2, screensize.Y / 2 + 300 / 2);
+
+	DesiredRect = rect;
+	recalculateAbsolutePosition(false);
+
+	v2s32 size = rect.getSize();
+	v2s32 topleft_client(0, 0);
+
+	const wchar_t *text;
+
+	/*
+		Add stuff
+	*/
+	s32 ypos = 30;
+	{
+		std::string address = m_address;
+		if (address == "")
+			address = "localhost";
+		core::rect<s32> rect(0, 0, 540, 90);
+		rect += topleft_client + v2s32(30, ypos);
+		static const std::string info_text_template = strgettext(
+				"You are about to join the server (%1$s) with name "
+				"and password, but no player account is registered "
+				"on the name \"%2$s\" yet. If you proceed, a new "
+				"password-protected player account with this name "
+				"will be created on this server.\nIf you want to "
+				"create an account and join this server, please "
+				"enter the previously entered password once again "
+				"to confirm account creation:");
+		char info_text_buf[600];
+		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
+				address.c_str(), m_playername.c_str());
+		Environment->addStaticText(narrow_to_wide_c(info_text_buf), rect, false,
+				true, this, -1);
+	}
+
+	ypos += 120;
+	{
+		core::rect<s32> rect(0, 0, 540, 30);
+		rect += topleft_client + v2s32(30, ypos);
+		gui::IGUIEditBox *e = Environment->addEditBox(m_pass_confirm.c_str(),
+				rect, true, this, ID_confirmPassword);
+		e->setPasswordBox(true);
+	}
+
+	ypos += 90;
+	{
+		core::rect<s32> rect(0, 0, 230, 35);
+		rect = rect + v2s32(size.X / 2 - 220, ypos);
+		text = wgettext("Register and Join");
+		Environment->addButton(rect, this, ID_confirm, text);
+		delete[] text;
+	}
+	{
+		core::rect<s32> rect(0, 0, 120, 35);
+		rect = rect + v2s32(size.X / 2 + 70, ypos);
+		text = wgettext("Cancel");
+		Environment->addButton(rect, this, ID_cancel, text);
+		delete[] text;
+	}
+	{
+		core::rect<s32> rect(0, 0, 200, 20);
+		rect += topleft_client + v2s32(30, ypos - 40);
+		text = wgettext("Passwords do not match!");
+		IGUIElement *e = Environment->addStaticText(
+				text, rect, false, true, this, ID_message);
+		e->setVisible(false);
+		delete[] text;
+	}
+}
+
+void GUIConfirmRegistration::drawMenu()
+{
+	gui::IGUISkin *skin = Environment->getSkin();
+	if (!skin)
+		return;
+	video::IVideoDriver *driver = Environment->getVideoDriver();
+
+	video::SColor bgcolor(140, 0, 0, 0);
+	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+
+	gui::IGUIElement::draw();
+}
+
+void GUIConfirmRegistration::closeMenu(bool goNext)
+{
+	quitMenu();
+	if (goNext) {
+		m_client->confirmRegistration();
+	} else {
+		*m_aborted = true;
+		infostream << "Connect aborted [Escape]" << std::endl;
+	}
+}
+
+void GUIConfirmRegistration::acceptInput()
+{
+	gui::IGUIElement *e;
+	e = getElementFromId(ID_confirmPassword);
+	if (e)
+		m_pass_confirm = e->getText();
+}
+
+bool GUIConfirmRegistration::processInput()
+{
+	std::wstring m_password_ws = narrow_to_wide(m_password);
+	if (m_password_ws != m_pass_confirm) {
+		gui::IGUIElement *e = getElementFromId(ID_message);
+		if (e)
+			e->setVisible(true);
+		return false;
+	}
+	return true;
+}
+
+bool GUIConfirmRegistration::OnEvent(const SEvent &event)
+{
+	if (event.EventType == EET_KEY_INPUT_EVENT) {
+		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
+			closeMenu(false);
+			return true;
+		}
+		if (event.KeyInput.Key == KEY_RETURN && event.KeyInput.PressedDown) {
+			acceptInput();
+			if (processInput())
+				closeMenu(true);
+			return true;
+		}
+	}
+
+	if (event.EventType != EET_GUI_EVENT)
+		return Parent ? Parent->OnEvent(event) : false;
+
+	if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST &&
+			isVisible()) {
+		if (!canTakeFocus(event.GUIEvent.Element)) {
+			dstream << "GUIConfirmRegistration: Not allowing focus "
+				   "change."
+				<< std::endl;
+			// Returning true disables focus change
+			return true;
+		}
+	}
+	if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED) {
+		switch (event.GUIEvent.Caller->getID()) {
+		case ID_confirm:
+			acceptInput();
+			if (processInput())
+				closeMenu(true);
+			return true;
+		case ID_cancel:
+			closeMenu(false);
+			return true;
+		}
+	}
+	if (event.GUIEvent.EventType == gui::EGET_EDITBOX_ENTER) {
+		switch (event.GUIEvent.Caller->getID()) {
+		case ID_confirmPassword:
+			acceptInput();
+			if (processInput())
+				closeMenu(true);
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -198,8 +198,7 @@ bool GUIConfirmRegistration::OnEvent(const SEvent &event)
 	if (event.EventType != EET_GUI_EVENT)
 		return Parent ? Parent->OnEvent(event) : false;
 
-	if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST &&
-			isVisible()) {
+	if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST && isVisible()) {
 		if (!canTakeFocus(event.GUIEvent.Element)) {
 			dstream << "GUIConfirmRegistration: Not allowing focus "
 				   "change."

--- a/src/gui/guiConfirmRegistration.h
+++ b/src/gui/guiConfirmRegistration.h
@@ -1,0 +1,61 @@
+/*
+Minetest
+Copyright (C) 2018 srifqi, Muhammad Rifqi Priyo Susanto
+		<muhammadrifqipriyosusanto@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "modalMenu.h"
+#include <string>
+
+class Client;
+
+class GUIConfirmRegistration : public GUIModalMenu
+{
+public:
+	GUIConfirmRegistration(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
+			s32 id, IMenuManager *menumgr, Client *client,
+			const std::string &playername, const std::string &password,
+			const std::string &address, bool *aborted);
+	~GUIConfirmRegistration();
+
+	void removeChildren();
+	/*
+		Remove and re-add (or reposition) stuff
+	*/
+	void regenerateGui(v2u32 screensize);
+
+	void drawMenu();
+
+	void closeMenu(bool goNext);
+
+	void acceptInput();
+
+	bool processInput();
+
+	bool OnEvent(const SEvent &event);
+
+private:
+	Client *m_client = nullptr;
+	const std::string &m_playername;
+	const std::string &m_password;
+	const std::string &m_address;
+	bool *m_aborted = nullptr;
+	std::wstring m_pass_confirm = L"";
+};

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -98,7 +98,7 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 	if (chosen_auth_mechanism != AUTH_MECHANISM_NONE) {
 		if (chosen_auth_mechanism == AUTH_MECHANISM_FIRST_SRP
 				&& !m_simple_singleplayer_mode) {
-			promptConfirmRegister(chosen_auth_mechanism);
+			promptConfirmRegistration(chosen_auth_mechanism);
 		} else {
 			startAuth(chosen_auth_mechanism);
 		}

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -96,7 +96,12 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 
 	// Authenticate using that method, or abort if there wasn't any method found
 	if (chosen_auth_mechanism != AUTH_MECHANISM_NONE) {
-		startAuth(chosen_auth_mechanism);
+		if (chosen_auth_mechanism == AUTH_MECHANISM_FIRST_SRP
+				&& !m_simple_singleplayer_mode) {
+			promptConfirmRegister(chosen_auth_mechanism);
+		} else {
+			startAuth(chosen_auth_mechanism);
+		}
 	} else {
 		m_chosen_auth_mech = AUTH_MECHANISM_NONE;
 		m_access_denied = true;


### PR DESCRIPTION
It will show a confirmation dialog for new player not in singleplayer mode.

Using SRP auth mechanism, if server sent `AUTH_MECHANISM_FIRST_SRP` that means the player isn't exist. This is _not_ supported by older network protocol.

Fixes #258 and closes #3167.

**TODO**:
- [X] How to display the confirmation dialog.
- [X] Ways to convert from `std::wstring` to `std::string` and vice versa (for comparing and `swprintf()`).
- [X] Use template to also show the server (IP address) and the name which the player chose.

-------

![confirmation dialog for new player](https://user-images.githubusercontent.com/4017302/34903058-a92205f6-f85b-11e7-970d-e5e49d1032d1.png)

(Old screenshot) https://user-images.githubusercontent.com/4017302/34456483-e3f3479a-edc9-11e7-9d23-d3d155b2d872.png
(Older screenshot) https://user-images.githubusercontent.com/4017302/34455891-70557dac-edbb-11e7-9003-ab7f7359d545.png