### PR TITLE
Biomes: Add vertical biome blend

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4989,18 +4989,18 @@ Definition tables
         y_min = 1,
         y_max = 31000,
     --  ^ Lower and upper limits for biome.
+        vertical_blend = 8,
+    --  ^ Vertical distance in nodes above 'y_max' over which the biome will
+    --  ^ blend with the biome above.
+    --  ^ Set to 0 for no vertical blend. Defaults to 0.
         heat_point = 0,
         humidity_point = 50,
-    --  ^ Characteristic average temperature and humidity for the biome.
-    --  ^ These values create 'biome points' on a voronoi diagram that has heat
-    --  ^ and humidity as axes. The resulting voronoi cells determine which
-    --  ^ heat/humidity points belong to which biome, and therefore determine
-    --  ^ the area and location of each biome in the world.
-    --  ^ The biome points need to be carefully and evenly spaced on the voronoi
-    --  ^ diagram to result in roughly equal size biomes.
+    --  ^ Characteristic temperature and humidity for the biome.
+    --  ^ These values create 'biome points' on a voronoi diagram with heat and
+    --  ^ humidity as axes. The resulting voronoi cells determine the
+    --  ^ distribution of the biomes.
     --  ^ Heat and humidity have average values of 50, vary mostly between
-    --  ^ 0 and 100 but also often exceed these values.
-    --  ^ Heat is not in degrees Celsius, both values are abstract.
+    --  ^ 0 and 100 but can exceed these values.
     }
 
 ### Decoration definition (`register_decoration`)

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -67,6 +67,7 @@ public:
 	s16 y_max;
 	float heat_point;
 	float humidity_point;
+	s16 vertical_blend;
 
 	virtual void resolveNodeNames();
 };

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -392,6 +392,7 @@ Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef)
 	b->y_max           = getintfield_default(L,    index, "y_max",           31000);
 	b->heat_point      = getfloatfield_default(L,  index, "heat_point",      0.f);
 	b->humidity_point  = getfloatfield_default(L,  index, "humidity_point",  0.f);
+	b->vertical_blend  = getintfield_default(L,    index, "vertical_blend",  0);
 	b->flags           = 0; //reserved
 
 	std::vector<std::string> &nn = b->m_nodenames;


### PR DESCRIPTION
 Biomes: Add vertical biome blend

Add 'vertical blend' parameter to biome registration that defines how
many nodes above the biome's 'y max' limit the blend will extend.
////////////////

![screenshot_20171229_234324_1](https://user-images.githubusercontent.com/3686677/34449756-eed4cb7e-ecf3-11e7-952b-8517b6d699e6.png)

![screenshot_20171229_234854](https://user-images.githubusercontent.com/3686677/34449758-f3752688-ecf3-11e7-9e36-f95d327a649f.png)

Addresses #5308 
The new parameter is 0 by default so existing worlds using biomes without the parameter set are not affected. If the parameter is 0 the biome code is no more intensive than before.
Being a per-biome parameter allows vertical blend distance to be set to 0 where it needs to be, for example at the water's edge.
I tuned the setting of the PRNG seed such that vertical blend is 'blobby' and forms more interesting patterns than single-node dither, this is also consistent with horizontal biome blend which is 'blobby'.