### PR TITLE
Fix Wstringop-overflow warning from util/srp.cpp

### DIFF
--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
+#include <cstdint>
 
 #include <config.h>
 
@@ -418,7 +419,7 @@ static SRP_Result H_nn(
 }
 
 static SRP_Result H_ns(mpz_t result, SRP_HashAlgorithm alg, const unsigned char *n,
-	size_t len_n, const unsigned char *bytes, unsigned int len_bytes)
+	size_t len_n, const unsigned char *bytes, uint32_t len_bytes)
 {
 	unsigned char buff[SHA512_DIGEST_LENGTH];
 	size_t nbytes = len_n + len_bytes;

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -418,7 +418,7 @@ static SRP_Result H_nn(
 }
 
 static SRP_Result H_ns(mpz_t result, SRP_HashAlgorithm alg, const unsigned char *n,
-	size_t len_n, const unsigned char *bytes, size_t len_bytes)
+	size_t len_n, const unsigned char *bytes, unsigned int len_bytes)
 {
 	unsigned char buff[SHA512_DIGEST_LENGTH];
 	size_t nbytes = len_n + len_bytes;


### PR DESCRIPTION
When compiling minetest I got this warning referring to https://github.com/minetest/minetest/blob/master/src/util/srp.cpp#L428:
```C
[  0%] Building CXX object src/CMakeFiles/minetest.dir/util/srp.cpp.o
In file included from /usr/include/string.h:494:0,
                 from /usr/include/c++/7/cstring:42,
                 from […]/minetest/src/util/srp.cpp:40:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘int calculate_x(__mpz_struct*, SRP_HashAlgorithm, const unsigned char*, size_t, const char*, const unsigned char*, size_t)’ at […]/minetest/src/util/srp.cpp:428:8:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:71: warning: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’: specified size 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
                                                                       ^
```
I don't conceive the reason of this warning, however, when using an `unsigned int` instead of `size_t` for `len_bytes`, the warning doesn't appear.
When I used `short` or returned SRP_ERR if `len_bytes` is negative, the warning still appeared.