### PR TITLE
Fix buffer parameter not working in LuaPerlinNoiseMap::l_getMapSlice()

### DIFF
--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -311,7 +311,7 @@ int LuaPerlinNoiseMap::l_getMapSlice(lua_State *L)
 	Noise *n = o->noise;
 
 	if (use_buffer)
-		lua_pushvalue(L, 3);
+		lua_pushvalue(L, 4);
 	else
 		lua_newtable(L);
 


### PR DESCRIPTION
Test case:

```lua
local data = {}
local pm = PerlinNoiseMap({offset=0, scale=1, spread={x=100,y=100,z=100}, seed=23, octaves=1, persist=0.7}, {x=1, y=1, z=1})
pm:getMapSlice({}, {}, data)
assert(data[1])
```

The assertion fails unless this patch is applied. It's a pretty obvious typo, though.
