### PR TITLE
Prevent GUITable from capturing mouse events outside of it

### DIFF
--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -588,6 +588,7 @@ void GUITable::setSelected(s32 index)
 GUITable::DynamicData GUITable::getDynamicData() const
 {
 	DynamicData dyndata;
+	dyndata.is_mouse_captured = m_is_mouse_captured;
 	dyndata.selected = getSelected();
 	dyndata.scrollpos = m_scrollbar->getPos();
 	dyndata.keynav_time = m_keynav_time;
@@ -601,6 +602,8 @@ void GUITable::setDynamicData(const DynamicData &dyndata)
 {
 	if (m_has_tree_column)
 		setOpenedTrees(dyndata.opened_trees);
+
+	m_is_mouse_captured = dyndata.is_mouse_captured;
 
 	m_keynav_time = dyndata.keynav_time;
 	m_keynav_buffer = dyndata.keynav_buffer;
@@ -881,9 +884,20 @@ bool GUITable::OnEvent(const SEvent &event)
 				m_scrollbar->isPointInside(p))
 			return true;
 
+		// Drop the capture when player releases the left mouse button
+		if (!event.MouseInput.isLeftPressed())
+			m_is_mouse_captured = false;
+
+		bool is_inside = isPointInside(p);
 		if (event.MouseInput.isLeftPressed() &&
-				(isPointInside(p) ||
-				 event.MouseInput.Event == EMIE_MOUSE_MOVED)) {
+				(is_inside || event.MouseInput.Event == EMIE_MOUSE_MOVED)) {
+			// Capture the mouse if the mouse pointer is over the table
+			if (is_inside)
+				m_is_mouse_captured = true;
+
+			if (!m_is_mouse_captured)
+				return true;
+
 			s32 sel_column = 0;
 			bool sel_doubleclick = (event.MouseInput.Event
 					== EMIE_LMOUSE_DOUBLE_CLICK);

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -50,6 +50,7 @@ public:
 	*/
 	struct DynamicData
 	{
+		bool is_mouse_captured = false;
 		s32 selected = 0;
 		s32 scrollpos = 0;
 		s32 keynav_time = 0;
@@ -185,6 +186,9 @@ protected:
 	s32 m_selected = -1; // index of row (1...n), or 0 if none selected
 	s32 m_sel_column = 0;
 	bool m_sel_doubleclick = false;
+
+	// Mouse state
+	bool m_is_mouse_captured = false;
 
 	// Keyboard navigation stuff
 	u64 m_keynav_time = 0;


### PR DESCRIPTION
This PR fixes an obscure bug when placing an item into a slot, then moving the mouse with the left button still pressed triggers a table event.

Essentially, this restricts GUITable's event handling to what it actually is supposed to handle. 
  