### PR TITLE
Fix off-by-one in log output line length

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -347,13 +347,10 @@ void StringBuffer::push_back(char c)
 			flush(std::string(buffer, buffer_index));
 		buffer_index = 0;
 	} else {
-		int index = buffer_index;
-		buffer[index++] = c;
-		if (index >= BUFFER_LENGTH) {
-			flush(std::string(buffer, index));
+		buffer[buffer_index++] = c;
+		if (buffer_index >= BUFFER_LENGTH) {
+			flush(std::string(buffer, buffer_index));
 			buffer_index = 0;
-		} else {
-			buffer_index = index;
 		}
 	}
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -350,7 +350,7 @@ void StringBuffer::push_back(char c)
 		int index = buffer_index;
 		buffer[index++] = c;
 		if (index >= BUFFER_LENGTH) {
-			flush(std::string(buffer, buffer_index));
+			flush(std::string(buffer, index));
 			buffer_index = 0;
 		} else {
 			buffer_index = index;


### PR DESCRIPTION
When a log line is over 255 characters, only the first 255 were printed, and the next line would start in the 257th, hence skipping one.

I'd rather get rid of the local, though, which I find distracting and prone to bugs like this one.