### PR TITLE
Fix grammar in registration confirmation dialog

### DIFF
--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -92,8 +92,9 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 				"name \"%2$s\" for the first time. If you proceed, a "
 				"new account using your credentials will be created "
 				"on this server.\n"
-				"Please retype your password to confirm account "
-				"creation or cancel to abort.");
+				"Please retype your password and click Register and "
+				"Join to confirm account creation or click Cancel to "
+				"abort.");
 		char info_text_buf[1024];
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -88,12 +88,12 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 540, 90);
 		rect += topleft_client + v2s32(30, ypos);
 		static const std::string info_text_template = strgettext(
-				"You are about to join this server (%1$s) with the "
-				"name \"%2$s\" the first time. If you proceed, a "
+				"You are about to join the server at %1$s with the "
+				"name \"%2$s\" for the first time. If you proceed, a "
 				"new account using your credentials will be created "
 				"on this server.\n"
-				"Please type your password once again to confirm "
-				"account creation or cancel to abort.");
+				"Please retype your password to confirm account "
+				"creation or cancel to abort.");
 		char info_text_buf[1024];
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());


### PR DESCRIPTION
See https://github.com/minetest/minetest/commit/792752997c5ae2aaa4f54d0a2e2af2a96d7d1e9f#r26833999

![screenshot](https://user-images.githubusercontent.com/4017302/34908013-5fdbc642-f8bb-11e7-86a1-cda51d976a36.png)