### PR TITLE
[WIP] Don’t copy TileSpecs

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(client_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/meshgen/collector.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/render/anaglyph.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/render/core.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/render/factory.cpp

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -62,19 +62,20 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		video::SColor color = c;
 		if (!light_source)
 			applyFacesShading(color, vertices[i].Normal);
-		p.vertices.emplace_back(vertices[i].Pos + pos, vertices[i].Normal,
-				color, scale * vertices[i].TCoords);
+		p.vertices.emplace_back(vertices[i].Pos + pos, vertices[i].Normal, color,
+				scale * vertices[i].TCoords);
 	}
 
 	for (u32 i = 0; i < numIndices; i++)
 		p.indices.push_back(indices[i] + vertex_count);
 }
 
-PreMeshBuffer &MeshCollector::findBuffer(const TileLayer& layer, u8 layernum,
-		u32 numVertices)
+PreMeshBuffer &MeshCollector::findBuffer(
+		const TileLayer &layer, u8 layernum, u32 numVertices)
 {
 	if (numVertices > U16_MAX)
-		throw std::invalid_argument("MeshCollector does not support more than 65536 vertices");
+		throw std::invalid_argument(
+				"Mesh can't contain more than 65536 vertices");
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
 	for (PreMeshBuffer &p : buffers)
 		if (p.layer == layer && p.vertices.size() + numVertices <= U16_MAX)

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -80,16 +80,13 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 }
 
 PreMeshBuffer &MeshCollector::findBuffer(const TileLayer& layer, u8 layernum,
-		u32 numIndices)
+		u32 numVertices)
 {
-	if (numIndices > 65535) {
-		errorstream << "FIXME: MeshCollector::append() called with numIndices="
-			<< numIndices << " (limit 65535)" << std::endl;
-		throw std::invalid_argument("MeshCollector does not support more than 65535 indices");
-	}
+	if (numVertices > U16_MAX)
+		throw std::invalid_argument("MeshCollector does not support more than 65536 vertices");
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
 	for (PreMeshBuffer &p : buffers)
-		if (p.layer == layer && p.indices.size() + numIndices <= 65535)
+		if (p.layer == layer && p.indices.size() + numIndices <= U16_MAX)
 			return p;
 	PreMeshBuffer pp;
 	pp.layer = layer;

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -1,0 +1,129 @@
+#include "collector.h"
+#include "log.h"
+#include "mesh.h"
+
+void MeshCollector::append(
+		const TileSpec &tile,
+		const video::S3DVertex *vertices, u32 numVertices,
+		const u16 *indices, u32 numIndices)
+{
+	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
+		const TileLayer *layer = &tile.layers[layernum];
+		if (layer->texture_id == 0)
+			continue;
+		append(*layer, vertices, numVertices, indices, numIndices,
+			layernum, tile.world_aligned);
+	}
+}
+
+void MeshCollector::append(
+		const TileLayer &layer,
+		const video::S3DVertex *vertices, u32 numVertices,
+		const u16 *indices, u32 numIndices,
+		u8 layernum, bool use_scale)
+{
+	if (numIndices > 65535) {
+		dstream << "FIXME: MeshCollector::append() called with numIndices="
+				<< numIndices << " (limit 65535)" << std::endl;
+		return;
+	}
+	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
+
+	PreMeshBuffer *p = NULL;
+	for (PreMeshBuffer &pp : *buffers) {
+		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
+			p = &pp;
+			break;
+		}
+	}
+
+	if (p == NULL) {
+		PreMeshBuffer pp;
+		pp.layer = layer;
+		buffers->push_back(pp);
+		p = &(*buffers)[buffers->size() - 1];
+	}
+
+	f32 scale = 1.0;
+	if (use_scale)
+		scale = 1.0 / layer.scale;
+
+	u32 vertex_count = p->vertices.size();
+	for (u32 i = 0; i < numVertices; i++) {
+		video::S3DVertex vert(vertices[i].Pos, vertices[i].Normal,
+				vertices[i].Color, scale * vertices[i].TCoords);
+		p->vertices.push_back(vert);
+	}
+
+	for (u32 i = 0; i < numIndices; i++) {
+		u32 j = indices[i] + vertex_count;
+		p->indices.push_back(j);
+	}
+}
+
+void MeshCollector::append(
+		const TileSpec &tile,
+		const video::S3DVertex *vertices, u32 numVertices,
+		const u16 *indices, u32 numIndices,
+		v3f pos, video::SColor c, u8 light_source)
+{
+	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
+		const TileLayer *layer = &tile.layers[layernum];
+		if (layer->texture_id == 0)
+			continue;
+		append(*layer, vertices, numVertices, indices, numIndices, pos,
+				c, light_source, layernum, tile.world_aligned);
+	}
+}
+
+void MeshCollector::append(
+		const TileLayer &layer,
+		const video::S3DVertex *vertices, u32 numVertices,
+		const u16 *indices, u32 numIndices,
+		v3f pos, video::SColor c, u8 light_source,
+		u8 layernum, bool use_scale)
+{
+	if (numIndices > 65535) {
+		dstream << "FIXME: MeshCollector::append() called with numIndices="
+				<< numIndices << " (limit 65535)" << std::endl;
+		return;
+	}
+	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
+
+	PreMeshBuffer *p = NULL;
+	for (PreMeshBuffer &pp : *buffers) {
+		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
+			p = &pp;
+			break;
+		}
+	}
+
+	if (p == NULL) {
+		PreMeshBuffer pp;
+		pp.layer = layer;
+		buffers->push_back(pp);
+		p = &(*buffers)[buffers->size() - 1];
+	}
+
+	f32 scale = 1.0;
+	if (use_scale)
+		scale = 1.0 / layer.scale;
+
+	video::SColor original_c = c;
+	u32 vertex_count = p->vertices.size();
+	for (u32 i = 0; i < numVertices; i++) {
+		if (!light_source) {
+			c = original_c;
+			applyFacesShading(c, vertices[i].Normal);
+		}
+		video::S3DVertex vert(vertices[i].Pos + pos, vertices[i].Normal, c,
+			scale * vertices[i].TCoords);
+		p->vertices.push_back(vert);
+	}
+
+	for (u32 i = 0; i < numIndices; i++) {
+		u32 j = indices[i] + vertex_count;
+		p->indices.push_back(j);
+	}
+}
+

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -21,9 +21,9 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 {
 	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
 
-	f32 scale = 1.0;
+	f32 scale = 1.0f;
 	if (use_scale)
-		scale = 1.0 / layer.scale;
+		scale = 1.0f / layer.scale;
 
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
@@ -57,9 +57,9 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 {
 	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
 
-	f32 scale = 1.0;
+	f32 scale = 1.0f;
 	if (use_scale)
-		scale = 1.0 / layer.scale;
+		scale = 1.0f / layer.scale;
 
 	video::SColor original_c = c;
 	u32 vertex_count = p.vertices.size();

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -2,29 +2,25 @@
 #include "log.h"
 #include "mesh.h"
 
-void MeshCollector::append(
-		const TileSpec &tile,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices)
+void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
+		u32 numVertices, const u16 *indices, u32 numIndices)
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
 		const TileLayer *layer = &tile.layers[layernum];
 		if (layer->texture_id == 0)
 			continue;
-		append(*layer, vertices, numVertices, indices, numIndices,
-			layernum, tile.world_aligned);
+		append(*layer, vertices, numVertices, indices, numIndices, layernum,
+				tile.world_aligned);
 	}
 }
 
-void MeshCollector::append(
-		const TileLayer &layer,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices,
-		u8 layernum, bool use_scale)
+void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
+		u32 numVertices, const u16 *indices, u32 numIndices, u8 layernum,
+		bool use_scale)
 {
 	if (numIndices > 65535) {
 		dstream << "FIXME: MeshCollector::append() called with numIndices="
-				<< numIndices << " (limit 65535)" << std::endl;
+			<< numIndices << " (limit 65535)" << std::endl;
 		return;
 	}
 	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
@@ -61,31 +57,26 @@ void MeshCollector::append(
 	}
 }
 
-void MeshCollector::append(
-		const TileSpec &tile,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source)
+void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
+		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
+		video::SColor c, u8 light_source)
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
 		const TileLayer *layer = &tile.layers[layernum];
 		if (layer->texture_id == 0)
 			continue;
-		append(*layer, vertices, numVertices, indices, numIndices, pos,
-				c, light_source, layernum, tile.world_aligned);
+		append(*layer, vertices, numVertices, indices, numIndices, pos, c,
+				light_source, layernum, tile.world_aligned);
 	}
 }
 
-void MeshCollector::append(
-		const TileLayer &layer,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source,
-		u8 layernum, bool use_scale)
+void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *vertices,
+		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
+		video::SColor c, u8 light_source, u8 layernum, bool use_scale)
 {
 	if (numIndices > 65535) {
 		dstream << "FIXME: MeshCollector::append() called with numIndices="
-				<< numIndices << " (limit 65535)" << std::endl;
+			<< numIndices << " (limit 65535)" << std::endl;
 		return;
 	}
 	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
@@ -117,7 +108,7 @@ void MeshCollector::append(
 			applyFacesShading(c, vertices[i].Normal);
 		}
 		video::S3DVertex vert(vertices[i].Pos + pos, vertices[i].Normal, c,
-			scale * vertices[i].TCoords);
+				scale * vertices[i].TCoords);
 		p->vertices.push_back(vert);
 	}
 
@@ -126,4 +117,3 @@ void MeshCollector::append(
 		p->indices.push_back(j);
 	}
 }
-

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -1,4 +1,5 @@
 #include "collector.h"
+#include <stdexcept>
 #include "log.h"
 #include "mesh.h"
 
@@ -18,42 +19,22 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		u32 numVertices, const u16 *indices, u32 numIndices, u8 layernum,
 		bool use_scale)
 {
-	if (numIndices > 65535) {
-		dstream << "FIXME: MeshCollector::append() called with numIndices="
-			<< numIndices << " (limit 65535)" << std::endl;
-		return;
-	}
-	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
-
-	PreMeshBuffer *p = NULL;
-	for (PreMeshBuffer &pp : *buffers) {
-		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
-			p = &pp;
-			break;
-		}
-	}
-
-	if (p == NULL) {
-		PreMeshBuffer pp;
-		pp.layer = layer;
-		buffers->push_back(pp);
-		p = &(*buffers)[buffers->size() - 1];
-	}
+	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
 
 	f32 scale = 1.0;
 	if (use_scale)
 		scale = 1.0 / layer.scale;
 
-	u32 vertex_count = p->vertices.size();
+	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
 		video::S3DVertex vert(vertices[i].Pos, vertices[i].Normal,
 				vertices[i].Color, scale * vertices[i].TCoords);
-		p->vertices.push_back(vert);
+		p.vertices.push_back(vert);
 	}
 
 	for (u32 i = 0; i < numIndices; i++) {
 		u32 j = indices[i] + vertex_count;
-		p->indices.push_back(j);
+		p.indices.push_back(j);
 	}
 }
 
@@ -74,34 +55,14 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
 		video::SColor c, u8 light_source, u8 layernum, bool use_scale)
 {
-	if (numIndices > 65535) {
-		dstream << "FIXME: MeshCollector::append() called with numIndices="
-			<< numIndices << " (limit 65535)" << std::endl;
-		return;
-	}
-	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
-
-	PreMeshBuffer *p = NULL;
-	for (PreMeshBuffer &pp : *buffers) {
-		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
-			p = &pp;
-			break;
-		}
-	}
-
-	if (p == NULL) {
-		PreMeshBuffer pp;
-		pp.layer = layer;
-		buffers->push_back(pp);
-		p = &(*buffers)[buffers->size() - 1];
-	}
+	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
 
 	f32 scale = 1.0;
 	if (use_scale)
 		scale = 1.0 / layer.scale;
 
 	video::SColor original_c = c;
-	u32 vertex_count = p->vertices.size();
+	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
 		if (!light_source) {
 			c = original_c;
@@ -109,11 +70,29 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		}
 		video::S3DVertex vert(vertices[i].Pos + pos, vertices[i].Normal, c,
 				scale * vertices[i].TCoords);
-		p->vertices.push_back(vert);
+		p.vertices.push_back(vert);
 	}
 
 	for (u32 i = 0; i < numIndices; i++) {
 		u32 j = indices[i] + vertex_count;
-		p->indices.push_back(j);
+		p.indices.push_back(j);
 	}
+}
+
+PreMeshBuffer &MeshCollector::findBuffer(const TileLayer& layer, u8 layernum,
+		u32 numIndices)
+{
+	if (numIndices > 65535) {
+		errorstream << "FIXME: MeshCollector::append() called with numIndices="
+			<< numIndices << " (limit 65535)" << std::endl;
+		throw std::invalid_argument("MeshCollector does not support more than 65535 indices");
+	}
+	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
+	for (PreMeshBuffer &p : buffers)
+		if (p.layer == layer && p.indices.size() + numIndices <= 65535)
+			return p;
+	PreMeshBuffer pp;
+	pp.layer = layer;
+	buffers.push_back(pp);
+	return buffers.back();
 }

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -19,7 +19,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		u32 numVertices, const u16 *indices, u32 numIndices, u8 layernum,
 		bool use_scale)
 {
-	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
+	PreMeshBuffer &p = findBuffer(layer, layernum, numVertices);
 
 	f32 scale = 1.0f;
 	if (use_scale)
@@ -51,7 +51,7 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		u32 numVertices, const u16 *indices, u32 numIndices, v3f pos,
 		video::SColor c, u8 light_source, u8 layernum, bool use_scale)
 {
-	PreMeshBuffer &p = findBuffer(layer, layernum, numIndices);
+	PreMeshBuffer &p = findBuffer(layer, layernum, numVertices);
 
 	f32 scale = 1.0f;
 	if (use_scale)

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -26,16 +26,12 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 		scale = 1.0f / layer.scale;
 
 	u32 vertex_count = p.vertices.size();
-	for (u32 i = 0; i < numVertices; i++) {
-		video::S3DVertex vert(vertices[i].Pos, vertices[i].Normal,
+	for (u32 i = 0; i < numVertices; i++)
+		p.vertices.emplace_back(vertices[i].Pos, vertices[i].Normal,
 				vertices[i].Color, scale * vertices[i].TCoords);
-		p.vertices.push_back(vert);
-	}
 
-	for (u32 i = 0; i < numIndices; i++) {
-		u32 j = indices[i] + vertex_count;
-		p.indices.push_back(j);
-	}
+	for (u32 i = 0; i < numIndices; i++)
+		p.indices.push_back(indices[i] + vertex_count);
 }
 
 void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertices,
@@ -61,22 +57,17 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 	if (use_scale)
 		scale = 1.0f / layer.scale;
 
-	video::SColor original_c = c;
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
-		if (!light_source) {
-			c = original_c;
-			applyFacesShading(c, vertices[i].Normal);
-		}
-		video::S3DVertex vert(vertices[i].Pos + pos, vertices[i].Normal, c,
-				scale * vertices[i].TCoords);
-		p.vertices.push_back(vert);
+		video::SColor color = c;
+		if (!light_source)
+			applyFacesShading(color, vertices[i].Normal);
+		p.vertices.emplace_back(vertices[i].Pos + pos, vertices[i].Normal,
+				color, scale * vertices[i].TCoords);
 	}
 
-	for (u32 i = 0; i < numIndices; i++) {
-		u32 j = indices[i] + vertex_count;
-		p.indices.push_back(j);
-	}
+	for (u32 i = 0; i < numIndices; i++)
+		p.indices.push_back(indices[i] + vertex_count);
 }
 
 PreMeshBuffer &MeshCollector::findBuffer(const TileLayer& layer, u8 layernum,
@@ -86,10 +77,8 @@ PreMeshBuffer &MeshCollector::findBuffer(const TileLayer& layer, u8 layernum,
 		throw std::invalid_argument("MeshCollector does not support more than 65536 vertices");
 	std::vector<PreMeshBuffer> &buffers = prebuffers[layernum];
 	for (PreMeshBuffer &p : buffers)
-		if (p.layer == layer && p.indices.size() + numIndices <= U16_MAX)
+		if (p.layer == layer && p.vertices.size() + numVertices <= U16_MAX)
 			return p;
-	PreMeshBuffer pp;
-	pp.layer = layer;
-	buffers.push_back(pp);
+	buffers.emplace_back(layer);
 	return buffers.back();
 }

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <array>
+#include <vector>
+#include "irrlichttypes.h"
+#include <S3DVertex.h>
+#include "client/tile.h"
+
+struct PreMeshBuffer
+{
+	TileLayer layer;
+	std::vector<u16> indices;
+	std::vector<video::S3DVertex> vertices;
+};
+
+struct MeshCollector
+{
+	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
+
+	void append(
+			const TileSpec &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices);
+	void append(
+			const TileSpec &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices,
+			v3f pos, video::SColor c, u8 light_source);
+
+private:
+	void append(
+			const TileLayer &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices,
+			u8 layernum, bool use_scale = false);
+	void append(
+			const TileLayer &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices,
+			v3f pos, video::SColor c, u8 light_source,
+			u8 layernum, bool use_scale = false);
+};

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -4,15 +4,16 @@
 #include "irrlichttypes.h"
 #include <S3DVertex.h>
 #include "client/tile.h"
+#include "client/tileref.h"
 
 struct PreMeshBuffer
 {
-	TileLayer layer;
+	LayerRef layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
 
 	PreMeshBuffer() = default;
-	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}
+	explicit PreMeshBuffer(const LayerRef &layer) : layer(layer) {}
 };
 
 struct MeshCollector
@@ -20,10 +21,10 @@ struct MeshCollector
 	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
 
 	// clang-format off
-	void append(const TileSpec &material,
+	void append(const TileRef &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);
-	void append(const TileSpec &material,
+	void append(const TileRef &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			v3f pos, video::SColor c, u8 light_source);
@@ -31,16 +32,14 @@ struct MeshCollector
 
 private:
 	// clang-format off
-	void append(const TileLayer &material,
+	void append(const LayerRef &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices);
+	void append(const LayerRef &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
-			u8 layernum, bool use_scale = false);
-	void append(const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source,
-			u8 layernum, bool use_scale = false);
+			v3f pos, video::SColor c, u8 light_source);
 	// clang-format on
 
-	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);
+	PreMeshBuffer &findBuffer(const LayerRef &layer, u32 numVertices);
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -40,5 +40,5 @@ private:
 	// clang-format on
 
 	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum,
-			u32 numIndices);
+			u32 numVertices);
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -16,26 +16,26 @@ struct MeshCollector
 {
 	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
 
-	void append(
-			const TileSpec &material,
+	// clang-format off
+	void append(const TileSpec &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices);
-	void append(
-			const TileSpec &material,
+	void append(const TileSpec &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			v3f pos, video::SColor c, u8 light_source);
+	// clang-format on
 
 private:
-	void append(
-			const TileLayer &material,
+	// clang-format off
+	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			u8 layernum, bool use_scale = false);
-	void append(
-			const TileLayer &material,
+	void append(const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
 			const u16 *indices, u32 numIndices,
 			v3f pos, video::SColor c, u8 light_source,
 			u8 layernum, bool use_scale = false);
+	// clang-format on
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -38,4 +38,7 @@ private:
 			v3f pos, video::SColor c, u8 light_source,
 			u8 layernum, bool use_scale = false);
 	// clang-format on
+
+	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum,
+			u32 numIndices);
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -42,6 +42,5 @@ private:
 			u8 layernum, bool use_scale = false);
 	// clang-format on
 
-	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum,
-			u32 numVertices);
+	PreMeshBuffer &findBuffer(const TileLayer &layer, u8 layernum, u32 numVertices);
 };

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -10,6 +10,9 @@ struct PreMeshBuffer
 	TileLayer layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
+
+	PreMeshBuffer() = default;
+	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}
 };
 
 struct MeshCollector

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -292,7 +292,7 @@ struct TileLayer
 	//! If true, the tile has its own color.
 	bool has_color = false;
 
-	std::shared_ptr<std::vector<FrameSpec>> frames = nullptr;
+	std::vector<FrameSpec> frames;
 
 	/*!
 	 * The color of the tile, or if the tile does not own
@@ -308,10 +308,7 @@ struct TileLayer
  */
 struct TileSpec
 {
-	TileSpec() {
-		for (auto &layer : layers)
-			layer = TileLayer();
-	}
+	TileSpec() = default;
 
 	/*!
 	 * Returns true if this tile can be merged with the other tile.

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -198,85 +198,12 @@ struct FrameSpec
 //! Defines a layer of a tile.
 struct TileLayer
 {
-	TileLayer() = default;
-
-	/*!
-	 * Two layers are equal if they can be merged.
-	 */
-	bool operator==(const TileLayer &other) const
-	{
-		return
-			texture_id == other.texture_id &&
-			material_type == other.material_type &&
-			material_flags == other.material_flags &&
-			color == other.color &&
-			scale == other.scale;
-	}
-
-	/*!
-	 * Two tiles are not equal if they must have different vertices.
-	 */
-	bool operator!=(const TileLayer &other) const
-	{
-		return !(*this == other);
-	}
-
-	// Sets everything else except the texture in the material
-	void applyMaterialOptions(video::SMaterial &material) const
-	{
-		switch (material_type) {
-		case TILE_MATERIAL_OPAQUE:
-		case TILE_MATERIAL_LIQUID_OPAQUE:
-			material.MaterialType = video::EMT_SOLID;
-			break;
-		case TILE_MATERIAL_BASIC:
-		case TILE_MATERIAL_WAVING_LEAVES:
-		case TILE_MATERIAL_WAVING_PLANTS:
-			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-			break;
-		case TILE_MATERIAL_ALPHA:
-		case TILE_MATERIAL_LIQUID_TRANSPARENT:
-			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-			break;
-		default:
-			break;
-		}
-		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-		}
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-		}
-	}
-
-	void applyMaterialOptionsWithShaders(video::SMaterial &material) const
-	{
-		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-			material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-		}
-		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-			material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-		}
-	}
-
-	bool isTileable() const
-	{
-		return (material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)
-			&& (material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL);
-	}
-
-	// Ordered for size, please do not reorder
-
+	std::vector<FrameSpec> frames;
 	video::ITexture *texture = nullptr;
 	video::ITexture *normal_texture = nullptr;
 	video::ITexture *flags_texture = nullptr;
 
 	u32 shader_id = 0;
-
 	u32 texture_id = 0;
 
 	u16 animation_frame_length_ms = 0;
@@ -292,8 +219,6 @@ struct TileLayer
 	//! If true, the tile has its own color.
 	bool has_color = false;
 
-	std::vector<FrameSpec> frames;
-
 	/*!
 	 * The color of the tile, or if the tile does not own
 	 * a color then the color of the node owning this tile.
@@ -308,31 +233,10 @@ struct TileLayer
  */
 struct TileSpec
 {
-	TileSpec() = default;
-
-	/*!
-	 * Returns true if this tile can be merged with the other tile.
-	 */
-	bool isTileable(const TileSpec &other) const {
-		for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
-			if (layers[layer] != other.layers[layer])
-				return false;
-			if (!layers[layer].isTileable())
-				return false;
-		}
-		return rotation == 0
-			&& rotation == other.rotation
-			&& emissive_light == other.emissive_light;
-	}
-
-	//! If true, the tile rotation is ignored.
-	bool world_aligned = false;
-	//! Tile rotation.
-	u8 rotation = 0;
-	//! This much light does the tile emit.
-	u8 emissive_light = 0;
 	//! The first is base texture, the second is overlay.
 	TileLayer layers[MAX_TILE_LAYERS];
+	//! If true, the tile rotation is ignored.
+	bool world_aligned = false;
 };
 
 const std::vector<std::string> &getTextureDirs();

--- a/src/client/tileref.h
+++ b/src/client/tileref.h
@@ -1,0 +1,117 @@
+#pragma once
+#include <cassert>
+#include "tile.h"
+
+struct LayerRef
+{
+	const TileSpec *tile = nullptr;
+	video::SColor color = video::SColor(0xFFFFFFFF);
+	u8 material_flags = 0;
+	u8 rotation = 0;
+	u8 emissive_light = 0;
+	u8 layer = 0;
+
+	LayerRef() = default;
+
+	LayerRef(const TileSpec *tile, int layer = 0) :
+		tile(tile),
+		layer(layer)
+	{
+	}
+
+	const TileLayer &get() const
+	{
+		return tile->layers[layer];
+	}
+
+	explicit operator bool() const
+	{
+		return bool(get().texture_id);
+	}
+
+	explicit operator TileLayer() const
+	{
+		TileLayer result = get();
+		result.color = color;
+		result.material_flags = material_flags;
+		return result;
+	}
+
+	const TileLayer *operator->() const
+	{
+		return &get();
+	}
+
+	bool operator==(const LayerRef &b) const
+	{
+		return get() == b.get();
+	}
+};
+
+struct TileRef
+{
+	const TileSpec *tile = nullptr;
+	video::SColor colors[MAX_TILE_LAYERS];
+	u8 material_flags[MAX_TILE_LAYERS];
+	u8 rotation = 0;
+	u8 emissive_light = 0;
+
+	TileRef() = default;
+
+	TileRef(const TileSpec *tile) :
+		tile(tile)
+	{
+		for (int k = 0; k < MAX_TILE_LAYERS; k++) {
+			const TileLayer &layer = tile->layers[k];
+			colors[k] = layer.color;
+			material_flags[k] = layer.material_flags;
+		}
+	}
+
+	TileRef(const TileSpec *tile, video::SColor color) :
+		tile(tile)
+	{
+		for (int k = 0; k < MAX_TILE_LAYERS; k++) {
+			const TileLayer &layer = tile->layers[k];
+			colors[k] = layer.has_color ? layer.color : color;
+			material_flags[k] = layer.material_flags;
+		}
+	}
+
+	void setMaterialFlags(u8 set_flags, u8 clear_flags = 0)
+	{
+		u8 mask = ~clear_flags;
+		for(u8 &mf : material_flags) {
+			mf |= set_flags;
+			mf &= mask;
+		}
+	}
+
+	LayerRef getLayer(int layer = 0) const
+	{
+		assert((layer >= 0) && (layer < MAX_TILE_LAYERS));
+		LayerRef ref;
+		ref.tile = tile;
+		ref.color = colors[layer];
+		ref.material_flags = material_flags[layer];
+		ref.rotation = rotation;
+		ref.emissive_light = emissive_light;
+		ref.layer = layer;
+		return ref;
+	}
+
+	bool isTileable(const TileRef &b) const
+	{
+		return false; // FIXME: stub
+	}
+
+	const TileSpec *operator->() const
+	{
+		return tile;
+	}
+
+	LayerRef operator[](int layer) const
+	{
+		return getLayer(layer);
+	}
+};

--- a/src/client/tileref.h
+++ b/src/client/tileref.h
@@ -44,7 +44,12 @@ struct LayerRef
 
 	bool operator==(const LayerRef &b) const
 	{
-		return get() == b.get();
+		return
+			material_flags == b.material_flags &&
+			color == b.color &&
+			get().texture_id == b->texture_id &&
+			get().material_type == b->material_type &&
+			get().scale == b->scale;
 	}
 };
 

--- a/src/client/tileref.h
+++ b/src/client/tileref.h
@@ -16,6 +16,46 @@ struct LayerRef
 		return tile->layers[layer];
 	}
 
+	// Sets everything else except the texture in the material
+	void applyMaterialOptions(video::SMaterial &material) const
+	{
+		switch (get().material_type) {
+		case TILE_MATERIAL_OPAQUE:
+		case TILE_MATERIAL_LIQUID_OPAQUE:
+			material.MaterialType = video::EMT_SOLID;
+			break;
+		case TILE_MATERIAL_BASIC:
+		case TILE_MATERIAL_WAVING_LEAVES:
+		case TILE_MATERIAL_WAVING_PLANTS:
+			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+			break;
+		case TILE_MATERIAL_ALPHA:
+		case TILE_MATERIAL_LIQUID_TRANSPARENT:
+			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+			break;
+		default:
+			break;
+		}
+		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL))
+			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL))
+			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+	}
+
+	void applyMaterialOptionsWithShaders(video::SMaterial &material) const
+	{
+		material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
+			material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+			material.TextureLayer[1].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
+		}
+		if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
+			material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+			material.TextureLayer[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+		}
+	}
+
 	bool isTileable() const
 	{
 		return (material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/tile.h"
 #include "mesh.h"
 #include <IMeshManipulator.h>
+#include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
 #include "client.h"
 #include "noise.h"

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include "client/tileref.h"
 #include "nodedef.h"
 #include <IMeshManipulator.h>
 
@@ -64,7 +65,7 @@ public:
 	LightPair light;
 	LightFrame frame;
 	video::SColor color;
-	TileSpec tile;
+	TileRef tile;
 	float scale;
 
 // lighting
@@ -75,25 +76,24 @@ public:
 
 	void useTile(int index = 0, u8 set_flags = MATERIAL_FLAG_CRACK_OVERLAY,
 		u8 reset_flags = 0, bool special = false);
-	void getTile(int index, TileSpec *tile);
-	void getTile(v3s16 direction, TileSpec *tile);
-	void getSpecialTile(int index, TileSpec *tile, bool apply_crack = false);
+	TileRef getTile(v3s16 direction);
+	TileRef getSpecialTile(int index);
 
 // face drawing
 	void drawQuad(v3f *vertices, const v3s16 &normal = v3s16(0, 0, 0),
 		float vertical_tiling = 1.0);
 
 // cuboid drawing!
-	void drawCuboid(const aabb3f &box, TileSpec *tiles, int tilecount,
+	void drawCuboid(const aabb3f &box, TileRef *tiles, int tilecount,
 		const LightPair *lights , const f32 *txc);
 	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
 	void drawAutoLightedCuboid(aabb3f box, const f32 *txc = NULL,
-		TileSpec *tiles = NULL, int tile_count = 0);
+		TileRef *tiles = NULL, int tile_count = 0);
 
 // liquid-specific
 	bool top_is_same_liquid;
-	TileSpec tile_liquid;
-	TileSpec tile_liquid_top;
+	TileRef tile_liquid;
+	TileRef tile_liquid_top;
 	content_t c_flowing;
 	content_t c_source;
 	video::SColor color_liquid_top;

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "minimap.h"
 #include "content_mapblock.h"
 #include "util/directiontables.h"
+#include "client/meshgen/collector.h"
 #include "client/renderingengine.h"
 #include <array>
 
@@ -1417,135 +1418,6 @@ void MapBlockMesh::updateCameraOffset(v3s16 camera_offset)
 				layer->setDirty();
 		}
 		m_camera_offset = camera_offset;
-	}
-}
-
-/*
-	MeshCollector
-*/
-
-void MeshCollector::append(const TileSpec &tile,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices)
-{
-	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
-		const TileLayer *layer = &tile.layers[layernum];
-		if (layer->texture_id == 0)
-			continue;
-		append(*layer, vertices, numVertices, indices, numIndices,
-			layernum, tile.world_aligned);
-	}
-}
-
-void MeshCollector::append(const TileLayer &layer,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices, u8 layernum,
-		bool use_scale)
-{
-	if (numIndices > 65535) {
-		dstream << "FIXME: MeshCollector::append() called with numIndices="
-				<< numIndices << " (limit 65535)" << std::endl;
-		return;
-	}
-	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
-
-	PreMeshBuffer *p = NULL;
-	for (PreMeshBuffer &pp : *buffers) {
-		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
-			p = &pp;
-			break;
-		}
-	}
-
-	if (p == NULL) {
-		PreMeshBuffer pp;
-		pp.layer = layer;
-		buffers->push_back(pp);
-		p = &(*buffers)[buffers->size() - 1];
-	}
-
-	f32 scale = 1.0;
-	if (use_scale)
-		scale = 1.0 / layer.scale;
-
-	u32 vertex_count = p->vertices.size();
-	for (u32 i = 0; i < numVertices; i++) {
-		video::S3DVertex vert(vertices[i].Pos, vertices[i].Normal,
-				vertices[i].Color, scale * vertices[i].TCoords);
-		p->vertices.push_back(vert);
-	}
-
-	for (u32 i = 0; i < numIndices; i++) {
-		u32 j = indices[i] + vertex_count;
-		p->indices.push_back(j);
-	}
-}
-
-/*
-	MeshCollector - for meshnodes and converted drawtypes.
-*/
-
-void MeshCollector::append(const TileSpec &tile,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source)
-{
-	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
-		const TileLayer *layer = &tile.layers[layernum];
-		if (layer->texture_id == 0)
-			continue;
-		append(*layer, vertices, numVertices, indices, numIndices, pos,
-				c, light_source, layernum, tile.world_aligned);
-	}
-}
-
-void MeshCollector::append(const TileLayer &layer,
-		const video::S3DVertex *vertices, u32 numVertices,
-		const u16 *indices, u32 numIndices,
-		v3f pos, video::SColor c, u8 light_source, u8 layernum,
-		bool use_scale)
-{
-	if (numIndices > 65535) {
-		dstream << "FIXME: MeshCollector::append() called with numIndices="
-				<< numIndices << " (limit 65535)" << std::endl;
-		return;
-	}
-	std::vector<PreMeshBuffer> *buffers = &prebuffers[layernum];
-
-	PreMeshBuffer *p = NULL;
-	for (PreMeshBuffer &pp : *buffers) {
-		if (pp.layer == layer && pp.indices.size() + numIndices <= 65535) {
-			p = &pp;
-			break;
-		}
-	}
-
-	if (p == NULL) {
-		PreMeshBuffer pp;
-		pp.layer = layer;
-		buffers->push_back(pp);
-		p = &(*buffers)[buffers->size() - 1];
-	}
-
-	f32 scale = 1.0;
-	if (use_scale)
-		scale = 1.0 / layer.scale;
-
-	video::SColor original_c = c;
-	u32 vertex_count = p->vertices.size();
-	for (u32 i = 0; i < numVertices; i++) {
-		if (!light_source) {
-			c = original_c;
-			applyFacesShading(c, vertices[i].Normal);
-		}
-		video::S3DVertex vert(vertices[i].Pos + pos, vertices[i].Normal, c,
-			scale * vertices[i].TCoords);
-		p->vertices.push_back(vert);
-	}
-
-	for (u32 i = 0; i < numIndices; i++) {
-		u32 j = indices[i] + vertex_count;
-		p->indices.push_back(j);
 	}
 }
 

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -1213,12 +1213,12 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			if (m_enable_shaders) {
 				material.MaterialType = m_shdrsrc->getShaderInfo(
 						p.layer->shader_id).material;
-				p.layer->applyMaterialOptionsWithShaders(material);
+				p.layer.applyMaterialOptionsWithShaders(material);
 				if (p.layer->normal_texture)
 					material.setTexture(1, p.layer->normal_texture);
 				material.setTexture(2, p.layer->flags_texture);
 			} else {
-				p.layer->applyMaterialOptions(material);
+				p.layer.applyMaterialOptions(material);
 			}
 
 			scene::SMesh *mesh = (scene::SMesh *)m_mesh[layer];

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "irrlichttypes_extrabloated.h"
 #include "client/tile.h"
+#include "client/tileref.h"
 #include "voxel.h"
 #include <array>
 #include <map>
@@ -223,5 +224,6 @@ void final_color_blend(video::SColor *result,
 // Adds MATERIAL_FLAG_CRACK if the node is cracked
 // TileSpec should be passed as reference due to the underlying TileFrame and its vector
 // TileFrame vector copy cost very much to client
-void getNodeTileN(MapNode mn, v3s16 p, u8 tileindex, MeshMakeData *data, TileSpec &tile);
-void getNodeTile(MapNode mn, v3s16 p, v3s16 dir, MeshMakeData *data, TileSpec &tile);
+TileRef getNodeTile(MapNode node, const ContentFeatures &f, u8 tileindex);
+TileRef getNodeTile(MapNode node, v3s16 p, u8 tileindex, MeshMakeData *data);
+TileRef getNodeTile(MapNode node, v3s16 p, v3s16 dir, MeshMakeData *data);

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -188,33 +188,29 @@ struct PreMeshBuffer
 struct MeshCollector
 {
 	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
-	bool m_use_tangent_vertices;
 
-	MeshCollector(bool use_tangent_vertices):
-		m_use_tangent_vertices(use_tangent_vertices)
-	{
-	}
+	void append(
+			const TileSpec &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices);
+	void append(
+			const TileSpec &material,
+			const video::S3DVertex *vertices, u32 numVertices,
+			const u16 *indices, u32 numIndices,
+			v3f pos, video::SColor c, u8 light_source);
 
-	void append(const TileSpec &material,
-				const video::S3DVertex *vertices, u32 numVertices,
-				const u16 *indices, u32 numIndices);
-	void append(const TileLayer &material,
+private:
+	void append(
+			const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices, u8 layernum,
-			bool use_scale = false);
-	void append(const TileSpec &material,
-				const video::S3DVertex *vertices, u32 numVertices,
-				const u16 *indices, u32 numIndices, v3f pos,
-				video::SColor c, u8 light_source);
-	void append(const TileLayer &material,
+			const u16 *indices, u32 numIndices,
+			u8 layernum, bool use_scale = false);
+	void append(
+			const TileLayer &material,
 			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices, v3f pos,
-			video::SColor c, u8 light_source, u8 layernum,
-			bool use_scale = false);
-	/*!
-	 * Colorizes all vertices in the collector.
-	 */
-	void applyTileColors();
+			const u16 *indices, u32 numIndices,
+			v3f pos, video::SColor c, u8 light_source,
+			u8 layernum, bool use_scale = false);
 };
 
 /*!

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -173,46 +173,6 @@ private:
 	v3s16 m_camera_offset;
 };
 
-
-
-/*
-	This is used because CMeshBuffer::append() is very slow
-*/
-struct PreMeshBuffer
-{
-	TileLayer layer;
-	std::vector<u16> indices;
-	std::vector<video::S3DVertex> vertices;
-};
-
-struct MeshCollector
-{
-	std::array<std::vector<PreMeshBuffer>, MAX_TILE_LAYERS> prebuffers;
-
-	void append(
-			const TileSpec &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices);
-	void append(
-			const TileSpec &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source);
-
-private:
-	void append(
-			const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			u8 layernum, bool use_scale = false);
-	void append(
-			const TileLayer &material,
-			const video::S3DVertex *vertices, u32 numVertices,
-			const u16 *indices, u32 numIndices,
-			v3f pos, video::SColor c, u8 light_source,
-			u8 layernum, bool use_scale = false);
-};
-
 /*!
  * Encodes light of a node.
  * The result is not the final color, but a

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -183,7 +183,6 @@ struct PreMeshBuffer
 	TileLayer layer;
 	std::vector<u16> indices;
 	std::vector<video::S3DVertex> vertices;
-	std::vector<video::S3DVertexTangents> tangent_vertices;
 };
 
 struct MeshCollector

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -58,11 +58,14 @@ MapNode::MapNode(INodeDefManager *ndef, const std::string &name,
 
 void MapNode::getColor(const ContentFeatures &f, video::SColor *color) const
 {
-	if (f.palette) {
-		*color = (*f.palette)[param2];
-		return;
-	}
-	*color = f.color;
+	*color = getColor(f);
+}
+
+video::SColor MapNode::getColor(const ContentFeatures &f) const
+{
+	if (f.palette)
+		return (*f.palette)[param2];
+	return f.color;
 }
 
 void MapNode::setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f)

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -190,6 +190,7 @@ struct MapNode
 	 * \param color output, contains the node's color.
 	 */
 	void getColor(const ContentFeatures &f, video::SColor *color) const;
+	video::SColor getColor(const ContentFeatures &f) const;
 
 	void setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f);
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -681,10 +681,7 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 		layer->material_flags &= ~MATERIAL_FLAG_ANIMATION;
 	} else {
 		std::ostringstream os(std::ios::binary);
-		if (!layer->frames) {
-			layer->frames = std::make_shared<std::vector<FrameSpec>>();
-		}
-		layer->frames->resize(frame_count);
+		layer->frames.resize(frame_count);
 
 		for (int i = 0; i < frame_count; i++) {
 
@@ -699,7 +696,7 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 			if (layer->normal_texture)
 				frame.normal_texture = tsrc->getNormalTexture(os.str());
 			frame.flags_texture = layer->flags_texture;
-			(*layer->frames)[i] = frame;
+			layer->frames[i] = frame;
 		}
 	}
 }

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -592,7 +592,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 
 	// Only use first frame of animated texture
 	if (tile.material_flags & MATERIAL_FLAG_ANIMATION)
-		texture = (*tile.frames)[0].texture;
+		texture = tile.frames[0].texture;
 	else
 		texture = tile.texture;
 

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -322,7 +322,7 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 				v.Color.setAlpha(255);
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
 			buf->Material.setTexture(0, texture);
-			p.layer->applyMaterialOptions(buf->Material);
+			p.layer.applyMaterialOptions(buf->Material);
 			mesh->addMeshBuffer(buf);
 			buf->append(&p.vertices[0], p.vertices.size(),
 					&p.indices[0], p.indices.size());
@@ -640,11 +640,11 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 		colors->push_back(ItemPartColor());
 
 	for (u32 i = 0; i < mc; ++i) {
-		const TileSpec *tile = &(f.tiles[i]);
+		TileRef tile = &f.tiles[i];
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 		for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
-			const TileLayer *layer = &tile->layers[layernum];
-			if (layer->texture_id == 0)
+			LayerRef layer = tile.getLayer(layernum);
+			if (!layer)
 				continue;
 			if (layernum != 0) {
 				scene::IMeshBuffer *copy = cloneMeshBuffer(buf);
@@ -653,13 +653,13 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				copy->drop();
 				buf = copy;
 				colors->push_back(
-					ItemPartColor(layer->has_color, layer->color));
+					ItemPartColor(layer->has_color, layer.color));
 			} else {
-				(*colors)[i] = ItemPartColor(layer->has_color, layer->color);
+				(*colors)[i] = ItemPartColor(layer->has_color, layer.color);
 			}
 			video::SMaterial &material = buf->getMaterial();
 			if (set_material)
-				layer->applyMaterialOptions(material);
+				layer.applyMaterialOptions(material);
 			if (mattype) {
 				material.MaterialType = *mattype;
 			}

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -304,7 +304,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<ItemPartColor> *colors)
 {
 	MeshMakeData mesh_make_data(client, false, false);
-	MeshCollector collector(false);
+	MeshCollector collector;
 	mesh_make_data.setSmoothLighting(false);
 	MapblockMeshGenerator gen(&mesh_make_data, &collector);
 	gen.renderSingle(id);

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mesh.h"
 #include "content_mapblock.h"
 #include "mapblock_mesh.h"
+#include "client/meshgen/collector.h"
 #include "client/tile.h"
 #include "log.h"
 #include "util/numeric.h"

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -313,22 +313,22 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 	scene::SMesh *mesh = new scene::SMesh();
 	for (auto &prebuffers : collector.prebuffers)
 		for (PreMeshBuffer &p : prebuffers) {
+			video::ITexture *texture = p.layer->texture;
 			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
-				const FrameSpec &frame = (*p.layer.frames)[0];
-				p.layer.texture = frame.texture;
-				p.layer.normal_texture = frame.normal_texture;
+				const FrameSpec &frame = p.layer->frames[0];
+				texture = frame.texture;
 			}
 			for (video::S3DVertex &v : p.vertices)
 				v.Color.setAlpha(255);
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
-			buf->Material.setTexture(0, p.layer.texture);
-			p.layer.applyMaterialOptions(buf->Material);
+			buf->Material.setTexture(0, texture);
+			p.layer->applyMaterialOptions(buf->Material);
 			mesh->addMeshBuffer(buf);
 			buf->append(&p.vertices[0], p.vertices.size(),
 					&p.indices[0], p.indices.size());
 			buf->drop();
 			colors->push_back(
-				ItemPartColor(p.layer.has_color, p.layer.color));
+				ItemPartColor(p.layer->has_color, p.layer.color));
 		}
 	return mesh;
 }
@@ -664,7 +664,7 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				material.MaterialType = *mattype;
 			}
 			if (layer->animation_frame_count > 1) {
-				const FrameSpec &animation_frame = (*layer->frames)[0];
+				const FrameSpec &animation_frame = layer->frames[0];
 				material.setTexture(0, animation_frame.texture);
 			} else {
 				material.setTexture(0, layer->texture);
@@ -672,7 +672,7 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 			if (use_shaders) {
 				if (layer->normal_texture) {
 					if (layer->animation_frame_count > 1) {
-						const FrameSpec &animation_frame = (*layer->frames)[0];
+						const FrameSpec &animation_frame = layer->frames[0];
 						material.setTexture(1, animation_frame.normal_texture);
 					} else
 						material.setTexture(1, layer->normal_texture);


### PR DESCRIPTION
Includes #6904.
Should improve meshgen performance: TileSpecs are used to be slow to copy. Should not affect GPU load at all.

*diff: https://github.com/minetest/minetest/pull/6930/files/46b36798ffaa00e505b77b7d33e79d268d3f00d3..c7e7f025970b3240fd7a22f14035d88e4ffe15c5*