### PR TITLE
Remove CSM screenshot API

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -765,8 +765,6 @@ Call these functions only at load time!
 * `minetest.disconnect()`
     * Disconnect from the server and exit to main menu.
     * Returns `false` if the client is already disconnecting otherwise returns `true`.
-* `minetest.take_screenshot()`
-    * Take a screenshot.
 * `minetest.get_server_info()`
     * Returns [server info](#server-info).
 * `minetest.send_respawn()`

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -330,13 +330,6 @@ int ModApiClient::l_get_node_def(lua_State *L)
 	return 1;
 }
 
-int ModApiClient::l_take_screenshot(lua_State *L)
-{
-	Client *client = getClient(L);
-	client->makeScreenshot();
-	return 0;
-}
-
 int ModApiClient::l_get_privilege_list(lua_State *L)
 {
 	const Client *client = getClient(L);
@@ -377,7 +370,6 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_server_info);
 	API_FCT(get_item_def);
 	API_FCT(get_node_def);
-	API_FCT(take_screenshot);
 	API_FCT(get_privilege_list);
 	API_FCT(get_builtin_path);
 	API_FCT(get_language);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -87,9 +87,6 @@ private:
 	// get_node_def(nodename)
 	static int l_get_node_def(lua_State *L);
 
-	// take_screenshot()
-	static int l_take_screenshot(lua_State *L);
-
 	// get_privilege_list()
 	static int l_get_privilege_list(lua_State *L);
 


### PR DESCRIPTION
Can be easily abused to fill all the free space on a players hard drive. Could possibly be re-added later with rate-limiting for use only by user approved mods, but right now this just makes implementing server provided mods needlessly complicated.