### PR TITLE
Fix issues with earlier CSM HUD commit

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -422,6 +422,11 @@ public:
 		return m_csm_noderange_limit;
 	}
 
+	inline std::unordered_map<u32, u32> &getHUDTranslationMap()
+	{
+		return m_hud_server_to_client;
+	}
+
 	bool joinModChannel(const std::string &channel);
 	bool leaveModChannel(const std::string &channel);
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -116,7 +116,7 @@ struct ClientEvent
 		} delete_particlespawner;
 		struct
 		{
-			u32 id;
+			u32 server_id;
 			u8 type;
 			v2f *pos;
 			std::string *name;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2562,12 +2562,12 @@ void Game::handleClientEvent_HandleParticleEvent(ClientEvent *event,
 void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	auto hud_server_to_client = client->getHUDTranslationMap();
 
-	u32 id = event->hudadd.id;
-
-	HudElement *e = player->getHud(id);
-
-	if (e != NULL) {
+	u32 server_id = event->hudadd.server_id;
+	// ignore if we already have a HUD with that ID
+	auto i = hud_server_to_client.find(server_id);
+	if (i != hud_server_to_client.end()) {
 		delete event->hudadd.pos;
 		delete event->hudadd.name;
 		delete event->hudadd.scale;
@@ -2579,7 +2579,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 		return;
 	}
 
-	e = new HudElement;
+	HudElement *e = new HudElement;
 	e->type   = (HudElementType)event->hudadd.type;
 	e->pos    = *event->hudadd.pos;
 	e->name   = *event->hudadd.name;
@@ -2592,10 +2592,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->offset = *event->hudadd.offset;
 	e->world_pos = *event->hudadd.world_pos;
 	e->size = *event->hudadd.size;
-
-	u32 new_id = player->addHud(e);
-	//if this isn't true our huds aren't consistent
-	sanity_check(new_id == id);
+	hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd.pos;
 	delete event->hudadd.name;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1052,12 +1052,10 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	try {
 		*pkt >> size;
 	} catch(SerializationError &e) {};
-	u32 client_id = getEnv().getLocalPlayer()->getFreeHudID();
-	m_hud_server_to_client[server_id] = client_id;
 
 	ClientEvent *event = new ClientEvent();
 	event->type             = CE_HUDADD;
-	event->hudadd.id        = client_id;
+	event->hudadd.server_id = server_id;
 	event->hudadd.type      = type;
 	event->hudadd.pos       = new v2f(pos);
 	event->hudadd.name      = new std::string(name);
@@ -1079,7 +1077,7 @@ void Client::handleCommand_HudRemove(NetworkPacket* pkt)
 
 	*pkt >> server_id;
 
-	std::unordered_map<u32, u32>::const_iterator i = m_hud_server_to_client.find(server_id);
+	auto i = m_hud_server_to_client.find(server_id);
 	if (i != m_hud_server_to_client.end()) {
 		int client_id = i->second;
 		m_hud_server_to_client.erase(i);


### PR DESCRIPTION
## Issue
It appears the issue was caused by events being queued together before being processed, this either didn't happen before (event refactor?) or it happened to a lesser degree and I somehow missed it while testing the PR.

## Fix
Move generating client IDs for HUD elements sent by the server to the event handler for HUD creation.

I think it fixes #6937 and also should fix #6968