### PR TITLE
[CSM] Don't Load the package library

### DIFF
--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -139,7 +139,6 @@ void ScriptApiBase::clientOpenLibs(lua_State *L)
 {
 	static const std::vector<std::pair<std::string, lua_CFunction>> m_libs = {
 		{ "", luaopen_base },
-		{ LUA_LOADLIBNAME, luaopen_package },
 		{ LUA_TABLIBNAME,  luaopen_table   },
 		{ LUA_OSLIBNAME,   luaopen_os      },
 		{ LUA_STRLIBNAME,  luaopen_string  },


### PR DESCRIPTION
Already removed by a latter step in CSM init so this just saves on pointless work.