### PR TITLE
Send server info for pause menu over network.

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -114,6 +114,14 @@ private:
 class ClientScripting;
 class GameUI;
 
+struct ServerInfo {
+	bool enable_damage;
+	bool creative_mode;
+	bool server_announce;
+	bool enable_pvp;
+	std::string server_name;
+};
+
 class Client : public con::PeerHandler, public InventoryManager, public IGameDef
 {
 public:
@@ -226,6 +234,7 @@ public:
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
 	void handleCommand_CSMFlavourLimits(NetworkPacket *pkt);
+	void handleCommand_ServerInfo(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -427,6 +436,8 @@ public:
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
 
+	const ServerInfo &getServerInfo() const { return m_server_info; }
+
 private:
 	void loadMods();
 	bool checkBuiltinIntegrity();
@@ -595,4 +606,6 @@ private:
 	u32 m_csm_noderange_limit = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
+
+	ServerInfo m_server_info;
 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4066,38 +4066,47 @@ void Game::showPauseMenu()
 		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
 		<< "\n"
 		<<  strgettext("Game info:") << "\n";
-	const std::string &address = client->getAddressName();
+	const ServerInfo &server_info = client->getServerInfo();
+
+	// cache strings we use a lot
 	static const std::string mode = strgettext("- Mode: ");
+	static const std::string on = strgettext("On");
+	static const std::string off = strgettext("Off");
+
+	const std::string &damage = server_info.enable_damage ? on : off;
+	const std::string &creative = server_info.creative_mode ? on : off;
+	const std::string &announced = server_info.server_announce ? on : off;
+	const std::string &pvp = server_info.enable_pvp ? on : off;
+
+	const std::string &address = client->getAddressName();
+	std::string server_name = server_info.server_name;
+	str_formspec_escape(server_name);
+
+	std::string connection_info;
 	if (!simple_singleplayer_mode) {
 		Address serverAddress = client->getServerAddress();
 		if (!address.empty()) {
-			os << mode << strgettext("Remote server") << "\n"
-					<< strgettext("- Address: ") << address;
+			os << mode << strgettext("Remote server") << "\n";
+			connection_info = strgettext("- Address: ") + address + "\n";
 		} else {
-			os << mode << strgettext("Hosting server");
+			os << mode << strgettext("Hosting server") << "\n";
 		}
-		os << "\n" << strgettext("- Port: ") << serverAddress.getPort() << "\n";
+		connection_info += strgettext("- Port: ") + std::to_string(serverAddress.getPort()) + "\n";
 	} else {
 		os << mode << strgettext("Singleplayer") << "\n";
 	}
-	if (simple_singleplayer_mode || address.empty()) {
-		static const std::string on = strgettext("On");
-		static const std::string off = strgettext("Off");
-		const std::string &damage = g_settings->getBool("enable_damage") ? on : off;
-		const std::string &creative = g_settings->getBool("creative_mode") ? on : off;
-		const std::string &announced = g_settings->getBool("server_announce") ? on : off;
-		os << strgettext("- Damage: ") << damage << "\n"
-				<< strgettext("- Creative Mode: ") << creative << "\n";
-		if (!simple_singleplayer_mode) {
-			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
-			os << strgettext("- PvP: ") << pvp << "\n"
-					<< strgettext("- Public: ") << announced << "\n";
-			std::string server_name = g_settings->get("server_name");
-			str_formspec_escape(server_name);
-			if (announced == on && !server_name.empty())
-				os << strgettext("- Server Name: ") << server_name;
 
-		}
+	// Server name doesn't make much sense for a server that isn't public
+	if (server_info.server_announce && !server_name.empty())
+		os << strgettext("- Server Name: ") << server_name << "\n";
+	os << connection_info << strgettext("- Creative Mode: ") << creative << "\n"
+		<< strgettext("- Damage: ") << damage << "\n";
+
+	// PvP don't make sense if there is only one player or damage is off
+	if (!simple_singleplayer_mode) {
+		if (server_info.enable_damage)
+			os << strgettext("- PvP: ") << pvp << "\n";
+		os << strgettext("- Public: ") << announced << "\n";
 	}
 	os << ";]";
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -41,7 +41,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler, // 0x0E
 	null_command_handler, // 0x0F
 	null_command_handler, // 0x10
-	null_command_handler,
+	{ "TOCLIENT_SERVER_INFO",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ServerInfo }, // 0x11
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1449,3 +1449,12 @@ void Client::handleCommand_ModChannelSignal(NetworkPacket *pkt)
 	if (valid_signal)
 		m_script->on_modchannel_signal(channel, signal);
 }
+
+void Client::handleCommand_ServerInfo(NetworkPacket *pkt)
+{
+	*pkt >> m_server_info.enable_damage
+		>> m_server_info.creative_mode
+		>> m_server_info.server_announce
+		>> m_server_info.enable_pvp
+		>> m_server_info.server_name;
+}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -253,6 +253,15 @@ enum ToClientCommand
 
 	TOCLIENT_INIT_LEGACY = 0x10, // Obsolete
 
+	TOCLIENT_SERVER_INFO = 0x11,
+	/*
+	 * u8 enable_damage
+	 * u8 creative_mode
+	 * u8 server_announce
+	 * u8 enable_pvp
+	 * std::string server_name
+	 */
+
 	TOCLIENT_BLOCKDATA = 0x20, //TODO: Multiple blocks
 	TOCLIENT_ADDNODE = 0x21,
 	/*

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -130,7 +130,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory, // 0x0E
 	null_command_factory, // 0x0F
 	{ "TOCLIENT_INIT",              0, true }, // 0x10
-	null_command_factory,
+	{ "TOCLIENT_SERVER_INFO",       0, true }, // 0x11
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,
@@ -200,8 +200,8 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_CLOUD_PARAMS",             0, true }, // 0x54
 	{ "TOCLIENT_FADE_SOUND",               0, true }, // 0x55
 	{ "TOCLIENT_UPDATE_PLAYER_LIST",       0, true }, // 0x56
-	{ "TOCLIENT_MODCHANNEL_MSG",           0, true}, // 0x57
-	{ "TOCLIENT_MODCHANNEL_SIGNAL",        0, true}, // 0x58
+	{ "TOCLIENT_MODCHANNEL_MSG",           0, true }, // 0x57
+	{ "TOCLIENT_MODCHANNEL_SIGNAL",        0, true }, // 0x58
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -394,6 +394,19 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	}
 	m_clients.send(peer_id, 0, &list_pkt, true);
 
+	NetworkPacket server_info(TOCLIENT_SERVER_INFO, 0, peer_id);
+
+	bool is_public = false;
+	if (!m_simple_singleplayer_mode)
+		is_public = g_settings->getBool("server_announce");
+
+	server_info << g_settings->getBool("enable_damage")
+		<< g_settings->getBool("creative_mode")
+		<< is_public
+		<< g_settings->getBool("enable_pvp")
+		<< g_settings->get("server_name");
+	m_clients.send(peer_id, 0, &server_info, true);
+
 	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
 	// (u16) 1 + std::string represents a pseudo vector serialization representation
 	notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(playersao->getPlayer()->getName());


### PR DESCRIPTION
This allows for more detailed information about remote servers to be displayed.
Before:
![screenshot from 2018-01-21 14-42-44](https://user-images.githubusercontent.com/12450071/35195542-09b761d8-febd-11e7-9237-dbedf38315ea.png)
After:
![screenshot from 2018-01-21 15-06-18](https://user-images.githubusercontent.com/12450071/35195547-172f61e4-febd-11e7-9a5f-e7ef2209061a.png)
