### PR TITLE
Add Android drivers to the video_driver drop-down menu

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -593,7 +593,7 @@ lighting_boost_spread (Light curve mid boost spread) float 0.2 0.0 1.0
 texture_path (Texture path) path
 
 #    The rendering back-end for Irrlicht.
-video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl
+video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.
 #    Values larger than 26 will start to produce sharp cutoffs at cloud area corners.


### PR DESCRIPTION
Adds the Android video drivers ogles1 and ogles2 to the video_drivers drop-down menu so Android users don't have to manually edit the minetest.conf