### PR TITLE
Check that Lua's v3f inputs are not NaN

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -28,7 +28,7 @@ extern "C" {
 #include "common/c_converter.h"
 #include "common/c_internal.h"
 #include "constants.h"
-
+#include <cmath>
 
 #define CHECK_TYPE(index, name, type) { \
 		int t = lua_type(L, (index)); \
@@ -39,15 +39,24 @@ extern "C" {
 				" got " + lua_typename(L, t) + ").\n" + traceback); \
 		} \
 	}
-#define CHECK_POS_COORD(name) CHECK_TYPE(-1, "position coordinate '" name "'", LUA_TNUMBER)
+
+#define CHECK_POS_COORD(var, name) \
+ 	do { \
+		CHECK_TYPE(-1, "position coordinate '" name "'", LUA_TNUMBER); \
+		var = lua_tonumber(L, -1); \
+		if (std::isnan(var)) \
+			throw LuaError("NaN passed as " name " coordinate."); \
+	} while (0)
+
 #define CHECK_FLOAT_RANGE(value, name) \
-if (value < F1000_MIN || value > F1000_MAX) { \
-	std::ostringstream error_text; \
-	error_text << "Invalid float vector dimension range '" name "' " << \
-	"(expected " << F1000_MIN << " < " name " < " << F1000_MAX << \
-	" got " << value << ")." << std::endl; \
-	throw LuaError(error_text.str()); \
-}
+	if (value < F1000_MIN || value > F1000_MAX) { \
+		std::ostringstream error_text; \
+		error_text << "Invalid float vector dimension range '" name "' " << \
+		"(expected " << F1000_MIN << " < " name " < " << F1000_MAX << \
+		" got " << value << ")." << std::endl; \
+		throw LuaError(error_text.str()); \
+	}
+
 #define CHECK_POS_TAB(index) CHECK_TYPE(index, "position", LUA_TTABLE)
 
 
@@ -118,12 +127,10 @@ v2s16 check_v2s16(lua_State *L, int index)
 	v2s16 p;
 	CHECK_POS_TAB(index);
 	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
-	p.X = lua_tonumber(L, -1);
+	CHECK_POS_COORD(p.X, "x");
 	lua_pop(L, 1);
 	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
-	p.Y = lua_tonumber(L, -1);
+	CHECK_POS_COORD(p.Y, "y");
 	lua_pop(L, 1);
 	return p;
 }
@@ -177,12 +184,10 @@ v2f check_v2f(lua_State *L, int index)
 	v2f p;
 	CHECK_POS_TAB(index);
 	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
-	p.X = lua_tonumber(L, -1);
+	CHECK_POS_COORD(p.X, "x");
 	lua_pop(L, 1);
 	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
-	p.Y = lua_tonumber(L, -1);
+	CHECK_POS_COORD(p.Y, "y");
 	lua_pop(L, 1);
 	return p;
 }
@@ -208,17 +213,17 @@ v3f check_v3f(lua_State *L, int index)
 	v3f pos;
 	CHECK_POS_TAB(index);
 	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
+	CHECK_POS_COORD(pos.X, "x");
 	pos.X = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.X, "x")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
+	CHECK_POS_COORD(pos.Y, "y");
 	pos.Y = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.Y, "y")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "z");
-	CHECK_POS_COORD("z");
+	CHECK_POS_COORD(pos.Z, "z");
 	pos.Z = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.Z, "z")
 	lua_pop(L, 1);
@@ -246,17 +251,17 @@ v3d check_v3d(lua_State *L, int index)
 	v3d pos;
 	CHECK_POS_TAB(index);
 	lua_getfield(L, index, "x");
-	CHECK_POS_COORD("x");
+	CHECK_POS_COORD(pos.X, "x");
 	pos.X = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.X, "x")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "y");
-	CHECK_POS_COORD("y");
+	CHECK_POS_COORD(pos.Y, "y");
 	pos.Y = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.Y, "y")
 	lua_pop(L, 1);
 	lua_getfield(L, index, "z");
-	CHECK_POS_COORD("z");
+	CHECK_POS_COORD(pos.Z, "z");
 	pos.Z = lua_tonumber(L, -1);
 	CHECK_FLOAT_RANGE(pos.Z, "z")
 	lua_pop(L, 1);


### PR DESCRIPTION
Without this change, a mod can crash the server in a hard-to-debug way when NaN
is caught at serialization time, losing information about who actually supplied
the erroneous value.