### PR TITLE
Main menu: Change tabs to 'Start Game' and 'Join Game'

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -310,7 +310,7 @@ end
 --------------------------------------------------------------------------------
 return {
 	name = "local",
-	caption = fgettext("Local Game"),
+	caption = fgettext("Start Game"),
 	cbf_formspec = get_formspec,
 	cbf_button_handler = main_button_handler,
 	on_change = on_change

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -344,7 +344,7 @@ end
 --------------------------------------------------------------------------------
 return {
 	name = "online",
-	caption = fgettext("Play Online"),
+	caption = fgettext("Join Game"),
 	cbf_formspec = get_formspec,
 	cbf_button_handler = main_button_handler,
 	on_change = on_change


### PR DESCRIPTION
![screenshot from 2018-01-23 15-13-17](https://user-images.githubusercontent.com/3686677/35283374-fd38e44c-004f-11e8-9394-32351192e14b.png)

Attends to #5982 using suggeston by @rubenwardy https://github.com/minetest/minetest/issues/5982#issuecomment-344764057
All other code including tab 'name's are left unchanged, best we separate the 'name' from the actual text used as it may change again later.