### PR TITLE
Include alpha channel reference in MaterialTypeParam

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -232,6 +232,7 @@ struct TileLayer
 		case TILE_MATERIAL_BASIC:
 		case TILE_MATERIAL_WAVING_LEAVES:
 		case TILE_MATERIAL_WAVING_PLANTS:
+			material.MaterialTypeParam = 0.5;
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 			break;
 		case TILE_MATERIAL_ALPHA:


### PR DESCRIPTION
Fixes #5600

For ogles2, irrlicht has replaced the missing fixed-pipline alpha-test with a builtin shader, however, by default it renders fully opaque without a specified reference.

This PR includes the alpha reference in the free parameter `MaterialTypeParam` which is used by the transparency shader or otherwise simply ignored.

Thanks to @numberZero for pointing this out :)