### PR TITLE
Make settings files per-world.

### DIFF
--- a/builtin/fstk/dialog.lua
+++ b/builtin/fstk/dialog.lua
@@ -30,7 +30,7 @@ end
 local dialog_metatable = {
 	eventhandler = dialog_event_handler,
 	get_formspec = function(self)
-				if not self.hidden then return self.formspec(self.data) end
+				if not self.hidden then return self.formspec(self.data, self.name, self) end
 			end,
 	handle_buttons = function(self,fields)
 				if not self.hidden then return self.buttonhandler(self,fields) end

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -327,16 +327,14 @@ end
 
 function get_world_setting(selected, setting)
 	local world_conf = get_world_config(selected)
-	if not world_conf then
-		world_conf = core.settings
-	end
-
-	return world_conf:get(setting) or core.settings:get(setting)
+	return (world_conf and world_conf:get(setting)) or core.settings:get(setting)
 end
 
 function set_world_setting(selected, setting, value)
 	local world_conf = get_world_config(selected)
-	if not world_conf or not value then return end
+	if not world_conf or not value then
+		return
+	end
 
 	world_conf:set(setting, value)
 	if not world_conf:write() then

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -315,34 +315,31 @@ function is_server_protocol_compat_or_error(server_proto_min, server_proto_max)
 	return true
 end
 --------------------------------------------------------------------------------
-function menu_worldmt(selected, setting, value)
+function get_world_config(selected)
 	local world = menudata.worldlist:get_list()[selected]
 	if world then
 		local filename = world.path .. DIR_DELIM .. "world.mt"
-		local world_conf = Settings(filename)
-
-		if value then
-			if not world_conf:write() then
-				core.log("error", "Failed to write world config file")
-			end
-			world_conf:set(setting, value)
-			world_conf:write()
-		else
-			return world_conf:get(setting)
-		end
+		return Settings(filename)
 	else
 		return nil
 	end
 end
 
-function menu_worldmt_legacy(selected)
-	local modes_names = {"creative_mode", "enable_damage", "server_announce"}
-	for _, mode_name in pairs(modes_names) do
-		local mode_val = menu_worldmt(selected, mode_name)
-		if mode_val then
-			core.settings:set(mode_name, mode_val)
-		else
-			menu_worldmt(selected, mode_name, core.settings:get(mode_name))
-		end
+function get_world_setting(selected, setting)
+	local world_conf = get_world_config(selected)
+	if not world_conf then
+		world_conf = core.settings
+	end
+
+	return world_conf:get(setting) or core.settings:get(setting)
+end
+
+function set_world_setting(selected, setting, value)
+	local world_conf = get_world_config(selected)
+	if not world_conf or not value then return end
+
+	world_conf:set(setting, value)
+	if not world_conf:write() then
+		core.log("error", "Failed to write world config file")
 	end
 end

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -928,8 +928,16 @@ local function create_settings_formspec(tabdata)
 	if #settings > 0 then
 		formspec = formspec:sub(1, -2) -- remove trailing comma
 	end
+	
+	local exit_buttom_text
+	if tabdata.is_world then
+		exit_buttom_text = fgettext("< Back to Start Game")
+	else
+		exit_buttom_text = fgettext("< Back to Settings page")
+	end
+	
 	formspec = formspec .. ";" .. selected_setting .. "]" ..
-			"button[0,6;4,1;btn_back;".. fgettext("< Back to Settings page") .. "]" ..
+			"button[0,6;4,1;btn_back;".. exit_buttom_text .. "]" ..
 			"button[10,6;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
 			"button[7,6;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
 			"checkbox[0,5.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
@@ -1042,6 +1050,7 @@ function create_adv_settings_dlg()
 		handle_settings_buttons,
 		nil)
 	dlg.data.settings = core.settings
+	dlg.data.is_world = false
 	return dlg
 end
 
@@ -1053,6 +1062,7 @@ function create_world_settings_dlg()
 
 	local server_settings = filter_world_settings()
 	settings, selected_setting = filter_settings(server_settings, search_string)
+	dlg.data.is_world = true
 	return dlg
 end
 

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -860,15 +860,14 @@ local function handle_change_setting_buttons(this, fields)
 end
 
 local function filter_world_settings()
-	local current_level = 0
 	local settings = {}
 	local ignore_top_level_category = false
 	local world_settings_categories = {"Server / Singleplayer", "Client and Server", "Games", "Mods"}
 	for _, entry in ipairs(full_settings) do
 		if entry.type == "category" and entry.level == 0 then
 			ignore_top_level_category = true
-			for _, allowed_catergory in ipairs(world_settings_categories) do
-				if entry.name == allowed_catergory then
+			for _, allowed_category in ipairs(world_settings_categories) do
+				if entry.name == allowed_category then
 					ignore_top_level_category = false
 				end
 			end
@@ -1018,7 +1017,7 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		if setting and setting.type ~= "category" then
 			if setting.type == "noise_params_2d"
 					or setting.type == "noise_params_3d" then
-			conf:set(setting.name, setting.default)
+				conf:set_np_group(setting.name, setting.default_table)
 			else
 				conf:set(setting.name, setting.default)
 			end

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -863,7 +863,7 @@ local function filter_world_settings()
 	local current_level = 0
 	local settings = {}
 	local ignore_top_level_category = false
-	local world_settings_categories = {"Server / Singleplayer", "Client and Server", "Mapgen", "Games", "Mods"}
+	local world_settings_categories = {"Server / Singleplayer", "Client and Server", "Games", "Mods"}
 	for _, entry in ipairs(full_settings) do
 		if entry.type == "category" and entry.level == 0 then
 			ignore_top_level_category = true

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -228,7 +228,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		end
 	end
 
-	if fields["world_create"] ~= nil then
+	if fields["world_create"] then
 		local create_world_dlg = create_create_world_dlg(true)
 		create_world_dlg:set_parent(this)
 		this:hide()
@@ -237,7 +237,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		return true
 	end
 
-	if fields["world_delete"] ~= nil then
+	if fields["world_delete"] then
 		local selected = core.get_textlist_index("sp_worlds")
 		if selected ~= nil and
 			selected <= menudata.worldlist:size() then
@@ -257,7 +257,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		return true
 	end
 
-	if fields["world_configure"] ~= nil then
+	if fields["world_configure"] then
 		local selected = core.get_textlist_index("sp_worlds")
 		if selected ~= nil then
 			local configdialog =
@@ -275,7 +275,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		return true
 	end
 	
-	if fields["world_settings"] ~= nil then
+	if fields["world_settings"] then
 		local selected = core.get_textlist_index("sp_worlds")
 		if not selected then
 			return true

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -277,6 +277,10 @@ local function main_button_handler(this, fields, name, tabdata)
 	
 	if fields["world_settings"] ~= nil then
 		local selected = core.get_textlist_index("sp_worlds")
+		if not selected then
+			return true
+		end
+
 		local adv_settings_dlg = create_world_settings_dlg()
 		adv_settings_dlg.data.settings = get_world_config(selected)
 		adv_settings_dlg:set_parent(this)

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -48,7 +48,6 @@ local function singleplayer_refresh_gamebar()
 							index = #menudata.worldlist:get_list()
 						end
 					end
-					menu_worldmt_legacy(index)
 					return true
 				end
 			end
@@ -95,12 +94,13 @@ local function get_formspec(tabview, name, tabdata)
 	retval = retval ..
 			"button[4,3.95;2.6,1;world_delete;".. fgettext("Delete") .. "]" ..
 			"button[6.5,3.95.15;2.8,1;world_create;".. fgettext("New") .. "]" ..
-			"button[9.2,3.95;2.5,1;world_configure;".. fgettext("Configure") .. "]" ..
+			"button[9.2,3.95;2.5,1;world_configure;".. fgettext("Configure Mods") .. "]" ..
+			"button[4,5;2.6,0.5;world_settings;".. fgettext("World Settings") .. "]" ..
 			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
 			"checkbox[0.25,0.25;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
-			dump(core.settings:get_bool("creative_mode")) .. "]"..
+			get_world_setting(index, "creative_mode") .. "]"..
 			"checkbox[0.25,0.7;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
-			dump(core.settings:get_bool("enable_damage")) .. "]"..
+			get_world_setting(index, "enable_damage") .. "]"..
 			"checkbox[0.25,1.15;cb_server;".. fgettext("Host Server") ..";" ..
 			dump(core.settings:get_bool("enable_server")) .. "]" ..
 			"textlist[4,0.25;7.5,3.7;sp_worlds;" ..
@@ -111,23 +111,23 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval ..
 				"button[8.5,4.8;3.2,1;play;".. fgettext("Host Game") .. "]" ..
 				"checkbox[0.25,1.6;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
-				dump(core.settings:get_bool("server_announce")) .. "]" ..
+				get_world_setting(index, "server_announce") .. "]" ..
 				"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
 				"field[0.55,3.2;3.5,0.5;te_playername;;" ..
-				core.formspec_escape(core.settings:get("name")) .. "]" ..
+				core.formspec_escape(get_world_setting(index, "name")) .. "]" ..
 				"pwdfield[0.55,4;3.5,0.5;te_passwd;]"
 
-		local bind_addr = core.settings:get("bind_address")
+		local bind_addr = get_world_setting(index, "bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
 				"field[0.55,5.2;2.25,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
-				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
+				core.formspec_escape(get_world_setting(index, "bind_address")) .. "]" ..
 				"field[2.8,5.2;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				core.formspec_escape(get_world_setting(index, "port")) .. "]"
 		else
 			retval = retval ..
 				"field[0.55,5.2;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				core.formspec_escape(get_world_setting(index, "port")) .. "]"
 		end
 	else
 		retval = retval ..
@@ -147,8 +147,6 @@ local function main_button_handler(this, fields, name, tabdata)
 		local event = core.explode_textlist_event(fields["sp_worlds"])
 		local selected = core.get_textlist_index("sp_worlds")
 
-		menu_worldmt_legacy(selected)
-
 		if event.type == "DCL" then
 			world_doubleclick = true
 		end
@@ -165,17 +163,15 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["cb_creative_mode"] then
-		core.settings:set("creative_mode", fields["cb_creative_mode"])
 		local selected = core.get_textlist_index("sp_worlds")
-		menu_worldmt(selected, "creative_mode", fields["cb_creative_mode"])
+		set_world_setting(selected, "creative_mode", fields["cb_creative_mode"])
 
 		return true
 	end
 
 	if fields["cb_enable_damage"] then
-		core.settings:set("enable_damage", fields["cb_enable_damage"])
 		local selected = core.get_textlist_index("sp_worlds")
-		menu_worldmt(selected, "enable_damage", fields["cb_enable_damage"])
+		set_world_setting(selected, "enable_damage", fields["cb_enable_damage"])
 
 		return true
 	end
@@ -187,9 +183,8 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["cb_server_announce"] then
-		core.settings:set("server_announce", fields["cb_server_announce"])
-		local selected = core.get_textlist_index("srv_worlds")
-		menu_worldmt(selected, "server_announce", fields["cb_server_announce"])
+		local selected = core.get_textlist_index("sp_worlds")
+		set_world_setting(selected, "server_announce", fields["cb_server_announce"])
 
 		return true
 	end
@@ -200,15 +195,14 @@ local function main_button_handler(this, fields, name, tabdata)
 
 		if core.settings:get_bool("enable_server") then
 			if selected ~= nil and gamedata.selected_world ~= 0 then
-				gamedata.playername     = fields["te_playername"]
-				gamedata.password       = fields["te_passwd"]
-				gamedata.port           = fields["te_serverport"]
+				set_world_setting(selected,   "name",          fields.te_playername)
+				set_world_setting(selected,   "port",          fields.te_serverport)
+				set_world_setting(selected,   "bind_address",  fields.te_serveraddr)
+				
+				gamedata.playername     = fields.te_playername
+				gamedata.port           = fields.te_serverport
+				gamedata.password       = fields.te_passwd
 				gamedata.address        = ""
-
-				core.settings:set("port",gamedata.port)
-				if fields["te_serveraddr"] ~= nil then
-					core.settings:set("bind_address",fields["te_serveraddr"])
-				end
 
 				--update last game
 				local world = menudata.worldlist:get_raw_element(gamedata.selected_world)
@@ -278,6 +272,17 @@ local function main_button_handler(this, fields, name, tabdata)
 			end
 		end
 
+		return true
+	end
+	
+	if fields["world_settings"] ~= nil then
+		local selected = core.get_textlist_index("sp_worlds")
+		local adv_settings_dlg = create_world_settings_dlg()
+		adv_settings_dlg.data.settings = get_world_config(selected)
+		adv_settings_dlg:set_parent(this)
+		this:hide()
+		adv_settings_dlg:show()
+		
 		return true
 	end
 end

--- a/doc/fst_api.txt
+++ b/doc/fst_api.txt
@@ -95,7 +95,7 @@ dialog_create(name, cbf_formspec, cbf_button_handler, cbf_events)
 ^ create a dialog component
 ^ name: name of component (unique per ui)
 ^ cbf_formspec: function to be called to get formspec
-	function(dialogdata)
+	function(dialogdata, name, dialog)
 ^ cbf_button_handler: function to handle buttons
 	function(dialog, fields)
 ^ cbf_events: function to handle events

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -546,8 +546,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 void Camera::updateViewingRange()
 {
-	f32 viewing_range = g_settings->getFloat("viewing_range");
-	f32 near_plane = g_settings->getFloat("near_plane");
+	f32 viewing_range = g_main_settings->getFloat("viewing_range");
+	f32 near_plane = g_main_settings->getFloat("near_plane");
 
 	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 4000);
 	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -104,12 +104,12 @@ Client::Client(
 	// Add local player
 	m_env.setLocalPlayer(new LocalPlayer(this, playername));
 
-	if (g_settings->getBool("enable_minimap")) {
+	if (g_main_settings->getBool("enable_minimap")) {
 		m_minimap = new Minimap(this);
 	}
-	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
+	m_cache_save_interval = g_main_settings->getU16("server_map_save_interval");
 
-	m_modding_enabled = g_settings->getBool("enable_client_modding");
+	m_modding_enabled = g_main_settings->getBool("enable_client_modding");
 	m_script = new ClientScripting(this);
 	m_env.setScript(m_script);
 	m_script->setEnv(&m_env);
@@ -352,8 +352,8 @@ void Client::step(float dtime)
 		ScopeProfiler sp(g_profiler, "Client: map timer and unload");
 		std::vector<v3s16> deleted_blocks;
 		m_env.getMap().timerUpdate(map_timer_and_unload_dtime,
-			g_settings->getFloat("client_unload_unused_data_timeout"),
-			g_settings->getS32("client_mapblock_limit"),
+			g_main_settings->getFloat("client_unload_unused_data_timeout"),
+			g_main_settings->getS32("client_mapblock_limit"),
 			&deleted_blocks);
 
 		/*
@@ -585,7 +585,7 @@ void Client::step(float dtime)
 	m_mod_storage_save_timer -= dtime;
 	if (m_mod_storage_save_timer <= 0.0f) {
 		verbosestream << "Saving registered mod storages." << std::endl;
-		m_mod_storage_save_timer = g_settings->getFloat("server_map_save_interval");
+		m_mod_storage_save_timer = g_main_settings->getFloat("server_map_save_interval");
 		for (std::unordered_map<std::string, ModMetadata *>::const_iterator
 				it = m_mod_storages.begin(); it != m_mod_storages.end(); ++it) {
 			if (it->second->isModified()) {
@@ -741,7 +741,7 @@ void Client::initLocalMapSaving(const Address &address,
 		const std::string &hostname,
 		bool is_local_server)
 {
-	if (!g_settings->getBool("enable_local_map_saving") || is_local_server) {
+	if (!g_main_settings->getBool("enable_local_map_saving") || is_local_server) {
 		return;
 	}
 
@@ -1147,7 +1147,7 @@ bool Client::canSendChatMessage() const
 
 void Client::sendChatMessage(const std::wstring &message)
 {
-	const s16 max_queue_size = g_settings->getS16("max_out_chat_queue_size");
+	const s16 max_queue_size = g_main_settings->getS16("max_out_chat_queue_size");
 	if (canSendChatMessage()) {
 		u32 now = time(NULL);
 		float time_passed = now - m_last_chat_message_sent;
@@ -1696,7 +1696,7 @@ void Client::afterContentReceived()
 	m_state = LC_Ready;
 	sendReady();
 
-	if (g_settings->getBool("enable_client_modding")) {
+	if (g_main_settings->getBool("enable_client_modding")) {
 		m_script->on_client_ready(m_env.getLocalPlayer());
 	}
 
@@ -1731,14 +1731,14 @@ void Client::makeScreenshot()
 	char timetstamp_c[64];
 	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", tm);
 
-	std::string filename_base = g_settings->get("screenshot_path")
+	std::string filename_base = g_main_settings->get("screenshot_path")
 			+ DIR_DELIM
 			+ std::string("screenshot_")
 			+ std::string(timetstamp_c);
-	std::string filename_ext = "." + g_settings->get("screenshot_format");
+	std::string filename_ext = "." + g_main_settings->get("screenshot_format");
 	std::string filename;
 
-	u32 quality = (u32)g_settings->getS32("screenshot_quality");
+	u32 quality = (u32)g_main_settings->getS32("screenshot_quality");
 	quality = MYMIN(MYMAX(quality, 0), 100) / 100.0 * 255;
 
 	// Try to find a unique filename

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -619,10 +619,9 @@ u64 RemoteClient::uptime() const
 	return porting::getTimeS() - m_connection_time;
 }
 
-ClientInterface::ClientInterface(const std::shared_ptr<con::Connection> & con)
+ClientInterface::ClientInterface()
 :
-	m_con(con),
-	m_env(NULL),
+	m_env(nullptr),
 	m_print_info_timer(0.0f)
 {
 

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -422,8 +422,10 @@ public:
 
 	friend class Server;
 
-	ClientInterface(const std::shared_ptr<con::Connection> &con);
+	ClientInterface();
 	~ClientInterface();
+
+	void SetConnection(const std::shared_ptr<con::Connection> &con) { m_con = con; }
 
 	/* run sync step */
 	void step(float dtime);

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -261,16 +261,13 @@ void ModConfiguration::addMods(const std::vector<ModSpec> &new_mods)
 	}
 }
 
-void ModConfiguration::addModsFromConfig(
-		const std::string &settings_path, const std::set<std::string> &mods)
+void ModConfiguration::addModsFromConfig(Settings *conf, const std::set<std::string> &mods)
 {
-	Settings conf;
 	std::set<std::string> load_mod_names;
 
-	conf.readConfigFile(settings_path.c_str());
-	std::vector<std::string> names = conf.getNames();
+	std::vector<std::string> names = conf->getNames();
 	for (const std::string &name : names) {
-		if (name.compare(0, 9, "load_mod_") == 0 && conf.getBool(name))
+		if (name.compare(0, 9, "load_mod_") == 0 && conf->getBool(name))
 			load_mod_names.insert(name.substr(9));
 	}
 
@@ -283,10 +280,9 @@ void ModConfiguration::addModsFromConfig(
 			if (load_mod_names.count(mod.name) != 0)
 				addon_mods.push_back(mod);
 			else
-				conf.setBool("load_mod_" + mod.name, false);
+				conf->setBool("load_mod_" + mod.name, false);
 		}
 	}
-	conf.updateConfigFile(settings_path.c_str());
 
 	addMods(addon_mods);
 	checkConflictsAndDeps();
@@ -380,13 +376,19 @@ void ModConfiguration::resolveDependencies()
 ClientModConfiguration::ClientModConfiguration(const std::string &path) :
 		ModConfiguration(path)
 {
+	Settings conf;
 	std::set<std::string> paths;
+
 	std::string path_user = porting::path_user + DIR_DELIM + "clientmods";
 	paths.insert(path);
 	paths.insert(path_user);
 
 	std::string settings_path = path_user + DIR_DELIM + "mods.conf";
-	addModsFromConfig(settings_path, paths);
+	conf.readConfigFile(settings_path.c_str());
+
+	addModsFromConfig(&conf, paths);
+
+	conf.updateConfigFile(settings_path.c_str());
 }
 #endif
 

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 #include "config.h"
 #include "metadata.h"
+#include "settings.h"
 
 #define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
 
@@ -97,8 +98,7 @@ protected:
 	// adds all mods in the set.
 	void addMods(const std::vector<ModSpec> &new_mods);
 
-	void addModsFromConfig(const std::string &settings_path,
-			const std::set<std::string> &mods);
+	void addModsFromConfig(Settings *conf, const std::set<std::string> &mods);
 
 	void checkConflictsAndDeps();
 

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -325,6 +325,9 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 
 		if (!conf.updateConfigFile(worldmt_path.c_str()))
 			return false;
+	} else {
+		// read settings for use by map_meta.txt
+		conf.readConfigFile(worldmt_path.c_str());
 	}
 
 	// Create map_meta.txt if does not already exist
@@ -347,3 +350,5 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 	}
 	return true;
 }
+
+#undef SETUP_SETTING

--- a/src/database/database-redis.cpp
+++ b/src/database/database-redis.cpp
@@ -32,18 +32,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cassert>
 
 
-Database_Redis::Database_Redis(Settings &conf)
+Database_Redis::Database_Redis()
 {
 	std::string tmp;
 	try {
-		tmp = conf.get("redis_address");
-		hash = conf.get("redis_hash");
+		tmp = g_settings->get("redis_address");
+		hash = g_settings->get("redis_hash");
 	} catch (SettingNotFoundException &) {
 		throw SettingNotFoundException("Set redis_address and "
 			"redis_hash in world.mt to use the redis backend");
 	}
 	const char *addr = tmp.c_str();
-	int port = conf.exists("redis_port") ? conf.getU16("redis_port") : 6379;
+	int port = g_settings->exists("redis_port") ? g_settings->getU16("redis_port") : 6379;
 	// if redis_address contains '/' assume unix socket, else hostname/ip
 	ctx = tmp.find('/') != std::string::npos ? redisConnectUnix(addr) : redisConnect(addr, port);
 	if (!ctx) {
@@ -53,8 +53,8 @@ Database_Redis::Database_Redis(Settings &conf)
 		redisFree(ctx);
 		throw DatabaseException(err);
 	}
-	if (conf.exists("redis_password")) {
-		tmp = conf.get("redis_password");
+	if (g_settings->exists("redis_password")) {
+		tmp = g_settings->get("redis_password");
 		redisReply *reply = static_cast<redisReply *>(redisCommand(ctx, "AUTH %s", tmp.c_str()));
 		if (!reply)
 			throw DatabaseException("Redis authentication failed");

--- a/src/database/database-redis.h
+++ b/src/database/database-redis.h
@@ -32,7 +32,7 @@ class Settings;
 class Database_Redis : public MapDatabase
 {
 public:
-	Database_Redis(Settings &conf);
+	Database_Redis();
 	~Database_Redis();
 
 	void beginSave();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -290,6 +290,8 @@ void set_default_settings(Settings *settings)
 	// Server
 	settings->setDefault("disable_escape_sequences", "false");
 	settings->setDefault("strip_color_codes", "false");
+	settings->setDefault("backend", "sqlite3");
+	settings->setDefault("player_backend", "sqlite3");
 
 	// Network
 	settings->setDefault("enable_ipv6", "true");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -415,7 +415,7 @@ public:
 	void onSettingsChange(const std::string &name)
 	{
 		if (name == "enable_fog")
-			m_fog_enabled = g_settings->getBool("enable_fog");
+			m_fog_enabled = g_main_settings->getBool("enable_fog");
 	}
 
 	static void settingsCallback(const std::string &name, void *userdata)
@@ -443,13 +443,13 @@ public:
 		m_texture_flags("textureFlags"),
 		m_client(client)
 	{
-		g_settings->registerChangedCallback("enable_fog", settingsCallback, this);
-		m_fog_enabled = g_settings->getBool("enable_fog");
+		g_main_settings->registerChangedCallback("enable_fog", settingsCallback, this);
+		m_fog_enabled = g_main_settings->getBool("enable_fog");
 	}
 
 	~GameGlobalShaderConstantSetter()
 	{
-		g_settings->deregisterChangedCallback("enable_fog", settingsCallback, this);
+		g_main_settings->deregisterChangedCallback("enable_fog", settingsCallback, this);
 	}
 
 	virtual void onSetConstants(video::IMaterialRendererServices *services,
@@ -895,31 +895,31 @@ private:
 Game::Game() :
 	m_game_ui(new GameUI())
 {
-	g_settings->registerChangedCallback("doubletap_jump",
+	g_main_settings->registerChangedCallback("doubletap_jump",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("enable_clouds",
+	g_main_settings->registerChangedCallback("enable_clouds",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("doubletap_joysticks",
+	g_main_settings->registerChangedCallback("doubletap_joysticks",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("enable_particles",
+	g_main_settings->registerChangedCallback("enable_particles",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("enable_fog",
+	g_main_settings->registerChangedCallback("enable_fog",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("mouse_sensitivity",
+	g_main_settings->registerChangedCallback("mouse_sensitivity",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("joystick_frustum_sensitivity",
+	g_main_settings->registerChangedCallback("joystick_frustum_sensitivity",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("repeat_rightclick_time",
+	g_main_settings->registerChangedCallback("repeat_rightclick_time",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("noclip",
 		&settingChangedCallback, this);
 	g_settings->registerChangedCallback("free_move",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("cinematic",
+	g_main_settings->registerChangedCallback("cinematic",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("cinematic_camera_smoothing",
+	g_main_settings->registerChangedCallback("cinematic_camera_smoothing",
 		&settingChangedCallback, this);
-	g_settings->registerChangedCallback("camera_smoothing",
+	g_main_settings->registerChangedCallback("camera_smoothing",
 		&settingChangedCallback, this);
 
 	readSettings();
@@ -958,27 +958,27 @@ Game::~Game()
 
 	extendedResourceCleanup();
 
-	g_settings->deregisterChangedCallback("doubletap_jump",
+	g_main_settings->deregisterChangedCallback("doubletap_jump",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("enable_clouds",
+	g_main_settings->deregisterChangedCallback("enable_clouds",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("enable_particles",
+	g_main_settings->deregisterChangedCallback("enable_particles",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("enable_fog",
+	g_main_settings->deregisterChangedCallback("enable_fog",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("mouse_sensitivity",
+	g_main_settings->deregisterChangedCallback("mouse_sensitivity",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("repeat_rightclick_time",
+	g_main_settings->deregisterChangedCallback("repeat_rightclick_time",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("noclip",
 		&settingChangedCallback, this);
 	g_settings->deregisterChangedCallback("free_move",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("cinematic",
+	g_main_settings->deregisterChangedCallback("cinematic",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("cinematic_camera_smoothing",
+	g_main_settings->deregisterChangedCallback("cinematic_camera_smoothing",
 		&settingChangedCallback, this);
-	g_settings->deregisterChangedCallback("camera_smoothing",
+	g_main_settings->deregisterChangedCallback("camera_smoothing",
 		&settingChangedCallback, this);
 }
 
@@ -1021,7 +1021,7 @@ bool Game::startup(bool *kill,
 
 	m_game_ui->initFlags();
 
-	m_invert_mouse = g_settings->getBool("invert_mouse");
+	m_invert_mouse = g_main_settings->getBool("invert_mouse");
 	m_first_loop_after_window_activation = true;
 
 	g_translations->clear();
@@ -1053,15 +1053,15 @@ void Game::run()
 
 	draw_times.last_time = RenderingEngine::get_timer_time();
 
-	set_light_table(g_settings->getFloat("display_gamma"));
+	set_light_table(g_main_settings->getFloat("display_gamma"));
 
 #ifdef __ANDROID__
 	m_cache_hold_aux1 = g_settings->getBool("fast_move")
 			&& client->checkPrivilege("fast");
 #endif
 
-	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
-		g_settings->getU16("screen_h"));
+	irr::core::dimension2d<u32> previous_screen_size(g_main_settings->getU16("screen_w"),
+		g_main_settings->getU16("screen_h"));
 
 	while (RenderingEngine::run()
 			&& !(*kill || g_gamecallback->shutdown_requested
@@ -1074,9 +1074,9 @@ void Game::run()
 		// First condition is cheaper
 		if (previous_screen_size != current_screen_size &&
 				current_screen_size != irr::core::dimension2d<u32>(0,0) &&
-				g_settings->getBool("autosave_screensize")) {
-			g_settings->setU16("screen_w", current_screen_size.Width);
-			g_settings->setU16("screen_h", current_screen_size.Height);
+				g_main_settings->getBool("autosave_screensize")) {
+			g_main_settings->setU16("screen_w", current_screen_size.Width);
+			g_main_settings->setU16("screen_h", current_screen_size.Height);
 			previous_screen_size = current_screen_size;
 		}
 
@@ -1130,7 +1130,7 @@ void Game::shutdown()
 {
 	RenderingEngine::finalize();
 #if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 8
-	if (g_settings->get("3d_mode") == "pageflip") {
+	if (g_main_settings->get("3d_mode") == "pageflip") {
 		driver->setRenderTarget(irr::video::ERT_STEREO_BOTH_BUFFERS);
 	}
 #endif
@@ -1218,7 +1218,7 @@ bool Game::init(
 bool Game::initSound()
 {
 #if USE_SOUND
-	if (g_settings->getBool("enable_sound")) {
+	if (g_main_settings->getBool("enable_sound")) {
 		infostream << "Attempting to use OpenAL audio" << std::endl;
 		sound = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 		if (!sound)
@@ -1247,10 +1247,10 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 {
 	showOverlayMessage("Creating server...", 0, 5);
 
-	std::string bind_str = g_settings->get("bind_address");
+	std::string bind_str = g_main_settings->get("bind_address");
 	Address bind_addr(0, 0, 0, 0, port);
 
-	if (g_settings->getBool("ipv6_server")) {
+	if (g_main_settings->getBool("ipv6_server")) {
 		bind_addr.setAddress((IPv6AddressBytes *) NULL);
 	}
 
@@ -1262,7 +1262,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 			   << " -- Listening on all addresses." << std::endl;
 	}
 
-	if (bind_addr.isIPv6() && !g_settings->getBool("enable_ipv6")) {
+	if (bind_addr.isIPv6() && !g_main_settings->getBool("enable_ipv6")) {
 		*error_message = "Unable to listen on " +
 				bind_addr.serializeString() +
 				" because IPv6 is disabled";
@@ -1452,7 +1452,7 @@ bool Game::connectToServer(const std::string &playername,
 		return false;
 	}
 
-	if (connect_address.isIPv6() && !g_settings->getBool("enable_ipv6")) {
+	if (connect_address.isIPv6() && !g_main_settings->getBool("enable_ipv6")) {
 		*error_message = "Unable to connect to " +
 				connect_address.serializeString() +
 				" because IPv6 is disabled";
@@ -1621,7 +1621,7 @@ bool Game::getServerContent(bool *aborted)
 			message.precision(2);
 
 			if ((USE_CURL == 0) ||
-					(!g_settings->getBool("enable_remote_media_server"))) {
+					(!g_main_settings->getBool("enable_remote_media_server"))) {
 				float cur = client->getCurRate();
 				std::string cur_unit = gettext("KiB/s");
 
@@ -1724,7 +1724,7 @@ void Game::processQueues()
 void Game::updateProfilers(const RunStats &stats, const FpsControl &draw_times, f32 dtime)
 {
 	float profiler_print_interval =
-			g_settings->getFloat("profiler_print_interval");
+			g_main_settings->getFloat("profiler_print_interval");
 	bool print_to_log = true;
 
 	if (profiler_print_interval == 0) {
@@ -1878,7 +1878,7 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::CMD_LOCAL)) {
 		openConsole(0.2, L".");
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
-		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
+		openConsole(core::clamp(g_main_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {
 		toggleFreeMove();
 	} else if (wasKeyDown(KeyType::JUMP)) {
@@ -1888,24 +1888,24 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::NOCLIP)) {
 		toggleNoClip();
 	} else if (wasKeyDown(KeyType::MUTE)) {
-		bool new_mute_sound = !g_settings->getBool("mute_sound");
-		g_settings->setBool("mute_sound", new_mute_sound);
+		bool new_mute_sound = !g_main_settings->getBool("mute_sound");
+		g_main_settings->setBool("mute_sound", new_mute_sound);
 		if (new_mute_sound)
 			m_game_ui->showTranslatedStatusText("Sound muted");
 		else
 			m_game_ui->showTranslatedStatusText("Sound unmuted");
 	} else if (wasKeyDown(KeyType::INC_VOLUME)) {
-		float new_volume = rangelim(g_settings->getFloat("sound_volume") + 0.1f, 0.0f, 1.0f);
+		float new_volume = rangelim(g_main_settings->getFloat("sound_volume") + 0.1f, 0.0f, 1.0f);
 		wchar_t buf[100];
-		g_settings->setFloat("sound_volume", new_volume);
+		g_main_settings->setFloat("sound_volume", new_volume);
 		const wchar_t *str = wgettext("Volume changed to %d%%");
 		swprintf(buf, sizeof(buf) / sizeof(wchar_t), str, myround(new_volume * 100));
 		delete[] str;
 		m_game_ui->showStatusText(buf);
 	} else if (wasKeyDown(KeyType::DEC_VOLUME)) {
-		float new_volume = rangelim(g_settings->getFloat("sound_volume") - 0.1f, 0.0f, 1.0f);
+		float new_volume = rangelim(g_main_settings->getFloat("sound_volume") - 0.1f, 0.0f, 1.0f);
 		wchar_t buf[100];
-		g_settings->setFloat("sound_volume", new_volume);
+		g_main_settings->setFloat("sound_volume", new_volume);
 		const wchar_t *str = wgettext("Volume changed to %d%%");
 		swprintf(buf, sizeof(buf) / sizeof(wchar_t), str, myround(new_volume * 100));
 		delete[] str;
@@ -2134,8 +2134,8 @@ void Game::toggleNoClip()
 
 void Game::toggleCinematic()
 {
-	bool cinematic = !g_settings->getBool("cinematic");
-	g_settings->set("cinematic", bool_to_cstr(cinematic));
+	bool cinematic = !g_main_settings->getBool("cinematic");
+	g_main_settings->set("cinematic", bool_to_cstr(cinematic));
 
 	if (cinematic)
 		m_game_ui->showTranslatedStatusText("Cinematic mode enabled");
@@ -2262,7 +2262,7 @@ void Game::toggleUpdateCamera()
 
 void Game::increaseViewRange()
 {
-	s16 range = g_settings->getS16("viewing_range");
+	s16 range = g_main_settings->getS16("viewing_range");
 	s16 range_new = range + 10;
 
 	wchar_t buf[255];
@@ -2280,13 +2280,13 @@ void Game::increaseViewRange()
 		delete[] str;
 		m_game_ui->showStatusText(buf);
 	}
-	g_settings->set("viewing_range", itos(range_new));
+	g_main_settings->set("viewing_range", itos(range_new));
 }
 
 
 void Game::decreaseViewRange()
 {
-	s16 range = g_settings->getS16("viewing_range");
+	s16 range = g_main_settings->getS16("viewing_range");
 	s16 range_new = range - 10;
 
 	wchar_t buf[255];
@@ -2303,7 +2303,7 @@ void Game::decreaseViewRange()
 		delete[] str;
 		m_game_ui->showStatusText(buf);
 	}
-	g_settings->set("viewing_range", itos(range_new));
+	g_main_settings->set("viewing_range", itos(range_new));
 }
 
 
@@ -2768,10 +2768,7 @@ void Game::updateChat(f32 dtime, const v2u32 &screensize)
 	// Get new messages from error log buffer
 	while (!chat_log_error_buf.empty()) {
 		std::wstring error_message = utf8_to_wide(chat_log_error_buf.get());
-		if (!g_settings->getBool("disable_escape_sequences")) {
-			error_message.insert(0, L"\x1b(c@red)");
-			error_message.append(L"\x1b(c@white)");
-		}
+		error_message = L"\x1b(c@red)" + error_message + L"\x1b(c@white)";
 		chat_backend->addMessage(L"", error_message);
 	}
 
@@ -2870,17 +2867,17 @@ void Game::updateSound(f32 dtime)
 			      camera->getDirection(),
 			      camera->getCameraNode()->getUpVector());
 
-	bool mute_sound = g_settings->getBool("mute_sound");
+	bool mute_sound = g_main_settings->getBool("mute_sound");
 	if (mute_sound) {
 		sound->setListenerGain(0.0f);
 	} else {
 		// Check if volume is in the proper range, else fix it.
-		float old_volume = g_settings->getFloat("sound_volume");
+		float old_volume = g_main_settings->getFloat("sound_volume");
 		float new_volume = rangelim(old_volume, 0.0f, 1.0f);
 		sound->setListenerGain(new_volume);
 
 		if (old_volume != new_volume) {
-			g_settings->setFloat("sound_volume", new_volume);
+			g_main_settings->setFloat("sound_volume", new_volume);
 		}
 	}
 
@@ -2947,7 +2944,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 
 #ifdef HAVE_TOUCHSCREENGUI
 
-	if ((g_settings->getBool("touchtarget")) && (g_touchscreengui)) {
+	if ((g_main_settings->getBool("touchtarget")) && (g_touchscreengui)) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach
 		shootline.end = shootline.start
@@ -3018,7 +3015,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	soundmaker->m_player_leftpunch_sound.name = "";
 
 	// Prepare for repeating, unless we're not supposed to
-	if (input->getRightState() && !g_settings->getBool("safe_dig_and_place"))
+	if (input->getRightState() && !g_main_settings->getBool("safe_dig_and_place"))
 		runData.repeat_rightclick_timer += dtime;
 	else
 		runData.repeat_rightclick_timer = 0;
@@ -3071,7 +3068,7 @@ PointedThing Game::updatePointedThing(
 	std::vector<aabb3f> *selectionboxes = hud->getSelectionBoxes();
 	selectionboxes->clear();
 	hud->setSelectedFaceNormal(v3f(0.0, 0.0, 0.0));
-	static thread_local const bool show_entity_selectionbox = g_settings->getBool(
+	static thread_local const bool show_entity_selectionbox = g_main_settings->getBool(
 		"show_entity_selectionbox");
 
 	ClientEnvironment &env = client->getEnv();
@@ -3815,7 +3812,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			(camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 #ifdef HAVE_TOUCHSCREENGUI
 	try {
-		draw_crosshair = !g_settings->getBool("touchtarget");
+		draw_crosshair = !g_main_settings->getBool("touchtarget");
 	} catch (SettingNotFoundException) {
 	}
 #endif
@@ -3896,8 +3893,8 @@ inline void Game::limitFps(FpsControl *fps_timings, f32 *dtime)
 		fps_timings->busy_time = 0;
 
 	u32 frametime_min = 1000 / (g_menumgr.pausesGame()
-			? g_settings->getFloat("pause_fps_max")
-			: g_settings->getFloat("fps_max"));
+			? g_main_settings->getFloat("pause_fps_max")
+			: g_main_settings->getFloat("fps_max"));
 
 	if (fps_timings->busy_time < frametime_min) {
 		fps_timings->sleep_time = frametime_min - fps_timings->busy_time;
@@ -3938,31 +3935,31 @@ void Game::settingChangedCallback(const std::string &setting_name, void *data)
 
 void Game::readSettings()
 {
-	m_cache_doubletap_jump               = g_settings->getBool("doubletap_jump");
-	m_cache_enable_clouds                = g_settings->getBool("enable_clouds");
-	m_cache_enable_joysticks             = g_settings->getBool("enable_joysticks");
-	m_cache_enable_particles             = g_settings->getBool("enable_particles");
-	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
-	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity");
-	m_cache_joystick_frustum_sensitivity = g_settings->getFloat("joystick_frustum_sensitivity");
-	m_repeat_right_click_time            = g_settings->getFloat("repeat_rightclick_time");
+	m_cache_doubletap_jump               = g_main_settings->getBool("doubletap_jump");
+	m_cache_enable_clouds                = g_main_settings->getBool("enable_clouds");
+	m_cache_enable_joysticks             = g_main_settings->getBool("enable_joysticks");
+	m_cache_enable_particles             = g_main_settings->getBool("enable_particles");
+	m_cache_enable_fog                   = g_main_settings->getBool("enable_fog");
+	m_cache_mouse_sensitivity            = g_main_settings->getFloat("mouse_sensitivity");
+	m_cache_joystick_frustum_sensitivity = g_main_settings->getFloat("joystick_frustum_sensitivity");
+	m_repeat_right_click_time            = g_main_settings->getFloat("repeat_rightclick_time");
 
 	m_cache_enable_noclip                = g_settings->getBool("noclip");
 	m_cache_enable_free_move             = g_settings->getBool("free_move");
 
-	m_cache_fog_start                    = g_settings->getFloat("fog_start");
+	m_cache_fog_start                    = g_main_settings->getFloat("fog_start");
 
 	m_cache_cam_smoothing = 0;
-	if (g_settings->getBool("cinematic"))
-		m_cache_cam_smoothing = 1 - g_settings->getFloat("cinematic_camera_smoothing");
+	if (g_main_settings->getBool("cinematic"))
+		m_cache_cam_smoothing = 1 - g_main_settings->getFloat("cinematic_camera_smoothing");
 	else
-		m_cache_cam_smoothing = 1 - g_settings->getFloat("camera_smoothing");
+		m_cache_cam_smoothing = 1 - g_main_settings->getFloat("camera_smoothing");
 
 	m_cache_fog_start = rangelim(m_cache_fog_start, 0.0f, 0.99f);
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
 	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
 
-	m_does_lost_focus_pause_game = g_settings->getBool("pause_on_lost_focus");
+	m_does_lost_focus_pause_game = g_main_settings->getBool("pause_on_lost_focus");
 }
 
 /****************************************************************************/

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -173,7 +173,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 			core::rect<s32> rect(0, 0, option_w, 30);
 			rect += topleft + v2s32(option_x, option_y);
 			const wchar_t *text = wgettext("\"Special\" = climb down");
-			Environment->addCheckBox(g_settings->getBool("aux1_descends"), rect, this,
+			Environment->addCheckBox(g_main_settings->getBool("aux1_descends"), rect, this,
 					GUI_ID_CB_AUX1_DESCENDS, text);
 			delete[] text;
 		}
@@ -188,7 +188,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 			core::rect<s32> rect(0, 0, option_w, 30);
 			rect += topleft + v2s32(option_x, option_y);
 			const wchar_t *text = wgettext("Double tap \"jump\" to toggle fly");
-			Environment->addCheckBox(g_settings->getBool("doubletap_jump"), rect, this,
+			Environment->addCheckBox(g_main_settings->getBool("doubletap_jump"), rect, this,
 					GUI_ID_CB_DOUBLETAP_JUMP, text);
 			delete[] text;
 		}
@@ -234,18 +234,18 @@ void GUIKeyChangeMenu::drawMenu()
 bool GUIKeyChangeMenu::acceptInput()
 {
 	for (key_setting *k : key_settings) {
-		g_settings->set(k->setting_name, k->key.sym());
+		g_main_settings->set(k->setting_name, k->key.sym());
 	}
 
 	{
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUX1_DESCENDS);
 		if(e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("aux1_descends", ((gui::IGUICheckBox*)e)->isChecked());
+			g_main_settings->setBool("aux1_descends", ((gui::IGUICheckBox*)e)->isChecked());
 	}
 	{
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_DOUBLETAP_JUMP);
 		if(e != NULL && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
+			g_main_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
 	}
 
 	clearKeyCache();

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -79,7 +79,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 	recalculateAbsolutePosition(false);
 
 	v2s32 size = DesiredRect.getSize();
-	int volume = (int)(g_settings->getFloat("sound_volume") * 100);
+	int volume = (int)(g_main_settings->getFloat("sound_volume") * 100);
 
 	/*
 		Add stuff
@@ -116,7 +116,7 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		core::rect<s32> rect(0, 0, 160, 20);
 		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 35);
 		const wchar_t *text = wgettext("Muted");
-		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
+		Environment->addCheckBox(g_main_settings->getBool("mute_sound"), rect, this,
 				ID_soundMuteButton, text);
 		delete[] text;
 	}
@@ -149,7 +149,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 		if (event.GUIEvent.EventType == gui::EGET_CHECKBOX_CHANGED) {
 			gui::IGUIElement *e = getElementFromId(ID_soundMuteButton);
 			if (e != NULL && e->getType() == gui::EGUIET_CHECK_BOX) {
-				g_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
+				g_main_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
 			}
 
 			Environment->setFocus(this);
@@ -176,7 +176,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
 				s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
-				g_settings->setFloat("sound_volume", (float) pos / 100);
+				g_main_settings->setFloat("sound_volume", (float) pos / 100);
 
 				gui::IGUIElement *e = getElementFromId(ID_soundText);
 				const wchar_t *text = wgettext("Sound Volume: ");

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -368,7 +368,7 @@ KeyPress getKeySetting(const char *settingname)
 	if (n != g_key_setting_cache.end())
 		return n->second;
 
-	KeyPress k(g_settings->get(settingname).c_str());
+	KeyPress k(g_main_settings->get(settingname).c_str());
 	g_key_setting_cache[settingname] = k;
 	return k;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1000,5 +1000,8 @@ static bool migrate_map_database(const GameParams &game_params, const Settings &
 	else
 		actionstream << "world.mt updated" << std::endl;
 
+	// reset settings
+	g_settings = g_main_settings;
+
 	return true;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1150,18 +1150,12 @@ ServerMap::ServerMap(const std::string &savedir, IGameDef *gamedef,
 	*/
 
 	// Determine which database backend to use
-	std::string conf_path = savedir + DIR_DELIM + "world.mt";
-	Settings conf;
-	bool succeeded = conf.readConfigFile(conf_path.c_str());
-	if (!succeeded || !conf.exists("backend")) {
+	if (!g_settings->existsNoDefault("backend")) {
 		// fall back to sqlite3
-		conf.set("backend", "sqlite3");
+		g_settings->set("backend", "sqlite3");
 	}
-	std::string backend = conf.get("backend");
-	dbase = createDatabase(backend, savedir, conf);
-
-	if (!conf.updateConfigFile(conf_path.c_str()))
-		errorstream << "ServerMap::ServerMap(): Failed to update world.mt!" << std::endl;
+	std::string backend = g_settings->get("backend");
+	dbase = createDatabase(backend, savedir);
 
 	m_savedir = savedir;
 	m_map_saving_enabled = false;
@@ -1888,8 +1882,7 @@ void ServerMap::listAllLoadedBlocks(std::vector<v3s16> &dst)
 
 MapDatabase *ServerMap::createDatabase(
 	const std::string &name,
-	const std::string &savedir,
-	Settings &conf)
+	const std::string &savedir)
 {
 	if (name == "sqlite3")
 		return new MapDatabaseSQLite3(savedir);
@@ -1901,12 +1894,12 @@ MapDatabase *ServerMap::createDatabase(
 	#endif
 	#if USE_REDIS
 	if (name == "redis")
-		return new Database_Redis(conf);
+		return new Database_Redis();
 	#endif
 	#if USE_POSTGRESQL
 	if (name == "postgresql") {
 		std::string connect_string;
-		conf.getNoEx("pgsql_connection", connect_string);
+		g_settings->getNoEx("pgsql_connection", connect_string);
 		return new MapDatabasePostgreSQL(connect_string);
 	}
 	#endif

--- a/src/map.h
+++ b/src/map.h
@@ -400,7 +400,7 @@ public:
 	/*
 		Database functions
 	*/
-	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir, Settings &conf);
+	static MapDatabase *createDatabase(const std::string &name, const std::string &savedir);
 
 	// Returns true if the database file does not exist
 	bool loadFromFolders();

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -26,7 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #define SET_SECURITY_CHECK(L, name) \
-	if (o->m_settings == g_settings && ScriptApiSecurity::isSecure(L) && \
+	if ((o->m_settings == g_settings || o->m_settings == g_main_settings) && \
+			ScriptApiSecurity::isSecure(L) && \
 			name.compare(0, 7, "secure.") == 0) { \
 		throw LuaError("Attempt to set secure setting."); \
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -220,15 +220,15 @@ Server::Server(
 	m_admin_chat(iface),
 	m_modchannel_mgr(new ModChannelMgr())
 {
-	// set global settings to server settings;
-	g_settings = m_conf;
-
 	// Initialize settings
 	set_default_settings(m_conf);
 	override_default_settings(m_conf, g_main_settings);
 	m_settings_path = path_world + DIR_DELIM + "world.mt";
 	if (!m_conf->readConfigFile(m_settings_path.c_str()))
 		errorstream << "Failed to load config file" << std::endl;
+
+	// set global settings to server settings;
+	g_settings = m_conf;
 
 	m_con = std::make_shared<con::Connection>(PROTOCOL_ID,
 			512,

--- a/src/server.h
+++ b/src/server.h
@@ -342,6 +342,8 @@ public:
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
 
+	const std::string &getSettingsPath() const { return m_settings_path; }
+
 	// Bind address
 	Address m_bind_addr;
 
@@ -508,6 +510,9 @@ private:
 
 	// World directory
 	std::string m_path_world;
+	// config file
+	std::string m_settings_path;
+	Settings *m_conf;
 	// Subgame specification
 	SubgameSpec m_gamespec;
 	// If true, do not allow multiple players and hide some multiplayer

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -43,8 +43,7 @@ ServerModManager::ServerModManager(const std::string &worldpath) :
 	addModsInPath(worldpath + DIR_DELIM + "worldmods");
 
 	// Load normal mods
-	std::string worldmt = worldpath + DIR_DELIM + "world.mt";
-	addModsFromConfig(worldmt, gamespec.addon_mods_paths);
+	addModsFromConfig(g_settings, gamespec.addon_mods_paths);
 }
 
 // clang-format off

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -362,7 +362,7 @@ private:
 	void loadDefaultMeta();
 
 	static PlayerDatabase *openPlayerDatabase(const std::string &name,
-			const std::string &savedir, const Settings &conf);
+			const std::string &savedir);
 	/*
 		Internal ActiveObject interface
 		-------------------------------------------

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 static Settings main_settings;
 Settings *g_settings = &main_settings;
+Settings * const g_main_settings = &main_settings;
 std::string g_settings_path;
 
 Settings::~Settings()
@@ -563,6 +564,13 @@ bool Settings::exists(const std::string &name) const
 
 	return (m_settings.find(name) != m_settings.end() ||
 		m_defaults.find(name) != m_defaults.end());
+}
+
+bool Settings::existsNoDefault(const std::string &name) const
+{
+	MutexAutoLock lock(m_mutex);
+
+	return m_settings.find(name) != m_settings.end();
 }
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -32,6 +32,7 @@ struct NoiseParams;
 // Global objects
 extern Settings *g_settings;
 extern std::string g_settings_path;
+extern Settings * const g_main_settings;
 
 // Type for a settings changed callback function
 typedef void (*SettingsChangedCallback)(const std::string &name, void *data);
@@ -155,6 +156,7 @@ public:
 	// return all keys used
 	std::vector<std::string> getNames() const;
 	bool exists(const std::string &name) const;
+	bool existsNoDefault(const std::string &name) const;
 
 
 	/***************************************


### PR DESCRIPTION
### Core changes

Settings are now loaded from `world.mt` on server start up, with `minetest.conf` settings being used as defaults.

### Main menu Changes

The biggest change is a new menu based on the advanced settings menu that can be used to set per-world settings. A few small changes were also made to the "start game" tab to better support then new way that `world.mt` is used.

This PR replaces #6528 and is a simpler implementation, it still allows for separating client and server settings, WIP as it needs testing and some input on which client settings should be always global. It also closes #6966.