### PR TITLE
Fix falling node infinite falling on overhigh collision box, and rotation of facedir nodes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -27,6 +27,14 @@ core.register_entity(":__builtin:falling_node", {
 			is_visible = true,
 			textures = {node.name},
 		})
+		local def = core.registered_nodes[node.name]
+		if node.param2 ~= 0 then
+			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
+				self.object:set_yaw(core.dir_to_yaw(core.facedir_to_dir(node.param2)))
+			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
+				self.object:set_yaw(core.dir_to_yaw(core.wallmounted_to_dir(node.param2)))
+			end
+		end
 	end,
 
 	get_staticdata = function(self)


### PR DESCRIPTION
This PR fixes 2 bugs in falling nodes:

1. When a falling node falls on a node with an overhigh collision box (i.e. upper collision box Y > 1.0), the falling node stops (because it collides), then it teleports a short distance upwards, then falls again, and stops again at the overhigh collisionbox, etc. In other words, the falling node is stuck in an infinite loop. This is really bad.
    I use this as a fix: When the falling node suddenly stops (i.e. velocity = 0), it drops as item(s). Because if a falling node hits an overhigh collision box, there is no clean way to actually place the node.



2. Partial fix of #5324. If the node uses facedir, wallmounted, colorfacedir, or colorwallmounted, the yaw of the entity is set properly. Limitation: If the axis of the node is rotated as well, the rotation is still wrong. The full fix is not possible with current entities as entities can't pitch or roll.

No. 1 was tested successfully with an overhigh Minetest Game fence.
No. 2 was tested successfully with a Minetest Game chest, but with `falling_node=1`. And some other nodes.