### PR TITLE
Add kill command and don't add player and world privileges

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -988,11 +988,11 @@ core.register_chatcommand("clearinv", {
 
 local function handle_kill_command(murderer, victim)
 	if core.settings:get_bool("enable_damage") == false then
-		return false, "Players can't be killed right now, damage has been disabled."
+		return false, "Players can't be killed, damage has been disabled."
 	end
 	local victimref = core.get_player_by_name(victim)
 	if victimref == nil then
-		return false, string.format("Player %s does not exist.", victim)
+		return false, string.format("Player %s is not online.", victim)
 	elseif victimref:get_hp() <= 0 then
 		if murderer == victim then
 			return false, "You are already dead"
@@ -1013,12 +1013,6 @@ core.register_chatcommand("kill", {
 	description = "Kill player or yourself",
 	privs = {server=true},
 	func = function(name, param)
-		if(param == "") then
-			-- Selfkill
-			return handle_kill_command(name, name)
-		else
-			-- Kill other player
-			return handle_kill_command(name, param)
-		end
+		return handle_kill_command(name, param == "" and name or param)
 	end,
 })

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -616,7 +616,7 @@ core.register_chatcommand("giveme", {
 core.register_chatcommand("spawnentity", {
 	params = "<EntityName> [<X>,<Y>,<Z>]",
 	description = "Spawn entity at given (or your) position",
-	privs = {give=true, interact=true},
+	privs = {world=true},
 	func = function(name, param)
 		local entityname, p = string.match(param, "^([^ ]+) *(.*)$")
 		if not entityname then

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -986,7 +986,7 @@ core.register_chatcommand("clearinv", {
 	end,
 })
 
-local function handle_kill_command(murderer, victim)
+local function handle_kill_command(killer, victim)
 	if core.settings:get_bool("enable_damage") == false then
 		return false, "Players can't be killed, damage has been disabled."
 	end
@@ -994,18 +994,18 @@ local function handle_kill_command(murderer, victim)
 	if victimref == nil then
 		return false, string.format("Player %s is not online.", victim)
 	elseif victimref:get_hp() <= 0 then
-		if murderer == victim then
-			return false, "You are already dead"
+		if killer == victim then
+			return false, "You are already dead."
 		else
-			return false, string.format("%s is already dead", victim)
+			return false, string.format("%s is already dead.", victim)
 		end
 	end
-	if not murderer == victim then
-		core.log("action", string.format("%s killed %s", murderer, victim))
+	if not killer == victim then
+		core.log("action", string.format("%s killed %s", killer, victim))
 	end
 	-- Kill victim
 	victimref:set_hp(0)
-	return true
+	return true, string.format("%s has been killed.", victim)
 end
 
 core.register_chatcommand("kill", {

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -82,7 +82,7 @@ core.register_chatcommand("me", {
 core.register_chatcommand("admin", {
 	description = "Show the name of the server owner",
 	func = function(name)
-		local admin = minetest.settings:get("name")
+		local admin = core.settings:get("name")
 		if admin then
 			return true, "The administrator of this server is "..admin.."."
 		else
@@ -104,7 +104,7 @@ core.register_chatcommand("privs", {
 })
 
 local function handle_grant_command(caller, grantname, grantprivstr)
-	local caller_privs = minetest.get_player_privs(caller)
+	local caller_privs = core.get_player_privs(caller)
 	if not (caller_privs.privs or caller_privs.basic_privs) then
 		return false, "Your privileges are insufficient."
 	end
@@ -629,7 +629,7 @@ core.register_chatcommand("spawnentity", {
 			core.log("error", "Unable to spawn entity, player is nil")
 			return false, "Unable to spawn entity, player is nil"
 		end
-		if not minetest.registered_entities[entityname] then
+		if not core.registered_entities[entityname] then
 			return false, "Cannot spawn an unknown entity"
 		end
 		if p == "" then
@@ -987,10 +987,10 @@ core.register_chatcommand("clearinv", {
 })
 
 local function handle_kill_command(murderer, victim)
-	if minetest.settings:get_bool("damage_enabled") == false then
+	if core.settings:get_bool("enable_damage") == false then
 		return false, "Players can't be killed right now, damage has been disabled."
 	end
-	local victimref = minetest.get_player_by_name(victim)
+	local victimref = core.get_player_by_name(victim)
 	if victimref == nil then
 		return false, string.format("Player %s does not exist.", victim)
 	elseif victimref:get_hp() <= 0 then
@@ -1001,14 +1001,14 @@ local function handle_kill_command(murderer, victim)
 		end
 	end
 	if not murderer == victim then
-		minetest.log("action", string.format("%s killed %s", murderer, victim))
+		core.log("action", string.format("%s killed %s", murderer, victim))
 	end
 	-- Kill victim
 	victimref:set_hp(0)
 	return true
 end
 
-minetest.register_chatcommand("kill", {
+core.register_chatcommand("kill", {
 	params = "[<name>]",
 	description = "Kill player or yourself",
 	privs = {player=true},

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -616,7 +616,7 @@ core.register_chatcommand("giveme", {
 core.register_chatcommand("spawnentity", {
 	params = "<EntityName> [<X>,<Y>,<Z>]",
 	description = "Spawn entity at given (or your) position",
-	privs = {world=true},
+	privs = {give=true, interact=true},
 	func = function(name, param)
 		local entityname, p = string.match(param, "^([^ ]+) *(.*)$")
 		if not entityname then
@@ -964,9 +964,9 @@ core.register_chatcommand("clearinv", {
 	func = function(name, param)
 		local player
 		if param and param ~= "" and param ~= name then
-			if not core.check_player_privs(name, {player=true}) then
+			if not core.check_player_privs(name, {server=true}) then
 				return false, "You don't have permission"
-						.. " to clear another player's inventory (missing privilege: player)"
+						.. " to clear another player's inventory (missing privilege: server)"
 			end
 			player = core.get_player_by_name(param)
 			core.chat_send_player(param, name.." cleared your inventory.")
@@ -1011,7 +1011,7 @@ end
 core.register_chatcommand("kill", {
 	params = "[<name>]",
 	description = "Kill player or yourself",
-	privs = {player=true},
+	privs = {server=true},
 	func = function(name, param)
 		if(param == "") then
 			-- Selfkill

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -54,6 +54,10 @@ core.register_privilege("protection_bypass", {
 	description = "Can bypass node protection in the world",
 	give_to_singleplayer = false,
 })
+core.register_privilege("player", {
+	description = "Can change player attributes",
+	give_to_singleplayer = false,
+})
 core.register_privilege("ban", {
 	description = "Can ban and unban players",
 	give_to_singleplayer = false,

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -54,10 +54,6 @@ core.register_privilege("protection_bypass", {
 	description = "Can bypass node protection in the world",
 	give_to_singleplayer = false,
 })
-core.register_privilege("player", {
-	description = "Can change player attributes",
-	give_to_singleplayer = false,
-})
 core.register_privilege("ban", {
 	description = "Can ban and unban players",
 	give_to_singleplayer = false,
@@ -91,10 +87,6 @@ core.register_privilege("noclip", {
 })
 core.register_privilege("rollback", {
 	description = "Can use the rollback functionality",
-	give_to_singleplayer = false,
-})
-core.register_privilege("world", {
-	description = "Can make advanced changes to the world",
 	give_to_singleplayer = false,
 })
 core.register_privilege("debug", {

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -93,6 +93,10 @@ core.register_privilege("rollback", {
 	description = "Can use the rollback functionality",
 	give_to_singleplayer = false,
 })
+core.register_privilege("world", {
+	description = "Can make advanced changes to the world",
+	give_to_singleplayer = false,
+})
 core.register_privilege("debug", {
 	description = "Allows enabling various debug options that may affect gameplay",
 	give_to_singleplayer = false,


### PR DESCRIPTION
See https://github.com/minetest/minetest/issues/6960.

* Adds the `kill` command in builtin. Kills yourself or a given player.
* Adds priv: `player`: Required to run `kill`. Also required to run `clearinv` on another player. Intended for all player manipulations
* Adds priv: `world`: Required to run `spawnentity` (instead of `server`). Intended for general world manipulations. Could be adoped by mods like WorldEdit in an attempt to standardize world editing a bit. Currently each mod basically adds its own “world editing” priv, which is messy.

Other commands are not included because of too much opposition. Apparently *setting a node in Minetest* is hugely controversial. xD

EDIT: This PR has just been butchered even more. Now it only adds the `kill` command and it requires the `server` priv now.