### PR TITLE
Add limit parameter to decompressZlib

### DIFF
--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -101,7 +101,7 @@ void compressZlib(const std::string &data, std::ostream &os, int level)
 	compressZlib((u8*)data.c_str(), data.size(), os, level);
 }
 
-void decompressZlib(std::istream &is, std::ostream &os)
+void decompressZlib(std::istream &is, std::ostream &os, size_t limit)
 {
 	z_stream z;
 	const s32 bufsize = 16384;
@@ -110,6 +110,7 @@ void decompressZlib(std::istream &is, std::ostream &os)
 	int status = 0;
 	int ret;
 	int bytes_read = 0;
+	int bytes_written = 0;
 	int input_buffer_len = 0;
 
 	z.zalloc = Z_NULL;
@@ -126,8 +127,20 @@ void decompressZlib(std::istream &is, std::ostream &os)
 
 	for(;;)
 	{
+		int output_size = bufsize;
 		z.next_out = (Bytef*)output_buffer;
-		z.avail_out = bufsize;
+		z.avail_out = output_size;
+
+		if (limit) {
+			int limit_remaining = limit - bytes_written;
+			if (limit_remaining <= 0) {
+				// we're aborting ahead of time - throw an error?
+				break;
+			}
+			if (limit_remaining < output_size) {
+				z.avail_out = output_size = limit_remaining;
+			}
+		}
 
 		if(z.avail_in == 0)
 		{
@@ -155,10 +168,11 @@ void decompressZlib(std::istream &is, std::ostream &os)
 			zerr(status);
 			throw SerializationError("decompressZlib: inflate failed");
 		}
-		int count = bufsize - z.avail_out;
+		int count = output_size - z.avail_out;
 		//dstream<<"count="<<count<<std::endl;
 		if(count)
 			os.write(output_buffer, count);
+		bytes_written += count;
 		if(status == Z_STREAM_END)
 		{
 			//dstream<<"Z_STREAM_END"<<std::endl;

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -87,7 +87,7 @@ inline bool ser_ver_supported(s32 v) {
 
 void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level = -1);
 void compressZlib(const std::string &data, std::ostream &os, int level = -1);
-void decompressZlib(std::istream &is, std::ostream &os);
+void decompressZlib(std::istream &is, std::ostream &os, size_t limit = 0);
 
 // These choose between zlib and a self-made one according to version
 void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version);


### PR DESCRIPTION
This can prevent untrusted data, such as sent over the network, from consuming all memory with a specially crafted payload. Default is still "no limit".

Includes unit tests!