### PR TITLE
New default keys: C: camera, Tab: minimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Some can be changes in the key config dialog in the settings tab.
 | T                             | Chat                                                           |
 | /                             | Command                                                        |
 | Esc                           | Pause menu/abort/exit (pauses only singleplayer game)          |
+| C                             | Cycle through camera modes                                     |
+| Tab                           | Cycle through minimap modes                                    |
+| Shift + Tab                   | Change minimap orientation                                     |
+| F8                            | Toggle cinematic mode                                          |
 | R                             | Enable/disable full range view                                 |
 | +                             | Increase view range                                            |
 | -                             | Decrease view range                                            |
@@ -66,10 +70,6 @@ Some can be changes in the key config dialog in the settings tab.
 | F4                            |  Disable/enable camera update (Mapblocks are not updated anymore when disabled, disabled in release builds)  |
 | F5                            |  Cycle through debug info screens                              |
 | F6                            |  Cycle through profiler info screens                           |
-| F7                            |  Cycle through camera modes                                    |
-| F8                            |  Toggle cinematic mode                                         |
-| F9                            |  Cycle through minimap modes                                   |
-| Shift + F9                    | Change minimap orientation                                     |
 | F10                           | Show/hide console                                              |
 | F12                           | Take screenshot                                                |
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -226,7 +226,7 @@ keymap_cinematic (Cinematic mode key) key
 
 #    Key for toggling display of minimap.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_minimap (Minimap key) key KEY_F9
+keymap_minimap (Minimap key) key KEY_TAB
 
 #    Key for taking screenshots.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -362,7 +362,7 @@ keymap_toggle_profiler (Profiler toggle key) key KEY_F6
 
 #    Key for switching between first- and third-person camera.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_camera_mode (Toggle camera mode key) key KEY_F7
+keymap_camera_mode (Toggle camera mode key) key KEY_KEY_C
 
 #    Key for increasing the viewing range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -222,7 +222,7 @@
 #    Key for toggling display of minimap.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
-# keymap_minimap = KEY_F9
+# keymap_minimap = KEY_TAB
 
 #    Key for taking screenshots.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
@@ -392,7 +392,7 @@
 #    Key for switching between first- and third-person camera.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 #    type: key
-# keymap_camera_mode = KEY_F7
+# keymap_camera_mode = KEY_KEY_C
 
 #    Key for increasing the viewing range.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -76,7 +76,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("keymap_chat", "KEY_KEY_T");
 	settings->setDefault("keymap_cmd", "/");
 	settings->setDefault("keymap_cmd_local", ".");
-	settings->setDefault("keymap_minimap", "KEY_F9");
+	settings->setDefault("keymap_minimap", "KEY_TAB");
 	settings->setDefault("keymap_console", "KEY_F10");
 	settings->setDefault("keymap_rangeselect", "KEY_KEY_R");
 	settings->setDefault("keymap_freemove", "KEY_KEY_K");
@@ -98,7 +98,7 @@ void set_default_settings(Settings *settings)
 #endif
 	settings->setDefault("keymap_toggle_debug", "KEY_F5");
 	settings->setDefault("keymap_toggle_profiler", "KEY_F6");
-	settings->setDefault("keymap_camera_mode", "KEY_F7");
+	settings->setDefault("keymap_camera_mode", "KEY_KEY_C");
 	settings->setDefault("keymap_screenshot", "KEY_F12");
 	settings->setDefault("keymap_increase_viewing_range_min", "+");
 	settings->setDefault("keymap_decrease_viewing_range_min", "-");


### PR DESCRIPTION
This PR changes default keys:

* Camera: C (old key: F7)
* Minimap: Tab (old key: F9)

Fixes #6374.

It seems the “print stacks” feature has been removed, so there's no change here.