### PR TITLE
SAO limits: Allow SAOs to function outside the set 'mapgen limit'

### DIFF
--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -133,9 +133,6 @@ struct MapgenParams {
 
 	BiomeParams *bparams = nullptr;
 
-	s16 mapgen_edge_min = -MAX_MAP_GENERATION_LIMIT;
-	s16 mapgen_edge_max = MAX_MAP_GENERATION_LIMIT;
-
 	virtual void readParams(const Settings *settings);
 	virtual void writeParams(Settings *settings) const;
 
@@ -143,10 +140,14 @@ struct MapgenParams {
 	s32 getSpawnRangeMax();
 
 private:
-	void calcMapgenEdges();
+	void calcMapgenEdges(s16 mg_limit, s16 csize_n, s16 ccmin, s16 ccmax,
+	s16 ccfmin, s16 ccfmax, s16 *mapgen_edge_min, s16 *mapgen_edge_max);
+	void calcMgEdgesAndSpawnLimit();
 
 	float m_sao_limit_min = -MAX_MAP_GENERATION_LIMIT * BS;
 	float m_sao_limit_max = MAX_MAP_GENERATION_LIMIT * BS;
+	// Initial value set to maximum spawn search range of Server::findSpawnPos()
+	s32 m_spawn_range_max = 4000;
 	bool m_mapgen_edges_calculated = false;
 };
 


### PR DESCRIPTION
Attends to #6984 

Should be backported to 0.4.17 to help against the recent world-generation server attacks. Server owners need to be able to reduce 'mapgen limit' to limit how much world is generated. This ability is also extremely useful for limiting world database size.

The intention of 'mapgen limit', which was hmmmm's intention also, is that it only prevents map generation outside a set limit, it should not do anything else. The limit is often changed and reduced for various reasons and the world outside is deliberately visible and accessible to players. It should function normally in all ways.

Previously, this code calculated the exact world edges corresponding to the 'mapgen limit' setting, and deleted SAO entities at these edges.

With this PR, the same code is used but two different calculations are done:
The first is for the exact world edges corresponding to MAX MAP GENERATION LIMIT (31000), SAOs are now deleted at these edges only.
The second is the previous calculation of the exact world edges coresponding to the 'mapgen limit' setting, this is used to set the maximum new player spawn range which must remain within the set 'mapgen limit'.