### PR TITLE
Item entity: Prevent motion in ignore nodes

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -147,9 +147,9 @@ core.register_entity(":__builtin:item", {
 		})
 		local vel = self.object:getvelocity()
 		local def = node and core.registered_nodes[node.name]
-		-- Ignore is nil -> stop until the block loaded
-		local is_moving = (def and not def.walkable) or
-				vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0
+		-- Avoid entity falling into ignore nodes or unloaded areas
+		local is_moving = node and node.name ~= "ignore" and
+			((def and not def.walkable) or vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0)
 		local is_slippery = false
 
 		if def and def.walkable then


### PR DESCRIPTION
![screenshot_20180201_010053](https://user-images.githubusercontent.com/3686677/35656241-289d8846-06ee-11e8-9349-fcfd4640c2c9.png)

![screenshot_20180201_010257](https://user-images.githubusercontent.com/3686677/35656246-2d62341c-06ee-11e8-8dfc-d8da5155747c.png)

^ Both thrown into ignore nodes at world's edge and base.
Item entity stops moving once in ignore nodes.

See #6984 and #6998 
Partial fix for #2702 and #5824

If #6998 is merged we need to prevent entities falling into ignore nodes.
This PR fixes code that was intended to stop item entities doing this but fails to do so.
The advantage of this over #5889 is that the item is not deleted, it just 'sticks' in ignore and can be picked up again.

To allow testing this PR, by throwing item entities into ignore nodes, the SAO limit check has been temporarily disabled because it automatically deletes any SAO that passes over the mapgen limit.