### PR TITLE
improving error message in src/map.cpp -  closes #6977

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -220,11 +220,8 @@ void Map::setNode(v3s16 p, MapNode & n)
 			<< " while trying to replace \""
 			<< m_nodedef->get(block->getNodeNoCheck(relpos, &temp_bool)).name
 			<< "\" at " << PP(p) << " (block " << PP(blockpos) << ") "
-			<< "with an unrecognized node: (" << " Param0=" << n.getContent()
-			<< ", param1= " << unsigned(n.getParam1())
-			<< ", param2= " << unsigned(n.getParam2())
-			<< ") This is likely because you're missing or disabled "
-			<< "a required mod" << std::endl;
+			<< "with an unrecognized node. This is likely due to "
+			<< "a missing, disabled, unstable, or otherwise malfunctioning mod."<< std::endl;
 		return;
 	}
 	block->setNodeNoCheck(relpos, n);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -220,8 +220,7 @@ void Map::setNode(v3s16 p, MapNode & n)
 			<< " while trying to replace \""
 			<< m_nodedef->get(block->getNodeNoCheck(relpos, &temp_bool)).name
 			<< "\" at " << PP(p) << " (block " << PP(blockpos) << ") "
-			<< "with an unrecognized node. This is likely due to "
-			<< "a missing, disabled, unstable, or otherwise malfunctioning mod."<< std::endl;
+			<< "with an unrecognized node."<< std::endl;
 		return;
 	}
 	block->setNodeNoCheck(relpos, n);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -216,10 +216,15 @@ void Map::setNode(v3s16 p, MapNode & n)
 	// Never allow placing CONTENT_IGNORE, it fucks up stuff
 	if(n.getContent() == CONTENT_IGNORE){
 		bool temp_bool;
-		errorstream<<"Map::setNode(): Not allowing to place CONTENT_IGNORE"
-				<<" while trying to replace \""
-				<<m_nodedef->get(block->getNodeNoCheck(relpos, &temp_bool)).name
-				<<"\" at "<<PP(p)<<" (block "<<PP(blockpos)<<")"<<std::endl;
+		errorstream << "Map::setNode(): Not allowing to place CONTENT_IGNORE"
+			<< " while trying to replace \""
+			<< m_nodedef->get(block->getNodeNoCheck(relpos, &temp_bool)).name
+			<< "\" at " << PP(p) << " (block " << PP(blockpos) << ") "
+			<< "with an unrecognized node: (" << " Param0=" << n.getContent()
+			<< ", param1= " << unsigned(n.getParam1())
+			<< ", param2= " << unsigned(n.getParam2())
+			<< ") This is likely because you're missing or disabled "
+			<< "a required mod" << std::endl;
 		return;
 	}
 	block->setNodeNoCheck(relpos, n);


### PR DESCRIPTION
Adds node params and a better hint in error stream when player attempts to place an unknown node.

This can be a work in progress as it's my first commit ever to minetest, please let me know how to improve it. sofar had suggested propagating the error up the stack and i tried to figure out where last night but kinda gave up after realizing all the node information is already passed into where the error is being logged currently.

thanks for your feedback in advance.