### PR TITLE
Abort when trying to set a not registered node

### DIFF
--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -44,18 +44,6 @@ static const u8 rot_to_wallmounted[] = {
 	MapNode
 */
 
-// Create directly from a nodename
-// If name is unknown, sets CONTENT_IGNORE
-MapNode::MapNode(const NodeDefManager *ndef, const std::string &name,
-		u8 a_param1, u8 a_param2)
-{
-	content_t id = CONTENT_IGNORE;
-	ndef->getId(name, id);
-	param0 = id;
-	param1 = a_param1;
-	param2 = a_param2;
-}
-
 void MapNode::getColor(const ContentFeatures &f, video::SColor *color) const
 {
 	if (f.palette) {

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -145,11 +145,6 @@ struct MapNode
 		  param2(a_param2)
 	{ }
 
-	// Create directly from a nodename
-	// If name is unknown, sets CONTENT_IGNORE
-	MapNode(const NodeDefManager *ndef, const std::string &name,
-			u8 a_param1=0, u8 a_param2=0);
-
 	bool operator==(const MapNode &other) const noexcept
 	{
 		return (param0 == other.param0

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -139,7 +139,12 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 				return false;
 			}
 			// Create rollback node
-			MapNode n(ndef, n_old.name, n_old.param1, n_old.param2);
+			content_t id = CONTENT_IGNORE;
+			if (!ndef->getId(n_old.name, id)) {
+				// The old node is not registered
+				return false;
+			}
+			MapNode n(id, n_old.param1, n_old.param2);
 			// Set rollback node
 			try {
 				if (!map->addNodeWithEvent(p, n)) {
@@ -203,7 +208,7 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 					<< inventory_location << std::endl;
 				return false;
 			}
-			
+
 			// If item was added, take away item, otherwise add removed item
 			if (inventory_add) {
 				// Silently ignore different current item

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1093,7 +1093,7 @@ MapNode readnode(lua_State *L, int index, const NodeDefManager *ndef)
 	lua_getfield(L, index, "name");
 	if (!lua_isstring(L, -1))
 		throw LuaError("Node name is not set or is not a string!");
-	const char *name = lua_tostring(L, -1);
+	std::string name = lua_tostring(L, -1);
 	lua_pop(L, 1);
 
 	u8 param1 = 0;
@@ -1108,7 +1108,11 @@ MapNode readnode(lua_State *L, int index, const NodeDefManager *ndef)
 		param2 = lua_tonumber(L, -1);
 	lua_pop(L, 1);
 
-	return {ndef, name, param1, param2};
+	content_t id = CONTENT_IGNORE;
+	if (!ndef->getId(name, id))
+		throw LuaError("\"" + name + "\" is not a registered node!");
+
+	return {id, param1, param2};
 }
 
 /******************************************************************************/


### PR DESCRIPTION
I removed the MapNode constructor which takes a nodename and gives the node's id or CONTENT_IGNORE
The code which used this constructor (two places) now handles the situation of not registered nodes correctly:
* minetest.set_node and similar functions make minetest crash when a not registered node is passed
* reverting a node with rollback aborts if the node is not registered (tbh, l don't know what that rollback code actually is supposed to do)

fixes #6977