### PR TITLE
Node definition manager refactor

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -413,7 +413,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 				my_cp.Y = m_camera_position.Y + (m_camera_direction.Y * -i);
 
 			// Prevent camera positioned inside nodes
-			INodeDefManager *nodemgr = m_client->ndef();
+			const NodeDefManager *nodemgr = m_client->ndef();
 			MapNode n = m_client->getEnv().getClientMap()
 				.getNodeNoEx(floatToInt(my_cp, BS));
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1798,7 +1798,7 @@ IItemDefManager* Client::getItemDefManager()
 {
 	return m_itemdef;
 }
-INodeDefManager* Client::getNodeDefManager()
+const NodeDefManager* Client::getNodeDefManager()
 {
 	return m_nodedef;
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -71,7 +71,7 @@ Client::Client(
 		IWritableTextureSource *tsrc,
 		IWritableShaderSource *shsrc,
 		IWritableItemDefManager *itemdef,
-		IWritableNodeDefManager *nodedef,
+		NodeDefManager *nodedef,
 		ISoundManager *sound,
 		MtEventManager *event,
 		bool ipv6,

--- a/src/client.h
+++ b/src/client.h
@@ -48,7 +48,7 @@ class MapBlockMesh;
 class IWritableTextureSource;
 class IWritableShaderSource;
 class IWritableItemDefManager;
-class IWritableNodeDefManager;
+class NodeDefManager;
 //class IWritableCraftDefManager;
 class ClientMediaDownloader;
 struct MapDrawControl;
@@ -129,7 +129,7 @@ public:
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,
 			IWritableItemDefManager *itemdef,
-			IWritableNodeDefManager *nodedef,
+			NodeDefManager *nodedef,
 			ISoundManager *sound,
 			MtEventManager *event,
 			bool ipv6,
@@ -477,7 +477,7 @@ private:
 	IWritableTextureSource *m_tsrc;
 	IWritableShaderSource *m_shsrc;
 	IWritableItemDefManager *m_itemdef;
-	IWritableNodeDefManager *m_nodedef;
+	NodeDefManager *m_nodedef;
 	ISoundManager *m_sound;
 	MtEventManager *m_event;
 

--- a/src/client.h
+++ b/src/client.h
@@ -365,7 +365,7 @@ public:
 
 	// IGameDef interface
 	virtual IItemDefManager* getItemDefManager();
-	virtual INodeDefManager* getNodeDefManager();
+	virtual const NodeDefManager* getNodeDefManager();
 	virtual ICraftDefManager* getCraftDefManager();
 	ITextureSource* getTextureSource();
 	virtual IShaderSource* getShaderSource();

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -131,7 +131,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 
 		if (pointed_old.type == POINTEDTHING_NODE) {
 			ClientMap &map = client->getEnv().getClientMap();
-			const INodeDefManager *nodedef = client->getNodeDefManager();
+			const NodeDefManager *nodedef = client->getNodeDefManager();
 			MapNode n = map.getNodeNoEx(pointed_old.node_undersurface);
 
 			if (n.getContent() != CONTENT_IGNORE && nodedef->get(n).name != "unknown") {

--- a/src/clientmap.cpp
+++ b/src/clientmap.cpp
@@ -480,9 +480,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 }
 
 static bool getVisibleBrightness(Map *map, const v3f &p0, v3f dir, float step,
-		float step_multiplier, float start_distance, float end_distance,
-		INodeDefManager *ndef, u32 daylight_factor, float sunlight_min_d,
-		int *result, bool *sunlight_seen)
+	float step_multiplier, float start_distance, float end_distance,
+	const NodeDefManager *ndef, u32 daylight_factor, float sunlight_min_d,
+	int *result, bool *sunlight_seen)
 {
 	int brightness_sum = 0;
 	int brightness_count = 0;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -202,8 +202,8 @@ bool wouldCollideWithCeiling(
 	return false;
 }
 
-static inline void getNeighborConnectingFace(const v3s16 &p, INodeDefManager *nodedef,
-		Map *map, MapNode n, int v, int *neighbors)
+static inline void getNeighborConnectingFace(const v3s16 &p,
+	const NodeDefManager *nodedef, Map *map, MapNode n, int v, int *neighbors)
 {
 	MapNode n2 = map->getNodeNoEx(p);
 	if (nodedef->nodeboxConnects(n, n2, v))
@@ -283,7 +283,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			// Object collides into walkable nodes
 
 			any_position_valid = true;
-			INodeDefManager *nodedef = gamedef->getNodeDefManager();
+			const NodeDefManager *nodedef = gamedef->getNodeDefManager();
 			const ContentFeatures &f = nodedef->get(n);
 
 			if (!f.walkable)

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -874,7 +874,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		if (m_step_distance_counter > 1.5f * BS) {
 			m_step_distance_counter = 0.0f;
 			if (!m_is_local_player && m_prop.makes_footstep_sound) {
-				INodeDefManager *ndef = m_client->ndef();
+				const NodeDefManager *ndef = m_client->ndef();
 				v3s16 p = floatToInt(getPosition() +
 					v3f(0.0f, (m_prop.collisionbox.MinEdge.Y - 0.5f) * BS, 0.0f), BS);
 				MapNode n = m_env->getMap().getNodeNoEx(p);

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -49,7 +49,7 @@ public:
 	MeshMakeData *data;
 	MeshCollector *collector;
 
-	INodeDefManager *nodedef;
+	const NodeDefManager *nodedef;
 	scene::IMeshManipulator *meshmanip;
 
 // options

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -36,7 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 }
 
 class EmergeThread;
-class INodeDefManager;
+class NodeDefManager;
 class Settings;
 
 class BiomeManager;
@@ -53,7 +53,7 @@ struct BlockMakeData {
 	v3s16 blockpos_max;
 	v3s16 blockpos_requested;
 	UniqueQueue<v3s16> transforming_liquid;
-	INodeDefManager *nodedef = nullptr;
+	const NodeDefManager *nodedef = nullptr;
 
 	BlockMakeData() = default;
 
@@ -88,7 +88,7 @@ struct BlockEmergeData {
 
 class EmergeManager {
 public:
-	INodeDefManager *ndef;
+	const NodeDefManager *ndef;
 	bool enable_mapgen_debug_info;
 
 	// Generation Notify

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -87,7 +87,7 @@ float Environment::getTimeOfDayF()
 	Check if a node is pointable
 */
 inline static bool isPointableNode(const MapNode &n,
-			    INodeDefManager *nodedef , bool liquids_pointable)
+	const NodeDefManager *nodedef , bool liquids_pointable)
 {
 	const ContentFeatures &features = nodedef->get(n);
 	return features.pointable ||
@@ -96,7 +96,7 @@ inline static bool isPointableNode(const MapNode &n,
 
 void Environment::continueRaycast(RaycastState *state, PointedThing *result)
 {
-	INodeDefManager *nodedef = getMap().getNodeDefManager();
+	const NodeDefManager *nodedef = getMap().getNodeDefManager();
 	if (state->m_initialization_needed) {
 		// Add objects
 		if (state->m_objects_pointable) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -255,7 +255,7 @@ public:
 class SoundMaker
 {
 	ISoundManager *m_sound;
-	INodeDefManager *m_ndef;
+	const NodeDefManager *m_ndef;
 public:
 	bool makes_footstep_sound;
 	float m_player_step_timer;
@@ -264,7 +264,7 @@ public:
 	SimpleSoundSpec m_player_leftpunch_sound;
 	SimpleSoundSpec m_player_rightpunch_sound;
 
-	SoundMaker(ISoundManager *sound, INodeDefManager *ndef):
+	SoundMaker(ISoundManager *sound, const NodeDefManager *ndef):
 		m_sound(sound),
 		m_ndef(ndef),
 		makes_footstep_sound(true),
@@ -3065,7 +3065,7 @@ PointedThing Game::updatePointedThing(
 
 	ClientEnvironment &env = client->getEnv();
 	ClientMap &map = env.getClientMap();
-	INodeDefManager *nodedef = map.getNodeDefManager();
+	const NodeDefManager *nodedef = map.getNodeDefManager();
 
 	runData.selected_object = NULL;
 
@@ -3251,7 +3251,7 @@ bool Game::nodePlacementPrediction(const ItemDefinition &playeritem_def,
 	const ItemStack &playeritem, const v3s16 &nodepos, const v3s16 &neighbourpos)
 {
 	std::string prediction = playeritem_def.node_placement_prediction;
-	INodeDefManager *nodedef = client->ndef();
+	const NodeDefManager *nodedef = client->ndef();
 	ClientMap &map = client->getEnv().getClientMap();
 	MapNode node;
 	bool is_valid_position;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -809,7 +809,7 @@ private:
 
 	// When created, these will be filled with data received from the server
 	IWritableItemDefManager *itemdef_manager = nullptr;
-	IWritableNodeDefManager *nodedef_manager = nullptr;
+	NodeDefManager *nodedef_manager = nullptr;
 
 	GameOnDemandSoundFetcher soundfetcher; // useful when testing
 	ISoundManager *sound = nullptr;

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 
 class IItemDefManager;
-class INodeDefManager;
+class NodeDefManager;
 class ICraftDefManager;
 class ITextureSource;
 class ISoundManager;
@@ -53,7 +53,7 @@ public:
 	// These are thread-safe IF they are not edited while running threads.
 	// Thus, first they are set up and then they are only read.
 	virtual IItemDefManager* getItemDefManager()=0;
-	virtual INodeDefManager* getNodeDefManager()=0;
+	virtual const NodeDefManager* getNodeDefManager()=0;
 	virtual ICraftDefManager* getCraftDefManager()=0;
 
 	// Used for keeping track of names/ids of unknown nodes
@@ -67,7 +67,7 @@ public:
 
 	// Shorthands
 	IItemDefManager  *idef()     { return getItemDefManager(); }
-	INodeDefManager  *ndef()     { return getNodeDefManager(); }
+	const NodeDefManager  *ndef() { return getNodeDefManager(); }
 	ICraftDefManager *cdef()     { return getCraftDefManager(); }
 
 	MtEventManager   *event()    { return getEventManager(); }

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -70,7 +70,7 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 		v3s16(-1, 0, -1)
 	};
 
-	INodeDefManager *nodemgr = m_client->ndef();
+	const NodeDefManager *nodemgr = m_client->ndef();
 	MapNode node;
 	bool is_valid_position;
 	bool new_sneak_node_exists = m_sneak_node_exists;
@@ -181,7 +181,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	}
 
 	Map *map = &env->getMap();
-	INodeDefManager *nodemgr = m_client->ndef();
+	const NodeDefManager *nodemgr = m_client->ndef();
 
 	v3f position = getPosition();
 
@@ -762,7 +762,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		std::vector<CollisionInfo> *collision_info)
 {
 	Map *map = &env->getMap();
-	INodeDefManager *nodemgr = m_client->ndef();
+	const NodeDefManager *nodemgr = m_client->ndef();
 
 	v3f position = getPosition();
 
@@ -1063,7 +1063,7 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 
 	float slip_factor = 1.0f;
 	// Slip on slippery nodes
-	const INodeDefManager *nodemgr = env->getGameDef()->ndef();
+	const NodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
 	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(
 			floatToInt(getPosition() - v3f(0, 0.05f * BS, 0), BS)));

--- a/src/map.h
+++ b/src/map.h
@@ -178,7 +178,7 @@ public:
 	virtual MapBlock * emergeBlock(v3s16 p, bool create_blank=true)
 	{ return getBlockNoCreateNoEx(p); }
 
-	inline INodeDefManager * getNodeDefManager() { return m_nodedef; }
+	inline const NodeDefManager * getNodeDefManager() { return m_nodedef; }
 
 	// Returns InvalidPositionException if not found
 	bool isNodeUnderground(v3s16 p);
@@ -311,7 +311,7 @@ protected:
 	UniqueQueue<v3s16> m_transforming_liquid;
 
 	// This stores the properties of the nodes on the map.
-	INodeDefManager *m_nodedef;
+	const NodeDefManager *m_nodedef;
 
 	bool isOccluded(v3s16 p0, v3s16 p1, float step, float stepfac,
 			float start_off, float end_off, u32 needed_count);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -132,6 +132,7 @@ std::string MapBlock::getModifiedReasonString()
 	return reason;
 }
 
+
 void MapBlock::copyTo(VoxelManipulator &dst)
 {
 	v3s16 data_size(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE);
@@ -154,7 +155,7 @@ void MapBlock::copyFrom(VoxelManipulator &dst)
 
 void MapBlock::actuallyUpdateDayNightDiff()
 {
-	INodeDefManager *nodemgr = m_gamedef->ndef();
+	const NodeDefManager *nodemgr = m_gamedef->ndef();
 
 	// Running this function un-expires m_day_night_differs
 	m_day_night_differs_expired = false;
@@ -252,7 +253,7 @@ s16 MapBlock::getGroundLevel(v2s16 p2d)
 // mapblocks.
 static content_t getBlockNodeIdMapping_mapping[USHRT_MAX + 1];
 static void getBlockNodeIdMapping(NameIdMapping *nimap, MapNode *nodes,
-		INodeDefManager *nodedef)
+	const NodeDefManager *nodedef)
 {
 	memset(getBlockNodeIdMapping_mapping, 0xFF, (USHRT_MAX + 1) * sizeof(content_t));
 
@@ -294,7 +295,7 @@ static void getBlockNodeIdMapping(NameIdMapping *nimap, MapNode *nodes,
 static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 		IGameDef *gamedef)
 {
-	INodeDefManager *nodedef = gamedef->ndef();
+	const NodeDefManager *nodedef = gamedef->ndef();
 	// This means the block contains incorrect ids, and we contain
 	// the information to convert those to names.
 	// nodedef contains information to convert our names to globally
@@ -741,7 +742,7 @@ void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 
 	// Legacy data changes
 	// This code has to convert from pre-22 to post-22 format.
-	INodeDefManager *nodedef = m_gamedef->ndef();
+	const NodeDefManager *nodedef = m_gamedef->ndef();
 	for(u32 i=0; i<nodecount; i++)
 	{
 		const ContentFeatures &f = nodedef->get(data[i].getContent());

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -127,7 +127,7 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	Single light bank.
 */
 static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
-		INodeDefManager *ndef)
+	const NodeDefManager *ndef)
 {
 	u8 light = n.getLight(bank, ndef);
 
@@ -149,7 +149,7 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 	Calculate non-smooth lighting at interior of node.
 	Both light banks.
 */
-u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef)
+u16 getInteriorLight(MapNode n, s32 increment, const NodeDefManager *ndef)
 {
 	u16 day = getInteriorLight(LIGHTBANK_DAY, n, increment, ndef);
 	u16 night = getInteriorLight(LIGHTBANK_NIGHT, n, increment, ndef);
@@ -161,7 +161,7 @@ u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef)
 	Single light bank.
 */
 static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
-		v3s16 face_dir, INodeDefManager *ndef)
+	v3s16 face_dir, const NodeDefManager *ndef)
 {
 	u8 light;
 	u8 l1 = n.getLight(bank, ndef);
@@ -184,7 +184,8 @@ static u8 getFaceLight(enum LightBank bank, MapNode n, MapNode n2,
 	Calculate non-smooth lighting at face of node.
 	Both light banks.
 */
-u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef)
+u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir,
+	const NodeDefManager *ndef)
 {
 	u16 day = getFaceLight(LIGHTBANK_DAY, n, n2, face_dir, ndef);
 	u16 night = getFaceLight(LIGHTBANK_NIGHT, n, n2, face_dir, ndef);
@@ -198,7 +199,7 @@ u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef)
 static u16 getSmoothLightCombined(const v3s16 &p,
 	const std::array<v3s16,8> &dirs, MeshMakeData *data)
 {
-	INodeDefManager *ndef = data->m_client->ndef();
+	const NodeDefManager *ndef = data->m_client->ndef();
 
 	u16 ambient_occlusion = 0;
 	u16 light_count = 0;
@@ -672,7 +673,7 @@ static void makeFastFace(const TileSpec &tile, u16 li0, u16 li1, u16 li2, u16 li
 	TODO: Add 3: Both faces drawn with backface culling, remove equivalent
 */
 static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
-		INodeDefManager *ndef)
+	const NodeDefManager *ndef)
 {
 	*equivalent = false;
 
@@ -717,7 +718,7 @@ static u8 face_contents(content_t m1, content_t m2, bool *equivalent,
 */
 void getNodeTileN(MapNode mn, v3s16 p, u8 tileindex, MeshMakeData *data, TileSpec &tile)
 {
-	INodeDefManager *ndef = data->m_client->ndef();
+	const NodeDefManager *ndef = data->m_client->ndef();
 	const ContentFeatures &f = ndef->get(mn);
 	tile = f.tiles[tileindex];
 	bool has_crack = p == data->m_crack_pos_relative;
@@ -737,7 +738,7 @@ void getNodeTileN(MapNode mn, v3s16 p, u8 tileindex, MeshMakeData *data, TileSpe
 */
 void getNodeTile(MapNode mn, v3s16 p, v3s16 dir, MeshMakeData *data, TileSpec &tile)
 {
-	INodeDefManager *ndef = data->m_client->ndef();
+	const NodeDefManager *ndef = data->m_client->ndef();
 
 	// Direction must be (1,0,0), (-1,0,0), (0,1,0), (0,-1,0),
 	// (0,0,1), (0,0,-1) or (0,0,0)
@@ -810,7 +811,7 @@ static void getTileInfo(
 	)
 {
 	VoxelManipulator &vmanip = data->m_vmanip;
-	INodeDefManager *ndef = data->m_client->ndef();
+	const NodeDefManager *ndef = data->m_client->ndef();
 	v3s16 blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
 
 	const MapNode &n0 = vmanip.getNodeRefUnsafe(blockpos_nodes + p);

--- a/src/mapblock_mesh.h
+++ b/src/mapblock_mesh.h
@@ -233,8 +233,9 @@ struct MeshCollector
 video::SColor encode_light(u16 light, u8 emissive_light);
 
 // Compute light at node
-u16 getInteriorLight(MapNode n, s32 increment, INodeDefManager *ndef);
-u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir, INodeDefManager *ndef);
+u16 getInteriorLight(MapNode n, s32 increment, const NodeDefManager *ndef);
+u16 getFaceLight(MapNode n, MapNode n2, v3s16 face_dir,
+	const NodeDefManager *ndef);
 u16 getSmoothLightSolid(const v3s16 &p, const v3s16 &face_dir, const v3s16 &corner, MeshMakeData *data);
 u16 getSmoothLightTransparent(const v3s16 &p, const v3s16 &corner, MeshMakeData *data);
 

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -36,7 +36,7 @@ static NoiseParams nparams_caveliquids(0, 1, v3f(150.0, 150.0, 150.0), 776, 3, 0
 ////
 
 CavesNoiseIntersection::CavesNoiseIntersection(
-	INodeDefManager *nodedef, BiomeManager *biomemgr, v3s16 chunksize,
+	const NodeDefManager *nodedef, BiomeManager *biomemgr, v3s16 chunksize,
 	NoiseParams *np_cave1, NoiseParams *np_cave2, s32 seed, float cave_width)
 {
 	assert(nodedef);
@@ -174,7 +174,7 @@ void CavesNoiseIntersection::generateCaves(MMVManip *vm,
 ////
 
 CavernsNoise::CavernsNoise(
-	INodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
+	const NodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
 	s32 seed, float cavern_limit, float cavern_taper, float cavern_threshold)
 {
 	assert(nodedef);
@@ -272,7 +272,7 @@ bool CavernsNoise::generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax)
 ////
 
 CavesRandomWalk::CavesRandomWalk(
-	INodeDefManager *ndef,
+	const NodeDefManager *ndef,
 	GenerateNotifier *gennotify,
 	s32 seed,
 	int water_level,
@@ -585,7 +585,7 @@ inline bool CavesRandomWalk::isPosAboveSurface(v3s16 p)
 //// CavesV6
 ////
 
-CavesV6::CavesV6(INodeDefManager *ndef, GenerateNotifier *gennotify,
+CavesV6::CavesV6(const NodeDefManager *ndef, GenerateNotifier *gennotify,
 	int water_level, content_t water_source, content_t lava_source)
 {
 	assert(ndef);

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -39,15 +39,15 @@ class GenerateNotifier;
 class CavesNoiseIntersection
 {
 public:
-	CavesNoiseIntersection(INodeDefManager *nodedef, BiomeManager *biomemgr,
-			v3s16 chunksize, NoiseParams *np_cave1, NoiseParams *np_cave2,
-			s32 seed, float cave_width);
+	CavesNoiseIntersection(const NodeDefManager *nodedef,
+		BiomeManager *biomemgr, v3s16 chunksize, NoiseParams *np_cave1,
+		NoiseParams *np_cave2, s32 seed, float cave_width);
 	~CavesNoiseIntersection();
 
 	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, u8 *biomemap);
 
 private:
-	INodeDefManager *m_ndef;
+	const NodeDefManager *m_ndef;
 	BiomeManager *m_bmgr;
 
 	// configurable parameters
@@ -68,15 +68,15 @@ private:
 class CavernsNoise
 {
 public:
-	CavernsNoise(INodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
-			s32 seed, float cavern_limit, float cavern_taper,
-			float cavern_threshold);
+	CavernsNoise(const NodeDefManager *nodedef, v3s16 chunksize,
+		NoiseParams *np_cavern, s32 seed, float cavern_limit,
+		float cavern_taper, float cavern_threshold);
 	~CavernsNoise();
 
 	bool generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax);
 
 private:
-	INodeDefManager *m_ndef;
+	const NodeDefManager *m_ndef;
 
 	// configurable parameters
 	v3s16 m_csize;
@@ -111,7 +111,7 @@ class CavesRandomWalk
 {
 public:
 	MMVManip *vm;
-	INodeDefManager *ndef;
+	const NodeDefManager *ndef;
 	GenerateNotifier *gennotify;
 	s16 *heightmap;
 
@@ -153,10 +153,10 @@ public:
 
 	// ndef is a mandatory parameter.
 	// If gennotify is NULL, generation events are not logged.
-	CavesRandomWalk(INodeDefManager *ndef, GenerateNotifier *gennotify = NULL,
-			s32 seed = 0, int water_level = 1,
-			content_t water_source = CONTENT_IGNORE,
-			content_t lava_source = CONTENT_IGNORE, int lava_depth = -256);
+	CavesRandomWalk(const NodeDefManager *ndef, GenerateNotifier *gennotify =
+		NULL, s32 seed = 0, int water_level = 1, content_t water_source =
+		CONTENT_IGNORE, content_t lava_source = CONTENT_IGNORE,
+		int lava_depth = -256);
 
 	// vm and ps are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to
@@ -188,7 +188,7 @@ class CavesV6
 {
 public:
 	MMVManip *vm;
-	INodeDefManager *ndef;
+	const NodeDefManager *ndef;
 	GenerateNotifier *gennotify;
 	PseudoRandom *ps;
 	PseudoRandom *ps2;
@@ -224,7 +224,7 @@ public:
 
 	// ndef is a mandatory parameter.
 	// If gennotify is NULL, generation events are not logged.
-	CavesV6(INodeDefManager *ndef, GenerateNotifier *gennotify = NULL,
+	CavesV6(const NodeDefManager *ndef, GenerateNotifier *gennotify = NULL,
 			int water_level = 1, content_t water_source = CONTENT_IGNORE,
 			content_t lava_source = CONTENT_IGNORE);
 

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -37,7 +37,7 @@ NoiseParams nparams_dungeon_alt_wall(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6,
 ///////////////////////////////////////////////////////////////////////////////
 
 
-DungeonGen::DungeonGen(INodeDefManager *ndef,
+DungeonGen::DungeonGen(const NodeDefManager *ndef,
 	GenerateNotifier *gennotify, DungeonParams *dparams)
 {
 	assert(ndef);

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		VMANIP_FLAG_DUNGEON_INSIDE|VMANIP_FLAG_DUNGEON_PRESERVE)
 
 class MMVManip;
-class INodeDefManager;
+class NodeDefManager;
 
 v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs);
 v3s16 turn_xz(v3s16 olddir, int t);
@@ -69,7 +69,7 @@ struct DungeonParams {
 class DungeonGen {
 public:
 	MMVManip *vm;
-	INodeDefManager *ndef;
+	const NodeDefManager *ndef;
 	GenerateNotifier *gennotify;
 
 	u32 blockseed;
@@ -83,7 +83,7 @@ public:
 	v3s16 m_pos;
 	v3s16 m_dir;
 
-	DungeonGen(INodeDefManager *ndef,
+	DungeonGen(const NodeDefManager *ndef,
 		GenerateNotifier *gennotify, DungeonParams *dparams);
 
 	void generate(MMVManip *vm, u32 bseed,

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -41,7 +41,7 @@ typedef u8 biome_t;  // copy from mg_biome.h to avoid an unnecessary include
 
 class Settings;
 class MMVManip;
-class INodeDefManager;
+class NodeDefManager;
 
 extern FlagDesc flagdesc_mapgen[];
 extern FlagDesc flagdesc_gennotify[];
@@ -170,7 +170,7 @@ public:
 	int id = -1;
 
 	MMVManip *vm = nullptr;
-	INodeDefManager *ndef = nullptr;
+	const NodeDefManager *ndef = nullptr;
 
 	u32 blockseed;
 	s16 *heightmap = nullptr;

--- a/src/mapgen/mapgen_singlenode.cpp
+++ b/src/mapgen/mapgen_singlenode.cpp
@@ -35,7 +35,7 @@ MapgenSinglenode::MapgenSinglenode(int mapgenid,
 {
 	flags = params->flags;
 
-	INodeDefManager *ndef = emerge->ndef;
+	const NodeDefManager *ndef = emerge->ndef;
 
 	c_node = ndef->getId("mapgen_singlenode");
 	if (c_node == CONTENT_IGNORE)

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -85,7 +85,7 @@ MapgenV6::MapgenV6(int mapgenid, MapgenV6Params *params, EmergeManager *emerge)
 			csize.X + 2 * MAP_BLOCKSIZE, csize.Y + 2 * MAP_BLOCKSIZE);
 
 	//// Resolve nodes to be used
-	INodeDefManager *ndef = emerge->ndef;
+	const NodeDefManager *ndef = emerge->ndef;
 
 	c_stone           = ndef->getId("mapgen_stone");
 	c_dirt            = ndef->getId("mapgen_dirt");

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -427,7 +427,7 @@ bool Schematic::serializeToLua(std::ostream *os,
 
 
 bool Schematic::loadSchematicFromFile(const std::string &filename,
-	INodeDefManager *ndef, StringMap *replace_names)
+	const NodeDefManager *ndef, StringMap *replace_names)
 {
 	std::ifstream is(filename.c_str(), std::ios_base::binary);
 	if (!is.good()) {
@@ -461,7 +461,7 @@ bool Schematic::loadSchematicFromFile(const std::string &filename,
 
 
 bool Schematic::saveSchematicToFile(const std::string &filename,
-	INodeDefManager *ndef)
+	const NodeDefManager *ndef)
 {
 	MapNode *orig_schemdata = schemdata;
 	std::vector<std::string> ndef_nodenames;
@@ -554,7 +554,7 @@ void Schematic::applyProbabilities(v3s16 p0,
 
 
 void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,
-	std::vector<std::string> *usednodes, INodeDefManager *ndef)
+	std::vector<std::string> *usednodes, const NodeDefManager *ndef)
 {
 	std::unordered_map<content_t, content_t> nodeidmap;
 	content_t numids = 0;

--- a/src/mapgen/mg_schematic.h
+++ b/src/mapgen/mg_schematic.h
@@ -97,9 +97,10 @@ public:
 
 	virtual void resolveNodeNames();
 
-	bool loadSchematicFromFile(const std::string &filename, INodeDefManager *ndef,
-		StringMap *replace_names=NULL);
-	bool saveSchematicToFile(const std::string &filename, INodeDefManager *ndef);
+	bool loadSchematicFromFile(const std::string &filename,
+		const NodeDefManager *ndef, StringMap *replace_names = NULL);
+	bool saveSchematicToFile(const std::string &filename,
+		const NodeDefManager *ndef);
 	bool getSchematicFromMap(Map *map, v3s16 p1, v3s16 p2);
 
 	bool deserializeFromMts(std::istream *is, std::vector<std::string> *names);
@@ -144,4 +145,4 @@ private:
 };
 
 void generate_nodelist_and_update_ids(MapNode *nodes, size_t nodecount,
-	std::vector<std::string> *usednodes, INodeDefManager *ndef);
+	std::vector<std::string> *usednodes, const NodeDefManager *ndef);

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -33,8 +33,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 namespace treegen
 {
 
-void make_tree(MMVManip &vmanip, v3s16 p0,
-		bool is_apple_tree, INodeDefManager *ndef, s32 seed)
+void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
+	const NodeDefManager *ndef, s32 seed)
 {
 	/*
 		NOTE: Tree-placing code is currently duplicated in the engine
@@ -115,7 +115,7 @@ void make_tree(MMVManip &vmanip, v3s16 p0,
 
 // L-System tree LUA spawner
 treegen::error spawn_ltree(ServerEnvironment *env, v3s16 p0,
-		INodeDefManager *ndef, const TreeDef &tree_definition)
+	const NodeDefManager *ndef, const TreeDef &tree_definition)
 {
 	ServerMap *map = &env->getServerMap();
 	std::map<v3s16, MapBlock*> modified_blocks;
@@ -142,7 +142,7 @@ treegen::error spawn_ltree(ServerEnvironment *env, v3s16 p0,
 
 //L-System tree generator
 treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
-		INodeDefManager *ndef, TreeDef tree_definition)
+	const NodeDefManager *ndef, TreeDef tree_definition)
 {
 	MapNode dirtnode(ndef->getId("mapgen_dirt"));
 	s32 seed;
@@ -648,7 +648,8 @@ v3f transposeMatrix(irr::core::matrix4 M, v3f v)
 }
 
 
-void make_jungletree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, s32 seed)
+void make_jungletree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
+	s32 seed)
 {
 	/*
 		NOTE: Tree-placing code is currently duplicated in the engine
@@ -747,7 +748,8 @@ void make_jungletree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, s32 seed
 }
 
 
-void make_pine_tree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef, s32 seed)
+void make_pine_tree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
+	s32 seed)
 {
 	/*
 		NOTE: Tree-placing code is currently duplicated in the engine

--- a/src/mapgen/treegen.h
+++ b/src/mapgen/treegen.h
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "noise.h"
 
 class MMVManip;
-class INodeDefManager;
+class NodeDefManager;
 class ServerEnvironment;
 
 
@@ -61,20 +61,20 @@ namespace treegen {
 
 	// Add default tree
 	void make_tree(MMVManip &vmanip, v3s16 p0,
-		bool is_apple_tree, INodeDefManager *ndef, s32 seed);
+		bool is_apple_tree, const NodeDefManager *ndef, s32 seed);
 	// Add jungle tree
 	void make_jungletree(MMVManip &vmanip, v3s16 p0,
-		INodeDefManager *ndef, s32 seed);
+		const NodeDefManager *ndef, s32 seed);
 	// Add pine tree
 	void make_pine_tree(MMVManip &vmanip, v3s16 p0,
-		INodeDefManager *ndef, s32 seed);
+		const NodeDefManager *ndef, s32 seed);
 
 	// Add L-Systems tree (used by engine)
-	treegen::error make_ltree(MMVManip &vmanip, v3s16 p0, INodeDefManager *ndef,
-		TreeDef tree_definition);
+	treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
+		const NodeDefManager *ndef, TreeDef tree_definition);
 	// Spawn L-systems tree from LUA
-	treegen::error spawn_ltree (ServerEnvironment *env, v3s16 p0, INodeDefManager *ndef,
-		const TreeDef &tree_definition);
+	treegen::error spawn_ltree (ServerEnvironment *env, v3s16 p0,
+		const NodeDefManager *ndef, const TreeDef &tree_definition);
 
 	// L-System tree gen helper functions
 	void tree_node_placement(MMVManip &vmanip, v3f p0,

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -46,7 +46,7 @@ static const u8 rot_to_wallmounted[] = {
 
 // Create directly from a nodename
 // If name is unknown, sets CONTENT_IGNORE
-MapNode::MapNode(INodeDefManager *ndef, const std::string &name,
+MapNode::MapNode(const NodeDefManager *ndef, const std::string &name,
 		u8 a_param1, u8 a_param2)
 {
 	content_t id = CONTENT_IGNORE;
@@ -84,12 +84,13 @@ void MapNode::setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f
 		assert("Invalid light bank" == NULL);
 }
 
-void MapNode::setLight(enum LightBank bank, u8 a_light, INodeDefManager *nodemgr)
+void MapNode::setLight(enum LightBank bank, u8 a_light,
+	const NodeDefManager *nodemgr)
 {
 	setLight(bank, a_light, nodemgr->get(*this));
 }
 
-bool MapNode::isLightDayNightEq(INodeDefManager *nodemgr) const
+bool MapNode::isLightDayNightEq(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	bool isEqual;
@@ -105,7 +106,7 @@ bool MapNode::isLightDayNightEq(INodeDefManager *nodemgr) const
 	return isEqual;
 }
 
-u8 MapNode::getLight(enum LightBank bank, INodeDefManager *nodemgr) const
+u8 MapNode::getLight(enum LightBank bank, const NodeDefManager *nodemgr) const
 {
 	// Select the brightest of [light source, propagated light]
 	const ContentFeatures &f = nodemgr->get(*this);
@@ -132,7 +133,8 @@ u8 MapNode::getLightNoChecks(enum LightBank bank, const ContentFeatures *f) cons
 	             bank == LIGHTBANK_DAY ? param1 & 0x0f : (param1 >> 4) & 0x0f);
 }
 
-bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const
+bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight,
+	const NodeDefManager *nodemgr) const
 {
 	// Select the brightest of [light source, propagated light]
 	const ContentFeatures &f = nodemgr->get(*this);
@@ -153,7 +155,8 @@ bool MapNode::getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodem
 	return f.param_type == CPT_LIGHT || f.light_source != 0;
 }
 
-u8 MapNode::getFaceDir(INodeDefManager *nodemgr, bool allow_wallmounted) const
+u8 MapNode::getFaceDir(const NodeDefManager *nodemgr,
+	bool allow_wallmounted) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_FACEDIR ||
@@ -165,7 +168,7 @@ u8 MapNode::getFaceDir(INodeDefManager *nodemgr, bool allow_wallmounted) const
 	return 0;
 }
 
-u8 MapNode::getWallMounted(INodeDefManager *nodemgr) const
+u8 MapNode::getWallMounted(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.param_type_2 == CPT2_WALLMOUNTED ||
@@ -174,7 +177,7 @@ u8 MapNode::getWallMounted(INodeDefManager *nodemgr) const
 	return 0;
 }
 
-v3s16 MapNode::getWallMountedDir(INodeDefManager *nodemgr) const
+v3s16 MapNode::getWallMountedDir(const NodeDefManager *nodemgr) const
 {
 	switch(getWallMounted(nodemgr))
 	{
@@ -187,7 +190,7 @@ v3s16 MapNode::getWallMountedDir(INodeDefManager *nodemgr) const
 	}
 }
 
-void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
+void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 {
 	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
 
@@ -244,7 +247,8 @@ void MapNode::rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot)
 }
 
 void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
-		INodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes, u8 neighbors = 0)
+	const NodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes,
+	u8 neighbors = 0)
 {
 	std::vector<aabb3f> &boxes = *p_boxes;
 
@@ -518,7 +522,7 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 }
 
 static inline void getNeighborConnectingFace(
-	const v3s16 &p, INodeDefManager *nodedef,
+	const v3s16 &p, const NodeDefManager *nodedef,
 	Map *map, MapNode n, u8 bitmask, u8 *neighbors)
 {
 	MapNode n2 = map->getNodeNoEx(p);
@@ -528,7 +532,7 @@ static inline void getNeighborConnectingFace(
 
 u8 MapNode::getNeighbors(v3s16 p, Map *map)
 {
-	INodeDefManager *nodedef=map->getNodeDefManager();
+	const NodeDefManager *nodedef = map->getNodeDefManager();
 	u8 neighbors = 0;
 	const ContentFeatures &f = nodedef->get(*this);
 	// locate possible neighboring nodes to connect to
@@ -562,13 +566,15 @@ u8 MapNode::getNeighbors(v3s16 p, Map *map)
 	return neighbors;
 }
 
-void MapNode::getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
+void MapNode::getNodeBoxes(const NodeDefManager *nodemgr,
+	std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	transformNodeBox(*this, f.node_box, nodemgr, boxes, neighbors);
 }
 
-void MapNode::getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
+void MapNode::getCollisionBoxes(const NodeDefManager *nodemgr,
+	std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	if (f.collision_box.fixed.empty())
@@ -577,13 +583,14 @@ void MapNode::getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *b
 		transformNodeBox(*this, f.collision_box, nodemgr, boxes, neighbors);
 }
 
-void MapNode::getSelectionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors)
+void MapNode::getSelectionBoxes(const NodeDefManager *nodemgr,
+	std::vector<aabb3f> *boxes, u8 neighbors)
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	transformNodeBox(*this, f.selection_box, nodemgr, boxes, neighbors);
 }
 
-u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const
+u8 MapNode::getMaxLevel(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
@@ -594,7 +601,7 @@ u8 MapNode::getMaxLevel(INodeDefManager *nodemgr) const
 	return 0;
 }
 
-u8 MapNode::getLevel(INodeDefManager *nodemgr) const
+u8 MapNode::getLevel(const NodeDefManager *nodemgr) const
 {
 	const ContentFeatures &f = nodemgr->get(*this);
 	// todo: after update in all games leave only if (f.param_type_2 ==
@@ -615,7 +622,7 @@ u8 MapNode::getLevel(INodeDefManager *nodemgr) const
 	return 0;
 }
 
-u8 MapNode::setLevel(INodeDefManager *nodemgr, s8 level)
+u8 MapNode::setLevel(const NodeDefManager *nodemgr, s8 level)
 {
 	u8 rest = 0;
 	if (level < 1) {
@@ -643,7 +650,7 @@ u8 MapNode::setLevel(INodeDefManager *nodemgr, s8 level)
 	return rest;
 }
 
-u8 MapNode::addLevel(INodeDefManager *nodemgr, s8 add)
+u8 MapNode::addLevel(const NodeDefManager *nodemgr, s8 add)
 {
 	s8 level = getLevel(nodemgr);
 	if (add == 0) level = 1;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <vector>
 
-class INodeDefManager;
+class NodeDefManager;
 class Map;
 
 /*
@@ -147,7 +147,7 @@ struct MapNode
 
 	// Create directly from a nodename
 	// If name is unknown, sets CONTENT_IGNORE
-	MapNode(INodeDefManager *ndef, const std::string &name,
+	MapNode(const NodeDefManager *ndef, const std::string &name,
 			u8 a_param1=0, u8 a_param2=0);
 
 	bool operator==(const MapNode &other)
@@ -193,16 +193,17 @@ struct MapNode
 
 	void setLight(enum LightBank bank, u8 a_light, const ContentFeatures &f);
 
-	void setLight(enum LightBank bank, u8 a_light, INodeDefManager *nodemgr);
+	void setLight(enum LightBank bank, u8 a_light,
+		const NodeDefManager *nodemgr);
 
 	/**
 	 * Check if the light value for night differs from the light value for day.
 	 *
 	 * @return If the light values are equal, returns true; otherwise false
 	 */
-	bool isLightDayNightEq(INodeDefManager *nodemgr) const;
+	bool isLightDayNightEq(const NodeDefManager *nodemgr) const;
 
-	u8 getLight(enum LightBank bank, INodeDefManager *nodemgr) const;
+	u8 getLight(enum LightBank bank, const NodeDefManager *nodemgr) const;
 
 	/*!
 	 * Returns the node's light level from param1.
@@ -212,15 +213,15 @@ struct MapNode
 	u8 getLightRaw(enum LightBank bank, const ContentFeatures &f) const;
 
 	/**
-	 * This function differs from getLight(enum LightBank bank, INodeDefManager *nodemgr)
+	 * This function differs from getLight(enum LightBank bank, NodeDefManager *nodemgr)
 	 * in that the ContentFeatures of the node in question are not retrieved by
 	 * the function itself.  Thus, if you have already called nodemgr->get() to
 	 * get the ContentFeatures you pass it to this function instead of the
-	 * function getting ContentFeatures itself.  Since INodeDefManager::get()
+	 * function getting ContentFeatures itself.  Since NodeDefManager::get()
 	 * is relatively expensive this can lead to significant performance
 	 * improvements in some situations.  Call this function if (and only if)
 	 * you have already retrieved the ContentFeatures by calling
-	 * INodeDefManager::get() for the node you're working with and the
+	 * NodeDefManager::get() for the node you're working with and the
 	 * pre-conditions listed are true.
 	 *
 	 * @pre f != NULL
@@ -228,11 +229,12 @@ struct MapNode
 	 */
 	u8 getLightNoChecks(LightBank bank, const ContentFeatures *f) const;
 
-	bool getLightBanks(u8 &lightday, u8 &lightnight, INodeDefManager *nodemgr) const;
+	bool getLightBanks(u8 &lightday, u8 &lightnight,
+		const NodeDefManager *nodemgr) const;
 
 	// 0 <= daylight_factor <= 1000
 	// 0 <= return value <= LIGHT_SUN
-	u8 getLightBlend(u32 daylight_factor, INodeDefManager *nodemgr) const
+	u8 getLightBlend(u32 daylight_factor, const NodeDefManager *nodemgr) const
 	{
 		u8 lightday = 0;
 		u8 lightnight = 0;
@@ -240,11 +242,12 @@ struct MapNode
 		return blend_light(daylight_factor, lightday, lightnight);
 	}
 
-	u8 getFaceDir(INodeDefManager *nodemgr, bool allow_wallmounted = false) const;
-	u8 getWallMounted(INodeDefManager *nodemgr) const;
-	v3s16 getWallMountedDir(INodeDefManager *nodemgr) const;
+	u8 getFaceDir(const NodeDefManager *nodemgr,
+		bool allow_wallmounted = false) const;
+	u8 getWallMounted(const NodeDefManager *nodemgr) const;
+	v3s16 getWallMountedDir(const NodeDefManager *nodemgr) const;
 
-	void rotateAlongYAxis(INodeDefManager *nodemgr, Rotation rot);
+	void rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot);
 
 	/*!
 	 * Checks which neighbors does this node connect to.
@@ -256,25 +259,28 @@ struct MapNode
 	/*
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))
 	*/
-	void getNodeBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+	void getNodeBoxes(const NodeDefManager *nodemgr, std::vector<aabb3f> *boxes,
+		u8 neighbors = 0);
 
 	/*
 		Gets list of selection boxes
 	*/
-	void getSelectionBoxes(INodeDefManager *nodemg, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+	void getSelectionBoxes(const NodeDefManager *nodemg,
+		std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Gets list of collision boxes
 	*/
-	void getCollisionBoxes(INodeDefManager *nodemgr, std::vector<aabb3f> *boxes, u8 neighbors = 0);
+	void getCollisionBoxes(const NodeDefManager *nodemgr,
+		std::vector<aabb3f> *boxes, u8 neighbors = 0);
 
 	/*
 		Liquid helpers
 	*/
-	u8 getMaxLevel(INodeDefManager *nodemgr) const;
-	u8 getLevel(INodeDefManager *nodemgr) const;
-	u8 setLevel(INodeDefManager *nodemgr, s8 level = 1);
-	u8 addLevel(INodeDefManager *nodemgr, s8 add = 1);
+	u8 getMaxLevel(const NodeDefManager *nodemgr) const;
+	u8 getLevel(const NodeDefManager *nodemgr) const;
+	u8 setLevel(const NodeDefManager *nodemgr, s8 level = 1);
+	u8 addLevel(const NodeDefManager *nodemgr, s8 add = 1);
 
 	/*
 		Serialization functions

--- a/src/minimap.h
+++ b/src/minimap.h
@@ -152,7 +152,7 @@ public:
 private:
 	ITextureSource *m_tsrc;
 	IShaderSource *m_shdrsrc;
-	INodeDefManager *m_ndef;
+	const NodeDefManager *m_ndef;
 	MinimapUpdateThread *m_minimap_update_thread;
 	scene::SMeshBuffer *m_meshbuffer;
 	bool m_enable_shaders;

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -934,7 +934,7 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 	CNodeDefManager
 */
 
-class CNodeDefManager: public IWritableNodeDefManager {
+class CNodeDefManager: public NodeDefManager {
 public:
 	CNodeDefManager();
 	virtual ~CNodeDefManager();
@@ -1574,7 +1574,7 @@ void CNodeDefManager::addNameIdMapping(content_t i, std::string name)
 }
 
 
-IWritableNodeDefManager *createNodeDefManager()
+NodeDefManager *createNodeDefManager()
 {
 	return new CNodeDefManager();
 }

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -960,12 +960,13 @@ public:
 
 	inline virtual void setNodeRegistrationStatus(bool completed);
 
-	virtual void pendNodeResolve(NodeResolver *nr);
-	virtual bool cancelNodeResolveCallback(NodeResolver *nr);
+	virtual void pendNodeResolve(NodeResolver *nr) const;
+	virtual bool cancelNodeResolveCallback(NodeResolver *nr) const;
 	virtual void runNodeResolveCallbacks();
 	virtual void resetNodeResolveState();
 	virtual void mapNodeboxConnections();
-	virtual bool nodeboxConnects(MapNode from, MapNode to, u8 connect_face);
+	virtual bool nodeboxConnects(MapNode from, MapNode to,
+		u8 connect_face) const;
 	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const
 	{
 		return m_selection_box_int_union;
@@ -1000,7 +1001,8 @@ private:
 	content_t m_next_id;
 
 	// NodeResolvers to callback once node registration has ended
-	std::vector<NodeResolver *> m_pending_resolve_callbacks;
+	// Even constant NodeDefManagers can register listeners.
+	mutable std::vector<NodeResolver *> m_pending_resolve_callbacks;
 
 	// True when all nodes have been registered
 	bool m_node_registration_complete;
@@ -1585,7 +1587,7 @@ inline void CNodeDefManager::setNodeRegistrationStatus(bool completed)
 }
 
 
-void CNodeDefManager::pendNodeResolve(NodeResolver *nr)
+void CNodeDefManager::pendNodeResolve(NodeResolver *nr) const
 {
 	nr->m_ndef = this;
 	if (m_node_registration_complete)
@@ -1595,7 +1597,7 @@ void CNodeDefManager::pendNodeResolve(NodeResolver *nr)
 }
 
 
-bool CNodeDefManager::cancelNodeResolveCallback(NodeResolver *nr)
+bool CNodeDefManager::cancelNodeResolveCallback(NodeResolver *nr) const
 {
 	size_t len = m_pending_resolve_callbacks.size();
 	for (size_t i = 0; i != len; i++) {
@@ -1641,7 +1643,8 @@ void CNodeDefManager::mapNodeboxConnections()
 	}
 }
 
-bool CNodeDefManager::nodeboxConnects(MapNode from, MapNode to, u8 connect_face)
+bool CNodeDefManager::nodeboxConnects(MapNode from, MapNode to,
+	u8 connect_face) const
 {
 	const ContentFeatures &f1 = get(from);
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -931,99 +931,19 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 #endif
 
 /*
-	CNodeDefManager
+	NodeDefManager
 */
 
-class CNodeDefManager: public NodeDefManager {
-public:
-	CNodeDefManager();
-	virtual ~CNodeDefManager();
-	void clear();
-
-	inline virtual const ContentFeatures& get(content_t c) const;
-	inline virtual const ContentFeatures& get(const MapNode &n) const;
-	virtual bool getId(const std::string &name, content_t &result) const;
-	virtual content_t getId(const std::string &name) const;
-	virtual bool getIds(const std::string &name, std::vector<content_t> &result) const;
-	virtual const ContentFeatures& get(const std::string &name) const;
-	content_t allocateId();
-	virtual content_t set(const std::string &name, const ContentFeatures &def);
-	virtual content_t allocateDummy(const std::string &name);
-	virtual void removeNode(const std::string &name);
-	virtual void updateAliases(IItemDefManager *idef);
-	virtual void applyTextureOverrides(const std::string &override_filepath);
-	virtual void updateTextures(IGameDef *gamedef,
-		void (*progress_cbk)(void *progress_args, u32 progress, u32 max_progress),
-		void *progress_cbk_args);
-	void serialize(std::ostream &os, u16 protocol_version) const;
-	void deSerialize(std::istream &is);
-
-	inline virtual void setNodeRegistrationStatus(bool completed);
-
-	virtual void pendNodeResolve(NodeResolver *nr) const;
-	virtual bool cancelNodeResolveCallback(NodeResolver *nr) const;
-	virtual void runNodeResolveCallbacks();
-	virtual void resetNodeResolveState();
-	virtual void mapNodeboxConnections();
-	virtual bool nodeboxConnects(MapNode from, MapNode to,
-		u8 connect_face) const;
-	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const
-	{
-		return m_selection_box_int_union;
-	}
-
-private:
-	void addNameIdMapping(content_t i, std::string name);
-	/*!
-	 * Recalculates m_selection_box_int_union based on
-	 * m_selection_box_union.
-	 */
-	void fixSelectionBoxIntUnion();
-
-	// Features indexed by id
-	std::vector<ContentFeatures> m_content_features;
-
-	// A mapping for fast converting back and forth between names and ids
-	NameIdMapping m_name_id_mapping;
-
-	// Like m_name_id_mapping, but only from names to ids, and includes
-	// item aliases too. Updated by updateAliases()
-	// Note: Not serialized.
-
-	std::unordered_map<std::string, content_t> m_name_id_mapping_with_aliases;
-
-	// A mapping from groups to a vector of content_ts that belong to it.
-	// Necessary for a direct lookup in getIds().
-	// Note: Not serialized.
-	std::unordered_map<std::string, std::vector<content_t>> m_group_to_items;
-
-	// Next possibly free id
-	content_t m_next_id;
-
-	// NodeResolvers to callback once node registration has ended
-	// Even constant NodeDefManagers can register listeners.
-	mutable std::vector<NodeResolver *> m_pending_resolve_callbacks;
-
-	// True when all nodes have been registered
-	bool m_node_registration_complete;
-
-	//! The union of all nodes' selection boxes.
-	aabb3f m_selection_box_union;
-	/*!
-	 * The smallest box in node coordinates that
-	 * contains all nodes' selection boxes.
-	 */
-	core::aabbox3d<s16> m_selection_box_int_union;
-};
 
 
-CNodeDefManager::CNodeDefManager()
+
+NodeDefManager::NodeDefManager()
 {
 	clear();
 }
 
 
-CNodeDefManager::~CNodeDefManager()
+NodeDefManager::~NodeDefManager()
 {
 #ifndef SERVER
 	for (ContentFeatures &f : m_content_features) {
@@ -1036,7 +956,7 @@ CNodeDefManager::~CNodeDefManager()
 }
 
 
-void CNodeDefManager::clear()
+void NodeDefManager::clear()
 {
 	m_content_features.clear();
 	m_name_id_mapping.clear();
@@ -1105,20 +1025,7 @@ void CNodeDefManager::clear()
 }
 
 
-inline const ContentFeatures& CNodeDefManager::get(content_t c) const
-{
-	return c < m_content_features.size()
-			? m_content_features[c] : m_content_features[CONTENT_UNKNOWN];
-}
-
-
-inline const ContentFeatures& CNodeDefManager::get(const MapNode &n) const
-{
-	return get(n.getContent());
-}
-
-
-bool CNodeDefManager::getId(const std::string &name, content_t &result) const
+bool NodeDefManager::getId(const std::string &name, content_t &result) const
 {
 	std::unordered_map<std::string, content_t>::const_iterator
 		i = m_name_id_mapping_with_aliases.find(name);
@@ -1129,7 +1036,7 @@ bool CNodeDefManager::getId(const std::string &name, content_t &result) const
 }
 
 
-content_t CNodeDefManager::getId(const std::string &name) const
+content_t NodeDefManager::getId(const std::string &name) const
 {
 	content_t id = CONTENT_IGNORE;
 	getId(name, id);
@@ -1137,7 +1044,7 @@ content_t CNodeDefManager::getId(const std::string &name) const
 }
 
 
-bool CNodeDefManager::getIds(const std::string &name,
+bool NodeDefManager::getIds(const std::string &name,
 		std::vector<content_t> &result) const
 {
 	//TimeTaker t("getIds", NULL, PRECISION_MICRO);
@@ -1162,7 +1069,7 @@ bool CNodeDefManager::getIds(const std::string &name,
 }
 
 
-const ContentFeatures& CNodeDefManager::get(const std::string &name) const
+const ContentFeatures& NodeDefManager::get(const std::string &name) const
 {
 	content_t id = CONTENT_UNKNOWN;
 	getId(name, id);
@@ -1171,7 +1078,7 @@ const ContentFeatures& CNodeDefManager::get(const std::string &name) const
 
 
 // returns CONTENT_IGNORE if no free ID found
-content_t CNodeDefManager::allocateId()
+content_t NodeDefManager::allocateId()
 {
 	for (content_t id = m_next_id;
 			id >= m_next_id; // overflow?
@@ -1299,7 +1206,7 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 }
 
 
-inline void CNodeDefManager::fixSelectionBoxIntUnion()
+inline void NodeDefManager::fixSelectionBoxIntUnion()
 {
 	m_selection_box_int_union.MinEdge.X = floorf(
 		m_selection_box_union.MinEdge.X / BS + 0.5f);
@@ -1317,7 +1224,7 @@ inline void CNodeDefManager::fixSelectionBoxIntUnion()
 
 
 // IWritableNodeDefManager
-content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &def)
+content_t NodeDefManager::set(const std::string &name, const ContentFeatures &def)
 {
 	// Pre-conditions
 	assert(name != "");
@@ -1359,7 +1266,7 @@ content_t CNodeDefManager::set(const std::string &name, const ContentFeatures &d
 }
 
 
-content_t CNodeDefManager::allocateDummy(const std::string &name)
+content_t NodeDefManager::allocateDummy(const std::string &name)
 {
 	assert(name != "");	// Pre-condition
 	ContentFeatures f;
@@ -1368,7 +1275,7 @@ content_t CNodeDefManager::allocateDummy(const std::string &name)
 }
 
 
-void CNodeDefManager::removeNode(const std::string &name)
+void NodeDefManager::removeNode(const std::string &name)
 {
 	// Pre-condition
 	assert(name != "");
@@ -1395,7 +1302,7 @@ void CNodeDefManager::removeNode(const std::string &name)
 }
 
 
-void CNodeDefManager::updateAliases(IItemDefManager *idef)
+void NodeDefManager::updateAliases(IItemDefManager *idef)
 {
 	std::set<std::string> all;
 	idef->getAll(all);
@@ -1410,9 +1317,9 @@ void CNodeDefManager::updateAliases(IItemDefManager *idef)
 	}
 }
 
-void CNodeDefManager::applyTextureOverrides(const std::string &override_filepath)
+void NodeDefManager::applyTextureOverrides(const std::string &override_filepath)
 {
-	infostream << "CNodeDefManager::applyTextureOverrides(): Applying "
+	infostream << "NodeDefManager::applyTextureOverrides(): Applying "
 		"overrides to textures from " << override_filepath << std::endl;
 
 	std::ifstream infile(override_filepath.c_str());
@@ -1464,12 +1371,12 @@ void CNodeDefManager::applyTextureOverrides(const std::string &override_filepath
 	}
 }
 
-void CNodeDefManager::updateTextures(IGameDef *gamedef,
+void NodeDefManager::updateTextures(IGameDef *gamedef,
 	void (*progress_callback)(void *progress_args, u32 progress, u32 max_progress),
 	void *progress_callback_args)
 {
 #ifndef SERVER
-	infostream << "CNodeDefManager::updateTextures(): Updating "
+	infostream << "NodeDefManager::updateTextures(): Updating "
 		"textures in node definitions" << std::endl;
 
 	Client *client = (Client *)gamedef;
@@ -1490,7 +1397,7 @@ void CNodeDefManager::updateTextures(IGameDef *gamedef,
 #endif
 }
 
-void CNodeDefManager::serialize(std::ostream &os, u16 protocol_version) const
+void NodeDefManager::serialize(std::ostream &os, u16 protocol_version) const
 {
 	writeU8(os, 1); // version
 	u16 count = 0;
@@ -1519,7 +1426,7 @@ void CNodeDefManager::serialize(std::ostream &os, u16 protocol_version) const
 }
 
 
-void CNodeDefManager::deSerialize(std::istream &is)
+void NodeDefManager::deSerialize(std::istream &is)
 {
 	clear();
 	int version = readU8(is);
@@ -1569,7 +1476,7 @@ void CNodeDefManager::deSerialize(std::istream &is)
 }
 
 
-void CNodeDefManager::addNameIdMapping(content_t i, std::string name)
+void NodeDefManager::addNameIdMapping(content_t i, std::string name)
 {
 	m_name_id_mapping.set(i, name);
 	m_name_id_mapping_with_aliases.insert(std::make_pair(name, i));
@@ -1578,16 +1485,11 @@ void CNodeDefManager::addNameIdMapping(content_t i, std::string name)
 
 NodeDefManager *createNodeDefManager()
 {
-	return new CNodeDefManager();
-}
-
-inline void CNodeDefManager::setNodeRegistrationStatus(bool completed)
-{
-	m_node_registration_complete = completed;
+	return new NodeDefManager();
 }
 
 
-void CNodeDefManager::pendNodeResolve(NodeResolver *nr) const
+void NodeDefManager::pendNodeResolve(NodeResolver *nr) const
 {
 	nr->m_ndef = this;
 	if (m_node_registration_complete)
@@ -1597,7 +1499,7 @@ void CNodeDefManager::pendNodeResolve(NodeResolver *nr) const
 }
 
 
-bool CNodeDefManager::cancelNodeResolveCallback(NodeResolver *nr) const
+bool NodeDefManager::cancelNodeResolveCallback(NodeResolver *nr) const
 {
 	size_t len = m_pending_resolve_callbacks.size();
 	for (size_t i = 0; i != len; i++) {
@@ -1614,7 +1516,7 @@ bool CNodeDefManager::cancelNodeResolveCallback(NodeResolver *nr) const
 }
 
 
-void CNodeDefManager::runNodeResolveCallbacks()
+void NodeDefManager::runNodeResolveCallbacks()
 {
 	for (size_t i = 0; i != m_pending_resolve_callbacks.size(); i++) {
 		NodeResolver *nr = m_pending_resolve_callbacks[i];
@@ -1625,13 +1527,13 @@ void CNodeDefManager::runNodeResolveCallbacks()
 }
 
 
-void CNodeDefManager::resetNodeResolveState()
+void NodeDefManager::resetNodeResolveState()
 {
 	m_node_registration_complete = false;
 	m_pending_resolve_callbacks.clear();
 }
 
-void CNodeDefManager::mapNodeboxConnections()
+void NodeDefManager::mapNodeboxConnections()
 {
 	for (ContentFeatures &f : m_content_features) {
 		if (f.drawtype != NDT_NODEBOX || f.node_box.type != NODEBOX_CONNECTED)
@@ -1643,7 +1545,7 @@ void CNodeDefManager::mapNodeboxConnections()
 	}
 }
 
-bool CNodeDefManager::nodeboxConnects(MapNode from, MapNode to,
+bool NodeDefManager::nodeboxConnects(MapNode from, MapNode to,
 	u8 connect_face) const
 {
 	const ContentFeatures &f1 = get(from);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -438,119 +438,290 @@ struct ContentFeatures
 #endif
 };
 
+/*!
+ * @brief This class is for getting the actual properties of nodes from their
+ * content ID.
+ *
+ * @details The nodes on the map are represented by three numbers (see MapNode).
+ * The first number (param0) is the type of a node. All node types have own
+ * properties (see ContentFeatures). This class is for storing and getting the
+ * properties of nodes.
+ * The manager is first filled with registered nodes, then as the game begins,
+ * functions only get `const` pointers to it, to prevent modification of
+ * registered nodes.
+ */
 class NodeDefManager {
 public:
+	/*!
+	 * Creates a NodeDefManager, and registers three ContentFeatures:
+	 * \ref CONTENT_AIR, \ref CONTENT_UNKNOWN and \ref CONTENT_IGNORE.
+	 */
 	NodeDefManager();
 	~NodeDefManager();
 
-	// Get node definition
+	/*!
+	 * Returns the properties for the given content type.
+	 * @param c content type of a node
+	 * @return properties of the given content type, or \ref CONTENT_UNKNOWN
+	 * if the given content type is not registered.
+	 */
 	inline const ContentFeatures& get(content_t c) const {
 		return
 			c < m_content_features.size() ?
 				m_content_features[c] : m_content_features[CONTENT_UNKNOWN];
 	}
 
+	/*!
+	 * Returns the properties of the given node.
+	 * @param n a map node
+	 * @return properties of the given node or @ref CONTENT_UNKNOWN if the
+	 * given content type is not registered.
+	 */
 	inline const ContentFeatures& get(const MapNode &n) const {
 		return get(n.getContent());
 	}
 
-	bool getId(const std::string &name, content_t &result) const;
-	// If not found, returns CONTENT_IGNORE
-	content_t getId(const std::string &name) const;
-	// Allows "group:name" in addition to regular node names
-	// returns false if node name not found, true otherwise
-	bool getIds(const std::string &name, std::vector<content_t> &result) const;
-	// If not found, returns the features of CONTENT_UNKNOWN
+	/*!
+	 * Returns the node properties for a node name.
+	 * @param name name of a node
+	 * @return properties of the given node or @ref CONTENT_UNKNOWN if
+	 * not found
+	 */
 	const ContentFeatures& get(const std::string &name) const;
-	// Register node definition by name (allocate an id)
-	// If returns CONTENT_IGNORE, could not allocate id
+
+	/*!
+	 * Returns the content ID for the given name.
+	 * @param name a node name
+	 * @param[out] result will contain the content ID if found, otherwise
+	 * remains unchanged
+	 * @return true if the ID was found, false otherwise
+	 */
+	bool getId(const std::string &name, content_t &result) const;
+
+	/*!
+	 * Returns the content ID for the given name.
+	 * @param name a node name
+	 * @return ID of the node or @ref CONTENT_IGNORE if not found
+	 */
+	content_t getId(const std::string &name) const;
+
+	/*!
+	 * Returns the content IDs of the given node name or node group name.
+	 * Group names start with "group:".
+	 * @param name a node name or node group name
+	 * @param[out] result will be appended with matching IDs
+	 * @return true if `name` is a valid node name or a (not necessarily
+	 * valid) group name
+	 */
+	bool getIds(const std::string &name, std::vector<content_t> &result) const;
+
+	/*!
+	 * Returns the smallest box in integer node coordinates that
+	 * contains all nodes' selection boxes. The returned box might be larger
+	 * than the minimal size if the largest node is removed from the manager.
+	 */
+	inline core::aabbox3d<s16> getSelectionBoxIntUnion() const {
+		return m_selection_box_int_union;
+	}
+
+	/*!
+	 * Checks whether a node connects to an adjacent node.
+	 * @param from the node to be checked
+	 * @param to the adjacent node
+	 * @param connect_face a bit field indicating which face of the node is
+	 * adjacent to the other node.
+	 * Bits: +y (least significant), -y, -z, -x, +z, +x (most significant).
+	 * @return true if the node connects, false otherwise
+	 */
+	bool nodeboxConnects(MapNode from, MapNode to,
+			u8 connect_face) const;
+
+	/*!
+	 * Registers a NodeResolver to wait for the registration of
+	 * ContentFeatures. Once the node registration finishes, all
+	 * listeners are notified.
+	 */
+	void pendNodeResolve(NodeResolver *nr) const;
+
+	/*!
+	 * Stops listening to the NodeDefManager.
+	 * @return true if the listener was registered before, false otherwise
+	 */
+	bool cancelNodeResolveCallback(NodeResolver *nr) const;
+
+	/*!
+	 * Registers a new node type with the given name and allocates a new
+	 * content ID.
+	 * Should not be called with an already existing name.
+	 * @param name name of the node, must match with `def.name`.
+	 * @param def definition of the registered node type.
+	 * @return ID of the registered node or @ref CONTENT_IGNORE if
+	 * the function could not allocate an ID.
+	 */
 	content_t set(const std::string &name, const ContentFeatures &def);
-	// If returns CONTENT_IGNORE, could not allocate id
+
+	/*!
+	 * Allocates a blank node ID for the given name.
+	 * @param name name of a node
+	 * @return allocated ID or @ref CONTENT_IGNORE if could not allocate
+	 * an ID.
+	 */
 	content_t allocateDummy(const std::string &name);
-	// Remove a node
+
+	/*!
+	 * Removes the given node name from the manager.
+	 * The node ID will remain in the manager, but won't be linked to any name.
+	 * @param name name to be removed
+	 */
 	void removeNode(const std::string &name);
-	/*
-		Update item alias mapping.
-		Call after updating item definitions.
-	*/
+
+	/*!
+	 * Regenerates the alias list (a map from names to node IDs).
+	 * @param idef the item definition manager containing alias information
+	 */
 	void updateAliases(IItemDefManager *idef);
-	/*
-		Override textures from servers with ones specified in texturepack/override.txt
-	*/
+
+	/*!
+	 * Reads the used texture pack's override.txt, and replaces the textures
+	 * of registered nodes with the ones specified there.
+	 *
+	 * Format of the input file: in each line
+	 * `node_name top|bottom|right|left|front|back|all|*|sides texture_name.png`
+	 *
+	 * @param override_filepath path to 'texturepack/override.txt'
+	 */
 	void applyTextureOverrides(const std::string &override_filepath);
-	/*
-		Update tile textures to latest return values of TextueSource.
-	*/
+
+	/*!
+	 * Only the client uses this. Loads textures and shaders required for
+	 * rendering the nodes.
+	 * @param gamedef must be a Client.
+	 * @param progress_cbk called each time a node is loaded. Arguments:
+	 * `progress_cbk_args`, number of loaded ContentFeatures, number of
+	 * total ContentFeatures.
+	 * @param progress_cbk_args passed to the callback function
+	 */
 	void updateTextures(IGameDef *gamedef,
 		void (*progress_cbk)(void *progress_args, u32 progress, u32 max_progress),
 		void *progress_cbk_args);
+
+	/*!
+	 * Writes the content of this manager to the given output stream.
+	 * @param protocol_version serialization version of ContentFeatures
+	 */
 	void serialize(std::ostream &os, u16 protocol_version) const;
+
+	/*!
+	 * Restores the manager from a serialized stream.
+	 * This clears the previous state.
+	 * @param is input stream containing a serialized NodeDefManager
+	 */
 	void deSerialize(std::istream &is);
 
+	/*!
+	 * Used to indicate that node registration has finished.
+	 * @param completed tells whether registration is complete
+	 */
 	inline void setNodeRegistrationStatus(bool completed) {
 		m_node_registration_complete = completed;
 	}
 
-	void pendNodeResolve(NodeResolver *nr) const;
-	bool cancelNodeResolveCallback(NodeResolver *nr) const;
-	void runNodeResolveCallbacks();
-	void resetNodeResolveState();
-	void mapNodeboxConnections();
-	bool nodeboxConnects(MapNode from, MapNode to,
-		u8 connect_face) const;
 	/*!
-	 * Returns the smallest box in node coordinates that
-	 * contains all nodes' selection boxes.
+	 * Notifies the registered NodeResolver instances that node registration
+	 * has finished, then unregisters all listeners.
+	 * Must be called after node registration has finished!
 	 */
-	inline core::aabbox3d<s16> getSelectionBoxIntUnion() const
-	{
-		return m_selection_box_int_union;
-	}
+	void runNodeResolveCallbacks();
+
+	/*!
+	 * Sets the registration completion flag to false and unregisters all
+	 * NodeResolver instances listening to the manager.
+	 */
+	void resetNodeResolveState();
+
+	/*!
+	 * Resolves the IDs to which connecting nodes connect from names.
+	 * Must be called after node registration has finished!
+	 */
+	void mapNodeboxConnections();
 
 private:
+	/*!
+	 * Resets the manager to its initial state.
+	 * See the documentation of the constructor.
+	 */
 	void clear();
+
+	/*!
+	 * Allocates a new content ID, and returns it.
+	 * @return the allocated ID or \ref CONTENT_IGNORE if could not allocate
+	 */
 	content_t allocateId();
+
+	/*!
+	 * Binds the given content ID and node name.
+	 * Registers them in \ref m_name_id_mapping and
+	 * \ref m_name_id_mapping_with_aliases.
+	 * @param i a content ID
+	 * @param name a node name
+	 */
 	void addNameIdMapping(content_t i, std::string name);
+
 	/*!
 	 * Recalculates m_selection_box_int_union based on
 	 * m_selection_box_union.
 	 */
 	void fixSelectionBoxIntUnion();
 
-	// Features indexed by id
+	//! Features indexed by ID.
 	std::vector<ContentFeatures> m_content_features;
 
-	// A mapping for fast converting back and forth between names and ids
+	//! A mapping for fast conversion between names and IDs
 	NameIdMapping m_name_id_mapping;
 
-	// Like m_name_id_mapping, but only from names to ids, and includes
-	// item aliases too. Updated by updateAliases()
-	// Note: Not serialized.
-
+	/*!
+	 * Like @ref m_name_id_mapping, but maps only from names to IDs, and
+	 * includes aliases too. Updated by \ref updateAliases().
+	 * Note: Not serialized.
+	 */
 	std::unordered_map<std::string, content_t> m_name_id_mapping_with_aliases;
 
-	// A mapping from groups to a vector of content_ts that belong to it.
-	// Necessary for a direct lookup in getIds().
-	// Note: Not serialized.
+	/*!
+	 * A mapping from group names to a vector of content types that belong
+	 * to it. Necessary for a direct lookup in \ref getIds().
+	 * Note: Not serialized.
+	 */
 	std::unordered_map<std::string, std::vector<content_t>> m_group_to_items;
 
-	// Next possibly free id
+	/*!
+	 * The next ID that might be free to allocate.
+	 * It can be allocated already, because \ref CONTENT_AIR,
+	 * \ref CONTENT_UNKNOWN and \ref CONTENT_IGNORE are registered when the
+	 * manager is initialized, and new IDs are allocated from 0.
+	 */
 	content_t m_next_id;
 
-	// NodeResolvers to callback once node registration has ended
-	// Even constant NodeDefManagers can register listeners.
-	mutable std::vector<NodeResolver *> m_pending_resolve_callbacks;
-
-	// True when all nodes have been registered
+	//! True if all nodes have been registered.
 	bool m_node_registration_complete;
 
-	//! The union of all nodes' selection boxes.
-	aabb3f m_selection_box_union;
 	/*!
-	 * The smallest box in node coordinates that
+	 * The union of all nodes' selection boxes.
+	 * Might be larger if big nodes are removed from the manager.
+	 */
+	aabb3f m_selection_box_union;
+
+	/*!
+	 * The smallest box in integer node coordinates that
 	 * contains all nodes' selection boxes.
+	 * Might be larger if big nodes are removed from the manager.
 	 */
 	core::aabbox3d<s16> m_selection_box_int_union;
+
+	/*!
+	 * NodeResolver instances to notify once node registration has finished.
+	 * Even constant NodeDefManager instances can register listeners.
+	 */
+	mutable std::vector<NodeResolver *> m_pending_resolve_callbacks;
 };
 
 NodeDefManager *createNodeDefManager();

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -437,36 +437,7 @@ struct ContentFeatures
 #endif
 };
 
-class INodeDefManager {
-public:
-	INodeDefManager() = default;
-	virtual ~INodeDefManager() = default;
-
-	// Get node definition
-	virtual const ContentFeatures &get(content_t c) const=0;
-	virtual const ContentFeatures &get(const MapNode &n) const=0;
-	virtual bool getId(const std::string &name, content_t &result) const=0;
-	virtual content_t getId(const std::string &name) const=0;
-	// Allows "group:name" in addition to regular node names
-	// returns false if node name not found, true otherwise
-	virtual bool getIds(const std::string &name, std::vector<content_t> &result)
-			const=0;
-	virtual const ContentFeatures &get(const std::string &name) const=0;
-
-	virtual void serialize(std::ostream &os, u16 protocol_version) const=0;
-
-	virtual void pendNodeResolve(NodeResolver *nr) const=0;
-	virtual bool cancelNodeResolveCallback(NodeResolver *nr) const=0;
-	virtual bool nodeboxConnects(const MapNode from, const MapNode to,
-		u8 connect_face) const=0;
-	/*!
-	 * Returns the smallest box in node coordinates that
-	 * contains all nodes' selection boxes.
-	 */
-	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
-};
-
-class NodeDefManager : public INodeDefManager {
+class NodeDefManager {
 public:
 	NodeDefManager() = default;
 	virtual ~NodeDefManager() = default;
@@ -478,6 +449,7 @@ public:
 	// If not found, returns CONTENT_IGNORE
 	virtual content_t getId(const std::string &name) const=0;
 	// Allows "group:name" in addition to regular node names
+	// returns false if node name not found, true otherwise
 	virtual bool getIds(const std::string &name, std::vector<content_t> &result)
 		const=0;
 	// If not found, returns the features of CONTENT_UNKNOWN
@@ -520,6 +492,12 @@ public:
 	virtual void runNodeResolveCallbacks()=0;
 	virtual void resetNodeResolveState()=0;
 	virtual void mapNodeboxConnections()=0;
+	virtual bool nodeboxConnects(const MapNode from, const MapNode to,
+		u8 connect_face) const=0;
+	/*!
+	 * Returns the smallest box in node coordinates that
+	 * contains all nodes' selection boxes.
+	 */
 	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
 };
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -456,9 +456,10 @@ public:
 
 	virtual void serialize(std::ostream &os, u16 protocol_version) const=0;
 
-	virtual void pendNodeResolve(NodeResolver *nr)=0;
-	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
-	virtual bool nodeboxConnects(const MapNode from, const MapNode to, u8 connect_face)=0;
+	virtual void pendNodeResolve(NodeResolver *nr) const=0;
+	virtual bool cancelNodeResolveCallback(NodeResolver *nr) const=0;
+	virtual bool nodeboxConnects(const MapNode from, const MapNode to,
+		u8 connect_face) const=0;
 	/*!
 	 * Returns the smallest box in node coordinates that
 	 * contains all nodes' selection boxes.
@@ -515,8 +516,8 @@ public:
 
 	virtual void setNodeRegistrationStatus(bool completed)=0;
 
-	virtual void pendNodeResolve(NodeResolver *nr)=0;
-	virtual bool cancelNodeResolveCallback(NodeResolver *nr)=0;
+	virtual void pendNodeResolve(NodeResolver *nr) const=0;
+	virtual bool cancelNodeResolveCallback(NodeResolver *nr) const=0;
 	virtual void runNodeResolveCallbacks()=0;
 	virtual void resetNodeResolveState()=0;
 	virtual void mapNodeboxConnections()=0;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -34,7 +34,6 @@ class Client;
 #include "constants.h" // BS
 #include "tileanimation.h"
 
-class INodeDefManager;
 class IItemDefManager;
 class ITextureSource;
 class IShaderSource;
@@ -543,6 +542,6 @@ public:
 	u32 m_nnlistsizes_idx = 0;
 	std::vector<std::string> m_nodenames;
 	std::vector<size_t> m_nnlistsizes;
-	INodeDefManager *m_ndef = nullptr;
+	const NodeDefManager *m_ndef = nullptr;
 	bool m_resolve_done = false;
 };

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -466,10 +466,10 @@ public:
 	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
 };
 
-class IWritableNodeDefManager : public INodeDefManager {
+class NodeDefManager : public INodeDefManager {
 public:
-	IWritableNodeDefManager() = default;
-	virtual ~IWritableNodeDefManager() = default;
+	NodeDefManager() = default;
+	virtual ~NodeDefManager() = default;
 
 	// Get node definition
 	virtual const ContentFeatures &get(content_t c) const=0;
@@ -523,7 +523,7 @@ public:
 	virtual core::aabbox3d<s16> getSelectionBoxIntUnion() const=0;
 };
 
-IWritableNodeDefManager *createNodeDefManager();
+NodeDefManager *createNodeDefManager();
 
 class NodeResolver {
 public:

--- a/src/objdef.h
+++ b/src/objdef.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 
 class IGameDef;
-class INodeDefManager;
+class NodeDefManager;
 
 #define OBJDEF_INVALID_INDEX ((u32)(-1))
 #define OBJDEF_INVALID_HANDLE 0
@@ -80,7 +80,7 @@ public:
 
 	size_t getNumObjects() const { return m_objects.size(); }
 	ObjDefType getType() const { return m_objtype; }
-	INodeDefManager *getNodeDef() const { return m_ndef; }
+	const NodeDefManager *getNodeDef() const { return m_ndef; }
 
 	u32 validateHandle(ObjDefHandle handle) const;
 	static ObjDefHandle createHandle(u32 index, ObjDefType type, u32 uid);
@@ -88,7 +88,7 @@ public:
 		ObjDefType *type, u32 *uid);
 
 protected:
-	INodeDefManager *m_ndef;
+	const NodeDefManager *m_ndef;
 	std::vector<ObjDef *> m_objects;
 	ObjDefType m_objtype;
 };

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -493,7 +493,7 @@ void PathGridnode::setCost(v3s16 dir, const PathCost &cost)
 
 void GridNodeContainer::initNode(v3s16 ipos, PathGridnode *p_node)
 {
-	INodeDefManager *ndef = m_pathf->m_env->getGameDef()->ndef();
+	const NodeDefManager *ndef = m_pathf->m_env->getGameDef()->ndef();
 	PathGridnode &elem = *p_node;
 
 	v3s16 realpos = m_pathf->getRealPos(ipos);
@@ -754,7 +754,7 @@ v3s16 Pathfinder::getRealPos(v3s16 ipos)
 /******************************************************************************/
 PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 {
-	INodeDefManager *ndef = m_env->getGameDef()->ndef();
+	const NodeDefManager *ndef = m_env->getGameDef()->ndef();
 	PathCost retval;
 
 	retval.updated = true;

--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/timetaker.h"
 
 
-ReflowScan::ReflowScan(Map *map, INodeDefManager *ndef) :
+ReflowScan::ReflowScan(Map *map, const NodeDefManager *ndef) :
 	m_map(map),
 	m_ndef(ndef)
 {

--- a/src/reflowscan.h
+++ b/src/reflowscan.h
@@ -22,13 +22,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/container.h"
 #include "irrlichttypes_bloated.h"
 
-class INodeDefManager;
+class NodeDefManager;
 class Map;
 class MapBlock;
 
 class ReflowScan {
 public:
-	ReflowScan(Map *map, INodeDefManager *ndef);
+	ReflowScan(Map *map, const NodeDefManager *ndef);
 	void scan(MapBlock *block, UniqueQueue<v3s16> *liquid_queue);
 
 private:
@@ -39,7 +39,7 @@ private:
 
 private:
 	Map *m_map = nullptr;
-	INodeDefManager *m_ndef = nullptr;
+	const NodeDefManager *m_ndef = nullptr;
 	v3s16 m_block_pos, m_rel_block_pos;
 	UniqueQueue<v3s16> *m_liquid_queue = nullptr;
 	MapBlock *m_lookup[3 * 3 * 3];

--- a/src/rollback_interface.cpp
+++ b/src/rollback_interface.cpp
@@ -36,7 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 RollbackNode::RollbackNode(Map *map, v3s16 p, IGameDef *gamedef)
 {
-	INodeDefManager *ndef = gamedef->ndef();
+	const NodeDefManager *ndef = gamedef->ndef();
 	MapNode n = map->getNodeNoEx(p);
 	name = ndef->get(n).name;
 	param1 = n.param1;
@@ -90,7 +90,7 @@ bool RollbackAction::isImportant(IGameDef *gamedef) const
 	// If metadata differs, action is always important
 	if(n_old.meta != n_new.meta)
 		return true;
-	INodeDefManager *ndef = gamedef->ndef();
+	const NodeDefManager *ndef = gamedef->ndef();
 	// Both are of the same name, so a single definition is needed
 	const ContentFeatures &def = ndef->get(n_old.name);
 	// If the type is flowing liquid, action is not important
@@ -128,7 +128,7 @@ bool RollbackAction::applyRevert(Map *map, InventoryManager *imgr, IGameDef *gam
 		case TYPE_NOTHING:
 			return true;
 		case TYPE_SET_NODE: {
-			INodeDefManager *ndef = gamedef->ndef();
+			const NodeDefManager *ndef = gamedef->ndef();
 			// Make sure position is loaded from disk
 			map->emergeBlock(getContainerPos(p, MAP_BLOCKSIZE), false);
 			// Check current node

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1075,7 +1075,7 @@ NodeBox read_nodebox(lua_State *L, int index)
 }
 
 /******************************************************************************/
-MapNode readnode(lua_State *L, int index, INodeDefManager *ndef)
+MapNode readnode(lua_State *L, int index, const NodeDefManager *ndef)
 {
 	lua_getfield(L, index, "name");
 	if (!lua_isstring(L, -1))
@@ -1099,7 +1099,7 @@ MapNode readnode(lua_State *L, int index, INodeDefManager *ndef)
 }
 
 /******************************************************************************/
-void pushnode(lua_State *L, const MapNode &n, INodeDefManager *ndef)
+void pushnode(lua_State *L, const MapNode &n, const NodeDefManager *ndef)
 {
 	lua_newtable(L);
 	lua_pushstring(L, ndef->get(n).name.c_str());

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -44,7 +44,7 @@ extern "C" {
 namespace Json { class Value; }
 
 struct MapNode;
-class INodeDefManager;
+class NodeDefManager;
 struct PointedThing;
 struct ItemStack;
 struct ItemDefinition;
@@ -120,9 +120,9 @@ void               read_inventory_list       (lua_State *L, int tableindex,
                                               Server *srv, int forcesize=-1);
 
 MapNode            readnode                  (lua_State *L, int index,
-                                              INodeDefManager *ndef);
+                                              const NodeDefManager *ndef);
 void               pushnode                  (lua_State *L, const MapNode &n,
-                                              INodeDefManager *ndef);
+                                              const NodeDefManager *ndef);
 
 
 void               read_groups               (lua_State *L, int index,

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -144,7 +144,7 @@ bool ScriptApiClient::on_dignode(v3s16 p, MapNode node)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	INodeDefManager *ndef = getClient()->ndef();
+	const NodeDefManager *ndef = getClient()->ndef();
 
 	// Get core.registered_on_dignode
 	lua_getglobal(L, "core");
@@ -163,7 +163,7 @@ bool ScriptApiClient::on_punchnode(v3s16 p, MapNode node)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	INodeDefManager *ndef = getClient()->ndef();
+	const NodeDefManager *ndef = getClient()->ndef();
 
 	// Get core.registered_on_punchgnode
 	lua_getglobal(L, "core");

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -100,7 +100,7 @@ bool ScriptApiNode::node_on_punch(v3s16 p, MapNode node,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_punch", &p))
@@ -123,7 +123,7 @@ bool ScriptApiNode::node_on_dig(v3s16 p, MapNode node,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_dig", &p))
@@ -144,7 +144,7 @@ void ScriptApiNode::node_on_construct(v3s16 p, MapNode node)
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_construct", &p))
@@ -162,7 +162,7 @@ void ScriptApiNode::node_on_destruct(v3s16 p, MapNode node)
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_destruct", &p))
@@ -180,7 +180,7 @@ bool ScriptApiNode::node_on_flood(v3s16 p, MapNode node, MapNode newnode)
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_flood", &p))
@@ -201,7 +201,7 @@ void ScriptApiNode::node_after_destruct(v3s16 p, MapNode node)
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "after_destruct", &p))
@@ -220,7 +220,7 @@ bool ScriptApiNode::node_on_timer(v3s16 p, MapNode node, f32 dtime)
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// Push callback function on stack
 	if (!getItemCallback(ndef->get(node).name.c_str(), "on_timer", &p))
@@ -243,7 +243,7 @@ void ScriptApiNode::node_on_receive_fields(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);

--- a/src/script/cpp_api/s_nodemeta.cpp
+++ b/src/script/cpp_api/s_nodemeta.cpp
@@ -36,7 +36,7 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowMove(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);
@@ -74,7 +74,7 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowPut(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);
@@ -110,7 +110,7 @@ int ScriptApiNodemeta::nodemeta_inventory_AllowTake(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);
@@ -147,7 +147,7 @@ void ScriptApiNodemeta::nodemeta_inventory_OnMove(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);
@@ -180,7 +180,7 @@ void ScriptApiNodemeta::nodemeta_inventory_OnPut(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);
@@ -211,7 +211,7 @@ void ScriptApiNodemeta::nodemeta_inventory_OnTake(v3s16 p,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	INodeDefManager *ndef = getServer()->ndef();
+	const NodeDefManager *ndef = getServer()->ndef();
 
 	// If node doesn't exist, we don't know what callback to call
 	MapNode node = getEnv()->getMap().getNodeNoEx(p);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -311,7 +311,7 @@ int ModApiClient::l_get_node_def(lua_State *L)
 	IGameDef *gdef = getGameDef(L);
 	assert(gdef);
 
-	INodeDefManager *ndef = gdef->ndef();
+	const NodeDefManager *ndef = gdef->ndef();
 	assert(ndef);
 
 	if (!lua_isstring(L, 1))

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -263,7 +263,7 @@ int ModApiEnvMod::l_set_node(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	INodeDefManager *ndef = env->getGameDef()->ndef();
+	const NodeDefManager *ndef = env->getGameDef()->ndef();
 	// parameters
 	v3s16 pos = read_v3s16(L, 1);
 	MapNode n = readnode(L, 2, ndef);
@@ -279,7 +279,7 @@ int ModApiEnvMod::l_bulk_set_node(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	INodeDefManager *ndef = env->getGameDef()->ndef();
+	const NodeDefManager *ndef = env->getGameDef()->ndef();
 	// parameters
 	if (!lua_istable(L, 1)) {
 		return 0;
@@ -331,7 +331,7 @@ int ModApiEnvMod::l_swap_node(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	INodeDefManager *ndef = env->getGameDef()->ndef();
+	const NodeDefManager *ndef = env->getGameDef()->ndef();
 	// parameters
 	v3s16 pos = read_v3s16(L, 1);
 	MapNode n = readnode(L, 2, ndef);
@@ -394,7 +394,7 @@ int ModApiEnvMod::l_get_node_light(lua_State *L)
 	bool is_position_ok;
 	MapNode n = env->getMap().getNodeNoEx(pos, &is_position_ok);
 	if (is_position_ok) {
-		INodeDefManager *ndef = env->getGameDef()->ndef();
+		const NodeDefManager *ndef = env->getGameDef()->ndef();
 		lua_pushinteger(L, n.getLightBlend(dnr, ndef));
 	} else {
 		lua_pushnil(L);
@@ -410,7 +410,7 @@ int ModApiEnvMod::l_place_node(lua_State *L)
 
 	ScriptApiItem *scriptIfaceItem = getScriptApi<ScriptApiItem>(L);
 	Server *server = getServer(L);
-	INodeDefManager *ndef = server->ndef();
+	const NodeDefManager *ndef = server->ndef();
 	IItemDefManager *idef = server->idef();
 
 	v3s16 pos = read_v3s16(L, 1);
@@ -748,7 +748,7 @@ int ModApiEnvMod::l_find_node_near(lua_State *L)
 		return 0;
 	}
 
-	INodeDefManager *ndef = getGameDef(L)->ndef();
+	const NodeDefManager *ndef = getGameDef(L)->ndef();
 	v3s16 pos = read_v3s16(L, 1);
 	int radius = luaL_checkinteger(L, 2);
 	std::vector<content_t> filter;
@@ -795,7 +795,7 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 {
 	GET_ENV_PTR;
 
-	INodeDefManager *ndef = getServer(L)->ndef();
+	const NodeDefManager *ndef = getServer(L)->ndef();
 	v3s16 minp = read_v3s16(L, 1);
 	v3s16 maxp = read_v3s16(L, 2);
 	sortBoxVerticies(minp, maxp);
@@ -867,7 +867,7 @@ int ModApiEnvMod::l_find_nodes_in_area_under_air(lua_State *L)
 
 	GET_ENV_PTR;
 
-	INodeDefManager *ndef = getServer(L)->ndef();
+	const NodeDefManager *ndef = getServer(L)->ndef();
 	v3s16 minp = read_v3s16(L, 1);
 	v3s16 maxp = read_v3s16(L, 2);
 	sortBoxVerticies(minp, maxp);
@@ -1182,7 +1182,7 @@ int ModApiEnvMod::l_spawn_tree(lua_State *L)
 
 	treegen::TreeDef tree_def;
 	std::string trunk,leaves,fruit;
-	INodeDefManager *ndef = env->getGameDef()->ndef();
+	const NodeDefManager *ndef = env->getGameDef()->ndef();
 
 	if(lua_istable(L, 2))
 	{

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -593,7 +593,7 @@ int ModApiItemMod::l_get_content_id(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	std::string name = luaL_checkstring(L, 1);
 
-	INodeDefManager *ndef = getGameDef(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getGameDef(L)->getNodeDefManager();
 	content_t c = ndef->getId(name);
 
 	lua_pushinteger(L, c);
@@ -606,7 +606,7 @@ int ModApiItemMod::l_get_name_from_content_id(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	content_t c = luaL_checkint(L, 1);
 
-	INodeDefManager *ndef = getGameDef(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getGameDef(L)->getNodeDefManager();
 	const char *name = ndef->get(c).name.c_str();
 
 	lua_pushstring(L, name);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -501,7 +501,7 @@ int ModApiItemMod::l_register_item_raw(lua_State *L)
 	// Get the writable item and node definition managers from the server
 	IWritableItemDefManager *idef =
 			getServer(L)->getWritableItemDefManager();
-	IWritableNodeDefManager *ndef =
+	NodeDefManager *ndef =
 			getServer(L)->getWritableNodeDefManager();
 
 	// Check if name is defined
@@ -561,7 +561,7 @@ int ModApiItemMod::l_unregister_item_raw(lua_State *L)
 
 	// Unregister the node
 	if (idef->get(name).type == ITEM_NODE) {
-		IWritableNodeDefManager *ndef =
+		NodeDefManager *ndef =
 			getServer(L)->getWritableNodeDefManager();
 		ndef->removeNode(name);
 	}

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -99,16 +99,16 @@ ObjDef *get_objdef(lua_State *L, int index, ObjDefManager *objmgr);
 
 Biome *get_or_load_biome(lua_State *L, int index,
 	BiomeManager *biomemgr);
-Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef);
+Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef);
 size_t get_biome_list(lua_State *L, int index,
 	BiomeManager *biomemgr, std::unordered_set<u8> *biome_id_list);
 
 Schematic *get_or_load_schematic(lua_State *L, int index,
 	SchematicManager *schemmgr, StringMap *replace_names);
-Schematic *load_schematic(lua_State *L, int index, INodeDefManager *ndef,
+Schematic *load_schematic(lua_State *L, int index, const NodeDefManager *ndef,
 	StringMap *replace_names);
 Schematic *load_schematic_from_def(lua_State *L, int index,
-	INodeDefManager *ndef, StringMap *replace_names);
+	const NodeDefManager *ndef, StringMap *replace_names);
 bool read_schematic_def(lua_State *L, int index,
 	Schematic *schem, std::vector<std::string> *names);
 
@@ -160,7 +160,7 @@ Schematic *get_or_load_schematic(lua_State *L, int index,
 }
 
 
-Schematic *load_schematic(lua_State *L, int index, INodeDefManager *ndef,
+Schematic *load_schematic(lua_State *L, int index, const NodeDefManager *ndef,
 	StringMap *replace_names)
 {
 	if (index < 0)
@@ -196,7 +196,7 @@ Schematic *load_schematic(lua_State *L, int index, INodeDefManager *ndef,
 
 
 Schematic *load_schematic_from_def(lua_State *L, int index,
-	INodeDefManager *ndef, StringMap *replace_names)
+	const NodeDefManager *ndef, StringMap *replace_names)
 {
 	Schematic *schem = SchematicManager::create(SCHEMATIC_NORMAL);
 
@@ -374,7 +374,7 @@ Biome *get_or_load_biome(lua_State *L, int index, BiomeManager *biomemgr)
 }
 
 
-Biome *read_biome_def(lua_State *L, int index, INodeDefManager *ndef)
+Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 {
 	if (!lua_istable(L, index))
 		return NULL;
@@ -1014,7 +1014,7 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 	int index = 1;
 	luaL_checktype(L, index, LUA_TTABLE);
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
 
 	Biome *biome = read_biome_def(L, index, ndef);
@@ -1040,7 +1040,7 @@ int ModApiMapgen::l_register_decoration(lua_State *L)
 	int index = 1;
 	luaL_checktype(L, index, LUA_TTABLE);
 
-	INodeDefManager *ndef      = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef      = getServer(L)->getNodeDefManager();
 	DecorationManager *decomgr = getServer(L)->getEmergeManager()->decomgr;
 	BiomeManager *biomemgr     = getServer(L)->getEmergeManager()->biomemgr;
 	SchematicManager *schemmgr = getServer(L)->getEmergeManager()->schemmgr;
@@ -1197,7 +1197,7 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	int index = 1;
 	luaL_checktype(L, index, LUA_TTABLE);
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
 	OreManager *oremgr    = getServer(L)->getEmergeManager()->oremgr;
 
@@ -1469,7 +1469,7 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
 	const char *filename = luaL_checkstring(L, 4);
 	CHECK_SECURE_PATH(L, filename, true);

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -136,7 +136,7 @@ int LuaVoxelManip::l_get_node_at(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
@@ -149,7 +149,7 @@ int LuaVoxelManip::l_set_node_at(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	v3s16 pos        = check_v3s16(L, 2);
@@ -167,7 +167,7 @@ int LuaVoxelManip::l_update_liquids(lua_State *L)
 	LuaVoxelManip *o = checkobject(L, 1);
 
 	Map *map = &(env->getMap());
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	MMVManip *vm = o->vm;
 
 	Mapgen mg;
@@ -188,7 +188,7 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 	if (!o->is_mapgen_vm)
 		return 0;
 
-	INodeDefManager *ndef = getServer(L)->getNodeDefManager();
+	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
 	MMVManip *vm = o->vm;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1501,7 +1501,7 @@ void Server::SendItemDef(session_t peer_id,
 }
 
 void Server::SendNodeDef(session_t peer_id,
-		INodeDefManager *nodedef, u16 protocol_version)
+	const NodeDefManager *nodedef, u16 protocol_version)
 {
 	NetworkPacket pkt(TOCLIENT_NODEDEF, 0, peer_id);
 
@@ -3341,7 +3341,7 @@ IItemDefManager *Server::getItemDefManager()
 	return m_itemdef;
 }
 
-INodeDefManager *Server::getNodeDefManager()
+const NodeDefManager *Server::getNodeDefManager()
 {
 	return m_nodedef;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3366,7 +3366,7 @@ IWritableItemDefManager *Server::getWritableItemDefManager()
 	return m_itemdef;
 }
 
-IWritableNodeDefManager *Server::getWritableNodeDefManager()
+NodeDefManager *Server::getWritableNodeDefManager()
 {
 	return m_nodedef;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -45,7 +45,7 @@ class ChatEvent;
 struct ChatEventChat;
 struct ChatInterface;
 class IWritableItemDefManager;
-class IWritableNodeDefManager;
+class NodeDefManager;
 class IWritableCraftDefManager;
 class BanManager;
 class EventManager;
@@ -264,7 +264,7 @@ public:
 	virtual EmergeManager *getEmergeManager() { return m_emerge; }
 
 	IWritableItemDefManager* getWritableItemDefManager();
-	IWritableNodeDefManager* getWritableNodeDefManager();
+	NodeDefManager* getWritableNodeDefManager();
 	IWritableCraftDefManager* getWritableCraftDefManager();
 
 	virtual const std::vector<ModSpec> &getMods() const { return m_mods; }
@@ -544,7 +544,7 @@ private:
 	IWritableItemDefManager *m_itemdef;
 
 	// Node definition manager
-	IWritableNodeDefManager *m_nodedef;
+	NodeDefManager *m_nodedef;
 
 	// Craft definition manager
 	IWritableCraftDefManager *m_craftdef;

--- a/src/server.h
+++ b/src/server.h
@@ -256,7 +256,7 @@ public:
 	// IGameDef interface
 	// Under envlock
 	virtual IItemDefManager* getItemDefManager();
-	virtual INodeDefManager* getNodeDefManager();
+	virtual const NodeDefManager* getNodeDefManager();
 	virtual ICraftDefManager* getCraftDefManager();
 	virtual u16 allocateUnknownNodeId(const std::string &name);
 	virtual MtEventManager* getEventManager();
@@ -366,7 +366,8 @@ private:
 	void SendDeathscreen(session_t peer_id, bool set_camera_point_target,
 		v3f camera_point_target);
 	void SendItemDef(session_t peer_id, IItemDefManager *itemdef, u16 protocol_version);
-	void SendNodeDef(session_t peer_id, INodeDefManager *nodedef, u16 protocol_version);
+	void SendNodeDef(session_t peer_id, const NodeDefManager *nodedef,
+		u16 protocol_version);
 
 	/* mark blocks not sent for all clients */
 	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -80,7 +80,7 @@ void LBMContentMapping::addLBM(LoadingBlockModifierDef *lbm_def, IGameDef *gamed
 {
 	// Add the lbm_def to the LBMContentMapping.
 	// Unknown names get added to the global NameIdMapping.
-	INodeDefManager *nodedef = gamedef->ndef();
+	const NodeDefManager *nodedef = gamedef->ndef();
 
 	lbm_list.push_back(lbm_def);
 
@@ -691,7 +691,7 @@ public:
 	{
 		if(dtime_s < 0.001)
 			return;
-		INodeDefManager *ndef = env->getGameDef()->ndef();
+		const NodeDefManager *ndef = env->getGameDef()->ndef();
 		for (ABMWithState &abmws : abms) {
 			ActiveBlockModifier *abm = abmws.abm;
 			float trigger_interval = abm->getTriggerInterval();
@@ -914,7 +914,7 @@ void ServerEnvironment::addLoadingBlockModifierDef(LoadingBlockModifierDef *lbm)
 
 bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 {
-	INodeDefManager *ndef = m_server->ndef();
+	const NodeDefManager *ndef = m_server->ndef();
 	MapNode n_old = m_map->getNodeNoEx(p);
 
 	const ContentFeatures &cf_old = ndef->get(n_old);
@@ -947,7 +947,7 @@ bool ServerEnvironment::setNode(v3s16 p, const MapNode &n)
 
 bool ServerEnvironment::removeNode(v3s16 p)
 {
-	INodeDefManager *ndef = m_server->ndef();
+	const NodeDefManager *ndef = m_server->ndef();
 	MapNode n_old = m_map->getNodeNoEx(p);
 
 	// Call destructor

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -113,7 +113,7 @@ TestGameDef::~TestGameDef()
 void TestGameDef::defineSomeNodes()
 {
 	IWritableItemDefManager *idef = (IWritableItemDefManager *)m_itemdef;
-	IWritableNodeDefManager *ndef = (IWritableNodeDefManager *)m_nodedef;
+	NodeDefManager *ndef = (NodeDefManager *)m_nodedef;
 
 	ItemDefinition itemdef;
 	ContentFeatures f;

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -45,7 +45,7 @@ public:
 	~TestGameDef();
 
 	IItemDefManager *getItemDefManager() { return m_itemdef; }
-	INodeDefManager *getNodeDefManager() { return m_nodedef; }
+	const NodeDefManager *getNodeDefManager() { return m_nodedef; }
 	ICraftDefManager *getCraftDefManager() { return m_craftdef; }
 	ITextureSource *getTextureSource() { return m_texturesrc; }
 	IShaderSource *getShaderSource() { return m_shadersrc; }
@@ -80,7 +80,7 @@ public:
 
 private:
 	IItemDefManager *m_itemdef = nullptr;
-	INodeDefManager *m_nodedef = nullptr;
+	const NodeDefManager *m_nodedef = nullptr;
 	ICraftDefManager *m_craftdef = nullptr;
 	ITextureSource *m_texturesrc = nullptr;
 	IShaderSource *m_shadersrc = nullptr;

--- a/src/unittest/test_mapnode.cpp
+++ b/src/unittest/test_mapnode.cpp
@@ -31,7 +31,7 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
-	void testNodeProperties(INodeDefManager *nodedef);
+	void testNodeProperties(const NodeDefManager *nodedef);
 };
 
 static TestMapNode g_test_instance;
@@ -43,7 +43,7 @@ void TestMapNode::runTests(IGameDef *gamedef)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TestMapNode::testNodeProperties(INodeDefManager *nodedef)
+void TestMapNode::testNodeProperties(const NodeDefManager *nodedef)
 {
 	MapNode n(CONTENT_AIR);
 

--- a/src/unittest/test_noderesolver.cpp
+++ b/src/unittest/test_noderesolver.cpp
@@ -34,18 +34,18 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
-	void testNodeResolving(IWritableNodeDefManager *ndef);
-	void testPendingResolveCancellation(IWritableNodeDefManager *ndef);
-	void testDirectResolveMethod(IWritableNodeDefManager *ndef);
-	void testNoneResolveMethod(IWritableNodeDefManager *ndef);
+	void testNodeResolving(NodeDefManager *ndef);
+	void testPendingResolveCancellation(NodeDefManager *ndef);
+	void testDirectResolveMethod(NodeDefManager *ndef);
+	void testNoneResolveMethod(NodeDefManager *ndef);
 };
 
 static TestNodeResolver g_test_instance;
 
 void TestNodeResolver::runTests(IGameDef *gamedef)
 {
-	IWritableNodeDefManager *ndef =
-		(IWritableNodeDefManager *)gamedef->getNodeDefManager();
+	NodeDefManager *ndef =
+		(NodeDefManager *)gamedef->getNodeDefManager();
 
 	ndef->resetNodeResolveState();
 	TEST(testNodeResolving, ndef);
@@ -104,7 +104,7 @@ void Foobaz::resolveNodeNames()
 }
 
 
-void TestNodeResolver::testNodeResolving(IWritableNodeDefManager *ndef)
+void TestNodeResolver::testNodeResolving(NodeDefManager *ndef)
 {
 	Foobar foobar;
 	size_t i;
@@ -182,7 +182,7 @@ void TestNodeResolver::testNodeResolving(IWritableNodeDefManager *ndef)
 }
 
 
-void TestNodeResolver::testPendingResolveCancellation(IWritableNodeDefManager *ndef)
+void TestNodeResolver::testPendingResolveCancellation(NodeDefManager *ndef)
 {
 	Foobaz foobaz1;
 	foobaz1.test_content1 = 1234;

--- a/src/unittest/test_schematic.cpp
+++ b/src/unittest/test_schematic.cpp
@@ -44,8 +44,8 @@ static TestSchematic g_test_instance;
 
 void TestSchematic::runTests(IGameDef *gamedef)
 {
-	IWritableNodeDefManager *ndef =
-		(IWritableNodeDefManager *)gamedef->getNodeDefManager();
+	NodeDefManager *ndef =
+		(NodeDefManager *)gamedef->getNodeDefManager();
 
 	ndef->setNodeRegistrationStatus(true);
 

--- a/src/unittest/test_schematic.cpp
+++ b/src/unittest/test_schematic.cpp
@@ -30,9 +30,9 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
-	void testMtsSerializeDeserialize(INodeDefManager *ndef);
-	void testLuaTableSerialize(INodeDefManager *ndef);
-	void testFileSerializeDeserialize(INodeDefManager *ndef);
+	void testMtsSerializeDeserialize(const NodeDefManager *ndef);
+	void testLuaTableSerialize(const NodeDefManager *ndef);
+	void testFileSerializeDeserialize(const NodeDefManager *ndef);
 
 	static const content_t test_schem1_data[7 * 6 * 4];
 	static const content_t test_schem2_data[3 * 3 * 3];
@@ -58,7 +58,7 @@ void TestSchematic::runTests(IGameDef *gamedef)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TestSchematic::testMtsSerializeDeserialize(INodeDefManager *ndef)
+void TestSchematic::testMtsSerializeDeserialize(const NodeDefManager *ndef)
 {
 	static const v3s16 size(7, 6, 4);
 	static const u32 volume = size.X * size.Y * size.Z;
@@ -104,7 +104,7 @@ void TestSchematic::testMtsSerializeDeserialize(INodeDefManager *ndef)
 }
 
 
-void TestSchematic::testLuaTableSerialize(INodeDefManager *ndef)
+void TestSchematic::testLuaTableSerialize(const NodeDefManager *ndef)
 {
 	static const v3s16 size(3, 3, 3);
 	static const u32 volume = size.X * size.Y * size.Z;
@@ -132,7 +132,7 @@ void TestSchematic::testLuaTableSerialize(INodeDefManager *ndef)
 }
 
 
-void TestSchematic::testFileSerializeDeserialize(INodeDefManager *ndef)
+void TestSchematic::testFileSerializeDeserialize(const NodeDefManager *ndef)
 {
 	static const v3s16 size(3, 3, 3);
 	static const u32 volume = size.X * size.Y * size.Z;

--- a/src/unittest/test_voxelalgorithms.cpp
+++ b/src/unittest/test_voxelalgorithms.cpp
@@ -30,21 +30,21 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
-	void testVoxelLineIterator(INodeDefManager *ndef);
+	void testVoxelLineIterator(const NodeDefManager *ndef);
 };
 
 static TestVoxelAlgorithms g_test_instance;
 
 void TestVoxelAlgorithms::runTests(IGameDef *gamedef)
 {
-	INodeDefManager *ndef = gamedef->getNodeDefManager();
+	const NodeDefManager *ndef = gamedef->getNodeDefManager();
 
 	TEST(testVoxelLineIterator, ndef);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TestVoxelAlgorithms::testVoxelLineIterator(INodeDefManager *ndef)
+void TestVoxelAlgorithms::testVoxelLineIterator(const NodeDefManager *ndef)
 {
 	// Test some lines
 	// Do not test lines that start or end on the border of

--- a/src/unittest/test_voxelmanipulator.cpp
+++ b/src/unittest/test_voxelmanipulator.cpp
@@ -33,7 +33,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testVoxelArea();
-	void testVoxelManipulator(INodeDefManager *nodedef);
+	void testVoxelManipulator(const NodeDefManager *nodedef);
 };
 
 static TestVoxelManipulator g_test_instance;
@@ -80,7 +80,7 @@ void TestVoxelManipulator::testVoxelArea()
 }
 
 
-void TestVoxelManipulator::testVoxelManipulator(INodeDefManager *nodedef)
+void TestVoxelManipulator::testVoxelManipulator(const NodeDefManager *nodedef)
 {
 	VoxelManipulator v;
 

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -48,8 +48,8 @@ void VoxelManipulator::clear()
 	m_flags = nullptr;
 }
 
-void VoxelManipulator::print(std::ostream &o, INodeDefManager *ndef,
-		VoxelPrintMode mode)
+void VoxelManipulator::print(std::ostream &o, const NodeDefManager *ndef,
+	VoxelPrintMode mode)
 {
 	const v3s16 &em = m_area.getExtent();
 	v3s16 of = m_area.MinEdge;

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include "util/basic_macros.h"
 
-class INodeDefManager;
+class NodeDefManager;
 
 // For VC++
 #undef min
@@ -449,7 +449,7 @@ public:
 
 	virtual void clear();
 
-	void print(std::ostream &o, INodeDefManager *nodemgr,
+	void print(std::ostream &o, const NodeDefManager *nodemgr,
 			VoxelPrintMode mode=VOXELPRINT_MATERIAL);
 
 	void addArea(const VoxelArea &area);

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -246,7 +246,7 @@ bool step_rel_block_pos(direction dir, relative_v3 &rel_pos,
  * \param light_sources nodes that should be re-lighted
  * \param modified_blocks output, all modified map blocks are added to this
  */
-void unspread_light(Map *map, INodeDefManager *nodemgr, LightBank bank,
+void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	UnlightQueue &from_nodes, ReLightQueue &light_sources,
 	std::map<v3s16, MapBlock*> &modified_blocks)
 {
@@ -350,7 +350,7 @@ void unspread_light(Map *map, INodeDefManager *nodemgr, LightBank bank,
  * \param light_sources starting nodes
  * \param modified_blocks output, all modified map blocks are added to this
  */
-void spread_light(Map *map, INodeDefManager *nodemgr, LightBank bank,
+void spread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	LightQueue &light_sources,
 	std::map<v3s16, MapBlock*> &modified_blocks)
 {
@@ -427,7 +427,7 @@ struct SunlightPropagationData{
  *
  * \param pos position of the node.
  */
-bool is_sunlight_above(Map *map, v3s16 pos, INodeDefManager *ndef)
+bool is_sunlight_above(Map *map, v3s16 pos, const NodeDefManager *ndef)
 {
 	bool sunlight = true;
 	mapblock_v3 source_block_pos;
@@ -470,7 +470,7 @@ void update_lighting_nodes(Map *map,
 	std::vector<std::pair<v3s16, MapNode> > &oldnodes,
 	std::map<v3s16, MapBlock*> &modified_blocks)
 {
-	INodeDefManager *ndef = map->getNodeDefManager();
+	const NodeDefManager *ndef = map->getNodeDefManager();
 	// For node getter functions
 	bool is_valid_position;
 
@@ -664,8 +664,8 @@ const VoxelArea block_borders[] = {
  * its light source and its brightest neighbor minus one.
  * .
  */
-bool is_light_locally_correct(Map *map, INodeDefManager *ndef, LightBank bank,
-	v3s16 pos)
+bool is_light_locally_correct(Map *map, const NodeDefManager *ndef,
+	LightBank bank, v3s16 pos)
 {
 	bool is_valid_position;
 	MapNode n = map->getNodeNoEx(pos, &is_valid_position);
@@ -691,7 +691,7 @@ bool is_light_locally_correct(Map *map, INodeDefManager *ndef, LightBank bank,
 void update_block_border_lighting(Map *map, MapBlock *block,
 	std::map<v3s16, MapBlock*> &modified_blocks)
 {
-	INodeDefManager *ndef = map->getNodeDefManager();
+	const NodeDefManager *ndef = map->getNodeDefManager();
 	bool is_valid_position;
 	for (LightBank bank : banks) {
 		// Since invalid light is not common, do not allocate
@@ -777,7 +777,7 @@ void update_block_border_lighting(Map *map, MapBlock *block,
  * After the procedure returns, this contains outgoing light at
  * the bottom of the voxel manipulator.
  */
-void fill_with_sunlight(MMVManip *vm, INodeDefManager *ndef, v2s16 offset,
+void fill_with_sunlight(MMVManip *vm, const NodeDefManager *ndef, v2s16 offset,
 	bool light[MAP_BLOCKSIZE][MAP_BLOCKSIZE])
 {
 	// Distance in array between two nodes on top of each other.
@@ -829,7 +829,7 @@ void fill_with_sunlight(MMVManip *vm, INodeDefManager *ndef, v2s16 offset,
  * node coordinates.
  */
 void is_sunlight_above_block(ServerMap *map, mapblock_v3 pos,
-	INodeDefManager *ndef, bool light[MAP_BLOCKSIZE][MAP_BLOCKSIZE])
+	const NodeDefManager *ndef, bool light[MAP_BLOCKSIZE][MAP_BLOCKSIZE])
 {
 	mapblock_v3 source_block_pos = pos + v3s16(0, 1, 0);
 	// Get or load source block.
@@ -874,7 +874,7 @@ void is_sunlight_above_block(ServerMap *map, mapblock_v3 pos,
  *
  * \returns true if the block was modified, false otherwise.
  */
-bool propagate_block_sunlight(Map *map, INodeDefManager *ndef,
+bool propagate_block_sunlight(Map *map, const NodeDefManager *ndef,
 	SunlightPropagationData *data, UnlightQueue *unlight, ReLightQueue *relight)
 {
 	bool modified = false;
@@ -980,7 +980,7 @@ void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 	mapblock_v3 maxblock, UnlightQueue unlight[2], ReLightQueue relight[2],
 	std::map<v3s16, MapBlock*> *modified_blocks)
 {
-	INodeDefManager *ndef = map->getNodeDefManager();
+	const NodeDefManager *ndef = map->getNodeDefManager();
 	// dummy boolean
 	bool is_valid;
 
@@ -1048,7 +1048,7 @@ void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 void blit_back_with_light(ServerMap *map, MMVManip *vm,
 	std::map<v3s16, MapBlock*> *modified_blocks)
 {
-	INodeDefManager *ndef = map->getNodeDefManager();
+	const NodeDefManager *ndef = map->getNodeDefManager();
 	mapblock_v3 minblock = getNodeBlockPos(vm->m_area.MinEdge);
 	mapblock_v3 maxblock = getNodeBlockPos(vm->m_area.MaxEdge);
 	// First queue is for day light, second is for night light.
@@ -1152,7 +1152,7 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
  * After the procedure returns, this contains outgoing light at
  * the bottom of the map block.
  */
-void fill_with_sunlight(MapBlock *block, INodeDefManager *ndef,
+void fill_with_sunlight(MapBlock *block, const NodeDefManager *ndef,
 	bool light[MAP_BLOCKSIZE][MAP_BLOCKSIZE])
 {
 	if (block->isDummy())
@@ -1190,7 +1190,7 @@ void repair_block_light(ServerMap *map, MapBlock *block,
 {
 	if (!block || block->isDummy())
 		return;
-	INodeDefManager *ndef = map->getNodeDefManager();
+	const NodeDefManager *ndef = map->getNodeDefManager();
 	// First queue is for day light, second is for night light.
 	UnlightQueue unlight[] = { UnlightQueue(256), UnlightQueue(256) };
 	ReLightQueue relight[] = { ReLightQueue(256), ReLightQueue(256) };

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -337,7 +337,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 	ITextureSource *tsrc = client->getTextureSource();
 	IItemDefManager *idef = client->getItemDefManager();
 	IShaderSource *shdrsrc = client->getShaderSource();
-	INodeDefManager *ndef = client->getNodeDefManager();
+	const NodeDefManager *ndef = client->getNodeDefManager();
 	const ItemDefinition &def = item.getDefinition(idef);
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);
@@ -495,7 +495,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 {
 	ITextureSource *tsrc = client->getTextureSource();
 	IItemDefManager *idef = client->getItemDefManager();
-	INodeDefManager *ndef = client->getNodeDefManager();
+	const NodeDefManager *ndef = client->getNodeDefManager();
 	const ItemDefinition &def = item.getDefinition(idef);
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);


### PR DESCRIPTION
This is mainly a maintenance PR, put there is a smaller performance improvement too.

There was three classes associated with the node definition manager:

- `INodeDefManager` in `nodedef.h`: a wrapper interface for reading the manager
- `IWritableNodeDefManager` in `nodedef.h`: a wrapper interface for modifying the manager
- `CNodeDefManager`.cpp in `nodedef.cpp`: actual implementation

I moved these three classes into one `NodeDefManager` class. This eliminates the virtual function calls generated by the interfaces, slightly increasing performance where `INodeDefManager::get()` was frequently called. But more importantly, making the manager easier to understand. Now new contributors will find the implementation more easily. The changes on an image:
![nodedef](https://user-images.githubusercontent.com/20600448/35781718-f2d45bb0-09ed-11e8-9e1f-e4dd0e1056a3.png)

Performance difference:

  | mapgen v7 | mesh generation | liquid reflow scan | /fixlight here 32
-- | -- | -- | -- | --
Current | 137238,5 μs/chunk | 2143,5 μs/block | 71,1 μs/block | 125321,1 μs
This PR | 137348,4 μs/chunk | 2105,3 μs/block | 49,0 μs/block | 110190,9 μs
Change | 0,08% | -1,78% | -31,08% | -12,07%

I made the following steps to achieve this, in each step you should be able to compile the source code:

1. Rename `IWritableNodeDefManager` to `NodeDefManager`: this interface contains all methods that are used elsewhere, this will be the base of the new class.
2. Make `INodeDefManager` functions constant: there are listeners that listen on node registration completion. Even a constant pointer to `NodeDefManager` should be able to register listeners (the actual content of the manager remains constant). Therefore, I made the listener array `mutable`.
3. Replace all `INodeDefManager` pointers with `const NodeDefManager` pointers
4. Remove `INodeDefManager`: it is not used anymore.
5. Merge `NodeDefManager` with `CNodeDefManager`: move data fields and inline methods to the header file. `NodeDefManager` has no more virtual members.
6. Add doxygen documentation: make the manager contributor-friendly.

The possible downsides that I see:

- Conflicts with other PRs: fortunately resolving the conflicts is easy: just replace `*INodeDefManager` with `const *NodeDefManager`.
- Breaks consistency with `IItemDefManager` and `ICraftDefManager`: maybe those should be refactored too.
- If the implementation is changed (a new member will be added to the class), lots of files will need recompiling: the structure of the node definition manager is changed rarely.