### PR TITLE
Falling.lua: Delete falling node entities on contact with 'ignore'

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -60,8 +60,13 @@ core.register_entity(":__builtin:falling_node", {
 		local pos = self.object:getpos()
 		-- Position of bottom center point
 		local bcp = {x = pos.x, y = pos.y - 0.7, z = pos.z}
-		-- Avoid bugs caused by an unloaded node below
+		-- 'bcn' is nil for unloaded nodes
 		local bcn = core.get_node_or_nil(bcp)
+		-- Delete on contact with ignore at world edges
+		if bcn and bcn.name == "ignore" then
+			self.object:remove()
+			return
+		end
 		local bcd = bcn and core.registered_nodes[bcn.name]
 		if bcn and
 				(not bcd or bcd.walkable or


### PR DESCRIPTION
Prevents falling node entities entering the ignore at a world edge and
resting on unloaded nodes 16 nodes below, unreachable, undiggable and
still being processed by 'on step' because they don't revert to nodes.
//////////////////

See #6984 
Will be needed if #6998 is merged, for the situation of a reduced 'mapgen limit' setting, which causes world outside the limit to have an irregular world edge. This PR helps by being a per-node approach rather than deleting at a fixed distance as in #5889

In MT master:

In the situation of a generated mapchunk above a world edge, the generated mapchunk has a single layer of loaded mapblocks below it (the padding of the mapchunk) filled with ignore, below that is unloaded blocks.

Falling node entities fall through the ignore and end up resting on unloaded area 16 nodes below the generated mapchunk, but do not revert to nodes so continue to be processed by 'on step' lua code. They are unreachable by players but also not pickupable even if a player noclips through ignore to reach them. They become an intensive and hard to fix problem for a server.

The changes in mapgen.cpp are only there to allow testing of this PR, they simluate the changes of #6998 