### PR TITLE
Position entity nametags relative to selection-box

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -636,7 +636,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 	if (node && !m_prop.nametag.empty() && !m_is_local_player) {
 		// Add nametag
 		v3f pos;
-		pos.Y = m_prop.collisionbox.MaxEdge.Y + 0.3f;
+		pos.Y = m_prop.selectionbox.MaxEdge.Y + 0.3f;
 		m_nametag = m_client->getCamera()->addNametag(node,
 			m_prop.nametag, m_prop.nametag_color,
 			pos);


### PR DESCRIPTION
Partly addresses #7025

Trivial PR to use the selection-box instead of the collision-box to determine nametag position. This probably should have been done as part of #6218 and would have had I been aware of this usage.