### PR TITLE
Item entity: Delete in 'ignore' nodes

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -145,11 +145,17 @@ core.register_entity(":__builtin:item", {
 			y = pos.y + self.object:get_properties().collisionbox[2] - 0.05,
 			z = pos.z
 		})
+		-- Delete in 'ignore' nodes
+		if node and node.name == "ignore" then
+			self.itemstring = ""
+			self.object:remove()
+			return
+		end
+
 		local vel = self.object:getvelocity()
 		local def = node and core.registered_nodes[node.name]
-		-- Avoid entity falling into ignore nodes or unloaded areas
-		local is_moving = node and node.name ~= "ignore" and
-			((def and not def.walkable) or vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0)
+		local is_moving = (def and not def.walkable) or
+			vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0
 		local is_slippery = false
 
 		if def and def.walkable then


### PR DESCRIPTION
Better implementation of 520293b4cbcdc0ae3c435150114dfe0be7f9582d #6999 (that change, that set velocity to zero in ignore, is reverted).
Deleting the item entity is more consistent with previous behaviour and with the deletion of falling nodes in #7024 
This is part of world edge stuff, see #6984 

The change in mapgen.cpp is only there to allow testing of this PR, i will remove that change if approved.