### PR TITLE
Fix missing warningstream (or similar problem)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1212,13 +1212,6 @@ language (Language) enum   ,be,ca,cs,da,de,dv,en,eo,es,et,fr,he,hu,id,it,ja,jbo,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
-#    ANSI colored logs: red error log, yellow warning and grey info and verbose logs
-#    Note that it doesn't work on Windows
-#    "yes" always enables it,
-#    "detect" enables it when printing to terminal and
-#    "no" disables it
-log_color (Colored logs) enum detect yes,detect,no
-
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -351,7 +351,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
-	settings->setDefault("log_color", "detect");
 	settings->setDefault("emergequeue_limit_total", "256");
 	settings->setDefault("emergequeue_limit_diskonly", "32");
 	settings->setDefault("emergequeue_limit_generate", "32");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -251,6 +251,8 @@ const std::string Logger::getLevelLabel(LogLevel lev)
 	return names[lev];
 }
 
+LogColor Logger::color_mode = LOG_COLOR_AUTO;
+
 const std::string Logger::getThreadName()
 {
 	std::map<std::thread::id, std::string>::const_iterator it;

--- a/src/log.h
+++ b/src/log.h
@@ -121,7 +121,7 @@ public:
 		colored = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
 			(Logger::color_mode == LOG_COLOR_AUTO && isatty(fileno(stdout)));
 #else
-		colored = Logger::color_mode == COLOR_ALWAYS;
+		colored = Logger::color_mode == LOG_COLOR_ALWAYS;
 #endif
 	}
 

--- a/src/log.h
+++ b/src/log.h
@@ -28,7 +28,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #if !defined(_WIN32)  // POSIX
 	#include <unistd.h>
 #endif
-#include "settings.h"
 #include "irrlichttypes.h"
 
 class ILogOutput;
@@ -41,6 +40,12 @@ enum LogLevel {
 	LL_INFO,
 	LL_VERBOSE,
 	LL_MAX,
+};
+
+enum LogColor {
+	LOG_COLOR_NEVER,
+	LOG_COLOR_ALWAYS,
+	LOG_COLOR_AUTO,
 };
 
 typedef u8 LogLevelMask;
@@ -67,6 +72,8 @@ public:
 
 	static LogLevel stringToLevel(const std::string &name);
 	static const std::string getLevelLabel(LogLevel lev);
+
+	static LogColor color_mode;
 
 private:
 	void logToOutputsRaw(LogLevel, const std::string &line);
@@ -111,18 +118,17 @@ public:
 		m_stream(stream)
 	{
 #if !defined(_WIN32)
-		is_tty = isatty(fileno(stdout));
+		colored = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
+			(Logger::color_mode == LOG_COLOR_AUTO && isatty(fileno(stdout)));
 #else
-		is_tty = false;
+		colored = Logger::color_mode == COLOR_ALWAYS;
 #endif
 	}
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{
-		static const std::string use_logcolor = g_settings->get("log_color");
-
-		bool colored = use_logcolor == "detect" ? is_tty : use_logcolor == "yes";
-		if (colored)
+		bool colored_message = colored;
+		if (colored_message)
 			switch (lev) {
 			case LL_ERROR:
 				// error is red
@@ -142,19 +148,19 @@ public:
 				break;
 			default:
 				// action is white
-				colored = false;
+				colored_message = false;
 			}
 
 		m_stream << line << std::endl;
 
-		if (colored)
+		if (colored_message)
 			// reset to white color
 			m_stream << "\033[0m";
 	}
 
 private:
 	std::ostream &m_stream;
-	bool is_tty;
+	bool colored;
 };
 
 class FileLogOutput : public ICombinedLogOutput {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,9 +257,15 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Set world by name (implies local game)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
+#if !defined(_WIN32)
 	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
-			_("Coloured logs ('always', 'never' or 'auto'), 'auto' doesn't "
-				"work on Windows."))));
+			_("Coloured logs ('always', 'never' or 'auto'), defaults to 'auto'"
+			))));
+#else
+	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
+			_("Coloured logs ('always' or 'never'), defaults to 'never'"
+			))));
+#endif
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
 			_("Print more information to console"))));
 	allowed_options->insert(std::make_pair("verbose",  ValueSpec(VALUETYPE_FLAG,
@@ -388,8 +394,12 @@ static void setup_log_params(const Settings &cmd_args)
 	// Coloured log messages (see log.h)
 	if (cmd_args.exists("color")) {
 		std::string mode = cmd_args.get("color");
-		Logger::color_mode = (mode == "auto") ? LOG_COLOR_AUTO :
-			(mode == "always") ? LOG_COLOR_ALWAYS : LOG_COLOR_NEVER;
+		if (mode == "auto")
+			Logger::color_mode = LOG_COLOR_AUTO;
+		else if (mode == "always")
+			Logger::color_mode = LOG_COLOR_ALWAYS;
+		else
+			Logger::color_mode = LOG_COLOR_NEVER;
 	}
 
 	// If trace is enabled, enable logging of certain things

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,16 +258,8 @@ static void set_allowed_options(OptionList *allowed_options)
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
 	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
-			_("ANSI colored logs: red error log, yellow warning and grey info "
-				"and verbose logs\n"
-				// same argument names as for ls, dmesg and other well known
-				// commands for consistency reasons
-				"Set this parameter to \"always\" to enable colourization even "
-				"when not printing to a tty,\n"
-				"\"never\" to disable colourization or\n"
-				"\"auto\" (default) to enable colourization only when printing "
-				"to a tty.\n"
-				"Note that \"auto\" does not work on Windows."))));
+			_("Coloured logs ('always', 'never' or 'auto'), 'auto' doesn't "
+				"work on Windows."))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
 			_("Print more information to console"))));
 	allowed_options->insert(std::make_pair("verbose",  ValueSpec(VALUETYPE_FLAG,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,6 +257,17 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Set world by name (implies local game)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
+	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
+			_("ANSI colored logs: red error log, yellow warning and grey info "
+				"and verbose logs\n"
+				// same argument names as for ls, dmesg and other well known
+				// commands for consistency reasons
+				"Set this parameter to \"always\" to enable colourization even "
+				"when not printing to a tty,\n"
+				"\"never\" to disable colourization or\n"
+				"\"auto\" (default) to enable colourization only when printing "
+				"to a tty.\n"
+				"Note that \"auto\" does not work on Windows."))));
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
 			_("Print more information to console"))));
 	allowed_options->insert(std::make_pair("verbose",  ValueSpec(VALUETYPE_FLAG,
@@ -380,6 +391,13 @@ static void setup_log_params(const Settings &cmd_args)
 	if (cmd_args.getFlag("quiet")) {
 		g_logger.removeOutput(&stderr_output);
 		g_logger.addOutputMaxLevel(&stderr_output, LL_ERROR);
+	}
+
+	// Coloured log messages (see log.h)
+	if (cmd_args.exists("color")) {
+		std::string mode = cmd_args.get("color");
+		Logger::color_mode = (mode == "auto") ? LOG_COLOR_AUTO :
+			(mode == "always") ? LOG_COLOR_ALWAYS : LOG_COLOR_NEVER;
 	}
 
 	// If trace is enabled, enable logging of certain things


### PR DESCRIPTION
This is a fix for #6861.
Instead of a minetest setting, a command line parameter is used to en-/disable coloured logs.