### PR TITLE
Dungeons: Avoid generation in multiple liquid nodes and 'airlike' 

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -55,14 +55,9 @@ DungeonGen::DungeonGen(INodeDefManager *ndef,
 		// Default dungeon parameters
 		dp.seed = 0;
 
-		dp.c_water       = ndef->getId("mapgen_water_source");
-		dp.c_river_water = ndef->getId("mapgen_river_water_source");
-		dp.c_wall        = ndef->getId("mapgen_cobble");
-		dp.c_alt_wall    = ndef->getId("mapgen_mossycobble");
-		dp.c_stair       = ndef->getId("mapgen_stair_cobble");
-
-		if (dp.c_river_water == CONTENT_IGNORE)
-			dp.c_river_water = ndef->getId("mapgen_water_source");
+		dp.c_wall     = ndef->getId("mapgen_cobble");
+		dp.c_alt_wall = ndef->getId("mapgen_mossycobble");
+		dp.c_stair    = ndef->getId("mapgen_stair_cobble");
 
 		dp.diagonal_dirs       = false;
 		dp.only_in_ground      = true;
@@ -107,17 +102,17 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	vm->clearFlag(VMANIP_FLAG_DUNGEON_INSIDE | VMANIP_FLAG_DUNGEON_PRESERVE);
 
 	if (dp.only_in_ground) {
-		// Set all air and water to be untouchable to make dungeons open to
-		// caves and open air. Optionally set ignore to be untouchable to
-		// prevent protruding dungeons.
+		// Set all air and liquid drawtypes to be untouchable to make dungeons
+		// open to air and liquids. Optionally set ignore to be untouchable to
+		// prevent projecting dungeons.
 		for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 			for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 				u32 i = vm->m_area.index(nmin.X, y, z);
 				for (s16 x = nmin.X; x <= nmax.X; x++) {
 					content_t c = vm->m_data[i].getContent();
-					if (c == CONTENT_AIR || c == dp.c_water ||
-							(preserve_ignore && c == CONTENT_IGNORE) ||
-							c == dp.c_river_water)
+					NodeDrawType dtype = ndef->get(c).drawtype;
+					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
+							(preserve_ignore && c == CONTENT_IGNORE))
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -41,8 +41,6 @@ int dir_to_facedir(v3s16 d);
 struct DungeonParams {
 	s32 seed;
 
-	content_t c_water;
-	content_t c_river_water;
 	content_t c_wall;
 	content_t c_alt_wall;
 	content_t c_stair;

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -886,8 +886,6 @@ void MapgenBasic::generateDungeons(s16 max_stone_y,
 	DungeonParams dp;
 
 	dp.seed             = seed;
-	dp.c_water          = c_water_source;
-	dp.c_river_water    = c_river_water_source;
 
 	dp.only_in_ground   = true;
 	dp.corridor_len_min = 1;

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -557,8 +557,6 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 		DungeonParams dp;
 
 		dp.seed             = seed;
-		dp.c_water          = c_water_source;
-		dp.c_river_water    = c_water_source;
 
 		dp.only_in_ground   = true;
 		dp.corridor_len_min = 1;


### PR DESCRIPTION
Previously only 'mapgen water source' and 'mapgen river water source'
were checked for. Games can use multiple liquid nodes defined for biomes,
many of which will not be aliased to those 2 mapgen aliases, causing
floating dungeons to generate in some liquids.

Now we check for liquid drawtype instead, so can remove liquid nodes
from dungeonparams.

Also check for 'airlike' drawtype instead of 'CONTENT_AIR' to avoid
generation in 'airlike' nodes in some rare situations. This will also be
needed for when we add definable biome air nodes.
//////////////

Bug discovered in a game written by @Ezhh 
Tested.