### PR TITLE
Add `on_auth_fail` callback

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -584,6 +584,7 @@ core.registered_on_priv_grant, core.register_on_priv_grant = make_registration()
 core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration()
 core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_registration()
 core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
+core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2615,6 +2615,10 @@ Call these functions only at load time!
 * `minetest.register_on_leaveplayer(func(ObjectRef, timed_out))`
     * Called when a player leaves the game
     * `timed_out`: True for timeout, false for other reasons.
+* `minetest.register_on_auth_fail(func(name, ip))`
+    * Called when a client attempts to log into an account but supplies the wrong password.
+    * `ip`: The IP address of the client.
+    * `name`: The account the client attempted to log into.
 * `minetest.register_on_cheat(func(ObjectRef, cheat))`
     * Called when a player cheats
     * `cheat`: `{type=<cheat_type>}`, where `<cheat_type>` is one of:

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1735,10 +1735,12 @@ void Server::handleCommand_SrpBytesM(NetworkPacket* pkt)
 			return;
 		}
 
+		std::string ip = getPeerAddress(pkt->getPeerId()).serializeString();
 		actionstream << "Server: User " << client->getName()
-			<< " at " << getPeerAddress(pkt->getPeerId()).serializeString()
+			<< " at " << ip
 			<< " supplied wrong password (auth mechanism: SRP)."
 			<< std::endl;
+		m_script->on_auth_failure(client->getName(), ip);
 		DenyAccess(pkt->getPeerId(), SERVER_ACCESSDENIED_WRONG_PASSWORD);
 		return;
 	}

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -206,3 +206,14 @@ void ScriptApiPlayer::on_playerReceiveFields(ServerActiveObject *player,
 	runCallbacks(3, RUN_CALLBACKS_MODE_OR_SC);
 }
 
+void ScriptApiPlayer::on_auth_failure(const std::string &name, const std::string &ip)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_auth_failure
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_auth_fail");
+	lua_pushstring(L, name.c_str());
+	lua_pushstring(L, ip.c_str());
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
+}

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -45,4 +45,5 @@ public:
 	s16 on_player_hpchange(ServerActiveObject *player, s16 hp_change);
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
+	void on_auth_failure(const std::string &name, const std::string &ip);
 };


### PR DESCRIPTION
Called when a client fails to supply the correct password for the account it's attempting to login as.