### PR TITLE
Dungeons: Add Y limits in all mapgens 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1323,6 +1323,12 @@ mgv5_cavern_taper (Cavern taper) int 256
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv5_cavern_threshold (Cavern threshold) float 0.7
 
+#    Lower Y limit of dungeons.
+mgv5_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv5_dungeon_ymax (Dungeon maximum Y) int 31000
+
 [**Noises]
 
 #    Variation of biome filler depth.
@@ -1363,6 +1369,12 @@ mgv6_freq_desert (Desert noise threshold) float 0.45
 
 #    Sandy beaches occur when np_beach exceeds this value.
 mgv6_freq_beach (Beach noise threshold) float 0.15
+
+#    Lower Y limit of dungeons.
+mgv6_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv6_dungeon_ymax (Dungeon maximum Y) int 31000
 
 [**Noises]
 
@@ -1444,6 +1456,12 @@ mgv7_cavern_taper (Cavern taper) int 256
 #    Defines full size of caverns, smaller values create larger caverns.
 mgv7_cavern_threshold (Cavern threshold) float 0.7
 
+#    Lower Y limit of dungeons.
+mgv7_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgv7_dungeon_ymax (Dungeon maximum Y) int 31000
+
 [**Noises]
 
 #    Y-level of higher (cliff-top) terrain.
@@ -1515,6 +1533,12 @@ mgcarpathian_cavern_taper (Cavern taper) int 256
 
 #    Defines full size of caverns, smaller values create larger caverns.
 mgcarpathian_cavern_threshold (Cavern threshold) float 0.7
+
+#    Lower Y limit of dungeons.
+mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000
 
 [**Noises]
 
@@ -1602,6 +1626,12 @@ mgflat_hill_threshold (Hill threshold) float 0.45
 #    Controls steepness/height of hills.
 mgflat_hill_steepness (Hill steepness) float 64.0
 
+#    Lower Y limit of dungeons.
+mgflat_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgflat_dungeon_ymax (Dungeon maximum Y) int 31000
+
 [**Noises]
 
 #    Defines location and terrain of optional hills and lakes.
@@ -1626,6 +1656,12 @@ mgfractal_large_cave_depth (Large cave depth) int -33
 
 #    Y of upper limit of lava in large caves.
 mgfractal_lava_depth (Lava depth) int -256
+
+#    Lower Y limit of dungeons.
+mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgfractal_dungeon_ymax (Dungeon maximum Y) int 31000
 
 #    Choice of 18 fractals from 9 formulas.
 #    1 = 4D "Roundy" mandelbrot set.
@@ -1733,6 +1769,12 @@ mgvalleys_water_features (Water features) int 0
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgvalleys_cave_width (Cave width) float 0.09
+
+#    Lower Y limit of dungeons.
+mgvalleys_dungeon_ymin (Dungeon minimum Y) int -31000
+
+#    Upper Y limit of dungeons.
+mgvalleys_dungeon_ymax (Dungeon maximum Y) int 31000
 
 [**Noises]
 

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -61,7 +61,10 @@ MapgenCarpathian::MapgenCarpathian(
 	cavern_limit     = params->cavern_limit;
 	cavern_taper     = params->cavern_taper;
 	cavern_threshold = params->cavern_threshold;
-	grad_wl          = 1 - water_level;
+	dungeon_ymin     = params->dungeon_ymin;
+	dungeon_ymax     = params->dungeon_ymax;
+
+	grad_wl = 1 - water_level;
 
 	//// 2D Terrain noise
 	noise_base          = new Noise(&params->np_base,          seed, csize.X, csize.Z);
@@ -136,6 +139,8 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 	settings->getS16NoEx("mgcarpathian_cavern_limit",       cavern_limit);
 	settings->getS16NoEx("mgcarpathian_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgcarpathian_cavern_threshold", cavern_threshold);
+	settings->getS16NoEx("mgcarpathian_dungeon_ymin",       dungeon_ymin);
+	settings->getS16NoEx("mgcarpathian_dungeon_ymax",       dungeon_ymax);
 
 	settings->getNoiseParams("mgcarpathian_np_base",          np_base);
 	settings->getNoiseParams("mgcarpathian_np_filler_depth",  np_filler_depth);
@@ -165,6 +170,8 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setS16("mgcarpathian_cavern_limit",       cavern_limit);
 	settings->setS16("mgcarpathian_cavern_taper",       cavern_taper);
 	settings->setFloat("mgcarpathian_cavern_threshold", cavern_threshold);
+	settings->setS16("mgcarpathian_dungeon_ymin",       dungeon_ymin);
+	settings->setS16("mgcarpathian_dungeon_ymax",       dungeon_ymax);
 
 	settings->setNoiseParams("mgcarpathian_np_base",          np_base);
 	settings->setNoiseParams("mgcarpathian_np_filler_depth",  np_filler_depth);
@@ -264,7 +271,8 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate dungeons
-	if (flags & MG_DUNGEONS)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -40,6 +40,8 @@ struct MapgenCarpathianParams : public MapgenParams
 	s16 cavern_limit       = -256;
 	s16 cavern_taper       = 256;
 	float cavern_threshold = 0.7f;
+	s16 dungeon_ymin       = -31000;
+	s16 dungeon_ymax       = 31000;
 
 	NoiseParams np_base;
 	NoiseParams np_filler_depth;
@@ -83,6 +85,8 @@ public:
 private:
 	s16 large_cave_depth;
 	s32 grad_wl;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
 
 	Noise *noise_base;
 	Noise *noise_height1;

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -60,6 +60,8 @@ MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *em
 	lake_steepness   = params->lake_steepness;
 	hill_threshold   = params->hill_threshold;
 	hill_steepness   = params->hill_steepness;
+	dungeon_ymin     = params->dungeon_ymin;
+	dungeon_ymax     = params->dungeon_ymax;
 
 	// 2D noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
@@ -101,6 +103,8 @@ void MapgenFlatParams::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgflat_lake_steepness", lake_steepness);
 	settings->getFloatNoEx("mgflat_hill_threshold", hill_threshold);
 	settings->getFloatNoEx("mgflat_hill_steepness", hill_steepness);
+	settings->getS16NoEx("mgflat_dungeon_ymin",     dungeon_ymin);
+	settings->getS16NoEx("mgflat_dungeon_ymax",     dungeon_ymax);
 
 	settings->getNoiseParams("mgflat_np_terrain",      np_terrain);
 	settings->getNoiseParams("mgflat_np_filler_depth", np_filler_depth);
@@ -120,6 +124,8 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setFloat("mgflat_lake_steepness", lake_steepness);
 	settings->setFloat("mgflat_hill_threshold", hill_threshold);
 	settings->setFloat("mgflat_hill_steepness", hill_steepness);
+	settings->setS16("mgflat_dungeon_ymin",     dungeon_ymin);
+	settings->setS16("mgflat_dungeon_ymax",     dungeon_ymax);
 
 	settings->setNoiseParams("mgflat_np_terrain",      np_terrain);
 	settings->setNoiseParams("mgflat_np_filler_depth", np_filler_depth);
@@ -198,7 +204,8 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
-	if (flags & MG_DUNGEONS)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -41,6 +41,9 @@ struct MapgenFlatParams : public MapgenParams
 	float lake_steepness = 48.0f;
 	float hill_threshold = 0.45f;
 	float hill_steepness = 64.0f;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 31000;
+
 	NoiseParams np_terrain;
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
@@ -72,5 +75,8 @@ private:
 	float lake_steepness;
 	float hill_threshold;
 	float hill_steepness;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
+
 	Noise *noise_terrain;
 };

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -53,6 +53,8 @@ MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeMa
 	cave_width       = params->cave_width;
 	large_cave_depth = params->large_cave_depth;
 	lava_depth       = params->lava_depth;
+	dungeon_ymin     = params->dungeon_ymin;
+	dungeon_ymax     = params->dungeon_ymax;
 	fractal          = params->fractal;
 	iterations       = params->iterations;
 	scale            = params->scale;
@@ -97,6 +99,8 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgfractal_cave_width",     cave_width);
 	settings->getS16NoEx("mgfractal_large_cave_depth", large_cave_depth);
 	settings->getS16NoEx("mgfractal_lava_depth",       lava_depth);
+	settings->getS16NoEx("mgfractal_dungeon_ymin",     dungeon_ymin);
+	settings->getS16NoEx("mgfractal_dungeon_ymax",     dungeon_ymax);
 	settings->getU16NoEx("mgfractal_fractal",          fractal);
 	settings->getU16NoEx("mgfractal_iterations",       iterations);
 	settings->getV3FNoEx("mgfractal_scale",            scale);
@@ -120,6 +124,8 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setFloat("mgfractal_cave_width",     cave_width);
 	settings->setS16("mgfractal_large_cave_depth", large_cave_depth);
 	settings->setS16("mgfractal_lava_depth",       lava_depth);
+	settings->setS16("mgfractal_dungeon_ymin",     dungeon_ymin);
+	settings->setS16("mgfractal_dungeon_ymax",     dungeon_ymax);
 	settings->setU16("mgfractal_fractal",          fractal);
 	settings->setU16("mgfractal_iterations",       iterations);
 	settings->setV3F("mgfractal_scale",            scale);
@@ -208,7 +214,8 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
-	if (flags & MG_DUNGEONS)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -35,6 +35,8 @@ struct MapgenFractalParams : public MapgenParams
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 31000;
 	u16 fractal = 1;
 	u16 iterations = 11;
 	v3f scale = v3f(4096.0, 1024.0, 4096.0);
@@ -44,6 +46,7 @@ struct MapgenFractalParams : public MapgenParams
 	float julia_y = 0.2f;
 	float julia_z = 0.133f;
 	float julia_w = 0.067f;
+
 	NoiseParams np_seabed;
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
@@ -74,6 +77,8 @@ private:
 	bool julia;
 
 	s16 large_cave_depth;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
 	u16 fractal;
 	u16 iterations;
 	v3f scale;

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -55,6 +55,8 @@ MapgenV5::MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge)
 	cavern_limit     = params->cavern_limit;
 	cavern_taper     = params->cavern_taper;
 	cavern_threshold = params->cavern_threshold;
+	dungeon_ymin     = params->dungeon_ymin;
+	dungeon_ymax     = params->dungeon_ymax;
 
 	// Terrain noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
@@ -101,6 +103,8 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getS16NoEx("mgv5_cavern_limit",       cavern_limit);
 	settings->getS16NoEx("mgv5_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgv5_cavern_threshold", cavern_threshold);
+	settings->getS16NoEx("mgv5_dungeon_ymin",       dungeon_ymin);
+	settings->getS16NoEx("mgv5_dungeon_ymax",       dungeon_ymax);
 
 	settings->getNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->getNoiseParams("mgv5_np_factor",       np_factor);
@@ -121,6 +125,8 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setS16("mgv5_cavern_limit",       cavern_limit);
 	settings->setS16("mgv5_cavern_taper",       cavern_taper);
 	settings->setFloat("mgv5_cavern_threshold", cavern_threshold);
+	settings->setS16("mgv5_dungeon_ymin",       dungeon_ymin);
+	settings->setS16("mgv5_dungeon_ymax",       dungeon_ymax);
 
 	settings->setNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgv5_np_factor",       np_factor);
@@ -223,7 +229,8 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate dungeons and desert temples
-	if (flags & MG_DUNGEONS)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -38,6 +38,8 @@ struct MapgenV5Params : public MapgenParams
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 31000;
 
 	NoiseParams np_filler_depth;
 	NoiseParams np_factor;
@@ -68,6 +70,9 @@ public:
 
 private:
 	s16 large_cave_depth;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
+
 	Noise *noise_factor;
 	Noise *noise_height;
 	Noise *noise_ground;

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -63,9 +63,11 @@ MapgenV6::MapgenV6(int mapgenid, MapgenV6Params *params, EmergeManager *emerge)
 
 	heightmap = new s16[csize.X * csize.Z];
 
-	spflags     = params->spflags;
-	freq_desert = params->freq_desert;
-	freq_beach  = params->freq_beach;
+	spflags      = params->spflags;
+	freq_desert  = params->freq_desert;
+	freq_beach   = params->freq_beach;
+	dungeon_ymin = params->dungeon_ymin;
+	dungeon_ymax = params->dungeon_ymax;
 
 	np_cave        = &params->np_cave;
 	np_humidity    = &params->np_humidity;
@@ -166,6 +168,8 @@ void MapgenV6Params::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgv6_spflags", spflags, flagdesc_mapgen_v6);
 	settings->getFloatNoEx("mgv6_freq_desert", freq_desert);
 	settings->getFloatNoEx("mgv6_freq_beach",  freq_beach);
+	settings->getS16NoEx("mgv6_dungeon_ymin",  dungeon_ymin);
+	settings->getS16NoEx("mgv6_dungeon_ymax",  dungeon_ymax);
 
 	settings->getNoiseParams("mgv6_np_terrain_base",   np_terrain_base);
 	settings->getNoiseParams("mgv6_np_terrain_higher", np_terrain_higher);
@@ -186,6 +190,8 @@ void MapgenV6Params::writeParams(Settings *settings) const
 	settings->setFlagStr("mgv6_spflags", spflags, flagdesc_mapgen_v6, U32_MAX);
 	settings->setFloat("mgv6_freq_desert", freq_desert);
 	settings->setFloat("mgv6_freq_beach",  freq_beach);
+	settings->setS16("mgv6_dungeon_ymin",  dungeon_ymin);
+	settings->setS16("mgv6_dungeon_ymax",  dungeon_ymax);
 
 	settings->setNoiseParams("mgv6_np_terrain_base",   np_terrain_base);
 	settings->setNoiseParams("mgv6_np_terrain_higher", np_terrain_higher);
@@ -553,7 +559,8 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Add dungeons
-	if ((flags & MG_DUNGEONS) && (stone_surface_max_y >= node_min.Y)) {
+	if ((flags & MG_DUNGEONS) && stone_surface_max_y >= node_min.Y &&
+			full_node_min.Y >= dungeon_ymin && full_node_max.Y <= dungeon_ymax) {
 		DungeonParams dp;
 
 		dp.seed             = seed;

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -59,6 +59,9 @@ struct MapgenV6Params : public MapgenParams {
 		MGV6_BIOMEBLEND | MGV6_MUDFLOW;
 	float freq_desert = 0.45f;
 	float freq_beach = 0.15f;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 31000;
+
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_higher;
 	NoiseParams np_steepness;
@@ -104,8 +107,11 @@ public:
 	NoiseParams *np_humidity;
 	NoiseParams *np_trees;
 	NoiseParams *np_apple_trees;
+
 	float freq_desert;
 	float freq_beach;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
 
 	content_t c_stone;
 	content_t c_dirt;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -66,6 +66,8 @@ MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
 	cavern_limit         = params->cavern_limit;
 	cavern_taper         = params->cavern_taper;
 	cavern_threshold     = params->cavern_threshold;
+	dungeon_ymin         = params->dungeon_ymin;
+	dungeon_ymax         = params->dungeon_ymax;
 
 	// This is to avoid a divide-by-zero.
 	// Parameter will be saved to map_meta.txt in limited form.
@@ -162,6 +164,8 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getS16NoEx("mgv7_cavern_limit",           cavern_limit);
 	settings->getS16NoEx("mgv7_cavern_taper",           cavern_taper);
 	settings->getFloatNoEx("mgv7_cavern_threshold",     cavern_threshold);
+	settings->getS16NoEx("mgv7_dungeon_ymin",           dungeon_ymin);
+	settings->getS16NoEx("mgv7_dungeon_ymax",           dungeon_ymax);
 
 	settings->getNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
 	settings->getNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
@@ -195,6 +199,8 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setS16("mgv7_cavern_limit",           cavern_limit);
 	settings->setS16("mgv7_cavern_taper",           cavern_taper);
 	settings->setFloat("mgv7_cavern_threshold",     cavern_threshold);
+	settings->setS16("mgv7_dungeon_ymin",           dungeon_ymin);
+	settings->setS16("mgv7_dungeon_ymax",           dungeon_ymax);
 
 	settings->setNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
 	settings->setNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
@@ -327,7 +333,8 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	}
 
 	// Generate dungeons
-	if (flags & MG_DUNGEONS)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -48,6 +48,8 @@ struct MapgenV7Params : public MapgenParams {
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 31000;
 
 	NoiseParams np_terrain_base;
 	NoiseParams np_terrain_alt;
@@ -99,6 +101,8 @@ private:
 	float float_mount_exponent;
 	s16 floatland_level;
 	s16 shadow_limit;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
 
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -78,6 +78,8 @@ MapgenValleys::MapgenValleys(int mapgenid, MapgenValleysParams *params, EmergeMa
 	river_size_factor  = params->river_size / 100.f;
 	water_features_lim = rangelim(params->water_features, 0, 10);
 	cave_width         = params->cave_width;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
 
 	//// 2D Terrain noise
 	noise_filler_depth       = new Noise(&params->np_filler_depth,       seed, csize.X, csize.Z);
@@ -150,6 +152,8 @@ void MapgenValleysParams::readParams(const Settings *settings)
 	settings->getU16NoEx("mgvalleys_river_size",         river_size);
 	settings->getU16NoEx("mgvalleys_water_features",     water_features);
 	settings->getFloatNoEx("mgvalleys_cave_width",       cave_width);
+	settings->getS16NoEx("mgvalleys_dungeon_ymin",       dungeon_ymin);
+	settings->getS16NoEx("mgvalleys_dungeon_ymax",       dungeon_ymax);
 
 	settings->getNoiseParams("mgvalleys_np_cave1",              np_cave1);
 	settings->getNoiseParams("mgvalleys_np_cave2",              np_cave2);
@@ -175,6 +179,8 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setU16("mgvalleys_river_size",         river_size);
 	settings->setU16("mgvalleys_water_features",     water_features);
 	settings->setFloat("mgvalleys_cave_width",       cave_width);
+	settings->setS16("mgvalleys_dungeon_ymin",       dungeon_ymin);
+	settings->setS16("mgvalleys_dungeon_ymax",       dungeon_ymax);
 
 	settings->setNoiseParams("mgvalleys_np_cave1",              np_cave1);
 	settings->setNoiseParams("mgvalleys_np_cave2",              np_cave2);
@@ -244,7 +250,8 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	// Dungeon creation
-	if ((flags & MG_DUNGEONS) && node_max.Y < 50)
+	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
+			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
 
 	// Generate the registered decorations

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -54,6 +54,9 @@ struct MapgenValleysParams : public MapgenParams {
 	u16 river_size = 5; // How wide to make rivers.
 	u16 water_features = 0; // How often water will occur in caves.
 	float cave_width = 0.09f;
+	s16 dungeon_ymin = -31000;
+	s16 dungeon_ymax = 63; // No higher than surface mapchunks
+
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_filler_depth;
@@ -99,19 +102,22 @@ public:
 private:
 	BiomeGenOriginal *m_bgen;
 
+	float altitude_chill;
+	s16 massive_cave_depth;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
+
 	bool humid_rivers;
 	bool use_altitude_chill;
 	float humidity_adjust;
 	s16 cave_water_max_height;
 	s16 lava_max_height;
-
-	float altitude_chill;
 	s16 lava_features_lim;
-	s16 massive_cave_depth;
 	float river_depth_bed;
 	float river_size_factor;
 	float *tcave_cache;
 	s16 water_features_lim;
+
 	Noise *noise_inter_valley_fill;
 	Noise *noise_inter_valley_slope;
 	Noise *noise_rivers;


### PR DESCRIPTION
 Dungeons: Add Y limits in all mapgens

Preserve the upper limit used in mgvalleys.
///////////////

For v5, v6, v7, valleys, carpathian, flat, fractal (all mapgens except singlenode).
Requested by game creators.
This should have been done long ago when i made dungeons occur at all y instead of surface  mapchunk downwards.
Valleys mapgen already limited dungeons to surface mapchunks downwards so that is preserved here.