### PR TITLE
Cleanup in flat lighting

### DIFF
--- a/src/light.h
+++ b/src/light.h
@@ -37,16 +37,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 inline u8 diminish_light(u8 light)
 {
+	assert(light <= LIGHT_SUN);
 	if (light == 0)
 		return 0;
-	if (light >= LIGHT_MAX)
-		return LIGHT_MAX - 1;
-
 	return light - 1;
 }
 
 inline u8 diminish_light(u8 light, u8 distance)
 {
+	assert(light <= LIGHT_SUN);
 	if (distance >= light)
 		return 0;
 	return light - distance;
@@ -59,9 +58,8 @@ inline u8 undiminish_light(u8 light)
 	// Thus, keep it at 0.
 	if (light == 0)
 		return 0;
-	if (light >= LIGHT_MAX)
+	if (light >= LIGHT_SUN)
 		return light;
-
 	return light + 1;
 }
 

--- a/src/light.h
+++ b/src/light.h
@@ -35,34 +35,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // This brightness is reserved for sunlight
 #define LIGHT_SUN 15
 
-inline u8 diminish_light(u8 light)
-{
-	assert(light <= LIGHT_SUN);
-	if (light == 0)
-		return 0;
-	return light - 1;
-}
-
-inline u8 diminish_light(u8 light, u8 distance)
-{
-	assert(light <= LIGHT_SUN);
-	if (distance >= light)
-		return 0;
-	return light - distance;
-}
-
-inline u8 undiminish_light(u8 light)
-{
-	assert(light <= LIGHT_SUN);
-	// We don't know if light should undiminish from this particular 0.
-	// Thus, keep it at 0.
-	if (light == 0)
-		return 0;
-	if (light >= LIGHT_SUN)
-		return light;
-	return light + 1;
-}
-
 #ifndef SERVER
 
 /**

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -122,6 +122,34 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	Light and vertex color functions
 */
 
+inline u8 diminish_light(u8 light)
+{
+	assert(light <= LIGHT_SUN);
+	if (light == 0)
+		return 0;
+	return light - 1;
+}
+
+inline u8 diminish_light(u8 light, u8 distance)
+{
+	assert(light <= LIGHT_SUN);
+	if (distance >= light)
+		return 0;
+	return light - distance;
+}
+
+inline u8 undiminish_light(u8 light)
+{
+	assert(light <= LIGHT_SUN);
+	// We don't know if light should undiminish from this particular 0.
+	// Thus, keep it at 0.
+	if (light == 0)
+		return 0;
+	if (light >= LIGHT_SUN)
+		return light;
+	return light + 1;
+}
+
 /*
 	Calculate non-smooth lighting at interior of node.
 	Single light bank.

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -130,7 +130,7 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 	const NodeDefManager *ndef)
 {
 	u8 light = n.getLight(bank, ndef);
-	if (light)
+	if (light > 0)
 		light = rangelim(light + increment, 0, LIGHT_SUN);
 	return decode_light(light);
 }

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -122,34 +122,6 @@ void MeshMakeData::setSmoothLighting(bool smooth_lighting)
 	Light and vertex color functions
 */
 
-inline u8 diminish_light(u8 light)
-{
-	assert(light <= LIGHT_SUN);
-	if (light == 0)
-		return 0;
-	return light - 1;
-}
-
-inline u8 diminish_light(u8 light, u8 distance)
-{
-	assert(light <= LIGHT_SUN);
-	if (distance >= light)
-		return 0;
-	return light - distance;
-}
-
-inline u8 undiminish_light(u8 light)
-{
-	assert(light <= LIGHT_SUN);
-	// We don't know if light should undiminish from this particular 0.
-	// Thus, keep it at 0.
-	if (light == 0)
-		return 0;
-	if (light >= LIGHT_SUN)
-		return light;
-	return light + 1;
-}
-
 /*
 	Calculate non-smooth lighting at interior of node.
 	Single light bank.
@@ -158,18 +130,8 @@ static u8 getInteriorLight(enum LightBank bank, MapNode n, s32 increment,
 	const NodeDefManager *ndef)
 {
 	u8 light = n.getLight(bank, ndef);
-
-	while(increment > 0)
-	{
-		light = undiminish_light(light);
-		--increment;
-	}
-	while(increment < 0)
-	{
-		light = diminish_light(light);
-		++increment;
-	}
-
+	if (light)
+		light = rangelim(light + increment, 0, LIGHT_SUN);
 	return decode_light(light);
 }
 


### PR DESCRIPTION
Fixes flat lighting part of #7040
![screenshot_20180218_004553](https://user-images.githubusercontent.com/7352626/36346000-bf3fa134-1446-11e8-9bdd-9c695bdc7ba8.png)

////////////////////
EDIT by paramat:
More explanation for reviewers from https://github.com/minetest/minetest/issues/7040#issuecomment-366447191
> nodeboxes use light one level brighter for drawing than their true light value. But to do that, undiminish_light is used, which clamps at LIGHT_MAX, which is 14. So solid nodes get 15, and nodeboxes are drawn at 14 under direct sunlight.

So the difference in light levels only became visible now that light levels 14 and 15 are visibly different due to #6696 