### PR TITLE
Fix for /shutdown don't doing the countdown when using reconnect and/or shutdown message

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -828,7 +828,7 @@ core.register_chatcommand("shutdown", {
 		message = message or ""
 
 		if delay ~= "" then
-			delay = tonumber(param) or 0
+			delay = tonumber(delay) or 0
 		else
 			delay = 0
 			core.log("action", name .. " shuts down server")


### PR DESCRIPTION
Delay was converted from the param string and not the delay value, thus never using the actual given delay value when used in combination with other string values in the param, in this case reconnect and the shutdown messsage.