### PR TITLE
Fix node-nodebox lighting difference in direct sunlight

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -310,12 +310,12 @@ LightInfo MapblockMeshGenerator::blendLight(const v3f &vertex_pos)
 		f32 dx = (k & 4) ? x : 1 - x;
 		f32 dy = (k & 2) ? y : 1 - y;
 		f32 dz = (k & 1) ? z : 1 - z;
+		f32 lightC = frame.sunlight[k] ? 0xFF : frame.lightsA[k];
 		lightA += dx * dy * dz * frame.lightsA[k];
 		lightB += dx * dy * dz * frame.lightsB[k];
-		if (frame.sunlight[k])
-			sunlight += dx * dy * dz;
+		sunlight += dx * dy * dz * lightC;
 	}
-	return LightInfo{lightA, lightB, sunlight_boost_strength * sunlight};
+	return LightInfo{lightA, lightB, sunlight};
 }
 
 // Calculates vertex color to be used in mapblock mesh

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -330,7 +330,8 @@ video::SColor MapblockMeshGenerator::blendLightColor(const v3f &vertex_pos)
 video::SColor MapblockMeshGenerator::blendLightColor(const v3f &vertex_pos,
 	const v3f &vertex_normal)
 {
-	video::SColor color = blendLightColor(vertex_pos);
+	LightInfo light = blendLight(vertex_pos);
+	video::SColor color = encode_light(light.getPair(MYMAX(0.0f, vertex_normal.Y)), f->light_source);
 	if (!f->light_source)
 		applyFacesShading(color, vertex_normal);
 	return color;

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -68,7 +68,6 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 
 	enable_mesh_cache = g_settings->getBool("enable_mesh_cache") &&
 		!data->m_smooth_lighting; // Mesh cache is not supported with smooth lighting
-	sunlight_boost_strength = decode_light(LIGHT_SUN) - decode_light(LIGHT_SUN - 1);
 
 	blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
 }

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -38,9 +38,21 @@ struct LightPair {
 	operator u16() const { return lightA | lightB << 8; }
 };
 
+struct LightInfo {
+	float light_day;
+	float light_night;
+	float sunlight_boost;
+
+	LightPair getPair(float sunlight = 0.0) const
+	{
+		return LightPair(light_day + sunlight * sunlight_boost, light_night);
+	}
+};
+
 struct LightFrame {
 	f32 lightsA[8];
 	f32 lightsB[8];
+	bool sunlight[8];
 };
 
 class MapblockMeshGenerator
@@ -68,8 +80,10 @@ public:
 	float scale;
 
 // lighting
+	float sunlight_boost_strength;
+
 	void getSmoothLightFrame();
-	LightPair blendLight(const v3f &vertex_pos);
+	LightInfo blendLight(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos, const v3f &vertex_normal);
 
@@ -85,7 +99,7 @@ public:
 
 // cuboid drawing!
 	void drawCuboid(const aabb3f &box, TileSpec *tiles, int tilecount,
-		const LightPair *lights , const f32 *txc);
+		const LightInfo *lights , const f32 *txc);
 	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
 	void drawAutoLightedCuboid(aabb3f box, const f32 *txc = NULL,
 		TileSpec *tiles = NULL, int tile_count = 0);

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -45,7 +45,7 @@ struct LightInfo {
 
 	LightPair getPair(float sunlight = 0.0) const
 	{
-		return LightPair(light_day + sunlight * sunlight_boost, light_night);
+		return LightPair((1 - sunlight) * light_day + sunlight * sunlight_boost, light_night);
 	}
 };
 

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -80,8 +80,6 @@ public:
 	float scale;
 
 // lighting
-	float sunlight_boost_strength;
-
 	void getSmoothLightFrame();
 	LightInfo blendLight(const v3f &vertex_pos);
 	video::SColor blendLightColor(const v3f &vertex_pos);

--- a/src/content_mapblock.h
+++ b/src/content_mapblock.h
@@ -26,32 +26,35 @@ struct MeshMakeData;
 struct MeshCollector;
 
 struct LightPair {
-	u8 lightA;
-	u8 lightB;
+	u8 lightDay;
+	u8 lightNight;
 
 	LightPair() = default;
-	explicit LightPair(u16 value) : lightA(value & 0xff), lightB(value >> 8) {}
-	LightPair(u8 valueA, u8 valueB) : lightA(valueA), lightB(valueB) {}
+	explicit LightPair(u16 value) : lightDay(value & 0xff), lightNight(value >> 8) {}
+	LightPair(u8 valueA, u8 valueB) : lightDay(valueA), lightNight(valueB) {}
 	LightPair(float valueA, float valueB) :
-		lightA(core::clamp(core::round32(valueA), 0, 255)),
-		lightB(core::clamp(core::round32(valueB), 0, 255)) {}
-	operator u16() const { return lightA | lightB << 8; }
+		lightDay(core::clamp(core::round32(valueA), 0, 255)),
+		lightNight(core::clamp(core::round32(valueB), 0, 255)) {}
+	operator u16() const { return lightDay | lightNight << 8; }
 };
 
 struct LightInfo {
 	float light_day;
 	float light_night;
-	float sunlight_boost;
+	float light_boosted;
 
-	LightPair getPair(float sunlight = 0.0) const
+	LightPair getPair(float sunlight_boost = 0.0) const
 	{
-		return LightPair((1 - sunlight) * light_day + sunlight * sunlight_boost, light_night);
+		return LightPair(
+			(1 - sunlight_boost) * light_day
+			+ sunlight_boost * light_boosted,
+			light_night);
 	}
 };
 
 struct LightFrame {
-	f32 lightsA[8];
-	f32 lightsB[8];
+	f32 lightsDay[8];
+	f32 lightsNight[8];
 	bool sunlight[8];
 };
 

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -206,7 +206,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	u8 light_source_max = 0;
 	u16 light_day = 0;
 	u16 light_night = 0;
-	bool sunlight = false;
+	bool direct_sunlight = false;
 
 	auto add_node = [&] (u8 i, bool obstructed = false) -> bool {
 		if (obstructed) {
@@ -224,7 +224,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			u8 light_level_day = n.getLightNoChecks(LIGHTBANK_DAY, &f);
 			u8 light_level_night = n.getLightNoChecks(LIGHTBANK_NIGHT, &f);
 			if (light_level_day == LIGHT_SUN)
-				sunlight = true;
+				direct_sunlight = true;
 			light_day += decode_light(light_level_day);
 			light_night += decode_light(light_level_night);
 			light_count++;
@@ -258,7 +258,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		light_night /= light_count;
 	}
 
-	if (sunlight)
+	// boost direct sunlight, if any
+	if (direct_sunlight)
 		light_day = 0xFF;
 
 	// Boost brightness around light sources

--- a/src/mapblock_mesh.cpp
+++ b/src/mapblock_mesh.cpp
@@ -206,6 +206,7 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	u8 light_source_max = 0;
 	u16 light_day = 0;
 	u16 light_night = 0;
+	bool sunlight = false;
 
 	auto add_node = [&] (u8 i, bool obstructed = false) -> bool {
 		if (obstructed) {
@@ -220,8 +221,12 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 			light_source_max = f.light_source;
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.solidness != 2) {
-			light_day += decode_light(n.getLightNoChecks(LIGHTBANK_DAY, &f));
-			light_night += decode_light(n.getLightNoChecks(LIGHTBANK_NIGHT, &f));
+			u8 light_level_day = n.getLightNoChecks(LIGHTBANK_DAY, &f);
+			u8 light_level_night = n.getLightNoChecks(LIGHTBANK_NIGHT, &f);
+			if (light_level_day == LIGHT_SUN)
+				sunlight = true;
+			light_day += decode_light(light_level_day);
+			light_night += decode_light(light_level_night);
 			light_count++;
 		} else {
 			ambient_occlusion++;
@@ -252,6 +257,9 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		light_day /= light_count;
 		light_night /= light_count;
 	}
+
+	if (sunlight)
+		light_day = 0xFF;
 
 	// Boost brightness around light sources
 	bool skip_ambient_occlusion_day = false;


### PR DESCRIPTION
Fixes smooth lighting part of #7040

1. In `getSmoothLightCombined` (which is called for each corner of the node), it now checks for direct sunlight (light level of 15). If it is detected, full brightness (255) is used instead of the average. Then, ambient occlusion is applied, if necessary; otherwise it returns 255 for the day light bank.
2. `MapblockMeshGenerator::getSmoothLightFrame` checks for that value and marks the corresponding corner **and** its bottom counterpart (for convenience) as exposed to direct sunlight.
3. `MapblockMeshGenerator::blendLight` now calculates two values for the day light bank: a base light value (used for sides), computed as usual, and a boosted value (used for sun-facing quads), computed considering marked corners as having full light.
4. `LightInfo::getPair` blends these values using given factor, for which dot product of sun direction (0, 1, 0) and face normal, clamped to [0, 1], is used. This way, sides and bottom faces are not affected, but top faces get full sunlight. This feature is only used for nodeboxes and mesh nodes.

Note: lighting settings on screenshot are **extreme** to make defects, if any, more noticeable. That’s the reason for such dark shadow.
![screenshot_20180220_160414](https://user-images.githubusercontent.com/7352626/36425670-898d7930-1658-11e8-9f21-978ad227f329.png)