### PR TITLE
Vertical biome blend: Tune blend patterns

### DIFF
--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -196,7 +196,7 @@ BiomeGenOriginal::~BiomeGenOriginal()
 	delete noise_humidity_blend;
 }
 
-
+// Only usable in a mapgen thread
 Biome *BiomeGenOriginal::calcBiomeAtPoint(v3s16 pos) const
 {
 	float heat =
@@ -286,8 +286,9 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, s16 y) c
 	}
 
 	// Carefully tune pseudorandom seed variation to avoid single node dither
-	// and create larger scale blending patterns.
-	mysrand(y + (heat - humidity) * 2);
+	// and create larger scale blending patterns similar to horizontal biome
+	// blend.
+	mysrand(y + (heat + humidity) / 2);
 
 	if (biome_closest_blend &&
 			myrand_range(0, biome_closest_blend->vertical_blend) >=


### PR DESCRIPTION
With vertical blend distance of 4 nodes:

![screenshot_20180220_133349](https://user-images.githubusercontent.com/3686677/36427119-289fb3a4-1644-11e8-87d2-a1a388d92c17.png)

^ PR
Vertical blend patterns are now similar to horizontal blend patterns and have less single-node dithering.

![screenshot_20180220_134807](https://user-images.githubusercontent.com/3686677/36427295-bc42cd80-1644-11e8-90f4-ad0802aa4d2f.png)

^ MT master 'alien graffiti'.