### PR TITLE
Global initialization of sound using SoundManagerGlobal

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -35,6 +35,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "renderingengine.h"
 #include "network/networkexceptions.h"
 
+#if USE_SOUND
+	#include "sound_openal.h"
+#endif
+
 /* mainmenumanager.h
  */
 gui::IGUIEnvironment *guienv = nullptr;
@@ -70,6 +74,11 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	// List video modes if requested
 	if (list_video_modes)
 		return RenderingEngine::print_video_modes();
+
+#if USE_SOUND
+	if (g_settings->getBool("enable_sound"))
+		g_sound_manager_global = createSoundManagerGlobal();
+#endif
 
 	if (!init_engine()) {
 		errorstream << "Could not initialize game engine." << std::endl;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -77,7 +77,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 
 #if USE_SOUND
 	if (g_settings->getBool("enable_sound"))
-		g_sound_manager_global = createSoundManagerGlobal();
+		g_sound_manager_singleton = createSoundManagerSingleton();
 #endif
 
 	if (!init_engine()) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1219,7 +1219,7 @@ bool Game::initSound()
 #if USE_SOUND
 	if (g_settings->getBool("enable_sound")) {
 		infostream << "Attempting to use OpenAL audio" << std::endl;
-		sound = createOpenALSoundManager(&soundfetcher);
+		sound = createOpenALSoundManager(g_sound_manager_global.get(), &soundfetcher);
 		if (!sound)
 			infostream << "Failed to initialize OpenAL audio" << std::endl;
 	} else

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1219,7 +1219,7 @@ bool Game::initSound()
 #if USE_SOUND
 	if (g_settings->getBool("enable_sound")) {
 		infostream << "Attempting to use OpenAL audio" << std::endl;
-		sound = createOpenALSoundManager(g_sound_manager_global.get(), &soundfetcher);
+		sound = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 		if (!sound)
 			infostream << "Failed to initialize OpenAL audio" << std::endl;
 	} else

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -137,7 +137,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	//create soundmanager
 	MenuMusicFetcher soundfetcher;
 #if USE_SOUND
-	m_sound_manager = createOpenALSoundManager(g_sound_manager_global.get(), &soundfetcher);
+	m_sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 #endif
 	if(!m_sound_manager)
 		m_sound_manager = &dummySoundManager;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -137,7 +137,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	//create soundmanager
 	MenuMusicFetcher soundfetcher;
 #if USE_SOUND
-	m_sound_manager = createOpenALSoundManager(&soundfetcher);
+	m_sound_manager = createOpenALSoundManager(g_sound_manager_global.get(), &soundfetcher);
 #endif
 	if(!m_sound_manager)
 		m_sound_manager = &dummySoundManager;

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -63,7 +63,7 @@ static void delete_alcdevice(ALCdevice *p)
 static void delete_alccontext(ALCcontext *p)
 {
 	if (p) {
-		alcMakeContextCurrent(NULL);
+		alcMakeContextCurrent(nullptr);
 		alcDestroyContext(p);
 	}
 }
@@ -166,7 +166,7 @@ SoundBuffer *load_opened_ogg_file(OggVorbis_File *oggFile,
 			infostream << "Audio: Error decoding "
 				<< filename_for_logging << std::endl;
 			delete snd;
-			return NULL;
+			return nullptr;
 		}
 
 		// Append to end of buffer
@@ -204,7 +204,7 @@ SoundBuffer *load_ogg_from_file(const std::string &path)
 	if (ov_fopen(path.c_str(), &oggFile) != 0) {
 		infostream << "Audio: Error opening " << path
 			<< " for decoding" << std::endl;
-		return NULL;
+		return nullptr;
 	}
 
 	return load_opened_ogg_file(&oggFile, path);
@@ -257,7 +257,7 @@ long BufferSourceell_func(void *datasource)
 static ov_callbacks g_buffer_ov_callbacks = {
 	&buffer_sound_read_func,
 	&buffer_sound_seek_func,
-	NULL,
+	nullptr,
 	&BufferSourceell_func
 };
 
@@ -270,10 +270,10 @@ SoundBuffer *load_ogg_from_buffer(const std::string &buf, const std::string &id_
 	s.cur_offset = 0;
 	s.len = buf.size();
 
-	if (ov_open_callbacks(&s, &oggFile, NULL, 0, g_buffer_ov_callbacks) != 0) {
+	if (ov_open_callbacks(&s, &oggFile, nullptr, 0, g_buffer_ov_callbacks) != 0) {
 		infostream << "Audio: Error opening " << id_for_log
 			<< " for decoding" << std::endl;
-		return NULL;
+		return nullptr;
 	}
 
 	return load_opened_ogg_file(&oggFile, id_for_log);
@@ -295,11 +295,11 @@ public:
 		m_device(nullptr, delete_alcdevice),
 		m_context(nullptr, delete_alccontext)
 	{
-		if (!(m_device = unique_ptr_alcdevice(alcOpenDevice(NULL), delete_alcdevice)))
+		if (!(m_device = unique_ptr_alcdevice(alcOpenDevice(nullptr), delete_alcdevice)))
 			throw std::runtime_error("Audio: Global Initialization: Device Open");
 
 		if (!(m_context = unique_ptr_alccontext(
-				alcCreateContext(m_device.get(), NULL), delete_alccontext))) {
+				alcCreateContext(m_device.get(), nullptr), delete_alccontext))) {
 			throw std::runtime_error("Audio: Global Initialization: Context Create");
 		}
 
@@ -403,7 +403,7 @@ public:
 		std::unordered_map<std::string, std::vector<SoundBuffer*>>::iterator i =
 				m_buffers.find(name);
 		if(i == m_buffers.end())
-			return NULL;
+			return nullptr;
 		std::vector<SoundBuffer*> &bufs = i->second;
 		int j = myrand() % bufs.size();
 		return bufs[j];
@@ -503,7 +503,7 @@ public:
 		if(buf)
 			return buf;
 		if(!m_fetcher)
-			return NULL;
+			return nullptr;
 		std::set<std::string> paths;
 		std::set<std::string> datas;
 		m_fetcher->fetchSounds(name, paths, datas);

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -181,8 +181,8 @@ SoundBuffer *load_opened_ogg_file(OggVorbis_File *oggFile,
 	ALenum error = alGetError();
 
 	if(error != AL_NO_ERROR){
-		infostream << "Audio: OpenAL error: "<<alErrorString(error)
-				<< "preparing sound buffer"<<std::endl;
+		infostream << "Audio: OpenAL error: " << alErrorString(error)
+				<< "preparing sound buffer" << std::endl;
 	}
 
 	infostream << "Audio file "
@@ -292,15 +292,14 @@ public:
 	unique_ptr_alccontext m_context;
 public:
 	SoundManagerSingleton() :
-		m_device(NULL, delete_alcdevice),
-		m_context(NULL, delete_alccontext)
+		m_device(nullptr, delete_alcdevice),
+		m_context(nullptr, delete_alccontext)
 	{
 		if (!(m_device = unique_ptr_alcdevice(alcOpenDevice(NULL), delete_alcdevice)))
 			throw std::runtime_error("Audio: Global Initialization: Device Open");
 
 		if (!(m_context = unique_ptr_alccontext(
-				alcCreateContext(m_device.get(), NULL), delete_alccontext)))
-		{
+				alcCreateContext(m_device.get(), NULL), delete_alccontext))) {
 			throw std::runtime_error("Audio: Global Initialization: Context Create");
 		}
 
@@ -319,11 +318,6 @@ public:
 
 	~SoundManagerSingleton()
 	{
-		infostream << "Audio: Global Deinitializing..." << std::endl;
-
-		m_context.reset();
-		m_device.reset();
-
 		infostream << "Audio: Global Deinitialized." << std::endl;
 	}
 };
@@ -360,7 +354,6 @@ public:
 		m_next_id(1),
 		m_fade_delay(0)
 	{
-		infostream << "Audio: Initializing..." << std::endl;
 		infostream << "Audio: Initialized: OpenAL " << std::endl;
 	}
 
@@ -594,7 +587,7 @@ public:
 			return 0;
 		SoundBuffer *buf = getFetchBuffer(name);
 		if(!buf){
-			infostream << "OpenALSoundManager: \""<<name<<"\" not found."
+			infostream << "OpenALSoundManager: \"" << name << "\" not found."
 					<< std::endl;
 			return -1;
 		}
@@ -615,7 +608,7 @@ public:
 			return 0;
 		SoundBuffer *buf = getFetchBuffer(name);
 		if(!buf){
-			infostream << "OpenALSoundManager: \""<<name<<"\" not found."
+			infostream << "OpenALSoundManager: \"" << name << "\" not found."
 					<< std::endl;
 			return -1;
 		}

--- a/src/sound_openal.h
+++ b/src/sound_openal.h
@@ -23,8 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "sound.h"
 
-class SoundManagerGlobal;
-extern std::shared_ptr<SoundManagerGlobal> g_sound_manager_global;
+class SoundManagerSingleton;
+extern std::shared_ptr<SoundManagerSingleton> g_sound_manager_singleton;
 
-std::shared_ptr<SoundManagerGlobal> createSoundManagerGlobal();
-ISoundManager *createOpenALSoundManager(SoundManagerGlobal *smg, OnDemandSoundFetcher *fetcher);
+std::shared_ptr<SoundManagerSingleton> createSoundManagerSingleton();
+ISoundManager *createOpenALSoundManager(SoundManagerSingleton *smg, OnDemandSoundFetcher *fetcher);

--- a/src/sound_openal.h
+++ b/src/sound_openal.h
@@ -19,6 +19,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <memory>
+
 #include "sound.h"
 
-ISoundManager *createOpenALSoundManager(OnDemandSoundFetcher *fetcher);
+class SoundManagerGlobal;
+extern std::shared_ptr<SoundManagerGlobal> g_sound_manager_global;
+
+std::shared_ptr<SoundManagerGlobal> createSoundManagerGlobal();
+ISoundManager *createOpenALSoundManager(SoundManagerGlobal *smg, OnDemandSoundFetcher *fetcher);


### PR DESCRIPTION
Description and rationale
=

Currently minetest performs global audio initialization and cleanup in the OpenALSoundManager class.
The initialization and cleanup cycle is actually performed multiple times (Specifically: GUIEngine constructor creates an OpenALSoundManager for use by the menu, Game::initSound creates one for use by the actual game).

A key resource managed by OpenALSoundManager is the OpenAL context.
Due to a design defect of OpenAL there can only be one "current" context per process.
This is unlike, for example OpenGL, whose contexts can be made "current" on a per-thread basis.

Features I am working on (text-to-speech and voice chat) are designed to access an OpenAL context from within separate threads.
(WIP branch here: https://github.com/nOOb3167/minetest/tree/z_mine3ns)

Ideally, a context would be created for each thread, which however, as described above, is impossible in OpenAL by design.

This PR will cause the OpenAL device be opened, and the OpenAL context be initialized, only once and kept until the end.

This enables safe use of an OpenAL context from a separate thread without the danger of the context being suddenly destroyed while still in use.

Destroying m_sounds_playing
=

This PR undoes a nonobvious resource handling 'optimization' - where Minetest relied on certain OpenAL resources being destroyed as a side effect of an OpenAL function. Is is described below

Note how this PR destroys m_sounds_playing within ~OpenALSoundManager() destructor, whereas in the old code the sounds are not destroyed.
The old code has been getting away with not destroying m_sounds_playing because the only resource held were OpenAL sources (see PlayingSound::source_id), which a call to the alcDestroyContext automatically destroys.
As this PR keeps the OpenAL context until the end (eschewing calls to alcDestroyContext), destroying m_sounds_playing becomes necessary (the deleteSound() function is called).
