### PR TITLE
Find nodes in area (under air): Raise volume limit and document it

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2819,9 +2819,11 @@ and `minetest.auth_reload` call the authentication handler.
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
     * First return value: Table with all node positions
     * Second return value: Table with the count of each node with the node name as index
+    * Area volume is limited to 4,096,000 nodes
 * `minetest.find_nodes_in_area_under_air(pos1, pos2, nodenames)`: returns a list of positions
     * `nodenames`: e.g. `{"ignore", "group:tree"}` or `"default:dirt"`
     * Return value: Table with all node positions with a node air above
+    * Area volume is limited to 4,096,000 nodes
 * `minetest.get_perlin(noiseparams)`
 * `minetest.get_perlin(seeddiff, octaves, persistence, scale)`
     * Return world-specific perlin noise (`int(worldseed)+seeddiff`)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -801,14 +801,10 @@ int ModApiEnvMod::l_find_nodes_in_area(lua_State *L)
 	sortBoxVerticies(minp, maxp);
 
 	v3s16 cube = maxp - minp + 1;
-
-	/* Limit for too large areas, assume default values
-	 * and give tolerances of 1 node on each side
-	 * (chunksize * MAP_BLOCKSIZE + 2)^3 = 551368
-	*/
-	if ((u64)cube.X * (u64)cube.Y * (u64)cube.Z > 551368) {
+	// Volume limit equal to 8 default mapchunks, (80 * 2) ^ 3 = 4,096,000
+	if ((u64)cube.X * (u64)cube.Y * (u64)cube.Z > 4096000) {
 		luaL_error(L, "find_nodes_in_area(): area volume"
-				" exceeds allowed value of 551368");
+				" exceeds allowed value of 4096000");
 		return 0;
 	}
 
@@ -873,14 +869,10 @@ int ModApiEnvMod::l_find_nodes_in_area_under_air(lua_State *L)
 	sortBoxVerticies(minp, maxp);
 
 	v3s16 cube = maxp - minp + 1;
-
-	/* Limit for too large areas, assume default values
-	 * and give tolerances of 1 node on each side
-	 * (chunksize * MAP_BLOCKSIZE + 2)^3 = 551368
-	*/
-	if ((u64)cube.X * (u64)cube.Y * (u64)cube.Z > 551368) {
+	// Volume limit equal to 8 default mapchunks, (80 * 2) ^ 3 = 4,096,000
+	if ((u64)cube.X * (u64)cube.Y * (u64)cube.Z > 4096000) {
 		luaL_error(L, "find_nodes_in_area_under_air(): area volume"
-				" exceeds allowed value of 551368");
+				" exceeds allowed value of 4096000");
 		return 0;
 	}
 


### PR DESCRIPTION
For #7021 
I calculated the volume needed for moretrees mod date palms and exceeded that.
Volume is equal to a cube of radius 1 default mapchunk.