### PR TITLE
[WIP] Add minetest.register_on_moveplayer

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -575,6 +575,7 @@ core.registered_on_joinplayers, core.register_on_joinplayer = make_registration(
 core.registered_on_leaveplayers, core.register_on_leaveplayer = make_registration()
 core.registered_on_player_receive_fields, core.register_on_player_receive_fields = make_registration_reverse()
 core.registered_on_cheats, core.register_on_cheat = make_registration()
+core.registered_on_moveplayer, core.register_on_moveplayer = make_registration()
 core.registered_on_crafts, core.register_on_craft = make_registration()
 core.registered_craft_predicts, core.register_craft_predict = make_registration()
 core.registered_on_protection_violation, core.register_on_protection_violation = make_registration()

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -491,6 +491,8 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	player->control.LMB = (keyPressed & 128);
 	player->control.RMB = (keyPressed & 256);
 
+	m_script->on_moveplayer(playersao, position);
+
 	if (playersao->checkMovementCheat()) {
 		// Call callbacks
 		m_script->on_cheat(playersao, "moved_too_fast");

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -179,6 +179,27 @@ void ScriptApiPlayer::on_cheat(ServerActiveObject *player,
 	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
 }
 
+void ScriptApiPlayer::on_moveplayer(ServerActiveObject* player, 
+		const v3f newpos)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_moveplayer
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_moveplayer");
+	// Call callbacks
+	objectrefGetOrCreate(L, player);
+	lua_newtable(L);
+	lua_pushnumber(L, newpos.X);
+	lua_setfield(L, -2, "x");
+	lua_pushnumber(L, newpos.Y);
+	lua_setfield(L, -2, "y");
+	lua_pushnumber(L, newpos.Z);
+	lua_setfield(L, -2, "z");
+
+	runCallbacks(2, RUN_CALLBACKS_MODE_FIRST);
+}
+
 void ScriptApiPlayer::on_playerReceiveFields(ServerActiveObject *player,
 		const std::string &formname,
 		const StringMap &fields)

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -39,6 +39,7 @@ public:
 	void on_joinplayer(ServerActiveObject *player);
 	void on_leaveplayer(ServerActiveObject *player, bool timeout);
 	void on_cheat(ServerActiveObject *player, const std::string &cheat_type);
+	void on_moveplayer(ServerActiveObject* player, const v3f newpos);
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);


### PR DESCRIPTION
A function that's called every time player moves.  
Is there a function for converting engine coords to node coords?  
I also need to figure out how to ignore player turn events, because it's being called every time player turns, too.  
Please review.