### PR TITLE
Biomes: Add X and Z biome limits / Getv3intfield: Fix logic of return bool 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5114,9 +5114,16 @@ Definition tables
         node_riverbed = "default:gravel",
         depth_riverbed = 2,
     --  ^ Node placed under river water and thickness of this layer.
-        y_min = 1,
         y_max = 31000,
-    --  ^ Lower and upper limits for biome.
+        y_min = 1,
+    --  ^ Upper and lower limits for biome.
+    --  ^ Alternatively you can use xyz limits as shown below.
+        max_pos = {x = 31000, y = 128, z = 31000},
+        min_pos = {x = -31000, y = 9, z = -31000},
+    --  ^ xyz limits for biome, an alternative to using 'y_min' and 'y_max'.
+    --  ^ Biome is limited to a cuboid defined by these positions.
+    --  ^ Any x, y or z field left undefined defaults to -31000 in 'min_pos' or
+    --  ^ 31000 in 'max_pos'.
         vertical_blend = 8,
     --  ^ Vertical distance in nodes above 'y_max' over which the biome will
     --  ^ blend with the biome above.

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -693,7 +693,7 @@ void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
 
 			if (is_stone_surface || is_water_surface) {
 				// (Re)calculate biome
-				biome = biomegen->getBiomeAtIndex(index, y);
+				biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
 
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
 					biomemap[index] = biome->index;
@@ -704,7 +704,7 @@ void MapgenBasic::generateBiomes(MgStoneType *mgstone_type,
 					noise_filler_depth->result[index], 0.0f);
 				depth_water_top = biome->depth_water_top;
 				depth_riverbed = biome->depth_riverbed;
-				biome_y_min = biome->y_min;
+				biome_y_min = biome->min_pos.Y;
 
 				// Detect stone type for dungeons during every biome calculation.
 				// If none detected the last selected biome stone is chosen.

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -63,8 +63,8 @@ public:
 	s16 depth_water_top;
 	s16 depth_riverbed;
 
-	s16 y_min;
-	s16 y_max;
+	v3s16 min_pos;
+	v3s16 max_pos;
 	float heat_point;
 	float humidity_point;
 	s16 vertical_blend;
@@ -108,14 +108,14 @@ public:
 	// Gets all biomes in current chunk using each corresponding element of
 	// heightmap as the y position, then stores the results by biome index in
 	// biomemap (also returned)
-	virtual biome_t *getBiomes(s16 *heightmap) = 0;
+	virtual biome_t *getBiomes(s16 *heightmap, v3s16 pmin) = 0;
 
 	// Gets a single biome at the specified position, which must be contained
 	// in the region formed by m_pmin and (m_pmin + m_csize - 1).
 	virtual Biome *getBiomeAtPoint(v3s16 pos) const = 0;
 
 	// Same as above, but uses a raw numeric index correlating to the (x,z) position.
-	virtual Biome *getBiomeAtIndex(size_t index, s16 y) const = 0;
+	virtual Biome *getBiomeAtIndex(size_t index, v3s16 pos) const = 0;
 
 	// Result of calcBiomes bulk computation.
 	biome_t *biomemap = nullptr;
@@ -164,11 +164,11 @@ public:
 	Biome *calcBiomeAtPoint(v3s16 pos) const;
 	void calcBiomeNoise(v3s16 pmin);
 
-	biome_t *getBiomes(s16 *heightmap);
+	biome_t *getBiomes(s16 *heightmap, v3s16 pmin);
 	Biome *getBiomeAtPoint(v3s16 pos) const;
-	Biome *getBiomeAtIndex(size_t index, s16 y) const;
+	Biome *getBiomeAtIndex(size_t index, v3s16 pos) const;
 
-	Biome *calcBiomeFromNoise(float heat, float humidity, s16 y) const;
+	Biome *calcBiomeFromNoise(float heat, float humidity, v3s16 pos) const;
 
 	float *heatmap;
 	float *humidmap;
@@ -230,7 +230,7 @@ public:
 		NoiseParams &np_heat_blend, u64 seed);
 	float getHumidityAtPosOriginal(v3s16 pos, NoiseParams &np_humidity,
 		NoiseParams &np_humidity_blend, u64 seed);
-	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, s16 y);
+	Biome *getBiomeFromNoiseOriginal(float heat, float humidity, v3s16 pos);
 
 private:
 	Server *m_server;

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -66,9 +66,9 @@ bool getv3intfield(lua_State *L, int index,
 	lua_getfield(L, index, fieldname);
 	bool got = false;
 	if (lua_istable(L, -1)) {
-		got = getintfield(L, index, "x", result.X) ||
-			getintfield(L, index, "y", result.Y) ||
-			getintfield(L, index, "z", result.Z);
+		got |= getintfield(L, -1, "x", result.X);
+		got |= getintfield(L, -1, "y", result.Y);
+		got |= getintfield(L, -1, "z", result.Z);
 	}
 	lua_pop(L, 1);
 	return got;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -388,12 +388,15 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	b->depth_filler    = getintfield_default(L,    index, "depth_filler",    -31000);
 	b->depth_water_top = getintfield_default(L,    index, "depth_water_top", 0);
 	b->depth_riverbed  = getintfield_default(L,    index, "depth_riverbed",  0);
-	b->y_min           = getintfield_default(L,    index, "y_min",           -31000);
-	b->y_max           = getintfield_default(L,    index, "y_max",           31000);
 	b->heat_point      = getfloatfield_default(L,  index, "heat_point",      0.f);
 	b->humidity_point  = getfloatfield_default(L,  index, "humidity_point",  0.f);
 	b->vertical_blend  = getintfield_default(L,    index, "vertical_blend",  0);
-	b->flags           = 0; //reserved
+	b->flags           = 0; // reserved
+
+	b->min_pos = getv3s16field_default(L, index, "min_pos", v3s16(-31000, -31000, -31000));
+	getintfield(L, index, "y_min", b->min_pos.Y);
+	b->max_pos = getv3s16field_default(L, index, "max_pos", v3s16(31000, 31000, 31000));
+	getintfield(L, index, "y_max", b->max_pos.Y);
 
 	std::vector<std::string> &nn = b->m_nodenames;
 	nn.push_back(getstringfield_default(L, index, "node_top",         ""));
@@ -617,7 +620,7 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 	if (!humidity)
 		return 0;
 
-	Biome *biome = (Biome *)bmgr->getBiomeFromNoiseOriginal(heat, humidity, pos.Y);
+	Biome *biome = (Biome *)bmgr->getBiomeFromNoiseOriginal(heat, humidity, pos);
 	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
 
@@ -1041,7 +1044,7 @@ int ModApiMapgen::l_register_biome(lua_State *L)
 	luaL_checktype(L, index, LUA_TTABLE);
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
-	BiomeManager *bmgr    = getServer(L)->getEmergeManager()->biomemgr;
+	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
 
 	Biome *biome = read_biome_def(L, index, ndef);
 	if (!biome)


### PR DESCRIPTION
Commit 1:
Biomes: Add X and Z biome limits

Commit 2:
Getv3intfield: Fix logic of return bool

Commit 3:
Biomes: Document alternative xyz biome limits 
////////////////

![screenshot_20180223_094403](https://user-images.githubusercontent.com/3686677/36587961-95b645ac-187e-11e8-91fe-eb49a3266aca.png)

^ Normal biomes restricted to (-100, -100) to (100, 100)

For part of #5725 
Set limits are precise to a node.
Backwards compatible with any biome registration using 'y_min' and 'y_max'.
Uses the new 'getv3intfield' feature, which commit 2 fixes.

Testing mod:
```
minetest.clear_registered_biomes()
minetest.clear_registered_ores()
minetest.clear_registered_decorations()

	minetest.register_biome({
		name = "upper",
		--node_dust = "",
		node_top = "default:dirt_with_grass",
		depth_top = 1,
		node_filler = "default:dirt",
		depth_filler = 3,
		node_stone = "default:stone",
		--node_water_top = "",
		--depth_water_top = ,
		--node_water = "",
		--node_river_water = "",
		min_pos = {x = -100, y = -100, z = -100},
		max_pos = {x = 100, y = 100, z = 100},
		heat_point = 50,
		humidity_point = 50,
	})
```