### PR TITLE
Place schematic (on vmanip): Enable use of 'place center' flags 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3276,7 +3276,7 @@ These functions return the leftover itemstack.
             * If slice probability list equals `nil`, no slice probabilities are applied.
     * Saves schematic in the Minetest Schematic format to filename.
 
-* `minetest.place_schematic(pos, schematic, rotation, replacements, force_placement)`
+* `minetest.place_schematic(pos, schematic, rotation, replacements, force_placement, flags)`
     * Place the schematic specified by schematic (see: Schematic specifier) at `pos`.
     * `rotation` can equal `"0"`, `"90"`, `"180"`, `"270"`, or `"random"`.
     * If the `rotation` parameter is omitted, the schematic is not rotated.
@@ -3288,14 +3288,22 @@ These functions return the leftover itemstack.
       will always use the cached version and the replacement list defined for it,
       regardless of whether the file or the replacement list parameter have changed.
       The only way to load the file anew is to restart the server.
+    * `flags` is a flag field with the available flags:
+        * place_center_x
+        * place_center_y
+        * place_center_z
 
-* `minetest.place_schematic_on_vmanip(vmanip, pos, schematic, rotation, replacement, force_placement)`:
+* `minetest.place_schematic_on_vmanip(vmanip, pos, schematic, rotation, replacement, force_placement, flags)`:
     * This function is analogous to minetest.place_schematic, but places a schematic onto the
       specified VoxelManip object `vmanip` instead of the whole map.
     * Returns false if any part of the schematic was cut-off due to the VoxelManip not
       containing the full area required, and true if the whole schematic was able to fit.
     * Returns nil if the schematic could not be loaded.
     * After execution, any external copies of the VoxelManip contents are invalidated.
+    * `flags` is a flag field with the available flags:
+        * place_center_x
+        * place_center_y
+        * place_center_z
 
 * `minetest.serialize_schematic(schematic, format, options)`
     * Return the serialized schematic specified by schematic (see: Schematic specifier)

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -188,15 +188,15 @@ bool Schematic::placeOnVManip(MMVManip *vm, v3s16 p, u32 flags,
 
 	//// Adjust placement position if necessary
 	if (flags & DECO_PLACE_CENTER_X)
-		p.X -= (s.X + 1) / 2;
+		p.X -= (s.X - 1) / 2;
 	if (flags & DECO_PLACE_CENTER_Y)
-		p.Y -= (s.Y + 1) / 2;
+		p.Y -= (s.Y - 1) / 2;
 	if (flags & DECO_PLACE_CENTER_Z)
-		p.Z -= (s.Z + 1) / 2;
+		p.Z -= (s.Z - 1) / 2;
 
 	blitToVManip(vm, p, rot, force_place);
 
-	return vm->m_area.contains(VoxelArea(p, p + s - v3s16(1,1,1)));
+	return vm->m_area.contains(VoxelArea(p, p + s - v3s16(1, 1, 1)));
 }
 
 void Schematic::placeOnMap(ServerMap *map, v3s16 p, u32 flags,
@@ -219,16 +219,16 @@ void Schematic::placeOnMap(ServerMap *map, v3s16 p, u32 flags,
 
 	//// Adjust placement position if necessary
 	if (flags & DECO_PLACE_CENTER_X)
-		p.X -= (s.X + 1) / 2;
+		p.X -= (s.X - 1) / 2;
 	if (flags & DECO_PLACE_CENTER_Y)
-		p.Y -= (s.Y + 1) / 2;
+		p.Y -= (s.Y - 1) / 2;
 	if (flags & DECO_PLACE_CENTER_Z)
-		p.Z -= (s.Z + 1) / 2;
+		p.Z -= (s.Z - 1) / 2;
 
 	//// Create VManip for effected area, emerge our area, modify area
 	//// inside VManip, then blit back.
 	v3s16 bp1 = getNodeBlockPos(p);
-	v3s16 bp2 = getNodeBlockPos(p + s - v3s16(1,1,1));
+	v3s16 bp2 = getNodeBlockPos(p + s - v3s16(1, 1, 1));
 
 	MMVManip vm(map);
 	vm.initialEmerge(bp1, bp2);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1529,7 +1529,8 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 }
 
 
-// place_schematic(p, schematic, rotation, replacement)
+// place_schematic(p, schematic, rotation,
+//     replacements, force_placement, flagstring)
 int ModApiMapgen::l_place_schematic(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
@@ -1565,12 +1566,19 @@ int ModApiMapgen::l_place_schematic(lua_State *L)
 		return 0;
 	}
 
-	schem->placeOnMap(map, p, 0, (Rotation)rot, force_placement);
+	//// Read flags
+	u32 flags = 0;
+	read_flags(L, 6, flagdesc_deco, &flags, NULL);
+
+	schem->placeOnMap(map, p, flags, (Rotation)rot, force_placement);
 
 	lua_pushboolean(L, true);
 	return 1;
 }
 
+
+// place_schematic_on_vmanip(vm, p, schematic, rotation,
+//     replacements, force_placement, flagstring)
 int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1606,12 +1614,17 @@ int ModApiMapgen::l_place_schematic_on_vmanip(lua_State *L)
 		return 0;
 	}
 
+	//// Read flags
+	u32 flags = 0;
+	read_flags(L, 7, flagdesc_deco, &flags, NULL);
+
 	bool schematic_did_fit = schem->placeOnVManip(
-		vm, p, 0, (Rotation)rot, force_placement);
+		vm, p, flags, (Rotation)rot, force_placement);
 
 	lua_pushboolean(L, schematic_did_fit);
 	return 1;
 }
+
 
 // serialize_schematic(schematic, format, options={...})
 int ModApiMapgen::l_serialize_schematic(lua_State *L)

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -70,10 +70,10 @@ private:
 	// get_noiseparam_defaults(name)
 	static int l_get_noiseparams(lua_State *L);
 
-	// set_gen_notify(flagstring)
+	// set_gen_notify(flags, {deco_id_table})
 	static int l_set_gen_notify(lua_State *L);
 
-	// set_gen_notify(flagstring)
+	// get_gen_notify()
 	static int l_get_gen_notify(lua_State *L);
 
 	// register_biome({lots of stuff})
@@ -109,11 +109,12 @@ private:
 	// create_schematic(p1, p2, probability_list, filename)
 	static int l_create_schematic(lua_State *L);
 
-	// place_schematic(p, schematic, rotation, replacements, force_placement)
+	// place_schematic(p, schematic, rotation,
+	//     replacements, force_placement, flagstring)
 	static int l_place_schematic(lua_State *L);
 
-	// place_schematic_on_vmanip(vm, p, schematic,
-	//     rotation, replacements, force_placement)
+	// place_schematic_on_vmanip(vm, p, schematic, rotation,
+	//     replacements, force_placement, flagstring)
 	static int l_place_schematic_on_vmanip(lua_State *L);
 
 	// serialize_schematic(schematic, format, options={...})


### PR DESCRIPTION
 Place schematic (on vmanip): Enable use of 'place center' flags

For 'place schematic' and 'place schematic on vmanip' APIs.
Fix 'place center' code to properly centre schematics.
Fix some comments.
///////////////

For #7066 
@Gael-de-Sailly please could you test this?