### PR TITLE
is_area_protected: Rename from intersects_protection

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -173,11 +173,6 @@ function core.record_protection_violation(pos, name)
 end
 
 
--- Backwards compatibility (remove after 0.5.0 release)
-function core.intersects_protection(...)
-	return core.is_area_protected(...) ~= nil
-end
-
 -- Checks if specified volume intersects a protected volume
 
 function core.is_area_protected(minp, maxp, player_name, interval)
@@ -199,10 +194,11 @@ function core.is_area_protected(minp, maxp, player_name, interval)
 			maxp[c] = minp[c]
 			minp[c] = tmp
 		end
+
 		if maxp[c] > minp[c] then
 			d[c] = (maxp[c] - minp[c]) /
 				math.ceil((maxp[c] - minp[c]) / interval) - 1e-4
-		elseif maxp[c] == minp[c] then
+		else
 			d[c] = 1 -- Any value larger than 0 to avoid division by zero
 		end
 	end
@@ -220,6 +216,7 @@ function core.is_area_protected(minp, maxp, player_name, interval)
 			end
 		end
 	end
+	return false
 end
 
 

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -173,9 +173,14 @@ function core.record_protection_violation(pos, name)
 end
 
 
+-- Backwards compatibility (remove after 0.5.0 release)
+function core.intersects_protection(...)
+	return core.is_area_protected(...) ~= nil
+end
+
 -- Checks if specified volume intersects a protected volume
 
-function core.intersects_protection(minp, maxp, player_name, interval)
+function core.is_area_protected(minp, maxp, player_name, interval)
 	-- 'interval' is the largest allowed interval for the 3D lattice of checks.
 
 	-- Compute the optimal float step 'd' for each axis so that all corners and
@@ -188,14 +193,17 @@ function core.intersects_protection(minp, maxp, player_name, interval)
 	local d = {}
 
 	for _, c in pairs({"x", "y", "z"}) do
+		if minp[c] > maxp[c] then
+			-- Repair positions: 'minp' > 'maxp'
+			local tmp = maxp[c]
+			maxp[c] = minp[c]
+			minp[c] = tmp
+		end
 		if maxp[c] > minp[c] then
 			d[c] = (maxp[c] - minp[c]) /
 				math.ceil((maxp[c] - minp[c]) / interval) - 1e-4
 		elseif maxp[c] == minp[c] then
 			d[c] = 1 -- Any value larger than 0 to avoid division by zero
-		else -- maxp[c] < minp[c], print error and treat as protection intersected
-			minetest.log("error", "maxp < minp in 'minetest.intersects_protection()'")
-			return true
 		end
 	end
 
@@ -205,14 +213,13 @@ function core.intersects_protection(minp, maxp, player_name, interval)
 			local y = math.floor(yf + 0.5)
 			for xf = minp.x, maxp.x, d.x do
 				local x = math.floor(xf + 0.5)
-				if core.is_protected({x = x, y = y, z = z}, player_name) then
-					return true
+				local pos = {x = x, y = y, z = z}
+				if core.is_protected(pos, player_name) then
+					return pos
 				end
 			end
 		end
 	end
-
-	return false
 end
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3429,10 +3429,10 @@ These functions return the leftover itemstack.
 * `minetest.record_protection_violation(pos, name)`
     * This function calls functions registered with
       `minetest.register_on_protection_violation`.
-* `minetest.is_area_protected(minp, maxp, player_name, interval)
+* `minetest.is_area_protected(pos1, pos2, player_name, interval)
     * Returns the position of the first node that `player_name` may not modify in
-      the specified cuboid between `minp` and `maxp`.
-    * Returns `nil` if no protections were found.
+      the specified cuboid between `pos1` and `pos2`.
+    * Returns `false` if no protections were found.
     * Applies `is_protected()` to a 3D lattice of points in the defined volume.
       The points are spaced evenly throughout the volume and have a spacing
       similar to, but no larger than, `interval`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3429,9 +3429,10 @@ These functions return the leftover itemstack.
 * `minetest.record_protection_violation(pos, name)`
     * This function calls functions registered with
       `minetest.register_on_protection_violation`.
-* `minetest.intersects_protection(minp, maxp, player_name, interval)
-    * Returns a boolean, returns true if the volume defined by `minp` and `maxp`
-      intersects a protected area not owned by `player_name`.
+* `minetest.is_area_protected(minp, maxp, player_name, interval)
+    * Returns the position of the first node that `player_name` may not modify in
+      the specified cuboid between `minp` and `maxp`.
+    * Returns `nil` if no protections were found.
     * Applies `is_protected()` to a 3D lattice of points in the defined volume.
       The points are spaced evenly throughout the volume and have a spacing
       similar to, but no larger than, `interval`.
@@ -3439,6 +3440,8 @@ These functions return the leftover itemstack.
     * `interval` defaults to 4.
     * `interval` should be carefully chosen and maximised to avoid an excessive
       number of points being checked.
+    * Like `minetest.is_protected`, this function may be extended or overwritten by
+      mods to provide a faster implementation to check the cuboid for intersections.
 * `minetest.rotate_and_place(itemstack, placer, pointed_thing, infinitestacks, orient_flags)`
     * Attempt to predict the desired orientation of the facedir-capable node
       defined by `itemstack`, and place it accordingly (on-wall, on the floor, or


### PR DESCRIPTION
Addresses comment: https://github.com/minetest/minetest/commit/01bc817fe0a59e2e2b20c26d395c5b989c5156c9#commitcomment-27049889

What's new:
1) The function now returns the first detected, protected position so mods can tell the player where the "problem" is.
2) `minp > maxp` is now corrected automatically as it's already done in `find_nodes_in_area`

Testing script:
```Lua
core.register_on_joinplayer(function(player)
	local pos = vector.round(player:get_pos())
	print(dump(core.intersects_protection(
		vector.add(pos, 10),
		vector.add(pos, -10),
		player:get_player_name()
	)))
end)
```