### PR TITLE
Fix #7047

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -530,7 +530,9 @@ set(server_SRCS
 )
 list(SORT server_SRCS)
 
-if ((CMAKE_VERSION VERSION_GREATER 3.8) OR (CMAKE_VERSION VERSION_EQUAL 3.8))
+# Avoid source_group on broken CMake version.
+# see issue #7074 #7075
+if (CMAKE_VERSION VERSION_GREATER 3.8.1)
 	source_group(TREE ${PROJECT_SOURCE_DIR} PREFIX "Source Files" FILES ${client_SRCS})
 	source_group(TREE ${PROJECT_SOURCE_DIR} PREFIX "Source Files" FILES ${server_SRCS})
 endif()


### PR DESCRIPTION
Fix #7047 by specifying absolute paths for source files within src/CMakeLists.txt (more detail as to why this works in the #7047 comments).
That file was the only place where relative paths were used for source files, therefore after this commit it is now consistent throughout the codebase.

Looking at the source lists, two files were found specified twice (first in common_SRCS, then again in client_SRCS. (client_SRCS includes common_SRCS)): convert_json.cpp and hud.cpp.
These two files are now specified just in common_SRCS.


Alternatively the required CMake version could be bumped past the version exhibiting this bug (3.8.1).
