### PR TITLE
Cavegen mgv6: Do not excavate ice

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -586,7 +586,7 @@ inline bool CavesRandomWalk::isPosAboveSurface(v3s16 p)
 ////
 
 CavesV6::CavesV6(const NodeDefManager *ndef, GenerateNotifier *gennotify,
-	int water_level, content_t water_source, content_t lava_source)
+	int water_level, content_t water_source, content_t lava_source, content_t ice)
 {
 	assert(ndef);
 
@@ -605,6 +605,12 @@ CavesV6::CavesV6(const NodeDefManager *ndef, GenerateNotifier *gennotify,
 		c_lava_source = ndef->getId("mapgen_lava_source");
 	if (c_lava_source == CONTENT_IGNORE)
 		c_lava_source = CONTENT_AIR;
+
+	c_ice = ice;
+	if (c_ice == CONTENT_IGNORE)
+		c_ice = ndef->getId("mapgen_ice");
+	if (c_ice == CONTENT_IGNORE)
+		c_ice = c_water_source;
 }
 
 
@@ -843,7 +849,8 @@ void CavesV6::carveRoute(v3f vec, float f, bool randomize_xz,
 
 				u32 i = vm->m_area.index(p);
 				content_t c = vm->m_data[i].getContent();
-				if (!ndef->get(c).is_ground_content)
+				// Don't excavate sea ice to avoid ugly holes
+				if (!ndef->get(c).is_ground_content or c == c_ice)
 					continue;
 
 				if (large_cave) {

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -200,6 +200,7 @@ public:
 	int water_level;
 
 	// intermediate state variables
+	content_t c_ice;
 	u16 ystride;
 
 	s16 min_tunnel_diameter;
@@ -226,7 +227,8 @@ public:
 	// If gennotify is NULL, generation events are not logged.
 	CavesV6(const NodeDefManager *ndef, GenerateNotifier *gennotify = NULL,
 			int water_level = 1, content_t water_source = CONTENT_IGNORE,
-			content_t lava_source = CONTENT_IGNORE);
+			content_t lava_source = CONTENT_IGNORE,
+			content_t ice = CONTENT_IGNORE);
 
 	// vm, ps, and ps2 are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -1119,7 +1119,8 @@ void MapgenV6::generateCaves(int max_stone_y)
 	}
 
 	for (u32 i = 0; i < caves_count + bruises_count; i++) {
-		CavesV6 cave(ndef, &gennotify, water_level, c_water_source, c_lava_source);
+		CavesV6 cave(ndef, &gennotify, water_level,
+			c_water_source, c_lava_source, c_ice);
 
 		bool large_cave = (i >= caves_count);
 		cave.makeCave(vm, node_min, node_max, &ps, &ps2,


### PR DESCRIPTION
Allows games to make ice nodes 'ground content = true' to allow caves
in land ice.
Avoids ugly holes in mgv6 sea ice.
///////////////

![screenshot_20180226_231820](https://user-images.githubusercontent.com/3686677/36701506-96ab75c0-1b4b-11e8-9927-154a5aaeabaa.png)

See https://github.com/minetest/minetest_game/pull/2062#issuecomment-368678272 and that whole thread for explanation. This is preparation for work to add ice caves to non-mgv6 mapgens.

Ugly holes in mgv6 sea ice are now avoided by hardcoding instead of by checking 'is ground content'.
Luckily mgv6 has it's own dedicated cavegen code.
The few straight-edged holes still seen are due to large cave overgeneration and are unavoidable.