### PR TITLE
MapgenValleys: Fix submarine valleys shape

### DIFF
--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "mg_decoration.h"
 #include "mapgen_valleys.h"
 #include "cavegen.h"
+#include <cmath>
 
 
 //#undef NDEBUG
@@ -373,7 +374,7 @@ float MapgenValleys::terrainLevelFromNoise(TerrainNoise *tn)
 	//   (here x = "river" and a = valley_profile).
 	//  "valley" represents the height of the terrain, from the rivers.
 	{
-		float t = river / tn->valley_profile;
+		float t = std::fmax(river / tn->valley_profile, 0.0f);
 		*tn->valley = valley_d * (1.f - exp(- MYSQUARE(t)));
 	}
 


### PR DESCRIPTION
Sometimes in very mountainous terrain you can see sand lines in undersea valleys, like this:
![screenshot_20180228_184348](https://user-images.githubusercontent.com/6905002/36803940-556126fe-1cb9-11e8-893b-585810154cd4.png)
This is a glitch due to the mapgen trying to calculate the valley height with a negative value for distance to rivers. It's fixed by this trivial patch.
![screenshot_20180228_185005](https://user-images.githubusercontent.com/6905002/36803942-557b987c-1cb9-11e8-95e7-611ff8fb0380.png)