### PR TITLE
c_converter: Function template for numeric fields, add v3s16 default

### DIFF
--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -467,71 +467,6 @@ bool getstringfield(lua_State *L, int table,
 	return got;
 }
 
-bool getintfield(lua_State *L, int table,
-		const char *fieldname, int &result)
-{
-	lua_getfield(L, table, fieldname);
-	bool got = false;
-	if(lua_isnumber(L, -1)){
-		result = lua_tointeger(L, -1);
-		got = true;
-	}
-	lua_pop(L, 1);
-	return got;
-}
-
-bool getintfield(lua_State *L, int table,
-		const char *fieldname, u8 &result)
-{
-	lua_getfield(L, table, fieldname);
-	bool got = false;
-	if(lua_isnumber(L, -1)){
-		result = lua_tointeger(L, -1);
-		got = true;
-	}
-	lua_pop(L, 1);
-	return got;
-}
-
-bool getintfield(lua_State *L, int table,
-		const char *fieldname, s8 &result)
-{
-	lua_getfield(L, table, fieldname);
-	bool got = false;
-	if (lua_isnumber(L, -1)) {
-		result = lua_tointeger(L, -1);
-		got = true;
-	}
-	lua_pop(L, 1);
-	return got;
-}
-
-bool getintfield(lua_State *L, int table,
-		const char *fieldname, u16 &result)
-{
-	lua_getfield(L, table, fieldname);
-	bool got = false;
-	if(lua_isnumber(L, -1)){
-		result = lua_tointeger(L, -1);
-		got = true;
-	}
-	lua_pop(L, 1);
-	return got;
-}
-
-bool getintfield(lua_State *L, int table,
-		const char *fieldname, u32 &result)
-{
-	lua_getfield(L, table, fieldname);
-	bool got = false;
-	if(lua_isnumber(L, -1)){
-		result = lua_tointeger(L, -1);
-		got = true;
-	}
-	lua_pop(L, 1);
-	return got;
-}
-
 bool getfloatfield(lua_State *L, int table,
 		const char *fieldname, float &result)
 {
@@ -610,6 +545,13 @@ bool getboolfield_default(lua_State *L, int table,
 	bool result = default_;
 	getboolfield(L, table, fieldname, result);
 	return result;
+}
+
+v3s16 getv3s16field_default(lua_State *L, int table,
+		const char *fieldname, v3s16 default_)
+{
+	getv3field(L, table, fieldname, default_);
+	return default_;
 }
 
 void setstringfield(lua_State *L, int table,

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -550,7 +550,7 @@ bool getboolfield_default(lua_State *L, int table,
 v3s16 getv3s16field_default(lua_State *L, int table,
 		const char *fieldname, v3s16 default_)
 {
-	getv3field(L, table, fieldname, default_);
+	getv3intfield(L, table, fieldname, default_);
 	return default_;
 }
 

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -42,31 +42,51 @@ bool               getboolfield_default(lua_State *L, int table,
                              const char *fieldname, bool default_);
 float              getfloatfield_default(lua_State *L, int table,
                              const char *fieldname, float default_);
-int                getintfield_default           (lua_State *L, int table,
+int                getintfield_default(lua_State *L, int table,
                              const char *fieldname, int default_);
 
+template<typename T>
+bool getintfield(lua_State *L, int table,
+		const char *fieldname, T &result)
+{
+	lua_getfield(L, table, fieldname);
+	bool got = false;
+	if (lua_isnumber(L, -1)){
+		result = lua_tointeger(L, -1);
+		got = true;
+	}
+	lua_pop(L, 1);
+	return got;
+}
+
+template<class T>
+bool getv3field(lua_State *L, int index,
+		const char *fieldname, T &result)
+{
+	lua_getfield(L, index, fieldname);
+	bool got = false;
+	if (lua_istable(L, -1)) {
+		got = getintfield(L, index, "x", result.X) ||
+			getintfield(L, index, "y", result.Y) ||
+			getintfield(L, index, "z", result.Z);
+	}
+	lua_pop(L, 1);
+	return got;
+}
+
+v3s16              getv3s16field_default(lua_State *L, int table,
+                             const char *fieldname, v3s16 default_);
 bool               getstringfield(lua_State *L, int table,
                              const char *fieldname, std::string &result);
 size_t             getstringlistfield(lua_State *L, int table,
                              const char *fieldname,
                              std::vector<std::string> *result);
-bool               getintfield(lua_State *L, int table,
-                             const char *fieldname, int &result);
-bool               getintfield(lua_State *L, int table,
-                             const char *fieldname, u8 &result);
-bool               getintfield(lua_State *L, int table,
-                             const char *fieldname, s8 &result);
-bool               getintfield(lua_State *L, int table,
-                             const char *fieldname, u16 &result);
-bool               getintfield(lua_State *L, int table,
-                             const char *fieldname, u32 &result);
 void               read_groups(lua_State *L, int index,
                              std::unordered_map<std::string, int> &result);
 bool               getboolfield(lua_State *L, int table,
                              const char *fieldname, bool &result);
 bool               getfloatfield(lua_State *L, int table,
                              const char *fieldname, float &result);
-
 std::string        checkstringfield(lua_State *L, int table,
                              const char *fieldname);
 

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -60,7 +60,7 @@ bool getintfield(lua_State *L, int table,
 }
 
 template<class T>
-bool getv3field(lua_State *L, int index,
+bool getv3intfield(lua_State *L, int index,
 		const char *fieldname, T &result)
 {
 	lua_getfield(L, index, fieldname);


### PR DESCRIPTION
Simplifies the c_converter functions to templates which can not be anywhere else than in headers.
Also adds an implementation of `getv3s16field_default` for #7070

**How to test**
1) Compile
2) No linker errors