### PR TITLE
Generate Notifier: Clear events once after all 'on generated' functions

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -585,6 +585,12 @@ MapBlock *EmergeThread::finishGen(v3s16 pos, BlockMakeData *bmdata,
 		m_server->setAsyncFatalError("Lua: finishGen" + std::string(e.what()));
 	}
 
+	/*
+		Clear generate notifier events
+	*/
+	Mapgen *mg = m_emerge->getCurrentMapgen();
+	mg->gennotify.clearEvents();
+
 	EMERGE_DBG_OUT("ended up with: " << analyze_block(block));
 
 	/*

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -1003,8 +1003,7 @@ bool GenerateNotifier::addEvent(GenNotifyType type, v3s16 pos, u32 id)
 
 
 void GenerateNotifier::getEvents(
-	std::map<std::string, std::vector<v3s16> > &event_map,
-	bool peek_events)
+	std::map<std::string, std::vector<v3s16> > &event_map)
 {
 	std::list<GenNotifyEvent>::iterator it;
 
@@ -1016,9 +1015,12 @@ void GenerateNotifier::getEvents(
 
 		event_map[name].push_back(gn.pos);
 	}
+}
 
-	if (!peek_events)
-		m_notify_events.clear();
+
+void GenerateNotifier::clearEvents()
+{
+	m_notify_events.clear();
 }
 
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -99,8 +99,8 @@ public:
 	void setNotifyOnDecoIds(std::set<u32> *notify_on_deco_ids);
 
 	bool addEvent(GenNotifyType type, v3s16 pos, u32 id=0);
-	void getEvents(std::map<std::string, std::vector<v3s16> > &event_map,
-		bool peek_events=false);
+	void getEvents(std::map<std::string, std::vector<v3s16> > &event_map);
+	void clearEvents();
 
 private:
 	u32 m_notify_on = 0;


### PR DESCRIPTION
For #6590 
Works but i am not confident about implementation, needs checking.
`m_notify_events.clear()` is removed from `GenerateNotifier::getEvents()`, made a separate function, and called after all 'on generated' functions have been run.
I checked and 'peek events' is never set to anything other than the default value, so is removed.
~~I added a destructor to `GenerateNotifier` that clears the events, not sure if necessary, trying to avoid a memory leak.~~

To test add a mod, that depends on 'dungeon_loot', with:
```
minetest.set_gen_notify({decoration = true}, {0})

minetest.register_on_generated(function(minp, maxp, blockseed)
	local gennotify = minetest.get_mapgen_object("gennotify")
	local poslist = gennotify["decoration#0"] or {}
	if #poslist ~= 0 then
		print(#poslist .. " apple trees")
	else
		print("none")
	end
end)
```
And find the apple tree biome. It works even though dungeon loot mod is active.