### PR TITLE
Decorations: Add API for decoration ID from decoration name

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2842,8 +2842,11 @@ and `minetest.auth_reload` call the authentication handler.
         * decoration
     * The second parameter is a list of IDS of decorations which notification
       is requested for.
-* `get_gen_notify()`
+* `minetest.get_gen_notify()`
     * Returns a flagstring and a table with the `deco_id`s.
+* `minetest.get_decoration_id(decoration_name)
+    * Returns the decoration ID number for the provided decoration name string,
+      or `nil` on failure.
 * `minetest.get_mapgen_object(objectname)`
     * Return requested mapgen object if available (see "Mapgen objects")
 * `minetest.get_heat(pos)`

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1006,6 +1006,32 @@ int ModApiMapgen::l_get_gen_notify(lua_State *L)
 }
 
 
+// get_decoration_id(decoration_name)
+// returns the decoration ID as used in gennotify
+int ModApiMapgen::l_get_decoration_id(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const char *deco_str = luaL_checkstring(L, 1);
+	if (!deco_str)
+		return 0;
+
+	DecorationManager *dmgr = getServer(L)->getEmergeManager()->decomgr;
+
+	if (!dmgr)
+		return 0;
+
+	Decoration *deco = (Decoration *)dmgr->getByName(deco_str);
+
+	if (!deco)
+		return 0;
+
+	lua_pushinteger(L, deco->index);
+
+	return 1;
+}
+
+
 // register_biome({lots of stuff})
 int ModApiMapgen::l_register_biome(lua_State *L)
 {
@@ -1696,6 +1722,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 	API_FCT(get_noiseparams);
 	API_FCT(set_gen_notify);
 	API_FCT(get_gen_notify);
+	API_FCT(get_decoration_id);
 
 	API_FCT(register_biome);
 	API_FCT(register_decoration);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -76,6 +76,10 @@ private:
 	// get_gen_notify()
 	static int l_get_gen_notify(lua_State *L);
 
+	// get_decoration_id(decoration_name)
+	// returns the decoration ID as used in gennotify
+	static int l_get_decoration_id(lua_State *L);
+
 	// register_biome({lots of stuff})
 	static int l_register_biome(lua_State *L);
 


### PR DESCRIPTION
Needed for use with gennotify, as the deco ID depends on mods present and mod load order.
However to use this the decoration must be given a name, currently MTG does not name its decorations (TODO): `name = "apple_tree",`
Code is edited copypaste from
https://github.com/minetest/minetest/blob/e7f16119913f7b2c98059398085d410684c9d8c0/src/script/lua_api/l_mapgen.cpp#L467
Tested.