### PR TITLE
[WIP] Obsoleting #6826 (play sound with an offset)

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -734,6 +734,8 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 		[25 + len] bool loop
 		[26 + len] f32 fade
 		[30 + len] f32 pitch
+		[34 + len] f32 offset_start
+		[38 + len] f32 offset_end
 	*/
 
 	s32 server_id;
@@ -746,12 +748,16 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 	bool loop;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float offset_start = 0.0f;
+	float offset_end = -1.0f;
 
 	*pkt >> server_id >> name >> gain >> type >> pos >> object_id >> loop;
 
 	try {
 		*pkt >> fade;
 		*pkt >> pitch;
+		*pkt >> offset_start;
+		*pkt >> offset_end;
 	} catch (PacketError &e) {};
 
 	// Start playing

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -764,17 +764,17 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 	int client_id = -1;
 	switch(type) {
 		case 0: // local
-			client_id = m_sound->playSound(name, loop, gain, fade, pitch);
+			client_id = m_sound->playSound(name, loop, gain, fade, pitch, offset_start, offset_end);
 			break;
 		case 1: // positional
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, offset_start, offset_end);
 			break;
 		case 2:
 		{ // object
 			ClientActiveObject *cao = m_env.getActiveObject(object_id);
 			if (cao)
 				pos = cao->getPosition();
-			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch);
+			client_id = m_sound->playSoundAt(name, loop, gain, pos, pitch, offset_start, offset_end);
 			// TODO: Set up sound to move with object
 			break;
 		}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1013,6 +1013,8 @@ void read_soundspec(lua_State *L, int index, SimpleSoundSpec &spec)
 		getfloatfield(L, index, "gain", spec.gain);
 		getfloatfield(L, index, "fade", spec.fade);
 		getfloatfield(L, index, "pitch", spec.pitch);
+		getfloatfield(L, index, "offset_start", spec.offset_start);
+		getfloatfield(L, index, "offset_end", spec.offset_end);
 	} else if(lua_isstring(L, index)){
 		spec.name = lua_tostring(L, index);
 	}
@@ -1029,6 +1031,10 @@ void push_soundspec(lua_State *L, const SimpleSoundSpec &spec)
 	lua_setfield(L, -2, "fade");
 	lua_pushnumber(L, spec.pitch);
 	lua_setfield(L, -2, "pitch");
+	lua_pushnumber(L, spec.offset_start);
+	lua_setfield(L, -2, "offset_start");
+	lua_pushnumber(L, spec.offset_end);
+	lua_setfield(L, -2, "offset_end");
 }
 
 /******************************************************************************/

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -242,13 +242,16 @@ int ModApiClient::l_sound_play(lua_State *L)
 			v3f pos = read_v3f(L, -1) * BS;
 			lua_pop(L, 1);
 			handle = sound->playSoundAt(
-					spec.name, looped, gain * spec.gain, pos, pitch);
+					spec.name, looped, gain * spec.gain, pos, pitch,
+					spec.offset_start, spec.offset_end);
 			lua_pushinteger(L, handle);
 			return 1;
 		}
 	}
 
-	handle = sound->playSound(spec.name, looped, gain * spec.gain, 0.0f, pitch);
+	handle = sound->playSound(
+			spec.name, looped, gain * spec.gain, 0.0f, pitch,
+			spec.offset_start, spec.offset_end);
 	lua_pushinteger(L, handle);
 
 	return 1;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2001,7 +2001,8 @@ s32 Server::playSound(const SimpleSoundSpec &spec,
 	NetworkPacket pkt(TOCLIENT_PLAY_SOUND, 0);
 	pkt << id << spec.name << gain
 			<< (u8) params.type << pos << params.object
-			<< params.loop << params.fade << params.pitch;
+			<< params.loop << params.fade << params.pitch
+			<< spec.offset_start << spec.offset_end;
 
 	// Backwards compability
 	bool play_sound = gain > 0;

--- a/src/sound.h
+++ b/src/sound.h
@@ -71,9 +71,11 @@ public:
 	// playSound functions return -1 on failure, otherwise a handle to the
 	// sound. If name=="", call should be ignored without error.
 	virtual int playSound(const std::string &name, bool loop, float volume,
-			float fade = 0.0f, float pitch = 1.0f) = 0;
-	virtual int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch = 1.0f) = 0;
+			float fade = 0.0f, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
+	virtual int playSoundAt(const std::string &name, bool loop, float volume,
+			v3f pos, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) = 0;
 	virtual void stopSound(int sound) = 0;
 	virtual bool soundExists(int sound) = 0;
 	virtual void updateSoundPosition(int sound, v3f pos) = 0;
@@ -84,11 +86,13 @@ public:
 
 	int playSound(const SimpleSoundSpec &spec, bool loop)
 	{
-		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch);
+		return playSound(spec.name, loop, spec.gain, spec.fade, spec.pitch,
+				spec.offset_start, spec.offset_end);
 	}
 	int playSoundAt(const SimpleSoundSpec &spec, bool loop, const v3f &pos)
 	{
-		return playSoundAt(spec.name, loop, spec.gain, pos, spec.pitch);
+		return playSoundAt(spec.name, loop, spec.gain, pos, spec.pitch,
+				spec.offset_start, spec.offset_end);
 	}
 };
 
@@ -105,13 +109,15 @@ public:
 	}
 	void updateListener(v3f pos, v3f vel, v3f at, v3f up) {}
 	void setListenerGain(float gain) {}
-	int playSound(const std::string &name, bool loop, float volume, float fade,
-			float pitch)
+	int playSound(const std::string &name, bool loop, float volume,
+			float fade, float pitch,
+			float offset_start, float offset_end)
 	{
 		return 0;
 	}
-	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos,
-			float pitch)
+	int playSoundAt(const std::string &name, bool loop, float volume,
+			v3f pos, float pitch,
+			float offset_start, float offset_end)
 	{
 		return 0;
 	}

--- a/src/sound.h
+++ b/src/sound.h
@@ -34,9 +34,11 @@ public:
 struct SimpleSoundSpec
 {
 	SimpleSoundSpec(const std::string &name = "", float gain = 1.0f,
-			float fade = 0.0f, float pitch = 1.0f) :
+			float fade = 0.0f, float pitch = 1.0f,
+			float offset_start = 0.0f, float offset_end = -1.0f) :
 			name(name),
-			gain(gain), fade(fade), pitch(pitch)
+			gain(gain), fade(fade), pitch(pitch),
+			offset_start(offset_start), offset_end(offset_end)
 	{
 	}
 
@@ -46,6 +48,8 @@ struct SimpleSoundSpec
 	float gain = 1.0f;
 	float fade = 0.0f;
 	float pitch = 1.0f;
+	float offset_start;
+	float offset_end;
 };
 
 class ISoundManager

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -504,7 +504,9 @@ public:
 		warn_if_error(alGetError(), "createPlayingSoundAt");
 	}
 
-	int playSoundRaw(SoundBuffer *buf, bool loop, float volume, float pitch)
+	int playSoundRaw(SoundBuffer *buf, bool loop, float volume,
+			float pitch,
+			float offset_start, float offset_end)
 	{
 		PlayingSound *sound = new PlayingSound(unique_ptr_albuffer(new ALuint(buf->buffer_id), no_delete_albuffer));
 		createPlayingSound(sound, loop, volume, pitch);
@@ -513,8 +515,9 @@ public:
 		return id;
 	}
 
-	int playSoundRawAt(SoundBuffer *buf, bool loop, float volume, const v3f &pos,
-			float pitch)
+	int playSoundRawAt(SoundBuffer *buf, bool loop, float volume,
+			const v3f &pos, float pitch,
+			float offset_start, float offset_end)
 	{
 		PlayingSound *sound = new PlayingSound(unique_ptr_albuffer(new ALuint(buf->buffer_id), no_delete_albuffer));
 		createPlayingSoundAt(sound, loop, volume, pos, pitch);
@@ -618,7 +621,9 @@ public:
 		alListenerf(AL_GAIN, gain);
 	}
 
-	int playSound(const std::string &name, bool loop, float volume, float fade, float pitch)
+	int playSound(const std::string &name, bool loop, float volume,
+			float fade, float pitch,
+			float offset_start, float offset_end)
 	{
 		maintain();
 		if (name.empty())
@@ -631,15 +636,17 @@ public:
 		}
 		int handle = -1;
 		if (fade > 0) {
-			handle = playSoundRaw(buf, loop, 0.0f, pitch);
+			handle = playSoundRaw(buf, loop, 0.0f, pitch, offset_start, offset_end);
 			fadeSound(handle, fade, volume);
 		} else {
-			handle = playSoundRaw(buf, loop, volume, pitch);
+			handle = playSoundRaw(buf, loop, volume, pitch, offset_start, offset_end);
 		}
 		return handle;
 	}
 
-	int playSoundAt(const std::string &name, bool loop, float volume, v3f pos, float pitch)
+	int playSoundAt(const std::string &name, bool loop, float volume,
+			v3f pos, float pitch,
+			float offset_start, float offset_end)
 	{
 		maintain();
 		if (name.empty())
@@ -650,7 +657,7 @@ public:
 					<<std::endl;
 			return -1;
 		}
-		return playSoundRawAt(buf, loop, volume, pos, pitch);
+		return playSoundRawAt(buf, loop, volume, pos, pitch, offset_start, offset_end);
 	}
 
 	void stopSound(int sound)

--- a/src/sound_openal.cpp
+++ b/src/sound_openal.cpp
@@ -111,6 +111,33 @@ struct SoundBuffer
 	std::vector<char> buffer;
 };
 
+int sound_buffer_bytes_per_sample_frame(SoundBuffer *SoundBuffer)
+{
+	/* number_of_channels (MONO=1, STEREO=2) times bits_per_channel (8=1, 16=2) */
+	switch (SoundBuffer->format) {
+	case AL_FORMAT_MONO8:
+		return 1 * 1;
+	case AL_FORMAT_MONO16:
+		return 1 * 2;
+	case AL_FORMAT_STEREO8:
+		return 2 * 1;
+	case AL_FORMAT_STEREO16:
+		return 2 * 2;
+	}
+	return 0;
+}
+
+int convert_time_offset_to_sample_offset(
+		int bytes_per_sample_frame, int frequency,
+		int buffer_size_bytes, double time_offset)
+{
+	const int num_buffer_sample_frames = buffer_size_bytes / bytes_per_sample_frame;
+	const int last_sample_frame = num_buffer_sample_frames - 1;
+	if (time_offset == -1.0)
+		return last_sample_frame;
+	return rangelim(time_offset * frequency, 0, last_sample_frame);
+}
+
 SoundBuffer *load_opened_ogg_file(OggVorbis_File *oggFile,
 		const std::string &filename_for_logging)
 {


### PR DESCRIPTION
The reason cited for an inexact (repeatedly polling current offset of playing sound) implementation of this feature in #6826 was:

> Copying the sound range would likely be necessary to implement the range playback behaviour with perfect fidelity.
Copying is not done due to performance concerns

In #6719, copying was dismissed but likely not on base of measurements / profiling:

> >I can only do that by copying the sound buffer and modifying it by cutting it short, then uploading it back to OpenAL.

>Not acceptable of course.

I have now implemented copying. Here is an excerpt of the profiling results:

![rationale_copy_method](https://user-images.githubusercontent.com/814784/36942098-3e4ff562-1f6b-11e8-8301-8482c164cf73.png)

The profiler used is Very Sleepy CS, result files attached below, if anyone needs:

[copy_method_profiling_VerySleepy.zip](https://github.com/minetest/minetest/files/1778190/copy_method_profiling_VerySleepy.zip)

Copying is done by transmitting sound data to OpenAL using alBufferData.
In the image above, it is clear this function takes very little time.

Intuitively, this makes sense.
At some point in the audio stack, all playing sounds have to be _mixed_ into a single stream.
This stream _mixing_ operation is guaranteed to be at least as, or more, expensive than copying all playing sounds.
Assume the worst case scenario of mixing consisting of 100% audio processing time taken by Minetest.
If audio processing consists of, say, 5% of total workload (the rest being networking, rendering, etc), and 100% of those 5% are mixing, AND mixing is at least as expensive as copying, then copying shall cause the audio workload to no more than double - to 10%.
We should have a pretty good sense of performance impact potentially caused by sound copying.

The mod (CSM) used for profiling is attached below. Note that the mod plays a sound - make sure your minetest directory ends up with this structure:
$DIR/bin/minetest.exe ...
$DIR/clientmods/offsetcsm/init.lua
$DIR/sounds/FindingShiners.ogg

Beware that the mod starts up 50 simultaneous sounds each second.
This results in very loud volume.

[offsetcsm2.zip](https://github.com/minetest/minetest/files/1778192/offsetcsm2.zip)

If performance impact is considered satisfactorily low, the final code past WIP stage can be simplified considerably.

To test the performance impact, please use these branches:
For the copy method (new):  https://github.com/nOOb3167/minetest/tree/offset_copy
For the polling method (old): https://github.com/nOOb3167/minetest/tree/offset_positional
