### PR TITLE
Add formspec theming using prepended strings

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4046,6 +4046,11 @@ This is basically a reference to a C++ `ServerActiveObject`
     * Redefine player's inventory form
     * Should usually be called in `on_joinplayer`
 * `get_inventory_formspec()`: returns a formspec string
+* `set_formspec_prepend(formspec)`: the formspec string will be added to every
+    formspec shown to the user. This should be used to set style elements such
+    as background[] and bgcolor[], any other elements may result in weird behaviour.
+    Only affects formspecs shown after this is called.
+* `get_formspec_prepend(formspec)`: returns a formspec string.
 * `get_player_control()`: returns table with player pressed keys
     * The table consists of fields with boolean value representing the pressed
       keys, the fields are jump, right, left, LMB, RMB, sneak, aux1, down, up.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2001,6 +2001,10 @@ supported. It is a string, with a somewhat strange format.
 Spaces and newlines can be inserted between the blocks, as is used in the
 examples.
 
+WARNING: Minetest allows you to add elements to every single formspec instance
+using player:set_formspec_prepend(), which may be the reason backgrounds are
+appearing when you don't expect them to be.
+
 ### Examples
 
 #### Chest
@@ -4046,10 +4050,11 @@ This is basically a reference to a C++ `ServerActiveObject`
     * Redefine player's inventory form
     * Should usually be called in `on_joinplayer`
 * `get_inventory_formspec()`: returns a formspec string
-* `set_formspec_prepend(formspec)`: the formspec string will be added to every
-    formspec shown to the user. This should be used to set style elements such
-    as background[] and bgcolor[], any other elements may result in weird behaviour.
-    Only affects formspecs shown after this is called.
+* `set_formspec_prepend(formspec)`:
+    * the formspec string will be added to every formspec shown to the user.
+    * This should be used to set style elements such as background[] and
+      bgcolor[], any non-style elements (eg: label) may result in weird behaviour.
+    * Only affects formspecs shown after this is called.
 * `get_formspec_prepend(formspec)`: returns a formspec string.
 * `get_player_control()`: returns table with player pressed keys
     * The table consists of fields with boolean value representing the pressed

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2003,7 +2003,7 @@ examples.
 
 WARNING: Minetest allows you to add elements to every single formspec instance
 using player:set_formspec_prepend(), which may be the reason backgrounds are
-appearing when you don't expect them to be.
+appearing when you don't expect them to be. See `no_prepend[]`
 
 ### Examples
 
@@ -2056,6 +2056,10 @@ appearing when you don't expect them to be.
 
 * `position` and `anchor` elements need suitable values to avoid a formspec
   extending off the game window due to particular game window sizes.
+
+#### `no_prepend[]`
+* Must be used after both `size`, `position`, and `anchor` (if present) elements.
+* Disables player:set_formspec_prepend() from applying to this formspec.
 
 #### `container[<X>,<Y>]`
 * Start of a container block, moves all physical elements in the container by
@@ -4051,7 +4055,8 @@ This is basically a reference to a C++ `ServerActiveObject`
     * Should usually be called in `on_joinplayer`
 * `get_inventory_formspec()`: returns a formspec string
 * `set_formspec_prepend(formspec)`:
-    * the formspec string will be added to every formspec shown to the user.
+    * the formspec string will be added to every formspec shown to the user,
+      except for those with a no_prepend[] tag.
     * This should be used to set style elements such as background[] and
       bgcolor[], any non-style elements (eg: label) may result in weird behaviour.
     * Only affects formspecs shown after this is called.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2003,7 +2003,7 @@ examples.
 
 WARNING: Minetest allows you to add elements to every single formspec instance
 using player:set_formspec_prepend(), which may be the reason backgrounds are
-appearing when you don't expect them to be. See `no_prepend[]`
+appearing when you don't expect them to. See `no_prepend[]`
 
 ### Examples
 
@@ -2058,7 +2058,7 @@ appearing when you don't expect them to be. See `no_prepend[]`
   extending off the game window due to particular game window sizes.
 
 #### `no_prepend[]`
-* Must be used after both `size`, `position`, and `anchor` (if present) elements.
+* Must be used after the `size`, `position`, and `anchor` elements (if present).
 * Disables player:set_formspec_prepend() from applying to this formspec.
 
 #### `container[<X>,<Y>]`

--- a/src/client.h
+++ b/src/client.h
@@ -224,8 +224,8 @@ public:
 	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);
 	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);
-	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
-	void handleCommand_FormspecPrepend(NetworkPacket* pkt);
+	void handleCommand_SrpBytesSandB(NetworkPacket *pkt);
+	void handleCommand_FormspecPrepend(NetworkPacket *pkt);
 	void handleCommand_CSMFlavourLimits(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
@@ -435,7 +435,7 @@ public:
 
 	const std::string &getFormspecPrepend()
 	{
-		return getEnv().getLocalPlayer()->formspec_prepend;
+		return m_env.getLocalPlayer()->formspec_prepend;
 	}
 private:
 	void loadMods();

--- a/src/client.h
+++ b/src/client.h
@@ -225,6 +225,7 @@ public:
 	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket* pkt);
+	void handleCommand_FormspecPrepend(NetworkPacket* pkt);
 	void handleCommand_CSMFlavourLimits(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
@@ -431,7 +432,6 @@ public:
 	bool leaveModChannel(const std::string &channel);
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
-
 private:
 	void loadMods();
 	bool checkBuiltinIntegrity();

--- a/src/client.h
+++ b/src/client.h
@@ -433,7 +433,7 @@ public:
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
 
-	const std::string &getFormspecPrepend()
+	const std::string &getFormspecPrepend() const
 	{
 		return m_env.getLocalPlayer()->formspec_prepend;
 	}

--- a/src/client.h
+++ b/src/client.h
@@ -432,6 +432,11 @@ public:
 	bool leaveModChannel(const std::string &channel);
 	bool sendModChannelMessage(const std::string &channel, const std::string &message);
 	ModChannel *getModChannel(const std::string &channel);
+
+	const std::string &getFormspecPrepend()
+	{
+		return getEnv().getLocalPlayer()->formspec_prepend;
+	}
 private:
 	void loadMods();
 	bool checkBuiltinIntegrity();

--- a/src/clientenvironment.h
+++ b/src/clientenvironment.h
@@ -78,7 +78,7 @@ public:
 	void step(f32 dtime);
 
 	virtual void setLocalPlayer(LocalPlayer *player);
-	LocalPlayer *getLocalPlayer() { return m_local_player; }
+	LocalPlayer *getLocalPlayer() const { return m_local_player; }
 
 	/*
 		ClientSimpleObjects

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2028,7 +2028,7 @@ void Game::openInventory()
 			|| !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc))) {
 		TextDest *txt_dst = new TextDestPlayerInventory(client);
 		GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src,
-			txt_dst);
+			txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
 		cur_formname = "";
 		current_formspec->setFormSpec(fs_src->getForm(), inventoryloc);
 	}
@@ -2535,7 +2535,7 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 			new TextDestPlayerInventory(client, *(event->show_formspec.formname));
 
 		GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
-			fs_src, txt_dst);
+			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
 		cur_formname = *(event->show_formspec.formname);
 	}
 
@@ -2548,7 +2548,8 @@ void Game::handleClientEvent_ShowLocalFormSpec(ClientEvent *event, CameraOrienta
 	FormspecFormSource *fs_src = new FormspecFormSource(*event->show_formspec.formspec);
 	LocalFormspecHandler *txt_dst =
 		new LocalFormspecHandler(*event->show_formspec.formname, client);
-	GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src, txt_dst);
+	GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
+			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
 
 	delete event->show_formspec.formspec;
 	delete event->show_formspec.formname;
@@ -3210,7 +3211,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 			TextDest *txt_dst = new TextDestNodeMetadata(nodepos, client);
 
 			GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src,
-				txt_dst);
+				txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
 			cur_formname.clear();
 
 			current_formspec->setFormSpec(meta->getString("formspec"), inventoryloc);
@@ -4105,7 +4106,8 @@ void Game::showPauseMenu()
 	FormspecFormSource *fs_src = new FormspecFormSource(os.str());
 	LocalFormspecHandler *txt_dst = new LocalFormspecHandler("MT_PAUSE_MENU");
 
-	GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src, txt_dst);
+	GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
+			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
 	current_formspec->setFocus("btn_continue");
 	current_formspec->doPause = true;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2028,7 +2028,7 @@ void Game::openInventory()
 			|| !client->getScript()->on_inventory_open(fs_src->m_client->getInventory(inventoryloc))) {
 		TextDest *txt_dst = new TextDestPlayerInventory(client);
 		GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src,
-			txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
+			txt_dst, client->getFormspecPrepend());
 		cur_formname = "";
 		current_formspec->setFormSpec(fs_src->getForm(), inventoryloc);
 	}
@@ -2535,7 +2535,7 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 			new TextDestPlayerInventory(client, *(event->show_formspec.formname));
 
 		GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
-			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
+			fs_src, txt_dst, client->getFormspecPrepend());
 		cur_formname = *(event->show_formspec.formname);
 	}
 
@@ -2549,7 +2549,7 @@ void Game::handleClientEvent_ShowLocalFormSpec(ClientEvent *event, CameraOrienta
 	LocalFormspecHandler *txt_dst =
 		new LocalFormspecHandler(*event->show_formspec.formname, client);
 	GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
-			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
+			fs_src, txt_dst, client->getFormspecPrepend());
 
 	delete event->show_formspec.formspec;
 	delete event->show_formspec.formname;
@@ -3211,7 +3211,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 			TextDest *txt_dst = new TextDestNodeMetadata(nodepos, client);
 
 			GUIFormSpecMenu::create(current_formspec, client, &input->joystick, fs_src,
-				txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
+				txt_dst, client->getFormspecPrepend());
 			cur_formname.clear();
 
 			current_formspec->setFormSpec(meta->getString("formspec"), inventoryloc);
@@ -4107,7 +4107,7 @@ void Game::showPauseMenu()
 	LocalFormspecHandler *txt_dst = new LocalFormspecHandler("MT_PAUSE_MENU");
 
 	GUIFormSpecMenu::create(current_formspec, client, &input->joystick,
-			fs_src, txt_dst, client->getEnv().getLocalPlayer()->formspec_prepend);
+			fs_src, txt_dst, client->getFormspecPrepend());
 	current_formspec->setFocus("btn_continue");
 	current_formspec->doPause = true;
 }

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -164,6 +164,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 			m_texture_source,
 			m_formspecgui,
 			m_buttonhandler,
+			"",
 			false);
 
 	m_menu->allowClose(false);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -92,10 +92,10 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_invmgr(client),
 	m_tsrc(tsrc),
 	m_client(client),
+	m_formspec_prepend(formspecPrepend),
 	m_form_src(fsrc),
 	m_text_dst(tdst),
 	m_joystick(joystick),
-	m_formspec_prepend(formspecPrepend),
 	m_remap_dbl_click(remap_dbl_click)
 #ifdef __ANDROID__
 	, m_JavaDialogFieldName("")

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -130,7 +130,8 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 }
 
 void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
-	JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest, std::string formspecPrepend)
+	JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest,
+	const std::string &formspecPrepend)
 {
 	if (cur_formspec == nullptr) {
 		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
@@ -1933,7 +1934,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	parserData mydata;
 
 	//preserve tables
-	for (auto& m_table : m_tables) {
+	for (auto &m_table : m_tables) {
 		std::string tablename = m_table.first.fname;
 		GUITable *table = m_table.second;
 		mydata.table_dyndata[tablename] = table->getDynamicData();
@@ -1993,28 +1994,25 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
 		m_bgcolor = video::SColor(
-				(u8) clamp_u8(
-						g_settings->getS32("formspec_default_bg_opacity")),
-				clamp_u8(myround(formspec_bgcolor.X)),
-				clamp_u8(myround(formspec_bgcolor.Y)),
-				clamp_u8(myround(formspec_bgcolor.Z))
+			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
 		);
 	}
 
 	{
-		v3f formspec_bgcolor = g_settings->getV3F(
-				"formspec_fullscreen_bg_color");
+		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
 		m_fullscreen_bgcolor = video::SColor(
-				(u8) clamp_u8(
-						g_settings->getS32("formspec_fullscreen_bg_opacity")),
-				clamp_u8(myround(formspec_bgcolor.X)),
-				clamp_u8(myround(formspec_bgcolor.Y)),
-				clamp_u8(myround(formspec_bgcolor.Z))
+			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
+			clamp_u8(myround(formspec_bgcolor.X)),
+			clamp_u8(myround(formspec_bgcolor.Y)),
+			clamp_u8(myround(formspec_bgcolor.Z))
 		);
 	}
 
-	m_slotbg_n = video::SColor(255, 128, 128, 128);
-	m_slotbg_h = video::SColor(255, 192, 192, 192);
+	m_slotbg_n = video::SColor(255,128,128,128);
+	m_slotbg_h = video::SColor(255,192,192,192);
 
 	m_default_tooltip_bgcolor = video::SColor(255, 110, 130, 60);
 	m_default_tooltip_color = video::SColor(255, 255, 255, 255);
@@ -2027,20 +2025,19 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 		assert(!m_tooltip_element);
 		// Note: parent != this so that the tooltip isn't clipped by the menu rectangle
 		m_tooltip_element = gui::StaticText::add(Environment, L"",
-				core::rect<s32>(0, 0, 110, 18));
+			core::rect<s32>(0, 0, 110, 18));
 		m_tooltip_element->enableOverrideColor(true);
 		m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
 		m_tooltip_element->setDrawBackground(true);
 		m_tooltip_element->setDrawBorder(true);
 		m_tooltip_element->setOverrideColor(m_default_tooltip_color);
-		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER,
-				gui::EGUIA_CENTER);
+		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
 		m_tooltip_element->setWordWrap(false);
 		//we're not parent so no autograb for this one!
 		m_tooltip_element->grab();
 	}
 
-	std::vector<std::string> elements = split(m_formspec_string, ']');
+	std::vector<std::string> elements = split(m_formspec_string,']');
 	unsigned int i = 0;
 
 	/* try to read version from first element only */
@@ -2052,21 +2049,21 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parseSizeDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "position" element is always after "size" element if it used */
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parsePositionDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "anchor" element is always after "position" (or  "size" element) if it used */
-	for (; i < elements.size(); i++) {
+	for (; i< elements.size(); i++) {
 		if (!parseAnchorDirect(&mydata, elements[i])) {
 			break;
 		}
@@ -2101,11 +2098,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 			else
 				delta.X = 0;
 
-			offset = v2s32(delta.X, delta.Y);
+			offset = v2s32(delta.X,delta.Y);
 
 			mydata.screensize = m_lockscreensize;
 		} else {
-			offset = v2s32(0, 0);
+			offset = v2s32(0,0);
 		}
 
 		double gui_scaling = g_settings->getFloat("gui_scaling");
@@ -2137,15 +2134,15 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 			// multiplied by gui_scaling, even if this means
 			// the form doesn't fit the screen.
 			double prefer_imgsize = mydata.screensize.Y / 15 *
-					gui_scaling;
+				gui_scaling;
 			double fitx_imgsize = mydata.screensize.X /
-					((5.0 / 4.0) * (0.5 + mydata.invsize.X));
+				((5.0/4.0) * (0.5 + mydata.invsize.X));
 			double fity_imgsize = mydata.screensize.Y /
-					((15.0 / 13.0) * (0.85 * mydata.invsize.Y));
+				((15.0/13.0) * (0.85 * mydata.invsize.Y));
 			double screen_dpi = RenderingEngine::getDisplayDensity() * 96;
 			double min_imgsize = 0.3 * screen_dpi * gui_scaling;
 			use_imgsize = MYMAX(min_imgsize, MYMIN(prefer_imgsize,
-					MYMIN(fitx_imgsize, fity_imgsize)));
+				MYMIN(fitx_imgsize, fity_imgsize)));
 		}
 
 		// Everything else is scaled in proportion to the
@@ -2157,32 +2154,24 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 		// is 2/5 vertical inventory slot spacing, and button
 		// half-height is 7/8 of font height.
 		imgsize = v2s32(use_imgsize, use_imgsize);
-		spacing = v2s32(use_imgsize * 5.0 / 4, use_imgsize * 15.0 / 13);
-		padding = v2s32(use_imgsize * 3.0 / 8, use_imgsize * 3.0 / 8);
-		m_btn_height = use_imgsize * 15.0 / 13 * 0.35;
+		spacing = v2s32(use_imgsize*5.0/4, use_imgsize*15.0/13);
+		padding = v2s32(use_imgsize*3.0/8, use_imgsize*3.0/8);
+		m_btn_height = use_imgsize*15.0/13 * 0.35;
 
 		m_font = g_fontengine->getFont();
 
 		mydata.size = v2s32(
-				padding.X * 2 + spacing.X * (mydata.invsize.X - 1.0) +
-						imgsize.X,
-				padding.Y * 2 + spacing.Y * (mydata.invsize.Y - 1.0) +
-						imgsize.Y + m_btn_height * 2.0 / 3.0
+			padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
+			padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
 		);
 		DesiredRect = mydata.rect = core::rect<s32>(
-				(s32) ((f32) mydata.screensize.X * mydata.offset.X) -
-						(s32) (mydata.anchor.X * (f32) mydata.size.X) +
-						offset.X,
-				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) -
-						(s32) (mydata.anchor.Y * (f32) mydata.size.Y) +
-						offset.Y,
-				(s32) ((f32) mydata.screensize.X * mydata.offset.X) +
-						(s32) ((1.0 - mydata.anchor.X) * (f32) mydata.size.X) +
-						offset.X,
-				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) +
-						(s32) ((1.0 - mydata.anchor.Y) * (f32) mydata.size.Y) +
-						offset.Y
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
 		);
+
+
 	} else {
 		// Non-size[] form must consist only of text fields and
 		// implicit "Proceed" button.  Use default font, and
@@ -2190,14 +2179,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 		m_font = g_fontengine->getFont();
 		m_btn_height = font_line_height(m_font) * 0.875;
 		DesiredRect = core::rect<s32>(
-				(s32) ((f32) mydata.screensize.X * mydata.offset.X) -
-						(s32) (mydata.anchor.X * 580.0),
-				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) -
-						(s32) (mydata.anchor.Y * 300.0),
-				(s32) ((f32) mydata.screensize.X * mydata.offset.X) +
-						(s32) ((1.0 - mydata.anchor.X) * 580.0),
-				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) +
-						(s32) ((1.0 - mydata.anchor.Y) * 300.0)
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * 580.0),
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * 300.0),
+			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * 580.0),
+			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * 300.0)
 		);
 	}
 	recalculateAbsolutePosition(false);
@@ -2212,10 +2197,9 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	pos_offset = v2s32();
 
 	if (enable_prepends) {
-		std::vector<std::string> prependElements = split(m_formspec_prepend, ']');
-		for (const auto& element : prependElements) {
+		std::vector<std::string> prepend_elements = split(m_formspec_prepend, ']');
+		for (const auto &element : prepend_elements)
 			parseElement(&mydata, element);
-		}
 	}
 
 	for (; i< elements.size(); i++) {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1925,7 +1925,8 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 			<< std::endl;
 }
 
-void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
+void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
+{
 	/* useless to regenerate without a screensize */
 	if ((screensize.X <= 0) || (screensize.Y <= 0)) {
 		return;
@@ -1949,7 +1950,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	if (focused_element && focused_element->getParent() == this) {
 		s32 focused_id = focused_element->getID();
 		if (focused_id > 257) {
-			for (const GUIFormSpecMenu::FieldSpec& field : m_fields) {
+			for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {
 				if (field.fid == focused_id) {
 					mydata.focused_fieldname = field.fname;
 					break;
@@ -1961,11 +1962,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	// Remove children
 	removeChildren();
 
-	for (auto& table_it : m_tables) {
+	for (auto &table_it : m_tables) {
 		table_it.second->drop();
 	}
 
-	mydata.size = v2s32(100, 100);
+	mydata.size= v2s32(100,100);
 	mydata.screensize = screensize;
 	mydata.offset = v2f32(0.5f, 0.5f);
 	mydata.anchor = v2f32(0.5f, 0.5f);
@@ -2014,10 +2015,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	m_slotbg_n = video::SColor(255,128,128,128);
 	m_slotbg_h = video::SColor(255,192,192,192);
 
-	m_default_tooltip_bgcolor = video::SColor(255, 110, 130, 60);
-	m_default_tooltip_color = video::SColor(255, 255, 255, 255);
+	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
+	m_default_tooltip_color = video::SColor(255,255,255,255);
 
-	m_slotbordercolor = video::SColor(200, 0, 0, 0);
+	m_slotbordercolor = video::SColor(200,0,0,0);
 	m_slotborder = false;
 
 	// Add tooltip
@@ -2165,13 +2166,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 			padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
 		);
 		DesiredRect = mydata.rect = core::rect<s32>(
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
+				(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
+				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
 		);
-
-
 	} else {
 		// Non-size[] form must consist only of text fields and
 		// implicit "Proceed" button.  Use default font, and

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -86,7 +86,8 @@ inline u32 clamp_u8(s32 value)
 GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		Client *client, ISimpleTextureSource *tsrc, IFormSource *fsrc, TextDest *tdst,
-		bool remap_dbl_click) :
+		std::string formspecPrepend,
+		bool remap_dbl_click):
 	GUIModalMenu(RenderingEngine::get_gui_env(), parent, id, menumgr),
 	m_invmgr(client),
 	m_tsrc(tsrc),
@@ -94,6 +95,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_form_src(fsrc),
 	m_text_dst(tdst),
 	m_joystick(joystick),
+	m_formspec_prepend(formspecPrepend),
 	m_remap_dbl_click(remap_dbl_click)
 #ifdef __ANDROID__
 	, m_JavaDialogFieldName("")
@@ -128,11 +130,11 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 }
 
 void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
-	JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest)
+	JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest, std::string formspecPrepend)
 {
 	if (cur_formspec == nullptr) {
 		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
-			client, client->getTextureSource(), fs_src, txt_dest);
+			client, client->getTextureSource(), fs_src, txt_dest, formspecPrepend);
 		cur_formspec->doPause = false;
 
 		/*
@@ -144,6 +146,7 @@ void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
 		*/
 
 	} else {
+		cur_formspec->setFormspecPrepend(formspecPrepend);
 		cur_formspec->setFormSource(fs_src);
 		cur_formspec->setTextDest(txt_dest);
 	}
@@ -2179,6 +2182,12 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	skin->setFont(m_font);
 
 	pos_offset = v2s32();
+
+	std::vector<std::string> prependElements = split(m_formspec_prepend, ']');
+	for (const auto &element : prependElements) {
+		parseElement(&mydata, element);
+	}
+
 	for (; i< elements.size(); i++) {
 		parseElement(&mydata, elements[i]);
 	}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1924,8 +1924,7 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 			<< std::endl;
 }
 
-void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
-{
+void GUIFormSpecMenu::regenerateGui(v2u32 screensize) {
 	/* useless to regenerate without a screensize */
 	if ((screensize.X <= 0) || (screensize.Y <= 0)) {
 		return;
@@ -1934,7 +1933,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	parserData mydata;
 
 	//preserve tables
-	for (auto &m_table : m_tables) {
+	for (auto& m_table : m_tables) {
 		std::string tablename = m_table.first.fname;
 		GUITable *table = m_table.second;
 		mydata.table_dyndata[tablename] = table->getDynamicData();
@@ -1949,7 +1948,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	if (focused_element && focused_element->getParent() == this) {
 		s32 focused_id = focused_element->getID();
 		if (focused_id > 257) {
-			for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {
+			for (const GUIFormSpecMenu::FieldSpec& field : m_fields) {
 				if (field.fid == focused_id) {
 					mydata.focused_fieldname = field.fname;
 					break;
@@ -1961,11 +1960,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// Remove children
 	removeChildren();
 
-	for (auto &table_it : m_tables) {
+	for (auto& table_it : m_tables) {
 		table_it.second->drop();
 	}
 
-	mydata.size= v2s32(100,100);
+	mydata.size = v2s32(100, 100);
 	mydata.screensize = screensize;
 	mydata.offset = v2f32(0.5f, 0.5f);
 	mydata.anchor = v2f32(0.5f, 0.5f);
@@ -1994,31 +1993,33 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	{
 		v3f formspec_bgcolor = g_settings->getV3F("formspec_default_bg_color");
 		m_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_default_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
+				(u8) clamp_u8(
+						g_settings->getS32("formspec_default_bg_opacity")),
+				clamp_u8(myround(formspec_bgcolor.X)),
+				clamp_u8(myround(formspec_bgcolor.Y)),
+				clamp_u8(myround(formspec_bgcolor.Z))
 		);
 	}
 
 	{
-		v3f formspec_bgcolor = g_settings->getV3F("formspec_fullscreen_bg_color");
+		v3f formspec_bgcolor = g_settings->getV3F(
+				"formspec_fullscreen_bg_color");
 		m_fullscreen_bgcolor = video::SColor(
-			(u8) clamp_u8(g_settings->getS32("formspec_fullscreen_bg_opacity")),
-			clamp_u8(myround(formspec_bgcolor.X)),
-			clamp_u8(myround(formspec_bgcolor.Y)),
-			clamp_u8(myround(formspec_bgcolor.Z))
+				(u8) clamp_u8(
+						g_settings->getS32("formspec_fullscreen_bg_opacity")),
+				clamp_u8(myround(formspec_bgcolor.X)),
+				clamp_u8(myround(formspec_bgcolor.Y)),
+				clamp_u8(myround(formspec_bgcolor.Z))
 		);
 	}
 
+	m_slotbg_n = video::SColor(255, 128, 128, 128);
+	m_slotbg_h = video::SColor(255, 192, 192, 192);
 
-	m_slotbg_n = video::SColor(255,128,128,128);
-	m_slotbg_h = video::SColor(255,192,192,192);
+	m_default_tooltip_bgcolor = video::SColor(255, 110, 130, 60);
+	m_default_tooltip_color = video::SColor(255, 255, 255, 255);
 
-	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
-	m_default_tooltip_color = video::SColor(255,255,255,255);
-
-	m_slotbordercolor = video::SColor(200,0,0,0);
+	m_slotbordercolor = video::SColor(200, 0, 0, 0);
 	m_slotborder = false;
 
 	// Add tooltip
@@ -2026,50 +2027,63 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		assert(!m_tooltip_element);
 		// Note: parent != this so that the tooltip isn't clipped by the menu rectangle
 		m_tooltip_element = gui::StaticText::add(Environment, L"",
-			core::rect<s32>(0, 0, 110, 18));
+				core::rect<s32>(0, 0, 110, 18));
 		m_tooltip_element->enableOverrideColor(true);
 		m_tooltip_element->setBackgroundColor(m_default_tooltip_bgcolor);
 		m_tooltip_element->setDrawBackground(true);
 		m_tooltip_element->setDrawBorder(true);
 		m_tooltip_element->setOverrideColor(m_default_tooltip_color);
-		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_CENTER);
+		m_tooltip_element->setTextAlignment(gui::EGUIA_CENTER,
+				gui::EGUIA_CENTER);
 		m_tooltip_element->setWordWrap(false);
 		//we're not parent so no autograb for this one!
 		m_tooltip_element->grab();
 	}
 
-	std::vector<std::string> elements = split(m_formspec_string,']');
+	std::vector<std::string> elements = split(m_formspec_string, ']');
 	unsigned int i = 0;
 
 	/* try to read version from first element only */
 	if (!elements.empty()) {
-		if ( parseVersionDirect(elements[0]) ) {
+		if (parseVersionDirect(elements[0])) {
 			i++;
 		}
 	}
 
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parseSizeDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "position" element is always after "size" element if it used */
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parsePositionDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
 	/* "anchor" element is always after "position" (or  "size" element) if it used */
-	for (; i< elements.size(); i++) {
+	for (; i < elements.size(); i++) {
 		if (!parseAnchorDirect(&mydata, elements[i])) {
 			break;
 		}
 	}
 
+	/* "no_prepend" element is always after "position" (or  "size" element) if it used */
+	bool enable_prepends = true;
+	for (; i < elements.size(); i++) {
+		if (elements[i].empty())
+			break;
+
+		std::vector<std::string> parts = split(elements[i], '[');
+		if (parts[0] == "no_prepend")
+			enable_prepends = false;
+		else
+			break;
+	}
 
 	if (mydata.explicit_size) {
 		// compute scaling for specified form size
@@ -2087,11 +2101,11 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			else
 				delta.X = 0;
 
-			offset = v2s32(delta.X,delta.Y);
+			offset = v2s32(delta.X, delta.Y);
 
 			mydata.screensize = m_lockscreensize;
 		} else {
-			offset = v2s32(0,0);
+			offset = v2s32(0, 0);
 		}
 
 		double gui_scaling = g_settings->getFloat("gui_scaling");
@@ -2123,15 +2137,15 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			// multiplied by gui_scaling, even if this means
 			// the form doesn't fit the screen.
 			double prefer_imgsize = mydata.screensize.Y / 15 *
-							gui_scaling;
+					gui_scaling;
 			double fitx_imgsize = mydata.screensize.X /
-				((5.0/4.0) * (0.5 + mydata.invsize.X));
+					((5.0 / 4.0) * (0.5 + mydata.invsize.X));
 			double fity_imgsize = mydata.screensize.Y /
-				((15.0/13.0) * (0.85 * mydata.invsize.Y));
+					((15.0 / 13.0) * (0.85 * mydata.invsize.Y));
 			double screen_dpi = RenderingEngine::getDisplayDensity() * 96;
 			double min_imgsize = 0.3 * screen_dpi * gui_scaling;
 			use_imgsize = MYMAX(min_imgsize, MYMIN(prefer_imgsize,
-				MYMIN(fitx_imgsize, fity_imgsize)));
+					MYMIN(fitx_imgsize, fity_imgsize)));
 		}
 
 		// Everything else is scaled in proportion to the
@@ -2143,21 +2157,31 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		// is 2/5 vertical inventory slot spacing, and button
 		// half-height is 7/8 of font height.
 		imgsize = v2s32(use_imgsize, use_imgsize);
-		spacing = v2s32(use_imgsize*5.0/4, use_imgsize*15.0/13);
-		padding = v2s32(use_imgsize*3.0/8, use_imgsize*3.0/8);
-		m_btn_height = use_imgsize*15.0/13 * 0.35;
+		spacing = v2s32(use_imgsize * 5.0 / 4, use_imgsize * 15.0 / 13);
+		padding = v2s32(use_imgsize * 3.0 / 8, use_imgsize * 3.0 / 8);
+		m_btn_height = use_imgsize * 15.0 / 13 * 0.35;
 
 		m_font = g_fontengine->getFont();
 
 		mydata.size = v2s32(
-			padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
-			padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
+				padding.X * 2 + spacing.X * (mydata.invsize.X - 1.0) +
+						imgsize.X,
+				padding.Y * 2 + spacing.Y * (mydata.invsize.Y - 1.0) +
+						imgsize.Y + m_btn_height * 2.0 / 3.0
 		);
 		DesiredRect = mydata.rect = core::rect<s32>(
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
-				(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * (f32)mydata.size.X) + offset.X,
-				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * (f32)mydata.size.Y) + offset.Y
+				(s32) ((f32) mydata.screensize.X * mydata.offset.X) -
+						(s32) (mydata.anchor.X * (f32) mydata.size.X) +
+						offset.X,
+				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) -
+						(s32) (mydata.anchor.Y * (f32) mydata.size.Y) +
+						offset.Y,
+				(s32) ((f32) mydata.screensize.X * mydata.offset.X) +
+						(s32) ((1.0 - mydata.anchor.X) * (f32) mydata.size.X) +
+						offset.X,
+				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) +
+						(s32) ((1.0 - mydata.anchor.Y) * (f32) mydata.size.Y) +
+						offset.Y
 		);
 	} else {
 		// Non-size[] form must consist only of text fields and
@@ -2166,26 +2190,32 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_font = g_fontengine->getFont();
 		m_btn_height = font_line_height(m_font) * 0.875;
 		DesiredRect = core::rect<s32>(
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * 580.0),
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * 300.0),
-			(s32)((f32)mydata.screensize.X * mydata.offset.X) + (s32)((1.0 - mydata.anchor.X) * 580.0),
-			(s32)((f32)mydata.screensize.Y * mydata.offset.Y) + (s32)((1.0 - mydata.anchor.Y) * 300.0)
+				(s32) ((f32) mydata.screensize.X * mydata.offset.X) -
+						(s32) (mydata.anchor.X * 580.0),
+				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) -
+						(s32) (mydata.anchor.Y * 300.0),
+				(s32) ((f32) mydata.screensize.X * mydata.offset.X) +
+						(s32) ((1.0 - mydata.anchor.X) * 580.0),
+				(s32) ((f32) mydata.screensize.Y * mydata.offset.Y) +
+						(s32) ((1.0 - mydata.anchor.Y) * 300.0)
 		);
 	}
 	recalculateAbsolutePosition(false);
 	mydata.basepos = getBasePos();
 	m_tooltip_element->setOverrideFont(m_font);
 
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 	sanity_check(skin);
 	gui::IGUIFont *old_font = skin->getFont();
 	skin->setFont(m_font);
 
 	pos_offset = v2s32();
 
-	std::vector<std::string> prependElements = split(m_formspec_prepend, ']');
-	for (const auto &element : prependElements) {
-		parseElement(&mydata, element);
+	if (enable_prepends) {
+		std::vector<std::string> prependElements = split(m_formspec_prepend, ']');
+		for (const auto& element : prependElements) {
+			parseElement(&mydata, element);
+		}
 	}
 
 	for (; i< elements.size(); i++) {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -304,7 +304,7 @@ public:
 		regenerateGui(m_screensize_old);
 	}
 
-	void setFormspecPrepend(const std::string formspecPrepend)
+	void setFormspecPrepend(const std::string &formspecPrepend)
 	{
 		m_formspec_prepend = formspecPrepend;
 	}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -287,12 +287,13 @@ public:
 			ISimpleTextureSource *tsrc,
 			IFormSource* fs_src,
 			TextDest* txt_dst,
+			std::string formspecPrepend,
 			bool remap_dbl_click = true);
 
 	~GUIFormSpecMenu();
 
 	static void create(GUIFormSpecMenu *&cur_formspec, Client *client,
-		JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest);
+		JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest, std::string formspecPrepend);
 
 	void setFormSpec(const std::string &formspec_string,
 			const InventoryLocation &current_inventory_location)
@@ -300,6 +301,11 @@ public:
 		m_formspec_string = formspec_string;
 		m_current_inventory_location = current_inventory_location;
 		regenerateGui(m_screensize_old);
+	}
+
+	void setFormspecPrepend(const std::string formspecPrepend)
+	{
+		m_formspec_prepend = formspecPrepend;
 	}
 
 	// form_src is deleted by this GUIFormSpecMenu
@@ -378,6 +384,7 @@ protected:
 	Client *m_client;
 
 	std::string m_formspec_string;
+	std::string m_formspec_prepend;
 	InventoryLocation m_current_inventory_location;
 
 	std::vector<ListDrawSpec> m_inventorylists;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -293,7 +293,8 @@ public:
 	~GUIFormSpecMenu();
 
 	static void create(GUIFormSpecMenu *&cur_formspec, Client *client,
-		JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest, std::string formspecPrepend);
+		JoystickController *joystick, IFormSource *fs_src, TextDest *txt_dest,
+		const std::string &formspecPrepend);
 
 	void setFormSpec(const std::string &formspec_string,
 			const InventoryLocation &current_inventory_location)

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -121,6 +121,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60
+	{ "TOCLIENT_FORMSPEC_PREPEND",         TOCLIENT_STATE_CONNECTED, &Client::handleCommand_FormspecPrepend }, // 0x61,
 };
 
 const static ServerCommandFactory null_command_factory = { "TOSERVER_NULL", 0, false };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1330,7 +1330,7 @@ void Client::handleCommand_FormspecPrepend(NetworkPacket *pkt)
 	assert(player != NULL);
 
 	// Store formspec in LocalPlayer
-	player->formspec_prepend = pkt->readLongString();
+	*pkt >> player->formspec_prepend;
 }
 
 void Client::handleCommand_CSMFlavourLimits(NetworkPacket *pkt)

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1324,6 +1324,15 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 	Send(&resp_pkt);
 }
 
+void Client::handleCommand_FormspecPrepend(NetworkPacket* pkt)
+{
+	LocalPlayer *player = m_env.getLocalPlayer();
+	assert(player != NULL);
+
+	// Store formspec in LocalPlayer
+	player->formspec_prepend = pkt->readLongString();
+}
+
 void Client::handleCommand_CSMFlavourLimits(NetworkPacket *pkt)
 {
 	*pkt >> m_csm_flavour_limits >> m_csm_noderange_limit;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1324,7 +1324,7 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 	Send(&resp_pkt);
 }
 
-void Client::handleCommand_FormspecPrepend(NetworkPacket* pkt)
+void Client::handleCommand_FormspecPrepend(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -937,4 +937,3 @@ enum CSMFlavourLimit : u64 {
 	CSM_FL_LOOKUP_NODES = 0x00000010, // Limit node lookups
 	CSM_FL_ALL = 0xFFFFFFFF,
 };
-

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -187,6 +187,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 			'zoom_fov'.
 		Nodebox version 5
 		Add disconnected nodeboxes
+		Add TOCLIENT_FORMSPEC_PREPEND
 */
 
 #define LATEST_PROTOCOL_VERSION 36
@@ -644,7 +645,13 @@ enum ToClientCommand
 		std::string bytes_B
 	*/
 
-	TOCLIENT_NUM_MSG_TYPES = 0x61,
+	TOCLIENT_FORMSPEC_PREPEND = 0x61,
+	/*
+		u32 len
+		u8[len] formspec
+	*/
+
+	TOCLIENT_NUM_MSG_TYPES = 0x62,
 };
 
 enum ToServerCommand

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -647,7 +647,7 @@ enum ToClientCommand
 
 	TOCLIENT_FORMSPEC_PREPEND = 0x61,
 	/*
-		u32 len
+		u16 len
 		u8[len] formspec
 	*/
 

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -210,4 +210,5 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory,
 	null_command_factory,
 	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60
+	{ "TOCLIENT_FORMSPEC_PREPEND",         0, true }, // 0x61
 };

--- a/src/player.h
+++ b/src/player.h
@@ -148,6 +148,7 @@ public:
 	float local_animation_speed;
 
 	std::string inventory_formspec;
+	std::string formspec_prepend;
 
 	PlayerControl control;
 	const PlayerControl& getPlayerControl() { return control; }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1244,6 +1244,34 @@ int ObjectRef::l_get_inventory_formspec(lua_State *L)
 	return 1;
 }
 
+// set_inventory_formspec(self, formspec)
+int ObjectRef::l_set_formspec_prepend(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == NULL) return 0;
+	std::string formspec = luaL_checkstring(L, 2);
+
+	player->formspec_prepend = formspec;
+	getServer(L)->reportFormspecPrependModified(player->getName());
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+// get_inventory_formspec(self) -> formspec
+int ObjectRef::l_get_formspec_prepend(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == NULL) return 0;
+
+	std::string formspec = player->formspec_prepend;
+	lua_pushlstring(L, formspec.c_str(), formspec.size());
+	return 1;
+}
+
 // get_player_control(self)
 int ObjectRef::l_get_player_control(lua_State *L)
 {
@@ -1817,6 +1845,8 @@ const luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_attribute),
 	luamethod(ObjectRef, set_inventory_formspec),
 	luamethod(ObjectRef, get_inventory_formspec),
+	luamethod(ObjectRef, set_formspec_prepend),
+	luamethod(ObjectRef, get_formspec_prepend),
 	luamethod(ObjectRef, get_player_control),
 	luamethod(ObjectRef, get_player_control_bits),
 	luamethod(ObjectRef, set_physics_override),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1244,13 +1244,15 @@ int ObjectRef::l_get_inventory_formspec(lua_State *L)
 	return 1;
 }
 
-// set_inventory_formspec(self, formspec)
+// set_formspec_prepend(self, formspec)
 int ObjectRef::l_set_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	if (player == NULL)
+		return 0;
+
 	std::string formspec = luaL_checkstring(L, 2);
 
 	player->formspec_prepend = formspec;
@@ -1259,13 +1261,14 @@ int ObjectRef::l_set_formspec_prepend(lua_State *L)
 	return 1;
 }
 
-// get_inventory_formspec(self) -> formspec
+// get_formspec_prepend(self) -> formspec
 int ObjectRef::l_get_formspec_prepend(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	RemotePlayer *player = getplayer(ref);
-	if (player == NULL) return 0;
+	if (player == NULL)
+		 return 0;
 
 	std::string formspec = player->formspec_prepend;
 	lua_pushlstring(L, formspec.c_str(), formspec.size());

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -253,10 +253,10 @@ private:
 	// get_inventory_formspec(self) -> formspec
 	static int l_get_inventory_formspec(lua_State *L);
 
-	// set_inventory_formspec(self, formspec)
+	// set_formspec_prepend(self, formspec)
 	static int l_set_formspec_prepend(lua_State *L);
 
-	// get_inventory_formspec(self) -> formspec
+	// get_formspec_prepend(self) -> formspec
 	static int l_get_formspec_prepend(lua_State *L);
 
 	// get_player_control(self)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -253,6 +253,12 @@ private:
 	// get_inventory_formspec(self) -> formspec
 	static int l_get_inventory_formspec(lua_State *L);
 
+	// set_inventory_formspec(self, formspec)
+	static int l_set_formspec_prepend(lua_State *L);
+
+	// get_inventory_formspec(self) -> formspec
+	static int l_get_formspec_prepend(lua_State *L);
+
 	// get_player_control(self)
 	static int l_get_player_control(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1886,7 +1886,7 @@ void Server::SendPlayerFormspecPrepend(session_t peer_id)
 		return;
 
 	NetworkPacket pkt(TOCLIENT_FORMSPEC_PREPEND, 0, peer_id);
-	pkt.putLongString(FORMSPEC_VERSION_STRING + player->formspec_prepend);
+	pkt << FORMSPEC_VERSION_STRING + player->formspec_prepend;
 	Send(&pkt);
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1870,11 +1870,23 @@ void Server::SendPlayerInventoryFormspec(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
-	if(player->getPeerId() == PEER_ID_INEXISTENT)
+	if (player->getPeerId() == PEER_ID_INEXISTENT)
 		return;
 
 	NetworkPacket pkt(TOCLIENT_INVENTORY_FORMSPEC, 0, peer_id);
 	pkt.putLongString(FORMSPEC_VERSION_STRING + player->inventory_formspec);
+	Send(&pkt);
+}
+
+void Server::SendPlayerFormspecPrepend(session_t peer_id)
+{
+	RemotePlayer *player = m_env->getPlayer(peer_id);
+	assert(player);
+	if (player->getPeerId() == PEER_ID_INEXISTENT)
+		return;
+
+	NetworkPacket pkt(TOCLIENT_FORMSPEC_PREPEND, 0, peer_id);
+	pkt.putLongString(FORMSPEC_VERSION_STRING + player->formspec_prepend);
 	Send(&pkt);
 }
 
@@ -2916,6 +2928,14 @@ void Server::reportInventoryFormspecModified(const std::string &name)
 	if (!player)
 		return;
 	SendPlayerInventoryFormspec(player->getPeerId());
+}
+
+void Server::reportFormspecPrependModified(const std::string &name)
+{
+	RemotePlayer *player = m_env->getPlayer(name.c_str());
+	if (!player)
+		return;
+	SendPlayerFormspecPrepend(player->getPeerId());
 }
 
 void Server::setIpBanned(const std::string &ip, const std::string &name)

--- a/src/server.h
+++ b/src/server.h
@@ -216,6 +216,7 @@ public:
 	bool checkPriv(const std::string &name, const std::string &priv);
 	void reportPrivsModified(const std::string &name=""); // ""=all
 	void reportInventoryFormspecModified(const std::string &name);
+	void reportFormspecPrependModified(const std::string &name);
 
 	void setIpBanned(const std::string &ip, const std::string &name);
 	void unsetIpBanned(const std::string &ip_or_name);
@@ -376,6 +377,7 @@ private:
 	void SendEyeOffset(session_t peer_id, v3f first, v3f third);
 	void SendPlayerPrivileges(session_t peer_id);
 	void SendPlayerInventoryFormspec(session_t peer_id);
+	void SendPlayerFormspecPrepend(session_t peer_id);
 	void SendShowFormspecMessage(session_t peer_id, const std::string &formspec,
 		const std::string &formname);
 	void SendHUDAdd(session_t peer_id, u32 id, HudElement *form);

--- a/src/test_config.h
+++ b/src/test_config.h
@@ -1,0 +1,6 @@
+// Filled in by the build system
+
+#pragma once
+
+#define TEST_WORLDDIR "/home/ruben/dev/minetest/src/unittest/test_world"
+#define TEST_SUBGAME_PATH "/home/ruben/dev/minetest/src/unittest/../../games/minimal"

--- a/src/test_config.h
+++ b/src/test_config.h
@@ -1,6 +1,0 @@
-// Filled in by the build system
-
-#pragma once
-
-#define TEST_WORLDDIR "/home/ruben/dev/minetest/src/unittest/test_world"
-#define TEST_SUBGAME_PATH "/home/ruben/dev/minetest/src/unittest/../../games/minimal"


### PR DESCRIPTION
Fixes #7068

After this PR, default/init.lua should be changed to:

```lua
default.gui_bg     = ""
default.gui_bg_img = ""
default.gui_slots  = ""

minetest.register_on_joinplayer(function(player)
	player:set_formspec_prepend("bgcolor[#080808BB;true]" .. 
			"background[5,5;1,1;gui_formbg.png;true]" ..
			"listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF]")
end)
```

-----
* `set_formspec_prepend(formspec)`:
    * the formspec string will be added to every formspec shown to the user.
    * This should be used to set style elements such as background[] and
      bgcolor[], any non-style elements (eg: label) may result in weird behaviour.
    * Only affects formspecs shown after this is called.
* `get_formspec_prepend(formspec)`: returns a formspec string.