### PR TITLE
mods.cpp/h: little performance improvement in getModsInPath (+ codestyle)

### DIFF
--- a/src/mods.cpp
+++ b/src/mods.cpp
@@ -85,24 +85,31 @@ void parseModContents(ModSpec &spec)
 	}
 }
 
-std::map<std::string, ModSpec> getModsInPath(std::string path, bool part_of_modpack)
+std::map<std::string, ModSpec> getModsInPath(const std::string &path,
+	bool part_of_modpack)
 {
 	// NOTE: this function works in mutual recursion with parseModContents
 
 	std::map<std::string, ModSpec> result;
 	std::vector<fs::DirListNode> dirlist = fs::GetDirListing(path);
+	std::string modpath;
+
 	for (const fs::DirListNode &dln : dirlist) {
-		if(!dln.dir)
+		if (!dln.dir)
 			continue;
+
 		const std::string &modname = dln.name;
 		// Ignore all directories beginning with a ".", especially
 		// VCS directories like ".git" or ".svn"
 		if (modname[0] == '.')
 			continue;
-		std::string modpath = path + DIR_DELIM + modname;
 
-		ModSpec spec(modname, modpath);
-		spec.part_of_modpack = part_of_modpack;
+		modpath.clear();
+		modpath.append(path)
+			.append(DIR_DELIM)
+			.append(modname);
+
+		ModSpec spec(modname, modpath, part_of_modpack);
 		parseModContents(spec);
 		result.insert(std::make_pair(modname, spec));
 	}

--- a/src/mods.h
+++ b/src/mods.h
@@ -49,10 +49,10 @@ struct ModSpec
 		name(name_),
 		path(path_)
 	{}
-	ModSpec(const std::string &name_, const std::string &path_, bool p_o_m):
+	ModSpec(const std::string &name_, const std::string &path_, bool part_of_modpack_):
 		name(name_),
 		path(path_),
-		part_of_modpack(p_o_m)
+		part_of_modpack(part_of_modpack_)
 	{}
 };
 

--- a/src/mods.h
+++ b/src/mods.h
@@ -45,16 +45,22 @@ struct ModSpec
 	bool is_modpack = false;
 	// if modpack:
 	std::map<std::string,ModSpec> modpack_content;
-	ModSpec(const std::string &name_="", const std::string &path_=""):
+	ModSpec(const std::string &name_ = "", const std::string &path_ = ""):
 		name(name_),
 		path(path_)
+	{}
+	ModSpec(const std::string &name_, const std::string &path_, bool p_o_m):
+		name(name_),
+		path(path_),
+		part_of_modpack(p_o_m)
 	{}
 };
 
 // Retrieves depends, optdepends, is_modpack and modpack_content
 void parseModContents(ModSpec &mod);
 
-std::map<std::string,ModSpec> getModsInPath(std::string path, bool part_of_modpack = false);
+std::map<std::string,ModSpec> getModsInPath(const std::string &path,
+	bool part_of_modpack = false);
 
 // replaces modpack Modspecs with their content
 std::vector<ModSpec> flattenMods(std::map<std::string,ModSpec> mods);


### PR DESCRIPTION
As i'm working on the CSM mod sending, i need to backport some cleanups to master branch to reduce the PR size while i'm working on it.

I unroll a string variable and add string performance enhancement, add a const ref & do some code cleanups in getModsInPath function