### PR TITLE
Formspecs: Allow specifying a certain alpha value for the box[] element 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2283,10 +2283,11 @@ appearing when you don't expect them to. See `no_prepend[]`
 * `draw_border` (optional): draw border
 
 #### `box[<X>,<Y>;<W>,<H>;<color>]`
-* Simple colored semitransparent box
+* Simple colored box
 * `x` and `y` position the box relative to the top left of the menu
 * `w` and `h` are the size of box
-* `color` is color specified as a `ColorString`
+* `color` is color specified as a `ColorString`.
+  If the alpha component is left blank, the box will be semitransparent.
 
 #### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
 * Show a dropdown field

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1560,7 +1560,7 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 
 		video::SColor tmp_color;
 
-		if (parseColorString(parts[2], tmp_color, false)) {
+		if (parseColorString(parts[2], tmp_color, false, 0x8C)) {
 			BoxDrawSpec spec(pos, geom, tmp_color);
 
 			m_boxes.push_back(spec);
@@ -2514,8 +2514,6 @@ void GUIFormSpecMenu::drawMenu()
 	*/
 	for (const GUIFormSpecMenu::BoxDrawSpec &spec : m_boxes) {
 		irr::video::SColor todraw = spec.color;
-
-		todraw.setAlpha(140);
 
 		core::rect<s32> rect(spec.pos.X,spec.pos.Y,
 							spec.pos.X + spec.geom.X,spec.pos.Y + spec.geom.Y);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -223,7 +223,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 	struct BoxDrawSpec
 	{
-		BoxDrawSpec(v2s32 a_pos, v2s32 a_geom,irr::video::SColor a_color):
+		BoxDrawSpec(v2s32 a_pos, v2s32 a_geom, irr::video::SColor a_color):
 			pos(a_pos),
 			geom(a_geom),
 			color(a_color)

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -43,7 +43,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	#define BSD_ICONV_USED
 #endif
 
-static bool parseHexColorString(const std::string &value, video::SColor &color);
+static bool parseHexColorString(const std::string &value, video::SColor &color,
+		unsigned char default_alpha = 0xff);
 static bool parseNamedColorString(const std::string &value, video::SColor &color);
 
 #ifndef _WIN32
@@ -464,12 +465,13 @@ u64 read_seed(const char *str)
 	return num;
 }
 
-bool parseColorString(const std::string &value, video::SColor &color, bool quiet)
+bool parseColorString(const std::string &value, video::SColor &color, bool quiet,
+		unsigned char default_alpha)
 {
 	bool success;
 
 	if (value[0] == '#')
-		success = parseHexColorString(value, color);
+		success = parseHexColorString(value, color, default_alpha);
 	else
 		success = parseNamedColorString(value, color);
 
@@ -479,9 +481,10 @@ bool parseColorString(const std::string &value, video::SColor &color, bool quiet
 	return success;
 }
 
-static bool parseHexColorString(const std::string &value, video::SColor &color)
+static bool parseHexColorString(const std::string &value, video::SColor &color,
+		unsigned char default_alpha)
 {
-	unsigned char components[] = { 0x00, 0x00, 0x00, 0xff }; // R,G,B,A
+	unsigned char components[] = { 0x00, 0x00, 0x00, default_alpha }; // R,G,B,A
 
 	if (value[0] != '#')
 		return false;

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -85,7 +85,8 @@ std::string writeFlagString(u32 flags, const FlagDesc *flagdesc, u32 flagmask);
 size_t mystrlcpy(char *dst, const char *src, size_t size);
 char *mystrtok_r(char *s, const char *sep, char **lasts);
 u64 read_seed(const char *str);
-bool parseColorString(const std::string &value, video::SColor &color, bool quiet);
+bool parseColorString(const std::string &value, video::SColor &color, bool quiet,
+		unsigned char default_alpha = 0xff);
 
 
 /**


### PR DESCRIPTION
This allows using the alpha component of the ColorString.
The default behaviour is unchanged.
Backwards compatible (only boxes with the new, fourth parameter are not drawn in old clients).

I'm looking forward to your comments! Thanks in advance for your efforts!