### PR TITLE
Biome API: Add 'get_biome_name(biome_id)' API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2959,6 +2959,10 @@ handler.
 * `minetest.get_biome_id(biome_name)`
     * Returns the biome id, as used in the biomemap Mapgen object and returned
       by `minetest.get_biome_data(pos)`, for a given biome_name string.
+* `minetest.get_biome_name(biome_id)`
+    * Returns the biome name string for the provided biome id, or `nil` on
+      failure.
+    * If no biomes have been registered, such as in mgv6, returns `default`.
 * `minetest.get_mapgen_params()`
     * Deprecated: use `minetest.get_mapgen_setting(name)` instead.
     * Returns a table containing:

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -40,7 +40,7 @@ BiomeManager::BiomeManager(Server *server) :
 	// Create default biome to be used in case none exist
 	Biome *b = new Biome;
 
-	b->name            = "Default";
+	b->name            = "default";
 	b->flags           = 0;
 	b->depth_top       = 0;
 	b->depth_filler    = -MAX_MAP_GENERATION_LIMIT;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -476,16 +476,33 @@ int ModApiMapgen::l_get_biome_id(lua_State *L)
 		return 0;
 
 	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
-
 	if (!bmgr)
 		return 0;
 
 	Biome *biome = (Biome *)bmgr->getByName(biome_str);
-
 	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
 		return 0;
 
 	lua_pushinteger(L, biome->index);
+
+	return 1;
+}
+
+
+// get_biome_name(biome_id)
+// returns the biome name string
+int ModApiMapgen::l_get_biome_name(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	int biome_id = luaL_checkinteger(L, 1);
+
+	BiomeManager *bmgr = getServer(L)->getEmergeManager()->biomemgr;
+	if (!bmgr)
+		return 0;
+
+	Biome *b = (Biome *)bmgr->getRaw(biome_id);
+	lua_pushstring(L, b->name.c_str());
 
 	return 1;
 }
@@ -1731,6 +1748,7 @@ int ModApiMapgen::l_serialize_schematic(lua_State *L)
 void ModApiMapgen::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_biome_id);
+	API_FCT(get_biome_name);
 	API_FCT(get_heat);
 	API_FCT(get_humidity);
 	API_FCT(get_biome_data);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -28,6 +28,10 @@ private:
 	// returns the biome id as used in biomemap and returned by 'get_biome_data()'
 	static int l_get_biome_id(lua_State *L);
 
+	// get_biome_name(biome_id)
+	// returns the biome name string
+	static int l_get_biome_name(lua_State *L);
+
 	// get_heat(pos)
 	// returns the heat at the position
 	static int l_get_heat(lua_State *L);


### PR DESCRIPTION
For #7105 
Many APIs use the biome ID, this is useful to get the name string from the ID.

Tested with this mod that prints biome name as you explore:
```
local timer = 0

	minetest.register_globalstep(function(dtime)
		timer = timer + dtime
		if timer > 2 then
			timer = 0
			for _, player in ipairs(minetest.get_connected_players()) do
				local pos = player:getpos()
				pos.x = math.floor(pos.x)
				pos.y = math.floor(pos.y)
				pos.z = math.floor(pos.z)
				local biome_data = minetest.get_biome_data(pos)
				local biome_name = minetest.get_biome_name(biome_data.biome)
				print(biome_name)
			end
		end
	end)
```
Note in mgv6 which does not define biomes 'default' is returned.