### PR TITLE
Biomes: Fix vertical blend

### DIFF
--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -139,7 +139,7 @@ Biome *BiomeManager::getBiomeFromNoiseOriginal(float heat, float humidity, v3s16
 	}
 
 	mysrand(pos.Y + (heat + humidity) / 2);
-	if (biome_closest_blend &&
+	if (biome_closest_blend && dist_min_blend <= dist_min &&
 			myrand_range(0, biome_closest_blend->vertical_blend) >=
 			pos.Y - biome_closest_blend->max_pos.Y)
 		return biome_closest_blend;
@@ -300,7 +300,7 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 	// blend.
 	mysrand(pos.Y + (heat + humidity) / 2);
 
-	if (biome_closest_blend &&
+	if (biome_closest_blend && dist_min_blend <= dist_min &&
 			myrand_range(0, biome_closest_blend->vertical_blend) >=
 			pos.Y - biome_closest_blend->max_pos.Y)
 		return biome_closest_blend;


### PR DESCRIPTION
![screenshot_20180315_231818](https://user-images.githubusercontent.com/3686677/37496125-938bf5ee-28a8-11e8-94ad-31cfa5360220.png)

![screenshot_20180315_232615](https://user-images.githubusercontent.com/3686677/37496127-97f5b7f0-28a8-11e8-8fe8-9de0b0e0e580.png)

For #7134 
See tests above, the dark grey biome blends into the light grey biome above it, the blending does not interfere with the coloured biomes (red, range, yellow).
The test i used for the original feature turned out to be constructed in a way that disguised the bug. I now understand why the bug happened.

Test code:
```
minetest.clear_registered_biomes()
minetest.clear_registered_ores()
minetest.clear_registered_decorations()

minetest.register_biome({
	name = "",
	--node_dust = "",
	node_top = "default:desert_sandstone",
	depth_top = 1,
	--node_filler = "",
	--depth_filler = ,
	--node_stone = ",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	--y_max = 12,
	--y_min = -31000,
	max_pos = {x = 31000, y = 31000, z = 31000},
	min_pos = {x = -31000, y = -31000, z = -31000},
	heat_point = 25,
	humidity_point = 25,
})

minetest.register_biome({
	name = "",
	--node_dust = "",
	node_top = "default:sandstone",
	depth_top = 1,
	--node_filler = "",
	--depth_filler = ,
	--node_stone = ",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	--y_max = 12,
	--y_min = -31000,
	max_pos = {x = 31000, y = 31000, z = 31000},
	min_pos = {x = -31000, y = -31000, z = -31000},
	heat_point = 25,
	humidity_point = 75,
})

minetest.register_biome({
	name = "",
	--node_dust = "",
	node_top = "default:desert_stone",
	depth_top = 1,
	--node_filler = "",
	--depth_filler = ,
	--node_stone = ",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	--y_max = 12,
	--y_min = -31000,
	max_pos = {x = 31000, y = 31000, z = 31000},
	min_pos = {x = -31000, y = -31000, z = -31000},
	heat_point = 75,
	humidity_point = 25,
})

minetest.register_biome({
	name = "",
	--node_dust = "",
	node_top = "default:silver_sandstone",
	depth_top = 1,
	--node_filler = "",
	--depth_filler = ,
	--node_stone = ",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	--y_max = 12,
	--y_min = -31000,
	max_pos = {x = 31000, y = 31000, z = 31000},
	min_pos = {x = -31000, y = 17, z = -31000},
	heat_point = 75,
	humidity_point = 75,
})

minetest.register_biome({
	name = "",
	--node_dust = "",
	node_top = "default:stone",
	depth_top = 1,
	--node_filler = "",
	--depth_filler = ,
	--node_stone = ",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	--y_max = 12,
	--y_min = -31000,
	max_pos = {x = 31000, y = 16, z = 31000},
	min_pos = {x = -31000, y = -31000, z = -31000},
	vertical_blend = 8,
	heat_point = 75,
	humidity_point = 75,
})
```