### PR TITLE
Print the mod loading time

### DIFF
--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -70,8 +70,8 @@ void ServerModManager::loadMods(ServerScripting *script)
 		auto t = std::chrono::steady_clock::now();
 		script->loadMod(script_path, mod.name);
 		infostream << "Mod \"" << mod.name << "\" loaded after "
-			<< std::chrono::duration_cast<std::chrono::microseconds>(
-				std::chrono::steady_clock::now() - t).count() * 0.000001f
+			<< std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now() - t).count() * 0.001f
 			<< " seconds" << std::endl;
 	}
 }

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -47,6 +47,7 @@ ServerModManager::ServerModManager(const std::string &worldpath) :
 	addModsFromConfig(worldmt, gamespec.addon_mods_paths);
 }
 
+// clang-format off
 // This function cannot be currenctly easily tested but it should be ASAP
 void ServerModManager::loadMods(ServerScripting *script)
 {
@@ -76,6 +77,7 @@ void ServerModManager::loadMods(ServerScripting *script)
 	}
 }
 
+// clang-format on
 const ModSpec *ServerModManager::getModSpec(const std::string &modname) const
 {
 	std::vector<ModSpec>::const_iterator it;

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -66,8 +66,13 @@ void ServerModManager::loadMods(ServerScripting *script)
 		}
 		std::string script_path = mod.path + DIR_DELIM + "init.lua";
 		infostream << "  [" << padStringRight(mod.name, 12) << "] [\""
-			   << script_path << "\"]" << std::endl;
+			<< script_path << "\"]" << std::endl;
+		auto t = std::chrono::steady_clock::now();
 		script->loadMod(script_path, mod.name);
+		infostream << "Mod \"" << mod.name << "\" loaded after "
+			<< std::chrono::duration_cast<std::chrono::microseconds>(
+				std::chrono::steady_clock::now() - t).count() * 0.000001f
+			<< " seconds" << std::endl;
 	}
 }
 


### PR DESCRIPTION
When a mod took a noticeable loading time (at least 0.1 seconds), the mod name and time is logged as action, else it's logged to infostream.