### PR TITLE
Minetest ASCII art: Move from actionstream to rawstream

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -366,7 +366,7 @@ void Server::start()
 	m_thread->start();
 
 	// ASCII art for the win!
-	actionstream
+	rawstream
 		<< "        .__               __                   __   " << std::endl
 		<< "  _____ |__| ____   _____/  |_  ____   _______/  |_ " << std::endl
 		<< " /     \\|  |/    \\_/ __ \\   __\\/ __ \\ /  ___/\\   __\\" << std::endl


### PR DESCRIPTION
![ascii](https://user-images.githubusercontent.com/3686677/37560496-1de32b7a-2a31-11e8-997b-e21d675bd317.png)

Attends to #7014 by removing the art from actionstream as requested, #7030 does not remove it from actionstream.

This PR moves the ASCII art from 'actionstream' to 'rawstream' and so appears without the prefixed timestamp and log level readout, for a cleaner appearence and less chance of line wrap in the terminal.
Log-processing programs can now filter out the art due to it no longer being in 'action'.