### PR TITLE
 Optional alpha channel support for entities

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4841,6 +4841,8 @@ Definition tables
     --  ^ "wielditem" expects 'textures = {itemname}' (see 'visual' above).
         colors = {},
     --  ^ Number of required colors depends on visual.
+        use_texture_alpha = false,
+    --  ^ Use texture's alpha channel, excludes "upright_sprite" and "wielditem"
         spritediv = {x = 1, y = 1},
     --  ^ Used with spritesheet textures for animation and/or frame selection
     --    according to position relative to player.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4843,6 +4843,8 @@ Definition tables
     --  ^ Number of required colors depends on visual.
         use_texture_alpha = false,
     --  ^ Use texture's alpha channel, excludes "upright_sprite" and "wielditem"
+	--  ^ Note: currently causes visual issues when viewed through other
+	--  ^ semi-transparent materials such as water.
         spritediv = {x = 1, y = 1},
     --  ^ Used with spritesheet textures for animation and/or frame selection
     --    according to position relative to player.

--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -476,6 +476,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		return;
 	}
 
+	video::E_MATERIAL_TYPE material_type = (m_prop.use_texture_alpha) ?
+		video::EMT_TRANSPARENT_ALPHA_CHANNEL : video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+
 	if (m_prop.visual == "sprite") {
 		infostream<<"GenericCAO::addToScene(): single_sprite"<<std::endl;
 		m_spritenode = RenderingEngine::get_scene_manager()->addBillboardSceneNode(
@@ -485,7 +488,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 				tsrc->getTextureForMesh("unknown_node.png"));
 		m_spritenode->setMaterialFlag(video::EMF_LIGHTING, false);
 		m_spritenode->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
-		m_spritenode->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF);
+		m_spritenode->setMaterialType(material_type);
 		m_spritenode->setMaterialFlag(video::EMF_FOG_ENABLE, true);
 		u8 li = m_last_light;
 		m_spritenode->setColor(video::SColor(255,li,li,li));
@@ -563,7 +566,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 
 		m_meshnode->setMaterialFlag(video::EMF_LIGHTING, false);
 		m_meshnode->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
-		m_meshnode->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF);
+		m_meshnode->setMaterialType(material_type);
 		m_meshnode->setMaterialFlag(video::EMF_FOG_ENABLE, true);
 	}
 	else if(m_prop.visual == "mesh") {
@@ -586,15 +589,12 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 
 			setAnimatedMeshColor(m_animated_meshnode, video::SColor(255,li,li,li));
 
-			bool backface_culling = m_prop.backface_culling;
-			if (m_is_player)
-				backface_culling = false;
-
 			m_animated_meshnode->setMaterialFlag(video::EMF_LIGHTING, true);
 			m_animated_meshnode->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
-			m_animated_meshnode->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF);
+			m_animated_meshnode->setMaterialType(material_type);
 			m_animated_meshnode->setMaterialFlag(video::EMF_FOG_ENABLE, true);
-			m_animated_meshnode->setMaterialFlag(video::EMF_BACK_FACE_CULLING, backface_culling);
+			m_animated_meshnode->setMaterialFlag(video::EMF_BACK_FACE_CULLING,
+				m_prop.backface_culling);
 		}
 		else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
@@ -993,12 +993,16 @@ void GenericCAO::updateTextures(std::string mod)
 	m_current_texture_modifier = mod;
 	m_glow = m_prop.glow;
 
+	video::E_MATERIAL_TYPE material_type = (m_prop.use_texture_alpha) ?
+		video::EMT_TRANSPARENT_ALPHA_CHANNEL : video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+
 	if (m_spritenode) {
 		if (m_prop.visual == "sprite") {
 			std::string texturestring = "unknown_node.png";
 			if (!m_prop.textures.empty())
 				texturestring = m_prop.textures[0];
 			texturestring += mod;
+			m_spritenode->getMaterial(0).MaterialType = material_type;
 			m_spritenode->setMaterialTexture(0,
 					tsrc->getTextureForMesh(texturestring));
 
@@ -1033,9 +1037,11 @@ void GenericCAO::updateTextures(std::string mod)
 
 				// Set material flags and texture
 				video::SMaterial& material = m_animated_meshnode->getMaterial(i);
+				material.MaterialType = material_type;
 				material.TextureLayer[0].Texture = texture;
 				material.setFlag(video::EMF_LIGHTING, true);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
+				material.setFlag(video::EMF_BACK_FACE_CULLING, m_prop.backface_culling);
 
 				// don't filter low-res textures, makes them look blurry
 				// player models have a res of 64
@@ -1077,6 +1083,7 @@ void GenericCAO::updateTextures(std::string mod)
 
 				// Set material flags and texture
 				video::SMaterial& material = m_meshnode->getMaterial(i);
+				material.MaterialType = material_type;
 				material.setFlag(video::EMF_LIGHTING, false);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setTexture(0,

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -801,6 +801,7 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_prop.eye_height = 1.625f;
 	// End of default appearance
 	m_prop.is_visible = true;
+	m_prop.backface_culling = false;
 	m_prop.makes_footstep_sound = true;
 	m_prop.stepheight = PLAYER_DEFAULT_STEPHEIGHT * BS;
 	m_hp = m_prop.hp_max;

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -68,6 +68,7 @@ std::string ObjectProperties::dump()
 	os << ", static_save=" << static_save;
 	os << ", eye_height=" << eye_height;
 	os << ", zoom_fov=" << zoom_fov;
+	os << ", use_texture_alpha=" << use_texture_alpha;
 	return os.str();
 }
 
@@ -113,6 +114,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU16(os, breath_max);
 	writeF1000(os, eye_height);
 	writeF1000(os, zoom_fov);
+	writeU8(os, use_texture_alpha);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -164,4 +166,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	breath_max = readU16(is);
 	eye_height = readF1000(is);
 	zoom_fov = readF1000(is);
+	use_texture_alpha = readU8(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -60,6 +60,7 @@ struct ObjectProperties
 	bool static_save = true;
 	float eye_height = 1.625f;
 	float zoom_fov = 0.0f;
+	bool use_texture_alpha = false;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -304,6 +304,7 @@ void read_object_properties(lua_State *L, int index,
 	lua_pop(L, 1);
 
 	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
+	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
 }
 
 /******************************************************************************/
@@ -386,6 +387,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "wield_item");
 	lua_pushnumber(L, prop->zoom_fov);
 	lua_setfield(L, -2, "zoom_fov");
+	lua_pushboolean(L, prop->use_texture_alpha);
+	lua_setfield(L, -2, "use_texture_alpha");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Replaces #6857 (borked rebase)

This PR allows optional use of alpha-channel for cube, sprite and mesh active objects. Supports dynamic updating so could be useful for temporary materialization effects, etc.

Currently entities use the EMT_TRANSPARENT_ALPHA_CHANNEL_REF material type flag which results in pixels being rendered either fully transparent or fully opaque depending on individual alpha level.
The EMT_TRANSPARENT_ALPHA_CHANNEL flag, which does support full alpha-channel, is know to have z-sorting issues, like being invisible from underwater, so cannot be simply used as the default.

This change does not apply to upright_sprite or wielditem visuals since the former already appears to support alpha (at least for the front face) and wielditems would probably look terrible with the broken depth sorting and how they are constructed, though I haven’t actually tried this.

This also allows for dynamic update of a mesh object’s backface_culling property. This is of particular importance if you wanted to use alpha support for a given player as player face culling is currently hard-coded false for player objects in a really crude way. Testing has shown that semi-transparent objects both look and behave better with backface culling enabled.

Using this property for players is not really recommend for the reasons pointed out above, however, it may be deemed acceptable under the right circumstances. As with nodes, this feature should be used sparingly and with caution, at least until depth sorting is improved.

Some example screenshots here: https://forum.minetest.net/viewtopic.php?f=47&t=18026#p305791

**Note:** This PR introduces a new object property `use_texture_alpha` so will not be compatible with older servers. However since 0.5.0 is a breaking release anyway this should not matter, unless you wanted backport it, which seems unlikely given that it's a new feature and not a bugfix.