### PR TITLE
macOS: don't require X11 libraries during compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -336,12 +336,12 @@ else()
 		endif(HAVE_LIBRT)
 	endif(APPLE)
 
-	if(NOT HAIKU)
+	if(NOT HAIKU AND NOT APPLE)
 	# This way Xxf86vm is found on OpenBSD too
 		find_library(XXF86VM_LIBRARY Xxf86vm)
 		mark_as_advanced(XXF86VM_LIBRARY)
 		set(CLIENT_PLATFORM_LIBS ${CLIENT_PLATFORM_LIBS} ${XXF86VM_LIBRARY})
-	endif(NOT HAIKU)
+	endif(NOT HAIKU AND NOT APPLE)
 
 	# Prefer local iconv if installed
 	find_library(ICONV_LIBRARY iconv)


### PR DESCRIPTION
This library needs to be removed from Apple builds to avoid CMake Error XXF86VM_LIBRARY is NOTFOUND