### PR TITLE
guard sound manager initialization with enable_sound

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -137,7 +137,8 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	//create soundmanager
 	MenuMusicFetcher soundfetcher;
 #if USE_SOUND
-	m_sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
+	if (g_settings->getBool("enable_sound"))
+		m_sound_manager = createOpenALSoundManager(g_sound_manager_singleton.get(), &soundfetcher);
 #endif
 	if(!m_sound_manager)
 		m_sound_manager = &dummySoundManager;


### PR DESCRIPTION
Reported by user epoch in IRC.

There are two sound related code guards in MT:
USE_SOUND definition at compile time, and enable_sound option at runtime.

Minetest still used to run OpenAL calls with enable_sound set to false.
(GUIEngine constructor just had USE_SOUND but not enable_sound)

The reason this now causes a bug is because, with the singleton / global sound initialization, part of the code that used to run from GUIEngine was split out and now runs from clientlauncher.cpp, and the rest remained in GUIEngine.
The clientlauncher.cpp code correctly uses both USE_SOUND and enable_sound.
However, GUIEngine was left with just USE_SOUND.
This caused part of the code to run - and part not.

With this PR, GUIEngine constructor is updated to use both USE_SOUND and enable_sound.