### PR TITLE
fix static initialization order dependency by not having one

### DIFF
--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -295,11 +295,6 @@ public:
 			<< ", using " << alcGetString(m_device.get(), ALC_DEVICE_SPECIFIER)
 			<< std::endl;
 	}
-
-	~SoundManagerSingleton()
-	{
-		infostream << "Audio: Global Deinitialized." << std::endl;
-	}
 };
 
 class OpenALSoundManager: public ISoundManager


### PR DESCRIPTION
Crash on program exit starting from commit 4fd97158 (PR #7158).
The bug was exposed by this commit however it originates in commit 9293d8e2 (PR #7063).

infostream is used from the destructor which runs from a statically initialized object.
However infostream is a statically initialized object itself, therefore there an order dependency on destruction is created.

As the destructor is otherwise empty, I've resolved the dependency by removing it.

Analogue use of infostream from the constructor does not cause such dependency, thus no change.

C++ standard term when describing static initialization order is 'indeterminately sequenced' so bug reproducibility may depend on platform.
