### PR TITLE
Fix --color command line parameter ignorance

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -118,16 +118,16 @@ public:
 		m_stream(stream)
 	{
 #if !defined(_WIN32)
-		colored = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
-			(Logger::color_mode == LOG_COLOR_AUTO && isatty(fileno(stdout)));
+		is_tty = isatty(fileno(stdout));
 #else
-		colored = Logger::color_mode == LOG_COLOR_ALWAYS;
+		is_tty = false;
 #endif
 	}
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{
-		bool colored_message = colored;
+		bool colored_message = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
+			(Logger::color_mode == LOG_COLOR_AUTO && is_tty);
 		if (colored_message)
 			switch (lev) {
 			case LL_ERROR:
@@ -160,7 +160,7 @@ public:
 
 private:
 	std::ostream &m_stream;
-	bool colored;
+	bool is_tty;
 };
 
 class FileLogOutput : public ICombinedLogOutput {

--- a/src/log.h
+++ b/src/log.h
@@ -120,7 +120,7 @@ public:
 #if !defined(_WIN32)
 		is_tty = isatty(fileno(stdout));
 #else
-		is_tty = false;
+		is_tty = _isatty(_fileno(stdout));
 #endif
 	}
 

--- a/src/log.h
+++ b/src/log.h
@@ -120,7 +120,7 @@ public:
 #if !defined(_WIN32)
 		is_tty = isatty(fileno(stdout));
 #else
-		is_tty = _isatty(_fileno(stdout));
+		is_tty = false;
 #endif
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,15 +266,9 @@ static void set_allowed_options(OptionList *allowed_options)
 			"'name' lists names, 'both' lists both)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
-#if !defined(_WIN32)
 	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
 			_("Coloured logs ('always', 'never' or 'auto'), defaults to 'auto'"
 			))));
-#else
-	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
-			_("Coloured logs ('always' or 'never'), defaults to 'never'"
-			))));
-#endif
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
 			_("Print more information to console"))));
 	allowed_options->insert(std::make_pair("verbose",  ValueSpec(VALUETYPE_FLAG,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,9 +266,15 @@ static void set_allowed_options(OptionList *allowed_options)
 			"'name' lists names, 'both' lists both)"))));
 	allowed_options->insert(std::make_pair("quiet", ValueSpec(VALUETYPE_FLAG,
 			_("Print to console errors only"))));
+#if !defined(_WIN32)
 	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
 			_("Coloured logs ('always', 'never' or 'auto'), defaults to 'auto'"
 			))));
+#else
+	allowed_options->insert(std::make_pair("color", ValueSpec(VALUETYPE_STRING,
+			_("Coloured logs ('always' or 'never'), defaults to 'never'"
+			))));
+#endif
 	allowed_options->insert(std::make_pair("info", ValueSpec(VALUETYPE_FLAG,
 			_("Print more information to console"))));
 	allowed_options->insert(std::make_pair("verbose",  ValueSpec(VALUETYPE_FLAG,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,8 +407,10 @@ static void setup_log_params(const Settings &cmd_args)
 			Logger::color_mode = LOG_COLOR_AUTO;
 		else if (mode == "always")
 			Logger::color_mode = LOG_COLOR_ALWAYS;
-		else
+		else if (mode == "never")
 			Logger::color_mode = LOG_COLOR_NEVER;
+		else
+			errorstream << "Invalid color mode: " << mode << std::endl;
 	}
 
 	// If trace is enabled, enable logging of certain things

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -417,16 +417,16 @@ static void setup_log_params(const Settings &cmd_args)
 			color_mode = color_mode_env;
 #endif
 	}
-	if (color_mode == "")
-		// Use default logger color_mode
-	else if (color_mode == "auto")
-		Logger::color_mode = LOG_COLOR_AUTO;
-	else if (color_mode == "always")
-		Logger::color_mode = LOG_COLOR_ALWAYS;
-	else if (color_mode == "never")
-		Logger::color_mode = LOG_COLOR_NEVER;
-	else
-		errorstream << "Invalid color mode: " << color_mode << std::endl;
+	if (color_mode != "") {
+		if (color_mode == "auto")
+			Logger::color_mode = LOG_COLOR_AUTO;
+		else if (color_mode == "always")
+			Logger::color_mode = LOG_COLOR_ALWAYS;
+		else if (color_mode == "never")
+			Logger::color_mode = LOG_COLOR_NEVER;
+		else
+			errorstream << "Invalid color mode: " << color_mode << std::endl;
+	}
 
 	// If trace is enabled, enable logging of certain things
 	if (cmd_args.getFlag("trace")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,17 +407,26 @@ static void setup_log_params(const Settings &cmd_args)
 	}
 
 	// Coloured log messages (see log.h)
+	std::string color_mode;
 	if (cmd_args.exists("color")) {
-		std::string mode = cmd_args.get("color");
-		if (mode == "auto")
-			Logger::color_mode = LOG_COLOR_AUTO;
-		else if (mode == "always")
-			Logger::color_mode = LOG_COLOR_ALWAYS;
-		else if (mode == "never")
-			Logger::color_mode = LOG_COLOR_NEVER;
-		else
-			errorstream << "Invalid color mode: " << mode << std::endl;
+		color_mode = cmd_args.get("color");
+#if !defined(_WIN32)
+	} else {
+		char *color_mode_env = getenv("MT_LOGCOLOR");
+		if (color_mode_env)
+			color_mode = color_mode_env;
+#endif
 	}
+	if (color_mode == "")
+		// Use default logger color_mode
+	else if (color_mode == "auto")
+		Logger::color_mode = LOG_COLOR_AUTO;
+	else if (color_mode == "always")
+		Logger::color_mode = LOG_COLOR_ALWAYS;
+	else if (color_mode == "never")
+		Logger::color_mode = LOG_COLOR_NEVER;
+	else
+		errorstream << "Invalid color mode: " << color_mode << std::endl;
 
 	// If trace is enabled, enable logging of certain things
 	if (cmd_args.getFlag("trace")) {


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/pull/7034#issuecomment-376007017
When parsing the parameter, the log streams are already available, so the passed argument was silently ignored.