### PR TITLE
Key change menu: Fix empty string translation

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -51,10 +51,19 @@ extern wchar_t *utf8_to_wide_c(const char *str);
 // The returned string is allocated using new
 inline const wchar_t *wgettext(const char *str)
 {
-	return utf8_to_wide_c(gettext(str));
+#if USE_GETTEXT
+	// We must check here that is not an empty string to avoid trying to translate it
+	return str[0] ? utf8_to_wide_c(gettext(str)) : utf8_to_wide_c("");
+#else
+	return utf8_to_wide_c(str);
+#endif
 }
 
 inline std::string strgettext(const std::string &text)
 {
-	return gettext(text.c_str());
+#if USE_GETTEXT
+	return text.empty() ? text.c_str() : gettext(text.c_str());
+#else
+	return text.c_str();
+#endif
 }

--- a/src/gettext.h
+++ b/src/gettext.h
@@ -51,19 +51,11 @@ extern wchar_t *utf8_to_wide_c(const char *str);
 // The returned string is allocated using new
 inline const wchar_t *wgettext(const char *str)
 {
-#if USE_GETTEXT
 	// We must check here that is not an empty string to avoid trying to translate it
 	return str[0] ? utf8_to_wide_c(gettext(str)) : utf8_to_wide_c("");
-#else
-	return utf8_to_wide_c(str);
-#endif
 }
 
 inline std::string strgettext(const std::string &text)
 {
-#if USE_GETTEXT
 	return text.empty() ? text.c_str() : gettext(text.c_str());
-#else
-	return text.c_str();
-#endif
 }

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -153,7 +153,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : utf8_to_wide_c("");
+			const wchar_t *text = wgettext(k->key.name());
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -153,8 +153,9 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			k->button = Environment->addButton(rect, this, k->id,
-							   k->key.name()[0] ? wgettext(k->key.name()) : L"");
+			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : utf8_to_wide_c("");
+			k->button = Environment->addButton(rect, this, k->id, text);
+			delete[] text;
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
 			offset.X += 230;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -153,9 +153,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = wgettext(k->key.name());
-			k->button = Environment->addButton(rect, this, k->id, text);
-			delete[] text;
+			k->button = Environment->addButton(rect, this, k->id,
+							   k->key.name()[0] ? wgettext(k->key.name()) : L"");
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
 			offset.X += 230;


### PR DESCRIPTION
Fix for incorrect translation of empty strings in key change menu

In the key change menu, when a button key not have name an empty string is passed to gettext.
The empty string is reserved for gettext to return de header of the .po file an this is shoved in the button

![minetest-es](https://user-images.githubusercontent.com/30205587/37967088-d6c3fcca-31b9-11e8-8bc1-139bc777dc61.png)

The capture is from version 0.4.16 but the code is the same in the master branch.