### PR TITLE
[Don't squash me!] Add player inventory callbacks & refactor

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -593,6 +593,8 @@ core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration
 core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_registration()
 core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
 core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
+core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
+core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2880,6 +2880,22 @@ Call these functions only at load time!
 * `minetest.register_craft_predict(func(itemstack, player, old_craft_grid, craft_inv))`
     * The same as before, except that it is called before the player crafts, to
       make craft prediction, and it should not change anything.
+* `minetest.register_allow_player_inventory_action(func(player, inventory, action, inventory_info))`
+    * Determinates how much of a stack may be taken, put or moved to a
+      player inventory.
+    * `player` (type `ObjectRef`) is the player who modified the inventory
+      `inventory` (type `InvRef`).
+    * List of possible `action` (string) values and their
+      `inventory_info` (table) contents:
+        * `move`: `{from_list=string, to_list=string, from_index=number, to_index=number, count=number}`
+        * `put`:  `{listname=string, index=number, stack=ItemStack}`
+        * `take`: Same as `put`
+    * Return a numeric value to limit the amount of items to be taken, put or
+      moved. A value of `-1` for `take` will make the source stack infinite.
+* `minetest.register_on_player_inventory_action(func(player, inventory, action, inventory_info))`
+    * Called after a take, put or move event from/to/in a player inventory
+    * Function arguments: see `minetest.register_allow_player_inventory_action`
+    * Does not accept or handle any return value.
 * `minetest.register_on_protection_violation(func(pos, name))`
     * Called by `builtin` and mods when a player violates protection at a
       position (eg, digs a node or punches a protected entity).

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -266,8 +266,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::DETACHED &&
 			from_inv.name == to_inv.name) {
 		src_can_take_count = PLAYER_TO_SA(player)->detached_inventory_AllowMove(
-				from_inv.name, from_list, from_i,
-				to_list, to_i, try_take_count, player);
+			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
 	} else {
 		// Destination is detached
@@ -275,14 +274,14 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			dst_can_put_count = PLAYER_TO_SA(player)->detached_inventory_AllowPut(
-					to_inv.name, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is detached
 		if (from_inv.type == InventoryLocation::DETACHED) {
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			src_can_take_count = PLAYER_TO_SA(player)->detached_inventory_AllowTake(
-					from_inv.name, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -294,8 +293,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::NODEMETA &&
 			from_inv.p == to_inv.p) {
 		src_can_take_count = PLAYER_TO_SA(player)->nodemeta_inventory_AllowMove(
-				from_inv.p, from_list, from_i,
-				to_list, to_i, try_take_count, player);
+			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
 	} else {
 		// Destination is nodemeta
@@ -303,14 +301,14 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			dst_can_put_count = PLAYER_TO_SA(player)->nodemeta_inventory_AllowPut(
-					to_inv.p, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is nodemeta
 		if (from_inv.type == InventoryLocation::NODEMETA) {
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			src_can_take_count = PLAYER_TO_SA(player)->nodemeta_inventory_AllowTake(
-					from_inv.p, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -321,8 +319,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::PLAYER &&
 			from_inv.name == to_inv.name) {
 		src_can_take_count = PLAYER_TO_SA(player)->player_inventory_AllowMove(
-			from_inv, from_list, from_i,
-			to_list, to_i, try_take_count, player);
+			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
 	} else {
 		// Destination is a player
@@ -330,14 +327,14 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			dst_can_put_count = PLAYER_TO_SA(player)->player_inventory_AllowPut(
-				to_inv, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is a player
 		if (from_inv.type == InventoryLocation::PLAYER) {
 			ItemStack src_item = list_from->getItem(from_i);
 			src_item.count = try_take_count;
 			src_can_take_count = PLAYER_TO_SA(player)->player_inventory_AllowTake(
-				from_inv, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -478,18 +475,17 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::DETACHED &&
 			from_inv.name == to_inv.name) {
 		PLAYER_TO_SA(player)->detached_inventory_OnMove(
-				from_inv.name, from_list, from_i,
-				to_list, to_i, count, player);
+				*this, count, player);
 	} else {
 		// Destination is detached
 		if (to_inv.type == InventoryLocation::DETACHED) {
 			PLAYER_TO_SA(player)->detached_inventory_OnPut(
-					to_inv.name, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is detached
 		if (from_inv.type == InventoryLocation::DETACHED) {
 			PLAYER_TO_SA(player)->detached_inventory_OnTake(
-					from_inv.name, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -500,18 +496,17 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::NODEMETA &&
 			from_inv.p == to_inv.p) {
 		PLAYER_TO_SA(player)->nodemeta_inventory_OnMove(
-				from_inv.p, from_list, from_i,
-				to_list, to_i, count, player);
+			*this, count, player);
 	} else {
 		// Destination is nodemeta
 		if (to_inv.type == InventoryLocation::NODEMETA) {
 			PLAYER_TO_SA(player)->nodemeta_inventory_OnPut(
-					to_inv.p, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is nodemeta
 		if (from_inv.type == InventoryLocation::NODEMETA) {
 			PLAYER_TO_SA(player)->nodemeta_inventory_OnTake(
-					from_inv.p, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -522,18 +517,17 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			to_inv.type == InventoryLocation::PLAYER &&
 			from_inv.name == to_inv.name) {
 		PLAYER_TO_SA(player)->player_inventory_OnMove(
-			from_inv, from_list, from_i,
-			to_list, to_i, count, player);
+			*this, count, player);
 	} else {
 		// Destination is player inventory
 		if (to_inv.type == InventoryLocation::PLAYER) {
 			PLAYER_TO_SA(player)->player_inventory_OnPut(
-				to_inv, to_list, to_i, src_item, player);
+				*this, src_item, player);
 		}
 		// Source is player inventory
 		if (from_inv.type == InventoryLocation::PLAYER) {
 			PLAYER_TO_SA(player)->player_inventory_OnTake(
-				from_inv, from_list, from_i, src_item, player);
+				*this, src_item, player);
 		}
 	}
 
@@ -635,20 +629,25 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		take_count = count;
 	int src_can_take_count = take_count;
 
-	// Source is detached
-	if (from_inv.type == InventoryLocation::DETACHED) {
-		ItemStack src_item = list_from->getItem(from_i);
-		src_item.count = take_count;
-		src_can_take_count = PLAYER_TO_SA(player)->detached_inventory_AllowTake(
-				from_inv.name, from_list, from_i, src_item, player);
-	}
+	ItemStack src_item = list_from->getItem(from_i);
+	src_item.count = take_count;
 
-	// Source is nodemeta
-	if (from_inv.type == InventoryLocation::NODEMETA) {
-		ItemStack src_item = list_from->getItem(from_i);
-		src_item.count = take_count;
+	// Run callbacks depending on source inventory
+	switch (from_inv.type) {
+	case InventoryLocation::DETACHED:
+		src_can_take_count = PLAYER_TO_SA(player)->detached_inventory_AllowTake(
+			*this, src_item, player);
+		break;
+	case InventoryLocation::NODEMETA:
 		src_can_take_count = PLAYER_TO_SA(player)->nodemeta_inventory_AllowTake(
-				from_inv.p, from_list, from_i, src_item, player);
+			*this, src_item, player);
+		break;
+	case InventoryLocation::PLAYER:
+		src_can_take_count = PLAYER_TO_SA(player)->player_inventory_AllowTake(
+			*this, src_item, player);
+		break;
+	default:
+		break;
 	}
 
 	if (src_can_take_count != -1 && src_can_take_count < take_count)
@@ -656,7 +655,8 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	int actually_dropped_count = 0;
 
-	ItemStack src_item = list_from->getItem(from_i);
+	// Update item due executed callbacks
+	src_item = list_from->getItem(from_i);
 
 	// Drop the item
 	ItemStack item1 = list_from->getItem(from_i);
@@ -694,16 +694,21 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		Report drop to endpoints
 	*/
 
-	// Source is detached
-	if (from_inv.type == InventoryLocation::DETACHED) {
+	switch (from_inv.type) {
+	case InventoryLocation::DETACHED:
 		PLAYER_TO_SA(player)->detached_inventory_OnTake(
-				from_inv.name, from_list, from_i, src_item, player);
-	}
-
-	// Source is nodemeta
-	if (from_inv.type == InventoryLocation::NODEMETA) {
+			*this, src_item, player);
+		break;
+	case InventoryLocation::NODEMETA:
 		PLAYER_TO_SA(player)->nodemeta_inventory_OnTake(
-				from_inv.p, from_list, from_i, src_item, player);
+			*this, src_item, player);
+		break;
+	case InventoryLocation::PLAYER:
+		PLAYER_TO_SA(player)->player_inventory_OnTake(
+			*this, src_item, player);
+		break;
+	default:
+		break;
 	}
 
 	/*

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -245,8 +245,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	*/
 	bool ignore_rollback = (
 		from_inv.type == InventoryLocation::PLAYER &&
-		to_inv.type == InventoryLocation::PLAYER &&
-		from_inv.name == to_inv.name);
+		from_inv == to_inv);
 
 	/*
 		Collect information of endpoints
@@ -263,8 +262,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Move occurs in the same detached inventory
 	if (from_inv.type == InventoryLocation::DETACHED &&
-			to_inv.type == InventoryLocation::DETACHED &&
-			from_inv.name == to_inv.name) {
+			from_inv == to_inv) {
 		src_can_take_count = PLAYER_TO_SA(player)->detached_inventory_AllowMove(
 			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
@@ -290,8 +288,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 	// Both endpoints are nodemeta
 	// Move occurs in the same nodemeta inventory
 	if (from_inv.type == InventoryLocation::NODEMETA &&
-			to_inv.type == InventoryLocation::NODEMETA &&
-			from_inv.p == to_inv.p) {
+			from_inv == to_inv) {
 		src_can_take_count = PLAYER_TO_SA(player)->nodemeta_inventory_AllowMove(
 			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
@@ -316,8 +313,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Move occurs in the same player inventory
 	if (from_inv.type == InventoryLocation::PLAYER &&
-			to_inv.type == InventoryLocation::PLAYER &&
-			from_inv.name == to_inv.name) {
+			from_inv == to_inv) {
 		src_can_take_count = PLAYER_TO_SA(player)->player_inventory_AllowMove(
 			*this, try_take_count, player);
 		dst_can_put_count = src_can_take_count;
@@ -472,8 +468,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Both endpoints are same detached
 	if (from_inv.type == InventoryLocation::DETACHED &&
-			to_inv.type == InventoryLocation::DETACHED &&
-			from_inv.name == to_inv.name) {
+			from_inv == to_inv) {
 		PLAYER_TO_SA(player)->detached_inventory_OnMove(
 				*this, count, player);
 	} else {
@@ -493,8 +488,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Both endpoints are same nodemeta
 	if (from_inv.type == InventoryLocation::NODEMETA &&
-			to_inv.type == InventoryLocation::NODEMETA &&
-			from_inv.p == to_inv.p) {
+			from_inv == to_inv) {
 		PLAYER_TO_SA(player)->nodemeta_inventory_OnMove(
 			*this, count, player);
 	} else {
@@ -514,8 +508,7 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	// Both endpoints are same player inventory
 	if (from_inv.type == InventoryLocation::PLAYER &&
-			to_inv.type == InventoryLocation::PLAYER &&
-			from_inv.name == to_inv.name) {
+			from_inv == to_inv) {
 		PLAYER_TO_SA(player)->player_inventory_OnMove(
 			*this, count, player);
 	} else {

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -134,16 +134,20 @@ struct InventoryAction
 	virtual ~InventoryAction() = default;;
 };
 
-struct IMoveAction : public InventoryAction
+struct MoveAction
 {
-	// count=0 means "everything"
-	u16 count = 0;
 	InventoryLocation from_inv;
 	std::string from_list;
 	s16 from_i = -1;
 	InventoryLocation to_inv;
 	std::string to_list;
 	s16 to_i = -1;
+};
+
+struct IMoveAction : public InventoryAction, public MoveAction
+{
+	// count=0 means "everything"
+	u16 count = 0;
 	bool move_somewhere = false;
 
 	// treat these as private
@@ -181,13 +185,10 @@ struct IMoveAction : public InventoryAction
 	void clientApply(InventoryManager *mgr, IGameDef *gamedef);
 };
 
-struct IDropAction : public InventoryAction
+struct IDropAction : public InventoryAction, public MoveAction
 {
 	// count=0 means "everything"
 	u16 count = 0;
-	InventoryLocation from_inv;
-	std::string from_list;
-	s16 from_i = -1;
 
 	IDropAction() = default;
 

--- a/src/script/cpp_api/s_inventory.h
+++ b/src/script/cpp_api/s_inventory.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_base.h"
 
+struct MoveAction;
 struct ItemStack;
 
 class ScriptApiDetached
@@ -30,35 +31,27 @@ public:
 	/* Detached inventory callbacks */
 	// Return number of accepted items to be moved
 	int detached_inventory_AllowMove(
-			const std::string &name,
-			const std::string &from_list, int from_index,
-			const std::string &to_list, int to_index,
-			int count, ServerActiveObject *player);
+			const MoveAction &ma, int count,
+			ServerActiveObject *player);
 	// Return number of accepted items to be put
 	int detached_inventory_AllowPut(
-			const std::string &name,
-			const std::string &listname, int index, ItemStack &stack,
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Return number of accepted items to be taken
 	int detached_inventory_AllowTake(
-			const std::string &name,
-			const std::string &listname, int index, ItemStack &stack,
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Report moved items
 	void detached_inventory_OnMove(
-			const std::string &name,
-			const std::string &from_list, int from_index,
-			const std::string &to_list, int to_index,
-			int count, ServerActiveObject *player);
+			const MoveAction &ma, int count,
+			ServerActiveObject *player);
 	// Report put items
 	void detached_inventory_OnPut(
-			const std::string &name,
-			const std::string &listname, int index, ItemStack &stack,
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Report taken items
 	void detached_inventory_OnTake(
-			const std::string &name,
-			const std::string &listname, int index, ItemStack &stack,
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 private:
 	bool getDetachedInventoryCallback(

--- a/src/script/cpp_api/s_nodemeta.h
+++ b/src/script/cpp_api/s_nodemeta.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_item.h"
 #include "irr_v3d.h"
 
+struct MoveAction;
 struct ItemStack;
 
 class ScriptApiNodemeta
@@ -34,30 +35,28 @@ public:
 	virtual ~ScriptApiNodemeta() = default;
 
 	// Return number of accepted items to be moved
-	int nodemeta_inventory_AllowMove(v3s16 p,
-			const std::string &from_list, int from_index,
-			const std::string &to_list, int to_index,
-			int count, ServerActiveObject *player);
+	int nodemeta_inventory_AllowMove(
+			const MoveAction &ma, int count,
+			ServerActiveObject *player);
 	// Return number of accepted items to be put
-	int nodemeta_inventory_AllowPut(v3s16 p,
-			const std::string &listname, int index, ItemStack &stack,
+	int nodemeta_inventory_AllowPut(
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Return number of accepted items to be taken
-	int nodemeta_inventory_AllowTake(v3s16 p,
-			const std::string &listname, int index, ItemStack &stack,
+	int nodemeta_inventory_AllowTake(
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Report moved items
-	void nodemeta_inventory_OnMove(v3s16 p,
-			const std::string &from_list, int from_index,
-			const std::string &to_list, int to_index,
-			int count, ServerActiveObject *player);
+	void nodemeta_inventory_OnMove(
+			const MoveAction &ma, int count,
+			ServerActiveObject *player);
 	// Report put items
-	void nodemeta_inventory_OnPut(v3s16 p,
-			const std::string &listname, int index, ItemStack &stack,
+	void nodemeta_inventory_OnPut(
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 	// Report taken items
-	void nodemeta_inventory_OnTake(v3s16 p,
-			const std::string &listname, int index, ItemStack &stack,
+	void nodemeta_inventory_OnTake(
+			const MoveAction &ma, const ItemStack &stack,
 			ServerActiveObject *player);
 private:
 

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v3d.h"
 #include "util/string.h"
 
+struct MoveAction;
 struct InventoryLocation;
 struct ItemStack;
 struct ToolCapabilities;
@@ -54,43 +55,33 @@ public:
 	// Player inventory callbacks
 	// Return number of accepted items to be moved
 	int player_inventory_AllowMove(
-		const InventoryLocation &loc,
-		const std::string &from_list, int from_index,
-		const std::string &to_list, int to_index,
-		int count, ServerActiveObject *player);
+		const MoveAction &ma, int count,
+		ServerActiveObject *player);
 	// Return number of accepted items to be put
 	int player_inventory_AllowPut(
-		const InventoryLocation &loc,
-		const std::string &listname, int index, const ItemStack &stack,
+		const MoveAction &ma, const ItemStack &stack,
 		ServerActiveObject *player);
 	// Return number of accepted items to be taken
 	int player_inventory_AllowTake(
-		const InventoryLocation &loc,
-		const std::string &listname, int index, const ItemStack &stack,
+		const MoveAction &ma, const ItemStack &stack,
 		ServerActiveObject *player);
 	// Report moved items
 	void player_inventory_OnMove(
-		const InventoryLocation &loc,
-		const std::string &from_list, int from_index,
-		const std::string &to_list, int to_index,
-		int count, ServerActiveObject *player);
+		const MoveAction &ma, int count,
+		ServerActiveObject *player);
 	// Report put items
 	void player_inventory_OnPut(
-		const InventoryLocation &loc,
-		const std::string &listname, int index, const ItemStack &stack,
+		const MoveAction &ma, const ItemStack &stack,
 		ServerActiveObject *player);
 	// Report taken items
 	void player_inventory_OnTake(
-		const InventoryLocation &loc,
-		const std::string &listname, int index, const ItemStack &stack,
+		const MoveAction &ma, const ItemStack &stack,
 		ServerActiveObject *player);
 private:
 	void pushPutTakeArguments(
 		const char *method, const InventoryLocation &loc,
 		const std::string &listname, int index, const ItemStack &stack,
 		ServerActiveObject *player);
-	void pushMoveArguments(const InventoryLocation &loc,
-		const std::string &from_list, int from_index,
-		const std::string &to_list, int to_index,
+	void pushMoveArguments(const MoveAction &ma,
 		int count, ServerActiveObject *player);
 };

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -23,6 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v3d.h"
 #include "util/string.h"
 
+struct InventoryLocation;
+struct ItemStack;
 struct ToolCapabilities;
 struct PlayerHPChangeReason;
 
@@ -48,4 +50,47 @@ public:
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
 	void on_auth_failure(const std::string &name, const std::string &ip);
+
+	// Player inventory callbacks
+	// Return number of accepted items to be moved
+	int player_inventory_AllowMove(
+		const InventoryLocation &loc,
+		const std::string &from_list, int from_index,
+		const std::string &to_list, int to_index,
+		int count, ServerActiveObject *player);
+	// Return number of accepted items to be put
+	int player_inventory_AllowPut(
+		const InventoryLocation &loc,
+		const std::string &listname, int index, const ItemStack &stack,
+		ServerActiveObject *player);
+	// Return number of accepted items to be taken
+	int player_inventory_AllowTake(
+		const InventoryLocation &loc,
+		const std::string &listname, int index, const ItemStack &stack,
+		ServerActiveObject *player);
+	// Report moved items
+	void player_inventory_OnMove(
+		const InventoryLocation &loc,
+		const std::string &from_list, int from_index,
+		const std::string &to_list, int to_index,
+		int count, ServerActiveObject *player);
+	// Report put items
+	void player_inventory_OnPut(
+		const InventoryLocation &loc,
+		const std::string &listname, int index, const ItemStack &stack,
+		ServerActiveObject *player);
+	// Report taken items
+	void player_inventory_OnTake(
+		const InventoryLocation &loc,
+		const std::string &listname, int index, const ItemStack &stack,
+		ServerActiveObject *player);
+private:
+	void pushPutTakeArguments(
+		const char *method, const InventoryLocation &loc,
+		const std::string &listname, int index, const ItemStack &stack,
+		ServerActiveObject *player);
+	void pushMoveArguments(const InventoryLocation &loc,
+		const std::string &from_list, int from_index,
+		const std::string &to_list, int to_index,
+		int count, ServerActiveObject *player);
 };

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -258,6 +258,7 @@ src/script/cpp_api/s_node.h
 src/script/cpp_api/s_nodemeta.cpp
 src/script/cpp_api/s_nodemeta.h
 src/script/cpp_api/s_player.cpp
+src/script/cpp_api/s_player.h
 src/script/cpp_api/s_security.cpp
 src/script/cpp_api/s_security.h
 src/script/cpp_api/s_server.cpp


### PR DESCRIPTION
**Player inventory callbacks**
Fixes/Implements #4813
New callbacks:
 * `register_allow_player_inventory_action(player, inventory, action, inventory_info)`
 * `register_on_player_inventory_action(player, inventory, action, inventory_info)`

This PR also contains a code refactor to make a better use of the `IMoveAction` parameters directly.

**To reviewers:**
All but the `IDropAction` callbacks are added in the first commit.

**Test code:**
```Lua
core.register_allow_player_inventory_action(function(player, action, inv, data)
	print(("DO?  action=%s name=%s"):format(action, player:get_player_name()))
	if action == "move" and data.to_list ~= "craft" then
		-- Do not move anything but to craft
		return 0
	end
	if action == "take" and data.stack:get_name() == "default:sand" then
		-- Infinite sand in inventory
		return -1
	end
end)

core.register_on_player_inventory_action(function(player, action, inv, data)
	print(("DONE action=%s name=%s"):format(action, player:get_player_name()))
end)
```