### PR TITLE
Do not crash if the map is read only

### DIFF
--- a/builtin/game/forceloading.lua
+++ b/builtin/game/forceloading.lua
@@ -86,12 +86,6 @@ local function read_file(filename)
 	return core.deserialize(t) or {}
 end
 
-local function write_file(filename, table)
-	local f = io.open(filename, "w")
-	f:write(core.serialize(table))
-	f:close()
-end
-
 blocks_forceloaded = read_file(wpath.."/force_loaded.txt")
 for _, __ in pairs(blocks_forceloaded) do
 	total_forceloaded = total_forceloaded + 1
@@ -106,7 +100,13 @@ end)
 
 -- persists the currently forceloaded blocks to disk
 local function persist_forceloaded_blocks()
-	write_file(wpath.."/force_loaded.txt", blocks_forceloaded)
+	local file_saved = minetest.safe_file_write(wpath .. "/force_loaded.txt",
+		core.serialize(blocks_forceloaded))
+	if not file_saved then
+		minetest.log("error",
+			"Could not open <worldpath>/force_loaded.txt for writing")
+		return
+	end
 end
 
 -- periodical forceload persistence

--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -77,8 +77,8 @@ void BanManager::save()
 		ss << ip.first << "|" << ip.second << "\n";
 
 	if (!fs::safeWriteToFile(m_banfilepath, ss.str())) {
-		infostream << "BanManager: failed saving to " << m_banfilepath << std::endl;
-		throw SerializationError("BanManager::save(): Couldn't write file");
+		errorstream << "BanManager: failed saving to " << m_banfilepath <<
+			std::endl;
 	}
 
 	m_modified = false;

--- a/src/map.h
+++ b/src/map.h
@@ -273,6 +273,9 @@ public:
 	*/
 	std::map<v2s16, MapSector*> *getSectorsPtr(){return &m_sectors;}
 
+	bool isReadonly() const { return m_readonly; }
+	void setReadonly() { m_readonly = true; }
+
 	/*
 		Variables
 	*/
@@ -312,6 +315,7 @@ private:
 	u32 m_unprocessed_count = 0;
 	u64 m_inc_trending_up_start_time = 0; // milliseconds
 	bool m_queue_size_timer_started = false;
+	bool m_readonly = false;
 };
 
 /*

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <set>
 #include "irr_v3d.h"
 #include "mapnode.h"
+#include "map.h"
 #include "exceptions.h"
 #include "constants.h"
 #include "staticobject.h"
@@ -324,6 +325,9 @@ public:
 
 	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode & n)
 	{
+		if (m_parent->isReadonly())
+			return;
+
 		if (!data)
 			throw InvalidPositionException();
 


### PR DESCRIPTION
This add more robustness for read-only files. For example, when Minetest cannot save to a read-only map.sqlite, it shows an error message instead of crashing.
Features:
* Show errors instead of crashing for various read-only files
* If the map is read-only: nodes do not appear, or to be more precise, they appear more or less just temporarily due to node placement prediction. With this players who ignore the error message notice that something is wrong and they do not continue building for hours and suddenly notice that everything was in vain.

This PR addresses #7081

#### Remaining problems

* The auth.sqlite must be writeable
* The folder must me writeable
* Find out what https://github.com/minetest/minetest/pull/7544 has changed