### PR TITLE
Fix many issues reported by clang-tidy

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -37,13 +37,12 @@ ChatBuffer::ChatBuffer(u32 scrollback):
 	m_empty_formatted_line.first = true;
 }
 
-void ChatBuffer::addLine(std::wstring name, std::wstring text)
+void ChatBuffer::addLine(const std::wstring &name, const std::wstring &text)
 {
 	ChatLine line(name, text);
 	m_unformatted.push_back(line);
 
-	if (m_rows > 0)
-	{
+	if (m_rows > 0) {
 		// m_formatted is valid and must be kept valid
 		bool scrolled_at_bottom = (m_scroll == getBottomScrollPos());
 		u32 num_added = formatChatLine(line, m_cols, m_formatted);
@@ -52,8 +51,7 @@ void ChatBuffer::addLine(std::wstring name, std::wstring text)
 	}
 
 	// Limit number of lines by m_scrollback
-	if (m_unformatted.size() > m_scrollback)
-	{
+	if (m_unformatted.size() > m_scrollback) {
 		deleteOldest(m_unformatted.size() - m_scrollback);
 	}
 }

--- a/src/chat.h
+++ b/src/chat.h
@@ -77,7 +77,7 @@ public:
 
 	// Append chat line
 	// Removes oldest chat line if scrollback size is reached
-	void addLine(std::wstring name, std::wstring text);
+	void addLine(const std::wstring &name, const std::wstring &text);
 
 	// Remove all chat lines
 	void clear();

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "util/numeric.h"
+#include <cmath>
 #include "map.h"
 #include "mapgen.h"
 #include "mapgen_v5.h"

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -248,7 +248,7 @@ bool CavernsNoise::generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax)
 				VoxelArea::add_y(em, vi, -1),
 				cavern_amp_index++) {
 			content_t c = vm->m_data[vi].getContent();
-			float n_absamp_cavern = fabs(noise_cavern->result[index3d]) *
+			float n_absamp_cavern = std::fabs(noise_cavern->result[index3d]) *
 				cavern_amp[cavern_amp_index];
 			// Disable CavesRandomWalk at a safe distance from caverns
 			// to avoid excessively spreading liquids in caverns.

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "dungeongen.h"
+#include <cmath>
 #include "mapgen.h"
 #include "voxel.h"
 #include "noise.h"

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -121,7 +121,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	}
 
 	// Add them
-	for (u32 i = 0; i < floor(nval_density); i++)
+	for (u32 i = 0; i < std::floor(nval_density); i++)
 		makeDungeon(v3s16(1, 1, 1) * MAP_BLOCKSIZE);
 
 	// Optionally convert some structure to alternative structure

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -205,7 +205,7 @@ inline float MapgenCarpathian::getLerp(float noise1, float noise2, float mod)
 float MapgenCarpathian::getSteps(float noise)
 {
 	float w = 0.5f;
-	float k = floor(noise / w);
+	float k = std::floor(noise / w);
 	float f = (noise - k * w) / w;
 	float s = std::fmin(2.f * f, 1.f);
 	return (k + s) * w;
@@ -342,8 +342,8 @@ float MapgenCarpathian::terrainLevelAtPoint(s16 x, s16 z)
 			std::fmax(std::fmin(hill1, hill2), std::fmin(hill3, hill4));
 
 		// Rolling hills
-		float hill_mnt = hilliness * pow(n_hills, 2.f);
-		float hills = pow(hter, 3.f) * hill_mnt;
+		float hill_mnt = hilliness * std::pow(n_hills, 2.f);
+		float hills = std::pow(hter, 3.f) * hill_mnt;
 
 		// Ridged mountains
 		float ridge_mnt = hilliness * (1.f - std::fabs(n_ridge_mnt));

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #include "mapgen.h"
+#include <cmath>
 #include "voxel.h"
 #include "noise.h"
 #include "mapblock.h"

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -306,45 +306,45 @@ bool MapgenFractal::getFractalAtPoint(s16 x, s16 y, s16 z)
 			break;
 		case 6: // 3D "Christmas Tree"
 			// Altering the formula here is necessary to avoid division by zero
-			if (fabs(oz) < 0.000000001f) {
+			if (std::fabs(oz) < 0.000000001f) {
 				nx = ox * ox - oy * oy - oz * oz + cx;
 				ny = 2.0f * oy * ox + cy;
 				nz = 4.0f * oz * ox + cz;
 			} else {
-				float a = (2.0f * ox) / (sqrt(oy * oy + oz * oz));
+				float a = (2.0f * ox) / (std::sqrt(oy * oy + oz * oz));
 				nx = ox * ox - oy * oy - oz * oz + cx;
 				ny = a * (oy * oy - oz * oz) + cy;
 				nz = a * 2.0f * oy * oz + cz;
 			}
 			break;
 		case 7: // 3D "Mandelbulb"
-			if (fabs(oy) < 0.000000001f) {
+			if (std::fabs(oy) < 0.000000001f) {
 				nx = ox * ox - oz * oz + cx;
 				ny = cy;
-				nz = -2.0f * oz * sqrt(ox * ox) + cz;
+				nz = -2.0f * oz * std::sqrt(ox * ox) + cz;
 			} else {
 				float a = 1.0f - (oz * oz) / (ox * ox + oy * oy);
 				nx = (ox * ox - oy * oy) * a + cx;
 				ny = 2.0f * ox * oy * a + cy;
-				nz = -2.0f * oz * sqrt(ox * ox + oy * oy) + cz;
+				nz = -2.0f * oz * std::sqrt(ox * ox + oy * oy) + cz;
 			}
 			break;
 		case 8: // 3D "Cosine Mandelbulb"
-			if (fabs(oy) < 0.000000001f) {
+			if (std::fabs(oy) < 0.000000001f) {
 				nx = 2.0f * ox * oz + cx;
 				ny = 4.0f * oy * oz + cy;
 				nz = oz * oz - ox * ox - oy * oy + cz;
 			} else {
-				float a = (2.0f * oz) / sqrt(ox * ox + oy * oy);
+				float a = (2.0f * oz) / std::sqrt(ox * ox + oy * oy);
 				nx = (ox * ox - oy * oy) * a + cx;
 				ny = 2.0f * ox * oy * a + cy;
 				nz = oz * oz - ox * ox - oy * oy + cz;
 			}
 			break;
 		case 9: // 4D "Mandelbulb"
-			float rxy = sqrt(ox * ox + oy * oy);
-			float rxyz = sqrt(ox * ox + oy * oy + oz * oz);
-			if (fabs(ow) < 0.000000001f && fabs(oz) < 0.000000001f) {
+			float rxy = std::sqrt(ox * ox + oy * oy);
+			float rxyz = std::sqrt(ox * ox + oy * oy + oz * oz);
+			if (std::fabs(ow) < 0.000000001f && std::fabs(oz) < 0.000000001f) {
 				nx = (ox * ox - oy * oy) + cx;
 				ny = 2.0f * ox * oy + cy;
 				nz = -2.0f * rxy * oz + cz;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #include "mapgen.h"
+#include <cmath>
 #include "voxel.h"
 #include "noise.h"
 #include "mapblock.h"

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -228,7 +228,7 @@ int MapgenV7::getSpawnLevelAtPoint(v2s16 p)
 	if (spflags & MGV7_RIDGES) {
 		float width = 0.2;
 		float uwatern = NoisePerlin2D(&noise_ridge_uwater->np, p.X, p.Y, seed) * 2;
-		if (fabs(uwatern) <= width)
+		if (std::fabs(uwatern) <= width)
 			return MAX_MAP_GENERATION_LIMIT;  // Unsuitable spawn point
 	}
 
@@ -426,9 +426,9 @@ bool MapgenV7::getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y)
 {
 	// Make rim 2 nodes thick to match floatland base terrain
 	float density_gradient = (y >= floatland_level) ?
-		-pow((float)(y - floatland_level) / float_mount_height,
+		-std::pow((float)(y - floatland_level) / float_mount_height,
 		float_mount_exponent) :
-		-pow((float)(floatland_level - 1 - y) / float_mount_height,
+		-std::pow((float)(floatland_level - 1 - y) / float_mount_height,
 		float_mount_exponent);
 
 	float floatn = noise_mountain->result[idx_xyz] + float_mount_density;
@@ -456,7 +456,7 @@ void MapgenV7::floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max, 
 			base_max = floatland_level - (amp - ridge * 2.0f) / 2.0f;
 		} else {
 			// Hills and ridges
-			float diff = fabs(amp - ridge) / ridge;
+			float diff = std::fabs(amp - ridge) / ridge;
 			// Smooth ridges using the 'smoothstep function'
 			float smooth_diff = diff * diff * (3.0f - 2.0f * diff);
 			base_max = floatland_level + ridge - smooth_diff * ridge;
@@ -569,7 +569,7 @@ void MapgenV7::generateRidgeTerrain()
 			int j = (z - node_min.Z) * csize.X + (x - node_min.X);
 
 			float uwatern = noise_ridge_uwater->result[j] * 2;
-			if (fabs(uwatern) > width)
+			if (std::fabs(uwatern) > width)
 				continue;
 
 			float altitude = y - water_level;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -366,7 +366,7 @@ float MapgenValleys::terrainLevelFromNoise(TerrainNoise *tn)
 	float base = tn->terrain_height + valley_d;
 
 	// "river" represents the distance from the river, in arbitrary units.
-	float river = fabs(*tn->rivers) - river_size_factor;
+	float river = std::fabs(*tn->rivers) - river_size_factor;
 
 	// Use the curve of the function 1-exp(-(x/a)^2) to model valleys.
 	//  Making "a" vary (0 < a <= 1) changes the shape of the valleys.
@@ -375,7 +375,7 @@ float MapgenValleys::terrainLevelFromNoise(TerrainNoise *tn)
 	//  "valley" represents the height of the terrain, from the rivers.
 	{
 		float t = std::fmax(river / tn->valley_profile, 0.0f);
-		*tn->valley = valley_d * (1.f - exp(- MYSQUARE(t)));
+		*tn->valley = valley_d * (1.f - std::exp(- MYSQUARE(t)));
 	}
 
 	// approximate height of the terrain at this point
@@ -392,7 +392,7 @@ float MapgenValleys::terrainLevelFromNoise(TerrainNoise *tn)
 		float depth;
 		{
 			float t = river / river_size_factor + 1;
-			depth = (river_depth_bed * sqrt(MYMAX(0, 1.f - MYSQUARE(t))));
+			depth = (river_depth_bed * std::sqrt(MYMAX(0, 1.f - MYSQUARE(t))));
 		}
 
 		// base - depth : height of the bottom of the river
@@ -496,7 +496,7 @@ int MapgenValleys::generateTerrain()
 		heightmap[index_2d] = -MAX_MAP_GENERATION_LIMIT;
 
 		if (surface_y > surface_max_y)
-			surface_max_y = ceil(surface_y);
+			surface_max_y = std::ceil(surface_y);
 
 		if (humid_rivers) {
 			// Derive heat from (base) altitude. This will be most correct
@@ -562,7 +562,7 @@ int MapgenValleys::generateTerrain()
 			float t_alt = MYMAX(noise_rivers->result[index_2d], (float)heightmap[index_2d]);
 			float humid = m_bgen->humidmap[index_2d];
 			float water_depth = (t_alt - river_y) / humidity_dropoff;
-			humid *= 1.f + pow(0.5f, MYMAX(water_depth, 1.f));
+			humid *= 1.f + std::pow(0.5f, MYMAX(water_depth, 1.f));
 
 			// Reduce humidity with altitude (ignoring riverbeds).
 			// This is similar to the lua version's seawater adjustment,
@@ -637,11 +637,12 @@ void MapgenValleys::generateCaves(s16 max_stone_y, s16 large_cave_depth)
 
 	// lava_depth varies between one and ten as you approach
 	//  the bottom of the world.
-	s16 lava_depth = ceil((lava_max_height - node_min.Y + 1) * 10.f / mapgen_limit);
+	s16 lava_depth = std::ceil((lava_max_height - node_min.Y + 1) * 10.f / mapgen_limit);
 	// This allows random lava spawns to be less common at the surface.
 	s16 lava_chance = MYCUBE(lava_features_lim) * lava_depth;
 	// water_depth varies between ten and one on the way down.
-	s16 water_depth = ceil((mapgen_limit - abs(node_min.Y) + 1) * 10.f / mapgen_limit);
+	s16 water_depth = std::ceil((mapgen_limit - std::abs(node_min.Y) + 1) * 10.f /
+		mapgen_limit);
 	// This allows random water spawns to be more common at the surface.
 	s16 water_chance = MYCUBE(water_features_lim) * water_depth;
 

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -345,8 +345,7 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			float ydist = (s32)y1 - (s32)csize / 2;
 			float zdist = (s32)z1 - (s32)csize / 2;
 
-			noiseval -= (std::sqrt(xdist * xdist + ydist * ydist + zdist * zdist) /
-				csize);
+			noiseval -= std::sqrt(xdist * xdist + ydist * ydist + zdist * zdist) / csize;
 
 			if (noiseval < nthresh)
 				continue;

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -345,7 +345,8 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 			float ydist = (s32)y1 - (s32)csize / 2;
 			float zdist = (s32)z1 - (s32)csize / 2;
 
-			noiseval -= (sqrt(xdist * xdist + ydist * ydist + zdist * zdist) / csize);
+			noiseval -= (std::sqrt(xdist * xdist + ydist * ydist + zdist * zdist) /
+				csize);
 
 			if (noiseval < nthresh)
 				continue;
@@ -469,7 +470,7 @@ void OreStratum::generate(MMVManip *vm, int mapseed, u32 blockseed,
 				noise_stratum_thickness->result[index] : (float)stratum_thickness) /
 				2.0f;
 			float nmid = noise->result[index];
-			y0 = MYMAX(nmin.Y, ceil(nmid - nhalfthick));
+			y0 = MYMAX(nmin.Y, std::ceil(nmid - nhalfthick));
 			y1 = MYMIN(nmax.Y, nmid + nhalfthick);
 		} else { // Simple horizontal stratum
 			y0 = nmin.Y;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1060,7 +1060,8 @@ int ObjectRef::l_get_look_dir(lua_State *L)
 	// Do it
 	float pitch = co->getRadPitchDep();
 	float yaw = co->getRadYawDep();
-	v3f v(cos(pitch)*cos(yaw), sin(pitch), cos(pitch)*sin(yaw));
+	v3f v(std::cos(pitch) * std::cos(yaw), std::sin(pitch), std::cos(pitch) *
+		std::sin(yaw));
 	push_v3f(L, v);
 	return 1;
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "lua_api/l_object.h"
+#include <cmath>
 #include "lua_api/l_internal.h"
 #include "lua_api/l_inventory.h"
 #include "lua_api/l_item.h"

--- a/src/unittest/test_noise.cpp
+++ b/src/unittest/test_noise.cpp
@@ -61,7 +61,7 @@ void TestNoise::testNoise2dPoint()
 	for (u32 x = 0; x != 10; x++, i++) {
 		float actual   = NoisePerlin2D(&np_normal, x, y, 1337);
 		float expected = expected_2d_results[i];
-		UASSERT(fabs(actual - expected) <= 0.00001);
+		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
 }
 
@@ -74,7 +74,7 @@ void TestNoise::testNoise2dBulk()
 	for (u32 i = 0; i != 10 * 10; i++) {
 		float actual   = noisevals[i];
 		float expected = expected_2d_results[i];
-		UASSERT(fabs(actual - expected) <= 0.00001);
+		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
 }
 
@@ -88,7 +88,7 @@ void TestNoise::testNoise3dPoint()
 	for (u32 x = 0; x != 10; x++, i++) {
 		float actual   = NoisePerlin3D(&np_normal, x, y, z, 1337);
 		float expected = expected_3d_results[i];
-		UASSERT(fabs(actual - expected) <= 0.00001);
+		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
 }
 
@@ -101,7 +101,7 @@ void TestNoise::testNoise3dBulk()
 	for (u32 i = 0; i != 10 * 10 * 10; i++) {
 		float actual   = noisevals[i];
 		float expected = expected_3d_results[i];
-		UASSERT(fabs(actual - expected) <= 0.00001);
+		UASSERT(std::fabs(actual - expected) <= 0.00001);
 	}
 }
 

--- a/src/unittest/test_noise.cpp
+++ b/src/unittest/test_noise.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 
+#include <cmath>
 #include "exceptions.h"
 #include "noise.h"
 

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -157,7 +157,7 @@ void TestRandom::testPcgRandomNormalDist()
 	int range      = (max - min + 1);
 	float mean     = (max + min) / 2;
 	float variance = ((range * range - 1) / 12) / num_trials;
-	float stddev   = sqrt(variance);
+	float stddev   = std::sqrt(variance);
 
 	static const float prediction_intervals[] = {
 		0.68269f, // 1.0
@@ -180,7 +180,7 @@ void TestRandom::testPcgRandomNormalDist()
 			accum += bins[j - min];
 
 		float actual = (float)accum / num_samples;
-		UASSERT(fabs(actual - prediction_intervals[i]) < 0.02);
+		UASSERT(std::fabs(actual - prediction_intervals[i]) < 0.02f);
 	}
 }
 

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 
+#include <cmath>
 #include "util/numeric.h"
 #include "exceptions.h"
 #include "noise.h"

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -174,14 +174,14 @@ void TestSettings::testAllSettings()
 
 	NoiseParams np;
 	UASSERT(s.getNoiseParams("np_terrain", np) == true);
-	UASSERT(fabs(np.offset - 5) < 0.001);
-	UASSERT(fabs(np.scale - 40) < 0.001);
-	UASSERT(fabs(np.spread.X - 250) < 0.001);
-	UASSERT(fabs(np.spread.Y - 250) < 0.001);
-	UASSERT(fabs(np.spread.Z - 250) < 0.001);
+	UASSERT(std::fabs(np.offset - 5) < 0.001f);
+	UASSERT(std::fabs(np.scale - 40) < 0.001f);
+	UASSERT(std::fabs(np.spread.X - 250) < 0.001f);
+	UASSERT(std::fabs(np.spread.Y - 250) < 0.001f);
+	UASSERT(std::fabs(np.spread.Z - 250) < 0.001f);
 	UASSERT(np.seed == 12341);
 	UASSERT(np.octaves == 5);
-	UASSERT(fabs(np.persist - 0.7) < 0.001);
+	UASSERT(std::fabs(np.persist - 0.7) < 0.001f);
 
 	np.offset  = 3.5;
 	np.octaves = 6;

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 
+#include <cmath>
 #include "settings.h"
 #include "noise.h"
 

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "test.h"
 
+#include <cmath>
 #include "util/numeric.h"
 #include "util/string.h"
 

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -111,13 +111,13 @@ void TestUtilities::testAngleWrapAround()
 	UASSERT(fabs(modulo360f(-365.5) - (-5.5)) < 0.001);
 
 	for (float f = -720; f <= -360; f += 0.25) {
-		UASSERT(fabs(modulo360f(f) - modulo360f(f + 360)) < 0.001);
+		UASSERT(std::fabs(modulo360f(f) - modulo360f(f + 360)) < 0.001);
 	}
 
 	for (float f = -1440; f <= 1440; f += 0.25) {
-		UASSERT(fabs(modulo360f(f) - fmodf(f, 360)) < 0.001);
-		UASSERT(fabs(wrapDegrees_180(f) - ref_WrapDegrees180(f)) < 0.001);
-		UASSERT(fabs(wrapDegrees_0_360(f) - ref_WrapDegrees_0_360(f)) < 0.001);
+		UASSERT(std::fabs(modulo360f(f) - fmodf(f, 360)) < 0.001);
+		UASSERT(std::fabs(wrapDegrees_180(f) - ref_WrapDegrees180(f)) < 0.001);
+		UASSERT(std::fabs(wrapDegrees_0_360(f) - ref_WrapDegrees_0_360(f)) < 0.001);
 		UASSERT(wrapDegrees_0_360(fabs(wrapDegrees_180(f) - wrapDegrees_0_360(f))) < 0.001);
 	}
 }


### PR DESCRIPTION
We have many issues in code related to some performance to float <-> double.
Clang-tidy reported it in performance-type-promotion-in-math-fn

I fixed many of them. It's not ready for a promote to blocking

Also fix some value which should be const-ref