### PR TITLE
[clang-tidy] Promote some performance-* as a coding error

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -908,8 +908,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			updateTextures(m_previous_texture_modifier);
 		}
 	}
-	if(!getParent() && fabs(m_prop.automatic_rotate) > 0.001)
-	{
+	if (!getParent() && std::fabs(m_prop.automatic_rotate) > 0.001) {
 		m_yaw += dtime * m_prop.automatic_rotate * 180 / M_PI;
 		updateNodePos();
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3638,12 +3638,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	float time_of_day_smooth = runData.time_of_day_smooth;
 	float time_of_day = client->getEnv().getTimeOfDayF();
 
-	static const float maxsm = 0.05;
-	static const float todsm = 0.05;
+	static const float maxsm = 0.05f;
+	static const float todsm = 0.05f;
 
-	if (fabs(time_of_day - time_of_day_smooth) > maxsm &&
-			fabs(time_of_day - time_of_day_smooth + 1.0) > maxsm &&
-			fabs(time_of_day - time_of_day_smooth - 1.0) > maxsm)
+	if (std::fabs(time_of_day - time_of_day_smooth) > maxsm &&
+			std::fabs(time_of_day - time_of_day_smooth + 1.0) > maxsm &&
+			std::fabs(time_of_day - time_of_day_smooth - 1.0) > maxsm)
 		time_of_day_smooth = time_of_day;
 
 	if (time_of_day_smooth > 0.8 && time_of_day < 0.2)
@@ -3715,7 +3715,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 				video::EFT_FOG_LINEAR,
 				100000 * BS,
 				110000 * BS,
-				0.01,
+				0.01f,
 				false, // pixel fog
 				false // range fog
 		);

--- a/util/travis/clangtidy.sh
+++ b/util/travis/clangtidy.sh
@@ -19,7 +19,7 @@ cd ..
 echo "Performing clang-tidy checks..."
 ./util/travis/run-clang-tidy.py -clang-tidy-binary=${CLANG_TIDY} -p cmakebuild \
 	-checks='-*,modernize-use-emplace,modernize-avoid-bind,performance-*' \
-	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn' \
+	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find' \
 	-no-command-on-stdout -quiet \
 	files 'src/.*'
 RET=$?

--- a/util/travis/clangtidy.sh
+++ b/util/travis/clangtidy.sh
@@ -19,7 +19,7 @@ cd ..
 echo "Performing clang-tidy checks..."
 ./util/travis/run-clang-tidy.py -clang-tidy-binary=${CLANG_TIDY} -p cmakebuild \
 	-checks='-*,modernize-use-emplace,modernize-avoid-bind,performance-*' \
-	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find' \
+	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find,performance-implicit-cast-in-loop' \
 	-no-command-on-stdout -quiet \
 	files 'src/.*'
 RET=$?

--- a/util/travis/clangtidy.sh
+++ b/util/travis/clangtidy.sh
@@ -19,7 +19,7 @@ cd ..
 echo "Performing clang-tidy checks..."
 ./util/travis/run-clang-tidy.py -clang-tidy-binary=${CLANG_TIDY} -p cmakebuild \
 	-checks='-*,modernize-use-emplace,modernize-avoid-bind,performance-*' \
-	-warningsaserrors='-*,modernize-use-emplace' \
+	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn' \
 	-no-command-on-stdout -quiet \
 	files 'src/.*'
 RET=$?


### PR DESCRIPTION
Promote the following checks as errors:
* performance-implicit-cast-in-loop
* performance-type-promotion-in-math-fn
* performance-faster-string-find

