### PR TITLE
Huge LBM lookup performance improvement on mapblock loading

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -254,23 +254,39 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 	MapNode n;
 	content_t c;
 	lbm_lookup_map::const_iterator it = getLBMsIntroducedAfter(stamp);
-	for (pos.X = 0; pos.X < MAP_BLOCKSIZE; pos.X++)
-		for (pos.Y = 0; pos.Y < MAP_BLOCKSIZE; pos.Y++)
-			for (pos.Z = 0; pos.Z < MAP_BLOCKSIZE; pos.Z++)
-			{
-				n = block->getNodeNoEx(pos);
-				c = n.getContent();
-				for (LBMManager::lbm_lookup_map::const_iterator iit = it;
-					iit != m_lbm_lookup.end(); ++iit) {
-					const std::vector<LoadingBlockModifierDef *> *lbm_list =
-						iit->second.lookup(c);
+
+	for (LBMManager::lbm_lookup_map::const_iterator iit = it;
+		iit != m_lbm_lookup.end(); ++iit) {
+		// Cache previous version to speedup lookup which has a very high performance
+		// penalty on each call
+		std::vector<LoadingBlockModifierDef *> *previous_lbm_list = nullptr;
+		content_t previous_c{};
+		std::vector<LoadingBlockModifierDef *> *lbm_list = nullptr;
+
+		for (pos.X = 0; pos.X < MAP_BLOCKSIZE; pos.X++)
+			for (pos.Y = 0; pos.Y < MAP_BLOCKSIZE; pos.Y++)
+				for (pos.Z = 0; pos.Z < MAP_BLOCKSIZE; pos.Z++) {
+					n = block->getNodeNoEx(pos);
+					c = n.getContent();
+
+					// If content_t are not matching perform an ABM lookup
+					if (previous_c != c) {
+						lbm_list = (std::vector<LoadingBlockModifierDef *> *)
+							iit->second.lookup(c);
+						previous_c = c;
+						previous_lbm_list = lbm_list;
+					// else reused cached lookup
+					} else {
+						lbm_list = previous_lbm_list;
+					}
+
 					if (!lbm_list)
 						continue;
 					for (auto lbmdef : *lbm_list) {
 						lbmdef->trigger(env, pos + pos_of_block, n);
 					}
 				}
-			}
+	}
 }
 
 /*

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -257,7 +257,6 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 	for (; it != m_lbm_lookup.end(); ++it) {
 		// Cache previous version to speedup lookup which has a very high performance
 		// penalty on each call
-		std::vector<LoadingBlockModifierDef *> *previous_lbm_list = nullptr;
 		content_t previous_c{};
 		std::vector<LoadingBlockModifierDef *> *lbm_list = nullptr;
 
@@ -272,7 +271,6 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 						lbm_list = (std::vector<LoadingBlockModifierDef *> *)
 							it->second.lookup(c);
 						previous_c = c;
-						previous_lbm_list = lbm_list;
 					}
 
 					if (!lbm_list)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -273,9 +273,6 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 							it->second.lookup(c);
 						previous_c = c;
 						previous_lbm_list = lbm_list;
-					// else reused cached lookup
-					} else {
-						lbm_list = previous_lbm_list;
 					}
 
 					if (!lbm_list)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -269,7 +269,7 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 					n = block->getNodeNoEx(pos);
 					c = n.getContent();
 
-					// If content_t are not matching perform an ABM lookup
+					// If content_t are not matching perform an LBM lookup
 					if (previous_c != c) {
 						lbm_list = (std::vector<LoadingBlockModifierDef *> *)
 							iit->second.lookup(c);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -254,9 +254,7 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 	MapNode n;
 	content_t c;
 	lbm_lookup_map::const_iterator it = getLBMsIntroducedAfter(stamp);
-
-	for (LBMManager::lbm_lookup_map::const_iterator iit = it;
-		iit != m_lbm_lookup.end(); ++iit) {
+	for (; it != m_lbm_lookup.end(); ++it) {
 		// Cache previous version to speedup lookup which has a very high performance
 		// penalty on each call
 		std::vector<LoadingBlockModifierDef *> *previous_lbm_list = nullptr;
@@ -272,7 +270,7 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 					// If content_t are not matching perform an LBM lookup
 					if (previous_c != c) {
 						lbm_list = (std::vector<LoadingBlockModifierDef *> *)
-							iit->second.lookup(c);
+							it->second.lookup(c);
 						previous_c = c;
 						previous_lbm_list = lbm_list;
 					// else reused cached lookup


### PR DESCRIPTION
The LBM map lookup has a very high cost. Change loop order and cache the LBM for same node content_t to reduce the lookup overhead

Before:
![capture d ecran de 2018-04-04 00-42-16](https://user-images.githubusercontent.com/119752/38279636-795f7b48-37a1-11e8-8f4c-2298861c5a19.png)

After:
![capture d ecran de 2018-04-04 00-42-03](https://user-images.githubusercontent.com/119752/38279628-74d25226-37a1-11e8-8c7f-a94bf23350e4.png)
