### PR TITLE
Add player:get_meta(), deprecate player attributes

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -347,6 +347,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_nodetimer.cpp    \
 		jni/src/script/lua_api/l_noise.cpp        \
 		jni/src/script/lua_api/l_object.cpp       \
+		jni/src/script/lua_api/l_playermeta.cpp   \
 		jni/src/script/lua_api/l_particles.cpp    \
 		jni/src/script/lua_api/l_particles_local.cpp\
 		jni/src/script/lua_api/l_rollback.cpp     \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3902,7 +3902,7 @@ An interface to use mod channels on client and server
     * Message size is limited to 65535 characters by protocol.
 
 ### `MetaDataRef`
-See `StorageRef`, `NodeMetaRef` and `ItemStackMetaRef`.
+See `StorageRef`, `NodeMetaRef`, `ItemStackMetaRef`, and `PlayerMetaRef`.
 
 #### Methods
 * `set_string(name, value)`
@@ -3951,6 +3951,17 @@ Can be obtained via `minetest.get_mod_storage()` during load time.
 
 #### Methods
 * All methods in MetaDataRef
+
+### `PlayerMetaRef`
+Player metadata. Deprecated attributes are automagically imported into player meta.
+Can be obtained using `player:get_meta()`.
+
+#### Methods
+* All methods in MetaDataRef
+* `set_tool_capabilities([tool_capabilities])`
+    * Overrides the item's tool capabilities
+    * A nil value will clear the override data and restore the original
+      behavior.
 
 ### `NodeTimerRef`
 Node Timers: a high resolution persistent per-node timer.
@@ -4101,14 +4112,15 @@ This is basically a reference to a C++ `ServerActiveObject`
         * `0`: player is drowning
         * max: bubbles bar is not shown
         * See Object Properties for more information
-* `set_attribute(attribute, value)`:
+* `set_attribute(attribute, value)`:  DEPRECATED, use get_meta() instead
     * Sets an extra attribute with value on player.
     * `value` must be a string, or a number which will be converted to a
       string.
     * If `value` is `nil`, remove attribute from player.
-* `get_attribute(attribute)`:
+* `get_attribute(attribute)`:  DEPRECATED, use get_meta() instead
     * Returns value (a string) for extra attribute.
     * Returns `nil` if no attribute found.
+* `get_meta()`: Returns a PlayerMetaRef.
 * `set_inventory_formspec(formspec)`
     * Redefine player's inventory form
     * Should usually be called in `on_joinplayer`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3953,7 +3953,9 @@ Can be obtained via `minetest.get_mod_storage()` during load time.
 * All methods in MetaDataRef
 
 ### `PlayerMetaRef`
-Player metadata. Deprecated attributes are automagically imported into player meta.
+Player metadata.
+Uses the same method of storage as the deprecated player attribute API, so
+data there will also be in player meta.
 Can be obtained using `player:get_meta()`.
 
 #### Methods

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3958,10 +3958,6 @@ Can be obtained using `player:get_meta()`.
 
 #### Methods
 * All methods in MetaDataRef
-* `set_tool_capabilities([tool_capabilities])`
-    * Overrides the item's tool capabilities
-    * A nil value will clear the override data and restore the original
-      behavior.
 
 ### `NodeTimerRef`
 Node Timers: a high resolution persistent per-node timer.

--- a/games/minimal/mods/test/init.lua
+++ b/games/minimal/mods/test/init.lua
@@ -13,7 +13,7 @@ assert(pseudo:next() == 13854)
 -- HP Change Reasons
 --
 local expect = nil
-minetest.register_on_joinplayer(function(player)
+local function run_hpchangereason_tests(player)
 	expect = { type = "set_hp", from = "mod" }
 	player:set_hp(3)
 	assert(expect == nil)
@@ -25,8 +25,7 @@ minetest.register_on_joinplayer(function(player)
 	expect = { df = 3458973454, type = "fall", from = "mod" }
 	player:set_hp(10, { type = "fall", df = 3458973454 })
 	assert(expect == nil)
-end)
-
+end
 minetest.register_on_player_hpchange(function(player, hp, reason)
 	for key, value in pairs(reason) do
 		assert(expect[key] == value)
@@ -38,3 +37,32 @@ minetest.register_on_player_hpchange(function(player, hp, reason)
 
 	expect = nil
 end)
+
+
+
+local function run_player_meta_tests(player)
+	local meta = player:get_meta()
+	meta:set_string("foo", "bar")
+	assert(meta:get_string("foo") == "bar")
+
+	local meta2 = player:get_meta()
+	assert(meta2:get_string("foo") == "bar")
+	assert(meta:equals(meta2))
+	assert(player:get_attribute("foo") == "bar")
+
+	meta:set_string("bob", "dillan")
+	assert(meta:get_string("foo") == "bar")
+	assert(meta:get_string("bob") == "dillan")
+	assert(meta2:get_string("foo") == "bar")
+	assert(meta2:get_string("bob") == "dillan")
+	assert(meta:equals(meta2))
+	assert(player:get_attribute("foo") == "bar")
+	assert(player:get_attribute("bob") == "dillan")
+end
+
+local function run_player_tests(player)
+	run_hpchangereason_tests(player)
+	run_player_meta_tests(player)
+	minetest.chat_send_all("All tests pass!")
+end
+minetest.register_on_joinplayer(run_player_tests)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -197,7 +197,6 @@ public:
 	}
 };
 
-typedef std::unordered_map<std::string, std::string> PlayerAttributes;
 class RemotePlayer;
 
 class PlayerSAO : public UnitSAO
@@ -268,49 +267,6 @@ public:
 	bool setWieldedItem(const ItemStack &item);
 	int getWieldIndex() const;
 	void setWieldIndex(int i);
-
-	/*
-		Modding interface
-	*/
-	inline void setExtendedAttribute(const std::string &attr, const std::string &value)
-	{
-		m_extra_attributes[attr] = value;
-		m_extended_attributes_modified = true;
-	}
-
-	inline bool getExtendedAttribute(const std::string &attr, std::string *value)
-	{
-		if (m_extra_attributes.find(attr) == m_extra_attributes.end())
-			return false;
-
-		*value = m_extra_attributes[attr];
-		return true;
-	}
-
-	inline void removeExtendedAttribute(const std::string &attr)
-	{
-		PlayerAttributes::iterator it = m_extra_attributes.find(attr);
-		if (it == m_extra_attributes.end())
-			return;
-
-		m_extra_attributes.erase(it);
-		m_extended_attributes_modified = true;
-	}
-
-	inline const PlayerAttributes &getExtendedAttributes()
-	{
-		return m_extra_attributes;
-	}
-
-	inline bool extendedAttributesModified() const
-	{
-		return m_extended_attributes_modified;
-	}
-
-	inline void setExtendedAttributeModified(bool v)
-	{
-		m_extended_attributes_modified = v;
-	}
 
 	/*
 		PlayerSAO-specific
@@ -409,9 +365,6 @@ private:
 	f32 m_pitch = 0.0f;
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
-
-	PlayerAttributes m_extra_attributes;
-	bool m_extended_attributes_modified = false;
 public:
 	float m_physics_override_speed = 1.0f;
 	float m_physics_override_jump = 1.0f;
@@ -420,6 +373,8 @@ public:
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
 	bool m_physics_override_sent = false;
+
+	Metadata m_meta;
 };
 
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -331,6 +331,8 @@ public:
 	v3f getEyePosition() const { return m_base_position + getEyeOffset(); }
 	v3f getEyeOffset() const;
 
+	inline Metadata &getMeta() { return m_meta; }
+
 private:
 	std::string getPropertyPacket();
 	void unlinkPlayerSessionAndSave();
@@ -365,6 +367,8 @@ private:
 	f32 m_pitch = 0.0f;
 	f32 m_fov = 0.0f;
 	s16 m_wanted_range = 0.0f;
+
+	Metadata m_meta;
 public:
 	float m_physics_override_speed = 1.0f;
 	float m_physics_override_jump = 1.0f;
@@ -373,8 +377,6 @@ public:
 	bool m_physics_override_sneak_glitch = false;
 	bool m_physics_override_new_move = true;
 	bool m_physics_override_sent = false;
-
-	Metadata m_meta;
 };
 
 

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -527,7 +527,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 		};
 		execPrepared("save_player_metadata", 3, meta_values);
 	}
-    sao->getMeta().setModified(false);
+	sao->getMeta().setModified(false);
 	endSave();
 }
 

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -596,6 +596,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	for (int row = 0; row < numrows; row++) {
 		sao->getMeta().setString(PQgetvalue(results, row, 0), PQgetvalue(results, row, 1));
 	}
+    sao->getMeta().setModified(false);
 
 	PQclear(results);
 

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -518,7 +518,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	}
 
 	execPrepared("remove_player_metadata", 1, rmvalues);
-	const PlayerAttributes &attrs = sao->getExtendedAttributes();
+	const StringMap &attrs = sao->m_meta.getStrings();
 	for (const auto &attr : attrs) {
 		const char *meta_values[] = {
 			player->getName(),
@@ -594,7 +594,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 
 	int numrows = PQntuples(results);
 	for (int row = 0; row < numrows; row++) {
-		sao->setExtendedAttribute(PQgetvalue(results, row, 0),PQgetvalue(results, row, 1));
+		sao->m_meta.setString(PQgetvalue(results, row, 0), PQgetvalue(results, row, 1));
 	}
 
 	PQclear(results);

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -527,6 +527,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 		};
 		execPrepared("save_player_metadata", 3, meta_values);
 	}
+    sao->getMeta().setModified(false);
 	endSave();
 }
 

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -597,7 +597,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	for (int row = 0; row < numrows; row++) {
 		sao->getMeta().setString(PQgetvalue(results, row, 0), PQgetvalue(results, row, 1));
 	}
-    sao->getMeta().setModified(false);
+	sao->getMeta().setModified(false);
 
 	PQclear(results);
 

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -518,7 +518,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	}
 
 	execPrepared("remove_player_metadata", 1, rmvalues);
-	const StringMap &attrs = sao->m_meta.getStrings();
+	const StringMap &attrs = sao->getMeta().getStrings();
 	for (const auto &attr : attrs) {
 		const char *meta_values[] = {
 			player->getName(),
@@ -594,7 +594,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 
 	int numrows = PQntuples(results);
 	for (int row = 0; row < numrows; row++) {
-		sao->m_meta.setString(PQgetvalue(results, row, 0), PQgetvalue(results, row, 1));
+		sao->getMeta().setString(PQgetvalue(results, row, 0), PQgetvalue(results, row, 1));
 	}
 
 	PQclear(results);

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -520,7 +520,7 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_vrfy(sqlite3_step(m_stmt_player_metadata_remove), SQLITE_DONE);
 	sqlite3_reset(m_stmt_player_metadata_remove);
 
-	const StringMap &attrs = sao->m_meta.getStrings();
+	const StringMap &attrs = sao->getMeta().getStrings();
 	for (const auto &attr : attrs) {
 		str_to_sqlite(m_stmt_player_metadata_add, 1, player->getName());
 		str_to_sqlite(m_stmt_player_metadata_add, 2, attr.first);
@@ -578,7 +578,7 @@ bool PlayerDatabaseSQLite3::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 		std::string attr = sqlite_to_string(m_stmt_player_metadata_load, 0);
 		std::string value = sqlite_to_string(m_stmt_player_metadata_load, 1);
 
-		sao->m_meta.setString(attr, value);
+		sao->getMeta().setString(attr, value);
 	}
 	sqlite3_reset(m_stmt_player_metadata_load);
 	return true;

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -528,7 +528,7 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 		sqlite3_vrfy(sqlite3_step(m_stmt_player_metadata_add), SQLITE_DONE);
 		sqlite3_reset(m_stmt_player_metadata_add);
 	}
-    sao->getMeta().setModified(false);
+	sao->getMeta().setModified(false);
 
 	endSave();
 }

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -520,7 +520,7 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_vrfy(sqlite3_step(m_stmt_player_metadata_remove), SQLITE_DONE);
 	sqlite3_reset(m_stmt_player_metadata_remove);
 
-	const PlayerAttributes &attrs = sao->getExtendedAttributes();
+	const StringMap &attrs = sao->m_meta.getStrings();
 	for (const auto &attr : attrs) {
 		str_to_sqlite(m_stmt_player_metadata_add, 1, player->getName());
 		str_to_sqlite(m_stmt_player_metadata_add, 2, attr.first);
@@ -578,7 +578,7 @@ bool PlayerDatabaseSQLite3::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 		std::string attr = sqlite_to_string(m_stmt_player_metadata_load, 0);
 		std::string value = sqlite_to_string(m_stmt_player_metadata_load, 1);
 
-		sao->setExtendedAttribute(attr, value);
+		sao->m_meta.setString(attr, value);
 	}
 	sqlite3_reset(m_stmt_player_metadata_load);
 	return true;

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -580,6 +580,7 @@ bool PlayerDatabaseSQLite3::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 
 		sao->getMeta().setString(attr, value);
 	}
+	sao->getMeta().setModified(false);
 	sqlite3_reset(m_stmt_player_metadata_load);
 	return true;
 }

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -528,6 +528,7 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 		sqlite3_vrfy(sqlite3_step(m_stmt_player_metadata_add), SQLITE_DONE);
 		sqlite3_reset(m_stmt_player_metadata_add);
 	}
+    sao->getMeta().setModified(false);
 
 	endSave();
 }

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -1,3 +1,23 @@
+/*
+Minetest
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+
 #include "itemstackmetadata.h"
 #include "util/serialize.h"
 #include "util/strfnd.h"

--- a/src/itemstackmetadata.cpp
+++ b/src/itemstackmetadata.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2017-8 rubenwardy <rw@rubenwardy>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2010-2013 rubenwardy <rubenwardy@gmail.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/itemstackmetadata.h
+++ b/src/itemstackmetadata.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2017-8 rubenwardy <rw@rubenwardy>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -69,8 +69,8 @@ const std::string &Metadata::getString(const std::string &name, u16 recursion) c
 	return resolveString(it->second, recursion);
 }
 
-bool Metadata::getStringToRef(const std::string &name, std::string &str,
-		u16 recursion) const
+bool Metadata::getStringToRef(
+		const std::string &name, std::string &str, u16 recursion) const
 {
 	StringMap::const_iterator it = m_stringvars.find(name);
 	if (it == m_stringvars.end()) {

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -81,7 +81,6 @@ bool Metadata::getStringToRef(
 	return true;
 }
 
-
 /**
  * Sets var to name key in the metadata storage
  *

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 void Metadata::clear()
 {
 	m_stringvars.clear();
+	m_modified = true;
 }
 
 bool Metadata::empty() const
@@ -68,6 +69,19 @@ const std::string &Metadata::getString(const std::string &name, u16 recursion) c
 	return resolveString(it->second, recursion);
 }
 
+bool Metadata::getStringToRef(const std::string &name, std::string &str,
+		u16 recursion) const
+{
+	StringMap::const_iterator it = m_stringvars.find(name);
+	if (it == m_stringvars.end()) {
+		return false;
+	}
+
+	str = resolveString(it->second, recursion);
+	return true;
+}
+
+
 /**
  * Sets var to name key in the metadata storage
  *
@@ -88,6 +102,7 @@ bool Metadata::setString(const std::string &name, const std::string &var)
 	}
 
 	m_stringvars[name] = var;
+	m_modified = true;
 	return true;
 }
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class Metadata
 {
+	bool m_modified = false;
 public:
 	virtual ~Metadata() = default;
 
@@ -63,5 +64,4 @@ public:
 	}
 protected:
 	StringMap m_stringvars;
-	bool m_modified = false;
 };

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -56,12 +56,8 @@ public:
 	// Add support for variable names in values
 	const std::string &resolveString(const std::string &str, u16 recursion = 0) const;
 
-	inline bool isModified() const {
-		return m_modified;
-	}
-	inline void setModified(bool v) {
-		m_modified = v;
-	}
+	inline bool isModified() const  { return m_modified; }
+	inline void setModified(bool v) { m_modified = v; }
 protected:
 	StringMap m_stringvars;
 };

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -45,14 +45,23 @@ public:
 	size_t size() const;
 	bool contains(const std::string &name) const;
 	const std::string &getString(const std::string &name, u16 recursion = 0) const;
+	bool getStringToRef(const std::string &name, std::string &str, u16 recursion = 0) const;
 	virtual bool setString(const std::string &name, const std::string &var);
+	inline bool removeString(const std::string &name) { return setString(name, ""); }
 	const StringMap &getStrings() const
 	{
 		return m_stringvars;
 	}
 	// Add support for variable names in values
 	const std::string &resolveString(const std::string &str, u16 recursion = 0) const;
+
+	inline bool isModified() const {
+		return m_modified;
+	}
+	inline void setModified(bool v) {
+		m_modified = v;
+	}
 protected:
 	StringMap m_stringvars;
-
+	bool m_modified = false;
 };

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -73,14 +73,14 @@ void RemotePlayer::serializeExtraAttributes(std::string &output)
 	assert(m_sao);
 	Json::Value json_root;
 
-	const StringMap &attrs = m_sao->m_meta.getStrings();
+	const StringMap &attrs = m_sao->getMeta().getStrings();
 	for (const auto &attr : attrs) {
 		json_root[attr.first] = attr.second;
 	}
 
 	output = fastWriteJson(json_root);
 
-	m_sao->m_meta.setModified(false);
+	m_sao->getMeta().setModified(false);
 }
 
 
@@ -133,7 +133,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 			const Json::Value::Members attr_list = attr_root.getMemberNames();
 			for (const auto &it : attr_list) {
 				Json::Value attr_value = attr_root[it];
-				sao->m_meta.setString(it, attr_value.asString());
+				sao->getMeta().setString(it, attr_value.asString());
 			}
 		} catch (SettingNotFoundException &e) {}
 	}

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -72,14 +72,15 @@ void RemotePlayer::serializeExtraAttributes(std::string &output)
 {
 	assert(m_sao);
 	Json::Value json_root;
-	const PlayerAttributes &attrs = m_sao->getExtendedAttributes();
+
+	const StringMap &attrs = m_sao->m_meta.getStrings();
 	for (const auto &attr : attrs) {
 		json_root[attr.first] = attr.second;
 	}
 
 	output = fastWriteJson(json_root);
 
-	m_sao->setExtendedAttributeModified(false);
+	m_sao->m_meta.setModified(false);
 }
 
 
@@ -132,7 +133,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 			const Json::Value::Members attr_list = attr_root.getMemberNames();
 			for (const auto &it : attr_list) {
 				Json::Value attr_value = attr_root[it];
-				sao->setExtendedAttribute(it, attr_value.asString());
+				sao->m_meta.setString(it, attr_value.asString());
 			}
 		} catch (SettingNotFoundException &e) {}
 	}

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -135,6 +135,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 				Json::Value attr_value = attr_root[it];
 				sao->getMeta().setString(it, attr_value.asString());
 			}
+			sao->getMeta().setModified(false);
 		} catch (SettingNotFoundException &e) {}
 	}
 

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -15,6 +15,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_noise.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_object.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_particles.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_playermeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_rollback.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_server.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_settings.cpp

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -1,6 +1,8 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2017 raymoo
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -1,6 +1,8 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2017 raymoo
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_metadata.h
+++ b/src/script/lua_api/l_metadata.h
@@ -1,6 +1,7 @@
 /*
 Minetest
-Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2013-8 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1219,9 +1219,8 @@ int ObjectRef::l_set_attribute(lua_State *L)
 {
 	ObjectRef *ref = checkobject(L, 1);
 	PlayerSAO* co = getplayersao(ref);
-	if (co == NULL) {
+	if (co == NULL)
 		return 0;
-	}
 
 	std::string attr = luaL_checkstring(L, 2);
 	if (lua_isnil(L, 3)) {
@@ -1238,9 +1237,8 @@ int ObjectRef::l_get_attribute(lua_State *L)
 {
 	ObjectRef *ref = checkobject(L, 1);
 	PlayerSAO* co = getplayersao(ref);
-	if (co == NULL) {
+	if (co == NULL)
 		return 0;
-	}
 
 	std::string attr = luaL_checkstring(L, 2);
 
@@ -1259,9 +1257,8 @@ int ObjectRef::l_get_meta(lua_State *L)
 {
 	ObjectRef *ref = checkobject(L, 1);
 	PlayerSAO *co = getplayersao(ref);
-	if (co == NULL) {
+	if (co == NULL)
 		return 0;
-	}
 
 	PlayerMetaRef::create(L, &co->getMeta());
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_internal.h"
 #include "lua_api/l_inventory.h"
 #include "lua_api/l_item.h"
+#include "lua_api/l_playermeta.h"
 #include "common/c_converter.h"
 #include "common/c_content.h"
 #include "log.h"
@@ -1224,10 +1225,10 @@ int ObjectRef::l_set_attribute(lua_State *L)
 
 	std::string attr = luaL_checkstring(L, 2);
 	if (lua_isnil(L, 3)) {
-		co->removeExtendedAttribute(attr);
+		co->m_meta.removeString(attr);
 	} else {
 		std::string value = luaL_checkstring(L, 3);
-		co->setExtendedAttribute(attr, value);
+		co->m_meta.setString(attr, value);
 	}
 	return 1;
 }
@@ -1244,12 +1245,26 @@ int ObjectRef::l_get_attribute(lua_State *L)
 	std::string attr = luaL_checkstring(L, 2);
 
 	std::string value;
-	if (co->getExtendedAttribute(attr, &value)) {
+	if (co->m_meta.getStringToRef(attr, value)) {
 		lua_pushstring(L, value.c_str());
 		return 1;
 	}
 
 	return 0;
+}
+
+
+// get_meta(self, attribute)
+int ObjectRef::l_get_meta(lua_State *L)
+{
+	ObjectRef *ref = checkobject(L, 1);
+	PlayerSAO *co = getplayersao(ref);
+	if (co == NULL) {
+		return 0;
+	}
+
+	PlayerMetaRef::create(L, &co->m_meta);
+	return 1;
 }
 
 
@@ -1884,6 +1899,7 @@ const luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_breath),
 	luamethod(ObjectRef, get_attribute),
 	luamethod(ObjectRef, set_attribute),
+	luamethod(ObjectRef, get_meta),
 	luamethod(ObjectRef, set_inventory_formspec),
 	luamethod(ObjectRef, get_inventory_formspec),
 	luamethod(ObjectRef, set_formspec_prepend),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1225,10 +1225,10 @@ int ObjectRef::l_set_attribute(lua_State *L)
 
 	std::string attr = luaL_checkstring(L, 2);
 	if (lua_isnil(L, 3)) {
-		co->m_meta.removeString(attr);
+		co->getMeta().removeString(attr);
 	} else {
 		std::string value = luaL_checkstring(L, 3);
-		co->m_meta.setString(attr, value);
+		co->getMeta().setString(attr, value);
 	}
 	return 1;
 }
@@ -1245,7 +1245,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 	std::string attr = luaL_checkstring(L, 2);
 
 	std::string value;
-	if (co->m_meta.getStringToRef(attr, value)) {
+	if (co->getMeta().getStringToRef(attr, value)) {
 		lua_pushstring(L, value.c_str());
 		return 1;
 	}
@@ -1263,7 +1263,7 @@ int ObjectRef::l_get_meta(lua_State *L)
 		return 0;
 	}
 
-	PlayerMetaRef::create(L, &co->m_meta);
+	PlayerMetaRef::create(L, &co->getMeta());
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -250,7 +250,7 @@ private:
 	// get_attribute(self, attribute)
 	static int l_get_attribute(lua_State *L);
 
-	// get_meta(self, attribute)
+	// get_meta(self)
 	static int l_get_meta(lua_State *L);
 
 	// set_inventory_formspec(self, formspec)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -250,6 +250,9 @@ private:
 	// get_attribute(self, attribute)
 	static int l_get_attribute(lua_State *L);
 
+	// get_meta(self, attribute)
+	static int l_get_meta(lua_State *L);
+
 	// set_inventory_formspec(self, formspec)
 	static int l_set_inventory_formspec(lua_State *L);
 

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -1,7 +1,7 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -97,8 +97,8 @@ void PlayerMetaRef::Register(lua_State *L)
 
 	lua_pop(L, 1); // drop metatable
 
-	luaL_openlib(L, 0, methods, 0); // fill methodtable
-	lua_pop(L, 1);                  // drop methodtable
+	luaL_openlib(L, 0, methods, 0);
+	lua_pop(L, 1);
 
 	// Cannot be created from Lua
 	// lua_register(L, className, create_object);

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -1,0 +1,118 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_playermeta.h"
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+
+/*
+	NodeMetaRef
+*/
+PlayerMetaRef* PlayerMetaRef::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata(L, narg, className);
+	if (!ud)
+		luaL_typerror(L, narg, className);
+
+	return *(PlayerMetaRef**)ud;  // unbox pointer
+}
+
+Metadata* PlayerMetaRef::getmeta(bool auto_create)
+{
+	return metadata;
+}
+
+void PlayerMetaRef::clearMeta()
+{
+	metadata->clear();
+}
+
+void PlayerMetaRef::reportMetadataChange()
+{
+	// TODO
+}
+
+// garbage collector
+int PlayerMetaRef::gc_object(lua_State *L) {
+	PlayerMetaRef *o = *(PlayerMetaRef **)(lua_touserdata(L, 1));
+	delete o;
+	return 0;
+}
+
+// Creates an PlayerMetaRef and leaves it on top of stack
+// Not callable from Lua; all references are created on the C side.
+void PlayerMetaRef::create(lua_State *L, Metadata *metadata)
+{
+	PlayerMetaRef *o = new PlayerMetaRef(metadata);
+	//infostream<<"NodeMetaRef::create: o="<<o<<std::endl;
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+void PlayerMetaRef::Register(lua_State *L)
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, className);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "metadata_class");
+	lua_pushlstring(L, className, strlen(className));
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__eq");
+	lua_pushcfunction(L, l_equals);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);  // drop metatable
+
+	luaL_openlib(L, 0, methods, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+
+	// Cannot be created from Lua
+	//lua_register(L, className, create_object);
+}
+
+const char PlayerMetaRef::className[] = "PlayerMetaRef";
+const luaL_Reg PlayerMetaRef::methods[] = {
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, set_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, set_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, to_table),
+	luamethod(MetaDataRef, from_table),
+	luamethod(MetaDataRef, equals),
+	{0,0}
+};

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_content.h"
 
 /*
-	NodeMetaRef
+	PlayerMetaRef
 */
 PlayerMetaRef* PlayerMetaRef::checkobject(lua_State *L, int narg)
 {

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -32,7 +32,7 @@ PlayerMetaRef *PlayerMetaRef::checkobject(lua_State *L, int narg)
 	if (!ud)
 		luaL_typerror(L, narg, className);
 
-	return *(PlayerMetaRef **)ud;  // unbox pointer
+	return *(PlayerMetaRef **)ud; // unbox pointer
 }
 
 Metadata *PlayerMetaRef::getmeta(bool auto_create)
@@ -97,13 +97,14 @@ void PlayerMetaRef::Register(lua_State *L)
 
 	lua_pop(L, 1); // drop metatable
 
-	luaL_openlib(L, 0, methods, 0);  // fill methodtable
-	lua_pop(L, 1);                   // drop methodtable
+	luaL_openlib(L, 0, methods, 0); // fill methodtable
+	lua_pop(L, 1);                  // drop methodtable
 
 	// Cannot be created from Lua
 	// lua_register(L, className, create_object);
 }
 
+// clang-format off
 const char PlayerMetaRef::className[] = "PlayerMetaRef";
 const luaL_Reg PlayerMetaRef::methods[] = {
 	luamethod(MetaDataRef, get_string),
@@ -117,3 +118,4 @@ const luaL_Reg PlayerMetaRef::methods[] = {
 	luamethod(MetaDataRef, equals),
 	{0,0}
 };
+// clang-format on

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	PlayerMetaRef
 */
-PlayerMetaRef* PlayerMetaRef::checkobject(lua_State *L, int narg)
+PlayerMetaRef *PlayerMetaRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
@@ -35,7 +35,7 @@ PlayerMetaRef* PlayerMetaRef::checkobject(lua_State *L, int narg)
 	return *(PlayerMetaRef**)ud;  // unbox pointer
 }
 
-Metadata* PlayerMetaRef::getmeta(bool auto_create)
+Metadata *PlayerMetaRef::getmeta(bool auto_create)
 {
 	return metadata;
 }

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -32,7 +32,7 @@ PlayerMetaRef *PlayerMetaRef::checkobject(lua_State *L, int narg)
 	if (!ud)
 		luaL_typerror(L, narg, className);
 
-	return *(PlayerMetaRef**)ud;  // unbox pointer
+	return *(PlayerMetaRef **)ud;  // unbox pointer
 }
 
 Metadata *PlayerMetaRef::getmeta(bool auto_create)
@@ -51,7 +51,8 @@ void PlayerMetaRef::reportMetadataChange()
 }
 
 // garbage collector
-int PlayerMetaRef::gc_object(lua_State *L) {
+int PlayerMetaRef::gc_object(lua_State *L)
+{
 	PlayerMetaRef *o = *(PlayerMetaRef **)(lua_touserdata(L, 1));
 	delete o;
 	return 0;
@@ -62,7 +63,6 @@ int PlayerMetaRef::gc_object(lua_State *L) {
 void PlayerMetaRef::create(lua_State *L, Metadata *metadata)
 {
 	PlayerMetaRef *o = new PlayerMetaRef(metadata);
-	//infostream<<"NodeMetaRef::create: o="<<o<<std::endl;
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
@@ -77,7 +77,7 @@ void PlayerMetaRef::Register(lua_State *L)
 
 	lua_pushliteral(L, "__metatable");
 	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+	lua_settable(L, metatable); // hide metatable from Lua getmetatable()
 
 	lua_pushliteral(L, "metadata_class");
 	lua_pushlstring(L, className, strlen(className));
@@ -95,13 +95,13 @@ void PlayerMetaRef::Register(lua_State *L)
 	lua_pushcfunction(L, l_equals);
 	lua_settable(L, metatable);
 
-	lua_pop(L, 1);  // drop metatable
+	lua_pop(L, 1); // drop metatable
 
 	luaL_openlib(L, 0, methods, 0);  // fill methodtable
-	lua_pop(L, 1);  // drop methodtable
+	lua_pop(L, 1);                   // drop methodtable
 
 	// Cannot be created from Lua
-	//lua_register(L, className, create_object);
+	// lua_register(L, className, create_object);
 }
 
 const char PlayerMetaRef::className[] = "PlayerMetaRef";

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -45,7 +45,7 @@ private:
 	// garbage collector
 	static int gc_object(lua_State *L);
 public:
-	PlayerMetaRef(Metadata *metadata): metadata(metadata) {}
+	PlayerMetaRef(Metadata *metadata) : metadata(metadata) {}
 	~PlayerMetaRef() = default;
 
 	// Creates an ItemStackMetaRef and leaves it on top of stack

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -1,7 +1,7 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
-Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2017-8 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -44,6 +44,7 @@ private:
 
 	// garbage collector
 	static int gc_object(lua_State *L);
+
 public:
 	PlayerMetaRef(Metadata *metadata) : metadata(metadata) {}
 	~PlayerMetaRef() = default;

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -1,6 +1,7 @@
 /*
 Minetest
 Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -1,0 +1,55 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "lua_api/l_base.h"
+#include "lua_api/l_metadata.h"
+#include "irrlichttypes_bloated.h"
+#include "inventory.h"
+#include "metadata.h"
+
+class PlayerMetaRef : public MetaDataRef
+{
+private:
+	Metadata *metadata = nullptr;
+
+	static const char className[];
+	static const luaL_Reg methods[];
+
+	static PlayerMetaRef *checkobject(lua_State *L, int narg);
+
+	virtual Metadata* getmeta(bool auto_create);
+
+	virtual void clearMeta();
+
+	virtual void reportMetadataChange();
+
+	// garbage collector
+	static int gc_object(lua_State *L);
+public:
+	PlayerMetaRef(Metadata *metadata): metadata(metadata) {}
+	~PlayerMetaRef() = default;
+
+	// Creates an ItemStackMetaRef and leaves it on top of stack
+	// Not callable from Lua; all references are created on the C side.
+	static void create(lua_State *L, Metadata *metadata);
+
+	static void Register(lua_State *L);
+};

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -36,7 +36,7 @@ private:
 
 	static PlayerMetaRef *checkobject(lua_State *L, int narg);
 
-	virtual Metadata* getmeta(bool auto_create);
+	virtual Metadata *getmeta(bool auto_create);
 
 	virtual void clearMeta();
 

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -35,6 +35,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_nodetimer.h"
 #include "lua_api/l_noise.h"
 #include "lua_api/l_object.h"
+#include "lua_api/l_playermeta.h"
 #include "lua_api/l_particles.h"
 #include "lua_api/l_rollback.h"
 #include "lua_api/l_server.h"
@@ -99,6 +100,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	NodeMetaRef::Register(L);
 	NodeTimerRef::Register(L);
 	ObjectRef::Register(L);
+	PlayerMetaRef::Register(L);
 	LuaSettings::Register(L);
 	StorageRef::Register(L);
 	ModChannelRef::Register(L);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -535,7 +535,7 @@ void ServerEnvironment::saveLoadedPlayers()
 
 	for (RemotePlayer *player : m_players) {
 		if (player->checkModified() || (player->getPlayerSAO() &&
-				player->getPlayerSAO()->m_meta.isModified())) {
+				player->getPlayerSAO()->getMeta().isModified())) {
 			try {
 				m_player_database->savePlayer(player);
 			} catch (DatabaseException &e) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -535,7 +535,7 @@ void ServerEnvironment::saveLoadedPlayers()
 
 	for (RemotePlayer *player : m_players) {
 		if (player->checkModified() || (player->getPlayerSAO() &&
-				player->getPlayerSAO()->extendedAttributesModified())) {
+				player->getPlayerSAO()->m_meta.isModified())) {
 			try {
 				m_player_database->savePlayer(player);
 			} catch (DatabaseException &e) {


### PR DESCRIPTION
This is required as a prerequisite to allow loading player attributes whilst the player is offline.

The PlayerMetaRef currently takes a pointer to the meta, ideally it should instead have a reference counter to notify the meta holder when the reference is garbage collected to allow it to be unloaded. This can be done in a future "get player meta whilst online" PR