### PR TITLE
Mgcarpathian: Remove insignificant 'base' noise variation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1509,6 +1509,9 @@ mgv7_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 
 #    Flags starting with 'no' are used to explicitly disable them.
 mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns caverns,nocaverns
 
+#    Defines the base ground level.
+mgcarpathian_base_level (Base ground level) float 12.0
+
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgcarpathian_cave_width (Cave width) float 0.09
 
@@ -1534,9 +1537,6 @@ mgcarpathian_dungeon_ymin (Dungeon minimum Y) int -31000
 mgcarpathian_dungeon_ymax (Dungeon maximum Y) int 31000
 
 [**Noises]
-
-#    2D noise that defines the base ground level.
-mgcarpathian_np_base (Base ground noise) noise_params_2d 12, 1, (2557, 2557, 2557), 6538, 4, 0.8, 0.5, eased
 
 #    Variation of biome filler depth.
 mgcarpathian_np_filler_depth (Filler depth noise) noise_params_2d 0, 1, (128, 128, 128), 261, 3, 0.7, 2.0, eased

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -33,6 +33,8 @@ extern FlagDesc flagdesc_mapgen_carpathian[];
 
 struct MapgenCarpathianParams : public MapgenParams
 {
+	float base_level       = 12.0f;
+
 	u32 spflags            = MGCARPATHIAN_CAVERNS;
 	float cave_width       = 0.09f;
 	s16 large_cave_depth   = -33;
@@ -43,7 +45,6 @@ struct MapgenCarpathianParams : public MapgenParams
 	s16 dungeon_ymin       = -31000;
 	s16 dungeon_ymax       = 31000;
 
-	NoiseParams np_base;
 	NoiseParams np_filler_depth;
 	NoiseParams np_height1;
 	NoiseParams np_height2;
@@ -83,12 +84,13 @@ public:
 	int getSpawnLevelAtPoint(v2s16 p);
 
 private:
-	s16 large_cave_depth;
+	float base_level;
 	s32 grad_wl;
+
+	s16 large_cave_depth;
 	s16 dungeon_ymin;
 	s16 dungeon_ymax;
 
-	Noise *noise_base;
 	Noise *noise_height1;
 	Noise *noise_height2;
 	Noise *noise_height3;


### PR DESCRIPTION
Was only +-1 node over a scale of thousands of nodes.
Replace with 'base_level' parameter value.
///////////////////

Change agreed with mapgen creator @vlapsley in #7165 
Treating as trivial as is my speciality and is fairly simple.