### PR TITLE
Run code style linter first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,26 @@ notifications:
 matrix:
   fast_finish: true
   include:
+
+    - env: LINT=1
+      compiler: clang
+      os: linux
+      addons:
+        apt:
+          packages: ['clang-format-5.0']
+          sources: &sources
+            - llvm-toolchain-trusty-5.0
+
+    - env: CLANG_TIDY=1
+      compiler: clang
+      os: linux
+      script: ./util/travis/clangtidy.sh
+      addons:
+        apt:
+          packages: ['clang-tidy-5.0']
+          sources: &sources
+            - llvm-toolchain-trusty-5.0
+
     - env: PLATFORM=Win32
       compiler: gcc
       os: linux
@@ -87,24 +107,3 @@ matrix:
           packages: ['valgrind', 'clang-5.0', 'clang++-5.0']
           sources: &sources
             - llvm-toolchain-trusty-5.0
-
-    - env: LINT=1
-      compiler: clang
-      os: linux
-      addons:
-        apt:
-          packages: ['clang-format-5.0']
-          sources: &sources
-            - llvm-toolchain-trusty-5.0
-    - env: CLANG_TIDY=1
-      compiler: clang
-      os: linux
-      script: ./util/travis/clangtidy.sh
-      addons:
-        apt:
-          packages: ['clang-tidy-5.0']
-          sources: &sources
-            - llvm-toolchain-trusty-5.0
-
-
-


### PR DESCRIPTION
The code style linter is the most likely to fail, so should be
placed at the top of the list so it's started first. Note that
a failed job doesn't stop others from running