### PR TITLE
Add an empty, default tool capabilities tables

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -511,7 +511,7 @@ core.nodedef_default = {
 	stack_max = 99,
 	usable = false,
 	liquids_pointable = false,
-	tool_capabilities = nil,
+	tool_capabilities = {},
 	node_placement_prediction = nil,
 
 	-- Interaction callbacks
@@ -573,7 +573,7 @@ core.craftitemdef_default = {
 	wield_scale = {x=1,y=1,z=1},
 	stack_max = 99,
 	liquids_pointable = false,
-	tool_capabilities = nil,
+	tool_capabilities = {},
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
@@ -591,7 +591,7 @@ core.tooldef_default = {
 	wield_scale = {x=1,y=1,z=1},
 	stack_max = 1,
 	liquids_pointable = false,
-	tool_capabilities = nil,
+	tool_capabilities = {},
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
@@ -609,7 +609,7 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 	wield_scale = {x=1,y=1,z=1},
 	stack_max = 99,
 	liquids_pointable = false,
-	tool_capabilities = nil,
+	tool_capabilities = {},
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'),


### PR DESCRIPTION
This fixes the segfault explained at <https://github.com/minetest/minetest/issues/7215>.