### PR TITLE
Biome API / dungeons: Add biome-defined dungeon nodes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5666,6 +5666,17 @@ Definition tables
     --  ^ Nodes placed as a blob of liquid in 50% of large caves.
     --  ^ If absent, cave liquids fall back to classic behaviour of lava or
     --  ^ water distributed according to a hardcoded 3D noise.
+        node_dungeon = "default:cobble",
+    --  ^ Node used for primary dungeon structure.
+    --  ^ If absent, dungeon materials fall back to classic behaviour.
+    --  ^ If present, the following two nodes are also used.
+        node_dungeon_alt = "default:mossycobble",
+    --  ^ Node used for randomly-distributed alternative structure nodes.
+    --  ^ If alternative structure nodes are not wanted leave this absent for
+    --  ^ performance reasons.
+        node_dungeon_stair = "stairs:stair_cobble",
+    --  ^ Node used for dungeon stairs.
+    --  ^ If absent, stairs fall back to 'node_dungeon'.
         y_max = 31000,
         y_min = 1,
     --  ^ Upper and lower limits for biome.

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -77,13 +77,6 @@ enum GenNotifyType {
 	NUM_GENNOTIFY_TYPES
 };
 
-enum MgStoneType {
-	MGSTONE_STONE,
-	MGSTONE_DESERT_STONE,
-	MGSTONE_SANDSTONE,
-	MGSTONE_OTHER,
-};
-
 struct GenNotifyEvent {
 	GenNotifyType type;
 	v3s16 pos;
@@ -247,10 +240,8 @@ public:
 
 	virtual void generateCaves(s16 max_stone_y, s16 large_cave_depth);
 	virtual bool generateCaverns(s16 max_stone_y);
-	virtual void generateDungeons(s16 max_stone_y,
-		MgStoneType stone_type, content_t biome_stone);
-	virtual void generateBiomes(MgStoneType *mgstone_type,
-		content_t *biome_stone);
+	virtual void generateDungeons(s16 max_stone_y);
+	virtual void generateBiomes();
 	virtual void dustTopNodes();
 
 protected:

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -248,10 +248,7 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -272,7 +269,7 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 	// Generate dungeons
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -196,17 +196,14 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -207,17 +207,14 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	if (flags & MG_CAVES)
 		generateCaves(stone_surface_max_y, large_cave_depth);
 
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -207,10 +207,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -231,7 +228,7 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	// Generate dungeons and desert temples
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -311,10 +311,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 
 	// Init biome generator, place biome-specific nodes, and build biomemap
 	biomegen->calcBiomeNoise(node_min);
-
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	// Generate caverns, tunnels and classic caves
 	if (flags & MG_CAVES) {
@@ -335,7 +332,7 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	// Generate dungeons
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -242,9 +242,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	updateHeightmap(node_min, node_max);
 
 	// Place biome-specific nodes and build biomemap
-	MgStoneType mgstone_type;
-	content_t biome_stone;
-	generateBiomes(&mgstone_type, &biome_stone);
+	generateBiomes();
 
 	// Cave creation.
 	if (flags & MG_CAVES)
@@ -253,7 +251,7 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	// Dungeon creation
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
-		generateDungeons(stone_surface_max_y, mgstone_type, biome_stone);
+		generateDungeons(stone_surface_max_y);
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -63,6 +63,9 @@ BiomeManager::BiomeManager(Server *server) :
 	b->m_nodenames.emplace_back("mapgen_stone");
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
+	b->m_nodenames.emplace_back("ignore");
+	b->m_nodenames.emplace_back("ignore");
+	b->m_nodenames.emplace_back("ignore");
 	m_ndef->pendNodeResolve(b);
 
 	add(b);
@@ -314,13 +317,16 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 
 void Biome::resolveNodeNames()
 {
-	getIdFromNrBacklog(&c_top,         "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_filler,      "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_stone,       "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_water_top,   "mapgen_water_source",       CONTENT_AIR);
-	getIdFromNrBacklog(&c_water,       "mapgen_water_source",       CONTENT_AIR);
-	getIdFromNrBacklog(&c_river_water, "mapgen_river_water_source", CONTENT_AIR);
-	getIdFromNrBacklog(&c_riverbed,    "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_dust,        "ignore",                    CONTENT_IGNORE);
-	getIdFromNrBacklog(&c_cave_liquid, "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_top,           "mapgen_stone",              CONTENT_AIR);
+	getIdFromNrBacklog(&c_filler,        "mapgen_stone",              CONTENT_AIR);
+	getIdFromNrBacklog(&c_stone,         "mapgen_stone",              CONTENT_AIR);
+	getIdFromNrBacklog(&c_water_top,     "mapgen_water_source",       CONTENT_AIR);
+	getIdFromNrBacklog(&c_water,         "mapgen_water_source",       CONTENT_AIR);
+	getIdFromNrBacklog(&c_river_water,   "mapgen_river_water_source", CONTENT_AIR);
+	getIdFromNrBacklog(&c_riverbed,      "mapgen_stone",              CONTENT_AIR);
+	getIdFromNrBacklog(&c_dust,          "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_cave_liquid,   "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_dungeon_alt,   "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_dungeon_stair, "ignore",                    CONTENT_IGNORE);
 }

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -53,6 +53,9 @@ public:
 	content_t c_riverbed;
 	content_t c_dust;
 	content_t c_cave_liquid;
+	content_t c_dungeon;
+	content_t c_dungeon_alt;
+	content_t c_dungeon_stair;
 
 	s16 depth_top;
 	s16 depth_filler;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -397,15 +397,18 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	getintfield(L, index, "y_max", b->max_pos.Y);
 
 	std::vector<std::string> &nn = b->m_nodenames;
-	nn.push_back(getstringfield_default(L, index, "node_top",         ""));
-	nn.push_back(getstringfield_default(L, index, "node_filler",      ""));
-	nn.push_back(getstringfield_default(L, index, "node_stone",       ""));
-	nn.push_back(getstringfield_default(L, index, "node_water_top",   ""));
-	nn.push_back(getstringfield_default(L, index, "node_water",       ""));
-	nn.push_back(getstringfield_default(L, index, "node_river_water", ""));
-	nn.push_back(getstringfield_default(L, index, "node_riverbed",    ""));
-	nn.push_back(getstringfield_default(L, index, "node_dust",        ""));
-	nn.push_back(getstringfield_default(L, index, "node_cave_liquid", ""));
+	nn.push_back(getstringfield_default(L, index, "node_top",           ""));
+	nn.push_back(getstringfield_default(L, index, "node_filler",        ""));
+	nn.push_back(getstringfield_default(L, index, "node_stone",         ""));
+	nn.push_back(getstringfield_default(L, index, "node_water_top",     ""));
+	nn.push_back(getstringfield_default(L, index, "node_water",         ""));
+	nn.push_back(getstringfield_default(L, index, "node_river_water",   ""));
+	nn.push_back(getstringfield_default(L, index, "node_riverbed",      ""));
+	nn.push_back(getstringfield_default(L, index, "node_dust",          ""));
+	nn.push_back(getstringfield_default(L, index, "node_cave_liquid",   ""));
+	nn.push_back(getstringfield_default(L, index, "node_dungeon",       ""));
+	nn.push_back(getstringfield_default(L, index, "node_dungeon_alt",   ""));
+	nn.push_back(getstringfield_default(L, index, "node_dungeon_stair", ""));
 	ndef->pendNodeResolve(b);
 
 	return b;


### PR DESCRIPTION
 Biome API / dungeons: Add biome-defined dungeon nodes

Add new biome fields 'node_dungeon', 'node_dungeon_alt', 'node_dungeon_stair'.
If 'node_dungeon' is not defined dungeons fall back to classic behaviour.

Remove messy and imprecise dungeon material code from 'generateBiomes()'.
Code deciding dungeon materials is now in 'generateDungeons()' and uses the
biome at mapchunk centre for more precision.

Remove hardcoded 'MG_STONE' types as long intended.
////////////////

Properly attends to the comment by hmmmm found in 0.4.16:
```
// TODO(hmmmm/paramat): make stone type selection dynamic
enum MgStoneType {
	MGSTONE_STONE,
	MGSTONE_DESERT_STONE,
	MGSTONE_SANDSTONE,
};
```
Previous choosing of dungeon material was imprecise. It happened in 'generateBiomes()' according to the biome 'node stone' placed.
For every node in mapchunk:
```
				// Detect stone type for dungeons during every biome calculation.
				// If none detected the last selected biome stone is chosen.
				if (biome->c_stone == c_stone)
					stone_type = MGSTONE_STONE;
				else if (biome->c_stone == c_desert_stone)
					stone_type = MGSTONE_DESERT_STONE;
				else if (biome->c_stone == c_sandstone)
					stone_type = MGSTONE_SANDSTONE;
```
The resulting 'stone type' for a mapchunk depended on what stone node was placed last in the mapchunk. For example a mapchunk could be almost completely stone but if the last stone node placed in one corner was sandstone this would cause the dungeons of that mapchunk to be sandstone brick dungeons.

This PR calculates the biome active at the mapchunk centre to be more precise. The code is now in 'generateBiomes()' where it should be. A lot of messy code is removed and some code simplified.

If the biome field 'node_dungeon' is present the new behaviour is chosen, with 'node_dungeon_alt' and 'node_dungeon_stair' both falling back to 'node_dungeon' if they are not present.
'node_dungeon_alt' is the alternative structure material that is randomly scattered, such as mossycobble in cobble dungeons.

If the biome field 'node_dungeon' is not present behaviour falls back to previous behaviour, so dungeons are unchanged for backwards compatibility, tested in mgv7 with MTG missing the new biome fields:

![screenshot_20180406_181320](https://user-images.githubusercontent.com/3686677/38435681-52fc0c2a-39ca-11e8-8849-d564da6907e1.png)

![screenshot_20180406_182014](https://user-images.githubusercontent.com/3686677/38435684-58ebad16-39ca-11e8-81f8-68781faaac8d.png)

![screenshot_20180406_182218](https://user-images.githubusercontent.com/3686677/38435690-5c46624e-39ca-11e8-865e-203c90111af5.png)

![screenshot_20180406_182450](https://user-images.githubusercontent.com/3686677/38435695-603a1abc-39ca-11e8-94dd-87d02a2e736c.png)

Testing by defining glass walls, then adding meselamp as alt wall, then adding desert sandstone for stairs:

![screenshot_20180406_185853](https://user-images.githubusercontent.com/3686677/38436728-5500b644-39cd-11e8-9b5f-13f062400243.png)

![screenshot_20180406_190103](https://user-images.githubusercontent.com/3686677/38436737-59f35724-39cd-11e8-82ae-95409f289d8a.png)

![screenshot_20180406_190215](https://user-images.githubusercontent.com/3686677/38436747-5e0a9908-39cd-11e8-99bf-fbe6e880bf1a.png)