### PR TITLE
Normalize LuaReference objects & simpler lua registration method

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -770,7 +770,7 @@ Call these functions only at load time!
 
 ### Storage API
 * `minetest.get_mod_storage()`:
-    * returns reference to mod private `StorageRef`
+    * returns reference to mod private `LuaModMetadata`
     * must be called during mod load time
 
 ### Mod channels

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3679,7 +3679,7 @@ These functions return the leftover itemstack.
 
 ### Storage API:
 * `minetest.get_mod_storage()`:
-    * returns reference to mod private `StorageRef`
+    * returns reference to mod private `LuaModMetadata`
     * must be called during mod load time
 
 ### Misc.
@@ -3902,7 +3902,7 @@ An interface to use mod channels on client and server
     * Message size is limited to 65535 characters by protocol.
 
 ### `MetaDataRef`
-See `StorageRef`, `NodeMetaRef`, `ItemStackMetaRef`, and `PlayerMetaRef`.
+See `LuaModMetadata`, `NodeMetaRef`, `ItemStackMetaRef`, and `PlayerMetaRef`.
 
 #### Methods
 * `set_string(name, value)`
@@ -3945,7 +3945,7 @@ Can be obtained via `item:get_meta()`.
     * A nil value will clear the override data and restore the original
       behavior.
 
-### `StorageRef`
+### `LuaModMetadata`
 Mod metadata: per mod metadata, saved automatically.
 Can be obtained via `minetest.get_mod_storage()` during load time.
 

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -27,7 +27,6 @@ struct ItemStack;
 class ServerActiveObject;
 struct ItemDefinition;
 class LuaItemStack;
-class ModApiItemMod;
 class InventoryList;
 struct InventoryLocation;
 
@@ -50,7 +49,6 @@ public:
 
 protected:
 	friend class LuaItemStack;
-	friend class ModApiItemMod;
 	friend class LuaRaycast;
 
 	bool getItemCallback(const char *name, const char *callbackname, const v3s16 *p = nullptr);

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -84,3 +84,29 @@ bool ModApiBase::registerFunction(lua_State *L, const char *name,
 
 	return true;
 }
+
+void ModApiBase::BaseRegister(lua_State *L, const char *name, const luaL_Reg *methods,
+	int (*gc_f)(lua_State *))
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, name);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_f);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);
+
+	luaL_openlib(L, 0, methods, 0);
+	lua_pop(L, 1);
+}

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -37,25 +37,6 @@ class Server;
 class Environment;
 class GUIEngine;
 
-/**
- * This macro permits to bootstrap easily a Lua Referenced object
- */
-#define LUAREF_OBJECT(name)                                                                                        \
-private:                                                                                                           \
-    name *m_object = nullptr;                                                                                                \
-    static const char className[];                                                                                 \
-    static const luaL_Reg methods[];                                                                               \
-    static int gc_object(lua_State *L);                                                                            \
-                                                                                                                   \
-public:                                                                                                            \
-    explicit Lua##name(name *object);                                                                           \
-    virtual ~Lua##name();                                                                                       \
-    static void Register(lua_State *L);                                                                            \
-    static void create(lua_State *L, name *object);                                                                \
-    static Lua##name *checkobject(lua_State *L, int narg);                                                      \
-    static name *getobject(Lua##name *ref);
-
-
 class ModApiBase {
 
 public:

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -69,4 +69,14 @@ public:
 			const char* name,
 			lua_CFunction func,
 			int top);
+
+	/**
+	 * Standard function to register objects on the Lua state
+	 * @param L Lua state
+	 * @param name LuaRef name
+	 * @param methods LuaRef methods
+	 * @param gc_f LuaRef gc method
+	 */
+	static void BaseRegister(lua_State *L, const char *name, const luaL_Reg *methods,
+		int (*gc_f)(lua_State *));
 };

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -37,6 +37,25 @@ class Server;
 class Environment;
 class GUIEngine;
 
+/**
+ * This macro permits to bootstrap easily a Lua Referenced object
+ */
+#define LUAREF_OBJECT(name)                                                                                        \
+private:                                                                                                           \
+    name *m_object = nullptr;                                                                                                \
+    static const char className[];                                                                                 \
+    static const luaL_Reg methods[];                                                                               \
+    static int gc_object(lua_State *L);                                                                            \
+                                                                                                                   \
+public:                                                                                                            \
+    explicit Lua##name(name *object);                                                                           \
+    virtual ~Lua##name();                                                                                       \
+    static void Register(lua_State *L);                                                                            \
+    static void create(lua_State *L, name *object);                                                                \
+    static Lua##name *checkobject(lua_State *L, int narg);                                                      \
+    static name *getobject(Lua##name *ref);
+
+
 class ModApiBase {
 
 public:

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -192,27 +192,7 @@ int LuaCamera::gc_object(lua_State *L)
 
 void LuaCamera::Register(lua_State *L)
 {
-	lua_newtable(L);
-	int methodtable = lua_gettop(L);
-	luaL_newmetatable(L, className);
-	int metatable = lua_gettop(L);
-
-	lua_pushliteral(L, "__metatable");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__index");
-	lua_pushvalue(L, methodtable);
-	lua_settable(L, metatable);
-
-	lua_pushliteral(L, "__gc");
-	lua_pushcfunction(L, gc_object);
-	lua_settable(L, metatable);
-
-	lua_pop(L, 1);
-
-	luaL_openlib(L, 0, methods, 0);
-	lua_pop(L, 1);
+	ModApiBase::BaseRegister(L, className, methods, LuaCamera::gc_object);
 }
 
 const char LuaCamera::className[] = "Camera";

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -25,7 +25,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "camera.h"
 #include "client.h"
 
-LuaCamera::LuaCamera(Camera *m) : m_camera(m)
+LuaCamera::LuaCamera(Camera *m) : m_object(m)
+{
+}
+
+LuaCamera::~LuaCamera()
 {
 }
 
@@ -166,7 +170,7 @@ LuaCamera *LuaCamera::checkobject(lua_State *L, int narg)
 
 Camera *LuaCamera::getobject(LuaCamera *ref)
 {
-	return ref->m_camera;
+	return ref->m_object;
 }
 
 Camera *LuaCamera::getobject(lua_State *L, int narg)

--- a/src/script/lua_api/l_camera.h
+++ b/src/script/lua_api/l_camera.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "l_base.h"
+#include "l_internal.h"
 
 class Camera;
 

--- a/src/script/lua_api/l_camera.h
+++ b/src/script/lua_api/l_camera.h
@@ -25,13 +25,8 @@ class Camera;
 
 class LuaCamera : public ModApiBase
 {
+	LUAREF_OBJECT(Camera)
 private:
-	static const char className[];
-	static const luaL_Reg methods[];
-
-	// garbage collector
-	static int gc_object(lua_State *L);
-
 	static int l_set_camera_mode(lua_State *L);
 	static int l_get_camera_mode(lua_State *L);
 
@@ -44,17 +39,6 @@ private:
 	static int l_get_look_horizontal(lua_State *L);
 	static int l_get_aspect_ratio(lua_State *L);
 
-	Camera *m_camera = nullptr;
-
 public:
-	LuaCamera(Camera *m);
-	~LuaCamera() = default;
-
-	static void create(lua_State *L, Camera *m);
-
-	static LuaCamera *checkobject(lua_State *L, int narg);
-	static Camera *getobject(LuaCamera *ref);
 	static Camera *getobject(lua_State *L, int narg);
-
-	static void Register(lua_State *L);
 };

--- a/src/script/lua_api/l_internal.h
+++ b/src/script/lua_api/l_internal.h
@@ -43,3 +43,22 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define GET_ENV_PTR         \
 	MAP_LOCK_REQUIRED;      \
 	GET_ENV_PTR_NO_MAP_LOCK
+
+
+/**
+ * This macro permits to bootstrap easily a Lua Referenced object
+ */
+#define LUAREF_OBJECT(name)                                                                                        \
+private:                                                                                                           \
+    name *m_object = nullptr;                                                                                                \
+    static const char className[];                                                                                 \
+    static const luaL_Reg methods[];                                                                               \
+    static int gc_object(lua_State *L);                                                                            \
+                                                                                                                   \
+public:                                                                                                            \
+    explicit Lua##name(name *object);                                                                           \
+    virtual ~Lua##name();                                                                                       \
+    static void Register(lua_State *L);                                                                            \
+    static void create(lua_State *L, name *object);                                                                \
+    static Lua##name *checkobject(lua_State *L, int narg);                                                      \
+    static name *getobject(Lua##name *ref);

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_content.h"
 
 /*
-	NodeMetaRef
+	ItemStackMetaRef
 */
 ItemStackMetaRef* ItemStackMetaRef::checkobject(lua_State *L, int narg)
 {

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -24,7 +24,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "hud.h"
 #include "common/c_content.h"
 
-LuaLocalPlayer::LuaLocalPlayer(LocalPlayer *m) : m_localplayer(m)
+LuaLocalPlayer::LuaLocalPlayer(LocalPlayer *m) : m_object(m)
+{
+}
+
+LuaLocalPlayer::~LuaLocalPlayer()
 {
 }
 
@@ -354,7 +358,7 @@ LuaLocalPlayer *LuaLocalPlayer::checkobject(lua_State *L, int narg)
 
 LocalPlayer *LuaLocalPlayer::getobject(LuaLocalPlayer *ref)
 {
-	return ref->m_localplayer;
+	return ref->m_object;
 }
 
 LocalPlayer *LuaLocalPlayer::getobject(lua_State *L, int narg)

--- a/src/script/lua_api/l_localplayer.h
+++ b/src/script/lua_api/l_localplayer.h
@@ -20,18 +20,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "l_base.h"
+#include "l_internal.h"
 
 class LocalPlayer;
 
 class LuaLocalPlayer : public ModApiBase
 {
+	LUAREF_OBJECT(LocalPlayer);
 private:
-	static const char className[];
-	static const luaL_Reg methods[];
-
-	// garbage collector
-	static int gc_object(lua_State *L);
-
 	static int l_get_velocity(lua_State *L);
 
 	static int l_get_hp(lua_State *L);
@@ -76,18 +72,6 @@ private:
 	static int l_hud_change(lua_State *L);
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
-
-	LocalPlayer *m_localplayer = nullptr;
-
 public:
-	LuaLocalPlayer(LocalPlayer *m);
-	~LuaLocalPlayer() = default;
-
-	static void create(lua_State *L, LocalPlayer *m);
-
-	static LuaLocalPlayer *checkobject(lua_State *L, int narg);
-	static LocalPlayer *getobject(LuaLocalPlayer *ref);
 	static LocalPlayer *getobject(lua_State *L, int narg);
-
-	static void Register(lua_State *L);
 };

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -25,7 +25,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "minimap.h"
 #include "settings.h"
 
-LuaMinimap::LuaMinimap(Minimap *m) : m_minimap(m)
+LuaMinimap::LuaMinimap(Minimap *m) : m_object(m)
+{
+}
+
+LuaMinimap::~LuaMinimap()
 {
 }
 
@@ -177,7 +181,7 @@ LuaMinimap *LuaMinimap::checkobject(lua_State *L, int narg)
 
 Minimap* LuaMinimap::getobject(LuaMinimap *ref)
 {
-	return ref->m_minimap;
+	return ref->m_object;
 }
 
 int LuaMinimap::gc_object(lua_State *L) {

--- a/src/script/lua_api/l_minimap.h
+++ b/src/script/lua_api/l_minimap.h
@@ -20,18 +20,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "l_base.h"
+#include "l_internal.h"
 
 class Minimap;
 
 class LuaMinimap : public ModApiBase
 {
+	LUAREF_OBJECT(Minimap);
 private:
-	static const char className[];
-	static const luaL_Reg methods[];
-
-	// garbage collector
-	static int gc_object(lua_State *L);
-
 	static int l_get_pos(lua_State *L);
 	static int l_set_pos(lua_State *L);
 
@@ -46,17 +42,4 @@ private:
 
 	static int l_set_shape(lua_State *L);
 	static int l_get_shape(lua_State *L);
-
-	Minimap *m_minimap = nullptr;
-
-public:
-	LuaMinimap(Minimap *m);
-	~LuaMinimap() = default;
-
-	static void create(lua_State *L, Minimap *object);
-
-	static LuaMinimap *checkobject(lua_State *L, int narg);
-	static Minimap *getobject(LuaMinimap *ref);
-
-	static void Register(lua_State *L);
 };

--- a/src/script/lua_api/l_modchannels.h
+++ b/src/script/lua_api/l_modchannels.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_base.h"
 #include "config.h"
+#include "l_internal.h"
 
 class ModChannel;
 
@@ -34,15 +35,10 @@ public:
 	static void Initialize(lua_State *L, int top);
 };
 
-class ModChannelRef : public ModApiBase
+class LuaModChannel : public ModApiBase
 {
+	LUAREF_OBJECT(ModChannel);
 public:
-	ModChannelRef(ModChannel *modchannel);
-	~ModChannelRef() = default;
-
-	static void Register(lua_State *L);
-	static void create(lua_State *L, ModChannel *channel);
-
 	// leave()
 	static int l_leave(lua_State *L);
 
@@ -51,16 +47,4 @@ public:
 
 	// is_writeable()
 	static int l_is_writeable(lua_State *L);
-
-private:
-	// garbage collector
-	static int gc_object(lua_State *L);
-
-	static ModChannelRef *checkobject(lua_State *L, int narg);
-	static ModChannel *getobject(ModChannelRef *ref);
-
-	ModChannel *m_modchannel = nullptr;
-
-	static const char className[];
-	static const luaL_Reg methods[];
 };

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -280,9 +280,6 @@ private:
 	// hud_change(self, id, stat, data)
 	static int l_hud_change(lua_State *L);
 
-	// hud_get_next_id(self)
-	static u32 hud_get_next_id(lua_State *L);
-
 	// hud_get(self, id)
 	static int l_hud_get(lua_State *L);
 

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -237,7 +237,7 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 		glow = getintfield_default(L, 1, "glow", 0);
 	}
 
-	u32 id = getServer(L)->addParticleSpawner(amount, time,
+	s32 id = getServer(L)->addParticleSpawner(amount, time,
 			minpos, maxpos,
 			minvel, maxvel,
 			minacc, maxacc,

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -21,18 +21,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "common/c_content.h"
 #include "lua_api/l_base.h"
+#include "l_internal.h"
 
 class Settings;
 
 class LuaSettings : public ModApiBase
 {
+	LUAREF_OBJECT(Settings);
 private:
-	static const char className[];
-	static const luaL_Reg methods[];
-
-	// garbage collector
-	static int gc_object(lua_State *L);
-
 	// get(self, key) -> value
 	static int l_get(lua_State *L);
 
@@ -63,7 +59,6 @@ private:
 	// to_table(self) -> {[key1]=value1,...}
 	static int l_to_table(lua_State *L);
 
-	Settings *m_settings = nullptr;
 	std::string m_filename;
 	bool m_is_own_settings = false;
 	bool m_write_allowed = true;
@@ -71,15 +66,10 @@ private:
 public:
 	LuaSettings(Settings *settings, const std::string &filename);
 	LuaSettings(const std::string &filename, bool write_allowed);
-	~LuaSettings();
 
 	static void create(lua_State *L, Settings *settings, const std::string &filename);
 
 	// LuaSettings(filename)
 	// Creates a LuaSettings and leaves it on top of the stack
 	static int create_object(lua_State *L);
-
-	static LuaSettings *checkobject(lua_State *L, int narg);
-
-	static void Register(lua_State *L);
 };

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -40,7 +40,7 @@ int ModApiStorage::l_get_mod_storage(lua_State *L)
 		assert(false); // this should not happen
 	}
 
-	StorageRef::create(L, store);
+	LuaModMetadata::create(L, store);
 	int object = lua_gettop(L);
 
 	lua_pushvalue(L, object);
@@ -52,22 +52,26 @@ void ModApiStorage::Initialize(lua_State *L, int top)
 	API_FCT(get_mod_storage);
 }
 
-StorageRef::StorageRef(ModMetadata *object):
+LuaModMetadata::LuaModMetadata(ModMetadata *object):
 	m_object(object)
 {
 }
 
-void StorageRef::create(lua_State *L, ModMetadata *object)
+LuaModMetadata::~LuaModMetadata()
 {
-	StorageRef *o = new StorageRef(object);
+}
+
+void LuaModMetadata::create(lua_State *L, ModMetadata *object)
+{
+	LuaModMetadata *o = new LuaModMetadata(object);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
 }
 
-int StorageRef::gc_object(lua_State *L)
+int LuaModMetadata::gc_object(lua_State *L)
 {
-	StorageRef *o = *(StorageRef **)(lua_touserdata(L, 1));
+	LuaModMetadata *o = *(LuaModMetadata **)(lua_touserdata(L, 1));
 	// Server side
 	if (IGameDef *gamedef = getGameDef(L))
 		gamedef->unregisterModStorage(getobject(o)->getModName());
@@ -75,7 +79,7 @@ int StorageRef::gc_object(lua_State *L)
 	return 0;
 }
 
-void StorageRef::Register(lua_State *L)
+void LuaModMetadata::Register(lua_State *L)
 {
 	lua_newtable(L);
 	int methodtable = lua_gettop(L);
@@ -108,32 +112,32 @@ void StorageRef::Register(lua_State *L)
 	lua_pop(L, 1);  // drop methodtable
 }
 
-StorageRef* StorageRef::checkobject(lua_State *L, int narg)
+LuaModMetadata* LuaModMetadata::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
 	if (!ud) luaL_typerror(L, narg, className);
-	return *(StorageRef**)ud;  // unbox pointer
+	return *(LuaModMetadata**)ud;  // unbox pointer
 }
 
-ModMetadata* StorageRef::getobject(StorageRef *ref)
+ModMetadata* LuaModMetadata::getobject(LuaModMetadata *ref)
 {
 	ModMetadata *co = ref->m_object;
 	return co;
 }
 
-Metadata* StorageRef::getmeta(bool auto_create)
+Metadata* LuaModMetadata::getmeta(bool auto_create)
 {
 	return m_object;
 }
 
-void StorageRef::clearMeta()
+void LuaModMetadata::clearMeta()
 {
 	m_object->clear();
 }
 
-const char StorageRef::className[] = "StorageRef";
-const luaL_Reg StorageRef::methods[] = {
+const char LuaModMetadata::className[] = "LuaModMetadata";
+const luaL_Reg LuaModMetadata::methods[] = {
 	luamethod(MetaDataRef, get_string),
 	luamethod(MetaDataRef, set_string),
 	luamethod(MetaDataRef, get_int),

--- a/src/script/lua_api/l_storage.h
+++ b/src/script/lua_api/l_storage.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "l_metadata.h"
 #include "lua_api/l_base.h"
+#include "l_internal.h"
 
 class ModMetadata;
 
@@ -34,27 +35,10 @@ public:
 	static void Initialize(lua_State *L, int top);
 };
 
-class StorageRef : public MetaDataRef
+class LuaModMetadata : public MetaDataRef
 {
+	LUAREF_OBJECT(ModMetadata);
 private:
-	ModMetadata *m_object = nullptr;
-
-	static const char className[];
-	static const luaL_Reg methods[];
-
 	virtual Metadata *getmeta(bool auto_create);
 	virtual void clearMeta();
-
-	// garbage collector
-	static int gc_object(lua_State *L);
-
-public:
-	StorageRef(ModMetadata *object);
-	~StorageRef() = default;
-
-	static void Register(lua_State *L);
-	static void create(lua_State *L, ModMetadata *object);
-
-	static StorageRef *checkobject(lua_State *L, int narg);
-	static ModMetadata *getobject(StorageRef *ref);
 };

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -102,6 +102,4 @@ public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
-
-	static void InitializeAsync(AsyncEngine &engine);
 };

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -67,7 +67,7 @@ ClientScripting::ClientScripting(Client *client):
 void ClientScripting::InitializeModApi(lua_State *L, int top)
 {
 	LuaItemStack::Register(L);
-	StorageRef::Register(L);
+	LuaModMetadata::Register(L);
 	LuaMinimap::Register(L);
 	NodeMetaRef::RegisterClient(L);
 	LuaLocalPlayer::Register(L);

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -72,7 +72,7 @@ void ClientScripting::InitializeModApi(lua_State *L, int top)
 	NodeMetaRef::RegisterClient(L);
 	LuaLocalPlayer::Register(L);
 	LuaCamera::Register(L);
-	ModChannelRef::Register(L);
+	LuaModChannel::Register(L);
 
 	ModApiUtil::InitializeClient(L, top);
 	ModApiClient::Initialize(L, top);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -103,7 +103,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	PlayerMetaRef::Register(L);
 	LuaSettings::Register(L);
 	StorageRef::Register(L);
-	ModChannelRef::Register(L);
+	LuaModChannel::Register(L);
 
 	// Initialize mod api modules
 	ModApiCraft::Initialize(L, top);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -102,7 +102,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ObjectRef::Register(L);
 	PlayerMetaRef::Register(L);
 	LuaSettings::Register(L);
-	StorageRef::Register(L);
+	LuaModMetadata::Register(L);
 	LuaModChannel::Register(L);
 
 	// Initialize mod api modules

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3154,7 +3154,7 @@ void Server::spawnParticle(const std::string &playername, v3f pos,
 			collision_removal, vertical, texture, animation, glow);
 }
 
-u32 Server::addParticleSpawner(u16 amount, float spawntime,
+s32 Server::addParticleSpawner(u16 amount, float spawntime,
 	v3f minpos, v3f maxpos, v3f minvel, v3f maxvel, v3f minacc, v3f maxacc,
 	float minexptime, float maxexptime, float minsize, float maxsize,
 	bool collisiondetection, bool collision_removal,

--- a/src/server.h
+++ b/src/server.h
@@ -232,7 +232,7 @@ public:
 		bool vertical, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	u32 addParticleSpawner(u16 amount, float spawntime,
+	s32 addParticleSpawner(u16 amount, float spawntime,
 		v3f minpos, v3f maxpos,
 		v3f minvel, v3f maxvel,
 		v3f minacc, v3f maxacc,


### PR DESCRIPTION
Backport a macro i used on another project permitting to standardize our Lua references

This is not possible on all objects but i hope at a point this will be possible :)

If merged, please use it for future LuaObject refs :)

Not all metadata are possible but maybe we can make all of them use it (some super objects are missing)

Note: the macro requires m_object Type and Lua class to be coherent "Lua[name]". Original it was "Lua[name]Ref" but MT isn't coherent in any model, i choose "Lua[name]". It can be changed