### PR TITLE
FOV: Raise lower limit to avoid zoom-loading distant world 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -567,7 +567,7 @@ fullscreen_bpp (Full screen BPP) int 24
 vsync (V-Sync) bool false
 
 #    Field of view in degrees.
-fov (Field of view) int 72 30 160
+fov (Field of view) int 72 45 160
 
 #    Adjust the gamma encoding for the light tables. Higher numbers are brighter.
 #    This setting is for the client only and is ignored by the server.

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -71,7 +71,9 @@ Camera::Camera(MapDrawControl &draw_control, Client *client):
 	 */
 	m_cache_fall_bobbing_amount = g_settings->getFloat("fall_bobbing_amount");
 	m_cache_view_bobbing_amount = g_settings->getFloat("view_bobbing_amount");
-	m_cache_fov                 = g_settings->getFloat("fov");
+	// 45 degrees is the lowest FOV that doesn't cause the server to treat this
+	// as a zoom FOV and load world beyond the set server limits.
+	m_cache_fov                 = std::fmax(g_settings->getFloat("fov"), 45.0f);
 	m_arm_inertia               = g_settings->getBool("arm_inertia");
 	m_nametags.clear();
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1473,3 +1473,8 @@ bool PlayerSAO::getSelectionBox(aabb3f *toset) const
 
 	return true;
 }
+
+float PlayerSAO::getZoomFOV() const
+{
+	return m_prop.zoom_fov;
+}

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -330,6 +330,7 @@ public:
 
 	v3f getEyePosition() const { return m_base_position + getEyeOffset(); }
 	v3f getEyeOffset() const;
+	float getZoomFOV() const;
 
 	inline Metadata &getMeta() { return m_meta; }
 


### PR DESCRIPTION
In the client, raise lower limit from 30 to 45 degrees, to avoid server
seeing this as a zoom and loading world beyond the server-set limit.
Add minimum in settingtypes.txt and enforce lower limit when set using
minetest.conf.

In the server, distrust the client-sent FOV if below the heuristic zoom
threshold and use the player object property 'zoom_fov' to check it, to
protect against hacked clients.
////////////

For #6991 
In clientiface.cpp in the server:
The client-sent FOV is checked against the heurisitc zoom threshold (see adjustDist() in numeric.cpp).
If below, the player object property 'zoom_fov' is checked to see if the player is allowed to zoom.
If it isn't, FOV is set to just above the heuristic zoom threshold.
If it is, FOV is set to the object property 'zoom_fov'.