### PR TITLE
Global new() or grab() to be managed in constuctor only (#7235 partial)

### DIFF
--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -501,6 +501,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);
 
+	FATAL_ERROR_IF(!g_extrusion_mesh_cache, "Extrusion mesh cache is not yet initialized");
+	
 	scene::SMesh *mesh = nullptr;
 
 	// Shading is on by default

--- a/src/wieldmesh.cpp
+++ b/src/wieldmesh.cpp
@@ -501,12 +501,6 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 	const ContentFeatures &f = ndef->get(def.name);
 	content_t id = ndef->getId(def.name);
 
-	if (!g_extrusion_mesh_cache) {
-		g_extrusion_mesh_cache = new ExtrusionMeshCache();
-	} else {
-		g_extrusion_mesh_cache->grab();
-	}
-
 	scene::SMesh *mesh = nullptr;
 
 	// Shading is on by default


### PR DESCRIPTION
Global g_extrusion_mesh_cache was getting grab()-ed by each call to getItemMesh, incrementing its reference  count. What was to be the final drop() in the destructor ended up with > 0 reference count, so memory not freed by Irrlicht.
Each additional instance of the class will increment the ref count on the global, but each of their destructors will decrement it, finally to zero with the last instance and allow Irrlicht to free the memory.