### PR TITLE
Biome API: Implement biome-defined air nodes

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -183,6 +183,7 @@ LOCAL_SRC_FILES := \
 		jni/src/mapgen/mapgen_carpathian.cpp      \
 		jni/src/mapgen/mapgen_flat.cpp            \
 		jni/src/mapgen/mapgen_fractal.cpp         \
+		jni/src/mapgen/mapgen_planet.cpp          \
 		jni/src/mapgen/mapgen_singlenode.cpp      \
 		jni/src/mapgen/mapgen_v5.cpp              \
 		jni/src/mapgen/mapgen_v6.cpp              \

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -710,6 +710,7 @@ core.nodedef_default = {
 	climbable = false,
 	buildable_to = false,
 	floodable = false,
+	air_equivalent = false,
 	liquidtype = "none",
 	liquid_alternative_flowing = "",
 	liquid_alternative_source = "",

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -365,7 +365,6 @@ core.register_node(":ignore", {
 	pointable = false,
 	diggable = false,
 	buildable_to = true, -- A way to remove accidentally placed ignores
-	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
 })

--- a/src/mapgen/CMakeLists.txt
+++ b/src/mapgen/CMakeLists.txt
@@ -5,6 +5,7 @@ set(mapgen_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_flat.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_fractal.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_planet.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_singlenode.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_v5.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapgen_v6.cpp

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -29,26 +29,20 @@ class GenerateNotifier;
 	web-like, continuous tunnels at points where the density of the intersection
 	between two separate 3d noises is above a certain value.  This value,
 	cave_width, can be modified to set the effective width of these tunnels.
-
-	This algorithm is relatively heavyweight, taking ~80ms to generate an
-	80x80x80 chunk of map on a modern processor.  Use sparingly!
-
-	TODO(hmmmm): Remove dependency on biomes
-	TODO(hmmmm): Find alternative to overgeneration as solution for sunlight issue
 */
 class CavesNoiseIntersection
 {
 public:
-	CavesNoiseIntersection(const NodeDefManager *nodedef,
-		BiomeManager *biomemgr, v3s16 chunksize, NoiseParams *np_cave1,
-		NoiseParams *np_cave2, s32 seed, float cave_width);
+	CavesNoiseIntersection(const NodeDefManager *nodedef, v3s16 chunksize,
+		NoiseParams *np_cave1, NoiseParams *np_cave2, s32 seed,
+		float cave_width, BiomeGen *biomegen);
 	~CavesNoiseIntersection();
 
-	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax, u8 *biomemap);
+	void generateCaves(MMVManip *vm, v3s16 nmin, v3s16 nmax);
 
 private:
 	const NodeDefManager *m_ndef;
-	BiomeManager *m_bmgr;
+	BiomeGen *m_bmgn;
 
 	// configurable parameters
 	v3s16 m_csize;
@@ -69,14 +63,15 @@ class CavernsNoise
 {
 public:
 	CavernsNoise(const NodeDefManager *nodedef, v3s16 chunksize,
-		NoiseParams *np_cavern, s32 seed, float cavern_limit,
-		float cavern_taper, float cavern_threshold);
+	NoiseParams *np_cavern, s32 seed, float cavern_limit, float cavern_taper,
+	float cavern_threshold, BiomeGen *biomegen);
 	~CavernsNoise();
 
 	bool generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax);
 
 private:
 	const NodeDefManager *m_ndef;
+	BiomeGen *m_bmgn;
 
 	// configurable parameters
 	v3s16 m_csize;
@@ -156,9 +151,9 @@ public:
 	// If gennotify is NULL, generation events are not logged.
 	// If biomegen is NULL, cave liquids have classic behaviour.
 	CavesRandomWalk(const NodeDefManager *ndef, GenerateNotifier *gennotify =
-		NULL, s32 seed = 0, int water_level = 1, content_t water_source =
+		nullptr, s32 seed = 0, int water_level = 1, content_t water_source =
 		CONTENT_IGNORE, content_t lava_source = CONTENT_IGNORE,
-		int lava_depth = -256, BiomeGen *biomegen = NULL);
+		int lava_depth = -256, BiomeGen *biomegen = nullptr);
 
 	// vm and ps are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -44,6 +44,7 @@ struct DungeonParams {
 	content_t c_wall;
 	content_t c_alt_wall;
 	content_t c_stair;
+	content_t c_air;
 
 	bool diagonal_dirs;
 	bool only_in_ground;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -110,6 +110,7 @@ enum MapgenType {
 	MAPGEN_VALLEYS,
 	MAPGEN_SINGLENODE,
 	MAPGEN_CARPATHIAN,
+	MAPGEN_PLANET,
 	MAPGEN_INVALID,
 };
 
@@ -256,12 +257,13 @@ protected:
 	v3s16 full_node_max;
 
 	// Content required for generateBiomes
+	content_t c_air;
 	content_t c_stone;
-	content_t c_desert_stone;
-	content_t c_sandstone;
 	content_t c_water_source;
 	content_t c_river_water_source;
 	content_t c_lava_source;
+	content_t c_desert_stone;
+	content_t c_sandstone;
 
 	// Content required for generateDungeons
 	content_t c_cobble;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -273,7 +273,8 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -207,7 +207,8 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -218,7 +218,8 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mapgen_planet.cpp
+++ b/src/mapgen/mapgen_planet.cpp
@@ -1,0 +1,282 @@
+/*
+Minetest
+Copyright (C) 2018 paramat
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+
+#include <cmath>
+#include "mapgen.h"
+#include "voxel.h"
+#include "noise.h"
+#include "mapblock.h"
+#include "mapnode.h"
+#include "map.h"
+#include "content_sao.h"
+#include "nodedef.h"
+#include "voxelalgorithms.h"
+//#include "profiler.h" // For TimeTaker
+#include "settings.h" // For g_settings
+#include "emerge.h"
+#include "dungeongen.h"
+#include "cavegen.h"
+#include "mg_biome.h"
+#include "mg_ore.h"
+#include "mg_decoration.h"
+#include "mapgen_planet.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MapgenPlanet::MapgenPlanet(
+		int mapgenid, MapgenPlanetParams *params, EmergeManager *emerge)
+	: MapgenBasic(mapgenid, params, emerge)
+{
+	spflags          = params->spflags;
+	cave_width       = params->cave_width;
+	large_cave_depth = params->large_cave_depth;
+	lava_depth       = params->lava_depth;
+	dungeon_ymin     = params->dungeon_ymin;
+	dungeon_ymax     = params->dungeon_ymax;
+
+	//// 2D Terrain noise
+	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
+
+	//// 3D terrain noise
+	// 1 up 1 down overgeneration
+	noise_terrain = new Noise(&params->np_terrain, seed, csize.X, csize.Y + 2, csize.Z);
+
+	//// Cave noise
+	MapgenBasic::np_cave1 = params->np_cave1;
+	MapgenBasic::np_cave2 = params->np_cave2;
+}
+
+
+MapgenPlanet::~MapgenPlanet()
+{
+	delete noise_filler_depth;
+	delete noise_terrain;
+}
+
+
+MapgenPlanetParams::MapgenPlanetParams():
+	np_filler_depth (0,  1.2, v3f(128, 128, 128), 261,   3, 0.7,  2.0),
+	np_terrain      (0,  1,   v3f(384, 192, 384), 1692,  5, 0.63, 2.0),
+	np_cave1        (0,  12,  v3f(61,  61,  61),  52534, 3, 0.5,  2.0),
+	np_cave2        (0,  12,  v3f(67,  67,  67),  10325, 3, 0.5,  2.0)
+{
+}
+
+
+void MapgenPlanetParams::readParams(const Settings *settings)
+{
+	settings->getFloatNoEx("mgplanet_cave_width",       cave_width);
+	settings->getS16NoEx("mgplanet_large_cave_depth",   large_cave_depth);
+	settings->getS16NoEx("mgplanet_lava_depth",         lava_depth);
+	settings->getS16NoEx("mgplanet_dungeon_ymin",       dungeon_ymin);
+	settings->getS16NoEx("mgplanet_dungeon_ymax",       dungeon_ymax);
+
+	settings->getNoiseParams("mgplanet_np_filler_depth", np_filler_depth);
+	settings->getNoiseParams("mgplanet_np_terrain",      np_terrain);
+	settings->getNoiseParams("mgplanet_np_cave1",        np_cave1);
+	settings->getNoiseParams("mgplanet_np_cave2",        np_cave2);
+}
+
+
+void MapgenPlanetParams::writeParams(Settings *settings) const
+{
+	settings->setFloat("mgplanet_cave_width",       cave_width);
+	settings->setS16("mgplanet_large_cave_depth",   large_cave_depth);
+	settings->setS16("mgplanet_lava_depth",         lava_depth);
+	settings->setS16("mgplanet_dungeon_ymin",       dungeon_ymin);
+	settings->setS16("mgplanet_dungeon_ymax",       dungeon_ymax);
+
+	settings->setNoiseParams("mgplanet_np_filler_depth", np_filler_depth);
+	settings->setNoiseParams("mgplanet_np_terrain",      np_terrain);
+	settings->setNoiseParams("mgplanetn_np_cave1",       np_cave1);
+	settings->setNoiseParams("mgplanet_np_cave2",        np_cave2);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MapgenPlanet::makeChunk(BlockMakeData *data)
+{
+	// Pre-conditions
+	assert(data->vmanip);
+	assert(data->nodedef);
+	assert(data->blockpos_requested.X >= data->blockpos_min.X &&
+			data->blockpos_requested.Y >= data->blockpos_min.Y &&
+			data->blockpos_requested.Z >= data->blockpos_min.Z);
+	assert(data->blockpos_requested.X <= data->blockpos_max.X &&
+			data->blockpos_requested.Y <= data->blockpos_max.Y &&
+			data->blockpos_requested.Z <= data->blockpos_max.Z);
+
+	this->generating = true;
+	this->vm = data->vmanip;
+	this->ndef = data->nodedef;
+
+	v3s16 blockpos_min = data->blockpos_min;
+	v3s16 blockpos_max = data->blockpos_max;
+	node_min = blockpos_min * MAP_BLOCKSIZE;
+	node_max = (blockpos_max + v3s16(1, 1, 1)) * MAP_BLOCKSIZE - v3s16(1, 1, 1);
+	full_node_min = (blockpos_min - 1) * MAP_BLOCKSIZE;
+	full_node_max = (blockpos_max + 2) * MAP_BLOCKSIZE - v3s16(1, 1, 1);
+
+	// Create a block-specific seed
+	blockseed = getBlockSeed2(full_node_min, seed);
+
+	// Generate terrain or air mapchunks
+	bool planet = true;
+	s16 stone_surface_max_y;
+
+	if (node_min.X < -192 ||
+			node_min.X > 128 ||
+			node_min.Y < -192 ||
+			node_min.Y > 128 ||
+			node_min.Z < -192 ||
+			node_min.Z > 128) {
+		stone_surface_max_y = generateAir();
+		planet = false;
+	} else {
+		stone_surface_max_y = generateTerrain();
+	}
+
+	// Create heightmap
+	if (planet)
+		updateHeightmap(node_min, node_max);
+
+	// Init biome generator, place biome-specific nodes, and build biomemap
+	biomegen->calcBiomeNoise(node_min);
+	generateBiomes();
+
+	if (planet) {
+		// Generate caverns, tunnels and classic caves
+		if (flags & MG_CAVES)
+			generateCaves(stone_surface_max_y, large_cave_depth);
+
+		// Generate dungeons
+		if ((flags & MG_DUNGEONS) &&
+				full_node_min.Y >= dungeon_ymin &&
+				full_node_max.Y <= dungeon_ymax)
+			generateDungeons(stone_surface_max_y);
+
+		// Generate the registered decorations
+		if (flags & MG_DECORATIONS)
+			m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+				ndef);
+
+		// Generate the registered ores
+		m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
+		// Sprinkle some dust on top after everything else was generated
+		dustTopNodes();
+
+		// Update liquids
+		updateLiquid(&data->transforming_liquid, full_node_min, full_node_max);
+	}
+
+	// Calculate lighting
+	if (flags & MG_LIGHT) {
+		// Avoid darkness on planet side
+		if (!planet)
+			setLighting(LIGHT_SUN,
+				node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0));
+
+		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
+				full_node_min, full_node_max, planet);
+	}
+
+	this->generating = false;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+int MapgenPlanet::getSpawnLevelAtPoint(v2s16 p)
+{
+	if (p.X < -192 ||
+			p.X > 207 ||
+			p.Y < -192 ||
+			p.Y > 207 )
+		return MAX_MAP_GENERATION_LIMIT; // Unsuitable spawn point
+
+	return 128;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+int MapgenPlanet::generateAir()
+{
+	MapNode mn_air(c_air);
+
+	for (s16 z = node_min.Z; z <= node_max.Z; z++)
+	for (s16 y = node_min.Y; y <= node_max.Y; y++) {
+		u32 vi = vm->m_area.index(node_min.X, y, z);
+		for (s16 x = node_min.X; x <= node_max.X; x++, vi++) {
+			vm->m_data[vi] = mn_air;
+		}
+	}
+
+	return -MAX_MAP_GENERATION_LIMIT;
+}
+
+
+int MapgenPlanet::generateTerrain()
+{
+	MapNode mn_air(c_air);
+	MapNode mn_stone(c_stone);
+	MapNode mn_water(c_water_source);
+
+	// Calculate noise for terrain generation
+	noise_terrain->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
+
+	//// Place nodes
+	s16 stone_surface_max_y = -MAX_MAP_GENERATION_LIMIT;
+	u32 index3d = 0;
+
+	for (s16 z = node_min.Z; z <= node_max.Z; z++)
+	for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
+		u32 vi = vm->m_area.index(node_min.X, y, z);
+		for (s16 x = node_min.X; x <= node_max.X; x++, index3d++, vi++) {
+			if (vm->m_data[vi].getContent() != CONTENT_IGNORE)
+				continue;
+
+			float n_terrain = noise_terrain->result[index3d];
+			float den_grad = (y >= 5) ?
+				(float)(5 - y) / 96.0f :
+				(float)(5 - y) / 32.0f;
+			float density = n_terrain + den_grad;
+
+			if (density > 0.0f) {
+				vm->m_data[vi] = mn_stone; // Stone
+				if (y > stone_surface_max_y)
+					stone_surface_max_y = y;
+			} else if (y <= water_level) {
+				vm->m_data[vi] = mn_water; // Sea water
+			} else {
+				vm->m_data[vi] = mn_air; // Air
+			}
+		}
+	}
+
+	return stone_surface_max_y;
+}

--- a/src/mapgen/mapgen_planet.h
+++ b/src/mapgen/mapgen_planet.h
@@ -1,0 +1,72 @@
+/*
+Minetest
+Copyright (C) 2018 paramat
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "mapgen.h"
+
+class BiomeManager;
+
+extern FlagDesc flagdesc_mapgen_planet[];
+
+
+struct MapgenPlanetParams : public MapgenParams
+{
+	u32 spflags            = 0;
+	float cave_width       = 0.09f;
+	s16 large_cave_depth   = -33;
+	s16 lava_depth         = -33;
+	s16 dungeon_ymin       = -31000;
+	s16 dungeon_ymax       = 31000;
+
+	NoiseParams np_filler_depth;
+	NoiseParams np_terrain;
+	NoiseParams np_cave1;
+	NoiseParams np_cave2;
+
+	MapgenPlanetParams();
+	~MapgenPlanetParams() = default;
+
+	void readParams(const Settings *settings);
+	void writeParams(Settings *settings) const;
+};
+
+
+class MapgenPlanet : public MapgenBasic
+{
+public:
+	MapgenPlanet(int mapgenid, MapgenPlanetParams *params,
+			EmergeManager *emerge);
+	~MapgenPlanet();
+
+	virtual MapgenType getType() const { return MAPGEN_PLANET; }
+
+	virtual void makeChunk(BlockMakeData *data);
+	int getSpawnLevelAtPoint(v2s16 p);
+
+private:
+	s16 large_cave_depth;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
+
+	Noise *noise_terrain;
+
+	int generateAir();
+	int generateTerrain();
+};

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -232,7 +232,8 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -620,7 +620,8 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -255,7 +255,8 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
-		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
+		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max,
+			ndef);
 
 	// Generate the registered ores
 	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -66,6 +66,7 @@ BiomeManager::BiomeManager(Server *server) :
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
+	b->m_nodenames.emplace_back("mapgen_air");
 	m_ndef->pendNodeResolve(b);
 
 	add(b);
@@ -329,4 +330,5 @@ void Biome::resolveNodeNames()
 	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE);
 	getIdFromNrBacklog(&c_dungeon_alt,   "ignore",                    CONTENT_IGNORE);
 	getIdFromNrBacklog(&c_dungeon_stair, "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_air,           "mapgen_air",                CONTENT_AIR);
 }

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -56,6 +56,7 @@ public:
 	content_t c_dungeon;
 	content_t c_dungeon_alt;
 	content_t c_dungeon_stair;
+	content_t c_air;
 
 	s16 depth_top;
 	s16 depth_filler;

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -56,9 +56,11 @@ public:
 	virtual void resolveNodeNames();
 
 	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
-	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax,
+		const NodeDefManager *nodedef);
 
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling) = 0;
+	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling,
+		const NodeDefManager *nodedef) = 0;
 
 	u32 flags = 0;
 	int mapseed = 0;
@@ -79,7 +81,8 @@ public:
 class DecoSimple : public Decoration {
 public:
 	virtual void resolveNodeNames();
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
+	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling,
+		const NodeDefManager *nodedef);
 
 	std::vector<content_t> c_decos;
 	s16 deco_height;
@@ -93,7 +96,8 @@ class DecoSchematic : public Decoration {
 public:
 	DecoSchematic() = default;
 
-	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling);
+	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling,
+		const NodeDefManager *nodedef);
 
 	Rotation rotation;
 	Schematic *schematic = nullptr;
@@ -132,5 +136,6 @@ public:
 		}
 	}
 
-	size_t placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+	size_t placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax,
+		const NodeDefManager *nodedef);
 };

--- a/src/mapgen/mg_schematic.cpp
+++ b/src/mapgen/mg_schematic.cpp
@@ -152,7 +152,7 @@ void Schematic::blitToVManip(MMVManip *vm, v3s16 p, Rotation rot, bool force_pla
 
 				if (!force_place && !force_place_node) {
 					content_t c = vm->m_data[vi].getContent();
-					if (c != CONTENT_AIR && c != CONTENT_IGNORE)
+					if (!m_ndef->get(c).air_equivalent && c != CONTENT_IGNORE)
 						continue;
 				}
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -188,6 +188,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Nodebox version 5
 		Add disconnected nodeboxes
 		Add TOCLIENT_FORMSPEC_PREPEND
+		Add 'air_equivalent' to ContentFeatures
 */
 
 #define LATEST_PROTOCOL_VERSION 36

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -389,6 +389,7 @@ void ContentFeatures::reset()
 	buildable_to = false;
 	floodable = false;
 	rightclickable = true;
+	air_equivalent = false;
 	leveled = 0;
 	liquid_type = LIQUID_NONE;
 	liquid_alternative_flowing = "";
@@ -488,6 +489,9 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, liquid_range);
 	writeU8(os, drowning);
 	writeU8(os, floodable);
+
+	// CONTENT_AIR equivalence
+	writeU8(os, air_equivalent);
 
 	// node boxes
 	node_box.serialize(os, protocol_version);
@@ -598,6 +602,9 @@ void ContentFeatures::deSerialize(std::istream &is)
 	liquid_range = readU8(is);
 	drowning = readU8(is);
 	floodable = readU8(is);
+
+	// CONTENT_AIR equivalence
+	air_equivalent = readU8(is);	
 
 	// node boxes
 	node_box.deSerialize(is);
@@ -998,6 +1005,7 @@ void NodeDefManager::clear()
 		f.buildable_to        = true;
 		f.floodable           = true;
 		f.is_ground_content   = true;
+		f.air_equivalent      = true;
 		// Insert directly into containers
 		content_t c = CONTENT_AIR;
 		m_content_features[c] = f;

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -376,6 +376,11 @@ struct ContentFeatures
 	// Liquids flow into and replace node
 	bool floodable;
 
+	// --- CONTENT_AIR EQUIVALENCE ---
+
+	// Node is treated like CONTENT_AIR. Used for biome-defined air nodes
+	bool air_equivalent;
+
 	// --- NODEBOXES ---
 
 	NodeBox node_box;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -653,6 +653,8 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	getboolfield(L, index, "buildable_to", f.buildable_to);
 	// Liquids flow into and replace node
 	getboolfield(L, index, "floodable", f.floodable);
+	// Node is treated like CONTENT_AIR. Used for biome-defined air nodes
+	getboolfield(L, index, "air_equivalent", f.air_equivalent);
 	// Whether the node is non-liquid, source liquid or flowing liquid
 	f.liquid_type = (LiquidType)getenumfield(L, index, "liquidtype",
 			ScriptApiNode::es_LiquidType, LIQUID_NONE);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -409,6 +409,7 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	nn.push_back(getstringfield_default(L, index, "node_dungeon",       ""));
 	nn.push_back(getstringfield_default(L, index, "node_dungeon_alt",   ""));
 	nn.push_back(getstringfield_default(L, index, "node_dungeon_stair", ""));
+	nn.push_back(getstringfield_default(L, index, "node_air",           ""));
 	ndef->pendNodeResolve(b);
 
 	return b;
@@ -1527,7 +1528,7 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+	emerge->decomgr->placeAllDecos(&mg, blockseed, pmin, pmax, mg.ndef);
 
 	return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3368,7 +3368,7 @@ v3f Server::findSpawnPos()
 			v3s16 blockpos = getNodeBlockPos(nodepos);
 			map.emergeBlock(blockpos, true);
 			content_t c = map.getNodeNoEx(nodepos).getContent();
-			if (c == CONTENT_AIR || c == CONTENT_IGNORE) {
+			if (m_nodedef->get(c).air_equivalent || c == CONTENT_IGNORE) {
 				air_count++;
 				if (air_count >= 2) {
 					nodeposf = intToFloat(nodepos, BS);


### PR DESCRIPTION
WIP in long-term development and testing.
For #5725 
If this is approved i will create new PRs rebased on master, as rebasing all this will be not worth it.
This is not for 5.0.0, too big and potentially problematic for such a near release.

* Nodedef:
Resurrect 'air_equivalent = bool' nodedef actually stated for "air" but not used anywhere. This is used for nodes that should be treated by the engine like "air" is now. Using "airlike" drawtype for this purpose is not ideal as visible nodes are also wanted.
* Record the new field in network protocol.

////////////////
* General mapgen:
Add "mapgen_air" alias as the 4th base terrain node, falls back to "air" to not break games.
* Mapgens:
Place the new base terrain node "mapgen_air" instead of hardcoded "air".
Avoid overgeneration removing biome-defined air.
* Biomes:
Add "node_air" field as the new biome-defined air node.
* Biome generation:
Detect this new base terrain node and place biome-defined air nodes.
Update dust placement.
* Decorations:
Allow simple decorations to be placed in 'air_equivalent' without using forced placement.
* Schematic decorations:
Allow schematic nodes to be placed in 'air_equivalent' without using forced placement.
* Cavegen:
For tunnels and caverns: Make generation similar to biome generation. calculating biome at node resolution and placing the biome-defined air nodes when excavating.
For large randomwalk caves: The biome for each cave segment is already calculated for biome-defined cave liquids, for each segment place the biome-defined air node when excavating.
* Dungeons:
The biome for each dungeon is already calculated for biome-defined dungeon nodes, place the biome-defined air node when excavating the rooms and corridors.

///////////////////
* Player spawn:
Allow player to spawn in 'air_equivalent' nodes. 
* Liquid processing:
When a flowing liquid disappears from a node due to source removal replace with any detected 'air_equivalent' face-connected neighbour node. If none fallback to "air".
* Dug nodes and minetest.remove_node():
Replace with any detected 'air_equivalent' face-connected neighbour node. If none fallback to "air".

////////////////////
* Add a planetoid core mapgen for testing biome air / space mapgen issues. Not for merging.