### PR TITLE
PlayerSettings struct for player movement code

### DIFF
--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -191,11 +191,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		return;
 	}
 
+	PlayerSettings &player_settings = getPlayerSettings();
+
 	// Skip collision detection if noclip mode is used
 	bool fly_allowed = m_client->checkLocalPrivilege("fly");
-	bool noclip = m_client->checkLocalPrivilege("noclip") &&
-		g_settings->getBool("noclip");
-	bool free_move = g_settings->getBool("free_move") && fly_allowed;
+	bool noclip = m_client->checkLocalPrivilege("noclip") && player_settings.noclip;
+	bool free_move = player_settings.free_move && fly_allowed;
 
 	if (noclip && free_move) {
 		position += m_speed * dtime;
@@ -479,6 +480,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		return;
 	}
 
+	PlayerSettings &player_settings = getPlayerSettings();
+
 	v3f move_direction = v3f(0,0,1);
 	move_direction.rotateXZBy(getYaw());
 
@@ -488,12 +491,12 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	bool fly_allowed = m_client->checkLocalPrivilege("fly");
 	bool fast_allowed = m_client->checkLocalPrivilege("fast");
 
-	bool free_move = fly_allowed && g_settings->getBool("free_move");
-	bool fast_move = fast_allowed && g_settings->getBool("fast_move");
+	bool free_move = fly_allowed && player_settings.free_move;
+	bool fast_move = fast_allowed && player_settings.fast_move;
 	// When aux1_descends is enabled the fast key is used to go down, so fast isn't possible
-	bool fast_climb = fast_move && control.aux1 && !g_settings->getBool("aux1_descends");
-	bool continuous_forward = g_settings->getBool("continuous_forward");
-	bool always_fly_fast = g_settings->getBool("always_fly_fast");
+	bool fast_climb = fast_move && control.aux1 && !player_settings.aux1_descends;
+	bool continuous_forward = player_settings.continuous_forward;
+	bool always_fly_fast = player_settings.always_fly_fast;
 
 	// Whether superspeed mode is used or not
 	bool superspeed = false;
@@ -502,7 +505,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		superspeed = true;
 
 	// Old descend control
-	if(g_settings->getBool("aux1_descends"))
+	if (player_settings.aux1_descends)
 	{
 		// If free movement and fast movement, always move fast
 		if(free_move && fast_move)
@@ -610,7 +613,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	if(control.jump)
 	{
 		if (free_move) {
-			if (g_settings->getBool("aux1_descends") || always_fly_fast) {
+			if (player_settings.aux1_descends || always_fly_fast) {
 				if (fast_move)
 					speedV.Y = movement_speed_fast;
 				else
@@ -773,11 +776,12 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		return;
 	}
 
+	PlayerSettings &player_settings = getPlayerSettings();
+
 	// Skip collision detection if noclip mode is used
 	bool fly_allowed = m_client->checkLocalPrivilege("fly");
-	bool noclip = m_client->checkLocalPrivilege("noclip") &&
-		g_settings->getBool("noclip");
-	bool free_move = noclip && fly_allowed && g_settings->getBool("free_move");
+	bool noclip = m_client->checkLocalPrivilege("noclip") && player_settings.noclip;
+	bool free_move = noclip && fly_allowed && player_settings.free_move;
 	if (free_move) {
 		position += m_speed * dtime;
 		setPosition(position);
@@ -859,7 +863,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		fall off from it
 	*/
 	if (control.sneak && m_sneak_node_exists &&
-			!(fly_allowed && g_settings->getBool("free_move")) && !in_liquid &&
+			!(fly_allowed && player_settings.free_move) && !in_liquid &&
 			physics_override_sneak) {
 		f32 maxd = 0.5 * BS + sneak_max;
 		v3f lwn_f = intToFloat(m_sneak_node, BS);
@@ -1003,7 +1007,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		Report collisions
 	*/
 	// Dont report if flying
-	if (collision_info && !(g_settings->getBool("free_move") && fly_allowed)) {
+	if (collision_info && !(player_settings.free_move && fly_allowed)) {
 		for (const auto &info : result.collisions) {
 			collision_info->push_back(info);
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -74,6 +74,20 @@ Player::Player(const char *name, IItemDefManager *idef):
 		HUD_FLAG_MINIMAP_RADAR_VISIBLE;
 
 	hud_hotbar_itemcount = HUD_HOTBAR_ITEMCOUNT_DEFAULT;
+
+	m_player_settings.readGlobalSettings();
+	g_settings->registerChangedCallback("free_move", &Player::settingsChangedCallback,
+			&m_player_settings);
+	g_settings->registerChangedCallback("fast_move", &Player::settingsChangedCallback,
+			&m_player_settings);
+	g_settings->registerChangedCallback("continuous_forward",
+			&Player::settingsChangedCallback, &m_player_settings);
+	g_settings->registerChangedCallback("always_fly_fast",
+			&Player::settingsChangedCallback, &m_player_settings);
+	g_settings->registerChangedCallback("aux1_descends",
+			&Player::settingsChangedCallback, &m_player_settings);
+	g_settings->registerChangedCallback(
+			"noclip", &Player::settingsChangedCallback, &m_player_settings);
 }
 
 Player::~Player()
@@ -125,4 +139,19 @@ void Player::clearHud()
 		delete hud.back();
 		hud.pop_back();
 	}
+}
+
+void PlayerSettings::readGlobalSettings()
+{
+	free_move = g_settings->getBool("free_move");
+	fast_move = g_settings->getBool("fast_move");
+	continuous_forward = g_settings->getBool("continuous_forward");
+	always_fly_fast = g_settings->getBool("always_fly_fast");
+	aux1_descends = g_settings->getBool("aux1_descends");
+	noclip = g_settings->getBool("noclip");
+}
+
+void Player::settingsChangedCallback(const std::string &name, void *data)
+{
+	((PlayerSettings *)data)->readGlobalSettings();
 }

--- a/src/player.h
+++ b/src/player.h
@@ -84,6 +84,18 @@ struct PlayerControl
 	float forw_move_joystick_axis = 0.0f;
 };
 
+struct PlayerSettings
+{
+	bool free_move = false;
+	bool fast_move = false;
+	bool continuous_forward = false;
+	bool always_fly_fast = false;
+	bool aux1_descends = false;
+	bool noclip = false;
+
+	void readGlobalSettings();
+};
+
 class Map;
 struct CollisionInfo;
 struct HudElement;
@@ -152,6 +164,8 @@ public:
 
 	PlayerControl control;
 	const PlayerControl& getPlayerControl() { return control; }
+	PlayerSettings &getPlayerSettings() { return m_player_settings; }
+	static void settingsChangedCallback(const std::string &name, void *data);
 
 	u32 keyPressed = 0;
 
@@ -172,4 +186,5 @@ private:
 	// hud for example can be modified by EmergeThread
 	// and ServerThread
 	std::mutex m_mutex;
+	PlayerSettings m_player_settings;
 };


### PR DESCRIPTION
Instead of calling `g_settings->getBool("flag")` multiple times during each movement step, the current settings are cached in a new player object member. Updated via registered callbacks.

This PR is a response to change requirements in PR #7228 and PR #7220 . Once this PR is accepted, I'll be able to adapt those two PRs to use this mechanism (actually, this mechanism is partly lifted from #7220).

Those two PRs in turn are my personal prerequsites for continuing on / rebasing PR #6219 , which has become too large and unmanagable.