### PR TITLE
Cavegen: Fix variable typo that broke mgvalleys large cave distribution

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -355,7 +355,7 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 
 	route_y_min = 0;
 	// Allow half a diameter + 7 over stone surface
-	route_y_max = -of.Y + max_stone_y + max_tunnel_diameter / 2 + 7;
+	route_y_max = -of.Y + max_stone_height + max_tunnel_diameter / 2 + 7;
 
 	// Limit maximum to area
 	route_y_max = rangelim(route_y_max, 0, ar.Y - 1);

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -134,7 +134,6 @@ public:
 	bool large_cave_is_flat;
 	bool flooded;
 
-	s16 max_stone_y;
 	v3s16 node_min;
 	v3s16 node_max;
 


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/pull/7244#issuecomment-381832940
'max_stone_y' did not match the function argument 'max_stone_height', see the same line in `CavesV6::makeCave()` which does match the function argument:
https://github.com/minetest/minetest/blob/574dab5c1195f7ce30cf9b59950a229a953fd59f/src/mapgen/cavegen.cpp#L676
`max_stone_y` still worked and didn't cause a compile error somehow, maybe because it is present here:
https://github.com/minetest/minetest/blob/574dab5c1195f7ce30cf9b59950a229a953fd59f/src/mapgen/cavegen.h#L137
And here:
https://github.com/minetest/minetest/blob/574dab5c1195f7ce30cf9b59950a229a953fd59f/src/mapgen/mapgen.cpp#L827
So mgvalleys large caves were broken all this time.