### PR TITLE
Add function `minetest.read_schematic`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4743,6 +4743,18 @@ Schematics
           the Lua code generated will use that number of spaces as indentation
           instead of a tab character.
 
+* `minetest.read_schematic(schematic, options)`
+    * Returns a Lua table representing the schematic (see: [Schematic specifier])
+    * `schematic` is the schematic to read (see: [Schematic specifier])
+    * `options` is a table containing the following optional parameters:
+        * `write_yslice_prob`: string value:
+            * `none`: no `write_yslice_prob` table is inserted,
+            * `low`: only probabilities that are not 254 or 255 are written in
+              the `write_ylisce_prob` table,
+            * `all`: write all probabilities to the `write_yslice_prob` table.
+            * The default for this option is `all`.
+            * Any invalid value will be interpreted as `all`.
+
 HTTP Requests
 -------------
 

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -131,6 +131,9 @@ private:
 	// serialize_schematic(schematic, format, options={...})
 	static int l_serialize_schematic(lua_State *L);
 
+	// read_schematic(schematic, options={...})
+	static int l_read_schematic(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 


### PR DESCRIPTION
Implementation for issue https://github.com/minetest/minetest/issues/7247.

This pull request adds a `minetest.read_schematic` API function that reads a schematic and returns a Lua table describing it (in Schematic specifier format).

The input schematic can be in any format, but the function seems especially useful when used with a path to an MTS file as schematic.