### PR TITLE
Builtin auth handler: Speed up file writing

### DIFF
--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -42,13 +42,13 @@ local function save_auth_file()
 		assert(type(stuff.privileges) == "table")
 		assert(stuff.last_login == nil or type(stuff.last_login) == "number")
 	end
-	local content = ""
+	local content = {}
 	for name, stuff in pairs(auth_table) do
 		local priv_string = core.privs_to_string(stuff.privileges)
 		local parts = {name, stuff.password, priv_string, stuff.last_login or ""}
-		content = content .. table.concat(parts, ":") .. "\n"
+		content[#content + 1] = table.concat(parts, ":")
 	end
-	if not core.safe_file_write(auth_file_path, content) then
+	if not core.safe_file_write(auth_file_path, table.concat(content, "\n")) then
 		error(auth_file_path.." could not be written to")
 	end
 end


### PR DESCRIPTION
String concat is ridiculous slow, whereas table concat results in some interesting speed benefits. Our auth saving system uses the first method, thus it doesn't surprise that there are lag spikes on each save cycle.

**Concept testing mod**
```Lua
local modpath = minetest.get_modpath(minetest.get_current_modname())
local data

local function profile(name, func)
	local t0 = minetest.get_us_time()
	func()
	local t1 = minetest.get_us_time()
	print("Function " .. name .. " took " ..
		math.floor((t1 - t0) / 1000 + 0.5) .. " ms")
end

local function generate_PlainText()
	data = {}
	for i = 1, 10E3 do
		local pos = {
			x = math.floor(math.random() * 1000 - 500),
			y = math.floor(math.random() * 1000 - 500),
			z = math.floor(math.random() * 1000 - 500)
		}
		data[pos.x..","..pos.y..","..pos.z] = "some data" .. i
	end
end

local function save_StringConcat()
	for i = 1, 10 do
		local contents = ""
		for pos, dat in pairs(data) do
			contents = contents .. pos .. " " .. "singleplayer" .. " " .. dat .. "\n"
		end
		minetest.safe_file_write(modpath .. "/dump2.dat", contents)
		collectgarbage()
		print("Loop " .. i)
	end
end

local function save_TableConcat()
	for i = 1, 10 do
		local contents = {}
		for pos, dat in pairs(data) do
			contents[#contents + 1] = pos .. " " .. "singleplayer" .. " " .. dat
		end
		minetest.safe_file_write(modpath .. "/dump2.dat", table.concat(contents, "\n"))
		collectgarbage()
		print("Loop " .. i)
	end
end

profile("generate   ", generate_PlainText)
profile("save string", save_StringConcat)
profile("save table ", save_TableConcat)
```

**Test results using LuaJIT**
```
Function generate    took 36 ms
Loop 1
<snip>
Loop 10
Function save string took 18923 ms
Loop 1
<snip>
Loop 10
Function save table  took 151 ms
```
May be interesting in combination with #7248