### PR TITLE
Node resolver: Make error on fallback optional, disable for mapgen aliases

### DIFF
--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -317,16 +317,16 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 
 void Biome::resolveNodeNames()
 {
-	getIdFromNrBacklog(&c_top,           "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_filler,        "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_stone,         "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_water_top,     "mapgen_water_source",       CONTENT_AIR);
-	getIdFromNrBacklog(&c_water,         "mapgen_water_source",       CONTENT_AIR);
-	getIdFromNrBacklog(&c_river_water,   "mapgen_river_water_source", CONTENT_AIR);
-	getIdFromNrBacklog(&c_riverbed,      "mapgen_stone",              CONTENT_AIR);
-	getIdFromNrBacklog(&c_dust,          "ignore",                    CONTENT_IGNORE);
-	getIdFromNrBacklog(&c_cave_liquid,   "ignore",                    CONTENT_IGNORE);
-	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE);
-	getIdFromNrBacklog(&c_dungeon_alt,   "ignore",                    CONTENT_IGNORE);
-	getIdFromNrBacklog(&c_dungeon_stair, "ignore",                    CONTENT_IGNORE);
+	getIdFromNrBacklog(&c_top,           "mapgen_stone",              CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_filler,        "mapgen_stone",              CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_stone,         "mapgen_stone",              CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_water_top,     "mapgen_water_source",       CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_water,         "mapgen_water_source",       CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_river_water,   "mapgen_river_water_source", CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_riverbed,      "mapgen_stone",              CONTENT_AIR,    false);
+	getIdFromNrBacklog(&c_dust,          "ignore",                    CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&c_cave_liquid,   "ignore",                    CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&c_dungeon_alt,   "ignore",                    CONTENT_IGNORE, false);
+	getIdFromNrBacklog(&c_dungeon_stair, "ignore",                    CONTENT_IGNORE, false);
 }

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1621,7 +1621,7 @@ void NodeResolver::nodeResolveInternal()
 
 
 bool NodeResolver::getIdFromNrBacklog(content_t *result_out,
-	const std::string &node_alt, content_t c_fallback)
+	const std::string &node_alt, content_t c_fallback, bool error_on_fallback)
 {
 	if (m_nodenames_idx == m_nodenames.size()) {
 		*result_out = c_fallback;
@@ -1639,8 +1639,9 @@ bool NodeResolver::getIdFromNrBacklog(content_t *result_out,
 	}
 
 	if (!success) {
-		errorstream << "NodeResolver: failed to resolve node name '" << name
-			<< "'." << std::endl;
+		if (error_on_fallback)
+			errorstream << "NodeResolver: failed to resolve node name '" << name
+				<< "'." << std::endl;
 		c = c_fallback;
 	}
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -733,9 +733,10 @@ public:
 	virtual void resolveNodeNames() = 0;
 
 	bool getIdFromNrBacklog(content_t *result_out,
-		const std::string &node_alt, content_t c_fallback);
+		const std::string &node_alt, content_t c_fallback,
+		bool error_on_fallback = true);
 	bool getIdsFromNrBacklog(std::vector<content_t> *result_out,
-		bool all_required=false, content_t c_fallback=CONTENT_IGNORE);
+		bool all_required = false, content_t c_fallback = CONTENT_IGNORE);
 
 	void nodeResolveInternal();
 


### PR DESCRIPTION
For #1840 
Many games leave out some mapgen aliases, which is fine and should not print an error. Disable the error when resolving mapgen aliases only.
Tested by removing all mapgen aliases from a game.
@rubenwardy 