### PR TITLE
"static constexpr v3s16 light_dirs[8]" fails to compile.

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -43,7 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Corresponding offsets are listed in g_27dirs
 #define FRAMED_NEIGHBOR_COUNT 18
 
-static constexpr v3s16 light_dirs[8] = {
+static const v3s16 light_dirs[8] = {
 	v3s16(-1, -1, -1),
 	v3s16(-1, -1,  1),
 	v3s16(-1,  1, -1),


### PR DESCRIPTION
Sync it with master branch.