### PR TITLE
Dungeons: Mostly fix missing stair nodes 

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -431,8 +431,10 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 					VMANIP_FLAG_DUNGEON_UNTOUCHABLE,
 					MapNode(dp.c_wall),
 					0);
-				makeHole(p);
-				makeHole(p - dir);
+				makeFill(p, dp.holesize, VMANIP_FLAG_DUNGEON_UNTOUCHABLE,
+					MapNode(CONTENT_AIR), VMANIP_FLAG_DUNGEON_INSIDE);
+				makeFill(p - dir, dp.holesize, VMANIP_FLAG_DUNGEON_UNTOUCHABLE,
+					MapNode(CONTENT_AIR), VMANIP_FLAG_DUNGEON_INSIDE);
 
 				// TODO: fix stairs code so it works 100%
 				// (quite difficult)
@@ -451,16 +453,21 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 					v3s16 swv = (dir.Z != 0) ? v3s16(1, 0, 0) : v3s16(0, 0, 1);
 
 					for (u16 st = 0; st < stair_width; st++) {
-						u32 vi = vm->m_area.index(ps.X - dir.X, ps.Y - 1, ps.Z - dir.Z);
-						if (vm->m_area.contains(ps + v3s16(-dir.X, -1, -dir.Z)) &&
-								vm->m_data[vi].getContent() == dp.c_wall)
-							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
-
-						vi = vm->m_area.index(ps.X, ps.Y, ps.Z);
-						if (vm->m_area.contains(ps) &&
-								vm->m_data[vi].getContent() == dp.c_wall)
-							vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
-
+						if (make_stairs == -1) {
+							u32 vi = vm->m_area.index(ps.X - dir.X, ps.Y - 1, ps.Z - dir.Z);
+							if (vm->m_area.contains(ps + v3s16(-dir.X, -1, -dir.Z)) &&
+									vm->m_data[vi].getContent() == dp.c_wall) {
+								vm->m_flags[vi] |= VMANIP_FLAG_DUNGEON_UNTOUCHABLE;
+								vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
+							}
+						} else if (make_stairs == 1) {
+							u32 vi = vm->m_area.index(ps.X, ps.Y - 1, ps.Z);
+							if (vm->m_area.contains(ps + v3s16(0, -1, 0)) &&
+									vm->m_data[vi].getContent() == dp.c_wall) {
+								vm->m_flags[vi] |= VMANIP_FLAG_DUNGEON_UNTOUCHABLE;
+								vm->m_data[vi] = MapNode(dp.c_stair, 0, facedir);
+							}
+						}
 						ps += swv;
 					}
 				}


### PR DESCRIPTION
Attends to a very long lived (at least 5 years, probably longer) bug.
Code cleanup (long lines and optimisations) will come later.

Previously stair nodes only appeared with a success of less than 50% and only in corridors rising in 2 directions. 2-node wide corridors often had stair nodes only appearing on one side only.

First i set the 'untouchable' flag for any stair nodes placed to preserve them, as i suspected they were being removed by dungeon air or wall placement.
The air placement code in `makeCorridor()` was altered to avoid removing 'untouchable' nodes.

Then after much experimentation i saw that one of the stair nodes was being placed in a useless place, moving it down 1 node and adding conditionals fixed most stairs.
Now stairs appear with an overall success of around 80%. 100% in many dungeons.

In testing you will still find stair weirdness but it is much improved compared to before.