### PR TITLE
Player physics modifiers

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5141,7 +5141,25 @@ This is basically a reference to a C++ `ServerActiveObject`
   keys.
     * bit nr/meaning: 0/up, 1/down, 2/left, 3/right, 4/jump, 5/aux1, 6/sneak,
       7/LMB, 8/RMB
-* `set_physics_override(override_table)`
+* `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
+   the player under the given key. Values from all modifiers apply to the player
+   cumulatively.
+   * `key_string`: A string key identifying this modifier. Should take the format
+     "modname:modifier_name".
+   * `modifier_table`: a table with the following fields:
+        * `speed`: multiplier to default walking speed value (default: `1`)
+        * `jump`: multiplier to default jump value (default: `1`)
+        * `gravity`: multiplier to default gravity value (default: `1`)
+        * `sneak`: whether player can sneak (default: `true`)
+        * `sneak_glitch`: whether player can use the new move code replications
+          of the old sneak side-effects: sneak ladders and 2 node sneak jump
+          (default: `false`)
+* `delete_physics_modifier(key_string)`: Removes the physics modifier set with
+  `set_physics_modifier` using key `key_string`.
+* `set_physics_override(override_table)`: Overrides the player's movement physics
+  parameters and disables physics modifiers. After calling this function on a
+  player, only this function will be able to change that player's physics
+  parameters.
     * `override_table` is a table with the following fields:
         * `speed`: multiplier to default walking speed value (default: `1`)
         * `jump`: multiplier to default jump value (default: `1`)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5142,8 +5142,10 @@ This is basically a reference to a C++ `ServerActiveObject`
     * bit nr/meaning: 0/up, 1/down, 2/left, 3/right, 4/jump, 5/aux1, 6/sneak,
       7/LMB, 8/RMB
 * `set_physics_modifier(key_string, modifier_table)`: Adds a physics modifier to
-   the player under the given key. Values from all modifiers apply to the player
-   cumulatively.
+   the player under the given key. For multipliers, the product of the
+   multipliers from each physics modifier applies. For boolean values, players
+   start with the default value, but get the non-default value if any physics
+   modifier sets it to the non-default value.
    * `key_string`: A string key identifying this modifier. Should take the format
      "modname:modifier_name".
    * `modifier_table`: a table with the following fields:
@@ -5160,14 +5162,7 @@ This is basically a reference to a C++ `ServerActiveObject`
   parameters and disables physics modifiers. After calling this function on a
   player, only this function will be able to change that player's physics
   parameters.
-    * `override_table` is a table with the following fields:
-        * `speed`: multiplier to default walking speed value (default: `1`)
-        * `jump`: multiplier to default jump value (default: `1`)
-        * `gravity`: multiplier to default gravity value (default: `1`)
-        * `sneak`: whether player can sneak (default: `true`)
-        * `sneak_glitch`: whether player can use the new move code replications
-          of the old sneak side-effects: sneak ladders and 2 node sneak jump
-          (default: `false`)
+    * `override_table` is a table with the fields from `modifier_table` in `set_physics_modifier` plus the following:
         * `new_move`: use new move/sneak code. When `false` the exact old code
           is used for the specific old sneak behaviour (default: `true`)
 * `get_physics_override()`: returns the table given to `set_physics_override`

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1426,17 +1426,17 @@ PlayerSAO::PhysicsModifier PlayerSAO::calculatePhysicsModifier()
 
 const PlayerSAO::PhysicsModifier &PlayerSAO::getTotalPhysicsModifier()
 {
-	if (physics_modifier_dirty) {
-		physics_modifier = calculatePhysicsModifier();
-		physics_modifier_dirty = false;
+	if (m_physics_modifier_dirty) {
+		m_physics_modifier = calculatePhysicsModifier();
+		m_physics_modifier_dirty = false;
 	}
 
-	return physics_modifier;
+	return m_physics_modifier;
 }
 
 void PlayerSAO::dirtyPhysicsModifier()
 {
-	physics_modifier_dirty = true;
+	m_physics_modifier_dirty = true;
 	m_physics_override_sent = false;
 }
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1418,17 +1418,15 @@ void PlayerSAO::unlinkPlayerSessionAndSave()
 PlayerSAO::PhysicsModifier PlayerSAO::calculatePhysicsModifier()
 {
 	PhysicsModifier result;
-	for (const auto& pair : m_physics_modifiers) {
+	for (const auto &pair : m_physics_modifiers)
 		result *= pair.second;
-	}
 
 	return result;
 }
 
-const PlayerSAO::PhysicsModifier& PlayerSAO::getTotalPhysicsModifier()
+const PlayerSAO::PhysicsModifier &PlayerSAO::getTotalPhysicsModifier()
 {
-	if (physics_modifier_dirty)
-	{
+	if (physics_modifier_dirty) {
 		physics_modifier = calculatePhysicsModifier();
 		physics_modifier_dirty = false;
 	}
@@ -1444,9 +1442,7 @@ void PlayerSAO::dirtyPhysicsModifier()
 
 std::string PlayerSAO::getPhysicsOverrideString()
 {
-	if (!m_physics_override_sent)
-		m_physics_override_sent = true;
-
+	m_physics_override_sent = true;
 	const PhysicsModifier physics = getEffectivePhysics();
 		
 	return gob_cmd_update_physics_override(physics.speed,
@@ -1479,7 +1475,7 @@ bool PlayerSAO::checkMovementCheat()
 		too, and much more lightweight.
 	*/
 
-	const PhysicsModifier& physics = getEffectivePhysics();
+	const PhysicsModifier &physics = getEffectivePhysics();
 
 	float player_max_walk = 0; // horizontal movement
 	float player_max_jump = 0; // vertical upwards movement
@@ -1560,20 +1556,20 @@ float PlayerSAO::getZoomFOV() const
 }
 
 void PlayerSAO::setPhysicsModifier(
-	const std::string& key, const PhysicsModifier& modifier)
+	const std::string &key, const PhysicsModifier &modifier)
 {
 	dirtyPhysicsModifier();
 	m_physics_modifiers[key] = modifier;
 }
 
 void PlayerSAO::deletePhysicsModifier(
-	const std::string& key)
+	const std::string &key)
 {
 	dirtyPhysicsModifier();
 	m_physics_modifiers.erase(key);
 }
 
-const PlayerSAO::PhysicsModifier& PlayerSAO::getEffectivePhysics()
+const PlayerSAO::PhysicsModifier &PlayerSAO::getEffectivePhysics()
 {
 	return m_physics_override_set ? m_physics_override : getTotalPhysicsModifier();
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -441,8 +441,8 @@ private:
 	s16 m_wanted_range = 0.0f;
 
 	std::unordered_map<std::string, PhysicsModifier> m_physics_modifiers;
-	PhysicsModifier physics_modifier; // Cache for calculatePhysicsModifier
-	bool physics_modifier_dirty = true;
+	PhysicsModifier m_physics_modifier; // Cache for calculatePhysicsModifier
+	bool m_physics_modifier_dirty = true;
 
 	Metadata m_meta;
 public:

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -360,7 +360,7 @@ public:
 	{
 		m_nocheat_dig_pos = v3s16(32767, 32767, 32767);
 	}
-	LagPool& getDigPool()
+	LagPool &getDigPool()
 	{
 		return m_dig_pool;
 	}
@@ -386,11 +386,16 @@ public:
 	v3f getEyeOffset() const;
 	float getZoomFOV() const;
 
-	void setPhysicsModifier(const std::string& key, const PhysicsModifier& modifier);
-	void deletePhysicsModifier(const std::string& key);
+	const std::unordered_map<std::string, PhysicsModifier>& getPhysicsModifiers()
+	{
+		return m_physics_modifiers;
+	}
+		
+	void setPhysicsModifier(const std::string &key, const PhysicsModifier &modifier);
+	void deletePhysicsModifier(const std::string &key);
 
 	// Not const - physics modifier is cached
-	const PhysicsModifier& getEffectivePhysics();
+	const PhysicsModifier &getEffectivePhysics();
 
 	inline Metadata &getMeta() { return m_meta; }
 
@@ -400,7 +405,7 @@ private:
 
 	// Not const since it may cache
 	PhysicsModifier calculatePhysicsModifier();
-	const PhysicsModifier& getTotalPhysicsModifier();
+	const PhysicsModifier &getTotalPhysicsModifier();
 	void dirtyPhysicsModifier();
 	std::string getPhysicsOverrideString();
 
@@ -441,7 +446,7 @@ private:
 
 	Metadata m_meta;
 public:
-	PhysicsModifier m_physics_override; // Used for compatibility with non-table format
+	PhysicsModifier m_physics_override;
 
 	// Flag, when set to true, disables physics modifiers so that only the override
 	// matters. It is set when a mod calls set_physics_override and is irreversible

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -433,6 +433,13 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 			co->m_physics_override_set = true;
 		}
 	}
+
+		if (!co->getPhysicsModifiers().empty()) {
+		warningstream << "Use of set_physics_override will remove active ";
+		warningstream << "physics modifiers" << std::endl;
+		warningstream << script_get_backtrace(L);
+	}
+		
 	return 0;
 }
 
@@ -466,7 +473,7 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	const std::string key = lua_tostring(L, 2);
+	const std::string key = readParam<std::string>(L, 2);
 	PlayerSAO::PhysicsModifier modifier;
 	if (!read_physics_modifier(L, 3, modifier))
 		throw LuaError("set_physics_modifier expects (string, table)");
@@ -474,10 +481,10 @@ int ObjectRef::l_set_physics_modifier(lua_State *L)
 	if (PlayerSAO *player = dynamic_cast<PlayerSAO*>(getobject(ref))) {
 		player->setPhysicsModifier(key, modifier);
 		
-		if (player->m_physics_override_set)
-		{
+		if (player->m_physics_override_set) {
 			warningstream << "set_physics_modifier will have no effect because ";
 			warningstream << "set_physics_override was previously called" << std::endl;
+			warningstream << script_get_backtrace(L);
 		}
 	}
 
@@ -489,15 +496,15 @@ int ObjectRef::l_delete_physics_modifier(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	const std::string key = lua_tostring(L, 2);
+	const std::string key = readParam<std::string>(L, 2);
 
 	if (PlayerSAO *player = dynamic_cast<PlayerSAO*>(getobject(ref))) {
 		player->deletePhysicsModifier(key);
 		
-		if (player->m_physics_override_set)
-		{
+		if (player->m_physics_override_set) {
 			warningstream << "delete_physics_modifier will have no effect because ";
 			warningstream << "set_physics_override was previously called" << std::endl;
+			warningstream << script_get_backtrace(L);
 		}
 	}
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -435,7 +435,7 @@ int ObjectRef::l_set_physics_override(lua_State *L)
 	}
 
 		if (!co->getPhysicsModifiers().empty()) {
-		warningstream << "Use of set_physics_override will remove active ";
+		warningstream << "Use of set_physics_override will disable active ";
 		warningstream << "physics modifiers" << std::endl;
 		warningstream << script_get_backtrace(L);
 	}

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -122,6 +122,12 @@ private:
 	// get_physics_override(self)
 	static int l_get_physics_override(lua_State *L);
 
+	// set_physics_modifier(self, key, modifier_table)
+	static int l_set_physics_modifier(lua_State *L);
+
+	// delete_physics_modifier(self, key)
+	static int l_delete_physics_modifier(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 	static int l_set_animation(lua_State *L);
 


### PR DESCRIPTION
Adds something like `set_physics_override` except they can combine together, avoiding conflict when multiple mods use it. See minetest/minetest_game#1909.