### PR TITLE
Mgvalleys: Code cleanup

### DIFF
--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -32,23 +32,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGVALLEYS_ALT_CHILL    0x01
 #define MGVALLEYS_HUMID_RIVERS 0x02
 
-// Feed only one variable into these.
+// Feed only one variable into these
 #define MYSQUARE(x) (x) * (x)
 #define MYCUBE(x) (x) * (x) * (x)
 
 class BiomeManager;
 class BiomeGenOriginal;
 
-// Global profiler
-//class Profiler;
-//extern Profiler *mapgen_profiler;
-
 
 struct MapgenValleysParams : public MapgenParams {
 	u32 spflags = MGVALLEYS_HUMID_RIVERS | MGVALLEYS_ALT_CHILL;
-	u16 altitude_chill = 90; // The altitude at which temperature drops by 20C.
-	u16 river_depth = 4; // How deep to carve river channels.
-	u16 river_size = 5; // How wide to make rivers.
+	u16 altitude_chill = 90; // The altitude at which temperature drops by 20C
+	u16 river_depth = 4; // How deep to carve river channels
+	u16 river_size = 5; // How wide to make rivers
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -122,9 +118,7 @@ private:
 	Noise *noise_valley_profile;
 
 	float terrainLevelAtPoint(s16 x, s16 z);
-
 	void calculateNoise();
-
 	virtual int generateTerrain();
 	float terrainLevelFromNoise(TerrainNoise *tn);
 	float adjustedTerrainLevelFromNoise(TerrainNoise *tn);


### PR DESCRIPTION
Split some long lines.
Edit comments.
Remove unnecessary comments and unnecessary commented-out code.
Use std::fmax/fmin instead of MYMAX/MYMIN.
Remove scope-limiting braces.
Consistently define literals as floats, except in noise parameters.
Cleanup literals in noise parameters.
Remove unnecessary 'near_cavern' line.
Reduce max spawn y to be consistent with other mapgens.
///////////////////

Some of these changes were requested by @SmallJoker 
Testing confirms no changes to terrain:

![valms](https://user-images.githubusercontent.com/3686677/39105056-5ffd8be0-46ab-11e8-90ba-9439af709c3b.png)

^ Generate some terrain in master

![valpr](https://user-images.githubusercontent.com/3686677/39105061-633780fe-46ab-11e8-89bc-557b25eb586f.png)

^ Generate some more in PR, no discontinuities (checked in-game).