### PR TITLE
Move ASCII art to std::cerr, to remove it from logs

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -363,7 +363,7 @@ void Server::start()
 	m_thread->start();
 
 	// ASCII art for the win!
-	rawstream
+	std::cerr
 		<< "        .__               __                   __   " << std::endl
 		<< "  _____ |__| ____   _____/  |_  ____   _______/  |_ " << std::endl
 		<< " /     \\|  |/    \\_/ __ \\   __\\/ __ \\ /  ___/\\   __\\" << std::endl


### PR DESCRIPTION
Fixes #7014