### PR TITLE
Meta-set node offset

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1963,6 +1963,13 @@ Some of the values in the key-value store are handled specially:
 
 * `formspec`: Defines a right-click inventory menu. See "Formspec".
 * `infotext`: Text shown on the screen when the node is pointed at
+* `offset`: Moves the visual appearance of a node and its selection and collision
+            boxes about the given value.
+            The `offset` value must have the format `(<x>, <y>, <z>)`.
+            Correct behaviour is only guaranteed, if the whole node stays inside
+            its { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 } area.
+            Supported for drawtypes "plantlike", "signlike", "torchlike",
+            "firelike", "mesh" and "nodebox".
 
 Example stuff:
 
@@ -1972,6 +1979,7 @@ Example stuff:
             "list[context;main;0,0;8,4;]"..
             "list[current_player;main;0,5;8,4;]")
     meta:set_string("infotext", "Chest");
+    meta:set_string("offset", "(0.1, 0.2, 0.3)")
     local inv = meta:get_inventory()
     inv:set_size("main", 8*4)
     print(dump(meta:to_table()))

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "serverobject.h"
 #include "util/timetaker.h"
 #include "profiler.h"
+#include "util/strfnd.h"
 
 // float error is 10 - 9.96875 = 0.03125
 //#define COLL_ZERO 0.032 // broken unit tests
@@ -321,7 +322,18 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				getNeighborConnectingFace(p2, nodedef, map, n, 32, &neighbors);
 			}
 			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
+
+			v3f offset = v3f(0, 0, 0);
+
+			NodeMetadata *meta = map->getNodeMetadata(p);
+			if (meta) {
+				Strfnd f(meta->getString("offset"));
+				f.next("(");
+				offset.X = stof(f.next(",")) * BS;
+				offset.Y = stof(f.next(",")) * BS;
+				offset.Z = stof(f.next(")")) * BS;
+			}
+			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors, offset);
 
 			// Calculate float position only once
 			v3f posf = intToFloat(p, BS);

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -26,6 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 #include "daynightratio.h"
 #include "emerge.h"
+#include "nodemetadata.h"
+#include "util/strfnd.h"
 
 
 Environment::Environment(IGameDef *gamedef):
@@ -167,9 +169,20 @@ void Environment::continueRaycast(RaycastState *state, PointedThing *result)
 
 			PointedThing result;
 
+			v3f offset = v3f(0, 0, 0);
+
+			NodeMetadata *meta = map.getNodeMetadata(np);
+			if (meta) {
+				Strfnd f(meta->getString("offset"));
+				f.next("(");
+				offset.X = stof(f.next(",")) * BS;
+				offset.Y = stof(f.next(",")) * BS;
+				offset.Z = stof(f.next(")")) * BS;
+			}
+
 			std::vector<aabb3f> boxes;
 			n.getSelectionBoxes(nodedef, &boxes,
-				n.getNeighbors(np, &map));
+				n.getNeighbors(np, &map), offset);
 
 			// Is there a collision with a selection box?
 			bool is_colliding = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -67,6 +67,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlicht_changes/static_text.h"
 #include "version.h"
 #include "script/scripting_client.h"
+#include "util/strfnd.h"
 
 #if USE_SOUND
 	#include "client/sound_openal.h"
@@ -3087,9 +3088,21 @@ PointedThing Game::updatePointedThing(
 	} else if (result.type == POINTEDTHING_NODE) {
 		// Update selection boxes
 		MapNode n = map.getNodeNoEx(result.node_undersurface);
+
+		v3f offset = v3f(0, 0, 0);
+
+		NodeMetadata *meta = map.getNodeMetadata(result.node_undersurface);
+		if (meta) {
+			Strfnd f(meta->getString("offset"));
+			f.next("(");
+			offset.X = stof(f.next(",")) * BS;
+			offset.Y = stof(f.next(",")) * BS;
+			offset.Z = stof(f.next(")")) * BS;
+		}
+
 		std::vector<aabb3f> boxes;
 		n.getSelectionBoxes(nodedef, &boxes,
-			n.getNeighbors(result.node_undersurface, &map));
+			n.getNeighbors(result.node_undersurface, &map), offset);
 
 		f32 d = 0.002 * BS;
 		for (std::vector<aabb3f>::const_iterator i = boxes.begin();

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -27,6 +27,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "client.h"
 #include "content_cao.h"
+#include "nodemetadata.h"
+#include "util/strfnd.h"
 
 /*
 	LocalPlayer
@@ -147,7 +149,18 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 	// Update saved top bounding box of sneak node
 	node = map->getNodeNoEx(m_sneak_node);
 	std::vector<aabb3f> nodeboxes;
-	node.getCollisionBoxes(nodemgr, &nodeboxes);
+
+	v3f offset = v3f(0, 0, 0);
+
+	NodeMetadata *meta = map->getNodeMetadata(m_sneak_node);
+	if (meta) {
+		Strfnd f(meta->getString("offset"));
+		f.next("(");
+		offset.X = stof(f.next(",")) * BS;
+		offset.Y = stof(f.next(",")) * BS;
+		offset.Z = stof(f.next(")")) * BS;
+	}
+	node.getCollisionBoxes(nodemgr, &nodeboxes, 0, offset);
 	m_sneak_node_bb_top = getNodeBoundingBox(nodeboxes);
 
 	if (physics_override_sneak_glitch) {
@@ -980,7 +993,17 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			f32 cb_max = 0;
 			MapNode n = map->getNodeNoEx(m_sneak_node);
 			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(nodemgr, &nodeboxes);
+			v3f offset = v3f(0, 0, 0);
+
+			NodeMetadata *meta = map->getNodeMetadata(m_sneak_node);
+			if (meta) {
+				Strfnd f(meta->getString("offset"));
+				f.next("(");
+				offset.X = stof(f.next(",")) * BS;
+				offset.Y = stof(f.next(",")) * BS;
+				offset.Z = stof(f.next(")")) * BS;
+			}
+			n.getCollisionBoxes(nodemgr, &nodeboxes, 0, offset);
 			for (const auto &box : nodeboxes) {
 				if (box.MaxEdge.Y > cb_max)
 					cb_max = box.MaxEdge.Y;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -260,19 +260,19 @@ struct MapNode
 		Gets list of node boxes (used for rendering (NDT_NODEBOX))
 	*/
 	void getNodeBoxes(const NodeDefManager *nodemgr, std::vector<aabb3f> *boxes,
-		u8 neighbors = 0);
+		u8 neighbors = 0, v3f offset = v3f(0, 0, 0));
 
 	/*
 		Gets list of selection boxes
 	*/
 	void getSelectionBoxes(const NodeDefManager *nodemg,
-		std::vector<aabb3f> *boxes, u8 neighbors = 0);
+		std::vector<aabb3f> *boxes, u8 neighbors = 0, v3f offset = v3f(0, 0, 0));
 
 	/*
 		Gets list of collision boxes
 	*/
 	void getCollisionBoxes(const NodeDefManager *nodemgr,
-		std::vector<aabb3f> *boxes, u8 neighbors = 0);
+		std::vector<aabb3f> *boxes, u8 neighbors = 0, v3f offset = v3f(0, 0, 0));
 
 	/*
 		Liquid helpers


### PR DESCRIPTION
Moves the visual appearance of a node and its selection and collision
boxes about the given value.
The `offset` value must have the format `(<x>, <y>, <z>)`.
Correct behaviour is only guaranteed, if the whole node stays inside
its { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 } area.
Supported for drawtypes "plantlike", "signlike", "torchlike",
"firelike", "mesh" and "nodebox".