### PR TITLE
Biome-defined cave liquids: Use faster biome calculation

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -507,7 +507,7 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 	MapNode liquidnode = CONTENT_IGNORE;
 
 	if (bmgn) {
-		Biome *biome = (Biome *)bmgn->calcBiomeAtPoint(cpabs);
+		Biome *biome = (Biome *)bmgn->getBiomeAtPoint(cpabs);
 		if (biome->c_cave_liquid != CONTENT_IGNORE)
 			liquidnode = biome->c_cave_liquid;
 	}


### PR DESCRIPTION
![screenshot_20180426_131807](https://user-images.githubusercontent.com/3686677/39305451-1202b512-4955-11e8-81cb-997d4089ab28.png)

Fixes mistake in 32d456bd2d4dda50f77c01c702d1b5a5ff26134b
'calcBiomeAtPoint()' calculates the heat and humidity noises, but we already have those calculated and stored in the noise perlinmaps, so use 'getBiomeAtPoint()' instead which gets the noise values from the perlinmaps.
Improves performance.
A similar PR for the same mistake in biome-defined dungeon nodes is coming soon.
Tested.