### PR TITLE
Biome-defined dungeon nodes: Use faster biome calculation

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -868,7 +868,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 
 	// Get biome at mapchunk midpoint
 	v3s16 chunk_mid = node_min + (node_max - node_min) / v3s16(2, 2, 2);
-	Biome *biome = (Biome *)biomegen->calcBiomeAtPoint(chunk_mid);
+	Biome *biome = (Biome *)biomegen->getBiomeAtPoint(chunk_mid);
 
 	DungeonParams dp;
 


### PR DESCRIPTION
Fixes mistake in 746ca41f58e356b0fbeeca1b43b7061ad1e1c02d
'calcBiomeAtPoint()' calculates the heat and humidity noises, but we already have those calculated and stored in the noise perlinmaps, so use 'getBiomeAtPoint()' instead which gets the noise values from the perlinmaps.
Improves performance.
Tested.