### PR TITLE
Delete two method definition in nodedef.h file.

### DIFF
--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -405,8 +405,6 @@ struct ContentFeatures
 	void reset();
 	void serialize(std::ostream &os, u16 protocol_version) const;
 	void deSerialize(std::istream &is);
-	void serializeOld(std::ostream &os, u16 protocol_version) const;
-	void deSerializeOld(std::istream &is, int version);
 	/*!
 	 * Since vertex alpha is no longer supported, this method
 	 * adds opacity directly to the texture pixels.


### PR DESCRIPTION
Delete unused method definition in nodedef.h file.
