### PR TITLE
Cavegen: Allow small RandomWalk caves to generate beyond mapchunk border

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -569,9 +569,6 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 					else
 						vm->m_data[i] = airnode;
 				} else {
-					if (c == CONTENT_IGNORE)
-						continue;
-
 					vm->m_data[i] = airnode;
 					vm->m_flags[i] |= VMANIP_FLAG_CAVE;
 				}
@@ -874,7 +871,7 @@ void CavesV6::carveRoute(v3f vec, float f, bool randomize_xz,
 						vm->m_data[i] = airnode;
 					}
 				} else {
-					if (c == CONTENT_IGNORE || c == CONTENT_AIR)
+					if (c == CONTENT_AIR)
 						continue;
 
 					vm->m_data[i] = airnode;


### PR DESCRIPTION
WIP in testing

I noticed that the small randomwalk caves (mgv6 small tunnels) are not allowed to generate beyond mapchunk edges while the large randomwalk caves (mgv6 large caves and medium-size caves of other mapgens) are. The intent of allowing this 'overgeneration' is that caves sometimes overlap and link to caves belonging to neighbouring mapchunks.

I then found the 6 year old commit that stopped small cave overgeneration c0bd96d9b314e78a7aeb74b1bff70e1023b2f9e2 "Attempt to fix flying gravel and dirt" by celeron55.
However since then dirt and gravel placement has completely changed and we now have 'is_ground_content = bool' to control what nodes caves can excavate. Also, since large randomwalk caves do not cause bugs the small randomwalk caves will not either since they have the same generation (but i will test).

This PR will help small randomwalk caves to overlap and link up to be more continuous, instead of being limited to one mapchunk.
Although mgv6 is officially 'stable' i think this can still be done as it will be a slight extension of mgv6 small caves with very little effect on terrain shape, and will improve them.
Small randomwalk caves are not currently used by any other mapgen.