### PR TITLE
Fix builtin inventory list crash when size = 0

### DIFF
--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -141,7 +141,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 
 	inventory.deSerialize(is);
 
-	if (inventory.getList("craftpreview") == NULL) {
+	if (!inventory.getList("craftpreview") && inventory.getList("craftresult")) {
 		// Convert players without craftpreview
 		inventory.addList("craftpreview", 1);
 

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -177,7 +177,7 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 		const InventoryList *old_craft_grid, const InventoryLocation &craft_inv)
 {
 	SCRIPTAPI_PRECHECKHEADER
-
+	sanity_check(old_craft_grid);
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	lua_getglobal(L, "core");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2686,7 +2686,7 @@ void Server::DeleteClient(session_t peer_id, ClientDeletionReason reason)
 void Server::UpdateCrafting(RemotePlayer *player)
 {
 	InventoryList *clist = player->inventory.getList("craft");
-	if (!clist || clist->getSize() < 1)
+	if (!clist || clist->getSize() == 0)
 		return;
 
 	// Get a preview for crafting

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2685,6 +2685,10 @@ void Server::DeleteClient(session_t peer_id, ClientDeletionReason reason)
 
 void Server::UpdateCrafting(RemotePlayer *player)
 {
+	InventoryList *clist = player->inventory.getList("craft");
+	if (!clist || clist->getSize() < 1)
+		return;
+
 	// Get a preview for crafting
 	ItemStack preview;
 	InventoryLocation loc;
@@ -2692,13 +2696,13 @@ void Server::UpdateCrafting(RemotePlayer *player)
 	std::vector<ItemStack> output_replacements;
 	getCraftingResult(&player->inventory, preview, output_replacements, false, this);
 	m_env->getScriptIface()->item_CraftPredict(preview, player->getPlayerSAO(),
-			(&player->inventory)->getList("craft"), loc);
+			clist, loc);
 
-	// Put the new preview in
 	InventoryList *plist = player->inventory.getList("craftpreview");
-	sanity_check(plist);
-	sanity_check(plist->getSize() >= 1);
-	plist->changeItem(0, preview);
+	if (plist && plist->getSize() >= 1) {
+		// Put the new preview in
+		plist->changeItem(0, preview);
+	}
 }
 
 void Server::handleChatInterfaceEvent(ChatEvent *evt)


### PR DESCRIPTION
Fixes #7296 

Testing code:
```Lua
minetest.register_on_joinplayer(function(player)
	local inv = player:get_inventory()
	inv:set_size("craft", 0) -- either this = 0
	inv:set_size("craftpreview", 0) -- or this = 0
end)
```

`minetest.register_craft_predict` is still triggered when "craft" has at least one slot, even when "craftresult" has the size 0. This might seem a bit weird but makes it possible to implement custom crafting methods, which work differently to what we currently have. 