### PR TITLE
Small usage changes for air and ignore items

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -557,7 +557,7 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 	local itemstack = ItemStack(stackstring)
 	if itemstack:is_empty() then
 		return false, "Cannot give an empty item"
-	elseif not itemstack:is_known() then
+	elseif (not itemstack:is_known()) or (itemstack:get_name() == "unknown") then
 		return false, "Cannot give an unknown item"
 	-- Forbid giving 'ignore' due to unwanted side effects
 	elseif itemstack:get_name() == "ignore" then

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -576,14 +576,27 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 	-- The actual item stack string may be different from what the "giver"
 	-- entered (e.g. big numbers are always interpreted as 2^16-1).
 	stackstring = itemstack:to_string()
+	-- easter egg when giving "forbidden" items
+	local you_hacker = itemstack:get_name() == "air" or itemstack:get_name() == "ignore"
+	local msg
 	if giver == receiver then
-		return true, ("%q %sadded to inventory.")
-				:format(stackstring, partiality)
+		if you_hacker then
+			msg = "%q %sadded to inventory (you hacker, you!)."
+		else
+			msg = "%q %sadded to inventory."
+		end
+		msg = msg:format(stackstring, partiality)
+		return true, msg
 	else
 		core.chat_send_player(receiver, ("%q %sadded to inventory.")
 				:format(stackstring, partiality))
-		return true, ("%q %sadded to %s's inventory.")
-				:format(stackstring, partiality, receiver)
+		if you_hacker then
+			msg = "%q %sadded to %s's inventory (you hacker, you!)."
+		else
+			msg = "%q %sadded to %s's inventory."
+		end
+		msg = msg:format(stackstring, partiality, receiver)
+		return true, msg
 	end
 end
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -579,24 +579,13 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 	-- The actual item stack string may be different from what the "giver"
 	-- entered (e.g. big numbers are always interpreted as 2^16-1).
 	stackstring = itemstack:to_string()
-	-- Air is not that useful as an item, but it also does no real harm.
-	local you_hacker = itemstack:get_name() == "air"
-	local msg
 	if giver == receiver then
-		if you_hacker then
-			msg = "%q %sadded to inventory (you hacker, you!)."
-		else
-			msg = "%q %sadded to inventory."
-		end
+		local msg = "%q %sadded to inventory."
 		return true, msg:format(stackstring, partiality)
 	else
 		core.chat_send_player(receiver, ("%q %sadded to inventory.")
 				:format(stackstring, partiality))
-		if you_hacker then
-			msg = "%q %sadded to %s's inventory (you hacker, you!)."
-		else
-			msg = "%q %sadded to %s's inventory."
-		end
+		local msg = "%q %sadded to %s's inventory."
 		return true, msg:format(stackstring, partiality, receiver)
 	end
 end

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -585,8 +585,7 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 		else
 			msg = "%q %sadded to inventory."
 		end
-		msg = msg:format(stackstring, partiality)
-		return true, msg
+		return true, msg:format(stackstring, partiality)
 	else
 		core.chat_send_player(receiver, ("%q %sadded to inventory.")
 				:format(stackstring, partiality))
@@ -595,8 +594,7 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 		else
 			msg = "%q %sadded to %s's inventory."
 		end
-		msg = msg:format(stackstring, partiality, receiver)
-		return true, msg
+		return true, msg:format(stackstring, partiality, receiver)
 	end
 end
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -559,14 +559,9 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 		return false, "Cannot give an empty item"
 	elseif not itemstack:is_known() then
 		return false, "Cannot give an unknown item"
-	--[[ We forbid giving 'ignore' because it's useless as an item and
-	also a bit dangerous.
-	Note this does NOT make it completely impossible for players to
-	get 'ignore'; they might still obtain it via mods or bugs in mods,
-	so beware. ]]
+	-- Forbid giving 'ignore' due to unwanted side effects
 	elseif itemstack:get_name() == "ignore" then
-		-- A little humour is good, this is a game, after all. :-)
-		return false, "One does not simpliy give 'ignore' items!"
+		return false, "Giving 'ignore' is not allowed"
 	end
 	local receiverref = core.get_player_by_name(receiver)
 	if receiverref == nil then
@@ -585,7 +580,6 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 	-- entered (e.g. big numbers are always interpreted as 2^16-1).
 	stackstring = itemstack:to_string()
 	-- Air is not that useful as an item, but it also does no real harm.
-	-- Thus we do not forbid giving it, but we DO have a snarky comment. ;-)
 	local you_hacker = itemstack:get_name() == "air"
 	local msg
 	if giver == receiver then

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -559,6 +559,14 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 		return false, "Cannot give an empty item"
 	elseif not itemstack:is_known() then
 		return false, "Cannot give an unknown item"
+	--[[ We forbid giving 'ignore' because it's useless as an item and
+	also a bit dangerous.
+	Note this does NOT make it completely impossible for players to
+	get 'ignore'; they might still obtain it via mods or bugs in mods,
+	so beware. ]]
+	elseif itemstack:get_name() == "ignore" then
+		-- A little humour is good, this is a game, after all. :-)
+		return false, "One does not simpliy give 'ignore' items!"
 	end
 	local receiverref = core.get_player_by_name(receiver)
 	if receiverref == nil then
@@ -576,8 +584,9 @@ local function handle_give_command(cmd, giver, receiver, stackstring)
 	-- The actual item stack string may be different from what the "giver"
 	-- entered (e.g. big numbers are always interpreted as 2^16-1).
 	stackstring = itemstack:to_string()
-	-- easter egg when giving "forbidden" items
-	local you_hacker = itemstack:get_name() == "air" or itemstack:get_name() == "ignore"
+	-- Air is not that useful as an item, but it also does no real harm.
+	-- Thus we do not forbid giving it, but we DO have a snarky comment. ;-)
+	local you_hacker = itemstack:get_name() == "air"
 	local msg
 	if giver == receiver then
 		if you_hacker then

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -369,9 +369,10 @@ core.register_node(":ignore", {
 	drop = "",
 	groups = {not_in_creative_inventory=1},
 	-- Prevent placement of ignore (to prevent engine error message spam in logs)
+	-- and destroy itemstack.
 	on_place = function(itemstack, placer, pointed_thing)
-		minetest.chat_send_player(placer:get_player_name(), minetest.colorize("#FF0000", "One does not simply place ignore nodes in the world!"))
-		return itemstack
+		minetest.chat_send_player(placer:get_player_name(), minetest.colorize("#FF0000", "One does not simply place 'ignore' nodes!"))
+		return ""
 	end,
 })
 

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -368,10 +368,11 @@ core.register_node(":ignore", {
 	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
-	-- Prevent placement of ignore (to prevent engine error message spam in logs)
-	-- and destroy itemstack.
 	on_place = function(itemstack, placer, pointed_thing)
-		minetest.chat_send_player(placer:get_player_name(), minetest.colorize("#FF0000", "One does not simply place 'ignore' nodes!"))
+		minetest.chat_send_player(
+				placer:get_player_name(),
+				minetest.colorize("#FF0000",
+				"You can't place 'ignore' nodes!"))
 		return ""
 	end,
 })

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -368,6 +368,11 @@ core.register_node(":ignore", {
 	air_equivalent = true,
 	drop = "",
 	groups = {not_in_creative_inventory=1},
+	-- Prevent placement of ignore (to prevent engine error message spam in logs)
+	on_place = function(itemstack, placer, pointed_thing)
+		minetest.chat_send_player(placer:get_player_name(), minetest.colorize("#FF0000", "One does not simply place ignore nodes in the world!"))
+		return itemstack
+	end,
 })
 
 -- The hand (bare definition)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -338,7 +338,7 @@ core.register_item(":unknown", {
 })
 
 core.register_node(":air", {
-	description = "Air (you hacker you!)",
+	description = "Air",
 	inventory_image = "air.png",
 	wield_image = "air.png",
 	drawtype = "airlike",
@@ -355,7 +355,7 @@ core.register_node(":air", {
 })
 
 core.register_node(":ignore", {
-	description = "Ignore (you hacker you!)",
+	description = "Ignore",
 	inventory_image = "ignore.png",
 	wield_image = "ignore.png",
 	drawtype = "airlike",


### PR DESCRIPTION
This PR makes some tweaks to air and ignore (in item form):

The “you hacker you!” in the `description` is removed. Instead, this message appears on `/give` and `/giveme`.
Reason: To keep the tooltip clean, and because the `description` might be parsed by mods like `doc` to display item names in a list, so the `description` should be general-purpose.

The placement of `ignore` is prevented straight in `builtin` with a custom error message directed at the player.
Reason: To catch the placement before it goes to the engine, which would cause massive error message spam with cryptic messages.