### PR TITLE
WIP: Fix confirm registration: snprintf in windows

### DIFF
--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -99,18 +99,21 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 
 #ifdef _MSC_VER
 		int sizeBuffer = sizeof(info_text_buf) -
-				  (info_text_template.length() - 8 + address.length() +
-						  m_playername.length());
+				 (info_text_template.length() - 8 + address.length() +
+						 m_playername.length());
 
 		if (sizeBuffer >= 0) {
-			sprintf(info_text_buf, info_text_template.c_str(), address.c_str(), 
-					m_playername.c_str());
+			sprintf(info_text_buf, info_text_template.c_str(),
+					address.c_str(), m_playername.c_str());
 		} else {
-			warningstream << "the info_text_buf buffer is too small" << std::endl;
+			warningstream << "Failed to generate info_text. Buffer is too "
+					 "small"
+				      << std::endl;
 			int new_size_text_template =
 					(int)info_text_template.size() + (sizeBuffer - 4);
 			if (new_size_text_template > 0) {
-				std::string info_text_template_trunq = info_text_template.substr(0,
+				std::string info_text_template_trunq =
+						info_text_template.substr(0,
 								new_size_text_template);
 				info_text_template_trunq.append("...");
 				sprintf(info_text_buf, info_text_template_trunq.c_str(),

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -112,11 +112,11 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 			int new_size_text_template =
 					(int)info_text_template.size() + (sizeBuffer - 4);
 			if (new_size_text_template > 0) {
-				std::string info_text_template_trunq =
+				std::string info_text_template_trunc =
 						info_text_template.substr(0,
 								new_size_text_template);
-				info_text_template_trunq.append("...");
-				sprintf(info_text_buf, info_text_template_trunq.c_str(),
+				info_text_template_trunc.append("...");
+				sprintf(info_text_buf, info_text_template_trunc.c_str(),
 						address.c_str(), m_playername.c_str());
 			}
 		}

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -98,8 +98,25 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 		char info_text_buf[1024];
 
 #ifdef _MSC_VER
-		sprintf(info_text_buf, info_text_template.c_str(), address.c_str(),
-				m_playername.c_str());
+		int sizeBuffer = sizeof(info_text_buf) -
+				  (info_text_template.length() - 8 + address.length() +
+						  m_playername.length());
+
+		if (sizeBuffer >= 0) {
+			sprintf(info_text_buf, info_text_template.c_str(), address.c_str(), 
+					m_playername.c_str());
+		} else {
+			warningstream << "the info_text_buf buffer is too small" << std::endl;
+			int new_size_text_template =
+					(int)info_text_template.size() + (sizeBuffer - 4);
+			if (new_size_text_template > 0) {
+				std::string info_text_template_trunq = info_text_template.substr(0,
+								new_size_text_template);
+				info_text_template_trunq.append("...");
+				sprintf(info_text_buf, info_text_template_trunq.c_str(),
+						address.c_str(), m_playername.c_str());
+			}
+		}
 #else
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -98,11 +98,16 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 		char info_text_buf[1024];
 
 #ifdef _MSC_VER
-		int sizeBuffer = sizeof(info_text_buf) -
+		/*
+			Remove 8 to ignore %1$s and %2$s
+			If the template + the server ip + the player name is greater than
+			the buffer then bufferSize will be negative
+		*/
+		int bufferSize = sizeof(info_text_buf) -
 				 (info_text_template.length() - 8 + address.length() +
 						 m_playername.length());
 
-		if (sizeBuffer >= 0) {
+		if (bufferSize >= 0) {
 			sprintf(info_text_buf, info_text_template.c_str(),
 					address.c_str(), m_playername.c_str());
 		} else {
@@ -110,7 +115,7 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 					 "small"
 				      << std::endl;
 			int new_size_text_template =
-					(int)info_text_template.size() + (sizeBuffer - 4);
+					(int)info_text_template.size() + (bufferSize - 4);
 			if (new_size_text_template > 0) {
 				std::string info_text_template_trunc =
 						info_text_template.substr(0,

--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -96,8 +96,14 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 				"Join to confirm account creation or click Cancel to "
 				"abort.");
 		char info_text_buf[1024];
+
+#ifdef _MSC_VER
+		sprintf(info_text_buf, info_text_template.c_str(), address.c_str(),
+				m_playername.c_str());
+#else
 		snprintf(info_text_buf, sizeof(info_text_buf), info_text_template.c_str(),
 				address.c_str(), m_playername.c_str());
+#endif
 
 		gui::IGUIEditBox *e = new gui::intlGUIEditBox(
 				utf8_to_wide_c(info_text_buf), true, Environment, this,


### PR DESCRIPTION
I fix crash in windows when you first join a server :

![image](https://user-images.githubusercontent.com/3883583/39786242-f2e47d58-531f-11e8-841b-1418930b51b3.png)

**But now the text displayed is as follows:**

![image](https://user-images.githubusercontent.com/3883583/39786288-33066c0c-5320-11e8-9678-ac69f6150ffe.png)

**And when I click a button**

![image](https://user-images.githubusercontent.com/3883583/39786292-39387304-5320-11e8-937d-abfa3819e26d.png)

I continue to study this problem tomorrow. But if you have any ideas do not hesitate. Maybe I misunderstood. 
**This page works on linux?**
