### PR TITLE
Player hand list: Deny interactions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2065,7 +2065,7 @@ Player Inventory lists
 * `craftpreview`: list containing the craft prediction
 * `craftresult`: list containing the crafted output
 * `hand`: list containing an override for the empty hand
-    * Is not created automatically, use `InvRef:set_size`
+    * Cannot be modified by players directly
 
 `ColorString`
 -------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2062,8 +2062,10 @@ Player Inventory lists
 ----------------------
 * `main`: list containing the default inventory
 * `craft`: list containing the craft input
-* `craftpreview`: list containing the craft output
+* `craftpreview`: list containing the craft prediction
+* `craftresult`: list containing the crafted output
 * `hand`: list containing an override for the empty hand
+    * Is not created automatically, use `InvRef:set_size`
 
 `ColorString`
 -------------

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3378,6 +3378,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			s_count = list_s->getItem(s.i).count;
 		} while(0);
 
+		// Prevent visual desync with server: Deny interacting with this slot
+		if (s.listname == "hand")
+			s.i = -1; // Mark as invalid
+
 		bool identical = m_selected_item && s.isValid() &&
 			(inv_selected == inv_s) &&
 			(m_selected_item->listname == s.listname) &&

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -632,9 +632,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		}
 
 		/*
-			Disable moving items out of craftpreview
+			Disable moving items out of craftpreview and hand
 		*/
-		if (ma->from_list == "craftpreview") {
+		if (ma->from_list == "craftpreview" || ma->from_list == "hand") {
 			infostream << "Ignoring IMoveAction from "
 					<< (ma->from_inv.dump()) << ":" << ma->from_list
 					<< " to " << (ma->to_inv.dump()) << ":" << ma->to_list
@@ -644,9 +644,10 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		}
 
 		/*
-			Disable moving items into craftresult and craftpreview
+			Disable moving items into craftresult, craftpreview and hand
 		*/
-		if (ma->to_list == "craftpreview" || ma->to_list == "craftresult") {
+		if (ma->to_list == "craftpreview" || ma->to_list == "craftresult" ||
+				ma->to_list == "hand") {
 			infostream << "Ignoring IMoveAction from "
 					<< (ma->from_inv.dump()) << ":" << ma->from_list
 					<< " to " << (ma->to_inv.dump()) << ":" << ma->to_list
@@ -677,9 +678,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		setInventoryModified(da->from_inv, false);
 
 		/*
-			Disable dropping items out of craftpreview
+			Disable dropping items out of craftpreview and hand
 		*/
-		if (da->from_list == "craftpreview") {
+		if (da->from_list == "craftpreview" || da->from_list == "hand") {
 			infostream << "Ignoring IDropAction from "
 					<< (da->from_inv.dump()) << ":" << da->from_list
 					<< " because src is " << da->from_list << std::endl;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -36,7 +36,6 @@ Player::Player(const char *name, IItemDefManager *idef):
 
 	inventory.clear();
 	inventory.addList("main", PLAYER_INVENTORY_SIZE);
-	inventory.addList("hand", 1);
 	InventoryList *craft = inventory.addList("craft", 9);
 	craft->setWidth(3);
 	inventory.addList("craftpreview", 1);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -36,6 +36,7 @@ Player::Player(const char *name, IItemDefManager *idef):
 
 	inventory.clear();
 	inventory.addList("main", PLAYER_INVENTORY_SIZE);
+	inventory.addList("hand", 1);
 	InventoryList *craft = inventory.addList("craft", 9);
 	craft->setWidth(3);
 	inventory.addList("craftpreview", 1);


### PR DESCRIPTION
Mods will now have to initialize the list/slot in order to define the default player hand.
They may use the inventory callbacks to prevent abuse of this list.

Currently this slot can be abused by CSM for various reasons, whereas putting and taking items to and from the slot is the most important. The other solution would be to restrict all inventory actions for this list (like `craftpreview` and partially `craftresult`) - which however won't allow direct access by players, whereas it's totally possible with inventory callbacks.

EDIT: Yes, the diff is minimalistic - but the point of this PR is to check whether the hand is in use anywhere and whether this solution is preferred over the other.