### PR TITLE
Implemented hasprivs chat-command (Closes #7266)

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -106,7 +106,7 @@ core.register_chatcommand("privs", {
 core.register_chatcommand("hasprivs", {
 	params = "<priv>",
 	description = "Returns a list of all online players with the priv passed as param. e.g. /hasprivs fly",
-	privs = {server = true},
+	privs = {basic_privs = true},
 	func = function(caller, param)
 		param = param:trim()
 		if param == "" then

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -104,7 +104,7 @@ core.register_chatcommand("privs", {
 })
 
 core.register_chatcommand("hasprivs", {
-	params = "<priv>",
+	params = "<privilege>",
 	description = "Return list of all online players with privilege.",
 	privs = {basic_privs = true},
 	func = function(caller, param)
@@ -118,12 +118,12 @@ core.register_chatcommand("hasprivs", {
 		local privs = core.string_to_privs(param)
 		local players_with_privs = {}
 		for _, player in pairs(core.get_connected_players()) do
-			local toname = player:get_player_name()
-			if core.check_player_privs(toname, privs) then
-				table.insert(players_with_privs, toname)
+			local player_name = player:get_player_name()
+			if core.check_player_privs(player_name, privs) then
+				table.insert(players_with_privs, player_name)
 			end
 		end	
-		return true, "Players with the " ..param.. " priv: " ..table.concat(players_with_privs, ", ")
+		return true, "Players with the " .. param .. " priv: " .. table.concat(players_with_privs, ", ")
 	end	
 })
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -123,7 +123,7 @@ core.register_chatcommand("hasprivs", {
 				table.insert(players_with_privs, player_name)
 			end
 		end	
-		return true, "Players with the \"" .. param .. "\" priv: " ..
+		return true, "Players online with the \"" .. param .. "\" priv: " ..
 			table.concat(players_with_privs, ", ")
 	end	
 })

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -123,7 +123,8 @@ core.register_chatcommand("hasprivs", {
 				table.insert(players_with_privs, player_name)
 			end
 		end	
-		return true, "Players with the " .. param .. " priv: " .. table.concat(players_with_privs, ", ")
+		return true, "Players with the " .. param .. " priv: " ..
+			table.concat(players_with_privs, ", ")
 	end	
 })
 

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -41,7 +41,7 @@ end)
 
 if core.settings:get_bool("profiler.load") then
 	-- Run after register_chatcommand and its register_on_chat_message
-	-- Before any chattcommands that should be profiled
+	-- Before any chatcommands that should be profiled
 	profiler.init_chatcommand()
 end
 
@@ -101,6 +101,30 @@ core.register_chatcommand("privs", {
 			.. core.privs_to_string(
 				core.get_player_privs(name), ' ')
 	end,
+})
+
+core.register_chatcommand("hasprivs", {
+	params = "<priv>",
+	description = "Returns a list of all online players with the priv passed as param. e.g. /hasprivs fly",
+	privs = {server = true},
+	func = function(caller, param)
+		param = param:trim()
+		if param == "" then
+			return false, "Invalid parameters (see /help hasprivs)"
+		end
+		if not core.registered_privileges[param] then
+			return false, "Unknown privilege!"
+		end
+		local privs = core.string_to_privs(param)
+		local players_with_privs = {}
+		for _, player in pairs(core.get_connected_players()) do
+			local toname = player:get_player_name()
+			if core.check_player_privs(toname, privs) then
+				table.insert(players_with_privs, toname)
+			end
+		end	
+		return true, "Players with the " ..param.. " priv: " ..table.concat(players_with_privs, ", ")
+	end	
 })
 
 local function handle_grant_command(caller, grantname, grantprivstr)

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -105,7 +105,7 @@ core.register_chatcommand("privs", {
 
 core.register_chatcommand("hasprivs", {
 	params = "<priv>",
-	description = "Returns a list of all online players with the priv passed as param. e.g. /hasprivs fly",
+	description = "Return list of all online players with privilege.",
 	privs = {basic_privs = true},
 	func = function(caller, param)
 		param = param:trim()

--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -123,7 +123,7 @@ core.register_chatcommand("hasprivs", {
 				table.insert(players_with_privs, player_name)
 			end
 		end	
-		return true, "Players with the " .. param .. " priv: " ..
+		return true, "Players with the \"" .. param .. "\" priv: " ..
 			table.concat(players_with_privs, ", ")
 	end	
 })


### PR DESCRIPTION
## Proposed Changes
- Implemented new chat-command to list all online players with a given priv.
- Minor typo fix in builtin/game/chatcommands.lua (`chattcommands -> chatcommands`).

#### Syntax of `hasprivs`
- `/hasprivs <priv>`
  - `priv` should be a registered privilege.
  - Requires `basic_privs`.

#### Sample output
- `Players (online) with the "ban" priv: Moderator1, Moderator2, Moderator3`

#### Example usage
- `/hasprivs kick`
- `/hasprivs server`

**Note: This hasn't been tested in a multi-user environment. Testing it _before_ merging is advisable, so as to verify that the code works alright in a server environment.**