### PR TITLE
Don't show Android edit dialog when tapping read-only field

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3028,29 +3028,31 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 				core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
 		if ((hovered) && (hovered->getType() == irr::gui::EGUIET_EDIT_BOX)) {
 			bool retval = hovered->OnEvent(event);
-			if (retval) {
+			if (retval)
 				Environment->setFocus(hovered);
-			}
-			m_JavaDialogFieldName = getNameByID(hovered->getID());
+
+			std::string field_name = getNameByID(hovered->getID());
+			/* read-only field */
+			if (field_name == "")
+				return retval;
+
+			m_JavaDialogFieldName = field_name;
 			std::string message   = gettext("Enter ");
 			std::string label     = wide_to_utf8(getLabelByID(hovered->getID()));
-			if (label == "") {
+			if (label == "")
 				label = "text";
-			}
 			message += gettext(label) + ":";
 
 			/* single line text input */
 			int type = 2;
 
 			/* multi line text input */
-			if (((gui::IGUIEditBox*) hovered)->isMultiLineEnabled()) {
+			if (((gui::IGUIEditBox*) hovered)->isMultiLineEnabled())
 				type = 1;
-			}
 
 			/* passwords are always single line */
-			if (((gui::IGUIEditBox*) hovered)->isPasswordBox()) {
+			if (((gui::IGUIEditBox*) hovered)->isPasswordBox())
 				type = 3;
-			}
 
 			porting::showInputDialog(gettext("ok"), "",
 					wide_to_utf8(((gui::IGUIEditBox*) hovered)->getText()),

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3033,13 +3033,13 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 
 			std::string field_name = getNameByID(hovered->getID());
 			/* read-only field */
-			if (field_name == "")
+			if (field_name.empty())
 				return retval;
 
 			m_JavaDialogFieldName = field_name;
 			std::string message   = gettext("Enter ");
 			std::string label     = wide_to_utf8(getLabelByID(hovered->getID()));
-			if (label == "")
+			if (label.empty())
 				label = "text";
 			message += gettext(label) + ":";
 


### PR DESCRIPTION
https://github.com/minetest/minetest/blob/a1598e1b83e28503745165d5749cd21b77e97818/doc/lua_api.txt#L2205

However, Android edit dialog is still shown when the read-only text area is tapped. This PR fixes that.

Fixes #7170.