### PR TITLE
Say position of locale dir more clearly in docs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2613,7 +2613,7 @@ operations such as `minetest.colorize` which are also concatenation.
 
 ### Translation file format
 A translation file has the suffix `.[lang].tr`, where `[lang]` is the language
-it corresponds to.
+it corresponds to. It must be put into the `locale` subdirectory of the mod.
 The file should be a text file, with the following format:
 
 * Lines beginning with `# textdomain:` (the space is significant) can be used


### PR DESCRIPTION
This tiny PR adds the following sentence into the Lua API docs:
“It must be put into the `locale` subdirectory of the mod.”
(context: “It” refers to the `.tr` file used for the client-side translation system)

Because it was not clear before. It's already written in the Lua API doc, but can be easily overlooked. Proof: https://forum.minetest.net/viewtopic.php?f=18&t=18349&start=50#p318678