### PR TITLE
Pointed_thing_to_face_pos: Fix crash when inside a node

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -685,6 +685,12 @@ end
 -- Returns the exact coordinate of a pointed surface
 --------------------------------------------------------------------------------
 function core.pointed_thing_to_face_pos(placer, pointed_thing)
+	-- Avoid crash in some situations when player is inside a node, causing
+	-- 'above' to equal 'under'.
+	if vector.equals(pointed_thing.above, pointed_thing.under) then
+		return pointed_thing.under
+	end
+
 	local eye_height = placer:get_properties().eye_height
 	local eye_offset_first = placer:get_eye_offset()
 	local node_pos = pointed_thing.under


### PR DESCRIPTION
#6643 Avoid crash when head is inside a non-walkable and buildable_to node,
causing 'above' to equal 'under'.
In this situation return 'under' which is a vector very close to what
would be returned if not inside the node.
//////////////////

For #6643 
Tested.

To reproduce crash in MTG:
Enable free move, fly down a little, and place a stair or slab while player head is inside long grass, dry shrub, junglegrass etc.

With PR, the result is suitable and intuitive: the stair or slab is placed where the plantlike node is.

The issue suggested returning `vector.new()` (a zero vector). Although that has the same suitable result in the 'stairs' mod it may be unsuitable for other mods. Normally a float position vector is returned that is the point on the node's face, so i chose to return `pointed_thing.under` which is the integer position vector of the node itself.