### PR TITLE
Protocol cleanups: Remove legacy access denied, legacy HUDs; improve damage & HP values

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -437,7 +437,7 @@ void Client::step(float dtime)
 		ClientEnvEvent envEvent = m_env.getClientEnvEvent();
 
 		if (envEvent.type == CEE_PLAYER_DAMAGE) {
-			u8 damage = envEvent.player_damage.amount;
+			u16 damage = envEvent.player_damage.amount;
 
 			if (envEvent.player_damage.send_to_server)
 				sendDamage(damage);
@@ -1213,9 +1213,9 @@ void Client::sendChangePassword(const std::string &oldpassword,
 }
 
 
-void Client::sendDamage(u8 damage)
+void Client::sendDamage(u16 damage)
 {
-	NetworkPacket pkt(TOSERVER_DAMAGE, sizeof(u8));
+	NetworkPacket pkt(TOSERVER_DAMAGE, sizeof(u16));
 	pkt << damage;
 	Send(&pkt);
 }
@@ -1515,17 +1515,6 @@ void Client::typeChatMessage(const std::wstring &message)
 
 	// Send to others
 	sendChatMessage(message);
-
-	// Show locally
-	if (message[0] != L'/') {
-		// compatibility code
-		if (m_proto_ver < 29) {
-			LocalPlayer *player = m_env.getLocalPlayer();
-			assert(player);
-			std::wstring name = narrow_to_wide(player->getName());
-			pushToChatQueue(new ChatMessage(CHATMESSAGE_TYPE_NORMAL, message, name));
-		}
-	}
 }
 
 void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -243,7 +243,7 @@ public:
 	void clearOutChatQueue();
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword);
-	void sendDamage(u8 damage);
+	void sendDamage(u16 damage);
 	void sendRespawn();
 	void sendReady();
 
@@ -342,7 +342,7 @@ public:
 	bool mediaReceived()
 	{ return !m_media_downloader; }
 
-	u8 getProtoVersion()
+	u16 getProtoVersion() const
 	{ return m_proto_ver; }
 
 	bool connectedToServer();
@@ -500,11 +500,8 @@ private:
 	u8 m_server_ser_ver;
 
 	// Used version of the protocol with server
-	// Values smaller than 25 only mean they are smaller than 25,
-	// and aren't accurate. We simply just don't know, because
-	// the server didn't send the version back then.
 	// If 0, server init hasn't been received yet.
-	u8 m_proto_ver = 0;
+	u16 m_proto_ver = 0;
 
 	u16 m_playeritem = 0;
 	bool m_inventory_updated = false;

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -228,7 +228,7 @@ void ClientEnvironment::step(float dtime)
 		float speed = pre_factor * speed_diff.getLength();
 		if (speed > tolerance && !player_immortal) {
 			f32 damage_f = (speed - tolerance) / BS * post_factor;
-			u8 damage = (u8)MYMIN(damage_f + 0.5, 255);
+			u16 damage = MYMIN(damage_f + 0.5, U16_MAX);
 			if (damage != 0) {
 				damageLocalPlayer(damage, true);
 				m_client->getEventManager()->put(
@@ -419,7 +419,7 @@ void ClientEnvironment::processActiveObjectMessage(u16 id, const std::string &da
 	Callbacks for activeobjects
 */
 
-void ClientEnvironment::damageLocalPlayer(u8 damage, bool handle_hp)
+void ClientEnvironment::damageLocalPlayer(u16 damage, bool handle_hp)
 {
 	LocalPlayer *lplayer = getLocalPlayer();
 	assert(lplayer);

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -53,7 +53,7 @@ struct ClientEnvEvent
 		//struct{
 		//} none;
 		struct{
-			u8 amount;
+			u16 amount;
 			bool send_to_server;
 		} player_damage;
 	};
@@ -115,7 +115,7 @@ public:
 		Callbacks for activeobjects
 	*/
 
-	void damageLocalPlayer(u8 damage, bool handle_hp=true);
+	void damageLocalPlayer(u16 damage, bool handle_hp = true);
 
 	/*
 		Client likes to call these

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -371,7 +371,7 @@ void GenericCAO::processInitData(const std::string &data)
 	m_id = readU16(is);
 	m_position = readV3F32(is);
 	m_rotation = readV3F32(is);
-	m_hp = readS16(is);
+	m_hp = readU16(is);
 	const u8 num_messages = readU8(is);
 
 	for (int i = 0; i < num_messages; i++) {
@@ -1488,11 +1488,10 @@ void GenericCAO::processMessage(const std::string &data)
 
 		updateAttachments();
 	} else if (cmd == GENERIC_CMD_PUNCHED) {
-		/*s16 damage =*/ readS16(is);
-		s16 result_hp = readS16(is);
+		u16 result_hp = readU16(is);
 
 		// Use this instead of the send damage to not interfere with prediction
-		s16 damage = m_hp - result_hp;
+		s32 damage = (s32)m_hp - result_hp;
 
 		m_hp = result_hp;
 
@@ -1523,16 +1522,6 @@ void GenericCAO::processMessage(const std::string &data)
 			std::string name = deSerializeString(is);
 			int rating = readS16(is);
 			m_armor_groups[name] = rating;
-		}
-	} else if (cmd == GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES) {
-		// Deprecated, for backwards compatibility only.
-		readU8(is); // version
-		m_prop.nametag_color = readARGB8(is);
-		if (m_nametag != NULL) {
-			m_nametag->nametag_color = m_prop.nametag_color;
-			v3f pos;
-			pos.Y = m_prop.collisionbox.MaxEdge.Y + 0.3f;
-			m_nametag->nametag_pos = pos;
 		}
 	} else if (cmd == GENERIC_CMD_SPAWN_INFANT) {
 		u16 child_id = readU16(is);

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -86,7 +86,7 @@ private:
 	v3f m_velocity;
 	v3f m_acceleration;
 	v3f m_rotation;
-	s16 m_hp = 1;
+	u16 m_hp = 1;
 	SmoothTranslator<v3f> pos_translator;
 	SmoothTranslatorWrappedv3f rot_translator;
 	// Spritesheet/animation stuff

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -475,25 +475,6 @@ void Hud::drawHotbar(u16 playeritem) {
 				hotbar_itemcount / 2, mainlist, playeritem + 1, 0);
 		}
 	}
-
-	//////////////////////////// compatibility code to be removed //////////////
-	// this is ugly as hell but there's no other way to keep compatibility to
-	// old servers
-	if ((player->hud_flags & HUD_FLAG_HEALTHBAR_VISIBLE)) {
-		drawStatbar(v2s32(floor(0.5 * (float)m_screensize.X + 0.5),
-			floor(1 * (float) m_screensize.Y + 0.5)),
-			HUD_CORNER_UPPER, 0, "heart.png",
-			player->hp, v2s32((-10*24)-25,-(48+24+10)), v2s32(24,24));
-	}
-
-	if ((player->hud_flags & HUD_FLAG_BREATHBAR_VISIBLE) &&
-			(player->getBreath() < 11)) {
-		drawStatbar(v2s32(floor(0.5 * (float)m_screensize.X + 0.5),
-			floor(1 * (float) m_screensize.Y + 0.5)),
-			HUD_CORNER_UPPER, 0, "bubble.png",
-			player->getBreath(), v2s32(25,-(48+24+10)), v2s32(24,24));
-	}
-	////////////////////////////////////////////////////////////////////////////
 }
 
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -935,8 +935,8 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 {
 	std::ostringstream os(std::ios::binary);
 
-	// Protocol >= 36
-	writeU8(os, 2); // version
+	// Protocol >= 15
+	writeU8(os, 1); // version
 	os << serializeString(m_player->getName()); // name
 	writeU8(os, 1); // is_player
 	writeS16(os, getId()); // id

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -39,7 +39,7 @@ public:
 	// Deprecated
 	f32 getRadYawDep() const { return (m_rotation.Y + 90.) * core::DEGTORAD; }
 
-	s16 getHP() const { return m_hp; }
+	u16 getHP() const { return m_hp; }
 	// Use a function, if isDead can be defined by other conditions
 	bool isDead() const { return m_hp == 0; }
 
@@ -64,7 +64,7 @@ public:
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();
 protected:
-	s16 m_hp = -1;
+	u16 m_hp = 1;
 
 	v3f m_rotation;
 
@@ -127,8 +127,7 @@ public:
 	void moveTo(v3f pos, bool continuous);
 	float getMinimumSavedMovement();
 	std::string getDescription();
-	void setHP(s16 hp, const PlayerHPChangeReason &reason);
-	s16 getHP() const;
+	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity)
@@ -258,9 +257,8 @@ public:
 		ServerActiveObject *puncher,
 		float time_from_last_punch);
 	void rightClick(ServerActiveObject *clicker) {}
-	void setHP(s16 hp, const PlayerHPChangeReason &reason);
-	void setHPRaw(s16 hp) { m_hp = hp; }
-	s16 readDamage();
+	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHPRaw(u16 hp) { m_hp = hp; }
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);
 
@@ -351,7 +349,6 @@ private:
 	RemotePlayer *m_player = nullptr;
 	session_t m_peer_id = 0;
 	Inventory *m_inventory = nullptr;
-	s16 m_damage = 0;
 
 	// Cheat prevention
 	LagPool m_dig_pool;

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -553,7 +553,7 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 		pg_to_float(results, 0, 3),
 		pg_to_float(results, 0, 4))
 	);
-	sao->setHPRaw((s16) pg_to_int(results, 0, 5));
+	sao->setHPRaw((u16) pg_to_int(results, 0, 5));
 	sao->setBreath((u16) pg_to_int(results, 0, 6), false);
 
 	PQclear(results);

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -546,7 +546,7 @@ bool PlayerDatabaseSQLite3::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	sao->setLookPitch(sqlite_to_float(m_stmt_player_load, 0));
 	sao->setPlayerYaw(sqlite_to_float(m_stmt_player_load, 1));
 	sao->setBasePosition(sqlite_to_v3f(m_stmt_player_load, 2));
-	sao->setHPRaw((s16) MYMIN(sqlite_to_int(m_stmt_player_load, 5), S16_MAX));
+	sao->setHPRaw((u16) MYMIN(sqlite_to_int(m_stmt_player_load, 5), U16_MAX));
 	sao->setBreath((u16) MYMIN(sqlite_to_int(m_stmt_player_load, 6), U16_MAX), false);
 	sqlite3_reset(m_stmt_player_load);
 

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -92,13 +92,11 @@ std::string gob_cmd_set_sprite(
 	return os.str();
 }
 
-std::string gob_cmd_punched(s16 damage, s16 result_hp)
+std::string gob_cmd_punched(u16 result_hp)
 {
 	std::ostringstream os(std::ios::binary);
 	// command
 	writeU8(os, GENERIC_CMD_PUNCHED);
-	// damage
-	writeS16(os, damage);
 	// result_hp
 	writeS16(os, result_hp);
 	return os.str();
@@ -181,17 +179,6 @@ std::string gob_cmd_update_attachment(int parent_id, const std::string &bone,
 	os<<serializeString(bone);
 	writeV3F32(os, position);
 	writeV3F32(os, rotation);
-	return os.str();
-}
-
-std::string gob_cmd_update_nametag_attributes(video::SColor color)
-{
-	std::ostringstream os(std::ios::binary);
-	// command
-	writeU8(os, GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES);
-	// parameters
-	writeU8(os, 1); // version for forward compatibility
-	writeARGB8(os, color);
 	return os.str();
 }
 

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -35,8 +35,7 @@ enum GenericCMD {
 	GENERIC_CMD_SET_BONE_POSITION,
 	GENERIC_CMD_ATTACH_TO,
 	GENERIC_CMD_SET_PHYSICS_OVERRIDE,
-	GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES,
-	GENERIC_CMD_SPAWN_INFANT,
+	GENERIC_CMD_SPAWN_INFANT = 11,
 	GENERIC_CMD_SET_ANIMATION_SPEED
 };
 
@@ -63,7 +62,7 @@ std::string gob_cmd_set_sprite(
 	bool select_horiz_by_yawpitch
 );
 
-std::string gob_cmd_punched(s16 damage, s16 result_hp);
+std::string gob_cmd_punched(u16 result_hp);
 
 std::string gob_cmd_update_armor_groups(const ItemGroupList &armor_groups);
 
@@ -80,8 +79,6 @@ std::string gob_cmd_update_bone_position(const std::string &bone, v3f position,
 
 std::string gob_cmd_update_attachment(int parent_id, const std::string &bone,
 		v3f position, v3f rotation);
-
-std::string gob_cmd_update_nametag_attributes(video::SColor color);
 
 std::string gob_cmd_update_infant(u16 id, u8 type,
 		const std::string &client_initialization_data);

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -77,7 +77,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ActiveObjectMessages }, // 0x32
 	{ "TOCLIENT_HP",                       TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HP }, // 0x33
 	{ "TOCLIENT_MOVE_PLAYER",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_MovePlayer }, // 0x34
-	{ "TOCLIENT_ACCESS_DENIED_LEGACY",     TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_AccessDenied }, // 0x35
+	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_DEATHSCREEN",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_DeathScreen }, // 0x37
 	{ "TOCLIENT_MEDIA",                    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_Media }, // 0x38

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -345,11 +345,7 @@ enum ToClientCommand
 		f1000 player yaw
 	*/
 
-	TOCLIENT_ACCESS_DENIED_LEGACY = 0x35,
-	/*
-		u16 reason_length
-		wstring reason
-	*/
+	TOCLIENT_ACCESS_DENIED_LEGACY = 0x35, // Obsolete
 
 	TOCLIENT_PLAYERITEM = 0x36, // Obsolete
 
@@ -771,7 +767,7 @@ enum ToServerCommand
 
 	TOSERVER_DAMAGE = 0x35,
 	/*
-		u8 amount
+		u16 amount
 	*/
 
 	TOSERVER_PASSWORD_LEGACY = 0x36, // Obsolete

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -166,7 +166,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_ACTIVE_OBJECT_MESSAGES",   0, true }, // 0x32 Special packet, sent by 0 (rel) and 1 (unrel) channel
 	{ "TOCLIENT_HP",                       0, true }, // 0x33
 	{ "TOCLIENT_MOVE_PLAYER",              0, true }, // 0x34
-	{ "TOCLIENT_ACCESS_DENIED_LEGACY",     0, true }, // 0x35
+	null_command_factory, // 0x35
 	null_command_factory, // 0x36
 	{ "TOCLIENT_DEATHSCREEN",              0, true }, // 0x37
 	{ "TOCLIENT_MEDIA",                    2, true }, // 0x38

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -776,7 +776,7 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 
 void Server::handleCommand_Damage(NetworkPacket* pkt)
 {
-	u8 damage;
+	u16 damage;
 
 	*pkt >> damage;
 
@@ -812,7 +812,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 				<< std::endl;
 
 		PlayerHPChangeReason reason(PlayerHPChangeReason::FALL);
-		playersao->setHP(playersao->getHP() - damage, reason);
+		playersao->setHP((s32)playersao->getHP() - damage, reason);
 		SendPlayerHPOrDie(playersao, reason);
 	}
 }

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -75,7 +75,7 @@ std::string ObjectProperties::dump()
 void ObjectProperties::serialize(std::ostream &os) const
 {
 	writeU8(os, 4); // PROTOCOL_VERSION >= 37
-	writeS16(os, hp_max);
+	writeU16(os, hp_max);
 	writeU8(os, physical);
 	writeF32(os, weight);
 	writeV3F32(os, collisionbox.MinEdge);
@@ -126,7 +126,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 	if (version != 4)
 		throw SerializationError("unsupported ObjectProperties version");
 
-	hp_max = readS16(is);
+	hp_max = readU16(is);
 	physical = readU8(is);
 	weight = readF32(is);
 	collisionbox.MinEdge = readV3F32(is);

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 struct ObjectProperties
 {
-	s16 hp_max = 1;
+	u16 hp_max = 1;
 	u16 breath_max = 0;
 	bool physical = false;
 	bool collideWithObjects = true;

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -98,7 +98,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 
 	if (sao) {
 		try {
-			sao->setHPRaw(args.getS32("hp"));
+			sao->setHPRaw(args.getU16("hp"));
 		} catch(SettingNotFoundException &e) {
 			sao->setHPRaw(PLAYER_MAX_HP_DEFAULT);
 		}
@@ -115,7 +115,7 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 		} catch (SettingNotFoundException &e) {}
 
 		try {
-			sao->setBreath(args.getS32("breath"), false);
+			sao->setBreath(args.getU16("breath"), false);
 		} catch (SettingNotFoundException &e) {}
 
 		try {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -191,7 +191,7 @@ void read_object_properties(lua_State *L, int index,
 
 	int hp_max = 0;
 	if (getintfield(L, -1, "hp_max", hp_max))
-		prop->hp_max = (s16)rangelim(hp_max, 0, S16_MAX);
+		prop->hp_max = (u16)rangelim(hp_max, 0, U16_MAX);
 
 	getintfield(L, -1, "breath_max", prop->breath_max);
 	getboolfield(L, -1, "physical", prop->physical);

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -169,24 +169,6 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	// Set default values that differ from ObjectProperties defaults
 	prop->hp_max = 10;
 
-	/* Read stuff */
-
-	prop->hp_max = getintfield_default(L, -1, "hp_max", 10);
-
-	getboolfield(L, -1, "physical", prop->physical);
-	getboolfield(L, -1, "collide_with_objects", prop->collideWithObjects);
-
-	getfloatfield(L, -1, "weight", prop->weight);
-
-	lua_getfield(L, -1, "collisionbox");
-	if (lua_istable(L, -1))
-		prop->collisionbox = read_aabb3f(L, -1, 1.0);
-	lua_pop(L, 1);
-
-	getstringfield(L, -1, "visual", prop->visual);
-
-	getstringfield(L, -1, "mesh", prop->mesh);
-
 	// Deprecated: read object properties directly
 	read_object_properties(L, -1, prop, getServer()->idef());
 

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -77,8 +77,8 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 	return readParam<bool>(L, -1);
 }
 
-s16 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
-	s16 hp_change, const PlayerHPChangeReason &reason)
+s32 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
+	s32 hp_change, const PlayerHPChangeReason &reason)
 {
 	SCRIPTAPI_PRECHECKHEADER
 

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -46,7 +46,7 @@ public:
 	bool on_punchplayer(ServerActiveObject *player, ServerActiveObject *hitter,
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);
-	s16 on_player_hpchange(ServerActiveObject *player, s16 hp_change,
+	s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
 			const PlayerHPChangeReason &reason);
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -321,7 +321,9 @@ int ModApiServer::l_kick_player(lua_State *L)
 		lua_pushboolean(L, false); // No such player
 		return 1;
 	}
-	getServer(L)->DenyAccess_Legacy(player->getPeerId(), utf8_to_wide(message));
+
+	getServer(L)->DenyAccess(player->getPeerId(),
+		SERVER_ACCESSDENIED_CUSTOM_STRING, message);
 	lua_pushboolean(L, true);
 	return 1;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -376,7 +376,6 @@ private:
 	void SendBreath(session_t peer_id, u16 breath);
 	void SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 		const std::string &custom_reason, bool reconnect = false);
-	void SendAccessDenied_Legacy(session_t peer_id, const std::wstring &reason);
 	void SendDeathscreen(session_t peer_id, bool set_camera_point_target,
 		v3f camera_point_target);
 	void SendItemDef(session_t peer_id, IItemDefManager *itemdef, u16 protocol_version);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -140,10 +140,8 @@ public:
 	{ return 0; }
 	virtual void rightClick(ServerActiveObject *clicker)
 	{}
-	virtual void setHP(s16 hp, const PlayerHPChangeReason &reason)
-	{}
-	virtual s16 getHP() const
-	{ return 0; }
+	virtual void setHP(s32 hp, const PlayerHPChangeReason &reason) {}
+	virtual u16 getHP() const { return 0; }
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}


### PR DESCRIPTION
Remove TOCLIENT_ACCESS_DENIED_LEGACY and DenyAccess_Legacy
Remove deprecated GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES
 -> Raise client initialization data version
Remove health and breath HUD compatibility code

Breaks backwards compatibility (again).