### PR TITLE
Make the server status message customizable

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -768,7 +768,11 @@ core.register_chatcommand("rollback", {
 core.register_chatcommand("status", {
 	description = "Show server status",
 	func = function(name, param)
-		return true, core.get_server_status()
+		local status = core.get_server_status(name, false)
+		if status and status ~= "" then
+			return true, status
+		end
+		return false, "This command was disabled by a mod or game"
 	end,
 })
 

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -62,6 +62,12 @@ end
 core.register_on_joinplayer(function(player)
 	local player_name = player:get_player_name()
 	player_list[player_name] = player
+	if not minetest.is_singleplayer() then
+		local status = core.get_server_status(player_name, true)
+		if status and status ~= "" then
+			core.chat_send_player(player_name, status)
+		end
+	end
 	core.send_join_message(player_name)
 end)
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -948,9 +948,6 @@ map-dir (Map directory) path
 #    Setting it to -1 disables the feature.
 item_entity_ttl (Item entity TTL) int 900
 
-#    If enabled, show the server status message on player connection.
-show_statusline_on_connect (Status message on connection) bool true
-
 #    Enable players getting damage and dying.
 enable_damage (Damage) bool false
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3536,7 +3536,13 @@ These functions return the leftover itemstack.
       Negative delay cancels the current active shutdown.
       Zero delay triggers an immediate shutdown.
 * `minetest.cancel_shutdown_requests()`: cancel current delayed shutdown
-* `minetest.get_server_status()`: returns server status string
+* `minetest.get_server_status(name, joined)`
+    * Returns the server status string when a player joins or when the command
+      `/status` is called. Returns `nil` or an empty string when the message is
+      disabled.
+    * `joined`: Boolean value, indicates whether the function was called when
+      a player joined.
+    * This function may be overwritten by mods to customize the status message.
 * `minetest.get_server_uptime()`: returns the server uptime in seconds
 * `minetest.remove_player(name)`: remove player from database (if they are not
   connected).

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1130,10 +1130,6 @@
 #    type: int
 # item_entity_ttl = 900
 
-#    If enabled, show the server status message on player connection.
-#    type: bool
-# show_statusline_on_connect = true
-
 #    Enable players getting damage and dying.
 #    type: bool
 # enable_damage = false

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -305,7 +305,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("motd", "");
 	settings->setDefault("max_users", "15");
 	settings->setDefault("creative_mode", "false");
-	settings->setDefault("show_statusline_on_connect", "true");
 	settings->setDefault("enable_damage", "true");
 	settings->setDefault("default_password", "");
 	settings->setDefault("default_privs", "interact, shout");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1032,11 +1032,6 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	// Send Breath
 	SendPlayerBreath(playersao);
 
-	// Note things in chat if not in simple singleplayer mode
-	if (!m_simple_singleplayer_mode && g_settings->getBool("show_statusline_on_connect")) {
-		// Send information about server to player in chat
-		SendChatMessage(peer_id, ChatMessage(CHATMESSAGE_TYPE_SYSTEM, getStatusString()));
-	}
 	Address addr = getPeerAddress(player->getPeerId());
 	std::string ip_str = addr.serializeString();
 	actionstream<<player->getName() <<" [" << ip_str << "] joins game. " << std::endl;


### PR DESCRIPTION
Implements feature request in #7354  

Remove now redundant setting show_statusline_on_connect
Improve documentation of `minetest.get_server_status`

Difference to before: The current player name is now shown in the player list too on join.
```
# Server: version=0.5.0-dev-debug, uptime=0.871, max_lag=0.5459, clients={Foobar}
*** Foobar joined the game.
```