### PR TITLE
Dungeons: Fix duplication of y limit parameters

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -71,8 +71,6 @@ DungeonGen::DungeonGen(const NodeDefManager *ndef,
 		dp.room_size_large_max = v3s16(16, 16, 16);
 		dp.rooms_min           = 2;
 		dp.rooms_max           = 16;
-		dp.y_min               = -MAX_MAP_GENERATION_LIMIT;
-		dp.y_max               = MAX_MAP_GENERATION_LIMIT;
 		dp.notifytype          = GENNOTIFY_DUNGEON;
 
 		dp.np_density  = nparams_dungeon_density;
@@ -86,8 +84,6 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	assert(vm);
 
 	//TimeTaker t("gen dungeons");
-	if (nmin.Y < dp.y_min || nmax.Y > dp.y_max)
-		return;
 
 	float nval_density = NoisePerlin3D(&dp.np_density, nmin.X, nmin.Y, nmin.Z, dp.seed);
 	if (nval_density < 1.0f)

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -56,8 +56,6 @@ struct DungeonParams {
 	v3s16 room_size_large_max;
 	u16 rooms_min;
 	u16 rooms_max;
-	s16 y_min;
-	s16 y_max;
 	GenNotifyType notifytype;
 
 	NoiseParams np_density;

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -883,8 +883,6 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 	dp.corridor_len_max = 13;
 	dp.rooms_min        = 2;
 	dp.rooms_max        = 16;
-	dp.y_min            = -MAX_MAP_GENERATION_LIMIT;
-	dp.y_max            = MAX_MAP_GENERATION_LIMIT;
 
 	dp.np_density       = nparams_dungeon_density;
 	dp.np_alt_wall      = nparams_dungeon_alt_wall;

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -564,14 +564,11 @@ void MapgenV6::makeChunk(BlockMakeData *data)
 		DungeonParams dp;
 
 		dp.seed             = seed;
-
 		dp.only_in_ground   = true;
 		dp.corridor_len_min = 1;
 		dp.corridor_len_max = 13;
 		dp.rooms_min        = 2;
 		dp.rooms_max        = 16;
-		dp.y_min            = -MAX_MAP_GENERATION_LIMIT;
-		dp.y_max            = MAX_MAP_GENERATION_LIMIT;
 
 		dp.np_density
 			= NoiseParams(0.9, 0.5, v3f(500.0, 500.0, 500.0), 0, 2, 0.8, 2.0);


### PR DESCRIPTION
In 04fb10914c0d03ee77dafe610f336f23c58949ab i added dungeon y-limits to 'DungeonParams' so that either mapgens could use these (they never did) or these would become user-settable if 'DungeonParams' became accessible to users, as hmmmm planned to do (but they never did, he left MT).

More recently i added dungeon y-limits as new mapgen-specific parameters to make these settable by users, forgetting that this caused a duplication. This PR removes the original and unused y-limit parameters.
Like the cave parameters in mapgen parameters, it is a better implementation to move some dungeon parameters into mapgen parameters, so that they are set and stored per-world.