### PR TITLE
Schematic decorations: Fix placement bug when centred and rotated

### DIFF
--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -360,13 +360,22 @@ size_t DecoSchematic::generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceilin
 	if (p.Y < vm->m_area.MinEdge.Y)
 		return 0;
 
-	if (flags & DECO_PLACE_CENTER_X)
-		p.X -= (schematic->size.X - 1) / 2;
-	if (flags & DECO_PLACE_CENTER_Z)
-		p.Z -= (schematic->size.Z - 1) / 2;
-
 	Rotation rot = (rotation == ROTATE_RAND) ?
 		(Rotation)pr->range(ROTATE_0, ROTATE_270) : rotation;
+
+	if (flags & DECO_PLACE_CENTER_X) {
+		if (rot == ROTATE_0 || rot == ROTATE_180)
+			p.X -= (schematic->size.X - 1) / 2;
+		else
+			p.Z -= (schematic->size.X - 1) / 2;
+	}
+	if (flags & DECO_PLACE_CENTER_Z) {
+		if (rot == ROTATE_0 || rot == ROTATE_180)
+			p.Z -= (schematic->size.Z - 1) / 2;
+		else
+			p.X -= (schematic->size.Z - 1) / 2;
+	}
+
 	bool force_placement = (flags & DECO_FORCE_PLACEMENT);
 
 	schematic->blitToVManip(vm, p, rot, force_placement);


### PR DESCRIPTION
Previously, the centering caused by the 'place center x/z' flags did
not take rotation into account. So schematics with unequal X and Z
dimensions were incorrectly placed. The bug was hidden for schematics
equal in X and Z dimensions.
/////////////////////////

A game was experiencing placement problems with long horizontal log schematics, many were floating above the ground. As in MTG these used the 'place center x' flag and random rotation.

I tested for a bug by creating an 11-node long log with random rotation and 'place center x'. The length was long to show up any bug.
Many logs were floating a few nodes off the ground, many with no node anywhere near ground.
I noticed only the N-S logs had a placement bug. Because the log was defined as long in the X axis, the N-S logs were the rotated ones. The bug was therefore due to incompatibility between 'place center x/z' and rotation.
The code did not take rotation into account when applying the X and Z centering offsets.

The reason this bug went unnoticed so long is that most schematics have equal X and Z dimensions. Only schematics unequal in X and Z dimensions show the bug, and this now explains why MTG logs are sometimes placed strangely, it was just not very noticeable due to the short log length.

Screenshots show PR testing.
Note an 11 node log will have 5 nodes of overhang, the other end is often buried in a hill, so the screenshots show correct placement.

![screenshot_20180523_021837](https://user-images.githubusercontent.com/3686677/40398664-35c750e8-5e31-11e8-9cc9-f7f07cfdc94e.png)

^ Tree log was defined as long in X. All rotations checked as having correct placement

![screenshot_20180523_021441](https://user-images.githubusercontent.com/3686677/40398660-317add84-5e31-11e8-932c-f07d9fd233e7.png)

^ Acacia tree log was defined as long in Z. All rotations checked as having correct placement