### PR TITLE
Fix builtin lua function os.tempfolder

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -173,7 +173,8 @@ os.tempfolder = function()
 
 	local randname = "MTTempModFolder_" .. math.random(0,10000)
 	local backstring = filetocheck:reverse()
-	return filetocheck:sub(0,filetocheck:len()-backstring:find(DIR_DELIM)+1) ..randname
+	return filetocheck:sub(0, filetocheck:len() - backstring:find(DIR_DELIM) + 1) ..
+		randname
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -172,14 +172,8 @@ os.tempfolder = function()
 	os.remove(filetocheck)
 
 	local randname = "MTTempModFolder_" .. math.random(0,10000)
-	if DIR_DELIM == "\\" then
-		local tempfolder = os.getenv("TEMP")
-		return tempfolder .. filetocheck
-	else
-		local backstring = filetocheck:reverse()
-		return filetocheck:sub(0,filetocheck:len()-backstring:find(DIR_DELIM)+1) ..randname
-	end
-
+	local backstring = filetocheck:reverse()
+	return filetocheck:sub(0,filetocheck:len()-backstring:find(DIR_DELIM)+1) ..randname
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
@rubenwardy отлично seems that recent online content browser commit experiences crash.
It seems the commit itself is fine, but calls a previously unused os.tempfolder function, which behaves out of spec.

When DIR_DELIM is detected to be a "\\" backslash, the TEMP environment variable is concatenated with a filename obtained by os.tmpname.
A typical value of TEMP is: "C:\\Users\\blah\\AppData\\Local\\Temp\\"
A typical value of os.tmpname is ""C:\\Users\\blah\\AppData\\Local\\Temp\\3e340j" (and on linux platforms: "/tmp/s56.2f")

In other words both are absolute filenames, and cannot be concatenated.
os.tmpname already provides a suitable value, and does not need further processing.
Thus the special handling of DIR_DELIM "\\" is not necessary - removing it also fixes the crash.
