### PR TITLE
Vein ore: Fix bug caused by changing perlinmap Y size

### DIFF
--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -371,17 +371,23 @@ void OreVein::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	PcgRandom pr(blockseed + 520);
 	MapNode n_ore(c_ore, 0, ore_param2);
 
-	u32 sizex = (nmax.X - nmin.X + 1);
-
-	if (!noise) {
-		int sx = nmax.X - nmin.X + 1;
-		int sy = nmax.Y - nmin.Y + 1;
-		int sz = nmax.Z - nmin.Z + 1;
-		noise  = new Noise(&np, mapseed, sx, sy, sz);
-		noise2 = new Noise(&np, mapseed + 436, sx, sy, sz);
+	int sizex = nmax.X - nmin.X + 1;
+	int sizey = nmax.Y - nmin.Y + 1;
+	// Because this ore uses 3D noise the perlinmap Y size can be different in
+	// different mapchunks due to ore Y limits. So recreate the noise objects
+	// if Y size has changed.
+	// Because these noise objects are created multiple times for this ore type
+	// it is necessary to 'delete' them here.
+	if (!noise || sizey != sizey_prev) {
+		delete noise;
+		delete noise2;
+		int sizez = nmax.Z - nmin.Z + 1;
+		noise  = new Noise(&np, mapseed, sizex, sizey, sizez);
+		noise2 = new Noise(&np, mapseed + 436, sizex, sizey, sizez);
+		sizey_prev = sizey;
 	}
-	bool noise_generated = false;
 
+	bool noise_generated = false;
 	size_t index = 0;
 	for (int z = nmin.Z; z <= nmax.Z; z++)
 	for (int y = nmin.Y; y <= nmax.Y; y++)

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -126,6 +126,7 @@ public:
 
 	float random_factor;
 	Noise *noise2 = nullptr;
+	int sizey_prev = 0;
 
 	OreVein() = default;
 	virtual ~OreVein();


### PR DESCRIPTION
Because vein ore uses 3D noise (all the other ores use 2D noise) the
perlinmap Y size can be different in different mapchunks when close
to the ore Y limits.
Previously this caused bugs in the vein structure because changes in
perlinmap Y size did not recreate the noise objects.

Recreate the noise objects with the new Y size if Y size has changed.
//////////////////////

Fixes #7364 
Tested, used printf() to check when noise objects were recreated.