### PR TITLE
Print error when HOME is not set

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -351,6 +351,21 @@ bool getCurrentExecPath(char *buf, size_t len)
 #endif
 
 
+//// Non-Windows
+#if !defined(_WIN32)
+
+const char *getHomeOrFail()
+{
+	const char *home = getenv("HOME");
+	// In rare cases the HOME environment variable may be unset
+	FATAL_ERROR_IF(!home,
+		"Required environment variable HOME is not set");
+	return home;
+}
+
+#endif
+
+
 //// Windows
 #if defined(_WIN32)
 
@@ -430,7 +445,7 @@ bool setSystemPaths()
 	}
 
 #ifndef __ANDROID__
-	path_user = std::string(getenv("HOME")) + DIR_DELIM "."
+	path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
 		+ PROJECT_NAME;
 #endif
 
@@ -454,7 +469,7 @@ bool setSystemPaths()
 	}
 	CFRelease(resources_url);
 
-	path_user = std::string(getenv("HOME"))
+	path_user = std::string(getHomeOrFail())
 		+ "/Library/Application Support/"
 		+ PROJECT_NAME;
 	return true;
@@ -466,7 +481,7 @@ bool setSystemPaths()
 bool setSystemPaths()
 {
 	path_share = STATIC_SHAREDIR;
-	path_user  = std::string(getenv("HOME")) + DIR_DELIM "."
+	path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
 		+ lowercase(PROJECT_NAME);
 	return true;
 }


### PR DESCRIPTION
Related to #6869. When no HOME is set, the server crashes with
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```
which leaves the user in the dark. With this commit, the server will crash with
```
minetest/src/porting.cpp:1b3: bool porting::setSystemPaths(): A fatal error occured: Required environment variable HOME is not set
```
instead which is arguably nicer. Feel free to make this prettier if you like.

This PR modifies code for macOS and other Unices too, but tested only on Linux.