### PR TITLE
minetest.log: Add mod origin

### DIFF
--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -116,3 +116,6 @@ void script_run_callbacks_f(lua_State *L, int nargs,
 
 void log_deprecated(lua_State *L, const std::string &message,
 	int stack_depth=1);
+std::string get_optional_origin(lua_State *L, const std::string &modname);
+void log_warning(lua_State *L, const std::string &message);
+void log_error(lua_State *L, const std::string &message);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -69,7 +69,17 @@ int ModApiUtil::l_log(lua_State *L)
 			level = LL_NONE;
 		}
 	}
-	g_logger.log(level, text);
+	switch (level) {
+	case LL_ERROR:
+		log_error(L, text);
+		break;
+	case LL_WARNING:
+		log_warning(L, text);
+		break;
+	default:
+		g_logger.log(level,
+			get_optional_origin(L, getScriptApiBase(L)->getOrigin()) + text);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
See #6205
The log functions can be used for messages other than those generated by minetest.log, too.

Lots of mods prepend `[<modname>] ` to log messages because minetest didn't do this.

No level provided:
```
2018-05-27 12:39:24: [Server]: [luacmd] test
```

Action:
```
2018-05-27 12:39:31: ACTION[Server]: [luacmd] test
```

Warning:
```
2018-05-27 12:39:48: WARNING[Server]: test (at /home/ulrich/.minetest/mods/luacmd/init.lua:26)
```

Deprecated (same as deprecated was before):
```
2018-05-27 12:40:12: WARNING[Server]: test (at /home/ulrich/.minetest/mods/luacmd/init.lua:26)
```

Error:
```
2018-05-27 12:45:34: ERROR[Server]: test
2018-05-27 12:45:34: ERROR[Server]: stack traceback:
2018-05-27 12:45:34: ERROR[Server]: 	[C]: in function 'log'
2018-05-27 12:45:34: ERROR[Server]: 	[string "/lua command"]:1: in function 'cmdFunc'
2018-05-27 12:45:34: ERROR[Server]: 	/home/ulrich/.minetest/mods/luacmd/init.lua:26: in function </home/ulrich/.minetest/mods/luacmd/init.lua:12>
[…]
```
Is there a way to remove the log call from the stack traceback?