### PR TITLE
Mgv7: Avoid rivergen removing mod-placed nodes when overgenerating

### DIFF
--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -591,6 +591,11 @@ void MapgenV7::generateRidgeTerrain()
 			float uwatern = noise_ridge_uwater->result[index2d] * 2.0f;
 			if (std::fabs(uwatern) > width)
 				continue;
+			// Optimises, but also avoids removing nodes placed by mods in
+			// 'on-generated', when generating outside mapchunk.
+			content_t c = vm->m_data[vi].getContent();
+			if (c != c_stone)
+				continue;
 
 			float altitude = y - water_level;
 			float height_mod = (altitude + 17.0f) / 2.5f;


### PR DESCRIPTION
Only allow river generation to replace c_stone.
This also acts as an optimisation by being placed before canyon shape
calculation.
///////////////////

Fixes #7379 

Rivergen only needs to replace stone nodes as it runs directly after terrain generation. If it is not replacing stone it is replacing air with air or water with water.
Checking the content ID is faster than checking the nodedef for 'is_ground_content', the suggestion i made in the issue, this also avoids all 'ground content' nodes placed by mods being excavated.

I placed the new check after the check for being within the maximum area of the river canyon, and before the calculations that create the actual canyon shape.
The large majority of river generation is replacing air with air or water with water, so placing this new check where it is skips a lot of processing and acts as a performance optimisation.

Build fail is Travis error.