### PR TITLE
Biomemap: Avoid empty biomemap entry to fix failing biome dust 

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -692,6 +692,7 @@ void MapgenBasic::generateBiomes()
 				// (Re)calculate biome
 				biome = biomegen->getBiomeAtIndex(index, v3s16(x, y, z));
 
+				// Add biome to biomemap at first stone surface detected
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
 					biomemap[index] = biome->index;
 
@@ -760,6 +761,19 @@ void MapgenBasic::generateBiomes()
 			}
 
 			VoxelArea::add_y(em, vi, -1);
+		}
+		// If no stone surface was detected in this mapchunk column the biomemap
+		// will be empty for this (x, z) position. Add the currently active
+		// biome to the biomemap, or if biome is NULL calculate it for this
+		// position.
+		if (biomemap[index] == BIOME_NONE) {
+			if (biome) {
+				biomemap[index] = biome->index;
+			} else {
+				biome =
+					biomegen->getBiomeAtIndex(index, v3s16(x, node_min.Y, z));
+				biomemap[index] = biome->index;
+			}
 		}
 	}
 }


### PR DESCRIPTION
'generateBiomes()' constructs the biomemap as it generates biomes.
The biome calculated at first stone surface encountered is added to
the biomemap.
Previously, if no stone surface was encountered in a mapchunk column
the biomemap was left empty for that (x, z) position, causing biome
dust and water surface decoration placement to fail.

If at the base of a mapchunk column the biomemap is empty, add the
currently active biome to the biomemap, or if biome is NULL calculate
it for this position and add it to the biomemap.
/////////////////////////////

![screenshot_20180601_062308](https://user-images.githubusercontent.com/3686677/40822508-5b6d14c4-6564-11e8-94dc-cc03a5b210c2.png)

^ Fixed, compare with issue screenshot.

![screenshot_20180602_011836](https://user-images.githubusercontent.com/3686677/40868413-96de136e-6604-11e8-8302-06dad5e25926.png)

^ Fixed, compare with issue screenshot.

Fixes #7392 