### PR TITLE
World config: Make depends easier to read

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -74,23 +74,14 @@ local function get_formspec(data)
 					hard_deps_str .. ";0]" ..
 					"label[0,6;" .. fgettext("No optional dependencies") .. "]"
 			else
-				-- set the heights according to the number of list elements
-				local ratio = #hard_deps / (#soft_deps + #hard_deps)
-				-- avoid making one of the lists too short
-				local min_l = math.min(0.5,
-					math.min(#soft_deps, #hard_deps) * 0.25)
-				ratio = math.max(min_l, math.min(1.0 - min_l, ratio))
-				local h1 = 4.0 * ratio
-				local h2 = 4.0 - h1
-				local s_opt = 1.25 + h1 + 0.5
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
-					"textlist[0,1.75;5," .. h1 .. ";world_config_depends;" ..
+					"textlist[0,1.75;5,2.125;world_config_depends;" ..
 					hard_deps_str .. ";0]" ..
-					"label[0," .. s_opt .. ";" ..
-					fgettext("Optional dependencies:") .. "]" ..
-					"textlist[0," .. s_opt + 0.5 .. ";5," .. h2 ..
-					";world_config_optdepends;" .. soft_deps_str .. ";0]"
+					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
+					"]" ..
+					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
+					soft_deps_str .. ";0]"
 			end
 		end
 	end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -56,7 +56,7 @@ local function get_formspec(data)
 			if soft_deps_str == "" then
 				retval = retval ..
 					"label[0,1.25;" ..
-					fgettext("This mod does not have dependencies.") .. "]"
+					fgettext("No (optional) dependencies") .. "]"
 			else
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("No hard dependencies") ..
@@ -78,7 +78,7 @@ local function get_formspec(data)
 				local ratio = #hard_deps / (#soft_deps + #hard_deps)
 				-- avoid making one of the lists too short
 				local min_l = math.min(0.5,
-					math.min(#soft_deps, #hard_deps) * 0.15)
+					math.min(#soft_deps, #hard_deps) * 0.25)
 				ratio = math.max(min_l, math.min(1.0 - min_l, ratio))
 				local h1 = 4.0 * ratio
 				local h2 = 4.0 - h1

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -31,10 +31,6 @@ local function get_formspec(data)
 		"label[0.5,0;" .. fgettext("World:") .. "]" ..
 		"label[1.75,0;" .. data.worldspec.name .. "]"
 
-	local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
-	local hard_deps_str = table.concat(hard_deps, ",")
-	local soft_deps_str = table.concat(soft_deps, ",")
-
 	if mod.is_modpack or mod.type == "game" then
 		local info = minetest.formspec_escape(
 			core.get_content_info(mod.path).description)
@@ -48,6 +44,10 @@ local function get_formspec(data)
 		retval = retval ..
 			"textarea[0.25,0.7;5.75,7.2;;" .. info .. ";]"
 	else
+		local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
+		local hard_deps_str = table.concat(hard_deps, ",")
+		local soft_deps_str = table.concat(soft_deps, ",")
+
 		retval = retval ..
 			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
 			"label[0.75,0.7;" .. mod.name .. "]"

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -32,6 +32,8 @@ local function get_formspec(data)
 		"label[1.75,0;" .. data.worldspec.name .. "]"
 
 	local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
+	local hard_deps_str = table.concat(hard_deps, ",")
+	local soft_deps_str = table.concat(soft_deps, ",")
 
 	if mod.is_modpack or mod.type == "game" then
 		local info = minetest.formspec_escape(
@@ -50,8 +52,8 @@ local function get_formspec(data)
 			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
 			"label[0.75,0.7;" .. mod.name .. "]"
 
-		if hard_deps == "" then
-			if soft_deps == "" then
+		if hard_deps_str == "" then
+			if soft_deps_str == "" then
 				retval = retval ..
 					"label[0,1.25;" ..
 					fgettext("This mod does not have dependencies.") .. "]"
@@ -62,24 +64,33 @@ local function get_formspec(data)
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
 					"textlist[0,2.1;5,4;world_config_optdepends;" ..
-					soft_deps .. ";0]"
+					soft_deps_str .. ";0]"
 			end
 		else
-			if soft_deps == "" then
+			if soft_deps_str == "" then
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
 					"textlist[0,1.75;5,4;world_config_depends;" ..
-					hard_deps .. ";0]" ..
+					hard_deps_str .. ";0]" ..
 					"label[0,6;" .. fgettext("No optional dependencies") .. "]"
 			else
+				-- set the heights according to the number of list elements
+				local ratio = #hard_deps / (#soft_deps + #hard_deps)
+				-- avoid making one of the lists too short
+				local min_l = math.min(0.5,
+					math.min(#soft_deps, #hard_deps) * 0.15)
+				ratio = math.max(min_l, math.min(1.0 - min_l, ratio))
+				local h1 = 4.0 * ratio
+				local h2 = 4.0 - h1
+				local s_opt = 1.25 + h1 + 0.5
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
-					"textlist[0,1.75;5,2.125;world_config_depends;" ..
-					hard_deps .. ";0]" ..
-					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
-					"]" ..
-					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
-					soft_deps .. ";0]"
+					"textlist[0,1.75;5," .. h1 .. ";world_config_depends;" ..
+					hard_deps_str .. ";0]" ..
+					"label[0," .. s_opt .. ";" ..
+					fgettext("Optional dependencies:") .. "]" ..
+					"textlist[0," .. s_opt + 0.5 .. ";5," .. h2 ..
+					";world_config_optdepends;" .. soft_deps_str .. ";0]"
 			end
 		end
 	end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -48,13 +48,40 @@ local function get_formspec(data)
 	else
 		retval = retval ..
 			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
-			"label[0.75,0.7;" .. mod.name .. "]" ..
-			"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
-			"textlist[0,1.75;5,2.125;world_config_depends;" .. hard_deps ..
-			";0]" ..
-			"label[0,3.875;" .. fgettext("Optional dependencies:") .. "]" ..
-			"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
-			soft_deps .. ";0]"
+			"label[0.75,0.7;" .. mod.name .. "]"
+
+		if hard_deps == "" then
+			if soft_deps == "" then
+				retval = retval ..
+					"label[0,1.25;" ..
+					fgettext("This mod does not have dependencies.") .. "]"
+			else
+				retval = retval ..
+					"label[0,1.25;" .. fgettext("No hard dependencies") ..
+					"]" ..
+					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
+					"]" ..
+					"textlist[0,2.1;5,4;world_config_optdepends;" ..
+					soft_deps .. ";0]"
+			end
+		else
+			if soft_deps == "" then
+				retval = retval ..
+					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
+					"textlist[0,1.75;5,4;world_config_depends;" ..
+					hard_deps .. ";0]" ..
+					"label[0,6;" .. fgettext("No optional dependencies") .. "]"
+			else
+				retval = retval ..
+					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
+					"textlist[0,1.75;5,2.125;world_config_depends;" ..
+					hard_deps .. ";0]" ..
+					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
+					"]" ..
+					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
+					soft_deps .. ";0]"
+			end
+		end
 	end
 	retval = retval ..
 		"button[3.25,7;2.5,0.5;btn_config_world_save;" ..

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -63,7 +63,7 @@ local function get_formspec(data)
 					"]" ..
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
-					"textlist[0,2.1;5,4;world_config_optdepends;" ..
+					"textlist[0,2.25;5,4;world_config_optdepends;" ..
 					soft_deps_str .. ";0]"
 			end
 		else

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -332,11 +332,11 @@ end
 --------------------------------------------------------------------------------
 function pkgmgr.get_dependencies(path)
 	if path == nil then
-		return "", ""
+		return {}, {}
 	end
 
 	local info = core.get_content_info(path)
-	return table.concat(info.depends or {}, ","), table.concat(info.optional_depends or {}, ",")
+	return info.depends or {}, info.optional_depends or {}
 end
 
 ----------- tests whether all of the mods in the modpack are enabled -----------


### PR DESCRIPTION
* Do not show an empty list but a message that there're no depends instead
* Adjust the list height to avoid the scrollbar (reverted)
* Show one big list if there're either no optional or only optional depends

![2017-02-11-121451_1920x1080_scrot](https://cloud.githubusercontent.com/assets/3192173/22853385/633c0596-f055-11e6-871d-1f80f3edf5ec.png)
![2018-07-14-203929_1920x1056_scrot](https://user-images.githubusercontent.com/3192173/42727439-dcc46c52-87a6-11e8-9a27-3e2d37a42b1a.png)
[old screenshot, smaller minimum height](https://user-images.githubusercontent.com/3192173/40878761-d53d8914-6695-11e8-98e9-293f639d6950.png)
