### PR TITLE
World config: Add modpack descriptions and remove dependencies there

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -35,7 +35,7 @@ local function get_formspec(data)
 
 	if mod.is_modpack then
 		local info = minetest.formspec_escape(
-			pkgmgr.get_modpack_description(mod.path))
+			core.get_content_info(mod.path).description)
 		if info == "" then
 			info = fgettext("No modpack description provided.")
 		end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -34,7 +34,8 @@ local function get_formspec(data)
 	local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
 
 	if mod.is_modpack then
-		local info = pkgmgr.get_modpack_description(mod.path)
+		local info = minetest.formspec_escape(
+			pkgmgr.get_modpack_description(mod.path))
 		if info == "" then
 			info = fgettext("No modpack description provided.")
 		end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -33,14 +33,25 @@ local function get_formspec(data)
 
 	local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
 
+	if mod.is_modpack then
+		local info = pkgmgr.get_modpack_description(mod.path)
+		if info == "" then
+			info = fgettext("No modpack description provided.")
+		end
+		retval = retval ..
+			"label[0,0.7;" .. info .. "]"
+	else
+		retval = retval ..
+			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
+			"label[0.75,0.7;" .. mod.name .. "]" ..
+			"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
+			"textlist[0,1.75;5,2.125;world_config_depends;" .. hard_deps ..
+			";0]" ..
+			"label[0,3.875;" .. fgettext("Optional dependencies:") .. "]" ..
+			"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
+			soft_deps .. ";0]"
+	end
 	retval = retval ..
-		"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
-		"label[0.75,0.7;" .. mod.name .. "]" ..
-		"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
-		"textlist[0,1.75;5,2.125;world_config_depends;" .. hard_deps .. ";0]" ..
-		"label[0,3.875;" .. fgettext("Optional dependencies:") .. "]" ..
-		"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
-		soft_deps .. ";0]" ..
 		"button[3.25,7;2.5,0.5;btn_config_world_save;" ..
 		fgettext("Save") .. "]" ..
 		"button[5.75,7;2.5,0.5;btn_config_world_cancel;" ..

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -39,7 +39,7 @@ local function get_formspec(data)
 			info = fgettext("No modpack description provided.")
 		end
 		retval = retval ..
-			"label[0,0.7;" .. info .. "]"
+			"textarea[0.25,0.7;5.75,7.2;;" .. info .. ";]"
 	else
 		retval = retval ..
 			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -300,6 +300,18 @@ function pkgmgr.render_packagelist(render_list)
 end
 
 --------------------------------------------------------------------------------
+function pkgmgr.get_modpack_description(modfolder)
+	assert(modfolder, "missing modpack folder")
+	local descf = io.open(modfolder .. DIR_DELIM .. "description.txt", "r")
+	if not descf then
+		return "No description provided."
+	end
+	local content = descf:read("*all")
+	descf:close()
+	return minetest.formspec_escape(content)
+end
+
+--------------------------------------------------------------------------------
 function pkgmgr.get_dependencies(path)
 	if path == nil then
 		return "", ""

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -304,11 +304,11 @@ function pkgmgr.get_modpack_description(modfolder)
 	assert(modfolder, "missing modpack folder")
 	local descf = io.open(modfolder .. DIR_DELIM .. "description.txt", "r")
 	if not descf then
-		return "No description provided."
+		return ""
 	end
 	local content = descf:read("*all")
 	descf:close()
-	return minetest.formspec_escape(content)
+	return content
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -300,18 +300,6 @@ function pkgmgr.render_packagelist(render_list)
 end
 
 --------------------------------------------------------------------------------
-function pkgmgr.get_modpack_description(modfolder)
-	assert(modfolder, "missing modpack folder")
-	local descf = io.open(modfolder .. DIR_DELIM .. "description.txt", "r")
-	if not descf then
-		return ""
-	end
-	local content = descf:read("*all")
-	descf:close()
-	return content
-end
-
---------------------------------------------------------------------------------
 function pkgmgr.get_dependencies(path)
 	if path == nil then
 		return "", ""


### PR DESCRIPTION
This allows adding a description.txt to modpacks which is shown in the world config menu.
Before the PR, dependencies of the modpack were shown, which is nonsense because modpacks don't have depends.