### PR TITLE
Damage flash/camera tilt: Make shorter to reduce player blindness

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3833,23 +3833,23 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		Damage flash
 	*/
-	if (runData.damage_flash > 0.0) {
+	if (runData.damage_flash > 0.0f) {
 		video::SColor color(runData.damage_flash, 180, 0, 0);
 		driver->draw2DRectangle(color,
 					core::rect<s32>(0, 0, screensize.X, screensize.Y),
 					NULL);
 
-		runData.damage_flash -= 100.0 * dtime;
+		runData.damage_flash -= 384.0f * dtime;
 	}
 
 	/*
 		Damage camera tilt
 	*/
-	if (player->hurt_tilt_timer > 0.0) {
-		player->hurt_tilt_timer -= dtime * 5;
+	if (player->hurt_tilt_timer > 0.0f) {
+		player->hurt_tilt_timer -= dtime * 6.0f;
 
-		if (player->hurt_tilt_timer < 0)
-			player->hurt_tilt_strength = 0;
+		if (player->hurt_tilt_timer < 0.0f)
+			player->hurt_tilt_strength = 0.0f;
 	}
 
 	/*


### PR DESCRIPTION
 Damage flash/camera tilt: Make shorter to reduce player blindness

Damage flash is shortened from 0.98-1.27s to 0.25s-0.33s to reduce
player in-game blindness, especially useful for combat situations.
Is also visually more comfortable.
Damage camera tilt is made slightly shorter to match in duration.
Both flash and camera tilt are now of similar length to a typical
damage sound, such as the one used by Minetest Game which is 0.27s.
The 3 effects therefore become more synchronised and unified.