### PR TITLE
Stop autoforward on BACKWARD key-press (if autoforward is active)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1861,6 +1861,9 @@ void Game::processKeyInput()
 		dropSelectedItem(isKeyDown(KeyType::SNEAK));
 	} else if (wasKeyDown(KeyType::AUTOFORWARD)) {
 		toggleAutoforward();
+	} else if (wasKeyDown(KeyType::BACKWARD)) {
+		if (g_settings->getBool("continuous_forward"))
+			toggleAutoforward();
 	} else if (wasKeyDown(KeyType::INVENTORY)) {
 		openInventory();
 	} else if (input->cancelPressed()) {


### PR DESCRIPTION
Hi! I love the autoforward feature so I thought I would enhance it with this behavior. It comes naturally for me from playing other games with autorun in them. Also, since you cannot possibly walk forward and backward at the same time, it's only natural that pressing backwards would stop you moving forward, I believe.

I was not sure if I should create a new branch for this or not but since this is such a small commit, I thought I'd just send it to `master` anyway. Let me know if I should create a new request and thanks for your consideration!