### PR TITLE
Set ENABLE_GETTEXT to TRUE by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ if(NOT USE_CURL)
 endif()
 
 
-option(ENABLE_GETTEXT "Use GetText for internationalization" FALSE)
+option(ENABLE_GETTEXT "Use GetText for internationalization" TRUE)
 set(USE_GETTEXT FALSE)
 
 if(ENABLE_GETTEXT)


### PR DESCRIPTION
This sets the CMake option `ENABLE_GETTEXT` to `TRUE` by default.
In other words, Minetest will now build with translations enabled by default.

Gettext is currently disabled by default. Strange this wasn't noticed earlier.