### PR TITLE
Stop autoforward on BACKWARD key-press (if autoforward is active)

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -115,7 +115,8 @@ safe_dig_and_place (Safe digging and placing) bool false
 #    Enable random user input (only used for testing).
 random_input (Random input) bool false
 
-#    Continuous forward movement, toggled by autoforward key.
+#    Continuous forward movement, toggled by autoforward key. 
+#    Press the autoforward key again or the backwards movement to disable.
 continuous_forward (Continuous forward) bool false
 
 #    The length in pixels it takes for touch screen interaction to start.
@@ -147,6 +148,7 @@ joystick_frustum_sensitivity (Joystick frustum sensitivity) float 170
 keymap_forward (Forward key) key KEY_KEY_W
 
 #    Key for moving the player backward.
+#    Will also disable autoforward, when active.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
 keymap_backward (Backward key) key KEY_KEY_S
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1861,6 +1861,9 @@ void Game::processKeyInput()
 		dropSelectedItem(isKeyDown(KeyType::SNEAK));
 	} else if (wasKeyDown(KeyType::AUTOFORWARD)) {
 		toggleAutoforward();
+	} else if (wasKeyDown(KeyType::BACKWARD)) {
+		if (g_settings->getBool("continuous_forward"))
+			toggleAutoforward();
 	} else if (wasKeyDown(KeyType::INVENTORY)) {
 		openInventory();
 	} else if (input->cancelPressed()) {


### PR DESCRIPTION
This is a documentation update for pull request #7414, as requested by @paramat.