### PR TITLE
Lua_api.txt: Warn of errors possible with use of VoxelArea:index()/indexp()

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4725,9 +4725,14 @@ The coordinates are *inclusive*, like most other things in Minetest.
   `MaxEdge`.
 * `index(x, y, z)`: returns the index of an absolute position in a flat array
   starting at `1`.
-    * useful for things like `VoxelManip`, raw Schematic specifiers,
+    * `x`, `y` and `z` must be integers to avoid an incorrect index result.
+    * The position (x, y, z) is not checked for being inside the area volume,
+      being outside can cause an incorrect index result.
+    * Useful for things like `VoxelManip`, raw Schematic specifiers,
       `PerlinNoiseMap:get2d`/`3dMap`, and so on.
-* `indexp(p)`: same as above, except takes a vector
+* `indexp(p)`: same functionality as `index(x, y, z)` but takes a vector.
+    * As with `index(x, y, z)`, the components of `p` must be integers, and `p`
+      is not checked for being inside the area volume.
 * `position(i)`: returns the absolute position vector corresponding to index
   `i`.
 * `contains(x, y, z)`: check if (`x`,`y`,`z`) is inside area formed by


### PR DESCRIPTION
These warnings help to avoid difficult-to-resolve bugs that have caused me grief many times when modding.