### PR TITLE
RTT fixes

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -437,7 +437,7 @@ void Client::step(float dtime)
 		counter = 0.0;
 		// connectedAndInitialized() is true, peer exists.
 		float avg_rtt = getRTT();
-		infostream << "Client: avg_rtt=" << avg_rtt << std::endl;
+		infostream << "Client: average rtt: " << avg_rtt << std::endl;
 	}
 
 	/*
@@ -1706,9 +1706,17 @@ void Client::afterContentReceived()
 	delete[] text;
 }
 
+// returns the Round Trip Time
+// if the RTT did not become updated within 2 seconds, e.g. before timing out,
+// it returns the expired time instead
 float Client::getRTT()
 {
-	return m_con->getPeerStat(PEER_ID_SERVER,con::AVG_RTT);
+	float avg_rtt = m_con->getPeerStat(PEER_ID_SERVER, con::AVG_RTT);
+	float time_from_last_rtt =
+		m_con->getPeerStat(PEER_ID_SERVER, con::TIMEOUT_COUNTER);
+	if (avg_rtt + 2.0f > time_from_last_rtt)
+		return avg_rtt;
+	return time_from_last_rtt;
 }
 
 float Client::getCurRate()

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -827,7 +827,7 @@ void Peer::DecUseCount()
 
 void Peer::RTTStatistics(float rtt, const std::string &profiler_id)
 {
-	static const float avg_factor = 0.1f / MAX_RELIABLE_WINDOW_SIZE;
+	static const float avg_factor = 100.0f / MAX_RELIABLE_WINDOW_SIZE;
 
 	if (m_last_rtt > 0) {
 		/* set min max values */
@@ -840,8 +840,7 @@ void Peer::RTTStatistics(float rtt, const std::string &profiler_id)
 		if (m_rtt.avg_rtt < 0.0)
 			m_rtt.avg_rtt = rtt;
 		else
-			m_rtt.avg_rtt = m_rtt.avg_rtt +
-				(rtt - m_rtt.avg_rtt) * avg_factor;
+			m_rtt.avg_rtt += (rtt - m_rtt.avg_rtt) * avg_factor;
 
 		/* do jitter calculation */
 
@@ -856,8 +855,7 @@ void Peer::RTTStatistics(float rtt, const std::string &profiler_id)
 		if (m_rtt.jitter_avg < 0.0)
 			m_rtt.jitter_avg = jitter;
 		else
-			m_rtt.jitter_avg = m_rtt.jitter_avg +
-				(jitter - m_rtt.jitter_avg) * avg_factor;
+			m_rtt.jitter_avg += (jitter - m_rtt.jitter_avg) * avg_factor;
 
 		if (!profiler_id.empty()) {
 			g_profiler->graphAdd(profiler_id + "_rtt", rtt);

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -934,9 +934,8 @@ void UDPPeer::setNonLegacyPeer()
 
 void UDPPeer::reportRTT(float rtt)
 {
-	if (rtt < 0.0) {
-		return;
-	}
+	assert(rtt >= 0.0f);
+
 	RTTStatistics(rtt,"rudp",MAX_RELIABLE_WINDOW_SIZE*10);
 
 	float timeout = getStat(AVG_RTT) * RESEND_TIMEOUT_FACTOR;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -601,9 +601,7 @@ class Peer {
 	protected:
 		virtual void reportRTT(float rtt) {};
 
-		void RTTStatistics(float rtt,
-							const std::string &profiler_id = "",
-							unsigned int num_samples = 1000);
+		void RTTStatistics(float rtt, const std::string &profiler_id = "");
 
 		bool IncUseCount();
 		void DecUseCount();

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -593,6 +593,8 @@ class Peer {
 					return m_rtt.jitter_max;
 				case AVG_JITTER:
 					return m_rtt.jitter_avg;
+				case TIMEOUT_COUNTER:
+					return m_timeout_counter;
 			}
 			return -1;
 		}

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1169,7 +1169,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 				// rtt miscalculation we handle it here
 				float rtt;
 				if (current_time > p.absolute_send_time) {
-					rtt = (current_time - p.absolute_send_time) / 1000.0;
+					rtt = (current_time - p.absolute_send_time) / 1000.0f;
 				} else if (p.totaltime > 0) {
 					rtt = p.totaltime;
 				}

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1167,19 +1167,16 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 
 				// a overflow is quite unlikely but as it'd result in major
 				// rtt miscalculation we handle it here
+				float rtt;
 				if (current_time > p.absolute_send_time) {
-					float rtt = (current_time - p.absolute_send_time) / 1000.0;
-
-					// Let peer calculate stuff according to it
-					// (avg_rtt and resend_timeout)
-					dynamic_cast<UDPPeer *>(peer)->reportRTT(rtt);
+					rtt = (current_time - p.absolute_send_time) / 1000.0;
 				} else if (p.totaltime > 0) {
-					float rtt = p.totaltime;
-
-					// Let peer calculate stuff according to it
-					// (avg_rtt and resend_timeout)
-					dynamic_cast<UDPPeer *>(peer)->reportRTT(rtt);
+					rtt = p.totaltime;
 				}
+
+				// Let peer calculate stuff according to it
+				// (avg_rtt and resend_timeout)
+				dynamic_cast<UDPPeer *>(peer)->reportRTT(rtt);
 			}
 			// put bytes for max bandwidth calculation
 			channel->UpdateBytesSent(p.data.getSize(), 1);

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -30,7 +30,8 @@ typedef enum {
 	AVG_RTT,
 	MIN_JITTER,
 	MAX_JITTER,
-	AVG_JITTER
+	AVG_JITTER,
+	TIMEOUT_COUNTER
 } rtt_stat_type;
 
 class Peer;


### PR DESCRIPTION
Small code changes: remove duplicate code and use assert where rtt should not be negative
When the server probably crashed, after 2 seconds show the time since crash instead of average RTT because the average RTT doesn't longer pertain in this case
 The RTT usually is less than 2 seconds I hope 
Fix #4214 (please test)