### PR TITLE
Fix the /shutdown command

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -827,13 +827,15 @@ core.register_chatcommand("shutdown", {
 	description = "Shutdown server (-1 cancels a delayed shutdown)",
 	privs = {server=true},
 	func = function(name, param)
-		local delay, reconnect, message = param:match("([^ ][-]?[0-9]+)([^ ]+)(.*)")
-		message = message or ""
+		local delay, reconnect, message
+		delay, param = param:match("^%s*(%S+)(.*)")
+		if param then
+			reconnect, param = param:match("^%s*(%S+)(.*)")
+		end
+		message = param and param:match("^%s*(.+)") or ""
+		delay = tonumber(delay) or 0
 
-		if delay ~= "" then
-			delay = tonumber(delay) or 0
-		else
-			delay = 0
+		if delay == 0 then
 			core.log("action", name .. " shuts down server")
 			core.chat_send_all("*** Server shutting down (operator request).")
 		end

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3396,10 +3396,6 @@ v3f Server::findSpawnPos()
 
 void Server::requestShutdown(const std::string &msg, bool reconnect, float delay)
 {
-	m_shutdown_timer = delay;
-	m_shutdown_msg = msg;
-	m_shutdown_ask_reconnect = reconnect;
-
 	if (delay == 0.0f) {
 	// No delay, shutdown immediately
 		m_shutdown_requested = true;
@@ -3418,17 +3414,23 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 
 		infostream << wide_to_utf8(ws.str()).c_str() << std::endl;
 		SendChatMessage(PEER_ID_INEXISTENT, ws.str());
+		// m_shutdown_* are already handled, skip.
+		return;
 	} else if (delay > 0.0f) {
 	// Positive delay, tell the clients when the server will shut down
 		std::wstringstream ws;
 
 		ws << L"*** Server shutting down in "
-				<< duration_to_string(myround(m_shutdown_timer)).c_str()
+				<< duration_to_string(myround(delay)).c_str()
 				<< ".";
 
 		infostream << wide_to_utf8(ws.str()).c_str() << std::endl;
 		SendChatMessage(PEER_ID_INEXISTENT, ws.str());
 	}
+
+	m_shutdown_timer = delay;
+	m_shutdown_msg = msg;
+	m_shutdown_ask_reconnect = reconnect;
 }
 
 PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version)


### PR DESCRIPTION
Lua code based on the commit here: https://github.com/minetest/minetest/issues/7223#issuecomment-379570930

Fixes #7223 and the bug where the message `*** Server shutdown canceled.` is not sent to the players.