### PR TITLE
Server: move shutdown parts to a specific shutdown state object

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1065,7 +1065,7 @@ void Game::run()
 
 	while (RenderingEngine::run()
 			&& !(*kill || g_gamecallback->shutdown_requested
-			|| (server && server->getShutdownRequested()))) {
+			|| (server && server->isShutdownRequested()))) {
 
 		const irr::core::dimension2d<u32> &current_screen_size =
 			RenderingEngine::get_video_driver()->getScreenSize();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1271,6 +1271,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 	}
 
 	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr, false);
+	server->init();
 	server->start();
 
 	return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -870,6 +870,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec,
 					false, bind_addr, true, &iface);
+			server.init();
 
 			g_term_console.setup(&iface, &kill, admin_nick);
 
@@ -904,6 +905,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec, false,
 				bind_addr, true);
+			server.init();
 			server.start();
 
 			// Run server

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -402,11 +402,8 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	m_clients.event(peer_id, CSE_SetClientReady);
 	m_script->on_joinplayer(playersao);
 	// Send shutdown timer if shutdown has been scheduled
-	if (m_shutdown_timer > 0.0f) {
-		std::wstringstream ws;
-		ws << L"*** Server shutting down in "
-				<< duration_to_string(myround(m_shutdown_timer)).c_str() << ".";
-		SendChatMessage(pkt->getPeerId(), ws.str());
+	if (m_shutdown_state.isTimerRunning()) {
+		SendChatMessage(pkt->getPeerId(), m_shutdown_state.getShutdownTimerMessage());
 	}
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -156,33 +156,33 @@ void Server::ShutdownState::trigger(float delay, const std::string &msg, bool re
 
 void Server::ShutdownState::tick(float dtime, Server *server)
 {
+	if (m_timer <= 0.0f)
+		return;
+
 	// Timed shutdown
 	static const float shutdown_msg_times[] =
 	{
-		1, 2, 3, 4, 5, 10, 15, 20, 25, 30, 45, 60, 120, 180, 300, 600, 1200, 1800, 3600
+		1, 2, 3, 4, 5, 10, 20, 40, 60, 120, 180, 300, 600, 1200, 1800, 3600
 	};
 
-	if (m_timer > 0.0f) {
-		// Automated messages
-		if (m_timer < shutdown_msg_times[ARRLEN(shutdown_msg_times) - 1]) {
-			for (u16 i = 0; i < ARRLEN(shutdown_msg_times) - 1; i++) {
-				// If shutdown timer matches an automessage, shot it
-				if (m_timer > shutdown_msg_times[i] &&
-					m_timer - dtime < shutdown_msg_times[i]) {
-					std::wstring periodicMsg = getShutdownTimerMessage();
+	// Automated messages
+	if (m_timer < shutdown_msg_times[ARRLEN(shutdown_msg_times) - 1]) {
+		for (float t : shutdown_msg_times) {
+			// If shutdown timer matches an automessage, shot it
+			if (m_timer > t && m_timer - dtime < t) {
+				std::wstring periodicMsg = getShutdownTimerMessage();
 
-					infostream << wide_to_utf8(periodicMsg).c_str() << std::endl;
-					server->SendChatMessage(PEER_ID_INEXISTENT, periodicMsg);
-					break;
-				}
+				infostream << wide_to_utf8(periodicMsg).c_str() << std::endl;
+				server->SendChatMessage(PEER_ID_INEXISTENT, periodicMsg);
+				break;
 			}
 		}
+	}
 
-		m_timer -= dtime;
-		if (m_timer < 0.0f) {
-			m_timer = 0.0f;
-			is_requested = true;
-		}
+	m_timer -= dtime;
+	if (m_timer < 0.0f) {
+		m_timer = 0.0f;
+		is_requested = true;
 	}
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -201,7 +201,7 @@ public:
 	inline double getUptime() const { return m_uptime.m_value; }
 
 	// read shutdown state
-	inline bool getShutdownRequested() const { return m_shutdown_requested; }
+	inline bool isShutdownRequested() const { return m_shutdown_state.is_requested; }
 
 	// request server to shutdown
 	void requestShutdown(const std::string &msg, bool reconnect, float delay = 0.0f);
@@ -351,6 +351,21 @@ private:
 
 	friend class EmergeThread;
 	friend class RemoteClient;
+
+	struct ShutdownState {
+		public:
+			bool is_requested = false;
+			bool should_reconnect = false;
+			std::string message;
+
+			void reset();
+			void trigger(float delay, const std::string &msg, bool reconnect);
+			void tick(float dtime, Server *server);
+			std::wstring getShutdownTimerMessage() const;
+			bool isTimerRunning() const { return m_timer > 0.0f; }
+		private:
+			float m_timer = 0.0f;
+	};
 
 	void SendMovement(session_t peer_id);
 	void SendHP(session_t peer_id, u16 hp);
@@ -586,10 +601,7 @@ private:
 		Random stuff
 	*/
 
-	bool m_shutdown_requested = false;
-	std::string m_shutdown_msg;
-	bool m_shutdown_ask_reconnect = false;
-	float m_shutdown_timer = 0.0f;
+	ShutdownState m_shutdown_state;
 
 	ChatInterface *m_admin_chat;
 	std::string m_admin_nick;

--- a/src/server.h
+++ b/src/server.h
@@ -128,6 +128,7 @@ public:
 	~Server();
 	DISABLE_CLASS_COPY(Server);
 
+	void init();
 	void start();
 	void stop();
 	// This is mainly a way to pass the time to the server.
@@ -348,11 +349,12 @@ public:
 	std::mutex m_env_mutex;
 
 private:
-
 	friend class EmergeThread;
 	friend class RemoteClient;
+	friend class TestServerShutdownState;
 
 	struct ShutdownState {
+		friend class TestServerShutdownState;
 		public:
 			bool is_requested = false;
 			bool should_reconnect = false;
@@ -383,7 +385,7 @@ private:
 	void SetBlocksNotSent(std::map<v3s16, MapBlock *>& block);
 
 
-	void SendChatMessage(session_t peer_id, const ChatMessage &message);
+	virtual void SendChatMessage(session_t peer_id, const ChatMessage &message);
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
 	void SendPlayerHP(session_t peer_id);
 

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -20,6 +20,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_random.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_schematic.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_serialization.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_server_shutdown_state.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_settings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_socket.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_serveractiveobjectmap.cpp

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -1,0 +1,117 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <server.h>
+#include "test.h"
+
+#include "util/string.h"
+#include "util/serialize.h"
+
+class FakeServer: public Server
+{
+public:
+	FakeServer(): Server("fakeworld", SubgameSpec("fakespec", "fakespec"), true,
+		Address(), true, nullptr) {}
+private:
+	void SendChatMessage(session_t peer_id, const ChatMessage &message)
+	{
+		// NOOP
+	}
+};
+
+class TestServerShutdownState : public TestBase {
+public:
+	TestServerShutdownState() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestServerShutdownState"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testInit();
+	void testReset();
+	void testTrigger();
+	void testTick();
+};
+
+static TestServerShutdownState g_test_instance;
+
+void TestServerShutdownState::runTests(IGameDef *gamedef)
+{
+	TEST(testInit);
+	TEST(testReset);
+	TEST(testTrigger);
+	TEST(testTick);
+}
+
+void TestServerShutdownState::testInit()
+{
+	Server::ShutdownState ss;
+	UASSERT(!ss.is_requested);
+	UASSERT(!ss.should_reconnect);
+	UASSERT(ss.message.empty());
+	UASSERT(ss.m_timer == 0.0f);
+}
+
+void TestServerShutdownState::testReset()
+{
+	Server::ShutdownState ss;
+	ss.reset();
+	UASSERT(!ss.is_requested);
+	UASSERT(!ss.should_reconnect);
+	UASSERT(ss.message.empty());
+	UASSERT(ss.m_timer == 0.0f);
+}
+
+void TestServerShutdownState::testTrigger()
+{
+	Server::ShutdownState ss;
+	ss.trigger(3.0f, "testtrigger", true);
+	UASSERT(!ss.is_requested);
+	UASSERT(ss.should_reconnect);
+	UASSERT(ss.message == "testtrigger");
+	UASSERT(ss.m_timer == 3.0f);
+}
+
+void TestServerShutdownState::testTick()
+{
+	std::unique_ptr<FakeServer> fakeServer(new FakeServer());
+	Server::ShutdownState ss;
+	ss.trigger(28.0f, "testtrigger", true);
+	ss.tick(0.0f, fakeServer.get());
+
+	// Tick with no time should not change anything
+	UASSERT(!ss.is_requested);
+	UASSERT(ss.should_reconnect);
+	UASSERT(ss.message == "testtrigger");
+	UASSERT(ss.m_timer == 28.0f);
+
+	// Tick 2 seconds
+	ss.tick(2.0f, fakeServer.get());
+	UASSERT(!ss.is_requested);
+	UASSERT(ss.should_reconnect);
+	UASSERT(ss.message == "testtrigger");
+	UASSERT(ss.m_timer == 26.0f);
+
+	// Tick remaining seconds + additional expire
+	ss.tick(26.1f, fakeServer.get());
+	UASSERT(ss.is_requested);
+	UASSERT(ss.should_reconnect);
+	UASSERT(ss.message == "testtrigger");
+	UASSERT(ss.m_timer == 0.0f);
+
+}

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2018 nerzhul, Loic BLOT <loic.blot@unix-experience.fr>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -23,11 +23,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/serialize.h"
 
-class FakeServer: public Server
+class FakeServer : public Server
 {
 public:
-	FakeServer(): Server("fakeworld", SubgameSpec("fakespec", "fakespec"), true,
-		Address(), true, nullptr) {}
+	// clang-format off
+	FakeServer() : Server("fakeworld", SubgameSpec("fakespec", "fakespec"), true,
+					Address(), true, nullptr)
+	{
+	}
+	// clang-format on
+
 private:
 	void SendChatMessage(session_t peer_id, const ChatMessage &message)
 	{
@@ -35,7 +40,8 @@ private:
 	}
 };
 
-class TestServerShutdownState : public TestBase {
+class TestServerShutdownState : public TestBase
+{
 public:
 	TestServerShutdownState() { TestManager::registerTestModule(this); }
 	const char *getName() { return "TestServerShutdownState"; }
@@ -113,5 +119,4 @@ void TestServerShutdownState::testTick()
 	UASSERT(ss.should_reconnect);
 	UASSERT(ss.message == "testtrigger");
 	UASSERT(ss.m_timer == 0.0f);
-
 }


### PR DESCRIPTION
A simple PR moving shutdown parts outside of server object to a child objet permitting to add unittests.
When the PR is review & ready i will add the required unittests