### PR TITLE
Make os.tempfolder work correctly for MinGW and MSVC

### DIFF
--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -171,6 +171,23 @@ os.tempfolder = function()
 	local filetocheck = os.tmpname()
 	os.remove(filetocheck)
 
+	-- https://blogs.msdn.microsoft.com/vcblog/2014/06/18/c-runtime-crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1/
+	--   The C runtime (CRT) function called by os.tmpname is tmpnam.
+	--   Microsofts tmpnam implementation in older CRT / MSVC releases is defective.
+	--   tmpnam return values starting with a backslash characterize this behavior.
+	-- https://sourceforge.net/p/mingw-w64/bugs/555/
+	--   MinGW tmpnam implementation is forwarded to the CRT directly.
+	-- https://sourceforge.net/p/mingw-w64/discussion/723797/thread/55520785/
+	--   MinGW links to an older CRT release (msvcrt.dll).
+	--   Due to legal concerns MinGW will never use a newer CRT.
+	--
+	--   Make use of TEMP to compose the temporary filename if an old
+	--   style tmpnam return value is detected.
+	if filetocheck:sub(1, 1) == "\\" then
+		local tempfolder = os.getenv("TEMP")
+		return tempfolder .. filetocheck
+	end
+
 	local randname = "MTTempModFolder_" .. math.random(0,10000)
 	local backstring = filetocheck:reverse()
 	return filetocheck:sub(0, filetocheck:len() - backstring:find(DIR_DELIM) + 1) ..


### PR DESCRIPTION
The code is commented to give an idea of what problem is being addressed.

Basically due to Microsoft pulling creative things with licensing of their newer CRTs (msvcr120.dll and such), MinGW is perpetually stuck linking to the old mscvcrt.dll .
As CRT behaviour changes through years due to bugfixes and standard compliance improvements,
MSVC and MinGW will see different behaviour on CRT calls (in this case tmpnam).

Since tmpnam can be detected by examining its return value, it is not necessary to ifdef code or detect platform / CRT version explicitly.

Timeline:
Old code: Activate alternate codepath on all windows-like platforms. Fails on newer MSVC. Works on older MSVC and MinGW.
Code after first fix: Never activate alternate codepath. Works on newer MSVC. Fails on older MSVC and MinGW causing #7430.
Code after this fix: Activate alternate codepath upon examining tmpnam return value. Expected to work in all cases.

I've spent some time trying to set up MinGW but seems after years of using MSVC i am finally too stupid to do so lol.
If possible, testing on MinGW would be appreciated.
