### PR TITLE
Xorg/net wm pid

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -103,6 +103,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	}
 
 	RenderingEngine::setXorgClassHint(video_driver->getExposedVideoData(), PROJECT_NAME_C);
+	RenderingEngine::setXorgNetWMPID(video_driver->getExposedVideoData());
 	RenderingEngine::get_instance()->setWindowIcon();
 
 	/*

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -96,16 +96,13 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 		return true;
 	}
 
-	video::IVideoDriver *video_driver = RenderingEngine::get_video_driver();
-	if (video_driver == NULL) {
+	if (RenderingEngine::get_video_driver() == NULL) {
 		errorstream << "Could not initialize video driver." << std::endl;
 		return false;
 	}
 
-	RenderingEngine::setXorgClassHint(video_driver->getExposedVideoData(), PROJECT_NAME_C);
-	RenderingEngine::setXorgNetWMPID(video_driver->getExposedVideoData());
-	RenderingEngine::get_instance()->setWindowIcon();
-
+	RenderingEngine::get_instance()->setupTopLevelWindow(PROJECT_NAME_C);
+	
 	/*
 		This changes the minimum allowed number of vertices in a VBO.
 		Default is 500.

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -41,14 +41,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define XORG_USED
 #endif
 #ifdef XORG_USED
-#include <stdlib.h>
-#include <string>
-#include <sys/socket.h>
-#include <sys/utsname.h>
-#include <netdb.h>
-#include <irrlicht.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -41,8 +41,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define XORG_USED
 #endif
 #ifdef XORG_USED
+#include <stdlib.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/utsname.h>
+#include <netdb.h>
+#include <irrlicht.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xatom.h>
 #endif
 
 #ifdef __ANDROID__
@@ -200,6 +209,149 @@ void RenderingEngine::setXorgClassHint(
 	XSetClassHint((Display *)video_data.OpenGLLinux.X11Display,
 			video_data.OpenGLLinux.X11Window, classhint);
 	XFree(classhint);
+#endif
+}
+
+void RenderingEngine::setXorgNetWMPID(
+        const video::SExposedVideoData &video_data)
+{
+#ifdef XORG_USED
+    // Used to set the _NET_WM_PID window property according to 
+    // the Extended Window Manager Hints(WWMH) spec. _NET_WM_PID (in
+    // conjunction with WM_CLIENT_MACHINE) can be used by window 
+    // managers to force a shutdown of an application if it doesn't
+    // respond to the destroy window message. 
+    
+    //const video::SExposedVideoData &video_data = device->getExposedVideoData();
+
+    Display *x11_dpl = (Display *)video_data.OpenGLLinux.X11Display;
+	if (x11_dpl == NULL) {
+		warningstream << "Could not find X11 Display in ExposedVideoData"
+            << std::endl;
+		return;
+    }
+
+    verbosestream << "Setting Xorg _NET_WM_PID window property"
+        << std::endl;
+
+    Window x11_win = (Window)video_data.OpenGLLinux.X11Window;
+
+    // Set the _NET_WM_PID for the window. 
+
+    Atom NET_WM_PID = XInternAtom(x11_dpl,
+            "_NET_WM_PID",
+            false);
+
+    pid_t pid = getpid();
+    infostream << "PID is '" << (long)pid << "'"
+        << std::endl;
+    
+    XChangeProperty(x11_dpl, x11_win, NET_WM_PID, XA_CARDINAL, 32, PropModeReplace, (unsigned char *) &pid,1);
+
+    // According to the Extended Window Manager Hints spec if _NET_WM_PID
+    // is set then WM_CLIENT_MACHINE must also be set.
+    
+    verbosestream << "Attempting to determine Fully Qualified Domain Name for client"
+        << std::endl;
+
+    // Get the X client hostname which will be used to get address info 
+    // further down. If a canonical name can't be determined then 
+    // hostname will be used for the FQDN. 
+    //
+    // There is no way to know for sure what the max length of the hostname
+    // will be as in modern linux distributions this is a configurable option. 
+    // Most likely it will be be no longer than 64 bytes as this is the default
+    // but it can be longer ... instead of trying to guess the length use
+    // the results of gethostname to determine the length. 
+
+	size_t hostname_len=128;
+	char* hostname=0;
+	while (1) {
+		// (Re)allocate buffer of length hostname_len.
+		char* realloc_hostname=(char *) realloc(hostname,hostname_len);
+		if (realloc_hostname==0) {
+			free(hostname);
+            // This should probably raise an error or exit the program 
+            // if this happens. 
+            errorstream << "Failed to allocate memory for hostname"
+                << std::endl;
+            return;
+		}
+		hostname=realloc_hostname;
+
+		// Terminate the buffer.
+		hostname[hostname_len-1]=0;
+
+		// Offer all but the last byte of the buffer to gethostname.
+		if (gethostname(hostname,hostname_len-1)==0) {
+			size_t count=strlen(hostname);
+			if (count<hostname_len-2) {
+				// Break from loop if hostname definitely not truncated
+				break;
+			}
+		}
+
+		// Double size of buffer and try again.
+		hostname_len*=2;
+	}
+
+    // The EWMH spec specifies that WM_CLIENT_MACHINE should be set to the 
+    // Fully Qualified Domain Name (FQDN) of the client. Here, attempt 
+    // to determine the FQDN using getaddrinfo. If that fails then fall
+    // back to the hostname discovered above. 
+
+	struct addrinfo hints={0};
+	hints.ai_family=AF_UNSPEC;
+	hints.ai_flags=AI_CANONNAME;
+    // gethostname and getaddrinfo do not support IDN (thank the 
+    // flying spagehti monster) this means that fqdn will be represented
+    // in ASCII (any IDN names would be converted using punycode).
+	std::string *fqdn_ptr;          
+
+	struct addrinfo* res=0;
+	if (getaddrinfo(hostname,0,&hints,&res)==0) {
+        infostream << "Hostname '" << hostname
+            << "' was successfully resolved as '" 
+            << res->ai_canonname << "'"
+            << std::endl;
+
+        // Copy canonical name to new string so that addrinfo can be freed
+		fqdn_ptr = new std::string(res->ai_canonname, res->ai_canonname+strlen(res->ai_canonname));
+		freeaddrinfo(res);
+	} else {
+        infostream << "Couldn't resolve hostname '"
+            << hostname << "' using hostname instead." 
+            << std::endl;
+
+        // Copy hostname to new string so that hostname can be freed
+		fqdn_ptr = new std::string(hostname, hostname+strlen(hostname));
+	}
+    // hostname is no longer needed so free it. 
+	free(hostname);
+
+    verbosestream << "Setting Xorg WM_CLIENT_MACHINE window property"
+        << std::endl;
+
+	XTextProperty wm_client_machine;
+
+    // The following is needed because XStringListToTextProperty expects
+    // a list of writeable strings to be passed. string::c_str returns a 
+    // const char * and so is not suitable for this purpose. 
+	std::string &fqdn = *fqdn_ptr;
+	char* sl = &fqdn[0];
+
+    // Create the XTextProperty value here for fqdn.
+    XStringListToTextProperty(&sl, 1, &wm_client_machine);
+	//XwcTextListToTextProperty(x11_dpl, &sl, 1, XStdICCTextStyle, &wm_client_machine);
+	XSetWMClientMachine(x11_dpl, x11_win, &wm_client_machine);
+
+    // X handles the allocation of memory for the text value in the 
+    // XTextProperty structure but it must be freed here once it is 
+    // no longer needed
+	XFree(wm_client_machine.value);
+
+    verbosestream << "Successfully set Xorg EWMH _NET_WM_PID"
+        << std::endl;
 #endif
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -220,7 +220,7 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 #ifdef XORG_USED
 	const video::SExposedVideoData exposedData = driver->getExposedVideoData();
 
-	Display *x11_dpl = (Display *)exposedData.OpenGLLinux.X11Display;
+	Display *x11_dpl = reinterpret_cast<Display *>(exposedData.OpenGLLinux.X11Display);
 	if (x11_dpl == NULL) {
 		warningstream << "Client: Could not find X11 Display in ExposedVideoData"
 			<< std::endl; 
@@ -232,7 +232,7 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 		<< std::endl;
 
 
-	Window x11_win = (Window)exposedData.OpenGLLinux.X11Window;
+	Window x11_win = reinterpret_cast<Window>(exposedData.OpenGLLinux.X11Window);
 
 	// Set application name and class hints. For now name and class are the same.
 	XClassHint *classhint = XAllocClassHint();
@@ -247,7 +247,7 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 	// method. But for now (as it would require some significant changes) 
 	// leave the code as is. 
 	
-    // The following is borrowed from the above gdk source for setting top
+	// The following is borrowed from the above gdk source for setting top
 	// level windows. The source indicates and the Xlib docs suggest that
 	// this will set the WM_CLIENT_MACHINE and WM_LOCAL_NAME. This will not 
 	// set the WM_CLIENT_MACHINE to a Fully Qualified Domain Name (FQDN) which is 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -216,53 +216,53 @@ void RenderingEngine::setXorgNetWMPID(
         const video::SExposedVideoData &video_data)
 {
 #ifdef XORG_USED
-    // Used to set the _NET_WM_PID window property according to 
-    // the Extended Window Manager Hints(WWMH) spec. _NET_WM_PID (in
-    // conjunction with WM_CLIENT_MACHINE) can be used by window 
-    // managers to force a shutdown of an application if it doesn't
-    // respond to the destroy window message. 
+	// Used to set the _NET_WM_PID window property according to 
+	// the Extended Window Manager Hints(WWMH) spec. _NET_WM_PID (in
+	// conjunction with WM_CLIENT_MACHINE) can be used by window 
+	// managers to force a shutdown of an application if it doesn't
+	// respond to the destroy window message. 
     
-    //const video::SExposedVideoData &video_data = device->getExposedVideoData();
-
-    Display *x11_dpl = (Display *)video_data.OpenGLLinux.X11Display;
+	Display *x11_dpl = (Display *)video_data.OpenGLLinux.X11Display;
 	if (x11_dpl == NULL) {
 		warningstream << "Could not find X11 Display in ExposedVideoData"
-            << std::endl;
+			<< std::endl;
 		return;
-    }
+	}
 
-    verbosestream << "Setting Xorg _NET_WM_PID window property"
-        << std::endl;
+	verbosestream << "Setting Xorg _NET_WM_PID window property"
+		<< std::endl;
 
-    Window x11_win = (Window)video_data.OpenGLLinux.X11Window;
+	Window x11_win = (Window)video_data.OpenGLLinux.X11Window;
 
-    // Set the _NET_WM_PID for the window. 
+	// Set the _NET_WM_PID for the window. 
 
-    Atom NET_WM_PID = XInternAtom(x11_dpl,
-            "_NET_WM_PID",
-            false);
+	Atom NET_WM_PID = XInternAtom(x11_dpl,
+		"_NET_WM_PID",
+		false);
 
-    pid_t pid = getpid();
-    infostream << "PID is '" << (long)pid << "'"
-        << std::endl;
-    
-    XChangeProperty(x11_dpl, x11_win, NET_WM_PID, XA_CARDINAL, 32, PropModeReplace, (unsigned char *) &pid,1);
+	pid_t pid = getpid();
+	infostream << "PID is '" << (long)pid << "'"
+		<< std::endl;
 
-    // According to the Extended Window Manager Hints spec if _NET_WM_PID
-    // is set then WM_CLIENT_MACHINE must also be set.
-    
-    verbosestream << "Attempting to determine Fully Qualified Domain Name for client"
-        << std::endl;
+	XChangeProperty(x11_dpl, x11_win, NET_WM_PID, 
+			XA_CARDINAL, 32, PropModeReplace, 
+			(unsigned char *) &pid,1);
 
-    // Get the X client hostname which will be used to get address info 
-    // further down. If a canonical name can't be determined then 
-    // hostname will be used for the FQDN. 
-    //
-    // There is no way to know for sure what the max length of the hostname
-    // will be as in modern linux distributions this is a configurable option. 
-    // Most likely it will be be no longer than 64 bytes as this is the default
-    // but it can be longer ... instead of trying to guess the length use
-    // the results of gethostname to determine the length. 
+	// According to the Extended Window Manager Hints spec if _NET_WM_PID
+	// is set then WM_CLIENT_MACHINE must also be set.
+
+	verbosestream << "Attempting to determine Fully Qualified Domain Name for client"
+		<< std::endl;
+
+	// Get the X client hostname which will be used to get address info 
+	// further down. If a canonical name can't be determined then 
+	// hostname will be used for the FQDN. 
+	//
+	// There is no way to know for sure what the max length of the hostname
+	// will be as in modern linux distributions this is a configurable option. 
+	// Most likely it will be be no longer than 64 bytes as this is the default
+	// but it can be longer ... instead of trying to guess the length use
+	// the results of gethostname to determine the length. 
 
 	size_t hostname_len=128;
 	char* hostname=0;
@@ -271,11 +271,11 @@ void RenderingEngine::setXorgNetWMPID(
 		char* realloc_hostname=(char *) realloc(hostname,hostname_len);
 		if (realloc_hostname==0) {
 			free(hostname);
-            // This should probably raise an error or exit the program 
-            // if this happens. 
-            errorstream << "Failed to allocate memory for hostname"
-                << std::endl;
-            return;
+			// This should probably raise an error or exit the program 
+			// if this happens. 
+			errorstream << "Failed to allocate memory for hostname"
+				<< std::endl;
+			return;
 		}
 		hostname=realloc_hostname;
 
@@ -295,63 +295,63 @@ void RenderingEngine::setXorgNetWMPID(
 		hostname_len*=2;
 	}
 
-    // The EWMH spec specifies that WM_CLIENT_MACHINE should be set to the 
-    // Fully Qualified Domain Name (FQDN) of the client. Here, attempt 
-    // to determine the FQDN using getaddrinfo. If that fails then fall
-    // back to the hostname discovered above. 
+	// The EWMH spec specifies that WM_CLIENT_MACHINE should be set to the 
+	// Fully Qualified Domain Name (FQDN) of the client. Here, attempt 
+	// to determine the FQDN using getaddrinfo. If that fails then fall
+	// back to the hostname discovered above. 
 
 	struct addrinfo hints={0};
 	hints.ai_family=AF_UNSPEC;
 	hints.ai_flags=AI_CANONNAME;
-    // gethostname and getaddrinfo do not support IDN (thank the 
-    // flying spagehti monster) this means that fqdn will be represented
-    // in ASCII (any IDN names would be converted using punycode).
+
+	// gethostname and getaddrinfo do not support IDN (thank the 
+	// flying spagehti monster) this means that fqdn will be represented
+	// in ASCII (any IDN names would be converted using punycode).
 	std::string *fqdn_ptr;          
 
 	struct addrinfo* res=0;
 	if (getaddrinfo(hostname,0,&hints,&res)==0) {
-        infostream << "Hostname '" << hostname
-            << "' was successfully resolved as '" 
-            << res->ai_canonname << "'"
-            << std::endl;
+		infostream << "Hostname '" << hostname
+			<< "' was successfully resolved as '" 
+			<< res->ai_canonname << "'"
+			<< std::endl;
 
-        // Copy canonical name to new string so that addrinfo can be freed
+		// Copy canonical name to new string so that addrinfo can be freed
 		fqdn_ptr = new std::string(res->ai_canonname, res->ai_canonname+strlen(res->ai_canonname));
 		freeaddrinfo(res);
 	} else {
-        infostream << "Couldn't resolve hostname '"
-            << hostname << "' using hostname instead." 
-            << std::endl;
+		infostream << "Couldn't resolve hostname '"
+			<< hostname << "' using hostname instead." 
+			<< std::endl;
 
-        // Copy hostname to new string so that hostname can be freed
+		// Copy hostname to new string so that hostname can be freed
 		fqdn_ptr = new std::string(hostname, hostname+strlen(hostname));
 	}
-    // hostname is no longer needed so free it. 
+	// hostname is no longer needed so free it. 
 	free(hostname);
 
-    verbosestream << "Setting Xorg WM_CLIENT_MACHINE window property"
-        << std::endl;
+	verbosestream << "Setting Xorg WM_CLIENT_MACHINE window property"
+		<< std::endl;
 
 	XTextProperty wm_client_machine;
 
-    // The following is needed because XStringListToTextProperty expects
-    // a list of writeable strings to be passed. string::c_str returns a 
-    // const char * and so is not suitable for this purpose. 
+	// The following is needed because XStringListToTextProperty expects
+	// a list of writeable strings to be passed. string::c_str returns a 
+	// const char * and so is not suitable for this purpose. 
 	std::string &fqdn = *fqdn_ptr;
 	char* sl = &fqdn[0];
 
-    // Create the XTextProperty value here for fqdn.
-    XStringListToTextProperty(&sl, 1, &wm_client_machine);
-	//XwcTextListToTextProperty(x11_dpl, &sl, 1, XStdICCTextStyle, &wm_client_machine);
+	// Create the XTextProperty value here for fqdn.
+	XStringListToTextProperty(&sl, 1, &wm_client_machine);
 	XSetWMClientMachine(x11_dpl, x11_win, &wm_client_machine);
 
-    // X handles the allocation of memory for the text value in the 
-    // XTextProperty structure but it must be freed here once it is 
-    // no longer needed
+	// X handles the allocation of memory for the text value in the 
+	// XTextProperty structure but it must be freed here once it is 
+	// no longer needed
 	XFree(wm_client_machine.value);
 
-    verbosestream << "Successfully set Xorg EWMH _NET_WM_PID"
-        << std::endl;
+	verbosestream << "Successfully set Xorg EWMH _NET_WM_PID"
+		<< std::endl;
 #endif
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -305,7 +305,7 @@ void RenderingEngine::setXorgNetWMPID(
 	hints.ai_flags=AI_CANONNAME;
 
 	// gethostname and getaddrinfo do not support IDN (thank the 
-	// flying spagehti monster) this means that fqdn will be represented
+	// flying spaghetti monster) this means that fqdn will be represented
 	// in ASCII (any IDN names would be converted using punycode).
 	std::string *fqdn_ptr;          
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -191,19 +191,11 @@ bool RenderingEngine::setupTopLevelWindow(const std::string &name)
 {
 	// FIXME: It would make more sense for there to be a switch of some
 	// sort here that would call the correct toplevel setup methods for
-	// the environment Minetest is running in but for not deviating from
-	// the original pattern.
+	// the environment Minetest is running in but for now not deviating
+	// from the original pattern.
 	
 	/* Setting Xorg properties for the top level window */
-	verbosestream << "Client: Configuring Xorg specific top level"
-		<< " window properties"
-		<< std::endl;
-
 	setupTopLevelXorgWindow(name);
-
-	verbosestream << "Client: Finished configuring Xorg specific top level"
-		<< " window properties"
-		<< std::endl;
 	/* Done with Xorg properties */
 
 	/* Setting general properties for the top level window */
@@ -235,12 +227,17 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 		return;
 	}
 
+	verbosestream << "Client: Configuring Xorg specific top level"
+		<< " window properties"
+		<< std::endl;
+
+
 	Window x11_win = (Window)exposedData.OpenGLLinux.X11Window;
 
 	// Set application name and class hints. For now name and class are the same.
 	XClassHint *classhint = XAllocClassHint();
-	classhint->res_name = (char *)name.c_str();
-	classhint->res_class = (char *)name.c_str();
+	classhint->res_name = const_cast<char *>(name.c_str());
+	classhint->res_class = const_cast<char *>(name.c_str());
 
 	XSetClassHint(x11_dpl, x11_win, classhint);
 	XFree(classhint);
@@ -251,14 +248,14 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 	// leave the code as is. 
 	
     // The following is borrowed from the above gdk source for setting top
-	// level windows. The source indicates (and the Xlib docs) suggest that
+	// level windows. The source indicates and the Xlib docs suggest that
 	// this will set the WM_CLIENT_MACHINE and WM_LOCAL_NAME. This will not 
 	// set the WM_CLIENT_MACHINE to a Fully Qualified Domain Name (FQDN) which is 
 	// required by the Extended Window Manager Hints (EWMH) spec when setting
-	// the _NET_WM_PID (see further down) but, as running Minetest in an env
+	// the _NET_WM_PID (see further down) but running Minetest in an env
 	// where the window manager is on another machine from Minetest (therefore
-	// making the PID useless) it is not expected to be a problem. Further
-	// more, using gtk/gdk as the model it would seem that using a FQDN is
+	// making the PID useless) is not expected to be a problem. Further
+	// more, using gtk/gdk as the model it would seem that not using a FQDN is
 	// not an issue for modern Xorg window managers.
 	
 	verbosestream << "Client: Setting Xorg window manager Properties"
@@ -277,15 +274,15 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 	Atom NET_WM_PID = XInternAtom(x11_dpl, "_NET_WM_PID", false);
 
 	pid_t pid = getpid();
-	infostream << "Client: PID is '" << (long)pid << "'"
+	infostream << "Client: PID is '" << static_cast<long>(pid) << "'"
 		<< std::endl;
 
 	XChangeProperty(x11_dpl, x11_win, NET_WM_PID, 
 			XA_CARDINAL, 32, PropModeReplace, 
-			(unsigned char *) &pid,1);
+			reinterpret_cast<unsigned char *>(&pid),1);
 
 	// Set the WM_CLIENT_LEADER window property here. Minetest has only one
-	// window so it will always be the leader. 
+	// window and that window will always be the leader. 
 
 	verbosestream << "Client: Setting Xorg WM_CLIENT_LEADER property"
 		<< std::endl;
@@ -294,7 +291,11 @@ void RenderingEngine::setupTopLevelXorgWindow(const std::string &name)
 
 	XChangeProperty (x11_dpl, x11_win, WM_CLIENT_LEADER,
 		XA_WINDOW, 32, PropModeReplace,
-		(unsigned char *) &x11_win, 1);
+		reinterpret_cast<unsigned char *>(&x11_win), 1);
+
+	verbosestream << "Client: Finished configuring Xorg specific top level"
+		<< " window properties"
+		<< std::endl;
 #endif
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -236,9 +236,7 @@ void RenderingEngine::setXorgNetWMPID(
 
 	// Set the _NET_WM_PID for the window. 
 
-	Atom NET_WM_PID = XInternAtom(x11_dpl,
-		"_NET_WM_PID",
-		false);
+	Atom NET_WM_PID = XInternAtom(x11_dpl, "_NET_WM_PID", false);
 
 	pid_t pid = getpid();
 	infostream << "PID is '" << (long)pid << "'"
@@ -264,12 +262,12 @@ void RenderingEngine::setXorgNetWMPID(
 	// but it can be longer ... instead of trying to guess the length use
 	// the results of gethostname to determine the length. 
 
-	size_t hostname_len=128;
-	char* hostname=0;
+	size_t hostname_len = 128;
+	char *hostname = nullptr;
 	while (1) {
 		// (Re)allocate buffer of length hostname_len.
-		char* realloc_hostname=(char *) realloc(hostname,hostname_len);
-		if (realloc_hostname==0) {
+		char *realloc_hostname = (char *) realloc(hostname,hostname_len);
+		if (realloc_hostname == nullptr) {
 			free(hostname);
 			// This should probably raise an error or exit the program 
 			// if this happens. 
@@ -277,22 +275,22 @@ void RenderingEngine::setXorgNetWMPID(
 				<< std::endl;
 			return;
 		}
-		hostname=realloc_hostname;
+		hostname = realloc_hostname;
 
 		// Terminate the buffer.
-		hostname[hostname_len-1]=0;
+		hostname[hostname_len-1] = 0;
 
 		// Offer all but the last byte of the buffer to gethostname.
-		if (gethostname(hostname,hostname_len-1)==0) {
-			size_t count=strlen(hostname);
-			if (count<hostname_len-2) {
+		if (gethostname(hostname,hostname_len-1) == 0) {
+			size_t count = strlen(hostname);
+			if (count < hostname_len-2) {
 				// Break from loop if hostname definitely not truncated
 				break;
 			}
 		}
 
 		// Double size of buffer and try again.
-		hostname_len*=2;
+		hostname_len *= 2;
 	}
 
 	// The EWMH spec specifies that WM_CLIENT_MACHINE should be set to the 
@@ -300,24 +298,24 @@ void RenderingEngine::setXorgNetWMPID(
 	// to determine the FQDN using getaddrinfo. If that fails then fall
 	// back to the hostname discovered above. 
 
-	struct addrinfo hints={0};
-	hints.ai_family=AF_UNSPEC;
-	hints.ai_flags=AI_CANONNAME;
+	struct addrinfo hints = {0};
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_flags = AI_CANONNAME;
 
 	// gethostname and getaddrinfo do not support IDN (thank the 
 	// flying spaghetti monster) this means that fqdn will be represented
 	// in ASCII (any IDN names would be converted using punycode).
-	std::string *fqdn_ptr;          
+	std::string fqdn;          
 
-	struct addrinfo* res=0;
-	if (getaddrinfo(hostname,0,&hints,&res)==0) {
+	struct addrinfo* res = 0;
+	if (getaddrinfo(hostname,0,&hints,&res) == 0) {
 		infostream << "Hostname '" << hostname
 			<< "' was successfully resolved as '" 
 			<< res->ai_canonname << "'"
 			<< std::endl;
 
 		// Copy canonical name to new string so that addrinfo can be freed
-		fqdn_ptr = new std::string(res->ai_canonname, res->ai_canonname+strlen(res->ai_canonname));
+		fqdn.assign(res->ai_canonname);
 		freeaddrinfo(res);
 	} else {
 		infostream << "Couldn't resolve hostname '"
@@ -325,7 +323,7 @@ void RenderingEngine::setXorgNetWMPID(
 			<< std::endl;
 
 		// Copy hostname to new string so that hostname can be freed
-		fqdn_ptr = new std::string(hostname, hostname+strlen(hostname));
+		fqdn.assign(hostname);
 	}
 	// hostname is no longer needed so free it. 
 	free(hostname);
@@ -338,8 +336,7 @@ void RenderingEngine::setXorgNetWMPID(
 	// The following is needed because XStringListToTextProperty expects
 	// a list of writeable strings to be passed. string::c_str returns a 
 	// const char * and so is not suitable for this purpose. 
-	std::string &fqdn = *fqdn_ptr;
-	char* sl = &fqdn[0];
+	char *sl = &fqdn[0];
 
 	// Create the XTextProperty value here for fqdn.
 	XStringListToTextProperty(&sl, 1, &wm_client_machine);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -53,7 +53,7 @@ public:
 
 	static void setXorgClassHint(const video::SExposedVideoData &video_data,
 			const std::string &name);
-    static void setXorgNetWMPID(const video::SExposedVideoData &video_data);
+	static void setXorgNetWMPID(const video::SExposedVideoData &video_data);
 
 	bool setWindowIcon();
 	bool setXorgWindowIconFromPath(const std::string &icon_file);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -51,10 +51,8 @@ public:
 	static float getDisplayDensity();
 	static v2u32 getDisplaySize();
 
-	static void setXorgClassHint(const video::SExposedVideoData &video_data,
-			const std::string &name);
-	static void setXorgNetWMPID(const video::SExposedVideoData &video_data);
-
+	bool setupTopLevelWindow(const std::string &name);
+	void setupTopLevelXorgWindow(const std::string &name);
 	bool setWindowIcon();
 	bool setXorgWindowIconFromPath(const std::string &icon_file);
 	static bool print_video_modes();

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -53,6 +53,8 @@ public:
 
 	static void setXorgClassHint(const video::SExposedVideoData &video_data,
 			const std::string &name);
+    static void setXorgNetWMPID(const video::SExposedVideoData &video_data);
+
 	bool setWindowIcon();
 	bool setXorgWindowIconFromPath(const std::string &icon_file);
 	static bool print_video_modes();


### PR DESCRIPTION
While working on a personal X window manager project I discovered that minetest does not support most of the [Extended Window Manager Hints spec](https://specifications.freedesktop.org/wm-spec/latest/ar01s05.html#idm139870829938624). This includes things like _NET_WM_PID which allows the discovery of the process underlying a window. 

Providing _NET_WM_PID will allow window managers to terminate an unresponsive minetest window. 

There is actually quite a bit of work that could be done to improve how minetest handles the additional Xorg stuff that Irrlicht doesn't support but for a start getting support for _NET_WM_PID is probably the easiest to achieve. 

I have also created a backport of these changes to the 14.7.1 branch if that will be useful. 

--EDIT--
Editing to add that xprop can be used at the CLI to verify that _NET_WM_PID and WM_CLIENT_MACHINE have been set correctly. 
