### PR TITLE
Update menu_lua_api.txt to replace deprecated functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ set(GCC_MINIMUM_VERSION "4.8")
 set(CLANG_MINIMUM_VERSION "3.4")
 
 # Also remember to set PROTOCOL_VERSION in network/networkprotocol.h when releasing
-set(VERSION_MAJOR 0)
-set(VERSION_MINOR 5)
+set(VERSION_MAJOR 5)
+set(VERSION_MINOR 0)
 set(VERSION_PATCH 0)
 set(VERSION_EXTRA "" CACHE STRING "Stuff to append to version string")
 

--- a/README.md
+++ b/README.md
@@ -431,9 +431,11 @@ This is how we build Windows releases.
 Version scheme
 --------------
 
-Minetest doesn't follow semver. Instead, we do something roughly similar to 0.major.minor.
+Minetest partially follows semver (major.minor.patch).
 
-Since 0.5.0-dev and 0.4.17-dev, the dev notation refers to the next release, 
-ie: 0.5.0-dev is the development version leading to 0.5.0.
+Since 5.0.0-dev and 0.4.17-dev, the dev notation refers to the next release, 
+ie: 5.0.0-dev is the development version leading to 5.0.0.
 
 Prior to that, we used oldversion-dev.
+
+Semver was adopted after 0.4.X series. Before that we used 0.major.minor scheme.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1,4 +1,4 @@
-Minetest Lua Client Modding API Reference 0.5.0
+Minetest Lua Client Modding API Reference 5.0.0
 ================================================
 * More information at <http://www.minetest.net/>
 * Developer Wiki: <http://dev.minetest.net/>

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -1,4 +1,4 @@
-Minetest Lua Mainmenu API Reference 0.5.0
+Minetest Lua Mainmenu API Reference 5.0.0
 ========================================
 
 Introduction

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
 Minetest Lua Mainmenu API Reference 5.0.0
-========================================
-=======
-Minetest Lua Mainmenu API Reference 0.5.0
 =========================================
->>>>>>> f2043e6a20de218723ba6733522e50791aa2d215
 
 Introduction
 -------------

--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -88,17 +88,17 @@ function on_step(dtime)
 	experimental.t1 = experimental.t1 + dtime
 	if experimental.t1 >= 2 then
 		experimental.t1 = experimental.t1 - 2
-		minetest.log("time of day is "..minetest.get_timeofday())
+		minetest.log("verbose", "time of day is "..minetest.get_timeofday())
 		if experimental.day then
-			minetest.log("forcing day->night")
+			minetest.log("verbose", "forcing day->night")
 			experimental.day = false
 			minetest.set_timeofday(0.0)
 		else
-			minetest.log("forcing night->day")
+			minetest.log("verbose", "forcing night->day")
 			experimental.day = true
 			minetest.set_timeofday(0.5)
 		end
-		minetest.log("time of day is "..minetest.get_timeofday())
+		minetest.log("verbose", "time of day is "..minetest.get_timeofday())
 	end
 	--]]
 end
@@ -228,7 +228,7 @@ minetest.register_entity("experimental:dummyball", {
 	phasetimer = 0,
 
 	on_activate = function(self, staticdata)
-		minetest.log("Dummyball activated!")
+		minetest.log("action", "Dummyball activated!")
 	end,
 
 	on_step = function(self, dtime)
@@ -750,24 +750,45 @@ minetest.register_chatcommand("bench_bulk_set_node", {
 	end,
 })
 
+local formspec_test_active = false
+
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-	experimental.print_to_everything("Inventory fields 1: player="..player:get_player_name()..", fields="..dump(fields))
+	if formspec_test_active then
+		experimental.print_to_everything("Inventory fields 1: player="..player:get_player_name()..", fields="..dump(fields))
+	end
 end)
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-	experimental.print_to_everything("Inventory fields 2: player="..player:get_player_name()..", fields="..dump(fields))
-	return true -- Disable the first callback
+	if formspec_test_active then
+		experimental.print_to_everything("Inventory fields 2: player="..player:get_player_name()..", fields="..dump(fields))
+		return true -- Disable the first callback
+	end
 end)
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-	experimental.print_to_everything("Inventory fields 3: player="..player:get_player_name()..", fields="..dump(fields))
+	if formspec_test_active then
+		experimental.print_to_everything("Inventory fields 3: player="..player:get_player_name()..", fields="..dump(fields))
+	end
 end)
 
-minetest.log("experimental modname="..dump(minetest.get_current_modname()))
-minetest.log("experimental modpath="..dump(minetest.get_modpath("experimental")))
-minetest.log("experimental worldpath="..dump(minetest.get_worldpath()))
+minetest.register_chatcommand("test_formspec", {
+	param = "",
+	description = "Test 4: Toggle formspec test",
+	func = function(name, param)
+		formspec_test_active = not formspec_test_active
+		if formspec_test_active then
+			minetest.chat_send_player(name, "Formspec test enabled!")
+		else
+			minetest.chat_send_player(name, "Formspec test disabled!")
+		end
+	end
+})
+
+minetest.log("info", "experimental modname="..dump(minetest.get_current_modname()))
+minetest.log("info", "experimental modpath="..dump(minetest.get_modpath("experimental")))
+minetest.log("info", "experimental worldpath="..dump(minetest.get_worldpath()))
 
 
 core.register_on_mods_loaded(function()
-	core.log("Yeah experimental loaded mods.")
+	core.log("action", "Yeah experimental loaded mods.")
 end)
 
 -- END

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1184,9 +1184,7 @@ void Server::setTimeOfDay(u32 time)
 
 void Server::onMapEditEvent(MapEditEvent *event)
 {
-	if(m_ignore_map_edit_events)
-		return;
-	if(m_ignore_map_edit_events_area.contains(event->getArea()))
+	if (m_ignore_map_edit_events_area.contains(event->getArea()))
 		return;
 	MapEditEvent *e = event->clone();
 	m_unsent_map_edit_queue.push(e);

--- a/src/server.h
+++ b/src/server.h
@@ -623,12 +623,6 @@ private:
 	*/
 	std::queue<MapEditEvent*> m_unsent_map_edit_queue;
 	/*
-		Set to true when the server itself is modifying the map and does
-		all sending of information by itself.
-		This is behind m_env_mutex
-	*/
-	bool m_ignore_map_edit_events = false;
-	/*
 		If a non-empty area, map edit events contained within are left
 		unsent. Done at map generation time to speed up editing of the
 		generated area, as it will be sent anyway.

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -50,9 +50,9 @@ back_to_devel() {
 
 	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/menu_lua_api.txt
 
-	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/client_lua_api.md
+	sed -i -re "1s/[0-9]+\.[0-9]+\.[0-9]+/$NEXT_VERSION/g" doc/client_lua_api.txt
 
-	git add -f CMakeLists.txt doc/menu_lua_api.txt doc/client_lua_api.md
+	git add -f CMakeLists.txt doc/menu_lua_api.txt doc/client_lua_api.txt
 
 	git commit -m "Continue with $NEXT_VERSION-dev"
 }


### PR DESCRIPTION
This minor PR replaces all occurrences of `core.setting_*` (deprecated) with `core.settings:*`
in `doc/menu_lua_api.txt`