### PR TITLE
Decoration API: Add lightweight ability to have complete coverage

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5769,6 +5769,8 @@ Definition tables
         fill_ratio = 0.02,
     --  ^ The value determines 'decorations per surface node'.
     --  ^ Used only if noise_params is not specified.
+    --  ^ If >= 10.0 complete coverage is enabled and decoration placement uses
+    --  ^ a different and much faster method.
         noise_params = {
             offset = 0,
             scale = 0.45,
@@ -5783,6 +5785,8 @@ Definition tables
     --  ^ distribution.
     --  ^ A noise value is calculated for each square division and determines
     --  ^ 'decorations per surface node' within each division.
+    --  ^ If the noise value >= 10.0 complete coverage is enabled and decoration
+    --  ^ placement uses a different and much faster method.
         biomes = {"Oceanside", "Hills", "Plains"},
     --  ^ List of biomes in which this decoration occurs. Occurs in all biomes
     --  ^ if this is omitted, and ignored if the Mapgen being used does not


### PR DESCRIPTION
When the noise value or fill_ratio >= 10.0 complete coverage is enabled.
This disables random placement to avoid redundant multiple placements
at one position. Instead, 1 decoration per surface node is placed by
looping across each division.

'10' was chosen as this is the fill_ratio that previously created
very near complete coverage. The complete coverage feature therefore
integrates smoothly when noise is used for variable decoration density.

'fill_ratio = 10' should be used by modders who want a decoration
placed on every surface node. Compared to before such a decoration
placement will be 10 times faster.
///////////////////

For #7382 
Tested.

In MT master:

The number of decorations to place in a division of a mapchunk is calculated from the decoration chance and division area, then those decorations are randomly placed.

For a typical division of 16x16 = 256 nodes, fill_ratio = 1.0 results in 256 decorations being placed, however these will not completely cover the surface because they are randomly placed and many decorations will be placed several times at one position. The result is:

![screenshot_20180616_194649](https://user-images.githubusercontent.com/3686677/41509825-cbed5e26-7251-11e8-9ca0-3d0437b90de6.png)

To get complete coverage fill_ratio actually needs to be set to roughly 10.0, so 2560 decorations are placed to cover 256 nodes, 10 times more than necessary.

In this PR:

This PR treats fill_ratio >= 10.0 as a request for complete coverage, random placement is not needed, instead we simply loop over each node in the division and place a decoration on every node. 256 decorations are placed instead of 2560.

Uses:

Working with the Biomes API it has been found very useful to have complete coverage for certain decorations in certain situations. This has been done to excellent effect in 'certain games', not so much yet in MTG.