### PR TITLE
F5 debug info: Use full words for NSEW directions for readability 

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -33,7 +33,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 inline static const char *yawToDirectionString(int yaw)
 {
-	static const char *direction[4] = {"N +Z", "W -X", "S -Z", "E +X"};
+	static const char *direction[4] =
+		{"North +Z", "West -X", "South -Z", "East +X"};
 
 	yaw = wrapDegrees_0_360(yaw);
 	yaw = (yaw + 45) % 360 / 90;


### PR DESCRIPTION
![screenshot_20181006_004703](https://user-images.githubusercontent.com/3686677/46564757-64e9e300-c901-11e8-855d-9ded7ec8690b.png)

F5 debug info was altered a while ago, i have been notified of some issues ~and agreed to change these 2 things.~
I admit that changing the direction words to single letters had made them much less readable.
~The removal of the 'pos' label in front of position is to make position the first thing to catch the eye on the 2nd line, making it more readable and as it was in 0.4.16. I feel position doesn't really need a label because it is so obvious when the player moves.~