### PR TITLE
Biome dust: Revert fix that added dust to mod structures

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -763,16 +763,6 @@ void MapgenBasic::generateBiomes()
 
 			VoxelArea::add_y(em, vi, -1);
 		}
-		// If no stone surface was detected in this mapchunk column the biomemap
-		// will be empty for this (x, z) position. Add the currently active
-		// biome to the biomemap, or if biome is NULL calculate it for this
-		// position and add it.
-		if (biomemap[index] == BIOME_NONE) {
-			if (!biome)
-				biome = biomegen->getBiomeAtIndex(
-					index, v3s16(x, node_min.Y, z));
-			biomemap[index] = biome->index;
-		}
 	}
 }
 


### PR DESCRIPTION
Revert commit 99143f494711034068685b6ee845ce19fa09d7d9 and commit
f4ca830abe1aa22875c99b31bf2ee56e26f83f05.

These commits caused biome dust to be applied even when there was no core
mapgen terrain in a mapchunk column. So the dust, which overgenerates,
then appeared on structures added by mods in 'on_generated', such as
floatlands, asteroids or above-surface realms.
////////////////////

![screenshot_20180619_200842](https://user-images.githubusercontent.com/3686677/41619005-9f822c84-73fc-11e8-8b78-64d5eda11ec0.png)

^ Fixed, see issue screenshot.

Fixes #7458 
The mod breakage outweighs the benefits of the fix.
Here we can't do an automatic revert.
This will be followed up by a PR to fix water surface decorations when there are no solid nodes in a mapchuk column. I will reopen #7392 when this is merged.