### PR TITLE
Formspecs: Add tooltip element for area

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1883,6 +1883,11 @@ Elements
 * `<bgcolor>` tooltip background color as `ColorString` (optional)
 * `<fontcolor>` tooltip font color as `ColorString` (optional)
 
+### `tooltip[<X>,<Y>;<W>,<H>;<tooltip_text>;<bgcolor>;<fontcolor>]`
+* Adds tooltip for an area. Other tooltips will take priority when present.
+* `<bgcolor>` tooltip background color as `ColorString` (optional)
+* `<fontcolor>` tooltip font color as `ColorString` (optional)
+
 ### `image[<X>,<Y>;<W>,<H>;<texture name>]`
 * Show an image
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -402,6 +402,7 @@ protected:
 	std::vector<std::pair<FieldSpec,GUITable*> > m_tables;
 	std::vector<std::pair<FieldSpec,gui::IGUICheckBox*> > m_checkboxes;
 	std::map<std::string, TooltipSpec> m_tooltips;
+	std::vector<std::pair<irr::core::rect<s32>, TooltipSpec>> m_tooltip_rects;
 	std::vector<std::pair<FieldSpec,gui::IGUIScrollBar*> > m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string> > > m_dropdowns;
 


### PR DESCRIPTION
![](https://i.rubenwardy.com/Rrpjj.png)

```lua
minetest.register_on_joinplayer(function(player)
	minetest.after(1, function(name)
		local fs = [[
			size[4,4]
			label[0,0;Test!]
			box[1,1;2,2;#ff0000]
			tooltip[1,1;2,2;Test tooltip]
		]]

		minetest.show_formspec(name, "a", fs)
	end, player:get_player_name())
end)
```