### PR TITLE
Biome API: Fix missing water decorations and biome 'dust' in deep water

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -655,6 +655,7 @@ void MapgenBasic::generateBiomes()
 	for (s16 z = node_min.Z; z <= node_max.Z; z++)
 	for (s16 x = node_min.X; x <= node_max.X; x++, index++) {
 		Biome *biome = NULL;
+		biome_t water_biome_index = 0;
 		u16 depth_top = 0;
 		u16 base_filler = 0;
 		u16 depth_water_top = 0;
@@ -696,6 +697,11 @@ void MapgenBasic::generateBiomes()
 				// Add biome to biomemap at first stone surface detected
 				if (biomemap[index] == BIOME_NONE && is_stone_surface)
 					biomemap[index] = biome->index;
+
+				// Store biome of first water surface detected, as a fallback
+				// entry for the biomemap.
+				if (water_biome_index == 0 && is_water_surface)
+					water_biome_index = biome->index;
 
 				depth_top = biome->depth_top;
 				base_filler = MYMAX(depth_top +
@@ -763,6 +769,11 @@ void MapgenBasic::generateBiomes()
 
 			VoxelArea::add_y(em, vi, -1);
 		}
+		// If no stone surface detected in mapchunk column and a water surface
+		// biome fallback exists, add it to the biomemap. This avoids water
+		// surface decorations failing in deep water.
+ 		if (biomemap[index] == BIOME_NONE && water_biome_index != 0)
+			biomemap[index] = water_biome_index;
 	}
 }
 

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -194,9 +194,9 @@ BiomeGenOriginal::BiomeGenOriginal(BiomeManager *biomemgr,
 	humidmap = noise_humidity->result;
 
 	biomemap = new biome_t[m_csize.X * m_csize.Z];
-	// Initialise with the ID of the default biome so that cavegen can get
-	// biomes when biome generation (which calculates the biomemap IDs) is
-	// disabled.
+	// Initialise with the ID of 'BIOME_NONE' so that cavegen can get the
+	// fallback biome when biome generation (which calculates the biomemap IDs)
+	// is disabled.
 	memset(biomemap, 0, sizeof(biome_t) * m_csize.X * m_csize.Z);
 }
 


### PR DESCRIPTION
![screenshot_20180621_134147](https://user-images.githubusercontent.com/3686677/41719918-5ea56c86-7559-11e8-91b1-9ac18bf59a4d.png)

![screenshot_20180601_054515](https://user-images.githubusercontent.com/3686677/40821539-6f62a1ec-655f-11e8-92c8-dcc959a2464a.png)

^ The bugs. The patch of missing snowblock dust is over an area of deep ocean.

![screenshot_20180621_135843](https://user-images.githubusercontent.com/3686677/41720544-4d1ee580-755b-11e8-82e8-93696d74a0d7.png)

![screenshot_20180621_135455](https://user-images.githubusercontent.com/3686677/41720551-513a34a8-755b-11e8-9fc3-6bf7f6b752cc.png)

^ Fixed.

Fixes most of #7392 
Testing mod for waterlilies (use in mgv5 as that has deep oceans):
```
minetest.clear_registered_biomes()
minetest.clear_registered_ores()
minetest.clear_registered_decorations()

minetest.register_biome({
	name = "grassland",
	--node_dust = "",
	node_top = "default:dirt_with_grass",
	depth_top = 1,
	node_filler = "default:dirt",
	depth_filler = 3,
	--node_stone = "",
	--node_water_top = "",
	--depth_water_top = ,
	--node_water = "",
	--node_river_water = "",
	y_max = 31000,
	y_min = -31000,
	heat_point = 50,
	humidity_point = 50,
})

	minetest.register_decoration({
		name = "",
		deco_type = "simple",
		place_on = {"default:water_source"},
		sidelen = 16,
		fill_ratio = 1,
		biomes = {"grassland"},
		y_max = 1,
		y_min = 1,
		decoration = "flowers:waterlily",
		flags = "liquid_surface",
	})
```