### PR TITLE
README.md: Improve formatting for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further documentation
 - Developer wiki: http://dev.minetest.net/
 - Forum: http://forum.minetest.net/
 - Github: https://github.com/minetest/minetest/
-- [doc/](https://github.com/minetest/minetest/tree/master/docs/) directory of source distribution
+- [doc/](doc/) directory of source distribution
 
 Default controls
 ----------------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further documentation
 - Developer wiki: http://dev.minetest.net/
 - Forum: http://forum.minetest.net/
 - Github: https://github.com/minetest/minetest/
-- `[doc/]`(https://github.com/minetest/minetest/tree/master/docs/) directory of source distribution
+- [doc/](https://github.com/minetest/minetest/tree/master/docs/) directory of source distribution
 
 Default controls
 ----------------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further documentation
 - Developer wiki: http://dev.minetest.net/
 - Forum: http://forum.minetest.net/
 - Github: https://github.com/minetest/minetest/
-- doc/ directory of source distribution
+- `[doc/]`(https://github.com/minetest/minetest/tree/master/docs/) directory of source distribution
 
 Default controls
 ----------------
@@ -72,26 +72,26 @@ Paths
 -----
 Locations:
 
-* bin   - Compiled binaries
-* share - Distributed read-only data
-* user  - User-created modifiable data
+* `bin`   - Compiled binaries
+* `share` - Distributed read-only data
+* `user`  - User-created modifiable data
 
 Where each location is on each platform:
 
 * Windows .zip / RUN_IN_PLACE source:
-    * bin   = bin
-    * share = .
-    * user  = .
+    * `bin`   = `bin`
+    * `share` = `.`
+    * `user`  = `.`
 * Linux installed:
-    * bin   = /usr/bin
-    * share = /usr/share/minetest
-    * user  = ~/.minetest
+    * `bin`   = `/usr/bin`
+    * `share` = `/usr/share/minetest`
+    * `user`  = `~/.minetest`
 * macOS:
-    * bin   = Contents/MacOS
-    * share = Contents/Resources
-    * user  = Contents/User OR ~/Library/Application Support/minetest
+    * `bin`   = `Contents/MacOS`
+    * `share` = `Contents/Resources`
+    * `user`  = `Contents/User OR ~/Library/Application Support/minetest`
 
-Worlds can be found as separate folders in: user/worlds/
+Worlds can be found as separate folders in: `user/worlds/`
 
 Configuration file:
 -------------------
@@ -105,7 +105,7 @@ Configuration file:
 
 Command-line options:
 ---------------------
-- Use --help
+- Use `--help`
 
 Compiling
 ---------
@@ -177,15 +177,15 @@ Run it:
 
     $ ./bin/minetest
 
-- Use cmake . -LH to see all CMake options and their current state
+- Use `cmake . -LH` to see all CMake options and their current state
 - If you want to install it system-wide (or are making a distribution package),
-  you will want to use -DRUN_IN_PLACE=FALSE
-- You can build a bare server by specifying -DBUILD_SERVER=TRUE
-- You can disable the client build by specifying -DBUILD_CLIENT=FALSE
-- You can select between Release and Debug build by -DCMAKE_BUILD_TYPE=<Debug or Release>
+  you will want to use `-DRUN_IN_PLACE=FALSE`
+- You can build a bare server by specifying `-DBUILD_SERVER=TRUE`
+- You can disable the client build by specifying `-DBUILD_CLIENT=FALSE`
+- You can select between Release and Debug build by `-DCMAKE_BUILD_TYPE=<Debug or Release>`
   - Debug build is slower, but gives much more useful output in a debugger
 - If you build a bare server, you don't need to have Irrlicht installed.
-  In that case use -DIRRLICHT_SOURCE_DIR=/the/irrlicht/source
+  - In that case use `-DIRRLICHT_SOURCE_DIR=/the/irrlicht/source`
 
 ### CMake options
 
@@ -273,7 +273,7 @@ Library specific options:
 ### Compiling on Windows
 
 * This section is outdated. In addition to what is described here:
-  * In addition to minetest, you need to download minetest_game.
+  * In addition to minetest, you need to download [minetest_game](https://github.com/minetest/minetest_game).
   * If you wish to have sound support, you need libogg, libvorbis and libopenal
   
 * You need:
@@ -428,7 +428,7 @@ This is how we build Windows releases.
 
 Version scheme
 --------------
-We use major.minor.patch since 5.0.0-dev. Prior to that we used 0.major.minor.
+We use `major.minor.patch` since 5.0.0-dev. Prior to that we used `0.major.minor`.
 
 - Major is incremented when the release contains breaking changes, all other
 numbers are set to 0.
@@ -439,4 +439,4 @@ minor/trivial features considered necessary.
 
 Since 5.0.0-dev and 0.4.17-dev, the dev notation refers to the next release, 
 ie: 5.0.0-dev is the development version leading to 5.0.0. 
-Prior to that we used previous_version-dev.
+Prior to that we used `previous_version-dev`.


### PR DESCRIPTION
## Proposed changes
- Add missing back-ticks to paths, cmake options, command-line options and more.
- Replace names with their respective links in a couple of places.