### PR TITLE
core.spawn_falling_node: Keep metadata

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -132,11 +132,18 @@ core.register_entity(":__builtin:falling_node", {
 	end
 })
 
-local function spawn_falling_node(p, node, meta)
-	local obj = core.add_entity(p, "__builtin:falling_node")
-	if obj then
-		obj:get_luaentity():set_node(node, meta)
+local function convert_to_falling_node(pos, node)
+	local obj = core.add_entity(pos, "__builtin:falling_node")
+	if not obj then
+		return false
 	end
+	node.level = core.get_node_level(pos)
+	local meta = core.get_meta(pos)
+	local metatable = meta and meta:to_table() or {}
+
+	obj:get_luaentity():set_node(node, metatable)
+	core.remove_node(pos)
+	return true
 end
 
 function core.spawn_falling_node(pos)
@@ -144,13 +151,7 @@ function core.spawn_falling_node(pos)
 	if node.name == "air" or node.name == "ignore" then
 		return false
 	end
-	local obj = core.add_entity(pos, "__builtin:falling_node")
-	if obj then
-		obj:get_luaentity():set_node(node)
-		core.remove_node(pos)
-		return true
-	end
-	return false
+	return convert_to_falling_node(pos, node)
 end
 
 local function drop_attached_node(p)
@@ -223,14 +224,7 @@ function core.check_single_for_falling(p)
 				core.get_node_max_level(p_bottom))) and
 
 				(not d_bottom.walkable or d_bottom.buildable_to) then
-			n.level = core.get_node_level(p)
-			local meta = core.get_meta(p)
-			local metatable = {}
-			if meta ~= nil then
-				metatable = meta:to_table()
-			end
-			core.remove_node(p)
-			spawn_falling_node(p, n, metatable)
+			convert_to_falling_node(p, n)
 			return true
 		end
 	end


### PR DESCRIPTION
Fixes #7475

`core.spawn_falling_node` and automatically falling nodes are now handled by the same function.