### PR TITLE
Cavegen: Fix crash when getting biome outside mapchunk

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -507,7 +507,16 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 	MapNode liquidnode = CONTENT_IGNORE;
 
 	if (bmgn) {
-		Biome *biome = (Biome *)bmgn->getBiomeAtPoint(cpabs);
+		Biome *biome = nullptr;
+		if (cpabs.X < node_min.X || cpabs.X > node_max.X ||
+				cpabs.Z < node_min.Z || cpabs.Z > node_max.Z)
+			// Point is outside heat and humidity noise maps so use point noise
+			// calculations.
+			biome = (Biome *)bmgn->calcBiomeAtPoint(cpabs);
+		else
+			// Point is inside heat and humidity noise maps so use them
+			biome = (Biome *)bmgn->getBiomeAtPoint(cpabs);
+
 		if (biome->c_cave_liquid != CONTENT_IGNORE)
 			liquidnode = biome->c_cave_liquid;
 	}


### PR DESCRIPTION
 Cavegen: Fix errors when getting biome outside mapchunk

Some cave segments are outside the mapchunk.

Previously, biome was being calculated by a function that uses the noise
maps. Points outside the mapchunk resulted in incorrect noise map indexes
that were sometimes outside the noise map size, causing a crash.

Use either noise maps or point noise calculations depending on point
location.
////////////////////////

Attends to https://github.com/minetest/minetest/issues/7272#issuecomment-399753619 and https://github.com/minetest/minetest/issues/7272#issuecomment-399754512

Cavegen gets the biome for each cave segment in order to place biome-defined cave liquids.
See bb3baef , this caused the bug and the crashes. This PR is a partial revert of that.

`calcBiomeAtPoint()` was used originally, that function can be used for any point, inside or outside the currently generating mapchunk.

`getBiomeAtPoint()` is used in current master. It can only be used for X, Z values inside the currently generating mapchunk because it uses the heat and humidity values from the noise maps for the currently generating mapchunk. However it is faster as it does not calculate noise.

I just realised that cavegen generates out beyond the mapchunk borders so occasionally the biome is being 'got' for a point just outside the mapchunk.
`getBiomeAtPoint()` calculates the index for the noise maps:
```
Biome *BiomeGenOriginal::getBiomeAtPoint(v3s16 pos) const
{
	return getBiomeAtIndex(
		(pos.Z - m_pmin.Z) * m_csize.X + (pos.X - m_pmin.X),
		pos);
}
```
For a point outside the mapchunk this mostly results in a weird index value that accesses an incorrect position, but sometimes it can result in a negative index or an index larger than the noisemap size, that probably causes rare crashes and probably caused https://github.com/minetest/minetest/issues/7272#issuecomment-399753619

This PR checks X, Z values and uses the fast function if inside the mapchunk and the slower one if outside.