### PR TITLE
Fix buffer overrun in SRP

### DIFF
--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -613,7 +613,7 @@ SRP_Result srp_create_salted_verification_key( SRP_HashAlgorithm alg,
 			if (fill_buff() != SRP_OK) goto error_and_exit;
 		*bytes_s = (unsigned char *)srp_alloc(size_to_fill);
 		if (!*bytes_s) goto error_and_exit;
-		memcpy(*bytes_s, &g_rand_buff + g_rand_idx, size_to_fill);
+		memcpy(*bytes_s, &g_rand_buff[g_rand_idx], size_to_fill);
 		g_rand_idx += size_to_fill;
 	}
 


### PR DESCRIPTION
The old code got a pointer to the array instead of the first element, this resulted in a buffer overflow when the function was used more than once. Issue initially reported in #7272.