### PR TITLE
Log deprecated Lua function calls

### DIFF
--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -91,7 +91,7 @@ bool ModApiBase::registerFunction(lua_State *L, const char *name,
 std::unordered_map<std::string, luaL_Reg> ModApiBase::m_deprecated_wrappers;
 bool ModApiBase::m_error_deprecated_calls = false;
 
-int ModApiBase::l_deprecatedFunction(lua_State *L)
+int ModApiBase::l_deprecated_function(lua_State *L)
 {
 	thread_local std::vector<u64> deprecated_logged;
 
@@ -131,7 +131,7 @@ int ModApiBase::l_deprecatedFunction(lua_State *L)
 	}
 
 	u64 end_time = porting::getTimeUs();
-	g_profiler->avg("l_deprecatedFunction", end_time - start_time);
+	g_profiler->avg("l_deprecated_function", end_time - start_time);
 
 	return it->second.func(L);
 }
@@ -156,7 +156,7 @@ void ModApiBase::markAliasDeprecated(luaL_Reg *reg)
 				{ .name = last_name, .func = reg->func }
 			);
 			m_deprecated_wrappers.emplace(entry);
-			reg->func = l_deprecatedFunction;
+			reg->func = l_deprecated_function;
 		}
 
 		last_func = reg->func;

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -21,7 +21,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_internal.h"
 #include "cpp_api/s_base.h"
 #include "content/mods.h"
+#include "profiler.h"
 #include "server.h"
+#include <algorithm>
 #include <cmath>
 
 ScriptApiBase *ModApiBase::getScriptApiBase(lua_State *L)
@@ -84,4 +86,81 @@ bool ModApiBase::registerFunction(lua_State *L, const char *name,
 	lua_setfield(L, top, name);
 
 	return true;
+}
+
+std::unordered_map<std::string, luaL_Reg> ModApiBase::m_deprecated_wrappers;
+bool ModApiBase::m_error_deprecated_calls = false;
+
+int ModApiBase::l_deprecatedFunction(lua_State *L)
+{
+	thread_local std::vector<u64> deprecated_logged;
+
+	u64 start_time = porting::getTimeUs();
+	lua_Debug ar;
+
+	// Get function name for lookup
+	FATAL_ERROR_IF(!lua_getstack(L, 0, &ar), "lua_getstack() failed");
+	FATAL_ERROR_IF(!lua_getinfo(L, "n", &ar), "lua_getinfo() failed");
+
+	// Combine name with line and script backtrace
+	FATAL_ERROR_IF(!lua_getstack(L, 1, &ar), "lua_getstack() failed");
+	FATAL_ERROR_IF(!lua_getinfo(L, "Sl", &ar), "lua_getinfo() failed");
+
+	// Get parent class to get the wrappers map
+	luaL_checktype(L, 1, LUA_TUSERDATA);
+	void *ud = lua_touserdata(L, 1);
+	ModApiBase *o = *(ModApiBase**)ud;
+
+	// New function and new function name
+	auto it = o->m_deprecated_wrappers.find(ar.name);
+
+	// Get backtrace and hash it to reduce the warning flood
+	std::string backtrace = ar.short_src;
+	backtrace.append(":").append(std::to_string(ar.currentline));
+	u64 hash = murmur_hash_64_ua(backtrace.data(), backtrace.length(), 0xBADBABE);
+
+	if (std::find(deprecated_logged.begin(), deprecated_logged.end(), hash)
+			== deprecated_logged.end()) {
+
+		deprecated_logged.emplace_back(hash);
+		warningstream << "Call to deprecated function '"  << ar.name << "', please use '"
+			<< it->second.name << "' at " << backtrace << std::endl;
+
+		if (m_error_deprecated_calls)
+			script_error(L, LUA_ERRRUN, NULL, NULL);
+	}
+
+	u64 end_time = porting::getTimeUs();
+	g_profiler->avg("l_deprecatedFunction", end_time - start_time);
+
+	return it->second.func(L);
+}
+
+void ModApiBase::markAliasDeprecated(luaL_Reg *reg)
+{
+	std::string value = g_settings->get("deprecated_lua_api_handling");
+	m_error_deprecated_calls = value == "error";
+
+	if (!m_error_deprecated_calls && value != "log")
+		return;
+
+	const char *last_name = nullptr;
+	lua_CFunction last_func = nullptr;
+
+	// ! Null termination !
+	while (reg->func) {
+		if (last_func == reg->func) {
+			// Duplicate found
+			std::pair<std::string, luaL_Reg> entry(
+				reg->name,
+				{ .name = last_name, .func = reg->func }
+			);
+			m_deprecated_wrappers.emplace(entry);
+			reg->func = l_deprecatedFunction;
+		}
+
+		last_func = reg->func;
+		last_name = reg->name;
+		++reg;
+	}
 }

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "common/c_internal.h"
 #include "common/helper.h"
 #include "gamedef.h"
+#include <unordered_map>
 
 extern "C" {
 #include <lua.h>
@@ -70,4 +71,11 @@ public:
 			const char* name,
 			lua_CFunction func,
 			int top);
+
+	static int l_deprecatedFunction(lua_State *L);
+	static void markAliasDeprecated(luaL_Reg *reg);
+private:
+	// <old_name> = { <new_name>, <new_function> }
+	static std::unordered_map<std::string, luaL_Reg> m_deprecated_wrappers;
+	static bool m_error_deprecated_calls;
 };

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -72,7 +72,7 @@ public:
 			lua_CFunction func,
 			int top);
 
-	static int l_deprecatedFunction(lua_State *L);
+	static int l_deprecated_function(lua_State *L);
 	static void markAliasDeprecated(luaL_Reg *reg);
 private:
 	// <old_name> = { <new_name>, <new_function> }

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -122,6 +122,7 @@ void LuaPerlinNoise::Register(lua_State *L)
 
 	lua_pop(L, 1);
 
+	markAliasDeprecated(methods);
 	luaL_openlib(L, 0, methods, 0);
 	lua_pop(L, 1);
 
@@ -130,7 +131,7 @@ void LuaPerlinNoise::Register(lua_State *L)
 
 
 const char LuaPerlinNoise::className[] = "PerlinNoise";
-const luaL_Reg LuaPerlinNoise::methods[] = {
+luaL_Reg LuaPerlinNoise::methods[] = {
 	luamethod_aliased(LuaPerlinNoise, get_2d, get2d),
 	luamethod_aliased(LuaPerlinNoise, get_3d, get3d),
 	{0,0}
@@ -380,6 +381,7 @@ void LuaPerlinNoiseMap::Register(lua_State *L)
 
 	lua_pop(L, 1);
 
+	markAliasDeprecated(methods);
 	luaL_openlib(L, 0, methods, 0);
 	lua_pop(L, 1);
 
@@ -388,7 +390,7 @@ void LuaPerlinNoiseMap::Register(lua_State *L)
 
 
 const char LuaPerlinNoiseMap::className[] = "PerlinNoiseMap";
-const luaL_Reg LuaPerlinNoiseMap::methods[] = {
+luaL_Reg LuaPerlinNoiseMap::methods[] = {
 	luamethod_aliased(LuaPerlinNoiseMap, get_2d_map,      get2dMap),
 	luamethod_aliased(LuaPerlinNoiseMap, get_2d_map_flat, get2dMap_flat),
 	luamethod_aliased(LuaPerlinNoiseMap, calc_2d_map,     calc2dMap),

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -31,7 +31,7 @@ class LuaPerlinNoise : public ModApiBase
 private:
 	NoiseParams np;
 	static const char className[];
-	static const luaL_Reg methods[];
+	static luaL_Reg methods[];
 
 	// Exported functions
 
@@ -63,7 +63,7 @@ class LuaPerlinNoiseMap : public ModApiBase
 	Noise *noise;
 	bool m_is3d;
 	static const char className[];
-	static const luaL_Reg methods[];
+	static luaL_Reg methods[];
 
 	// Exported functions
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1815,6 +1815,7 @@ void ObjectRef::Register(lua_State *L)
 
 	lua_pop(L, 1);  // drop metatable
 
+	markAliasDeprecated(methods);
 	luaL_openlib(L, 0, methods, 0);  // fill methodtable
 	lua_pop(L, 1);  // drop methodtable
 
@@ -1823,7 +1824,7 @@ void ObjectRef::Register(lua_State *L)
 }
 
 const char ObjectRef::className[] = "ObjectRef";
-const luaL_Reg ObjectRef::methods[] = {
+luaL_Reg ObjectRef::methods[] = {
 	// ServerActiveObject
 	luamethod(ObjectRef, remove),
 	luamethod_aliased(ObjectRef, get_pos, getpos),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -50,9 +50,8 @@ public:
 	static ServerActiveObject* getobject(ObjectRef *ref);
 private:
 	ServerActiveObject *m_object = nullptr;
-
 	static const char className[];
-	static const luaL_Reg methods[];
+	static luaL_Reg methods[];
 
 
 	static LuaEntitySAO* getluaobject(ObjectRef *ref);


### PR DESCRIPTION
Logs calls to `setpos`, `setvelocity` etc, so these can be removed in the future to drop a part of our legacy modding API together with `minetest.env:`.

This is a generic approach: (explanation using own thoughts)
1) There are currently 21 deprecated function names, some of them often used
2) The old function names are aliased to the new C++ function, `luamethod_aliased` registers the old function always below the new function. Both have the same function pointer (was only renamed)
3) Backtrace to the bad file is in all cases required to avoid spam log messages (imagine `on_step` calling `:getpos` directly)
4) All API classes differ, but the function types don't -> call the pointer
5) The pointer is either specified on-compile or by a lookup table in between. See question below for the on-compile option.

**Why not a new function for each deprecated function?**
Possible using a giant `#define NEW_DEP_API_FUNC(class, oldname, newname, newfunc)` to do the backtrace and ignoring duplicates. Plus additional lines to declare them in the header files. At the end it would save the lookup table `m_deprecated_wrappers` which has only 11 entries for `ObjectRef` (max).

**How fast is it?**
About 8 μs on my system (debug build) for each deprecated function call -> see the F6 stats, page 3: `l_deprecatedFunction`