### PR TITLE
Shaders support for Android

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -206,15 +206,18 @@ local function formspec(tabview, name, tabdata)
 		"box[8,0;3.75,4.5;#999999]"
 
 	local video_driver = core.settings:get("video_driver")
-	local shaders_supported = video_driver == "opengl"
-	local shaders_enabled = false
-	if shaders_supported then
-		shaders_enabled = core.settings:get_bool("enable_shaders")
+	local shaders_enabled = core.settings:get_bool("enable_shaders")
+	if video_driver == "opengl" then
 		tab_string = tab_string ..
 			"checkbox[8.25,0;cb_shaders;" .. fgettext("Shaders") .. ";"
 					.. tostring(shaders_enabled) .. "]"
+	elseif video_driver == "ogles2" then
+		tab_string = tab_string ..
+			"checkbox[8.25,0;cb_shaders;" .. fgettext("Shaders (experimental)") .. ";"
+					.. tostring(shaders_enabled) .. "]"
 	else
 		core.settings:set_bool("enable_shaders", false)
+		shaders_enabled = false
 		tab_string = tab_string ..
 			"label[8.38,0.2;" .. core.colorize("#888888",
 					fgettext("Shaders (unavailable)")) .. "]"

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -615,8 +615,9 @@ texture_path (Texture path) path
 #    The rendering back-end for Irrlicht.
 #    A restart is required after changing this.
 #    Note: On Android, stick with OGLES1 if unsure! App may fail to start otherwise.
-#    On other platforms, OpenGL is recommended, and it’s the only driver with
-#    shader support currently.
+#    On other platforms, OpenGL is recommended.
+#    Shaders are supported by OpenGL (desktop only) and OGLES2 (experimental,
+#    Android only)
 video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.

--- a/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
+++ b/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
@@ -2,5 +2,5 @@ void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_Vertex;
-	gl_FrontColor = gl_BackColor = gl_Color;
+	varColor = gl_Color;
 }

--- a/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
+++ b/client/shaders/3d_interlaced_merge/opengl_vertex.glsl
@@ -2,5 +2,4 @@ void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = gl_Vertex;
-	varColor = gl_Color;
 }

--- a/client/shaders/default_shader/opengl_fragment.glsl
+++ b/client/shaders/default_shader/opengl_fragment.glsl
@@ -1,3 +1,5 @@
+varying vec4 varColor;
+
 void main(void)
 {
 	gl_FragColor = varColor;

--- a/client/shaders/default_shader/opengl_fragment.glsl
+++ b/client/shaders/default_shader/opengl_fragment.glsl
@@ -1,4 +1,4 @@
 void main(void)
 {
-	gl_FragColor = gl_Color;
+	gl_FragColor = varColor;
 }

--- a/client/shaders/default_shader/opengl_vertex.glsl
+++ b/client/shaders/default_shader/opengl_vertex.glsl
@@ -5,5 +5,5 @@ void main(void)
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = mWorldViewProj * gl_Vertex;
 
-	gl_FrontColor = gl_BackColor = gl_Color;
+	varColor = gl_Color;
 }

--- a/client/shaders/default_shader/opengl_vertex.glsl
+++ b/client/shaders/default_shader/opengl_vertex.glsl
@@ -1,5 +1,7 @@
 uniform mat4 mWorldViewProj;
 
+varying vec4 varColor;
+
 void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;

--- a/client/shaders/minimap_shader/opengl_fragment.glsl
+++ b/client/shaders/minimap_shader/opengl_fragment.glsl
@@ -2,6 +2,8 @@ uniform sampler2D baseTexture;
 uniform sampler2D normalTexture;
 uniform vec3 yawVec;
 
+varying vec4 varColor;
+
 void main (void)
 {
 	vec2 uv = gl_TexCoord[0].st;

--- a/client/shaders/minimap_shader/opengl_fragment.glsl
+++ b/client/shaders/minimap_shader/opengl_fragment.glsl
@@ -27,6 +27,6 @@ void main (void)
 
 	vec3 color = (1.1 * diffuse + 0.05 * height + 0.5 * specular) * base.rgb;
 	vec4 col = vec4(color.rgb, base.a);
-	col *= gl_Color;
+	col *= varColor;
 	gl_FragColor = vec4(col.rgb, base.a);
 }

--- a/client/shaders/minimap_shader/opengl_vertex.glsl
+++ b/client/shaders/minimap_shader/opengl_vertex.glsl
@@ -1,6 +1,8 @@
 uniform mat4 mWorldViewProj;
 uniform mat4 mWorld;
 
+varying vec4 varColor;
+
 void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;

--- a/client/shaders/minimap_shader/opengl_vertex.glsl
+++ b/client/shaders/minimap_shader/opengl_vertex.glsl
@@ -5,5 +5,5 @@ void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = mWorldViewProj * gl_Vertex;
-	gl_FrontColor = gl_BackColor = gl_Color;
+	varColor = gl_Color;
 }

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -9,6 +9,7 @@ uniform vec3 eyePosition;
 varying vec3 vPosition;
 varying vec3 worldPosition;
 varying float area_enable_parallax;
+varying vec4 varColor;
 
 varying vec3 eyeVec;
 varying vec3 tsEyeVec;

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -156,6 +156,13 @@ void main(void)
 	}
 #endif
 
+	vec4 base = texture2D(baseTexture, uv).rgba;
+// alpha test (for non-blending materials only)
+#if MATERIAL_TYPE != TILE_MATERIAL_ALPHA && MATERIAL_TYPE != TILE_MATERIAL_LIQUID_TRANSPARENT
+	if (base.a < 0.5)
+		discard;
+#endif
+
 #if USE_NORMALMAPS == 1
 	if (normalTexturePresent) {
 		bump = get_normal_map(uv);
@@ -179,7 +186,6 @@ void main(void)
 		use_normalmap = true;
 	}
 #endif
-	vec4 base = texture2D(baseTexture, uv).rgba;
 
 #ifdef ENABLE_BUMPMAPPING
 	if (use_normalmap) {

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -20,7 +20,7 @@ bool normalTexturePresent = false;
 const float e = 2.718281828459;
 const float BS = 10.0;
 const float fogStart = FOG_START;
-const float fogShadingParameter = 1 / ( 1 - fogStart);
+const float fogShadingParameter = 1.0 / ( 1.0 - fogStart);
 
 #ifdef ENABLE_TONE_MAPPING
 
@@ -195,7 +195,7 @@ void main(void)
 	color = base.rgb;
 #endif
 
-	vec4 col = vec4(color.rgb * gl_Color.rgb, 1.0); 
+	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
 	
 #ifdef ENABLE_TONE_MAPPING
 	col = applyToneMapping(col);

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -129,8 +129,8 @@ void main(void)
 
 #ifdef ENABLE_PARALLAX_OCCLUSION
 	vec2 eyeRay = vec2 (tsEyeVec.x, -tsEyeVec.y);
-	const float scale = PARALLAX_OCCLUSION_SCALE / PARALLAX_OCCLUSION_ITERATIONS;
-	const float bias = PARALLAX_OCCLUSION_BIAS / PARALLAX_OCCLUSION_ITERATIONS;
+	const float scale = PARALLAX_OCCLUSION_SCALE / PARALLAX_OCCLUSION_ITERATIONS.0;
+	const float bias = PARALLAX_OCCLUSION_BIAS / PARALLAX_OCCLUSION_ITERATIONS.0;
 
 #if PARALLAX_OCCLUSION_MODE == 0
 	// Parallax occlusion with slope information

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -130,8 +130,8 @@ void main(void)
 
 #ifdef ENABLE_PARALLAX_OCCLUSION
 	vec2 eyeRay = vec2 (tsEyeVec.x, -tsEyeVec.y);
-	const float scale = PARALLAX_OCCLUSION_SCALE / PARALLAX_OCCLUSION_ITERATIONS.0;
-	const float bias = PARALLAX_OCCLUSION_BIAS / PARALLAX_OCCLUSION_ITERATIONS.0;
+	const float scale = PARALLAX_OCCLUSION_SCALE / float(PARALLAX_OCCLUSION_ITERATIONS);
+	const float bias = PARALLAX_OCCLUSION_BIAS / float(PARALLAX_OCCLUSION_ITERATIONS);
 
 #if PARALLAX_OCCLUSION_MODE == 0
 	// Parallax occlusion with slope information

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -1,5 +1,7 @@
 uniform mat4 mWorldViewProj;
+uniform mat4 mWorldView;
 uniform mat4 mWorld;
+uniform mat3 mNormal;
 
 // Color of the light emitted by the sun.
 uniform vec3 dayLight;

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -129,16 +129,16 @@ float disp_z;
 	// The pre-baked colors are halved to prevent overflow.
 	vec4 color;
 	// The alpha gives the ratio of sunlight in the incoming light.
-	float nightRatio = 1 - gl_Color.a;
+	float nightRatio = 1.0 - gl_Color.a;
 	color.rgb = gl_Color.rgb * (gl_Color.a * dayLight.rgb + 
-		nightRatio * artificialLight.rgb) * 2;
-	color.a = 1;
+		nightRatio * artificialLight.rgb) * 2.0;
+	color.a = 1.0;
 	
 	// Emphase blue a bit in darker places
 	// See C++ implementation in mapblock_mesh.cpp final_color_blend()
-	float brightness = (color.r + color.g + color.b) / 3;
+	float brightness = (color.r + color.g + color.b) / 3.0;
 	color.b += max(0.0, 0.021 - abs(0.2 * brightness - 0.021) +
 		0.07 * brightness);
 	
-	gl_FrontColor = gl_BackColor = clamp(color, 0.0, 1.0);
+	varColor = clamp(color, 0.0, 1.0);
 }

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -10,6 +10,7 @@ uniform float animationTimer;
 
 varying vec3 vPosition;
 varying vec3 worldPosition;
+varying vec4 varColor;
 
 varying vec3 eyeVec;
 varying vec3 lightVec;

--- a/client/shaders/selection_shader/opengl_fragment.glsl
+++ b/client/shaders/selection_shader/opengl_fragment.glsl
@@ -1,5 +1,7 @@
 uniform sampler2D baseTexture;
 
+varying vec4 varColor;
+
 void main(void)
 {
 	vec2 uv = gl_TexCoord[0].st;

--- a/client/shaders/selection_shader/opengl_fragment.glsl
+++ b/client/shaders/selection_shader/opengl_fragment.glsl
@@ -4,6 +4,6 @@ void main(void)
 {
 	vec2 uv = gl_TexCoord[0].st;
 	vec4 color = texture2D(baseTexture, uv);
-	color.rgb *= gl_Color.rgb;
+	color.rgb *= varColor.rgb;
 	gl_FragColor = color;
 }

--- a/client/shaders/selection_shader/opengl_vertex.glsl
+++ b/client/shaders/selection_shader/opengl_vertex.glsl
@@ -5,5 +5,5 @@ void main(void)
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	gl_Position = mWorldViewProj * gl_Vertex;
 
-	gl_FrontColor = gl_BackColor = gl_Color;
+	varColor = gl_Color;
 }

--- a/client/shaders/selection_shader/opengl_vertex.glsl
+++ b/client/shaders/selection_shader/opengl_vertex.glsl
@@ -1,5 +1,7 @@
 uniform mat4 mWorldViewProj;
 
+varying vec4 varColor;
+
 void main(void)
 {
 	gl_TexCoord[0] = gl_MultiTexCoord0;

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -20,7 +20,7 @@ bool texSeamless = false;
 const float e = 2.718281828459;
 const float BS = 10.0;
 const float fogStart = FOG_START;
-const float fogShadingParameter = 1 / ( 1 - fogStart);
+const float fogShadingParameter = 1.0 / ( 1.0 - fogStart);
 
 void get_texture_flags()
 {
@@ -109,7 +109,7 @@ void main(void)
 #endif
 
 	vec4 col = vec4(color.rgb, base.a);
-	col *= gl_Color;
+	col *= varColor;
 	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
 	// the fog will only be rendered correctly if the last operation before the
 	// clamp() is an addition. Else, the clamp() seems to be ignored.

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -8,6 +8,7 @@ uniform vec3 eyePosition;
 
 varying vec3 vPosition;
 varying vec3 worldPosition;
+varying vec4 varColor;
 
 varying vec3 eyeVec;
 varying vec3 lightVec;

--- a/client/shaders/wielded_shader/opengl_fragment.glsl
+++ b/client/shaders/wielded_shader/opengl_fragment.glsl
@@ -68,6 +68,13 @@ void main(void)
 	bool use_normalmap = false;
 	get_texture_flags();
 
+	vec4 base = texture2D(baseTexture, uv).rgba;
+// alpha test (for non-blending materials only)
+#if MATERIAL_TYPE != TILE_MATERIAL_ALPHA && MATERIAL_TYPE != TILE_MATERIAL_LIQUID_TRANSPARENT
+	if (base.a < 0.5)
+		discard;
+#endif
+
 #if USE_NORMALMAPS == 1
 	if (normalTexturePresent) {
 		bump = get_normal_map(uv);
@@ -91,8 +98,6 @@ void main(void)
 		use_normalmap = true;
 	}
 #endif
-
-	vec4 base = texture2D(baseTexture, uv).rgba;
 
 #ifdef ENABLE_BUMPMAPPING
 	if (use_normalmap) {

--- a/client/shaders/wielded_shader/opengl_vertex.glsl
+++ b/client/shaders/wielded_shader/opengl_vertex.glsl
@@ -1,5 +1,7 @@
 uniform mat4 mWorldViewProj;
+uniform mat4 mWorldView;
 uniform mat4 mWorld;
+uniform mat3 mNormal;
 
 uniform vec3 eyePosition;
 uniform float animationTimer;

--- a/client/shaders/wielded_shader/opengl_vertex.glsl
+++ b/client/shaders/wielded_shader/opengl_vertex.glsl
@@ -28,5 +28,5 @@ void main(void)
 	lightVec = sunPosition - worldPosition;
 	eyeVec = -(gl_ModelViewMatrix * gl_Vertex).xyz;
 
-	gl_FrontColor = gl_BackColor = gl_Color;
+	varColor = gl_Color;
 }

--- a/client/shaders/wielded_shader/opengl_vertex.glsl
+++ b/client/shaders/wielded_shader/opengl_vertex.glsl
@@ -8,6 +8,7 @@ uniform float animationTimer;
 
 varying vec3 vPosition;
 varying vec3 worldPosition;
+varying vec4 varColor;
 
 varying vec3 eyeVec;
 varying vec3 lightVec;

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -14,6 +14,7 @@
 #define STATIC_LOCALEDIR "@LOCALEDIR@"
 #define BUILD_TYPE "@CMAKE_BUILD_TYPE@"
 #define ICON_DIR "@ICONDIR@"
+#cmakedefine01 ENABLE_GLES
 #cmakedefine01 RUN_IN_PLACE
 #cmakedefine01 USE_GETTEXT
 #cmakedefine01 USE_CURL

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,7 @@
 	#define PROJECT_NAME "minetest"
 	#define PROJECT_NAME_C "Minetest"
 	#define STATIC_SHAREDIR ""
+	#define ENABLE_GLES 1
 	#include "android_version.h"
 	#ifdef NDEBUG
 		#define BUILD_TYPE "Release"

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -636,8 +636,6 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		;
 
 	std::string vertex_header = "" \
-			"attribute mat4 mWorldView;\n" \
-			"attribute mat3 mNormal;\n" \
 			"attribute vec4 inVertexPosition;\n" \
 			"attribute vec3 inVertexNormal;\n" \
 			"attribute vec4 inVertexColor;\n" \

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "gamedef.h"
 #include "client/tile.h"
+#include "cmake_config.h"
 
 /*
 	A cache from shader name to shader path
@@ -209,7 +210,7 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 {
 	CachedVertexShaderSetting<float, 16> m_world_view_proj;
 	CachedVertexShaderSetting<float, 16> m_world;
-#ifdef ENABLE_GLES
+#if ENABLE_GLES
 	// Modelview matrix
 	CachedVertexShaderSetting<float, 16> m_world_view;
 	// Normal matrix
@@ -220,7 +221,7 @@ public:
 	MainShaderConstantSetter() :
 		  m_world_view_proj("mWorldViewProj")
 		, m_world("mWorld")
-#ifdef ENABLE_GLES
+#if ENABLE_GLES
 		, m_world_view("mWorldView")
 		, m_normal("mNormal")
 #endif
@@ -252,7 +253,7 @@ public:
 		else
 			services->setVertexShaderConstant(world.pointer(), 4, 4);
 
-#ifdef ENABLE_GLES
+#if ENABLE_GLES
 		if (is_highlevel) {
 			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
 			core::matrix4 normal;
@@ -621,7 +622,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 
 	// Create shaders header
 	bool use_gles = false;
-#ifdef ENABLE_GLES
+#if ENABLE_GLES
 	use_gles = driver->getDriverType() == video::EDT_OGLES2;
 #endif
 	std::string shaders_header = use_gles ?
@@ -914,7 +915,7 @@ void load_shaders(const std::string &name, SourceShaderCache *sourcecache,
 		break;
 
 	case video::EDT_OPENGL:
-#ifdef ENABLE_GLES
+#if ENABLE_GLES
 	case video::EDT_OGLES2:
 #endif
 		// OpenGL: GLSL

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -37,7 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "log.h"
 #include "gamedef.h"
 #include "client/tile.h"
-#include "cmake_config.h"
+#include "config.h"
 
 /*
 	A cache from shader name to shader path

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -629,7 +629,6 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 			"#version 100\n" \
 			"precision mediump float;\n" \
 			"varying vec4 varTexCoord[1];\n" \
-			"varying vec4 varColor;\n" \
 			"#define gl_TexCoord varTexCoord\n" \
 		:
 			"#version 120\n" \

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -209,11 +209,21 @@ class MainShaderConstantSetter : public IShaderConstantSetter
 {
 	CachedVertexShaderSetting<float, 16> m_world_view_proj;
 	CachedVertexShaderSetting<float, 16> m_world;
+#ifdef ENABLE_GLES
+	// Modelview matrix
+	CachedVertexShaderSetting<float, 16> m_world_view;
+	// Normal matrix
+	CachedVertexShaderSetting<float, 9> m_normal;
+#endif
 
 public:
 	MainShaderConstantSetter() :
-		m_world_view_proj("mWorldViewProj"),
-		m_world("mWorld")
+		  m_world_view_proj("mWorldViewProj")
+		, m_world("mWorld")
+#ifdef ENABLE_GLES
+		, m_world_view("mWorldView")
+		, m_normal("mNormal")
+#endif
 	{}
 	~MainShaderConstantSetter() = default;
 
@@ -224,10 +234,12 @@ public:
 		sanity_check(driver);
 
 		// Set clip matrix
+		core::matrix4 worldView;
+		worldView = driver->getTransform(video::ETS_VIEW);
+		worldView *= driver->getTransform(video::ETS_WORLD);
 		core::matrix4 worldViewProj;
 		worldViewProj = driver->getTransform(video::ETS_PROJECTION);
-		worldViewProj *= driver->getTransform(video::ETS_VIEW);
-		worldViewProj *= driver->getTransform(video::ETS_WORLD);
+		worldViewProj *= worldView;
 		if (is_highlevel)
 			m_world_view_proj.set(*reinterpret_cast<float(*)[16]>(worldViewProj.pointer()), services);
 		else
@@ -240,6 +252,20 @@ public:
 		else
 			services->setVertexShaderConstant(world.pointer(), 4, 4);
 
+#ifdef ENABLE_GLES
+		if (is_highlevel) {
+			m_world_view.set(*reinterpret_cast<float(*)[16]>(worldView.pointer()), services);
+			core::matrix4 normal;
+			worldView.getTransposed(normal);
+			sanity_check(normal.makeInverse());
+			float m[9] = {
+				normal[0], normal[1], normal[2],
+				normal[4], normal[5], normal[6],
+				normal[8], normal[9], normal[10],
+			};
+			m_normal.set(m, services);
+		}
+#endif
 	}
 };
 
@@ -594,7 +620,44 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		return shaderinfo;
 
 	// Create shaders header
-	std::string shaders_header = "#version 120\n";
+	bool use_gles = false;
+#ifdef ENABLE_GLES
+	use_gles = driver->getDriverType() == video::EDT_OGLES2;
+#endif
+	std::string shaders_header = use_gles ?
+			"#version 100\n" \
+			"precision mediump float;\n" \
+			"varying vec4 varTexCoord[1];\n" \
+			"varying vec4 varColor;\n" \
+			"#define gl_TexCoord varTexCoord\n" \
+		:
+			"#version 120\n" \
+		;
+
+	std::string vertex_header = "" \
+			"attribute mat4 mWorldView;\n" \
+			"attribute mat3 mNormal;\n" \
+			"attribute vec4 inVertexPosition;\n" \
+			"attribute vec3 inVertexNormal;\n" \
+			"attribute vec4 inVertexColor;\n" \
+			"attribute vec4 inTexCoord0;\n" \
+/* 			"attribute vec4 inTexCoord1;\n" */\
+			"attribute vec4 inVertexTangent;\n" \
+			"attribute vec4 inVertexBinormal;\n" \
+			"\n" \
+			"#define gl_ModelViewMatrix mWorldView\n" \
+			"#define gl_NormalMatrix mNormal\n" \
+			"#define gl_Vertex inVertexPosition\n" \
+			"#define gl_Normal inVertexNormal\n" \
+			"#define gl_Color inVertexColor\n" \
+			"#define gl_MultiTexCoord0 inTexCoord0\n" \
+			"#define gl_MultiTexCoord1 inVertexTangent\n" \
+			"#define gl_MultiTexCoord2 inVertexBinormal\n" \
+		;
+	std::string pixel_header = "" \
+		;
+
+	// geometry shaders aren’t supported in GLES<3
 
 	static const char* drawTypes[] = {
 		"NDT_NORMAL",
@@ -620,7 +683,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaders_header += "#define ";
 		shaders_header += drawTypes[i];
 		shaders_header += " ";
-		shaders_header += itos(i);
+		shaders_header += std::to_string(i);
 		shaders_header += "\n";
 	}
 
@@ -638,15 +701,15 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaders_header += "#define ";
 		shaders_header += materialTypes[i];
 		shaders_header += " ";
-		shaders_header += itos(i);
+		shaders_header += std::to_string(i);
 		shaders_header += "\n";
 	}
 
 	shaders_header += "#define MATERIAL_TYPE ";
-	shaders_header += itos(material_type);
+	shaders_header += std::to_string(material_type);
 	shaders_header += "\n";
 	shaders_header += "#define DRAW_TYPE ";
-	shaders_header += itos(drawtype);
+	shaders_header += std::to_string(drawtype);
 	shaders_header += "\n";
 
 	if (g_settings->getBool("generate_normalmaps")) {
@@ -655,7 +718,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaders_header += "#define GENERATE_NORMALMAPS 0\n";
 	}
 	shaders_header += "#define NORMALMAPS_STRENGTH ";
-	shaders_header += ftos(g_settings->getFloat("normalmaps_strength"));
+	shaders_header += std::to_string(g_settings->getFloat("normalmaps_strength"));
 	shaders_header += "\n";
 	float sample_step;
 	int smooth = (int)g_settings->getFloat("normalmaps_smooth");
@@ -674,7 +737,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		break;
 	}
 	shaders_header += "#define SAMPLE_STEP ";
-	shaders_header += ftos(sample_step);
+	shaders_header += std::to_string(sample_step);
 	shaders_header += "\n";
 
 	if (g_settings->getBool("enable_bumpmapping"))
@@ -687,16 +750,16 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		int iterations = g_settings->getFloat("parallax_occlusion_iterations");
 		shaders_header += "#define ENABLE_PARALLAX_OCCLUSION\n";
 		shaders_header += "#define PARALLAX_OCCLUSION_MODE ";
-		shaders_header += itos(mode);
+		shaders_header += std::to_string(mode);
 		shaders_header += "\n";
 		shaders_header += "#define PARALLAX_OCCLUSION_SCALE ";
-		shaders_header += ftos(scale);
+		shaders_header += std::to_string(scale);
 		shaders_header += "\n";
 		shaders_header += "#define PARALLAX_OCCLUSION_BIAS ";
-		shaders_header += ftos(bias);
+		shaders_header += std::to_string(bias);
 		shaders_header += "\n";
 		shaders_header += "#define PARALLAX_OCCLUSION_ITERATIONS ";
-		shaders_header += itos(iterations);
+		shaders_header += std::to_string(iterations);
 		shaders_header += "\n";
 	}
 
@@ -709,13 +772,13 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	if (g_settings->getBool("enable_waving_water")){
 		shaders_header += "#define ENABLE_WAVING_WATER 1\n";
 		shaders_header += "#define WATER_WAVE_HEIGHT ";
-		shaders_header += ftos(g_settings->getFloat("water_wave_height"));
+		shaders_header += std::to_string(g_settings->getFloat("water_wave_height"));
 		shaders_header += "\n";
 		shaders_header += "#define WATER_WAVE_LENGTH ";
-		shaders_header += ftos(g_settings->getFloat("water_wave_length"));
+		shaders_header += std::to_string(g_settings->getFloat("water_wave_length"));
 		shaders_header += "\n";
 		shaders_header += "#define WATER_WAVE_SPEED ";
-		shaders_header += ftos(g_settings->getFloat("water_wave_speed"));
+		shaders_header += std::to_string(g_settings->getFloat("water_wave_speed"));
 		shaders_header += "\n";
 	} else{
 		shaders_header += "#define ENABLE_WAVING_WATER 0\n";
@@ -737,7 +800,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaders_header += "#define ENABLE_TONE_MAPPING\n";
 
 	shaders_header += "#define FOG_START ";
-	shaders_header += ftos(rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f));
+	shaders_header += std::to_string(rangelim(g_settings->getFloat("fog_start"), 0.0f, 0.99f));
 	shaders_header += "\n";
 
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
@@ -745,11 +808,17 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	const c8* pixel_program_ptr = 0;
 	const c8* geometry_program_ptr = 0;
 	if (!vertex_program.empty()) {
-		vertex_program = shaders_header + vertex_program;
+		if (use_gles)
+			vertex_program = shaders_header + vertex_header + vertex_program;
+		else
+			vertex_program = shaders_header + vertex_program;
 		vertex_program_ptr = vertex_program.c_str();
 	}
 	if (!pixel_program.empty()) {
-		pixel_program = shaders_header + pixel_program;
+		if (use_gles)
+			pixel_program = shaders_header + pixel_header + pixel_program;
+		else
+			pixel_program = shaders_header + pixel_program;
 		pixel_program_ptr = pixel_program.c_str();
 	}
 	if (!geometry_program.empty()) {
@@ -831,27 +900,37 @@ void load_shaders(const std::string &name, SourceShaderCache *sourcecache,
 	geometry_program = "";
 	is_highlevel = false;
 
-	if(enable_shaders){
-		// Look for high level shaders
-		if(drivertype == video::EDT_DIRECT3D9){
-			// Direct3D 9: HLSL
-			// (All shaders in one file)
-			vertex_program = sourcecache->getOrLoad(name, "d3d9.hlsl");
-			pixel_program = vertex_program;
-			geometry_program = vertex_program;
-		}
-		else if(drivertype == video::EDT_OPENGL){
-			// OpenGL: GLSL
-			vertex_program = sourcecache->getOrLoad(name, "opengl_vertex.glsl");
-			pixel_program = sourcecache->getOrLoad(name, "opengl_fragment.glsl");
-			geometry_program = sourcecache->getOrLoad(name, "opengl_geometry.glsl");
-		}
-		if (!vertex_program.empty() || !pixel_program.empty() || !geometry_program.empty()){
-			is_highlevel = true;
-			return;
-		}
-	}
+	if (!enable_shaders)
+		return;
 
+	// Look for high level shaders
+	switch (drivertype) {
+	case video::EDT_DIRECT3D9:
+		// Direct3D 9: HLSL
+		// (All shaders in one file)
+		vertex_program = sourcecache->getOrLoad(name, "d3d9.hlsl");
+		pixel_program = vertex_program;
+		geometry_program = vertex_program;
+		break;
+
+	case video::EDT_OPENGL:
+#ifdef ENABLE_GLES
+	case video::EDT_OGLES2:
+#endif
+		// OpenGL: GLSL
+		vertex_program = sourcecache->getOrLoad(name, "opengl_vertex.glsl");
+		pixel_program = sourcecache->getOrLoad(name, "opengl_fragment.glsl");
+		geometry_program = sourcecache->getOrLoad(name, "opengl_geometry.glsl");
+		break;
+
+	default:
+		// e.g. OpenGL ES 1 (with no shader support)
+		break;
+	}
+	if (!vertex_program.empty() || !pixel_program.empty() || !geometry_program.empty()){
+		is_highlevel = true;
+		return;
+	}
 }
 
 void dumpShaderProgram(std::ostream &output_stream,


### PR DESCRIPTION
Fix #2060 
Tested on desktop with GLES2 emulation. Shaders seem to work well.

@stujones11 test results (on real Android):

config | result | comment
----|----|----
plain | works
generate normalmaps | works | no effect (as expected)
generate normalmaps, bump mapping | crashes
generate normalmaps, parallax occlusion | ? | syntax error fixed (?)
generate normalmaps, bump mapping, parallax occlusion | ? | syntax error fixed (?)
normalmaps included, bump mapping | works
normalmaps included, parallax occlusion | ? | syntax error fixed (?)
normalmaps included, bump mapping, parallax occlusion | ? | syntax error fixed (?)

Waving works, tone mapping works.