### PR TITLE
[WIP] Wield animations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5736,7 +5736,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         wield_overlay = "",
 
         wield_animation = "",
-        -- default "mine", also "dig"
+        -- default "punch", also "dig" or "eat"
 
         palette = "",
         -- An image file containing the palette of a node.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5735,6 +5735,9 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         wield_overlay = "",
 
+        wield_animation = "",
+        -- default "mine", also "dig"
+
         palette = "",
         -- An image file containing the palette of a node.
         -- You can set the currently used color as the "palette_index" field of

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,6 +510,7 @@ set(client_SRCS
 	shader.cpp
 	sky.cpp
 	splinesequence.cpp
+	wieldanimation.cpp
 	wieldmesh.cpp
 	${client_SCRIPT_SRCS}
 	${UNITTEST_CLIENT_SRCS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -509,6 +509,7 @@ set(client_SRCS
 	particles.cpp
 	shader.cpp
 	sky.cpp
+	splinesequence.cpp
 	wieldmesh.cpp
 	${client_SCRIPT_SRCS}
 	${UNITTEST_CLIENT_SRCS}

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -35,12 +35,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "constants.h"
 #include "fontengine.h"
 #include "script/scripting_client.h"
+#include "wieldanimation.h"
 
 #define CAMERA_OFFSET_STEP 200
 #define WIELDMESH_OFFSET_X 55.0f
 #define WIELDMESH_OFFSET_Y -35.0f
-
-static core::quaternion quatFromAngles(float pitch, float roll, float yaw);
 
 Camera::Camera(MapDrawControl &draw_control, Client *client):
 	m_draw_control(draw_control),
@@ -698,147 +697,4 @@ void Camera::removeNametag(Nametag *nametag)
 {
 	m_nametags.remove(nametag);
 	delete nametag;
-}
-
-static core::quaternion quatFromAngles(float pitch, float yaw, float roll)
-{
-	// if the order of angles is important:
-	core::quaternion res;
-	//res *= core::quaternion().fromAngleAxis(pitch * core::DEGTORAD, v3f(0.0f, 0.0f, 1.0f));
-	//res *= core::quaternion().fromAngleAxis(roll  * core::DEGTORAD, v3f(1.0f, 0.0f, 0.0f));
-	//res *= core::quaternion().fromAngleAxis(yaw   * core::DEGTORAD, v3f(0.0f, 1.0f, 0.0f));
-	res *= core::quaternion(pitch * core::DEGTORAD, 0, 0);
-	res *= core::quaternion(0, yaw * core::DEGTORAD, 0);
-	res *= core::quaternion(0, 0, roll * core::DEGTORAD);
-	return res;
-	//return core::quaternion(
-	//	pitch * core::DEGTORAD,
-	//	yaw   * core::DEGTORAD,
-	//	roll  * core::DEGTORAD
-	//);
-}
-
-v3f WieldAnimation::getTranslationAt(float time) const
-{
-	v3f translation;
-	m_translationspline.interpolate(translation, time);
-	return translation;
-}
-
-core::quaternion WieldAnimation::getRotationAt(float time) const
-{
-	core::quaternion rotation;
-	m_rotationspline.interpolate(rotation, time);
-	return rotation;
-}
-
-float WieldAnimation::getDuration() const
-{
-	return m_duration;
-}
-
-void WieldAnimation::setDuration(float duration)
-{
-	m_duration = duration;
-	m_translationspline.normalizeDurations(duration);
-	m_rotationspline.normalizeDurations(duration);
-}
-
-const WieldAnimation& WieldAnimation::getNamed(const std::string &name)
-{
-	if (repository.size() == 0)
-		fillRepository();
-
-	if (repository.find(name) == repository.end())
-		return repository["punch"];
-
-	return repository[name];
-}
-
-std::unordered_map<std::string, WieldAnimation> WieldAnimation::repository;
-
-void WieldAnimation::fillRepository()
-{
-	// default: "punch"
-	WieldAnimation &punch = repository["punch"];
-	punch.m_translationspline
-		.addNode(v3f(0, 0, 0))
-		.addNode(v3f(-70,  50, 0))
-		.addNode(v3f(-70,  -50, 0))
-		.addNode(v3f(0, 0, 0))
-		;
-	punch.m_translationspline
-		.addIndex(1.0, 0, 3)
-		;
-
-	punch.m_rotationspline
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 90.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		;
-	punch.m_rotationspline
-		.addIndex(1.0, 0, 2)
-		;
-	punch.setDuration(0.3f);
-
-	WieldAnimation &dig = repository["dig"];
-	dig.m_translationspline
-		.addNode(v3f(0, 0, 0))
-		.addNode(v3f(-70,  -50, 0))
-		.addNode(v3f(-70,  50, 0))
-		.addNode(v3f(0, 0, 0))
-		;
-	dig.m_translationspline
-		.addIndex(1.0, 0, 3)
-		;
-
-	dig.m_rotationspline
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 135.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 135.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, -80.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		;
-	dig.m_rotationspline
-		.addIndex(1.0, 0, 2)
-		.addIndex(1.0, 2, 3)
-		;
-	dig.setDuration(0.3f);
-
-	// eat (without chewing)
-	WieldAnimation &eat = repository["eat"];
-	eat.m_translationspline
-		.addNode(v3f(0, 0, 0))
-		.addNode(v3f(-35,  20, 0))
-		.addNode(v3f(-55,  10, 0))
-		.addNode(v3f(-55,  10, 0))
-		.addNode(v3f(-55,  15, 0))
-		.addNode(v3f(-55,  10, 0))
-		.addNode(v3f(-55,  15, 0))
-		.addNode(v3f(-55,  10, 0))
-		.addNode(v3f(-30,  0, 0))
-		.addNode(v3f(0, 0, 0))
-		.addNode(v3f(0, 0, 0))
-		;
-	eat.m_translationspline
-		.addIndex(1.0, 0, 3)
-		.addIndex(0.5, 3, 1)
-		.addIndex(0.5, 4, 1)
-		.addIndex(0.5, 5, 1)
-		.addIndex(0.5, 6, 1)
-		.addIndex(1.0, 7, 3)
-		;
-
-	eat.m_rotationspline
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		.addNode(quatFromAngles( -90.0f, 20.0f, -80.0f))
-		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
-		;
-	eat.m_rotationspline
-		.addIndex(1.0, 0, 1)
-		.addIndex(2.0, 1, 0)
-		.addIndex(1.0, 1, 1)
-		;
-	eat.setDuration(1.0f);
 }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -127,8 +127,12 @@ void Camera::step(f32 dtime)
 	bool was_under_zero = m_wield_change_timer < 0;
 	m_wield_change_timer = MYMIN(m_wield_change_timer + dtime, 0.125);
 
-	if (m_wield_change_timer >= 0 && was_under_zero)
+	if (m_wield_change_timer >= 0 && was_under_zero) {
 		m_wieldnode->setItem(m_wield_item_next, m_client);
+		m_wield_animation = m_wield_item_next
+				.getDefinition(m_client->getItemDefManager())
+				.wield_animation;
+	}
 
 	if (m_view_bobbing_state != 0)
 	{
@@ -520,7 +524,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		.normalizeDurations()
 		;
 
-	std::string which_anim = "mine";
+	std::string which_anim = m_wield_animation;
+	if (positionsplines.find(which_anim) == positionsplines.end())
+		which_anim = "mine";
 
 	// Position the wielded item
 	//v3f wield_position = v3f(45, -35, 65);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -526,7 +526,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		//std::cout << "Third block, frac = " << bobfrac << std::endl;
 		wield_position.X -= sin(bobfrac*M_PI*2.0) * 3.0;
 		wield_position.Y += sin(my_modf(bobfrac*2.0)*M_PI) * 3.0;
-#if 1
+#if 0
 		// to help with finding rotations, change the '0' above
 		// to '1' and recompile, then fly around.
 
@@ -812,13 +812,22 @@ void WieldAnimation::fillRepository()
 		.addNode(v3f(0, 0, 0))
 		.addNode(v3f(-35,  20, 0))
 		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  15, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  15, 0))
+		.addNode(v3f(-55,  10, 0))
 		.addNode(v3f(-30,  0, 0))
+		.addNode(v3f(0, 0, 0))
 		.addNode(v3f(0, 0, 0))
 		;
 	eat.m_translationspline
-		.addIndex(1.0, 0, 2)
-		.addIndex(2.0, 2, 0)
-		.addIndex(1.0, 2, 2)
+		.addIndex(1.0, 0, 3)
+		.addIndex(0.5, 3, 1)
+		.addIndex(0.5, 4, 1)
+		.addIndex(0.5, 5, 1)
+		.addIndex(0.5, 6, 1)
+		.addIndex(1.0, 7, 3)
 		;
 
 	eat.m_rotationspline

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -174,15 +174,15 @@ void Camera::step(f32 dtime)
 	}
 
 	if (m_digging_button != -1) {
-		f32 offset = dtime * 3.5f;
 		float m_digging_anim_was = m_digging_anim;
-		m_digging_anim += offset;
-		if (m_digging_anim >= 1)
+		m_digging_anim += dtime;
+		const WieldAnimation &wield_anim = WieldAnimation::getNamed(m_wield_animation);
+		if (m_digging_anim >= wield_anim.getDuration())
 		{
 			m_digging_anim = 0;
 			m_digging_button = -1;
 		}
-		float lim = 0.15;
+		float lim = 0.05f;
 		if(m_digging_anim_was < lim && m_digging_anim >= lim)
 		{
 			if (m_digging_button == 0) {
@@ -487,6 +487,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	v3f wield_rotation = v3f(-100, 120, -100);
 	core::quaternion wield_rotation_q = core::quaternion(wield_rotation * core::DEGTORAD);
 	wield_position.Y += fabs(m_wield_change_timer)*320 - 40;
+#if 0
 	if(m_digging_anim < 0.05 || m_digging_anim > 0.5)
 	{
 		// Why is this block here?
@@ -504,6 +505,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		//wield_rotation.X -= frac * 15.0 * pow(ratiothing2, 1.4f);
 		//wield_rotation.Z += frac * 15.0 * pow(ratiothing2, 1.0f);
 	}
+#endif
 	if (m_digging_button != -1)
 	{
 		f32 digfrac = m_digging_anim;
@@ -730,6 +732,18 @@ core::quaternion WieldAnimation::getRotationAt(float time) const
 	return rotation;
 }
 
+float WieldAnimation::getDuration() const
+{
+	return m_duration;
+}
+
+void WieldAnimation::setDuration(float duration)
+{
+	m_duration = duration;
+	m_translationspline.normalizeDurations(duration);
+	m_rotationspline.normalizeDurations(duration);
+}
+
 const WieldAnimation& WieldAnimation::getNamed(const std::string &name)
 {
 	if (repository.size() == 0)
@@ -755,7 +769,6 @@ void WieldAnimation::fillRepository()
 		;
 	punch.m_translationspline
 		.addIndex(1.0, 0, 3)
-		.normalizeDurations()
 		;
 
 	punch.m_rotationspline
@@ -765,8 +778,8 @@ void WieldAnimation::fillRepository()
 		;
 	punch.m_rotationspline
 		.addIndex(1.0, 0, 2)
-		.normalizeDurations()
 		;
+	punch.setDuration(0.3f);
 
 	WieldAnimation &dig = repository["dig"];
 	dig.m_translationspline
@@ -777,7 +790,6 @@ void WieldAnimation::fillRepository()
 		;
 	dig.m_translationspline
 		.addIndex(1.0, 0, 3)
-		.normalizeDurations()
 		;
 
 	dig.m_rotationspline
@@ -791,8 +803,8 @@ void WieldAnimation::fillRepository()
 	dig.m_rotationspline
 		.addIndex(1.0, 0, 2)
 		.addIndex(1.0, 2, 3)
-		.normalizeDurations()
 		;
+	dig.setDuration(0.3f);
 
 	// eat (without chewing)
 	WieldAnimation &eat = repository["eat"];
@@ -805,8 +817,8 @@ void WieldAnimation::fillRepository()
 		;
 	eat.m_translationspline
 		.addIndex(1.0, 0, 2)
+		.addIndex(2.0, 2, 0)
 		.addIndex(1.0, 2, 2)
-		.normalizeDurations()
 		;
 
 	eat.m_rotationspline
@@ -816,7 +828,8 @@ void WieldAnimation::fillRepository()
 		;
 	eat.m_rotationspline
 		.addIndex(1.0, 0, 1)
+		.addIndex(2.0, 1, 0)
 		.addIndex(1.0, 1, 1)
-		.normalizeDurations()
 		;
+	eat.setDuration(1.0f);
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -22,11 +22,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "inventory.h"
 #include "client/tile.h"
-#include "splinesequence.h"
 #include <ICameraSceneNode.h>
 #include <ISceneNode.h>
 #include <list>
-#include <unordered_map>
 
 class LocalPlayer;
 struct MapDrawControl;
@@ -48,24 +46,6 @@ struct Nametag {
 	std::string nametag_text;
 	video::SColor nametag_color;
 	v3f nametag_pos;
-};
-
-class WieldAnimation {
-public:
-	v3f getTranslationAt(float time) const;
-	core::quaternion getRotationAt(float time) const;
-	float getDuration() const;
-	// call this *after* filling the splines
-	void setDuration(float duration);
-
-	static const WieldAnimation& getNamed(const std::string &name);
-private:
-	SplineSequence<v3f> m_translationspline;
-	SplineSequence<core::quaternion> m_rotationspline;
-	float m_duration;
-
-	static std::unordered_map<std::string, WieldAnimation> repository;
-	static void fillRepository();
 };
 
 enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};

--- a/src/camera.h
+++ b/src/camera.h
@@ -54,11 +54,15 @@ class WieldAnimation {
 public:
 	v3f getTranslationAt(float time) const;
 	core::quaternion getRotationAt(float time) const;
+	float getDuration() const;
+	// call this *after* filling the splines
+	void setDuration(float duration);
 
 	static const WieldAnimation& getNamed(const std::string &name);
 private:
 	SplineSequence<v3f> m_translationspline;
 	SplineSequence<core::quaternion> m_rotationspline;
+	float m_duration;
 
 	static std::unordered_map<std::string, WieldAnimation> repository;
 	static void fillRepository();
@@ -225,7 +229,8 @@ private:
 	// Fall view bobbing
 	f32 m_view_bobbing_fall = 0.0f;
 
-	// Digging animation frame (0 <= m_digging_anim < 1)
+	// Digging animation frame, in seconds
+	// (0 <= m_digging_anim < m_wield_animation.getDuration())
 	f32 m_digging_anim = 0.0f;
 	// If -1, no digging animation
 	// If 0, left-click digging animation

--- a/src/camera.h
+++ b/src/camera.h
@@ -215,6 +215,7 @@ private:
 	// If 0, left-click digging animation
 	// If 1, right-click digging animation
 	s32 m_digging_button = -1;
+	std::string m_wield_animation = "";
 
 	// Animation when changing wielded item
 	f32 m_wield_change_timer = 0.125f;

--- a/src/camera.h
+++ b/src/camera.h
@@ -22,9 +22,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "inventory.h"
 #include "client/tile.h"
+#include "splinesequence.h"
 #include <ICameraSceneNode.h>
 #include <ISceneNode.h>
 #include <list>
+#include <unordered_map>
 
 class LocalPlayer;
 struct MapDrawControl;
@@ -46,6 +48,20 @@ struct Nametag {
 	std::string nametag_text;
 	video::SColor nametag_color;
 	v3f nametag_pos;
+};
+
+class WieldAnimation {
+public:
+	v3f getTranslationAt(float time) const;
+	core::quaternion getRotationAt(float time) const;
+
+	static const WieldAnimation& getNamed(const std::string &name);
+private:
+	SplineSequence<v3f> m_translationspline;
+	SplineSequence<core::quaternion> m_rotationspline;
+
+	static std::unordered_map<std::string, WieldAnimation> repository;
+	static void fillRepository();
 };
 
 enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -70,6 +70,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	inventory_overlay = def.inventory_overlay;
 	wield_image = def.wield_image;
 	wield_overlay = def.wield_overlay;
+	wield_animation = def.wield_animation;
 	wield_scale = def.wield_scale;
 	stack_max = def.stack_max;
 	usable = def.usable;
@@ -110,6 +111,7 @@ void ItemDefinition::reset()
 	inventory_overlay = "";
 	wield_image = "";
 	wield_overlay = "";
+	wield_animation = "";
 	palette_image = "";
 	color = video::SColor(0xFFFFFFFF);
 	wield_scale = v3f(1.0, 1.0, 1.0);
@@ -165,6 +167,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	writeF1000(os, sound_place_failed.pitch);
 	os << serializeString(inventory_overlay);
 	os << serializeString(wield_overlay);
+	os << serializeString(wield_animation);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)
@@ -219,8 +222,9 @@ void ItemDefinition::deSerialize(std::istream &is)
 
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.
-	//try {
-	//} catch(SerializationError &e) {};
+	try {
+		wield_animation = deSerializeString(is);
+	} catch(SerializationError &e) {};
 }
 
 /*

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -63,6 +63,7 @@ struct ItemDefinition
 	std::string inventory_overlay; // Overlay of inventory_image.
 	std::string wield_image; // If empty, inventory_image or mesh (only nodes) is used
 	std::string wield_overlay; // Overlay of wield_image.
+	std::string wield_animation; // Named wield animation
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.
 	v3f wield_scale;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -59,6 +59,7 @@ void read_item_definition(lua_State* L, int index,
 	getstringfield(L, index, "inventory_overlay", def.inventory_overlay);
 	getstringfield(L, index, "wield_image", def.wield_image);
 	getstringfield(L, index, "wield_overlay", def.wield_overlay);
+	getstringfield(L, index, "wield_animation", def.wield_animation);
 	getstringfield(L, index, "palette", def.palette_image);
 
 	// Read item color.
@@ -150,6 +151,8 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "wield_image");
 	lua_pushstring(L, i.wield_overlay.c_str());
 	lua_setfield(L, -2, "wield_overlay");
+	lua_pushstring(L, i.wield_animation.c_str());
+	lua_setfield(L, -2, "wield_animation");
 	lua_pushstring(L, i.palette_image.c_str());
 	lua_setfield(L, -2, "palette_image");
 	push_ARGB8(L, i.color);

--- a/src/splinesequence.cpp
+++ b/src/splinesequence.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest SplineSequence
-Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+Copyright (C) 2016-2018 Ben Deutsch <ben@bendeutsch.de>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/splinesequence.cpp
+++ b/src/splinesequence.cpp
@@ -1,0 +1,43 @@
+/*
+Minetest SplineSequence
+Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "splinesequence.h"
+#include "irrlichttypes_extrabloated.h"
+
+SplineSequence<core::quaternion> quatSplineSequence;
+
+static void fill_it() {
+	core::quaternion a_quat;
+	quatSplineSequence.addNode(a_quat);
+	quatSplineSequence.addIndex(0.0, 0, 0);
+	quatSplineSequence.normalizeDurations();
+}
+
+// some specializations
+
+template<>
+core::quaternion SplineSequence<core::quaternion>::_interpolate(
+	core::quaternion &bottom, core::quaternion &top, float alpha
+) const {
+	core::quaternion result;
+	// slerp or lerp? We're dealing with splines anyway...
+	result.slerp(bottom, top, alpha);
+	return result;
+}
+

--- a/src/splinesequence.h
+++ b/src/splinesequence.h
@@ -1,0 +1,186 @@
+/*
+Minetest SplineSequence
+Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include <vector>
+#include <iostream>
+
+struct SplineIndex {
+	float duration;
+	unsigned int offset;
+	unsigned int length;
+};
+
+template<typename T>
+class SplineSequence {
+private:
+	std::vector<T> nodes;
+	std::vector<SplineIndex> indices; 
+	float m_totalDuration;
+
+public:
+	SplineSequence();
+	~SplineSequence();
+
+	SplineSequence<T>& addNode(T node);
+	SplineSequence<T>& addIndex(float duration, unsigned int offset, unsigned int length);
+	// after this, all durations are non-negative, and sum to 1.0
+	// or passed number
+	SplineSequence<T>& normalizeDurations(float total = 1.0f);
+
+	inline float getTotalDuration() { return m_totalDuration; };
+
+	void interpolate(T &result, float alpha) const;
+
+	T _interpolate(T &bottom, T &top, float alpha) const;
+};
+
+template<typename T>
+SplineSequence<T>::SplineSequence() : m_totalDuration(0.0f) {
+	// noop
+}
+
+template<typename T>
+SplineSequence<T>::~SplineSequence() {
+	// noop
+}
+
+template<typename T>
+SplineSequence<T> &SplineSequence<T>::addNode(T node) {
+	nodes.push_back(node);
+	return *this;
+}
+
+template<typename T>
+SplineSequence<T> &SplineSequence<T>::addIndex(float duration, unsigned int offset, unsigned int length) {
+	// TODO: in-place constructor for structs?
+	// TODO: sanity checks for durations
+	SplineIndex index;
+	index.duration = duration;
+	index.offset   = offset;
+	index.length   = length;
+	indices.push_back(index);
+	m_totalDuration += duration;
+	return *this;
+}
+
+template<typename T>
+SplineSequence<T> &SplineSequence<T>::normalizeDurations(float target) {
+	float sum = 0.0;
+	for(
+		std::vector<SplineIndex>::iterator i = indices.begin();
+		i != indices.end(); i++
+	) {
+		float d = i->duration;
+		if (d < 0.0) d = 0.0; // TODO: sanity check in addIndex
+		sum += d;
+	}
+
+	if (sum == 0.0) {
+		// TODO: throw exception or similar
+	}
+	float adjust = target / sum;
+
+	for(
+		std::vector<SplineIndex>::iterator i = indices.begin();
+		i != indices.end(); i++
+	) {
+		float d = i->duration;
+		if (d < 0.0) d = 0.0;
+		d = d * adjust;
+		i->duration = d;
+	}
+	m_totalDuration = target;
+	return *this;
+}
+
+template<typename T>
+void SplineSequence<T>::interpolate(T &result, float alpha) const {
+
+	// find the index
+	std::vector<SplineIndex>::const_iterator index = indices.begin();
+	while (index != indices.end() && index->duration <= alpha) {
+		alpha -= index->duration;
+		index++;
+	}
+	if (index == indices.end()) {
+		// search unsuccessful?
+		return;
+	}
+	//std::cout << "Found index " << index->offset << ", " << index->length << std::endl;
+	/*
+	0.3 0.3 0.4 , 0.0 -> 1st, 0.0 rem -> 0.0
+	0.3 0.3 0.4 , 0.5 -> 2nd, 0.2 rem -> 0.66
+	*/
+	alpha = alpha / index->duration;
+	//std::cout << "Remaining alpha " << alpha << std::endl;
+
+	typename std::vector<T>::const_iterator start = nodes.begin();
+	start += index->offset;
+	typename std::vector<T>::const_iterator end   = start;
+	end += index->length;
+	//std::cout << "Start: " << start->X << " " << start->Y << " " << start->Z << std::endl;
+	//std::cout << "End:   " << end->X << " " << end->Y << " " << end->Z << std::endl;
+	//std::cout << "Ends: " << *start << " " << *end << std::endl;
+	// these are both inclusive, but vector's range constructor
+	// excludes the end -> advance by one
+	end++;
+
+	std::vector<T> workspace(start, end);
+	for(unsigned int degree=index->length; degree>0; degree--) {
+		for(unsigned int i=0; i<degree; i++) {
+			//std::cout << "Interpolating alpha " << alpha << ", degree " << degree << ", step " << i << std::endl;
+			//std::cout << "Before " << workspace[i] << " onto " << workspace[i+1] << std::endl;
+			workspace[i] = _interpolate(workspace[i], workspace[i+1], alpha);
+			//_interpolate(workspace[i], alpha, index->length);
+			//workspace[i] = (1.0-alpha) * workspace[i] + alpha * workspace[i+1];
+			//std::cout << "After " << workspace[i] << " onto " << workspace[i+1] << std::endl;
+		}
+	}
+	result = workspace[0];
+
+	//SplineIndex index;
+	//for(
+	//	std::vector<SplineIndex>::const_iterator i = indices.begin();
+	//	i != indices.end(); i++
+	//) {
+	//	if (i->duration >= alpha) {
+	//		index = *i;
+	//		alpha -= i->duration;
+	//	}
+	//}
+	//if (index->duration <= 0.0) {
+	//	return;
+	//}
+}
+
+template<typename T>
+T SplineSequence<T>::_interpolate(T &bottom, T &top, float alpha) const {
+	return (1.0 - alpha) * bottom + alpha * top;
+}
+
+// declare specializations
+
+// quaternions have a special interpolation
+template<>
+core::quaternion SplineSequence<core::quaternion>::_interpolate(
+	core::quaternion &bottom, core::quaternion &top, float alpha
+) const;

--- a/src/splinesequence.h
+++ b/src/splinesequence.h
@@ -1,6 +1,6 @@
 /*
 Minetest SplineSequence
-Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+Copyright (C) 2016-2018 Ben Deutsch <ben@bendeutsch.de>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -25,6 +25,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_settings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_socket.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_servermodmanager.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_splinesequence.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_threading.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_utilities.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_voxelarea.cpp

--- a/src/unittest/test.h
+++ b/src/unittest/test.h
@@ -88,6 +88,23 @@ class TestFailedException : public std::exception {
 
 #define UASSERTEQ(T, actual, expected) UASSERTCMP(T, ==, actual, expected)
 
+// Asserts the value is near to the expected value (up to a specified distance),
+// or fails the current unit test
+#define UASSERTNEAR(T, actual, expected, epsilon) {                       \
+	T a = (actual);                                                       \
+	T e = (expected);                                                     \
+	if (!(fabs( a - e ) < epsilon)) {                                     \
+		rawstream                                                         \
+			<< "Test assertion failed: " << #actual << " near "           \
+			<< #expected << std::endl                                     \
+			<< "    at " << fs::GetFilenameFromPath(__FILE__) << ":"      \
+			<< __LINE__ << std::endl                                      \
+			<< "    actual:   " << a << std::endl << "    expected: "     \
+			<< e << std::endl;                                            \
+		throw TestFailedException();                                      \
+	}                                                                     \
+}
+
 // UASSERTs that the specified exception occurs
 #define EXCEPTION_CHECK(EType, code) {    \
 	bool exception_thrown = false;        \

--- a/src/unittest/test_splinesequence.cpp
+++ b/src/unittest/test_splinesequence.cpp
@@ -1,0 +1,244 @@
+ /*
+Minetest
+Copyright (C) 2016 Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+
+#include "splinesequence.h"
+#include "irrlichttypes_extrabloated.h"
+
+class TestSplineSequence : public TestBase {
+public:
+	TestSplineSequence() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestSplineSequence"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testBasic();
+	void testDegree0();
+	void testNormalize();
+	void testUnNormalized();
+
+	void testDegree2();
+	void testDegree3();
+
+	void testV3f();
+	void testQuaternion();
+};
+
+static TestSplineSequence g_test_instance;
+
+void TestSplineSequence::runTests(IGameDef *gamedef)
+{
+	TEST(testBasic);
+	TEST(testDegree0);
+	TEST(testNormalize);
+	TEST(testUnNormalized);
+	TEST(testDegree2);
+	TEST(testDegree3);
+	TEST(testV3f);
+	TEST(testQuaternion);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TestSplineSequence::testBasic()
+{
+	SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(0.0)
+		.addNode(1.0)
+		.addNode(3.0);
+	spline_sequence.addIndex(1.0f, 0, 1);
+	double result = 0.0;
+	spline_sequence.interpolate(result, 0.5f);
+	UASSERTNEAR(double, result, 0.5, 0.0001);
+	UASSERTEQ(float, spline_sequence.getTotalDuration(), 1.0f);
+}
+
+// Should work for degree 0, too!
+// (i.e. always return the first node)
+//
+void TestSplineSequence::testDegree0()
+{
+	SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(4.0)
+		.addNode(5.0);
+	spline_sequence.addIndex(1.0f, 0, 0);
+	double result = 0.0;
+	spline_sequence.interpolate(result, 0.5f);
+	UASSERTEQ(double, result, 4.0);
+}
+
+void TestSplineSequence::testNormalize()
+{
+    SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(3.0)
+		.addNode(4.0)
+		.addNode(5.0)
+		.addNode(6.0);
+	spline_sequence.addIndex(1.0f, 0, 1);
+	spline_sequence.addIndex(2.0f, 2, 1);
+	UASSERTNEAR(float, spline_sequence.getTotalDuration(), 3.0f, 0.0001f);
+    spline_sequence.normalizeDurations();
+	UASSERTNEAR(float, spline_sequence.getTotalDuration(), 1.0f, 0.0001f);
+	double result = 0.0;
+	spline_sequence.interpolate(result, 0.33f);
+	UASSERTNEAR(double, result, 4.0, 0.01);
+	spline_sequence.interpolate(result, 0.34f);
+	UASSERTNEAR(double, result, 5.0, 0.01);
+}
+
+// Un-normalized should also work, just remember the total!
+// If this is not wanted, adjust this test
+//
+void TestSplineSequence::testUnNormalized()
+{
+    SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(3.0)
+		.addNode(4.0)
+		.addNode(5.0)
+		.addNode(6.0);
+	spline_sequence.addIndex(1.0f, 0, 1);
+	spline_sequence.addIndex(2.0f, 2, 1);
+	// not spline_sequence.normalizeDurations();
+	UASSERTNEAR(float, spline_sequence.getTotalDuration(), 3.0f, 0.0001f);
+	double result = 0.0;
+	spline_sequence.interpolate(result, 0.99f);
+	UASSERTNEAR(double, result, 4.0, 0.01);
+	spline_sequence.interpolate(result, 1.01f);
+	UASSERTNEAR(double, result, 5.0, 0.01);
+}
+
+void TestSplineSequence::testDegree2()
+{
+	SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(0.0)
+		.addNode(1.0)
+		.addNode(3.0);
+	spline_sequence.addIndex(1.0f, 0, 2);
+	double result = 0.0;
+
+	// (0.5 + 2.0) / 2.0 = 1.25
+	spline_sequence.interpolate(result, 0.5f);
+	UASSERTNEAR(double, result, 1.25, 0.0001);
+}
+
+void TestSplineSequence::testDegree3()
+{
+	SplineSequence<double> spline_sequence;
+	spline_sequence
+		.addNode(0.0)
+		.addNode(1.0)
+		.addNode(3.0)
+		.addNode(7.0);
+	spline_sequence.addIndex(1.0f, 0, 3);
+	double result = 0.0;
+
+	// (0.5 + 2.0) / 2.0 = 
+	spline_sequence.interpolate(result, 0.5f);
+	double expect = (
+		((0.0 + 1.0) * 0.5 +
+		(1.0 + 3.0) * 0.5) * 0.5 +
+		((1.0 + 3.0) * 0.5 +
+		(3.0 + 7.0) * 0.5) * 0.5
+	) * 0.5;
+	UASSERTNEAR(double, result, expect, 0.0001);
+}
+
+void TestSplineSequence::testV3f()
+{
+	SplineSequence<v3f> spline_sequence;
+	spline_sequence
+		.addNode(v3f(0.0f, 1.0f, 2.0f))
+		.addNode(v3f(1.0f, 0.0f, 2.0f))
+		.addNode(v3f(0.0f, 0.0f, 1.0f));
+	spline_sequence.addIndex(1.0f, 0, 2);
+	v3f result(0.0f, 0.0f, 0.0f);
+
+	// visually inspect values like this:
+#if 0
+	for(float a=0.1f; a<1.0f; a+=0.1f) {
+		spline_sequence.interpolate(result, a);
+		std::cout << result.X << ", " << result.Y << ", " << result.Z << std::endl;
+	}
+#endif
+
+	// test two points: 0.2 and 0.6 - should be enough
+	spline_sequence.interpolate(result, 0.2f);
+	UASSERTNEAR(float, result.X, 0.32f, 0.001f);
+	UASSERTNEAR(float, result.Y, 0.64f, 0.001f);
+	UASSERTNEAR(float, result.Z, 1.96f, 0.001f);
+
+	spline_sequence.interpolate(result, 0.6f);
+	UASSERTNEAR(float, result.X, 0.48f, 0.001f);
+	UASSERTNEAR(float, result.Y, 0.16f, 0.001f);
+	UASSERTNEAR(float, result.Z, 1.64f, 0.001f);
+}
+
+// Support functions for the quaternion test
+// We're usually going for rotations, so test with those,
+// usually as Euler angles, in degrees
+core::quaternion from_euler(float x, float y, float z) {
+	v3f vec(x, y, z);
+	vec *= core::DEGTORAD;
+	return core::quaternion(vec);
+}
+v3f to_euler(core::quaternion q) {
+	v3f vec;
+	q.toEuler(vec);
+	vec *= core::RADTODEG;
+	return vec;
+}
+
+void TestSplineSequence::testQuaternion()
+{
+	SplineSequence<core::quaternion> spline_sequence;
+	spline_sequence
+		.addNode(from_euler(0.0f, 0.0f, -90.0f))
+		.addNode(from_euler(90.0f, 0.0f, -90.0f))
+		.addNode(from_euler(90.0f, 0.0f, 0.0f));
+	spline_sequence.addIndex(1.0f, 0, 2);
+	core::quaternion result;
+
+	// visually inspect values like this:
+#if 0
+	for(float a=0.0f; a<=1.0f; a+=0.1f) {
+		spline_sequence.interpolate(result, a);
+		v3f result_euler = to_euler(result);
+		std::cout << result_euler.X << ", " << result_euler.Y << ", " << result_euler.Z << std::endl;
+	}
+#endif
+
+	// test two points: 0.2 and 0.6 - should be enough
+	spline_sequence.interpolate(result, 0.2f);
+	v3f result1 = to_euler(result);
+	UASSERTNEAR(float, result1.X, 32.3f, 0.1f);
+	UASSERTNEAR(float, result1.Y, 1.8f, 0.1f);
+	UASSERTNEAR(float, result1.Z, -86.6f, 0.1f);
+
+	spline_sequence.interpolate(result, 0.6f);
+	v3f result2 = to_euler(result);
+	UASSERTNEAR(float, result2.X, 75.7f, 0.1f);
+	UASSERTNEAR(float, result2.Y, 4.1f, 0.1f);
+	UASSERTNEAR(float, result2.Z, -57.5f, 0.1f);
+}

--- a/src/unittest/test_splinesequence.cpp
+++ b/src/unittest/test_splinesequence.cpp
@@ -1,6 +1,6 @@
  /*
 Minetest
-Copyright (C) 2016 Ben Deutsch <ben@bendeutsch.de>
+Copyright (C) 2016-2018 Ben Deutsch <ben@bendeutsch.de>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/wieldanimation.cpp
+++ b/src/wieldanimation.cpp
@@ -152,4 +152,31 @@ void WieldAnimation::fillRepository()
 		.addIndex(1.0, 1, 1)
 		;
 	eat.setDuration(1.0f);
+
+	// "poke"
+	WieldAnimation &poke = repository["poke"];
+	poke.m_translationspline
+		.addNode(v3f(0, 0, 0))
+		.addNode(v3f(0, -10, 0))
+		.addNode(v3f(-50,  20, 50))
+		.addNode(v3f(0, -10, 0))
+		.addNode(v3f(0, 0, 0))
+		;
+	poke.m_translationspline
+		.addIndex(1.0, 0, 2)
+		.addIndex(1.0, 2, 2)
+		;
+
+	poke.m_rotationspline
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 90.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 90.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 90.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		;
+	poke.m_rotationspline
+		.addIndex(1.0, 0, 2)
+		.addIndex(1.0, 2, 2)
+		;
+	poke.setDuration(0.5f);
 }

--- a/src/wieldanimation.cpp
+++ b/src/wieldanimation.cpp
@@ -1,0 +1,155 @@
+/*
+Minetest WieldAnimation
+Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "wieldanimation.h"
+
+static core::quaternion quatFromAngles(float pitch, float yaw, float roll)
+{
+	// the order of angles is important:
+	core::quaternion res;
+	res *= core::quaternion(pitch * core::DEGTORAD, 0, 0);
+	res *= core::quaternion(0, yaw * core::DEGTORAD, 0);
+	res *= core::quaternion(0, 0, roll * core::DEGTORAD);
+	return res;
+}
+
+v3f WieldAnimation::getTranslationAt(float time) const
+{
+	v3f translation;
+	m_translationspline.interpolate(translation, time);
+	return translation;
+}
+
+core::quaternion WieldAnimation::getRotationAt(float time) const
+{
+	core::quaternion rotation;
+	m_rotationspline.interpolate(rotation, time);
+	return rotation;
+}
+
+float WieldAnimation::getDuration() const
+{
+	return m_duration;
+}
+
+void WieldAnimation::setDuration(float duration)
+{
+	m_duration = duration;
+	m_translationspline.normalizeDurations(duration);
+	m_rotationspline.normalizeDurations(duration);
+}
+
+const WieldAnimation& WieldAnimation::getNamed(const std::string &name)
+{
+	if (repository.size() == 0)
+		fillRepository();
+
+	if (repository.find(name) == repository.end())
+		return repository["punch"];
+
+	return repository[name];
+}
+
+std::unordered_map<std::string, WieldAnimation> WieldAnimation::repository;
+
+void WieldAnimation::fillRepository()
+{
+	// default: "punch"
+	WieldAnimation &punch = repository["punch"];
+	punch.m_translationspline
+		.addNode(v3f(0, 0, 0))
+		.addNode(v3f(-70,  50, 0))
+		.addNode(v3f(-70,  -50, 0))
+		.addNode(v3f(0, 0, 0))
+		;
+	punch.m_translationspline
+		.addIndex(1.0, 0, 3)
+		;
+
+	punch.m_rotationspline
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 90.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		;
+	punch.m_rotationspline
+		.addIndex(1.0, 0, 2)
+		;
+	punch.setDuration(0.3f);
+
+	WieldAnimation &dig = repository["dig"];
+	dig.m_translationspline
+		.addNode(v3f(0, 0, 0))
+		.addNode(v3f(-70,  -50, 0))
+		.addNode(v3f(-70,  50, 0))
+		.addNode(v3f(0, 0, 0))
+		;
+	dig.m_translationspline
+		.addIndex(1.0, 0, 3)
+		;
+
+	dig.m_rotationspline
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 135.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 135.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, -80.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		;
+	dig.m_rotationspline
+		.addIndex(1.0, 0, 2)
+		.addIndex(1.0, 2, 3)
+		;
+	dig.setDuration(0.3f);
+
+	// eat (without chewing)
+	WieldAnimation &eat = repository["eat"];
+	eat.m_translationspline
+		.addNode(v3f(0, 0, 0))
+		.addNode(v3f(-35,  20, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  15, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-55,  15, 0))
+		.addNode(v3f(-55,  10, 0))
+		.addNode(v3f(-30,  0, 0))
+		.addNode(v3f(0, 0, 0))
+		.addNode(v3f(0, 0, 0))
+		;
+	eat.m_translationspline
+		.addIndex(1.0, 0, 3)
+		.addIndex(0.5, 3, 1)
+		.addIndex(0.5, 4, 1)
+		.addIndex(0.5, 5, 1)
+		.addIndex(0.5, 6, 1)
+		.addIndex(1.0, 7, 3)
+		;
+
+	eat.m_rotationspline
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		.addNode(quatFromAngles( -90.0f, 20.0f, -80.0f))
+		.addNode(quatFromAngles( 0.0f, 0.0f, 0.0f))
+		;
+	eat.m_rotationspline
+		.addIndex(1.0, 0, 1)
+		.addIndex(2.0, 1, 0)
+		.addIndex(1.0, 1, 1)
+		;
+	eat.setDuration(1.0f);
+}

--- a/src/wieldanimation.h
+++ b/src/wieldanimation.h
@@ -1,0 +1,42 @@
+/*
+Minetest WieldAnimation
+Copyright (C) 2018 Ben Deutsch <ben@bendeutsch.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "splinesequence.h"
+#include <unordered_map>
+
+class WieldAnimation {
+public:
+	v3f getTranslationAt(float time) const;
+	core::quaternion getRotationAt(float time) const;
+	float getDuration() const;
+	// call this *after* filling the splines
+	void setDuration(float duration);
+
+	static const WieldAnimation& getNamed(const std::string &name);
+private:
+	SplineSequence<v3f> m_translationspline;
+	SplineSequence<core::quaternion> m_rotationspline;
+	float m_duration;
+
+	static std::unordered_map<std::string, WieldAnimation> repository;
+	static void fillRepository();
+};


### PR DESCRIPTION
The shovel in minetest game points downwards when you hold it. This seems strange, but the reason becomes clear when you dig something: the digging motion is downwards, and if the shovel were the "normal" way up, it would look like the player is just hitting stuff with the flat side of the shovel.

Wouldn't it make more sense for a shovel to dig upwards? This pull request aims to do exactly that: items can define a wield animation instead of the pickaxe inspired downwards swing.

The animations are defined via splines for position (points) and rotation (quaternions), or rather spline sequences (_bonus: this pull request includes a spline sequence class!_)

The current plan is to define a standard set of wield animations (mining, digging, poking, sweeping, eating), identified by a short string, and let the item definition select this. An alternative could be for the item definition to define the splines themselves, but this is for future generations.