### PR TITLE
Implement ChatMessage into the API

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -13,6 +13,7 @@ core.features = {
 	no_chat_message_prediction = true,
 	object_use_texture_alpha = true,
 	object_independent_selectionbox = true,
+	chat_message_table = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -567,6 +567,7 @@ core.registered_decorations = make_registration_wrap("register_decoration", "cle
 core.unregister_biome = make_wrap_deregistration(core.register_biome, core.clear_registered_biomes, core.registered_biomes)
 
 core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
+core.registered_on_chat_messages2, core.register_on_chat_message2 = make_registration()
 core.registered_globalsteps, core.register_globalstep = make_registration()
 core.registered_playerevents, core.register_playerevent = make_registration()
 core.registered_on_mods_loaded, core.register_on_mods_loaded = make_registration()

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -68,13 +68,11 @@ core.register_on_item_use(function(itemstack, pointed_thing)
 	return false
 end)
 
--- This is an example function to ensure it's working properly, should be removed before merge
 core.register_on_receiving_chat_message(function(message)
-	print("[PREVIEW] Received message " .. message)
+	print("[PREVIEW] Received message " .. dump(message))
 	return false
 end)
 
--- This is an example function to ensure it's working properly, should be removed before merge
 core.register_on_sending_chat_message(function(message)
 	print("[PREVIEW] Sending message " .. message)
 	return false

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -656,11 +656,13 @@ Call these functions only at load time!
       callbacks **will likely not be run**. Data should be saved at
       semi-frequent intervals as well as on server shutdown.
 * `minetest.register_on_receiving_chat_message(function(message))`
-    * Called always when a client receive a message
-    * Return `true` to mark the message as handled, which means that it will not be shown to chat
+    * Called always when the client receives a message
+    * message: (table) see `ChatMessage` in
+      [lua_api.txt](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt)
+    * Return `true` to mark the message as handled by Lua and to abort the callbacks
 * `minetest.register_on_sending_chat_message(function(message))`
-    * Called always when a client send a message from chat
-    * Return `true` to mark the message as handled, which means that it will not be sent to server
+    * Called always when a client sends a chat message
+    * Return `true` to mark the message as handled and to abort sending it to the server
 * `minetest.register_chatcommand(cmd, chatcommand definition)`
     * Adds definition to minetest.registered_chatcommands
 * `minetest.unregister_chatcommand(name)`
@@ -860,10 +862,13 @@ Call these functions only at load time!
     * If client disabled minimap (using enable_minimap setting) this reference will be nil.
 * `minetest.camera`
     * Reference to the camera object. See [`Camera`](#camera) class reference for methods.
-* `minetest.show_formspec(formname, formspec)` : returns true on success
-	* Shows a formspec to the player
-* `minetest.display_chat_message(message)` returns true on success
-	* Shows a chat message to the current player.
+* `minetest.show_formspec(formname, formspec)`
+    * Shows a formspec to the player
+    * Returns true on success
+* `minetest.display_chat_message(message)`
+    * Shows a chat message to the current player. 
+    * message: see `ChatMessage`.
+    * Returns true on success
 
 Class reference
 ---------------
@@ -1161,6 +1166,7 @@ Can be obtained via `minetest.get_meta(pos)`.
         func = function(param),        -- Called when command is run.
                                        -- Returns boolean success and text output.
     }
+
 ### Server info
 ```lua
 {

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3660,19 +3660,6 @@ Call these functions only at load time!
         * `dug_unbreakable`
         * `dug_too_fast`
 * `minetest.register_on_chat_message(function(name, message, message_type))`
-    * Called always when a player says something
-    * Return `true` to mark the message as handled, which means that it will
-      not be sent to other players.
-    * message_type: string, see `Chat message type`
-* `minetest.register_on_player_receive_fields(function(player, formname, fields))`
-    * Called when a button is pressed in player's inventory form, when form
-      values are submitted or when the form is actively closed by the player.
-    * Fields are sent for formspec elements which define a field, and the "quit"
-      field is sent when actively closing the form by mouse click, keypress or
-      through a button_exit[] element.
-    * Newest functions are called first
-    * If function returns `true`, remaining functions are not called
-* `minetest.register_on_chat_message(function(name, message, message_type))`
     * (deprecated) Called when a player says something
     * message: string, the text line
     * Return `true` to mark the message as handled, which means that it will
@@ -3682,6 +3669,14 @@ Call these functions only at load time!
     * message: (table) see `ChatMessage`
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
+* `minetest.register_on_player_receive_fields(function(player, formname, fields))`
+    * Called when a button is pressed in player's inventory form, when form
+      values are submitted or when the form is actively closed by the player.
+    * Fields are sent for formspec elements which define a field, and the "quit"
+      field is sent when actively closing the form by mouse click, keypress or
+      through a button_exit[] element.
+    * Newest functions are called first
+    * If function returns `true`, remaining functions are not called
 * `minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv))`
     * Called when `player` crafts something
     * `itemstack` is the output

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3416,6 +3416,8 @@ Utilities
           object_use_texture_alpha = true,
           -- Object selectionbox is settable independently from collisionbox
           object_independent_selectionbox = true,
+          -- The `ChatMessage` table is available and accepted by chat functions
+          chat_message_table = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`
@@ -3657,10 +3659,11 @@ Call these functions only at load time!
         * `finished_unknown_dig`
         * `dug_unbreakable`
         * `dug_too_fast`
-* `minetest.register_on_chat_message(function(name, message))`
+* `minetest.register_on_chat_message(function(name, message, message_type))`
     * Called always when a player says something
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
+    * message_type: string, see `Chat message type`
 * `minetest.register_on_player_receive_fields(function(player, formname, fields))`
     * Called when a button is pressed in player's inventory form, when form
       values are submitted or when the form is actively closed by the player.
@@ -3669,6 +3672,16 @@ Call these functions only at load time!
       through a button_exit[] element.
     * Newest functions are called first
     * If function returns `true`, remaining functions are not called
+* `minetest.register_on_chat_message(function(name, message, message_type))`
+    * (deprecated) Called when a player says something
+    * message: string, the text line
+    * Return `true` to mark the message as handled, which means that it will
+      not be sent to other players.
+* `minetest.register_on_chat_message2(function(message))`
+    * Called when a player says something
+    * message: (table) see `ChatMessage`
+    * Return `true` to mark the message as handled, which means that it will
+      not be sent to other players.
 * `minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv))`
     * Called when `player` crafts something
     * `itemstack` is the output
@@ -3785,8 +3798,22 @@ handler.
 Chat
 ----
 
-* `minetest.chat_send_all(text)`
-* `minetest.chat_send_player(name, text)`
+* `minetest.chat_send_all(message)`
+    * message: see `ChatMessage`.
+* `minetest.chat_send_player(name, message)`
+    * Like `minetest.chat_send_all` but limited to the given player name
+
+ChatMessage
+-----------
+Can either be a string (chat text) or a table with the following fields:
+* `type` (string), defaults to `raw`
+    * `raw`
+    * `normal`: Regular chat message
+    * `announce`: Global server actions
+    * `system`: Player-specific messages (Password change, ...)
+* `sender` (string), defaults to `""`, is the player name who sent the message
+* `text` (string), defaults to `""`, is the actual chat message text
+* `timestamp` (number), defaults to the current tiem, is a UNIX timestamp
 
 Environment access
 ------------------

--- a/src/chatmessage.h
+++ b/src/chatmessage.h
@@ -33,17 +33,17 @@ enum ChatMessageType
 
 struct ChatMessage
 {
-	ChatMessage(const std::wstring &m = L"") : message(m) {}
+	ChatMessage(const std::wstring &m = L"") : text(m) {}
 
 	ChatMessage(ChatMessageType t, const std::wstring &m, const std::wstring &s = L"",
 			std::time_t ts = std::time(0)) :
 			type(t),
-			message(m), sender(s), timestamp(ts)
+			text(m), sender(s), timestamp(ts)
 	{
 	}
 
 	ChatMessageType type = CHATMESSAGE_TYPE_RAW;
-	std::wstring message = L"";
+	std::wstring text = L"";
 	std::wstring sender = L"";
 	std::time_t timestamp = std::time(0);
 };

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1470,13 +1470,13 @@ bool Client::getChatMessage(std::wstring &res)
 		case CHATMESSAGE_TYPE_RAW:
 		case CHATMESSAGE_TYPE_ANNOUNCE:
 		case CHATMESSAGE_TYPE_SYSTEM:
-			res = chatMessage->message;
+			res = chatMessage->text;
 			break;
 		case CHATMESSAGE_TYPE_NORMAL: {
 			if (!chatMessage->sender.empty())
-				res = L"<" + chatMessage->sender + L"> " + chatMessage->message;
+				res = L"<" + chatMessage->sender + L"> " + chatMessage->text;
 			else
-				res = chatMessage->message;
+				res = chatMessage->text;
 			break;
 		}
 		default:
@@ -1499,17 +1499,6 @@ void Client::typeChatMessage(const std::wstring &message)
 
 	// Send to others
 	sendChatMessage(message);
-
-	// Show locally
-	if (message[0] != L'/') {
-		// compatibility code
-		if (m_proto_ver < 29) {
-			LocalPlayer *player = m_env.getLocalPlayer();
-			assert(player);
-			std::wstring name = narrow_to_wide(player->getName());
-			pushToChatQueue(new ChatMessage(CHATMESSAGE_TYPE_NORMAL, message, name));
-		}
-	}
 }
 
 void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -765,12 +765,12 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 	// Get player name of this client
 	std::string name = player->getName();
 	std::wstring wname = narrow_to_wide(name);
+	ChatMessage msg(CHATMESSAGE_TYPE_NORMAL, message, wname);
 
-	std::wstring answer_to_sender = handleChat(name, wname, message, true, player);
-	if (!answer_to_sender.empty()) {
+	msg.text = handleChat(msg, true, player);
+	if (!msg.text.empty()) {
 		// Send the answer to sender
-		SendChatMessage(pkt->getPeerId(), ChatMessage(CHATMESSAGE_TYPE_NORMAL,
-				answer_to_sender, wname));
+		SendChatMessage(pkt->getPeerId(), msg);
 	}
 }
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -44,6 +44,16 @@ struct EnumString es_TileAnimationType[] =
 	{0, NULL},
 };
 
+struct EnumString es_ChatMessageType[] =
+{
+	{ CHATMESSAGE_TYPE_RAW, "raw" },
+	{ CHATMESSAGE_TYPE_NORMAL, "normal" },
+	{ CHATMESSAGE_TYPE_ANNOUNCE, "announce" },
+	{ CHATMESSAGE_TYPE_SYSTEM, "system" },
+	{ 0, nullptr },
+};
+
+
 /******************************************************************************/
 void read_item_definition(lua_State* L, int index,
 		const ItemDefinition &default_def, ItemDefinition &def)
@@ -1151,6 +1161,18 @@ bool string_to_enum(const EnumString *spec, int &result,
 	return false;
 }
 
+bool enum_to_string(const EnumString *spec, const int enum_num,
+		std::string &enum_string)
+{
+	for (const EnumString *esp = spec; esp->str; esp++) {
+		if (esp->num == enum_num) {
+			enum_string = esp->str;
+			return true;
+		}
+	}
+	return false;
+}
+
 /******************************************************************************/
 ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 {
@@ -1951,4 +1973,33 @@ HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
 			break;
 	}
 	return stat;
+}
+
+void push_chat_message(lua_State *L, const ChatMessage &msg)
+{
+	lua_newtable(L);
+
+	std::string type = "raw";
+	enum_to_string(es_ChatMessageType, msg.type, type);
+	setstringfield(L, -1, "type", type.c_str());
+	setstringfield(L, -1, "sender", wide_to_utf8(msg.sender).c_str());
+	setstringfield(L, -1, "text", wide_to_utf8(msg.text).c_str());
+	setintfield(L, -1, "timestamp", msg.timestamp);
+
+}
+
+ChatMessage read_chat_message(lua_State *L, int index)
+{
+	ChatMessage msg;
+	if (lua_isstring(L, index)) {
+		msg.text = utf8_to_wide(lua_tostring(L, index));
+	} else {
+		msg.type = static_cast<ChatMessageType>(getenumfield(L, index, "type",
+			es_ChatMessageType, CHATMESSAGE_TYPE_RAW));
+		msg.sender = getstringfield_default(L, index, "sender", msg.sender);
+		msg.text = getstringfield_default(L, index, "text", msg.text);
+		msg.timestamp = getintfield_default(L, index, "timestamp", msg.timestamp);
+	}
+
+	return msg;
 }

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -43,25 +43,26 @@ extern "C" {
 
 namespace Json { class Value; }
 
-struct MapNode;
-class NodeDefManager;
-struct PointedThing;
-struct ItemStack;
-struct ItemDefinition;
-struct ToolCapabilities;
-struct ObjectProperties;
-struct SimpleSoundSpec;
-struct ServerSoundParams;
 class Inventory;
-struct NodeBox;
-struct ContentFeatures;
-struct TileDef;
-class Server;
-struct DigParams;
-struct HitParams;
-struct EnumString;
-struct NoiseParams;
+class NodeDefManager;
 class Schematic;
+class Server;
+struct ChatMessage;
+struct ContentFeatures;
+struct DigParams;
+struct EnumString;
+struct HitParams;
+struct ItemDefinition;
+struct ItemStack;
+struct MapNode;
+struct NodeBox;
+struct NoiseParams;
+struct ObjectProperties;
+struct PointedThing;
+struct ServerSoundParams;
+struct SimpleSoundSpec;
+struct TileDef;
+struct ToolCapabilities;
 
 
 ContentFeatures    read_content_features     (lua_State *L, int index);
@@ -166,6 +167,10 @@ bool               string_to_enum            (const EnumString *spec,
                                               int &result,
                                               const std::string &str);
 
+bool               enum_to_string            (const EnumString *spec,
+                                              const int enum_num,
+                                              std::string &enum_string);
+
 bool               read_noiseparams          (lua_State *L, int index,
                                               NoiseParams *np);
 void               push_noiseparams          (lua_State *L, NoiseParams *np);
@@ -194,4 +199,8 @@ void               push_hud_element          (lua_State *L, HudElement *elem);
 
 HudElementStat     read_hud_change           (lua_State *L, HudElement *elem, void **value);
 
+void               push_chat_message         (lua_State *L, const ChatMessage &msg);
+ChatMessage        read_chat_message         (lua_State *L, int index);
+
 extern struct EnumString es_TileAnimationType[];
+extern struct EnumString es_ChatMessageType[];

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -452,6 +452,17 @@ bool getstringfield(lua_State *L, int table,
 	return got;
 }
 
+bool getstringfield(lua_State *L, int table,
+		const char *fieldname, std::wstring &result)
+{
+	std::string narrow_result;
+	if (getstringfield(L, table, fieldname, narrow_result)) {
+		result = utf8_to_wide(narrow_result);
+		return true;
+	}
+	return false;
+}
+
 bool getfloatfield(lua_State *L, int table,
 		const char *fieldname, float &result)
 {
@@ -504,6 +515,14 @@ std::string getstringfield_default(lua_State *L, int table,
 		const char *fieldname, const std::string &default_)
 {
 	std::string result = default_;
+	getstringfield(L, table, fieldname, result);
+	return result;
+}
+
+std::wstring getstringfield_default(lua_State *L, int table,
+		const char *fieldname, const std::wstring &default_)
+{
+	std::wstring result = default_;
 	getstringfield(L, table, fieldname, result);
 	return result;
 }

--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -38,6 +38,8 @@ extern "C" {
 
 std::string        getstringfield_default(lua_State *L, int table,
                              const char *fieldname, const std::string &default_);
+std::wstring       getstringfield_default(lua_State *L, int table,
+                             const char *fieldname, const std::wstring &default_);
 bool               getboolfield_default(lua_State *L, int table,
                              const char *fieldname, bool default_);
 float              getfloatfield_default(lua_State *L, int table,
@@ -78,6 +80,8 @@ v3s16              getv3s16field_default(lua_State *L, int table,
                              const char *fieldname, v3s16 default_);
 bool               getstringfield(lua_State *L, int table,
                              const char *fieldname, std::string &result);
+bool               getstringfield(lua_State *L, int table,
+                             const char *fieldname, std::wstring &result);
 size_t             getstringlistfield(lua_State *L, int table,
                              const char *fieldname,
                              std::vector<std::string> *result);

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -60,7 +60,7 @@ bool ScriptApiClient::on_sending_message(const std::string &message)
 	return readParam<bool>(L, -1);
 }
 
-bool ScriptApiClient::on_receiving_message(const std::string &message)
+bool ScriptApiClient::on_receiving_message(const ChatMessage &msg)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -68,7 +68,7 @@ bool ScriptApiClient::on_receiving_message(const std::string &message)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_receiving_chat_message");
 	// Call callbacks
-	lua_pushstring(L, message.c_str());
+	push_chat_message(L, msg);
 	runCallbacks(1, RUN_CALLBACKS_MODE_OR_SC);
 	return readParam<bool>(L, -1);
 }

--- a/src/script/cpp_api/s_client.h
+++ b/src/script/cpp_api/s_client.h
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 class ClientEnvironment;
+struct ChatMessage;
 
 class ScriptApiClient : virtual public ScriptApiBase
 {
@@ -45,7 +46,7 @@ public:
 
 	// Chat message handlers
 	bool on_sending_message(const std::string &message);
-	bool on_receiving_message(const std::string &message);
+	bool on_receiving_message(const ChatMessage &msg);
 
 	void on_damage_taken(int32_t damage_amount);
 	void on_hp_modification(int32_t newhp);

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -19,7 +19,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "cpp_api/s_server.h"
 #include "cpp_api/s_internal.h"
+#include "common/c_content.h"
 #include "common/c_converter.h"
+#include "chatmessage.h"
+#include "util/string.h"
+
 
 bool ScriptApiServer::getAuth(const std::string &playername,
 		std::string *dst_password,
@@ -131,18 +135,31 @@ bool ScriptApiServer::setPassword(const std::string &playername,
 	return lua_toboolean(L, -1);
 }
 
-bool ScriptApiServer::on_chat_message(const std::string &name,
-		const std::string &message)
+bool ScriptApiServer::on_chat_message(const ChatMessage &msg)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_chat_messages");
-	// Call callbacks
-	lua_pushstring(L, name.c_str());
-	lua_pushstring(L, message.c_str());
+	// Push function arguments
+	lua_pushstring(L, wide_to_utf8(msg.sender).c_str());
+	lua_pushstring(L, wide_to_utf8(msg.text).c_str());
+
 	runCallbacks(2, RUN_CALLBACKS_MODE_OR_SC);
+	return readParam<bool>(L, -1);
+}
+
+bool ScriptApiServer::on_chat_message2(const ChatMessage &msg)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_chat_messages
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_chat_messages2");
+	push_chat_message(L, msg);
+
+	runCallbacks(1, RUN_CALLBACKS_MODE_OR_SC);
 	return readParam<bool>(L, -1);
 }
 

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -22,13 +22,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include <set>
 
+struct ChatMessage;
+
 class ScriptApiServer
 		: virtual public ScriptApiBase
 {
 public:
 	// Calls on_chat_message handlers
 	// Returns true if script handled message
-	bool on_chat_message(const std::string &name, const std::string &message);
+	bool on_chat_message(const ChatMessage &msg);
+	bool on_chat_message2(const ChatMessage &msg);
 
 	// Calls when mods are loaded
 	void on_mods_loaded();

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -78,11 +78,8 @@ int ModApiClient::l_print(lua_State *L)
 // display_chat_message(message)
 int ModApiClient::l_display_chat_message(lua_State *L)
 {
-	if (!lua_isstring(L, 1))
-		return 0;
-
-	std::string message = luaL_checkstring(L, 1);
-	getClient(L)->pushToChatQueue(new ChatMessage(utf8_to_wide(message)));
+	ChatMessage msg = read_chat_message(L, 1);
+	getClient(L)->pushToChatQueue(new ChatMessage(msg));
 	lua_pushboolean(L, true);
 	return 1;
 }
@@ -90,9 +87,6 @@ int ModApiClient::l_display_chat_message(lua_State *L)
 // send_chat_message(message)
 int ModApiClient::l_send_chat_message(lua_State *L)
 {
-	if (!lua_isstring(L, 1))
-		return 0;
-
 	// If server disabled this API, discard
 
 	// clang-format off

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -70,11 +70,11 @@ int ModApiServer::l_print(lua_State *L)
 int ModApiServer::l_chat_send_all(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	const char *text = luaL_checkstring(L, 1);
+	ChatMessage msg = read_chat_message(L, 1);
+
 	// Get server from registry
 	Server *server = getServer(L);
-	// Send
-	server->notifyPlayers(utf8_to_wide(text));
+	server->notifyPlayers(msg);
 	return 0;
 }
 
@@ -83,12 +83,11 @@ int ModApiServer::l_chat_send_player(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	const char *name = luaL_checkstring(L, 1);
-	const char *text = luaL_checkstring(L, 2);
+	ChatMessage msg = read_chat_message(L, 2);
 
 	// Get server from registry
 	Server *server = getServer(L);
-	// Send
-	server->notifyPlayer(name, utf8_to_wide(text));
+	server->notifyPlayer(name, msg);
 	return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -224,8 +224,12 @@ public:
 	void unsetIpBanned(const std::string &ip_or_name);
 	std::string getBanDescription(const std::string &ip_or_name);
 
-	void notifyPlayer(const char *name, const std::wstring &msg);
-	void notifyPlayers(const std::wstring &msg);
+	void notifyPlayer(const char *name, const ChatMessage &msg);
+	inline void notifyPlayers(const ChatMessage &msg)
+	{
+		SendChatMessage(PEER_ID_INEXISTENT, msg);
+	}
+
 	void spawnParticle(const std::string &playername,
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
@@ -482,9 +486,7 @@ private:
 	void handleChatInterfaceEvent(ChatEvent *evt);
 
 	// This returns the answer to the sender of wmessage, or "" if there is none
-	std::wstring handleChat(const std::string &name, const std::wstring &wname,
-		std::wstring wmessage_input,
-		bool check_shout_priv = false,
+	std::wstring handleChat(ChatMessage msg, bool check_shout_priv = false,
 		RemotePlayer *player = NULL);
 	void handleAdminChat(const ChatEventChat *evt);
 


### PR DESCRIPTION
Contains https://github.com/red-001/minetest/commits/new_chat_interface

**Testing mod (SSM)**
```Lua
-- Catch the /msg chatcommand
table.insert(core.registered_on_chat_messages, 1,
	function(name, message)
		print(("name=%s, message=%s"):format(name, message))
		return false
	end)

table.insert(core.registered_on_chat_messages2, 1,
	function(message)
		print(("table=%s"):format(dump(message)))
		return false
	end)

minetest.register_chatcommand("msg", {
func = function(name, param)
	minetest.chat_send_player("singleplayer",
		{ text = "## System " .. math.random(), type = "system", sender = "pm_dude" })
	minetest.chat_send_all(
		{ text = "## Announce " .. math.random(), type = "announce" })
	minetest.chat_send_player("singleplayer", "old format")
end
})
```

**Testing mod (CSM)**
Use the `preview` CSM from this PR