### PR TITLE
Correctly verify client passed zoom at the server.

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -199,7 +199,10 @@ void RemoteClient::GetNextBlocks (
 	// Distrust client-sent FOV and get server-set player object property
 	// zoom FOV (degrees) as a check to avoid hacked clients using FOV to load
 	// distant world.
-	float prop_zoom_fov = sao->getZoomFOV() * core::DEGTORAD;
+	// (zoom is disabled by value 0)
+	float prop_zoom_fov = sao->getZoomFOV() < 0.001f ?
+		0.0f :
+		std::max(camera_fov, sao->getZoomFOV() * core::DEGTORAD);
 
 	const s16 full_d_max = std::min(adjustDist(m_max_send_distance, prop_zoom_fov),
 		wanted_range);


### PR DESCRIPTION
The fix in #7333 is not correct. Now the server will always use the serverobject's zoom fov for distance calculation, allowing loading of far (zoom distant) worlds at normal fov.

Instead we want to limit the client passed fov by at least the zoom fov.
Now if zoom is disabled on the server, we do not allow extra distance at all.
If zoom is enabled on the server that zoom fov is the minimum fov used for extra distances.

A well behaved client will work, and hacked client can at most zoom to the zoom distance and only when the server allows it.

////////////////////
EDIT by paramat: Fixes #7518 