### PR TITLE
Mgvalleys: Make river depth variation and humidity drop optional

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1756,14 +1756,16 @@ mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 
 [*Mapgen Valleys]
 
 #    Map generation attributes specific to Mapgen Valleys.
-#    'altitude_chill' makes higher elevations colder, which may cause biome issues.
-#    'humid_rivers' modifies the humidity around rivers and in areas where water would tend to pool,
-#    it may interfere with delicately adjusted biomes.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
-mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers
+#    'altitude_chill': Reduces heat with altitude.
+#    'humid_rivers': Increases humidity around rivers and where water pools.
+#    'vary_river_depth': If enabled, low humidity and high heat causes rivers
+#    to become shallower and occasionally dry.
+#    'altitude_dry': Reduces humidity with altitude.
+mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry
 
-# The altitude at which temperature drops by 20.
+# The vertical distance over which heat drops by 20 if 'altitude_chill' is
+# enabled. Also the vertical distance over which humidity drops by 10 if
+# 'altitude_dry' is enabled.
 mgvalleys_altitude_chill (Altitude chill) int 90
 
 # Depth below which you'll find large caves.

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -28,9 +28,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "mapgen.h"
 
-////////////// Mapgen Valleys flags
-#define MGVALLEYS_ALT_CHILL    0x01
-#define MGVALLEYS_HUMID_RIVERS 0x02
+/////////////////// Mapgen Valleys flags
+#define MGVALLEYS_ALT_CHILL        0x01
+#define MGVALLEYS_HUMID_RIVERS     0x02
+#define MGVALLEYS_VARY_RIVER_DEPTH 0x04
+#define MGVALLEYS_ALT_DRY          0x08
 
 // Feed only one variable into these
 #define MYSQUARE(x) (x) * (x)
@@ -39,12 +41,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class BiomeManager;
 class BiomeGenOriginal;
 
+extern FlagDesc flagdesc_mapgen_valleys[];
+
 
 struct MapgenValleysParams : public MapgenParams {
-	u32 spflags = MGVALLEYS_HUMID_RIVERS | MGVALLEYS_ALT_CHILL;
-	u16 altitude_chill = 90; // The altitude at which temperature drops by 20C
-	u16 river_depth = 4; // How deep to carve river channels
-	u16 river_size = 5; // How wide to make rivers
+	u32 spflags = MGVALLEYS_ALT_CHILL | MGVALLEYS_HUMID_RIVERS |
+		MGVALLEYS_VARY_RIVER_DEPTH | MGVALLEYS_ALT_DRY;
+	u16 altitude_chill = 90;
+	u16 river_depth = 4;
+	u16 river_size = 5;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -53,7 +58,7 @@ struct MapgenValleysParams : public MapgenParams {
 	s16 cavern_taper = 192;
 	float cavern_threshold = 0.6f;
 	s16 dungeon_ymin = -31000;
-	s16 dungeon_ymax = 63; // No higher than surface mapchunks
+	s16 dungeon_ymax = 63;
 
 	NoiseParams np_filler_depth;
 	NoiseParams np_inter_valley_fill;
@@ -88,7 +93,8 @@ struct TerrainNoise {
 class MapgenValleys : public MapgenBasic {
 public:
 
-	MapgenValleys(int mapgenid, MapgenValleysParams *params, EmergeManager *emerge);
+	MapgenValleys(int mapgenid, MapgenValleysParams *params,
+		EmergeManager *emerge);
 	~MapgenValleys();
 
 	virtual MapgenType getType() const { return MAPGEN_VALLEYS; }
@@ -100,8 +106,6 @@ private:
 	BiomeGenOriginal *m_bgen;
 
 	float altitude_chill;
-	bool humid_rivers;
-	bool use_altitude_chill;
 	float humidity_adjust;
 	float river_depth_bed;
 	float river_size_factor;


### PR DESCRIPTION
 Mgvalleys: Make river depth variation and humidity drop optional

Add 2 new mapgen flags to make river depth variation and humidity drop
with altitude independently optional, instead of both being enabled by
the 'humid rivers' flag.

Simplify and clarify related code by removing a low priority
optimisation regarding 't_heat'.
Remove unnecessary optimisation bools and use spflags directly instead.
Improve and fix documentation in settingtypes.txt.
A few minor code cleanups.
/////////////////////////////

Closes #7274 
New and improved version of #7277 (that actually had 2 errors).

Mg valleys has 4 special features:
* River depth variation according to heat and humidity.
* Increased humidity around rivers.
* Decreased humidity with altitude.
* Decreased heat with altitude.

However the first 3 were all controlled by 1 flag: 'humid_rivers'.
This PR splits these into 4 separate flags.