### PR TITLE
Stop players on Prejoin if they are already connected.

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -78,7 +78,7 @@ core.register_on_leaveplayer(function(player, timed_out)
 	core.send_leave_message(player_name, timed_out)
 end)
 
-minetest.register_on_prejoinplayer(function(name)
+core.register_on_prejoinplayer(function(name)
 	if core.get_player_by_name(name) then
 		return "Another client is connected with this name.  If your client closed unexpectedly, try again in a minute."
 	end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -78,6 +78,11 @@ core.register_on_leaveplayer(function(player, timed_out)
 	core.send_leave_message(player_name, timed_out)
 end)
 
+minetest.register_on_prejoinplayer(function(name)
+	if core.get_player_by_name(name) then
+		return "Another client is connected with this name.  If your client closed unexpectedly, try again in a minute."
+	end
+end)
 
 function core.get_connected_players()
 	local temp_table = {}


### PR DESCRIPTION
Prevents that you have to wait until everything is loaded and then you get the message that you can't join.