### PR TITLE
Reduce block load glitches

### DIFF
--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -332,7 +332,7 @@ void RemoteClient::GetNextBlocks (
 					differs from day-time mesh.
 				*/
 				if (d >= d_opt) {
-					if (!block->getDayNightDiff())
+					if (!block->getIsUnderground() && !block->getDayNightDiff())
 						continue;
 				}
 


### PR DESCRIPTION
Fixes #7541 . See comments there.
This will load more blocks, but remove almost all glitches of blocks that are visible but not loaded. The deep ocean glitches and large underground cave glitches are gone.

This will not cause many more blocks underground, due to server side occlusion culling.

For an above ground scene this might load 50% more blocks over the default setting.
(For comparison disabling the optimization completely would load almost 5x as many blocks.)

Note that this is just an improved heuristic. It won't help in above ground level caves or above ground deep lakes.
