### PR TITLE
Make player liquid speed independent of FPS

### DIFF
--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -189,7 +189,7 @@ void ClientEnvironment::step(float dtime)
 						dl = lplayer->movement_liquid_fluidity_smooth;
 					dl *= (lplayer->liquid_viscosity * viscosity_factor) + (1 - viscosity_factor);
 
-					v3f d = d_wanted.normalize() * dl;
+					v3f d = d_wanted.normalize() * (dl * dtime_part * 100.0f);
 					speed += d;
 				}
 

--- a/src/clientenvironment.cpp
+++ b/src/clientenvironment.cpp
@@ -165,30 +165,31 @@ void ClientEnvironment::step(float dtime)
 
 		{
 			// Apply physics
-			if(!free_move && !is_climbing)
-			{
+			if (!free_move && !is_climbing) {
 				// Gravity
 				v3f speed = lplayer->getSpeed();
-				if(!lplayer->in_liquid)
-					speed.Y -= lplayer->movement_gravity * lplayer->physics_override_gravity * dtime_part * 2;
+				if (!lplayer->in_liquid)
+					speed.Y -= lplayer->movement_gravity *
+						lplayer->physics_override_gravity * dtime_part * 2.0f;
 
 				// Liquid floating / sinking
-				if(lplayer->in_liquid && !lplayer->swimming_vertical)
-					speed.Y -= lplayer->movement_liquid_sink * dtime_part * 2;
+				if (lplayer->in_liquid && !lplayer->swimming_vertical)
+					speed.Y -= lplayer->movement_liquid_sink * dtime_part * 2.0f;
 
 				// Liquid resistance
-				if(lplayer->in_liquid_stable || lplayer->in_liquid)
-				{
-					// How much the node's viscosity blocks movement, ranges between 0 and 1
-					// Should match the scale at which viscosity increase affects other liquid attributes
-					const f32 viscosity_factor = 0.3;
+				if (lplayer->in_liquid_stable || lplayer->in_liquid) {
+					// How much the node's viscosity blocks movement, ranges
+					// between 0 and 1. Should match the scale at which viscosity
+					// increase affects other liquid attributes.
+					static const f32 viscosity_factor = 0.3f;
 
 					v3f d_wanted = -speed / lplayer->movement_liquid_fluidity;
 					f32 dl = d_wanted.getLength();
-					if(dl > lplayer->movement_liquid_fluidity_smooth)
+					if (dl > lplayer->movement_liquid_fluidity_smooth)
 						dl = lplayer->movement_liquid_fluidity_smooth;
-					dl *= (lplayer->liquid_viscosity * viscosity_factor) + (1 - viscosity_factor);
 
+					dl *= (lplayer->liquid_viscosity * viscosity_factor) +
+						(1 - viscosity_factor);
 					v3f d = d_wanted.normalize() * (dl * dtime_part * 100.0f);
 					speed += d;
 				}


### PR DESCRIPTION
2nd commit: Fix codestyle issues in code block 
//////////////////////
Closes #7530 

The code in ClientEnvironment::step(float dtime) splits 'dtime' (1 / FPS)  into several smaller 'dtime_part's, each part being a maximum 0.0100s.
With my FPS at 60, printing 'dtime_part' gives:
```
  0.0100
  0.0060
  0.0100
  0.0070
  0.0100
  0.0060
  0.0100
  0.0070
  0.0100
  0.0070
  0.0100
  0.0070
  0.0100
  0.0060
  0.0100
  0.0070
  0.0100
  0.0060
  0.0100
  0.0070
  0.0100
  0.0070
```
Each 'dtime' of 1/60 = 0.0167s is split into 2 parts.

With my FPS at 30, printing 'dtime_part' gives:
```
  0.0100
  0.0100
  0.0100
  0.0030
  0.0100
  0.0100
  0.0100
  0.0030
  0.0100
  0.0100
  0.0100
  0.0030
  0.0100
  0.0100
  0.0100
  0.0030
  0.0100
  0.0100
  0.0100
  0.0030
```
Each 'dtime' of 1/30 = 0.033s is split into 4 parts.

Every 'dtime_part', speed is reduced to slow the player in liquid.

For very low FPS 'dtime' is split into many parts of 0.0100 plus 1 variable part. So 'dtime_part' averages roughly 0.0100, so speed is reduced roughly 100 times per second.
At 99FPS 'dtime' is 0.0101 which is split into 2 parts 0.0100 + 0.001 so 'dtime_part' averages roughly 0.0050, so speed is reduced roughly 200 times per second.
At 101FPS 'dtime' is 0.0099 which is split into one part 0.0099 so 'dtime_part' averages to 0.0099,  so speed is reduced 101 times per second.

This must be the cause of liquid speed depending on FPS. There should be a big change between 99 and 101 FPS.

This is not straightforward to fix then and the current PR code is being reconsidered.