### PR TITLE
Allow an optional readonly base database

### DIFF
--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -98,8 +98,15 @@ See Player File Format below.
 world.mt
 ---------
 World metadata.
-Example content (added indentation):
-  gameid = mesetint
+Example content (added indentation and - explanations):
+  gameid = mesetint             - name of the game
+  enable_damage = true          - whether damage is enabled or not
+  creative_mode = false         - whether creative mode is enabled or not
+  backend = sqlite3             - which DB backend to use for blocks (sqlite3, dummy, leveldb, redis, postgresql)
+  player_backend = sqlite3      - which DB backend to use for player data
+  readonly_backend = sqlite3    - optionally readonly seed DB (DB file _must_ be located in "readonly" subfolder)
+  server_announce = false       - whether the server is publicly announced or not
+  load_mod_<mod> = false        - whether <mod> is to be loaded in this world
 
 Player File Format
 ===================

--- a/src/map.h
+++ b/src/map.h
@@ -469,6 +469,7 @@ private:
 	*/
 	bool m_map_metadata_changed = true;
 	MapDatabase *dbase = nullptr;
+	MapDatabase *dbase_ro = nullptr;
 };
 
 


### PR DESCRIPTION
This is a trivial change that optionally allows for a readonly base DB that resides in a "readonly" subfolder of the world folder.
Usecases would be the following:
1. Make the primary backend dummy. Now the readonly DB can be the seed, the games can proceed and easily be reverted back.
2. The primary could also be persistent. Now we can collect "diffs" to the base DB and copy those around.

If we have a readonly DB configured we won't attempt to load from files.
I tested this with a few maps, works as expected!

This is just a concept for discussion. Should we have a lua API with this? How would that work? etc
