### PR TITLE
CSM: Disallow exploitable clientside mod functions by default 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1126,17 +1126,17 @@ block_send_optimize_distance (Block send optimize distance) int 4 2
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
 #    Restricts the access of certain client-side functions on servers
-#    Combine these byteflags below to restrict more client-side features:
+#    Combine these byteflags below to restrict client-side features:
 #    LOAD_CLIENT_MODS: 1 (disable client mods loading)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_restriction_noderange)
-csm_restriction_flags (Client side modding restrictions) int 18
+csm_restriction_flags (Client side modding restrictions) int 30
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.
-csm_restriction_noderange (Client side node lookup range restriction) int 8
+csm_restriction_noderange (Client side node lookup range restriction) int 0
 
 [*Security]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -331,8 +331,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_restriction_flags", "18");
-	settings->setDefault("csm_restriction_noderange", "8");
+	settings->setDefault("csm_restriction_flags", "30");
+	settings->setDefault("csm_restriction_noderange", "0");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
 	settings->setDefault("world_start_time", "5250");


### PR DESCRIPTION
Since client-provided CSM is so controversial and has such potential to disrupt servers, the default setting should obviously be a complete disable of all exploitable functions, so that they are opt-in not opt-out. It should be a concious decision to enable them.

Currently client mods are allowed to load and are allowed to read item and nodedefs. This will be disruptive for servers as these often contaon the secrets and inner workings of a server.
Many servers are started casually by people who will not understand the issues of CSM and don't know about the restrictions flag, the current default will allow malicious clients to exploit this situation.

This will not work against CSM in any way, as those server admin who know what they're doing will reset the restriction flag to their requirements. This will only reduce exploitation and avoid ignorant usage of CSM.
Any player can quickly contact server admin and ask that they consider the setting of the CSM restriction flags.
This will only inconvenience players who try to use CSM against the wishes of the server.

@rubenwardy @Ezhh @celeron55 