### PR TITLE
Ensure that legacy mode is correctly disabled.

### DIFF
--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1208,6 +1208,10 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 			m_connection->SetPeerID(peer_id_new);
 		}
 
+		// set non legacy mode locally
+		dynamic_cast<UDPPeer *>(peer)->setNonLegacyPeer();
+
+		// request the same from the remote side
 		ConnectionCommand cmd;
 
 		SharedBuffer<u8> reply(2);


### PR DESCRIPTION
Fixes #7545

For some reason legacy mode was never properly disabled and that caused the UdpPeer's sliding window size to be hardcoded to 5, which kills performance on higher latency links (as low as 20-30ms RTTs)