### PR TITLE
Remove old (unnecessary) legacy client handling.

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -663,45 +663,35 @@ void Channel::UpdateTimers(float dtime)
 
 		if (packets_successful > 0) {
 			successful_to_lost_ratio = packet_loss/packets_successful;
-		}
-		else if (packet_loss > 0)
-		{
+		} else if (packet_loss > 0) {
 			window_size = std::max(
 					(window_size - 10),
 					MIN_RELIABLE_WINDOW_SIZE);
 			done = true;
 		}
 
-		if (!done)
-		{
+		if (!done) {
 			if ((successful_to_lost_ratio < 0.01f) &&
-				(window_size < MAX_RELIABLE_WINDOW_SIZE))
-			{
+				(window_size < MAX_RELIABLE_WINDOW_SIZE)) {
 				/* don't even think about increasing if we didn't even
 				 * use major parts of our window */
 				if (reasonable_amount_of_data_transmitted)
 					window_size = std::min(
 							(window_size + 100),
 							MAX_RELIABLE_WINDOW_SIZE);
-			}
-			else if ((successful_to_lost_ratio < 0.05f) &&
-					(window_size < MAX_RELIABLE_WINDOW_SIZE))
-			{
+			} else if ((successful_to_lost_ratio < 0.05f) &&
+					(window_size < MAX_RELIABLE_WINDOW_SIZE)) {
 				/* don't even think about increasing if we didn't even
 				 * use major parts of our window */
 				if (reasonable_amount_of_data_transmitted)
 					window_size = std::min(
 							(window_size + 50),
 							MAX_RELIABLE_WINDOW_SIZE);
-			}
-			else if (successful_to_lost_ratio > 0.15f)
-			{
+			} else if (successful_to_lost_ratio > 0.15f) {
 				window_size = std::max(
 						(window_size - 100),
 						MIN_RELIABLE_WINDOW_SIZE);
-			}
-			else if (successful_to_lost_ratio > 0.1f)
-			{
+			} else if (successful_to_lost_ratio > 0.1f) {
 				window_size = std::max(
 						(window_size - 50),
 						MIN_RELIABLE_WINDOW_SIZE);
@@ -901,10 +891,8 @@ void Peer::Drop()
 UDPPeer::UDPPeer(u16 a_id, Address a_address, Connection* connection) :
 	Peer(a_address,a_id,connection)
 {
-	for(unsigned int i=0; i< CHANNEL_COUNT; i++)
-	{
-		channels[i].setWindowSize(g_settings->getU16("max_packets_per_iteration"));
-	}
+	for (Channel &channel : channels)
+		channel.setWindowSize(g_settings->getU16("max_packets_per_iteration"));
 }
 
 bool UDPPeer::getAddress(MTProtocols type,Address& toset)

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -632,8 +632,7 @@ void Channel::UpdateTimers(float dtime)
 	bpm_counter += dtime;
 	packet_loss_counter += dtime;
 
-	if (packet_loss_counter > 1.0f)
-	{
+	if (packet_loss_counter > 1.0f) {
 		packet_loss_counter -= 1.0f;
 
 		unsigned int packet_loss = 11; /* use a neutral value for initialization */
@@ -648,8 +647,7 @@ void Channel::UpdateTimers(float dtime)
 			//packet_too_late = current_packet_too_late;
 			packets_successful = current_packet_successful;
 
-			if (current_bytes_transfered > (unsigned int) (window_size*512/2))
-			{
+			if (current_bytes_transfered > (unsigned int) (window_size*512/2)) {
 				reasonable_amount_of_data_transmitted = true;
 			}
 			current_packet_loss = 0;
@@ -699,29 +697,26 @@ void Channel::UpdateTimers(float dtime)
 		}
 	}
 
-	if (bpm_counter > 10.0)
-	{
+	if (bpm_counter > 10.0f) {
 		{
 			MutexAutoLock internal(m_internal_mutex);
 			cur_kbps                 =
-					(((float) current_bytes_transfered)/bpm_counter)/1024.0;
+					(((float) current_bytes_transfered)/bpm_counter)/1024.0f;
 			current_bytes_transfered = 0;
 			cur_kbps_lost            =
-					(((float) current_bytes_lost)/bpm_counter)/1024.0;
+					(((float) current_bytes_lost)/bpm_counter)/1024.0f;
 			current_bytes_lost       = 0;
 			cur_incoming_kbps        =
-					(((float) current_bytes_received)/bpm_counter)/1024.0;
+					(((float) current_bytes_received)/bpm_counter)/1024.0f;
 			current_bytes_received   = 0;
-			bpm_counter              = 0;
+			bpm_counter              = 0.0f;
 		}
 
-		if (cur_kbps > max_kbps)
-		{
+		if (cur_kbps > max_kbps) {
 			max_kbps = cur_kbps;
 		}
 
-		if (cur_kbps_lost > max_kbps_lost)
-		{
+		if (cur_kbps_lost > max_kbps_lost) {
 			max_kbps_lost = cur_kbps_lost;
 		}
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -176,7 +176,6 @@ controltype and data description:
 #define CONTROLTYPE_SET_PEER_ID 1
 #define CONTROLTYPE_PING 2
 #define CONTROLTYPE_DISCO 3
-#define CONTROLTYPE_ENABLE_BIG_SEND_WINDOW 4
 
 /*
 ORIGINAL: This is a plain packet with no control and no error
@@ -316,8 +315,7 @@ enum ConnectionCommandType{
 	CONNCMD_SEND,
 	CONNCMD_SEND_TO_ALL,
 	CONCMD_ACK,
-	CONCMD_CREATE_PEER,
-	CONCMD_DISABLE_LEGACY
+	CONCMD_CREATE_PEER
 };
 
 struct ConnectionCommand
@@ -384,16 +382,6 @@ struct ConnectionCommand
 		reliable = true;
 		raw = true;
 	}
-
-	void disableLegacy(session_t peer_id_, const SharedBuffer<u8> &data_)
-	{
-		type = CONCMD_DISABLE_LEGACY;
-		peer_id = peer_id_;
-		data = data_;
-		channelnum = 0;
-		reliable = true;
-		raw = true;
-	}
 };
 
 /* maximum window size to use, 0xFFFF is theoretical maximum  don't think about
@@ -442,7 +430,7 @@ public:
 	void UpdateBytesLost(unsigned int bytes);
 	void UpdateBytesReceived(unsigned int bytes);
 
-	void UpdateTimers(float dtime, bool legacy_peer);
+	void UpdateTimers(float dtime);
 
 	const float getCurrentDownloadRateKB()
 		{ MutexAutoLock lock(m_internal_mutex); return cur_kbps; };
@@ -480,7 +468,7 @@ private:
 
 	unsigned int current_packet_loss = 0;
 	unsigned int current_packet_too_late = 0;
-	unsigned int current_packet_successfull = 0;
+	unsigned int current_packet_successful = 0;
 	float packet_loss_counter = 0.0f;
 
 	unsigned int current_bytes_transfered = 0;
@@ -659,11 +647,6 @@ public:
 
 	bool getAddress(MTProtocols type, Address& toset);
 
-	void setNonLegacyPeer();
-
-	bool getLegacyPeer()
-	{ return m_legacy_peer; }
-
 	u16 getNextSplitSequenceNumber(u8 channel);
 	void setNextSplitSequenceNumber(u8 channel, u16 seqnum);
 
@@ -698,8 +681,6 @@ private:
 	bool processReliableSendCommand(
 					ConnectionCommand &c,
 					unsigned int max_packet_size);
-
-	bool m_legacy_peer = true;
 };
 
 /*


### PR DESCRIPTION
See also #7548

This removes legacy client handling code that actually never worked before - it would treat all clients as legacy clients!
The largest change is just whitespace.
