### PR TITLE
Reduce ABM checks.

### DIFF
--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -521,9 +521,6 @@ public:
 #ifndef SERVER // Only on client
 	MapBlockMesh *mesh = nullptr;
 #endif
-	std::unordered_set<content_t> contents;
-	bool contents_cached = false;
-	bool do_not_cache_contents = false;
 
 	NodeMetadataList m_node_metadata;
 	NodeTimerList m_node_timers;
@@ -533,6 +530,14 @@ public:
 	static const u32 zstride = MAP_BLOCKSIZE * MAP_BLOCKSIZE;
 
 	static const u32 nodecount = MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE;
+
+	//// ABM optimizations ////
+	// cache of content types
+	std::unordered_set<content_t> contents;
+	// true if content types are cached
+	bool contents_cached = false;
+	// true if we never want to cache content types for this block
+	bool do_not_cache_contents = false;
 
 private:
 	/*

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -114,6 +114,8 @@ public:
 		} else if (mod == m_modified) {
 			m_modified_reason |= reason;
 		}
+		if (mod == MOD_STATE_WRITE_NEEDED)
+			contents_cached = false;
 	}
 
 	inline u32 getModified()
@@ -519,6 +521,9 @@ public:
 #ifndef SERVER // Only on client
 	MapBlockMesh *mesh = nullptr;
 #endif
+	std::set<content_t> contents;
+	bool contents_cached = false;
+	bool do_not_cache_contents = false;
 
 	NodeMetadataList m_node_metadata;
 	NodeTimerList m_node_timers;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -521,7 +521,7 @@ public:
 #ifndef SERVER // Only on client
 	MapBlockMesh *mesh = nullptr;
 #endif
-	std::set<content_t> contents;
+	std::unordered_set<content_t> contents;
 	bool contents_cached = false;
 	bool do_not_cache_contents = false;
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -532,11 +532,11 @@ public:
 	static const u32 nodecount = MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE;
 
 	//// ABM optimizations ////
-	// cache of content types
+	// Cache of content types
 	std::unordered_set<content_t> contents;
-	// true if content types are cached
+	// True if content types are cached
 	bool contents_cached = false;
-	// true if we never want to cache content types for this block
+	// True if we never want to cache content types for this block
 	bool do_not_cache_contents = false;
 
 private:

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -807,7 +807,7 @@ public:
 
 		if (block->contents_cached) {
 			bool run_abms = false;
-			for(content_t c : block->contents) {
+			for (content_t c : block->contents) {
 				if (c < m_aabms.size() && m_aabms[c]) {
 					run_abms = true;
 					break;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -805,9 +805,9 @@ public:
 		if(m_aabms.empty() || block->isDummy())
 			return;
 
-		// check the content type cache first
+		// Check the content type cache first
 		// to see whether there are any ABMs
-		// to be run at all for this block
+		// to be run at all for this block.
 		if (block->contents_cached) {
 			blocks_cached++;
 			bool run_abms = false;
@@ -820,7 +820,7 @@ public:
 			if (!run_abms)
 				return;
 		} else {
-			// clear any caching
+			// Clear any caching
 			block->contents.clear();
 		}
 		blocks_scanned++;
@@ -838,11 +838,11 @@ public:
 		{
 			const MapNode &n = block->getNodeUnsafe(p0);
 			content_t c = n.getContent();
-			// cache content types as we go
+			// Cache content types as we go
 			if (!block->contents_cached && !block->do_not_cache_contents) {
 				block->contents.insert(c);
 				if (block->contents.size() > 64) {
-					// too many different nodes... don't try to cache
+					// Too many different nodes... don't try to cache
 					block->do_not_cache_contents = true;
 					block->contents.clear();
 				}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -805,6 +805,9 @@ public:
 		if(m_aabms.empty() || block->isDummy())
 			return;
 
+		// check the content type cache first
+		// to see whether there are any ABMs
+		// to be run at all for this block
 		if (block->contents_cached) {
 			bool run_abms = false;
 			for (content_t c : block->contents) {
@@ -813,9 +816,8 @@ public:
 					break;
 				}
 			}
-			if (!run_abms) {
+			if (!run_abms)
 				return;
-			}
 		} else {
 			// clear any caching
 			block->contents.clear();
@@ -836,9 +838,10 @@ public:
 		{
 			const MapNode &n = block->getNodeUnsafe(p0);
 			content_t c = n.getContent();
+			// cache content types as we go
 			if (!block->contents_cached && !block->do_not_cache_contents) {
 				block->contents.insert(c);
-				if (block->contents.size() > 32) {
+				if (block->contents.size() > 64) {
 					// too many different nodes... don't try to cache
 					block->do_not_cache_contents = true;
 					block->contents.clear();


### PR DESCRIPTION
See #7280

Since is simple and low risk change, reducing the number of time blocks needs to be checked for whether ABMs needs to be run or not, by doing some simple caching.

This builds a cache of the node types in a blocks (up to ~~64~~ 32) and stores this with a cached block. Before any ABMs are checked we first check against this set.

The advantage is that cache invalidation is simple and only depends on a single block; the risk of incorrectly handling this is low.
The disadvantage is that we lose out of further optimization - for example we could cache whether the neighbor check failed, but then we'd need a more tricky protocol for cache invalidation.

Have a look. Something to discuss; but it is functioning as is.