### PR TITLE
Disable shaders GUI on unsupported drivers

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -203,9 +203,20 @@ local function formspec(tabview, name, tabdata)
 		"label[4.25,3.45;" .. fgettext("Screen:") .. "]" ..
 		"checkbox[4.25,3.6;cb_autosave_screensize;" .. fgettext("Autosave Screen Size") .. ";"
 				.. dump(core.settings:get_bool("autosave_screensize")) .. "]" ..
-		"box[8,0;3.75,4.5;#999999]" ..
-		"checkbox[8.25,0;cb_shaders;" .. fgettext("Shaders") .. ";"
-				.. dump(core.settings:get_bool("enable_shaders")) .. "]"
+		"box[8,0;3.75,4.5;#999999]"
+
+	local video_driver = core.settings:get("video_driver")
+	local shaders_supported = video_driver == "opengl"
+	local shaders_enabled = shaders_supported and core.settings:get_bool("enable_shaders")
+	if shaders_supported then
+		tab_string = tab_string ..
+			"checkbox[8.25,0;cb_shaders;" .. fgettext("Shaders") .. ";"
+					.. dump(core.settings:get_bool("enable_shaders")) .. "]"
+	else
+		tab_string = tab_string ..
+			"label[8.38,0.2;" .. core.colorize("#888888",
+					fgettext("Shaders")) .. "]"
+	end
 
 	if PLATFORM == "Android" then
 		tab_string = tab_string ..
@@ -229,7 +240,7 @@ local function formspec(tabview, name, tabdata)
 			((tonumber(core.settings:get("touchscreen_threshold")) / 10) + 1) .. "]"
 	end
 
-	if core.settings:get_bool("enable_shaders") then
+	if shaders_enabled then
 		tab_string = tab_string ..
 			"checkbox[8.25,0.5;cb_bumpmapping;" .. fgettext("Bump Mapping") .. ";"
 					.. dump(core.settings:get_bool("enable_bumpmapping")) .. "]" ..

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -602,6 +602,10 @@ lighting_boost_spread (Light curve mid boost spread) float 0.2 0.0 1.0
 texture_path (Texture path) path
 
 #    The rendering back-end for Irrlicht.
+#    A restart is required after changing this.
+#    NB: on Android, stick with OGLES1 if unsure! App may fail to start otherwise.
+#    On other platforms, OpenGL is recommended, and it’s the only driver with
+#    shader support currently.
 video_driver (Video driver) enum opengl null,software,burningsvideo,direct3d8,direct3d9,opengl,ogles1,ogles2
 
 #    Radius of cloud area stated in number of 64 node cloud squares.


### PR DESCRIPTION
Fix #2060 
Shaders will be re-enabled for GLES2 in #7514 