### PR TITLE
VoxelManip: Abort if an argument is missing instead of silently doing nothing

### DIFF
--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -91,7 +91,7 @@ int LuaVoxelManip::l_set_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		return 0;
+		throw LuaError("set_data called with missing parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {
@@ -186,7 +186,8 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	if (!o->is_mapgen_vm)
-		return 0;
+		throw LuaError("calc_lighting called for a non-mapgen VoxelManip "
+				"object");
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
@@ -219,10 +220,11 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	if (!o->is_mapgen_vm)
-		return 0;
+		throw LuaError("set_lighting called for a non-mapgen VoxelManip "
+				"object");
 
 	if (!lua_istable(L, 2))
-		return 0;
+		throw LuaError("set_lighting called with missing parameter");
 
 	u8 light;
 	light  = (getintfield_default(L, 2, "day",   0) & 0x0F);
@@ -273,7 +275,7 @@ int LuaVoxelManip::l_set_light_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		return 0;
+		throw LuaError("set_light_data called with missing parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {
@@ -321,7 +323,7 @@ int LuaVoxelManip::l_set_param2_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		return 0;
+		throw LuaError("set_param2_data called with missing parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -185,9 +185,11 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaVoxelManip *o = checkobject(L, 1);
-	if (!o->is_mapgen_vm)
-		throw LuaError("calc_lighting called for a non-mapgen VoxelManip "
-				"object");
+	if (!o->is_mapgen_vm) {
+		warningstream << "calc_lighting called for a non-mapgen VoxelManip "
+			"object" << std::endl;
+		return 0;
+	}
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 	EmergeManager *emerge = getServer(L)->getEmergeManager();
@@ -219,9 +221,11 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 
 	LuaVoxelManip *o = checkobject(L, 1);
-	if (!o->is_mapgen_vm)
-		throw LuaError("set_lighting called for a non-mapgen VoxelManip "
-				"object");
+	if (!o->is_mapgen_vm) {
+		warningstream << "set_lighting called for a non-mapgen VoxelManip "
+			"object" << std::endl;
+		return 0;
+	}
 
 	if (!lua_istable(L, 2))
 		throw LuaError("set_lighting called with missing parameter");

--- a/src/script/lua_api/l_vmanip.cpp
+++ b/src/script/lua_api/l_vmanip.cpp
@@ -91,7 +91,7 @@ int LuaVoxelManip::l_set_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		throw LuaError("set_data called with missing parameter");
+		throw LuaError("VoxelManip:set_data called with missing parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {
@@ -186,8 +186,8 @@ int LuaVoxelManip::l_calc_lighting(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	if (!o->is_mapgen_vm) {
-		warningstream << "calc_lighting called for a non-mapgen VoxelManip "
-			"object" << std::endl;
+		warningstream << "VoxelManip:calc_lighting called for a non-mapgen "
+			"VoxelManip object" << std::endl;
 		return 0;
 	}
 
@@ -222,13 +222,13 @@ int LuaVoxelManip::l_set_lighting(lua_State *L)
 
 	LuaVoxelManip *o = checkobject(L, 1);
 	if (!o->is_mapgen_vm) {
-		warningstream << "set_lighting called for a non-mapgen VoxelManip "
-			"object" << std::endl;
+		warningstream << "VoxelManip:set_lighting called for a non-mapgen "
+			"VoxelManip object" << std::endl;
 		return 0;
 	}
 
 	if (!lua_istable(L, 2))
-		throw LuaError("set_lighting called with missing parameter");
+		throw LuaError("VoxelManip:set_lighting called with missing parameter");
 
 	u8 light;
 	light  = (getintfield_default(L, 2, "day",   0) & 0x0F);
@@ -279,7 +279,8 @@ int LuaVoxelManip::l_set_light_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		throw LuaError("set_light_data called with missing parameter");
+		throw LuaError("VoxelManip:set_light_data called with missing "
+				"parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {
@@ -327,7 +328,8 @@ int LuaVoxelManip::l_set_param2_data(lua_State *L)
 	MMVManip *vm = o->vm;
 
 	if (!lua_istable(L, 2))
-		throw LuaError("set_param2_data called with missing parameter");
+		throw LuaError("VoxelManip:set_param2_data called with missing "
+				"parameter");
 
 	u32 volume = vm->m_area.getVolume();
 	for (u32 i = 0; i != volume; i++) {


### PR DESCRIPTION
Before this PR, you could e.g. call the calc_lighting for a non-mapgen vmanip object and nothing happened.
Now it aborts instead, the modder is informed that they did something wrong.