### PR TITLE
Check node updates whether the blocks are known

### DIFF
--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -274,6 +274,11 @@ public:
 
 	u32 getSendingCount() const { return m_blocks_sending.size(); }
 
+	bool isBlockSent(v3s16 p) const
+	{
+		return m_blocks_sent.find(p) != m_blocks_sent.end();
+	}
+
 	// Increments timeouts and removes timed-out blocks from list
 	// NOTE: This doesn't fix the server-not-sending-block bug
 	//       because it is related to emerging, not sending.

--- a/src/map.h
+++ b/src/map.h
@@ -76,7 +76,6 @@ struct MapEditEvent
 	v3s16 p;
 	MapNode n = CONTENT_AIR;
 	std::set<v3s16> modified_blocks;
-	u16 already_known_by_peer = 0;
 
 	MapEditEvent() = default;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -873,14 +873,14 @@ void Server::AsyncRunStep(bool initial_step)
 			case MEET_ADDNODE:
 			case MEET_SWAPNODE:
 				prof.add("MEET_ADDNODE", 1);
-				sendAddNode(event->p, event->n, event->already_known_by_peer,
-						&far_players, disable_single_change_sending ? 5 : 30,
+				sendAddNode(event->p, event->n, &far_players,
+						disable_single_change_sending ? 5 : 30,
 						event->type == MEET_ADDNODE);
 				break;
 			case MEET_REMOVENODE:
 				prof.add("MEET_REMOVENODE", 1);
-				sendRemoveNode(event->p, event->already_known_by_peer,
-						&far_players, disable_single_change_sending ? 5 : 30);
+				sendRemoveNode(event->p, &far_players,
+						disable_single_change_sending ? 5 : 30);
 				break;
 			case MEET_BLOCK_NODE_METADATA_CHANGED:
 				infostream << "Server: MEET_BLOCK_NODE_METADATA_CHANGED" << std::endl;
@@ -2078,8 +2078,8 @@ void Server::fadeSound(s32 handle, float step, float gain)
 	}
 }
 
-void Server::sendRemoveNode(v3s16 p, u16 ignore_id,
-		std::unordered_set<u16> *far_players, float far_d_nodes)
+void Server::sendRemoveNode(v3s16 p, std::unordered_set<u16> *far_players,
+		float far_d_nodes)
 {
 	float maxd = far_d_nodes * BS;
 	v3f p_f = intToFloat(p, BS);
@@ -2116,9 +2116,8 @@ void Server::sendRemoveNode(v3s16 p, u16 ignore_id,
 	m_clients.unlock();
 }
 
-void Server::sendAddNode(v3s16 p, MapNode n, u16 ignore_id,
-		std::unordered_set<u16> *far_players, float far_d_nodes,
-		bool remove_metadata)
+void Server::sendAddNode(v3s16 p, MapNode n, std::unordered_set<u16> *far_players,
+		float far_d_nodes, bool remove_metadata)
 {
 	float maxd = far_d_nodes * BS;
 	v3f p_f = intToFloat(p, BS);

--- a/src/server.h
+++ b/src/server.h
@@ -416,11 +416,11 @@ private:
 		far_d_nodes are ignored and their peer_ids are added to far_players
 	*/
 	// Envlock and conlock should be locked when calling these
-	void sendRemoveNode(v3s16 p, u16 ignore_id=0,
-			std::vector<u16> *far_players=NULL, float far_d_nodes=100);
-	void sendAddNode(v3s16 p, MapNode n, u16 ignore_id=0,
-			std::vector<u16> *far_players=NULL, float far_d_nodes=100,
-			bool remove_metadata=true);
+	void sendRemoveNode(v3s16 p, u16 ignore_id,
+			std::unordered_set<u16> *far_players = nullptr, float far_d_nodes = 100);
+	void sendAddNode(v3s16 p, MapNode n, u16 ignore_id,
+			std::unordered_set<u16> *far_players = nullptr, float far_d_nodes = 100,
+			bool remove_metadata = true);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver, u16 net_proto_version);

--- a/src/server.h
+++ b/src/server.h
@@ -416,11 +416,11 @@ private:
 		far_d_nodes are ignored and their peer_ids are added to far_players
 	*/
 	// Envlock and conlock should be locked when calling these
-	void sendRemoveNode(v3s16 p, u16 ignore_id,
-			std::unordered_set<u16> *far_players = nullptr, float far_d_nodes = 100);
-	void sendAddNode(v3s16 p, MapNode n, u16 ignore_id,
-			std::unordered_set<u16> *far_players = nullptr, float far_d_nodes = 100,
-			bool remove_metadata = true);
+	void sendRemoveNode(v3s16 p, std::unordered_set<u16> *far_players = nullptr,
+			float far_d_nodes = 100);
+	void sendAddNode(v3s16 p, MapNode n,
+			std::unordered_set<u16> *far_players = nullptr,
+			float far_d_nodes = 100, bool remove_metadata = true);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver, u16 net_proto_version);


### PR DESCRIPTION
This PR ought to prevent some of the warnings
`Map::removeNodeMetadata(): Block not found`
`Map::setNodeMetadata(): Block not found`

Fixes #5246 

**Testing code:**
```Lua
-- depends on default

local old_def = core.registered_nodes["default:torch"].after_place_node
core.override_item("default:torch", {
	after_place_node = function(pos, placer)
		minetest.get_node_timer(pos):start(1)
		if old_def then
			old_def(pos, placer)
		end
	end,
	on_timer = function(pos, time)
		minetest.set_node(pos, {name = "default:torch", param2 = math.random(24) - 1})
		return true
	end
})
```
PS: Currently trying to arise these warnings with an older build.. yet the success may come..