### PR TITLE
Send custom floats (log2)

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -1311,17 +1311,17 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == GENERIC_CMD_UPDATE_POSITION) {
 		// Not sent by the server if this object is an attachment.
 		// We might however get here if the server notices the object being detached before the client.
-		m_position = readV3F1000(is);
-		m_velocity = readV3F1000(is);
-		m_acceleration = readV3F1000(is);
+		m_position = readV3F32(is);
+		m_velocity = readV3F32(is);
+		m_acceleration = readV3F32(is);
 		if (std::fabs(m_prop.automatic_rotate) < 0.001f)
-			m_yaw = readF1000(is);
+			m_yaw = readF32(is);
 		else
-			readF1000(is);
+			readF32(is);
 		m_yaw = wrapDegrees_0_360(m_yaw);
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
-		float update_interval = readF1000(is);
+		float update_interval = readF32(is);
 
 		// Place us a bit higher if we're physical, to not sink into
 		// the ground due to sucky collision detection...

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -49,19 +49,19 @@ std::string gob_cmd_update_position(
 	// command
 	writeU8(os, GENERIC_CMD_UPDATE_POSITION);
 	// pos
-	writeV3F1000(os, position);
+	writeV3F32(os, position);
 	// velocity
-	writeV3F1000(os, velocity);
+	writeV3F32(os, velocity);
 	// acceleration
-	writeV3F1000(os, acceleration);
+	writeV3F32(os, acceleration);
 	// yaw
-	writeF1000(os, yaw);
+	writeF32(os, yaw);
 	// do_interpolate
 	writeU8(os, do_interpolate);
 	// is_end_position (for interpolation)
 	writeU8(os, is_movement_end);
 	// update_interval (for interpolation)
-	writeF1000(os, update_interval);
+	writeF32(os, update_interval);
 	return os.str();
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -188,19 +188,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Nodebox version 5
 		Add disconnected nodeboxes
 		Add TOCLIENT_FORMSPEC_PREPEND
+	PROTOCOL VERSION 37:
+		New network float format
 */
 
-#define LATEST_PROTOCOL_VERSION 36
+#define LATEST_PROTOCOL_VERSION 37
 #define LATEST_PROTOCOL_VERSION_STRING TOSTRING(LATEST_PROTOCOL_VERSION)
 
 // Server's supported network protocol range
-#define SERVER_PROTOCOL_VERSION_MIN 36
+#define SERVER_PROTOCOL_VERSION_MIN 37
 #define SERVER_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Client's supported network protocol range
 // The minimal version depends on whether
 // send_pre_v25_init is enabled or not
-#define CLIENT_PROTOCOL_VERSION_MIN 36
+#define CLIENT_PROTOCOL_VERSION_MIN 37
 #define CLIENT_PROTOCOL_VERSION_MAX LATEST_PROTOCOL_VERSION
 
 // Constant that differentiates the protocol from random data and other protocols

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -77,14 +77,14 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeU8(os, 3); // version, protocol_version >= 36
 	writeS16(os, hp_max);
 	writeU8(os, physical);
-	writeF1000(os, weight);
-	writeV3F1000(os, collisionbox.MinEdge);
-	writeV3F1000(os, collisionbox.MaxEdge);
-	writeV3F1000(os, selectionbox.MinEdge);
-	writeV3F1000(os, selectionbox.MaxEdge);
+	writeF32(os, weight);
+	writeV3F32(os, collisionbox.MinEdge);
+	writeV3F32(os, collisionbox.MaxEdge);
+	writeV3F32(os, selectionbox.MinEdge);
+	writeV3F32(os, selectionbox.MaxEdge);
 	writeU8(os, pointable);
 	os << serializeString(visual);
-	writeV2F1000(os, visual_size);
+	writeV2F32(os, visual_size);
 	writeU16(os, textures.size());
 	for (const std::string &texture : textures) {
 		os << serializeString(texture);
@@ -93,7 +93,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeV2S16(os, initial_sprite_basepos);
 	writeU8(os, is_visible);
 	writeU8(os, makes_footstep_sound);
-	writeF1000(os, automatic_rotate);
+	writeF32(os, automatic_rotate);
 	// Added in protocol version 14
 	os << serializeString(mesh);
 	writeU16(os, colors.size());
@@ -101,19 +101,19 @@ void ObjectProperties::serialize(std::ostream &os) const
 		writeARGB8(os, color);
 	}
 	writeU8(os, collideWithObjects);
-	writeF1000(os, stepheight);
+	writeF32(os, stepheight);
 	writeU8(os, automatic_face_movement_dir);
-	writeF1000(os, automatic_face_movement_dir_offset);
+	writeF32(os, automatic_face_movement_dir_offset);
 	writeU8(os, backface_culling);
 	os << serializeString(nametag);
 	writeARGB8(os, nametag_color);
-	writeF1000(os, automatic_face_movement_max_rotation_per_sec);
+	writeF32(os, automatic_face_movement_max_rotation_per_sec);
 	os << serializeString(infotext);
 	os << serializeString(wield_item);
 	writeS8(os, glow);
 	writeU16(os, breath_max);
-	writeF1000(os, eye_height);
-	writeF1000(os, zoom_fov);
+	writeF32(os, eye_height);
+	writeF32(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
 
 	// Add stuff only at the bottom.
@@ -128,14 +128,14 @@ void ObjectProperties::deSerialize(std::istream &is)
 
 	hp_max = readS16(is);
 	physical = readU8(is);
-	weight = readF1000(is);
-	collisionbox.MinEdge = readV3F1000(is);
-	collisionbox.MaxEdge = readV3F1000(is);
-	selectionbox.MinEdge = readV3F1000(is);
-	selectionbox.MaxEdge = readV3F1000(is);
+	weight = readF32(is);
+	collisionbox.MinEdge = readV3F32(is);
+	collisionbox.MaxEdge = readV3F32(is);
+	selectionbox.MinEdge = readV3F32(is);
+	selectionbox.MaxEdge = readV3F32(is);
 	pointable = readU8(is);
 	visual = deSerializeString(is);
-	visual_size = readV2F1000(is);
+	visual_size = readV2F32(is);
 	textures.clear();
 	u32 texture_count = readU16(is);
 	for (u32 i = 0; i < texture_count; i++){
@@ -145,7 +145,7 @@ void ObjectProperties::deSerialize(std::istream &is)
 	initial_sprite_basepos = readV2S16(is);
 	is_visible = readU8(is);
 	makes_footstep_sound = readU8(is);
-	automatic_rotate = readF1000(is);
+	automatic_rotate = readF32(is);
 	mesh = deSerializeString(is);
 	colors.clear();
 	u32 color_count = readU16(is);
@@ -153,18 +153,18 @@ void ObjectProperties::deSerialize(std::istream &is)
 		colors.push_back(readARGB8(is));
 	}
 	collideWithObjects = readU8(is);
-	stepheight = readF1000(is);
+	stepheight = readF32(is);
 	automatic_face_movement_dir = readU8(is);
-	automatic_face_movement_dir_offset = readF1000(is);
+	automatic_face_movement_dir_offset = readF32(is);
 	backface_culling = readU8(is);
 	nametag = deSerializeString(is);
 	nametag_color = readARGB8(is);
-	automatic_face_movement_max_rotation_per_sec = readF1000(is);
+	automatic_face_movement_max_rotation_per_sec = readF32(is);
 	infotext = deSerializeString(is);
 	wield_item = deSerializeString(is);
 	glow = readS8(is);
 	breath_max = readU16(is);
-	eye_height = readF1000(is);
-	zoom_fov = readF1000(is);
+	eye_height = readF32(is);
+	zoom_fov = readF32(is);
 	use_texture_alpha = readU8(is);
 }

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -654,6 +654,17 @@ inline void putF1000(std::vector<u8> *dest, f32 val)
 	putS32(dest, val * FIXEDPOINT_FACTOR);
 }
 
+inline void putF32(std::vector<u8> *dest, f32 val)
+{
+	assert(!std::isnan(val) && !std::isinf(val));
+	float fraction;
+	int exponent;
+	fraction = frexp(val, &exponent) * 0x800000;
+
+	u32 dat = (u32)(exponent - 1) << 24 | ((u32)fraction & 0xFFFFFF);
+	putU32(dest, dat);
+}
+
 inline void putV2S16(std::vector<u8> *dest, v2s16 val)
 {
 	putS16(dest, val.X);

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -188,6 +188,20 @@ inline f32 readF1000(const u8 *data)
 	return (f32)readS32(data) / FIXEDPOINT_FACTOR;
 }
 
+inline f32 readF32(const u8 *data)
+{
+	const u32 v = readU32(data);
+	u32 fraction_i = v & 0xFFFFFF;
+	u32 exponent_i = v >> 24;
+	// Correct negative number notation
+	if (v & 0x00800000)
+		fraction_i |= 0xFF000000;
+
+	float fraction = (s32)fraction_i / (float)0x800000;
+
+	return ldexp(fraction, (int)exponent_i - 127);
+}
+
 inline video::SColor readARGB8(const u8 *data)
 {
 	video::SColor p(readU32(data));
@@ -245,6 +259,23 @@ inline v3f readV3F1000(const u8 *data)
 	return p;
 }
 
+inline v2f readV2F32(const u8 *data)
+{
+	v2f p;
+	p.X = readF32(&data[0]);
+	p.Y = readF32(&data[4]);
+	return p;
+}
+
+inline v3f readV3F32(const u8 *data)
+{
+	v3f p;
+	p.X = readF32(&data[0]);
+	p.Y = readF32(&data[4]);
+	p.Z = readF32(&data[8]);
+	return p;
+}
+
 /////////////// write routines ////////////////
 
 inline void writeU8(u8 *data, u8 i)
@@ -276,6 +307,18 @@ inline void writeF1000(u8 *data, f32 i)
 {
 	assert(i >= F1000_MIN && i <= F1000_MAX);
 	writeS32(data, i * FIXEDPOINT_FACTOR);
+}
+
+inline void writeF32(u8 *data, f32 i)
+{
+	float fraction;
+	int exponent;
+	fraction = frexp(i, &exponent) * 0x800000;
+
+	// [x...x...][x...x...x...x...x...x...]
+	//  EXPONENT      MANTISSA (24 bits)
+	u32 dat = (u32)(exponent + 127) << 24 | ((u32)fraction & 0xFFFFFF);
+	writeU32(data, dat);
 }
 
 inline void writeARGB8(u8 *data, video::SColor p)
@@ -322,6 +365,20 @@ inline void writeV3F1000(u8 *data, v3f p)
 	writeF1000(&data[8], p.Z);
 }
 
+inline void writeV2F32(u8 *data, v2f p)
+{
+	writeF32(&data[0], p.X);
+	writeF32(&data[4], p.Y);
+}
+
+inline void writeV3F32(u8 *data, v3f p)
+{
+	writeF32(&data[0], p.X);
+	writeF32(&data[4], p.Y);
+	writeF32(&data[8], p.Z);
+}
+
+
 ////
 //// Iostream wrapper for data read/write
 ////
@@ -350,11 +407,14 @@ MAKE_STREAM_READ_FXN(s8,    S8,       1);
 MAKE_STREAM_READ_FXN(s16,   S16,      2);
 MAKE_STREAM_READ_FXN(s32,   S32,      4);
 MAKE_STREAM_READ_FXN(s64,   S64,      8);
+MAKE_STREAM_READ_FXN(f32,   F32,      4);
 MAKE_STREAM_READ_FXN(f32,   F1000,    4);
 MAKE_STREAM_READ_FXN(v2s16, V2S16,    4);
 MAKE_STREAM_READ_FXN(v3s16, V3S16,    6);
 MAKE_STREAM_READ_FXN(v2s32, V2S32,    8);
 MAKE_STREAM_READ_FXN(v3s32, V3S32,   12);
+MAKE_STREAM_READ_FXN(v2f,   V2F32,    8);
+MAKE_STREAM_READ_FXN(v3f,   V3F32,   12);
 MAKE_STREAM_READ_FXN(v2f,   V2F1000,  8);
 MAKE_STREAM_READ_FXN(v3f,   V3F1000, 12);
 MAKE_STREAM_READ_FXN(video::SColor, ARGB8, 4);
@@ -367,11 +427,14 @@ MAKE_STREAM_WRITE_FXN(s8,    S8,       1);
 MAKE_STREAM_WRITE_FXN(s16,   S16,      2);
 MAKE_STREAM_WRITE_FXN(s32,   S32,      4);
 MAKE_STREAM_WRITE_FXN(s64,   S64,      8);
+MAKE_STREAM_WRITE_FXN(f32,   F32,      4);
 MAKE_STREAM_WRITE_FXN(f32,   F1000,    4);
 MAKE_STREAM_WRITE_FXN(v2s16, V2S16,    4);
 MAKE_STREAM_WRITE_FXN(v3s16, V3S16,    6);
 MAKE_STREAM_WRITE_FXN(v2s32, V2S32,    8);
 MAKE_STREAM_WRITE_FXN(v3s32, V3S32,   12);
+MAKE_STREAM_WRITE_FXN(v2f,   V2F32,    8);
+MAKE_STREAM_WRITE_FXN(v3f,   V3F32,   12);
 MAKE_STREAM_WRITE_FXN(v2f,   V2F1000,  8);
 MAKE_STREAM_WRITE_FXN(v3f,   V3F1000, 12);
 MAKE_STREAM_WRITE_FXN(video::SColor, ARGB8, 4);
@@ -463,11 +526,14 @@ public:
 	MAKE_BUFREADER_GETNOEX_FXN(s16,   S16,      2);
 	MAKE_BUFREADER_GETNOEX_FXN(s32,   S32,      4);
 	MAKE_BUFREADER_GETNOEX_FXN(s64,   S64,      8);
+	MAKE_BUFREADER_GETNOEX_FXN(f32,   F32,      4);
 	MAKE_BUFREADER_GETNOEX_FXN(f32,   F1000,    4);
 	MAKE_BUFREADER_GETNOEX_FXN(v2s16, V2S16,    4);
 	MAKE_BUFREADER_GETNOEX_FXN(v3s16, V3S16,    6);
 	MAKE_BUFREADER_GETNOEX_FXN(v2s32, V2S32,    8);
 	MAKE_BUFREADER_GETNOEX_FXN(v3s32, V3S32,   12);
+	MAKE_BUFREADER_GETNOEX_FXN(v2f,   V2F32,    8);
+	MAKE_BUFREADER_GETNOEX_FXN(v3f,   V3F32,   12);
 	MAKE_BUFREADER_GETNOEX_FXN(v2f,   V2F1000,  8);
 	MAKE_BUFREADER_GETNOEX_FXN(v3f,   V3F1000, 12);
 	MAKE_BUFREADER_GETNOEX_FXN(video::SColor, ARGB8, 4);
@@ -485,11 +551,14 @@ public:
 	MAKE_BUFREADER_GET_FXN(s16,           S16);
 	MAKE_BUFREADER_GET_FXN(s32,           S32);
 	MAKE_BUFREADER_GET_FXN(s64,           S64);
+	MAKE_BUFREADER_GET_FXN(f32,           F32);
 	MAKE_BUFREADER_GET_FXN(f32,           F1000);
 	MAKE_BUFREADER_GET_FXN(v2s16,         V2S16);
 	MAKE_BUFREADER_GET_FXN(v3s16,         V3S16);
 	MAKE_BUFREADER_GET_FXN(v2s32,         V2S32);
 	MAKE_BUFREADER_GET_FXN(v3s32,         V3S32);
+	MAKE_BUFREADER_GET_FXN(v2f,           V2F32);
+	MAKE_BUFREADER_GET_FXN(v3f,           V3F32);
 	MAKE_BUFREADER_GET_FXN(v2f,           V2F1000);
 	MAKE_BUFREADER_GET_FXN(v3f,           V3F1000);
 	MAKE_BUFREADER_GET_FXN(video::SColor, ARGB8);


### PR DESCRIPTION
PoC for a custom (& portable) float format over the network.
It has already been discussed earlier on how to replace our current float encoding with something better.
1) Disassemble the floats and assemble them together again so that they look like the IEEE format
2) Integrate `sqrt` into the currently linear encoding to get a higher value range on cost of precision for larger numbers
3) Use `log2`, put the exponent and the mantissa as efficient as possible into 32 bits. May look like IEEE on the first view, but isn't.

This PR implements number 3. The exponent and mantissa are both signed integers which are squashed into a 32-bit unsigned integer over the network. On the other end, they're disassembled again. 

**Testing code:**
Custom C++ file for speed measuring, precision tests: https://gist.github.com/SmallJoker/bb655b4425ab539587dd9b89ad756196
(Rather) old Lua file for precision tests (only for the sqrt approach) https://pastebin.com/raw/L7nBhD3y

**To be added:**
  * [x] Unittests

///////////////////////////////////////
EDIT by paramat:
This is not a blocker as in it needs to be merged, but it needs to be considered and decided on before 5.0.0 due to breaking compatibility.