### PR TITLE
Settings: Fix indents, chat_message_*. Update translations

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -895,8 +895,8 @@ server_announce (Announce server) bool false
 #    Announce to this serverlist.
 serverlist_url (Serverlist URL) string servers.minetest.net
 
-# Remove color codes from incoming chat messages
-# Use this to stop players from being able to use color in their messages
+#    Remove color codes from incoming chat messages
+#    Use this to stop players from being able to use color in their messages
 strip_color_codes (Strip color codes) bool false
 
 [*Network]
@@ -1049,13 +1049,13 @@ world_start_time (World start time) int 5250 0 23999
 server_map_save_interval (Map save interval) float 5.3
 
 #    Set the maximum character length of a chat message sent by clients.
-# chat_message_max_size int 500
+chat_message_max_size (Chat message max length) int 500
 
-#    Limit a single player to send X messages per 10 seconds.
-# chat_message_limit_per_10sec float 10.0
+#    Amount of messages a player may send per 10 seconds.
+chat_message_limit_per_10sec (Chat message count limit) float 10.0
 
-#    Kick player if send more than X messages per 10 seconds.
-# chat_message_limit_trigger_kick int 50
+#    Kick players who sent more than X messages per 10 seconds.
+chat_message_limit_trigger_kick (Chat message kick threshold) int 50
 
 [**Physics]
 
@@ -1157,8 +1157,8 @@ secure.enable_security (Enable mod security) bool true
 #    functions even when mod security is on (via request_insecure_environment()).
 secure.trusted_mods (Trusted mods) string
 
-#	Comma-separated list of mods that are allowed to access HTTP APIs, which
-#	allow them to upload and download data to/from the internet.
+#    Comma-separated list of mods that are allowed to access HTTP APIs, which
+#    allow them to upload and download data to/from the internet.
 secure.http_mods (HTTP mods) string
 
 [*Advanced]
@@ -1773,30 +1773,30 @@ mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 
 #    'altitude_dry': Reduces humidity with altitude.
 mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry
 
-# The vertical distance over which heat drops by 20 if 'altitude_chill' is
-# enabled. Also the vertical distance over which humidity drops by 10 if
-# 'altitude_dry' is enabled.
+#    The vertical distance over which heat drops by 20 if 'altitude_chill' is
+#    enabled. Also the vertical distance over which humidity drops by 10 if
+#    'altitude_dry' is enabled.
 mgvalleys_altitude_chill (Altitude chill) int 90
 
-# Depth below which you'll find large caves.
+#    Depth below which you'll find large caves.
 mgvalleys_large_cave_depth (Large cave depth) int -33
 
-# Y of upper limit of lava in large caves.
+#    Y of upper limit of lava in large caves.
 mgvalleys_lava_depth (Lava depth) int 1
 
-# Depth below which you'll find giant caverns.
+#    Depth below which you'll find giant caverns.
 mgvalleys_cavern_limit (Cavern upper limit) int -256
 
-# Y-distance over which caverns expand to full size.
+#    Y-distance over which caverns expand to full size.
 mgvalleys_cavern_taper (Cavern taper) int 192
 
-# Defines full size of caverns, smaller values create larger caverns.
+#    Defines full size of caverns, smaller values create larger caverns.
 mgvalleys_cavern_threshold (Cavern threshold) float 0.6
 
-# How deep to make rivers.
+#    How deep to make rivers.
 mgvalleys_river_depth (River depth) int 4
 
-# How wide to make rivers.
+#    How wide to make rivers.
 mgvalleys_river_size (River size) int 5
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
@@ -1810,34 +1810,34 @@ mgvalleys_dungeon_ymax (Dungeon maximum Y) int 63
 
 [**Noises]
 
-# Caves and tunnels form at the intersection of the two noises.
+#    Caves and tunnels form at the intersection of the two noises.
 mgvalleys_np_cave1 (Cave noise #1) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 2.0
 
-# Caves and tunnels form at the intersection of the two noises.
+#    Caves and tunnels form at the intersection of the two noises.
 mgvalleys_np_cave2 (Cave noise #2) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
-# The depth of dirt or other biome filler node.
+#    The depth of dirt or other biome filler node.
 mgvalleys_np_filler_depth (Filler depth) noise_params_2d 0, 1.2, (256, 256, 256), 1605, 3, 0.5, 2.0, eased
 
-# 3D noise defining giant caverns.
+#    3D noise defining giant caverns.
 mgvalleys_np_cavern (Cavern noise) noise_params_3d 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
 
-# River noise. Rivers occur close to noise value zero.
+#    River noise. Rivers occur close to noise value zero.
 mgvalleys_np_rivers (River noise) noise_params_2d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
 
-# Base terrain height.
+#    Base terrain height.
 mgvalleys_np_terrain_height (Terrain height) noise_params_2d -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0, eased
 
-# Raises terrain to make valleys around the rivers.
+#    Raises terrain to make valleys around the rivers.
 mgvalleys_np_valley_depth (Valley depth) noise_params_2d 5, 4, (512, 512, 512), -1914, 1, 1.0, 2.0, eased
 
-# Slope and fill work together to modify the heights.
+#    Slope and fill work together to modify the heights.
 mgvalleys_np_inter_valley_fill (Valley fill) noise_params_3d 0, 1, (256, 512, 256), 1993, 6, 0.8, 2.0
 
-# Amplifies the valleys.
+#    Amplifies the valleys.
 mgvalleys_np_valley_profile (Valley profile) noise_params_2d 0.6, 0.5, (512, 512, 512), 777, 1, 1.0, 2.0, eased
 
-# Slope and fill work together to modify the heights.
+#    Slope and fill work together to modify the heights.
 mgvalleys_np_inter_valley_slope (Valley slope) noise_params_2d 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0, eased
 
 [*Advanced]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -96,6 +96,11 @@
 #    type: bool
 # fixed_virtual_joystick = false
 
+#    (Android) Use virtual joystick to trigger "aux" button.
+#    If enabled, virtual joystick will also tap "aux" button when out of main circle.
+#    type: bool
+# virtual_joystick_triggers_aux = false
+
 #    Enable joysticks
 #    type: bool
 # enable_joysticks = false
@@ -465,7 +470,9 @@
 
 ### Filtering
 
-#    Use mip mapping to scale textures. May slightly increase performance.
+#    Use mip mapping to scale textures. May slightly increase performance,
+#    especially when using a high resolution texture pack.
+#    Gamma correct downscaling is not supported.
 #    type: bool
 # mip_map = false
 
@@ -694,6 +701,10 @@
 # texture_path =
 
 #    The rendering back-end for Irrlicht.
+#    A restart is required after changing this.
+#    Note: on Android, stick with OGLES1 if unsure! App may fail to start otherwise.
+#    On other platforms, OpenGL is recommended, and it’s the only driver with
+#    shader support currently.
 #    type: enum values: null, software, burningsvideo, direct3d8, direct3d9, opengl, ogles1, ogles2
 # video_driver = opengl
 
@@ -1255,6 +1266,18 @@
 #    type: float
 # server_map_save_interval = 5.3
 
+#    Set the maximum character length of a chat message sent by clients.
+#    type: int
+# chat_message_max_size = 500
+
+#    Amount of messages a player may send per 10 seconds.
+#    type: float
+# chat_message_limit_per_10sec = 10.0
+
+#    Kick players who sent more than X messages per 10 seconds.
+#    type: int
+# chat_message_limit_trigger_kick = 50
+
 ### Physics
 
 #    type: float
@@ -1372,19 +1395,19 @@
 # server_side_occlusion_culling = true
 
 #    Restricts the access of certain client-side functions on servers
-#    Combine these byteflags below to restrict more client-side features:
+#    Combine these byteflags below to restrict client-side features:
 #    LOAD_CLIENT_MODS: 1 (disable client mods loading)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_restriction_noderange)
 #    type: int
-# csm_restriction_flags = 18
+# csm_restriction_flags = 30
 
 #    If the CSM restriction for node range is enabled, get_node calls are limited
 #    to this distance from the player to the node.
 #    type: int
-# csm_restriction_noderange = 8
+# csm_restriction_noderange = 0
 
 ## Security
 
@@ -2695,15 +2718,17 @@
 ## Mapgen Valleys
 
 #    Map generation attributes specific to Mapgen Valleys.
-#    'altitude_chill' makes higher elevations colder, which may cause biome issues.
-#    'humid_rivers' modifies the humidity around rivers and in areas where water would tend to pool,
-#    it may interfere with delicately adjusted biomes.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
-#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers
-# mg_valleys_spflags = altitude_chill,humid_rivers
+#    'altitude_chill': Reduces heat with altitude.
+#    'humid_rivers': Increases humidity around rivers and where water pools.
+#    'vary_river_depth': If enabled, low humidity and high heat causes rivers
+#    to become shallower and occasionally dry.
+#    'altitude_dry': Reduces humidity with altitude.
+#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers, vary_river_depth, novary_river_depth, altitude_dry, noaltitude_dry
+# mgvalleys_spflags = altitude_chill,humid_rivers,vary_river_depth,altitude_dry
 
-#    The altitude at which temperature drops by 20.
+#    The vertical distance over which heat drops by 20 if 'altitude_chill' is
+#    enabled. Also the vertical distance over which humidity drops by 10 if
+#    'altitude_dry' is enabled.
 #    type: int
 # mgvalleys_altitude_chill = 90
 

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -35,11 +35,13 @@ fake_function() {
 	gettext("Random input");
 	gettext("Enable random user input (only used for testing).");
 	gettext("Continuous forward");
-	gettext("Continuous forward movement, toggled by autoforward key. \nPress the autoforward key again or the backwards movement to disable.");
+	gettext("Continuous forward movement, toggled by autoforward key.\nPress the autoforward key again or the backwards movement to disable.");
 	gettext("Touch screen threshold");
 	gettext("The length in pixels it takes for touch screen interaction to start.");
 	gettext("Fixed virtual joystick");
 	gettext("(Android) Fixes the position of virtual joystick.\nIf disabled, virtual joystick will center to first-touch's position.");
+	gettext("Virtual joystick triggers aux button");
+	gettext("(Android) Use virtual joystick to trigger \"aux\" button.\nIf enabled, virtual joystick will also tap \"aux\" button when out of main circle.");
 	gettext("Enable joysticks");
 	gettext("Enable joysticks");
 	gettext("Joystick ID");
@@ -191,7 +193,7 @@ fake_function() {
 	gettext("Adds particles when digging a node.");
 	gettext("Filtering");
 	gettext("Mipmapping");
-	gettext("Use mip mapping to scale textures. May slightly increase performance.");
+	gettext("Use mip mapping to scale textures. May slightly increase performance,\nespecially when using a high resolution texture pack.\nGamma correct downscaling is not supported.");
 	gettext("Anisotropic filtering");
 	gettext("Use anisotropic filtering when viewing at textures from an angle.");
 	gettext("Bilinear filtering");
@@ -288,7 +290,7 @@ fake_function() {
 	gettext("Texture path");
 	gettext("Path to texture directory. All textures are first searched from here.");
 	gettext("Video driver");
-	gettext("The rendering back-end for Irrlicht.");
+	gettext("The rendering back-end for Irrlicht.\nA restart is required after changing this.\nNote: on Android, stick with OGLES1 if unsure! App may fail to start otherwise.\nOn other platforms, OpenGL is recommended, and it’s the only driver with\nshader support currently.");
 	gettext("Cloud radius");
 	gettext("Radius of cloud area stated in number of 64 node cloud squares.\nValues larger than 26 will start to produce sharp cutoffs at cloud area corners.");
 	gettext("View bobbing factor");
@@ -438,7 +440,7 @@ fake_function() {
 	gettext("Announce server");
 	gettext("Automaticaly report to the serverlist.");
 	gettext("Serverlist URL");
-	gettext("Announce to this serverlist.\nIf you want to announce your ipv6 address, use  serverlist_url = v6.servers.minetest.net.");
+	gettext("Announce to this serverlist.");
 	gettext("Strip color codes");
 	gettext("Remove color codes from incoming chat messages\nUse this to stop players from being able to use color in their messages");
 	gettext("Network");
@@ -470,8 +472,6 @@ fake_function() {
 	gettext("World directory (everything in the world is stored here).\nNot needed if starting from the main menu.");
 	gettext("Item entity TTL");
 	gettext("Time in seconds for item entity (dropped items) to live.\nSetting it to -1 disables the feature.");
-	gettext("Status message on connection");
-	gettext("If enabled, show the server status message on player connection.");
 	gettext("Damage");
 	gettext("Enable players getting damage and dying.");
 	gettext("Creative");
@@ -522,6 +522,12 @@ fake_function() {
 	gettext("Time of day when a new world is started, in millihours (0-23999).");
 	gettext("Map save interval");
 	gettext("Interval of saving important changes in the world, stated in seconds.");
+	gettext("Chat message max length");
+	gettext("Set the maximum character length of a chat message sent by clients.");
+	gettext("Chat message count limit");
+	gettext("Amount of messages a player may send per 10 seconds.");
+	gettext("Chat message kick threshold");
+	gettext("Kick players who sent more than X messages per 10 seconds.");
 	gettext("Physics");
 	gettext("Default acceleration");
 	gettext("Acceleration in air");
@@ -567,8 +573,8 @@ fake_function() {
 	gettext("Server side occlusion culling");
 	gettext("If enabled the server will perform map block occlusion culling based on\non the eye position of the player. This can reduce the number of blocks\nsent to the client 50-80%. The client will not longer receive most invisible\nso that the utility of noclip mode is reduced.");
 	gettext("Client side modding restrictions");
-	gettext("Restricts the access of certain client-side functions on servers\nCombine these byteflags below to restrict more client-side features:\nLOAD_CLIENT_MODS: 1 (disable client mods loading)\nCHAT_MESSAGES: 2 (disable send_chat_message call client-side)\nREAD_ITEMDEFS: 4 (disable get_item_def call client-side)\nREAD_NODEDEFS: 8 (disable get_node_def call client-side)\nLOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_restriction_noderange)");
-	gettext("Client side node lookup restriction");
+	gettext("Restricts the access of certain client-side functions on servers\nCombine these byteflags below to restrict client-side features:\nLOAD_CLIENT_MODS: 1 (disable client mods loading)\nCHAT_MESSAGES: 2 (disable send_chat_message call client-side)\nREAD_ITEMDEFS: 4 (disable get_item_def call client-side)\nREAD_NODEDEFS: 8 (disable get_node_def call client-side)\nLOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to csm_restriction_noderange)");
+	gettext("Client side node lookup range restriction");
 	gettext("If the CSM restriction for node range is enabled, get_node calls are limited\nto this distance from the player to the node.");
 	gettext("Security");
 	gettext("Enable mod security");
@@ -620,7 +626,7 @@ fake_function() {
 	gettext("High-precision FPU");
 	gettext("Makes DirectX work with LuaJIT. Disable if it causes troubles.");
 	gettext("Main menu style");
-	gettext("Changes the main menu UI:\n-   Full:  Multple singleplayer worlds, game choice, texture pack chooser, etc.\n-   Simple: One singleplayer world, no game or texture pack choosers. May be necessary for smaller screens.\n-   Auto: Simple on Android, full on everything else. ");
+	gettext("Changes the main menu UI:\n-   Full:  Multple singleplayer worlds, game choice, texture pack chooser, etc.\n-   Simple: One singleplayer world, no game or texture pack choosers. May be necessary for smaller screens.\n-   Auto: Simple on Android, full on everything else.");
 	gettext("Main menu script");
 	gettext("Replaces the default main menu with a custom one.");
 	gettext("Main menu game manager");
@@ -901,9 +907,9 @@ fake_function() {
 	gettext("Second of 2 3D noises that together define tunnels.");
 	gettext("Mapgen Valleys");
 	gettext("Mapgen Valleys specific flags");
-	gettext("Map generation attributes specific to Mapgen Valleys.\n'altitude_chill' makes higher elevations colder, which may cause biome issues.\n'humid_rivers' modifies the humidity around rivers and in areas where water would tend to pool,\nit may interfere with delicately adjusted biomes.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen Valleys.\n'altitude_chill': Reduces heat with altitude.\n'humid_rivers': Increases humidity around rivers and where water pools.\n'vary_river_depth': If enabled, low humidity and high heat causes rivers\nto become shallower and occasionally dry.\n'altitude_dry': Reduces humidity with altitude.");
 	gettext("Altitude chill");
-	gettext("The altitude at which temperature drops by 20.");
+	gettext("The vertical distance over which heat drops by 20 if 'altitude_chill' is\nenabled. Also the vertical distance over which humidity drops by 10 if\n'altitude_dry' is enabled.");
 	gettext("Large cave depth");
 	gettext("Depth below which you'll find large caves.");
 	gettext("Lava depth");
@@ -957,5 +963,5 @@ fake_function() {
 	gettext("Limit of emerge queues to generate");
 	gettext("Maximum number of blocks to be queued that are to be generated.\nSet to blank for an appropriate amount to be chosen automatically.");
 	gettext("Number of emerge threads");
-	gettext("Number of emerge threads to use. Make this field blank, or increase this number\nto use multiple threads. On multiprocessor systems, this will improve mapgen speed greatly\nat the cost of slightly buggy caves.");
+	gettext("Number of emerge threads to use. Make this field blank or 0, or increase this number\nto use multiple threads. On multiprocessor systems, this will improve mapgen speed greatly\nat the cost of slightly buggy caves.");
 }


### PR DESCRIPTION
`chat_message_*` were previously not documented because they were not formatted correctly.
Also updates the translations.