### PR TITLE
Fix build on gcc 5.0

### DIFF
--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "log.h"
 #include "util/numeric.h"
+#include <cmath>
 #include <algorithm>
 
 

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <iomanip>
 #include <cerrno>
 #include <algorithm>
+#include <cmath>
 #include "connection.h"
 #include "serialization.h"
 #include "log.h"

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -27,6 +27,9 @@
  */
 
 // clang-format off
+
+#include <cstddef>
+
 #ifdef WIN32
 	#include <windows.h>
 	#include <wincrypt.h>


### PR DESCRIPTION
The master branch is supposed to build on gcc 4.8 and higher. However, the patches in this pull request (adding some includes only) were necessary for building on different Linux-based platforms when using the vanilla gcc 5.0 compiler from the gcc developers.