### PR TITLE
Implement on_wielditem_change callback registration

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -612,6 +612,7 @@ core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_
 core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
 core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
 core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
+core.registered_on_wielditem_change, core.register_on_wielditem_change = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4531,11 +4531,17 @@ Call these functions only at load time!
       once with revoker being the player name, and again with revoker being nil.
 * `minetest.register_can_bypass_userlimit(function(name, ip))`
     * Called when `name` user connects with `ip`.
-    * Return `true` to by pass the player limit
+    * Return `true` to bypass the player limit
 * `minetest.register_on_modchannel_message(function(channel_name, sender, message))`
     * Called when an incoming mod channel message is received
     * You should have joined some channels to receive events.
     * If message comes from a server mod, `sender` field is an empty string.
+* `minetest.register_on_wielditem_change(function(player, old_item, old_idx, new_item, new_idx))`
+    * Called when a player selects a wield item, either by using the scroll wheel,
+      or by pressing the corresponding hotbar key.
+    * `player` is an ObjectRef.
+    * `old_item` and `new_item` are ItemStacks.
+    * `old_idx` and `new_idx` are wield indices of the old and new items.
 
 Setting-related
 ---------------

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -235,6 +235,30 @@ void ScriptApiPlayer::on_authplayer(const std::string &name, const std::string &
 	runCallbacks(3, RUN_CALLBACKS_MODE_FIRST);
 }
 
+void ScriptApiPlayer::on_wielditem_change(ServerActiveObject *player,
+	const ItemStack &old_item, u16 old_wield_idx,
+	const ItemStack &new_item, u16 new_wield_idx)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_on_wielditem_change callbacks
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_on_wielditem_change");
+
+	// First param: player object
+	objectrefGetOrCreate(L, player);
+
+	// Params 2 & 3: Old wielded item and its wield index
+	LuaItemStack::create(L, old_item);
+	lua_pushnumber(L, old_wield_idx);
+
+	// Params 4 & 5: New wielded item and its wield index
+	LuaItemStack::create(L, new_item);
+	lua_pushnumber(L, new_wield_idx);
+
+	runCallbacks(5, RUN_CALLBACKS_MODE_FIRST);
+}
+
 void ScriptApiPlayer::pushMoveArguments(
 		const MoveAction &ma, int count,
 		ServerActiveObject *player)

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -52,6 +52,9 @@ public:
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
 	void on_authplayer(const std::string &name, const std::string &ip, bool is_success);
+	void on_wielditem_change(ServerActiveObject *player,
+		const ItemStack &old_item, u16 old_wield_idx,
+		const ItemStack &new_item, u16 new_wield_idx);
 
 	// Player inventory callbacks
 	// Return number of accepted items to be moved


### PR DESCRIPTION
This PR implements the following global callback:

```lua
register_on_wielditem_change(player, old_item, old_wield_index, new_item, new_wield_index)
```

- `player`: An ObjectRef. Refers to player whose wielditem changed.
- `old_item`: An ItemStack holding the previous wielditem of `player`.
- `old_wield_index`: Wield-index of the old item.
- `new_item`: An ItemStack holding the current wielditem of `player`.
- `new_wield_index`: Wield-index of the new item.

`on_wielditem_change` callbacks are invoked whenever the current wielded item is changed by using the scroll wheel, or by pressing on the (numerical) hot-keys.

****

Here's some testing code:
```lua
minetest.register_on_wielditem_change(function(player, old_item, old_idx, new_item, new_idx)
	minetest.chat_send_all("\n********\n" ..
		"on_wielditem_change:" ..
		"\n\tname = " .. player:get_player_name() ..
		"\n\told_item = " .. old_item:to_string() ..
		"\n\tnew_idx = " .. old_idx ..
		"\n\tnew_item = " .. new_item:to_string() ..
		"\n\tnew_idx = " .. new_idx ..
		"\n********\n")
end)
```

Closes #1377. Ready for review. Tested; works.