### PR TITLE
Log server shutdown using actionstream

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -236,7 +236,6 @@ Server::Server(
 
 Server::~Server()
 {
-	infostream << "Server destructing" << std::endl;
 
 	// Send shutdown message
 	SendChatMessage(PEER_ID_INEXISTENT, ChatMessage(CHATMESSAGE_TYPE_ANNOUNCE,
@@ -261,6 +260,8 @@ Server::~Server()
 		m_env->kickAllPlayers(SERVER_ACCESSDENIED_SHUTDOWN,
 			kick_msg, reconnect);
 	}
+	
+	actionstream << "Server: Shutting down" << std::endl;
 
 	// Do this before stopping the server in case mapgen callbacks need to access
 	// server-controlled resources (like ModStorages). Also do them before


### PR DESCRIPTION
- Existing message of type `infostream` is converted to type `actionstream`.
- At shutdown, MT logs **Server: Shutting down** at the `action` level.
- Message is re-positioned to be printed _after_ the following messages have been printed:
  - `Server: Saving players`
  - `Server: Kicking players`

Closes #7049 