### PR TITLE
get_node_drops: Make empty drop return empty table

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -197,7 +197,7 @@ function core.get_node_drops(node, toolname)
 		return {nodename}
 	elseif type(drop) == "string" then
 		-- itemstring drop
-		return {drop}
+		return drop ~= "" and {drop} or {}
 	elseif drop.items == nil then
 		-- drop = {} to disable default drop
 		return {}


### PR DESCRIPTION
This stops get_node_drops from returning an empty string when using drop = "" and instead returns the supposed empty table instead {}