### PR TITLE
Fix sky objects not rendering with ogles

### DIFF
--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -44,7 +44,11 @@ Sky::Sky(s32 id, ITextureSource *tsrc):
 
 	video::SMaterial mat;
 	mat.Lighting = false;
+#ifdef __ANDROID__
+	mat.ZBuffer = video::ECFN_DISABLED;
+#else
 	mat.ZBuffer = video::ECFN_NEVER;
+#endif
 	mat.ZWriteEnable = false;
 	mat.AntiAliasing = 0;
 	mat.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
@@ -449,6 +453,34 @@ void Sky::render()
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
 			if (starcolor.getBlue() < m_skycolor.getBlue())
 				break;
+#ifdef __ANDROID__
+			u16 indices[SKY_STAR_COUNT * 3];
+			video::S3DVertex vertices[SKY_STAR_COUNT * 3];
+			for (u32 i = 0; i < SKY_STAR_COUNT; i++) {
+				indices[i * 3 + 0] = i * 3 + 0;
+				indices[i * 3 + 1] = i * 3 + 1;
+				indices[i * 3 + 2] = i * 3 + 2;
+				v3f p = m_stars[i];
+				core::CMatrix4<f32> a;
+				a.buildRotateFromTo(v3f(0, 1, 0), v3f(d, 1 + d, -d / 2));
+				v3f p1 = p;
+				a.rotateVect(p1);
+				a.buildRotateFromTo(v3f(0, 1, 0), v3f(d, 1 - d, d / 2));
+				v3f p2 = p;
+				a.rotateVect(p2);
+				p.rotateXYBy(wicked_time_of_day * 360 - 90);
+				p1.rotateXYBy(wicked_time_of_day * 360 - 90);
+				p2.rotateXYBy(wicked_time_of_day * 360 - 90);
+				vertices[i * 3 + 0].Pos = p;
+				vertices[i * 3 + 0].Color = starcolor;
+				vertices[i * 3 + 1].Pos = p1;
+				vertices[i * 3 + 1].Color = starcolor;
+				vertices[i * 3 + 2].Pos = p2;
+				vertices[i * 3 + 2].Color = starcolor;
+			}
+			driver->drawIndexedTriangleList(&vertices[0], SKY_STAR_COUNT * 3,
+					&indices[0], SKY_STAR_COUNT);
+#else
 			u16 indices[SKY_STAR_COUNT * 4];
 			video::S3DVertex vertices[SKY_STAR_COUNT * 4];
 			for (u32 i = 0; i < SKY_STAR_COUNT; i++) {
@@ -483,6 +515,7 @@ void Sky::render()
 			driver->drawVertexPrimitiveList(vertices, SKY_STAR_COUNT * 4,
 				indices, SKY_STAR_COUNT, video::EVT_STANDARD,
 				scene::EPT_QUADS, video::EIT_16BIT);
+#endif
 		} while(false);
 
 		// Draw far cloudy fog thing below east and west horizons

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -478,8 +478,8 @@ void Sky::render()
 				vertices[i * 3 + 2].Pos = p2;
 				vertices[i * 3 + 2].Color = starcolor;
 			}
-			driver->drawIndexedTriangleList(&vertices[0], SKY_STAR_COUNT * 3,
-					&indices[0], SKY_STAR_COUNT);
+			driver->drawIndexedTriangleList(vertices, SKY_STAR_COUNT * 3,
+					indices, SKY_STAR_COUNT);
 #else
 			u16 indices[SKY_STAR_COUNT * 4];
 			video::S3DVertex vertices[SKY_STAR_COUNT * 4];


### PR DESCRIPTION
Fixes #3155 and possibly #7573

Note that the primitive type `scene::EPT_QUADS` is not implemented by Irrlicht ES yet so I have used a triangle indexed list instead. We could produce the full quad by drawing two triangles but the effect is lost at such low resolution it is difficult to tell the difference IMO.

![screen1](https://user-images.githubusercontent.com/3710749/43370813-d72422c8-937d-11e8-8712-ff743bb78e58.png)
![screen](https://user-images.githubusercontent.com/3710749/43370811-cc38beaa-937d-11e8-96fe-0e25fdf4839f.png)
