### PR TITLE
Save debug.txt to build dir for RUN_IN_PLACE build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -530,11 +530,8 @@ static bool read_config_file(const Settings &cmd_args)
 
 static void init_log_streams(const Settings &cmd_args)
 {
-#if RUN_IN_PLACE
-	std::string log_filename = DEBUGFILE;
-#else
 	std::string log_filename = porting::path_user + DIR_DELIM + DEBUGFILE;
-#endif
+
 	if (cmd_args.exists("logfile"))
 		log_filename = cmd_args.get("logfile");
 


### PR DESCRIPTION
For the RUN_IN_PLACE build, debug.txt gets saved to the current working directory, usually my home dir. Shouldn't it go in the build dir along with everything else?

Tested.