### PR TITLE
Fix tooltip colors specified by formspec part

### DIFF
--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -274,7 +274,7 @@ inline void setStaticText(irr::gui::IGUIStaticText *static_text, const EnrichedS
 
 inline void setStaticText(irr::gui::IGUIStaticText *static_text, const wchar_t *text)
 {
-	setStaticText(static_text, EnrichedString(text));
+	setStaticText(static_text, EnrichedString(text, static_text->getOverrideColor()));
 }
 
 #endif // _IRR_COMPILE_WITH_GUI_


### PR DESCRIPTION
The issue was that EnrichedString defaults to white if you don't provide a color.

![screenshot_2018-08-04_18-33-14](https://user-images.githubusercontent.com/2122943/43679056-3b867c6a-9816-11e8-8d60-320073a93303.png)

```lua
minetest.register_on_joinplayer(function(player)
	minetest.after(1, function(name)
		local fs = [[
			size[4,4]
			label[0,0;Test!]
			button[1,1;1,1;a;Hello]
			button[1,2;1,1;b;Hello]
			tooltip[a;Test tooltip] ]] ..

			"tooltip[b;" .. minetest.formspec_escape("Test " .. minetest.colorize("#0f0", "tooltip")) .. ";#00f;#f00]"

		minetest.show_formspec(name, "a", fs)
	end, player:get_player_name())
end)
