### PR TITLE
feature check for commit ac4884c3d677ef51bcce47f95ccd49d874022692

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -3,7 +3,6 @@
 core.features = {
 	glasslike_framed = true,
 	nodebox_as_selectionbox = true,
-	independent_selectionbox = true,
 	chat_send_player_param3 = true,
 	get_all_craft_recipes_works = true,
 	use_texture_alpha = true,
@@ -13,6 +12,7 @@ core.features = {
 	add_entity_with_staticdata = true,
 	no_chat_message_prediction = true,
 	object_use_texture_alpha = true,
+	entity_independent_selectionbox = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -12,7 +12,7 @@ core.features = {
 	add_entity_with_staticdata = true,
 	no_chat_message_prediction = true,
 	object_use_texture_alpha = true,
-	entity_independent_selectionbox = true,
+	object_independent_selectionbox = true,
 }
 
 function core.has_feature(arg)

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -3,6 +3,7 @@
 core.features = {
 	glasslike_framed = true,
 	nodebox_as_selectionbox = true,
+	independent_selectionbox = true,
 	chat_send_player_param3 = true,
 	get_all_craft_recipes_works = true,
 	use_texture_alpha = true,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3265,6 +3265,8 @@ Utilities
       {
           glasslike_framed = true,
           nodebox_as_selectionbox = true,
+          -- selectionbox is settable independently from collisionbox
+          independent_selectionbox = true,
           chat_send_player_param3 = true,
           get_all_craft_recipes_works = true,
           -- The transparency channel of textures can optionally be used on

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3265,8 +3265,6 @@ Utilities
       {
           glasslike_framed = true,
           nodebox_as_selectionbox = true,
-          -- selectionbox is settable independently from collisionbox
-          independent_selectionbox = true,
           chat_send_player_param3 = true,
           get_all_craft_recipes_works = true,
           -- The transparency channel of textures can optionally be used on
@@ -3284,7 +3282,9 @@ Utilities
           no_chat_message_prediction = true,
           -- The transparency channel of textures can optionally be used on
           -- objects (ie: players and lua entities)
-          object_use_texture_alpha = true
+          object_use_texture_alpha = true,
+          -- Object selectionbox is settable independently from collisionbox
+          object_independent_selectionbox = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`


### PR DESCRIPTION
Commit [1] introduced the possibility to set the selectionbox of an entity independently from its collisionbox. However, there seems to be no way to check for this engine feature (otherwise having to fall back to setting the collisionbox), so I currently have to work around it by comparing version numbers (which is error-prone).

I therefore suggest to allow the feature to be checked through minetest.features, by checking for the key "independent_selectionbox".

[1] https://github.com/minetest/minetest/commit/ac4884c3d677ef51bcce47f95ccd49d874022692