### PR TITLE
Entity lighting fix

### DIFF
--- a/src/content_cao.cpp
+++ b/src/content_cao.cpp
@@ -716,12 +716,26 @@ void GenericCAO::updateLightNoCheck(u8 light_at_pos)
 	}
 }
 
+m4x4f GenericCAO::getTransform()
+{
+	scene::ISceneNode *node = getSceneNode();
+	if (node)
+		return m4x4f(node->getAbsoluteTransformation());
+	
+	return m4x4f( m4x4f::EM4CONST_IDENTITY );
+}
+
 v3s16 GenericCAO::getLightPosition()
 {
-	if (m_is_player)
-		return floatToInt(m_position + v3f(0, 0.5 * BS, 0), BS);
-
-	return floatToInt(m_position, BS);
+	// Players and entities now both use a property to define the light sampling offset.
+	// The offset is in the entity's local space.
+	
+	v3f offset = v3f( m_prop.light_anchor );
+	
+	m4x4f transform = getTransform();
+	transform.rotateVect( offset );
+	
+	return floatToInt( m_position + offset , BS );
 }
 
 void GenericCAO::updateNodePos()

--- a/src/content_cao.h
+++ b/src/content_cao.h
@@ -154,6 +154,8 @@ public:
 	const bool isImmortal();
 
 	scene::ISceneNode *getSceneNode();
+	
+	m4x4f getTransform();
 
 	scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode();
 

--- a/src/irr_matrix.h
+++ b/src/irr_matrix.h
@@ -1,0 +1,26 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes.h"
+
+#include <matrix4.h>
+
+typedef core::CMatrix4<float> m4x4f;

--- a/src/irrlichttypes_bloated.h
+++ b/src/irrlichttypes_bloated.h
@@ -24,5 +24,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irr_v2d.h"
 #include "irr_v3d.h"
 #include "irr_aabb3d.h"
+#include "irr_matrix.h"
 
 #include <SColor.h>

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -69,6 +69,7 @@ std::string ObjectProperties::dump()
 	os << ", eye_height=" << eye_height;
 	os << ", zoom_fov=" << zoom_fov;
 	os << ", use_texture_alpha=" << use_texture_alpha;
+	os << ", light_anchor=" << PP(light_anchor);
 	return os.str();
 }
 
@@ -115,7 +116,8 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF1000(os, eye_height);
 	writeF1000(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
-
+	writeV3F1000( os, light_anchor );
+	
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
 }
@@ -167,4 +169,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF1000(is);
 	zoom_fov = readF1000(is);
 	use_texture_alpha = readU8(is);
+	light_anchor = readV3F1000(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -61,6 +61,7 @@ struct ObjectProperties
 	float eye_height = 1.625f;
 	float zoom_fov = 0.0f;
 	bool use_texture_alpha = false;
+	v3f light_anchor = v3f(0.0f, 0.6f, 0.0f);
 
 	ObjectProperties();
 	std::string dump();


### PR DESCRIPTION
This fixes the bug where entities would turn black if they had the origin at the feet, and were out of sunlight.
To make the fix more robust, a `light_anchor` property was created, replacing the hardcoded offset. The offset is applied in the entity's local space.
In order to easily transform said point to the entity's space, a typedef and a helper function for getting the scene node's matrix were added, since I couldn't find anything like that already in.
The default offset is +0.6 Y, which should work for almost any entity.