### PR TITLE
Run Minetest update checker on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ set(VERSION_EXTRA "" CACHE STRING "Stuff to append to version string")
 # Change to false for releases
 set(DEVELOPMENT_BUILD TRUE)
 
-set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
-	"Whether to enable the update checker by default")
-
 set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 if(VERSION_EXTRA)
 	set(VERSION_STRING "${VERSION_STRING}-${VERSION_EXTRA}")
@@ -63,6 +60,9 @@ if(NOT CMAKE_BUILD_TYPE)
 	# Default to release
 	set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type: Debug or Release" FORCE)
 endif()
+
+set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
+	"Whether to enable update checks by default")
 
 # Included stuff
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ set(VERSION_EXTRA "" CACHE STRING "Stuff to append to version string")
 # Change to false for releases
 set(DEVELOPMENT_BUILD TRUE)
 
+set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
+	"Whether to enable the update checker by default")
+
 set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 if(VERSION_EXTRA)
 	set(VERSION_STRING "${VERSION_STRING}-${VERSION_EXTRA}")

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ General options and their default values:
     ENABLE_SYSTEM_GMP=ON       - Use GMP from system (much faster than bundled mini-gmp)
     ENABLE_SYSTEM_JSONCPP=ON   - Use JsonCPP from system
     RUN_IN_PLACE=FALSE         - Create a portable install (worlds, settings etc. in current directory)
-    ENABLE_UPDATE_CHECKER=TRUE - Whether to enable the update checker by default
+    ENABLE_UPDATE_CHECKER=TRUE - Whether to enable update checks by default
     USE_GPROF=FALSE            - Enable profiling using GProf
     VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=foobar -> Minetest 0.4.9-foobar)
     ENABLE_TOUCH=FALSE         - Enable Touchscreen support (requires support by IrrlichtMt)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ General options and their default values:
     ENABLE_SYSTEM_GMP=ON       - Use GMP from system (much faster than bundled mini-gmp)
     ENABLE_SYSTEM_JSONCPP=ON   - Use JsonCPP from system
     RUN_IN_PLACE=FALSE         - Create a portable install (worlds, settings etc. in current directory)
+    ENABLE_UPDATE_CHECKER=TRUE - Whether to enable the update checker by default
     USE_GPROF=FALSE            - Enable profiling using GProf
     VERSION_EXTRA=             - Text to append to version (e.g. VERSION_EXTRA=foobar -> Minetest 0.4.9-foobar)
     ENABLE_TOUCH=FALSE         - Enable Touchscreen support (requires support by IrrlichtMt)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ project.ext.set("versionMinor", 6)      // Version Minor
 project.ext.set("versionPatch", 0)      // Version Patch
 project.ext.set("versionExtra", "-dev") // Version Extra
 project.ext.set("versionCode", 38)      // Android Version Code
+project.ext.set("developmentBuild", 1) // Whether it is a development build, or a release
 // NOTE: +2 after each release!
 // +1 for ARM and +1 for ARM64 APK's, because
 // each APK must have a larger `versionCode` than the previous

--- a/android/native/build.gradle
+++ b/android/native/build.gradle
@@ -14,7 +14,8 @@ android {
 						"versionMajor=${versionMajor}",
 						"versionMinor=${versionMinor}",
 						"versionPatch=${versionPatch}",
-						"versionExtra=${versionExtra}"
+						"versionExtra=${versionExtra}",
+						"developmentBuild=${developmentBuild}"
 			}
 		}
 	}

--- a/android/native/jni/Android.mk
+++ b/android/native/jni/Android.mk
@@ -102,6 +102,7 @@ LOCAL_CFLAGS += \
 	-DVERSION_MINOR=${versionMinor} \
 	-DVERSION_PATCH=${versionPatch} \
 	-DVERSION_EXTRA=${versionExtra} \
+	-DDEVELOPMENT_BUILD=${developmentBuild} \
 	$(GPROF_DEF)
 
 ifdef USE_BUILTIN_LUA

--- a/android/native/jni/Android.mk
+++ b/android/native/jni/Android.mk
@@ -98,7 +98,6 @@ LOCAL_CFLAGS += \
 	-DUSE_SOUND=1                   \
 	-DUSE_LEVELDB=0                 \
 	-DUSE_GETTEXT=1                 \
-	-DENABLE_UPDATE_CHECKER=0       \
 	-DVERSION_MAJOR=${versionMajor} \
 	-DVERSION_MINOR=${versionMinor} \
 	-DVERSION_PATCH=${versionPatch} \

--- a/android/native/jni/Android.mk
+++ b/android/native/jni/Android.mk
@@ -98,6 +98,7 @@ LOCAL_CFLAGS += \
 	-DUSE_SOUND=1                   \
 	-DUSE_LEVELDB=0                 \
 	-DUSE_GETTEXT=1                 \
+	-DENABLE_UPDATE_CHECKER=0       \
 	-DVERSION_MAJOR=${versionMajor} \
 	-DVERSION_MINOR=${versionMinor} \
 	-DVERSION_PATCH=${versionPatch} \

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -34,15 +34,15 @@ local function version_info_formspec(data)
 
 	local fs = {
 		"formspec_version[3]",
-		"size[10,5.5]",
+		"size[12.8,7]",
 		"style_type[label;textcolor=#0E0]",
-		"label[0.375,0.775;", core.formspec_escape(title), "]",
-		"textarea[0.375,1.375;9.25,2.75;;;",
+		"label[0.5,0.8;", core.formspec_escape(title), "]",
+		"textarea[0.4,1.6;12,3.4;;;",
 			core.formspec_escape(message), "]",
-		"container[0.375,4.375]",
-		"button[0,0;2.92,0.75;version_check_visit;", fgettext("Visit website"), "]",
-		"button[3.16,0;2.92,0.75;version_check_remind;", fgettext("Later"), "]",
-		"button[6.33,0;2.92,0.75;version_check_never;", fgettext("Never"), "]",
+		"container[0.4,5.8]",
+		"button[0.0,0;4.0,0.8;version_check_visit;", fgettext("Visit website"), "]",
+		"button[4.5,0;3.5,0.8;version_check_remind;", fgettext("Later"), "]",
+		"button[8.5.5,0;3.5,0.8;version_check_never;", fgettext("Never"), "]",
 		"container_end[]",
 	}
 

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -1,0 +1,157 @@
+--[[
+Minetest
+Copyright (C) 2018-2020 SmallJoker
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+]]
+
+local function version_info_formspec(data)
+	local title = fgettext("A new Minetest version is available")
+	local message =
+		fgettext("Current version: $1\nNew version: $2\n" ..
+				"Visit $3 to find out how to get the newest version to stay up to date" ..
+				" with the features and bugfixes.",
+			core.get_version().string, data.new_version, data.url)
+
+	local fs = {
+		"formspec_version[3]",
+		"size[10,5.5]",
+		"style_type[label;textcolor=#0E0]",
+		"label[0.375,0.775;", core.formspec_escape(title), "]",
+		"textarea[0.375,1.375;9.25,2.75;;;",
+			core.formspec_escape(message), "]",
+		"container[0.375,4.375]",
+		"button[0,0;2.92,0.75;version_check_visit;", fgettext("Visit website"), "]",
+		"button[3.16,0;2.92,0.75;version_check_remind;", fgettext("Later"), "]",
+		"button[6.33,0;2.92,0.75;version_check_never;", fgettext("Never"), "]",
+		"container_end[]",
+	}
+
+	return table.concat(fs, "")
+end
+
+local function version_info_buttonhandler(this, fields)
+	if fields.version_check_remind then
+		-- Only wait for the check interval
+		core.settings:set("update_last_known", "")
+		this:delete()
+		return true
+	end
+	if fields.version_check_never then
+		core.settings:set("update_last_checked", "disabled")
+		this:delete()
+		return true
+	end
+	if fields.version_check_visit then
+		core.open_url(this.data.url)
+		this:delete()
+		return true
+	end
+
+	return false
+end
+
+local function create_version_info_dlg(new_version, url)
+	assert(type(new_version) == "string")
+	assert(type(url) == "string")
+
+	local retval = dialog_create("version_info",
+		version_info_formspec,
+		version_info_buttonhandler,
+		nil)
+
+	retval.data.new_version = new_version
+	retval.data.url = url
+
+	return retval
+end
+
+local function get_current_version_code()
+	-- Format: Major.Minor.Patch
+	-- Convert to MMMNNNPPP
+	local cur_string = core.get_version().string
+	local cur_major, cur_minor, cur_patch = cur_string:match("^(%d+).(%d+).(%d+)")
+
+	if not cur_patch then
+		core.log("error", "Failed to read version numbers (invalid tag format?)")
+		return
+	end
+
+	return (cur_major * 1000 + cur_minor) * 1000 + cur_patch
+end
+
+local function on_version_info_received(json)
+	local known_update = tonumber(core.settings:get("update_last_known")) or 0
+
+	-- Format: MMNNPPP (Major, Minor, Patch)
+	local new_number = json.latest.version_code
+	if not new_number then
+		core.log("error", "Failed to read version numbers (invalid tag format?)")
+		return
+	end
+
+	local cur_number = get_current_version_code()
+	if new_number <= known_update or new_number < cur_number then
+		return
+	end
+
+	-- Also consider updating from 1.2.3-dev to 1.2.3
+	if new_number == cur_number and not core.get_version().is_dev then
+		return
+	end
+
+	core.settings:set("update_last_known", tostring(new_number))
+
+	local tabs = ui.find_by_name("maintab")
+	tabs:hide()
+
+	local version_info_dlg = create_version_info_dlg(json.latest.version, json.latest.url)
+	version_info_dlg:set_parent(tabs)
+	version_info_dlg:show()
+
+	ui.update()
+end
+
+function check_new_version()
+	local url = core.settings:get("update_information_url")
+	if core.settings:get("update_last_checked") == "disabled" or
+			url == "" then
+		-- Never show any updates
+		return
+	end
+
+	local time_now = os.time()
+	local time_checked = tonumber(core.settings:get("update_last_checked")) or 0
+	if time_now - time_checked < 2 * 24 * 3600 then
+		-- Check interval of 2 entire days
+		return
+	end
+
+	core.settings:set("update_last_checked", tostring(time_now))
+
+	core.handle_async(function(params)
+		local http = core.get_http_api()
+		return http.fetch_sync(params)
+	end, { url = url }, function(result)
+		local json = result.succeeded and core.parse_json(result.data)
+		if type(json) ~= "table" or not json.latest then
+			core.log("error", "Failed to read JSON output from " .. url ..
+					", status code = " .. result.code)
+			return
+		end
+
+		on_version_info_received(json)
+	end)
+end

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -1,6 +1,6 @@
 --[[
 Minetest
-Copyright (C) 2018-2020 SmallJoker
+Copyright (C) 2018-2020 SmallJoker, 2022 rubenwardy
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/builtin/mainmenu/dlg_version_info.lua
+++ b/builtin/mainmenu/dlg_version_info.lua
@@ -102,6 +102,12 @@ local function get_current_version_code()
 end
 
 local function on_version_info_received(json)
+	local maintab = ui.find_by_name("maintab")
+	if maintab.hidden then
+		-- Another dialog is open, abort.
+		return
+	end
+
 	local known_update = tonumber(core.settings:get("update_last_known")) or 0
 
 	-- Format: MMNNPPP (Major, Minor, Patch)
@@ -124,11 +130,10 @@ local function on_version_info_received(json)
 	core.settings:set("update_last_known", tostring(new_number))
 
 	-- Show version info dialog (once)
-	local tabs = ui.find_by_name("maintab")
-	tabs:hide()
+	maintab:hide()
 
 	local version_info_dlg = create_version_info_dlg(json.latest.version, json.latest.url)
-	version_info_dlg:set_parent(tabs)
+	version_info_dlg:set_parent(maintab)
 	version_info_dlg:show()
 
 	ui.update()

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -46,6 +46,7 @@ dofile(menupath .. DIR_DELIM .. "dlg_delete_content.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_delete_world.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_register.lua")
 dofile(menupath .. DIR_DELIM .. "dlg_rename_modpack.lua")
+dofile(menupath .. DIR_DELIM .. "dlg_version_info.lua")
 
 local tabs = {}
 
@@ -120,8 +121,8 @@ local function init_globals()
 	end
 
 	ui.set_default("maintab")
+	check_new_version()
 	tv_main:show()
-
 	ui.update()
 end
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -578,7 +578,7 @@ update_information_url (Update information URL) string https://www.minetest.net/
 #    Set this value to "disabled" to never check for updates.
 update_last_checked (Last update check) string
 
-#    Version number which was last checked for an update.
+#    Version number which was last seen during an update check.
 #
 #    Representation: MMMIIIPPP, where M=Major, I=Minor, P=Patch
 #    Ex: 5.5.0 is 005005000

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -571,6 +571,19 @@ serverlist_url (Serverlist URL) string servers.minetest.net
 #    If disabled, new accounts will be registered automatically when logging in.
 enable_split_login_register (Enable split login/register) bool true
 
+#    URL to JSON file which provides information about the newest Minetest release
+update_information_url (Update information URL) string https://www.minetest.net/release_info.json
+
+#    Unix timestamp (integer) of when the client last checked for an update
+#    Set this value to "disabled" to never check for updates.
+update_last_checked (Last update check) string
+
+#    Version number which was last checked for an update.
+#
+#    Representation: MMMIIIPPP, where M=Major, I=Minor, P=Patch
+#    Ex: 5.5.0 is 005005000
+update_last_known (Last known version update) int 0
+
 [*Server]
 
 #    Name of the player.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4921,6 +4921,7 @@ Utilities
     * `string`: Simple version, eg, "1.2.3-dev"
     * `hash`: Full git version (only set if available),
       eg, "1.2.3-dev-01234567-dirty".
+    * `is_dev`: Boolean value indicating whether it's a development build
   Use this for informational purposes only. The information in the returned
   table does not represent the capabilities of the engine, nor is it
   reliable or verifiable. Compatible forks will have a different name and

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -15,6 +15,8 @@
 #define BUILD_TYPE "@CMAKE_BUILD_TYPE@"
 #define ICON_DIR "@ICONDIR@"
 #cmakedefine01 RUN_IN_PLACE
+#cmakedefine01 DEVELOPMENT_BUILD
+#cmakedefine01 ENABLE_UPDATE_CHECKER
 #cmakedefine01 USE_GETTEXT
 #cmakedefine01 USE_CURL
 #cmakedefine01 USE_SOUND

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,7 @@
 		#define PROJECT_NAME "minetest"
 		#define PROJECT_NAME_C "Minetest"
 		#define STATIC_SHAREDIR ""
+		#define ENABLE_UPDATE_CHECKER 0
 		#define VERSION_STRING STR(VERSION_MAJOR) "." STR(VERSION_MINOR) "." STR(VERSION_PATCH) STR(VERSION_EXTRA)
 	#endif
 	#ifdef NDEBUG

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -335,6 +335,13 @@ void set_default_settings()
 	settings->setDefault("contentdb_flag_blacklist", "nonfree, desktop_default");
 #endif
 
+	settings->setDefault("update_information_url", "https://www.minetest.net/release_info.json");
+#if ENABLE_UPDATE_CHECKER
+	settings->setDefault("update_last_checked", "");
+#else
+	settings->setDefault("update_last_checked", "disabled");
+#endif
+	settings->setDefault("update_last_known", "");
 
 	// Server
 	settings->setDefault("disable_escape_sequences", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,7 +341,6 @@ void set_default_settings()
 #else
 	settings->setDefault("update_last_checked", "disabled");
 #endif
-	settings->setDefault("update_last_known", "");
 
 	// Server
 	settings->setDefault("disable_escape_sequences", "false");

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1671,7 +1671,7 @@ void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
 
 void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &element)
 {
-	MY_CHECKCLIENT("list");
+	MY_CHECKCLIENT("hypertext");
 
 	std::vector<std::string> parts;
 	if (!precheckElement("hypertext", element, 4, 4, parts))

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -480,6 +480,8 @@ int ModApiUtil::l_get_version(lua_State *L)
 		lua_setfield(L, table, "hash");
 	}
 
+	lua_pushboolean(L, DEVELOPMENT_BUILD);
+	lua_setfield(L, table, "is_dev");
 	return 1;
 }
 

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -26,6 +26,7 @@ perform_release() {
 	sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt
 
 	sed -i 's/project.ext.set("versionExtra", "-dev")/project.ext.set("versionExtra", "")/' android/build.gradle
+	sed -i 's/project.ext.set("developmentBuild", 1)/project.ext.set("developmentBuild", 0)/' android/build.gradle
 	sed -i -re "s/\"versionCode\", [0-9]+/\"versionCode\", $NEW_ANDROID_VERSION_CODE/" android/build.gradle
 
 	sed -i '/\<release/s/\(version\)="[^"]*"/\1="'"$RELEASE_VERSION"'"/' misc/net.minetest.minetest.appdata.xml
@@ -55,6 +56,7 @@ back_to_devel() {
 
 	# Update Android versions
 	sed -i 's/set("versionExtra", "")/set("versionExtra", "-dev")/' android/build.gradle
+	sed -i 's/project.ext.set("developmentBuild", 0)/project.ext.set("developmentBuild", 1)/' android/build.gradle
 	sed -i -re "s/set\(\"versionMajor\", [0-9]+\)/set(\"versionMajor\", $NEXT_VERSION_MAJOR)/" android/build.gradle
 	sed -i -re "s/set\(\"versionMinor\", [0-9]+\)/set(\"versionMinor\", $NEXT_VERSION_MINOR)/" android/build.gradle
 	sed -i -re "s/set\(\"versionPatch\", [0-9]+\)/set(\"versionPatch\", $NEXT_VERSION_PATCH)/" android/build.gradle


### PR DESCRIPTION
~However, the version checking is not optimal (relies on `MINOR.MAJOR.PATCH`) and GitHub seems to limit the API page calls ([source](http://irc.minetest.net/minetest-hub/2018-08-08#i_5375273)). `core.get_version` should probably also be extended by a `is_dev_build` field to get around the ugly detection.~

See https://github.com/minetest/minetest/pull/7629#issuecomment-656786622 for the current status and testing instructions.