### PR TITLE
lua_api.txt: Relocate item-def section

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5414,6 +5414,62 @@ Used by `minetest.register_lbm`.
         action = func(pos, node),
     }
 
+Tile definition
+---------------
+
+* `"image.png"`
+* `{name="image.png", animation={Tile Animation definition}}`
+* `{name="image.png", backface_culling=bool, tileable_vertical=bool,
+  tileable_horizontal=bool, align_style="node"/"world"/"user", scale=int}`
+    * backface culling enabled by default for most nodes
+    * tileable flags are info for shaders, how they should treat texture
+      when displacement mapping is used.
+      Directions are from the point of view of the tile texture,
+      not the node it's on.
+    * align style determines whether the texture will be rotated with the node
+      or kept aligned with its surroundings. "user" means that client
+      setting will be used, similar to `glasslike_framed_optional`.
+      Note: supported by solid nodes and nodeboxes only.
+    * scale is used to make texture span several (exactly `scale`) nodes,
+      instead of just one, in each direction. Works for world-aligned
+      textures only.
+      Note that as the effect is applied on per-mapblock basis, `16` should
+      be equally divisible by `scale` or you may get wrong results.
+* `{name="image.png", color=ColorSpec}`
+    * the texture's color will be multiplied with this color.
+    * the tile's color overrides the owning node's color in all cases.
+* deprecated, yet still supported field names:
+    * `image` (name)
+
+Tile animation definition
+-------------------------
+
+    {
+        type = "vertical_frames",
+
+        aspect_w = 16,
+        -- Width of a frame in pixels
+
+        aspect_h = 16,
+        -- Height of a frame in pixels
+
+        length = 3.0,
+        -- Full loop length
+    }
+
+    {
+        type = "sheet_2d",
+
+        frames_w = 5,
+        -- Width in number of frames
+
+        frames_h = 3,
+        -- Height in number of frames
+
+        frame_length = 0.5,
+        -- Length of a single frame
+    }
+
 Item definition
 ---------------
 
@@ -5528,62 +5584,6 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- Add your own custom fields. By convention, all custom field names
         -- should start with `_` to avoid naming collisions with future engine
         -- usage.
-    }
-
-Tile definition
----------------
-
-* `"image.png"`
-* `{name="image.png", animation={Tile Animation definition}}`
-* `{name="image.png", backface_culling=bool, tileable_vertical=bool,
-  tileable_horizontal=bool, align_style="node"/"world"/"user", scale=int}`
-    * backface culling enabled by default for most nodes
-    * tileable flags are info for shaders, how they should treat texture
-      when displacement mapping is used.
-      Directions are from the point of view of the tile texture,
-      not the node it's on.
-    * align style determines whether the texture will be rotated with the node
-      or kept aligned with its surroundings. "user" means that client
-      setting will be used, similar to `glasslike_framed_optional`.
-      Note: supported by solid nodes and nodeboxes only.
-    * scale is used to make texture span several (exactly `scale`) nodes,
-      instead of just one, in each direction. Works for world-aligned
-      textures only.
-      Note that as the effect is applied on per-mapblock basis, `16` should
-      be equally divisible by `scale` or you may get wrong results.
-* `{name="image.png", color=ColorSpec}`
-    * the texture's color will be multiplied with this color.
-    * the tile's color overrides the owning node's color in all cases.
-* deprecated, yet still supported field names:
-    * `image` (name)
-
-Tile animation definition
--------------------------
-
-    {
-        type = "vertical_frames",
-
-        aspect_w = 16,
-        -- Width of a frame in pixels
-
-        aspect_h = 16,
-        -- Height of a frame in pixels
-
-        length = 3.0,
-        -- Full loop length
-    }
-
-    {
-        type = "sheet_2d",
-
-        frames_w = 5,
-        -- Width in number of frames
-
-        frames_h = 3,
-        -- Height in number of frames
-
-        frame_length = 0.5,
-        -- Length of a single frame
     }
 
 Node definition


### PR DESCRIPTION
https://github.com/minetest/minetest/blob/ea26076bcb032584c3af0a4e8e47f13afea6286b/doc/lua_api.txt#L5595

This line is used here to prevent duplication of the same fields in multiple definitions, but it also means that one would have to refer to the item def section whenever they look up the node def section. Hence this trivial PR to relocate the item def section. No idea why the tile def and tile anim def sections were right in between though...