### PR TITLE
Builtin: Move player out of decorations on (re)spawn

### DIFF
--- a/builtin/game/static_spawn.lua
+++ b/builtin/game/static_spawn.lua
@@ -8,9 +8,70 @@ if static_spawnpoint_string and
 			static_spawnpoint_string .. '"')
 end
 
+local function check_walkable(player)
+	-- Because delayed, check if player still present
+	local playername = player:get_player_name()
+	if not playername then
+		return
+	end
+
+	local ppos = vector.round(player:get_pos())
+	print("Checking if you are out of your tree")
+
+	for move = 1, 16 do
+		local spawn_y = minetest.get_spawn_level(ppos.x, ppos.z)
+		if spawn_y then
+			-- 'Suitable spawn point'
+			ppos.y = spawn_y
+			local nodel = minetest.get_node(ppos)
+			local defl = minetest.registered_nodes[nodel.name]
+			ppos.y = ppos.y + 1
+			local nodeu = minetest.get_node(ppos)
+			local defu = minetest.registered_nodes[nodeu.name]
+			if defl and defu and (not defl.walkable and not defu.walkable) then
+				if move == 1 then
+					print("You are out of your tree. Z " .. ppos.z)
+					return
+				end
+				ppos.y = ppos.y - 1
+				print("Found space. Moving you out of your tree. Z " .. ppos.z)
+				player:set_pos(ppos)
+				return
+			end
+		end
+
+		print("You are in your tree. Z " .. ppos.z)
+		print("Moving check Northwards")
+		ppos.z = ppos.z + 1 -- TODO use a spiral search
+	end
+end
+
+local function check_for_walkable(player)
+	-- Because delayed, check if player still present
+	local playername = player:get_player_name()
+	if not playername then
+		return
+	end
+
+	local ppos = player:get_pos()
+	-- Check for unloaded area or loaded ignore
+	local nodep = minetest.get_node_or_nil(ppos)
+	if not nodep or nodep.name == "ignore" then
+		-- Wait for mapgen or world loading
+		minetest.after(0.5, check_for_walkable, player)
+		print("Waiting for world generation or loading")
+		return
+	end
+
+	print("World loaded or generated. Waiting a little more")
+	minetest.after(1, check_walkable, player)
+end
+
 local function put_player_in_spawn(player_obj)
 	local static_spawnpoint = core.setting_get_pos("static_spawnpoint")
 	if not static_spawnpoint then
+		-- Move player out of decoration if necessary
+		minetest.after(0.5, check_for_walkable, player_obj)
 		return false
 	end
 	core.log("action", "Moving " .. player_obj:get_player_name() ..


### PR DESCRIPTION
WIP but seems to work, debugging comments are still present (useful for testing), also a spiral search may be used instead of only moving Northwards.

Closes #5863 
This was partly derived from #7565 which had several issues.

If no static spawnpoint is set there is a delay, then the first function checks to see if world has generated/loaded, this ensures that the MTG spawn mod (or equivalent in a game) runs first and repositions the player.
Then there is another delay which seems necessary to make this work. Perhaps due to decorations from a neighbouring mapchunk.
Then the second function gets the spawn level for the X, Z position and checks 2 vertically-stacked nodes for solidness, if either are solid the position is moved 1 node northwards and the check run again.
When 2 nodes of space are found the player is moved to that position, or not moved if the initial position was fine.

![tree2](https://user-images.githubusercontent.com/3686677/44294439-030ce580-a28f-11e8-9053-d5834b7ba22a.png)

To test, edit MTG spawn mod to always spawn you in a deciduous forest:
```
-- Table of suitable biomes

local biome_ids = {
	minetest.get_biome_id("deciduous_forest"),
}
```
And default/mapgen.lua for lots of appletrees:
```
	minetest.register_decoration({
		name = "default:apple_tree",
		deco_type = "schematic",
		place_on = {"default:dirt_with_grass"},
		sidelen = 16,
		noise_params = {
			offset = 0.04,
			scale = 0.0,
			spread = {x = 250, y = 250, z = 250},
			seed = 2,
			octaves = 3,
			persist = 0.66
		},
		biomes = {"deciduous_forest"},
		y_max = 31000,
		y_min = 1,
		schematic = minetest.get_modpath("default") .. "/schematics/apple_tree.mts",
		flags = "place_center_x, place_center_z",
		rotation = "random",
	})
```