### PR TITLE
Change mapgen order to ores > dungeons > decorations

### DIFF
--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -273,6 +273,9 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 			generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	// Generate dungeons
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
@@ -281,9 +284,6 @@ void MapgenCarpathian::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -207,6 +207,9 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 		generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y);
@@ -214,9 +217,6 @@ void MapgenFlat::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -218,6 +218,9 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 		generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
 		generateDungeons(stone_surface_max_y);
@@ -225,9 +228,6 @@ void MapgenFractal::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -232,6 +232,9 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 			generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	// Generate dungeons and desert temples
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
@@ -240,9 +243,6 @@ void MapgenV5::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -352,6 +352,9 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 			generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	// Generate dungeons
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
@@ -360,9 +363,6 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -253,6 +253,9 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 			generateCavesRandomWalk(stone_surface_max_y, large_cave_depth);
 	}
 
+	// Generate the registered ores
+	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
+
 	// Dungeon creation
 	if ((flags & MG_DUNGEONS) && full_node_min.Y >= dungeon_ymin &&
 			full_node_max.Y <= dungeon_ymax)
@@ -261,9 +264,6 @@ void MapgenValleys::makeChunk(BlockMakeData *data)
 	// Generate the registered decorations
 	if (flags & MG_DECORATIONS)
 		m_emerge->decomgr->placeAllDecos(this, blockseed, node_min, node_max);
-
-	// Generate the registered ores
-	m_emerge->oremgr->placeAllOres(this, blockseed, node_min, node_max);
 
 	// Sprinkle some dust on top after everything else was generated
 	if (flags & MG_BIOMES)


### PR DESCRIPTION
Previously dungeons > decorations > ores.
Decorations depend on the node they are placed on, and ore types are
increasingly able to place large continuous volumes of nodes, such as
strata. Decorations are increasingly being used underground.

The new order avoids a node being changed by ore generation after a
decoration has been placed on it.
The new order also avoids ores appearing in the walls of a dungeon if
the wall nodes match the local stone node.
///////////////////////

Closes #7609 
Not done for mgv6 though, not sure if it should.
Tested mgv7 and saw no issues. Any issues are likely to be difficult to forsee or test so best merge to get wider testing well before 5.0.0.