### PR TITLE
Load translations after media download, add fallback translations

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -139,7 +139,7 @@ Mod directory structure
     │   ├── media
     │   ├── locale
     │   │   └── modname.en.tr
-    │   │   └── modname.fr_FR.tr
+    │   │   └── modname.pt_BR.tr
     │   └── <custom data>
     └── another
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -138,6 +138,8 @@ Mod directory structure
     │   ├── sounds
     │   ├── media
     │   ├── locale
+    │   │   └── modname.en.tr
+    │   │   └── modname.fr_FR.tr
     │   └── <custom data>
     └── another
 
@@ -2511,9 +2513,11 @@ operations such as `minetest.colorize` which are also concatenation.
 Translation file format
 -----------------------
 
-A translation file has the suffix `.[lang].tr`, where `[lang]` is the language
-it corresponds to. It must be put into the `locale` subdirectory of the mod.
-The file should be a text file, with the following format:
+A translation file has the suffix `.[lang].tr`, where `[lang]` has the format
+`[ISO 639]_[ISO 3166-1 alpha-2]` whereas the country code addition is optional.
+The best fitting language code will overwrite the fallback translation (`en`).
+The file must be put into the `locale` subdirectory of the mod. It is a text
+file with the following format:
 
 * Lines beginning with `# textdomain:` (the space is significant) can be used
   to specify the text domain of all following translations in the file.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1707,10 +1707,8 @@ void Client::afterContentReceived()
 
 				auto it = std::find(locale.begin(), locale.end(), lang_code);
 				if (it == locale.end())
-					it--;
+					it--; // Should not happen, load it anyway
 				translations[it - locale.begin()].push_back(&i.second);
-				std::cout << "Load " << (it - locale.begin()) << " -> file=" << i.first
-					<< ", code=" << lang_code << std::endl;
 			}
 			for (size_t i = locale.size(); i > 0; --i) {
 				for (auto &data : translations[i - 1])

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1141,29 +1141,12 @@ const std::vector<std::string> &Client::getLanguageCodes()
 	if (!codes.empty())
 		return codes;
 
-	std::string lang = setlocale(LC_ALL, "");
-
-#if defined(_WIN32)
-	// https://msdn.microsoft.com/en-gb/library/39cwe7zf.aspx
-	lang = str_replace(lang, '-', '_');
-#endif
-
-	// POSIX systems: ISO/IEC 15897 format
-	// Remove encoding information (ex. "en_GB@variant.utf-8" -> "en_GB")
-	size_t delim = lang.find('@');
-	if (delim != std::string::npos) {
-		lang.resize(delim);
+	std::string lang = gettext("LANG_CODE");
+	if (!lang.empty())
 		codes.emplace_back(lang);
-	} else {
-		delim = lang.find('.');
-		if (delim != std::string::npos) {
-			lang.resize(delim);
-			codes.emplace_back(lang);
-		}
-	}
 
 	// Remove country specific information
-	delim = lang.find('_');
+	size_t delim = lang.find('_');
 	if (delim != std::string::npos) {
 		lang.resize(delim);
 		codes.emplace_back(lang);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -467,6 +467,8 @@ private:
 	void sendGotBlocks(v3s16 block);
 	void sendRemovedSounds(std::vector<s32> &soundList);
 
+	const std::vector<std::string> &getLanguageCodes();
+
 	// Helper function
 	inline std::string getPlayerName()
 	{ return m_env.getLocalPlayer()->getName(); }
@@ -546,6 +548,7 @@ private:
 	bool m_nodedef_received = false;
 	bool m_mods_loaded = false;
 	ClientMediaDownloader *m_media_downloader;
+	std::unordered_map<std::string, std::string> m_translation_media;
 
 	// time_of_day speed approximation for old protocol
 	bool m_time_of_day_set = false;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -132,12 +132,12 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 					<< m_recommended_send_interval<<std::endl;
 
 	// Reply to server
-	std::string lang = gettext("LANG_CODE");
-	if (lang == "LANG_CODE")
-		lang = "";
+	auto &locale = getLanguageCodes();
+	NetworkPacket resp_pkt(TOSERVER_INIT2, 1);
+	resp_pkt << (u8)locale.size();
+	for (auto &code : locale)
+		resp_pkt << code;
 
-	NetworkPacket resp_pkt(TOSERVER_INIT2, sizeof(u16) + lang.size());
-	resp_pkt << lang;
 	Send(&resp_pkt);
 
 	m_state = LC_Init;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -132,11 +132,9 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 					<< m_recommended_send_interval<<std::endl;
 
 	// Reply to server
-	auto &locale = getLanguageCodes();
-	NetworkPacket resp_pkt(TOSERVER_INIT2, 1);
-	resp_pkt << (u8)locale.size();
-	for (auto &code : locale)
-		resp_pkt << code;
+	const std::vector<std::string> &locale = getLanguageCodes();
+	NetworkPacket resp_pkt(TOSERVER_INIT2, 0);
+	resp_pkt << locale;
 
 	Send(&resp_pkt);
 

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -19,7 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "networkpacket.h"
 #include <sstream>
-#include "networkexceptions.h"
 #include "util/serialize.h"
 #include "networkprotocol.h"
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -119,7 +119,7 @@ public:
 	NetworkPacket &operator>>(video::SColor &dst);
 	NetworkPacket &operator<<(video::SColor src);
 
-	template<typename T> NetworkPacket &operator >> (std::vector<T> &dst)
+	template <typename T> NetworkPacket &operator>>(std::vector<T> &dst)
 	{
 		u16 count;
 		*this >> count;
@@ -133,7 +133,7 @@ public:
 		return *this;
 	}
 
-	template<typename T> NetworkPacket &operator << (const std::vector<T> &src)
+	template <typename T> NetworkPacket &operator<<(const std::vector<T> &src)
 	{
 		if (src.size() > U16_MAX)
 			throw PacketError("Vector is too long");

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -289,15 +289,8 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 
 	// Receive the client locale
 	std::vector<std::string> locale;
-	u8 locale_count = 0;
 	try {
-		*pkt >> locale_count;
-
-		while (locale_count-- > 0) {
-			std::string code;
-			*pkt >> code;
-			locale.push_back(code);
-		}
+		*pkt >> locale;
 	} catch (PacketError &e) {}
 
 	/*

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -287,9 +287,18 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	m_clients.event(pkt->getPeerId(), CSE_GotInit2);
 	u16 protocol_version = m_clients.getProtocolVersion(pkt->getPeerId());
 
-	std::string lang;
-	if (pkt->getSize() > 0)
-		*pkt >> lang;
+	// Receive the client locale
+	std::vector<std::string> locale;
+	u8 locale_count = 0;
+	try {
+		*pkt >> locale_count;
+
+		while (locale_count-- > 0) {
+			std::string code;
+			*pkt >> code;
+			locale.push_back(code);
+		}
+	} catch (PacketError &e) {}
 
 	/*
 		Send some initialization data
@@ -310,7 +319,7 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	m_clients.event(pkt->getPeerId(), CSE_SetDefinitionsSent);
 
 	// Send media announcement
-	sendMediaAnnouncement(pkt->getPeerId(), lang);
+	sendMediaAnnouncement(pkt->getPeerId(), locale);
 
 	// Send detached inventories
 	sendDetachedInventories(pkt->getPeerId());

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2359,7 +2359,7 @@ void Server::sendMediaAnnouncement(session_t peer_id,
 		std::string lang_code = name.substr(
 			lang_dot + 1, tr_dot - lang_dot - 1);
 		auto it = std::find(locale.begin(), locale.end(), lang_code);
-std::cout << "found: " << lang_code << " in " << name << std::endl;
+		// Skip (return true) when it's not found
 		return it == locale.end();
 	};
 

--- a/src/server.h
+++ b/src/server.h
@@ -431,7 +431,8 @@ private:
 	void SendBlocks(float dtime);
 
 	void fillMediaCache();
-	void sendMediaAnnouncement(session_t peer_id, const std::string &lang_code);
+	void sendMediaAnnouncement(session_t peer_id,
+			const std::vector<std::string> &locale);
 	void sendRequestedMedia(session_t peer_id,
 			const std::vector<std::string> &tosend);
 


### PR DESCRIPTION
~`gettext("LANG_CODE")` returned an empty string, so this PR will now use the `setlocale` output which does not seem to follow any C standard. If you find something more reliable, please add a comment.~
Note to myself: Update the `locale` directory next time when working with gettext.

**What this PR does**
 * ~Now detects the language correctly in most cases~
 * `.en.tr` as fallback for mods which aren't translated entirely (or in another language)
 * Language loading priorities, first `en`, then `pt` and `pt_BR` for the final overwrite if such translations were found. This language priority list may be extended to 255 entries for a custom fallback order
 * Improved documentation

**Testing**
[Here's](https://github.com/SmallJoker/upgrade_packs) a rather simple mod with a few translated strings. Copy&paste the files (or rename) for your language code.


Implements #7171
Replaces PR #7182 