### PR TITLE
Formspecs: Remove invalid background warning

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -674,6 +674,10 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 			pos.Y = stoi(v_pos[1]); //acts as offset
 			clip = true;
 		}
+		
+		if (!data->explicit_size && !clip)
+			warningstream<<"invalid use of unclipped background without a size[] element"<<std::endl;
+		
 		m_backgrounds.emplace_back(name, pos, geom, clip);
 
 		return;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -668,9 +668,6 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		geom.X = stof(v_geom[0]) * spacing.X;
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 
-		if (!data->explicit_size)
-			warningstream<<"invalid use of background without a size[] element"<<std::endl;
-
 		bool clip = false;
 		if (parts.size() == 4 && is_yes(parts[3])) {
 			pos.X = stoi(v_pos[0]); //acts as offset

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -676,7 +676,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		}
 		
 		if (!data->explicit_size && !clip)
-			warningstream<<"invalid use of unclipped background without a size[] element"<<std::endl;
+			warningstream << "invalid use of unclipped background without a size[] element" << std::endl;
 		
 		m_backgrounds.emplace_back(name, pos, geom, clip);
 


### PR DESCRIPTION
clipped backgrounds are still valid with no size[] tag, as they will apply themselves correct on any size

Fixes #7197 