### PR TITLE
Content tab: Fix clipped text in button

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -97,7 +97,7 @@ local function get_formspec(tabview, name, tabdata)
 		if selected_pkg.type == "mod" then
 			if selected_pkg.is_modpack then
 				retval = retval .. ";0]" ..
-					"button[8.9,4.65;3,1;btn_mod_mgr_rename_modpack;" ..
+					"button[8.65,4.65;3.25,1;btn_mod_mgr_rename_modpack;" ..
 					fgettext("Rename") .. "]"
 			else
 				--show dependencies
@@ -128,17 +128,17 @@ local function get_formspec(tabview, name, tabdata)
 			if selected_pkg.type == "txp" then
 				if selected_pkg.enabled then
 					retval = retval ..
-						"button[8.9,4.65;3,1;btn_mod_mgr_disable_txp;" ..
+						"button[8.65,4.65;3.25,1;btn_mod_mgr_disable_txp;" ..
 						fgettext("Disable Texture Pack") .. "]"
 				else
 					retval = retval ..
-						"button[8.9,4.65;3,1;btn_mod_mgr_use_txp;" ..
+						"button[8.65,4.65;3.25,1;btn_mod_mgr_use_txp;" ..
 						fgettext("Use Texture Pack") .. "]"
 				end
 			end
 		end
 
-		retval = retval .. "button[5.5,4.65;3,1;btn_mod_mgr_delete_mod;"
+		retval = retval .. "button[5.5,4.65;3.25,1;btn_mod_mgr_delete_mod;"
 			.. fgettext("Uninstall Package") .. "]"
 	end
 	return retval


### PR DESCRIPTION
 Content tab: Fix clipped text in button

Wider buttons to not clip 'Disable Texture Pack' text when using a
small game window (1024x600, the default).
///////////////////////

![screenshot from 2018-08-21 01-07-09](https://user-images.githubusercontent.com/3686677/44373098-56757280-a4df-11e8-8ade-7f401b7d7dd3.png)

![screenshot from 2018-08-21 22-30-09](https://user-images.githubusercontent.com/3686677/44430514-ce50a500-a592-11e8-8d8e-c073112f832e.png)

^ Both screenshots with 1024x600 window (the default)

Closes #7662 
I was just able to fit the 'disable texture pack' text while still keeping a space between buttons.
I made sure to also resize the modpack 'rename' button.