### PR TITLE
CMake: Enable RUN_IN_PLACE by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,7 @@ message(STATUS "*** Will build version ${VERSION_STRING} ***")
 
 
 # Configuration options
-set(DEFAULT_RUN_IN_PLACE FALSE)
-if(WIN32)
-	set(DEFAULT_RUN_IN_PLACE TRUE)
-endif()
-set(RUN_IN_PLACE ${DEFAULT_RUN_IN_PLACE} CACHE BOOL
-	"Run directly in source directory structure")
+set(RUN_IN_PLACE TRUE CACHE BOOL "Run directly in source directory structure")
 
 
 set(BUILD_CLIENT TRUE CACHE BOOL "Build client")


### PR DESCRIPTION
`RUN_IN_PLACE` should be set, keeping in mind how many people prefer the system-wide install option while manually building from source, which I think is not much. Hence the proposal to enable it by default.

Please do share your opinions and thoughts on this - Are there a lot of people running MT system-wide while building from source?