### PR TITLE
[WIP] Display large screenshot in package dialog

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -205,7 +205,8 @@ function package_dialog.get_formspec()
 	local formspec = {
 		"size[9,4;true]",
 		"label[2.5,0.2;", core.formspec_escape(package.title), "]",
-		"textarea[0.2,1;9,3;;;", core.formspec_escape(package.short_description), "]",
+		"textarea[3.2,1;6,3;;;", core.formspec_escape(package.short_description), "]",
+		"image[0.2,1.6;3,2;", core.formspec_escape(get_screenshot(package)), "]",
 		"button[0,0;2,1;back;", fgettext("Back"), "]",
 	}
 


### PR DESCRIPTION
- Display large screenshot within package dialog. No need for magnifying glasses any more, yay! :)
  - Small issue: If the screenshot hasn't yet loaded when "View" is clicked, `loading_screenshot.png` is displayed. To load the actual screenshot, one has to reopen the package dialog _after_ it has loaded. Should I add a `core.after` to fix this? Assuming yes, this PR is WIP.
- Ideally, I'd also like to list `depends` and `optional_depends` in that dialog too, but that's not as straight-forward, since those fields aren't in the `package` table. Maybe that's for a different PR...

![image](https://user-images.githubusercontent.com/36130650/44578232-bd7d7a80-a7b0-11e8-95c5-87dcb8742ade.png)
