### PR TITLE
Play damage sound on player death

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2492,22 +2492,23 @@ void Game::handleClientEvent_None(ClientEvent *event, CameraOrientation *cam)
 
 void Game::handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation *cam)
 {
-	if (client->getHP() == 0)
-		return;
-
 	if (client->moddingEnabled()) {
 		client->getScript()->on_damage_taken(event->player_damage.amount);
 	}
 
-	runData.damage_flash += 95.0 + 3.2 * event->player_damage.amount;
-	runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
+	// Damage flash and hurt tilt are not used at death
+	if (client->getHP() > 0) {
+		runData.damage_flash += 95.0f + 3.2f * event->player_damage.amount;
+		runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
 
-	LocalPlayer *player = client->getEnv().getLocalPlayer();
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
-	player->hurt_tilt_timer = 1.5;
-	player->hurt_tilt_strength =
-		rangelim(event->player_damage.amount / 4, 1.0f, 4.0f);
+		player->hurt_tilt_timer = 1.5f;
+		player->hurt_tilt_strength =
+			rangelim(event->player_damage.amount / 4.0f, 1.0f, 4.0f);
+	}
 
+	// Play damage sound
 	client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_DAMAGE));
 }
 


### PR DESCRIPTION
 Play damage sound on player death

Also run CSM 'on_damage_taken' callback.
Improve function logic and remove 'return'.
///////////////////

The event `MtEvent::PLAYER_DAMAGE` triggers the damage sound here:
https://github.com/minetest/minetest/blob/9537cfd3f8264700619f58d15741829489e1099e/src/game.cpp#L341
https://github.com/minetest/minetest/blob/9537cfd3f8264700619f58d15741829489e1099e/src/game.cpp#L321
Tested with falling, drowning, lava.