### PR TITLE
Add disable_jump to liquids and ladders

### DIFF
--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -309,7 +309,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 			collision_info->push_back(colinfo);
 
 			if (colinfo.type != COLLISION_NODE ||
-					colinfo.new_speed.Y != 0 ||
+					colinfo.axis != COLLISION_AXIS_Y ||
 					(could_sneak && m_sneak_node_exists))
 				continue;
 
@@ -435,20 +435,15 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Check properties of the node on which the player is standing
 	*/
-	const ContentFeatures &f_under = nodemgr->get(map->getNodeNoEx(m_standing_node));
-	const ContentFeatures &f_above = nodemgr->get(map->getNodeNoEx(
-		floatToInt(m_position + v3f(0, 0.2f * BS, 0), BS)));
+	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(m_standing_node));
 
 	// Determine if jumping is possible
-	m_disable_jump = itemgroup_get(f_under.groups, "disable_jump");
+	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
 	m_can_jump = ((touching_ground && !is_climbing)
 			|| sneak_can_jump) && !m_disable_jump;
 
-	// Disallow swimming upwards
-	m_disable_jump |= itemgroup_get(f_above.groups, "disable_jump");
-
 	// Jump key pressed while jumping off from a bouncy block
-	if (m_can_jump && control.jump && itemgroup_get(f_under.groups, "bouncy") &&
+	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
 		m_speed.Y >= -0.5 * BS) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
 		if (m_speed.Y > 1) {

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -892,6 +892,12 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		pos_max_d, m_collisionbox, player_stepheight, dtime,
 		&position, &m_speed, accel_f);
 
+	// Positition was slightly changed; update standing node pos
+	if (touching_ground)
+		m_standing_node = floatToInt(m_position - v3f(0, 0.1f * BS, 0), BS);
+	else
+		m_standing_node = floatToInt(m_position, BS);
+
 	/*
 		If the player's feet touch the topside of any node, this is
 		set to true.
@@ -1032,20 +1038,15 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Check properties of the node on which the player is standing
 	*/
-	const ContentFeatures &f_under = nodemgr->get(map->getNodeNoEx(
+	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(
 		getStandingNodePos()));
-	const ContentFeatures &f_above = nodemgr->get(map->getNodeNoEx(
-		floatToInt(m_position + v3f(0, 0.2f * BS, 0), BS)));
 
 	// Determine if jumping is possible
-	m_disable_jump = itemgroup_get(f_under.groups, "disable_jump");
+	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
 	m_can_jump = touching_ground && !m_disable_jump;
 
-	// Disallow swimming upwards
-	m_disable_jump |= itemgroup_get(f_above.groups, "disable_jump");
-
 	// Jump key pressed while jumping off from a bouncy block
-	if (m_can_jump && control.jump && itemgroup_get(f_under.groups, "bouncy") &&
+	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
 			m_speed.Y >= -0.5 * BS) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
 		if (m_speed.Y > 1) {

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -182,6 +182,7 @@ private:
 	// ***** End of variables for temporary option *****
 
 	bool m_can_jump = false;
+	bool m_disable_jump = false;
 	u16 m_breath = PLAYER_MAX_BREATH_DEFAULT;
 	f32 m_yaw = 0.0f;
 	f32 m_pitch = 0.0f;

--- a/src/collision.h
+++ b/src/collision.h
@@ -33,11 +33,20 @@ enum CollisionType
 	COLLISION_OBJECT,
 };
 
+enum CollisionAxis
+{
+	COLLISION_AXIS_NONE = -1,
+	COLLISION_AXIS_X,
+	COLLISION_AXIS_Y,
+	COLLISION_AXIS_Z,
+};
+
 struct CollisionInfo
 {
 	CollisionInfo() = default;
 
 	CollisionType type = COLLISION_NODE;
+	CollisionAxis axis = COLLISION_AXIS_NONE;
 	v3s16 node_p = v3s16(-32768,-32768,-32768); // COLLISION_NODE
 	v3f old_speed;
 	v3f new_speed;
@@ -66,7 +75,7 @@ collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
 // Checks for collision of a moving aabbox with a static aabbox
 // Returns -1 if no collision, 0 if X collision, 1 if Y collision, 2 if Z collision
 // dtime receives time until first collision, invalid if -1 is returned
-int axisAlignedCollision(
+CollisionAxis axisAlignedCollision(
 		const aabb3f &staticbox, const aabb3f &movingbox,
 		const v3f &speed, f32 d, f32 *dtime);
 


### PR DESCRIPTION
Implements feature requested in #4494

Jumping is now no longer possible when the group `disable_jump = 1` is set. Jumping at the bottom of liquids may look a bit weird, but is actually because the node below can be used to jump.

**Testing code**
```Lua
-- river water for comparison
core.override_item("default:water_source", {
	groups = {
		disable_jump = 1,
		water = 3, liquid = 3, puts_out_fire = 1, cools_lava = 1
	}
})

core.override_item("default:water_flowing", {
	groups = {
		disable_jump = 1,
		water = 3, liquid = 3, puts_out_fire = 1,
		not_in_creative_inventory = 1, cools_lava = 1
	}
})

core.override_item("default:leaves", {
	groups = {
		disable_jump = 1,
		cracky = 3
	}
})
-- steel ladder for comparison
core.override_item("default:ladder_wood", {
	groups = {
		disable_jump = 1,
		cracky = 3
	}
})
```