### PR TITLE
Fix decode_light_f

### DIFF
--- a/src/light.cpp
+++ b/src/light.cpp
@@ -46,16 +46,20 @@ void set_light_table(float gamma)
 // Gamma correction
 	gamma = rangelim(gamma, 0.5f, 3.0f);
 
-	for (size_t i = 0; i < LIGHT_SUN; i++) {
+// Boundary values should be fixed
+	light_LUT[0] = 0;
+	light_LUT[LIGHT_SUN] = 255;
+
+	for (size_t i = 1; i < LIGHT_SUN; i++) {
 		float x = i;
 		x /= LIGHT_SUN;
 		float brightness = a * x * x * x + b * x * x + c * x;
 		float boost = d * std::exp(-((x - e) * (x - e)) / (2.0f * f * f));
 		brightness = powf(brightness + boost, 1.0f / gamma);
 		light_LUT[i] = rangelim((u32)(255.0f * brightness), 0, 255);
+		// Ensure light brightens with each level
 		if (i > 1 && light_LUT[i] <= light_LUT[i - 1])
 			light_LUT[i] = light_LUT[i - 1] + 1;
 	}
-	light_LUT[LIGHT_SUN] = 255;
 }
 #endif

--- a/src/light.h
+++ b/src/light.h
@@ -65,18 +65,17 @@ inline u8 decode_light(u8 light)
 // 0.0 <= return value <= 1.0
 inline float decode_light_f(float light_f)
 {
-	s32 i = (u32)(light_f * LIGHT_MAX + 0.5);
-
-	if (i <= 0)
-		return (float)light_decode_table[0] / 255.0;
-	if (i >= LIGHT_SUN)
-		return (float)light_decode_table[LIGHT_SUN] / 255.0;
-
-	float v1 = (float)light_decode_table[i - 1] / 255.0;
-	float v2 = (float)light_decode_table[i] / 255.0;
-	float f0 = (float)i - 0.5;
-	float f = light_f * LIGHT_MAX - f0;
-	return f * v2 + (1.0 - f) * v1;
+	light_f *= LIGHT_SUN; // should be [0, LIGHT_SUN]
+	if (light_f <= 0)
+		return 0.0f;
+	if (light_f >= LIGHT_SUN)
+		return 1.0f;
+	u8 index = light_f; // truncate fractional part
+	assert(index < LIGHT_SUN); // index <= light_f < LIGHT_SUN
+	float d = light_f - index;
+	float v1 = light_decode_table[index] / 255.0f;
+	float v2 = light_decode_table[index + 1] / 255.0f;
+	return d * v2 + (1.0f - d) * v1;
 }
 
 void set_light_table(float gamma);


### PR DESCRIPTION
Besides giving wrong values on high light level, it could trigger UB (float-to-integer conversion overflow) if called wrongly.
This PR fixes dark sky (https://github.com/minetest/minetest/issues/7686#issuecomment-417853517).