### PR TITLE
Added minetest.conf flag to enable/disable drowning

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -963,6 +963,9 @@ item_entity_ttl (Item entity TTL) int 900
 #    Enable players getting damage and dying.
 enable_damage (Damage) bool false
 
+#    Enable players to drown.
+enable_drowning bool true
+
 #    Enable creative mode for new created maps.
 creative_mode (Creative) bool false
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -966,7 +966,9 @@ void PlayerSAO::getStaticData(std::string * result) const
 
 void PlayerSAO::step(float dtime, bool send_recommended)
 {
-	if ( g_settings->getBool("enable_drowning") ){
+	static thread_local cache_is_drowning = g_settings->getBool("enable_drowning");
+	
+	if ( cache_is_drowning ){
 		
 	    if (m_drowning_interval.step(dtime, 2.0f)) {
 		    // Get nose/mouth position, approximate with eye position

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -967,7 +967,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 {
 	static thread_local cache_is_drowning = g_settings->getBool("enable_drowning");
 	
-	if ( cache_is_drowning ){
+	if (cache_is_drowning){
 		
 	    if (m_drowning_interval.step(dtime, 2.0f)) {
 		    // Get nose/mouth position, approximate with eye position

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
 Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+(C) 2018 crazyBaboon, nuno360@gmail.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1,6 +1,7 @@
 /*
 Minetest
 Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+(C) 2018 N Ferreira, nuno360@gmail.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -965,33 +966,36 @@ void PlayerSAO::getStaticData(std::string * result) const
 
 void PlayerSAO::step(float dtime, bool send_recommended)
 {
-	if (m_drowning_interval.step(dtime, 2.0f)) {
-		// Get nose/mouth position, approximate with eye position
-		v3s16 p = floatToInt(getEyePosition(), BS);
-		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
-		// If node generates drown
-		if (c.drowning > 0 && m_hp > 0) {
-			if (m_breath > 0)
-				setBreath(m_breath - 1);
+	if ( g_settings->getBool("enable_drowning") ){
+		
+	    if (m_drowning_interval.step(dtime, 2.0f)) {
+		    // Get nose/mouth position, approximate with eye position
+		    v3s16 p = floatToInt(getEyePosition(), BS);
+		    MapNode n = m_env->getMap().getNodeNoEx(p);
+		    const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
+		    // If node generates drown
+		    if (c.drowning > 0 && m_hp > 0) {
+		    	if (m_breath > 0)
+			    	setBreath(m_breath - 1);
 
-			// No more breath, damage player
-			if (m_breath == 0) {
-				PlayerHPChangeReason reason(PlayerHPChangeReason::DROWNING);
-				setHP(m_hp - c.drowning, reason);
-				m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
-			}
-		}
-	}
+			    // No more breath, damage player
+			    if (m_breath == 0) {
+			    	PlayerHPChangeReason reason(PlayerHPChangeReason::DROWNING);
+			    	setHP(m_hp - c.drowning, reason);
+			    	m_env->getGameDef()->SendPlayerHPOrDie(this, reason);
+			    }
+		    }
+	    }
 
-	if (m_breathing_interval.step(dtime, 0.5f)) {
-		// Get nose/mouth position, approximate with eye position
-		v3s16 p = floatToInt(getEyePosition(), BS);
-		MapNode n = m_env->getMap().getNodeNoEx(p);
-		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
-		// If player is alive & no drowning, breathe
-		if (m_hp > 0 && m_breath < m_prop.breath_max && c.drowning == 0)
-			setBreath(m_breath + 1);
+	    if (m_breathing_interval.step(dtime, 0.5f)) {
+	    	// Get nose/mouth position, approximate with eye position
+	    	v3s16 p = floatToInt(getEyePosition(), BS);
+	    	MapNode n = m_env->getMap().getNodeNoEx(p);
+	    	const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
+	    	// If player is alive & no drowning, breathe
+	    	if (m_hp > 0 && m_breath < m_prop.breath_max && c.drowning == 0)
+	    		setBreath(m_breath + 1);
+	    }
 	}
 
 	if (m_node_hurt_interval.step(dtime, 1.0f)) {

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1,7 +1,6 @@
 /*
 Minetest
 Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
-(C) 2018 N Ferreira, nuno360@gmail.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -306,6 +306,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_users", "15");
 	settings->setDefault("creative_mode", "false");
 	settings->setDefault("enable_damage", "true");
+	settings->setDefault("enable_drowning", "true");
 	settings->setDefault("default_password", "");
 	settings->setDefault("default_privs", "interact, shout");
 	settings->setDefault("enable_pvp", "true");


### PR DESCRIPTION
This PR adds a minetest.conf setting "enable_drowning". If in the minetest.conf you write "enable_drowning = false", you won't drown and the oxigen bars will not be shown.

It works by bypassing 20 or so lines of code checks relative to the drowning in **content_sao.cpp**. By not executing this checks, it might decrease the computational load when drowning is off, even if by an insignificant margin.

Drowning is such a fundamental part of the game that I feel like one should be able to control it from minetest.conf, rather than by installing a mod (which is of course ok, but mods by themselves are not part of minetest). The default behaviour should enable drowning. If you want to disable it, add "enable_drowning = false" in the minetest.conf file. I guess it's time for water elevators again ;)