### PR TITLE
Expose min/max_net_proto_version to on_prejoinplayer callbacks

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3635,7 +3635,7 @@ Call these functions only at load time!
     * Called when player is to be respawned
     * Called _before_ repositioning of player occurs
     * return true in func to disable regular player placement
-* `minetest.register_on_prejoinplayer(func(name, ip))`
+* `minetest.register_on_prejoinplayer(func(name, ip, min_net_proto_version, max_net_proto_version))`
     * Called before a player joins the game
     * If it returns a string, the player is disconnected with that string as
       reason.

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -187,7 +187,8 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 
 	{
 		std::string reason;
-		if (m_script->on_prejoinplayer(playername, addr_s, &reason)) {
+		if (m_script->on_prejoinplayer(playername, addr_s,
+				min_net_proto_version, max_net_proto_version, &reason)) {
 			actionstream << "Server: Player with the name \"" << playerName << "\" "
 					<< "tried to connect from " << addr_s << " "
 					<< "but it was disallowed for the following reason: "

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -117,6 +117,8 @@ bool ScriptApiPlayer::on_respawnplayer(ServerActiveObject *player)
 bool ScriptApiPlayer::on_prejoinplayer(
 	const std::string &name,
 	const std::string &ip,
+	const u16 min_net_proto_version,
+	const u16 max_net_proto_version,
 	std::string *reason)
 {
 	SCRIPTAPI_PRECHECKHEADER
@@ -126,7 +128,10 @@ bool ScriptApiPlayer::on_prejoinplayer(
 	lua_getfield(L, -1, "registered_on_prejoinplayers");
 	lua_pushstring(L, name.c_str());
 	lua_pushstring(L, ip.c_str());
-	runCallbacks(2, RUN_CALLBACKS_MODE_OR);
+	lua_pushnumber(L, min_net_proto_version);
+	lua_pushnumber(L, max_net_proto_version);
+
+	runCallbacks(4, RUN_CALLBACKS_MODE_OR);
 	if (lua_isstring(L, -1)) {
 		reason->assign(readParam<std::string>(L, -1));
 		return true;

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -38,6 +38,7 @@ public:
 	void on_dieplayer(ServerActiveObject *player, const PlayerHPChangeReason &reason);
 	bool on_respawnplayer(ServerActiveObject *player);
 	bool on_prejoinplayer(const std::string &name, const std::string &ip,
+			const u16 min_net_proto_version, const u16 max_net_proto_version,
 			std::string *reason);
 	bool can_bypass_userlimit(const std::string &name, const std::string &ip);
 	void on_joinplayer(ServerActiveObject *player);


### PR DESCRIPTION
This could be used by servers, to prevent older clients from connecting for example...

Let's take [playertags]() mod by Elkien3 for example - it allows other players' nametags to be hidden when not in line-of-sight of the player. But when playing on the server with a 0.4.13 client, some very weird glitches can be encountered. This feature can be used to prevent clients older than, let's say 0.4.15, from connecting.

Example:
```lua
minetest.register_on_prejoinplayer(func(name, ip, min_proto_version, max_proto_version)
    if min_proto_version == 32 then
        return "You are using an old version of Minetest. Please download the"
            .. " latest version to be able to play on this server."
    end
end)
```

Tested. Both min and max were 36 while using the latest 5.0.0-dev, so it works. Also note that backwards-compatibility is still retained.
