### PR TITLE
Add test_config.h to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ locale/
 *.ninja
 .ninja*
 *.gch
+test_config.h
 cmake-build-debug/
 cmake-build-release/
 cmake_config.h


### PR DESCRIPTION
**Very** trivial. Prevents git from tracking `test_config.h` which is a ~useless~ file generated when building from source.