### PR TITLE
Inv deSerialize(): Prevent infinite loop, error on failure

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -436,8 +436,7 @@ void InventoryList::deSerialize(std::istream &is)
 	u32 item_i = 0;
 	m_width = 0;
 
-	for(;;)
-	{
+	while (is.good()) {
 		std::string line;
 		std::getline(is, line, '\n');
 
@@ -447,14 +446,12 @@ void InventoryList::deSerialize(std::istream &is)
 		std::string name;
 		std::getline(iss, name, ' ');
 
-		if (name == "EndInventoryList") {
-			break;
-		}
+		if (name == "EndInventoryList")
+			return;
 
 		// This is a temporary backwards compatibility fix
-		if (name == "end") {
-			break;
-		}
+		if (name == "end")
+			return;
 
 		if (name == "Width") {
 			iss >> m_width;
@@ -476,6 +473,14 @@ void InventoryList::deSerialize(std::istream &is)
 			m_items[item_i++].clear();
 		}
 	}
+
+	// Contents given to deSerialize() were not terminated properly: throw error.
+
+	std::ostringstream ss;
+	ss << "Malformatted inventory list. list="
+		<< m_name << ", read " << item_i << " of " << getSize()
+		<< " ItemStacks." << std::endl;
+	throw SerializationError(ss.str());
 }
 
 InventoryList::InventoryList(const InventoryList &other)
@@ -859,8 +864,7 @@ void Inventory::deSerialize(std::istream &is)
 {
 	clear();
 
-	for(;;)
-	{
+	while (is.good()) {
 		std::string line;
 		std::getline(is, line, '\n');
 
@@ -869,14 +873,12 @@ void Inventory::deSerialize(std::istream &is)
 		std::string name;
 		std::getline(iss, name, ' ');
 
-		if (name == "EndInventory") {
-			break;
-		}
+		if (name == "EndInventory")
+			return;
 
 		// This is a temporary backwards compatibility fix
-		if (name == "end") {
-			break;
-		}
+		if (name == "end")
+			return;
 
 		if (name == "List") {
 			std::string listname;
@@ -895,6 +897,13 @@ void Inventory::deSerialize(std::istream &is)
 			throw SerializationError("invalid inventory specifier: " + name);
 		}
 	}
+
+	// Contents given to deSerialize() were not terminated properly: throw error.
+
+	std::ostringstream ss;
+	ss << "Malformatted inventory (damaged?). "
+		<< m_lists.size() << " lists read." << std::endl;
+	throw SerializationError(ss.str());
 }
 
 InventoryList * Inventory::addList(const std::string &name, u32 size)

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -139,7 +139,12 @@ void RemotePlayer::deSerialize(std::istream &is, const std::string &playername,
 		} catch (SettingNotFoundException &e) {}
 	}
 
-	inventory.deSerialize(is);
+	try {
+		inventory.deSerialize(is);
+	} catch (SerializationError &e) {
+		errorstream << "Failed to deserialize player inventory. player_name="
+			<< name << " " << e.what() << std::endl;
+	}
 
 	if (!inventory.getList("craftpreview") && inventory.getList("craftresult")) {
 		// Convert players without craftpreview


### PR DESCRIPTION
Throws an error about potentially damaged player inventories but proceeds converting the rest of them

Potential fix for #7701
Thanks to @t0ny2 to [point out](https://github.com/minetest/minetest/issues/7701#issuecomment-418510930) the deserialize infinite loop.

Example gdb/terminal output:
```
Starting program: <minetest> --server --migrate-players sqlite3 --world <worldname>
<irrelevant>
2018-09-07 20:06:52: ERROR[Main]: Failed to deserialize player inventory. player_name=fake Malformatted inventory list. list=craft, read 3 of 9 ItemStacks.
2018-09-07 20:06:52: ACTION[Main]: Migrating player singleplayer
2018-09-07 20:06:52: ACTION[Main]: Migrating player dummy
2018-09-07 20:06:52: ACTION[Main]: Migrating player root
2018-09-07 20:06:52: ACTION[Main]: Migrating player fake
2018-09-07 20:06:52: ERROR[Main]: Failed to deserialize player inventory. player_name=fake Malformatted inventory list. list=craft, read 3 of 9 ItemStacks.
2018-09-07 20:06:53: ACTION[Main]: Migrating player k
2018-09-07 20:06:53: ACTION[Main]: Migrating player Krock
2018-09-07 20:06:53: ACTION[Main]: Successfully migrated 6 players
2018-09-07 20:06:53: ACTION[Main]: world.mt updated
[Inferior 1 (process 3979) exited normally]
```

**Testing instructions**
1) Just chop some lines of a player file so it looks like this:
```
extended_attributes = {"test_attribute":"test_me"}
breath = 11
yaw = 106.14
pitch = 70.86
version = 1
name = fake
hp = 20
position = (-48.79,94,-47.18)
PlayerArgsEnd
List main 32
Width 0
Item default:pick_stone
Item default:torch 99
Item default:cobble 99
Item default:wood 99
Item default:axe_steel
Item default:shovel_steel
Item default:pick_wood
Item default:pick_steel
Item default:pick_mese
Item default:mese 99
Item default:water_source 99
Item experimental:tester_tool_1
Empty
Empty
Empty
```