### PR TITLE
Dig particles: Use gravity setting and physics override. More velocity to be more visible. More lightweight

### DIFF
--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -617,25 +617,26 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	else
 		texture = tile.texture;
 
-	float size = rand() % 64 / 512.;
+	float size = (rand() % 64) / 512.0f;
 	float visual_size = BS * size;
 	if (tile.scale)
 		size /= tile.scale;
-	v2f texsize(size * 2, size * 2);
+	v2f texsize(size * 2.0f, size * 2.0f);
 	v2f texpos;
-	texpos.X = ((rand() % 64) / 64. - texsize.X);
-	texpos.Y = ((rand() % 64) / 64. - texsize.Y);
+	texpos.X = (rand() % 64) / 64.0f - texsize.X;
+	texpos.Y = (rand() % 64) / 64.0f - texsize.Y;
 
 	// Physics
-	v3f velocity((rand() % 100 / 50. - 1) / 1.5,
-			rand() % 100 / 35.,
-			(rand() % 100 / 50. - 1) / 1.5);
-
-	v3f acceleration(0,-9,0);
+	v3f velocity(
+		((rand() % 100) / 50.0f - 1.0f) / 1.5f,
+		(rand() % 100) / 35.0f,
+		((rand() % 100) / 50.0f - 1.0f) / 1.5f
+	);
+	v3f acceleration(0.0f, -player->movement_gravity / BS, 0.0f);
 	v3f particlepos = v3f(
-		(f32) pos.X + rand() %100 /200. - 0.25,
-		(f32) pos.Y + rand() %100 /200. - 0.25,
-		(f32) pos.Z + rand() %100 /200. - 0.25
+		(f32)pos.X + (rand() % 100) / 200.0f - 0.25f,
+		(f32)pos.Y + (rand() % 100) / 200.0f - 0.25f,
+		(f32)pos.Z + (rand() % 100) / 200.0f - 0.25f
 	);
 
 	video::SColor color;
@@ -651,7 +652,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 		particlepos,
 		velocity,
 		acceleration,
-		rand() % 100 / 100., // expiration time
+		(rand() % 100) / 100.0f, // expiration time
 		visual_size,
 		true,
 		false,

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -584,6 +584,9 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 	}
 }
 
+// The final burst of particles when a node is finally dug, *not* particles
+// spawned during the digging of a node.
+
 void ParticleManager::addDiggingParticles(IGameDef* gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
 {
@@ -591,11 +594,13 @@ void ParticleManager::addDiggingParticles(IGameDef* gamedef,
 	if (f.drawtype == NDT_AIRLIKE)
 		return;
 
-	// set the amount of particles here
 	for (u16 j = 0; j < 16; j++) {
 		addNodeParticle(gamedef, player, pos, n, f);
 	}
 }
+
+// During the digging of a node particles are spawned individually by this
+// function, called from Game::handleDigging() in game.cpp.
 
 void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
@@ -632,7 +637,11 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 		(rand() % 150) / 50.0f,
 		(rand() % 150) / 50.0f - 1.5f
 	);
-	v3f acceleration(0.0f, -player->movement_gravity / BS, 0.0f);
+	v3f acceleration(
+		0.0f,
+		-player->movement_gravity * player->physics_override_gravity / BS,
+		0.0f
+	);
 	v3f particlepos = v3f(
 		(f32)pos.X + (rand() % 100) / 200.0f - 0.25f,
 		(f32)pos.Y + (rand() % 100) / 200.0f - 0.25f,

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -592,7 +592,7 @@ void ParticleManager::addDiggingParticles(IGameDef* gamedef,
 		return;
 
 	// set the amount of particles here
-	for (u16 j = 0; j < 32; j++) {
+	for (u16 j = 0; j < 16; j++) {
 		addNodeParticle(gamedef, player, pos, n, f);
 	}
 }
@@ -617,7 +617,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	else
 		texture = tile.texture;
 
-	float size = (rand() % 64) / 512.0f;
+	float size = (rand() % 8) / 64.0f;
 	float visual_size = BS * size;
 	if (tile.scale)
 		size /= tile.scale;
@@ -628,9 +628,9 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 
 	// Physics
 	v3f velocity(
-		((rand() % 100) / 50.0f - 1.0f) / 1.5f,
-		(rand() % 100) / 35.0f,
-		((rand() % 100) / 50.0f - 1.0f) / 1.5f
+		(rand() % 150) / 50.0f - 1.5f,
+		(rand() % 150) / 50.0f,
+		(rand() % 150) / 50.0f - 1.5f
 	);
 	v3f acceleration(0.0f, -player->movement_gravity / BS, 0.0f);
 	v3f particlepos = v3f(


### PR DESCRIPTION
Commit 1: Dig particles: Improve codestyle, use movement_gravity setting.
------------------

Particle gravity uses the global setting, by default 9.81 instead of a hardcoded and inaccurate 9.

Commit 2: Halve particles in final burst when node dug. No tiny particles. More velocity to be more visible
--------------------

I noticed that 32 particles were spawned in the final burst when a node is dug. Because particles are intensive on the client FPS, 32 is a significant load that is occuring very often (players dig a lot) for a very basic reason, this is before any other additional particles are taken into account.

When digging a node, only a few dig particles are seen and they don't move much. I realised this is because of the low velocity they are given when spawned near the centre of the node, so most particles never pass out of the node cube to be visible.
I increased the particle velocity, now they are far more are visible outside the node cube.

The particle sizes used to range down to 1/64th of full size, but this makes some particles extremely tiny and is an unnecessary range. I changed this so the minimum size is 1/8th of full size, still small but all particles are now visible, without any visually noticeable change in size range.

Commit 3: Apply gravity physics override. Add clarifying comments.
----------------------