### PR TITLE
document which formspec fields are sent

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3663,11 +3663,11 @@ Call these functions only at load time!
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
 * `minetest.register_on_player_receive_fields(func(player, formname, fields))`
-    * Called when a button is pressed in player's inventory form, or when the
-      form is closed by the player's keypress
+    * Called when a button is pressed in player's inventory form, when form
+      values are submitted or when the form is actively closed by the player.
     * Fields are sent for formspec elements which define a field, and the "quit"
-      field is sent when closing the form by keypress or through a
-      button_exit[] element.
+      field is sent when actively closing the form by mouse click, keypress or
+      through a button_exit[] element.
     * Newest functions are called first
     * If function returns `true`, remaining functions are not called
 * `minetest.register_on_craft(func(itemstack, player, old_craft_grid, craft_inv))`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3663,7 +3663,10 @@ Call these functions only at load time!
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
 * `minetest.register_on_player_receive_fields(func(player, formname, fields))`
-    * Called when a button is pressed in player's inventory form
+    * Called when a button is pressed in player's inventory form, or when the
+      form is closed by the player's keypress
+    * Fields are sent for formspec elements which define a field, and the "quit"
+      field is sent when closing the form by keypress.
     * Newest functions are called first
     * If function returns `true`, remaining functions are not called
 * `minetest.register_on_craft(func(itemstack, player, old_craft_grid, craft_inv))`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3666,7 +3666,8 @@ Call these functions only at load time!
     * Called when a button is pressed in player's inventory form, or when the
       form is closed by the player's keypress
     * Fields are sent for formspec elements which define a field, and the "quit"
-      field is sent when closing the form by keypress.
+      field is sent when closing the form by keypress or through a
+      button_exit[] element.
     * Newest functions are called first
     * If function returns `true`, remaining functions are not called
 * `minetest.register_on_craft(func(itemstack, player, old_craft_grid, craft_inv))`


### PR DESCRIPTION
There seems to be no documentation so far which makes it clear what is sent when a formspec is closed through the keyboard.