### PR TITLE
Add sounds for falling and attached nodes

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -141,6 +141,11 @@ local function convert_to_falling_node(pos, node)
 	local meta = core.get_meta(pos)
 	local metatable = meta and meta:to_table() or {}
 
+	local def = core.registered_nodes[node.name]
+	if def and def.sounds and def.sounds.fall and def.sounds.fall.name then
+		core.sound_play(def.sounds.fall, {pos = pos})
+	end
+
 	obj:get_luaentity():set_node(node, metatable)
 	core.remove_node(pos)
 	return true
@@ -169,6 +174,9 @@ local function drop_attached_node(p)
 		end
 		drops = drop_stacks
 		def.preserve_metadata(pos_copy, node_copy, oldmeta, drops)
+	end
+	if def and def.sounds and def.sounds.fall and def.sounds.fall.name then
+		core.sound_play(def.sounds.fall, {pos = p})
 	end
 	core.remove_node(p)
 	for _, item in pairs(drops) do

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -116,7 +116,7 @@ core.register_entity(":__builtin:falling_node", {
 					local meta = core.get_meta(np)
 					meta:from_table(self.meta)
 				end
-				if def.sounds and def.sounds.place and def.sounds.place.name then
+				if def.sounds and def.sounds.place then
 					core.sound_play(def.sounds.place, {pos = np})
 				end
 			end
@@ -142,7 +142,7 @@ local function convert_to_falling_node(pos, node)
 	local metatable = meta and meta:to_table() or {}
 
 	local def = core.registered_nodes[node.name]
-	if def and def.sounds and def.sounds.fall and def.sounds.fall.name then
+	if def and def.sounds and def.sounds.fall then
 		core.sound_play(def.sounds.fall, {pos = pos})
 	end
 
@@ -175,7 +175,7 @@ local function drop_attached_node(p)
 		drops = drop_stacks
 		def.preserve_metadata(pos_copy, node_copy, oldmeta, drops)
 	end
-	if def and def.sounds and def.sounds.fall and def.sounds.fall.name then
+	if def and def.sounds and def.sounds.fall then
 		core.sound_play(def.sounds.fall, {pos = p})
 	end
 	core.remove_node(p)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5988,6 +5988,7 @@ Used by `minetest.register_node`.
             dug = <SimpleSoundSpec>,
             place = <SimpleSoundSpec>,
             place_failed = <SimpleSoundSpec>,
+            fall = <SimpleSoundSpec>,
         },
 
         drop = "",


### PR DESCRIPTION
As requested in #6355.

The sound specified in `node_definition.sounds.fall` is used.
When a falling node is spawned at a position or an attached node drops, the sound is played at this position.

I've tested this with `default:sand` and `default:torch` by adding in `minetest_game/mods/default/functions.lua` to `default.node_sound_defaults` the lines:
```lua
	table.fall = table.fall or
			{name = "default_break_glass", gain = 1.0}
```