### PR TITLE
Fix "Hunk #1 FAILED at 9 (different line endings)."

### DIFF
--- a/build/android/patches/irrlicht-native_activity.patch
+++ b/build/android/patches/irrlicht-native_activity.patch
@@ -1,5 +1,5 @@
---- irrlicht/source/Irrlicht/CEGLManager.cpp.orig	2018-06-10 16:58:11.357709173 +0200
-+++ irrlicht/source/Irrlicht/CEGLManager.cpp	2018-06-10 16:58:25.100709843 +0200
+--- irrlicht/source/Irrlicht/CEGLManager.cpp.orig	2018-09-11 18:19:51.453403631 +0300
++++ irrlicht/source/Irrlicht/CEGLManager.cpp	2018-09-11 18:36:24.603471869 +0300
 @@ -9,6 +9,10 @@
  #include "irrString.h"
  #include "os.h"


### PR DESCRIPTION
Added carriage return character in all strings. This will fix irrlicht patching on Linux platform.