### PR TITLE
Spatial Vectors: Add vector.angle(a, b)

### DIFF
--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -70,6 +70,15 @@ function vector.direction(pos1, pos2)
 	})
 end
 
+function vector.angle(a, b)
+	local dotp = a.x * b.x + a.y * b.y + a.z * b.z
+	local cpx = a.y * b.z - a.z * b.y
+	local cpy = a.z * b.x - a.x * b.z
+	local cpz = a.x * b.y - a.y * b.x
+	local crossplen = math.sqrt(cpx ^ 2 + cpy ^ 2 + cpz ^ 2)
+	return math.atan2(crossplen, dotp)
+end
+
 function vector.add(a, b)
 	if type(b) == "table" then
 		return {x = a.x + b.x,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2341,6 +2341,8 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns a boolean, `true` if the vectors are identical.
 * `vector.sort(v1, v2)`:
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
+* `vector.angle(v1, v2)`:
+    * Returns the angle between `v1` and `v2` in radians.
 
 For the following functions `x` can be either a vector or a number:
 


### PR DESCRIPTION
- Added new spatial vectors helper function `vector.angle(a, b)`
  - where `a` and `b` are vectors
  - returns angular difference between `a` and `b` in radians.

Test code:
```lua
local dir1
minetest.register_chatcommand("dir1", {
	func = function(name, param)
		dir1 = minetest.get_player_by_name(name):get_look_dir()
	end
})

local dir2
minetest.register_chatcommand("dir2", {
	func = function(name, param)
		dir2 = minetest.get_player_by_name(name):get_look_dir()
	end
})

minetest.register_chatcommand("angle", {
	func = function(name, param)
		minetest.chat_send_player(name, math.deg(vector.angle(dir1, dir2)))
	end
})
```

closes #7736 