### PR TITLE
Ease selection of entities behind nodes

### DIFF
--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -28,12 +28,22 @@ bool RaycastSort::operator() (const PointedThing &pt1,
 	// "nothing" can not be sorted
 	assert(pt1.type != POINTEDTHING_NOTHING);
 	assert(pt2.type != POINTEDTHING_NOTHING);
+	f32 pt1_dist = pt1.distanceSq;
+
+	// Add some bonus when one of them is an object
+	if (pt1.type != pt2.type) {
+		if (pt1.type == POINTEDTHING_OBJECT)
+			pt1_dist -= BS * BS;
+		else if (pt2.type == POINTEDTHING_OBJECT)
+			pt1_dist += BS * BS;
+	}
+
 	// returns false if pt1 is nearer than pt2
-	if (pt1.distanceSq < pt2.distanceSq) {
+	if (pt1_dist < pt2.distanceSq) {
 		return false;
 	}
 
-	if (pt1.distanceSq == pt2.distanceSq) {
+	if (pt1_dist == pt2.distanceSq) {
 		// Sort them to allow only one order
 		if (pt1.type == POINTEDTHING_OBJECT)
 			return (pt2.type == POINTEDTHING_OBJECT


### PR DESCRIPTION
Applies non-linear magical numbers to prioritize entity selection boxes over node boxes the closer you walk towards them. This approach is the simplest (but not algebraic correct) approach to ease selection of entities behind other selection boxes.

Fixes #5483

When you point at an entity, a modified squared distance is taken to sort the Raycast `PointedThing` queue.