### PR TITLE
Fix various code issues highlighted by cppcheck

### DIFF
--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -846,7 +846,7 @@ void ICraftAction::apply(InventoryManager *mgr,
 			count_remaining--;
 
 		// Get next crafting result
-		found = getCraftingResult(inv_craft, crafted, temp, false, gamedef);
+		getCraftingResult(inv_craft, crafted, temp, false, gamedef);
 		PLAYER_TO_SA(player)->item_CraftPredict(crafted, player, list_craft, craft_inv);
 		found = !crafted.empty();
 	}

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -64,7 +64,7 @@ struct DungeonParams {
 
 class DungeonGen {
 public:
-	MMVManip *vm;
+	MMVManip *vm = nullptr;
 	const NodeDefManager *ndef;
 	GenerateNotifier *gennotify;
 

--- a/src/mapgen/mapgen_singlenode.cpp
+++ b/src/mapgen/mapgen_singlenode.cpp
@@ -33,8 +33,6 @@ MapgenSinglenode::MapgenSinglenode(int mapgenid,
 	MapgenParams *params, EmergeManager *emerge)
 	: Mapgen(mapgenid, params, emerge)
 {
-	flags = params->flags;
-
 	const NodeDefManager *ndef = emerge->ndef;
 
 	c_node = ndef->getId("mapgen_singlenode");

--- a/src/mapgen/mapgen_singlenode.h
+++ b/src/mapgen/mapgen_singlenode.h
@@ -35,7 +35,6 @@ struct MapgenSinglenodeParams : public MapgenParams
 class MapgenSinglenode : public Mapgen
 {
 public:
-	u32 flags;
 	content_t c_node;
 	u8 set_light;
 


### PR DESCRIPTION
For parts of #6808 
////////////////
* `[src/mapgen/mapgen_singlenode.h:38] -> [src/mapgen/mapgen.h:168]:` (warning) The class 'MapgenSinglenode' defines member variable with name 'flags' also defined in its parent class 'Mapgen'.

In core mapgens 'flags' is a 'class Mapgen' member and should not be a 'class MapgenSInglenode' member set to singlenode params, where it actually does not exist. Removed.
///////////////////
* `[src/mapgen/dungeongen.cpp:39]:` (warning) Member variable 'DungeonGen::vm' is not initialized in the constructor.

Initialised to 'nullptr' in header file.
///////////////
* `[src/inventorymanager.cpp:802] -> [src/inventorymanager.cpp:804]:` (style) Variable 'found' is reassigned a value before the old one has been used.`

https://github.com/minetest/minetest/blob/785f68ef3366e93c17f190535ba5604896fcf21c/src/inventorymanager.cpp#L849
Seems obviously wrong comparing with the similar 3 lines above:
https://github.com/minetest/minetest/blob/785f68ef3366e93c17f190535ba5604896fcf21c/src/inventorymanager.cpp#L809
So removed 'found = '.
/////////////////

MT seems to run ok with these done.