### PR TITLE
Night clouds: Boost brightness for a moonlit appearence

### DIFF
--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -730,6 +730,10 @@ void Sky::update(float time_of_day, float time_brightness,
 		} else {
 			cloud_direct_brightness = std::fmin(m_horizon_blend() * 0.15f +
 				m_time_brightness, 1.0f);
+			// Set the same minimum cloud brightness at night
+			if (time_brightness < 0.5f)
+				cloud_direct_brightness = std::fmax(cloud_direct_brightness,
+					time_brightness * 1.3f);
 		}
 	} else {
 		cloud_direct_brightness = direct_brightness;

--- a/src/sky.cpp
+++ b/src/sky.cpp
@@ -720,15 +720,16 @@ void Sky::update(float time_of_day, float time_brightness,
 		m_skycolor = m_mix_scolor(m_skycolor, pointcolor, m_horizon_blend() * 0.25);
 	}
 
-	float cloud_direct_brightness = 0;
+	float cloud_direct_brightness = 0.0f;
 	if (sunlight_seen) {
 		if (!m_directional_colored_fog) {
 			cloud_direct_brightness = time_brightness;
-			if (time_brightness >= 0.2 && time_brightness < 0.7)
-				cloud_direct_brightness *= 1.3;
+			// Boost cloud brightness relative to sky, at dawn, dusk and at night
+			if (time_brightness < 0.7f)
+				cloud_direct_brightness *= 1.3f;
 		} else {
-			cloud_direct_brightness = MYMIN(m_horizon_blend() * 0.15 +
-				m_time_brightness, 1);
+			cloud_direct_brightness = std::fmin(m_horizon_blend() * 0.15f +
+				m_time_brightness, 1.0f);
 		}
 	} else {
 		cloud_direct_brightness = direct_brightness;


### PR DESCRIPTION
Previously, night clouds were almost indistinguishable from night sky,
especially since a recent commit that made night sky brighter.
They were lacking the beautiful luminosity caused by being lit by the
permanently-full moon.

Simply allow the 'dawn/dusk cloud brightness boost' to apply at night
too.
//////////////////

Screenshots at midnight with  'directional_colored_fog = false'.

![screenshot_20180926_003720](https://user-images.githubusercontent.com/3686677/46049881-e59e2780-c128-11e8-99f3-1280682119af.png)

^ PR

![screenshot_20180926_003458](https://user-images.githubusercontent.com/3686677/46049887-ec2c9f00-c128-11e8-883a-c49ac811ad49.png)

^ Master

WIP: Need to also apply this when 'directional_colored_fog = true'

This 1st commit also states float literals properly and uses `std::fmin()`.
There was already a boost for cloud brightness relative to sky during dawn and dusk, this commit simply allows that boost to continue throughout the night.