### PR TITLE
Fix temporary path crash in TestAuthDatabase

### DIFF
--- a/src/unittest/test_authdatabase.cpp
+++ b/src/unittest/test_authdatabase.cpp
@@ -90,10 +90,7 @@ private:
 class TestAuthDatabase : public TestBase
 {
 public:
-	TestAuthDatabase()
-	{
-		TestManager::registerTestModule(this);
-	}
+	TestAuthDatabase() { TestManager::registerTestModule(this); }
 	const char *getName() { return "TestAuthDatabase"; }
 
 	void runTests(IGameDef *gamedef);

--- a/src/unittest/test_authdatabase.cpp
+++ b/src/unittest/test_authdatabase.cpp
@@ -93,8 +93,6 @@ public:
 	TestAuthDatabase()
 	{
 		TestManager::registerTestModule(this);
-		// fixed directory, for persistence
-		test_dir = getTestTempDirectory();
 	}
 	const char *getName() { return "TestAuthDatabase"; }
 
@@ -112,7 +110,6 @@ public:
 	void testDelete();
 
 private:
-	std::string test_dir;
 	AuthDatabaseProvider *auth_provider;
 };
 
@@ -120,6 +117,9 @@ static TestAuthDatabase g_test_instance;
 
 void TestAuthDatabase::runTests(IGameDef *gamedef)
 {
+	// fixed directory, for persistence
+	thread_local const std::string test_dir = getTestTempDirectory();
+
 	// Each set of tests is run twice for each database type:
 	// one where we reuse the same AuthDatabase object (to test local caching),
 	// and one where we create a new AuthDatabase object for each call


### PR DESCRIPTION
The constructor of TestAuthDatabase was called immediately, so that the settings weren't initialized properly yet.

@stujones11 

Tested on Linux by creating a `TMPFolder` default setting and using that in `fileysy.cpp, TempPath()`.

Fixes #7672