### PR TITLE
Fix mgValleys getSpawnLevelAtPoint()

### DIFF
--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -395,7 +395,6 @@ float MapgenValleys::adjustedTerrainLevelFromNoise(TerrainNoise *tn)
 	float mount = terrainLevelFromNoise(tn);
 	float result = mount;
 	s16 y_start = myround(mount);
-
 	float fill =
 		NoisePerlin3D(&noise_inter_valley_fill->np, tn->x, y_start, tn->z, seed);
 	bool is_ground = fill * *tn->slope >= y_start - mount;
@@ -408,8 +407,10 @@ float MapgenValleys::adjustedTerrainLevelFromNoise(TerrainNoise *tn)
 
 		bool was_ground = is_ground;
 		is_ground = fill * *tn->slope >= y - mount;
-		if (is_ground) result = y;
-		if (is_ground != was_ground) break;
+		if (is_ground)
+			result = y;
+		if (is_ground != was_ground)
+			break;
 	}
 
 	return result;
@@ -428,7 +429,8 @@ int MapgenValleys::getSpawnLevelAtPoint(v2s16 p)
 			level_at_point > water_level + 16)
 		return MAX_MAP_GENERATION_LIMIT;  // Unsuitable spawn point
 
-	return level_at_point;
+	// +1 to account for biome dust that can be 1 node deep
+	return level_at_point + 1; 
 }
 
 


### PR DESCRIPTION
adjustedTerrainLevelFromNoise() will only add the effect of inter_valley_fill 3D noise when the noise is raising the terrain height, but sometimes the noise lowers the terrain height, and this can lower it below sea-level.

For example, on seed 1, calling `minetest.get_spawn_level(-1400, 520)` in Lua returns 4, but this location is ocean:
![screenshot_20180929_160903](https://user-images.githubusercontent.com/6390507/46241817-811de980-c402-11e8-806c-f9c74d20caf9.jpg)

The code in this pull request is a C++ port of the fix made in Amidst, which had the results shown below, but I have not tested *or even compiled* this C++ code as I don't have a Minetest build environment set up (yay for Travis CI!).

![mgvalleys fix](https://user-images.githubusercontent.com/6390507/46241846-20db7780-c403-11e8-8cf7-452883588998.png)

(note I've assumed the terrain generation is authoritative, if the mgValleys author only intended 3D noise to raise the terrain height, then adjustedTerrainLevelFromNoise() might be correct and the terrain generation might be wrong)