### PR TITLE
Add setting to filter non-free packages

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -285,6 +285,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("font_size", font_size_str);
 	settings->setDefault("mono_font_size", font_size_str);
 	settings->setDefault("contentdb_url", "https://content.minetest.net");
+	settings->setDefault("show_nonfree_packages", "false");
 
 
 	// Server

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -993,10 +993,12 @@ int ModApiMainMenu::l_get_screen_info(lua_State *L)
 
 int ModApiMainMenu::l_get_package_list(lua_State *L)
 {
-	std::string url = g_settings->get("contentdb_url");
+	std::string url   = g_settings->get("contentdb_url");
+	bool show_nonfree = g_settings->getBool("show_nonfree_packages");
 	std::vector<Package> packages = getPackagesFromURL(url +
 			"/api/packages/?type=mod&type=game&type=txp&protocol_version="
-			LATEST_PROTOCOL_VERSION_STRING);
+			LATEST_PROTOCOL_VERSION_STRING "&nonfree=" +
+			(show_nonfree ? "true" : "false"));
 
 	// Make table
 	lua_newtable(L);


### PR DESCRIPTION
Defaulting to hiding in order to help with Debian/etc distribution.
This could be changed at a later date.

Fixes #7640