### PR TITLE
Add release information to appdata file

### DIFF
--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -55,4 +55,7 @@
 	</provides>
 	<translation type="gettext">minetest</translation>
 	<update_contact>sfan5@live.de</update_contact>
+	<releases>
+    		<release date="2018-06-10" version="0.4.17.1"/>
+  	</releases>
 </component>

--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -56,6 +56,6 @@
 	<translation type="gettext">minetest</translation>
 	<update_contact>sfan5@live.de</update_contact>
 	<releases>
-    		<release date="2018-06-10" version="0.4.17.1"/>
-  	</releases>
+		<release date="2018-06-10" version="0.4.17.1"/>
+	</releases>
 </component>

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -17,12 +17,15 @@ prompt_for_number() {
 # On a release the following actions are performed
 # * DEVELOPMENT_BUILD is set to false
 # * android versionCode is bumped
+# * appdata release version is bumped
 # * Commit the changes
 # * Tag with current version
 perform_release() {
 	sed -i -re "s/^set\(DEVELOPMENT_BUILD TRUE\)$/set(DEVELOPMENT_BUILD FALSE)/" CMakeLists.txt
 
 	sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle
+
+	sed -i 's/\(version\)="[^"]*"/\1="'"$RELEASE_VERSION"'"/' misc/net.minetest.minetest.appdata.xml
 
 	git add -f CMakeLists.txt build/android/build.gradle
 
@@ -128,4 +131,3 @@ echo "New version: $NEXT_VERSION"
 ########################
 
 back_to_devel
-

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -25,7 +25,7 @@ perform_release() {
 
 	sed -i -re "s/versionCode [0-9]+$/versionCode $NEW_ANDROID_VERSION_CODE/" build/android/build.gradle
 
-	sed -i 's/\(version\)="[^"]*"/\1="'"$RELEASE_VERSION"'"/' misc/net.minetest.minetest.appdata.xml
+	sed -i '/\<release/s/\(version\)="[^"]*"/\1="'"$RELEASE_VERSION"'"/' misc/net.minetest.minetest.appdata.xml
 
 	RELEASE_DATE=`date +%Y-%m-%d`
 

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -17,7 +17,7 @@ prompt_for_number() {
 # On a release the following actions are performed
 # * DEVELOPMENT_BUILD is set to false
 # * android versionCode is bumped
-# * appdata release version is bumped
+# * appdata release version and date are updated
 # * Commit the changes
 # * Tag with current version
 perform_release() {
@@ -27,7 +27,11 @@ perform_release() {
 
 	sed -i 's/\(version\)="[^"]*"/\1="'"$RELEASE_VERSION"'"/' misc/net.minetest.minetest.appdata.xml
 
-	git add -f CMakeLists.txt build/android/build.gradle
+	RELEASE_DATE=`date +%Y-%m-%d`
+
+	sed -i 's/\(<release date\)="[^"]*"/\1="'"$RELEASE_DATE"'"/' misc/net.minetest.minetest.appdata.xml
+
+	git add -f CMakeLists.txt build/android/build.gradle misc/net.minetest.minetest.appdata.xml
 
 	git commit -m "Bump version to $RELEASE_VERSION"
 


### PR DESCRIPTION
This enables users installing minetest through software "stores" such as kde discover or gnome software to see which version they are installing or upgrading to.