### PR TITLE
Advanced settings menu: Centre setting edit box

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -704,7 +704,7 @@ local function create_change_setting_formspec(dialogdata)
 				text = dialogdata.entered_text
 			end
 		end
-		formspec = formspec .. "field[0.5,4;" .. width .. ",1;te_setting_value;;"
+		formspec = formspec .. "field[0.28,4;" .. width .. ",1;te_setting_value;;"
 				.. core.formspec_escape(text) .. "]"
 	end
 	return formspec


### PR DESCRIPTION
![screenshot from 2018-10-11 04-57-20](https://user-images.githubusercontent.com/3686677/46780112-ec28c380-cd12-11e8-9d07-8ebbe538fdf5.png)

^ PR

Box remains the same length but is shifted leftwards to centre it.
Previously:

![screenshot from 2018-10-11 03-13-01](https://user-images.githubusercontent.com/3686677/46776484-b6301300-cd03-11e8-98ca-0eda27dde535.png)
