### PR TITLE
Advanced settings tree menu: Resize, fix clipped values

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -855,13 +855,13 @@ local function handle_change_setting_buttons(this, fields)
 end
 
 local function create_settings_formspec(tabview, name, tabdata)
-	local formspec = "size[12,6.5;true]" ..
-			"tablecolumns[color;tree;text,width=32;text]" ..
+	local formspec = "size[12,5.4;true]" ..
+			"tablecolumns[color;tree;text,width=28;text]" ..
 			"tableoptions[background=#00000000;border=false]" ..
 			"field[0.3,0.1;10.2,1;search_string;;" .. core.formspec_escape(search_string) .. "]" ..
 			"field_close_on_enter[search_string;false]" ..
 			"button[10.2,-0.2;2,1;search;" .. fgettext("Search") .. "]" ..
-			"table[0,0.8;12,4.5;list_settings;"
+			"table[0,0.8;12,3.5;list_settings;"
 
 	local current_level = 0
 	for _, entry in ipairs(settings) do
@@ -903,10 +903,10 @@ local function create_settings_formspec(tabview, name, tabdata)
 		formspec = formspec:sub(1, -2) -- remove trailing comma
 	end
 	formspec = formspec .. ";" .. selected_setting .. "]" ..
-			"button[0,6;4,1;btn_back;".. fgettext("< Back to Settings page") .. "]" ..
-			"button[10,6;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
-			"button[7,6;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
-			"checkbox[0,5.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
+			"button[0,4.9;4,1;btn_back;".. fgettext("< Back to Settings page") .. "]" ..
+			"button[10,4.9;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
+			"button[7,4.9;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
+			"checkbox[0,4.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
 					.. dump(core.settings:get_bool("main_menu_technical_settings")) .. "]"
 
 	return formspec


### PR DESCRIPTION
All screenshots taken with game window at default size 1024x600, which is considered the minimum size we fully support. All menu settings default.

![screenshot from 2018-10-17 04-32-09](https://user-images.githubusercontent.com/3686677/47060549-fa208d80-d1c5-11e8-9d69-029ad54cdcd1.png)

^ PR. The tree menu formspec is now identical in height to the basic settings menu (screenshot below), and therefore identical in dimensons to most of the mainmenu pages. this makes switching between basic and advanced settings a more satisfying and cleaner experience, it feels just like switching between the menu tabs.

![screenshot from 2018-10-17 04-33-56](https://user-images.githubusercontent.com/3686677/47060566-0d335d80-d1c6-11e8-8368-89365b1b47fb.png)

///////////////////

![screenshot from 2018-10-17 04-32-52](https://user-images.githubusercontent.com/3686677/47060722-a8c4ce00-d1c6-11e8-8a4f-cee89a38811f.png)

^ PR. When opening a part of the tree, the currently set values are now visible on the right. In MT master these values are clipped (screenshot below) when using the default game window size 1024x600.

![screenshot from 2018-10-17 04-45-42](https://user-images.githubusercontent.com/3686677/47060971-88494380-d1c7-11e8-862c-1d34ffef1f9c.png)

^ MT master. Oops a slightly sloppy result for a default window size.

![screenshot from 2018-10-17 04-33-23](https://user-images.githubusercontent.com/3686677/47060829-0822de00-d1c7-11e8-9a54-a0b43e9d95a6.png)

^ PR. This is the setting that extends the furthest across the formspec, note that the setting name and the value column both have roughly equal room for expansion due to font size. This is how i chose the optimum value column position.