### PR TITLE
Formspecs: Fix clipped text in multi-line fields

### DIFF
--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -57,7 +57,6 @@ GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t* text, bool borde
 
 	if (has_vscrollbar) {
 		createVScrollBar();
-		RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 	}
 
 	calculateFrameRect();
@@ -1401,6 +1400,8 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 		skin = Environment->getSkin();
 
 	m_scrollbar_width = skin ? skin->getSize(gui::EGDS_SCROLLBAR_SIZE) : 16;
+
+	RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 
 	irr::core::rect<s32> scrollbarrect = m_frame_rect;
 	scrollbarrect.UpperLeftCorner.X += m_frame_rect.getWidth() - m_scrollbar_width;

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -57,6 +57,7 @@ GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t* text, bool borde
 
 	if (has_vscrollbar) {
 		createVScrollBar();
+		RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 	}
 
 	calculateFrameRect();

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -97,7 +97,6 @@ intlGUIEditBox::intlGUIEditBox(const wchar_t* text, bool border,
 
 		if (m_scrollbar_width > 0) {
 			createVScrollBar();
-			RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 		}
 	}
 
@@ -1482,6 +1481,8 @@ void intlGUIEditBox::createVScrollBar()
 			}
 		}
 	}
+
+	RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 
 	irr::core::rect<s32> scrollbarrect = FrameRect;
 	scrollbarrect.UpperLeftCorner.X += FrameRect.getWidth() - m_scrollbar_width;

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -97,6 +97,7 @@ intlGUIEditBox::intlGUIEditBox(const wchar_t* text, bool border,
 
 		if (m_scrollbar_width > 0) {
 			createVScrollBar();
+			RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 		}
 	}
 


### PR DESCRIPTION
Before | After
-|-
![unknown](https://user-images.githubusercontent.com/35757396/47455159-f96b9680-d785-11e8-8cae-41d6ef292a71.png) | ![unknown2](https://user-images.githubusercontent.com/35757396/47455167-fd97b400-d785-11e8-905d-fca679905fef.png)

This should be a simple fix, although there are other possible ways to handle this sort of text wrapping which may or may not be more desirable.
