### PR TITLE
Advanced settings: Fix noise parameter flags

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -625,6 +625,11 @@ local function create_change_setting_formspec(dialogdata)
 			-- Index by name, to avoid iterating over all enabled_flags for every possible flag.
 			flags[name] = true
 		end
+		for _, name in ipairs(setting.flags) do
+			local checkbox_name = "cb_" .. name
+			local is_enabled = flags[name] == true -- to get false if nil
+			checkboxes[checkbox_name] = is_enabled
+		end
 		-- Flags
 		formspec = table.concat(fields)
 				.. "checkbox[0.5," .. height - 0.6 .. ";cb_defaults;defaults;" -- defaults


### PR DESCRIPTION
Fixes second bug (advanced settings) of #7776 , specifically https://github.com/minetest/minetest/issues/7776#issuecomment-428769352 and
https://github.com/minetest/minetest/issues/7776#issuecomment-428775279
@SmallJoker might be interested due to your coding here.

Read https://github.com/minetest/minetest/issues/7776#issuecomment-433726791 for more details.
The `checkboxes` table wasn't set up for noise params, as it is for a 'flags' type setting below:
https://github.com/minetest/minetest/blob/2322078fe480a338422b35ee29fee3c0767f3e1d/builtin/mainmenu/dlg_settings_advanced.lua#L677
So on opening the noise params edit formspec, the checkboxes were visually ticked but actually all set disabled, so saving saved all flags as disabled.