### PR TITLE
Framed glasslike: Fix and document top/base textures feature

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1082,6 +1082,11 @@ Look for examples in `games/minimal` or `games/minetest_game`.
       size: 1 pixel for 16x16, 2 pixels for 32x32 etc.
     * The glass 'shine' (or other desired detail) on each node face is supplied
       by the second texture specified in `tiles`.
+    * If a third texture is specified in `tiles` it will be used for the top and
+      base of the glass volume.
+    * If third and fourth textures are specified in `tiles`, the third will be
+      used for the top of the glass volume and the fourth will be used for the
+      base of the glass volume.
 * `glasslike_framed_optional`
     * This switches between the above 2 drawtypes according to the menu setting
       'Connected Glass'.

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -702,7 +702,7 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 			tiles[2].layers[0].texture &&
 			tiles[3].layers[0].texture) {
 		glass_tiles[0] = tiles[4];
-		glass_tiles[1] = tiles[0];
+		glass_tiles[1] = tiles[2];
 		glass_tiles[2] = tiles[4];
 		glass_tiles[3] = tiles[4];
 		glass_tiles[4] = tiles[3];


### PR DESCRIPTION
![screenshot_20181030_033535](https://user-images.githubusercontent.com/3686677/47694277-eed15700-dbf4-11e8-89ab-a438a26fa493.png)

See https://github.com/minetest/minetest/issues/7823#issuecomment-434157302 and following 2 comments for details.
The feature was broken in MT master as the top tile should be `tiles[2]`.
The feature was undocumented, like the liquid tank feature used to be.
```
minetest.register_node("default:glass", {
	description = "Glass",
	drawtype = "glasslike_framed_optional",
	tiles = {
		"default_glass.png",
		"default_glass_detail.png",
		"default_aspen_wood.png",
		"default_wood.png", -- also comment out this line as part of testing
	},
	paramtype = "light",
	paramtype2 = "glasslikeliquidlevel",
	sunlight_propagates = true,
	is_ground_content = false,
	groups = {cracky = 3, oddly_breakable_by_hand = 3},
	sounds = default.node_sound_glass_defaults(),
})
```