### PR TITLE
Fix string.split returning an empty table if string starts with sepearator

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -166,7 +166,7 @@ end
 --------------------------------------------------------------------------------
 function string.split(str, delim, include_empty, max_splits, sep_is_pattern)
 	delim = delim or ","
-	max_splits = max_splits or -1
+	max_splits = max_splits or -2
 	local items = {}
 	local pos, len = 1, #str
 	local plain = not sep_is_pattern


### PR DESCRIPTION
Calling string.split(":A:B:C:D", ":") returns an empty array.

This is due to first empty string not making repeat loop decreasing max_split which has a 0 value when reaching until.

Changing max_splits default value from -1 to -2 fixes that issue (any lower value would fit).