### PR TITLE
Framed glasslike: Don't use cuboids to draw glass faces

### DIFF
--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -701,19 +701,8 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 		color = encode_light(light, f->light_source);
 
 	TileSpec glass_tiles[6];
-	if (tiles[1].layers[0].texture &&
-			tiles[2].layers[0].texture &&
-			tiles[3].layers[0].texture) {
-		glass_tiles[0] = tiles[4];
-		glass_tiles[1] = tiles[2];
-		glass_tiles[2] = tiles[4];
-		glass_tiles[3] = tiles[4];
-		glass_tiles[4] = tiles[3];
-		glass_tiles[5] = tiles[4];
-	} else {
-		for (auto &glass_tile : glass_tiles)
-			glass_tile = tiles[4];
-	}
+	for (auto &glass_tile : glass_tiles)
+		glass_tile = tiles[4];
 
 	u8 param2 = n.getParam2();
 	bool H_merge = !(param2 & 128);

--- a/src/content_mapblock.cpp
+++ b/src/content_mapblock.cpp
@@ -697,6 +697,9 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 	for (int face = 0; face < 6; face++)
 		getTile(g_6dirs[face], &tiles[face]);
 
+	if (!data->m_smooth_lighting)
+		color = encode_light(light, f->light_source);
+
 	TileSpec glass_tiles[6];
 	if (tiles[1].layers[0].texture &&
 			tiles[2].layers[0].texture &&
@@ -734,14 +737,6 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 		aabb3f(-a, -a,  b,  a, -b,  a), // z+
 		aabb3f(-a, -a, -a,  a, -b, -b), // z-
 		aabb3f(-a,  b, -a,  a,  a, -b), // z-
-	};
-	static const aabb3f glass_faces[6] = {
-		aabb3f(-g, -g,  g,  g,  g,  g), // z+
-		aabb3f(-g,  g, -g,  g,  g,  g), // y+
-		aabb3f( g, -g, -g,  g,  g,  g), // x+
-		aabb3f(-g, -g, -g,  g,  g, -g), // z-
-		aabb3f(-g, -g, -g,  g, -g,  g), // y-
-		aabb3f(-g, -g, -g, -g,  g,  g), // x-
 	};
 
 	// tables of neighbour (connect if same type and merge allowed),
@@ -800,8 +795,34 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 	for (int face = 0; face < 6; face++) {
 		if (nb[face])
 			continue;
+
 		tile = glass_tiles[face];
-		drawAutoLightedCuboid(glass_faces[face]);
+		// Face at Z-
+		v3f vertices[4] = {
+			v3f(-a,  a, -g),
+			v3f( a,  a, -g),
+			v3f( a, -a, -g),
+			v3f(-a, -a, -g),
+		};
+
+		for (v3f &vertex : vertices) {
+			switch (face) {
+				case D6D_ZP:
+					vertex.rotateXZBy(180); break;
+				case D6D_YP:
+					vertex.rotateYZBy( 90); break;
+				case D6D_XP:
+					vertex.rotateXZBy( 90); break;
+				case D6D_ZN:
+					vertex.rotateXZBy(  0); break;
+				case D6D_YN:
+					vertex.rotateYZBy(-90); break;
+				case D6D_XN:
+					vertex.rotateXZBy(-90); break;
+			}
+		}
+		v3s16 dir = g_6dirs[face];
+		drawQuad(vertices, dir);
 	}
 
 	// Optionally render internal liquid level defined by param2


### PR DESCRIPTION
Commit 1:
Framed glasslike: Don't use cuboids to draw glass faces

Previously, each glass face used drawAutoLightedCuboid() to draw a
flat cuboid. This also disallowed backface culling, making the
backface culling inconsistent with 'glasslike'.

Use code from 'glasslike' to draw glass faces using drawQuad().
//////////////////////
Commit 2:
Framed glasslike: Remove long-unknown top/bottom textures feature

Makes the code simpler and cleaner.
Never documented, long-unknown and not of much use. We are already
considering making this drawtype accept 6 textures for the 6 faces,
which will be far more useful.
///////////////////////

![screenshot_20181102_220235](https://user-images.githubusercontent.com/3686677/47943420-e24b4800-deed-11e8-81da-57a63c9606fd.png)

^ Smooth lighting disabled

![screenshot_20181102_220140](https://user-images.githubusercontent.com/3686677/47943425-e70ffc00-deed-11e8-81f4-e6beb4d07cda.png)

^ Smooth lighting enabled

![screenshot_20181102_230640](https://user-images.githubusercontent.com/3686677/47969982-48afa200-e077-11e8-8e94-a623b233d752.png)

^ Backface culling can be disabled for the glass faces, no z-fighting

Fixes remaining bug of #7823 : lack of backface culling.
See https://github.com/minetest/minetest/issues/7823#issuecomment-434794055 onwards for more details.

For reviewers:

Instead of using `drawAutoLightedCuboid()` to draw each glass face, code from `drawGlasslikeNode()` (which is directly above) is copy-pasted.
The only changes are:
* Using the slightly inset distance `g` for vertexes to avoid z-fighting against adjacent nodes if backface culling is disabled.
* Because `drawGlasslikeFramedNode()` uses `getTile()` instead of `useTile()` it has this code from `useTile()` added for correct lighting:
```
	if (!data->m_smooth_lighting)
		color = encode_light(light, f->light_source);
```

See #1428 . The addition of top/bottom textures was not mentioned or discussed in the PR. "add interior volume." refers to the internal liquid feature, and both new features were not documented, sloppy, it's good to know our quality and required standards are higher now.