### PR TITLE
falling entity rewrite

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -17,28 +17,20 @@ core.register_entity(":__builtin:falling_node", {
 		collisionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
 	},
 
-	node = {},
-	meta = {},
-
 	set_node = function(self, node, meta)
 		self.node = node
-		self.meta = meta or {}
-		self.object:set_properties({
-			is_visible = true,
-			textures = {node.name},
-		})
+		self.meta = meta
+		self.hurt_toggle = true
+		self.object:set_properties({is_visible = true, textures = {node.name}})
 	end,
 
 	get_staticdata = function(self)
-		local ds = {
-			node = self.node,
-			meta = self.meta,
-		}
-		return core.serialize(ds)
+		return core.serialize({node = self.node, meta = self.meta})
 	end,
 
 	on_activate = function(self, staticdata)
 		self.object:set_armor_groups({immortal = 1})
+		self.object:set_acceleration({x = 0, y = -10, z = 0})
 
 		local ds = core.deserialize(staticdata)
 		if ds and ds.node then
@@ -56,78 +48,91 @@ core.register_entity(":__builtin:falling_node", {
 		if not vector.equals(acceleration, {x = 0, y = -10, z = 0}) then
 			self.object:set_acceleration({x = 0, y = -10, z = 0})
 		end
-		-- Turn to actual node when colliding with ground, or continue to move
+
 		local pos = self.object:get_pos()
 		-- Position of bottom center point
-		local bcp = {x = pos.x, y = pos.y - 0.7, z = pos.z}
-		-- 'bcn' is nil for unloaded nodes
-		local bcn = core.get_node_or_nil(bcp)
+		local below_pos = {x = pos.x, y = pos.y - 0.7, z = pos.z}
+		-- Avoid bugs caused by an unloaded node below
+		local below_node = core.get_node(below_pos)
 		-- Delete on contact with ignore at world edges
-		if bcn and bcn.name == "ignore" then
+		if below_node.name == "ignore" then
 			self.object:remove()
 			return
 		end
-		local bcd = bcn and core.registered_nodes[bcn.name]
-		if bcn and
-				(not bcd or bcd.walkable or
-				(core.get_item_group(self.node.name, "float") ~= 0 and
-				bcd.liquidtype ~= "none")) then
-			if bcd and bcd.leveled and
-					bcn.name == self.node.name then
-				local addlevel = self.node.level
-				if not addlevel or addlevel <= 0 then
-					addlevel = bcd.leveled
-				end
-				if core.add_node_level(bcp, addlevel) == 0 then
-					self.object:remove()
-					return
-				end
-			elseif bcd and bcd.buildable_to and
-					(core.get_item_group(self.node.name, "float") == 0 or
-					bcd.liquidtype == "none") then
-				core.remove_node(bcp)
+
+		local below_nodef = core.registered_nodes[below_node.name]
+		-- Is it a level node we can add to?
+		if below_nodef
+		and below_nodef.leveled
+		and below_node.name == self.node.name then
+			local addlevel = self.node.level
+			if not addlevel or addlevel <= 0 then
+				addlevel = below_nodef.leveled
+			end
+			if core.add_node_level(below_pos, addlevel) == 0 then
+				self.object:remove()
 				return
 			end
-			local np = {x = bcp.x, y = bcp.y + 1, z = bcp.z}
-			-- Check what's here
-			local n2 = core.get_node(np)
-			local nd = core.registered_nodes[n2.name]
-			-- If it's not air or liquid, remove node and replace it with
-			-- it's drops
-			if n2.name ~= "air" and (not nd or nd.liquidtype == "none") then
-				core.remove_node(np)
-				if nd and nd.buildable_to == false then
-					-- Add dropped items
-					local drops = core.get_node_drops(n2, "")
-					for _, dropped_item in pairs(drops) do
-						core.add_item(np, dropped_item)
-					end
-				end
-				-- Run script hook
-				for _, callback in pairs(core.registered_on_dignodes) do
-					callback(np, n2)
-				end
-			end
-			-- Create node and remove entity
-			local def = core.registered_nodes[self.node.name]
-			if def then
-				core.add_node(np, self.node)
-				if self.meta then
-					local meta = core.get_meta(np)
-					meta:from_table(self.meta)
-				end
-				if def.sounds and def.sounds.place and def.sounds.place.name then
-					core.sound_play(def.sounds.place, {pos = np})
-				end
-			end
-			self.object:remove()
-			core.check_for_falling(np)
-			return
 		end
+
+		-- Stop node if it falls on walkable surface, or floats on water
+		if (below_nodef and below_nodef.walkable == true)
+		or (below_nodef
+				and core.get_item_group(self.node.name, "float") ~= 0
+				and below_nodef.liquidtype ~= "none") then
+
+			self.object:set_velocity({x = 0, y = 0, z = 0})
+		end
+
+		-- Has the fallen node stopped moving ?
 		local vel = self.object:get_velocity()
 		if vector.equals(vel, {x = 0, y = 0, z = 0}) then
 			local npos = self.object:get_pos()
-			self.object:set_pos(vector.round(npos))
+			-- Get node we've landed inside
+			local cnode = minetest.get_node(npos).name
+			local cdef = core.registered_nodes[cnode]
+			-- If 'air' or buildable_to or an attached_node then place node,
+			-- otherwise drop falling node as an item instead.
+			if cnode == "air"
+			or (cdef and cdef.buildable_to == true)
+			or (cdef and cdef.liquidtype ~= "none")
+			or core.get_item_group(cnode, "attached_node") ~= 0 then
+				-- Are we an attached node ? (grass, flowers, torch)
+				if core.get_item_group(cnode, "attached_node") ~= 0 then
+					-- Add drops from attached node
+					local drops = core.get_node_drops(cnode, "")
+					for _, dropped_item in pairs(drops) do
+						core.add_item(npos, dropped_item)
+					end
+					-- Run script hook
+					for _, callback in pairs(core.registered_on_dignodes) do
+						callback(npos, cnode)
+					end
+				end
+				-- Round position
+				npos = vector.round(npos)
+				-- Place falling entity as node and write any metadata
+				core.add_node(npos, self.node)
+				if self.meta then
+					local meta = core.get_meta(npos)
+					meta:from_table(self.meta)
+				end
+				-- Play placed sound
+				local def = core.registered_nodes[self.node.name]
+				if def.sounds and def.sounds.place and def.sounds.place.name then
+					core.sound_play(def.sounds.place, {pos = npos})
+				end
+				-- Just incase we landed on other falling nodes
+				core.check_for_falling(npos)
+			else
+				-- Add drops from falling node
+				local drops = core.get_node_drops(self.node, "")
+				for _, dropped_item in pairs(drops) do
+					core.add_item(npos, dropped_item)
+				end
+			end
+			-- Remove falling entity
+			self.object:remove()
 		end
 	end
 })


### PR DESCRIPTION
Falling nodes will only replace air, buildable to, water and attached nodes.  This gets rid of the old glitch where lag could cause falling nodes to remove certain blocks.