### PR TITLE
Degrotate support for mesh nodes

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -157,7 +157,7 @@ end
 
 function core.is_colored_paramtype(ptype)
 	return (ptype == "color") or (ptype == "colorfacedir") or
-		(ptype == "colorwallmounted")
+		(ptype == "colorwallmounted") or (ptype == "colordegrotate")
 end
 
 function core.strip_param2_color(param2, paramtype2)
@@ -168,6 +168,8 @@ function core.strip_param2_color(param2, paramtype2)
 		param2 = math.floor(param2 / 32) * 32
 	elseif paramtype2 == "colorwallmounted" then
 		param2 = math.floor(param2 / 8) * 8
+	elseif paramtype2 == "colordegrotate" then
+		param2 = math.floor(param2 / 32) * 32
 	end
 	-- paramtype2 == "color" requires no modification.
 	return param2
@@ -344,6 +346,8 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 		elseif def.paramtype2 == "colorwallmounted" then
 			color_divisor = 8
 		elseif def.paramtype2 == "colorfacedir" then
+			color_divisor = 32
+		elseif def.paramtype2 == "colordegrotate" then
 			color_divisor = 32
 		end
 		if color_divisor then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1043,9 +1043,9 @@ The function of `param2` is determined by `paramtype2` in node definition.
             * The height of the 'plantlike' section is stored in `param2`.
             * The height is (`param2` / 16) nodes.
 * `paramtype2 = "degrotate"`
-    * Only valid for "plantlike" drawtype. The rotation of the node is stored in
-      `param2`.
-    * Values range 0 - 179. The value stored in `param2` is multiplied by two to
+    * Valid for `plantlike` and `mesh` drawtypes. The rotation of the node is
+      stored in `param2`.
+    * Values range 0–239. The value stored in `param2` is multiplied by 1.5 to
       get the actual rotation in degrees of the node.
 * `paramtype2 = "meshoptions"`
     * Only valid for "plantlike" drawtype. `param2` encodes the shape and
@@ -1083,6 +1083,11 @@ The function of `param2` is determined by `paramtype2` in node definition.
     * `param2` values 0-63 define 64 levels of internal liquid, 0 being empty
       and 63 being full.
     * Liquid texture is defined using `special_tiles = {"modname_tilename.png"}`
+* `paramtype2 = "colordegrotate"`
+    * Same as `degrotate`, but with colors.
+    * The first (most-significant) three bits of `param2` tells which color
+      is picked from the palette. The palette should have 8 pixels.
+    * Remaining 5 bits store rotation in range 0–23 (i.e. in 15° steps)
 * `paramtype2 = "none"`
     * `param2` will not be used by the engine and can be used to store
       an arbitrary value

--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -223,6 +223,30 @@ minetest.register_node("testnodes:plantlike_waving", {
 
 
 -- param2 will rotate
+local function rotate_on_rightclick(pos, node, clicker)
+	local def = minetest.registered_nodes[node.name]
+	local aux1 = clicker:get_player_control().aux1
+
+	local deg, deg_max
+	local color, color_mult = 0, 0
+	if def.paramtype2 == "degrotate" then
+		deg = node.param2
+		deg_max = 240
+	elseif def.paramtype2 == "colordegrotate" then
+		-- MSB [3x color, 5x rotation] LSB
+		deg = node.param2 % 2^5
+		deg_max = 24
+		color_mult = 2^5
+		color = math.floor(node.param2 / color_mult)
+	end
+
+	deg = (deg + (aux1 and 10 or 1)) % deg_max
+	node.param2 = color * color_mult + deg
+	minetest.swap_node(pos, node)
+	minetest.chat_send_player(clicker:get_player_name(),
+		"Rotation is now " .. deg .. " / " .. deg_max)
+end
+
 minetest.register_node("testnodes:plantlike_degrotate", {
 	description = S("Degrotate Plantlike Drawtype Test Node"),
 	drawtype = "plantlike",
@@ -230,8 +254,38 @@ minetest.register_node("testnodes:plantlike_degrotate", {
 	paramtype2 = "degrotate",
 	tiles = { "testnodes_plantlike_degrotate.png" },
 
-
+	on_rightclick = rotate_on_rightclick,
+	place_param2 = 7,
 	walkable = false,
+	sunlight_propagates = true,
+	groups = { dig_immediate = 3 },
+})
+
+minetest.register_node("testnodes:mesh_degrotate", {
+	description = S("Degrotate Mesh Drawtype Test Node"),
+	drawtype = "mesh",
+	paramtype = "light",
+	paramtype2 = "degrotate",
+	mesh = "testnodes_pyramid.obj",
+	tiles = { "testnodes_mesh_stripes2.png" },
+
+	on_rightclick = rotate_on_rightclick,
+	place_param2 = 7,
+	sunlight_propagates = true,
+	groups = { dig_immediate = 3 },
+})
+
+minetest.register_node("testnodes:mesh_colordegrotate", {
+	description = S("Color Degrotate Mesh Drawtype Test Node"),
+	drawtype = "mesh",
+	paramtype2 = "colordegrotate",
+	palette = "testnodes_palette_facedir.png",
+	mesh = "testnodes_pyramid.obj",
+	tiles = { "testnodes_mesh_stripes2.png" },
+
+	on_rightclick = rotate_on_rightclick,
+	-- color index 1, 7 steps rotated
+	place_param2 = 1 * 2^5 + 7,
 	sunlight_propagates = true,
 	groups = { dig_immediate = 3 },
 })

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -139,7 +139,7 @@ public:
 // plantlike-specific
 	PlantlikeStyle draw_style;
 	v3f offset;
-	int rotate_degree;
+	float rotate_degree;
 	bool random_offset_Y;
 	int face_num;
 	float plant_height;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -177,6 +177,16 @@ v3s16 MapNode::getWallMountedDir(const NodeDefManager *nodemgr) const
 	}
 }
 
+u8 MapNode::getDegRotate(const NodeDefManager *nodemgr) const
+{
+	const ContentFeatures &f = nodemgr->get(*this);
+	if (f.param_type_2 == CPT2_DEGROTATE)
+		return getParam2() % 240;
+	if (f.param_type_2 == CPT2_COLORED_DEGROTATE)
+		return 10 * ((getParam2() & 0x1F) % 24);
+	return 0;
+}
+
 void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 {
 	ContentParamType2 cpt2 = nodemgr->get(*this).param_type_2;
@@ -230,6 +240,17 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 		Rotation oldrot = wallmounted_to_rot[wmountface - 2];
 		param2 &= ~7;
 		param2 |= rot_to_wallmounted[(oldrot - rot) & 3];
+	} else if (cpt2 == CPT2_DEGROTATE) {
+		int angle = param2; // in 1.5°
+		angle += 60 * rot; // don’t do that on u8
+		angle %= 240;
+		param2 = angle;
+	} else if (cpt2 == CPT2_COLORED_DEGROTATE) {
+		int angle = param2 & 0x1F; // in 15°
+		int color = param2 & 0x60;
+		angle += 6 * rot;
+		angle %= 24;
+		param2 = color | angle;
 	}
 }
 

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -247,7 +247,7 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 		param2 = angle;
 	} else if (cpt2 == CPT2_COLORED_DEGROTATE) {
 		int angle = param2 & 0x1F; // in 15°
-		int color = param2 & 0x60;
+		int color = param2 & 0xE0;
 		angle += 6 * rot;
 		angle %= 24;
 		param2 = color | angle;

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -240,6 +240,9 @@ struct MapNode
 	u8 getWallMounted(const NodeDefManager *nodemgr) const;
 	v3s16 getWallMountedDir(const NodeDefManager *nodemgr) const;
 
+	/// @returns Rotation in range 0–239 (in 1.5° steps)
+	u8 getDegRotate(const NodeDefManager *nodemgr) const;
+
 	void rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot);
 
 	/*!

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -930,7 +930,8 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 
 	if (param_type_2 == CPT2_COLOR ||
 			param_type_2 == CPT2_COLORED_FACEDIR ||
-			param_type_2 == CPT2_COLORED_WALLMOUNTED)
+			param_type_2 == CPT2_COLORED_WALLMOUNTED ||
+			param_type_2 == CPT2_COLORED_DEGROTATE)
 		palette = tsrc->getPalette(palette_name);
 
 	if (drawtype == NDT_MESH && !mesh.empty()) {

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -64,7 +64,7 @@ enum ContentParamType2
 	CPT2_WALLMOUNTED,
 	// Block level like FLOWINGLIQUID
 	CPT2_LEVELED,
-	// 2D rotation for things like plants
+	// 2D rotation
 	CPT2_DEGROTATE,
 	// Mesh options for plants
 	CPT2_MESHOPTIONS,
@@ -76,6 +76,8 @@ enum ContentParamType2
 	CPT2_COLORED_WALLMOUNTED,
 	// Glasslike framed drawtype internal liquid level, param2 values 0 to 63
 	CPT2_GLASSLIKE_LIQUID_LEVEL,
+	// 3 bits of palette index, then degrotate
+	CPT2_COLORED_DEGROTATE,
 };
 
 enum LiquidType

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -649,7 +649,8 @@ void read_content_features(lua_State *L, ContentFeatures &f, int index)
 	if (!f.palette_name.empty() &&
 			!(f.param_type_2 == CPT2_COLOR ||
 			f.param_type_2 == CPT2_COLORED_FACEDIR ||
-			f.param_type_2 == CPT2_COLORED_WALLMOUNTED))
+			f.param_type_2 == CPT2_COLORED_WALLMOUNTED ||
+			f.param_type_2 == CPT2_COLORED_DEGROTATE))
 		warningstream << "Node " << f.name.c_str()
 			<< " has a palette, but not a suitable paramtype2." << std::endl;
 

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -65,6 +65,7 @@ struct EnumString ScriptApiNode::es_ContentParamType2[] =
 		{CPT2_COLORED_FACEDIR, "colorfacedir"},
 		{CPT2_COLORED_WALLMOUNTED, "colorwallmounted"},
 		{CPT2_GLASSLIKE_LIQUID_LEVEL, "glasslikeliquidlevel"},
+		{CPT2_COLORED_DEGROTATE, "colordegrotate"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
For convenience, `degrotate` range is changed from 180 (2° steps) to 240 (1.5° steps). Most importantly that allows exact diagonals, [as requested](https://github.com/minetest/minetest/issues/6172#issuecomment-317998633), while still allowing thirds and fifths (but not ninths).

This also adds a new option, `colordegrotate`. It has reduced range (24, 15° steps) to support 8 colors but still allows exact diagonals. The range could be 32 (11.25° steps) at most with the same number of colors but I considered thirds more important than additional two-fold.

![screenshot_20181111_011427](https://user-images.githubusercontent.com/7352626/48306742-6eddb200-e54f-11e8-8028-71c37117b118.png)