### PR TITLE
Escape special characters when searching the server list

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -256,6 +256,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		-- setup the keyword list
 		local keywords = {}
 		for word in input:gmatch("%S+") do
+			word = word:gsub("([^%w])", "%%%1")
 			table.insert(keywords, word)
 		end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -256,7 +256,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		-- setup the keyword list
 		local keywords = {}
 		for word in input:gmatch("%S+") do
-			word = word:gsub("([^%w])", "%%%1")
+			word = word:gsub("(%W)", "%%%1")
 			table.insert(keywords, word)
 		end
 


### PR DESCRIPTION
Searching for special characters in the server search causes a crash

This simple fix stops searching for "[" or other special characters causing a crash by escaping special characters when performing the search.

Tested on 0.4.17.1.

Bug reported by Peppy in IRC. Sorry for tiny PR, or if I messed something up.