### PR TITLE
Remove quotation marks in flags settings

### DIFF
--- a/builtin/mainmenu/generate_from_settingtypes.lua
+++ b/builtin/mainmenu/generate_from_settingtypes.lua
@@ -31,7 +31,7 @@ local group_format_template = [[
 #    octaves     = %s,
 #    persistence = %s,
 #    lacunarity  = %s,
-#    flags       = "%s"
+#    flags       = %s
 # }
 
 ]]


### PR DESCRIPTION
The quotation marks make the flags cannot be read. Removing it fixes #7776.

Before:
```
# mgv7_np_floatland_base = {
#    offset      = -0.6,
#    scale       = 1.5,
#    spread      = (600, 600, 600),
#    seed        = 114,
#    octaves     = 5,
#    persistence = 0.6,
#    lacunarity  = 2.0,
#    flags       = "eased"
# }
```
After:
```
# mgv7_np_floatland_base = {
#    offset      = -0.6,
#    scale       = 1.5,
#    spread      = (600, 600, 600),
#    seed        = 114,
#    octaves     = 5,
#    persistence = 0.6,
#    lacunarity  = 2.0,
#    flags       = eased
# }
```