### PR TITLE
Don't use separate checkbox to disable flag

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -678,7 +678,7 @@ local function create_change_setting_formspec(dialogdata)
 			end
 		end
 		local flags_count = #setting.possible / 2
-		local max_height = flags_count / 4
+		local max_height = math.ceil(flags_count / 2) / 2
 
 		-- More space for flags
 		description_height = description_height - 1
@@ -836,10 +836,12 @@ local function handle_change_setting_buttons(this, fields)
 		elseif setting.type == "flags" then
 			local values = {}
 			for _, name in ipairs(setting.possible) do
-				if checkboxes["cb_" .. name] then
-					table.insert(values, name)
-				else
-					table.insert(values, "no" .. name)
+				if name:sub(1, 2) ~= "no" then
+					if checkboxes["cb_" .. name] then
+						table.insert(values, name)
+					else
+						table.insert(values, "no" .. name)
+					end
 				end
 			end
 

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -667,13 +667,17 @@ local function create_change_setting_formspec(dialogdata)
 		height = height + 1.1
 
 	elseif setting.type == "flags" then
-		local enabled_flags = flags_to_table(get_current_value(setting))
+		local current_flags = flags_to_table(get_current_value(setting))
 		local flags = {}
-		for _, name in ipairs(enabled_flags) do
+		for _, name in ipairs(current_flags) do
 			-- Index by name, to avoid iterating over all enabled_flags for every possible flag.
-			flags[name] = true
+			if name:sub(1, 2) == "no" then
+				flags[name:sub(3)] = false
+			else
+				flags[name] = true
+			end
 		end
-		local flags_count = #setting.possible
+		local flags_count = #setting.possible / 2
 		local max_height = flags_count / 4
 
 		-- More space for flags
@@ -682,19 +686,21 @@ local function create_change_setting_formspec(dialogdata)
 
 		local fields = {} -- To build formspec
 		for i, name in ipairs(setting.possible) do
-			local x = 0.5
-			local y = height + i / 2 - 0.75
-			if i - 1 >= flags_count / 2 then -- 2nd column
-				x = 5
-				y = y - max_height
-			end
-			local checkbox_name = "cb_" .. name
-			local is_enabled = flags[name] == true -- to get false if nil
-			checkboxes[checkbox_name] = is_enabled
+			if name:sub(1, 2) ~= "no" then
+				local x = 0.5
+				local y = height + i / 2 - 0.75
+				if i - 1 >= flags_count / 2 then -- 2nd column
+					x = 5
+					y = y - max_height
+				end
+				local checkbox_name = "cb_" .. name
+				local is_enabled = flags[name] == true -- to get false if nil
+				checkboxes[checkbox_name] = is_enabled
 
-			fields[#fields + 1] = ("checkbox[%f,%f;%s;%s;%s]"):format(
-				x, y, checkbox_name, name, tostring(is_enabled)
-			)
+				fields[#fields + 1] = ("checkbox[%f,%f;%s;%s;%s]"):format(
+					x, y, checkbox_name, name, tostring(is_enabled)
+				)
+			end
 		end
 		formspec = table.concat(fields)
 		height = height + max_height + 0.25
@@ -832,6 +838,8 @@ local function handle_change_setting_buttons(this, fields)
 			for _, name in ipairs(setting.possible) do
 				if checkboxes["cb_" .. name] then
 					table.insert(values, name)
+				else
+					table.insert(values, "no" .. name)
 				end
 			end
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1819,7 +1819,7 @@ mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
-mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry
+mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,humid_rivers,vary_river_depth,altitude_dry,noaltitude_chill,nohumid_rivers,novary_river_depth,noaltitude_dry
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -403,7 +403,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_level", "1");
 	settings->setDefault("mapgen_limit", "31000");
 	settings->setDefault("chunksize", "5");
-	settings->setDefault("mg_flags", "dungeons");
+	settings->setDefault("mg_flags", "caves,dungeons,light,decorations,biomes");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "8");
 	settings->setDefault("projecting_dungeons", "true");


### PR DESCRIPTION
~Remove flags with "no" prefix from possible flags.~
Always force with or without "no" prefix but not both.
Update documentation.

![mt_new_flags](https://user-images.githubusercontent.com/4017302/48291692-f1139b00-e4a9-11e8-880b-afabb56e08cc.png)
[(old screenshot)](https://user-images.githubusercontent.com/4017302/48253835-e5d55680-e43a-11e8-88ad-8475bc9ba65b.png)

Fixes #7757.