### PR TITLE
Make non-formspec modal menus respect gui scale

### DIFF
--- a/src/gui/guiConfirmRegistration.cpp
+++ b/src/gui/guiConfirmRegistration.cpp
@@ -70,13 +70,16 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	core::rect<s32> rect(screensize.X / 2 - 600 / 2, screensize.Y / 2 - 360 / 2,
-			screensize.X / 2 + 600 / 2, screensize.Y / 2 + 360 / 2);
-
-	DesiredRect = rect;
+	const float s = m_gui_scale;
+	DesiredRect = core::rect<s32>(
+		screensize.X / 2 - 600 * s / 2,
+		screensize.Y / 2 - 360 * s / 2,
+		screensize.X / 2 + 600 * s / 2,
+		screensize.Y / 2 + 360 * s / 2
+	);
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = rect.getSize();
+	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft_client(0, 0);
 
 	const wchar_t *text;
@@ -84,13 +87,13 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 	/*
 		Add stuff
 	*/
-	s32 ypos = 30;
+	s32 ypos = 30 * s;
 	{
 		std::string address = m_address;
 		if (address.empty())
 			address = "localhost";
-		core::rect<s32> rect2(0, 0, 540, 180);
-		rect2 += topleft_client + v2s32(30, ypos);
+		core::rect<s32> rect2(0, 0, 540 * s, 180 * s);
+		rect2 += topleft_client + v2s32(30 * s, ypos);
 		static const std::string info_text_template = strgettext(
 				"You are about to join the server at %1$s with the "
 				"name \"%2$s\" for the first time. If you proceed, a "
@@ -114,33 +117,33 @@ void GUIConfirmRegistration::regenerateGui(v2u32 screensize)
 		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
 	}
 
-	ypos += 210;
+	ypos += 210 * s;
 	{
-		core::rect<s32> rect2(0, 0, 540, 30);
-		rect2 += topleft_client + v2s32(30, ypos);
+		core::rect<s32> rect2(0, 0, 540 * s, 30 * s);
+		rect2 += topleft_client + v2s32(30 * s, ypos);
 		gui::IGUIEditBox *e = Environment->addEditBox(m_pass_confirm.c_str(),
 				rect2, true, this, ID_confirmPassword);
 		e->setPasswordBox(true);
 	}
 
-	ypos += 60;
+	ypos += 60 * s;
 	{
-		core::rect<s32> rect2(0, 0, 230, 35);
-		rect2 = rect2 + v2s32(size.X / 2 - 220, ypos);
+		core::rect<s32> rect2(0, 0, 230 * s, 35 * s);
+		rect2 = rect2 + v2s32(size.X / 2 - 220 * s, ypos);
 		text = wgettext("Register and Join");
 		Environment->addButton(rect2, this, ID_confirm, text);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect2(0, 0, 120, 35);
-		rect2 = rect2 + v2s32(size.X / 2 + 70, ypos);
+		core::rect<s32> rect2(0, 0, 120 * s, 35 * s);
+		rect2 = rect2 + v2s32(size.X / 2 + 70 * s, ypos);
 		text = wgettext("Cancel");
 		Environment->addButton(rect2, this, ID_cancel, text);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect2(0, 0, 200, 20);
-		rect2 += topleft_client + v2s32(30, ypos - 40);
+		core::rect<s32> rect2(0, 0, 200 * s, 20 * s);
+		rect2 += topleft_client + v2s32(30 * s, ypos - 40 * s);
 		text = wgettext("Passwords do not match!");
 		IGUIElement *e = Environment->addStaticText(
 				text, rect2, false, true, this, ID_message);

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -116,20 +116,22 @@ void GUIKeyChangeMenu::removeChildren()
 void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 {
 	removeChildren();
-	v2s32 size(745, 430);
 
-	core::rect < s32 > rect(screensize.X / 2 - size.X / 2,
-							screensize.Y / 2 - size.Y / 2, screensize.X / 2 + size.X / 2,
-							screensize.Y / 2 + size.Y / 2);
-
-	DesiredRect = rect;
+	const float s = m_gui_scale;
+	DesiredRect = core::rect<s32>(
+		screensize.X / 2 - 745 * s / 2,
+		screensize.Y / 2 - 430 * s / 2,
+		screensize.X / 2 + 745 * s / 2,
+		screensize.Y / 2 + 430 * s / 2
+	);
 	recalculateAbsolutePosition(false);
 
+	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft(0, 0);
 
 	{
-		core::rect < s32 > rect(0, 0, 600, 40);
-		rect += topleft + v2s32(25, 3);
+		core::rect<s32> rect(0, 0, 600 * s, 40 * s);
+		rect += topleft + v2s32(25 * s, 3 * s);
 		//gui::IGUIStaticText *t =
 		const wchar_t *text = wgettext("Keybindings. (If this menu screws up, remove stuff from minetest.conf)");
 		Environment->addStaticText(text,
@@ -140,68 +142,68 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 
 	// Build buttons
 
-	v2s32 offset(25, 60);
+	v2s32 offset(25 * s, 60 * s);
 
 	for(size_t i = 0; i < key_settings.size(); i++)
 	{
 		key_setting *k = key_settings.at(i);
 		{
-			core::rect < s32 > rect(0, 0, 150, 20);
+			core::rect<s32> rect(0, 0, 150 * s, 20 * s);
 			rect += topleft + v2s32(offset.X, offset.Y);
 			Environment->addStaticText(k->button_name, rect, false, true, this, -1);
 		}
 
 		{
-			core::rect < s32 > rect(0, 0, 100, 30);
-			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
+			core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+			rect += topleft + v2s32(offset.X + 120 * s, offset.Y - 5 * s);
 			const wchar_t *text = wgettext(k->key.name());
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
-			offset.X += 230;
-			offset.Y = 60;
+			offset.X += 230 * s;
+			offset.Y = 60 * s;
 		} else {
-			offset += v2s32(0, 25);
+			offset += v2s32(0, 25 * s);
 		}
 	}
 
 	{
 		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5;
-		u32 option_w = 180;
+		s32 option_y = offset.Y + 5 * s;
+		u32 option_w = 180 * s;
 		{
-			core::rect<s32> rect(0, 0, option_w, 30);
+			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
 			const wchar_t *text = wgettext("\"Special\" = climb down");
 			Environment->addCheckBox(g_settings->getBool("aux1_descends"), rect, this,
 					GUI_ID_CB_AUX1_DESCENDS, text);
 			delete[] text;
 		}
-		offset += v2s32(0, 25);
+		offset += v2s32(0, 25 * s);
 	}
 
 	{
 		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5;
-		u32 option_w = 280;
+		s32 option_y = offset.Y + 5 * s;
+		u32 option_w = 280 * s;
 		{
-			core::rect<s32> rect(0, 0, option_w, 30);
+			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
 			const wchar_t *text = wgettext("Double tap \"jump\" to toggle fly");
 			Environment->addCheckBox(g_settings->getBool("doubletap_jump"), rect, this,
 					GUI_ID_CB_DOUBLETAP_JUMP, text);
 			delete[] text;
 		}
-		offset += v2s32(0, 25);
+		offset += v2s32(0, 25 * s);
 	}
 
 	{
 		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5;
+		s32 option_y = offset.Y + 5 * s;
 		u32 option_w = 280;
 		{
-			core::rect<s32> rect(0, 0, option_w, 30);
+			core::rect<s32> rect(0, 0, option_w, 30 * s);
 			rect += topleft + v2s32(option_x, option_y);
 			const wchar_t *text = wgettext("Automatic jumping");
 			Environment->addCheckBox(g_settings->getBool("autojump"), rect, this,
@@ -212,16 +214,16 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	}
 
 	{
-		core::rect < s32 > rect(0, 0, 100, 30);
-		rect += topleft + v2s32(size.X / 2 - 105, size.Y - 40);
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect += topleft + v2s32(size.X / 2 - 105 * s, size.Y - 40 * s);
 		const wchar_t *text =  wgettext("Save");
 		Environment->addButton(rect, this, GUI_ID_BACK_BUTTON,
 				 text);
 		delete[] text;
 	}
 	{
-		core::rect < s32 > rect(0, 0, 100, 30);
-		rect += topleft + v2s32(size.X / 2 + 5, size.Y - 40);
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect += topleft + v2s32(size.X / 2 + 5 * s, size.Y - 40 * s);
 		const wchar_t *text = wgettext("Cancel");
 		Environment->addButton(rect, this, GUI_ID_ABORT_BUTTON,
 				text);
@@ -237,12 +239,7 @@ void GUIKeyChangeMenu::drawMenu()
 	video::IVideoDriver* driver = Environment->getVideoDriver();
 
 	video::SColor bgcolor(140, 0, 0, 0);
-
-	{
-		core::rect < s32 > rect(0, 0, 745, 620);
-		rect += AbsoluteRect.UpperLeftCorner;
-		driver->draw2DRectangle(bgcolor, rect, &AbsoluteClippingRect);
-	}
+	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
 
 	gui::IGUIElement::draw();
 }

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -76,91 +76,90 @@ void GUIPasswordChange::regenerateGui(v2u32 screensize)
 	/*
 		Calculate new sizes and positions
 	*/
-	core::rect<s32> rect(
-			screensize.X/2 - 580/2,
-			screensize.Y/2 - 300/2,
-			screensize.X/2 + 580/2,
-			screensize.Y/2 + 300/2
+	const float s = m_gui_scale;
+	DesiredRect = core::rect<s32>(
+		screensize.X / 2 - 580 * s / 2,
+		screensize.Y / 2 - 300 * s / 2,
+		screensize.X / 2 + 580 * s / 2,
+		screensize.Y / 2 + 300 * s / 2
 	);
-
-	DesiredRect = rect;
 	recalculateAbsolutePosition(false);
 
-	v2s32 size = rect.getSize();
-	v2s32 topleft_client(40, 0);
+	v2s32 size = DesiredRect.getSize();
+	v2s32 topleft_client(40 * s, 0);
 
 	const wchar_t *text;
 
 	/*
 		Add stuff
 	*/
-	s32 ypos = 50;
+	s32 ypos = 50 * s;
 	{
-		core::rect<s32> rect(0, 0, 150, 20);
-		rect += topleft_client + v2s32(25, ypos + 6);
+		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
+		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
 		text = wgettext("Old Password");
 		Environment->addStaticText(text, rect, false, true, this, -1);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect(0, 0, 230, 30);
-		rect += topleft_client + v2s32(160, ypos);
+		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
+		rect += topleft_client + v2s32(160 * s, ypos);
 		gui::IGUIEditBox *e = Environment->addEditBox(
 				m_oldpass.c_str(), rect, true, this, ID_oldPassword);
 		Environment->setFocus(e);
 		e->setPasswordBox(true);
 	}
-	ypos += 50;
+	ypos += 50 * s;
 	{
-		core::rect<s32> rect(0, 0, 150, 20);
-		rect += topleft_client + v2s32(25, ypos + 6);
+		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
+		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
 		text = wgettext("New Password");
 		Environment->addStaticText(text, rect, false, true, this, -1);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect(0, 0, 230, 30);
-		rect += topleft_client + v2s32(160, ypos);
+		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
+		rect += topleft_client + v2s32(160 * s, ypos);
 		gui::IGUIEditBox *e = Environment->addEditBox(
 				m_newpass.c_str(), rect, true, this, ID_newPassword1);
 		e->setPasswordBox(true);
 	}
-	ypos += 50;
+	ypos += 50 * s;
 	{
-		core::rect<s32> rect(0, 0, 150, 20);
-		rect += topleft_client + v2s32(25, ypos + 6);
+		core::rect<s32> rect(0, 0, 150 * s, 20 * s);
+		rect += topleft_client + v2s32(25 * s, ypos + 6 * s);
 		text = wgettext("Confirm Password");
 		Environment->addStaticText(text, rect, false, true, this, -1);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect(0, 0, 230, 30);
-		rect += topleft_client + v2s32(160, ypos);
+		core::rect<s32> rect(0, 0, 230 * s, 30 * s);
+		rect += topleft_client + v2s32(160 * s, ypos);
 		gui::IGUIEditBox *e = Environment->addEditBox(
 				m_newpass_confirm.c_str(), rect, true, this, ID_newPassword2);
 		e->setPasswordBox(true);
 	}
 
-	ypos += 50;
+	ypos += 50 * s;
 	{
-		core::rect<s32> rect(0, 0, 100, 30);
-		rect = rect + v2s32(size.X / 4 + 56, ypos);
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect = rect + v2s32(size.X / 4 + 56 * s, ypos);
 		text = wgettext("Change");
 		Environment->addButton(rect, this, ID_change, text);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect(0, 0, 100, 30);
-		rect = rect + v2s32(size.X / 4 + 185, ypos);
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect = rect + v2s32(size.X / 4 + 185 * s, ypos);
 		text = wgettext("Cancel");
 		Environment->addButton(rect, this, ID_cancel, text);
 		delete[] text;
 	}
 
-	ypos += 50;
+	ypos += 50 * s;
 	{
-		core::rect<s32> rect(0, 0, 300, 20);
-		rect += topleft_client + v2s32(35, ypos);
+		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
+		rect += topleft_client + v2s32(35 * s, ypos);
 		text = wgettext("Passwords do not match!");
 		IGUIElement *e =
 			Environment->addStaticText(

--- a/src/gui/guiPathSelectMenu.cpp
+++ b/src/gui/guiPathSelectMenu.cpp
@@ -41,7 +41,7 @@ void GUIFileSelectMenu::regenerateGui(v2u32 screensize)
 	removeChildren();
 	m_fileOpenDialog = 0;
 
-	core::dimension2du size(600, 400);
+	core::dimension2du size(600 * m_gui_scale, 400 * m_gui_scale);
 	core::rect<s32> rect(0, 0, screensize.X, screensize.Y);
 
 	DesiredRect = rect;

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -66,15 +66,15 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		Remove stuff
 	*/
 	removeChildren();
-
 	/*
 		Calculate new sizes and positions
 	*/
+	const float s = m_gui_scale;
 	DesiredRect = core::rect<s32>(
-		screensize.X/2 - 380/2,
-		screensize.Y/2 - 200/2,
-		screensize.X/2 + 380/2,
-		screensize.Y/2 + 200/2
+		screensize.X / 2 - 380 * s / 2,
+		screensize.Y / 2 - 200 * s / 2,
+		screensize.X / 2 + 380 * s / 2,
+		screensize.Y / 2 + 200 * s / 2
 	);
 	recalculateAbsolutePosition(false);
 
@@ -85,8 +85,8 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 		Add stuff
 	*/
 	{
-		core::rect<s32> rect(0, 0, 160, 20);
-		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 70);
+		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
+		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 70 * s);
 
 		const wchar_t *text = wgettext("Sound Volume: ");
 		core::stringw volume_text = text;
@@ -97,24 +97,24 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 				true, this, ID_soundText);
 	}
 	{
-		core::rect<s32> rect(0, 0, 80, 30);
-		rect = rect + v2s32(size.X/2-80/2, size.Y/2+55);
+		core::rect<s32> rect(0, 0, 80 * s, 30 * s);
+		rect = rect + v2s32(size.X / 2 - 80 * s / 2, size.Y / 2 + 55 * s);
 		const wchar_t *text = wgettext("Exit");
 		Environment->addButton(rect, this, ID_soundExitButton,
 			text);
 		delete[] text;
 	}
 	{
-		core::rect<s32> rect(0, 0, 300, 20);
-		rect = rect + v2s32(size.X / 2 - 150, size.Y / 2);
+		core::rect<s32> rect(0, 0, 300 * s, 20 * s);
+		rect = rect + v2s32(size.X / 2 - 150 * s, size.Y / 2);
 		gui::IGUIScrollBar *e = Environment->addScrollBar(true,
 			rect, this, ID_soundSlider);
 		e->setMax(100);
 		e->setPos(volume);
 	}
 	{
-		core::rect<s32> rect(0, 0, 160, 20);
-		rect = rect + v2s32(size.X / 2 - 80, size.Y / 2 - 35);
+		core::rect<s32> rect(0, 0, 160 * s, 20 * s);
+		rect = rect + v2s32(size.X / 2 - 80 * s, size.Y / 2 - 35 * s);
 		const wchar_t *text = wgettext("Muted");
 		Environment->addCheckBox(g_settings->getBool("mute_sound"), rect, this,
 				ID_soundMuteButton, text);

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "modalMenu.h"
 #include "gettext.h"
 #include "porting.h"
+#include "settings.h"
 
 #ifdef HAVE_TOUCHSCREENGUI
 #include "touchscreengui.h"
@@ -37,6 +38,11 @@ GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent, 
 #endif
 		m_menumgr(menumgr)
 {
+	m_gui_scale = g_settings->getFloat("gui_scaling");
+#ifdef __ANDROID__
+	float d = porting::getDisplayDensity();
+	m_gui_scale *= 1.1 - 0.3 * d + 0.2 * d * d;
+#endif
 	setVisible(true);
 	Environment->setFocus(this);
 	m_menumgr->createdMenu(this);

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -65,6 +65,7 @@ protected:
 	v2s32 m_pointer;
 	v2s32 m_old_pointer;  // Mouse position after previous mouse event
 	v2u32 m_screensize_old;
+	float m_gui_scale;
 #ifdef __ANDROID__
 	v2s32 m_down_pos;
 	std::string m_jni_field_name;

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -86,6 +86,7 @@ src/gettext.cpp
 src/gettext.h
 src/gui/guiChatConsole.cpp
 src/gui/guiChatConsole.h
+src/gui/guiConfirmRegistration.cpp
 src/gui/guiEditBoxWithScrollbar.cpp
 src/gui/guiEditBoxWithScrollbar.h
 src/gui/guiEngine.cpp


### PR DESCRIPTION
Currently the non-formspec `GUIModalMenu` based dialogs do not scale according with the user’s `gui_scaling` configuration which I consider a bug, itself, worthy of fixing.

**Dialogs affected:**
- Confirm registration
- Password change
- Path select
- Key change menu
- Volume change

While this PR is not Android specific, this is of particular importance for mobile devices. For this platform, I have also included some factoring for density. After much experimentation I came up with a simple polynomial that seems to work quite well across a wide range of resolutions and densities.

| Density  | Scale |
| ------------- | ------------- |
| 0.75 | 0.987  |
| 1  | 1  |
| 1.5  | 1.1  |
| 2  | 1.3  |
| 3  | 2  |