### PR TITLE
Clean up stack after script_get_backtrace.

### DIFF
--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -27,7 +27,9 @@ std::string script_get_backtrace(lua_State *L)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_BACKTRACE);
 	lua_call(L, 0, 1);
-	return luaL_checkstring(L, -1);
+	std::string result = luaL_checkstring(L, -1);
+	lua_pop(L, 1);
+	return result;
 }
 
 int script_exception_wrapper(lua_State *L, lua_CFunction f)


### PR DESCRIPTION
script_get_backtrace() was leaving its return value on the stack, corrupting
subsequent lua operations for functions that did not immediately return.

This problem can specifically be observed in the case of multiple "groupcaps"
entries, each of which provides the legacy "maxwear" property.  These cause a
backtrace and thus pollute the stack for the following lua_next() call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/minetest/minetest/7854)
<!-- Reviewable:end -->
