### PR TITLE
Set subtle fall bobbing as the default instead of none

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -629,7 +629,7 @@ view_bobbing_amount (View bobbing factor) float 1.0
 
 #    Multiplier for fall bobbing.
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
-fall_bobbing_amount (Fall bobbing factor) float 0.0
+fall_bobbing_amount (Fall bobbing factor) float 0.03
 
 #    3D support.
 #    Currently supported:

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -176,7 +176,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("cinematic_camera_smoothing", "0.7");
 	settings->setDefault("enable_clouds", "true");
 	settings->setDefault("view_bobbing_amount", "1.0");
-	settings->setDefault("fall_bobbing_amount", "0.0");
+	settings->setDefault("fall_bobbing_amount", "0.03");
 	settings->setDefault("enable_3d_clouds", "true");
 	settings->setDefault("cloud_radius", "12");
 	settings->setDefault("menu_clouds", "true");


### PR DESCRIPTION
I think that some people don't like normal (1.0) fall bobbing because the camera moving down after falling can be distracting. 
With disabled fall bobbing (0.0), landing after a having a high falling velocity looks very hard because the velocity is set to 0 in an instant (this is the current default).
I set fall_bobbing_amount to 0.03, which makes you notice the bobbing only if you pay enough attention, so it's not distracting and there is no sudden velocity change.
I think that most minetest players do not change the fall bobbing setting manually because they don't know the setting and hardly care about it.
Please test and tell me what you think about it.