### PR TITLE
Lua API: Add register_on_chatcommand to SSM and CSM

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -23,6 +23,11 @@ core.register_on_sending_chat_message(function(message)
 		return true
 	end
 
+	-- Run core.registered_on_chatcommand callbacks.
+	if core.run_callbacks(core.registered_on_chatcommand, 5, cmd, param) then
+		return true
+	end
+
 	local cmd_def = core.registered_chatcommands[cmd]
 	if cmd_def then
 		core.set_last_run_mod(cmd_def.mod_origin)

--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -63,6 +63,7 @@ core.registered_on_mods_loaded, core.register_on_mods_loaded = make_registration
 core.registered_on_shutdown, core.register_on_shutdown = make_registration()
 core.registered_on_receiving_chat_message, core.register_on_receiving_chat_message = make_registration()
 core.registered_on_sending_chat_message, core.register_on_sending_chat_message = make_registration()
+core.registered_on_chatcommand, core.register_on_chatcommand = make_registration()
 core.registered_on_death, core.register_on_death = make_registration()
 core.registered_on_hp_modification, core.register_on_hp_modification = make_registration()
 core.registered_on_damage_taken, core.register_on_damage_taken = make_registration()

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -58,6 +58,11 @@ core.register_on_chat_message(function(name, message)
 
 	param = param or ""
 
+	-- Run core.registered_on_chatcommands callbacks.
+	if core.run_callbacks(core.registered_on_chatcommands, 5, name, cmd, param) then
+		return true
+	end
+
 	local cmd_def = core.registered_chatcommands[cmd]
 	if not cmd_def then
 		core.chat_send_player(name, "-!- Invalid command: " .. cmd)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -584,6 +584,7 @@ core.unregister_biome = make_wrap_deregistration(core.register_biome,
 		core.clear_registered_biomes, core.registered_biomes)
 
 core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
+core.registered_on_chatcommands, core.register_on_chatcommand = make_registration()
 core.registered_globalsteps, core.register_globalstep = make_registration()
 core.registered_playerevents, core.register_playerevent = make_registration()
 core.registered_on_mods_loaded, core.register_on_mods_loaded = make_registration()

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -109,6 +109,10 @@ core.register_on_sending_chat_message(function(message)
 	return false
 end)
 
+core.register_on_chatcommand(function(command, params)
+	print("[PREVIEW] caught command '"..command.."'. Parameters: '"..params.."'")
+end)
+
 -- This is an example function to ensure it's working properly, should be removed before merge
 core.register_on_hp_modification(function(hp)
 	print("[PREVIEW] HP modified " .. hp)

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -686,6 +686,11 @@ Call these functions only at load time!
     * Adds definition to minetest.registered_chatcommands
 * `minetest.unregister_chatcommand(name)`
     * Unregisters a chatcommands registered with register_chatcommand.
+* `minetest.register_on_chatcommand(function(command, params))`
+    * Called always when a chatcommand is triggered, before `minetest.registered_chatcommands`
+      is checked to see if that the command exists, but after the input is parsed.
+    * Return `true` to mark the command as handled, which means that the default
+      handlers will be prevented.
 * `minetest.register_on_death(function())`
     * Called when the local player dies
 * `minetest.register_on_hp_modification(function(hp))`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4606,6 +4606,11 @@ Call these functions only at load time!
     * Called always when a player says something
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
+* `minetest.register_on_chatcommand(function(name, command, params))`
+    * Called always when a chatcommand is triggered, before `minetest.registered_chatcommands`
+      is checked to see if the command exists, but after the input is parsed.
+    * Return `true` to mark the command as handled, which means that the default
+      handlers will be prevented.
 * `minetest.register_on_player_receive_fields(function(player, formname, fields))`
     * Called when the server received input from `player` in a formspec with
       the given `formname`. Specifically, this is called on any of the

--- a/games/devtest/mods/experimental/commands.lua
+++ b/games/devtest/mods/experimental/commands.lua
@@ -214,3 +214,6 @@ minetest.register_chatcommand("test_place_nodes", {
 	end,
 })
 
+core.register_on_chatcommand(function(name, command, params)
+	minetest.log("caught command '"..command.."', issued by '"..name.."'. Parameters: '"..params.."'")
+end)


### PR DESCRIPTION
Allows catching a chatcommand call just after the command and the parameters are parsed but before its existence is checked and before the corresponding function is run. Returning `true` from a callback function will prevent default handling of the command leaving mods to handle the
command manually.

## Example Usecase

Chatcommands that are meant to be contextual depending on the player's location. And yes, a check could simply be added to each individual chatcommand, but this could prove rather repetitive if any special handling were required for pre-existing commands. Instead, this feature could, for example, allow an additional field to be added to the definition of chatcommands that are limited to particular regions, and whenever a chatcommand is run, the field could be checked to ensure that it evaluates to `true` (or doesn't exist at all).

## How to test

- Launch a Minimal Test world.
- Type a server-side chatcommand, it doesn't have to exist, and verify that a message similar to the following appears in the log:
```
caught command 'test', issued by 'singleplayer'. Parameters: ''
```
- Type a client-side chatcommand, it doesn't have to exist, and verify that a message similar to the following appears in the log:
```
[PREVIEW] caught command 'test'. Parameters: ''
```