### PR TITLE
Add crosshair support for Android

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -308,10 +308,6 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		core.show_keys_menu()
 		return true
 	end
-	if fields["cb_touchscreen_target"] then
-		core.settings:set("touchtarget", fields["cb_touchscreen_target"])
-		return true
-	end
 
 	--Note dropdowns have to be handled LAST!
 	local ddhandled = false

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -117,6 +117,10 @@ mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 #    The length in pixels it takes for touch screen interaction to start.
 touchscreen_threshold (Touch screen threshold) int 20 0 100
 
+#    (Android) Use crosshair to select object instead of whole screen.
+#    If enabled, a crosshair will be shown and will be used for selecting object.
+use_crosshair (Use crosshair) bool false
+
 #    (Android) Fixes the position of virtual joystick.
 #    If disabled, virtual joystick will center to first-touch's position.
 fixed_virtual_joystick (Fixed virtual joystick) bool false

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -117,7 +117,7 @@ mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 #    The length in pixels it takes for touch screen interaction to start.
 touchscreen_threshold (Touch screen threshold) int 20 0 100
 
-#    (Android) Use crosshair to select object instead of whole screen.
+#    Use crosshair to select object instead of whole screen.
 #    If enabled, a crosshair will be shown and will be used for selecting object.
 touch_use_crosshair (Use crosshair for touch screen) bool false
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -119,7 +119,7 @@ touchscreen_threshold (Touch screen threshold) int 20 0 100
 
 #    (Android) Use crosshair to select object instead of whole screen.
 #    If enabled, a crosshair will be shown and will be used for selecting object.
-use_crosshair (Use crosshair) bool false
+touch_use_crosshair (Use crosshair for touch screen) bool false
 
 #    (Android) Fixes the position of virtual joystick.
 #    If disabled, virtual joystick will center to first-touch's position.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3104,6 +3104,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 
 #ifdef HAVE_TOUCHSCREENGUI
 	if (g_settings->getBool("touchtarget") && g_touchscreengui &&
+			!g_settings->getBool("use_crosshair") &&
 			camera->getCameraMode() == CAMERA_MODE_FIRST) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -920,8 +920,7 @@ private:
 
 #ifdef HAVE_TOUCHSCREENGUI
 	bool m_cache_hold_aux1;
-	bool m_android_touchtarget;
-	bool m_android_use_crosshair;
+	bool m_touch_use_crosshair;
 #endif
 #ifdef __ANDROID__
 	bool m_android_chat_open;
@@ -1054,8 +1053,7 @@ bool Game::startup(bool *kill,
 	m_first_loop_after_window_activation = true;
 
 #ifdef HAVE_TOUCHSCREENGUI
-	m_android_touchtarget = g_settings->getBool("touchtarget");
-	m_android_use_crosshair = g_settings->getBool("touch_use_crosshair");
+	m_touch_use_crosshair = g_settings->getBool("touch_use_crosshair");
 #endif
 
 	g_client_translations->clear();
@@ -2990,7 +2988,7 @@ void Game::updateCamera(f32 dtime)
 
 #ifdef HAVE_TOUCHSCREENGUI
 		if (g_touchscreengui)
-			g_touchscreengui->setUseCrosshair(m_android_use_crosshair ||
+			g_touchscreengui->setUseCrosshair(m_touch_use_crosshair ||
 					camera->getCameraMode() == CAMERA_MODE_THIRD);
 #endif
 
@@ -3104,7 +3102,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	shootline.end = shootline.start + camera_direction * BS * d;
 
 #ifdef HAVE_TOUCHSCREENGUI
-	if (m_android_touchtarget && g_touchscreengui && !m_android_use_crosshair &&
+	if (g_touchscreengui && !m_touch_use_crosshair &&
 			camera->getCameraMode() == CAMERA_MODE_FIRST) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach
@@ -4003,7 +4001,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 #ifdef HAVE_TOUCHSCREENGUI
-	if (!m_android_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST)
+	if (!m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST)
 		draw_crosshair = false;
 #endif
 	m_rendering_engine->draw_scene(skycolor, m_game_ui->m_flags.show_hud,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -920,11 +920,11 @@ private:
 
 #ifdef HAVE_TOUCHSCREENGUI
 	bool m_cache_hold_aux1;
+	bool m_android_touchtarget;
+	bool m_android_use_crosshair;
 #endif
 #ifdef __ANDROID__
 	bool m_android_chat_open;
-	bool m_android_touchtarget;
-	bool m_android_use_crosshair;
 #endif
 };
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2991,8 +2991,7 @@ void Game::updateCamera(f32 dtime)
 
 #ifdef HAVE_TOUCHSCREENGUI
 		if (g_touchscreengui)
-			g_touchscreengui->setUseCrosshair(m_touch_use_crosshair ||
-					camera->getCameraMode() == CAMERA_MODE_THIRD);
+			g_touchscreengui->setUseCrosshair(!isNoCrosshairAllowed());
 #endif
 
 		// Make the player visible depending on camera mode.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -921,6 +921,9 @@ private:
 #ifdef HAVE_TOUCHSCREENGUI
 	bool m_cache_hold_aux1;
 	bool m_touch_use_crosshair;
+	inline bool isNoCrosshairAllowed() {
+		return !m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST;
+	}
 #endif
 #ifdef __ANDROID__
 	bool m_android_chat_open;
@@ -3102,8 +3105,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	shootline.end = shootline.start + camera_direction * BS * d;
 
 #ifdef HAVE_TOUCHSCREENGUI
-	if (g_touchscreengui && !m_touch_use_crosshair &&
-			camera->getCameraMode() == CAMERA_MODE_FIRST) {
+	if (g_touchscreengui && isNoCrosshairAllowed()) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach
 		shootline.end = shootline.start +
@@ -4001,7 +4003,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 #ifdef HAVE_TOUCHSCREENGUI
-	if (!m_touch_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST)
+	if (isNoCrosshairAllowed())
 		draw_crosshair = false;
 #endif
 	m_rendering_engine->draw_scene(skycolor, m_game_ui->m_flags.show_hud,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1055,7 +1055,7 @@ bool Game::startup(bool *kill,
 
 #ifdef HAVE_TOUCHSCREENGUI
 	m_android_touchtarget = g_settings->getBool("touchtarget");
-	m_android_use_crosshair = g_settings->getBool("use_crosshair");
+	m_android_use_crosshair = g_settings->getBool("touch_use_crosshair");
 #endif
 
 	g_client_translations->clear();
@@ -2990,7 +2990,8 @@ void Game::updateCamera(f32 dtime)
 
 #ifdef HAVE_TOUCHSCREENGUI
 		if (g_touchscreengui)
-			g_touchscreengui->setCameraMode(camera->getCameraMode());
+			g_touchscreengui->setUseCrosshair(m_android_use_crosshair ||
+					camera->getCameraMode() == CAMERA_MODE_THIRD);
 #endif
 
 		// Make the player visible depending on camera mode.
@@ -3103,8 +3104,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	shootline.end = shootline.start + camera_direction * BS * d;
 
 #ifdef HAVE_TOUCHSCREENGUI
-	if (g_settings->getBool("touchtarget") && g_touchscreengui &&
-			!g_settings->getBool("use_crosshair") &&
+	if (m_android_touchtarget && g_touchscreengui && !m_android_use_crosshair &&
 			camera->getCameraMode() == CAMERA_MODE_FIRST) {
 		shootline = g_touchscreengui->getShootline();
 		// Scale shootline to the acual distance the player can reach
@@ -3999,15 +3999,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	bool draw_wield_tool = (m_game_ui->m_flags.show_hud &&
 			(player->hud_flags & HUD_FLAG_WIELDITEM_VISIBLE) &&
 			(camera->getCameraMode() == CAMERA_MODE_FIRST));
-#ifndef HAVE_TOUCHSCREENGUI
 	bool draw_crosshair = (
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
-#else
-	bool draw_crosshair = !m_android_touchtarget ||
-			(m_android_use_crosshair &&
-			camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT) ||
-			camera->getCameraMode() == CAMERA_MODE_THIRD;
+#ifdef HAVE_TOUCHSCREENGUI
+	if (!m_android_use_crosshair && camera->getCameraMode() == CAMERA_MODE_FIRST)
+		draw_crosshair = false;
 #endif
 	m_rendering_engine->draw_scene(skycolor, m_game_ui->m_flags.show_hud,
 			m_game_ui->m_flags.show_minimap, draw_wield_tool, draw_crosshair);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -467,7 +467,7 @@ void set_default_settings()
 #ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("touchtarget", "true");
 	settings->setDefault("touchscreen_threshold","20");
-	settings->setDefault("use_crosshair", "false");
+	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
 	settings->setDefault("clickable_chat_weblinks", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -465,7 +465,6 @@ void set_default_settings()
 #endif
 
 #ifdef HAVE_TOUCHSCREENGUI
-	settings->setDefault("touchtarget", "true");
 	settings->setDefault("touchscreen_threshold","20");
 	settings->setDefault("touch_use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -467,6 +467,7 @@ void set_default_settings()
 #ifdef HAVE_TOUCHSCREENGUI
 	settings->setDefault("touchtarget", "true");
 	settings->setDefault("touchscreen_threshold","20");
+	settings->setDefault("use_crosshair", "false");
 	settings->setDefault("fixed_virtual_joystick", "false");
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
 	settings->setDefault("clickable_chat_weblinks", "false");

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -425,6 +425,7 @@ TouchScreenGUI::TouchScreenGUI(IrrlichtDevice *device, IEventReceiver *receiver)
 	m_touchscreen_threshold = g_settings->getU16("touchscreen_threshold");
 	m_fixed_joystick = g_settings->getBool("fixed_virtual_joystick");
 	m_joystick_triggers_aux1 = g_settings->getBool("virtual_joystick_triggers_aux1");
+	m_use_crosshair = g_settings->getBool("use_crosshair");
 	m_screensize = m_device->getVideoDriver()->getScreenSize();
 	button_size = MYMIN(m_screensize.Y / 4.5f,
 			RenderingEngine::getDisplayDensity() *
@@ -678,12 +679,17 @@ void TouchScreenGUI::handleReleaseEvent(size_t evt_id)
 			auto *translated = new SEvent;
 			memset(translated, 0, sizeof(SEvent));
 			translated->EventType               = EET_MOUSE_INPUT_EVENT;
-			translated->MouseInput.X            = m_move_downlocation.X;
-			translated->MouseInput.Y            = m_move_downlocation.Y;
 			translated->MouseInput.Shift        = false;
 			translated->MouseInput.Control      = false;
 			translated->MouseInput.ButtonStates = 0;
 			translated->MouseInput.Event        = EMIE_LMOUSE_LEFT_UP;
+			if (m_use_crosshair || m_camera_mode == CAMERA_MODE_THIRD) {
+				translated->MouseInput.X = m_screensize.X / 2;
+				translated->MouseInput.Y = m_screensize.Y / 2;
+			} else {
+				translated->MouseInput.X = m_move_downlocation.X;
+				translated->MouseInput.Y = m_move_downlocation.Y;
+			}
 			m_receiver->OnEvent(*translated);
 			delete translated;
 		} else {
@@ -803,8 +809,11 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					m_move_id                  = event.TouchInput.ID;
 					m_move_has_really_moved    = false;
 					m_move_downtime            = porting::getTimeMs();
-					m_move_downlocation        = v2s32(event.TouchInput.X, event.TouchInput.Y);
 					m_move_sent_as_mouse_event = false;
+					if (m_use_crosshair || m_camera_mode == CAMERA_MODE_THIRD)
+						m_move_downlocation = v2s32(m_screensize.X / 2, m_screensize.Y / 2);
+					else
+						m_move_downlocation = v2s32(event.TouchInput.X, event.TouchInput.Y);
 				}
 			}
 		}
@@ -823,9 +832,9 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 			return;
 
 		if (m_has_move_id) {
-			if ((event.TouchInput.ID == m_move_id) &&
-				(!m_move_sent_as_mouse_event)) {
-
+			if (event.TouchInput.ID == m_move_id &&
+					(!m_move_sent_as_mouse_event || m_use_crosshair ||
+					m_camera_mode == CAMERA_MODE_THIRD)) {
 				double distance = sqrt(
 						(m_pointerpos[event.TouchInput.ID].X - event.TouchInput.X) *
 						(m_pointerpos[event.TouchInput.ID].X - event.TouchInput.X) +
@@ -841,6 +850,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					// update camera_yaw and camera_pitch
 					s32 dx = X - m_pointerpos[event.TouchInput.ID].X;
 					s32 dy = Y - m_pointerpos[event.TouchInput.ID].Y;
+					m_pointerpos[event.TouchInput.ID] = v2s32(X, Y);
 
 					// adapt to similar behaviour as pc screen
 					const double d = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f) * 3.0f;
@@ -849,11 +859,14 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dy * d), -180), 180);
 
 					// update shootline
+					if (m_use_crosshair || m_camera_mode == CAMERA_MODE_THIRD) {
+						X = m_screensize.X / 2;
+						Y = m_screensize.Y / 2;
+					}
 					m_shootline = m_device
 							->getSceneManager()
 							->getSceneCollisionManager()
 							->getRayFromScreenCoordinates(v2s32(X, Y));
-					m_pointerpos[event.TouchInput.ID] = v2s32(X, Y);
 				}
 			} else if ((event.TouchInput.ID == m_move_id) &&
 					(m_move_sent_as_mouse_event)) {
@@ -1010,11 +1023,18 @@ bool TouchScreenGUI::doubleTapDetection()
 	if (distance > (20 + m_touchscreen_threshold))
 		return false;
 
+	s32 mX = m_key_events[0].x;
+	s32 mY = m_key_events[0].y;
+	if (m_use_crosshair || m_camera_mode == CAMERA_MODE_THIRD) {
+		mX = m_screensize.X / 2;
+		mY = m_screensize.Y / 2;
+	}
+
 	auto *translated = new SEvent();
 	memset(translated, 0, sizeof(SEvent));
 	translated->EventType               = EET_MOUSE_INPUT_EVENT;
-	translated->MouseInput.X            = m_key_events[0].x;
-	translated->MouseInput.Y            = m_key_events[0].y;
+	translated->MouseInput.X            = mX;
+	translated->MouseInput.Y            = mY;
 	translated->MouseInput.Shift        = false;
 	translated->MouseInput.Control      = false;
 	translated->MouseInput.ButtonStates = EMBSM_RIGHT;
@@ -1023,7 +1043,7 @@ bool TouchScreenGUI::doubleTapDetection()
 	m_shootline = m_device
 			->getSceneManager()
 			->getSceneCollisionManager()
-			->getRayFromScreenCoordinates(v2s32(m_key_events[0].x, m_key_events[0].y));
+			->getRayFromScreenCoordinates(v2s32(mX, mY));
 
 	translated->MouseInput.Event = EMIE_RMOUSE_PRESSED_DOWN;
 	verbosestream << "TouchScreenGUI::translateEvent right click press" << std::endl;
@@ -1124,17 +1144,23 @@ void TouchScreenGUI::step(float dtime)
 		u64 delta = porting::getDeltaMs(m_move_downtime, porting::getTimeMs());
 
 		if (delta > MIN_DIG_TIME_MS) {
+			s32 mX = m_move_downlocation.X;
+			s32 mY = m_move_downlocation.Y;
+			if (m_use_crosshair || m_camera_mode == CAMERA_MODE_THIRD) {
+				mX = m_screensize.X / 2;
+				mY = m_screensize.Y / 2;
+			}
 			m_shootline = m_device
 					->getSceneManager()
 					->getSceneCollisionManager()
 					->getRayFromScreenCoordinates(
-							v2s32(m_move_downlocation.X,m_move_downlocation.Y));
+							v2s32(mX, mY));
 
 			SEvent translated;
 			memset(&translated, 0, sizeof(SEvent));
 			translated.EventType               = EET_MOUSE_INPUT_EVENT;
-			translated.MouseInput.X            = m_move_downlocation.X;
-			translated.MouseInput.Y            = m_move_downlocation.Y;
+			translated.MouseInput.X            = mX;
+			translated.MouseInput.Y            = mY;
 			translated.MouseInput.Shift        = false;
 			translated.MouseInput.Control      = false;
 			translated.MouseInput.ButtonStates = EMBSM_LEFT;

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -855,10 +855,7 @@ void TouchScreenGUI::translateEvent(const SEvent &event)
 					m_camera_pitch = MYMIN(MYMAX(m_camera_pitch + (dy * d), -180), 180);
 
 					// update shootline
-					if (m_draw_crosshair) {
-						X = m_screensize.X / 2;
-						Y = m_screensize.Y / 2;
-					}
+					// no need to update (X, Y) when using crosshair since the shootline is not used
 					m_shootline = m_device
 							->getSceneManager()
 							->getSceneCollisionManager()

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "client/tile.h"
 #include "client/game.h"
+#include "client/camera.h"
 
 using namespace irr;
 using namespace irr::core;
@@ -194,6 +195,7 @@ public:
 	void step(float dtime);
 	void resetHud();
 	void registerHudItem(int index, const rect<s32> &rect);
+	inline void setCameraMode(CameraMode camera_mode) { m_camera_mode = camera_mode; }
 	void Toggle(bool visible);
 
 	void hide();
@@ -214,6 +216,9 @@ private:
 	// value in degree
 	double m_camera_yaw_change = 0.0;
 	double m_camera_pitch = 0.0;
+
+	// camera mode (used for crosshair)
+	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
 
 	// forward, backward, left, right
 	touch_gui_button_id m_joystick_names[5] = {
@@ -240,6 +245,7 @@ private:
 	bool m_joystick_has_really_moved = false;
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
+	bool m_use_crosshair = false;
 	button_info *m_joystick_btn_off = nullptr;
 	button_info *m_joystick_btn_bg = nullptr;
 	button_info *m_joystick_btn_center = nullptr;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -195,7 +195,7 @@ public:
 	void step(float dtime);
 	void resetHud();
 	void registerHudItem(int index, const rect<s32> &rect);
-	inline void setCameraMode(CameraMode camera_mode) { m_camera_mode = camera_mode; }
+	inline void setUseCrosshair(bool use_crosshair) { m_draw_crosshair = use_crosshair; }
 	void Toggle(bool visible);
 
 	void hide();
@@ -216,9 +216,6 @@ private:
 	// value in degree
 	double m_camera_yaw_change = 0.0;
 	double m_camera_pitch = 0.0;
-
-	// camera mode (used for crosshair)
-	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
 
 	// forward, backward, left, right
 	touch_gui_button_id m_joystick_names[5] = {
@@ -245,7 +242,7 @@ private:
 	bool m_joystick_has_really_moved = false;
 	bool m_fixed_joystick = false;
 	bool m_joystick_triggers_aux1 = false;
-	bool m_use_crosshair = false;
+	bool m_draw_crosshair = false;
 	button_info *m_joystick_btn_off = nullptr;
 	button_info *m_joystick_btn_bg = nullptr;
 	button_info *m_joystick_btn_center = nullptr;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -29,7 +29,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "client/tile.h"
 #include "client/game.h"
-#include "client/camera.h"
 
 using namespace irr;
 using namespace irr::core;


### PR DESCRIPTION
If `touch_use_crosshair` is enabled, a crosshair will be shown to select the object. This will give Android (or any touch screen interface) player a way to play like they play on desktop (with mouse).

For third-person camera mode, it is same as the desktop version: on third-person back camera mode, player is forced to use crosshair; while on third-person front camera mode, player is unable to select anything.

Possibly fixes #7645 and fixes #6181.

[YouTube video (1)](https://youtu.be/wF1Dpdrnhds)
[YouTube video (2)](https://youtu.be/Hw73Ohyodls)