### PR TITLE
Add 'item' visual type

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5472,7 +5472,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         pointable = true,
         -- Overrides selection box when false
 
-        visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem",
+        visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem" / "node",
         -- "cube" is a node-sized cube.
         -- "sprite" is a flat texture always facing the player.
         -- "upright_sprite" is a vertical flat texture.
@@ -5488,6 +5488,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         --   of its texture.
         --   Otherwise for non-node items, the object will be an extrusion of
         --   'inventory_image'.
+		-- "node" mirrors behavior of "mesh" without the 'wield_image' check.
 
         visual_size = {x = 1, y = 1},
         -- `x` multiplies horizontal (X and Z) visual size.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5472,7 +5472,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         pointable = true,
         -- Overrides selection box when false
 
-        visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem" / "node",
+        visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem" / "item",
         -- "cube" is a node-sized cube.
         -- "sprite" is a flat texture always facing the player.
         -- "upright_sprite" is a vertical flat texture.
@@ -5488,7 +5488,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         --   of its texture.
         --   Otherwise for non-node items, the object will be an extrusion of
         --   'inventory_image'.
-	    -- "node" is similar to "wielditem" but ignores the 'wield_image' parameter.
+        -- "item" is similar to "wielditem" but ignores the 'wield_image' parameter.
 
         visual_size = {x = 1, y = 1},
         -- `x` multiplies horizontal (X and Z) visual size.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5488,7 +5488,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         --   of its texture.
         --   Otherwise for non-node items, the object will be an extrusion of
         --   'inventory_image'.
-	    -- "node" mirrors behavior of "mesh" without the 'wield_image' check.
+	    -- "node" is similar to "wielditem" but ignores the 'wield_image' parameter.
 
         visual_size = {x = 1, y = 1},
         -- `x` multiplies horizontal (X and Z) visual size.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5488,7 +5488,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         --   of its texture.
         --   Otherwise for non-node items, the object will be an extrusion of
         --   'inventory_image'.
-		-- "node" mirrors behavior of "mesh" without the 'wield_image' check.
+	    -- "node" mirrors behavior of "mesh" without the 'wield_image' check.
 
         visual_size = {x = 1, y = 1},
         -- `x` multiplies horizontal (X and Z) visual size.

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -683,9 +683,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		
 		// Does wield_image need to be checked or not
 		if (m_prop.visual == "wielditem") {
-			m_wield_meshnode->setItemCheck(item, m_client, true);
+			m_wield_meshnode->setItem(item, m_client, true);
 		} else {
-			m_wield_meshnode->setItemCheck(item, m_client, false);
+			m_wield_meshnode->setItem(item, m_client, false);
 		}
 
 		m_wield_meshnode->setScale(

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -682,13 +682,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 			RenderingEngine::get_scene_manager(), -1);
 		m_wield_meshnode->setItem(item, m_client,
 			(m_prop.visual == "wielditem"));
-		
-		// Does wield_image need to be checked or not
-		if (m_prop.visual == "wielditem") {
-			m_wield_meshnode->setItem(item, m_client, true);
-		} else {
-			m_wield_meshnode->setItem(item, m_client, false);
-		}
 
 		m_wield_meshnode->setScale(
 			v3f(m_prop.visual_size.X / 2, m_prop.visual_size.Y / 2,

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -662,7 +662,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		}
 		else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
-	} else if (m_prop.visual == "wielditem") {
+	} else if (m_prop.visual == "wielditem" || m_prop.visual == "node") {
 		ItemStack item;
 		infostream << "GenericCAO::addToScene(): wielditem" << std::endl;
 		if (m_prop.wield_item.empty()) {
@@ -680,7 +680,13 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		}
 		m_wield_meshnode = new WieldMeshSceneNode(
 			RenderingEngine::get_scene_manager(), -1);
-		m_wield_meshnode->setItem(item, m_client);
+		
+		// Does wield_image need to be checked or not
+		if (m_prop.visual == "wielditem") {
+			m_wield_meshnode->setItemCheck(item, m_client, true);
+		} else {
+			m_wield_meshnode->setItemCheck(item, m_client, false);
+		}
 
 		m_wield_meshnode->setScale(
 			v3f(m_prop.visual_size.X / 2, m_prop.visual_size.Y / 2,

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -662,7 +662,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		}
 		else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
-	} else if (m_prop.visual == "wielditem" || m_prop.visual == "node") {
+	} else if (m_prop.visual == "wielditem" || m_prop.visual == "item") {
 		ItemStack item;
 		infostream << "GenericCAO::addToScene(): wielditem" << std::endl;
 		if (m_prop.wield_item.empty()) {
@@ -680,6 +680,8 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		}
 		m_wield_meshnode = new WieldMeshSceneNode(
 			RenderingEngine::get_scene_manager(), -1);
+		m_wield_meshnode->setItem(item, m_client,
+			(m_prop.visual == "wielditem"));
 		
 		// Does wield_image need to be checked or not
 		if (m_prop.visual == "wielditem") {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -333,7 +333,8 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 	return mesh;
 }
 
-void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
+// Wrapper for original setItem to not break things
+void WieldMeshSceneNode::setItemCheck(const ItemStack &item, Client *client, bool check_wield_image)
 {
 	ITextureSource *tsrc = client->getTextureSource();
 	IItemDefManager *idef = client->getItemDefManager();
@@ -354,8 +355,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 	m_colors.clear();
 	m_base_color = idef->getItemstackColor(item, client);
 
-	// If wield_image is defined, it overrides everything else
-	if (!def.wield_image.empty()) {
+	// If wield_image needs to be checked and is defined, it overrides everything else
+	if (!def.wield_image.empty() && check_wield_image) {
 		setExtruded(def.wield_image, def.wield_overlay, def.wield_scale, tsrc,
 			1);
 		m_colors.emplace_back();
@@ -443,6 +444,12 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
 
 	// no wield mesh found
 	changeToMesh(nullptr);
+}
+
+void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
+{
+	// Call with default of true
+	this->setItemCheck(item, client, true);
 }
 
 void WieldMeshSceneNode::setColor(video::SColor c)

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -333,8 +333,7 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 	return mesh;
 }
 
-// Wrapper for original setItem to not break things
-void WieldMeshSceneNode::setItemCheck(const ItemStack &item, Client *client, bool check_wield_image)
+void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool check_wield_image)
 {
 	ITextureSource *tsrc = client->getTextureSource();
 	IItemDefManager *idef = client->getItemDefManager();
@@ -444,12 +443,6 @@ void WieldMeshSceneNode::setItemCheck(const ItemStack &item, Client *client, boo
 
 	// no wield mesh found
 	changeToMesh(nullptr);
-}
-
-void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client)
-{
-	// Call with default of true
-	this->setItemCheck(item, client, true);
 }
 
 void WieldMeshSceneNode::setColor(video::SColor c)

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -80,8 +80,7 @@ public:
 	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
-	void setItemCheck(const ItemStack &item, Client *client, bool check_wield_image);
-	void setItem(const ItemStack &item, Client *client);
+	void setItem(const ItemStack &item, Client *client, bool check_wield_image=true);
 
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -80,7 +80,7 @@ public:
 	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
-	void setItem(const ItemStack &item, Client *client, bool check_wield_image=true);
+	void setItem(const ItemStack &item, Client *client, bool check_wield_image = true);
 
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -80,7 +80,8 @@ public:
 	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
-	void setItem(const ItemStack &item, Client *client, bool check_wield_image = true);
+	void setItem(const ItemStack &item, Client *client,
+			bool check_wield_image = true);
 
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -80,6 +80,7 @@ public:
 	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
 			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
+	void setItemCheck(const ItemStack &item, Client *client, bool check_wield_image);
 	void setItem(const ItemStack &item, Client *client);
 
 	// Sets the vertex color of the wield mesh.


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/6986

First pull request for Minetest, and I am a beginner in C++; expect things to be wrong (for example, my commit message is probably too short.)

The `node` visual type for entities mirrors `wielditem` behavior without checking for `wield_image`.

Some test code:
```lua
minetest.register_entity("test:node", {
	visual = "node",
	textures = {"default:fence_wood"},
})

minetest.register_entity("test:wield", {
	visual = "wielditem",
	textures = {"default:fence_wood"},
})
```