### PR TITLE
Fix Android build

### DIFF
--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -31,7 +31,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 #include <irrTypes.h>
-#include <irrMath.h>
 
 using namespace irr;
 
@@ -52,6 +51,9 @@ namespace irr {
 
 #if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR >= 9)
 namespace core {
+	template <typename T>
+	inline T roundingError();
+
 	template <>
 	inline s16 roundingError()
 	{


### PR DESCRIPTION
http://irc.minetest.net/minetest-dev/2018-11-16#i_5440265 (https://github.com/minetest/minetest/pull/7839#issuecomment-439547256)
Older IrrLicht revision used on Android is labelled as 1.9 but lacks `roundingError`, so I add the prototype.