### PR TITLE
Android: Fix recursive delete

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -303,7 +303,11 @@ bool RecursiveDelete(const std::string &path)
 	{
 		// Child
 		char argv_data[3][10000];
+#ifdef __ANDROID__
+		strcpy(argv_data[0], "/system/bin/rm");
+#else
 		strcpy(argv_data[0], "/bin/rm");
+#endif
 		strcpy(argv_data[1], "-rf");
 		strncpy(argv_data[2], path.c_str(), 10000);
 		char *argv[4];


### PR DESCRIPTION
Fixes: #7789

Currently `fs::RecursiveDelete` does not work on android since it uses the wrong path for `rm -rf`