### PR TITLE
CircleCI config file added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,158 @@
+version: 2
+jobs:
+  clang-format:
+    machine: true
+    environment:
+      LINT: 1
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y clang-format-5.0
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  clang-tidy:
+    machine: true
+    environment:
+      CLANG_TIDY: 1
+      COMPILER: gcc-4.9
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-4.9 g++-4.9
+      - run: sudo apt-get install -y clang-tidy-5.0
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/clangtidy.sh
+  win32:
+    machine: true
+    environment:
+      PLATFORM: Win32
+    steps:
+      - checkout
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  win64:
+    machine: true
+    environment:
+      PLATFORM: Win64
+    steps:
+      - checkout
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  osx:
+    macos:
+        xcode: "8.0"
+    environment:
+      PLATFORM: Unix
+      TRAVIS_OS_NAME: osx
+    steps:
+      - checkout
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  gcc6:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: gcc-6
+      TRAVIS_OS_NAME: linux
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-6 g++-6
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  gcc7:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: gcc-7
+      TRAVIS_OS_NAME: linux
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-7 g++-7
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  clang36:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: clang-3.6
+      TRAVIS_OS_NAME: linux
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.6 main"
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-4.9 g++-4.9
+      - run: sudo apt-get install -y clang-3.6 clang++-3.6
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  clang50:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: clang-5.0
+      TRAVIS_OS_NAME: linux
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-4.9 g++-4.9
+      - run: sudo apt-get install -y clang-5.0 clang++-5.0
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  clang50_no_freetype:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: clang-5.0
+      TRAVIS_OS_NAME: linux
+      FREETYPE: 0
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-4.9 g++-4.9
+      - run: sudo apt-get install -y clang-5.0 clang++-5.0
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+  clang50_valgrind:
+    machine: true
+    environment:
+      PLATFORM: Unix
+      COMPILER: clang-5.0
+      TRAVIS_OS_NAME: linux
+      VALGRIND: 1
+    steps:
+      - checkout
+      - run: sudo add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+      - run: sudo add-apt-repository "ppa:ubuntu-toolchain-r/test"
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y gcc-4.9 g++-4.9
+      - run: sudo apt-get install -y valgrind clang-5.0 clang++-5.0
+      - run: ./util/circleci/before_install.sh
+      - run: ./util/circleci/script.sh
+workflows:
+  version: 2
+  lint:
+    jobs:
+        - clang-format
+        - clang-tidy
+  build:
+    jobs:
+        - win32
+        - win64
+        - gcc6
+        - gcc7
+        - clang36
+        - clang50
+        - clang50_no_freetype
+        - clang50_valgrind
+

--- a/lib/jsoncpp/CMakeLists.txt
+++ b/lib/jsoncpp/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 add_library(jsoncpp jsoncpp.cpp)
 target_link_libraries(jsoncpp)
 

--- a/src/irrlichttypes.h
+++ b/src/irrlichttypes.h
@@ -30,6 +30,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #	include <cstdint>
 #endif
 
+// Fixes MinGW error in CircleCI
+#ifndef M_PI
+#define M_PI (3.14159265358979323846)
+// #define M_PI (3.14159265358979323846264338327950288)
+#endif
+
 #include <irrTypes.h>
 
 using namespace irr;

--- a/util/circleci/before_install.sh
+++ b/util/circleci/before_install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+. util/circleci/common.sh
+
+echo "Preparing for ${CIRCLE_SHA1}"
+
+if [[ "${LINT}" == "1" ]]; then
+	exit 0
+fi
+
+needs_compile || exit 0
+
+if [[ $PLATFORM == "Unix" ]] || [[ $CLANG_TIDY == "1" ]]; then
+	if [[ $TRAVIS_OS_NAME == "linux" ]] || [[ $CLANG_TIDY == "1" ]]; then
+		install_linux_deps
+	else
+		install_macosx_deps
+	fi
+elif [[ $PLATFORM == "Win32" ]]; then
+	sudo apt-get update
+	sudo apt-get install p7zip-full
+	wget http://minetest.kitsunemimi.pw/mingw-w64-i686_7.1.1_ubuntu14.04.7z -O mingw.7z
+	sed -e "s|%PREFIX%|i686-w64-mingw32|" \
+		-e "s|%ROOTPATH%|/usr/i686-w64-mingw32|" \
+		< util/travis/toolchain_mingw.cmake.in > util/buildbot/toolchain_mingw.cmake
+	sudo 7z x -y -o/usr mingw.7z
+elif [[ $PLATFORM == "Win64" ]]; then
+	sudo apt-get update
+	sudo apt-get install p7zip-full
+	wget http://minetest.kitsunemimi.pw/mingw-w64-x86_64_7.1.1_ubuntu14.04.7z -O mingw.7z
+	sed -e "s|%PREFIX%|x86_64-w64-mingw32|" \
+		-e "s|%ROOTPATH%|/usr/x86_64-w64-mingw32|" \
+		< util/travis/toolchain_mingw.cmake.in > util/buildbot/toolchain_mingw64.cmake
+	sudo 7z x -y -o/usr mingw.7z
+fi

--- a/util/circleci/clangtidy.sh
+++ b/util/circleci/clangtidy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+. util/circleci/common.sh
+
+needs_compile || exit 0
+
+set_linux_compiler_env
+
+if hash clang-tidy-5.0 2>/dev/null; then
+	CLANG_TIDY=clang-tidy-5.0
+else
+	CLANG_TIDY=clang-tidy
+fi
+
+files_to_analyze="$(find src/ -name '*.cpp' -or -name '*.h')"
+
+mkdir -p cmakebuild && cd cmakebuild
+cmake -DCMAKE_BUILD_TYPE=Debug \
+	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+	-DRUN_IN_PLACE=TRUE \
+	-DENABLE_GETTEXT=TRUE \
+	-DENABLE_SOUND=FALSE \
+	-DBUILD_SERVER=TRUE ..
+make GenerateVersion
+cd ..
+
+echo "Performing clang-tidy checks..."
+./util/travis/run-clang-tidy.py -clang-tidy-binary=${CLANG_TIDY} -p cmakebuild \
+	-checks='-*,modernize-use-emplace,modernize-avoid-bind,performance-*' \
+	-warningsaserrors='-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find,performance-implicit-cast-in-loop' \
+	-no-command-on-stdout -quiet \
+	files 'src/.*'
+RET=$?
+echo "Clang tidy returned $RET"
+exit $RET

--- a/util/circleci/common.sh
+++ b/util/circleci/common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+set_linux_compiler_env() {
+	if [[ "${COMPILER}" == "gcc-4.9" ]]; then
+		export CC=gcc-4.9
+		export CXX=g++-4.9
+	elif [[ "${COMPILER}" == "gcc-6" ]]; then
+		export CC=gcc-6
+		export CXX=g++-6
+	elif [[ "${COMPILER}" == "gcc-7" ]]; then
+		export CC=gcc-7
+		export CXX=g++-7
+	elif [[ "${COMPILER}" == "clang-3.6" ]]; then
+		export CC=clang-3.6
+		export CXX=clang++-3.6
+	elif [[ "${COMPILER}" == "clang-5.0" ]]; then
+		export CC=clang-5.0
+		export CXX=clang++-5.0
+	fi
+}
+
+# Linux build only
+install_linux_deps() {
+	sudo apt-get update
+	sudo apt-get install libirrlicht-dev cmake libbz2-dev libpng12-dev \
+		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
+		libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
+		gettext libpq-dev libleveldb-dev
+}
+
+# Mac OSX build only
+install_macosx_deps() {
+	brew update
+	brew install freetype gettext hiredis irrlicht leveldb libogg libvorbis luajit
+	if brew ls | grep -q jpeg; then
+		brew upgrade jpeg
+	else
+		brew install jpeg
+	fi
+	#brew upgrade postgresql
+}
+
+# Relative to git-repository root:
+TRIGGER_COMPILE_PATHS="src/.*\.(c|cpp|h)|CMakeLists.txt|cmake/Modules/|util/circleci/|util/buildbot/"
+
+needs_compile() {
+	RANGE=${CIRCLE_SHA1}
+	if [[ "$(git diff --name-only $RANGE -- 2>/dev/null)" == "" ]]; then
+		RANGE="$RANGE^...$RANGE"
+		echo "Fixed range: $RANGE"
+	fi
+	git diff --name-only $RANGE -- | egrep -q "^($TRIGGER_COMPILE_PATHS)"
+}
+

--- a/util/circleci/script.sh
+++ b/util/circleci/script.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+. util/circleci/common.sh
+. util/travis/lint.sh
+
+needs_compile || exit 0
+
+if [[ "$LINT" == "1" ]]; then
+	# Lint and exit CI
+	perform_lint
+	exit 0
+fi
+
+set_linux_compiler_env
+
+if [[ ${PLATFORM} == "Unix" ]]; then
+	mkdir -p circlecibuild
+	cd circlecibuild || exit 1
+
+	CMAKE_FLAGS=''
+
+	if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+		CMAKE_FLAGS+=' -DCUSTOM_GETTEXT_PATH=/usr/local/opt/gettext'
+	fi
+
+	if [[ -n "${FREETYPE}" ]] && [[ "${FREETYPE}" == "0" ]]; then
+		CMAKE_FLAGS+=' -DENABLE_FREETYPE=0'
+	fi
+
+	cmake -DCMAKE_BUILD_TYPE=Debug \
+		-DRUN_IN_PLACE=TRUE \
+		-DENABLE_GETTEXT=TRUE \
+		-DBUILD_SERVER=TRUE \
+		${CMAKE_FLAGS} ..
+	make -j2
+
+	echo "Running unit tests."
+	CMD="../bin/minetest --run-unittests"
+	if [[ "${VALGRIND}" == "1" ]]; then
+		valgrind --leak-check=full --leak-check-heuristics=all --undef-value-errors=no --error-exitcode=9 ${CMD} && exit 0
+	else
+		${CMD} && exit 0
+	fi
+
+elif [[ $PLATFORM == Win* ]]; then
+	[[ $CC == "clang" ]] && exit 1 # Not supposed to happen
+	# We need to have our build directory outside of the minetest directory because
+	#  CMake will otherwise get very very confused with symlinks and complain that
+	#  something is not a subdirectory of something even if it actually is.
+	# e.g.:
+	# /home/circleci/minetest/minetest/circlecibuild/minetest
+	# \/  \/  \/
+	# /home/circleci/minetest/minetest/circlecibuild/minetest/circlecibuild/minetest
+	# \/  \/  \/
+	# /home/circleci/minetest/minetest/circlecibuild/minetest/circlecibuild/minetest/circlecibuild/minetest
+	# You get the idea.
+	OLDDIR=$(pwd)
+	cd ..
+	export EXISTING_MINETEST_DIR=$OLDDIR
+	export NO_MINETEST_GAME=1
+	if [[ $PLATFORM == "Win32" ]]; then
+		"$OLDDIR/util/buildbot/buildwin32.sh" circlecibuild && exit 0
+	elif [[ $PLATFORM == "Win64" ]]; then
+		"$OLDDIR/util/buildbot/buildwin64.sh" circlecibuild && exit 0
+	fi
+else
+	echo "Unknown platform \"${PLATFORM}\"."
+	exit 1
+fi
+


### PR DESCRIPTION
I'm making this PR because #6766 is a "Can't add", but take it as a temporary fix.
I personnally prefer TravisCI so keeping old files and compatibility may be useful if we decide to switch back to it.

But TravisCI delayed their open source projects migration from `travis-ci.org` to `travis-ci.com` so I made some research: to fix this issue some open-source projects in a similar situation moved to CircleCI.

The GitHub integration looks like this: https://github.com/travis-ci/travis-ci/issues/5035#issuecomment-319737651

Since this could be a valid option, I tried to make a config file for it.

List of the tests that currently work:

- [x] clang-format 
- [x] clang-tidy
- [x] win32
- [x] win64
- [ ] osx
- [x] gcc 6
- [x] gcc 7
- [x] clang 3.6
- [x] clang 5
- [x] clang 5 without freetype
- [x] clang 5 with valgrind

OSX free plan has to be asked directly to CircleCI though: cs@circleci.com
https://circleci.com/pricing/#faq-section-os-x