### PR TITLE
Slightly alter star appearence time and full brightness time

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -445,12 +445,16 @@ void Sky::render()
 		// Draw stars
 		do {
 			driver->setMaterial(m_materials[1]);
+			// Tune values, so that stars begin to be drawn at the same time the
+			// sun disappears over the horizon, and so that star full brightness
+			// is reached at time 20000, for 8 'hours' of full star brightness.
 			float starbrightness = MYMAX(0, MYMIN(1,
-				(0.285 - fabs(wicked_time_of_day < 0.5 ?
-				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 10));
+				(0.25 - fabs(wicked_time_of_day < 0.5 ?
+				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 20));
 			float f = starbrightness;
-			float d = 0.007/2;
+			float d = 0.007 / 2;
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
+			// Stars are only drawn when brighter than skycolor
 			if (starcolor.getBlue() < m_skycolor.getBlue())
 				break;
 #ifdef __ANDROID__


### PR DESCRIPTION
Closes #7905 

At sunset:
In MT master, stars first appear when the sun is only halfway across the horizon, causing dark stars to occasionally appear in front of the sun glow texture. It's also a little too early, seeing stars while still viewing a bright sun.
Stars reach full brightness a little too long after sunset and long after maximum sky darkness, at time 20275.

PR:
With shaders on or off, stars first appear at the exact time the sun disappears over the horizon, so very little chance of seeing a dark star in front of the sun glow texture.
With shaders off, stars first appear exactly at the time of the first sky-darkening step after the sun sets, that is, at the first significantly dark sky.
Stars reach full brightness a little quicker, to do so at 20000 instead of 20275, it seemed good to get 8 'hours' (one third of a day) of full star brightness.