### PR TITLE
Improve world configure menu

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -68,11 +68,11 @@ local function get_formspec(data)
 			if pkgmgr.is_modpack_entirely_enabled(data, mod.name) then
 				retval = retval ..
 					"button[5.5,0.125;2.5,0.5;btn_mp_disable;" ..
-					fgettext("Disable MP") .. "]"
+					fgettext("Disable modpack") .. "]"
 			else
 				retval = retval ..
 					"button[5.5,0.125;2.5,0.5;btn_mp_enable;" ..
-					fgettext("Enable MP") .. "]"
+					fgettext("Enable modpack") .. "]"
 			end
 		else
 			retval = retval ..

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -67,11 +67,11 @@ local function get_formspec(data)
 
 			if pkgmgr.is_modpack_entirely_enabled(data, mod.name) then
 				retval = retval ..
-					"button[5.5,0.125;2.5,0.5;btn_mp_disable;" ..
+					"button[5.5,0.125;3,0.5;btn_mp_disable;" ..
 					fgettext("Disable modpack") .. "]"
 			else
 				retval = retval ..
-					"button[5.5,0.125;2.5,0.5;btn_mp_enable;" ..
+					"button[5.5,0.125;3,0.5;btn_mp_enable;" ..
 					fgettext("Enable modpack") .. "]"
 			end
 		else
@@ -82,11 +82,11 @@ local function get_formspec(data)
 	end
 	if enabled_all then
 		retval = retval ..
-			"button[8.75,0.125;2.5,0.5;btn_disable_all_mods;" ..
+			"button[8.95,0.125;2.5,0.5;btn_disable_all_mods;" ..
 			fgettext("Disable all") .. "]"
 	else
 		retval = retval ..
-			"button[8.75,0.125;2.5,0.5;btn_enable_all_mods;" ..
+			"button[8.95,0.125;2.5,0.5;btn_enable_all_mods;" ..
 			fgettext("Enable all") .. "]"
 	end
 	return retval ..

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -33,11 +33,15 @@ local function get_formspec(data)
 
 	local hard_deps, soft_deps = pkgmgr.get_dependencies(mod.path)
 
-	if mod.is_modpack then
+	if mod.is_modpack or mod.type == "game" then
 		local info = minetest.formspec_escape(
 			core.get_content_info(mod.path).description)
 		if info == "" then
-			info = fgettext("No modpack description provided.")
+			if mod.is_modpack then
+				info = fgettext("No modpack description provided.")
+			else
+				info = fgettext("No game description provided.")
+			end
 		end
 		retval = retval ..
 			"textarea[0.25,0.7;5.75,7.2;;" .. info .. ";]"

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -21,7 +21,7 @@ function get_mods(path,retval,modpack)
 
 	for _, name in ipairs(mods) do
 		if name:sub(1, 1) ~= "." then
-			local prefix = path .. DIR_DELIM .. name .. DIR_DELIM
+			local prefix = path .. DIR_DELIM .. name
 			local toadd = {}
 			retval[#retval + 1] = toadd
 
@@ -39,7 +39,7 @@ function get_mods(path,retval,modpack)
 			if modpack ~= nil and modpack ~= "" then
 				toadd.modpack = modpack
 			else
-				local modpackfile = io.open(prefix .. "modpack.txt")
+				local modpackfile = io.open(prefix .. DIR_DELIM .. "modpack.txt")
 				if modpackfile then
 					modpackfile:close()
 					toadd.type = "modpack"
@@ -532,7 +532,8 @@ function pkgmgr.preparemodlist(data)
 		retval[#retval + 1] = {
 			type = "game",
 			is_game_content = true,
-			name = fgettext("Subgame Mods")
+			name = fgettext(gamespec.name .. " mods"),
+			path = gamespec.path
 		}
 	end
 


### PR DESCRIPTION
Replace 'Subgame mods' with \<game name\> mods.
Display game description on left instead of dependencies.
Fix double DIR_DELIM in some paths.
Enable/disable MP --> modpack (fits nicely without increasing button size)

Does this require any changes to a translation file?

Before:
![before](https://user-images.githubusercontent.com/21223385/49326550-bf7a7680-f521-11e8-9bfa-c34059433303.png)
After:
![after](https://user-images.githubusercontent.com/21223385/49326551-c3a69400-f521-11e8-87a2-b823ae2612e0.png)
Note: MTG could use a description in mod.conf.