### PR TITLE
Fix android build error messages introduced by commit 5f1cd555cd9d1c64426e173b30b5b792d211c835

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -22,12 +22,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes.h"
 #include "irr_v2d.h"
 #include "log.h"
-#include "keycode.h"
+#include "client/keycode.h"
 #include "settings.h"
 #include "gettime.h"
 #include "util/numeric.h"
 #include "porting.h"
-#include "guiscalingfilter.h"
+#include "client/guiscalingfilter.h"
 
 #include <iostream>
 #include <algorithm>

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -27,7 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 
 #include "client/tile.h"
-#include "game.h"
+#include "client/game.h"
 
 using namespace irr;
 using namespace irr::core;


### PR DESCRIPTION
Fix #7933
After commit 5f1cd555cd9d1c64426e173b30b5b792d211c835 got merged it broke android build (touchscreengui.* files were pointing to old file locations). This PR fixes that.