### PR TITLE
Main menu style: Set to 'full' for Android, remove 'auto' option

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -25,9 +25,6 @@ mt_color_dark_green = "#25C191"
 local menupath = core.get_mainmenu_path()
 local basepath = core.get_builtin_path()
 local menustyle = core.settings:get("main_menu_style")
-if menustyle == "auto" then
-	menustyle = PLATFORM == "Android" and "simple" or "full"
-end
 defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
 					DIR_DELIM .. "pack" .. DIR_DELIM
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1309,8 +1309,7 @@ high_precision_fpu (High-precision FPU) bool true
 #    -   Full:  Multple singleplayer worlds, game choice, texture pack chooser, etc.
 #    -   Simple: One singleplayer world, no game or texture pack choosers. May be
 #                necessary for smaller screens.
-#    -   Auto: Simple on Android, full on everything else.
-main_menu_style (Main menu style) enum auto auto,full,simple
+main_menu_style (Main menu style) enum full full,simple
 
 #    Replaces the default main menu with a custom one.
 main_menu_script (Main menu script) string

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -271,7 +271,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("joystick_frustum_sensitivity", "170");
 
 	// Main menu
-	settings->setDefault("main_menu_style", "auto");
+	settings->setDefault("main_menu_style", "full");
 	settings->setDefault("main_menu_path", "");
 	settings->setDefault("serverlist_file", "favoriteservers.txt");
 


### PR DESCRIPTION
Initial work for #2600 
See comments of support https://github.com/minetest/minetest/issues/2600#issuecomment-134766359 and https://github.com/minetest/minetest/issues/2600#issuecomment-443699377
I can also remove simple menu code if or when full menu is confirmed ok for all Android devices.