### PR TITLE
Force-disable client-provided CSM until server-sent CSM completed

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -898,6 +898,7 @@ enable_local_map_saving (Saving map received from server) bool false
 #    when connecting to the server.
 enable_remote_media_server (Connect to external media server) bool true
 
+#    Note: Setting currently has no effect as CSM is in development.
 #    Enable Lua modding support on client.
 #    This support is experimental and API can change.
 enable_client_modding (Client modding) bool false
@@ -1190,6 +1191,7 @@ block_send_optimize_distance (Block send optimize distance) int 4 2
 #    so that the utility of noclip mode is reduced.
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
+#    Note: Setting currently has no effect as CSM is in development.
 #    Restricts the access of certain client-side functions on servers
 #    Combine these byteflags below to restrict client-side features:
 #    LOAD_CLIENT_MODS: 1 (disable client mods loading)
@@ -1198,10 +1200,11 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
-csm_restriction_flags (Client side modding restrictions) int 30
+csm_restriction_flags (Client side modding restrictions) int 31
 
-#   If the CSM restriction for node range is enabled, get_node calls are limited
-#   to this distance from the player to the node.
+#    Note: Setting currently has no effect as CSM is in development.
+#    If the CSM restriction for node range is enabled, get_node calls are limited
+#    to this distance from the player to the node.
 csm_restriction_noderange (Client side node lookup range restriction) int 0
 
 [*Security]

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -3,6 +3,8 @@ Minetest Lua Client Modding API Reference 5.0.0
 * More information at <http://www.minetest.net/>
 * Developer Wiki: <http://dev.minetest.net/>
 
+** NOTE: Client-side modding is in development and is currently unusable. **
+
 Introduction
 ------------
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -109,7 +109,8 @@ Client::Client(
 	}
 	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
 
-	m_modding_enabled = g_settings->getBool("enable_client_modding");
+	// Disable client-provided CSM until server-sent CSM is completed
+	m_modding_enabled = false; // g_settings->getBool("enable_client_modding");
 	// Only create the client script environment if client modding is enabled
 	if (m_modding_enabled) {
 		m_script = new ClientScripting(this);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -402,8 +402,10 @@ void Server::init()
 
 	m_liquid_transform_every = g_settings->getFloat("liquid_update");
 	m_max_chatmessage_length = g_settings->getU16("chat_message_max_size");
-	m_csm_restriction_flags = g_settings->getU64("csm_restriction_flags");
-	m_csm_restriction_noderange = g_settings->getU32("csm_restriction_noderange");
+
+	// Disable client-provided CSM mod loading until server-sent CSM is completed
+	m_csm_restriction_flags = 31; //g_settings->getU64("csm_restriction_flags");
+	m_csm_restriction_noderange = 0; //g_settings->getU32("csm_restriction_noderange");
 }
 
 void Server::start()


### PR DESCRIPTION
Clarification:

This PR is about whether or not client-provided CSM should be a long-term standalone feature.
celeron55, rubenwardy and myself think it should not and it wasn't intended to be.
* I, and it seems some other core devs, consider the releasing of CPCSM into MT 0.4.16 stable a mistake. Doing so was not necessary for the development of server-provided CSM.
* CPCSM on it's own in a stable release was only intended to be a brief development step towards server-provided CSM. So if CSM development had continued SPCSM would be released into MT 5.0.0 stable.
However development of SPCSM has not started. Considering the lack of core dev time and the security aspects it may be 1-2 dev cycles away. There's still a chance it may not happen.

So CPCSM should be disabled in stable MT until SPCSM is completed. To fix the mistake, to follow the long-agreed plan, and to avoid users getting too used to a feature that may not be present in the future.

////////////////////////

Releasing client-provided CSM in 0.4.16 stable was a mistake (and all of us core devs are to blame for allowing this to happen), not just due to having no server restrictions (which is now resolved), but also due to client-provided CSM having never been intended as a standalone feature. CSM should not have been released half-developed and there was no need to release it in that state.
Client-provided CSM is not mentioned in the original plan https://dev.minetest.net/Client_scripting_plans

It seems that releasing client-provided CSM in stable was intended as a brief and temporary step in the development of the primary feature of server-sent CSM. However client-provided CSM was merged in #5088 on 13 March 2017, 1 year and 9 months ago, with no progress towards server-sent CSM since then. By the time MT 5.0.0 is released it will be 2 years. Development is slow and no-one is yet intending to complete server-sent CSM, including the original CSM devs. CSM development is 'on indefinite hold' and it's future uncertain.

Considering this we can't let client-provided CSM continue to remain as a standalone feature.

Celeron55 and sofar's opinions:

http://irc.minetest.net/minetest-dev/2017-12-03#i_5154908
07:05 celeron55    i mean seriously, it's a real possibility that we just need to rip out CSM and live without it
...
...
07:16 celeron55    for one, i think leaving csm in without code downloaded from the server is stupid
07:16 sofar        agreed
07:16 celeron55    either that or nothing is the future
07:17 sofar        I've said something similar a few times
07:17 celeron55    i'm fine with either
07:17 VanessaE     my opinion is that we should have never had client-provided csm.  it should have been server-provided from the start
07:17 sofar        I will start making CSM mods when servers can send code
07:17 sofar        not before
07:17 sofar        well it's a good lesson
07:17 sofar        I don't think nerzhul and red thought it through either
07:18 celeron55    VanessaE: that was my plan, but things tend to go the way the actual implementer does it

I, and it seems @sofar and @rubenwardy also, agree that we should either have complete CSM or nothing, which means at the least not having client-provided CSM as a standalone feature.

The loss of client-provided CSM is not a big issue. I recently looked through the CSM mods on the forum and was surprised, there are only a very few, quite boring and nothing of any significance, it mostly seems to be several different types of coloured chat mod.
Consider that many servers already completely disallow any type of client-provided CSM to be used, and when CSM restrictions arrive in MT 5.0.0 are likely to use them to enforce this, so it won't make much difference on many servers.