### PR TITLE
Fix crash if display resolution is not set

### DIFF
--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -315,6 +315,11 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 		}
 		u32 size = std::floor(RenderingEngine::getDisplayDensity() *
 				m_settings->getFloat("gui_scaling") * basesize);
+		if (size == 0) {
+			errorstream << "FontEngine: attempt to use font size 0" << std::endl;
+			errorstream << "  display density: " << RenderingEngine::getDisplayDensity() << std::endl;
+			abort();
+		}
 		u32 font_shadow       = 0;
 		u32 font_shadow_alpha = 0;
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -624,20 +624,17 @@ static float calcDisplayDensity()
 
 		if (x11display != NULL) {
 			/* try x direct */
-			float dpi_height = floor(
-					DisplayHeight(x11display, 0) /
-							(DisplayHeightMM(x11display, 0) *
-									0.039370) +
-					0.5);
-			float dpi_width = floor(
-					DisplayWidth(x11display, 0) /
-							(DisplayWidthMM(x11display, 0) *
-									0.039370) +
-					0.5);
-
+			int dh = DisplayHeight(x11display, 0);
+			int dw = DisplayWidth(x11display, 0);
+			int dh_mm = DisplayHeightMM(x11display, 0);
+			int dw_mm = DisplayWidthMM(x11display, 0);
 			XCloseDisplay(x11display);
 
-			return std::max(dpi_height, dpi_width) / 96.0;
+			if (dh_mm != 0 && dw_mm != 0) {
+				float dpi_height = floor(dh / (dh_mm * 0.039370) + 0.5);
+				float dpi_width = floor(dw / (dw_mm * 0.039370) + 0.5);
+				return std::max(dpi_height, dpi_width) / 96.0;
+			}
 		}
 	}
 


### PR DESCRIPTION
On my wayland / gnome3 setup DisplayHeightMM() returns 0. This resulted in a
misleading startup error suggesting to fix my font paths.