### PR TITLE
Log deprecated messages only once per line

### DIFF
--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -30,10 +30,8 @@ core.env = {}
 local envref_deprecation_message_printed = false
 setmetatable(core.env, {
 	__index = function(table, key)
-		if not envref_deprecation_message_printed then
-			core.log("deprecated", "core.env:[...] is deprecated and should be replaced with core.[...]")
-			envref_deprecation_message_printed = true
-		end
+		core.log("deprecated", "core.env:[...] is deprecated and "
+			.. "should be replaced with core.[...]", 2)
 		local func = core[key]
 		if type(func) == "function" then
 			rawset(table, key, function(self, ...)
@@ -58,9 +56,8 @@ local settings = core.settings
 
 local function setting_proxy(name)
 	return function(...)
-		core.log("deprecated", "WARNING: minetest.setting_* "..
-			"functions are deprecated.  "..
-			"Use methods on the minetest.settings object.")
+		core.log("deprecated", "Call to deprecated function. "
+			.. "Instead, use the minetest.settings object.", 1)
 		return settings[name](settings, ...)
 	end
 end

--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -27,7 +27,6 @@ end
 -- EnvRef
 --
 core.env = {}
-local envref_deprecation_message_printed = false
 setmetatable(core.env, {
 	__index = function(table, key)
 		core.log("deprecated", "core.env:[...] is deprecated and "

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3538,7 +3538,10 @@ Logging
     * Equivalent to `minetest.log(table.concat({...}, "\t"))`
 * `minetest.log([level,] text)`
     * `level` is one of `"none"`, `"error"`, `"warning"`, `"action"`,
-      `"info"`, or `"verbose"`.  Default is `"none"`.
+      `"info"`, `"verbose"` or `"deprecated"`.  Default is `"none"`.
+    * When `level` is `"deprecated"`, then an optional 3rd integer parameter
+      may be used to specify the function call depth for the log message.
+
 
 Registration functions
 ----------------------

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -32,6 +32,7 @@ extern "C" {
 }
 
 #include "common/c_types.h"
+#include <vector>
 
 
 /*
@@ -103,4 +104,4 @@ int script_exception_wrapper(lua_State *L, lua_CFunction f);
 void script_error(lua_State *L, int pcall_result, const char *mod, const char *fxn);
 void script_run_callbacks_f(lua_State *L, int nargs,
 	RunCallbacksMode mode, const char *fxn);
-void log_deprecated(lua_State *L, const std::string &message);
+void log_deprecated(lua_State *L, const std::string &message, int depth = 0);

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -373,12 +373,13 @@ void ScriptApiBase::objectrefGetOrCreate(lua_State *L,
 {
 	if (cobj == NULL || cobj->getId() == 0) {
 		ObjectRef::create(L, cobj);
+		log_deprecated(L, "ScriptApiBase::objectrefGetOrCreate() "
+			"Created reference for non-existing object");
 	} else {
 		push_objectRef(L, cobj->getId());
 		if (cobj->isGone())
-			warningstream << "ScriptApiBase::objectrefGetOrCreate(): "
-					<< "Pushing ObjectRef to removed/deactivated object"
-					<< ", this is probably a bug." << std::endl;
+			log_deprecated(L, "ScriptApiBase::objectrefGetOrCreate() "
+				"Pushing removed/deactivated object");
 	}
 }
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -373,13 +373,12 @@ void ScriptApiBase::objectrefGetOrCreate(lua_State *L,
 {
 	if (cobj == NULL || cobj->getId() == 0) {
 		ObjectRef::create(L, cobj);
-		log_deprecated(L, "ScriptApiBase::objectrefGetOrCreate() "
-			"Created reference for non-existing object");
 	} else {
 		push_objectRef(L, cobj->getId());
 		if (cobj->isGone())
-			log_deprecated(L, "ScriptApiBase::objectrefGetOrCreate() "
-				"Pushing removed/deactivated object");
+			warningstream << "ScriptApiBase::objectrefGetOrCreate(): "
+					<< "Pushing ObjectRef to removed/deactivated object"
+					<< ", this is probably a bug." << std::endl;
 	}
 }
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -59,7 +59,7 @@ int ModApiUtil::l_log(lua_State *L)
 		std::string name = luaL_checkstring(L, 1);
 		text = luaL_checkstring(L, 2);
 		if (name == "deprecated") {
-			log_deprecated(L, text);
+			log_deprecated(L, text, readParam<s16>(L, 3));
 			return 0;
 		}
 		level = Logger::stringToLevel(name);


### PR DESCRIPTION
- Default to deprecated handling `log`
- New `minetest.log("deprecated", "msg", <depth>)` optional parameter

**Sample terminal output** (full backtrace only visible with log level `info`)
```
Loaded texture: /data/Minetest/run/games/subgames/menu/icon.png
2018-12-09 13:33:26: WARNING[Main]: Function 'setting_getbool': Call to deprecated function. Instead, use the minetest.settings object. (at /data/Minetest/run/bin/../mods/worldedit/worldedit/init.lua:45)
[OK] Mesecons
2018-12-09 13:33:26: WARNING[Main]: Function 'set_mapgen_params': set_mapgen_params is deprecated; use set_mapgen_setting instead (at /data/Minetest/run/bin/../mods/lab/init.lua:22)
2018-12-09 13:33:26: WARNING[Main]: core.env:[...] is deprecated and should be replaced with core.[...] (at /data/Minetest/run/bin/../mods/lab/init.lua:23)
<SNIP MT LOGO>
2018-12-09 13:33:29: ACTION[Server]: singleplayer joins game. List of players: singleplayer
2018-12-09 13:33:29: WARNING[Server]: Function 'get_entity_name': Deprecated call to "get_entity_name (at /data/Minetest/run/bin/../mods/lab/init.lua:7)
2018-12-09 13:33:29: WARNING[Server]: Function 'get_look_pitch': Deprecated call to get_look_pitch, use get_look_vertical instead (at /data/Minetest/run/bin/../mods/lab/init.lua:8)
2018-12-09 13:33:29: WARNING[Server]: Function 'add_particle': Deprecated add_particle call with individual parameters instead of definition (at /data/Minetest/run/bin/../mods/lab/init.lua:18)
2018-12-09 13:33:30: WARNING[Server]: Function 'get_entity_name': Deprecated call to "get_entity_name (at /data/Minetest/run/bin/../mods/lab/init.lua:33)
2018-12-09 13:33:30: WARNING[Server]: Function 'get_look_pitch': Deprecated call to get_look_pitch, use get_look_vertical instead (at /data/Minetest/run/bin/../mods/lab/init.lua:34)
2018-12-09 13:33:33: WARNING[Main]: Deprecated formspec element "invsize" is used
```

**Test script**
```Lua
local players = {}

core.register_on_joinplayer(function(player)
	local inv = player:get_inventory()
	inv:set_list("hand", {"default:cobble"})
	players[#players + 1] = player
	player:get_entity_name()
	player:get_look_pitch()

	core.after(5, function()
    	core.show_formspec(player:get_player_name(), "lab:testy",
    		"invsize[9,7]"..
    		"no_prepends[]"..
    		"list[current_player;hand;8,6;1,1;]"
    	)
	end)
	
	core.add_particle(vector.new(), vector.new(), 
		vector.new(), 20, 1, false, "default_dirt.png")
end)

core.set_mapgen_params()
core.env:set_mapgen_params()

local time = 0
core.register_globalstep(function(dtime)
	time = time + dtime
	if time < 3 then
		return
	end
	time = time - 3
	for i, player in ipairs(players) do
		player:get_entity_name()
		player:get_look_pitch()
	end
end)
```