### PR TITLE
Make showOverlayMessage strings translatable (take 2)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1146,7 +1146,7 @@ void Game::shutdown()
 	if (current_formspec)
 		current_formspec->quitMenu();
 
-	showOverlayMessage("Shutting down...", 0, 0, false);
+	showOverlayMessage(N_("Shutting down..."), 0, 0, false);
 
 	if (clouds)
 		clouds->drop();
@@ -1198,7 +1198,7 @@ bool Game::init(
 {
 	texture_src = createTextureSource();
 
-	showOverlayMessage("Loading...", 0, 0);
+	showOverlayMessage(N_("Loading..."), 0, 0);
 
 	shader_src = createShaderSource();
 
@@ -1254,7 +1254,7 @@ bool Game::initSound()
 bool Game::createSingleplayerServer(const std::string &map_dir,
 		const SubgameSpec &gamespec, u16 port, std::string *address)
 {
-	showOverlayMessage("Creating server...", 0, 5);
+	showOverlayMessage(N_("Creating server..."), 0, 5);
 
 	std::string bind_str = g_settings->get("bind_address");
 	Address bind_addr(0, 0, 0, 0, port);
@@ -1289,7 +1289,7 @@ bool Game::createSingleplayerServer(const std::string &map_dir,
 bool Game::createClient(const std::string &playername,
 		const std::string &password, std::string *address, u16 port)
 {
-	showOverlayMessage("Creating client...", 0, 10);
+	showOverlayMessage(N_("Creating client..."), 0, 10);
 
 	draw_control = new MapDrawControl;
 	if (!draw_control)
@@ -1442,7 +1442,7 @@ bool Game::connectToServer(const std::string &playername,
 	*connection_aborted = false;
 	bool local_server_mode = false;
 
-	showOverlayMessage("Resolving address...", 0, 15);
+	showOverlayMessage(N_("Resolving address..."), 0, 15);
 
 	Address connect_address(0, 0, 0, 0, port);
 
@@ -1557,7 +1557,7 @@ bool Game::connectToServer(const std::string &playername,
 				}
 
 				// Update status
-				showOverlayMessage("Connecting to server...", dtime, 20);
+				showOverlayMessage(N_("Connecting to server..."), dtime, 20);
 			}
 		}
 	} catch (con::PeerNotFoundException &e) {


### PR DESCRIPTION
This PR makes strings put into `showOverlayMessage` in `game.cpp` translatable, i.e. these are the texts that show up in the loading screen on the loading bar.

Partial fix of #7880.