### PR TITLE
Add a Dockerfile + gitlab CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ stages:
 
 variables:
   MINETEST_GAME_REPO: "https://github.com/minetest/minetest_game.git"
+  CONTAINER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH
 
 .build_template: &build_definition
   stage: build
@@ -308,3 +309,15 @@ package:win64:
     NO_PACKAGE: "1"
     WIN_ARCH: "x86_64"
     TOOLCHAIN_OUTPUT: "util/buildbot/toolchain_mingw64.cmake"
+
+package:docker:
+  stage: package
+  image: docker:stable
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
+  script:
+    - docker build . -t ${CONTAINER_IMAGE}/minetestserver:$CI_COMMIT_REF_NAME -t ${CONTAINER_IMAGE}/minetestserver:latest
+    - docker push ${CONTAINER_IMAGE}/minetestserver:$CI_COMMIT_REF_NAME
+    - docker push ${CONTAINER_IMAGE}/minetestserver:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch
 USER root
 RUN apt-get update -y && \
 	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
-		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev && \
+		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev git && \
 		apt-get clean && rm -rf /var/cache/apt/archives/* && \
 		rm -rf /var/lib/apt/lists/*
 
@@ -17,7 +17,9 @@ RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && 
 		-DENABLE_SYSTEM_JSONCPP=1 \
 		-DENABLE_SOUND=0 \
 		.. && \
-		make -j2 && make install
+		make -j2 && \
+		rm -Rf ../games/minetest_game && git clone https://github.com/minetest/minetest_game ../games/minetest_game && \
+		make install
 
 FROM debian:stretch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
 		-DENABLE_GETTEXT=TRUE \
 		-DBUILD_SERVER=TRUE \
 		-DBUILD_CLIENT=FALSE \
+		-DENABLE_SYSTEM_JSONCPP=1 \
 		-DENABLE_SOUND=0 .. && \
 	make -j2 && make install
 
@@ -23,9 +24,15 @@ RUN	apt-get clean && rm -rf /var/cache/apt/archives/* && \
 
 FROM debian:stretch
 
-RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest
+USER root
+RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest &&
+    apt-get update -y && \
+    apt-get -y install libcurl3-gnutls libjsoncpp1 liblua5.1-0 libluajit-5.1-2 libpq5 libsqlite3-0 \
+        libstdc++6 zlib1g
 
 WORKDIR /var/lib/minetest
+
 COPY --from=0 /usr/local/share/minetest /usr/local/share/minetest
+COPY --from=0 /usr/local/bin/minetestserver /usr/local/bin/minetestserver
 
 RUN find /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ WORKDIR /var/lib/minetest
 
 COPY --from=0 /usr/local/share/minetest /usr/local/share/minetest
 COPY --from=0 /usr/local/bin/minetestserver /usr/local/bin/minetestserver
+COPY --from=0 /usr/local/share/doc/minetest/minetest.conf.example /etc/minetest/minetest.conf
 
-RUN find /usr/local
+USER minetest
 
 EXPOSE 30000/udp
 
-CMD ["/usr/local/bin/minetestserver"]
+CMD ["/usr/local/bin/minetestserver", "--config", "/etc/minetest/minetest.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ COPY . /usr/src/minetest
 USER root
 RUN apt-get update -y && \
 	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
-		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev
+		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev && \
+		useradd -m -d /usr/src/minetest builder
 
+USER builder
 RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
     	cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DRUN_IN_PLACE=FALSE \
 		-DENABLE_GETTEXT=TRUE \
@@ -18,3 +20,12 @@ RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
 USER root
 RUN	apt-get clean && rm -rf /var/cache/apt/archives/* && \
 	rm -rf /var/lib/apt/lists/*
+
+FROM debian:stretch
+
+RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest
+
+WORKDIR /var/lib/minetest
+COPY --from=0 /usr/local/share/minetest /usr/local/share/minetest
+
+RUN find /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,28 @@ USER root
 RUN apt-get update -y && \
 	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
 		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev && \
-		useradd -m -d /usr/src/minetest builder && \
 		apt-get clean && rm -rf /var/cache/apt/archives/* && \
 		rm -rf /var/lib/apt/lists/*
 
 COPY . /usr/src/minetest
 
-USER builder
 RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
     	cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DRUN_IN_PLACE=FALSE \
 		-DENABLE_GETTEXT=TRUE \
 		-DBUILD_SERVER=TRUE \
 		-DBUILD_CLIENT=FALSE \
 		-DENABLE_SYSTEM_JSONCPP=1 \
-		-DENABLE_SOUND=0 .. && \
-	make -j2 && make install
+		-DENABLE_SOUND=0 \
+		.. && \
+		make -j2 && make install
 
 FROM debian:stretch
 
 USER root
-RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest && \
+RUN groupadd minetest && useradd -m -g minetest -d /var/lib/minetest minetest && \
     apt-get update -y && \
     apt-get -y install libcurl3-gnutls libjsoncpp1 liblua5.1-0 libluajit-5.1-2 libpq5 libsqlite3-0 \
-        libstdc++6 zlib1g
+        libstdc++6 zlib1g libirrlicht1.8 libc6
 
 WORKDIR /var/lib/minetest
 
@@ -34,3 +33,7 @@ COPY --from=0 /usr/local/share/minetest /usr/local/share/minetest
 COPY --from=0 /usr/local/bin/minetestserver /usr/local/bin/minetestserver
 
 RUN find /usr/local
+
+EXPOSE 30000/udp
+
+CMD ["/usr/local/bin/minetestserver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM debian:stretch
 
-COPY . /usr/src/minetest
-
 USER root
 RUN apt-get update -y && \
 	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
 		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev && \
-		useradd -m -d /usr/src/minetest builder
+		useradd -m -d /usr/src/minetest builder && \
+		apt-get clean && rm -rf /var/cache/apt/archives/* && \
+		rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/src/minetest
 
 USER builder
-RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
+RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
     	cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DRUN_IN_PLACE=FALSE \
 		-DENABLE_GETTEXT=TRUE \
 		-DBUILD_SERVER=TRUE \
@@ -18,14 +20,10 @@ RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
 		-DENABLE_SOUND=0 .. && \
 	make -j2 && make install
 
-USER root
-RUN	apt-get clean && rm -rf /var/cache/apt/archives/* && \
-	rm -rf /var/lib/apt/lists/*
-
 FROM debian:stretch
 
 USER root
-RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest &&
+RUN groupadd minetest && useradd -m -g -d /var/lib/minetest minetest && \
     apt-get update -y && \
     apt-get -y install libcurl3-gnutls libjsoncpp1 liblua5.1-0 libluajit-5.1-2 libpq5 libsqlite3-0 \
         libstdc++6 zlib1g

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ COPY . /usr/src/minetest
 
 RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
     	cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DRUN_IN_PLACE=FALSE \
-		-DENABLE_GETTEXT=TRUE \
 		-DBUILD_SERVER=TRUE \
 		-DBUILD_CLIENT=FALSE \
 		-DENABLE_SYSTEM_JSONCPP=1 \
-		-DENABLE_SOUND=0 \
 		.. && \
 		make -j2 && \
 		rm -Rf ../games/minetest_game && git clone https://github.com/minetest/minetest_game ../games/minetest_game && \
@@ -27,7 +25,7 @@ USER root
 RUN groupadd minetest && useradd -m -g minetest -d /var/lib/minetest minetest && \
     apt-get update -y && \
     apt-get -y install libcurl3-gnutls libjsoncpp1 liblua5.1-0 libluajit-5.1-2 libpq5 libsqlite3-0 \
-        libstdc++6 zlib1g libirrlicht1.8 libc6
+        libstdc++6 zlib1g libc6
 
 WORKDIR /var/lib/minetest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:stretch
+
+COPY . /usr/src/minetest
+
+USER root
+RUN apt-get update -y && \
+	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
+		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev
+
+RUN	mkdir /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && \
+    	cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DRUN_IN_PLACE=FALSE \
+		-DENABLE_GETTEXT=TRUE \
+		-DBUILD_SERVER=TRUE \
+		-DBUILD_CLIENT=FALSE \
+		-DENABLE_SOUND=0 .. && \
+	make -j2 && make install
+
+USER root
+RUN	apt-get clean && rm -rf /var/cache/apt/archives/* && \
+	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Permit to distribute minetest server as a docker file, embedded in the Gitlab CI + Gitlab registry permitting to provide minetest server daily builds.

It can also permit servers owners to use minetest server through docker easily, if it's a valid usecase do you want some documentation ?

Here is the demonstration build video connecting a local client on the minetest server inside the container

https://www.youtube.com/watch?v=fT4FBmUZPWI
