### PR TITLE
Formspec refactor proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.orig
 # Vim
 *.vim
+.ycm_extra_conf.py
 # Kate
 .*.kate-swp
 .swp.*

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -12,5 +12,6 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/intlGUIEditBox.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/widget/box_widget.cpp
 	PARENT_SCOPE
 )

--- a/src/gui/formspec_data.h
+++ b/src/gui/formspec_data.h
@@ -1,0 +1,40 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <stack>
+
+#include "irr_v2d.h"
+#include "rect.h"
+
+struct FormSpecData {
+	u32 formspec_version = 0;
+
+	v2s32 padding;
+	v2f32 spacing;
+	v2s32 imgsize;
+	v2s32 offset;
+	v2f32 pos_offset;
+
+	core::rect<s32> absolute_rect;
+
+	std::stack<v2f32> container_stack;
+};
+

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -31,6 +31,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "util/enriched_string.h"
 
+#include "gui/parser_data.h"
+#include "gui/formspec_data.h"
+#include "gui/widget/box_widget.h"
+
 class InventoryManager;
 class ISimpleTextureSource;
 class Client;
@@ -221,19 +225,6 @@ class GUIFormSpecMenu : public GUIModalMenu
 		core::rect<s32> rect;
 	};
 
-	struct BoxDrawSpec
-	{
-		BoxDrawSpec(v2s32 a_pos, v2s32 a_geom, irr::video::SColor a_color):
-			pos(a_pos),
-			geom(a_geom),
-			color(a_color)
-		{
-		}
-		v2s32 pos;
-		v2s32 geom;
-		irr::video::SColor color;
-	};
-
 	struct TooltipSpec
 	{
 		TooltipSpec() = default;
@@ -370,19 +361,14 @@ public:
 protected:
 	v2s32 getBasePos() const
 	{
-			return padding + offset + AbsoluteRect.UpperLeftCorner;
+			return m_data.padding + m_data.offset + AbsoluteRect.UpperLeftCorner;
 	}
 	std::wstring getLabelByID(s32 id);
 	std::string getNameByID(s32 id);
 	v2s32 getElementBasePos(bool absolute,
 			const std::vector<std::string> *v_pos);
 
-	v2s32 padding;
-	v2f32 spacing;
-	v2s32 imgsize;
-	v2s32 offset;
-	v2f32 pos_offset;
-	std::stack<v2f32> container_stack;
+	FormSpecData m_data;
 
 	InventoryManager *m_invmgr;
 	ISimpleTextureSource *m_tsrc;
@@ -397,7 +383,6 @@ protected:
 	std::vector<ImageDrawSpec> m_backgrounds;
 	std::vector<ImageDrawSpec> m_images;
 	std::vector<ImageDrawSpec> m_itemimages;
-	std::vector<BoxDrawSpec> m_boxes;
 	std::unordered_map<std::string, bool> field_close_on_enter;
 	std::vector<FieldSpec> m_fields;
 	std::vector<StaticTextSpec> m_static_texts;
@@ -407,6 +392,8 @@ protected:
 	std::vector<std::pair<irr::core::rect<s32>, TooltipSpec>> m_tooltip_rects;
 	std::vector<std::pair<FieldSpec,gui::IGUIScrollBar*> > m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string> > > m_dropdowns;
+
+	std::vector<BoxWidget> m_box_widgets;
 
 	ItemSpec *m_selected_item = nullptr;
 	u16 m_selected_amount = 0;
@@ -439,25 +426,8 @@ protected:
 private:
 	IFormSource        *m_form_src;
 	TextDest           *m_text_dst;
-	u32                 m_formspec_version = 0;
 	std::string         m_focused_element = "";
 	JoystickController *m_joystick;
-
-	typedef struct {
-		bool explicit_size;
-		v2f invsize;
-		v2s32 size;
-		v2f32 offset;
-		v2f32 anchor;
-		core::rect<s32> rect;
-		v2s32 basepos;
-		v2u32 screensize;
-		std::string focused_fieldname;
-		GUITable::TableOptions table_options;
-		GUITable::TableColumns table_columns;
-		// used to restore table selection/scroll/treeview state
-		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
-	} parserData;
 
 	typedef struct {
 		bool key_up;
@@ -501,7 +471,6 @@ private:
 			const std::string &type);
 	void parseItemImageButton(parserData* data, const std::string &element);
 	void parseTabHeader(parserData* data, const std::string &element);
-	void parseBox(parserData* data, const std::string &element);
 	void parseBackgroundColor(parserData* data, const std::string &element);
 	void parseListColors(parserData* data, const std::string &element);
 	void parseTooltip(parserData* data, const std::string &element);

--- a/src/gui/parser_data.h
+++ b/src/gui/parser_data.h
@@ -1,0 +1,60 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <unordered_map>
+
+#include "irr_v2d.h"
+#include "rect.h"
+#include "guiTable.h"
+
+// These macros were moved here for convenience, feel free to move them
+
+#define MY_CHECKPOS(a,b)													\
+	if (v_pos.size() != 2) {												\
+		errorstream<< "Invalid pos for element " << a << "specified: \""	\
+			<< parts[b] << "\"" << std::endl;								\
+			return;															\
+	}
+
+#define MY_CHECKGEOM(a,b)													\
+	if (v_geom.size() != 2) {												\
+		errorstream<< "Invalid pos for element " << a << "specified: \""	\
+			<< parts[b] << "\"" << std::endl;								\
+			return;															\
+	}
+
+// Used for parsing in FormSpecMenu and Widgets
+struct parserData {
+	bool explicit_size;
+	v2f invsize;
+	v2s32 size;
+	v2f32 offset;
+	v2f32 anchor;
+	core::rect<s32> rect;
+	v2s32 basepos;
+	v2u32 screensize;
+	std::string focused_fieldname;
+	GUITable::TableOptions table_options;
+	GUITable::TableColumns table_columns;
+	// used to restore table selection/scroll/treeview state
+	std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
+};
+

--- a/src/gui/widget/box_widget.cpp
+++ b/src/gui/widget/box_widget.cpp
@@ -1,0 +1,66 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "gui/parser_data.h"
+#include "gui/widget/box_widget.h"
+#include "log.h"
+#include "network/networkprotocol.h"
+#include "util/string.h"
+
+void BoxWidget::draw(video::IVideoDriver *driver) const
+{
+	core::rect<s32> rect(m_pos.X, m_pos.Y, m_pos.X + m_geom.X, m_pos.Y + m_geom.Y);
+
+	driver->draw2DRectangle(m_color, rect, 0);
+}
+
+void BoxWidget::parse(parserData* data, const std::string &element,
+		const FormSpecData &formdata, std::vector<BoxWidget> &widgets)
+{
+	std::vector<std::string> parts = split(element, ';');
+
+	if ((parts.size() == 3) ||
+			((parts.size() > 3) && (formdata.formspec_version > FORMSPEC_API_VERSION)))
+	{
+		std::vector<std::string> v_pos = split(parts[0], ',');
+		std::vector<std::string> v_geom = split(parts[1], ',');
+
+		MY_CHECKPOS("box", 0);
+		MY_CHECKGEOM("box", 1);
+
+		v2s32 pos = Widget::getElementBasePos(true, formdata, &v_pos);
+		v2s32 geom;
+		geom.X = stof(v_geom[0]) * formdata.spacing.X;
+		geom.Y = stof(v_geom[1]) * formdata.spacing.Y;
+
+		video::SColor tmp_color;
+
+		if (parseColorString(parts[2], tmp_color, false, 0x8C)) {
+			widgets.emplace_back(pos, geom, tmp_color);
+		}
+		else {
+			errorstream<< "Invalid Box element(" << parts.size() << "): '" << element << "'  INVALID COLOR"  << std::endl;
+		}
+
+		return;
+	}
+
+	errorstream<< "Invalid Box element(" << parts.size() << "): '" << element << "'"  << std::endl;
+}
+

--- a/src/gui/widget/box_widget.h
+++ b/src/gui/widget/box_widget.h
@@ -1,0 +1,43 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "gui/widget/widget.h"
+
+struct parserData;
+
+class BoxWidget : public Widget
+{
+public:
+	BoxWidget(v2s32 pos, v2s32 geom, irr::video::SColor color):
+		m_pos(pos), m_geom(geom), m_color(color)
+	{}
+
+	void draw(video::IVideoDriver *driver) const override;
+
+	static void parse(parserData* data, const std::string &element,
+			const FormSpecData &formdata, std::vector<BoxWidget> &widgets);
+
+private:
+	v2s32 m_pos;
+	v2s32 m_geom;
+	irr::video::SColor m_color;
+};
+

--- a/src/gui/widget/widget.h
+++ b/src/gui/widget/widget.h
@@ -1,0 +1,50 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "irrlichttypes_extrabloated.h"
+
+#include "gui/formspec_data.h"
+
+class Widget
+{
+public:
+	virtual ~Widget() = default;
+
+	virtual void draw(video::IVideoDriver *driver) const = 0;
+
+	static v2s32 getElementBasePos(bool absolute, const FormSpecData &formdata, const std::vector<std::string> *v_pos)
+	{
+		v2s32 pos = formdata.padding;
+		if (absolute)
+			pos += formdata.absolute_rect.UpperLeftCorner;
+
+		v2f32 pos_f = v2f32(pos.X, pos.Y) + formdata.pos_offset * formdata.spacing;
+		if (v_pos) {
+			pos_f.X += stof((*v_pos)[0]) * formdata.spacing.X;
+			pos_f.Y += stof((*v_pos)[1]) * formdata.spacing.Y;
+		}
+		return v2s32(pos_f.X, pos_f.Y);
+	}
+};
+


### PR DESCRIPTION
I started a refactor on `GUIFormSpecMenu` and I replaced `BoxDrawSpec` by a new class `BoxWidget`.

The goal of this PR is to split all the widget-specific code from the main class.

This PR is a **proposal**. I know this kind of changes probably won't be merged before 5.0.0, but I won't add new stuff until your review anyway.

**NB:** `m_box_widgets` is temporary since `Widget` will be used as an interface for all widgets.