### PR TITLE
FormSpec: support custom size and spacing for slots in list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.orig
 # Vim
 *.vim
+.ycm_extra_conf.py
 # Kate
 .*.kate-swp
 .swp.*

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1923,7 +1923,7 @@ Elements
 * Sets default background color of tooltips
 * Sets default font color of tooltips
 
-### `listoptions[<spacing factor width>,<spacing factor height>;<img factor size>]`
+### `listoptions[<spacing factor width>,<spacing factor height>;<img factor size>;<border>]`
 
 * Set style options for inventory lists
 * `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
@@ -1934,6 +1934,7 @@ Elements
   the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
   example 1 : 1.0 for `img factor size` means that you use the default size for a slot
   example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
+* `border` is the border of a slot, 1 is the default and 0 means no border
 
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1891,18 +1891,6 @@ Elements
 
 * Show an inventory list
 
-### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>;<spacing factor width>,<spacing factor height>;<img factor size>]`
-
-* Show an inventory list
-* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
-  example 1 : (0.0,0.0) for spacing means that there are no space between slots
-  example 2 : (1.0,1.0) for spacing means that default space between slots is used
-  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
-* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
-  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
-  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
-  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
-
 ### `listring[<inventory location>;<list name>]`
 
 * Allows to create a ring of inventory lists
@@ -1934,6 +1922,18 @@ Elements
 * Sets color of slots border
 * Sets default background color of tooltips
 * Sets default font color of tooltips
+
+### `listoptions[<spacing factor width>,<spacing factor height>;<img factor size>]`
+
+* Set style options for inventory lists
+* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
+  example 1 : (0.0,0.0) for spacing means that there are no space between slots
+  example 2 : (1.0,1.0) for spacing means that default space between slots is used
+  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
+* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
+  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
+  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
+  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
 
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1891,6 +1891,18 @@ Elements
 
 * Show an inventory list
 
+### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>;<spacing factor width>,<spacing factor height>;<img factor size>]`
+
+* Show an inventory list
+* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
+  example 1 : (0.0,0.0) for spacing means that there are no space between slots
+  example 2 : (1.0,1.0) for spacing means that default space between slots is used
+  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
+* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
+  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
+  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
+  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
+
 ### `listring[<inventory location>;<list name>]`
 
 * Allows to create a ring of inventory lists

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -339,9 +339,15 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 		std::string listname = parts[1];
 		std::vector<std::string> v_pos  = split(parts[2],',');
 		std::vector<std::string> v_geom = split(parts[3],',');
-		std::string startindex;
-		if (parts.size() == 5)
-			startindex = parts[4];
+		bool has_startindex = parts.size() > 4;
+		std::string startindex = has_startindex ? parts[4] : "";
+		bool has_spacing_factors = parts.size() > 5;
+		std::vector<std::string> v_spacing_factors =
+			has_spacing_factors ?
+			split(parts[5], ',') : std::vector<std::string>();
+		bool has_slot_size_factor = parts.size() > 6;
+		std::string slot_size_factor = has_slot_size_factor ? parts[6] : "";
+		const s32 border = 1;
 
 		MY_CHECKPOS("list",2);
 		MY_CHECKGEOM("list",3);
@@ -359,17 +365,34 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 		geom.Y = stoi(v_geom[1]);
 
 		s32 start_i = 0;
-		if (!startindex.empty())
+		if (has_startindex)
 			start_i = stoi(startindex);
 
-		if (geom.X < 0 || geom.Y < 0 || start_i < 0) {
+		v2s32 _imgsize = imgsize;
+		if (has_slot_size_factor && !slot_size_factor.empty()) {
+			f32 size_factor = stof(slot_size_factor);
+			_imgsize.X = (s32)(imgsize.X * size_factor);
+			_imgsize.Y = (s32)(imgsize.Y * size_factor);
+		}
+
+		v2f32 _spacing = spacing;
+		if (has_spacing_factors && v_spacing_factors.size() == 2) {
+			_spacing.X = _imgsize.X + 2 * border
+			+ stof(v_spacing_factors[0]) * (spacing.X - imgsize.X - 2 * border);
+			_spacing.Y = _imgsize.Y + 2 * border
+			+ stof(v_spacing_factors[1]) * (spacing.Y - imgsize.Y - 2 * border);
+		}
+
+		if (geom.X < 0 || geom.Y < 0 || start_i < 0
+			|| (has_spacing_factors && v_spacing_factors.size() != 2)) {
 			errorstream<< "Invalid list element: '" << element << "'"  << std::endl;
 			return;
 		}
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of list without a size[] element"<<std::endl;
-		m_inventorylists.emplace_back(loc, listname, pos, geom, start_i);
+		m_inventorylists.emplace_back(loc, listname, pos, geom, start_i,
+				_imgsize, _spacing, border);
 		return;
 	}
 	errorstream<< "Invalid list element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -2313,18 +2336,19 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 	for (const GUIFormSpecMenu::ListDrawSpec &s : m_inventorylists) {
 		for(s32 i=0; i<s.geom.X*s.geom.Y; i++) {
 			s32 item_i = i + s.start_item_i;
-			s32 x = (i%s.geom.X) * spacing.X;
-			s32 y = (i/s.geom.X) * spacing.Y;
+			s32 x = (i % s.geom.X) * s.spacing.X;
+			s32 y = (i / s.geom.X) * s.spacing.Y;
 			v2s32 p0(x,y);
 			core::rect<s32> rect = imgrect + s.pos + p0;
 			if(rect.isPointInside(p))
 			{
-				return ItemSpec(s.inventoryloc, s.listname, item_i);
+				return ItemSpec(s.inventoryloc, s.listname, item_i, s.imgsize,
+					s.spacing, s.border);
 			}
 		}
 	}
 
-	return ItemSpec(InventoryLocation(), "", -1);
+	return ItemSpec(InventoryLocation(), "", -1, imgsize, spacing, 1);
 }
 
 void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
@@ -2349,15 +2373,16 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		return;
 	}
 
-	core::rect<s32> imgrect(0,0,imgsize.X,imgsize.Y);
+	core::rect<s32> imgrect(0, 0, s.imgsize.X, s.imgsize.Y);
 
 	for (s32 i = 0; i < s.geom.X * s.geom.Y; i++) {
 		s32 item_i = i + s.start_item_i;
 		if (item_i >= (s32)ilist->getSize())
 			break;
 
-		s32 x = (i%s.geom.X) * spacing.X;
-		s32 y = (i/s.geom.X) * spacing.Y;
+		s32 x = (i % s.geom.X) * s.spacing.X;
+		s32 y = (i / s.geom.X) * s.spacing.Y;
+
 		v2s32 p(x,y);
 		core::rect<s32> rect = imgrect + s.pos + p;
 		ItemStack item = ilist->getItem(item_i);
@@ -2385,7 +2410,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 			s32 y1 = rect.UpperLeftCorner.Y;
 			s32 x2 = rect.LowerRightCorner.X;
 			s32 y2 = rect.LowerRightCorner.Y;
-			s32 border = 1;
+			s32 border = s.border;
 			driver->draw2DRectangle(m_slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y1 - border),
 								v2s32(x2 + border, y1)), NULL);
@@ -2454,7 +2479,7 @@ void GUIFormSpecMenu::drawSelectedItem()
 	ItemStack stack = list->getItem(m_selected_item->i);
 	stack.count = m_selected_amount;
 
-	core::rect<s32> imgrect(0,0,imgsize.X,imgsize.Y);
+	core::rect<s32> imgrect(0,0, m_selected_item->imgsize.X, m_selected_item->imgsize.Y);
 	core::rect<s32> rect = imgrect + (m_pointer - imgrect.getCenter());
 	rect.constrainTo(driver->getViewPort());
 	drawItemStack(driver, m_font, stack, rect, NULL, m_client, IT_ROT_DRAGGED);
@@ -2772,6 +2797,9 @@ void GUIFormSpecMenu::updateSelectedItem()
 			m_selected_item->inventoryloc = s.inventoryloc;
 			m_selected_item->listname = "craftresult";
 			m_selected_item->i = 0;
+			m_selected_item->imgsize = s.imgsize;
+			m_selected_item->spacing = s.spacing;
+			m_selected_item->border = s.border;
 			m_selected_amount = item.count;
 			m_selected_dragging = false;
 			break;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -78,11 +78,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 		ItemSpec() = default;
 
 		ItemSpec(const InventoryLocation &a_inventoryloc,
-				const std::string &a_listname,
-				s32 a_i) :
+				const std::string &a_listname, s32 a_i,
+				const v2s32 &a_spacing, const v2s32 &a_imgsize, s32 a_border):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
-			i(a_i)
+			i(a_i),
+			spacing(a_spacing),
+			imgsize(a_imgsize),
+			border(a_border)
 		{
 		}
 
@@ -91,6 +94,11 @@ class GUIFormSpecMenu : public GUIModalMenu
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i = -1;
+
+		// listoptions
+		v2s32 spacing;
+		v2s32 imgsize;
+		s32 border = 1;
 	};
 
 	struct ListDrawSpec
@@ -99,12 +107,16 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				v2s32 a_spacing, v2s32 a_imgsize, s32 a_border):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			spacing(a_spacing),
+			imgsize(a_imgsize),
+			border(a_border)
 		{
 		}
 
@@ -113,6 +125,11 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+
+		// listoptions
+		v2s32 spacing;
+		v2s32 imgsize;
+		s32 border = 1;
 	};
 
 	struct ListRingSpec
@@ -443,10 +460,6 @@ private:
 	std::string         m_focused_element = "";
 	JoystickController *m_joystick;
 
-	v2s32 m_list_imgsize;
-	v2s32 m_list_spacing;
-	s32 m_list_border = 1;
-
 	typedef struct {
 		bool explicit_size;
 		v2f invsize;
@@ -461,6 +474,10 @@ private:
 		GUITable::TableColumns table_columns;
 		// used to restore table selection/scroll/treeview state
 		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
+		// listoptions
+		v2s32 list_imgsize;
+		v2s32 list_spacing;
+		s32 list_border = 1;
 	} parserData;
 
 	typedef struct {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -79,16 +79,10 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i,
-				const v2s32 &a_imgsize,
-				const v2s32 &a_spacing,
-				s32 a_border) :
+				s32 a_i) :
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
-			i(a_i),
-			imgsize(a_imgsize),
-			spacing(a_spacing),
-			border(a_border)
+			i(a_i)
 		{
 		}
 
@@ -96,12 +90,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		InventoryLocation inventoryloc;
 		std::string listname;
-
 		s32 i = -1;
-
-		v2s32 imgsize;
-		v2s32 spacing;
-		s32 border;
 	};
 
 	struct ListDrawSpec
@@ -110,16 +99,12 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
-				v2s32 a_imgsize, v2s32 a_spacing, s32 a_border):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i),
-			imgsize(a_imgsize),
-			spacing(a_spacing),
-			border(a_border)
+			start_item_i(a_start_item_i)
 		{
 		}
 
@@ -128,9 +113,6 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
-		v2s32 imgsize;
-		v2s32 spacing;
-		s32 border;
 	};
 
 	struct ListRingSpec
@@ -461,6 +443,10 @@ private:
 	std::string         m_focused_element = "";
 	JoystickController *m_joystick;
 
+	v2s32 m_list_imgsize;
+	v2s32 m_list_spacing;
+	s32 m_list_border = 1;
+
 	typedef struct {
 		bool explicit_size;
 		v2f invsize;
@@ -522,6 +508,7 @@ private:
 	void parseBox(parserData* data, const std::string &element);
 	void parseBackgroundColor(parserData* data, const std::string &element);
 	void parseListColors(parserData* data, const std::string &element);
+	void parseListOptions(parserData* data, const std::string &element);
 	void parseTooltip(parserData* data, const std::string &element);
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -79,10 +79,16 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ItemSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				s32 a_i) :
+				s32 a_i,
+				const v2s32 &a_imgsize,
+				const v2s32 &a_spacing,
+				s32 a_border) :
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
-			i(a_i)
+			i(a_i),
+			imgsize(a_imgsize),
+			spacing(a_spacing),
+			border(a_border)
 		{
 		}
 
@@ -90,7 +96,12 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		InventoryLocation inventoryloc;
 		std::string listname;
+
 		s32 i = -1;
+
+		v2s32 imgsize;
+		v2s32 spacing;
+		s32 border;
 	};
 
 	struct ListDrawSpec
@@ -99,12 +110,16 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				v2s32 a_imgsize, v2s32 a_spacing, s32 a_border):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			imgsize(a_imgsize),
+			spacing(a_spacing),
+			border(a_border)
 		{
 		}
 
@@ -113,6 +128,9 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+		v2s32 imgsize;
+		v2s32 spacing;
+		s32 border;
 	};
 
 	struct ListRingSpec

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -212,7 +212,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PASSWORD_SIZE 28       // Maximum password length. Allows for
                                // base64-encoded SHA-1 (27+\0).
 
-#define FORMSPEC_API_VERSION 1
+#define FORMSPEC_API_VERSION 2
 #define FORMSPEC_VERSION_STRING "formspec_version[" TOSTRING(FORMSPEC_API_VERSION) "]"
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -212,7 +212,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PASSWORD_SIZE 28       // Maximum password length. Allows for
                                // base64-encoded SHA-1 (27+\0).
 
-#define FORMSPEC_API_VERSION 2
+#define FORMSPEC_API_VERSION 1
 #define FORMSPEC_VERSION_STRING "formspec_version[" TOSTRING(FORMSPEC_API_VERSION) "]"
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"


### PR DESCRIPTION
I really like #5395 but it seems dead, so I decided to rebase it and to take it further.

@rubenwardy suggested changes, I made them, however these changes makes the styling "global" instead of per-inventory list.

**`listoptions[<spacing factor width>,<spacing factor height>;<img factor size>;<border_size>]`**

- Set inventory list style

- `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
example 1 : (0.0,0.0) for spacing means that there are no space between slots
example 2 : (1.0,1.0) for spacing means that default space between slots is used
example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
- `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
the default value for the img factor size is 1.0 (42 pixels with border included for a 800x600 screen size)
example 1 : 1.0 for img factor size means that you use the default size for a slot
example 2 : 2.0 for img factor size means that you use the default size x2 for a slot
- `border size` is the size of the border of a slot (wasn't in the original PR)

***

<details><summary>Example 1</summary>
<p>

```
size[8,7.5;]
image[1,0.6;1,2;player.png]
listoptions[0,0;1;0]
list[current_player;main;0,3.5;8,4;]
list[current_player;craft;3,0;3,3;]
list[current_player;craftpreview;7,1;1,1;]
```

![screenshot-20181214030139](https://user-images.githubusercontent.com/554446/49978862-d02ce280-ff4c-11e8-8bc8-0b8bf9bdb633.png)
</p>
</details>

***

<details><summary>Example 2</summary>
<p>

```
size[8,7.5;]
image[1,0.6;1,2;player.png]
listoptions[1,1;0.5;1]
list[current_player;main;0,3.5;8,4;]
list[current_player;craft;3,0;3,3;]
list[current_player;craftpreview;7,1;1,1;]
```

![screenshot-20181214092130](https://user-images.githubusercontent.com/554446/49991574-d5f0eb00-ff81-11e8-938e-c02836620854.png)

</p>
</details>

***

<details><summary>Example 3</summary>
<p>

```
size[8,7.5;]
image[1,0.6;1,2;player.png]
listoptions[0,0;1;0]
list[current_player;main;0,3.5;8,4;]
listoptions[1,1;0.5;1]
list[current_player;craft;3,0;3,3;]
listoptions[1,1;1.2;1]
list[current_player;craftpreview;7,1;1,1;]
```

![screenshot-20181214185411](https://user-images.githubusercontent.com/554446/50019088-c13c4380-ffd1-11e8-84ff-20c991b2ee7c.png)

</p>

***
