### PR TITLE
HUD: Font shadow added on item stacks for better readability. (Really trivial)

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -771,6 +771,9 @@ void drawItemStack(video::IVideoDriver *driver,
 		video::SColor bgcolor(128,0,0,0);
 		driver->draw2DRectangle(bgcolor, rect2, clip);
 
+		video::SColor shadow_color(0,0,0,255);
+		font->draw(text.c_str(), rect2 + v2s32(1, 1), shadow_color, false, false, clip);
+
 		video::SColor color(255,255,255,255);
 		font->draw(text.c_str(), rect2, color, false, false, clip);
 	}

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -761,18 +761,15 @@ void drawItemStack(video::IVideoDriver *driver,
 		v2u32 dim = font->getDimension(utf8_to_wide(text).c_str());
 		v2s32 sdim(dim.X,dim.Y);
 
+		s32 shadow_offset = 1;
 		core::rect<s32> rect2(
-			/*rect.UpperLeftCorner,
-			core::dimension2d<u32>(rect.getWidth(), 15)*/
-			rect.LowerRightCorner - sdim,
-			sdim
+			rect.LowerRightCorner - sdim - shadow_offset,
+			sdim - shadow_offset
 		);
 
-		video::SColor bgcolor(128,0,0,0);
-		driver->draw2DRectangle(bgcolor, rect2, clip);
-
 		video::SColor shadow_color(0,0,0,255);
-		font->draw(text.c_str(), rect2 + v2s32(1, 1), shadow_color, false, false, clip);
+		font->draw(text.c_str(), rect2 + v2s32(shadow_offset, shadow_offset),
+				shadow_color, false, false, clip);
 
 		video::SColor color(255,255,255,255);
 		font->draw(text.c_str(), rect2, color, false, false, clip);


### PR DESCRIPTION
What the title says.

***

<details><summary>Before</summary>
<p>

![screenshot-20181214105149](https://user-images.githubusercontent.com/554446/49996206-b90ee480-ff8e-11e8-97ff-f93f1605ba83.png)

</p>
</details>

***

<details><summary>After</summary>
<p>

![screenshot-20181214105117](https://user-images.githubusercontent.com/554446/49996204-b613f400-ff8e-11e8-84a9-81e234fc3ccc.png)

</p>
</details>

***

<details><summary>Offset fix</summary>
<p>

![screenshot-20181214114602](https://user-images.githubusercontent.com/554446/49999000-faef5900-ff95-11e8-80ce-69481ca5a837.png)

</p>
</details>

***