### PR TITLE
New object property to hide selection box.

### DIFF
--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -810,6 +810,35 @@ minetest.register_chatcommand("test_formspec", {
 	end
 })
 
+--
+-- Test entity without selection box
+--
+
+minetest.register_entity("experimental:testentity_nobox", {
+	initial_properties = {
+		visual = "wielditem",
+		textures = {"default:dirt"},
+		show_selection_box = false,
+		visual_size = {x = 0.666 / 2, y = 0.666 / 2},
+	},
+
+	on_punch = function(self, hitter)
+		self.object:remove()
+	end,
+})
+
+minetest.register_chatcommand("test_entity_nobox", {
+	params = "",
+	description = "Test: Hide entity selection box",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return
+		end
+		minetest.add_entity(player:get_pos(), "experimental:testentity_nobox")
+	end,
+})
+
 minetest.log("info", "experimental modname="..dump(minetest.get_current_modname()))
 minetest.log("info", "experimental modpath="..dump(minetest.get_modpath("experimental")))
 minetest.log("info", "experimental worldpath="..dump(minetest.get_worldpath()))

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -233,4 +233,8 @@ public:
 	{
 		return m_prop.infotext;
 	}
+
+	bool doShowSelectionBox() override {
+		return m_prop.show_selection_box;
+	}
 };

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -69,6 +69,7 @@ std::string ObjectProperties::dump()
 	os << ", eye_height=" << eye_height;
 	os << ", zoom_fov=" << zoom_fov;
 	os << ", use_texture_alpha=" << use_texture_alpha;
+	os << ", show_selection_box=" << show_selection_box;
 	return os.str();
 }
 
@@ -115,6 +116,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF1000(os, eye_height);
 	writeF1000(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
+	writeU8(os, show_selection_box);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -167,4 +169,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF1000(is);
 	zoom_fov = readF1000(is);
 	use_texture_alpha = readU8(is);
+	show_selection_box = readU8(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -61,6 +61,7 @@ struct ObjectProperties
 	float eye_height = 1.625f;
 	float zoom_fov = 0.0f;
 	bool use_texture_alpha = false;
+	bool show_selection_box = true;
 
 	ObjectProperties();
 	std::string dump();

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -305,6 +305,7 @@ void read_object_properties(lua_State *L, int index,
 
 	getfloatfield(L, -1, "zoom_fov", prop->zoom_fov);
 	getboolfield(L, -1, "use_texture_alpha", prop->use_texture_alpha);
+	getboolfield(L, -1, "show_selection_box", prop->show_selection_box);
 }
 
 /******************************************************************************/
@@ -389,6 +390,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "zoom_fov");
 	lua_pushboolean(L, prop->use_texture_alpha);
 	lua_setfield(L, -2, "use_texture_alpha");
+	lua_pushboolean(L, prop->show_selection_box);
+	lua_setfield(L, -2, "show_selection_box");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
What the title says, it could be nice to have this feature for mobs and some item drop mods.

The new property is called `show_selection_box` but feel free to tell me if you want to change.

To test it, just run `/test_entity_nobox` in `minimal`.

![screenshot-20181219153502](https://user-images.githubusercontent.com/554446/50226537-c15a8b80-03a3-11e9-9936-00c22930d41e.png)