### PR TITLE
CSM restrictions: Make 'LOAD_CLIENT_MODS' disable loading of 'builtin' 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1190,14 +1190,16 @@ block_send_optimize_distance (Block send optimize distance) int 4 2
 #    so that the utility of noclip mode is reduced.
 server_side_occlusion_culling (Server side occlusion culling) bool true
 
-#    Restricts the access of certain client-side functions on servers
-#    Combine these byteflags below to restrict client-side features:
-#    LOAD_CLIENT_MODS: 1 (disable client mods loading)
+#    Restricts the access of certain client-side functions on servers.
+#    Combine the byteflags below to restrict client-side features, or set to 0
+#    for no restrictions:
+#    LOAD_CLIENT_MODS: 1 (disable loading client-provided mods)
 #    CHAT_MESSAGES: 2 (disable send_chat_message call client-side)
 #    READ_ITEMDEFS: 4 (disable get_item_def call client-side)
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
+#    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
 csm_restriction_flags (Client side modding restrictions) int 62
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1891,7 +1891,7 @@ void Game::processKeyInput()
 		if (client->moddingEnabled())
 			openConsole(0.2, L".");
 		else
-			m_game_ui->showStatusText(wgettext("CSM is disabled"));
+			m_game_ui->showStatusText(wgettext("Client side scripting is disabled"));
 	} else if (wasKeyDown(KeyType::CONSOLE)) {
 		openConsole(core::clamp(g_settings->getFloat("console_height"), 0.1f, 1.0f));
 	} else if (wasKeyDown(KeyType::FREEMOVE)) {
@@ -2554,7 +2554,7 @@ void Game::handleClientEvent_PlayerForceMove(ClientEvent *event, CameraOrientati
 
 void Game::handleClientEvent_Deathscreen(ClientEvent *event, CameraOrientation *cam)
 {
-	// If CSM enabled, deathscreen is handled by CSM code in
+	// If client scripting is enabled, deathscreen is handled by CSM code in
 	// builtin/client/init.lua
 	if (client->moddingEnabled())
 		client->getScript()->on_death();

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -947,7 +947,11 @@ enum PlayerListModifer: u8
 
 enum CSMRestrictionFlags : u64 {
 	CSM_RF_NONE = 0x00000000,
-	CSM_RF_LOAD_CLIENT_MODS = 0x00000001, // Disable mods provided by clients
+	// Until server-sent CSM and verifying of builtin are complete,
+	// 'CSM_RF_LOAD_CLIENT_MODS' also disables loading 'builtin'.
+	// When those are complete, this should return to only being a restriction on the
+	// loading of client mods.
+	CSM_RF_LOAD_CLIENT_MODS = 0x00000001, // Don't load client-provided mods or 'builtin'
 	CSM_RF_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
 	CSM_RF_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_RF_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups


### PR DESCRIPTION
Previously, when the CSM restriction 'LOAD_CLIENT_MODS' was used a
client was still able to add CSM code to 'builtin' to bypass that
restriction, because 'builtin' is not yet verified.

Until server-sent CSM and verifying of 'builtin' are complete, make
'LOAD_CLIENT_MODS' disable the loading of builtin.

Clarify code comments and messages to distinguish between client-side
modding and client-side scripting. 'Scripting' includes 'builtin',
'modding' does not.
///////////////////////////////

A CSM restriction exists ('LOAD_CLIENT_MODS' ) that stops a client loading CSMods, this is for servers that want to stop a client using any CSM code, whether it is generally considered harmful or not.
However this restriction does not stop the client loading the 'builtin' CSM code, and it's easy to add CSM code to builtin, and builtin is not yet checked for such added code.