### PR TITLE
Android: Fix start-up crashes on version 4.x

### DIFF
--- a/build/android/src/main/java/net.minetest.minetest/MtNativeActivity.java
+++ b/build/android/src/main/java/net.minetest.minetest/MtNativeActivity.java
@@ -10,6 +10,7 @@ import android.view.WindowManager;
 public class MtNativeActivity extends NativeActivity {
 
 	static {
+		System.loadLibrary("c++_shared");
 		System.loadLibrary("openal");
 		System.loadLibrary("ogg");
 		System.loadLibrary("vorbis");

--- a/build/android/src/main/res/values-v21/styles.xml
+++ b/build/android/src/main/res/values-v21/styles.xml
@@ -4,7 +4,7 @@
 	<style name="AppTheme" parent="@android:style/android:Theme.Material.Light.NoActionBar.Fullscreen">
 		<item name="android:windowNoTitle">true</item>
 		<item name="android:windowAnimationStyle">@null</item>
-		<item name="android:background">@drawable/bg</item>
+		<item name="android:windowBackground">@drawable/bg</item>
 	</style>
 
 	<style name="Theme.Dialog" parent="@android:style/Theme.Material.Light.Dialog.NoActionBar"/>

--- a/build/android/src/main/res/values/styles.xml
+++ b/build/android/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
 	<style name="AppTheme" parent="@android:style/android:Theme.Holo.Light.NoActionBar.Fullscreen">
 		<item name="android:windowNoTitle">true</item>
 		<item name="android:windowAnimationStyle">@null</item>
-		<item name="android:background">@drawable/bg</item>
+		<item name="android:windowBackground">@drawable/bg</item>
 	</style>
 
 	<style name="Theme.Dialog" parent="@android:style/android:Theme.Holo.Light.Dialog.NoActionBar"/>


### PR DESCRIPTION
Now that we are using a shared STL we must include and load the library. It would seem that `libc++_shared.so` is already included from around android 5 onwards, however, it is not present on earlier versions resulting in a start-up crash.
```
     Caused by: java.lang.UnsatisfiedLinkError: Cannot load library: soinfo_link_image(linker.cpp:1635): could not load library "libc++_shared.so" needed by "libiconv.so"; caused by load_library(linker.cpp:745): library "libc++_shared.so" not found
```

This PR now also includes a fix for the following error reported in #7994. I will let the developers decide whether to squash these commits or not.
```
E/AndroidRuntime(15502): Caused by: java.lang.NumberFormatException: Invalid int: "res/drawable/bg.xml"
```

Tested on Android 4.2.1 (Jelly Bean)

![game](https://user-images.githubusercontent.com/3710749/50243775-01cb0100-03c6-11e9-831f-ba9d3fd38701.png)

It's actually surprisingly playable on something that only cost me about 60 quid (bnib) 5 years ago :)

Test APK available here:  [Minetest-java-fix.apk](https://www.dropbox.com/s/8d8ghg38xx03oj0/Minetest-java-fix.apk?dl=0) @Fixer-007 @niansa @MoNTE48 

Edit: I just realized that the commit actually reads as Load standard template library library, nvm :D