### PR TITLE
Fix more transparency issues with ogles2 driver

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1062,6 +1062,7 @@ void GenericCAO::updateTextures(std::string mod)
 				texturestring = m_prop.textures[0];
 			texturestring += mod;
 			m_spritenode->getMaterial(0).MaterialType = material_type;
+			m_spritenode->getMaterial(0).MaterialTypeParam = 0.5f;
 			m_spritenode->setMaterialTexture(0,
 					tsrc->getTextureForMesh(texturestring));
 
@@ -1097,6 +1098,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial& material = m_animated_meshnode->getMaterial(i);
 				material.MaterialType = material_type;
+				material.MaterialTypeParam = 0.5f;
 				material.TextureLayer[0].Texture = texture;
 				material.setFlag(video::EMF_LIGHTING, true);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
@@ -1143,6 +1145,7 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial& material = m_meshnode->getMaterial(i);
 				material.MaterialType = material_type;
+				material.MaterialTypeParam = 0.5f;
 				material.setFlag(video::EMF_LIGHTING, false);
 				material.setFlag(video::EMF_BILINEAR_FILTER, false);
 				material.setTexture(0,

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -282,6 +282,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		material.TextureLayer[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
 		material.TextureLayer[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
 		material.MaterialType = m_material_type;
+		material.MaterialTypeParam = 0.5f;
 		material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 		// Enable bi/trilinear filtering only for high resolution textures
 		if (dim.Width > 32) {
@@ -426,6 +427,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		for (u32 i = 0; i < material_count; ++i) {
 			video::SMaterial &material = m_meshnode->getMaterial(i);
 			material.MaterialType = m_material_type;
+			material.MaterialTypeParam = 0.5f;
 			material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 			material.setFlag(video::EMF_BILINEAR_FILTER, m_bilinear_filter);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, m_trilinear_filter);
@@ -569,6 +571,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+			material.MaterialTypeParam = 0.5f;
 			material.setFlag(video::EMF_BILINEAR_FILTER, false);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, false);
 			material.setFlag(video::EMF_BACK_FACE_CULLING, true);
@@ -619,6 +622,7 @@ scene::SMesh *getExtrudedMesh(ITextureSource *tsrc,
 		material.setFlag(video::EMF_BACK_FACE_CULLING, true);
 		material.setFlag(video::EMF_LIGHTING, false);
 		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		material.MaterialTypeParam = 0.5f;
 	}
 	scaleMesh(mesh, v3f(2.0, 2.0, 2.0));
 


### PR DESCRIPTION
It turns out that the I fix made for node tiles in #6971 needs to be applied in a few more places.

Wield Hand
![wield](https://user-images.githubusercontent.com/3710749/50304266-6e5a0480-0487-11e9-9225-a32a9308701e.png)

Entities
![entity](https://user-images.githubusercontent.com/3710749/50304291-7a45c680-0487-11e9-8647-a47e60a6ea6a.png)

Inventory Items
![inventory](https://user-images.githubusercontent.com/3710749/50304316-8762b580-0487-11e9-8297-9605e661e0b4.png)


