### PR TITLE
Move touchscreen rare controls inline with settings icon

### DIFF
--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -81,7 +81,7 @@ typedef enum {
 #define BUTTON_REPEAT_DELAY 0.2f
 
 #define SETTINGS_BAR_Y_OFFSET 5
-#define RARE_CONTROLS_BAR_Y_OFFSET 4
+#define RARE_CONTROLS_BAR_Y_OFFSET 5
 
 extern const char **touchgui_button_imagenames;
 extern const char **touchgui_joystick_imagenames;


### PR DESCRIPTION
This fixes an issue I have on two of my devices using the 'fixed' virtual joystick where the rare buttons are overlapping.

**Before**
![before](https://user-images.githubusercontent.com/3710749/50305489-deb65500-048a-11e9-8409-f655aed83a03.png)

**After**
![after](https://user-images.githubusercontent.com/3710749/50305492-e2e27280-048a-11e9-929b-9467bffc12ad.png)

There is no problem with the two menus being inline as the code ensures that only one of them can be open at any time.
