### PR TITLE
CSM: add requested CSM_RF_READ_PLAYERINFO

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -40,11 +40,11 @@ end)
 core.register_chatcommand("list_players", {
 	description = core.gettext("List online players"),
 	func = function(param)
-	    local player_names = core.get_player_names()
-	    if player_names == nil then
-	        core.display_chat_message(core.gettext("This command is disabled by server."))
-	        return
-	    end
+		local player_names = core.get_player_names()
+		if player_names == nil then
+			core.display_chat_message(core.gettext("This command is disabled by server."))
+		return
+	end
 
         local players = table.concat(player_names, ", ")
         core.display_chat_message(core.gettext("Online players: ") .. players)

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -41,13 +41,12 @@ core.register_chatcommand("list_players", {
 	description = core.gettext("List online players"),
 	func = function(param)
 		local player_names = core.get_player_names()
-		if player_names == nil then
-			return false, core.display_chat_message(core.gettext("This command is disabled by server."))
+		if not player_names then
+			return false, core.gettext("This command is disabled by server.")
+		end
 
-        end
-
-        local players = table.concat(player_names, ", ")
-        return true, core.display_chat_message(core.gettext("Online players: ") .. players)
+		local players = table.concat(player_names, ", ")
+		return true, core.gettext("Online players: ") .. players
 	end
 })
 

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -41,7 +41,7 @@ core.register_chatcommand("list_players", {
 	description = core.gettext("List online players"),
 	func = function(param)
 	    player_names = core.get_player_names()
-	    if players == nil then
+	    if player_names == nil then
 	        core.display_chat_message(core.gettext("This command is restricted by server."))
 	        return
 	    end

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -40,8 +40,14 @@ end)
 core.register_chatcommand("list_players", {
 	description = core.gettext("List online players"),
 	func = function(param)
-		local players = table.concat(core.get_player_names(), ", ")
-		core.display_chat_message(core.gettext("Online players: ") .. players)
+	    player_names = core.get_player_names()
+	    if players == nil then
+	        core.display_chat_message(core.gettext("This command is restricted by server."))
+	        return
+	    end
+
+        local players = table.concat(player_names, ", ")
+        core.display_chat_message(core.gettext("Online players: ") .. players)
 	end
 })
 

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -42,7 +42,7 @@ core.register_chatcommand("list_players", {
 	func = function(param)
 	    local player_names = core.get_player_names()
 	    if player_names == nil then
-	        core.display_chat_message(core.gettext("This command is restricted by server."))
+	        core.display_chat_message(core.gettext("This command is disabled by server."))
 	        return
 	    end
 

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -42,12 +42,12 @@ core.register_chatcommand("list_players", {
 	func = function(param)
 		local player_names = core.get_player_names()
 		if player_names == nil then
-			core.display_chat_message(core.gettext("This command is disabled by server."))
-		return
-	end
+			return false, core.display_chat_message(core.gettext("This command is disabled by server."))
+
+        end
 
         local players = table.concat(player_names, ", ")
-        core.display_chat_message(core.gettext("Online players: ") .. players)
+        return true, core.display_chat_message(core.gettext("Online players: ") .. players)
 	end
 })
 

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -40,7 +40,7 @@ end)
 core.register_chatcommand("list_players", {
 	description = core.gettext("List online players"),
 	func = function(param)
-	    player_names = core.get_player_names()
+	    local player_names = core.get_player_names()
 	    if player_names == nil then
 	        core.display_chat_message(core.gettext("This command is restricted by server."))
 	        return

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1198,7 +1198,7 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
-csm_restriction_flags (Client side modding restrictions) int 30
+csm_restriction_flags (Client side modding restrictions) int 62
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -763,7 +763,7 @@ Call these functions only at load time!
 
 ### Client Environment
 * `minetest.get_player_names()`
-    * Returns list of player names on server
+    * Returns list of player names on server (nil if CSM_RF_READ_PLAYERINFO is enabled by server)
 * `minetest.disconnect()`
     * Disconnect from the server and exit to main menu.
     * Returns `false` if the client is already disconnecting otherwise returns `true`.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1470,7 +1470,7 @@
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
 #    type: int
-# csm_restriction_flags = 63
+# csm_restriction_flags = 62
 
 #    If the CSM restriction for node range is enabled, get_node calls are limited
 #    to this distance from the player to the node.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1468,6 +1468,7 @@
 #    READ_NODEDEFS: 8 (disable get_node_def call client-side)
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
+#    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
 #    type: int
 # csm_restriction_flags = 30
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1470,7 +1470,7 @@
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
 #    type: int
-# csm_restriction_flags = 30
+# csm_restriction_flags = 63
 
 #    If the CSM restriction for node range is enabled, get_node calls are limited
 #    to this distance from the player to the node.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -346,7 +346,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "9");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_restriction_flags", "30");
+	settings->setDefault("csm_restriction_flags", "62");
 	settings->setDefault("csm_restriction_noderange", "0");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -952,5 +952,6 @@ enum CSMRestrictionFlags : u64 {
 	CSM_RF_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
 	CSM_RF_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
 	CSM_RF_LOOKUP_NODES = 0x00000010, // Limit node lookups
+	CSM_RF_READ_PLAYERINFO = 0x00000020, // Disable player info lookups
 	CSM_RF_ALL = 0xFFFFFFFF,
 };

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -116,6 +116,11 @@ int ModApiClient::l_clear_out_chat_queue(lua_State *L)
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
+	if (getClient(L)->checkCSMRestrictionFlag(
+			CSMRestrictionFlags::CSM_RF_READ_PLAYERINFO)) {
+		return 0;
+	}
+
 	const std::list<std::string> &plist = getClient(L)->getConnectedPlayerNames();
 	lua_createtable(L, plist.size(), 0);
 	int newTable = lua_gettop(L);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -116,10 +116,12 @@ int ModApiClient::l_clear_out_chat_queue(lua_State *L)
 // get_player_names()
 int ModApiClient::l_get_player_names(lua_State *L)
 {
+	// clang-format off
 	if (getClient(L)->checkCSMRestrictionFlag(
 			CSMRestrictionFlags::CSM_RF_READ_PLAYERINFO)) {
 		return 0;
 	}
+	// clang-format on
 
 	const std::list<std::string> &plist = getClient(L)->getConnectedPlayerNames();
 	lua_createtable(L, plist.size(), 0);


### PR DESCRIPTION
This new CSM limit permit to limit PLAYERINFO read from server.

It affects get_player_names call
///////////////
EDIT by paramat:
For request https://github.com/minetest/minetest/issues/7995#issuecomment-449212091