### PR TITLE
lua_api.txt: Add documentation of missing field to `on_punch`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3268,7 +3268,7 @@ Callbacks:
     * Called on every server tick, after movement and collision processing.
       `dtime` is usually 0.1 seconds, as per the `dedicated_server_step` setting
       in `minetest.conf`.
-* `on_punch(self, puncher, time_from_last_punch, tool_capabilities, dir)`
+* `on_punch(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)`
     * Called when somebody punches the object.
     * Note that you probably want to handle most punches using the automatic
       armor group system.
@@ -3278,6 +3278,7 @@ Callbacks:
     * `tool_capabilities`: capability table of used tool (can be `nil`)
     * `dir`: unit vector of direction of punch. Always defined. Points from the
       puncher to the punched.
+    * `damage`: damage that will be done to entity.
 * `on_death(self, killer)`
     * Called when the object dies.
     * `killer`: an `ObjectRef` (can be `nil`)


### PR DESCRIPTION
Trivial documentation PR to add documentation of missing `damage` field to `on_punch` in the Entity Definition section. Copy-pasted from the entity damage calculation section:

https://github.com/minetest/minetest/blob/d994f7ca5f75431da8e17fd6762209c404d89482/doc/lua_api.txt#L1689-L1703