### PR TITLE
Android: Fix memory leak when displaying images in the mainmenu

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -70,22 +70,30 @@ MenuTextureSource::~MenuTextureSource()
 /******************************************************************************/
 video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 {
-	if(id)
+	if (id)
 		*id = 0;
-	if(name.empty())
+
+	if (name.empty())
 		return NULL;
+
 	m_to_delete.insert(name);
 
 #ifdef __ANDROID__
-	video::IImage *image = m_driver->createImageFromFile(name.c_str());
-	if (image) {
-		image = Align2Npot2(image, m_driver);
-		video::ITexture* retval = m_driver->addTexture(name.c_str(), image);
-		image->drop();
+	video::ITexture *retval = m_driver->findTexture(name.c_str());
+	if (retval)
 		return retval;
-	}
-#endif
+
+	video::IImage *image = m_driver->createImageFromFile(name.c_str());
+	if (!image)
+		return NULL;
+
+	image = Align2Npot2(image, m_driver);
+	retval = m_driver->addTexture(name.c_str(), image);
+	image->drop();
+	return retval;
+#else
 	return m_driver->getTexture(name.c_str());
+#endif
 }
 
 /******************************************************************************/


### PR DESCRIPTION
ISimpleTextureSource::getTexture() is called once for every image every tick. The Android specific code allocates a new texture every time this happens, resulting in a memory leak

Fixes #8010