### PR TITLE
Remove 'Reset singleplayer world' button from full menu on Android

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -220,7 +220,8 @@ local function formspec(tabview, name, tabdata)
 					fgettext("Shaders (unavailable)")) .. "]"
 	end
 
-	if PLATFORM == "Android" then
+	if core.settings:get("main_menu_style") == "simple" then
+		-- 'Reset singleplayer world' only functions with simple menu
 		tab_string = tab_string ..
 			"button[8,4.75;3.95,1;btn_reset_singleplayer;"
 			.. fgettext("Reset singleplayer world") .. "]"


### PR DESCRIPTION
Make button appearence dependent on menustyle not platform.
Button only functions with simple menu.
///////////////////////

Closes #8016 
Tested on desktop in 'simple' and 'full' modes.