### PR TITLE
Add /say chat-command

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -79,6 +79,16 @@ core.register_chatcommand("me", {
 	end,
 })
 
+core.register_chatcommand("say", {
+	params = "<message>",
+	description = "Send a raw chat message",
+	privs = {shout = true},
+	func = function(name, param)
+		param = param:trim()
+		core.chat_send_all("<" .. name .. "> " .. param)
+	end
+})
+
 core.register_chatcommand("admin", {
 	description = "Show the name of the server owner",
 	func = function(name)


### PR DESCRIPTION
It feels hacky, not to mention it's kinda annoying, to add a space before a message if it starts with `/` to not be parsed as a chat-command. Presenting `/say`, the chat-command that displays the raw message as-is without checking if it's a chat-command. Many popular IRC daemons and clients provide a `SAY` command for the same reason.

#### Example

```
<PlayerA> How to PM you?
(PlayerB types "/say /msg PlayerB message")
<PlayerB> /msg PlayerB message
```

The short description (`params`) and long description (`description`) could be improved. Any suggestions?