### PR TITLE
Add minetest.load_area

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3989,6 +3989,12 @@ Environment access
         * mode = `"quick"`: Clear objects immediately in loaded mapblocks,
                             clear objects in unloaded mapblocks only when the
                             mapblocks are next activated.
+* `minetest.load_area(pos1[, pos2])`
+    * Load the mapblock which contains `pos1`
+      or blocks in the area from `pos1` to `pos2` if `pos2` is specified.
+    * This function does not trigger map generation.
+      After executing it, `minetest.get_node_or_nil` returns the node even
+      if it is far away from a player.
 * `minetest.emerge_area(pos1, pos2, [callback], [param])`
     * Queue all blocks in the area from `pos1` to `pos2`, inclusive, to be
       asynchronously fetched from memory, loaded from disk, or if inexistent,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3990,11 +3990,9 @@ Environment access
                             clear objects in unloaded mapblocks only when the
                             mapblocks are next activated.
 * `minetest.load_area(pos1[, pos2])`
-    * Load the mapblock which contains `pos1`
-      or blocks in the area from `pos1` to `pos2` if `pos2` is specified.
+    * Load the mapblock containing the area from `pos1` to `pos2`.
+      `pos2` defaults to `pos1` if not specified.
     * This function does not trigger map generation.
-      After executing it, `minetest.get_node_or_nil` returns the node even
-      if it is far away from a player.
 * `minetest.emerge_area(pos1, pos2, [callback], [param])`
     * Queue all blocks in the area from `pos1` to `pos2`, inclusive, to be
       asynchronously fetched from memory, loaded from disk, or if inexistent,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3990,7 +3990,7 @@ Environment access
                             clear objects in unloaded mapblocks only when the
                             mapblocks are next activated.
 * `minetest.load_area(pos1[, pos2])`
-    * Load the mapblock containing the area from `pos1` to `pos2`.
+    * Load the mapblocks containing the area from `pos1` to `pos2`.
       `pos2` defaults to `pos1` if not specified.
     * This function does not trigger map generation.
 * `minetest.emerge_area(pos1, pos2, [callback], [param])`

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1047,6 +1047,30 @@ int ModApiEnvMod::l_raycast(lua_State *L)
 	return LuaRaycast::create_object(L);
 }
 
+// load_area(p1, [p2])
+// load mapblocks in area p1..p2, but do not generate map
+int ModApiEnvMod::l_load_area(lua_State *L)
+{
+	GET_ENV_PTR;
+	MAP_LOCK_REQUIRED;
+
+	Map *map = &(env->getMap());
+	v3s16 bp1 = getNodeBlockPos(check_v3s16(L, 1));
+	if (!lua_istable(L, 2)) {
+		map->emergeBlock(bp1);
+	} else {
+		v3s16 bp2 = getNodeBlockPos(check_v3s16(L, 2));
+		sortBoxVerticies(bp1, bp2);
+		for (s16 z = bp1.Z; z <= bp2.Z; z++)
+		for (s16 y = bp1.Y; y <= bp2.Y; y++)
+		for (s16 x = bp1.X; x <= bp2.X; x++) {
+			map->emergeBlock(v3s16(x, y, z));
+		}
+	}
+
+	return 0;
+}
+
 // emerge_area(p1, p2, [callback, context])
 // emerge mapblocks in area p1..p2, calls callback with context upon completion
 int ModApiEnvMod::l_emerge_area(lua_State *L)
@@ -1287,6 +1311,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(find_nodes_in_area);
 	API_FCT(find_nodes_in_area_under_air);
 	API_FCT(fix_light);
+	API_FCT(load_area);
 	API_FCT(emerge_area);
 	API_FCT(delete_area);
 	API_FCT(get_perlin);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -135,6 +135,9 @@ private:
 	// fix_light(p1, p2) -> true/false
 	static int l_fix_light(lua_State *L);
 
+	// load_area(p1)
+	static int l_load_area(lua_State *L);
+
 	// emerge_area(p1, p2)
 	static int l_emerge_area(lua_State *L);
 


### PR DESCRIPTION
It is less hacky than minetest.get_voxel_manip():read_from_map(pos1, pos2) for getting nodes at unloaded places.
This is the implementation of #7206.

When editing the code, I noticed that many functions, including this one, do not check for overflow.
`getNodeBlockPos(check_v3s16(L, 1))` converts an arbitrary position to a 16 bit vector without testing if the position from the mod actually is inside the map, so using minetest.emerge_area is dangerous on map boundaries. Is this intended behaviour?