### PR TITLE
Fix attached object selectionbox bug 

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -430,12 +430,11 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	}
 
 	// Update offset if too far away from the center of the map
-	m_camera_offset.X += CAMERA_OFFSET_STEP*
-			(((s16)(my_cp.X/BS) - m_camera_offset.X)/CAMERA_OFFSET_STEP);
-	m_camera_offset.Y += CAMERA_OFFSET_STEP*
-			(((s16)(my_cp.Y/BS) - m_camera_offset.Y)/CAMERA_OFFSET_STEP);
-	m_camera_offset.Z += CAMERA_OFFSET_STEP*
-			(((s16)(my_cp.Z/BS) - m_camera_offset.Z)/CAMERA_OFFSET_STEP);
+	{
+		v3s16 d_nodepos_offset = floatToInt(my_cp, BS) - m_camera_offset;
+		m_camera_offset += CAMERA_OFFSET_STEP *
+			(d_nodepos_offset / CAMERA_OFFSET_STEP);
+	}
 
 	// Set camera node transformation
 	m_cameranode->setPosition(my_cp-intToFloat(m_camera_offset, BS));


### PR DESCRIPTION
A clean up of camera offset code, originally by SmallJoker, that
unexpectedly fixes a bug.

Previously, an attached object would not display its selectionbox
when further than 200 nodes from (0,0,0).
/////////////////////

![screenshot_20181230_020249](https://user-images.githubusercontent.com/3686677/50543733-aa077380-0bd7-11e9-9a89-b505460f66be.png)

![screenshot_20181230_020234](https://user-images.githubusercontent.com/3686677/50543734-aecc2780-0bd7-11e9-8505-5b6dc85d6f38.png)

![screenshot_20181230_020240](https://user-images.githubusercontent.com/3686677/50543735-b25fae80-0bd7-11e9-87cf-2adc18b18f16.png)

^ Using test code from #8015 

Is #8015 without the changes to third person camera code.
Marked as blocker as is a bugfix that should be considered for 5.0.0.
@GreenXenith 