### PR TITLE
Disable auto-setting server as favorite on connect; display "Add Favorite" button

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -61,7 +61,11 @@ local function get_formspec(tabview, name, tabdata)
 		if gamedata.fav then
 			retval = retval .. "button[7.73,4.9;2.3,1;btn_delete_favorite;" ..
 				fgettext("Del. Favorite") .. "]"
+		else
+			retval = retval .. "button[7.73,4.9;2.3,1;btn_add_favorite;" ..
+				fgettext("Add Favorite") .. "]"
 		end
+
 		if fav_selected.description then
 			retval = retval .. "textarea[8.1,2.3;4.23,2.9;;;" ..
 				core.formspec_escape((gamedata.serverdescription or ""), true) .. "]"
@@ -228,6 +232,17 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 		tabdata.fav_selected = fav_idx
 		return true
+	end
+
+	if fields.btn_add_favorite then
+		core.add_favorite({
+			name        = gamedata.servername,
+			address     = gamedata.address,
+			port        = gamedata.port,
+			description = gamedata.description
+		})
+		asyncOnlineFavourites()
+		tabdata.fav_selected = core.get_table_index("favourites")
 	end
 
 	if fields.btn_delete_favorite then

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -17,12 +17,12 @@ Gamedata
 --------
 The "gamedata" table is read when calling core.start(). It should contain:
 {
-	playername     = <name>,
-	password       = <password>,
-	address        = <IP/adress>,
-	port           = <port>,
-	selected_world = <index>, -- 0 for client mode
-	singleplayer   = <true/false>,
+    playername     = <name>,
+    password       = <password>,
+    address        = <IP/adress>,
+    port           = <port>,
+    selected_world = <index>, -- 0 for client mode
+    singleplayer   = <true/false>,
 }
 
 Functions
@@ -102,12 +102,12 @@ core.show_path_select_dialog(formname, caption, is_file_select)
 ^ returns nil or selected file/folder
 core.get_screen_info()
 ^ returns {
-	density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
-	display_width   = <width of display>,
-	display_height  = <height of display>,
-	window_width    = <current window width>,
-	window_height   = <current window height>
-	}
+    density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
+    display_width   = <width of display>,
+    display_height  = <height of display>,
+    window_width    = <current window width>,
+    window_height   = <current window height>
+    }
 
 ### Content and Packages
 
@@ -115,61 +115,73 @@ Content - an installed mod, modpack, game, or texture pack (txt)
 Package - content which is downloadable from the content db, may or may not be installed.
 
 * core.get_modpath() (possible in async calls)
-	* returns path to global modpath
+    * returns path to global modpath
 * core.get_clientmodpath() (possible in async calls)
-	* returns path to global client-side modpath
+    * returns path to global client-side modpath
 * core.get_gamepath() (possible in async calls)
-	* returns path to global gamepath
+    * returns path to global gamepath
 * core.get_texturepath() (possible in async calls)
-	* returns path to default textures
+    * returns path to default textures
 * core.get_game(index)
-	* returns:
+    * returns:
 
-		{
-			id               = <id>,
-			path             = <full path to game>,
-			gamemods_path    = <path>,
-			name             = <name of game>,
-			menuicon_path    = <full path to menuicon>,
-			author           = "author",
-			DEPRECATED:
-			addon_mods_paths = {[1] = <path>,},
-		}
+        {
+            id               = <id>,
+            path             = <full path to game>,
+            gamemods_path    = <path>,
+            name             = <name of game>,
+            menuicon_path    = <full path to menuicon>,
+            author           = "author",
+            DEPRECATED:
+            addon_mods_paths = {[1] = <path>,},
+        }
 
 * core.get_games() -> table of all games in upper format (possible in async calls)
 * core.get_content_info(path)
-	* returns
+    * returns
 
-		{
-			name             = "name of content",
-			type             = "mod" or "modpack" or "game" or "txp",
-			description      = "description",
-			author           = "author",
-			path             = "path/to/content",
-			depends          = {"mod", "names"}, -- mods only
-			optional_depends = {"mod", "names"}, -- mods only
-		}
+        {
+            name             = "name of content",
+            type             = "mod" or "modpack" or "game" or "txp",
+            description      = "description",
+            author           = "author",
+            path             = "path/to/content",
+            depends          = {"mod", "names"}, -- mods only
+            optional_depends = {"mod", "names"}, -- mods only
+        }
 
 
 Favorites:
-core.get_favorites(location) -> list of favorites (possible in async calls)
-^ location: "local" or "online"
-^ returns {
-	[1] = {
-	clients       = <number of clients/nil>,
-	clients_max   = <maximum number of clients/nil>,
-	version       = <server version/nil>,
-	password      = <true/nil>,
-	creative      = <true/nil>,
-	damage        = <true/nil>,
-	pvp           = <true/nil>,
-	description   = <server description/nil>,
-	name          = <server name/nil>,
-	address       = <address of server/nil>,
-	port          = <port>
-	},
+- core.get_favorites(location) -> list of favorites (possible in async calls)
+  - `location`: "local" or "online"
+  - returns {
+    [1] = {
+    clients       = <number of clients/nil>,
+    clients_max   = <maximum number of clients/nil>,
+    version       = <server version/nil>,
+    password      = <true/nil>,
+    creative      = <true/nil>,
+    damage        = <true/nil>,
+    pvp           = <true/nil>,
+    description   = <server description/nil>,
+    name          = <server name/nil>,
+    address       = <address of server/nil>,
+    port          = <port>
+    },
 }
-core.delete_favorite(id, location) -> success
+
+- core.add_favorite(server)
+  - Adds a server to the local favorites list
+  - `server`: {
+        `name` (server name)
+        `address`
+        `port`
+        `description`
+    }
+
+- core.delete_favorite(idx)
+  - Removes a server from the local favorites list. Returns `true` on success.
+  - `idx`: Index of server to be removed
 
 Logging:
 core.debug(line) (possible in async calls)
@@ -191,11 +203,11 @@ For a complete list of methods of the Settings object see
 Worlds:
 core.get_worlds() -> list of worlds (possible in async calls)
 ^ returns {
-	[1] = {
-	path   = <full path to world>,
-	name   = <name of world>,
-	gameid = <gameid of world>,
-	},
+    [1] = {
+    path   = <full path to world>,
+    name   = <name of world>,
+    gameid = <gameid of world>,
+    },
 }
 core.create_world(worldname, gameid)
 core.delete_world(index)
@@ -242,7 +254,7 @@ core.handle_async(async_job,parameters,finished)
 Limitations of Async operations
  -No access to global lua variables, don't even try
  -Limited set of available functions
-	e.g. No access to functions modifying menu like core.start,core.close,
+	e.g. No access to functions modifying menu like core.start, core.close,
 	core.show_path_select_dialog
 
 Background music

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -105,7 +105,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	}
 
 	RenderingEngine::get_instance()->setupTopLevelWindow(PROJECT_NAME_C);
-	
+
 	/*
 		This changes the minimum allowed number of vertices in a VBO.
 		Default is 500.
@@ -475,14 +475,6 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		current_port = myrand_range(49152, 65535);
 	} else {
 		g_settings->set("name", playername);
-		if (!address.empty()) {
-			ServerListSpec server;
-			server["name"] = menudata.servername;
-			server["address"] = menudata.address;
-			server["port"] = menudata.port;
-			server["description"] = menudata.serverdescription;
-			ServerList::insert(server);
-		}
 	}
 
 	infostream << "Selected world: " << worldspec.name

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -413,32 +413,41 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::l_delete_favorite(lua_State *L)
+int ModApiMainMenu::l_add_favorite(lua_State *L)
 {
-	std::vector<ServerListSpec> servers;
-
-	std::string listtype = "local";
-
-	if (!lua_isnone(L,2)) {
-		listtype = luaL_checkstring(L,2);
-	}
-
-	if ((listtype != "local") &&
-		(listtype != "online"))
+	ServerListSpec server;
+	if (!lua_istable(L,1))
 		return 0;
 
+	lua_getfield(L, 1, "name");
+	server["name"] = lua_tostring(L, -1);
+	lua_pop(L, 1);
 
-	if(listtype == "online") {
-		servers = ServerList::getOnline();
-	} else {
-		servers = ServerList::getLocal();
-	}
+	lua_getfield(L, 1, "address");
+	server["address"] = lua_tostring(L, -1);
+	lua_pop(L, 1);
 
-	int fav_idx	= luaL_checkinteger(L,1) -1;
+	lua_getfield(L, 1, "port");
+	server["port"] = lua_tostring(L, -1);
+	lua_pop(L, 1);
 
+	lua_getfield(L, 1, "description");
+	server["description"] = lua_tostring(L, -1);
+	lua_pop(L, 1);
+
+	ServerList::insert(server);
+
+	return 0;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_delete_favorite(lua_State *L)
+{
+	std::vector<ServerListSpec> servers = ServerList::getLocal();
+
+	int fav_idx = luaL_checkinteger(L, 1) - 1;
 	if ((fav_idx >= 0) &&
 			(fav_idx < (int) servers.size())) {
-
 		ServerList::deleteEntry(servers[fav_idx]);
 	}
 
@@ -1066,6 +1075,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_content_info);
 	API_FCT(start);
 	API_FCT(close);
+	API_FCT(add_favorite);
 	API_FCT(get_favorites);
 	API_FCT(show_keys_menu);
 	API_FCT(create_world);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -76,6 +76,8 @@ private:
 
 	static int l_get_favorites(lua_State *L);
 
+	static int l_add_favorite(lua_State *L);
+
 	static int l_delete_favorite(lua_State *L);
 
 	static int l_gettext(lua_State *L);

--- a/src/serverlist.cpp
+++ b/src/serverlist.cpp
@@ -268,4 +268,3 @@ void sendAnnounce(AnnounceAction action,
 #endif
 
 } // namespace ServerList
-


### PR DESCRIPTION
Currently, a server is automatically added to one's favourites when they connect to it (or even attempt to connect to it). I think this isn't a good idea, as players would be trying out new servers, and might not ever visit them again, and yet, those servers will unnecessarily be added to their favourites.

This PR disables "auto-favouriting" all servers the player joins, and provides an "Add Favorite" button. Depending on whether a server is marked as favourite, there will be a "Del. Favorite" button or an "Add Favorite" button. A server will be marked as favorite only when a player explicitly adds it by pressing the "Add Favorite" button.