### PR TITLE
Remove remote media compatibility mode.

### DIFF
--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -105,7 +105,6 @@ void ClientMediaDownloader::addRemoteServer(const std::string &baseurl)
 		RemoteServerStatus *remote = new RemoteServerStatus();
 		remote->baseurl = baseurl;
 		remote->active_count = 0;
-		remote->request_by_filename = false;
 		m_remotes.push_back(remote);
 	}
 
@@ -299,28 +298,6 @@ void ClientMediaDownloader::remoteHashSetReceived(
 				<< e.what() << std::endl;
 		}
 	}
-
-	// For compatibility: If index.mth is not found, assume that the
-	// server contains files named like the original files (not their sha1)
-
-	// Do NOT check for any particular response code (e.g. 404) here,
-	// because different servers respond differently
-
-	if (!fetch_result.succeeded && !fetch_result.timeout) {
-		infostream << "Client: Enabling compatibility mode for remote "
-			<< "server \"" << remote->baseurl << "\"" << std::endl;
-		remote->request_by_filename = true;
-
-		// Assume every file is available on this server
-
-		for(std::map<std::string, FileStatus*>::iterator
-				it = m_files.upper_bound(m_name_bound);
-				it != m_files.end(); ++it) {
-			FileStatus *f = it->second;
-			if (!f->received)
-				f->available_remotes.push_back(remote_id);
-		}
-	}
 }
 
 void ClientMediaDownloader::remoteMediaReceived(
@@ -425,8 +402,7 @@ void ClientMediaDownloader::startRemoteMediaTransfers()
 					m_remotes[remote_id];
 
 				std::string url = remote->baseurl +
-					(remote->request_by_filename ? name :
-					hex_encode(filestatus->sha1));
+					hex_encode(filestatus->sha1);
 				verbosestream << "Client: "
 					<< "Requesting remote media file "
 					<< "\"" << name << "\" "

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -92,7 +92,6 @@ private:
 	struct RemoteServerStatus {
 		std::string baseurl;
 		s32 active_count;
-		bool request_by_filename;
 	};
 
 	void initialStep(Client *client);


### PR DESCRIPTION
The fallback code shouldn't be needed and is a remnant of the GET
method that old media servers use. Clients using it are likely
to just waste bandwidth and having to download the media again
through the normal transfer from server method. The most reliable
method is to get all missing textures therefore from the server
directly and not spam the remote media server with 404s.