### PR TITLE
Fix player's attachments not updating visibility correctly

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1303,9 +1303,9 @@ void GenericCAO::updateAttachments()
 			LocalPlayer *player = m_env->getLocalPlayer();
 			player->isAttached = true;
 		}
-		GenericCAO* parentCAO = m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]);
-		if (parentCAO && parentCAO->m_is_local_player) {
-			//Update attachment visibility for the player's children
+		GenericCAO *parent_obj = m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]);
+		if (parent_obj && parent_obj->m_is_local_player) {
+			// Update attachment visibility for the player's children
 			setVisible(m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
 		}
 	}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1303,6 +1303,11 @@ void GenericCAO::updateAttachments()
 			LocalPlayer *player = m_env->getLocalPlayer();
 			player->isAttached = true;
 		}
+		
+		if (m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]) && m_env->getGenericCAO(m_env->attachement_parent_ids[getId()])->m_is_local_player) {
+			//Update attachment visibility for the player's children
+			setVisible(m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
+		}
 	}
 }
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1303,11 +1303,6 @@ void GenericCAO::updateAttachments()
 			LocalPlayer *player = m_env->getLocalPlayer();
 			player->isAttached = true;
 		}
-		GenericCAO *parent_obj = m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]);
-		if (parent_obj && parent_obj->m_is_local_player) {
-			// Update attachment visibility for the player's children
-			setVisible(m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
-		}
 	}
 }
 
@@ -1488,9 +1483,9 @@ void GenericCAO::processMessage(const std::string &data)
 		if (!m_is_local_player) {
 			m_attached_to_local = getParent() != NULL && getParent()->isLocalPlayer();
 			// Objects attached to the local player should be hidden by default
-			m_is_visible = !m_attached_to_local;
+			m_is_visible = (!m_attached_to_local) 
+				|| (m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
 		}
-
 		updateAttachments();
 	} else if (cmd == GENERIC_CMD_PUNCHED) {
 		/*s16 damage =*/ readS16(is);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1304,7 +1304,8 @@ void GenericCAO::updateAttachments()
 			player->isAttached = true;
 		}
 		
-		if (m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]) && m_env->getGenericCAO(m_env->attachement_parent_ids[getId()])->m_is_local_player) {
+		if (m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]) 
+			&& m_env->getGenericCAO(m_env->attachement_parent_ids[getId()])->m_is_local_player) {
 			//Update attachment visibility for the player's children
 			setVisible(m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
 		}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1303,9 +1303,8 @@ void GenericCAO::updateAttachments()
 			LocalPlayer *player = m_env->getLocalPlayer();
 			player->isAttached = true;
 		}
-		
-		if (m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]) 
-			&& m_env->getGenericCAO(m_env->attachement_parent_ids[getId()])->m_is_local_player) {
+		GenericCAO* parentCAO = m_env->getGenericCAO(m_env->attachement_parent_ids[getId()]);
+		if (parentCAO && parentCAO->m_is_local_player) {
 			//Update attachment visibility for the player's children
 			setVisible(m_client->getCamera()->getCameraMode() > CAMERA_MODE_FIRST);
 		}


### PR DESCRIPTION
I found and solved this issue after noticing that several mods I have made would not display items attached to the player properly.

More specifically, when an item is attached to a player while they are in third person, it will not be visible to them until they refresh their view. This is a solution to that problem. 

On another note, I would also suggest implementing some option (for example, "visible_in_first_person") for players' children to be shown to them even in first person, as that would make things easier for my hangglider mod.