### PR TITLE
Increase default active_object_send_range_blocks

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1069,7 +1069,7 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
-active_object_send_range_blocks (Active object send range) int 3
+active_object_send_range_blocks (Active object send range) int 9
 
 #    The radius of the volume of blocks around every player that is subject to the
 #    active block stuff, stated in mapblocks (16 nodes).

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -339,7 +339,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ask_reconnect_on_crash", "false");
 
 	settings->setDefault("profiler_print_interval", "0");
-	settings->setDefault("active_object_send_range_blocks", "3");
+	settings->setDefault("active_object_send_range_blocks", "9");
 	settings->setDefault("active_block_range", "3");
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?


### PR DESCRIPTION
See #8048.

Increase default active_object_send_range_blocks to match max_block_send_distance.