### PR TITLE
world.mt: Only accept true/false/nil values

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -138,7 +138,7 @@ local function handle_buttons(this, fields)
 					not mod.is_game_content then
 				if modname_valid(mod.name) then
 					worldfile:set("load_mod_" .. mod.name,
-							tostring(mod.enabled))
+						mod.enabled and "true" or "false")
 				elseif mod.enabled then
 					gamedata.errormessage = fgettext_ne("Failed to enable mo" ..
 							"d \"$1\" as it contains disallowed characters. " ..

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -366,6 +366,8 @@ function pkgmgr.get_worldconfig(worldpath)
 		if key == "gameid" then
 			worldconfig.id = value
 		elseif key:sub(0, 9) == "load_mod_" then
+			-- Compatibility: Check against "nil" which was erroneously used
+			-- as value for fresh configured worlds
 			worldconfig.global_mods[key] = value ~= "false" and value ~= "nil"
 				and value
 		else

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -366,7 +366,8 @@ function pkgmgr.get_worldconfig(worldpath)
 		if key == "gameid" then
 			worldconfig.id = value
 		elseif key:sub(0, 9) == "load_mod_" then
-			worldconfig.global_mods[key] = core.is_yes(value)
+			worldconfig.global_mods[key] = value ~= "false" and value ~= "nil"
+				and value
 		else
 			worldconfig[key] = value
 		end
@@ -566,7 +567,7 @@ function pkgmgr.preparemodlist(data)
 				end
 			end
 			if element ~= nil then
-				element.enabled = core.is_yes(value)
+				element.enabled = value ~= "false" and value ~= "nil" and value
 			else
 				core.log("info", "Mod: " .. key .. " " .. dump(value) .. " but not found")
 			end

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -270,7 +270,8 @@ void ModConfiguration::addModsFromConfig(
 	conf.readConfigFile(settings_path.c_str());
 	std::vector<std::string> names = conf.getNames();
 	for (const std::string &name : names) {
-		if (name.compare(0, 9, "load_mod_") == 0 && conf.getBool(name))
+		if (name.compare(0, 9, "load_mod_") == 0 && conf.get(name) != "false"
+				&& conf.get(name) != "nil")
 			load_mod_names.insert(name.substr(9));
 	}
 


### PR DESCRIPTION
This patch will make distinguishable mods in modpacks possible in the future
`nil` checks are required to provide backwards-compatibility for fresh configured worlds

Patch source: #7914
