### PR TITLE
Add fatal error on missing dependency

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -334,7 +334,22 @@ void Server::init()
 	std::vector<ModSpec> unsatisfied_mods = m_modmgr->getUnsatisfiedMods();
 	// complain about mods with unsatisfied dependencies
 	if (!m_modmgr->isConsistent()) {
-		m_modmgr->printUnsatisfiedModsError();
+		std::ostringstream error;
+		error << "Some mods have unsatisfied dependencies:" << std::endl;
+
+		for (const ModSpec &mod : m_modmgr->getUnsatisfiedMods()) {
+			error << " - " << mod.name
+					<< " is missing: ";
+			for (const std::string &unsatisfied_depend : mod.unsatisfied_depends)
+				error << " " << unsatisfied_depend;
+			error << std::endl;
+		}
+
+		error << "Install and enable the required mods, or disable the mods causing errors." << std::endl;
+		error << "Note: this may be caused by a cyclic dependency, "
+			<< " in which case try updating the mods.";
+
+		throw ServerError(error.str());
 	}
 
 	//lock environment


### PR DESCRIPTION
Minetest silently not loading the mod caused a security vulnerability on my server, because a mod wasn't loaded.

![image](https://user-images.githubusercontent.com/2122943/50736288-8df56a80-11b3-11e9-941d-47dad23d00f0.png)
