### PR TITLE
Content store: Disable more details dialog for now

### DIFF
--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -466,7 +466,7 @@ function store.get_formspec()
 		formspec[#formspec + 1] = "]"
 
 		-- description
-		if package.path and  package.installed_release < package.release then
+		if package.path and package.installed_release < package.release then
 			formspec[#formspec + 1] = "textarea[1.25,0.3;7.5,1;;;"
 		else
 			formspec[#formspec + 1] = "textarea[1.25,0.3;9,1;;;"

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -481,26 +481,23 @@ function store.get_formspec()
 			formspec[#formspec + 1] = ";"
 			formspec[#formspec + 1] = fgettext("Install")
 			formspec[#formspec + 1] = "]"
-		elseif package.installed_release < package.release then
-			-- The install_ action also handles updating
-			formspec[#formspec + 1] = "button[8.4,0;1.5,1;install_"
-			formspec[#formspec + 1] = tostring(i)
-			formspec[#formspec + 1] = ";"
-			formspec[#formspec + 1] = fgettext("Update")
-			formspec[#formspec + 1] = "]"
+		else
+			if package.installed_release < package.release then
+				-- The install_ action also handles updating
+				formspec[#formspec + 1] = "button[8.4,0;1.5,1;install_"
+				formspec[#formspec + 1] = tostring(i)
+				formspec[#formspec + 1] = ";"
+				formspec[#formspec + 1] = fgettext("Update")
+				formspec[#formspec + 1] = "]"
+			end
 
 			formspec[#formspec + 1] = "button[9.9,0;1.5,1;uninstall_"
 			formspec[#formspec + 1] = tostring(i)
 			formspec[#formspec + 1] = ";"
 			formspec[#formspec + 1] = fgettext("Uninstall")
 			formspec[#formspec + 1] = "]"
-		else
-			formspec[#formspec + 1] = "button[9.9,0;1.5,1;uninstall_"
-			formspec[#formspec + 1] = tostring(i)
-			formspec[#formspec + 1] = ";"
-			formspec[#formspec + 1] = fgettext("Uninstall")
-			formspec[#formspec + 1] = "]"
 		end
+
 		--formspec[#formspec + 1] = "button[9.9,0;1.5,1;view_"
 		--formspec[#formspec + 1] = tostring(i)
 		--formspec[#formspec + 1] = ";"

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -466,13 +466,17 @@ function store.get_formspec()
 		formspec[#formspec + 1] = "]"
 
 		-- description
-		formspec[#formspec + 1] = "textarea[1.25,0.3;7.5,1;;;"
+		if package.path and  package.installed_release < package.release then
+			formspec[#formspec + 1] = "textarea[1.25,0.3;7.5,1;;;"
+		else
+			formspec[#formspec + 1] = "textarea[1.25,0.3;9,1;;;"
+		end
 		formspec[#formspec + 1] = core.formspec_escape(package.short_description)
 		formspec[#formspec + 1] = "]"
 
 		-- buttons
 		if not package.path then
-			formspec[#formspec + 1] = "button[8.4,0;1.5,1;install_"
+			formspec[#formspec + 1] = "button[9.9,0;1.5,1;install_"
 			formspec[#formspec + 1] = tostring(i)
 			formspec[#formspec + 1] = ";"
 			formspec[#formspec + 1] = fgettext("Install")
@@ -484,18 +488,24 @@ function store.get_formspec()
 			formspec[#formspec + 1] = ";"
 			formspec[#formspec + 1] = fgettext("Update")
 			formspec[#formspec + 1] = "]"
+
+			formspec[#formspec + 1] = "button[9.9,0;1.5,1;uninstall_"
+			formspec[#formspec + 1] = tostring(i)
+			formspec[#formspec + 1] = ";"
+			formspec[#formspec + 1] = fgettext("Uninstall")
+			formspec[#formspec + 1] = "]"
 		else
-			formspec[#formspec + 1] = "button[8.4,0;1.5,1;uninstall_"
+			formspec[#formspec + 1] = "button[9.9,0;1.5,1;uninstall_"
 			formspec[#formspec + 1] = tostring(i)
 			formspec[#formspec + 1] = ";"
 			formspec[#formspec + 1] = fgettext("Uninstall")
 			formspec[#formspec + 1] = "]"
 		end
-		formspec[#formspec + 1] = "button[9.9,0;1.5,1;view_"
-		formspec[#formspec + 1] = tostring(i)
-		formspec[#formspec + 1] = ";"
-		formspec[#formspec + 1] = fgettext("View")
-		formspec[#formspec + 1] = "]"
+		--formspec[#formspec + 1] = "button[9.9,0;1.5,1;view_"
+		--formspec[#formspec + 1] = tostring(i)
+		--formspec[#formspec + 1] = ";"
+		--formspec[#formspec + 1] = fgettext("View")
+		--formspec[#formspec + 1] = "]"
 
 		formspec[#formspec + 1] = "container_end[]"
 	end


### PR DESCRIPTION
The more details dialog isn't very useful, and currently shows a pixellated image. This PR disables the button for now.

In the next release, opening the dialog will send a HTTP request to get more information such as licenses and deps, then show that in the dialog

![image](https://user-images.githubusercontent.com/2122943/50736632-acf5fb80-11b7-11e9-8f77-992602447be1.png)
