### PR TITLE
Settingtypes.txt: Rewrite misleading documentation of 'num_emerge_threads'

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1922,9 +1922,16 @@ emergequeue_limit_diskonly (Limit of emerge queues on disk) int 64
 emergequeue_limit_generate (Limit of emerge queues to generate) int 64
 
 #    Number of emerge threads to use.
-#    Make this field blank or 0, or increase this number to use multiple threads.
-#    On multiprocessor systems, this will improve mapgen speed greatly at the cost
-#    of slightly buggy caves.
+#    Empty or 0 value:
+#    -    Automatic selection. The number of emerge threads will be
+#    -    'number of processors - 2', with a lower limit of 1.
+#    Any other value:
+#    -    Specifies the number of emerge threads, with a lower limit of 1.
+#    Warning: Increasing the number of emerge threads increases engine mapgen
+#    speed, but this may harm game performance by interfering with other
+#    processes, especially in singleplayer and/or when running Lua code in
+#    'on_generated'.
+#    For many users the optimum setting may be '1'.
 num_emerge_threads (Number of emerge threads) int 0
 
 [Content Store]


### PR DESCRIPTION
Closes #4879 
Quite important as the previous wording is too promising and many users are increasing this without realising it may be harming game performance.

See rogier's quote in https://github.com/minetest/minetest/issues/4879#issue-194766354

Also see hecks' posts in IRC:
http://irc.minetest.net/minetest/2019-01-06#i_5474155 to 01:01
http://irc.minetest.net/minetest/2019-01-06#i_5474325 to 02:38
http://irc.minetest.net/minetest-dev/2019-01-06#i_5474926
http://irc.minetest.net/minetest-dev/2019-01-07#i_5475067