### PR TITLE
Valleys Mapgen: Optionally use 3D noise for rivers

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1834,7 +1834,9 @@ mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500),
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
-mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry,canyons altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry,canyons,nocanyons
+#    'canyons': Use 3D noise for valleys, resulting in more cliffs and steep
+#    structures around rivers
+mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry,canyons,nocanyons
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1834,7 +1834,7 @@ mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500),
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
-mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry
+mgvalleys_spflags (Mapgen Valleys specific flags) flags altitude_chill,humid_rivers,vary_river_depth,altitude_dry,canyons altitude_chill,noaltitude_chill,humid_rivers,nohumid_rivers,vary_river_depth,novary_river_depth,altitude_dry,noaltitude_dry,canyons,nocanyons
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
 #    enabled. Also the vertical distance over which humidity drops by 10 if
@@ -1886,7 +1886,9 @@ mgvalleys_np_filler_depth (Filler depth) noise_params_2d 0, 1.2, (256, 256, 256)
 mgvalleys_np_cavern (Cavern noise) noise_params_3d 0, 1, (768, 256, 768), 59033, 6, 0.63, 2.0
 
 #    Defines large-scale river channel structure.
-mgvalleys_np_rivers (River noise) noise_params_2d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
+#    Used as 3D noise if 'canyons' spflag is enabled,
+#    otherwise used as 2D noise with Y spread ignored.
+mgvalleys_np_rivers (River noise) noise_params_3d 0, 1, (256, 256, 256), -6050, 5, 0.6, 2.0, eased
 
 #    Base terrain height.
 mgvalleys_np_terrain_height (Terrain height) noise_params_2d -10, 50, (1024, 1024, 1024), 5202, 6, 0.4, 2.0, eased

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2783,7 +2783,7 @@
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
-#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers, vary_river_depth, novary_river_depth, altitude_dry, noaltitude_dry
+#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers, vary_river_depth, novary_river_depth, altitude_dry, noaltitude_dry, canyons, nocanyons
 # mgvalleys_spflags = altitude_chill,humid_rivers,vary_river_depth,altitude_dry
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
@@ -2887,7 +2887,9 @@
 # }
 
 #    Defines large-scale river channel structure.
-#    type: noise_params_2d
+#    Used as 3D noise if 'canyons' spflag is enabled,
+#    otherwise used as 2D noise with Y spread ignored.
+#    type: noise_params_3d
 # mgvalleys_np_rivers = {
 #    offset      = 0,
 #    scale       = 1,

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2783,7 +2783,7 @@
 #    'vary_river_depth': If enabled, low humidity and high heat causes rivers
 #    to become shallower and occasionally dry.
 #    'altitude_dry': Reduces humidity with altitude.
-#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers, vary_river_depth, novary_river_depth, altitude_dry, noaltitude_dry, canyons, nocanyons
+#    type: flags possible values: altitude_chill, noaltitude_chill, humid_rivers, nohumid_rivers, vary_river_depth, novary_river_depth, altitude_dry, noaltitude_dry
 # mgvalleys_spflags = altitude_chill,humid_rivers,vary_river_depth,altitude_dry
 
 #    The vertical distance over which heat drops by 20 if 'altitude_chill' is
@@ -2887,9 +2887,7 @@
 # }
 
 #    Defines large-scale river channel structure.
-#    Used as 3D noise if 'canyons' spflag is enabled,
-#    otherwise used as 2D noise with Y spread ignored.
-#    type: noise_params_3d
+#    type: noise_params_2d
 # mgvalleys_np_rivers = {
 #    offset      = 0,
 #    scale       = 1,

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -83,10 +83,10 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	noise_valley_profile     = new Noise(&params->np_valley_profile,     seed, csize.X, csize.Z);
 
 	//// River noise, 2D or 3D
-	if (spflags & MGVALLEYS_CANYONS)
+	if (spflags & MGVALLEYS_CANYONS) {
 		noise_rivers     = new Noise(&params->np_rivers, seed,
 				csize.X, csize.Y + 2, csize.Z);
-	else {
+	} else {
 		v3f *spread = &params->np_rivers.spread;
 		spread->Y = spread->Z;
 		noise_rivers     = new Noise(&params->np_rivers,             seed, csize.X, csize.Z);

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -109,5 +109,6 @@ private:
 	Noise *noise_valley_profile;
 
 	virtual int generateTerrain();
+	float getRiverDepth(float n_rivers);
 	float getValleyHeight(int index, float valley_d, float valley_profile);
 };

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGVALLEYS_HUMID_RIVERS     0x02
 #define MGVALLEYS_VARY_RIVER_DEPTH 0x04
 #define MGVALLEYS_ALT_DRY          0x08
+#define MGVALLEYS_CANYONS          0x10
 
 class BiomeManager;
 class BiomeGenOriginal;
@@ -108,4 +109,5 @@ private:
 	Noise *noise_valley_profile;
 
 	virtual int generateTerrain();
+	float getValleyHeight(int index, float valley_d, float valley_profile);
 };


### PR DESCRIPTION
This follows the changes I've made on my Lua version of Valleys Mapgen some time ago (see [here](https://forum.minetest.net/viewtopic.php?p=330950#p330950)).

The idea is to use a 3D noise instead of 2D for `noise_rivers`. This has an effect on the shape of valleys, allowing steeper and more irregular slopes, sometimes even overhanging the river. The deepest the valleys are, the most noticeable it is. This is why this feature has been named Canyons.

The algorithm remains the same, except that the river noise value now depends on elevation, so I moved all calculations involving it from the 2D loop to the 3D one (including `terrainLevelFromNoise(&tn)` that I had to remove from the function `calculateNoise()` and put it in `generateTerrain()`).

It is optional, enabled by the `canyon` spflag, disabled by default for backward compatibility.
Since it needs to handle both mapgen methods, I've done my best to make the code as flexible as possible regarding river noise dimension.

Notes:
- The 2D version uses the X-Z spread values for the river noise, instead of X-Y, so that adjusting the vertical spread for 3D noise won't stretch the rivers horizontally when switching back to 2D.
- For the 3D version, spawnplayer function doesn't avoid rivers.
- I'm wondering whether doing `if (spflags & MGVALLEYS_CANYONS)` results in a significant loss of time in the 3D loop, in which case I will convert it into a boolean outside the loop. What do you think?

Some screenshots (using my custom mapgen parameters)
![Screenshot](https://user-images.githubusercontent.com/6905002/50848754-5a623e00-1375-11e9-820d-2bfa453593d5.png)
![Screenshots](https://user-images.githubusercontent.com/6905002/50848821-84b3fb80-1375-11e9-8341-e864ac04a452.png)
![screenshot_20190108_224531](https://user-images.githubusercontent.com/6905002/50863962-cc03b180-13a0-11e9-86ff-229b4e9481b2.png)
![screenshot_20190106_210041](https://user-images.githubusercontent.com/6905002/50863994-ea69ad00-13a0-11e9-9c0b-d459088a3ffb.png)