### PR TITLE
[Do not squash me] Fix group setting bugs

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -522,8 +522,10 @@ local function get_current_np_group_as_string(setting)
 			value.seed .. ", " ..
 			value.octaves .. ", " ..
 			value.persistence .. ", " ..
-			value.lacunarity .. ", " ..
-			value.flags
+			value.lacunarity
+		if value.flags ~= "" then
+			t = t .. ", " .. value.flags
+		end
 	end
 	return t
 end

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -249,6 +249,9 @@ bool Settings::updateConfigObject(std::istream &is, std::ostream &os,
 			} else if (it == m_settings.end()) {
 				// Remove by skipping
 				was_modified = true;
+				Settings removed_group; // Move 'is' to group end
+				std::stringstream ss;
+				removed_group.updateConfigObject(is, ss, "}", tab_depth + 1);
 				break;
 			} else {
 				printEntry(os, name, it->second, tab_depth);


### PR DESCRIPTION
Fixes tailing `}` reported in https://github.com/minetest/minetest/issues/8076#issuecomment-452564733
Fixes low-priority tailing comma #8077 (patch from @srifqi )

EDIT: **How to test**
1) In current master: Edit noise settings, save, reset to default, repeat. A bunch of closing brackets will be left over.
2) Same for this PR: The group setting are removed properly
3) With this PR: remove all mapgen flags on a setting. No tailing comma is written to the config.