### PR TITLE
Optimize subgames search a little bit

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -195,6 +195,7 @@ std::vector<SubgameSpec> getAvailableGames()
 {
 	std::vector<SubgameSpec> specs;
 	std::set<std::string> gameids = getAvailableGameIds();
+	specs.reserve(gameids.size());
 	for (const auto &gameid : gameids)
 		specs.push_back(findSubgame(gameid));
 	return specs;


### PR DESCRIPTION
Reserve space for 16 games in findWorldSubgame. Most users
won't have installed more than that so make the game scan
slightly faster by preallocating 16 slots in the list. The
size was chosen based on the length of the game selection
hotbar in the main menu, rounded up to the nearest power
of 2. The performance gain is pretty much negligible but
this change also gets rid of a performance warning by
CLANG TIDY.
