### PR TITLE
Speed up the craft definition handling

### DIFF
--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -112,6 +112,7 @@ static std::vector<std::string> craftGetItemNames(
 		const std::vector<std::string> &itemstrings, IGameDef *gamedef)
 {
 	std::vector<std::string> result;
+	result.reserve(itemstrings.size());
 	for (const auto &itemstring : itemstrings) {
 		result.push_back(craftGetItemName(itemstring, gamedef));
 	}
@@ -123,6 +124,7 @@ static std::vector<std::string> craftGetItemNames(
 		const std::vector<ItemStack> &items, IGameDef *gamedef)
 {
 	std::vector<std::string> result;
+	result.reserve(items.size());
 	for (const auto &item : items) {
 		result.push_back(item.name);
 	}
@@ -134,6 +136,7 @@ static std::vector<ItemStack> craftGetItems(
 		const std::vector<std::string> &items, IGameDef *gamedef)
 {
 	std::vector<ItemStack> result;
+	result.reserve(items.size());
 	for (const auto &item : items) {
 		result.emplace_back(std::string(item), (u16)1,
 			(u16)0, gamedef->getItemDefManager());


### PR DESCRIPTION
The craft definition handling code that collects the names of
the craftable nodes suffers from vector reallocation
performance hits, slowing down instances with lots of
crafting recipes (VanessaE's DreamBuilder and most public
server some to my mind when thinking about this). As in each
instance the size of the resulting vector is already known,
add a reserve() call before the offending loops to allocate
the needed chunk of memory within the result vector in one
go, getting rid of the overhead.