### PR TITLE
Optimize path finalization in pathfinder

### DIFF
--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -707,6 +707,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 
 		//finalize path
 		std::vector<v3s16> full_path;
+		full_path.reserve(path.size());
 		for (const v3s16 &i : path) {
 			full_path.push_back(getIndexElement(i).pos);
 		}


### PR DESCRIPTION
The pathfinder needs quite a bunch of items to add to the
resulting list. It turns out the amount of the space needed
for the finalized path is known in advance so preallocate it
to avoid a burst of reallocation calls each time something
needs to look for a path.