### PR TITLE
Add setting to disable confirmation on new player registration

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -912,6 +912,10 @@ serverlist_file (Serverlist file) string favoriteservers.txt
 #    0 to disable queueing and -1 to make the queue size unlimited.
 max_out_chat_queue_size (Maximum size of the out chat queue) int 20
 
+#    Enable register confirmation when connecting to server.
+#    If disabled, new account will be registered automatically.
+enable_register_confirmation (Enable register confirmation) bool true
+
 [*Advanced]
 
 #    Timeout for client to remove unused map data from memory.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -349,6 +349,7 @@ public:
 	void confirmRegistration();
 	bool m_is_registration_confirmation_state = false;
 	bool m_simple_singleplayer_mode;
+	bool m_enable_register_confirmation;
 
 	float mediaReceiveProgress();
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1483,6 +1483,7 @@ bool Game::connectToServer(const std::string &playername,
 		return false;
 
 	client->m_simple_singleplayer_mode = simple_singleplayer_mode;
+	client->m_enable_register_confirmation = g_settings->getBool("enable_register_confirmation");
 
 	infostream << "Connecting to server at ";
 	connect_address.print(&infostream);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -60,6 +60,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("enable_client_modding", "false");
 	settings->setDefault("max_out_chat_queue_size", "20");
 	settings->setDefault("pause_on_lost_focus", "false");
+	settings->setDefault("enable_register_confirmation", "true");
 
 	// Keymap
 	settings->setDefault("remote_port", "30000");

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -98,7 +98,8 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 	// Authenticate using that method, or abort if there wasn't any method found
 	if (chosen_auth_mechanism != AUTH_MECHANISM_NONE) {
 		if (chosen_auth_mechanism == AUTH_MECHANISM_FIRST_SRP
-				&& !m_simple_singleplayer_mode) {
+				&& !m_simple_singleplayer_mode
+				&& m_enable_register_confirmation) {
 			promptConfirmRegistration(chosen_auth_mechanism);
 		} else {
 			startAuth(chosen_auth_mechanism);


### PR DESCRIPTION
Disable the confirmation by disabling enable_register_confirmation (Client -> Network).

This is a simple setting for 5.0.0 while we reconsider the confirmation dialog (#7237) for future release.