### PR TITLE
Add translation of LANG_CODE in all languages

### DIFF
--- a/po/be/minetest.po
+++ b/po/be/minetest.po
@@ -1717,7 +1717,7 @@ msgstr "Увод "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "be"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ca/minetest.po
+++ b/po/ca/minetest.po
@@ -1737,7 +1737,7 @@ msgstr "Introdueix "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ca"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/cs/minetest.po
+++ b/po/cs/minetest.po
@@ -1718,7 +1718,7 @@ msgstr "Zadejte "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "cs"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/da/minetest.po
+++ b/po/da/minetest.po
@@ -1723,7 +1723,7 @@ msgstr " "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "da"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/de/minetest.po
+++ b/po/de/minetest.po
@@ -1722,7 +1722,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "de"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/dv/minetest.po
+++ b/po/dv/minetest.po
@@ -1659,7 +1659,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "dv"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/eo/minetest.po
+++ b/po/eo/minetest.po
@@ -1719,7 +1719,7 @@ msgstr "Enigi "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "eo"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/es/minetest.po
+++ b/po/es/minetest.po
@@ -1725,7 +1725,7 @@ msgstr "Ingresar "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "es"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/et/minetest.po
+++ b/po/et/minetest.po
@@ -1724,7 +1724,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "et"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/fr/minetest.po
+++ b/po/fr/minetest.po
@@ -1720,7 +1720,7 @@ msgstr "Entrer "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "fr"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/he/minetest.po
+++ b/po/he/minetest.po
@@ -1645,7 +1645,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "he"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/hu/minetest.po
+++ b/po/hu/minetest.po
@@ -1719,7 +1719,7 @@ msgstr "Belépés "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "hu"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/id/minetest.po
+++ b/po/id/minetest.po
@@ -1721,7 +1721,7 @@ msgstr "Masuk "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "id"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/it/minetest.po
+++ b/po/it/minetest.po
@@ -1717,7 +1717,7 @@ msgstr "Invio "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "it"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ja/minetest.po
+++ b/po/ja/minetest.po
@@ -1710,7 +1710,7 @@ msgstr "エンター "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ja"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/jbo/minetest.po
+++ b/po/jbo/minetest.po
@@ -1679,7 +1679,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "jbo"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ko/minetest.po
+++ b/po/ko/minetest.po
@@ -1724,7 +1724,7 @@ msgstr "들어가기 "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ko"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ky/minetest.po
+++ b/po/ky/minetest.po
@@ -1733,7 +1733,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ky"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/lt/minetest.po
+++ b/po/lt/minetest.po
@@ -1749,7 +1749,7 @@ msgstr "Įvesti"
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "lt"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ms/minetest.po
+++ b/po/ms/minetest.po
@@ -1719,7 +1719,7 @@ msgstr "Masuk "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ms"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/nb/minetest.po
+++ b/po/nb/minetest.po
@@ -1696,7 +1696,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "nb"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/nl/minetest.po
+++ b/po/nl/minetest.po
@@ -1735,7 +1735,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "nl"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/pl/minetest.po
+++ b/po/pl/minetest.po
@@ -1720,7 +1720,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "pl"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/pt/minetest.po
+++ b/po/pt/minetest.po
@@ -1733,7 +1733,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "pt"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/pt_BR/minetest.po
+++ b/po/pt_BR/minetest.po
@@ -1737,7 +1737,7 @@ msgstr "Entrar "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "pt_BR"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ro/minetest.po
+++ b/po/ro/minetest.po
@@ -1735,7 +1735,7 @@ msgstr ""
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ro"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/ru/minetest.po
+++ b/po/ru/minetest.po
@@ -1722,7 +1722,7 @@ msgstr "Введите "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "ru"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/sl/minetest.po
+++ b/po/sl/minetest.po
@@ -1711,7 +1711,7 @@ msgstr "Vpis "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "sl"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/sr_Cyrl/minetest.po
+++ b/po/sr_Cyrl/minetest.po
@@ -1720,7 +1720,7 @@ msgstr "Уреду "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "sr_Cyrl"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/sv/minetest.po
+++ b/po/sv/minetest.po
@@ -1751,7 +1751,7 @@ msgstr "Enter "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "sv"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/sw/minetest.po
+++ b/po/sw/minetest.po
@@ -1733,7 +1733,7 @@ msgstr "Ingiza"
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "sw"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/tr/minetest.po
+++ b/po/tr/minetest.po
@@ -1716,7 +1716,7 @@ msgstr "Gir "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "tr"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/uk/minetest.po
+++ b/po/uk/minetest.po
@@ -1720,7 +1720,7 @@ msgstr "Ввід "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "uk"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/zh_CN/minetest.po
+++ b/po/zh_CN/minetest.po
@@ -1709,7 +1709,7 @@ msgstr "输入 "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "zh_CN"
 
 #: src/settings_translation_file.cpp
 msgid ""

--- a/po/zh_TW/minetest.po
+++ b/po/zh_TW/minetest.po
@@ -1713,7 +1713,7 @@ msgstr "輸入 "
 
 #: src/network/clientpackethandler.cpp
 msgid "LANG_CODE"
-msgstr ""
+msgstr "zh_TW"
 
 #: src/settings_translation_file.cpp
 msgid ""


### PR DESCRIPTION
The translation being absent caused the issue that client-side translations did not work (see https://forum.minetest.net/viewtopic.php?f=47&t=21974 ).

I know translations should be done via weblate, however, since this is a single string to translate in all languages that has some special property that translators might not know about, I believe it is probably better to do it that way.