### PR TITLE
Fix warnings about dungeongen.cpp memcpy() and unused variable in MapBlock::deSerializeNetworkSpecific()

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -558,8 +558,9 @@ void MapBlock::deSerializeNetworkSpecific(std::istream &is)
 {
 	try {
 		const u8 version = readU8(is);
-		//if(version != 1)
-		//	throw SerializationError("unsupported MapBlock version");
+		if (version != 1) {
+			// throw SerializationError("unsupported MapBlock version");
+		}
 
 	} catch(SerializationError &e) {
 		warningstream<<"MapBlock::deSerializeNetworkSpecific(): Ignoring an error"

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -557,10 +557,10 @@ void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)
 void MapBlock::deSerializeNetworkSpecific(std::istream &is)
 {
 	try {
-		const u8 version = readU8(is);
-		if (version != 1) {
-			// throw SerializationError("unsupported MapBlock version");
-		}
+		readU8(is);
+		//const u8 version = readU8(is);
+		//if (version != 1)
+			//throw SerializationError("unsupported MapBlock version");
 
 	} catch(SerializationError &e) {
 		warningstream<<"MapBlock::deSerializeNetworkSpecific(): Ignoring an error"

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -51,7 +51,7 @@ DungeonGen::DungeonGen(const NodeDefManager *ndef,
 #endif
 
 	if (dparams) {
-		memcpy(&dp, dparams, sizeof(dp));
+		dp = *dparams;
 	} else {
 		// Default dungeon parameters
 		dp.seed = 0;


### PR DESCRIPTION
Fix warning about dungeongen.cpp memcpy()

Closes #8117 
Change was suggested by sfan5.
Dungeons tested and ok.
////////////////////////

2nd commit:
Fix unused variable in MapBlock::deSerializeNetworkSpecific()

Closes #8121 
Use 'version' variable while keeping conditional non-functional.
////////////////////////

3rd commit:
Fix unused variable a simpler way