### PR TITLE
Fix thin strips at node edges

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -795,6 +795,10 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    Show entity selection boxes
 show_entity_selectionbox (Show entity selection boxes) bool true
 
+#    Optimize solid node rendering by merging identical adjacent
+#    faces in long strips. May cause visible gaps between nodes.
+enable_fastface_tiling (Enable FastFaces tiling) bool true
+
 [*Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -799,6 +799,18 @@ show_entity_selectionbox (Show entity selection boxes) bool true
 #    faces in long strips. May cause visible gaps between nodes.
 enable_fastface_tiling (Enable FastFaces tiling) bool true
 
+#    Disable tiling for solid node textures to fix thin wrongly-colored
+#    strips that may appear at node edges, esp. with FSAA enabled.
+#    Only effective if FastFaces tiling is disabled.
+#    Auto enables iff FSAA is enabled but neither texture filtering nor
+#    FastFaces tiling.
+clean_solid_textures (Clean solid node edges) enum auto disable,enable,auto
+
+#    Stretch nodebox textures a tiny bit to fix thin wrongly-colored
+#    (or transparent) strips that may appear at nodebox edges.
+#    Auto enables iff FSAA is enabled but texture filtering isn’t.
+clean_nodebox_textures (Clean nodebox edges) enum auto disable,enable,auto
+
 [*Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -934,6 +934,11 @@
 #    type: bool
 # show_entity_selectionbox = true
 
+#    Optimize solid node rendering by merging identical adjacent
+#    faces in long strips. May cause visible gaps between nodes.
+#    type: bool
+# enable_fastface_tiling = true
+
 ## Menus
 
 #    Use a cloud animation for the main menu background.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -939,6 +939,20 @@
 #    type: bool
 # enable_fastface_tiling = true
 
+#    Disable tiling for solid node textures to fix thin wrongly-colored
+#    strips that may appear at node edges, esp. with FSAA enabled.
+#    Only effective if FastFaces tiling is disabled.
+#    Auto enables iff FSAA is enabled but neither texture filtering nor
+#    FastFaces tiling.
+#    type: enum values: disable, enable, auto
+# clean_solid_textures = auto
+
+#    Stretch nodebox textures a tiny bit to fix thin wrongly-colored
+#    (or transparent) strips that may appear at nodebox edges.
+#    Auto enables iff FSAA is enabled but texture filtering isn’t.
+#    type: enum values: disable, enable, auto
+# clean_nodebox_textures = auto
+
 ## Menus
 
 #    Use a cloud animation for the main menu background.

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -67,7 +67,7 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 	nodedef   = data->m_client->ndef();
 	meshmanip = RenderingEngine::get_scene_manager()->getMeshManipulator();
 
-	std::string clean_nodebox_textures = g_settings->get("clean_nodebox_textures");
+	const std::string &clean_nodebox_textures = g_settings->get("clean_nodebox_textures");
 	if (clean_nodebox_textures == "enable") {
 		stretch_nodebox_textures = true;
 	} else if (clean_nodebox_textures == "disable") {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -227,7 +227,7 @@ void MapblockMeshGenerator::drawCuboid(const aabb3f &box,
 		2, 6, 4, 0
 	};
 
-	static const f32 texture_offset = 1.f / 8192.f;
+	static constexpr f32 texture_offset = 1.f / 8192.f;
 
 	for (int face = 0; face < 6; face++) {
 		int tileindex = MYMIN(face, tilecount - 1);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -67,12 +67,19 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 	nodedef   = data->m_client->ndef();
 	meshmanip = RenderingEngine::get_scene_manager()->getMeshManipulator();
 
-	bool fsaa = g_settings->getU16("fsaa") > 1;
-	bool filtering = g_settings->getBool("bilinear_filter") || g_settings->getBool("trilinear_filter");
+	std::string clean_nodebox_textures = g_settings->get("clean_nodebox_textures");
+	if (clean_nodebox_textures == "enable") {
+		stretch_nodebox_textures = true;
+	} else if (clean_nodebox_textures == "disable") {
+		stretch_nodebox_textures = false;
+	} else {
+		bool fsaa = g_settings->getU16("fsaa") > 1;
+		bool filtering = g_settings->getBool("bilinear_filter") || g_settings->getBool("trilinear_filter");
+		stretch_nodebox_textures = fsaa && !filtering;
+	}
 
 	enable_mesh_cache = g_settings->getBool("enable_mesh_cache") &&
 		!data->m_smooth_lighting; // Mesh cache is not supported with smooth lighting
-	stretch_nodebox_textures = fsaa && !filtering;
 
 	blockpos_nodes = data->m_blockpos * MAP_BLOCKSIZE;
 }

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -69,6 +69,7 @@ public:
 
 // options
 	bool enable_mesh_cache;
+	bool stretch_nodebox_textures;
 
 // current node
 	v3s16 blockpos_nodes;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -40,7 +40,9 @@ MeshMakeData::MeshMakeData(Client *client, bool use_shaders,
 	m_client(client),
 	m_use_shaders(use_shaders),
 	m_use_tangent_vertices(use_tangent_vertices)
-{}
+{
+	m_enable_tiling = g_settings->getBool("enable_fastface_tiling");
+}
 
 void MeshMakeData::fillBlockDataBegin(const v3s16 &blockpos)
 {
@@ -912,7 +914,8 @@ static void updateFastFaceRow(
 					next_face_dir_corrected, next_lights,
 					next_tile);
 
-			if (next_makes_face == makes_face
+			if (data->m_enable_tiling
+					&& next_makes_face == makes_face
 					&& next_p_corrected == p_corrected + translate_dir
 					&& next_face_dir_corrected == face_dir_corrected
 					&& memcmp(next_lights, lights, ARRLEN(lights) * sizeof(u16)) == 0

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -42,6 +42,7 @@ struct MeshMakeData
 	v3s16 m_blockpos = v3s16(-1337,-1337,-1337);
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
 	bool m_smooth_lighting = false;
+	bool m_enable_tiling;
 
 	Client *m_client;
 	bool m_use_shaders;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -153,6 +153,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("undersampling", "0");
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");
+	settings->setDefault("enable_fastface_tiling", "true");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -154,6 +154,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");
 	settings->setDefault("enable_fastface_tiling", "true");
+	settings->setDefault("clean_solid_textures", "auto");
+	settings->setDefault("clean_nodebox_textures", "auto");
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -274,10 +274,10 @@ void TextureSettings::readSettings()
 	enable_minimap                 = g_settings->getBool("enable_minimap");
 	node_texture_size              = g_settings->getU16("texture_min_size");
 	bool enable_fastface_tiling    = g_settings->getBool("enable_fastface_tiling");
-	std::string leaves_style_str         = g_settings->get("leaves_style");
-	std::string world_aligned_mode_str   = g_settings->get("world_aligned_mode");
-	std::string autoscale_mode_str       = g_settings->get("autoscale_mode");
-	std::string clean_solid_textures_str = g_settings->get("clean_solid_textures");
+	const std::string &leaves_style_str         = g_settings->get("leaves_style");
+	const std::string &world_aligned_mode_str   = g_settings->get("world_aligned_mode");
+	const std::string &autoscale_mode_str       = g_settings->get("autoscale_mode");
+	const std::string &clean_solid_textures_str = g_settings->get("clean_solid_textures");
 	int fsaa              = g_settings->getU16("fsaa");
 	bool bilinear_filter  = g_settings->getBool("bilinear_filter");
 	bool trilinear_filter = g_settings->getBool("trilinear_filter");

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -160,7 +160,7 @@ public:
 	bool use_normal_texture;
 	bool enable_mesh_cache;
 	bool enable_minimap;
-	bool disable_tiling;
+	bool disable_solid_tiling;
 
 	TextureSettings() = default;
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -160,6 +160,7 @@ public:
 	bool use_normal_texture;
 	bool enable_mesh_cache;
 	bool enable_minimap;
+	bool disable_tiling;
 
 	TextureSettings() = default;
 

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -381,6 +381,8 @@ fake_function() {
 	gettext("World-aligned textures may be scaled to span several nodes. However,\nthe server may not send the scale you want, especially if you use\na specially-designed texture pack; with this option, the client tries\nto determine the scale automatically basing on the texture size.\nSee also texture_min_size.\nWarning: This option is EXPERIMENTAL!");
 	gettext("Show entity selection boxes");
 	gettext("Show entity selection boxes");
+	gettext("Enable FastFaces tiling");
+	gettext("Optimize solid node rendering by merging identical adjacent\nfaces in long strips. May cause visible gaps between nodes.");
 	gettext("Menus");
 	gettext("Clouds in menu");
 	gettext("Use a cloud animation for the main menu background.");

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -383,6 +383,10 @@ fake_function() {
 	gettext("Show entity selection boxes");
 	gettext("Enable FastFaces tiling");
 	gettext("Optimize solid node rendering by merging identical adjacent\nfaces in long strips. May cause visible gaps between nodes.");
+	gettext("Clean solid node edges");
+	gettext("Disable tiling for solid node textures to fix thin wrongly-colored\nstrips that may appear at node edges, esp. with FSAA enabled.\nOnly effective if FastFaces tiling is disabled.\nAuto enables iff FSAA is enabled but neither texture filtering nor\nFastFaces tiling.");
+	gettext("Clean nodebox edges");
+	gettext("Stretch nodebox textures a tiny bit to fix thin wrongly-colored\n(or transparent) strips that may appear at nodebox edges.\nAuto enables iff FSAA is enabled but texture filtering isn’t.");
 	gettext("Menus");
 	gettext("Clouds in menu");
 	gettext("Use a cloud animation for the main menu background.");


### PR DESCRIPTION
Fix #6860. This uses different approaches for nodeboxes and solid nodes: for the latter, disabling tiling should be enough, while for the former, the texture has to be stretched as face edge is not the texture edge. I hope such tiny offset is enough as the effect was at sub-pixel level; can’t test, however, as FSAA is not supported on my current GPU.
@HybridDog