### PR TITLE
WIP: Network performance

### DIFF
--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -56,7 +56,7 @@ std::mutex log_message_mutex;
 
 #define PING_TIMEOUT 5.0
 
-BufferedPacket makePacket(Address &address, SharedBuffer<u8> data,
+BufferedPacket makePacket(Address &address, const SharedBuffer<u8> &data,
 		u32 protocol_id, session_t sender_peer_id, u8 channel)
 {
 	u32 packet_size = data.getSize() + BASE_HEADER_SIZE;
@@ -126,7 +126,7 @@ void makeSplitPacket(const SharedBuffer<u8> &data, u32 chunksize_max, u16 seqnum
 	}
 }
 
-void makeAutoSplitPacket(SharedBuffer<u8> data, u32 chunksize_max,
+void makeAutoSplitPacket(const SharedBuffer<u8> &data, u32 chunksize_max,
 		u16 &split_seqnum, std::list<SharedBuffer<u8>> *list)
 {
 	u32 original_header_size = 1;
@@ -140,7 +140,7 @@ void makeAutoSplitPacket(SharedBuffer<u8> data, u32 chunksize_max,
 	list->push_back(makeOriginalPacket(data));
 }
 
-SharedBuffer<u8> makeReliablePacket(SharedBuffer<u8> data, u16 seqnum)
+SharedBuffer<u8> makeReliablePacket(const SharedBuffer<u8> &data, u16 seqnum)
 {
 	u32 header_size = 3;
 	u32 packet_size = data.getSize() + header_size;

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -103,16 +103,16 @@ struct BufferedPacket
 };
 
 // This adds the base headers to the data and makes a packet out of it
-BufferedPacket makePacket(Address &address, SharedBuffer<u8> data,
+BufferedPacket makePacket(Address &address, const SharedBuffer<u8> &data,
 		u32 protocol_id, session_t sender_peer_id, u8 channel);
 
 // Depending on size, make a TYPE_ORIGINAL or TYPE_SPLIT packet
 // Increments split_seqnum if a split packet is made
-void makeAutoSplitPacket(SharedBuffer<u8> data, u32 chunksize_max,
+void makeAutoSplitPacket(const SharedBuffer<u8> &data, u32 chunksize_max,
 		u16 &split_seqnum, std::list<SharedBuffer<u8>> *list);
 
 // Add the TYPE_RELIABLE header to the data
-SharedBuffer<u8> makeReliablePacket(SharedBuffer<u8> data, u16 seqnum);
+SharedBuffer<u8> makeReliablePacket(const SharedBuffer<u8> &data, u16 seqnum);
 
 struct IncomingSplitPacket
 {

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -327,7 +327,7 @@ void ConnectionSendThread::sendAsPacketReliable(BufferedPacket &p, Channel *chan
 }
 
 bool ConnectionSendThread::rawSendAsPacket(session_t peer_id, u8 channelnum,
-	SharedBuffer<u8> data, bool reliable)
+	const SharedBuffer<u8> &data, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 	if (!peer) {
@@ -575,7 +575,7 @@ void ConnectionSendThread::disconnect_peer(session_t peer_id)
 }
 
 void ConnectionSendThread::send(session_t peer_id, u8 channelnum,
-	SharedBuffer<u8> data)
+	const SharedBuffer<u8> &data)
 {
 	assert(channelnum < CHANNEL_COUNT); // Pre-condition
 
@@ -615,7 +615,7 @@ void ConnectionSendThread::sendReliable(ConnectionCommand &c)
 	peer->PutReliableSendCommand(c, m_max_packet_size);
 }
 
-void ConnectionSendThread::sendToAll(u8 channelnum, SharedBuffer<u8> data)
+void ConnectionSendThread::sendToAll(u8 channelnum, const SharedBuffer<u8> &data)
 {
 	std::list<session_t> peerids = m_connection->getPeerIDs();
 
@@ -776,7 +776,7 @@ void ConnectionSendThread::sendPackets(float dtime)
 }
 
 void ConnectionSendThread::sendAsPacket(session_t peer_id, u8 channelnum,
-	SharedBuffer<u8> data, bool ack)
+	const SharedBuffer<u8> &data, bool ack)
 {
 	OutgoingPacket packet(peer_id, channelnum, data, false, ack);
 	m_outgoing_queue.push(packet);

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1086,7 +1086,7 @@ bool ConnectionReceiveThread::checkIncomingBuffers(Channel *channel,
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::processPacket(Channel *channel,
-	SharedBuffer<u8> packetdata, session_t peer_id, u8 channelnum, bool reliable)
+	const SharedBuffer<u8> &packetdata, session_t peer_id, u8 channelnum, bool reliable)
 {
 	PeerHelper peer = m_connection->getPeerNoEx(peer_id);
 
@@ -1125,7 +1125,7 @@ const ConnectionReceiveThread::PacketTypeHandler
 };
 
 SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *channel,
-	SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum, bool reliable)
+	const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum, bool reliable)
 {
 	if (packetdata.getSize() < 2)
 		throw InvalidIncomingDataException("packetdata.getSize() < 2");
@@ -1222,7 +1222,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Control(Channel *chan
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Original(Channel *channel,
-	SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum, bool reliable)
+	const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum, bool reliable)
 {
 	if (packetdata.getSize() <= ORIGINAL_HEADER_SIZE)
 		throw InvalidIncomingDataException
@@ -1236,7 +1236,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Original(Channel *cha
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Split(Channel *channel,
-	SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum, bool reliable)
+	const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum, bool reliable)
 {
 	Address peer_address;
 
@@ -1267,7 +1267,7 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Split(Channel *channe
 }
 
 SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Reliable(Channel *channel,
-	SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum, bool reliable)
+	const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum, bool reliable)
 {
 	assert(channel != NULL);
 

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -52,8 +52,8 @@ public:
 private:
 	void runTimeouts(float dtime);
 	void rawSend(const BufferedPacket &packet);
-	bool rawSendAsPacket(session_t peer_id, u8 channelnum, SharedBuffer<u8> data,
-			bool reliable);
+	bool rawSendAsPacket(session_t peer_id, u8 channelnum,
+			const SharedBuffer<u8> &data, bool reliable);
 
 	void processReliableCommand(ConnectionCommand &c);
 	void processNonReliableCommand(ConnectionCommand &c);
@@ -61,14 +61,14 @@ private:
 	void connect(Address address);
 	void disconnect();
 	void disconnect_peer(session_t peer_id);
-	void send(session_t peer_id, u8 channelnum, SharedBuffer<u8> data);
+	void send(session_t peer_id, u8 channelnum, const SharedBuffer<u8> &data);
 	void sendReliable(ConnectionCommand &c);
-	void sendToAll(u8 channelnum, SharedBuffer<u8> data);
+	void sendToAll(u8 channelnum, const SharedBuffer<u8> &data);
 	void sendToAllReliable(ConnectionCommand &c);
 
 	void sendPackets(float dtime);
 
-	void sendAsPacket(session_t peer_id, u8 channelnum, SharedBuffer<u8> data,
+	void sendAsPacket(session_t peer_id, u8 channelnum, const SharedBuffer<u8> &data,
 			bool ack = false);
 
 	void sendAsPacketReliable(BufferedPacket &p, Channel *channel);

--- a/src/network/connectionthreads.h
+++ b/src/network/connectionthreads.h
@@ -119,26 +119,27 @@ private:
 			channelnum: channel on which the packet was sent
 			reliable: true if recursing into a reliable packet
 	*/
-	SharedBuffer<u8> processPacket(Channel *channel, SharedBuffer<u8> packetdata,
-			session_t peer_id, u8 channelnum, bool reliable);
+	SharedBuffer<u8> processPacket(Channel *channel,
+			const SharedBuffer<u8> &packetdata, session_t peer_id,
+			u8 channelnum, bool reliable);
 
 	SharedBuffer<u8> handlePacketType_Control(Channel *channel,
-			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,
+			const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum,
 			bool reliable);
 	SharedBuffer<u8> handlePacketType_Original(Channel *channel,
-			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,
+			const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum,
 			bool reliable);
 	SharedBuffer<u8> handlePacketType_Split(Channel *channel,
-			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,
+			const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum,
 			bool reliable);
 	SharedBuffer<u8> handlePacketType_Reliable(Channel *channel,
-			SharedBuffer<u8> packetdata, Peer *peer, u8 channelnum,
+			const SharedBuffer<u8> &packetdata, Peer *peer, u8 channelnum,
 			bool reliable);
 
 	struct PacketTypeHandler
 	{
 		SharedBuffer<u8> (ConnectionReceiveThread::*handler)(Channel *channel,
-				SharedBuffer<u8> packet, Peer *peer, u8 channelnum,
+				const SharedBuffer<u8> &packet, Peer *peer, u8 channelnum,
 				bool reliable);
 	};
 


### PR DESCRIPTION
Here is a bunch of unnecessary SharedBuffer<u8> and one std::string copying, all in the network code. Especially the SharedBuffer<u8> copying hurts a lot as these hold packet data which can get bulky with things like mapblock sending and stuff. The std::string copying appears to be a mistake (a missing "&" was added).