### PR TITLE
Optimize string (mis)handling

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1034,7 +1034,7 @@ void GenericCAO::updateTexturePos()
 	}
 }
 
-void GenericCAO::updateTextures(std::string mod)
+void GenericCAO::updateTextures(const std::string &modref)
 {
 	ITextureSource *tsrc = m_client->tsrc();
 
@@ -1043,8 +1043,20 @@ void GenericCAO::updateTextures(std::string mod)
 	bool use_anisotropic_filter = g_settings->getBool("anisotropic_filter");
 
 	m_previous_texture_modifier = m_current_texture_modifier;
-	m_current_texture_modifier = mod;
+	m_current_texture_modifier = modref;
 	m_glow = m_prop.glow;
+
+	// Create a reference to the copy of "modref" just created. The
+	// following code will then use this reference instead of the
+	// original parameter which was passed by reference. This is
+	// necessary as "modref" can be a class member and there is a swap on
+	// those class members which can get triggered by the rest of the
+	// code of this method. This is faster than passing the "mod" by
+	// value because it reuses the copy made by the assignment to
+	// m_current_texture_modifier for the "mod" instead of having two
+	// copies, one for "mod" and another one (created from "mod") for
+	// the m_current_texture_modifier class member.
+	const std::string &mod = m_current_texture_modifier;
 
 	video::E_MATERIAL_TYPE material_type = (m_prop.use_texture_alpha) ?
 		video::EMT_TRANSPARENT_ALPHA_CHANNEL : video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -210,9 +210,7 @@ public:
 
 	void updateTexturePos();
 
-	// std::string copy is mandatory as mod can be a class member and there is a swap
-	// on those class members... do NOT pass by reference
-	void updateTextures(std::string mod);
+	void updateTextures(const std::string &modref);
 
 	void updateAnimation();
 

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -39,7 +39,7 @@ std::map<io::path, video::ITexture *> g_txrCache;
 /* Manually insert an image into the cache, useful to avoid texture-to-image
  * conversion whenever we can intercept it.
  */
-void guiScalingCache(io::path key, video::IVideoDriver *driver, video::IImage *value)
+void guiScalingCache(const io::path &key, video::IVideoDriver *driver, video::IImage *value)
 {
 	if (!g_settings->getBool("gui_scaling_filter"))
 		return;

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /* Manually insert an image into the cache, useful to avoid texture-to-image
  * conversion whenever we can intercept it.
  */
-void guiScalingCache(io::path key, video::IVideoDriver *driver, video::IImage *value);
+void guiScalingCache(const io::path &key, video::IVideoDriver *driver, video::IImage *value);
 
 // Manually clear the cache, e.g. when switching to different worlds.
 void guiScalingCacheClear();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -372,7 +372,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 }
 
 
-void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture,
+void Hud::drawStatbar(v2s32 pos, u16 corner, u16 drawdir, const std::string &texture,
 		s32 count, v2s32 offset, v2s32 size)
 {
 	const video::SColor color(255, 255, 255, 255);

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -81,7 +81,7 @@ public:
 	void drawLuaElements(const v3s16 &camera_offset);
 
 private:
-	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, std::string texture,
+	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, const std::string &texture,
 			s32 count, v2s32 offset, v2s32 size = v2s32());
 
 	void drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -131,7 +131,8 @@ std::string getTexturePath(const std::string &filename)
 		Check from texture_path
 	*/
 	for (const auto &path : getTextureDirs()) {
-		std::string testpath = path + DIR_DELIM + filename;
+		std::string testpath = path + DIR_DELIM;
+		testpath.append(filename);
 		// Check all filename extensions. Returns "" if not found.
 		fullpath = getImagePath(testpath);
 		if (!fullpath.empty())

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -139,7 +139,7 @@ f32 GUIChatConsole::getDesiredHeight() const
 	return m_desired_height_fraction;
 }
 
-void GUIChatConsole::replaceAndAddToHistory(std::wstring line)
+void GUIChatConsole::replaceAndAddToHistory(const std::wstring &line)
 {
 	ChatPrompt& prompt = m_chat_backend->getPrompt();
 	prompt.addToHistory(prompt.getLine());

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -60,7 +60,7 @@ public:
 	f32 getDesiredHeight() const;
 
 	// Replace actual line when adding the actual to the history (if there is any)
-	void replaceAndAddToHistory(std::wstring line);
+	void replaceAndAddToHistory(const std::wstring &line);
 
 	// Change how the cursor looks
 	void setCursor(

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -574,7 +574,7 @@ void GUIEngine::updateTopLeftTextSize()
 }
 
 /******************************************************************************/
-s32 GUIEngine::playSound(SimpleSoundSpec spec, bool looped)
+s32 GUIEngine::playSound(const SimpleSoundSpec &spec, bool looped)
 {
 	s32 handle = m_sound_manager->playSound(spec, looped);
 	return handle;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -500,7 +500,7 @@ void GUIEngine::drawFooter(video::IVideoDriver *driver)
 }
 
 /******************************************************************************/
-bool GUIEngine::setTexture(texture_layer layer, std::string texturepath,
+bool GUIEngine::setTexture(texture_layer layer, const std::string &texturepath,
 		bool tile_image, unsigned int minsize)
 {
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -247,7 +247,7 @@ private:
 	 * @param layer draw layer to specify texture
 	 * @param texturepath full path of texture to load
 	 */
-	bool setTexture(texture_layer layer, std::string texturepath,
+	bool setTexture(texture_layer layer, const std::string &texturepath,
 			bool tile_image, unsigned int minsize);
 
 	/**

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -296,7 +296,7 @@ private:
 	clouddata   m_cloud;
 
 	/** start playing a sound and return handle */
-	s32 playSound(SimpleSoundSpec spec, bool looped);
+	s32 playSound(const SimpleSoundSpec &spec, bool looped);
 	/** stop playing a sound started with playSound() */
 	void stopSound(s32 handle);
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -86,7 +86,7 @@ inline u32 clamp_u8(s32 value)
 GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		Client *client, ISimpleTextureSource *tsrc, IFormSource *fsrc, TextDest *tdst,
-		std::string formspecPrepend,
+		const std::string &formspecPrepend,
 		bool remap_dbl_click):
 	GUIModalMenu(RenderingEngine::get_gui_env(), parent, id, menumgr),
 	m_invmgr(client),

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -287,7 +287,7 @@ public:
 			ISimpleTextureSource *tsrc,
 			IFormSource* fs_src,
 			TextDest* txt_dst,
-			std::string formspecPrepend,
+			const std::string &formspecPrepend,
 			bool remap_dbl_click = true);
 
 	~GUIFormSpecMenu();

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -93,7 +93,7 @@ void InventoryLocation::deSerialize(std::istream &is)
 	}
 }
 
-void InventoryLocation::deSerialize(std::string s)
+void InventoryLocation::deSerialize(const std::string &s)
 {
 	std::istringstream is(s, std::ios::binary);
 	deSerialize(is);

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -97,7 +97,7 @@ struct InventoryLocation
 	std::string dump() const;
 	void serialize(std::ostream &os) const;
 	void deSerialize(std::istream &is);
-	void deSerialize(std::string s);
+	void deSerialize(const std::string &s);
 };
 
 struct InventoryAction;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1717,7 +1717,7 @@ bool ServerMap::loadFromFolders() {
 	return false;
 }
 
-void ServerMap::createDirs(std::string path)
+void ServerMap::createDirs(const std::string &path)
 {
 	if (!fs::CreateAllDirs(path)) {
 		m_dout<<"ServerMap: Failed to create directory "

--- a/src/map.h
+++ b/src/map.h
@@ -389,7 +389,7 @@ public:
 		Misc. helper functions for fiddling with directory and file
 		names when saving
 	*/
-	void createDirs(std::string path);
+	void createDirs(const std::string &path);
 	// returns something like "map/sectors/xxxxxxxx"
 	std::string getSectorDir(v2s16 pos, int layout = 2);
 	// dirname: final directory name

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3178,7 +3178,7 @@ bool Server::hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount)
 	return true;
 }
 
-void Server::hudSetHotbarImage(RemotePlayer *player, std::string name)
+void Server::hudSetHotbarImage(RemotePlayer *player, const std::string &name)
 {
 	if (!player)
 		return;
@@ -3187,7 +3187,7 @@ void Server::hudSetHotbarImage(RemotePlayer *player, std::string name)
 	SendHUDSetParam(player->getPeerId(), HUD_PARAM_HOTBAR_IMAGE, name);
 }
 
-void Server::hudSetHotbarSelectedImage(RemotePlayer *player, std::string name)
+void Server::hudSetHotbarSelectedImage(RemotePlayer *player, const std::string &name)
 {
 	if (!player)
 		return;

--- a/src/server.h
+++ b/src/server.h
@@ -296,8 +296,8 @@ public:
 	bool hudChange(RemotePlayer *player, u32 id, HudElementStat stat, void *value);
 	bool hudSetFlags(RemotePlayer *player, u32 flags, u32 mask);
 	bool hudSetHotbarItemcount(RemotePlayer *player, s32 hotbar_itemcount);
-	void hudSetHotbarImage(RemotePlayer *player, std::string name);
-	void hudSetHotbarSelectedImage(RemotePlayer *player, std::string name);
+	void hudSetHotbarImage(RemotePlayer *player, const std::string &name);
+	void hudSetHotbarSelectedImage(RemotePlayer *player, const std::string &name);
 
 	Address getPeerAddress(session_t peer_id);
 

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -145,6 +145,8 @@ void Translations::loadTranslation(const std::string &data)
 			            << wide_to_utf8(oword1) << "\"" << std::endl;
 		}
 
-		m_translations[textdomain + L"|" + oword1] = oword2;
+		std::wstring translation_index = textdomain + L"|";
+		translation_index.append(oword1);
+		m_translations[translation_index] = oword2;
 	}
 }

--- a/src/unittest/test_areastore.cpp
+++ b/src/unittest/test_areastore.cpp
@@ -152,7 +152,7 @@ void TestAreaStore::testSerialization()
 			1 + 2 +
 			6 + 6 + 2 + 6 +
 			6 + 6 + 2 + 6);
-	UASSERTEQ(std::string, str, str_wanted);
+	UASSERTEQ(const std::string &, str, str_wanted);
 
 	std::istringstream is(str);
 	store.deserialize(is);


### PR DESCRIPTION
Here are some unnecessary-string-by-value and unnecessary-temporaries fixes. One turned out to be rather peculiar ("optimize animations in client" where the code relied on the parameter passed by value for correctness, the code was updated to use the already made copy of that value in a class member) but the rest is, according to my humble opinion, rather straightforward.