### PR TITLE
Optimize random turns in dungeongen

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -657,12 +657,13 @@ void random_turn(PseudoRandom &random, v3s16 &dir)
 	if (turn == 0) {
 		// Go straight: nothing to do
 		return;
-	} else if (turn == 1)
+	} else if (turn == 1) {
 		// Turn right
-		dir = turn_xz(olddir, 0);
-	else
+		dir = turn_xz(dir, 0);
+	} else {
 		// Turn left
-		dir = turn_xz(olddir, 1);
+		dir = turn_xz(dir, 1);
+	}
 }
 
 

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -651,17 +651,18 @@ v3s16 turn_xz(v3s16 olddir, int t)
 }
 
 
-void random_turn(PseudoRandom &random, v3s16 &olddir)
+void random_turn(PseudoRandom &random, v3s16 &dir)
 {
 	int turn = random.range(0, 2);
 	if (turn == 0) {
 		// Go straight: nothing to do
+		return;
 	} else if (turn == 1)
 		// Turn right
-		olddir = turn_xz(olddir, 0);
+		dir = turn_xz(olddir, 0);
 	else
 		// Turn left
-		olddir = turn_xz(olddir, 1);
+		dir = turn_xz(olddir, 1);
 }
 
 

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -490,7 +490,7 @@ void DungeonGen::makeCorridor(v3s16 doorplace, v3s16 doordir,
 		if (partcount >= partlength) {
 			partcount = 0;
 
-			dir = random_turn(random, dir);
+			random_turn(random, dir);
 
 			partlength = random.range(1, length);
 
@@ -651,20 +651,17 @@ v3s16 turn_xz(v3s16 olddir, int t)
 }
 
 
-v3s16 random_turn(PseudoRandom &random, v3s16 olddir)
+void random_turn(PseudoRandom &random, v3s16 &olddir)
 {
 	int turn = random.range(0, 2);
-	v3s16 dir;
-	if (turn == 0)
-		// Go straight
-		dir = olddir;
-	else if (turn == 1)
+	if (turn == 0) {
+		// Go straight: nothing to do
+	} else if (turn == 1)
 		// Turn right
-		dir = turn_xz(olddir, 0);
+		olddir = turn_xz(olddir, 0);
 	else
 		// Turn left
-		dir = turn_xz(olddir, 1);
-	return dir;
+		olddir = turn_xz(olddir, 1);
 }
 
 

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -34,7 +34,7 @@ class NodeDefManager;
 
 v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs);
 v3s16 turn_xz(v3s16 olddir, int t);
-void random_turn(PseudoRandom &random, v3s16 &olddir);
+void random_turn(PseudoRandom &random, v3s16 &dir);
 int dir_to_facedir(v3s16 d);
 
 

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -34,7 +34,7 @@ class NodeDefManager;
 
 v3s16 rand_ortho_dir(PseudoRandom &random, bool diagonal_dirs);
 v3s16 turn_xz(v3s16 olddir, int t);
-v3s16 random_turn(PseudoRandom &random, v3s16 olddir);
+void random_turn(PseudoRandom &random, v3s16 &olddir);
 int dir_to_facedir(v3s16 d);
 
 


### PR DESCRIPTION
Here are some unnecessary-string-by-value and unnecessary-temporaries fixes. One turned out to be rather peculiar ("optimize animations in client" where the code relied on the parameter passed by value for correctness, the code was updated to use the already made copy of that value in a class member) but the rest is, according to my humble opinion, rather straightforward.

This is a rather peculiar fix that according to my opinion merits its own pull request so the community has a chance to check whether the proposed fix is going to work, especially in long term.