### PR TITLE
Rename 'Advanced Settings' button to 'All Settings'

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -233,7 +233,7 @@ local function formspec(tabview, name, tabdata)
 
 	tab_string = tab_string ..
 		"button[0,4.75;3.95,1;btn_advanced_settings;"
-		.. fgettext("Advanced Settings") .. "]"
+		.. fgettext("All Settings") .. "]"
 
 
 	if core.settings:get("touchscreen_threshold") ~= nil then


### PR DESCRIPTION
![screenshot from 2019-01-24 22-05-01](https://user-images.githubusercontent.com/3686677/51711684-9f000180-2024-11e9-95c1-dbf3c23f7971.png)

Closes #8028 see issue for why.
Seems supported by @rubenwardy 
Because this is trivial, marking for 5.0.0.