### PR TITLE
Rename 'Connect' button to 'Connect / Register'

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -55,7 +55,7 @@ local function get_formspec(tabview, name, tabdata)
 		"box[7.73,2.25;4.25,2.6;#999999]"..
 
 		-- Connect
-		"button[9.88,4.9;2.3,1;btn_mp_connect;" .. fgettext("Connect") .. "]"
+		"button[7.73,4.9;4.47,1;btn_mp_connect;" .. fgettext("Connect / Register") .. "]"
 
 	if tabdata.fav_selected and fav_selected then
 		if gamedata.fav then


### PR DESCRIPTION
![screenshot from 2019-01-25 02-30-07](https://user-images.githubusercontent.com/3686677/51721459-cc12db00-2049-11e9-85da-d578165a71e1.png)

Quick random PR to help with #258 but obviously not a complete solution. However this might help because the current password confirmation screen may be removed in #8111 

Eventually i feel this menu screen should have the password confirmation when registering, or because there is little spare room here, a separate 'register' button that leads to a double password entry.
So what this PR does may be temporary, therefore marking for 5.0.0. This button may later be split into separate 'Connect' and 'Register' buttons.