### PR TITLE
[WIP] Add URL button

### DIFF
--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -89,7 +89,7 @@ return {
 		local version = core.get_version()
 		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
 			"label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
-			"button_url[0.25,3.5;3,2;;minetest.net;http://minetest.net]" ..
+			"button_url[0.25,3.5;3,2;;minetest.net;https://www.minetest.net]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
 			"table[3.5,-0.25;8.5,6.05;list_credits;" ..

--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -89,7 +89,7 @@ return {
 		local version = core.get_version()
 		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
 			"label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
-			"button_url[0.5,3.5;2,2;;http://minetest.net;http://minetest.net]" ..
+			"button_url[0.25,3.5;3,2;;minetest.net;http://minetest.net]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
 			"table[3.5,-0.25;8.5,6.05;list_credits;" ..

--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -89,7 +89,7 @@ return {
 		local version = core.get_version()
 		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
 			"label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
-			"label[0.5,3.5;http://minetest.net]" ..
+			"button_url[0.5,3.5;2,2;;http://minetest.net;http://minetest.net]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
 			"table[3.5,-0.25;8.5,6.05;list_credits;" ..

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1772,6 +1772,57 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 			<< "'" << std::endl;
 }
 
+void GUIFormSpecMenu::parseButtonURL(parserData *data, const std::string &element)
+{
+
+	std::vector<std::string> parts = split(element,';');
+
+	if ((parts.size() == 5) ||
+		((parts.size() > 5) && (m_formspec_version > FORMSPEC_API_VERSION)))
+	{
+		std::vector<std::string> v_pos = split(parts[0],',');
+		std::vector<std::string> v_geom = split(parts[1],',');
+		std::string name = parts[2];
+		std::string label = parts[3];
+
+		MY_CHECKPOS("button",0);
+		MY_CHECKGEOM("button",1);
+
+		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 geom;
+		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+
+		core::rect<s32> rect =
+				core::rect<s32>(pos.X, pos.Y - m_btn_height,
+								pos.X + geom.X, pos.Y + m_btn_height);
+
+		if(!data->explicit_size)
+			warningstream<<"invalid use of button without a size[] element"<<std::endl;
+
+		std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
+
+		FieldSpec spec(
+				name,
+				wlabel,
+				L"",
+				258+m_fields.size()
+		);
+		spec.ftype = f_Button;
+		spec.url = parts[4];
+		gui::IGUIButton* e = Environment->addButton(rect, this, spec.fid,
+													spec.flabel.c_str());
+
+		if (spec.fname == data->focused_fieldname) {
+			Environment->setFocus(e);
+		}
+
+		m_fields.push_back(spec);
+		return;
+	}
+	errorstream<< "Invalid button element(" << parts.size() << "): '" << element << "'"  << std::endl;
+}
+
 void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
 	//some prechecks
@@ -1929,6 +1980,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 
 	if (type == "scrollbar") {
 		parseScrollBar(data, description);
+		return;
+	}
+
+	if (type == "button_url" && !m_client) {
+		parseButtonURL(data, description);
 		return;
 	}
 
@@ -3627,6 +3683,14 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 							m_text_dst->gotText(L"ExitButton");
 						}
 						return true;
+					}
+
+					if (!s.url.empty()) {
+						if (m_client) {
+							errorstream << "Unable to use button_url in game!" << std::endl;
+						} else {
+							porting::openURL(s.url);
+						}
 					}
 
 					acceptInput(quit_mode_no);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -214,6 +214,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		std::string fname;
 		std::wstring flabel;
 		std::wstring fdefault;
+		std::string url;
 		int fid;
 		bool send;
 		FormspecFieldType ftype;
@@ -512,6 +513,7 @@ private:
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
+	void parseButtonURL(parserData *data, const std::string &element);
 
 	void tryClose();
 

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "porting.h"
 
+
 #if defined(__FreeBSD__)  || defined(__NetBSD__) || defined(__DragonFly__)
 	#include <sys/types.h>
 	#include <sys/sysctl.h>
@@ -52,6 +53,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <list>
 #include <cstdarg>
 #include <cstdio>
+#include <regex>
 
 namespace porting
 {
@@ -695,6 +697,20 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 #endif // _MSC_VER
 	va_end(args);
 	return c;
+}
+
+bool openURL(std::string url)
+{
+	if (!std::regex_match(url, std::regex("^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$") )) {
+		errorstream << "Invalid url: " << url << std::endl;
+		return false;
+	}
+
+#ifdef _WIN32
+	return system((std::string("open ") + url).c_str()) == 0;
+#else
+	return system((std::string("xdg-open ") + url).c_str()) == 0;
+#endif
 }
 
 // Load performance counter frequency only once at startup

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -701,15 +701,16 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 
 bool openURL(std::string url)
 {
-	if (!std::regex_match(url, std::regex("^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$") )) {
+	if (!std::regex_match(url,
+			std::regex(R"(^https?:\/\/([\w\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$)") )) {
 		errorstream << "Invalid url: " << url << std::endl;
 		return false;
 	}
 
 #ifdef _WIN32
-	return system((std::string("open ") + url).c_str()) == 0;
+	return system((std::string("open '") + url + "'").c_str()) == 0;
 #else
-	return system((std::string("xdg-open ") + url).c_str()) == 0;
+	return system((std::string("xdg-open '") + url + "'").c_str()) == 0;
 #endif
 }
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -329,6 +329,10 @@ bool secure_rand_fill_buf(void *buf, size_t len);
 void attachOrCreateConsole();
 
 int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...);
+
+
+bool openURL(std::string url);
+
 } // namespace porting
 
 #ifdef __ANDROID__


### PR DESCRIPTION
Adds a formspec element to open URLs in a browser.

## Note that this is only enabled in the mainmenu (currently)
This cannot be used whilst in-game, due to the obvious issues. I'd like to add support for this eventually, with a confirmation dialog showing the requested URL. But this would should not be done in this PR

## Usecase
The use case in mind is allowing a button to open up the ContentDB pages of packages. 

To implement reviews and comments, I don't want to have to add login support to the client. Instead, I'd prefer to have a button to open up ContentDB in a web browser.

## To do
- [ ] Ensure security
  - [ ] Is m_client always non-null in-game?
  - [ ] Is the regex safe? I haven't checked whether it disallows spaces and such
- [ ] Make it obvious that the button opens a link - Internet icon?
- [ ] OS support - eg: Android, mac-OS