### PR TITLE
Settings: Slightly increase block generate, block send, object send distances

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1069,7 +1069,7 @@ ask_reconnect_on_crash (Ask to reconnect after crash) bool false
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
-active_object_send_range_blocks (Active object send range) int 3
+active_object_send_range_blocks (Active object send range) int 4
 
 #    The radius of the volume of blocks around every player that is subject to the
 #    active block stuff, stated in mapblocks (16 nodes).
@@ -1079,7 +1079,7 @@ active_object_send_range_blocks (Active object send range) int 3
 active_block_range (Active block range) int 3
 
 #    From how far blocks are sent to clients, stated in mapblocks (16 nodes).
-max_block_send_distance (Max block send distance) int 9
+max_block_send_distance (Max block send distance) int 10
 
 #    Maximum number of forceloaded mapblocks.
 max_forceloaded_blocks (Maximum forceloaded blocks) int 16
@@ -1333,7 +1333,7 @@ mg_name (Mapgen name) enum v7 v5,v6,v7,valleys,carpathian,fractal,flat,singlenod
 water_level (Water level) int 1
 
 #    From how far blocks are generated for clients, stated in mapblocks (16 nodes).
-max_block_generate_distance (Max block generate distance) int 6
+max_block_generate_distance (Max block generate distance) int 8
 
 #    Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).
 #    Only mapchunks completely within the mapgen limit are generated.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -339,11 +339,11 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ask_reconnect_on_crash", "false");
 
 	settings->setDefault("profiler_print_interval", "0");
-	settings->setDefault("active_object_send_range_blocks", "3");
+	settings->setDefault("active_object_send_range_blocks", "4");
 	settings->setDefault("active_block_range", "3");
 	//settings->setDefault("max_simultaneous_block_sends_per_client", "1");
 	// This causes frametime jitter on client side, or does it?
-	settings->setDefault("max_block_send_distance", "9");
+	settings->setDefault("max_block_send_distance", "10");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
 	settings->setDefault("csm_restriction_flags", "62");
@@ -400,7 +400,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "dungeons");
 	settings->setDefault("fixed_map_seed", "");
-	settings->setDefault("max_block_generate_distance", "7");
+	settings->setDefault("max_block_generate_distance", "8");
 	settings->setDefault("projecting_dungeons", "true");
 	settings->setDefault("enable_mapgen_debug_info", "false");
 


### PR DESCRIPTION
Attends to #8050 I suggested 4, @sfan5 seems to support 4 https://github.com/minetest/minetest/pull/8050#issuecomment-452720784
3 -> 4 will increase area of activated objects by 19% and stops objects disappearing only 48 nodes away, a slight but welcome increase to 64 nodes.
The feature (view direction maintaining of objects) enabled by having active_object_send_range_blocks larger than active_block_range is currently not enabled. When the feature was added we decided to make the settings changes another time but forgot to do so.

Increases both distances discussed in #8049 See https://github.com/minetest/minetest/issues/8049#issuecomment-451722422
Again slight but welcome increases, both effectively become 160 nodes.
Also fixes the non-matching max_block_generate_distance value in settingtypes.txt.