### PR TITLE
Main menu: Fix cloud color

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -323,7 +323,7 @@ void GUIEngine::cloudInit()
 {
 	m_cloud.clouds = new Clouds(m_smgr, -1, rand());
 	m_cloud.clouds->setHeight(100.0f);
-	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,200,200,255));
+	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,255,255,255));
 
 	m_cloud.camera = m_smgr->addCameraSceneNode(0,
 				v3f(0,0,0), v3f(0, 60, 100));


### PR DESCRIPTION
Removes that weird purple/blue tint.

Before:
![clouds_before](https://user-images.githubusercontent.com/35757396/52184050-4fa79700-27c3-11e9-8bea-8e31f4432954.png)

After:
![clouds_after](https://user-images.githubusercontent.com/35757396/52184052-56cea500-27c3-11e9-90f0-97116c5195db.png)

