### PR TITLE
Fix coloured fog in main menu

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -242,6 +242,24 @@ void GUIEngine::run()
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
 
+	const video::SColor sky_color(255, 140, 186, 250);
+
+	// Reset fog color
+	{
+		video::SColor fog_color;
+		video::E_FOG_TYPE fog_type = video::EFT_FOG_LINEAR;
+		f32 fog_start = 0;
+		f32 fog_end = 0;
+		f32 fog_density = 0;
+		bool fog_pixelfog = false;
+		bool fog_rangefog = false;
+		driver->getFog(fog_color, fog_type, fog_start, fog_end, fog_density,
+				fog_pixelfog, fog_rangefog);
+
+		driver->setFog(sky_color, fog_type, fog_start, fog_end, fog_density,
+				fog_pixelfog, fog_rangefog);
+	}
+
 	while (RenderingEngine::run() && (!m_startgame) && (!m_kill)) {
 
 		const irr::core::dimension2d<u32> &current_screen_size =
@@ -263,7 +281,7 @@ void GUIEngine::run()
 			text_height = g_fontengine->getTextHeight();
 		}
 
-		driver->beginScene(true, true, video::SColor(255,140,186,250));
+		driver->beginScene(true, true, sky_color);
 
 		if (m_clouds_enabled)
 		{

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -242,7 +242,7 @@ void GUIEngine::run()
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
 
-	const video::SColor sky_color(255, 140, 186, 250);
+	static const video::SColor sky_color(255, 140, 186, 250);
 
 	// Reset fog color
 	{


### PR DESCRIPTION
Fixes #4727. The issue was due to the video driver fog colour never getting reset after closing the game.

To test:
1. Open a game with WorldEdit enabled.
2. Run `//l minetest.get_player_by_name("singleplayer"):set_sky("#00FF00", "plain")`.
3. Exit the game.
4. Observe the fog at the far edges of the cloud layer.