### PR TITLE
Fix grayed-out modpacks in world configuration dialog

### DIFF
--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -603,7 +603,11 @@ function pkgmgr.preparemodlist(data)
 				end
 			end
 			if element ~= nil then
-				element.enabled = value ~= "false" and value ~= "nil" and value
+				if value ~= "false" and value ~= "nil" and value then
+					element.enabled = true
+				else
+					element.enabled = false
+				end
 			else
 				core.log("info", "Mod: " .. key .. " " .. dump(value) .. " but not found")
 			end


### PR DESCRIPTION
Previously, enabled modpacks would not show as green in the world configuration screen. This was due to some Lua weirdness causing a `true` value to become `"true"` and causing unexpected behaviour.

Before:
![worldconfig_before](https://user-images.githubusercontent.com/35757396/52437214-35273380-2acb-11e9-9e86-7c9a45d62eb3.png)
After:
![worldconfig_after](https://user-images.githubusercontent.com/35757396/52437223-3a847e00-2acb-11e9-82c7-a7140475882a.png)

The first modpack was intentionally left disabled.
