### PR TITLE
Update gamebar on tab enter

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -144,7 +144,10 @@ local function init_globals()
 	tv_main:set_fixed_size(false)
 
 	if menustyle ~= "simple" then
-		tv_main:set_tab(core.settings:get("maintab_LAST"))
+		local last_tab = core.settings:get("maintab_LAST")
+		if last_tab and tv_main.current_tab ~= last_tab then
+			tv_main:set_tab(last_tab)
+		end
 	end
 	ui.set_default("maintab")
 	tv_main:show()

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -294,13 +294,6 @@ end
 local on_change
 if enable_gamebar then
 	function on_change(type, old_tab, new_tab)
-		local buttonbar = ui.find_by_name("game_button_bar")
-
-		if ( buttonbar == nil ) then
-			singleplayer_refresh_gamebar()
-			buttonbar = ui.find_by_name("game_button_bar")
-		end
-
 		if (type == "ENTER") then
 			local game = current_game()
 
@@ -309,10 +302,15 @@ if enable_gamebar then
 				core.set_topleft_text(game.name)
 				mm_texture.update("singleplayer",game)
 			end
-			buttonbar:show()
+
+			singleplayer_refresh_gamebar()
+			ui.find_by_name("game_button_bar"):show()
 		else
 			menudata.worldlist:set_filtercriteria(nil)
-			buttonbar:hide()
+			local gamebar = ui.find_by_name("game_button_bar")
+			if gamebar then
+				gamebar:hide()
+			end
 			core.set_topleft_text("")
 			mm_texture.update(new_tab,nil)
 		end


### PR DESCRIPTION
So that a restart isn't required to update the gamebar after installing or uninstalling a game [using CDB].
Attends to https://github.com/minetest/minetest/issues/8165#issuecomment-460110723