### PR TITLE
Optimize interaction distance checker

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -952,7 +952,7 @@ void Server::handleCommand_Respawn(NetworkPacket* pkt)
 	// the previous addition has been successfully removed
 }
 
-bool Server::checkInteractDistance(RemotePlayer *player, const f32 d, const std::string what)
+bool Server::checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what)
 {
 	PlayerSAO *playersao = player->getPlayerSAO();
 	const InventoryList *hlist = playersao->getInventory()->getList("hand");

--- a/src/server.h
+++ b/src/server.h
@@ -477,7 +477,7 @@ private:
 	void RespawnPlayer(session_t peer_id);
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);
-	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string what);
+	bool checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what);
 
 	void handleChatInterfaceEvent(ChatEvent *evt);
 


### PR DESCRIPTION
The "what" parameter is being passed by value, most likely by
accident as the type is "const std::string". Convert it to a
reference by adding the missing "&".

This change was originally part of "NetworkPerformance" but as it was approved by nerzhul while the rest of that pull request wasn't, I extracted it here to make merging easier.