### PR TITLE
Remove fgettext("") in builtin

### DIFF
--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -36,7 +36,7 @@ local function get_formspec(tabview, name, tabdata)
 		"field[0.15,0.075;5.91,1;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
 		"button[5.62,-0.25;1.5,1;btn_mp_search;" .. fgettext("Search") .. "]" ..
 		"image_button[6.97,-.165;.83,.83;" .. core.formspec_escape(defaulttexturedir .. "refresh.png")
-			.. ";btn_mp_refresh;" .. fgettext("") .. "]" ..
+			.. ";btn_mp_refresh;]" ..
 
 		-- Address / Port
 		"label[7.75,-0.25;" .. fgettext("Address / Port") .. "]" ..


### PR DESCRIPTION
This call is useless and wrong, the empty string has a special meaning in Gettext as it returns the metadata of the PO file which you find at the header of each PO file.
The call appeared in the `label` field of the refesh image button from the serverlist.
It is clear from the code that the “refresh” image button does not need any label, so the fix is simply removing it.

It seems that this call also broke a few other things (not sure). It might (*might!*) be the reason why Weblate failed to update.