### PR TITLE
Add newline before itemstring in item tooltip

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2425,7 +2425,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 					if (tooltip_text.empty())
 						tooltip_text = utf8_to_wide(item.name);
 					else if (m_tooltip_append_itemname)
-						tooltip_text += utf8_to_wide(" [" + item.name + "]");
+						tooltip_text += utf8_to_wide("\n[" + item.name + "]");
 				}
 			}
 			if (!tooltip_text.empty()) {


### PR DESCRIPTION
Because I think it's a bit more pleasant to read that way because the “real” item name and the internal one are visually more separated.

How to test:
1. Enable `tooltip_append_itemname`
2. Start a game and hover some items