### PR TITLE
Don't regain breath while in ignore node

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1015,9 +1015,11 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// Get nose/mouth position, approximate with eye position
 		v3s16 p = floatToInt(getEyePosition(), BS);
 		MapNode n = m_env->getMap().getNodeNoEx(p);
+		content_t content = n.getContent();
 		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
-		// If player is alive & no drowning, breathe
-		if (m_hp > 0 && m_breath < m_prop.breath_max && c.drowning == 0)
+		// If player is alive & no drowning & not in ignore, breathe
+		if (m_breath < m_prop.breath_max &&
+				c.drowning == 0 && content != CONTENT_IGNORE && m_hp > 0)
 			setBreath(m_breath + 1);
 	}
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1015,11 +1015,10 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// Get nose/mouth position, approximate with eye position
 		v3s16 p = floatToInt(getEyePosition(), BS);
 		MapNode n = m_env->getMap().getNodeNoEx(p);
-		content_t content = n.getContent();
 		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
 		// If player is alive & no drowning & not in ignore, breathe
 		if (m_breath < m_prop.breath_max &&
-				c.drowning == 0 && content != CONTENT_IGNORE && m_hp > 0)
+				c.drowning == 0 && n.getContent() != CONTENT_IGNORE && m_hp > 0)
 			setBreath(m_breath + 1);
 	}
 


### PR DESCRIPTION
Fixes #8217.

The player shall neither lose or gain breath while in `ignore` because we don't know yet if the node will turn out to be a drowning node or a non-drowning one.

How to test: Start simple server, can even be locally from client. Drop in liquid. Lose breath. Stop server. Restart server. Look at breath meter. If the breath meter does not change, it works.