### PR TITLE
core.extract_zip: Don't convert uppercase filenames to lowercase on content download

### DIFF
--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -761,7 +761,7 @@ int ModApiMainMenu::l_extract_zip(lua_State *L)
 
 		io::IFileSystem *fs = RenderingEngine::get_filesystem();
 
-		if (!fs->addFileArchive(zipfile,true,false,io::EFAT_ZIP)) {
+		if (!fs->addFileArchive(zipfile,false,false,io::EFAT_ZIP)) {
 			lua_pushboolean(L,false);
 			return 1;
 		}


### PR DESCRIPTION
For #8203 
See https://github.com/minetest/minetest/issues/8203#issuecomment-462471389
Works for me on Linux Ubuntu when testing downloading of technic mod.
Note: "I suspect that this would break it on Windows"