### PR TITLE
Dungeon generation: Avoid removing nodes with 'is_ground_content = false'

### DIFF
--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -110,7 +110,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 					NodeDrawType dtype = ndef->get(c).drawtype;
 					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
 							(preserve_ignore && c == CONTENT_IGNORE) ||
-							! ndef->get(c).is_ground_content)
+							!ndef->get(c).is_ground_content)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -109,7 +109,8 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 					content_t c = vm->m_data[i].getContent();
 					NodeDrawType dtype = ndef->get(c).drawtype;
 					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
-							(preserve_ignore && c == CONTENT_IGNORE))
+							(preserve_ignore && c == CONTENT_IGNORE) ||
+							! ndef->get(c).is_ground_content)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}


### PR DESCRIPTION
EDIT by paramat:
WARNING: DO NOT MERGE, PATCH FREEZES MT.
////////////////////////

Dungeon generation: Avoid nodes with "is_ground_content" flag == false

It seems like dungeon generation should obey this flag in the same way that cave generation does.  This would be a single-line change.  

My apologies if I have not formatted this request properly.  I'm kind of new to this process.  I'm willing to do the footwork of reformatting it if need be.