### PR TITLE
Fix profiler crash

### DIFF
--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -88,7 +88,7 @@ local function instrument(def)
 	if not def or not def.func then
 		return
 	end
-	def.mod = def.mod or get_current_modname()
+	def.mod = def.mod or get_current_modname() or "after init"
 	local modname = def.mod
 	local instrument_name = generate_name(def)
 	local func = def.func

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -88,7 +88,7 @@ local function instrument(def)
 	if not def or not def.func then
 		return
 	end
-	def.mod = def.mod or get_current_modname() or "after init"
+	def.mod = def.mod or get_current_modname() or "??"
 	local modname = def.mod
 	local instrument_name = generate_name(def)
 	local func = def.func


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/8237. Maybe not the best solution.
Labels callbacks registered after init time with "after init" in place of the mod name.

Profiler output:
```
 instrumentation                |    min µs |    max µs |    avg µs | min % | max % | avg %
------------------------------- | --------- | --------- | --------- | ----- | ----- | ------
 after init:                    |         0 |       124 |         0 |   0.0 |   0.6 |   0.0
  - on_joinplayer[1] .........  |       124 |       124 |       124 |   0.6 |   0.6 |   0.6
```