### PR TITLE
Fix profiler crash since eea1fda

### DIFF
--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -30,6 +30,7 @@ core.register_on_sending_chat_message(function(message)
 		if result then
 			core.display_chat_message(result)
 		end
+		core.set_last_run_mod(nil)
 	else
 		core.display_chat_message(core.gettext("-!- Invalid command: ") .. cmd)
 	end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -18,6 +18,8 @@ core.register_globalstep(function(dtime)
 		if time >= job.expire then
 			core.set_last_run_mod(job.mod_origin)
 			job.func(unpack(job.arg))
+			core.set_last_run_mod(nil)
+
 			local jobs_l = #jobs
 			jobs[i] = jobs[jobs_l]
 			jobs[jobs_l] = nil

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -56,6 +56,7 @@ core.register_on_chat_message(function(name, message)
 		if result then
 			core.chat_send_player(name, result)
 		end
+		core.set_last_run_mod(nil)
 	else
 		core.chat_send_player(name, "You don't have permission"
 				.. " to run this command (missing privileges: "

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -623,6 +623,7 @@ function core.node_dig(pos, node, digger)
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
 		callback(pos_copy, node_copy, digger)
+		core.set_last_run_mod(nil)
 	end
 end
 

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -415,6 +415,7 @@ function core.run_callbacks(callbacks, mode, ...)
 			core.set_last_run_mod(origin.mod)
 		end
 		local cb_ret = callbacks[i](...)
+		core.set_last_run_mod(nil)
 
 		if mode == 0 and i == 1 then
 			ret = cb_ret

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -164,7 +164,9 @@ end
 -- Append "update_builtin_statbars" as late as possible
 -- This ensures that the HUD is hidden when the flags are updated in this callback
 core.register_on_mods_loaded(function()
+	core.set_last_run_mod("*builtin*")
 	core.register_on_joinplayer(update_builtin_statbars)
+	core.set_last_run_mod(nil)
 end)
 core.register_on_leaveplayer(cleanup_builtin_statbars)
 core.register_playerevent(player_event_handler)

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -17,6 +17,7 @@
 
 local format, pairs, type = string.format, pairs, type
 local core, get_current_modname = core, core.get_current_modname
+local get_last_run_mod = core.get_last_run_mod
 local profiler, sampler, get_bool_default = ...
 
 local instrument_builtin = get_bool_default("instrument.builtin", false)
@@ -88,7 +89,7 @@ local function instrument(def)
 	if not def or not def.func then
 		return
 	end
-	def.mod = def.mod or get_current_modname() or "??"
+	def.mod = def.mod or get_last_run_mod() or "??"
 	local modname = def.mod
 	local instrument_name = generate_name(def)
 	local func = def.func

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -313,13 +313,10 @@ void ScriptApiBase::setOriginDirect(const char *origin)
 
 void ScriptApiBase::setOriginFromTableRaw(int index, const char *fxn)
 {
-#ifdef SCRIPTAPI_DEBUG
 	lua_State *L = getStack();
 
 	m_last_run_mod = lua_istable(L, index) ?
-		getstringfield_default(L, index, "mod_origin", "") : "";
-	//printf(">>>> running %s for mod: %s\n", fxn, m_last_run_mod.c_str());
-#endif
+		getstringfield_default(L, index, "mod_origin", "??") : "??";
 }
 
 void ScriptApiBase::addObjectReference(ServerActiveObject *cobj)

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -39,7 +39,6 @@ extern "C" {
 #include "config.h"
 
 #define SCRIPTAPI_LOCK_DEBUG
-#define SCRIPTAPI_DEBUG
 
 // MUST be an invalid mod name so that mods can't
 // use that name to bypass security!
@@ -144,7 +143,7 @@ protected:
 	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason& reason);
 
 	std::recursive_mutex m_luastackmutex;
-	std::string     m_last_run_mod;
+	std::string     m_last_run_mod = BUILTIN_MOD_NAME;
 	bool            m_secure = false;
 #ifdef SCRIPTAPI_LOCK_DEBUG
 	int             m_lock_recursion_count{};

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -57,13 +57,9 @@ int ModApiClient::l_get_last_run_mod(lua_State *L)
 // set_last_run_mod(modname)
 int ModApiClient::l_set_last_run_mod(lua_State *L)
 {
-	if (!lua_isstring(L, 1))
-		return 0;
-
-	const char *mod = lua_tostring(L, 1);
+	const char *mod = lua_tostring(L, 1); // `nil` (nullptr) to reset
 	getScriptApiBase(L)->setOriginDirect(mod);
-	lua_pushboolean(L, true);
-	return 1;
+	return 0;
 }
 
 // print(text)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -493,11 +493,9 @@ int ModApiServer::l_get_last_run_mod(lua_State *L)
 int ModApiServer::l_set_last_run_mod(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-#ifdef SCRIPTAPI_DEBUG
-	const char *mod = lua_tostring(L, 1);
+
+	const char *mod = lua_tostring(L, 1); // `nil` (nullptr) to reset
 	getScriptApiBase(L)->setOriginDirect(mod);
-	//printf(">>>> last mod set from Lua: %s\n", mod);
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
Properly reset the last run modname after execution
Remove always in use SCRIPTAPI_DEBUG macro checks
Default unknown mod names to '??'

Fixes #8237
Replaces #8239