### PR TITLE
Make autoforward simulate the up key

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2481,14 +2481,8 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 
 	// autoforward if set: simulate "up" key
 	if (player->getPlayerSettings().continuous_forward) {
-		// simulate "aux1" key if "up" key is already set
-		if (!control.up) {
-			control.up = true;
-			keypress_bits |= 1U << 0;
-		} else {
-			control.aux1 = true;
-			keypress_bits |= 1U << 5;
-		}
+		control.up = true;
+		keypress_bits |= 1U << 0;
 	}
 
 	client->setPlayerControl(control);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2480,14 +2480,15 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	}
 
 	// autoforward if set: simulate "up" key
-	if (g_settings->getBool("continuous_forward")) {
-		// also simulate "aux1" key if "up" key is already set
-		if (control.up) {
+	if (player->getPlayerSettings().continuous_forward) {
+		// simulate "aux1" key if "up" key is already set
+		if (!control.up) {
+			control.up = true;
+			keypress_bits |= 1U << 0;
+		} else {
 			control.aux1 = true;
 			keypress_bits |= 1U << 5;
 		}
-		control.up = true;
-		keypress_bits |= 1U << 0;
 	}
 
 	client->setPlayerControl(control);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2479,6 +2479,17 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 		keypress_bits |= 1U << 4;
 	}
 
+	// autoforward if set: simulate "up" key
+	if (g_settings->getBool("continuous_forward")) {
+		// also simulate "aux1" key if "up" key is already set
+		if (control.up) {
+			control.aux1 = true;
+			keypress_bits |= 1U << 5;
+		}
+		control.up = true;
+		keypress_bits |= 1U << 0;
+	}
+
 	client->setPlayerControl(control);
 	player->keyPressed = keypress_bits;
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -496,7 +496,6 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	bool pitch_move = (free_move || in_liquid) && player_settings.pitch_move;
 	// When aux1_descends is enabled the fast key is used to go down, so fast isn't possible
 	bool fast_climb = fast_move && control.aux1 && !player_settings.aux1_descends;
-	bool continuous_forward = player_settings.continuous_forward;
 	bool always_fly_fast = player_settings.always_fly_fast;
 
 	// Whether superspeed mode is used or not
@@ -583,16 +582,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		}
 	}
 
-	if (continuous_forward)
-		speedH += v3f(0,0,1);
-
 	if (control.up) {
-		if (continuous_forward) {
-			if (fast_move)
-				superspeed = true;
-		} else {
-			speedH += v3f(0,0,1);
-		}
+		speedH += v3f(0,0,1);
 	}
 	if (control.down) {
 		speedH -= v3f(0,0,1);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1102,7 +1102,7 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 	if (m_autojump)
 		return;
 
-	bool control_forward = control.up || player_settings.continuous_forward ||
+	bool control_forward = control.up ||
 			(!control.up && !control.down &&
 			control.forw_move_joystick_axis < -0.05);
 	bool could_autojump =


### PR DESCRIPTION
Fixes #7805.

~~Also if the player uses fast in autoforward mode by pressing the up key, the aux1 key is set now.~~
The up key now does nothing if it's pressed in autoforward mode.

I've tested this.

To test this you can use this:
```lua
minetest.register_globalstep(function(dtime)
	local players = minetest.get_connected_players()
	for i = 1, #players do
		local p = players[i]
		local s = p:get_player_name()
		for k, b in pairs(p:get_player_control()) do
			s = s .. " " .. minetest.colorize((b and "#00ff00" or "#ff0000"), k .. ":" .. (b and "t" or "f"))
		end
		minetest.chat_send_all(s)
	end
end)

```