### PR TITLE
Make group “immortal” protect players from damage

### DIFF
--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -50,7 +50,8 @@ local function update_builtin_statbars(player)
 	end
 	local hud = hud_ids[name]
 
-	if flags.healthbar and enable_damage then
+	local immortal = player:get_armor_groups().immortal == 1
+	if flags.healthbar and enable_damage and not immortal then
 		local number = scaleToDefault(player, "hp")
  		if hud.id_healthbar == nil then
  			local hud_def = table.copy(health_bar_definition)
@@ -65,7 +66,7 @@ local function update_builtin_statbars(player)
 	end
 
 	local breath_max = player:get_properties().breath_max
-	if flags.breathbar and enable_damage and
+	if flags.breathbar and enable_damage and not immortal and
 			player:get_breath() < breath_max then
 		local number = 2 * scaleToDefault(player, "breath")
 		if hud.id_breathbar == nil then
@@ -116,7 +117,7 @@ local function player_event_handler(player,eventname)
 		end
 	end
 
-	if eventname == "hud_changed" then
+	if eventname == "hud_changed" or eventname == "properties_changed" then
 		update_builtin_statbars(player)
 		return true
 	end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1485,7 +1485,8 @@ Another example: Make red wool from white wool and red dye:
 Special groups
 --------------
 
-* `immortal`: Disables the group damage system for an entity
+* `immortal`: Disables the group damage system for an entity.
+  Disables all damage for a player.
 * `punch_operable`: For entities; disables the regular damage mechanism for
   players punching it by hand or a non-tool item, so that it can do something
   else than take damage.

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1057,6 +1057,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// create message and add to list
 		ActiveObjectMessage aom(getId(), true, str);
 		m_messages_out.push(aom);
+		m_env->getScriptIface()->player_event(this, "properties_changed");
 	}
 
 	// If attached, check that our parent is still there. If it isn't, detach.

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -799,7 +799,8 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage")) {
+	if (g_settings->getBool("enable_damage") &&
+			(itemgroup_get(playersao->getArmorGroups(), "immortal") == 0)) {
 		if (playersao->isDead()) {
 			verbosestream << "Server::ProcessData(): Info: "
 				"Ignoring damage as player " << player->getName()

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -234,7 +234,13 @@ int ObjectRef::l_set_hp(lua_State *L)
 		return 0;
 
 	// Get HP
+	int old_hp = co->getHP();
 	int hp = lua_tonumber(L, 2);
+
+	// Protect from damage if immortal
+	if ((itemgroup_get(co->getArmorGroups(), "immortal") == 1) && (hp < old_hp)) {
+		return 0;
+	}
 
 	// Get Reason
 	PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);


### PR DESCRIPTION
Implements #2719. 

Currently, players ignore the `immortal` group. This PR changes this.

Specifically, this does the following:

For players that have the armor group `immortal=1` set:

* Will be immune to (hopefully) all damage
* Breath will never decrease
* Hides the builtin health and breath statbars (oddly delayed, might need review)

Tested for:
* fall damage
* punch damage
* `damage_per_second` node damage
* `drowning` node damage
* `set_hp` if new hp would be lower