### PR TITLE
Fix breath statbar scaling; defer breath_bar hiding by one second

### DIFF
--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -24,7 +24,7 @@ core.MAP_BLOCKSIZE = 16
 -- Default maximal HP of a player
 core.PLAYER_MAX_HP_DEFAULT = 20
 -- Default maximal breath of a player
-core.PLAYER_MAX_BREATH_DEFAULT = 11
+core.PLAYER_MAX_BREATH_DEFAULT = 10
 
 -- light.h
 -- Maximum value for node 'light_source' parameter

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -3,22 +3,22 @@ local enable_damage = core.settings:get_bool("enable_damage")
 
 local health_bar_definition = {
 	hud_elem_type = "statbar",
-	position = { x=0.5, y=1 },
+	position = {x = 0.5, y = 1},
 	text = "heart.png",
 	number = core.PLAYER_MAX_HP_DEFAULT,
 	direction = 0,
-	size = { x=24, y=24 },
-	offset = { x=(-10*24)-25, y=-(48+24+16)},
+	size = {x = 24, y = 24},
+	offset = {x = (-10 * 24) - 25, y = -(48 + 24 + 16)},
 }
 
 local breath_bar_definition = {
 	hud_elem_type = "statbar",
-	position = { x=0.5, y=1 },
+	position = {x = 0.5, y = 1},
 	text = "bubble.png",
 	number = core.PLAYER_MAX_BREATH_DEFAULT,
 	direction = 0,
-	size = { x=24, y=24 },
-	offset = {x=25,y=-(48+24+16)},
+	size = {x = 24, y = 24},
+	offset = {x = 25, y= -(48 + 24 + 16)},
 }
 
 local hud_ids = {}
@@ -26,7 +26,7 @@ local hud_ids = {}
 local function scaleToDefault(player, field)
 	-- Scale "hp" or "breath" to the default dimensions
 	local current = player["get_" .. field](player)
-	local nominal = core["PLAYER_MAX_".. field:upper() .. "_DEFAULT"]
+	local nominal = core["PLAYER_MAX_" .. field:upper() .. "_DEFAULT"]
 	local max_display = math.max(nominal,
 		math.max(player:get_properties()[field .. "_max"], current))
 	return current / max_display * nominal
@@ -49,6 +49,7 @@ local function update_builtin_statbars(player)
 	local hud = hud_ids[name]
 
 	local immortal = player:get_armor_groups().immortal == 1
+
 	if flags.healthbar and enable_damage and not immortal then
 		local number = scaleToDefault(player, "hp")
 		if hud.id_healthbar == nil then
@@ -63,19 +64,28 @@ local function update_builtin_statbars(player)
 		hud.id_healthbar = nil
 	end
 
+	local show_breathbar = flags.breathbar and enable_damage and not immortal
+
+	local breath     = player:get_breath()
 	local breath_max = player:get_properties().breath_max
-	if flags.breathbar and enable_damage and not immortal and
-			player:get_breath() < breath_max then
+	if show_breathbar and breath <= breath_max then
 		local number = 2 * scaleToDefault(player, "breath")
-		if hud.id_breathbar == nil then
+		if not hud.id_breathbar and breath < breath_max then
 			local hud_def = table.copy(breath_bar_definition)
 			hud_def.number = number
 			hud.id_breathbar = player:hud_add(hud_def)
-		else
+		elseif hud.id_breathbar then
 			player:hud_change(hud.id_breathbar, "number", number)
 		end
-	elseif hud.id_breathbar then
-		player:hud_remove(hud.id_breathbar)
+	end
+
+	if hud.id_breathbar and (not show_breathbar or breath == breath_max) then
+		minetest.after(1, function(player_name, breath_bar)
+			local player = minetest.get_player_by_name(player_name)
+			if player then
+				player:hud_remove(breath_bar)
+			end
+		end, name, hud.id_breathbar)
 		hud.id_breathbar = nil
 	end
 end

--- a/src/constants.h
+++ b/src/constants.h
@@ -93,7 +93,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define PLAYER_MAX_HP_DEFAULT 20
 
 // Default maximal breath of a player
-#define PLAYER_MAX_BREATH_DEFAULT 11
+#define PLAYER_MAX_BREATH_DEFAULT 10
 
 // Number of different files to try to save a player to if the first fails
 // (because of a case-insensitive filesystem)


### PR DESCRIPTION
`PLAYER_MAX_BREATH_DEFAULT` is set to 11 instead of 10, probably so that all 10 bubbles are shown before the breath bar disappears. See https://github.com/minetest/minetest/issues/8210#issuecomment-465919487 for more details.

This PR sets `PLAYER_MAX_BREATH_DEFAULT` to 10, and hides the breath bar after a delay of one second, so that all 10 bubbles are visible.

Fixes #8210. Tested.

To test:

- Start losing breath in a drown-able liquid
- Regain breath
- Observe that all 10 bubbles are shown, before the breath bar disappears a second later