### PR TITLE
Fix typo in automatic forward setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -244,7 +244,7 @@ keymap_decrease_volume (Dec. volume key) key
 
 #    Key for toggling autoforward.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3
-keymap_autoforward (Automatic forwards key) key
+keymap_autoforward (Automatic forward key) key
 
 #    Key for toggling cinematic mode.
 #    See http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2178,9 +2178,9 @@ void Game::toggleAutoforward()
 	g_settings->set("continuous_forward", bool_to_cstr(autorun_enabled));
 
 	if (autorun_enabled)
-		m_game_ui->showTranslatedStatusText("Automatic forwards enabled");
+		m_game_ui->showTranslatedStatusText("Automatic forward enabled");
 	else
-		m_game_ui->showTranslatedStatusText("Automatic forwards disabled");
+		m_game_ui->showTranslatedStatusText("Automatic forward disabled");
 }
 
 void Game::toggleMinimap(bool shift_pressed)

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -98,7 +98,7 @@ fake_function() {
 	gettext("Key for increasing the volume.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Dec. volume key");
 	gettext("Key for decreasing the volume.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
-	gettext("Automatic forwards key");
+	gettext("Automatic forward key");
 	gettext("Key for toggling autoforward.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");
 	gettext("Cinematic mode key");
 	gettext("Key for toggling cinematic mode.\nSee http://irrlicht.sourceforge.net/docu/namespaceirr.html#a54da2a0e231901735e3da1b0edf72eb3");


### PR DESCRIPTION
This PR removes an extra `s` from `Automatic forwards`.

I'm still not quite familiar with translations, so do let me know if I did something wrong.

Tested - works in English.