### PR TITLE
Attend to LINT sillyness

### DIFF
--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -282,10 +282,8 @@ bool Address::isLocalhost() const
 
 		auto addr = m_address.ipv6.sin6_addr.s6_addr;
 
-// clang-format off
 		return memcmp(addr, localhost_bytes, 16) == 0 ||
 			memcmp(addr, mapped_ipv4_localhost, 13) == 0;
-// clang-format on
 	}
 
 	return (m_address.ipv4.sin_addr.s_addr & 0xFF) == 0x7f;

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -256,6 +256,7 @@ src/minimap.cpp
 src/minimap.h
 src/mods.cpp
 src/mods.h
+src/network/address.cpp
 src/network/clientopcodes.cpp
 src/network/clientopcodes.h
 src/network/clientpackethandler.cpp


### PR DESCRIPTION
Builds are 'failing' because LINT is complaining about the formatting of the lines telling it to not complain about formatting. FFS.
```
<_<

>_>
```