### PR TITLE
Update minetest.conf.example and settings_translation_file.cpp

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -1072,7 +1072,8 @@ function create_adv_settings_dlg()
 				return dlg
 end
 
--- Uncomment to generate minetest.conf.example and settings_translation_file.cpp
--- For RUN_IN_PLACE the generated files may appear in the bin folder
+-- Uncomment to generate 'minetest.conf.example' and 'settings_translation_file.cpp'.
+-- For RUN_IN_PLACE the generated files may appear in the 'bin' folder.
+-- See comment and alternative line at the end of 'generate_from_settingtypes.lua'.
 
 --assert(loadfile(core.get_builtin_path().."mainmenu"..DIR_DELIM.."generate_from_settingtypes.lua"))(parse_config_file(true, false))

--- a/builtin/mainmenu/generate_from_settingtypes.lua
+++ b/builtin/mainmenu/generate_from_settingtypes.lua
@@ -121,6 +121,9 @@ file:write(create_minetest_conf_example())
 file:close()
 
 file = assert(io.open("src/settings_translation_file.cpp", "w"))
+-- If 'minetest.conf.example' appears in the 'bin' folder, the line below may have to be
+-- used instead. The file will also appear in the 'bin' folder.
+--file = assert(io.open("settings_translation_file.cpp", "w"))
 file:write(create_translation_file())
 file:close()
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1630,7 +1630,7 @@
 #    Name of map generator to be used when creating a new world.
 #    Creating a world in the main menu will override this.
 #    Current stable mapgens:
-#    v5, v6, v7 (except floatlands), flat, singlenode.
+#    v5, v6, v7 (except floatlands), singlenode.
 #    'stable' means the terrain shape in an existing world will not be changed
 #    in the future. Note that biomes are defined by games and may still change.
 #    type: enum values: v5, v6, v7, valleys, carpathian, fractal, flat, singlenode
@@ -1653,8 +1653,6 @@
 #    Global map generation attributes.
 #    In Mapgen v6 the 'decorations' flag controls all decorations except trees
 #    and junglegrass, in all other mapgens this flag controls all decorations.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: caves, dungeons, light, decorations, biomes, nocaves, nodungeons, nolight, nodecorations, nobiomes
 # mg_flags = caves,dungeons,light,decorations,biomes
 
@@ -1719,8 +1717,6 @@
 ## Mapgen V5
 
 #    Map generation attributes specific to Mapgen v5.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: caverns, nocaverns
 # mgv5_spflags = caverns
 
@@ -1856,8 +1852,6 @@
 #    The 'snowbiomes' flag enables the new 5 biome system.
 #    When the new biome system is enabled jungles are automatically enabled and
 #    the 'jungles' flag is ignored.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: jungles, biomeblend, mudflow, snowbiomes, flat, trees, nojungles, nobiomeblend, nomudflow, nosnowbiomes, noflat, notrees
 # mgv6_spflags = jungles,biomeblend,mudflow,snowbiomes,trees
 
@@ -2027,8 +2021,6 @@
 
 #    Map generation attributes specific to Mapgen v7.
 #    'ridges' enables the rivers.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: mountains, ridges, floatlands, caverns, nomountains, noridges, nofloatlands, nocaverns
 # mgv7_spflags = mountains,ridges,nofloatlands,caverns
 
@@ -2279,8 +2271,6 @@
 ## Mapgen Carpathian
 
 #    Map generation attributes specific to Mapgen Carpathian.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: caverns, nocaverns
 # mgcarpathian_spflags = caverns
 
@@ -2521,8 +2511,6 @@
 
 #    Map generation attributes specific to Mapgen flat.
 #    Occasional lakes and hills can be added to the flat world.
-#    Flags that are not enabled are not modified from the default.
-#    Flags starting with 'no' are used to explicitly disable them.
 #    type: flags possible values: lakes, hills, nolakes, nohills
 # mgflat_spflags = nolakes,nohills
 

--- a/src/settings_translation_file.cpp
+++ b/src/settings_translation_file.cpp
@@ -657,7 +657,7 @@ fake_function() {
 	gettext("Print the engine's profiling data in regular intervals (in seconds).\n0 = disable. Useful for developers.");
 	gettext("Mapgen");
 	gettext("Mapgen name");
-	gettext("Name of map generator to be used when creating a new world.\nCreating a world in the main menu will override this.\nCurrent stable mapgens:\nv5, v6, v7 (except floatlands), flat, singlenode.\n'stable' means the terrain shape in an existing world will not be changed\nin the future. Note that biomes are defined by games and may still change.");
+	gettext("Name of map generator to be used when creating a new world.\nCreating a world in the main menu will override this.\nCurrent stable mapgens:\nv5, v6, v7 (except floatlands), singlenode.\n'stable' means the terrain shape in an existing world will not be changed\nin the future. Note that biomes are defined by games and may still change.");
 	gettext("Water level");
 	gettext("Water surface level of the world.");
 	gettext("Max block generate distance");
@@ -665,7 +665,7 @@ fake_function() {
 	gettext("Map generation limit");
 	gettext("Limit of map generation, in nodes, in all 6 directions from (0, 0, 0).\nOnly mapchunks completely within the mapgen limit are generated.\nValue is stored per-world.");
 	gettext("Mapgen flags");
-	gettext("Global map generation attributes.\nIn Mapgen v6 the 'decorations' flag controls all decorations except trees\nand junglegrass, in all other mapgens this flag controls all decorations.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Global map generation attributes.\nIn Mapgen v6 the 'decorations' flag controls all decorations except trees\nand junglegrass, in all other mapgens this flag controls all decorations.");
 	gettext("Projecting dungeons");
 	gettext("Whether dungeons occasionally project from the terrain.");
 	gettext("Biome API temperature and humidity noise parameters");
@@ -679,7 +679,7 @@ fake_function() {
 	gettext("Small-scale humidity variation for blending biomes on borders.");
 	gettext("Mapgen V5");
 	gettext("Mapgen V5 specific flags");
-	gettext("Map generation attributes specific to Mapgen v5.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen v5.");
 	gettext("Cave width");
 	gettext("Controls width of tunnels, a smaller value creates wider tunnels.");
 	gettext("Large cave depth");
@@ -713,7 +713,7 @@ fake_function() {
 	gettext("3D noise defining terrain.");
 	gettext("Mapgen V6");
 	gettext("Mapgen V6 specific flags");
-	gettext("Map generation attributes specific to Mapgen v6.\nThe 'snowbiomes' flag enables the new 5 biome system.\nWhen the new biome system is enabled jungles are automatically enabled and\nthe 'jungles' flag is ignored.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen v6.\nThe 'snowbiomes' flag enables the new 5 biome system.\nWhen the new biome system is enabled jungles are automatically enabled and\nthe 'jungles' flag is ignored.");
 	gettext("Desert noise threshold");
 	gettext("Deserts occur when np_biome exceeds this value.\nWhen the new biome system is enabled, this is ignored.");
 	gettext("Beach noise threshold");
@@ -747,7 +747,7 @@ fake_function() {
 	gettext("Defines areas where trees have apples.");
 	gettext("Mapgen V7");
 	gettext("Mapgen V7 specific flags");
-	gettext("Map generation attributes specific to Mapgen v7.\n'ridges' enables the rivers.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen v7.\n'ridges' enables the rivers.");
 	gettext("Mountain zero level");
 	gettext("Y of mountain density gradient zero level. Used to shift mountains vertically.");
 	gettext("Cave width");
@@ -807,7 +807,7 @@ fake_function() {
 	gettext("Second of two 3D noises that together define tunnels.");
 	gettext("Mapgen Carpathian");
 	gettext("Mapgen Carpathian specific flags");
-	gettext("Map generation attributes specific to Mapgen Carpathian.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen Carpathian.");
 	gettext("Base ground level");
 	gettext("Defines the base ground level.");
 	gettext("Cave width");
@@ -859,7 +859,7 @@ fake_function() {
 	gettext("3D noise defining giant caverns.");
 	gettext("Mapgen Flat");
 	gettext("Mapgen Flat specific flags");
-	gettext("Map generation attributes specific to Mapgen flat.\nOccasional lakes and hills can be added to the flat world.\nFlags that are not enabled are not modified from the default.\nFlags starting with 'no' are used to explicitly disable them.");
+	gettext("Map generation attributes specific to Mapgen flat.\nOccasional lakes and hills can be added to the flat world.");
 	gettext("Ground level");
 	gettext("Y of flat ground.");
 	gettext("Large cave depth");


### PR DESCRIPTION
Attends to #8231 but don't close that issue in case further updates to minetest.conf.example become needed.

Updates files due to recent changes.
Also some improvements to comments and helpful comments related to auto-generation of these files.

I suggest a translation string freeze starts now.