### PR TITLE
Fix particle spawners not visible since CSM spawner implementation

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -565,9 +565,6 @@ private:
 	// And relations to objects
 	std::unordered_map<int, u16> m_sounds_to_objects;
 
-	// CSM/client IDs to SSM/server IDs Mapping
-	// Map server particle spawner IDs to client IDs
-	std::unordered_map<u32, u32> m_particles_server_to_client;
 	// Map server hud ids to client hud ids
 	std::unordered_map<u32, u32> m_hud_server_to_client;
 

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -108,7 +108,7 @@ struct ClientEvent
 			u16 attached_id;
 			bool vertical;
 			std::string *texture;
-			u32 id;
+			u64 id;
 			struct TileAnimationParams animation;
 			u8 glow;
 		} add_particlespawner;

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -261,7 +261,6 @@ ParticleSpawner::ParticleSpawner(
 	u16 attached_id,
 	bool vertical,
 	video::ITexture *texture,
-	u32 id,
 	const struct TileAnimationParams &anim,
 	u8 glow,
 	ParticleManager *p_manager
@@ -423,17 +422,11 @@ void ParticleManager::step(float dtime)
 void ParticleManager::stepSpawners (float dtime)
 {
 	MutexAutoLock lock(m_spawner_list_lock);
-	for (std::map<u32, ParticleSpawner*>::iterator i =
-			m_particle_spawners.begin();
-			i != m_particle_spawners.end();)
-	{
-		if (i->second->get_expired())
-		{
+	for (auto i = m_particle_spawners.begin(); i != m_particle_spawners.end();) {
+		if (i->second->get_expired()) {
 			delete i->second;
 			m_particle_spawners.erase(i++);
-		}
-		else
-		{
+		} else {
 			i->second->step(dtime, m_env);
 			++i;
 		}
@@ -443,17 +436,12 @@ void ParticleManager::stepSpawners (float dtime)
 void ParticleManager::stepParticles (float dtime)
 {
 	MutexAutoLock lock(m_particle_list_lock);
-	for(std::vector<Particle*>::iterator i = m_particles.begin();
-			i != m_particles.end();)
-	{
-		if ((*i)->get_expired())
-		{
+	for (auto i = m_particles.begin(); i != m_particles.end();) {
+		if ((*i)->get_expired()) {
 			(*i)->remove();
 			delete *i;
 			i = m_particles.erase(i);
-		}
-		else
-		{
+		} else {
 			(*i)->step(dtime);
 			++i;
 		}
@@ -464,10 +452,7 @@ void ParticleManager::clearAll ()
 {
 	MutexAutoLock lock(m_spawner_list_lock);
 	MutexAutoLock lock2(m_particle_list_lock);
-	for(std::map<u32, ParticleSpawner*>::iterator i =
-			m_particle_spawners.begin();
-			i != m_particle_spawners.end();)
-	{
+	for (auto i = m_particle_spawners.begin(); i != m_particle_spawners.end();) {
 		delete i->second;
 		m_particle_spawners.erase(i++);
 	}
@@ -509,7 +494,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 			video::ITexture *texture =
 				client->tsrc()->getTextureForMesh(*(event->add_particlespawner.texture));
 
-			ParticleSpawner *toadd = new ParticleSpawner(client, player,
+			auto toadd = new ParticleSpawner(client, player,
 					event->add_particlespawner.amount,
 					event->add_particlespawner.spawntime,
 					*event->add_particlespawner.minpos,
@@ -528,7 +513,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 					event->add_particlespawner.attached_id,
 					event->add_particlespawner.vertical,
 					texture,
-					event->add_particlespawner.id,
 					event->add_particlespawner.animation,
 					event->add_particlespawner.glow,
 					this);
@@ -544,10 +528,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 
 			{
 				MutexAutoLock lock(m_spawner_list_lock);
-				m_particle_spawners.insert(
-						std::pair<u32, ParticleSpawner*>(
-								event->add_particlespawner.id,
-								toadd));
+				m_particle_spawners[event->add_particlespawner.id] = toadd;
 			}
 			break;
 		}

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -132,7 +132,6 @@ public:
 		u16 attached_id,
 		bool vertical,
 		video::ITexture *texture,
-		u32 id,
 		const struct TileAnimationParams &anim, u8 glow,
 		ParticleManager* p_manager);
 
@@ -196,12 +195,16 @@ public:
 	void addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
 		const MapNode &n, const ContentFeatures &f);
 
-	u32 getSpawnerId() const
+	/**
+	 * This function is only used by client particle spawners
+	 *
+	 * We don't need to check the particle spawner list because client ID will n
+	 * ever overlap (u64)
+	 * @return new id
+	 */
+	u64 generateSpawnerId()
 	{
-		for (u32 id = 0;; ++id) { // look for unused particlespawner id
-	 		if (m_particle_spawners.find(id) == m_particle_spawners.end())
-	 			return id;
-	 	}
+		return m_next_particle_spawner_id++;
 	}
 
 protected:
@@ -209,13 +212,16 @@ protected:
 
 private:
 
-	void stepParticles (float dtime);
-	void stepSpawners (float dtime);
+	void stepParticles(float dtime);
+	void stepSpawners(float dtime);
 
-	void clearAll ();
+	void clearAll();
 
 	std::vector<Particle*> m_particles;
-	std::map<u32, ParticleSpawner*> m_particle_spawners;
+	std::unordered_map<u64, ParticleSpawner*> m_particle_spawners;
+	// Start the particle spawner ids generated from here after u32_max. lower values are
+	// for server sent spawners.
+	u64 m_next_particle_spawner_id = U32_MAX + 1;
 
 	ClientEnvironment* m_env;
 	std::mutex m_particle_list_lock;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1007,10 +1007,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 		object_collision = readU8(is);
 	} catch (...) {}
 
-	u32 client_id = m_particle_manager.getSpawnerId();
-	m_particles_server_to_client[server_id] = client_id;
-
-	ClientEvent *event = new ClientEvent();
+	auto event = new ClientEvent();
 	event->type                                   = CE_ADD_PARTICLESPAWNER;
 	event->add_particlespawner.amount             = amount;
 	event->add_particlespawner.spawntime          = spawntime;
@@ -1030,7 +1027,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	event->add_particlespawner.attached_id        = attached_id;
 	event->add_particlespawner.vertical           = vertical;
 	event->add_particlespawner.texture            = new std::string(texture);
-	event->add_particlespawner.id                 = client_id;
+	event->add_particlespawner.id                 = server_id;
 	event->add_particlespawner.animation          = animation;
 	event->add_particlespawner.glow               = glow;
 
@@ -1043,16 +1040,9 @@ void Client::handleCommand_DeleteParticleSpawner(NetworkPacket* pkt)
 	u32 server_id;
 	*pkt >> server_id;
 
-	u32 client_id;
-	auto i = m_particles_server_to_client.find(server_id);
-	if (i != m_particles_server_to_client.end())
-		client_id = i->second;
-	else
-		return;
-
 	ClientEvent *event = new ClientEvent();
 	event->type = CE_DELETE_PARTICLESPAWNER;
-	event->delete_particlespawner.id = client_id;
+	event->delete_particlespawner.id = server_id;
 
 	m_client_event_queue.push(event);
 }

--- a/src/script/lua_api/l_particles_local.cpp
+++ b/src/script/lua_api/l_particles_local.cpp
@@ -154,9 +154,9 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 	texture = getstringfield_default(L, 1, "texture", "");
 	glow = getintfield_default(L, 1, "glow", 0);
 
-	u32 id = getClient(L)->getParticleManager()->getSpawnerId();
+	u64 id = getClient(L)->getParticleManager()->generateSpawnerId();
 
-	ClientEvent *event = new ClientEvent();
+	auto event = new ClientEvent();
 	event->type                                   = CE_ADD_PARTICLESPAWNER;
 	event->add_particlespawner.amount             = amount;
 	event->add_particlespawner.spawntime          = time;


### PR DESCRIPTION
* Drop the ID mapper, use a big u64 instead. This will permit to resync server ids properly with the manager code
* Modernize some code parts (std::unordered_map, auto)
* generate id on client part on U32_MAX + 1 ids, lower are for server ids