### PR TITLE
Make FindCURL ready for vcpkg

### DIFF
--- a/cmake/Modules/FindCURL.cmake
+++ b/cmake/Modules/FindCURL.cmake
@@ -1,19 +1,16 @@
 mark_as_advanced(CURL_LIBRARY CURL_INCLUDE_DIR)
 
-find_library(CURL_LIBRARY NAMES curl)
+find_library(CURL_LIBRARY NAMES curl libcurl)
 find_path(CURL_INCLUDE_DIR NAMES curl/curl.h)
 
-set(CURL_REQUIRED_VARS CURL_LIBRARY CURL_INCLUDE_DIR)
-
 if(WIN32)
-	find_file(CURL_DLL NAMES libcurl-4.dll
-		PATHS
-		"C:/Windows/System32"
-		DOC "Path to the cURL DLL (for installation)")
-	mark_as_advanced(CURL_DLL)
-	set(CURL_REQUIRED_VARS ${CURL_REQUIRED_VARS} CURL_DLL)
+	# If VCPKG_APPLOCAL_DEPS is ON, dll's are automatically handled by VCPKG
+	if(NOT VCPKG_APPLOCAL_DEPS)
+		find_file(CURL_DLL NAMES libcurl-4.dll libcurl.dll
+			DOC "Path to the cURL DLL (for installation)")
+		mark_as_advanced(CURL_DLL)
+	endif()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CURL DEFAULT_MSG ${CURL_REQUIRED_VARS})
-
+find_package_handle_standard_args(CURL DEFAULT_MSG CURL_LIBRARY CURL_INCLUDE_DIR)


### PR DESCRIPTION
This allows to find and use curl with the vcpkg toolchain file.

There will be another PR regarding vcpkg on Windows, but this is kind of urgent: Never ever copy a file out of the Windows directory and redistribute them!
That might not work from technical aspects (x32 vs x64), it is also very questionable in terms of license.

Last but not least: This also allows to build Minetest on windows with a static linked version of curl.