### PR TITLE
Report missing inventory

### DIFF
--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -160,12 +160,14 @@ int InvRef::l_set_width(lua_State *L)
 	int newwidth = luaL_checknumber(L, 3);
 	Inventory *inv = getinv(L, ref);
 	if(inv == NULL){
+		errorstream << "Can't set width of list \"" << listname << "\" in non-existent inventory at " << ref->m_loc.dump() << std::endl;
 		return 0;
 	}
 	InventoryList *list = inv->getList(listname);
 	if(list){
 		list->setWidth(newwidth);
 	} else {
+		errorstream << "Can't set width of non-existing list \"" << listname << "\" in inventory at " << ref->m_loc.dump() << std::endl;
 		return 0;
 	}
 	reportInventoryChange(L, ref);
@@ -229,6 +231,7 @@ int InvRef::l_set_list(lua_State *L)
 	const char *listname = luaL_checkstring(L, 2);
 	Inventory *inv = getinv(L, ref);
 	if(inv == NULL){
+		errorstream << "Can't set list \"" << listname << "\" in non-existent inventory at " << ref->m_loc.dump() << std::endl;
 		return 0;
 	}
 	InventoryList *list = inv->getList(listname);
@@ -269,6 +272,7 @@ int InvRef::l_set_lists(lua_State *L)
 	InvRef *ref = checkobject(L, 1);
 	Inventory *inv = getinv(L, ref);
 	if (!inv) {
+		errorstream << "Can't set lists in non-existent inventory at " << ref->m_loc.dump() << std::endl;
 		return 0;
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1211,19 +1211,25 @@ Inventory* Server::getInventory(const InventoryLocation &loc)
 	case InventoryLocation::PLAYER:
 	{
 		RemotePlayer *player = m_env->getPlayer(loc.name.c_str());
-		if(!player)
+		if(!player) {
+			warningstream << "Can't get inventory of player " << loc.name << ": player not connected" << std::endl;
 			return NULL;
+		}
 		PlayerSAO *playersao = player->getPlayerSAO();
-		if(!playersao)
+		if(!playersao) {
+			errorstream << "Can't get inventory of player " << loc.name << ": PlayerSAO is absent" << std::endl;
 			return NULL;
+		}
 		return playersao->getInventory();
 	}
 		break;
 	case InventoryLocation::NODEMETA:
 	{
 		NodeMetadata *meta = m_env->getMap().getNodeMetadata(loc.p);
-		if(!meta)
+		if(!meta) {
+			errorstream << "Can't get node inventory at " << PP(loc.p) << ": meta doesn't exist" << std::endl;
 			return NULL;
+		}
 		return meta->getInventory();
 	}
 		break;


### PR DESCRIPTION
This PR is mainly intended to debug #8067

BTW it might be good to really do what a comment at `l_inventory.cpp:279` says:
```c++
	// Make a temporary inventory in case reading fails
	Inventory *tempInv(inv);
	tempInv->clear();
```
As you can see, only pointer is copied there instead of the actual inventory.