### PR TITLE
Change 'num_emerge_threads' default to 1

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1925,7 +1925,7 @@ emergequeue_limit_generate (Limit of emerge queues to generate) int 64
 #    processes, especially in singleplayer and/or when running Lua code in
 #    'on_generated'.
 #    For many users the optimum setting may be '1'.
-num_emerge_threads (Number of emerge threads) int 0
+num_emerge_threads (Number of emerge threads) int 1
 
 [Online Content Repository]
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3005,7 +3005,7 @@
 #    'on_generated'.
 #    For many users the optimum setting may be '1'.
 #    type: int
-# num_emerge_threads = 0
+# num_emerge_threads = 1
 
 #
 # Online Content Repository

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -374,7 +374,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");
-	settings->setDefault("num_emerge_threads", "0");
+	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");
 	settings->setDefault("secure.http_mods", "");


### PR DESCRIPTION
Not necessarily a blocker but high priority and i feel should be considered for release as is a trivial settings change.
conf.example is also updated in the PR so no need to autoregenerate that.
```
#    Number of emerge threads to use.
#    Empty or 0 value:
#    -    Automatic selection. The number of emerge threads will be
#    -    'number of processors - 2', with a lower limit of 1.
#    Any other value:
#    -    Specifies the number of emerge threads, with a lower limit of 1.
#    Warning: Increasing the number of emerge threads increases engine mapgen
#    speed, but this may harm game performance by interfering with other
#    processes, especially in singleplayer and/or when running Lua code in
#    'on_generated'.
#    For many users the optimum setting may be '1'.
num_emerge_threads (Number of emerge threads) int 0
```
See https://github.com/minetest/minetest/issues/8300#issuecomment-468813838 onwards:

nerzhul:
"sqlite is not thread safe you must not use emerge > 1"

paramat:
"Seems to me the default of 'num_emerge_threads' should be 1. Currently being 0 there is automatic selection, which for many users means 4 - 2 = 2, even though 1 is optimum for many users, 1 is the safest option, and some are using sqlite.
For example i have been using automatic and therefore 2 for years, and using sqlite, not knowing there is a problem with this."

Therefore the default of automatic selection is likely to be causing problems or even bugs for many users. We learned that for many users the optimum is 1, and some users use sqlite world database, where 'num_emerge_threads' must be 1 (this will be documented after release).

See this related PR with links to more information about what effects the setting has #8066 