### PR TITLE
getS16NoEx() returns true unless syntactical error in conf.

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -130,11 +130,13 @@ EmergeManager::EmergeManager(Server *server)
 
 	// If unspecified, leave a proc for the main thread and one for
 	// some other misc thread
-	s16 nthreads = 0;
-	if (!g_settings->getS16NoEx("num_emerge_threads", nthreads))
+	s16 nthreads;
+	g_settings->getS16NoEx("num_emerge_threads", nthreads);
+	if (nthreads == 0)
 		nthreads = Thread::getNumberOfProcessors() - 2;
 	if (nthreads < 1)
 		nthreads = 1;
+	verbosestream << "Using " << nthreads << " emerge threads." << std::endl;
 
 	m_qlimit_total = g_settings->getU16("emergequeue_limit_total");
 	if (!g_settings->getU16NoEx("emergequeue_limit_diskonly", m_qlimit_diskonly))


### PR DESCRIPTION
The getS16NoEx() handler will return true unless there is a
`[num_emerge_threads]` line in the `minetest.conf` at which
point the excption handler part is reached. Due to the fact that
`defaultsettings.cpp` has a default value set for this setting,
that never will happen.

Because of this, the code will never check the number of threads on
the system, and keep `nthreads = 0`. If that happens, the value is
changed to `1` and only 1 emerge thread will be used.

The default should be set to `1` instead, due to the potential unsafe
consequences for the standard sqlite map files, but that should be a
separate commit that also adds documentation for that setting. This
commit focuses on removing this `hiding` bug instead.