### PR TITLE
Display pitch angle in debug menu

### DIFF
--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -128,6 +128,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< ", " << (player_position.Z / BS)
 			<< "), yaw: " << (wrapDegrees_0_360(cam.camera_yaw)) << "° "
 			<< yawToDirectionString(cam.camera_yaw)
+			<< ", pitch: " << (wrapDegrees_180(cam.camera_pitch)) << "°"
 			<< ", seed: " << ((u64)client->getMapSeed());
 
 		if (pointed_old.type == POINTEDTHING_NODE) {


### PR DESCRIPTION
Since pitch-fly was added, it makes sense that the pitch angle is added to the debug menu.

EDIT: [Demonstration](https://youtu.be/S4KyCDlLIVw)