### PR TITLE
Fix definitively string serialization coding problems

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -945,7 +945,7 @@ void Client::interact(u8 action, const PointedThing& pointed)
 	std::ostringstream tmp_os(std::ios::binary);
 	pointed.serialize(tmp_os);
 
-	pkt.putLongString(tmp_os.str());
+	pkt << tmp_os.str();
 
 	writePlayerPos(myplayer, &m_env.getClientMap(), &pkt);
 
@@ -1111,8 +1111,7 @@ void Client::sendNodemetaFields(v3s16 p, const std::string &formname,
 	for (it = fields.begin(); it != fields.end(); ++it) {
 		const std::string &name = it->first;
 		const std::string &value = it->second;
-		pkt << name;
-		pkt.putLongString(value);
+		pkt << name << value;
 	}
 
 	Send(&pkt);
@@ -1131,8 +1130,7 @@ void Client::sendInventoryFields(const std::string &formname,
 	for (it = fields.begin(); it != fields.end(); ++it) {
 		const std::string &name  = it->first;
 		const std::string &value = it->second;
-		pkt << name;
-		pkt.putLongString(value);
+		pkt << name << value;
 	}
 
 	Send(&pkt);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1230,9 +1230,8 @@ void Client::sendReady()
 			1 + 1 + 1 + 1 + 2 + sizeof(char) * strlen(g_version_hash));
 
 	pkt << (u8) VERSION_MAJOR << (u8) VERSION_MINOR << (u8) VERSION_PATCH
-		<< (u8) 0 << (u16) strlen(g_version_hash);
+		<< (u8) 0 << std::string(g_version_hash);
 
-	pkt.putRawString(g_version_hash, (u16) strlen(g_version_hash));
 	Send(&pkt);
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -251,7 +251,9 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 	if (pkt->getSize() < 1)
 		return;
 
-	std::istringstream is(pkt->readLongString(), std::ios::binary);
+	std::string data;
+	*pkt >> data;
+	std::istringstream is(data, std::ios::binary);
 	std::stringstream sstr;
 	decompressZlib(is, sstr);
 
@@ -454,8 +456,9 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		*pkt >> added_count;
 
 		for (u16 i = 0; i < added_count; i++) {
-			*pkt >> id >> type;
-			m_env.addActiveObject(id, type, pkt->readLongString());
+			std::string ao_data;
+			*pkt >> id >> type >> ao_data;
+			m_env.addActiveObject(id, type, ao_data);
 		}
 	} catch (PacketError &e) {
 		infostream << "handleCommand_ActiveObjectRemoveAdd: " << e.what()
@@ -700,14 +703,11 @@ void Client::handleCommand_Media(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_thread.isRunning());
 
 	for (u32 i=0; i < num_files; i++) {
-		std::string name;
+		std::string name, data;
 
-		*pkt >> name;
+		*pkt >> name >> data;
 
-		std::string data = pkt->readLongString();
-
-		m_media_downloader->conventionalTransferDone(
-				name, data, this);
+		m_media_downloader->conventionalTransferDone(name, data, this);
 	}
 }
 
@@ -721,7 +721,9 @@ void Client::handleCommand_NodeDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_thread.isRunning());
 
 	// Decompress node definitions
-	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
+	std::string data;
+	*pkt >> data;
+	std::istringstream tmp_is(data, std::ios::binary);
 	std::ostringstream tmp_os;
 	decompressZlib(tmp_is, tmp_os);
 
@@ -741,7 +743,9 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 	sanity_check(!m_mesh_update_thread.isRunning());
 
 	// Decompress item definitions
-	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
+	std::string data;
+	*pkt >> data;
+	std::istringstream tmp_is(data, std::ios::binary);
 	std::ostringstream tmp_os;
 	decompressZlib(tmp_is, tmp_os);
 
@@ -867,7 +871,7 @@ void Client::handleCommand_InventoryFormSpec(NetworkPacket* pkt)
 	assert(player != NULL);
 
 	// Store formspec in LocalPlayer
-	player->inventory_formspec = pkt->readLongString();
+	*pkt >> player->inventory_formspec;
 }
 
 void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
@@ -903,10 +907,10 @@ void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
 
 void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
 {
-	std::string formspec = pkt->readLongString();
+	std::string formspec;
 	std::string formname;
 
-	*pkt >> formname;
+	*pkt >> formspec >> formname;
 
 	ClientEvent *event = new ClientEvent();
 	event->type = CE_SHOW_FORMSPEC;
@@ -978,14 +982,11 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	float maxsize;
 	bool collisiondetection;
 	u32 server_id;
+	std::string texture;
 
 	*pkt >> amount >> spawntime >> minpos >> maxpos >> minvel >> maxvel
 		>> minacc >> maxacc >> minexptime >> maxexptime >> minsize
-		>> maxsize >> collisiondetection;
-
-	std::string texture = pkt->readLongString();
-
-	*pkt >> server_id;
+		>> maxsize >> collisiondetection >> texture >> server_id;
 
 	bool vertical          = false;
 	bool collision_removal = false;

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -45,7 +45,8 @@ void NetworkPacket::checkReadOffset(u32 from_offset, u32 field_size)
 	if (from_offset + field_size > m_datasize) {
 		std::stringstream ss;
 		ss << "Reading outside packet (offset: " <<
-				from_offset << ", packet size: " << getSize() << ")";
+				from_offset << ", field_size: " << field_size <<
+				"packet size: " << m_datasize << ")";
 		throw PacketError(ss.str());
 	}
 }
@@ -89,9 +90,9 @@ void NetworkPacket::putRawString(const char* src, u32 len)
 
 NetworkPacket& NetworkPacket::operator>>(std::string& dst)
 {
-	checkReadOffset(m_read_offset, sizeof(u32));
+	checkReadOffset(m_read_offset, 4);
 	u32 strLen = readU32(&m_data[m_read_offset]);
-	m_read_offset += sizeof(u32);
+	m_read_offset += 4;
 
 	dst.clear();
 
@@ -124,9 +125,9 @@ NetworkPacket& NetworkPacket::operator<<(const std::string &src)
 
 NetworkPacket& NetworkPacket::operator>>(std::wstring& dst)
 {
-	checkReadOffset(m_read_offset, sizeof(u32));
+	checkReadOffset(m_read_offset, 4);
 	u32 strLen = readU32(&m_data[m_read_offset]);
-	m_read_offset += sizeof(u32);
+	m_read_offset += 4;
 
 	dst.clear();
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -57,12 +57,8 @@ public:
 	NetworkPacket &operator>>(std::string &dst);
 	NetworkPacket &operator<<(const std::string &src);
 
-	void putLongString(const std::string &src);
-
 	NetworkPacket &operator>>(std::wstring &dst);
 	NetworkPacket &operator<<(const std::wstring &src);
-
-	std::string readLongString();
 
 	char getChar(u32 offset);
 	NetworkPacket &operator>>(char &dst);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1433,7 +1433,8 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 	StringMap fields;
 	for (u16 k = 0; k < num; k++) {
 		std::string fieldname;
-		*pkt >> fieldname >> fields[fieldname];
+		*pkt >> fieldname;
+		*pkt >> fields[fieldname];
 	}
 
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
@@ -1483,7 +1484,8 @@ void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
 	StringMap fields;
 	for (u16 k = 0; k < num; k++) {
 		std::string fieldname;
-		*pkt >> fieldname >> fields[fieldname];
+		*pkt >> fieldname;
+		*pkt >> fields[fieldname];
 	}
 
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1003,9 +1003,10 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 	*/
 	u8 action;
 	u16 item_i;
-	*pkt >> action;
-	*pkt >> item_i;
-	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
+	std::string data;
+	*pkt >> action >> item_i >> data;
+
+	std::istringstream tmp_is(data, std::ios::binary);
 	PointedThing pointed;
 	pointed.deSerialize(tmp_is);
 
@@ -1432,8 +1433,7 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 	StringMap fields;
 	for (u16 k = 0; k < num; k++) {
 		std::string fieldname;
-		*pkt >> fieldname;
-		fields[fieldname] = pkt->readLongString();
+		*pkt >> fieldname >> fields[fieldname];
 	}
 
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
@@ -1483,8 +1483,7 @@ void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
 	StringMap fields;
 	for (u16 k = 0; k < num; k++) {
 		std::string fieldname;
-		*pkt >> fieldname;
-		fields[fieldname] = pkt->readLongString();
+		*pkt >> fieldname >> fields[fieldname];
 	}
 
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1583,7 +1583,7 @@ void Server::SendShowFormspecMessage(session_t peer_id, const std::string &forms
 		if (it != m_formspec_state_data.end() && it->second == formname) {
 			m_formspec_state_data.erase(peer_id);
 		}
-		pkt << std::string();
+		pkt << "";
 	} else {
 		m_formspec_state_data[peer_id] = formname;
 		pkt << std::string(FORMSPEC_VERSION_STRING + formspec);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1498,7 +1498,7 @@ void Server::SendItemDef(session_t peer_id,
 	itemdef->serialize(tmp_os, protocol_version);
 	std::ostringstream tmp_os2(std::ios::binary);
 	compressZlib(tmp_os.str(), tmp_os2);
-	pkt.putLongString(tmp_os2.str());
+	pkt << tmp_os2.str();
 
 	// Make data buffer
 	verbosestream << "Server: Sending item definitions to id(" << peer_id
@@ -1522,7 +1522,7 @@ void Server::SendNodeDef(session_t peer_id,
 	std::ostringstream tmp_os2(std::ios::binary);
 	compressZlib(tmp_os.str(), tmp_os2);
 
-	pkt.putLongString(tmp_os2.str());
+	pkt << tmp_os2.str();
 
 	// Make data buffer
 	verbosestream << "Server: Sending node definitions to id(" << peer_id
@@ -1583,10 +1583,10 @@ void Server::SendShowFormspecMessage(session_t peer_id, const std::string &forms
 		if (it != m_formspec_state_data.end() && it->second == formname) {
 			m_formspec_state_data.erase(peer_id);
 		}
-		pkt.putLongString("");
+		pkt << std::string();
 	} else {
 		m_formspec_state_data[peer_id] = formname;
-		pkt.putLongString(FORMSPEC_VERSION_STRING + formspec);
+		pkt << std::string(FORMSPEC_VERSION_STRING + formspec);
 	}
 	pkt << formname;
 
@@ -1631,8 +1631,7 @@ void Server::SendSpawnParticle(session_t peer_id, u16 protocol_version,
 	NetworkPacket pkt(TOCLIENT_SPAWN_PARTICLE, 0, peer_id);
 
 	pkt << pos << velocity << acceleration << expirationtime
-			<< size << collisiondetection;
-	pkt.putLongString(texture);
+			<< size << collisiondetection << texture;
 	pkt << vertical;
 	pkt << collision_removal;
 	// This is horrible but required (why are there two ways to serialize pkts?)
@@ -1676,9 +1675,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 			<< minacc << maxacc << minexptime << maxexptime << minsize
 			<< maxsize << collisiondetection;
 
-	pkt.putLongString(texture);
-
-	pkt << id << vertical;
+	pkt << texture << id << vertical;
 	pkt << collision_removal;
 	pkt << attached_id;
 	// This is horrible but required
@@ -1915,7 +1912,7 @@ void Server::SendPlayerInventoryFormspec(session_t peer_id)
 		return;
 
 	NetworkPacket pkt(TOCLIENT_INVENTORY_FORMSPEC, 0, peer_id);
-	pkt.putLongString(FORMSPEC_VERSION_STRING + player->inventory_formspec);
+	pkt << std::string(FORMSPEC_VERSION_STRING + player->inventory_formspec);
 	Send(&pkt);
 }
 
@@ -2220,7 +2217,7 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 		compressZlib(os.str(), oss);
 
 		NetworkPacket pkt(TOCLIENT_NODEMETA_CHANGED, 0);
-		pkt.putLongString(oss.str());
+		pkt << oss.str();
 		m_clients.send(i, 0, &pkt, true);
 
 		meta_updates_list.clear();
@@ -2534,8 +2531,7 @@ void Server::sendRequestedMedia(session_t peer_id,
 		pkt << num_bunches << i << (u32) file_bunches[i].size();
 
 		for (const SendableMedia &j : file_bunches[i]) {
-			pkt << j.name;
-			pkt.putLongString(j.data);
+			pkt << j.name << j.data;
 		}
 
 		verbosestream << "Server::sendRequestedMedia(): bunch "

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -55,11 +55,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define F1000_MIN ((float)(s32)((-0x7FFFFFFF - 1) / FIXEDPOINT_FACTOR))
 #define F1000_MAX ((float)(s32)((0x7FFFFFFF) / FIXEDPOINT_FACTOR))
 
-#define STRING_MAX_LEN 0xFFFF
-#define WIDE_STRING_MAX_LEN 0xFFFF
-// 64 MB ought to be enough for anybody - Billy G.
-#define LONG_STRING_MAX_LEN (64 * 1024 * 1024)
-
+#define STRING_MAX_LEN (64 * 1024 * 1024)
+#define WIDE_STRING_MAX_LEN (64 * 1024 * 1024)
 
 extern FloatType g_serialize_f32_type;
 
@@ -290,7 +287,7 @@ inline void writeS8(u8 *data, s8 i)
 
 inline void writeS16(u8 *data, s16 i)
 {
-	writeU16(data, (u16)i); 
+	writeU16(data, (u16)i);
 }
 
 inline void writeS32(u8 *data, s32 i)
@@ -678,7 +675,7 @@ inline void putString(std::vector<u8> *dest, const std::string &val)
 	if (val.size() > STRING_MAX_LEN)
 		throw SerializationError("String too long");
 
-	putU16(dest, val.size());
+	putU32(dest, val.size());
 	dest->insert(dest->end(), val.begin(), val.end());
 }
 
@@ -687,21 +684,8 @@ inline void putWideString(std::vector<u8> *dest, const std::wstring &val)
 	if (val.size() > WIDE_STRING_MAX_LEN)
 		throw SerializationError("String too long");
 
-	putU16(dest, val.size());
+	putU32(dest, val.size());
 	for (size_t i = 0; i != val.size(); i++)
 		putU16(dest, val[i]);
 }
 
-inline void putLongString(std::vector<u8> *dest, const std::string &val)
-{
-	if (val.size() > LONG_STRING_MAX_LEN)
-		throw SerializationError("String too long");
-
-	putU32(dest, val.size());
-	dest->insert(dest->end(), val.begin(), val.end());
-}
-
-inline void putRawData(std::vector<u8> *dest, const void *src, size_t len)
-{
-	dest->insert(dest->end(), (u8 *)src, (u8 *)src + len);
-}


### PR DESCRIPTION
NetworkPacket strings are serialized in the same way for short and long, we use long method.

This has side effects the serialization code, short has been updated to use long too.