### PR TITLE
Fix detach inventory serialisation

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -895,8 +895,10 @@ void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
 		inv = inv_it->second;
 	}
 
-	std::string contents;
-	*pkt >> contents;
+	u16 ignore;
+	*pkt >> ignore; // this used to be the length of the following string, ignore it
+
+	std::string contents = pkt->getRemainingString();
 	std::istringstream is(contents, std::ios::binary);
 	inv->deSerialize(is);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2576,7 +2576,10 @@ void Server::sendDetachedInventory(const std::string &name, session_t peer_id)
 		// Serialization & NetworkPacket isn't a love story
 		std::ostringstream os(std::ios_base::binary);
 		inv_it->second->serialize(os);
-		pkt << os.str();
+
+		std::string os_str = os.str();
+		pkt << static_cast<u16>(os_str.size()); // HACK: to keep compatibility with 5.0.0 clients
+		pkt.putRawString(os_str);
 	}
 
 	if (peer_id == PEER_ID_INEXISTENT)


### PR DESCRIPTION
Fixes #8325

Please read the summary: https://github.com/minetest/minetest/pull/8331#issuecomment-470288892

Testing:

* Small inventories work
   - [x] 5.0.0 client, 5.0.1 server
   - [x] 5.0.1 client, 5.0.0 server
* Big inventories (>65536)
   - [x] 5.0.1 will work on 5.0.1 server
   - [x] 5.0.0 will crash on either server
   - [x] 5.0.1 will crash on 5.0.0 server (maybe?)