### PR TITLE
Correctly set visibility of local player's attached objects

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1531,8 +1531,11 @@ void GenericCAO::processMessage(const std::string &data)
 		setAttachment(parent_id, bone, position, rotation);
 
 		// localplayer itself can't be attached to localplayer
-		if (!m_is_local_player)
-			m_is_visible = !m_attached_to_local;
+		if (!m_is_local_player) {
+			// Objects attached to the local player should be hidden in first person
+			m_is_visible = (!m_attached_to_local) ||
+					(m_client->getCamera()->getCameraMode() != CAMERA_MODE_FIRST);
+		}
 	} else if (cmd == GENERIC_CMD_PUNCHED) {
 		u16 result_hp = readU16(is);
 


### PR DESCRIPTION
This fixes the issue of objects becoming temporarily invisible when attached to the local player while the client isn't in first person view.

I proposed this change before, but I initially had no clue what I was doing, and figuring out the best approach resulted in a few pointless commits, and eventually, the pull request became so far behind the main branch that it might have broken something if it were merged, so I decided it was better to delete it.

This time, I've kept it simple, and based the changes off of the latest version as well.