### PR TITLE
Fix set_hp(0, reason) Lua error

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -646,8 +646,8 @@ int LuaEntitySAO::punch(v3f dir,
 
 	if (!damage_handled) {
 		if (result.did_punch) {
-			setHP((s32)getHP() - result.damage,
-				PlayerHPChangeReason(PlayerHPChangeReason::SET_HP));
+			PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
+			setHP((s32)getHP() - result.damage, reason);
 
 			if (result.damage > 0) {
 				std::string punchername = puncher ? puncher->getDescription() : "nil";
@@ -715,7 +715,7 @@ std::string LuaEntitySAO::getDescription()
 	return os.str();
 }
 
-void LuaEntitySAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
+void LuaEntitySAO::setHP(s32 hp, PlayerHPChangeReason &reason)
 {
 	m_hp = rangelim(hp, 0, U16_MAX);
 }
@@ -1294,8 +1294,8 @@ int PlayerSAO::punch(v3f dir,
 				hitparams.hp);
 
 	if (!damage_handled) {
-		setHP((s32)getHP() - (s32)hitparams.hp,
-				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, puncher));
+		PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, puncher);
+		setHP((s32)getHP() - (s32)hitparams.hp, reason);
 	} else { // override client prediction
 		if (puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
 			std::string str = gob_cmd_punched(getHP());
@@ -1318,7 +1318,7 @@ int PlayerSAO::punch(v3f dir,
 	return hitparams.wear;
 }
 
-void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
+void PlayerSAO::setHP(s32 hp, PlayerHPChangeReason &reason)
 {
 	s32 oldhp = m_hp;
 

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -127,7 +127,7 @@ public:
 	void moveTo(v3f pos, bool continuous);
 	float getMinimumSavedMovement();
 	std::string getDescription();
-	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHP(s32 hp, PlayerHPChangeReason &reason);
 	u16 getHP() const;
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
@@ -258,7 +258,7 @@ public:
 		ServerActiveObject *puncher,
 		float time_from_last_punch);
 	void rightClick(ServerActiveObject *clicker) {}
-	void setHP(s32 hp, const PlayerHPChangeReason &reason);
+	void setHP(s32 hp, PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1178,14 +1178,15 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			// If the object is a player and its HP changed
 			if (src_original_hp != pointed_object->getHP() &&
 					pointed_object->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-				SendPlayerHPOrDie((PlayerSAO *)pointed_object,
-						PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, playersao));
+				PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, playersao);
+				SendPlayerHPOrDie((PlayerSAO *)pointed_object, reason);
 			}
 
 			// If the puncher is a player and its HP changed
-			if (dst_origin_hp != playersao->getHP())
-				SendPlayerHPOrDie(playersao,
-						PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, pointed_object));
+			if (dst_origin_hp != playersao->getHP()) {
+				PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, pointed_object);
+				SendPlayerHPOrDie(playersao, reason);
+			}
 		}
 
 	} // action == 0

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -382,11 +382,12 @@ void ScriptApiBase::objectrefGetOrCreate(lua_State *L,
 	}
 }
 
-void ScriptApiBase::pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason &reason)
+void ScriptApiBase::pushPlayerHPChangeReason(lua_State *L, PlayerHPChangeReason &reason)
 {
 	if (reason.lua_reference >= 0) {
 		lua_rawgeti(L, LUA_REGISTRYINDEX, reason.lua_reference);
 		luaL_unref(L, LUA_REGISTRYINDEX, reason.lua_reference);
+		reason.lua_reference = -1;
 	} else
 		lua_newtable(L);
 

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -141,7 +141,7 @@ protected:
 
 	void objectrefGetOrCreate(lua_State *L, ServerActiveObject *cobj);
 
-	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason& reason);
+	void pushPlayerHPChangeReason(lua_State *L, PlayerHPChangeReason& reason);
 
 	std::recursive_mutex m_luastackmutex;
 	std::string     m_last_run_mod;

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -39,7 +39,7 @@ void ScriptApiPlayer::on_newplayer(ServerActiveObject *player)
 	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
 }
 
-void ScriptApiPlayer::on_dieplayer(ServerActiveObject *player, const PlayerHPChangeReason &reason)
+void ScriptApiPlayer::on_dieplayer(ServerActiveObject *player, PlayerHPChangeReason &reason)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -78,7 +78,7 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 }
 
 s32 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
-	s32 hp_change, const PlayerHPChangeReason &reason)
+	s32 hp_change, PlayerHPChangeReason &reason)
 {
 	SCRIPTAPI_PRECHECKHEADER
 

--- a/src/script/cpp_api/s_player.h
+++ b/src/script/cpp_api/s_player.h
@@ -35,7 +35,7 @@ public:
 	virtual ~ScriptApiPlayer() = default;
 
 	void on_newplayer(ServerActiveObject *player);
-	void on_dieplayer(ServerActiveObject *player, const PlayerHPChangeReason &reason);
+	void on_dieplayer(ServerActiveObject *player, PlayerHPChangeReason &reason);
 	bool on_respawnplayer(ServerActiveObject *player);
 	bool on_prejoinplayer(const std::string &name, const std::string &ip,
 			std::string *reason);
@@ -47,7 +47,7 @@ public:
 			float time_from_last_punch, const ToolCapabilities *toolcap,
 			v3f dir, s16 damage);
 	s32 on_player_hpchange(ServerActiveObject *player, s32 hp_change,
-			const PlayerHPChangeReason &reason);
+			PlayerHPChangeReason &reason);
 	void on_playerReceiveFields(ServerActiveObject *player,
 			const std::string &formname, const StringMap &fields);
 	void on_auth_failure(const std::string &name, const std::string &ip);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -192,14 +192,15 @@ int ObjectRef::l_punch(lua_State *L)
 	// If the punched is a player, and its HP changed
 	if (src_original_hp != co->getHP() &&
 			co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co, PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, puncher));
+		PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, puncher);
+		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)co, reason);
 	}
 
 	// If the puncher is a player, and its HP changed
 	if (dst_origin_hp != puncher->getHP() &&
 			puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher,
-				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, co));
+		PlayerHPChangeReason reason(PlayerHPChangeReason::PLAYER_PUNCH, co);
+		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher, reason);
 	}
 	return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1068,11 +1068,12 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	SendInventory(playersao);
 
 	// Send HP or death screen
-	if (playersao->isDead())
+	if (playersao->isDead()) {
 		SendDeathscreen(peer_id, false, v3f(0,0,0));
-	else
-		SendPlayerHPOrDie(playersao,
-				PlayerHPChangeReason(PlayerHPChangeReason::SET_HP));
+	} else {
+		PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
+		SendPlayerHPOrDie(playersao, reason);
+	}
 
 	// Send Breath
 	SendPlayerBreath(playersao);
@@ -1426,7 +1427,7 @@ void Server::SendMovement(session_t peer_id)
 	Send(&pkt);
 }
 
-void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason &reason)
+void Server::SendPlayerHPOrDie(PlayerSAO *playersao, PlayerHPChangeReason &reason)
 {
 	if (!g_settings->getBool("enable_damage"))
 		return;
@@ -2601,7 +2602,7 @@ void Server::sendDetachedInventories(session_t peer_id)
 	Something random
 */
 
-void Server::DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason)
+void Server::DiePlayer(session_t peer_id, PlayerHPChangeReason &reason)
 {
 	PlayerSAO *playersao = getPlayerSAO(peer_id);
 	// In some rare cases this can be NULL -- if the player is disconnected
@@ -2632,8 +2633,9 @@ void Server::RespawnPlayer(session_t peer_id)
 			<< playersao->getPlayer()->getName()
 			<< " respawns" << std::endl;
 
-	playersao->setHP(playersao->accessObjectProperties()->hp_max,
-			PlayerHPChangeReason(PlayerHPChangeReason::RESPAWN));
+	PlayerHPChangeReason reason(PlayerHPChangeReason::RESPAWN);
+	playersao->setHP(playersao->accessObjectProperties()->hp_max, reason);
+
 	playersao->setBreath(playersao->accessObjectProperties()->breath_max);
 
 	bool repositioned = m_script->on_respawnplayer(playersao);

--- a/src/server.h
+++ b/src/server.h
@@ -331,7 +331,7 @@ public:
 
 	void printToConsoleOnly(const std::string &text);
 
-	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason);
+	void SendPlayerHPOrDie(PlayerSAO *player, PlayerHPChangeReason &reason);
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO* playerSAO);
 	void SendMovePlayer(session_t peer_id);
@@ -473,7 +473,7 @@ private:
 		Something random
 	*/
 
-	void DiePlayer(session_t peer_id, const PlayerHPChangeReason &reason);
+	void DiePlayer(session_t peer_id, PlayerHPChangeReason &reason);
 	void RespawnPlayer(session_t peer_id);
 	void DeleteClient(session_t peer_id, ClientDeletionReason reason);
 	void UpdateCrafting(RemotePlayer *player);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -140,7 +140,7 @@ public:
 	{ return 0; }
 	virtual void rightClick(ServerActiveObject *clicker)
 	{}
-	virtual void setHP(s32 hp, const PlayerHPChangeReason &reason)
+	virtual void setHP(s32 hp, PlayerHPChangeReason &reason)
 	{}
 	virtual u16 getHP() const
 	{ return 0; }


### PR DESCRIPTION
Fixes #8227.

The fix is this line: https://github.com/minetest/minetest/pull/8347/files#diff-2d01836e6c0329cf2b516efb9b407661R390
That addition seems to necessitate the removal of `const` wherever `PlayerHPChangeReason` is used.

The crash occurred because the index of the reference to the Lua `PlayerHPChangeReason` table was not reset when the reference was deleted. This caused a problem when `pushPlayerHPChangeReason` was called twice with the same `PlayerHPChangeReason`, as is done when a player dies (for `on_player_hpchange` and `on_dieplayer` callbacks).