### PR TITLE
Damage: Play no damage sound when immortal

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -628,10 +628,10 @@ int LuaEntitySAO::punch(v3f dir,
 		return 0;
 	}
 
+	assert(puncher);
+
 	s32 old_hp = getHP();
-	ItemStack punchitem;
-	if (puncher)
-		punchitem = puncher->getWieldedItem();
+	const ItemStack &punchitem = puncher->getWieldedItem();
 
 	PunchDamageResult result = getPunchDamage(
 			m_armor_groups,
@@ -662,14 +662,14 @@ int LuaEntitySAO::punch(v3f dir,
 	}
 
 	char log[256];
-	std::string desc_puncher = puncher->getDescription(),
-			desc_self = getDescription();
+	const std::string &desc_puncher = puncher->getDescription(),
+			&desc_self = getDescription();
 	porting::mt_snprintf(log, sizeof(log),
 			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i",
 			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),
 			desc_self.c_str(), m_id, m_hp, (old_hp - (s32)getHP()),
 			damage_handled ? " (handled by Lua)" : "");
-	actionstream << log << std::endl;
+	infostream << log << std::endl;
 
 	return result.wear;
 }
@@ -1271,6 +1271,8 @@ int PlayerSAO::punch(v3f dir,
 	if (!toolcap)
 		return 0;
 
+	assert(puncher);
+
 	// No effect if PvP disabled
 	if (!g_settings->getBool("enable_pvp")) {
 		if (puncher->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
@@ -1305,8 +1307,8 @@ int PlayerSAO::punch(v3f dir,
 	}
 
 	char log[256];
-	std::string desc_puncher = puncher->getDescription(),
-			desc_self = getDescription();
+	const std::string &desc_puncher = puncher->getDescription(),
+			&desc_self = getDescription();
 	porting::mt_snprintf(log, sizeof(log),
 			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i%s",
 			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -628,17 +628,15 @@ int LuaEntitySAO::punch(v3f dir,
 		return 0;
 	}
 
-	ItemStack *punchitem = NULL;
-	ItemStack punchitem_static;
-	if (puncher) {
-		punchitem_static = puncher->getWieldedItem();
-		punchitem = &punchitem_static;
-	}
+	s32 old_hp = getHP();
+	ItemStack punchitem;
+	if (puncher)
+		punchitem = puncher->getWieldedItem();
 
 	PunchDamageResult result = getPunchDamage(
 			m_armor_groups,
 			toolcap,
-			punchitem,
+			&punchitem,
 			time_from_last_punch);
 
 	bool damage_handled = m_env->getScriptIface()->luaentity_Punch(m_id, puncher,
@@ -648,14 +646,6 @@ int LuaEntitySAO::punch(v3f dir,
 		if (result.did_punch) {
 			setHP((s32)getHP() - result.damage,
 				PlayerHPChangeReason(PlayerHPChangeReason::SET_HP));
-
-			if (result.damage > 0) {
-				std::string punchername = puncher ? puncher->getDescription() : "nil";
-
-				actionstream << getDescription() << " punched by "
-						<< punchername << ", damage " << result.damage
-						<< " hp, health now " << getHP() << " hp" << std::endl;
-			}
 
 			std::string str = gob_cmd_punched(getHP());
 			// create message and add to list
@@ -670,6 +660,16 @@ int LuaEntitySAO::punch(v3f dir,
 		clearChildAttachments();
 		m_env->getScriptIface()->luaentity_on_death(m_id, puncher);
 	}
+
+	char log[256];
+	std::string desc_puncher = puncher->getDescription(),
+			desc_self = getDescription();
+	porting::mt_snprintf(log, sizeof(log),
+			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i",
+			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),
+			desc_self.c_str(), m_id, m_hp, (old_hp - (s32)getHP()),
+			damage_handled ? " (handled by Lua)" : "");
+	actionstream << log << std::endl;
 
 	return result.wear;
 }
@@ -888,6 +888,9 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_breath = m_prop.breath_max;
 	// Disable zoom in survival mode using a value of 0
 	m_prop.zoom_fov = g_settings->getBool("creative_mode") ? 15.0f : 0.0f;
+
+	if (!g_settings->getBool("enable_damage"))
+		m_armor_groups["immortal"] = 1;
 }
 
 PlayerSAO::~PlayerSAO()
@@ -990,7 +993,7 @@ void PlayerSAO::getStaticData(std::string * result) const
 
 void PlayerSAO::step(float dtime, bool send_recommended)
 {
-	if (m_drowning_interval.step(dtime, 2.0f)) {
+	if (!isImmortal() && m_drowning_interval.step(dtime, 2.0f)) {
 		// Get nose/mouth position, approximate with eye position
 		v3s16 p = floatToInt(getEyePosition(), BS);
 		MapNode n = m_env->getMap().getNodeNoEx(p);
@@ -1020,7 +1023,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 			setBreath(m_breath + 1);
 	}
 
-	if (m_node_hurt_interval.step(dtime, 1.0f)) {
+	if (!isImmortal() && m_node_hurt_interval.step(dtime, 1.0f)) {
 		u32 damage_per_second = 0;
 		// Lowest and highest damage points are 0.1 within collisionbox
 		float dam_top = m_prop.collisionbox.MaxEdge.Y - 0.1f;
@@ -1279,13 +1282,9 @@ int PlayerSAO::punch(v3f dir,
 		}
 	}
 
+	s32 old_hp = getHP();
 	HitParams hitparams = getHitParams(m_armor_groups, toolcap,
 			time_from_last_punch);
-
-	std::string punchername = "nil";
-
-	if (puncher != 0)
-		punchername = puncher->getDescription();
 
 	PlayerSAO *playersao = m_player->getPlayerSAO();
 
@@ -1305,15 +1304,15 @@ int PlayerSAO::punch(v3f dir,
 		}
 	}
 
-
-	actionstream << "Player " << m_player->getName() << " punched by "
-			<< punchername;
-	if (!damage_handled) {
-		actionstream << ", damage " << hitparams.hp << " HP";
-	} else {
-		actionstream << ", damage handled by lua";
-	}
-	actionstream << std::endl;
+	char log[256];
+	std::string desc_puncher = puncher->getDescription(),
+			desc_self = getDescription();
+	porting::mt_snprintf(log, sizeof(log),
+			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i%s",
+			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),
+			desc_self.c_str(), m_id, m_hp, (old_hp - (s32)getHP()),
+			damage_handled ? " (handled by Lua)" : "");
+	actionstream << log << std::endl;
 
 	return hitparams.wear;
 }
@@ -1328,7 +1327,7 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 
 	hp = rangelim(oldhp + hp_change, 0, m_prop.hp_max);
 
-	if (hp < oldhp && !g_settings->getBool("enable_damage"))
+	if (hp < oldhp && isImmortal())
 		return;
 
 	m_hp = hp;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -628,7 +628,7 @@ int LuaEntitySAO::punch(v3f dir,
 		return 0;
 	}
 
-	assert(puncher);
+	FATAL_ERROR_IF(!puncher, "Punch action called without SAO");
 
 	s32 old_hp = getHP();
 	const ItemStack &punchitem = puncher->getWieldedItem();
@@ -661,15 +661,11 @@ int LuaEntitySAO::punch(v3f dir,
 		m_env->getScriptIface()->luaentity_on_death(m_id, puncher);
 	}
 
-	char log[256];
-	const std::string &desc_puncher = puncher->getDescription(),
-			&desc_self = getDescription();
-	porting::mt_snprintf(log, sizeof(log),
-			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i",
-			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),
-			desc_self.c_str(), m_id, m_hp, (old_hp - (s32)getHP()),
-			damage_handled ? " (handled by Lua)" : "");
-	infostream << log << std::endl;
+	actionstream << puncher->getDescription() << " (id=" << puncher->getId() <<
+			", hp=" << puncher->getHP() << ") punched " <<
+			getDescription() << " (id=" << m_id << ", hp=" << m_hp <<
+			"), damage=" << (old_hp - (s32)getHP()) <<
+			(damage_handled ? " (handled by Lua)" : "") << std::endl;
 
 	return result.wear;
 }
@@ -1271,7 +1267,7 @@ int PlayerSAO::punch(v3f dir,
 	if (!toolcap)
 		return 0;
 
-	assert(puncher);
+	FATAL_ERROR_IF(!puncher, "Punch action called without SAO");
 
 	// No effect if PvP disabled
 	if (!g_settings->getBool("enable_pvp")) {
@@ -1306,15 +1302,11 @@ int PlayerSAO::punch(v3f dir,
 		}
 	}
 
-	char log[256];
-	const std::string &desc_puncher = puncher->getDescription(),
-			&desc_self = getDescription();
-	porting::mt_snprintf(log, sizeof(log),
-			"%s (id=%i, hp=%i) punched %s (id=%i, hp=%i), damage=%i%s",
-			desc_puncher.c_str(), puncher->getId(), puncher->getHP(),
-			desc_self.c_str(), m_id, m_hp, (old_hp - (s32)getHP()),
-			damage_handled ? " (handled by Lua)" : "");
-	actionstream << log << std::endl;
+	actionstream << puncher->getDescription() << " (id=" << puncher->getId() <<
+		", hp=" << puncher->getHP() << ") punched " <<
+		getDescription() << " (id=" << m_id << ", hp=" << m_hp <<
+		"), damage=" << (old_hp - (s32)getHP()) <<
+		(damage_handled ? " (handled by Lua)" : "") << std::endl;
 
 	return hitparams.wear;
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -45,6 +45,8 @@ public:
 
 	inline bool isAttached() const
 	{ return getParent(); }
+	inline bool isImmortal() const
+	{ return itemgroup_get(m_armor_groups, "immortal"); }
 
 	void setArmorGroups(const ItemGroupList &armor_groups);
 	const ItemGroupList &getArmorGroups();

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -799,7 +799,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 		return;
 	}
 
-	if (g_settings->getBool("enable_damage")) {
+	if (!playersao->isImmortal()) {
 		if (playersao->isDead()) {
 			verbosestream << "Server::ProcessData(): Info: "
 				"Ignoring damage as player " << player->getName()
@@ -1155,10 +1155,6 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			// Skip if object can't be interacted with anymore
 			if (pointed_object->isGone())
 				return;
-
-			actionstream<<player->getName()<<" punches object "
-					<<pointed.object_id<<": "
-					<<pointed_object->getDescription()<<std::endl;
 
 			ItemStack punchitem = playersao->getWieldedItemOrHand();
 			ToolCapabilities toolcap =

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1428,7 +1428,7 @@ void Server::SendMovement(session_t peer_id)
 
 void Server::SendPlayerHPOrDie(PlayerSAO *playersao, const PlayerHPChangeReason &reason)
 {
-	if (!g_settings->getBool("enable_damage"))
+	if (playersao->isImmortal())
 		return;
 
 	session_t peer_id   = playersao->getPeerID();


### PR DESCRIPTION
Add isImmortal server-side for proper enable_damage handling
Rework log messages

Fixes #8214 
Partially implements #8266 

**How to test:**
1) Disable damage of a world
2) Join the world
3) Fall down
4) No damage sound

New log format:
```
2019-03-10 10:26:33: ACTION[Server]: Somebody damaged by 3 hp at (29.262,5.931,-35.038)
2019-03-10 10:26:34: ACTION[Server]: player Somebody (id=3, hp=6) punched player OnceToldMe (id=1, hp=17), damage=1
2019-03-10 10:26:35: ACTION[Server]: player Somebody (id=3, hp=6) punched player OnceToldMe (id=1, hp=17), damage=0
2019-03-10 10:26:35: ACTION[Server]: player Somebody (id=3, hp=6) punched player OnceToldMe (id=1, hp=17), damage=0
2019-03-10 10:26:38: ACTION[Server]: player OnceToldMe (id=1, hp=17) punched player Somebody (id=3, hp=1), damage=5
2019-03-10 10:26:40: ACTION[Server]: player OnceToldMe (id=1, hp=17) punched player Somebody (id=3, hp=0), damage=1
2019-03-10 10:26:40: ACTION[Server]: Somebody dies at (29,4,-35). No bones placed
2019-03-10 10:26:44: ACTION[Server]: Somebody respawns at (15,4,-14.5)
```