### PR TITLE
Improve core.after in a simple way

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -12,15 +12,15 @@ core.register_globalstep(function(dtime)
 	time_next = math.huge
 
 	-- Iterate backwards so that we miss any new timers added by
-	-- a timer callback, and so that we don't skip the next timer
-	-- in the list if we remove one.
+	-- a timer callback.
 	for i = #jobs, 1, -1 do
 		local job = jobs[i]
 		if time >= job.expire then
 			core.set_last_run_mod(job.mod_origin)
 			job.func(unpack(job.arg))
-			jobs[i] = jobs[#jobs]
-			jobs[#jobs] = nil
+			local jobs_l = #jobs
+			jobs[i] = jobs[jobs_l]
+			jobs[jobs_l] = nil
 		elseif job.expire < time_next then
 			time_next = job.expire
 		end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -1,12 +1,15 @@
 local jobs = {}
 local time = 0.0
+local time_next = math.huge
 
 core.register_globalstep(function(dtime)
 	time = time + dtime
 
-	if #jobs < 1 then
+	if time < time_next then
 		return
 	end
+
+	time_next = math.huge
 
 	-- Iterate backwards so that we miss any new timers added by
 	-- a timer callback, and so that we don't skip the next timer
@@ -16,7 +19,10 @@ core.register_globalstep(function(dtime)
 		if time >= job.expire then
 			core.set_last_run_mod(job.mod_origin)
 			job.func(unpack(job.arg))
-			table.remove(jobs, i)
+			jobs[i] = jobs[#jobs]
+			jobs[#jobs] = nil
+		else
+			time_next = math.min(time_next, job.expire)
 		end
 	end
 end)
@@ -24,10 +30,12 @@ end)
 function core.after(after, func, ...)
 	assert(tonumber(after) and type(func) == "function",
 		"Invalid core.after invocation")
+	local expire = time + after
 	jobs[#jobs + 1] = {
 		func = func,
-		expire = time + after,
+		expire = expire,
 		arg = {...},
 		mod_origin = core.get_last_run_mod()
 	}
+	time_next = math.min(time_next, expire)
 end

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -21,8 +21,8 @@ core.register_globalstep(function(dtime)
 			job.func(unpack(job.arg))
 			jobs[i] = jobs[#jobs]
 			jobs[#jobs] = nil
-		else
-			time_next = math.min(time_next, job.expire)
+		elseif job.expire < time_next then
+			time_next = job.expire
 		end
 	end
 end)


### PR DESCRIPTION
There were already PRs that wanted to make `core.after` faster, but it was argued against them because of their complexity.
In this PR there's
- no complicated data structure used.
- `table.remove` replaced with swapping the last element with the element to remove (O(1) instead of [O(n)](https://github.com/minetest/minetest/blob/b298b0339c79db7f5b3873e73ff9ea0130f05a8a/lib/lua/src/ltablib.c#L125-L128)).
- a better best case for checking the job expires (by saving the lowest next time). (This is the same as in  #6037.)
- No worse runtime at adding new jobs.

(n is the number of elements in the jobs table, k is the number of expired jobs)
globalstep runtimes:

case | old | new
--- | --- | ---
best case (k = 0) | O(n) | O(1)
average case | O(k*n) | O(n)
worst case (k = n) | O(k*n) = O(n^2) | O(n)

new after job runtimes:

 old | new
 --- | ---
 O(1) | O(1)

Is a change like this wanted or is this already too complicated and too hard to maintain?
