### PR TITLE
num_emerge_threads: Warn of crashes when > 1

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1915,16 +1915,18 @@ emergequeue_limit_diskonly (Limit of emerge queues on disk) int 64
 emergequeue_limit_generate (Limit of emerge queues to generate) int 64
 
 #    Number of emerge threads to use.
+#    WARNING: Currently there are multiple bugs that may cause crashes when
+#    'num_emerge_threads' is larger than 1. Until this warning is removed it is
+#    strongly recommended this value is set to the default '1'.
 #    Empty or 0 value:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.
 #    Any other value:
 #    -    Specifies the number of emerge threads, with a lower limit of 1.
-#    Warning: Increasing the number of emerge threads increases engine mapgen
+#    WARNING: Increasing the number of emerge threads increases engine mapgen
 #    speed, but this may harm game performance by interfering with other
 #    processes, especially in singleplayer and/or when running Lua code in
-#    'on_generated'.
-#    For many users the optimum setting may be '1'.
+#    'on_generated'. For many users the optimum setting may be '1'.
 num_emerge_threads (Number of emerge threads) int 1
 
 [Online Content Repository]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2994,16 +2994,18 @@
 # emergequeue_limit_generate = 64
 
 #    Number of emerge threads to use.
+#    WARNING: Currently there are multiple bugs that may cause crashes when
+#    'num_emerge_threads' is larger than 1. Until this warning is removed it is
+#    strongly recommended this value is set to the default '1'.
 #    Empty or 0 value:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.
 #    Any other value:
 #    -    Specifies the number of emerge threads, with a lower limit of 1.
-#    Warning: Increasing the number of emerge threads increases engine mapgen
+#    WARNING: Increasing the number of emerge threads increases engine mapgen
 #    speed, but this may harm game performance by interfering with other
 #    processes, especially in singleplayer and/or when running Lua code in
-#    'on_generated'.
-#    For many users the optimum setting may be '1'.
+#    'on_generated'. For many users the optimum setting may be '1'.
 #    type: int
 # num_emerge_threads = 1
 


### PR DESCRIPTION
See #8300 especially https://github.com/minetest/minetest/issues/8300#issuecomment-470929723 onwards.
This should be merged to master and backport-5 branches.
For backport-5 this should be merged together with, and after (to avoid a conflict), the following 2 commits that fix num_emerge_threads code and set a new default value:
https://github.com/minetest/minetest/commit/61e5fbab721898a431b15a5a7e24efb58cd80eb4
https://github.com/minetest/minetest/commit/1c87d57e1d144262419fd534e3dcd391e2e5bcbd