### PR TITLE
Lua_api.txt: Document blockpos, coordinate conversion, map terminology. Fix and improve LVM 'calc_lighting()' warning

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3248,10 +3248,8 @@ Methods
     * To be used only by a `VoxelManip` object from
       `minetest.get_mapgen_object`.
     * (`p1`, `p2`) is the area in which lighting is set, defaults to the whole
-      area if left out or nil.
-    * Setting `p1`, `p2` to `emin`, `emax` of the mapgen object voxelmanip (the
-      entire volume of the voxelmanip: the mapchunk plus a 1 mapblock thick
-      shell around it) will cause an error.
+      area if left out or nil. For almost all uses these should be left out
+      or nil to use the default.
     * `propagate_shadow` is an optional boolean deciding whether shadows in a
       generated mapchunk above are propagated down into the mapchunk, defaults
       to `true` if left out.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1188,9 +1188,8 @@ clients and handled by many parts of the engine.
 
 A 'mapchunk' (sometimes abbreviated to 'chunk') is usually 5x5x5 mapblocks
 (80x80x80 nodes) and is the volume of world generated in one operation by
-map generation.
-The size in mapblocks is chosen to optimise map generation, generating
-individual mapblocks is an inefficient use of map generation.
+the map generator.
+The size in mapblocks has been chosen to optimise map generation.
 
 Coordinates
 -----------
@@ -1201,27 +1200,31 @@ For node and mapblock coordinates, +X is East, +Y is up, +Z is North.
 
 ### Node coordinates
 
-Almost all positions used in the API are node coordinates that specify a
-particular node.
+Almost all positions used in the API use node coordinates.
 
 ### Mapblock coordinates
 
 Occasionally the API uses 'blockpos' which refers to mapblock coordinates that
 specify a particular mapblock.
 For example blockpos (0,0,0) specifies the mapblock that extends from
-nodepos (0,0,0) to nodepos (15,15,15).
+node position (0,0,0) to node position (15,15,15).
 
-#### Converting nodepos to blockpos
+#### Converting node position to the containing blockpos
 
-For each coordinate:
-blockpos = math.floor(nodepos / 16)
+To calculate the blockpos of the mapblock that contains the node at 'nodepos',
+for each axis:
 
-#### Converting blockpos to nodepos
+* blockpos = math.floor(nodepos / 16)
 
-For each coordinate the mapblock extends from
-nodepos = blockpos * 16
-to
-nodepos = blockpos * 16 + 15
+#### Converting blockpos to min/max node positions
+
+To calculate the min/max node positions contained in the mapblock at 'blockpos',
+for each axis:
+
+* Minimum:
+  nodepos = blockpos * 16
+* Maximum:
+  nodepos = blockpos * 16 + 15
 
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1171,6 +1171,61 @@ A box of a regular node would look like:
 
 
 
+Map terminology and coordinates
+===============================
+
+Nodes, mapblocks, mapchunks
+---------------------------
+
+A 'node' is the fundamental cubic unit of a world and appears to a player as
+roughly 1x1x1 meters in size.
+
+A 'mapblock' (often abbreviated to 'block') is 16x16x16 nodes and is the
+fundamental region of a world that is stored in the world database, sent to
+clients and handled by many parts of the engine.
+'mapblock' is preferred terminology to 'block' to help avoid confusion with
+'node', however 'block' often appears in the API.
+
+A 'mapchunk' (sometimes abbreviated to 'chunk') is usually 5x5x5 mapblocks
+(80x80x80 nodes) and is the volume of world generated in one operation by
+map generation.
+The size in mapblocks is chosen to optimise map generation, generating
+individual mapblocks is an inefficient use of map generation.
+
+Coordinates
+-----------
+
+### Orientation of axes
+
+For node and mapblock coordinates, +X is East, +Y is up, +Z is North.
+
+### Node coordinates
+
+Almost all positions used in the API are node coordinates that specify a
+particular node.
+
+### Mapblock coordinates
+
+Occasionally the API uses 'blockpos' which refers to mapblock coordinates that
+specify a particular mapblock.
+For example blockpos (0,0,0) specifies the mapblock that extends from
+nodepos (0,0,0) to nodepos (15,15,15).
+
+#### Converting nodepos to blockpos
+
+For each coordinate:
+blockpos = math.floor(nodepos / 16)
+
+#### Converting blockpos to nodepos
+
+For each coordinate the mapblock extends from
+nodepos = blockpos * 16
+to
+nodepos = blockpos * 16 + 15
+
+
+
+
 HUD
 ===
 


### PR DESCRIPTION
Closes #8356 and attends to https://github.com/minetest/minetest/issues/8220#issuecomment-472264807

Initially intended to close 8356 but it seemed logical to document coordinates, mapblocks, mapchunks etc. too, so i ended up creating a new lua_api section for this information.

@Ezhh since this is your speciality.