### PR TITLE
Fix debug.txt growing bigger and bigger

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1288,6 +1288,11 @@ language (Language) enum   ,be,ca,cs,da,de,dv,en,eo,es,et,fr,he,hu,id,it,ja,jbo,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
+#    If the file size of debug.txt exceeds the amount in bytes specified in
+#    this setting, the file's content is deleted when it is opened
+#    the next time.
+debug_log_size_max (Debug log file size threshold) int 1000000
+
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -371,6 +371,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
+	settings->setDefault("debug_log_size_max", "1000000");
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -325,7 +325,7 @@ void FileLogOutput::setFile(const std::string &filename)
 		m_stream.open(filename.c_str(), std::ios::app | std::ios::ate);
 	} else {
 		actionstream << "The log file grew too big. "
-			"I will remove the old log messages. " << std::endl;
+			"The older log messages will be removed." << std::endl;
 		m_stream.open(filename.c_str(), std::ios::trunc);
 	}
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -315,10 +315,10 @@ void FileLogOutput::setFile(const std::string &filename, u64 file_size_max)
 	actionstream << "Log messages are saved to " << filename << std::endl;
 
 	std::ifstream ifile(filename.c_str(), std::ios::binary | std::ios::ate);
-	bool truncate = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
+	bool is_too_large = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
 	ifile.close();
 
-	if (!truncate) {
+	if (!is_too_large) {
 		m_stream.open(filename.c_str(), std::ios::app | std::ios::ate);
 	} else {
 		actionstream << "The log file grew too big. "

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -34,9 +34,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cerrno>
 #include <cstring>
 
-// A Megabyte should suffice for the previous debug file deletion threshold
-#define DEBUGFILE_SIZE_MAX 1000000
-
 const int BUFFER_LENGTH = 256;
 
 class StringBuffer : public std::streambuf {
@@ -313,12 +310,12 @@ void Logger::logToOutputs(LogLevel lev, const std::string &combined,
 //// *LogOutput methods
 ////
 
-void FileLogOutput::setFile(const std::string &filename)
+void FileLogOutput::setFile(const std::string &filename, u64 file_size_max)
 {
 	actionstream << "Log messages are saved to " << filename << std::endl;
 
 	std::ifstream ifile(filename.c_str(), std::ios::binary | std::ios::ate);
-	bool truncate = ifile.tellg() > DEBUGFILE_SIZE_MAX;
+	bool truncate = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
 	ifile.close();
 
 	if (!truncate) {

--- a/src/log.h
+++ b/src/log.h
@@ -165,7 +165,7 @@ private:
 
 class FileLogOutput : public ICombinedLogOutput {
 public:
-	void open(const std::string &filename);
+	void setFile(const std::string &filename);
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{

--- a/src/log.h
+++ b/src/log.h
@@ -165,7 +165,7 @@ private:
 
 class FileLogOutput : public ICombinedLogOutput {
 public:
-	void setFile(const std::string &filename);
+	void setFile(const std::string &filename, u64 file_size_max);
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,9 +577,7 @@ static void init_log_streams(const Settings &cmd_args)
 			"using maximum." << std::endl;
 	}
 
-	verbosestream << "log_filename = " << log_filename << std::endl;
-
-	file_log_output.open(log_filename);
+	file_log_output.setFile(log_filename);
 	g_logger.addOutputMaxLevel(&file_log_output, log_level);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,7 +577,8 @@ static void init_log_streams(const Settings &cmd_args)
 			"using maximum." << std::endl;
 	}
 
-	file_log_output.setFile(log_filename);
+	file_log_output.setFile(log_filename,
+		g_settings->getU64("debug_log_size_max"));
 	g_logger.addOutputMaxLevel(&file_log_output, log_level);
 }
 


### PR DESCRIPTION
Before opening the file for writing, its file size is tested. If it exceeds 1 MB, it is deleted, otherwise the log is appended to the old messages.
Additionally, information about the log file location and whether it is deleted is printed to the action log when starting minetest.

The function which opens the file is now called setFile because "open" sounds too simple for what it does.

Fixes #4449. 