### PR TITLE
core.after: Improve assertion message

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -23,7 +23,7 @@ end)
 
 function core.after(after, func, ...)
 	assert(tonumber(after) and type(func) == "function",
-		"Invalid core.after invocation")
+		"Invalid minetest.after invocation")
 	jobs[#jobs + 1] = {
 		func = func,
 		expire = time + after,


### PR DESCRIPTION
It's most likely a third-party mod that'd tend to screw up `minetest.after` invocations. `core.after` is sure to be confusing to modders, as they haven't used it anywhere in their code. :)