### PR TITLE
num_emerge_threads: Fix documentation of automatic selection

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1918,7 +1918,7 @@ emergequeue_limit_generate (Limit of emerge queues to generate) int 64
 #    WARNING: Currently there are multiple bugs that may cause crashes when
 #    'num_emerge_threads' is larger than 1. Until this warning is removed it is
 #    strongly recommended this value is set to the default '1'.
-#    Empty or 0 value:
+#    Value 0:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.
 #    Any other value:

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -2997,7 +2997,7 @@
 #    WARNING: Currently there are multiple bugs that may cause crashes when
 #    'num_emerge_threads' is larger than 1. Until this warning is removed it is
 #    strongly recommended this value is set to the default '1'.
-#    Empty or 0 value:
+#    Value 0:
 #    -    Automatic selection. The number of emerge threads will be
 #    -    'number of processors - 2', with a lower limit of 1.
 #    Any other value:


### PR DESCRIPTION
Not essential for 5.0.1 but current documentation is misleading.
See https://github.com/minetest/minetest/commit/61e5fbab721898a431b15a5a7e24efb58cd80eb4
A lack of a value in minetest.conf no longer causes automatic selection.