### PR TITLE
Add hidden players and objects.

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5187,7 +5187,7 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table
-* `hide()`: Hides the object. *Hidden objects cannot be seen by players.*
+* `hide()`: Hides the object. *Hidden objects are not sent to clients.*
 * `unhide()` Unhides the object.
 * `is_hidden()`: Returns true if the object is hidden.
 * `is_player()`: returns true for players, false otherwise

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5187,6 +5187,9 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_bone_position(bone)`: returns position and rotation of the bone
 * `set_properties(object property table)`
 * `get_properties()`: returns object property table
+* `hide()`: Hides the object. *Hidden objects cannot be seen by players.*
+* `unhide()` Unhides the object.
+* `is_hidden()`: Returns true if the object is hidden.
 * `is_player()`: returns true for players, false otherwise
 * `get_nametag_attributes()`
     * returns a table with the attributes of the nametag of an object

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -806,6 +806,26 @@ ClientState ClientInterface::getClientState(session_t peer_id)
 	return n->second->getState();
 }
 
+void ClientInterface::sendFakeJoinLeaveMessage(std::string player_name,
+		bool in_game)
+{
+	if (in_game) {
+		NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0,
+			PEER_ID_INEXISTENT);
+		notice << (u8) PLAYER_LIST_ADD << (u16) 1 << player_name;
+		sendToAll(&notice);
+	} else {
+		// Inform connected clients.
+		NetworkPacket notice(TOCLIENT_UPDATE_PLAYER_LIST, 0,
+			PEER_ID_INEXISTENT);
+
+		notice << (u8) PLAYER_LIST_REMOVE << (u16) 1 << player_name;
+		sendToAll(&notice);
+	}
+
+	UpdatePlayerList();
+}
+
 void ClientInterface::setPlayerName(session_t peer_id, const std::string &name)
 {
 	MutexAutoLock clientslock(m_clients_mutex);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -705,7 +705,7 @@ void ClientInterface::UpdatePlayerList()
 			infostream << "* " << player->getName() << "\t";
 
 			PlayerSAO *sao = player->getPlayerSAO();
-			if (sao != nullptr && sao->isHidden())
+			if (sao && sao->isHidden())
 				continue;
 
 			{

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -699,10 +699,14 @@ void ClientInterface::UpdatePlayerList()
 		for (session_t i : clients) {
 			RemotePlayer *player = m_env->getPlayer(i);
 
-			if (player == NULL)
+			if (player == nullptr)
 				continue;
 
 			infostream << "* " << player->getName() << "\t";
+
+			PlayerSAO *sao = player->getPlayerSAO();
+			if (sao != nullptr && sao->isHidden())
+				continue;
 
 			{
 				MutexAutoLock clientslock(m_clients_mutex);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -702,11 +702,11 @@ void ClientInterface::UpdatePlayerList()
 			if (!player)
 				continue;
 
-			infostream << "* " << player->getName() << "\t";
-
 			PlayerSAO *sao = player->getPlayerSAO();
 			if (sao && sao->isHidden())
 				continue;
+
+			infostream << "* " << player->getName() << "\t";
 
 			{
 				MutexAutoLock clientslock(m_clients_mutex);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -699,7 +699,7 @@ void ClientInterface::UpdatePlayerList()
 		for (session_t i : clients) {
 			RemotePlayer *player = m_env->getPlayer(i);
 
-			if (player == nullptr)
+			if (!player)
 				continue;
 
 			infostream << "* " << player->getName() << "\t";

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -806,7 +806,7 @@ ClientState ClientInterface::getClientState(session_t peer_id)
 	return n->second->getState();
 }
 
-void ClientInterface::sendFakeJoinLeaveMessage(std::string player_name,
+void ClientInterface::sendFakeJoinLeaveMessage(const std::string &player_name,
 		bool in_game)
 {
 	if (in_game) {

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -467,7 +467,7 @@ public:
 	/* get state of client by id*/
 	ClientState getClientState(session_t peer_id);
 
-	void sendFakeJoinLeaveMessage(std::string player_name, bool in_game);
+	void sendFakeJoinLeaveMessage(const std::string &player_name, bool in_game);
 
 	/* set client playername */
 	void setPlayerName(session_t peer_id, const std::string &name);

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -467,6 +467,8 @@ public:
 	/* get state of client by id*/
 	ClientState getClientState(session_t peer_id);
 
+	void sendFakeJoinLeaveMessage(std::string player_name, bool in_game);
+
 	/* set client playername */
 	void setPlayerName(session_t peer_id, const std::string &name);
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1360,27 +1360,34 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 
 void PlayerSAO::hide()
 {
-	if (! m_hidden && m_player) {
-		Server *server = m_env->getGameDef();
-		if (! server)
-			return;
-
-		server->sendFakeJoinLeaveMessage(m_player->getName(), false);
-}
+	if (m_hidden)
+		return;
 
 	m_hidden = true;
+	if (! m_player)
+		return;
+
+	Server *server = m_env->getGameDef();
+	if (! server)
+		return;
+
+	server->sendFakeJoinLeaveMessage(m_player->getName(), false);
 }
 
 void PlayerSAO::unhide()
 {
-	if (m_hidden && m_player) {
-		Server *server = m_env->getGameDef();
-		if (! server)
-			return;
+	if (! m_hidden)
+		return;
 
-		server->sendFakeJoinLeaveMessage(m_player->getName(), true);
-	}
 	m_hidden = false;
+	if (! m_player)
+		return;
+
+	Server *server = m_env->getGameDef();
+	if (! server)
+		return;
+
+	server->sendFakeJoinLeaveMessage(m_player->getName(), true);
 }
 
 Inventory* PlayerSAO::getInventory()

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1364,11 +1364,11 @@ void PlayerSAO::hide()
 		return;
 
 	m_hidden = true;
-	if (! m_player)
+	if (!m_player)
 		return;
 
 	Server *server = m_env->getGameDef();
-	if (! server)
+	if (!server)
 		return;
 
 	server->sendFakeJoinLeaveMessage(m_player->getName(), false);
@@ -1376,15 +1376,15 @@ void PlayerSAO::hide()
 
 void PlayerSAO::unhide()
 {
-	if (! m_hidden)
+	if (!m_hidden)
 		return;
 
 	m_hidden = false;
-	if (! m_player)
+	if (!m_player)
 		return;
 
 	Server *server = m_env->getGameDef();
-	if (! server)
+	if (!server)
 		return;
 
 	server->sendFakeJoinLeaveMessage(m_player->getName(), true);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -536,6 +536,9 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 {
+	if (m_hidden)
+		return "";
+
 	std::ostringstream os(std::ios::binary);
 
 	// PROTOCOL_VERSION >= 37
@@ -932,6 +935,9 @@ void PlayerSAO::removingFromEnvironment()
 
 std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 {
+	if (m_hidden)
+		return "";
+
 	std::ostringstream os(std::ios::binary);
 
 	// Protocol >= 15
@@ -963,9 +969,11 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 	int message_count = 6 + m_bone_position.size();
 	for (std::unordered_set<int>::const_iterator ii = m_attachment_child_ids.begin();
 			ii != m_attachment_child_ids.end(); ++ii) {
-		if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
+		ServerActiveObject *obj = m_env->getActiveObject(*ii);
+		if (obj && !obj->isHidden()) {
 			message_count++;
-			msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
+			msg_os << serializeLongString(gob_cmd_update_infant(*ii,
+				obj->getSendType(),
 				obj->getClientInitializationData(protocol_version)));
 		}
 	}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -729,7 +729,7 @@ void LuaEntitySAO::unhide()
 	m_hidden = false;
 }
 
-bool LuaEntitySAO::isHidden() const
+const bool LuaEntitySAO::isHidden() const
 {
 	return m_hidden;
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1358,6 +1358,31 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 		m_env->getGameDef()->SendPlayerBreath(this);
 }
 
+void PlayerSAO::hide()
+{
+	if (! m_hidden && m_player) {
+		Server *server = m_env->getGameDef();
+		if (! server)
+			return;
+
+		server->sendFakeJoinLeaveMessage(m_player->getName(), false);
+}
+
+	m_hidden = true;
+}
+
+void PlayerSAO::unhide()
+{
+	if (m_hidden && m_player) {
+		Server *server = m_env->getGameDef();
+		if (! server)
+			return;
+
+		server->sendFakeJoinLeaveMessage(m_player->getName(), true);
+	}
+	m_hidden = false;
+}
+
 Inventory* PlayerSAO::getInventory()
 {
 	return m_inventory;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1059,7 +1059,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		}
 	}
 
-	if (!m_properties_sent && !m_hidden) {
+	if (!m_properties_sent) {
 		m_properties_sent = true;
 		std::string str = getPropertyPacket();
 		// create message and add to list
@@ -1104,7 +1104,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		setBasePosition(pos);
 	}
 
-	if (!send_recommended || m_hidden)
+	if (!send_recommended)
 		return;
 
 	// If the object is attached client-side, don't waste bandwidth sending its

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -719,21 +719,6 @@ u16 LuaEntitySAO::getHP() const
 	return m_hp;
 }
 
-void LuaEntitySAO::hide()
-{
-	m_hidden = true;
-}
-
-void LuaEntitySAO::unhide()
-{
-	m_hidden = false;
-}
-
-const bool LuaEntitySAO::isHidden() const
-{
-	return m_hidden;
-}
-
 void LuaEntitySAO::setVelocity(v3f velocity)
 {
 	m_velocity = velocity;
@@ -1358,12 +1343,12 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 		m_env->getGameDef()->SendPlayerBreath(this);
 }
 
-void PlayerSAO::hide()
+void PlayerSAO::hide(bool hidden)
 {
-	if (m_hidden)
+	if (m_hidden == hidden)
 		return;
 
-	m_hidden = true;
+	m_hidden = hidden;
 	if (!m_player)
 		return;
 
@@ -1371,23 +1356,7 @@ void PlayerSAO::hide()
 	if (!server)
 		return;
 
-	server->sendFakeJoinLeaveMessage(m_player->getName(), false);
-}
-
-void PlayerSAO::unhide()
-{
-	if (!m_hidden)
-		return;
-
-	m_hidden = false;
-	if (!m_player)
-		return;
-
-	Server *server = m_env->getGameDef();
-	if (!server)
-		return;
-
-	server->sendFakeJoinLeaveMessage(m_player->getName(), true);
+	server->sendFakeJoinLeaveMessage(m_player->getName(), !hidden);
 }
 
 Inventory* PlayerSAO::getInventory()

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -536,9 +536,6 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 {
-	if (m_hidden)
-		return "";
-
 	std::ostringstream os(std::ios::binary);
 
 	// PROTOCOL_VERSION >= 37
@@ -950,9 +947,6 @@ void PlayerSAO::removingFromEnvironment()
 
 std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 {
-	if (m_hidden)
-		return "";
-
 	std::ostringstream os(std::ios::binary);
 
 	// Protocol >= 15

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -131,7 +131,7 @@ public:
 	u16 getHP() const;
 	void hide();
 	void unhide();
-	bool isHidden() const;
+	const bool isHidden() const;
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -129,9 +129,8 @@ public:
 	std::string getDescription();
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	u16 getHP() const;
-	void hide();
-	void unhide();
-	const bool isHidden() const;
+	inline void hide(bool hidden) { m_hidden = hidden; };
+	inline const bool isHidden() const { return m_hidden; };
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity)
@@ -263,8 +262,7 @@ public:
 	void rightClick(ServerActiveObject *clicker) {}
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
-	void hide();
-	void unhide();
+	void hide(bool hidden);
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -129,6 +129,9 @@ public:
 	std::string getDescription();
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	u16 getHP() const;
+	void hide();
+	void unhide();
+	bool isHidden() const;
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -263,6 +263,8 @@ public:
 	void rightClick(ServerActiveObject *clicker) {}
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	void setHPRaw(u16 hp) { m_hp = hp; }
+	void hide();
+	void unhide();
 	s16 readDamage();
 	u16 getBreath() const { return m_breath; }
 	void setBreath(const u16 breath, bool send = true);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -129,8 +129,6 @@ public:
 	std::string getDescription();
 	void setHP(s32 hp, const PlayerHPChangeReason &reason);
 	u16 getHP() const;
-	inline void hide(bool hidden) { m_hidden = hidden; };
-	inline const bool isHidden() const { return m_hidden; };
 	/* LuaEntitySAO-specific */
 	void setVelocity(v3f velocity);
 	void addVelocity(v3f velocity)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -390,7 +390,7 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
 	list_pkt << (u8) PLAYER_LIST_INIT << (u16) players.size();
 	for (const std::string &player: players) {
-		list_pkt <<  player;
+		list_pkt << player;
 	}
 	m_clients.send(peer_id, 0, &list_pkt, true);
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -761,6 +761,53 @@ int ObjectRef::l_get_properties(lua_State *L)
 	return 1;
 }
 
+// hide(self)
+int ObjectRef::l_hide(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+
+	if (co == NULL)
+		return 0;
+
+	co->hide();
+	lua_pushboolean(L, true);
+
+	return 1;
+}
+
+// unhide(self)
+int ObjectRef::l_unhide(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+
+	if (co == NULL)
+		return 0;
+
+	co->unhide();
+	lua_pushboolean(L, true);
+
+	return 1;
+}
+
+// is_hidden(self)
+int ObjectRef::l_is_hidden(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+
+	if (co == NULL)
+		return 0;
+
+	lua_pushboolean(L, co->isHidden());
+
+	return 1;
+}
+
 // is_player(self)
 int ObjectRef::l_is_player(lua_State *L)
 {
@@ -1886,6 +1933,9 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_detach),
 	luamethod(ObjectRef, set_properties),
 	luamethod(ObjectRef, get_properties),
+	luamethod(ObjectRef, hide),
+	luamethod(ObjectRef, unhide),
+	luamethod(ObjectRef, is_hidden),
 	luamethod(ObjectRef, set_nametag_attributes),
 	luamethod(ObjectRef, get_nametag_attributes),
 	// LuaEntitySAO-only

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -768,7 +768,7 @@ int ObjectRef::l_hide(lua_State *L)
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
 
-	if (co == NULL)
+	if (!co)
 		return 0;
 
 	co->hide();
@@ -784,7 +784,7 @@ int ObjectRef::l_unhide(lua_State *L)
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
 
-	if (co == NULL)
+	if (!co)
 		return 0;
 
 	co->unhide();
@@ -800,7 +800,7 @@ int ObjectRef::l_is_hidden(lua_State *L)
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
 
-	if (co == NULL)
+	if (!co)
 		return 0;
 
 	lua_pushboolean(L, co->isHidden());

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -771,7 +771,7 @@ int ObjectRef::l_hide(lua_State *L)
 	if (!co)
 		return 0;
 
-	co->hide();
+	co->hide(true);
 	lua_pushboolean(L, true);
 
 	return 1;
@@ -787,7 +787,7 @@ int ObjectRef::l_unhide(lua_State *L)
 	if (!co)
 		return 0;
 
-	co->unhide();
+	co->hide(false);
 	lua_pushboolean(L, true);
 
 	return 1;

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -152,6 +152,15 @@ private:
 	// get_properties(self)
 	static int l_get_properties(lua_State *L);
 
+	// hide(self)
+	static int l_hide(lua_State *L);
+
+	// unhide(self)
+	static int l_unhide(lua_State *L);
+
+	// is_hidden(self)
+	static int l_is_hidden(lua_State *L);
+
 	// is_player(self)
 	static int l_is_player(lua_State *L);
 

--- a/src/server.h
+++ b/src/server.h
@@ -213,8 +213,8 @@ public:
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
 
-	inline void sendFakeJoinLeaveMessage(std::string player_name, bool in_game)
-	{
+	inline void sendFakeJoinLeaveMessage(const std::string &player_name,
+			bool in_game) {
 		return m_clients.sendFakeJoinLeaveMessage(player_name, in_game);
 	}
 

--- a/src/server.h
+++ b/src/server.h
@@ -213,6 +213,11 @@ public:
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
 
+	inline void sendFakeJoinLeaveMessage(std::string player_name, bool in_game)
+	{
+		return m_clients.sendFakeJoinLeaveMessage(player_name, in_game);
+	}
+
 	// Envlock
 	std::set<std::string> getPlayerEffectivePrivs(const std::string &name);
 	bool checkPriv(const std::string &name, const std::string &priv);

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -144,7 +144,7 @@ void ActiveObjectMgr::getAddedActiveObjectsAroundPos(const v3f &player_pos, f32 
 		if (!object)
 			continue;
 
-		if (object->isGone())
+		if (object->isGone() || object->isHidden())
 			continue;
 
 		f32 distance_f = object->getBasePosition().getDistanceFrom(player_pos);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1543,7 +1543,7 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 			continue;
 		}
 
-		if (object->isGone()) {
+		if (object->isGone() || (object->isHidden() && playersao != object)) {
 			removed_objects.push(id);
 			continue;
 		}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1509,6 +1509,12 @@ void ServerEnvironment::getAddedActiveObjects(PlayerSAO *playersao, s16 radius,
 
 	m_ao_manager.getAddedActiveObjectsAroundPos(playersao->getBasePosition(), radius_f,
 		player_radius_f, current_objects, added_objects);
+
+	if (playersao->isHidden()) {
+		const u16 id = playersao->getId();
+		if (current_objects.find(id) == current_objects.end())
+			added_objects.push(id);
+	}
 }
 
 /*

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -145,6 +145,10 @@ public:
 	virtual u16 getHP() const
 	{ return 0; }
 
+	virtual void hide() { m_hidden = true; }
+	virtual void unhide() { m_hidden = false; }
+	virtual bool isHidden() { return m_hidden; }
+
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}
 	virtual const ItemGroupList &getArmorGroups()
@@ -255,6 +259,8 @@ public:
 protected:
 	virtual void onAttach(int parent_id) {}
 	virtual void onDetach(int parent_id) {}
+
+	bool m_hidden = false;
 
 	// Used for creating objects based on type
 	typedef ServerActiveObject* (*Factory)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -145,8 +145,7 @@ public:
 	virtual u16 getHP() const
 	{ return 0; }
 
-	virtual void hide() { m_hidden = true; }
-	virtual void unhide() { m_hidden = false; }
+	virtual void hide(bool hidden) { m_hidden = hidden; }
 	virtual const bool isHidden() { return m_hidden; }
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -147,7 +147,7 @@ public:
 
 	virtual void hide() { m_hidden = true; }
 	virtual void unhide() { m_hidden = false; }
-	virtual bool isHidden() { return m_hidden; }
+	virtual const bool isHidden() { return m_hidden; }
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -145,8 +145,8 @@ public:
 	virtual u16 getHP() const
 	{ return 0; }
 
-	virtual void hide(bool hidden) { m_hidden = hidden; }
-	virtual const bool isHidden() { return m_hidden; }
+	inline void hide(bool hidden) { m_hidden = hidden; }
+	inline const bool isHidden() const { return m_hidden; }
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -414,7 +414,7 @@ static bool within(const core::matrix4 &m1, const core::matrix4 &m2,
 	const f32 *M1 = m1.pointer();
 	const f32 *M2 = m2.pointer();
 	for (int i = 0; i < 16; i++)
-		if (! within(M1[i], M2[i], precision))
+		if (!within(M1[i], M2[i], precision))
 			return false;
 	return true;
 }


### PR DESCRIPTION
Allows players and other objects to be hidden from clients with `object:hide()`.
For #8316 

Known issues:
* ~~Hiding players as soon as they join prevents `F7` from working until they are unhidden.~~ Fixed
* ~~Hidden player names are sent to clients.~~ Fixed
* The fake add/remove player messages sent to clients seem hacky, maybe there's a better way.
* The added documentation probably needs changing.