### PR TITLE
Rewrite camera modes; implement per-player camera modes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6224,6 +6224,19 @@ object you are working with still exists.
     * Returns `false` if failed.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
+* `set_camera_modes(modes)`: Sets the allowed camera modes for the player.
+    * `modes` is a table containing the following fields:
+      ```lua
+      {
+          "first" = true,
+          "third" = true,
+          "third_front" = true
+      }
+      ```
+    * Calling `set_camera_modes` without any table is shorthand for enabling
+      all camera modes (default).
+* `get_camera_modes()`: Returns a table of camera modes usable by the player
+  as in `set_camera_modes`.
 
 `PcgRandom`
 -----------

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "inventory.h"
 #include "client/tile.h"
+#include "player.h"
 #include <ICameraSceneNode.h>
 #include <ISceneNode.h>
 #include <list>
@@ -47,8 +48,6 @@ struct Nametag {
 	video::SColor nametag_color;
 	v3f nametag_pos;
 };
-
-enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};
 
 /*
 	Client camera class, manages the player and camera scene nodes, the viewing distance
@@ -142,14 +141,7 @@ public:
 	void drawWieldedTool(irr::core::matrix4* translation=NULL);
 
 	// Toggle the current camera mode
-	void toggleCameraMode() {
-		if (m_camera_mode == CAMERA_MODE_FIRST)
-			m_camera_mode = CAMERA_MODE_THIRD;
-		else if (m_camera_mode == CAMERA_MODE_THIRD)
-			m_camera_mode = CAMERA_MODE_THIRD_FRONT;
-		else
-			m_camera_mode = CAMERA_MODE_FIRST;
-	}
+	void toggleCameraMode();
 
 	// Set the current camera mode
 	inline void setCameraMode(CameraMode mode)
@@ -185,7 +177,7 @@ private:
 	WieldMeshSceneNode *m_wieldnode = nullptr;
 
 	// draw control
-	MapDrawControl& m_draw_control;
+	MapDrawControl &m_draw_control;
 
 	Client *m_client;
 
@@ -241,6 +233,11 @@ private:
 	ItemStack m_wield_item_next;
 
 	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
+	const std::set<CameraMode> m_default_camera_modes = {
+		CAMERA_MODE_FIRST,
+		CAMERA_MODE_FIRST,
+		CAMERA_MODE_THIRD
+	};
 
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -221,6 +221,7 @@ public:
 	void handleCommand_FormspecPrepend(NetworkPacket *pkt);
 	void handleCommand_CSMRestrictionFlags(NetworkPacket *pkt);
 	void handleCommand_PlayerSpeed(NetworkPacket *pkt);
+	void handleCommand_CameraModes(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2436,7 +2436,7 @@ void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 		v2s32 center(driver->getScreenSize().Width / 2, driver->getScreenSize().Height / 2);
 		v2s32 dist = input->getMousePos() - center;
 
-		if (m_invert_mouse || camera->getCameraMode() == CAMERA_MODE_THIRD_FRONT) {
+		if (m_invert_mouse || camera->getCameraMode() == CAMERA_MODE_FRONT) {
 			dist.Y = -dist.Y;
 		}
 
@@ -2954,8 +2954,8 @@ void Game::updateCamera(u32 busy_time, f32 dtime)
 
 		camera->toggleCameraMode();
 
-		playercao->setVisible(camera->getCameraMode() > CAMERA_MODE_FIRST);
-		playercao->setChildrenVisible(camera->getCameraMode() > CAMERA_MODE_FIRST);
+		playercao->setVisible(camera->getCameraMode() != CAMERA_MODE_FIRST);
+		playercao->setChildrenVisible(camera->getCameraMode() != CAMERA_MODE_FIRST);
 	}
 
 	float full_punch_interval = playeritem_toolcap.full_punch_interval;
@@ -3053,7 +3053,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		// Shoot from player head, no bobbing
 		shootline.start = camera->getHeadPosition();
 		break;
-	case CAMERA_MODE_THIRD_FRONT:
+	case CAMERA_MODE_FRONT:
 		shootline.start = camera->getHeadPosition();
 		// prevent player pointing anything in front-view
 		d = 0;
@@ -3912,7 +3912,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 			(camera->getCameraMode() == CAMERA_MODE_FIRST));
 	bool draw_crosshair = (
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
-			(camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
+			(camera->getCameraMode() != CAMERA_MODE_FRONT));
 #ifdef HAVE_TOUCHSCREENGUI
 	try {
 		draw_crosshair = !g_settings->getBool("touchtarget");

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -68,7 +68,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CSMRestrictionFlags }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerSpeed }, // 0x2B
-	null_command_handler,
+	{ "TOCLIENT_CAMERA_MODES",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CameraModes }, // 0x2C
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_CHAT_MESSAGE",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_ChatMessage }, // 0x2F

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1615,3 +1615,24 @@ void Client::handleCommand_ModChannelSignal(NetworkPacket *pkt)
 	if (valid_signal)
 		m_script->on_modchannel_signal(channel, signal);
 }
+
+void Client::handleCommand_CameraModes(NetworkPacket *pkt)
+{
+	u16 serialized_modes;
+	*pkt >> serialized_modes;
+	std::set<CameraMode> modes;
+
+	errorstream << "\thandleCommand_CameraModes | " << serialized_modes << std::endl;
+
+	LocalPlayer *player = m_env.getLocalPlayer();
+	if (!player)
+		return;
+
+	// De-serialise bit flags
+	for (u16 i = 0; es_CameraModes[i].num != CAMERA_MODE_NULL; ++i) {
+		if (serialized_modes & (1 << es_CameraModes[i].num))
+			modes.emplace(static_cast<CameraMode>(es_CameraModes[i].num));
+	}
+
+	player->setCameraModes(modes);
+}

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -204,6 +204,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 39:
 		Updated set_sky packet
 		Adds new sun, moon and stars packets
+		Add TOCLIENT_CAMERA_MODES
 */
 
 #define LATEST_PROTOCOL_VERSION 39
@@ -323,7 +324,10 @@ enum ToClientCommand
 		v3f added_vel
 	 */
 
-	// (oops, there is some gap here)
+	TOCLIENT_CAMERA_MODES = 0x2C,
+	/*
+		u16 serialized_camera_modes
+	 */
 
 	TOCLIENT_CHAT_MESSAGE = 0x2F,
 	/*

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -167,7 +167,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
 	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
-	null_command_factory, // 0x2C
+	{ "TOCLIENT_CAMERA_MODES",             0, true }, // 0x2C
 	null_command_factory, // 0x2D
 	null_command_factory, // 0x2E
 	{ "TOCLIENT_CHAT_MESSAGE",             0, true }, // 0x2F

--- a/src/player.h
+++ b/src/player.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_bloated.h"
 #include "inventory.h"
 #include "constants.h"
+#include "script/common/c_types.h"
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
 #include <list>
@@ -114,6 +115,18 @@ struct PlayerSettings
 	void readGlobalSettings();
 };
 
+enum CameraMode {
+	CAMERA_MODE_NULL = -1, CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_FRONT
+};
+
+const EnumString es_CameraModes[] = {
+	{ CAMERA_MODE_FIRST,       "first" },
+	{ CAMERA_MODE_THIRD,       "third" },
+	{ CAMERA_MODE_FRONT,       "front" },
+	{ CAMERA_MODE_NULL,        "" }
+	// FIXME: A class or struct with member functions might probably be a better solution
+};
+
 class Map;
 struct CollisionInfo;
 struct HudElement;
@@ -200,11 +213,14 @@ public:
 		return m_fov_override_spec;
 	}
 
+	void setCameraModes(std::set<CameraMode> &modes) { m_camera_modes = modes; }
+	const std::set<CameraMode> &getCameraModes() const { return m_camera_modes; }
+
 	u32 keyPressed = 0;
 
-	HudElement* getHud(u32 id);
+	HudElement *getHud(u32 id);
 	u32         addHud(HudElement* hud);
-	HudElement* removeHud(u32 id);
+	HudElement *removeHud(u32 id);
 	void        clearHud();
 
 	u32 hud_flags;
@@ -217,6 +233,7 @@ protected:
 	PlayerFovSpec m_fov_override_spec = { 0.0f, false, 0.0f };
 
 	std::vector<HudElement *> hud;
+	std::set<CameraMode> m_camera_modes;
 private:
 	// Protect some critical areas
 	// hud for example can be modified by EmergeThread

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1168,13 +1168,26 @@ int getenumfield(lua_State *L, int table,
 }
 
 /******************************************************************************/
-bool string_to_enum(const EnumString *spec, int &result,
-		const std::string &str)
+bool string_to_enum(const EnumString *spec, int &result, const std::string &str)
 {
 	const EnumString *esp = spec;
-	while(esp->str){
+	while(esp->str) {
 		if (!strcmp(str.c_str(), esp->str)) {
 			result = esp->num;
+			return true;
+		}
+		esp++;
+	}
+	return false;
+}
+
+/******************************************************************************/
+bool enum_to_string(const EnumString *spec, int &num, std::string &result)
+{
+	const EnumString *esp = spec;
+	while (esp->num) {
+		if (num == esp->num) {
+			result = std::string(esp->str);
 			return true;
 		}
 		esp++;

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -170,6 +170,10 @@ bool               string_to_enum            (const EnumString *spec,
                                               int &result,
                                               const std::string &str);
 
+bool               enum_to_string            (const EnumString *spec,
+                                              int &num,
+                                              std::string &result);
+
 bool               read_noiseparams          (lua_State *L, int index,
                                               NoiseParams *np);
 void               push_noiseparams          (lua_State *L, NoiseParams *np);

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -383,4 +383,11 @@ private:
 
 	// send_mapblock(pos)
 	static int l_send_mapblock(lua_State *L);
+
+	// set_camera_mode_restriction_flags(self, {first = , third = , third_front = })
+	static int l_set_camera_modes(lua_State *L);
+
+	// get_camera_mode_restriction_flags(self)
+	static int l_get_camera_modes(lua_State *L);
+
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1900,6 +1900,32 @@ void Server::SendPlayerFov(session_t peer_id)
 	Send(&pkt);
 }
 
+void Server::SendCameraModes(RemotePlayer *player, std::set<CameraMode> modes)
+{
+	errorstream << "\tSendCameraModes" << std::endl;
+	session_t peer_id = player->getPeerId();
+	if (peer_id == PEER_ID_INEXISTENT)
+		return;
+	errorstream<<"\tBreakpoint 1"<<std::endl;
+	NetworkPacket pkt(TOCLIENT_CAMERA_MODES, 0, peer_id);
+	errorstream<<"\tBreakpoint 2"<<std::endl;
+
+	// Serialize camera modes for sending over the network
+	u16 serialized_modes = 0;
+	for (u16 i = 0; es_CameraModes[i].num != CAMERA_MODE_NULL; i++) {
+		if (modes.find((CameraMode) es_CameraModes[i].num) != modes.end())
+			serialized_modes |= (1 << i);
+	}
+
+	errorstream<<"\tBreakpoint 3"<<std::endl;
+
+	errorstream << serialized_modes << std::endl;
+
+	pkt << serialized_modes;
+	Send(&pkt);
+	errorstream<<"\tBreakpoint 4"<<std::endl;
+}
+
 void Server::SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "hud.h"
 #include "gamedef.h"
+#include "player.h"
 #include "serialization.h" // For SER_FMT_VER_INVALID
 #include "content/mods.h"
 #include "inventorymanager.h"
@@ -347,6 +348,8 @@ public:
 	void SendPlayerFov(session_t peer_id);
 
 	void sendDetachedInventories(session_t peer_id, bool incremental);
+
+	void SendCameraModes(RemotePlayer *player, std::set<CameraMode> modes);
 
 	virtual bool registerModStorage(ModMetadata *storage);
 	virtual void unregisterModStorage(const std::string &name);


### PR DESCRIPTION
#### Use-cases

- 3rd-person mode generally offers players unfair advantages over players using 1st-person mode, like peripheral vision (looking around walls), noclip glitch (seeing through nodes in narrow passageways), etc.
- Gun mods work with the assumption that the player is in 1st-person mode, and if the player is in 3rd-person mode, most calculations will be borked and incorrect.

#### Changes

- enum `CameraMode` moved to class `Player`.
- New `EnumString` array `es_CameraModes` to store all camera mode enums and their string representation pairs.
- New attribute `std::set<CameraMode> Player::m_camera_modes` to store the enabled camera modes (both client-side and server-side) along with getter `Player::getCameraModes` and setter `Player::setCameraModes`.
- New Server->client packet (`TOCLIENT_CAMERA_MODES`).
- New Lua API methods `ObjectRef:get/set_camera_modes`.
- New method `Server::SendCameraModes` for serializing `Player::m_camera_modes` into a `u16` and sending it over the network.
- New client-side packet handler `Client::handleCommand_CameraModes` to deserialize the received `u16` back to `std::set<CameraMode>` and store it client-side.
- Documentation!

(Note: This PR also includes a couple of code-style fixes around the touched code)