### PR TITLE
World start time: Move to first full light (day night ratio = 1000) 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1097,7 +1097,7 @@ time_send_interval (Time send interval) int 5
 time_speed (Time speed) int 72
 
 #    Time of day when a new world is started, in millihours (0-23999).
-world_start_time (World start time) int 5250 0 23999
+world_start_time (World start time) int 6125 0 23999
 
 #    Interval of saving important changes in the world, stated in seconds.
 server_map_save_interval (Map save interval) float 5.3

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -355,7 +355,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("csm_restriction_noderange", "0");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");
-	settings->setDefault("world_start_time", "5250");
+	settings->setDefault("world_start_time", "6125");
 	settings->setDefault("server_unload_unused_data_timeout", "29");
 	settings->setDefault("max_objects_per_block", "64");
 	settings->setDefault("server_map_save_interval", "5.3");


### PR DESCRIPTION
Here are some screenshots taken at the start of a new Minetest Game world, in MT master branch, with default settings:

![screenshot_20190219_020529](https://user-images.githubusercontent.com/3686677/54725471-1a82b880-4b67-11e9-9336-dbc27988e9cb.png)

![screenshot_20190219_020628](https://user-images.githubusercontent.com/3686677/54725473-1eaed600-4b67-11e9-9609-1685f9248d28.png)

![screenshot_20190219_020640](https://user-images.githubusercontent.com/3686677/54725495-36865a00-4b67-11e9-9bd0-77b1bb389cc1.png)

![screenshot_20190219_020952](https://user-images.githubusercontent.com/3686677/54725501-3b4b0e00-4b67-11e9-8b08-469aef9fc8e2.png)

![screenshot_20190219_021125](https://user-images.githubusercontent.com/3686677/54725506-40a85880-4b67-11e9-98b6-e683f86116c4.png)

This will be most players very first experience of in-game Minetest.

I find this unpleasantly and irritatingly dark. Light level is increasing, but this means a player's first experience of in-game Minetest, and the first experience of every new world until they find the setting, is: 'it's really quite dark, i can't see well, it strains my eyes'.
The darkness has a drowsy and sleepy effect, which is very much the wrong way to make players feel in a new game or a new world. Players should feel awake and energised at this time.

Another issue is that some games and mods use darkness to spawn dangerous mobs, trigger danger or trigger nighttime features, all these should obviously not occur at new world start.

Investigating, i discovered that, if shaders are off, the start time isn't during the light level before full brightness, which seems reasonable, but during the light level before that.

EDIT: However, these are partly game issues, see post below. 