### PR TITLE
Stabilise 'day night ratio' to fix object brightness flicker

### DIFF
--- a/src/daynightratio.h
+++ b/src/daynightratio.h
@@ -52,15 +52,17 @@ inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 		return 1000;
 	}
 
+	if (t <= 4625) // 4500 + 125
+		return values[0][1];
+	else if (t >= 6125) // 6000 + 125
+		return 1000;
 	for (u32 i=0; i < sizeof(values) / sizeof(*values); i++) {
 			if (values[i][0] <= t)
 				continue;
-			if (i == 0)
-				return values[i][1];
+
 			float td0 = values[i][0] - values[i-1][0];
 			float f = (t - values[i-1][0]) / td0;
 			return f * values[i][1] + (1.0 - f) * values[i-1][1];
 		}
 		return 1000;
-
 }


### PR DESCRIPTION
 Stabilise 'day night ratio' to fix object brightness flicker

Previously, when basic shaders were enabled, the function
time_to_daynight_ratio() returned values jumping between 149 and 150
between times 4375 and 4625, and values jumping between 999 and 1000
between times 6125 and 6375, (and the corresponding times at sunset)
due to tiny float errors in the interpolation code.

This caused the light level returned by blend_light() to jump between
14 and 15, which became noticeable recently as those light levels were
given different visual brightnesses.

Add early returns to avoid the problematic interpolation, and to
avoid unnecessary running of the loop.
///////////////////////////////

Closes #8416 
Note: The codestyle is bad, table can have fewer entries and needs to be 'static', optimisation of the shaders off case may be possible, but to keep the bugfix clear i am leaving all that to a follow up PR.

The added early returns trigger at the times which would normally cause a fluctuating return value (149<->150 and 999<->1000). The early returns avoid the loop being run unnecessarily.