### PR TITLE
Add password manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,9 @@ if(RUN_IN_PLACE)
 	install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/textures/texture_packs_here.txt" DESTINATION "${SHAREDIR}/textures")
 endif()
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/games/minetest_game" DESTINATION "${SHAREDIR}/games/" 
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/games/minetest_game" DESTINATION "${SHAREDIR}/games/"
 	COMPONENT "SUBGAME_MINETEST_GAME" OPTIONAL PATTERN ".git*" EXCLUDE )
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/games/minimal" DESTINATION "${SHAREDIR}/games/" 
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/games/minimal" DESTINATION "${SHAREDIR}/games/"
 	COMPONENT "SUBGAME_MINIMAL" OPTIONAL PATTERN ".git*" EXCLUDE )
 
 if(BUILD_CLIENT)
@@ -284,12 +284,12 @@ if(WIN32)
 		set(CPACK_CREATE_DESKTOP_LINKS ${PROJECT_NAME})
 
 		set(CPACK_WIX_PRODUCT_ICON "${CMAKE_CURRENT_SOURCE_DIR}/misc/minetest-icon.ico")
-		# Supported languages can be found at 
+		# Supported languages can be found at
 		# http://wixtoolset.org/documentation/manual/v3/wixui/wixui_localization.html
 		#set(CPACK_WIX_CULTURES "ar-SA,bg-BG,ca-ES,hr-HR,cs-CZ,da-DK,nl-NL,en-US,et-EE,fi-FI,fr-FR,de-DE")
 		set(CPACK_WIX_UI_BANNER "${CMAKE_CURRENT_SOURCE_DIR}/misc/CPACK_WIX_UI_BANNER.BMP")
 		set(CPACK_WIX_UI_DIALOG "${CMAKE_CURRENT_SOURCE_DIR}/misc/CPACK_WIX_UI_DIALOG.BMP")
-		
+
 		set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/doc/lgpl-2.1.txt")
 
 		# The correct way would be to include both x32 and x64 into one installer

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -31,6 +31,12 @@ local function get_formspec(tabview, name, tabdata)
 		tabdata.search_for = ""
 	end
 
+	local address  = core.settings:get("address")
+	local port     = core.settings:get("remote_port")
+	local username = core.settings:get("name")
+	local password = core.formspec_escape(core.get_password(address, port, username)) or ""
+core.log("error", "Received password=\"" .. password .. "\" from LIBSECRET")
+
 	local retval =
 		-- Search
 		"field[0.15,0.075;5.91,1;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
@@ -41,15 +47,15 @@ local function get_formspec(tabview, name, tabdata)
 		-- Address / Port
 		"label[7.75,-0.25;" .. fgettext("Address / Port") .. "]" ..
 		"field[8,0.65;3.25,0.5;te_address;;" ..
-			core.formspec_escape(core.settings:get("address")) .. "]" ..
+			core.formspec_escape(address) .. "]" ..
 		"field[11.1,0.65;1.4,0.5;te_port;;" ..
-			core.formspec_escape(core.settings:get("remote_port")) .. "]" ..
+			core.formspec_escape(port) .. "]" ..
 
 		-- Name / Password
 		"label[7.75,0.95;" .. fgettext("Name / Password") .. "]" ..
 		"field[8,1.85;2.9,0.5;te_name;;" ..
-			core.formspec_escape(core.settings:get("name")) .. "]" ..
-		"pwdfield[10.73,1.85;1.77,0.5;te_pwd;]" ..
+			core.formspec_escape(username) .. "]" ..
+		"pwdfield[10.73,1.85;1.77,0.5;te_pwd;;" .. password .. "]" ..
 
 		-- Description Background
 		"box[7.73,2.25;4.25,2.6;#999999]"..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,19 @@ if(NOT USE_CURL)
 endif()
 
 
+option(ENABLE_LIBSECRET "Enable libsecret support for storing passwords securely" TRUE)
+set(USE_LIBSECRET FALSE)
+if(BUILD_CLIENT AND ENABLE_LIBSECRET)
+	include(FindPkgConfig)
+	pkg_check_modules(LIBSECRET glib-2.0 libsecret-1)
+	if(LIBSECRET_FOUND)
+		message(STATUS "libsecret support enabled")
+		set(USE_LIBSECRET TRUE)
+		include_directories(${LIBSECRET_INCLUDE_DIRS})
+	endif()
+endif()
+
+
 option(ENABLE_GETTEXT "Use GetText for internationalization" TRUE)
 set(USE_GETTEXT FALSE)
 
@@ -603,6 +616,9 @@ if(BUILD_CLIENT)
 	endif()
 	if (USE_SPATIAL)
 		target_link_libraries(${PROJECT_NAME} ${SPATIAL_LIBRARY})
+	endif()
+	if (USE_LIBSECRET)
+		target_link_libraries(${PROJECT_NAME} ${LIBSECRET_LIBRARIES})
 	endif()
 endif(BUILD_CLIENT)
 

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -53,6 +53,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mesh_generator_thread.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/minimap.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/particles.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/PasswordManager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/renderingengine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shader.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/sky.cpp

--- a/src/client/PasswordManager.cpp
+++ b/src/client/PasswordManager.cpp
@@ -1,0 +1,10 @@
+#include "PasswordManager.h"
+
+bool PasswordManager::get(const std::string &server, u16 port, const std::string &username, std::string &password) {
+	return false;
+}
+
+bool PasswordManager::store(const std::string &server, u16 port, const std::string &username,
+						  const std::string &password) {
+	return false;
+}

--- a/src/client/PasswordManager.cpp
+++ b/src/client/PasswordManager.cpp
@@ -1,10 +1,60 @@
 #include "PasswordManager.h"
+#include "../cmake_config.h"
+
+#ifdef USE_LIBSECRET
+	extern "C" {
+		#include <libsecret/secret.h>
+	}
+
+	const SecretSchema MinetestSecretSchema = {
+			"minetest_server_passwords",
+			SECRET_SCHEMA_NONE,
+			{
+					{ "server", SECRET_SCHEMA_ATTRIBUTE_STRING },
+					{ "port", SECRET_SCHEMA_ATTRIBUTE_INTEGER },
+					{ "username", SECRET_SCHEMA_ATTRIBUTE_STRING },
+					{ nullptr, SECRET_SCHEMA_ATTRIBUTE_STRING }
+			}
+	};
+
+	bool gnome_get_password(const std::string &server, u16 port, const std::string &username, std::string &password)
+	{
+		gchar *gpassword = secret_password_lookup_sync(&MinetestSecretSchema, NULL, NULL,
+				"server", server.c_str(),
+				"port", (int)port,
+				"username", username.c_str(), NULL);
+
+		password = gpassword;
+		return true;
+	}
+
+	bool gnome_store_password(const std::string &server, u16 port, const std::string &username, const std::string &password)
+	{
+		return secret_password_store_sync(&MinetestSecretSchema, NULL,
+									"minetest_login",
+									password.c_str(),
+									NULL,
+									NULL,
+										  "server", server.c_str(),
+										  "port", (int)port,
+										  "username", username.c_str(), NULL) > 0;
+	}
+#endif
+
 
 bool PasswordManager::get(const std::string &server, u16 port, const std::string &username, std::string &password) {
+#ifdef USE_LIBSECRET
+	return gnome_get_password(server, port, username, password);
+#endif
+
 	return false;
 }
 
 bool PasswordManager::store(const std::string &server, u16 port, const std::string &username,
 						  const std::string &password) {
+#ifdef USE_LIBSECRET
+	return gnome_store_password(server, port, username, password);
+#endif
+
 	return false;
 }

--- a/src/client/PasswordManager.h
+++ b/src/client/PasswordManager.h
@@ -1,0 +1,30 @@
+/*
+Minetest
+Copyright (C) 2019  rubenwardy
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+#include "irrlichttypes.h"
+
+
+class PasswordManager {
+public:
+	bool get(const std::string &server, u16 port, const std::string &username, std::string &password);
+	bool store(const std::string &server, u16 port, const std::string &username, const std::string &password);
+};

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -21,6 +21,7 @@
 #cmakedefine01 USE_FREETYPE
 #cmakedefine01 USE_CURSES
 #cmakedefine01 USE_LEVELDB
+#cmakedefine01 USE_LIBSECRET
 #cmakedefine01 USE_LUAJIT
 #cmakedefine01 USE_POSTGRESQL
 #cmakedefine01 USE_SPATIAL

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -930,6 +930,10 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		std::vector<std::string> v_geom = split(parts[1],',');
 		std::string name = parts[2];
 		std::string label = parts[3];
+		std::string default_val;
+		if (parts.size() >= 5) {
+			default_val = parts[4];
+		}
 
 		MY_CHECKPOS("pwdfield",0);
 		MY_CHECKGEOM("pwdfield",1);
@@ -955,8 +959,12 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 			258+m_fields.size()
 			);
 
+		if (m_form_src)
+			default_val = m_form_src->resolveText(default_val);
+
+		spec.fdefault = utf8_to_wide(unescape_string(default_val));
 		spec.send = true;
-		gui::IGUIEditBox * e = Environment->addEditBox(0, rect, true, this, spec.fid);
+		gui::IGUIEditBox * e = Environment->addEditBox(spec.fdefault.c_str(), rect, true, this, spec.fid);
 
 		if (spec.fname == data->focused_fieldname) {
 			Environment->setFocus(e);
@@ -980,14 +988,6 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		evt.KeyInput.Shift       = false;
 		evt.KeyInput.PressedDown = true;
 		e->OnEvent(evt);
-
-		if (parts.size() >= 5) {
-			// TODO: remove after 2016-11-03
-			warningstream << "pwdfield: use field_close_on_enter[name, enabled]" <<
-					" instead of the 5th param" << std::endl;
-			field_close_on_enter[name] = is_yes(parts[4]);
-		}
-
 		m_fields.push_back(spec);
 		return;
 	}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -40,6 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IFileSystem.h>
 #include "client/renderingengine.h"
 #include "network/networkprotocol.h"
+#include "client/PasswordManager.h"
 
 
 /******************************************************************************/
@@ -1038,6 +1039,38 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_get_password(lua_State *L)
+{
+	std::string server = luaL_checkstring(L, 1);
+	u16 port = luaL_checknumber(L, 2);
+	std::string username = luaL_checkstring(L, 3);
+
+	PasswordManager pwd;
+
+	std::string password;
+	if (!pwd.get(server, port, username, password)) {
+		return 0;
+	}
+
+	lua_pushstring(L, password.c_str());
+	return 1;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_store_password(lua_State *L)
+{
+	std::string server = luaL_checkstring(L, 1);
+	u16 port = luaL_checknumber(L, 2);
+	std::string username = luaL_checkstring(L, 3);
+	std::string password = luaL_checkstring(L, 4);
+
+	PasswordManager pwd;
+	bool ret = pwd.store(server, port, username, password);
+	lua_pushboolean(L, ret);
+	return 1;
+}
+
+/******************************************************************************/
 void ModApiMainMenu::Initialize(lua_State *L, int top)
 {
 	API_FCT(update_formspec);
@@ -1078,6 +1111,8 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	API_FCT(do_async_callback);
+	API_FCT(get_password);
+	API_FCT(store_password);
 }
 
 /******************************************************************************/

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -143,6 +143,10 @@ private:
 
 	static int l_get_max_supp_proto(lua_State *L);
 
+	static int l_get_password(lua_State *L);
+
+	static int l_store_password(lua_State *L);
+
 
 	// async
 	static int l_do_async_callback(lua_State *L);


### PR DESCRIPTION
This adds a password manager which, on GNU/Linux, will use freedesktop.org's LibSecret service. LibSecret is a standard which can communicate with GNOME's keyring and KDE's ksecretservice. On XFCE, I have GNOME Keyring installed, so don't be fooled by the "GNOME" branding.

I mostly did this for fun, not sure how much it's worth doing this over a simpler lua-based solution. LibSecret is also supposed to use an asynchronous API. 

LibSecret as a library is only needed if the system supports it, and if the system supports it the library will be available. Therefore, there should be no need to modify things as

![](https://i.rubenwardy.com/ViwvQ.png)

**TODO:**

- [ ] Use async LibSecret API
- [ ] Implement (less secure) plaintext backend
- [ ] Fix segfault