### PR TITLE
Dungeons: Do not remove nodes that have 'is_ground_content = false' 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6040,7 +6040,11 @@ Used by `minetest.register_node`.
         place_param2 = nil,  -- Force value for param2 when player places node
 
         is_ground_content = true,
-        -- If false, the cave generator will not carve through this node
+        -- If false, the cave generator and dungeon generator will not carve
+        -- through this node.
+        -- Specifically, this stops mod-added nodes being removed by caves and
+        -- dungeons when those generate in a neighbor mapchunk and extend out
+        -- beyond the edge of that mapchunk.
 
         sunlight_propagates = false,
         -- If true, sunlight will go infinitely through this node

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -100,8 +100,11 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 
 	if (dp.only_in_ground) {
 		// Set all air and liquid drawtypes to be untouchable to make dungeons
-		// open to air and liquids. Optionally set ignore to be untouchable to
-		// prevent projecting dungeons.
+		// open to air and liquids.
+		// Optionally set ignore to be untouchable to prevent projecting dungeons.
+		// Like randomwalk caves, preserve nodes that have 'is_ground_content = false',
+		// to avoid dungeons that generate out beyond the edge of a mapchunk destroying
+		// nodes added by mods in 'register_on_generated()'.
 		for (s16 z = nmin.Z; z <= nmax.Z; z++) {
 			for (s16 y = nmin.Y; y <= nmax.Y; y++) {
 				u32 i = vm->m_area.index(nmin.X, y, z);
@@ -109,7 +112,8 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 					content_t c = vm->m_data[i].getContent();
 					NodeDrawType dtype = ndef->get(c).drawtype;
 					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
-							(preserve_ignore && c == CONTENT_IGNORE))
+							(preserve_ignore && c == CONTENT_IGNORE) ||
+							!ndef->get(c).is_ground_content)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}


### PR DESCRIPTION
 Dungeons: Do not remove nodes that have 'is_ground_content = false'

Like randomwalk caves, preserve nodes that have 'is_ground_content = false',
to avoid dungeons that generate out beyond the edge of a mapchunk destroying
nodes added by mods in 'register_on_generated()'.

Issue discovered by, and original PR by, argyle77.
//////////////////////

Testing with dungeongen altered to create 8 dungeons per mapchunk, plus a mod that fills mapchunks with wood (is_ground_content = false):

![screenshot_20190325_235347](https://user-images.githubusercontent.com/3686677/54961842-323cb100-4f5a-11e9-8226-4b5bb475ad15.png)

^ PR.
Oddly a few small bits of dungeon remain, don't know why, but this is still a huge improvement.
Hopefully later we can improve on this.

![screenshot_20190325_235706](https://user-images.githubusercontent.com/3686677/54961845-3668ce80-4f5a-11e9-95a6-b36b4ee6f223.png)

^ Master

Replaces original PR #8223 
Big thanks to argyle77 for finding this overlooked issue.

Test code:
```
-- On generated function

minetest.register_on_generated(function(minp, maxp, seed)
	local x0 = minp.x
	local y0 = minp.y
	local z0 = minp.z
	local x1 = maxp.x
	local y1 = maxp.y
	local z1 = maxp.z

	local c_wood = minetest.get_content_id("default:wood")

	local vm, emin, emax = minetest.get_mapgen_object("voxelmanip")
	local area = VoxelArea:new{MinEdge = emin, MaxEdge = emax}
	local data = vm:get_data()

	for z = z0, z1 do
	for y = y0 - 1, y1 + 1 do
		local vi = area:index(x0, y, z)
		for x = x0, x1 do
			data[vi] = c_wood
			vi = vi + 1
		end
	end
	end

	vm:set_data(data)
	vm:set_lighting({day = 0, night = 0})
	vm:calc_lighting()
	vm:write_to_map()
end)
```