### PR TITLE
Cleanups around the mapgen init

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -186,12 +186,12 @@ EmergeManager::~EmergeManager()
 
 void EmergeManager::initMapgens(MapgenParams *params)
 {
-	FATAL_ERROR_IF(!m_mapgens.empty(), "mapgen already inited.");
+	FATAL_ERROR_IF(!m_mapgens.empty(), "Mapgen already initialised.");
 
 	mgparams = params;
 
 	for (u32 i = 0; i != m_threads.size(); i++)
-		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, i, params, this));
+		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, params, this));
 }
 
 

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -184,33 +184,28 @@ EmergeManager::~EmergeManager()
 }
 
 
-bool EmergeManager::initMapgens(MapgenParams *params)
+void EmergeManager::initMapgens(MapgenParams *params)
 {
-	if (!m_mapgens.empty())
-		return false;
+	FATAL_ERROR_IF(!m_mapgens.empty(), "mapgen already inited.");
 
-	this->mgparams = params;
+	mgparams = params;
 
-	for (u32 i = 0; i != m_threads.size(); i++) {
-		Mapgen *mg = Mapgen::createMapgen(params->mgtype, i, params, this);
-		m_mapgens.push_back(mg);
-	}
-
-	return true;
+	for (u32 i = 0; i != m_threads.size(); i++)
+		m_mapgens.push_back(Mapgen::createMapgen(params->mgtype, i, params, this));
 }
 
 
 Mapgen *EmergeManager::getCurrentMapgen()
 {
 	if (!m_threads_active)
-		return NULL;
+		return nullptr;
 
 	for (u32 i = 0; i != m_threads.size(); i++) {
 		if (m_threads[i]->isCurrentThread())
 			return m_threads[i]->m_mapgen;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 

--- a/src/emerge.h
+++ b/src/emerge.h
@@ -117,7 +117,7 @@ public:
 	~EmergeManager();
 	DISABLE_CLASS_COPY(EmergeManager);
 
-	bool initMapgens(MapgenParams *mgparams);
+	void initMapgens(MapgenParams *mgparams);
 
 	void startThreads();
 	void stopThreads();

--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -174,8 +174,8 @@ MapgenParams *MapSettingsManager::makeMapgenParams()
 
 	// Create our MapgenParams
 	MapgenParams *params = Mapgen::createMapgenParams(mgtype);
-	if (params == NULL)
-		return NULL;
+	if (!params)
+		return nullptr;
 
 	params->mgtype = mgtype;
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -148,8 +148,8 @@ const char *Mapgen::getMapgenName(MapgenType mgtype)
 }
 
 
-Mapgen *Mapgen::createMapgen(MapgenType mgtype, int mgid,
-	MapgenParams *params, EmergeManager *emerge)
+Mapgen *Mapgen::createMapgen(MapgenType mgtype, MapgenParams *params,
+	EmergeManager *emerge)
 {
 	switch (mgtype) {
 	case MAPGEN_CARPATHIAN:

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -153,23 +153,23 @@ Mapgen *Mapgen::createMapgen(MapgenType mgtype, int mgid,
 {
 	switch (mgtype) {
 	case MAPGEN_CARPATHIAN:
-		return new MapgenCarpathian(mgid, (MapgenCarpathianParams *)params, emerge);
+		return new MapgenCarpathian((MapgenCarpathianParams *)params, emerge);
 	case MAPGEN_FLAT:
-		return new MapgenFlat(mgid, (MapgenFlatParams *)params, emerge);
+		return new MapgenFlat((MapgenFlatParams *)params, emerge);
 	case MAPGEN_FRACTAL:
-		return new MapgenFractal(mgid, (MapgenFractalParams *)params, emerge);
+		return new MapgenFractal((MapgenFractalParams *)params, emerge);
 	case MAPGEN_SINGLENODE:
-		return new MapgenSinglenode(mgid, (MapgenSinglenodeParams *)params, emerge);
+		return new MapgenSinglenode((MapgenSinglenodeParams *)params, emerge);
 	case MAPGEN_V5:
-		return new MapgenV5(mgid, (MapgenV5Params *)params, emerge);
+		return new MapgenV5((MapgenV5Params *)params, emerge);
 	case MAPGEN_V6:
-		return new MapgenV6(mgid, (MapgenV6Params *)params, emerge);
+		return new MapgenV6((MapgenV6Params *)params, emerge);
 	case MAPGEN_V7:
-		return new MapgenV7(mgid, (MapgenV7Params *)params, emerge);
+		return new MapgenV7((MapgenV7Params *)params, emerge);
 	case MAPGEN_VALLEYS:
-		return new MapgenValleys(mgid, (MapgenValleysParams *)params, emerge);
+		return new MapgenValleys((MapgenValleysParams *)params, emerge);
 	default:
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -194,7 +194,7 @@ MapgenParams *Mapgen::createMapgenParams(MapgenType mgtype)
 	case MAPGEN_VALLEYS:
 		return new MapgenValleysParams;
 	default:
-		return NULL;
+		return nullptr;
 	}
 }
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -208,8 +208,8 @@ public:
 	// Mapgen management functions
 	static MapgenType getMapgenType(const std::string &mgname);
 	static const char *getMapgenName(MapgenType mgtype);
-	static Mapgen *createMapgen(MapgenType mgtype, int mgid,
-		MapgenParams *params, EmergeManager *emerge);
+	static Mapgen *createMapgen(MapgenType mgtype, MapgenParams *params,
+		EmergeManager *emerge);
 	static MapgenParams *createMapgenParams(MapgenType mgtype);
 	static void getMapgenNames(std::vector<const char *> *mgnames, bool include_hidden);
 

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -50,9 +50,8 @@ FlagDesc flagdesc_mapgen_carpathian[] = {
 ///////////////////////////////////////////////////////////////////////////////
 
 
-MapgenCarpathian::MapgenCarpathian(
-		int mapgenid, MapgenCarpathianParams *params, EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_CARPATHIAN, params, emerge)
 {
 	base_level       = params->base_level;
 

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -71,8 +71,7 @@ struct MapgenCarpathianParams : public MapgenParams
 class MapgenCarpathian : public MapgenBasic
 {
 public:
-	MapgenCarpathian(int mapgenid, MapgenCarpathianParams *params,
-			EmergeManager *emerge);
+	MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager *emerge);
 	~MapgenCarpathian();
 
 	virtual MapgenType getType() const { return MAPGEN_CARPATHIAN; }

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -48,8 +48,8 @@ FlagDesc flagdesc_mapgen_flat[] = {
 ///////////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenFlat::MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_FLAT, params, emerge)
 {
 	spflags          = params->spflags;
 	ground_level     = params->ground_level;

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -59,7 +59,7 @@ struct MapgenFlatParams : public MapgenParams
 class MapgenFlat : public MapgenBasic
 {
 public:
-	MapgenFlat(int mapgenid, MapgenFlatParams *params, EmergeManager *emerge);
+	MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge);
 	~MapgenFlat();
 
 	virtual MapgenType getType() const { return MAPGEN_FLAT; }

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -47,8 +47,8 @@ FlagDesc flagdesc_mapgen_fractal[] = {
 ///////////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenFractal::MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_FRACTAL, params, emerge)
 {
 	spflags          = params->spflags;
 	cave_width       = params->cave_width;

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -62,7 +62,7 @@ struct MapgenFractalParams : public MapgenParams
 class MapgenFractal : public MapgenBasic
 {
 public:
-	MapgenFractal(int mapgenid, MapgenFractalParams *params, EmergeManager *emerge);
+	MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge);
 	~MapgenFractal();
 
 	virtual MapgenType getType() const { return MAPGEN_FRACTAL; }

--- a/src/mapgen/mapgen_singlenode.cpp
+++ b/src/mapgen/mapgen_singlenode.cpp
@@ -29,9 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "emerge.h"
 
 
-MapgenSinglenode::MapgenSinglenode(int mapgenid,
-	MapgenParams *params, EmergeManager *emerge)
-	: Mapgen(mapgenid, params, emerge)
+MapgenSinglenode::MapgenSinglenode(MapgenParams *params, EmergeManager *emerge)
+	: Mapgen(MAPGEN_SINGLENODE, params, emerge)
 {
 	const NodeDefManager *ndef = emerge->ndef;
 

--- a/src/mapgen/mapgen_singlenode.h
+++ b/src/mapgen/mapgen_singlenode.h
@@ -38,7 +38,7 @@ public:
 	content_t c_node;
 	u8 set_light;
 
-	MapgenSinglenode(int mapgenid, MapgenParams *params, EmergeManager *emerge);
+	MapgenSinglenode(MapgenParams *params, EmergeManager *emerge);
 	~MapgenSinglenode() = default;
 
 	virtual MapgenType getType() const { return MAPGEN_SINGLENODE; }

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -45,8 +45,8 @@ FlagDesc flagdesc_mapgen_v5[] = {
 };
 
 
-MapgenV5::MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_V5, params, emerge)
 {
 	spflags          = params->spflags;
 	cave_width       = params->cave_width;

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -59,7 +59,7 @@ struct MapgenV5Params : public MapgenParams
 class MapgenV5 : public MapgenBasic
 {
 public:
-	MapgenV5(int mapgenid, MapgenV5Params *params, EmergeManager *emerge);
+	MapgenV5(MapgenV5Params *params, EmergeManager *emerge);
 	~MapgenV5();
 
 	virtual MapgenType getType() const { return MAPGEN_V5; }

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -55,8 +55,8 @@ FlagDesc flagdesc_mapgen_v6[] = {
 /////////////////////////////////////////////////////////////////////////////
 
 
-MapgenV6::MapgenV6(int mapgenid, MapgenV6Params *params, EmergeManager *emerge)
-	: Mapgen(mapgenid, params, emerge)
+MapgenV6::MapgenV6(MapgenV6Params *params, EmergeManager *emerge)
+	: Mapgen(MAPGEN_V6, params, emerge)
 {
 	m_emerge = emerge;
 	ystride = csize.X; //////fix this

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -132,7 +132,7 @@ public:
 	content_t c_stair_cobble;
 	content_t c_stair_desert_stone;
 
-	MapgenV6(int mapgenid, MapgenV6Params *params, EmergeManager *emerge);
+	MapgenV6(MapgenV6Params *params, EmergeManager *emerge);
 	~MapgenV6();
 
 	virtual MapgenType getType() const { return MAPGEN_V6; }

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -52,8 +52,8 @@ FlagDesc flagdesc_mapgen_v7[] = {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MapgenV7::MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_V7, params, emerge)
 {
 	spflags              = params->spflags;
 	mount_zero_level     = params->mount_zero_level;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -77,7 +77,7 @@ struct MapgenV7Params : public MapgenParams {
 
 class MapgenV7 : public MapgenBasic {
 public:
-	MapgenV7(int mapgenid, MapgenV7Params *params, EmergeManager *emerge);
+	MapgenV7(MapgenV7Params *params, EmergeManager *emerge);
 	~MapgenV7();
 
 	virtual MapgenType getType() const { return MAPGEN_V7; }

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -54,9 +54,8 @@ FlagDesc flagdesc_mapgen_valleys[] = {
 };
 
 
-MapgenValleys::MapgenValleys(int mapgenid, MapgenValleysParams *params,
-	EmergeManager *emerge)
-	: MapgenBasic(mapgenid, params, emerge)
+MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
+	: MapgenBasic(MAPGEN_VALLEYS, params, emerge)
 {
 	// NOTE: MapgenValleys has a hard dependency on BiomeGenOriginal
 	m_bgen = (BiomeGenOriginal *)biomegen;

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -79,7 +79,7 @@ struct MapgenValleysParams : public MapgenParams {
 class MapgenValleys : public MapgenBasic {
 public:
 
-	MapgenValleys(int mapgenid, MapgenValleysParams *params,
+	MapgenValleys(MapgenValleysParams *params,
 		EmergeManager *emerge);
 	~MapgenValleys();
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -220,6 +220,7 @@ Server::Server(
 	m_itemdef(createItemDefManager()),
 	m_nodedef(createNodeDefManager()),
 	m_craftdef(createCraftDefManager()),
+	m_thread(new ServerThread(this)),
 	m_uptime(0),
 	m_clients(m_con),
 	m_admin_chat(iface),
@@ -320,9 +321,6 @@ void Server::init()
 	// Create world if it doesn't exist
 	if (!loadGameConfAndInitWorld(m_path_world, m_gamespec))
 		throw ServerError("Failed to initialize world");
-
-	// Create server thread
-	m_thread = new ServerThread(this);
 
 	// Create emerge manager
 	m_emerge = new EmergeManager(this);


### PR DESCRIPTION
* Cleanup emergeManager::initMapgens function (error handling)
* cleanup Mapgen::createMapgen (mapgen enum ids mustn't be set to a misc value in constructor for childs
* initialize serverthread object in server, not in init phase (init phase is called after constructor, it's identical)

note: **don't squash commits**