### PR TITLE
Fix/Add inventory_overlay for nodes without inventory_image

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -693,6 +693,16 @@ void drawItemStack(video::IVideoDriver *driver,
 		driver->setTransform(video::ETS_VIEW, oldViewMat);
 		driver->setTransform(video::ETS_PROJECTION, oldProjMat);
 		driver->setViewPort(oldViewPort);
+
+		// draw the inventory_overlay
+		if (def.type == ITEM_NODE && def.inventory_image.empty() &&
+				!def.inventory_overlay.empty()) {
+			ITextureSource *tsrc = client->getTextureSource();
+			video::ITexture *overlay_texture = tsrc->getTexture(def.inventory_overlay);
+			core::dimension2d<u32> dimens = overlay_texture->getOriginalSize();
+			core::rect<s32> srcrect(0, 0, dimens.Width, dimens.Height);
+			draw2DImageFilterScaled(driver, overlay_texture, rect, srcrect, clip, 0, true);
+		}
 	}
 
 	if(def.type == ITEM_TOOL && item.wear != 0)


### PR DESCRIPTION
Closes #8430.
There might be many mistakes.

How to test this:
```lua
minetest.register_node("test_invcube:node", {
	description = "inventorycube node",
	tiles = {"unknown_item.png"},
	inventory_overlay = "camera_btn.png",
	groups = {oddly_breakable_by_hand = 3},
})
```
Here's a sceenshot:
![screenshot](https://user-images.githubusercontent.com/7613443/55278434-70482500-530c-11e9-929f-91345defee1f.png)
As you can see, the rotating of the node also works (`inventory_items_animations`).

If the `inventory_overlay` image is not quadratic, it is squashed in one direction (try with progress bar texture).