### PR TITLE
Find PostgreSQL correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Library specific options:
     LEVELDB_LIBRARY                 - Only when building with LevelDB; path to libleveldb.a/libleveldb.so/libleveldb.dll.a
     LEVELDB_DLL                     - Only when building with LevelDB on Windows; path to libleveldb.dll
     PostgreSQL_INCLUDE_DIR          - Only when building with PostgreSQL; directory that contains libpq-fe.h
-    POSTGRESQL_LIBRARY              - Only when building with PostgreSQL; path to libpq.a/libpq.so
+    PostgreSQL_LIBRARY              - Only when building with PostgreSQL; path to libpq.a/libpq.so/libpq.lib
     REDIS_INCLUDE_DIR               - Only when building with Redis; directory that contains hiredis.h
     REDIS_LIBRARY                   - Only when building with Redis; path to libhiredis.a/libhiredis.so
     SPATIAL_INCLUDE_DIR             - Only when building with LibSpatial; directory that contains spatialindex/SpatialIndex.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,27 +159,14 @@ option(ENABLE_POSTGRESQL "Enable PostgreSQL backend" TRUE)
 set(USE_POSTGRESQL FALSE)
 
 if(ENABLE_POSTGRESQL)
-	find_program(POSTGRESQL_CONFIG_EXECUTABLE pg_config DOC "pg_config")
-	find_library(POSTGRESQL_LIBRARY pq)
-	if(POSTGRESQL_CONFIG_EXECUTABLE)
-		execute_process(COMMAND ${POSTGRESQL_CONFIG_EXECUTABLE} --includedir-server
-			OUTPUT_VARIABLE POSTGRESQL_SERVER_INCLUDE_DIRS
-			OUTPUT_STRIP_TRAILING_WHITESPACE)
-		execute_process(COMMAND ${POSTGRESQL_CONFIG_EXECUTABLE}
-			OUTPUT_VARIABLE POSTGRESQL_CLIENT_INCLUDE_DIRS
-			OUTPUT_STRIP_TRAILING_WHITESPACE)
-		# This variable is case sensitive for the cmake PostgreSQL module
-		set(PostgreSQL_ADDITIONAL_SEARCH_PATHS ${POSTGRESQL_SERVER_INCLUDE_DIRS} ${POSTGRESQL_CLIENT_INCLUDE_DIRS})
-	endif()
-
 	find_package("PostgreSQL")
 
-	if(POSTGRESQL_FOUND)
+	if(PostgreSQL_FOUND)
 		set(USE_POSTGRESQL TRUE)
 		message(STATUS "PostgreSQL backend enabled")
 		# This variable is case sensitive, don't try to change it to POSTGRESQL_INCLUDE_DIR
-		message(STATUS "PostgreSQL includes: ${PostgreSQL_INCLUDE_DIR}")
-		include_directories(${PostgreSQL_INCLUDE_DIR})
+		message(STATUS "PostgreSQL includes: ${PostgreSQL_INCLUDE_DIRS}")
+		include_directories(${PostgreSQL_INCLUDE_DIRS})
 	else()
 		message(STATUS "PostgreSQL not found!")
 	endif()
@@ -593,7 +580,7 @@ if(BUILD_CLIENT)
 		target_link_libraries(${PROJECT_NAME} ${CURSES_LIBRARIES})
 	endif()
 	if (USE_POSTGRESQL)
-		target_link_libraries(${PROJECT_NAME} ${POSTGRESQL_LIBRARY})
+		target_link_libraries(${PROJECT_NAME} ${PostgreSQL_LIBRARIES})
 	endif()
 	if (USE_LEVELDB)
 		target_link_libraries(${PROJECT_NAME} ${LEVELDB_LIBRARY})
@@ -628,7 +615,7 @@ if(BUILD_SERVER)
 		target_link_libraries(${PROJECT_NAME}server ${CURSES_LIBRARIES})
 	endif()
 	if (USE_POSTGRESQL)
-		target_link_libraries(${PROJECT_NAME}server ${POSTGRESQL_LIBRARY})
+		target_link_libraries(${PROJECT_NAME}server ${PostgreSQL_LIBRARIES})
 	endif()
 	if (USE_LEVELDB)
 		target_link_libraries(${PROJECT_NAME}server ${LEVELDB_LIBRARY})


### PR DESCRIPTION
@nerzhul , You implemented the original part, please review. Thanks.
https://github.com/minetest/minetest/commit/ce42ff9cf74ebb8d4b68bc78c95e90ea3db02b78

As there might be questions:
See https://cmake.org/cmake/help/v3.14/module/FindPostgreSQL.html

The bulk to get an `PostgreSQL_ADDITIONAL_SEARCH_PATHS` did not work correctly the whole years, so I consider it as not needed.

This makes PostgereSQL usable on Windows too