### PR TITLE
Android settings: Use 'simple' leaves instead of 'fancy' 

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -450,8 +450,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("server_map_save_interval", "15");
 	settings->setDefault("client_mapblock_limit", "1000");
 	settings->setDefault("active_block_range", "2");
-	settings->setDefault("chunksize", "5");
 	settings->setDefault("viewing_range", "50");
+	settings->setDefault("leaves_style", "simple");
 	settings->setDefault("curl_verify_cert","false");
 
 	// Apply settings according to screen size


### PR DESCRIPTION
Fancy leaves are intensive to render.
Also remove the unnecessary duplicated setting of 'chunksize'.
//////////////////////

Android default settings are intentionally very lightweight, for example:
"enable_shaders", "false"
"smooth_lighting", "false"
"enable_3d_clouds", "false"
"viewing_range", "50"

However i discovered that leaves are 'fancy', which has a large performance impact, even for my Core i5 desktop (integrated GPU though).
This also makes the meshes more complex. Creating meshes is a bottleneck for a client, and meshes are by far the largest use of memory for a client.

There are many requests for how to improve FPS performance, "set leaves to opaque" is very often recommended.
The new default mapgen V7 uses MTG's new biome system, which has larger and denser forests, and larger trees.
I find the 'glasslike' drawtype 'simple' leaves unsatisfying, worse than 'opaque', due to the lack of visual density.

EDIT: Changed to 'simple'.