### PR TITLE
Separate server-side disabling of minimap from minimap mode

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2195,43 +2195,49 @@ void Game::toggleMinimap(bool shift_pressed)
 
 	u32 hud_flags = client->getEnv().getLocalPlayer()->hud_flags;
 
-	MinimapMode mode = MINIMAP_MODE_OFF;
-	if (hud_flags & HUD_FLAG_MINIMAP_VISIBLE) {
-		mode = mapper->getMinimapMode();
-		mode = (MinimapMode)((int)mode + 1);
-		// If radar is disabled and in, or switching to, radar mode
-		if (!(hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE) && mode > 3)
-			mode = MINIMAP_MODE_OFF;
-	}
+	MinimapMode mode = mapper->getMinimapMode();
+	mode = static_cast<MinimapMode>(++static_cast<int>(mode));
 
-	m_game_ui->m_flags.show_minimap = true;
+	// If radar is disabled and in or while switching to radar mode, set to OFF
+	if (!(hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE) &&
+			mode > MINIMAP_MODE_SURFACEx4)
+		mode = MINIMAP_MODE_OFF;
+
+	const wchar_t *wchar_status = nullptr;
 	switch (mode) {
 		case MINIMAP_MODE_SURFACEx1:
-			m_game_ui->showTranslatedStatusText("Minimap in surface mode, Zoom x1");
+			wchar_status = wgettext("Minimap in surface mode, Zoom x1");
 			break;
 		case MINIMAP_MODE_SURFACEx2:
-			m_game_ui->showTranslatedStatusText("Minimap in surface mode, Zoom x2");
+			wchar_status = wgettext("Minimap in surface mode, Zoom x2");
 			break;
 		case MINIMAP_MODE_SURFACEx4:
-			m_game_ui->showTranslatedStatusText("Minimap in surface mode, Zoom x4");
+			wchar_status = wgettext("Minimap in surface mode, Zoom x4");
 			break;
 		case MINIMAP_MODE_RADARx1:
-			m_game_ui->showTranslatedStatusText("Minimap in radar mode, Zoom x1");
+			wchar_status = wgettext("Minimap in radar mode, Zoom x1");
 			break;
 		case MINIMAP_MODE_RADARx2:
-			m_game_ui->showTranslatedStatusText("Minimap in radar mode, Zoom x2");
+			wchar_status = wgettext("Minimap in radar mode, Zoom x2");
 			break;
 		case MINIMAP_MODE_RADARx4:
-			m_game_ui->showTranslatedStatusText("Minimap in radar mode, Zoom x4");
+			wchar_status = wgettext("Minimap in radar mode, Zoom x4");
 			break;
 		default:
 			mode = MINIMAP_MODE_OFF;
-			m_game_ui->m_flags.show_minimap = false;
-			if (hud_flags & HUD_FLAG_MINIMAP_VISIBLE)
-				m_game_ui->showTranslatedStatusText("Minimap hidden");
-			else
-				m_game_ui->showTranslatedStatusText("Minimap currently disabled by game or mod");
+			wchar_status = wgettext("Minimap hidden");
+			break;
 	}
+
+	std::wstring wstr_status = wchar_status;
+	if (mapper->isDisabled())
+		wstr_status += L" (" +
+				std::wstring(wgettext("Minimap currently disabled by game or mod")) +
+				L")";
+
+	m_game_ui->showStatusText(wstr_status.c_str());
+
+	delete[] wchar_status;
 
 	mapper->setMinimapMode(mode);
 }

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -68,6 +68,8 @@ struct MinimapMapblock {
 	MinimapPixel data[MAP_BLOCKSIZE * MAP_BLOCKSIZE];
 };
 
+class Minimap;
+
 struct MinimapData {
 	bool is_radar;
 	MinimapMode mode;
@@ -78,6 +80,7 @@ struct MinimapData {
 	MinimapPixel minimap_scan[MINIMAP_MAX_SX * MINIMAP_MAX_SY];
 	bool map_invalidated;
 	bool minimap_shape_round;
+	Minimap *parent = nullptr;
 	video::IImage *minimap_mask_round = nullptr;
 	video::IImage *minimap_mask_square = nullptr;
 	video::ITexture *texture = nullptr;
@@ -133,6 +136,9 @@ public:
 	void setMinimapShape(MinimapShape shape);
 	MinimapShape getMinimapShape();
 
+	void setDisabled(const bool state);
+	const bool isDisabled() const { return m_disabled_by_server; };
+
 
 	video::ITexture *getMinimapTexture();
 
@@ -150,6 +156,7 @@ public:
 	MinimapData *data;
 
 private:
+	bool m_disabled_by_server = false;
 	ITextureSource *m_tsrc;
 	IShaderSource *m_shdrsrc;
 	const NodeDefManager *m_ndef;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1165,24 +1165,22 @@ void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
 
-	bool was_minimap_visible = player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE;
-	bool was_minimap_radar_visible = player->hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE;
+	bool was_radar_visible = player->hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE;
 
 	player->hud_flags &= ~mask;
 	player->hud_flags |= flags;
 
-	m_minimap_disabled_by_server = !(player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE);
-	bool m_minimap_radar_disabled_by_server = !(player->hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE);
+	// Enable/Disable minimap according to state of corresponding flag
+	if (m_minimap) {
+		bool is_disabled = !(player->hud_flags & HUD_FLAG_MINIMAP_VISIBLE);
+		bool is_radar_disabled = !(player->hud_flags & HUD_FLAG_MINIMAP_RADAR_VISIBLE);
 
-	// Hide minimap if it has been disabled by the server
-	if (m_minimap && m_minimap_disabled_by_server && was_minimap_visible)
-		// defers a minimap update, therefore only call it if really
-		// needed, by checking that minimap was visible before
-		m_minimap->setMinimapMode(MINIMAP_MODE_OFF);
+		m_minimap->setDisabled(is_disabled);
 
-	// Switch to surface mode if radar disabled by server
-	if (m_minimap && m_minimap_radar_disabled_by_server && was_minimap_radar_visible)
-		m_minimap->setMinimapMode(MINIMAP_MODE_SURFACEx1);
+		// Switch to surface mode if radar disabled by server
+		if (is_radar_disabled && was_radar_visible)
+			m_minimap->setMinimapMode(MINIMAP_MODE_SURFACEx1);
+	}
 }
 
 void Client::handleCommand_HudSetParam(NetworkPacket* pkt)


### PR DESCRIPTION
- Adds a property `Minimap::m_disabled_by_server` (+ getter `Minimap::isDisabled()` and setter `Minimap::setDisabled()`).
- The code that shows or hides the minimap now also queries this property along with checking if mode == `MINIMAP_MODE_OFF`.
- When the server disables minimap through `hud_set_flags`, the minimap mode is left intact, and the `Minimap::setDisabled` method is invoked instead. So when the minimap is (re-)enabled, the minimap will be restored to its last-used mode.

****

Some code to help with testing:
```lua
minetest.register_chatcommand("minimap", {
	description = "Enables/Disables minimap server-side",
	func = function(name)
		local player = minetest.get_player_by_name(name)
		local state = not player:hud_get_flags().minimap
		player:hud_set_flags({minimap = state})
	end
})
```

Fixes #8431. Tested, works _somewhat_ perfectly.