### PR TITLE
Prioritise craft recipes

### DIFF
--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -407,22 +407,6 @@ void CraftDefinitionShaped::decrementInput(CraftInput &input, std::vector<ItemSt
 	craftDecrementOrReplaceInput(input, output_replacements, replacements, gamedef);
 }
 
-CraftHashType CraftDefinitionShaped::getHashType() const
-{
-	assert(hash_inited); // Pre-condition
-	bool has_group = false;
-	for (const auto &recipe_name : recipe_names) {
-		if (isGroupRecipeStr(recipe_name)) {
-			has_group = true;
-			break;
-		}
-	}
-	if (has_group)
-		return CRAFT_HASH_TYPE_COUNT;
-
-	return CRAFT_HASH_TYPE_ITEM_NAMES;
-}
-
 u64 CraftDefinitionShaped::getHash(CraftHashType type) const
 {
 	assert(hash_inited); // Pre-condition
@@ -440,6 +424,15 @@ void CraftDefinitionShaped::initHash(IGameDef *gamedef)
 		return;
 	hash_inited = true;
 	recipe_names = craftGetItemNames(recipe, gamedef);
+
+	bool has_group = false;
+	for (const auto &recipe_name : recipe_names) {
+		if (isGroupRecipeStr(recipe_name)) {
+			has_group = true;
+			break;
+		}
+	}
+	hash_type = has_group ? CRAFT_HASH_TYPE_COUNT : CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 std::string CraftDefinitionShaped::dump() const
@@ -527,22 +520,6 @@ void CraftDefinitionShapeless::decrementInput(CraftInput &input, std::vector<Ite
 	craftDecrementOrReplaceInput(input, output_replacements, replacements, gamedef);
 }
 
-CraftHashType CraftDefinitionShapeless::getHashType() const
-{
-	assert(hash_inited); // Pre-condition
-	bool has_group = false;
-	for (const auto &recipe_name : recipe_names) {
-		if (isGroupRecipeStr(recipe_name)) {
-			has_group = true;
-			break;
-		}
-	}
-	if (has_group)
-		return CRAFT_HASH_TYPE_COUNT;
-
-	return CRAFT_HASH_TYPE_ITEM_NAMES;
-}
-
 u64 CraftDefinitionShapeless::getHash(CraftHashType type) const
 {
 	assert(hash_inited); // Pre-condition
@@ -558,6 +535,15 @@ void CraftDefinitionShapeless::initHash(IGameDef *gamedef)
 	hash_inited = true;
 	recipe_names = craftGetItemNames(recipe, gamedef);
 	std::sort(recipe_names.begin(), recipe_names.end());
+
+	bool has_group = false;
+	for (const auto &recipe_name : recipe_names) {
+		if (isGroupRecipeStr(recipe_name)) {
+			has_group = true;
+			break;
+		}
+	}
+	hash_type = has_group ? CRAFT_HASH_TYPE_COUNT : CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 std::string CraftDefinitionShapeless::dump() const
@@ -715,14 +701,6 @@ void CraftDefinitionCooking::decrementInput(CraftInput &input, std::vector<ItemS
 	craftDecrementOrReplaceInput(input, output_replacements, replacements, gamedef);
 }
 
-CraftHashType CraftDefinitionCooking::getHashType() const
-{
-	if (isGroupRecipeStr(recipe_name))
-		return CRAFT_HASH_TYPE_COUNT;
-
-	return CRAFT_HASH_TYPE_ITEM_NAMES;
-}
-
 u64 CraftDefinitionCooking::getHash(CraftHashType type) const
 {
 	if (type == CRAFT_HASH_TYPE_ITEM_NAMES) {
@@ -744,6 +722,11 @@ void CraftDefinitionCooking::initHash(IGameDef *gamedef)
 		return;
 	hash_inited = true;
 	recipe_name = craftGetItemName(recipe, gamedef);
+
+	if (isGroupRecipeStr(recipe_name))
+		hash_type = CRAFT_HASH_TYPE_COUNT;
+	else
+		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
 }
 
 std::string CraftDefinitionCooking::dump() const
@@ -808,14 +791,6 @@ void CraftDefinitionFuel::decrementInput(CraftInput &input, std::vector<ItemStac
 	craftDecrementOrReplaceInput(input, output_replacements, replacements, gamedef);
 }
 
-CraftHashType CraftDefinitionFuel::getHashType() const
-{
-	if (isGroupRecipeStr(recipe_name))
-		return CRAFT_HASH_TYPE_COUNT;
-
-	return CRAFT_HASH_TYPE_ITEM_NAMES;
-}
-
 u64 CraftDefinitionFuel::getHash(CraftHashType type) const
 {
 	if (type == CRAFT_HASH_TYPE_ITEM_NAMES) {
@@ -837,7 +812,13 @@ void CraftDefinitionFuel::initHash(IGameDef *gamedef)
 		return;
 	hash_inited = true;
 	recipe_name = craftGetItemName(recipe, gamedef);
+
+	if (isGroupRecipeStr(recipe_name))
+		hash_type = CRAFT_HASH_TYPE_COUNT;
+	else
+		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
 }
+
 std::string CraftDefinitionFuel::dump() const
 {
 	std::ostringstream os(std::ios::binary);

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -432,7 +432,13 @@ void CraftDefinitionShaped::initHash(IGameDef *gamedef)
 			break;
 		}
 	}
-	hash_type = has_group ? CRAFT_HASH_TYPE_COUNT : CRAFT_HASH_TYPE_ITEM_NAMES;
+	if (has_group) {
+		hash_type = CRAFT_HASH_TYPE_COUNT;
+		priority = SHAPED_AND_GROUPS;
+	} else {
+		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
+		priority = SHAPED;
+	}
 }
 
 std::string CraftDefinitionShaped::dump() const
@@ -543,7 +549,13 @@ void CraftDefinitionShapeless::initHash(IGameDef *gamedef)
 			break;
 		}
 	}
-	hash_type = has_group ? CRAFT_HASH_TYPE_COUNT : CRAFT_HASH_TYPE_ITEM_NAMES;
+	if (has_group) {
+		hash_type = CRAFT_HASH_TYPE_COUNT;
+		priority = SHAPELESS_AND_GROUPS;
+	} else {
+		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
+		priority = SHAPELESS;
+	}
 }
 
 std::string CraftDefinitionShapeless::dump() const
@@ -723,10 +735,13 @@ void CraftDefinitionCooking::initHash(IGameDef *gamedef)
 	hash_inited = true;
 	recipe_name = craftGetItemName(recipe, gamedef);
 
-	if (isGroupRecipeStr(recipe_name))
+	if (isGroupRecipeStr(recipe_name)) {
 		hash_type = CRAFT_HASH_TYPE_COUNT;
-	else
+		priority = SHAPELESS_AND_GROUPS;
+	} else {
 		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
+		priority = SHAPELESS;
+	}
 }
 
 std::string CraftDefinitionCooking::dump() const
@@ -813,10 +828,13 @@ void CraftDefinitionFuel::initHash(IGameDef *gamedef)
 	hash_inited = true;
 	recipe_name = craftGetItemName(recipe, gamedef);
 
-	if (isGroupRecipeStr(recipe_name))
+	if (isGroupRecipeStr(recipe_name)) {
 		hash_type = CRAFT_HASH_TYPE_COUNT;
-	else
+		priority = SHAPELESS_AND_GROUPS;
+	} else {
 		hash_type = CRAFT_HASH_TYPE_ITEM_NAMES;
+		priority = SHAPELESS;
+	}
 }
 
 std::string CraftDefinitionFuel::dump() const
@@ -867,7 +885,11 @@ public:
 		input_names = craftGetItemNames(input.items, gamedef);
 		std::sort(input_names.begin(), input_names.end());
 
-		// Try hash types with increasing collision rate, and return if found.
+		// Try hash types with increasing collision rate
+		// while remembering the latest, highest priority recipe.
+		CraftDefinition::RecipePriority priority_best =
+			CraftDefinition::NO_RECIPE;
+		CraftDefinition *def_best;
 		for (int type = 0; type <= craft_hash_type_max; type++) {
 			u64 hash = getHashForGrid((CraftHashType) type, input_names);
 
@@ -890,7 +912,9 @@ public:
 				/*errorstream << "Checking " << input.dump() << std::endl
 					<< " against " << def->dump() << std::endl;*/
 
-				if (def->check(input, gamedef)) {
+				CraftDefinition::RecipePriority priority = def->getPriority();
+				if (priority > priority_best
+						&& def->check(input, gamedef)) {
 					// Check if the crafted node/item exists
 					CraftOutput out = def->getOutput(input, gamedef);
 					ItemStack is;
@@ -901,17 +925,17 @@ public:
 						continue;
 					}
 
-					// Get output, then decrement input (if requested)
 					output = out;
-
-					if (decrementInput)
-						def->decrementInput(input, output_replacement, gamedef);
-					/*errorstream << "Check RETURNS TRUE" << std::endl;*/
-					return true;
+					priority_best = priority;
+					def_best = def;
 				}
 			}
 		}
-		return false;
+		if (priority_best == CraftDefinition::NO_RECIPE)
+			return false;
+		if (decrementInput)
+			def_best->decrementInput(input, output_replacement, gamedef);
+		return true;
 	}
 
 	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -889,7 +889,7 @@ public:
 		// while remembering the latest, highest priority recipe.
 		CraftDefinition::RecipePriority priority_best =
 			CraftDefinition::NO_RECIPE;
-		CraftDefinition *def_best;
+		CraftDefinition *def_best = nullptr;
 		for (int type = 0; type <= craft_hash_type_max; type++) {
 			u64 hash = getHashForGrid((CraftHashType) type, input_names);
 

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -149,13 +149,19 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const=0;
 
-	virtual CraftHashType getHashType() const = 0;
+	CraftHashType getHashType() const
+	{
+		return hash_type;
+	}
 	virtual u64 getHash(CraftHashType type) const = 0;
 
 	// to be called after all mods are loaded, so that we catch all aliases
 	virtual void initHash(IGameDef *gamedef) = 0;
 
 	virtual std::string dump() const=0;
+
+protected:
+	CraftHashType hash_type;
 };
 
 /*
@@ -186,7 +192,6 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
 
-	virtual CraftHashType getHashType() const;
 	virtual u64 getHash(CraftHashType type) const;
 
 	virtual void initHash(IGameDef *gamedef);
@@ -232,7 +237,6 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
 
-	virtual CraftHashType getHashType() const;
 	virtual u64 getHash(CraftHashType type) const;
 
 	virtual void initHash(IGameDef *gamedef);
@@ -274,10 +278,12 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
 
-	virtual CraftHashType getHashType() const { return CRAFT_HASH_TYPE_COUNT; }
 	virtual u64 getHash(CraftHashType type) const { return 2; }
 
-	virtual void initHash(IGameDef *gamedef) {}
+	virtual void initHash(IGameDef *gamedef)
+	{
+		hash_type = CRAFT_HASH_TYPE_COUNT;
+	}
 
 	virtual std::string dump() const;
 
@@ -314,7 +320,6 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
 
-	virtual CraftHashType getHashType() const;
 	virtual u64 getHash(CraftHashType type) const;
 
 	virtual void initHash(IGameDef *gamedef);
@@ -358,7 +363,6 @@ public:
 	virtual void decrementInput(CraftInput &input,
 		std::vector<ItemStack> &output_replacements, IGameDef *gamedef) const;
 
-	virtual CraftHashType getHashType() const;
 	virtual u64 getHash(CraftHashType type) const;
 
 	virtual void initHash(IGameDef *gamedef);

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -132,6 +132,23 @@ struct CraftReplacements
 class CraftDefinition
 {
 public:
+	/*
+		Craft recipe priorities, from low to high
+
+		Recipes are searched from latest to first.
+		If a recipe with higher priority than a previous found one is
+		encountered, it is selected instead.
+	*/
+	enum RecipePriority
+	{
+		NO_RECIPE,
+		TOOLREPAIR,
+		SHAPELESS_AND_GROUPS,
+		SHAPELESS,
+		SHAPED_AND_GROUPS,
+		SHAPED,
+	};
+
 	CraftDefinition() = default;
 	virtual ~CraftDefinition() = default;
 
@@ -140,6 +157,10 @@ public:
 
 	// Checks whether the recipe is applicable
 	virtual bool check(const CraftInput &input, IGameDef *gamedef) const=0;
+	RecipePriority getPriority() const
+	{
+		return priority;
+	}
 	// Returns the output structure, meaning depends on crafting method
 	// The implementation can assume that check(input) returns true
 	virtual CraftOutput getOutput(const CraftInput &input, IGameDef *gamedef) const=0;
@@ -162,6 +183,7 @@ public:
 
 protected:
 	CraftHashType hash_type;
+	RecipePriority priority;
 };
 
 /*
@@ -283,6 +305,7 @@ public:
 	virtual void initHash(IGameDef *gamedef)
 	{
 		hash_type = CRAFT_HASH_TYPE_COUNT;
+		priority = TOOLREPAIR;
 	}
 
 	virtual std::string dump() const;


### PR DESCRIPTION
Fixes #3972 and  #2881

I've also simplified getHashType (the first commit). 

### How to test the changes

Add this recipe to the **end** of default/crafting.lua:
```lua
minetest.register_craft({
	type = "shapeless",
	output = 'default:mese',
	recipe = {'default:coal_lump', 'group:stick'}
})
```
Then start Minetest and try to craft a Torch.

With this PR applied, the Torch recipe is prioritised over the shapeless one.