### PR TITLE
Allow custom values for item wear bar via meta

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1849,6 +1849,7 @@ Some of the values in the key-value store are handled specially:
 * `color`: A `ColorString`, which sets the stack's color.
 * `palette_index`: If the item has a palette, this is used to get the
   current color from the palette.
+* `wear_bar`: A float number, which is used to display a wear bar.
 
 Example:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1849,7 +1849,8 @@ Some of the values in the key-value store are handled specially:
 * `color`: A `ColorString`, which sets the stack's color.
 * `palette_index`: If the item has a palette, this is used to get the
   current color from the palette.
-* `wear_bar`: A float number, which is used to display a wear bar.
+* `wear_bar`: A float number, which is used to display a wear bar. It
+  ranges from 0 (full, green bar) to 1 (empty, red bar).
 
 Example:
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -695,7 +695,8 @@ void drawItemStack(video::IVideoDriver *driver,
 		driver->setViewPort(oldViewPort);
 	}
 
-	if(def.type == ITEM_TOOL && item.wear != 0)
+	const std::string &meta_bar = item.metadata.getString("wear_bar", 0);
+	if((def.type == ITEM_TOOL && item.wear != 0) || !meta_bar.empty())
 	{
 		// Draw a progressbar
 		float barheight = rect.getHeight()/16;
@@ -707,8 +708,14 @@ void drawItemStack(video::IVideoDriver *driver,
 			rect.LowerRightCorner.X - barpad_x,
 			rect.LowerRightCorner.Y - barpad_y);
 
-		// Shrink progressrect by amount of tool damage
-		float wear = item.wear / 65535.0;
+		float wear;
+		if (meta_bar.empty()) {
+			// Shrink progressrect by amount of tool damage
+			wear = item.wear / 65535.0;
+		} else {
+			// Set the bar amount to the value in item meta
+			wear = core::min_(core::max_(stof(meta_bar), 0.0f), 1.0f);
+		}
 		int progressmid =
 			wear * progressrect.UpperLeftCorner.X +
 			(1-wear) * progressrect.LowerRightCorner.X;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -696,7 +696,7 @@ void drawItemStack(video::IVideoDriver *driver,
 	}
 
 	const std::string &meta_bar = item.metadata.getString("wear_bar", 0);
-	if((def.type == ITEM_TOOL && item.wear != 0) || !meta_bar.empty())
+	if ((def.type == ITEM_TOOL && item.wear != 0) || !meta_bar.empty())
 	{
 		// Draw a progressbar
 		float barheight = rect.getHeight()/16;
@@ -711,10 +711,10 @@ void drawItemStack(video::IVideoDriver *driver,
 		float wear;
 		if (meta_bar.empty()) {
 			// Shrink progressrect by amount of tool damage
-			wear = item.wear / 65535.0;
+			wear = item.wear / 65535.0f;
 		} else {
 			// Set the bar amount to the value in item meta
-			wear = core::min_(core::max_(stof(meta_bar), 0.0f), 1.0f);
+			wear = rangelim(stof(meta_bar), 0.0f, 1.0f);
 		}
 		int progressmid =
 			wear * progressrect.UpperLeftCorner.X +


### PR DESCRIPTION
Allow to set the wear bar of an item with item metadata.
The field "wear_bar" is used. Values range from `1`(empty) to `0`(full).

I've used this to test:
```lua
minetest.register_chatcommand("bla", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local item = player:get_wielded_item()
		local meta = item:get_meta()
		meta:set_string("wear_bar", param)
		player:set_wielded_item(item)
		return true, "bla"
	end,
})
```
Screenshot:
![screenshot_20190403_194125](https://user-images.githubusercontent.com/7613443/55500433-9d684080-5648-11e9-8eda-23aaa2d39e8b.png)

Todo: test

Fixes: #6448