### PR TITLE
Fix regression in automatic_face_movement_max_rotation_per_sec

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5680,7 +5680,7 @@ Used by `ObjectRef` methods. Part of an Entity definition.
 
         automatic_face_movement_max_rotation_per_sec = -1,
         -- Limit automatic rotation to this value in degrees per second.
-        -- No limit if value < 0.
+        -- No limit if value <= 0.
 
         backface_culling = true,
         -- Set to false to disable backface_culling for model

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1000,10 +1000,16 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
-		float max_rotation_delta =
-				dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
+		float max_rotation_per_sec =
+				m_prop.automatic_face_movement_max_rotation_per_sec;
+		if (max_rotation_per_sec > 0) {
+			float max_rotation_delta = dtime * max_rotation_per_sec;
 
-		wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
+			wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
+		} else
+			// Negative values of ...max_rotation_per_sec mean disabled.
+			m_rotation.Y = target_yaw;
+
 		rot_translator.val_current = m_rotation;
 
 		updateNodePos();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -997,21 +997,20 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 	if (!getParent() && m_prop.automatic_face_movement_dir &&
 			(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)) {
-
 		float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
 		float max_rotation_per_sec =
 				m_prop.automatic_face_movement_max_rotation_per_sec;
-		if (max_rotation_per_sec > 0) {
-			float max_rotation_delta = dtime * max_rotation_per_sec;
 
-			wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
-		} else
-			// Negative values of ...max_rotation_per_sec mean disabled.
+		if (max_rotation_per_sec > 0) {
+			wrappedApproachShortest(m_rotation.Y, target_yaw,
+				dtime * max_rotation_per_sec, 360.f);
+		} else {
+			// Negative values of max_rotation_per_sec mean disabled.
 			m_rotation.Y = target_yaw;
+		}
 
 		rot_translator.val_current = m_rotation;
-
 		updateNodePos();
 	}
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -457,11 +457,16 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 			float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
-			float max_rotation_delta =
-					dtime * m_prop.automatic_face_movement_max_rotation_per_sec;
 
-			m_rotation.Y = wrapDegrees_0_360(m_rotation.Y);
-			wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
+			float max_rotation_per_sec =
+					m_prop.automatic_face_movement_max_rotation_per_sec;
+			if (max_rotation_per_sec > 0) {
+				float max_rotation_delta = dtime * max_rotation_per_sec;
+				m_rotation.Y = wrapDegrees_0_360(m_rotation.Y);
+				wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
+			} else
+				// Negative values of ...max_rotation_per_sec mean disabled.
+				m_rotation.Y = target_yaw;
 		}
 	}
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -454,19 +454,19 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 
 		if (m_prop.automatic_face_movement_dir &&
 				(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)) {
-
 			float target_yaw = atan2(m_velocity.Z, m_velocity.X) * 180 / M_PI
 				+ m_prop.automatic_face_movement_dir_offset;
-
 			float max_rotation_per_sec =
 					m_prop.automatic_face_movement_max_rotation_per_sec;
+
 			if (max_rotation_per_sec > 0) {
-				float max_rotation_delta = dtime * max_rotation_per_sec;
 				m_rotation.Y = wrapDegrees_0_360(m_rotation.Y);
-				wrappedApproachShortest(m_rotation.Y, target_yaw, max_rotation_delta, 360.f);
-			} else
-				// Negative values of ...max_rotation_per_sec mean disabled.
+				wrappedApproachShortest(m_rotation.Y, target_yaw,
+					dtime * max_rotation_per_sec, 360.f);
+			} else {
+				// Negative values of max_rotation_per_sec mean disabled.
 				m_rotation.Y = target_yaw;
+			}
 		}
 	}
 


### PR DESCRIPTION
Values <= 0 should make the yaw change instant. This worked in 0.4.16 but was broken in 089f59458286.

Per bug report by oil_boi_minetest on IRC.
////////////////////

Closes #8451 
1st commit by p_gimeno.