### PR TITLE
Add automatic_rotate_3d object propertiy

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5671,6 +5671,10 @@ Used by `ObjectRef` methods. Part of an Entity definition.
         automatic_rotate = 0,
         -- Set constant rotation in radians per second, positive or negative.
         -- Set to 0 to disable constant rotation.
+        -- This rotaion is only around y-axis.
+
+        automatic_rotate_3d = {x = 0, y = 0, z = 0},
+        -- Set constant rotation in radians per second in any direction.
 
         stepheight = 0,
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -994,6 +994,11 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		rot_translator.val_current = m_rotation;
 		updateNodePos();
 	}
+	if (!getParent() && m_prop.automatic_rotate_3d.getLengthSQ() > 0.000001f) {
+		m_rotation += dtime * m_prop.automatic_rotate_3d * 180 / M_PI;
+		rot_translator.val_current = m_rotation;
+		updateNodePos();
+	}
 
 	if (!getParent() && m_prop.automatic_face_movement_dir &&
 			(fabs(m_velocity.Z) > 0.001 || fabs(m_velocity.X) > 0.001)) {
@@ -1368,7 +1373,8 @@ void GenericCAO::processMessage(const std::string &data)
 		m_velocity = readV3F32(is);
 		m_acceleration = readV3F32(is);
 
-		if (std::fabs(m_prop.automatic_rotate) < 0.001f)
+		if (std::fabs(m_prop.automatic_rotate) < 0.001f &&
+				m_prop.automatic_rotate_3d.getLengthSQ() < 0.000001f)
 			m_rotation = readV3F32(is);
 		else
 			readV3F32(is);

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -58,6 +58,7 @@ std::string ObjectProperties::dump()
 	os << ", is_visible=" << is_visible;
 	os << ", makes_footstep_sound=" << makes_footstep_sound;
 	os << ", automatic_rotate="<< automatic_rotate;
+	os << ", automatic_rotate_3d="<< PP(automatic_rotate_3d);
 	os << ", backface_culling="<< backface_culling;
 	os << ", glow=" << glow;
 	os << ", nametag=" << nametag;
@@ -115,6 +116,7 @@ void ObjectProperties::serialize(std::ostream &os) const
 	writeF32(os, eye_height);
 	writeF32(os, zoom_fov);
 	writeU8(os, use_texture_alpha);
+	writeV3F32(os, automatic_rotate_3d);
 
 	// Add stuff only at the bottom.
 	// Never remove anything, because we don't want new versions of this
@@ -167,4 +169,5 @@ void ObjectProperties::deSerialize(std::istream &is)
 	eye_height = readF32(is);
 	zoom_fov = readF32(is);
 	use_texture_alpha = readU8(is);
+	automatic_rotate_3d = readV3F32(is);
 }

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -47,6 +47,7 @@ struct ObjectProperties
 	bool makes_footstep_sound = false;
 	f32 stepheight = 0.0f;
 	float automatic_rotate = 0.0f;
+	v3f automatic_rotate_3d = v3f(0.0f, 0.0f, 0.0f);
 	bool automatic_face_movement_dir = false;
 	f32 automatic_face_movement_dir_offset = 0.0f;
 	bool backface_culling = true;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -278,6 +278,10 @@ void read_object_properties(lua_State *L, int index,
 	getfloatfield(L, -1, "eye_height", prop->eye_height);
 
 	getfloatfield(L, -1, "automatic_rotate", prop->automatic_rotate);
+	lua_getfield(L, -1, "automatic_rotate_3d");
+	if (lua_istable(L, -1))
+		prop->automatic_rotate_3d = read_v3f(L, -1);
+	lua_pop(L, 1);
 	lua_getfield(L, -1, "automatic_face_movement_dir");
 	if (lua_isnumber(L, -1)) {
 		prop->automatic_face_movement_dir = true;
@@ -374,6 +378,8 @@ void push_object_properties(lua_State *L, ObjectProperties *prop)
 	lua_setfield(L, -2, "eye_height");
 	lua_pushnumber(L, prop->automatic_rotate);
 	lua_setfield(L, -2, "automatic_rotate");
+	push_v3f(L, prop->automatic_rotate_3d);
+	lua_setfield(L, -2, "automatic_rotate_3d");
 	if (prop->automatic_face_movement_dir)
 		lua_pushnumber(L, prop->automatic_face_movement_dir_offset);
 	else


### PR DESCRIPTION
See #8456 for a description.

Closes #8456.

Lua code to test:
```lua
minetest.register_entity("automatic_rotate_test:ent", {
	initial_properties = {
		collisionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		visual = "cube",
		--~ textures = {},
		--~ automatic_rotate = 0,
		automatic_rotate_3d = {x = 0, y = 0, z = 1},
		--~ automatic_face_movement_dir = 0.0,
		--~ automatic_face_movement_max_rotation_per_sec = -1,
		static_save = false,
	},
})

minetest.register_chatcommand("new", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local rot3d = minetest.string_to_pos(param)
		local player = minetest.get_player_by_name(name)
		local pos = vector.add(vector.add(player:get_pos(), player:get_eye_offset()),
				vector.multiply(player:get_look_dir(), 2))
		pos.y = pos.y + player:get_properties().eye_height
		local obj = minetest.add_entity(pos, "automatic_rotate_test:ent")
		if rot3d then
			obj:set_properties({automatic_rotate_3d = rot3d})
		end
		return true, "new ent"
	end,
})
```

Todo: testing (Somehow the rotation of cubes can look weird.)