### PR TITLE
util/hex.h: Remove whitespace-only line

### DIFF
--- a/src/util/hex.h
+++ b/src/util/hex.h
@@ -27,7 +27,7 @@ static inline std::string hex_encode(const char *data, unsigned int data_size)
 {
 	std::string ret;
 	ret.reserve(data_size * 2);
-	
+
 	char buf2[3];
 	buf2[2] = '\0';
 


### PR DESCRIPTION
This somehow crept into #8450 and was merged in spite of LINT failing.

See the output of LINT in the latest build of #8450: https://travis-ci.org/minetest/minetest/jobs/517077800#L510