### PR TITLE
Reimplement particles using the Irrlicht particle system and improve collision handling

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6831,14 +6831,14 @@ Used by `minetest.add_particle`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
-		bounce_fraction = 1,
-		-- Fraction of the velocity component that is kept after bouncing
-		-- in the corresponding direction.
+        bounce_fraction = 1,
+        -- Fraction of the velocity component that is kept after bouncing
+        -- in the corresponding direction.
 
-		bounce_threshold = 0,
-		-- If the absolute value of the velocity component in the direction
-		-- of a bounce is smaller than bounce_threshold * speed,
-		-- the velocity is set to, i.e. prevents "gliding".
+        bounce_threshold = 0,
+        -- If the absolute value of the velocity component in the direction
+        -- of a bounce is smaller than bounce_threshold * speed,
+        -- the velocity is set to, i.e. prevents "gliding".
 
         texture = "image.png",
 
@@ -6874,7 +6874,7 @@ Used by `minetest.add_particlespawner`.
         maxvel = {x=0, y=0, z=0},
         minacc = {x=0, y=0, z=0},
         maxacc = {x=0, y=0, z=0},
-		-- ^ Is cut off to 0 if the lengths of both minacc and maxacc are smaller than 0.001
+        -- ^ Is cut off to 0 if the lengths of both minacc and maxacc are smaller than 0.001
         minexptime = 1,
         maxexptime = 1,
         minsize = 1,
@@ -6896,14 +6896,14 @@ Used by `minetest.add_particlespawner`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
-		bounce_fraction = 1,
-		-- Fraction of the velocity component that is kept after bouncing
-		-- in the corresponding direction.
+        bounce_fraction = 1,
+        -- Fraction of the velocity component that is kept after bouncing
+        -- in the corresponding direction.
 
-		bounce_threshold = 0,
-		-- If the absolute value of the velocity component in the direction
-		-- of a bounce is smaller than bounce_threshold * speed,
-		-- the velocity is set to, i.e. prevents "gliding".
+        bounce_threshold = 0,
+        -- If the absolute value of the velocity component in the direction
+        -- of a bounce is smaller than bounce_threshold * speed,
+        -- the velocity is set to, i.e. prevents "gliding".
 
         attached = ObjectRef,
         -- If defined, particle positions, velocities and accelerations are

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6831,6 +6831,9 @@ Used by `minetest.add_particle`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
+	-- deprecated: `vertical = false`
+	-- Particles now always face player.
+
         bounce_fraction = 1,
         -- Fraction of the velocity component that is kept after bouncing
         -- in the corresponding direction.
@@ -6908,6 +6911,9 @@ Used by `minetest.add_particlespawner`.
         attached = ObjectRef,
         -- If defined, particle positions, velocities and accelerations are
         -- relative to this object's position and yaw
+
+	-- deprecated: `vertical = false`
+	-- Particles now always face player.
 
         texture = "image.png",
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6868,6 +6868,7 @@ Used by `minetest.add_particlespawner`.
         maxvel = {x=0, y=0, z=0},
         minacc = {x=0, y=0, z=0},
         maxacc = {x=0, y=0, z=0},
+		-- ^ Is cut off to 0 if the lengths of both minacc and maxacc are smaller than 0.001
         minexptime = 1,
         maxexptime = 1,
         minsize = 1,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6831,8 +6831,8 @@ Used by `minetest.add_particle`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
-	-- deprecated: `vertical = false`
-	-- Particles now always face player.
+        -- deprecated: `vertical = false`
+        -- Particles now always face player.
 
         bounce_fraction = 1,
         -- Fraction of the velocity component that is kept after bouncing
@@ -6912,8 +6912,8 @@ Used by `minetest.add_particlespawner`.
         -- If defined, particle positions, velocities and accelerations are
         -- relative to this object's position and yaw
 
-	-- deprecated: `vertical = false`
-	-- Particles now always face player.
+        -- deprecated: `vertical = false`
+        -- Particles now always face player.
 
         texture = "image.png",
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6831,8 +6831,14 @@ Used by `minetest.add_particle`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
-        vertical = false,
-        -- If true faces player using y axis only
+		bounce_fraction = 1,
+		-- Fraction of the velocity component that is kept after bouncing
+		-- in the corresponding direction.
+
+		bounce_threshold = 0,
+		-- If the absolute value of the velocity component in the direction
+		-- of a bounce is smaller than bounce_threshold * speed,
+		-- the velocity is set to, i.e. prevents "gliding".
 
         texture = "image.png",
 
@@ -6890,12 +6896,18 @@ Used by `minetest.add_particlespawner`.
         -- `physical = true,` and `collide_with_objects = true,`.
         -- Requires collisiondetection = true to have any effect.
 
+		bounce_fraction = 1,
+		-- Fraction of the velocity component that is kept after bouncing
+		-- in the corresponding direction.
+
+		bounce_threshold = 0,
+		-- If the absolute value of the velocity component in the direction
+		-- of a bounce is smaller than bounce_threshold * speed,
+		-- the velocity is set to, i.e. prevents "gliding".
+
         attached = ObjectRef,
         -- If defined, particle positions, velocities and accelerations are
         -- relative to this object's position and yaw
-
-        vertical = false,
-        -- If true face player using y axis only
 
         texture = "image.png",
 

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -83,7 +83,8 @@ struct ClientEvent
 			bool collisiondetection;
 			bool collision_removal;
 			bool object_collision;
-			bool vertical;
+			f32 bounce_fraction;
+			f32 bounce_threshold;
 			std::string *texture;
 			struct TileAnimationParams animation;
 			u8 glow;
@@ -105,8 +106,9 @@ struct ClientEvent
 			bool collisiondetection;
 			bool collision_removal;
 			bool object_collision;
+			f32 bounce_fraction;
+			f32 bounce_threshold;
 			u16 attached_id;
-			bool vertical;
 			std::string *texture;
 			u64 id;
 			struct TileAnimationParams animation;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3737,10 +3737,6 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		}
 	}
 
-	/*
-		Update particles
-	*/
-	client->getParticleManager()->step(dtime);
 
 	/*
 		Fog

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -107,10 +107,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< ", view range: "
 			<< (draw_control->range_all ? "All" : itos(draw_control->wanted_range))
 			<< std::setprecision(3)
-			<< ", RTT: " << client->getRTT() << "s"
-			<< ", RTT = " << client->getRTT() << " s"
-			<< ", single particles = " << client->getParticleManager()->getSingleParticleNumber()
-			<< ", particle spawners = " << client->getParticleManager()->getParticleSpawnerNumber();
+			<< ", RTT: " << client->getRTT() << "s";
 		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
 
 		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X,

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -107,7 +107,10 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 			<< ", view range: "
 			<< (draw_control->range_all ? "All" : itos(draw_control->wanted_range))
 			<< std::setprecision(3)
-			<< ", RTT: " << client->getRTT() << "s";
+			<< ", RTT: " << client->getRTT() << "s"
+			<< ", RTT = " << client->getRTT() << " s"
+			<< ", single particles = " << client->getParticleManager()->getSingleParticleNumber()
+			<< ", particle spawners = " << client->getParticleManager()->getParticleSpawnerNumber();
 		setStaticText(m_guitext, utf8_to_wide(os.str()).c_str());
 
 		m_guitext->setRelativePosition(core::rect<s32>(5, 5, screensize.X,

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -219,13 +219,6 @@ public:
 			v3f position = p.pos + camera_offset - dtime * p.vector * 1e3;;
 			v3f velocity = p.vector * 1e3f;
 
-			/*
-			aabb3f box {-half_width,-half_width,-half_width,half_width,half_width,half_width};
-			collisionMoveResult r_old = collisionMoveSimple(env, env->getGameDef(),
-					BS * 0.5, box, 0, dtime, &position, &velocity,
-					v3f {0.f, 0.f, 0.f}, nullptr, object_collision);
-			*/
-
 			collisionMoveResult r = collisionMovePoint(env, env->getGameDef(),
 					half_width, dtime, &position, &velocity, v3f {0.f, 0.f, 0.f},
 					nullptr, bounce_fraction, bounce_threshold, object_collision);
@@ -644,8 +637,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 		ps->addAffector(lighting_affector);
 		lighting_affector->drop();
 
-		ps->setDebugDataVisible(irr::scene::EDS_BBOX);
-
 		// Delete allocated content of event
 		delete event->add_particlespawner.minpos;
 		delete event->add_particlespawner.maxpos;
@@ -714,7 +705,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 			new LightingAffector(m_env, client, 0);
 		ps->addAffector(lighting_affector);
 		lighting_affector->drop();
-
 
 		ps->setMaterialFlag(video::EMF_LIGHTING, false);
 		ps->setMaterialFlag(video::EMF_BACK_FACE_CULLING, false);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include <array>
 #include <atomic>
+#include <cmath>
 
 static std::atomic<u64> single_particles_count(0);
 static std::atomic<u64> particle_spawners_count(0);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -17,8 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "particles.h"
-#include <cmath>
 #include "client.h"
 #include "collision.h"
 #include "client/clientevent.h"
@@ -31,571 +29,715 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "nodedef.h"
 #include "client.h"
 #include "settings.h"
+#include <array>
+#include <atomic>
 
-/*
-	Utility
-*/
+static std::atomic<u64> single_particles_count(0);
+static std::atomic<u64> particle_spawners_count(0);
 
-v3f random_v3f(v3f min, v3f max)
+static v3f random_v3f(v3f min, v3f max)
 {
-	return v3f( rand()/(float)RAND_MAX*(max.X-min.X)+min.X,
-			rand()/(float)RAND_MAX*(max.Y-min.Y)+min.Y,
-			rand()/(float)RAND_MAX*(max.Z-min.Z)+min.Z);
+	return v3f(rand() / (float) RAND_MAX * (max.X - min.X) + min.X,
+		rand() / (float) RAND_MAX * (max.Y - min.Y) + min.Y,
+		rand() / (float) RAND_MAX * (max.Z - min.Z) + min.Z);
 }
 
-Particle::Particle(
-	IGameDef *gamedef,
-	LocalPlayer *player,
-	ClientEnvironment *env,
-	v3f pos,
-	v3f velocity,
-	v3f acceleration,
-	float expirationtime,
-	float size,
-	bool collisiondetection,
-	bool collision_removal,
-	bool object_collision,
-	bool vertical,
-	video::ITexture *texture,
-	v2f texpos,
-	v2f texsize,
-	const struct TileAnimationParams &anim,
-	u8 glow,
-	video::SColor color
-):
-	scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),
-		RenderingEngine::get_scene_manager())
+static irr::core::matrix4 bottomUpTextureMatrix(float scale_x, float scale_y,
+	float coord_x, float coord_y)
 {
-	// Misc
-	m_gamedef = gamedef;
-	m_env = env;
-
-	// Texture
-	m_material.setFlag(video::EMF_LIGHTING, false);
-	m_material.setFlag(video::EMF_BACK_FACE_CULLING, false);
-	m_material.setFlag(video::EMF_BILINEAR_FILTER, false);
-	m_material.setFlag(video::EMF_FOG_ENABLE, true);
-	m_material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	m_material.setTexture(0, texture);
-	m_texpos = texpos;
-	m_texsize = texsize;
-	m_animation = anim;
-
-	// Color
-	m_base_color = color;
-	m_color = color;
-
-	// Particle related
-	m_pos = pos;
-	m_velocity = velocity;
-	m_acceleration = acceleration;
-	m_expiration = expirationtime;
-	m_player = player;
-	m_size = size;
-	m_collisiondetection = collisiondetection;
-	m_collision_removal = collision_removal;
-	m_object_collision = object_collision;
-	m_vertical = vertical;
-	m_glow = glow;
-
-	// Irrlicht stuff
-	m_collisionbox = aabb3f
-			(-size/2,-size/2,-size/2,size/2,size/2,size/2);
-	this->setAutomaticCulling(scene::EAC_OFF);
-
-	// Init lighting
-	updateLight();
-
-	// Init model
-	updateVertices();
+	// Transposed 3x3 2D-transformation matrix padded to 4x4
+	irr::core::matrix4 texture_matrix(irr::core::matrix4::EM4CONST_IDENTITY);
+	// Rotation and scaling
+	texture_matrix[0] = -scale_x;
+	texture_matrix[5] = -scale_y;
+	// Translation
+	texture_matrix[8] = scale_x + coord_x;
+	texture_matrix[9] = scale_y + coord_y;
+	return texture_matrix;
 }
 
-void Particle::OnRegisterSceneNode()
+class CameraOffsetAffector : public irr::scene::IParticleAffector
 {
-	if (IsVisible)
-		SceneManager->registerNodeForRendering(this, scene::ESNRP_TRANSPARENT_EFFECT);
-
-	ISceneNode::OnRegisterSceneNode();
-}
-
-void Particle::render()
-{
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
-	driver->setMaterial(m_material);
-	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
-
-	u16 indices[] = {0,1,2, 2,3,0};
-	driver->drawVertexPrimitiveList(m_vertices, 4,
-			indices, 2, video::EVT_STANDARD,
-			scene::EPT_TRIANGLES, video::EIT_16BIT);
-}
-
-void Particle::step(float dtime)
-{
-	m_time += dtime;
-	if (m_collisiondetection) {
-		aabb3f box = m_collisionbox;
-		v3f p_pos = m_pos * BS;
-		v3f p_velocity = m_velocity * BS;
-		collisionMoveResult r = collisionMoveSimple(m_env, m_gamedef, BS * 0.5f,
-			box, 0.0f, dtime, &p_pos, &p_velocity, m_acceleration * BS, nullptr,
-			m_object_collision);
-		if (m_collision_removal && r.collides) {
-			// force expiration of the particle
-			m_expiration = -1.0;
-		} else {
-			m_pos = p_pos / BS;
-			m_velocity = p_velocity / BS;
-		}
-	} else {
-		m_velocity += m_acceleration * dtime;
-		m_pos += m_velocity * dtime;
-	}
-	if (m_animation.type != TAT_NONE) {
-		m_animation_time += dtime;
-		int frame_length_i, frame_count;
-		m_animation.determineParams(
-				m_material.getTexture(0)->getSize(),
-				&frame_count, &frame_length_i, NULL);
-		float frame_length = frame_length_i / 1000.0;
-		while (m_animation_time > frame_length) {
-			m_animation_frame++;
-			m_animation_time -= frame_length;
-		}
+public:
+	CameraOffsetAffector(const ClientEnvironment &env,
+		irr::scene::IParticleSystemSceneNode *ps, const v3f &position) :
+		env(env), ps(ps), position(position)
+	{
 	}
 
-	// Update lighting
-	updateLight();
+	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	{
+		v3s16 camera_offset = env.getCameraOffset();
+		ps->setPosition(position - intToFloat(camera_offset, BS));
+	}
 
-	// Update model
-	updateVertices();
-}
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	{
+		return irr::scene::EPAT_NONE;
+	}
+private:
+	const ClientEnvironment &env;
+	irr::scene::IParticleSystemSceneNode *const ps;
+	v3f position;
+};
 
-void Particle::updateLight()
+static video::SColor getParticleLightColor(ClientEnvironment *env, const v3f &position,
+	IGameDef *gamedef, u8 glow, const video::SColor &base_color)
 {
 	u8 light = 0;
-	bool pos_ok;
+	bool pos_ok = true;
 
 	v3s16 p = v3s16(
-		floor(m_pos.X+0.5),
-		floor(m_pos.Y+0.5),
-		floor(m_pos.Z+0.5)
-	);
-	MapNode n = m_env->getClientMap().getNodeNoEx(p, &pos_ok);
+		floor(position.X+0.5),
+		floor(position.Y+0.5),
+		floor(position.Z+0.5));
+
+	MapNode map_node = env->getClientMap().getNodeNoEx(p, &pos_ok);
+
 	if (pos_ok)
-		light = n.getLightBlend(m_env->getDayNightRatio(), m_gamedef->ndef());
+		light = map_node.getLightBlend(env->getDayNightRatio(), gamedef->ndef());
 	else
-		light = blend_light(m_env->getDayNightRatio(), LIGHT_SUN, 0);
+		light = blend_light(env->getDayNightRatio(), LIGHT_SUN, 0);
 
-	u8 m_light = decode_light(light + m_glow);
-	m_color.set(255,
-		m_light * m_base_color.getRed() / 255,
-		m_light * m_base_color.getGreen() / 255,
-		m_light * m_base_color.getBlue() / 255);
+	u8 m_light = decode_light(light + glow);
+	return video::SColor (255,
+		m_light * base_color.getRed() / 255,
+		m_light * base_color.getGreen() / 255,
+		m_light * base_color.getBlue() / 255);
 }
 
-void Particle::updateVertices()
+class LightingAffector : public irr::scene::IParticleAffector
 {
-	f32 tx0, tx1, ty0, ty1;
+public:
+	LightingAffector(ClientEnvironment *env, IGameDef *gamedef,
+		u8 glow, const video::SColor &base_color = video::SColor(0xFFFFFFFF))
+		:env(env), gamedef(gamedef), glow(glow),
+		base_color(base_color)
+	{
+	}
 
-	if (m_animation.type != TAT_NONE) {
-		const v2u32 texsize = m_material.getTexture(0)->getSize();
-		v2f texcoord, framesize_f;
+	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	{
+		for (u32 i = 0; i < count; ++i) {
+			v3f pos = particlearray[i].pos +
+				intToFloat(env->getCameraOffset(), BS);
+			color = getParticleLightColor(env, pos / BS,
+				gamedef, glow, base_color);
+			particlearray[i].color = color;
+		}
+	}
+
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	{
+		return irr::scene::EPAT_NONE;
+	}
+private:
+	ClientEnvironment *env;
+	IGameDef *gamedef;
+	u8 glow;
+	video::SColor base_color;
+
+	video::SColor color;
+};
+
+class AnimationAffector : public irr::scene::IParticleAffector
+{
+public:
+	AnimationAffector (irr::scene::IParticleSystemSceneNode *ps,
+		const struct TileAnimationParams &anim)
+		: anim(anim), texture_matrix(&ps->getMaterial(0).getTextureMatrix(0)),
+		texsize(ps->getMaterial(0).getTexture(0)->getSize())
+	{
 		v2u32 framesize;
-		texcoord = m_animation.getTextureCoords(texsize, m_animation_frame);
-		m_animation.determineParams(texsize, NULL, NULL, &framesize);
-		framesize_f = v2f(framesize.X / (float) texsize.X, framesize.Y / (float) texsize.Y);
-
-		tx0 = m_texpos.X + texcoord.X;
-		tx1 = m_texpos.X + texcoord.X + framesize_f.X * m_texsize.X;
-		ty0 = m_texpos.Y + texcoord.Y;
-		ty1 = m_texpos.Y + texcoord.Y + framesize_f.Y * m_texsize.Y;
-	} else {
-		tx0 = m_texpos.X;
-		tx1 = m_texpos.X + m_texsize.X;
-		ty0 = m_texpos.Y;
-		ty1 = m_texpos.Y + m_texsize.Y;
+		anim.determineParams(ps->getMaterial(0).getTexture(0)->getSize(),
+			&frame_count, &frame_length_i, &framesize);
+		framesize_ratio = v2f(framesize.X / (float) texsize.X,
+			framesize.Y / (float) texsize.Y);
 	}
 
-	m_vertices[0] = video::S3DVertex(-m_size / 2, -m_size / 2,
-		0, 0, 0, 0, m_color, tx0, ty1);
-	m_vertices[1] = video::S3DVertex(m_size / 2, -m_size / 2,
-		0, 0, 0, 0, m_color, tx1, ty1);
-	m_vertices[2] = video::S3DVertex(m_size / 2, m_size / 2,
-		0, 0, 0, 0, m_color, tx1, ty0);
-	m_vertices[3] = video::S3DVertex(-m_size / 2, m_size / 2,
-		0, 0, 0, 0, m_color, tx0, ty0);
-
-	v3s16 camera_offset = m_env->getCameraOffset();
-	for (video::S3DVertex &vertex : m_vertices) {
-		if (m_vertical) {
-			v3f ppos = m_player->getPosition()/BS;
-			vertex.Pos.rotateXZBy(std::atan2(ppos.Z - m_pos.Z, ppos.X - m_pos.X) /
-				core::DEGTORAD + 90);
-		} else {
-			vertex.Pos.rotateYZBy(m_player->getPitch());
-			vertex.Pos.rotateXZBy(m_player->getYaw());
-		}
-		m_box.addInternalPoint(vertex.Pos);
-		vertex.Pos += m_pos*BS - intToFloat(camera_offset, BS);
-	}
-}
-
-/*
-	ParticleSpawner
-*/
-
-ParticleSpawner::ParticleSpawner(
-	IGameDef *gamedef,
-	LocalPlayer *player,
-	u16 amount,
-	float time,
-	v3f minpos, v3f maxpos,
-	v3f minvel, v3f maxvel,
-	v3f minacc, v3f maxacc,
-	float minexptime, float maxexptime,
-	float minsize, float maxsize,
-	bool collisiondetection,
-	bool collision_removal,
-	bool object_collision,
-	u16 attached_id,
-	bool vertical,
-	video::ITexture *texture,
-	const struct TileAnimationParams &anim,
-	u8 glow,
-	ParticleManager *p_manager
-):
-	m_particlemanager(p_manager)
-{
-	m_gamedef = gamedef;
-	m_player = player;
-	m_amount = amount;
-	m_spawntime = time;
-	m_minpos = minpos;
-	m_maxpos = maxpos;
-	m_minvel = minvel;
-	m_maxvel = maxvel;
-	m_minacc = minacc;
-	m_maxacc = maxacc;
-	m_minexptime = minexptime;
-	m_maxexptime = maxexptime;
-	m_minsize = minsize;
-	m_maxsize = maxsize;
-	m_collisiondetection = collisiondetection;
-	m_collision_removal = collision_removal;
-	m_object_collision = object_collision;
-	m_attached_id = attached_id;
-	m_vertical = vertical;
-	m_texture = texture;
-	m_time = 0;
-	m_animation = anim;
-	m_glow = glow;
-
-	for (u16 i = 0; i<=m_amount; i++)
+	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
 	{
-		float spawntime = (float)rand()/(float)RAND_MAX*m_spawntime;
-		m_spawntimes.push_back(spawntime);
-	}
-}
-
-void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
-	bool is_attached, const v3f &attached_pos, float attached_yaw)
-{
-	v3f ppos = m_player->getPosition() / BS;
-	v3f pos = random_v3f(m_minpos, m_maxpos);
-
-	// Need to apply this first or the following check
-	// will be wrong for attached spawners
-	if (is_attached) {
-		pos.rotateXZBy(attached_yaw);
-		pos += attached_pos;
-	}
-
-	if (pos.getDistanceFrom(ppos) > radius)
-		return;
-
-	v3f vel = random_v3f(m_minvel, m_maxvel);
-	v3f acc = random_v3f(m_minacc, m_maxacc);
-
-	if (is_attached) {
-		// Apply attachment yaw
-		vel.rotateXZBy(attached_yaw);
-		acc.rotateXZBy(attached_yaw);
-	}
-
-	float exptime = rand() / (float)RAND_MAX
-			* (m_maxexptime - m_minexptime)
-			+ m_minexptime;
-	float size = rand() / (float)RAND_MAX
-			* (m_maxsize - m_minsize)
-			+ m_minsize;
-
-	m_particlemanager->addParticle(new Particle(
-		m_gamedef,
-		m_player,
-		env,
-		pos,
-		vel,
-		acc,
-		exptime,
-		size,
-		m_collisiondetection,
-		m_collision_removal,
-		m_object_collision,
-		m_vertical,
-		m_texture,
-		v2f(0.0, 0.0),
-		v2f(1.0, 1.0),
-		m_animation,
-		m_glow
-	));
-}
-
-void ParticleSpawner::step(float dtime, ClientEnvironment* env)
-{
-	m_time += dtime;
-
-	static thread_local const float radius =
-			g_settings->getS16("max_block_send_distance") * MAP_BLOCKSIZE;
-
-	bool unloaded = false;
-	bool is_attached = false;
-	v3f attached_pos = v3f(0,0,0);
-	float attached_yaw = 0;
-	if (m_attached_id != 0) {
-		if (ClientActiveObject *attached = env->getActiveObject(m_attached_id)) {
-			attached_pos = attached->getPosition() / BS;
-			attached_yaw = attached->getYaw();
-			is_attached = true;
-		} else {
-			unloaded = true;
-		}
-	}
-
-	if (m_spawntime != 0) {
-		// Spawner exists for a predefined timespan
-		for (std::vector<float>::iterator i = m_spawntimes.begin();
-				i != m_spawntimes.end();) {
-			if ((*i) <= m_time && m_amount > 0) {
-				m_amount--;
-
-				// Pretend to, but don't actually spawn a particle if it is
-				// attached to an unloaded object or distant from player.
-				if (!unloaded)
-					spawnParticle(env, radius, is_attached, attached_pos, attached_yaw);
-
-				i = m_spawntimes.erase(i);
-			} else {
-				++i;
-			}
-		}
-	} else {
-		// Spawner exists for an infinity timespan, spawn on a per-second base
-
-		// Skip this step if attached to an unloaded object
-		if (unloaded)
+		if (last_time == 0) {
+			last_time = now;
 			return;
-
-		for (int i = 0; i <= m_amount; i++) {
-			if (rand() / (float)RAND_MAX < dtime)
-				spawnParticle(env, radius, is_attached, attached_pos, attached_yaw);
 		}
-	}
-}
 
+		animation_time += (now - last_time) * 1e-3f;
+		last_time = now;
+		float frame_length = frame_length_i * 1e-3f;
 
-ParticleManager::ParticleManager(ClientEnvironment* env) :
-	m_env(env)
-{}
+		animation_frame += (int) (animation_time / frame_length);
+		animation_frame %= frame_count;
+		animation_time = fmodf(animation_time, frame_length);
 
-ParticleManager::~ParticleManager()
-{
-	clearAll();
-}
-
-void ParticleManager::step(float dtime)
-{
-	stepParticles (dtime);
-	stepSpawners (dtime);
-}
-
-void ParticleManager::stepSpawners (float dtime)
-{
-	MutexAutoLock lock(m_spawner_list_lock);
-	for (auto i = m_particle_spawners.begin(); i != m_particle_spawners.end();) {
-		if (i->second->get_expired()) {
-			delete i->second;
-			m_particle_spawners.erase(i++);
-		} else {
-			i->second->step(dtime, m_env);
-			++i;
-		}
-	}
-}
-
-void ParticleManager::stepParticles (float dtime)
-{
-	MutexAutoLock lock(m_particle_list_lock);
-	for (auto i = m_particles.begin(); i != m_particles.end();) {
-		if ((*i)->get_expired()) {
-			(*i)->remove();
-			delete *i;
-			i = m_particles.erase(i);
-		} else {
-			(*i)->step(dtime);
-			++i;
-		}
-	}
-}
-
-void ParticleManager::clearAll ()
-{
-	MutexAutoLock lock(m_spawner_list_lock);
-	MutexAutoLock lock2(m_particle_list_lock);
-	for (auto i = m_particle_spawners.begin(); i != m_particle_spawners.end();) {
-		delete i->second;
-		m_particle_spawners.erase(i++);
+		v2f texcoord = anim.getTextureCoords(texsize, animation_frame);
+		*texture_matrix = bottomUpTextureMatrix(framesize_ratio.X, framesize_ratio.Y, texcoord.X, texcoord.Y);
 	}
 
-	for(std::vector<Particle*>::iterator i =
-			m_particles.begin();
-			i != m_particles.end();)
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
 	{
-		(*i)->remove();
-		delete *i;
-		i = m_particles.erase(i);
+		return irr::scene::EPAT_NONE;
 	}
-}
+private:
+	const struct TileAnimationParams anim;
+	float animation_time = 0.f;
+	int animation_frame = 0;
+	int frame_length_i, frame_count;
+	core::matrix4 *texture_matrix;
+	const v2u32 texsize;
+	v2f framesize_ratio;
+	u32 last_time = 0;
+};
 
-void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
-	LocalPlayer *player)
+// Should be added before AccelerationAffector to make behaviour in case of
+// collision consistent with the one for no collision
+class CollisionAffector : public irr::scene::IParticleAffector
 {
-	switch (event->type) {
-		case CE_DELETE_PARTICLESPAWNER: {
-			MutexAutoLock lock(m_spawner_list_lock);
-			if (m_particle_spawners.find(event->delete_particlespawner.id) !=
-					m_particle_spawners.end()) {
-				delete m_particle_spawners.find(event->delete_particlespawner.id)->second;
-				m_particle_spawners.erase(event->delete_particlespawner.id);
-			}
-			// no allocated memory in delete event
-			break;
+public:
+	CollisionAffector(ClientEnvironment *env, bool collision_removal, bool object_collision)
+		: env(env), last_time(0), collision_removal(collision_removal),
+		object_collision(object_collision)
+	{
+	}
+
+	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	{
+		if (last_time == 0) {
+			last_time = now;
+			return;
 		}
-		case CE_ADD_PARTICLESPAWNER: {
-			{
-				MutexAutoLock lock(m_spawner_list_lock);
-				if (m_particle_spawners.find(event->add_particlespawner.id) !=
-						m_particle_spawners.end()) {
-					delete m_particle_spawners.find(event->add_particlespawner.id)->second;
-					m_particle_spawners.erase(event->add_particlespawner.id);
+		f32 dtime = (now - last_time) * 1e-3f;
+		last_time = now;
+
+		for (u32 i = 0; i < count; ++i) {
+			irr::scene::SParticle &p = particlearray[i];
+			float half_width = p.size.Width / 2;
+			aabb3f box {-half_width,-half_width,-half_width,half_width,half_width,half_width};
+			v3f camera_offset = intToFloat(env->getCameraOffset(),BS);
+
+			// Undo Irrlicht position step
+			v3f position = p.pos + camera_offset - dtime * p.vector * 1e3;;
+			v3f velocity = p.vector * 1e3f;
+
+			collisionMoveResult r = collisionMoveSimple(env, env->getGameDef(),
+					BS * 0.5, box, 0, dtime, &position, &velocity,
+					v3f {0.f, 0.f, 0.f}, nullptr, object_collision);
+
+			if (r.collides) {
+				if (collision_removal) {
+					p.endTime = 0;
+				} else {
+					p.pos = position - camera_offset;
+					p.vector = velocity * 1e-3f;
+				}
+			}
+		}
+	}
+
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	{
+		return irr::scene::EPAT_NONE;
+	}
+private:
+	ClientEnvironment *env;
+	u32 last_time;
+	const bool collision_removal;
+	const bool object_collision;
+};
+
+class AccelerationAffector : public irr::scene::IParticleAffector
+{
+public:
+	AccelerationAffector(const v3f &minacc, const v3f &maxacc)
+		: last_time(0)
+	{
+		disabled = minacc.getLengthSQ() <= 1e-6 && maxacc.getLengthSQ() <= 1e-6;
+		acc = random_v3f(minacc,maxacc);
+	}
+	AccelerationAffector(const v3f &acc)
+		: acc(acc), disabled(acc.getLengthSQ() == 0.f), last_time(0)
+	{
+	}
+
+	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	{
+		if (last_time == 0) {
+			last_time = now;
+			return;
+		}
+		float dtime = (now - last_time) * 1e-3f;
+		last_time = now;
+		for (u32 i = 0; i < count; ++i) {
+			particlearray[i].vector += dtime * acc * BS * 1e-3f;
+		}
+	}
+
+	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	{
+		return irr::scene::EPAT_NONE;
+	}
+private:
+	v3f acc;
+	bool disabled;
+	u32 last_time;
+};
+class CustomEmitter : public irr::scene::IParticleEmitter
+{
+public:
+	// unused pure virtual methods
+	virtual void setDirection(const core::vector3df& /* newDirection */) {}
+	virtual void setMinParticlesPerSecond(u32 /* minPPS */) {}
+	virtual void setMaxParticlesPerSecond(u32 /* maxPPS */) {}
+	virtual void setMinStartColor(const video::SColor& /* color */) {}
+	virtual void setMaxStartColor(const video::SColor& /* color */) {}
+	virtual void setMaxLifeTime(const u32 /* t */) {}
+	virtual void setMinLifeTime(const u32 /* t */) {}
+	virtual u32 getMaxLifeTime() const {return 1;}
+	virtual u32 getMinLifeTime() const {return 1;}
+	virtual void setMaxAngleDegrees(const s32 /* t */) {}
+	virtual s32 getMaxAngleDegrees() const {return 0;}
+	virtual void setMaxStartSize(const core::dimension2df& /* size */) {}
+	virtual void setMinStartSize(const core::dimension2df& /* size */) {}
+	virtual void setCenter(const core::vector3df& /* center */) {}
+	virtual void setRadius(f32 /* radius */) {}
+	virtual const core::vector3df& getDirection() const {return direction;}
+	virtual u32 getMinParticlesPerSecond() const {return 1;}
+	virtual u32 getMaxParticlesPerSecond() const {return 1;}
+	virtual const video::SColor& getMinStartColor() const {return minStartColor;}
+	virtual const video::SColor& getMaxStartColor() const {return maxStartColor;}
+	virtual const core::dimension2df& getMaxStartSize() const {return max_size;}
+	virtual const core::dimension2df& getMinStartSize() const {return min_size;}
+	virtual const core::vector3df& getCenter() const {return center;}
+	virtual f32 getRadius() const {return 1.f;}
+	virtual irr::scene::E_PARTICLE_EMITTER_TYPE getType() const
+	{
+		return irr::scene::EPET_COUNT;
+	}
+protected:
+	core::dimension2df min_size, max_size;
+private:
+	// unused
+	const v3f direction;
+	const video::SColor minStartColor, maxStartColor;
+	const v3f center;
+};
+
+class SingleEmitter : public CustomEmitter
+{
+public:
+	SingleEmitter(irr::scene::ISceneManager *smgr,
+		irr::scene::IParticleSystemSceneNode *ps, const video::SColor &color, u32 number) :
+		smgr(smgr), ps(ps), number(number), deletion_time(0), color(color),
+		random_properties(true)
+	{
+		particles.reserve(number);
+		++single_particles_count;
+	}
+
+	SingleEmitter(irr::scene::ISceneManager *smgr,
+		irr::scene::IParticleSystemSceneNode *ps, const video::SColor &color,
+		f32 expirationtime, f32 size, const v3f &vel):
+		smgr(smgr), ps(ps), number(1), deletion_time(0), color(color),
+		expirationtime((u32) expirationtime * 1e3f), size(size), pos(0), vel(vel),
+		random_properties(false)
+	{
+		++single_particles_count;
+	}
+
+	~SingleEmitter()
+	{
+		--single_particles_count;
+	}
+
+	virtual s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray)
+	{
+		if (number == 0) {
+			if (now > deletion_time)
+				smgr->addToDeletionQueue(ps);
+			return 0;
+		}
+		if (random_properties)
+			deletion_time = now + 1000;
+		else
+			deletion_time = now + expirationtime;
+
+		irr::scene::SParticle p;
+		p.color = color;
+		p.startColor = p.color;
+		for (u32 i = 0; i < number; ++i) {
+			if (random_properties) {
+				pos = {
+					rand() % 100 / 200.f - 0.25f,
+					rand() % 100 / 200.f - 0.25f,
+					rand() % 100 / 200.f - 0.25f
+				};
+				vel = {
+					rand() % 150 / 50.f - 1.5f,
+					rand() % 150 / 50.f,
+					rand() % 150 / 50.f - 1.5f
+				};
+				size = rand() % 8 / 64.f * BS;
+			}
+			p.pos.set(pos);
+			p.startVector = p.vector = vel * BS * 1e-3f;
+
+			p.startTime = now;
+			if (random_properties)
+				p.endTime = now + (u32) (rand() % 100 * 10.f);
+			else
+				p.endTime = now + (u32) (expirationtime * 1e3f);
+
+			p.startSize = core::dimension2df(size,size);
+			p.size = p.startSize;
+			particles.push_back(p);
+		}
+		outArray = particles.data();
+		number = 0;
+		return particles.size();
+	}
+private:
+	irr::scene::ISceneManager *smgr;
+	irr::scene::IParticleSystemSceneNode *ps;
+	u32 number;
+	std::vector<irr::scene::SParticle> particles;
+	u32 deletion_time;
+	video::SColor color;
+	u32 expirationtime;
+
+	f32 size;
+	v3f pos, vel;
+	const bool random_properties;
+};
+
+class ContinuousEmitter : public CustomEmitter
+{
+public:
+	ContinuousEmitter(irr::scene::ISceneManager *smgr,
+		ClientEnvironment *env, irr::scene::IParticleSystemSceneNode *ps,
+		u16 amount, f32 spawntime, const v3f &minrelpos, const v3f &maxrelpos,
+		const v3f &minvel, const v3f &maxvel, f32 minexptime,
+		f32 maxexptime, f32 minsize, f32 maxsize, u16 attached_id)
+		: smgr(smgr), env(env), ps(ps), remaining_amount(amount),
+		spawntime(spawntime), minrelpos(minrelpos), maxrelpos(maxrelpos),
+		minvel(minvel), maxvel(maxvel), minexptime(minexptime),
+		maxexptime(maxexptime), minsize(minsize), maxsize(maxsize),
+		attached_id(attached_id), expired_time(0), emitting_time(0.f)
+	{
+		time_for_particle = spawntime == 0 ? 1.f / (float) amount :
+			spawntime / (float) amount;
+		++particle_spawners_count;
+	}
+
+	~ContinuousEmitter()
+	{
+		--particle_spawners_count;
+	}
+
+	virtual s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray)
+	{
+		if (spawntime != 0) {
+			expired_time += timeSinceLastCall;
+			if (expired_time * 1e-3f >= maxexptime + spawntime)
+				smgr->addToDeletionQueue(ps);
+
+			// Don't delete yet because of the existing particles
+			if (remaining_amount == 0)
+				return 0;
+		}
+
+		emitting_time += timeSinceLastCall * 1e-3f;
+		if (emitting_time >= time_for_particle) {
+			emitting_time = 0.f;
+			p.color = video::SColor(0xFFFFFFFF);
+			p.startColor = p.color;
+
+			p.pos = random_v3f(minrelpos, maxrelpos);
+			v3f vel = random_v3f(minvel, maxvel);
+			if (attached_id != 0) {
+				ClientActiveObject *attached =
+					env->getActiveObject(attached_id);
+				if (attached) {
+					vel.rotateXZBy(attached->getYaw());
+					p.pos.rotateXZBy(attached->getYaw());
+					ps->setPosition(attached->getPosition());
+				} else {
+					return 0;
 				}
 			}
 
-			video::ITexture *texture =
-				client->tsrc()->getTextureForMesh(*(event->add_particlespawner.texture));
+			// Velocity per millisecond
+			p.startVector = p.vector = random_v3f(minvel, maxvel) * BS * 1e-3f;
+			float size = minsize + (float) rand() / (float) RAND_MAX *
+				(maxsize - minsize);
+			p.size = core::dimension2df(size,size);
 
-			auto toadd = new ParticleSpawner(client, player,
-					event->add_particlespawner.amount,
-					event->add_particlespawner.spawntime,
-					*event->add_particlespawner.minpos,
-					*event->add_particlespawner.maxpos,
-					*event->add_particlespawner.minvel,
-					*event->add_particlespawner.maxvel,
-					*event->add_particlespawner.minacc,
-					*event->add_particlespawner.maxacc,
-					event->add_particlespawner.minexptime,
-					event->add_particlespawner.maxexptime,
-					event->add_particlespawner.minsize,
-					event->add_particlespawner.maxsize,
-					event->add_particlespawner.collisiondetection,
-					event->add_particlespawner.collision_removal,
-					event->add_particlespawner.object_collision,
-					event->add_particlespawner.attached_id,
-					event->add_particlespawner.vertical,
-					texture,
-					event->add_particlespawner.animation,
-					event->add_particlespawner.glow,
-					this);
+			p.startTime = now;
+			p.endTime = now + (u32) ((minexptime +
+				(float) rand() / (float) RAND_MAX *
+				(maxexptime - minexptime)) * 1e3f);
 
-			/* delete allocated content of event */
-			delete event->add_particlespawner.minpos;
-			delete event->add_particlespawner.maxpos;
-			delete event->add_particlespawner.minvel;
-			delete event->add_particlespawner.maxvel;
-			delete event->add_particlespawner.minacc;
-			delete event->add_particlespawner.texture;
-			delete event->add_particlespawner.maxacc;
+			if (remaining_amount > 0)
+				--remaining_amount;
+			outArray = &p;
+			return 1;
+		}
+		return 0;
+	}
+private:
+	irr::scene::ISceneManager *smgr;
+	ClientEnvironment *env;
+	irr::scene::IParticleSystemSceneNode *ps;
+	u16 remaining_amount;
+	f32 spawntime;
+	const v3f minrelpos, maxrelpos, minvel, maxvel;
+	const f32 minexptime, maxexptime;
+	const f32 minsize, maxsize;
+	const u16 attached_id;
 
-			{
-				MutexAutoLock lock(m_spawner_list_lock);
-				m_particle_spawners[event->add_particlespawner.id] = toadd;
+	u32 expired_time;
+	float emitting_time;
+	float time_for_particle;
+
+	irr::scene::SParticle p;
+
+};
+
+ParticleManager::ParticleManager(ClientEnvironment *env)
+	:m_env(env)
+{
+	m_smgr = RenderingEngine::get_scene_manager();
+}
+
+ParticleManager::~ParticleManager()
+{
+}
+
+void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, LocalPlayer *player)
+{
+	switch (event->type) {
+	case CE_DELETE_PARTICLESPAWNER: {
+		//scene::ISceneNode *node = m_particle_spawners.
+		MutexAutoLock lock(m_spawner_list_lock);
+		auto node_it = m_particle_spawners.find(event->delete_particlespawner.id);
+		if (node_it != m_particle_spawners.end()) {
+			m_smgr->addToDeletionQueue(node_it->second);
+			m_particle_spawners.erase(node_it);
+		}
+		
+		// No allocated memory in delete event
+		break;
+	}
+	case CE_ADD_PARTICLESPAWNER: {
+		{
+			MutexAutoLock lock(m_spawner_list_lock);
+			auto node_it = m_particle_spawners.find(event->add_particlespawner.id);
+			if (node_it != m_particle_spawners.end()) {
+				m_smgr->addToDeletionQueue(node_it->second);
+				m_particle_spawners.erase(node_it);
 			}
-			break;
 		}
-		case CE_SPAWN_PARTICLE: {
-			video::ITexture *texture =
-				client->tsrc()->getTextureForMesh(*(event->spawn_particle.texture));
 
-			Particle *toadd = new Particle(client, player, m_env,
-					*event->spawn_particle.pos,
-					*event->spawn_particle.vel,
-					*event->spawn_particle.acc,
-					event->spawn_particle.expirationtime,
-					event->spawn_particle.size,
-					event->spawn_particle.collisiondetection,
-					event->spawn_particle.collision_removal,
-					event->spawn_particle.object_collision,
-					event->spawn_particle.vertical,
-					texture,
-					v2f(0.0, 0.0),
-					v2f(1.0, 1.0),
-					event->spawn_particle.animation,
-					event->spawn_particle.glow);
+		scene::IParticleSystemSceneNode *ps =
+			m_smgr->addParticleSystemSceneNode(false,
+				RenderingEngine::get_scene_manager()->getRootSceneNode());
 
-			addParticle(toadd);
-
-			delete event->spawn_particle.pos;
-			delete event->spawn_particle.vel;
-			delete event->spawn_particle.acc;
-			delete event->spawn_particle.texture;
-
-			break;
+		{
+			MutexAutoLock lock(m_spawner_list_lock);
+			m_particle_spawners.insert({event->add_particlespawner.id, ps});
 		}
-		default: break;
+
+		ps->getMaterial(0).getTextureMatrix(0) = bottomUpTextureMatrix(1.f,1.f,0.f,0.f);
+
+		v3f minpos = *event->add_particlespawner.minpos * BS;
+		v3f maxpos = *event->add_particlespawner.maxpos * BS;
+		v3f meanpos = (minpos + maxpos) / 2.f;
+		ps->setPosition(meanpos);
+
+		scene::IParticlePointEmitter *continous_emitter =
+			new ContinuousEmitter(m_smgr, m_env, ps,
+			event->add_particlespawner.amount,
+			event->add_particlespawner.spawntime,
+			minpos - meanpos,
+			maxpos - meanpos,
+			*event->add_particlespawner.minvel,
+			*event->add_particlespawner.maxvel,
+			event->add_particlespawner.minexptime,
+			event->add_particlespawner.maxexptime,
+			event->add_particlespawner.minsize,
+			event->add_particlespawner.maxsize,
+			event->add_particlespawner.attached_id);
+
+		ps->setEmitter(continous_emitter);
+		continous_emitter->drop();
+		ps->setAutomaticCulling(scene::EAC_FRUSTUM_BOX);
+
+		scene::IParticleAffector *camera_offset_affector =
+			new CameraOffsetAffector(*m_env, ps,meanpos);
+		ps->addAffector(camera_offset_affector);
+		camera_offset_affector->drop();
+
+		video::ITexture *texture = client->tsrc()->getTextureForMesh(
+			*(event->add_particlespawner.texture));
+		ps->setMaterialTexture(0, texture);
+
+		ps->setMaterialFlag(video::EMF_LIGHTING, false);
+		ps->setMaterialFlag(video::EMF_BACK_FACE_CULLING, false);
+		ps->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
+		ps->setMaterialFlag(video::EMF_FOG_ENABLE, true);
+		ps->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL);
+
+		const struct TileAnimationParams &anim = event->add_particlespawner.animation;
+		if (anim.type != TAT_NONE) {
+			scene::IParticleAffector *animation_affector =
+				new AnimationAffector(ps, anim);
+			ps->addAffector(animation_affector);
+			animation_affector->drop();
+		}
+
+		if (event->add_particlespawner.collisiondetection) {
+			scene::IParticleAffector *collision_affector =
+				new CollisionAffector(m_env,
+					event->add_particlespawner.collision_removal,
+					event->add_particlespawner.object_collision);
+			ps->addAffector(collision_affector);
+			collision_affector->drop();
+		}
+
+		scene::IParticleAffector *acceleration_affector =
+			new AccelerationAffector(*event->add_particlespawner.minacc,
+				*event->add_particlespawner.maxacc);
+		ps->addAffector(acceleration_affector);
+		acceleration_affector->drop();
+
+
+		scene::IParticleAffector *lighting_affector =
+			new LightingAffector(m_env, client, 0);
+		ps->addAffector(lighting_affector);
+		lighting_affector->drop();
+
+		ps->setDebugDataVisible(irr::scene::EDS_BBOX);
+
+		// Delete allocated content of event
+		delete event->add_particlespawner.minpos;
+		delete event->add_particlespawner.maxpos;
+		delete event->add_particlespawner.minvel;
+		delete event->add_particlespawner.maxvel;
+		delete event->add_particlespawner.minacc;
+		delete event->add_particlespawner.maxacc;
+		delete event->add_particlespawner.texture;
+		break;
+	}
+	case CE_SPAWN_PARTICLE: {
+		scene::IParticleSystemSceneNode *ps =
+			m_smgr->addParticleSystemSceneNode(false,
+				RenderingEngine::get_scene_manager()->getRootSceneNode());
+
+		ps->getMaterial(0).getTextureMatrix(0) = bottomUpTextureMatrix(1.f,1.f,0.f,0.f);
+
+		video::ITexture *texture =
+			client->tsrc()->getTextureForMesh(
+				*(event->spawn_particle.texture));
+		ps->setMaterialTexture(0, texture);
+
+		v3s16 camera_offset = m_env->getCameraOffset();
+		v3f particle_pos = *event->spawn_particle.pos * BS - intToFloat(camera_offset, BS);
+		ps->setPosition(particle_pos);
+
+		scene::IParticleAffector *camera_offset_affector =
+			new CameraOffsetAffector(*m_env, ps, particle_pos);
+		ps->addAffector(camera_offset_affector);
+		camera_offset_affector->drop();
+
+		// Deletes ps after the particles have vanished
+		scene::IParticleEmitter *em = new SingleEmitter(m_smgr, ps,
+			event->spawn_particle.glow,
+			event->spawn_particle.expirationtime,
+			event->spawn_particle.size,
+			*event->spawn_particle.vel);
+		ps->setEmitter(em);
+		em->drop();
+
+		const struct TileAnimationParams &anim = event->spawn_particle.animation;
+		if (anim.type != TAT_NONE) {
+			scene::IParticleAffector *animation_affector =
+				new AnimationAffector(ps, anim);
+			ps->addAffector(animation_affector);
+			animation_affector->drop();
+		}
+
+		if (event->spawn_particle.collisiondetection){
+			scene::IParticleAffector *collision_affector =
+				new CollisionAffector(m_env,
+				event->spawn_particle.collision_removal,
+				event->spawn_particle.object_collision);
+			ps->addAffector(collision_affector);
+			collision_affector->drop();
+		}
+
+		scene::IParticleAffector *acceleration_affector =
+			new AccelerationAffector(*event->spawn_particle.acc);
+		ps->addAffector(acceleration_affector);
+		acceleration_affector->drop();
+
+		scene::IParticleAffector *lighting_affector =
+			new LightingAffector(m_env, client, 0);
+		ps->addAffector(lighting_affector);
+		lighting_affector->drop();
+
+
+		ps->setMaterialFlag(video::EMF_LIGHTING, false);
+		ps->setMaterialFlag(video::EMF_BACK_FACE_CULLING, false);
+		ps->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
+		ps->setMaterialFlag(video::EMF_FOG_ENABLE, true);
+		ps->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL);
+		ps->setAutomaticCulling(scene::EAC_OFF);
+
+		// Delete allocated content of event
+		delete event->spawn_particle.pos;
+		delete event->spawn_particle.vel;
+		delete event->spawn_particle.acc;
+		delete event->spawn_particle.texture;
+		break;
+	}
+	default:
+		break;
 	}
 }
 
 // The final burst of particles when a node is finally dug, *not* particles
 // spawned during the digging of a node.
 
-void ParticleManager::addDiggingParticles(IGameDef* gamedef,
-	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
+void ParticleManager::addDiggingParticles(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
+	const MapNode &n, const ContentFeatures &f)
 {
 	// No particles for "airlike" nodes
 	if (f.drawtype == NDT_AIRLIKE)
 		return;
 
-	for (u16 j = 0; j < 16; j++) {
-		addNodeParticle(gamedef, player, pos, n, f);
-	}
+	addNodeParticle(gamedef, player, pos, n, f, 16);
 }
 
 // During the digging of a node particles are spawned individually by this
 // function, called from Game::handleDigging() in game.cpp.
 
-void ParticleManager::addNodeParticle(IGameDef* gamedef,
-	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
+void ParticleManager::addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
+	const MapNode &n, const ContentFeatures &f, u32 number)
 {
 	// No particles for "airlike" nodes
 	if (f.drawtype == NDT_AIRLIKE)
 		return;
 
+	scene::IParticleSystemSceneNode* ps =
+		m_smgr->addParticleSystemSceneNode(false);
+
+	v3s16 camera_offset = m_env->getCameraOffset();
+	v3f particle_pos = intToFloat(pos - camera_offset, BS);
+	ps->setPosition(particle_pos);
+
 	// Texture
 	u8 texid = myrand_range(0, 5);
 	const TileLayer &tile = f.tiles[texid].layers[0];
 	video::ITexture *texture;
-	struct TileAnimationParams anim;
-	anim.type = TAT_NONE;
 
 	// Only use first frame of animated texture
 	if (tile.material_flags & MATERIAL_FLAG_ANIMATION)
@@ -603,63 +745,65 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	else
 		texture = tile.texture;
 
-	float size = (rand() % 8) / 64.0f;
-	float visual_size = BS * size;
-	if (tile.scale)
-		size /= tile.scale;
-	v2f texsize(size * 2.0f, size * 2.0f);
-	v2f texpos;
-	texpos.X = (rand() % 64) / 64.0f - texsize.X;
-	texpos.Y = (rand() % 64) / 64.0f - texsize.Y;
-
-	// Physics
-	v3f velocity(
-		(rand() % 150) / 50.0f - 1.5f,
-		(rand() % 150) / 50.0f,
-		(rand() % 150) / 50.0f - 1.5f
-	);
-	v3f acceleration(
-		0.0f,
-		-player->movement_gravity * player->physics_override_gravity / BS,
-		0.0f
-	);
-	v3f particlepos = v3f(
-		(f32)pos.X + (rand() % 100) / 200.0f - 0.25f,
-		(f32)pos.Y + (rand() % 100) / 200.0f - 0.25f,
-		(f32)pos.Z + (rand() % 100) / 200.0f - 0.25f
-	);
-
 	video::SColor color;
 	if (tile.has_color)
 		color = tile.color;
 	else
 		n.getColor(f, &color);
 
-	Particle* toadd = new Particle(
-		gamedef,
-		player,
-		m_env,
-		particlepos,
-		velocity,
-		acceleration,
-		(rand() % 100) / 100.0f, // expiration time
-		visual_size,
-		true,
-		false,
-		false,
-		false,
-		texture,
-		texpos,
-		texsize,
-		anim,
-		0,
-		color);
 
-	addParticle(toadd);
+	// Deletes ps after the particles have vanished
+	scene::IParticleEmitter *em = new SingleEmitter(m_smgr,ps,color,number);
+
+	ps->setEmitter(em);
+	em->drop();
+
+	v3f acceleration(
+		0.f,
+		-player->movement_gravity * player->physics_override_gravity / BS,
+		0.f
+	);
+
+	scene::IParticleAffector *collision_affector =
+		new CollisionAffector(m_env, false, true);
+	ps->addAffector(collision_affector);
+	collision_affector->drop();
+
+	scene::IParticleAffector *acceleration_affector =
+		new AccelerationAffector(acceleration);
+	ps->addAffector(acceleration_affector);
+	acceleration_affector->drop();
+
+	scene::IParticleAffector *lighting_affector =
+		new LightingAffector(m_env, gamedef, 0);
+	ps->addAffector(lighting_affector);
+	lighting_affector->drop();
+
+	ps->setMaterialTexture(0, texture);
+
+	ps->setMaterialFlag(video::EMF_LIGHTING, false);
+	ps->setMaterialFlag(video::EMF_BACK_FACE_CULLING, false);
+	ps->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
+	ps->setMaterialFlag(video::EMF_FOG_ENABLE, true);
+	ps->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL);
+
+	// Take a square (quarter the size of the texture) at a random position
+	float tile_scale = tile.scale ? (float) tile.scale : 1.f;
+	float scale_factor = 0.25 / tile_scale;
+	v2f texpos;
+	texpos.X = (rand() % 48) / 64.f;
+	texpos.Y = (rand() % 48) / 64.f;
+
+	ps->getMaterial(0).getTextureMatrix(0) = bottomUpTextureMatrix(scale_factor, scale_factor,
+			texpos.X, texpos.Y);
 }
 
-void ParticleManager::addParticle(Particle* toadd)
+u64 ParticleManager::getSingleParticleNumber()
 {
-	MutexAutoLock lock(m_particle_list_lock);
-	m_particles.push_back(toadd);
+	return single_particles_count.load();
+}
+
+u64 ParticleManager::getParticleSpawnerNumber()
+{
+	return particle_spawners_count.load();
 }

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -479,7 +479,7 @@ public:
 				if (attached) {
 					vel.rotateXZBy(attached->getYaw());
 					p.pos.rotateXZBy(attached->getYaw());
-					ps->setPosition(attached->getPosition());
+					p.pos += attached->getPosition();
 				} else {
 					return 0;
 				}

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -118,9 +118,9 @@ private:
 		bool pos_ok = true;
 
 		v3s16 p = v3s16(
-			floor(position.X + 0.5f),
-			floor(position.Y + 0.5f),
-			floor(position.Z + 0.5f));
+			std::floor(position.X + 0.5f),
+			std::floor(position.Y + 0.5f),
+			std::floor(position.Z + 0.5f));
 
 		MapNode map_node = m_env->getClientMap().getNodeNoEx(p, &pos_ok);
 

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -625,7 +625,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 			scene::IParticleAffector *collision_affector =
 				new CollisionAffector(m_env,
 					event->add_particlespawner.collision_removal,
-					event->add_particlespawner.object_collision, 1.0f, 0.0f);
+					event->add_particlespawner.object_collision, 0.1f, 0.3f);
 			ps->addAffector(collision_affector);
 			collision_affector->drop();
 		}

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -118,9 +118,9 @@ private:
 		bool pos_ok = true;
 
 		v3s16 p = v3s16(
-			floor(position.X+0.5),
-			floor(position.Y+0.5),
-			floor(position.Z+0.5));
+			floor(position.X + 0.5f),
+			floor(position.Y + 0.5f),
+			floor(position.Z + 0.5f));
 
 		MapNode map_node = m_env->getClientMap().getNodeNoEx(p, &pos_ok);
 

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -65,13 +65,13 @@ public:
 	{
 	}
 
-	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	void affect(u32 now, irr::scene::SParticle *particlearray, u32 count) override
 	{
 		v3s16 camera_offset = env.getCameraOffset();
 		ps->setPosition(position - intToFloat(camera_offset, BS));
 	}
 
-	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const override
 	{
 		return irr::scene::EPAT_NONE;
 	}
@@ -80,7 +80,6 @@ private:
 	irr::scene::IParticleSystemSceneNode *const ps;
 	v3f position;
 };
-
 
 class LightingAffector : public irr::scene::IParticleAffector
 {
@@ -92,7 +91,7 @@ public:
 	{
 	}
 
-	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	void affect(u32 now, irr::scene::SParticle *particlearray, u32 count) override
 	{
 		for (u32 i = 0; i < count; ++i) {
 			v3f pos = particlearray[i].pos +
@@ -102,7 +101,7 @@ public:
 		}
 	}
 
-	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const override
 	{
 		return irr::scene::EPAT_NONE;
 	}
@@ -154,7 +153,7 @@ public:
 			framesize.Y / (float) texsize.Y);
 	}
 
-	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	void affect(u32 now, irr::scene::SParticle *particlearray, u32 count) override
 	{
 		if (last_time == 0) {
 			last_time = now;
@@ -173,7 +172,7 @@ public:
 		*texture_matrix = bottomUpTextureMatrix(framesize_ratio.X, framesize_ratio.Y, texcoord.X, texcoord.Y);
 	}
 
-	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const override
 	{
 		return irr::scene::EPAT_NONE;
 	}
@@ -201,7 +200,7 @@ public:
 	{
 	}
 
-	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	void affect(u32 now, irr::scene::SParticle *particlearray, u32 count) override
 	{
 		if (last_time == 0) {
 			last_time = now;
@@ -234,7 +233,7 @@ public:
 		}
 	}
 
-	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const override
 	{
 		return irr::scene::EPAT_NONE;
 	}
@@ -261,7 +260,7 @@ public:
 	{
 	}
 
-	virtual void affect(u32 now, irr::scene::SParticle *particlearray, u32 count)
+	void affect(u32 now, irr::scene::SParticle *particlearray, u32 count) override
 	{
 		if (last_time == 0) {
 			last_time = now;
@@ -274,7 +273,7 @@ public:
 		}
 	}
 
-	virtual irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const
+	irr::scene::E_PARTICLE_AFFECTOR_TYPE getType() const override
 	{
 		return irr::scene::EPAT_NONE;
 	}
@@ -283,35 +282,35 @@ private:
 	bool disabled;
 	u32 last_time;
 };
+
+
 class CustomEmitter : public irr::scene::IParticleEmitter
 {
 public:
 	// unused pure virtual methods
-	virtual void setDirection(const core::vector3df& /* newDirection */) {}
-	virtual void setMinParticlesPerSecond(u32 /* minPPS */) {}
-	virtual void setMaxParticlesPerSecond(u32 /* maxPPS */) {}
-	virtual void setMinStartColor(const video::SColor& /* color */) {}
-	virtual void setMaxStartColor(const video::SColor& /* color */) {}
-	virtual void setMaxLifeTime(const u32 /* t */) {}
-	virtual void setMinLifeTime(const u32 /* t */) {}
-	virtual u32 getMaxLifeTime() const {return 1;}
-	virtual u32 getMinLifeTime() const {return 1;}
-	virtual void setMaxAngleDegrees(const s32 /* t */) {}
-	virtual s32 getMaxAngleDegrees() const {return 0;}
-	virtual void setMaxStartSize(const core::dimension2df& /* size */) {}
-	virtual void setMinStartSize(const core::dimension2df& /* size */) {}
-	virtual void setCenter(const core::vector3df& /* center */) {}
-	virtual void setRadius(f32 /* radius */) {}
-	virtual const core::vector3df& getDirection() const {return direction;}
-	virtual u32 getMinParticlesPerSecond() const {return 1;}
-	virtual u32 getMaxParticlesPerSecond() const {return 1;}
-	virtual const video::SColor& getMinStartColor() const {return minStartColor;}
-	virtual const video::SColor& getMaxStartColor() const {return maxStartColor;}
-	virtual const core::dimension2df& getMaxStartSize() const {return max_size;}
-	virtual const core::dimension2df& getMinStartSize() const {return min_size;}
-	virtual const core::vector3df& getCenter() const {return center;}
-	virtual f32 getRadius() const {return 1.f;}
-	virtual irr::scene::E_PARTICLE_EMITTER_TYPE getType() const
+	void setDirection(const core::vector3df& /* newDirection */) override {}
+	void setMinParticlesPerSecond(u32 /* minPPS */) override {}
+	void setMaxParticlesPerSecond(u32 /* maxPPS */) override {}
+	void setMinStartColor(const video::SColor& /* color */) override {}
+	void setMaxStartColor(const video::SColor& /* color */) override {}
+	void setMaxLifeTime(const u32 /* t */) override {}
+	void setMinLifeTime(const u32 /* t */) override {}
+	u32 getMaxLifeTime() const override {return 1;}
+	u32 getMinLifeTime() const override {return 1;}
+	void setMaxAngleDegrees(const s32 /* t */) override {}
+	s32 getMaxAngleDegrees() const override {return 0;}
+	void setMaxStartSize(const core::dimension2df& /* size */) override {}
+	void setMinStartSize(const core::dimension2df& /* size */) override {}
+	//void setCenter(const core::vector3df& /* center */) override {}
+	//void setRadius(f32 /* radius */) override {}
+	const core::vector3df& getDirection() const override {return direction;}
+	u32 getMinParticlesPerSecond() const override {return 1;}
+	u32 getMaxParticlesPerSecond() const override {return 1;}
+	const video::SColor& getMinStartColor() const override {return minStartColor;}
+	const video::SColor& getMaxStartColor() const override {return maxStartColor;}
+	const core::dimension2df& getMaxStartSize() const override {return max_size;}
+	const core::dimension2df& getMinStartSize() const override {return min_size;}
+	irr::scene::E_PARTICLE_EMITTER_TYPE getType() const override
 	{
 		return irr::scene::EPET_COUNT;
 	}
@@ -351,7 +350,7 @@ public:
 		--single_particles_count;
 	}
 
-	virtual s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray)
+	s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray) override
 	{
 		if (number == 0) {
 			if (now > deletion_time)
@@ -384,7 +383,6 @@ public:
 			p.startVector = p.vector = vel * BS * 1e-3f;
 
 			p.startTime = now;
-			//TEST
 			if (random_properties)
 				p.endTime = now + (u32) (rand() % 100 * 10.f);
 			else
@@ -436,7 +434,7 @@ public:
 		--particle_spawners_count;
 	}
 
-	virtual s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray)
+	s32 emitt(u32 now, u32 timeSinceLastCall, irr::scene::SParticle *&outArray) override
 	{
 		if (spawntime != 0) {
 			if (stopped && expired_time * 1e-3f < spawntime)
@@ -522,9 +520,8 @@ private:
 	float time_for_particle;
 
 	irr::scene::SParticle p;
-
-
 };
+
 
 ParticleManager::ParticleManager(ClientEnvironment *env)
 	:m_env(env)
@@ -624,7 +621,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 		ps->addAffector(acceleration_affector);
 		acceleration_affector->drop();
 
-
 		scene::IParticleAffector *lighting_affector =
 			new LightingAffector(m_env, client, 0);
 		ps->addAffector(lighting_affector);
@@ -720,7 +716,6 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 
 // The final burst of particles when a node is finally dug, *not* particles
 // spawned during the digging of a node.
-
 void ParticleManager::addDiggingParticles(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
 	const MapNode &n, const ContentFeatures &f)
 {
@@ -733,7 +728,6 @@ void ParticleManager::addDiggingParticles(IGameDef *gamedef, LocalPlayer *player
 
 // During the digging of a node particles are spawned individually by this
 // function, called from Game::handleDigging() in game.cpp.
-
 void ParticleManager::addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
 	const MapNode &n, const ContentFeatures &f, u32 number)
 {
@@ -764,7 +758,6 @@ void ParticleManager::addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3
 		color = tile.color;
 	else
 		n.getColor(f, &color);
-
 
 	// Deletes ps after the particles have vanished
 	scene::IParticleEmitter *em = new SingleEmitter(m_smgr,ps,color,number);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -211,7 +211,7 @@ public:
 		for (u32 i = 0; i < count; ++i) {
 			irr::scene::SParticle &p = particlearray[i];
 			float half_width = p.size.Width / 2;
-			v3f camera_offset = intToFloat(m_env->getCameraOffset(),BS);
+			v3f camera_offset = intToFloat(m_env->getCameraOffset(), BS);
 
 			// Undo Irrlicht position step
 			v3f position = p.pos + camera_offset - dtime * p.vector * 1e3;;
@@ -378,7 +378,7 @@ public:
 				};
 				size = rand() % 8 / 64.f * BS;
 			}
-			p.pos.set(pos);
+			p.pos = pos * BS;
 			p.startVector = p.vector = vel * BS * 1e-3f;
 
 			p.startTime = now;

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -625,7 +625,9 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 			scene::IParticleAffector *collision_affector =
 				new CollisionAffector(m_env,
 					event->add_particlespawner.collision_removal,
-					event->add_particlespawner.object_collision, 0.1f, 0.3f);
+					event->add_particlespawner.object_collision,
+					event->add_particlespawner.bounce_fraction,
+					event->add_particlespawner.bounce_threshold);
 			ps->addAffector(collision_affector);
 			collision_affector->drop();
 		}
@@ -696,7 +698,9 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client, Lo
 			scene::IParticleAffector *collision_affector =
 				new CollisionAffector(m_env,
 				event->spawn_particle.collision_removal,
-				event->spawn_particle.object_collision, 1.0f, 0.0f);
+				event->spawn_particle.object_collision,
+				event->spawn_particle.bounce_fraction,
+				event->spawn_particle.bounce_threshold);
 			ps->addAffector(collision_affector);
 			collision_affector->drop();
 		}

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -54,7 +54,7 @@ public:
 	* We don't need to check the particle spawner list because client ID will n
 	* ever overlap (u64)
 	* @return new id
-	 */
+	*/
 	u64 generateSpawnerId()
 	{
 			return m_next_particle_spawner_id++;

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -26,165 +26,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 
 struct ClientEvent;
-class ParticleManager;
 class ClientEnvironment;
 struct MapNode;
 struct ContentFeatures;
-
-class Particle : public scene::ISceneNode
-{
-	public:
-	Particle(
-		IGameDef* gamedef,
-		LocalPlayer *player,
-		ClientEnvironment *env,
-		v3f pos,
-		v3f velocity,
-		v3f acceleration,
-		float expirationtime,
-		float size,
-		bool collisiondetection,
-		bool collision_removal,
-		bool object_collision,
-		bool vertical,
-		video::ITexture *texture,
-		v2f texpos,
-		v2f texsize,
-		const struct TileAnimationParams &anim,
-		u8 glow,
-		video::SColor color = video::SColor(0xFFFFFFFF)
-	);
-	~Particle() = default;
-
-	virtual const aabb3f &getBoundingBox() const
-	{
-		return m_box;
-	}
-
-	virtual u32 getMaterialCount() const
-	{
-		return 1;
-	}
-
-	virtual video::SMaterial& getMaterial(u32 i)
-	{
-		return m_material;
-	}
-
-	virtual void OnRegisterSceneNode();
-	virtual void render();
-
-	void step(float dtime);
-
-	bool get_expired ()
-	{ return m_expiration < m_time; }
-
-private:
-	void updateLight();
-	void updateVertices();
-
-	video::S3DVertex m_vertices[4];
-	float m_time = 0.0f;
-	float m_expiration;
-
-	ClientEnvironment *m_env;
-	IGameDef *m_gamedef;
-	aabb3f m_box;
-	aabb3f m_collisionbox;
-	video::SMaterial m_material;
-	v2f m_texpos;
-	v2f m_texsize;
-	v3f m_pos;
-	v3f m_velocity;
-	v3f m_acceleration;
-	LocalPlayer *m_player;
-	float m_size;
-	//! Color without lighting
-	video::SColor m_base_color;
-	//! Final rendered color
-	video::SColor m_color;
-	bool m_collisiondetection;
-	bool m_collision_removal;
-	bool m_object_collision;
-	bool m_vertical;
-	v3s16 m_camera_offset;
-	struct TileAnimationParams m_animation;
-	float m_animation_time = 0.0f;
-	int m_animation_frame = 0;
-	u8 m_glow;
-};
-
-class ParticleSpawner
-{
-public:
-	ParticleSpawner(IGameDef* gamedef,
-		LocalPlayer *player,
-		u16 amount,
-		float time,
-		v3f minp, v3f maxp,
-		v3f minvel, v3f maxvel,
-		v3f minacc, v3f maxacc,
-		float minexptime, float maxexptime,
-		float minsize, float maxsize,
-		bool collisiondetection,
-		bool collision_removal,
-		bool object_collision,
-		u16 attached_id,
-		bool vertical,
-		video::ITexture *texture,
-		const struct TileAnimationParams &anim, u8 glow,
-		ParticleManager* p_manager);
-
-	~ParticleSpawner() = default;
-
-	void step(float dtime, ClientEnvironment *env);
-
-	bool get_expired ()
-	{ return (m_amount <= 0) && m_spawntime != 0; }
-
-private:
-	void spawnParticle(ClientEnvironment *env, float radius,
-			bool is_attached, const v3f &attached_pos,
-			float attached_yaw);
-
-	ParticleManager *m_particlemanager;
-	float m_time;
-	IGameDef *m_gamedef;
-	LocalPlayer *m_player;
-	u16 m_amount;
-	float m_spawntime;
-	v3f m_minpos;
-	v3f m_maxpos;
-	v3f m_minvel;
-	v3f m_maxvel;
-	v3f m_minacc;
-	v3f m_maxacc;
-	float m_minexptime;
-	float m_maxexptime;
-	float m_minsize;
-	float m_maxsize;
-	video::ITexture *m_texture;
-	std::vector<float> m_spawntimes;
-	bool m_collisiondetection;
-	bool m_collision_removal;
-	bool m_object_collision;
-	bool m_vertical;
-	u16 m_attached_id;
-	struct TileAnimationParams m_animation;
-	u8 m_glow;
-};
-
 /**
- * Class doing particle as well as their spawners handling
+ * Class doing handling of single particles and particle spawners
  */
 class ParticleManager
 {
-friend class ParticleSpawner;
 public:
 	ParticleManager(ClientEnvironment* env);
 	~ParticleManager();
 
-	void step (float dtime);
+	//void step (float dtime);
 
 	void handleParticleEvent(ClientEvent *event, Client *client,
 			LocalPlayer *player);
@@ -193,37 +47,28 @@ public:
 		const MapNode &n, const ContentFeatures &f);
 
 	void addNodeParticle(IGameDef *gamedef, LocalPlayer *player, v3s16 pos,
-		const MapNode &n, const ContentFeatures &f);
+		const MapNode &n, const ContentFeatures &f, u32 number = 1);
 
 	/**
-	 * This function is only used by client particle spawners
-	 *
-	 * We don't need to check the particle spawner list because client ID will n
-	 * ever overlap (u64)
-	 * @return new id
+	* This function is only used by client particle spawners
+	*
+	* We don't need to check the particle spawner list because client ID will n
+	* ever overlap (u64)
+	* @return new id
 	 */
 	u64 generateSpawnerId()
 	{
-		return m_next_particle_spawner_id++;
+			return m_next_particle_spawner_id++;
 	}
 
-protected:
-	void addParticle(Particle* toadd);
+	u64 getSingleParticleNumber();
+	u64 getParticleSpawnerNumber();
 
 private:
-
-	void stepParticles(float dtime);
-	void stepSpawners(float dtime);
-
-	void clearAll();
-
-	std::vector<Particle*> m_particles;
-	std::unordered_map<u64, ParticleSpawner*> m_particle_spawners;
-	// Start the particle spawner ids generated from here after u32_max. lower values are
-	// for server sent spawners.
-	u64 m_next_particle_spawner_id = U32_MAX + 1;
-
 	ClientEnvironment* m_env;
-	std::mutex m_particle_list_lock;
+	irr::scene::ISceneManager *m_smgr;
+
+	u64 m_next_particle_spawner_id = U32_MAX + 1;
+	std::unordered_map<u64, scene::IParticleSystemSceneNode*> m_particle_spawners;
 	std::mutex m_spawner_list_lock;
 };

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -61,7 +61,7 @@ public:
 
 	u64 getSingleParticleNumber();
 	u64 getParticleSpawnerNumber();
-	void removeParticleSpawner(u64 id);
+	void removeParticleSpawner(u64 id, bool stop);
 
 private:
 	ClientEnvironment* m_env;

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -38,8 +38,6 @@ public:
 	ParticleManager(ClientEnvironment* env);
 	~ParticleManager();
 
-	//void step (float dtime);
-
 	void handleParticleEvent(ClientEvent *event, Client *client,
 			LocalPlayer *player);
 
@@ -63,6 +61,7 @@ public:
 
 	u64 getSingleParticleNumber();
 	u64 getParticleSpawnerNumber();
+	void removeParticleSpawner(u64 id);
 
 private:
 	ClientEnvironment* m_env;

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -29,6 +29,7 @@ struct ClientEvent;
 class ClientEnvironment;
 struct MapNode;
 struct ContentFeatures;
+
 /**
  * Class doing handling of single particles and particle spawners
  */
@@ -66,7 +67,6 @@ public:
 private:
 	ClientEnvironment* m_env;
 	irr::scene::ISceneManager *m_smgr;
-
 	u64 m_next_particle_spawner_id = U32_MAX + 1;
 	std::unordered_map<u64, scene::IParticleSystemSceneNode*> m_particle_spawners;
 	std::mutex m_spawner_list_lock;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -756,9 +756,9 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 		return result;
 
 	// Limit speed for avoiding hangs
-	speed_f->Y = rangelim(speed_f->Y, -5000, 5000);
-	speed_f->X = rangelim(speed_f->X, -5000, 5000);
-	speed_f->Z = rangelim(speed_f->Z, -5000, 5000);
+	speed_f->Y = rangelim(speed_f->Y, -50*BS, 50*BS);
+	speed_f->X = rangelim(speed_f->X, -50*BS, 50*BS);
+	speed_f->Z = rangelim(speed_f->Z, -50*BS, 50*BS);
 
 
 	std::vector<NearbyCollisionInfo> cinfo_objects;
@@ -853,11 +853,19 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 
 		bool any_position_valid = false;
 
+		int loopcount_collect = 0;
 		v3s16 p = floatToInt(*pos_f, BS);
 		f32 dtime_collect = 0.f;
 		v3f pos_test = *pos_f;
 		bool finished = false;
 		while (true) {
+			++loopcount_collect;
+			if (loopcount_collect >= 100) {
+				warningstream << "collisionMovePoint collection Loop count exceeded, "
+					"aborting to avoid infinite loop" << std::endl;
+				break;
+			}
+
 			bool is_position_valid;
 			MapNode n = map->getNodeNoEx(p, &is_position_valid);
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -80,7 +80,7 @@ int axisAlignedCollision(
 		movingbox.MaxEdge.Z - staticbox.MinEdge.Z
 	);
 
-	if(speed.X > 0) { // Check for collision with X- plane
+	if (speed.X > 0) { // Check for collision with X- plane
 		if (relbox.MaxEdge.X <= d) {
 			*dtime = -relbox.MaxEdge.X / speed.X;
 			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)                 &&
@@ -88,10 +88,10 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
-		} else if(relbox.MinEdge.X > xsize) {
+		} else if (relbox.MinEdge.X > xsize) {
 			return -1;
 		}
-	} else if(speed.X < 0) { // Check for collision with X+ plane
+	} else if (speed.X < 0) { // Check for collision with X+ plane
 		if (relbox.MinEdge.X >= xsize - d) {
 			*dtime = (xsize - relbox.MinEdge.X) / speed.X;
 			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)                 &&
@@ -99,13 +99,13 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
-		} else if(relbox.MaxEdge.X < 0) {
+		} else if (relbox.MaxEdge.X < 0) {
 			return -1;
 		}
 	}
 	// NO else if here
 
-	if(speed.Y > 0) { // Check for collision with Y- plane
+	if (speed.Y > 0) { // Check for collision with Y- plane
 		if (relbox.MaxEdge.Y <= d) {
 			*dtime = -relbox.MaxEdge.Y / speed.Y;
 			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
@@ -113,10 +113,10 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
-		} else if(relbox.MinEdge.Y > ysize) {
+		} else if (relbox.MinEdge.Y > ysize) {
 			return -1;
 		}
-	} else if(speed.Y < 0) { // Check for collision with Y+ plane
+	} else if (speed.Y < 0) { // Check for collision with Y+ plane
 		if (relbox.MinEdge.Y >= ysize - d) {
 			*dtime = (ysize - relbox.MinEdge.Y) / speed.Y;
 			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
@@ -124,13 +124,13 @@ int axisAlignedCollision(
 					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
-		} else if(relbox.MaxEdge.Y < 0) {
+		} else if (relbox.MaxEdge.Y < 0) {
 			return -1;
 		}
 	}
 	// NO else if here
 
-	if(speed.Z > 0) { // Check for collision with Z- plane
+	if (speed.Z > 0) { // Check for collision with Z- plane
 		if (relbox.MaxEdge.Z <= d) {
 			*dtime = -relbox.MaxEdge.Z / speed.Z;
 			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
@@ -139,11 +139,11 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
-		//else if(relbox.MinEdge.Z > zsize)
+		//else if (relbox.MinEdge.Z > zsize)
 		//{
 		//	return -1;
 		//}
-	} else if(speed.Z < 0) { // Check for collision with Z+ plane
+	} else if (speed.Z < 0) { // Check for collision with Z+ plane
 		if (relbox.MinEdge.Z >= zsize - d) {
 			*dtime = (zsize - relbox.MinEdge.Z) / speed.Z;
 			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
@@ -152,7 +152,7 @@ int axisAlignedCollision(
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
-		//else if(relbox.MaxEdge.Z < 0)
+		//else if (relbox.MaxEdge.Z < 0)
 		//{
 		//	return -1;
 		//}
@@ -167,12 +167,8 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 	f32 dtime = 0.f;
 
 	// Keep distance from collision box
-	staticbox.MinEdge.X -= surface_dist;
-	staticbox.MinEdge.Y -= surface_dist;
-	staticbox.MinEdge.Z -= surface_dist;
-	staticbox.MaxEdge.X += surface_dist;
-	staticbox.MaxEdge.Y += surface_dist;
-	staticbox.MaxEdge.Z += surface_dist;
+	staticbox.MinEdge -= surface_dist;
+	staticbox.MaxEdge += surface_dist;
 	v3f relpos = pos - staticbox.MinEdge;
 
 	f32 xsize = (staticbox.MaxEdge.X - staticbox.MinEdge.X);
@@ -190,7 +186,7 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 	else
 		d = {0.f, 0.f, 0.f};
 
-	if(speed.X > 0) { // Check for collision with X- plane
+	if (speed.X > 0) { // Check for collision with X- plane
 		if (relpos.X <= d.X) {
 			dtime = -relpos.X / speed.X;
 			if ((relpos.Y + speed.Y * (dtime) < ysize)             &&
@@ -199,10 +195,10 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Z + speed.Z * (dtime) > 0)) {
 				return std::make_tuple(0, dtime, inside);
 			}
-		} else if(relpos.X > xsize) {
+		} else if (relpos.X > xsize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	} else if(speed.X < 0) { // Check for collision with X+ plane
+	} else if (speed.X < 0) { // Check for collision with X+ plane
 		if (relpos.X >= xsize - d.X) {
 			dtime = (xsize - relpos.X) / speed.X;
 			if ((relpos.Y + speed.Y * (dtime) < ysize)             &&
@@ -210,13 +206,13 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(0, dtime, inside);
-		} else if(relpos.X < 0) {
+		} else if (relpos.X < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 	// NO else if here
 
-	if(speed.Y > 0) { // Check for collision with Y- plane
+	if (speed.Y > 0) { // Check for collision with Y- plane
 		if (relpos.Y <= d.Y) {
 			dtime = -relpos.Y / speed.Y;
 			if ((relpos.X + speed.X * (dtime) < xsize)             &&
@@ -224,10 +220,10 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(1, dtime, inside);
-		} else if(relpos.Y > ysize) {
+		} else if (relpos.Y > ysize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	} else if(speed.Y < 0) { // Check for collision with Y+ plane
+	} else if (speed.Y < 0) { // Check for collision with Y+ plane
 		if (relpos.Y >= ysize - d.Y) {
 			dtime = (ysize - relpos.Y) / speed.Y;
 			if ((relpos.X + speed.X * (dtime) < xsize)             &&
@@ -235,13 +231,13 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(1, dtime, inside);
-		} else if(relpos.Y < 0) {
+		} else if (relpos.Y < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 	// NO else if here
 
-	if(speed.Z > 0) { // Check for collision with Z- plane
+	if (speed.Z > 0) { // Check for collision with Z- plane
 		if (relpos.Z <= d.Z) {
 			dtime = -relpos.Z / speed.Z;
 			if ((relpos.X + speed.X * (dtime) < xsize)             &&
@@ -249,10 +245,10 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
 				return std::make_tuple(2, dtime, inside);
-		} else if(relpos.Z > zsize) {
+		} else if (relpos.Z > zsize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	} else if(speed.Z < 0) { // Check for collision with Z+ plane
+	} else if (speed.Z < 0) { // Check for collision with Z+ plane
 		if (relpos.Z >= zsize - d.Z) {
 			dtime = (zsize - relpos.Z) / speed.Z;
 			if ((relpos.X + speed.X * (dtime) < xsize)             &&
@@ -260,7 +256,7 @@ std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
 				return std::make_tuple(2, dtime, inside);
-		} else if(relpos.Z < 0) {
+		} else if (relpos.Z < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
@@ -299,6 +295,136 @@ static inline void getNeighborConnectingFace(const v3s16 &p,
 	MapNode n2 = map->getNodeNoEx(p);
 	if (nodedef->nodeboxConnects(n, n2, v))
 		*neighbors |= v;
+}
+
+static void collect_object_nodeboxes(std::vector<NearbyCollisionInfo> &cinfo,
+	Environment *env, f32 dtime, v3f *pos_f, v3f *speed_f, ActiveObject *self,
+	f32 box_length)
+{
+
+	// add object boxes to cinfo
+	std::vector<ActiveObject*> objects;
+#ifndef SERVER
+	ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
+	if (c_env != 0) {
+		// Calculate distance by speed, add own extent and 1.5m of tolerance
+		f32 distance = speed_f->getLength() * dtime +
+			box_length + 1.5f * BS;
+		std::vector<DistanceSortedActiveObject> clientobjects;
+		c_env->getActiveObjects(*pos_f, distance, clientobjects);
+
+		for (auto &clientobject : clientobjects) {
+			// Do collide with everything but itself and the parent CAO
+			if (!self || (self != clientobject.obj &&
+					self != clientobject.obj->getParent())) {
+				objects.push_back((ActiveObject*) clientobject.obj);
+			}
+		}
+	} else
+#endif
+	{
+		ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
+		if (s_env != NULL) {
+			// Calculate distance by speed, add own extent and 1.5m of tolerance
+			f32 distance = speed_f->getLength() * dtime +
+				box_length + 1.5f * BS;
+			std::vector<u16> s_objects;
+			s_env->getObjectsInsideRadius(s_objects, *pos_f, distance);
+
+			for (u16 obj_id : s_objects) {
+				ServerActiveObject *current = s_env->getActiveObject(obj_id);
+
+				if (!self || (self != current &&
+						self != current->getParent())) {
+					objects.push_back((ActiveObject*)current);
+				}
+			}
+		}
+	}
+
+	for (std::vector<ActiveObject*>::const_iterator iter = objects.begin();
+			iter != objects.end(); ++iter) {
+		ActiveObject *object = *iter;
+
+		if (object) {
+			aabb3f object_collisionbox;
+			if (object->getCollisionBox(&object_collisionbox) &&
+					object->collideWithObjects()) {
+				cinfo.emplace_back(false, true, 0,
+					v3s16(), object_collisionbox);
+			}
+		}
+	}
+}
+
+static bool collect_node_nodeboxes(std::vector<NearbyCollisionInfo> &cinfo,
+	Map *map, v3s16 p, IGameDef *gamedef)
+{
+	bool is_position_valid;
+	MapNode n = map->getNodeNoEx(p, &is_position_valid);
+
+	if (is_position_valid && n.getContent() != CONTENT_IGNORE) {
+		// Object collides into walkable nodes
+
+		const NodeDefManager *nodedef = gamedef->getNodeDefManager();
+		const ContentFeatures &f = nodedef->get(n);
+
+		if (f.walkable) {
+			int neighbors = 0;
+			if (f.drawtype == NDT_NODEBOX &&
+				f.node_box.type == NODEBOX_CONNECTED) {
+				v3s16 p2 = p;
+
+				p2.Y++;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 1, &neighbors);
+
+				p2 = p;
+				p2.Y--;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 2, &neighbors);
+
+				p2 = p;
+				p2.Z--;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 4, &neighbors);
+
+				p2 = p;
+				p2.X--;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 8, &neighbors);
+
+				p2 = p;
+				p2.Z++;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 16, &neighbors);
+
+				p2 = p;
+				p2.X++;
+				getNeighborConnectingFace(p2, nodedef,
+					map, n, 32, &neighbors);
+			}
+			std::vector<aabb3f> nodeboxes;
+			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
+
+			// Calculate float position only once
+			v3f posf = intToFloat(p, BS);
+			for (auto box : nodeboxes) {
+				box.MinEdge += posf;
+				box.MaxEdge += posf;
+				cinfo.emplace_back(false, false, 0, p, box);
+			}
+		}
+		return true;
+	} else {
+		/*
+		 * Collide with unloaded nodes (position invalid) and loaded
+		 * CONTENT_IGNORE nodes (position valid)
+		 */
+		aabb3f box = getNodeBox(p, BS);
+		cinfo.emplace_back(true, false, 0, p, box);
+		return false;
+	}
 }
 
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
@@ -365,65 +491,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	for (p.X = min.X; p.X <= max.X; p.X++)
 	for (p.Y = min.Y; p.Y <= max.Y; p.Y++)
 	for (p.Z = min.Z; p.Z <= max.Z; p.Z++) {
-		bool is_position_valid;
-		MapNode n = map->getNodeNoEx(p, &is_position_valid);
-
-		if (is_position_valid && n.getContent() != CONTENT_IGNORE) {
-			// Object collides into walkable nodes
-
-			any_position_valid = true;
-			const NodeDefManager *nodedef = gamedef->getNodeDefManager();
-			const ContentFeatures &f = nodedef->get(n);
-
-			if (!f.walkable)
-				continue;
-
-			int n_bouncy_value = itemgroup_get(f.groups, "bouncy");
-
-			int neighbors = 0;
-			if (f.drawtype == NDT_NODEBOX &&
-					f.node_box.type == NODEBOX_CONNECTED) {
-				v3s16 p2 = p;
-
-				p2.Y++;
-				getNeighborConnectingFace(p2, nodedef, map, n, 1, &neighbors);
-
-				p2 = p;
-				p2.Y--;
-				getNeighborConnectingFace(p2, nodedef, map, n, 2, &neighbors);
-
-				p2 = p;
-				p2.Z--;
-				getNeighborConnectingFace(p2, nodedef, map, n, 4, &neighbors);
-
-				p2 = p;
-				p2.X--;
-				getNeighborConnectingFace(p2, nodedef, map, n, 8, &neighbors);
-
-				p2 = p;
-				p2.Z++;
-				getNeighborConnectingFace(p2, nodedef, map, n, 16, &neighbors);
-
-				p2 = p;
-				p2.X++;
-				getNeighborConnectingFace(p2, nodedef, map, n, 32, &neighbors);
-			}
-			std::vector<aabb3f> nodeboxes;
-			n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
-
-			// Calculate float position only once
-			v3f posf = intToFloat(p, BS);
-			for (auto box : nodeboxes) {
-				box.MinEdge += posf;
-				box.MaxEdge += posf;
-				cinfo.emplace_back(false, false, n_bouncy_value, p, box);
-			}
-		} else {
-			// Collide with unloaded nodes (position invalid) and loaded
-			// CONTENT_IGNORE nodes (position valid)
-			aabb3f box = getNodeBox(p, BS);
-			cinfo.emplace_back(true, false, 0, p, box);
-		}
+		any_position_valid |= collect_node_nodeboxes(cinfo, map, p, gamedef);
 	}
 
 	// Do not move if world has not loaded yet, since custom node boxes
@@ -437,63 +505,10 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	} // tt2
 
-	if(collideWithObjects) {
+	if (collideWithObjects) {
+		collect_object_nodeboxes(cinfo, env, dtime, pos_f, speed_f, self, box_0.getExtent().getLength());
 		ScopeProfiler sp2(g_profiler, "collisionMoveSimple objects avg", SPT_AVG);
 		// TimeTaker tt3("collisionMoveSimple collect object boxes");
-
-		// add object boxes to cinfo
-		std::vector<ActiveObject*> objects;
-#ifndef SERVER
-		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
-		if (c_env != 0) {
-			// Calculate distance by speed, add own extent and 1.5m of tolerance
-			f32 distance = speed_f->getLength() * dtime +
-				box_0.getExtent().getLength() + 1.5f * BS;
-			std::vector<DistanceSortedActiveObject> clientobjects;
-			c_env->getActiveObjects(*pos_f, distance, clientobjects);
-
-			for (auto &clientobject : clientobjects) {
-				// Do collide with everything but itself and the parent CAO
-				if (!self || (self != clientobject.obj &&
-						self != clientobject.obj->getParent())) {
-					objects.push_back((ActiveObject*) clientobject.obj);
-				}
-			}
-		} else
-#endif
-		{
-			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
-			if (s_env != NULL) {
-				// Calculate distance by speed, add own extent and 1.5m of tolerance
-				f32 distance = speed_f->getLength() * dtime +
-					box_0.getExtent().getLength() + 1.5f * BS;
-				std::vector<u16> s_objects;
-				s_env->getObjectsInsideRadius(s_objects, *pos_f, distance);
-
-				for (u16 obj_id : s_objects) {
-					ServerActiveObject *current = s_env->getActiveObject(obj_id);
-
-					if (!self || (self != current &&
-							self != current->getParent())) {
-						objects.push_back((ActiveObject*)current);
-					}
-				}
-			}
-		}
-
-		for (std::vector<ActiveObject*>::const_iterator iter = objects.begin();
-				iter != objects.end(); ++iter) {
-			ActiveObject *object = *iter;
-
-			if (object) {
-				aabb3f object_collisionbox;
-				if (object->getCollisionBox(&object_collisionbox) &&
-						object->collideWithObjects()) {
-					cinfo.emplace_back(false, true, 0,
-						v3s16(), object_collisionbox);
-				}
-			}
-		}
 	} //tt3
 
 	// Collision detection
@@ -510,7 +525,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	int loopcount = 0;
 
-	while(dtime > BS * 1e-10f) {
+	while (dtime > BS * 1e-10f) {
 		// TimeTaker tt3("collisionMoveSimple dtime loop");
 		ScopeProfiler sp2(g_profiler, "collisionMoveSimple dtime loop avg", SPT_AVG);
 
@@ -612,7 +627,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 					speed_f->X = 0;
 				result.collides = true;
 			} else if (nearest_collided == 1) { // Y
-				if(fabs(speed_f->Y) > BS * 3)
+				if (fabs(speed_f->Y) > BS * 3)
 					speed_f->Y *= bounce;
 				else
 					speed_f->Y = 0;
@@ -707,60 +722,9 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 	speed_f->Z = rangelim(speed_f->Z, -50*BS, 50*BS);
 
 	std::vector<NearbyCollisionInfo> cinfo_objects;
-	if(collideWithObjects) {
+	if (collideWithObjects) {
 		ScopeProfiler sp2(g_profiler, "collisionMovePoint objects avg", SPT_AVG);
-
-		// add object boxes to cinfo_objects
-		std::vector<ActiveObject*> objects;
-#ifndef SERVER
-		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
-		if (c_env != 0) {
-			// Calculate distance by speed, add 1.5m of tolerance
-			f32 distance = speed_f->getLength() * dtime + 1.5f * BS;
-			std::vector<DistanceSortedActiveObject> clientobjects;
-			c_env->getActiveObjects(*pos_f, distance, clientobjects);
-
-			for (auto &clientobject : clientobjects) {
-				// Do collide with everything but itself and the parent CAO
-				if (!self || (self != clientobject.obj &&
-						self != clientobject.obj->getParent())) {
-					objects.push_back((ActiveObject*) clientobject.obj);
-				}
-			}
-		} else
-#endif
-		{
-			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
-			if (s_env != NULL) {
-				// Calculate distance by speed, add 1.5m of tolerance
-				f32 distance = speed_f->getLength() * dtime + 1.5f * BS;
-				std::vector<u16> s_objects;
-				s_env->getObjectsInsideRadius(s_objects, *pos_f, distance);
-
-				for (u16 obj_id : s_objects) {
-					ServerActiveObject *current = s_env->getActiveObject(obj_id);
-
-					if (!self || (self != current &&
-							self != current->getParent())) {
-						objects.push_back((ActiveObject*)current);
-					}
-				}
-			}
-		}
-
-		for (std::vector<ActiveObject*>::const_iterator iter = objects.begin();
-				iter != objects.end(); ++iter) {
-			ActiveObject *object = *iter;
-
-			if (object) {
-				aabb3f object_collisionbox;
-				if (object->getCollisionBox(&object_collisionbox) &&
-						object->collideWithObjects()) {
-					cinfo_objects.emplace_back(false, true, 0,
-						v3s16(), object_collisionbox);
-				}
-			}
-		}
+		collect_object_nodeboxes(cinfo_objects, env, dtime, pos_f, speed_f, self, 0.f);
 	}
 
 	// Collision detection
@@ -768,7 +732,7 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 
 	bool previously_inside = false;
 
-	while(dtime > BS * 1e-10f) {
+	while (dtime > BS * 1e-10f) {
 		ScopeProfiler sp2(g_profiler, "collisionMovePoint dtime loop avg", SPT_AVG);
 
 		// Avoid infinite loop
@@ -804,70 +768,7 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 				break;
 			}
 
-			bool is_position_valid;
-			MapNode n = map->getNodeNoEx(p, &is_position_valid);
-
-			if (is_position_valid && n.getContent() != CONTENT_IGNORE) {
-				// Object collides into walkable nodes
-
-				any_position_valid = true;
-				const NodeDefManager *nodedef = gamedef->getNodeDefManager();
-				const ContentFeatures &f = nodedef->get(n);
-
-				if (f.walkable) {
-					int neighbors = 0;
-					if (f.drawtype == NDT_NODEBOX &&
-						f.node_box.type == NODEBOX_CONNECTED) {
-						v3s16 p2 = p;
-
-						p2.Y++;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 1, &neighbors);
-
-						p2 = p;
-						p2.Y--;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 2, &neighbors);
-
-						p2 = p;
-						p2.Z--;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 4, &neighbors);
-
-						p2 = p;
-						p2.X--;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 8, &neighbors);
-
-						p2 = p;
-						p2.Z++;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 16, &neighbors);
-
-						p2 = p;
-						p2.X++;
-						getNeighborConnectingFace(p2, nodedef,
-							map, n, 32, &neighbors);
-					}
-					std::vector<aabb3f> nodeboxes;
-					n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
-
-					// Calculate float position only once
-					v3f posf = intToFloat(p, BS);
-					for (auto box : nodeboxes) {
-						box.MinEdge += posf;
-						box.MaxEdge += posf;
-						cinfo.emplace_back(false, false, 0, p, box);
-					}
-				}
-			} else {
-				/*
-				 * Collide with unloaded nodes (position invalid) and loaded
-				 * CONTENT_IGNORE nodes (position valid)
-				 */
-				aabb3f box = getNodeBox(p, BS);
-				cinfo.emplace_back(true, false, 0, p, box);
-			}
+			any_position_valid |= collect_node_nodeboxes(cinfo, map, p, gamedef);
 
 			if (finished)
 				break;
@@ -909,6 +810,10 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 
 			dtime_collect += dtime_min;
 
+			/*
+			 * Check in which direction the nearest node border is.
+			 * If not near node border within dtime, do not add next node.
+			 */
 			if (dtime_min == dtime_X) {
 				f32 border_dist = std::fabs(std::fmod(pos_test.X, BS));
 				bool near_border;
@@ -976,7 +881,6 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 			}
 
 			pos_test += dtime_min * (*speed_f);
-
 
 			// Add next node anyway to keep a minimal distance of surface_dist
 			if (dtime_collect > dtime)

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -35,10 +35,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 //#define COLL_ZERO 0.032 // broken unit tests
 #define COLL_ZERO 0
 
-
-struct NearbyCollisionInfo {
+struct NearbyCollisionInfo
+{
 	NearbyCollisionInfo(bool is_ul, bool is_obj, int bouncy,
-			const v3s16 &pos, const aabb3f &box) :
+		const v3s16 &pos, const aabb3f &box) :
 		is_unloaded(is_ul),
 		is_object(is_obj),
 		bouncy(bouncy),
@@ -60,97 +60,82 @@ struct NearbyCollisionInfo {
 // Returns -1 if no collision, 0 if X collision, 1 if Y collision, 2 if Z collision
 // The time after which the collision occurs is stored in dtime.
 int axisAlignedCollision(
-		const aabb3f &staticbox, const aabb3f &movingbox,
-		const v3f &speed, f32 d, f32 *dtime)
+	const aabb3f &staticbox, const aabb3f &movingbox,
+	const v3f &speed, f32 d, f32 *dtime)
 {
 	//TimeTaker tt("axisAlignedCollision");
 
-	f32 xsize = (staticbox.MaxEdge.X - staticbox.MinEdge.X) - COLL_ZERO; // reduce box size for solve collision stuck (flying sand)
-	f32 ysize = (staticbox.MaxEdge.Y - staticbox.MinEdge.Y); // - COLL_ZERO; // Y - no sense for falling, but maybe try later
+	// reduce box size for solve collision stuck (flying sand)
+	f32 xsize = (staticbox.MaxEdge.X - staticbox.MinEdge.X) - COLL_ZERO;
+	// Y - no sense for falling, but maybe try later
+	f32 ysize = (staticbox.MaxEdge.Y - staticbox.MinEdge.Y); // - COLL_ZERO;
 	f32 zsize = (staticbox.MaxEdge.Z - staticbox.MinEdge.Z) - COLL_ZERO;
 
 	aabb3f relbox(
-			movingbox.MinEdge.X - staticbox.MinEdge.X,
-			movingbox.MinEdge.Y - staticbox.MinEdge.Y,
-			movingbox.MinEdge.Z - staticbox.MinEdge.Z,
-			movingbox.MaxEdge.X - staticbox.MinEdge.X,
-			movingbox.MaxEdge.Y - staticbox.MinEdge.Y,
-			movingbox.MaxEdge.Z - staticbox.MinEdge.Z
+		movingbox.MinEdge.X - staticbox.MinEdge.X,
+		movingbox.MinEdge.Y - staticbox.MinEdge.Y,
+		movingbox.MinEdge.Z - staticbox.MinEdge.Z,
+		movingbox.MaxEdge.X - staticbox.MinEdge.X,
+		movingbox.MaxEdge.Y - staticbox.MinEdge.Y,
+		movingbox.MaxEdge.Z - staticbox.MinEdge.Z
 	);
 
-	if(speed.X > 0) // Check for collision with X- plane
-	{
+	if(speed.X > 0) { // Check for collision with X- plane
 		if (relbox.MaxEdge.X <= d) {
 			*dtime = -relbox.MaxEdge.X / speed.X;
-			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize) &&
+			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)                 &&
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
+					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
-		}
-		else if(relbox.MinEdge.X > xsize)
-		{
+		} else if(relbox.MinEdge.X > xsize) {
 			return -1;
 		}
-	}
-	else if(speed.X < 0) // Check for collision with X+ plane
-	{
+	} else if(speed.X < 0) { // Check for collision with X+ plane
 		if (relbox.MinEdge.X >= xsize - d) {
 			*dtime = (xsize - relbox.MinEdge.X) / speed.X;
-			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize) &&
+			if ((relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)                 &&
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
+					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 0;
-		}
-		else if(relbox.MaxEdge.X < 0)
-		{
+		} else if(relbox.MaxEdge.X < 0) {
 			return -1;
 		}
 	}
-
 	// NO else if here
 
-	if(speed.Y > 0) // Check for collision with Y- plane
-	{
+	if(speed.Y > 0) { // Check for collision with Y- plane
 		if (relbox.MaxEdge.Y <= d) {
 			*dtime = -relbox.MaxEdge.Y / speed.Y;
-			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize) &&
+			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
 					(relbox.MaxEdge.X + speed.X * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
+					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
-		}
-		else if(relbox.MinEdge.Y > ysize)
-		{
+		} else if(relbox.MinEdge.Y > ysize) {
 			return -1;
 		}
-	}
-	else if(speed.Y < 0) // Check for collision with Y+ plane
-	{
+	} else if(speed.Y < 0) { // Check for collision with Y+ plane
 		if (relbox.MinEdge.Y >= ysize - d) {
 			*dtime = (ysize - relbox.MinEdge.Y) / speed.Y;
-			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize) &&
+			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
 					(relbox.MaxEdge.X + speed.X * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize) &&
+					(relbox.MinEdge.Z + speed.Z * (*dtime) < zsize)     &&
 					(relbox.MaxEdge.Z + speed.Z * (*dtime) > COLL_ZERO))
 				return 1;
-		}
-		else if(relbox.MaxEdge.Y < 0)
-		{
+		} else if(relbox.MaxEdge.Y < 0) {
 			return -1;
 		}
 	}
-
 	// NO else if here
 
-	if(speed.Z > 0) // Check for collision with Z- plane
-	{
+	if(speed.Z > 0) { // Check for collision with Z- plane
 		if (relbox.MaxEdge.Z <= d) {
 			*dtime = -relbox.MaxEdge.Z / speed.Z;
-			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize) &&
+			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
 					(relbox.MaxEdge.X + speed.X * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Y + speed.Y * (*dtime) < ysize) &&
+					(relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)     &&
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
@@ -158,14 +143,12 @@ int axisAlignedCollision(
 		//{
 		//	return -1;
 		//}
-	}
-	else if(speed.Z < 0) // Check for collision with Z+ plane
-	{
+	} else if(speed.Z < 0) { // Check for collision with Z+ plane
 		if (relbox.MinEdge.Z >= zsize - d) {
 			*dtime = (zsize - relbox.MinEdge.Z) / speed.Z;
-			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize) &&
+			if ((relbox.MinEdge.X + speed.X * (*dtime) < xsize)                 &&
 					(relbox.MaxEdge.X + speed.X * (*dtime) > COLL_ZERO) &&
-					(relbox.MinEdge.Y + speed.Y * (*dtime) < ysize) &&
+					(relbox.MinEdge.Y + speed.Y * (*dtime) < ysize)     &&
 					(relbox.MaxEdge.Y + speed.Y * (*dtime) > COLL_ZERO))
 				return 2;
 		}
@@ -178,9 +161,8 @@ int axisAlignedCollision(
 	return -1;
 }
 
-std::tuple<int, f32, bool> pointBoxCollision(
-		aabb3f staticbox, const v3f &pos, const v3f &speed,
-		f32 surface_dist)
+std::tuple<int, f32, bool> pointBoxCollision(aabb3f staticbox, const v3f &pos,
+	const v3f &speed, f32 surface_dist)
 {
 	f32 dtime = 0.f;
 
@@ -191,6 +173,7 @@ std::tuple<int, f32, bool> pointBoxCollision(
 	staticbox.MaxEdge.X += surface_dist;
 	staticbox.MaxEdge.Y += surface_dist;
 	staticbox.MaxEdge.Z += surface_dist;
+	v3f relpos = pos - staticbox.MinEdge;
 
 	f32 xsize = (staticbox.MaxEdge.X - staticbox.MinEdge.X);
 	f32 ysize = (staticbox.MaxEdge.Y - staticbox.MinEdge.Y);
@@ -207,102 +190,77 @@ std::tuple<int, f32, bool> pointBoxCollision(
 	else
 		d = {0.f, 0.f, 0.f};
 
-	v3f relpos = pos - staticbox.MinEdge;
-
-	if(speed.X > 0) // Check for collision with X- plane
-	{
+	if(speed.X > 0) { // Check for collision with X- plane
 		if (relpos.X <= d.X) {
 			dtime = -relpos.X / speed.X;
-			if ((relpos.Y + speed.Y * (dtime) < ysize) &&
-					(relpos.Y + speed.Y * (dtime) > 0) &&
+			if ((relpos.Y + speed.Y * (dtime) < ysize)             &&
+					(relpos.Y + speed.Y * (dtime) > 0)     &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0)) {
 				return std::make_tuple(0, dtime, inside);
 			}
-		}
-		else if(relpos.X > xsize)
-		{
+		} else if(relpos.X > xsize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	}
-	else if(speed.X < 0) // Check for collision with X+ plane
-	{
+	} else if(speed.X < 0) { // Check for collision with X+ plane
 		if (relpos.X >= xsize - d.X) {
 			dtime = (xsize - relpos.X) / speed.X;
-			if ((relpos.Y + speed.Y * (dtime) < ysize) &&
-					(relpos.Y + speed.Y * (dtime) > 0) &&
+			if ((relpos.Y + speed.Y * (dtime) < ysize)             &&
+					(relpos.Y + speed.Y * (dtime) > 0)     &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(0, dtime, inside);
-		}
-		else if(relpos.X < 0)
-		{
+		} else if(relpos.X < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
-
 	// NO else if here
 
-	if(speed.Y > 0) // Check for collision with Y- plane
-	{
+	if(speed.Y > 0) { // Check for collision with Y- plane
 		if (relpos.Y <= d.Y) {
 			dtime = -relpos.Y / speed.Y;
-			if ((relpos.X + speed.X * (dtime) < xsize) &&
-					(relpos.X + speed.X * (dtime) > 0) &&
+			if ((relpos.X + speed.X * (dtime) < xsize)             &&
+					(relpos.X + speed.X * (dtime) > 0)     &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(1, dtime, inside);
-		}
-		else if(relpos.Y > ysize)
-		{
+		} else if(relpos.Y > ysize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	}
-	else if(speed.Y < 0) // Check for collision with Y+ plane
-	{
+	} else if(speed.Y < 0) { // Check for collision with Y+ plane
 		if (relpos.Y >= ysize - d.Y) {
 			dtime = (ysize - relpos.Y) / speed.Y;
-			if ((relpos.X + speed.X * (dtime) < xsize) &&
-					(relpos.X + speed.X * (dtime) > 0) &&
+			if ((relpos.X + speed.X * (dtime) < xsize)             &&
+					(relpos.X + speed.X * (dtime) > 0)     &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
 				return std::make_tuple(1, dtime, inside);
-		}
-		else if(relpos.Y < 0)
-		{
+		} else if(relpos.Y < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
-
 	// NO else if here
 
-	if(speed.Z > 0) // Check for collision with Z- plane
-	{
+	if(speed.Z > 0) { // Check for collision with Z- plane
 		if (relpos.Z <= d.Z) {
 			dtime = -relpos.Z / speed.Z;
-			if ((relpos.X + speed.X * (dtime) < xsize) &&
-					(relpos.X + speed.X * (dtime) > 0) &&
+			if ((relpos.X + speed.X * (dtime) < xsize)             &&
+					(relpos.X + speed.X * (dtime) > 0)     &&
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
 				return std::make_tuple(2, dtime, inside);
-		}
-		else if(relpos.Z > zsize)
-		{
+		} else if(relpos.Z > zsize) {
 			return std::make_tuple(-1, dtime, inside);
 		}
-	}
-	else if(speed.Z < 0) // Check for collision with Z+ plane
-	{
+	} else if(speed.Z < 0) { // Check for collision with Z+ plane
 		if (relpos.Z >= zsize - d.Z) {
 			dtime = (zsize - relpos.Z) / speed.Z;
-			if ((relpos.X + speed.X * (dtime) < xsize) &&
-					(relpos.X + speed.X * (dtime) > 0) &&
+			if ((relpos.X + speed.X * (dtime) < xsize)             &&
+					(relpos.X + speed.X * (dtime) > 0)     &&
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
 				return std::make_tuple(2, dtime, inside);
-		}
-		else if(relpos.Z < 0)
-		{
+		} else if(relpos.Z < 0) {
 			return std::make_tuple(-1, dtime, inside);
 		}
 	}
@@ -313,9 +271,9 @@ std::tuple<int, f32, bool> pointBoxCollision(
 // Helper function:
 // Checks if moving the movingbox up by the given distance would hit a ceiling.
 bool wouldCollideWithCeiling(
-		const std::vector<NearbyCollisionInfo> &cinfo,
-		const aabb3f &movingbox,
-		f32 y_increase, f32 d)
+	const std::vector<NearbyCollisionInfo> &cinfo,
+	const aabb3f &movingbox,
+	f32 y_increase, f32 d)
 {
 	//TimeTaker tt("wouldCollideWithCeiling");
 
@@ -323,11 +281,11 @@ bool wouldCollideWithCeiling(
 
 	for (const auto &it : cinfo) {
 		const aabb3f &staticbox = it.box;
-		if ((movingbox.MaxEdge.Y - d <= staticbox.MinEdge.Y) &&
+		if ((movingbox.MaxEdge.Y - d <= staticbox.MinEdge.Y)                     &&
 				(movingbox.MaxEdge.Y + y_increase > staticbox.MinEdge.Y) &&
-				(movingbox.MinEdge.X < staticbox.MaxEdge.X) &&
-				(movingbox.MaxEdge.X > staticbox.MinEdge.X) &&
-				(movingbox.MinEdge.Z < staticbox.MaxEdge.Z) &&
+				(movingbox.MinEdge.X < staticbox.MaxEdge.X)              &&
+				(movingbox.MaxEdge.X > staticbox.MinEdge.X)              &&
+				(movingbox.MinEdge.Z < staticbox.MaxEdge.Z)              &&
 				(movingbox.MaxEdge.Z > staticbox.MinEdge.Z))
 			return true;
 	}
@@ -344,11 +302,11 @@ static inline void getNeighborConnectingFace(const v3s16 &p,
 }
 
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
-		f32 pos_max_d, const aabb3f &box_0,
-		f32 stepheight, f32 dtime,
-		v3f *pos_f, v3f *speed_f,
-		v3f accel_f, ActiveObject *self,
-		bool collideWithObjects)
+	f32 pos_max_d, const aabb3f &box_0,
+	f32 stepheight, f32 dtime,
+	v3f *pos_f, v3f *speed_f,
+	v3f accel_f, ActiveObject *self,
+	bool collideWithObjects)
 {
 	static bool time_notification_done = false;
 	Map *map = &env->getMap();
@@ -357,14 +315,12 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	collisionMoveResult result;
 
-	/*
-		Calculate new velocity
-	*/
+	// Calculate new velocity
 	if (dtime > 0.5f) {
 		if (!time_notification_done) {
 			time_notification_done = true;
-			infostream << "collisionMoveSimple: maximum step interval exceeded,"
-					" lost movement details!"<<std::endl;
+			infostream << "collisionMoveSimple: maximum step interval"
+				" exceeded, lost movement details!" << std::endl;
 		}
 		dtime = 0.5f;
 	} else {
@@ -381,18 +337,18 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	speed_f->X = rangelim(speed_f->X, -5000, 5000);
 	speed_f->Z = rangelim(speed_f->Z, -5000, 5000);
 
-	/*
-		Collect node boxes in movement range
-	*/
+	// Collect node boxes in movement range
 	std::vector<NearbyCollisionInfo> cinfo;
 	{
+
 	//TimeTaker tt2("collisionMoveSimple collect boxes");
 	ScopeProfiler sp2(g_profiler, "collisionMoveSimple collect boxes avg", SPT_AVG);
 
 	v3f newpos_f = *pos_f + *speed_f * dtime;
 	v3f minpos_f(
 		MYMIN(pos_f->X, newpos_f.X),
-		MYMIN(pos_f->Y, newpos_f.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
+		// bias rounding, player often at +/-n.5
+		MYMIN(pos_f->Y, newpos_f.Y) + 0.01f * BS,
 		MYMIN(pos_f->Z, newpos_f.Z)
 	);
 	v3f maxpos_f(
@@ -426,7 +382,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 			int neighbors = 0;
 			if (f.drawtype == NDT_NODEBOX &&
-				f.node_box.type == NODEBOX_CONNECTED) {
+					f.node_box.type == NODEBOX_CONNECTED) {
 				v3s16 p2 = p;
 
 				p2.Y++;
@@ -481,13 +437,11 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	} // tt2
 
-	if(collideWithObjects)
-	{
+	if(collideWithObjects) {
 		ScopeProfiler sp2(g_profiler, "collisionMoveSimple objects avg", SPT_AVG);
-		//TimeTaker tt3("collisionMoveSimple collect object boxes");
+		// TimeTaker tt3("collisionMoveSimple collect object boxes");
 
-		/* add object boxes to cinfo */
-
+		// add object boxes to cinfo
 		std::vector<ActiveObject*> objects;
 #ifndef SERVER
 		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
@@ -505,8 +459,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 					objects.push_back((ActiveObject*) clientobject.obj);
 				}
 			}
-		}
-		else
+		} else
 #endif
 		{
 			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
@@ -536,23 +489,21 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				aabb3f object_collisionbox;
 				if (object->getCollisionBox(&object_collisionbox) &&
 						object->collideWithObjects()) {
-					cinfo.emplace_back(false, true, 0, v3s16(), object_collisionbox);
+					cinfo.emplace_back(false, true, 0,
+						v3s16(), object_collisionbox);
 				}
 			}
 		}
 	} //tt3
 
+	// Collision detection
 	/*
-		Collision detection
-	*/
-
-	/*
-		Collision uncertainty radius
-		Make it a bit larger than the maximum distance of movement
-	*/
+	 * Collision uncertainty radius
+	 * Make it a bit larger than the maximum distance of movement
+	 */
 	f32 d = pos_max_d * 1.1f;
 	// A fairly large value in here makes moving smoother
-	//f32 d = 0.15*BS;
+	// f32 d = 0.15*BS;
 
 	// This should always apply, otherwise there are glitches
 	assert(d > pos_max_d);	// invariant
@@ -560,13 +511,14 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	int loopcount = 0;
 
 	while(dtime > BS * 1e-10f) {
-		//TimeTaker tt3("collisionMoveSimple dtime loop");
+		// TimeTaker tt3("collisionMoveSimple dtime loop");
 		ScopeProfiler sp2(g_profiler, "collisionMoveSimple dtime loop avg", SPT_AVG);
 
 		// Avoid infinite loop
 		loopcount++;
 		if (loopcount >= 100) {
-			warningstream << "collisionMoveSimple: Loop count exceeded, aborting to avoid infiniite loop" << std::endl;
+			warningstream << "collisionMoveSimple: Loop count exceeded,"
+				" aborting to avoid infiniite loop" << std::endl;
 			break;
 		}
 
@@ -578,9 +530,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		f32 nearest_dtime = dtime;
 		int nearest_boxindex = -1;
 
-		/*
-			Go through every nodebox, find nearest collision
-		*/
+		// Go through every nodebox, find nearest collision
 		for (u32 boxindex = 0; boxindex < cinfo.size(); boxindex++) {
 			const NearbyCollisionInfo &box_info = cinfo[boxindex];
 			// Ignore if already stepped up this nodebox.
@@ -609,15 +559,16 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			NearbyCollisionInfo &nearest_info = cinfo[nearest_boxindex];
 			const aabb3f& cbox = nearest_info.box;
 			// Check for stairs.
-			bool step_up = (nearest_collided != 1) && // must not be Y direction
-					(movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
-					(movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
-					(!wouldCollideWithCeiling(cinfo, movingbox,
-							cbox.MaxEdge.Y - movingbox.MinEdge.Y,
-							d));
+			bool step_up =
+				// must not be Y direction
+				(nearest_collided != 1)                             &&
+				(movingbox.MinEdge.Y < cbox.MaxEdge.Y)              &&
+				(movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
+				(!wouldCollideWithCeiling(cinfo, movingbox,
+					cbox.MaxEdge.Y - movingbox.MinEdge.Y, d));
 
 			// Get bounce multiplier
-			float bounce = -(float)nearest_info.bouncy / 100.0f;
+			float bounce = -(float) nearest_info.bouncy / 100.0f;
 
 			// Move to the point of collision and reduce dtime by nearest_dtime
 			if (nearest_dtime < 0) {
@@ -684,9 +635,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		}
 	}
 
-	/*
-		Final touches: Check if standing on ground, step up stairs.
-	*/
+	// Final touches: Check if standing on ground, step up stairs.
 	aabb3f box = box_0;
 	box.MinEdge += *pos_f;
 	box.MaxEdge += *pos_f;
@@ -694,14 +643,14 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		const aabb3f &cbox = box_info.box;
 
 		/*
-			See if the object is touching ground.
-
-			Object touches ground if object's minimum Y is near node's
-			maximum Y and object's X-Z-area overlaps with the node's
-			X-Z-area.
-
-			Use 0.15*BS so that it is easier to get on a node.
-		*/
+		 * See if the object is touching ground.
+		 *
+		 * Object touches ground if object's minimum Y is near node's
+		 * maximum Y and object's X-Z-area overlaps with the node's
+		 * X-Z-area.
+		 *
+		 * Use 0.15*BS so that it is easier to get on a node.
+		 */
 		if (cbox.MaxEdge.X - d > box.MinEdge.X && cbox.MinEdge.X + d < box.MaxEdge.X &&
 				cbox.MaxEdge.Z - d > box.MinEdge.Z &&
 				cbox.MinEdge.Z + d < box.MaxEdge.Z) {
@@ -724,11 +673,10 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 }
 
 
-
 collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
-		f32 surface_dist, f32 dtime, v3f *pos_f, v3f *speed_f,
-		v3f accel_f, ActiveObject *self, f32 bounce_fraction,
-		f32 bounce_threshold, bool collideWithObjects)
+	f32 surface_dist, f32 dtime, v3f *pos_f, v3f *speed_f,
+	v3f accel_f, ActiveObject *self, f32 bounce_fraction,
+	f32 bounce_threshold, bool collideWithObjects)
 {
 	static bool time_notification_done = false;
 	Map *map = &env->getMap();
@@ -736,14 +684,12 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 
 	collisionMoveResult result;
 
-	/*
-		Calculate new velocity
-	*/
+	// Calculate new velocity
 	if (dtime > 0.5f) {
 		if (!time_notification_done) {
 			time_notification_done = true;
-			infostream << "collisionMovePoint: maximum step interval exceeded,"
-					" lost movement details!" << std::endl;
+			infostream << "collisionMoveSimple: maximum step interval"
+				" exceeded, lost movement details!" << std::endl;
 		}
 		dtime = 0.5f;
 	} else {
@@ -760,14 +706,11 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 	speed_f->X = rangelim(speed_f->X, -50*BS, 50*BS);
 	speed_f->Z = rangelim(speed_f->Z, -50*BS, 50*BS);
 
-
 	std::vector<NearbyCollisionInfo> cinfo_objects;
-	if(collideWithObjects)
-	{
+	if(collideWithObjects) {
 		ScopeProfiler sp2(g_profiler, "collisionMovePoint objects avg", SPT_AVG);
 
-		/* add object boxes to cinfo_objects */
-
+		// add object boxes to cinfo_objects
 		std::vector<ActiveObject*> objects;
 #ifndef SERVER
 		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
@@ -784,8 +727,7 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 					objects.push_back((ActiveObject*) clientobject.obj);
 				}
 			}
-		}
-		else
+		} else
 #endif
 		{
 			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
@@ -814,16 +756,14 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 				aabb3f object_collisionbox;
 				if (object->getCollisionBox(&object_collisionbox) &&
 						object->collideWithObjects()) {
-					cinfo_objects.emplace_back(false, true, 0, v3s16(), object_collisionbox);
+					cinfo_objects.emplace_back(false, true, 0,
+						v3s16(), object_collisionbox);
 				}
 			}
 		}
 	}
 
-	/*
-		Collision detection
-	*/
-
+	// Collision detection
 	int loopcount = 0;
 
 	bool previously_inside = false;
@@ -834,7 +774,8 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 		// Avoid infinite loop
 		loopcount++;
 		if (loopcount >= 100) {
-			warningstream << "collisionMovePoint Loop count exceeded, aborting to avoid infinite loop" << std::endl;
+			warningstream << "collisionMovePoint: Loop count exceeded,"
+				" aborting to avoid infiniite loop" << std::endl;
 			break;
 		}
 
@@ -842,27 +783,24 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 		f32 nearest_dtime = dtime;
 		int nearest_boxindex = -1;
 
-		/*
-			Go through every nodebox in path, find nearest collision
-		*/
-		/*
-			Collect node boxes in movement range
-		*/
+		// Go through every nodebox in path, find nearest collision
+
+		// Collect node boxes in movement range
 		std::vector<NearbyCollisionInfo> cinfo = cinfo_objects;
-		{
 
 		bool any_position_valid = false;
-
 		int loopcount_collect = 0;
 		v3s16 p = floatToInt(*pos_f, BS);
 		f32 dtime_collect = 0.f;
 		v3f pos_test = *pos_f;
+
 		bool finished = false;
 		while (true) {
 			++loopcount_collect;
 			if (loopcount_collect >= 100) {
-				warningstream << "collisionMovePoint collection Loop count exceeded, "
-					"aborting to avoid infinite loop" << std::endl;
+				warningstream << "collisionMovePoint collection"
+					" node count exceeded, aborting to avoid"
+					" infinite loop" << std::endl;
 				break;
 			}
 
@@ -883,27 +821,33 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 						v3s16 p2 = p;
 
 						p2.Y++;
-						getNeighborConnectingFace(p2, nodedef, map, n, 1, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 1, &neighbors);
 
 						p2 = p;
 						p2.Y--;
-						getNeighborConnectingFace(p2, nodedef, map, n, 2, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 2, &neighbors);
 
 						p2 = p;
 						p2.Z--;
-						getNeighborConnectingFace(p2, nodedef, map, n, 4, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 4, &neighbors);
 
 						p2 = p;
 						p2.X--;
-						getNeighborConnectingFace(p2, nodedef, map, n, 8, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 8, &neighbors);
 
 						p2 = p;
 						p2.Z++;
-						getNeighborConnectingFace(p2, nodedef, map, n, 16, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 16, &neighbors);
 
 						p2 = p;
 						p2.X++;
-						getNeighborConnectingFace(p2, nodedef, map, n, 32, &neighbors);
+						getNeighborConnectingFace(p2, nodedef,
+							map, n, 32, &neighbors);
 					}
 					std::vector<aabb3f> nodeboxes;
 					n.getCollisionBoxes(gamedef->ndef(), &nodeboxes, neighbors);
@@ -917,8 +861,10 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 					}
 				}
 			} else {
-				// Collide with unloaded nodes (position invalid) and loaded
-				// CONTENT_IGNORE nodes (position valid)
+				/*
+				 * Collide with unloaded nodes (position invalid) and loaded
+				 * CONTENT_IGNORE nodes (position valid)
+				 */
 				aabb3f box = getNodeBox(p, BS);
 				cinfo.emplace_back(true, false, 0, p, box);
 			}
@@ -949,15 +895,13 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 				return dtime;
 			};
 
-			if(speed_f->X != 0) {
+			if(speed_f->X != 0)
 				dtime_X = calc_dtime(pos_node_center.X, pos_test.X, speed_f->X);
-			}
-			if(speed_f->Y != 0) {
+			if(speed_f->Y != 0)
 				dtime_Y = calc_dtime(pos_node_center.Y, pos_test.Y, speed_f->Y);
-			}
-			if(speed_f->Z != 0) {
+			if(speed_f->Z != 0)
 				dtime_Z = calc_dtime(pos_node_center.Z, pos_test.Z, speed_f->Z);
-			}
+
 			f32 dtime_min = MYMIN(dtime_X, MYMIN(dtime_Y, dtime_Z));
 
 			if (dtime_min == max_value)
@@ -988,15 +932,15 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 		}
 
 
-		// Do not collide if world has not loaded yet, since custom node boxes
-		// are not available for collision detection.
-		// This also intentionally occurs in the case of the object being positioned
-		// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-		// The behavior is different from collisionMoveSimple.
+		/*
+		 * Do not collide if world has not loaded yet, since custom node boxes
+		 * are not available for collision detection.
+		 * This also intentionally occurs in the case of the object being positioned
+		 * solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
+		 * The behavior is different from collisionMoveSimple.
+		 */
 		if (!any_position_valid) {
 			return result;
-		}
-
 		}
 
 		{
@@ -1009,8 +953,9 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 			f32 dtime_tmp;
 			int collided;
 			bool inside;
-			std::tie(collided, dtime_tmp, inside) = pointBoxCollision(box_info.box,
-					*pos_f, *speed_f, surface_dist);
+			std::tie(collided, dtime_tmp, inside) =
+				pointBoxCollision(box_info.box,
+				*pos_f, *speed_f, surface_dist);
 
 			any_inside |= inside;
 
@@ -1048,23 +993,26 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 			info.old_speed = *speed_f;
 			info.plane = nearest_collided;
 
-
 			bool below_threshold = false;
+			f32 bounce_thresholdSQ = bounce_threshold*bounce_threshold;
 			// Bounce the particle with the speed component that caused the collision
 			if (nearest_collided == 0) { // X
 				speed_f->X *= -bounce_fraction;
 				f32 speed_absSQ = speed_f->getLengthSQ();
-				if (speed_f->X*speed_f->X < bounce_threshold*bounce_threshold*speed_absSQ)
+				if (speed_f->X * speed_f->X <
+						bounce_thresholdSQ*speed_absSQ)
 					below_threshold = true;
 			} else if (nearest_collided == 1) { // Y
 				speed_f->Y *= -bounce_fraction;
 				f32 speed_absSQ = speed_f->getLengthSQ();
-				if (speed_f->Y*speed_f->Y < bounce_threshold*bounce_threshold*speed_absSQ)
+				if (speed_f->Y * speed_f->Y <
+						bounce_thresholdSQ * speed_absSQ)
 					below_threshold = true;
 			} else if (nearest_collided == 2) { // Z
 				speed_f->Z *= -bounce_fraction;
 				f32 speed_absSQ = speed_f->getLengthSQ();
-				if (speed_f->Z*speed_f->Z < bounce_threshold*bounce_threshold*speed_absSQ)
+				if (speed_f->Z * speed_f->Z <
+						bounce_thresholdSQ * speed_absSQ)
 					below_threshold = true;
 			}
 			result.collides = true;
@@ -1075,12 +1023,10 @@ collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
 			if (info.new_speed.getDistanceFrom(info.old_speed) < 0.1f * BS)
 				is_collision = false;
 
-			if (is_collision) {
+			if (is_collision)
 				result.collisions.push_back(info);
-			}
 
 		}
-
 		previously_inside = any_inside;
 
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -217,12 +217,12 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.Y + speed.Y * (dtime) > 0) &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0)) {
-				return {0, dtime, inside};
+				return std::make_tuple(0, dtime, inside);
 			}
 		}
 		else if(relpos.X > xsize)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 	else if(speed.X < 0) // Check for collision with X+ plane
@@ -233,11 +233,11 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.Y + speed.Y * (dtime) > 0) &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
-				return {0, dtime, inside};
+				return std::make_tuple(0, dtime, inside);
 		}
 		else if(relpos.X < 0)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 
@@ -251,11 +251,11 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.X + speed.X * (dtime) > 0) &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
-				return {1, dtime, inside};
+				return std::make_tuple(1, dtime, inside);
 		}
 		else if(relpos.Y > ysize)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 	else if(speed.Y < 0) // Check for collision with Y+ plane
@@ -266,11 +266,11 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.X + speed.X * (dtime) > 0) &&
 					(relpos.Z + speed.Z * (dtime) < zsize) &&
 					(relpos.Z + speed.Z * (dtime) > 0))
-				return {1, dtime, inside};
+				return std::make_tuple(1, dtime, inside);
 		}
 		else if(relpos.Y < 0)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 
@@ -284,11 +284,11 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.X + speed.X * (dtime) > 0) &&
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
-				return {2, dtime, inside};
+				return std::make_tuple(2, dtime, inside);
 		}
 		else if(relpos.Z > zsize)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 	else if(speed.Z < 0) // Check for collision with Z+ plane
@@ -299,15 +299,15 @@ std::tuple<int, f32, bool> pointBoxCollision(
 					(relpos.X + speed.X * (dtime) > 0) &&
 					(relpos.Y + speed.Y * (dtime) < ysize) &&
 					(relpos.Y + speed.Y * (dtime) > 0))
-				return {2, dtime, inside};
+				return std::make_tuple(2, dtime, inside);
 		}
 		else if(relpos.Z < 0)
 		{
-			return {-1, dtime, inside};
+			return std::make_tuple(-1, dtime, inside);
 		}
 	}
 
-	return {-1, dtime, inside};
+	return std::make_tuple(-1, dtime, inside);
 }
 
 // Helper function:

--- a/src/collision.h
+++ b/src/collision.h
@@ -55,11 +55,17 @@ struct collisionMoveResult
 };
 
 // Moves using a single iteration; speed should not exceed pos_max_d/dtime
-collisionMoveResult collisionMoveSimple(Environment *env,IGameDef *gamedef,
+collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		f32 pos_max_d, const aabb3f &box_0,
 		f32 stepheight, f32 dtime,
 		v3f *pos_f, v3f *speed_f,
-		v3f accel_f, ActiveObject *self=NULL,
+		v3f accel_f, ActiveObject *self=nullptr,
+		bool collideWithObjects=true);
+
+collisionMoveResult collisionMovePoint(Environment *env, IGameDef *gamedef,
+		f32 pos_max_d, f32 dtime, v3f *pos_f, v3f *speed_f,
+		v3f accel_f, ActiveObject *self=nullptr,
+		f32 bounce_fraction=0.f, f32 bounce_threshold = 0.f,
 		bool collideWithObjects=true);
 
 // Helper function:

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -934,18 +934,20 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	bool collisiondetection = readU8(is);
 	std::string texture     = deSerializeLongString(is);
 
-	bool vertical          = false;
 	bool collision_removal = false;
 	TileAnimationParams animation;
 	animation.type         = TAT_NONE;
 	u8 glow                = 0;
 	bool object_collision  = false;
+	f32 bounce_fraction = 1.f;
+	f32 bounce_threshold = 0.f;
 	try {
-		vertical = readU8(is);
 		collision_removal = readU8(is);
 		animation.deSerialize(is, m_proto_ver);
 		glow = readU8(is);
 		object_collision = readU8(is);
+		bounce_fraction = readF32(is);
+		bounce_threshold = readF32(is);
 	} catch (...) {}
 
 	ClientEvent *event = new ClientEvent();
@@ -958,7 +960,8 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	event->spawn_particle.collisiondetection = collisiondetection;
 	event->spawn_particle.collision_removal  = collision_removal;
 	event->spawn_particle.object_collision   = object_collision;
-	event->spawn_particle.vertical           = vertical;
+	event->spawn_particle.bounce_fraction    = bounce_fraction;
+	event->spawn_particle.bounce_threshold   = bounce_threshold;
 	event->spawn_particle.texture            = new std::string(texture);
 	event->spawn_particle.animation          = animation;
 	event->spawn_particle.glow               = glow;
@@ -991,15 +994,15 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 
 	*pkt >> server_id;
 
-	bool vertical          = false;
 	bool collision_removal = false;
 	u16 attached_id        = 0;
 	TileAnimationParams animation;
 	animation.type         = TAT_NONE;
 	u8 glow                = 0;
 	bool object_collision  = false;
+	f32 bounce_fraction = 1.f;
+	f32 bounce_threshold = 0.f;
 	try {
-		*pkt >> vertical;
 		*pkt >> collision_removal;
 		*pkt >> attached_id;
 
@@ -1009,6 +1012,8 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 		animation.deSerialize(is, m_proto_ver);
 		glow = readU8(is);
 		object_collision = readU8(is);
+		bounce_fraction = readF32(is);
+		bounce_threshold = readF32(is);
 	} catch (...) {}
 
 	auto event = new ClientEvent();
@@ -1028,8 +1033,9 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	event->add_particlespawner.collisiondetection = collisiondetection;
 	event->add_particlespawner.collision_removal  = collision_removal;
 	event->add_particlespawner.object_collision   = object_collision;
+	event->add_particlespawner.bounce_fraction    = bounce_fraction;
+	event->add_particlespawner.bounce_threshold   = bounce_threshold;
 	event->add_particlespawner.attached_id        = attached_id;
-	event->add_particlespawner.vertical           = vertical;
 	event->add_particlespawner.texture            = new std::string(texture);
 	event->add_particlespawner.id                 = server_id;
 	event->add_particlespawner.animation          = animation;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -939,8 +939,8 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	animation.type         = TAT_NONE;
 	u8 glow                = 0;
 	bool object_collision  = false;
-	f32 bounce_fraction = 1.f;
-	f32 bounce_threshold = 0.f;
+	f32 bounce_fraction    = 1.f;
+	f32 bounce_threshold   = 0.f;
 	try {
 		readU8(is); // Dummy value for vertical
 		collision_removal = readU8(is);
@@ -1003,8 +1003,8 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	animation.type         = TAT_NONE;
 	u8 glow                = 0;
 	bool object_collision  = false;
-	f32 bounce_fraction = 1.f;
-	f32 bounce_threshold = 0.f;
+	f32 bounce_fraction    = 1.f;
+	f32 bounce_threshold   = 0.f;
 	try {
 		bool vertical_dummy;
 		*pkt >> vertical_dummy;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -942,12 +942,15 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	f32 bounce_fraction = 1.f;
 	f32 bounce_threshold = 0.f;
 	try {
+		readU8(is); // Dummy value for vertical
 		collision_removal = readU8(is);
 		animation.deSerialize(is, m_proto_ver);
 		glow = readU8(is);
 		object_collision = readU8(is);
-		bounce_fraction = readF32(is);
-		bounce_threshold = readF32(is);
+		if (is.rdbuf()->in_avail() >= 4)
+			bounce_fraction = readF32(is);
+		if (is.rdbuf()->in_avail() >= 4)
+			bounce_threshold = readF32(is);
 	} catch (...) {}
 
 	ClientEvent *event = new ClientEvent();
@@ -1003,6 +1006,8 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 	f32 bounce_fraction = 1.f;
 	f32 bounce_threshold = 0.f;
 	try {
+		bool vertical_dummy;
+		*pkt >> vertical_dummy;
 		*pkt >> collision_removal;
 		*pkt >> attached_id;
 
@@ -1012,8 +1017,10 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 		animation.deSerialize(is, m_proto_ver);
 		glow = readU8(is);
 		object_collision = readU8(is);
-		bounce_fraction = readF32(is);
-		bounce_threshold = readF32(is);
+		if (is.rdbuf()->in_avail() >= 4)
+			bounce_fraction = readF32(is);
+		if (is.rdbuf()->in_avail() >= 4)
+			bounce_threshold = readF32(is);
 	} catch (...) {}
 
 	auto event = new ClientEvent();

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -485,6 +485,7 @@ enum ToClientCommand
 		u8 bool collisiondetection
 		u32 len
 		u8[len] texture
+		u8 bool vertical_dummy
 		u8 collision_removal
 		TileAnimation animation
 		u8 glow
@@ -510,6 +511,7 @@ enum ToClientCommand
 		u8 bool collisiondetection
 		u32 len
 		u8[len] texture
+		u8 bool vertical_dummy
 		u8 collision_removal
 		u32 id
 		TileAnimation animation

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -485,11 +485,12 @@ enum ToClientCommand
 		u8 bool collisiondetection
 		u32 len
 		u8[len] texture
-		u8 bool vertical
 		u8 collision_removal
 		TileAnimation animation
 		u8 glow
 		u8 object_collision
+		f32 bounce_fraction
+		f32 bounce_threshold
 	*/
 
 	TOCLIENT_ADD_PARTICLESPAWNER = 0x47,
@@ -509,12 +510,13 @@ enum ToClientCommand
 		u8 bool collisiondetection
 		u32 len
 		u8[len] texture
-		u8 bool vertical
 		u8 collision_removal
 		u32 id
 		TileAnimation animation
 		u8 glow
 		u8 object_collision
+		f32 bounce_fraction
+		f32 bounce_threshold
 	*/
 
 	TOCLIENT_DELETE_PARTICLESPAWNER_LEGACY = 0x48, // Obsolete

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -27,14 +27,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 // add_particle({pos=, velocity=, acceleration=, expirationtime=,
 //     size=, collisiondetection=, collision_removal=, object_collision=,
-//     vertical=, texture=, player=})
+//     bounce_fraction=, bounce_threshold=, texture=, player=})
 // pos/velocity/acceleration = {x=num, y=num, z=num}
 // expirationtime = num (seconds)
 // size = num
 // collisiondetection = bool
 // collision_removal = bool
 // object_collision = bool
-// vertical = bool
+// bounce_fraction = f32
+// bounce_threshold = f32
 // texture = e.g."default_wood.png"
 // animation = TileAnimation definition
 // glow = num
@@ -46,8 +47,9 @@ int ModApiParticles::l_add_particle(lua_State *L)
 	v3f pos, vel, acc;
 	float expirationtime, size;
 	expirationtime = size = 1;
-	bool collisiondetection, vertical, collision_removal, object_collision;
-	collisiondetection = vertical = collision_removal = object_collision = false;
+	bool collisiondetection, collision_removal, object_collision;
+	f32 bounce_fraction = 1.f, bounce_threshold = 0.f;
+	collisiondetection = collision_removal = object_collision = false;
 	struct TileAnimationParams animation;
 	animation.type = TAT_NONE;
 	std::string texture;
@@ -105,7 +107,8 @@ int ModApiParticles::l_add_particle(lua_State *L)
 			"collision_removal", collision_removal);
 		object_collision = getboolfield_default(L, 1,
 			"object_collision", object_collision);
-		vertical = getboolfield_default(L, 1, "vertical", vertical);
+		bounce_fraction = getfloatfield_default(L, 1, "bounce_fraction", 1.f);
+		bounce_threshold = getfloatfield_default(L, 1, "bounce_threshold", 0.f);
 
 		lua_getfield(L, 1, "animation");
 		animation = read_animation_definition(L, -1);
@@ -117,8 +120,8 @@ int ModApiParticles::l_add_particle(lua_State *L)
 		glow = getintfield_default(L, 1, "glow", 0);
 	}
 	getServer(L)->spawnParticle(playername, pos, vel, acc, expirationtime, size,
-			collisiondetection, collision_removal, object_collision, vertical,
-			texture, animation, glow);
+			collisiondetection, collision_removal, object_collision, bounce_fraction,
+			bounce_threshold, texture, animation, glow);
 	return 1;
 }
 
@@ -131,7 +134,8 @@ int ModApiParticles::l_add_particle(lua_State *L)
 //				collisiondetection=,
 //				collision_removal=,
 //				object_collision=,
-//				vertical=,
+//				bounce_fraction=,
+//				bounce_threshold=,
 //				texture=,
 //				player=})
 // minpos/maxpos/minvel/maxvel/minacc/maxacc = {x=num, y=num, z=num}
@@ -140,7 +144,8 @@ int ModApiParticles::l_add_particle(lua_State *L)
 // collisiondetection = bool
 // collision_removal = bool
 // object_collision = bool
-// vertical = bool
+// bounce_fraction = f32
+// bounce_threshold = f32
 // texture = e.g."default_wood.png"
 // animation = TileAnimation definition
 // glow = num
@@ -153,8 +158,9 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 	v3f minpos, maxpos, minvel, maxvel, minacc, maxacc;
 	float time, minexptime, maxexptime, minsize, maxsize;
 	time = minexptime = maxexptime = minsize = maxsize = 1;
-	bool collisiondetection, vertical, collision_removal, object_collision;
-	collisiondetection = vertical = collision_removal = object_collision = false;
+	bool collisiondetection, collision_removal, object_collision;
+	f32 bounce_fraction = 1.f, bounce_threshold = 0.f;
+	collisiondetection = collision_removal = object_collision = false;
 	struct TileAnimationParams animation;
 	animation.type = TAT_NONE;
 	ServerActiveObject *attached = NULL;
@@ -221,6 +227,8 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 			"collision_removal", collision_removal);
 		object_collision = getboolfield_default(L, 1,
 			"object_collision", object_collision);
+		bounce_fraction = getfloatfield_default(L, 1, "bounce_fraction", 1.f);
+		bounce_threshold = getfloatfield_default(L, 1, "bounce_threshold", 0.f);
 
 		lua_getfield(L, 1, "animation");
 		animation = read_animation_definition(L, -1);
@@ -233,7 +241,6 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 			attached = ObjectRef::getobject(ref);
 		}
 
-		vertical = getboolfield_default(L, 1, "vertical", vertical);
 		texture = getstringfield_default(L, 1, "texture", "");
 		playername = getstringfield_default(L, 1, "playername", "");
 		glow = getintfield_default(L, 1, "glow", 0);
@@ -248,8 +255,9 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 			collisiondetection,
 			collision_removal,
 			object_collision,
+			bounce_fraction,
+			bounce_threshold,
 			attached,
-			vertical,
 			texture, playername,
 			animation, glow);
 	lua_pushnumber(L, id);

--- a/src/script/lua_api/l_particles_local.cpp
+++ b/src/script/lua_api/l_particles_local.cpp
@@ -34,7 +34,8 @@ int ModApiParticlesLocal::l_add_particle(lua_State *L)
 	// Get parameters
 	v3f pos, vel, acc;
 	float expirationtime, size;
-	bool collisiondetection, vertical, collision_removal;
+	bool collisiondetection, collision_removal;
+	f32 bounce_fraction, bounce_threshold;
 
 	struct TileAnimationParams animation;
 	animation.type = TAT_NONE;
@@ -59,7 +60,8 @@ int ModApiParticlesLocal::l_add_particle(lua_State *L)
 	size = getfloatfield_default(L, 1, "size", 1);
 	collisiondetection = getboolfield_default(L, 1, "collisiondetection", false);
 	collision_removal = getboolfield_default(L, 1, "collision_removal", false);
-	vertical = getboolfield_default(L, 1, "vertical", false);
+	bounce_fraction = getfloatfield_default(L, 1, "bounce_fraction", 1.f);
+	bounce_threshold = getfloatfield_default(L, 1, "bounce_threshold", 0.f);
 
 	lua_getfield(L, 1, "animation");
 	animation = read_animation_definition(L, -1);
@@ -78,7 +80,8 @@ int ModApiParticlesLocal::l_add_particle(lua_State *L)
 	event->spawn_particle.size               = size;
 	event->spawn_particle.collisiondetection = collisiondetection;
 	event->spawn_particle.collision_removal  = collision_removal;
-	event->spawn_particle.vertical           = vertical;
+	event->spawn_particle.bounce_fraction    = bounce_fraction;
+	event->spawn_particle.bounce_threshold   = bounce_threshold;
 	event->spawn_particle.texture            = new std::string(texture);
 	event->spawn_particle.animation          = animation;
 	event->spawn_particle.glow               = glow;
@@ -94,7 +97,8 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 	u16 amount;
 	v3f minpos, maxpos, minvel, maxvel, minacc, maxacc;
 	float time, minexptime, maxexptime, minsize, maxsize;
-	bool collisiondetection, vertical, collision_removal;
+	bool collisiondetection, collision_removal;
+	f32 bounce_fraction, bounce_threshold;
 
 	struct TileAnimationParams animation;
 	animation.type = TAT_NONE;
@@ -137,7 +141,8 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 
 	collisiondetection = getboolfield_default(L, 1, "collisiondetection", false);
 	collision_removal = getboolfield_default(L, 1, "collision_removal", false);
-	vertical = getboolfield_default(L, 1, "vertical", false);
+	bounce_fraction = getfloatfield_default(L, 1, "bounce_fraction", 1.f);
+	bounce_threshold = getfloatfield_default(L, 1, "bounce_threshold", 0.f);
 
 	lua_getfield(L, 1, "animation");
 	animation = read_animation_definition(L, -1);
@@ -172,8 +177,9 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 	event->add_particlespawner.maxsize            = maxsize;
 	event->add_particlespawner.collisiondetection = collisiondetection;
 	event->add_particlespawner.collision_removal  = collision_removal;
+	event->add_particlespawner.bounce_fraction    = bounce_fraction;
+	event->add_particlespawner.bounce_threshold   = bounce_threshold;
 	event->add_particlespawner.attached_id        = 0;
-	event->add_particlespawner.vertical           = vertical;
 	event->add_particlespawner.texture            = new std::string(texture);
 	event->add_particlespawner.id                 = id;
 	event->add_particlespawner.animation          = animation;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1631,7 +1631,7 @@ void Server::SendSpawnParticle(session_t peer_id, u16 protocol_version,
 	pkt << pos << velocity << acceleration << expirationtime
 			<< size << collisiondetection;
 	pkt.putLongString(texture);
-	pkt << true; // Dummy value for vertical
+	pkt << false; // Dummy value for vertical
 	pkt << collision_removal;
 	// This is horrible but required (why are there two ways to serialize pkts?)
 	std::ostringstream os(std::ios_base::binary);
@@ -1679,7 +1679,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 	pkt.putLongString(texture);
 
 	pkt << id;
-	pkt << true; // Dummy value for vertical
+	pkt << false; // Dummy value for vertical
 	pkt << collision_removal;
 	pkt << attached_id;
 	// This is horrible but required

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1631,6 +1631,7 @@ void Server::SendSpawnParticle(session_t peer_id, u16 protocol_version,
 	pkt << pos << velocity << acceleration << expirationtime
 			<< size << collisiondetection;
 	pkt.putLongString(texture);
+	pkt << true; // Dummy value for vertical
 	pkt << collision_removal;
 	// This is horrible but required (why are there two ways to serialize pkts?)
 	std::ostringstream os(std::ios_base::binary);
@@ -1678,6 +1679,7 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 	pkt.putLongString(texture);
 
 	pkt << id;
+	pkt << true; // Dummy value for vertical
 	pkt << collision_removal;
 	pkt << attached_id;
 	// This is horrible but required

--- a/src/server.h
+++ b/src/server.h
@@ -230,7 +230,7 @@ public:
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
 		bool collisiondetection, bool collision_removal, bool object_collision,
-		bool vertical, const std::string &texture,
+		f32 bounce_fraction, f32 bounce_threshold, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
 	u32 addParticleSpawner(u16 amount, float spawntime,
@@ -240,9 +240,9 @@ public:
 		float minexptime, float maxexptime,
 		float minsize, float maxsize,
 		bool collisiondetection, bool collision_removal, bool object_collision,
-		ServerActiveObject *attached,
-		bool vertical, const std::string &texture,
-		const std::string &playername, const struct TileAnimationParams &animation,
+		f32 bounce_fraction, f32 bounce_threshold, ServerActiveObject *attached,
+		const std::string &texture, const std::string &playername,
+		const struct TileAnimationParams &animation,
 		u8 glow);
 
 	void deleteParticleSpawner(const std::string &playername, u32 id);
@@ -450,8 +450,8 @@ private:
 		float minexptime, float maxexptime,
 		float minsize, float maxsize,
 		bool collisiondetection, bool collision_removal, bool object_collision,
-		u16 attached_id,
-		bool vertical, const std::string &texture, u32 id,
+		f32 bounce_fraction, f32 bounce_threshold, u16 attached_id,
+		const std::string &texture, u32 id,
 		const struct TileAnimationParams &animation, u8 glow);
 
 	void SendDeleteParticleSpawner(session_t peer_id, u32 id);
@@ -461,7 +461,7 @@ private:
 		v3f pos, v3f velocity, v3f acceleration,
 		float expirationtime, float size,
 		bool collisiondetection, bool collision_removal, bool object_collision,
-		bool vertical, const std::string &texture,
+		f32 bounce_fraction, f32 bounce_threshold, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
 	u32 SendActiveObjectRemoveAdd(session_t peer_id, const std::string &datas);


### PR DESCRIPTION
Update to pull request #6540.
Addresses #6523, #1414, #2690.

I've included your suggestions and implemented the special collision handling for points, as well as addressed the previous TODOs.
-The scaling is correct now, the velocities for the Irrlicht particles are given per millisecond. @numberZero
-The collision detection is much faster, about ~5 times when I tested it (by doing the calculation
with both methods by uncommenting the `collisionMoveSimple` code in "particles.cpp" of 46dc879cf143fb838b6db3c9e330974762dbe0fe and comparing the Profiler info). This speedup comes from the much lower amount of nodes considered by the treatment as points.
-I added the `bounce_fraction` and the `bounce_threshold` properties to specify the retained fraction of the velocity component in the direction of the bounce, and the threshold for the ratio of this component to the total speed, below which the particle stops completely. This causes the "digging particles" not to slide anymore as before.
-The `vertical` property was removed.
-To prevent particles partially hidden in nodes (which also causes wrong lighting), the colliding nodeboxes are treated as enlarged by the particle size. This causes problems on the edges of nodes for large particles, but to change this more nodes have to be considered. For the most part, this is not really noticable.

The changed properties require a change in the network protocol, so the change in 9c57ce0122b54fc26f57fd8ab77d7de5e972ec73 could be removed in this pull request.

[Updated mod for testing](https://pastebin.com/sBKE13jv)