### PR TITLE
PlayerSAO::punch - Abort if punched player is already dead

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1279,6 +1279,10 @@ int PlayerSAO::punch(v3f dir,
 		}
 	}
 
+	// Abort if player is already dead
+	if (getHP() == 0)
+		return 0;
+
 	HitParams hitparams = getHitParams(m_armor_groups, toolcap,
 			time_from_last_punch);
 
@@ -1308,11 +1312,11 @@ int PlayerSAO::punch(v3f dir,
 
 	actionstream << "Player " << m_player->getName() << " punched by "
 			<< punchername;
-	if (!damage_handled) {
+	if (!damage_handled)
 		actionstream << ", damage " << hitparams.hp << " HP";
-	} else {
-		actionstream << ", damage handled by lua";
-	}
+	else
+		actionstream << ", damage handled by Lua";
+
 	actionstream << std::endl;
 
 	return hitparams.wear;


### PR DESCRIPTION
Punching a dead player executes all the punch code, the `on_punchplayer` callbacks, and subsequently the `on_hpchange` callbacks, which is a bug, IMHO.

This trivial PR adds simply aborts the execution of the function and the callbacks if the punched player's HP is 0.

Tested by registering `on_punchplayer` and `on_hpchange` callbacks which just output a couple of messages - these debug messages aren't printed to chat if the punched player is already dead.