### PR TITLE
InvRef: Add convenience method add_list for bulk transfer of items

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1276,17 +1276,23 @@ void push_tool_capabilities(lua_State *L,
 }
 
 /******************************************************************************/
+void push_inventory_list_raw(lua_State *L, InventoryList *invlist)
+{
+	std::vector<ItemStack> items;
+	for (u32 i = 0; i < invlist->getSize(); i++)
+		items.push_back(invlist->getItem(i));
+
+	push_items(L, items);
+}
+
+/******************************************************************************/
 void push_inventory_list(lua_State *L, Inventory *inv, const char *name)
 {
 	InventoryList *invlist = inv->getList(name);
-	if(invlist == NULL){
+	if (!invlist)
 		lua_pushnil(L);
-		return;
-	}
-	std::vector<ItemStack> items;
-	for(u32 i=0; i<invlist->getSize(); i++)
-		items.push_back(invlist->getItem(i));
-	push_items(L, items);
+	else
+		push_inventory_list_raw(L, invlist);
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -53,6 +53,7 @@ struct ObjectProperties;
 struct SimpleSoundSpec;
 struct ServerSoundParams;
 class Inventory;
+class InventoryList;
 struct NodeBox;
 struct ContentFeatures;
 struct TileDef;
@@ -112,6 +113,8 @@ void               read_object_properties    (lua_State *L, int index,
 void               push_object_properties    (lua_State *L,
                                               ObjectProperties *prop);
 
+void               push_inventory_list_raw   (lua_State *L,
+                                              InventoryList *invlist);
 void               push_inventory_list       (lua_State *L,
                                               Inventory *inv,
                                               const char *name);

--- a/src/script/lua_api/l_inventory.h
+++ b/src/script/lua_api/l_inventory.h
@@ -78,6 +78,9 @@ private:
 	// set_list(self, listname, list)
 	static int l_set_list(lua_State *L);
 
+	// add_list(self, listname, list)
+	static int l_add_list(lua_State *L);
+
 	// get_lists(self) -> list of InventoryLists
 	static int l_get_lists(lua_State *L);
 


### PR DESCRIPTION
- New Lua API method `InvRef:add_list(dst_listname, src_listname)` for bulk transfer of items from one inventory list to another.
- Returns the leftover items as an inventory list.
- New internal function `push_inventory_list_raw` (declared/defined in `c_content.{h|cpp}`) to directly push an `InventoryList *` object to the Lua stack. Existing function `push_inventory_list` now makes use of `push_inventory_list_raw` internally.

****

To test:

- Install and enable `luacmd` mod.
- Populate at least 10 slots with unique items in the main inventory list.
- Type the following into the console:
  ```lua
  /lua inv = me:get_inventory()
  /lua inv:set_list("main", inv:add_list("craft", "main"))
  ```

The above chat-command transfers all items in `main` to the crafting grid and sets the leftover back to `main`. Since there were more than 9 unique items in `main`, there's bound to be at least one item as leftover.

****

Closes #7663. Tested, works as expected.