### PR TITLE
Make automatic_rotate relative, allow setting rotation

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6223,6 +6223,7 @@ Player properties need to be saved manually.
 
         automatic_rotate = 0,
         -- Set constant rotation in radians per second, positive or negative.
+        -- Object rotates along the local Y-axis, and works with set_rotation.
         -- Set to 0 to disable constant rotation.
 
         stepheight = 0,

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1015,10 +1015,13 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			updateTextures(m_previous_texture_modifier);
 		}
 	}
+
 	if (!getParent() && std::fabs(m_prop.automatic_rotate) > 0.001) {
-		m_rotation.Y += dtime * m_prop.automatic_rotate * 180 / M_PI;
-		rot_translator.val_current = m_rotation;
-		updateNodePos();
+		// This is the child node's rotation. It is only used for automatic_rotate.
+		v3f local_rot = node->getRotation();
+		local_rot.Y = modulo360f(local_rot.Y - dtime * core::RADTODEG *
+				m_prop.automatic_rotate);
+		node->setRotation(local_rot);
 	}
 
 	if (!getParent() && m_prop.automatic_face_movement_dir &&
@@ -1408,11 +1411,7 @@ void GenericCAO::processMessage(const std::string &data)
 		m_position = readV3F32(is);
 		m_velocity = readV3F32(is);
 		m_acceleration = readV3F32(is);
-
-		if (std::fabs(m_prop.automatic_rotate) < 0.001f)
-			m_rotation = readV3F32(is);
-		else
-			readV3F32(is);
+		m_rotation = readV3F32(is);
 
 		m_rotation = wrapDegrees_0_360_v3f(m_rotation);
 		bool do_interpolate = readU8(is);


### PR DESCRIPTION
<details>

<summary>PR by p_gimeno: https://notabug.org/pgimeno/minetest/pulls/5</summary>

> `automatic_rotate` does not make sense if it is absolute. Make it relative.
> 
> To avoid bouncing, `set_rotation` did not update the client when automatic_rotate was set. That's no longer necessary because the new spinning method applies the rotation on top of the current one, and the updates are necessary for `set_rotation` to actually transform the object.
> 
> The problem fixed here is the result of an oversight when `set_rotation` was added. Objects couldn't be oriented in any other way before it was implemented, therefore this wasn't an issue.
> 
> This allows for single-object rotation as discussed in https://github.com/minetest/minetest/issues/8456, when it applies to objects that are not attached.
> 
> Full axis specification, as discussed there, while interesting, is not strictly necessary. As long as the model is constructed in such a way that it's designed to spin over its local Y axis (for example, making a propeller such that it "lies" on the XZ plane and with the rotation axis being the Y axis), it's possible to use `set_rotation` to reorient the object so that the rotation axis points in the desired direction.
> 
> Therefore, full axis specification would only be helpful in case the model does not meet that requirement. Assuming the creator has full control over the model, that's not necessary.
> 
> What is not covered by this patch is rotation of attachments. This means that e.g. a propeller attached to a plane is not possible without adding a new property. Current plans are to submit a separate PR for that.

</details>

Test mod (testing instructions provided in the mod's README): https://github.com/ClobberXD/auto_rot

Closes #8456. Tested, works.