### PR TITLE
Anti-cheat: Add line-of-sight check for player interactions

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3774,6 +3774,7 @@ Call these functions only at load time!
         * `moved_too_fast`
         * `interacted_too_far`
         * `interacted_while_dead`
+        * `interacted_without_line_of_sight`
         * `finished_unknown_dig`
         * `dug_unbreakable`
         * `dug_too_fast`


### PR DESCRIPTION
Interacting without a proper line of sight is relatively easier now, thanks to Raycast. I'm not going to go into the details of how this can be done for obvious reasons, but this PR adds a simple line-of-sight check, which when fails triggers the anti-cheat (if enabled).