### PR TITLE
Dungeons: Settable density noise, move number calculation to mapgens

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1417,6 +1417,9 @@ mgv5_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.6
 #    3D noise defining terrain.
 mgv5_np_ground (Ground noise) noise_params_3d 0, 40, (80, 80, 80), 983240, 4, 0.55, 2.0, eased
 
+#    3D noise that determines number of dungeons per mapchunk.
+mgv5_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
 [*Mapgen V6]
 
 #    Map generation attributes specific to Mapgen v6.
@@ -1569,6 +1572,9 @@ mgv7_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5, 
 #    Second of two 3D noises that together define tunnels.
 mgv7_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
+#    3D noise that determines number of dungeons per mapchunk.
+mgv7_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
 [*Mapgen Carpathian]
 
 #    Map generation attributes specific to Mapgen Carpathian.
@@ -1648,6 +1654,9 @@ mgcarpathian_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 
 #    3D noise defining giant caverns.
 mgcarpathian_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0
 
+#    3D noise that determines number of dungeons per mapchunk.
+mgcarpathian_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
 [*Mapgen Flat]
 
 #    Map generation attributes specific to Mapgen flat.
@@ -1701,6 +1710,9 @@ mgflat_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 0.5
 
 #    Second of two 3D noises that together define tunnels.
 mgflat_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Mapgen Fractal]
 
@@ -1811,6 +1823,9 @@ mgfractal_np_cave1 (Cave1 noise) noise_params_3d 0, 12, (61, 61, 61), 52534, 3, 
 #    Second of two 3D noises that together define tunnels.
 mgfractal_np_cave2 (Cave2 noise) noise_params_3d 0, 12, (67, 67, 67), 10325, 3, 0.5, 2.0
 
+#    3D noise that determines number of dungeons per mapchunk.
+mgfractal_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
+
 [*Mapgen Valleys]
 
 #    Map generation attributes specific to Mapgen Valleys.
@@ -1887,6 +1902,9 @@ mgvalleys_np_valley_profile (Valley profile) noise_params_2d 0.6, 0.5, (512, 512
 
 #    Slope and fill work together to modify the heights.
 mgvalleys_np_inter_valley_slope (Valley slope) noise_params_2d 0.5, 0.5, (128, 128, 128), 746, 1, 1.0, 2.0, eased
+
+#    3D noise that determines number of dungeons per mapchunk.
+mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2, 0.8, 2.0
 
 [*Advanced]
 

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -31,9 +31,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 //#define DGEN_USE_TORCHES
 
-NoiseParams nparams_dungeon_density(0.9, 0.5, v3f(500.0, 500.0, 500.0), 0, 2, 0.8, 2.0);
-NoiseParams nparams_dungeon_alt_wall(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6, 1.1, 2.0);
-
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -73,21 +70,21 @@ DungeonGen::DungeonGen(const NodeDefManager *ndef,
 		dp.rooms_max           = 16;
 		dp.notifytype          = GENNOTIFY_DUNGEON;
 
-		dp.np_density  = nparams_dungeon_density;
-		dp.np_alt_wall = nparams_dungeon_alt_wall;
+		dp.np_alt_wall = 
+			NoiseParams(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6, 1.1, 2.0);
 	}
 }
 
 
-void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
+void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax,
+	u16 num_dungeons)
 {
+	if (num_dungeons == 0)
+		return;
+
 	assert(vm);
 
 	//TimeTaker t("gen dungeons");
-
-	float nval_density = NoisePerlin3D(&dp.np_density, nmin.X, nmin.Y, nmin.Z, dp.seed);
-	if (nval_density < 1.0f)
-		return;
 
 	static const bool preserve_ignore = !g_settings->getBool("projecting_dungeons");
 
@@ -122,7 +119,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	}
 
 	// Add them
-	for (u32 i = 0; i < std::floor(nval_density); i++)
+	for (u32 i = 0; i < num_dungeons; i++)
 		makeDungeon(v3s16(1, 1, 1) * MAP_BLOCKSIZE);
 
 	// Optionally convert some structure to alternative structure

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -58,7 +58,6 @@ struct DungeonParams {
 	u16 rooms_max;
 	GenNotifyType notifytype;
 
-	NoiseParams np_density;
 	NoiseParams np_alt_wall;
 };
 
@@ -83,7 +82,7 @@ public:
 		GenerateNotifier *gennotify, DungeonParams *dparams);
 
 	void generate(MMVManip *vm, u32 bseed,
-		v3s16 full_node_min, v3s16 full_node_max);
+		v3s16 full_node_min, v3s16 full_node_max, u16 num_dungeons);
 
 	void makeDungeon(v3s16 start_padding);
 	void makeRoom(v3s16 roomsize, v3s16 roomplace);

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <cmath>
 #include "mapgen.h"
 #include "voxel.h"
 #include "noise.h"
@@ -889,6 +890,11 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 	if (max_stone_y < node_min.Y)
 		return;
 
+	u16 num_dungeons = std::fmax(std::floor(
+		NoisePerlin3D(np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
+	if (num_dungeons == 0)
+		return;
+
 	// Get biome at mapchunk midpoint
 	v3s16 chunk_mid = node_min + (node_max - node_min) / v3s16(2, 2, 2);
 	Biome *biome = (Biome *)biomegen->getBiomeAtPoint(chunk_mid);
@@ -902,8 +908,8 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 	dp.rooms_min        = 2;
 	dp.rooms_max        = 16;
 
-	dp.np_density       = nparams_dungeon_density;
-	dp.np_alt_wall      = nparams_dungeon_alt_wall;
+	dp.np_alt_wall = 
+		NoiseParams(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6, 1.1, 2.0);
 
 	// Biome-defined dungeon nodes
 	if (biome->c_dungeon != CONTENT_IGNORE) {
@@ -980,7 +986,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 	}
 
 	DungeonGen dgen(ndef, &gennotify, &dp);
-	dgen.generate(vm, blockseed, full_node_min, full_node_max);
+	dgen.generate(vm, blockseed, full_node_min, full_node_max, num_dungeons);
 }
 
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -891,7 +891,7 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 		return;
 
 	u16 num_dungeons = std::fmax(std::floor(
-		NoisePerlin3D(np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
+		NoisePerlin3D(&np_dungeons, node_min.X, node_min.Y, node_min.Z, seed)), 0.0f);
 	if (num_dungeons == 0)
 		return;
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -283,6 +283,7 @@ protected:
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_cavern;
+	NoiseParams *np_dungeons;
 	float cave_width;
 	float cavern_limit;
 	float cavern_taper;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -283,7 +283,7 @@ protected:
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_cavern;
-	NoiseParams *np_dungeons;
+	NoiseParams np_dungeons;
 	float cave_width;
 	float cavern_limit;
 	float cavern_taper;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -88,7 +88,7 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	MapgenBasic::np_cave1  = params->np_cave1;
 	MapgenBasic::np_cave2  = params->np_cave2;
 	MapgenBasic::np_cavern = params->np_cavern;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
 

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -88,6 +88,7 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	MapgenBasic::np_cave1  = params->np_cave1;
 	MapgenBasic::np_cave2  = params->np_cave2;
 	MapgenBasic::np_cavern = params->np_cavern;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 }
 
 
@@ -109,21 +110,22 @@ MapgenCarpathian::~MapgenCarpathian()
 
 
 MapgenCarpathianParams::MapgenCarpathianParams():
-	np_filler_depth  (0,  1,  v3f(128,  128,  128),  261,   3, 0.7,  2.0),
-	np_height1       (0,  5,  v3f(251,  251,  251),  9613,  5, 0.5,  2.0),
-	np_height2       (0,  5,  v3f(383,  383,  383),  1949,  5, 0.5,  2.0),
-	np_height3       (0,  5,  v3f(509,  509,  509),  3211,  5, 0.5,  2.0),
-	np_height4       (0,  5,  v3f(631,  631,  631),  1583,  5, 0.5,  2.0),
-	np_hills_terrain (1,  1,  v3f(1301, 1301, 1301), 1692,  5, 0.5,  2.0),
-	np_ridge_terrain (1,  1,  v3f(1889, 1889, 1889), 3568,  5, 0.5,  2.0),
-	np_step_terrain  (1,  1,  v3f(1889, 1889, 1889), 4157,  5, 0.5,  2.0),
-	np_hills         (0,  3,  v3f(257,  257,  257),  6604,  6, 0.5,  2.0),
-	np_ridge_mnt     (0,  12, v3f(743,  743,  743),  5520,  6, 0.7,  2.0),
-	np_step_mnt      (0,  8,  v3f(509,  509,  509),  2590,  6, 0.6,  2.0),
-	np_mnt_var       (0,  1,  v3f(499,  499,  499),  2490,  5, 0.55, 2.0),
-	np_cave1         (0,  12, v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
-	np_cave2         (0,  12, v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
-	np_cavern        (0,  1,  v3f(384,  128,  384),  723,   5, 0.63, 2.0)
+	np_filler_depth  (0,   1,   v3f(128,  128,  128),  261,   3, 0.7,  2.0),
+	np_height1       (0,   5,   v3f(251,  251,  251),  9613,  5, 0.5,  2.0),
+	np_height2       (0,   5,   v3f(383,  383,  383),  1949,  5, 0.5,  2.0),
+	np_height3       (0,   5,   v3f(509,  509,  509),  3211,  5, 0.5,  2.0),
+	np_height4       (0,   5,   v3f(631,  631,  631),  1583,  5, 0.5,  2.0),
+	np_hills_terrain (1,   1,   v3f(1301, 1301, 1301), 1692,  5, 0.5,  2.0),
+	np_ridge_terrain (1,   1,   v3f(1889, 1889, 1889), 3568,  5, 0.5,  2.0),
+	np_step_terrain  (1,   1,   v3f(1889, 1889, 1889), 4157,  5, 0.5,  2.0),
+	np_hills         (0,   3,   v3f(257,  257,  257),  6604,  6, 0.5,  2.0),
+	np_ridge_mnt     (0,   12,  v3f(743,  743,  743),  5520,  6, 0.7,  2.0),
+	np_step_mnt      (0,   8,   v3f(509,  509,  509),  2590,  6, 0.6,  2.0),
+	np_mnt_var       (0,   1,   v3f(499,  499,  499),  2490,  5, 0.55, 2.0),
+	np_cave1         (0,   12,  v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
+	np_cave2         (0,   12,  v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
+	np_cavern        (0,   1,   v3f(384,  128,  384),  723,   5, 0.63, 2.0),
+	np_dungeons      (0.9, 0.5, v3f(500,  500,  500),  0,     2, 0.8,  2.0)
 {
 }
 
@@ -156,6 +158,7 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 	settings->getNoiseParams("mgcarpathian_np_cave1",         np_cave1);
 	settings->getNoiseParams("mgcarpathian_np_cave2",         np_cave2);
 	settings->getNoiseParams("mgcarpathian_np_cavern",        np_cavern);
+	settings->getNoiseParams("mgcarpathian_np_dungeons",      np_dungeons);
 }
 
 
@@ -187,6 +190,7 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgcarpathian_np_cave1",         np_cave1);
 	settings->setNoiseParams("mgcarpathian_np_cave2",         np_cave2);
 	settings->setNoiseParams("mgcarpathian_np_cavern",        np_cavern);
+	settings->setNoiseParams("mgcarpathian_np_dungeons",      np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -60,6 +60,7 @@ struct MapgenCarpathianParams : public MapgenParams
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_cavern;
+	NoiseParams np_dungeons;
 
 	MapgenCarpathianParams();
 	~MapgenCarpathianParams() = default;

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -69,8 +69,9 @@ MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
 	if ((spflags & MGFLAT_LAKES) || (spflags & MGFLAT_HILLS))
 		noise_terrain = new Noise(&params->np_terrain, seed, csize.X, csize.Z);
 	// 3D noise
-	MapgenBasic::np_cave1 = params->np_cave1;
-	MapgenBasic::np_cave2 = params->np_cave2;
+	MapgenBasic::np_cave1    = params->np_cave1;
+	MapgenBasic::np_cave2    = params->np_cave2;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 }
 
 
@@ -84,10 +85,11 @@ MapgenFlat::~MapgenFlat()
 
 
 MapgenFlatParams::MapgenFlatParams():
-	np_terrain      (0, 1,   v3f(600, 600, 600), 7244,  5, 0.6, 2.0),
-	np_filler_depth (0, 1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0),
-	np_cave1        (0, 12,  v3f(61,  61,  61),  52534, 3, 0.5, 2.0),
-	np_cave2        (0, 12,  v3f(67,  67,  67),  10325, 3, 0.5, 2.0)
+	np_terrain      (0,   1,   v3f(600, 600, 600), 7244,  5, 0.6, 2.0),
+	np_filler_depth (0,   1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0),
+	np_cave1        (0,   12,  v3f(61,  61,  61),  52534, 3, 0.5, 2.0),
+	np_cave2        (0,   12,  v3f(67,  67,  67),  10325, 3, 0.5, 2.0),
+	np_dungeons     (0.9, 0.5, v3f(500, 500, 500), 0,     2, 0.8, 2.0)
 {
 }
 
@@ -110,6 +112,7 @@ void MapgenFlatParams::readParams(const Settings *settings)
 	settings->getNoiseParams("mgflat_np_filler_depth", np_filler_depth);
 	settings->getNoiseParams("mgflat_np_cave1",        np_cave1);
 	settings->getNoiseParams("mgflat_np_cave2",        np_cave2);
+	settings->getNoiseParams("mgflat_np_dungeons",     np_dungeons);
 }
 
 
@@ -131,6 +134,7 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgflat_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgflat_np_cave1",        np_cave1);
 	settings->setNoiseParams("mgflat_np_cave2",        np_cave2);
+	settings->setNoiseParams("mgflat_np_dungeons",     np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -71,7 +71,7 @@ MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
 	// 3D noise
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
 

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -48,6 +48,7 @@ struct MapgenFlatParams : public MapgenParams
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
+	NoiseParams np_dungeons;
 
 	MapgenFlatParams();
 	~MapgenFlatParams() = default;

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -72,7 +72,7 @@ MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 
 	formula = fractal / 2 + fractal % 2;
 	julia   = fractal % 2 == 0;

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -70,8 +70,9 @@ MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 	noise_seabed       = new Noise(&params->np_seabed, seed, csize.X, csize.Z);
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
 
-	MapgenBasic::np_cave1 = params->np_cave1;
-	MapgenBasic::np_cave2 = params->np_cave2;
+	MapgenBasic::np_cave1    = params->np_cave1;
+	MapgenBasic::np_cave2    = params->np_cave2;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 
 	formula = fractal / 2 + fractal % 2;
 	julia   = fractal % 2 == 0;
@@ -89,7 +90,8 @@ MapgenFractalParams::MapgenFractalParams():
 	np_seabed       (-14, 9,   v3f(600, 600, 600), 41900, 5, 0.6, 2.0),
 	np_filler_depth (0,   1.2, v3f(150, 150, 150), 261,   3, 0.7, 2.0),
 	np_cave1        (0,   12,  v3f(61,  61,  61),  52534, 3, 0.5, 2.0),
-	np_cave2        (0,   12,  v3f(67,  67,  67),  10325, 3, 0.5, 2.0)
+	np_cave2        (0,   12,  v3f(67,  67,  67),  10325, 3, 0.5, 2.0),
+	np_dungeons     (0.9, 0.5, v3f(500, 500, 500), 0,     2, 0.8, 2.0)
 {
 }
 
@@ -116,6 +118,7 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
 	settings->getNoiseParams("mgfractal_np_cave1",        np_cave1);
 	settings->getNoiseParams("mgfractal_np_cave2",        np_cave2);
+	settings->getNoiseParams("mgfractal_np_dungeons",     np_dungeons);
 }
 
 
@@ -141,6 +144,7 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgfractal_np_cave1",        np_cave1);
 	settings->setNoiseParams("mgfractal_np_cave2",        np_cave2);
+	settings->setNoiseParams("mgfractal_np_dungeons",     np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -51,6 +51,7 @@ struct MapgenFractalParams : public MapgenParams
 	NoiseParams np_filler_depth;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
+	NoiseParams np_dungeons;
 
 	MapgenFractalParams();
 	~MapgenFractalParams() = default;

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -67,9 +67,10 @@ MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	// 1-up 1-down overgeneration
 	noise_ground = new Noise(&params->np_ground, seed, csize.X, csize.Y + 2, csize.Z);
 	// 1 down overgeneration
-	MapgenBasic::np_cave1  = params->np_cave1;
-	MapgenBasic::np_cave2  = params->np_cave2;
-	MapgenBasic::np_cavern = params->np_cavern;
+	MapgenBasic::np_cave1    = params->np_cave1;
+	MapgenBasic::np_cave2    = params->np_cave2;
+	MapgenBasic::np_cavern   = params->np_cavern;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 }
 
 
@@ -83,13 +84,14 @@ MapgenV5::~MapgenV5()
 
 
 MapgenV5Params::MapgenV5Params():
-	np_filler_depth (0, 1,  v3f(150, 150, 150), 261,    4, 0.7,  2.0),
-	np_factor       (0, 1,  v3f(250, 250, 250), 920381, 3, 0.45, 2.0),
-	np_height       (0, 10, v3f(250, 250, 250), 84174,  4, 0.5,  2.0),
-	np_ground       (0, 40, v3f(80,  80,  80),  983240, 4, 0.55, 2.0, NOISE_FLAG_EASED),
-	np_cave1        (0, 12, v3f(61,  61,  61),  52534,  3, 0.5,  2.0),
-	np_cave2        (0, 12, v3f(67,  67,  67),  10325,  3, 0.5,  2.0),
-	np_cavern       (0, 1,  v3f(384, 128, 384), 723,    5, 0.63, 2.0)
+	np_filler_depth (0,   1,   v3f(150, 150, 150), 261,    4, 0.7,  2.0),
+	np_factor       (0,   1,   v3f(250, 250, 250), 920381, 3, 0.45, 2.0),
+	np_height       (0,   10,  v3f(250, 250, 250), 84174,  4, 0.5,  2.0),
+	np_ground       (0,   40,  v3f(80,  80,  80),  983240, 4, 0.55, 2.0, NOISE_FLAG_EASED),
+	np_cave1        (0,   12,  v3f(61,  61,  61),  52534,  3, 0.5,  2.0),
+	np_cave2        (0,   12,  v3f(67,  67,  67),  10325,  3, 0.5,  2.0),
+	np_cavern       (0,   1,   v3f(384, 128, 384), 723,    5, 0.63, 2.0),
+	np_dungeons     (0.9, 0.5, v3f(500, 500, 500), 0,      2, 0.8,  2.0)
 {
 }
 
@@ -113,6 +115,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getNoiseParams("mgv5_np_cave1",        np_cave1);
 	settings->getNoiseParams("mgv5_np_cave2",        np_cave2);
 	settings->getNoiseParams("mgv5_np_cavern",       np_cavern);
+	settings->getNoiseParams("mgv5_np_dungeons",     np_dungeons);
 }
 
 
@@ -135,6 +138,7 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgv5_np_cave1",        np_cave1);
 	settings->setNoiseParams("mgv5_np_cave2",        np_cave2);
 	settings->setNoiseParams("mgv5_np_cavern",       np_cavern);
+	settings->setNoiseParams("mgv5_np_dungeons",     np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -70,7 +70,7 @@ MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
 	MapgenBasic::np_cavern   = params->np_cavern;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
 

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -48,6 +48,7 @@ struct MapgenV5Params : public MapgenParams
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_cavern;
+	NoiseParams np_dungeons;
 
 	MapgenV5Params();
 	~MapgenV5Params() = default;

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -108,6 +108,8 @@ public:
 	NoiseParams *np_trees;
 	NoiseParams *np_apple_trees;
 
+	NoiseParams np_dungeons;
+
 	float freq_desert;
 	float freq_beach;
 	s16 dungeon_ymin;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -116,7 +116,7 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
 	MapgenBasic::np_cavern   = params->np_cavern;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
 

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -113,9 +113,10 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 			new Noise(&params->np_mountain, seed, csize.X, csize.Y + 2, csize.Z);
 
 	// 3D noise, 1 down overgeneration
-	MapgenBasic::np_cave1  = params->np_cave1;
-	MapgenBasic::np_cave2  = params->np_cave2;
-	MapgenBasic::np_cavern = params->np_cavern;
+	MapgenBasic::np_cave1    = params->np_cave1;
+	MapgenBasic::np_cave2    = params->np_cave2;
+	MapgenBasic::np_cavern   = params->np_cavern;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 }
 
 
@@ -159,7 +160,8 @@ MapgenV7Params::MapgenV7Params():
 	np_ridge             (0.0,   1.0,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0),
 	np_cavern            (0.0,   1.0,   v3f(384,  128,  384),  723,   5, 0.63, 2.0),
 	np_cave1             (0.0,   12.0,  v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
-	np_cave2             (0.0,   12.0,  v3f(67,   67,   67),   10325, 3, 0.5,  2.0)
+	np_cave2             (0.0,   12.0,  v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
+	np_dungeons          (0.9,   0.5,   v3f(500,  500,  500),  0,     2, 0.8,  2.0)
 {
 }
 
@@ -196,6 +198,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getNoiseParams("mgv7_np_cavern",            np_cavern);
 	settings->getNoiseParams("mgv7_np_cave1",             np_cave1);
 	settings->getNoiseParams("mgv7_np_cave2",             np_cave2);
+	settings->getNoiseParams("mgv7_np_dungeons",          np_dungeons);
 }
 
 
@@ -231,6 +234,7 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgv7_np_cavern",            np_cavern);
 	settings->setNoiseParams("mgv7_np_cave1",             np_cave1);
 	settings->setNoiseParams("mgv7_np_cave2",             np_cave2);
+	settings->setNoiseParams("mgv7_np_dungeons",          np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -66,6 +66,7 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_cavern;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
+	NoiseParams np_dungeons;
 
 	MapgenV7Params();
 	~MapgenV7Params() = default;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -87,9 +87,10 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	noise_inter_valley_fill = new Noise(&params->np_inter_valley_fill,
 		seed, csize.X, csize.Y + 2, csize.Z);
 	// 1-down overgeneraion
-	MapgenBasic::np_cave1   = params->np_cave1;
-	MapgenBasic::np_cave2   = params->np_cave2;
-	MapgenBasic::np_cavern  = params->np_cavern;
+	MapgenBasic::np_cave1    = params->np_cave1;
+	MapgenBasic::np_cave2    = params->np_cave2;
+	MapgenBasic::np_cavern   = params->np_cavern;
+	MapgenBasic::np_dungeons = &params->np_dungeons;
 }
 
 
@@ -115,7 +116,8 @@ MapgenValleysParams::MapgenValleysParams():
 	np_valley_profile     (0.6,   0.50, v3f(512,  512,  512),  777,   1, 1.0,  2.0),
 	np_cave1              (0.0,   12.0, v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
 	np_cave2              (0.0,   12.0, v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
-	np_cavern             (0.0,   1.0,  v3f(768,  256,  768),  59033, 6, 0.63, 2.0)
+	np_cavern             (0.0,   1.0,  v3f(768,  256,  768),  59033, 6, 0.63, 2.0),
+	np_dungeons           (0.9,   0.5,  v3f(500,  500,  500),  0,     2, 0.8,  2.0)
 {
 }
 
@@ -146,6 +148,7 @@ void MapgenValleysParams::readParams(const Settings *settings)
 	settings->getNoiseParams("mgvalleys_np_cave1",              np_cave1);
 	settings->getNoiseParams("mgvalleys_np_cave2",              np_cave2);
 	settings->getNoiseParams("mgvalleys_np_cavern",             np_cavern);
+	settings->getNoiseParams("mgvalleys_np_dungeons",           np_dungeons);
 }
 
 
@@ -175,6 +178,7 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgvalleys_np_cave1",              np_cave1);
 	settings->setNoiseParams("mgvalleys_np_cave2",              np_cave2);
 	settings->setNoiseParams("mgvalleys_np_cavern",             np_cavern);
+	settings->setNoiseParams("mgvalleys_np_dungeons",           np_dungeons);
 }
 
 

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -90,7 +90,7 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
 	MapgenBasic::np_cavern   = params->np_cavern;
-	MapgenBasic::np_dungeons = &params->np_dungeons;
+	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
 

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -67,6 +67,7 @@ struct MapgenValleysParams : public MapgenParams {
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
 	NoiseParams np_cavern;
+	NoiseParams np_dungeons;
 
 	MapgenValleysParams();
 	~MapgenValleysParams() = default;


### PR DESCRIPTION
Add user-settable noise parameters for dungeon density to each mapgen,
except V6 which hardcodes this noise parameter.

Move the calculation of number of dungeons generated in a mapchunk out
of dungeongen.cpp and into mapgen code, to allow mapgens to generate
any desired number of dungeons in a mapchunk, instead of being forced
to have number of dungeons determined by a density noise.

This is more flexible and allows mapgens to use dungeon generation to
create custom structures, such as occasional mega-dungeons.
////////////////////////
Match dungeon noise member type to cave1/cave2 
///////////////////////

Closes #5447 
This PR isn't as big as it first looks, lots of repetition and trivial changes in the diff.
It's well tested so you don't have to.
Although labelled a feature, this is an important step in de-hardcoding some aspects of mapgen.

This is also a little more efficient:

Previously in mapgen.cpp: Biome at mapchunk midpoint is calculated and used to decide dungeon materials, the dungeonparams `dp` are set, and dungeon generation is triggered. But then, most of the time nothing is generated in the mapchunk due to the dungeon distribution noise which is checked later in dungeon generation.

Now, the dungeon distribution noise is checked as the first step in mapgen.cpp, if there is no dungeon in the mapchunk much of the process mentioned above isn't executed.