### PR TITLE
Android: Clear chat open flag on cancel or completion

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1880,6 +1880,9 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::INVENTORY)) {
 		openInventory();
 	} else if (input->cancelPressed()) {
+#ifdef __ANDROID__
+		m_android_chat_open = false;
+#endif
 		if (!gui_chat_console->isOpenInhibited()) {
 			showPauseMenu();
 		}
@@ -2079,6 +2082,7 @@ void Game::handleAndroidChatInput()
 	if (m_android_chat_open && porting::getInputDialogState() == 0) {
 		std::string text = porting::getInputDialogValue();
 		client->typeChatMessage(utf8_to_wide(text));
+		m_android_chat_open = false;
 	}
 }
 #endif


### PR DESCRIPTION
Fixes:  #8476

This will ensure that only legitimate chat input gets handled as such. Previously this flag was set but then never unset.