### PR TITLE
Allow multiple cave liquids in a biome definition

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6517,6 +6517,7 @@ Used by `minetest.register_biome`.
         -- chosen node from the list.
         -- If this field is left out or 'nil', cave liquids fall back to
         -- classic behaviour of lava and water distributed using 3D noise.
+        -- For no cave liquid, specify "air".
 
         node_dungeon = "default:cobble",
         -- Node used for primary dungeon structure.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6510,10 +6510,13 @@ Used by `minetest.register_biome`.
         depth_riverbed = 2,
         -- Node placed under river water and thickness of this layer
 
-        node_cave_liquid = "default:water_source",
-        -- Nodes placed as a blob of liquid in 50% of large caves.
-        -- If absent, cave liquids fall back to classic behaviour of lava or
-        -- water distributed according to a hardcoded 3D noise.
+        node_cave_liquid = "default:lava_source",
+        node_cave_liquid = {"default:water_source", "default:lava_source"},
+        -- Nodes placed inside 50% of the medium size caves.
+        -- Multiple nodes can be specified, each cave will use a randomly
+        -- chosen node from the list.
+        -- If this field is left out or 'nil', cave liquids fall back to
+        -- classic behaviour of lava and water distributed using 3D noise.
 
         node_dungeon = "default:cobble",
         -- Node used for primary dungeon structure.

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -321,9 +321,23 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 
 	this->ystride = nmax.X - nmin.X + 1;
 
+	flooded = ps->range(1, 2) == 2;
+
+	// If flooded:
+	// Get biome at mapchunk midpoint. If cave liquid defined for biome, use it.
+	use_biome_liquid = false;
+	if (flooded && bmgn) {
+		v3s16 midp = node_min + (node_max - node_min) / v3s16(2, 2, 2);
+		Biome *biome = (Biome *)bmgn->getBiomeAtPoint(midp);
+		if (biome->c_cave_liquid[0] != CONTENT_IGNORE) {
+			use_biome_liquid = true;
+			c_biome_liquid =
+				biome->c_cave_liquid[ps->range(0, biome->c_cave_liquid.size() - 1)];
+		}
+	}
+
 	// Set initial parameters from randomness
 	int dswitchint = ps->range(1, 14);
-	flooded = ps->range(1, 2) == 2;
 
 	if (large_cave) {
 		part_max_length_rs = ps->range(2, 4);
@@ -502,31 +516,19 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 	fp.Z += 0.1f * ps->range(-10, 10);
 	v3s16 cp(fp.X, fp.Y, fp.Z);
 
-	// Get biome at 'cp + of', the absolute centre point of this route
-	v3s16 cpabs = cp + of;
+	// Choose cave liquid
 	MapNode liquidnode = CONTENT_IGNORE;
 
-	if (bmgn) {
-		Biome *biome = nullptr;
-		if (cpabs.X < node_min.X || cpabs.X > node_max.X ||
-				cpabs.Z < node_min.Z || cpabs.Z > node_max.Z)
-			// Point is outside heat and humidity noise maps so use point noise
-			// calculations.
-			biome = (Biome *)bmgn->calcBiomeAtPoint(cpabs);
-		else
-			// Point is inside heat and humidity noise maps so use them
-			biome = (Biome *)bmgn->getBiomeAtPoint(cpabs);
-
-		if (biome->c_cave_liquid != CONTENT_IGNORE)
-			liquidnode = biome->c_cave_liquid;
-	}
-
-	if (liquidnode == CONTENT_IGNORE) {
-		// Fallback to classic behaviour using point 'startp'
-		float nval = NoisePerlin3D(np_caveliquids, startp.X,
-			startp.Y, startp.Z, seed);
-		liquidnode = (nval < 0.40f && node_max.Y < lava_depth) ?
-			lavanode : waternode;
+	if (flooded) {
+		if (use_biome_liquid) {
+			liquidnode = c_biome_liquid;
+		} else {
+			// If cave liquid not defined by biome, fallback to old hardcoded behaviour
+			float nval = NoisePerlin3D(np_caveliquids, startp.X,
+				startp.Y, startp.Z, seed);
+			liquidnode = (nval < 0.40f && node_max.Y < lava_depth) ?
+				lavanode : waternode;
+		}
 	}
 
 	s16 d0 = -rs / 2;

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -325,6 +325,7 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 
 	// If flooded:
 	// Get biome at mapchunk midpoint. If cave liquid defined for biome, use it.
+	// If defined liquid is "air", disable 'flooded' to avoid placing "air".
 	use_biome_liquid = false;
 	if (flooded && bmgn) {
 		v3s16 midp = node_min + (node_max - node_min) / v3s16(2, 2, 2);
@@ -333,6 +334,8 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 			use_biome_liquid = true;
 			c_biome_liquid =
 				biome->c_cave_liquid[ps->range(0, biome->c_cave_liquid.size() - 1)];
+			if (c_biome_liquid == CONTENT_AIR)
+				flooded = false;
 		}
 	}
 

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -133,6 +133,7 @@ public:
 	bool large_cave;
 	bool large_cave_is_flat;
 	bool flooded;
+	bool use_biome_liquid;
 
 	v3s16 node_min;
 	v3s16 node_max;
@@ -150,6 +151,7 @@ public:
 
 	content_t c_water_source;
 	content_t c_lava_source;
+	content_t c_biome_liquid;
 
 	// ndef is a mandatory parameter.
 	// If gennotify is NULL, generation events are not logged.

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -63,6 +63,7 @@ BiomeManager::BiomeManager(Server *server) :
 	b->m_nodenames.emplace_back("mapgen_stone");
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
+	b->m_nnlistsizes.push_back(1);
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
 	b->m_nodenames.emplace_back("ignore");
@@ -330,7 +331,7 @@ void Biome::resolveNodeNames()
 	getIdFromNrBacklog(&c_river_water,   "mapgen_river_water_source", CONTENT_AIR,    false);
 	getIdFromNrBacklog(&c_riverbed,      "mapgen_stone",              CONTENT_AIR,    false);
 	getIdFromNrBacklog(&c_dust,          "ignore",                    CONTENT_IGNORE, false);
-	getIdFromNrBacklog(&c_cave_liquid,   "ignore",                    CONTENT_IGNORE, false);
+	getIdsFromNrBacklog(&c_cave_liquid);
 	getIdFromNrBacklog(&c_dungeon,       "ignore",                    CONTENT_IGNORE, false);
 	getIdFromNrBacklog(&c_dungeon_alt,   "ignore",                    CONTENT_IGNORE, false);
 	getIdFromNrBacklog(&c_dungeon_stair, "ignore",                    CONTENT_IGNORE, false);

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -52,7 +52,7 @@ public:
 	content_t c_river_water;
 	content_t c_riverbed;
 	content_t c_dust;
-	content_t c_cave_liquid;
+	std::vector<content_t> c_cave_liquid;
 	content_t c_dungeon;
 	content_t c_dungeon_alt;
 	content_t c_dungeon_stair;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -405,7 +405,16 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	nn.push_back(getstringfield_default(L, index, "node_river_water",   ""));
 	nn.push_back(getstringfield_default(L, index, "node_riverbed",      ""));
 	nn.push_back(getstringfield_default(L, index, "node_dust",          ""));
-	nn.push_back(getstringfield_default(L, index, "node_cave_liquid",   ""));
+
+	size_t nnames = getstringlistfield(L, index, "node_cave_liquid", &nn);
+	// If no cave liquids defined, set list to "ignore" to trigger old hardcoded
+	// cave liquid behaviour.
+	if (nnames == 0) {
+		nn.push_back("ignore");
+		nnames = 1;
+	}
+	b->m_nnlistsizes.push_back(nnames);
+
 	nn.push_back(getstringfield_default(L, index, "node_dungeon",       ""));
 	nn.push_back(getstringfield_default(L, index, "node_dungeon_alt",   ""));
 	nn.push_back(getstringfield_default(L, index, "node_dungeon_stair", ""));


### PR DESCRIPTION
Although labelled a feature, this is an important step in de-hardcoding some aspects of mapgen.

We already have a biome-defined cave liquids feature, however only 1 cave liquid per biome can be defined, which cannot reproduce the current mix of water and lava caves.

This PR allows games to replace the hardcoded engine distribution of cave liquids with biome-defined cave liquids, while preserving the ability to have multiple cave liquids in a biome (such as water and lava).
Relative chances can be altered by repeated entries in the list.

If a biome defined cave liquid (or multiple) is defined, each entire cave uses that node (or a randomly chosen node from the list). Previously, biome-defined cave liquid was calculated per cave segment.

The change from per-segment to per-cave avoids every cave segment randomly choosing a node from the list, resulting in too-rapidly changing cave liquids within one cave. For example if the 2 nodes were water and lava, switching back and forth every few nodes would result in almost completely obsidian, no more lava lakes.

So the code for biome-defined liquid has moved from 'carveRoute()' (which generates each cave segment) to 'makeCave()' (which applies to the entire cave).

If no biome defined cave liquids are defined, the behaviour falls back to the old hardcoded behaviour.

There is a small performance benefit as biome is no longer being calculated for every cave segment.

This arose from discussion of MTG cave liquids:
https://github.com/minetest/minetest_game/issues/2339#issuecomment-484290517
https://github.com/minetest/minetest_game/pull/2358

/////////////////////

Commit 2:
Don't place nodes if cave liquid is defined as 'air'

Avoids pointlessly placing huge numbers of "air" nodes when a cave liquid is defined to be air, for when no cave liquid is wanted.