### PR TITLE
Remove unnecessary CSM warning

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -121,15 +121,10 @@ Client::Client(
 
 void Client::loadMods()
 {
-	// Don't load mods twice
-	if (m_mods_loaded) {
-		return;
-	}
-
+	// Don't load mods twice.
 	// If client scripting is disabled by the client, don't load builtin or
 	// client-provided mods.
-	if (!m_modding_enabled) {
-		warningstream << "Client side scripting is disabled by client." << std::endl;
+	if (m_mods_loaded || !m_modding_enabled) {
 		return;
 	}
 


### PR DESCRIPTION
![stupid](https://user-images.githubusercontent.com/3686677/56549650-45539880-657b-11e9-9654-821d6b28fe06.png)

This warning is unnecessary and irritating, it shows up in distracting yellow in the terminal every time you use MT, only to inform that a setting is set to the default value, we don't do this for any other setting.

However, the 'Client-provided mod loading is disabled by server.' warning seems to make more sense to display, to clients connected to a server, so i have not touched that.

I have simplified the code as it is now possible to combine the 'return' with the one above.