### PR TITLE
[NO SQUASH PLS] PlayerSAO::setHP - Don't call on_hpchange callbacks if HP hasn't changed

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3718,6 +3718,7 @@ Call these functions only at load time!
     * Called after a new player has been created
 * `minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage))`
     * Called when a player is punched
+    * Note: This callback is invoked even if the punched player is dead.
     * `player`: ObjectRef - Player that was punched
     * `hitter`: ObjectRef - Player that hit
     * `time_from_last_punch`: Meant for disallowing spamming of clicks

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1336,11 +1336,13 @@ void PlayerSAO::setHP(s32 hp, const PlayerHPChangeReason &reason)
 
 	hp = rangelim(hp, 0, m_prop.hp_max);
 
-	s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - oldhp, reason);
-	if (hp_change == 0)
-		return;
+	if (oldhp != hp) {
+		s32 hp_change = m_env->getScriptIface()->on_player_hpchange(this, hp - oldhp, reason);
+		if (hp_change == 0)
+			return;
 
-	hp = rangelim(oldhp + hp_change, 0, m_prop.hp_max);
+		hp = rangelim(oldhp + hp_change, 0, m_prop.hp_max);
+	}
 
 	if (hp < oldhp && !g_settings->getBool("enable_damage"))
 		return;


### PR DESCRIPTION
Also document the fact that `on_punchplayer` is invoked, even if the punched player is dead.

See #8462, and https://github.com/minetest/minetest/pull/8462#issuecomment-482242096