### PR TITLE
Fix incorrect pointer placement repo-wide

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -68,7 +68,7 @@ u32 ChatBuffer::getLineCount() const
 	return m_unformatted.size();
 }
 
-const ChatLine& ChatBuffer::getLine(u32 index) const
+const ChatLine &ChatBuffer::getLine(u32 index) const
 {
 	assert(index < getLineCount());	// pre-condition
 	return m_unformatted[index];
@@ -189,7 +189,7 @@ void ChatBuffer::reformat(u32 cols, u32 rows)
 	}
 }
 
-const ChatFormattedLine& ChatBuffer::getFormattedLine(u32 row) const
+const ChatFormattedLine &ChatBuffer::getFormattedLine(u32 row) const
 {
 	s32 index = m_scroll + (s32) row;
 	if (index >= 0 && index < (s32) m_formatted.size())
@@ -225,7 +225,7 @@ void ChatBuffer::scrollTop()
 	m_scroll = getTopScrollPos();
 }
 
-u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
+u32 ChatBuffer::formatChatLine(const ChatLine &line, u32 cols,
 		std::vector<ChatFormattedLine>& destination) const
 {
 	u32 num_added = 0;
@@ -276,7 +276,7 @@ u32 ChatBuffer::formatChatLine(const ChatLine& line, u32 cols,
 		// Layout fragments into lines
 		while (!next_frags.empty())
 		{
-			ChatFormattedFragment& frag = next_frags[0];
+			ChatFormattedFragment &frag = next_frags[0];
 			if (frag.text.size() <= cols - out_column)
 			{
 				// Fragment fits into current line
@@ -696,12 +696,12 @@ void ChatBackend::addUnparsedMessage(std::wstring message)
 	addMessage(L"", message);
 }
 
-ChatBuffer& ChatBackend::getConsoleBuffer()
+ChatBuffer &ChatBackend::getConsoleBuffer()
 {
 	return m_console_buffer;
 }
 
-ChatBuffer& ChatBackend::getRecentBuffer()
+ChatBuffer &ChatBackend::getRecentBuffer()
 {
 	return m_recent_buffer;
 }
@@ -710,7 +710,7 @@ EnrichedString ChatBackend::getRecentChat() const
 {
 	EnrichedString result;
 	for (u32 i = 0; i < m_recent_buffer.getLineCount(); ++i) {
-		const ChatLine& line = m_recent_buffer.getLine(i);
+		const ChatLine &line = m_recent_buffer.getLine(i);
 		if (i != 0)
 			result += L"\n";
 		if (!line.name.empty()) {
@@ -723,7 +723,7 @@ EnrichedString ChatBackend::getRecentChat() const
 	return result;
 }
 
-ChatPrompt& ChatBackend::getPrompt()
+ChatPrompt &ChatBackend::getPrompt()
 {
 	return m_prompt;
 }

--- a/src/chat.h
+++ b/src/chat.h
@@ -85,7 +85,7 @@ public:
 	// Get number of lines currently in buffer.
 	u32 getLineCount() const;
 	// Get reference to i-th chat line.
-	const ChatLine& getLine(u32 index) const;
+	const ChatLine &getLine(u32 index) const;
 
 	// Increase each chat line's age by dtime.
 	void step(f32 dtime);
@@ -102,7 +102,7 @@ public:
 	void reformat(u32 cols, u32 rows);
 	// Get formatted line for a given row (0 is top of screen).
 	// Only valid after reformat has been called at least once
-	const ChatFormattedLine& getFormattedLine(u32 row) const;
+	const ChatFormattedLine &getFormattedLine(u32 row) const;
 	// Scrolling in formatted buffer (relative)
 	// positive rows == scroll up, negative rows == scroll down
 	void scroll(s32 rows);
@@ -116,7 +116,7 @@ public:
 	// Format a chat line for the given number of columns.
 	// Appends the formatted lines to the destination array and
 	// returns the number of formatted lines.
-	u32 formatChatLine(const ChatLine& line, u32 cols,
+	u32 formatChatLine(const ChatLine &line, u32 cols,
 			std::vector<ChatFormattedLine>& destination) const;
 
 	void resize(u32 scrollback);
@@ -261,13 +261,13 @@ public:
 	void addUnparsedMessage(std::wstring line);
 
 	// Get the console buffer
-	ChatBuffer& getConsoleBuffer();
+	ChatBuffer &getConsoleBuffer();
 	// Get the recent messages buffer
-	ChatBuffer& getRecentBuffer();
+	ChatBuffer &getRecentBuffer();
 	// Concatenate all recent messages
 	EnrichedString getRecentChat() const;
 	// Get the console prompt
-	ChatPrompt& getPrompt();
+	ChatPrompt &getPrompt();
 
 	// Reformat all buffers
 	void reformat(u32 cols, u32 rows);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -279,7 +279,7 @@ void Camera::addArmInertia(f32 player_yaw)
 	}
 }
 
-void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_reload_ratio)
+void Camera::update(LocalPlayer *player, f32 frametime, f32 busytime, f32 tool_reload_ratio)
 {
 	// Get player position
 	// Smooth the movement when walking up stairs
@@ -414,7 +414,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 			MapNode n = m_client->getEnv().getClientMap()
 				.getNodeNoEx(floatToInt(my_cp, BS));
 
-			const ContentFeatures& features = nodemgr->get(n);
+			const ContentFeatures &features = nodemgr->get(n);
 			if (features.walkable) {
 				my_cp.X += m_camera_direction.X*-1*-BS/2;
 				my_cp.Z += m_camera_direction.Z*-1*-BS/2;
@@ -576,13 +576,13 @@ void Camera::wield(const ItemStack &item)
 	}
 }
 
-void Camera::drawWieldedTool(irr::core::matrix4* translation)
+void Camera::drawWieldedTool(irr::core::matrix4 *translation)
 {
 	// Clear Z buffer so that the wielded tool stay in front of world geometry
 	m_wieldmgr->getVideoDriver()->clearZBuffer();
 
 	// Draw the wielded node (in a separate scene manager)
-	scene::ICameraSceneNode* cam = m_wieldmgr->getActiveCamera();
+	scene::ICameraSceneNode *cam = m_wieldmgr->getActiveCamera();
 	cam->setAspectRatio(m_cameranode->getAspectRatio());
 	cam->setFOV(72.0*M_PI/180.0);
 	cam->setNearValue(10);

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -63,7 +63,7 @@ public:
 
 	// Get camera scene node.
 	// It has the eye transformation, pitch and view bobbing applied.
-	inline scene::ICameraSceneNode* getCameraNode() const
+	inline scene::ICameraSceneNode *getCameraNode() const
 	{
 		return m_cameranode;
 	}
@@ -114,7 +114,7 @@ public:
 
 	// Update the camera from the local player's position.
 	// busytime is used to adjust the viewing range.
-	void update(LocalPlayer* player, f32 frametime, f32 busytime,
+	void update(LocalPlayer *player, f32 frametime, f32 busytime,
 			f32 tool_reload_ratio);
 
 	// Update render distance
@@ -130,7 +130,7 @@ public:
 	// Draw the wielded tool.
 	// This has to happen *after* the main scene is drawn.
 	// Warning: This clears the Z buffer.
-	void drawWieldedTool(irr::core::matrix4* translation=NULL);
+	void drawWieldedTool(irr::core::matrix4 *translation = NULL);
 
 	// Toggle the current camera mode
 	void toggleCameraMode() {
@@ -176,7 +176,7 @@ private:
 	WieldMeshSceneNode *m_wieldnode = nullptr;
 
 	// draw control
-	MapDrawControl& m_draw_control;
+	MapDrawControl &m_draw_control;
 
 	Client *m_client;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -58,7 +58,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "chatmessage.h"
 #include "translation.h"
 
-extern gui::IGUIEnvironment* guienv;
+extern gui::IGUIEnvironment *guienv;
 
 /*
 	Client
@@ -236,7 +236,7 @@ const std::vector<ModSpec>& Client::getMods() const
 	return client_modspec_temp;
 }
 
-const ModSpec* Client::getModSpec(const std::string &modname) const
+const ModSpec *Client::getModSpec(const std::string &modname) const
 {
 	return NULL;
 }
@@ -811,9 +811,9 @@ void Client::Receive()
 	ProcessData(&pkt);
 }
 
-inline void Client::handleCommand(NetworkPacket* pkt)
+inline void Client::handleCommand(NetworkPacket *pkt)
 {
-	const ToClientCommandHandler& opHandle = toClientCommandTable[pkt->getCommand()];
+	const ToClientCommandHandler &opHandle = toClientCommandTable[pkt->getCommand()];
 	(this->*opHandle.handler)(pkt);
 }
 
@@ -870,7 +870,7 @@ void Client::ProcessData(NetworkPacket *pkt)
 	handleCommand(pkt);
 }
 
-void Client::Send(NetworkPacket* pkt)
+void Client::Send(NetworkPacket *pkt)
 {
 	m_con->Send(PEER_ID_SERVER,
 		serverCommandFactoryTable[pkt->getCommand()].channel,
@@ -908,7 +908,7 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	*pkt << fov << wanted_range;
 }
 
-void Client::interact(u8 action, const PointedThing& pointed)
+void Client::interact(u8 action, const PointedThing &pointed)
 {
 	if(m_state != LC_Ready) {
 		errorstream << "Client::interact() "
@@ -1289,7 +1289,7 @@ void Client::sendPlayerItem(u16 item)
 
 void Client::removeNode(v3s16 p)
 {
-	std::map<v3s16, MapBlock*> modified_blocks;
+	std::map<v3s16, MapBlock *> modified_blocks;
 
 	try {
 		m_env.getMap().removeNodeAndUpdate(p, modified_blocks);
@@ -1370,7 +1370,7 @@ void Client::getLocalInventory(Inventory &dst)
 	dst = player->inventory;
 }
 
-Inventory* Client::getInventory(const InventoryLocation &loc)
+Inventory *Client::getInventory(const InventoryLocation &loc)
 {
 	switch(loc.type){
 	case InventoryLocation::UNDEFINED:
@@ -1622,13 +1622,13 @@ typedef struct TextureUpdateArgs {
 	gui::IGUIEnvironment *guienv;
 	u64 last_time_ms;
 	u16 last_percent;
-	const wchar_t* text_base;
+	const wchar_t *text_base;
 	ITextureSource *tsrc;
 } TextureUpdateArgs;
 
 void texture_update_progress(void *args, u32 progress, u32 max_progress)
 {
-		TextureUpdateArgs* targs = (TextureUpdateArgs*) args;
+		TextureUpdateArgs *targs = (TextureUpdateArgs*) args;
 		u16 cur_percent = ceil(progress / (double) max_progress * 100.);
 
 		// update the loading menu -- if neccessary
@@ -1657,7 +1657,7 @@ void Client::afterContentReceived()
 	assert(m_nodedef_received); // pre-condition
 	assert(mediaReceived()); // pre-condition
 
-	const wchar_t* text = wgettext("Loading textures...");
+	const wchar_t *text = wgettext("Loading textures...");
 
 	// Clear cached pre-scaled 2D GUI images, as this cache
 	// might have images with the same name but different
@@ -1730,7 +1730,7 @@ float Client::getCurRate()
 void Client::makeScreenshot()
 {
 	irr::video::IVideoDriver *driver = RenderingEngine::get_video_driver();
-	irr::video::IImage* const raw_image = driver->createScreenShot();
+	irr::video::IImage *const raw_image = driver->createScreenShot();
 
 	if (!raw_image)
 		return;
@@ -1765,7 +1765,7 @@ void Client::makeScreenshot()
 	if (serial == SCREENSHOT_MAX_SERIAL_TRIES) {
 		infostream << "Could not find suitable filename for screenshot" << std::endl;
 	} else {
-		irr::video::IImage* const image =
+		irr::video::IImage *const image =
 				driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
 
 		if (image) {
@@ -1804,24 +1804,24 @@ void Client::showMinimap(const bool show)
 
 // IGameDef interface
 // Under envlock
-IItemDefManager* Client::getItemDefManager()
+IItemDefManager *Client::getItemDefManager()
 {
 	return m_itemdef;
 }
-const NodeDefManager* Client::getNodeDefManager()
+const NodeDefManager *Client::getNodeDefManager()
 {
 	return m_nodedef;
 }
-ICraftDefManager* Client::getCraftDefManager()
+ICraftDefManager *Client::getCraftDefManager()
 {
 	return NULL;
 	//return m_craftdef;
 }
-ITextureSource* Client::getTextureSource()
+ITextureSource *Client::getTextureSource()
 {
 	return m_tsrc;
 }
-IShaderSource* Client::getShaderSource()
+IShaderSource *Client::getShaderSource()
 {
 	return m_shsrc;
 }
@@ -1834,21 +1834,21 @@ u16 Client::allocateUnknownNodeId(const std::string &name)
 
 	return CONTENT_IGNORE;
 }
-ISoundManager* Client::getSoundManager()
+ISoundManager *Client::getSoundManager()
 {
 	return m_sound;
 }
-MtEventManager* Client::getEventManager()
+MtEventManager *Client::getEventManager()
 {
 	return m_event;
 }
 
-ParticleManager* Client::getParticleManager()
+ParticleManager *Client::getParticleManager()
 {
 	return &m_particle_manager;
 }
 
-scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
+scene::IAnimatedMesh *Client::getMesh(const std::string &filename, bool cache)
 {
 	StringMap::const_iterator it = m_mesh_data.find(filename);
 	if (it == m_mesh_data.end()) {
@@ -1873,7 +1873,7 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
 	return mesh;
 }
 
-const std::string* Client::getModFile(const std::string &filename)
+const std::string *Client::getModFile(const std::string &filename)
 {
 	StringMap::const_iterator it = m_mod_files.find(filename);
 	if (it == m_mod_files.end()) {
@@ -1961,7 +1961,7 @@ bool Client::sendModChannelMessage(const std::string &channel, const std::string
 	return true;
 }
 
-ModChannel* Client::getModChannel(const std::string &channel)
+ModChannel *Client::getModChannel(const std::string &channel)
 {
 	return m_modchannel_mgr->getModChannel(channel);
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -174,54 +174,54 @@ public:
 	 * Command Handlers
 	 */
 
-	void handleCommand(NetworkPacket* pkt);
+	void handleCommand(NetworkPacket *pkt);
 
-	void handleCommand_Null(NetworkPacket* pkt) {};
-	void handleCommand_Deprecated(NetworkPacket* pkt);
-	void handleCommand_Hello(NetworkPacket* pkt);
-	void handleCommand_AuthAccept(NetworkPacket* pkt);
-	void handleCommand_AcceptSudoMode(NetworkPacket* pkt);
-	void handleCommand_DenySudoMode(NetworkPacket* pkt);
-	void handleCommand_AccessDenied(NetworkPacket* pkt);
-	void handleCommand_RemoveNode(NetworkPacket* pkt);
-	void handleCommand_AddNode(NetworkPacket* pkt);
+	void handleCommand_Null(NetworkPacket *pkt) {};
+	void handleCommand_Deprecated(NetworkPacket *pkt);
+	void handleCommand_Hello(NetworkPacket *pkt);
+	void handleCommand_AuthAccept(NetworkPacket *pkt);
+	void handleCommand_AcceptSudoMode(NetworkPacket *pkt);
+	void handleCommand_DenySudoMode(NetworkPacket *pkt);
+	void handleCommand_AccessDenied(NetworkPacket *pkt);
+	void handleCommand_RemoveNode(NetworkPacket *pkt);
+	void handleCommand_AddNode(NetworkPacket *pkt);
 	void handleCommand_NodemetaChanged(NetworkPacket *pkt);
-	void handleCommand_BlockData(NetworkPacket* pkt);
-	void handleCommand_Inventory(NetworkPacket* pkt);
-	void handleCommand_TimeOfDay(NetworkPacket* pkt);
+	void handleCommand_BlockData(NetworkPacket *pkt);
+	void handleCommand_Inventory(NetworkPacket *pkt);
+	void handleCommand_TimeOfDay(NetworkPacket *pkt);
 	void handleCommand_ChatMessage(NetworkPacket *pkt);
-	void handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt);
-	void handleCommand_ActiveObjectMessages(NetworkPacket* pkt);
-	void handleCommand_Movement(NetworkPacket* pkt);
-	void handleCommand_HP(NetworkPacket* pkt);
-	void handleCommand_Breath(NetworkPacket* pkt);
-	void handleCommand_MovePlayer(NetworkPacket* pkt);
-	void handleCommand_DeathScreen(NetworkPacket* pkt);
-	void handleCommand_AnnounceMedia(NetworkPacket* pkt);
-	void handleCommand_Media(NetworkPacket* pkt);
-	void handleCommand_NodeDef(NetworkPacket* pkt);
-	void handleCommand_ItemDef(NetworkPacket* pkt);
-	void handleCommand_PlaySound(NetworkPacket* pkt);
-	void handleCommand_StopSound(NetworkPacket* pkt);
+	void handleCommand_ActiveObjectRemoveAdd(NetworkPacket *pkt);
+	void handleCommand_ActiveObjectMessages(NetworkPacket *pkt);
+	void handleCommand_Movement(NetworkPacket *pkt);
+	void handleCommand_HP(NetworkPacket *pkt);
+	void handleCommand_Breath(NetworkPacket *pkt);
+	void handleCommand_MovePlayer(NetworkPacket *pkt);
+	void handleCommand_DeathScreen(NetworkPacket *pkt);
+	void handleCommand_AnnounceMedia(NetworkPacket *pkt);
+	void handleCommand_Media(NetworkPacket *pkt);
+	void handleCommand_NodeDef(NetworkPacket *pkt);
+	void handleCommand_ItemDef(NetworkPacket *pkt);
+	void handleCommand_PlaySound(NetworkPacket *pkt);
+	void handleCommand_StopSound(NetworkPacket *pkt);
 	void handleCommand_FadeSound(NetworkPacket *pkt);
-	void handleCommand_Privileges(NetworkPacket* pkt);
-	void handleCommand_InventoryFormSpec(NetworkPacket* pkt);
-	void handleCommand_DetachedInventory(NetworkPacket* pkt);
-	void handleCommand_ShowFormSpec(NetworkPacket* pkt);
-	void handleCommand_SpawnParticle(NetworkPacket* pkt);
-	void handleCommand_AddParticleSpawner(NetworkPacket* pkt);
-	void handleCommand_DeleteParticleSpawner(NetworkPacket* pkt);
-	void handleCommand_HudAdd(NetworkPacket* pkt);
-	void handleCommand_HudRemove(NetworkPacket* pkt);
-	void handleCommand_HudChange(NetworkPacket* pkt);
-	void handleCommand_HudSetFlags(NetworkPacket* pkt);
-	void handleCommand_HudSetParam(NetworkPacket* pkt);
-	void handleCommand_HudSetSky(NetworkPacket* pkt);
-	void handleCommand_CloudParams(NetworkPacket* pkt);
-	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
-	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
-	void handleCommand_EyeOffset(NetworkPacket* pkt);
-	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);
+	void handleCommand_Privileges(NetworkPacket *pkt);
+	void handleCommand_InventoryFormSpec(NetworkPacket *pkt);
+	void handleCommand_DetachedInventory(NetworkPacket *pkt);
+	void handleCommand_ShowFormSpec(NetworkPacket *pkt);
+	void handleCommand_SpawnParticle(NetworkPacket *pkt);
+	void handleCommand_AddParticleSpawner(NetworkPacket *pkt);
+	void handleCommand_DeleteParticleSpawner(NetworkPacket *pkt);
+	void handleCommand_HudAdd(NetworkPacket *pkt);
+	void handleCommand_HudRemove(NetworkPacket *pkt);
+	void handleCommand_HudChange(NetworkPacket *pkt);
+	void handleCommand_HudSetFlags(NetworkPacket *pkt);
+	void handleCommand_HudSetParam(NetworkPacket *pkt);
+	void handleCommand_HudSetSky(NetworkPacket *pkt);
+	void handleCommand_CloudParams(NetworkPacket *pkt);
+	void handleCommand_OverrideDayNightRatio(NetworkPacket *pkt);
+	void handleCommand_LocalPlayerAnimations(NetworkPacket *pkt);
+	void handleCommand_EyeOffset(NetworkPacket *pkt);
+	void handleCommand_UpdatePlayerList(NetworkPacket *pkt);
 	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
 	void handleCommand_ModChannelSignal(NetworkPacket *pkt);
 	void handleCommand_SrpBytesSandB(NetworkPacket *pkt);
@@ -230,9 +230,9 @@ public:
 
 	void ProcessData(NetworkPacket *pkt);
 
-	void Send(NetworkPacket* pkt);
+	void Send(NetworkPacket *pkt);
 
-	void interact(u8 action, const PointedThing& pointed);
+	void interact(u8 action, const PointedThing &pointed);
 
 	void sendNodemetaFields(v3s16 p, const std::string &formname,
 		const StringMap &fields);
@@ -247,14 +247,14 @@ public:
 	void sendRespawn();
 	void sendReady();
 
-	ClientEnvironment& getEnv() { return m_env; }
+	ClientEnvironment &getEnv() { return m_env; }
 	ITextureSource *tsrc() { return getTextureSource(); }
 	ISoundManager *sound() { return getSoundManager(); }
 	static const std::string &getBuiltinLuaPath();
 	static const std::string &getClientModsLuaPath();
 
 	const std::vector<ModSpec> &getMods() const override;
-	const ModSpec* getModSpec(const std::string &modname) const override;
+	const ModSpec *getModSpec(const std::string &modname) const override;
 
 	// Causes urgent mesh updates (unlike Map::add/removeNodeWithEvent)
 	void removeNode(v3s16 p);
@@ -282,7 +282,7 @@ public:
 	void getLocalInventory(Inventory &dst);
 
 	/* InventoryManager interface */
-	Inventory* getInventory(const InventoryLocation &loc) override;
+	Inventory *getInventory(const InventoryLocation &loc) override;
 	void inventoryAction(InventoryAction *a) override;
 
 	const std::list<std::string> &getConnectedPlayerNames()
@@ -305,7 +305,7 @@ public:
 	{ return m_privileges; }
 
 	bool getChatMessage(std::wstring &message);
-	void typeChatMessage(const std::wstring& message);
+	void typeChatMessage(const std::wstring &message);
 
 	u64 getMapSeed(){ return m_map_seed; }
 
@@ -357,27 +357,27 @@ public:
 	float getRTT();
 	float getCurRate();
 
-	Minimap* getMinimap() { return m_minimap; }
-	void setCamera(Camera* camera) { m_camera = camera; }
+	Minimap *getMinimap() { return m_minimap; }
+	void setCamera(Camera *camera) { m_camera = camera; }
 
-	Camera* getCamera () { return m_camera; }
+	Camera *getCamera () { return m_camera; }
 
 	bool shouldShowMinimap() const;
 
 	// IGameDef interface
-	IItemDefManager* getItemDefManager() override;
-	const NodeDefManager* getNodeDefManager() override;
-	ICraftDefManager* getCraftDefManager() override;
-	ITextureSource* getTextureSource();
-	virtual IShaderSource* getShaderSource();
+	IItemDefManager *getItemDefManager() override;
+	const NodeDefManager *getNodeDefManager() override;
+	ICraftDefManager *getCraftDefManager() override;
+	ITextureSource *getTextureSource();
+	virtual IShaderSource *getShaderSource();
 	u16 allocateUnknownNodeId(const std::string &name) override;
-	virtual ISoundManager* getSoundManager();
-	MtEventManager* getEventManager();
-	virtual ParticleManager* getParticleManager();
+	virtual ISoundManager *getSoundManager();
+	MtEventManager *getEventManager();
+	virtual ParticleManager *getParticleManager();
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
-	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
-	const std::string* getModFile(const std::string &filename);
+	virtual scene::IAnimatedMesh *getMesh(const std::string &filename, bool cache = false);
+	const std::string *getModFile(const std::string &filename);
 
 	std::string getModStoragePath() const override;
 	bool registerModStorage(ModMetadata *meta) override;
@@ -573,7 +573,7 @@ private:
 
 	// Detached inventories
 	// key = name
-	std::unordered_map<std::string, Inventory*> m_detached_inventories;
+	std::unordered_map<std::string, Inventory *> m_detached_inventories;
 
 	// Storage for mesh data for creating multiple instances of the same mesh
 	StringMap m_mesh_data;

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -308,11 +308,11 @@ void ClientEnvironment::addSimpleObject(ClientSimpleObject *simple)
 	m_simple_objects.push_back(simple);
 }
 
-GenericCAO* ClientEnvironment::getGenericCAO(u16 id)
+GenericCAO *ClientEnvironment::getGenericCAO(u16 id)
 {
 	ClientActiveObject *obj = getActiveObject(id);
 	if (obj && obj->getType() == ACTIVEOBJECT_TYPE_GENERIC)
-		return (GenericCAO*) obj;
+		return (GenericCAO *) obj;
 
 	return NULL;
 }
@@ -366,7 +366,7 @@ u16 ClientEnvironment::addActiveObject(ClientActiveObject *object)
 void ClientEnvironment::addActiveObject(u16 id, u8 type,
 	const std::string &init_data)
 {
-	ClientActiveObject* obj =
+	ClientActiveObject *obj =
 		ClientActiveObject::create((ActiveObjectType) type, m_client, this);
 	if(obj == NULL)
 	{

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -59,7 +59,7 @@ struct ClientEnvEvent
 	};
 };
 
-typedef std::unordered_map<u16, ClientActiveObject*> ClientActiveObjectMap;
+typedef std::unordered_map<u16, ClientActiveObject *> ClientActiveObjectMap;
 class ClientEnvironment : public Environment
 {
 public:
@@ -87,8 +87,8 @@ public:
 		ActiveObjects
 	*/
 
-	GenericCAO* getGenericCAO(u16 id);
-	ClientActiveObject* getActiveObject(u16 id)
+	GenericCAO *getGenericCAO(u16 id);
+	ClientActiveObject *getActiveObject(u16 id)
 	{
 		return m_ao_manager.getActiveObject(id);
 	}
@@ -153,7 +153,7 @@ private:
 	Client *m_client;
 	ClientScripting *m_script = nullptr;
 	client::ActiveObjectMgr m_ao_manager;
-	std::vector<ClientSimpleObject*> m_simple_objects;
+	std::vector<ClientSimpleObject *> m_simple_objects;
 	std::queue<ClientEnvEvent> m_client_event_queue;
 	IntervalLimiter m_active_object_light_update_interval;
 	std::list<std::string> m_player_names;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -105,7 +105,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	}
 
 	RenderingEngine::get_instance()->setupTopLevelWindow(PROJECT_NAME_C);
-	
+
 	/*
 		This changes the minimum allowed number of vertices in a VBO.
 		Default is 500.
@@ -170,7 +170,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 		g_menuclouds = new Clouds(g_menucloudsmgr, -1, rand());
 	g_menuclouds->setHeight(100.0f);
 	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
-	scene::ICameraSceneNode* camera;
+	scene::ICameraSceneNode *camera;
 	camera = g_menucloudsmgr->addCameraSceneNode(NULL, v3f(0, 0, 0), v3f(0, 60, 100));
 	camera->setFarValue(10000);
 

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -259,7 +259,7 @@ void ClientMap::updateDrawList()
 struct MeshBufList
 {
 	video::SMaterial m;
-	std::vector<scene::IMeshBuffer*> bufs;
+	std::vector<scene::IMeshBuffer *> bufs;
 };
 
 struct MeshBufListList
@@ -300,7 +300,7 @@ struct MeshBufListList
 	}
 };
 
-void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
+void ClientMap::renderMap(video::IVideoDriver *driver, s32 pass)
 {
 	bool is_transparent_pass = pass == scene::ESNRP_TRANSPARENT;
 
@@ -412,8 +412,8 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 				for (u32 i = 0; i < c; i++) {
 					scene::IMeshBuffer *buf = mesh->getMeshBuffer(i);
 
-					video::SMaterial& material = buf->getMaterial();
-					video::IMaterialRenderer* rnd =
+					video::SMaterial &material = buf->getMaterial();
+					video::IMaterialRenderer *rnd =
 						driver->getMaterialRenderer(material.MaterialType);
 					bool transparent = (rnd && rnd->isTransparent());
 					if (transparent == is_transparent_pass) {
@@ -645,7 +645,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	// - If the player is in a solid node, make everything black.
 	// - If the player is in liquid, draw a semi-transparent overlay.
 	// - Do not if player is in third person mode
-	const ContentFeatures& features = m_nodedef->get(n);
+	const ContentFeatures &features = m_nodedef->get(n);
 	video::SColor post_effect_color = features.post_effect_color;
 	if(features.solidness == 2 && !(g_settings->getBool("noclip") &&
 			m_client->checkLocalPrivilege("noclip")) &&
@@ -656,7 +656,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 	if (post_effect_color.getAlpha() != 0)
 	{
 		// Draw a full-screen rectangle
-		video::IVideoDriver* driver = SceneManager->getVideoDriver();
+		video::IVideoDriver *driver = SceneManager->getVideoDriver();
 		v2u32 ss = driver->getScreenSize();
 		core::rect<s32> rect(0,0, ss.X, ss.Y);
 		driver->draw2DRectangle(post_effect_color, rect);
@@ -667,5 +667,3 @@ void ClientMap::PrintInfo(std::ostream &out)
 {
 	out<<"ClientMap: ";
 }
-
-

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -90,7 +90,7 @@ public:
 
 	virtual void render()
 	{
-		video::IVideoDriver* driver = SceneManager->getVideoDriver();
+		video::IVideoDriver *driver = SceneManager->getVideoDriver();
 		driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
 		renderMap(driver, SceneManager->getSceneNodeRenderPass());
 	}
@@ -103,7 +103,7 @@ public:
 	void getBlocksInViewRange(v3s16 cam_pos_nodes,
 		v3s16 *p_blocks_min, v3s16 *p_blocks_max);
 	void updateDrawList();
-	void renderMap(video::IVideoDriver* driver, s32 pass);
+	void renderMap(video::IVideoDriver *driver, s32 pass);
 
 	int getBackgroundBrightness(float max_d, u32 daylight_factor,
 			int oldvalue, bool *sunlight_seen_result);
@@ -128,7 +128,7 @@ private:
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
 
-	std::map<v3s16, MapBlock*> m_drawlist;
+	std::map<v3s16, MapBlock *> m_drawlist;
 
 	std::set<v2s16> m_last_drawn_sectors;
 

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -294,7 +294,7 @@ void ClientMediaDownloader::remoteHashSetReceived(
 			// available on this server, add this server
 			// to the available_remotes array
 
-			for(std::map<std::string, FileStatus*>::iterator
+			for(std::map<std::string, FileStatus *>::iterator
 					it = m_files.upper_bound(m_name_bound);
 					it != m_files.end(); ++it) {
 				FileStatus *f = it->second;
@@ -391,7 +391,7 @@ void ClientMediaDownloader::startRemoteMediaTransfers()
 {
 	bool changing_name_bound = true;
 
-	for (std::map<std::string, FileStatus*>::iterator
+	for (std::map<std::string, FileStatus *>::iterator
 			files_iter = m_files.upper_bound(m_name_bound);
 			files_iter != m_files.end(); ++files_iter) {
 
@@ -477,7 +477,7 @@ void ClientMediaDownloader::conventionalTransferDone(
 		Client *client)
 {
 	// Check that file was announced
-	std::map<std::string, FileStatus*>::iterator
+	std::map<std::string, FileStatus *>::iterator
 		file_iter = m_files.find(name);
 	if (file_iter == m_files.end()) {
 		errorstream << "Client: server sent media file that was"
@@ -522,7 +522,7 @@ bool ClientMediaDownloader::checkAndLoad(
 		SHA1 data_sha1_calculator;
 		data_sha1_calculator.addBytes(data.c_str(), data.size());
 		unsigned char *data_tmpdigest = data_sha1_calculator.getDigest();
-		data_sha1.assign((char*) data_tmpdigest, 20);
+		data_sha1.assign((char *) data_tmpdigest, 20);
 		free(data_tmpdigest);
 	}
 
@@ -582,7 +582,7 @@ std::string ClientMediaDownloader::serializeRequiredHashSet()
 
 	// Write list of hashes of files that have not been
 	// received (found in cache) yet
-	for (std::map<std::string, FileStatus*>::iterator
+	for (std::map<std::string, FileStatus *>::iterator
 			it = m_files.begin();
 			it != m_files.end(); ++it) {
 		if (!it->second->received) {
@@ -603,7 +603,7 @@ void ClientMediaDownloader::deSerializeHashSet(const std::string &data,
 				"invalid hash set file size");
 	}
 
-	const u8 *data_cstr = (const u8*) data.c_str();
+	const u8 *data_cstr = (const u8 *) data.c_str();
 
 	u32 signature = readU32(&data_cstr[0]);
 	if (signature != MTHASHSET_FILE_SIGNATURE) {

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -111,10 +111,10 @@ private:
 			std::set<std::string> &result);
 
 	// Maps filename to file status
-	std::map<std::string, FileStatus*> m_files;
+	std::map<std::string, FileStatus *> m_files;
 
 	// Array of remote media servers
-	std::vector<RemoteServerStatus*> m_remotes;
+	std::vector<RemoteServerStatus *> m_remotes;
 
 	// Filesystem-based media cache
 	FileCache m_media_cache;

--- a/src/client/clientobject.cpp
+++ b/src/client/clientobject.cpp
@@ -38,7 +38,7 @@ ClientActiveObject::~ClientActiveObject()
 	removeFromScene(true);
 }
 
-ClientActiveObject* ClientActiveObject::create(ActiveObjectType type,
+ClientActiveObject *ClientActiveObject::create(ActiveObjectType type,
 		Client *client, ClientEnvironment *env)
 {
 	// Find factory function
@@ -62,5 +62,3 @@ void ClientActiveObject::registerType(u16 type, Factory f)
 		return;
 	m_types[type] = f;
 }
-
-

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -71,7 +71,7 @@ public:
 	virtual void initialize(const std::string &data){}
 
 	// Create a certain type of ClientActiveObject
-	static ClientActiveObject* create(ActiveObjectType type, Client *client,
+	static ClientActiveObject *create(ActiveObjectType type, Client *client,
 			ClientEnvironment *env);
 
 	// If returns true, punch will not be sent to the server

--- a/src/client/clouds.cpp
+++ b/src/client/clouds.cpp
@@ -40,7 +40,7 @@ static void cloud_3d_setting_changed(const std::string &settingname, void *data)
 	((Clouds *)data)->readSettings();
 }
 
-Clouds::Clouds(scene::ISceneManager* mgr,
+Clouds::Clouds(scene::ISceneManager *mgr,
 		s32 id,
 		u32 seed
 ):
@@ -93,7 +93,7 @@ void Clouds::render()
 	if (m_params.density <= 0.0f)
 		return; // no need to do anything
 
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
 
 	if(SceneManager->getSceneNodeRenderPass() != scene::ESNRP_TRANSPARENT)
 	//if(SceneManager->getSceneNodeRenderPass() != scene::ESNRP_SOLID)

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -35,7 +35,7 @@ extern irr::scene::ISceneManager *g_menucloudsmgr;
 class Clouds : public scene::ISceneNode
 {
 public:
-	Clouds(scene::ISceneManager* mgr,
+	Clouds(scene::ISceneManager *mgr,
 			s32 id,
 			u32 seed
 	);
@@ -60,7 +60,7 @@ public:
 		return 1;
 	}
 
-	virtual video::SMaterial& getMaterial(u32 i)
+	virtual video::SMaterial &getMaterial(u32 i)
 	{
 		return m_material;
 	}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -156,8 +156,8 @@ void SmoothTranslatorWrappedv3f::translate(f32 dtime)
 static void setBillboardTextureMatrix(scene::IBillboardSceneNode *bill,
 		float txs, float tys, int col, int row)
 {
-	video::SMaterial& material = bill->getMaterial(0);
-	core::matrix4& matrix = material.getTextureMatrix(0);
+	video::SMaterial &material = bill->getMaterial(0);
+	core::matrix4 &matrix = material.getTextureMatrix(0);
 	matrix.setTextureTranslate(txs*col, tys*row);
 	matrix.setTextureScale(txs, tys);
 }
@@ -177,7 +177,7 @@ public:
 		return ACTIVEOBJECT_TYPE_TEST;
 	}
 
-	static ClientActiveObject* create(Client *client, ClientEnvironment *env);
+	static ClientActiveObject *create(Client *client, ClientEnvironment *env);
 
 	void addToScene(ITextureSource *tsrc);
 	void removeFromScene(bool permanent);
@@ -206,7 +206,7 @@ TestCAO::TestCAO(Client *client, ClientEnvironment *env):
 	ClientActiveObject::registerType(getType(), create);
 }
 
-ClientActiveObject* TestCAO::create(Client *client, ClientEnvironment *env)
+ClientActiveObject *TestCAO::create(Client *client, ClientEnvironment *env)
 {
 	return new TestCAO(client, env);
 }
@@ -216,7 +216,7 @@ void TestCAO::addToScene(ITextureSource *tsrc)
 	if(m_node != NULL)
 		return;
 
-	//video::IVideoDriver* driver = smgr->getVideoDriver();
+	//video::IVideoDriver *driver = smgr->getVideoDriver();
 
 	scene::SMesh *mesh = new scene::SMesh();
 	scene::IMeshBuffer *buf = new scene::SMeshBuffer();
@@ -416,7 +416,7 @@ const bool GenericCAO::isImmortal()
 	return itemgroup_get(getGroups(), "immortal");
 }
 
-scene::ISceneNode* GenericCAO::getSceneNode()
+scene::ISceneNode *GenericCAO::getSceneNode()
 {
 	if (m_meshnode) {
 		return m_meshnode;
@@ -436,7 +436,7 @@ scene::ISceneNode* GenericCAO::getSceneNode()
 	return NULL;
 }
 
-scene::IAnimatedMeshSceneNode* GenericCAO::getAnimatedMeshSceneNode()
+scene::IAnimatedMeshSceneNode *GenericCAO::getAnimatedMeshSceneNode()
 {
 	return m_animated_meshnode;
 }
@@ -456,7 +456,7 @@ void GenericCAO::setAttachments()
 	updateAttachments();
 }
 
-ClientActiveObject* GenericCAO::getParent() const
+ClientActiveObject *GenericCAO::getParent() const
 {
 	ClientActiveObject *obj = NULL;
 
@@ -483,7 +483,7 @@ void GenericCAO::removeFromScene(bool permanent)
 
 		m_env->attachement_parent_ids[getId()] = 0;
 
-		LocalPlayer* player = m_env->getLocalPlayer();
+		LocalPlayer *player = m_env->getLocalPlayer();
 		if (this == player->parent) {
 			player->parent = nullptr;
 			player->isAttached = false;
@@ -1019,7 +1019,7 @@ void GenericCAO::updateTexturePos()
 {
 	if(m_spritenode)
 	{
-		scene::ICameraSceneNode* camera =
+		scene::ICameraSceneNode *camera =
 				m_spritenode->getSceneManager()->getActiveCamera();
 		if(!camera)
 			return;
@@ -1111,14 +1111,14 @@ void GenericCAO::updateTextures(std::string mod)
 				if (texturestring.empty())
 					continue; // Empty texture string means don't modify that material
 				texturestring += mod;
-				video::ITexture* texture = tsrc->getTextureForMesh(texturestring);
+				video::ITexture *texture = tsrc->getTextureForMesh(texturestring);
 				if (!texture) {
 					errorstream<<"GenericCAO::updateTextures(): Could not load texture "<<texturestring<<std::endl;
 					continue;
 				}
 
 				// Set material flags and texture
-				video::SMaterial& material = m_animated_meshnode->getMaterial(i);
+				video::SMaterial &material = m_animated_meshnode->getMaterial(i);
 				material.MaterialType = material_type;
 				material.MaterialTypeParam = 0.5f;
 				material.TextureLayer[0].Texture = texture;
@@ -1165,7 +1165,7 @@ void GenericCAO::updateTextures(std::string mod)
 
 
 				// Set material flags and texture
-				video::SMaterial& material = m_meshnode->getMaterial(i);
+				video::SMaterial &material = m_meshnode->getMaterial(i);
 				material.MaterialType = material_type;
 				material.MaterialTypeParam = 0.5f;
 				material.setFlag(video::EMF_LIGHTING, false);
@@ -1283,7 +1283,7 @@ void GenericCAO::updateBonePosition()
 		std::string bone_name = (*ii).first;
 		v3f bone_pos = (*ii).second.X;
 		v3f bone_rot = (*ii).second.Y;
-		irr::scene::IBoneSceneNode* bone = m_animated_meshnode->getJointNode(bone_name.c_str());
+		irr::scene::IBoneSceneNode *bone = m_animated_meshnode->getJointNode(bone_name.c_str());
 		if(bone)
 		{
 			bone->setPosition(bone_pos);

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -129,7 +129,7 @@ public:
 
 	~GenericCAO();
 
-	static ClientActiveObject* create(Client *client, ClientEnvironment *env)
+	static ClientActiveObject *create(Client *client, ClientEnvironment *env)
 	{
 		return new GenericCAO(client, env);
 	}

--- a/src/client/content_cso.cpp
+++ b/src/client/content_cso.cpp
@@ -69,9 +69,8 @@ public:
 	}
 };
 
-ClientSimpleObject* createSmokePuff(scene::ISceneManager *smgr,
+ClientSimpleObject *createSmokePuff(scene::ISceneManager *smgr,
 		ClientEnvironment *env, v3f pos, v2f size)
 {
 	return new SmokePuffCSO(smgr, env, pos, size);
 }
-

--- a/src/client/content_cso.h
+++ b/src/client/content_cso.h
@@ -22,5 +22,5 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "clientsimpleobject.h"
 
-ClientSimpleObject* createSmokePuff(scene::ISceneManager *smgr,
+ClientSimpleObject *createSmokePuff(scene::ISceneManager *smgr,
 		ClientEnvironment *env, v3f pos, v2f size);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1307,7 +1307,7 @@ void MapblockMeshGenerator::drawNodeboxNode()
 void MapblockMeshGenerator::drawMeshNode()
 {
 	u8 facedir = 0;
-	scene::IMesh* mesh;
+	scene::IMesh *mesh;
 	bool private_mesh; // as a grab/drop pair is not thread-safe
 
 	if (f->param_type_2 == CPT2_FACEDIR ||

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -33,7 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MAX_FONT_SIZE_OFFSET 10
 
 /** reference to access font engine, has to be initialized by main */
-FontEngine* g_fontengine = NULL;
+FontEngine *g_fontengine = NULL;
 
 /** callback to be used on change of font size setting */
 static void font_setting_changed(const std::string &name, void *userdata)
@@ -42,7 +42,7 @@ static void font_setting_changed(const std::string &name, void *userdata)
 }
 
 /******************************************************************************/
-FontEngine::FontEngine(Settings* main_settings, gui::IGUIEnvironment* env) :
+FontEngine::FontEngine(Settings *main_settings, gui::IGUIEnvironment *env) :
 	m_settings(main_settings),
 	m_env(env)
 {
@@ -125,7 +125,7 @@ void FontEngine::cleanCache()
 }
 
 /******************************************************************************/
-irr::gui::IGUIFont* FontEngine::getFont(unsigned int font_size, FontMode mode)
+irr::gui::IGUIFont *FontEngine::getFont(unsigned int font_size, FontMode mode)
 {
 	if (mode == FM_Unspecified) {
 		mode = m_currentMode;
@@ -160,7 +160,7 @@ irr::gui::IGUIFont* FontEngine::getFont(unsigned int font_size, FontMode mode)
 /******************************************************************************/
 unsigned int FontEngine::getTextHeight(unsigned int font_size, FontMode mode)
 {
-	irr::gui::IGUIFont* font = getFont(font_size, mode);
+	irr::gui::IGUIFont *font = getFont(font_size, mode);
 
 	// use current skin font as fallback
 	if (font == NULL) {
@@ -172,10 +172,10 @@ unsigned int FontEngine::getTextHeight(unsigned int font_size, FontMode mode)
 }
 
 /******************************************************************************/
-unsigned int FontEngine::getTextWidth(const std::wstring& text,
+unsigned int FontEngine::getTextWidth(const std::wstring &text,
 		unsigned int font_size, FontMode mode)
 {
-	irr::gui::IGUIFont* font = getFont(font_size, mode);
+	irr::gui::IGUIFont *font = getFont(font_size, mode);
 
 	// use current skin font as fallback
 	if (font == NULL) {
@@ -190,7 +190,7 @@ unsigned int FontEngine::getTextWidth(const std::wstring& text,
 /** get line height for a specific font (including empty room between lines) */
 unsigned int FontEngine::getLineHeight(unsigned int font_size, FontMode mode)
 {
-	irr::gui::IGUIFont* font = getFont(font_size, mode);
+	irr::gui::IGUIFont *font = getFont(font_size, mode);
 
 	// use current skin font as fallback
 	if (font == NULL) {
@@ -326,15 +326,15 @@ void FontEngine::initFont(unsigned int basesize, FontMode mode)
 		try {
 			font_shadow =
 					g_settings->getU16(font_config_prefix + "font_shadow");
-		} catch (SettingNotFoundException&) {}
+		} catch (SettingNotFoundException &) {}
 		try {
 			font_shadow_alpha =
 					g_settings->getU16(font_config_prefix + "font_shadow_alpha");
-		} catch (SettingNotFoundException&) {}
+		} catch (SettingNotFoundException &) {}
 
 		std::string font_path = g_settings->get(font_config_prefix + "font_path");
 
-		irr::gui::IGUIFont* font = gui::CGUITTFont::createTTFont(m_env,
+		irr::gui::IGUIFont *font = gui::CGUITTFont::createTTFont(m_env,
 				font_path.c_str(), size, true, true, font_shadow,
 				font_shadow_alpha);
 
@@ -439,7 +439,7 @@ void FontEngine::initSimpleFont(unsigned int basesize, FontMode mode)
 			m_settings->getFloat("gui_scaling") *
 			basesize);
 
-	irr::gui::IGUIFont* font = NULL;
+	irr::gui::IGUIFont *font = NULL;
 
 	for(unsigned int offset = 0; offset < MAX_FONT_SIZE_OFFSET; offset++) {
 

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -43,20 +43,20 @@ class FontEngine
 {
 public:
 
-	FontEngine(Settings* main_settings, gui::IGUIEnvironment* env);
+	FontEngine(Settings *main_settings, gui::IGUIEnvironment *env);
 
 	~FontEngine();
 
 	/** get Font */
-	irr::gui::IGUIFont* getFont(unsigned int font_size=FONT_SIZE_UNSPECIFIED,
-			FontMode mode=FM_Unspecified);
+	irr::gui::IGUIFont *getFont(unsigned int font_size = FONT_SIZE_UNSPECIFIED,
+			FontMode mode = FM_Unspecified);
 
 	/** get text height for a specific font */
-	unsigned int getTextHeight(unsigned int font_size=FONT_SIZE_UNSPECIFIED,
-			FontMode mode=FM_Unspecified);
+	unsigned int getTextHeight(unsigned int font_size = FONT_SIZE_UNSPECIFIED,
+			FontMode mode = FM_Unspecified);
 
 	/** get text width if a text for a specific font */
-	unsigned int getTextWidth(const std::string& text,
+	unsigned int getTextWidth(const std::string &text,
 			unsigned int font_size=FONT_SIZE_UNSPECIFIED,
 			FontMode mode=FM_Unspecified)
 	{
@@ -64,19 +64,19 @@ public:
 	}
 
 	/** get text width if a text for a specific font */
-	unsigned int getTextWidth(const std::wstring& text,
+	unsigned int getTextWidth(const std::wstring &text,
 			unsigned int font_size=FONT_SIZE_UNSPECIFIED,
-			FontMode mode=FM_Unspecified);
+			FontMode mode = FM_Unspecified);
 
 	/** get line height for a specific font (including empty room between lines) */
 	unsigned int getLineHeight(unsigned int font_size=FONT_SIZE_UNSPECIFIED,
-			FontMode mode=FM_Unspecified);
+			FontMode mode = FM_Unspecified);
 
 	/** get default font size */
 	unsigned int getDefaultFontSize();
 
 	/** initialize font engine */
-	void initialize(Settings* main_settings, gui::IGUIEnvironment* env);
+	void initialize(Settings *main_settings, gui::IGUIEnvironment *env);
 
 	/** update internal parameters from settings */
 	void readSettings();
@@ -86,7 +86,7 @@ private:
 	void updateFontCache();
 
 	/** initialize a new font */
-	void initFont(unsigned int basesize, FontMode mode=FM_Unspecified);
+	void initFont(unsigned int basesize, FontMode mode = FM_Unspecified);
 
 	/** initialize a font without freetype */
 	void initSimpleFont(unsigned int basesize, FontMode mode);
@@ -98,13 +98,13 @@ private:
 	void cleanCache();
 
 	/** pointer to settings for registering callbacks or reading config */
-	Settings* m_settings = nullptr;
+	Settings *m_settings = nullptr;
 
 	/** pointer to irrlicht gui environment */
-	gui::IGUIEnvironment* m_env = nullptr;
+	gui::IGUIEnvironment *m_env = nullptr;
 
 	/** internal storage for caching fonts of different size */
-	std::map<unsigned int, irr::gui::IGUIFont*> m_font_cache[FM_MaxMode];
+	std::map<unsigned int, irr::gui::IGUIFont *> m_font_cache[FM_MaxMode];
 
 	/** default font size to use */
 	unsigned int m_default_size[FM_MaxMode];
@@ -119,10 +119,10 @@ private:
 	unsigned int m_lastSize = 0;
 
 	/** last font returned */
-	irr::gui::IGUIFont* m_lastFont = nullptr;
+	irr::gui::IGUIFont *m_lastFont = nullptr;
 
 	DISABLE_CLASS_COPY(FontEngine);
 };
 
 /** interface to access main font engine*/
-extern FontEngine* g_fontengine;
+extern FontEngine *g_fontengine;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -302,7 +302,7 @@ public:
 
 	static void playerJump(MtEvent *e, void *data)
 	{
-		//SoundMaker *sm = (SoundMaker*)data;
+		//SoundMaker *sm = (SoundMaker *)data;
 	}
 
 	static void cameraPunchLeft(MtEvent *e, void *data)
@@ -427,7 +427,7 @@ public:
 
 	static void settingsCallback(const std::string &name, void *userdata)
 	{
-		reinterpret_cast<GameGlobalShaderConstantSetter*>(userdata)->onSettingsChange(name);
+		reinterpret_cast<GameGlobalShaderConstantSetter *>(userdata)->onSettingsChange(name);
 	}
 
 	void setSky(Sky *sky) { m_sky = sky; }
@@ -557,7 +557,7 @@ public:
 		created_nosky.clear();
 	}
 
-	virtual IShaderConstantSetter* create()
+	virtual IShaderConstantSetter *create()
 	{
 		GameGlobalShaderConstantSetter *scs = new GameGlobalShaderConstantSetter(
 				m_sky, m_force_fog_off, m_fog_range, m_client);
@@ -2798,7 +2798,7 @@ void Game::processClientEvents(CameraOrientation *cam)
 	while (client->hasClientEvents()) {
 		std::unique_ptr<ClientEvent> event(client->getClientEvent());
 		FATAL_ERROR_IF(event->type >= CLIENTEVENT_MAX, "Invalid clientevent type");
-		const ClientEventHandler& evHandler = clientEventHandler[event->type];
+		const ClientEventHandler &evHandler = clientEventHandler[event->type];
 		(this->*evHandler.handler)(event.get(), cam);
 	}
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -293,7 +293,7 @@ void GameUI::toggleProfiler()
 
 	if (m_profiler_current_page != 0) {
 		wchar_t buf[255];
-		const wchar_t* str = wgettext("Profiler shown (page %d of %d)");
+		const wchar_t *str = wgettext("Profiler shown (page %d of %d)");
 		swprintf(buf, sizeof(buf) / sizeof(wchar_t), str,
 			m_profiler_current_page, m_profiler_max_page);
 		delete[] str;

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -96,7 +96,7 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 
 	// Try to find the texture converted to an image in the cache.
 	// If the image was not found, try to extract it from the texture.
-	video::IImage* srcimg = g_imgCache[origname];
+	video::IImage *srcimg = g_imgCache[origname];
 	if (srcimg == NULL) {
 		if (!g_settings->getBool("gui_scaling_filter_txr2img"))
 			return src;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -282,7 +282,7 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 void Hud::drawLuaElements(const v3s16 &camera_offset)
 {
 	u32 text_height = g_fontengine->getTextHeight();
-	irr::gui::IGUIFont* font = g_fontengine->getFont();
+	irr::gui::IGUIFont *font = g_fontengine->getFont();
 	for (size_t i = 0; i != player->maxHudId(); i++) {
 		HudElement *e = player->getHud(i);
 		if (!e)
@@ -339,7 +339,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				v3f w_pos = e->world_pos * BS;
 				float distance = std::floor(10 * p_pos.getDistanceFrom(e->world_pos)) /
 					10.0f;
-				scene::ICameraSceneNode* camera =
+				scene::ICameraSceneNode *camera =
 					RenderingEngine::get_scene_manager()->getActiveCamera();
 				w_pos -= intToFloat(camera_offset, BS);
 				core::matrix4 trans = camera->getProjectionMatrix();
@@ -536,7 +536,7 @@ void Hud::drawSelectionMesh()
 			MYMIN(255, m_selection_mesh_color.getBlue() * 1.5));
 		setMeshColorByNormal(m_selection_mesh, m_selected_face_normal,
 			face_color);
-		scene::IMesh* mesh = cloneMesh(m_selection_mesh);
+		scene::IMesh *mesh = cloneMesh(m_selection_mesh);
 		translateMesh(mesh, m_selection_pos_with_offset);
 		u32 mc = m_selection_mesh->getMeshBufferCount();
 		for (u32 i = 0; i < mc; i++) {

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -274,7 +274,7 @@ struct table_key lookup_keychar(wchar_t Char)
 	}
 
 	std::ostringstream os;
-	os << "<Char " << hex_encode((char*) &Char, sizeof(wchar_t)) << ">";
+	os << "<Char " << hex_encode((char *) &Char, sizeof(wchar_t)) << ">";
 	throw UnknownKeycode(os.str().c_str());
 }
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -631,7 +631,7 @@ static void makeFastFace(const TileSpec &tile, u16 li0, u16 li1, u16 li2, u16 li
 
 	// equivalent to dest.push_back(FastFace()) but faster
 	dest.emplace_back();
-	FastFace& face = *dest.rbegin();
+	FastFace &face = *dest.rbegin();
 
 	for (u8 i = 0; i < 4; i++) {
 		video::SColor c = encode_light(li[i], tile.emissive_light);
@@ -1216,7 +1216,7 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			intToFloat(data->m_blockpos * MAP_BLOCKSIZE - camera_offset, BS));
 
 		if (m_use_tangent_vertices) {
-			scene::IMeshManipulator* meshmanip =
+			scene::IMeshManipulator *meshmanip =
 				RenderingEngine::get_scene_manager()->getMeshManipulator();
 			meshmanip->recalculateTangents(m_mesh[layer], true, false, false);
 		}

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -34,7 +34,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MY_ETLM_READ_ONLY video::ETLM_READ_ONLY
 #endif
 
-inline static void applyShadeFactor(video::SColor& color, float factor)
+inline static void applyShadeFactor(video::SColor &color, float factor)
 {
 	color.setRed(core::clamp(core::round32(color.getRed()*factor), 0, 255));
 	color.setGreen(core::clamp(core::round32(color.getGreen()*factor), 0, 255));
@@ -61,7 +61,7 @@ void applyFacesShading(video::SColor &color, const v3f &normal)
 		applyShadeFactor(color, 0.670820f * x2 + 1.000000f * y2 + 0.836660f * z2);
 }
 
-scene::IAnimatedMesh* createCubeMesh(v3f scale)
+scene::IAnimatedMesh *createCubeMesh(v3f scale)
 {
 	video::SColor c(255,255,255,255);
 	video::S3DVertex vertices[24] =
@@ -395,7 +395,7 @@ void recalculateBoundingBox(scene::IMesh *src_mesh)
 	src_mesh->setBoundingBox(bbox);
 }
 
-scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
+scene::IMeshBuffer *cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
 {
 	switch (mesh_buffer->getVertexType()) {
 	case video::EVT_STANDARD: {
@@ -432,9 +432,9 @@ scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer)
 	return NULL;
 }
 
-scene::SMesh* cloneMesh(scene::IMesh *src_mesh)
+scene::SMesh *cloneMesh(scene::IMesh *src_mesh)
 {
-	scene::SMesh* dst_mesh = new scene::SMesh();
+	scene::SMesh *dst_mesh = new scene::SMesh();
 	for (u16 j = 0; j < src_mesh->getMeshBufferCount(); j++) {
 		scene::IMeshBuffer *temp_buf = cloneMeshBuffer(
 			src_mesh->getMeshBuffer(j));
@@ -445,10 +445,10 @@ scene::SMesh* cloneMesh(scene::IMesh *src_mesh)
 	return dst_mesh;
 }
 
-scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
+scene::IMesh *convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 		const f32 *uv_coords, float expand)
 {
-	scene::SMesh* dst_mesh = new scene::SMesh();
+	scene::SMesh *dst_mesh = new scene::SMesh();
 
 	for (u16 j = 0; j < 6; j++)
 	{
@@ -713,7 +713,7 @@ http://home.comcast.net/~tom_forsyth/papers/fast_vert_cache_opt.html
 The function is thread-safe (read: you can optimize several meshes in different threads)
 
 \param mesh Source mesh for the operation.  */
-scene::IMesh* createForsythOptimizedMesh(const scene::IMesh *mesh)
+scene::IMesh *createForsythOptimizedMesh(const scene::IMesh *mesh)
 {
 	if (!mesh)
 		return 0;

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -35,7 +35,7 @@ void applyFacesShading(video::SColor &color, const v3f &normal);
 	The resulting mesh has 6 materials (up, down, right, left, back, front)
 	which must be defined by the caller.
 */
-scene::IAnimatedMesh* createCubeMesh(v3f scale);
+scene::IAnimatedMesh *createCubeMesh(v3f scale);
 
 /*
 	Multiplies each vertex coordinate by the specified scaling factors
@@ -100,12 +100,12 @@ void rotateMeshYZby (scene::IMesh *mesh, f64 degrees);
  *  Clone the mesh buffer.
  *  The returned pointer should be dropped.
  */
-scene::IMeshBuffer* cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer);
+scene::IMeshBuffer *cloneMeshBuffer(scene::IMeshBuffer *mesh_buffer);
 
 /*
 	Clone the mesh.
 */
-scene::SMesh* cloneMesh(scene::IMesh *src_mesh);
+scene::SMesh *cloneMesh(scene::IMesh *src_mesh);
 
 /*
 	Convert nodeboxes to mesh. Each tile goes into a different buffer.
@@ -113,7 +113,7 @@ scene::SMesh* cloneMesh(scene::IMesh *src_mesh);
 	uv_coords[24] - table of texture uv coords for each cuboid face
 	expand - factor by which cuboids will be resized
 */
-scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
+scene::IMesh *convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 		const f32 *uv_coords = NULL, float expand = 0);
 
 /*
@@ -126,4 +126,4 @@ void recalculateBoundingBox(scene::IMesh *src_mesh);
 	http://home.comcast.net/~tom_forsyth/papers/fast_vert_cache_opt.html
 	Ported from irrlicht 1.8
 */
-scene::IMesh* createForsythOptimizedMesh(const scene::IMesh *mesh);
+scene::IMesh *createForsythOptimizedMesh(const scene::IMesh *mesh);

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -82,7 +82,7 @@ void MeshUpdateQueue::addBlock(Map *map, v3s16 p, bool ack_block_to_server, bool
 		Cache the block data (force-update the center block, don't update the
 		neighbors but get them if they aren't already cached)
 	*/
-	std::vector<CachedMapBlockData*> cached_blocks;
+	std::vector<CachedMapBlockData *> cached_blocks;
 	size_t cache_hit_counter = 0;
 	cached_blocks.reserve(3*3*3);
 	v3s16 dp;
@@ -146,7 +146,7 @@ QueuedMeshUpdate *MeshUpdateQueue::pop()
 	MutexAutoLock lock(m_mutex);
 
 	bool must_be_urgent = !m_urgents.empty();
-	for (std::vector<QueuedMeshUpdate*>::iterator i = m_queue.begin();
+	for (std::vector<QueuedMeshUpdate *>::iterator i = m_queue.begin();
 			i != m_queue.end(); ++i) {
 		QueuedMeshUpdate *q = *i;
 		if(must_be_urgent && m_urgents.count(q->p) == 0)
@@ -159,10 +159,10 @@ QueuedMeshUpdate *MeshUpdateQueue::pop()
 	return NULL;
 }
 
-CachedMapBlockData* MeshUpdateQueue::cacheBlock(Map *map, v3s16 p, UpdateMode mode,
+CachedMapBlockData *MeshUpdateQueue::cacheBlock(Map *map, v3s16 p, UpdateMode mode,
 			size_t *cache_hit_counter)
 {
-	std::map<v3s16, CachedMapBlockData*>::iterator it =
+	std::map<v3s16, CachedMapBlockData *>::iterator it =
 			m_cache.find(p);
 	if (it != m_cache.end()) {
 		// Already in cache
@@ -199,9 +199,9 @@ CachedMapBlockData* MeshUpdateQueue::cacheBlock(Map *map, v3s16 p, UpdateMode mo
 	return cached_block;
 }
 
-CachedMapBlockData* MeshUpdateQueue::getCachedBlock(const v3s16 &p)
+CachedMapBlockData *MeshUpdateQueue::getCachedBlock(const v3s16 &p)
 {
-	std::map<v3s16, CachedMapBlockData*>::iterator it = m_cache.find(p);
+	std::map<v3s16, CachedMapBlockData *>::iterator it = m_cache.find(p);
 	if (it != m_cache.end()) {
 		return it->second;
 	}
@@ -253,7 +253,7 @@ void MeshUpdateQueue::cleanupCache()
 
 	int t_now = time(0);
 
-	for (std::map<v3s16, CachedMapBlockData*>::iterator it = m_cache.begin();
+	for (std::map<v3s16, CachedMapBlockData *>::iterator it = m_cache.begin();
 			it != m_cache.end(); ) {
 		CachedMapBlockData *cached_block = it->second;
 		if (cached_block->refcount_from_queue == 0 &&

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -92,7 +92,7 @@ void MinimapUpdateThread::doUpdate()
 	while (popBlockUpdate(&update)) {
 		if (update.data) {
 			// Swap two values in the map using single lookup
-			std::pair<std::map<v3s16, MinimapMapblock*>::iterator, bool>
+			std::pair<std::map<v3s16, MinimapMapblock *>::iterator, bool>
 			    result = m_blocks_cache.insert(std::make_pair(update.pos, update.data));
 			if (!result.second) {
 				delete result.first->second;

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -146,7 +146,7 @@ public:
 	void drawMinimap();
 
 	video::IVideoDriver *driver;
-	Client* client;
+	Client *client;
 	MinimapData *data;
 
 private:

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -120,7 +120,7 @@ void Particle::OnRegisterSceneNode()
 
 void Particle::render()
 {
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
 	driver->setMaterial(m_material);
 	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
 
@@ -351,7 +351,7 @@ void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
 	));
 }
 
-void ParticleSpawner::step(float dtime, ClientEnvironment* env)
+void ParticleSpawner::step(float dtime, ClientEnvironment *env)
 {
 	m_time += dtime;
 
@@ -404,7 +404,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 }
 
 
-ParticleManager::ParticleManager(ClientEnvironment* env) :
+ParticleManager::ParticleManager(ClientEnvironment *env) :
 	m_env(env)
 {}
 
@@ -568,7 +568,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 // The final burst of particles when a node is finally dug, *not* particles
 // spawned during the digging of a node.
 
-void ParticleManager::addDiggingParticles(IGameDef* gamedef,
+void ParticleManager::addDiggingParticles(IGameDef *gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
 {
 	// No particles for "airlike" nodes
@@ -583,7 +583,7 @@ void ParticleManager::addDiggingParticles(IGameDef* gamedef,
 // During the digging of a node particles are spawned individually by this
 // function, called from Game::handleDigging() in game.cpp.
 
-void ParticleManager::addNodeParticle(IGameDef* gamedef,
+void ParticleManager::addNodeParticle(IGameDef *gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
 {
 	// No particles for "airlike" nodes
@@ -635,7 +635,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	else
 		n.getColor(f, &color);
 
-	Particle* toadd = new Particle(
+	Particle *toadd = new Particle(
 		gamedef,
 		player,
 		m_env,
@@ -658,7 +658,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	addParticle(toadd);
 }
 
-void ParticleManager::addParticle(Particle* toadd)
+void ParticleManager::addParticle(Particle *toadd)
 {
 	MutexAutoLock lock(m_particle_list_lock);
 	m_particles.push_back(toadd);

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -35,7 +35,7 @@ class Particle : public scene::ISceneNode
 {
 	public:
 	Particle(
-		IGameDef* gamedef,
+		IGameDef *gamedef,
 		LocalPlayer *player,
 		ClientEnvironment *env,
 		v3f pos,
@@ -66,7 +66,7 @@ class Particle : public scene::ISceneNode
 		return 1;
 	}
 
-	virtual video::SMaterial& getMaterial(u32 i)
+	virtual video::SMaterial &getMaterial(u32 i)
 	{
 		return m_material;
 	}
@@ -117,7 +117,7 @@ private:
 class ParticleSpawner
 {
 public:
-	ParticleSpawner(IGameDef* gamedef,
+	ParticleSpawner(IGameDef *gamedef,
 		LocalPlayer *player,
 		u16 amount,
 		float time,
@@ -133,7 +133,7 @@ public:
 		bool vertical,
 		video::ITexture *texture,
 		const struct TileAnimationParams &anim, u8 glow,
-		ParticleManager* p_manager);
+		ParticleManager *p_manager);
 
 	~ParticleSpawner() = default;
 
@@ -181,7 +181,7 @@ class ParticleManager
 {
 friend class ParticleSpawner;
 public:
-	ParticleManager(ClientEnvironment* env);
+	ParticleManager(ClientEnvironment *env);
 	~ParticleManager();
 
 	void step (float dtime);
@@ -208,7 +208,7 @@ public:
 	}
 
 protected:
-	void addParticle(Particle* toadd);
+	void addParticle(Particle *toadd);
 
 private:
 
@@ -217,13 +217,13 @@ private:
 
 	void clearAll();
 
-	std::vector<Particle*> m_particles;
-	std::unordered_map<u64, ParticleSpawner*> m_particle_spawners;
+	std::vector<Particle *> m_particles;
+	std::unordered_map<u64, ParticleSpawner *> m_particle_spawners;
 	// Start the particle spawner ids generated from here after u32_max. lower values are
 	// for server sent spawners.
 	u64 m_next_particle_spawner_id = U32_MAX + 1;
 
-	ClientEnvironment* m_env;
+	ClientEnvironment *m_env;
 	std::mutex m_particle_list_lock;
 	std::mutex m_spawner_list_lock;
 };

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -173,7 +173,7 @@ private:
 
 class ShaderCallback : public video::IShaderConstantSetCallBack
 {
-	std::vector<IShaderConstantSetter*> m_setters;
+	std::vector<IShaderConstantSetter *> m_setters;
 
 public:
 	ShaderCallback(const std::vector<IShaderConstantSetterFactory *> &factories)
@@ -247,7 +247,7 @@ public:
 class MainShaderConstantSetterFactory : public IShaderConstantSetterFactory
 {
 public:
-	virtual IShaderConstantSetter* create()
+	virtual IShaderConstantSetter *create()
 		{ return new MainShaderConstantSetter(); }
 };
 
@@ -599,7 +599,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	// Create shaders header
 	std::string shaders_header = "#version 120\n";
 
-	static const char* drawTypes[] = {
+	static const char *drawTypes[] = {
 		"NDT_NORMAL",
 		"NDT_AIRLIKE",
 		"NDT_LIQUID",
@@ -627,7 +627,7 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 		shaders_header += "\n";
 	}
 
-	static const char* materialTypes[] = {
+	static const char *materialTypes[] = {
 		"TILE_MATERIAL_BASIC",
 		"TILE_MATERIAL_ALPHA",
 		"TILE_MATERIAL_LIQUID_TRANSPARENT",
@@ -747,9 +747,9 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	shaders_header += "\n";
 
 	// Call addHighLevelShaderMaterial() or addShaderMaterial()
-	const c8* vertex_program_ptr = 0;
-	const c8* pixel_program_ptr = 0;
-	const c8* geometry_program_ptr = 0;
+	const c8 *vertex_program_ptr = 0;
+	const c8 *pixel_program_ptr = 0;
+	const c8 *geometry_program_ptr = 0;
 	if (!vertex_program.empty()) {
 		vertex_program = shaders_header + vertex_program;
 		vertex_program_ptr = vertex_program.c_str();

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -73,7 +73,7 @@ public:
 class IShaderConstantSetterFactory {
 public:
 	virtual ~IShaderConstantSetterFactory() = default;
-	virtual IShaderConstantSetter* create() = 0;
+	virtual IShaderConstantSetter *create() = 0;
 };
 
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -118,8 +118,8 @@ void Sky::render()
 	if (!m_visible)
 		return;
 
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
-	scene::ICameraSceneNode* camera = SceneManager->getActiveCamera();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
+	scene::ICameraSceneNode *camera = SceneManager->getActiveCamera();
 
 	if (!camera || !driver)
 		return;
@@ -179,7 +179,7 @@ void Sky::render()
 
 		if (m_sun_tonemap) {
 			u8 * texels = (u8 *)m_sun_tonemap->lock();
-			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
+			video::SColor *texel = (video::SColor *)(texels + (u32)offset * 4);
 			video::SColor texel_color (255, texel->getRed(),
 				texel->getGreen(), texel->getBlue());
 			m_sun_tonemap->unlock();
@@ -188,7 +188,7 @@ void Sky::render()
 
 		if (m_moon_tonemap) {
 			u8 * texels = (u8 *)m_moon_tonemap->lock();
-			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
+			video::SColor *texel = (video::SColor *)(texels + (u32)offset * 4);
 			video::SColor texel_color (255, texel->getRed(),
 				texel->getGreen(), texel->getBlue());
 			m_moon_tonemap->unlock();
@@ -260,9 +260,9 @@ void Sky::render()
 		do {
 			driver->setMaterial(m_materials[1]);
 			// Tune values so that stars first appear just after the sun
-			// disappears over the horizon, and disappear just before the sun 
+			// disappears over the horizon, and disappear just before the sun
 			// appears over the horizon.
-			// Also tune so that stars are at full brightness from time 20000 to 
+			// Also tune so that stars are at full brightness from time 20000 to
 			// time 4000.
 			float starbrightness = MYMAX(0, MYMIN(1,
 				(0.25 - fabs(wicked_time_of_day < 0.5 ?

--- a/src/client/sound_openal.cpp
+++ b/src/client/sound_openal.cpp
@@ -309,8 +309,8 @@ private:
 	ALCdevice *m_device;
 	ALCcontext *m_context;
 	int m_next_id;
-	std::unordered_map<std::string, std::vector<SoundBuffer*>> m_buffers;
-	std::unordered_map<int, PlayingSound*> m_sounds_playing;
+	std::unordered_map<std::string, std::vector<SoundBuffer *>> m_buffers;
+	std::unordered_map<int, PlayingSound *> m_sounds_playing;
 	struct FadeState {
 		FadeState() = default;
 
@@ -366,29 +366,29 @@ public:
 
 	void addBuffer(const std::string &name, SoundBuffer *buf)
 	{
-		std::unordered_map<std::string, std::vector<SoundBuffer*>>::iterator i =
+		std::unordered_map<std::string, std::vector<SoundBuffer *>>::iterator i =
 				m_buffers.find(name);
 		if(i != m_buffers.end()){
 			i->second.push_back(buf);
 			return;
 		}
-		std::vector<SoundBuffer*> bufs;
+		std::vector<SoundBuffer *> bufs;
 		bufs.push_back(buf);
 		m_buffers[name] = bufs;
 	}
 
-	SoundBuffer* getBuffer(const std::string &name)
+	SoundBuffer *getBuffer(const std::string &name)
 	{
-		std::unordered_map<std::string, std::vector<SoundBuffer*>>::iterator i =
+		std::unordered_map<std::string, std::vector<SoundBuffer *>>::iterator i =
 				m_buffers.find(name);
 		if(i == m_buffers.end())
 			return nullptr;
-		std::vector<SoundBuffer*> &bufs = i->second;
+		std::vector<SoundBuffer *> &bufs = i->second;
 		int j = myrand() % bufs.size();
 		return bufs[j];
 	}
 
-	PlayingSound* createPlayingSound(SoundBuffer *buf, bool loop,
+	PlayingSound *createPlayingSound(SoundBuffer *buf, bool loop,
 			float volume, float pitch)
 	{
 		infostream << "OpenALSoundManager: Creating playing sound" << std::endl;
@@ -410,7 +410,7 @@ public:
 		return sound;
 	}
 
-	PlayingSound* createPlayingSoundAt(SoundBuffer *buf, bool loop,
+	PlayingSound *createPlayingSoundAt(SoundBuffer *buf, bool loop,
 			float volume, v3f pos, float pitch)
 	{
 		infostream << "OpenALSoundManager: Creating positional playing sound"
@@ -464,7 +464,7 @@ public:
 
 	void deleteSound(int id)
 	{
-		std::unordered_map<int, PlayingSound*>::iterator i = m_sounds_playing.find(id);
+		std::unordered_map<int, PlayingSound *>::iterator i = m_sounds_playing.find(id);
 		if(i == m_sounds_playing.end())
 			return;
 		PlayingSound *sound = i->second;
@@ -476,7 +476,7 @@ public:
 	}
 
 	/* If buffer does not exist, consult the fetcher */
-	SoundBuffer* getFetchBuffer(const std::string &name)
+	SoundBuffer *getFetchBuffer(const std::string &name)
 	{
 		SoundBuffer *buf = getBuffer(name);
 		if(buf)

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -198,14 +198,14 @@ public:
 	{
 		assert(img); // Pre-condition
 		// Remove old image
-		std::map<std::string, video::IImage*>::iterator n;
+		std::map<std::string, video::IImage *>::iterator n;
 		n = m_images.find(name);
 		if (n != m_images.end()){
 			if (n->second)
 				n->second->drop();
 		}
 
-		video::IImage* toadd = img;
+		video::IImage *toadd = img;
 		bool need_to_grab = true;
 
 		// Try to use local texture instead if asked to
@@ -225,9 +225,9 @@ public:
 			toadd->grab();
 		m_images[name] = toadd;
 	}
-	video::IImage* get(const std::string &name)
+	video::IImage *get(const std::string &name)
 	{
-		std::map<std::string, video::IImage*>::iterator n;
+		std::map<std::string, video::IImage *>::iterator n;
 		n = m_images.find(name);
 		if (n != m_images.end())
 			return n->second;
@@ -236,7 +236,7 @@ public:
 	// Primarily fetches from cache, secondarily tries to read from filesystem
 	video::IImage *getOrLoad(const std::string &name)
 	{
-		std::map<std::string, video::IImage*>::iterator n;
+		std::map<std::string, video::IImage *>::iterator n;
 		n = m_images.find(name);
 		if (n != m_images.end()){
 			n->second->grab(); // Grab for caller
@@ -260,7 +260,7 @@ public:
 		return img;
 	}
 private:
-	std::map<std::string, video::IImage*> m_images;
+	std::map<std::string, video::IImage *> m_images;
 };
 
 /*
@@ -325,9 +325,9 @@ public:
 		and not found in cache, the call is queued to the main thread
 		for processing.
 	*/
-	video::ITexture* getTexture(u32 id);
+	video::ITexture *getTexture(u32 id);
 
-	video::ITexture* getTexture(const std::string &name, u32 *id = NULL);
+	video::ITexture *getTexture(const std::string &name, u32 *id = NULL);
 
 	/*
 		Get a texture specifically intended for mesh
@@ -335,9 +335,9 @@ public:
 		use.  This texture may be a different size and may
 		have had additional filters applied.
 	*/
-	video::ITexture* getTextureForMesh(const std::string &name, u32 *id);
+	video::ITexture *getTextureForMesh(const std::string &name, u32 *id);
 
-	virtual Palette* getPalette(const std::string &name);
+	virtual Palette *getPalette(const std::string &name);
 
 	bool isKnownSourceImage(const std::string &name)
 	{
@@ -363,7 +363,7 @@ public:
 	// Shall be called from the main thread.
 	void rebuildImagesAndTextures();
 
-	video::ITexture* getNormalTexture(const std::string &name);
+	video::ITexture *getNormalTexture(const std::string &name);
 	video::SColor getTextureAverageColor(const std::string &name);
 	video::ITexture *getShaderFlagsTexture(bool normamap_present);
 
@@ -388,7 +388,7 @@ private:
 	 * Shall be called from the main thread.
 	 * The returned Image should be dropped.
 	 */
-	video::IImage* generateImage(const std::string &name);
+	video::IImage *generateImage(const std::string &name);
 
 	// Thread-safe cache of what source images are known (true = known)
 	MutexedMap<std::string, bool> m_source_image_existence;
@@ -405,8 +405,8 @@ private:
 	RequestQueue<std::string, u32, u8, u8> m_get_texture_queue;
 
 	// Textures that have been overwritten with other ones
-	// but can't be deleted because the ITexture* might still be used
-	std::vector<video::ITexture*> m_texture_trash;
+	// but can't be deleted because the ITexture * might still be used
+	std::vector<video::ITexture *> m_texture_trash;
 
 	// Maps image file names to loaded palettes.
 	std::unordered_map<std::string, Palette> m_palettes;
@@ -546,7 +546,7 @@ static void draw_crack(video::IImage *crack, video::IImage *dst,
 // Brighten image
 void brighten(video::IImage *image);
 // Parse a transform name
-u32 parseImageTransform(const std::string& s);
+u32 parseImageTransform(const std::string &s);
 // Apply transform to image dimension
 core::dimension2d<u32> imageTransformDimension(u32 transform, core::dimension2d<u32> dim);
 // Apply transform to image data
@@ -632,7 +632,7 @@ std::string TextureSource::getTextureName(u32 id)
 	return m_textureinfo_cache[id].name;
 }
 
-video::ITexture* TextureSource::getTexture(u32 id)
+video::ITexture *TextureSource::getTexture(u32 id)
 {
 	MutexAutoLock lock(m_textureinfo_cache_mutex);
 
@@ -642,7 +642,7 @@ video::ITexture* TextureSource::getTexture(u32 id)
 	return m_textureinfo_cache[id].texture;
 }
 
-video::ITexture* TextureSource::getTexture(const std::string &name, u32 *id)
+video::ITexture *TextureSource::getTexture(const std::string &name, u32 *id)
 {
 	u32 actual_id = getTextureId(name);
 	if (id){
@@ -651,12 +651,12 @@ video::ITexture* TextureSource::getTexture(const std::string &name, u32 *id)
 	return getTexture(actual_id);
 }
 
-video::ITexture* TextureSource::getTextureForMesh(const std::string &name, u32 *id)
+video::ITexture *TextureSource::getTextureForMesh(const std::string &name, u32 *id)
 {
 	return getTexture(name + "^[applyfiltersformesh", id);
 }
 
-Palette* TextureSource::getPalette(const std::string &name)
+Palette *TextureSource::getPalette(const std::string &name)
 {
 	// Only the main thread may load images
 	sanity_check(std::this_thread::get_id() == m_main_thread);
@@ -887,7 +887,7 @@ static video::IImage *createInventoryCubeImage(
 	return result;
 }
 
-video::IImage* TextureSource::generateImage(const std::string &name)
+video::IImage *TextureSource::generateImage(const std::string &name)
 {
 	// Get the base image
 
@@ -1004,7 +1004,7 @@ inline u16 get_GL_major_version()
 }
 
 video::IImage * Align2Npot2(video::IImage * image,
-		video::IVideoDriver* driver)
+		video::IVideoDriver *driver)
 {
 	if (image == NULL) {
 		return image;
@@ -2044,7 +2044,7 @@ void brighten(video::IImage *image)
 	}
 }
 
-u32 parseImageTransform(const std::string& s)
+u32 parseImageTransform(const std::string &s)
 {
 	int total_transform = 0;
 
@@ -2147,7 +2147,7 @@ void imageTransform(u32 transform, video::IImage *src, video::IImage *dst)
 	}
 }
 
-video::ITexture* TextureSource::getNormalTexture(const std::string &name)
+video::ITexture *TextureSource::getNormalTexture(const std::string &name)
 {
 	if (isKnownSourceImage("override_normal.png"))
 		return getTexture("override_normal.png");

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -78,7 +78,7 @@ public:
 
 	virtual ~ISimpleTextureSource() = default;
 
-	virtual video::ITexture* getTexture(
+	virtual video::ITexture *getTexture(
 			const std::string &name, u32 *id = nullptr) = 0;
 };
 
@@ -91,10 +91,10 @@ public:
 
 	virtual u32 getTextureId(const std::string &name)=0;
 	virtual std::string getTextureName(u32 id)=0;
-	virtual video::ITexture* getTexture(u32 id)=0;
-	virtual video::ITexture* getTexture(
+	virtual video::ITexture *getTexture(u32 id)=0;
+	virtual video::ITexture *getTexture(
 			const std::string &name, u32 *id = nullptr)=0;
-	virtual video::ITexture* getTextureForMesh(
+	virtual video::ITexture *getTextureForMesh(
 			const std::string &name, u32 *id = nullptr) = 0;
 	/*!
 	 * Returns a palette from the given texture name.
@@ -102,9 +102,9 @@ public:
 	 * destructed.
 	 * Should be called from the main thread.
 	 */
-	virtual Palette* getPalette(const std::string &name) = 0;
+	virtual Palette *getPalette(const std::string &name) = 0;
 	virtual bool isKnownSourceImage(const std::string &name)=0;
-	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
+	virtual video::ITexture *getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
@@ -118,15 +118,15 @@ public:
 
 	virtual u32 getTextureId(const std::string &name)=0;
 	virtual std::string getTextureName(u32 id)=0;
-	virtual video::ITexture* getTexture(u32 id)=0;
-	virtual video::ITexture* getTexture(
+	virtual video::ITexture *getTexture(u32 id)=0;
+	virtual video::ITexture *getTexture(
 			const std::string &name, u32 *id = nullptr)=0;
 	virtual bool isKnownSourceImage(const std::string &name)=0;
 
 	virtual void processQueue()=0;
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;
 	virtual void rebuildImagesAndTextures()=0;
-	virtual video::ITexture* getNormalTexture(const std::string &name)=0;
+	virtual video::ITexture *getNormalTexture(const std::string &name)=0;
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 	virtual video::ITexture *getShaderFlagsTexture(bool normalmap_present)=0;
 };
@@ -134,7 +134,7 @@ public:
 IWritableTextureSource *createTextureSource();
 
 #ifdef __ANDROID__
-video::IImage * Align2Npot2(video::IImage * image, irr::video::IVideoDriver* driver);
+video::IImage * Align2Npot2(video::IImage * image, irr::video::IVideoDriver *driver);
 #endif
 
 enum MaterialType{

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -155,7 +155,7 @@ public:
 	}
 	// Get closest extrusion mesh for given image dimensions
 	// Caller must drop the returned pointer
-	scene::IMesh* create(core::dimension2d<u32> dim)
+	scene::IMesh *create(core::dimension2d<u32> dim)
 	{
 		// handle non-power of two textures inefficiently without cache
 		if (!is_power_of_two(dim.Width) || !is_power_of_two(dim.Height)) {
@@ -179,7 +179,7 @@ public:
 	}
 	// Returns a 1x1x1 cube mesh with one meshbuffer (material) per face
 	// Caller must drop the returned pointer
-	scene::IMesh* createCube()
+	scene::IMesh *createCube()
 	{
 		m_cube->grab();
 		return m_cube;
@@ -504,7 +504,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 	content_t id = ndef->getId(def.name);
 
 	FATAL_ERROR_IF(!g_extrusion_mesh_cache, "Extrusion mesh cache is not yet initialized");
-	
+
 	scene::SMesh *mesh = nullptr;
 
 	// Shading is on by default

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -441,7 +441,7 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 	m_blocks_modified.insert(p);
 }
 
-void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks)
+void RemoteClient::SetBlocksNotSent(std::map<v3s16, MapBlock *> &blocks)
 {
 	m_nearest_unsent_d = 0;
 	m_nothing_to_send_pause_timer = 0;
@@ -706,7 +706,7 @@ void ClientInterface::UpdatePlayerList()
 
 			{
 				MutexAutoLock clientslock(m_clients_mutex);
-				RemoteClient* client = lockedGetClientNoEx(i);
+				RemoteClient *client = lockedGetClientNoEx(i);
 				if (client)
 					client->PrintInfo(infostream);
 			}
@@ -761,7 +761,7 @@ void ClientInterface::sendToAllCompat(NetworkPacket *pkt, NetworkPacket *legacyp
 	}
 }
 
-RemoteClient* ClientInterface::getClientNoEx(session_t peer_id, ClientState state_min)
+RemoteClient *ClientInterface::getClientNoEx(session_t peer_id, ClientState state_min)
 {
 	MutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
@@ -776,7 +776,7 @@ RemoteClient* ClientInterface::getClientNoEx(session_t peer_id, ClientState stat
 	return NULL;
 }
 
-RemoteClient* ClientInterface::lockedGetClientNoEx(session_t peer_id, ClientState state_min)
+RemoteClient *ClientInterface::lockedGetClientNoEx(session_t peer_id, ClientState state_min)
 {
 	RemoteClientMap::const_iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
@@ -831,7 +831,7 @@ void ClientInterface::DeleteClient(session_t peer_id)
 	// Handle objects
 	for (u16 id : client->m_known_objects) {
 		// Get object
-		ServerActiveObject* obj = m_env->getActiveObject(id);
+		ServerActiveObject *obj = m_env->getActiveObject(id);
 
 		if(obj && obj->m_known_by_count > 0)
 			obj->m_known_by_count--;

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -254,7 +254,7 @@ public:
 		Environment should be locked when this is called.
 		dtime is used for resetting send radius at slow interval
 	*/
-	void GetNextBlocks(ServerEnvironment *env, EmergeManager* emerge,
+	void GetNextBlocks(ServerEnvironment *env, EmergeManager *emerge,
 			float dtime, std::vector<PrioritySortedBlockTransfer> &dest);
 
 	void GotBlock(v3s16 p);
@@ -262,7 +262,7 @@ public:
 	void SentBlock(v3s16 p);
 
 	void SetBlockNotSent(v3s16 p);
-	void SetBlocksNotSent(std::map<v3s16, MapBlock*> &blocks);
+	void SetBlocksNotSent(std::map<v3s16, MapBlock *> &blocks);
 
 	/**
 	 * tell client about this block being modified right now.
@@ -420,7 +420,7 @@ private:
 	const u64 m_connection_time = porting::getTimeS();
 };
 
-typedef std::unordered_map<u16, RemoteClient*> RemoteClientMap;
+typedef std::unordered_map<u16, RemoteClient *> RemoteClientMap;
 
 class ClientInterface {
 public:
@@ -493,7 +493,7 @@ protected:
 	void lock() { m_clients_mutex.lock(); }
 	void unlock() { m_clients_mutex.unlock(); }
 
-	RemoteClientMap& getClientList() { return m_clients; }
+	RemoteClientMap &getClientList() { return m_clients; }
 
 private:
 	/* update internal player list */

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -356,9 +356,9 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		/* add object boxes to cinfo */
 
-		std::vector<ActiveObject*> objects;
+		std::vector<ActiveObject *> objects;
 #ifndef SERVER
-		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
+		ClientEnvironment *c_env = dynamic_cast<ClientEnvironment *>(env);
 		if (c_env != 0) {
 			// Calculate distance by speed, add own extent and 1.5m of tolerance
 			f32 distance = speed_f->getLength() * dtime +
@@ -370,14 +370,14 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				// Do collide with everything but itself and the parent CAO
 				if (!self || (self != clientobject.obj &&
 						self != clientobject.obj->getParent())) {
-					objects.push_back((ActiveObject*) clientobject.obj);
+					objects.push_back((ActiveObject *) clientobject.obj);
 				}
 			}
 		}
 		else
 #endif
 		{
-			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment*>(env);
+			ServerEnvironment *s_env = dynamic_cast<ServerEnvironment *>(env);
 			if (s_env != NULL) {
 				// Calculate distance by speed, add own extent and 1.5m of tolerance
 				f32 distance = speed_f->getLength() * dtime +
@@ -390,13 +390,13 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 					if (!self || (self != current &&
 							self != current->getParent())) {
-						objects.push_back((ActiveObject*)current);
+						objects.push_back((ActiveObject *)current);
 					}
 				}
 			}
 		}
 
-		for (std::vector<ActiveObject*>::const_iterator iter = objects.begin();
+		for (std::vector<ActiveObject *>::const_iterator iter = objects.begin();
 				iter != objects.end(); ++iter) {
 			ActiveObject *object = *iter;
 
@@ -475,7 +475,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		} else {
 			// Otherwise, a collision occurred.
 			NearbyCollisionInfo &nearest_info = cinfo[nearest_boxindex];
-			const aabb3f& cbox = nearest_info.box;
+			const aabb3f &cbox = nearest_info.box;
 			// Check for stairs.
 			bool step_up = (nearest_collided != 1) && // must not be Y direction
 					(movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -51,7 +51,7 @@ public:
 	ActiveObjectType getType() const
 	{ return ACTIVEOBJECT_TYPE_TEST; }
 
-	static ServerActiveObject* create(ServerEnvironment *env, v3f pos,
+	static ServerActiveObject *create(ServerEnvironment *env, v3f pos,
 			const std::string &data)
 	{
 		return new TestSAO(env, pos);
@@ -279,7 +279,7 @@ void UnitSAO::onDetach(int parent_id)
 		m_env->getScriptIface()->luaentity_on_detach_child(parent_id, this);
 }
 
-ObjectProperties* UnitSAO::accessObjectProperties()
+ObjectProperties *UnitSAO::accessObjectProperties()
 {
 	return &m_prop;
 }
@@ -342,7 +342,7 @@ void LuaEntitySAO::addedToEnvironment(u32 dtime_s)
 	}
 }
 
-ServerActiveObject* LuaEntitySAO::create(ServerEnvironment *env, v3f pos,
+ServerActiveObject *LuaEntitySAO::create(ServerEnvironment *env, v3f pos,
 		const std::string &data)
 {
 	std::string name;
@@ -1363,11 +1363,11 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 		m_env->getGameDef()->SendPlayerBreath(this);
 }
 
-Inventory* PlayerSAO::getInventory()
+Inventory *PlayerSAO::getInventory()
 {
 	return m_inventory;
 }
-const Inventory* PlayerSAO::getInventory() const
+const Inventory *PlayerSAO::getInventory() const
 {
 	return m_inventory;
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -61,7 +61,7 @@ public:
 	void removeAttachmentChild(int child_id);
 	const std::unordered_set<int> &getAttachmentChildIds();
 	ServerActiveObject *getParent() const;
-	ObjectProperties* accessObjectProperties();
+	ObjectProperties *accessObjectProperties();
 	void notifyObjectPropertiesModified();
 protected:
 	u16 m_hp = 1;
@@ -111,7 +111,7 @@ public:
 	ActiveObjectType getSendType() const
 	{ return ACTIVEOBJECT_TYPE_GENERIC; }
 	virtual void addedToEnvironment(u32 dtime_s);
-	static ServerActiveObject* create(ServerEnvironment *env, v3f pos,
+	static ServerActiveObject *create(ServerEnvironment *env, v3f pos,
 			const std::string &data);
 	void step(float dtime, bool send_recommended);
 	std::string getClientInitializationData(u16 protocol_version);
@@ -268,8 +268,8 @@ public:
 		Inventory interface
 	*/
 
-	Inventory* getInventory();
-	const Inventory* getInventory() const;
+	Inventory *getInventory();
+	const Inventory *getInventory() const;
 	InventoryLocation getInventoryLocation() const;
 	std::string getWieldList() const;
 	ItemStack getWieldedItem() const;
@@ -316,7 +316,7 @@ public:
 	{
 		m_nocheat_dig_pos = v3s16(32767, 32767, 32767);
 	}
-	LagPool& getDigPool()
+	LagPool &getDigPool()
 	{
 		return m_dig_pool;
 	}

--- a/src/craftdef.cpp
+++ b/src/craftdef.cpp
@@ -899,10 +899,10 @@ public:
 			if (col_iter == (m_craft_defs[type]).end())
 				continue;
 
-			const std::vector<CraftDefinition*> &hash_collisions = col_iter->second;
+			const std::vector<CraftDefinition *> &hash_collisions = col_iter->second;
 			// Walk crafting definitions from back to front, so that later
 			// definitions can override earlier ones.
-			for (std::vector<CraftDefinition*>::size_type
+			for (std::vector<CraftDefinition *>::size_type
 					i = hash_collisions.size(); i > 0; i--) {
 				CraftDefinition *def = hash_collisions[i - 1];
 
@@ -933,21 +933,21 @@ public:
 		return false;
 	}
 
-	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
+	virtual std::vector<CraftDefinition *> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const
 	{
-		std::vector<CraftDefinition*> recipes;
+		std::vector<CraftDefinition *> recipes;
 
 		auto vec_iter = m_output_craft_definitions.find(output.item);
 
 		if (vec_iter == m_output_craft_definitions.end())
 			return recipes;
 
-		const std::vector<CraftDefinition*> &vec = vec_iter->second;
+		const std::vector<CraftDefinition *> &vec = vec_iter->second;
 
 		recipes.reserve(limit ? MYMIN(limit, vec.size()) : vec.size());
 
-		for (std::vector<CraftDefinition*>::size_type i = vec.size();
+		for (std::vector<CraftDefinition *>::size_type i = vec.size();
 				i > 0; i--) {
 			CraftDefinition *def = vec[i - 1];
 			if (limit && recipes.size() >= limit)
@@ -965,11 +965,11 @@ public:
 		if (vec_iter == m_output_craft_definitions.end())
 			return false;
 
-		std::vector<CraftDefinition*> &vec = vec_iter->second;
+		std::vector<CraftDefinition *> &vec = vec_iter->second;
 		for (auto def : vec) {
 			// Recipes are not yet hashed at this point
-			std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
-			std::vector<CraftDefinition*> new_vec_by_input;
+			std::vector<CraftDefinition *> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
+			std::vector<CraftDefinition *> new_vec_by_input;
 			/* We will preallocate necessary memory addresses, so we don't need to reallocate them later.
 				This would save us some performance. */
 			new_vec_by_input.reserve(unhashed_inputs_vec.size());
@@ -999,10 +999,10 @@ public:
 
 		CraftInput input(craft_method, craft_grid_width, craftGetItems(recipe, gamedef));
 		// Recipes are not yet hashed at this point
-		std::vector<CraftDefinition*> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
-		std::vector<CraftDefinition*> new_vec_by_input;
+		std::vector<CraftDefinition *> &unhashed_inputs_vec = m_craft_defs[(int) CRAFT_HASH_TYPE_UNHASHED][0];
+		std::vector<CraftDefinition *> new_vec_by_input;
 		bool got_hit = false;
-		for (std::vector<CraftDefinition*>::size_type
+		for (std::vector<CraftDefinition *>::size_type
 				i = unhashed_inputs_vec.size(); i > 0; i--) {
 			CraftDefinition *def = unhashed_inputs_vec[i - 1];
 			/* If the input doesn't match the recipe definition, this recipe definition later
@@ -1016,8 +1016,8 @@ public:
 			auto vec_iter = m_output_craft_definitions.find(output.item);
 			if (vec_iter == m_output_craft_definitions.end())
 				continue;
-			std::vector<CraftDefinition*> &vec = vec_iter->second;
-			std::vector<CraftDefinition*> new_vec_by_output;
+			std::vector<CraftDefinition *> &vec = vec_iter->second;
+			std::vector<CraftDefinition *> new_vec_by_output;
 			/* We will preallocate necessary memory addresses, so we don't need
 				to reallocate them later. This would save us some performance. */
 			new_vec_by_output.reserve(vec.size());
@@ -1047,7 +1047,7 @@ public:
 		for (int type = 0; type <= craft_hash_type_max; ++type) {
 			for (auto it = m_craft_defs[type].begin();
 					it != m_craft_defs[type].end(); ++it) {
-				for (std::vector<CraftDefinition*>::size_type i = 0;
+				for (std::vector<CraftDefinition *>::size_type i = 0;
 						i < it->second.size(); i++) {
 					os << "type " << type
 						<< " hash " << it->first
@@ -1099,13 +1099,13 @@ public:
 		unhashed.clear();
 	}
 private:
-	std::vector<std::unordered_map<u64, std::vector<CraftDefinition*> > >
+	std::vector<std::unordered_map<u64, std::vector<CraftDefinition *> > >
 		m_craft_defs;
-	std::unordered_map<std::string, std::vector<CraftDefinition*> >
+	std::unordered_map<std::string, std::vector<CraftDefinition *> >
 		m_output_craft_definitions;
 };
 
-IWritableCraftDefManager* createCraftDefManager()
+IWritableCraftDefManager *createCraftDefManager()
 {
 	return new CCraftDefManager();
 }

--- a/src/craftdef.h
+++ b/src/craftdef.h
@@ -391,7 +391,7 @@ public:
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
 			std::vector<ItemStack> &output_replacements,
 			bool decrementInput, IGameDef *gamedef) const=0;
-	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
+	virtual std::vector<CraftDefinition *> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 
 	// Print crafting recipes for debugging
@@ -408,7 +408,7 @@ public:
 	virtual bool getCraftResult(CraftInput &input, CraftOutput &output,
 			std::vector<ItemStack> &output_replacements,
 			bool decrementInput, IGameDef *gamedef) const=0;
-	virtual std::vector<CraftDefinition*> getCraftRecipes(CraftOutput &output,
+	virtual std::vector<CraftDefinition *> getCraftRecipes(CraftOutput &output,
 			IGameDef *gamedef, unsigned limit=0) const=0;
 
 	virtual bool clearCraftRecipesByOutput(const CraftOutput &output, IGameDef *gamedef) = 0;
@@ -429,4 +429,4 @@ public:
 	virtual void initHashes(IGameDef *gamedef) = 0;
 };
 
-IWritableCraftDefManager* createCraftDefManager();
+IWritableCraftDefManager *createCraftDefManager();

--- a/src/database/database-leveldb.cpp
+++ b/src/database/database-leveldb.cpp
@@ -89,7 +89,7 @@ bool Database_LevelDB::deleteBlock(const v3s16 &pos)
 
 void Database_LevelDB::listAllLoadableBlocks(std::vector<v3s16> &dst)
 {
-	leveldb::Iterator* it = m_database->NewIterator(leveldb::ReadOptions());
+	leveldb::Iterator *it = m_database->NewIterator(leveldb::ReadOptions());
 	for (it->SeekToFirst(); it->Valid(); it->Next()) {
 		dst.push_back(getIntegerAsBlock(stoi64(it->key().ToString())));
 	}
@@ -98,4 +98,3 @@ void Database_LevelDB::listAllLoadableBlocks(std::vector<v3s16> &dst)
 }
 
 #endif // USE_LEVELDB
-

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -447,7 +447,7 @@ bool PlayerDatabasePostgreSQL::playerDataExists(const std::string &playername)
 
 void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 {
-	PlayerSAO* sao = player->getPlayerSAO();
+	PlayerSAO *sao = player->getPlayerSAO();
 	if (!sao)
 		return;
 
@@ -470,7 +470,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 		breath.c_str()
 	};
 
-	const char* rmvalues[] = { player->getName() };
+	const char *rmvalues[] = { player->getName() };
 	beginSave();
 
 	if (getPGVersion() < 90500) {
@@ -486,14 +486,14 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 	execPrepared("remove_player_inventories", 1, rmvalues);
 	execPrepared("remove_player_inventory_items", 1, rmvalues);
 
-	std::vector<const InventoryList*> inventory_lists = sao->getInventory()->getLists();
+	std::vector<const InventoryList *> inventory_lists = sao->getInventory()->getLists();
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
-		const InventoryList* list = inventory_lists[i];
+		const InventoryList *list = inventory_lists[i];
 		const std::string &name = list->getName();
 		std::string width = itos(list->getWidth()),
 			inv_id = itos(i), lsize = itos(list->getSize());
 
-		const char* inv_values[] = {
+		const char *inv_values[] = {
 			player->getName(),
 			inv_id.c_str(),
 			width.c_str(),
@@ -507,7 +507,7 @@ void PlayerDatabasePostgreSQL::savePlayer(RemotePlayer *player)
 			list->getItem(j).serialize(os);
 			std::string itemStr = os.str(), slotId = itos(j);
 
-			const char* invitem_values[] = {
+			const char *invitem_values[] = {
 				player->getName(),
 				inv_id.c_str(),
 				slotId.c_str(),
@@ -564,14 +564,14 @@ bool PlayerDatabasePostgreSQL::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 	int resultCount = PQntuples(results);
 
 	for (int row = 0; row < resultCount; ++row) {
-		InventoryList* invList = player->inventory.
+		InventoryList *invList = player->inventory.
 			addList(PQgetvalue(results, row, 2), pg_to_uint(results, row, 3));
 		invList->setWidth(pg_to_uint(results, row, 1));
 
 		u32 invId = pg_to_uint(results, row, 0);
 		std::string invIdStr = itos(invId);
 
-		const char* values2[] = {
+		const char *values2[] = {
 			player->getName(),
 			invIdStr.c_str()
 		};

--- a/src/database/database-postgresql.h
+++ b/src/database/database-postgresql.h
@@ -70,7 +70,7 @@ protected:
 		bool clear = true, bool nobinary = true)
 	{
 		return checkResults(PQexecPrepared(m_conn, stmtName, paramsNumber,
-			(const char* const*) params, paramsLengths, paramsFormats,
+			(const char * const *) params, paramsLengths, paramsFormats,
 			nobinary ? 1 : 0), clear);
 	}
 

--- a/src/database/database-sqlite3.cpp
+++ b/src/database/database-sqlite3.cpp
@@ -448,7 +448,7 @@ bool PlayerDatabaseSQLite3::playerDataExists(const std::string &name)
 
 void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 {
-	PlayerSAO* sao = player->getPlayerSAO();
+	PlayerSAO *sao = player->getPlayerSAO();
 	sanity_check(sao);
 
 	const v3f &pos = sao->getBasePosition();
@@ -490,9 +490,9 @@ void PlayerDatabaseSQLite3::savePlayer(RemotePlayer *player)
 	sqlite3_vrfy(sqlite3_step(m_stmt_player_remove_inventory_items), SQLITE_DONE);
 	sqlite3_reset(m_stmt_player_remove_inventory_items);
 
-	std::vector<const InventoryList*> inventory_lists = sao->getInventory()->getLists();
+	std::vector<const InventoryList *> inventory_lists = sao->getInventory()->getLists();
 	for (u16 i = 0; i < inventory_lists.size(); i++) {
-		const InventoryList* list = inventory_lists[i];
+		const InventoryList *list = inventory_lists[i];
 
 		str_to_sqlite(m_stmt_player_add_inventory, 1, player->getName());
 		int_to_sqlite(m_stmt_player_add_inventory, 2, i);

--- a/src/database/database-sqlite3.h
+++ b/src/database/database-sqlite3.h
@@ -71,7 +71,7 @@ protected:
 
 	inline std::string sqlite_to_string(sqlite3_stmt *s, int iCol)
 	{
-		const char* text = reinterpret_cast<const char*>(sqlite3_column_text(s, iCol));
+		const char *text = reinterpret_cast<const char *>(sqlite3_column_text(s, iCol));
 		return std::string(text ? text : "");
 	}
 

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -50,16 +50,16 @@ class IGameDef
 public:
 	// These are thread-safe IF they are not edited while running threads.
 	// Thus, first they are set up and then they are only read.
-	virtual IItemDefManager* getItemDefManager()=0;
-	virtual const NodeDefManager* getNodeDefManager()=0;
-	virtual ICraftDefManager* getCraftDefManager()=0;
+	virtual IItemDefManager *getItemDefManager()=0;
+	virtual const NodeDefManager *getNodeDefManager()=0;
+	virtual ICraftDefManager *getCraftDefManager()=0;
 
 	// Used for keeping track of names/ids of unknown nodes
 	virtual u16 allocateUnknownNodeId(const std::string &name)=0;
 
 	// Only usable on the server, and NOT thread-safe. It is usable from the
 	// environment thread.
-	virtual IRollbackManager* getRollbackManager() { return NULL; }
+	virtual IRollbackManager *getRollbackManager() { return NULL; }
 
 	// Shorthands
 	IItemDefManager  *idef()     { return getItemDefManager(); }

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -39,7 +39,7 @@ static std::map<std::wstring, std::wstring> glb_supported_locales;
 /******************************************************************************/
 BOOL CALLBACK UpdateLocaleCallback(LPTSTR pStr)
 {
-	char* endptr = 0;
+	char *endptr = 0;
 	int LOCALEID = strtol(pStr, &endptr,16);
 
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
@@ -78,7 +78,7 @@ BOOL CALLBACK UpdateLocaleCallback(LPTSTR pStr)
 }
 
 /******************************************************************************/
-const char* MSVC_LocaleLookup(const char* raw_shortname) {
+const char *MSVC_LocaleLookup(const char *raw_shortname) {
 
 	/* NULL is used to read locale only so we need to return it too */
 	if (raw_shortname == NULL) return NULL;

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -42,12 +42,12 @@ inline u32 clamp_u8(s32 value)
 
 
 GUIChatConsole::GUIChatConsole(
-		gui::IGUIEnvironment* env,
-		gui::IGUIElement* parent,
+		gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent,
 		s32 id,
-		ChatBackend* backend,
-		Client* client,
-		IMenuManager* menumgr
+		ChatBackend *backend,
+		Client *client,
+		IMenuManager *menumgr
 ):
 	IGUIElement(gui::EGUIET_ELEMENT, env, parent, id,
 			core::rect<s32>(0,0,100,100)),
@@ -141,7 +141,7 @@ f32 GUIChatConsole::getDesiredHeight() const
 
 void GUIChatConsole::replaceAndAddToHistory(std::wstring line)
 {
-	ChatPrompt& prompt = m_chat_backend->getPrompt();
+	ChatPrompt &prompt = m_chat_backend->getPrompt();
 	prompt.addToHistory(prompt.getLine());
 	prompt.replace(line);
 }
@@ -176,7 +176,7 @@ void GUIChatConsole::draw()
 	if(!IsVisible)
 		return;
 
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	// Check screen size
 	v2u32 screensize = driver->getScreenSize();
@@ -279,7 +279,7 @@ void GUIChatConsole::animate(u32 msec)
 
 void GUIChatConsole::drawBackground()
 {
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 	if (m_background != NULL)
 	{
 		core::rect<s32> sourcerect(0, -m_height, m_screensize.X, 0);
@@ -305,10 +305,10 @@ void GUIChatConsole::drawText()
 	if (m_font == NULL)
 		return;
 
-	ChatBuffer& buf = m_chat_backend->getConsoleBuffer();
+	ChatBuffer &buf = m_chat_backend->getConsoleBuffer();
 	for (u32 row = 0; row < buf.getRows(); ++row)
 	{
-		const ChatFormattedLine& line = buf.getFormattedLine(row);
+		const ChatFormattedLine &line = buf.getFormattedLine(row);
 		if (line.fragments.empty())
 			continue;
 
@@ -356,7 +356,7 @@ void GUIChatConsole::drawPrompt()
 	s32 line_height = m_fontsize.Y;
 	s32 y = row * line_height + m_height - m_desired_height;
 
-	ChatPrompt& prompt = m_chat_backend->getPrompt();
+	ChatPrompt &prompt = m_chat_backend->getPrompt();
 	std::wstring prompt_text = prompt.getVisiblePortion();
 
 	// FIXME Draw string at once, not character by character
@@ -383,7 +383,7 @@ void GUIChatConsole::drawPrompt()
 		if (cursor_pos >= 0)
 		{
 			s32 cursor_len = prompt.getCursorLength();
-			video::IVideoDriver* driver = Environment->getVideoDriver();
+			video::IVideoDriver *driver = Environment->getVideoDriver();
 			s32 x = (1 + cursor_pos) * m_fontsize.X;
 			core::rect<s32> destrect(
 				x,
@@ -401,7 +401,7 @@ void GUIChatConsole::drawPrompt()
 
 }
 
-bool GUIChatConsole::OnEvent(const SEvent& event)
+bool GUIChatConsole::OnEvent(const SEvent &event)
 {
 
 	ChatPrompt &prompt = m_chat_backend->getPrompt();
@@ -560,7 +560,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 			const c8 *text = os_operator->getTextFromClipboard();
 			if (!text)
 				return true;
-			std::basic_string<unsigned char> str((const unsigned char*)text);
+			std::basic_string<unsigned char> str((const unsigned char *)text);
 			prompt.input(std::wstring(str.begin(), str.end()));
 			return true;
 		}
@@ -639,4 +639,3 @@ void GUIChatConsole::setVisible(bool visible)
 		recalculateConsolePosition();
 	}
 }
-

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -29,12 +29,12 @@ class Client;
 class GUIChatConsole : public gui::IGUIElement
 {
 public:
-	GUIChatConsole(gui::IGUIEnvironment* env,
-			gui::IGUIElement* parent,
+	GUIChatConsole(gui::IGUIEnvironment *env,
+			gui::IGUIElement *parent,
 			s32 id,
-			ChatBackend* backend,
-			Client* client,
-			IMenuManager* menumgr);
+			ChatBackend *backend,
+			Client *client,
+			IMenuManager *menumgr);
 	virtual ~GUIChatConsole();
 
 	// Open the console (height = desired fraction of screen size)
@@ -72,9 +72,9 @@ public:
 	// Irrlicht draw method
 	virtual void draw();
 
-	bool canTakeFocus(gui::IGUIElement* element) { return false; }
+	bool canTakeFocus(gui::IGUIElement *element) { return false; }
 
-	virtual bool OnEvent(const SEvent& event);
+	virtual bool OnEvent(const SEvent &event);
 
 	virtual void setVisible(bool visible);
 
@@ -89,9 +89,9 @@ private:
 	void drawPrompt();
 
 private:
-	ChatBackend* m_chat_backend;
-	Client* m_client;
-	IMenuManager* m_menumgr;
+	ChatBackend *m_chat_backend;
+	Client *m_client;
+	IMenuManager *m_menumgr;
 
 	// current screen size
 	v2u32 m_screensize;

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -25,8 +25,8 @@ numerical
 
 
 //! constructor
-GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t* text, bool border,
-	IGUIEnvironment* environment, IGUIElement* parent, s32 id,
+GUIEditBoxWithScrollBar::GUIEditBoxWithScrollBar(const wchar_t *text, bool border,
+	IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 	const core::rect<s32>& rectangle, bool writable, bool has_vscrollbar)
 	: IGUIEditBox(environment, parent, id, rectangle), m_mouse_marking(false),
 	m_border(border), m_background(true), m_override_color_enabled(false), m_mark_begin(0), m_mark_end(0),
@@ -81,7 +81,7 @@ GUIEditBoxWithScrollBar::~GUIEditBoxWithScrollBar()
 
 
 //! Sets another skin independent font.
-void GUIEditBoxWithScrollBar::setOverrideFont(IGUIFont* font)
+void GUIEditBoxWithScrollBar::setOverrideFont(IGUIFont *font)
 {
 	if (m_override_font == font)
 		return;
@@ -98,17 +98,17 @@ void GUIEditBoxWithScrollBar::setOverrideFont(IGUIFont* font)
 }
 
 //! Gets the override font (if any)
-IGUIFont * GUIEditBoxWithScrollBar::getOverrideFont() const
+IGUIFont *GUIEditBoxWithScrollBar::getOverrideFont() const
 {
 	return m_override_font;
 }
 
 //! Get the font which is used right now for drawing
-IGUIFont* GUIEditBoxWithScrollBar::getActiveFont() const
+IGUIFont *GUIEditBoxWithScrollBar::getActiveFont() const
 {
 	if (m_override_font)
 		return m_override_font;
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (skin)
 		return skin->getFont();
 	return 0;
@@ -218,7 +218,7 @@ void GUIEditBoxWithScrollBar::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_A
 
 
 //! called if an event happened.
-bool GUIEditBoxWithScrollBar::OnEvent(const SEvent& event)
+bool GUIEditBoxWithScrollBar::OnEvent(const SEvent &event)
 {
 	if (isEnabled()) {
 		switch (event.EventType)
@@ -248,7 +248,7 @@ bool GUIEditBoxWithScrollBar::OnEvent(const SEvent& event)
 }
 
 
-bool GUIEditBoxWithScrollBar::processKey(const SEvent& event)
+bool GUIEditBoxWithScrollBar::processKey(const SEvent &event)
 {
 	if (!m_writable) {
 		return false;
@@ -325,7 +325,7 @@ bool GUIEditBoxWithScrollBar::processKey(const SEvent& event)
 				const s32 realmend = m_mark_begin < m_mark_end ? m_mark_end : m_mark_begin;
 
 				// add new character
-				const c8* p = m_operator->getTextFromClipboard();
+				const c8 *p = m_operator->getTextFromClipboard();
 				if (p) {
 					if (m_mark_begin == m_mark_end) {
 						// insert text
@@ -659,7 +659,7 @@ void GUIEditBoxWithScrollBar::draw()
 
 	const bool focus = Environment->hasFocus(this);
 
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
 
@@ -690,7 +690,7 @@ void GUIEditBoxWithScrollBar::draw()
 
 	// draw the text
 
-	IGUIFont* font = getActiveFont();
+	IGUIFont *font = getActiveFont();
 
 	s32 cursor_line = 0;
 	s32 charcursorpos = 0;
@@ -840,7 +840,7 @@ void GUIEditBoxWithScrollBar::draw()
 
 
 //! Sets the new caption of this element.
-void GUIEditBoxWithScrollBar::setText(const wchar_t* text)
+void GUIEditBoxWithScrollBar::setText(const wchar_t *text)
 {
 	Text = text;
 	if (u32(m_cursor_pos) > Text.size())
@@ -904,7 +904,7 @@ u32 GUIEditBoxWithScrollBar::getMax() const
 }
 
 
-bool GUIEditBoxWithScrollBar::processMouse(const SEvent& event)
+bool GUIEditBoxWithScrollBar::processMouse(const SEvent &event)
 {
 	switch (event.MouseInput.Event)
 	{
@@ -966,7 +966,7 @@ bool GUIEditBoxWithScrollBar::processMouse(const SEvent& event)
 
 s32 GUIEditBoxWithScrollBar::getCursorPos(s32 x, s32 y)
 {
-	IGUIFont* font = getActiveFont();
+	IGUIFont *font = getActiveFont();
 
 	const u32 line_count = (m_word_wrap || m_multiline) ? m_broken_text.size() : 1;
 
@@ -1016,7 +1016,7 @@ void GUIEditBoxWithScrollBar::breakText()
 	m_broken_text.clear(); // need to reallocate :/
 	m_broken_text_positions.clear();
 
-	IGUIFont* font = getActiveFont();
+	IGUIFont *font = getActiveFont();
 	if (!font)
 		return;
 
@@ -1118,7 +1118,7 @@ void GUIEditBoxWithScrollBar::setTextRect(s32 line)
 	if (line < 0)
 		return;
 
-	IGUIFont* font = getActiveFont();
+	IGUIFont *font = getActiveFont();
 	if (!font)
 		return;
 
@@ -1237,10 +1237,10 @@ void GUIEditBoxWithScrollBar::calculateScrollPos()
 	if (!m_autoscroll)
 		return;
 
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
-	IGUIFont* font = m_override_font ? m_override_font : skin->getFont();
+	IGUIFont *font = m_override_font ? m_override_font : skin->getFont();
 	if (!font)
 		return;
 
@@ -1254,7 +1254,7 @@ void GUIEditBoxWithScrollBar::calculateScrollPos()
 	// NOTE: Calculations different to vertical scrolling because setTextRect interprets VAlign relative to line but HAlign not relative to row
 	{
 		// get cursor position
-		IGUIFont* font = getActiveFont();
+		IGUIFont *font = getActiveFont();
 		if (!font)
 			return;
 
@@ -1468,7 +1468,7 @@ void GUIEditBoxWithScrollBar::setBackgroundColor(const video::SColor &bg_color)
 }
 
 //! Writes attributes of the element.
-void GUIEditBoxWithScrollBar::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options = 0) const
+void GUIEditBoxWithScrollBar::serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options = 0) const
 {
 	// IGUIEditBox::serializeAttributes(out,options);
 
@@ -1494,7 +1494,7 @@ void GUIEditBoxWithScrollBar::serializeAttributes(io::IAttributes* out, io::SAtt
 
 
 //! Reads attributes of the element
-void GUIEditBoxWithScrollBar::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options = 0)
+void GUIEditBoxWithScrollBar::deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options = 0)
 {
 	IGUIEditBox::deserializeAttributes(in, options);
 

--- a/src/gui/guiEditBoxWithScrollbar.h
+++ b/src/gui/guiEditBoxWithScrollbar.h
@@ -18,24 +18,24 @@ class GUIEditBoxWithScrollBar : public IGUIEditBox
 public:
 
 	//! constructor
-	GUIEditBoxWithScrollBar(const wchar_t* text, bool border, IGUIEnvironment* environment,
-		IGUIElement* parent, s32 id, const core::rect<s32>& rectangle,
+	GUIEditBoxWithScrollBar(const wchar_t *text, bool border, IGUIEnvironment *environment,
+		IGUIElement *parent, s32 id, const core::rect<s32>& rectangle,
 		bool writable = true, bool has_vscrollbar = true);
 
 	//! destructor
 	virtual ~GUIEditBoxWithScrollBar();
 
 	//! Sets another skin independent font.
-	virtual void setOverrideFont(IGUIFont* font = 0);
+	virtual void setOverrideFont(IGUIFont *font = 0);
 
 	//! Gets the override font (if any)
 	/** \return The override font (may be 0) */
-	virtual IGUIFont* getOverrideFont() const;
+	virtual IGUIFont *getOverrideFont() const;
 
 	//! Get the font which is used right now for drawing
 	/** Currently this is the override font when one is set and the
 	font of the active skin otherwise */
-	virtual IGUIFont* getActiveFont() const;
+	virtual IGUIFont *getActiveFont() const;
 
 	//! Sets another color for the text.
 	virtual void setOverrideColor(video::SColor color);
@@ -89,13 +89,13 @@ public:
 	virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical);
 
 	//! called if an event happened.
-	virtual bool OnEvent(const SEvent& event);
+	virtual bool OnEvent(const SEvent &event);
 
 	//! draws the element and its children
 	virtual void draw();
 
 	//! Sets the new caption of this element.
-	virtual void setText(const wchar_t* text);
+	virtual void setText(const wchar_t *text);
 
 	//! Sets the maximum amount of characters which may be entered in the box.
 	//! \param max: Maximum amount of characters. If 0, the character amount is
@@ -116,17 +116,17 @@ public:
 
 	//! Updates the absolute position, splits text if required
 	virtual void updateAbsolutePosition();
-	
+
 	virtual void setWritable(bool writable);
 
 	//! Change the background color
 	virtual void setBackgroundColor(const video::SColor &bg_color);
 
 	//! Writes attributes of the element.
-	virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;
+	virtual void serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options) const;
 
 	//! Reads attributes of the element
-	virtual void deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options);
+	virtual void deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options);
 
 	virtual bool isDrawBackgroundEnabled() const;
 	virtual bool isDrawBorderEnabled() const;
@@ -157,8 +157,8 @@ protected:
 	//! update the vertical scrollBar (visibilty & position)
 	void updateVScrollBar();
 
-	bool processKey(const SEvent& event);
-	bool processMouse(const SEvent& event);
+	bool processKey(const SEvent &event);
+	bool processMouse(const SEvent &event);
 	s32 getCursorPos(s32 x, s32 y);
 
 	bool m_mouse_marking;
@@ -170,7 +170,7 @@ protected:
 
 	video::SColor m_override_color;
 	gui::IGUIFont *m_override_font, *m_last_break_font;
-	IOSOperator* m_operator;
+	IOSOperator *m_operator;
 
 	u32 m_blink_start_time;
 	s32 m_cursor_pos;
@@ -196,4 +196,3 @@ protected:
 
 
 #endif // GUIEDITBOXWITHSCROLLBAR_HEADER
-

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -395,7 +395,7 @@ void GUIEngine::drawBackground(video::IVideoDriver *driver)
 {
 	v2u32 screensize = driver->getScreenSize();
 
-	video::ITexture* texture = m_textures[TEX_LAYER_BACKGROUND].texture;
+	video::ITexture *texture = m_textures[TEX_LAYER_BACKGROUND].texture;
 
 	/* If no texture, draw background of solid color */
 	if(!texture){
@@ -437,7 +437,7 @@ void GUIEngine::drawOverlay(video::IVideoDriver *driver)
 {
 	v2u32 screensize = driver->getScreenSize();
 
-	video::ITexture* texture = m_textures[TEX_LAYER_OVERLAY].texture;
+	video::ITexture *texture = m_textures[TEX_LAYER_OVERLAY].texture;
 
 	/* If no texture, draw nothing */
 	if(!texture)
@@ -456,7 +456,7 @@ void GUIEngine::drawHeader(video::IVideoDriver *driver)
 {
 	core::dimension2d<u32> screensize = driver->getScreenSize();
 
-	video::ITexture* texture = m_textures[TEX_LAYER_HEADER].texture;
+	video::ITexture *texture = m_textures[TEX_LAYER_HEADER].texture;
 
 	/* If no texture, draw nothing */
 	if(!texture)
@@ -490,7 +490,7 @@ void GUIEngine::drawFooter(video::IVideoDriver *driver)
 {
 	core::dimension2d<u32> screensize = driver->getScreenSize();
 
-	video::ITexture* texture = m_textures[TEX_LAYER_FOOTER].texture;
+	video::ITexture *texture = m_textures[TEX_LAYER_FOOTER].texture;
 
 	/* If no texture, draw nothing */
 	if(!texture)
@@ -611,4 +611,3 @@ unsigned int GUIEngine::queueAsync(const std::string &serialized_func,
 {
 	return m_script->queueAsync(serialized_func, serialized_params);
 }
-

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -67,7 +67,7 @@ public:
 	 * default constructor
 	 * @param engine the engine data is transmitted for further processing
 	 */
-	TextDestGuiEngine(GUIEngine* engine) : m_engine(engine) {};
+	TextDestGuiEngine(GUIEngine *engine) : m_engine(engine) {};
 
 	/**
 	 * receive fields transmitted by guiFormSpecMenu

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -152,7 +152,7 @@ void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
 
 void GUIFormSpecMenu::removeChildren()
 {
-	const core::list<gui::IGUIElement*> &children = getChildren();
+	const core::list<gui::IGUIElement *> &children = getChildren();
 
 	while(!children.empty()) {
 		(*children.getLast())->remove();
@@ -176,10 +176,10 @@ void GUIFormSpecMenu::setInitialFocus()
 	// 5. first focusable (not statictext, not tabheader)
 	// 6. first child element
 
-	core::list<gui::IGUIElement*> children = getChildren();
+	core::list<gui::IGUIElement *> children = getChildren();
 
 	// in case "children" contains any NULL elements, remove them
-	for (core::list<gui::IGUIElement*>::Iterator it = children.begin();
+	for (core::list<gui::IGUIElement *>::Iterator it = children.begin();
 			it != children.end();) {
 		if (*it)
 			++it;
@@ -213,7 +213,7 @@ void GUIFormSpecMenu::setInitialFocus()
 	}
 
 	// 4. last button
-	for (core::list<gui::IGUIElement*>::Iterator it = children.getLast();
+	for (core::list<gui::IGUIElement *>::Iterator it = children.getLast();
 			it != children.end(); --it) {
 		if ((*it)->getType() == gui::EGUIET_BUTTON) {
 			Environment->setFocus(*it);
@@ -237,7 +237,7 @@ void GUIFormSpecMenu::setInitialFocus()
 		Environment->setFocus(*(children.begin()));
 }
 
-GUITable* GUIFormSpecMenu::getTable(const std::string &tablename)
+GUITable *GUIFormSpecMenu::getTable(const std::string &tablename)
 {
 	for (auto &table : m_tables) {
 		if (tablename == table.first.fname)
@@ -270,7 +270,7 @@ v2s32 GUIFormSpecMenu::getElementBasePos(bool absolute,
 	return v2s32(pos_f.X, pos_f.Y);
 }
 
-void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseSize(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,',');
 
@@ -297,7 +297,7 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 	errorstream<< "Invalid size element (" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseContainer(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ',');
 
@@ -313,7 +313,7 @@ void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &elemen
 	errorstream<< "Invalid container start element (" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseContainerEnd(parserData* data)
+void GUIFormSpecMenu::parseContainerEnd(parserData *data)
 {
 	if (container_stack.empty()) {
 		errorstream<< "Invalid container end element, no matching container start element"  << std::endl;
@@ -323,7 +323,7 @@ void GUIFormSpecMenu::parseContainerEnd(parserData* data)
 	}
 }
 
-void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 {
 	if (m_client == 0) {
 		warningstream<<"invalid use of 'list' with m_client==0"<<std::endl;
@@ -375,7 +375,7 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 	errorstream<< "Invalid list element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseListRing(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseListRing(parserData *data, const std::string &element)
 {
 	if (m_client == 0) {
 		errorstream << "WARNING: invalid use of 'listring' with m_client==0" << std::endl;
@@ -413,7 +413,7 @@ void GUIFormSpecMenu::parseListRing(parserData* data, const std::string &element
 		<< m_inventorylists.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseCheckbox(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -458,7 +458,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 
 		spec.ftype = f_CheckBox;
 
-		gui::IGUICheckBox* e = Environment->addCheckBox(fselected, rect, this,
+		gui::IGUICheckBox *e = Environment->addCheckBox(fselected, rect, this,
 					spec.fid, spec.flabel.c_str());
 
 		if (spec.fname == data->focused_fieldname) {
@@ -472,7 +472,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 	errorstream<< "Invalid checkbox element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseScrollBar(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -513,7 +513,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 		spec.ftype = f_ScrollBar;
 		spec.send  = true;
-		gui::IGUIScrollBar* e =
+		gui::IGUIScrollBar *e =
 				Environment->addScrollBar(is_horizontal,rect,this,spec.fid);
 
 		e->setMax(1000);
@@ -529,7 +529,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 	errorstream<< "Invalid scrollbar element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseImage(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -570,7 +570,7 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 	errorstream<< "Invalid image element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseItemImage(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -597,7 +597,7 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 	errorstream<< "Invalid ItemImage element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
+void GUIFormSpecMenu::parseButton(parserData *data, const std::string &element,
 		const std::string &type)
 {
 	std::vector<std::string> parts = split(element,';');
@@ -636,7 +636,7 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		spec.ftype = f_Button;
 		if(type == "button_exit")
 			spec.is_exit = true;
-		gui::IGUIButton* e = Environment->addButton(rect, this, spec.fid,
+		gui::IGUIButton *e = Environment->addButton(rect, this, spec.fid,
 				spec.flabel.c_str());
 
 		if (spec.fname == data->focused_fieldname) {
@@ -649,7 +649,7 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 	errorstream<< "Invalid button element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBackground(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -688,7 +688,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 	errorstream<< "Invalid background element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseTableOptions(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTableOptions(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -700,7 +700,7 @@ void GUIFormSpecMenu::parseTableOptions(parserData* data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTableColumns(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTableColumns(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -720,7 +720,7 @@ void GUIFormSpecMenu::parseTableColumns(parserData* data, const std::string &ele
 	}
 }
 
-void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTable(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -784,7 +784,7 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 	errorstream<< "Invalid table element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTextList(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -853,7 +853,7 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 }
 
 
-void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseDropDown(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -923,7 +923,7 @@ void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string
 	}
 }
 
-void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parsePwdField(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1063,7 +1063,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	}
 }
 
-void GUIFormSpecMenu::parseSimpleField(parserData* data,
+void GUIFormSpecMenu::parseSimpleField(parserData *data,
 		std::vector<std::string> &parts)
 {
 	std::string name = parts[0];
@@ -1108,7 +1108,7 @@ void GUIFormSpecMenu::parseSimpleField(parserData* data,
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& parts,
+void GUIFormSpecMenu::parseTextArea(parserData *data, std::vector<std::string>& parts,
 		const std::string &type)
 {
 
@@ -1170,7 +1170,7 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 	m_fields.push_back(spec);
 }
 
-void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
+void GUIFormSpecMenu::parseField(parserData *data, const std::string &element,
 		const std::string &type)
 {
 	std::vector<std::string> parts = split(element,';');
@@ -1189,7 +1189,7 @@ void GUIFormSpecMenu::parseField(parserData* data, const std::string &element,
 	errorstream<< "Invalid field element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseLabel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1243,7 +1243,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	errorstream<< "Invalid label element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseVertLabel(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1291,7 +1291,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 	errorstream<< "Invalid vertlabel element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &element,
+void GUIFormSpecMenu::parseImageButton(parserData *data, const std::string &element,
 		const std::string &type)
 {
 	std::vector<std::string> parts = split(element,';');
@@ -1378,7 +1378,7 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 	errorstream<< "Invalid imagebutton element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTabHeader(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1454,7 +1454,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 			<< element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseItemImageButton(parserData *data, const std::string &element)
 {
 
 	if (m_client == 0) {
@@ -1525,7 +1525,7 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	errorstream<< "Invalid ItemImagebutton element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBox(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1558,7 +1558,7 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 	errorstream<< "Invalid Box element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1578,7 +1578,7 @@ void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &
 			<< std::endl;
 }
 
-void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseListColors(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
@@ -1606,7 +1606,7 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 	errorstream<< "Invalid listcolors element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseTooltip(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 	if (parts.size() < 2) {
@@ -1683,7 +1683,7 @@ bool GUIFormSpecMenu::parseVersionDirect(const std::string &data)
 	return false;
 }
 
-bool GUIFormSpecMenu::parseSizeDirect(parserData* data, const std::string &element)
+bool GUIFormSpecMenu::parseSizeDirect(parserData *data, const std::string &element)
 {
 	if (element.empty())
 		return false;
@@ -1776,7 +1776,7 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 			<< "'" << std::endl;
 }
 
-void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseElement(parserData *data, const std::string &element)
 {
 	//some prechecks
 	if (element.empty())
@@ -2292,7 +2292,7 @@ bool GUIFormSpecMenu::getAndroidUIInput()
 		if (iter->fname != fieldname) {
 			continue;
 		}
-		IGUIElement* tochange = getElementFromId(iter->fid);
+		IGUIElement *tochange = getElementFromId(iter->fid);
 
 		if (tochange == 0) {
 			return false;
@@ -2334,7 +2334,7 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		bool &item_hovered)
 {
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	Inventory *inv = m_invmgr->getInventory(s.inventoryloc);
 	if(!inv){
@@ -2442,7 +2442,7 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 
 void GUIFormSpecMenu::drawSelectedItem()
 {
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	if (!m_selected_item) {
 		drawItemStack(driver, m_font, ItemStack(),
@@ -2474,14 +2474,14 @@ void GUIFormSpecMenu::drawMenu()
 		}
 	}
 
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 	sanity_check(skin != NULL);
 	gui::IGUIFont *old_font = skin->getFont();
 	skin->setFont(m_font);
 
 	updateSelectedItem();
 
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	v2u32 screenSize = driver->getScreenSize();
 	core::rect<s32> allbg(0, 0, screenSize.X, screenSize.Y);
@@ -2886,7 +2886,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 					IGUIElement * element = getElementFromId(s.fid);
 					gui::IGUIComboBox *e = NULL;
 					if ((element) && (element->getType() == gui::EGUIET_COMBO_BOX)) {
-						e = static_cast<gui::IGUIComboBox*>(element);
+						e = static_cast<gui::IGUIComboBox *>(element);
 					}
 					s32 selected = e->getSelected();
 					if (selected >= 0) {
@@ -2918,7 +2918,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 					IGUIElement * element = getElementFromId(s.fid);
 					gui::IGUICheckBox *e = NULL;
 					if ((element) && (element->getType() == gui::EGUIET_CHECK_BOX)) {
-						e = static_cast<gui::IGUICheckBox*>(element);
+						e = static_cast<gui::IGUICheckBox *>(element);
 					}
 
 					if (e != 0) {
@@ -2934,7 +2934,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 					IGUIElement * element = getElementFromId(s.fid);
 					gui::IGUIScrollBar *e = NULL;
 					if ((element) && (element->getType() == gui::EGUIET_SCROLL_BAR)) {
-						e = static_cast<gui::IGUIScrollBar*>(element);
+						e = static_cast<gui::IGUIScrollBar *>(element);
 					}
 
 					if (e != 0) {
@@ -2948,7 +2948,7 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 				}
 				else
 				{
-					IGUIElement* e = getElementFromId(s.fid);
+					IGUIElement *e = getElementFromId(s.fid);
 					if(e != NULL) {
 						fields[name] = wide_to_utf8(e->getText());
 					}
@@ -2971,7 +2971,7 @@ static bool isChild(gui::IGUIElement * tocheck, gui::IGUIElement * parent)
 	return false;
 }
 
-bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
+bool GUIFormSpecMenu::preprocessEvent(const SEvent &event)
 {
 	// The IGUITabControl renders visually using the skin's selected
 	// font, which we override for the duration of form drawing,
@@ -2988,7 +2988,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 				core::position2d<s32>(x, y));
 		if (hovered && isMyChild(hovered) &&
 				hovered->getType() == gui::EGUIET_TAB_CONTROL) {
-			gui::IGUISkin* skin = Environment->getSkin();
+			gui::IGUISkin *skin = Environment->getSkin();
 			sanity_check(skin != NULL);
 			gui::IGUIFont *old_font = skin->getFont();
 			skin->setFont(m_font);
@@ -3104,7 +3104,7 @@ bool GUIFormSpecMenu::DoubleClickDetection(const SEvent event)
 			return false;
 		}
 
-		SEvent* translated = new SEvent();
+		SEvent *translated = new SEvent();
 		assert(translated != 0);
 		//translate doubleclick to escape
 		memset(translated, 0, sizeof(SEvent));
@@ -3149,7 +3149,7 @@ enum ButtonEventType : u8
 	BET_OTHER
 };
 
-bool GUIFormSpecMenu::OnEvent(const SEvent& event)
+bool GUIFormSpecMenu::OnEvent(const SEvent &event)
 {
 	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -281,12 +281,12 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 public:
 	GUIFormSpecMenu(JoystickController *joystick,
-			gui::IGUIElement* parent, s32 id,
+			gui::IGUIElement *parent, s32 id,
 			IMenuManager *menumgr,
 			Client *client,
 			ISimpleTextureSource *tsrc,
-			IFormSource* fs_src,
-			TextDest* txt_dst,
+			IFormSource *fs_src,
+			TextDest *txt_dst,
 			std::string formspecPrepend,
 			bool remap_dbl_click = true);
 
@@ -355,12 +355,12 @@ public:
 	ItemStack verifySelectedItem();
 
 	void acceptInput(FormspecQuitMode quitmode);
-	bool preprocessEvent(const SEvent& event);
-	bool OnEvent(const SEvent& event);
+	bool preprocessEvent(const SEvent &event);
+	bool OnEvent(const SEvent &event);
 	bool doPause;
 	bool pausesGame() { return doPause; }
 
-	GUITable* getTable(const std::string &tablename);
+	GUITable *getTable(const std::string &tablename);
 	std::vector<std::string>* getDropDownValues(const std::string &name);
 
 #ifdef __ANDROID__
@@ -401,11 +401,11 @@ protected:
 	std::unordered_map<std::string, bool> field_close_on_enter;
 	std::vector<FieldSpec> m_fields;
 	std::vector<StaticTextSpec> m_static_texts;
-	std::vector<std::pair<FieldSpec,GUITable*> > m_tables;
-	std::vector<std::pair<FieldSpec,gui::IGUICheckBox*> > m_checkboxes;
+	std::vector<std::pair<FieldSpec,GUITable *> > m_tables;
+	std::vector<std::pair<FieldSpec,gui::IGUICheckBox *> > m_checkboxes;
 	std::map<std::string, TooltipSpec> m_tooltips;
 	std::vector<std::pair<irr::core::rect<s32>, TooltipSpec>> m_tooltip_rects;
-	std::vector<std::pair<FieldSpec,gui::IGUIScrollBar*> > m_scrollbars;
+	std::vector<std::pair<FieldSpec,gui::IGUIScrollBar *> > m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string> > > m_dropdowns;
 
 	ItemSpec *m_selected_item = nullptr;
@@ -469,45 +469,45 @@ private:
 	fs_key_pendig current_keys_pending;
 	std::string current_field_enter_pending = "";
 
-	void parseElement(parserData* data, const std::string &element);
+	void parseElement(parserData *data, const std::string &element);
 
-	void parseSize(parserData* data, const std::string &element);
-	void parseContainer(parserData* data, const std::string &element);
-	void parseContainerEnd(parserData* data);
-	void parseList(parserData* data, const std::string &element);
-	void parseListRing(parserData* data, const std::string &element);
-	void parseCheckbox(parserData* data, const std::string &element);
-	void parseImage(parserData* data, const std::string &element);
-	void parseItemImage(parserData* data, const std::string &element);
-	void parseButton(parserData* data, const std::string &element,
+	void parseSize(parserData *data, const std::string &element);
+	void parseContainer(parserData *data, const std::string &element);
+	void parseContainerEnd(parserData *data);
+	void parseList(parserData *data, const std::string &element);
+	void parseListRing(parserData *data, const std::string &element);
+	void parseCheckbox(parserData *data, const std::string &element);
+	void parseImage(parserData *data, const std::string &element);
+	void parseItemImage(parserData *data, const std::string &element);
+	void parseButton(parserData *data, const std::string &element,
 			const std::string &typ);
-	void parseBackground(parserData* data, const std::string &element);
-	void parseTableOptions(parserData* data, const std::string &element);
-	void parseTableColumns(parserData* data, const std::string &element);
-	void parseTable(parserData* data, const std::string &element);
-	void parseTextList(parserData* data, const std::string &element);
-	void parseDropDown(parserData* data, const std::string &element);
+	void parseBackground(parserData *data, const std::string &element);
+	void parseTableOptions(parserData *data, const std::string &element);
+	void parseTableColumns(parserData *data, const std::string &element);
+	void parseTable(parserData *data, const std::string &element);
+	void parseTextList(parserData *data, const std::string &element);
+	void parseDropDown(parserData *data, const std::string &element);
 	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
-	void parsePwdField(parserData* data, const std::string &element);
-	void parseField(parserData* data, const std::string &element, const std::string &type);
+	void parsePwdField(parserData *data, const std::string &element);
+	void parseField(parserData *data, const std::string &element, const std::string &type);
 	void createTextField(parserData *data, FieldSpec &spec,
 		core::rect<s32> &rect, bool is_multiline);
-	void parseSimpleField(parserData* data,std::vector<std::string> &parts);
-	void parseTextArea(parserData* data,std::vector<std::string>& parts,
+	void parseSimpleField(parserData *data,std::vector<std::string> &parts);
+	void parseTextArea(parserData *data,std::vector<std::string>& parts,
 			const std::string &type);
-	void parseLabel(parserData* data, const std::string &element);
-	void parseVertLabel(parserData* data, const std::string &element);
-	void parseImageButton(parserData* data, const std::string &element,
+	void parseLabel(parserData *data, const std::string &element);
+	void parseVertLabel(parserData *data, const std::string &element);
+	void parseImageButton(parserData *data, const std::string &element,
 			const std::string &type);
-	void parseItemImageButton(parserData* data, const std::string &element);
-	void parseTabHeader(parserData* data, const std::string &element);
-	void parseBox(parserData* data, const std::string &element);
-	void parseBackgroundColor(parserData* data, const std::string &element);
-	void parseListColors(parserData* data, const std::string &element);
-	void parseTooltip(parserData* data, const std::string &element);
+	void parseItemImageButton(parserData *data, const std::string &element);
+	void parseTabHeader(parserData *data, const std::string &element);
+	void parseBox(parserData *data, const std::string &element);
+	void parseBackgroundColor(parserData *data, const std::string &element);
+	void parseListColors(parserData *data, const std::string &element);
+	void parseTooltip(parserData *data, const std::string &element);
 	bool parseVersionDirect(const std::string &data);
-	bool parseSizeDirect(parserData* data, const std::string &element);
-	void parseScrollBar(parserData* data, const std::string &element);
+	bool parseSizeDirect(parserData *data, const std::string &element);
+	void parseScrollBar(parserData *data, const std::string &element);
 	bool parsePositionDirect(parserData *data, const std::string &element);
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -80,8 +80,8 @@ enum
 	GUI_ID_CB_AUTOJUMP,
 };
 
-GUIKeyChangeMenu::GUIKeyChangeMenu(gui::IGUIEnvironment* env,
-				gui::IGUIElement* parent, s32 id, IMenuManager *menumgr) :
+GUIKeyChangeMenu::GUIKeyChangeMenu(gui::IGUIEnvironment *env,
+				gui::IGUIElement *parent, s32 id, IMenuManager *menumgr) :
 GUIModalMenu(env, parent, id, menumgr)
 {
 	init_keys();
@@ -102,8 +102,8 @@ GUIKeyChangeMenu::~GUIKeyChangeMenu()
 
 void GUIKeyChangeMenu::removeChildren()
 {
-	const core::list<gui::IGUIElement*> &children = getChildren();
-	core::list<gui::IGUIElement*> children_copy;
+	const core::list<gui::IGUIElement *> &children = getChildren();
+	core::list<gui::IGUIElement *> children_copy;
 	for (gui::IGUIElement*i : children) {
 		children_copy.push_back(i);
 	}
@@ -233,10 +233,10 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 
 void GUIKeyChangeMenu::drawMenu()
 {
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	video::SColor bgcolor(140, 0, 0, 0);
 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
@@ -253,17 +253,17 @@ bool GUIKeyChangeMenu::acceptInput()
 	{
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUX1_DESCENDS);
 		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("aux1_descends", ((gui::IGUICheckBox*)e)->isChecked());
+			g_settings->setBool("aux1_descends", ((gui::IGUICheckBox *)e)->isChecked());
 	}
 	{
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_DOUBLETAP_JUMP);
 		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
+			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox *)e)->isChecked());
 	}
 	{
 		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUTOJUMP);
 		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("autojump", ((gui::IGUICheckBox*)e)->isChecked());
+			g_settings->setBool("autojump", ((gui::IGUICheckBox *)e)->isChecked());
 	}
 
 	clearKeyCache();
@@ -290,7 +290,7 @@ bool GUIKeyChangeMenu::resetMenu()
 	}
 	return true;
 }
-bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
+bool GUIKeyChangeMenu::OnEvent(const SEvent &event)
 {
 	if (event.EventType == EET_KEY_INPUT_EVENT && activeKey >= 0
 			&& event.KeyInput.PressedDown) {

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -34,10 +34,10 @@ const int ID_change = 259;
 const int ID_message = 260;
 const int ID_cancel = 261;
 
-GUIPasswordChange::GUIPasswordChange(gui::IGUIEnvironment* env,
-		gui::IGUIElement* parent, s32 id,
+GUIPasswordChange::GUIPasswordChange(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id,
 		IMenuManager *menumgr,
-		Client* client
+		Client *client
 ):
 	GUIModalMenu(env, parent, id, menumgr),
 	m_client(client)

--- a/src/gui/guiPathSelectMenu.cpp
+++ b/src/gui/guiPathSelectMenu.cpp
@@ -19,8 +19,8 @@
 
 #include "guiPathSelectMenu.h"
 
-GUIFileSelectMenu::GUIFileSelectMenu(gui::IGUIEnvironment* env,
-		gui::IGUIElement* parent, s32 id, IMenuManager *menumgr,
+GUIFileSelectMenu::GUIFileSelectMenu(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		const std::string &title, const std::string &formname,
 		bool is_file_select) :
 	GUIModalMenu(env, parent, id, menumgr),

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -43,7 +43,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 GUITable::GUITable(gui::IGUIEnvironment *env,
-		gui::IGUIElement* parent, s32 id,
+		gui::IGUIElement *parent, s32 id,
 		core::rect<s32> rectangle,
 		ISimpleTextureSource *tsrc
 ):
@@ -52,7 +52,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 {
 	assert(tsrc != NULL);
 
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 
 	m_font = skin->getFont();
 	if (m_font) {
@@ -446,7 +446,7 @@ void GUITable::setTable(const TableOptions &options,
 			Row *row = &m_rows[i];
 			row->cellcount = rows[i].cells.size();
 			row->cells = new Cell[row->cellcount];
-			memcpy((void*) row->cells, (void*) &rows[i].cells[0],
+			memcpy((void *) row->cells, (void *) &rows[i].cells[0],
 					row->cellcount * sizeof(Cell));
 			row->indent = rows[i].indent;
 			row->visible_index = i;
@@ -613,7 +613,7 @@ void GUITable::setDynamicData(const DynamicData &dyndata)
 	m_scrollbar->setPos(dyndata.scrollpos);
 }
 
-const c8* GUITable::getTypeName() const
+const c8 *GUITable::getTypeName() const
 {
 	return "GUITable";
 }
@@ -975,7 +975,7 @@ void GUITable::allocationComplete()
 	m_alloc_images.clear();
 }
 
-const GUITable::Row* GUITable::getRow(s32 i) const
+const GUITable::Row *GUITable::getRow(s32 i) const
 {
 	if (i >= 0 && i < (s32) m_visible_rows.size())
 		return &m_rows[m_visible_rows[i]];

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -129,7 +129,7 @@ public:
 	void setDynamicData(const DynamicData &dyndata);
 
 	/* Returns "GUITable" */
-	virtual const c8* getTypeName() const;
+	virtual const c8 *getTypeName() const;
 
 	/* Must be called when position or size changes */
 	virtual void updateAbsolutePosition();
@@ -202,7 +202,7 @@ protected:
 
 	// Allocated strings and images
 	std::vector<core::stringw> m_strings;
-	std::vector<video::ITexture*> m_images;
+	std::vector<video::ITexture *> m_images;
 	std::map<std::string, s32> m_alloc_strings;
 	std::map<std::string, s32> m_alloc_images;
 

--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -35,8 +35,8 @@ const int ID_soundExitButton = 264;
 const int ID_soundSlider = 265;
 const int ID_soundMuteButton = 266;
 
-GUIVolumeChange::GUIVolumeChange(gui::IGUIEnvironment* env,
-		gui::IGUIElement* parent, s32 id,
+GUIVolumeChange::GUIVolumeChange(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id,
 		IMenuManager *menumgr
 ):
 	GUIModalMenu(env, parent, id, menumgr)
@@ -124,16 +124,16 @@ void GUIVolumeChange::regenerateGui(v2u32 screensize)
 
 void GUIVolumeChange::drawMenu()
 {
-	gui::IGUISkin* skin = Environment->getSkin();
+	gui::IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 	video::SColor bgcolor(140, 0, 0, 0);
 	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
 	gui::IGUIElement::draw();
 }
 
-bool GUIVolumeChange::OnEvent(const SEvent& event)
+bool GUIVolumeChange::OnEvent(const SEvent &event)
 {
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		if (event.KeyInput.Key == KEY_ESCAPE && event.KeyInput.PressedDown) {
@@ -149,7 +149,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 		if (event.GUIEvent.EventType == gui::EGET_CHECKBOX_CHANGED) {
 			gui::IGUIElement *e = getElementFromId(ID_soundMuteButton);
 			if (e != NULL && e->getType() == gui::EGUIET_CHECK_BOX) {
-				g_settings->setBool("mute_sound", ((gui::IGUICheckBox*)e)->isChecked());
+				g_settings->setBool("mute_sound", ((gui::IGUICheckBox *)e)->isChecked());
 			}
 
 			Environment->setFocus(this);
@@ -175,7 +175,7 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 		}
 		if (event.GUIEvent.EventType == gui::EGET_SCROLL_BAR_CHANGED) {
 			if (event.GUIEvent.Caller->getID() == ID_soundSlider) {
-				s32 pos = ((gui::IGUIScrollBar*)event.GUIEvent.Caller)->getPos();
+				s32 pos = ((gui::IGUIScrollBar *)event.GUIEvent.Caller)->getPos();
 				g_settings->setFloat("sound_volume", (float) pos / 100);
 
 				gui::IGUIElement *e = getElementFromId(ID_soundText);
@@ -193,4 +193,3 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 
 	return Parent ? Parent->OnEvent(event) : false;
 }
-

--- a/src/gui/guiVolumeChange.h
+++ b/src/gui/guiVolumeChange.h
@@ -26,8 +26,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 class GUIVolumeChange : public GUIModalMenu
 {
 public:
-	GUIVolumeChange(gui::IGUIEnvironment* env,
-			gui::IGUIElement* parent, s32 id,
+	GUIVolumeChange(gui::IGUIEnvironment *env,
+			gui::IGUIElement *parent, s32 id,
 			IMenuManager *menumgr);
 	~GUIVolumeChange();
 
@@ -39,7 +39,7 @@ public:
 
 	void drawMenu();
 
-	bool OnEvent(const SEvent& event);
+	bool OnEvent(const SEvent &event);
 
 	bool pausesGame() { return true; }
 

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -56,8 +56,8 @@ namespace gui
 {
 
 //! constructor
-intlGUIEditBox::intlGUIEditBox(const wchar_t* text, bool border,
-		IGUIEnvironment* environment, IGUIElement* parent, s32 id,
+intlGUIEditBox::intlGUIEditBox(const wchar_t *text, bool border,
+		IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 		const core::rect<s32>& rectangle, bool writable, bool has_vscrollbar)
 	: IGUIEditBox(environment, parent, id, rectangle),
 	Border(border), FrameRect(rectangle),
@@ -117,7 +117,7 @@ intlGUIEditBox::~intlGUIEditBox()
 
 
 //! Sets another skin independent font.
-void intlGUIEditBox::setOverrideFont(IGUIFont* font)
+void intlGUIEditBox::setOverrideFont(IGUIFont *font)
 {
 	if (OverrideFont == font)
 		return;
@@ -139,11 +139,11 @@ IGUIFont * intlGUIEditBox::getOverrideFont() const
 }
 
 //! Get the font which is used right now for drawing
-IGUIFont* intlGUIEditBox::getActiveFont() const
+IGUIFont *intlGUIEditBox::getActiveFont() const
 {
 	if ( OverrideFont )
 		return OverrideFont;
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (skin)
 		return skin->getFont();
 	return 0;
@@ -251,7 +251,7 @@ void intlGUIEditBox::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT 
 
 
 //! called if an event happened.
-bool intlGUIEditBox::OnEvent(const SEvent& event)
+bool intlGUIEditBox::OnEvent(const SEvent &event)
 {
 	if (IsEnabled)
 	{
@@ -306,7 +306,7 @@ bool intlGUIEditBox::OnEvent(const SEvent& event)
 }
 
 
-bool intlGUIEditBox::processKey(const SEvent& event)
+bool intlGUIEditBox::processKey(const SEvent &event)
 {
 	if (!event.KeyInput.PressedDown)
 		return false;
@@ -381,7 +381,7 @@ bool intlGUIEditBox::processKey(const SEvent& event)
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
 				// add new character
-				const c8* p = Operator->getTextFromClipboard();
+				const c8 *p = Operator->getTextFromClipboard();
 				if (p)
 				{
 					if (MarkBegin == MarkEnd)
@@ -761,7 +761,7 @@ void intlGUIEditBox::draw()
 
 	const bool focus = Environment->hasFocus(this);
 
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
 
@@ -788,7 +788,7 @@ void intlGUIEditBox::draw()
 
 	// draw the text
 
-	IGUIFont* font = OverrideFont;
+	IGUIFont *font = OverrideFont;
 	if (!OverrideFont)
 		font = skin->getFont();
 
@@ -952,7 +952,7 @@ void intlGUIEditBox::draw()
 
 
 //! Sets the new caption of this element.
-void intlGUIEditBox::setText(const wchar_t* text)
+void intlGUIEditBox::setText(const wchar_t *text)
 {
 	Text = text;
 	if (u32(CursorPos) > Text.size())
@@ -1017,7 +1017,7 @@ u32 intlGUIEditBox::getMax() const
 }
 
 
-bool intlGUIEditBox::processMouse(const SEvent& event)
+bool intlGUIEditBox::processMouse(const SEvent &event)
 {
 	switch(event.MouseInput.Event)
 	{
@@ -1093,8 +1093,8 @@ bool intlGUIEditBox::processMouse(const SEvent& event)
 
 s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 {
-	IGUIFont* font = OverrideFont;
-	IGUISkin* skin = Environment->getSkin();
+	IGUIFont *font = OverrideFont;
+	IGUISkin *skin = Environment->getSkin();
 	if (!OverrideFont)
 		font = skin->getFont();
 
@@ -1139,7 +1139,7 @@ s32 intlGUIEditBox::getCursorPos(s32 x, s32 y)
 //! Breaks the single text line.
 void intlGUIEditBox::breakText()
 {
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 
 	if ((!WordWrap && !MultiLine) || !skin)
 		return;
@@ -1147,7 +1147,7 @@ void intlGUIEditBox::breakText()
 	BrokenText.clear(); // need to reallocate :/
 	BrokenTextPositions.set_used(0);
 
-	IGUIFont* font = OverrideFont;
+	IGUIFont *font = OverrideFont;
 	if (!OverrideFont)
 		font = skin->getFont();
 
@@ -1253,11 +1253,11 @@ void intlGUIEditBox::setTextRect(s32 line)
 {
 	core::dimension2du d;
 
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
 
-	IGUIFont* font = OverrideFont ? OverrideFont : skin->getFont();
+	IGUIFont *font = OverrideFont ? OverrideFont : skin->getFont();
 
 	if (!font)
 		return;
@@ -1395,10 +1395,10 @@ void intlGUIEditBox::calculateScrollPos()
 	if (!WordWrap)
 	{
 		// get cursor position
-		IGUISkin* skin = Environment->getSkin();
+		IGUISkin *skin = Environment->getSkin();
 		if (!skin)
 			return;
-		IGUIFont* font = OverrideFont ? OverrideFont : skin->getFont();
+		IGUIFont *font = OverrideFont ? OverrideFont : skin->getFont();
 		if (!font)
 			return;
 
@@ -1468,8 +1468,8 @@ void intlGUIEditBox::createVScrollBar()
 	if (OverrideFont) {
 		fontHeight = OverrideFont->getDimension(L"").Height;
 	} else {
-		if (IGUISkin* skin = Environment->getSkin()) {
-			if (IGUIFont* font = skin->getFont()) {
+		if (IGUISkin *skin = Environment->getSkin()) {
+			if (IGUIFont *font = skin->getFont()) {
 				fontHeight = font->getDimension(L"").Height;
 			}
 		}
@@ -1538,7 +1538,7 @@ void intlGUIEditBox::setWritable(bool can_write_text)
 }
 
 //! Writes attributes of the element.
-void intlGUIEditBox::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options=0) const
+void intlGUIEditBox::serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options = 0) const
 {
 	// IGUIEditBox::serializeAttributes(out,options);
 
@@ -1562,7 +1562,7 @@ void intlGUIEditBox::serializeAttributes(io::IAttributes* out, io::SAttributeRea
 
 
 //! Reads attributes of the element
-void intlGUIEditBox::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options=0)
+void intlGUIEditBox::deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options = 0)
 {
 	IGUIEditBox::deserializeAttributes(in,options);
 

--- a/src/gui/intlGUIEditBox.h
+++ b/src/gui/intlGUIEditBox.h
@@ -21,24 +21,24 @@ namespace gui
 	public:
 
 		//! constructor
-		intlGUIEditBox(const wchar_t* text, bool border, IGUIEnvironment* environment,
-			IGUIElement* parent, s32 id, const core::rect<s32>& rectangle,
+		intlGUIEditBox(const wchar_t *text, bool border, IGUIEnvironment *environment,
+			IGUIElement *parent, s32 id, const core::rect<s32>& rectangle,
 			bool writable = true, bool has_vscrollbar = false);
 
 		//! destructor
 		virtual ~intlGUIEditBox();
 
 		//! Sets another skin independent font.
-		virtual void setOverrideFont(IGUIFont* font=0);
+		virtual void setOverrideFont(IGUIFont *font=0);
 
 		//! Gets the override font (if any)
 		/** \return The override font (may be 0) */
-		virtual IGUIFont* getOverrideFont() const;
+		virtual IGUIFont *getOverrideFont() const;
 
 		//! Get the font which is used right now for drawing
 		/** Currently this is the override font when one is set and the
 		font of the active skin otherwise */
-		virtual IGUIFont* getActiveFont() const;
+		virtual IGUIFont *getActiveFont() const;
 
 		//! Sets another color for the text.
 		virtual void setOverrideColor(video::SColor color);
@@ -96,13 +96,13 @@ namespace gui
 		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical);
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event);
+		virtual bool OnEvent(const SEvent &event);
 
 		//! draws the element and its children
 		virtual void draw();
 
 		//! Sets the new caption of this element.
-		virtual void setText(const wchar_t* text);
+		virtual void setText(const wchar_t *text);
 
 		//! Sets the maximum amount of characters which may be entered in the box.
 		//! \param max: Maximum amount of characters. If 0, the character amount is
@@ -128,10 +128,10 @@ namespace gui
 		virtual void setWritable(bool can_write_text);
 
 		//! Writes attributes of the element.
-		virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;
+		virtual void serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options) const;
 
 		//! Reads attributes of the element
-		virtual void deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options);
+		virtual void deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options);
 
 		virtual void setCursorChar(const wchar_t cursorChar) {}
 
@@ -157,8 +157,8 @@ namespace gui
 		//! set text markers
 		void setTextMarkers(s32 begin, s32 end);
 
-		bool processKey(const SEvent& event);
-		bool processMouse(const SEvent& event);
+		bool processKey(const SEvent &event);
+		bool processMouse(const SEvent &event);
 		s32 getCursorPos(s32 x, s32 y);
 
 		//! Create a vertical scrollbar

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -64,7 +64,7 @@ public:
 		// Remove all entries if there are duplicates
 		m_stack.remove(menu);
 
-		/*core::list<GUIModalMenu*>::Iterator i = m_stack.getLast();
+		/*core::list<GUIModalMenu *>::Iterator i = m_stack.getLast();
 		assert(*i == menu);
 		m_stack.erase(i);*/
 
@@ -73,11 +73,11 @@ public:
 	}
 
 	// Returns true to prevent further processing
-	virtual bool preprocessEvent(const SEvent& event)
+	virtual bool preprocessEvent(const SEvent &event)
 	{
 		if (m_stack.empty())
 			return false;
-		GUIModalMenu *mm = dynamic_cast<GUIModalMenu*>(m_stack.back());
+		GUIModalMenu *mm = dynamic_cast<GUIModalMenu *>(m_stack.back());
 		return mm && mm->preprocessEvent(event);
 	}
 
@@ -89,14 +89,14 @@ public:
 	bool pausesGame()
 	{
 		for (gui::IGUIElement *i : m_stack) {
-			GUIModalMenu *mm = dynamic_cast<GUIModalMenu*>(i);
+			GUIModalMenu *mm = dynamic_cast<GUIModalMenu *>(i);
 			if (mm && mm->pausesGame())
 				return true;
 		}
 		return false;
 	}
 
-	std::list<gui::IGUIElement*> m_stack;
+	std::list<gui::IGUIElement *> m_stack;
 };
 
 extern MainMenuManager g_menumgr;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 // clang-format off
-GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent, s32 id,
+GUIModalMenu::GUIModalMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 		IMenuManager *menumgr) :
 		IGUIElement(gui::EGUIET_ELEMENT, env, parent, id,
 				core::rect<s32>(0, 0, 100, 100)),

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -38,7 +38,7 @@ public:
 class GUIModalMenu : public gui::IGUIElement
 {
 public:
-	GUIModalMenu(gui::IGUIEnvironment* env, gui::IGUIElement* parent, s32 id,
+	GUIModalMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
 		IMenuManager *menumgr);
 	virtual ~GUIModalMenu();
 
@@ -50,8 +50,8 @@ public:
 
 	virtual void regenerateGui(v2u32 screensize) = 0;
 	virtual void drawMenu() = 0;
-	virtual bool preprocessEvent(const SEvent& event);
-	virtual bool OnEvent(const SEvent& event) { return false; };
+	virtual bool preprocessEvent(const SEvent &event);
+	virtual bool OnEvent(const SEvent &event) { return false; };
 	virtual bool pausesGame() { return false; } // Used for pause menu
 #ifdef __ANDROID__
 	virtual bool getAndroidUIInput() { return false; }

--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -341,7 +341,7 @@ bool AutoHideButtonBar::isButton(const SEvent &event)
 			m_active = true;
 			m_timeout = 0;
 
-			std::vector<button_info*>::iterator iter = m_buttons.begin();
+			std::vector<button_info *>::iterator iter = m_buttons.begin();
 
 			while (iter != m_buttons.end()) {
 				(*iter)->guibutton->setVisible(true);

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -153,7 +153,7 @@ bool httpfetch_async_get(unsigned long caller, HTTPFetchResult &fetch_result)
 static size_t httpfetch_writefunction(
 		char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-	std::ostringstream *stream = (std::ostringstream*)userdata;
+	std::ostringstream *stream = (std::ostringstream *)userdata;
 	size_t count = size * nmemb;
 	stream->write(ptr, count);
 	return count;
@@ -167,14 +167,14 @@ static size_t httpfetch_discardfunction(
 
 class CurlHandlePool
 {
-	std::list<CURL*> handles;
+	std::list<CURL *> handles;
 
 public:
 	CurlHandlePool() = default;
 
 	~CurlHandlePool()
 	{
-		for (std::list<CURL*>::iterator it = handles.begin();
+		for (std::list<CURL *>::iterator it = handles.begin();
 				it != handles.end(); ++it) {
 			curl_easy_cleanup(*it);
 		}
@@ -441,7 +441,7 @@ protected:
 	size_t m_parallel_limit;
 
 	// Variables exclusively used within thread
-	std::vector<HTTPFetchOngoing*> m_all_ongoing;
+	std::vector<HTTPFetchOngoing *> m_all_ongoing;
 	std::list<HTTPFetchRequest> m_queued_fetches;
 
 public:
@@ -497,7 +497,7 @@ protected:
 			unsigned long caller = req.fetch_request.caller;
 
 			// Abort all ongoing fetches for the caller
-			for (std::vector<HTTPFetchOngoing*>::iterator
+			for (std::vector<HTTPFetchOngoing *>::iterator
 					it = m_all_ongoing.begin();
 					it != m_all_ongoing.end();) {
 				if ((*it)->getRequest().caller == caller) {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -550,13 +550,13 @@ u32 InventoryList::getFreeSlots() const
 	return getSize() - getUsedSlots();
 }
 
-const ItemStack& InventoryList::getItem(u32 i) const
+const ItemStack &InventoryList::getItem(u32 i) const
 {
 	assert(i < m_size); // Pre-condition
 	return m_items[i];
 }
 
-ItemStack& InventoryList::getItem(u32 i)
+ItemStack &InventoryList::getItem(u32 i)
 {
 	assert(i < m_size); // Pre-condition
 	return m_items[i];
@@ -937,9 +937,9 @@ InventoryList * Inventory::getList(const std::string &name)
 	return m_lists[i];
 }
 
-std::vector<const InventoryList*> Inventory::getLists()
+std::vector<const InventoryList *> Inventory::getLists()
 {
-	std::vector<const InventoryList*> lists;
+	std::vector<const InventoryList *> lists;
 	for (auto list : m_lists) {
 		lists.push_back(list);
 	}

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -101,14 +101,14 @@ struct ItemStack
 
 	// Returns a pointer to the item definition struct,
 	// or a fallback one (name="unknown") if the item is unknown.
-	const ItemDefinition& getDefinition(
+	const ItemDefinition &getDefinition(
 			IItemDefManager *itemdef) const
 	{
 		return itemdef->get(name);
 	}
 
 	// Get tool digging properties, or those of the hand if not a tool
-	const ToolCapabilities& getToolCapabilities(
+	const ToolCapabilities &getToolCapabilities(
 			IItemDefManager *itemdef) const
 	{
 		const ToolCapabilities *item_cap =
@@ -198,8 +198,8 @@ public:
 	u32 getFreeSlots() const;
 
 	// Get reference to item
-	const ItemStack& getItem(u32 i) const;
-	ItemStack& getItem(u32 i);
+	const ItemStack &getItem(u32 i) const;
+	ItemStack &getItem(u32 i);
 	// Returns old item. Parameter can be an empty item.
 	ItemStack changeItem(u32 i, const ItemStack &newitem);
 	// Delete item
@@ -281,7 +281,7 @@ public:
 	InventoryList * addList(const std::string &name, u32 size);
 	InventoryList * getList(const std::string &name);
 	const InventoryList * getList(const std::string &name) const;
-	std::vector<const InventoryList*> getLists();
+	std::vector<const InventoryList *> getLists();
 	bool deleteList(const std::string &name);
 	// A shorthand for adding items. Returns leftover item (possibly empty).
 	ItemStack addItem(const std::string &listname, const ItemStack &newitem)
@@ -307,7 +307,7 @@ private:
 	// -1 if not found
 	const s32 getListIndex(const std::string &name) const;
 
-	std::vector<InventoryList*> m_lists;
+	std::vector<InventoryList *> m_lists;
 	IItemDefManager *m_itemdef;
 	bool m_dirty = false;
 };

--- a/src/inventorymanager.h
+++ b/src/inventorymanager.h
@@ -109,10 +109,10 @@ public:
 	virtual ~InventoryManager() = default;
 
 	// Get an inventory (server and client)
-	virtual Inventory* getInventory(const InventoryLocation &loc){return NULL;}
-    // Set modified (will be saved and sent over network; only on server)
+	virtual Inventory *getInventory(const InventoryLocation &loc){return NULL;}
+	// Set modified (will be saved and sent over network; only on server)
 	virtual void setInventoryModified(const InventoryLocation &loc, bool playerSend = true){}
-    // Send inventory action to server (only on client)
+	// Send inventory action to server (only on client)
 	virtual void inventoryAction(InventoryAction *a){}
 };
 

--- a/src/irrlicht_changes/CGUITTFont.cpp
+++ b/src/irrlicht_changes/CGUITTFont.cpp
@@ -43,7 +43,7 @@ struct SGUITTFace : public virtual irr::IReferenceCounted
 {
 	SGUITTFace() : face_buffer(0), face_buffer_size(0)
 	{
-		memset((void*)&face, 0, sizeof(FT_Face));
+		memset((void *)&face, 0, sizeof(FT_Face));
 	}
 
 	~SGUITTFace()
@@ -53,15 +53,15 @@ struct SGUITTFace : public virtual irr::IReferenceCounted
 	}
 
 	FT_Face face;
-	FT_Byte* face_buffer;
+	FT_Byte *face_buffer;
 	FT_Long face_buffer_size;
 };
 
 // Static variables.
 FT_Library CGUITTFont::c_library;
-core::map<io::path, SGUITTFace*> CGUITTFont::c_faces;
+core::map<io::path, SGUITTFace *> CGUITTFont::c_faces;
 bool CGUITTFont::c_libraryLoaded = false;
-scene::IMesh* CGUITTFont::shared_plane_ptr_ = 0;
+scene::IMesh *CGUITTFont::shared_plane_ptr_ = 0;
 scene::SMesh CGUITTFont::shared_plane_;
 
 //
@@ -79,7 +79,7 @@ inline void checkFontBitmapSize(const FT_Bitmap &bits)
 	}
 }
 
-video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVideoDriver* driver) const
+video::IImage *SGUITTGlyph::createGlyphImage(const FT_Bitmap &bits, video::IVideoDriver *driver) const
 {
 	// Make sure our casts to s32 in the loops below will not cause problems
 	checkFontBitmapSize(bits);
@@ -91,7 +91,7 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 	//core::dimension2du texture_size(bits.width + 1, bits.rows + 1);
 
 	// Create and load our image now.
-	video::IImage* image = 0;
+	video::IImage *image = 0;
 	switch (bits.pixel_mode)
 	{
 		case FT_PIXEL_MODE_MONO:
@@ -103,12 +103,12 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 
 			// Load the monochrome data in.
 			const u32 image_pitch = image->getPitch() / sizeof(u16);
-			u16* image_data = (u16*)image->lock();
-			u8* glyph_data = bits.buffer;
+			u16 *image_data = (u16 *)image->lock();
+			u8 *glyph_data = bits.buffer;
 
 			for (s32 y = 0; y < (s32)bits.rows; ++y)
 			{
-				u16* row = image_data;
+				u16 *row = image_data;
 				for (s32 x = 0; x < (s32)bits.width; ++x)
 				{
 					// Monochrome bitmaps store 8 pixels per byte.  The left-most pixel is the bit 0x80.
@@ -133,11 +133,11 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 			// Load the grayscale data in.
 			const float gray_count = static_cast<float>(bits.num_grays);
 			const u32 image_pitch = image->getPitch() / sizeof(u32);
-			u32* image_data = (u32*)image->lock();
-			u8* glyph_data = bits.buffer;
+			u32 *image_data = (u32 *)image->lock();
+			u8 *glyph_data = bits.buffer;
 			for (s32 y = 0; y < (s32)bits.rows; ++y)
 			{
-				u8* row = glyph_data;
+				u8 *row = glyph_data;
 				for (s32 x = 0; x < (s32)bits.width; ++x)
 				{
 					image_data[y * image_pitch + x] |= static_cast<u32>(255.0f * (static_cast<float>(*row++) / gray_count)) << 24;
@@ -155,7 +155,7 @@ video::IImage* SGUITTGlyph::createGlyphImage(const FT_Bitmap& bits, video::IVide
 	return image;
 }
 
-void SGUITTGlyph::preload(u32 char_index, FT_Face face, video::IVideoDriver* driver, u32 font_size, const FT_Int32 loadFlags)
+void SGUITTGlyph::preload(u32 char_index, FT_Face face, video::IVideoDriver *driver, u32 font_size, const FT_Int32 loadFlags)
 {
 	if (isLoaded) return;
 
@@ -175,7 +175,7 @@ void SGUITTGlyph::preload(u32 char_index, FT_Face face, video::IVideoDriver* dri
 	offset = core::vector2di(glyph->bitmap_left, glyph->bitmap_top);
 
 	// Try to get the last page with available slots.
-	CGUITTGlyphPage* page = parent->getLastGlyphPage();
+	CGUITTGlyphPage *page = parent->getLastGlyphPage();
 
 	// If we need to make a new page, do that now.
 	if (!page)
@@ -218,7 +218,7 @@ void SGUITTGlyph::unload()
 
 //////////////////////
 
-CGUITTFont* CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path& filename, const u32 size, const bool antialias, const bool transparency, const u32 shadow, const u32 shadow_alpha)
+CGUITTFont *CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path &filename, const u32 size, const bool antialias, const bool transparency, const u32 shadow, const u32 shadow_alpha)
 {
 	if (!c_libraryLoaded)
 	{
@@ -227,7 +227,7 @@ CGUITTFont* CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path& filen
 		c_libraryLoaded = true;
 	}
 
-	CGUITTFont* font = new CGUITTFont(env);
+	CGUITTFont *font = new CGUITTFont(env);
 	bool ret = font->load(filename, size, antialias, transparency);
 	if (!ret)
 	{
@@ -241,7 +241,7 @@ CGUITTFont* CGUITTFont::createTTFont(IGUIEnvironment *env, const io::path& filen
 	return font;
 }
 
-CGUITTFont* CGUITTFont::createTTFont(IrrlichtDevice *device, const io::path& filename, const u32 size, const bool antialias, const bool transparency)
+CGUITTFont *CGUITTFont::createTTFont(IrrlichtDevice *device, const io::path &filename, const u32 size, const bool antialias, const bool transparency)
 {
 	if (!c_libraryLoaded)
 	{
@@ -250,7 +250,7 @@ CGUITTFont* CGUITTFont::createTTFont(IrrlichtDevice *device, const io::path& fil
 		c_libraryLoaded = true;
 	}
 
-	CGUITTFont* font = new CGUITTFont(device->getGUIEnvironment());
+	CGUITTFont *font = new CGUITTFont(device->getGUIEnvironment());
 	font->Device = device;
 	bool ret = font->load(filename, size, antialias, transparency);
 	if (!ret)
@@ -262,12 +262,12 @@ CGUITTFont* CGUITTFont::createTTFont(IrrlichtDevice *device, const io::path& fil
 	return font;
 }
 
-CGUITTFont* CGUITTFont::create(IGUIEnvironment *env, const io::path& filename, const u32 size, const bool antialias, const bool transparency)
+CGUITTFont *CGUITTFont::create(IGUIEnvironment *env, const io::path &filename, const u32 size, const bool antialias, const bool transparency)
 {
 	return CGUITTFont::createTTFont(env, filename, size, antialias, transparency);
 }
 
-CGUITTFont* CGUITTFont::create(IrrlichtDevice *device, const io::path& filename, const u32 size, const bool antialias, const bool transparency)
+CGUITTFont *CGUITTFont::create(IrrlichtDevice *device, const io::path &filename, const u32 size, const bool antialias, const bool transparency)
 {
 	return CGUITTFont::createTTFont(device, filename, size, antialias, transparency);
 }
@@ -298,15 +298,15 @@ batch_load_size(1), Device(0), Environment(env), Driver(0), GlobalKerningWidth(0
 	Glyphs.set_free_when_destroyed(false);
 }
 
-bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antialias, const bool transparency)
+bool CGUITTFont::load(const io::path &filename, const u32 size, const bool antialias, const bool transparency)
 {
 	// Some sanity checks.
 	if (Environment == 0 || Driver == 0) return false;
 	if (size == 0) return false;
 	if (filename.size() == 0) return false;
 
-	io::IFileSystem* filesystem = Environment->getFileSystem();
-	irr::ILogger* logger = (Device != 0 ? Device->getLogger() : 0);
+	io::IFileSystem *filesystem = Environment->getFileSystem();
+	irr::ILogger *logger = (Device != 0 ? Device->getLogger() : 0);
 	this->size = size;
 	this->filename = filename;
 
@@ -320,8 +320,8 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 		logger->log(L"CGUITTFont", core::stringw(core::stringw(L"Creating new font: ") + core::ustring(filename).toWCHAR_s() + L" " + core::stringc(size) + L"pt " + (antialias ? L"+antialias " : L"-antialias ") + (transparency ? L"+transparency" : L"-transparency")).c_str(), irr::ELL_INFORMATION);
 
 	// Grab the face.
-	SGUITTFace* face = 0;
-	core::map<io::path, SGUITTFace*>::Node* node = c_faces.find(filename);
+	SGUITTFace *face = 0;
+	core::map<io::path, SGUITTFace *>::Node *node = c_faces.find(filename);
 	if (node == 0)
 	{
 		face = new SGUITTFace();
@@ -330,7 +330,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 		if (filesystem)
 		{
 			// Read in the file data.
-			io::IReadFile* file = filesystem->createAndOpenFile(filename);
+			io::IReadFile *file = filesystem->createAndOpenFile(filename);
 			if (file == 0)
 			{
 				if (logger) logger->log(L"CGUITTFont", L"Failed to open the file.", irr::ELL_INFORMATION);
@@ -359,7 +359,7 @@ bool CGUITTFont::load(const io::path& filename, const u32 size, const bool antia
 		else
 		{
 			core::ustring converter(filename);
-			if (FT_New_Face(c_library, reinterpret_cast<const char*>(converter.toUTF8_s().c_str()), 0, &face->face))
+			if (FT_New_Face(c_library, reinterpret_cast<const char *>(converter.toUTF8_s().c_str()), 0, &face->face))
 			{
 				if (logger) logger->log(L"CGUITTFont", L"FT_New_Face failed.", irr::ELL_INFORMATION);
 
@@ -416,10 +416,10 @@ CGUITTFont::~CGUITTFont()
 	//Glyphs.clear();
 
 	// We aren't using this face anymore.
-	core::map<io::path, SGUITTFace*>::Node* n = c_faces.find(filename);
+	core::map<io::path, SGUITTFace *>::Node *n = c_faces.find(filename);
 	if (n)
 	{
-		SGUITTFace* f = n->getValue();
+		SGUITTFace *f = n->getValue();
 
 		// Drop our face.  If this was the last face, the destructor will clean up.
 		if (f->drop())
@@ -462,9 +462,9 @@ void CGUITTFont::update_glyph_pages() const
 	}
 }
 
-CGUITTGlyphPage* CGUITTFont::getLastGlyphPage() const
+CGUITTGlyphPage *CGUITTFont::getLastGlyphPage() const
 {
-	CGUITTGlyphPage* page = 0;
+	CGUITTGlyphPage *page = 0;
 	if (Glyph_Pages.empty())
 		return 0;
 	else
@@ -476,10 +476,10 @@ CGUITTGlyphPage* CGUITTFont::getLastGlyphPage() const
 	return page;
 }
 
-CGUITTGlyphPage* CGUITTFont::createGlyphPage(const u8& pixel_mode)
+CGUITTGlyphPage *CGUITTFont::createGlyphPage(const u8 &pixel_mode)
 {
-	CGUITTGlyphPage* page = 0;
-	
+	CGUITTGlyphPage *page = 0;
+
 	// Name of our page.
 	io::path name("TTFontGlyphPage_");
 	name += tt_face->family_name;
@@ -546,12 +546,12 @@ void CGUITTFont::setFontHinting(const bool enable, const bool enable_auto_hintin
 	reset_images();
 }
 
-void CGUITTFont::draw(const core::stringw& text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>* clip)
+void CGUITTFont::draw(const core::stringw &text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32> *clip)
 {
 	draw(EnrichedString(std::wstring(text.c_str()), color), position, color, hcenter, vcenter, clip);
 }
 
-void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32>* clip)
+void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& position, video::SColor color, bool hcenter, bool vcenter, const core::rect<s32> *clip)
 {
 	std::vector<video::SColor> colors = text.getColors();
 
@@ -585,7 +585,7 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 	core::ustring utext = text.getString();
 
 	// Set up our render map.
-	core::map<u32, CGUITTGlyphPage*> Render_Map;
+	core::map<u32, CGUITTGlyphPage *> Render_Map;
 
 	// Start parsing characters.
 	u32 n;
@@ -633,8 +633,8 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 			offset.Y += k.Y;
 
 			// Determine rendering information.
-			SGUITTGlyph& glyph = Glyphs[n-1];
-			CGUITTGlyphPage* const page = Glyph_Pages[glyph.glyph_page];
+			SGUITTGlyph &glyph = Glyphs[n-1];
+			CGUITTGlyphPage *const page = Glyph_Pages[glyph.glyph_page];
 			page->render_positions.push_back(core::position2di(offset.X + offx, offset.Y + offy));
 			page->render_source_rects.push_back(glyph.source_rect);
 			Render_Map.set(glyph.glyph_page, page);
@@ -650,14 +650,14 @@ void CGUITTFont::draw(const EnrichedString &text, const core::rect<s32>& positio
 
 	// Draw now.
 	update_glyph_pages();
-	core::map<u32, CGUITTGlyphPage*>::Iterator j = Render_Map.getIterator();
+	core::map<u32, CGUITTGlyphPage *>::Iterator j = Render_Map.getIterator();
 	while (!j.atEnd())
 	{
-		core::map<u32, CGUITTGlyphPage*>::Node* n = j.getNode();
+		core::map<u32, CGUITTGlyphPage *>::Node *n = j.getNode();
 		j++;
 		if (n == 0) continue;
 
-		CGUITTGlyphPage* page = n->getValue();
+		CGUITTGlyphPage *page = n->getValue();
 
 		if (shadow_offset) {
 			for (size_t i = 0; i < page->render_positions.size(); ++i)
@@ -685,12 +685,12 @@ core::dimension2d<u32> CGUITTFont::getCharDimension(const wchar_t ch) const
 	return core::dimension2d<u32>(getWidthFromCharacter(ch), getHeightFromCharacter(ch));
 }
 
-core::dimension2d<u32> CGUITTFont::getDimension(const wchar_t* text) const
+core::dimension2d<u32> CGUITTFont::getDimension(const wchar_t *text) const
 {
 	return getDimension(core::ustring(text));
 }
 
-core::dimension2d<u32> CGUITTFont::getDimension(const core::ustring& text) const
+core::dimension2d<u32> CGUITTFont::getDimension(const core::ustring &text) const
 {
 	// Get the maximum font height.  Unfortunately, we have to do this hack as
 	// Irrlicht will draw things wrong.  In FreeType, the font size is the
@@ -829,7 +829,7 @@ u32 CGUITTFont::getGlyphIndexByChar(uchar32_t c) const
 		// If the glyph hasn't been loaded yet, do it now.
 		if (char_index)
 		{
-			SGUITTGlyph& glyph = Glyphs[char_index - 1];
+			SGUITTGlyph &glyph = Glyphs[char_index - 1];
 			if (!glyph.isLoaded)
 			{
 				glyph.preload(char_index, tt_face, Driver, size, load_flags);
@@ -843,12 +843,12 @@ u32 CGUITTFont::getGlyphIndexByChar(uchar32_t c) const
 	return glyph;
 }
 
-s32 CGUITTFont::getCharacterFromPos(const wchar_t* text, s32 pixel_x) const
+s32 CGUITTFont::getCharacterFromPos(const wchar_t *text, s32 pixel_x) const
 {
 	return getCharacterFromPos(core::ustring(text), pixel_x);
 }
 
-s32 CGUITTFont::getCharacterFromPos(const core::ustring& text, s32 pixel_x) const
+s32 CGUITTFont::getCharacterFromPos(const core::ustring &text, s32 pixel_x) const
 {
 	s32 x = 0;
 	//s32 idx = 0;
@@ -886,7 +886,7 @@ void CGUITTFont::setKerningHeight(s32 kerning)
 	GlobalKerningHeight = kerning;
 }
 
-s32 CGUITTFont::getKerningWidth(const wchar_t* thisLetter, const wchar_t* previousLetter) const
+s32 CGUITTFont::getKerningWidth(const wchar_t *thisLetter, const wchar_t *previousLetter) const
 {
 	if (tt_face == 0)
 		return GlobalKerningWidth;
@@ -954,43 +954,43 @@ void CGUITTFont::setInvisibleCharacters(const wchar_t *s)
 	Invisible = us;
 }
 
-void CGUITTFont::setInvisibleCharacters(const core::ustring& s)
+void CGUITTFont::setInvisibleCharacters(const core::ustring &s)
 {
 	Invisible = s;
 }
 
-video::IImage* CGUITTFont::createTextureFromChar(const uchar32_t& ch)
+video::IImage *CGUITTFont::createTextureFromChar(const uchar32_t &ch)
 {
 	u32 n = getGlyphIndexByChar(ch);
-	const SGUITTGlyph& glyph = Glyphs[n-1];
-	CGUITTGlyphPage* page = Glyph_Pages[glyph.glyph_page];
+	const SGUITTGlyph &glyph = Glyphs[n-1];
+	CGUITTGlyphPage *page = Glyph_Pages[glyph.glyph_page];
 
 	if (page->dirty)
 		page->updateTexture();
 
-	video::ITexture* tex = page->texture;
+	video::ITexture *tex = page->texture;
 
 	// Acquire a read-only lock of the corresponding page texture.
 	#if IRRLICHT_VERSION_MAJOR==1 && IRRLICHT_VERSION_MINOR>=8
-	void* ptr = tex->lock(video::ETLM_READ_ONLY);
+	void *ptr = tex->lock(video::ETLM_READ_ONLY);
 	#else
-	void* ptr = tex->lock(true);
+	void *ptr = tex->lock(true);
 	#endif
 
 	video::ECOLOR_FORMAT format = tex->getColorFormat();
 	core::dimension2du tex_size = tex->getOriginalSize();
-	video::IImage* pageholder = Driver->createImageFromData(format, tex_size, ptr, true, false);
+	video::IImage *pageholder = Driver->createImageFromData(format, tex_size, ptr, true, false);
 
 	// Copy the image data out of the page texture.
 	core::dimension2du glyph_size(glyph.source_rect.getSize());
-	video::IImage* image = Driver->createImage(format, glyph_size);
+	video::IImage *image = Driver->createImage(format, glyph_size);
 	pageholder->copyTo(image, core::position2di(0, 0), glyph.source_rect);
 
 	tex->unlock();
 	return image;
 }
 
-video::ITexture* CGUITTFont::getPageTextureByIndex(const u32& page_index) const
+video::ITexture *CGUITTFont::getPageTextureByIndex(const u32 &page_index) const
 {
 	if (page_index < Glyph_Pages.size())
 		return Glyph_Pages[page_index]->texture;
@@ -1018,7 +1018,7 @@ void CGUITTFont::createSharedPlane()
 	vertices[2] = S3DVertex(vector3df(0, 0,0), vector3df(0,0,-1), SColor(255,255,255,255), vector2df(0,0));
 	vertices[3] = S3DVertex(vector3df(1, 0,0), vector3df(0,0,-1), SColor(255,255,255,255), vector2df(1,0));
 
-	SMeshBuffer* buf = new SMeshBuffer();
+	SMeshBuffer *buf = new SMeshBuffer();
 	buf->append(vertices, 4, indices, 6);
 
 	shared_plane_.addMeshBuffer( buf );
@@ -1027,22 +1027,22 @@ void CGUITTFont::createSharedPlane()
 	buf->drop(); //the addMeshBuffer method will grab it, so we can drop this ptr.
 }
 
-core::dimension2d<u32> CGUITTFont::getDimensionUntilEndOfLine(const wchar_t* p) const
+core::dimension2d<u32> CGUITTFont::getDimensionUntilEndOfLine(const wchar_t *p) const
 {
 	core::stringw s;
-	for (const wchar_t* temp = p; temp && *temp != '\0' && *temp != L'\r' && *temp != L'\n'; ++temp )
+	for (const wchar_t *temp = p; temp && *temp != '\0' && *temp != L'\r' && *temp != L'\n'; ++temp )
 		s.append(*temp);
 
 	return getDimension(s.c_str());
 }
 
-core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text, scene::ISceneManager* smgr, scene::ISceneNode* parent, const video::SColor& color, bool center)
+core::array<scene::ISceneNode *> CGUITTFont::addTextSceneNode(const wchar_t *text, scene::ISceneManager *smgr, scene::ISceneNode *parent, const video::SColor &color, bool center)
 {
 	using namespace core;
 	using namespace video;
 	using namespace scene;
 
-	array<scene::ISceneNode*> container;
+	array<scene::ISceneNode *> container;
 
 	if (!Driver || !smgr) return container;
 	if (!parent)
@@ -1115,7 +1115,7 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 				glyph_indices.push_back( n );
 
 				// Store glyph size and offset informations.
-				SGUITTGlyph const& glyph = Glyphs[n-1];
+				SGUITTGlyph const &glyph = Glyphs[n-1];
 				u32 texw = glyph.source_rect.getWidth();
 				u32 texh = glyph.source_rect.getHeight();
 				s32 offx = glyph.offset.X;
@@ -1130,15 +1130,15 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 				dimension2d<u32> letter_size = dimension2d<u32>(texw, texh);
 
 				// Now we copy planes corresponding to the letter size.
-				IMeshManipulator* mani = smgr->getMeshManipulator();
-				IMesh* meshcopy = mani->createMeshCopy(shared_plane_ptr_);
+				IMeshManipulator *mani = smgr->getMeshManipulator();
+				IMesh *meshcopy = mani->createMeshCopy(shared_plane_ptr_);
 				#if IRRLICHT_VERSION_MAJOR==1 && IRRLICHT_VERSION_MINOR>=8
 				mani->scale(meshcopy, vector3df((f32)letter_size.Width, (f32)letter_size.Height, 1));
 				#else
 				mani->scaleMesh(meshcopy, vector3df((f32)letter_size.Width, (f32)letter_size.Height, 1));
 				#endif
 
-				ISceneNode* current_node = smgr->addMeshSceneNode(meshcopy, parent, -1, current_pos);
+				ISceneNode *current_node = smgr->addMeshSceneNode(meshcopy, parent, -1, current_pos);
 				meshcopy->drop();
 
 				current_node->getMaterial(0) = mat;
@@ -1160,8 +1160,8 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 	for (u32 i = 0; i < glyph_indices.size(); ++i)
 	{
 		u32 n = glyph_indices[i];
-		SGUITTGlyph const& glyph = Glyphs[n-1];
-		ITexture* current_tex = Glyph_Pages[glyph.glyph_page]->texture;
+		SGUITTGlyph const &glyph = Glyphs[n-1];
+		ITexture *current_tex = Glyph_Pages[glyph.glyph_page]->texture;
 		f32 page_texture_size = (f32)current_tex->getSize().Width;
 		//Now we calculate the UV position according to the texture size and the source rect.
 		//
@@ -1177,9 +1177,9 @@ core::array<scene::ISceneNode*> CGUITTFont::addTextSceneNode(const wchar_t* text
 		f32 v2 = v1 + (glyph.source_rect.getHeight() / page_texture_size);
 
 		//we can be quite sure that this is IMeshSceneNode, because we just added them in the above loop.
-		IMeshSceneNode* node = static_cast<IMeshSceneNode*>(container[i]);
+		IMeshSceneNode *node = static_cast<IMeshSceneNode *>(container[i]);
 
-		S3DVertex* pv = static_cast<S3DVertex*>(node->getMesh()->getMeshBuffer(0)->getVertices());
+		S3DVertex *pv = static_cast<S3DVertex *>(node->getMesh()->getMeshBuffer(0)->getVertices());
 		//pv[0].TCoords.Y = pv[1].TCoords.Y = (letter_size.Height - 1) / static_cast<f32>(letter_size.Height);
 		//pv[1].TCoords.X = pv[3].TCoords.X = (letter_size.Width - 1)  / static_cast<f32>(letter_size.Width);
 		pv[0].TCoords = vector2df(u1, v2);

--- a/src/irrlicht_changes/CGUITTFont.h
+++ b/src/irrlicht_changes/CGUITTFont.h
@@ -71,13 +71,13 @@ namespace gui
 		//! However, it simply defines the SGUITTGlyph's properties and will only create the page
 		//! textures if necessary.  The actual creation of the textures should only occur right
 		//! before the batch draw call.
-		void preload(u32 char_index, FT_Face face, video::IVideoDriver* driver, u32 font_size, const FT_Int32 loadFlags);
+		void preload(u32 char_index, FT_Face face, video::IVideoDriver *driver, u32 font_size, const FT_Int32 loadFlags);
 
 		//! Unloads the glyph.
 		void unload();
 
 		//! Creates the IImage object from the FT_Bitmap.
-		video::IImage* createGlyphImage(const FT_Bitmap& bits, video::IVideoDriver* driver) const;
+		video::IImage *createGlyphImage(const FT_Bitmap &bits, video::IVideoDriver *driver) const;
 
 		//! If true, the glyph has been loaded.
 		bool isLoaded;
@@ -96,17 +96,17 @@ namespace gui
 
 		//! This is just the temporary image holder.  After this glyph is paged,
 		//! it will be dropped.
-		mutable video::IImage* surface;
+		mutable video::IImage *surface;
 
 		//! The pointer pointing to the parent (CGUITTFont)
-		CGUITTFont* parent;
+		CGUITTFont *parent;
 	};
 
 	//! Holds a sheet of glyphs.
 	class CGUITTGlyphPage
 	{
 		public:
-			CGUITTGlyphPage(video::IVideoDriver* Driver, const io::path& texture_name) :texture(0), available_slots(0), used_slots(0), dirty(false), driver(Driver), name(texture_name) {}
+			CGUITTGlyphPage(video::IVideoDriver *Driver, const io::path &texture_name) :texture(0), available_slots(0), used_slots(0), dirty(false), driver(Driver), name(texture_name) {}
 			~CGUITTGlyphPage()
 			{
 				if (texture)
@@ -118,7 +118,7 @@ namespace gui
 			}
 
 			//! Create the actual page texture,
-			bool createPageTexture(const u8& pixel_mode, const core::dimension2du& texture_size)
+			bool createPageTexture(const u8 &pixel_mode, const core::dimension2du &texture_size)
 			{
 				if( texture )
 					return false;
@@ -152,7 +152,7 @@ namespace gui
 
 			//! Add the glyph to a list of glyphs to be paged.
 			//! This collection will be cleared after updateTexture is called.
-			void pushGlyphToBePaged(const SGUITTGlyph* glyph)
+			void pushGlyphToBePaged(const SGUITTGlyph *glyph)
 			{
 				glyph_to_be_paged.push_back(glyph);
 			}
@@ -162,14 +162,14 @@ namespace gui
 			{
 				if (!dirty) return;
 
-				void* ptr = texture->lock();
+				void *ptr = texture->lock();
 				video::ECOLOR_FORMAT format = texture->getColorFormat();
 				core::dimension2du size = texture->getOriginalSize();
-				video::IImage* pageholder = driver->createImageFromData(format, size, ptr, true, false);
+				video::IImage *pageholder = driver->createImageFromData(format, size, ptr, true, false);
 
 				for (u32 i = 0; i < glyph_to_be_paged.size(); ++i)
 				{
-					const SGUITTGlyph* glyph = glyph_to_be_paged[i];
+					const SGUITTGlyph *glyph = glyph_to_be_paged[i];
 					if (glyph && glyph->isLoaded)
 					{
 						if (glyph->surface)
@@ -192,7 +192,7 @@ namespace gui
 				dirty = false;
 			}
 
-			video::ITexture* texture;
+			video::ITexture *texture;
 			u32 available_slots;
 			u32 used_slots;
 			bool dirty;
@@ -201,8 +201,8 @@ namespace gui
 			core::array<core::recti> render_source_rects;
 
 		private:
-			core::array<const SGUITTGlyph*> glyph_to_be_paged;
-			video::IVideoDriver* driver;
+			core::array<const SGUITTGlyph *> glyph_to_be_paged;
+			video::IVideoDriver *driver;
 			io::path name;
 	};
 
@@ -217,10 +217,10 @@ namespace gui
 			//! \param antialias set the use_monochrome (opposite to antialias) flag
 			//! \param transparency set the use_transparency flag
 			//! \return Returns a pointer to a CGUITTFont.  Will return 0 if the font failed to load.
-			static CGUITTFont* createTTFont(IGUIEnvironment *env, const io::path& filename, const u32 size, const bool antialias = true, const bool transparency = true, const u32 shadow = 0, const u32 shadow_alpha = 255);
-			static CGUITTFont* createTTFont(IrrlichtDevice *device, const io::path& filename, const u32 size, const bool antialias = true, const bool transparency = true);
-			static CGUITTFont* create(IGUIEnvironment *env, const io::path& filename, const u32 size, const bool antialias = true, const bool transparency = true);
-			static CGUITTFont* create(IrrlichtDevice *device, const io::path& filename, const u32 size, const bool antialias = true, const bool transparency = true);
+			static CGUITTFont *createTTFont(IGUIEnvironment *env, const io::path &filename, const u32 size, const bool antialias = true, const bool transparency = true, const u32 shadow = 0, const u32 shadow_alpha = 255);
+			static CGUITTFont *createTTFont(IrrlichtDevice *device, const io::path &filename, const u32 size, const bool antialias = true, const bool transparency = true);
+			static CGUITTFont *create(IGUIEnvironment *env, const io::path &filename, const u32 size, const bool antialias = true, const bool transparency = true);
+			static CGUITTFont *create(IrrlichtDevice *device, const io::path &filename, const u32 size, const bool antialias = true, const bool transparency = true);
 
 			//! Destructor
 			virtual ~CGUITTFont();
@@ -229,7 +229,7 @@ namespace gui
 			virtual void setBatchLoadSize(u32 batch_size) { batch_load_size = batch_size; }
 
 			//! Sets the maximum texture size for a page of glyphs.
-			virtual void setMaxPageTextureSize(const core::dimension2du& texture_size) { max_page_texture_size = texture_size; }
+			virtual void setMaxPageTextureSize(const core::dimension2du &texture_size) { max_page_texture_size = texture_size; }
 
 			//! Get the font size.
 			virtual u32 getFontSize() const { return size; }
@@ -265,11 +265,11 @@ namespace gui
 			virtual void setFontHinting(const bool enable, const bool enable_auto_hinting = true);
 
 			//! Draws some text and clips it to the specified rectangle if wanted.
-			virtual void draw(const core::stringw& text, const core::rect<s32>& position,
+			virtual void draw(const core::stringw &text, const core::rect<s32>& position,
 				video::SColor color, bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
-			virtual void draw(const EnrichedString& text, const core::rect<s32>& position,
+			virtual void draw(const EnrichedString &text, const core::rect<s32>& position,
 				video::SColor color, bool hcenter=false, bool vcenter=false,
 				const core::rect<s32>* clip=0);
 
@@ -277,12 +277,12 @@ namespace gui
 			virtual core::dimension2d<u32> getCharDimension(const wchar_t ch) const;
 
 			//! Returns the dimension of a text string.
-			virtual core::dimension2d<u32> getDimension(const wchar_t* text) const;
-			virtual core::dimension2d<u32> getDimension(const core::ustring& text) const;
+			virtual core::dimension2d<u32> getDimension(const wchar_t *text) const;
+			virtual core::dimension2d<u32> getDimension(const core::ustring &text) const;
 
 			//! Calculates the index of the character in the text which is on a specific position.
-			virtual s32 getCharacterFromPos(const wchar_t* text, s32 pixel_x) const;
-			virtual s32 getCharacterFromPos(const core::ustring& text, s32 pixel_x) const;
+			virtual s32 getCharacterFromPos(const wchar_t *text, s32 pixel_x) const;
+			virtual s32 getCharacterFromPos(const core::ustring &text, s32 pixel_x) const;
 
 			//! Sets global kerning width for the font.
 			virtual void setKerningWidth(s32 kerning);
@@ -291,7 +291,7 @@ namespace gui
 			virtual void setKerningHeight(s32 kerning);
 
 			//! Gets kerning values (distance between letters) for the font. If no parameters are provided,
-			virtual s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const;
+			virtual s32 getKerningWidth(const wchar_t *thisLetter=0, const wchar_t *previousLetter=0) const;
 			virtual s32 getKerningWidth(const uchar32_t thisLetter=0, const uchar32_t previousLetter=0) const;
 
 			//! Returns the distance between letters
@@ -299,16 +299,16 @@ namespace gui
 
 			//! Define which characters should not be drawn by the font.
 			virtual void setInvisibleCharacters(const wchar_t *s);
-			virtual void setInvisibleCharacters(const core::ustring& s);
+			virtual void setInvisibleCharacters(const core::ustring &s);
 
 			//! Get the last glyph page if there's still available slots.
 			//! If not, it will return zero.
-			CGUITTGlyphPage* getLastGlyphPage() const;
+			CGUITTGlyphPage *getLastGlyphPage() const;
 
 			//! Create a new glyph page texture.
 			//! \param pixel_mode the pixel mode defined by FT_Pixel_Mode
 			//should be better typed. fix later.
-			CGUITTGlyphPage* createGlyphPage(const u8& pixel_mode);
+			CGUITTGlyphPage *createGlyphPage(const u8 &pixel_mode);
 
 			//! Get the last glyph page's index.
 			u32 getLastGlyphPageIndex() const { return Glyph_Pages.size() - 1; }
@@ -316,16 +316,16 @@ namespace gui
 			//! Create corresponding character's software image copy from the font,
 			//! so you can use this data just like any ordinary video::IImage.
 			//! \param ch The character you need
-			virtual video::IImage* createTextureFromChar(const uchar32_t& ch);
+			virtual video::IImage *createTextureFromChar(const uchar32_t &ch);
 
 			//! This function is for debugging mostly. If the page doesn't exist it returns zero.
 			//! \param page_index Simply return the texture handle of a given page index.
-			virtual video::ITexture* getPageTextureByIndex(const u32& page_index) const;
+			virtual video::ITexture *getPageTextureByIndex(const u32 &page_index) const;
 
 			//! Add a list of scene nodes generated by putting font textures on the 3D planes.
-			virtual core::array<scene::ISceneNode*> addTextSceneNode
-				(const wchar_t* text, scene::ISceneManager* smgr, scene::ISceneNode* parent = 0,
-				 const video::SColor& color = video::SColor(255, 0, 0, 0), bool center = false );
+			virtual core::array<scene::ISceneNode *> addTextSceneNode
+				(const wchar_t *text, scene::ISceneManager *smgr, scene::ISceneNode *parent = 0,
+				 const video::SColor &color = video::SColor(255, 0, 0, 0), bool center = false );
 
 		protected:
 			bool use_monochrome;
@@ -339,13 +339,13 @@ namespace gui
 		private:
 			// Manages the FreeType library.
 			static FT_Library c_library;
-			static core::map<io::path, SGUITTFace*> c_faces;
+			static core::map<io::path, SGUITTFace *> c_faces;
 			static bool c_libraryLoaded;
-			static scene::IMesh* shared_plane_ptr_;
+			static scene::IMesh *shared_plane_ptr_;
 			static scene::SMesh  shared_plane_;
 
 			CGUITTFont(IGUIEnvironment *env);
-			bool load(const io::path& filename, const u32 size, const bool antialias, const bool transparency);
+			bool load(const io::path &filename, const u32 size, const bool antialias, const bool transparency);
 			void reset_images();
 			void update_glyph_pages() const;
 			void update_load_flags()
@@ -365,19 +365,19 @@ namespace gui
 			u32 getGlyphIndexByChar(uchar32_t c) const;
 			core::vector2di getKerning(const wchar_t thisLetter, const wchar_t previousLetter) const;
 			core::vector2di getKerning(const uchar32_t thisLetter, const uchar32_t previousLetter) const;
-			core::dimension2d<u32> getDimensionUntilEndOfLine(const wchar_t* p) const;
+			core::dimension2d<u32> getDimensionUntilEndOfLine(const wchar_t *p) const;
 
 			void createSharedPlane();
 
-			irr::IrrlichtDevice* Device;
-			gui::IGUIEnvironment* Environment;
-			video::IVideoDriver* Driver;
+			irr::IrrlichtDevice *Device;
+			gui::IGUIEnvironment *Environment;
+			video::IVideoDriver *Driver;
 			io::path filename;
 			FT_Face tt_face;
 			FT_Size_Metrics font_metrics;
 			FT_Int32 load_flags;
 
-			mutable core::array<CGUITTGlyphPage*> Glyph_Pages;
+			mutable core::array<CGUITTGlyphPage *> Glyph_Pages;
 			mutable core::array<SGUITTGlyph> Glyphs;
 
 			s32 GlobalKerningWidth;

--- a/src/irrlicht_changes/irrUString.h
+++ b/src/irrlicht_changes/irrUString.h
@@ -118,14 +118,14 @@ inline uchar32_t toUTF32(uchar16_t high, uchar16_t low)
 
 //! Swaps the endianness of a 16-bit value.
 //! \return The new value.
-inline uchar16_t swapEndian16(const uchar16_t& c)
+inline uchar16_t swapEndian16(const uchar16_t &c)
 {
 	return ((c >> 8) & 0x00FF) | ((c << 8) & 0xFF00);
 }
 
 //! Swaps the endianness of a 32-bit value.
 //! \return The new value.
-inline uchar32_t swapEndian32(const uchar32_t& c)
+inline uchar32_t swapEndian32(const uchar32_t &c)
 {
 	return  ((c >> 24) & 0x000000FF) |
 			((c >> 8)  & 0x0000FF00) |
@@ -230,7 +230,7 @@ inline core::array<u8> getUnicodeBOM(EUTF_ENCODE mode)
 //! Detects if the given data stream starts with a unicode BOM.
 //! \param data The data stream to check.
 //! \return The unicode BOM associated with the data stream, or EUTFE_NONE if none was found.
-inline EUTF_ENCODE determineUnicodeBOM(const char* data)
+inline EUTF_ENCODE determineUnicodeBOM(const char *data)
 {
 	if (memcmp(data, BOM_ENCODE_UTF8, 3) == 0) return EUTFE_UTF8;
 	if (memcmp(data, BOM_ENCODE_UTF16_BE, 2) == 0) return EUTFE_UTF16_BE;
@@ -268,7 +268,7 @@ public:
 			//! Allow one to change the character in the unicode string.
 			//! \param c The new character to use.
 			//! \return Myself.
-			_ustring16_iterator_access& operator=(const uchar32_t c)
+			_ustring16_iterator_access &operator=(const uchar32_t c)
 			{
 				_set(c);
 				return *this;
@@ -276,7 +276,7 @@ public:
 
 			//! Increments the value by 1.
 			//! \return Myself.
-			_ustring16_iterator_access& operator++()
+			_ustring16_iterator_access &operator++()
 			{
 				_set(_get() + 1);
 				return *this;
@@ -293,7 +293,7 @@ public:
 
 			//! Decrements the value by 1.
 			//! \return Myself.
-			_ustring16_iterator_access& operator--()
+			_ustring16_iterator_access &operator--()
 			{
 				_set(_get() - 1);
 				return *this;
@@ -311,7 +311,7 @@ public:
 			//! Adds to the value by a specified amount.
 			//! \param val The amount to add to this character.
 			//! \return Myself.
-			_ustring16_iterator_access& operator+=(int val)
+			_ustring16_iterator_access &operator+=(int val)
 			{
 				_set(_get() + val);
 				return *this;
@@ -320,7 +320,7 @@ public:
 			//! Subtracts from the value by a specified amount.
 			//! \param val The amount to subtract from this character.
 			//! \return Myself.
-			_ustring16_iterator_access& operator-=(int val)
+			_ustring16_iterator_access &operator-=(int val)
 			{
 				_set(_get() - val);
 				return *this;
@@ -329,7 +329,7 @@ public:
 			//! Multiples the value by a specified amount.
 			//! \param val The amount to multiply this character by.
 			//! \return Myself.
-			_ustring16_iterator_access& operator*=(int val)
+			_ustring16_iterator_access &operator*=(int val)
 			{
 				_set(_get() * val);
 				return *this;
@@ -338,7 +338,7 @@ public:
 			//! Divides the value by a specified amount.
 			//! \param val The amount to divide this character by.
 			//! \return Myself.
-			_ustring16_iterator_access& operator/=(int val)
+			_ustring16_iterator_access &operator/=(int val)
 			{
 				_set(_get() / val);
 				return *this;
@@ -347,7 +347,7 @@ public:
 			//! Modulos the value by a specified amount.
 			//! \param val The amount to modulo this character by.
 			//! \return Myself.
-			_ustring16_iterator_access& operator%=(int val)
+			_ustring16_iterator_access &operator%=(int val)
 			{
 				_set(_get() % val);
 				return *this;
@@ -397,7 +397,7 @@ public:
 			//! Gets a uchar32_t from our current position.
 			uchar32_t _get() const
 			{
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				if (!UTF16_IS_SURROGATE(a[pos]))
 					return static_cast<uchar32_t>(a[pos]);
 				else
@@ -413,7 +413,7 @@ public:
 			void _set(uchar32_t c)
 			{
 				ustring16<TAlloc>* ref2 = const_cast<ustring16<TAlloc>*>(ref);
-				const uchar16_t* a = ref2->c_str();
+				const uchar16_t *a = ref2->c_str();
 				if (c > 0xFFFF)
 				{
 					// c will be multibyte, so split it up into the high and low surrogate pairs.
@@ -481,7 +481,7 @@ public:
 #endif
 
 			//! Constructors.
-			_ustring16_const_iterator(const _Iter& i) : ref(i.ref), pos(i.pos) {}
+			_ustring16_const_iterator(const _Iter &i) : ref(i.ref), pos(i.pos) {}
 			_ustring16_const_iterator(const ustring16<TAlloc>& s) : ref(&s), pos(0) {}
 			_ustring16_const_iterator(const ustring16<TAlloc>& s, const u32 p) : ref(&s), pos(0)
 			{
@@ -491,7 +491,7 @@ public:
 				// Go to the appropriate position.
 				u32 i = p;
 				u32 sr = ref->size_raw();
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				while (i != 0 && pos < sr)
 				{
 					if (UTF16_IS_SURROGATE_HI(a[pos]))
@@ -502,7 +502,7 @@ public:
 			}
 
 			//! Test for equalness.
-			bool operator==(const _Iter& iter) const
+			bool operator==(const _Iter &iter) const
 			{
 				if (ref == iter.ref && pos == iter.pos)
 					return true;
@@ -510,7 +510,7 @@ public:
 			}
 
 			//! Test for unequalness.
-			bool operator!=(const _Iter& iter) const
+			bool operator!=(const _Iter &iter) const
 			{
 				if (ref != iter.ref || pos != iter.pos)
 					return true;
@@ -518,10 +518,10 @@ public:
 			}
 
 			//! Switch to the next full character in the string.
-			_Iter& operator++()
+			_Iter &operator++()
 			{	// ++iterator
 				if (pos == ref->size_raw()) return *this;
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				if (UTF16_IS_SURROGATE_HI(a[pos]))
 					pos += 2;			// TODO: check for valid low surrogate?
 				else ++pos;
@@ -538,10 +538,10 @@ public:
 			}
 
 			//! Switch to the previous full character in the string.
-			_Iter& operator--()
+			_Iter &operator--()
 			{	// --iterator
 				if (pos == 0) return *this;
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				--pos;
 				if (UTF16_IS_SURROGATE_LO(a[pos]) && pos != 0)	// low surrogate, go back one more.
 					--pos;
@@ -558,7 +558,7 @@ public:
 
 			//! Advance a specified number of full characters in the string.
 			//! \return Myself.
-			_Iter& operator+=(const difference_type v)
+			_Iter &operator+=(const difference_type v)
 			{
 				if (v == 0) return *this;
 				if (v < 0) return operator-=(v * -1);
@@ -570,7 +570,7 @@ public:
 				// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
 				u32 i = (u32)v;
 				u32 sr = ref->size_raw();
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				while (i != 0 && pos < sr)
 				{
 					if (UTF16_IS_SURROGATE_HI(a[pos]))
@@ -586,7 +586,7 @@ public:
 
 			//! Go back a specified number of full characters in the string.
 			//! \return Myself.
-			_Iter& operator-=(const difference_type v)
+			_Iter &operator-=(const difference_type v)
 			{
 				if (v == 0) return *this;
 				if (v > 0) return operator+=(v * -1);
@@ -597,7 +597,7 @@ public:
 				// Go to the appropriate position.
 				// TODO: Don't force u32 on an x64 OS.  Make it agnostic.
 				u32 i = (u32)v;
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				while (i != 0 && pos != 0)
 				{
 					--pos;
@@ -626,7 +626,7 @@ public:
 			}
 
 			//! Returns the distance between two iterators.
-			difference_type operator-(const _Iter& iter) const
+			difference_type operator-(const _Iter &iter) const
 			{
 				// Make sure we reference the same object!
 				if (ref != iter.ref)
@@ -660,7 +660,7 @@ public:
 			{
 				if (pos >= ref->size_raw())
 				{
-					const uchar16_t* a = ref->c_str();
+					const uchar16_t *a = ref->c_str();
 					u32 p = ref->size_raw();
 					if (UTF16_IS_SURROGATE_LO(a[p]))
 						--p;
@@ -676,7 +676,7 @@ public:
 			{
 				if (pos >= ref->size_raw())
 				{
-					const uchar16_t* a = ref->c_str();
+					const uchar16_t *a = ref->c_str();
 					u32 p = ref->size_raw();
 					if (UTF16_IS_SURROGATE_LO(a[p]))
 						--p;
@@ -708,7 +708,7 @@ public:
 			//! Is the iterator at the end of the string?
 			bool atEnd() const
 			{
-				const uchar16_t* a = ref->c_str();
+				const uchar16_t *a = ref->c_str();
 				if (UTF16_IS_SURROGATE(a[pos]))
 					return (pos + 1) >= ref->size_raw();
 				else return pos >= ref->size_raw();
@@ -758,7 +758,7 @@ public:
 			using _Base::ref;
 
 			//! Constructors.
-			_ustring16_iterator(const _Iter& i) : _ustring16_const_iterator(i) {}
+			_ustring16_iterator(const _Iter &i) : _ustring16_const_iterator(i) {}
 			_ustring16_iterator(const ustring16<TAlloc>& s) : _ustring16_const_iterator(s) {}
 			_ustring16_iterator(const ustring16<TAlloc>& s, const u32 p) : _ustring16_const_iterator(s, p) {}
 
@@ -767,7 +767,7 @@ public:
 			{
 				if (pos >= ref->size_raw())
 				{
-					const uchar16_t* a = ref->c_str();
+					const uchar16_t *a = ref->c_str();
 					u32 p = ref->size_raw();
 					if (UTF16_IS_SURROGATE_LO(a[p]))
 						--p;
@@ -783,7 +783,7 @@ public:
 			{
 				if (pos >= ref->size_raw())
 				{
-					const uchar16_t* a = ref->c_str();
+					const uchar16_t *a = ref->c_str();
 					u32 p = ref->size_raw();
 					if (UTF16_IS_SURROGATE_LO(a[p]))
 						--p;
@@ -891,7 +891,7 @@ public:
 
 #ifndef USTRING_CPP0X_NEWLITERALS
 	//! Constructor for copying a character string from a pointer.
-	ustring16(const char* const c)
+	ustring16(const char *const c)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -901,12 +901,12 @@ public:
 #endif
 
 		loadDataStream(c, strlen(c));
-		//append((uchar8_t*)c);
+		//append((uchar8_t *)c);
 	}
 
 
 	//! Constructor for copying a character string from a pointer with a given length.
-	ustring16(const char* const c, u32 length)
+	ustring16(const char *const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -921,7 +921,7 @@ public:
 
 
 	//! Constructor for copying a UTF-8 string from a pointer.
-	ustring16(const uchar8_t* const c)
+	ustring16(const uchar8_t *const c)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -949,7 +949,7 @@ public:
 
 
 	//! Constructor for copying a UTF-8 string from a pointer with a given length.
-	ustring16(const uchar8_t* const c, u32 length)
+	ustring16(const uchar8_t *const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -963,7 +963,7 @@ public:
 
 
 	//! Constructor for copying a UTF-16 string from a pointer.
-	ustring16(const uchar16_t* const c)
+	ustring16(const uchar16_t *const c)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -977,7 +977,7 @@ public:
 
 
 	//! Constructor for copying a UTF-16 string from a pointer with a given length
-	ustring16(const uchar16_t* const c, u32 length)
+	ustring16(const uchar16_t *const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -991,7 +991,7 @@ public:
 
 
 	//! Constructor for copying a UTF-32 string from a pointer.
-	ustring16(const uchar32_t* const c)
+	ustring16(const uchar32_t *const c)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -1005,7 +1005,7 @@ public:
 
 
 	//! Constructor for copying a UTF-32 from a pointer with a given length.
-	ustring16(const uchar32_t* const c, u32 length)
+	ustring16(const uchar32_t *const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -1019,7 +1019,7 @@ public:
 
 
 	//! Constructor for copying a wchar_t string from a pointer.
-	ustring16(const wchar_t* const c)
+	ustring16(const wchar_t *const c)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -1029,16 +1029,16 @@ public:
 #endif
 
 		if (sizeof(wchar_t) == 4)
-			append(reinterpret_cast<const uchar32_t* const>(c));
+			append(reinterpret_cast<const uchar32_t *const>(c));
 		else if (sizeof(wchar_t) == 2)
-			append(reinterpret_cast<const uchar16_t* const>(c));
+			append(reinterpret_cast<const uchar16_t *const>(c));
 		else if (sizeof(wchar_t) == 1)
-			append(reinterpret_cast<const uchar8_t* const>(c));
+			append(reinterpret_cast<const uchar8_t *const>(c));
 	}
 
 
 	//! Constructor for copying a wchar_t string from a pointer with a given length.
-	ustring16(const wchar_t* const c, u32 length)
+	ustring16(const wchar_t *const c, u32 length)
 	: array(0), allocated(0), used(0)
 	{
 #if __BYTE_ORDER == __BIG_ENDIAN
@@ -1048,11 +1048,11 @@ public:
 #endif
 
 		if (sizeof(wchar_t) == 4)
-			append(reinterpret_cast<const uchar32_t* const>(c), length);
+			append(reinterpret_cast<const uchar32_t *const>(c), length);
 		else if (sizeof(wchar_t) == 2)
-			append(reinterpret_cast<const uchar16_t* const>(c), length);
+			append(reinterpret_cast<const uchar16_t *const>(c), length);
 		else if (sizeof(wchar_t) == 1)
-			append(reinterpret_cast<const uchar8_t* const>(c), length);
+			append(reinterpret_cast<const uchar8_t *const>(c), length);
 	}
 
 
@@ -1077,7 +1077,7 @@ public:
 
 
 	//! Assignment operator
-	ustring16& operator=(const ustring16<TAlloc>& other)
+	ustring16 &operator=(const ustring16<TAlloc>& other)
 	{
 		if (this == &other)
 			return *this;
@@ -1090,7 +1090,7 @@ public:
 			array = allocator.allocate(used + 1); //new u16[used];
 		}
 
-		const uchar16_t* p = other.c_str();
+		const uchar16_t *p = other.c_str();
 		for (u32 i=0; i<=used; ++i, ++p)
 			array[i] = *p;
 
@@ -1105,7 +1105,7 @@ public:
 
 #ifdef USTRING_CPP0X
 	//! Move assignment operator
-	ustring16& operator=(ustring16<TAlloc>&& other)
+	ustring16 &operator=(ustring16<TAlloc>&& other)
 	{
 		if (this != &other)
 		{
@@ -1134,7 +1134,7 @@ public:
 
 
 	//! Assignment operator for UTF-8 strings
-	ustring16<TAlloc>& operator=(const uchar8_t* const c)
+	ustring16<TAlloc>& operator=(const uchar8_t *const c)
 	{
 		if (!array)
 		{
@@ -1152,7 +1152,7 @@ public:
 
 
 	//! Assignment operator for UTF-16 strings
-	ustring16<TAlloc>& operator=(const uchar16_t* const c)
+	ustring16<TAlloc>& operator=(const uchar16_t *const c)
 	{
 		if (!array)
 		{
@@ -1170,7 +1170,7 @@ public:
 
 
 	//! Assignment operator for UTF-32 strings
-	ustring16<TAlloc>& operator=(const uchar32_t* const c)
+	ustring16<TAlloc>& operator=(const uchar32_t *const c)
 	{
 		if (!array)
 		{
@@ -1191,14 +1191,14 @@ public:
 	/** Note that this assumes that a correct unicode string is stored in the wchar_t string.
 		Since wchar_t changes depending on its platform, it could either be a UTF-8, -16, or -32 string.
 		This function assumes you are storing the correct unicode encoding inside the wchar_t string. **/
-	ustring16<TAlloc>& operator=(const wchar_t* const c)
+	ustring16<TAlloc>& operator=(const wchar_t *const c)
 	{
 		if (sizeof(wchar_t) == 4)
-			*this = reinterpret_cast<const uchar32_t* const>(c);
+			*this = reinterpret_cast<const uchar32_t *const>(c);
 		else if (sizeof(wchar_t) == 2)
-			*this = reinterpret_cast<const uchar16_t* const>(c);
+			*this = reinterpret_cast<const uchar16_t *const>(c);
 		else if (sizeof(wchar_t) == 1)
-			*this = reinterpret_cast<const uchar8_t* const>(c);
+			*this = reinterpret_cast<const uchar8_t *const>(c);
 
 		return *this;
 	}
@@ -1207,14 +1207,14 @@ public:
 	//! Assignment operator for other strings.
 	/** Note that this assumes that a correct unicode string is stored in the string. **/
 	template <class B>
-	ustring16<TAlloc>& operator=(const B* const c)
+	ustring16<TAlloc>& operator=(const B *const c)
 	{
 		if (sizeof(B) == 4)
-			*this = reinterpret_cast<const uchar32_t* const>(c);
+			*this = reinterpret_cast<const uchar32_t *const>(c);
 		else if (sizeof(B) == 2)
-			*this = reinterpret_cast<const uchar16_t* const>(c);
+			*this = reinterpret_cast<const uchar16_t *const>(c);
 		else if (sizeof(B) == 1)
-			*this = reinterpret_cast<const uchar8_t* const>(c);
+			*this = reinterpret_cast<const uchar8_t *const>(c);
 
 		return *this;
 	}
@@ -1239,7 +1239,7 @@ public:
 
 
 	//! Equality operator
-	bool operator ==(const uchar16_t* const str) const
+	bool operator ==(const uchar16_t *const str) const
 	{
 		if (!str)
 			return false;
@@ -1279,7 +1279,7 @@ public:
 
 
 	//! Inequality operator
-	bool operator !=(const uchar16_t* const str) const
+	bool operator !=(const uchar16_t *const str) const
 	{
 		return !(*this == str);
 	}
@@ -1317,7 +1317,7 @@ public:
 
 	//! Returns a pointer to the raw UTF-16 string data.
 	//! \return pointer to C-style NUL terminated array of UTF-16 code points.
-	const uchar16_t* c_str() const
+	const uchar16_t *c_str() const
 	{
 		return array;
 	}
@@ -1330,7 +1330,7 @@ public:
 	bool equalsn(const ustring16<TAlloc>& other, u32 n) const
 	{
 		u32 i;
-		const uchar16_t* oa = other.c_str();
+		const uchar16_t *oa = other.c_str();
 		for(i=0; array[i] && oa[i] && i < n; ++i)
 			if (array[i] != oa[i])
 				return false;
@@ -1345,7 +1345,7 @@ public:
 	//! \param str Other string to compare to.
 	//! \param n Number of characters to compare.
 	//! \return True if the n first characters of both strings are equal.
-	bool equalsn(const uchar16_t* const str, u32 n) const
+	bool equalsn(const uchar16_t *const str, u32 n) const
 	{
 		if (!str)
 			return false;
@@ -1394,14 +1394,14 @@ public:
 	//! \param other The UTF-8 string to append.
 	//! \param length The length of the string to append.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar8_t* const other, u32 length=0xffffffff)
+	ustring16<TAlloc>& append(const uchar8_t *const other, u32 length = 0xffffffff)
 	{
 		if (!other)
 			return *this;
 
 		// Determine if the string is long enough for a BOM.
 		u32 len = 0;
-		const uchar8_t* p = other;
+		const uchar8_t *p = other;
 		do
 		{
 			++len;
@@ -1416,7 +1416,7 @@ public:
 		}
 
 		// If a BOM was found, don't include it in the string.
-		const uchar8_t* c2 = other;
+		const uchar8_t *c2 = other;
 		if (c_bom != unicode::EUTFE_NONE)
 		{
 			c2 = other + unicode::BOM_UTF8_LEN;
@@ -1570,14 +1570,14 @@ public:
 	//! \param other The UTF-16 string to append.
 	//! \param length The length of the string to append.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar16_t* const other, u32 length=0xffffffff)
+	ustring16<TAlloc>& append(const uchar16_t *const other, u32 length=0xffffffff)
 	{
 		if (!other)
 			return *this;
 
 		// Determine if the string is long enough for a BOM.
 		u32 len = 0;
-		const uchar16_t* p = other;
+		const uchar16_t *p = other;
 		do
 		{
 			++len;
@@ -1591,7 +1591,7 @@ public:
 			c_end = unicode::EUTFEE_BIG;
 
 		// If a BOM was found, don't include it in the string.
-		const uchar16_t* c2 = other;
+		const uchar16_t *c2 = other;
 		if (c_end != unicode::EUTFEE_NATIVE)
 		{
 			c2 = other + unicode::BOM_UTF16_LEN;
@@ -1635,7 +1635,7 @@ public:
 	//! \param other The UTF-32 string to append.
 	//! \param length The length of the string to append.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& append(const uchar32_t* const other, u32 length=0xffffffff)
+	ustring16<TAlloc>& append(const uchar32_t *const other, u32 length=0xffffffff)
 	{
 		if (!other)
 			return *this;
@@ -1648,7 +1648,7 @@ public:
 			c_end = unicode::EUTFEE_BIG;
 
 		// If a BOM was found, don't include it in the string.
-		const uchar32_t* c2 = other;
+		const uchar32_t *c2 = other;
 		if (c_end != unicode::EUTFEE_NATIVE)
 		{
 			c2 = other + unicode::BOM_UTF32_LEN;
@@ -1657,7 +1657,7 @@ public:
 
 		// Calculate the size of the string to read in.
 		u32 len = 0;
-		const uchar32_t* p = c2;
+		const uchar32_t *p = c2;
 		do
 		{
 			++len;
@@ -1713,7 +1713,7 @@ public:
 	//! \return A reference to our current string.
 	ustring16<TAlloc>& append(const ustring16<TAlloc>& other)
 	{
-		const uchar16_t* oa = other.c_str();
+		const uchar16_t *oa = other.c_str();
 
 		u32 len = other.size_raw();
 
@@ -1797,7 +1797,7 @@ public:
 	//! \param c A list of characters to find. For example if the method should find the first occurrence of 'a' or 'b', this parameter should be "ab".
 	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
 	//! \return Position where one of the characters has been found, or -1 if not found.
-	s32 findFirstChar(const uchar32_t* const c, u32 count=1) const
+	s32 findFirstChar(const uchar32_t *const c, u32 count=1) const
 	{
 		if (!c || !count)
 			return -1;
@@ -1823,7 +1823,7 @@ public:
 	//! \param c A list of characters to NOT find. For example if the method should find the first occurrence of a character not 'a' or 'b', this parameter should be "ab".
 	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
 	//! \return Position where the character has been found, or -1 if not found.
-	s32 findFirstCharNotInList(const uchar32_t* const c, u32 count=1) const
+	s32 findFirstCharNotInList(const uchar32_t *const c, u32 count=1) const
 	{
 		if (!c || !count)
 			return -1;
@@ -1852,7 +1852,7 @@ public:
 	//! \param c A list of characters to NOT find. For example if the method should find the first occurrence of a character not 'a' or 'b', this parameter should be "ab".
 	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
 	//! \return Position where the character has been found, or -1 if not found.
-	s32 findLastCharNotInList(const uchar32_t* const c, u32 count=1) const
+	s32 findLastCharNotInList(const uchar32_t *const c, u32 count=1) const
 	{
 		if (!c || !count)
 			return -1;
@@ -1927,7 +1927,7 @@ public:
 	//! \param c A list of strings to find. For example if the method should find the last occurrence of 'a' or 'b', this parameter should be "ab".
 	//! \param count The amount of characters in the list. Usually, this should be strlen(c).
 	//! \return Position where one of the characters has been found, or -1 if not found.
-	s32 findLastChar(const uchar32_t* const c, u32 count=1) const
+	s32 findLastChar(const uchar32_t *const c, u32 count=1) const
 	{
 		if (!c || !count)
 			return -1;
@@ -1994,7 +1994,7 @@ public:
 	//! \return Positions where the string has been found, or -1 if not found.
 	s32 find_raw(const ustring16<TAlloc>& str, const u32 start = 0) const
 	{
-		const uchar16_t* data = str.c_str();
+		const uchar16_t *data = str.c_str();
 		if (data && *data)
 		{
 			u32 len = 0;
@@ -2146,7 +2146,7 @@ public:
 	//! Appends a char ustring16 to this ustring16.
 	//! \param c Char ustring16 to append.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& operator += (const uchar16_t* const c)
+	ustring16<TAlloc>& operator += (const uchar16_t *const c)
 	{
 		append(c);
 		return *this;
@@ -2190,8 +2190,8 @@ public:
 		if (toReplace.size() == 0)
 			return *this;
 
-		const uchar16_t* other = toReplace.c_str();
-		const uchar16_t* replace = replaceWith.c_str();
+		const uchar16_t *other = toReplace.c_str();
+		const uchar16_t *replace = replaceWith.c_str();
 		const u32 other_size = toReplace.size_raw();
 		const u32 replace_size = replaceWith.size_raw();
 
@@ -2267,9 +2267,9 @@ public:
 		pos = 0;
 		while ((pos = find_raw(other, pos)) != -1)
 		{
-			uchar16_t* start = array + pos + other_size - 1;
-			uchar16_t* ptr   = array + used;
-			uchar16_t* end   = array + used + delta;
+			uchar16_t *start = array + pos + other_size - 1;
+			uchar16_t *ptr   = array + used;
+			uchar16_t *end   = array + used + delta;
 
 			// Shift characters to make room for the string.
 			while (ptr != start)
@@ -2337,7 +2337,7 @@ public:
 		u32 size = toRemove.size_raw();
 		if (size == 0) return *this;
 
-		const uchar16_t* tra = toRemove.c_str();
+		const uchar16_t *tra = toRemove.c_str();
 		u32 pos = 0;
 		u32 found = 0;
 		for (u32 i=0; i<=used; ++i)
@@ -2537,7 +2537,7 @@ public:
 	\return The number of resulting substrings
 	*/
 	template<class container>
-	u32 split(container& ret, const uchar32_t* const c, u32 count=1, bool ignoreEmptyTokens=true, bool keepSeparators=false) const
+	u32 split(container &ret, const uchar32_t *const c, u32 count=1, bool ignoreEmptyTokens=true, bool keepSeparators=false) const
 	{
 		if (!c)
 			return 0;
@@ -2594,7 +2594,7 @@ public:
 	\return The number of resulting substrings
 	*/
 	template<class container>
-	u32 split(container& ret, const ustring16<TAlloc>& c, bool ignoreEmptyTokens=true, bool keepSeparators=false) const
+	u32 split(container &ret, const ustring16<TAlloc>& c, bool ignoreEmptyTokens=true, bool keepSeparators=false) const
 	{
 		core::array<uchar32_t> v = c.toUTF32();
 		return split(ret, v.pointer(), v.size(), ignoreEmptyTokens, keepSeparators);
@@ -2670,7 +2670,7 @@ public:
 		for (u32 i = used - 2; i > iter.getPos() + len; --i)
 			array[i] = array[i - len];
 
-		const uchar16_t* s = c.c_str();
+		const uchar16_t *s = c.c_str();
 		for (u32 i = 0; i < len; ++i)
 		{
 			array[pos++] = *s;
@@ -2916,13 +2916,13 @@ public:
 				ret[0] = unicode::BOM;
 			else if (endian == unicode::EUTFEE_LITTLE)
 			{
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(&ret[0]);
+				uchar8_t *ptr8 = reinterpret_cast<uchar8_t *>(&ret[0]);
 				*ptr8++ = unicode::BOM_ENCODE_UTF16_LE[0];
 				*ptr8 = unicode::BOM_ENCODE_UTF16_LE[1];
 			}
 			else
 			{
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(&ret[0]);
+				uchar8_t *ptr8 = reinterpret_cast<uchar8_t *>(&ret[0]);
 				*ptr8++ = unicode::BOM_ENCODE_UTF16_BE[0];
 				*ptr8 = unicode::BOM_ENCODE_UTF16_BE[1];
 			}
@@ -2931,7 +2931,7 @@ public:
 		ret.append(array);
 		if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian)
 		{
-			char16_t* ptr = ret.c_str();
+			char16_t *ptr = ret.c_str();
 			for (u32 i = 0; i < ret.size(); ++i)
 				*ptr++ = unicode::swapEndian16(*ptr);
 		}
@@ -2948,7 +2948,7 @@ public:
 	core::array<uchar16_t> toUTF16(const unicode::EUTF_ENDIAN endian = unicode::EUTFEE_NATIVE, const bool addBOM = false) const
 	{
 		core::array<uchar16_t> ret(used + (addBOM ? unicode::BOM_UTF16_LEN : 0) + 1);
-		uchar16_t* ptr = ret.pointer();
+		uchar16_t *ptr = ret.pointer();
 
 		// Add the BOM if specified.
 		if (addBOM)
@@ -2957,20 +2957,20 @@ public:
 				*ptr = unicode::BOM;
 			else if (endian == unicode::EUTFEE_LITTLE)
 			{
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ptr);
+				uchar8_t *ptr8 = reinterpret_cast<uchar8_t *>(ptr);
 				*ptr8++ = unicode::BOM_ENCODE_UTF16_LE[0];
 				*ptr8 = unicode::BOM_ENCODE_UTF16_LE[1];
 			}
 			else
 			{
-				uchar8_t* ptr8 = reinterpret_cast<uchar8_t*>(ptr);
+				uchar8_t *ptr8 = reinterpret_cast<uchar8_t *>(ptr);
 				*ptr8++ = unicode::BOM_ENCODE_UTF16_BE[0];
 				*ptr8 = unicode::BOM_ENCODE_UTF16_BE[1];
 			}
 			++ptr;
 		}
 
-		memcpy((void*)ptr, (void*)array, used * sizeof(uchar16_t));
+		memcpy((void *)ptr, (void *)array, used * sizeof(uchar16_t));
 		if (endian != unicode::EUTFEE_NATIVE && getEndianness() != endian)
 		{
 			for (u32 i = 0; i <= used; ++i)
@@ -3144,7 +3144,7 @@ public:
 			core::array<uchar32_t> a(toUTF32(endian, addBOM));
 			core::array<wchar_t> ret(a.size());
 			ret.set_used(a.size());
-			memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar32_t));
+			memcpy((void *)ret.pointer(), (void *)a.pointer(), a.size() * sizeof(uchar32_t));
 			return ret;
 		}
 		if (sizeof(wchar_t) == 2)
@@ -3153,7 +3153,7 @@ public:
 			{
 				core::array<wchar_t> ret(used);
 				ret.set_used(used);
-				memcpy((void*)ret.pointer(), (void*)array, used * sizeof(uchar16_t));
+				memcpy((void *)ret.pointer(), (void *)array, used * sizeof(uchar16_t));
 				return ret;
 			}
 			else
@@ -3161,7 +3161,7 @@ public:
 				core::array<uchar16_t> a(toUTF16(endian, addBOM));
 				core::array<wchar_t> ret(a.size());
 				ret.set_used(a.size());
-				memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar16_t));
+				memcpy((void *)ret.pointer(), (void *)a.pointer(), a.size() * sizeof(uchar16_t));
 				return ret;
 			}
 		}
@@ -3170,7 +3170,7 @@ public:
 			core::array<uchar8_t> a(toUTF8(addBOM));
 			core::array<wchar_t> ret(a.size());
 			ret.set_used(a.size());
-			memcpy((void*)ret.pointer(), (void*)a.pointer(), a.size() * sizeof(uchar8_t));
+			memcpy((void *)ret.pointer(), (void *)a.pointer(), a.size() * sizeof(uchar8_t));
 			return ret;
 		}
 
@@ -3196,7 +3196,7 @@ public:
 	//! \param data The data stream to load from.
 	//! \param data_size The length of the data string.
 	//! \return A reference to our current string.
-	ustring16<TAlloc>& loadDataStream(const char* data, size_t data_size)
+	ustring16<TAlloc>& loadDataStream(const char *data, size_t data_size)
 	{
 		// Clear our string.
 		*this = "";
@@ -3208,19 +3208,19 @@ public:
 		{
 			default:
 			case unicode::EUTFE_UTF8:
-				append((uchar8_t*)data, data_size);
+				append((uchar8_t *)data, data_size);
 				break;
 
 			case unicode::EUTFE_UTF16:
 			case unicode::EUTFE_UTF16_BE:
 			case unicode::EUTFE_UTF16_LE:
-				append((uchar16_t*)data, data_size / 2);
+				append((uchar16_t *)data, data_size / 2);
 				break;
 
 			case unicode::EUTFE_UTF32:
 			case unicode::EUTFE_UTF32_BE:
 			case unicode::EUTFE_UTF32_LE:
-				append((uchar32_t*)data, data_size / 4);
+				append((uchar32_t *)data, data_size / 4);
 				break;
 		}
 
@@ -3250,7 +3250,7 @@ private:
 	//! \param new_size The new size of the string.
 	void reallocate(u32 new_size)
 	{
-		uchar16_t* old_array = array;
+		uchar16_t *old_array = array;
 
 		array = allocator.allocate(new_size + 1); //new u16[new_size];
 		allocated = new_size + 1;
@@ -3270,7 +3270,7 @@ private:
 
 	//--- member variables
 
-	uchar16_t* array;
+	uchar16_t *array;
 	unicode::EUTF_ENCODE encoding;
 	u32 allocated;
 	u32 used;
@@ -3293,7 +3293,7 @@ inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const ustring1
 
 //! Appends a ustring16 and a null-terminated unicode string.
 template <typename TAlloc, class B>
-inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const B* const right)
+inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const B *const right)
 {
 	ustring16<TAlloc> ret(left);
 	ret += right;
@@ -3303,7 +3303,7 @@ inline ustring16<TAlloc> operator+(const ustring16<TAlloc>& left, const B* const
 
 //! Appends a ustring16 and a null-terminated unicode string.
 template <class B, typename TAlloc>
-inline ustring16<TAlloc> operator+(const B* const left, const ustring16<TAlloc>& right)
+inline ustring16<TAlloc> operator+(const B *const left, const ustring16<TAlloc>& right)
 {
 	ustring16<TAlloc> ret(left);
 	ret += right;
@@ -3595,9 +3595,9 @@ inline ustring16<TAlloc>&& operator+(ustring16<TAlloc>&& left, ustring16<TAlloc>
 
 //! Appends a ustring16 and a null-terminated unicode string.
 template <typename TAlloc, class B>
-inline ustring16<TAlloc>&& operator+(ustring16<TAlloc>&& left, const B* const right)
+inline ustring16<TAlloc>&& operator+(ustring16<TAlloc>&& left, const B * const right)
 {
-	//std::cout << "MOVE operator+(&&, B*)" << std::endl;
+	//std::cout << "MOVE operator+(&&, B *)" << std::endl;
 	left.append(right);
 	return std::move(left);
 }
@@ -3605,7 +3605,7 @@ inline ustring16<TAlloc>&& operator+(ustring16<TAlloc>&& left, const B* const ri
 
 //! Appends a ustring16 and a null-terminated unicode string.
 template <class B, typename TAlloc>
-inline ustring16<TAlloc>&& operator+(const B* const left, ustring16<TAlloc>&& right)
+inline ustring16<TAlloc>&& operator+(const B *const left, ustring16<TAlloc>&& right)
 {
 	//std::cout << "MOVE operator+(B*, &&)" << std::endl;
 	right.insert(left, 0);
@@ -3839,7 +3839,7 @@ inline ustring16<TAlloc> operator+(const double left, ustring16<TAlloc>&& right)
 #ifndef USTRING_NO_STL
 //! Writes a ustring16 to an ostream.
 template <typename TAlloc>
-inline std::ostream& operator<<(std::ostream& out, const ustring16<TAlloc>& in)
+inline std::ostream &operator<<(std::ostream &out, const ustring16<TAlloc>& in)
 {
 	out << in.toUTF8_s().c_str();
 	return out;
@@ -3847,7 +3847,7 @@ inline std::ostream& operator<<(std::ostream& out, const ustring16<TAlloc>& in)
 
 //! Writes a ustring16 to a wostream.
 template <typename TAlloc>
-inline std::wostream& operator<<(std::wostream& out, const ustring16<TAlloc>& in)
+inline std::wostream &operator<<(std::wostream &out, const ustring16<TAlloc>& in)
 {
 	out << in.toWCHAR_s().c_str();
 	return out;
@@ -3865,7 +3865,7 @@ namespace unicode
 class hash : public std::unary_function<core::ustring, size_t>
 {
 	public:
-		size_t operator()(const core::ustring& s) const
+		size_t operator()(const core::ustring &s) const
 		{
 			size_t ret = 2166136261U;
 			size_t index = 0;

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -27,7 +27,7 @@ namespace gui
 {
 //! constructor
 StaticText::StaticText(const EnrichedString &text, bool border,
-			IGUIEnvironment* environment, IGUIElement* parent,
+			IGUIEnvironment *environment, IGUIElement *parent,
 			s32 id, const core::rect<s32>& rectangle,
 			bool background)
 : IGUIStaticText(environment, parent, id, rectangle),
@@ -63,10 +63,10 @@ void StaticText::draw()
 	if (!IsVisible)
 		return;
 
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (!skin)
 		return;
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	core::rect<s32> frameRect(AbsoluteRect);
 
@@ -91,7 +91,7 @@ void StaticText::draw()
 	// draw the text
 	if (cText.size())
 	{
-		IGUIFont* font = getActiveFont();
+		IGUIFont *font = getActiveFont();
 
 		if (font)
 		{
@@ -109,7 +109,7 @@ void StaticText::draw()
 						font->getDimension(cText.c_str()).Width;
 				}
 
-				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
+				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont *>(font);
 				tmp->draw(cText, frameRect,
 					OverrideColorEnabled ? OverrideColor : skin->getColor(isEnabled() ? EGDC_BUTTON_TEXT : EGDC_GRAY_TEXT),
 					HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER, (RestrainTextInside ? &AbsoluteClippingRect : NULL));
@@ -148,7 +148,7 @@ void StaticText::draw()
 					//if (!colors.empty())
 					//	previous_color = colors[colors.size() - 1];
 
-					irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
+					irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont *>(font);
 					tmp->draw(str, r,
 						previous_color, // FIXME
 						HAlign == EGUIA_CENTER, false, (RestrainTextInside ? &AbsoluteClippingRect : NULL));
@@ -165,7 +165,7 @@ void StaticText::draw()
 
 
 //! Sets another skin independent font.
-void StaticText::setOverrideFont(IGUIFont* font)
+void StaticText::setOverrideFont(IGUIFont *font)
 {
 	if (OverrideFont == font)
 		return;
@@ -188,11 +188,11 @@ IGUIFont * StaticText::getOverrideFont() const
 }
 
 //! Get the font which is used right now for drawing
-IGUIFont* StaticText::getActiveFont() const
+IGUIFont *StaticText::getActiveFont() const
 {
 	if ( OverrideFont )
 		return OverrideFont;
-	IGUISkin* skin = Environment->getSkin();
+	IGUISkin *skin = Environment->getSkin();
 	if (skin)
 		return skin->getFont();
 	return 0;
@@ -270,7 +270,7 @@ void StaticText::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vert
 
 
 #if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
-const video::SColor& StaticText::getOverrideColor() const
+const video::SColor &StaticText::getOverrideColor() const
 #else
 video::SColor StaticText::getOverrideColor() const
 #endif
@@ -332,8 +332,8 @@ void StaticText::breakText()
 
 	BrokenText.clear();
 
-	IGUISkin* skin = Environment->getSkin();
-	IGUIFont* font = getActiveFont();
+	IGUISkin *skin = Environment->getSkin();
+	IGUIFont *font = getActiveFont();
 	if (!font)
 		return;
 
@@ -549,7 +549,7 @@ void StaticText::breakText()
 
 
 //! Sets the new caption of this element.
-void StaticText::setText(const wchar_t* text)
+void StaticText::setText(const wchar_t *text)
 {
 	setText(EnrichedString(text));
 }
@@ -576,7 +576,7 @@ void StaticText::updateAbsolutePosition()
 //! Returns the height of the text in pixels when it is drawn.
 s32 StaticText::getTextHeight() const
 {
-	IGUIFont* font = getActiveFont();
+	IGUIFont *font = getActiveFont();
 	if (!font)
 		return 0;
 
@@ -619,7 +619,7 @@ s32 StaticText::getTextWidth() const
 //! Writes attributes of the element.
 //! Implement this to expose the attributes of your element for
 //! scripting languages, editors, debuggers or xml serialization purposes.
-void StaticText::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options=0) const
+void StaticText::serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options = 0) const
 {
 	IGUIStaticText::serializeAttributes(out,options);
 
@@ -640,7 +640,7 @@ void StaticText::serializeAttributes(io::IAttributes* out, io::SAttributeReadWri
 
 
 //! Reads attributes of the element
-void StaticText::deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options=0)
+void StaticText::deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options = 0)
 {
 	IGUIStaticText::deserializeAttributes(in,options);
 

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -35,8 +35,8 @@ namespace gui
 	public:
 
 		//! constructor
-		StaticText(const EnrichedString &text, bool border, IGUIEnvironment* environment,
-			IGUIElement* parent, s32 id, const core::rect<s32>& rectangle,
+		StaticText(const EnrichedString &text, bool border, IGUIEnvironment *environment,
+			IGUIElement *parent, s32 id, const core::rect<s32>& rectangle,
 			bool background = false);
 
 		//! destructor
@@ -100,13 +100,13 @@ namespace gui
 		virtual void draw();
 
 		//! Sets another skin independent font.
-		virtual void setOverrideFont(IGUIFont* font=0);
+		virtual void setOverrideFont(IGUIFont *font = 0);
 
 		//! Gets the override font (if any)
-		virtual IGUIFont* getOverrideFont() const;
+		virtual IGUIFont *getOverrideFont() const;
 
 		//! Get the font which is used right now for drawing
-		virtual IGUIFont* getActiveFont() const;
+		virtual IGUIFont *getActiveFont() const;
 
 		//! Sets another color for the text.
 		virtual void setOverrideColor(video::SColor color);
@@ -134,7 +134,7 @@ namespace gui
 
 		//! Gets the override color
 		#if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
-		virtual const video::SColor& getOverrideColor() const;
+		virtual const video::SColor &getOverrideColor() const;
 		#else
 		virtual video::SColor getOverrideColor() const;
 		#endif
@@ -160,7 +160,7 @@ namespace gui
 		virtual bool isWordWrapEnabled() const;
 
 		//! Sets the new caption of this element.
-		virtual void setText(const wchar_t* text);
+		virtual void setText(const wchar_t *text);
 
 		//! Returns the height of the text in pixels when it is drawn.
 		virtual s32 getTextHeight() const;
@@ -183,10 +183,10 @@ namespace gui
 		virtual bool isRightToLeft() const;
 
 		//! Writes attributes of the element.
-		virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;
+		virtual void serializeAttributes(io::IAttributes *out, io::SAttributeReadWriteOptions *options) const;
 
 		//! Reads attributes of the element
-		virtual void deserializeAttributes(io::IAttributes* in, io::SAttributeReadWriteOptions* options);
+		virtual void deserializeAttributes(io::IAttributes *in, io::SAttributeReadWriteOptions *options);
 
 		virtual bool hasType(EGUI_ELEMENT_TYPE t) const {
 			return (t == EGUIET_ENRICHED_STATIC_TEXT) || (t == EGUIET_STATIC_TEXT);
@@ -213,8 +213,8 @@ namespace gui
 		bool RightToLeft;
 
 		video::SColor OverrideColor, BGColor;
-		gui::IGUIFont* OverrideFont;
-		gui::IGUIFont* LastBreakFont; // stored because: if skin changes, line break must be recalculated.
+		gui::IGUIFont *OverrideFont;
+		gui::IGUIFont *LastBreakFont; // stored because: if skin changes, line break must be recalculated.
 
 		EnrichedString cText;
 		core::array< EnrichedString > BrokenText;
@@ -230,7 +230,7 @@ inline void setStaticText(irr::gui::IGUIStaticText *static_text, const EnrichedS
 	// dynamic_cast not possible due to some distributions shipped
 	// without rtti support in irrlicht
 	if (static_text->hasType(irr::gui::EGUIET_ENRICHED_STATIC_TEXT)) {
-		irr::gui::StaticText* stext = static_cast<irr::gui::StaticText*>(static_text);
+		irr::gui::StaticText *stext = static_cast<irr::gui::StaticText *>(static_text);
 		stext->setText(text);
 	} else {
 		static_text->setText(text.c_str());

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -56,7 +56,7 @@ ItemDefinition::ItemDefinition(const ItemDefinition &def)
 	*this = def;
 }
 
-ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
+ItemDefinition &ItemDefinition::operator=(const ItemDefinition &def)
 {
 	if(this == &def)
 		return *this;
@@ -256,7 +256,7 @@ public:
 	virtual ~CItemDefManager()
 	{
 #ifndef SERVER
-		const std::vector<ClientCached*> &values = m_clientcached.getValues();
+		const std::vector<ClientCached *> &values = m_clientcached.getValues();
 		for (ClientCached *cc : values) {
 			if (cc->wield_mesh.mesh)
 				cc->wield_mesh.mesh->drop();
@@ -269,12 +269,12 @@ public:
 		}
 		m_item_definitions.clear();
 	}
-	virtual const ItemDefinition& get(const std::string &name_) const
+	virtual const ItemDefinition &get(const std::string &name_) const
 	{
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
+		std::map<std::string, ItemDefinition *>::const_iterator i;
 		i = m_item_definitions.find(name);
 		if(i == m_item_definitions.end())
 			i = m_item_definitions.find("unknown");
@@ -304,12 +304,12 @@ public:
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
+		std::map<std::string, ItemDefinition *>::const_iterator i;
 		return m_item_definitions.find(name) != m_item_definitions.end();
 	}
 #ifndef SERVER
 public:
-	ClientCached* createClientCachedDirect(const std::string &name,
+	ClientCached *createClientCachedDirect(const std::string &name,
 			Client *client) const
 	{
 		infostream<<"Lazily creating item texture and mesh for \""
@@ -347,7 +347,7 @@ public:
 
 		return cc;
 	}
-	ClientCached* getClientCached(const std::string &name,
+	ClientCached *getClientCached(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = NULL;
@@ -381,7 +381,7 @@ public:
 		}
 	}
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -390,7 +390,7 @@ public:
 		return cc->inventory_texture;
 	}
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
+	virtual ItemMesh *getWieldMesh(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -400,7 +400,7 @@ public:
 	}
 
 	// Get item palette
-	virtual Palette* getPalette(const std::string &name,
+	virtual Palette *getPalette(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -428,7 +428,7 @@ public:
 #endif
 	void clear()
 	{
-		for(std::map<std::string, ItemDefinition*>::const_iterator
+		for(std::map<std::string, ItemDefinition *>::const_iterator
 				i = m_item_definitions.begin();
 				i != m_item_definitions.end(); ++i)
 		{
@@ -444,23 +444,23 @@ public:
 		//   "air" is the air node
 		//   "ignore" is the ignore node
 
-		ItemDefinition* hand_def = new ItemDefinition;
+		ItemDefinition *hand_def = new ItemDefinition;
 		hand_def->name = "";
 		hand_def->wield_image = "wieldhand.png";
 		hand_def->tool_capabilities = new ToolCapabilities;
 		m_item_definitions.insert(std::make_pair("", hand_def));
 
-		ItemDefinition* unknown_def = new ItemDefinition;
+		ItemDefinition *unknown_def = new ItemDefinition;
 		unknown_def->type = ITEM_NODE;
 		unknown_def->name = "unknown";
 		m_item_definitions.insert(std::make_pair("unknown", unknown_def));
 
-		ItemDefinition* air_def = new ItemDefinition;
+		ItemDefinition *air_def = new ItemDefinition;
 		air_def->type = ITEM_NODE;
 		air_def->name = "air";
 		m_item_definitions.insert(std::make_pair("air", air_def));
 
-		ItemDefinition* ignore_def = new ItemDefinition;
+		ItemDefinition *ignore_def = new ItemDefinition;
 		ignore_def->type = ITEM_NODE;
 		ignore_def->name = "ignore";
 		m_item_definitions.insert(std::make_pair("ignore", ignore_def));
@@ -566,7 +566,7 @@ public:
 	}
 private:
 	// Key is name
-	std::map<std::string, ItemDefinition*> m_item_definitions;
+	std::map<std::string, ItemDefinition *> m_item_definitions;
 	// Aliases
 	StringMap m_aliases;
 #ifndef SERVER
@@ -575,13 +575,13 @@ private:
 	// A reference to this can be returned when nothing is found, to avoid NULLs
 	mutable ClientCached m_dummy_clientcached;
 	// Cached textures and meshes
-	mutable MutexedMap<std::string, ClientCached*> m_clientcached;
+	mutable MutexedMap<std::string, ClientCached *> m_clientcached;
 	// Queued clientcached fetches (to be processed by the main thread)
 	mutable RequestQueue<std::string, ClientCached*, u8, u8> m_get_clientcached_queue;
 #endif
 };
 
-IWritableItemDefManager* createItemDefManager()
+IWritableItemDefManager *createItemDefManager()
 {
 	return new CItemDefManager();
 }

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -90,7 +90,7 @@ struct ItemDefinition
 	*/
 	ItemDefinition();
 	ItemDefinition(const ItemDefinition &def);
-	ItemDefinition& operator=(const ItemDefinition &def);
+	ItemDefinition &operator=(const ItemDefinition &def);
 	~ItemDefinition();
 	void reset();
 	void serialize(std::ostream &os, u16 protocol_version) const;
@@ -107,7 +107,7 @@ public:
 	virtual ~IItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition &get(const std::string &name) const=0;
 	// Get alias definition
 	virtual const std::string &getAlias(const std::string &name) const=0;
 	// Get set of all defined item names and aliases
@@ -116,13 +116,13 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
 			Client *client) const=0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
+	virtual ItemMesh *getWieldMesh(const std::string &name,
 		Client *client) const=0;
 	// Get item palette
-	virtual Palette* getPalette(const std::string &name,
+	virtual Palette *getPalette(const std::string &name,
 		Client *client) const = 0;
 	// Returns the base color of an item stack: the color of all
 	// tiles that do not define their own color.
@@ -141,7 +141,7 @@ public:
 	virtual ~IWritableItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition &get(const std::string &name) const=0;
 	// Get alias definition
 	virtual const std::string &getAlias(const std::string &name) const=0;
 	// Get set of all defined item names and aliases
@@ -150,10 +150,10 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
 			Client *client) const=0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
+	virtual ItemMesh *getWieldMesh(const std::string &name,
 		Client *client) const=0;
 #endif
 
@@ -176,4 +176,4 @@ public:
 	virtual void processQueue(IGameDef *gamedef)=0;
 };
 
-IWritableItemDefManager* createItemDefManager();
+IWritableItemDefManager *createItemDefManager();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -829,7 +829,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 	Address bind_addr(0, 0, 0, 0, game_params.socket_port);
 
 	if (g_settings->getBool("ipv6_server")) {
-		bind_addr.setAddress((IPv6AddressBytes*) NULL);
+		bind_addr.setAddress((IPv6AddressBytes *) NULL);
 	}
 	try {
 		bind_addr.Resolve(bind_str.c_str());

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -103,7 +103,7 @@ MapSector * Map::getSectorNoGenerateNoExNoLock(v2s16 p)
 		return sector;
 	}
 
-	std::map<v2s16, MapSector*>::iterator n = m_sectors.find(p);
+	std::map<v2s16, MapSector *>::iterator n = m_sectors.find(p);
 
 	if (n == m_sectors.end())
 		return NULL;
@@ -226,7 +226,7 @@ void Map::setNode(v3s16 p, MapNode & n)
 }
 
 void Map::addNodeAndUpdate(v3s16 p, MapNode n,
-		std::map<v3s16, MapBlock*> &modified_blocks,
+		std::map<v3s16, MapBlock *> &modified_blocks,
 		bool remove_metadata)
 {
 	// Collect old node for rollback
@@ -282,7 +282,7 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 }
 
 void Map::removeNodeAndUpdate(v3s16 p,
-		std::map<v3s16, MapBlock*> &modified_blocks)
+		std::map<v3s16, MapBlock *> &modified_blocks)
 {
 	addNodeAndUpdate(p, MapNode(CONTENT_AIR), modified_blocks, true);
 }
@@ -296,7 +296,7 @@ bool Map::addNodeWithEvent(v3s16 p, MapNode n, bool remove_metadata)
 
 	bool succeeded = true;
 	try{
-		std::map<v3s16, MapBlock*> modified_blocks;
+		std::map<v3s16, MapBlock *> modified_blocks;
 		addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
 
 		// Copy modified_blocks to event
@@ -321,7 +321,7 @@ bool Map::removeNodeWithEvent(v3s16 p)
 
 	bool succeeded = true;
 	try{
-		std::map<v3s16, MapBlock*> modified_blocks;
+		std::map<v3s16, MapBlock *> modified_blocks;
 		removeNodeAndUpdate(p, modified_blocks);
 
 		// Copy modified_blocks to event
@@ -538,7 +538,7 @@ void Map::transforming_liquid_add(v3s16 p) {
         m_transforming_liquid.push_back(p);
 }
 
-void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
+void Map::transformLiquids(std::map<v3s16, MapBlock *> &modified_blocks,
 		ServerEnvironment *env)
 {
 	u32 loopcount = 0;
@@ -1240,7 +1240,7 @@ ServerMap::~ServerMap()
 	/*
 		Free all MapChunks
 	*/
-	core::map<v2s16, MapChunk*>::Iterator i = m_chunks.getIterator();
+	core::map<v2s16, MapChunk *>::Iterator i = m_chunks.getIterator();
 	for(; i.atEnd() == false; i++)
 	{
 		MapChunk *chunk = i.getNode()->getValue();
@@ -1362,7 +1362,7 @@ bool ServerMap::initBlockMake(v3s16 blockpos, BlockMakeData *data)
 }
 
 void ServerMap::finishBlockMake(BlockMakeData *data,
-	std::map<v3s16, MapBlock*> *changed_blocks)
+	std::map<v3s16, MapBlock *> *changed_blocks)
 {
 	v3s16 bpmin = data->blockpos_min;
 	v3s16 bpmax = data->blockpos_max;
@@ -1466,7 +1466,7 @@ MapSector *ServerMap::createSector(v2s16 p2d)
 */
 MapBlock * ServerMap::generateBlock(
 		v3s16 p,
-		std::map<v3s16, MapBlock*> &modified_blocks
+		std::map<v3s16, MapBlock *> &modified_blocks
 )
 {
 	bool enable_mapgen_debug_info = g_settings->getBool("enable_mapgen_debug_info");
@@ -1955,7 +1955,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db)
 		[1] data
 	*/
 	std::ostringstream o(std::ios_base::binary);
-	o.write((char*) &version, 1);
+	o.write((char *) &version, 1);
 	block->serialize(o, version, true);
 
 	bool ret = db->saveBlock(p3d, o.str());
@@ -1981,7 +1981,7 @@ void ServerMap::loadBlock(const std::string &sectordir, const std::string &block
 		assert(sector->getPos() == p2d);
 
 		u8 version = SER_FMT_VER_INVALID;
-		is.read((char*)&version, 1);
+		is.read((char *)&version, 1);
 
 		if(is.fail())
 			throw SerializationError("ServerMap::loadBlock(): Failed"
@@ -1989,7 +1989,7 @@ void ServerMap::loadBlock(const std::string &sectordir, const std::string &block
 
 		/*u32 block_size = MapBlock::serializedLength(version);
 		SharedBuffer<u8> data(block_size);
-		is.read((char*)*data, block_size);*/
+		is.read((char *)*data, block_size);*/
 
 		// This will always return a sector because we're the server
 		//MapSector *sector = emergeSector(p2d);
@@ -2049,7 +2049,7 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 		std::istringstream is(*blob, std::ios_base::binary);
 
 		u8 version = SER_FMT_VER_INVALID;
-		is.read((char*)&version, 1);
+		is.read((char *)&version, 1);
 
 		if(is.fail())
 			throw SerializationError("ServerMap::loadBlock(): Failed"
@@ -2104,7 +2104,7 @@ void ServerMap::loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool 
 	}
 }
 
-MapBlock* ServerMap::loadBlock(v3s16 blockpos)
+MapBlock *ServerMap::loadBlock(v3s16 blockpos)
 {
 	bool created_new = (getBlockNoCreateNoEx(blockpos) == NULL);
 
@@ -2157,7 +2157,7 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if (created_new && (block != NULL)) {
-		std::map<v3s16, MapBlock*> modified_blocks;
+		std::map<v3s16, MapBlock *> modified_blocks;
 		// Fix lighting if necessary
 		voxalgo::update_block_border_lighting(this, block, modified_blocks);
 		if (!modified_blocks.empty()) {
@@ -2300,7 +2300,7 @@ void MMVManip::initialEmerge(v3s16 blockpos_min, v3s16 blockpos_max,
 	m_is_dirty = false;
 }
 
-void MMVManip::blitBackAll(std::map<v3s16, MapBlock*> *modified_blocks,
+void MMVManip::blitBackAll(std::map<v3s16, MapBlock *> *modified_blocks,
 	bool overwrite_generated)
 {
 	if(m_area.getExtent() == v3s16(0,0,0))

--- a/src/map.h
+++ b/src/map.h
@@ -197,10 +197,10 @@ public:
 		These handle lighting but not faces.
 	*/
 	void addNodeAndUpdate(v3s16 p, MapNode n,
-			std::map<v3s16, MapBlock*> &modified_blocks,
+			std::map<v3s16, MapBlock *> &modified_blocks,
 			bool remove_metadata = true);
 	void removeNodeAndUpdate(v3s16 p,
-			std::map<v3s16, MapBlock*> &modified_blocks);
+			std::map<v3s16, MapBlock *> &modified_blocks);
 
 	/*
 		Wrappers for the latter ones.
@@ -242,7 +242,7 @@ public:
 	// For debug printing. Prints "Map: ", "ServerMap: " or "ClientMap: "
 	virtual void PrintInfo(std::ostream &out);
 
-	void transformLiquids(std::map<v3s16, MapBlock*> & modified_blocks,
+	void transformLiquids(std::map<v3s16, MapBlock *> & modified_blocks,
 			ServerEnvironment *env);
 
 	/*
@@ -282,7 +282,7 @@ public:
 	/*
 		Misc.
 	*/
-	std::map<v2s16, MapSector*> *getSectorsPtr(){return &m_sectors;}
+	std::map<v2s16, MapSector *> *getSectorsPtr(){return &m_sectors;}
 
 	/*
 		Variables
@@ -298,9 +298,9 @@ protected:
 
 	IGameDef *m_gamedef;
 
-	std::set<MapEventReceiver*> m_event_receivers;
+	std::set<MapEventReceiver *> m_event_receivers;
 
-	std::map<v2s16, MapSector*> m_sectors;
+	std::map<v2s16, MapSector *> m_sectors;
 
 	// Be sure to set this to NULL when the cached sector is deleted
 	MapSector *m_sector_cache = nullptr;
@@ -356,7 +356,7 @@ public:
 	bool blockpos_over_mapgen_limit(v3s16 p);
 	bool initBlockMake(v3s16 blockpos, BlockMakeData *data);
 	void finishBlockMake(BlockMakeData *data,
-		std::map<v3s16, MapBlock*> *changed_blocks);
+		std::map<v3s16, MapBlock *> *changed_blocks);
 
 	/*
 		Get a block from somewhere.
@@ -420,7 +420,7 @@ public:
 	// This will generate a sector with getSector if not found.
 	void loadBlock(const std::string &sectordir, const std::string &blockfile,
 			MapSector *sector, bool save_after_load=false);
-	MapBlock* loadBlock(v3s16 p);
+	MapBlock *loadBlock(v3s16 p);
 	// Database version
 	void loadBlock(std::string *blob, v3s16 p3d, MapSector *sector, bool save_after_load=false);
 
@@ -460,7 +460,7 @@ private:
 	// If 0, chunks are disabled.
 	s16 m_chunksize;
 	// Chunks
-	core::map<v2s16, MapChunk*> m_chunks;
+	core::map<v2s16, MapChunk *> m_chunks;
 #endif
 
 	/*
@@ -492,7 +492,7 @@ public:
 		bool load_if_inexistent = true);
 
 	// This is much faster with big chunks of generated data
-	void blitBackAll(std::map<v3s16, MapBlock*> * modified_blocks,
+	void blitBackAll(std::map<v3s16, MapBlock *> *modified_blocks,
 		bool overwrite_generated = true);
 
 	bool m_is_dirty = false;

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -640,7 +640,7 @@ void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 		}
 	} else { // All other versions (10 to 21)
 		u8 flags;
-		is.read((char*)&flags, 1);
+		is.read((char *)&flags, 1);
 		is_underground = (flags & 0x01) != 0;
 		m_day_night_differs = (flags & 0x02) != 0;
 		if(version >= 18)

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -96,7 +96,7 @@ public:
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_REALLOCATE);
 	}
 
-	MapNode* getData()
+	MapNode *getData()
 	{
 		return data;
 	}
@@ -620,7 +620,7 @@ private:
 	int m_refcount = 0;
 };
 
-typedef std::vector<MapBlock*> MapBlockVect;
+typedef std::vector<MapBlock *> MapBlockVect;
 
 inline bool objectpos_over_limit(v3f p)
 {

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -118,7 +118,7 @@ treegen::error spawn_ltree(ServerEnvironment *env, v3s16 p0,
 	const NodeDefManager *ndef, const TreeDef &tree_definition)
 {
 	ServerMap *map = &env->getServerMap();
-	std::map<v3s16, MapBlock*> modified_blocks;
+	std::map<v3s16, MapBlock *> modified_blocks;
 	MMVManip vmanip(map);
 	v3s16 tree_blockp = getNodeBlockPos(p0);
 	treegen::error e;

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -739,7 +739,7 @@ void MapNode::serializeBulk(std::ostream &os, int version,
 	if (compressed)
 		compressZlib(databuf, databuf_size, os);
 	else
-		os.write((const char*) &databuf[0], databuf_size);
+		os.write((const char *) &databuf[0], databuf_size);
 
 	delete [] databuf;
 }
@@ -772,7 +772,7 @@ void MapNode::deSerializeBulk(std::istream &is, int version,
 	}
 	else
 	{
-		is.read((char*) &databuf[0], len);
+		is.read((char *) &databuf[0], len);
 		if(is.eof() || is.fail())
 			throw SerializationError("deSerializeBulkNodes: "
 					"failed to read bulk node data");

--- a/src/mapsector.cpp
+++ b/src/mapsector.cpp
@@ -57,7 +57,7 @@ MapBlock * MapSector::getBlockBuffered(s16 y)
 	}
 
 	// If block doesn't exist, return NULL
-	std::unordered_map<s16, MapBlock*>::const_iterator n = m_blocks.find(y);
+	std::unordered_map<s16, MapBlock *>::const_iterator n = m_blocks.find(y);
 	block = (n != m_blocks.end() ? n->second : nullptr);
 
 	// Cache the last result

--- a/src/mapsector.h
+++ b/src/mapsector.h
@@ -65,7 +65,7 @@ public:
 protected:
 
 	// The pile of MapBlocks
-	std::unordered_map<s16, MapBlock*> m_blocks;
+	std::unordered_map<s16, MapBlock *> m_blocks;
 
 	Map *m_parent;
 	// Position on parent (in MapBlock widths)

--- a/src/network/clientopcodes.h
+++ b/src/network/clientopcodes.h
@@ -33,14 +33,14 @@ enum ToClientConnectionState {
 
 struct ToClientCommandHandler
 {
-    const char* name;
-    ToClientConnectionState state;
-    void (Client::*handler)(NetworkPacket* pkt);
+	const char *name;
+	ToClientConnectionState state;
+	void (Client::*handler)(NetworkPacket *pkt);
 };
 
 struct ServerCommandFactory
 {
-	const char* name;
+	const char *name;
 	u8 channel;
 	bool reliable;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -41,14 +41,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "tileanimation.h"
 #include "gettext.h"
 
-void Client::handleCommand_Deprecated(NetworkPacket* pkt)
+void Client::handleCommand_Deprecated(NetworkPacket *pkt)
 {
 	infostream << "Got deprecated command "
 			<< toClientCommandTable[pkt->getCommand()].name << " from peer "
 			<< pkt->getPeerId() << "!" << std::endl;
 }
 
-void Client::handleCommand_Hello(NetworkPacket* pkt)
+void Client::handleCommand_Hello(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 1)
 		return;
@@ -114,7 +114,7 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 
 }
 
-void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
+void Client::handleCommand_AuthAccept(NetworkPacket *pkt)
 {
 	deleteAuthData();
 
@@ -144,7 +144,7 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 
 	m_state = LC_Init;
 }
-void Client::handleCommand_AcceptSudoMode(NetworkPacket* pkt)
+void Client::handleCommand_AcceptSudoMode(NetworkPacket *pkt)
 {
 	deleteAuthData();
 
@@ -158,7 +158,7 @@ void Client::handleCommand_AcceptSudoMode(NetworkPacket* pkt)
 	// reset again
 	m_chosen_auth_mech = AUTH_MECHANISM_NONE;
 }
-void Client::handleCommand_DenySudoMode(NetworkPacket* pkt)
+void Client::handleCommand_DenySudoMode(NetworkPacket *pkt)
 {
 	ChatMessage *chatMessage = new ChatMessage(CHATMESSAGE_TYPE_SYSTEM,
 			L"Password change denied. Password NOT changed.");
@@ -167,7 +167,7 @@ void Client::handleCommand_DenySudoMode(NetworkPacket* pkt)
 	deleteAuthData();
 }
 
-void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
+void Client::handleCommand_AccessDenied(NetworkPacket *pkt)
 {
 	// The server didn't like our password. Note, this needs
 	// to be processed even if the serialisation format has
@@ -216,7 +216,7 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_RemoveNode(NetworkPacket* pkt)
+void Client::handleCommand_RemoveNode(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 6)
 		return;
@@ -226,7 +226,7 @@ void Client::handleCommand_RemoveNode(NetworkPacket* pkt)
 	removeNode(p);
 }
 
-void Client::handleCommand_AddNode(NetworkPacket* pkt)
+void Client::handleCommand_AddNode(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 6 + MapNode::serializedLength(m_server_ser_ver))
 		return;
@@ -272,7 +272,7 @@ void Client::handleCommand_NodemetaChanged(NetworkPacket *pkt)
 	}
 }
 
-void Client::handleCommand_BlockData(NetworkPacket* pkt)
+void Client::handleCommand_BlockData(NetworkPacket *pkt)
 {
 	// Ignore too small packet
 	if (pkt->getSize() < 6)
@@ -320,7 +320,7 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 	addUpdateMeshTaskWithEdge(p, true);
 }
 
-void Client::handleCommand_Inventory(NetworkPacket* pkt)
+void Client::handleCommand_Inventory(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 1)
 		return;
@@ -340,7 +340,7 @@ void Client::handleCommand_Inventory(NetworkPacket* pkt)
 	m_inventory_from_server_age = 0.0;
 }
 
-void Client::handleCommand_TimeOfDay(NetworkPacket* pkt)
+void Client::handleCommand_TimeOfDay(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 2)
 		return;
@@ -424,7 +424,7 @@ void Client::handleCommand_ChatMessage(NetworkPacket *pkt)
 	}
 }
 
-void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
+void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket *pkt)
 {
 	/*
 		u16 count of removed objects
@@ -465,7 +465,7 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_ActiveObjectMessages(NetworkPacket* pkt)
+void Client::handleCommand_ActiveObjectMessages(NetworkPacket *pkt)
 {
 	/*
 		for all objects
@@ -495,7 +495,7 @@ void Client::handleCommand_ActiveObjectMessages(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_Movement(NetworkPacket* pkt)
+void Client::handleCommand_Movement(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -519,7 +519,7 @@ void Client::handleCommand_Movement(NetworkPacket* pkt)
 	player->movement_gravity                = g * BS;
 }
 
-void Client::handleCommand_HP(NetworkPacket* pkt)
+void Client::handleCommand_HP(NetworkPacket *pkt)
 {
 
 	LocalPlayer *player = m_env.getLocalPlayer();
@@ -545,7 +545,7 @@ void Client::handleCommand_HP(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_Breath(NetworkPacket* pkt)
+void Client::handleCommand_Breath(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -557,7 +557,7 @@ void Client::handleCommand_Breath(NetworkPacket* pkt)
 	player->setBreath(breath);
 }
 
-void Client::handleCommand_MovePlayer(NetworkPacket* pkt)
+void Client::handleCommand_MovePlayer(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -588,7 +588,7 @@ void Client::handleCommand_MovePlayer(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_DeathScreen(NetworkPacket* pkt)
+void Client::handleCommand_DeathScreen(NetworkPacket *pkt)
 {
 	bool set_camera_point_target;
 	v3f camera_point_target;
@@ -605,7 +605,7 @@ void Client::handleCommand_DeathScreen(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_AnnounceMedia(NetworkPacket* pkt)
+void Client::handleCommand_AnnounceMedia(NetworkPacket *pkt)
 {
 	u16 num_files;
 
@@ -651,14 +651,14 @@ void Client::handleCommand_AnnounceMedia(NetworkPacket* pkt)
 				m_media_downloader->addRemoteServer(baseurl);
 		}
 	}
-	catch(SerializationError& e) {
+	catch(SerializationError &e) {
 		// not supported by server or turned off
 	}
 
 	m_media_downloader->step(this);
 }
 
-void Client::handleCommand_Media(NetworkPacket* pkt)
+void Client::handleCommand_Media(NetworkPacket *pkt)
 {
 	/*
 		u16 command
@@ -713,7 +713,7 @@ void Client::handleCommand_Media(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_NodeDef(NetworkPacket* pkt)
+void Client::handleCommand_NodeDef(NetworkPacket *pkt)
 {
 	infostream << "Client: Received node definitions: packet size: "
 			<< pkt->getSize() << std::endl;
@@ -733,7 +733,7 @@ void Client::handleCommand_NodeDef(NetworkPacket* pkt)
 	m_nodedef_received = true;
 }
 
-void Client::handleCommand_ItemDef(NetworkPacket* pkt)
+void Client::handleCommand_ItemDef(NetworkPacket *pkt)
 {
 	infostream << "Client: Received item definitions: packet size: "
 			<< pkt->getSize() << std::endl;
@@ -753,7 +753,7 @@ void Client::handleCommand_ItemDef(NetworkPacket* pkt)
 	m_itemdef_received = true;
 }
 
-void Client::handleCommand_PlaySound(NetworkPacket* pkt)
+void Client::handleCommand_PlaySound(NetworkPacket *pkt)
 {
 	/*
 		[0] u32 server_id
@@ -816,7 +816,7 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_StopSound(NetworkPacket* pkt)
+void Client::handleCommand_StopSound(NetworkPacket *pkt)
 {
 	s32 server_id;
 
@@ -844,7 +844,7 @@ void Client::handleCommand_FadeSound(NetworkPacket *pkt)
 		m_sound->fadeSound(i->second, step, gain);
 }
 
-void Client::handleCommand_Privileges(NetworkPacket* pkt)
+void Client::handleCommand_Privileges(NetworkPacket *pkt)
 {
 	m_privileges.clear();
 	infostream << "Client: Privileges updated: ";
@@ -863,7 +863,7 @@ void Client::handleCommand_Privileges(NetworkPacket* pkt)
 	infostream << std::endl;
 }
 
-void Client::handleCommand_InventoryFormSpec(NetworkPacket* pkt)
+void Client::handleCommand_InventoryFormSpec(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -872,7 +872,7 @@ void Client::handleCommand_InventoryFormSpec(NetworkPacket* pkt)
 	player->inventory_formspec = pkt->readLongString();
 }
 
-void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
+void Client::handleCommand_DetachedInventory(NetworkPacket *pkt)
 {
 	std::string name;
 	bool keep_inv = true;
@@ -905,7 +905,7 @@ void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)
 	inv->deSerialize(is);
 }
 
-void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
+void Client::handleCommand_ShowFormSpec(NetworkPacket *pkt)
 {
 	std::string formspec = pkt->readLongString();
 	std::string formname;
@@ -921,7 +921,7 @@ void Client::handleCommand_ShowFormSpec(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
+void Client::handleCommand_SpawnParticle(NetworkPacket *pkt)
 {
 	std::string datastring(pkt->getString(0), pkt->getSize());
 	std::istringstream is(datastring, std::ios_base::binary);
@@ -966,7 +966,7 @@ void Client::handleCommand_SpawnParticle(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
+void Client::handleCommand_AddParticleSpawner(NetworkPacket *pkt)
 {
 	u16 amount;
 	float spawntime;
@@ -1039,7 +1039,7 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 }
 
 
-void Client::handleCommand_DeleteParticleSpawner(NetworkPacket* pkt)
+void Client::handleCommand_DeleteParticleSpawner(NetworkPacket *pkt)
 {
 	u32 server_id;
 	*pkt >> server_id;
@@ -1051,7 +1051,7 @@ void Client::handleCommand_DeleteParticleSpawner(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_HudAdd(NetworkPacket* pkt)
+void Client::handleCommand_HudAdd(NetworkPacket *pkt)
 {
 	std::string datastring(pkt->getString(0), pkt->getSize());
 	std::istringstream is(datastring, std::ios_base::binary);
@@ -1099,7 +1099,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_HudRemove(NetworkPacket* pkt)
+void Client::handleCommand_HudRemove(NetworkPacket *pkt)
 {
 	u32 server_id;
 
@@ -1117,7 +1117,7 @@ void Client::handleCommand_HudRemove(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_HudChange(NetworkPacket* pkt)
+void Client::handleCommand_HudChange(NetworkPacket *pkt)
 {
 	std::string sdata;
 	v2f v2fdata;
@@ -1156,7 +1156,7 @@ void Client::handleCommand_HudChange(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
+void Client::handleCommand_HudSetFlags(NetworkPacket *pkt)
 {
 	u32 flags, mask;
 
@@ -1185,7 +1185,7 @@ void Client::handleCommand_HudSetFlags(NetworkPacket* pkt)
 		m_minimap->setMinimapMode(MINIMAP_MODE_SURFACEx1);
 }
 
-void Client::handleCommand_HudSetParam(NetworkPacket* pkt)
+void Client::handleCommand_HudSetParam(NetworkPacket *pkt)
 {
 	u16 param; std::string value;
 
@@ -1195,7 +1195,7 @@ void Client::handleCommand_HudSetParam(NetworkPacket* pkt)
 	assert(player != NULL);
 
 	if (param == HUD_PARAM_HOTBAR_ITEMCOUNT && value.size() == 4) {
-		s32 hotbar_itemcount = readS32((u8*) value.c_str());
+		s32 hotbar_itemcount = readS32((u8 *) value.c_str());
 		if (hotbar_itemcount > 0 && hotbar_itemcount <= HUD_HOTBAR_ITEMCOUNT_MAX)
 			player->hud_hotbar_itemcount = hotbar_itemcount;
 	}
@@ -1219,7 +1219,7 @@ void Client::handleCommand_HudSetParam(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
+void Client::handleCommand_HudSetSky(NetworkPacket *pkt)
 {
 	std::string datastring(pkt->getString(0), pkt->getSize());
 	std::istringstream is(datastring, std::ios_base::binary);
@@ -1246,7 +1246,7 @@ void Client::handleCommand_HudSetSky(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_CloudParams(NetworkPacket* pkt)
+void Client::handleCommand_CloudParams(NetworkPacket *pkt)
 {
 	f32 density;
 	video::SColor color_bright;
@@ -1274,7 +1274,7 @@ void Client::handleCommand_CloudParams(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
+void Client::handleCommand_OverrideDayNightRatio(NetworkPacket *pkt)
 {
 	bool do_override;
 	u16 day_night_ratio_u;
@@ -1290,7 +1290,7 @@ void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
-void Client::handleCommand_LocalPlayerAnimations(NetworkPacket* pkt)
+void Client::handleCommand_LocalPlayerAnimations(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -1302,7 +1302,7 @@ void Client::handleCommand_LocalPlayerAnimations(NetworkPacket* pkt)
 	*pkt >> player->local_animation_speed;
 }
 
-void Client::handleCommand_EyeOffset(NetworkPacket* pkt)
+void Client::handleCommand_EyeOffset(NetworkPacket *pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	assert(player != NULL);
@@ -1310,7 +1310,7 @@ void Client::handleCommand_EyeOffset(NetworkPacket* pkt)
 	*pkt >> player->eye_offset_first >> player->eye_offset_third;
 }
 
-void Client::handleCommand_UpdatePlayerList(NetworkPacket* pkt)
+void Client::handleCommand_UpdatePlayerList(NetworkPacket *pkt)
 {
 	u8 type;
 	u16 num_players;
@@ -1332,7 +1332,7 @@ void Client::handleCommand_UpdatePlayerList(NetworkPacket* pkt)
 	}
 }
 
-void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
+void Client::handleCommand_SrpBytesSandB(NetworkPacket *pkt)
 {
 	if (m_chosen_auth_mech != AUTH_MECHANISM_SRP &&
 			m_chosen_auth_mech != AUTH_MECHANISM_LEGACY_PASSWORD) {

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -202,7 +202,7 @@ RPBSearchResult ReliablePacketBuffer::notFound()
 {
 	return m_list.end();
 }
-bool ReliablePacketBuffer::getFirstSeqnum(u16& result)
+bool ReliablePacketBuffer::getFirstSeqnum(u16 &result)
 {
 	MutexAutoLock listlock(m_list_mutex);
 	if (m_list.empty())
@@ -541,7 +541,7 @@ void Channel::setNextSplitSeqNum(u16 seqnum)
 	next_outgoing_split_seqnum = seqnum;
 }
 
-u16 Channel::getOutgoingSequenceNumber(bool& successful)
+u16 Channel::getOutgoingSequenceNumber(bool &successful)
 {
 	MutexAutoLock internal(m_internal_mutex);
 	u16 retval = next_outgoing_seqnum;
@@ -741,7 +741,7 @@ void Channel::UpdateTimers(float dtime)
 	Peer
 */
 
-PeerHelper::PeerHelper(Peer* peer) :
+PeerHelper::PeerHelper(Peer *peer) :
 	m_peer(peer)
 {
 	if (peer && !peer->IncUseCount())
@@ -756,7 +756,7 @@ PeerHelper::~PeerHelper()
 	m_peer = nullptr;
 }
 
-PeerHelper& PeerHelper::operator=(Peer* peer)
+PeerHelper &PeerHelper::operator=(Peer *peer)
 {
 	m_peer = peer;
 	if (peer && !peer->IncUseCount())
@@ -764,12 +764,12 @@ PeerHelper& PeerHelper::operator=(Peer* peer)
 	return *this;
 }
 
-Peer* PeerHelper::operator->() const
+Peer *PeerHelper::operator->() const
 {
 	return m_peer;
 }
 
-Peer* PeerHelper::operator&() const
+Peer *PeerHelper::operator&() const
 {
 	return m_peer;
 }
@@ -779,9 +779,9 @@ bool PeerHelper::operator!()
 	return ! m_peer;
 }
 
-bool PeerHelper::operator!=(void* ptr)
+bool PeerHelper::operator!=(void *ptr)
 {
-	return ((void*) m_peer != ptr);
+	return ((void *) m_peer != ptr);
 }
 
 bool Peer::IncUseCount()
@@ -891,14 +891,14 @@ void Peer::Drop()
 	delete this;
 }
 
-UDPPeer::UDPPeer(u16 a_id, Address a_address, Connection* connection) :
+UDPPeer::UDPPeer(u16 a_id, Address a_address, Connection *connection) :
 	Peer(a_address,a_id,connection)
 {
 	for (Channel &channel : channels)
 		channel.setWindowSize(g_settings->getU16("max_packets_per_iteration"));
 }
 
-bool UDPPeer::getAddress(MTProtocols type,Address& toset)
+bool UDPPeer::getAddress(MTProtocols type,Address &toset)
 {
 	if ((type == MTP_UDP) || (type == MTP_MINETEST_RELIABLE_UDP) || (type == MTP_PRIMARY))
 	{
@@ -1191,10 +1191,10 @@ PeerHelper Connection::getPeerNoEx(session_t peer_id)
 }
 
 /* find peer_id for address */
-u16 Connection::lookupPeer(Address& sender)
+u16 Connection::lookupPeer(Address &sender)
 {
 	MutexAutoLock peerlock(m_peers_mutex);
-	std::map<u16, Peer*>::iterator j;
+	std::map<u16, Peer *>::iterator j;
 	j = m_peers.begin();
 	for(; j != m_peers.end(); ++j)
 	{
@@ -1300,7 +1300,7 @@ void Connection::Disconnect()
 	putCommand(c);
 }
 
-void Connection::Receive(NetworkPacket* pkt)
+void Connection::Receive(NetworkPacket *pkt)
 {
 	for(;;) {
 		ConnectionEvent e = waitEvent(m_bc_receive_timeout);
@@ -1402,7 +1402,7 @@ float Connection::getLocalStat(rate_stat_type type)
 	return retval;
 }
 
-u16 Connection::createPeer(Address& sender, MTProtocols protocol, int fd)
+u16 Connection::createPeer(Address &sender, MTProtocols protocol, int fd)
 {
 	// Somebody wants to make a new connection
 
@@ -1502,7 +1502,7 @@ void Connection::sendAck(session_t peer_id, u8 channelnum, u16 seqnum)
 	m_sendThread->Trigger();
 }
 
-UDPPeer* Connection::createServerPeer(Address& address)
+UDPPeer *Connection::createServerPeer(Address &address)
 {
 	if (getPeerNoEx(PEER_ID_SERVER) != 0)
 	{

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -236,7 +236,7 @@ class ReliablePacketBuffer
 public:
 	ReliablePacketBuffer() = default;
 
-	bool getFirstSeqnum(u16& result);
+	bool getFirstSeqnum(u16 &result);
 
 	BufferedPacket popFirst();
 	BufferedPacket popSeqnum(u16 seqnum);
@@ -282,7 +282,7 @@ public:
 
 private:
 	// Key is seqnum
-	std::map<u16, IncomingSplitPacket*> m_buf;
+	std::map<u16, IncomingSplitPacket *> m_buf;
 
 	std::mutex m_map_mutex;
 };
@@ -399,7 +399,7 @@ public:
 	u16 readNextIncomingSeqNum();
 	u16 incNextIncomingSeqNum();
 
-	u16 getOutgoingSequenceNumber(bool& successfull);
+	u16 getOutgoingSequenceNumber(bool &successfull);
 	u16 readOutgoingSequenceNumber();
 	bool putBackSequenceNumber(u16);
 
@@ -494,14 +494,14 @@ class PeerHelper
 {
 public:
 	PeerHelper() = default;
-	PeerHelper(Peer* peer);
+	PeerHelper(Peer *peer);
 	~PeerHelper();
 
-	PeerHelper&   operator=(Peer* peer);
+	PeerHelper&   operator=(Peer *peer);
 	Peer*         operator->() const;
 	bool          operator!();
 	Peer*         operator&() const;
-	bool          operator!=(void* ptr);
+	bool          operator!=(void *ptr);
 
 private:
 	Peer *m_peer = nullptr;
@@ -522,7 +522,7 @@ class Peer {
 	public:
 		friend class PeerHelper;
 
-		Peer(Address address_,u16 id_,Connection* connection) :
+		Peer(Address address_,u16 id_,Connection *connection) :
 			id(id_),
 			m_connection(connection),
 			address(address_),
@@ -543,7 +543,7 @@ class Peer {
 		virtual void PutReliableSendCommand(ConnectionCommand &c,
 						unsigned int max_packet_size) {};
 
-		virtual bool getAddress(MTProtocols type, Address& toset) = 0;
+		virtual bool getAddress(MTProtocols type, Address &toset) = 0;
 
 		bool isPendingDeletion()
 		{ MutexAutoLock lock(m_exclusive_access_mutex); return m_pending_deletion; };
@@ -598,7 +598,7 @@ class Peer {
 
 		bool m_pending_deletion = false;
 
-		Connection* m_connection;
+		Connection *m_connection;
 
 		// Address of the peer
 		Address address;
@@ -639,13 +639,13 @@ public:
 	friend class ConnectionSendThread;
 	friend class Connection;
 
-	UDPPeer(u16 a_id, Address a_address, Connection* connection);
+	UDPPeer(u16 a_id, Address a_address, Connection *connection);
 	virtual ~UDPPeer() = default;
 
 	void PutReliableSendCommand(ConnectionCommand &c,
 							unsigned int max_packet_size);
 
-	bool getAddress(MTProtocols type, Address& toset);
+	bool getAddress(MTProtocols type, Address &toset);
 
 	u16 getNextSplitSequenceNumber(u8 channel);
 	void setNextSplitSequenceNumber(u8 channel, u16 seqnum);
@@ -768,7 +768,7 @@ public:
 	void Connect(Address address);
 	bool Connected();
 	void Disconnect();
-	void Receive(NetworkPacket* pkt);
+	void Receive(NetworkPacket *pkt);
 	void Send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable);
 	session_t GetPeerID() const { return m_peer_id; }
 	Address GetPeerAddress(session_t peer_id);
@@ -780,10 +780,10 @@ public:
 
 protected:
 	PeerHelper getPeerNoEx(session_t peer_id);
-	u16   lookupPeer(Address& sender);
+	u16   lookupPeer(Address &sender);
 
-	u16 createPeer(Address& sender, MTProtocols protocol, int fd);
-	UDPPeer*  createServerPeer(Address& sender);
+	u16 createPeer(Address &sender, MTProtocols protocol, int fd);
+	UDPPeer*  createServerPeer(Address &sender);
 	bool deletePeer(session_t peer_id, bool timeout);
 
 	void SetPeerID(session_t id) { m_peer_id = id; }

--- a/src/network/connectionthreads.cpp
+++ b/src/network/connectionthreads.cpp
@@ -1309,8 +1309,8 @@ SharedBuffer<u8> ConnectionReceiveThread::handlePacketType_Reliable(Channel *cha
 			// we already have this packet so this one was on wire at least
 			// the current timeout
 			// we don't know how long this packet was on wire don't do silly guessing
-			// dynamic_cast<UDPPeer*>(&peer)->
-			//     reportRTT(dynamic_cast<UDPPeer*>(&peer)->getResendTimeout());
+			// dynamic_cast<UDPPeer *>(&peer)->
+			//     reportRTT(dynamic_cast<UDPPeer *>(&peer)->getResendTimeout());
 
 			throw ProcessedSilentlyException("Retransmitting ack for old packet");
 		}

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -66,14 +66,14 @@ void NetworkPacket::putRawPacket(u8 *data, u32 datasize, session_t peer_id)
 	memcpy(m_data.data(), &data[2], m_datasize);
 }
 
-const char* NetworkPacket::getString(u32 from_offset)
+const char *NetworkPacket::getString(u32 from_offset)
 {
 	checkReadOffset(from_offset, 0);
 
-	return (char*)&m_data[from_offset];
+	return (char *)&m_data[from_offset];
 }
 
-void NetworkPacket::putRawString(const char* src, u32 len)
+void NetworkPacket::putRawString(const char *src, u32 len)
 {
 	if (m_read_offset + len > m_datasize) {
 		m_datasize = m_read_offset + len;
@@ -87,7 +87,7 @@ void NetworkPacket::putRawString(const char* src, u32 len)
 	m_read_offset += len;
 }
 
-NetworkPacket& NetworkPacket::operator>>(std::string& dst)
+NetworkPacket &NetworkPacket::operator>>(std::string &dst)
 {
 	checkReadOffset(m_read_offset, 2);
 	u16 strLen = readU16(&m_data[m_read_offset]);
@@ -102,13 +102,13 @@ NetworkPacket& NetworkPacket::operator>>(std::string& dst)
 	checkReadOffset(m_read_offset, strLen);
 
 	dst.reserve(strLen);
-	dst.append((char*)&m_data[m_read_offset], strLen);
+	dst.append((char *)&m_data[m_read_offset], strLen);
 
 	m_read_offset += strLen;
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(const std::string &src)
+NetworkPacket &NetworkPacket::operator<<(const std::string &src)
 {
 	if (src.size() > STRING_MAX_LEN) {
 		throw PacketError("String too long");
@@ -136,7 +136,7 @@ void NetworkPacket::putLongString(const std::string &src)
 	putRawString(src.c_str(), msgsize);
 }
 
-NetworkPacket& NetworkPacket::operator>>(std::wstring& dst)
+NetworkPacket &NetworkPacket::operator>>(std::wstring &dst)
 {
 	checkReadOffset(m_read_offset, 2);
 	u16 strLen = readU16(&m_data[m_read_offset]);
@@ -160,7 +160,7 @@ NetworkPacket& NetworkPacket::operator>>(std::wstring& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(const std::wstring &src)
+NetworkPacket &NetworkPacket::operator<<(const std::wstring &src)
 {
 	if (src.size() > WIDE_STRING_MAX_LEN) {
 		throw PacketError("String too long");
@@ -197,14 +197,14 @@ std::string NetworkPacket::readLongString()
 	std::string dst;
 
 	dst.reserve(strLen);
-	dst.append((char*)&m_data[m_read_offset], strLen);
+	dst.append((char *)&m_data[m_read_offset], strLen);
 
 	m_read_offset += strLen;
 
 	return dst;
 }
 
-NetworkPacket& NetworkPacket::operator>>(char& dst)
+NetworkPacket &NetworkPacket::operator>>(char &dst)
 {
 	checkReadOffset(m_read_offset, 1);
 
@@ -221,7 +221,7 @@ char NetworkPacket::getChar(u32 offset)
 	return readU8(&m_data[offset]);
 }
 
-NetworkPacket& NetworkPacket::operator<<(char src)
+NetworkPacket &NetworkPacket::operator<<(char src)
 {
 	checkDataSize(1);
 
@@ -231,7 +231,7 @@ NetworkPacket& NetworkPacket::operator<<(char src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(u8 src)
+NetworkPacket &NetworkPacket::operator<<(u8 src)
 {
 	checkDataSize(1);
 
@@ -241,7 +241,7 @@ NetworkPacket& NetworkPacket::operator<<(u8 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(bool src)
+NetworkPacket &NetworkPacket::operator<<(bool src)
 {
 	checkDataSize(1);
 
@@ -251,7 +251,7 @@ NetworkPacket& NetworkPacket::operator<<(bool src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(u16 src)
+NetworkPacket &NetworkPacket::operator<<(u16 src)
 {
 	checkDataSize(2);
 
@@ -261,7 +261,7 @@ NetworkPacket& NetworkPacket::operator<<(u16 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(u32 src)
+NetworkPacket &NetworkPacket::operator<<(u32 src)
 {
 	checkDataSize(4);
 
@@ -271,7 +271,7 @@ NetworkPacket& NetworkPacket::operator<<(u32 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(u64 src)
+NetworkPacket &NetworkPacket::operator<<(u64 src)
 {
 	checkDataSize(8);
 
@@ -281,7 +281,7 @@ NetworkPacket& NetworkPacket::operator<<(u64 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(float src)
+NetworkPacket &NetworkPacket::operator<<(float src)
 {
 	checkDataSize(4);
 
@@ -291,7 +291,7 @@ NetworkPacket& NetworkPacket::operator<<(float src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(bool& dst)
+NetworkPacket &NetworkPacket::operator>>(bool &dst)
 {
 	checkReadOffset(m_read_offset, 1);
 
@@ -301,7 +301,7 @@ NetworkPacket& NetworkPacket::operator>>(bool& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(u8& dst)
+NetworkPacket &NetworkPacket::operator>>(u8 &dst)
 {
 	checkReadOffset(m_read_offset, 1);
 
@@ -318,7 +318,7 @@ u8 NetworkPacket::getU8(u32 offset)
 	return readU8(&m_data[offset]);
 }
 
-u8* NetworkPacket::getU8Ptr(u32 from_offset)
+u8 *NetworkPacket::getU8Ptr(u32 from_offset)
 {
 	if (m_datasize == 0) {
 		return NULL;
@@ -326,10 +326,10 @@ u8* NetworkPacket::getU8Ptr(u32 from_offset)
 
 	checkReadOffset(from_offset, 1);
 
-	return (u8*)&m_data[from_offset];
+	return (u8 *)&m_data[from_offset];
 }
 
-NetworkPacket& NetworkPacket::operator>>(u16& dst)
+NetworkPacket &NetworkPacket::operator>>(u16 &dst)
 {
 	checkReadOffset(m_read_offset, 2);
 
@@ -346,7 +346,7 @@ u16 NetworkPacket::getU16(u32 from_offset)
 	return readU16(&m_data[from_offset]);
 }
 
-NetworkPacket& NetworkPacket::operator>>(u32& dst)
+NetworkPacket &NetworkPacket::operator>>(u32 &dst)
 {
 	checkReadOffset(m_read_offset, 4);
 
@@ -356,7 +356,7 @@ NetworkPacket& NetworkPacket::operator>>(u32& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(u64& dst)
+NetworkPacket &NetworkPacket::operator>>(u64 &dst)
 {
 	checkReadOffset(m_read_offset, 8);
 
@@ -366,7 +366,7 @@ NetworkPacket& NetworkPacket::operator>>(u64& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(float& dst)
+NetworkPacket &NetworkPacket::operator>>(float &dst)
 {
 	checkReadOffset(m_read_offset, 4);
 
@@ -376,7 +376,7 @@ NetworkPacket& NetworkPacket::operator>>(float& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(v2f& dst)
+NetworkPacket &NetworkPacket::operator>>(v2f &dst)
 {
 	checkReadOffset(m_read_offset, 8);
 
@@ -386,7 +386,7 @@ NetworkPacket& NetworkPacket::operator>>(v2f& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(v3f& dst)
+NetworkPacket &NetworkPacket::operator>>(v3f &dst)
 {
 	checkReadOffset(m_read_offset, 12);
 
@@ -396,7 +396,7 @@ NetworkPacket& NetworkPacket::operator>>(v3f& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(s16& dst)
+NetworkPacket &NetworkPacket::operator>>(s16 &dst)
 {
 	checkReadOffset(m_read_offset, 2);
 
@@ -406,13 +406,13 @@ NetworkPacket& NetworkPacket::operator>>(s16& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(s16 src)
+NetworkPacket &NetworkPacket::operator<<(s16 src)
 {
 	*this << (u16) src;
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(s32& dst)
+NetworkPacket &NetworkPacket::operator>>(s32 &dst)
 {
 	checkReadOffset(m_read_offset, 4);
 
@@ -422,13 +422,13 @@ NetworkPacket& NetworkPacket::operator>>(s32& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(s32 src)
+NetworkPacket &NetworkPacket::operator<<(s32 src)
 {
 	*this << (u32) src;
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(v3s16& dst)
+NetworkPacket &NetworkPacket::operator>>(v3s16 &dst)
 {
 	checkReadOffset(m_read_offset, 6);
 
@@ -438,7 +438,7 @@ NetworkPacket& NetworkPacket::operator>>(v3s16& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(v2s32& dst)
+NetworkPacket &NetworkPacket::operator>>(v2s32 &dst)
 {
 	checkReadOffset(m_read_offset, 8);
 
@@ -448,7 +448,7 @@ NetworkPacket& NetworkPacket::operator>>(v2s32& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(v3s32& dst)
+NetworkPacket &NetworkPacket::operator>>(v3s32 &dst)
 {
 	checkReadOffset(m_read_offset, 12);
 
@@ -458,14 +458,14 @@ NetworkPacket& NetworkPacket::operator>>(v3s32& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(v2f src)
+NetworkPacket &NetworkPacket::operator<<(v2f src)
 {
 	*this << (float) src.X;
 	*this << (float) src.Y;
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(v3f src)
+NetworkPacket &NetworkPacket::operator<<(v3f src)
 {
 	*this << (float) src.X;
 	*this << (float) src.Y;
@@ -473,7 +473,7 @@ NetworkPacket& NetworkPacket::operator<<(v3f src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(v3s16 src)
+NetworkPacket &NetworkPacket::operator<<(v3s16 src)
 {
 	*this << (s16) src.X;
 	*this << (s16) src.Y;
@@ -481,14 +481,14 @@ NetworkPacket& NetworkPacket::operator<<(v3s16 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(v2s32 src)
+NetworkPacket &NetworkPacket::operator<<(v2s32 src)
 {
 	*this << (s32) src.X;
 	*this << (s32) src.Y;
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(v3s32 src)
+NetworkPacket &NetworkPacket::operator<<(v3s32 src)
 {
 	*this << (s32) src.X;
 	*this << (s32) src.Y;
@@ -496,7 +496,7 @@ NetworkPacket& NetworkPacket::operator<<(v3s32 src)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator>>(video::SColor& dst)
+NetworkPacket &NetworkPacket::operator>>(video::SColor &dst)
 {
 	checkReadOffset(m_read_offset, 4);
 
@@ -506,7 +506,7 @@ NetworkPacket& NetworkPacket::operator>>(video::SColor& dst)
 	return *this;
 }
 
-NetworkPacket& NetworkPacket::operator<<(video::SColor src)
+NetworkPacket &NetworkPacket::operator<<(video::SColor src)
 {
 	checkDataSize(4);
 
@@ -521,7 +521,7 @@ SharedBuffer<u8> NetworkPacket::oldForgePacket()
 	SharedBuffer<u8> sb(m_datasize + 2);
 	writeU16(&sb[0], m_command);
 
-	u8* datas = getU8Ptr(0);
+	u8 *datas = getU8Ptr(0);
 
 	if (datas != NULL)
 		memcpy(&sb[2], datas, m_datasize);

--- a/src/network/serveropcodes.h
+++ b/src/network/serveropcodes.h
@@ -35,12 +35,12 @@ struct ToServerCommandHandler
 {
     const std::string name;
     ToServerConnectionState state;
-    void (Server::*handler)(NetworkPacket* pkt);
+    void (Server::*handler)(NetworkPacket *pkt);
 };
 
 struct ClientCommandFactory
 {
-	const char* name;
+	const char *name;
 	u8 channel;
 	bool reliable;
 };

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -40,19 +40,19 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/serialize.h"
 #include "util/srp.h"
 
-void Server::handleCommand_Deprecated(NetworkPacket* pkt)
+void Server::handleCommand_Deprecated(NetworkPacket *pkt)
 {
 	infostream << "Server: " << toServerCommandTable[pkt->getCommand()].name
 		<< " not supported anymore" << std::endl;
 }
 
-void Server::handleCommand_Init(NetworkPacket* pkt)
+void Server::handleCommand_Init(NetworkPacket *pkt)
 {
 
 	if(pkt->getSize() < 1)
 		return;
 
-	RemoteClient* client = getClient(pkt->getPeerId(), CS_Created);
+	RemoteClient *client = getClient(pkt->getPeerId(), CS_Created);
 
 	std::string addr_s;
 	try {
@@ -155,7 +155,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	/*
 		Validate player name
 	*/
-	const char* playername = playerName.c_str();
+	const char *playername = playerName.c_str();
 
 	size_t pns = playerName.size();
 	if (pns == 0 || pns > PLAYERNAME_SIZE) {
@@ -279,7 +279,7 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	m_clients.event(pkt->getPeerId(), CSE_Hello);
 }
 
-void Server::handleCommand_Init2(NetworkPacket* pkt)
+void Server::handleCommand_Init2(NetworkPacket *pkt)
 {
 	verbosestream << "Server: Got TOSERVER_INIT2 from "
 			<< pkt->getPeerId() << std::endl;
@@ -331,7 +331,7 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
+void Server::handleCommand_RequestMedia(NetworkPacket *pkt)
 {
 	std::vector<std::string> tosend;
 	u16 numfiles;
@@ -355,11 +355,11 @@ void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
 	sendRequestedMedia(pkt->getPeerId(), tosend);
 }
 
-void Server::handleCommand_ClientReady(NetworkPacket* pkt)
+void Server::handleCommand_ClientReady(NetworkPacket *pkt)
 {
 	session_t peer_id = pkt->getPeerId();
 
-	PlayerSAO* playersao = StageTwoClientInit(peer_id);
+	PlayerSAO *playersao = StageTwoClientInit(peer_id);
 
 	if (playersao == NULL) {
 		actionstream
@@ -407,7 +407,7 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_GotBlocks(NetworkPacket* pkt)
+void Server::handleCommand_GotBlocks(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 1)
 		return;
@@ -495,7 +495,7 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	}
 }
 
-void Server::handleCommand_PlayerPos(NetworkPacket* pkt)
+void Server::handleCommand_PlayerPos(NetworkPacket *pkt)
 {
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 	if (player == NULL) {
@@ -525,7 +525,7 @@ void Server::handleCommand_PlayerPos(NetworkPacket* pkt)
 	process_PlayerPos(player, playersao, pkt);
 }
 
-void Server::handleCommand_DeletedBlocks(NetworkPacket* pkt)
+void Server::handleCommand_DeletedBlocks(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 1)
 		return;
@@ -555,7 +555,7 @@ void Server::handleCommand_DeletedBlocks(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
+void Server::handleCommand_InventoryAction(NetworkPacket *pkt)
 {
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 
@@ -603,7 +603,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		Handle restrictions and special cases of the move action
 	*/
 	if (a->getType() == IAction::Move) {
-		IMoveAction *ma = (IMoveAction*)a;
+		IMoveAction *ma = (IMoveAction *)a;
 
 		ma->from_inv.applyCurrentPlayer(player->getName());
 		ma->to_inv.applyCurrentPlayer(player->getName());
@@ -672,7 +672,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		Handle restrictions and special cases of the drop action
 	*/
 	else if (a->getType() == IAction::Drop) {
-		IDropAction *da = (IDropAction*)a;
+		IDropAction *da = (IDropAction *)a;
 
 		da->from_inv.applyCurrentPlayer(player->getName());
 
@@ -708,7 +708,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		Handle restrictions and special cases of the craft action
 	*/
 	else if (a->getType() == IAction::Craft) {
-		ICraftAction *ca = (ICraftAction*)a;
+		ICraftAction *ca = (ICraftAction *)a;
 
 		ca->craft_inv.applyCurrentPlayer(player->getName());
 
@@ -735,7 +735,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	SendInventory(playersao);
 }
 
-void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
+void Server::handleCommand_ChatMessage(NetworkPacket *pkt)
 {
 	/*
 		u16 command
@@ -774,7 +774,7 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_Damage(NetworkPacket* pkt)
+void Server::handleCommand_Damage(NetworkPacket *pkt)
 {
 	u16 damage;
 
@@ -817,7 +817,7 @@ void Server::handleCommand_Damage(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_Password(NetworkPacket* pkt)
+void Server::handleCommand_Password(NetworkPacket *pkt)
 {
 	if (pkt->getSize() != PASSWORD_SIZE * 2)
 		return;
@@ -826,7 +826,7 @@ void Server::handleCommand_Password(NetworkPacket* pkt)
 	std::string newpwd;
 
 	// Deny for clients using the new protocol
-	RemoteClient* client = getClient(pkt->getPeerId(), CS_Created);
+	RemoteClient *client = getClient(pkt->getPeerId(), CS_Created);
 	if (client->net_proto_version >= 25) {
 		infostream << "Server::handleCommand_Password(): Denying change: "
 			<< " Client protocol version for peer_id=" << pkt->getPeerId()
@@ -895,7 +895,7 @@ void Server::handleCommand_Password(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
+void Server::handleCommand_PlayerItem(NetworkPacket *pkt)
 {
 	if (pkt->getSize() < 2)
 		return;
@@ -926,7 +926,7 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 	playersao->setWieldIndex(item);
 }
 
-void Server::handleCommand_Respawn(NetworkPacket* pkt)
+void Server::handleCommand_Respawn(NetworkPacket *pkt)
 {
 	RemotePlayer *player = m_env->getPlayer(pkt->getPeerId());
 	if (player == NULL) {
@@ -984,7 +984,7 @@ bool Server::checkInteractDistance(RemotePlayer *player, const f32 d, const std:
 	return true;
 }
 
-void Server::handleCommand_Interact(NetworkPacket* pkt)
+void Server::handleCommand_Interact(NetworkPacket *pkt)
 {
 	/*
 		[0] u16 command
@@ -1400,7 +1400,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_RemovedSounds(NetworkPacket* pkt)
+void Server::handleCommand_RemovedSounds(NetworkPacket *pkt)
 {
 	u16 num;
 	*pkt >> num;
@@ -1421,7 +1421,7 @@ void Server::handleCommand_RemovedSounds(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
+void Server::handleCommand_NodeMetaFields(NetworkPacket *pkt)
 {
 	v3s16 p;
 	std::string formname;
@@ -1473,7 +1473,7 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
+void Server::handleCommand_InventoryFields(NetworkPacket *pkt)
 {
 	std::string client_formspec_name;
 	u16 num;
@@ -1536,9 +1536,9 @@ void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
 	actionstream << ", possible exploitation attempt" << std::endl;
 }
 
-void Server::handleCommand_FirstSrp(NetworkPacket* pkt)
+void Server::handleCommand_FirstSrp(NetworkPacket *pkt)
 {
-	RemoteClient* client = getClient(pkt->getPeerId(), CS_Invalid);
+	RemoteClient *client = getClient(pkt->getPeerId(), CS_Invalid);
 	ClientState cstate = client->getState();
 
 	std::string playername = client->getName();
@@ -1602,9 +1602,9 @@ void Server::handleCommand_FirstSrp(NetworkPacket* pkt)
 	}
 }
 
-void Server::handleCommand_SrpBytesA(NetworkPacket* pkt)
+void Server::handleCommand_SrpBytesA(NetworkPacket *pkt)
 {
-	RemoteClient* client = getClient(pkt->getPeerId(), CS_Invalid);
+	RemoteClient *client = getClient(pkt->getPeerId(), CS_Invalid);
 	ClientState cstate = client->getState();
 
 	bool wantSudo = (cstate == CS_Active);
@@ -1708,9 +1708,9 @@ void Server::handleCommand_SrpBytesA(NetworkPacket* pkt)
 	Send(&resp_pkt);
 }
 
-void Server::handleCommand_SrpBytesM(NetworkPacket* pkt)
+void Server::handleCommand_SrpBytesM(NetworkPacket *pkt)
 {
-	RemoteClient* client = getClient(pkt->getPeerId(), CS_Invalid);
+	RemoteClient *client = getClient(pkt->getPeerId(), CS_Invalid);
 	ClientState cstate = client->getState();
 
 	bool wantSudo = (cstate == CS_Active);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -1048,7 +1048,7 @@ bool NodeDefManager::getIds(const std::string &name,
 }
 
 
-const ContentFeatures& NodeDefManager::get(const std::string &name) const
+const ContentFeatures &NodeDefManager::get(const std::string &name) const
 {
 	content_t id = CONTENT_UNKNOWN;
 	getId(name, id);

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -466,7 +466,7 @@ public:
 	 * @return properties of the given content type, or \ref CONTENT_UNKNOWN
 	 * if the given content type is not registered.
 	 */
-	inline const ContentFeatures& get(content_t c) const {
+	inline const ContentFeatures &get(content_t c) const {
 		return
 			c < m_content_features.size() ?
 				m_content_features[c] : m_content_features[CONTENT_UNKNOWN];
@@ -478,7 +478,7 @@ public:
 	 * @return properties of the given node or @ref CONTENT_UNKNOWN if the
 	 * given content type is not registered.
 	 */
-	inline const ContentFeatures& get(const MapNode &n) const {
+	inline const ContentFeatures &get(const MapNode &n) const {
 		return get(n.getContent());
 	}
 
@@ -488,7 +488,7 @@ public:
 	 * @return properties of the given node or @ref CONTENT_UNKNOWN if
 	 * not found
 	 */
-	const ContentFeatures& get(const std::string &name) const;
+	const ContentFeatures &get(const std::string &name) const;
 
 	/*!
 	 * Returns the content ID for the given name.

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -382,7 +382,7 @@ private:
 /* implementation                                                             */
 /******************************************************************************/
 
-std::vector<v3s16> get_path(ServerEnvironment* env,
+std::vector<v3s16> get_path(ServerEnvironment *env,
 							v3s16 source,
 							v3s16 destination,
 							unsigned int searchdistance,

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -104,7 +104,7 @@ u32 Player::addHud(HudElement *toadd)
 	return id;
 }
 
-HudElement* Player::getHud(u32 id)
+HudElement *Player::getHud(u32 id)
 {
 	MutexAutoLock lock(m_mutex);
 
@@ -114,11 +114,11 @@ HudElement* Player::getHud(u32 id)
 	return NULL;
 }
 
-HudElement* Player::removeHud(u32 id)
+HudElement *Player::removeHud(u32 id)
 {
 	MutexAutoLock lock(m_mutex);
 
-	HudElement* retval = NULL;
+	HudElement *retval = NULL;
 	if (id < hud.size()) {
 		retval = hud[id];
 		hud[id] = NULL;

--- a/src/player.h
+++ b/src/player.h
@@ -169,15 +169,15 @@ public:
 	std::string formspec_prepend;
 
 	PlayerControl control;
-	const PlayerControl& getPlayerControl() { return control; }
+	const PlayerControl &getPlayerControl() { return control; }
 	PlayerSettings &getPlayerSettings() { return m_player_settings; }
 	static void settingsChangedCallback(const std::string &name, void *data);
 
 	u32 keyPressed = 0;
 
-	HudElement* getHud(u32 id);
-	u32         addHud(HudElement* hud);
-	HudElement* removeHud(u32 id);
+	HudElement *getHud(u32 id);
+	u32         addHud(HudElement *hud);
+	HudElement *removeHud(u32 id);
 	void        clearHud();
 
 	u32 hud_flags;

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -73,7 +73,7 @@ extern "C" {
 			JNIEnv * env, jclass thiz, jstring text)
 	{
 		errorstream << "Java_net_minetest_MtNativeActivity_putMessageBoxResult got: "
-				<< std::string((const char*)env->GetStringChars(text,0))
+				<< std::string((const char *)env->GetStringChars(text,0))
 				<< std::endl;
 	}
 }
@@ -82,7 +82,7 @@ namespace porting {
 
 std::string path_storage = DIR_DELIM "sdcard" DIR_DELIM;
 
-android_app* app_global;
+android_app *app_global;
 JNIEnv*      jnienv;
 jclass       nativeActivity;
 
@@ -223,8 +223,8 @@ void initializePathsAndroid()
 	migrateCachePath();
 }
 
-void showInputDialog(const std::string& acceptButton, const  std::string& hint,
-		const std::string& current, int editType)
+void showInputDialog(const std::string &acceptButton, const std::string &hint,
+		const std::string &current, int editType)
 {
 	jmethodID showdialog = jnienv->GetMethodID(nativeActivity,"showDialog",
 		"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
@@ -266,7 +266,7 @@ std::string getInputDialogValue()
 	jobject result = jnienv->CallObjectMethod(app_global->activity->clazz,
 			dialogvalue);
 
-	const char* javachars = jnienv->GetStringUTFChars((jstring) result,0);
+	const char *javachars = jnienv->GetStringUTFChars((jstring) result,0);
 	std::string text(javachars);
 	jnienv->ReleaseStringUTFChars((jstring) result, javachars);
 

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -61,8 +61,8 @@ void copyAssets();
  * @param editType type of texfield
  * (1==multiline text input; 2==single line text input; 3=password field)
  */
-void showInputDialog(const std::string& acceptButton,
-		const  std::string& hint, const std::string& current, int editType);
+void showInputDialog(const std::string &acceptButton,
+		const  std::string &hint, const std::string &current, int editType);
 
 /**
  * WORKAROUND for not working callbacks from java -> c++

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -163,7 +163,7 @@ public:
 		m_graphvalues.clear();
 	}
 
-	void remove(const std::string& name)
+	void remove(const std::string &name)
 	{
 		MutexAutoLock lock(m_mutex);
 		m_avgcounts.erase(name);

--- a/src/rollback.cpp
+++ b/src/rollback.cpp
@@ -471,7 +471,7 @@ bool RollbackManager::registerRow(const ActionRow & row)
 }
 
 
-const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt* stmt)
+const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt *stmt)
 {
 	std::list<ActionRow> rows;
 	const unsigned char * text;
@@ -487,7 +487,7 @@ const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt* s
 		if (row.type == RollbackAction::TYPE_MODIFY_INVENTORY_STACK) {
 			text = sqlite3_column_text (stmt, 3);
 			size = sqlite3_column_bytes(stmt, 3);
-			row.list        = std::string(reinterpret_cast<const char*>(text), size);
+			row.list        = std::string(reinterpret_cast<const char *>(text), size);
 			row.index       = sqlite3_column_int(stmt, 4);
 			row.add         = sqlite3_column_int(stmt, 5);
 			row.stack.id    = sqlite3_column_int(stmt, 6);
@@ -507,13 +507,13 @@ const std::list<ActionRow> RollbackManager::actionRowsFromSelect(sqlite3_stmt* s
 			row.oldParam2 = sqlite3_column_int(stmt, 14);
 			text = sqlite3_column_text (stmt, 15);
 			size = sqlite3_column_bytes(stmt, 15);
-			row.oldMeta   = std::string(reinterpret_cast<const char*>(text), size);
+			row.oldMeta   = std::string(reinterpret_cast<const char *>(text), size);
 			row.newNode   = sqlite3_column_int(stmt, 16);
 			row.newParam1 = sqlite3_column_int(stmt, 17);
 			row.newParam2 = sqlite3_column_int(stmt, 18);
 			text = sqlite3_column_text(stmt, 19);
 			size = sqlite3_column_bytes(stmt, 19);
-			row.newMeta   = std::string(reinterpret_cast<const char*>(text), size);
+			row.newMeta   = std::string(reinterpret_cast<const char *>(text), size);
 			row.guessed   = sqlite3_column_int(stmt, 20);
 		}
 
@@ -968,4 +968,3 @@ std::list<RollbackAction> RollbackManager::getRevertActions(
 
 	return getActionsSince(first_time, actor_filter);
 }
-

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -45,7 +45,7 @@ struct EnumString es_TileAnimationType[] =
 };
 
 /******************************************************************************/
-void read_item_definition(lua_State* L, int index,
+void read_item_definition(lua_State *L, int index,
 		const ItemDefinition &default_def, ItemDefinition &def)
 {
 	if (index < 0)
@@ -1166,7 +1166,7 @@ bool string_to_enum(const EnumString *spec, int &result,
 }
 
 /******************************************************************************/
-ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
+ItemStack read_item(lua_State *L, int index, IItemDefManager *idef)
 {
 	if(index < 0)
 		index = lua_gettop(L) + 1 + index;
@@ -1291,7 +1291,7 @@ void push_inventory_list(lua_State *L, Inventory *inv, const char *name)
 
 /******************************************************************************/
 void read_inventory_list(lua_State *L, int tableindex,
-		Inventory *inv, const char *name, Server* srv, int forcesize)
+		Inventory *inv, const char *name, Server *srv, int forcesize)
 {
 	if(tableindex < 0)
 		tableindex = lua_gettop(L) + 1 + tableindex;

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -157,7 +157,7 @@ void               push_items                (lua_State *L,
 
 std::vector<ItemStack> read_items            (lua_State *L,
                                               int index,
-                                              Server* srv);
+                                              Server *srv);
 
 void               push_soundspec            (lua_State *L,
                                               const SimpleSoundSpec &spec);

--- a/src/script/cpp_api/s_async.cpp
+++ b/src/script/cpp_api/s_async.cpp
@@ -158,7 +158,7 @@ void AsyncEngine::step(lua_State *L)
 }
 
 /******************************************************************************/
-void AsyncEngine::pushFinishedJobs(lua_State* L) {
+void AsyncEngine::pushFinishedJobs(lua_State *L) {
 	// Result Table
 	MutexAutoLock l(resultQueueMutex);
 
@@ -187,7 +187,7 @@ void AsyncEngine::pushFinishedJobs(lua_State* L) {
 }
 
 /******************************************************************************/
-void AsyncEngine::prepareEnvironment(lua_State* L, int top)
+void AsyncEngine::prepareEnvironment(lua_State *L, int top)
 {
 	for (StateInitializer &stateInitializer : stateInitializers) {
 		stateInitializer(L, top);
@@ -195,7 +195,7 @@ void AsyncEngine::prepareEnvironment(lua_State* L, int top)
 }
 
 /******************************************************************************/
-AsyncWorkerThread::AsyncWorkerThread(AsyncEngine* jobDispatcher,
+AsyncWorkerThread::AsyncWorkerThread(AsyncEngine *jobDispatcher,
 		const std::string &name) :
 	Thread(name),
 	ScriptApiBase(ScriptingType::Async),
@@ -221,7 +221,7 @@ AsyncWorkerThread::~AsyncWorkerThread()
 }
 
 /******************************************************************************/
-void* AsyncWorkerThread::run()
+void *AsyncWorkerThread::run()
 {
 	lua_State *L = getStack();
 
@@ -286,4 +286,3 @@ void* AsyncWorkerThread::run()
 
 	return 0;
 }
-

--- a/src/script/cpp_api/s_async.h
+++ b/src/script/cpp_api/s_async.h
@@ -54,7 +54,7 @@ struct LuaJobInfo
 // Asynchronous working environment
 class AsyncWorkerThread : public Thread, public ScriptApiBase {
 public:
-	AsyncWorkerThread(AsyncEngine* jobDispatcher, const std::string &name);
+	AsyncWorkerThread(AsyncEngine *jobDispatcher, const std::string &name);
 	virtual ~AsyncWorkerThread();
 
 	void *run();
@@ -125,7 +125,7 @@ protected:
 	 * @param L Lua stack to initialize
 	 * @param top Stack position
 	 */
-	void prepareEnvironment(lua_State* L, int top);
+	void prepareEnvironment(lua_State *L, int top);
 
 private:
 	// Variable locking the engine against further modification
@@ -149,7 +149,7 @@ private:
 	std::deque<LuaJobInfo> resultQueue;
 
 	// List of current worker threads
-	std::vector<AsyncWorkerThread*> workerThreads;
+	std::vector<AsyncWorkerThread *> workerThreads;
 
 	// Counter semaphore for job dispatching
 	Semaphore jobQueueCounter;

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -89,7 +89,7 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	else
 		luaL_openlibs(m_luastack);
 
-	// Make the ScriptApiBase* accessible to ModApiBase
+	// Make the ScriptApiBase * accessible to ModApiBase
 	lua_pushlightuserdata(m_luastack, this);
 	lua_rawseti(m_luastack, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 
@@ -102,7 +102,7 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	// If we are using LuaJIT add a C++ wrapper function to catch
 	// exceptions thrown in Lua -> C++ calls
 #if USE_LUAJIT
-	lua_pushlightuserdata(m_luastack, (void*) script_exception_wrapper);
+	lua_pushlightuserdata(m_luastack, (void *) script_exception_wrapper);
 	luaJIT_setmode(m_luastack, -1, LUAJIT_MODE_WRAPCFUNC | LUAJIT_MODE_ON);
 	lua_pop(m_luastack, 1);
 #endif
@@ -410,12 +410,12 @@ void ScriptApiBase::pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeR
 	}
 }
 
-Server* ScriptApiBase::getServer()
+Server *ScriptApiBase::getServer()
 {
 	return dynamic_cast<Server *>(m_gamedef);
 }
 #ifndef SERVER
-Client* ScriptApiBase::getClient()
+Client *ScriptApiBase::getClient()
 {
 	return dynamic_cast<Client *>(m_gamedef);
 }

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -102,10 +102,10 @@ public:
 	void removeObjectReference(ServerActiveObject *cobj);
 
 	IGameDef *getGameDef() { return m_gamedef; }
-	Server* getServer();
+	Server *getServer();
 	ScriptingType getType() { return m_type; }
 #ifndef SERVER
-	Client* getClient();
+	Client *getClient();
 #endif
 
 	std::string getOrigin() { return m_last_run_mod; }
@@ -124,24 +124,24 @@ protected:
 	friend class ModApiEnvMod;
 	friend class LuaVoxelManip;
 
-	lua_State* getStack()
+	lua_State *getStack()
 		{ return m_luastack; }
 
 	void realityCheck();
 	void scriptError(int result, const char *fxn);
 	void stackDump(std::ostream &o);
 
-	void setGameDef(IGameDef* gamedef) { m_gamedef = gamedef; }
+	void setGameDef(IGameDef *gamedef) { m_gamedef = gamedef; }
 
-	Environment* getEnv() { return m_environment; }
-	void setEnv(Environment* env) { m_environment = env; }
+	Environment *getEnv() { return m_environment; }
+	void setEnv(Environment *env) { m_environment = env; }
 
-	GUIEngine* getGuiEngine() { return m_guiengine; }
-	void setGuiEngine(GUIEngine* guiengine) { m_guiengine = guiengine; }
+	GUIEngine *getGuiEngine() { return m_guiengine; }
+	void setGuiEngine(GUIEngine *guiengine) { m_guiengine = guiengine; }
 
 	void objectrefGetOrCreate(lua_State *L, ServerActiveObject *cobj);
 
-	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason& reason);
+	void pushPlayerHPChangeReason(lua_State *L, const PlayerHPChangeReason &reason);
 
 	std::recursive_mutex m_luastackmutex;
 	std::string     m_last_run_mod;

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -228,11 +228,11 @@ bool ScriptApiClient::on_inventory_open(Inventory *inventory)
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_on_inventory_open");
 
-	std::vector<const InventoryList*> lists = inventory->getLists();
-	std::vector<const InventoryList*>::iterator iter = lists.begin();
+	std::vector<const InventoryList *> lists = inventory->getLists();
+	std::vector<const InventoryList *>::iterator iter = lists.begin();
 	lua_createtable(L, 0, lists.size());
 	for (; iter != lists.end(); iter++) {
-		const char* name = (*iter)->getName().c_str();
+		const char *name = (*iter)->getName().c_str();
 		lua_pushstring(L, name);
 		push_inventory_list(L, inventory, name);
 		lua_rawset(L, -3);

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -214,7 +214,7 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 bool ScriptApiItem::getItemCallback(const char *name, const char *callbackname,
 		const v3s16 *p)
 {
-	lua_State* L = getStack();
+	lua_State *L = getStack();
 
 	lua_getglobal(L, "core");
 	lua_getfield(L, -1, "registered_items");
@@ -257,8 +257,7 @@ bool ScriptApiItem::getItemCallback(const char *name, const char *callbackname,
 
 void ScriptApiItem::pushPointedThing(const PointedThing &pointed, bool hitpoint)
 {
-	lua_State* L = getStack();
+	lua_State *L = getStack();
 
 	push_pointed_thing(L, pointed, false, hitpoint);
 }
-

--- a/src/script/lua_api/l_auth.h
+++ b/src/script/lua_api/l_auth.h
@@ -45,7 +45,7 @@ private:
 	// auth_reload()
 	static int l_auth_reload(lua_State *L);
 
-	// helper for auth* methods
+	// helper for auth * methods
 	static AuthDatabase *getAuthDb(lua_State *L);
 	static void pushAuthEntry(lua_State *L, const AuthEntry &authEntry);
 

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -30,7 +30,7 @@ ScriptApiBase *ModApiBase::getScriptApiBase(lua_State *L)
 {
 	// Get server from registry
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
-	ScriptApiBase *sapi_ptr = (ScriptApiBase*) lua_touserdata(L, -1);
+	ScriptApiBase *sapi_ptr = (ScriptApiBase *) lua_touserdata(L, -1);
 	lua_pop(L, 1);
 	return sapi_ptr;
 }

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -58,9 +58,9 @@ public:
 	// Get an arbitrary subclass of ScriptApiBase
 	// by using dynamic_cast<> on getScriptApiBase()
 	template<typename T>
-	static T* getScriptApi(lua_State *L) {
+	static T *getScriptApi(lua_State *L) {
 		ScriptApiBase *scriptIface = getScriptApiBase(L);
-		T *scriptIfaceDowncast = dynamic_cast<T*>(scriptIface);
+		T *scriptIfaceDowncast = dynamic_cast<T *>(scriptIface);
 		if (!scriptIfaceDowncast) {
 			throw LuaError("Requested unavailable ScriptApi - core engine bug!");
 		}
@@ -68,7 +68,7 @@ public:
 	}
 
 	static bool registerFunction(lua_State *L,
-			const char* name,
+			const char *name,
 			lua_CFunction func,
 			int top);
 

--- a/src/script/lua_api/l_craft.cpp
+++ b/src/script/lua_api/l_craft.cpp
@@ -456,7 +456,7 @@ static void push_craft_recipe(lua_State *L, IGameDef *gdef,
 }
 
 static void push_craft_recipes(lua_State *L, IGameDef *gdef,
-		const std::vector<CraftDefinition*> &recipes,
+		const std::vector<CraftDefinition *> &recipes,
 		const CraftOutput &output)
 {
 	lua_createtable(L, recipes.size(), 0);
@@ -466,7 +466,7 @@ static void push_craft_recipes(lua_State *L, IGameDef *gdef,
 		return;
 	}
 
-	std::vector<CraftDefinition*>::const_iterator it = recipes.begin();
+	std::vector<CraftDefinition *>::const_iterator it = recipes.begin();
 	for (unsigned i = 0; it != recipes.end(); ++it) {
 		lua_newtable(L);
 		push_craft_recipe(L, gdef, *it, output);
@@ -483,7 +483,7 @@ int ModApiCraft::l_get_craft_recipe(lua_State *L)
 	std::string item = luaL_checkstring(L, 1);
 	Server *server = getServer(L);
 	CraftOutput output(item, 0);
-	std::vector<CraftDefinition*> recipes = server->cdef()
+	std::vector<CraftDefinition *> recipes = server->cdef()
 			->getCraftRecipes(output, server, 1);
 
 	lua_createtable(L, 1, 0);
@@ -506,7 +506,7 @@ int ModApiCraft::l_get_all_craft_recipes(lua_State *L)
 	std::string item = luaL_checkstring(L, 1);
 	Server *server = getServer(L);
 	CraftOutput output(item, 0);
-	std::vector<CraftDefinition*> recipes = server->cdef()
+	std::vector<CraftDefinition *> recipes = server->cdef()
 			->getCraftRecipes(output, server);
 
 	push_craft_recipes(L, server, recipes, output);

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -28,7 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	InvRef
 */
-InvRef* InvRef::checkobject(lua_State *L, int narg)
+InvRef *InvRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
@@ -36,12 +36,12 @@ InvRef* InvRef::checkobject(lua_State *L, int narg)
 	return *(InvRef**)ud;  // unbox pointer
 }
 
-Inventory* InvRef::getinv(lua_State *L, InvRef *ref)
+Inventory *InvRef::getinv(lua_State *L, InvRef *ref)
 {
 	return getServer(L)->getInventory(ref->m_loc);
 }
 
-InventoryList* InvRef::getlist(lua_State *L, InvRef *ref,
+InventoryList *InvRef::getlist(lua_State *L, InvRef *ref,
 		const char *listname)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -250,11 +250,11 @@ int InvRef::l_get_lists(lua_State *L)
 	if (!inv) {
 		return 0;
 	}
-	std::vector<const InventoryList*> lists = inv->getLists();
-	std::vector<const InventoryList*>::iterator iter = lists.begin();
+	std::vector<const InventoryList *> lists = inv->getLists();
+	std::vector<const InventoryList *>::iterator iter = lists.begin();
 	lua_createtable(L, 0, lists.size());
 	for (; iter != lists.end(); iter++) {
-		const char* name = (*iter)->getName().c_str();
+		const char *name = (*iter)->getName().c_str();
 		lua_pushstring(L, name);
 		push_inventory_list(L, inv, name);
 		lua_rawset(L, -3);

--- a/src/script/lua_api/l_inventory.h
+++ b/src/script/lua_api/l_inventory.h
@@ -39,9 +39,9 @@ private:
 
 	static InvRef *checkobject(lua_State *L, int narg);
 
-	static Inventory* getinv(lua_State *L, InvRef *ref);
+	static Inventory *getinv(lua_State *L, InvRef *ref);
 
-	static InventoryList* getlist(lua_State *L, InvRef *ref,
+	static InventoryList *getlist(lua_State *L, InvRef *ref,
 			const char *listname);
 
 	static void reportInventoryChange(lua_State *L, InvRef *ref);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -390,11 +390,11 @@ LuaItemStack::LuaItemStack(const ItemStack &item):
 {
 }
 
-const ItemStack& LuaItemStack::getItem() const
+const ItemStack &LuaItemStack::getItem() const
 {
 	return m_stack;
 }
-ItemStack& LuaItemStack::getItem()
+ItemStack &LuaItemStack::getItem()
 {
 	return m_stack;
 }
@@ -422,7 +422,7 @@ int LuaItemStack::create(lua_State *L, const ItemStack &item)
 	return 1;
 }
 
-LuaItemStack* LuaItemStack::checkobject(lua_State *L, int narg)
+LuaItemStack *LuaItemStack::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -123,15 +123,15 @@ public:
 	LuaItemStack(const ItemStack &item);
 	~LuaItemStack() = default;
 
-	const ItemStack& getItem() const;
-	ItemStack& getItem();
+	const ItemStack &getItem() const;
+	ItemStack &getItem();
 
 	// LuaItemStack(itemstack or itemstring or table or nil)
 	// Creates an LuaItemStack and leaves it on top of stack
 	static int create_object(lua_State *L);
 	// Not callable from Lua
 	static int create(lua_State *L, const ItemStack &item);
-	static LuaItemStack* checkobject(lua_State *L, int narg);
+	static LuaItemStack *checkobject(lua_State *L, int narg);
 	static void Register(lua_State *L);
 
 };

--- a/src/script/lua_api/l_itemstackmeta.cpp
+++ b/src/script/lua_api/l_itemstackmeta.cpp
@@ -26,7 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	NodeMetaRef
 */
-ItemStackMetaRef* ItemStackMetaRef::checkobject(lua_State *L, int narg)
+ItemStackMetaRef *ItemStackMetaRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);

--- a/src/script/lua_api/l_itemstackmeta.h
+++ b/src/script/lua_api/l_itemstackmeta.h
@@ -36,7 +36,7 @@ private:
 
 	static ItemStackMetaRef *checkobject(lua_State *L, int narg);
 
-	virtual Metadata* getmeta(bool auto_create);
+	virtual Metadata *getmeta(bool auto_create);
 
 	virtual void clearMeta();
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -56,7 +56,7 @@ std::string ModApiMainMenu::getTextData(lua_State *L, std::string name)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::getIntegerData(lua_State *L, std::string name,bool& valid)
+int ModApiMainMenu::getIntegerData(lua_State *L, std::string name, bool &valid)
 {
 	lua_getglobal(L, "gamedata");
 
@@ -72,7 +72,7 @@ int ModApiMainMenu::getIntegerData(lua_State *L, std::string name,bool& valid)
 }
 
 /******************************************************************************/
-int ModApiMainMenu::getBoolData(lua_State *L, std::string name,bool& valid)
+int ModApiMainMenu::getBoolData(lua_State *L, std::string name, bool &valid)
 {
 	lua_getglobal(L, "gamedata");
 
@@ -90,7 +90,7 @@ int ModApiMainMenu::getBoolData(lua_State *L, std::string name,bool& valid)
 /******************************************************************************/
 int ModApiMainMenu::l_update_formspec(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	if (engine->m_startgame)
@@ -109,7 +109,7 @@ int ModApiMainMenu::l_update_formspec(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_start(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	//update c++ gamedata from lua table
@@ -138,7 +138,7 @@ int ModApiMainMenu::l_start(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_close(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	engine->m_kill = true;
@@ -148,7 +148,7 @@ int ModApiMainMenu::l_close(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_background(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	std::string backgroundlevel(luaL_checkstring(L, 1));
@@ -193,7 +193,7 @@ int ModApiMainMenu::l_set_background(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_clouds(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	bool value = readParam<bool>(L,1);
@@ -213,7 +213,7 @@ int ModApiMainMenu::l_get_textlist_index(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_table_index(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	std::string tablename(luaL_checkstring(L, 1));
@@ -290,7 +290,7 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 		if (!server["clients"].asString().empty()) {
 			std::string clients_raw = server["clients"].asString();
-			char* endptr = 0;
+			char *endptr = 0;
 			int numbervalue = strtol(clients_raw.c_str(),&endptr,10);
 
 			if ((!clients_raw.empty()) && (*endptr == 0)) {
@@ -303,7 +303,7 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 		if (!server["clients_max"].asString().empty()) {
 
 			std::string clients_max_raw = server["clients_max"].asString();
-			char* endptr = 0;
+			char *endptr = 0;
 			int numbervalue = strtol(clients_max_raw.c_str(),&endptr,10);
 
 			if ((!clients_max_raw.empty()) && (*endptr == 0)) {
@@ -552,7 +552,7 @@ int ModApiMainMenu::l_get_content_info(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_show_keys_menu(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	GUIKeyChangeMenu *kmenu = new GUIKeyChangeMenu(RenderingEngine::get_gui_env(),
@@ -610,7 +610,7 @@ int ModApiMainMenu::l_delete_world(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_set_topleft_text(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	std::string text;
@@ -771,10 +771,10 @@ int ModApiMainMenu::l_extract_zip(lua_State *L)
 		/**********************************************************************/
 		/* WARNING this is not threadsafe!!                                   */
 		/**********************************************************************/
-		io::IFileArchive* opened_zip =
+		io::IFileArchive *opened_zip =
 			fs->getFileArchive(fs->getFileArchiveCount()-1);
 
-		const io::IFileList* files_in_zip = opened_zip->getFileList();
+		const io::IFileList *files_in_zip = opened_zip->getFileList();
 
 		unsigned int number_of_files = files_in_zip->getFileCount();
 
@@ -791,7 +791,7 @@ int ModApiMainMenu::l_extract_zip(lua_State *L)
 					return 1;
 				}
 
-				io::IReadFile* toread = opened_zip->createAndOpenFile(i);
+				io::IReadFile *toread = opened_zip->createAndOpenFile(i);
 
 				FILE *targetfile = fopen(fullpath.c_str(),"wb");
 
@@ -836,7 +836,7 @@ int ModApiMainMenu::l_extract_zip(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_mainmenu_path(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	lua_pushstring(L,engine->getScriptDir().c_str());
@@ -880,14 +880,14 @@ int ModApiMainMenu::l_may_modify_path(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_show_path_select_dialog(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
 	const char *formname= luaL_checkstring(L, 1);
 	const char *title	= luaL_checkstring(L, 2);
 	bool is_file_select = readParam<bool>(L, 3);
 
-	GUIFileSelectMenu* fileOpenMenu =
+	GUIFileSelectMenu *fileOpenMenu =
 		new GUIFileSelectMenu(RenderingEngine::get_gui_env(),
 								engine->m_parent,
 								-1,
@@ -1019,12 +1019,12 @@ int ModApiMainMenu::l_get_max_supp_proto(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_do_async_callback(lua_State *L)
 {
-	GUIEngine* engine = getGuiEngine(L);
+	GUIEngine *engine = getGuiEngine(L);
 
 	size_t func_length, param_length;
-	const char* serialized_func_raw = luaL_checklstring(L, 1, &func_length);
+	const char *serialized_func_raw = luaL_checklstring(L, 1, &func_length);
 
-	const char* serialized_param_raw = luaL_checklstring(L, 2, &param_length);
+	const char *serialized_param_raw = luaL_checklstring(L, 2, &param_length);
 
 	sanity_check(serialized_func_raw != NULL);
 	sanity_check(serialized_param_raw != NULL);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -42,7 +42,7 @@ private:
 	 * @param name name of variable to read
 	 * @return integer value of requested variable
 	 */
-	static int getIntegerData(lua_State *L, std::string name,bool& valid);
+	static int getIntegerData(lua_State *L, std::string name, bool &valid);
 
 	/**
 	 * read a bool variable from gamedata table within lua stack
@@ -50,7 +50,7 @@ private:
 	 * @param name name of variable to read
 	 * @return bool value of requested variable
 	 */
-	static int getBoolData(lua_State *L, std::string name,bool& valid);
+	static int getBoolData(lua_State *L, std::string name, bool &valid);
 
 	/**
 	 * Checks if a path may be modified. Paths in the temp directory or the user

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -39,7 +39,7 @@ void *luaL_checkudata_is_metadataref(lua_State *L, int ud) {
 	return NULL;
 }
 
-MetaDataRef* MetaDataRef::checkobject(lua_State *L, int narg)
+MetaDataRef *MetaDataRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata_is_metadataref(L, narg);

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -175,7 +175,7 @@ LuaMinimap *LuaMinimap::checkobject(lua_State *L, int narg)
 	return *(LuaMinimap **)ud;  // unbox pointer
 }
 
-Minimap* LuaMinimap::getobject(LuaMinimap *ref)
+Minimap *LuaMinimap::getobject(LuaMinimap *ref)
 {
 	return ref->m_minimap;
 }

--- a/src/script/lua_api/l_nodemeta.cpp
+++ b/src/script/lua_api/l_nodemeta.cpp
@@ -62,7 +62,7 @@ void NodeMetaRef::reportMetadataChange(const std::string *name)
 {
 	// NOTE: This same code is in rollback_interface.cpp
 	// Inform other things that the metadata has changed
-	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(m_meta);
+	NodeMetadata *meta = dynamic_cast<NodeMetadata *>(m_meta);
 
 	MapEditEvent event;
 	event.type = MEET_BLOCK_NODE_METADATA_CHANGED;
@@ -97,7 +97,7 @@ int NodeMetaRef::l_mark_as_private(lua_State *L)
 	MAP_LOCK_REQUIRED;
 
 	NodeMetaRef *ref = checkobject(L, 1);
-	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
+	NodeMetadata *meta = dynamic_cast<NodeMetadata *>(ref->getmeta(true));
 	assert(meta);
 
 	if (lua_istable(L, 2)) {
@@ -122,7 +122,7 @@ void NodeMetaRef::handleToTable(lua_State *L, Metadata *_meta)
 	// fields
 	MetaDataRef::handleToTable(L, _meta);
 
-	NodeMetadata *meta = (NodeMetadata*) _meta;
+	NodeMetadata *meta = (NodeMetadata *) _meta;
 
 	// inventory
 	lua_newtable(L);
@@ -145,7 +145,7 @@ bool NodeMetaRef::handleFromTable(lua_State *L, int table, Metadata *_meta)
 	if (!MetaDataRef::handleFromTable(L, table, _meta))
 		return false;
 
-	NodeMetadata *meta = (NodeMetadata*) _meta;
+	NodeMetadata *meta = (NodeMetadata *) _meta;
 
 	// inventory
 	Inventory *inv = meta->getInventory();

--- a/src/script/lua_api/l_nodemeta.h
+++ b/src/script/lua_api/l_nodemeta.h
@@ -57,7 +57,7 @@ private:
 	 * @param auto_create when true, try to create metadata information for the node if it has none.
 	 * @return pointer to a @c NodeMetadata object or @c NULL in case of error.
 	 */
-	virtual Metadata* getmeta(bool auto_create);
+	virtual Metadata *getmeta(bool auto_create);
 	virtual void clearMeta();
 
 	virtual void reportMetadataChange(const std::string *name = nullptr);

--- a/src/script/lua_api/l_nodetimer.cpp
+++ b/src/script/lua_api/l_nodetimer.cpp
@@ -29,7 +29,7 @@ int NodeTimerRef::gc_object(lua_State *L) {
 	return 0;
 }
 
-NodeTimerRef* NodeTimerRef::checkobject(lua_State *L, int narg)
+NodeTimerRef *NodeTimerRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -39,7 +39,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 
-ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
+ObjectRef *ObjectRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
@@ -47,30 +47,30 @@ ObjectRef* ObjectRef::checkobject(lua_State *L, int narg)
 	return *(ObjectRef**)ud;  // unbox pointer
 }
 
-ServerActiveObject* ObjectRef::getobject(ObjectRef *ref)
+ServerActiveObject *ObjectRef::getobject(ObjectRef *ref)
 {
 	ServerActiveObject *co = ref->m_object;
 	return co;
 }
 
-LuaEntitySAO* ObjectRef::getluaobject(ObjectRef *ref)
+LuaEntitySAO *ObjectRef::getluaobject(ObjectRef *ref)
 {
 	ServerActiveObject *obj = getobject(ref);
 	if (obj == NULL)
 		return NULL;
 	if (obj->getType() != ACTIVEOBJECT_TYPE_LUAENTITY)
 		return NULL;
-	return (LuaEntitySAO*)obj;
+	return (LuaEntitySAO *)obj;
 }
 
-PlayerSAO* ObjectRef::getplayersao(ObjectRef *ref)
+PlayerSAO *ObjectRef::getplayersao(ObjectRef *ref)
 {
 	ServerActiveObject *obj = getobject(ref);
 	if (obj == NULL)
 		return NULL;
 	if (obj->getType() != ACTIVEOBJECT_TYPE_PLAYER)
 		return NULL;
-	return (PlayerSAO*)obj;
+	return (PlayerSAO *)obj;
 }
 
 RemotePlayer *ObjectRef::getplayer(ObjectRef *ref)
@@ -353,7 +353,7 @@ int ObjectRef::l_set_wielded_item(lua_State *L)
 	ItemStack item = read_item(L, 2, getServer(L)->idef());
 	bool success = co->setWieldedItem(item);
 	if (success && co->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
-		getServer(L)->SendInventory(((PlayerSAO*)co));
+		getServer(L)->SendInventory(((PlayerSAO *)co));
 	}
 	lua_pushboolean(L, success);
 	return 1;
@@ -1080,7 +1080,7 @@ int ObjectRef::l_get_look_dir(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	float pitch = co->getRadLookPitchDep();
@@ -1101,7 +1101,7 @@ int ObjectRef::l_get_look_pitch(lua_State *L)
 		"Deprecated call to get_look_pitch, use get_look_vertical instead");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	lua_pushnumber(L, co->getRadLookPitchDep());
@@ -1118,7 +1118,7 @@ int ObjectRef::l_get_look_yaw(lua_State *L)
 		"Deprecated call to get_look_yaw, use get_look_horizontal instead");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	lua_pushnumber(L, co->getRadYawDep());
@@ -1130,7 +1130,7 @@ int ObjectRef::l_get_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	lua_pushnumber(L, co->getRadLookPitch());
@@ -1142,7 +1142,7 @@ int ObjectRef::l_get_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	lua_pushnumber(L, co->getRadRotation().Y);
@@ -1154,7 +1154,7 @@ int ObjectRef::l_set_look_vertical(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	float pitch = readParam<float>(L, 2) * core::RADTODEG;
 	// Do it
@@ -1167,7 +1167,7 @@ int ObjectRef::l_set_look_horizontal(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	float yaw = readParam<float>(L, 2) * core::RADTODEG;
 	// Do it
@@ -1185,7 +1185,7 @@ int ObjectRef::l_set_look_pitch(lua_State *L)
 		"Deprecated call to set_look_pitch, use set_look_vertical instead.");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	float pitch = readParam<float>(L, 2) * core::RADTODEG;
 	// Do it
@@ -1203,7 +1203,7 @@ int ObjectRef::l_set_look_yaw(lua_State *L)
 		"Deprecated call to set_look_yaw, use set_look_horizontal instead.");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	float yaw = readParam<float>(L, 2) * core::RADTODEG;
 	// Do it
@@ -1216,7 +1216,7 @@ int ObjectRef::l_set_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	u16 breath = luaL_checknumber(L, 2);
 	co->setBreath(breath);
@@ -1229,7 +1229,7 @@ int ObjectRef::l_get_breath(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL) return 0;
 	// Do it
 	u16 breath = co->getBreath();
@@ -1244,7 +1244,7 @@ int ObjectRef::l_set_attribute(lua_State *L)
 		"Deprecated call to set_attribute, use MetaDataRef methods instead.");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL)
 		return 0;
 
@@ -1265,7 +1265,7 @@ int ObjectRef::l_get_attribute(lua_State *L)
 		"Deprecated call to get_attribute, use MetaDataRef methods instead.");
 
 	ObjectRef *ref = checkobject(L, 1);
-	PlayerSAO* co = getplayersao(ref);
+	PlayerSAO *co = getplayersao(ref);
 	if (co == NULL)
 		return 0;
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -47,16 +47,16 @@ public:
 
 	static ObjectRef *checkobject(lua_State *L, int narg);
 
-	static ServerActiveObject* getobject(ObjectRef *ref);
+	static ServerActiveObject *getobject(ObjectRef *ref);
 private:
 	ServerActiveObject *m_object = nullptr;
 	static const char className[];
 	static luaL_Reg methods[];
 
 
-	static LuaEntitySAO* getluaobject(ObjectRef *ref);
+	static LuaEntitySAO *getluaobject(ObjectRef *ref);
 
-	static PlayerSAO* getplayersao(ObjectRef *ref);
+	static PlayerSAO *getplayersao(ObjectRef *ref);
 
 	static RemotePlayer *getplayer(ObjectRef *ref);
 

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -64,19 +64,19 @@ void LuaSettings::create(lua_State *L, Settings *settings,
 
 
 // garbage collector
-int LuaSettings::gc_object(lua_State* L)
+int LuaSettings::gc_object(lua_State *L)
 {
-	LuaSettings* o = *(LuaSettings **)(lua_touserdata(L, 1));
+	LuaSettings *o = *(LuaSettings **)(lua_touserdata(L, 1));
 	delete o;
 	return 0;
 }
 
 
 // get(self, key) -> value
-int LuaSettings::l_get(lua_State* L)
+int LuaSettings::l_get(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -90,10 +90,10 @@ int LuaSettings::l_get(lua_State* L)
 }
 
 // get_bool(self, key) -> boolean
-int LuaSettings::l_get_bool(lua_State* L)
+int LuaSettings::l_get_bool(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	if (o->m_settings->exists(key)) {
@@ -129,13 +129,13 @@ int LuaSettings::l_get_np_group(lua_State *L)
 }
 
 // set(self, key, value)
-int LuaSettings::l_set(lua_State* L)
+int LuaSettings::l_set(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
-	const char* value = luaL_checkstring(L, 3);
+	const char *value = luaL_checkstring(L, 3);
 
 	SET_SECURITY_CHECK(L, key);
 
@@ -146,10 +146,10 @@ int LuaSettings::l_set(lua_State* L)
 }
 
 // set_bool(self, key, value)
-int LuaSettings::l_set_bool(lua_State* L)
+int LuaSettings::l_set_bool(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 	bool value = readParam<bool>(L, 3);
@@ -179,10 +179,10 @@ int LuaSettings::l_set_np_group(lua_State *L)
 }
 
 // remove(self, key) -> success
-int LuaSettings::l_remove(lua_State* L)
+int LuaSettings::l_remove(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::string key = std::string(luaL_checkstring(L, 2));
 
@@ -195,10 +195,10 @@ int LuaSettings::l_remove(lua_State* L)
 }
 
 // get_names(self) -> {key1, ...}
-int LuaSettings::l_get_names(lua_State* L)
+int LuaSettings::l_get_names(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::vector<std::string> keys = o->m_settings->getNames();
 
@@ -213,10 +213,10 @@ int LuaSettings::l_get_names(lua_State* L)
 }
 
 // write(self) -> success
-int LuaSettings::l_write(lua_State* L)
+int LuaSettings::l_write(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	if (!o->m_write_allowed) {
 		throw LuaError("Settings: writing " + o->m_filename +
@@ -230,10 +230,10 @@ int LuaSettings::l_write(lua_State* L)
 }
 
 // to_table(self) -> {[key1]=value1,...}
-int LuaSettings::l_to_table(lua_State* L)
+int LuaSettings::l_to_table(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	LuaSettings* o = checkobject(L, 1);
+	LuaSettings *o = checkobject(L, 1);
 
 	std::vector<std::string> keys = o->m_settings->getNames();
 
@@ -247,7 +247,7 @@ int LuaSettings::l_to_table(lua_State* L)
 }
 
 
-void LuaSettings::Register(lua_State* L)
+void LuaSettings::Register(lua_State *L)
 {
 	lua_newtable(L);
 	int methodtable = lua_gettop(L);
@@ -277,20 +277,20 @@ void LuaSettings::Register(lua_State* L)
 
 // LuaSettings(filename)
 // Creates a LuaSettings and leaves it on top of the stack
-int LuaSettings::create_object(lua_State* L)
+int LuaSettings::create_object(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	bool write_allowed = true;
-	const char* filename = luaL_checkstring(L, 1);
+	const char *filename = luaL_checkstring(L, 1);
 	CHECK_SECURE_PATH_POSSIBLE_WRITE(L, filename, &write_allowed);
-	LuaSettings* o = new LuaSettings(filename, write_allowed);
+	LuaSettings *o = new LuaSettings(filename, write_allowed);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
 	return 1;
 }
 
-LuaSettings* LuaSettings::checkobject(lua_State* L, int narg)
+LuaSettings *LuaSettings::checkobject(lua_State *L, int narg)
 {
 	NO_MAP_LOCK_REQUIRED;
 	luaL_checktype(L, narg, LUA_TUSERDATA);

--- a/src/script/lua_api/l_storage.cpp
+++ b/src/script/lua_api/l_storage.cpp
@@ -114,7 +114,7 @@ void StorageRef::Register(lua_State *L)
 	lua_pop(L, 1);  // drop methodtable
 }
 
-StorageRef* StorageRef::checkobject(lua_State *L, int narg)
+StorageRef *StorageRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
@@ -122,13 +122,13 @@ StorageRef* StorageRef::checkobject(lua_State *L, int narg)
 	return *(StorageRef**)ud;  // unbox pointer
 }
 
-ModMetadata* StorageRef::getobject(StorageRef *ref)
+ModMetadata *StorageRef::getobject(StorageRef *ref)
 {
 	ModMetadata *co = ref->m_object;
 	return co;
 }
 
-Metadata* StorageRef::getmeta(bool auto_create)
+Metadata *StorageRef::getmeta(bool auto_create)
 {
 	return m_object;
 }

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -459,7 +459,7 @@ int ModApiUtil::l_sha1(lua_State *L)
 		SHA1 ctx;
 		ctx.addBytes(data, size);
 		unsigned char *data_tmpdigest = ctx.getDigest();
-		data_sha1.assign((char*) data_tmpdigest, 20);
+		data_sha1.assign((char *) data_tmpdigest, 20);
 		free(data_tmpdigest);
 	}
 
@@ -562,4 +562,3 @@ void ModApiUtil::InitializeAsync(lua_State *L, int top)
 	LuaSettings::create(L, g_settings, g_settings_path);
 	lua_setfield(L, top, "settings");
 }
-

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -34,7 +34,7 @@ extern "C" {
 #define MAINMENU_NUM_ASYNC_THREADS 4
 
 
-MainMenuScripting::MainMenuScripting(GUIEngine* guiengine):
+MainMenuScripting::MainMenuScripting(GUIEngine *guiengine):
 		ScriptApiBase(ScriptingType::MainMenu)
 {
 	setGuiEngine(guiengine);
@@ -95,4 +95,3 @@ unsigned int MainMenuScripting::queueAsync(const std::string &serialized_func,
 {
 	return asyncEngine.queueAsyncJob(serialized_func, serialized_param);
 }
-

--- a/src/script/scripting_mainmenu.h
+++ b/src/script/scripting_mainmenu.h
@@ -32,7 +32,7 @@ class MainMenuScripting
 		  public ScriptApiMainMenu
 {
 public:
-	MainMenuScripting(GUIEngine* guiengine);
+	MainMenuScripting(GUIEngine *guiengine);
 
 	// Global step handler to pass back async events
 	void step();

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -50,7 +50,7 @@ extern "C" {
 #include "lualib.h"
 }
 
-ServerScripting::ServerScripting(Server* server):
+ServerScripting::ServerScripting(Server *server):
 		ScriptApiBase(ScriptingType::Server)
 {
 	setGameDef(server);

--- a/src/script/scripting_server.h
+++ b/src/script/scripting_server.h
@@ -44,7 +44,7 @@ class ServerScripting:
 		public ScriptApiSecurity
 {
 public:
-	ServerScripting(Server* server);
+	ServerScripting(Server *server);
 
 	// use ScriptApiBase::loadMod() to load mods
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -70,12 +70,12 @@ void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level)
 		throw SerializationError("compressZlib: deflateInit failed");
 
 	// Point zlib to our input buffer
-	z.next_in = (Bytef*)&data[0];
+	z.next_in = (Bytef *)&data[0];
 	z.avail_in = data_size;
 	// And get all output
 	for(;;)
 	{
-		z.next_out = (Bytef*)output_buffer;
+		z.next_out = (Bytef *)output_buffer;
 		z.avail_out = bufsize;
 
 		status = deflate(&z, Z_FINISH);
@@ -98,7 +98,7 @@ void compressZlib(const u8 *data, size_t data_size, std::ostream &os, int level)
 
 void compressZlib(const std::string &data, std::ostream &os, int level)
 {
-	compressZlib((u8*)data.c_str(), data.size(), os, level);
+	compressZlib((u8 *)data.c_str(), data.size(), os, level);
 }
 
 void decompressZlib(std::istream &is, std::ostream &os)
@@ -126,12 +126,12 @@ void decompressZlib(std::istream &is, std::ostream &os)
 
 	for(;;)
 	{
-		z.next_out = (Bytef*)output_buffer;
+		z.next_out = (Bytef *)output_buffer;
 		z.avail_out = bufsize;
 
 		if(z.avail_in == 0)
 		{
-			z.next_in = (Bytef*)input_buffer;
+			z.next_in = (Bytef *)input_buffer;
 			is.read(input_buffer, bufsize);
 			input_buffer_len = is.gcount();
 			z.avail_in = input_buffer_len;
@@ -200,7 +200,7 @@ void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version)
 
 	u8 tmp[4];
 	writeU32(tmp, data.getSize());
-	os.write((char*)tmp, 4);
+	os.write((char *)tmp, 4);
 
 	// We will be writing 8-bit pairs of more_count and byte
 	u8 more_count = 0;
@@ -213,8 +213,8 @@ void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version)
 		)
 		{
 			// write count and byte
-			os.write((char*)&more_count, 1);
-			os.write((char*)&current_byte, 1);
+			os.write((char *)&more_count, 1);
+			os.write((char *)&current_byte, 1);
 			more_count = 0;
 			current_byte = data[i];
 		}
@@ -224,8 +224,8 @@ void compress(const SharedBuffer<u8> &data, std::ostream &os, u8 version)
 		}
 	}
 	// write count and byte
-	os.write((char*)&more_count, 1);
-	os.write((char*)&current_byte, 1);
+	os.write((char *)&more_count, 1);
+	os.write((char *)&current_byte, 1);
 }
 
 void decompress(std::istream &is, std::ostream &os, u8 version)
@@ -239,7 +239,7 @@ void decompress(std::istream &is, std::ostream &os, u8 version)
 	// Read length (u32)
 
 	u8 tmp[4];
-	is.read((char*)tmp, 4);
+	is.read((char *)tmp, 4);
 	u32 len = readU32(tmp);
 
 	// We will be reading 8-bit pairs of more_count and byte
@@ -249,15 +249,15 @@ void decompress(std::istream &is, std::ostream &os, u8 version)
 		u8 more_count=0;
 		u8 byte=0;
 
-		is.read((char*)&more_count, 1);
+		is.read((char *)&more_count, 1);
 
-		is.read((char*)&byte, 1);
+		is.read((char *)&byte, 1);
 
 		if(is.eof())
 			throw SerializationError("decompress: stream ended halfway");
 
 		for(s32 i=0; i<(u16)more_count+1; i++)
-			os.write((char*)&byte, 1);
+			os.write((char *)&byte, 1);
 
 		count += (u16)more_count+1;
 
@@ -265,5 +265,3 @@ void decompress(std::istream &is, std::ostream &os, u8 version)
 			break;
 	}
 }
-
-

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -581,7 +581,7 @@ void Server::AsyncRunStep(bool initial_step)
 
 		ScopeProfiler sp(g_profiler, "Server: liquid transform");
 
-		std::map<v3s16, MapBlock*> modified_blocks;
+		std::map<v3s16, MapBlock *> modified_blocks;
 		m_env->getMap().transformLiquids(modified_blocks, m_env);
 
 		/*
@@ -681,15 +681,15 @@ void Server::AsyncRunStep(bool initial_step)
 			char buf[4];
 
 			// Handle removed objects
-			writeU16((u8*)buf, removed_objects.size());
+			writeU16((u8 *)buf, removed_objects.size());
 			data_buffer.append(buf, 2);
 			while (!removed_objects.empty()) {
 				// Get object
 				u16 id = removed_objects.front();
-				ServerActiveObject* obj = m_env->getActiveObject(id);
+				ServerActiveObject *obj = m_env->getActiveObject(id);
 
 				// Add to data buffer for sending
-				writeU16((u8*)buf, id);
+				writeU16((u8 *)buf, id);
 				data_buffer.append(buf, 2);
 
 				// Remove from known objects
@@ -701,12 +701,12 @@ void Server::AsyncRunStep(bool initial_step)
 			}
 
 			// Handle added objects
-			writeU16((u8*)buf, added_objects.size());
+			writeU16((u8 *)buf, added_objects.size());
 			data_buffer.append(buf, 2);
 			while (!added_objects.empty()) {
 				// Get object
 				u16 id = added_objects.front();
-				ServerActiveObject* obj = m_env->getActiveObject(id);
+				ServerActiveObject *obj = m_env->getActiveObject(id);
 
 				// Get object type
 				u8 type = ACTIVEOBJECT_TYPE_INVALID;
@@ -716,9 +716,9 @@ void Server::AsyncRunStep(bool initial_step)
 					type = obj->getSendType();
 
 				// Add to data buffer for sending
-				writeU16((u8*)buf, id);
+				writeU16((u8 *)buf, id);
 				data_buffer.append(buf, 2);
-				writeU8((u8*)buf, type);
+				writeU8((u8 *)buf, type);
 				data_buffer.append(buf, 1);
 
 				if(obj)
@@ -809,7 +809,7 @@ void Server::AsyncRunStep(bool initial_step)
 					std::string new_data;
 					// Add object id
 					char buf[2];
-					writeU16((u8*)&buf[0], aom.id);
+					writeU16((u8 *)&buf[0], aom.id);
 					new_data.append(buf, 2);
 					// Add data
 					new_data += serializeString(aom.datastring);
@@ -863,7 +863,7 @@ void Server::AsyncRunStep(bool initial_step)
 		std::list<v3s16> node_meta_updates;
 
 		while (!m_unsent_map_edit_queue.empty()) {
-			MapEditEvent* event = m_unsent_map_edit_queue.front();
+			MapEditEvent *event = m_unsent_map_edit_queue.front();
 			m_unsent_map_edit_queue.pop();
 
 			// Players far away from the change are stored here.
@@ -919,7 +919,7 @@ void Server::AsyncRunStep(bool initial_step)
 			*/
 			if (!far_players.empty()) {
 				// Convert list format to that wanted by SetBlocksNotSent
-				std::map<v3s16, MapBlock*> modified_blocks2;
+				std::map<v3s16, MapBlock *> modified_blocks2;
 				for (const v3s16 &modified_block : event->modified_blocks) {
 					modified_blocks2[modified_block] =
 							m_env->getMap().getBlockNoCreateNoEx(modified_block);
@@ -1016,13 +1016,13 @@ void Server::Receive()
 	}
 }
 
-PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
+PlayerSAO *Server::StageTwoClientInit(session_t peer_id)
 {
 	std::string playername;
 	PlayerSAO *playersao = NULL;
 	m_clients.lock();
 	try {
-		RemoteClient* client = m_clients.lockedGetClientNoEx(peer_id, CS_InitDone);
+		RemoteClient *client = m_clients.lockedGetClientNoEx(peer_id, CS_InitDone);
 		if (client) {
 			playername = client->getName();
 			playersao = emergePlayer(playername.c_str(), peer_id, client->net_proto_version);
@@ -1095,9 +1095,9 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	return playersao;
 }
 
-inline void Server::handleCommand(NetworkPacket* pkt)
+inline void Server::handleCommand(NetworkPacket *pkt)
 {
-	const ToServerCommandHandler& opHandle = toServerCommandTable[pkt->getCommand()];
+	const ToServerCommandHandler &opHandle = toServerCommandTable[pkt->getCommand()];
 	(this->*opHandle.handler)(pkt);
 }
 
@@ -1201,7 +1201,7 @@ void Server::onMapEditEvent(MapEditEvent *event)
 	m_unsent_map_edit_queue.push(e);
 }
 
-Inventory* Server::getInventory(const InventoryLocation &loc)
+Inventory *Server::getInventory(const InventoryLocation &loc)
 {
 	switch (loc.type) {
 	case InventoryLocation::UNDEFINED:
@@ -1310,7 +1310,7 @@ void Server::deletingPeer(con::Peer *peer, bool timeout)
 	m_peer_change_queue.push(con::PeerChange(con::PEER_REMOVED, peer->id, timeout));
 }
 
-bool Server::getClientConInfo(session_t peer_id, con::rtt_stat_type type, float* retval)
+bool Server::getClientConInfo(session_t peer_id, con::rtt_stat_type type, float *retval)
 {
 	*retval = m_con->getPeerStat(peer_id,type);
 	return *retval != -1;
@@ -1318,19 +1318,19 @@ bool Server::getClientConInfo(session_t peer_id, con::rtt_stat_type type, float*
 
 bool Server::getClientInfo(
 		session_t    peer_id,
-		ClientState* state,
+		ClientState *state,
 		u32*         uptime,
 		u8*          ser_vers,
 		u16*         prot_vers,
 		u8*          major,
 		u8*          minor,
 		u8*          patch,
-		std::string* vers_string
+		std::string *vers_string
 	)
 {
 	*state = m_clients.getClientState(peer_id);
 	m_clients.lock();
-	RemoteClient* client = m_clients.lockedGetClientNoEx(peer_id, CS_Invalid);
+	RemoteClient *client = m_clients.lockedGetClientNoEx(peer_id, CS_Invalid);
 
 	if (!client) {
 		m_clients.unlock();
@@ -1533,7 +1533,7 @@ void Server::SendNodeDef(session_t peer_id,
 	Non-static send methods
 */
 
-void Server::SendInventory(PlayerSAO* playerSAO)
+void Server::SendInventory(PlayerSAO *playerSAO)
 {
 	UpdateCrafting(playerSAO->getPlayer());
 
@@ -2391,7 +2391,7 @@ void Server::fillMediaCache()
 
 			unsigned char *digest = sha1.getDigest();
 			std::string sha1_base64 = base64_encode(digest, 20);
-			std::string sha1_hex = hex_encode((char*)digest, 20);
+			std::string sha1_hex = hex_encode((char *)digest, 20);
 			free(digest);
 
 			// Put in list
@@ -2687,7 +2687,7 @@ void Server::DisconnectPeer(session_t peer_id)
 void Server::acceptAuth(session_t peer_id, bool forSudoMode)
 {
 	if (!forSudoMode) {
-		RemoteClient* client = getClient(peer_id, CS_Invalid);
+		RemoteClient *client = getClient(peer_id, CS_Invalid);
 
 		NetworkPacket resp_pkt(TOCLIENT_AUTH_ACCEPT, 1 + 6 + 8 + 4, peer_id);
 
@@ -3005,7 +3005,7 @@ std::wstring Server::getStatusString()
 	}
 	os << L"}";
 
-	if (m_env && !((ServerMap*)(&m_env->getMap()))->isSavingEnabled())
+	if (m_env && !((ServerMap *)(&m_env->getMap()))->isSavingEnabled())
 		os << std::endl << L"# Server: " << " WARNING: Map saving is disabled.";
 
 	if (!g_settings->get("motd").empty())
@@ -3132,7 +3132,7 @@ bool Server::hudRemove(RemotePlayer *player, u32 id) {
 	if (!player)
 		return false;
 
-	HudElement* todel = player->removeHud(id);
+	HudElement *todel = player->removeHud(id);
 
 	if (!todel)
 		return false;
@@ -3161,7 +3161,7 @@ bool Server::hudSetFlags(RemotePlayer *player, u32 flags, u32 mask)
 	player->hud_flags &= ~mask;
 	player->hud_flags |= flags;
 
-	PlayerSAO* playersao = player->getPlayerSAO();
+	PlayerSAO *playersao = player->getPlayerSAO();
 
 	if (!playersao)
 		return false;
@@ -3339,7 +3339,7 @@ void Server::deleteParticleSpawner(const std::string &playername, u32 id)
 	SendDeleteParticleSpawner(peer_id, id);
 }
 
-Inventory* Server::createDetachedInventory(const std::string &name, const std::string &player)
+Inventory *Server::createDetachedInventory(const std::string &name, const std::string &player)
 {
 	if(m_detached_inventories.count(name) > 0){
 		infostream<<"Server clearing detached inventory \""<<name<<"\""<<std::endl;
@@ -3386,7 +3386,7 @@ bool Server::rollbackRevertActions(const std::list<RollbackAction> &actions,
 		std::list<std::string> *log)
 {
 	infostream<<"Server::rollbackRevertActions(len="<<actions.size()<<")"<<std::endl;
-	ServerMap *map = (ServerMap*)(&m_env->getMap());
+	ServerMap *map = (ServerMap *)(&m_env->getMap());
 
 	// Fail if no actions to handle
 	if (actions.empty()) {
@@ -3572,7 +3572,7 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 	m_shutdown_state.trigger(delay, msg, reconnect);
 }
 
-PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version)
+PlayerSAO *Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version)
 {
 	/*
 		Try to get an existing player
@@ -3706,7 +3706,7 @@ bool Server::sendModChannelMessage(const std::string &channel, const std::string
 	return true;
 }
 
-ModChannel* Server::getModChannel(const std::string &channel)
+ModChannel *Server::getModChannel(const std::string &channel)
 {
 	return m_modchannel_mgr->getModChannel(channel);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -137,39 +137,39 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
-	PlayerSAO* StageTwoClientInit(session_t peer_id);
+	PlayerSAO *StageTwoClientInit(session_t peer_id);
 
 	/*
 	 * Command Handlers
 	 */
 
-	void handleCommand(NetworkPacket* pkt);
+	void handleCommand(NetworkPacket *pkt);
 
-	void handleCommand_Null(NetworkPacket* pkt) {};
-	void handleCommand_Deprecated(NetworkPacket* pkt);
-	void handleCommand_Init(NetworkPacket* pkt);
-	void handleCommand_Init2(NetworkPacket* pkt);
+	void handleCommand_Null(NetworkPacket *pkt) {};
+	void handleCommand_Deprecated(NetworkPacket *pkt);
+	void handleCommand_Init(NetworkPacket *pkt);
+	void handleCommand_Init2(NetworkPacket *pkt);
 	void handleCommand_ModChannelJoin(NetworkPacket *pkt);
 	void handleCommand_ModChannelLeave(NetworkPacket *pkt);
 	void handleCommand_ModChannelMsg(NetworkPacket *pkt);
-	void handleCommand_RequestMedia(NetworkPacket* pkt);
-	void handleCommand_ClientReady(NetworkPacket* pkt);
-	void handleCommand_GotBlocks(NetworkPacket* pkt);
-	void handleCommand_PlayerPos(NetworkPacket* pkt);
-	void handleCommand_DeletedBlocks(NetworkPacket* pkt);
-	void handleCommand_InventoryAction(NetworkPacket* pkt);
-	void handleCommand_ChatMessage(NetworkPacket* pkt);
-	void handleCommand_Damage(NetworkPacket* pkt);
-	void handleCommand_Password(NetworkPacket* pkt);
-	void handleCommand_PlayerItem(NetworkPacket* pkt);
-	void handleCommand_Respawn(NetworkPacket* pkt);
-	void handleCommand_Interact(NetworkPacket* pkt);
-	void handleCommand_RemovedSounds(NetworkPacket* pkt);
-	void handleCommand_NodeMetaFields(NetworkPacket* pkt);
-	void handleCommand_InventoryFields(NetworkPacket* pkt);
-	void handleCommand_FirstSrp(NetworkPacket* pkt);
-	void handleCommand_SrpBytesA(NetworkPacket* pkt);
-	void handleCommand_SrpBytesM(NetworkPacket* pkt);
+	void handleCommand_RequestMedia(NetworkPacket *pkt);
+	void handleCommand_ClientReady(NetworkPacket *pkt);
+	void handleCommand_GotBlocks(NetworkPacket *pkt);
+	void handleCommand_PlayerPos(NetworkPacket *pkt);
+	void handleCommand_DeletedBlocks(NetworkPacket *pkt);
+	void handleCommand_InventoryAction(NetworkPacket *pkt);
+	void handleCommand_ChatMessage(NetworkPacket *pkt);
+	void handleCommand_Damage(NetworkPacket *pkt);
+	void handleCommand_Password(NetworkPacket *pkt);
+	void handleCommand_PlayerItem(NetworkPacket *pkt);
+	void handleCommand_Respawn(NetworkPacket *pkt);
+	void handleCommand_Interact(NetworkPacket *pkt);
+	void handleCommand_RemovedSounds(NetworkPacket *pkt);
+	void handleCommand_NodeMetaFields(NetworkPacket *pkt);
+	void handleCommand_InventoryFields(NetworkPacket *pkt);
+	void handleCommand_FirstSrp(NetworkPacket *pkt);
+	void handleCommand_SrpBytesA(NetworkPacket *pkt);
+	void handleCommand_SrpBytesM(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 
@@ -194,7 +194,7 @@ public:
 	/*
 		Shall be called with the environment and the connection locked.
 	*/
-	Inventory* getInventory(const InventoryLocation &loc);
+	Inventory *getInventory(const InventoryLocation &loc);
 	void setInventoryModified(const InventoryLocation &loc, bool playerSend = true);
 
 	// Connection must be locked when called
@@ -262,19 +262,19 @@ public:
 
 	// IGameDef interface
 	// Under envlock
-	virtual IItemDefManager* getItemDefManager();
-	virtual const NodeDefManager* getNodeDefManager();
-	virtual ICraftDefManager* getCraftDefManager();
+	virtual IItemDefManager *getItemDefManager();
+	virtual const NodeDefManager *getNodeDefManager();
+	virtual ICraftDefManager *getCraftDefManager();
 	virtual u16 allocateUnknownNodeId(const std::string &name);
 	IRollbackManager *getRollbackManager() { return m_rollback; }
 	virtual EmergeManager *getEmergeManager() { return m_emerge; }
 
-	IWritableItemDefManager* getWritableItemDefManager();
-	NodeDefManager* getWritableNodeDefManager();
-	IWritableCraftDefManager* getWritableCraftDefManager();
+	IWritableItemDefManager *getWritableItemDefManager();
+	NodeDefManager *getWritableNodeDefManager();
+	IWritableCraftDefManager *getWritableCraftDefManager();
 
 	virtual const std::vector<ModSpec> &getMods() const;
-	virtual const ModSpec* getModSpec(const std::string &modname) const;
+	virtual const ModSpec *getModSpec(const std::string &modname) const;
 	void getModNames(std::vector<std::string> &modlist);
 	std::string getBuiltinLuaPath();
 	virtual std::string getWorldPath() const { return m_path_world; }
@@ -326,14 +326,14 @@ public:
 	void DisconnectPeer(session_t peer_id);
 	bool getClientConInfo(session_t peer_id, con::rtt_stat_type type, float *retval);
 	bool getClientInfo(session_t peer_id, ClientState *state, u32 *uptime,
-			u8* ser_vers, u16* prot_vers, u8* major, u8* minor, u8* patch,
-			std::string* vers_string);
+			u8 *ser_vers, u16 *prot_vers, u8 *major, u8 *minor, u8 *patch,
+			std::string *vers_string);
 
 	void printToConsoleOnly(const std::string &text);
 
 	void SendPlayerHPOrDie(PlayerSAO *player, const PlayerHPChangeReason &reason);
 	void SendPlayerBreath(PlayerSAO *sao);
-	void SendInventory(PlayerSAO* playerSAO);
+	void SendInventory(PlayerSAO *playerSAO);
 	void SendMovePlayer(session_t peer_id);
 
 	virtual bool registerModStorage(ModMetadata *storage);
@@ -489,8 +489,8 @@ private:
 	void handleAdminChat(const ChatEventChat *evt);
 
 	// When called, connection mutex should be locked
-	RemoteClient* getClient(session_t peer_id, ClientState state_min = CS_Active);
-	RemoteClient* getClientNoEx(session_t peer_id, ClientState state_min = CS_Active);
+	RemoteClient *getClient(session_t peer_id, ClientState state_min = CS_Active);
+	RemoteClient *getClientNoEx(session_t peer_id, ClientState state_min = CS_Active);
 
 	// When called, environment mutex should be locked
 	std::string getPlayerName(session_t peer_id);
@@ -626,7 +626,7 @@ private:
 		Queue of map edits from the environment for sending to the clients
 		This is behind m_env_mutex
 	*/
-	std::queue<MapEditEvent*> m_unsent_map_edit_queue;
+	std::queue<MapEditEvent *> m_unsent_map_edit_queue;
 	/*
 		If a non-empty area, map edit events contained within are left
 		unsent. Done at map generation time to speed up editing of the
@@ -648,7 +648,7 @@ private:
 		Detached inventories (behind m_env_mutex)
 	*/
 	// key = name
-	std::map<std::string, Inventory*> m_detached_inventories;
+	std::map<std::string, Inventory *> m_detached_inventories;
 	// value = "" (visible to all players) or player name
 	std::map<std::string, std::string> m_detached_inventories_player;
 

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -320,7 +320,7 @@ void fillViewConeBlock(v3s16 p0,
 	}
 }
 
-void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
+void ActiveBlockList::update(std::vector<PlayerSAO *> &active_players,
 	s16 active_block_range,
 	s16 active_object_range,
 	std::set<v3s16> &blocks_removed,
@@ -499,7 +499,7 @@ RemotePlayer *ServerEnvironment::getPlayer(const session_t peer_id)
 	return NULL;
 }
 
-RemotePlayer *ServerEnvironment::getPlayer(const char* name)
+RemotePlayer *ServerEnvironment::getPlayer(const char *name)
 {
 	for (RemotePlayer *player : m_players) {
 		if (strcmp(player->getName(), name) == 0)
@@ -1239,7 +1239,7 @@ void ServerEnvironment::step(float dtime)
 		/*
 			Get player block positions
 		*/
-		std::vector<PlayerSAO*> players;
+		std::vector<PlayerSAO *> players;
 		for (RemotePlayer *player: m_players) {
 			// Ignore disconnected players
 			if (player->getPeerId() == PEER_ID_INEXISTENT)
@@ -1603,7 +1603,7 @@ void ServerEnvironment::getSelectedActiveObjects(
 	const v3f line_vector = shootline_on_map.getVector();
 
 	for (u16 objectId : objectIds) {
-		ServerActiveObject* obj = getActiveObject(objectId);
+		ServerActiveObject *obj = getActiveObject(objectId);
 
 		aabb3f selection_box;
 		if (!obj->getSelectionBox(&selection_box))

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -156,7 +156,7 @@ private:
 class ActiveBlockList
 {
 public:
-	void update(std::vector<PlayerSAO*> &active_players,
+	void update(std::vector<PlayerSAO *> &active_players,
 		s16 active_block_range,
 		s16 active_object_range,
 		std::set<v3s16> &blocks_removed,
@@ -209,7 +209,7 @@ public:
 	ServerMap & getServerMap();
 
 	//TODO find way to remove this fct!
-	ServerScripting* getScriptIface()
+	ServerScripting *getScriptIface()
 	{ return m_script; }
 
 	Server *getGameDef()
@@ -244,7 +244,7 @@ public:
 		-------------------------------------------
 	*/
 
-	ServerActiveObject* getActiveObject(u16 id)
+	ServerActiveObject *getActiveObject(u16 id)
 	{
 		return m_ao_manager.getActiveObject(id);
 	}
@@ -356,7 +356,7 @@ public:
 		bool static_exists, v3s16 static_block=v3s16(0,0,0));
 
 	RemotePlayer *getPlayer(const session_t peer_id);
-	RemotePlayer *getPlayer(const char* name);
+	RemotePlayer *getPlayer(const char *name);
 	u32 getPlayerCount() const { return m_players.size(); }
 
 	static bool migratePlayersDatabase(const GameParams &game_params,
@@ -429,7 +429,7 @@ private:
 	// The map
 	ServerMap *m_map;
 	// Lua state
-	ServerScripting* m_script;
+	ServerScripting *m_script;
 	// Server definition
 	Server *m_server;
 	// Active Object Manager
@@ -465,7 +465,7 @@ private:
 	float m_max_lag_estimate = 0.1f;
 
 	// peer_ids in here should be unique, except that there may be many 0s
-	std::vector<RemotePlayer*> m_players;
+	std::vector<RemotePlayer *> m_players;
 
 	PlayerDatabase *m_player_database = nullptr;
 	AuthDatabase *m_auth_database = nullptr;

--- a/src/serverobject.cpp
+++ b/src/serverobject.cpp
@@ -30,7 +30,7 @@ ServerActiveObject::ServerActiveObject(ServerEnvironment *env, v3f pos):
 {
 }
 
-ServerActiveObject* ServerActiveObject::create(ActiveObjectType type,
+ServerActiveObject *ServerActiveObject::create(ActiveObjectType type,
 		ServerEnvironment *env, u16 id, v3f pos,
 		const std::string &data)
 {

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -71,7 +71,7 @@ public:
 	{ return true; }
 
 	// Create a certain type of ServerActiveObject
-	static ServerActiveObject* create(ActiveObjectType type,
+	static ServerActiveObject *create(ActiveObjectType type,
 			ServerEnvironment *env, u16 id, v3f pos,
 			const std::string &data);
 
@@ -80,7 +80,7 @@ public:
 	*/
 	v3f getBasePosition() const { return m_base_position; }
 	void setBasePosition(v3f pos){ m_base_position = pos; }
-	ServerEnvironment* getEnv(){ return m_env; }
+	ServerEnvironment *getEnv(){ return m_env; }
 
 	/*
 		Some more dynamic interface
@@ -174,15 +174,15 @@ public:
 	virtual const std::unordered_set<int> &getAttachmentChildIds()
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual ServerActiveObject *getParent() const { return nullptr; }
-	virtual ObjectProperties* accessObjectProperties()
+	virtual ObjectProperties *accessObjectProperties()
 	{ return NULL; }
 	virtual void notifyObjectPropertiesModified()
 	{}
 
 	// Inventory and wielded item
-	virtual Inventory* getInventory()
+	virtual Inventory *getInventory()
 	{ return NULL; }
-	virtual const Inventory* getInventory() const
+	virtual const Inventory *getInventory() const
 	{ return NULL; }
 	virtual InventoryLocation getInventoryLocation() const
 	{ return InventoryLocation(); }

--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -408,7 +408,7 @@ void TerminalChatConsole::step(int ch)
 	// draw prompt
 	if (!m_esc_mode) {
 		// normal prompt
-		ChatPrompt& prompt = m_chat_backend.getPrompt();
+		ChatPrompt &prompt = m_chat_backend.getPrompt();
 		std::string prompt_text = wide_to_utf8(prompt.getVisiblePortion());
 		move(m_rows - 1, 0);
 		clrtoeol();
@@ -433,11 +433,11 @@ void TerminalChatConsole::step(int ch)
 
 void TerminalChatConsole::draw_text()
 {
-	ChatBuffer& buf = m_chat_backend.getConsoleBuffer();
+	ChatBuffer &buf = m_chat_backend.getConsoleBuffer();
 	for (u32 row = 0; row < buf.getRows(); row++) {
 		move_for_backend(row, 0);
 		clrtoeol();
-		const ChatFormattedLine& line = buf.getFormattedLine(row);
+		const ChatFormattedLine &line = buf.getFormattedLine(row);
 		if (line.fragments.empty())
 			continue;
 		for (const ChatFormattedFragment &fragment : line.fragments) {

--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -67,7 +67,7 @@ public:
 		static std::vector<ModSpec> testmodspec;
 		return testmodspec;
 	}
-	virtual const ModSpec* getModSpec(const std::string &modname) const { return NULL; }
+	virtual const ModSpec *getModSpec(const std::string &modname) const { return NULL; }
 	virtual std::string getModStoragePath() const { return "."; }
 	virtual bool registerModStorage(ModMetadata *meta) { return true; }
 	virtual void unregisterModStorage(const std::string &name) {}

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -243,7 +243,7 @@ void TestConnection::testConnectSendReceive()
 	*/
 	{
 		NetworkPacket pkt;
-		pkt.putRawPacket((u8*) "Hello World !", 14, 0);
+		pkt.putRawPacket((u8 *) "Hello World !", 14, 0);
 
 		SharedBuffer<u8> sentdata = pkt.oldForgePacket();
 
@@ -257,7 +257,7 @@ void TestConnection::testConnectSendReceive()
 		server.Receive(&recvpacket);
 		infostream << "** Server received: peer_id=" << pkt.getPeerId()
 				<< ", size=" << pkt.getSize()
-				<< ", data=" << (const char*)pkt.getU8Ptr(0)
+				<< ", data=" << (const char *)pkt.getU8Ptr(0)
 				<< std::endl;
 
 		SharedBuffer<u8> recvdata = pkt.oldForgePacket();

--- a/src/util/base64.cpp
+++ b/src/util/base64.cpp
@@ -38,7 +38,7 @@ static inline bool is_base64(unsigned char c) {
 	return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-bool base64_is_valid(std::string const& s)
+bool base64_is_valid(std::string const &s)
 {
 	for (char i : s)
 		if (!is_base64(i))
@@ -46,7 +46,7 @@ bool base64_is_valid(std::string const& s)
 	return true;
 }
 
-std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
+std::string base64_encode(unsigned char const *bytes_to_encode, unsigned int in_len) {
 	std::string ret;
 	int i = 0;
 	int j = 0;
@@ -90,7 +90,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 
 }
 
-std::string base64_decode(std::string const& encoded_string) {
+std::string base64_decode(std::string const &encoded_string) {
 	int in_len = encoded_string.size();
 	int i = 0;
 	int j = 0;

--- a/src/util/base64.h
+++ b/src/util/base64.h
@@ -21,6 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <string>
 
-bool base64_is_valid(std::string const& s);
-std::string base64_encode(unsigned char const* , unsigned int len);
-std::string base64_decode(std::string const& s);
+bool base64_is_valid(std::string const &s);
+std::string base64_encode(unsigned char const *, unsigned int len);
+std::string base64_decode(std::string const &s);

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -44,7 +44,7 @@ public:
 	true: value added
 	false: value already exists
 	*/
-	bool push_back(const Value& value)
+	bool push_back(const Value &value)
 	{
 		if (m_set.insert(value).second)
 		{
@@ -60,7 +60,7 @@ public:
 		m_queue.pop();
 	}
 
-	const Value& front() const
+	const Value &front() const
 	{
 		return m_queue.front();
 	}

--- a/src/util/pointer.h
+++ b/src/util/pointer.h
@@ -66,7 +66,7 @@ public:
 	{
 		drop();
 	}
-	Buffer& operator=(const Buffer &buffer)
+	Buffer &operator=(const Buffer &buffer)
 	{
 		if(this == &buffer)
 			return *this;

--- a/src/util/serialize.cpp
+++ b/src/util/serialize.cpp
@@ -201,7 +201,7 @@ std::string serializeLongString(const std::string &plain)
 	if (plain.size() > LONG_STRING_MAX_LEN)
 		throw SerializationError("String too long for serializeLongString");
 
-	writeU32((u8*)&buf[0], plain.size());
+	writeU32((u8 *)&buf[0], plain.size());
 	std::string s;
 	s.append(buf, 4);
 	s.append(plain);

--- a/src/util/sha1.cpp
+++ b/src/util/sha1.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 #include "sha1.h"
 
 // print out memory in hexadecimal
-void SHA1::hexPrinter( unsigned char* c, int l )
+void SHA1::hexPrinter( unsigned char *c, int l )
 {
 	assert( c );
 	assert( l > 0 );
@@ -51,7 +51,7 @@ Uint32 SHA1::lrot( Uint32 x, int bits )
 };
 
 // Save a 32-bit unsigned integer to memory, in big-endian order
-void SHA1::storeBigEndianUint32( unsigned char* byte, Uint32 num )
+void SHA1::storeBigEndianUint32( unsigned char *byte, Uint32 num )
 {
 	assert( byte );
 	byte[0] = (unsigned char)(num>>24);
@@ -134,7 +134,7 @@ void SHA1::process()
 }
 
 // addBytes **********************************************************
-void SHA1::addBytes( const char* data, int num )
+void SHA1::addBytes( const char *data, int num )
 {
 	assert( data );
 	assert( num >= 0 );
@@ -161,7 +161,7 @@ void SHA1::addBytes( const char* data, int num )
 }
 
 // digest ************************************************************
-unsigned char* SHA1::getDigest()
+unsigned char *SHA1::getDigest()
 {
 	// save the message size
 	Uint32 totalBitsL = size << 3;
@@ -176,7 +176,7 @@ unsigned char* SHA1::getDigest()
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 	// block has no room for 8-byte filesize, so finish it
 	if( unprocessedBytes > 56 )
-		addBytes( (char*)footer, 64 - unprocessedBytes);
+		addBytes( (char *)footer, 64 - unprocessedBytes);
 	assert( unprocessedBytes <= 56 );
 	// how many zeros do we need
 	int neededZeros = 56 - unprocessedBytes;
@@ -184,9 +184,9 @@ unsigned char* SHA1::getDigest()
 	storeBigEndianUint32( footer + neededZeros    , totalBitsH );
 	storeBigEndianUint32( footer + neededZeros + 4, totalBitsL );
 	// finish the final block
-	addBytes( (char*)footer, neededZeros + 8 );
+	addBytes( (char *)footer, neededZeros + 8 );
 	// allocate memory for the digest bytes
-	unsigned char* digest = (unsigned char*)malloc( 20 );
+	unsigned char *digest = (unsigned char *)malloc( 20 );
 	// copy the digest bytes
 	storeBigEndianUint32( digest, H0 );
 	storeBigEndianUint32( digest + 4, H1 );

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -575,7 +575,7 @@ static SRP_Result init_random()
 /*void srp_dbg_num(mpz_t num, char * prevtext)
 {
 	int len_num = mpz_num_bytes(num);
-	char *bytes_num = (char*) srp_alloc(len_num);
+	char *bytes_num = (char *) srp_alloc(len_num);
 	mpz_to_bin(num, (unsigned char *) bytes_num);
 	srp_dbg_data(bytes_num, len_num, prevtext);
 	srp_free(bytes_num);

--- a/src/util/srp.h
+++ b/src/util/srp.h
@@ -121,14 +121,14 @@ SRP_Result srp_create_salted_verification_key(SRP_HashAlgorithm alg,
  *
  * Returns pointer to SRPVerifier on success, and NULL on error.
  */
-struct SRPVerifier* srp_verifier_new(SRP_HashAlgorithm alg, SRP_NGType ng_type,
+struct SRPVerifier *srp_verifier_new(SRP_HashAlgorithm alg, SRP_NGType ng_type,
 	const char *username,
 	const unsigned char *bytes_s, size_t len_s,
 	const unsigned char *bytes_v, size_t len_v,
 	const unsigned char *bytes_A, size_t len_A,
 	const unsigned char *bytes_b, size_t len_b,
 	unsigned char** bytes_B, size_t *len_B,
-	const char* n_hex, const char* g_hex);
+	const char *n_hex, const char *g_hex);
 
 // clang-format on
 
@@ -175,9 +175,9 @@ size_t srp_user_get_session_key_length(struct SRPUser *usr);
 /* Output: username, bytes_A, len_A.
  * If you don't want it get written, set username to NULL.
  * If bytes_a == NULL, random data is used for a. */
-SRP_Result srp_user_start_authentication(struct SRPUser* usr, char **username,
+SRP_Result srp_user_start_authentication(struct SRPUser *usr, char **username,
 	const unsigned char *bytes_a, size_t len_a,
-	unsigned char **bytes_A, size_t* len_A);
+	unsigned char **bytes_A, size_t *len_A);
 
 /* Output: bytes_M, len_M  (len_M may be null and will always be
  *                          srp_user_get_session_key_length() bytes in size) */

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -207,7 +207,7 @@ wchar_t *narrow_to_wide_c(const char *str)
 
 #ifdef __ANDROID__
 
-const wchar_t* wide_chars =
+const wchar_t *wide_chars =
 	L" !\"#$%&'()*+,-./0123456789:;<=>?@"
 	L"ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
 	L"abcdefghijklmnopqrstuvwxyz{|}~";

--- a/src/util/timetaker.cpp
+++ b/src/util/timetaker.cpp
@@ -39,7 +39,7 @@ u64 TimeTaker::stop(bool quiet)
 			(*m_result) += dtime;
 		} else {
 			if (!quiet) {
-				static const char* const units[] = {
+				static const char *const units[] = {
 					"s"  /* PRECISION_SECONDS */,
 					"ms" /* PRECISION_MILLI */,
 					"us" /* PRECISION_MICRO */,
@@ -60,4 +60,3 @@ u64 TimeTaker::getTimerTime()
 {
 	return porting::getTime(m_precision) - m_time1;
 }
-

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -203,7 +203,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	//dstream<<"addArea done"<<std::endl;
 }
 
-void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
+void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea &src_area,
 		v3s16 from_pos, v3s16 to_pos, const v3s16 &size)
 {
 	/* The reason for this optimised code is that we're a member function
@@ -251,7 +251,7 @@ void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
 	}
 }
 
-void VoxelManipulator::copyTo(MapNode *dst, const VoxelArea& dst_area,
+void VoxelManipulator::copyTo(MapNode *dst, const VoxelArea &dst_area,
 		v3s16 dst_pos, v3s16 from_pos, const v3s16 &size)
 {
 	for(s16 z=0; z<size.Z; z++)

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -469,11 +469,11 @@ public:
 		Copy data and set flags to 0
 		dst_area.getExtent() <= src_area.getExtent()
 	*/
-	void copyFrom(MapNode *src, const VoxelArea& src_area,
+	void copyFrom(MapNode *src, const VoxelArea &src_area,
 			v3s16 from_pos, v3s16 to_pos, const v3s16 &size);
 
 	// Copy data
-	void copyTo(MapNode *dst, const VoxelArea& dst_area,
+	void copyTo(MapNode *dst, const VoxelArea &dst_area,
 			v3s16 dst_pos, v3s16 from_pos, const v3s16 &size);
 
 	/*

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -248,7 +248,7 @@ bool step_rel_block_pos(direction dir, relative_v3 &rel_pos,
  */
 void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	UnlightQueue &from_nodes, ReLightQueue &light_sources,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	std::map<v3s16, MapBlock *> &modified_blocks)
 {
 	// Stores data popped from from_nodes
 	u8 current_light;
@@ -352,7 +352,7 @@ void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
  */
 void spread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	LightQueue &light_sources,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	std::map<v3s16, MapBlock *> &modified_blocks)
 {
 	// The light the current node can provide to its neighbors.
 	u8 spreading_light;
@@ -468,7 +468,7 @@ static const LightBank banks[] = { LIGHTBANK_DAY, LIGHTBANK_NIGHT };
 
 void update_lighting_nodes(Map *map,
 	std::vector<std::pair<v3s16, MapNode> > &oldnodes,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	std::map<v3s16, MapBlock *> &modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	// For node getter functions
@@ -689,7 +689,7 @@ bool is_light_locally_correct(Map *map, const NodeDefManager *ndef,
 }
 
 void update_block_border_lighting(Map *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	std::map<v3s16, MapBlock *> &modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	bool is_valid_position;
@@ -978,7 +978,7 @@ const VoxelArea block_pad[] = {
  */
 void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 	mapblock_v3 maxblock, UnlightQueue unlight[2], ReLightQueue relight[2],
-	std::map<v3s16, MapBlock*> *modified_blocks)
+	std::map<v3s16, MapBlock *> *modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	// dummy boolean
@@ -1047,7 +1047,7 @@ void finish_bulk_light_update(Map *map, mapblock_v3 minblock,
 }
 
 void blit_back_with_light(ServerMap *map, MMVManip *vm,
-	std::map<v3s16, MapBlock*> *modified_blocks)
+	std::map<v3s16, MapBlock *> *modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	mapblock_v3 minblock = getNodeBlockPos(vm->m_area.MinEdge);
@@ -1190,7 +1190,7 @@ void fill_with_sunlight(MapBlock *block, const NodeDefManager *ndef,
 }
 
 void repair_block_light(ServerMap *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> *modified_blocks)
+	std::map<v3s16, MapBlock *> *modified_blocks)
 {
 	if (!block || block->isDummy())
 		return;
@@ -1331,4 +1331,3 @@ s16 VoxelLineIterator::getIndex(v3s16 voxel){
 }
 
 } // namespace voxalgo
-

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -46,7 +46,7 @@ namespace voxalgo
 void update_lighting_nodes(
 	Map *map,
 	std::vector<std::pair<v3s16, MapNode> > &oldnodes,
-	std::map<v3s16, MapBlock*> &modified_blocks);
+	std::map<v3s16, MapBlock *> &modified_blocks);
 
 /*!
  * Updates borders of the given mapblock.
@@ -58,7 +58,7 @@ void update_lighting_nodes(
  * the function modified
  */
 void update_block_border_lighting(Map *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> &modified_blocks);
+	std::map<v3s16, MapBlock *> &modified_blocks);
 
 /*!
  * Copies back nodes from a voxel manipulator
@@ -69,7 +69,7 @@ void update_block_border_lighting(Map *map, MapBlock *block,
  * the function modified
  */
 void blit_back_with_light(ServerMap *map, MMVManip *vm,
-	std::map<v3s16, MapBlock*> *modified_blocks);
+	std::map<v3s16, MapBlock *> *modified_blocks);
 
 /*!
  * Corrects the light in a map block.
@@ -78,7 +78,7 @@ void blit_back_with_light(ServerMap *map, MMVManip *vm,
  * \param block the block to update
  */
 void repair_block_light(ServerMap *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> *modified_blocks);
+	std::map<v3s16, MapBlock *> *modified_blocks);
 
 /*!
  * This class iterates trough voxels that intersect with


### PR DESCRIPTION
This PR attends to incorrect pointer placement, across the whole repo.

The corrections were performed manually by me, and weren't automated by a script. This is to prevent messing up other things like this example comment:
```
This is *not* the best way to do this, but hey, this is Minetest, and this is how we roll :D
            ^
```

Yes, there's a \*lot\* (ha!) of comments that use `*` around words for emphasis. :P

P.S. Do let me know if there's any way to automate this without messing up other things like comments, or badly-formatted mathematical expressions (e.g. `invList->setSize(8* 4)`)

****

I've corrected all occurrences of incorrect pointer placement, that matches either of the following regular expressions:

- **`\w(\*|&) \w`**  (moved the `*`/`&` operator after the space, for all matches)
  - `handleCommand_Interact(NetworkPacket* pkt);`
  - `NetworkPacket& NetworkPacket::operator <<(v3f dst);`
- **`\w(\*|&)(>|\))`** (added a space between the `*`/`&` operator and typename, for all matches)
  - `std::vector<EmergeThread*> m_threads;`
  - `} catch (SettingNotFoundException&) {}`