### PR TITLE
 builtin/../register.lua: Abort make_wrap_deregistration if param is invalid

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -514,11 +514,17 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 end
 
 local function make_wrap_deregistration(reg_fn, clear_fn, list)
-	local unregister = function (unregistered_key)
+	local unregister = function (key)
+		if type(key) ~= "string" then
+			error("key is not a string", 2)
+		end
+		if not list[key] then
+			error("Attempt to unregister non-existent element - '" .. key .. "'", 2)
+		end
 		local temporary_list = table.copy(list)
 		clear_fn()
 		for k,v in pairs(temporary_list) do
-			if unregistered_key ~= k then
+			if key ~= k then
 				reg_fn(v)
 			end
 		end
@@ -564,7 +570,8 @@ core.registered_biomes      = make_registration_wrap("register_biome",      "cle
 core.registered_ores        = make_registration_wrap("register_ore",        "clear_registered_ores")
 core.registered_decorations = make_registration_wrap("register_decoration", "clear_registered_decorations")
 
-core.unregister_biome = make_wrap_deregistration(core.register_biome, core.clear_registered_biomes, core.registered_biomes)
+core.unregister_biome = make_wrap_deregistration(core.register_biome,
+		core.clear_registered_biomes, core.registered_biomes)
 
 core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
 core.registered_globalsteps, core.register_globalstep = make_registration()


### PR DESCRIPTION
`make_wrap_deregistration` works by creating a new table, copying all elements except the one to be unregistered, and assigns the new table to the list. As table copying can potentially cause performance hits, this PR prevents the copy from happening if the param passed to `make_wrap_deregistration` is not valid (i.e. if `nil`, or if the index doesn't exist).