### PR TITLE
Added ability to store and restore map backup to sqlite3 backend

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4589,6 +4589,22 @@ Storage API
     * returns reference to mod private `StorageRef`
     * must be called during mod load time
 
+Database Backups
+----------------
+
+* `minetest.map_list_backups()`:
+    * returns a list of existing backups names
+
+* `minetest.map_create_backup(backup_name)`:
+    * Creates a backup of the map
+
+* `minetest.map_restore_backup(backup_name)`:
+    * Restores an existing backup of the map. Warning: this may destroy a lot of
+      players's work
+
+* `minetest.map_delete_backup(backup_name)`:
+	* Deletes an existing backup of the map
+
 Misc.
 -----
 

--- a/src/database/database-sqlite3.h
+++ b/src/database/database-sqlite3.h
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <cstring>
 #include <string>
+#include <thread>
 #include "database.h"
 #include "exceptions.h"
 
@@ -42,6 +43,9 @@ protected:
 
 	// Open and initialize the database if needed
 	void verifyDatabase();
+
+	// Tells if a table exists in the database
+	bool tableExists(const std::string &table_name);
 
 	// Convertors
 	inline void str_to_sqlite(sqlite3_stmt *s, int iCol, const std::string &str) const
@@ -153,12 +157,23 @@ public:
 
 	void beginSave() { Database_SQLite3::beginSave(); }
 	void endSave() { Database_SQLite3::endSave(); }
+
+	void listBackups(std::vector<std::string> &dst);
+	bool createBackup(const std::string &name);
+	void restoreBackup(const std::string &name);
+	void deleteBackup(const std::string &name);
+
 protected:
 	virtual void createDatabase();
 	virtual void initStatements();
+	void upgradeDatabaseStructure();
+	bool m_thread_stop = true;
+ 	std::thread m_thread;
 
 private:
 	void bindPos(sqlite3_stmt *stmt, const v3s16 &pos, int index = 1);
+	void setCurrentVersion(int id);
+ 	int getVersionByName(const std::string &name);
 
 	// Map
 	sqlite3_stmt *m_stmt_read = nullptr;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -46,6 +46,11 @@ public:
 	static s64 getBlockAsInteger(const v3s16 &pos);
 	static v3s16 getIntegerAsBlock(s64 i);
 
+	virtual void listBackups(std::vector<std::string> &dst) {};
+	virtual bool createBackup(const std::string &name) { return false; };
+	virtual void restoreBackup(const std::string &name) {};
+	virtual void deleteBackup(const std::string &name) {};
+
 	virtual void listAllLoadableBlocks(std::vector<v3s16> &dst) = 0;
 };
 

--- a/src/map.h
+++ b/src/map.h
@@ -446,6 +446,11 @@ public:
 	bool repairBlockLight(v3s16 blockpos,
 		std::map<v3s16, MapBlock *> *modified_blocks);
 
+	void createBackup(const std::string &backup_name);
+	void restoreBackup(const std::string &backup_name);
+	void deleteBackup(const std::string &backup_name);
+	void listBackups(std::vector<std::string> &dst);
+
 	MapSettingsManager settings_mgr;
 
 private:

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1279,6 +1279,53 @@ int ModApiEnvMod::l_forceload_free_block(lua_State *L)
 	return 0;
 }
 
+int ModApiEnvMod::l_map_create_backup(lua_State *L)
+{
+	GET_ENV_PTR;
+	const char *backup_name = luaL_checkstring(L, 1);
+	ServerMap &map = env->getServerMap();
+	env->clearActiveBlocks();
+	map.createBackup(backup_name);
+	return 0;
+}
+
+int ModApiEnvMod::l_map_delete_backup(lua_State *L)
+{
+	GET_ENV_PTR;
+	const char *backup_name = luaL_checkstring(L, 1);
+	ServerMap &map = env->getServerMap();
+	env->clearActiveBlocks();
+	map.deleteBackup(backup_name);
+	return 0;
+}
+
+int ModApiEnvMod::l_map_list_backups(lua_State *L)
+{
+	GET_ENV_PTR;
+	ServerMap &map = env->getServerMap();
+	std::vector<std::string> list;
+	map.listBackups(list);
+
+	lua_newtable(L);
+	for (size_t i = 0; i != list.size(); i++) {
+		lua_pushstring(L, list[i].c_str());
+		lua_rawseti(L, -2, i + 1);
+	}
+
+	return 1;
+}
+
+int ModApiEnvMod::l_map_restore_backup(lua_State *L)
+{
+	GET_ENV_PTR;
+	const char *backup_name = luaL_checkstring(L, 1);
+	ServerMap &map = env->getServerMap();
+	env->clearObjects(CLEAR_OBJECTS_MODE_LOADED_ONLY);
+	env->clearActiveBlocks();
+	map.restoreBackup(backup_name);
+	return 0;
+}
+
 void ModApiEnvMod::Initialize(lua_State *L, int top)
 {
 	API_FCT(set_node);
@@ -1325,6 +1372,10 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(transforming_liquid_add);
 	API_FCT(forceload_block);
 	API_FCT(forceload_free_block);
+	API_FCT(map_create_backup);
+	API_FCT(map_list_backups);
+	API_FCT(map_restore_backup);
+	API_FCT(map_delete_backup);	
 }
 
 void ModApiEnvMod::InitializeClient(lua_State *L, int top)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1284,7 +1284,12 @@ int ModApiEnvMod::l_map_create_backup(lua_State *L)
 	GET_ENV_PTR;
 	const char *backup_name = luaL_checkstring(L, 1);
 	ServerMap &map = env->getServerMap();
+
+	// Force loaded entities to hibernate
 	env->clearActiveBlocks();
+	env->deactivateFarObjects(false);
+	map.unloadUnreferencedBlocks(NULL);
+
 	map.createBackup(backup_name);
 	return 0;
 }
@@ -1375,7 +1380,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(map_create_backup);
 	API_FCT(map_list_backups);
 	API_FCT(map_restore_backup);
-	API_FCT(map_delete_backup);	
+	API_FCT(map_delete_backup);
 }
 
 void ModApiEnvMod::InitializeClient(lua_State *L, int top)

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -184,6 +184,22 @@ private:
 	// stops forceloading a position
 	static int l_forceload_free_block(lua_State *L);
 
+	// map_create_backup(backup_name)
+	// Create a new map backup
+	static int l_map_create_backup(lua_State *L);
+
+	// map_list_backups()
+	// Return a list of available map backups
+	static int l_map_list_backups(lua_State *L);
+
+	// map_restore_backup(backup_name)
+	// Restore the given map backup (beware current map state lost)
+	static int l_map_restore_backup(lua_State *L);
+
+	// map_delete_backup(backup_name)
+	// Delete a map backup
+	static int l_map_delete_backup(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1187,7 +1187,8 @@ void ServerEnvironment::clearObjects(ClearObjectsMode mode)
 		block->refDrop();
 	}
 
-	m_last_clear_objects_time = m_game_time;
+	if (mode != CLEAR_OBJECTS_MODE_LOADED_ONLY)
+		m_last_clear_objects_time = m_game_time;
 
 	actionstream << "ServerEnvironment::clearObjects(): "
 		<< "Finished: Cleared " << num_objs_cleared << " objects"
@@ -2241,4 +2242,9 @@ bool ServerEnvironment::migrateAuthDatabase(
 		return false;
 	}
 	return true;
+}
+
+// Clear active blocks list
+void ServerEnvironment::clearActiveBlocks() {
+	m_active_blocks.clear();
 }

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -373,6 +373,17 @@ public:
  	// Clear active blocks list
  	void clearActiveBlocks();
 
+	/*
+		Convert objects that are not in active blocks to static.
+
+		If m_known_by_count != 0, active object is not deleted, but static
+		data is still updated.
+
+		If force_delete is set, active object is deleted nevertheless. It
+		shall only be set so in the destructor of the environment.
+	*/
+	void deactivateFarObjects(bool force_delete);
+
 private:
 
 	/**
@@ -410,17 +421,6 @@ private:
 		Convert stored objects from block to active
 	*/
 	void activateObjects(MapBlock *block, u32 dtime_s);
-
-	/*
-		Convert objects that are not in active blocks to static.
-
-		If m_known_by_count != 0, active object is not deleted, but static
-		data is still updated.
-
-		If force_delete is set, active object is deleted nevertheless. It
-		shall only be set so in the destructor of the environment.
-	*/
-	void deactivateFarObjects(bool force_delete);
 
 	/*
 		A few helpers used by the three above methods

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -187,6 +187,10 @@ enum ClearObjectsMode {
 	// Clear objects immediately in loaded mapblocks;
 	// clear objects in unloaded mapblocks only when the mapblocks are next activated.
 		CLEAR_OBJECTS_MODE_QUICK,
+
+ 	// Special mode that clears loaded objects but does not clear objects on further mapblock activation
+		CLEAR_OBJECTS_MODE_LOADED_ONLY,
+
 };
 
 /*
@@ -365,6 +369,10 @@ public:
 	AuthDatabase *getAuthDatabase() { return m_auth_database; }
 	static bool migrateAuthDatabase(const GameParams &game_params,
 			const Settings &cmd_args);
+
+ 	// Clear active blocks list
+ 	void clearActiveBlocks();
+
 private:
 
 	/**


### PR DESCRIPTION
**Purpose**
This PR adds ability, when using sqlite3 back end, to store, manage and restore map backups.
Creating, deleting and restore backups is instantaneous, regardless of the map size or the amount of changes done.

This is a functionality that we needed on our project but it could be useful to other projects like _Capture The Flag_. Likely to be totally useless on traditional Minetest servers as it may destroy player's builds.

**Drawbacks**
  * Works only with sqlite3. Should be very easy to port to other SQL databases, like PostgreSQL. I don't know how it could be difficult to port to non SQL databases.
  * Needs a map conversion that could be *very* long on big maps (but most likely to be useful on small maps like CTF) because ...:
  * It adds a field in the "blocks" table and changes its primary key (Sqlite does not support changing primary key, so this operation involves the copy of the whole "blocks" table into a new one). 

**Axes of improvements**
We did that change with a SQL oriented mind. It may not be the best way for Minetest. Some queries may look a bit complex and could be simplified by "de-SQLize" the thing (more code, less SQL).

The change consist in adding a "versions" table and a "version_id" field in the "blocks" table. The same position could have several versions. Switching from a backup to another consists only in changing versions status (and informing clients of the change). That's why it is instant.

The addition of the "version_id" field is not totally satisfying because :
  * It breaks map compatibility somehow 
  * It makes necessary to use database able to manipulate tables with fields (not like key-value databases)

We thought of adding "version_id" in the 64 bits of the "pos" field. Only 3x16 bits are actually used, so 16 bits could be available for version. This makes it possible to have 64000+ versions.

To keep it instant, we need to create a new version at each *restore*. So this means 64000 possible restore in the server life (if 1 restore each 5 minutes, 24/24 7/7, this makes only 220 days).

A reuse mechanisme could be implemented once unused blocks/versions are purged to get rid of this limitation.

**Known bugs**
  * Wont work / not tested on Android (sqlite3 is slightly different on this platform) but should work with some work done.
  * Loaded entities (alive entities) are not taken in account in backups. Only stored entities are stored/restored.
