### PR TITLE
[NO SQUASH; KETCHUP OK] Disable autoforward if player is dead

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1244,8 +1244,12 @@ void Client::sendPlayerPos()
 	u8 camera_fov    = map.getCameraFov();
 	u8 wanted_range  = map.getControl().wanted_range;
 
-	// Save bandwidth by only updating position when something changed
-	if(myplayer->last_position        == myplayer->getPosition() &&
+	// Save bandwidth by only updating position when
+	// player is not dead and something changed
+	if (myplayer->isDead())
+		return;
+
+	if (myplayer->last_position        == myplayer->getPosition() &&
 			myplayer->last_speed        == myplayer->getSpeed()    &&
 			myplayer->last_pitch        == myplayer->getPitch()    &&
 			myplayer->last_yaw          == myplayer->getYaw()      &&

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1249,7 +1249,7 @@ void Client::sendPlayerPos()
 	if (myplayer->isDead())
 		return;
 
-	if (myplayer->last_position        == myplayer->getPosition() &&
+	if (myplayer->last_position == myplayer->getPosition() &&
 			myplayer->last_speed        == myplayer->getSpeed()    &&
 			myplayer->last_pitch        == myplayer->getPitch()    &&
 			myplayer->last_yaw          == myplayer->getYaw()      &&

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1541,6 +1541,9 @@ void GenericCAO::processMessage(const std::string &data)
 
 		m_hp = result_hp;
 
+		if (m_is_local_player)
+			m_env->getLocalPlayer()->hp = m_hp;
+
 		if (damage > 0)
 		{
 			if (m_hp <= 0)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2466,7 +2466,7 @@ void Game::updatePlayerControl(const CameraOrientation &cam)
 	}
 
 	// autoforward if set: simulate "up" key
-	if (player->getPlayerSettings().continuous_forward) {
+	if (player->getPlayerSettings().continuous_forward && !player->isDead()) {
 		control.up = true;
 		keypress_bits |= 1U << 0;
 	}
@@ -2483,7 +2483,7 @@ inline void Game::step(f32 *dtime)
 	bool can_be_and_is_paused =
 			(simple_singleplayer_mode && g_menumgr.pausesGame());
 
-	if (can_be_and_is_paused) {	// This is for a singleplayer server
+	if (can_be_and_is_paused) { // This is for a singleplayer server
 		*dtime = 0;             // No time passes
 	} else {
 		if (server)

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -259,7 +259,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	}
 
 	/*
-	        Check if player is climbing
+			Check if player is climbing
 	*/
 
 
@@ -489,7 +489,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	PlayerSettings &player_settings = getPlayerSettings();
 
 	// All vectors are relative to the player's yaw,
-	// (and pitch if pitch fly mode enabled),
+	// (and pitch if pitch move mode enabled),
 	// and will be rotated at the end
 	v3f speedH = v3f(0,0,0); // Horizontal (X, Z)
 	v3f speedV = v3f(0,0,0); // Vertical (Y)
@@ -930,11 +930,11 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	bool touching_ground_was = touching_ground;
 	touching_ground = result.touching_ground;
 
-    //bool standing_on_unloaded = result.standing_on_unloaded;
+	//bool standing_on_unloaded = result.standing_on_unloaded;
 
 	/*
 		Check the nodes under the player to see from which node the
-		player is sneaking from, if any.  If the node from under
+		player is sneaking from, if any. If the node from under
 		the player has been removed, the player falls.
 	*/
 	f32 position_y_mod = 0.05 * BS;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -100,7 +100,7 @@ public:
 	bool makes_footstep_sound = true;
 
 	int last_animation = NO_ANIM;
-	float last_animation_speed;
+	float last_animation_speed = 0.0f;
 
 	std::string hotbar_image = "";
 	std::string hotbar_selected_image = "";
@@ -148,6 +148,8 @@ public:
 	void setZoomFOV(float zoom_fov) { m_zoom_fov = zoom_fov; }
 
 	bool getAutojump() const { return m_autojump; }
+
+	bool isDead() const { return hp <= 0; }
 
 	inline void addVelocity(const v3f &vel)
 	{


### PR DESCRIPTION
Server checks if player is dead before processing movement packets, so the issue of player creeping forward even while dead (when autoforward is enabled) is purely client-side. This PR fixes that.

- Make use of unused property `u16 LocalPlayer::hp` to actually store player's HP.
- Add convenience method `bool LocalPlayer::isDead()`, which just returns `hp <= 0`.
- Check if player is dead before setting automatic forward, in `LocalPlayer::applyControl`.

****

Tested :ok:. Fixes #8387.