### PR TITLE
Add matrix helpers to builtin

### DIFF
--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -11,6 +11,15 @@ function matrix.new(a, ...)
 	end
 end
 
+function matrix.equals(m1, m2)
+	for i = 1, 9 do
+		if m1[i] ~= m2[i] then
+			return false
+		end
+	end
+	return true
+end
+
 function matrix.index(m, l, c)
 	return m[(l - 1) * 3 + c]
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -144,7 +144,7 @@ function matrix.rotation_around_z(angle)
 	        0,  0, 1}
 end
 
-function matrix.rotation_around_vector(v, angle) --todo: test this and correct it if necessary
+function matrix.rotation_around_vector(v, angle)
 	local length_v = vector.length(v)
 	v = vector.divide(v, length_v)
 	angle = angle or length_v

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -43,12 +43,6 @@ local function multiply_scalar(m, a)
 end
 
 local function vector_matrix_multiply(m1, v)
-	--~ local m2 = matrix.new()
-	--~ m2[1] = v.x
-	--~ m2[4] = v.y
-	--~ m2[7] = v.z
-	--~ local m3 = matrix.multiply(m1, m2)
-	--~ return vector.new(m3[1], m3[4], m3[7])
 	return {
 		x = m1[1] * v.x + m1[2] * v.y + m1[3] * v.z,
 		y = m1[4] * v.x + m1[5] * v.y + m1[6] * v.z,
@@ -126,7 +120,7 @@ function matrix.rotation_around_z(angle)
 	        0,  0, 1}
 end
 
-function matrix.rotation_around_vector(v, angle)
+function matrix.rotation_around_vector(v, angle) --todo: test this and correct it if necessary
 	local length_v = vector.length(v)
 	v = vector.divide(v, length_v)
 	angle = angle or length_v
@@ -149,5 +143,5 @@ end
 
 function matrix.from_yaw_pitch_roll(v)
 	return matrix.multiply(matrix.rotation_around_y(v.y),
-			matrix.rotation_around_x(v.x),matrix.rotation_around_z(v.z)) -- the order might be wrong
+			matrix.rotation_around_x(v.x), matrix.rotation_around_z(v.z)) -- the order might be wrong; todo:test
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -119,15 +119,6 @@ function matrix3.invert(a)
 	return b
 end
 
--- note that minetest has a left-handed coordinate system.
--- ergo the rotation will be clockwise
--- (see wikipedia for details)
-
---~ local rounding_precision = 1000000
---~ local function round(a)
-	--~ return math.floor(a * rounding_precision + 0.5) / rounding_precision
---~ end
-
 local function sin(x)
 	if x % math.pi == 0 then
 		return 0
@@ -183,45 +174,6 @@ function matrix3.rotation_around_vector(v, angle)
 	}
 end
 
---~ function matrix3.to_pitch_yaw_roll(m)
-	--~ local r = vector.new()
-	--~ if round(math.abs(m[6])) ~= 1 then
-		--~ r.x = -math.asin(m[6])
-		--~ local cosx = math.cos(r.x)
-		--~ r.y = math.atan2(m[3] / cosx, m[9] / cosx)
-		--~ r.z = math.atan2(m[4] / cosx, m[5] / cosx)
-	--~ elseif m[6] < 0 then -- gimbal lock
-		--~ r.x = math.pi / 2
-		--~ r.z = 0
-		--~ r.y = math.atan2(m[2], m[1])
-	--~ else
-		--~ r.x = -math.pi / 2
-		--~ r.z = 0
-		--~ r.y = math.atan2(-m[2], m[1])
-	--~ end
-	--~ r.x = -r.x
-	--~ r.y = -r.y
-	--~ r.z = -r.z
-	--~ return r
---~ end
---~ function matrix3.to_pitch_yaw_roll(m)
-	--~ local r = vector.new()
-	--~ if round(math.abs(m[6])) ~= 1 then
-		--~ r.x = math.asin(m[6])
-		--~ local cosx = math.cos(r.x)
-		--~ r.y = math.atan2(-m[3] / cosx, m[9] / cosx)
-		--~ r.z = math.atan2(-m[4] / cosx, m[5] / cosx)
-	--~ elseif m[6] > 0 then -- gimbal lock
-		--~ r.x = math.pi / 2
-		--~ r.z = 0
-		--~ r.y = math.atan2(m[2], m[1])
-	--~ else
-		--~ r.x = -math.pi / 2
-		--~ r.z = 0
-		--~ r.y = math.atan2(m[7], m[8])
-	--~ end
-	--~ return r
---~ end
 function matrix3.to_pitch_yaw_roll(m)
 	local r = vector.new()
 	r.y = math.atan2(-m[3], m[9])
@@ -234,8 +186,6 @@ function matrix3.to_pitch_yaw_roll(m)
 end
 
 function matrix3.from_pitch_yaw_roll(v)
-	--~ return matrix3.multiply(matrix3.multiply(matrix3.rotation_around_y(-v.y),
-			--~ matrix3.rotation_around_x(-v.x)), matrix3.rotation_around_z(-v.z))
 	local sx, cx = sin(v.x), cos(v.x)
 	local sy, cy = sin(v.y), cos(v.y)
 	local sz, cz = sin(v.z), cos(v.z)

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -13,22 +13,6 @@ end
 
 matrix.identity = {1, 0, 0, 0, 1, 0, 0, 0, 1}
 
-function matrix.floor(m)
-	local mr = {}
-	for i = 1, 9 do
-		mr[i] = math.floor(m[i])
-	end
-	return mr
-end
-
-function matrix.round(m)
-	local mr = {}
-	for i = 1, 9 do
-		mr[i] = math.floor(m[i] + 0.5)
-	end
-	return mr
-end
-
 function matrix.apply(m, func)
 	local mr = {}
 	for i = 1, 9 do

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -107,8 +107,8 @@ end
 
 function matrix.transpose(m)
 	return {m[1], m[4], m[7],
-			m[2], m[5], m[8],
-			m[3], m[6], m[9]}
+	        m[2], m[5], m[8],
+	        m[3], m[6], m[9]}
 end
 
 -- note that minetest has a left-handed coordinate system.
@@ -120,27 +120,51 @@ local function round(a)
 	return math.floor(a * rounding_precision + 0.5) / rounding_precision
 end
 
+local function sin(x)
+	if x % math.pi == 0 then
+		return 0
+	elseif x % (2 * math.pi) == math.pi / 2 then
+		return 1
+	elseif x % (2 * math.pi) == math.pi * 3 / 2 then
+		return -1
+	else
+		return math.sin(x)
+	end
+end
+
+local function cos(x)
+	if x % math.pi == math.pi / 2 then
+		return 0
+	elseif x % (2 * math.pi) == 0 then
+		return 1
+	elseif x % (2 * math.pi) == math.pi then
+		return -1
+	else
+		return math.cos(x)
+	end
+end
+
 function matrix.rotation_around_x(angle)
-	local s = round(math.sin(angle))
-	local c = round(math.cos(angle))
+	local s = sin(angle)
+	local c = cos(angle)
 	return {1, 0,  0,
-            0, c, -s,
+	        0, c, -s,
 	        0, s,  c}
 end
 
 function matrix.rotation_around_y(angle)
-	local s = round(math.sin(angle))
-	local c = round(math.cos(angle))
+	local s = sin(angle)
+	local c = cos(angle)
 	return { c, 0, s,
-             0, 1, 0,
+	         0, 1, 0,
 	        -s, 0, c}
 end
 
 function matrix.rotation_around_z(angle)
-	local s = round(math.sin(angle))
-	local c = round(math.cos(angle))
+	local s = sin(angle)
+	local c = cos(angle)
 	return {c, -s, 0,
-            s,  c, 0,
+	        s,  c, 0,
 	        0,  0, 1}
 end
 
@@ -149,8 +173,8 @@ function matrix.rotation_around_vector(v, angle)
 	v = vector.divide(v, length_v)
 	angle = angle or length_v
 
-	local s = round(math.sin(angle))
-	local c = round(math.cos(angle))
+	local s = sin(angle)
+	local c = cos(angle)
 	local omc = 1 - c
 	return {
 		v.x * v.x * omc + c,       v.x * v.y * omc - v.z * s, v.x * v.z * omc + v.y * s,

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -95,6 +95,30 @@ function matrix3.transpose(m)
 	        m[3], m[6], m[9]}
 end
 
+function matrix3.determinant(m)
+	return m[1] * (m[5] * m[9] - m[6] * m[8])
+	     + m[2] * (m[6] * m[7] - m[4] * m[9])
+	     + m[3] * (m[4] * m[8] - m[5] * m[7])
+end
+
+function matrix3.invert(a)
+	local t11 = a[5] * a[9] - a[6] * a[8]
+	local t12 = a[6] * a[7] - a[4] * a[9]
+	local t13 = a[4] * a[8] - a[5] * a[7]
+
+	local det = a[1] * t11 + a[2] * t12 + a[3] * t13
+
+	if det == 0 then
+		return false -- there is no inverted
+	end
+	local b = {
+		t11 / det, (a[3]*a[8] - a[2]*a[9]) / det, (a[2]*a[6] - a[3]*a[5]) / det,
+		t12 / det, (a[1]*a[9] - a[3]*a[7]) / det, (a[3]*a[4] - a[1]*a[6]) / det,
+		t13 / det, (a[2]*a[7] - a[1]*a[8]) / det, (a[1]*a[5] - a[2]*a[4]) / det
+	}
+	return b
+end
+
 -- note that minetest has a left-handed coordinate system.
 -- ergo the rotation will be clockwise
 -- (see wikipedia for details)

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -1,7 +1,7 @@
 
-matrix = {}
+matrix3 = {}
 
-function matrix.new(a, ...)
+function matrix3.new(a, ...)
 	if not a then
 		return {0, 0, 0, 0, 0, 0, 0, 0, 0}
 	elseif type(a) ~= "table" then
@@ -11,9 +11,9 @@ function matrix.new(a, ...)
 	end
 end
 
-matrix.identity = {1, 0, 0, 0, 1, 0, 0, 0, 1}
+matrix3.identity = {1, 0, 0, 0, 1, 0, 0, 0, 1}
 
-function matrix.apply(m, func)
+function matrix3.apply(m, func)
 	local mr = {}
 	for i = 1, 9 do
 		mr[i] = func(m[i])
@@ -21,7 +21,7 @@ function matrix.apply(m, func)
 	return mr
 end
 
-function matrix.equals(m1, m2)
+function matrix3.equals(m1, m2)
 	for i = 1, 9 do
 		if m1[i] ~= m2[i] then
 			return false
@@ -30,11 +30,11 @@ function matrix.equals(m1, m2)
 	return true
 end
 
-function matrix.index(m, l, c)
+function matrix3.index(m, l, c)
 	return m[(l - 1) * 3 + c]
 end
 
-function matrix.add(m1, m2)
+function matrix3.add(m1, m2)
 	local m3 = {}
 	for i = 1, 9 do
 		m3[i] = m1[i] + m2[i]
@@ -50,7 +50,7 @@ local function multiply_scalar(m, a)
 	return mr
 end
 
-local function vector_matrix_multiply(m1, v)
+local function vector_matrix3_multiply(m1, v)
 	return {
 		x = m1[1] * v.x + m1[2] * v.y + m1[3] * v.z,
 		y = m1[4] * v.x + m1[5] * v.y + m1[6] * v.z,
@@ -58,11 +58,11 @@ local function vector_matrix_multiply(m1, v)
 	}
 end
 
-function matrix.multiply(m1, m2)
+function matrix3.multiply(m1, m2)
 	if type(m2) ~= "table" then
 		return multiply_scalar(m1, m2)
 	elseif m2.x then
-		return vector_matrix_multiply(m1, m2)
+		return vector_matrix3_multiply(m1, m2)
 	end
 	local m3 = {}
 	for l = 1, 3 do
@@ -77,19 +77,19 @@ function matrix.multiply(m1, m2)
 	return m3
 end
 
-function matrix.tensor_multiply(a, b)
-	local m1 = matrix.new()
+function matrix3.tensor_multiply(a, b)
+	local m1 = matrix3.new()
 	m1[1] = a.x
 	m1[4] = a.y
 	m1[7] = a.z
-	local m2 = matrix.new()
+	local m2 = matrix3.new()
 	m2[1] = a.x
 	m2[2] = a.y
 	m2[3] = a.z
-	return matrix.multiply(m1, m2)
+	return matrix3.multiply(m1, m2)
 end
 
-function matrix.transpose(m)
+function matrix3.transpose(m)
 	return {m[1], m[4], m[7],
 	        m[2], m[5], m[8],
 	        m[3], m[6], m[9]}
@@ -120,7 +120,7 @@ local function cos(x)
 	end
 end
 
-function matrix.rotation_around_x(angle)
+function matrix3.rotation_around_x(angle)
 	local s = sin(angle)
 	local c = cos(angle)
 	return {1, 0,  0,
@@ -128,7 +128,7 @@ function matrix.rotation_around_x(angle)
 	        0, s,  c}
 end
 
-function matrix.rotation_around_y(angle)
+function matrix3.rotation_around_y(angle)
 	local s = sin(angle)
 	local c = cos(angle)
 	return { c, 0, s,
@@ -136,7 +136,7 @@ function matrix.rotation_around_y(angle)
 	        -s, 0, c}
 end
 
-function matrix.rotation_around_z(angle)
+function matrix3.rotation_around_z(angle)
 	local s = sin(angle)
 	local c = cos(angle)
 	return {c, -s, 0,
@@ -144,7 +144,7 @@ function matrix.rotation_around_z(angle)
 	        0,  0, 1}
 end
 
-function matrix.rotation_around_vector(v, angle)
+function matrix3.rotation_around_vector(v, angle)
 	local length_v = vector.length(v)
 	v = vector.divide(v, length_v)
 	angle = angle or length_v
@@ -159,7 +159,7 @@ function matrix.rotation_around_vector(v, angle)
 	}
 end
 
---~ function matrix.to_yaw_pitch_roll(m)
+--~ function matrix3.to_yaw_pitch_roll(m)
 	--~ local r = vector.new()
 	--~ if round(math.abs(m[6])) ~= 1 then
 		--~ r.x = -math.asin(m[6])
@@ -180,7 +180,7 @@ end
 	--~ r.z = -r.z
 	--~ return r
 --~ end
---~ function matrix.to_yaw_pitch_roll(m)
+--~ function matrix3.to_yaw_pitch_roll(m)
 	--~ local r = vector.new()
 	--~ if round(math.abs(m[6])) ~= 1 then
 		--~ r.x = math.asin(m[6])
@@ -198,7 +198,7 @@ end
 	--~ end
 	--~ return r
 --~ end
-function matrix.to_yaw_pitch_roll(m)
+function matrix3.to_yaw_pitch_roll(m)
 	local r = vector.new()
 	r.y = math.atan2(-m[3], m[9])
 	local c2 = math.sqrt(m[4]^2 + m[5]^2)
@@ -209,7 +209,7 @@ function matrix.to_yaw_pitch_roll(m)
 	return r
 end
 
-function matrix.from_yaw_pitch_roll(v)
-	return matrix.multiply(matrix.multiply(matrix.rotation_around_y(-v.y),
-			matrix.rotation_around_x(-v.x)), matrix.rotation_around_z(-v.z))
+function matrix3.from_yaw_pitch_roll(v)
+	return matrix3.multiply(matrix3.multiply(matrix3.rotation_around_y(-v.y),
+			matrix3.rotation_around_x(-v.x)), matrix3.rotation_around_z(-v.z))
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -42,7 +42,7 @@ function matrix3.add(m1, m2)
 	return m3
 end
 
-local function multiply_scalar(m, a)
+local function multiply_matrix3_scalar(m, a)
 	local mr = {}
 	for i = 1, 9 do
 		mr[i] = m[i] * a
@@ -50,7 +50,7 @@ local function multiply_scalar(m, a)
 	return mr
 end
 
-local function vector_matrix3_multiply(m1, v)
+local function multiply_matrix3_vector(m1, v)
 	return {
 		x = m1[1] * v.x + m1[2] * v.y + m1[3] * v.z,
 		y = m1[4] * v.x + m1[5] * v.y + m1[6] * v.z,
@@ -60,9 +60,9 @@ end
 
 function matrix3.multiply(m1, m2)
 	if type(m2) ~= "table" then
-		return multiply_scalar(m1, m2)
+		return multiply_matrix3_scalar(m1, m2)
 	elseif m2.x then
-		return vector_matrix3_multiply(m1, m2)
+		return multiply_matrix3_vector(m1, m2)
 	end
 	local m3 = {}
 	for l = 1, 3 do

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -1,0 +1,118 @@
+
+matrix = {}
+
+function matrix.new(a, ...)
+	if not a then
+		return {0, 0, 0, 0, 0, 0, 0, 0, 0}
+	elseif type(a) ~= "table" then
+		return {a, ...}
+	else
+		return {a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9]}
+	end
+end
+
+function matrix.index(m, l, c)
+	return m[(l - 1) * 3 + c]
+end
+
+function matrix.add(m1, m2)
+	local m3 = {}
+	for i = 1, 9 do
+		m3[i] = m1[i] + m2[i]
+	end
+	return m3
+end
+
+local function multiply_scalar(m, a)
+	local mr = {}
+	for i = 1, 9 do
+		mr[i] = m[i] * a
+	end
+	return mr
+end
+
+local function vector_matrix_multiply(m1, v)
+	local m2 = matrix.new()
+	m2[1] = v.x
+	m2[2] = v.y
+	m2[3] = v.z
+	local m3 = matrix.multiply(m1, m2)
+	return vector.new(m3[1], m3[4], m3[7])
+end
+
+function matrix.multiply(m1, m2)
+	if type(m2) ~= "table" then
+		return multiply_scalar(m1, m2)
+	elseif m2.x then
+		return vector_matrix_multiply(m1, m2)
+	end
+	local m3 = {}
+	for l = 1, 3 do
+		for c = 1, 3 do
+			local i = (l - 1) * 3 + c
+			m3[i] = 0
+			for k = 1, 3 do
+				m3[i] = m3[i] + m1[(l - 1) * 3 + k] + m3[(k - 1) * 3 + c]
+			end
+		end
+	end
+	return m3
+end
+
+function matrix.tensor_multiply(a, b)
+	local m1 = matrix.new()
+	m1[1] = a.x
+	m1[4] = a.y
+	m1[7] = a.z
+	local m2 = matrix.new()
+	m2[1] = a.x
+	m2[2] = a.y
+	m2[3] = a.z
+	return matrix.multiply(m1, m2)
+end
+
+function matrix.transpose(m)
+	return {m[1], m[4], m[7],
+			m[2], m[5], m[8],
+			m[3], m[6], m[9]}
+end
+
+-- note that minetest has a left-handed coordinate system.
+-- ergo the rotation will be clockwise
+-- (see wikipedia for details)
+
+function matrix.rotation_around_x(angle)
+	local s = math.sin(angle)
+	local c = math.cos(angle)
+	return {1, 0,  0,
+            0, c, -s,
+	        0, s,  c}
+end
+
+function matrix.rotation_around_y(angle)
+	local s = math.sin(angle)
+	local c = math.cos(angle)
+	return { c, 0, s,
+             0, 1, 0,
+	        -s, 0, c}
+end
+
+function matrix.rotation_around_z(angle)
+	local s = math.sin(angle)
+	local c = math.cos(angle)
+	return {c, -s, 0,
+            s,  c, 0,
+	        0,  0, 1}
+end
+
+function matrix.rotation_around_vector(v, angle)
+	--todo
+end
+
+function matrix.to_yaw_pitch_roll(m)
+	--todo
+end
+
+function matrix.from_yaw_pitch_roll(v)
+	--todo
+end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -115,9 +115,9 @@ end
 -- ergo the rotation will be clockwise
 -- (see wikipedia for details)
 
-local round_exactness = 1000000
+local rounding_precision = 1000000
 local function round(a)
-	return math.floor(a * round_exactness + 0.5) / round_exactness
+	return math.floor(a * rounding_precision + 0.5) / rounding_precision
 end
 
 function matrix.rotation_around_x(angle)

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -204,22 +204,32 @@ end
 	--~ r.z = -r.z
 	--~ return r
 --~ end
+--~ function matrix.to_yaw_pitch_roll(m)
+	--~ local r = vector.new()
+	--~ if round(math.abs(m[6])) ~= 1 then
+		--~ r.x = math.asin(m[6])
+		--~ local cosx = math.cos(r.x)
+		--~ r.y = math.atan2(-m[3] / cosx, m[9] / cosx)
+		--~ r.z = math.atan2(-m[4] / cosx, m[5] / cosx)
+	--~ elseif m[6] > 0 then -- gimbal lock
+		--~ r.x = math.pi / 2
+		--~ r.z = 0
+		--~ r.y = math.atan2(m[2], m[1])
+	--~ else
+		--~ r.x = -math.pi / 2
+		--~ r.z = 0
+		--~ r.y = math.atan2(m[7], m[8])
+	--~ end
+	--~ return r
+--~ end
 function matrix.to_yaw_pitch_roll(m)
 	local r = vector.new()
-	if round(math.abs(m[6])) ~= 1 then
-		r.x = math.asin(m[6])
-		local cosx = math.cos(r.x)
-		r.y = math.atan2(-m[3] / cosx, m[9] / cosx)
-		r.z = math.atan2(-m[4] / cosx, m[5] / cosx)
-	elseif m[6] > 0 then -- gimbal lock
-		r.x = math.pi / 2
-		r.z = 0
-		r.y = math.atan2(m[2], m[1])
-	else
-		r.x = -math.pi / 2
-		r.z = 0
-		r.y = math.atan2(m[7], m[8])
-	end
+	r.y = math.atan2(-m[3], m[9])
+	local c2 = math.sqrt(m[4]^2 + m[5]^2)
+	r.x = math.atan2(m[6], c2)
+	local s1 = sin(r.y)
+	local c1 = cos(r.y)
+	r.z = math.atan2(s1 * m[8] + c1 * m[2], s1 * m[7] + c1 * m[1])
 	return r
 end
 

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -97,25 +97,30 @@ end
 -- ergo the rotation will be clockwise
 -- (see wikipedia for details)
 
+local round_exactness = 100000
+local function round(a)
+	return math.floor(a * round_exactness + 0.5) / round_exactness
+end
+
 function matrix.rotation_around_x(angle)
-	local s = math.sin(angle)
-	local c = math.cos(angle)
+	local s = round(math.sin(angle))
+	local c = round(math.cos(angle))
 	return {1, 0,  0,
             0, c, -s,
 	        0, s,  c}
 end
 
 function matrix.rotation_around_y(angle)
-	local s = math.sin(angle)
-	local c = math.cos(angle)
+	local s = round(math.sin(angle))
+	local c = round(math.cos(angle))
 	return { c, 0, s,
              0, 1, 0,
 	        -s, 0, c}
 end
 
 function matrix.rotation_around_z(angle)
-	local s = math.sin(angle)
-	local c = math.cos(angle)
+	local s = round(math.sin(angle))
+	local c = round(math.cos(angle))
 	return {c, -s, 0,
             s,  c, 0,
 	        0,  0, 1}
@@ -126,8 +131,8 @@ function matrix.rotation_around_vector(v, angle)
 	v = vector.divide(v, length_v)
 	angle = angle or length_v
 
-	local s = math.sin(angle)
-	local c = math.cos(angle)
+	local s = round(math.sin(angle))
+	local c = round(math.cos(angle))
 	local omc = 1 - c
 	return {
 		v.x * v.x * omc + c,       v.x * v.y * omc - v.z * s, v.x * v.z * omc + v.y * s,

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -234,6 +234,14 @@ function matrix3.to_pitch_yaw_roll(m)
 end
 
 function matrix3.from_pitch_yaw_roll(v)
-	return matrix3.multiply(matrix3.multiply(matrix3.rotation_around_y(-v.y),
-			matrix3.rotation_around_x(-v.x)), matrix3.rotation_around_z(-v.z))
+	--~ return matrix3.multiply(matrix3.multiply(matrix3.rotation_around_y(-v.y),
+			--~ matrix3.rotation_around_x(-v.x)), matrix3.rotation_around_z(-v.z))
+	local sx, cx = sin(v.x), cos(v.x)
+	local sy, cy = sin(v.y), cos(v.y)
+	local sz, cz = sin(v.z), cos(v.z)
+	return {
+		-sy * sx * sz + cy * cz, cz * sy * sx + cy * sz,  -cx * sy,
+		-cx * sz,                cx * cz,                 sx,
+		cy * sx * sz + cz * sy,  -cy * cz * sx + sy * sz, cy * cx
+	}
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -115,7 +115,7 @@ end
 -- ergo the rotation will be clockwise
 -- (see wikipedia for details)
 
-local round_exactness = 100000
+local round_exactness = 1000000
 local function round(a)
 	return math.floor(a * round_exactness + 0.5) / round_exactness
 end
@@ -159,10 +159,44 @@ function matrix.rotation_around_vector(v, angle)
 	}
 end
 
+--~ function matrix.to_yaw_pitch_roll(m)
+	--~ local r = vector.new()
+	--~ if round(math.abs(m[6])) ~= 1 then
+		--~ r.x = -math.asin(m[6])
+		--~ local cosx = math.cos(r.x)
+		--~ r.y = math.atan2(m[3] / cosx, m[9] / cosx)
+		--~ r.z = math.atan2(m[4] / cosx, m[5] / cosx)
+	--~ elseif m[6] < 0 then -- gimbal lock
+		--~ r.x = math.pi / 2
+		--~ r.z = 0
+		--~ r.y = math.atan2(m[2], m[1])
+	--~ else
+		--~ r.x = -math.pi / 2
+		--~ r.z = 0
+		--~ r.y = math.atan2(-m[2], m[1])
+	--~ end
+	--~ r.x = -r.x
+	--~ r.y = -r.y
+	--~ r.z = -r.z
+	--~ return r
+--~ end
 function matrix.to_yaw_pitch_roll(m)
-	--todo
-	-- I do not know how to do this yet.
-	return vector.new()
+	local r = vector.new()
+	if round(math.abs(m[6])) ~= 1 then
+		r.x = math.asin(m[6])
+		local cosx = math.cos(r.x)
+		r.y = math.atan2(-m[3] / cosx, m[9] / cosx)
+		r.z = math.atan2(-m[4] / cosx, m[5] / cosx)
+	elseif m[6] > 0 then -- gimbal lock
+		r.x = math.pi / 2
+		r.z = 0
+		r.y = math.atan2(m[2], m[1])
+	else
+		r.x = -math.pi / 2
+		r.z = 0
+		r.y = math.atan2(m[7], m[8])
+	end
+	return r
 end
 
 function matrix.from_yaw_pitch_roll(v)

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -123,10 +123,10 @@ end
 -- ergo the rotation will be clockwise
 -- (see wikipedia for details)
 
-local rounding_precision = 1000000
-local function round(a)
-	return math.floor(a * rounding_precision + 0.5) / rounding_precision
-end
+--~ local rounding_precision = 1000000
+--~ local function round(a)
+	--~ return math.floor(a * rounding_precision + 0.5) / rounding_precision
+--~ end
 
 local function sin(x)
 	if x % math.pi == 0 then

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -11,6 +11,8 @@ function matrix.new(a, ...)
 	end
 end
 
+matrix.identity = {1, 0, 0, 0, 1, 0, 0, 0, 1}
+
 function matrix.equals(m1, m2)
 	for i = 1, 9 do
 		if m1[i] ~= m2[i] then
@@ -61,7 +63,7 @@ function matrix.multiply(m1, m2)
 			local i = (l - 1) * 3 + c
 			m3[i] = 0
 			for k = 1, 3 do
-				m3[i] = m3[i] + m1[(l - 1) * 3 + k] + m3[(k - 1) * 3 + c]
+				m3[i] = m3[i] + m1[(l - 1) * 3 + k] + m2[(k - 1) * 3 + c]
 			end
 		end
 	end
@@ -116,12 +118,15 @@ end
 
 function matrix.rotation_around_vector(v, angle)
 	--todo
+	return matrix.new(matrix.identity)
 end
 
 function matrix.to_yaw_pitch_roll(m)
 	--todo
+	return vector.new()
 end
 
 function matrix.from_yaw_pitch_roll(v)
 	--todo
+	return matrix.new(matrix.identity)
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -159,7 +159,7 @@ function matrix3.rotation_around_vector(v, angle)
 	}
 end
 
---~ function matrix3.to_yaw_pitch_roll(m)
+--~ function matrix3.to_pitch_yaw_roll(m)
 	--~ local r = vector.new()
 	--~ if round(math.abs(m[6])) ~= 1 then
 		--~ r.x = -math.asin(m[6])
@@ -180,7 +180,7 @@ end
 	--~ r.z = -r.z
 	--~ return r
 --~ end
---~ function matrix3.to_yaw_pitch_roll(m)
+--~ function matrix3.to_pitch_yaw_roll(m)
 	--~ local r = vector.new()
 	--~ if round(math.abs(m[6])) ~= 1 then
 		--~ r.x = math.asin(m[6])
@@ -198,7 +198,7 @@ end
 	--~ end
 	--~ return r
 --~ end
-function matrix3.to_yaw_pitch_roll(m)
+function matrix3.to_pitch_yaw_roll(m)
 	local r = vector.new()
 	r.y = math.atan2(-m[3], m[9])
 	local c2 = math.sqrt(m[4]^2 + m[5]^2)
@@ -209,7 +209,7 @@ function matrix3.to_yaw_pitch_roll(m)
 	return r
 end
 
-function matrix3.from_yaw_pitch_roll(v)
+function matrix3.from_pitch_yaw_roll(v)
 	return matrix3.multiply(matrix3.multiply(matrix3.rotation_around_y(-v.y),
 			matrix3.rotation_around_x(-v.x)), matrix3.rotation_around_z(-v.z))
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -123,10 +123,6 @@ end
 local function sin(x)
 	if x % math.pi == 0 then
 		return 0
-	elseif x % (2 * math.pi) == math.pi / 2 then
-		return 1
-	elseif x % (2 * math.pi) == math.pi * 3 / 2 then
-		return -1
 	else
 		return math.sin(x)
 	end
@@ -135,10 +131,6 @@ end
 local function cos(x)
 	if x % math.pi == math.pi / 2 then
 		return 0
-	elseif x % (2 * math.pi) == 0 then
-		return 1
-	elseif x % (2 * math.pi) == math.pi then
-		return -1
 	else
 		return math.cos(x)
 	end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -117,16 +117,27 @@ function matrix.rotation_around_z(angle)
 end
 
 function matrix.rotation_around_vector(v, angle)
-	--todo
-	return matrix.new(matrix.identity)
+	local length_v = vector.length(v)
+	v = vector.divide(v, length_v)
+	angle = angle or length_v
+
+	local s = math.sin(angle)
+	local c = math.cos(angle)
+	local omc = 1 - c
+	return {
+		v.x * v.x * omc + c,       v.x * v.y * omc - v.z * s, v.x * v.z * omc + v.y * s,
+		v.y * v.x * omc + v.z * s, v.y * v.y * omc + c,       v.y * v.z * omc - v.x * s,
+		v.z * v.x * omc - v.y * s, v.z * v.y * omc + v.x * s, v.z * v.z * omc + c
+	}
 end
 
 function matrix.to_yaw_pitch_roll(m)
 	--todo
+	-- I do not know how to do this yet.
 	return vector.new()
 end
 
 function matrix.from_yaw_pitch_roll(v)
-	--todo
-	return matrix.new(matrix.identity)
+	return matrix.multiply(matrix.rotation_around_y(v.y),
+			matrix.rotation_around_x(v.x),matrix.rotation_around_z(v.z)) -- the order might be wrong
 end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -43,12 +43,17 @@ local function multiply_scalar(m, a)
 end
 
 local function vector_matrix_multiply(m1, v)
-	local m2 = matrix.new()
-	m2[1] = v.x
-	m2[2] = v.y
-	m2[3] = v.z
-	local m3 = matrix.multiply(m1, m2)
-	return vector.new(m3[1], m3[4], m3[7])
+	--~ local m2 = matrix.new()
+	--~ m2[1] = v.x
+	--~ m2[4] = v.y
+	--~ m2[7] = v.z
+	--~ local m3 = matrix.multiply(m1, m2)
+	--~ return vector.new(m3[1], m3[4], m3[7])
+	return {
+		x = m1[1] * v.x + m1[2] * v.y + m1[3] * v.z,
+		y = m1[4] * v.x + m1[5] * v.y + m1[6] * v.z,
+		z = m1[7] * v.x + m1[8] * v.y + m1[9] * v.z,
+	}
 end
 
 function matrix.multiply(m1, m2)
@@ -63,7 +68,7 @@ function matrix.multiply(m1, m2)
 			local i = (l - 1) * 3 + c
 			m3[i] = 0
 			for k = 1, 3 do
-				m3[i] = m3[i] + m1[(l - 1) * 3 + k] + m2[(k - 1) * 3 + c]
+				m3[i] = m3[i] + m1[(l - 1) * 3 + k] * m2[(k - 1) * 3 + c]
 			end
 		end
 	end

--- a/builtin/common/matrix.lua
+++ b/builtin/common/matrix.lua
@@ -13,6 +13,30 @@ end
 
 matrix.identity = {1, 0, 0, 0, 1, 0, 0, 0, 1}
 
+function matrix.floor(m)
+	local mr = {}
+	for i = 1, 9 do
+		mr[i] = math.floor(m[i])
+	end
+	return mr
+end
+
+function matrix.round(m)
+	local mr = {}
+	for i = 1, 9 do
+		mr[i] = math.floor(m[i] + 0.5)
+	end
+	return mr
+end
+
+function matrix.apply(m, func)
+	local mr = {}
+	for i = 1, 9 do
+		mr[i] = func(m[i])
+	end
+	return mr
+end
+
 function matrix.equals(m1, m2)
 	for i = 1, 9 do
 		if m1[i] ~= m2[i] then
@@ -142,6 +166,6 @@ function matrix.to_yaw_pitch_roll(m)
 end
 
 function matrix.from_yaw_pitch_roll(v)
-	return matrix.multiply(matrix.rotation_around_y(v.y),
-			matrix.rotation_around_x(v.x), matrix.rotation_around_z(v.z)) -- the order might be wrong; todo:test
+	return matrix.multiply(matrix.multiply(matrix.rotation_around_y(-v.y),
+			matrix.rotation_around_x(-v.x)), matrix.rotation_around_z(-v.z))
 end

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -258,6 +258,11 @@ function math.factorial(x)
 end
 
 --------------------------------------------------------------------------------
+function math.round(x)
+	return math.floor(x + 0.5)
+end
+
+--------------------------------------------------------------------------------
 function get_last_folder(text,count)
 	local parts = text:split(DIR_DELIM)
 

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -70,18 +70,6 @@ function vector.direction(pos1, pos2)
 	})
 end
 
-function vector.dot(a, b)
-	return a.x * b.x + a.y * b.y + a.z * b.z
-end
-
-function vector.cross(a, b)
-	return {
-		x = a.z * b.y - a.y * b.z,
-		y = a.x * b.z - a.z * b.x,
-		z = a.y * b.x - a.x * b.y,
-	}
-end
-
 function vector.angle(a, b)
 	local dotp = vector.dot(a, b)
 	local cp = vector.cross(a, b)

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -74,6 +74,14 @@ function vector.dot(a, b)
 	return a.x * b.x + a.y * b.y + a.z * b.z
 end
 
+function vector.cross(a, b)
+	return {
+		x = a.y * b.z - a.z * b.y,
+		y = a.z * b.x - a.x * b.z,
+		y = a.x * b.y - a.y * b.x,
+	}
+end
+
 function vector.angle(a, b)
 	local dotp = vector.dot(a, b)
 	local cp = vector.cross(a, b)

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -76,9 +76,9 @@ end
 
 function vector.cross(a, b)
 	return {
-		x = a.y * b.z - a.z * b.y,
-		y = a.z * b.x - a.x * b.z,
-		y = a.x * b.y - a.y * b.x,
+		x = a.z * b.y - a.y * b.z,
+		y = a.x * b.z - a.z * b.x,
+		y = a.y * b.x - a.x * b.y,
 	}
 end
 

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -70,6 +70,10 @@ function vector.direction(pos1, pos2)
 	})
 end
 
+function vector.dot(a, b)
+	return a.x * b.x + a.y * b.y + a.z * b.z
+end
+
 function vector.angle(a, b)
 	local dotp = vector.dot(a, b)
 	local cp = vector.cross(a, b)

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -78,7 +78,7 @@ function vector.cross(a, b)
 	return {
 		x = a.z * b.y - a.y * b.z,
 		y = a.x * b.z - a.z * b.x,
-		y = a.y * b.x - a.x * b.y,
+		z = a.y * b.x - a.x * b.y,
 	}
 end
 

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -8,6 +8,7 @@ local gamepath = scriptpath.."game"..DIR_DELIM
 local builtin_shared = {}
 
 dofile(commonpath.."vector.lua")
+dofile(commonpath.."matrix.lua")
 
 dofile(gamepath.."constants.lua")
 assert(loadfile(gamepath.."item.lua"))(builtin_shared)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -145,16 +145,8 @@ local matrix3_facedirs = {}
 -- returns a number asuming that the matrix3 has only -1, 0 and 1
 local function matrix3_1p_1n_0_hash(m)
 	local r = 0
-	for i = 1, 9 do
+	for i = 1, 6 do
 		r = r + (m[i] + 1) * 3^(i-1)
-		-- wrong values are possible, eg. m[i] could be 2. the following would fix that:
-		--~ if m[i] == 0 then
-			--~ r = r + 1 * 3^(i-1)
-		--~ elseif m[i] == 1 then
-			--~ r = r + 2 * 3^(i-1)
-		--~ elseif m[i] ~= -1 then
-			--~ return -1
-		--~ end
 	end
 	return r
 end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -115,7 +115,7 @@ end
 local facedir_matrices = {}
 do
 	local m_dirs = {
-		[0] = {1, 0, 0, 0, 1, 0, 0, 0, 1},
+		[0] = matrix.identity,
 		matrix.rotation_around_x(math.pi / 2),
 		matrix.rotation_around_x(-math.pi / 2),
 		matrix.rotation_around_z(-math.pi / 2),
@@ -123,7 +123,7 @@ do
 		matrix.rotation_around_z(-math.pi)
 	}
 	local m_rots = {
-		[0] = {1, 0, 0, 0, 1, 0, 0, 0, 1},
+		[0] = matrix.identity,
 		matrix.rotation_around_z(math.pi / 2),
 		matrix.rotation_around_z(math.pi),
 		matrix.rotation_around_z(math.pi * 3 / 2)
@@ -135,7 +135,7 @@ do
 	end
 end
 
-function core.facedir_to_matrix(facedir)
+function core.facedir_to_matrix(facedir, nocopy)
 	--~ --todo
 	--~ --[[
 	--~ from lua_api.txt:
@@ -175,7 +175,7 @@ function core.facedir_to_matrix(facedir)
 	--~ -- return the combined rotation matrix
 	--~ return matrix.multiply(m_dir, m_rot) -- the order might be wrong here; todo
 
-	return matrix.new(facedir_matrices[facedir])
+	return nocopy and facedir_matrices[facedir] or matrix.new(facedir_matrices[facedir])
 end
 
 local matrix_facedirs = {}
@@ -195,10 +195,8 @@ local function matrix_1p_1n_0_hash(m)
 	return r
 end
 
-do
-	for i = 0, 23 do
-		matrix_facedirs[matrix_1p_1n_0_hash(facedir_matrices[i])] = i
-	end
+for i = 0, 23 do
+	matrix_facedirs[matrix_1p_1n_0_hash(facedir_matrices[i])] = i
 end
 
 function core.matrix_to_facedir(m)
@@ -250,8 +248,8 @@ local wallmounted_to_facedir = {
 	4 + 2
 }
 
-function core.wallmounted_to_matrix(wallmounted)
-	return core.facedir_to_matrix(wallmounted_to_facedir[wallmounted])
+function core.wallmounted_to_matrix(wallmounted, nocopy)
+	return core.facedir_to_matrix(wallmounted_to_facedir[wallmounted], nocopy)
 end
 
 function core.matrix_to_wallmounted(m)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -209,16 +209,9 @@ function core.wallmounted_to_matrix3(wallmounted, nocopy)
 end
 
 function core.matrix3_to_wallmounted(m)
-	local f = core.matrix3_to_facedir(m)
-	if not f then
-		return nil -- no suitable facedir value found
-	end
-	for i = 1, 6 do
-		if wallmounted_to_facedir[i] == f then
-			return i
-		end
-	end
-	return nil -- matrix3 was not from wallmounted but from facedir
+	local w = table.indexof(wallmounted_to_facedir, core.matrix3_to_facedir(m))
+	w = w ~= -1 and w or nil
+	return w
 end
 
 function core.dir_to_yaw(dir)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -114,6 +114,7 @@ end
 
 local facedir_matrices = {}
 do
+	-- the following is taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
 	local m_dirs = {
 		[0] = matrix.identity,
 		matrix.rotation_around_x(math.pi / 2),
@@ -124,14 +125,14 @@ do
 	}
 	local m_rots = {
 		[0] = matrix.identity,
-		matrix.rotation_around_z(math.pi / 2),
-		matrix.rotation_around_z(math.pi),
-		matrix.rotation_around_z(math.pi * 3 / 2)
+		matrix.rotation_around_y(math.pi / 2),
+		matrix.rotation_around_y(math.pi),
+		matrix.rotation_around_y(math.pi * 3 / 2)
 	}
 	for facedir = 0, 23 do
 		local dir = math.floor(facedir / 4)
 		local rot = facedir % 4
-		facedir_matrices[facedir] = matrix.multiply(m_dirs[dir], m_rots[rot]) -- the order might be wrong here; todo
+		facedir_matrices[facedir] = matrix.multiply(m_dirs[dir], m_rots[rot])
 	end
 end
 
@@ -149,7 +150,7 @@ function core.facedir_to_matrix(facedir, nocopy)
 	--~ local dir = math.floor(facedir / 4)
 	--~ local rot = facedir % 4
 
-	--~ -- the following is taken from rotateMeshBy6dFacedir in mesh.cpp
+	--~ -- the following is taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
 	--~ -- the signs of the angles probably have to be swapped because minetest has
 	--~ -- a left-handed coordinate system
 
@@ -170,7 +171,7 @@ function core.facedir_to_matrix(facedir, nocopy)
 	--~ end
 
 	--~ -- make the rotation around axis rotation matrix
-	--~ local m_rot = matrix.rotation_around_z(math.pi * rot / 2)
+	--~ local m_rot = matrix.rotation_around_y(math.pi * rot / 2)
 
 	--~ -- return the combined rotation matrix
 	--~ return matrix.multiply(m_dir, m_rot) -- the order might be wrong here; todo

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -114,7 +114,7 @@ end
 
 local facedir_matrices = {}
 do
-	-- the following is taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
+	-- the following rotations are taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
 	local m_dirs = {
 		[0] = matrix.identity,
 		matrix.rotation_around_x(math.pi / 2),
@@ -137,61 +137,24 @@ do
 end
 
 function core.facedir_to_matrix(facedir, nocopy)
-	--~ --todo
-	--~ --[[
-	--~ from lua_api.txt:
-	--~ * Values range 0 - 23
-	--~ * facedir / 4 = axis direction:
-	  --~ 0 = y+,   1 = z+,   2 = z-,   3 = x+,   4 = x-,   5 = y-
-	--~ * facedir modulo 4 = rotation around that axis
-	--~ ]]
-
-	--~ -- get the parts from facedir
-	--~ local dir = math.floor(facedir / 4)
-	--~ local rot = facedir % 4
-
-	--~ -- the following is taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
-	--~ -- the signs of the angles probably have to be swapped because minetest has
-	--~ -- a left-handed coordinate system
-
-	--~ -- make the axis direction rotation matrix
-	--~ local m_dir
-	--~ if dir == 0 then
-		--~ m_dir = matrix.identity
-	--~ elseif dir == 1 then
-		--~ m_dir = matrix.rotation_around_x(math.pi / 2)
-	--~ elseif dir == 2 then
-		--~ m_dir = matrix.rotation_around_x(-math.pi / 2)
-	--~ elseif dir == 3 then
-		--~ m_dir = matrix.rotation_around_z(-math.pi / 2)
-	--~ elseif dir == 4 then
-		--~ m_dir = matrix.rotation_around_z(math.pi / 2)
-	--~ else
-		--~ m_rot = matrix.rotation_around_z(-math.pi)
-	--~ end
-
-	--~ -- make the rotation around axis rotation matrix
-	--~ local m_rot = matrix.rotation_around_y(math.pi * rot / 2)
-
-	--~ -- return the combined rotation matrix
-	--~ return matrix.multiply(m_dir, m_rot) -- the order might be wrong here; todo
-
 	return nocopy and facedir_matrices[facedir] or matrix.new(facedir_matrices[facedir])
 end
 
 local matrix_facedirs = {}
 
+-- returns a number asuming that the matrix has only -1, 0 and 1
 local function matrix_1p_1n_0_hash(m)
 	local r = 0
 	for i = 1, 9 do
-		--~ r = r + (m[i] + 1) * 3^(i-1)
-		if m[i] == 1 then
-			r = r + 1 * 3^(i-1)
-		elseif m[i] == -1 then
-			r = r + 2 * 3^(i-1)
-		elseif m[i] ~= 0 then
-			return -1
-		end
+		r = r + (m[i] + 1) * 3^(i-1)
+		-- wrong values are possible, eg. m[i] could be 2. the following would fix that:
+		--~ if m[i] == 0 then
+			--~ r = r + 1 * 3^(i-1)
+		--~ elseif m[i] == 1 then
+			--~ r = r + 2 * 3^(i-1)
+		--~ elseif m[i] ~= -1 then
+			--~ return -1
+		--~ end
 	end
 	return r
 end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -116,34 +116,34 @@ local facedir_matrices = {}
 do
 	-- the following rotations are taken from rotateMeshBy6dFacedir in src/client/mesh.cpp
 	local m_dirs = {
-		[0] = matrix.identity,
-		matrix.rotation_around_x(math.pi / 2),
-		matrix.rotation_around_x(-math.pi / 2),
-		matrix.rotation_around_z(-math.pi / 2),
-		matrix.rotation_around_z(math.pi / 2),
-		matrix.rotation_around_z(-math.pi)
+		[0] = matrix3.identity,
+		matrix3.rotation_around_x(math.pi / 2),
+		matrix3.rotation_around_x(-math.pi / 2),
+		matrix3.rotation_around_z(-math.pi / 2),
+		matrix3.rotation_around_z(math.pi / 2),
+		matrix3.rotation_around_z(-math.pi)
 	}
 	local m_rots = {
-		[0] = matrix.identity,
-		matrix.rotation_around_y(math.pi / 2),
-		matrix.rotation_around_y(math.pi),
-		matrix.rotation_around_y(math.pi * 3 / 2)
+		[0] = matrix3.identity,
+		matrix3.rotation_around_y(math.pi / 2),
+		matrix3.rotation_around_y(math.pi),
+		matrix3.rotation_around_y(math.pi * 3 / 2)
 	}
 	for facedir = 0, 23 do
 		local dir = math.floor(facedir / 4)
 		local rot = facedir % 4
-		facedir_matrices[facedir] = matrix.multiply(m_dirs[dir], m_rots[rot])
+		facedir_matrices[facedir] = matrix3.multiply(m_dirs[dir], m_rots[rot])
 	end
 end
 
-function core.facedir_to_matrix(facedir, nocopy)
-	return nocopy and facedir_matrices[facedir] or matrix.new(facedir_matrices[facedir])
+function core.facedir_to_matrix3(facedir, nocopy)
+	return nocopy and facedir_matrices[facedir] or matrix3.new(facedir_matrices[facedir])
 end
 
-local matrix_facedirs = {}
+local matrix3_facedirs = {}
 
--- returns a number asuming that the matrix has only -1, 0 and 1
-local function matrix_1p_1n_0_hash(m)
+-- returns a number asuming that the matrix3 has only -1, 0 and 1
+local function matrix3_1p_1n_0_hash(m)
 	local r = 0
 	for i = 1, 9 do
 		r = r + (m[i] + 1) * 3^(i-1)
@@ -160,11 +160,11 @@ local function matrix_1p_1n_0_hash(m)
 end
 
 for i = 0, 23 do
-	matrix_facedirs[matrix_1p_1n_0_hash(facedir_matrices[i])] = i
+	matrix3_facedirs[matrix3_1p_1n_0_hash(facedir_matrices[i])] = i
 end
 
-function core.matrix_to_facedir(m)
-	return matrix_facedirs[matrix_1p_1n_0_hash(m)]
+function core.matrix3_to_facedir(m)
+	return matrix3_facedirs[matrix3_1p_1n_0_hash(m)]
 end
 
 function core.dir_to_wallmounted(dir)
@@ -212,12 +212,12 @@ local wallmounted_to_facedir = {
 	4 + 2
 }
 
-function core.wallmounted_to_matrix(wallmounted, nocopy)
-	return core.facedir_to_matrix(wallmounted_to_facedir[wallmounted], nocopy)
+function core.wallmounted_to_matrix3(wallmounted, nocopy)
+	return core.facedir_to_matrix3(wallmounted_to_facedir[wallmounted], nocopy)
 end
 
-function core.matrix_to_wallmounted(m)
-	local f = core.matrix_to_facedir(m)
+function core.matrix3_to_wallmounted(m)
+	local f = core.matrix3_to_facedir(m)
 	if not f then
 		return nil -- no suitable facedir value found
 	end
@@ -226,7 +226,7 @@ function core.matrix_to_wallmounted(m)
 			return i
 		end
 	end
-	return nil -- matrix was not from wallmounted but from facedir
+	return nil -- matrix3 was not from wallmounted but from facedir
 end
 
 function core.dir_to_yaw(dir)

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -130,7 +130,7 @@ do
 	}
 	for facedir = 0, 23 do
 		local dir = math.floor(facedir / 4)
-		local rot = facedir - dir
+		local rot = facedir % 4
 		facedir_matrices[facedir] = matrix.multiply(m_dirs[dir], m_rots[rot]) -- the order might be wrong here; todo
 	end
 end
@@ -147,7 +147,7 @@ function core.facedir_to_matrix(facedir, nocopy)
 
 	--~ -- get the parts from facedir
 	--~ local dir = math.floor(facedir / 4)
-	--~ local rot = facedir - dir
+	--~ local rot = facedir % 4
 
 	--~ -- the following is taken from rotateMeshBy6dFacedir in mesh.cpp
 	--~ -- the signs of the angles probably have to be swapped because minetest has
@@ -156,7 +156,7 @@ function core.facedir_to_matrix(facedir, nocopy)
 	--~ -- make the axis direction rotation matrix
 	--~ local m_dir
 	--~ if dir == 0 then
-		--~ m_dir = {1, 0, 0, 0, 1, 0, 0, 0, 1}
+		--~ m_dir = matrix.identity
 	--~ elseif dir == 1 then
 		--~ m_dir = matrix.rotation_around_x(math.pi / 2)
 	--~ elseif dir == 2 then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2520,6 +2520,8 @@ For the following functions, `v`, `v1`, `v2` are vectors,
 * `vector.dot(v1, v2)`:
     * Returns the dot product of `v1` and `v2`.
     * Returns the matrix product of the transposed of `v1` and `v2`.
+* `vector.cross(v1, v2)`:
+    * Returns the cross product of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
     * Returns the angle between `v1` and `v2` in radians.
 * `vector.dot(v1, v2)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2563,10 +2563,6 @@ Matrices can be used for rotation.
     * A copy of the matrix `m` is returned.
 * `matrix.identity`:
     * This is the identity matrix. Do not modify it.
-* `matrix.floor(m)`:
-    * Returns a matrix, each component rounded down.
-* `matrix.round(m)`:
-    * Returns a matrix, each component rounded to nearest integer.
 * `matrix.apply(m, func)`:
     * Returns a matrix where the function `func` has been applied to each
       component.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2484,7 +2484,7 @@ A spatial vector is similar to a position, but instead using
 absolute world coordinates, it uses *relative* coordinates, relative to
 no particular point.
 
-A vector is a 3x1 matrix3 (see Matrices).
+A vector is a 3x1 matrix (see Matrices).
 
 Internally, it is implemented as a table with the 3 fields
 `x`, `y` and `z`. Example: `{x = 0, y = 1, z = 0}`.
@@ -2519,7 +2519,7 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
 * `vector.dot(v1, v2)`:
     * Returns the dot product of `v1` and `v2`.
-    * Returns the matrix3 product of the transposed of `v1` and `v2`.
+    * Returns the matrix product of the transposed of `v1` and `v2`.
 * `vector.cross(v1, v2)`:
     * Returns the cross product of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
@@ -2553,7 +2553,7 @@ Minetest has helpers for 3x3 matrices.
 Matrices can be used for rotation.
 
 * `matrix3.new()`:
-    * Returns a matrix3 filled with zeros.
+    * Returns a 3x3 matrix filled with zeros.
 * `matrix3.new(m_11, m_12, m_13, m_21, m_22, m_23, m_31, m_32, m_33)`:
     * Returns a matrix3:
       ```
@@ -2577,12 +2577,12 @@ Matrices can be used for rotation.
 * `matrix3.multiply(m, a)`:
     * Returns the scalar product of the matrix3 `m` and the scalar `a`.
 * `matrix3.multiply(m1, m2)`:
-    * Returns the matrix3 product of the matrices `m1` and `m2`.
+    * Returns the matrix product of the matrices `m1` and `m2`.
 * `matrix3.multiply(m, v)`:
-    * Returns the matrix3 product of the matrix3 `m` and the vector `v` as vector.
+    * Returns the matrix product of the matrix3 `m` and the vector `v` as vector.
 * `matrix3.tensor_multiply(v1, v2)`:
     * `v1` and `v2` are vectors.
-    * Returns the matrix3 product of `v1` and the transposed of `v2`.
+    * Returns the matrix product of `v1` and the transposed of `v2`.
 * `matrix3.transpose(m)`:
     * Returns the transposed martix of `m`.
 * `matrix3.rotation_around_x(angle)`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2559,6 +2559,8 @@ Matrices can be used for rotation.
            m_31, m_32, m_33}
 * `matrix.new(m)`:
     * A copy of the matrix `m` is returned.
+* `matrix.equals(m1, m2)`:
+    * Returns a boolean, `true` if the matrices are identical.
 * `matrix.index(m, l, c)`:
     * Returns `m[(l - 1) * 3 + c]`.
 * `matrix.add(m1, m2)`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2559,6 +2559,8 @@ Matrices can be used for rotation.
            m_31, m_32, m_33}
 * `matrix.new(m)`:
     * A copy of the matrix `m` is returned.
+* `matrix.identity`:
+    * This is the identity matrix. Do not modify it.
 * `matrix.equals(m1, m2)`:
     * Returns a boolean, `true` if the matrices are identical.
 * `matrix.index(m, l, c)`:
@@ -4505,8 +4507,11 @@ Item handling
 * `minetest.facedir_to_dir(facedir)`
     * Convert a facedir back into a vector aimed directly out the "back" of a
       node.
-* `minetest.facedir_to_matrix(facedir)`
+* `minetest.facedir_to_matrix(facedir[, nocopy])`
     * Convert a facedir into a rotation matrix. Also see Matrices.
+    * `nocopy` is `false` by default. If you set it to `true`, a reference is
+      returned that must not be edited. However, this is faster as it does not
+      involve copying.
 * `minetest.matrix_to_facedir(matrix)`
     * Convert a matrix back to a facedir.
     * Returns `nil` if there is no suitable value.
@@ -4516,8 +4521,11 @@ Item handling
 * `minetest.wallmounted_to_dir(wallmounted)`
     * Convert a wallmounted value back into a vector aimed directly out the
       "back" of a node.
-* `minetest.wallmounted_to_matrix(wallmounted)`
+* `minetest.wallmounted_to_matrix(wallmounted[, nocopy])`
     * Convert a wallmounted into a rotation matrix. Also see Matrices.
+    * `nocopy` is `false` by default. If you set it to `true`, a reference is
+      returned that must not be edited. However, this is faster as it does not
+      involve copying.
 * `minetest.matrix_to_wallmounted(matrix)`
     * Convert a matrix back to a wallmounted.
     * Returns `nil` if there is no suitable value.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2551,12 +2551,14 @@ Minetest has helpers for 3x3 matrices.
 Matrices can be used for rotation.
 
 * `matrix.new()`:
-    * returns a matrix filled with zeros
+    * Returns a matrix filled with zeros.
 * `matrix.new(m_11, m_12, m_13, m_21, m_22, m_23, m_31, m_32, m_33)`:
-    * returns a matrix
+    * Returns a matrix:
+      ```
       M = {m_11, m_12, m_13,
            m_21, m_22, m_23,
            m_31, m_32, m_33}
+      ```
 * `matrix.new(m)`:
     * A copy of the matrix `m` is returned.
 * `matrix.identity`:
@@ -2598,9 +2600,9 @@ Matrices can be used for rotation.
     * `angle` is given in radians.
     * Returns a rotation matrix around an axis in the direction of `v`.
 * `matrix.to_yaw_pitch_roll(m)`:
-    * Returns a vector `{x = pitch, y = yaw, z = roll}`.
+    * Returns a vector filled with euler angles `{x = pitch, y = yaw, z = roll}`.
 * `matrix.from_yaw_pitch_roll(v)`:
-    * bla
+    * Returns a matrix where the euler angles given in `v` were applied.
 
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2561,6 +2561,13 @@ Matrices can be used for rotation.
     * A copy of the matrix `m` is returned.
 * `matrix.identity`:
     * This is the identity matrix. Do not modify it.
+* `matrix.floor(m)`:
+    * Returns a matrix, each component rounded down.
+* `matrix.round(m)`:
+    * Returns a matrix, each component rounded to nearest integer.
+* `matrix.apply(m, func)`:
+    * Returns a matrix where the function `func` has been applied to each
+      component.
 * `matrix.equals(m1, m2)`:
     * Returns a boolean, `true` if the matrices are identical.
 * `matrix.index(m, l, c)`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2519,7 +2519,7 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
 * `vector.dot(v1, v2)`:
     * Returns the dot product of `v1` and `v2`.
-    * Returns the matrix product of the transposed of `v1` and `v2`.
+    * Returns the matrix product of the transpose of `v1` and `v2`.
 * `vector.cross(v1, v2)`:
     * Returns the cross product of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
@@ -2582,9 +2582,9 @@ Matrices can be used for rotation.
     * Returns the matrix product of the matrix3 `m` and the vector `v` as vector.
 * `matrix3.tensor_multiply(v1, v2)`:
     * `v1` and `v2` are vectors.
-    * Returns the matrix product of `v1` and the transposed of `v2`.
+    * Returns the matrix product of `v1` and the transpose of `v2`.
 * `matrix3.transpose(m)`:
-    * Returns the transposed martix of `m`.
+    * Returns the transpose martix of `m`.
 * `matrix3.rotation_around_x(angle)`:
     * `angle` is given in radians.
     * Returns a rotation matrix3 around the x-axis.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2524,10 +2524,6 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns the cross product of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
     * Returns the angle between `v1` and `v2` in radians.
-* `vector.dot(v1, v2)`
-    * Returns the dot product of `v1` and `v2`
-* `vector.cross(v1, v2)`
-    * Returns the cross product of `v1` and `v2`
 
 For the following functions `x` can be either a vector or a number:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2484,7 +2484,7 @@ A spatial vector is similar to a position, but instead using
 absolute world coordinates, it uses *relative* coordinates, relative to
 no particular point.
 
-A vector is a 3x1 matrix (see Matrices).
+A vector is a 3x1 matrix3 (see Matrices).
 
 Internally, it is implemented as a table with the 3 fields
 `x`, `y` and `z`. Example: `{x = 0, y = 1, z = 0}`.
@@ -2519,7 +2519,7 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
 * `vector.dot(v1, v2)`:
     * Returns the dot product of `v1` and `v2`.
-    * Returns the matrix product of the transposed of `v1` and `v2`.
+    * Returns the matrix3 product of the transposed of `v1` and `v2`.
 * `vector.cross(v1, v2)`:
     * Returns the cross product of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
@@ -2552,55 +2552,55 @@ Matrices
 Minetest has helpers for 3x3 matrices.
 Matrices can be used for rotation.
 
-* `matrix.new()`:
-    * Returns a matrix filled with zeros.
-* `matrix.new(m_11, m_12, m_13, m_21, m_22, m_23, m_31, m_32, m_33)`:
-    * Returns a matrix:
+* `matrix3.new()`:
+    * Returns a matrix3 filled with zeros.
+* `matrix3.new(m_11, m_12, m_13, m_21, m_22, m_23, m_31, m_32, m_33)`:
+    * Returns a matrix3:
       ```
       M = {m_11, m_12, m_13,
            m_21, m_22, m_23,
            m_31, m_32, m_33}
       ```
-* `matrix.new(m)`:
-    * A copy of the matrix `m` is returned.
-* `matrix.identity`:
-    * This is the identity matrix. Do not modify it.
-* `matrix.apply(m, func)`:
-    * Returns a matrix where the function `func` has been applied to each
+* `matrix3.new(m)`:
+    * A copy of the matrix3 `m` is returned.
+* `matrix3.identity`:
+    * This is the identity matrix3. Do not modify it.
+* `matrix3.apply(m, func)`:
+    * Returns a matrix3 where the function `func` has been applied to each
       component.
-* `matrix.equals(m1, m2)`:
+* `matrix3.equals(m1, m2)`:
     * Returns a boolean, `true` if the matrices are identical.
-* `matrix.index(m, l, c)`:
+* `matrix3.index(m, l, c)`:
     * Returns `m[(l - 1) * 3 + c]`.
-* `matrix.add(m1, m2)`:
-    * Returns a new matrix where all components are added each.
-* `matrix.multiply(m, a)`:
-    * Returns the scalar product of the matrix `m` and the scalar `a`.
-* `matrix.multiply(m1, m2)`:
-    * Returns the matrix product of the matrices `m1` and `m2`.
-* `matrix.multiply(m, v)`:
-    * Returns the matrix product of the matrix `m` and the vector `v` as vector.
-* `matrix.tensor_multiply(v1, v2)`:
+* `matrix3.add(m1, m2)`:
+    * Returns a new matrix3 where all components are added each.
+* `matrix3.multiply(m, a)`:
+    * Returns the scalar product of the matrix3 `m` and the scalar `a`.
+* `matrix3.multiply(m1, m2)`:
+    * Returns the matrix3 product of the matrices `m1` and `m2`.
+* `matrix3.multiply(m, v)`:
+    * Returns the matrix3 product of the matrix3 `m` and the vector `v` as vector.
+* `matrix3.tensor_multiply(v1, v2)`:
     * `v1` and `v2` are vectors.
-    * Returns the matrix product of `v1` and the transposed of `v2`.
-* `matrix.transpose(m)`:
+    * Returns the matrix3 product of `v1` and the transposed of `v2`.
+* `matrix3.transpose(m)`:
     * Returns the transposed martix of `m`.
-* `matrix.rotation_around_x(angle)`:
+* `matrix3.rotation_around_x(angle)`:
     * `angle` is given in radians.
-    * Returns a rotation matrix around the x-axis.
-* `matrix.rotation_around_y(angle)`:
+    * Returns a rotation matrix3 around the x-axis.
+* `matrix3.rotation_around_y(angle)`:
     * `angle` is given in radians.
-    * Returns a rotation matrix around the y-axis.
-* `matrix.rotation_around_z(angle)`:
+    * Returns a rotation matrix3 around the y-axis.
+* `matrix3.rotation_around_z(angle)`:
     * `angle` is given in radians.
-    * Returns a rotation matrix around the z-axis.
-* `matrix.rotation_around_vector(v, angle)`:
+    * Returns a rotation matrix3 around the z-axis.
+* `matrix3.rotation_around_vector(v, angle)`:
     * `angle` is given in radians.
-    * Returns a rotation matrix around an axis in the direction of `v`.
-* `matrix.to_yaw_pitch_roll(m)`:
+    * Returns a rotation matrix3 around an axis in the direction of `v`.
+* `matrix3.to_yaw_pitch_roll(m)`:
     * Returns a vector filled with euler angles `{x = pitch, y = yaw, z = roll}`.
-* `matrix.from_yaw_pitch_roll(v)`:
-    * Returns a matrix where the euler angles given in `v` were applied.
+* `matrix3.from_yaw_pitch_roll(v)`:
+    * Returns a matrix3 where the euler angles given in `v` were applied.
 
 
 
@@ -4515,13 +4515,13 @@ Item handling
 * `minetest.facedir_to_dir(facedir)`
     * Convert a facedir back into a vector aimed directly out the "back" of a
       node.
-* `minetest.facedir_to_matrix(facedir[, nocopy])`
-    * Convert a facedir into a rotation matrix. Also see Matrices.
+* `minetest.facedir_to_matrix3(facedir[, nocopy])`
+    * Convert a facedir into a rotation matrix3. Also see Matrices.
     * `nocopy` is `false` by default. If you set it to `true`, a reference is
       returned that must not be edited. However, this is faster as it does not
       involve copying.
-* `minetest.matrix_to_facedir(matrix)`
-    * Convert a matrix back to a facedir.
+* `minetest.matrix3_to_facedir(matrix3)`
+    * Convert a matrix3 back to a facedir.
     * Returns `nil` if there is no suitable value.
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for
@@ -4529,13 +4529,13 @@ Item handling
 * `minetest.wallmounted_to_dir(wallmounted)`
     * Convert a wallmounted value back into a vector aimed directly out the
       "back" of a node.
-* `minetest.wallmounted_to_matrix(wallmounted[, nocopy])`
-    * Convert a wallmounted into a rotation matrix. Also see Matrices.
+* `minetest.wallmounted_to_matrix3(wallmounted[, nocopy])`
+    * Convert a wallmounted into a rotation matrix3. Also see Matrices.
     * `nocopy` is `false` by default. If you set it to `true`, a reference is
       returned that must not be edited. However, this is faster as it does not
       involve copying.
-* `minetest.matrix_to_wallmounted(matrix)`
-    * Convert a matrix back to a wallmounted.
+* `minetest.matrix3_to_wallmounted(matrix3)`
+    * Convert a matrix3 back to a wallmounted.
     * Returns `nil` if there is no suitable value.
 * `minetest.dir_to_yaw(dir)`
     * Convert a vector into a yaw (angle)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2484,6 +2484,8 @@ A spatial vector is similar to a position, but instead using
 absolute world coordinates, it uses *relative* coordinates, relative to
 no particular point.
 
+A vector is a 3x1 matrix (see Matrices).
+
 Internally, it is implemented as a table with the 3 fields
 `x`, `y` and `z`. Example: `{x = 0, y = 1, z = 0}`.
 
@@ -2515,6 +2517,9 @@ For the following functions, `v`, `v1`, `v2` are vectors,
     * Returns a boolean, `true` if the vectors are identical.
 * `vector.sort(v1, v2)`:
     * Returns in order minp, maxp vectors of the cuboid defined by `v1`, `v2`.
+* `vector.dot(v1, v2)`:
+    * Returns the dot product of `v1` and `v2`.
+    * Returns the matrix product of the transposed of `v1` and `v2`.
 * `vector.angle(v1, v2)`:
     * Returns the angle between `v1` and `v2` in radians.
 * `vector.dot(v1, v2)`
@@ -2536,6 +2541,55 @@ For the following functions `x` can be either a vector or a number:
     * Returns a scaled vector or Schur product.
 * `vector.divide(v, x)`:
     * Returns a scaled vector or Schur quotient.
+
+
+
+
+Matrices
+========
+Minetest has helpers for 3x3 matrices.
+Matrices can be used for rotation.
+
+* `matrix.new()`:
+    * returns a matrix filled with zeros
+* `matrix.new(m_11, m_12, m_13, m_21, m_22, m_23, m_31, m_32, m_33)`:
+    * returns a matrix
+      M = {m_11, m_12, m_13,
+           m_21, m_22, m_23,
+           m_31, m_32, m_33}
+* `matrix.new(m)`:
+    * A copy of the matrix `m` is returned.
+* `matrix.index(m, l, c)`:
+    * Returns `m[(l - 1) * 3 + c]`.
+* `matrix.add(m1, m2)`:
+    * Returns a new matrix where all components are added each.
+* `matrix.multiply(m, a)`:
+    * Returns the scalar product of the matrix `m` and the scalar `a`.
+* `matrix.multiply(m1, m2)`:
+    * Returns the matrix product of the matrices `m1` and `m2`.
+* `matrix.multiply(m, v)`:
+    * Returns the matrix product of the matrix `m` and the vector `v` as vector.
+* `matrix.tensor_multiply(v1, v2)`:
+    * `v1` and `v2` are vectors.
+    * Returns the matrix product of `v1` and the transposed of `v2`.
+* `matrix.transpose(m)`:
+    * Returns the transposed martix of `m`.
+* `matrix.rotation_around_x(angle)`:
+    * `angle` is given in radians.
+    * Returns a rotation matrix around the x-axis.
+* `matrix.rotation_around_y(angle)`:
+    * `angle` is given in radians.
+    * Returns a rotation matrix around the y-axis.
+* `matrix.rotation_around_z(angle)`:
+    * `angle` is given in radians.
+    * Returns a rotation matrix around the z-axis.
+* `matrix.rotation_around_vector(v, angle)`:
+    * `angle` is given in radians.
+    * Returns a rotation matrix around an axis in the direction of `v`.
+* `matrix.to_yaw_pitch_roll(m)`:
+    * Returns a vector `{x = pitch, y = yaw, z = roll}`.
+* `matrix.from_yaw_pitch_roll(v)`:
+    * bla
 
 
 
@@ -4449,12 +4503,22 @@ Item handling
 * `minetest.facedir_to_dir(facedir)`
     * Convert a facedir back into a vector aimed directly out the "back" of a
       node.
+* `minetest.facedir_to_matrix(facedir)`
+    * Convert a facedir into a rotation matrix. Also see Matrices.
+* `minetest.matrix_to_facedir(matrix)`
+    * Convert a matrix back to a facedir.
+    * Returns `nil` if there is no suitable value.
 * `minetest.dir_to_wallmounted(dir)`
     * Convert a vector to a wallmounted value, used for
       `paramtype2="wallmounted"`.
 * `minetest.wallmounted_to_dir(wallmounted)`
     * Convert a wallmounted value back into a vector aimed directly out the
       "back" of a node.
+* `minetest.wallmounted_to_matrix(wallmounted)`
+    * Convert a wallmounted into a rotation matrix. Also see Matrices.
+* `minetest.matrix_to_wallmounted(matrix)`
+    * Convert a matrix back to a wallmounted.
+    * Returns `nil` if there is no suitable value.
 * `minetest.dir_to_yaw(dir)`
     * Convert a vector into a yaw (angle)
 * `minetest.yaw_to_dir(yaw)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2585,6 +2585,10 @@ Matrices can be used for rotation.
     * Returns the matrix product of `v1` and the transpose of `v2`.
 * `matrix3.transpose(m)`:
     * Returns the transpose martix of `m`.
+* `matrix3.determinant(m)`:
+    * Returns the determinant martix of `m`.
+* `matrix3.invert(m)`:
+    * Returns the inverted martix of `m` or `false` if there is no inverted matrix.
 * `matrix3.rotation_around_x(angle)`:
     * `angle` is given in radians.
     * Returns a rotation matrix3 around the x-axis.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2625,6 +2625,7 @@ Helper functions
     * If the absolute value of `x` is within the `tolerance` or `x` is NaN,
       `0` is returned.
 * `math.factorial(x)`: returns the factorial of `x`
+* `math.round(x)`: returns the nearest integer to `x`
 * `string.split(str, separator, include_empty, max_splits, sep_is_pattern)`
     * `separator`: string, default: `","`
     * `include_empty`: boolean, default: `false`


### PR DESCRIPTION
# matrices

#### summary
This PR adds helpers for using 3x3 matrices to builtin in lua.

#### what the helpers can do
These include not only operations like multiplying, adding or transposing matrices, but also making facedir or wallmounted values to rotation matrices and vice versa, getting rotation matrices for rotations around coordinate axes or around any given vector and conversion to and from euler angle vectors used for `obj:set_rotation(…)`.
The matrices can be used in modding for any vector transformation like rotating, scaling, ….

#### usecases
Usecases in detail:
- Mods like mesecons (or pipeworks or etc.) can rotate their "rules" easily.
- Objects can be rotated easily. Example: Rotate falling nodes in facedir orientation.
- Selection- and collisionboxes can be rotated easily.
- `fine_pointed` positions can be rotated.
- Other screwdrivers can be made very easily.
- Much more…

#### where I got the information for calculating and co. from
I got much information for making this PR from wikipedia, ~~are there problems with licencing?~~ (Edit: [no](http://irc.minetest.net/minetest-dev/2019-05-12#i_5543043).)
~~Also I used [this](http://www.gregslabaugh.net/publications/euler.pdf) as source (I got the calculations the same way as described there, I could show you a pdf, probably).~~
[This paper](https://www.semanticscholar.org/paper/Extracting-Euler-Angles-from-a-Rotation-Matrix-Day/668137fa4b875d890f446e689eea1e334bcf6bf6) was used. And [here](https://github.com/minetest/minetest/files/3170051/to_yaw_roll_pitch_show.pdf) is a pdf made by myself for you.

#### testing
Here is a mod that might help you to test everything: https://github.com/DS-Minetest/matrix_test
Play around with its code yourself.

#### some notes
Note that minetest has a left-handed coordinate system. Wikipedia says that these rotations will make rotations clockwise. You can get the rotation direction around a vector or an axis with the left hand rule.
The euler angles however are counter clockwise.
~~I could make it so that the rotation can be gotten with the right hand rule, if you want so. You have to decide.~~
~~I think, there might have been something else that I want you to decide upon, but I don't remember.~~
~~Edit: Should degree instead of radians be used?~~ Edit: [Q&A in irc](http://irc.minetest.net/minetest-dev/2019-05-12#i_5543025), it's ok as it is now.

(Btw. I found an interesting bug(?) in minetest's set_rotation while testing: there is always more than one way to rotate an object with euler angles, if you swap from one to another, you can see the object doing something weird at a moment. I guess this is because the anlges are not sent at once but each on its own? Try secondary using with the test item of the test mod I linked and wait and look.)

#### relations to other issues and PRs
Closes #7478.