### PR TITLE
Define operators == and != for ItemStack

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -508,11 +508,9 @@ bool InventoryList::operator == (const InventoryList &other) const
 		return false;
 	if(m_name != other.m_name)
 		return false;
-	for(u32 i = 0; i < m_items.size(); i++)
-	{
-		if(m_items[i] != other.m_items[i])
+	for (u32 i = 0; i < m_items.size(); i++)
+		if (m_items[i] != other.m_items[i])
 			return false;
-	}
 
 	return true;
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -508,12 +508,9 @@ bool InventoryList::operator == (const InventoryList &other) const
 		return false;
 	if(m_name != other.m_name)
 		return false;
-	for(u32 i=0; i<m_items.size(); i++)
+	for(u32 i = 0; i < m_items.size(); i++)
 	{
-		ItemStack s1 = m_items[i];
-		ItemStack s2 = other.m_items[i];
-		if(s1.name != s2.name || s1.wear!= s2.wear || s1.count != s2.count ||
-				s1.metadata != s2.metadata)
+		if(m_items[i] != other.m_items[i])
 			return false;
 	}
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -41,7 +41,7 @@ struct ItemStack
 
 	// Serialization
 	void serialize(std::ostream &os) const;
-	// Deserialization.  Pass itemdef unless you don't want aliases resolved.
+	// Deserialization. Pass itemdef unless you don't want aliases resolved.
 	void deSerialize(std::istream &is, IItemDefManager *itemdef = NULL);
 	void deSerialize(const std::string &s, IItemDefManager *itemdef = NULL);
 
@@ -160,6 +160,19 @@ struct ItemStack
 
 	// Similar to takeItem, but keeps this ItemStack intact.
 	ItemStack peekItem(u32 peekcount) const;
+
+	bool operator ==(const ItemStack &s) const
+	{
+		return (this->name     == s.name &&
+				this->count    == s.count &&
+				this->wear     == s.wear &&
+				this->metadata == s.metadata);
+	}
+
+	bool operator !=(const ItemStack &s) const
+	{
+		return !(*this == s);
+	}
 
 	/*
 		Properties


### PR DESCRIPTION
- `==` operator returns `true` if the name, count, wear, _and_ metadata of the two stacks are the same.
- `!=` operator uses `==` internally, and returns the inverse of the result. i.e. `return !(s1 == s2);`

I used the following regex pattern to check for itemstack comparisons, and couldn't find any:
```regex
\w+(->|\.)name != \w+(->|\.)name
```

Therefore, this PR is complete.

Use-cases:

- ItemStack comparison for whatever reason :)
- A new API method `ItemStack:equals` could be implemented later on.

See IRC logs for related discussion - http://irc.minetest.net/minetest-dev/2019-05-05#i_5540154