### PR TITLE
Revert e6a9e60

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -311,7 +311,6 @@ bool ItemStack::itemFits(ItemStack newitem,
 		newitem.clear();
 	}
 	// Else the item does not fit fully. Return the rest.
-	// the rest.
 	else
 	{
 		u16 freespace = freeSpace(itemdef);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -257,17 +257,8 @@ ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		const u16 stackMax = newitem.getStackMax(itemdef);
-
 		*this = newitem;
-
-		// If the item fits fully, delete it
-		if (count <= stackMax) {
-			newitem.clear();
-		} else { // Else the item does not fit fully. Return the rest.
-			count = stackMax;
-			newitem.remove(count);
-		}
+		newitem.clear();
 	}
 	// If item name or metadata differs, bail out
 	else if (name != newitem.name
@@ -306,14 +297,7 @@ bool ItemStack::itemFits(ItemStack newitem,
 	// If this is an empty item, it's an easy job.
 	else if(empty())
 	{
-		const u16 stackMax = newitem.getStackMax(itemdef);
-
-		// If the item fits fully, delete it
-		if (newitem.count <= stackMax) {
-			newitem.clear();
-		} else { // Else the item does not fit fully. Return the rest.
-			newitem.remove(stackMax);
-		}
+		newitem.clear();
 	}
 	// If item name or metadata differs, bail out
 	else if (name != newitem.name
@@ -327,6 +311,7 @@ bool ItemStack::itemFits(ItemStack newitem,
 		newitem.clear();
 	}
 	// Else the item does not fit fully. Return the rest.
+	// the rest.
 	else
 	{
 		u16 freespace = freeSpace(itemdef);
@@ -335,6 +320,7 @@ bool ItemStack::itemFits(ItemStack newitem,
 
 	if(restitem)
 		*restitem = newitem;
+
 	return newitem.empty();
 }
 


### PR DESCRIPTION
Revert commit "Inventory: Make addItem for empty ItemStacks respect max stack size".

See #8518 and https://github.com/minetest/minetest/pull/6159#issuecomment-322027220

Tested, this fixes #8518.