### PR TITLE
Move HTTP request logging to infostream

### DIFF
--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -94,7 +94,7 @@ int ModApiHttp::l_http_fetch_async(lua_State *L)
 	HTTPFetchRequest req;
 	read_http_fetch_request(L, req);
 
-	actionstream << "Mod performs HTTP request with URL " << req.url << std::endl;
+	infostream << "Mod performs HTTP request with URL " << req.url << std::endl;
 	httpfetch_async(req);
 
 	// Convert handle to hex string since lua can't handle 64-bit integers


### PR DESCRIPTION
Closes #8525. I too don't think this is important enough to be logged at `action` level.