### PR TITLE
Add scrollbaroptions FormSpec element

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2368,6 +2368,9 @@ Elements
     * scrolled, defaults to `10`
 * `largestep=<int>`
     * Sets scrollbar step value when the bar itself is clicked, defaults to `100`
+* `pagesize=<int>`
+    * Sets size of a single screen for the scrollbar. Setting this to -1 lets the
+    * scrollbar calculate this automatically.
 
 ### `table[<X>,<Y>;<W>,<H>;<name>;<cell 1>,<cell 2>,...,<cell n>;<selected idx>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2362,6 +2362,7 @@ Elements
     * Sets scrollbar minimum value, defaults to `0`
 * `max=<int>`
     * Sets scrollbar maximum value, defaults to `1000`
+	* If the max is equal to the min, the scrollbar will be disabled
 * `smallstep=<int>`
     * Sets scrollbar step value when the arrows are clicked, defaults to `10`
 * `largestep=<int>`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2359,18 +2359,20 @@ Elements
 ### `scrollbaroptions[opt1;opt2;...]`
 * Sets options for all following `scrollbar[]` elements
 * `min=<int>`
-    * Sets scrollbar minimum value, defaults to `0`
+    * Sets scrollbar minimum value, defaults to `0`.
 * `max=<int>`
-    * Sets scrollbar maximum value, defaults to `1000`
-    * If the max is equal to the min, the scrollbar will be disabled
+    * Sets scrollbar maximum value, defaults to `1000`.
+      If the max is equal to the min, the scrollbar will be disabled.
 * `smallstep=<int>`
     * Sets scrollbar step value when the arrows are clicked or the mouse wheel is
-    * scrolled, defaults to `10`
+      scrolled, defaults to `10`.
 * `largestep=<int>`
-    * Sets scrollbar step value when the bar itself is clicked, defaults to `100`
-* `pagesize=<int>`
-    * Sets size of a single screen for the scrollbar. Setting this to -1 lets the
-    * scrollbar calculate this automatically.
+    * Sets scrollbar step value when the bar itself is clicked, defaults to `100`.
+* `thumbsize=<int>`
+    * Sets size of the thumb on the scrollbar. Size is calculated in the number of
+      units the scrollbar spans out of the range of the scrollbar values.
+      Example: If a scrollbar has a min of 1 and a max of 1000, a thumbsize of 10
+      would span a tenth of the scrollbar space.
 
 ### `table[<X>,<Y>;<W>,<H>;<name>;<cell 1>,<cell 2>,...,<cell n>;<selected idx>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2365,14 +2365,17 @@ Elements
       If the max is equal to the min, the scrollbar will be disabled.
 * `smallstep=<int>`
     * Sets scrollbar step value when the arrows are clicked or the mouse wheel is
-      scrolled, defaults to `10`.
+      scrolled.
+    * If this is set to a negative number, the value will be reset to `10`.
 * `largestep=<int>`
-    * Sets scrollbar step value when the bar itself is clicked, defaults to `100`.
+    * Sets scrollbar step value when the bar itself is clicked.
+    * If this is set to a negative number, the value will be reset to `100`.
 * `thumbsize=<int>`
     * Sets size of the thumb on the scrollbar. Size is calculated in the number of
-      units the scrollbar spans out of the range of the scrollbar values.
-      Example: If a scrollbar has a min of 1 and a max of 1000, a thumbsize of 10
+      units the thumb spans out of the range of the scrollbar values.
+    * Example: If a scrollbar has a `min` of 1 and a `max` of 100, a thumbsize of 10
       would span a tenth of the scrollbar space.
+    * If this is set to zero or less, the value will be reset to `1`.
 
 ### `table[<X>,<Y>;<W>,<H>;<name>;<cell 1>,<cell 2>,...,<cell n>;<selected idx>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2368,7 +2368,7 @@ Elements
       scrolled.
     * If this is set to a negative number, the value will be reset to `10`.
 * `largestep=<int>`
-    * Sets scrollbar step value when the bar itself is clicked.
+    * Sets scrollbar step value used by page up and page down.
     * If this is set to a negative number, the value will be reset to `100`.
 * `thumbsize=<int>`
     * Sets size of the thumb on the scrollbar. Size is calculated in the number of

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2346,15 +2346,26 @@ Elements
 
 ### `scrollbar[<X>,<Y>;<W>,<H>;<orientation>;<name>;<value>]`
 
-* Show a scrollbar
+* Show a scrollbar using options defined by the previous `scrollbaroptions[]`
 * There are two ways to use it:
     1. handle the changed event (only changed scrollbar is available)
     2. read the value on pressing a button (all scrollbars are available)
 * `orientation`:  `vertical`/`horizontal`
 * Fieldname data is transferred to Lua
-* Value this trackbar is set to (`0`-`1000`)
+* Value of this trackbar is set to (`0`-`1000`) by default
 * See also `minetest.explode_scrollbar_event`
   (main menu: `core.explode_scrollbar_event`).
+
+### `scrollbaroptions[opt1;opt2;...]`
+* Sets options for all following `scrollbar[]` elements
+* `min=<int>`
+    * Sets scrollbar minimum value, defaults to `0`
+* `max=<int>`
+    * Sets scrollbar maximum value, defaults to `1000`
+* `smallstep=<int>`
+    * Sets scrollbar step value when the arrows are clicked, defaults to `10`
+* `largestep=<int>`
+    * Sets scrollbar step value when the bar itself is clicked, defaults to `100`
 
 ### `table[<X>,<Y>;<W>,<H>;<name>;<cell 1>,<cell 2>,...,<cell n>;<selected idx>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2362,7 +2362,7 @@ Elements
     * Sets scrollbar minimum value, defaults to `0`
 * `max=<int>`
     * Sets scrollbar maximum value, defaults to `1000`
-	* If the max is equal to the min, the scrollbar will be disabled
+    * If the max is equal to the min, the scrollbar will be disabled
 * `smallstep=<int>`
     * Sets scrollbar step value when the arrows are clicked, defaults to `10`
 * `largestep=<int>`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2376,6 +2376,9 @@ Elements
     * Example: If a scrollbar has a `min` of 1 and a `max` of 100, a thumbsize of 10
       would span a tenth of the scrollbar space.
     * If this is set to zero or less, the value will be reset to `1`.
+* `arrows=<show/hide/default>`
+    * Whether to show the arrow buttons on the scrollbar. `default` hides the arrows
+      when the scrollbar gets too small, but shows them otherwise.
 
 ### `table[<X>,<Y>;<W>,<H>;<name>;<cell 1>,<cell 2>,...,<cell n>;<selected idx>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2364,7 +2364,8 @@ Elements
     * Sets scrollbar maximum value, defaults to `1000`
     * If the max is equal to the min, the scrollbar will be disabled
 * `smallstep=<int>`
-    * Sets scrollbar step value when the arrows are clicked, defaults to `10`
+    * Sets scrollbar step value when the arrows are clicked or the mouse wheel is
+    * scrolled, defaults to `10`
 * `largestep=<int>`
     * Sets scrollbar step value when the bar itself is clicked, defaults to `100`
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2651,7 +2651,6 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 
 	if (type == "scrollbaroptions") {
 		parseScrollBarOptions(data, description);
-
 		return;
 	}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -623,6 +623,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 		auto style = getStyleForElement("scrollbar", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setArrowsVisible(data->scrollBarOptions.showArrows);
 
 		s32 max = data->scrollBarOptions.max;
 		s32 min = data->scrollBarOptions.min;
@@ -647,7 +648,8 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		m_fields.push_back(spec);
 		return;
 	}
-	errorstream<< "Invalid scrollbar element(" << parts.size() << "): '" << element << "'"  << std::endl;
+	errorstream << "Invalid scrollbar element(" << parts.size() << "): '" << element
+		<< "'" << std::endl;
 }
 
 void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string &element)
@@ -669,26 +671,37 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 			continue; // Go to next option
 		}
 
-		int value = stoi(options[1]);
-
 		if (options[0] == "max") {
-			data->scrollBarOptions.max = value;
+			data->scrollBarOptions.max = stoi(options[1]);
 			continue;
 		}
-		if (options[0] == "min") {
-			data->scrollBarOptions.min = value;
+		else if (options[0] == "min") {
+			data->scrollBarOptions.min = stoi(options[1]);
 			continue;
 		}
-		if (options[0] == "smallstep") {
+		else if (options[0] == "smallstep") {
+			int value = stoi(options[1]);
 			data->scrollBarOptions.smallStep = value < 0 ? 10 : value;
 			continue;
 		}
-		if (options[0] == "largestep") {
+		else if (options[0] == "largestep") {
+			int value = stoi(options[1]);
 			data->scrollBarOptions.largeStep = value < 0 ? 100 : value;
 			continue;
 		}
-		if (options[0] == "thumbsize") {
+		else if (options[0] == "thumbsize") {
+			int value = stoi(options[1]);
 			data->scrollBarOptions.thumbSize = value <= 0 ? 1 : value;
+			continue;
+		}
+		else if (options[0] == "arrows") {
+			std::string value = trim(options[1]);
+			if (value == "hide")
+				data->scrollBarOptions.showArrows = 0;
+			else if (value == "show")
+				data->scrollBarOptions.showArrows = 1;
+			else // Auto hide/show
+				data->scrollBarOptions.showArrows = 2;
 			continue;
 		}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -618,17 +618,62 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		auto style = getStyleForElement("scrollbar", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
-		e->setMax(1000);
-		e->setMin(0);
+		e->setMax(data->scrollBarOptions.max);
+		e->setMin(data->scrollBarOptions.min);
+
 		e->setPos(stoi(parts[4]));
-		e->setSmallStep(10);
-		e->setLargeStep(100);
+		e->setSmallStep(data->scrollBarOptions.smallStep);
+		e->setLargeStep(data->scrollBarOptions.largeStep);
 
 		m_scrollbars.emplace_back(spec,e);
 		m_fields.push_back(spec);
 		return;
 	}
 	errorstream<< "Invalid scrollbar element(" << parts.size() << "): '" << element << "'"  << std::endl;
+}
+
+void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string &element)
+{
+	std::vector<std::string> parts = split(element, ';');
+
+	if (parts.size() > 0) {
+		for (unsigned int i = 0; i < parts.size(); i++) {
+
+			std::vector<std::string> options = split(parts[i], '=');
+
+			if (options.size() != 2) {
+				errorstream << "Invalid scrollbaroptions option syntax: '" <<
+					element << "'" << std::endl;
+				continue; // Go to next option
+			}
+
+			int value = stoi(options[1]);
+
+			if (options[0] == "max") {
+				data->scrollBarOptions.max = value;
+				continue;
+			}
+			if (options[0] == "min") {
+				data->scrollBarOptions.min = value;
+				continue;
+			}
+			if (options[0] == "smallstep") {
+				data->scrollBarOptions.smallStep = value;
+				continue;
+			}
+			if (options[0] == "largestep") {
+				data->scrollBarOptions.largeStep = value;
+				continue;
+			}
+
+			errorstream << "Invalid scrollbaroptions option(" << options[0] <<
+				"): '" << element << "'" << std::endl;
+		}
+		return;
+	}
+
+	errorstream << "Invalid scrollbaroptions element(" << parts.size() << "): '" <<
+		element << "'"  << std::endl;
 }
 
 void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
@@ -2581,6 +2626,12 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 
 	if (type == "style_type") {
 		parseStyle(data, description, true);
+		return;
+	}
+
+	if (type == "scrollbaroptions") {
+		parseScrollBarOptions(data, description);
+
 		return;
 	}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -625,6 +625,16 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		e->setSmallStep(data->scrollBarOptions.smallStep);
 		e->setLargeStep(data->scrollBarOptions.largeStep);
 
+		if (scrollBarOptions.pageSize < 0) {
+			if (is_horizontal) {
+				e->setPageSize(dim.X);
+			} else {
+				e->setPageSize(dim.Y);
+			}
+		} else {
+			e->setPageSize(data->scrollBarOptions.pageSize);
+		}
+
 		m_scrollbars.emplace_back(spec,e);
 		m_fields.push_back(spec);
 		return;
@@ -648,25 +658,38 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 			}
 
 			int value = stoi(options[1]);
+			int option = options[0];
 
-			if (options[0] == "max") {
+			if (option == "max") {
 				data->scrollBarOptions.max = value;
 				continue;
 			}
-			if (options[0] == "min") {
+			if (option == "min") {
 				data->scrollBarOptions.min = value;
 				continue;
 			}
-			if (options[0] == "smallstep") {
-				data->scrollBarOptions.smallStep = value;
+			if (option == "smallstep") {
+				if (value < 0) {
+					data->scrollBarOptions.smallStep = 10;
+				} else {
+					data->scrollBarOptions.smallStep = value;
+				}
 				continue;
 			}
-			if (options[0] == "largestep") {
-				data->scrollBarOptions.largeStep = value;
+			if (option == "largestep") {
+				if (value < 0) {
+					data->scrollBarOptions.largeStep = 100;
+				} else {
+					data->scrollBarOptions.largeStep = value;
+				}
+				continue;
+			}
+			if (option == "pagesize") {
+				data->scrollBarOptions.pageSize = value;
 				continue;
 			}
 
-			errorstream << "Invalid scrollbaroptions option(" << options[0] <<
+			errorstream << "Invalid scrollbaroptions option(" << option <<
 				"): '" << element << "'" << std::endl;
 		}
 		return;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -143,6 +143,10 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 		tooltip_rect_it.first->drop();
 	}
 
+	for (auto &scrollbar_it : m_scrollbars) {
+		scrollbar_it.second->drop();
+	}
+
 	delete m_selected_item;
 	delete m_form_src;
 	delete m_text_dst;
@@ -649,57 +653,47 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 {
 	std::vector<std::string> parts = split(element, ';');
 
-	if (parts.size() > 0) {
-		for (unsigned int i = 0; i < parts.size(); i++) {
-
-			std::vector<std::string> options = split(parts[i], '=');
-
-			if (options.size() != 2) {
-				warningstream << "Invalid scrollbaroptions option syntax: '" <<
-					element << "'" << std::endl;
-				continue; // Go to next option
-			}
-
-			int value = stoi(options[1]);
-
-			if (options[0] == "max") {
-				data->scrollBarOptions.max = value;
-				continue;
-			}
-			if (options[0] == "min") {
-				data->scrollBarOptions.min = value;
-				continue;
-			}
-			if (options[0] == "smallstep") {
-				if (value < 0)
-					data->scrollBarOptions.smallStep = 10;
-				else
-					data->scrollBarOptions.smallStep = value;
-				continue;
-			}
-			if (options[0] == "largestep") {
-				if (value < 0)
-					data->scrollBarOptions.largeStep = 100;
-				else
-					data->scrollBarOptions.largeStep = value;
-				continue;
-			}
-			if (options[0] == "thumbsize") {
-				if (value < 0)
-					data->scrollBarOptions.thumbSize = 1;
-				else
-					data->scrollBarOptions.thumbSize = value;
-				continue;
-			}
-
-			warningstream << "Invalid scrollbaroptions option(" << options[0] <<
-				"): '" << element << "'" << std::endl;
-		}
+	if (parts.size() == 0) {
+		warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '" <<
+			element << "'"  << std::endl;
 		return;
 	}
 
-	warningstream << "Invalid scrollbaroptions element(" << parts.size() << "): '" <<
-		element << "'"  << std::endl;
+	for (const std::string &i : parts) {
+		std::vector<std::string> options = split(i, '=');
+
+		if (options.size() != 2) {
+			warningstream << "Invalid scrollbaroptions option syntax: '" <<
+				element << "'" << std::endl;
+			continue; // Go to next option
+		}
+
+		int value = stoi(options[1]);
+
+		if (options[0] == "max") {
+			data->scrollBarOptions.max = value;
+			continue;
+		}
+		if (options[0] == "min") {
+			data->scrollBarOptions.min = value;
+			continue;
+		}
+		if (options[0] == "smallstep") {
+			data->scrollBarOptions.smallStep = value < 0 ? 10 : value;
+			continue;
+		}
+		if (options[0] == "largestep") {
+			data->scrollBarOptions.largeStep = value < 0 ? 100 : value;
+			continue;
+		}
+		if (options[0] == "thumbsize") {
+			data->scrollBarOptions.thumbSize = value <= 0 ? 1 : value;
+			continue;
+		}
+
+		warningstream << "Invalid scrollbaroptions option(" << options[0] <<
+			"): '" << element << "'" << std::endl;
+	}
 }
 
 void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -24,8 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include <limits>
 #include "guiFormSpecMenu.h"
-#include "guiTable.h"
 #include "guiScrollBar.h"
+#include "guiTable.h"
 #include "constants.h"
 #include "gamedef.h"
 #include "client/keycode.h"

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -125,7 +125,7 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 {
 	removeChildren();
 
-	for (auto &table_it : m_tables) {
+	for (auto &table_it : m_tables)
 		table_it.second->drop();
 	}
 	for (auto &inventorylist_it : m_inventorylists) {
@@ -142,10 +142,6 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 	}
 	for (auto &tooltip_rect_it : m_tooltip_rects) {
 		tooltip_rect_it.first->drop();
-	}
-
-	for (auto &scrollbar_it : m_scrollbars) {
-		scrollbar_it.second->drop();
 	}
 
 	delete m_selected_item;
@@ -2710,7 +2706,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// Remove children
 	removeChildren();
 
-	for (auto &table_it : m_tables) {
+	for (auto &table_it : m_tables)
 		table_it.second->drop();
 	}
 	for (auto &inventorylist_it : m_inventorylists) {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -684,11 +684,11 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 		} else if (options[0] == "arrows") {
 			std::string value = trim(options[1]);
 			if (value == "hide")
-				data->scrollbar_options.arrow_visiblity = HIDE;
+				data->scrollbar_options.arrow_visiblity = GUIScrollBar::HIDE;
 			else if (value == "show")
-				data->scrollbar_options.arrow_visiblity = SHOW;
+				data->scrollbar_options.arrow_visiblity = GUIScrollBar::SHOW;
 			else // Auto hide/show
-				data->scrollbar_options.arrow_visiblity = DEFAULT;
+				data->scrollbar_options.arrow_visiblity = GUIScrollBar::DEFAULT;
 			continue;
 		}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -625,7 +625,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		e->setSmallStep(data->scrollBarOptions.smallStep);
 		e->setLargeStep(data->scrollBarOptions.largeStep);
 
-		if (scrollBarOptions.pageSize < 0) {
+		if (data->scrollBarOptions.pageSize < 0) {
 			if (is_horizontal) {
 				e->setPageSize(dim.X);
 			} else {
@@ -658,17 +658,16 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 			}
 
 			int value = stoi(options[1]);
-			int option = options[0];
 
-			if (option == "max") {
+			if (options[0] == "max") {
 				data->scrollBarOptions.max = value;
 				continue;
 			}
-			if (option == "min") {
+			if (options[0] == "min") {
 				data->scrollBarOptions.min = value;
 				continue;
 			}
-			if (option == "smallstep") {
+			if (options[0] == "smallstep") {
 				if (value < 0) {
 					data->scrollBarOptions.smallStep = 10;
 				} else {
@@ -676,7 +675,7 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 				}
 				continue;
 			}
-			if (option == "largestep") {
+			if (options[0] == "largestep") {
 				if (value < 0) {
 					data->scrollBarOptions.largeStep = 100;
 				} else {
@@ -684,12 +683,12 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 				}
 				continue;
 			}
-			if (option == "pagesize") {
+			if (options[0] == "pagesize") {
 				data->scrollBarOptions.pageSize = value;
 				continue;
 			}
 
-			errorstream << "Invalid scrollbaroptions option(" << option <<
+			errorstream << "Invalid scrollbaroptions option(" << options[0] <<
 				"): '" << element << "'" << std::endl;
 		}
 		return;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -619,26 +619,22 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 		auto style = getStyleForElement("scrollbar", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setArrowsVisible(data->scrollBarOptions.showArrows);
+		e->setArrowsVisible(data->scrollbar_options.arrow_visiblity);
 
-		s32 max = data->scrollBarOptions.max;
-		s32 min = data->scrollBarOptions.min;
+		s32 max = data->scrollbar_options.max;
+		s32 min = data->scrollbar_options.min;
 
 		e->setMax(max);
 		e->setMin(min);
 
 		e->setPos(stoi(parts[4]));
 
-		e->setSmallStep(data->scrollBarOptions.smallStep);
-		e->setLargeStep(data->scrollBarOptions.largeStep);
+		e->setSmallStep(data->scrollbar_options.small_step);
+		e->setLargeStep(data->scrollbar_options.large_step);
 
-		s32 scrollbar_size;
-		if (is_horizontal)
-			scrollbar_size = dim.X;
-		else
-			scrollbar_size = dim.Y;
+		s32 scrollbar_size = is_horizontal ? dim.X : dim.Y;
 
-		e->setPageSize(scrollbar_size * (max-min+1) / data->scrollBarOptions.thumbSize);
+		e->setPageSize(scrollbar_size * (max - min + 1) / data->scrollbar_options.thumb_size);
 
 		m_scrollbars.emplace_back(spec,e);
 		m_fields.push_back(spec);
@@ -668,36 +664,31 @@ void GUIFormSpecMenu::parseScrollBarOptions(parserData* data, const std::string 
 		}
 
 		if (options[0] == "max") {
-			data->scrollBarOptions.max = stoi(options[1]);
+			data->scrollbar_options.max = stoi(options[1]);
 			continue;
-		}
-		else if (options[0] == "min") {
-			data->scrollBarOptions.min = stoi(options[1]);
+		} else if (options[0] == "min") {
+			data->scrollbar_options.min = stoi(options[1]);
 			continue;
-		}
-		else if (options[0] == "smallstep") {
+		} else if (options[0] == "smallstep") {
 			int value = stoi(options[1]);
-			data->scrollBarOptions.smallStep = value < 0 ? 10 : value;
+			data->scrollbar_options.small_step = value < 0 ? 10 : value;
 			continue;
-		}
-		else if (options[0] == "largestep") {
+		} else if (options[0] == "largestep") {
 			int value = stoi(options[1]);
-			data->scrollBarOptions.largeStep = value < 0 ? 100 : value;
+			data->scrollbar_options.large_step = value < 0 ? 100 : value;
 			continue;
-		}
-		else if (options[0] == "thumbsize") {
+		} else if (options[0] == "thumbsize") {
 			int value = stoi(options[1]);
-			data->scrollBarOptions.thumbSize = value <= 0 ? 1 : value;
+			data->scrollbar_options.thumb_size = value <= 0 ? 1 : value;
 			continue;
-		}
-		else if (options[0] == "arrows") {
+		} else if (options[0] == "arrows") {
 			std::string value = trim(options[1]);
 			if (value == "hide")
-				data->scrollBarOptions.showArrows = 0;
+				data->scrollbar_options.arrow_visiblity = HIDE;
 			else if (value == "show")
-				data->scrollBarOptions.showArrows = 1;
+				data->scrollbar_options.arrow_visiblity = SHOW;
 			else // Auto hide/show
-				data->scrollBarOptions.showArrows = 2;
+				data->scrollbar_options.arrow_visiblity = DEFAULT;
 			continue;
 		}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -127,22 +127,16 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 
 	for (auto &table_it : m_tables)
 		table_it.second->drop();
-	}
-	for (auto &inventorylist_it : m_inventorylists) {
+	for (auto &inventorylist_it : m_inventorylists)
 		inventorylist_it.e->drop();
-	}
-	for (auto &checkbox_it : m_checkboxes) {
+	for (auto &checkbox_it : m_checkboxes)
 		checkbox_it.second->drop();
-	}
-	for (auto &scrollbar_it : m_scrollbars) {
+	for (auto &scrollbar_it : m_scrollbars)
 		scrollbar_it.second->drop();
-	}
-	for (auto &background_it : m_backgrounds) {
+	for (auto &background_it : m_backgrounds)
 		background_it->drop();
-	}
-	for (auto &tooltip_rect_it : m_tooltip_rects) {
+	for (auto &tooltip_rect_it : m_tooltip_rects)
 		tooltip_rect_it.first->drop();
-	}
 
 	delete m_selected_item;
 	delete m_form_src;
@@ -2699,22 +2693,16 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	for (auto &table_it : m_tables)
 		table_it.second->drop();
-	}
-	for (auto &inventorylist_it : m_inventorylists) {
+	for (auto &inventorylist_it : m_inventorylists)
 		inventorylist_it.e->drop();
-	}
-	for (auto &checkbox_it : m_checkboxes) {
+	for (auto &checkbox_it : m_checkboxes)
 		checkbox_it.second->drop();
-	}
-	for (auto &scrollbar_it : m_scrollbars) {
+	for (auto &scrollbar_it : m_scrollbars)
 		scrollbar_it.second->drop();
-	}
-	for (auto &background_it : m_backgrounds) {
+	for (auto &background_it : m_backgrounds)
 		background_it->drop();
-	}
-	for (auto &tooltip_rect_it : m_tooltip_rects) {
+	for (auto &tooltip_rect_it : m_tooltip_rects)
 		tooltip_rect_it.first->drop();
-	}
 
 	mydata.size= v2s32(100,100);
 	mydata.screensize = screensize;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -24,6 +24,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sstream>
 #include <limits>
 #include "guiFormSpecMenu.h"
+#include "guiTable.h"
+#include "guiScrollBar.h"
 #include "constants.h"
 #include "gamedef.h"
 #include "client/keycode.h"
@@ -35,7 +37,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <IGUIStaticText.h>
 #include <IGUIFont.h>
 #include <IGUITabControl.h>
-#include "guiScrollBar.h"
 #include "client/renderingengine.h"
 #include "log.h"
 #include "client/tile.h" // ITextureSource
@@ -618,7 +619,7 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		spec.ftype = f_ScrollBar;
 		spec.send  = true;
 		GUIScrollBar *e = new GUIScrollBar(Environment, this, spec.fid, rect,
-				is_horizontal, false);
+				is_horizontal, true);
 
 		auto style = getStyleForElement("scrollbar", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -404,6 +404,7 @@ private:
 			int min = 0;
 			int smallStep = 10;
 			int largeStep = 100;
+			int pageSize = -1;
 		} scrollBarOptions;
 
 		// used to restore table selection/scroll/treeview state

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -37,6 +37,7 @@ class InventoryManager;
 class ISimpleTextureSource;
 class Client;
 class GUIScrollBar;
+enum ScrollBarArrowVisibility;
 
 typedef enum {
 	f_Button,
@@ -402,11 +403,11 @@ private:
 		struct {
 			s32 max = 1000;
 			s32 min = 0;
-			s32 smallStep = 10;
-			s32 largeStep = 100;
-			s32 thumbSize = 1;
-			u8 showArrows = 2;
-		} scrollBarOptions;
+			s32 small_step = 10;
+			s32 large_step = 100;
+			s32 thumb_size = 1;
+			ScrollBarArrowVisibility arrow_visiblity = DEFAULT;
+		} scrollbar_options;
 
 		// used to restore table selection/scroll/treeview state
 		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -398,6 +398,14 @@ private:
 		std::string focused_fieldname;
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
+
+		struct {
+			int max = 1000;
+			int min = 0;
+			int smallStep = 10;
+			int largeStep = 100;
+		} scrollBarOptions;
+
 		// used to restore table selection/scroll/treeview state
 		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
 	} parserData;
@@ -452,6 +460,7 @@ private:
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);
 	void parseScrollBar(parserData* data, const std::string &element);
+	void parseScrollBarOptions(parserData* data, const std::string &element);
 	bool parsePositionDirect(parserData *data, const std::string &element);
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -405,6 +405,7 @@ private:
 			s32 smallStep = 10;
 			s32 largeStep = 100;
 			s32 thumbSize = 1;
+			u8 showArrows = 2;
 		} scrollBarOptions;
 
 		// used to restore table selection/scroll/treeview state

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -37,7 +37,6 @@ class InventoryManager;
 class ISimpleTextureSource;
 class Client;
 class GUIScrollBar;
-enum ScrollBarArrowVisibility;
 
 typedef enum {
 	f_Button,
@@ -406,7 +405,7 @@ private:
 			s32 small_step = 10;
 			s32 large_step = 100;
 			s32 thumb_size = 1;
-			ScrollBarArrowVisibility arrow_visiblity = DEFAULT;
+			GUIScrollBar::ArrowVisibility arrow_visiblity = GUIScrollBar::DEFAULT;
 		} scrollbar_options;
 
 		// used to restore table selection/scroll/treeview state

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventorymanager.h"
 #include "modalMenu.h"
 #include "guiTable.h"
+#include "guiScrollBar.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
 #include "util/string.h"
@@ -400,11 +401,11 @@ private:
 		GUITable::TableColumns table_columns;
 
 		struct {
-			int max = 1000;
-			int min = 0;
-			int smallStep = 10;
-			int largeStep = 100;
-			int thumbSize = 1;
+			s32 max = 1000;
+			s32 min = 0;
+			s32 smallStep = 10;
+			s32 largeStep = 100;
+			s32 thumbSize = 1;
 		} scrollBarOptions;
 
 		// used to restore table selection/scroll/treeview state
@@ -461,7 +462,7 @@ private:
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);
 	void parseScrollBar(parserData* data, const std::string &element);
-	void parseScrollBarOptions(parserData* data, const std::string &element);
+	void parseScrollBarOptions(parserData * data, const std::string &element);
 	bool parsePositionDirect(parserData *data, const std::string &element);
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -27,7 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inventorymanager.h"
 #include "modalMenu.h"
 #include "guiTable.h"
-#include "guiScrollBar.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
 #include "util/string.h"
@@ -462,7 +461,7 @@ private:
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);
 	void parseScrollBar(parserData* data, const std::string &element);
-	void parseScrollBarOptions(parserData * data, const std::string &element);
+	void parseScrollBarOptions(parserData *data, const std::string &element);
 	bool parsePositionDirect(parserData *data, const std::string &element);
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -376,7 +376,7 @@ protected:
 	video::SColor m_default_tooltip_bgcolor;
 	video::SColor m_default_tooltip_color;
 
-	
+
 private:
 	IFormSource        *m_form_src;
 	TextDest           *m_text_dst;
@@ -404,7 +404,7 @@ private:
 			int min = 0;
 			int smallStep = 10;
 			int largeStep = 100;
-			int pageSize = -1;
+			int thumbSize = 1;
 		} scrollBarOptions;
 
 		// used to restore table selection/scroll/treeview state

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -316,6 +316,12 @@ void GUIScrollBar::setPageSize(const s32 &size)
 	setPos(scroll_pos);
 }
 
+void GUIScrollBar::setArrowsVisible(u8 visible)
+{
+	is_arrows_visible = visible;
+	refreshControls();
+}
+
 s32 GUIScrollBar::getPos() const
 {
 	return scroll_pos;
@@ -420,7 +426,22 @@ void GUIScrollBar::refreshControls()
 		down_button->setAlignment(EGUIA_UPPERLEFT, EGUIA_LOWERRIGHT,
 				EGUIA_LOWERRIGHT, EGUIA_LOWERRIGHT);
 	}
-	bool visible = (border_size != 0);
+
+	bool visible;
+	if (is_arrows_visible == 2)
+		visible = (border_size != 0);
+	else if (is_arrows_visible == 0) {
+		visible = false;
+		border_size = 0;
+	}
+	else {
+		visible = true;
+		if (is_horizontal)
+			border_size = RelativeRect.getHeight();
+		else
+			border_size = RelativeRect.getWidth();
+	}
+
 	up_button->setVisible(visible);
 	down_button->setVisible(visible);
 }

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -316,7 +316,7 @@ void GUIScrollBar::setPageSize(const s32 &size)
 	setPos(scroll_pos);
 }
 
-void GUIScrollBar::setArrowsVisible(ScrollBarArrowVisibility visible)
+void GUIScrollBar::setArrowsVisible(ArrowVisibility visible)
 {
 	arrow_visibility = visible;
 	refreshControls();

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -272,7 +272,7 @@ void GUIScrollBar::setPos(const s32 &pos)
 
 	f32 f = core::isnotzero(range()) ? (f32(thumb_area) - f32(thumb_size)) / range()
 					 : 1.0f;
-	draw_center = s32((f32(scroll_pos) * f) + (f32(thumb_size) * 0.5f)) + border_size;
+	draw_center = s32((f32(scroll_pos - min) * f) + (f32(thumb_size) * 0.5f)) + border_size;
 }
 
 void GUIScrollBar::setSmallStep(const s32 &step)

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -272,7 +272,8 @@ void GUIScrollBar::setPos(const s32 &pos)
 
 	f32 f = core::isnotzero(range()) ? (f32(thumb_area) - f32(thumb_size)) / range()
 					 : 1.0f;
-	draw_center = s32((f32(scroll_pos - min) * f) + (f32(thumb_size) * 0.5f)) + border_size;
+	draw_center = s32((f32(scroll_pos - min_pos) * f) + (f32(thumb_size) * 0.5f)) +
+		border_size;
 }
 
 void GUIScrollBar::setSmallStep(const s32 &step)

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -316,9 +316,9 @@ void GUIScrollBar::setPageSize(const s32 &size)
 	setPos(scroll_pos);
 }
 
-void GUIScrollBar::setArrowsVisible(u8 visible)
+void GUIScrollBar::setArrowsVisible(ScrollBarArrowVisibility visible)
 {
-	is_arrows_visible = visible;
+	arrow_visibility = visible;
 	refreshControls();
 }
 
@@ -428,13 +428,12 @@ void GUIScrollBar::refreshControls()
 	}
 
 	bool visible;
-	if (is_arrows_visible == 2)
+	if (arrow_visibility == DEFAULT)
 		visible = (border_size != 0);
-	else if (is_arrows_visible == 0) {
+	else if (arrow_visibility == HIDE) {
 		visible = false;
 		border_size = 0;
-	}
-	else {
+	} else {
 		visible = true;
 		if (is_horizontal)
 			border_size = RelativeRect.getHeight();

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -247,7 +247,7 @@ s32 GUIScrollBar::getPosFromMousePos(const core::position2di &pos) const
 		w = RelativeRect.getHeight() - border_size * 2 - thumb_size;
 		p = pos.Y - AbsoluteRect.UpperLeftCorner.Y - border_size - offset;
 	}
-	return core::isnotzero(range()) ? s32(f32(p) / f32(w) * range()) + min_pos : 0;
+	return core::isnotzero(range()) ? s32(f32(p) / f32(w) * range() + 0.5f) + min_pos : 0;
 }
 
 void GUIScrollBar::setPos(const s32 &pos)

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -17,6 +17,12 @@ the arrow buttons where there is insufficient space.
 using namespace irr;
 using namespace gui;
 
+enum ScrollBarArrowVisibility {
+	HIDE,
+	SHOW,
+	DEFAULT
+};
+
 class GUIScrollBar : public IGUIElement
 {
 public:
@@ -39,7 +45,7 @@ public:
 	void setLargeStep(const s32 &step);
 	void setPos(const s32 &pos);
 	void setPageSize(const s32 &size);
-	void setArrowsVisible(u8 visible);
+	void setArrowsVisible(ScrollBarArrowVisibility visible);
 
 private:
 	void refreshControls();
@@ -48,7 +54,7 @@ private:
 
 	IGUIButton *up_button;
 	IGUIButton *down_button;
-	u8 is_arrows_visible = 2;
+	ScrollBarArrowVisibility arrow_visibility = DEFAULT;
 	bool is_dragging;
 	bool is_horizontal;
 	bool is_auto_scaling;

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -39,6 +39,7 @@ public:
 	void setLargeStep(const s32 &step);
 	void setPos(const s32 &pos);
 	void setPageSize(const s32 &size);
+	void setArrowsVisible(u8 visible);
 
 private:
 	void refreshControls();
@@ -47,6 +48,7 @@ private:
 
 	IGUIButton *up_button;
 	IGUIButton *down_button;
+	u8 is_arrows_visible = 2;
 	bool is_dragging;
 	bool is_horizontal;
 	bool is_auto_scaling;

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -17,17 +17,17 @@ the arrow buttons where there is insufficient space.
 using namespace irr;
 using namespace gui;
 
-enum ScrollBarArrowVisibility {
-	HIDE,
-	SHOW,
-	DEFAULT
-};
-
 class GUIScrollBar : public IGUIElement
 {
 public:
 	GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 			core::rect<s32> rectangle, bool horizontal, bool auto_scale);
+
+	enum ArrowVisibility {
+		HIDE,
+		SHOW,
+		DEFAULT
+	};
 
 	virtual void draw();
 	virtual void updateAbsolutePosition();
@@ -45,7 +45,7 @@ public:
 	void setLargeStep(const s32 &step);
 	void setPos(const s32 &pos);
 	void setPageSize(const s32 &size);
-	void setArrowsVisible(ScrollBarArrowVisibility visible);
+	void setArrowsVisible(ArrowVisibility visible);
 
 private:
 	void refreshControls();
@@ -54,7 +54,7 @@ private:
 
 	IGUIButton *up_button;
 	IGUIButton *down_button;
-	ScrollBarArrowVisibility arrow_visibility = DEFAULT;
+	ArrowVisibility arrow_visibility = DEFAULT;
 	bool is_dragging;
 	bool is_horizontal;
 	bool is_auto_scaling;


### PR DESCRIPTION
This PR adds a `scrollbaroptions` element for formspecs.  Similar to `tableoptions`, it must be placed before the scrollbars it modifies.  Old scrollbars are not affected.  Closes #8575.

Valid options are:

- `min` - Minimum value of the scrollbar (default 0)
- `max` - Maximum value of the scrollbar (default 1000)
- `smallstep` - Scroll amount when using arrows or scroll wheel (default 10)
- `largestep` - Scroll amount when clicking the bar itself (default 100)
- `thumbsize` - Size of the thumb determined by the number of unit the thumb spans out of the range of values (max - min).
- `arrows` - Whether to make the arrows hidden, shown, or automatic.

Some potential examples:

`scrollbaroptions[min=0;max=255;smallstep=8;largestep=16;thumbsize=8;arrows=hide]`
`scrollbaroptions[max=10000;largestep=1000]`

If the step value is negative, it will use Irrlicht's defaults.  If the max is less than or equal to the min, the scrollbar element will have no bar and do nothing, i.e. disabled.  If thumbsize is zero or less, it defaults to 1 (which usually will appear as a square).

This PR is Ready for Review.