### PR TITLE
Add content_rating tag to appdata

### DIFF
--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -3,6 +3,10 @@
 	<id>net.minetest.minetest.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>LGPL-2.1+ and CC-BY-SA-3.0 and MIT and Apache-2.0</project_license>
+	<content_rating type="oars-1.0">
+		<content_attribute id="violence-cartoon">mild</content_attribute>
+		<content_attribute id="social-chat">intense</content_attribute>
+	</content_rating>
 	<name>Minetest</name>
 	<summary>Multiplayer infinite-world block sandbox game</summary>
 	<description>

--- a/misc/net.minetest.minetest.appdata.xml
+++ b/misc/net.minetest.minetest.appdata.xml
@@ -5,7 +5,9 @@
 	<project_license>LGPL-2.1+ and CC-BY-SA-3.0 and MIT and Apache-2.0</project_license>
 	<content_rating type="oars-1.0">
 		<content_attribute id="violence-cartoon">mild</content_attribute>
+		<content_attribute id="violence-fantasy">mild</content_attribute>
 		<content_attribute id="social-chat">intense</content_attribute>
+		<content_attribute id="social-info">mild</content_attribute>
 	</content_rating>
 	<name>Minetest</name>
 	<summary>Multiplayer infinite-world block sandbox game</summary>


### PR DESCRIPTION
This tag allows software stores (KDE discover, etc) to filter and know whether applications are suitable for young users.