### PR TITLE
Kick and take over old session on join (ghosting)

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1398,6 +1398,11 @@ void PlayerSAO::disconnected()
 	m_pending_removal = true;
 }
 
+void PlayerSAO::updatePeerId()
+{
+	m_peer_id = m_player ? m_player->getPeerId() : PEER_ID_INEXISTENT;
+}
+
 void PlayerSAO::unlinkPlayerSessionAndSave()
 {
 	assert(m_player->getPlayerSAO() == this);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -287,7 +287,8 @@ public:
 	void disconnected();
 
 	RemotePlayer *getPlayer() { return m_player; }
-	session_t getPeerID() const { return m_peer_id; }
+	session_t getPeerId() const { return m_peer_id; }
+	void updatePeerId();
 
 	// Cheat prevention
 
@@ -352,7 +353,7 @@ private:
 	void unlinkPlayerSessionAndSave();
 
 	RemotePlayer *m_player = nullptr;
-	session_t m_peer_id = 0;
+	session_t m_peer_id = PEER_ID_INEXISTENT;
 
 	// Cheat prevention
 	LagPool m_dig_pool;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -944,6 +944,7 @@ enum AccessDeniedCode {
 	SERVER_ACCESSDENIED_CUSTOM_STRING,
 	SERVER_ACCESSDENIED_SHUTDOWN,
 	SERVER_ACCESSDENIED_CRASH,
+	SERVER_ACCESSDENIED_GHOST_KICK,
 	SERVER_ACCESSDENIED_MAX,
 };
 
@@ -964,7 +965,8 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"Server authentication failed.  This is likely a server error.",
 	"",
 	"Server shutting down.",
-	"This server has experienced an internal error. You will now be disconnected."
+	"This server has experienced an internal error. You will now be disconnected.",
+	"Another client logged in with this player name."
 };
 
 enum PlayerListModifer: u8

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -365,9 +365,9 @@ void Server::handleCommand_RequestMedia(NetworkPacket* pkt)
 
 void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 {
+	bool reuse_old_session = false;
 	session_t peer_id = pkt->getPeerId();
-
-	PlayerSAO* playersao = StageTwoClientInit(peer_id);
+	PlayerSAO *playersao = StageTwoClientInit(peer_id, reuse_old_session);
 
 	if (playersao == NULL) {
 		actionstream
@@ -376,7 +376,6 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 		DisconnectPeer(peer_id);
 		return;
 	}
-
 
 	if (pkt->getSize() < 8) {
 		errorstream
@@ -397,21 +396,34 @@ void Server::handleCommand_ClientReady(NetworkPacket* pkt)
 	if (pkt->getRemainingBytes() >= 2)
 		*pkt >> playersao->getPlayer()->formspec_version;
 
-	const std::vector<std::string> &players = m_clients.getPlayerNames();
-	NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
-	list_pkt << (u8) PLAYER_LIST_INIT << (u16) players.size();
-	for (const std::string &player: players) {
-		list_pkt <<  player;
+	if (!reuse_old_session) {
+		const std::vector<std::string> &players = m_clients.getPlayerNames();
+		NetworkPacket list_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, peer_id);
+		list_pkt << (u8)PLAYER_LIST_INIT << (u16)players.size();
+		for (const std::string &player : players)
+			list_pkt << player;
+
+		m_clients.send(peer_id, 0, &list_pkt, true);
+
+		NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
+		// (u16) 1 + std::string represents a pseudo vector serialization representation
+		notice_pkt << (u8) PLAYER_LIST_ADD << (u16)1 << std::string(playersao->getPlayer()->getName());
+		m_clients.sendToAll(&notice_pkt);
+
+		m_clients.event(peer_id, CSE_SetClientReady);
+		m_script->on_joinplayer(playersao);
+	} else {
+		m_clients.event(peer_id, CSE_SetClientReady);
+
+		const auto &list = playersao->getPlayer()->getHudList();
+		for (size_t id = 0; id < list.size(); ++id) {
+			if (!list[id])
+				continue;
+
+			SendHUDAdd(peer_id, id, list[id]);
+		}
 	}
-	m_clients.send(peer_id, 0, &list_pkt, true);
 
-	NetworkPacket notice_pkt(TOCLIENT_UPDATE_PLAYER_LIST, 0, PEER_ID_INEXISTENT);
-	// (u16) 1 + std::string represents a pseudo vector serialization representation
-	notice_pkt << (u8) PLAYER_LIST_ADD << (u16) 1 << std::string(playersao->getPlayer()->getName());
-	m_clients.sendToAll(&notice_pkt);
-
-	m_clients.event(peer_id, CSE_SetClientReady);
-	m_script->on_joinplayer(playersao);
 	// Send shutdown timer if shutdown has been scheduled
 	if (m_shutdown_state.isTimerRunning()) {
 		SendChatMessage(pkt->getPeerId(), m_shutdown_state.getShutdownTimerMessage());

--- a/src/player.h
+++ b/src/player.h
@@ -200,6 +200,7 @@ public:
 	u32         addHud(HudElement* hud);
 	HudElement* removeHud(u32 id);
 	void        clearHud();
+	const std::vector<HudElement *> &getHudList() const { return hud; };
 
 	u32 hud_flags;
 	s32 hud_hotbar_itemcount;

--- a/src/server.h
+++ b/src/server.h
@@ -137,7 +137,7 @@ public:
 	// This is run by ServerThread and does the actual processing
 	void AsyncRunStep(bool initial_step=false);
 	void Receive();
-	PlayerSAO* StageTwoClientInit(session_t peer_id);
+	PlayerSAO *StageTwoClientInit(session_t peer_id, bool &ghost_kick);
 
 	/*
 	 * Command Handlers
@@ -406,7 +406,7 @@ private:
 	void SendPlayerFormspecPrepend(session_t peer_id);
 	void SendShowFormspecMessage(session_t peer_id, const std::string &formspec,
 		const std::string &formname);
-	void SendHUDAdd(session_t peer_id, u32 id, HudElement *form);
+	void SendHUDAdd(session_t peer_id, u32 id, const HudElement *form);
 	void SendHUDRemove(session_t peer_id, u32 id);
 	void SendHUDChange(session_t peer_id, u32 id, HudElementStat stat, void *value);
 	void SendHUDSetFlags(session_t peer_id, u32 flags, u32 mask);


### PR DESCRIPTION
PR for #8521

An in-game player is kicked when the following conditions are met:
 * New player logs in with the correct password
 * The in-game player is not the game host (server peer ID + 1)

The player object and connection is entirely taken over to the new client's peer ID, followed by the default procedure of sending the initial data. This way attachments are still valid (same object) and there are no join/leave messages.