### PR TITLE
Remove modstore leftovers. Fix core.show_path_select_dialog documentation

### DIFF
--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -153,11 +153,6 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 		return true
 	end
 
-	if fields["btn_mod_mgr_install_local"] ~= nil then
-		core.show_path_select_dialog("mod_mgt_open_dlg", fgettext("Select Package File:"), true)
-		return true
-	end
-
 	if fields["btn_contentdb"] ~= nil then
 		local dlg = create_store_dlg()
 		dlg:set_parent(tabview)
@@ -198,12 +193,6 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 	if fields.btn_mod_mgr_disable_txp then
 		core.settings:set("texture_path", "")
 		packages = nil
-		return true
-	end
-
-	if fields["mod_mgt_open_dlg_accepted"] and
-			fields["mod_mgt_open_dlg_accepted"] ~= "" then
-		pkgmgr.install_mod(fields["mod_mgt_open_dlg_accepted"],nil)
 		return true
 	end
 

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -154,7 +154,7 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 	end
 
 	if fields["btn_mod_mgr_install_local"] ~= nil then
-		core.show_file_open_dialog("mod_mgt_open_dlg", fgettext("Select Package File:"))
+		core.show_path_select_dialog("mod_mgt_open_dlg", fgettext("Select Package File:"), true)
 		return true
 	end
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -89,13 +89,14 @@ core.set_background(type, texturepath,[tile],[minsize])
 core.set_clouds(<true/false>)
 core.set_topleft_text(text)
 core.show_keys_menu()
-core.file_open_dialog(formname,caption)
-^ shows a file open dialog
+core.show_path_select_dialog(formname, caption, is_file_select)
+^ shows a path select dialog
 ^ formname is base name of dialog response returned in fields
 ^     -if dialog was accepted "_accepted"
-^^       will be added to fieldname containing the path
+^        will be added to fieldname containing the path
 ^     -if dialog was canceled "_cancelled"
 ^        will be added to fieldname value is set to formname itself
+^ if `is_file_select` is `true`, a file and not a folder will be selected
 ^ returns nil or selected file/folder
 core.get_screen_info()
 ^ returns {
@@ -240,4 +241,4 @@ Limitations of Async operations
  -No access to global lua variables, don't even try
  -Limited set of available functions
 	e.g. No access to functions modifying menu like core.start,core.close,
-	core.file_open_dialog
+	core.show_path_select_dialog


### PR DESCRIPTION
In #5852, it was forgotten to update the documentation and to replace `show_file_open_dialog` in  `builtin/mainmenu/tab_content.lua`. This PR fixes this.

Notes:
- I did not test this.
- I wonder why there was no crash yet. Or is there an issue?
- It might be that in `tab_content.lua` it's not a file selector, please check.