### PR TITLE
Add ymin parameter to caverns

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1379,7 +1379,10 @@ mgv5_large_cave_depth (Large cave depth) int -256
 mgv5_lava_depth (Lava depth) int -256
 
 #    Y-level of cavern upper limit.
-mgv5_cavern_limit (Cavern limit) int -256
+mgv5_cavern_limit (Cavern maximum y) int -256
+
+#    Y-level of cavern lower limit.
+mgv5_cavern_ymin (Cavern minimum y) int -32000
 
 #    Y-distance over which caverns expand to full size.
 mgv5_cavern_taper (Cavern taper) int 256
@@ -1511,7 +1514,10 @@ mgv7_floatland_level (Floatland level) int 1280
 mgv7_shadow_limit (Shadow limit) int 1024
 
 #    Y-level of cavern upper limit.
-mgv7_cavern_limit (Cavern limit) int -256
+mgv7_cavern_limit (Cavern maximum y) int -256
+
+#    Y-level of cavern lower limit.
+mgv7_cavern_ymin (Cavern minimum y) int -32000
 
 #    Y-distance over which caverns expand to full size.
 mgv7_cavern_taper (Cavern taper) int 256
@@ -1593,7 +1599,10 @@ mgcarpathian_large_cave_depth (Large cave depth) int -33
 mgcarpathian_lava_depth (Lava depth) int -256
 
 #    Y-level of cavern upper limit.
-mgcarpathian_cavern_limit (Cavern limit) int -256
+mgcarpathian_cavern_limit (Cavern maximum y) int -256
+
+#    Y-level of cavern lower limit.
+mgcarpathian_cavern_ymin (Cavern minimum y) int -32000
 
 #    Y-distance over which caverns expand to full size.
 mgcarpathian_cavern_taper (Cavern taper) int 256
@@ -1847,8 +1856,11 @@ mgvalleys_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgvalleys_lava_depth (Lava depth) int 1
 
-#    Depth below which you'll find giant caverns.
-mgvalleys_cavern_limit (Cavern upper limit) int -256
+#    Y-level of cavern upper limit.
+mgvalleys_cavern_limit (Cavern maximum y) int -256
+
+#    Y-level of cavern lower limit.
+mgvalleys_cavern_ymin (Cavern minimum y) int -32000
 
 #    Y-distance over which caverns expand to full size.
 mgvalleys_cavern_taper (Cavern taper) int 192

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -68,9 +68,9 @@ private:
 class CavernsNoise
 {
 public:
-	CavernsNoise(const NodeDefManager *nodedef, v3s16 chunksize,
-		NoiseParams *np_cavern, s32 seed, float cavern_limit,
-		float cavern_taper, float cavern_threshold);
+	CavernsNoise(const NodeDefManager *nodedef, v3s16 chunksize, NoiseParams *np_cavern,
+		s32 seed, float cavern_limit, float cavern_ymin, float cavern_taper,
+		float cavern_threshold);
 	~CavernsNoise();
 
 	bool generateCaverns(MMVManip *vm, v3s16 nmin, v3s16 nmax);
@@ -81,6 +81,7 @@ private:
 	// configurable parameters
 	v3s16 m_csize;
 	float m_cavern_limit;
+	float m_cavern_ymin;
 	float m_cavern_taper;
 	float m_cavern_threshold;
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -875,11 +875,12 @@ void MapgenBasic::generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_depth)
 
 bool MapgenBasic::generateCavernsNoise(s16 max_stone_y)
 {
-	if (node_min.Y > max_stone_y || node_min.Y > cavern_limit)
+	if (node_min.Y > max_stone_y || node_min.Y > cavern_limit ||
+			node_max.Y < cavern_ymin)
 		return false;
 
-	CavernsNoise caverns_noise(ndef, csize, &np_cavern,
-		seed, cavern_limit, cavern_taper, cavern_threshold);
+	CavernsNoise caverns_noise(ndef, csize, &np_cavern, seed,
+		cavern_limit, cavern_ymin, cavern_taper, cavern_threshold);
 
 	return caverns_noise.generateCaverns(vm, node_min, node_max);
 }

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -286,6 +286,7 @@ protected:
 	NoiseParams np_dungeons;
 	float cave_width;
 	float cavern_limit;
+	float cavern_ymin;
 	float cavern_taper;
 	float cavern_threshold;
 	int lava_depth;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -60,6 +60,7 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	large_cave_depth = params->large_cave_depth;
 	lava_depth       = params->lava_depth;
 	cavern_limit     = params->cavern_limit;
+	cavern_ymin      = params->cavern_ymin;
 	cavern_taper     = params->cavern_taper;
 	cavern_threshold = params->cavern_threshold;
 	dungeon_ymin     = params->dungeon_ymin;
@@ -138,6 +139,7 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 	settings->getS16NoEx("mgcarpathian_large_cave_depth",   large_cave_depth);
 	settings->getS16NoEx("mgcarpathian_lava_depth",         lava_depth);
 	settings->getS16NoEx("mgcarpathian_cavern_limit",       cavern_limit);
+	settings->getS16NoEx("mgcarpathian_cavern_ymin",        cavern_ymin);
 	settings->getS16NoEx("mgcarpathian_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgcarpathian_cavern_threshold", cavern_threshold);
 	settings->getS16NoEx("mgcarpathian_dungeon_ymin",       dungeon_ymin);
@@ -170,6 +172,7 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setS16("mgcarpathian_large_cave_depth",   large_cave_depth);
 	settings->setS16("mgcarpathian_lava_depth",         lava_depth);
 	settings->setS16("mgcarpathian_cavern_limit",       cavern_limit);
+	settings->setS16("mgcarpathian_cavern_ymin",        cavern_ymin);
 	settings->setS16("mgcarpathian_cavern_taper",       cavern_taper);
 	settings->setFloat("mgcarpathian_cavern_threshold", cavern_threshold);
 	settings->setS16("mgcarpathian_dungeon_ymin",       dungeon_ymin);

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -40,6 +40,7 @@ struct MapgenCarpathianParams : public MapgenParams
 	s16 large_cave_depth   = -33;
 	s16 lava_depth         = -256;
 	s16 cavern_limit       = -256;
+	s16 cavern_ymin        = -32000;
 	s16 cavern_taper       = 256;
 	float cavern_threshold = 0.7f;
 	s16 dungeon_ymin       = -31000;

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -53,6 +53,7 @@ MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	large_cave_depth = params->large_cave_depth;
 	lava_depth       = params->lava_depth;
 	cavern_limit     = params->cavern_limit;
+	cavern_ymin      = params->cavern_ymin;
 	cavern_taper     = params->cavern_taper;
 	cavern_threshold = params->cavern_threshold;
 	dungeon_ymin     = params->dungeon_ymin;
@@ -103,6 +104,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getS16NoEx("mgv5_large_cave_depth",   large_cave_depth);
 	settings->getS16NoEx("mgv5_lava_depth",         lava_depth);
 	settings->getS16NoEx("mgv5_cavern_limit",       cavern_limit);
+	settings->getS16NoEx("mgv5_cavern_ymin",        cavern_ymin);
 	settings->getS16NoEx("mgv5_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgv5_cavern_threshold", cavern_threshold);
 	settings->getS16NoEx("mgv5_dungeon_ymin",       dungeon_ymin);
@@ -126,6 +128,7 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setS16("mgv5_large_cave_depth",   large_cave_depth);
 	settings->setS16("mgv5_lava_depth",         lava_depth);
 	settings->setS16("mgv5_cavern_limit",       cavern_limit);
+	settings->setS16("mgv5_cavern_ymin",        cavern_ymin);
 	settings->setS16("mgv5_cavern_taper",       cavern_taper);
 	settings->setFloat("mgv5_cavern_threshold", cavern_threshold);
 	settings->setS16("mgv5_dungeon_ymin",       dungeon_ymin);

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -36,6 +36,7 @@ struct MapgenV5Params : public MapgenParams
 	s16 large_cave_depth = -256;
 	s16 lava_depth = -256;
 	s16 cavern_limit = -256;
+	s16 cavern_ymin = -32000;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;
 	s16 dungeon_ymin = -31000;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -66,6 +66,7 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	large_cave_depth     = params->large_cave_depth;
 	lava_depth           = params->lava_depth;
 	cavern_limit         = params->cavern_limit;
+	cavern_ymin          = params->cavern_ymin;
 	cavern_taper         = params->cavern_taper;
 	cavern_threshold     = params->cavern_threshold;
 	dungeon_ymin         = params->dungeon_ymin;
@@ -179,6 +180,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getS16NoEx("mgv7_floatland_level",        floatland_level);
 	settings->getS16NoEx("mgv7_shadow_limit",           shadow_limit);
 	settings->getS16NoEx("mgv7_cavern_limit",           cavern_limit);
+	settings->getS16NoEx("mgv7_cavern_ymin",            cavern_ymin);
 	settings->getS16NoEx("mgv7_cavern_taper",           cavern_taper);
 	settings->getFloatNoEx("mgv7_cavern_threshold",     cavern_threshold);
 	settings->getS16NoEx("mgv7_dungeon_ymin",           dungeon_ymin);
@@ -215,6 +217,7 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setS16("mgv7_floatland_level",        floatland_level);
 	settings->setS16("mgv7_shadow_limit",           shadow_limit);
 	settings->setS16("mgv7_cavern_limit",           cavern_limit);
+	settings->setS16("mgv7_cavern_ymin",            cavern_ymin);
 	settings->setS16("mgv7_cavern_taper",           cavern_taper);
 	settings->setFloat("mgv7_cavern_threshold",     cavern_threshold);
 	settings->setS16("mgv7_dungeon_ymin",           dungeon_ymin);

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -47,6 +47,7 @@ struct MapgenV7Params : public MapgenParams {
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
 	s16 cavern_limit = -256;
+	s16 cavern_ymin = -32000;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;
 	s16 dungeon_ymin = -31000;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -69,6 +69,7 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
 	cavern_limit       = params->cavern_limit;
+	cavern_ymin        = params->cavern_ymin;
 	cavern_taper       = params->cavern_taper;
 	cavern_threshold   = params->cavern_threshold;
 	dungeon_ymin       = params->dungeon_ymin;
@@ -132,6 +133,7 @@ void MapgenValleysParams::readParams(const Settings *settings)
 	settings->getU16NoEx("mgvalleys_river_size",         river_size);
 	settings->getFloatNoEx("mgvalleys_cave_width",       cave_width);
 	settings->getS16NoEx("mgvalleys_cavern_limit",       cavern_limit);
+	settings->getS16NoEx("mgvalleys_cavern_ymin",        cavern_ymin);
 	settings->getS16NoEx("mgvalleys_cavern_taper",       cavern_taper);
 	settings->getFloatNoEx("mgvalleys_cavern_threshold", cavern_threshold);
 	settings->getS16NoEx("mgvalleys_dungeon_ymin",       dungeon_ymin);
@@ -162,6 +164,7 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setU16("mgvalleys_river_size",         river_size);
 	settings->setFloat("mgvalleys_cave_width",       cave_width);
 	settings->setS16("mgvalleys_cavern_limit",       cavern_limit);
+	settings->setS16("mgvalleys_cavern_ymin",        cavern_ymin);
 	settings->setS16("mgvalleys_cavern_taper",       cavern_taper);
 	settings->setFloat("mgvalleys_cavern_threshold", cavern_threshold);
 	settings->setS16("mgvalleys_dungeon_ymin",       dungeon_ymin);

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -51,6 +51,7 @@ struct MapgenValleysParams : public MapgenParams {
 	s16 large_cave_depth = -33;
 	s16 lava_depth = 1;
 	s16 cavern_limit = -256;
+	s16 cavern_ymin = -32000;
 	s16 cavern_taper = 192;
 	float cavern_threshold = 0.6f;
 	s16 dungeon_ymin = -31000;


### PR DESCRIPTION
WIP, unsure about the new tapering code. Unsure about the whole PR.
Implements part of #8406 

Previously, caverns only had a parameter for their upper limit, this PR adds a parameter for a lower limit.
Existing worlds have, for example, `mgcarpathian_cavern_ymin = -32000` added to their map_meta.txt, and their terrain is unchanged due to ymin being set to -32000 by default.