### PR TITLE
Add reset button (Incomplete, work needed)

### DIFF
--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -130,17 +130,6 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 	v2s32 size = DesiredRect.getSize();
 	v2s32 topleft(0, 0);
 
-	{
-		core::rect<s32> rect(0, 0, 600 * s, 40 * s);
-		rect += topleft + v2s32(25 * s, 3 * s);
-		//gui::IGUIStaticText *t =
-		const wchar_t *text = wgettext("Keybindings. (If this menu screws up, remove stuff from minetest.conf)");
-		Environment->addStaticText(text,
-								   rect, false, true, this, -1);
-		delete[] text;
-		//t->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
-	}
-
 	// Build buttons
 
 	v2s32 offset(25 * s, 60 * s);
@@ -418,7 +407,10 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 					return true;
 				case GUI_ID_RESET_BUTTON: //reset
 					resetInput();
-					quitMenu();
+                    regenerateGui(m_screensize_old);
+                    key_settings.clear();
+                    init_keys();
+					//quitMenu();
 					return true;
 				default:
 					key_setting *k = NULL;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -285,11 +285,8 @@ bool GUIKeyChangeMenu::acceptInput()
 
 bool GUIKeyChangeMenu::resetInput()
 {
-	int i = 0;
 	for (key_setting *k : key_settings) {
-		char keys[33][50] = {"W", "S", "A", "D", "E", "KEY_SPACE", "KEY_LSHIFT", "Q", "I", "B", "N", "Z", "KEY_F7", "KEY_F9", "K", "P", "J", "H", "M", "", "", "", "T", "KEY_F12", "R", "-", "+", "KEY_F10", "/", ".", "KEY_F1", "KEY_F2", "KEY_F3"};
-		g_settings->set(k->setting_name, keys[i]);
-		i = i + 1;
+		g_settings->remove(k->setting_name);
 	}
 
 	{

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -407,9 +407,9 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 					return true;
 				case GUI_ID_RESET_BUTTON: //reset
 					resetInput();
-                    regenerateGui(m_screensize_old);
-                    key_settings.clear();
-                    init_keys();
+					regenerateGui(m_screensize_old);
+					key_settings.clear();
+					init_keys();
 					//quitMenu();
 					return true;
 				default:

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -40,6 +40,7 @@ extern MainGameCallback *g_gamecallback;
 enum
 {
 	GUI_ID_BACK_BUTTON = 101, GUI_ID_ABORT_BUTTON, GUI_ID_SCROLL_BAR,
+	GUI_ID_RESET_BUTTON,
 	// buttons
 	GUI_ID_KEY_FORWARD_BUTTON,
 	GUI_ID_KEY_BACKWARD_BUTTON,
@@ -229,6 +230,15 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 				text);
 		delete[] text;
 	}
+
+	{
+		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
+		rect += topleft + v2s32(10 * s, size.Y - 40 * s);
+		const wchar_t *text =  wgettext("Reset keys");
+		Environment->addButton(rect, this, GUI_ID_RESET_BUTTON,
+				 text);
+		delete[] text;
+	}
 }
 
 void GUIKeyChangeMenu::drawMenu()
@@ -248,6 +258,38 @@ bool GUIKeyChangeMenu::acceptInput()
 {
 	for (key_setting *k : key_settings) {
 		g_settings->set(k->setting_name, k->key.sym());
+	}
+
+	{
+		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUX1_DESCENDS);
+		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
+			g_settings->setBool("aux1_descends", ((gui::IGUICheckBox*)e)->isChecked());
+	}
+	{
+		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_DOUBLETAP_JUMP);
+		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
+			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
+	}
+	{
+		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUTOJUMP);
+		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
+			g_settings->setBool("autojump", ((gui::IGUICheckBox*)e)->isChecked());
+	}
+
+	clearKeyCache();
+
+	g_gamecallback->signalKeyConfigChange();
+
+	return true;
+}
+
+bool GUIKeyChangeMenu::resetInput()
+{
+	int i = 0;
+	for (key_setting *k : key_settings) {
+		char keys[33][50] = {"W", "S", "A", "D", "E", "KEY_SPACE", "KEY_LSHIFT", "Q", "I", "B", "N", "Z", "KEY_F7", "KEY_F9", "K", "P", "J", "H", "M", "", "", "", "T", "KEY_F12", "R", "-", "+", "KEY_F10", "/", ".", "KEY_F1", "KEY_F2", "KEY_F3"};
+		g_settings->set(k->setting_name, keys[i]);
+		i = i + 1;
 	}
 
 	{
@@ -375,6 +417,10 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 					quitMenu();
 					return true;
 				case GUI_ID_ABORT_BUTTON: //abort
+					quitMenu();
+					return true;
+				case GUI_ID_RESET_BUTTON: //reset
+					resetInput();
 					quitMenu();
 					return true;
 				default:

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -54,6 +54,8 @@ public:
 
 	bool acceptInput();
 
+	bool resetInput();
+
 	bool OnEvent(const SEvent &event);
 
 	bool pausesGame() { return true; }


### PR DESCRIPTION
Ref: #8064 
Adds a reset button for the keys.
![keys](https://user-images.githubusercontent.com/49789044/59209008-42038300-8ba2-11e9-946e-c2f8d4aa815a.png)

Here's the process:
1. Mess up the keys.
2. Press the reset button (menu quits)
3. Open "Change Keys" and they are all already reset.

There are a few problems. It's my first time programming in `C++` so some parts of the code are incorrect.

1. The keys text needs to update when the reset button is pressed instead of having to `quitMenu();`
2. Currently, the keys are reset to an array that I created in the loop (see line `290`), instead of getting the list of keys from the settings script or elsewhere. The array isn't initialized properly either.
3. I copied `acceptInput()` and used it as a template, but some of the code might not be needed.

Tasks:
- [x] Make buttons reset correctly.
- [x] Make GUI automatically update when reset button is pressed
- [x] Create an "Are you sure?" popup or double click to make sure.
- [ ] Fix `Segmentation fault (core dumped)` error.