### PR TITLE
Settings: Disallow space characters entirely

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -69,7 +69,9 @@ Settings & Settings::operator = (const Settings &other)
 bool Settings::checkNameValid(const std::string &name)
 {
 	bool valid = name.find_first_of("=\"{}#") == std::string::npos;
-	if (valid) valid = trim(name) == name;
+	if (valid)
+		valid = std::find_if(name.begin(), name.end(), ::isspace) == name.end();
+
 	if (!valid) {
 		errorstream << "Invalid setting name \"" << name << "\""
 			<< std::endl;


### PR DESCRIPTION
Fixes a settings:set() loophole where it's possible to use newlines in setting names to override other settings.
Reported by @HybridDog https://github.com/minetest/minetest/commit/3a8c7888807e4483bbdb3edd81c9893f3e2f427d#r33872939

Lua API:
https://github.com/minetest/minetest/blob/e2f8f4da83206d551f9acebd14d574ea37ca214a/doc/lua_api.txt#L5553-L5554

So this PR will follow the documentation and disallow all white-spaces.

**Testing script:**
```Lua
local is_secure = core.settings:get_bool("secure.enable_security")
core.settings:set_bool(".\nsecure.enable_security", not is_secure)
core.log("warning", "Set security to " .. tostring(not is_secure):upper())

--[[
Old output:

.
secure.enable_security = false
.
secure.enable_security = false
.
secure.enable_security = false
.
secure.enable_security = true
]]
```