### PR TITLE
Add scroll_container formspec element

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -177,15 +177,19 @@ LOCAL_SRC_FILES := \
 		jni/src/filesys.cpp                       \
 		jni/src/genericobject.cpp                 \
 		jni/src/gettext.cpp                       \
+		jni/src/gui/guiBackgroundImage.cpp        \
+		jni/src/gui/guiBox.cpp                    \
 		jni/src/gui/guiChatConsole.cpp            \
 		jni/src/gui/guiConfirmRegistration.cpp    \
 		jni/src/gui/guiEditBoxWithScrollbar.cpp   \
 		jni/src/gui/guiEngine.cpp                 \
 		jni/src/gui/guiFormSpecMenu.cpp           \
+		jni/src/gui/guiItemImage.cpp              \
 		jni/src/gui/guiKeyChangeMenu.cpp          \
 		jni/src/gui/guiPasswordChange.cpp         \
 		jni/src/gui/guiPathSelectMenu.cpp         \
 		jni/src/gui/guiScrollBar.cpp              \
+		jni/src/gui/guiScrollContainer.cpp        \
 		jni/src/gui/guiTable.cpp                  \
 		jni/src/gui/guiVolumeChange.cpp           \
 		jni/src/gui/intlGUIEditBox.cpp            \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1882,6 +1882,11 @@ When displaying text which can contain formspec code, e.g. text set by a player,
 use `minetest.formspec_escape`.
 For coloured text you can use `minetest.colorize`.
 
+Elements drawn in the order they are defined. All background elements are drawn
+before all other elements.
+`list` elements are an exception here. They are drawn last. This, however, might
+be changed at any time.
+
 WARNING: Minetest allows you to add elements to every single formspec instance
 using `player:set_formspec_prepend()`, which may be the reason backgrounds are
 appearing when you don't expect them to. See [`no_prepend[]`].
@@ -1971,6 +1976,23 @@ Elements
 * End of a container, following elements are no longer relative to this
   container.
 
+### `scroll_container[<X>,<Y>;<W>,<H>;<scrollbar name>;<direction>;<multiplier>]`
+
+* Start of a scroll_container block, all elements in a scroll_container block will
+  * take the block's coordinate as position origin,
+  * be additionally moved by the current value of the scrollbar with the name
+    `scrollbar name` times `multiplier` in the direction `direction` and
+  * be clipped to the rectangle defined by `X`, `Y`, `W` and `H`.
+* Possible values for `direction` are `down` and `right`.
+* `multiplier` is optional and defaults to `0.1`.
+* Nesting is possible.
+* Some elements might work a little different if they are in a scroll_container.
+
+### `scroll_container_end[]`
+
+* End of a scroll_container, following elements are no longer bound to this
+  container.
+
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;]`
 
 * Show an inventory list if it has been sent to the client. Nothing will
@@ -2037,11 +2059,15 @@ Elements
 
 * Show an inventory image of registered item/node
 
-### `bgcolor[<color>;<fullscreen>]`
+### `bgcolor[<color>]`
 
 * Sets background color of formspec as `ColorString`
-* If `true`, the background color is drawn fullscreen (does not affect the size
-  of the formspec).
+
+### `bgcolor[<color>;<fullscreen>]`
+
+* If `color` is a valid `ColorString`, the fullscreen background color
+  is set to `color`.
+* If `fullscreen` is a true value, the fullscreen background color is drawn.
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>]`
 

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -169,7 +169,8 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 }
 
 void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
-		const core::rect<s32> &rect, const core::rect<s32> &middle)
+		const core::rect<s32> &rect, const core::rect<s32> &middle,
+		const core::rect<s32> *cliprect)
 {
 	const video::SColor color(255,255,255,255);
 	const video::SColor colors[] = {color,color,color,color};
@@ -222,7 +223,7 @@ void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
 
 			draw2DImageFilterScaled(driver, texture, dest,
 					src,
-					NULL/*&AbsoluteClippingRect*/, colors, true);
+					cliprect, colors, true);
 		}
 	}
 }

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -53,4 +53,5 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
  * 9-slice / segment drawing
  */
 void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
-		const core::rect<s32> &rect, const core::rect<s32> &middle);
+		const core::rect<s32> &rect, const core::rect<s32> &middle,
+		const core::rect<s32> *cliprect = 0);

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,13 +1,17 @@
 set(gui_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiBox.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiChatConsole.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiConfirmRegistration.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEditBoxWithScrollbar.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEngine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiFormSpecMenu.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiItemImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiKeyChangeMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiPasswordChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiPathSelectMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiScrollBar.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiScrollContainer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiTable.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiVolumeChange.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/intlGUIEditBox.cpp

--- a/src/gui/guiBackgroundImage.cpp
+++ b/src/gui/guiBackgroundImage.cpp
@@ -1,0 +1,71 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiBackgroundImage.h"
+#include "client/guiscalingfilter.h"
+#include "log.h"
+
+GUIBackgroundImage::GUIBackgroundImage(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id, core::rect<s32> &rectangle,
+		const std::string &name, const core::rect<s32> &middle,
+		ISimpleTextureSource *tsrc) :
+		gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+		m_name(name), m_middle(middle), m_tsrc(tsrc)
+{
+}
+
+void GUIBackgroundImage::draw()
+{
+	if (!IsVisible)
+		return;
+
+	video::ITexture *texture = m_tsrc->getTexture(m_name);
+
+	if (!texture) {
+		errorstream << "GUIBackgroundImage::draw() Unable to load texture:"
+			    << std::endl;
+		errorstream << "\t" << m_name << std::endl;
+		return;
+	}
+
+	video::IVideoDriver *driver = Environment->getVideoDriver();
+	core::rect<s32> middle = m_middle;
+
+	if (middle.getArea() == 0) {
+		const video::SColor color(255, 255, 255, 255);
+		const video::SColor colors[] = {color, color, color, color};
+		draw2DImageFilterScaled(driver, texture, AbsoluteRect,
+				core::rect<s32>(core::position2d<s32>(0, 0),
+						core::dimension2di(
+								texture->getOriginalSize())),
+				&AbsoluteClippingRect, colors, true);
+	} else {
+		// `-x` is interpreted as `w - x`
+		if (middle.LowerRightCorner.X < 0) {
+			middle.LowerRightCorner.X += texture->getOriginalSize().Width;
+		}
+		if (middle.LowerRightCorner.Y < 0) {
+			middle.LowerRightCorner.Y += texture->getOriginalSize().Height;
+		}
+		draw2DImage9Slice(driver, texture, AbsoluteRect, middle,
+				&AbsoluteClippingRect);
+	}
+
+	IGUIElement::draw();
+}

--- a/src/gui/guiBackgroundImage.h
+++ b/src/gui/guiBackgroundImage.h
@@ -1,0 +1,39 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "util/string.h"
+#include "client/tile.h" // ITextureSource
+
+class GUIBackgroundImage : public gui::IGUIElement
+{
+public:
+	GUIBackgroundImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+			core::rect<s32> &rectangle, const std::string &name,
+			const core::rect<s32> &middle, ISimpleTextureSource *tsrc);
+
+	virtual void draw();
+
+private:
+	std::string m_name;
+	core::rect<s32> m_middle;
+	ISimpleTextureSource *m_tsrc;
+};

--- a/src/gui/guiBox.cpp
+++ b/src/gui/guiBox.cpp
@@ -1,0 +1,38 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiBox.h"
+
+GUIBox::GUIBox(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+		core::rect<s32> &rectangle, video::SColor &color) :
+		gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+		m_color(color)
+{
+}
+
+void GUIBox::draw()
+{
+	if (!IsVisible)
+		return;
+
+	Environment->getVideoDriver()->draw2DRectangle(
+			m_color, AbsoluteRect, &AbsoluteClippingRect);
+
+	IGUIElement::draw();
+}

--- a/src/gui/guiBox.h
+++ b/src/gui/guiBox.h
@@ -1,0 +1,34 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+
+class GUIBox : public gui::IGUIElement
+{
+public:
+	GUIBox(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+			core::rect<s32> &rectangle, video::SColor &color);
+
+	virtual void draw();
+
+private:
+	video::SColor m_color;
+};

--- a/src/gui/guiItemImage.cpp
+++ b/src/gui/guiItemImage.cpp
@@ -1,0 +1,61 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiItemImage.h"
+
+GUIItemImage::GUIItemImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+		const core::rect<s32> &rectangle, std::string item_name,
+		gui::IGUIFont *font, Client *client) :
+		gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+		m_item_name(item_name), m_font(font), m_client(client),
+		m_label(core::stringw())
+{
+}
+
+void GUIItemImage::draw()
+{
+	if (!m_client) {
+		IGUIElement::draw();
+		return;
+	}
+
+	IItemDefManager *idef = m_client->idef();
+	ItemStack item;
+	item.deSerialize(m_item_name, idef);
+	// Viewport rectangle on screen
+	core::rect<s32> rect = core::rect<s32>(AbsoluteRect);
+	if (Parent->getType() == gui::EGUIET_BUTTON &&
+			((irr::gui::IGUIButton *)Parent)->isPressed()) {
+#if (IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR < 8)
+		rect += core::dimension2d<s32>(0.05 * (float)rect.getWidth(),
+				0.05 * (float)rect.getHeight());
+#else
+		gui::IGUISkin *skin = Environment->getSkin();
+		rect += core::dimension2d<s32>(
+				skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_X),
+				skin->getSize(irr::gui::EGDS_BUTTON_PRESSED_IMAGE_OFFSET_Y));
+#endif
+	}
+	drawItemStack(Environment->getVideoDriver(), m_font, item, rect,
+			&AbsoluteClippingRect, m_client, IT_ROT_NONE);
+	video::SColor color(255, 255, 255, 255);
+	m_font->draw(m_label, rect, color, true, true, &AbsoluteClippingRect);
+
+	IGUIElement::draw();
+}

--- a/src/gui/guiItemImage.h
+++ b/src/gui/guiItemImage.h
@@ -1,0 +1,46 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "util/string.h"
+#include "client/client.h"
+
+class GUIItemImage : public gui::IGUIElement
+{
+public:
+	GUIItemImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+			const core::rect<s32> &rectangle, std::string item_name,
+			gui::IGUIFont *font, Client *client);
+
+	virtual void draw();
+
+	virtual void setText(const wchar_t *text)
+	{
+		m_label = core::stringw();
+		m_label.append(text);
+	}
+
+private:
+	std::string m_item_name;
+	gui::IGUIFont *m_font;
+	Client *m_client;
+	core::stringw m_label;
+};

--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -1,0 +1,55 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiScrollContainer.h"
+
+GUIScrollContainer::GUIScrollContainer(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent, s32 id, core::rect<s32> &rectangle,
+		const std::string &direction, f32 scrollfactor) :
+		gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+		m_scrollbar(nullptr), m_direction(direction), m_scrollfactor(scrollfactor)
+{
+}
+
+bool GUIScrollContainer::OnEvent(const SEvent &event)
+{
+	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
+			event.MouseInput.Event == EMIE_MOUSE_WHEEL && m_scrollbar) {
+		Environment->setFocus(m_scrollbar);
+		return m_scrollbar->OnEvent(event);
+	}
+
+	return IGUIElement::OnEvent(event);
+}
+
+void GUIScrollContainer::OnScrollEvent(gui::IGUIElement *caller)
+{
+	if (caller != m_scrollbar)
+		return;
+
+	s32 pos = m_scrollbar->getPos();
+	core::rect<s32> rect = getRelativePosition();
+
+	if (m_direction == "down")
+		rect.UpperLeftCorner.Y = pos * m_scrollfactor;
+	else if (m_direction == "right")
+		rect.UpperLeftCorner.X = pos * m_scrollfactor;
+
+	setRelativePosition(rect);
+}

--- a/src/gui/guiScrollContainer.h
+++ b/src/gui/guiScrollContainer.h
@@ -1,0 +1,43 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes_extrabloated.h"
+#include "util/string.h"
+#include "guiScrollBar.h"
+
+class GUIScrollContainer : public gui::IGUIElement
+{
+public:
+	GUIScrollContainer(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
+			core::rect<s32> &rectangle, const std::string &direction,
+			f32 scrollfactor);
+
+	virtual bool OnEvent(const SEvent &event);
+
+	void OnScrollEvent(gui::IGUIElement *caller);
+
+	inline void setScrollBar(guiScrollBar *scrollbar) { m_scrollbar = scrollbar; }
+
+private:
+	guiScrollBar *m_scrollbar;
+	std::string m_direction;
+	f32 m_scrollfactor;
+};


### PR DESCRIPTION
Does what is described in #8576 and closes #8576.
Also fixes #8336. (Closes #8716, closes #8740.)
I recommend reviewing and merging #8716 and #8740 first.

- There are a three new classes (`GUIBox`, `GUIItemImage` and `GUIScrollContainer`).
- All elements are realized with or bound to `IGUIElement`s. This is to make use of parents.
- There's no need to get an absolute element position as every element is a child.
- Lists are still drawn after everything else, ergo #4844 is not entirely fixed. (I've tried to add a `GUIList` class which draws a list, but it was too hard and would have gone too far.)
- The scroll_container consists of two elements. One clips every child, the other moves them. The clipper is the parent of the mover.
- The scroll container mover (of class `GUIScrollContainer`) is moved on event.
- I guess some things can be optimized, I'm very inexperienced.

<details><summary>Here's a formspec that I've used for testing.</summary>

```lua
local my_formspec =
	"size[10,8]"..
	--~ "position[0.2,0.7]"..
	--~ "anchor[0,1]"..
	"button[8,1;1,1;bla;Bla]"..
	"scrollbar[7.5,0;0.3,4;vertical;scrbar;0]"..
	"scroll_container[1,1;8,6;scrbar;down;0.06]"..
		"button[0,1;1,1;baum;Baum]"..
		--~ "container[0,0]"..
		"button[0,10;1,1;planze;Pflanze]"..
		"pwdfield[2,2;1,1;baum2;Baum]"..
		--~ "container_end[]"..
		"list[current_player;main;4,4;1,5;]"..
		"box[2,5;3,2;#ffff00]"..
		"image[1,10;3,2;bubble.png]"..
		"image[3,1;bubble.png]"..
		"item_image[2,6;3,2;default:mese]"..
		"label[2,15;bla baum\nfoo bar]"..
		--~ "textarea[2,10;5,6;txtarea;Baum;bla]"..
		"item_image_button[2,3;1,1;default:dirt_with_grass;itemimagebutton;ItemImageButton]"..
		--~ "tooltip[planze;Blatt;#f00;#000]"..
		"tooltip[0,11;3,2;Blatt;#f00;#000]"..
		"box[0,11;3,2;#00ff00]"..
		--~ "checkbox[2,25;chb;ChB;false]",
		"container[0,18]"..
			"scroll_container[1,2;3,2;scrbar2;right;0.1]"..
				"label[10,0;nest]"..
				"button[0,0;6,1;butnest;Nest]"..
				"bgcolor[#aa0a]"..
			"scroll_container_end[]"..
			"scrollbar[1,0;3.5,0.3;horizontal;scrbar2;0]"..
		"container_end[]"..
		--~ "tablecolumns[text,bla]"..
		--~ "table[1,23;3,1;tbl;a,b,c,d;2]"..
		--~ "textlist[0,5;2,0.5;txtlst;a,b,c]"..
		"dropdown[0,6;2;hmdrpdwn;apfel,birne;1]"..
		"image_button[0,4;2,2;bubble.png;bubblebutton;bbbbtt;false;true;heart.png]"..
		--~ "tabheader[-1,9;mytabheader;a,b,c;2;false;false]"..
		--~ "background[2,4;2,2;default_wood.png;true]"..
		"bgcolor[#00aa]"..
	"scroll_container_end[]"..
	--~ "textarea[5,0.5;1,1;scrtxtarea;Baum;blablaajk adfkjgn \n akfjb]"..
	--~ "bgcolor[;true]"..
	--~ "bgcolor[#0000]"..
	""
```
</details>

Here's a demo video: [scroll_container_show.m4v.zip](https://github.com/minetest/minetest/files/3273388/scroll_container_show.m4v.zip)