### PR TITLE
Add core.open_url() to main menu API

### DIFF
--- a/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -117,4 +117,9 @@ public class GameActivity extends NativeActivity {
 	public int getDisplayWidth() {
 		return getResources().getDisplayMetrics().widthPixels;
 	}
+
+	public void openURL(String url) {
+		Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+		startActivity(browserIntent);
+	}
 }

--- a/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/build/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -22,6 +22,7 @@ package net.minetest.minetest;
 
 import android.app.NativeActivity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;

--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -101,8 +101,8 @@ return {
 		local logofile = defaulttexturedir .. "logo.png"
 		local version = core.get_version()
 		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
-			"label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
-			"label[0.5,3.5;http://minetest.net]" ..
+			"label[0.5,2.8;" .. version.project .. " " .. version.string .. "]" ..
+			"button[0.5,3;2,2;homepage;minetest.net]" ..
 			"tablecolumns[color;text]" ..
 			"tableoptions[background=#00000000;highlight=#00000000;border=false]" ..
 			"table[3.5,-0.25;8.5,6.05;list_credits;" ..
@@ -115,5 +115,10 @@ return {
 			"#FFFF00," .. fgettext("Previous Contributors") .. ",," ..
 			buildCreditList(previous_contributors) .. "," ..
 			";1]"
-	end
+	end,
+	cbf_button_handler = function(this, fields, name, tabdata)
+		if fields.homepage then
+			core.open_url("https://www.minetest.net")
+		end
+	end,
 }

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -238,7 +238,6 @@ Other:
 core.open_url(url)
 ^ opens the URL in a web browser, returns false on failure.
 ^ Must begin with http:// or https://
-^ Full regex: ^https?:\/\/([\w\.-\/\?=\%\+\#\&]+)$
 
 Async:
 core.handle_async(async_job,parameters,finished)

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -234,6 +234,12 @@ core.get_min_supp_proto()
 core.get_max_supp_proto()
 ^ returns the maximum supported network protocol version
 
+Other:
+core.open_url(url)
+^ opens the URL in a web browser, returns false on failure.
+^ Must begin with http:// or https://
+^ Full regex: ^https?:\/\/([\w\.-\/\?=\%\+\#\&]+)$
+
 Async:
 core.handle_async(async_job,parameters,finished)
 ^ execute a function asynchronously

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -713,7 +713,7 @@ bool openURL(std::string url)
 	}
 
 #if defined(_WIN32)
-	return (int)ShellExecuteA(NULL, NULL, url.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
+	return (intptr_t)ShellExecuteA(NULL, NULL, url.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
 #elif defined(__ANDROID__)
 	openURLAndroid(url);
 	return true;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -55,11 +55,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "log.h"
 #include "util/string.h"
-#include "settings.h"
 #include <list>
 #include <cstdarg>
 #include <cstdio>
-#include <regex>
 
 namespace porting
 {
@@ -705,7 +703,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 	return c;
 }
 
-bool openURL(std::string url)
+bool openURL(const std::string &url)
 {
 	if (url.substr(0, 7) != "http://" && url.substr(0, 8) != "https://") {
 		errorstream << "Invalid url: " << url << std::endl;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -707,8 +707,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 
 bool openURL(std::string url)
 {
-	if (!std::regex_match(url,
-			std::regex(R"(^https?:\/\/[\w\.-\/\?=\%\+\#\&]+$)") )) {
+	if (url.substr(0, 7) != "http://" && url.substr(0, 8) != "https://") {
 		errorstream << "Invalid url: " << url << std::endl;
 		return false;
 	}

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -705,7 +705,8 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 
 bool openURL(const std::string &url)
 {
-	if (url.substr(0, 7) != "http://" && url.substr(0, 8) != "https://") {
+	if ((url.substr(0, 7) != "http://" && url.substr(0, 8) != "https://") ||
+			url.find_first_of("\r\n") != std::string::npos) {
 		errorstream << "Invalid url: " << url << std::endl;
 		return false;
 	}

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -713,7 +713,7 @@ bool openURL(std::string url)
 	}
 
 #if defined(_WIN32)
-	return ShellExecuteA(NULL, NULL, url.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
+	return (int)ShellExecuteA(NULL, NULL, url.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
 #elif defined(__ANDROID__)
 	openURLAndroid(url);
 	return true;

--- a/src/porting.h
+++ b/src/porting.h
@@ -329,6 +329,9 @@ bool secure_rand_fill_buf(void *buf, size_t len);
 void attachOrCreateConsole();
 
 int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...);
+
+bool openURL(std::string url);
+
 } // namespace porting
 
 #ifdef __ANDROID__

--- a/src/porting.h
+++ b/src/porting.h
@@ -330,7 +330,7 @@ void attachOrCreateConsole();
 
 int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...);
 
-bool openURL(std::string url);
+bool openURL(const std::string &url);
 
 } // namespace porting
 

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -218,9 +218,8 @@ void openURLAndroid(const std::string &url)
 	jmethodID url_open = jnienv->GetMethodID(nativeActivity, "openURL",
 			"(Ljava/lang/String)V");
 
-	if (url_open == 0) {
-		assert("porting::openURLAndroid unable to find java show dialog method" == 0);
-	}
+	FATAL_ERROR_IF(url_open == nullptr,
+				   "porting::openURLAndroid unable to find java show dialog method");
 
 	jstring jurl = jnienv->NewStringUTF(url.c_str());
 	jnienv->CallVoidMethod(app_global->activity->clazz, url_open, jurl);

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -216,10 +216,10 @@ void showInputDialog(const std::string &acceptButton, const std::string &hint,
 void openURLAndroid(const std::string &url)
 {
 	jmethodID url_open = jnienv->GetMethodID(nativeActivity, "openURL",
-			"(Ljava/lang/String)V");
+		"(Ljava/lang/String)V");
 
 	FATAL_ERROR_IF(url_open == nullptr,
-				   "porting::openURLAndroid unable to find java show dialog method");
+		"porting::openURLAndroid unable to find java openURL method");
 
 	jstring jurl = jnienv->NewStringUTF(url.c_str());
 	jnienv->CallVoidMethod(app_global->activity->clazz, url_open, jurl);

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -213,6 +213,19 @@ void showInputDialog(const std::string &acceptButton, const std::string &hint,
 			jacceptButton, jhint, jcurrent, jeditType);
 }
 
+void openURLAndroid(const std::string &url)
+{
+	jmethodID url_open = jnienv->GetMethodID(nativeActivity, "openURL",
+			"(Ljava/lang/String)V");
+
+	if (url_open == 0) {
+		assert("porting::openURLAndroid unable to find java show dialog method" == 0);
+	}
+
+	jstring jurl = jnienv->NewStringUTF(url.c_str());
+	jnienv->CallVoidMethod(app_global->activity->clazz, url_open, jurl);
+}
+
 int getInputDialogState()
 {
 	jmethodID dialogstate = jnienv->GetMethodID(nativeActivity,

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -216,7 +216,7 @@ void showInputDialog(const std::string &acceptButton, const std::string &hint,
 void openURLAndroid(const std::string &url)
 {
 	jmethodID url_open = jnienv->GetMethodID(nativeActivity, "openURL",
-		"(Ljava/lang/String)V");
+		"(Ljava/lang/String;)V");
 
 	FATAL_ERROR_IF(url_open == nullptr,
 		"porting::openURLAndroid unable to find java openURL method");

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -58,6 +58,8 @@ void initializePathsAndroid();
 void showInputDialog(const std::string &acceptButton,
 					const std::string &hint, const std::string &current, int editType);
 
+void openURLAndroid(const std::string &url);
+
 /**
  * WORKAROUND for not working callbacks from java -> c++
  * get current state of input dialog

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1064,6 +1064,14 @@ int ModApiMainMenu::l_get_max_supp_proto(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_open_url(lua_State *L)
+{
+	std::string url = luaL_checkstring(L, 1);
+	lua_pushboolean(L, porting::openURL(url));
+	return 1;
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_do_async_callback(lua_State *L)
 {
 	GUIEngine* engine = getGuiEngine(L);
@@ -1125,6 +1133,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_screen_info);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
+	API_FCT(open_url);
 	API_FCT(do_async_callback);
 }
 

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -145,6 +145,9 @@ private:
 
 	static int l_get_max_supp_proto(lua_State *L);
 
+	// other
+	static int l_open_url(lua_State *L);
+
 
 	// async
 	static int l_do_async_callback(lua_State *L);


### PR DESCRIPTION
Variant of #8139

## Use case

The use case in mind is allowing a button to open up the ContentDB pages of packages.

To implement reviews and comments, I don't want to have to add login support to the client. Instead, I'd prefer to have a button to open up ContentDB in a web browser.

![image](https://user-images.githubusercontent.com/2122943/59288956-db976700-8c6c-11e9-84a0-4c5f67a1b17c.png)

![image](https://user-images.githubusercontent.com/2122943/59288931-d1756880-8c6c-11e9-808d-a9a23af97690.png)


## Security

URLs are opened with methods that take explicit program names and arguments. URLs are checked to make sure they start with `http://` or `https://`. No other checks are done.

Currently, this is only allowed in the main menu, however, I would like to add support for this to the server-side scripting API in the future. Security will need to be considered in more detail at that point.