### PR TITLE
Dungeongen: Remove hardcoded dungeon nodes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -282,36 +282,26 @@ Mapgen aliases
 --------------
 
 In a game, a certain number of these must be set to tell core mapgens which
-of the game's nodes are to be used by the core mapgens. For example:
+of the game's nodes are to be used for core mapgen generation. For example:
 
     minetest.register_alias("mapgen_stone", "default:stone")
 
 ### Aliases needed for all mapgens except Mapgen V6
 
-#### Base terrain
-
 * mapgen_stone
 * mapgen_water_source
 * mapgen_river_water_source
 
-#### Caves
+`mapgen_river_water_source` is required for mapgens with sloping rivers where
+it is necessary to have a river liquid node with a short `liquid_range` and
+`liquid_renewable = false` to avoid flooding.
 
-Not required if cave liquid nodes are set in biome definitions.
+#### Deprecated aliases
 
 * mapgen_lava_source
-
-#### Dungeons
-
-Not required if dungeon nodes are set in biome definitions.
-
 * mapgen_cobble
-* mapgen_stair_cobble
-* mapgen_mossycobble
-* mapgen_desert_stone
-* mapgen_stair_desert_stone
-* mapgen_sandstone
-* mapgen_sandstonebrick
-* mapgen_stair_sandstone_block
+
+Use biome-defined cave liquids and dungeon nodes instead.
 
 ### Aliases needed for Mapgen V6
 

--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -42,22 +42,35 @@ struct DungeonParams {
 	s32 seed;
 
 	content_t c_wall;
+	// Randomly scattered alternative wall nodes
 	content_t c_alt_wall;
 	content_t c_stair;
 
+	// Diagonal corridors are possible
 	bool diagonal_dirs;
+	// Dungeon only generates in ground
 	bool only_in_ground;
+	// Dimensions of 3D 'brush' that creates corridors.
+	// Dimensions are of the empty space, not including walls / floor / ceilng.
 	v3s16 holesize;
+	// Corridor length
 	u16 corridor_len_min;
 	u16 corridor_len_max;
+	// Room size includes walls / floor / ceilng
 	v3s16 room_size_min;
 	v3s16 room_size_max;
+	// The 1st room generated has a 1 in 4 chance of being 'large', all other
+	// rooms are not 'large'.
 	v3s16 room_size_large_min;
 	v3s16 room_size_large_max;
+	// Number of rooms
 	u16 rooms_min;
 	u16 rooms_max;
+	// Usually 'GENNOTIFY_DUNGEON', but mapgen v6 uses 'GENNOTIFY_TEMPLE' for
+	// desert dungeons.
 	GenNotifyType notifytype;
 
+	// 3D noise that determines which c_wall nodes are converted to c_alt_wall
 	NoiseParams np_alt_wall;
 };
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -257,21 +257,11 @@ protected:
 	v3s16 full_node_min;
 	v3s16 full_node_max;
 
-	// Content required for generateBiomes
 	content_t c_stone;
-	content_t c_desert_stone;
-	content_t c_sandstone;
 	content_t c_water_source;
 	content_t c_river_water_source;
 	content_t c_lava_source;
-
-	// Content required for generateDungeons
 	content_t c_cobble;
-	content_t c_stair_cobble;
-	content_t c_mossycobble;
-	content_t c_stair_desert_stone;
-	content_t c_sandstonebrick;
-	content_t c_stair_sandstone_block;
 
 	int ystride;
 	int zstride;


### PR DESCRIPTION
 Dungeongen: Remove most hardcoded dungeon nodes

Biome-defined dungeon nodes was added as a feature to MT 5.0.0.
So now remove most of the hardcoded dungeon node code that assumes a
game has stone, sandstone, desert stone, and no other stone types.
If biome-defined dungeon nodes are not found, dungeon nodes fall back
to the 'cobble' mapgen alias if present, if not present they fall back
to biome-defined 'stone'.
Remove now-unnecessary mapgen aliases from MapgenBasic. Non-mgv6 games
now only need to define 3 to 5 mapgen aliases.

Document dungeon parameters.

Make c_lava_source fallback to c_water_source as both are used as cave
liquids.
//////////////////////////////////////

Attends to part of #8251 
A follow-up PR will use randomness to create a wide variety of dungeon parameters, so that dungeon structure has much more variation.

See #8251 for a description of MT master behaviour.

MT 5.0.0 made dungeon nodes defined by biomes, this PR is the next step, it removes the horrible horrible hardcoded node-selection code that assumes a game has stone, sandstone and desert stone (and no other stone types). This allows many of the mapgen aliases to be removed from class MapgenBasic, such that only 3 to 5 are needed when using non-mgv6 mapgens, this will make game creation easier.

If this PR is merged i will add a forum post to inform game makers that dungeon nodes should now be defined in biomes.
I will also make a MTG PR to define dungeon nodes in biomes.