### PR TITLE
Add support for 9-sliced backgrounds

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2048,8 +2048,8 @@ Elements
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>;<middle>]`
 
-* 9-sliced background. Middle is a rect which defined the middle of the 9-slice.
-* Middle can be:
+* 9-sliced background. See https://en.wikipedia.org/wiki/9-slice_scaling
+* Middle is a rect which defines the middle of the 9-slice.
 	* `x` - The middle will be x pixels from all sides.
 	* `x,y` - The middle will be x pixels from the horizontal and y from the vertical.
 	* `x,y,x2,y2` - The middle will start at x,y, and end at x2, y2. Negative x2 and y2 values

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2034,13 +2034,11 @@ Elements
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>]`
 
-* Use a background. Inventory rectangles are not drawn then.
 * Example for formspec 8x4 in 16x resolution: image shall be sized
   8 times 16px  times  4 times 16px.
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>]`
 
-* Use a background. Inventory rectangles are not drawn then.
 * Example for formspec 8x4 in 16x resolution:
   image shall be sized 8 times 16px  times  4 times 16px
 * If `auto_clip` is `true`, the background is clipped to the formspec size
@@ -2056,7 +2054,6 @@ Elements
 		will be added to the width and height of the texture, allowing it to be used as the
 		distance from the far end.
 	* All numbers in middle are integers.
-* Use a background. Inventory rectangles are not drawn then.
 * Example for formspec 8x4 in 16x resolution:
   image shall be sized 8 times 16px  times  4 times 16px
 * If `auto_clip` is `true`, the background is clipped to the formspec size

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2046,6 +2046,22 @@ Elements
 * If `auto_clip` is `true`, the background is clipped to the formspec size
   (`x` and `y` are used as offset values, `w` and `h` are ignored)
 
+### `background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>;<middle>]`
+
+* 9-sliced background. Middle is a rect which defined the middle of the 9-slice.
+* Middle can be:
+	* `x` - The middle will be x pixels from all sides.
+	* `x,y` - The middle will be x pixels from the horizontal and y from the vertical.
+	* `x,y,x2,y2` - The middle will start at x,y, and end at x2, y2. Negative x2 and y2 values
+		will be added to the width and height of the texture, allowing it to be used as the
+		distance from the far end.
+	* All numbers in middle are integers.
+* Use a background. Inventory rectangles are not drawn then.
+* Example for formspec 8x4 in 16x resolution:
+  image shall be sized 8 times 16px  times  4 times 16px
+* If `auto_clip` is `true`, the background is clipped to the formspec size
+  (`x` and `y` are used as offset values, `w` and `h` are ignored)
+
 ### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
 * Textual password style field; will be sent to server when a button is clicked

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -168,7 +168,7 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 	driver->draw2DImage(scaled, destrect, mysrcrect, cliprect, colors, usealpha);
 }
 
-void draw2DImage9Splice(video::IVideoDriver *driver, video::ITexture *texture,
+void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
 		const core::rect<s32> &rect, const core::rect<s32> &middle)
 {
 	const video::SColor color(255,255,255,255);

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -167,3 +167,49 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 
 	driver->draw2DImage(scaled, destrect, mysrcrect, cliprect, colors, usealpha);
 }
+
+void draw2DImage9Splice(video::IVideoDriver *driver, video::ITexture *texture,
+		const core::rect<s32> &rect, const core::rect<s32> &middle)
+{
+	const video::SColor color(255,255,255,255);
+	const video::SColor colors[] = {color,color,color,color};
+
+	auto originalSize = texture->getOriginalSize();
+	core::vector2di lowerRightOffset = core::vector2di(originalSize.Width, originalSize.Height) - middle.LowerRightCorner;
+
+	for (int y = 0; y < 3; ++y) {
+		for (int x = 0; x < 3; ++x) {
+			core::rect<s32> src({0, 0}, originalSize);
+			core::rect<s32> dest = rect;
+			if (x == 0) {
+				dest.LowerRightCorner.X = rect.UpperLeftCorner.X + middle.UpperLeftCorner.X;
+				src.LowerRightCorner.X = middle.UpperLeftCorner.X;
+			} else if (x == 1) {
+				dest.UpperLeftCorner.X += middle.UpperLeftCorner.X;
+				dest.LowerRightCorner.X -= lowerRightOffset.X;
+				src.UpperLeftCorner.X = middle.UpperLeftCorner.X;
+				src.LowerRightCorner.X = middle.LowerRightCorner.X;
+			} else if (x == 2) {
+				dest.UpperLeftCorner.X = rect.LowerRightCorner.X - lowerRightOffset.X;
+				src.UpperLeftCorner.X = middle.LowerRightCorner.X;
+			}
+
+			if (y == 0) {
+				dest.LowerRightCorner.Y = rect.UpperLeftCorner.Y + middle.UpperLeftCorner.Y;
+				src.LowerRightCorner.Y = middle.UpperLeftCorner.Y;
+			} else if (y == 1) {
+				dest.UpperLeftCorner.Y += middle.UpperLeftCorner.Y;
+				dest.LowerRightCorner.Y -= lowerRightOffset.Y;
+				src.UpperLeftCorner.Y = middle.UpperLeftCorner.Y;
+				src.LowerRightCorner.Y = middle.LowerRightCorner.Y;
+			} else if (y == 2) {
+				dest.UpperLeftCorner.Y = rect.LowerRightCorner.Y - lowerRightOffset.Y;
+				src.UpperLeftCorner.Y = middle.LowerRightCorner.Y;
+			}
+
+			draw2DImageFilterScaled(driver, texture, dest,
+					src,
+					NULL/*&AbsoluteClippingRect*/, colors, true);
+		}
+	}
+}

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -181,30 +181,43 @@ void draw2DImage9Splice(video::IVideoDriver *driver, video::ITexture *texture,
 		for (int x = 0; x < 3; ++x) {
 			core::rect<s32> src({0, 0}, originalSize);
 			core::rect<s32> dest = rect;
-			if (x == 0) {
+
+			switch (x) {
+			case 0:
 				dest.LowerRightCorner.X = rect.UpperLeftCorner.X + middle.UpperLeftCorner.X;
 				src.LowerRightCorner.X = middle.UpperLeftCorner.X;
-			} else if (x == 1) {
+				break;
+
+			case 1:
 				dest.UpperLeftCorner.X += middle.UpperLeftCorner.X;
 				dest.LowerRightCorner.X -= lowerRightOffset.X;
 				src.UpperLeftCorner.X = middle.UpperLeftCorner.X;
 				src.LowerRightCorner.X = middle.LowerRightCorner.X;
-			} else if (x == 2) {
+				break;
+
+			case 2:
 				dest.UpperLeftCorner.X = rect.LowerRightCorner.X - lowerRightOffset.X;
 				src.UpperLeftCorner.X = middle.LowerRightCorner.X;
+				break;
 			}
 
-			if (y == 0) {
+			switch (y) {
+			case 0:
 				dest.LowerRightCorner.Y = rect.UpperLeftCorner.Y + middle.UpperLeftCorner.Y;
 				src.LowerRightCorner.Y = middle.UpperLeftCorner.Y;
-			} else if (y == 1) {
+				break;
+
+			case 1:
 				dest.UpperLeftCorner.Y += middle.UpperLeftCorner.Y;
 				dest.LowerRightCorner.Y -= lowerRightOffset.Y;
 				src.UpperLeftCorner.Y = middle.UpperLeftCorner.Y;
 				src.LowerRightCorner.Y = middle.LowerRightCorner.Y;
-			} else if (y == 2) {
+				break;
+
+			case 2:
 				dest.UpperLeftCorner.Y = rect.LowerRightCorner.Y - lowerRightOffset.Y;
 				src.UpperLeftCorner.Y = middle.LowerRightCorner.Y;
+				break;
 			}
 
 			draw2DImageFilterScaled(driver, texture, dest,

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -52,5 +52,5 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 /*
  * 9-slice / segment drawing
  */
-void draw2DImage9Splice(video::IVideoDriver *driver, video::ITexture *texture,
+void draw2DImage9Slice(video::IVideoDriver *driver, video::ITexture *texture,
 		const core::rect<s32> &rect, const core::rect<s32> &middle);

--- a/src/client/guiscalingfilter.h
+++ b/src/client/guiscalingfilter.h
@@ -48,3 +48,9 @@ void draw2DImageFilterScaled(video::IVideoDriver *driver, video::ITexture *txr,
 		const core::rect<s32> &destrect, const core::rect<s32> &srcrect,
 		const core::rect<s32> *cliprect = 0, const video::SColor *const colors = 0,
 		bool usealpha = false);
+
+/*
+ * 9-slice / segment drawing
+ */
+void draw2DImage9Splice(video::IVideoDriver *driver, video::ITexture *texture,
+		const core::rect<s32> &rect, const core::rect<s32> &middle);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -653,9 +653,8 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 {
 	std::vector<std::string> parts = split(element,';');
 
-	if (((parts.size() >= 3) || (parts.size() <= 5)) ||
-		((parts.size() > 4) && (m_formspec_version > FORMSPEC_API_VERSION)))
-	{
+	if ((parts.size() >= 3 && parts.size() <= 5) ||
+			(parts.size() > 5 && m_formspec_version > FORMSPEC_API_VERSION)) {
 		std::vector<std::string> v_pos = split(parts[0],',');
 		std::vector<std::string> v_geom = split(parts[1],',');
 		std::string name = unescape_string(parts[2]);
@@ -2561,7 +2560,7 @@ void GUIFormSpecMenu::drawMenu()
 				if (middle.LowerRightCorner.Y < 0) {
 					middle.LowerRightCorner.Y += texture->getOriginalSize().Height;
 				}
-				draw2DImage9Splice(driver, texture, rect, middle);
+				draw2DImage9Slice(driver, texture, rect, middle);
 			}
 		} else {
 			errorstream << "GUIFormSpecMenu::drawMenu() Draw backgrounds unable to load texture:" << std::endl;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -653,7 +653,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 {
 	std::vector<std::string> parts = split(element,';');
 
-	if (((parts.size() == 3) || (parts.size() == 4)) ||
+	if (((parts.size() >= 3) || (parts.size() <= 5)) ||
 		((parts.size() > 4) && (m_formspec_version > FORMSPEC_API_VERSION)))
 	{
 		std::vector<std::string> v_pos = split(parts[0],',');
@@ -672,16 +672,37 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		geom.Y = stof(v_geom[1]) * spacing.Y;
 
 		bool clip = false;
-		if (parts.size() == 4 && is_yes(parts[3])) {
+		if (parts.size() >= 4 && is_yes(parts[3])) {
 			pos.X = stoi(v_pos[0]); //acts as offset
 			pos.Y = stoi(v_pos[1]); //acts as offset
 			clip = true;
 		}
 
+		core::rect<s32> middle;
+		if (parts.size() >= 5) {
+			std::vector<std::string> v_middle = split(parts[4], ',');
+			if (v_middle.size() == 2) {
+				s32 x = stoi(v_middle[0]);
+				middle.UpperLeftCorner = core::vector2di(x, x);
+				middle.LowerRightCorner = core::vector2di(-x, -x);
+			} else if (v_middle.size() == 2) {
+				s32 x = stoi(v_middle[0]);
+				s32 y =	stoi(v_middle[1]);
+				middle.UpperLeftCorner = core::vector2di(x, y);
+				middle.LowerRightCorner = core::vector2di(-x, -y);
+				// `-x` is interpreted as `w - x`
+			} else if (v_middle.size() == 4) {
+				middle.UpperLeftCorner = core::vector2di(stoi(v_middle[0]), stoi(v_middle[1]));
+				middle.LowerRightCorner = core::vector2di(stoi(v_middle[2]), stoi(v_middle[3]));
+			} else {
+				warningstream << "Invalid rectangle given to middle param of background[] element" << std::endl;
+			}
+		}
+
 		if (!data->explicit_size && !clip)
 			warningstream << "invalid use of unclipped background without a size[] element" << std::endl;
 
-		m_backgrounds.emplace_back(name, pos, geom, clip);
+		m_backgrounds.emplace_back(name, pos, geom, middle, clip);
 
 		return;
 	}
@@ -2514,6 +2535,8 @@ void GUIFormSpecMenu::drawMenu()
 			core::rect<s32> imgrect(0, 0, spec.geom.X, spec.geom.Y);
 			// Image rectangle on screen
 			core::rect<s32> rect = imgrect + spec.pos;
+			// Middle rect for 9-slicing
+			core::rect<s32> middle = spec.middle;
 
 			if (spec.clip) {
 				core::dimension2d<s32> absrec_size = AbsoluteRect.getSize();
@@ -2523,12 +2546,23 @@ void GUIFormSpecMenu::drawMenu()
 									AbsoluteRect.UpperLeftCorner.Y + absrec_size.Height + spec.pos.Y);
 			}
 
-			const video::SColor color(255,255,255,255);
-			const video::SColor colors[] = {color,color,color,color};
-			draw2DImageFilterScaled(driver, texture, rect,
-				core::rect<s32>(core::position2d<s32>(0,0),
-						core::dimension2di(texture->getOriginalSize())),
-				NULL/*&AbsoluteClippingRect*/, colors, true);
+			if (middle.getSize() == core::vector2di(0, 0)) {
+				const video::SColor color(255, 255, 255, 255);
+				const video::SColor colors[] = {color, color, color, color};
+				draw2DImageFilterScaled(driver, texture, rect,
+						core::rect<s32>(core::position2d<s32>(0, 0),
+								core::dimension2di(texture->getOriginalSize())),
+						NULL/*&AbsoluteClippingRect*/, colors, true);
+			} else {
+				// `-x` is interpreted as `w - x`
+				if (middle.LowerRightCorner.X < 0) {
+					middle.LowerRightCorner.X += texture->getOriginalSize().Width;
+				}
+				if (middle.LowerRightCorner.Y < 0) {
+					middle.LowerRightCorner.Y += texture->getOriginalSize().Height;
+				}
+				draw2DImage9Splice(driver, texture, rect, middle);
+			}
 		} else {
 			errorstream << "GUIFormSpecMenu::drawMenu() Draw backgrounds unable to load texture:" << std::endl;
 			errorstream << "\t" << spec.name << std::endl;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2545,7 +2545,7 @@ void GUIFormSpecMenu::drawMenu()
 									AbsoluteRect.UpperLeftCorner.Y + absrec_size.Height + spec.pos.Y);
 			}
 
-			if (middle.getSize() == core::vector2di(0, 0)) {
+			if (middle.getArea() == 0) {
 				const video::SColor color(255, 255, 255, 255);
 				const video::SColor colors[] = {color, color, color, color};
 				draw2DImageFilterScaled(driver, texture, rect,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -681,7 +681,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		core::rect<s32> middle;
 		if (parts.size() >= 5) {
 			std::vector<std::string> v_middle = split(parts[4], ',');
-			if (v_middle.size() == 2) {
+			if (v_middle.size() == 1) {
 				s32 x = stoi(v_middle[0]);
 				middle.UpperLeftCorner = core::vector2di(x, x);
 				middle.LowerRightCorner = core::vector2di(-x, -x);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -177,6 +177,18 @@ class GUIFormSpecMenu : public GUIModalMenu
 		}
 
 		ImageDrawSpec(const std::string &a_name,
+				const v2s32 &a_pos, const v2s32 &a_geom, const core::rect<s32> &middle, bool clip=false):
+				name(a_name),
+				parent_button(NULL),
+				pos(a_pos),
+				geom(a_geom),
+				middle(middle),
+				scale(true),
+				clip(clip)
+		{
+		}
+
+		ImageDrawSpec(const std::string &a_name,
 				const v2s32 &a_pos):
 			name(a_name),
 			parent_button(NULL),
@@ -191,6 +203,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		gui::IGUIButton *parent_button;
 		v2s32 pos;
 		v2s32 geom;
+		core::rect<s32> middle;
 		bool scale;
 		bool clip;
 	};


### PR DESCRIPTION
This PR adds support for 9-sliced textures to Minetest. 9-slice textures are commonly used in GUIs to allow scaling them to match any resolution without distortion.

This PR only implements 9-slices to be used with the `background[]` element.

![image](https://user-images.githubusercontent.com/2122943/59524717-86f22700-8ecc-11e9-9cb0-a093a7ad1945.png)

https://en.wikipedia.org/wiki/9-slice_scaling

## To do

- [ ] Think of better place to put `draw2DImage9Splice`

## How to test

[![](https://i.rubenwardy.com/Iltif.png)](https://i.rubenwardy.com/Iltif.png)

```lua
minetest.register_on_joinplayer(function(player)
    minetest.show_formspec(player:get_player_name(), "aaa", [[
            size[4,6]
            background[5,5;1,1;testbg.png;true;10]
       ]])
end)
```

