### PR TITLE
Mods: Improve mod loading priorities

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -333,51 +333,119 @@ void ModConfiguration::checkConflictsAndDeps()
 	resolveDependencies();
 }
 
+struct PrioritySortedMod
+{
+	PrioritySortedMod(ModSpec *mod) : spec(mod) {}
+
+	static bool sorter(const PrioritySortedMod *a, const PrioritySortedMod *b)
+	{
+		// Return true means: move 'a' towards begin() in std::sort
+		return a->deps_chain.size() > b->deps_chain.size();
+	}
+
+	void addDependingMod(const std::string &modname,
+			std::unordered_map<std::string, PrioritySortedMod> &mods_by_name);
+
+	std::unordered_set<std::string> deps_chain;
+	ModSpec *spec;
+};
+
+void PrioritySortedMod::addDependingMod(const std::string &modname,
+		std::unordered_map<std::string, PrioritySortedMod> &mods_by_name)
+{
+	if (deps_chain.find(modname) != deps_chain.end()) {
+		// clang-format off
+		if (modname == spec->name)
+			warningstream << "PrioritySortedMod::addDependingMod(): Detected" <<
+					" circular dependencies in mod '" << modname << "'" << std::endl;
+		// clang-format on
+		return;
+	}
+
+	deps_chain.emplace(modname);
+
+	for (const std::string &dependency : spec->depends) {
+		auto &mod = mods_by_name.find(dependency)->second;
+		mod.addDependingMod(modname, mods_by_name);
+	}
+
+	for (const std::string &dependency : spec->optdepends) {
+		auto &mod = mods_by_name.find(dependency)->second;
+		mod.addDependingMod(modname, mods_by_name);
+	}
+}
+
 void ModConfiguration::resolveDependencies()
 {
-	// Step 1: Compile a list of the mod names we're working with
-	std::set<std::string> modnames;
-	for (const ModSpec &mod : m_unsatisfied_mods) {
-		modnames.insert(mod.name);
+	std::unordered_map<std::string, PrioritySortedMod> mods_by_name;
+	for (ModSpec &mod : m_unsatisfied_mods) {
+		// Reduce memory copy time by passing 'mod' as pointer
+		// 'm_unsatisfied_mods' owns the value!
+		mods_by_name.emplace(std::pair<std::string, PrioritySortedMod>(
+				mod.name, &mod));
 	}
 
-	// Step 2: get dependencies (including optional dependencies)
-	// of each mod, split mods into satisfied and unsatisfied
-	std::list<ModSpec> satisfied;
-	std::list<ModSpec> unsatisfied;
-	for (ModSpec mod : m_unsatisfied_mods) {
-		mod.unsatisfied_depends = mod.depends;
-		// check which optional dependencies actually exist
-		for (const std::string &optdep : mod.optdepends) {
-			if (modnames.count(optdep) != 0)
-				mod.unsatisfied_depends.insert(optdep);
-		}
-		// if a mod has no depends it is initially satisfied
-		if (mod.unsatisfied_depends.empty())
-			satisfied.push_back(mod);
-		else
-			unsatisfied.push_back(mod);
-	}
+	std::vector<ModSpec> unsatisfied;
 
-	// Step 3: mods without unmet dependencies can be appended to
-	// the sorted list.
-	while (!satisfied.empty()) {
-		ModSpec mod = satisfied.back();
-		m_sorted_mods.push_back(mod);
-		satisfied.pop_back();
-		for (auto it = unsatisfied.begin(); it != unsatisfied.end();) {
-			ModSpec &mod2 = *it;
-			mod2.unsatisfied_depends.erase(mod.name);
-			if (mod2.unsatisfied_depends.empty()) {
-				satisfied.push_back(mod2);
-				it = unsatisfied.erase(it);
+	// Step 1: Cleanup missing mods
+	size_t old_list_size;
+	do {
+		old_list_size = mods_by_name.size();
+
+		for (auto mod_it = mods_by_name.begin(); mod_it != mods_by_name.end();) {
+			ModSpec &mod = *mod_it->second.spec;
+
+			for (auto it = mod.optdepends.begin();
+					it != mod.optdepends.end();) {
+				// Remove what cannot be satisfied anyway
+				if (mods_by_name.find(*it) == mods_by_name.end())
+					mod.optdepends.erase(it++);
+				else
+					++it;
+			}
+
+			bool ok = true;
+			for (const std::string &dependency : mod.depends) {
+				if (mods_by_name.find(dependency) == mods_by_name.end()) {
+					mod.unsatisfied_depends.emplace(dependency);
+					ok = false;
+				}
+			}
+
+			if (ok) {
+				++mod_it;
 			} else {
-				++it;
+				unsatisfied.push_back(mod);
+				mods_by_name.erase(mod_it++);
 			}
 		}
+	} while (mods_by_name.size() != old_list_size);
+
+	// Step 2: Recursively add the current mod to the dependency lists
+	// of its depending mods.
+	for (auto &mod : mods_by_name)
+		mod.second.addDependingMod(mod.first, mods_by_name);
+
+	// Step 3: Sort it according to the new priorities
+	// The mod with the most hard dependencies must be loaded first
+	std::vector<const PrioritySortedMod *> mods;
+	for (const auto &mod : mods_by_name)
+		mods.push_back(&mod.second);
+
+	std::sort(mods.begin(), mods.end(), PrioritySortedMod::sorter);
+	for (auto &mod : mods) {
+		m_sorted_mods.push_back(*mod->spec);
+		// clang-format off
+		verbosestream << "Sorted mod: " << mod->spec->name <<
+				"   hard_deps=" << mod->deps_chain.size() << ", soft_deps=" <<
+				mod->deps_chain.size() << std::endl;
+		// clang-format on
 	}
 
-	// Step 4: write back list of unsatisfied mods
+	// Step 4: Update the list of unsatisfied mods
+	mods.clear();
+	mods_by_name.clear();
+	// Don't even try to dereference ModSpec now
 	m_unsatisfied_mods.assign(unsatisfied.begin(), unsatisfied.end());
 }
 

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -343,36 +343,55 @@ struct PrioritySortedMod
 		return a->deps_chain.size() > b->deps_chain.size();
 	}
 
-	void addDependingMod(const std::string &modname,
+	bool addDependingMod(const std::string &modname,
 			std::unordered_map<std::string, PrioritySortedMod> &mods_by_name);
 
 	std::unordered_set<std::string> deps_chain;
+	bool is_circular = false;
 	ModSpec *spec;
 };
 
-void PrioritySortedMod::addDependingMod(const std::string &modname,
+bool PrioritySortedMod::addDependingMod(const std::string &modname,
 		std::unordered_map<std::string, PrioritySortedMod> &mods_by_name)
 {
 	if (deps_chain.find(modname) != deps_chain.end()) {
-		// clang-format off
-		if (modname == spec->name)
-			warningstream << "PrioritySortedMod::addDependingMod(): Detected" <<
-					" circular dependencies in mod '" << modname << "'" << std::endl;
-		// clang-format on
-		return;
+		if (modname == spec->name) {
+			// Step 4: Reached the very same mod again.
+			// Stop the circular dependencies
+
+			// clang-format off
+			warningstream << "Detected circular dependencies in mod '" <<
+					modname << "'" << std::endl;
+			// clang-format on
+			is_circular = true;
+			return false;
+		}
+		return true; // The dependency trees merge. Nothing unusual
 	}
 
 	deps_chain.emplace(modname);
 
+	const auto &map_end = mods_by_name.end();
+
+	// Step 3: Follow the dependeny path and "push up" each
+	// mod which is required by 'modname'
 	for (const std::string &dependency : spec->depends) {
-		auto &mod = mods_by_name.find(dependency)->second;
-		mod.addDependingMod(modname, mods_by_name);
+		const auto &mod = mods_by_name.find(dependency);
+		if (mod != map_end) {
+			mod->second.addDependingMod(modname, mods_by_name);
+		} else if (modname == spec->name) {
+			// Missing hard dependency
+			spec->unsatisfied_depends.emplace(dependency);
+			return false;
+		}
 	}
 
 	for (const std::string &dependency : spec->optdepends) {
-		auto &mod = mods_by_name.find(dependency)->second;
-		mod.addDependingMod(modname, mods_by_name);
+		const auto &mod = mods_by_name.find(dependency);
+		if (mod != map_end)
+			mod->second.addDependingMod(modname, mods_by_name);
 	}
+	return !is_circular;
 }
 
 void ModConfiguration::resolveDependencies()
@@ -387,62 +406,54 @@ void ModConfiguration::resolveDependencies()
 
 	std::vector<ModSpec> unsatisfied;
 
-	// Step 1: Cleanup missing mods
 	size_t old_list_size;
 	do {
 		old_list_size = mods_by_name.size();
 
+		// Step 0: Clean up old data for new weighting calculation
+		for (auto &mod : mods_by_name)
+			mod.second.deps_chain.clear();
+
 		for (auto mod_it = mods_by_name.begin(); mod_it != mods_by_name.end();) {
 			ModSpec &mod = *mod_it->second.spec;
 
-			for (auto it = mod.optdepends.begin();
-					it != mod.optdepends.end();) {
-				// Remove what cannot be satisfied anyway
-				if (mods_by_name.find(*it) == mods_by_name.end())
-					mod.optdepends.erase(it++);
-				else
-					++it;
-			}
-
-			bool ok = true;
-			for (const std::string &dependency : mod.depends) {
-				if (mods_by_name.find(dependency) == mods_by_name.end()) {
-					mod.unsatisfied_depends.emplace(dependency);
-					ok = false;
-				}
-			}
-
-			if (ok) {
+			// If the dependencies are given:
+			// Step 1: Recursively add the name to its dependency mods
+			if (!mod_it->second.is_circular &&
+					mod_it->second.addDependingMod(
+							mod.name, mods_by_name)) {
+				// Steps 3-4: See 'addDependingMod()'
 				++mod_it;
 			} else {
+				// One of the following cases occured:
+				// 1) Hard-dependency is missing
+				// 2) Recursive dependencies were detected
+
+				// Mod cannot be satisfied: Add to the "error list"
+				// also skip it in the next loop
 				unsatisfied.push_back(mod);
 				mods_by_name.erase(mod_it++);
 			}
 		}
 	} while (mods_by_name.size() != old_list_size);
 
-	// Step 2: Recursively add the current mod to the dependency lists
-	// of its depending mods.
-	for (auto &mod : mods_by_name)
-		mod.second.addDependingMod(mod.first, mods_by_name);
-
-	// Step 3: Sort it according to the new priorities
+	// Step 5: Sort the mods by the count of mods which depend on it
 	// The mod with the most hard dependencies must be loaded first
 	std::vector<const PrioritySortedMod *> mods;
 	for (const auto &mod : mods_by_name)
 		mods.push_back(&mod.second);
 
 	std::sort(mods.begin(), mods.end(), PrioritySortedMod::sorter);
+
 	for (auto &mod : mods) {
 		m_sorted_mods.push_back(*mod->spec);
 		// clang-format off
 		verbosestream << "Sorted mod: " << mod->spec->name <<
-				"   hard_deps=" << mod->deps_chain.size() << ", soft_deps=" <<
-				mod->deps_chain.size() << std::endl;
+				"\t depending=" << mod->deps_chain.size() << std::endl;
 		// clang-format on
 	}
 
-	// Step 4: Update the list of unsatisfied mods
+	// Step 6: Update the list of unsatisfied mods
 	mods.clear();
 	mods_by_name.clear();
 	// Don't even try to dereference ModSpec now


### PR DESCRIPTION
Fixes #8601

## How it works
_Documentation in the code™_
There is now a new list to determinate how many mods depend on the mod:
   * deps_chain: Contains all mod names which either need or may need the mod

1) Dependencies are read from the mod's config
2) Mods with incomplete hard-dependencies are disabled (same as before)
3) Each mod adds itself to the list of each mod it needs
   * ...and then adds itself to the list of that mod's dependencies and so on
4) Sort the final list: Sort the `ModSpec`s according to the amount of mods depending on this mod
5) Load the mods

FYI: The code was last modified 7 years ago, in 6af8a34. Apparently it worked quite reliable so far.

## To do

- [x] Some local tests
- [ ] Submit YOUR mod dependency issues, or test the PR to see whether it works as expected

## How to test

1) Download [`mod_sorting_pack.zip`](https://github.com/minetest/minetest/files/3293490/mod_sorting_pack.zip)
2) Enable all mods inside the "Mod sorting modpack"
3) Join the world (maybe check `verbose` output)
4) Test with your own complicated dependency issues