### PR TITLE
Add "speed" group to change the walking speed on and in blocks

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1570,8 +1570,9 @@ Special groups
 * `disable_repair`: If set to 1 for a tool, it cannot be repaired using the
   `"toolrepair"` crafting recipe
 * `speed`: Changes movement speed for players and items will moving on the node.
+	Excessive use of increased speed may trigger anti-cheat on the server. Make sure you do.
    * `speed = -1`: to slow down  the movement (min. `-9`, -90%)
-   * `speed =  1`: to speed up the movement (max. `100` +1000%)
+   * `speed =  1`: to speed up the movement (max. `15` +150%)
 
 Known damage and digging time defining groups
 ---------------------------------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1571,7 +1571,7 @@ Special groups
   `"toolrepair"` crafting recipe
 * `speed`: Changes movement speed for players and items will moving on the node.
 	Only a decrease in speed is possible.
-   * `speed = -1`: to slow down the movement (min. `-99`, 1% of normal speed)
+   * `speed = -1`: to slow down the movement (min. `-100`, unable to walk)
 
 Known damage and digging time defining groups
 ---------------------------------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1570,9 +1570,8 @@ Special groups
 * `disable_repair`: If set to 1 for a tool, it cannot be repaired using the
   `"toolrepair"` crafting recipe
 * `speed`: Changes movement speed for players and items will moving on the node.
-	Excessive use of increased speed may trigger anti-cheat on the server. Make sure you do.
-   * `speed = -1`: to slow down  the movement (min. `-9`, -90%)
-   * `speed =  1`: to speed up the movement (max. `15` +150%)
+	Only a decrease in speed is possible.
+   * `speed = -1`: to slow down the movement (min. `-99`, 1% of normal speed)
 
 Known damage and digging time defining groups
 ---------------------------------------------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1569,6 +1569,9 @@ Special groups
   Slipperiness rises steadily with `slippery` value, starting at 1.
 * `disable_repair`: If set to 1 for a tool, it cannot be repaired using the
   `"toolrepair"` crafting recipe
+* `speed`: Changes movement speed for players and items will moving on the node.
+   * `speed = -1`: to slow down  the movement (min. `-9`, -90%)
+   * `speed =  1`: to speed up the movement (max. `100` +1000%)
 
 Known damage and digging time defining groups
 ---------------------------------------------

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1123,10 +1123,11 @@ float LocalPlayer::getSpeedFactor(Environment *env)
 			pos + v3s16(0, 2, 0)));
 		speed_above = itemgroup_get(f3.groups, "speed");
 	}
+
 	int speed = speed_below + speed_above;
-	if (speed != 0) {
-		return core::clamp(1.0f + f32(speed) / 10.f, 0.1f, 1.5f);
-	}
+	if (speed != 0)
+		return core::clamp(1.0f + f32(speed) / 100.f, 0.01f, 1.f);
+
 	return 1.0f;
 }
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1107,7 +1107,7 @@ float LocalPlayer::getSpeedFactor(Environment *env)
 {
 	int speed_below = 0, speed_above = 0;
 	v3s16 pos = getStandingNodePos();
-	const INodeDefManager *nodemgr = env->getGameDef()->ndef();
+	const NodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
 
 	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(pos));

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1105,16 +1105,27 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 
 float LocalPlayer::getSpeedFactor(Environment *env)
 {
-	const NodeDefManager *nodemgr = env->getGameDef()->ndef();
+	int speed_below = 0, speed_above = 0;
+	v3s16 pos = getStandingNodePos();
+	const INodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
-	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(
-			getStandingNodePos()));
-	int speed = 0;
-	if (f.walkable)
-		speed = itemgroup_get(f.groups, "speed");
 
+	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(pos));
+	if (f.walkable)
+		speed_below = itemgroup_get(f.groups, "speed");
+
+	const ContentFeatures &f2 = nodemgr->get(map->getNodeNoEx(
+		pos + v3s16(0, 1, 0)));
+	speed_above = itemgroup_get(f2.groups, "speed");
+
+	if (speed_above == 0) {
+		const ContentFeatures &f3 = nodemgr->get(map->getNodeNoEx(
+			pos + v3s16(0, 2, 0)));
+		speed_above = itemgroup_get(f3.groups, "speed");
+	}
+	int speed = speed_below + speed_above;
 	if (speed != 0) {
-		return core::clamp(1.0f + (float)speed / 10.0f, 0.1f, 10.0f);
+		return core::clamp(1.0f + f32(speed) / 10.f, 0.1f, 1.5f);
 	}
 	return 1.0f;
 }

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1126,7 +1126,7 @@ float LocalPlayer::getSpeedFactor(Environment *env)
 
 	int speed = speed_below + speed_above;
 	if (speed != 0)
-		return core::clamp(1.0f + f32(speed) / 100.f, 0.0f, 1.0f);
+		return core::clamp(1.0f + f32(speed) / 100.0f, 0.0f, 1.0f);
 
 	return 1.0f;
 }

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1110,23 +1110,23 @@ float LocalPlayer::getSpeedFactor(Environment *env)
 	const NodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
 
-	const ContentFeatures &f = nodemgr->get(map->getNodeNoEx(pos));
+	const ContentFeatures &f = nodemgr->get(map->getNode(pos));
 	if (f.walkable)
 		speed_below = itemgroup_get(f.groups, "speed");
 
-	const ContentFeatures &f2 = nodemgr->get(map->getNodeNoEx(
+	const ContentFeatures &f2 = nodemgr->get(map->getNode(
 		pos + v3s16(0, 1, 0)));
 	speed_above = itemgroup_get(f2.groups, "speed");
 
 	if (speed_above == 0) {
-		const ContentFeatures &f3 = nodemgr->get(map->getNodeNoEx(
+		const ContentFeatures &f3 = nodemgr->get(map->getNode(
 			pos + v3s16(0, 2, 0)));
 		speed_above = itemgroup_get(f3.groups, "speed");
 	}
 
 	int speed = speed_below + speed_above;
 	if (speed != 0)
-		return core::clamp(1.0f + f32(speed) / 100.f, 0.01f, 1.f);
+		return core::clamp(1.0f + f32(speed) / 100.f, 0.0f, 1.0f);
 
 	return 1.0f;
 }

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -154,6 +154,7 @@ private:
 			const f32 max_increase_V, const bool use_pitch);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);
 	float getSlipFactor(Environment *env, const v3f &speedH);
+	float getSpeedFactor(Environment *env);
 	void handleAutojump(f32 dtime, Environment *env,
 			const collisionMoveResult &result,
 			const v3f &position_before_move, const v3f &speed_before_move,


### PR DESCRIPTION
As the name says, it allows you to easily change the speed of walking along various blocks without server load.
This idea came to me from playerplus mod (https://notabug.org/TenPlus1/playerplus), which I have been using for a long time. Unfortunately, checking once every 1 second turned out to be insufficient, and checking 10 times a second I heavily loaded the server with many players. Therefore, it was decided to transfer this function to the engine. See the documentation.
Just add the group "speed = -5" or "speed = 10" to any block and walk on it.
Can be used to slow down in the snow, speeding up on asphalt, give the API modders, they will figure out what to do with it!

For #1822  and #7785