### PR TITLE
Add /spawn command

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1100,3 +1100,36 @@ core.register_chatcommand("kill", {
 		return handle_kill_command(name, param == "" and name or param)
 	end,
 })
+
+core.register_chatcommand("spawn", {
+	description = "Teleport to the spawn point",
+	privs  = {spawn = true},
+	func = function(name, param)
+		local player = core.get_player_by_name(name)
+		if not player then
+			return false
+		end
+		local spawnpoint = core.setting_get_pos("static_spawnpoint")
+		if spawnpoint then
+			player:set_pos(spawnpoint)
+			return true, "Teleporting to spawn..."
+		else
+			return false, "The spawn point is not set!"
+		end
+	end
+})
+
+core.register_chatcommand("setspawn", {
+	description = "Sets the spawn point to your current position",
+	privs = {server = true},
+	func = function(name, param)
+		local player = core.get_player_by_name(name)
+		if not player then
+			return false
+		end
+		local pos = vector.round(player:get_pos())
+		local pos_to_string = pos.x .. "," .. pos.y .. "," .. pos.z
+		core.settings:set("static_spawnpoint", pos_to_string)
+		return true, "Setting spawn point to (" .. pos_to_string .. ")"
+	end
+})

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -41,6 +41,10 @@ core.register_privilege("bring", {
 	description = "Can teleport other players",
 	give_to_singleplayer = false,
 })
+core.register_privilege("spawn", {
+	description = "Can teleport self to spawn",
+	give_to_singleplayer = false,
+})
 core.register_privilege("settime", {
 	description = "Can set the time of day using /time",
 	give_to_singleplayer = false,


### PR DESCRIPTION
Adds the command /spawn and /setspawn, respectively.
This is from some WTFPL code and slightly modified to work with new MT versions. The code simply changes the static_spawnpoint setting. It must be on every server.
There are mods that do this in some other way, but it doesn't make sense - all we want from the /spawn command is to return to the spawn point. Just like from the /home command, we are waiting for a return to our home.