### PR TITLE
Add server-side formspec context storage

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -13,6 +13,7 @@ core.features = {
 	object_use_texture_alpha = true,
 	object_independent_selectionbox = true,
 	httpfetch_binary_data = true,
+	formspec_context = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3785,7 +3785,7 @@ Call these functions only at load time!
     * Called always when a player says something
     * Return `true` to mark the message as handled, which means that it will
       not be sent to other players.
-* `minetest.register_on_player_receive_fields(function(player, formname, fields))`
+* `minetest.register_on_player_receive_fields(function(player, formname, fields, context))`
     * Called when the server received input from `player` in a formspec with
       the given `formname`. Specifically, this is called on any of the
       following events:
@@ -3820,6 +3820,7 @@ Call these functions only at load time!
           additionally, the index `key_enter_field` contains the name of the
           text field. See also: `field_close_on_enter`.
     * Newest functions are called first
+    * `context` is custom information passed from show_formspec, and stored on the server.
     * If function returns `true`, remaining functions are not called
 * `minetest.register_on_craft(function(itemstack, player, old_craft_grid, craft_inv))`
     * Called when `player` crafts something
@@ -4277,11 +4278,13 @@ Inventory
 Formspec
 --------
 
-* `minetest.show_formspec(playername, formname, formspec)`
+* `minetest.show_formspec(playername, formname, formspec, context)`
     * `playername`: name of player to show formspec
     * `formname`: name passed to `on_player_receive_fields` callbacks.
       It should follow the `"modname:<whatever>"` naming convention
     * `formspec`: formspec to display
+    * `context`: passed to `on_player_receive_fields` callbacks.
+         Can be nil, never sent to the client.
 * `minetest.close_formspec(playername, formname)`
     * `playername`: name of player to close formspec
     * `formname`: has to exactly match the one given in `show_formspec`, or the

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "../../content_sao.h"
+#include "../../remoteplayer.h"
 #include "cpp_api/s_player.h"
 #include "cpp_api/s_internal.h"
 #include "common/c_converter.h"
@@ -213,7 +215,19 @@ void ScriptApiPlayer::on_playerReceiveFields(ServerActiveObject *player,
 		lua_pushlstring(L, value.c_str(), value.size());
 		lua_settable(L, -3);
 	}
-	runCallbacks(3, RUN_CALLBACKS_MODE_OR_SC);
+	// param 4
+	if (formname.empty()) {
+		lua_pushnil(L);
+	} else {
+		lua_getglobal(L, "core");
+		int tmp = lua_gettop(L);
+		lua_getfield(L, -1, "fs_contexts");
+		lua_getfield(L, -1, ((PlayerSAO*)player)->getPlayer()->getName());
+		lua_replace(L, -3);
+		lua_settop(L, -2);
+	}
+
+	runCallbacks(4, RUN_CALLBACKS_MODE_OR_SC);
 }
 
 void ScriptApiPlayer::on_auth_failure(const std::string &name, const std::string &ip)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -360,12 +360,16 @@ int ModApiServer::l_show_formspec(lua_State *L)
 	const char *formname = luaL_checkstring(L, 2);
 	const char *formspec = luaL_checkstring(L, 3);
 
-	if(getServer(L)->showFormspec(playername,formspec,formname))
-	{
-		lua_pushboolean(L, true);
-	}else{
-		lua_pushboolean(L, false);
-	}
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "fs_contexts");
+	if (lua_isnil(L, 4))
+		lua_pushnil(L);
+	else
+		lua_pushvalue(L, 4);
+	lua_setfield(L, -2, playername);
+
+	bool suc = getServer(L)->showFormspec(playername, formspec, formname);
+	lua_pushboolean(L, suc);
 	return 1;
 }
 

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -73,6 +73,9 @@ ServerScripting::ServerScripting(Server* server):
 	lua_newtable(L);
 	lua_setfield(L, -2, "luaentities");
 
+	lua_newtable(L);
+	lua_setfield(L, -2, "fs_contexts");
+
 	// Initialize our lua_api modules
 	InitializeModApi(L, top);
 	lua_pop(L, 1);


### PR DESCRIPTION
Fixes #7535. Allows mods to store arbitrary Lua information to be passed to on_receive_fields callbacks.

Note: this is Lua API level, and technically not to do with formspecs

## How to test

<!-- Example code or instructions -->
