### PR TITLE
Increase upper limit of display_gamma

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -637,7 +637,7 @@ fov (Field of view) int 72 45 160
 
 #    Adjust the gamma encoding for the light tables. Higher numbers are brighter.
 #    This setting is for the client only and is ignored by the server.
-display_gamma (Gamma) float 1.0 0.5 3.0
+display_gamma (Gamma) float 1.0 0.5 10.0
 
 #    Gradient of light curve at minimum light level.
 lighting_alpha (Darkness sharpness) float 0.0 0.0 4.0

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -66,7 +66,7 @@ void set_light_table(float gamma)
 	params.center = g_settings->getFloat("lighting_boost_center");
 	params.sigma = g_settings->getFloat("lighting_boost_spread");
 // Gamma correction
-	params.gamma = rangelim(gamma, 0.5f, 3.0f);
+	params.gamma = rangelim(gamma, 0.5f, 10.0f);
 
 // Boundary values should be fixed
 	light_LUT[0] = 0;


### PR DESCRIPTION
Increases working upper limit of `display_gamma` to 10.0. The lower limit and default values are untouched.

Closes #8577.

## How to test

- Add the following line to `minetest.conf`
  ```
  display_gamma = 10
  ```
- Run Minetest.
<!-- Example code or instructions -->
