### PR TITLE
Add Lua sandbox to main menu

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -16,6 +16,7 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 local FILENAME = "settingtypes.txt"
+local csettings = core.get_secure_settings()
 
 local CHAR_CLASSES = {
 	SPACE = "[%s]",
@@ -484,7 +485,7 @@ local settings = full_settings
 local selected_setting = 1
 
 local function get_current_value(setting)
-	local value = core.settings:get(setting.name)
+	local value = csettings:get(setting.name)
 	if value == nil then
 		value = setting.default
 	end
@@ -492,7 +493,7 @@ local function get_current_value(setting)
 end
 
 local function get_current_np_group(setting)
-	local value = core.settings:get_np_group(setting.name)
+	local value = csettings:get_np_group(setting.name)
 	local t = {}
 	if value == nil then
 		t = setting.values
@@ -512,7 +513,7 @@ local function get_current_np_group(setting)
 end
 
 local function get_current_np_group_as_string(setting)
-	local value = core.settings:get_np_group(setting.name)
+	local value = csettings:get_np_group(setting.name)
 	local t
 	if value == nil then
 		t = setting.default
@@ -788,11 +789,11 @@ local function handle_change_setting_buttons(this, fields)
 		if setting.type == "bool" then
 			local new_value = fields["dd_setting_value"]
 			-- Note: new_value is the actual (translated) value shown in the dropdown
-			core.settings:set_bool(setting.name, new_value == fgettext("Enabled"))
+			csettings:set_bool(setting.name, new_value == fgettext("Enabled"))
 
 		elseif setting.type == "enum" then
 			local new_value = fields["dd_setting_value"]
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 
 		elseif setting.type == "int" then
 			local new_value = tonumber(fields["te_setting_value"])
@@ -814,7 +815,7 @@ local function handle_change_setting_buttons(this, fields)
 				core.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 
 		elseif setting.type == "float" then
 			local new_value = tonumber(fields["te_setting_value"])
@@ -836,7 +837,7 @@ local function handle_change_setting_buttons(this, fields)
 				core.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 
 		elseif setting.type == "flags" then
 			local values = {}
@@ -853,7 +854,7 @@ local function handle_change_setting_buttons(this, fields)
 			checkboxes = {}
 
 			local new_value = table.concat(values, ", ")
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 
 		elseif setting.type == "noise_params_2d" or setting.type == "noise_params_3d" then
 			local np_flags = {}
@@ -882,20 +883,20 @@ local function handle_change_setting_buttons(this, fields)
 				lacunarity = fields["te_lacun"],
 				flags = table.concat(np_flags, ", ")
 			}
-			core.settings:set_np_group(setting.name, new_value)
+			csettings:set_np_group(setting.name, new_value)
 
 		elseif setting.type == "v3f" then
 			local new_value = "("
 					.. fields["te_x"] .. ", "
 					.. fields["te_y"] .. ", "
 					.. fields["te_z"] .. ")"
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 
 		else
 			local new_value = fields["te_setting_value"]
-			core.settings:set(setting.name, new_value)
+			csettings:set(setting.name, new_value)
 		end
-		core.settings:write()
+		csettings:write()
 		this:delete()
 		return true
 	end
@@ -945,7 +946,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 	local current_level = 0
 	for _, entry in ipairs(settings) do
 		local name
-		if not core.settings:get_bool("main_menu_technical_settings") and entry.readable_name then
+		if not csettings:get_bool("main_menu_technical_settings") and entry.readable_name then
 			name = fgettext_ne(entry.readable_name)
 		else
 			name = entry.name
@@ -986,7 +987,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 			"button[10,4.9;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
 			"button[7,4.9;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
 			"checkbox[0,4.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
-					.. dump(core.settings:get_bool("main_menu_technical_settings")) .. "]"
+					.. dump(csettings:get_bool("main_menu_technical_settings")) .. "]"
 
 	return formspec
 end
@@ -1000,8 +1001,8 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 			local setting = settings[selected_setting]
 			if setting and setting.type == "bool" then
 				local current_value = get_current_value(setting)
-				core.settings:set_bool(setting.name, not core.is_yes(current_value))
-				core.settings:write()
+				csettings:set_bool(setting.name, not core.is_yes(current_value))
+				csettings:write()
 				return true
 			else
 				list_enter = true
@@ -1056,8 +1057,8 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	if fields["btn_restore"] then
 		local setting = settings[selected_setting]
 		if setting and setting.type ~= "category" then
-			core.settings:remove(setting.name)
-			core.settings:write()
+			csettings:remove(setting.name)
+			csettings:write()
 			core.update_formspec(this:get_formspec())
 		end
 		return true
@@ -1069,8 +1070,8 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 
 	if fields["cb_tech_settings"] then
-		core.settings:set("main_menu_technical_settings", fields["cb_tech_settings"])
-		core.settings:write()
+		csettings:set("main_menu_technical_settings", fields["cb_tech_settings"])
+		csettings:write()
 		core.update_formspec(this:get_formspec())
 		return true
 	end

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -66,6 +66,10 @@ core.get_video_drivers()
 core.get_mapgen_names([include_hidden=false]) -> table of map generator algorithms
     registered in the core (possible in async calls)
 core.get_cache_path() -> path of cache
+core.get_secure_settings()
+^ Settings() object which can write to `secure.` settings
+^ Will return `nil` if file is not permitted access.
+  Can only be requested in `<mainmenudir>/dlg_settings_advanced.lua`
 
 Formspec:
 core.update_formspec(formspec)

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -619,3 +619,44 @@ unsigned int GUIEngine::queueAsync(const std::string &serialized_func,
 {
 	return m_script->queueAsync(serialized_func, serialized_params);
 }
+
+/******************************************************************************/
+bool GUIEngine::CheckAbsPath(const std::string &path, bool *write_allowed)
+{
+	if (path.empty())
+		return false;
+
+	if (fs::PathStartsWith(path, fs::TempPath()) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "games")) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "mods")) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "textures")) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user + DIR_DELIM "worlds")) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_cache))) {
+		if (write_allowed)
+			*write_allowed = true;
+		return true;
+	}
+
+	if (fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_share)) ||
+			fs::PathStartsWith(path, fs::RemoveRelativePathComponents(porting::path_user))) {
+		if (write_allowed)
+			*write_allowed = false;
+		return true;
+	}
+
+	return false;
+}
+
+/******************************************************************************/
+bool GUIEngine::MayModifyPath(const std::string &path)
+{
+	bool ret = false;
+	CheckAbsPath(fs::AbsolutePath(path), &ret);
+	return ret;
+}
+
+/******************************************************************************/
+bool GUIEngine::MayReadPath(const std::string &path)
+{
+	return CheckAbsPath(fs::AbsolutePath(path));
+}

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -178,6 +178,36 @@ public:
 	unsigned int queueAsync(const std::string &serialized_fct,
 			const std::string &serialized_params);
 
+	/**
+	 * Checks if a path may be read or modified.
+	 * Paths in the temp directory or the user
+	 * games, mods, textures, or worlds directories may be modified.
+	 *
+	 * Path **must** be an absolute path with no relative components
+	 *
+	 * @param path path to check
+	 * @param write_allowed pointer to return write status
+	 * @return true if the path may be read
+	 */
+	static bool CheckAbsPath(const std::string &path, bool *write_allowed=nullptr);
+
+	/**
+	 * Checks if a (relative or absolute) path may be modified.
+	 * Paths in the temp directory or the user
+	 * games, mods, textures, or worlds directories may be modified.
+	 * @param path path to check
+	 * @return true if the path may be modified
+	 */
+	static bool MayModifyPath(const std::string &path);
+
+	/**
+	 * Checks if a (relative or absolute) path may be read.
+	 * Paths in the temp directory or the user directories may be read
+	 * @param path path to check
+	 * @return true if the path may be read
+	 */
+	static bool MayReadPath(const std::string &path);
+
 private:
 
 	/** find and run the main menu script */

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -503,10 +503,12 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
 	lua_pop(L, 1);
 
+#ifndef SERVER
 	// Mainmenu has read access to all of Minetest's files, but writing is restricted.
 	if (script->getType() == ScriptingType::MainMenu) {
 		return GUIEngine::CheckAbsPath(abs_path, write_allowed);
 	}
+#endif
 
 	const IGameDef *gamedef = script->getGameDef();
 	if (!gamedef)

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server.h"
 #include "client/client.h"
 #include "settings.h"
+#include "gui/guiEngine.h"
 
 #include <cerrno>
 #include <string>
@@ -501,6 +502,12 @@ bool ScriptApiSecurity::checkPath(lua_State *L, const char *path,
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_SCRIPTAPI);
 	ScriptApiBase *script = (ScriptApiBase *) lua_touserdata(L, -1);
 	lua_pop(L, 1);
+
+	// Mainmenu has read access to all of Minetest's files, but writing is restricted.
+	if (script->getType() == ScriptingType::MainMenu) {
+		return GUIEngine::CheckAbsPath(abs_path, write_allowed);
+	}
+
 	const IGameDef *gamedef = script->getGameDef();
 	if (!gamedef)
 		return false;

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -56,7 +56,7 @@ public:
 	static bool safeLoadFile(lua_State *L, const char *path, const char *display_name = NULL);
 	// Checks if mods are allowed to read (and optionally write) to the path
 	static bool checkPath(lua_State *L, const char *path, bool write_required,
-			bool *write_allowed=NULL);
+			bool *write_allowed=nullptr);
 
 private:
 	// Syntax: "sl_" <Library name or 'g' (global)> '_' <Function name>

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -996,11 +996,10 @@ int ModApiMainMenu::l_gettext(lua_State *L)
 int ModApiMainMenu::l_get_secure_settings(lua_State *L)
 {
 	if (ScriptApiSecurity::isSecure(L)) {
-		// We have to make sure that this function is being called directly by
-		// a mod, otherwise a malicious mod could override this function and
-		// steal its return value.
+		// We have to make sure that this function is being called by the correct
+		// whitelisted file, otherwise a malicious game script could change
+		// secure settings and escape the sandbox
 		lua_Debug info;
-		// Make sure there's only one item below this function on the stack...
 		if (lua_getstack(L, 6, &info)) {
 			return 0;
 		}

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -72,6 +72,8 @@ private:
 
 	static int l_gettext(lua_State *L);
 
+	static int l_get_secure_settings(lua_State *L);
+
 	//packages
 
 	static int l_get_games(lua_State *L);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -52,14 +52,6 @@ private:
 	 */
 	static int getBoolData(lua_State *L, std::string name,bool& valid);
 
-	/**
-	 * Checks if a path may be modified. Paths in the temp directory or the user
-	 * games, mods, textures, or worlds directories may be modified.
-	 * @param path path to check
-	 * @return true if the path may be modified
-	 */
-	static bool mayModifyPath(const std::string &path);
-
 	//api calls
 
 	static int l_start(lua_State *L);

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -26,14 +26,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 
 #define SET_SECURITY_CHECK(L, name) \
-	if (o->m_settings == g_settings && ScriptApiSecurity::isSecure(L) && \
+	if (o->m_security_enabled && o->m_settings == g_settings && ScriptApiSecurity::isSecure(L) && \
 			name.compare(0, 7, "secure.") == 0) { \
 		throw LuaError("Attempt to set secure setting."); \
 	}
 
-LuaSettings::LuaSettings(Settings *settings, const std::string &filename) :
+LuaSettings::LuaSettings(Settings *settings, const std::string &filename, bool security_enabled) :
 	m_settings(settings),
-	m_filename(filename)
+	m_filename(filename),
+	m_security_enabled(security_enabled)
 {
 }
 
@@ -54,9 +55,9 @@ LuaSettings::~LuaSettings()
 
 
 void LuaSettings::create(lua_State *L, Settings *settings,
-		const std::string &filename)
+		const std::string &filename, bool security_enabled)
 {
-	LuaSettings *o = new LuaSettings(settings, filename);
+	LuaSettings *o = new LuaSettings(settings, filename, security_enabled);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -70,11 +70,13 @@ private:
 	bool m_security_enabled = true;
 
 public:
-	LuaSettings(Settings *settings, const std::string &filename, bool security_enabled);
+	LuaSettings(Settings *settings, const std::string &filename,
+			bool security_enabled);
 	LuaSettings(const std::string &filename, bool write_allowed);
 	~LuaSettings();
 
-	static void create(lua_State *L, Settings *settings, const std::string &filename, bool security_enabled=true);
+	static void create(lua_State *L, Settings *settings, const std::string &filename,
+			bool security_enabled=true);
 
 	// LuaSettings(filename)
 	// Creates a LuaSettings and leaves it on top of the stack

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -67,13 +67,14 @@ private:
 	std::string m_filename;
 	bool m_is_own_settings = false;
 	bool m_write_allowed = true;
+	bool m_security_enabled = true;
 
 public:
-	LuaSettings(Settings *settings, const std::string &filename);
+	LuaSettings(Settings *settings, const std::string &filename, bool security_enabled);
 	LuaSettings(const std::string &filename, bool write_allowed);
 	~LuaSettings();
 
-	static void create(lua_State *L, Settings *settings, const std::string &filename);
+	static void create(lua_State *L, Settings *settings, const std::string &filename, bool security_enabled=true);
 
 	// LuaSettings(filename)
 	// Creates a LuaSettings and leaves it on top of the stack

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_util.h"
 #include "lua_api/l_settings.h"
 #include "log.h"
+#include "gui/guiEngine.h"
 
 extern "C" {
 #include "lualib.h"
@@ -40,6 +41,8 @@ MainMenuScripting::MainMenuScripting(GUIEngine* guiengine):
 	setGuiEngine(guiengine);
 
 	SCRIPTAPI_PRECHECKHEADER
+
+	initializeSecurity();
 
 	lua_getglobal(L, "core");
 	int top = lua_gettop(L);
@@ -95,4 +98,3 @@ unsigned int MainMenuScripting::queueAsync(const std::string &serialized_func,
 {
 	return asyncEngine.queueAsyncJob(serialized_func, serialized_param);
 }
-

--- a/src/script/scripting_mainmenu.h
+++ b/src/script/scripting_mainmenu.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_mainmenu.h"
 #include "cpp_api/s_async.h"
+#include "cpp_api/s_security.h"
+
 
 /*****************************************************************************/
 /* Scripting <-> Main Menu Interface                                         */
@@ -29,7 +31,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 class MainMenuScripting
 		: virtual public ScriptApiBase,
-		  public ScriptApiMainMenu
+		  public ScriptApiMainMenu,
+		  public ScriptApiSecurity
+
 {
 public:
 	MainMenuScripting(GUIEngine* guiengine);


### PR DESCRIPTION
This enables Lua security for the main menu. The sandbox is the least strict of all the sandboxes, and allows full read access to Minetest resources but limited write access.

This is needed to facilitate per-game menu scripts automatically running in the future. In the meantime, it makes bugs in the main menu less dangerous

## To do

- [x] Readd support for changing secure settings in the main menu

## How to test

<!-- Example code or instructions -->
