### PR TITLE
Add Full Screen Sized FormSpecs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1875,9 +1875,14 @@ is used when the server receives user input. You must not use the name
 Spaces and newlines can be inserted between the blocks, as is used in the
 examples.
 
-Position and size units are inventory slots, `X` and `Y` position the formspec
-element relative to the top left of the menu or container. `W` and `H` are its
-width and height values.
+Position and size units are inventory slots unless the new coordinating system
+is enabled. `X` and `Y` position the formspec element relative to the top left
+of the menu or container. `W` and `H` are its width and height values.
+
+If the new system is enabled, all elements have unified cooridinates for all
+elements with no padding or spacing in between. This is highly recommended
+for new forms. See `real_coordinates[<bool>]`.
+
 Inventories with a `player:<name>` inventory location are only sent to the
 player named `<name>`.
 
@@ -1951,6 +1956,14 @@ Elements
 * Must be used after the `size`, `position`, and `anchor` elements (if present).
 * Disables player:set_formspec_prepend() from applying to this formspec.
 
+### `real_coordinates[<bool>]`
+
+* Must be used either before or anywhere after `size`, `position`, `anchor`, and
+  `no_prepend` (if present) elements.
+* When set to true, all following formspec elements will use the new coordinate system.
+* **Note**: Formspec prepends are not affected by the coordinates in the main form.
+  They must enable it explicitly.
+
 ### `container[<X>,<Y>]`
 
 * Start of a container block, moves all physical elements in the container by
@@ -1968,11 +1981,15 @@ Elements
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
+* **Note**: The spacing between inventory places is not affected by the
+  new coordinate system.
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
+* **Note**: The spacing between inventory places is not affected by the
+  new coordinate system.
 
 ### `listring[<inventory location>;<list name>]`
 
@@ -2064,7 +2081,8 @@ Elements
 * Textual password style field; will be sent to server when a button is clicked
 * When enter is pressed in field, fields.key_enter_field will be sent with the
   name of this field.
-* Fields are a set height, but will be vertically centred on `H`
+* Fields are a set height, but will be vertically centred on `H` with the old
+  system.  With the new coordinate system, `H` will modify the height.
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
 * See `field_close_on_enter` to stop enter closing the formspec
@@ -2074,7 +2092,8 @@ Elements
 * Textual field; will be sent to server when a button is clicked
 * When enter is pressed in field, `fields.key_enter_field` will be sent with
   the name of this field.
-* Fields are a set height, but will be vertically centred on `H`
+* Fields are a set height, but will be vertically centred on `H` with the old
+  system.  With the new coordinate system, `H` will modify the height.
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
 * `default` is the default value of the field
@@ -2112,7 +2131,8 @@ Elements
 * The label formspec element displays the text set in `label`
   at the specified position.
 * The text is displayed directly without automatic line breaking,
-  so label should not be used for big text chunks.
+  so label should not be used for big text chunks.  Newlines can be
+  used to make labels multiline, but `textarea` is preferred.
 
 ### `vertlabel[<X>,<Y>;<label>]`
 
@@ -2122,12 +2142,14 @@ Elements
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
 * Clickable button. When clicked, fields will be sent.
-* Fixed button height. It will be vertically centred on `H`
+* Fixed button height. It will be vertically centred on `H` with the old system.
+  With the new coordinate system, `H` will modify the height.
 * `label` is the text on the button
 
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * `texture name` is the filename of an image
+* **Note**: Height can be modified on image buttons.
 
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>;<noclip>;<drawborder>;<pressed texture name>]`
 
@@ -2146,10 +2168,12 @@ Elements
 ### `button_exit[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
 * When clicked, fields will be sent and the form will quit.
+* Same as `button` in all other respects.
 
 ### `image_button_exit[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * When clicked, fields will be sent and the form will quit.
+* Same as `button` in all other respects.
 
 ### `textlist[<X>,<Y>;<W>,<H>;<name>;<listelem 1>,<listelem 2>,...,<listelem n>]`
 
@@ -2175,6 +2199,22 @@ Elements
 ### `tabheader[<X>,<Y>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
+* `x` and `y`: position of the tabheader
+* `name` fieldname data is transferred to Lua
+* `caption 1`...: name shown on top of tab
+* `current_tab`: index of selected tab 1...
+* `transparent` (optional): show transparent
+* `draw_border` (optional): draw border
+
+### `tabheader[<X>,<Y>;<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
+
+* Show a tab**header** at specific position (ignores formsize)
+* **Important note**: This syntax for tabheaders can only be used if the new
+  coordinate system is enabled.
+* `x` and `y`: position of the tabheader
+* `h`: height of the tabheader
+* **Important Note**: The tabheader height can only be modified if the new
+  coordinate system is enabled.
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
@@ -2193,8 +2233,22 @@ Elements
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
-* `x` and `y` position of dropdown
-* Width of dropdown
+* `x` and `y`: position of the dropdown
+* `w`: width of the dropdown
+* Fieldname data is transferred to Lua
+* Items to be shown in dropdown
+* Index of currently selected dropdown item
+
+### `dropdown[<X>,<Y>;<W>,<H>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
+
+* Show a dropdown field
+* **Important note**: This syntax for dropdowns can only be used if the new
+  coordinate system is enabled.
+* **Important note**: There are two different operation modes:
+    1. handle directly on change (only changed dropdown is submitted)
+    2. read the value on pressing a button (all dropdown values are available)
+* `x` and `y`: position of the dropdown
+* `w` and `h`: width and height of the dropdown
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
@@ -3734,7 +3788,6 @@ Call these functions only at load time!
     * Called after a new player has been created
 * `minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage))`
     * Called when a player is punched
-    * Note: This callback is invoked even if the punched player is dead.
     * `player`: ObjectRef - Player that was punched
     * `hitter`: ObjectRef - Player that hit
     * `time_from_last_punch`: Meant for disallowing spamming of clicks
@@ -5399,11 +5452,6 @@ This is basically a reference to a C++ `ServerActiveObject`
     * in first person view
     * in third person view (max. values `{x=-10/10,y=-10,15,z=-5/5}`)
 * `get_eye_offset()`: returns `offset_first` and `offset_third`
-* `send_mapblock(blockpos)`:
-    * Sends a server-side loaded mapblock to the player.
-    * Returns `false` if failed.
-    * Resource intensive - use sparsely
-    * To get blockpos, integer divide pos by 16
 
 `PcgRandom`
 -----------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2081,8 +2081,8 @@ Elements
 * Textual password style field; will be sent to server when a button is clicked
 * When enter is pressed in field, fields.key_enter_field will be sent with the
   name of this field.
-* Fields are a set height, but will be vertically centred on `H` with the old
-  system.  With the new coordinate system, `H` will modify the height.
+* With the old coordinate system, fields are a set height, but will be vertically
+  centred on `H`. With the new coordinate system, `H` will modify the height.
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
 * See `field_close_on_enter` to stop enter closing the formspec
@@ -2199,6 +2199,8 @@ Elements
 ### `tabheader[<X>,<Y>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
+* **Important note**: This syntax for tabheaders can only be used with the
+  old coordinate system.
 * `X` and `Y`: position of the tabheader
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
@@ -2209,8 +2211,8 @@ Elements
 ### `tabheader[<X>,<Y>;<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
-* **Important Note**: The tabheader height can only be modified if the new
-  coordinate system is enabled.
+* **Important note**: This syntax for tabheaders can only be used with the
+  new coordinate system.
 * `X` and `Y`: position of the tabheader
 * `H`: height of the tabheader
 * `name` fieldname data is transferred to Lua
@@ -2228,6 +2230,8 @@ Elements
 ### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
 
 * Show a dropdown field
+* **Important note**: This syntax for dropdowns can only be used with the
+  old coordinate system.
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
@@ -2240,8 +2244,8 @@ Elements
 ### `dropdown[<X>,<Y>;<W>,<H>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
 
 * Show a dropdown field
-* **Important note**: This syntax for dropdowns can only be used if the new
-  coordinate system is enabled.
+* **Important note**: This syntax for dropdowns can only be used with the
+  new coordinate system.
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
@@ -3786,7 +3790,7 @@ Call these functions only at load time!
     * Called after a new player has been created
 * `minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage))`
     * Called when a player is punched
-	* Note: This callback is invoked even if the punched player is dead.
+    * Note: This callback is invoked even if the punched player is dead.
     * `player`: ObjectRef - Player that was punched
     * `hitter`: ObjectRef - Player that hit
     * `time_from_last_punch`: Meant for disallowing spamming of clicks

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2201,6 +2201,7 @@ Elements
 
 * Show a tab**header** at specific position (ignores formsize)
 * `X` and `Y`: position of the tabheader
+* *Note*: Width and height are automatically chosen with this syntax
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
@@ -2213,7 +2214,20 @@ Elements
 * **Important note**: This syntax for tabheaders can only be used with the
   new coordinate system.
 * `X` and `Y`: position of the tabheader
-* `H`: height of the tabheader
+* `H`: height of the tabheader. Width is automatically determined with this syntax.
+* `name` fieldname data is transferred to Lua
+* `caption 1`...: name shown on top of tab
+* `current_tab`: index of selected tab 1...
+* `transparent` (optional): show transparent
+* `draw_border` (optional): draw border
+
+### `tabheader[<X>,<Y>;<W>,<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
+
+* Show a tab**header** at specific position (ignores formsize)
+* **Important note**: This syntax for tabheaders can only be used with the
+  new coordinate system.
+* `X` and `Y`: position of the tabheader
+* `W` and `H`: width and height of the tabheader
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
@@ -2233,7 +2247,7 @@ Elements
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
 * `X` and `Y`: position of the dropdown
-* `W`: width of the dropdown
+* `W`: width of the dropdown. Height is automatically chosen with this syntax.
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2130,14 +2130,21 @@ Elements
 
 * The label formspec element displays the text set in `label`
   at the specified position.
+* **Note**: If the new coordinate system is enabled, labels are
+  positioned from the center of the text, not the top.
 * The text is displayed directly without automatic line breaking,
   so label should not be used for big text chunks.  Newlines can be
-  used to make labels multiline, but `textarea` is preferred.
+  used to make labels multiline.
+* **Note**: With the new coordinate system, newlines are spaced with
+  half a coordinate.  With the old system, newlines are spaced 2/5 of
+  an inventory slot.
 
 ### `vertlabel[<X>,<Y>;<label>]`
 
 * Textual label drawn vertically
 * `label` is the text on the label
+* **Note**: If the new coordinate system is enabled, vertlabels are
+  positioned from the center of the text, not the left.
 
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
@@ -2272,6 +2279,8 @@ Elements
 * `name` fieldname data is transferred to Lua
 * `label` to be shown left of checkbox
 * `selected` (optional): `true`/`false`
+* **Note**: If the new coordinate system is enabled, checkboxes are
+  positioned from the center of the checkbox, not the top.
 
 ### `scrollbar[<X>,<Y>;<W>,<H>;<orientation>;<name>;<value>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2392,7 +2392,7 @@ offsets when migrating:
 |---------|------------|---------|-------
 | box     | +0.3, +0.1 | 0, -0.4 |
 | button  |            |         | Buttons now support height, so you will need to set h=1 and reposition if h!=1 before
-| list    |            |         | Note: spacing is now 0.25 for both directions, meaning lists will be taller in height
+| list    |            |         | Spacing is now 0.25 for both directions, meaning lists will be taller in height
 | label   |            |  +0.3   | The first line of text is now positioned centered exactly at the position specified
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1879,7 +1879,7 @@ Position and size units are inventory slots unless the new coordinating system
 is enabled. `X` and `Y` position the formspec element relative to the top left
 of the menu or container. `W` and `H` are its width and height values.
 
-If the new system is enabled, all elements have unified cooridinates for all
+If the new system is enabled, all elements have unified coordinates for all
 elements with no padding or spacing in between. This is highly recommended
 for new forms. See `real_coordinates[<bool>]`.
 
@@ -1981,15 +1981,15 @@ Elements
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
-* **Note**: The spacing between inventory slots is not affected by the
-  new coordinate system.
+* **Note**: With the new coordinate system, the spacing between inventory
+  slots is one-fourth the size of an inventory slot.
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
-* **Note**: The spacing between inventory slots is not affected by the
-  new coordinate system.
+* **Note**: With the new coordinate system, the spacing between inventory
+  slots is one-fourth the size of an inventory slot.
 
 ### `listring[<inventory location>;<list name>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1981,14 +1981,14 @@ Elements
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
-* **Note**: The spacing between inventory places is not affected by the
+* **Note**: The spacing between inventory slots is not affected by the
   new coordinate system.
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 
 * Show an inventory list if it has been sent to the client. Nothing will
   be shown if the inventory list is of size 0.
-* **Note**: The spacing between inventory places is not affected by the
+* **Note**: The spacing between inventory slots is not affected by the
   new coordinate system.
 
 ### `listring[<inventory location>;<list name>]`
@@ -2092,8 +2092,8 @@ Elements
 * Textual field; will be sent to server when a button is clicked
 * When enter is pressed in field, `fields.key_enter_field` will be sent with
   the name of this field.
-* Fields are a set height, but will be vertically centred on `H` with the old
-  system.  With the new coordinate system, `H` will modify the height.
+* With the old coordinate system, fields are a set height, but will be vertically
+  centred on `H`. With the new coordinate system, `H` will modify the height.
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
 * `default` is the default value of the field
@@ -2142,8 +2142,8 @@ Elements
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
 * Clickable button. When clicked, fields will be sent.
-* Fixed button height. It will be vertically centred on `H` with the old system.
-  With the new coordinate system, `H` will modify the height.
+* With the old coordinate system, buttons are a set height, but will be vertically
+  centred on `H`. With the new coordinate system, `H` will modify the height.
 * `label` is the text on the button
 
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2149,7 +2149,8 @@ Elements
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * `texture name` is the filename of an image
-* **Note**: Height can be modified on image buttons.
+* **Note**: Height is supported on both the old and new coordinate systems
+  for image_buttons.
 
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>;<noclip>;<drawborder>;<pressed texture name>]`
 
@@ -2199,8 +2200,6 @@ Elements
 ### `tabheader[<X>,<Y>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
-* **Important note**: This syntax for tabheaders can only be used with the
-  old coordinate system.
 * `X` and `Y`: position of the tabheader
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
@@ -2230,8 +2229,6 @@ Elements
 ### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
 
 * Show a dropdown field
-* **Important note**: This syntax for dropdowns can only be used with the
-  old coordinate system.
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2212,7 +2212,7 @@ Elements
 * **Important note**: This syntax for tabheaders can only be used if the new
   coordinate system is enabled.
 * `X` and `Y`: position of the tabheader
-* `W`: height of the tabheader
+* `H`: height of the tabheader
 * **Important Note**: The tabheader height can only be modified if the new
   coordinate system is enabled.
 * `name` fieldname data is transferred to Lua

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1881,7 +1881,8 @@ of the menu or container. `W` and `H` are its width and height values.
 
 If the new system is enabled, all elements have unified coordinates for all
 elements with no padding or spacing in between. This is highly recommended
-for new forms. See `real_coordinates[<bool>]`.
+for new forms. See `real_coordinates[<bool>]` and `Migrating to Real
+Coordinates`.
 
 Inventories with a `player:<name>` inventory location are only sent to the
 player named `<name>`.
@@ -1963,6 +1964,8 @@ Elements
   (if present), the form size will use the new coordinate system.
 * **Note**: Formspec prepends are not affected by the coordinates in the main form.
   They must enable it explicitly.
+* For information on converting forms to the new coordinate system, see `Migrating
+  to Real Coordinates`.
 
 ### `container[<X>,<Y>]`
 
@@ -2356,6 +2359,44 @@ Elements
 
 **Note**: do _not_ use a element name starting with `key_`; those names are
 reserved to pass key press events to formspec!
+
+
+
+
+Migrating to Real Coordinates
+=============================
+
+In the old system, positions included padding and spacing. Padding is a gap between
+the formspec window edges and content, and spacing is the gaps between items. For
+example, two `1x1` elements at `0,0` and `1,1` would have a spacing of `5/4` between them,
+and a padding of `3/8` from the formspec edge. It may be easiest to recreate old layouts
+in the new coordinate system from scratch.
+
+To recreate an old layout with padding, you'll need to pass the positions and sizes
+through the following formula to re-introduce padding:
+
+```
+pos = (oldpos + 1)*spacing + padding
+where
+    padding = 3/8
+    spacing = 5/4
+```
+
+You'll need to change the `size[]` tag like this:
+
+```
+size = (oldsize-1)*spacing + padding*2 + 1
+```
+
+A few elements had random offsets in the old system. Here is a table which shows these
+offsets when migrating:
+
+| Element |  Position  |  Size   | Notes
+|---------|------------|---------|-------
+| box     | +0.3, +0.1 | 0, -0.4 |
+| button  |            |         | Buttons now support height, so you will need to set h=1 and reposition if h!=1 before
+| list    |            |         | Note: spacing is now 0.25 for both directions, meaning lists will be taller in height
+| label   |            |  +0.3   | The first line of text is now positioned centered exactly at the position specified
 
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2360,11 +2360,8 @@ Elements
 **Note**: do _not_ use a element name starting with `key_`; those names are
 reserved to pass key press events to formspec!
 
-
-
-
 Migrating to Real Coordinates
-=============================
+-----------------------------
 
 In the old system, positions included padding and spacing. Padding is a gap between
 the formspec window edges and content, and spacing is the gaps between items. For

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1875,7 +1875,7 @@ is used when the server receives user input. You must not use the name
 Spaces and newlines can be inserted between the blocks, as is used in the
 examples.
 
-Position and size units are inventory slots unless the new coordinating system
+Position and size units are inventory slots unless the new coordinate system
 is enabled. `X` and `Y` position the formspec element relative to the top left
 of the menu or container. `W` and `H` are its width and height values.
 
@@ -1958,9 +1958,9 @@ Elements
 
 ### `real_coordinates[<bool>]`
 
-* Must be used either before or anywhere after `size`, `position`, `anchor`, and
-  `no_prepend` (if present) elements.
 * When set to true, all following formspec elements will use the new coordinate system.
+* If used immediately after `size`, `position`, `anchor`, and `no_prepend` elements
+  (if present), the form size will use the new coordinate system.
 * **Note**: Formspec prepends are not affected by the coordinates in the main form.
   They must enable it explicitly.
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1923,10 +1923,14 @@ Examples
 Elements
 --------
 
-### `size[<W>,<H>,<fixed_size>]`
+### `size[<W>,<H>,<size type>]`
 
 * Define the size of the menu in inventory slots
-* `fixed_size`: `true`/`false` (optional)
+* `size type`: `false`/`true`/`stretch` (optional)
+    * `false`: Scaled form size.  This is default.
+    * `true`: Fixed 800x600 pixel form size.  Acts like `false` on Android.
+    * `stretch`: Fills entire screen. Coordinates are stretched accordingly. This
+      only works with the new coordinate system.
 * deprecated: `invsize[<W>,<H>;]`
 
 ### `position[<X>,<Y>]`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2173,7 +2173,7 @@ Elements
 ### `image_button_exit[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * When clicked, fields will be sent and the form will quit.
-* Same as `button` in all other respects.
+* Same as `image_button` in all other respects.
 
 ### `textlist[<X>,<Y>;<W>,<H>;<name>;<listelem 1>,<listelem 2>,...,<listelem n>]`
 
@@ -2199,7 +2199,7 @@ Elements
 ### `tabheader[<X>,<Y>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
-* `x` and `y`: position of the tabheader
+* `X` and `Y`: position of the tabheader
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
@@ -2211,8 +2211,8 @@ Elements
 * Show a tab**header** at specific position (ignores formsize)
 * **Important note**: This syntax for tabheaders can only be used if the new
   coordinate system is enabled.
-* `x` and `y`: position of the tabheader
-* `h`: height of the tabheader
+* `X` and `Y`: position of the tabheader
+* `W`: height of the tabheader
 * **Important Note**: The tabheader height can only be modified if the new
   coordinate system is enabled.
 * `name` fieldname data is transferred to Lua
@@ -2233,8 +2233,8 @@ Elements
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
-* `x` and `y`: position of the dropdown
-* `w`: width of the dropdown
+* `X` and `Y`: position of the dropdown
+* `W`: width of the dropdown
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
@@ -2247,8 +2247,8 @@ Elements
 * **Important note**: There are two different operation modes:
     1. handle directly on change (only changed dropdown is submitted)
     2. read the value on pressing a button (all dropdown values are available)
-* `x` and `y`: position of the dropdown
-* `w` and `h`: width and height of the dropdown
+* `X` and `Y`: position of the dropdown
+* `W` and `H`: width and height of the dropdown
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
@@ -3788,6 +3788,7 @@ Call these functions only at load time!
     * Called after a new player has been created
 * `minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage))`
     * Called when a player is punched
+	* Note: This callback is invoked even if the punched player is dead.
     * `player`: ObjectRef - Player that was punched
     * `hitter`: ObjectRef - Player that hit
     * `time_from_last_punch`: Meant for disallowing spamming of clicks
@@ -5452,6 +5453,11 @@ This is basically a reference to a C++ `ServerActiveObject`
     * in first person view
     * in third person view (max. values `{x=-10/10,y=-10,15,z=-5/5}`)
 * `get_eye_offset()`: returns `offset_first` and `offset_third`
+* `send_mapblock(blockpos)`:
+    * Sends a server-side loaded mapblock to the player.
+    * Returns `false` if failed.
+    * Resource intensive - use sparsely
+    * To get blockpos, integer divide pos by 16
 
 `PcgRandom`
 -----------

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2391,9 +2391,9 @@ offsets when migrating:
 | Element |  Position  |  Size   | Notes
 |---------|------------|---------|-------
 | box     | +0.3, +0.1 | 0, -0.4 |
-| button  |            |         | Buttons now support height, so you will need to set h=1 and reposition if h!=1 before
+| button  |            |         | Buttons now support height, so set h = 2 * 15/13 * 0.35, and reposition if h ~= 15/13 * 0.35 before
 | list    |            |         | Spacing is now 0.25 for both directions, meaning lists will be taller in height
-| label   |            |  +0.3   | The first line of text is now positioned centered exactly at the position specified
+| label   | 0, +0.3    |         | The first line of text is now positioned centered exactly at the position specified
 
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2209,12 +2209,10 @@ Elements
 ### `tabheader[<X>,<Y>;<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
 * Show a tab**header** at specific position (ignores formsize)
-* **Important note**: This syntax for tabheaders can only be used if the new
+* **Important Note**: The tabheader height can only be modified if the new
   coordinate system is enabled.
 * `X` and `Y`: position of the tabheader
 * `H`: height of the tabheader
-* **Important Note**: The tabheader height can only be modified if the new
-  coordinate system is enabled.
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2565,8 +2565,8 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 			s32 x;
 			s32 y;
 			if (s.real_coordinates) {
-				x = (i%s.geom.X) * (imgsize.X * 1.5);
-				y = (i/s.geom.X) * (imgsize.Y * 1.5);
+				x = (i%s.geom.X) * (imgsize.X * 1.25);
+				y = (i/s.geom.X) * (imgsize.Y * 1.25);
 			} else {
 				x = (i%s.geom.X) * spacing.X;
 				y = (i/s.geom.X) * spacing.Y;
@@ -2615,8 +2615,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		s32 x;
 		s32 y;
 		if (s.real_coordinates) {
-			x = (i%s.geom.X) * (imgsize.X * 1.5);
-			y = (i/s.geom.X) * (imgsize.Y * 1.5);
+			x = (i%s.geom.X) * (imgsize.X * 1.25);
+			y = (i/s.geom.X) * (imgsize.Y * 1.25);
 		} else {
 			x = (i%s.geom.X) * spacing.X;
 			y = (i/s.geom.X) * spacing.Y;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2565,8 +2565,8 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 			s32 x;
 			s32 y;
 			if (s.real_coordinates) {
-				x = (i%s.geom.X) * (imgsize.X / 2);
-				y = (i/s.geom.X) * (imgsize.Y / 2);
+				x = (i%s.geom.X) * (imgsize.X * 1.5);
+				y = (i/s.geom.X) * (imgsize.Y * 1.5);
 			} else {
 				x = (i%s.geom.X) * spacing.X;
 				y = (i/s.geom.X) * spacing.Y;
@@ -2615,8 +2615,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		s32 x;
 		s32 y;
 		if (s.real_coordinates) {
-			x = (i%s.geom.X) * (imgsize.X / 2);
-			y = (i/s.geom.X) * (imgsize.Y / 2);
+			x = (i%s.geom.X) * (imgsize.X * 1.5);
+			y = (i/s.geom.X) * (imgsize.Y * 1.5);
 		} else {
 			x = (i%s.geom.X) * spacing.X;
 			y = (i/s.geom.X) * spacing.Y;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2604,8 +2604,18 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		if (item_i >= (s32)ilist->getSize())
 			break;
 
-		s32 x = (i%s.geom.X) * spacing.X;
-		s32 y = (i/s.geom.X) * spacing.Y;
+		s32 x;
+		s32 y;
+		if (data->real_coordinates) {
+			// Space inventory slots 1/2 imgsize apart, which
+			// is a good default, easily changeable, and can
+			// be aligned to with real coordinates well.
+			x = (i%s.geom.X) * (imgsize.X / 2)
+			y = (i/s.geom.X) * (imgsize.Y / 2)
+		} else {
+			x = (i%s.geom.X) * spacing.X;
+			y = (i/s.geom.X) * spacing.Y;
+		}
 		v2s32 p(x,y);
 		core::rect<s32> rect = imgrect + s.pos + p;
 		ItemStack item = ilist->getItem(item_i);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1984,11 +1984,6 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 			<< "'" << std::endl;
 }
 
-void GUIFormSpecMenu::parseRealCoordinates(parserData* data, const std::string
-	&element) {
-	data->real_coordinates = is_yes(element);
-}
-
 void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
 	//some prechecks
@@ -2150,7 +2145,7 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 	}
 
 	if (type == "real_coordinates") {
-		parseRealCoordinates(data, description);
+		data->real_coordinates = is_yes(description);
 		return;
 	}
 
@@ -2290,7 +2285,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			std::vector<std::string> parts = split(elements[i], '[');
 			std::string name = trim(parts[0]);
 			if (name == "real_coordinates")
-				parseRealCoordinates(&mydata, trim(parts[1]));
+				mydata.real_coordinates = is_yes(trim(parts[1]));
 			if (name == "size" || name == "invsize")
 				break;
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -303,13 +303,25 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
 
 		lockSize(false);
-#ifndef __ANDROID__
+		data->stretch_size = false;
+
 		if (parts.size() == 3) {
-			if (parts[2] == "true") {
-				lockSize(true,v2u32(800,600));
+			std::string size_type = trim(parts[2]);
+#ifndef __ANDROID__
+			if (size_type == "true") {
+				lockSize(true, v2u32(800, 600));
+			}
+#endif
+			if (size_type == "stretch") {
+				if (invsize.X == 0 || invsize.Y == 0) {
+					warningstream << "Invalid use of 'stretch' with a form size of 0." <<
+						std::endl;
+				} else {
+					data->stretch_size = true;
+				}
 			}
 		}
-#endif
+
 		data->explicit_size = true;
 		return;
 	}
@@ -2451,6 +2463,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_font = g_fontengine->getFont();
 
 		if (mydata.real_coordinates) {
+			if (mydata.stretch_size) {
+				imgsize.X = data->screensize.X / invsize.X;
+				imgsize.Y = data->screensize.Y / invsize.Y;
+			}
 			mydata.size = v2s32(
 				mydata.invsize.X*imgsize.X,
 				mydata.invsize.Y*imgsize.Y

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2610,8 +2610,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 			// Space inventory slots 1/2 imgsize apart, which
 			// is a good default, easily changeable, and can
 			// be aligned to with real coordinates well.
-			x = (i%s.geom.X) * (imgsize.X / 2)
-			y = (i/s.geom.X) * (imgsize.Y / 2)
+			x = (i%s.geom.X) * (imgsize.X / 2);
+			y = (i/s.geom.X) * (imgsize.Y / 2);
 		} else {
 			x = (i%s.geom.X) * spacing.X;
 			y = (i/s.geom.X) * spacing.Y;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -466,18 +466,29 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		s32 y_center = (std::max(label_size.Height, (u32)cb_size) + 1) / 2;
 
 		v2s32 pos;
+		core::rect<s32> rect;
 
-		if (data->real_coordinates)
+		if (data->real_coordinates) {
 			pos = getRealCoordinateBasePos(false, v_pos);
-		else
-			pos = getElementBasePos(false, &v_pos);
 
-		core::rect<s32> rect = core::rect<s32>(
-				pos.X,
-				pos.Y + imgsize.Y / 2 - y_center,
-				pos.X + label_size.Width + cb_size + 7,
-				pos.Y + imgsize.Y / 2 + y_center
-			);
+			// Position from center, not top
+			pos.Y -= imgsize.Y / 2;
+
+			rect = core::rect<s32>(
+					pos.X,
+					pos.Y - y_center,
+					pos.X + label_size.Width + cb_size + 7,
+					pos.Y + y_center
+				);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			rect = core::rect<s32>(
+					pos.X,
+					pos.Y + imgsize.Y / 2 - y_center,
+					pos.X + label_size.Width + cb_size + 7,
+					pos.Y + imgsize.Y / 2 + y_center
+				);
+		}
 
 		FieldSpec spec(
 				name,
@@ -1348,13 +1359,13 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				// spacing.
 				v2s32 pos = getRealCoordinateBasePos(false, v_pos);
 
-				// Add offset for smaller rect.
-				pos.Y += (imgsize.Y / 4) + (((float) imgsize.Y) * i / 2);
+				// Labels are positioned by their center, not their top.
+				pos.Y += (((float) imgsize.Y) / -2) + (((float) imgsize.Y) * i / 2);
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y,
 					pos.X + m_font->getDimension(wlabel.c_str()).Width,
-					pos.Y + imgsize.Y / 2);
+					pos.Y + imgsize.Y);
 
 			} else {
 				// Lines are spaced at the nominal distance of
@@ -1416,13 +1427,13 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		if (data->real_coordinates) {
 			pos = getRealCoordinateBasePos(false, v_pos);
 
-			// Add offset for smaller rect.
-			pos.X += (imgsize.X / 4);
+			// Vertlabels are positioned by center, not left.
+			pos.X -= imgsize.X / 2;
 
 			// We use text.length + 1 because without it, the rect
 			// isn't quite tall enough and cuts off the text.
 			rect = core::rect<s32>(pos.X, pos.Y,
-				pos.X + imgsize.Y / 2,
+				pos.X + imgsize.X,
 				pos.Y + font_line_height(m_font) *
 				(text.length() + 1));
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2610,8 +2610,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 			// Space inventory slots 1/2 imgsize apart, which
 			// is a good default, easily changeable, and can
 			// be aligned to with real coordinates well.
-			x = (i%s.geom.X) * (imgsize.X / 2);
-			y = (i/s.geom.X) * (imgsize.Y / 2);
+			x = (i%s.geom.X) * (imgsize.X / 2)
+			y = (i/s.geom.X) * (imgsize.Y / 2)
 		} else {
 			x = (i%s.geom.X) * spacing.X;
 			y = (i/s.geom.X) * spacing.Y;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -394,7 +394,7 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of list without a size[] element"<<std::endl;
-		m_inventorylists.emplace_back(loc, listname, pos, geom, start_i);
+		m_inventorylists.emplace_back(loc, listname, pos, geom, start_i, data->real_coordinates);
 		return;
 	}
 	errorstream<< "Invalid list element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -2561,8 +2561,16 @@ GUIFormSpecMenu::ItemSpec GUIFormSpecMenu::getItemAtPos(v2s32 p) const
 	for (const GUIFormSpecMenu::ListDrawSpec &s : m_inventorylists) {
 		for(s32 i=0; i<s.geom.X*s.geom.Y; i++) {
 			s32 item_i = i + s.start_item_i;
-			s32 x = (i%s.geom.X) * spacing.X;
-			s32 y = (i/s.geom.X) * spacing.Y;
+
+			s32 x;
+			s32 y;
+			if (s.real_coordinates) {
+				x = (i%s.geom.X) * (imgsize.X / 2);
+				y = (i/s.geom.X) * (imgsize.Y / 2);
+			} else {
+				x = (i%s.geom.X) * spacing.X;
+				y = (i/s.geom.X) * spacing.Y;
+			}
 			v2s32 p0(x,y);
 			core::rect<s32> rect = imgrect + s.pos + p0;
 			if(rect.isPointInside(p))
@@ -2604,8 +2612,15 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		if (item_i >= (s32)ilist->getSize())
 			break;
 
-		s32 x = (i%s.geom.X) * spacing.X;
-		s32 y = (i/s.geom.X) * spacing.Y;
+		s32 x;
+		s32 y;
+		if (s.real_coordinates) {
+			x = (i%s.geom.X) * (imgsize.X / 2);
+			y = (i/s.geom.X) * (imgsize.Y / 2);
+		} else {
+			x = (i%s.geom.X) * spacing.X;
+			y = (i/s.geom.X) * spacing.Y;
+		}
 		v2s32 p(x,y);
 		core::rect<s32> rect = imgrect + s.pos + p;
 		ItemStack item = ilist->getItem(item_i);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1574,17 +1574,16 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		// Width is not here because tabs are the width of the text, and
 		// there's no reason to change that.
 		unsigned int i = 0;
-		std::vector<std::string> v_geom;
-		bool auto_width = false;
+		std::vector<std::string> v_geom = {"1", "1"}; // Default width and dummy height
+		bool auto_width = true;
 		if (parts.size() == 7) {
 			i++;
 
 			v_geom = split(parts[1], ',');
-
-			if (v_geom.size() == 1) {
-				auto_width = true;
-				v_geom.emplace_back("1"); // Dummy value
-			}
+			if (v_geom.size() == 1)
+				v_geom.insert(v_geom.begin(), "1"); // Dummy value
+			else
+				auto_width = false;
 		}
 
 		std::string name = parts[i+1];

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1569,7 +1569,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		// If we're using real coordinates, add an extra field for height.
 		// Width is not here because tabs are the width of the text, and
 		// there's no reason to change that.
-		int i = 0;
+		unsigned int i = 0;
 		std::string h_geom;
 		if (data->real_coordinates) {
 			i++;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1873,13 +1873,20 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 		std::vector<std::string> v_pos  = split(parts[0], ',');
 		std::vector<std::string> v_geom = split(parts[1], ',');
 
-		MY_CHECKPOS("tooltip",  0);
+		MY_CHECKPOS("tooltip", 0);
 		MY_CHECKGEOM("tooltip", 1);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * spacing.X;
-		geom.Y = stof(v_geom[1]) * spacing.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(true, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
+		} else {
+			pos = getElementBasePos(true, &v_pos);
+			geom.X = stof(v_geom[0]) * spacing.X;
+			geom.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		irr::core::rect<s32> rect(pos, pos + geom);
 		m_tooltip_rects.emplace_back(rect, spec);
@@ -2299,17 +2306,6 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		}
 	}
 
-	/* Copy of the "real_coordinates" element for before the form size. */
-	mydata.real_coordinates = false;
-	for (; i < elements.size(); i++) {
-		std::vector<std::string> parts = split(elements[i], '[');
-		std::string name = trim(parts[0]);
-		if (name != "real_coordinates" || parts.size() != 2)
-			break; // Invalid format
-
-		mydata.real_coordinates = is_yes(trim(parts[1]));
-	}
-
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
 	for (; i< elements.size(); i++) {
@@ -2343,6 +2339,17 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			enable_prepends = false;
 		else
 			break;
+	}
+
+	/* Copy of the "real_coordinates" element for after the form size. */
+	mydata.real_coordinates = false;
+	for (; i < elements.size(); i++) {
+		std::vector<std::string> parts = split(elements[i], '[');
+		std::string name = trim(parts[0]);
+		if (name != "real_coordinates" || parts.size() != 2)
+			break; // Invalid format
+
+		mydata.real_coordinates = is_yes(trim(parts[1]));
 	}
 
 	if (mydata.explicit_size) {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -66,8 +66,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #define MY_CHECKGEOM(a,b)													\
 	if (v_geom.size() != 2) {												\
-		errorstream<< "Invalid pos for element " << a << "specified: \""	\
-			<< parts[b] << "\"" << std::endl;								\
+		errorstream<< "Invalid geometry for element " << a <<				\
+			"specified: \"" << parts[b] << "\"" << std::endl;				\
 			return;															\
 	}
 /*
@@ -270,6 +270,25 @@ v2s32 GUIFormSpecMenu::getElementBasePos(bool absolute,
 	return v2s32(pos_f.X, pos_f.Y);
 }
 
+v2s32 GUIFormSpecMenu::getRealCoordinateBasePos(bool absolute,
+		const std::vector<std::string> *v_pos)
+{
+	v2f32 pos_f = v2f32(0.0f, 0.0f);
+
+	pos_f.X += stof((*v_pos)[0]) + pos_offset.X;
+	pos_f.Y += stof((*v_pos)[1]) + pos_offset.Y;
+
+	if (absolute)
+		return v2s32(pos_f.X * imgsize.X + AbsoluteRect.UpperLeftCorner.X,
+				pos_f.Y * imgsize.Y + AbsoluteRect.UpperLeftCorner.Y);
+	return v2s32(pos_f.X * imgsize.X, pos_f.Y * imgsize.Y);
+}
+
+v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> *v_geom)
+{
+	return v2s32(stof((*v_geom)[0]) * imgsize.X, stof((*v_geom)[1]) * imgsize.Y);
+}
+
 void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,',');
@@ -348,13 +367,19 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 
 		InventoryLocation loc;
 
-		if(location == "context" || location == "current_name")
+		if (location == "context" || location == "current_name")
 			loc = m_current_inventory_location;
 		else
 			loc.deSerialize(location);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
+
+		if (data->real_coordinates)
+			pos = getRealCoordinateBasePos(true, &v_pos);
+		else
+			pos = getElementBasePos(true, &v_pos);
+
 		geom.X = stoi(v_geom[0]);
 		geom.Y = stoi(v_geom[1]);
 
@@ -430,8 +455,6 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 
 		MY_CHECKPOS("checkbox",0);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
-
 		bool fselected = false;
 
 		if (selected == "true")
@@ -441,6 +464,13 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		const core::dimension2d<u32> label_size = m_font->getDimension(wlabel.c_str());
 		s32 cb_size = Environment->getSkin()->getSize(gui::EGDS_CHECK_BOX_WIDTH);
 		s32 y_center = (std::max(label_size.Height, (u32)cb_size) + 1) / 2;
+
+		v2s32 pos;
+
+		if (data->real_coordinates)
+			pos = getRealCoordinateBasePos(false, &v_pos);
+		else
+			pos = getElementBasePos(false, &v_pos);
 
 		core::rect<s32> rect = core::rect<s32>(
 				pos.X,
@@ -478,23 +508,24 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 
 	if (parts.size() >= 5) {
 		std::vector<std::string> v_pos = split(parts[0],',');
-		std::vector<std::string> v_dim = split(parts[1],',');
+		std::vector<std::string> v_geom = split(parts[1],',');
 		std::string name = parts[3];
 		std::string value = parts[4];
 
 		MY_CHECKPOS("scrollbar",0);
+		MY_CHECKGEOM("scrollbar",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
-
-		if (v_dim.size() != 2) {
-			errorstream<< "Invalid size for element " << "scrollbar"
-				<< "specified: \"" << parts[1] << "\"" << std::endl;
-			return;
-		}
-
+		v2s32 pos;
 		v2s32 dim;
-		dim.X = stof(v_dim[0]) * spacing.X;
-		dim.Y = stof(v_dim[1]) * spacing.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			dim = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			dim.X = stof(v_geom[0]) * spacing.X;
+			dim.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		core::rect<s32> rect =
 				core::rect<s32>(pos.X, pos.Y, pos.X + dim.X, pos.Y + dim.Y);
@@ -543,10 +574,17 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		MY_CHECKPOS("image", 0);
 		MY_CHECKGEOM("image", 1);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * (float)imgsize.X;
-		geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(true, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(true, &v_pos);
+			geom.X = stof(v_geom[0]) * (float)imgsize.X;
+			geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
+		}
 
 		if (!data->explicit_size)
 			warningstream<<"invalid use of image without a size[] element"<<std::endl;
@@ -584,10 +622,17 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 		MY_CHECKPOS("itemimage",0);
 		MY_CHECKGEOM("itemimage",1);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * (float)imgsize.X;
-		geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(true, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(true, &v_pos);
+			geom.X = stof(v_geom[0]) * (float)imgsize.X;
+			geom.Y = stof(v_geom[1]) * (float)imgsize.Y;
+		}
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of item_image without a size[] element"<<std::endl;
@@ -613,14 +658,23 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		MY_CHECKPOS("button",0);
 		MY_CHECKGEOM("button",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+		core::rect<s32> rect;
 
-		core::rect<s32> rect =
-				core::rect<s32>(pos.X, pos.Y - m_btn_height,
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+			rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
+				pos.Y+geom.Y);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+
+			rect = core::rect<s32>(pos.X, pos.Y - m_btn_height,
 						pos.X + geom.X, pos.Y + m_btn_height);
+		}
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of button without a size[] element"<<std::endl;
@@ -662,18 +716,30 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		MY_CHECKPOS("background",0);
 		MY_CHECKGEOM("background",1);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
-		pos.X -= (spacing.X - (float)imgsize.X) / 2;
-		pos.Y -= (spacing.Y - (float)imgsize.Y) / 2;
-
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * spacing.X;
-		geom.Y = stof(v_geom[1]) * spacing.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(true, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(true, &v_pos);
+			pos.X -= (spacing.X - (float)imgsize.X) / 2;
+			pos.Y -= (spacing.Y - (float)imgsize.Y) / 2;
+
+			geom.X = stof(v_geom[0]) * spacing.X;
+			geom.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		bool clip = false;
 		if (parts.size() >= 4 && is_yes(parts[3])) {
-			pos.X = stoi(v_pos[0]); //acts as offset
-			pos.Y = stoi(v_pos[1]); //acts as offset
+			if (data->real_coordinates) {
+				pos = getRealCoordinateBasePos(false, &v_pos) * -1;
+				geom = v2s32(0, 0);
+			} else {
+				pos.X = stoi(v_pos[0]); //acts as offset
+				pos.Y = stoi(v_pos[1]);
+			}
 			clip = true;
 		}
 
@@ -760,10 +826,17 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		MY_CHECKPOS("table",0);
 		MY_CHECKGEOM("table",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * spacing.X;
-		geom.Y = stof(v_geom[1]) * spacing.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			geom.X = stof(v_geom[0]) * spacing.X;
+			geom.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
@@ -827,11 +900,17 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		MY_CHECKPOS("textlist",0);
 		MY_CHECKGEOM("textlist",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * spacing.X;
-		geom.Y = stof(v_geom[1]) * spacing.Y;
 
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			geom.X = stof(v_geom[0]) * spacing.X;
+			geom.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
@@ -888,12 +967,26 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 
 		MY_CHECKPOS("dropdown",0);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
+		v2s32 geom;
+		core::rect<s32> rect;
 
-		s32 width = stof(parts[1]) * spacing.Y;
+		if (data->real_coordinates) {
 
-		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y,
-				pos.X + width, pos.Y + (m_btn_height * 2));
+			std::vector<std::string> v_geom = split(parts[1],',');
+			MY_CHECKGEOM("dropdown",1);
+
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+			rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+
+			s32 width = stof(parts[1]) * spacing.Y;
+
+			rect = core::rect<s32>(pos.X, pos.Y,
+					pos.X + width, pos.Y + (m_btn_height * 2));
+		}
 
 		FieldSpec spec(
 			name,
@@ -958,15 +1051,22 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		MY_CHECKPOS("pwdfield",0);
 		MY_CHECKGEOM("pwdfield",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
-		pos -= padding;
-
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
 
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
-		pos.Y -= m_btn_height;
-		geom.Y = m_btn_height*2;
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			pos -= padding;
+
+			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+
+			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+			pos.Y -= m_btn_height;
+			geom.Y = m_btn_height*2;
+		}
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
@@ -1141,23 +1241,29 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 	MY_CHECKPOS(type,0);
 	MY_CHECKGEOM(type,1);
 
-	v2s32 pos = getElementBasePos(false, &v_pos);
-	pos -= padding;
-
+	v2s32 pos;
 	v2s32 geom;
 
-	geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+	if (data->real_coordinates) {
+		pos = getRealCoordinateBasePos(false, &v_pos);
+		geom = getRealCoordinateGeometry(&v_geom);
+	} else {
+		pos = getElementBasePos(false, &v_pos);
+		pos -= padding;
 
-	if (type == "textarea")
-	{
-		geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y-imgsize.Y);
-		pos.Y += m_btn_height;
-	}
-	else
-	{
-		pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
-		pos.Y -= m_btn_height;
-		geom.Y = m_btn_height*2;
+		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+
+		if (type == "textarea")
+		{
+			geom.Y = (stof(v_geom[1]) * (float)imgsize.Y) - (spacing.Y-imgsize.Y);
+			pos.Y += m_btn_height;
+		}
+		else
+		{
+			pos.Y += (stof(v_geom[1]) * (float)imgsize.Y)/2;
+			pos.Y -= m_btn_height;
+			geom.Y = m_btn_height*2;
+		}
 	}
 
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
@@ -1221,10 +1327,6 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 		MY_CHECKPOS("label",0);
 
-		v2s32 pos = getElementBasePos(false, nullptr);
-		pos.X += stof(v_pos[0]) * spacing.X;
-		pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
-
 		if(!data->explicit_size)
 			warningstream<<"invalid use of label without a size[] element"<<std::endl;
 
@@ -1240,12 +1342,34 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 			// than multiply by 0.4, to get exact results
 			// in the integer cases: 0.4 is not exactly
 			// representable in binary floating point.
-			s32 posy = pos.Y + ((float)i) * spacing.Y * 2.0 / 5.0;
 			std::wstring wlabel = utf8_to_wide(unescape_string(lines[i]));
-			core::rect<s32> rect = core::rect<s32>(
-				pos.X, posy - m_btn_height,
-				pos.X + m_font->getDimension(wlabel.c_str()).Width,
-				posy + m_btn_height);
+
+			core::rect<s32> rect;
+
+			if (data->real_coordinates) {
+				v2s32 pos = getRealCoordinateBasePos(false, &v_pos);
+
+				// Add offset for smaller rect.
+				pos.Y += (imgsize.Y / 4) + ( ((float)imgsize.Y) * i / 2);
+
+				rect = core::rect<s32>(
+					pos.X, pos.Y,
+					pos.X + m_font->getDimension(wlabel.c_str()).Width,
+					pos.Y + imgsize.Y / 2);
+
+			} else {
+				v2s32 pos = getElementBasePos(false, nullptr);
+				pos.X += stof(v_pos[0]) * spacing.X;
+				pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
+
+				s32 posy = pos.Y + ((float)i) * spacing.Y * 2.0 / 5.0;
+
+				rect = core::rect<s32>(
+					pos.X, posy - m_btn_height,
+					pos.X + m_font->getDimension(wlabel.c_str()).Width,
+					posy + m_btn_height);
+			}
+
 			FieldSpec spec(
 				"",
 				wlabel,
@@ -1260,7 +1384,8 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 		return;
 	}
-	errorstream<< "Invalid label element(" << parts.size() << "): '" << element << "'"  << std::endl;
+	errorstream << "Invalid label element(" << parts.size() << "): '" << element
+		<< "'"  << std::endl;
 }
 
 void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &element)
@@ -1276,15 +1401,33 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 
 		MY_CHECKPOS("vertlabel",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
+		core::rect<s32> rect;
 
-		core::rect<s32> rect = core::rect<s32>(
-				pos.X, pos.Y+((imgsize.Y/2)- m_btn_height),
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+
+			// Add offset for smaller rect.
+			pos.X += (imgsize.X / 4);
+
+			rect = core::rect<s32>(pos.X, pos.Y,
+				pos.X + imgsize.Y / 2,
+				pos.Y + font_line_height(m_font) *
+				(text.length() + 1));
+
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+
+			rect = core::rect<s32>(
+				pos.X, pos.Y+((imgsize.Y/2) - m_btn_height),
 				pos.X+15, pos.Y +
-					font_line_height(m_font)
-					* (text.length()+1)
-					+((imgsize.Y/2)- m_btn_height));
-		//actually text.length() would be correct but adding +1 avoids to break all mods
+					font_line_height(m_font) *
+					(text.length() + 1) +
+					((imgsize.Y/2) - m_btn_height));
+
+			// Actually text.length() would be correct but adding +1 avoids
+			// breaking mods.
+		}
 
 		if(!data->explicit_size)
 			warningstream<<"invalid use of label without a size[] element"<<std::endl;
@@ -1328,11 +1471,6 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 		MY_CHECKPOS("imagebutton",0);
 		MY_CHECKGEOM("imagebutton",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
-		v2s32 geom;
-		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
-		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
-
 		bool noclip     = false;
 		bool drawborder = true;
 		std::string pressed_image_name;
@@ -1348,9 +1486,22 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 			pressed_image_name = parts[7];
 		}
 
-		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
+		v2s32 pos;
+		v2s32 geom;
 
-		if(!data->explicit_size)
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+			geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
+		}
+
+		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
+			pos.Y+geom.Y);
+
+		if (!data->explicit_size)
 			warningstream<<"invalid use of image_button without a size[] element"<<std::endl;
 
 		image_name = unescape_string(image_name);
@@ -1365,7 +1516,7 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 			258+m_fields.size()
 		);
 		spec.ftype = f_Button;
-		if(type == "image_button_exit")
+		if (type == "image_button_exit")
 			spec.is_exit = true;
 
 		video::ITexture *texture = 0;
@@ -1402,23 +1553,35 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 {
 	std::vector<std::string> parts = split(element,';');
 
-	if (((parts.size() == 4) || (parts.size() == 6)) ||
-		((parts.size() > 6) && (m_formspec_version > FORMSPEC_API_VERSION)))
+	if (((parts.size() == 4) || (parts.size() == 6)) || (parts.size() == 7 &&
+		data->real_coordinates) || ((parts.size() > 6) &&
+		(m_formspec_version > FORMSPEC_API_VERSION)))
 	{
 		std::vector<std::string> v_pos = split(parts[0],',');
-		std::string name = parts[1];
-		std::vector<std::string> buttons = split(parts[2],',');
-		std::string str_index = parts[3];
+
+		// If we're using real coordinates, add an extra field for height.
+		// Width is not here because tabs are the width of the text, and
+		// there's no reason to change that.
+		int i = 0;
+		std::string h_geom;
+		if (data->real_coordinates) {
+			i++;
+			h_geom = parts[1];
+		}
+
+		std::string name = parts[i+1];
+		std::vector<std::string> buttons = split(parts[i+2],',');
+		std::string str_index = parts[i+3];
 		bool show_background = true;
 		bool show_border = true;
 		int tab_index = stoi(str_index) -1;
 
 		MY_CHECKPOS("tabheader",0);
 
-		if (parts.size() == 6) {
-			if (parts[4] == "true")
+		if (parts.size() >= 6) {
+			if (parts[4+i] == "true")
 				show_background = false;
-			if (parts[5] == "false")
+			if (parts[5+i] == "false")
 				show_border = false;
 		}
 
@@ -1432,15 +1595,22 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		spec.ftype = f_TabHeader;
 
 		v2s32 pos;
-		{
+		v2s32 geom;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			std::vector<std::string> v_geom = {"1", h_geom}; // Dummy value
+			geom = getRealCoordinateGeometry(&v_geom);
+			pos.Y -= geom.Y; // TabHeader base pos is the bottom, not the top.
+		} else {
 			v2f32 pos_f = pos_offset * spacing;
 			pos_f.X += stof(v_pos[0]) * spacing.X;
 			pos_f.Y += stof(v_pos[1]) * spacing.Y - m_btn_height * 2;
 			pos = v2s32(pos_f.X, pos_f.Y);
+
+			geom.Y = m_btn_height*2;
 		}
-		v2s32 geom;
 		geom.X = DesiredRect.getWidth();
-		geom.Y = m_btn_height*2;
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
 				pos.Y+geom.Y);
@@ -1449,7 +1619,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 				show_background, show_border, spec.fid);
 		e->setAlignment(irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_UPPERLEFT,
 				irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_LOWERRIGHT);
-		e->setTabHeight(m_btn_height*2);
+		e->setTabHeight(geom.Y);
 
 		if (spec.fname == data->focused_fieldname) {
 			Environment->setFocus(e);
@@ -1500,10 +1670,17 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		MY_CHECKPOS("itemimagebutton",0);
 		MY_CHECKGEOM("itemimagebutton",1);
 
-		v2s32 pos = getElementBasePos(false, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
-		geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(false, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(false, &v_pos);
+			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
+			geom.Y = (stof(v_geom[1]) * spacing.Y) - (spacing.Y - imgsize.Y);
+		}
 
 		core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
@@ -1537,7 +1714,11 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		spec.rect=rect;
 		m_fields.push_back(spec);
 
-		pos = getElementBasePos(true, &v_pos);
+		if (data->real_coordinates)
+			pos = getRealCoordinateBasePos(true, &v_pos);
+		else
+			pos = getElementBasePos(true, &v_pos);
+
 		m_itemimages.emplace_back("", item_name, e, pos, geom);
 		m_static_texts.emplace_back(utf8_to_wide(label), rect, e);
 		return;
@@ -1558,10 +1739,17 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 		MY_CHECKPOS("box",0);
 		MY_CHECKGEOM("box",1);
 
-		v2s32 pos = getElementBasePos(true, &v_pos);
+		v2s32 pos;
 		v2s32 geom;
-		geom.X = stof(v_geom[0]) * spacing.X;
-		geom.Y = stof(v_geom[1]) * spacing.Y;
+
+		if (data->real_coordinates) {
+			pos = getRealCoordinateBasePos(true, &v_pos);
+			geom = getRealCoordinateGeometry(&v_geom);
+		} else {
+			pos = getElementBasePos(true, &v_pos);
+			geom.X = stof(v_geom[0]) * spacing.X;
+			geom.Y = stof(v_geom[1]) * spacing.Y;
+		}
 
 		video::SColor tmp_color;
 
@@ -1796,6 +1984,11 @@ void GUIFormSpecMenu::parseAnchor(parserData *data, const std::string &element)
 			<< "'" << std::endl;
 }
 
+void GUIFormSpecMenu::parseRealCoordinates(parserData* data, const std::string
+	&element) {
+	data->real_coordinates = is_yes(element);
+}
+
 void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
 	//some prechecks
@@ -1956,6 +2149,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "real_coordinates") {
+		parseRealCoordinates(data, description);
+		return;
+	}
+
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
 			<< std::endl;
@@ -2085,6 +2283,19 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		}
 	}
 
+	/* Copy of the "real_coordinates" element for before the form size. */
+	mydata.real_coordinates = false;
+	for (; i< elements.size(); i++) {
+		if (!elements[i].empty()) {
+			std::vector<std::string> parts = split(elements[i], '[');
+			std::string name = trim(parts[0]);
+			if (name == "real_coordinates")
+				parseRealCoordinates(&mydata, trim(parts[1]));
+			if (name == "size" || name == "invsize")
+				break;
+		}
+	}
+
 	/* we need size first in order to calculate image scale */
 	mydata.explicit_size = false;
 	for (; i< elements.size(); i++) {
@@ -2210,10 +2421,18 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 		m_font = g_fontengine->getFont();
 
-		mydata.size = v2s32(
-			padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
-			padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
-		);
+		if (mydata.real_coordinates) {
+			mydata.size = v2s32(
+				mydata.invsize.X*imgsize.X,
+				mydata.invsize.Y*imgsize.Y
+			);
+		} else {
+			mydata.size = v2s32(
+				padding.X*2+spacing.X*(mydata.invsize.X-1.0)+imgsize.X,
+				padding.Y*2+spacing.Y*(mydata.invsize.Y-1.0)+imgsize.Y + m_btn_height*2.0/3.0
+			);
+		}
+
 		DesiredRect = mydata.rect = core::rect<s32>(
 				(s32)((f32)mydata.screensize.X * mydata.offset.X) - (s32)(mydata.anchor.X * (f32)mydata.size.X) + offset.X,
 				(s32)((f32)mydata.screensize.Y * mydata.offset.Y) - (s32)(mydata.anchor.Y * (f32)mydata.size.Y) + offset.Y,
@@ -2245,9 +2464,13 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	pos_offset = v2f32();
 
 	if (enable_prepends) {
+		// Backup the coordinates so that prepends can use the coordinates of choice.
+		bool rc_backup = mydata.real_coordinates;
+		mydata.real_coordinates = false; // Old coordinates by default.
 		std::vector<std::string> prepend_elements = split(m_formspec_prepend, ']');
 		for (const auto &element : prepend_elements)
 			parseElement(&mydata, element);
+		mydata.real_coordinates = rc_backup; // Restore coordinates
 	}
 
 	for (; i< elements.size(); i++) {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2280,15 +2280,13 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	/* Copy of the "real_coordinates" element for before the form size. */
 	mydata.real_coordinates = false;
-	for (; i< elements.size(); i++) {
-		if (!elements[i].empty()) {
-			std::vector<std::string> parts = split(elements[i], '[');
-			std::string name = trim(parts[0]);
-			if (name == "real_coordinates")
-				mydata.real_coordinates = is_yes(trim(parts[1]));
-			if (name == "size" || name == "invsize")
-				break;
-		}
+	for (; i < elements.size(); i++) {
+		std::vector<std::string> parts = split(elements[i], '[');
+		std::string name = trim(parts[0]);
+		if (name != "real_coordinates" || parts.size() != 2)
+			break; // Invalid format
+
+		mydata.real_coordinates = is_yes(trim(parts[1]));
 	}
 
 	/* we need size first in order to calculate image scale */

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -313,7 +313,7 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 			}
 #endif
 			if (size_type == "stretch") {
-				if (invsize.X == 0 || invsize.Y == 0) {
+				if (data->invsize.X == 0 || data->invsize.Y == 0) {
 					warningstream << "Invalid use of 'stretch' with a form size of 0." <<
 						std::endl;
 				} else {
@@ -2464,8 +2464,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 		if (mydata.real_coordinates) {
 			if (mydata.stretch_size) {
-				imgsize.X = data->screensize.X / invsize.X;
-				imgsize.Y = data->screensize.Y / invsize.Y;
+				imgsize.X = mydata.screensize.X / mydata.invsize.X;
+				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
 			}
 			mydata.size = v2s32(
 				mydata.invsize.X*imgsize.X,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -471,9 +471,6 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		if (data->real_coordinates) {
 			pos = getRealCoordinateBasePos(false, v_pos);
 
-			// Position from center, not top
-			pos.Y -= imgsize.Y / 2;
-
 			rect = core::rect<s32>(
 					pos.X,
 					pos.Y - y_center,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -973,6 +973,10 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 
 		if (data->real_coordinates) {
 			std::vector<std::string> v_geom = split(parts[1],',');
+
+			if (v_geom.size() == 1)
+				v_geom.push_back("1");
+
 			MY_CHECKGEOM("dropdown",1);
 
 			pos = getRealCoordinateBasePos(false, v_pos);
@@ -1570,8 +1574,8 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		// Width is not here because tabs are the width of the text, and
 		// there's no reason to change that.
 		unsigned int i = 0;
-		std::string h_geom;
-		if (data->real_coordinates) {
+		std::string h_geom = "1"; // Default height
+		if (parts.size() == 7) {
 			i++;
 			h_geom = parts[1];
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2604,18 +2604,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		if (item_i >= (s32)ilist->getSize())
 			break;
 
-		s32 x;
-		s32 y;
-		if (data->real_coordinates) {
-			// Space inventory slots 1/2 imgsize apart, which
-			// is a good default, easily changeable, and can
-			// be aligned to with real coordinates well.
-			x = (i%s.geom.X) * (imgsize.X / 2)
-			y = (i/s.geom.X) * (imgsize.Y / 2)
-		} else {
-			x = (i%s.geom.X) * spacing.X;
-			y = (i/s.geom.X) * spacing.Y;
-		}
+		s32 x = (i%s.geom.X) * spacing.X;
+		s32 y = (i/s.geom.X) * spacing.Y;
 		v2s32 p(x,y);
 		core::rect<s32> rect = imgrect + s.pos + p;
 		ItemStack item = ilist->getItem(item_i);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -271,12 +271,12 @@ v2s32 GUIFormSpecMenu::getElementBasePos(bool absolute,
 }
 
 v2s32 GUIFormSpecMenu::getRealCoordinateBasePos(bool absolute,
-		const std::vector<std::string> *v_pos)
+		const std::vector<std::string> &v_pos)
 {
 	v2f32 pos_f = v2f32(0.0f, 0.0f);
 
-	pos_f.X += stof((*v_pos)[0]) + pos_offset.X;
-	pos_f.Y += stof((*v_pos)[1]) + pos_offset.Y;
+	pos_f.X += stof(v_pos[0]) + pos_offset.X;
+	pos_f.Y += stof(v_pos[1]) + pos_offset.Y;
 
 	if (absolute)
 		return v2s32(pos_f.X * imgsize.X + AbsoluteRect.UpperLeftCorner.X,
@@ -284,9 +284,9 @@ v2s32 GUIFormSpecMenu::getRealCoordinateBasePos(bool absolute,
 	return v2s32(pos_f.X * imgsize.X, pos_f.Y * imgsize.Y);
 }
 
-v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> *v_geom)
+v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> &v_geom)
 {
-	return v2s32(stof((*v_geom)[0]) * imgsize.X, stof((*v_geom)[1]) * imgsize.Y);
+	return v2s32(stof(v_geom[0]) * imgsize.X, stof(v_geom[1]) * imgsize.Y);
 }
 
 void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
@@ -376,7 +376,7 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 		v2s32 geom;
 
 		if (data->real_coordinates)
-			pos = getRealCoordinateBasePos(true, &v_pos);
+			pos = getRealCoordinateBasePos(true, v_pos);
 		else
 			pos = getElementBasePos(true, &v_pos);
 
@@ -468,7 +468,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		v2s32 pos;
 
 		if (data->real_coordinates)
-			pos = getRealCoordinateBasePos(false, &v_pos);
+			pos = getRealCoordinateBasePos(false, v_pos);
 		else
 			pos = getElementBasePos(false, &v_pos);
 
@@ -519,8 +519,8 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		v2s32 dim;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			dim = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			dim = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			dim.X = stof(v_geom[0]) * spacing.X;
@@ -578,8 +578,8 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(true, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(true, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(true, &v_pos);
 			geom.X = stof(v_geom[0]) * (float)imgsize.X;
@@ -626,8 +626,8 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(true, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(true, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(true, &v_pos);
 			geom.X = stof(v_geom[0]) * (float)imgsize.X;
@@ -663,8 +663,8 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		core::rect<s32> rect;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 			rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X,
 				pos.Y+geom.Y);
 		} else {
@@ -720,8 +720,8 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(true, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(true, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(true, &v_pos);
 			pos.X -= (spacing.X - (float)imgsize.X) / 2;
@@ -734,7 +734,7 @@ void GUIFormSpecMenu::parseBackground(parserData* data, const std::string &eleme
 		bool clip = false;
 		if (parts.size() >= 4 && is_yes(parts[3])) {
 			if (data->real_coordinates) {
-				pos = getRealCoordinateBasePos(false, &v_pos) * -1;
+				pos = getRealCoordinateBasePos(false, v_pos) * -1;
 				geom = v2s32(0, 0);
 			} else {
 				pos.X = stoi(v_pos[0]); //acts as offset
@@ -830,8 +830,8 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			geom.X = stof(v_geom[0]) * spacing.X;
@@ -904,8 +904,8 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			geom.X = stof(v_geom[0]) * spacing.X;
@@ -972,12 +972,11 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 		core::rect<s32> rect;
 
 		if (data->real_coordinates) {
-
 			std::vector<std::string> v_geom = split(parts[1],',');
 			MY_CHECKGEOM("dropdown",1);
 
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 			rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
@@ -1055,8 +1054,8 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			pos -= padding;
@@ -1245,8 +1244,8 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 	v2s32 geom;
 
 	if (data->real_coordinates) {
-		pos = getRealCoordinateBasePos(false, &v_pos);
-		geom = getRealCoordinateGeometry(&v_geom);
+		pos = getRealCoordinateBasePos(false, v_pos);
+		geom = getRealCoordinateGeometry(v_geom);
 	} else {
 		pos = getElementBasePos(false, &v_pos);
 		pos -= padding;
@@ -1333,24 +1332,20 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 		std::vector<std::string> lines = split(text, '\n');
 
 		for (unsigned int i = 0; i != lines.size(); i++) {
-			// Lines are spaced at the nominal distance of
-			// 2/5 inventory slot, even if the font doesn't
-			// quite match that.  This provides consistent
-			// form layout, at the expense of sometimes
-			// having sub-optimal spacing for the font.
-			// We multiply by 2 and then divide by 5, rather
-			// than multiply by 0.4, to get exact results
-			// in the integer cases: 0.4 is not exactly
-			// representable in binary floating point.
 			std::wstring wlabel = utf8_to_wide(unescape_string(lines[i]));
 
 			core::rect<s32> rect;
 
 			if (data->real_coordinates) {
-				v2s32 pos = getRealCoordinateBasePos(false, &v_pos);
+				// Lines are spaced at the distance of 1/2 imgsize.
+				// This alows lines that line up with the new elements
+				// easily without sacrificing good line distance.  If
+				// it was one whole imgsize, it would have too much
+				// spacing.
+				v2s32 pos = getRealCoordinateBasePos(false, v_pos);
 
 				// Add offset for smaller rect.
-				pos.Y += (imgsize.Y / 4) + ( ((float)imgsize.Y) * i / 2);
+				pos.Y += (imgsize.Y / 4) + (((float) imgsize.Y) * i / 2);
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y,
@@ -1358,16 +1353,26 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 					pos.Y + imgsize.Y / 2);
 
 			} else {
+				// Lines are spaced at the nominal distance of
+				// 2/5 inventory slot, even if the font doesn't
+				// quite match that.  This provides consistent
+				// form layout, at the expense of sometimes
+				// having sub-optimal spacing for the font.
+				// We multiply by 2 and then divide by 5, rather
+				// than multiply by 0.4, to get exact results
+				// in the integer cases: 0.4 is not exactly
+				// representable in binary floating point.
+
 				v2s32 pos = getElementBasePos(false, nullptr);
 				pos.X += stof(v_pos[0]) * spacing.X;
 				pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
 
-				s32 posy = pos.Y + ((float)i) * spacing.Y * 2.0 / 5.0;
+				pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
 
 				rect = core::rect<s32>(
-					pos.X, posy - m_btn_height,
+					pos.X, pos.Y - m_btn_height,
 					pos.X + m_font->getDimension(wlabel.c_str()).Width,
-					posy + m_btn_height);
+					pos.Y + m_btn_height);
 			}
 
 			FieldSpec spec(
@@ -1405,11 +1410,13 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		core::rect<s32> rect;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
+			pos = getRealCoordinateBasePos(false, v_pos);
 
 			// Add offset for smaller rect.
 			pos.X += (imgsize.X / 4);
 
+			// We use text.length + 1 because without it, the rect
+			// isn't quite tall enough and cuts off the text.
 			rect = core::rect<s32>(pos.X, pos.Y,
 				pos.X + imgsize.Y / 2,
 				pos.Y + font_line_height(m_font) *
@@ -1418,15 +1425,15 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 
+			// As above, the length must be one longer. The width of
+			// the rect (15 pixels) seems rather arbitrary, but
+			// changing it might break something.
 			rect = core::rect<s32>(
 				pos.X, pos.Y+((imgsize.Y/2) - m_btn_height),
 				pos.X+15, pos.Y +
 					font_line_height(m_font) *
 					(text.length() + 1) +
 					((imgsize.Y/2) - m_btn_height));
-
-			// Actually text.length() would be correct but adding +1 avoids
-			// breaking mods.
 		}
 
 		if(!data->explicit_size)
@@ -1490,8 +1497,8 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
@@ -1574,11 +1581,11 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		std::string str_index = parts[i+3];
 		bool show_background = true;
 		bool show_border = true;
-		int tab_index = stoi(str_index) -1;
+		int tab_index = stoi(str_index) - 1;
 
 		MY_CHECKPOS("tabheader",0);
 
-		if (parts.size() >= 6) {
+		if (parts.size() == 6 + i) {
 			if (parts[4+i] == "true")
 				show_background = false;
 			if (parts[5+i] == "false")
@@ -1598,17 +1605,18 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
+			pos = getRealCoordinateBasePos(false, v_pos);
 			std::vector<std::string> v_geom = {"1", h_geom}; // Dummy value
-			geom = getRealCoordinateGeometry(&v_geom);
+			geom = getRealCoordinateGeometry(v_geom);
 			pos.Y -= geom.Y; // TabHeader base pos is the bottom, not the top.
+			MY_CHECKPOS("tabheader",0);
 		} else {
 			v2f32 pos_f = pos_offset * spacing;
 			pos_f.X += stof(v_pos[0]) * spacing.X;
 			pos_f.Y += stof(v_pos[1]) * spacing.Y - m_btn_height * 2;
 			pos = v2s32(pos_f.X, pos_f.Y);
 
-			geom.Y = m_btn_height*2;
+			geom.Y = m_btn_height * 2;
 		}
 		geom.X = DesiredRect.getWidth();
 
@@ -1674,8 +1682,8 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(false, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(false, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(false, &v_pos);
 			geom.X = (stof(v_geom[0]) * spacing.X) - (spacing.X - imgsize.X);
@@ -1715,7 +1723,7 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		m_fields.push_back(spec);
 
 		if (data->real_coordinates)
-			pos = getRealCoordinateBasePos(true, &v_pos);
+			pos = getRealCoordinateBasePos(true, v_pos);
 		else
 			pos = getElementBasePos(true, &v_pos);
 
@@ -1743,8 +1751,8 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 		v2s32 geom;
 
 		if (data->real_coordinates) {
-			pos = getRealCoordinateBasePos(true, &v_pos);
-			geom = getRealCoordinateGeometry(&v_geom);
+			pos = getRealCoordinateBasePos(true, v_pos);
+			geom = getRealCoordinateGeometry(v_geom);
 		} else {
 			pos = getElementBasePos(true, &v_pos);
 			geom.X = stof(v_geom[0]) * spacing.X;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1574,7 +1574,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		// Width is not here because tabs are the width of the text, and
 		// there's no reason to change that.
 		unsigned int i = 0;
-		std::vector<std::string> v_geom = {"1", "1"}; // Default width and dummy height
+		std::vector<std::string> v_geom = {"1", "0.75"}; // Dummy width and default height
 		bool auto_width = true;
 		if (parts.size() == 7) {
 			i++;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -100,7 +100,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
 				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
-				a_real_coordinates):
+				bool a_real_coordinates):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -534,7 +534,6 @@ private:
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
-	void parseRealCoordinates(parserData *data, const std::string &element);
 
 	void tryClose();
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -394,6 +394,9 @@ protected:
 	std::string getNameByID(s32 id);
 	v2s32 getElementBasePos(bool absolute,
 			const std::vector<std::string> *v_pos);
+	v2s32 getRealCoordinateBasePos(bool absolute,
+			const std::vector<std::string> *v_pos);
+	v2s32 getRealCoordinateGeometry(const std::vector<std::string> *v_geom);
 
 	v2s32 padding;
 	v2f32 spacing;
@@ -463,6 +466,7 @@ private:
 
 	typedef struct {
 		bool explicit_size;
+		bool real_coordinates;
 		v2f invsize;
 		v2s32 size;
 		v2f32 offset;
@@ -530,6 +534,7 @@ private:
 	void parsePosition(parserData *data, const std::string &element);
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
+	void parseRealCoordinates(parserData *data, const std::string &element);
 
 	void tryClose();
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -395,8 +395,8 @@ protected:
 	v2s32 getElementBasePos(bool absolute,
 			const std::vector<std::string> *v_pos);
 	v2s32 getRealCoordinateBasePos(bool absolute,
-			const std::vector<std::string> *v_pos);
-	v2s32 getRealCoordinateGeometry(const std::vector<std::string> *v_geom);
+			const std::vector<std::string> &v_pos);
+	v2s32 getRealCoordinateGeometry(const std::vector<std::string> &v_geom);
 
 	v2s32 padding;
 	v2f32 spacing;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -469,6 +469,7 @@ private:
 
 	typedef struct {
 		bool explicit_size;
+		bool stretch_size;
 		bool real_coordinates;
 		v2f invsize;
 		v2s32 size;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -99,12 +99,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
-				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i):
+				v2s32 a_pos, v2s32 a_geom, s32 a_start_item_i,
+				a_real_coordinates):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			pos(a_pos),
 			geom(a_geom),
-			start_item_i(a_start_item_i)
+			start_item_i(a_start_item_i),
+			real_coordinates(a_real_coordinates)
 		{
 		}
 
@@ -113,6 +115,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 pos;
 		v2s32 geom;
 		s32 start_item_i;
+		bool real_coordinates;
 	};
 
 	struct ListRingSpec


### PR DESCRIPTION
This PR give FormSpecs the ability to be the full size of the screen instead of a box in the center.  This solves problems like https://github.com/minetest/minetest/issues/6733#issuecomment-506000467, which says that FormSpecs (the main menu in this case) are crammed into a small box.  It requires `real_coordinates` to be enabled (https://github.com/minetest/minetest/pull/8524 is required).

The syntax uses the third parameter of the `size` element, like so: `size[5,5,stretch]`.  The original behavior of `true` and `false` for the third parameter for fixed size is untouched for compatibility.  On older clients, this will appear to be a normal scaled FormSpec.

When stretching is enabled, coordinates will be stretched to fit the FormSpec size.  For instance, if the FormSpec uses `size[10,5,stretch]`, the X coordinates will be a tenth of the screen, and elements one wide will be a tenth of the screen.  Likewise, the Y coordinates will be a fifth of the screen.

### Screenshots

Replace X and Y with the numbers above the screenshots
```
size[<X>,<Y>,stretch]
real_coordinates[true]
box[0,0;0.5,0.5;#000000]
box[0.5,0.5;0.5,0.5;#FFFFFF]
```

X, Y = 1
![1,1](https://user-images.githubusercontent.com/31123645/60210724-6b631680-9812-11e9-8b78-bade30e26e2d.png)

X, Y = 10
![10,10](https://user-images.githubusercontent.com/31123645/60210725-6b631680-9812-11e9-8528-d6eebc9cbe12.png)

Notice how in the second screenshot, there is a slight border at the top and bottom.  This is because the screen might not divide evenly, especially with larger numbers, so a size of `1,1` is recommended or the background should be removed.  If I did make the form fill the whole screen, there would be small inaccuracies with the coordinates.

This PR is Ready for Review.