### PR TITLE
Make in-liquid falling acceleration directly proportional to player gravity

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -170,10 +170,34 @@ void ClientEnvironment::step(float dtime)
 						lplayer->physics_override_gravity * dtime_part * 2.0f;
 
 				// Liquid floating / sinking
-				if (lplayer->in_liquid && !lplayer->swimming_vertical &&
-						!lplayer->swimming_pitch)
-					speed.Y -= lplayer->movement_liquid_sink *
+				//~ if (lplayer->in_liquid && !lplayer->swimming_vertical &&
+						//~ !lplayer->swimming_pitch)
+					//~ speed.Y -= lplayer->movement_liquid_sink *
+						//~ lplayer->physics_override_gravity * dtime_part * 2.0f;
+				if (lplayer->in_liquid && !lplayer->swimming_pitch) {
+					f32 liquid_falling = -lplayer->movement_liquid_sink *
 						lplayer->physics_override_gravity * dtime_part * 2.0f;
+					if (!lplayer->swimming_vertical) {
+						speed.Y += liquid_falling;
+					} else {
+						//~ f32 mov_acc = m_client->checkLocalPrivilege("fast") &&
+								//~ lplayer->getPlayerSettings().fast_move &&
+								//~ lplayer->control.aux1 &&
+								//~ !lplayer->getPlayerSettings().aux1_descends ?
+								//~ lplayer->movement_acceleration_fast :
+								//~ lplayer->movement_acceleration_default;
+						if (lplayer->control.jump) { //player swims up
+							//~ liquid_falling = speed.Y + liquid_falling - mov_acc * BS;
+							speed.Y = MYMAX(speed.Y, liquid_falling + lplayer->speed_before_control_Y);
+						} else { //player swims down
+							//~ liquid_falling = speed.Y + liquid_falling + mov_acc * BS;
+							speed.Y = MYMIN(speed.Y, liquid_falling + lplayer->speed_before_control_Y);
+						}
+					}
+					//~ else if (speed.Y < 0.0f && liquid_falling < speed.Y ||
+							//~ speed.Y > 0.0f && liquid_falling > speed.Y)
+						//~ speed.Y = liquid_falling;
+				}
 
 				// Liquid resistance
 				if (lplayer->in_liquid_stable || lplayer->in_liquid) {

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -170,33 +170,20 @@ void ClientEnvironment::step(float dtime)
 						lplayer->physics_override_gravity * dtime_part * 2.0f;
 
 				// Liquid floating / sinking
-				//~ if (lplayer->in_liquid && !lplayer->swimming_vertical &&
-						//~ !lplayer->swimming_pitch)
-					//~ speed.Y -= lplayer->movement_liquid_sink *
-						//~ lplayer->physics_override_gravity * dtime_part * 2.0f;
 				if (lplayer->in_liquid && !lplayer->swimming_pitch) {
 					f32 liquid_falling = -lplayer->movement_liquid_sink *
 						lplayer->physics_override_gravity * dtime_part * 2.0f;
 					if (!lplayer->swimming_vertical) {
 						speed.Y += liquid_falling;
 					} else {
-						//~ f32 mov_acc = m_client->checkLocalPrivilege("fast") &&
-								//~ lplayer->getPlayerSettings().fast_move &&
-								//~ lplayer->control.aux1 &&
-								//~ !lplayer->getPlayerSettings().aux1_descends ?
-								//~ lplayer->movement_acceleration_fast :
-								//~ lplayer->movement_acceleration_default;
 						if (lplayer->control.jump) { //player swims up
-							//~ liquid_falling = speed.Y + liquid_falling - mov_acc * BS;
-							speed.Y = MYMAX(speed.Y, liquid_falling + lplayer->speed_before_control_Y);
+							speed.Y = MYMAX(speed.Y, liquid_falling +
+								lplayer->speed_before_control_Y);
 						} else { //player swims down
-							//~ liquid_falling = speed.Y + liquid_falling + mov_acc * BS;
-							speed.Y = MYMIN(speed.Y, liquid_falling + lplayer->speed_before_control_Y);
+							speed.Y = MYMIN(speed.Y, liquid_falling +
+								lplayer->speed_before_control_Y);
 						}
 					}
-					//~ else if (speed.Y < 0.0f && liquid_falling < speed.Y ||
-							//~ speed.Y > 0.0f && liquid_falling > speed.Y)
-						//~ speed.Y = liquid_falling;
 				}
 
 				// Liquid resistance

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -172,7 +172,8 @@ void ClientEnvironment::step(float dtime)
 				// Liquid floating / sinking
 				if (lplayer->in_liquid && !lplayer->swimming_vertical &&
 						!lplayer->swimming_pitch)
-					speed.Y -= lplayer->movement_liquid_sink * dtime_part * 2.0f;
+					speed.Y -= lplayer->movement_liquid_sink *
+						lplayer->physics_override_gravity * dtime_part * 2.0f;
 
 				// Liquid resistance
 				if (lplayer->in_liquid_stable || lplayer->in_liquid) {

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -467,6 +467,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d)
 
 void LocalPlayer::applyControl(float dtime, Environment *env)
 {
+	speed_before_control_Y = m_speed.Y;
+
 	// Clear stuff
 	swimming_vertical = false;
 	swimming_pitch = false;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -83,6 +83,8 @@ public:
 
 	void applyControl(float dtime, Environment *env);
 
+	f32 speed_before_control_Y = 0.0f;
+
 	v3s16 getStandingNodePos();
 	v3s16 getFootstepNodePos();
 


### PR DESCRIPTION
This a PR for #6123. (Fixes #6123.)

## To do

This PR is a Work in Progress

The sinking speed doesn't work correctly if the player swims down, todo.

## How to test

```lua
minetest.register_chatcommand("g", {
	params = "<value for g>",
	description = "sets own gravity",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		if not tonumber(param) then
			return false, "parameter for chatcommand g has to be a number"
		end
		player:set_physics_override({gravity = tonumber(param)})
		return true, "gravity set to "..param
	end,
})
```
