### PR TITLE
Add is_valid_pos

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -126,9 +126,10 @@ end
 
 
 function core.is_valid_pos(pos)
+	local mapgen_limit = tonumber(core.settings:get("mapgen_limit"))
 	if pos then
 		for _, v in pairs({"x", "y", "z"}) do
-			if not pos[v] or pos[v] < -32000 or pos[v] > 32000 then
+			if not pos[v] or pos[v] < -mapgen_limit or pos[v] > mapgen_limit then
 				return
 			end
 		end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -125,6 +125,18 @@ function core.get_player_radius_area(player_name, radius)
 end
 
 
+function core.is_valid_pos(pos)
+	if pos then
+		for _, v in pairs({"x", "y", "z"}) do
+			if not pos[v] or pos[v] < -32000 or pos[v] > 32000 then
+				return
+			end
+		end
+		return true
+	end
+end
+
+
 function core.hash_node_position(pos)
 	return (pos.z + 32768) * 65536 * 65536
 		 + (pos.y + 32768) * 65536

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -124,9 +124,8 @@ function core.get_player_radius_area(player_name, radius)
 	return p1, p2
 end
 
-
+local mapgen_limit = tonumber(core.settings:get("mapgen_limit"))
 function core.is_valid_pos(pos)
-	local mapgen_limit = tonumber(core.settings:get("mapgen_limit"))
 	if pos then
 		for _, v in pairs({"x", "y", "z"}) do
 			if not pos[v] or pos[v] < -mapgen_limit or pos[v] > mapgen_limit then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4240,7 +4240,7 @@ Environment access
     * The spawn level is intentionally above terrain level to cope with
       full-node biome 'dust' nodes.
 * `minetest.is_valid_pos(pos)`
-    * Returns `true` if the position lies within the range -32000 to 32000
+    * Returns `true` if the position lies within the mapgen_limit range.
 
 
 Mod channels

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4239,6 +4239,9 @@ Environment access
     * The spawn level returned is for a player spawn in unmodified terrain.
     * The spawn level is intentionally above terrain level to cope with
       full-node biome 'dust' nodes.
+* `minetest.is_valid_pos(pos)`
+    * Returns `true` if the position lies within the range -32000 to 32000
+
 
 Mod channels
 ------------


### PR DESCRIPTION
Solves #5135 and a lot of related.
Code example:
```
local pos = player:get_pos()
if not minetest.is_valid_pos(pos) then
	return		
end
```

Many mods are already using something similar. When I realized that 3 or 4 mods in MC use this code, I realized that it needs to be transferred to builtin. What's happening? Because of the lag between the execution of the action and the actual receipt of coordinates, there is a delay, which leads to this:

```
2019-05-25 14:42:59: ERROR[Main]: ServerError: AsyncErr: environment_Step: Invalid float vector dimension range 'x' (expected -2.14748e+06 < x < 2.14748e+06 got -2.14748e+06).
```

I have a ton of examples of this error. Such a simple check solves it.
I would agree that a fix is needed on the side of the engine. But we have known about the problem for more than 2 years. And modders fix it with similar code.