### PR TITLE
Do predict when sneak-place to node with on_rightclick

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3322,7 +3322,8 @@ bool Game::nodePlacementPrediction(const ItemDefinition &playeritem_def,
 	if (!is_valid_position)
 		return false;
 
-	if (!prediction.empty() && !nodedef->get(node).rightclickable) {
+	if (!prediction.empty() && !(nodedef->get(node).rightclickable &&
+			!isKeyDown(KeyType::SNEAK))) {
 		verbosestream << "Node placement prediction for "
 			<< playeritem_def.name << " is "
 			<< prediction << std::endl;


### PR DESCRIPTION
Fixes #4270.

## To do

This PR is a Ready for Review.

## How to test

- Place a node that has an `on_rightclick` field in its node definition. (Eg. wooden door or chest from mtg.)
- Place a node to it holding sneak.
- Hear the place sound.