### PR TITLE
Improve ABM time budget handling.

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -45,7 +45,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database/database-postgresql.h"
 #endif
 #include <algorithm>
-#include <random>
 
 #define LBM_NAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_:"
 
@@ -385,6 +384,9 @@ void ActiveBlockList::update(std::vector<PlayerSAO*> &active_players,
 	ServerEnvironment
 */
 
+// Random device to seed pseudo random generators.
+static std::random_device seed;
+
 ServerEnvironment::ServerEnvironment(ServerMap *map,
 	ServerScripting *scriptIface, Server *server,
 	const std::string &path_world):
@@ -392,7 +394,8 @@ ServerEnvironment::ServerEnvironment(ServerMap *map,
 	m_map(map),
 	m_script(scriptIface),
 	m_server(server),
-	m_path_world(path_world)
+	m_path_world(path_world),
+	m_rgen(seed())
 {
 	// Determine which database backend to use
 	std::string conf_path = path_world + DIR_DELIM + "world.mt";
@@ -1353,9 +1356,7 @@ void ServerEnvironment::step(float dtime)
 		std::vector<v3s16> output(m_active_blocks.m_abm_list.size());
 		std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
 
-		std::random_device rd;
-		std::mt19937 g(rd());
-		std::shuffle(output.begin(), output.end(), g);
+		std::shuffle(output.begin(), output.end(), m_rgen);
 
 		int i = 0;
 		u32 max_time_ms = 200;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1339,7 +1339,7 @@ void ServerEnvironment::step(float dtime)
 		}
 	}
 
-	if (m_active_block_modifier_interval.step(dtime, m_cache_abm_interval))
+	if (m_active_block_modifier_interval.step(dtime, m_cache_abm_interval)) {
 		ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
 		TimeTaker timer("modify in active blocks per interval");
 
@@ -1387,6 +1387,8 @@ void ServerEnvironment::step(float dtime)
 		g_profiler->avg("SEnv: ABMs run", abms_run);
 
 		timer.stop(true);
+	}
+
 	/*
 		Step script environment (run global on_step())
 	*/

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1354,12 +1354,15 @@ void ServerEnvironment::step(float dtime)
 		int blocks_cached = 0;
 
 		std::vector<v3s16> output(m_active_blocks.m_abm_list.size());
-		std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
 
+		// Shuffle the active blocks so that each block gets an equal chance
+		// of having its ABMs run.
+		std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
 		std::shuffle(output.begin(), output.end(), m_rgen);
 
 		int i = 0;
-		u32 max_time_ms = 200;
+		// The time budget for ABMs is 20%.
+		u32 max_time_ms = m_cache_abm_interval * 1000 / 5;
 		for (const v3s16 &p : output) {
 			MapBlock *block = m_map->getBlockNoCreateNoEx(p);
 			if (!block)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1339,53 +1339,50 @@ void ServerEnvironment::step(float dtime)
 	}
 
 	if (m_active_block_modifier_interval.step(dtime, m_cache_abm_interval))
-		do { // breakable
-			ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
-			TimeTaker timer("modify in active blocks per interval");
+		ScopeProfiler sp(g_profiler, "SEnv: modify in blocks avg per interval", SPT_AVG);
+		TimeTaker timer("modify in active blocks per interval");
 
-			// Initialize handling of ActiveBlockModifiers
-			ABMHandler abmhandler(m_abms, m_cache_abm_interval, this, true);
+		// Initialize handling of ActiveBlockModifiers
+		ABMHandler abmhandler(m_abms, m_cache_abm_interval, this, true);
 
-			int blocks_scanned = 0;
-			int abms_run = 0;
-			int blocks_cached = 0;
+		int blocks_scanned = 0;
+		int abms_run = 0;
+		int blocks_cached = 0;
 
-			std::vector<v3s16> output(m_active_blocks.m_abm_list.size());
-			std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
-			std::random_shuffle(output.begin(), output.end());
+		std::vector<v3s16> output(m_active_blocks.m_abm_list.size());
+		std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
+		std::random_shuffle(output.begin(), output.end());
 
-			int i = 0;
-			u32 max_time_ms = 200;
-			for (const v3s16 &p : output) {
-				MapBlock *block = m_map->getBlockNoCreateNoEx(p);
-				if (!block)
-					continue;
+		int i = 0;
+		u32 max_time_ms = 200;
+		for (const v3s16 &p : output) {
+			MapBlock *block = m_map->getBlockNoCreateNoEx(p);
+			if (!block)
+				continue;
 
-				i++;
+			i++;
 
-				// Set current time as timestamp
-				block->setTimestampNoChangedFlag(m_game_time);
+			// Set current time as timestamp
+			block->setTimestampNoChangedFlag(m_game_time);
 
-				/* Handle ActiveBlockModifiers */
-				abmhandler.apply(block, blocks_scanned, abms_run, blocks_cached);
+			/* Handle ActiveBlockModifiers */
+			abmhandler.apply(block, blocks_scanned, abms_run, blocks_cached);
 
-				u32 time_ms = timer.getTimerTime();
+			u32 time_ms = timer.getTimerTime();
 
-				if (time_ms > max_time_ms) {
-					warningstream<<"active block modifiers took "
-								 <<time_ms<<"ms (processed " << i << " of "
-								 <<output.size()<<" active blocks)"<<std::endl;
-					break;
-				}
+			if (time_ms > max_time_ms) {
+				warningstream << "active block modifiers took "
+					  << time_ms << "ms (processed " << i << " of "
+					  << output.size() << " active blocks)" << std::endl;
+				break;
 			}
-			g_profiler->avg("SEnv: active blocks", m_active_blocks.m_abm_list.size());
-			g_profiler->avg("SEnv: active blocks cached", blocks_cached);
-			g_profiler->avg("SEnv: active blocks scanned for ABMs", blocks_scanned);
-			g_profiler->avg("SEnv: ABMs run", abms_run);
+		}
+		g_profiler->avg("SEnv: active blocks", m_active_blocks.m_abm_list.size());
+		g_profiler->avg("SEnv: active blocks cached", blocks_cached);
+		g_profiler->avg("SEnv: active blocks scanned for ABMs", blocks_scanned);
+		g_profiler->avg("SEnv: ABMs run", abms_run);
 
-			timer.stop(true);
-		}while(0);
-
+		timer.stop(true);
 	/*
 		Step script environment (run global on_step())
 	*/

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -45,6 +45,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "database/database-postgresql.h"
 #endif
 #include <algorithm>
+#include <random>
 
 #define LBM_NAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_:"
 
@@ -1351,7 +1352,10 @@ void ServerEnvironment::step(float dtime)
 
 		std::vector<v3s16> output(m_active_blocks.m_abm_list.size());
 		std::copy(m_active_blocks.m_abm_list.begin(), m_active_blocks.m_abm_list.end(), output.begin());
-		std::random_shuffle(output.begin(), output.end());
+
+		std::random_device rd;
+		std::mt19937 g(rd());
+		std::shuffle(output.begin(), output.end(), g);
 
 		int i = 0;
 		u32 max_time_ms = 200;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -446,7 +446,6 @@ private:
 	IntervalLimiter m_active_blocks_management_interval;
 	IntervalLimiter m_active_block_modifier_interval;
 	IntervalLimiter m_active_blocks_nodemetadata_interval;
-	int m_active_block_interval_overload_skip = 0;
 	// Time from the beginning of the game in seconds.
 	// Incremented in step().
 	u32 m_game_time = 0;

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "server/activeobjectmgr.h"
 #include "util/numeric.h"
 #include <set>
+#include <random>
 
 class IGameDef;
 class ServerMap;
@@ -468,6 +469,9 @@ private:
 
 	PlayerDatabase *m_player_database = nullptr;
 	AuthDatabase *m_auth_database = nullptr;
+
+	// Pseudo random generator for shuffling, etc.
+	std::mt19937 m_rgen;
 
 	// Particles
 	IntervalLimiter m_particle_management_interval;


### PR DESCRIPTION
Handling long running ABMs has been awkward.
We used to run all ABM on all active blocks, and if a run took more than 200ms delay future runs based on how much longer than 200ms we took. That lead to very irregular ABM handling and still very long script runtimes because we do not check until after we ran all ABM on all blocks.

This PR turns this around:
1. First it shuffles the current active blocks. That is to ensure that no block receives preferred treatment.
2. Then we run ABMs against against blocks until we reached the time budget - still 200ms.
3. At that point we stop processing for this run. The next round with shuffle again and start again.

That way we can smoother behavior, and a better spread of the load across the active blocks.
On average the behavior is still that the ABMs are run less frequently on the active blocks.
The key point is that we stop ABM as soon as we reach the budget.

Please have a look. I tested this with some heavy mods (NSSM, etc) and the behavior is much more smooth. No more long gaps of no scripts.
