### PR TITLE
Add modifiable FormSpec size types

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1928,9 +1928,9 @@ Elements
 * Define the size of the menu in inventory slots
 * `size type` (optional): One of the below options:
     * These work on either the new or old coordinate system:
-        * `false`: Scaled form size.  This is default.
-        * `true`: Fixed 800x600 pixel form size.  Acts like `false` on Android.
-    * These only work on the new coordinate system:
+        * `false`: Scaled form size. This is default.
+        * `true`: Fixed 800x600 pixel form size. Acts like `false` on Android.
+    * These will not work properly on the old system:
         * `stretch`: Fills entire screen. Coordinates are stretched accordingly.
 	    * `fit`: The formspec is made as big as possible without stretching
           coordinates or leaving the screen.
@@ -1982,13 +1982,18 @@ Elements
 * For information on converting forms to the new coordinate system, see `Migrating
   to Real Coordinates`.
 
-### `container[<X>,<Y>]`
+### `container[<X>,<Y>,<size type>]`
 
 * Start of a container block, moves all physical elements in the container by
   (X, Y).
 * Must have matching `container_end`
 * Containers can be nested, in which case the offsets are added
   (child containers are relative to parent containers)
+* `size type` (optional): Changes the coordinate size, imitating the respective
+  coordinate sizes of the `size type` options of the `size` element.
+* **Note**: If the `size` element specifies `true` as the size type, then both
+  `true` and `false` will act like `true` in this element. Otherwise, both will
+  act like `false`.
 
 ### `container_end[]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1923,10 +1923,21 @@ Examples
 Elements
 --------
 
-### `size[<W>,<H>,<fixed_size>]`
+### `size[<W>,<H>,<size type>]`
 
 * Define the size of the menu in inventory slots
-* `fixed_size`: `true`/`false` (optional)
+* `size type` (optional): One of the below options:
+    * These work on either the new or old coordinate system:
+        * `false`: Scaled form size.  This is default.
+        * `true`: Fixed 800x600 pixel form size.  Acts like `false` on Android.
+    * These only work on the new coordinate system:
+        * `stretch`: Fills entire screen. Coordinates are stretched accordingly.
+	    * `fit`: The formspec is made as big as possible without stretching
+          coordinates or leaving the screen.
+        * `fill`: The formspec is made as big as the larger dimension of the
+          screen, cutting off on the other dimension if necessary.
+        * `mini`: Each single coordinate is made a single pixel. This is *not*
+          for normal forms; only use it for special uses.
 * deprecated: `invsize[<W>,<H>;]`
 
 ### `position[<X>,<Y>]`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1936,6 +1936,10 @@ Elements
           coordinates or leaving the screen.
         * `fill`: The formspec is made as big as the larger dimension of the
           screen, cutting off on the other dimension if necessary.
+        * `wide`: The formspec is as wide as the screen. The height may or may not
+          be cut off depending on the height of the screen.
+        * `tall`: The formspec is as tall as the screen. The width may or may not
+          be cut off depending on the width of the screen.
         * `mini`: Each single coordinate is made a single pixel. This is *not*
           for normal forms; only use it for special uses.
 * deprecated: `invsize[<W>,<H>;]`

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2461,22 +2461,32 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
 			}
 
-			if (mydata.size_type == "fit")
-				imgsize = MYMIN(mydata.screensize.X / mydata.invsize.X,
+			if (mydata.size_type == "fit") {
+				imgsize.X = MYMIN(mydata.screensize.X / mydata.invsize.X,
 					mydata.screensize.Y / mydata.invsize.Y);
+				imgsize.Y = imgsize.X;
+			}
 
-			if (mydata.size_type == "fill")
-				imgsize = MYMAX(mydata.screensize.X / mydata.invsize.X,
+			if (mydata.size_type == "fill") {
+				imgsize.X = MYMAX(mydata.screensize.X / mydata.invsize.X,
 					mydata.screensize.Y / mydata.invsize.Y);
+				imgsize.Y = imgsize.X;
+			}
 
-			if (mydata.size_type == "wide")
-				imgsize = mydata.screensize.X / mydata.invsize.X;
+			if (mydata.size_type == "wide") {
+				imgsize.X = mydata.screensize.X / mydata.invsize.X;
+				imgsize.Y = imgsize.X;
+			}
 
-			if (mydata.size_type == "tall")
-				imgsize = mydata.screensize.Y / mydata.invsize.Y;
+			if (mydata.size_type == "tall") {
+				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
+				imgsize.X = imgsize.Y;
+			}
 
-			if (mydata.size_type == "mini")
-				imgsize = 1;
+			if (mydata.size_type == "mini") {
+				imgsize.X = 1;
+				imgsize.Y = 1;
+			}
 
 			mydata.size = v2s32(
 				mydata.invsize.X*imgsize.X,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -311,13 +311,9 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 			if (type == "true") {
 				lockSize(true, v2u32(800, 600));
 			}
-			if (type == "stretch" || type == "fit" || type == "fill" ||
-				 type == "mini")
-			{
-				data->size_type = type;
-			}
-		}
 #endif
+			data->size_type = type;
+		}
 		data->explicit_size = true;
 		return;
 	}
@@ -2463,18 +2459,25 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 			if (mydata.size_type == "stretch") {
 				imgsize.X = mydata.screensize.X / mydata.invsize.X;
 				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
-			} else if (mydata.size_type == "fit") {
-				imgsize.X = MYMIN(mydata.screensize.X / mydata.invsize.X,
-					mydata.screensize.Y / mydata.invsize.Y);
-				imgsize.Y = imgsize.X;
-			} else if (mydata.size_type == "fill") {
-				imgsize.X = MYMAX(mydata.screensize.X / mydata.invsize.X,
-					mydata.screensize.Y / mydata.invsize.Y);
-				imgsize.Y = imgsize.X;
-			} else if (mydata.size_type == "mini") {
-				imgsize.X = 1;
-				imgsize.Y = 1;
 			}
+
+			if (mydata.size_type == "fit")
+				imgsize = MYMIN(mydata.screensize.X / mydata.invsize.X,
+					mydata.screensize.Y / mydata.invsize.Y);
+
+			if (mydata.size_type == "fill")
+				imgsize = MYMAX(mydata.screensize.X / mydata.invsize.X,
+					mydata.screensize.Y / mydata.invsize.Y);
+
+			if (mydata.size_type == "wide")
+				imgsize = mydata.screensize.X / mydata.invsize.X;
+
+			if (mydata.size_type == "tall")
+				imgsize = mydata.screensize.Y / mydata.invsize.Y;
+
+			if (mydata.size_type == "mini")
+				imgsize = 1;
+
 			mydata.size = v2s32(
 				mydata.invsize.X*imgsize.X,
 				mydata.invsize.Y*imgsize.Y

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -314,7 +314,7 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 			if (type == "stretch" || type == "fit" || type == "fill" ||
 				 type == "mini")
 			{
-				data->size_type = size;
+				data->size_type = type;
 			}
 		}
 #endif

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -289,6 +289,36 @@ v2s32 GUIFormSpecMenu::getRealCoordinateGeometry(const std::vector<std::string> 
 	return v2s32(stof(v_geom[0]) * imgsize.X, stof(v_geom[1]) * imgsize.Y);
 }
 
+void GUIFormSpecMenu::setSizeType(parserData *data, const std::string &size_type)
+{
+	if (size_type == "stretch") {
+		imgsize.X = data->screensize.X / data->invsize.X;
+		imgsize.Y = data->screensize.Y / data->invsize.Y;
+	}
+	else if (size_type == "fit") {
+		imgsize.X = MYMIN(data->screensize.X / data->invsize.X,
+			data->screensize.Y / data->invsize.Y);
+		imgsize.Y = imgsize.X;
+	}
+	else if (size_type == "fill") {
+		imgsize.X = MYMAX(data->screensize.X / data->invsize.X,
+			data->screensize.Y / data->invsize.Y);
+		imgsize.Y = imgsize.X;
+	}
+	else if (size_type == "wide") {
+		imgsize.X = data->screensize.X / data->invsize.X;
+		imgsize.Y = imgsize.X;
+	}
+	else if (size_type == "tall") {
+		imgsize.Y = data->screensize.Y / data->invsize.Y;
+		imgsize.X = imgsize.Y;
+	}
+	else if (size_type == "mini") {
+		imgsize.X = 1;
+		imgsize.Y = 1;
+	}
+}
+
 void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element, ',');
@@ -303,16 +333,19 @@ void GUIFormSpecMenu::parseSize(parserData* data, const std::string &element)
 		data->invsize.Y = MYMAX(0, stof(parts[1]));
 
 		lockSize(false);
-		data->size_type = "";
 
 		if (parts.size() == 3) {
-			std::string type = trim(parts[2]);
+			const std::string size_type = trim(parts[2]);
 #ifndef __ANDROID__
-			if (type == "true") {
+			if (size_type == "true") {
 				lockSize(true, v2u32(800, 600));
 			}
+			else {
+				setSizeType(data, size_type);
+			}
+#else
+			setSizeType(data, size_type);
 #endif
-			data->size_type = type;
 		}
 		data->explicit_size = true;
 		return;
@@ -332,6 +365,10 @@ void GUIFormSpecMenu::parseContainer(parserData* data, const std::string &elemen
 		container_stack.push(pos_offset);
 		pos_offset.X += MYMAX(0, stof(parts[0]));
 		pos_offset.Y += MYMAX(0, stof(parts[1]));
+
+		if (parts.size() == 3) {
+			setSizeType(data, trim(parts[2]));
+		}
 		return;
 	}
 	errorstream<< "Invalid container start element (" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -2456,38 +2493,6 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		m_font = g_fontengine->getFont();
 
 		if (mydata.real_coordinates) {
-			if (mydata.size_type == "stretch") {
-				imgsize.X = mydata.screensize.X / mydata.invsize.X;
-				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
-			}
-
-			if (mydata.size_type == "fit") {
-				imgsize.X = MYMIN(mydata.screensize.X / mydata.invsize.X,
-					mydata.screensize.Y / mydata.invsize.Y);
-				imgsize.Y = imgsize.X;
-			}
-
-			if (mydata.size_type == "fill") {
-				imgsize.X = MYMAX(mydata.screensize.X / mydata.invsize.X,
-					mydata.screensize.Y / mydata.invsize.Y);
-				imgsize.Y = imgsize.X;
-			}
-
-			if (mydata.size_type == "wide") {
-				imgsize.X = mydata.screensize.X / mydata.invsize.X;
-				imgsize.Y = imgsize.X;
-			}
-
-			if (mydata.size_type == "tall") {
-				imgsize.Y = mydata.screensize.Y / mydata.invsize.Y;
-				imgsize.X = imgsize.Y;
-			}
-
-			if (mydata.size_type == "mini") {
-				imgsize.X = 1;
-				imgsize.Y = 1;
-			}
-
 			mydata.size = v2s32(
 				mydata.invsize.X*imgsize.X,
 				mydata.invsize.Y*imgsize.Y

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -401,12 +401,15 @@ protected:
 			const std::vector<std::string> &v_pos);
 	v2s32 getRealCoordinateGeometry(const std::vector<std::string> &v_geom);
 
+	double use_imgsize;
 	v2s32 padding;
 	v2f32 spacing;
 	v2s32 imgsize;
 	v2s32 offset;
 	v2f32 pos_offset;
 	std::stack<v2f32> container_stack;
+	std::vector<v2f32> real_cont;
+	std::vector<v2s32> real_cont_imgsize;
 
 	InventoryManager *m_invmgr;
 	ISimpleTextureSource *m_tsrc;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -469,7 +469,6 @@ private:
 
 	typedef struct {
 		bool explicit_size;
-		std::string size_type;
 		bool real_coordinates;
 		v2f invsize;
 		v2s32 size;
@@ -496,6 +495,8 @@ private:
 	std::string current_field_enter_pending = "";
 
 	void parseElement(parserData* data, const std::string &element);
+
+	void setSizeType(parserData *data, const std::string &size_type);
 
 	void parseSize(parserData* data, const std::string &element);
 	void parseContainer(parserData* data, const std::string &element);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -469,6 +469,7 @@ private:
 
 	typedef struct {
 		bool explicit_size;
+		std::string size_type;
 		bool real_coordinates;
 		v2f invsize;
 		v2s32 size;


### PR DESCRIPTION
This PR adds multiple different size types of FormSpec sizing types.  All new types require `real_coordinates` to be set to `true`.  This is an expansion of #8630 (I meant to continue it, but I messed it up and accidentally deleted it while trying to rebase -- I'm still trying to figure out Git).

There are four new types of sizing: `stretch`, `fill`, `fit`, `wide`, `tall`, and `mini`.  These are illustrated in the below image (black is Minetest window, red is FormSpec):

![types](https://user-images.githubusercontent.com/31123645/60401053-ec7f1e00-9b30-11e9-80d4-51e04a562216.png)
<sup>In order: normal (`false`), `fit`, `fill`, `stretch`, `mini`, `wide`, `tall`</sup>

* `fit` is as big as possible without being cut off.
* `fill` is as big as possible without being bigger than the side of the screen, so the form will always be cut off.
* `stretch` stretches coordinates to make the form match the screen size, so things like images might look lopsided.
* `wide` is as wide as the screen, and the height may or may not be cut off depending on the screen size.
* `tall` is the same as `wide` but with the height as opposed to the width.
* `mini` works as a single pixel per coordinate.  Certain things (like labels) won't work in `mini`.  There is a note in `lua_api.txt` that states that `mini` should *not* be used for normal forms, only for specialized purposes.
* Everything except `mini` may not quite meet up with the edge of the screen when they should due to `imgsize` being integers, not floats.

To specify which system to use, you have to use the third parameter in the `size` element, e.g. `size[10,5,fit]`.  The old behavior of `true` for fixed size has not been changed for compatibility (although I don't think any mods use it).

<details>
<summary><b>Screenshots</b></summary>

`fit`, `fill`, and `stretch` FormSpec:
```
size[1,1,<type>]
real_coordinates[true]
box[0.25,0.25;0.25,0.25;#000000]
box[0.5,0.5;0.5,0.5;#FFFFFF]
```

`fit`
![fit](https://user-images.githubusercontent.com/31123645/60400729-fe5ec200-9b2c-11e9-9837-eb9350f10cfe.png)

`fill`
![fill](https://user-images.githubusercontent.com/31123645/60400730-028adf80-9b2d-11e9-89b4-fbd091d2d211.png)

`stretch`
![stretch](https://user-images.githubusercontent.com/31123645/60400732-074f9380-9b2d-11e9-9788-64f3faed00c7.png)

`wide`
```
size[5,1,wide]
real_coordinates[true]
box[0.25,0.25;0.25,0.25;#000000]
box[0.5,0.5;0.5,0.5;#FFFFFF]
```
![wide](https://user-images.githubusercontent.com/31123645/60401320-68c73080-9b34-11e9-9231-c92d3d8481be.png)

`tall`
```
size[1,5,tall]
real_coordinates[true]
box[0.25,0.25;0.25,0.25;#000000]
box[0.5,0.5;0.5,0.5;#FFFFFF]
```
![tall](https://user-images.githubusercontent.com/31123645/60401324-6c5ab780-9b34-11e9-883c-1acd9ea65a7b.png)

`mini`
```
size[20,20,mini]
real_coordinates[true]
box[5,5;5,5;#000000]
box[10,10;10,10;#FFFFFF]
```
![mini](https://user-images.githubusercontent.com/31123645/60400735-120a2880-9b2d-11e9-8cd1-612f3bddd17c.png)
</details>

This PR is Ready for Review.