### PR TITLE
Fix missing item images clipping in formspecs

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -652,23 +652,28 @@ void drawItemStack(video::IVideoDriver *driver,
 		core::rect<s32> viewrect = rect;
 		if (clip)
 			viewrect.clipAgainst(*clip);
+
 		core::matrix4 ProjMatrix;
+		ProjMatrix.buildProjectionMatrixOrthoLH(2.0f, 2.0f, -1.0f, 100.0f);
+
 		core::matrix4 ViewMatrix;
 		ViewMatrix.buildProjectionMatrixOrthoLH(
 			2.0f * viewrect.getWidth() / rect.getWidth(),
 			2.0f * viewrect.getHeight() / rect.getHeight(),
-			-1, 100);
+			-1.0f,
+			100.0f);
 		ViewMatrix.setTranslation(core::vector3df(
 			1.0f * (rect.LowerRightCorner.X + rect.UpperLeftCorner.X -
 					viewrect.LowerRightCorner.X - viewrect.UpperLeftCorner.X) /
 					viewrect.getWidth(),
 			1.0f * (viewrect.LowerRightCorner.Y + viewrect.UpperLeftCorner.Y -
 					rect.LowerRightCorner.Y - rect.UpperLeftCorner.Y) /
-					viewrect.getHeight(), 0));
+					viewrect.getHeight(),
+			0.0f));
 
-		ProjMatrix.buildProjectionMatrixOrthoLH(2, 2, -1, 100);
 		driver->setTransform(video::ETS_PROJECTION, ProjMatrix);
 		driver->setTransform(video::ETS_VIEW, ViewMatrix);
+
 		core::matrix4 matrix;
 		matrix.makeIdentity();
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -649,10 +649,25 @@ void drawItemStack(video::IVideoDriver *driver,
 		core::rect<s32> oldViewPort = driver->getViewPort();
 		core::matrix4 oldProjMat = driver->getTransform(video::ETS_PROJECTION);
 		core::matrix4 oldViewMat = driver->getTransform(video::ETS_VIEW);
+		core::rect<s32> viewrect = rect;
+		if (clip) viewrect.clipAgainst(*clip);
 		core::matrix4 ProjMatrix;
+		core::matrix4 ViewMatrix;
+		ViewMatrix.buildProjectionMatrixOrthoLH(
+			2.0 * viewrect.getWidth() / rect.getWidth(),
+			2.0 * viewrect.getHeight() / rect.getHeight(),
+			-1, 100);
+		ViewMatrix.setTranslation(core::vector3df(
+			1.0 * (rect.LowerRightCorner.X + rect.UpperLeftCorner.X -
+					viewrect.LowerRightCorner.X - viewrect.UpperLeftCorner.X) /
+					viewrect.getWidth(),
+			1.0 * (viewrect.LowerRightCorner.Y + viewrect.UpperLeftCorner.Y -
+					rect.LowerRightCorner.Y - rect.UpperLeftCorner.Y) /
+					viewrect.getHeight(), 0));
+
 		ProjMatrix.buildProjectionMatrixOrthoLH(2, 2, -1, 100);
 		driver->setTransform(video::ETS_PROJECTION, ProjMatrix);
-		driver->setTransform(video::ETS_VIEW, ProjMatrix);
+		driver->setTransform(video::ETS_VIEW, ViewMatrix);
 		core::matrix4 matrix;
 		matrix.makeIdentity();
 
@@ -662,7 +677,7 @@ void drawItemStack(video::IVideoDriver *driver,
 		}
 
 		driver->setTransform(video::ETS_WORLD, matrix);
-		driver->setViewPort(rect);
+		driver->setViewPort(viewrect);
 
 		video::SColor basecolor =
 			client->idef()->getItemstackColor(item, client);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -650,18 +650,19 @@ void drawItemStack(video::IVideoDriver *driver,
 		core::matrix4 oldProjMat = driver->getTransform(video::ETS_PROJECTION);
 		core::matrix4 oldViewMat = driver->getTransform(video::ETS_VIEW);
 		core::rect<s32> viewrect = rect;
-		if (clip) viewrect.clipAgainst(*clip);
+		if (clip)
+			viewrect.clipAgainst(*clip);
 		core::matrix4 ProjMatrix;
 		core::matrix4 ViewMatrix;
 		ViewMatrix.buildProjectionMatrixOrthoLH(
-			2.0 * viewrect.getWidth() / rect.getWidth(),
-			2.0 * viewrect.getHeight() / rect.getHeight(),
+			2.0f * viewrect.getWidth() / rect.getWidth(),
+			2.0f * viewrect.getHeight() / rect.getHeight(),
 			-1, 100);
 		ViewMatrix.setTranslation(core::vector3df(
-			1.0 * (rect.LowerRightCorner.X + rect.UpperLeftCorner.X -
+			1.0f * (rect.LowerRightCorner.X + rect.UpperLeftCorner.X -
 					viewrect.LowerRightCorner.X - viewrect.UpperLeftCorner.X) /
 					viewrect.getWidth(),
-			1.0 * (viewrect.LowerRightCorner.Y + viewrect.UpperLeftCorner.Y -
+			1.0f * (viewrect.LowerRightCorner.Y + viewrect.UpperLeftCorner.Y -
 					rect.LowerRightCorner.Y - rect.UpperLeftCorner.Y) /
 					viewrect.getHeight(), 0));
 


### PR DESCRIPTION
When using item_image_button in formspec with a node, item image is not clipped at all.

This PR makes drawItemStack clip drawn image against clip rectangle even with 3D rendered items.

## How to test
You can easily test result of this PR with this Lua code :
```lua
minetest.register_chatcommand("t", {
	params = "",
	description = "Test",
	func = function(name, param)
		minetest.show_formspec(name, "test", [[size[5,5]
		item_image_button[0,-0.75;1,1;default:stone;test;]
		item_image_button[1,-0.5;1,1;default:stone;test;]
		item_image_button[2,-0.25;1,1;default:stone;test;]
		item_image_button[3,0;1,1;default:stone;test;]
		item_image_button[1,5;1,1;default:stone;test;]
		item_image_button[-0.75,1;1,1;default:stone;test;]
		item_image_button[-0.5,2;1,1;default:stone;test;]
		item_image_button[-0.25,3;1,1;default:stone;test;]
		item_image_button[4.5,1;1,1;default:stone;test;]
		item_image_button[4.75,2;1,1;default:stone;test;]
		item_image_button[5,3;1,1;default:stone;test;]
		]])
	end,
})
```
Result before the modification:
![screenshot_20190702_234303](https://user-images.githubusercontent.com/13189280/60549426-1b5de580-9d25-11e9-9068-a874bde21bcb.png)

Result after it:
![screenshot_20190702_234055](https://user-images.githubusercontent.com/13189280/60549430-1e58d600-9d25-11e9-95ac-754f5a56a0d4.png)

