### PR TITLE
Serialize: userdata if it contains to_string function

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -147,6 +147,8 @@ function core.serialize(x)
 				end
 			end
 			return "{"..table.concat(vals, ", ").."}"
+		elseif tp == "userdata" and x.to_string then
+			return string.format("%q", x:to_string())
 		else
 			error("Can't serialize data of type "..tp)
 		end


### PR DESCRIPTION
Instead of trying to write userdata to the falling node entity this fix will run over each item stack in the node's inventory and convert it to a proper string.