### PR TITLE
Hide chat when console is open

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3835,7 +3835,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_last_cam_dir = camera_direction;
 	}
 
-	m_game_ui->update(*stats, client, draw_control, cam, runData.pointed_old, dtime);
+	m_game_ui->update(*stats, client, draw_control, cam, runData.pointed_old, gui_chat_console, dtime);
 
 	/*
 	   make sure menu is on top

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <irrlicht_changes/static_text.h>
 #include <gettext.h>
 #include "gui/mainmenumanager.h"
+#include "gui/guiChatConsole.h"
 #include "util/pointedthing.h"
 #include "client.h"
 #include "clientmap.h"
@@ -85,7 +86,8 @@ void GameUI::init()
 }
 
 void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_control,
-	const CameraOrientation &cam, const PointedThing &pointed_old, float dtime)
+	const CameraOrientation &cam, const PointedThing &pointed_old,
+	const GUIChatConsole *chat_console, float dtime)
 {
 	v2u32 screensize = RenderingEngine::get_instance()->getWindowSize();
 
@@ -186,6 +188,9 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		m_guitext_status->setOverrideColor(fade_color);
 		m_guitext_status->enableOverrideColor(true);
 	}
+
+	// Hide chat when console is visible
+	m_guitext_chat->setVisible(isChatVisible() && !chat_console->isVisible());
 }
 
 void GameUI::initFlags()
@@ -227,9 +232,7 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 	m_guitext_chat->setRelativePosition(core::rect<s32>(10, chat_y, width,
 		chat_y + m_guitext_chat->getTextHeight()));
 
-	// Don't show chat if disabled or empty or profiler is enabled
-	m_guitext_chat->setVisible(m_flags.show_chat &&
-		recent_chat_count != 0 && m_profiler_current_page == 0);
+	m_recent_chat_count = recent_chat_count;
 }
 
 void GameUI::updateProfiler()

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 using namespace irr;
 class Client;
+class GUIChatConsole;
 struct MapDrawControl;
 
 /*
@@ -63,7 +64,7 @@ public:
 	void init();
 	void update(const RunStats &stats, Client *client, MapDrawControl *draw_control,
 			const CameraOrientation &cam, const PointedThing &pointed_old,
-			float dtime);
+			const GUIChatConsole *chat_console, float dtime);
 
 	void initFlags();
 	const Flags &getFlags() const { return m_flags; }
@@ -81,6 +82,10 @@ public:
 	void showTranslatedStatusText(const char *str);
 	inline void clearStatusText() { m_statustext.clear(); }
 
+	const bool isChatVisible()
+	{
+		return m_flags.show_chat && m_recent_chat_count != 0 && m_profiler_current_page == 0;
+	}
 	void setChatText(const EnrichedString &chat_text, u32 recent_chat_count);
 
 	void updateProfiler();
@@ -114,6 +119,7 @@ private:
 	video::SColor m_statustext_initial_color;
 
 	gui::IGUIStaticText *m_guitext_chat = nullptr; // Chat text
+	u32 m_recent_chat_count = 0;
 
 	gui::IGUIStaticText *m_guitext_profiler = nullptr; // Profiler text
 	u8 m_profiler_current_page = 0;


### PR DESCRIPTION
This PR hides the chat when the console is displayed, to avoid ugly overlapping of text.

This PR is Ready for Review.
<!-- ^ delete one -->

## Screenshots

#### `master`

![Screenshot from 2019-07-05 20-35-40](https://user-images.githubusercontent.com/36130650/60799530-ef14ef80-a190-11e9-9908-cb64b65eb95c.png)

#### PR

![Screenshot from 2019-07-05 14-55-06](https://user-images.githubusercontent.com/36130650/60713283-613dc800-9f36-11e9-9dc5-10d1fcacc4c3.png)

## How to test

<!-- Example code or instructions -->
- Enter a couple of chat messages.
- Observe the messages being displayed in the top-left corner of the screen.
- Open the chat console by pressing `T`, `.`, `/`, or `F10`.
- Notice that the chat messages _behind_ the console disappears.