### PR TITLE
Add origin options to FormSpec labels

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2726,11 +2726,36 @@ Some types may inherit styles from parent types.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to false.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * halign - left/center/right, sets text horizontal alignment in respect to position.
-      Default right for label and center for vertlabel.
-    * valign - top/center/bottom, sets text vertical alignment in respect to position.
-      Default center for label and bottom for vertlabel.
-    * newline_spacing - number, sets space in coordinates between lines of text. Default 0.5.
+    * horigin - Sets horizontal origin in relation to label text. Possible values:
+        * `left`: Left side of the bounding box
+        * `center`: Center of the bounding box
+        * `right`: Right side of the bounding box
+        * `leftline`: **Note**: Only for negative `newline_spacing`
+            * `label`: Acts like `left`
+            * `vertlabel`: Left end of first column
+        * `centerline`:
+            * `label`: Center of first character
+            * `vertlabel`: Center of first column
+        * `rightline`:
+            * `label`: Right end of first character
+            * `vertlabel`: Right end of first column
+      Default `left` for label and `centerline` for vertlabel.
+    * vorigin - Sets vertical origin in relation to label text. Possible values:
+        * `top`: Top of the bounding box
+        * `center`: Center of the bounding box
+        * `bottom`: Bottom of the bounding box
+        * `topline`: **Note**: Only for negative `newline_spacing`
+            * `label`: Top of first line
+            * `vertlabel`: Acts like `top`
+        * `centerline`:
+            * `label`: Center of first line
+            * `vertlabel`: Center of first character
+        * `bottomline`:
+            * `label`: Bottom of first line
+            * `vertlabel`: Bottom of first character
+      Default `centerline` for label and `top` for vertlabel.
+    * newline_spacing - number/`auto`, sets space in coordinates between lines/columns of text.
+      If set to `auto`, the text is as close together as possible without overlap. Default 0.5.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.
     * fgimg_hovered - image when hovered. Defaults to fgimg when not provided.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2330,7 +2330,7 @@ Elements
 * `label` is the text on the label
 * **Note**: If the new coordinate system is enabled, vertlabels are positioned
   from the center of the text by default, not the left.
-* Newlines in a vertlabel are displayed to the right of the starting text.
+* Newlines in a vertlabel add columns to the right of the starting text.
 
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2312,7 +2312,7 @@ Elements
 * **Note**: If the new coordinate system is enabled, labels are
   positioned from the center of the text by default, not the top.
 * The text is displayed directly without automatic line breaking,
-  so label should not be used for big text chunks.  Newlines can be
+  so label should not be used for big text chunks. Newlines can be
   used to make labels multiline.
 * **Note**: With the new coordinate system, newlines are defaultly spaced
   with half a coordinate. With the old system, newlines are spaced 2/5 of
@@ -2330,7 +2330,7 @@ Elements
 * `label` is the text on the label
 * **Note**: If the new coordinate system is enabled, vertlabels are positioned
   from the center of the text by default, not the left.
-* Newlines in a vertlabel will be displayed to the right of the starting text.
+* Newlines in a vertlabel are displayed to the right of the starting text.
 
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
@@ -2726,8 +2726,10 @@ Some types may inherit styles from parent types.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to false.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-    * halign - left/center/right, sets text horizontal alignment in respect to position. Default left.
-    * valign - top/center/bottom, sets text vertical alignment in respect to position. Default center.
+    * halign - left/center/right, sets text horizontal alignment in respect to position.
+      Default right for label and center for vertlabel.
+    * valign - top/center/bottom, sets text vertical alignment in respect to position.
+      Default center for label and bottom for vertlabel.
     * newline_spacing - number, sets space in coordinates between lines of text. Default 0.5.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2310,12 +2310,12 @@ Elements
 * The label formspec element displays the text set in `label`
   at the specified position.
 * **Note**: If the new coordinate system is enabled, labels are
-  positioned from the center of the text, not the top.
+  positioned from the center of the text by default, not the top.
 * The text is displayed directly without automatic line breaking,
   so label should not be used for big text chunks.  Newlines can be
   used to make labels multiline.
-* **Note**: With the new coordinate system, newlines are spaced with
-  half a coordinate.  With the old system, newlines are spaced 2/5 of
+* **Note**: With the new coordinate system, newlines are defaultly spaced
+  with half a coordinate. With the old system, newlines are spaced 2/5 of
   an inventory slot.
 
 ### `hypertext[<X>,<Y>;<W>,<H>;<name>;<text>]`
@@ -2328,8 +2328,9 @@ Elements
 ### `vertlabel[<X>,<Y>;<label>]`
 * Textual label drawn vertically
 * `label` is the text on the label
-* **Note**: If the new coordinate system is enabled, vertlabels are
-  positioned from the center of the text, not the left.
+* **Note**: If the new coordinate system is enabled, vertlabels are positioned
+  from the center of the text by default, not the left.
+* Newlines in a vertlabel will be displayed to the right of the starting text.
 
 ### `button[<X>,<Y>;<W>,<H>;<name>;<label>]`
 
@@ -2725,6 +2726,9 @@ Some types may inherit styles from parent types.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to false.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+    * halign - left/center/right, sets text horizontal alignment in respect to position. Default left.
+    * valign - top/center/bottom, sets text vertical alignment in respect to position. Default center.
+    * newline_spacing - number, sets space in coordinates between lines of text. Default 0.5.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.
     * fgimg_hovered - image when hovered. Defaults to fgimg when not provided.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2730,29 +2730,17 @@ Some types may inherit styles from parent types.
         * `left`: Left side of the bounding box
         * `center`: Center of the bounding box
         * `right`: Right side of the bounding box
-        * `leftline`: **Note**: Only for negative `newline_spacing`
-            * `label`: Acts like `left`
-            * `vertlabel`: Left end of first column
-        * `centerline`:
-            * `label`: Center of first character
-            * `vertlabel`: Center of first column
-        * `rightline`:
-            * `label`: Right end of first character
-            * `vertlabel`: Right end of first column
+        * `leftline` (vertlabel only): Left end of first column
+        * `centerline` (vertlabel only): Center of first column
+        * `rightline` (vertlabel only): Right end of first column
       Default `left` for label and `centerline` for vertlabel.
     * vorigin - Sets vertical origin in relation to label text. Possible values:
         * `top`: Top of the bounding box
         * `center`: Center of the bounding box
         * `bottom`: Bottom of the bounding box
-        * `topline`: **Note**: Only for negative `newline_spacing`
-            * `label`: Top of first line
-            * `vertlabel`: Acts like `top`
-        * `centerline`:
-            * `label`: Center of first line
-            * `vertlabel`: Center of first character
-        * `bottomline`:
-            * `label`: Bottom of first line
-            * `vertlabel`: Bottom of first character
+        * `topline` (label only): Top of first line
+        * `centerline` (label only): Center of first line
+        * `bottomline` (label only): Bottom of first line
       Default `centerline` for label and `top` for vertlabel.
     * newline_spacing - number, sets space between lines/columns of text. If
       the number is prefixed with `*`, the spacing is set to a multiple of the

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2754,8 +2754,9 @@ Some types may inherit styles from parent types.
             * `label`: Bottom of first line
             * `vertlabel`: Bottom of first character
       Default `centerline` for label and `top` for vertlabel.
-    * newline_spacing - number/`auto`, sets space in coordinates between lines/columns of text.
-      If set to `auto`, the text is as close together as possible without overlap. Default 0.5.
+    * newline_spacing - number, sets space between lines/columns of text. If
+      the number is prefixed with `*`, the spacing is set to a multiple of the
+      label's font height or width, otherwise it's in coordinates. Default `0.5`.
 * image_button (additional properties)
     * fgimg - standard image. Defaults to none.
     * fgimg_hovered - image when hovered. Defaults to fgimg when not provided.

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -46,8 +46,8 @@ public:
 		ALPHA,
 		CONTENT_OFFSET,
 		PADDING,
-		HALIGN,
-		VALIGN,
+		HORIGIN,
+		VORIGIN,
 		NEWLINE_SPACING,
 		NUM_PROPERTIES,
 		NONE
@@ -101,10 +101,10 @@ public:
 			return CONTENT_OFFSET;
 		} else if (name == "padding") {
 			return PADDING;
-		} else if (name == "halign") {
-			return HALIGN;
-		} else if (name == "valign") {
-			return VALIGN;
+		} else if (name == "horigin") {
+			return HORIGIN;
+		} else if (name == "vorigin") {
+			return VORIGIN;
 		} else if (name == "newline_spacing") {
 			return NEWLINE_SPACING;
 		} else {

--- a/src/gui/StyleSpec.h
+++ b/src/gui/StyleSpec.h
@@ -46,6 +46,9 @@ public:
 		ALPHA,
 		CONTENT_OFFSET,
 		PADDING,
+		HALIGN,
+		VALIGN,
+		NEWLINE_SPACING,
 		NUM_PROPERTIES,
 		NONE
 	};
@@ -98,6 +101,12 @@ public:
 			return CONTENT_OFFSET;
 		} else if (name == "padding") {
 			return PADDING;
+		} else if (name == "halign") {
+			return HALIGN;
+		} else if (name == "valign") {
+			return VALIGN;
+		} else if (name == "newline_spacing") {
+			return NEWLINE_SPACING;
 		} else {
 			return NONE;
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1767,8 +1767,8 @@ void GUIFormSpecMenu::parseLabelOptions(parserData* data, const std::string &ele
 		std::string y_align = trim(parts[1]);
 		f32 spacing = stof(parts[2]);
 
-		auto x = gui::EGUIA_UPPERLEFT;
-		auto y = gui::EGUIA_CENTER;
+		EGUI_ALIGNMENT x = gui::EGUIA_UPPERLEFT;
+		EGUI_ALIGNMENT y = gui::EGUIA_CENTER;
 
 		if (x_align == "right")
 			x = gui::EGUIA_LOWEERRIGHT;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1827,7 +1827,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				v2s32 pos = getRealCoordinateBasePos(v_pos);
 
 				// Add newline spacing
-				pos.Y += (((float) imgsize.Y) * data->labelOptions.spacing);
+				pos.Y += (((float) imgsize.Y) * data->labelOptions.spacing * i);
 
 				f32 font_width = m_font->getDimension(wlabel.c_str()).Width;
 				f32 font_height = font_line_height(m_font);
@@ -1845,7 +1845,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				rect = core::rect<s32>(
 					pos.X, pos.Y,
 					pos.X + font_width,
-					pos.Y + imgsize.Y);
+					pos.Y + font_height);
 
 			} else {
 				// Lines are spaced at the nominal distance of

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1806,7 +1806,8 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				v2s32 pos = getRealCoordinateBasePos(v_pos);
 
 				// Add newline spacing
-				pos.Y += (((float) imgsize.Y) * stof(style.get(StyleSpec::NEWLINE_SPACING, "0.5")) * i);
+				pos.Y += (float)imgsize.Y * stof(style.get(StyleSpec::NEWLINE_SPACING,
+					"0.5")) * i;
 
 				// Move the label around for alignment
 				s32 font_width = m_font->getDimension(wlabel_plain.c_str()).Width;
@@ -1842,7 +1843,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				pos.X += stof(v_pos[0]) * spacing.X;
 				pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
 
-				pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
+				pos.Y += (float)i * spacing.Y * 2.0 / 5.0;
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y - m_btn_height,
@@ -1942,7 +1943,8 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 				pos = getRealCoordinateBasePos(v_pos);
 
 				// Add newline spacing
-				pos.X += (((float) imgsize.X) * stof(style.get(StyleSpec::NEWLINE_SPACING, "0.5")) * i);
+				pos.X += (float)imgsize.X * stof(style.get(StyleSpec::NEWLINE_SPACING,
+					"0.5")) * i;
 
 				// Move the label around for alignment
 				s32 font_width = m_font->getDimension(wlabel_plain.c_str()).Width;
@@ -1967,7 +1969,7 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 				pos = getElementBasePos(&v_pos);
 
 				// Add newline spacing. Just some necessary patching, so no styling
-				pos.X += (((float) imgsize.X) * 0.5 * i);
+				pos.X += (float)imgsize.X * 0.5 * i;
 
 				// The length must be one longer to fit the text. The
 				// width of the rect (15 pixels) seems rather arbitrary,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1806,10 +1806,12 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 		std::string str_newline = style.get(StyleSpec::NEWLINE_SPACING, "0.5");
 		float newline_spacing;
-		if (trim(str_newline) == "auto")
-			newline_spacing = (float)font_height;
-		else
+		if (str_newline.size() > 0 && str_newline[0] == '*') {
+			str_newline = str_newline.substr(1);
+			newline_spacing = stof(str_newline) * (float)font_height;
+		} else {
 			newline_spacing = stof(str_newline) * (float)imgsize.Y;
+		}
 
 		s32 rect_height = abs(newline_spacing) * (float)(lines.size() - 1) + font_height;
 
@@ -1989,8 +1991,10 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 
 		std::string str_newline = style.get(StyleSpec::NEWLINE_SPACING, "0.5");
 		float newline_spacing = 0;
-		if (trim(str_newline) == "auto") {
-			newline_spacing = (float)font_width + m_font->getKerningWidth();
+		if (str_newline.size() > 0 && str_newline[0] == '*') {
+			str_newline = str_newline.substr(1);
+			newline_spacing = stof(str_newline) * (float)font_width +
+				m_font->getKerningWidth();
 		} else {
 			newline_spacing = stof(str_newline) * (float)imgsize.X;
 		}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1771,14 +1771,14 @@ void GUIFormSpecMenu::parseLabelOptions(parserData* data, const std::string &ele
 		EGUI_ALIGNMENT y = gui::EGUIA_CENTER;
 
 		if (x_align == "right")
-			x = gui::EGUIA_LOWEERRIGHT;
+			x = gui::EGUIA_LOWERRIGHT;
 		if (x_align == "center")
 			x = gui::EGUIA_CENTER;
 
 		if (y_align == "top")
 			y = gui::EGUIA_UPPERLEFT;
 		if (y_align == "bottom")
-			y = gui::EGUIA_LOWEERRIGHT;
+			y = gui::EGUIA_LOWERRIGHT;
 
 		if (spacing > 0)
 			data->labelOptions.spacing = spacing;
@@ -1827,14 +1827,14 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 				v2s32 pos = getRealCoordinateBasePos(v_pos);
 
 				// Add newline spacing
-				pos.Y += (((float) imgsize.Y) * data->labelOptions.spacing)
+				pos.Y += (((float) imgsize.Y) * data->labelOptions.spacing);
 
 				f32 font_width = m_font->getDimension(wlabel.c_str()).Width;
 				f32 font_height = font_line_height(m_font);
 
 				if (data->labelOptions.X == gui::EGUIA_CENTER)
 					pos.X -= font_width / 2;
-				if (data->labelOptions.X == gui::EGUIA_LOWEERRIGHT)
+				if (data->labelOptions.X == gui::EGUIA_LOWERRIGHT)
 					pos.X -= font_width;
 
 				if (data->labelOptions.Y == gui::EGUIA_UPPERLEFT)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1784,12 +1784,6 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 			horigin = ORIGIN_LOWERRIGHT;
 		else if (str_horigin == "center")
 			horigin = ORIGIN_CENTER;
-		else if (str_horigin == "leftline")
-			horigin = ORIGIN_UPPERLEFT_LINE;
-		else if (str_horigin == "centerline")
-			horigin = ORIGIN_CENTER_LINE;
-		else if (str_horigin == "rightline")
-			horigin = ORIGIN_LOWERRIGHT_LINE;
 
 		if (str_vorigin == "top")
 			vorigin = ORIGIN_UPPERLEFT;
@@ -1815,14 +1809,6 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 
 		s32 rect_height = abs(newline_spacing) * (float)(lines.size() - 1) + font_height;
 
-		s32 first_char_width = 0;
-		if (lines[0].size() > 0) {
-			std::wstring unescaped = unescape_enriched(translate_string(
-				utf8_to_wide(unescape_string(lines[0]))));
-			wchar_t first[2] = {unescaped[0], '\0'};
-			first_char_width = m_font->getDimension(first).Width;
-		}
-
 		for (u32 i = 0; i < lines.size(); i++) {
 			std::wstring wlabel_colors = translate_string(
 				utf8_to_wide(unescape_string(lines[i])));
@@ -1844,10 +1830,6 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 					pos.X -= font_width / 2;
 				else if (horigin == ORIGIN_LOWERRIGHT)
 					pos.X -= font_width;
-				else if (horigin == ORIGIN_CENTER_LINE)
-					pos.X -= first_char_width / 2;
-				else if (horigin == ORIGIN_LOWERRIGHT_LINE)
-					pos.X -= first_char_width;
 
 				if (vorigin == ORIGIN_UPPERLEFT_LINE) {
 					// Don't move it
@@ -1967,12 +1949,6 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 			vorigin = ORIGIN_LOWERRIGHT;
 		else if (str_vorigin == "center")
 			vorigin = ORIGIN_CENTER;
-		else if (str_vorigin == "topline")
-			vorigin = ORIGIN_UPPERLEFT_LINE;
-		else if (str_vorigin == "centerline")
-			vorigin = ORIGIN_CENTER_LINE;
-		else if (str_vorigin == "bottomline")
-			vorigin = ORIGIN_LOWERRIGHT_LINE;
 
 		std::vector<std::wstring> lines;
 		lines.reserve(raw_lines.size());
@@ -2000,12 +1976,6 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 		}
 
 		s32 rect_width = abs(newline_spacing) * (float)(lines.size() - 1) + font_width;
-
-		s32 first_char_height = 0;
-		if (lines[0].size() > 0) {
-			wchar_t first[2] = {lines[0][0], '\0'};
-			first_char_height = m_font->getDimension(first).Height;
-		}
 
 		v2s32 pos;
 
@@ -2053,10 +2023,6 @@ void GUIFormSpecMenu::parseVertLabel(parserData* data, const std::string &elemen
 					pos.Y -= font.Height / 2;
 				else if (vorigin == ORIGIN_LOWERRIGHT)
 					pos.Y -= font.Height;
-				else if (vorigin == ORIGIN_LOWERRIGHT_LINE)
-					pos.Y -= first_char_height;
-				else if (vorigin == ORIGIN_CENTER_LINE)
-					pos.Y -= first_char_height / 2;
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1783,11 +1783,13 @@ void GUIFormSpecMenu::parseLabelOptions(parserData* data, const std::string &ele
 		if (spacing > 0)
 			data->labelOptions.spacing = spacing;
 		else
-			warningstream << "Invalid labeloptions spacing(" << spacing << "): '" <<
-				element << "'" << std::endl;
+			if (trim(parts[2]) == "")
+				warningstream << "Invalid labeloptions spacing(" << spacing << "): '" <<
+					element << "'" << std::endl;
 
 		data->labelOptions.X = x;
 		data->labelOptions.Y = y;
+		return;
 	}
 	warningstream << "Invalid labeloptions element(" << parts.size() << "): '" << element
 		<< "'" << std::endl;
@@ -1838,9 +1840,9 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 					pos.X -= font_width;
 
 				if (data->labelOptions.Y == gui::EGUIA_UPPERLEFT)
-					pos.X -= font_height;
+					pos.Y -= font_height;
 				if (data->labelOptions.Y == gui::EGUIA_CENTER)
-					pos.X -= font_height / 2;
+					pos.Y -= font_height / 2;
 
 				rect = core::rect<s32>(
 					pos.X, pos.Y,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1780,12 +1780,7 @@ void GUIFormSpecMenu::parseLabelOptions(parserData* data, const std::string &ele
 		if (y_align == "bottom")
 			y = gui::EGUIA_LOWERRIGHT;
 
-		if (spacing > 0)
-			data->labelOptions.spacing = spacing;
-		else
-			if (trim(parts[2]) == "")
-				warningstream << "Invalid labeloptions spacing(" << spacing << "): '" <<
-					element << "'" << std::endl;
+		data->labelOptions.spacing = spacing;
 
 		data->labelOptions.X = x;
 		data->labelOptions.Y = y;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -420,6 +420,7 @@ private:
 			const std::string &type);
 	void parseHyperText(parserData *data, const std::string &element);
 	void parseLabel(parserData* data, const std::string &element);
+	void parseLabelOptions(parserData* data, const std::string &element);
 	void parseVertLabel(parserData* data, const std::string &element);
 	void parseImageButton(parserData* data, const std::string &element,
 			const std::string &type);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -420,7 +420,6 @@ private:
 			const std::string &type);
 	void parseHyperText(parserData *data, const std::string &element);
 	void parseLabel(parserData* data, const std::string &element);
-	void parseLabelOptions(parserData* data, const std::string &element);
 	void parseVertLabel(parserData* data, const std::string &element);
 	void parseImageButton(parserData* data, const std::string &element,
 			const std::string &type);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -61,6 +61,15 @@ typedef enum {
 	quit_mode_cancel
 } FormspecQuitMode;
 
+typedef enum {
+	ORIGIN_UPPERLEFT,
+	ORIGIN_CENTER,
+	ORIGIN_LOWERRIGHT,
+	ORIGIN_UPPERLEFT_LINE,
+	ORIGIN_CENTER_LINE,
+	ORIGIN_LOWERRIGHT_LINE
+} FormSpecLabelOrigin;
+
 struct TextDest
 {
 	virtual ~TextDest() = default;


### PR DESCRIPTION
**Note**: This PR is closed due to bad implementation.  A new one will be worked on after #9755 is merged (or rejected for some reason).

This PR allows the `label` and `vertlabel` elements in FormSpecs to have origin set and custom newline spacing.  This closes #7613.  It adds three new styling options to `label` and `vertlabel`:

### From `lua_api.txt`:
* label, vertlabel
    * horigin - Sets horizontal origin in relation to label text. Possible values:
        * `left`: Left side of the bounding box
        * `center`: Center of the bounding box
        * `right`: Right side of the bounding box
        * `leftline` (vertlabel only): Left end of first column
        * `centerline` (vertlabel only): Center of first column
        * `rightline` (vertlabel only): Right end of first column
      Default `left` for label and `centerline` for vertlabel.
    * vorigin - Sets vertical origin in relation to label text. Possible values:
        * `top`: Top of the bounding box
        * `center`: Center of the bounding box
        * `bottom`: Bottom of the bounding box
        * `topline` (label only): Top of first line
        * `centerline` (label only): Center of first line
        * `bottomline` (label only): Bottom of first line
      Default `centerline` for label and `top` for vertlabel.
    * newline_spacing - number, sets space between lines/columns of text. If
      the number is prefixed with `*`, the spacing is set to a multiple of the
      label's font height or width, otherwise it's in coordinates. Default `0.5`.

In addition to these styling options, newlines have been added to `vertlabel` since it didn't previously support this.  Each newline moves the text to the right, unless, of course, it's negative.

A nice side effect of how it is implemented is that the `label` and `vertlabel` rects are as tall as the text height as opposed to a full coordinate as it is currently.  This also makes it so that it will work with really gigantic fonts as well as normal ones.

## Screenshot
A picture's worth a thousand words, so here you go:
![image](https://user-images.githubusercontent.com/31123645/81640590-c45c7e80-93d3-11ea-959d-7813147cb8d0.png)
The gray dots show where the label position is.

## To do

This PR is Ready to Review.

## How to test

<details><summary><b>It's <i>very</i> long</b></summary>

This is the above screenshot:
```lua
local function boxes(num_x, num_y)
	local boxes = ""
	for x = 0, num_x do
		for y = 0, num_y do
			if x % 2 == y % 2 then
				boxes = boxes .. "box["..x..","..y..";1,1;red]"
			end
		end
	end
	return boxes
end

local function point(x, y)
	return "box[".. x-0.05 ..",".. y-0.05 ..";0.1,0.1;gray]"
end

minetest.show_formspec("singleplayer", "formspec:test",
	"formspec_version[3]"..
	"size[20,12]"..
	boxes(19, 11)..
	---
	point(1, 1)..
	"style_type[label;horigin=left]".. -- Remove value for default label horigin: left
	"label[1,1;H-left]"..

	point(1, 2)..
	"style_type[label;horigin=center]"..
	"label[1,2;H-center]"..

	point(1, 3)..
	"style_type[label;horigin=right]"..
	"label[1,3;H-right]"..

	"box[2.95,0;0.1,12;gray]"..
	"box[0,6.95;3,0.1;gray]"..
	---
	point(1, 8)..
	"style_type[label;horigin=;newline_spacing=*1]"..
	"label[1,8;Newline 1 *1\nNewline 2 *1\nNewline 3 *1]"..
	
	point(1, 11)..
	"style_type[label;horigin=;newline_spacing=*-2]"..
	"label[1,11;Newline 1 *-2\nNewline 2 *-2\nNewline 3 *-2]"..
	---
	"style_type[label;newline_spacing=0.33]"..

	point(4, 1)..
	"style_type[label;vorigin=top]".. -- Remove value for default label vorigin: centerline
	"label[4,1;V-top\nV-top2\nV-top3]"..

	point(4, 3)..
	"style_type[label;vorigin=center]"..
	"label[4,3;V-center\nV-center2\nV-center3]"..

	point(4, 5)..
	"style_type[label;vorigin=bottom]"..
	"label[4,5;V-bottom\nV-bottom2\nV-bottom3]"..

	point(4, 6)..
	"style_type[label;vorigin=topline]"..
	"label[4,6;V-topline\nV-topline2\nV-topline3]"..

	point(4, 8)..
	"style_type[label;vorigin=centerline]"..
	"label[4,8;V-centerline\nV-centerline2\nV-centerline3]"..

	point(4, 10)..
	"style_type[label;vorigin=bottomline]"..
	"label[4,10;V-bottomline\nV-bottomline2\nV-bottomline3]"..

	"box[5.95,0;0.1,12;gray]"..
	---
	"style_type[label;newline_spacing=-0.33]"..

	point(7, 1)..
	"style_type[label;vorigin=top]"..
	"label[7,1;V-top\nV-top2\nV-top3]"..

	point(7, 3)..
	"style_type[label;vorigin=center]"..
	"label[7,3;V-center\nV-center2\nV-center3]"..

	point(7, 5)..
	"style_type[label;vorigin=bottom]"..
	"label[7,5;V-bottom\nV-bottom2\nV-bottom3]"..

	point(7, 6)..
	"style_type[label;vorigin=topline]"..
	"label[7,6;V-topline\nV-topline2\nV-topline3]"..

	point(7, 8)..
	"style_type[label;vorigin=centerline]"..
	"label[7,8;V-centerline\nV-centerline2\nV-centerline3]"..

	point(7, 10)..
	"style_type[label;vorigin=bottomline]"..
	"label[7,10;V-bottomline\nV-bottomline2\nV-bottomline3]"..

	"box[8.95,0;0.1,12;gray]"..
	---
	"style_type[label;horigin=]"..

	point(10, 2)..
	"style_type[label;vorigin=top]".. -- Remove value for default vertlabel vorigin: top
	"vertlabel[10,2;V|TOP]"..

	point(11, 2)..
	"style_type[label;vorigin=center]"..
	"vertlabel[11,2;V|CEN]"..

	point(12, 2)..
	"style_type[label;vorigin=bottom]"..
	"vertlabel[12,2;V|BTM]"..

	"box[9,3.95;11,0.1;gray]"..
	"box[15.95,0;0.1,4;gray]"..
	---
	point(17, 1)..
	"style_type[label;vorigin=;newline_spacing=*1]"..
	"vertlabel[17,1;\\\\N 1 *1\n\\\\N 2 *1\n\\\\N 3 *1]"..
	
	point(19, 1)..
	"style_type[label;vorigin=;newline_spacing=*-2]"..
	"vertlabel[19,1;\\\\N 1 *-2\n\\\\N 2 *-2\n\\\\N 3 *-2]"..
	---
	"style_type[label;newline_spacing=0.25]"..

	point(10, 5)..
	"style_type[label;horigin=left]".. -- Comment for default horigin: centerline
	"vertlabel[10,5;H|LFT\nH|LFT2\nH|LFT3]"..

	point(12, 5)..
	"style_type[label;horigin=center]"..
	"vertlabel[12,5;H|CEN\nH|CEN2\nH|CEN3]"..

	point(14, 5)..
	"style_type[label;horigin=right]"..
	"vertlabel[14,5;H|RGT\nH|RGT2\nH|RGT3]"..

	point(15, 5)..
	"style_type[label;horigin=leftline]"..
	"vertlabel[15,5;H|LFL\nH|LFL2\nH|LFL3]"..

	point(17, 5)..
	"style_type[label;horigin=centerline]"..
	"vertlabel[17,5;H|CTL\nH|CTL2\nH|CTL3]"..

	point(19, 5)..
	"style_type[label;horigin=rightline]"..
	"vertlabel[19,5;H|RTL\nH|RTL2\nH|RTL3]"..

	"box[9,7.95;11,0.1;gray]"..
	---
	"style_type[label;newline_spacing=-0.25]"..

	point(10, 9)..
	"style_type[label;horigin=left]"..
	"vertlabel[10,9;H|LFT\nH|LFT2\nH|LFT3]"..

	point(12, 9)..
	"style_type[label;horigin=center]"..
	"vertlabel[12,9;H|CEN\nH|CEN2\nH|CEN3]"..

	point(14, 9)..
	"style_type[label;horigin=right]"..
	"vertlabel[14,9;H|RGT\nH|RGT2\nH|RGT3]"..

	point(15, 9)..
	"style_type[label;horigin=leftline]"..
	"vertlabel[15,9;H|LFL\nH|LFL2\nH|LFL3]"..

	point(17, 9)..
	"style_type[label;horigin=centerline]"..
	"vertlabel[17,9;H|CTL\nH|CTL2\nH|CTL3]"..

	point(19, 9)..
	"style_type[label;horigin=rightline]"..
	"vertlabel[19,9;H|RTL\nH|RTL2\nH|RTL3]"
)
```
</details>
