### PR TITLE
Add nodebox type leveled_with_offset

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1007,13 +1007,22 @@ The function of `param2` is determined by `paramtype2` in node definition.
       0 = y+,   1 = z+,   2 = z-,   3 = x+,   4 = x-,   5 = y-
     * facedir modulo 4 = rotation around that axis
 * `paramtype2 = "leveled"`
-    * Only valid for "nodebox" with 'type = "leveled"', and "plantlike_rooted".
+    * Only valid for "nodebox" with 'type = "leveled"' or 'type = "leveled_with_offset"',
+      and "plantlike_rooted".
         * Leveled nodebox:
             * The level of the top face of the nodebox is stored in `param2`.
             * The other faces are defined by 'fixed = {}' like 'type = "fixed"'
               nodeboxes.
             * The nodebox height is (`param2` / 64) nodes.
-            * The maximum accepted value of `param2` is 127.
+            * The maximum accepted value of `param2` is `leveled_max`. (See Node
+              definition.)
+        * Leveled nodebox with offset:
+            * It is basically the same as leveled nodebox, but the height of each
+              box is (`given_height` + `param2` / 64) nodes, where `given_height`
+              is the value of the y-coordinate of the upper corner of the box.
+            * Note that you can not define a box with an upper corner than is lower
+              than the lower corner. Do not try to get negative offsets, instead add
+              a positive offset to the box that should be higher.
         * Rooted plantlike:
             * The height of the 'plantlike' section is stored in `param2`.
             * The height is (`param2` / 16) nodes.
@@ -1177,6 +1186,16 @@ A nodebox is defined as any of:
         -- by param2.
         -- Other faces are defined by 'fixed = {}' as with 'type = "fixed"'.
         type = "leveled",
+        fixed = box OR {box1, box2, ...}
+    }
+    {
+        -- A variable height box (or boxes) with the top face position moved
+        -- by the node parameter 'leveled = ', or if 'paramtype2 == "leveled"'
+        -- by param2.
+        -- Other faces are defined by 'fixed = {}' as with 'type = "fixed"'.
+        -- Using this with a top face position of `-0.5` is the same as using
+        -- `type = "leveled"`.
+        type = "leveled_with_offset",
         fixed = box OR {box1, box2, ...}
     }
     {
@@ -7119,10 +7138,11 @@ Used by `minetest.register_node`.
         -- sources nearby
 
         leveled = 0,
-        -- Only valid for "nodebox" drawtype with 'type = "leveled"'.
+        -- Only valid for "nodebox" drawtype with 'type = "leveled"' or
+        -- 'type = "leveled_with_offset"'.
         -- Allows defining the nodebox height without using param2.
-        -- The nodebox height is 'leveled' / 64 nodes.
-        -- The maximum value of 'leveled' is `leveled_max`.
+        -- The height of the boxes is the same as with `paramtype2 = "leveled"`
+        -- and `param2 = leveled`. (See `paramtype2 = "leveled"`.)
 
         leveled_max = 127,
         -- Maximum value for `leveled` (0-127), enforced in

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -239,7 +239,8 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 {
 	std::vector<aabb3f> &boxes = *p_boxes;
 
-	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
+	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED ||
+			nodebox.type == NODEBOX_LEVELED_OFFSET) {
 		const std::vector<aabb3f> &fixed = nodebox.fixed;
 		int facedir = n.getFaceDir(nodemgr, true);
 		u8 axisdir = facedir>>2;
@@ -247,6 +248,9 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 		for (aabb3f box : fixed) {
 			if (nodebox.type == NODEBOX_LEVELED)
 				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
+			else if (nodebox.type == NODEBOX_LEVELED_OFFSET) {
+				box.MaxEdge.Y += n.getLevel(nodemgr) / 64.0f * BS;
+			}
 
 			switch (axisdir) {
 			case 0:

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -78,6 +78,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, version);
 
 	switch (type) {
+	case NODEBOX_LEVELED_OFFSET:
 	case NODEBOX_LEVELED:
 	case NODEBOX_FIXED:
 		writeU8(os, type);
@@ -140,7 +141,8 @@ void NodeBox::deSerialize(std::istream &is)
 
 	type = (enum NodeBoxType)readU8(is);
 
-	if(type == NODEBOX_FIXED || type == NODEBOX_LEVELED)
+	if (type == NODEBOX_FIXED || type == NODEBOX_LEVELED ||
+			type == NODEBOX_LEVELED_OFFSET)
 	{
 		u16 fixed_count = readU16(is);
 		while(fixed_count--)
@@ -1125,12 +1127,14 @@ void getNodeBoxUnion(const NodeBox &nodebox, const ContentFeatures &features,
 {
 	switch(nodebox.type) {
 		case NODEBOX_FIXED:
-		case NODEBOX_LEVELED: {
+		case NODEBOX_LEVELED:
+		case NODEBOX_LEVELED_OFFSET: {
 			// Raw union
 			aabb3f half_processed(0, 0, 0, 0, 0, 0);
 			boxVectorUnion(nodebox.fixed, &half_processed);
 			// Set leveled boxes to maximal
-			if (nodebox.type == NODEBOX_LEVELED) {
+			if (nodebox.type == NODEBOX_LEVELED ||
+					nodebox.type == NODEBOX_LEVELED_OFFSET) {
 				half_processed.MaxEdge.Y = +BS / 2;
 			}
 			if (features.param_type_2 == CPT2_FACEDIR ||

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -92,6 +92,7 @@ enum NodeBoxType
 	NODEBOX_WALLMOUNTED, // Box for wall mounted nodes; (top, bottom, side)
 	NODEBOX_LEVELED, // Same as fixed, but with dynamic height from param2. for snow, ...
 	NODEBOX_CONNECTED, // optionally draws nodeboxes if a neighbor node attaches
+	NODEBOX_LEVELED_OFFSET, // Same as leveled, but the height of the box is used as offset
 };
 
 struct NodeBox

--- a/src/script/cpp_api/s_node.cpp
+++ b/src/script/cpp_api/s_node.cpp
@@ -90,6 +90,7 @@ struct EnumString ScriptApiNode::es_NodeBoxType[] =
 		{NODEBOX_WALLMOUNTED, "wallmounted"},
 		{NODEBOX_LEVELED, "leveled"},
 		{NODEBOX_CONNECTED, "connected"},
+		{NODEBOX_LEVELED_OFFSET, "leveled_with_offset"},
 		{0, NULL},
 	};
 


### PR DESCRIPTION
I'm always frustrated when I see that the +y value for leveled nodeboxes is completely unused, so I've added a new nodebox type that uses it as offset.

- Goal of the PR:
  - Giving the possibility to do the things described in the changes to `lua_api.txt`.
- How does the PR work:
  - There is a new nodebox (and collision- and selectionbox) type, called "leveled_with_offset".
  - The height of the box works as offset.
  - The nodebox type "leveled" is somewhat redundant now. "leveled_with_offset" can do the same with a height of `-0.5`.
- Usecases:
  - Adding something like layered snow and allow sinking into it.

## To do

This PR is a Ready for Review.

Note that I don't really know, why the changes in `nodedef.cpp` are needed. I've just done the same for offset leveled nodeboxes as for leveled ones.

## How to test
```lua
minetest.register_node("layered_offset_test:node", {
	description = "foo layer",
	tiles = {"default_dirt.png"},
	paramtype = "light",
	paramtype2 = "leveled",
	place_param2 = 16,
	--~ leveled = 1,
	drawtype = "nodebox",
	groups = {crumbly = 3},
	sounds = default.node_sound_dirt_defaults(),
	node_box = {
		type = "leveled_with_offset",
		fixed = {
			{-0.5, -0.5, -0.5, 0.5, -0.4, 0.5},
			{0, -0.5, 0, 0.5, 0, 0.5},
		},
	},
	selection_box = {
		type = "leveled",
		fixed = {-0.5, -0.5, -0.5, 0.5, 0.3, 0.5},
	},
	collision_box = {
		type = "leveled_with_offset",
		fixed = {-0.5, -0.5, -0.5, 0.5, -0.5, 0.5},
	},
	on_punch = function(pos, ...)
		local level = minetest.get_node_level(pos)
		--~ level = (level + 8) % (minetest.get_node_max_level(pos) + 1)
		level = (level + 8) % (63 + 1)
		minetest.set_node_level(pos, level)
		return minetest.node_punch(pos, ...)
	end,
})
```
