### PR TITLE
Formspec: change the appearance of the cursor on fields and co.

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1341,7 +1341,9 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 			name,
 			wlabel,
 			L"",
-			258 + m_fields.size()
+			258 + m_fields.size(),
+			0,
+			ECI_IBEAM
 			);
 
 		spec.send = true;
@@ -1500,7 +1502,9 @@ void GUIFormSpecMenu::parseSimpleField(parserData *data,
 		name,
 		wlabel,
 		utf8_to_wide(unescape_string(default_val)),
-		258 + m_fields.size()
+		258 + m_fields.size(),
+		0,
+		ECI_IBEAM
 	);
 
 	createTextField(data, spec, rect, false);
@@ -1562,7 +1566,9 @@ void GUIFormSpecMenu::parseTextArea(parserData* data, std::vector<std::string>& 
 		name,
 		wlabel,
 		utf8_to_wide(unescape_string(default_val)),
-		258 + m_fields.size()
+		258 + m_fields.size(),
+		0,
+		ECI_IBEAM
 	);
 
 	createTextField(data, spec, rect, type == "textarea");
@@ -3369,10 +3375,17 @@ void GUIFormSpecMenu::drawMenu()
 #endif
 
 	/*
-		Draw fields/buttons tooltips
+		Draw fields/buttons tooltips and update the mouse cursor
 	*/
 	gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(m_pointer);
+
+#ifndef HAVE_TOUCHSCREENGUI
+	gui::ICursorControl *cursor_control = RenderingEngine::get_raw_device()->
+			getCursorControl();
+	gui::ECURSOR_ICON current_cursor_icon = cursor_control->getActiveIcon();
+#endif
+	bool hovered_element_found = false;
 
 	if (hovered != NULL) {
 		s32 id = hovered->getID();
@@ -3389,21 +3402,38 @@ void GUIFormSpecMenu::drawMenu()
 			}
 		}
 
-		// Find and update the current tooltip
-		if (id != -1 && delta >= m_tooltip_show_delay) {
+		// Find and update the current tooltip and cursor icon
+		if (id != -1) {
 			for (const FieldSpec &field : m_fields) {
 
 				if (field.fid != id)
 					continue;
 
-				const std::wstring &text = m_tooltips[field.fname].tooltip;
-				if (!text.empty())
-					showTooltip(text, m_tooltips[field.fname].color,
-						m_tooltips[field.fname].bgcolor);
+				if (delta >= m_tooltip_show_delay) {
+					const std::wstring &text = m_tooltips[field.fname].tooltip;
+					if (!text.empty())
+						showTooltip(text, m_tooltips[field.fname].color,
+							m_tooltips[field.fname].bgcolor);
+				}
+
+#ifndef HAVE_TOUCHSCREENGUI
+				if (current_cursor_icon != field.fcursor_icon)
+					cursor_control->setActiveIcon(field.fcursor_icon);
+#endif
+
+				hovered_element_found = true;
 
 				break;
 			}
 		}
+	}
+
+	if (!hovered_element_found) {
+		// no element is hovered
+#ifndef HAVE_TOUCHSCREENGUI
+		if (current_cursor_icon != ECI_NORMAL)
+			cursor_control->setActiveIcon(ECI_NORMAL);
+#endif
 	}
 
 	m_tooltip_element->draw();

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -143,7 +143,8 @@ class GUIFormSpecMenu : public GUIModalMenu
 		FieldSpec() = default;
 
 		FieldSpec(const std::string &name, const std::wstring &label,
-				const std::wstring &default_text, s32 id, int priority = 0) :
+				const std::wstring &default_text, s32 id, int priority = 0,
+				gui::ECURSOR_ICON cursor_icon = ECI_NORMAL) :
 			fname(name),
 			flabel(label),
 			fdefault(unescape_enriched(translate_string(default_text))),
@@ -151,7 +152,8 @@ class GUIFormSpecMenu : public GUIModalMenu
 			send(false),
 			ftype(f_Unknown),
 			is_exit(false),
-			priority(priority)
+			priority(priority),
+			fcursor_icon(cursor_icon)
 		{
 		}
 
@@ -165,6 +167,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		// Draw priority for formspec version < 3
 		int priority;
 		core::rect<s32> rect;
+		gui::ECURSOR_ICON fcursor_icon;
 	};
 
 	struct TooltipSpec


### PR DESCRIPTION
Fixes #8523.

(There's a small bug: If you open a formspec and have your cursor on an element, it will stay normal until you move it away and back.)

## To do

This PR is a Ready to Review.

## How to test

- Start minetest.
- Join or start a game.
- Wait until you are connected.
- Press esc.
- Hover with you mouse over the text and look at your cursor.

It would be good if users of different operating systems could test this. I'm only able to test with Linux Lubuntu 18.04.