### PR TITLE
disable_jump check for the player's feet

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1666,6 +1666,7 @@ to games.
     * `2`: the node always gets the digging time 0.5 seconds (rail, sign)
     * `3`: the node always gets the digging time 0 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
+  or if their feet are on the node.
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1666,7 +1666,7 @@ to games.
     * `2`: the node always gets the digging time 0.5 seconds (rail, sign)
     * `3`: the node always gets the digging time 0 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
-  or if their feet are in the node.
+  or if their feet are in the node. Note: not supported for `new_move = false`
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1666,7 +1666,7 @@ to games.
     * `2`: the node always gets the digging time 0.5 seconds (rail, sign)
     * `3`: the node always gets the digging time 0 seconds (torch)
 * `disable_jump`: Player (and possibly other things) cannot jump from node
-  or if their feet are on the node.
+  or if their feet are in the node.
 * `fall_damage_add_percent`: damage speed = `speed * (1 + value/100)`
 * `falling_node`: if there is no walkable block under the node it will fall
 * `float`: the node will not fall through liquids

--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -56,9 +56,16 @@ minetest.register_node("testnodes:attached_wallmounted", {
 minetest.register_node("testnodes:nojump", {
 	description = S("Non-jumping Node"),
 	groups = {disable_jump=1, dig_immediate=3},
-
-
 	tiles = {"testnodes_nojump_top.png", "testnodes_nojump_side.png"},
+})
+
+-- Jump disabled plant
+minetest.register_node("testnodes:nojump_walkable", {
+	description = S("Non-jumping Plant Node"),
+	drawtype = "plantlike",
+	groups = {disable_jump=1, dig_immediate=3},
+	walkable = false,
+	tiles = {"testnodes_nojump_top.png"},
 })
 
 -- Climbable up and down with jump and sneak keys

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -439,8 +439,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	const ContentFeatures &f1 = nodemgr->get(map->getNode(m_standing_node + v3s16(0, 1, 0)));
 
 	// Determine if jumping is possible
-	m_disable_jump = (itemgroup_get(f.groups, "disable_jump") ||
-						itemgroup_get(f1.groups, "disable_jump"));
+	m_disable_jump = itemgroup_get(f.groups, "disable_jump") ||
+		itemgroup_get(f1.groups, "disable_jump");
 	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
 
 	// Jump key pressed while jumping off from a bouncy block

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -436,9 +436,11 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		Check properties of the node on which the player is standing
 	*/
 	const ContentFeatures &f = nodemgr->get(map->getNode(m_standing_node));
+	const ContentFeatures &f1 = nodemgr->get(map->getNode(m_standing_node + v3s16(0, 1, 0)));
 
 	// Determine if jumping is possible
-	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
+	m_disable_jump = (itemgroup_get(f.groups, "disable_jump") ||
+						itemgroup_get(f1.groups, "disable_jump"));
 	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
 
 	// Jump key pressed while jumping off from a bouncy block


### PR DESCRIPTION
At first I was surprised when disable_jump did not work for the walkable block. Then I realized that we do not check it.
Why do we need it? Well, for example, we can prohibit jumping into a cobweb, or any other node in which the player’s legs can get 'tangled'.