### PR TITLE
Some builtin functions from MC

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -129,6 +129,12 @@ core.register_entity(":__builtin:falling_node", {
 			local npos = self.object:get_pos()
 			self.object:set_pos(vector.round(npos))
 		end
+		-- Drop node if does not fall within 5 seconds
+		self.timer = self.timer + dtime
+		if self.timer > 5 then
+			core.add_item(pos, self.node)
+			self.object:remove()
+		end
 	end
 })
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -446,12 +446,19 @@ function core.item_drop(itemstack, dropper, pos)
 	local obj = core.add_item(p, item)
 	if obj then
 		if dropper_is_player then
+			local vel = dropper:get_player_velocity()
 			local dir = dropper:get_look_dir()
-			dir.x = dir.x * 2.9
-			dir.y = dir.y * 2.9 + 2
-			dir.z = dir.z * 2.9
+			dir.x = vel.x + dir.x * 4
+			dir.y = vel.y + dir.y * 4 + 2
+			dir.z = vel.z + dir.z * 4
 			obj:set_velocity(dir)
 			obj:get_luaentity().dropped_by = dropper:get_player_name()
+		else
+			obj:set_velocity({
+				x = math.random(-2.5, 2.5),
+				y = math.random(1, 4),
+				z = math.random(-2.5, 2.5)
+			})
 		end
 		return itemstack
 	end
@@ -530,12 +537,7 @@ function core.handle_node_drops(pos, drops, digger)
 	for _, dropped_item in pairs(drops) do
 		local left = give_item(dropped_item)
 		if not left:is_empty() then
-			local p = {
-				x = pos.x + math.random()/2-0.25,
-				y = pos.y + math.random()/2-0.25,
-				z = pos.z + math.random()/2-0.25,
-			}
-			core.add_item(p, left)
+			core.item_drop(left, nil, pos)
 		end
 	end
 end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -394,6 +394,16 @@ function core.override_item(name, redefinition)
 end
 
 
+function core.add_group(name, adding)
+	local addgroup = {}
+	addgroup = table.copy(core.registered_items[name].groups)
+	for k, v in pairs(adding) do
+		addgroup[k] = v
+	end
+	core.override_item(name, {groups = addgroup})
+end
+
+
 core.callback_origins = {}
 
 function core.run_callbacks(callbacks, mode, ...)

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -50,7 +50,7 @@ local function update_builtin_statbars(player)
 	end
 	local hud = hud_ids[name]
 
-	if flags.healthbar and enable_damage then
+	if flags.healthbar then
 		local number = scaleToDefault(player, "hp")
  		if hud.id_healthbar == nil then
  			local hud_def = table.copy(health_bar_definition)
@@ -65,7 +65,7 @@ local function update_builtin_statbars(player)
 	end
 
 	local breath_max = player:get_properties().breath_max
-	if flags.breathbar and enable_damage and
+	if flags.breathbar and
 			player:get_breath() < breath_max then
 		local number = 2 * scaleToDefault(player, "breath")
 		if hud.id_breathbar == nil then
@@ -162,10 +162,12 @@ function core.hud_replace_builtin(name, definition)
 	return false
 end
 
--- Append "update_builtin_statbars" as late as possible
--- This ensures that the HUD is hidden when the flags are updated in this callback
-core.register_on_mods_loaded(function()
-	core.register_on_joinplayer(update_builtin_statbars)
-end)
-core.register_on_leaveplayer(cleanup_builtin_statbars)
-core.register_playerevent(player_event_handler)
+if enable_damage then
+	-- Append "update_builtin_statbars" as late as possible
+	-- This ensures that the HUD is hidden when the flags are updated in this callback
+	core.register_on_mods_loaded(function()
+		core.register_on_joinplayer(update_builtin_statbars)
+	end)
+	core.register_on_leaveplayer(cleanup_builtin_statbars)
+	core.register_playerevent(player_event_handler)
+end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3616,6 +3616,11 @@ Call these functions only at load time!
     * Note: Item must already be defined, (opt)depend on the mod defining it.
     * Example: `minetest.override_item("default:mese",
       {light_source=minetest.LIGHT_MAX})`
+* `minetest.add_group(name, groups)`
+    * Adding new groups of an item registered with register_node/tool/craftitem.
+    * Note: Item must already be defined, (opt)depend on the mod defining it.
+    * Example: `minetest.add_group("default:stone_with_diamond",
+      {stone = 1, diamond = 2})`
 * `minetest.unregister_item(name)`
     * Unregisters the item from the engine, and deletes the entry with key
       `name` from `minetest.registered_items` and from the associated item table

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4439,6 +4439,7 @@ These functions return the leftover itemstack.
     * returns `itemstack, success`
 * `minetest.item_drop(itemstack, dropper, pos)`
     * Drop the item
+    * If dropper is `nil` items will be dropped near the pos
 * `minetest.item_eat(hp_change, replace_with_item)`
     * Eat the item.
     * `replace_with_item` is the itemstring which is added to the inventory.


### PR DESCRIPTION
Backporting some possibly useful builtin functions from MultiCraft.

1) drop the falling block if it does not land within 5 seconds. Eliminates a possible attack on the server, as well as landing on the mesh node. Thanks to the idiot who tried to dump my server :)
2) minetest.item_drop can now be used to drop items from a chest or furnace when destroyed, when leaving inventory from crafting positions, etc. Only 1 line. It is no longer necessary to add the item_drop function to each mod that needs it.
```
minetest.item_drop(stack, nil, pos)
```
Examples:
```
register_on_dieplayer
-- Drop inventory items
for i = 1, inv:get_size("main") do
	local stack = inv:get_stack("main", i)
	**minetest.item_drop(stack, nil, pos)**
	inv:set_stack("main", i, nil)
end
furnace
for _, name in pairs({"fuel", "dst", "src"}) do
	local stack = inv:get_stack(name, 1)
	**minetest.item_drop(stack, nil, pos)**
	stack:clear()
	inv:set_stack(name, 1, stack)
end
```
3) completely disable the processing of breath and health statbars when the damage is turned off. Did someone use profiler on the server? It consumes a lot of resources in the empty!
4) minetest.add_group
Allows you to add new groups without override item. You can add multiple groups.