### PR TITLE
New jitter, RTT maths for object position prediction

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3663,11 +3663,7 @@ Utilities
       {
           address = "127.0.0.1",     -- IP address of client
           ip_version = 4,            -- IPv4 / IPv6
-          min_rtt = 0.01,            -- minimum round trip time
-          max_rtt = 0.2,             -- maximum round trip time
           avg_rtt = 0.02,            -- average round trip time
-          min_jitter = 0.01,         -- minimum packet time jitter
-          max_jitter = 0.5,          -- maximum packet time jitter
           avg_jitter = 0.03,         -- average packet time jitter
           connection_uptime = 200,   -- seconds since client connected
           protocol_version = 32,     -- protocol version used by client

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3665,6 +3665,10 @@ Utilities
           ip_version = 4,            -- IPv4 / IPv6
           avg_rtt = 0.02,            -- average round trip time
           avg_jitter = 0.03,         -- average packet time jitter
+          min_rtt = 0.01,            -- DEPRECATED: equals to (avg_rtt - avg_jitter)
+          max_rtt = 0.2,             -- DEPRECATED: equals to (avg_rtt + avg_jitter)
+          min_jitter = 0.01,         -- DEPRECATED: constant (0.01)
+          max_jitter = 0.5,          -- DEPRECATED: constant (0.5)
           connection_uptime = 200,   -- seconds since client connected
           protocol_version = 32,     -- protocol version used by client
           -- following information is available on debug build only!!!

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -446,18 +446,6 @@ void Client::step(float dtime)
 	}
 
 	/*
-		Print some info
-	*/
-	float &counter = m_avg_rtt_timer;
-	counter += dtime;
-	if(counter >= 10) {
-		counter = 0.0;
-		// connectedAndInitialized() is true, peer exists.
-		float avg_rtt = getRTT();
-		infostream << "Client: avg_rtt=" << avg_rtt << std::endl;
-	}
-
-	/*
 		Send player position to server
 	*/
 	{
@@ -1711,9 +1699,9 @@ void Client::afterContentReceived()
 	delete[] text;
 }
 
-float Client::getRTT()
+float Client::getRTT(con::rtt_stat_type type)
 {
-	return m_con->getPeerStat(PEER_ID_SERVER,con::AVG_RTT);
+	return m_con->getPeerStat(PEER_ID_SERVER, type);
 }
 
 float Client::getCurRate()

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -354,7 +354,7 @@ public:
 
 	void afterContentReceived();
 
-	float getRTT();
+	float getRTT(con::rtt_stat_type type = con::AVG_RTT);
 	float getCurRate();
 
 	Minimap* getMinimap() { return m_minimap; }
@@ -476,7 +476,6 @@ private:
 
 	float m_packetcounter_timer = 0.0f;
 	float m_connection_reinit_timer = 0.1f;
-	float m_avg_rtt_timer = 0.0f;
 	float m_playerpos_send_timer = 0.0f;
 	IntervalLimiter m_map_timer_and_unload_interval;
 

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -569,18 +569,10 @@ class Peer {
 
 		virtual float getStat(rtt_stat_type type) const {
 			switch (type) {
-				case MIN_RTT:
-					return m_rtt.min_rtt;
-				case MAX_RTT:
-					return m_rtt.max_rtt;
 				case AVG_RTT:
 					return m_rtt.avg_rtt;
-				case MIN_JITTER:
-					return m_rtt.jitter_min;
-				case MAX_JITTER:
-					return m_rtt.jitter_max;
 				case AVG_JITTER:
-					return m_rtt.jitter_avg;
+					return m_rtt.avg_jitter;
 			}
 			return -1;
 		}
@@ -608,18 +600,13 @@ class Peer {
 	private:
 
 		struct rttstats {
-			float jitter_min = FLT_MAX;
-			float jitter_max = 0.0f;
-			float jitter_avg = -1.0f;
-			float min_rtt = FLT_MAX;
-			float max_rtt = 0.0f;
+			float avg_jitter = -1.0f;
 			float avg_rtt = -1.0f;
 
 			rttstats() = default;
 		};
 
 		rttstats m_rtt;
-		float m_last_rtt = -1.0f;
 
 		// current usage count
 		unsigned int m_usage = 0;

--- a/src/network/peerhandler.h
+++ b/src/network/peerhandler.h
@@ -26,11 +26,7 @@ namespace con
 
 typedef enum
 {
-	MIN_RTT,
-	MAX_RTT,
 	AVG_RTT,
-	MIN_JITTER,
-	MAX_JITTER,
 	AVG_JITTER
 } rtt_stat_type;
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -471,7 +471,9 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	pitch = modulo360f(pitch);
 	yaw = wrapDegrees_0_360(yaw);
 
-	playersao->setBasePosition(position);
+	f32 dtime = std::min(0.15f, m_con->getPeerStat(player->getPeerId(), con::AVG_RTT));
+
+	playersao->setBasePosition(position + speed * dtime);
 	player->setSpeed(speed);
 	playersao->setLookPitch(pitch);
 	playersao->setPlayerYaw(yaw);

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -157,7 +157,7 @@ int ModApiServer::l_get_player_information(lua_State *L)
 		return 1;
 	}
 
-	float min_rtt,max_rtt,avg_rtt,min_jitter,max_jitter,avg_jitter;
+	float avg_rtt, avg_jitter;
 	ClientState state;
 	u32 uptime;
 	u16 prot_vers;
@@ -171,13 +171,7 @@ int ModApiServer::l_get_player_information(lua_State *L)
 		return 1;                                                              \
 	}
 
-	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::MIN_RTT, &min_rtt))
-	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::MAX_RTT, &max_rtt))
 	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::AVG_RTT, &avg_rtt))
-	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::MIN_JITTER,
-		&min_jitter))
-	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::MAX_JITTER,
-		&max_jitter))
 	ERET(getServer(L)->getClientConInfo(player->getPeerId(), con::AVG_JITTER,
 		&avg_jitter))
 
@@ -201,24 +195,8 @@ int ModApiServer::l_get_player_information(lua_State *L)
 	}
 	lua_settable(L, table);
 
-	lua_pushstring(L,"min_rtt");
-	lua_pushnumber(L, min_rtt);
-	lua_settable(L, table);
-
-	lua_pushstring(L,"max_rtt");
-	lua_pushnumber(L, max_rtt);
-	lua_settable(L, table);
-
 	lua_pushstring(L,"avg_rtt");
 	lua_pushnumber(L, avg_rtt);
-	lua_settable(L, table);
-
-	lua_pushstring(L,"min_jitter");
-	lua_pushnumber(L, min_jitter);
-	lua_settable(L, table);
-
-	lua_pushstring(L,"max_jitter");
-	lua_pushnumber(L, max_jitter);
 	lua_settable(L, table);
 
 	lua_pushstring(L,"avg_jitter");


### PR DESCRIPTION
* Real average RTT and jitter calculations
  * Does #8183 occur again? I hope not. **<< Needs testing**
* Remove min/max RTT and jitter values
  * Useless. Missing cooldown they were only used in `l_get_player_information`
* Accept client-side object position drift within the network jitter
  * Smoother object movement with less "jump-back"s

## To do
Ready to test and review.

- [ ] Test whether this weird network regression occurs again

## How to test

Spawn lua entities on a server and compare the movement with before
 * If smoother: Nice
 * If it's somewhat inaccurate: Trash this PR.