### PR TITLE
Optimize getting active objects a bit.

### DIFF
--- a/src/client/activeobjectmgr.cpp
+++ b/src/client/activeobjectmgr.cpp
@@ -91,15 +91,16 @@ void ActiveObjectMgr::removeObject(u16 id)
 void ActiveObjectMgr::getActiveObjects(const v3f &origin, f32 max_d,
 		std::vector<DistanceSortedActiveObject> &dest)
 {
+	f32 max_d2 = max_d * max_d;
 	for (auto &ao_it : m_active_objects) {
 		ClientActiveObject *obj = ao_it.second;
 
-		f32 d = (obj->getPosition() - origin).getLength();
+		f32 d2 = (obj->getPosition() - origin).getLengthSQ();
 
-		if (d > max_d)
+		if (d2 > max_d2)
 			continue;
 
-		dest.emplace_back(obj, d);
+		dest.emplace_back(obj, d2);
 	}
 }
 

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -90,10 +90,10 @@ private:
 	static std::unordered_map<u16, Factory> m_types;
 };
 
-struct DistanceSortedActiveObject
+class DistanceSortedActiveObject
 {
+public:
 	ClientActiveObject *obj;
-	f32 d;
 
 	DistanceSortedActiveObject(ClientActiveObject *a_obj, f32 a_d)
 	{
@@ -105,4 +105,7 @@ struct DistanceSortedActiveObject
 	{
 		return d < other.d;
 	}
+
+private:
+	f32 d;
 };

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -115,11 +115,12 @@ void ActiveObjectMgr::removeObject(u16 id)
 void ActiveObjectMgr::getObjectsInsideRadius(
 		const v3f &pos, float radius, std::vector<u16> &result)
 {
+	float r2 = radius * radius;
 	for (auto &activeObject : m_active_objects) {
 		ServerActiveObject *obj = activeObject.second;
 		u16 id = activeObject.first;
 		const v3f &objectpos = obj->getBasePosition();
-		if (objectpos.getDistanceFrom(pos) > radius)
+		if (objectpos.getDistanceFromSQ(pos) > r2)
 			continue;
 		result.push_back(id);
 	}

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -290,17 +290,16 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 {
 	v3s16 p;
-	s32 r2 = r * r;
 	for(p.X=p0.X-r; p.X<=p0.X+r; p.X++)
-	for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
-	for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
-	{
-		// limit to a sphere
-		if (p.getDistanceFromSQ(p0) <= r2) {
-			// Set in list
-			list.insert(p);
-		}
-	}
+		for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
+			for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
+			{
+				// limit to a sphere
+				if (p.getDistanceFrom(p0) <= r) {
+					// Set in list
+					list.insert(p);
+				}
+			}
 }
 
 void fillViewConeBlock(v3s16 p0,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -290,16 +290,17 @@ void LBMManager::applyLBMs(ServerEnvironment *env, MapBlock *block, u32 stamp)
 void fillRadiusBlock(v3s16 p0, s16 r, std::set<v3s16> &list)
 {
 	v3s16 p;
+	s32 r2 = r * r;
 	for(p.X=p0.X-r; p.X<=p0.X+r; p.X++)
-		for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
-			for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
-			{
-				// limit to a sphere
-				if (p.getDistanceFrom(p0) <= r) {
-					// Set in list
-					list.insert(p);
-				}
-			}
+	for(p.Y=p0.Y-r; p.Y<=p0.Y+r; p.Y++)
+	for(p.Z=p0.Z-r; p.Z<=p0.Z+r; p.Z++)
+	{
+		// limit to a sphere
+		if (p.getDistanceFromSQ(p0) <= r2) {
+			// Set in list
+			list.insert(p);
+		}
+	}
 }
 
 void fillViewConeBlock(v3s16 p0,


### PR DESCRIPTION
This is a (slight) optimization when retrieving active objects.

Objects are retrieved (and sometimes sorted) by their distance. We can save some cycles by comparing (and sorting by) the square of the distance.

I noticed that with many active objects the various getActiveObjects and getObjectsInsideRadius methods show up prominently in profiler logs.

Note the change in DistanceSortedActiveObject. Since this now stores the square of the distance (order is still the same) I made d private so that nobody can access it and mistake it for an actual distance.

**Update:** I removed the change in serverenvironment.cpp. This one actually did not show in the profiler, and it would have led to overflows with radius' over 128, which can happen with zooming. The other methods use floats and hence are safe.