### PR TITLE
Unify wield item handling

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -935,7 +935,7 @@ void Client::interact(u8 action, const PointedThing& pointed)
 	NetworkPacket pkt(TOSERVER_INTERACT, 1 + 2 + 0);
 
 	pkt << action;
-	pkt << (u16)myplayer->getWieldIndex();
+	pkt << myplayer->getWieldIndex();
 
 	std::ostringstream tmp_os(std::ios::binary);
 	pointed.serialize(tmp_os);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -935,7 +935,7 @@ void Client::interact(u8 action, const PointedThing& pointed)
 	NetworkPacket pkt(TOSERVER_INTERACT, 1 + 2 + 0);
 
 	pkt << action;
-	pkt << (u16)getPlayerItem();
+	pkt << (u16)myplayer->getWieldIndex();
 
 	std::ostringstream tmp_os(std::ios::binary);
 	pointed.serialize(tmp_os);
@@ -1269,19 +1269,6 @@ void Client::sendPlayerPos()
 	Send(&pkt);
 }
 
-void Client::sendPlayerItem(u16 item)
-{
-	LocalPlayer *myplayer = m_env.getLocalPlayer();
-	if (!myplayer)
-		return;
-
-	NetworkPacket pkt(TOSERVER_PLAYERITEM, 2);
-
-	pkt << item;
-
-	Send(&pkt);
-}
-
 void Client::removeNode(v3s16 p)
 {
 	std::map<v3s16, MapBlock*> modified_blocks;
@@ -1341,11 +1328,14 @@ void Client::setPlayerControl(PlayerControl &control)
 	player->control = control;
 }
 
-void Client::selectPlayerItem(u16 item)
+void Client::setPlayerItem(u16 item)
 {
-	m_playeritem = item;
+	m_env.getLocalPlayer()->setWieldIndex(item);
 	m_inventory_updated = true;
-	sendPlayerItem(item);
+
+	NetworkPacket pkt(TOSERVER_PLAYERITEM, 2);
+	pkt << item;
+	Send(&pkt);
 }
 
 // Returns true if the inventory of the local player has been

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -271,10 +271,6 @@ public:
 
 	void setPlayerControl(PlayerControl &control);
 
-	void selectPlayerItem(u16 item);
-	u16 getPlayerItem() const
-	{ return m_playeritem; }
-
 	// Returns true if the inventory of the local player has been
 	// updated from the server. If it is true, it is set to false.
 	bool getLocalInventoryUpdated();
@@ -284,6 +280,9 @@ public:
 	/* InventoryManager interface */
 	Inventory* getInventory(const InventoryLocation &loc) override;
 	void inventoryAction(InventoryAction *a) override;
+
+	// Send the item number 'item' as player item to the server
+	void setPlayerItem(u16 item);
 
 	const std::list<std::string> &getConnectedPlayerNames()
 	{
@@ -454,8 +453,6 @@ private:
 	void Receive();
 
 	void sendPlayerPos();
-	// Send the item number 'item' as player item to the server
-	void sendPlayerItem(u16 item);
 
 	void deleteAuthData();
 	// helper method shared with clientpackethandler
@@ -506,7 +503,6 @@ private:
 	// If 0, server init hasn't been received yet.
 	u16 m_proto_ver = 0;
 
-	u16 m_playeritem = 0;
 	bool m_inventory_updated = false;
 	Inventory *m_inventory_from_server = nullptr;
 	float m_inventory_from_server_age = 0.0f;

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -86,7 +86,7 @@ void RenderingCore::drawHUD()
 	if (show_hud) {
 		if (draw_crosshair)
 			hud->drawCrosshair();
-		hud->drawHotbar(client->getPlayerItem());
+		hud->drawHotbar(client->getEnv().getLocalPlayer()->getWieldIndex());
 		hud->drawLuaElements(camera->getOffset());
 		camera->drawNametags();
 		if (mapper && show_minimap)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -1367,7 +1367,7 @@ InventoryLocation PlayerSAO::getInventoryLocation() const
 	return loc;
 }
 
-int PlayerSAO::getWieldIndex() const
+u16 PlayerSAO::getWieldIndex() const
 {
 	return m_player->getWieldIndex();
 }

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -894,18 +894,11 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 		m_armor_groups["immortal"] = 1;
 }
 
-PlayerSAO::~PlayerSAO()
-{
-	if(m_inventory != &m_player->inventory)
-		delete m_inventory;
-}
-
 void PlayerSAO::finalize(RemotePlayer *player, const std::set<std::string> &privs)
 {
 	assert(player);
 	m_player = player;
 	m_privs = privs;
-	m_inventory = &m_player->inventory;
 }
 
 v3f PlayerSAO::getEyeOffset() const
@@ -1362,13 +1355,9 @@ void PlayerSAO::setBreath(const u16 breath, bool send)
 		m_env->getGameDef()->SendPlayerBreath(this);
 }
 
-Inventory* PlayerSAO::getInventory()
+Inventory *PlayerSAO::getInventory() const
 {
-	return m_inventory;
-}
-const Inventory* PlayerSAO::getInventory() const
-{
-	return m_inventory;
+	return m_player ? &m_player->inventory : nullptr;
 }
 
 InventoryLocation PlayerSAO::getInventoryLocation() const
@@ -1378,59 +1367,25 @@ InventoryLocation PlayerSAO::getInventoryLocation() const
 	return loc;
 }
 
-std::string PlayerSAO::getWieldList() const
+int PlayerSAO::getWieldIndex() const
 {
-	return "main";
+	return m_player->getWieldIndex();
 }
 
 ItemStack PlayerSAO::getWieldedItem() const
 {
-	const Inventory *inv = getInventory();
-	ItemStack ret;
-	const InventoryList *mlist = inv->getList(getWieldList());
-	if (mlist && getWieldIndex() < (s32)mlist->getSize())
-		ret = mlist->getItem(getWieldIndex());
-	return ret;
-}
-
-ItemStack PlayerSAO::getWieldedItemOrHand() const
-{
-	const Inventory *inv = getInventory();
-	ItemStack ret;
-	const InventoryList *mlist = inv->getList(getWieldList());
-	if (mlist && getWieldIndex() < (s32)mlist->getSize())
-		ret = mlist->getItem(getWieldIndex());
-	if (ret.name.empty()) {
-		const InventoryList *hlist = inv->getList("hand");
-		if (hlist)
-			ret = hlist->getItem(0);
-	}
-	return ret;
+	ItemStack selected_item, hand_item;
+	return m_player->getWieldedItem(&selected_item, &hand_item);
 }
 
 bool PlayerSAO::setWieldedItem(const ItemStack &item)
 {
-	Inventory *inv = getInventory();
-	if (inv) {
-		InventoryList *mlist = inv->getList(getWieldList());
-		if (mlist) {
-			mlist->changeItem(getWieldIndex(), item);
-			return true;
-		}
+	InventoryList *mlist = m_player->inventory.getList(getWieldList());
+	if (mlist) {
+		mlist->changeItem(m_player->getWieldIndex(), item);
+		return true;
 	}
 	return false;
-}
-
-int PlayerSAO::getWieldIndex() const
-{
-	return m_wield_index;
-}
-
-void PlayerSAO::setWieldIndex(int i)
-{
-	if(i != m_wield_index) {
-		m_wield_index = i;
-	}
 }
 
 void PlayerSAO::disconnected()

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -216,7 +216,7 @@ class PlayerSAO : public UnitSAO
 public:
 	PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t peer_id_,
 			bool is_singleplayer);
-	~PlayerSAO();
+
 	ActiveObjectType getType() const
 	{ return ACTIVEOBJECT_TYPE_PLAYER; }
 	ActiveObjectType getSendType() const
@@ -269,16 +269,13 @@ public:
 	/*
 		Inventory interface
 	*/
-
-	Inventory* getInventory();
-	const Inventory* getInventory() const;
+	Inventory *getInventory() const;
 	InventoryLocation getInventoryLocation() const;
-	std::string getWieldList() const;
-	ItemStack getWieldedItem() const;
-	ItemStack getWieldedItemOrHand() const;
-	bool setWieldedItem(const ItemStack &item);
+	void setInventoryModified() {}
+	std::string getWieldList() const { return "main"; }
 	int getWieldIndex() const;
-	void setWieldIndex(int i);
+	ItemStack getWieldedItem() const;
+	bool setWieldedItem(const ItemStack &item);
 
 	/*
 		PlayerSAO-specific
@@ -352,7 +349,6 @@ private:
 
 	RemotePlayer *m_player = nullptr;
 	session_t m_peer_id = 0;
-	Inventory *m_inventory = nullptr;
 
 	// Cheat prevention
 	LagPool m_dig_pool;
@@ -368,7 +364,6 @@ private:
 	IntervalLimiter m_drowning_interval;
 	IntervalLimiter m_node_hurt_interval;
 
-	int m_wield_index = 0;
 	bool m_position_not_sent = false;
 
 	// Cached privileges for enforcement

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -273,7 +273,7 @@ public:
 	InventoryLocation getInventoryLocation() const;
 	void setInventoryModified() {}
 	std::string getWieldList() const { return "main"; }
-	int getWieldIndex() const;
+	u16 getWieldIndex() const;
 	ItemStack getWieldedItem() const;
 	bool setWieldedItem(const ItemStack &item);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -90,6 +90,29 @@ Player::~Player()
 	clearHud();
 }
 
+void Player::setWieldIndex(u16 index)
+{
+	const InventoryList *mlist = inventory.getList("main");
+	m_wield_index = MYMIN(index, mlist ? mlist->getSize() : 0);
+}
+
+ItemStack &Player::getWieldedItem(ItemStack *selected, ItemStack *hand) const
+{
+	assert(selected);
+
+	const InventoryList *mlist = inventory.getList("main"); // TODO: Make this generic
+	const InventoryList *hlist = inventory.getList("hand");
+
+	if (mlist && m_wield_index < mlist->getSize())
+		*selected = mlist->getItem(m_wield_index);
+
+	if (hand && hlist)
+		*hand = hlist->getItem(0);
+
+	// Return effective tool item
+	return (hand && selected->name.empty()) ? *hand : *selected;
+}
+
 u32 Player::addHud(HudElement *toadd)
 {
 	MutexAutoLock lock(m_mutex);

--- a/src/player.h
+++ b/src/player.h
@@ -173,6 +173,11 @@ public:
 	PlayerSettings &getPlayerSettings() { return m_player_settings; }
 	static void settingsChangedCallback(const std::string &name, void *data);
 
+	// Returns non-empty `selected` ItemStack. `hand` is a fallback, if specified
+	ItemStack &getWieldedItem(ItemStack *selected, ItemStack *hand) const;
+	void setWieldIndex(u16 index);
+	u16 getWieldIndex() const { return m_wield_index; }
+
 	u32 keyPressed = 0;
 
 	HudElement* getHud(u32 id);
@@ -185,6 +190,7 @@ public:
 protected:
 	char m_name[PLAYERNAME_SIZE];
 	v3f m_speed;
+	u16 m_wield_index = 0;
 
 	std::vector<HudElement *> hud;
 private:

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -210,17 +210,13 @@ int ModApiClient::l_get_language(lua_State *L)
 int ModApiClient::l_get_wielded_item(lua_State *L)
 {
 	Client *client = getClient(L);
+	LocalPlayer *player = client->getEnv().getLocalPlayer();
+	if (!player)
+		return 0;
 
-	Inventory local_inventory(client->idef());
-	client->getLocalInventory(local_inventory);
-
-	InventoryList *mlist = local_inventory.getList("main");
-
-	if (mlist && client->getPlayerItem() < mlist->getSize()) {
-		LuaItemStack::create(L, mlist->getItem(client->getPlayerItem()));
-	} else {
-		LuaItemStack::create(L, ItemStack());
-	}
+	ItemStack selected_item;
+	player->getWieldedItem(&selected_item, nullptr);
+	LuaItemStack::create(L, selected_item);
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -308,8 +308,9 @@ int ObjectRef::l_get_wield_list(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
-	if (co == NULL) return 0;
-	// Do it
+	if (!co)
+		return 0;
+
 	lua_pushstring(L, co->getWieldList().c_str());
 	return 1;
 }
@@ -320,8 +321,9 @@ int ObjectRef::l_get_wield_index(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
-	if (co == NULL) return 0;
-	// Do it
+	if (!co)
+		return 0;
+
 	lua_pushinteger(L, co->getWieldIndex() + 1);
 	return 1;
 }
@@ -332,12 +334,12 @@ int ObjectRef::l_get_wielded_item(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkobject(L, 1);
 	ServerActiveObject *co = getobject(ref);
-	if (co == NULL) {
+	if (!co) {
 		// Empty ItemStack
 		LuaItemStack::create(L, ItemStack());
 		return 1;
 	}
-	// Do it
+
 	LuaItemStack::create(L, co->getWieldedItem());
 	return 1;
 }

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -188,7 +188,7 @@ public:
 	{}
 	virtual std::string getWieldList() const
 	{ return ""; }
-	virtual int getWieldIndex() const
+	virtual u16 getWieldIndex() const
 	{ return 0; }
 	virtual ItemStack getWieldedItem() const;
 	virtual bool setWieldedItem(const ItemStack &item);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -180,9 +180,7 @@ public:
 	{}
 
 	// Inventory and wielded item
-	virtual Inventory* getInventory()
-	{ return NULL; }
-	virtual const Inventory* getInventory() const
+	virtual Inventory *getInventory() const
 	{ return NULL; }
 	virtual InventoryLocation getInventoryLocation() const
 	{ return InventoryLocation(); }

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "tool.h"
+#include "itemdef.h"
 #include "itemgroup.h"
 #include "log.h"
 #include "inventory.h"
@@ -275,4 +276,16 @@ PunchDamageResult getPunchDamage(
 	return result;
 }
 
+f32 getToolRange(const ItemDefinition &def_selected, const ItemDefinition &def_hand)
+{
+	float max_d = def_selected.range;
+	float max_d_hand = def_hand.range;
+
+	if (max_d < 0 && max_d_hand >= 0)
+		max_d = max_d_hand;
+	else if (max_d < 0)
+		max_d = 4.0f;
+
+	return max_d;
+}
 

--- a/src/tool.h
+++ b/src/tool.h
@@ -25,6 +25,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "itemgroup.h"
 #include <json/json.h>
 
+struct ItemDefinition;
+
 struct ToolGroupCap
 {
 	std::unordered_map<int, float> times;
@@ -132,3 +134,5 @@ PunchDamageResult getPunchDamage(
 		const ItemStack *punchitem,
 		float time_from_last_punch
 );
+
+f32 getToolRange(const ItemDefinition &def_selected, const ItemDefinition &def_hand);


### PR DESCRIPTION
This moves the wield item functions to Player and the tool utils for range calculation
Also 'local_inventory' was removed due to redundancy in Client
Removing this duplicated code reduces the possibility of different handling in server and client.

## To do
This PR is Ready for Review.

## How to test
Create a `hand` slot, put a tool or anything else in.
Click randomly in your world. If your hand is not capable of digging the node, it will try to fall back to `hand` (same as in master).
