### PR TITLE
Refactor of moon and sun drawing

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -31,6 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "camera.h"  // CameraModes
 
+#include <typeinfo>
+
 
 Sky::Sky(s32 id, ITextureSource *tsrc):
 		scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),
@@ -701,59 +703,29 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 	video::S3DVertex vertices[4];
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
+	std::array<video::S3DVertex, 4> vertices2;
 	if (!m_sun_texture) {
+		std::cout << "New code is called" << std::endl;
 		driver->setMaterial(m_materials[1]);
 		float d = sunsize * 1.7;
 		video::SColor c = suncolor;
 		c.setAlpha(0.05 * 255);
-		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to +X (east)
-			vertex.Pos.rotateXZBy(90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
+		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
 
 		d = sunsize * 1.2;
 		c = suncolor;
 		c.setAlpha(0.15 * 255);
-		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to +X (east)
-			vertex.Pos.rotateXZBy(90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
+		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
 
 		d = sunsize;
-		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor, t, t);
-		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor, o, t);
-		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor, o, o);
-		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to +X (east)
-			vertex.Pos.rotateXZBy(90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		vertices2 = draw_aster(wicked_time_of_day, d, suncolor, t, o);
+		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
 
 		d = sunsize * 0.7;
-		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor2, t, t);
-		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor2, o, t);
-		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor2, o, o);
-		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor2, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to +X (east)
-			vertex.Pos.rotateXZBy(90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		vertices2 = draw_aster(wicked_time_of_day, d, suncolor2, t, o);
+		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
 	} else {
 		driver->setMaterial(m_materials[3]);
 		float d = sunsize * 1.7;
@@ -773,4 +745,18 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		}
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
+}
+
+std::array<video::S3DVertex, 4> Sky::draw_aster(float wicked_time_of_day, float d, video::SColor c, const f32 t, const f32 o) {
+	std::array<video::S3DVertex, 4> vertices;
+	vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+	vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+	vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+	vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+	for (video::S3DVertex &vertex : vertices) {
+		// Switch from -Z (south) to +X (east)
+		vertex.Pos.rotateXZBy(90);
+		vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+	}
+	return vertices;
 }

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -677,13 +677,13 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 4> sunsizes = {
+		const float sunsizes[4] = {
 				sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
 		video::SColor c1 = suncolor;
 		video::SColor c2 = suncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
+		const video::SColor colors[4] = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(-sunsizes[i], sunsizes[i], colors[i]);
 			vertices = place_sky_body(
@@ -711,15 +711,15 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 4> moonsizes_1 = {
+		const float moonsizes_1[4] = {
 				-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const std::array<float, 4> moonsizes_2 = {moonsize * 1.9f,
+		const float moonsizes_2[4] = {moonsize * 1.9f,
 				moonsize * 1.3f, moonsize, moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const std::array<video::SColor, 4> colors = {
+		const video::SColor colors[4] = {
 				c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -684,7 +684,6 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
 	}
 }
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -707,25 +707,17 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 	if (!m_sun_texture) {
 		std::cout << "New code is called" << std::endl;
 		driver->setMaterial(m_materials[1]);
-		float d = sunsize * 1.7;
-		video::SColor c = suncolor;
-		c.setAlpha(0.05 * 255);
-		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+		const std::array<float, 4> sunsizes = {sunsize * 1.7, sunsize * 1.2, sunsize, sunsize * 0.7};
+		video::SColor c1 = suncolor;
+		video::SColor c2 = suncolor;
+		c1.setAlpha(0.05 * 255);
+		c2.setAlpha(0.15 * 255);
+		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
+		for (int i = 0; i<4; i++) {
 
-		d = sunsize * 1.2;
-		c = suncolor;
-		c.setAlpha(0.15 * 255);
-		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
-
-		d = sunsize;
-		vertices2 = draw_aster(wicked_time_of_day, d, suncolor, t, o);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
-
-		d = sunsize * 0.7;
-		vertices2 = draw_aster(wicked_time_of_day, d, suncolor2, t, o);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+			vertices2 = draw_aster(wicked_time_of_day, sunsizes[i], colors[i], t, o);
+			driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+		}
 	} else {
 		driver->setMaterial(m_materials[3]);
 		float d = sunsize * 1.7;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -31,8 +31,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "camera.h"  // CameraModes
 
-#include <typeinfo>
-
 
 Sky::Sky(s32 id, ITextureSource *tsrc):
 		scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -625,8 +625,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
-	video::SColor suncolor2, float wicked_time_of_day)
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor suncolor,
+	const video::SColor suncolor2, float wicked_time_of_day)
 	/* Draw sun in the sky.
 	 * driver: Video driver object used to draw
 	 * sunsize: the default size of the sun
@@ -665,8 +665,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 }
 
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
-	video::SColor mooncolor2, float wicked_time_of_day)
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor mooncolor,
+	const video::SColor mooncolor2, float wicked_time_of_day)
 	/*
 	 * Draw moon in the sky.
 	 * driver: Video driver object used to draw
@@ -717,7 +717,7 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 }
 
 
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c)
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, const video::SColor c)
 {
 	/*
 	 * Create an array of vertices with the dimensions specified.

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -366,78 +366,7 @@ void Sky::render()
 
 		// Draw sun
 		if (wicked_time_of_day > 0.15 && wicked_time_of_day < 0.85) {
-			if (!m_sun_texture) {
-				driver->setMaterial(m_materials[1]);
-				float d = sunsize * 1.7;
-				video::SColor c = suncolor;
-				c.setAlpha(0.05 * 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to +X (east)
-					vertex.Pos.rotateXZBy(90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				d = sunsize * 1.2;
-				c = suncolor;
-				c.setAlpha(0.15 * 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to +X (east)
-					vertex.Pos.rotateXZBy(90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				d = sunsize;
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to +X (east)
-					vertex.Pos.rotateXZBy(90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				d = sunsize * 0.7;
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor2, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor2, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor2, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor2, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to +X (east)
-					vertex.Pos.rotateXZBy(90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-			} else {
-				driver->setMaterial(m_materials[3]);
-				float d = sunsize * 1.7;
-				video::SColor c;
-				if (m_sun_tonemap)
-					c = video::SColor (0, 0, 0, 0);
-				else
-					c = video::SColor (255, 255, 255, 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to +X (east)
-					vertex.Pos.rotateXZBy(90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-			}
+			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
 		}
 
 		// Draw moon
@@ -764,5 +693,84 @@ void Sky::update(float time_of_day, float time_brightness,
 	if (m_directional_colored_fog) {
 		m_cloudcolor_f = m_mix_scolorf(m_cloudcolor_f,
 			video::SColorf(pointcolor), m_horizon_blend() * 0.25);
+	}
+}
+
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day) {
+	static const u16 indices[4] = {0, 1, 2, 3};
+	video::S3DVertex vertices[4];
+	const f32 t = 1.0f;
+	const f32 o = 0.0f;
+	if (!m_sun_texture) {
+		driver->setMaterial(m_materials[1]);
+		float d = sunsize * 1.7;
+		video::SColor c = suncolor;
+		c.setAlpha(0.05 * 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to +X (east)
+			vertex.Pos.rotateXZBy(90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		d = sunsize * 1.2;
+		c = suncolor;
+		c.setAlpha(0.15 * 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to +X (east)
+			vertex.Pos.rotateXZBy(90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		d = sunsize;
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to +X (east)
+			vertex.Pos.rotateXZBy(90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		d = sunsize * 0.7;
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, suncolor2, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, suncolor2, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, suncolor2, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, suncolor2, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to +X (east)
+			vertex.Pos.rotateXZBy(90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+	} else {
+		driver->setMaterial(m_materials[3]);
+		float d = sunsize * 1.7;
+		video::SColor c;
+		if (m_sun_tonemap)
+			c = video::SColor (0, 0, 0, 0);
+		else
+			c = video::SColor (255, 255, 255, 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to +X (east)
+			vertex.Pos.rotateXZBy(90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -629,13 +629,12 @@ void Sky::update(float time_of_day, float time_brightness,
 
 void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day) {
 	static const u16 indices[4] = {0, 1, 2, 3};
-	video::S3DVertex vertices[4];
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices2;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 4> sunsizes = {sunsize * 1.7, sunsize * 1.2, sunsize, sunsize * 0.7};
+		const std::array<float, 4> sunsizes = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
 		video::SColor c1 = suncolor;
 		video::SColor c2 = suncolor;
 		c1.setAlpha(0.05 * 255);
@@ -654,16 +653,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to +X (east)
-			vertex.Pos.rotateXZBy(90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
+		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
 	}
 }
 void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -373,78 +373,7 @@ void Sky::render()
 
 		// Draw moon
 		if (wicked_time_of_day < 0.3 || wicked_time_of_day > 0.7) {
-			if (!m_moon_texture) {
-				driver->setMaterial(m_materials[1]);
-				float d = moonsize * 1.9;
-				video::SColor c = mooncolor;
-				c.setAlpha(0.05 * 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to -X (west)
-					vertex.Pos.rotateXZBy(-90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				d = moonsize * 1.3;
-				c = mooncolor;
-				c.setAlpha(0.15 * 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to -X (west)
-					vertex.Pos.rotateXZBy(-90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				d = moonsize;
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, mooncolor, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, mooncolor, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, mooncolor, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, mooncolor, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to -X (west)
-					vertex.Pos.rotateXZBy(-90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-
-				float d2 = moonsize * 0.6;
-				vertices[0] = video::S3DVertex(-d, -d,  -1, 0, 0, 1, mooncolor2, t, t);
-				vertices[1] = video::S3DVertex( d2,-d,  -1, 0, 0, 1, mooncolor2, o, t);
-				vertices[2] = video::S3DVertex( d2, d2, -1, 0, 0, 1, mooncolor2, o, o);
-				vertices[3] = video::S3DVertex(-d,  d2, -1, 0, 0, 1, mooncolor2, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to -X (west)
-					vertex.Pos.rotateXZBy(-90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-			} else {
-				driver->setMaterial(m_materials[4]);
-				float d = moonsize * 1.9;
-				video::SColor c;
-				if (m_moon_tonemap)
-					c = video::SColor (0, 0, 0, 0);
-				else
-					c = video::SColor (255, 255, 255, 255);
-				vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					// Switch from -Z (south) to -X (west)
-					vertex.Pos.rotateXZBy(-90);
-					vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-			}
+			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
 		}
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
@@ -705,7 +634,6 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices2;
 	if (!m_sun_texture) {
-		std::cout << "New code is called" << std::endl;
 		driver->setMaterial(m_materials[1]);
 		const std::array<float, 4> sunsizes = {sunsize * 1.7, sunsize * 1.2, sunsize, sunsize * 0.7};
 		video::SColor c1 = suncolor;
@@ -738,6 +666,86 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {
+	static const u16 indices[4] = {0, 1, 2, 3};
+	video::S3DVertex vertices[4];
+	const f32 t = 1.0f;
+	const f32 o = 0.0f;
+	if (!m_moon_texture) {
+		driver->setMaterial(m_materials[1]);
+		float d = moonsize * 1.9;
+		video::SColor c = mooncolor;
+		c.setAlpha(0.05 * 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to -X (west)
+			vertex.Pos.rotateXZBy(-90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		d = moonsize * 1.3;
+		c = mooncolor;
+		c.setAlpha(0.15 * 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to -X (west)
+			vertex.Pos.rotateXZBy(-90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		d = moonsize;
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, mooncolor, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, mooncolor, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, mooncolor, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, mooncolor, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to -X (west)
+			vertex.Pos.rotateXZBy(-90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+
+		float d2 = moonsize * 0.6;
+		vertices[0] = video::S3DVertex(-d, -d,  -1, 0, 0, 1, mooncolor2, t, t);
+		vertices[1] = video::S3DVertex( d2,-d,  -1, 0, 0, 1, mooncolor2, o, t);
+		vertices[2] = video::S3DVertex( d2, d2, -1, 0, 0, 1, mooncolor2, o, o);
+		vertices[3] = video::S3DVertex(-d,  d2, -1, 0, 0, 1, mooncolor2, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to -X (west)
+			vertex.Pos.rotateXZBy(-90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+	} else {
+		driver->setMaterial(m_materials[4]);
+		float d = moonsize * 1.9;
+		video::SColor c;
+		if (m_moon_tonemap)
+			c = video::SColor (0, 0, 0, 0);
+		else
+			c = video::SColor (255, 255, 255, 255);
+		vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
+		vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
+		vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
+		vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+		for (video::S3DVertex &vertex : vertices) {
+			// Switch from -Z (south) to -X (west)
+			vertex.Pos.rotateXZBy(-90);
+			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
+		}
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
+	}
+}
+
+
 
 std::array<video::S3DVertex, 4> Sky::draw_aster(float wicked_time_of_day, float d, video::SColor c, const f32 t, const f32 o) {
 	std::array<video::S3DVertex, 4> vertices;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -713,14 +713,13 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		driver->setMaterial(m_materials[1]);
 		const float moonsizes_1[4] = {
 				-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const float moonsizes_2[4] = {moonsize * 1.9f,
-				moonsize * 1.3f, moonsize, moonsize * 0.6f};
+		const float moonsizes_2[4] = {moonsize * 1.9f, moonsize * 1.3f, moonsize,
+				moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {
-				c1, c2, mooncolor, mooncolor2};
+		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(
 					moonsizes_1[i], moonsizes_2[i], colors[i]);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -637,8 +637,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		c2.setAlpha(0.15 * 255);
 		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i<4; i++) {
-			vertices = draw_aster(-sunsizes[i], sunsizes[i], colors[i]);
-			vertices = place_aster(vertices, 90, wicked_time_of_day * 360 - 90);
+			vertices = draw_sky_body(-sunsizes[i], sunsizes[i], colors[i]);
+			vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -649,8 +649,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices = draw_aster(-d, d, c);
-		vertices = place_aster(vertices, 90, wicked_time_of_day * 360 - 90);
+		vertices = draw_sky_body(-d, d, c);
+		vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
@@ -669,8 +669,8 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		c2.setAlpha(0.15 * 255);
 		const std::array<video::SColor, 4> colors = {c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i<4; i++) {
-			vertices = draw_aster(moonsizes_1[i], moonsizes_2[i], colors[i]);
-			vertices = place_aster(vertices, -90, wicked_time_of_day * 360 - 90);
+			vertices = draw_sky_body(moonsizes_1[i], moonsizes_2[i], colors[i]);
+			vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -681,15 +681,15 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices = draw_aster(-d, d, c);
-		vertices = place_aster(vertices, -90, wicked_time_of_day * 360 - 90);
+		vertices = draw_sky_body(-d, d, c);
+		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 
 	}
 }
 
 
-std::array<video::S3DVertex, 4> Sky::draw_aster(float pos_1, float pos_2, video::SColor c) {
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c) {
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
@@ -701,7 +701,7 @@ std::array<video::S3DVertex, 4> Sky::draw_aster(float pos_1, float pos_2, video:
 }
 
 
-std::array<video::S3DVertex, 4> Sky::place_aster(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
+std::array<video::S3DVertex, 4> Sky::place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
 	for (video::S3DVertex &vertex : vertices) {
 		// Switch from -Z (south) to -X (west)
 		vertex.Pos.rotateXZBy(horizon_position);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -118,8 +118,8 @@ void Sky::render()
 	if (!m_visible)
 		return;
 
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
-	scene::ICameraSceneNode* camera = SceneManager->getActiveCamera();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
+	scene::ICameraSceneNode *camera = SceneManager->getActiveCamera();
 
 	if (!camera || !driver)
 		return;
@@ -337,7 +337,7 @@ void Sky::render()
 				indices, SKY_STAR_COUNT, video::EVT_STANDARD,
 				scene::EPT_QUADS, video::EIT_16BIT);
 #endif
-		} while(false);
+		} while (false);
 
 		// Draw sunrise/sunset horizon glow texture (textures/base/pack/sunrisebg.png)
 		{
@@ -625,7 +625,9 @@ void Sky::update(float time_of_day, float time_brightness,
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day) {
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
+		video::SColor suncolor2, float wicked_time_of_day)
+{
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
@@ -656,19 +658,31 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 }
 
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
+		video::SColor mooncolor2, float wicked_time_of_day)
+{
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
-		const float moonsizes_1[4] = {-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const float moonsizes_2[4] = {moonsize * 1.9f, moonsize * 1.3f, moonsize, moonsize * 0.6f};
+		const float moonsizes_1[4] = {
+				-moonsize * 1.9f,
+				-moonsize * 1.3f,
+				-moonsize,
+				-moonsize
+			};
+		const float moonsizes_2[4] = {
+				moonsize * 1.9f,
+				moonsize * 1.3f,
+				moonsize,
+				moonsize * 0.6f
+			};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
 		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
-		for (int i = 0; i<4; i++) {
+		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(moonsizes_1[i], moonsizes_2[i], colors[i]);
 			vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
@@ -678,9 +692,9 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		float d = moonsize * 1.9;
 		video::SColor c;
 		if (m_moon_tonemap)
-			c = video::SColor (0, 0, 0, 0);
+			c = video::SColor(0, 0, 0, 0);
 		else
-			c = video::SColor (255, 255, 255, 255);
+			c = video::SColor(255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
@@ -688,7 +702,9 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 }
 
 
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c) {
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(
+		float pos_1, float pos_2, video::SColor c)
+{
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
@@ -700,7 +716,9 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, vid
 }
 
 
-std::array<video::S3DVertex, 4> Sky::place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
+std::array<video::S3DVertex, 4> Sky::place_sky_body(
+		std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position)
+{
 	for (video::S3DVertex &vertex : vertices) {
 		// Switch from -Z (south) to -X (west)
 		vertex.Pos.rotateXZBy(horizon_position);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -648,9 +648,9 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		float d = sunsize * 1.7;
 		video::SColor c;
 		if (m_sun_tonemap)
-			c = video::SColor (0, 0, 0, 0);
+			c = video::SColor(0, 0, 0, 0);
 		else
-			c = video::SColor (255, 255, 255, 255);
+			c = video::SColor(255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -713,13 +713,14 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		driver->setMaterial(m_materials[1]);
 		const float moonsizes_1[4] = {
 				-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const float moonsizes_2[4] = {moonsize * 1.9f, moonsize * 1.3f, moonsize,
-				moonsize * 0.6f};
+		const float moonsizes_2[4] = {moonsize * 1.9f,
+				moonsize * 1.3f, moonsize, moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
+		const video::SColor colors[4] = {
+				c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(
 					moonsizes_1[i], moonsizes_2[i], colors[i]);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -413,8 +413,8 @@ void Sky::render()
 
 
 void Sky::update(float time_of_day, float time_brightness,
-		float direct_brightness, bool sunlight_seen,
-		CameraMode cam_mode, float yaw, float pitch)
+	float direct_brightness, bool sunlight_seen,
+	CameraMode cam_mode, float yaw, float pitch)
 {
 	// Stabilize initial brightness and color values by flooding updates
 	if (m_first_update) {
@@ -626,7 +626,7 @@ void Sky::update(float time_of_day, float time_brightness,
 }
 
 void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
-		video::SColor suncolor2, float wicked_time_of_day)
+	video::SColor suncolor2, float wicked_time_of_day)
 {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
@@ -659,7 +659,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 
 
 void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
-		video::SColor mooncolor2, float wicked_time_of_day)
+	video::SColor mooncolor2, float wicked_time_of_day)
 {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
@@ -702,8 +702,7 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 }
 
 
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(
-		float pos_1, float pos_2, video::SColor c)
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c)
 {
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
@@ -717,10 +716,10 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(
 
 
 std::array<video::S3DVertex, 4> Sky::place_sky_body(
-		std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position)
+	std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position)
 {
 	for (video::S3DVertex &vertex : vertices) {
-		// Switch from -Z (south) to -X (west)
+		// Body is directed to -Z (south) by default
 		vertex.Pos.rotateXZBy(horizon_position);
 		vertex.Pos.rotateXYBy(day_position);
 	}

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -646,8 +646,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 		c2.setAlpha(0.15 * 255);
 		const video::SColor colors[4] = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i < 4; i++) {
-			vertices = draw_sky_body(-sunsizes[i], sunsizes[i], colors[i]);
-			vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
+			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], colors[i]);
+			place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -658,8 +658,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		vertices = draw_sky_body(-d, d, c);
-		vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
+		draw_sky_body(vertices, -d, d, c);
+		place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
@@ -698,8 +698,8 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 		c2.setAlpha(0.15 * 255);
 		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i < 4; i++) {
-			vertices = draw_sky_body(moonsizes_1[i], moonsizes_2[i], colors[i]);
-			vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
+			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], colors[i]);
+			place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -710,14 +710,14 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		vertices = draw_sky_body(-d, d, c);
-		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
+		draw_sky_body(vertices, -d, d, c);
+		place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
 
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, const video::SColor c)
+void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, float pos_2, const video::SColor c)
 {
 	/*
 	 * Create an array of vertices with the dimensions specified.
@@ -727,17 +727,15 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, con
 
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
-	std::array<video::S3DVertex, 4> vertices;
 	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, c, t, t);
 	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, c, o, t);
 	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, c, o, o);
 	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, c, t, o);
-	return vertices;
 }
 
 
-std::array<video::S3DVertex, 4> Sky::place_sky_body(
-	std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position)
+void Sky::place_sky_body(
+	std::array<video::S3DVertex, 4> &vertices, float horizon_position, float day_position)
 	/*
 	 * Place body in the sky.
 	 * vertices: The body as a rectangle of 4 vertices
@@ -750,5 +748,4 @@ std::array<video::S3DVertex, 4> Sky::place_sky_body(
 		vertex.Pos.rotateXZBy(horizon_position);
 		vertex.Pos.rotateXYBy(day_position);
 	}
-	return vertices;
 }

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -23,18 +23,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "ICameraSceneNode.h"
 #include "S3DVertex.h"
 #include "client/tile.h"
-#include "noise.h" // easeCurve
+#include "noise.h"  // easeCurve
 #include "profiler.h"
 #include "util/numeric.h"
 #include <cmath>
 #include "client/renderingengine.h"
 #include "settings.h"
-#include "camera.h" // CameraModes
+#include "camera.h"  // CameraModes
 
-Sky::Sky(s32 id, ITextureSource *tsrc) :
-		scene::ISceneNode(
-				RenderingEngine::get_scene_manager()->getRootSceneNode(),
-				RenderingEngine::get_scene_manager(), id)
+
+Sky::Sky(s32 id, ITextureSource *tsrc):
+		scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),
+			RenderingEngine::get_scene_manager(), id)
 {
 	setAutomaticCulling(scene::EAC_OFF);
 	m_box.MaxEdge.set(0, 0, 0);
@@ -58,26 +58,22 @@ Sky::Sky(s32 id, ITextureSource *tsrc) :
 	m_materials[0] = mat;
 
 	m_materials[1] = mat;
-	// m_materials[1].MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+	//m_materials[1].MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_materials[1].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
 	m_materials[2] = mat;
 	m_materials[2].setTexture(0, tsrc->getTextureForMesh("sunrisebg.png"));
 	m_materials[2].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	// m_materials[2].MaterialType = video::EMT_TRANSPARENT_ADD_COLOR;
+	//m_materials[2].MaterialType = video::EMT_TRANSPARENT_ADD_COLOR;
 
-	m_sun_texture = tsrc->isKnownSourceImage("sun.png")
-					? tsrc->getTextureForMesh("sun.png")
-					: NULL;
-	m_moon_texture = tsrc->isKnownSourceImage("moon.png")
-					 ? tsrc->getTextureForMesh("moon.png")
-					 : NULL;
-	m_sun_tonemap = tsrc->isKnownSourceImage("sun_tonemap.png")
-					? tsrc->getTexture("sun_tonemap.png")
-					: NULL;
-	m_moon_tonemap = tsrc->isKnownSourceImage("moon_tonemap.png")
-					 ? tsrc->getTexture("moon_tonemap.png")
-					 : NULL;
+	m_sun_texture = tsrc->isKnownSourceImage("sun.png") ?
+		tsrc->getTextureForMesh("sun.png") : NULL;
+	m_moon_texture = tsrc->isKnownSourceImage("moon.png") ?
+		tsrc->getTextureForMesh("moon.png") : NULL;
+	m_sun_tonemap = tsrc->isKnownSourceImage("sun_tonemap.png") ?
+		tsrc->getTexture("sun_tonemap.png") : NULL;
+	m_moon_tonemap = tsrc->isKnownSourceImage("moon_tonemap.png") ?
+		tsrc->getTexture("moon_tonemap.png") : NULL;
 
 	if (m_sun_texture) {
 		m_materials[3] = mat;
@@ -96,13 +92,17 @@ Sky::Sky(s32 id, ITextureSource *tsrc) :
 	}
 
 	for (v3f &star : m_stars) {
-		star = v3f(myrand_range(-10000, 10000), myrand_range(-10000, 10000),
-				myrand_range(-10000, 10000));
+		star = v3f(
+			myrand_range(-10000, 10000),
+			myrand_range(-10000, 10000),
+			myrand_range(-10000, 10000)
+		);
 		star.normalize();
 	}
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 }
+
 
 void Sky::OnRegisterSceneNode()
 {
@@ -112,13 +112,14 @@ void Sky::OnRegisterSceneNode()
 	scene::ISceneNode::OnRegisterSceneNode();
 }
 
+
 void Sky::render()
 {
 	if (!m_visible)
 		return;
 
-	video::IVideoDriver *driver = SceneManager->getVideoDriver();
-	scene::ICameraSceneNode *camera = SceneManager->getActiveCamera();
+	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	scene::ICameraSceneNode* camera = SceneManager->getActiveCamera();
 
 	if (!camera || !driver)
 		return;
@@ -140,9 +141,9 @@ void Sky::render()
 	if (m_sunlight_seen) {
 		float sunsize = 0.07;
 		video::SColorf suncolor_f(1, 1, 0, 1);
-		// suncolor_f.r = 1;
-		// suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.7 + m_time_brightness * 0.5));
-		// suncolor_f.b = MYMAX(0.0, m_brightness * 0.95);
+		//suncolor_f.r = 1;
+		//suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.7 + m_time_brightness * 0.5));
+		//suncolor_f.b = MYMAX(0.0, m_brightness * 0.95);
 		video::SColorf suncolor2_f(1, 1, 1, 1);
 		// The values below were probably meant to be suncolor2_f instead of a
 		// reassignment of suncolor_f. However, the resulting colour was chosen
@@ -160,8 +161,7 @@ void Sky::render()
 		float wn = nightlength / 2;
 		float wicked_time_of_day = 0;
 		if (m_time_of_day > wn && m_time_of_day < 1.0 - wn)
-			wicked_time_of_day = (m_time_of_day - wn) / (1.0 - wn * 2) * 0.5 +
-					     0.25;
+			wicked_time_of_day = (m_time_of_day - wn) / (1.0 - wn * 2) * 0.5 + 0.25;
 		else if (m_time_of_day < 0.5)
 			wicked_time_of_day = m_time_of_day / wn * 0.25;
 		else
@@ -175,25 +175,22 @@ void Sky::render()
 		video::SColor mooncolor2 = mooncolor2_f.toSColor();
 
 		// Calculate offset normalized to the X dimension of a 512x1 px tonemap
-		float offset = (1.0 - fabs(sin((m_time_of_day - 0.5) * irr::core::PI))) *
-			       511;
+		float offset = (1.0 - fabs(sin((m_time_of_day - 0.5) * irr::core::PI))) * 511;
 
 		if (m_sun_tonemap) {
-			u8 *texels = (u8 *)m_sun_tonemap->lock();
-			video::SColor *texel =
-					(video::SColor *)(texels + (u32)offset * 4);
-			video::SColor texel_color(255, texel->getRed(), texel->getGreen(),
-					texel->getBlue());
+			u8 * texels = (u8 *)m_sun_tonemap->lock();
+			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
+			video::SColor texel_color (255, texel->getRed(),
+				texel->getGreen(), texel->getBlue());
 			m_sun_tonemap->unlock();
 			m_materials[3].EmissiveColor = texel_color;
 		}
 
 		if (m_moon_tonemap) {
-			u8 *texels = (u8 *)m_moon_tonemap->lock();
-			video::SColor *texel =
-					(video::SColor *)(texels + (u32)offset * 4);
-			video::SColor texel_color(255, texel->getRed(), texel->getGreen(),
-					texel->getBlue());
+			u8 * texels = (u8 *)m_moon_tonemap->lock();
+			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
+			video::SColor texel_color (255, texel->getRed(),
+				texel->getGreen(), texel->getBlue());
 			m_moon_tonemap->unlock();
 			m_materials[4].EmissiveColor = texel_color;
 		}
@@ -209,17 +206,16 @@ void Sky::render()
 
 		// Draw far cloudy fog thing blended with skycolor
 		for (u32 j = 0; j < 4; j++) {
-			video::SColor c =
-					cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
+			video::SColor c = cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
 			vertices[0] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex(1, 0.08, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex(1, 0.12, -1, 0, 0, 1, c, o, o);
+			vertices[1] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex( 1, 0.12, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, 0.12, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-				// Don't switch
-				{
-				} else if (j == 1)
+					// Don't switch
+					{}
+				else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -236,14 +232,14 @@ void Sky::render()
 		for (u32 j = 0; j < 4; j++) {
 			video::SColor c = cloudyfogcolor;
 			vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex(1, 0.08, -1, 0, 0, 1, c, o, o);
+			vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-				// Don't switch
-				{
-				} else if (j == 1)
+					// Don't switch
+					{}
+				else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -264,14 +260,13 @@ void Sky::render()
 		do {
 			driver->setMaterial(m_materials[1]);
 			// Tune values so that stars first appear just after the sun
-			// disappears over the horizon, and disappear just before the sun
+			// disappears over the horizon, and disappear just before the sun 
 			// appears over the horizon.
-			// Also tune so that stars are at full brightness from time 20000
-			// to time 4000.
-			float starbrightness = MYMAX(0,
-					MYMIN(1, (0.25 - fabs(wicked_time_of_day < 0.5 ? wicked_time_of_day
-										       : (1.0 - wicked_time_of_day))) *
-									20));
+			// Also tune so that stars are at full brightness from time 20000 to 
+			// time 4000.
+			float starbrightness = MYMAX(0, MYMIN(1,
+				(0.25 - fabs(wicked_time_of_day < 0.5 ?
+				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 20));
 			float f = starbrightness;
 			float d = 0.007 / 2;
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
@@ -318,8 +313,8 @@ void Sky::render()
 				core::CMatrix4<f32> a;
 				a.buildRotateFromTo(v3f(0, 1, 0), r);
 				v3f p = v3f(-d, 1, -d);
-				v3f p1 = v3f(d, 1, -d);
-				v3f p2 = v3f(d, 1, d);
+				v3f p1 = v3f( d, 1, -d);
+				v3f p2 = v3f( d, 1, d);
 				v3f p3 = v3f(-d, 1, d);
 				a.rotateVect(p);
 				a.rotateVect(p1);
@@ -339,28 +334,25 @@ void Sky::render()
 				vertices[i * 4 + 3].Color = starcolor;
 			}
 			driver->drawVertexPrimitiveList(vertices, SKY_STAR_COUNT * 4,
-					indices, SKY_STAR_COUNT, video::EVT_STANDARD,
-					scene::EPT_QUADS, video::EIT_16BIT);
+				indices, SKY_STAR_COUNT, video::EVT_STANDARD,
+				scene::EPT_QUADS, video::EIT_16BIT);
 #endif
-		} while (false);
+		} while(false);
 
-		// Draw sunrise/sunset horizon glow texture
-		// (textures/base/pack/sunrisebg.png)
+		// Draw sunrise/sunset horizon glow texture (textures/base/pack/sunrisebg.png)
 		{
 			driver->setMaterial(m_materials[2]);
 			float mid1 = 0.25;
 			float mid = wicked_time_of_day < 0.5 ? mid1 : (1.0 - mid1);
 			float a_ = 1.0f - std::fabs(wicked_time_of_day - mid) * 35.0f;
 			float a = easeCurve(MYMAX(0, MYMIN(1, a_)));
-			// std::cerr<<"a_="<<a_<<" a="<<a<<std::endl;
+			//std::cerr<<"a_="<<a_<<" a="<<a<<std::endl;
 			video::SColor c(255, 255, 255, 255);
 			float y = -(1.0 - a) * 0.22;
-			vertices[0] = video::S3DVertex(
-					-1, -0.05 + y, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex(
-					1, -0.05 + y, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex(1, 0.2 + y, -1, 0, 0, 1, c, o, o);
-			vertices[3] = video::S3DVertex(-1, 0.2 + y, -1, 0, 0, 1, c, t, o);
+			vertices[0] = video::S3DVertex(-1, -0.05 + y, -1, 0, 0, 1, c, t, t);
+			vertices[1] = video::S3DVertex( 1, -0.05 + y, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex( 1,   0.2 + y, -1, 0, 0, 1, c, o, o);
+			vertices[3] = video::S3DVertex(-1,   0.2 + y, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (wicked_time_of_day < 0.5)
 					// Switch from -Z (south) to +X (east)
@@ -374,14 +366,12 @@ void Sky::render()
 
 		// Draw sun
 		if (wicked_time_of_day > 0.15 && wicked_time_of_day < 0.85) {
-			draw_sun(driver, sunsize, suncolor, suncolor2,
-					wicked_time_of_day);
+			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
 		}
 
 		// Draw moon
 		if (wicked_time_of_day < 0.3 || wicked_time_of_day > 0.7) {
-			draw_moon(driver, moonsize, mooncolor, mooncolor2,
-					wicked_time_of_day);
+			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
 		}
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
@@ -390,15 +380,15 @@ void Sky::render()
 
 		for (u32 j = 0; j < 4; j++) {
 			video::SColor c = cloudyfogcolor;
-			vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex(1, -0.02, -1, 0, 0, 1, c, o, o);
+			vertices[0] = video::S3DVertex(-1, -1.0,  -1, 0, 0, 1, c, t, t);
+			vertices[1] = video::S3DVertex( 1, -1.0,  -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex( 1, -0.02, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, -0.02, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-				// Don't switch
-				{
-				} else if (j == 1)
+					// Don't switch
+					{}
+				else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -414,15 +404,17 @@ void Sky::render()
 		// Draw bottom far cloudy fog thing in front of sun, moon and stars
 		video::SColor c = cloudyfogcolor;
 		vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 1, 0, c, t, t);
-		vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 1, 0, c, o, t);
-		vertices[2] = video::S3DVertex(1, -1.0, 1, 0, 1, 0, c, o, o);
+		vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 1, 0, c, o, t);
+		vertices[2] = video::S3DVertex( 1, -1.0, 1, 0, 1, 0, c, o, o);
 		vertices[3] = video::S3DVertex(-1, -1.0, 1, 0, 1, 0, c, t, o);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-void Sky::update(float time_of_day, float time_brightness, float direct_brightness,
-		bool sunlight_seen, CameraMode cam_mode, float yaw, float pitch)
+
+void Sky::update(float time_of_day, float time_brightness,
+		float direct_brightness, bool sunlight_seen,
+		CameraMode cam_mode, float yaw, float pitch)
 {
 	// Stabilize initial brightness and color values by flooding updates
 	if (m_first_update) {
@@ -433,7 +425,7 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 		m_first_update = false;
 		for (u32 i = 0; i < 100; i++) {
 			update(time_of_day, time_brightness, direct_brightness,
-					sunlight_seen, cam_mode, yaw, pitch);
+				sunlight_seen, cam_mode, yaw, pitch);
 		}
 		return;
 	}
@@ -449,8 +441,8 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 	Development colours
 
 	video::SColorf bgcolor_bright_normal_f(170. / 255, 200. / 255, 230. / 255, 1.0);
-	video::SColorf bgcolor_bright_dawn_f(0.666, 200. / 255 * 0.7, 230. / 255 *
-	0.5, 1.0); video::SColorf bgcolor_bright_dawn_f(0.666, 0.549, 0.220, 1.0);
+	video::SColorf bgcolor_bright_dawn_f(0.666, 200. / 255 * 0.7, 230. / 255 * 0.5, 1.0);
+	video::SColorf bgcolor_bright_dawn_f(0.666, 0.549, 0.220, 1.0);
 	video::SColorf bgcolor_bright_dawn_f(0.666 * 1.2, 0.549 * 1.0, 0.220 * 1.0, 1.0);
 	video::SColorf bgcolor_bright_dawn_f(0.666 * 1.2, 0.549 * 1.0, 0.220 * 1.2, 1.0);
 
@@ -471,8 +463,7 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 	// pure white: becomes "diffuse light component" for clouds
 	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 255, 255, 255);
 	// dawn-factoring version of pure white (note: R is above 1.0)
-	video::SColorf cloudcolor_bright_dawn_f(
-			255.0f / 240.0f, 223.0f / 240.0f, 191.0f / 255.0f);
+	video::SColorf cloudcolor_bright_dawn_f(255.0f/240.0f, 223.0f/240.0f, 191.0f/255.0f);
 
 	float cloud_color_change_fraction = 0.95;
 	if (sunlight_seen) {
@@ -494,58 +485,58 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 	if (sunlight_seen) {
 		if (is_dawn) { // Dawn
 			m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-					bgcolor_bright_dawn_f, color_change_fraction);
+				bgcolor_bright_dawn_f, color_change_fraction);
 			m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-					skycolor_bright_dawn_f, color_change_fraction);
+				skycolor_bright_dawn_f, color_change_fraction);
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-					cloudcolor_bright_dawn_f, color_change_fraction);
+				cloudcolor_bright_dawn_f, color_change_fraction);
 		} else {
 			if (time_brightness < 0.13f) { // Night
 				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-						bgcolor_bright_night_f,
-						color_change_fraction);
+					bgcolor_bright_night_f, color_change_fraction);
 				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-						skycolor_bright_night_f,
-						color_change_fraction);
+					skycolor_bright_night_f, color_change_fraction);
 			} else { // Day
 				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-						bgcolor_bright_normal_f,
-						color_change_fraction);
+					bgcolor_bright_normal_f, color_change_fraction);
 				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-						skycolor_bright_normal_f,
-						color_change_fraction);
+					skycolor_bright_normal_f, color_change_fraction);
 			}
 
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-					cloudcolor_bright_normal_f,
-					color_change_fraction);
+				cloudcolor_bright_normal_f, color_change_fraction);
 		}
 	} else {
 		m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-				bgcolor_bright_indoor_f, color_change_fraction);
+			bgcolor_bright_indoor_f, color_change_fraction);
 		m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-				bgcolor_bright_indoor_f, color_change_fraction);
+			bgcolor_bright_indoor_f, color_change_fraction);
 		m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-				cloudcolor_bright_normal_f, color_change_fraction);
+			cloudcolor_bright_normal_f, color_change_fraction);
 		m_clouds_visible = false;
 	}
 
 	video::SColor bgcolor_bright = m_bgcolor_bright_f.toSColor();
-	m_bgcolor = video::SColor(255, bgcolor_bright.getRed() * m_brightness,
-			bgcolor_bright.getGreen() * m_brightness,
-			bgcolor_bright.getBlue() * m_brightness);
+	m_bgcolor = video::SColor(
+		255,
+		bgcolor_bright.getRed() * m_brightness,
+		bgcolor_bright.getGreen() * m_brightness,
+		bgcolor_bright.getBlue() * m_brightness
+	);
 
 	video::SColor skycolor_bright = m_skycolor_bright_f.toSColor();
-	m_skycolor = video::SColor(255, skycolor_bright.getRed() * m_brightness,
-			skycolor_bright.getGreen() * m_brightness,
-			skycolor_bright.getBlue() * m_brightness);
+	m_skycolor = video::SColor(
+		255,
+		skycolor_bright.getRed() * m_brightness,
+		skycolor_bright.getGreen() * m_brightness,
+		skycolor_bright.getBlue() * m_brightness
+	);
 
 	// Horizon coloring based on sun and moon direction during sunset and sunrise
 	video::SColor pointcolor = video::SColor(m_bgcolor.getAlpha(), 255, 255, 255);
 	if (m_directional_colored_fog) {
 		if (m_horizon_blend() != 0) {
-			// Calculate hemisphere value from yaw, (inverted in third person
-			// front view)
+			// Calculate hemisphere value from yaw, (inverted in third person front view)
 			s8 dir_factor = 1;
 			if (cam_mode > CAMERA_MODE_THIRD)
 				dir_factor = -1;
@@ -554,14 +545,11 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 				pointcolor_blend = 360 - pointcolor_blend;
 			pointcolor_blend /= 180;
 			// Bound view angle to determine where transition starts and ends
-			pointcolor_blend = rangelim(1 - pointcolor_blend * 1.375, 0,
-							   1 / 1.375) *
-					   1.375;
-			// Combine the colors when looking up or down, otherwise turning
-			// looks weird
+			pointcolor_blend = rangelim(1 - pointcolor_blend * 1.375, 0, 1 / 1.375) *
+				1.375;
+			// Combine the colors when looking up or down, otherwise turning looks weird
 			pointcolor_blend += (0.5 - pointcolor_blend) *
-					    (1 - MYMIN((90 - std::fabs(pitch)) / 90 * 1.5,
-								 1));
+				(1 - MYMIN((90 - std::fabs(pitch)) / 90 * 1.5, 1));
 			// Invert direction to match where the sun and moon are rising
 			if (m_time_of_day > 0.5)
 				pointcolor_blend = 1 - pointcolor_blend;
@@ -570,115 +558,79 @@ void Sky::update(float time_of_day, float time_brightness, float direct_brightne
 
 			video::SColorf pointcolor_sun_f(1, 1, 1, 1);
 			if (m_sun_tonemap) {
-				pointcolor_sun_f.r =
-						pointcolor_light *
-						(float)m_materials[3]
-								.EmissiveColor.getRed() /
-						255;
-				pointcolor_sun_f.b =
-						pointcolor_light *
-						(float)m_materials[3]
-								.EmissiveColor.getBlue() /
-						255;
+				pointcolor_sun_f.r = pointcolor_light *
+					(float)m_materials[3].EmissiveColor.getRed() / 255;
+				pointcolor_sun_f.b = pointcolor_light *
+					(float)m_materials[3].EmissiveColor.getBlue() / 255;
 				pointcolor_sun_f.g = pointcolor_light *
-						     (float)m_materials[3]
-								     .EmissiveColor
-								     .getGreen() /
-						     255;
+					(float)m_materials[3].EmissiveColor.getGreen() / 255;
 			} else {
 				pointcolor_sun_f.r = pointcolor_light * 1;
-				pointcolor_sun_f.b =
-						pointcolor_light *
-						(0.25 + (rangelim(m_time_brightness, 0.25,
-									 0.75) -
-									0.25) * 2 *
-										0.75);
-				pointcolor_sun_f.g =
-						pointcolor_light *
-						(pointcolor_sun_f.b * 0.375 +
-								(rangelim(m_time_brightness,
-										 0.05,
-										 0.15) -
-										0.05) *
-										10 *
-										0.625);
+				pointcolor_sun_f.b = pointcolor_light *
+					(0.25 + (rangelim(m_time_brightness, 0.25, 0.75) - 0.25) * 2 * 0.75);
+				pointcolor_sun_f.g = pointcolor_light * (pointcolor_sun_f.b * 0.375 +
+					(rangelim(m_time_brightness, 0.05, 0.15) - 0.05) * 10 * 0.625);
 			}
 
 			video::SColorf pointcolor_moon_f(0.5 * pointcolor_light,
-					0.6 * pointcolor_light, 0.8 * pointcolor_light,
-					1);
+				0.6 * pointcolor_light, 0.8 * pointcolor_light, 1);
 			if (m_moon_tonemap) {
-				pointcolor_moon_f.r =
-						pointcolor_light *
-						(float)m_materials[4]
-								.EmissiveColor.getRed() /
-						255;
-				pointcolor_moon_f.b =
-						pointcolor_light *
-						(float)m_materials[4]
-								.EmissiveColor.getBlue() /
-						255;
+				pointcolor_moon_f.r = pointcolor_light *
+					(float)m_materials[4].EmissiveColor.getRed() / 255;
+				pointcolor_moon_f.b = pointcolor_light *
+					(float)m_materials[4].EmissiveColor.getBlue() / 255;
 				pointcolor_moon_f.g = pointcolor_light *
-						      (float)m_materials[4]
-								      .EmissiveColor
-								      .getGreen() /
-						      255;
+					(float)m_materials[4].EmissiveColor.getGreen() / 255;
 			}
 
 			video::SColor pointcolor_sun = pointcolor_sun_f.toSColor();
 			video::SColor pointcolor_moon = pointcolor_moon_f.toSColor();
 			// Calculate the blend color
-			pointcolor = m_mix_scolor(pointcolor_moon, pointcolor_sun,
-					pointcolor_blend);
+			pointcolor = m_mix_scolor(pointcolor_moon, pointcolor_sun, pointcolor_blend);
 		}
 		m_bgcolor = m_mix_scolor(m_bgcolor, pointcolor, m_horizon_blend() * 0.5);
-		m_skycolor = m_mix_scolor(
-				m_skycolor, pointcolor, m_horizon_blend() * 0.25);
+		m_skycolor = m_mix_scolor(m_skycolor, pointcolor, m_horizon_blend() * 0.25);
 	}
 
 	float cloud_direct_brightness = 0.0f;
 	if (sunlight_seen) {
 		if (!m_directional_colored_fog) {
 			cloud_direct_brightness = time_brightness;
-			// Boost cloud brightness relative to sky, at dawn, dusk and at
-			// night
+			// Boost cloud brightness relative to sky, at dawn, dusk and at night
 			if (time_brightness < 0.7f)
 				cloud_direct_brightness *= 1.3f;
 		} else {
-			cloud_direct_brightness = std::fmin(
-					m_horizon_blend() * 0.15f + m_time_brightness,
-					1.0f);
+			cloud_direct_brightness = std::fmin(m_horizon_blend() * 0.15f +
+				m_time_brightness, 1.0f);
 			// Set the same minimum cloud brightness at night
 			if (time_brightness < 0.5f)
-				cloud_direct_brightness =
-						std::fmax(cloud_direct_brightness,
-								time_brightness * 1.3f);
+				cloud_direct_brightness = std::fmax(cloud_direct_brightness,
+					time_brightness * 1.3f);
 		}
 	} else {
 		cloud_direct_brightness = direct_brightness;
 	}
 
-	m_cloud_brightness =
-			m_cloud_brightness * cloud_color_change_fraction +
-			cloud_direct_brightness * (1.0 - cloud_color_change_fraction);
-	m_cloudcolor_f = video::SColorf(m_cloudcolor_bright_f.r * m_cloud_brightness,
-			m_cloudcolor_bright_f.g * m_cloud_brightness,
-			m_cloudcolor_bright_f.b * m_cloud_brightness, 1.0);
+	m_cloud_brightness = m_cloud_brightness * cloud_color_change_fraction +
+		cloud_direct_brightness * (1.0 - cloud_color_change_fraction);
+	m_cloudcolor_f = video::SColorf(
+		m_cloudcolor_bright_f.r * m_cloud_brightness,
+		m_cloudcolor_bright_f.g * m_cloud_brightness,
+		m_cloudcolor_bright_f.b * m_cloud_brightness,
+		1.0
+	);
 	if (m_directional_colored_fog) {
-		m_cloudcolor_f = m_mix_scolorf(m_cloudcolor_f, video::SColorf(pointcolor),
-				m_horizon_blend() * 0.25);
+		m_cloudcolor_f = m_mix_scolorf(m_cloudcolor_f,
+			video::SColorf(pointcolor), m_horizon_blend() * 0.25);
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
-		video::SColor suncolor2, float wicked_time_of_day)
-{
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day) {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
-		const float sunsizes[4] = {
-				sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
+		const float sunsizes[4] = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
 		video::SColor c1 = suncolor;
 		video::SColor c2 = suncolor;
 		c1.setAlpha(0.05 * 255);
@@ -686,8 +638,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		const video::SColor colors[4] = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(-sunsizes[i], sunsizes[i], colors[i]);
-			vertices = place_sky_body(
-					vertices, 90, wicked_time_of_day * 360 - 90);
+			vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -695,37 +646,31 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		float d = sunsize * 1.7;
 		video::SColor c;
 		if (m_sun_tonemap)
-			c = video::SColor(0, 0, 0, 0);
+			c = video::SColor (0, 0, 0, 0);
 		else
-			c = video::SColor(255, 255, 255, 255);
+			c = video::SColor (255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
-		video::SColor mooncolor2, float wicked_time_of_day)
-{
+
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
-		const float moonsizes_1[4] = {
-				-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const float moonsizes_2[4] = {moonsize * 1.9f,
-				moonsize * 1.3f, moonsize, moonsize * 0.6f};
+		const float moonsizes_1[4] = {-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
+		const float moonsizes_2[4] = {moonsize * 1.9f, moonsize * 1.3f, moonsize, moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {
-				c1, c2, mooncolor, mooncolor2};
-		for (int i = 0; i < 4; i++) {
-			vertices = draw_sky_body(
-					moonsizes_1[i], moonsizes_2[i], colors[i]);
-			vertices = place_sky_body(
-					vertices, -90, wicked_time_of_day * 360 - 90);
+		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
+		for (int i = 0; i<4; i++) {
+			vertices = draw_sky_body(moonsizes_1[i], moonsizes_2[i], colors[i]);
+			vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -733,18 +678,17 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		float d = moonsize * 1.9;
 		video::SColor c;
 		if (m_moon_tonemap)
-			c = video::SColor(0, 0, 0, 0);
+			c = video::SColor (0, 0, 0, 0);
 		else
-			c = video::SColor(255, 255, 255, 255);
+			c = video::SColor (255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(
-		float pos_1, float pos_2, video::SColor c)
-{
+
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c) {
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
@@ -755,10 +699,8 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(
 	return vertices;
 }
 
-std::array<video::S3DVertex, 4> Sky::place_sky_body(
-		std::array<video::S3DVertex, 4> vertices, float horizon_position,
-		float day_position)
-{
+
+std::array<video::S3DVertex, 4> Sky::place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
 	for (video::S3DVertex &vertex : vertices) {
 		// Switch from -Z (south) to -X (west)
 		vertex.Pos.rotateXZBy(horizon_position);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -637,7 +637,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		c2.setAlpha(0.15 * 255);
 		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i<4; i++) {
-			vertices = draw_aster(sunsizes[i], colors[i]);
+			vertices = draw_aster(-sunsizes[i], sunsizes[i], colors[i]);
 			vertices = place_aster(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
@@ -649,43 +649,30 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices = draw_aster(d, c);
+		vertices = draw_aster(-d, d, c);
 		vertices = place_aster(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
+
+
 void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {
 	static const u16 indices[4] = {0, 1, 2, 3};
-	video::S3DVertex vertices[4];
-	const f32 t = 1.0f;
-	const f32 o = 0.0f;
-	std::array<video::S3DVertex, 4> vertices2;
+	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 3> moonsizes = {moonsize * 1.9f, moonsize * 1.3f, moonsize};
+		const std::array<float, 4> moonsizes_1 = {-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
+		const std::array<float, 4> moonsizes_2 = {moonsize * 1.9f, moonsize * 1.3f, moonsize, moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const std::array<video::SColor, 3> colors = {c1, c2, mooncolor};
-		for (int i = 0; i<3; i++) {
-			vertices2 = draw_aster(moonsizes[i], colors[i]);
-			vertices2 = place_aster(vertices2, -90, wicked_time_of_day * 360 - 90);
-			driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+		const std::array<video::SColor, 4> colors = {c1, c2, mooncolor, mooncolor2};
+		for (int i = 0; i<4; i++) {
+			vertices = draw_aster(moonsizes_1[i], moonsizes_2[i], colors[i]);
+			vertices = place_aster(vertices, -90, wicked_time_of_day * 360 - 90);
+			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
-
-		float d = moonsize;
-		float d2 = moonsize * 0.6;
-		vertices[0] = video::S3DVertex(-d, -d,  -1, 0, 0, 1, mooncolor2, t, t);
-		vertices[1] = video::S3DVertex( d2,-d,  -1, 0, 0, 1, mooncolor2, o, t);
-		vertices[2] = video::S3DVertex( d2, d2, -1, 0, 0, 1, mooncolor2, o, o);
-		vertices[3] = video::S3DVertex(-d,  d2, -1, 0, 0, 1, mooncolor2, t, o);
-		for (video::S3DVertex &vertex : vertices) {
-			// Switch from -Z (south) to -X (west)
-			vertex.Pos.rotateXZBy(-90);
-			vertex.Pos.rotateXYBy(wicked_time_of_day * 360 - 90);
-		}
-		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	} else {
 		driver->setMaterial(m_materials[4]);
 		float d = moonsize * 1.9;
@@ -694,25 +681,25 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices2 = draw_aster(d, c);
-		vertices2 = place_aster(vertices2, -90, wicked_time_of_day * 360 - 90);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+		vertices = draw_aster(-d, d, c);
+		vertices = place_aster(vertices, -90, wicked_time_of_day * 360 - 90);
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 
 	}
 }
 
 
-
-std::array<video::S3DVertex, 4> Sky::draw_aster(float d, video::SColor c) {
+std::array<video::S3DVertex, 4> Sky::draw_aster(float pos_1, float pos_2, video::SColor c) {
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
-	vertices[0] = video::S3DVertex(-d, -d, -1, 0, 0, 1, c, t, t);
-	vertices[1] = video::S3DVertex( d, -d, -1, 0, 0, 1, c, o, t);
-	vertices[2] = video::S3DVertex( d,  d, -1, 0, 0, 1, c, o, o);
-	vertices[3] = video::S3DVertex(-d,  d, -1, 0, 0, 1, c, t, o);
+	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, c, t, t);
+	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, c, o, t);
+	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, c, o, o);
+	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, c, t, o);
 	return vertices;
 }
+
 
 std::array<video::S3DVertex, 4> Sky::place_aster(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
 	for (video::S3DVertex &vertex : vertices) {

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -366,12 +366,12 @@ void Sky::render()
 
 		// Draw sun
 		if (wicked_time_of_day > 0.15 && wicked_time_of_day < 0.85) {
-			draw_sun(driver, sunsize, &suncolor, &suncolor2, wicked_time_of_day);
+			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
 		}
 
 		// Draw moon
 		if (wicked_time_of_day < 0.3 || wicked_time_of_day > 0.7) {
-			draw_moon(driver, moonsize, &mooncolor, &mooncolor2, wicked_time_of_day);
+			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
 		}
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
@@ -625,8 +625,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor *suncolor,
-	const video::SColor *suncolor2, float wicked_time_of_day)
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
+	const video::SColor &suncolor2, float wicked_time_of_day)
 	/* Draw sun in the sky.
 	 * driver: Video driver object used to draw
 	 * sunsize: the default size of the sun
@@ -640,13 +640,13 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
 		const float sunsizes[4] = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
-		video::SColor c1 = *suncolor;
-		video::SColor c2 = *suncolor;
+		video::SColor c1 = suncolor;
+		video::SColor c2 = suncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {c1, c2, *suncolor, *suncolor2};
+		const video::SColor colors[4] = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i < 4; i++) {
-			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], &colors[i]);
+			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], colors[i]);
 			place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
@@ -658,15 +658,15 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		draw_sky_body(vertices, -d, d, &c);
+		draw_sky_body(vertices, -d, d, c);
 		place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor *mooncolor,
-	const video::SColor *mooncolor2, float wicked_time_of_day)
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor &mooncolor,
+	const video::SColor &mooncolor2, float wicked_time_of_day)
 	/*
 	 * Draw moon in the sky.
 	 * driver: Video driver object used to draw
@@ -692,13 +692,13 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 				moonsize,
 				moonsize * 0.6f
 			};
-		video::SColor c1 = *mooncolor;
-		video::SColor c2 = *mooncolor;
+		video::SColor c1 = mooncolor;
+		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {c1, c2, *mooncolor, *mooncolor2};
+		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
 		for (int i = 0; i < 4; i++) {
-			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], &colors[i]);
+			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], colors[i]);
 			place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
@@ -710,14 +710,14 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		draw_sky_body(vertices, -d, d, &c);
+		draw_sky_body(vertices, -d, d, c);
 		place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
 
-void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, float pos_2, const video::SColor *c)
+void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, float pos_2, const video::SColor &c)
 {
 	/*
 	 * Create an array of vertices with the dimensions specified.
@@ -727,10 +727,10 @@ void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, 
 
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
-	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, *c, t, t);
-	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, *c, o, t);
-	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, *c, o, o);
-	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, *c, t, o);
+	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, c, t, t);
+	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, c, o, t);
+	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, c, o, o);
+	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, c, t, o);
 }
 
 

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -723,6 +723,8 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, vid
 	 * Create an array of vertices with the dimensions specified.
 	 * pos_1, pos_2: position of the body's vertices
 	 * c: color of the body
+	 */
+
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -23,18 +23,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "ICameraSceneNode.h"
 #include "S3DVertex.h"
 #include "client/tile.h"
-#include "noise.h"  // easeCurve
+#include "noise.h" // easeCurve
 #include "profiler.h"
 #include "util/numeric.h"
 #include <cmath>
 #include "client/renderingengine.h"
 #include "settings.h"
-#include "camera.h"  // CameraModes
+#include "camera.h" // CameraModes
 
-
-Sky::Sky(s32 id, ITextureSource *tsrc):
-		scene::ISceneNode(RenderingEngine::get_scene_manager()->getRootSceneNode(),
-			RenderingEngine::get_scene_manager(), id)
+Sky::Sky(s32 id, ITextureSource *tsrc) :
+		scene::ISceneNode(
+				RenderingEngine::get_scene_manager()->getRootSceneNode(),
+				RenderingEngine::get_scene_manager(), id)
 {
 	setAutomaticCulling(scene::EAC_OFF);
 	m_box.MaxEdge.set(0, 0, 0);
@@ -58,22 +58,26 @@ Sky::Sky(s32 id, ITextureSource *tsrc):
 	m_materials[0] = mat;
 
 	m_materials[1] = mat;
-	//m_materials[1].MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+	// m_materials[1].MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 	m_materials[1].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 
 	m_materials[2] = mat;
 	m_materials[2].setTexture(0, tsrc->getTextureForMesh("sunrisebg.png"));
 	m_materials[2].MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-	//m_materials[2].MaterialType = video::EMT_TRANSPARENT_ADD_COLOR;
+	// m_materials[2].MaterialType = video::EMT_TRANSPARENT_ADD_COLOR;
 
-	m_sun_texture = tsrc->isKnownSourceImage("sun.png") ?
-		tsrc->getTextureForMesh("sun.png") : NULL;
-	m_moon_texture = tsrc->isKnownSourceImage("moon.png") ?
-		tsrc->getTextureForMesh("moon.png") : NULL;
-	m_sun_tonemap = tsrc->isKnownSourceImage("sun_tonemap.png") ?
-		tsrc->getTexture("sun_tonemap.png") : NULL;
-	m_moon_tonemap = tsrc->isKnownSourceImage("moon_tonemap.png") ?
-		tsrc->getTexture("moon_tonemap.png") : NULL;
+	m_sun_texture = tsrc->isKnownSourceImage("sun.png")
+					? tsrc->getTextureForMesh("sun.png")
+					: NULL;
+	m_moon_texture = tsrc->isKnownSourceImage("moon.png")
+					 ? tsrc->getTextureForMesh("moon.png")
+					 : NULL;
+	m_sun_tonemap = tsrc->isKnownSourceImage("sun_tonemap.png")
+					? tsrc->getTexture("sun_tonemap.png")
+					: NULL;
+	m_moon_tonemap = tsrc->isKnownSourceImage("moon_tonemap.png")
+					 ? tsrc->getTexture("moon_tonemap.png")
+					 : NULL;
 
 	if (m_sun_texture) {
 		m_materials[3] = mat;
@@ -92,17 +96,13 @@ Sky::Sky(s32 id, ITextureSource *tsrc):
 	}
 
 	for (v3f &star : m_stars) {
-		star = v3f(
-			myrand_range(-10000, 10000),
-			myrand_range(-10000, 10000),
-			myrand_range(-10000, 10000)
-		);
+		star = v3f(myrand_range(-10000, 10000), myrand_range(-10000, 10000),
+				myrand_range(-10000, 10000));
 		star.normalize();
 	}
 
 	m_directional_colored_fog = g_settings->getBool("directional_colored_fog");
 }
-
 
 void Sky::OnRegisterSceneNode()
 {
@@ -112,14 +112,13 @@ void Sky::OnRegisterSceneNode()
 	scene::ISceneNode::OnRegisterSceneNode();
 }
 
-
 void Sky::render()
 {
 	if (!m_visible)
 		return;
 
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
-	scene::ICameraSceneNode* camera = SceneManager->getActiveCamera();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
+	scene::ICameraSceneNode *camera = SceneManager->getActiveCamera();
 
 	if (!camera || !driver)
 		return;
@@ -141,9 +140,9 @@ void Sky::render()
 	if (m_sunlight_seen) {
 		float sunsize = 0.07;
 		video::SColorf suncolor_f(1, 1, 0, 1);
-		//suncolor_f.r = 1;
-		//suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.7 + m_time_brightness * 0.5));
-		//suncolor_f.b = MYMAX(0.0, m_brightness * 0.95);
+		// suncolor_f.r = 1;
+		// suncolor_f.g = MYMAX(0.3, MYMIN(1.0, 0.7 + m_time_brightness * 0.5));
+		// suncolor_f.b = MYMAX(0.0, m_brightness * 0.95);
 		video::SColorf suncolor2_f(1, 1, 1, 1);
 		// The values below were probably meant to be suncolor2_f instead of a
 		// reassignment of suncolor_f. However, the resulting colour was chosen
@@ -161,7 +160,8 @@ void Sky::render()
 		float wn = nightlength / 2;
 		float wicked_time_of_day = 0;
 		if (m_time_of_day > wn && m_time_of_day < 1.0 - wn)
-			wicked_time_of_day = (m_time_of_day - wn) / (1.0 - wn * 2) * 0.5 + 0.25;
+			wicked_time_of_day = (m_time_of_day - wn) / (1.0 - wn * 2) * 0.5 +
+					     0.25;
 		else if (m_time_of_day < 0.5)
 			wicked_time_of_day = m_time_of_day / wn * 0.25;
 		else
@@ -175,22 +175,25 @@ void Sky::render()
 		video::SColor mooncolor2 = mooncolor2_f.toSColor();
 
 		// Calculate offset normalized to the X dimension of a 512x1 px tonemap
-		float offset = (1.0 - fabs(sin((m_time_of_day - 0.5) * irr::core::PI))) * 511;
+		float offset = (1.0 - fabs(sin((m_time_of_day - 0.5) * irr::core::PI))) *
+			       511;
 
 		if (m_sun_tonemap) {
-			u8 * texels = (u8 *)m_sun_tonemap->lock();
-			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
-			video::SColor texel_color (255, texel->getRed(),
-				texel->getGreen(), texel->getBlue());
+			u8 *texels = (u8 *)m_sun_tonemap->lock();
+			video::SColor *texel =
+					(video::SColor *)(texels + (u32)offset * 4);
+			video::SColor texel_color(255, texel->getRed(), texel->getGreen(),
+					texel->getBlue());
 			m_sun_tonemap->unlock();
 			m_materials[3].EmissiveColor = texel_color;
 		}
 
 		if (m_moon_tonemap) {
-			u8 * texels = (u8 *)m_moon_tonemap->lock();
-			video::SColor* texel = (video::SColor *)(texels + (u32)offset * 4);
-			video::SColor texel_color (255, texel->getRed(),
-				texel->getGreen(), texel->getBlue());
+			u8 *texels = (u8 *)m_moon_tonemap->lock();
+			video::SColor *texel =
+					(video::SColor *)(texels + (u32)offset * 4);
+			video::SColor texel_color(255, texel->getRed(), texel->getGreen(),
+					texel->getBlue());
 			m_moon_tonemap->unlock();
 			m_materials[4].EmissiveColor = texel_color;
 		}
@@ -206,16 +209,17 @@ void Sky::render()
 
 		// Draw far cloudy fog thing blended with skycolor
 		for (u32 j = 0; j < 4; j++) {
-			video::SColor c = cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
+			video::SColor c =
+					cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
 			vertices[0] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex( 1, 0.12, -1, 0, 0, 1, c, o, o);
+			vertices[1] = video::S3DVertex(1, 0.08, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex(1, 0.12, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, 0.12, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-					// Don't switch
-					{}
-				else if (j == 1)
+				// Don't switch
+				{
+				} else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -232,14 +236,14 @@ void Sky::render()
 		for (u32 j = 0; j < 4; j++) {
 			video::SColor c = cloudyfogcolor;
 			vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, o);
+			vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex(1, 0.08, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-					// Don't switch
-					{}
-				else if (j == 1)
+				// Don't switch
+				{
+				} else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -260,13 +264,14 @@ void Sky::render()
 		do {
 			driver->setMaterial(m_materials[1]);
 			// Tune values so that stars first appear just after the sun
-			// disappears over the horizon, and disappear just before the sun 
+			// disappears over the horizon, and disappear just before the sun
 			// appears over the horizon.
-			// Also tune so that stars are at full brightness from time 20000 to 
-			// time 4000.
-			float starbrightness = MYMAX(0, MYMIN(1,
-				(0.25 - fabs(wicked_time_of_day < 0.5 ?
-				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 20));
+			// Also tune so that stars are at full brightness from time 20000
+			// to time 4000.
+			float starbrightness = MYMAX(0,
+					MYMIN(1, (0.25 - fabs(wicked_time_of_day < 0.5 ? wicked_time_of_day
+										       : (1.0 - wicked_time_of_day))) *
+									20));
 			float f = starbrightness;
 			float d = 0.007 / 2;
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
@@ -313,8 +318,8 @@ void Sky::render()
 				core::CMatrix4<f32> a;
 				a.buildRotateFromTo(v3f(0, 1, 0), r);
 				v3f p = v3f(-d, 1, -d);
-				v3f p1 = v3f( d, 1, -d);
-				v3f p2 = v3f( d, 1, d);
+				v3f p1 = v3f(d, 1, -d);
+				v3f p2 = v3f(d, 1, d);
 				v3f p3 = v3f(-d, 1, d);
 				a.rotateVect(p);
 				a.rotateVect(p1);
@@ -334,25 +339,28 @@ void Sky::render()
 				vertices[i * 4 + 3].Color = starcolor;
 			}
 			driver->drawVertexPrimitiveList(vertices, SKY_STAR_COUNT * 4,
-				indices, SKY_STAR_COUNT, video::EVT_STANDARD,
-				scene::EPT_QUADS, video::EIT_16BIT);
+					indices, SKY_STAR_COUNT, video::EVT_STANDARD,
+					scene::EPT_QUADS, video::EIT_16BIT);
 #endif
-		} while(false);
+		} while (false);
 
-		// Draw sunrise/sunset horizon glow texture (textures/base/pack/sunrisebg.png)
+		// Draw sunrise/sunset horizon glow texture
+		// (textures/base/pack/sunrisebg.png)
 		{
 			driver->setMaterial(m_materials[2]);
 			float mid1 = 0.25;
 			float mid = wicked_time_of_day < 0.5 ? mid1 : (1.0 - mid1);
 			float a_ = 1.0f - std::fabs(wicked_time_of_day - mid) * 35.0f;
 			float a = easeCurve(MYMAX(0, MYMIN(1, a_)));
-			//std::cerr<<"a_="<<a_<<" a="<<a<<std::endl;
+			// std::cerr<<"a_="<<a_<<" a="<<a<<std::endl;
 			video::SColor c(255, 255, 255, 255);
 			float y = -(1.0 - a) * 0.22;
-			vertices[0] = video::S3DVertex(-1, -0.05 + y, -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex( 1, -0.05 + y, -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex( 1,   0.2 + y, -1, 0, 0, 1, c, o, o);
-			vertices[3] = video::S3DVertex(-1,   0.2 + y, -1, 0, 0, 1, c, t, o);
+			vertices[0] = video::S3DVertex(
+					-1, -0.05 + y, -1, 0, 0, 1, c, t, t);
+			vertices[1] = video::S3DVertex(
+					1, -0.05 + y, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex(1, 0.2 + y, -1, 0, 0, 1, c, o, o);
+			vertices[3] = video::S3DVertex(-1, 0.2 + y, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (wicked_time_of_day < 0.5)
 					// Switch from -Z (south) to +X (east)
@@ -366,12 +374,14 @@ void Sky::render()
 
 		// Draw sun
 		if (wicked_time_of_day > 0.15 && wicked_time_of_day < 0.85) {
-			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
+			draw_sun(driver, sunsize, suncolor, suncolor2,
+					wicked_time_of_day);
 		}
 
 		// Draw moon
 		if (wicked_time_of_day < 0.3 || wicked_time_of_day > 0.7) {
-			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
+			draw_moon(driver, moonsize, mooncolor, mooncolor2,
+					wicked_time_of_day);
 		}
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
@@ -380,15 +390,15 @@ void Sky::render()
 
 		for (u32 j = 0; j < 4; j++) {
 			video::SColor c = cloudyfogcolor;
-			vertices[0] = video::S3DVertex(-1, -1.0,  -1, 0, 0, 1, c, t, t);
-			vertices[1] = video::S3DVertex( 1, -1.0,  -1, 0, 0, 1, c, o, t);
-			vertices[2] = video::S3DVertex( 1, -0.02, -1, 0, 0, 1, c, o, o);
+			vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 0, 1, c, t, t);
+			vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 0, 1, c, o, t);
+			vertices[2] = video::S3DVertex(1, -0.02, -1, 0, 0, 1, c, o, o);
 			vertices[3] = video::S3DVertex(-1, -0.02, -1, 0, 0, 1, c, t, o);
 			for (video::S3DVertex &vertex : vertices) {
 				if (j == 0)
-					// Don't switch
-					{}
-				else if (j == 1)
+				// Don't switch
+				{
+				} else if (j == 1)
 					// Switch from -Z (south) to +X (east)
 					vertex.Pos.rotateXZBy(90);
 				else if (j == 2)
@@ -404,17 +414,15 @@ void Sky::render()
 		// Draw bottom far cloudy fog thing in front of sun, moon and stars
 		video::SColor c = cloudyfogcolor;
 		vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 1, 0, c, t, t);
-		vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 1, 0, c, o, t);
-		vertices[2] = video::S3DVertex( 1, -1.0, 1, 0, 1, 0, c, o, o);
+		vertices[1] = video::S3DVertex(1, -1.0, -1, 0, 1, 0, c, o, t);
+		vertices[2] = video::S3DVertex(1, -1.0, 1, 0, 1, 0, c, o, o);
 		vertices[3] = video::S3DVertex(-1, -1.0, 1, 0, 1, 0, c, t, o);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-
-void Sky::update(float time_of_day, float time_brightness,
-		float direct_brightness, bool sunlight_seen,
-		CameraMode cam_mode, float yaw, float pitch)
+void Sky::update(float time_of_day, float time_brightness, float direct_brightness,
+		bool sunlight_seen, CameraMode cam_mode, float yaw, float pitch)
 {
 	// Stabilize initial brightness and color values by flooding updates
 	if (m_first_update) {
@@ -425,7 +433,7 @@ void Sky::update(float time_of_day, float time_brightness,
 		m_first_update = false;
 		for (u32 i = 0; i < 100; i++) {
 			update(time_of_day, time_brightness, direct_brightness,
-				sunlight_seen, cam_mode, yaw, pitch);
+					sunlight_seen, cam_mode, yaw, pitch);
 		}
 		return;
 	}
@@ -441,8 +449,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	Development colours
 
 	video::SColorf bgcolor_bright_normal_f(170. / 255, 200. / 255, 230. / 255, 1.0);
-	video::SColorf bgcolor_bright_dawn_f(0.666, 200. / 255 * 0.7, 230. / 255 * 0.5, 1.0);
-	video::SColorf bgcolor_bright_dawn_f(0.666, 0.549, 0.220, 1.0);
+	video::SColorf bgcolor_bright_dawn_f(0.666, 200. / 255 * 0.7, 230. / 255 *
+	0.5, 1.0); video::SColorf bgcolor_bright_dawn_f(0.666, 0.549, 0.220, 1.0);
 	video::SColorf bgcolor_bright_dawn_f(0.666 * 1.2, 0.549 * 1.0, 0.220 * 1.0, 1.0);
 	video::SColorf bgcolor_bright_dawn_f(0.666 * 1.2, 0.549 * 1.0, 0.220 * 1.2, 1.0);
 
@@ -463,7 +471,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	// pure white: becomes "diffuse light component" for clouds
 	video::SColorf cloudcolor_bright_normal_f = video::SColor(255, 255, 255, 255);
 	// dawn-factoring version of pure white (note: R is above 1.0)
-	video::SColorf cloudcolor_bright_dawn_f(255.0f/240.0f, 223.0f/240.0f, 191.0f/255.0f);
+	video::SColorf cloudcolor_bright_dawn_f(
+			255.0f / 240.0f, 223.0f / 240.0f, 191.0f / 255.0f);
 
 	float cloud_color_change_fraction = 0.95;
 	if (sunlight_seen) {
@@ -485,58 +494,58 @@ void Sky::update(float time_of_day, float time_brightness,
 	if (sunlight_seen) {
 		if (is_dawn) { // Dawn
 			m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-				bgcolor_bright_dawn_f, color_change_fraction);
+					bgcolor_bright_dawn_f, color_change_fraction);
 			m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-				skycolor_bright_dawn_f, color_change_fraction);
+					skycolor_bright_dawn_f, color_change_fraction);
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-				cloudcolor_bright_dawn_f, color_change_fraction);
+					cloudcolor_bright_dawn_f, color_change_fraction);
 		} else {
 			if (time_brightness < 0.13f) { // Night
 				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-					bgcolor_bright_night_f, color_change_fraction);
+						bgcolor_bright_night_f,
+						color_change_fraction);
 				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-					skycolor_bright_night_f, color_change_fraction);
+						skycolor_bright_night_f,
+						color_change_fraction);
 			} else { // Day
 				m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-					bgcolor_bright_normal_f, color_change_fraction);
+						bgcolor_bright_normal_f,
+						color_change_fraction);
 				m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-					skycolor_bright_normal_f, color_change_fraction);
+						skycolor_bright_normal_f,
+						color_change_fraction);
 			}
 
 			m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-				cloudcolor_bright_normal_f, color_change_fraction);
+					cloudcolor_bright_normal_f,
+					color_change_fraction);
 		}
 	} else {
 		m_bgcolor_bright_f = m_bgcolor_bright_f.getInterpolated(
-			bgcolor_bright_indoor_f, color_change_fraction);
+				bgcolor_bright_indoor_f, color_change_fraction);
 		m_skycolor_bright_f = m_skycolor_bright_f.getInterpolated(
-			bgcolor_bright_indoor_f, color_change_fraction);
+				bgcolor_bright_indoor_f, color_change_fraction);
 		m_cloudcolor_bright_f = m_cloudcolor_bright_f.getInterpolated(
-			cloudcolor_bright_normal_f, color_change_fraction);
+				cloudcolor_bright_normal_f, color_change_fraction);
 		m_clouds_visible = false;
 	}
 
 	video::SColor bgcolor_bright = m_bgcolor_bright_f.toSColor();
-	m_bgcolor = video::SColor(
-		255,
-		bgcolor_bright.getRed() * m_brightness,
-		bgcolor_bright.getGreen() * m_brightness,
-		bgcolor_bright.getBlue() * m_brightness
-	);
+	m_bgcolor = video::SColor(255, bgcolor_bright.getRed() * m_brightness,
+			bgcolor_bright.getGreen() * m_brightness,
+			bgcolor_bright.getBlue() * m_brightness);
 
 	video::SColor skycolor_bright = m_skycolor_bright_f.toSColor();
-	m_skycolor = video::SColor(
-		255,
-		skycolor_bright.getRed() * m_brightness,
-		skycolor_bright.getGreen() * m_brightness,
-		skycolor_bright.getBlue() * m_brightness
-	);
+	m_skycolor = video::SColor(255, skycolor_bright.getRed() * m_brightness,
+			skycolor_bright.getGreen() * m_brightness,
+			skycolor_bright.getBlue() * m_brightness);
 
 	// Horizon coloring based on sun and moon direction during sunset and sunrise
 	video::SColor pointcolor = video::SColor(m_bgcolor.getAlpha(), 255, 255, 255);
 	if (m_directional_colored_fog) {
 		if (m_horizon_blend() != 0) {
-			// Calculate hemisphere value from yaw, (inverted in third person front view)
+			// Calculate hemisphere value from yaw, (inverted in third person
+			// front view)
 			s8 dir_factor = 1;
 			if (cam_mode > CAMERA_MODE_THIRD)
 				dir_factor = -1;
@@ -545,11 +554,14 @@ void Sky::update(float time_of_day, float time_brightness,
 				pointcolor_blend = 360 - pointcolor_blend;
 			pointcolor_blend /= 180;
 			// Bound view angle to determine where transition starts and ends
-			pointcolor_blend = rangelim(1 - pointcolor_blend * 1.375, 0, 1 / 1.375) *
-				1.375;
-			// Combine the colors when looking up or down, otherwise turning looks weird
+			pointcolor_blend = rangelim(1 - pointcolor_blend * 1.375, 0,
+							   1 / 1.375) *
+					   1.375;
+			// Combine the colors when looking up or down, otherwise turning
+			// looks weird
 			pointcolor_blend += (0.5 - pointcolor_blend) *
-				(1 - MYMIN((90 - std::fabs(pitch)) / 90 * 1.5, 1));
+					    (1 - MYMIN((90 - std::fabs(pitch)) / 90 * 1.5,
+								 1));
 			// Invert direction to match where the sun and moon are rising
 			if (m_time_of_day > 0.5)
 				pointcolor_blend = 1 - pointcolor_blend;
@@ -558,87 +570,124 @@ void Sky::update(float time_of_day, float time_brightness,
 
 			video::SColorf pointcolor_sun_f(1, 1, 1, 1);
 			if (m_sun_tonemap) {
-				pointcolor_sun_f.r = pointcolor_light *
-					(float)m_materials[3].EmissiveColor.getRed() / 255;
-				pointcolor_sun_f.b = pointcolor_light *
-					(float)m_materials[3].EmissiveColor.getBlue() / 255;
+				pointcolor_sun_f.r =
+						pointcolor_light *
+						(float)m_materials[3]
+								.EmissiveColor.getRed() /
+						255;
+				pointcolor_sun_f.b =
+						pointcolor_light *
+						(float)m_materials[3]
+								.EmissiveColor.getBlue() /
+						255;
 				pointcolor_sun_f.g = pointcolor_light *
-					(float)m_materials[3].EmissiveColor.getGreen() / 255;
+						     (float)m_materials[3]
+								     .EmissiveColor
+								     .getGreen() /
+						     255;
 			} else {
 				pointcolor_sun_f.r = pointcolor_light * 1;
-				pointcolor_sun_f.b = pointcolor_light *
-					(0.25 + (rangelim(m_time_brightness, 0.25, 0.75) - 0.25) * 2 * 0.75);
-				pointcolor_sun_f.g = pointcolor_light * (pointcolor_sun_f.b * 0.375 +
-					(rangelim(m_time_brightness, 0.05, 0.15) - 0.05) * 10 * 0.625);
+				pointcolor_sun_f.b =
+						pointcolor_light *
+						(0.25 + (rangelim(m_time_brightness, 0.25,
+									 0.75) -
+									0.25) * 2 *
+										0.75);
+				pointcolor_sun_f.g =
+						pointcolor_light *
+						(pointcolor_sun_f.b * 0.375 +
+								(rangelim(m_time_brightness,
+										 0.05,
+										 0.15) -
+										0.05) *
+										10 *
+										0.625);
 			}
 
 			video::SColorf pointcolor_moon_f(0.5 * pointcolor_light,
-				0.6 * pointcolor_light, 0.8 * pointcolor_light, 1);
+					0.6 * pointcolor_light, 0.8 * pointcolor_light,
+					1);
 			if (m_moon_tonemap) {
-				pointcolor_moon_f.r = pointcolor_light *
-					(float)m_materials[4].EmissiveColor.getRed() / 255;
-				pointcolor_moon_f.b = pointcolor_light *
-					(float)m_materials[4].EmissiveColor.getBlue() / 255;
+				pointcolor_moon_f.r =
+						pointcolor_light *
+						(float)m_materials[4]
+								.EmissiveColor.getRed() /
+						255;
+				pointcolor_moon_f.b =
+						pointcolor_light *
+						(float)m_materials[4]
+								.EmissiveColor.getBlue() /
+						255;
 				pointcolor_moon_f.g = pointcolor_light *
-					(float)m_materials[4].EmissiveColor.getGreen() / 255;
+						      (float)m_materials[4]
+								      .EmissiveColor
+								      .getGreen() /
+						      255;
 			}
 
 			video::SColor pointcolor_sun = pointcolor_sun_f.toSColor();
 			video::SColor pointcolor_moon = pointcolor_moon_f.toSColor();
 			// Calculate the blend color
-			pointcolor = m_mix_scolor(pointcolor_moon, pointcolor_sun, pointcolor_blend);
+			pointcolor = m_mix_scolor(pointcolor_moon, pointcolor_sun,
+					pointcolor_blend);
 		}
 		m_bgcolor = m_mix_scolor(m_bgcolor, pointcolor, m_horizon_blend() * 0.5);
-		m_skycolor = m_mix_scolor(m_skycolor, pointcolor, m_horizon_blend() * 0.25);
+		m_skycolor = m_mix_scolor(
+				m_skycolor, pointcolor, m_horizon_blend() * 0.25);
 	}
 
 	float cloud_direct_brightness = 0.0f;
 	if (sunlight_seen) {
 		if (!m_directional_colored_fog) {
 			cloud_direct_brightness = time_brightness;
-			// Boost cloud brightness relative to sky, at dawn, dusk and at night
+			// Boost cloud brightness relative to sky, at dawn, dusk and at
+			// night
 			if (time_brightness < 0.7f)
 				cloud_direct_brightness *= 1.3f;
 		} else {
-			cloud_direct_brightness = std::fmin(m_horizon_blend() * 0.15f +
-				m_time_brightness, 1.0f);
+			cloud_direct_brightness = std::fmin(
+					m_horizon_blend() * 0.15f + m_time_brightness,
+					1.0f);
 			// Set the same minimum cloud brightness at night
 			if (time_brightness < 0.5f)
-				cloud_direct_brightness = std::fmax(cloud_direct_brightness,
-					time_brightness * 1.3f);
+				cloud_direct_brightness =
+						std::fmax(cloud_direct_brightness,
+								time_brightness * 1.3f);
 		}
 	} else {
 		cloud_direct_brightness = direct_brightness;
 	}
 
-	m_cloud_brightness = m_cloud_brightness * cloud_color_change_fraction +
-		cloud_direct_brightness * (1.0 - cloud_color_change_fraction);
-	m_cloudcolor_f = video::SColorf(
-		m_cloudcolor_bright_f.r * m_cloud_brightness,
-		m_cloudcolor_bright_f.g * m_cloud_brightness,
-		m_cloudcolor_bright_f.b * m_cloud_brightness,
-		1.0
-	);
+	m_cloud_brightness =
+			m_cloud_brightness * cloud_color_change_fraction +
+			cloud_direct_brightness * (1.0 - cloud_color_change_fraction);
+	m_cloudcolor_f = video::SColorf(m_cloudcolor_bright_f.r * m_cloud_brightness,
+			m_cloudcolor_bright_f.g * m_cloud_brightness,
+			m_cloudcolor_bright_f.b * m_cloud_brightness, 1.0);
 	if (m_directional_colored_fog) {
-		m_cloudcolor_f = m_mix_scolorf(m_cloudcolor_f,
-			video::SColorf(pointcolor), m_horizon_blend() * 0.25);
+		m_cloudcolor_f = m_mix_scolorf(m_cloudcolor_f, video::SColorf(pointcolor),
+				m_horizon_blend() * 0.25);
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day) {
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
+		video::SColor suncolor2, float wicked_time_of_day)
+{
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 4> sunsizes = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
+		const std::array<float, 4> sunsizes = {
+				sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
 		video::SColor c1 = suncolor;
 		video::SColor c2 = suncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
 		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
-		for (int i = 0; i<4; i++) {
+		for (int i = 0; i < 4; i++) {
 			vertices = draw_sky_body(-sunsizes[i], sunsizes[i], colors[i]);
-			vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
+			vertices = place_sky_body(
+					vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -646,31 +695,37 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		float d = sunsize * 1.7;
 		video::SColor c;
 		if (m_sun_tonemap)
-			c = video::SColor (0, 0, 0, 0);
+			c = video::SColor(0, 0, 0, 0);
 		else
-			c = video::SColor (255, 255, 255, 255);
+			c = video::SColor(255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
+		video::SColor mooncolor2, float wicked_time_of_day)
+{
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
 	if (!m_moon_texture) {
 		driver->setMaterial(m_materials[1]);
-		const std::array<float, 4> moonsizes_1 = {-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
-		const std::array<float, 4> moonsizes_2 = {moonsize * 1.9f, moonsize * 1.3f, moonsize, moonsize * 0.6f};
+		const std::array<float, 4> moonsizes_1 = {
+				-moonsize * 1.9f, -moonsize * 1.3f, -moonsize, -moonsize};
+		const std::array<float, 4> moonsizes_2 = {moonsize * 1.9f,
+				moonsize * 1.3f, moonsize, moonsize * 0.6f};
 		video::SColor c1 = mooncolor;
 		video::SColor c2 = mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const std::array<video::SColor, 4> colors = {c1, c2, mooncolor, mooncolor2};
-		for (int i = 0; i<4; i++) {
-			vertices = draw_sky_body(moonsizes_1[i], moonsizes_2[i], colors[i]);
-			vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
+		const std::array<video::SColor, 4> colors = {
+				c1, c2, mooncolor, mooncolor2};
+		for (int i = 0; i < 4; i++) {
+			vertices = draw_sky_body(
+					moonsizes_1[i], moonsizes_2[i], colors[i]);
+			vertices = place_sky_body(
+					vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
@@ -678,17 +733,18 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 		float d = moonsize * 1.9;
 		video::SColor c;
 		if (m_moon_tonemap)
-			c = video::SColor (0, 0, 0, 0);
+			c = video::SColor(0, 0, 0, 0);
 		else
-			c = video::SColor (255, 255, 255, 255);
+			c = video::SColor(255, 255, 255, 255);
 		vertices = draw_sky_body(-d, d, c);
 		vertices = place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
-
-std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c) {
+std::array<video::S3DVertex, 4> Sky::draw_sky_body(
+		float pos_1, float pos_2, video::SColor c)
+{
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
@@ -699,8 +755,10 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, vid
 	return vertices;
 }
 
-
-std::array<video::S3DVertex, 4> Sky::place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position) {
+std::array<video::S3DVertex, 4> Sky::place_sky_body(
+		std::array<video::S3DVertex, 4> vertices, float horizon_position,
+		float day_position)
+{
 	for (video::S3DVertex &vertex : vertices) {
 		// Switch from -Z (south) to -X (west)
 		vertex.Pos.rotateXZBy(horizon_position);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -631,7 +631,7 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 	static const u16 indices[4] = {0, 1, 2, 3};
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
-	std::array<video::S3DVertex, 4> vertices2;
+	std::array<video::S3DVertex, 4> vertices;
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
 		const std::array<float, 4> sunsizes = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
@@ -642,8 +642,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 		const std::array<video::SColor, 4> colors = {c1, c2, suncolor, suncolor2};
 		for (int i = 0; i<4; i++) {
 
-			vertices2 = draw_aster(wicked_time_of_day, sunsizes[i], colors[i], t, o);
-			driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+			vertices = draw_aster(wicked_time_of_day, sunsizes[i], colors[i], t, o);
+			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
 	} else {
 		driver->setMaterial(m_materials[3]);
@@ -653,8 +653,8 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 			c = video::SColor (0, 0, 0, 0);
 		else
 			c = video::SColor (255, 255, 255, 255);
-		vertices2 = draw_aster(wicked_time_of_day, d, c, t, o);
-		driver->drawIndexedTriangleFan(&vertices2[0], 4, indices, 2);
+		vertices = draw_aster(wicked_time_of_day, d, c, t, o);
+		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day) {

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -627,6 +627,13 @@ void Sky::update(float time_of_day, float time_brightness,
 
 void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
 	video::SColor suncolor2, float wicked_time_of_day)
+	/* Draw sun in the sky.
+	 * driver: Video driver object used to draw
+	 * sunsize: the default size of the sun
+	 * suncolor: main sun color
+	 * suncolor2: second sun color
+	 * wicked_time_of_day: current time of day, to know where should be the sun in the sky
+	 */
 {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
@@ -660,6 +667,14 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor sun
 
 void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
 	video::SColor mooncolor2, float wicked_time_of_day)
+	/*
+	 * Draw moon in the sky.
+	 * driver: Video driver object used to draw
+	 * moonsize: the default size of the moon
+	 * mooncolor: main moon color
+	 * mooncolor2: second moon color
+	 * wicked_time_of_day: current time of day, to know where should be the moon in the sky
+	 */
 {
 	static const u16 indices[4] = {0, 1, 2, 3};
 	std::array<video::S3DVertex, 4> vertices;
@@ -704,6 +719,10 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor m
 
 std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, video::SColor c)
 {
+	/*
+	 * Create an array of vertices with the dimensions specified.
+	 * pos_1, pos_2: position of the body's vertices
+	 * c: color of the body
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
 	std::array<video::S3DVertex, 4> vertices;
@@ -717,6 +736,12 @@ std::array<video::S3DVertex, 4> Sky::draw_sky_body(float pos_1, float pos_2, vid
 
 std::array<video::S3DVertex, 4> Sky::place_sky_body(
 	std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position)
+	/*
+	 * Place body in the sky.
+	 * vertices: The body as a rectangle of 4 vertices
+	 * horizon_position: turn the body around the Y axis
+	 * day_position: turn the body around the Z axis, to place it depending of the time of the day
+	 */
 {
 	for (video::S3DVertex &vertex : vertices) {
 		// Body is directed to -Z (south) by default

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -366,12 +366,12 @@ void Sky::render()
 
 		// Draw sun
 		if (wicked_time_of_day > 0.15 && wicked_time_of_day < 0.85) {
-			draw_sun(driver, sunsize, suncolor, suncolor2, wicked_time_of_day);
+			draw_sun(driver, sunsize, &suncolor, &suncolor2, wicked_time_of_day);
 		}
 
 		// Draw moon
 		if (wicked_time_of_day < 0.3 || wicked_time_of_day > 0.7) {
-			draw_moon(driver, moonsize, mooncolor, mooncolor2, wicked_time_of_day);
+			draw_moon(driver, moonsize, &mooncolor, &mooncolor2, wicked_time_of_day);
 		}
 
 		// Draw far cloudy fog thing below all horizons in front of sun, moon
@@ -625,8 +625,8 @@ void Sky::update(float time_of_day, float time_brightness,
 	}
 }
 
-void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor suncolor,
-	const video::SColor suncolor2, float wicked_time_of_day)
+void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor *suncolor,
+	const video::SColor *suncolor2, float wicked_time_of_day)
 	/* Draw sun in the sky.
 	 * driver: Video driver object used to draw
 	 * sunsize: the default size of the sun
@@ -640,13 +640,13 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 	if (!m_sun_texture) {
 		driver->setMaterial(m_materials[1]);
 		const float sunsizes[4] = {sunsize * 1.7f, sunsize * 1.2f, sunsize, sunsize * 0.7f};
-		video::SColor c1 = suncolor;
-		video::SColor c2 = suncolor;
+		video::SColor c1 = *suncolor;
+		video::SColor c2 = *suncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {c1, c2, suncolor, suncolor2};
+		const video::SColor colors[4] = {c1, c2, *suncolor, *suncolor2};
 		for (int i = 0; i < 4; i++) {
-			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], colors[i]);
+			draw_sky_body(vertices, -sunsizes[i], sunsizes[i], &colors[i]);
 			place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
@@ -658,15 +658,15 @@ void Sky::draw_sun(video::IVideoDriver *driver, float sunsize, const video::SCol
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		draw_sky_body(vertices, -d, d, c);
+		draw_sky_body(vertices, -d, d, &c);
 		place_sky_body(vertices, 90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
 
-void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor mooncolor,
-	const video::SColor mooncolor2, float wicked_time_of_day)
+void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor *mooncolor,
+	const video::SColor *mooncolor2, float wicked_time_of_day)
 	/*
 	 * Draw moon in the sky.
 	 * driver: Video driver object used to draw
@@ -692,13 +692,13 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 				moonsize,
 				moonsize * 0.6f
 			};
-		video::SColor c1 = mooncolor;
-		video::SColor c2 = mooncolor;
+		video::SColor c1 = *mooncolor;
+		video::SColor c2 = *mooncolor;
 		c1.setAlpha(0.05 * 255);
 		c2.setAlpha(0.15 * 255);
-		const video::SColor colors[4] = {c1, c2, mooncolor, mooncolor2};
+		const video::SColor colors[4] = {c1, c2, *mooncolor, *mooncolor2};
 		for (int i = 0; i < 4; i++) {
-			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], colors[i]);
+			draw_sky_body(vertices, moonsizes_1[i], moonsizes_2[i], &colors[i]);
 			place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 			driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 		}
@@ -710,14 +710,14 @@ void Sky::draw_moon(video::IVideoDriver *driver, float moonsize, const video::SC
 			c = video::SColor(0, 0, 0, 0);
 		else
 			c = video::SColor(255, 255, 255, 255);
-		draw_sky_body(vertices, -d, d, c);
+		draw_sky_body(vertices, -d, d, &c);
 		place_sky_body(vertices, -90, wicked_time_of_day * 360 - 90);
 		driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
 	}
 }
 
 
-void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, float pos_2, const video::SColor c)
+void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, float pos_2, const video::SColor *c)
 {
 	/*
 	 * Create an array of vertices with the dimensions specified.
@@ -727,10 +727,10 @@ void Sky::draw_sky_body(std::array<video::S3DVertex, 4> &vertices, float pos_1, 
 
 	const f32 t = 1.0f;
 	const f32 o = 0.0f;
-	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, c, t, t);
-	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, c, o, t);
-	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, c, o, o);
-	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, c, t, o);
+	vertices[0] = video::S3DVertex(pos_1, pos_1, -1, 0, 0, 1, *c, t, t);
+	vertices[1] = video::S3DVertex(pos_2, pos_1, -1, 0, 0, 1, *c, o, t);
+	vertices[2] = video::S3DVertex(pos_2, pos_2, -1, 0, 0, 1, *c, o, o);
+	vertices[3] = video::S3DVertex(pos_1, pos_2, -1, 0, 0, 1, *c, t, o);
 }
 
 

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,12 +146,12 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor *suncolor,
-			const video::SColor *suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor *mooncolor,
-			const video::SColor *mooncolor2, float wicked_time_of_day);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor &suncolor,
+			const video::SColor &suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor &mooncolor,
+			const video::SColor &mooncolor2, float wicked_time_of_day);
 	void draw_sky_body(std::array<video::S3DVertex, 4> &vertices,
-			float pos_1, float pos_2, const video::SColor *c);
+			float pos_1, float pos_2, const video::SColor &c);
 	void place_sky_body(
 			std::array<video::S3DVertex, 4> &vertices, float horizon_position,
 			float day_position);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -150,9 +150,9 @@ private:
 			const video::SColor suncolor2, float wicked_time_of_day);
 	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor mooncolor,
 			const video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_sky_body(
+	void draw_sky_body(std::array<video::S3DVertex, 4> &vertices,
 			float pos_1, float pos_2, const video::SColor c);
-	std::array<video::S3DVertex, 4> place_sky_body(
-			std::array<video::S3DVertex, 4> vertices, float horizon_position,
+	void place_sky_body(
+			std::array<video::S3DVertex, 4> &vertices, float horizon_position,
 			float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,4 +146,6 @@ private:
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
 	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
+	std::array<video::S3DVertex, 4> draw_aster(float wicked_time_of_day, float d, video::SColor c, const f32 t, const f32 o);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -147,6 +147,6 @@ private:
 	video::ITexture *m_moon_tonemap;
 	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
 	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_aster(float pos_1, float pos_2, video::SColor c);
-	std::array<video::S3DVertex, 4> place_aster(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
+	std::array<video::S3DVertex, 4> draw_sky_body(float pos_1, float pos_2, video::SColor c);
+	std::array<video::S3DVertex, 4> place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -151,8 +151,8 @@ private:
 	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
 			video::SColor mooncolor2, float wicked_time_of_day);
 	std::array<video::S3DVertex, 4> draw_sky_body(
-					float pos_1, float pos_2, video::SColor c);
+			float pos_1, float pos_2, video::SColor c);
 	std::array<video::S3DVertex, 4> place_sky_body(
-					std::array<video::S3DVertex, 4> vertices, float horizon_position,
-					float day_position);
+			std::array<video::S3DVertex, 4> vertices, float horizon_position,
+			float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -145,4 +145,5 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
+	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,12 +146,12 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
-			video::SColor suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
-			video::SColor mooncolor2, float wicked_time_of_day);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor suncolor,
+			const video::SColor suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor mooncolor,
+			const video::SColor mooncolor2, float wicked_time_of_day);
 	std::array<video::S3DVertex, 4> draw_sky_body(
-			float pos_1, float pos_2, video::SColor c);
+			float pos_1, float pos_2, const video::SColor c);
 	std::array<video::S3DVertex, 4> place_sky_body(
 			std::array<video::S3DVertex, 4> vertices, float horizon_position,
 			float day_position);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -147,6 +147,6 @@ private:
 	video::ITexture *m_moon_tonemap;
 	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
 	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_aster(float d, video::SColor c);
+	std::array<video::S3DVertex, 4> draw_aster(float pos_1, float pos_2, video::SColor c);
 	std::array<video::S3DVertex, 4> place_aster(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <ISceneNode.h>
+#include <array>
 #include "camera.h"
 #include "irrlichttypes_extrabloated.h"
 

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -147,5 +147,6 @@ private:
 	video::ITexture *m_moon_tonemap;
 	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
 	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_aster(float wicked_time_of_day, float d, video::SColor c, const f32 t, const f32 o);
+	std::array<video::S3DVertex, 4> draw_aster(float d, video::SColor c);
+	std::array<video::S3DVertex, 4> place_aster(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,12 +146,12 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor suncolor,
-			const video::SColor suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor mooncolor,
-			const video::SColor mooncolor2, float wicked_time_of_day);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, const video::SColor *suncolor,
+			const video::SColor *suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, const video::SColor *mooncolor,
+			const video::SColor *mooncolor2, float wicked_time_of_day);
 	void draw_sky_body(std::array<video::S3DVertex, 4> &vertices,
-			float pos_1, float pos_2, const video::SColor c);
+			float pos_1, float pos_2, const video::SColor *c);
 	void place_sky_body(
 			std::array<video::S3DVertex, 4> &vertices, float horizon_position,
 			float day_position);

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,8 +146,13 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_sky_body(float pos_1, float pos_2, video::SColor c);
-	std::array<video::S3DVertex, 4> place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
+			video::SColor suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor,
+			video::SColor mooncolor2, float wicked_time_of_day);
+	std::array<video::S3DVertex, 4> draw_sky_body(
+					float pos_1, float pos_2, video::SColor c);
+	std::array<video::S3DVertex, 4> place_sky_body(
+					std::array<video::S3DVertex, 4> vertices, float horizon_position,
+					float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,14 +146,8 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
-			video::SColor suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize,
-			video::SColor mooncolor, video::SColor mooncolor2,
-			float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_sky_body(
-			float pos_1, float pos_2, video::SColor c);
-	std::array<video::S3DVertex, 4> place_sky_body(
-			std::array<video::S3DVertex, 4> vertices, float horizon_position,
-			float day_position);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
+	std::array<video::S3DVertex, 4> draw_sky_body(float pos_1, float pos_2, video::SColor c);
+	std::array<video::S3DVertex, 4> place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
 };

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -146,8 +146,14 @@ private:
 	video::ITexture *m_moon_texture;
 	video::ITexture *m_sun_tonemap;
 	video::ITexture *m_moon_tonemap;
-	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor, video::SColor suncolor2, float wicked_time_of_day);
-	void draw_moon(video::IVideoDriver *driver, float moonsize, video::SColor mooncolor, video::SColor mooncolor2, float wicked_time_of_day);
-	std::array<video::S3DVertex, 4> draw_sky_body(float pos_1, float pos_2, video::SColor c);
-	std::array<video::S3DVertex, 4> place_sky_body(std::array<video::S3DVertex, 4> vertices, float horizon_position, float day_position);
+	void draw_sun(video::IVideoDriver *driver, float sunsize, video::SColor suncolor,
+			video::SColor suncolor2, float wicked_time_of_day);
+	void draw_moon(video::IVideoDriver *driver, float moonsize,
+			video::SColor mooncolor, video::SColor mooncolor2,
+			float wicked_time_of_day);
+	std::array<video::S3DVertex, 4> draw_sky_body(
+			float pos_1, float pos_2, video::SColor c);
+	std::array<video::S3DVertex, 4> place_sky_body(
+			std::array<video::S3DVertex, 4> vertices, float horizon_position,
+			float day_position);
 };


### PR DESCRIPTION
This PR is just refactoring. You won't see changes in your game. However, this will ease further feature implementation.

- The goal is to refactor the drawing of sun and moon in the sky

The drawing of sun and moon was in a big method called `render` in `src/client/sky.cpp`. Now, there is new methods `draw_sun` and `draw_moon` that do the job. There are also `draw_sky_body` and `place_sky_body` that create and set the position for the vertices of sun and moon. There are just there to reduce the amount of duplicated code. Feel free to find better names.

## To do

Ready for Review.

- [x] Write doc for thes changes


## How to test

The tests to do: run the game and check sun and moon are well displayed.
Set a texture for sun and moon, and check they're used and well displayed.