### PR TITLE
Player knockback and add_player_velocity API

### DIFF
--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -33,5 +33,6 @@ dofile(gamepath .. "features.lua")
 dofile(gamepath .. "voxelarea.lua")
 dofile(gamepath .. "forceloading.lua")
 dofile(gamepath .. "statbars.lua")
+dofile(gamepath .. "knockback.lua")
 
 profiler = nil

--- a/builtin/game/knockback.lua
+++ b/builtin/game/knockback.lua
@@ -1,0 +1,46 @@
+-- can be overriden by mods
+function core.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, distance, damage)
+	if damage == 0 or player:get_armor_groups().immortal then
+		return 0.0
+	end
+
+	local m = 8
+	-- solve m - m*e^(k*4) = 4 for k
+	local k = -0.17328
+	local res = m - m * math.exp(k * damage)
+
+	if distance < 2.0 then
+		res = res * 1.1 -- more knockback when closer
+	elseif distance > 4.0 then
+		res = res * 0.9 -- less when far away
+	end
+	return res
+end
+
+local function vector_absmax(v)
+	local max, abs = math.max, math.abs
+	return max(max(abs(v.x), abs(v.y)), abs(v.z))
+end
+
+core.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, unused_dir, damage)
+	if player:get_hp() == 0 then
+		return -- RIP
+	end
+
+	-- Server::handleCommand_Interact() adds eye offset to one but not the other
+	-- so the direction is slightly off, calculate it ourselves
+	local dir = vector.subtract(player:get_pos(), hitter:get_pos())
+	local d = vector.length(dir)
+	if d ~= 0.0 then
+		dir = vector.divide(dir, d)
+	end
+
+	local k = core.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, d, damage)
+
+	local kdir = vector.multiply(dir, k)
+	if vector_absmax(kdir) < 1.0 then
+		return -- barely noticeable, so don't even send
+	end
+
+	player:add_player_velocity(kdir)
+end)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5465,6 +5465,14 @@ This is basically a reference to a C++ `ServerActiveObject`
 * `get_player_name()`: returns `""` if is not a player
 * `get_player_velocity()`: returns `nil` if is not a player, otherwise a
   table {x, y, z} representing the player's instantaneous velocity in nodes/s
+* `add_player_velocity(vel)`
+    * Adds to player velocity, this happens client-side and only once.
+    * Does not apply during free_move.
+    * Note that since the player speed is normalized at each move step,
+      increasing e.g. Y velocity beyond what would usually be achieved
+      (see: physics overrides) will cause existing X/Z velocity to be reduced.
+    * Example: `add_player_velocity({x=0, y=6.5, z=0})` is equivalent to
+      pressing the jump key (assuming default settings)
 * `get_look_dir()`: get camera direction as a unit vector
 * `get_look_vertical()`: pitch in radians
     * Angle ranges between -pi/2 and pi/2, which are straight up and down

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5019,6 +5019,15 @@ Misc.
       of the creative mode setting, checks for "sneak" to set the `invert_wall`
       parameter and `prevent_after_place` set to `true`.
 
+* `minetest.calculate_knockback(player, hitter, time_from_last_punch,
+  tool_capabilities, dir, distance, damage)`
+    * Returns the amount of knockback applied on the punched player.
+    * Arguments are equivalent to `register_on_punchplayer`, except the following:
+        * `distance`: distance between puncher and punched player
+    * This function can be overriden by mods that wish to modify this behaviour.
+    * You may want to cache and call the old function to allow multiple mods to
+      change knockback behaviour.
+
 * `minetest.forceload_block(pos[, transient])`
     * forceloads the position `pos`.
     * returns `true` if area could be forceloaded

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -227,6 +227,7 @@ public:
 	void handleCommand_SrpBytesSandB(NetworkPacket *pkt);
 	void handleCommand_FormspecPrepend(NetworkPacket *pkt);
 	void handleCommand_CSMRestrictionFlags(NetworkPacket *pkt);
+	void handleCommand_PlayerSpeed(NetworkPacket *pkt);
 
 	void ProcessData(NetworkPacket *pkt);
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -188,6 +188,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Copy parent position if local player is attached
 	if (isAttached) {
 		setPosition(overridePosition);
+		added_velocity = v3f(); // ignored
 		return;
 	}
 
@@ -201,8 +202,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (noclip && free_move) {
 		position += m_speed * dtime;
 		setPosition(position);
+		added_velocity = v3f(); // ignored
 		return;
 	}
+
+	m_speed += added_velocity;
+	added_velocity = v3f();
 
 	/*
 		Collision detection
@@ -782,6 +787,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (isAttached) {
 		setPosition(overridePosition);
 		m_sneak_node_exists = false;
+		added_velocity = v3f();
 		return;
 	}
 
@@ -795,8 +801,12 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		position += m_speed * dtime;
 		setPosition(position);
 		m_sneak_node_exists = false;
+		added_velocity = v3f();
 		return;
 	}
+
+	m_speed += added_velocity;
+	added_velocity = v3f();
 
 	/*
 		Collision detection

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -149,6 +149,11 @@ public:
 
 	bool getAutojump() const { return m_autojump; }
 
+	inline void addVelocity(const v3f &vel)
+	{
+		added_velocity += vel;
+	}
+
 private:
 	void accelerate(const v3f &target_speed, const f32 max_increase_H,
 			const f32 max_increase_V, const bool use_pitch);
@@ -194,6 +199,7 @@ private:
 	float m_zoom_fov = 0.0f;
 	bool m_autojump = false;
 	float m_autojump_time = 0.0f;
+	v3f added_velocity = v3f(0.0f, 0.0f, 0.0f); // cleared on each move()
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -322,6 +322,7 @@ public:
 	{
 		return m_dig_pool;
 	}
+	void setMaxSpeedOverride(const v3f &vel);
 	// Returns true if cheated
 	bool checkMovementCheat();
 
@@ -361,6 +362,8 @@ private:
 	float m_time_from_last_punch = 0.0f;
 	v3s16 m_nocheat_dig_pos = v3s16(32767, 32767, 32767);
 	float m_nocheat_dig_time = 0.0f;
+	float m_max_speed_override_time = 0.0f;
+	v3f m_max_speed_override = v3f(0.0f, 0.0f, 0.0f);
 
 	// Timers
 	IntervalLimiter m_breathing_interval;

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -67,7 +67,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_handler,
 	{ "TOCLIENT_TIME_OF_DAY",              TOCLIENT_STATE_CONNECTED, &Client::handleCommand_TimeOfDay }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    TOCLIENT_STATE_CONNECTED, &Client::handleCommand_CSMRestrictionFlags }, // 0x2A
-	null_command_handler,
+	{ "TOCLIENT_PLAYER_SPEED",             TOCLIENT_STATE_CONNECTED, &Client::handleCommand_PlayerSpeed }, // 0x2B
 	null_command_handler,
 	null_command_handler,
 	null_command_handler,

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1383,6 +1383,17 @@ void Client::handleCommand_CSMRestrictionFlags(NetworkPacket *pkt)
 	loadMods();
 }
 
+void Client::handleCommand_PlayerSpeed(NetworkPacket *pkt)
+{
+	v3f added_vel;
+
+	*pkt >> added_vel;
+
+	LocalPlayer *player = m_env.getLocalPlayer();
+	assert(player != NULL);
+	player->addVelocity(added_vel);
+}
+
 /*
  * Mod channels
  */

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -194,6 +194,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		New network float format
 		ContentFeatures version 13
 		Add full Euler rotations instead of just yaw
+		Add TOCLIENT_PLAYER_SPEED
 */
 
 #define LATEST_PROTOCOL_VERSION 37
@@ -293,6 +294,11 @@ enum ToClientCommand
 	TOCLIENT_CSM_RESTRICTION_FLAGS = 0x2A,
 	/*
 		u32 CSMRestrictionFlags byteflag
+	 */
+
+	TOCLIENT_PLAYER_SPEED = 0x2B,
+	/*
+		v3f added_vel
 	 */
 
 	// (oops, there is some gap here)

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -156,7 +156,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	null_command_factory,
 	{ "TOCLIENT_TIME_OF_DAY",              0, true }, // 0x29
 	{ "TOCLIENT_CSM_RESTRICTION_FLAGS",    0, true }, // 0x2A
-	null_command_factory,
+	{ "TOCLIENT_PLAYER_SPEED",             0, true }, // 0x2B
 	null_command_factory,
 	null_command_factory,
 	null_command_factory,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1092,6 +1092,27 @@ int ObjectRef::l_get_player_velocity(lua_State *L)
 	return 1;
 }
 
+// add_player_velocity(self, {x=num, y=num, z=num})
+int ObjectRef::l_add_player_velocity(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	v3f vel = checkFloatPos(L, 2);
+
+	RemotePlayer *player = getplayer(ref);
+	PlayerSAO *co = getplayersao(ref);
+	if (!player || !co)
+		return 0;
+
+	session_t peer_id = player->getPeerId();
+	if (peer_id == PEER_ID_INEXISTENT)
+		return 0;
+	// Do it
+	co->setMaxSpeedOverride(vel);
+	getServer(L)->SendPlayerSpeed(peer_id, vel);
+	return 0;
+}
+
 // get_look_dir(self)
 int ObjectRef::l_get_look_dir(lua_State *L)
 {
@@ -1931,6 +1952,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, is_player_connected),
 	luamethod(ObjectRef, get_player_name),
 	luamethod(ObjectRef, get_player_velocity),
+	luamethod(ObjectRef, add_player_velocity),
 	luamethod(ObjectRef, get_look_dir),
 	luamethod(ObjectRef, get_look_pitch),
 	luamethod(ObjectRef, get_look_yaw),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -212,6 +212,9 @@ private:
 	// get_player_velocity(self)
 	static int l_get_player_velocity(lua_State *L);
 
+	// add_player_velocity(self, {x=num, y=num, z=num})
+	static int l_add_player_velocity(lua_State *L);
+
 	// get_look_dir(self)
 	static int l_get_look_dir(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1958,6 +1958,13 @@ void Server::SendCSMRestrictionFlags(session_t peer_id)
 	Send(&pkt);
 }
 
+void Server::SendPlayerSpeed(session_t peer_id, const v3f &added_vel)
+{
+	NetworkPacket pkt(TOCLIENT_PLAYER_SPEED, 0, peer_id);
+	pkt << added_vel;
+	Send(&pkt);
+}
+
 s32 Server::playSound(const SimpleSoundSpec &spec,
 		const ServerSoundParams &params)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -335,6 +335,7 @@ public:
 	void SendPlayerBreath(PlayerSAO *sao);
 	void SendInventory(PlayerSAO* playerSAO);
 	void SendMovePlayer(session_t peer_id);
+	void SendPlayerSpeed(session_t peer_id, const v3f &added_vel);
 
 	virtual bool registerModStorage(ModMetadata *storage);
 	virtual void unregisterModStorage(const std::string &name);


### PR DESCRIPTION
implements: #2394 #2960
replaces: #5679 #6489
**don't squash**

## To do

This PR is Ready for Review.

Not implemented:
- suggestion from https://github.com/minetest/minetest/pull/5679#issuecomment-298226660 to use tool/armor groups to determine knockback
- knockback for entities (possibly doable using interpolated move)

## How to test

Punch another player with different kinds of weapons.
