### PR TITLE
[WIP] Sort server list by latency estimation

### DIFF
--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -391,6 +391,13 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 			lua_settable(L, top_lvl2);
 		}
 
+		if (server.isMember("geo_continent")) {
+			lua_pushstring(L,"geo_continent");
+			std::string topush = server["geo_continent"].asString();
+			lua_pushstring(L,topush.c_str());
+			lua_settable(L, top_lvl2);
+		}
+
 		lua_settable(L, top);
 		index++;
 	}


### PR DESCRIPTION
Sort the server list in the mainmenu by (estimated) latency from client to server.
This makes more sense since the ping reported by the serverlist is only useful for its own location (Netherlands, EU).
see also minetest/master-server#29

## To do

This PR is a Work in Progress

- [ ] figure out and implement determining own continent
- [ ] decide how exactly sorting should work, currently populated servers will be pushed down because they are further away (see below)

![screenshot](https://user-images.githubusercontent.com/1042418/61379365-aef7f000-a8a7-11e9-9ff8-a16924d97b67.png)

## How to test

Edit `builtin/mainmenu/common.lua` line 66 with the continent code you reside on.
Then launch Minetest, switch to the multiplayer tab and see how the list is sorted.


<b>Please comment if you have suggestions regarding the open ToDo points.</b>