### PR TITLE
Don't unnecessarily clamp HP and breath to their maximums in set_properties().

### DIFF
--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -331,7 +331,7 @@ void LuaEntitySAO::addedToEnvironment(u32 dtime_s)
 	if(m_registered){
 		// Get properties
 		m_env->getScriptIface()->
-			luaentity_GetProperties(m_id, &m_prop);
+			luaentity_GetProperties(m_id, this, &m_prop);
 		// Initialize HP from properties
 		m_hp = m_prop.hp_max;
 		// Activate entity, supplying serialized state

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -62,6 +62,7 @@ struct HitParams;
 struct EnumString;
 struct NoiseParams;
 class Schematic;
+class ServerActiveObject;
 
 
 ContentFeatures    read_content_features     (lua_State *L, int index);
@@ -107,6 +108,7 @@ void               push_item_definition_full (lua_State *L,
                                               const ItemDefinition &i);
 
 void               read_object_properties    (lua_State *L, int index,
+                                              ServerActiveObject *sao,
                                               ObjectProperties *prop,
                                               IItemDefManager *idef);
 void               push_object_properties    (lua_State *L,

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -157,7 +157,7 @@ std::string ScriptApiEntity::luaentity_GetStaticdata(u16 id)
 }
 
 void ScriptApiEntity::luaentity_GetProperties(u16 id,
-		ObjectProperties *prop)
+		ServerActiveObject *self, ObjectProperties *prop)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -170,11 +170,11 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	prop->hp_max = 10;
 
 	// Deprecated: read object properties directly
-	read_object_properties(L, -1, prop, getServer()->idef());
+	read_object_properties(L, -1, self, prop, getServer()->idef());
 
 	// Read initial_properties
 	lua_getfield(L, -1, "initial_properties");
-	read_object_properties(L, -1, prop, getServer()->idef());
+	read_object_properties(L, -1, self, prop, getServer()->idef());
 	lua_pop(L, 1);
 }
 

--- a/src/script/cpp_api/s_entity.h
+++ b/src/script/cpp_api/s_entity.h
@@ -35,7 +35,7 @@ public:
 	void luaentity_Remove(u16 id);
 	std::string luaentity_GetStaticdata(u16 id);
 	void luaentity_GetProperties(u16 id,
-			ObjectProperties *prop);
+			ServerActiveObject *self, ObjectProperties *prop);
 	void luaentity_Step(u16 id, float dtime);
 	bool luaentity_Punch(u16 id,
 			ServerActiveObject *puncher, float time_from_last_punch,

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -757,20 +757,7 @@ int ObjectRef::l_set_properties(lua_State *L)
 	if (!prop)
 		return 0;
 
-	read_object_properties(L, 2, prop, getServer(L)->idef());
-
-	PlayerSAO *player = getplayersao(ref);
-
-	if (prop->hp_max < co->getHP()) {
-		PlayerHPChangeReason reason(PlayerHPChangeReason::SET_HP);
-		co->setHP(prop->hp_max, reason);
-		if (player)
-			getServer(L)->SendPlayerHPOrDie(player, reason);
-	}
-
-	if (player && prop->breath_max < player->getBreath())
-		player->setBreath(prop->breath_max);
-
+	read_object_properties(L, 2, co, prop, getServer(L)->idef());
 	co->notifyObjectPropertiesModified();
 	return 0;
 }


### PR DESCRIPTION
This PR's change prevents `set_properties()` calls that have nothing to do with `hp_max` or `breath_max` overriding the saved hp before another mod has the chance to set a player's intended `hp_max` (such as in `on_joinplayer`).

In my case, `player_api` in MTG calls `set_properties()` on the player when they join, overwriting player HP before I had a chance to set the `hp_max` property.
