### PR TITLE
Give the online lua mainmenu also the client_list and mods

### DIFF
--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -154,20 +154,21 @@ core.get_favorites(location) -> list of favorites (possible in async calls)
 ^ location: "local" or "online"
 ^ returns {
 	[1] = {
-	clients       = <number of clients/nil>,
-	clients_max   = <maximum number of clients/nil>,
-	version       = <server version/nil>,
-	password      = <true/nil>,
-	creative      = <true/nil>,
-	damage        = <true/nil>,
-	pvp           = <true/nil>,
-	description   = <server description/nil>,
-	name          = <server name/nil>,
-	address       = <address of server/nil>,
-	port          = <port>
-	clients_list  = <array of clients>
-	mods          = <array of mods>
+		clients       = <number of clients/nil>,
+		clients_max   = <maximum number of clients/nil>,
+		version       = <server version/nil>,
+		password      = <true/nil>,
+		creative      = <true/nil>,
+		damage        = <true/nil>,
+		pvp           = <true/nil>,
+		description   = <server description/nil>,
+		name          = <server name/nil>,
+		address       = <address of server/nil>,
+		port          = <port>
+		clients_list  = <array of clients/nil>
+		mods          = <array of mods/nil>
 	},
+	...
 }
 core.delete_favorite(id, location) -> success
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -165,6 +165,8 @@ core.get_favorites(location) -> list of favorites (possible in async calls)
 	name          = <server name/nil>,
 	address       = <address of server/nil>,
 	port          = <port>
+	clients_list  = <array of clients>
+	mods          = <array of mods>
 	},
 }
 core.delete_favorite(id, location) -> success

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -265,8 +265,8 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 {
 	std::string listtype = "local";
 
-	if (!lua_isnone(L,1)) {
-		listtype = luaL_checkstring(L,1);
+	if (!lua_isnone(L, 1)) {
+		listtype = luaL_checkstring(L, 1);
 	}
 
 	std::vector<ServerListSpec> servers;
@@ -283,7 +283,7 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 	for (const Json::Value &server : servers) {
 
-		lua_pushnumber(L,index);
+		lua_pushnumber(L, index);
 
 		lua_newtable(L);
 		int top_lvl2 = lua_gettop(L);
@@ -291,11 +291,11 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 		if (!server["clients"].asString().empty()) {
 			std::string clients_raw = server["clients"].asString();
 			char* endptr = 0;
-			int numbervalue = strtol(clients_raw.c_str(),&endptr,10);
+			int numbervalue = strtol(clients_raw.c_str(), &endptr,10);
 
 			if ((!clients_raw.empty()) && (*endptr == 0)) {
-				lua_pushstring(L,"clients");
-				lua_pushnumber(L,numbervalue);
+				lua_pushstring(L, "clients");
+				lua_pushnumber(L, numbervalue);
 				lua_settable(L, top_lvl2);
 			}
 		}
@@ -304,83 +304,83 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 			std::string clients_max_raw = server["clients_max"].asString();
 			char* endptr = 0;
-			int numbervalue = strtol(clients_max_raw.c_str(),&endptr,10);
+			int numbervalue = strtol(clients_max_raw.c_str(), &endptr,10);
 
 			if ((!clients_max_raw.empty()) && (*endptr == 0)) {
-				lua_pushstring(L,"clients_max");
-				lua_pushnumber(L,numbervalue);
+				lua_pushstring(L, "clients_max");
+				lua_pushnumber(L, numbervalue);
 				lua_settable(L, top_lvl2);
 			}
 		}
 
 		if (!server["version"].asString().empty()) {
-			lua_pushstring(L,"version");
+			lua_pushstring(L, "version");
 			std::string topush = server["version"].asString();
-			lua_pushstring(L,topush.c_str());
+			lua_pushstring(L, topush.c_str());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["proto_min"].asString().empty()) {
-			lua_pushstring(L,"proto_min");
+			lua_pushstring(L, "proto_min");
 			lua_pushinteger(L, server["proto_min"].asInt());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["proto_max"].asString().empty()) {
-			lua_pushstring(L,"proto_max");
+			lua_pushstring(L, "proto_max");
 			lua_pushinteger(L, server["proto_max"].asInt());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["password"].asString().empty()) {
-			lua_pushstring(L,"password");
+			lua_pushstring(L, "password");
 			lua_pushboolean(L, server["password"].asBool());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["creative"].asString().empty()) {
-			lua_pushstring(L,"creative");
+			lua_pushstring(L, "creative");
 			lua_pushboolean(L, server["creative"].asBool());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["damage"].asString().empty()) {
-			lua_pushstring(L,"damage");
+			lua_pushstring(L, "damage");
 			lua_pushboolean(L, server["damage"].asBool());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["pvp"].asString().empty()) {
-			lua_pushstring(L,"pvp");
+			lua_pushstring(L, "pvp");
 			lua_pushboolean(L, server["pvp"].asBool());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["description"].asString().empty()) {
-			lua_pushstring(L,"description");
+			lua_pushstring(L, "description");
 			std::string topush = server["description"].asString();
-			lua_pushstring(L,topush.c_str());
+			lua_pushstring(L, topush.c_str());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["name"].asString().empty()) {
-			lua_pushstring(L,"name");
+			lua_pushstring(L, "name");
 			std::string topush = server["name"].asString();
-			lua_pushstring(L,topush.c_str());
+			lua_pushstring(L, topush.c_str());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["address"].asString().empty()) {
-			lua_pushstring(L,"address");
+			lua_pushstring(L, "address");
 			std::string topush = server["address"].asString();
-			lua_pushstring(L,topush.c_str());
+			lua_pushstring(L, topush.c_str());
 			lua_settable(L, top_lvl2);
 		}
 
 		if (!server["port"].asString().empty()) {
-			lua_pushstring(L,"port");
+			lua_pushstring(L, "port");
 			std::string topush = server["port"].asString();
-			lua_pushstring(L,topush.c_str());
+			lua_pushstring(L, topush.c_str());
 			lua_settable(L, top_lvl2);
 		}
 
@@ -393,13 +393,13 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 		if (server["clients_list"].isArray()) {
 			unsigned int index_lvl2 = 1;
-			lua_pushstring(L,"clients_list");
+			lua_pushstring(L, "clients_list");
 			lua_newtable(L);
 			int top_lvl3 = lua_gettop(L);
 			for (const Json::Value &client : server["clients_list"]) {
-				lua_pushnumber(L,index_lvl2);
+				lua_pushnumber(L, index_lvl2);
 				std::string topush = client.asString();
-				lua_pushstring(L,topush.c_str());
+				lua_pushstring(L, topush.c_str());
 				lua_settable(L, top_lvl3);
 				index_lvl2++;
 			}
@@ -408,14 +408,14 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 
 		if (server["mods"].isArray()) {
 			unsigned int index_lvl2 = 1;
-			lua_pushstring(L,"mods");
+			lua_pushstring(L, "mods");
 			lua_newtable(L);
 			int top_lvl3 = lua_gettop(L);
 			for (const Json::Value &mod : server["mods"]) {
 
-				lua_pushnumber(L,index_lvl2);
+				lua_pushnumber(L, index_lvl2);
 				std::string topush = mod.asString();
-				lua_pushstring(L,topush.c_str());
+				lua_pushstring(L, topush.c_str());
 				lua_settable(L, top_lvl3);
 				index_lvl2++;
 			}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -391,6 +391,37 @@ int ModApiMainMenu::l_get_favorites(lua_State *L)
 			lua_settable(L, top_lvl2);
 		}
 
+		if (server["clients_list"].isArray()) {
+			unsigned int index_lvl2 = 1;
+			lua_pushstring(L,"clients_list");
+			lua_newtable(L);
+			int top_lvl3 = lua_gettop(L);
+			for (const Json::Value &client : server["clients_list"]) {
+				lua_pushnumber(L,index_lvl2);
+				std::string topush = client.asString();
+				lua_pushstring(L,topush.c_str());
+				lua_settable(L, top_lvl3);
+				index_lvl2++;
+			}
+			lua_settable(L, top_lvl2);
+		}
+
+		if (server["mods"].isArray()) {
+			unsigned int index_lvl2 = 1;
+			lua_pushstring(L,"mods");
+			lua_newtable(L);
+			int top_lvl3 = lua_gettop(L);
+			for (const Json::Value &mod : server["mods"]) {
+
+				lua_pushnumber(L,index_lvl2);
+				std::string topush = mod.asString();
+				lua_pushstring(L,topush.c_str());
+				lua_settable(L, top_lvl3);
+				index_lvl2++;
+			}
+			lua_settable(L, top_lvl2);
+		}
+
 		lua_settable(L, top);
 		index++;
 	}


### PR DESCRIPTION
The lua Mainmenu interface now gets also the clients and the mods!
This allows new Features just like listing players(maybe tooltip) or searching.
Finding servers with the wanted mods and more...