### PR TITLE
Dockerfile: correct `apt clean` + git clone --depth 1 + remove .git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && 
 		-DBUILD_CLIENT=FALSE \
 		-DENABLE_SYSTEM_JSONCPP=1 \
 		.. && \
-		make -j2 && \
-		rm -Rf ../games/minetest_game && git clone https://github.com/minetest/minetest_game ../games/minetest_game && \
+		make -j4 && \
+		rm -Rf ../games/minetest_game && git clone --depth 1 https://github.com/minetest/minetest_game ../games/minetest_game && \
 		make install
 
 FROM debian:stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM debian:stretch
 USER root
 RUN apt-get update -y && \
 	apt-get -y install build-essential libirrlicht-dev cmake libbz2-dev libpng-dev libjpeg-dev \
-		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev git && \
-		apt-get clean && rm -rf /var/cache/apt/archives/* && \
-		rm -rf /var/lib/apt/lists/*
+		libsqlite3-dev libcurl4-gnutls-dev zlib1g-dev libgmp-dev libjsoncpp-dev git
 
 COPY . /usr/src/minetest
 
@@ -15,7 +13,7 @@ RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && 
 		-DBUILD_CLIENT=FALSE \
 		-DENABLE_SYSTEM_JSONCPP=1 \
 		.. && \
-		make -j$(nproc) && \
+		make -j2 && \
 		rm -Rf ../games/minetest_game && git clone --depth 1 https://github.com/minetest/minetest_game ../games/minetest_game && \
 		make install
 
@@ -25,7 +23,9 @@ USER root
 RUN groupadd minetest && useradd -m -g minetest -d /var/lib/minetest minetest && \
     apt-get update -y && \
     apt-get -y install libcurl3-gnutls libjsoncpp1 liblua5.1-0 libluajit-5.1-2 libpq5 libsqlite3-0 \
-        libstdc++6 zlib1g libc6
+        libstdc++6 zlib1g libc6 && \
+    apt-get clean && rm -rf /var/cache/apt/archives/* && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/lib/minetest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && 
 		.. && \
 		make -j2 && \
 		rm -Rf ../games/minetest_game && git clone --depth 1 https://github.com/minetest/minetest_game ../games/minetest_game && \
+		rm -Rf ../games/minetest_game/.git
 		make install
 
 FROM debian:stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN	mkdir -p /usr/src/minetest/cmakebuild && cd /usr/src/minetest/cmakebuild && 
 		-DBUILD_CLIENT=FALSE \
 		-DENABLE_SYSTEM_JSONCPP=1 \
 		.. && \
-		make -j4 && \
+		make -j$(nproc) && \
 		rm -Rf ../games/minetest_game && git clone --depth 1 https://github.com/minetest/minetest_game ../games/minetest_game && \
 		make install
 


### PR DESCRIPTION
This change makes the Dockerfile use shallow cloning (which is faster than cloning the repository's whole Git history). 