### PR TITLE
ContentCAO: Fix broken attachments on join

### DIFF
--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -101,7 +101,7 @@ public:
 
 	virtual bool collideWithObjects() const = 0;
 
-	
+
 	virtual void setAttachment(int parent_id, const std::string &bone, v3f position,
 			v3f rotation) {}
 	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position,

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -20,7 +20,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include "irr_aabb3d.h"
+#include "irr_v3d.h"
 #include <string>
+
 
 enum ActiveObjectType {
 	ACTIVEOBJECT_TYPE_INVALID = 0,
@@ -98,6 +100,16 @@ public:
 
 
 	virtual bool collideWithObjects() const = 0;
+
+	
+	virtual void setAttachment(int parent_id, const std::string &bone, v3f position,
+			v3f rotation) {}
+	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position,
+			v3f *rotation) {}
+	virtual void clearChildAttachments() {}
+	virtual void clearParentAttachment() {}
+	virtual void addAttachmentChild(int child_id) {}
+	virtual void removeAttachmentChild(int child_id) {}
 protected:
 	u16 m_id; // 0 is invalid, "no id"
 };

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -105,7 +105,7 @@ public:
 	virtual void setAttachment(int parent_id, const std::string &bone, v3f position,
 			v3f rotation) {}
 	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position,
-			v3f *rotation) {}
+			v3f *rotation) const {}
 	virtual void clearChildAttachments() {}
 	virtual void clearParentAttachment() {}
 	virtual void addAttachmentChild(int child_id) {}

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -47,8 +47,6 @@ ClientEnvironment::ClientEnvironment(ClientMap *map,
 	m_texturesource(texturesource),
 	m_client(client)
 {
-	char zero = 0;
-	memset(attachement_parent_ids, zero, sizeof(attachement_parent_ids));
 }
 
 ClientEnvironment::~ClientEnvironment()
@@ -392,7 +390,17 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 			<<std::endl;
 	}
 
-	addActiveObject(obj);
+	u16 new_id = addActiveObject(obj);
+
+	std::cout << "Added " << new_id << " - was: " << id << std::endl;
+	if ((obj = getActiveObject(new_id))) {
+		const auto &children = obj->getAttachmentChildIds();
+		for (auto c_id : children) {
+			if (auto *o = getActiveObject(c_id))
+				o->updateAttachments();
+		}
+		obj->updateAttachments();
+	}
 }
 
 void ClientEnvironment::processActiveObjectMessage(u16 id, const std::string &data)

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -391,9 +391,9 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 	}
 
 	u16 new_id = addActiveObject(obj);
-
 	// Object initialized:
 	if ((obj = getActiveObject(new_id))) {
+		std::cout << "Added " << new_id << " (" << id << ")" << std::endl;
 		// Final step is to update all children which are already known
 		// Data provided by GENERIC_CMD_SPAWN_INFANT
 		const auto &children = obj->getAttachmentChildIds();
@@ -401,8 +401,6 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 			if (auto *o = getActiveObject(c_id))
 				o->updateAttachments();
 		}
-		// All other children will attach themselves (later on)
-		obj->updateAttachments();
 	}
 }
 

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -392,13 +392,16 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 
 	u16 new_id = addActiveObject(obj);
 
-	std::cout << "Added " << new_id << " - was: " << id << std::endl;
+	// Object initialized:
 	if ((obj = getActiveObject(new_id))) {
+		// Final step is to update all children which are already known
+		// Data provided by GENERIC_CMD_SPAWN_INFANT
 		const auto &children = obj->getAttachmentChildIds();
 		for (auto c_id : children) {
 			if (auto *o = getActiveObject(c_id))
 				o->updateAttachments();
 		}
+		// All other children will attach themselves (later on)
 		obj->updateAttachments();
 	}
 }

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -393,7 +393,6 @@ void ClientEnvironment::addActiveObject(u16 id, u8 type,
 	u16 new_id = addActiveObject(obj);
 	// Object initialized:
 	if ((obj = getActiveObject(new_id))) {
-		std::cout << "Added " << new_id << " (" << id << ")" << std::endl;
 		// Final step is to update all children which are already known
 		// Data provided by GENERIC_CMD_SPAWN_INFANT
 		const auto &children = obj->getAttachmentChildIds();

--- a/src/client/clientenvironment.h
+++ b/src/client/clientenvironment.h
@@ -138,8 +138,6 @@ public:
 		std::vector<PointedThing> &objects
 	);
 
-	u16 attachement_parent_ids[USHRT_MAX + 1];
-
 	const std::list<std::string> &getPlayerNames() { return m_player_names; }
 	void addPlayerName(const std::string &name) { m_player_names.push_back(name); }
 	void removePlayerName(const std::string &name) { m_player_names.remove(name); }

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -55,7 +55,7 @@ public:
 	virtual bool isLocalPlayer() const {return false;}
 
 	virtual ClientActiveObject *getParent() const { return nullptr; };
-	virtual const std::unordered_set<int> &getAttachmentChildIds()
+	virtual const std::unordered_set<int> &getAttachmentChildIds() const
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual void updateAttachments() {};
 

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -22,6 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "activeobject.h"
 #include <unordered_map>
+#include <unordered_set>
+
 
 class ClientEnvironment;
 class ITextureSource;
@@ -51,8 +53,12 @@ public:
 	virtual scene::ISceneNode *getSceneNode() { return NULL; }
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode() { return NULL; }
 	virtual bool isLocalPlayer() const {return false;}
+
 	virtual ClientActiveObject *getParent() const { return nullptr; };
-	virtual void setAttachments() {}
+	virtual const std::unordered_set<int> &getAttachmentChildIds()
+	{ static std::unordered_set<int> rv; return rv; }
+	virtual void updateAttachments() {};
+
 	virtual bool doShowSelectionBox(){return true;}
 
 	// Step object in time

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -495,7 +495,7 @@ void GenericCAO::clearChildAttachments()
 		int child_id = *m_attachment_child_ids.begin();
 
 		if (ClientActiveObject *child = m_env->getActiveObject(child_id))
-			child->setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
+			child->setAttachment(0, "", v3f(), v3f());
 
 		removeAttachmentChild(child_id);
 	}
@@ -506,7 +506,7 @@ void GenericCAO::clearParentAttachment()
 	if (m_attachment_parent_id)
 		setAttachment(0, "", m_attachment_position, m_attachment_rotation);
 	else
-		setAttachment(0, "", v3f(0, 0, 0), v3f(0, 0, 0));
+		setAttachment(0, "", v3f(), v3f());
 }
 
 void GenericCAO::addAttachmentChild(int child_id)
@@ -521,12 +521,8 @@ void GenericCAO::removeAttachmentChild(int child_id)
 
 ClientActiveObject* GenericCAO::getParent() const
 {
-	ClientActiveObject *obj = NULL;
-
-	if (m_attachment_parent_id)
-		obj = m_env->getActiveObject(m_attachment_parent_id);
-
-	return obj;
+	return m_attachment_parent_id ? m_env->getActiveObject(m_attachment_parent_id) :
+			nullptr;
 }
 
 void GenericCAO::removeFromScene(bool permanent)

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1570,6 +1570,12 @@ void GenericCAO::processMessage(const std::string &data)
 					m_reset_textures_timer += 0.05 * damage;
 				updateTextures(m_current_texture_modifier + "^[brighten");
 			}
+		} else {
+			// Same as 'Server::DiePlayer'
+			clearParentAttachment();
+			// Same as 'ObjectRef::l_remove'
+			if (!m_is_player)
+				clearChildAttachments();
 		}
 	} else if (cmd == GENERIC_CMD_UPDATE_ARMOR_GROUPS) {
 		m_armor_groups.clear();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -373,7 +373,6 @@ void GenericCAO::processInitData(const std::string &data)
 	m_rotation = readV3F32(is);
 	m_hp = readU16(is);
 
-	std::cout << "initData() id=" << m_id << ", name=" << m_name << std::endl;
 	const u8 num_messages = readU8(is);
 
 	for (int i = 0; i < num_messages; i++) {
@@ -477,7 +476,6 @@ void GenericCAO::setAttachment(int parent_id, const std::string &bone, v3f posit
 			parent->addAttachmentChild(m_id);
 	}
 
-	std::cout << " setAttachment() id=" << m_id << ", parent=" << (u64)parent << ", name=" << m_name << std::endl;
 	updateAttachments();
 }
 
@@ -1347,11 +1345,8 @@ void GenericCAO::updateAttachments()
 	ClientActiveObject *parent = getParent();
 	if (!parent && m_attachment_parent_id) {
 		// m_is_visible = false; but needs proper handling (future use)
-		return; 
+		return;
 	}
-
-	std::cout << "   update(): id=" << m_id << ", attach_id="
-		<< m_attachment_parent_id << ", obj=" << (u64)parent << std::endl;
 
 	if (!parent) { // Detach or don't attach
 		if (m_matrixnode) {
@@ -1374,8 +1369,6 @@ void GenericCAO::updateAttachments()
 			parent_node = parent_animated_mesh_node->getJointNode(m_attachment_bone.c_str());
 		}
 
-		std::cout << "\t"  <<  " matrix: " << (u64)m_matrixnode
-				<< " parent: " << (u64)parent_node << std::endl;
 		if (m_matrixnode && parent_node) {
 			m_matrixnode->setParent(parent_node);
 			getPosRotMatrix().setTranslation(m_attachment_position);
@@ -1549,7 +1542,7 @@ void GenericCAO::processMessage(const std::string &data)
 		u16 parent_id = readS16(is);
 		std::string bone = deSerializeString(is);
 		v3f position = readV3F32(is);
-		v3f rotation = readV3F32(is);	
+		v3f rotation = readV3F32(is);
 		setAttachment(parent_id, bone, position, rotation);
 	} else if (cmd == GENERIC_CMD_PUNCHED) {
 		u16 result_hp = readU16(is);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -469,7 +469,6 @@ void GenericCAO::setAttachment(int parent_id, const std::string &bone, v3f posit
 			parent->addAttachmentChild(m_id);
 	}
 
-	std::cout << " setAttachment() id=" << m_id << ", parent=" << (u64)parent << ", name=" << m_name << std::endl;
 	updateAttachments();
 }
 
@@ -1342,9 +1341,6 @@ void GenericCAO::updateAttachments()
 		return;
 	}
 
-	std::cout << "   updateAttachments(): id=" << m_id << ", attach_id="
-		<< m_attachment_parent_id << ", obj=" << (u64)parent << std::endl;
-
 	if (!parent) { // Detach or don't attach
 		if (m_matrixnode) {
 			v3f old_pos = m_matrixnode->getAbsolutePosition();
@@ -1373,8 +1369,6 @@ void GenericCAO::updateAttachments()
 			// use Irrlicht eulers instead
 			getPosRotMatrix().setRotationDegrees(m_attachment_rotation);
 			m_matrixnode->updateAbsolutePosition();
-		} else {
-			std::cout << "     matrix=" << (u64)m_matrixnode << ", node=" << (u64)parent_node << std::endl;
 		}
 		if (m_is_local_player) {
 			LocalPlayer *player = m_env->getLocalPlayer();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -473,7 +473,7 @@ void GenericCAO::setAttachment(int parent_id, const std::string &bone, v3f posit
 }
 
 void GenericCAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
-	v3f *rotation)
+	v3f *rotation) const
 {
 	*parent_id = m_attachment_parent_id;
 	*bone = m_attachment_bone;
@@ -1587,7 +1587,8 @@ void GenericCAO::processMessage(const std::string &data)
 		}
 	} else if (cmd == GENERIC_CMD_SPAWN_INFANT) {
 		u16 child_id = readU16(is);
-		//u8 type = readU8(is); maybe this will be useful later
+		u8 type = readU8(is); // maybe this will be useful later
+		(void)type;
 
 		addAttachmentChild(child_id);
 	} else {

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -202,13 +202,14 @@ public:
 
 	void setChildrenVisible(bool toset);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
-	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void getAttachment(int *parent_id, std::string *bone, v3f *position,
+			v3f *rotation) const;
 	void clearChildAttachments();
 	void clearParentAttachment();
 	void addAttachmentChild(int child_id);
 	void removeAttachmentChild(int child_id);
 	ClientActiveObject *getParent() const;
-	const std::unordered_set<int> &getAttachmentChildIds()
+	const std::unordered_set<int> &getAttachmentChildIds() const
 	{ return m_attachment_child_ids; }
 	void updateAttachments();
 

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -102,10 +102,14 @@ private:
 	bool m_animation_loop = true;
 	// stores position and rotation for each bone name
 	std::unordered_map<std::string, core::vector2d<v3f>> m_bone_position;
+
+	int m_attachment_parent_id = 0;
+	std::unordered_set<int> m_attachment_child_ids;
 	std::string m_attachment_bone = "";
 	v3f m_attachment_position;
 	v3f m_attachment_rotation;
 	bool m_attached_to_local = false;
+
 	int m_anim_frame = 0;
 	int m_anim_num_frames = 1;
 	float m_anim_framelength = 0.2f;
@@ -121,8 +125,6 @@ private:
 	u8 m_last_light = 255;
 	bool m_is_visible = false;
 	s8 m_glow = 0;
-
-	std::vector<u16> m_children;
 
 public:
 	GenericCAO(Client *client, ClientEnvironment *env);
@@ -199,10 +201,16 @@ public:
 	}
 
 	void setChildrenVisible(bool toset);
-
+	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
+	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void clearChildAttachments();
+	void clearParentAttachment();
+	void addAttachmentChild(int child_id);
+	void removeAttachmentChild(int child_id);
 	ClientActiveObject *getParent() const;
-
-	void setAttachments();
+	const std::unordered_set<int> &getAttachmentChildIds()
+	{ return m_attachment_child_ids; }
+	void updateAttachments();
 
 	void removeFromScene(bool permanent);
 
@@ -234,8 +242,6 @@ public:
 	void updateAnimationSpeed();
 
 	void updateBonePosition();
-
-	void updateAttachments();
 
 	void processMessage(const std::string &data);
 

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -575,6 +575,8 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 			(ii != m_attachment_child_ids.end()); ++ii) {
 		if (ServerActiveObject *obj = m_env->getActiveObject(*ii)) {
 			message_count++;
+			// TODO after a protocol bump: only send the object initialization data
+			// to older clients (superfluous since this message exists)
 			msg_os << serializeLongString(gob_cmd_update_infant(*ii, obj->getSendType(),
 				obj->getClientInitializationData(protocol_version)));
 		}

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -200,7 +200,7 @@ void UnitSAO::setAttachment(int parent_id, const std::string &bone, v3f position
 }
 
 void UnitSAO::getAttachment(int *parent_id, std::string *bone, v3f *position,
-	v3f *rotation)
+	v3f *rotation) const
 {
 	*parent_id = m_attachment_parent_id;
 	*bone = m_attachment_bone;
@@ -242,7 +242,7 @@ void UnitSAO::removeAttachmentChild(int child_id)
 	m_attachment_child_ids.erase(child_id);
 }
 
-const std::unordered_set<int> &UnitSAO::getAttachmentChildIds()
+const std::unordered_set<int> &UnitSAO::getAttachmentChildIds() const
 {
 	return m_attachment_child_ids;
 }

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -56,12 +56,13 @@ public:
 	void setBonePosition(const std::string &bone, v3f position, v3f rotation);
 	void getBonePosition(const std::string &bone, v3f *position, v3f *rotation);
 	void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation);
-	void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation);
+	void getAttachment(int *parent_id, std::string *bone, v3f *position,
+			v3f *rotation) const;
 	void clearChildAttachments();
 	void clearParentAttachment();
 	void addAttachmentChild(int child_id);
 	void removeAttachmentChild(int child_id);
-	const std::unordered_set<int> &getAttachmentChildIds();
+	const std::unordered_set<int> &getAttachmentChildIds() const;
 	ServerActiveObject *getParent() const;
 	ObjectProperties* accessObjectProperties();
 	void notifyObjectPropertiesModified();

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -161,7 +161,7 @@ public:
 	{}
 	virtual void getBonePosition(const std::string &bone, v3f *position, v3f *lotation)
 	{}
-	virtual const std::unordered_set<int> &getAttachmentChildIds()
+	virtual const std::unordered_set<int> &getAttachmentChildIds() const
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual ServerActiveObject *getParent() const { return nullptr; }
 	virtual ObjectProperties* accessObjectProperties()

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -161,16 +161,6 @@ public:
 	{}
 	virtual void getBonePosition(const std::string &bone, v3f *position, v3f *lotation)
 	{}
-	virtual void setAttachment(int parent_id, const std::string &bone, v3f position, v3f rotation)
-	{}
-	virtual void getAttachment(int *parent_id, std::string *bone, v3f *position, v3f *rotation)
-	{}
-	virtual void clearChildAttachments() {}
-	virtual void clearParentAttachment() {}
-	virtual void addAttachmentChild(int child_id)
-	{}
-	virtual void removeAttachmentChild(int child_id)
-	{}
 	virtual const std::unordered_set<int> &getAttachmentChildIds()
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual ServerActiveObject *getParent() const { return nullptr; }


### PR DESCRIPTION
**What happened:**
1) Object data is received. Client begins to read the data
2) Client initializes all its children (gob_cmd_update_infant)
3) Children try to attach to parent (yet not added)
4) Parent initializes, is added to the environment

And somewhere in between, Irrlicht wrecks up the attachments due to the missing matrix node

As a result, the attachments were just laying around at (0,0,0) without ever attaching to anything.

The solution here is to:
1) Use the same structure as `ServerActiveObject`
2) Attach all children _after_ the parent is _really_ initialized


## ToDo

**This PR is Ready for Review.**

If you have some time for testing: also check what happens when an entity dies.
Children attachments for players are kept, but lost for other entities.

## How to test
1) Install & enable [wield3d](https://forum.minetest.net/viewtopic.php?t=6407)
2) Start a server
3) Place a rail and put a cart on top
4) Attach to the cart
5) Join with a client. As soon they see the cart, the player must be inside
6) Punch the cart. If it drives away without the player this means you can trash this PR

Fixes #7841, #5075 (`GENERIC_CMD_PUNCHED` tweak, untested), partially #5013, 