### PR TITLE
Re-order mapgens in mainmenu and 'all settings' mapgen selection 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1329,7 +1329,7 @@ profiler_print_interval (Engine profiling data print interval) int 0
 #    Creating a world in the main menu will override this.
 #    Current mapgens in a highly unstable state:
 #    -    The optional floatlands of v7 (disabled by default).
-mg_name (Mapgen name) enum v7 v5,v6,v7,valleys,carpathian,fractal,flat,singlenode
+mg_name (Mapgen name) enum v7 v7,valleys,carpathian,v5,flat,fractal,singlenode,v6
 
 #    Water surface level of the world.
 water_level (Water level) int 1

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -81,15 +81,21 @@ struct MapgenDesc {
 //// Built-in mapgens
 ////
 
+// Order used here defines the order of appearence in mainmenu.
+// v6 always last to discourage selection.
+// Special mapgens flat, fractal, singlenode, next to last. Of these, singlenode
+// last to discourage selection.
+// Of the remaining, v5 last due to age, v7 first due to being the default.
+// The order of 'enum MapgenType' in mapgen.h must match this order.
 static MapgenDesc g_reg_mapgens[] = {
-	{"v5",         true},
-	{"v6",         true},
 	{"v7",         true},
+	{"valleys",    true},
+	{"carpathian", true},
+	{"v5",         true},
 	{"flat",       true},
 	{"fractal",    true},
-	{"valleys",    true},
 	{"singlenode", true},
-	{"carpathian", true},
+	{"v6",         true},
 };
 
 STATIC_ASSERT(

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -102,15 +102,16 @@ private:
 	std::list<GenNotifyEvent> m_notify_events;
 };
 
+// Order must match the order of 'static MapgenDesc g_reg_mapgens[]' in mapgen.cpp
 enum MapgenType {
-	MAPGEN_V5,
-	MAPGEN_V6,
 	MAPGEN_V7,
+	MAPGEN_VALLEYS,
+	MAPGEN_CARPATHIAN,
+	MAPGEN_V5,
 	MAPGEN_FLAT,
 	MAPGEN_FRACTAL,
-	MAPGEN_VALLEYS,
 	MAPGEN_SINGLENODE,
-	MAPGEN_CARPATHIAN,
+	MAPGEN_V6,
 	MAPGEN_INVALID,
 };
 


### PR DESCRIPTION
Text for each mapgen is still a good idea and will probably be done, but a logical display order in the mapgen selection dropdowns is also useful.
Somewhat attends to #8644
```
// Order used here defines the order of appearence in mainmenu.
// v6 always last to discourage selection.
// Special mapgens flat, fractal, singlenode, next to last. Of these, singlenode
// last to discourage selection.
// Of the remaining, v5 last due to age, v7 first due to being the default.
```
New order:
```
	{"v7",         true},
	{"valleys",    true},
	{"carpathian", true},
	{"v5",         true},
	{"flat",       true},
	{"fractal",    true},
	{"singlenode", true},
	{"v6",         true},
```
Promotes the newer mapgens Valleys and Carpathian more. The first 3 in the list are the 3 most impressive mapgens.