### PR TITLE
Removed debug.upvaluejoin to prevent leak of insecure environment

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -113,7 +113,6 @@ void ScriptApiSecurity::initializeSecurity()
 		"setupvalue",
 		"setmetatable",
 		"upvalueid",
-		"upvaluejoin",
 		"sethook",
 		"debug",
 		"setlocal",


### PR DESCRIPTION
This PR removes access to debug.upvaluejoin, as this function can be used to extract local variables from functions, and thus allow "secure" mods to gain access to the insecure environment.

This PR is Ready for Review.

## How to test

I have a gist that demonstrates how a mod can use debug.upvaluejoin to extract the insecure environment from the skinsdb mod. I can link that here if it is relevant.