### PR TITLE
Unify OpenGL ES to be a platform-independent cmake switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ General options and their default values:
     ENABLE_CURSES=ON           - Build with (n)curses; Enables a server side terminal (command line option: --terminal)
     ENABLE_FREETYPE=ON         - Build with FreeType2; Allows using TTF fonts
     ENABLE_GETTEXT=ON          - Build with Gettext; Allows using translations
-    ENABLE_GLES=OFF            - Search for Open GLES headers & libraries and use them
+    ENABLE_GLES=OFF            - Build for OpenGL ES instead of OpenGL (requires support by Irrlicht)
     ENABLE_LEVELDB=ON          - Build with LevelDB; Enables use of LevelDB map backend
     ENABLE_POSTGRESQL=ON       - Build with libpq; Enables use of PostgreSQL map backend (PostgreSQL 9.5 or greater recommended)
     ENABLE_REDIS=ON            - Build with libhiredis; Enables use of Redis map backend

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -65,6 +65,7 @@ endif
 
 LOCAL_CFLAGS := -D_IRR_ANDROID_PLATFORM_      \
 		-DHAVE_TOUCHSCREENGUI         \
+		-DENABLE_GLES=1               \
 		-DUSE_CURL=1                  \
 		-DUSE_SOUND=1                 \
 		-DUSE_FREETYPE=1              \

--- a/cmake/Modules/FindOpenGLES2.cmake
+++ b/cmake/Modules/FindOpenGLES2.cmake
@@ -1,6 +1,4 @@
 #-------------------------------------------------------------------
-# This file is stolen from part of the CMake build system for OGRE (Object-oriented Graphics Rendering Engine) http://www.ogre3d.org/
-#
 # The contents of this file are placed in the public domain. Feel
 # free to make use of it in any way you like.
 #-------------------------------------------------------------------
@@ -16,26 +14,18 @@
 #  EGL_INCLUDE_DIR  - the EGL include directory
 #  EGL_LIBRARIES    - Link these to use EGL
 
-# Win32, Apple, and Android are not tested!
+# Win32 and Apple are not tested!
 # Linux tested and works
 
 if(WIN32)
-	if(CYGWIN)
-		find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h)
-		find_library(OPENGLES2_LIBRARY libGLESv2)
-	else()
-		if(BORLAND)
-			set(OPENGLES2_LIBRARY import32 CACHE STRING "OpenGL ES 2.x library for Win32")
-		else()
-			# TODO
-			# set(OPENGLES_LIBRARY ${SOURCE_DIR}/Dependencies/lib/release/libGLESv2.lib CACHE STRING "OpenGL ES 2.x library for win32"
-		endif()
-	endif()
+	find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h)
+	find_library(OPENGLES2_LIBRARY libGLESv2)
 elseif(APPLE)
 	create_search_paths(/Developer/Platforms)
 	findpkg_framework(OpenGLES2)
 	set(OPENGLES2_LIBRARY "-framework OpenGLES")
 else()
+	# Unix
 	find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h
 		PATHS /usr/openwin/share/include
 			/opt/graphics/OpenGL/include
@@ -47,55 +37,34 @@ else()
 		NAMES GLESv2
 		PATHS /opt/graphics/OpenGL/lib
 			/usr/openwin/lib
-			/usr/shlib /usr/X11R6/lib
+			/usr/X11R6/lib
 			/usr/lib
 	)
 
-	if(NOT BUILD_ANDROID)
-		find_path(EGL_INCLUDE_DIR EGL/egl.h
-			PATHS /usr/openwin/share/include
-				/opt/graphics/OpenGL/include
-				/usr/X11R6/include
-				/usr/include
-		)
+	include(FindPackageHandleStandardArgs)
+	find_package_handle_standard_args(OPENGLES2 DEFAULT_MSG OPENGLES2_LIBRARY OPENGLES2_INCLUDE_DIR)
 
-		find_library(EGL_LIBRARY
-			NAMES EGL
-			PATHS /opt/graphics/OpenGL/lib
-				/usr/openwin/lib
-				/usr/shlib
-				/usr/X11R6/lib
-				/usr/lib
-		)
+	find_path(EGL_INCLUDE_DIR EGL/egl.h
+		PATHS /usr/openwin/share/include
+			/opt/graphics/OpenGL/include
+			/usr/X11R6/include
+			/usr/include
+	)
 
-		# On Unix OpenGL usually requires X11.
-		# It doesn't require X11 on OSX.
+	find_library(EGL_LIBRARY
+		NAMES EGL
+		PATHS /opt/graphics/OpenGL/lib
+			/usr/openwin/lib
+			/usr/X11R6/lib
+			/usr/lib
+	)
 
-		if(OPENGLES2_LIBRARY)
-			if(NOT X11_FOUND)
-				include(FindX11)
-			endif()
-			if(X11_FOUND)
-				set(OPENGLES2_LIBRARIES ${X11_LIBRARIES})
-			endif()
-		endif()
-	endif()
+	include(FindPackageHandleStandardArgs)
+	find_package_handle_standard_args(EGL DEFAULT_MSG EGL_LIBRARY EGL_INCLUDE_DIR)
 endif()
 
-set(OPENGLES2_LIBRARIES ${OPENGLES2_LIBRARIES} ${OPENGLES2_LIBRARY})
-
-if(BUILD_ANDROID)
-	if(OPENGLES2_LIBRARY)
-		set(EGL_LIBRARIES)
-		set(OPENGLES2_FOUND TRUE)
-	endif()
-else()
-	if(OPENGLES2_LIBRARY AND EGL_LIBRARY)
-		set(OPENGLES2_LIBRARIES ${OPENGLES2_LIBRARY} ${OPENGLES2_LIBRARIES})
-		set(EGL_LIBRARIES ${EGL_LIBRARY} ${EGL_LIBRARIES})
-		set(OPENGLES2_FOUND TRUE)
-	endif()
-endif()
+set(OPENGLES2_LIBRARIES ${OPENGLES2_LIBRARY})
+set(EGL_LIBRARIES ${EGL_LIBRARY})
 
 mark_as_advanced(
 	OPENGLES2_INCLUDE_DIR
@@ -103,10 +72,3 @@ mark_as_advanced(
 	EGL_INCLUDE_DIR
 	EGL_LIBRARY
 )
-
-if(OPENGLES2_FOUND)
-	message(STATUS "Found system OpenGL ES 2 library: ${OPENGLES2_LIBRARIES}")
-else()
-	set(OPENGLES2_LIBRARIES "")
-endif()
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,10 +102,18 @@ if(BUILD_CLIENT AND ENABLE_SOUND)
 endif()
 
 
-option(ENABLE_GLES "Enable OpenGL ES support" FALSE)
+option(ENABLE_GLES "Use OpenGL ES instead of OpenGL" FALSE)
 mark_as_advanced(ENABLE_GLES)
 if(ENABLE_GLES)
-	find_package(OpenGLES2)
+	find_package(OpenGLES2 REQUIRED)
+elseif()
+	if(NOT WIN32) # Unix probably
+		set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
+			"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
+		set(OpenGL_GL_PREFERENCE ${OPENGL_GL_PREFERENCE})
+
+		find_package(OpenGL REQUIRED)
+	endif()
 endif()
 
 
@@ -275,11 +283,6 @@ else()
 			find_package(X11 REQUIRED)
 		endif(NOT HAIKU)
 
-		set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
-			"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
-		set(OpenGL_GL_PREFERENCE ${OPENGL_GL_PREFERENCE})
-
-		find_package(OpenGL REQUIRED)
 		find_package(JPEG REQUIRED)
 		find_package(BZip2 REQUIRED)
 		find_package(PNG REQUIRED)
@@ -519,7 +522,6 @@ if(BUILD_CLIENT)
 		${PROJECT_NAME}
 		${ZLIB_LIBRARIES}
 		${IRRLICHT_LIBRARY}
-		${OPENGL_LIBRARIES}
 		${JPEG_LIBRARIES}
 		${BZIP2_LIBRARIES}
 		${PNG_LIBRARIES}
@@ -529,7 +531,6 @@ if(BUILD_CLIENT)
 		${LUA_LIBRARY}
 		${GMP_LIBRARY}
 		${JSON_LIBRARY}
-		${OPENGLES2_LIBRARIES}
 		${PLATFORM_LIBS}
 		${CLIENT_PLATFORM_LIBS}
 	)
@@ -541,6 +542,18 @@ if(BUILD_CLIENT)
 	else()
 		target_link_libraries(
 			${client_LIBS}
+		)
+	endif()
+	if(ENABLE_GLES)
+		target_link_libraries(
+			${PROJECT_NAME}
+			${OPENGLES2_LIBRARIES}
+			${EGL_LIBRARIES}
+		)
+	else()
+		target_link_libraries(
+			${PROJECT_NAME}
+			${OPENGL_LIBRARIES}
 		)
 	endif()
 	if(USE_GETTEXT)

--- a/src/client/guiscalingfilter.cpp
+++ b/src/client/guiscalingfilter.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include <cstdio>
 #include "client/renderingengine.h"
+#include "client/tile.h" // hasNPotSupport()
 
 /* Maintain a static cache to store the images that correspond to textures
  * in a format that's manipulable by code.  Some platforms exhibit issues
@@ -113,17 +114,18 @@ video::ITexture *guiScalingResizeCached(video::IVideoDriver *driver,
 			(u32)destrect.getHeight()));
 	imageScaleNNAA(srcimg, srcrect, destimg);
 
-#ifdef __ANDROID__
-	// Android is very picky about textures being powers of 2, so expand
-	// the image dimensions to the next power of 2, if necessary, for
-	// that platform.
-	video::IImage *po2img = driver->createImage(src->getColorFormat(),
-			core::dimension2d<u32>(npot2((u32)destrect.getWidth()),
-			npot2((u32)destrect.getHeight())));
-	po2img->fill(video::SColor(0, 0, 0, 0));
-	destimg->copyTo(po2img);
-	destimg->drop();
-	destimg = po2img;
+#if ENABLE_GLES
+	// Some platforms are picky about textures being powers of 2, so expand
+	// the image dimensions to the next power of 2, if necessary.
+	if (!hasNPotSupport()) {
+		video::IImage *po2img = driver->createImage(src->getColorFormat(),
+				core::dimension2d<u32>(npot2((u32)destrect.getWidth()),
+				npot2((u32)destrect.getHeight())));
+		po2img->fill(video::SColor(0, 0, 0, 0));
+		destimg->copyTo(po2img);
+		destimg->drop();
+		destimg = po2img;
+	}
 #endif
 
 	// Convert the scaled image back into a texture.

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -46,7 +46,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <X11/Xatom.h>
 #endif
 
-#ifdef __ANDROID__
+#if ENABLE_GLES
 #include "filesys.h"
 #endif
 
@@ -106,6 +106,11 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	params.OGLES2ShaderPath = std::string(porting::path_user + DIR_DELIM + "media" +
 		DIR_DELIM + "Shaders" + DIR_DELIM).c_str();
 	// clang-format on
+#elif ENABLE_GLES
+	// there is no standardized path for these on desktop
+	std::string rel_path = std::string("client") + DIR_DELIM
+			+ "shaders" + DIR_DELIM + "Irrlicht";
+	params.OGLES2ShaderPath = (porting::path_share + DIR_DELIM + rel_path + DIR_DELIM).c_str();
 #endif
 
 	m_device = createDeviceEx(params);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/renderingengine.h"
 #include "settings.h"
 #include "camera.h"  // CameraModes
+#include "config.h"
 
 
 Sky::Sky(s32 id, ITextureSource *tsrc):
@@ -44,7 +45,7 @@ Sky::Sky(s32 id, ITextureSource *tsrc):
 
 	video::SMaterial mat;
 	mat.Lighting = false;
-#ifdef __ANDROID__
+#if ENABLE_GLES
 	mat.ZBuffer = video::ECFN_DISABLED;
 #else
 	mat.ZBuffer = video::ECFN_NEVER;
@@ -273,7 +274,7 @@ void Sky::render()
 			// Stars are only drawn when brighter than skycolor
 			if (starcolor.getBlue() < m_skycolor.getBlue())
 				break;
-#ifdef __ANDROID__
+#if ENABLE_GLES
 			u16 indices[SKY_STAR_COUNT * 3];
 			video::S3DVertex vertices[SKY_STAR_COUNT * 3];
 			for (u32 i = 0; i < SKY_STAR_COUNT; i++) {

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <algorithm>
 #include <ICameraSceneNode.h>
+#include <IrrCompileConfig.h>
 #include "util/string.h"
 #include "util/container.h"
 #include "util/thread.h"
@@ -34,8 +35,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "renderingengine.h"
 
 
-#ifdef __ANDROID__
+#if ENABLE_GLES
+#ifdef _IRR_COMPILE_WITH_OGLES1_
 #include <GLES/gl.h>
+#else
+#include <GLES2/gl2.h>
+#endif
 #endif
 
 /*
@@ -595,7 +600,7 @@ u32 TextureSource::generateTexture(const std::string &name)
 	video::ITexture *tex = NULL;
 
 	if (img != NULL) {
-#ifdef __ANDROID__
+#if ENABLE_GLES
 		img = Align2Npot2(img, driver);
 #endif
 		// Create texture from resulting image
@@ -752,7 +757,7 @@ void TextureSource::rebuildImagesAndTextures()
 	// Recreate textures
 	for (TextureInfo &ti : m_textureinfo_cache) {
 		video::IImage *img = generateImage(ti.name);
-#ifdef __ANDROID__
+#if ENABLE_GLES
 		img = Align2Npot2(img, driver);
 #endif
 		// Create texture from resulting image
@@ -989,8 +994,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
 	return baseimg;
 }
 
-#ifdef __ANDROID__
-#include <GLES/gl.h>
+#if ENABLE_GLES
 /**
  * Check and align image to npot2 if required by hardware
  * @param image image to check for npot2 alignment
@@ -998,7 +1002,7 @@ video::IImage* TextureSource::generateImage(const std::string &name)
  * @return image or copy of image aligned to npot2
  */
 
-inline u16 get_GL_major_version()
+static inline u16 get_GL_major_version()
 {
 	const GLubyte *gl_version = glGetString(GL_VERSION);
 	return (u16) (gl_version[0] - '0');
@@ -1078,7 +1082,7 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 	// Stuff starting with [ are special commands
 	if (part_of_name.empty() || part_of_name[0] != '[') {
 		video::IImage *image = m_sourcecache.getOrLoad(part_of_name);
-#ifdef __ANDROID__
+#if ENABLE_GLES
 		image = Align2Npot2(image, driver);
 #endif
 		if (image == NULL) {

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -27,8 +27,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <SMaterial.h>
 #include <memory>
 #include "util/numeric.h"
+#include "config.h"
 
-#if __ANDROID__
+#if ENABLE_GLES
 #include <IVideoDriver.h>
 #endif
 
@@ -133,7 +134,7 @@ public:
 
 IWritableTextureSource *createTextureSource();
 
-#ifdef __ANDROID__
+#if ENABLE_GLES
 video::IImage * Align2Npot2(video::IImage * image, irr::video::IVideoDriver* driver);
 #endif
 

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -135,6 +135,7 @@ public:
 IWritableTextureSource *createTextureSource();
 
 #if ENABLE_GLES
+bool hasNPotSupport();
 video::IImage * Align2Npot2(video::IImage * image, irr::video::IVideoDriver* driver);
 #endif
 

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -26,6 +26,7 @@
 #cmakedefine01 USE_SPATIAL
 #cmakedefine01 USE_SYSTEM_GMP
 #cmakedefine01 USE_REDIS
+#cmakedefine01 ENABLE_GLES
 #cmakedefine01 HAVE_ENDIAN_H
 #cmakedefine01 CURSES_HAVE_CURSES_H
 #cmakedefine01 CURSES_HAVE_NCURSES_H

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <IrrCompileConfig.h>
 #include "settings.h"
 #include "porting.h"
 #include "filesys.h"
@@ -182,7 +183,15 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("lighting_boost_spread", "0.2");
 	settings->setDefault("texture_path", "");
 	settings->setDefault("shader_path", "");
+#if ENABLE_GLES
+#ifdef _IRR_COMPILE_WITH_OGLES1_
+	settings->setDefault("video_driver", "ogles1");
+#else
+	settings->setDefault("video_driver", "ogles2");
+#endif
+#else
 	settings->setDefault("video_driver", "opengl");
+#endif
 	settings->setDefault("cinematic", "false");
 	settings->setDefault("camera_smoothing", "0");
 	settings->setDefault("cinematic_camera_smoothing", "0.7");
@@ -217,7 +226,11 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("texture_clean_transparent", "false");
 	settings->setDefault("texture_min_size", "64");
 	settings->setDefault("ambient_occlusion_gamma", "2.2");
+#if ENABLE_GLES
+	settings->setDefault("enable_shaders", "false");
+#else
 	settings->setDefault("enable_shaders", "true");
+#endif
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("arm_inertia", "true");
 
@@ -429,9 +442,7 @@ void set_default_settings(Settings *settings)
 #ifdef __ANDROID__
 	settings->setDefault("screen_w", "0");
 	settings->setDefault("screen_h", "0");
-	settings->setDefault("enable_shaders", "false");
 	settings->setDefault("fullscreen", "true");
-	settings->setDefault("video_driver", "ogles1");
 	settings->setDefault("touchtarget", "true");
 	settings->setDefault("TMPFolder", porting::getDataPath("tmp" DIR_DELIM));
 	settings->setDefault("touchscreen_threshold","20");

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -39,9 +39,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/guiscalingfilter.h"
 #include "irrlicht_changes/static_text.h"
 
-#ifdef __ANDROID__
+#if ENABLE_GLES
 #include "client/tile.h"
-#include <GLES/gl.h>
 #endif
 
 
@@ -78,7 +77,7 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 
 	m_to_delete.insert(name);
 
-#ifdef __ANDROID__
+#if ENABLE_GLES
 	video::ITexture *retval = m_driver->findTexture(name.c_str());
 	if (retval)
 		return retval;

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -38,10 +38,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <map>
 #include <set>
 
-#ifdef __ANDROID__
-#include <GLES/gl.h>
-#endif
-
 /*
 	ItemDefinition
 */


### PR DESCRIPTION
This allows you to use OpenGL ES on desktop machines, for whatever reason you'd want that.
Would also help to support platforms such as the Raspberry Pi.

## To do
This PR is Ready for Review.

## How to test
I hate this section.
* grab irrlicht ogles from `svn://svn.code.sf.net/p/irrlicht/code/branches/ogl-es`
* edit `IrrCompileConfig.h` to disable opengl and ogles1 drivers
* compile and fix the egl.h include path to be `<EGL/egl.h>` if an error occurrs
* compile minetest with `-DENABLE_GLES=1` and the paths to your built irrlicht
* copy shaders from `<irrlicht>/media/Shaders` to `client/shaders/Irrlicht`
* start minetest and observe that it works

