### PR TITLE
guiScrollBar: move directly to clicked pos if clicked into tray

### DIFF
--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -26,7 +26,6 @@ public:
 	virtual void draw();
 	virtual void updateAbsolutePosition();
 	virtual bool OnEvent(const SEvent &event);
-	virtual void OnPostRender(u32 timeMs);
 
 	s32 getMax() const { return max_pos; }
 	s32 getMin() const { return min_pos; }
@@ -60,7 +59,6 @@ private:
 	s32 max_pos;
 	s32 small_step;
 	s32 large_step;
-	s32 desired_pos;
 	u32 last_change;
 	s32 drag_offset;
 	s32 page_size;


### PR DESCRIPTION
- Goal of the PR: Improve scrollbars
- The largestep is not removed, as it is still used for page up and page down.
- Fixes #7710.
- If not a bug fix, why is this PR needed? What usecases does it solve? See #7710.
Also a bug is fixed where you clicked somewhere on the tray and an offset from the mouse to the slider was applied when dragging.

## To do

This PR is a Ready for Review.

(Note that some things might be doable a bit less complicated, but I didn't want to touch everything.)

## How to test

Open minetest in mainmenu and play around with a scrollbar.
