### PR TITLE
Fix the bgcolor formspec element

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2037,11 +2037,15 @@ Elements
 
 * Show an inventory image of registered item/node
 
-### `bgcolor[<color>;<fullscreen>]`
+### `bgcolor[<color>]`
 
 * Sets background color of formspec as `ColorString`
-* If `true`, the background color is drawn fullscreen (does not affect the size
-  of the formspec).
+
+### `bgcolor[<color>;<fullscreen>]`
+
+* If `color` is a valid `ColorString`, the fullscreen background color
+  is set to `color`.
+* If `fullscreen` is a true value, the fullscreen background color is drawn.
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>]`
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1795,17 +1795,17 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 	errorstream<< "Invalid Box element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-void GUIFormSpecMenu::parseBackgroundColor(parserData* data, const std::string &element)
+void GUIFormSpecMenu::parseBackgroundColor(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
 
 	if (((parts.size() == 1) || (parts.size() == 2)) ||
 			((parts.size() > 2) && (m_formspec_version > FORMSPEC_API_VERSION))) {
-		parseColorString(parts[0], m_bgcolor, false);
-
-		if (parts.size() == 2) {
-			std::string fullscreen = parts[1];
-			m_bgfullscreen = is_yes(fullscreen);
+		if (parts.size() == 1) {
+			parseColorString(parts[0], m_bgcolor, false);
+		} else if (parts.size() == 2) {
+			parseColorString(parts[0], m_fullscreen_bgcolor, false);
+			m_bgfullscreen = is_yes(parts[1]);
 		}
 
 		return;
@@ -2775,8 +2775,7 @@ void GUIFormSpecMenu::drawMenu()
 
 	if (m_bgfullscreen)
 		driver->draw2DRectangle(m_fullscreen_bgcolor, allbg, &allbg);
-	else
-		driver->draw2DRectangle(m_bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+	driver->draw2DRectangle(m_bgcolor, AbsoluteRect, &AbsoluteClippingRect);
 
 	m_tooltip_element->setVisible(false);
 


### PR DESCRIPTION
- Goal of the PR: making `bgcolor` more useful and powerful
- The PR works by handling the bgcolor of the window separated from the fullscreen bgcolor. The old behaviour, where the window bgcolor was not shown if fullscreen bgcolor was activated (which is weird and unintuitive), can still be achieved by setting the window bgcolor to "#0000".
- ~~Fixes #8308.~~ Edit: Oops, wrong issue. I wanted to refer to #8336.
The change is taken form #8591.

## To do

This PR is a Ready for Review.

As it is now possible to set window and fullscreen bgcolor at once, minetest_game formspec, for example, might look a little different, but this is only a little visual change and can be fixed easily. 

## How to test

```lua
local my_formspec =
	"size[10,8]"..
	"bgcolor[;true]".. -- modify this however you want
	"bgcolor[#0000]"..
	""

minetest.register_node("test:node", {
	description = "test node",
	tiles = {"default_wood.png^heart.png"},
	groups = {choppy = 3, oddly_breakable_by_hand = 3},
	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
		minetest.show_formspec(clicker:get_player_name(), "my_formspec", my_formspec)
	end,
})
```
