### PR TITLE
Rename guiScrollBar to GUIScrollBar

### DIFF
--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -1400,7 +1400,7 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 
 	irr::core::rect<s32> scrollbarrect = m_frame_rect;
 	scrollbarrect.UpperLeftCorner.X += m_frame_rect.getWidth() - m_scrollbar_width;
-	m_vscrollbar = new guiScrollBar(Environment, getParent(), -1,
+	m_vscrollbar = new GUIScrollBar(Environment, getParent(), -1,
 			scrollbarrect, false, true);
 
 	m_vscrollbar->setVisible(false);

--- a/src/gui/guiEditBoxWithScrollbar.h
+++ b/src/gui/guiEditBoxWithScrollbar.h
@@ -116,7 +116,7 @@ public:
 
 	//! Updates the absolute position, splits text if required
 	virtual void updateAbsolutePosition();
-	
+
 	virtual void setWritable(bool writable);
 
 	//! Change the background color
@@ -187,7 +187,7 @@ protected:
 	core::rect<s32> m_current_text_rect, m_frame_rect; // temporary values
 
 	u32 m_scrollbar_width;
-	guiScrollBar *m_vscrollbar;
+	GUIScrollBar *m_vscrollbar;
 	bool m_writable;
 
 	bool m_bg_color_used;

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -14,7 +14,7 @@ the arrow buttons where there is insufficient space.
 #include <IGUIButton.h>
 #include <IGUISkin.h>
 
-guiScrollBar::guiScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
+GUIScrollBar::GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 		core::rect<s32> rectangle, bool horizontal, bool auto_scale) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
 		up_button(nullptr), down_button(nullptr), is_dragging(false),
@@ -30,7 +30,7 @@ guiScrollBar::guiScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s3
 	setPos(0);
 }
 
-bool guiScrollBar::OnEvent(const SEvent &event)
+bool GUIScrollBar::OnEvent(const SEvent &event)
 {
 	if (isEnabled()) {
 		switch (event.EventType) {
@@ -193,7 +193,7 @@ bool guiScrollBar::OnEvent(const SEvent &event)
 	return IGUIElement::OnEvent(event);
 }
 
-void guiScrollBar::draw()
+void GUIScrollBar::draw()
 {
 	if (!IsVisible)
 		return;
@@ -228,14 +228,14 @@ void guiScrollBar::draw()
 	IGUIElement::draw();
 }
 
-void guiScrollBar::updateAbsolutePosition()
+void GUIScrollBar::updateAbsolutePosition()
 {
 	IGUIElement::updateAbsolutePosition();
 	refreshControls();
 	setPos(scroll_pos);
 }
 
-s32 guiScrollBar::getPosFromMousePos(const core::position2di &pos) const
+s32 GUIScrollBar::getPosFromMousePos(const core::position2di &pos) const
 {
 	s32 w, p;
 	s32 offset = dragged_by_slider ? drag_offset : thumb_size / 2;
@@ -250,7 +250,7 @@ s32 guiScrollBar::getPosFromMousePos(const core::position2di &pos) const
 	return core::isnotzero(range()) ? s32(f32(p) / f32(w) * range()) + min_pos : 0;
 }
 
-void guiScrollBar::setPos(const s32 &pos)
+void GUIScrollBar::setPos(const s32 &pos)
 {
 	s32 thumb_area = 0;
 	s32 thumb_min = 0;
@@ -275,17 +275,17 @@ void guiScrollBar::setPos(const s32 &pos)
 	draw_center = s32((f32(scroll_pos) * f) + (f32(thumb_size) * 0.5f)) + border_size;
 }
 
-void guiScrollBar::setSmallStep(const s32 &step)
+void GUIScrollBar::setSmallStep(const s32 &step)
 {
 	small_step = step > 0 ? step : 10;
 }
 
-void guiScrollBar::setLargeStep(const s32 &step)
+void GUIScrollBar::setLargeStep(const s32 &step)
 {
 	large_step = step > 0 ? step : 50;
 }
 
-void guiScrollBar::setMax(const s32 &max)
+void GUIScrollBar::setMax(const s32 &max)
 {
 	max_pos = max;
 	if (min_pos > max_pos)
@@ -297,7 +297,7 @@ void guiScrollBar::setMax(const s32 &max)
 	setPos(scroll_pos);
 }
 
-void guiScrollBar::setMin(const s32 &min)
+void GUIScrollBar::setMin(const s32 &min)
 {
 	min_pos = min;
 	if (max_pos < min_pos)
@@ -309,18 +309,18 @@ void guiScrollBar::setMin(const s32 &min)
 	setPos(scroll_pos);
 }
 
-void guiScrollBar::setPageSize(const s32 &size)
+void GUIScrollBar::setPageSize(const s32 &size)
 {
 	page_size = size;
 	setPos(scroll_pos);
 }
 
-s32 guiScrollBar::getPos() const
+s32 GUIScrollBar::getPos() const
 {
 	return scroll_pos;
 }
 
-void guiScrollBar::refreshControls()
+void GUIScrollBar::refreshControls()
 {
 	IGUISkin *skin = Environment->getSkin();
 	IGUISpriteBank *sprites = nullptr;

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -17,10 +17,10 @@ the arrow buttons where there is insufficient space.
 using namespace irr;
 using namespace gui;
 
-class guiScrollBar : public IGUIElement
+class GUIScrollBar : public IGUIElement
 {
 public:
-	guiScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
+	GUIScrollBar(IGUIEnvironment *environment, IGUIElement *parent, s32 id,
 			core::rect<s32> rectangle, bool horizontal, bool auto_scale);
 
 	virtual void draw();

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -61,7 +61,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 	}
 
 	const s32 s = skin->getSize(gui::EGDS_SCROLLBAR_SIZE);
-	m_scrollbar = new guiScrollBar(Environment, this, -1,
+	m_scrollbar = new GUIScrollBar(Environment, this, -1,
 			core::rect<s32>(RelativeRect.getWidth() - s,
 					0,
 					RelativeRect.getWidth(),

--- a/src/gui/guiTable.h
+++ b/src/gui/guiTable.h
@@ -199,7 +199,7 @@ protected:
 	video::SColor m_highlight_text = video::SColor(255, 255, 255, 255);
 	s32 m_rowheight = 1;
 	gui::IGUIFont *m_font = nullptr;
-	guiScrollBar *m_scrollbar = nullptr;
+	GUIScrollBar *m_scrollbar = nullptr;
 
 	// Allocated strings and images
 	std::vector<core::stringw> m_strings;

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -1482,7 +1482,7 @@ void intlGUIEditBox::createVScrollBar()
 
 	irr::core::rect<s32> scrollbarrect = FrameRect;
 	scrollbarrect.UpperLeftCorner.X += FrameRect.getWidth() - m_scrollbar_width;
-	m_vscrollbar = new guiScrollBar(Environment, getParent(), -1,
+	m_vscrollbar = new GUIScrollBar(Environment, getParent(), -1,
 			scrollbarrect, false, true);
 
 	m_vscrollbar->setVisible(false);

--- a/src/gui/intlGUIEditBox.h
+++ b/src/gui/intlGUIEditBox.h
@@ -198,7 +198,7 @@ namespace gui
 		core::rect<s32> CurrentTextRect = core::rect<s32>(0,0,1,1);
 		core::rect<s32> FrameRect; // temporary values
 		u32 m_scrollbar_width;
-		guiScrollBar *m_vscrollbar;
+		GUIScrollBar *m_vscrollbar;
 		bool m_writable;
 
 	};


### PR DESCRIPTION
According to https://dev.minetest.net/Code_style_guidelines#Classes, class names should be PascalCase. Ergo the class `guiScrollBar` has to be renamed to `GUIScrollBar`.

## To do

This PR is a Ready for Review.

## How to test

Just compile.
(It compiles for me, so I guess there's no mistake.)
