### PR TITLE
Allow toolcaps to override the built-in times for dig_immediate

### DIFF
--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -172,14 +172,16 @@ void ToolCapabilities::deserializeJson(std::istream &is)
 DigParams getDigParams(const ItemGroupList &groups,
 		const ToolCapabilities *tp)
 {
-	// Group dig_immediate has fixed time and no wear
-	switch (itemgroup_get(groups, "dig_immediate")) {
-	case 2:
-		return DigParams(true, 0.5, 0, "dig_immediate");
-	case 3:
-		return DigParams(true, 0, 0, "dig_immediate");
-	default:
-		break;
+	// Group dig_immediate defaults to fixed time and no wear
+	if (tp->groupcaps.find("dig_immediate") == tp->groupcaps.cend()) {
+		switch (itemgroup_get(groups, "dig_immediate")) {
+		case 2:
+			return DigParams(true, 0.5, 0, "dig_immediate");
+		case 3:
+			return DigParams(true, 0, 0, "dig_immediate");
+		default:
+			break;
+		}
 	}
 
 	// Values to be returned (with a bit of conversion)


### PR DESCRIPTION
see #8721 
minetest_game can then use `dig_immediate = {times = {[2]=42/256, [3]=0}, maxlevel = 3},`
to make dig_immediate=2 nodes dig about as fast as everything else

## To do

This PR is a Ready for Review.