### PR TITLE
Add support for mesh items

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -13,6 +13,7 @@ core.features = {
 	object_use_texture_alpha = true,
 	object_independent_selectionbox = true,
 	httpfetch_binary_data = true,
+	mesh_items = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3657,6 +3657,7 @@ Utilities
           -- Specifies whether binary data can be uploaded or downloaded using
           -- the HTTP API (5.1.0)
           httpfetch_binary_data = true,
+          mesh_items = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`
@@ -6015,6 +6016,11 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         --      {soil = 2, outerspace = 1, crumbly = 1}
         --      {bendy = 2, snappy = 1},
         --      {hard = 1, metal = 1, spikes = 1}
+
+        mesh = "",
+        -- Requires `textures` to be defined.
+
+        textures = {},
 
         inventory_image = "default_tool_steelaxe.png",
 

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -56,8 +56,8 @@ Camera::Camera(MapDrawControl &draw_control, Client *client):
 	// all other 3D scene nodes and before the GUI.
 	m_wieldmgr = smgr->createNewSceneManager();
 	m_wieldmgr->addCameraSceneNode();
-	m_wieldnode = new WieldMeshSceneNode(m_wieldmgr, -1, false);
-	m_wieldnode->setItem(ItemStack(), m_client);
+	m_wieldnode = new WieldMeshSceneNode(m_wieldmgr, m_client, -1, false);
+	m_wieldnode->setItem(ItemStack());
 	m_wieldnode->drop(); // m_wieldmgr grabbed it
 
 	/* TODO: Add a callback function so these can be updated when a setting
@@ -125,7 +125,7 @@ void Camera::step(f32 dtime)
 	m_wield_change_timer = MYMIN(m_wield_change_timer + dtime, 0.125);
 
 	if (m_wield_change_timer >= 0 && was_under_zero)
-		m_wieldnode->setItem(m_wield_item_next, m_client);
+		m_wieldnode->setItem(m_wield_item_next);
 
 	if (m_view_bobbing_state != 0)
 	{

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -730,10 +730,9 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 			addDummyTransformationSceneNode(nullptr);
 		m_matrixnode->grab();
 		m_wield_meshnode = new WieldMeshSceneNode(
-			RenderingEngine::get_scene_manager(), -1);
+			RenderingEngine::get_scene_manager(), m_client, -1);
 		m_wield_meshnode->setParent(m_matrixnode);
-		m_wield_meshnode->setItem(item, m_client,
-			(m_prop.visual == "wielditem"));
+		m_wield_meshnode->setItem(item, (m_prop.visual == "wielditem"));
 
 		m_wield_meshnode->setScale(m_prop.visual_size / 2.0f);
 		u8 li = m_last_light;

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 
 struct ItemStack;
+struct ItemDefinition;
 class Client;
 class ITextureSource;
 struct ContentFeatures;
@@ -74,14 +75,17 @@ struct ItemMesh
 class WieldMeshSceneNode : public scene::ISceneNode
 {
 public:
-	WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id = -1, bool lighting = false);
+	WieldMeshSceneNode(scene::ISceneManager *mgr, Client *client, s32 id = -1, bool lighting = false);
 	virtual ~WieldMeshSceneNode();
 
+	// Helper function to setup material flags for the mesh texture
+	void setupMaterial();
+
+	void setMeshItem(const std::string &item_name);
 	void setCube(const ContentFeatures &f, v3f wield_scale);
 	void setExtruded(const std::string &imagename, const std::string &overlay_image,
-			v3f wield_scale, ITextureSource *tsrc, u8 num_frames);
-	void setItem(const ItemStack &item, Client *client,
-			bool check_wield_image = true);
+		v3f wield_scale, u8 num_frames);
+	void setItem(const ItemStack &item, bool check_wield_prop = true);
 
 	// Sets the vertex color of the wield mesh.
 	// Must only be used if the constructor was called with lighting = false
@@ -96,9 +100,11 @@ public:
 private:
 	void changeToMesh(scene::IMesh *mesh);
 
-	// Child scene node with the current wield mesh
+	// Child scene node of the current wield mesh
 	scene::IMeshSceneNode *m_meshnode = nullptr;
 	video::E_MATERIAL_TYPE m_material_type;
+
+	Client *m_client = nullptr;
 
 	// True if EMF_LIGHTING should be enabled.
 	bool m_lighting;
@@ -123,6 +129,8 @@ private:
 	// getBoundingBox() and is set to an empty box.
 	aabb3f m_bounding_box;
 };
+
+scene::SMesh *createMeshItem(Client *client, const ItemDefinition &def);
 
 void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result);
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -59,9 +59,11 @@ struct ItemDefinition
 	/*
 		Visual properties
 	*/
+	std::string mesh; // Optional, used instead of inventory_image and wield_image
+	std::vector<std::string> textures; // Required, if mesh is defined
 	std::string inventory_image; // Optional for nodes, mandatory for tools/craftitems
 	std::string inventory_overlay; // Overlay of inventory_image.
-	std::string wield_image; // If empty, inventory_image or mesh (only nodes) is used
+	std::string wield_image; // If empty, mesh or inventory_image is used
 	std::string wield_overlay; // Overlay of wield_image.
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.
@@ -107,20 +109,20 @@ public:
 	virtual ~IItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition& get(const std::string &name) const = 0;
 	// Get alias definition
-	virtual const std::string &getAlias(const std::string &name) const=0;
+	virtual const std::string &getAlias(const std::string &name) const = 0;
 	// Get set of all defined item names and aliases
-	virtual void getAll(std::set<std::string> &result) const=0;
+	virtual void getAll(std::set<std::string> &result) const = 0;
 	// Check if item is known
-	virtual bool isKnown(const std::string &name) const=0;
+	virtual bool isKnown(const std::string &name) const = 0;
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+		Client *client) const = 0;
 	// Get item wield mesh
 	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+		Client *client) const = 0;
 	// Get item palette
 	virtual Palette* getPalette(const std::string &name,
 		Client *client) const = 0;
@@ -130,7 +132,7 @@ public:
 		Client *client) const = 0;
 #endif
 
-	virtual void serialize(std::ostream &os, u16 protocol_version)=0;
+	virtual void serialize(std::ostream &os, u16 protocol_version) = 0;
 };
 
 class IWritableItemDefManager : public IItemDefManager
@@ -141,39 +143,39 @@ public:
 	virtual ~IWritableItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition& get(const std::string &name) const = 0;
 	// Get alias definition
-	virtual const std::string &getAlias(const std::string &name) const=0;
+	virtual const std::string &getAlias(const std::string &name) const = 0;
 	// Get set of all defined item names and aliases
-	virtual void getAll(std::set<std::string> &result) const=0;
+	virtual void getAll(std::set<std::string> &result) const = 0;
 	// Check if item is known
-	virtual bool isKnown(const std::string &name) const=0;
+	virtual bool isKnown(const std::string &name) const = 0;
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+			Client *client) const = 0;
 	// Get item wield mesh
 	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+		Client *client) const = 0;
 #endif
 
 	// Remove all registered item and node definitions and aliases
 	// Then re-add the builtin item definitions
-	virtual void clear()=0;
+	virtual void clear() = 0;
 	// Register item definition
-	virtual void registerItem(const ItemDefinition &def)=0;
-	virtual void unregisterItem(const std::string &name)=0;
+	virtual void registerItem(const ItemDefinition &def) = 0;
+	virtual void unregisterItem(const std::string &name) = 0;
 	// Set an alias so that items named <name> will load as <convert_to>.
 	// Alias is not set if <name> has already been defined.
 	// Alias will be removed if <name> is defined at a later point of time.
 	virtual void registerAlias(const std::string &name,
-			const std::string &convert_to)=0;
+			const std::string &convert_to) = 0;
 
-	virtual void serialize(std::ostream &os, u16 protocol_version)=0;
-	virtual void deSerialize(std::istream &is)=0;
+	virtual void serialize(std::ostream &os, u16 protocol_version) = 0;
+	virtual void deSerialize(std::istream &is) = 0;
 
 	// Do stuff asked by threads that can only be done in the main thread
-	virtual void processQueue(IGameDef *gamedef)=0;
+	virtual void processQueue(IGameDef *gamedef) = 0;
 };
 
 IWritableItemDefManager* createItemDefManager();


### PR DESCRIPTION
(See #3551)

This PR allows items to have a mesh visual by optionally defining the `mesh` field and a `textures` table in the item definition (like in the `initial_properties` table of the entity definition).

e.g. 
```lua
minetest.register_item("test:mesh", {
	description = "This is a mesh item :D",
	mesh = "character.b3d",
	textures = { "character.png" }
})
```

This PR is strictly WIP, and I haven't compiled the code even once. I've just made a draft PR for discussion, and for obtaining inputs and guidance.

This PR includes a bunch of code-style fixes. I promise I'll move these into a separate commit once this PR becomes ready for review. ;)

### TODO

- Actually finish implementing mesh items.

Closes #3551.