### PR TITLE
ItemDefinition: Fix inventory_overlay and wield_overlay not being (de)serialized

### DIFF
--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -56,7 +56,7 @@ ItemDefinition::ItemDefinition(const ItemDefinition &def)
 	*this = def;
 }
 
-ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
+ItemDefinition &ItemDefinition::operator=(const ItemDefinition &def)
 {
 	if(this == &def)
 		return *this;
@@ -74,11 +74,10 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	stack_max = def.stack_max;
 	usable = def.usable;
 	liquids_pointable = def.liquids_pointable;
+
 	if(def.tool_capabilities)
-	{
-		tool_capabilities = new ToolCapabilities(
-				*def.tool_capabilities);
-	}
+		tool_capabilities = new ToolCapabilities(*def.tool_capabilities);
+
 	groups = def.groups;
 	node_placement_prediction = def.node_placement_prediction;
 	sound_place = def.sound_place;
@@ -86,6 +85,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	range = def.range;
 	palette_image = def.palette_image;
 	color = def.color;
+
 	return *this;
 }
 
@@ -260,7 +260,7 @@ public:
 	virtual ~CItemDefManager()
 	{
 #ifndef SERVER
-		const std::vector<ClientCached*> &values = m_clientcached.getValues();
+		const std::vector<ClientCached *> &values = m_clientcached.getValues();
 		for (ClientCached *cc : values) {
 			if (cc->wield_mesh.mesh)
 				cc->wield_mesh.mesh->drop();
@@ -273,12 +273,12 @@ public:
 		}
 		m_item_definitions.clear();
 	}
-	virtual const ItemDefinition& get(const std::string &name_) const
+	virtual const ItemDefinition &get(const std::string &name_) const
 	{
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
+		std::map<std::string, ItemDefinition *>::const_iterator i;
 		i = m_item_definitions.find(name);
 		if(i == m_item_definitions.end())
 			i = m_item_definitions.find("unknown");
@@ -308,12 +308,12 @@ public:
 		// Convert name according to possible alias
 		std::string name = getAlias(name_);
 		// Get the definition
-		std::map<std::string, ItemDefinition*>::const_iterator i;
+		std::map<std::string, ItemDefinition *>::const_iterator i;
 		return m_item_definitions.find(name) != m_item_definitions.end();
 	}
 #ifndef SERVER
 public:
-	ClientCached* createClientCachedDirect(const std::string &name,
+	ClientCached *createClientCachedDirect(const std::string &name,
 			Client *client) const
 	{
 		infostream<<"Lazily creating item texture and mesh for \""
@@ -351,7 +351,7 @@ public:
 
 		return cc;
 	}
-	ClientCached* getClientCached(const std::string &name,
+	ClientCached *getClientCached(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = NULL;
@@ -385,7 +385,7 @@ public:
 		}
 	}
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -394,7 +394,7 @@ public:
 		return cc->inventory_texture;
 	}
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
+	virtual ItemMesh *getWieldMesh(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -404,7 +404,7 @@ public:
 	}
 
 	// Get item palette
-	virtual Palette* getPalette(const std::string &name,
+	virtual Palette *getPalette(const std::string &name,
 			Client *client) const
 	{
 		ClientCached *cc = getClientCached(name, client);
@@ -432,7 +432,7 @@ public:
 #endif
 	void clear()
 	{
-		for(std::map<std::string, ItemDefinition*>::const_iterator
+		for(std::map<std::string, ItemDefinition *>::const_iterator
 				i = m_item_definitions.begin();
 				i != m_item_definitions.end(); ++i)
 		{
@@ -448,23 +448,23 @@ public:
 		//   "air" is the air node
 		//   "ignore" is the ignore node
 
-		ItemDefinition* hand_def = new ItemDefinition;
+		ItemDefinition *hand_def = new ItemDefinition;
 		hand_def->name = "";
 		hand_def->wield_image = "wieldhand.png";
 		hand_def->tool_capabilities = new ToolCapabilities;
 		m_item_definitions.insert(std::make_pair("", hand_def));
 
-		ItemDefinition* unknown_def = new ItemDefinition;
+		ItemDefinition *unknown_def = new ItemDefinition;
 		unknown_def->type = ITEM_NODE;
 		unknown_def->name = "unknown";
 		m_item_definitions.insert(std::make_pair("unknown", unknown_def));
 
-		ItemDefinition* air_def = new ItemDefinition;
+		ItemDefinition *air_def = new ItemDefinition;
 		air_def->type = ITEM_NODE;
 		air_def->name = "air";
 		m_item_definitions.insert(std::make_pair("air", air_def));
 
-		ItemDefinition* ignore_def = new ItemDefinition;
+		ItemDefinition *ignore_def = new ItemDefinition;
 		ignore_def->type = ITEM_NODE;
 		ignore_def->name = "ignore";
 		m_item_definitions.insert(std::make_pair("ignore", ignore_def));
@@ -570,7 +570,7 @@ public:
 	}
 private:
 	// Key is name
-	std::map<std::string, ItemDefinition*> m_item_definitions;
+	std::map<std::string, ItemDefinition *> m_item_definitions;
 	// Aliases
 	StringMap m_aliases;
 #ifndef SERVER
@@ -579,13 +579,13 @@ private:
 	// A reference to this can be returned when nothing is found, to avoid NULLs
 	mutable ClientCached m_dummy_clientcached;
 	// Cached textures and meshes
-	mutable MutexedMap<std::string, ClientCached*> m_clientcached;
+	mutable MutexedMap<std::string, ClientCached *> m_clientcached;
 	// Queued clientcached fetches (to be processed by the main thread)
 	mutable RequestQueue<std::string, ClientCached*, u8, u8> m_get_clientcached_queue;
 #endif
 };
 
-IWritableItemDefManager* createItemDefManager()
+IWritableItemDefManager *createItemDefManager()
 {
 	return new CItemDefManager();
 }

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -135,7 +135,9 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString(name);
 	os << serializeString(description);
 	os << serializeString(inventory_image);
+	os << serializeString(inventory_overlay);
 	os << serializeString(wield_image);
+	os << serializeString(wield_overlay);
 	writeV3F32(os, wield_scale);
 	writeS16(os, stack_max);
 	writeU8(os, usable);
@@ -182,7 +184,9 @@ void ItemDefinition::deSerialize(std::istream &is)
 	name = deSerializeString(is);
 	description = deSerializeString(is);
 	inventory_image = deSerializeString(is);
+	inventory_overlay = deSerializeString(is);
 	wield_image = deSerializeString(is);
+	wield_overlay = deSerializeString(is);
 	wield_scale = readV3F32(is);
 	stack_max = readS16(is);
 	usable = readU8(is);

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -107,22 +107,22 @@ public:
 	virtual ~IItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition& get(const std::string &name) const = 0;
 	// Get alias definition
-	virtual const std::string &getAlias(const std::string &name) const=0;
+	virtual const std::string &getAlias(const std::string &name) const = 0;
 	// Get set of all defined item names and aliases
-	virtual void getAll(std::set<std::string> &result) const=0;
+	virtual void getAll(std::set<std::string> &result) const = 0;
 	// Check if item is known
-	virtual bool isKnown(const std::string &name) const=0;
+	virtual bool isKnown(const std::string &name) const = 0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
+			Client *client) const = 0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+	virtual ItemMesh *getWieldMesh(const std::string &name,
+		Client *client) const = 0;
 	// Get item palette
-	virtual Palette* getPalette(const std::string &name,
+	virtual Palette *getPalette(const std::string &name,
 		Client *client) const = 0;
 	// Returns the base color of an item stack: the color of all
 	// tiles that do not define their own color.
@@ -130,7 +130,7 @@ public:
 		Client *client) const = 0;
 #endif
 
-	virtual void serialize(std::ostream &os, u16 protocol_version)=0;
+	virtual void serialize(std::ostream &os, u16 protocol_version) = 0;
 };
 
 class IWritableItemDefManager : public IItemDefManager
@@ -141,39 +141,39 @@ public:
 	virtual ~IWritableItemDefManager() = default;
 
 	// Get item definition
-	virtual const ItemDefinition& get(const std::string &name) const=0;
+	virtual const ItemDefinition& get(const std::string &name) const = 0;
 	// Get alias definition
-	virtual const std::string &getAlias(const std::string &name) const=0;
+	virtual const std::string &getAlias(const std::string &name) const = 0;
 	// Get set of all defined item names and aliases
-	virtual void getAll(std::set<std::string> &result) const=0;
+	virtual void getAll(std::set<std::string> &result) const = 0;
 	// Check if item is known
-	virtual bool isKnown(const std::string &name) const=0;
+	virtual bool isKnown(const std::string &name) const = 0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+	virtual video::ITexture *getInventoryTexture(const std::string &name,
+			Client *client) const = 0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+	virtual ItemMesh *getWieldMesh(const std::string &name,
+		Client *client) const = 0;
 #endif
 
 	// Remove all registered item and node definitions and aliases
 	// Then re-add the builtin item definitions
-	virtual void clear()=0;
+	virtual void clear() = 0;
 	// Register item definition
-	virtual void registerItem(const ItemDefinition &def)=0;
-	virtual void unregisterItem(const std::string &name)=0;
+	virtual void registerItem(const ItemDefinition &def) = 0;
+	virtual void unregisterItem(const std::string &name) = 0;
 	// Set an alias so that items named <name> will load as <convert_to>.
 	// Alias is not set if <name> has already been defined.
 	// Alias will be removed if <name> is defined at a later point of time.
 	virtual void registerAlias(const std::string &name,
-			const std::string &convert_to)=0;
+			const std::string &convert_to) = 0;
 
-	virtual void serialize(std::ostream &os, u16 protocol_version)=0;
-	virtual void deSerialize(std::istream &is)=0;
+	virtual void serialize(std::ostream &os, u16 protocol_version) = 0;
+	virtual void deSerialize(std::istream &is) = 0;
 
 	// Do stuff asked by threads that can only be done in the main thread
-	virtual void processQueue(IGameDef *gamedef)=0;
+	virtual void processQueue(IGameDef *gamedef) = 0;
 };
 
-IWritableItemDefManager* createItemDefManager();
+IWritableItemDefManager *createItemDefManager();


### PR DESCRIPTION
While working on #8725, I noticed that `inventory_overlay` and `wield_overlay` aren't serialized while (de)serializing an `ItemDefinition` struct. Here's the commit that added `inventory_overlay` and `wield_overlay`: f6a33a1

This trivial PR:

- Adds the missing serialize and deserialize calls
- Fixes some code-style in `itemdef.h` and `itemdef.cpp`

Please let me know if these fields shouldn't be (de)serialized for some reason, or if I have to modify a couple other places that depend on the serialization of this struct.

****

I'd prefer to have this PR merged without squashing, if possible.