### PR TITLE
Avoid crash caused by, and improve, 'findSpawnPos()' 

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3512,52 +3512,68 @@ v3f Server::findSpawnPos()
 {
 	ServerMap &map = m_env->getServerMap();
 	v3f nodeposf;
-	if (g_settings->getV3FNoEx("static_spawnpoint", nodeposf)) {
+	if (g_settings->getV3FNoEx("static_spawnpoint", nodeposf))
 		return nodeposf * BS;
-	}
 
 	bool is_good = false;
 	// Limit spawn range to mapgen edges (determined by 'mapgen_limit')
 	s32 range_max = map.getMapgenParams()->getSpawnRangeMax();
 
 	// Try to find a good place a few times
-	for(s32 i = 0; i < 4000 && !is_good; i++) {
+	for (s32 i = 0; i < 4000 && !is_good; i++) {
 		s32 range = MYMIN(1 + i, range_max);
 		// We're going to try to throw the player to this position
 		v2s16 nodepos2d = v2s16(
 			-range + (myrand() % (range * 2)),
 			-range + (myrand() % (range * 2)));
-
 		// Get spawn level at point
 		s16 spawn_level = m_emerge->getSpawnLevelAtPoint(nodepos2d);
-		// Continue if MAX_MAP_GENERATION_LIMIT was returned by
-		// the mapgen to signify an unsuitable spawn position
-		if (spawn_level == MAX_MAP_GENERATION_LIMIT)
+		// Continue if MAX_MAP_GENERATION_LIMIT was returned by the mapgen to
+		// signify an unsuitable spawn position, or if outside limits.
+		if (spawn_level >= MAX_MAP_GENERATION_LIMIT ||
+				spawn_level <= -MAX_MAP_GENERATION_LIMIT)
 			continue;
 
 		v3s16 nodepos(nodepos2d.X, spawn_level, nodepos2d.Y);
-
+		// Consecutive empty nodes
 		s32 air_count = 0;
-		for (s32 i = 0; i < 10; i++) {
+
+		// Search upwards from 'spawn level' for 2 consecutive empty nodes, to
+		// avoid obstructions in already-generated mapblocks.
+		// In ungenerated mapblocks consisting of 'ignore' nodes, there will be
+		// no obstructions, but mapgen decorations are generated after spawn so
+		// the player may end up inside one.
+		for (s32 i = 0; i < 8; i++) {
 			v3s16 blockpos = getNodeBlockPos(nodepos);
 			map.emergeBlock(blockpos, true);
 			content_t c = map.getNodeNoEx(nodepos).getContent();
 			if (c == CONTENT_AIR || c == CONTENT_IGNORE) {
 				air_count++;
 				if (air_count >= 2) {
+					// Spawn in lower empty node
+					nodepos.Y--;
 					nodeposf = intToFloat(nodepos, BS);
 					// Don't spawn the player outside map boundaries
 					if (objectpos_over_limit(nodeposf))
-						continue;
+						// Exit this loop, positions above are probably over limit
+						break;
+
+					// Good position found, cause an exit from main loop
 					is_good = true;
 					break;
 				}
+			} else {
+				air_count = 0;
 			}
 			nodepos.Y++;
 		}
 	}
 
-	return nodeposf;
+	if (is_good)
+		return nodeposf;
+
+	// No suitable spawn point found, return fallback 0,0,0
+	return v3f(0.0f, 0.0f, 0.0f);
 }
 
 void Server::requestShutdown(const std::string &msg, bool reconnect, float delay)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3547,7 +3547,10 @@ v3f Server::findSpawnPos()
 			v3s16 blockpos = getNodeBlockPos(nodepos);
 			map.emergeBlock(blockpos, true);
 			content_t c = map.getNodeNoEx(nodepos).getContent();
-			if (c == CONTENT_AIR || c == CONTENT_IGNORE) {
+
+			// In generated mapblocks allow spawn in all 'airlike' drawtype nodes.
+			// In ungenerated mapblocks allow spawn in 'ignore' nodes.
+			if (m_nodedef->get(c).drawtype == NDT_AIRLIKE || c == CONTENT_IGNORE) {
 				air_count++;
 				if (air_count >= 2) {
 					// Spawn in lower empty node


### PR DESCRIPTION
 Avoid crash caused by, and improve, 'findSpawnPos()'

Avoid an unsuitable spawn position (which if outside mapgen limits can
cause a crash) if the main 0-3999 loop reaches its end. Fallback to a
spawn at 0,0,0.
Check the mapgen-returned 'spawn_level' value for being outside limits.
When 'air_count' reaches 2, move back down 1 to spawn in the lower
empty node.
If the spawn position is disallowed by 'objectpos_over_limit()', 'break'
from loop instead of 'continue' because positions above are probably
also over limit.
Reset 'air_count' to 0 if an obstruction is found, to make 'air_count'
consecutive empty nodes.
Add clarifying comments and improve codestyle.
////////////////////////////////////////
Commit 2:
Allow spawn in 'airlike' drawtype nodes
////////////////////////////////////////

Closes #8722 

How to test

The following mapgen parameters added to .conf, when using mgv7, will cause a crash in master branch. With this PR spawn falls back to 0,0,0.
'engine_spawn = true' is required to disable MTG spawn mod which may interfere.
```
engine_spawn = true
mgv7_np_terrain_base = {
    offset      = 32000,
    scale       = 0,
    spread      = (600, 600, 600),
    seed        = 82341,
    octaves     = 5,
    persistence = 0.6,
    lacunarity  = 2.0,
    flags       = eased
}
mgv7_np_terrain_alt = {
    offset      = 32000,
    scale       = 0,
    spread      = (600, 600, 600),
    seed        = 5934,
    octaves     = 5,
    persistence = 0.6,
    lacunarity  = 2.0,
    flags       = eased
}
```
These set the terrain surface to y = 32000.
The actual surface level is of course is limited to y = 30900 or so by 'mapgen limit'. However, the 'get spawn level at point' function of mgv7 actually returns y = 32000 in this situation (which i will fix in a separate PR), causing the player to be spawned at y = 32001. This then causes a crash as described above.