### PR TITLE
Mainmenu: Use textarea in error formspecs

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -78,28 +78,39 @@ end
 
 --------------------------------------------------------------------------------
 function ui.update()
-	local formspec = ""
+	local formspec = {}
 
 	-- handle errors
 	if gamedata ~= nil and gamedata.reconnect_requested then
-		formspec = wordwrap_quickhack(gamedata.errormessage or "")
-		formspec = "size[12,5]" ..
-				"label[0.5,0;" .. fgettext("The server has requested a reconnect:") ..
-				"]textlist[0.2,0.8;11.5,3.5;;" .. formspec ..
-				"]button[6,4.6;3,0.5;btn_reconnect_no;" .. fgettext("Main menu") .. "]" ..
-				"button[3,4.6;3,0.5;btn_reconnect_yes;" .. fgettext("Reconnect") .. "]"
+		local error_message = core.formspec_escape(
+				gamedata.errormessage or "<none available>")
+		formspec = {
+			"size[14,8]",
+			"real_coordinates[true]",
+			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
+				fgettext("The server has requested a reconnect:"), error_message),
+			"box[0.5,1.2;13,5;#000]",
+			"button[2,6.6;4,1;btn_reconnect_yes;" .. fgettext("Reconnect") .. "]",
+			"button[8,6.6;4,1;btn_reconnect_no;" .. fgettext("Main menu") .. "]"
+		}
 	elseif gamedata ~= nil and gamedata.errormessage ~= nil then
-		formspec = wordwrap_quickhack(gamedata.errormessage)
+		local error_message = core.formspec_escape(
+				gamedata.errormessage or "<none available>")
+
 		local error_title
 		if string.find(gamedata.errormessage, "ModError") then
-			error_title = fgettext("An error occurred in a Lua script, such as a mod:")
+			error_title = fgettext("An error occurred in a Lua script:")
 		else
 			error_title = fgettext("An error occurred:")
 		end
-		formspec = "size[12,5]" ..
-				"label[0.5,0;" .. error_title ..
-				"]textlist[0.2,0.8;11.5,3.5;;" .. formspec ..
-				"]button[4.5,4.6;3,0.5;btn_error_confirm;" .. fgettext("Ok") .. "]"
+		formspec = {
+			"size[14,8]",
+			"real_coordinates[true]",
+			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
+				error_title, error_message),
+			"box[0.5,1.2;13,5;#000]",
+			"button[5,6.6;4,1;btn_error_confirm;" .. fgettext("Ok") .. "]"
+		}
 	else
 		local active_toplevel_ui_elements = 0
 		for key,value in pairs(ui.childlist) do
@@ -107,8 +118,8 @@ function ui.update()
 				local retval = value:get_formspec()
 
 				if retval ~= nil and retval ~= "" then
-					active_toplevel_ui_elements = active_toplevel_ui_elements +1
-					formspec = formspec .. retval
+					active_toplevel_ui_elements = active_toplevel_ui_elements + 1
+					table.insert(formspec, retval)
 				end
 			end
 		end
@@ -120,7 +131,7 @@ function ui.update()
 					local retval = value:get_formspec()
 
 					if retval ~= nil and retval ~= "" then
-						formspec = formspec .. retval
+						table.insert(formspec, retval)
 					end
 				end
 			end
@@ -135,10 +146,10 @@ function ui.update()
 			core.log("warning", "no toplevel ui element "..
 					"active; switching to default")
 			ui.childlist[ui.default]:show()
-			formspec = ui.childlist[ui.default]:get_formspec()
+			formspec = { ui.childlist[ui.default]:get_formspec() }
 		end
 	end
-	core.update_formspec(formspec)
+	core.update_formspec(table.concat(formspec))
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -146,7 +146,7 @@ function ui.update()
 			core.log("warning", "no toplevel ui element "..
 					"active; switching to default")
 			ui.childlist[ui.default]:show()
-			formspec = { ui.childlist[ui.default]:get_formspec() }
+			formspec = {ui.childlist[ui.default]:get_formspec()}
 		end
 	end
 	core.update_formspec(table.concat(formspec))

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -87,9 +87,9 @@ function ui.update()
 		formspec = {
 			"size[14,8]",
 			"real_coordinates[true]",
+			"box[0.5,1.2;13,5;#000]",
 			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
 				fgettext("The server has requested a reconnect:"), error_message),
-			"box[0.5,1.2;13,5;#000]",
 			"button[2,6.6;4,1;btn_reconnect_yes;" .. fgettext("Reconnect") .. "]",
 			"button[8,6.6;4,1;btn_reconnect_no;" .. fgettext("Main menu") .. "]"
 		}
@@ -106,9 +106,9 @@ function ui.update()
 		formspec = {
 			"size[14,8]",
 			"real_coordinates[true]",
+			"box[0.5,1.2;13,5;#000]",
 			("textarea[0.5,1.2;13,5;;%s;%s]"):format(
 				error_title, error_message),
-			"box[0.5,1.2;13,5;#000]",
 			"button[5,6.6;4,1;btn_error_confirm;" .. fgettext("Ok") .. "]"
 		}
 	else

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4258,6 +4258,6 @@ void the_game(bool *kill,
 	} catch (ModError &e) {
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
-		errorstream << "ModError: " << error_message << std::endl;
+		errorstream << error_message << std::endl;
 	}
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4256,7 +4256,8 @@ void the_game(bool *kill,
 		error_message = e.what();
 		errorstream << "ServerError: " << error_message << std::endl;
 	} catch (ModError &e) {
-		error_message = e.what() + strgettext("\nCheck debug.txt for details.");
+		error_message = std::string("ModError: ") + e.what() +
+				strgettext("\nCheck debug.txt for details.");
 		errorstream << "ModError: " << error_message << std::endl;
 	}
 }


### PR DESCRIPTION
Benefits:
1) Easier text selection
2) Text wraps automatically

![Reconnect](https://user-images.githubusercontent.com/1497498/62284297-a977d980-b453-11e9-9e98-521d7397ed12.png)

![Lua error](https://user-images.githubusercontent.com/1497498/62284355-c14f5d80-b453-11e9-9b5d-5437f90e0cfe.png)


## To do

This PR is Ready for Review.


## How to test
1) Reconnect formspec: `/shutdown 0 true` (needs another client instance)
2) Error formspec: Do not test your mods
