### PR TITLE
Correct ServerActiveObject's virtual getArmorGroups() to be const.

### DIFF
--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -147,7 +147,7 @@ public:
 
 	virtual void setArmorGroups(const ItemGroupList &armor_groups)
 	{}
-	virtual const ItemGroupList &getArmorGroups()
+	virtual const ItemGroupList &getArmorGroups() const
 	{ static ItemGroupList rv; return rv; }
 	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
 	{}


### PR DESCRIPTION
Due to commit ec3142a , UnitSAO's getArmorGroups() did not match
ServerActiveObject's, notably resulting in the lua get_armor_groups() call
returning nothing.