### PR TITLE
Use `InteractAction` enum to denote interaction actions

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -903,7 +903,7 @@ void writePlayerPos(LocalPlayer *myplayer, ClientMap *clientMap, NetworkPacket *
 	*pkt << fov << wanted_range;
 }
 
-void Client::interact(u8 action, const PointedThing& pointed)
+void Client::interact(InteractAction action, const PointedThing& pointed)
 {
 	if(m_state != LC_Ready) {
 		errorstream << "Client::interact() "
@@ -923,18 +923,11 @@ void Client::interact(u8 action, const PointedThing& pointed)
 		[5] u32 length of the next item (plen)
 		[9] serialized PointedThing
 		[9 + plen] player position information
-		actions:
-		0: start digging (from undersurface) or use
-		1: stop digging (all parameters ignored)
-		2: digging completed
-		3: place block or item (to abovesurface)
-		4: use item
-		5: perform secondary action of item
 	*/
 
 	NetworkPacket pkt(TOSERVER_INTERACT, 1 + 2 + 0);
 
-	pkt << action;
+	pkt << (u8)action;
 	pkt << (u16)getPlayerItem();
 
 	std::ostringstream tmp_os(std::ios::binary);
@@ -1195,7 +1188,7 @@ void Client::clearOutChatQueue()
 }
 
 void Client::sendChangePassword(const std::string &oldpassword,
-        const std::string &newpassword)
+	const std::string &newpassword)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
 	if (player == NULL)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -232,7 +232,7 @@ public:
 
 	void Send(NetworkPacket* pkt);
 
-	void interact(u8 action, const PointedThing& pointed);
+	void interact(InteractAction action, const PointedThing& pointed);
 
 	void sendNodemetaFields(v3s16 p, const std::string &formname,
 		const StringMap &fields);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2992,7 +2992,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 		shootline = core::line3d<f32>(player_eye_position,
 			player_eye_position + camera_direction * BS * d);
 	} else {
-	    // prevent player pointing anything in front-view
+		// prevent player pointing anything in front-view
 		shootline = core::line3d<f32>(camera_position, camera_position);
 	}
 
@@ -3032,7 +3032,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	if (runData.digging) {
 		if (input->getLeftReleased()) {
 			infostream << "Left button released"
-			           << " (stopped digging)" << std::endl;
+					<< " (stopped digging)" << std::endl;
 			runData.digging = false;
 		} else if (pointed != runData.pointed_old) {
 			if (pointed.type == POINTEDTHING_NODE
@@ -3043,14 +3043,14 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 				// Don't reset.
 			} else {
 				infostream << "Pointing away from node"
-				           << " (stopped digging)" << std::endl;
+						<< " (stopped digging)" << std::endl;
 				runData.digging = false;
 				hud->updateSelectionMesh(camera_offset);
 			}
 		}
 
 		if (!runData.digging) {
-			client->interact(1, runData.pointed_old);
+			client->interact(INTERACT_STOP_DIGGING, runData.pointed_old);
 			client->setCrack(-1, v3s16(0, 0, 0));
 			runData.dig_time = 0.0;
 		}
@@ -3077,7 +3077,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud, bool show_debug)
 	if (playeritem_def.usable && input->getLeftState()) {
 		if (input->getLeftClicked() && (!client->moddingEnabled()
 				|| !client->getScript()->on_item_use(playeritem, pointed)))
-			client->interact(4, pointed);
+			client->interact(INTERACT_USE, pointed);
 	} else if (pointed.type == POINTEDTHING_NODE) {
 		ToolCapabilities playeritem_toolcap =
 				playeritem.getToolCapabilities(itemdef_manager);
@@ -3209,7 +3209,7 @@ void Game::handlePointingAtNothing(const ItemStack &playerItem)
 	infostream << "Right Clicked in Air" << std::endl;
 	PointedThing fauxPointed;
 	fauxPointed.type = POINTEDTHING_NOTHING;
-	client->interact(5, fauxPointed);
+	client->interact(INTERACT_ACTIVATE, fauxPointed);
 }
 
 
@@ -3257,7 +3257,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 				&& !isKeyDown(KeyType::SNEAK)) {
 			// Report right click to server
 			if (nodedef_manager->get(map.getNodeNoEx(nodepos)).rightclickable) {
-				client->interact(3, pointed);
+				client->interact(INTERACT_PLACE, pointed);
 			}
 
 			infostream << "Launching custom inventory view" << std::endl;
@@ -3286,7 +3286,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 
 			if (placed) {
 				// Report to server
-				client->interact(3, pointed);
+				client->interact(INTERACT_PLACE, pointed);
 				// Read the sound
 				soundmaker->m_player_rightpunch_sound =
 						playeritem_def.sound_place;
@@ -3299,7 +3299,7 @@ void Game::handlePointingAtNode(const PointedThing &pointed,
 
 				if (playeritem_def.node_placement_prediction.empty() ||
 						nodedef_manager->get(map.getNodeNoEx(nodepos)).rightclickable) {
-					client->interact(3, pointed); // Report to server
+					client->interact(INTERACT_PLACE, pointed); // Report to server
 				} else {
 					soundmaker->m_player_rightpunch_sound =
 						playeritem_def.sound_place_failed;
@@ -3509,11 +3509,11 @@ void Game::handlePointingAtObject(const PointedThing &pointed, const ItemStack &
 			runData.time_from_last_punch = 0;
 
 			if (!disable_send)
-				client->interact(0, pointed);
+				client->interact(INTERACT_START_DIGGING, pointed);
 		}
 	} else if (input->getRightClicked()) {
 		infostream << "Right-clicked object" << std::endl;
-		client->interact(3, pointed);  // place
+		client->interact(INTERACT_PLACE, pointed);  // place
 	}
 }
 
@@ -3560,7 +3560,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		runData.dig_instantly = runData.dig_time_complete == 0;
 		if (client->moddingEnabled() && client->getScript()->on_punchnode(nodepos, n))
 			return;
-		client->interact(0, pointed);
+		client->interact(INTERACT_START_DIGGING, pointed);
 		runData.digging = true;
 		runData.ldown_for_dig = true;
 	}
@@ -3619,7 +3619,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 		MapNode wasnode = map.getNodeNoEx(nodepos, &is_valid_position);
 		if (is_valid_position) {
 			if (client->moddingEnabled() &&
-			    		client->getScript()->on_dignode(nodepos, wasnode)) {
+					client->getScript()->on_dignode(nodepos, wasnode)) {
 				return;
 			}
 
@@ -3635,7 +3635,7 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 			// implicit else: no prediction
 		}
 
-		client->interact(2, pointed);
+		client->interact(INTERACT_DIGGING_COMPLETED, pointed);
 
 		if (m_cache_enable_particles) {
 			const ContentFeatures &features =

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -954,10 +954,20 @@ enum CSMRestrictionFlags : u64 {
 	// When those are complete, this should return to only being a restriction on the
 	// loading of client mods.
 	CSM_RF_LOAD_CLIENT_MODS = 0x00000001, // Don't load client-provided mods or 'builtin'
-	CSM_RF_CHAT_MESSAGES = 0x00000002, // Disable chat message sending from CSM
-	CSM_RF_READ_ITEMDEFS = 0x00000004, // Disable itemdef lookups
-	CSM_RF_READ_NODEDEFS = 0x00000008, // Disable nodedef lookups
-	CSM_RF_LOOKUP_NODES = 0x00000010, // Limit node lookups
-	CSM_RF_READ_PLAYERINFO = 0x00000020, // Disable player info lookups
+	CSM_RF_CHAT_MESSAGES = 0x00000002,    // Disable chat message sending from CSM
+	CSM_RF_READ_ITEMDEFS = 0x00000004,    // Disable itemdef lookups
+	CSM_RF_READ_NODEDEFS = 0x00000008,    // Disable nodedef lookups
+	CSM_RF_LOOKUP_NODES = 0x00000010,     // Limit node lookups
+	CSM_RF_READ_PLAYERINFO = 0x00000020,  // Disable player info lookups
 	CSM_RF_ALL = 0xFFFFFFFF,
+};
+
+enum InteractAction : u8
+{
+	INTERACT_START_DIGGING,     // 0: start digging (from undersurface) or use
+	INTERACT_STOP_DIGGING,      // 1: stop digging (all parameters ignored)
+	INTERACT_DIGGING_COMPLETED, // 2: digging completed
+	INTERACT_PLACE,             // 3: place block or item (to abovesurface)
+	INTERACT_USE,               // 4: use item
+	INTERACT_ACTIVATE           // 5: rightclick air ("activate")
 };

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -984,7 +984,7 @@ bool Server::checkInteractDistance(RemotePlayer *player, const f32 d, const std:
 	return true;
 }
 
-void Server::handleCommand_Interact(NetworkPacket* pkt)
+void Server::handleCommand_Interact(NetworkPacket *pkt)
 {
 	/*
 		[0] u16 command
@@ -993,18 +993,14 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		[5] u32 length of the next item (plen)
 		[9] serialized PointedThing
 		[9 + plen] player position information
-		actions:
-		0: start digging (from undersurface) or use
-		1: stop digging (all parameters ignored)
-		2: digging completed
-		3: place block or item (to abovesurface)
-		4: use item
-		5: rightclick air ("activate")
 	*/
-	u8 action;
+
+	InteractAction action;
 	u16 item_i;
-	*pkt >> action;
+
+	*pkt >> (u8 &)action;
 	*pkt >> item_i;
+
 	std::istringstream tmp_is(pkt->readLongString(), std::ios::binary);
 	PointedThing pointed;
 	pointed.deSerialize(tmp_is);
@@ -1083,18 +1079,18 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 		Make sure the player is allowed to do it
 	*/
 	if (!checkPriv(player->getName(), "interact")) {
-		actionstream<<player->getName()<<" attempted to interact with "
-				<<pointed.dump()<<" without 'interact' privilege"
-				<<std::endl;
+		actionstream << player->getName() << " attempted to interact with " <<
+				pointed.dump() << " without 'interact' privilege" << std::endl;
+
 		// Re-send block to revert change on client-side
 		RemoteClient *client = getClient(pkt->getPeerId());
 		// Digging completed -> under
-		if (action == 2) {
+		if (action == INTERACT_DIGGING_COMPLETED) {
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_under, BS));
 			client->SetBlockNotSent(blockpos);
 		}
 		// Placement -> above
-		else if (action == 3) {
+		else if (action == INTERACT_PLACE) {
 			v3s16 blockpos = getNodeBlockPos(floatToInt(pointed_pos_above, BS));
 			client->SetBlockNotSent(blockpos);
 		}
@@ -1108,10 +1104,10 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 	static thread_local const bool enable_anticheat =
 			!g_settings->getBool("disable_anticheat");
 
-	if ((action == 0 || action == 2 || action == 3 || action == 4) &&
+	if ((action == INTERACT_START_DIGGING || action == INTERACT_DIGGING_COMPLETED ||
+			action == INTERACT_PLACE || action == INTERACT_USE) &&
 			enable_anticheat && !isSingleplayer()) {
-		float d = playersao->getEyePosition()
-			.getDistanceFrom(pointed_pos_under);
+		float d = playersao->getEyePosition().getDistanceFrom(pointed_pos_under);
 
 		if (!checkInteractDistance(player, d, pointed.dump())) {
 			// Re-send block to revert change on client-side
@@ -1131,7 +1127,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 	/*
 		0: start digging or punch object
 	*/
-	if (action == 0) {
+	if (action == INTERACT_START_DIGGING) {
 		if (pointed.type == POINTEDTHING_NODE) {
 			MapNode n(CONTENT_IGNORE);
 			bool pos_ok;
@@ -1184,18 +1180,18 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 						PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, pointed_object));
 		}
 
-	} // action == 0
+	} // action == INTERACT_START_DIGGING
 
 	/*
 		1: stop digging
 	*/
-	else if (action == 1) {
-	} // action == 1
+	else if (action == INTERACT_STOP_DIGGING) {
+	} // action == INTERACT_STOP_DIGGING
 
 	/*
 		2: Digging completed
 	*/
-	else if (action == 2) {
+	else if (action == INTERACT_DIGGING_COMPLETED) {
 		// Only digging of nodes
 		if (pointed.type == POINTEDTHING_NODE) {
 			bool pos_ok;
@@ -1294,12 +1290,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 				client->ResendBlockIfOnWire(blockpos);
 			}
 		}
-	} // action == 2
+	} // action == INTERACT_DIGGING_COMPLETED
 
 	/*
 		3: place block or right-click object
 	*/
-	else if (action == 3) {
+	else if (action == INTERACT_PLACE) {
 		ItemStack item = playersao->getWieldedItem();
 
 		// Reset build time counter
@@ -1348,12 +1344,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 				client->ResendBlockIfOnWire(blockpos2);
 			}
 		}
-	} // action == 3
+	} // action == INTERACT_PLACE
 
 	/*
 		4: use
 	*/
-	else if (action == 4) {
+	else if (action == INTERACT_USE) {
 		ItemStack item = playersao->getWieldedItem();
 
 		actionstream << player->getName() << " uses " << item.name
@@ -1367,12 +1363,12 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 			}
 		}
 
-	} // action == 4
+	} // action == INTERACT_USE
 
 	/*
 		5: rightclick air
 	*/
-	else if (action == 5) {
+	else if (action == INTERACT_ACTIVATE) {
 		ItemStack item = playersao->getWieldedItem();
 
 		actionstream << player->getName() << " activates "
@@ -1384,7 +1380,7 @@ void Server::handleCommand_Interact(NetworkPacket* pkt)
 				SendInventory(playersao);
 			}
 		}
-	}
+	} // action == INTERACT_ACTIVATE
 
 
 	/*


### PR DESCRIPTION
This PR replaces the magic numbers used as interaction modes both client-side and server-side, primarily for the sake of ease-of-readability.

### How does the PR work?

- New enum `InteractAction` has been added to `src/network/networkprotocol.h`
- `Client::interact` and `Server::handleCommand_Interact` have been modified to work with this enum instead of magical `u8` values.

### Why is this PR needed?

Readability. Without the enum, someone new to this area of code might not immediately understand the magic numbers passed to `Client::interact`. These magic numbers _are_ documented, but one would still have to search for the documentation before understanding what it's supposed to mean.

### How to test

- Fire up Minetest.
- Run around the world punching, digging, placing, and using stuff (while pointing at something and while pointing at nothing). No behaviour should be different from how it is in `master`.

****

This PR is Ready for Review. Tested; works.
