### PR TITLE
Ignore near_plane setting on non-Android platforms

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -623,11 +623,11 @@ pause_on_lost_focus (Pause on lost window focus) bool false
 #    View distance in nodes.
 viewing_range (Viewing range) int 100 20 4000
 
-#   Camera 'near clipping plane' distance in nodes, between 0 and 0.5.
-#   Most users will not need to change this.
+#   Camera 'near clipping plane' distance in nodes, between 0 and 0.25
+#   Only works on Android. Most users will not need to change this.
 #   Increasing can reduce artifacting on weaker GPUs.
-#   0.1 = Default, 0.25 = Good value for weaker tablets.
-near_plane (Near clipping plane) float 0.1 0 0.5
+#   0.05 = Default, 0.25 = Good value for weaker tablets.
+near_plane (Near plane) float 0.05 0 0.25
 
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024 1

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -624,7 +624,7 @@ pause_on_lost_focus (Pause on lost window focus) bool false
 viewing_range (Viewing range) int 100 20 4000
 
 #   Camera 'near clipping plane' distance in nodes, between 0 and 0.25
-#   Only works on Android. Most users will not need to change this.
+#   Only works on GLES platforms. Most users will not need to change this.
 #   Increasing can reduce artifacting on weaker GPUs.
 #   0.1 = Default, 0.25 = Good value for weaker tablets.
 near_plane (Near plane) float 0.1 0 0.25

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -626,8 +626,8 @@ viewing_range (Viewing range) int 100 20 4000
 #   Camera 'near clipping plane' distance in nodes, between 0 and 0.25
 #   Only works on Android. Most users will not need to change this.
 #   Increasing can reduce artifacting on weaker GPUs.
-#   0.05 = Default, 0.25 = Good value for weaker tablets.
-near_plane (Near plane) float 0.05 0 0.25
+#   0.1 = Default, 0.25 = Good value for weaker tablets.
+near_plane (Near plane) float 0.1 0 0.25
 
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -702,9 +702,9 @@
 #    Camera 'near clipping plane' distance in nodes, between 0 and 0.25
 #    Only works on GLES platforms. Most users will not need to change this.
 #    Increasing can reduce artifacting on weaker GPUs.
-#    0.05 = Default, 0.25 = Good value for weaker tablets.
+#    0.01 = Default, 0.25 = Good value for weaker tablets.
 #    type: float min: 0 max: 0.25
-# near_plane = 0.05
+# near_plane = 0.1
 
 #    Width component of the initial window size.
 #    type: int min: 1

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -699,12 +699,12 @@
 #    type: int min: 20 max: 4000
 # viewing_range = 100
 
-#    Camera 'near clipping plane' distance in nodes, between 0 and 0.5.
-#    Most users will not need to change this.
+#    Camera 'near clipping plane' distance in nodes, between 0 and 0.25
+#    Only works on Android. Most users will not need to change this.
 #    Increasing can reduce artifacting on weaker GPUs.
-#    0.1 = Default, 0.25 = Good value for weaker tablets.
-#    type: float min: 0 max: 0.5
-# near_plane = 0.1
+#    0.05 = Default, 0.25 = Good value for weaker tablets.
+#    type: float min: 0 max: 0.25
+# near_plane = 0.05
 
 #    Width component of the initial window size.
 #    type: int min: 1
@@ -1297,7 +1297,7 @@
 # ask_reconnect_on_crash = false
 
 #    From how far clients know about objects, stated in mapblocks (16 nodes).
-#    
+#
 #    Setting this larger than active_block_range will also cause the server
 #    to maintain active objects up to this distance in the direction the
 #    player is looking. (This can avoid mobs suddenly disappearing from view)
@@ -1828,7 +1828,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -1841,7 +1841,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -1854,7 +1854,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining terrain.
@@ -1880,7 +1880,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen V6
@@ -2251,7 +2251,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining structure of river canyon walls.
@@ -2264,7 +2264,7 @@
 #    octaves     = 4,
 #    persistence = 0.75,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -2277,7 +2277,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2290,7 +2290,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2303,7 +2303,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2316,7 +2316,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Carpathian
@@ -2542,7 +2542,7 @@
 #    octaves     = 5,
 #    persistence = 0.55,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    First of two 3D noises that together define tunnels.
@@ -2555,7 +2555,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2568,7 +2568,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise defining giant caverns.
@@ -2581,7 +2581,7 @@
 #    octaves     = 5,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2594,7 +2594,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Flat
@@ -2687,7 +2687,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2700,7 +2700,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2713,7 +2713,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Fractal
@@ -2870,7 +2870,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2883,7 +2883,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    3D noise that determines number of dungeons per mapchunk.
@@ -2896,7 +2896,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Mapgen Valleys
@@ -2969,7 +2969,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Second of two 3D noises that together define tunnels.
@@ -2982,7 +2982,7 @@
 #    octaves     = 3,
 #    persistence = 0.5,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    The depth of dirt or other biome filler node.
@@ -3008,7 +3008,7 @@
 #    octaves     = 6,
 #    persistence = 0.63,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Defines large-scale river channel structure.
@@ -3060,7 +3060,7 @@
 #    octaves     = 6,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 #    Amplifies the valleys.
@@ -3099,7 +3099,7 @@
 #    octaves     = 2,
 #    persistence = 0.8,
 #    lacunarity  = 2.0,
-#    flags       = 
+#    flags       =
 # }
 
 ## Advanced
@@ -3163,4 +3163,3 @@
 #    so see a full list at https://content.minetest.net/help/content_flags/
 #    type: string
 # contentdb_flag_blacklist = nonfree, desktop_default
-

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -702,7 +702,7 @@
 #    Camera 'near clipping plane' distance in nodes, between 0 and 0.25
 #    Only works on GLES platforms. Most users will not need to change this.
 #    Increasing can reduce artifacting on weaker GPUs.
-#    0.01 = Default, 0.25 = Good value for weaker tablets.
+#    0.1 = Default, 0.25 = Good value for weaker tablets.
 #    type: float min: 0 max: 0.25
 # near_plane = 0.1
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -700,7 +700,7 @@
 # viewing_range = 100
 
 #    Camera 'near clipping plane' distance in nodes, between 0 and 0.25
-#    Only works on Android. Most users will not need to change this.
+#    Only works on GLES platforms. Most users will not need to change this.
 #    Increasing can reduce artifacting on weaker GPUs.
 #    0.05 = Default, 0.25 = Good value for weaker tablets.
 #    type: float min: 0 max: 0.25

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -571,7 +571,7 @@ void Camera::updateViewingRange()
 	m_cameranode->setNearValue(rangelim(
 		g_settings->getFloat("near_plane"), 0.0f, 0.25f) * BS);
 #else
-	m_cameranode->setNearValue(0.05f * BS);
+	m_cameranode->setNearValue(0.1f * BS);
 #endif
 
 	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 4000);

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -565,10 +565,16 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 void Camera::updateViewingRange()
 {
 	f32 viewing_range = g_settings->getFloat("viewing_range");
-	f32 near_plane = g_settings->getFloat("near_plane");
+
+	// Ignore near_plane setting on non-Android platforms to prevent abuse
+#ifdef __ANDROID__
+	m_cameranode->setNearValue(rangelim(
+		g_settings->getFloat("near_plane"), 0.0f, 0.25f) * BS);
+#else
+	m_cameranode->setNearValue(0.05f * BS);
+#endif
 
 	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 4000);
-	m_cameranode->setNearValue(rangelim(near_plane, 0.0f, 0.5f) * BS);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);
 		return;
@@ -596,7 +602,7 @@ void Camera::wield(const ItemStack &item)
 
 void Camera::drawWieldedTool(irr::core::matrix4* translation)
 {
-	// Clear Z buffer so that the wielded tool stay in front of world geometry
+	// Clear Z buffer so that the wielded tool stays in front of world geometry
 	m_wieldmgr->getVideoDriver()->clearZBuffer();
 
 	// Draw the wielded node (in a separate scene manager)

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "camera.h"
 #include "debug.h"
 #include "client.h"
+#include "config.h"
 #include "map.h"
 #include "clientmap.h"     // MapDrawControl
 #include "player.h"
@@ -566,8 +567,8 @@ void Camera::updateViewingRange()
 {
 	f32 viewing_range = g_settings->getFloat("viewing_range");
 
-	// Ignore near_plane setting on non-Android platforms to prevent abuse
-#ifdef __ANDROID__
+	// Ignore near_plane setting on all other platforms to prevent abuse
+#if ENABLE_GLES
 	m_cameranode->setNearValue(rangelim(
 		g_settings->getFloat("near_plane"), 0.0f, 0.25f) * BS);
 #else

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -165,7 +165,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
 #ifdef __ANDROID__
-	settings->setDefault("near_plane", "0.05");
+	settings->setDefault("near_plane", "0.1");
 #endif
 	settings->setDefault("screen_w", "1024");
 	settings->setDefault("screen_h", "600");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -164,7 +164,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
-#ifdef __ANDROID__
+#if ENABLE_GLES
 	settings->setDefault("near_plane", "0.1");
 #endif
 	settings->setDefault("screen_w", "1024");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -164,7 +164,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("fps_max", "60");
 	settings->setDefault("pause_fps_max", "20");
 	settings->setDefault("viewing_range", "100");
-	settings->setDefault("near_plane", "0.1");
+#ifdef __ANDROID__
+	settings->setDefault("near_plane", "0.05");
+#endif
 	settings->setDefault("screen_w", "1024");
 	settings->setDefault("screen_h", "600");
 	settings->setDefault("autosave_screensize", "true");


### PR DESCRIPTION
`near_plane` seems to be limited to 0.5 to prevent x-ray vision, but even 0.25 simulates x-ray vision across almost 25% of the screen. So this PR:

- Completely ignores this setting on non-Android devices.
- Changes the upper-bound of this setting from 0.5 to 0.25 on Android devices.
- Changes the default value of this setting from 0.1 to 0.05, because the default value would otherwise be the same as the upper-bound.

### To test

- Fire up one instance running the PR branch, and one instance running `master` (for comparison).
- Set `near_plane` to 0.25 in both instances.
- Observe that the x-ray effect is non-existent in the instance running the PR (as the setting is ignored).

![Screenshot from 2019-08-04 14-27-55](https://user-images.githubusercontent.com/36130650/62421999-de409680-b6c8-11e9-8cec-eba696ad8578.png)
(left: PR, right: `master`)

****

Needs testing on Android devices to ensure that 0.05 doesn't result in increased visual artifacts.