### PR TITLE
Do not add group values of zero to group lists.

### DIFF
--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1536,7 +1536,7 @@ void read_groups(lua_State *L, int index, ItemGroupList &result)
 		std::string name = luaL_checkstring(L, -2);
 		int rating = luaL_checkinteger(L, -1);
 		// zero rating indicates not in the group
-		if(rating != 0)
+		if (rating != 0)
 			result[name] = rating;
 		// removes value, keeps key for next iteration
 		lua_pop(L, 1);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1535,7 +1535,9 @@ void read_groups(lua_State *L, int index, ItemGroupList &result)
 		// key at index -2 and value at index -1
 		std::string name = luaL_checkstring(L, -2);
 		int rating = luaL_checkinteger(L, -1);
-		result[name] = rating;
+		// zero rating indicates not in the group
+		if(rating != 0)
+			result[name] = rating;
 		// removes value, keeps key for next iteration
 		lua_pop(L, 1);
 	}

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1529,9 +1529,9 @@ void read_groups(lua_State *L, int index, ItemGroupList &result)
 		return;
 	result.clear();
 	lua_pushnil(L);
-	if(index < 0)
+	if (index < 0)
 		index -= 1;
-	while(lua_next(L, index) != 0){
+	while (lua_next(L, index) != 0) {
 		// key at index -2 and value at index -1
 		std::string name = luaL_checkstring(L, -2);
 		int rating = luaL_checkinteger(L, -1);


### PR DESCRIPTION
This fixes an issue where when the engine looked up groups (for example, in ABM node names), NodeDefManager's m_group_to_items would contain nodes with a group value of zero, resulting in nodes with flammable = 0 being burned by a fire mod with a group:flammable checking ABM.

It brings consistency to the behaviour described in the api documentation, where zero and nil groups should be the same.