### PR TITLE
Add a detailed_description to items

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1877,6 +1877,8 @@ Some of the values in the key-value store are handled specially:
 
 * `description`: Set the item stack's description. Defaults to
   `idef.description`.
+* `detailed_description`: Set the item stack's detailed description.
+   Defaults to `idef.detailed_description`.
 * `color`: A `ColorString`, which sets the stack's color.
 * `palette_index`: If the item has a palette, this is used to get the
   current color from the palette.
@@ -6202,6 +6204,11 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
     {
         description = "Steel Axe",
+
+        detailed_description = "Steel Axe\nIt helps you chopping down trees.",
+        -- If this is defined and not `""` and the user holds down the shift key
+        -- when hovering with the cursor over the item, this is shown instead of
+        -- `description`.
 
         groups = {},
         -- key = name, value = rating; rating = 1..3.

--- a/games/minimal/mods/default/init.lua
+++ b/games/minimal/mods/default/init.lua
@@ -85,6 +85,8 @@ minetest.register_tool("default:pick_steel", {
 })
 minetest.register_tool("default:pick_mese", {
 	description = "Mese Pickaxe",
+	detailed_description = "Mese Pickaxe\n" ..
+		minetest.colorize("#ff0", "the fastest pickaxe"),
 	inventory_image = "default_tool_mesepick.png",
 	tool_capabilities = {
 		full_punch_interval = 1.0,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2855,9 +2855,8 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 					rotation_kind);
 				// Draw tooltip
 				if (hovering && !m_selected_item) {
-					std::string tooltip = item.getDescription(m_client->idef());
-					if (m_tooltip_append_itemname)
-						tooltip += "\n[" + item.name + "]";
+					std::string tooltip = item.getDescription(m_client->idef(),
+							isShiftPressed, m_tooltip_append_itemname);
 					showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,
 							m_default_tooltip_bgcolor);
 				}
@@ -3599,6 +3598,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			return true;
 		}
 
+		if (event.KeyInput.Key == KEY_LSHIFT)
+			isShiftPressed = event.KeyInput.PressedDown;
+
 		if (m_client != NULL && event.KeyInput.PressedDown &&
 				(kp == getKeySetting("keymap_screenshot"))) {
 			m_client->makeScreenshot();
@@ -3632,7 +3634,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			}
 			return true;
 		}
-
 	}
 
 	/* Mouse event other than movement, or crossing the border of inventory

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -503,6 +503,8 @@ private:
 	fs_key_pendig current_keys_pending;
 	std::string current_field_enter_pending = "";
 
+	bool isShiftPressed = false;
+
 	void parseElement(parserData* data, const std::string &element);
 
 	void parseSize(parserData* data, const std::string &element);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -247,12 +247,37 @@ std::string ItemStack::getItemString() const
 	return os.str();
 }
 
-std::string ItemStack::getDescription(IItemDefManager *itemdef) const
+std::string ItemStack::getDescription(IItemDefManager *itemdef, bool detailed,
+	bool append_itemname) const
 {
-	std::string desc = metadata.getString("description");
+	std::string desc;
+
+	if (detailed) {
+		// detailed_description...
+		// ...in meta
+		desc = metadata.getString("detailed_description");
+
+		// ...in definition
+		if (desc.empty())
+			desc = getDefinition(itemdef).detailed_description;
+	}
+
+	// normal description...
+	// ...in meta
+	if (desc.empty())
+		desc = metadata.getString("description");
+
+	// ...in definition
 	if (desc.empty())
 		desc = getDefinition(itemdef).description;
-	return desc.empty() ? name : desc;
+
+	// item name fallback / appendage
+	if (desc.empty())
+		desc = name;
+	else if (append_itemname)
+		desc += "\n[" + name + "]";
+
+	return desc;
 }
 
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -48,7 +48,8 @@ struct ItemStack
 	// Returns the string used for inventory
 	std::string getItemString() const;
 	// Returns the tooltip
-	std::string getDescription(IItemDefManager *itemdef) const;
+	std::string getDescription(IItemDefManager *itemdef, bool detailed = false,
+		bool append_itemname = false) const;
 
 	/*
 		Quantity methods

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -62,6 +62,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	type = def.type;
 	name = def.name;
 	description = def.description;
+	detailed_description = def.detailed_description;
 	inventory_image = def.inventory_image;
 	inventory_overlay = def.inventory_overlay;
 	wield_image = def.wield_image;
@@ -102,6 +103,7 @@ void ItemDefinition::reset()
 	type = ITEM_NONE;
 	name = "";
 	description = "";
+	detailed_description = "";
 	inventory_image = "";
 	inventory_overlay = "";
 	wield_image = "";
@@ -162,6 +164,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	writeARGB8(os, color);
 	os << serializeString(inventory_overlay);
 	os << serializeString(wield_overlay);
+	os << serializeString(detailed_description);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)
@@ -213,8 +216,9 @@ void ItemDefinition::deSerialize(std::istream &is)
 
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.
-	//try {
-	//} catch(SerializationError &e) {};
+	try {
+		detailed_description = deSerializeString(is);
+	} catch(SerializationError &e) {};
 }
 
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -55,6 +55,7 @@ struct ItemDefinition
 	ItemType type;
 	std::string name; // "" = hand
 	std::string description; // Shown in tooltip.
+	std::string detailed_description; // Shown in tooltip when holding shift.
 
 	/*
 		Visual properties

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -56,6 +56,7 @@ void read_item_definition(lua_State* L, int index,
 			es_ItemType, ITEM_NONE);
 	getstringfield(L, index, "name", def.name);
 	getstringfield(L, index, "description", def.description);
+	def.detailed_description = getstringfield_default(L, index, "detailed_description", "");
 	getstringfield(L, index, "inventory_image", def.inventory_image);
 	getstringfield(L, index, "inventory_overlay", def.inventory_overlay);
 	getstringfield(L, index, "wield_image", def.wield_image);
@@ -141,6 +142,10 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "name");
 	lua_pushstring(L, i.description.c_str());
 	lua_setfield(L, -2, "description");
+	if (!i.detailed_description.empty()) {
+		lua_pushstring(L, i.detailed_description.c_str());
+		lua_setfield(L, -2, "detailed_description");
+	}
 	lua_pushstring(L, type.c_str());
 	lua_setfield(L, -2, "type");
 	lua_pushstring(L, i.inventory_image.c_str());


### PR DESCRIPTION
- I'm always frustrated when I want to describe an item but don't want this description to be shown always. This PR adds the field `detailed_description` to the item definition and also the corresponding meta field. `detailed_description` is used in favour of `description` when the same key is pressed as the one needed for listrings, shift (not sneak).
- I think there was an issue for this. I'll have to search. Edit: I haven't found anything.
- There are probably many usecases for this, for example special properties for tools or a detailed description on how to use the screwdriver.
     

## Screenshot

![screenshot_20190804_194358](https://user-images.githubusercontent.com/7613443/62427369-6a1ae880-b6f2-11e9-82b7-6fe05369e406.png)
(That mouse is not real.)
## To do

This PR is a Ready for Review.
Please read my code comments, too.

## How to test

Try the minimal mese pick and use the following chatcommand to test the meta field:
```lua
minetest.register_chatcommand("dd", {
	params = "<detailed_description>",
	description = "set the detailed_description",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local item = player:get_wielded_item()
		local meta = item:get_meta()
		--~ meta:set_string("detailed_description", minetest.colorize("#abc", param))
		meta:set_string("detailed_description", param)
		player:set_wielded_item(item)
		return true, "detailed_description set to \"" .. param .. "\""
	end,
})
```

