### PR TITLE
Optimize usage of TOSERVER_GOTBLOCKS packet

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -465,7 +465,7 @@ private:
 	void promptConfirmRegistration(AuthMechanism chosen_auth_mechanism);
 	void startAuth(AuthMechanism chosen_auth_mechanism);
 	void sendDeletedBlocks(std::vector<v3s16> &blocks);
-	void sendGotBlocks(v3s16 block);
+	void sendGotBlocks(const std::vector<v3s16> &blocks);
 	void sendRemovedSounds(std::vector<s32> &soundList);
 
 	// Helper function


### PR DESCRIPTION
A `GOTBLOCKS` packet can hold up to 255 positions, but we've been sending one packet for each pos.
This is such an obvious optimization I wonder why it wasn't done earlier.

## To do
This PR is Ready for Review.

## How to test
Look at these screenshots and trust me.

Before patch:
![Bildschirmfoto_2019-08-07_10-33-57](https://user-images.githubusercontent.com/1042418/62607869-16c9b580-b8ff-11e9-807f-eebbe9231223.png)
After patch:
![Bildschirmfoto_2019-08-07_10-28-21](https://user-images.githubusercontent.com/1042418/62607971-45479080-b8ff-11e9-9cfb-b8d08ec9d606.png)
