### PR TITLE
Fix usage of wrong variable in builtin chat command handling.

### DIFF
--- a/builtin/game/chatcommands.lua
+++ b/builtin/game/chatcommands.lua
@@ -29,7 +29,7 @@ core.register_on_chat_message(function(name, message)
 		core.set_last_run_mod(cmd_def.mod_origin)
 		local _, result = cmd_def.func(name, param)
 		if result then
-			core.chat_send_player(name, message)
+			core.chat_send_player(name, result)
 		end
 	else
 		core.chat_send_player(name, "You don't have permission"


### PR DESCRIPTION
This was introduced in commit 8e75785 and resulted in chat commands not returning their output text.
