### PR TITLE
guiVolumeChange: Fix child not being removed

### DIFF
--- a/src/gui/guiVolumeChange.cpp
+++ b/src/gui/guiVolumeChange.cpp
@@ -58,6 +58,9 @@ void GUIVolumeChange::removeChildren()
 
 	if (gui::IGUIElement *e = getElementFromId(ID_soundSlider))
 		e->remove();
+
+	if (gui::IGUIElement *e = getElementFromId(ID_soundMuteButton))
+		e->remove();
 }
 
 void GUIVolumeChange::regenerateGui(v2u32 screensize)
@@ -193,4 +196,3 @@ bool GUIVolumeChange::OnEvent(const SEvent& event)
 
 	return Parent ? Parent->OnEvent(event) : false;
 }
-


### PR DESCRIPTION
This trivial PR fixes the "muted" checkbox not being removed in `removeChildren`, resulting in duplication when resizing the window, for example. Issue noted, and solution provided by @kilbith 

To test:
- Fire up MT and launch a game.
- Open Volume change dialog in the pause menu.
- Resize the window.
- Observe that the "muted" checkbox isn't duplicated anywhere (not the case in `master`)
