### PR TITLE
Fix rotation of attached particlespawner [no squash pls; ketchup ok]

### DIFF
--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -39,54 +39,53 @@ public:
 	ClientActiveObject(u16 id, Client *client, ClientEnvironment *env);
 	virtual ~ClientActiveObject();
 
-	virtual void addToScene(ITextureSource *tsrc) {};
+	virtual void addToScene(ITextureSource *tsrc) {}
 	virtual void removeFromScene(bool permanent) {}
 	// 0 <= light_at_pos <= LIGHT_SUN
-	virtual void updateLight(u8 light_at_pos){}
-	virtual void updateLightNoCheck(u8 light_at_pos){}
-	virtual v3s16 getLightPosition(){return v3s16(0,0,0);}
+	virtual void updateLight(u8 light_at_pos) {}
+	virtual void updateLightNoCheck(u8 light_at_pos) {}
+	virtual v3s16 getLightPosition() { return v3s16(0, 0, 0); }
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
 	virtual bool collideWithObjects() const { return false; }
 	virtual const v3f getPosition() const { return v3f(0.0f); }
 	virtual scene::ISceneNode *getSceneNode() { return NULL; }
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode() { return NULL; }
-	virtual bool isLocalPlayer() const {return false;}
+	virtual bool isLocalPlayer() const { return false; }
 
 	virtual ClientActiveObject *getParent() const { return nullptr; };
 	virtual const std::unordered_set<int> &getAttachmentChildIds() const
 	{ static std::unordered_set<int> rv; return rv; }
 	virtual void updateAttachments() {};
 
-	virtual bool doShowSelectionBox(){return true;}
+	virtual bool doShowSelectionBox() { return true; }
 
 	// Step object in time
-	virtual void step(float dtime, ClientEnvironment *env){}
+	virtual void step(float dtime, ClientEnvironment *env) {}
 
 	// Process a message sent by the server side object
-	virtual void processMessage(const std::string &data){}
+	virtual void processMessage(const std::string &data) {}
 
-	virtual std::string infoText() {return "";}
-	virtual std::string debugInfoText() {return "";}
+	virtual std::string infoText() { return ""; }
+	virtual std::string debugInfoText() { return ""; }
 
 	/*
 		This takes the return value of
 		ServerActiveObject::getClientInitializationData
 	*/
-	virtual void initialize(const std::string &data){}
+	virtual void initialize(const std::string &data) {}
 
 	// Create a certain type of ClientActiveObject
-	static ClientActiveObject* create(ActiveObjectType type, Client *client,
-			ClientEnvironment *env);
+	static ClientActiveObject *create(ActiveObjectType type, Client *client,
+		ClientEnvironment *env);
 
 	// If returns true, punch will not be sent to the server
-	virtual bool directReportPunch(v3f dir, const ItemStack *punchitem=NULL,
-			float time_from_last_punch=1000000)
-	{ return false; }
+	virtual bool directReportPunch(v3f dir, const ItemStack *punchitem = nullptr,
+		float time_from_last_punch = 1000000) { return false; }
 
 protected:
 	// Used for creating objects based on type
-	typedef ClientActiveObject* (*Factory)(Client *client, ClientEnvironment *env);
+	typedef ClientActiveObject *(*Factory)(Client *client, ClientEnvironment *env);
 	static void registerType(u16 type, Factory f);
 	Client *m_client;
 	ClientEnvironment *m_env;

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -48,8 +48,7 @@ public:
 	virtual bool getCollisionBox(aabb3f *toset) const { return false; }
 	virtual bool getSelectionBox(aabb3f *toset) const { return false; }
 	virtual bool collideWithObjects() const { return false; }
-	virtual v3f getPosition(){ return v3f(0,0,0); }
-	virtual float getYaw() const { return 0; }
+	virtual const v3f getPosition() const { return v3f(0.0f); }
 	virtual scene::ISceneNode *getSceneNode() { return NULL; }
 	virtual scene::IAnimatedMeshSceneNode *getAnimatedMeshSceneNode() { return NULL; }
 	virtual bool isLocalPlayer() const {return false;}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -401,7 +401,7 @@ bool GenericCAO::getSelectionBox(aabb3f *toset) const
 	return true;
 }
 
-v3f GenericCAO::getPosition()
+const v3f GenericCAO::getPosition() const
 {
 	if (getParent() != nullptr) {
 		if (m_matrixnode)

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -154,12 +154,9 @@ public:
 
 	virtual bool getSelectionBox(aabb3f *toset) const;
 
-	v3f getPosition();
+	const v3f getPosition() const;
 
-	inline const v3f &getRotation()
-	{
-		return m_rotation;
-	}
+	inline const v3f &getRotation() const { return m_rotation; }
 
 	const bool isImmortal();
 
@@ -178,6 +175,12 @@ public:
 	{
 		assert(m_matrixnode);
 		return m_matrixnode->getRelativeTransformationMatrix();
+	}
+
+	inline const core::matrix4 &getAbsolutePosRotMatrix() const
+	{
+		assert(m_matrixnode);
+		return m_matrixnode->getAbsoluteTransformation();
 	}
 
 	inline f32 getStepHeight() const

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -101,8 +101,13 @@ Particle::Particle(
 	m_glow = glow;
 
 	// Irrlicht stuff
-	m_collisionbox = aabb3f
-			(-size/2,-size/2,-size/2,size/2,size/2,size/2);
+	m_collisionbox = aabb3f(
+		-size / 2,
+		-size / 2,
+		-size / 2,
+		 size / 2,
+		 size / 2,
+		 size / 2);
 	this->setAutomaticCulling(scene::EAC_OFF);
 
 	// Init lighting
@@ -122,7 +127,7 @@ void Particle::OnRegisterSceneNode()
 
 void Particle::render()
 {
-	video::IVideoDriver* driver = SceneManager->getVideoDriver();
+	video::IVideoDriver *driver = SceneManager->getVideoDriver();
 	driver->setMaterial(m_material);
 	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);
 
@@ -293,9 +298,9 @@ ParticleSpawner::ParticleSpawner(
 	m_animation = anim;
 	m_glow = glow;
 
-	for (u16 i = 0; i<=m_amount; i++)
+	for (u16 i = 0; i <= m_amount; i++)
 	{
-		float spawntime = (float)rand()/(float)RAND_MAX*m_spawntime;
+		float spawntime = (float)rand() / (float)RAND_MAX * m_spawntime;
 		m_spawntimes.push_back(spawntime);
 	}
 }
@@ -359,7 +364,7 @@ void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
 	));
 }
 
-void ParticleSpawner::step(float dtime, ClientEnvironment* env)
+void ParticleSpawner::step(float dtime, ClientEnvironment *env)
 {
 	m_time += dtime;
 
@@ -381,7 +386,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 		for (std::vector<float>::iterator i = m_spawntimes.begin();
 				i != m_spawntimes.end();) {
 			if ((*i) <= m_time && m_amount > 0) {
-				m_amount--;
+				--m_amount;
 
 				// Pretend to, but don't actually spawn a particle if it is
 				// attached to an unloaded object or distant from player.
@@ -408,7 +413,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 }
 
 
-ParticleManager::ParticleManager(ClientEnvironment* env) :
+ParticleManager::ParticleManager(ClientEnvironment *env) :
 	m_env(env)
 {}
 
@@ -570,7 +575,7 @@ void ParticleManager::handleParticleEvent(ClientEvent *event, Client *client,
 // The final burst of particles when a node is finally dug, *not* particles
 // spawned during the digging of a node.
 
-void ParticleManager::addDiggingParticles(IGameDef* gamedef,
+void ParticleManager::addDiggingParticles(IGameDef *gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
 {
 	// No particles for "airlike" nodes
@@ -585,7 +590,7 @@ void ParticleManager::addDiggingParticles(IGameDef* gamedef,
 // During the digging of a node particles are spawned individually by this
 // function, called from Game::handleDigging() in game.cpp.
 
-void ParticleManager::addNodeParticle(IGameDef* gamedef,
+void ParticleManager::addNodeParticle(IGameDef *gamedef,
 	LocalPlayer *player, v3s16 pos, const MapNode &n, const ContentFeatures &f)
 {
 	// No particles for "airlike" nodes
@@ -637,7 +642,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	else
 		n.getColor(f, &color);
 
-	Particle* toadd = new Particle(
+	Particle *toadd = new Particle(
 		gamedef,
 		player,
 		m_env,
@@ -660,7 +665,7 @@ void ParticleManager::addNodeParticle(IGameDef* gamedef,
 	addParticle(toadd);
 }
 
-void ParticleManager::addParticle(Particle* toadd)
+void ParticleManager::addParticle(Particle *toadd)
 {
 	MutexAutoLock lock(m_particle_list_lock);
 	m_particles.push_back(toadd);

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cmath>
 #include "client.h"
 #include "collision.h"
+#include "client/content_cao.h"
 #include "client/clientevent.h"
 #include "client/renderingengine.h"
 #include "util/numeric.h"
@@ -38,9 +39,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 v3f random_v3f(v3f min, v3f max)
 {
-	return v3f( rand()/(float)RAND_MAX*(max.X-min.X)+min.X,
-			rand()/(float)RAND_MAX*(max.Y-min.Y)+min.Y,
-			rand()/(float)RAND_MAX*(max.Z-min.Z)+min.Z);
+	return v3f(
+		rand() / (float)RAND_MAX * (max.X - min.X) + min.X,
+		rand() / (float)RAND_MAX * (max.Y - min.Y) + min.Y,
+		rand() / (float)RAND_MAX * (max.Z - min.Z) + min.Z);
 }
 
 Particle::Particle(
@@ -299,16 +301,21 @@ ParticleSpawner::ParticleSpawner(
 }
 
 void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
-	bool is_attached, const v3f &attached_pos, float attached_yaw)
+	const core::matrix4 *attached_absolute_pos_rot_matrix)
 {
 	v3f ppos = m_player->getPosition() / BS;
 	v3f pos = random_v3f(m_minpos, m_maxpos);
 
 	// Need to apply this first or the following check
 	// will be wrong for attached spawners
-	if (is_attached) {
-		pos.rotateXZBy(attached_yaw);
-		pos += attached_pos;
+	if (attached_absolute_pos_rot_matrix) {
+		pos *= BS;
+		attached_absolute_pos_rot_matrix->transformVect(pos);
+		pos /= BS;
+		v3s16 camera_offset = m_particlemanager->m_env->getCameraOffset();
+		pos.X += camera_offset.X;
+		pos.Y += camera_offset.Y;
+		pos.Z += camera_offset.Z;
 	}
 
 	if (pos.getDistanceFrom(ppos) > radius)
@@ -317,18 +324,19 @@ void ParticleSpawner::spawnParticle(ClientEnvironment *env, float radius,
 	v3f vel = random_v3f(m_minvel, m_maxvel);
 	v3f acc = random_v3f(m_minacc, m_maxacc);
 
-	if (is_attached) {
-		// Apply attachment yaw
-		vel.rotateXZBy(attached_yaw);
-		acc.rotateXZBy(attached_yaw);
+	if (attached_absolute_pos_rot_matrix) {
+		// Apply attachment rotation
+		attached_absolute_pos_rot_matrix->rotateVect(vel);
+		attached_absolute_pos_rot_matrix->rotateVect(acc);
 	}
 
 	float exptime = rand() / (float)RAND_MAX
-			* (m_maxexptime - m_minexptime)
-			+ m_minexptime;
+		* (m_maxexptime - m_minexptime)
+		+ m_minexptime;
+
 	float size = rand() / (float)RAND_MAX
-			* (m_maxsize - m_minsize)
-			+ m_minsize;
+		* (m_maxsize - m_minsize)
+		+ m_minsize;
 
 	m_particlemanager->addParticle(new Particle(
 		m_gamedef,
@@ -359,14 +367,10 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 			g_settings->getS16("max_block_send_distance") * MAP_BLOCKSIZE;
 
 	bool unloaded = false;
-	bool is_attached = false;
-	v3f attached_pos = v3f(0,0,0);
-	float attached_yaw = 0;
-	if (m_attached_id != 0) {
-		if (ClientActiveObject *attached = env->getActiveObject(m_attached_id)) {
-			attached_pos = attached->getPosition() / BS;
-			attached_yaw = attached->getYaw();
-			is_attached = true;
+	const core::matrix4 *attached_absolute_pos_rot_matrix = nullptr;
+	if (m_attached_id) {
+		if (GenericCAO *attached = dynamic_cast<GenericCAO *>(env->getActiveObject(m_attached_id))) {
+			attached_absolute_pos_rot_matrix = &attached->getAbsolutePosRotMatrix();
 		} else {
 			unloaded = true;
 		}
@@ -382,7 +386,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 				// Pretend to, but don't actually spawn a particle if it is
 				// attached to an unloaded object or distant from player.
 				if (!unloaded)
-					spawnParticle(env, radius, is_attached, attached_pos, attached_yaw);
+					spawnParticle(env, radius, attached_absolute_pos_rot_matrix);
 
 				i = m_spawntimes.erase(i);
 			} else {
@@ -398,7 +402,7 @@ void ParticleSpawner::step(float dtime, ClientEnvironment* env)
 
 		for (int i = 0; i <= m_amount; i++) {
 			if (rand() / (float)RAND_MAX < dtime)
-				spawnParticle(env, radius, is_attached, attached_pos, attached_yaw);
+				spawnParticle(env, radius, attached_absolute_pos_rot_matrix);
 		}
 	}
 }
@@ -419,7 +423,7 @@ void ParticleManager::step(float dtime)
 	stepSpawners (dtime);
 }
 
-void ParticleManager::stepSpawners (float dtime)
+void ParticleManager::stepSpawners(float dtime)
 {
 	MutexAutoLock lock(m_spawner_list_lock);
 	for (auto i = m_particle_spawners.begin(); i != m_particle_spawners.end();) {
@@ -433,7 +437,7 @@ void ParticleManager::stepSpawners (float dtime)
 	}
 }
 
-void ParticleManager::stepParticles (float dtime)
+void ParticleManager::stepParticles(float dtime)
 {
 	MutexAutoLock lock(m_particle_list_lock);
 	for (auto i = m_particles.begin(); i != m_particles.end();) {
@@ -448,7 +452,7 @@ void ParticleManager::stepParticles (float dtime)
 	}
 }
 
-void ParticleManager::clearAll ()
+void ParticleManager::clearAll()
 {
 	MutexAutoLock lock(m_spawner_list_lock);
 	MutexAutoLock lock2(m_particle_list_lock);
@@ -457,9 +461,7 @@ void ParticleManager::clearAll ()
 		m_particle_spawners.erase(i++);
 	}
 
-	for(std::vector<Particle*>::iterator i =
-			m_particles.begin();
-			i != m_particles.end();)
+	for(auto i = m_particles.begin(); i != m_particles.end();)
 	{
 		(*i)->remove();
 		delete *i;

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -144,8 +144,7 @@ public:
 
 private:
 	void spawnParticle(ClientEnvironment *env, float radius,
-			bool is_attached, const v3f &attached_pos,
-			float attached_yaw);
+		const core::matrix4 *attached_absolute_pos_rot_matrix);
 
 	ParticleManager *m_particlemanager;
 	float m_time;


### PR DESCRIPTION
PR created from pgimeno's commit: https://gitlab.com/pgimeno/minetest/commit/16593ff796d8a4c96a60e69d1c7e6813d8ab22f3

****

This PR fixes attached particle spawners not rotating with the parent object. See #8363 for more information.

### Screenshot

![screenshot_20190809_163916](https://user-images.githubusercontent.com/36130650/62776254-a28e3e00-bac7-11e9-9707-297307e9f7ce.png)

### How to test

- Install and enable `advtrains` mod.
- Launch the game.
- Place a couple of tracks, and place a steam loco on a track.
- Observe that the steam particle spawner is positioned exactly on the chimney, and is fixed to the object in the same position irrespective of object's rotation (this is broken in `master`).

****

This PR is ready for review. Tested; works. Fixes #8363.

This PR also fixes code-style in `src/client/clientobject.h` and `src/client/particles.cpp` in a separate commit for ease of reviewing. Pls no squash.