### PR TITLE
Auto delete MetaData when = 0

### DIFF
--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -153,7 +153,9 @@ int MetaDataRef::l_set_int(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	int a = luaL_checkint(L, 3);
-	std::string str = itos(a);
+	std::string str = std::string("");
+	if (a != 0)
+		str = itos(a);
 
 	Metadata *meta = ref->getmeta(true);
 	if (meta == NULL || str == meta->getString(name))
@@ -191,7 +193,9 @@ int MetaDataRef::l_set_float(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	float a = readParam<float>(L, 3);
-	std::string str = ftos(a);
+	std::string str = std::string("");
+	if (a != 0)
+		str = ftos(a);	
 
 	Metadata *meta = ref->getmeta(true);
 	if (meta == NULL || str == meta->getString(name))

--- a/src/script/lua_api/l_metadata.cpp
+++ b/src/script/lua_api/l_metadata.cpp
@@ -153,7 +153,7 @@ int MetaDataRef::l_set_int(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	int a = luaL_checkint(L, 3);
-	std::string str = std::string("");
+	std::string str;
 	if (a != 0)
 		str = itos(a);
 
@@ -193,9 +193,9 @@ int MetaDataRef::l_set_float(lua_State *L)
 	MetaDataRef *ref = checkobject(L, 1);
 	std::string name = luaL_checkstring(L, 2);
 	float a = readParam<float>(L, 3);
-	std::string str = std::string("");
+	std::string str;
 	if (a != 0)
-		str = ftos(a);	
+		str = ftos(a);
 
 	Metadata *meta = ref->getmeta(true);
 	if (meta == NULL || str == meta->getString(name))


### PR DESCRIPTION
We still automatic delete a key of a metadata or mod_storage data if it is = ""
This PR also auto deletes if it is = 0
As we basically also return 0 for no value this makes no compatibility problems
This saves memory when mods for example remove a player and set the var to default = 0

## How to test
``` Lua
local storage = minetest.get_mod_storage()

storage:set_string("placeholder", "make sure file is not null")

storage:set_int("int", 100)
storage:set_int("int", 0)
storage:set_float("float", 100.1)
storage:set_float("float", 0)

storage:set_float("float2", 100.1)
storage:set_float("float2", 0.0)

storage:set_string("string", "stringggggggggggg")
storage:set_string("string", "")
```
All the entries will disappear without the PR float, float2 and int will stay = 0