### PR TITLE
Fix breakage of non-GLES2 setups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,15 +104,17 @@ endif()
 
 option(ENABLE_GLES "Use OpenGL ES instead of OpenGL" FALSE)
 mark_as_advanced(ENABLE_GLES)
-if(ENABLE_GLES)
-	find_package(OpenGLES2 REQUIRED)
-elseif()
-	if(NOT WIN32) # Unix probably
-		set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
-			"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
-		set(OpenGL_GL_PREFERENCE ${OPENGL_GL_PREFERENCE})
+if(BUILD_CLIENT)
+	if(ENABLE_GLES)
+		find_package(OpenGLES2 REQUIRED)
+	else()
+		if(NOT WIN32) # Unix probably
+			set(OPENGL_GL_PREFERENCE "LEGACY" CACHE STRING
+				"See CMake Policy CMP0072 for reference. GLVND is broken on some nvidia setups")
+			set(OpenGL_GL_PREFERENCE ${OPENGL_GL_PREFERENCE})
 
-		find_package(OpenGL REQUIRED)
+			find_package(OpenGL REQUIRED)
+		endif()
 	endif()
 endif()
 


### PR DESCRIPTION
This pull request fixes a "gotcha" in src/CMakeLists.txt: When you move the OpenGL detection code to the place where the GLES2 detection code is, the build will fail because the OpenGL libraries will NOT be in the list of libraries to be linked in. What I suspect is happening is that find_package tries to add the libraries into the list and later the list is cleared out and filled with other libraries (git show 526a9e4b66abaf83eb6b1aaa3e93375acd87b830 shows the code at the wrong location, then a huge pile of $(BLABLA_LIBRAR[Y|IES]), then the code at the right location removed).

EDIT: It turns out it is not a "gotcha" but a typo. One of the new lines in the original commit says "elseif()" instead of "else()", causing the code relevant for the non-GLES2 setups to be permanently disabled.

EDIT2: Turned out the line most likely wanted to be "elseif(BUILD_CLIENT)" and the "BUILD_CLIENT" part got lost somewhere.