### PR TITLE
Allow calling ItemStack with no arguments

### DIFF
--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -404,7 +404,9 @@ ItemStack& LuaItemStack::getItem()
 int LuaItemStack::create_object(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	ItemStack item = read_item(L, 1, getGameDef(L)->idef());
+	ItemStack item;
+	if (!lua_isnone(L, 1))
+		item = read_item(L, 1, getGameDef(L)->idef());
 	LuaItemStack *o = new LuaItemStack(item);
 	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
 	luaL_getmetatable(L, className);


### PR DESCRIPTION
Allows creating an ItemStack with `ItemStack()`. It creates an empy stack just like `ItemStack(nil)` and `ItemStack("")`.

~This also affects other places where `read_item` is used. E.g. `InvRef:add_item(listname)` will add an empty stack (note that `add_item(listname, nil)` is already possible).~

## How to test

`assert(ItemStack():to_string() == "")`