### PR TITLE
Fix unnecessary exception use in Map::isNodeUnderground

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -152,14 +152,8 @@ MapBlock * Map::getBlockNoCreate(v3s16 p3d)
 bool Map::isNodeUnderground(v3s16 p)
 {
 	v3s16 blockpos = getNodeBlockPos(p);
-	try{
-		MapBlock * block = getBlockNoCreate(blockpos);
-		return block->getIsUnderground();
-	}
-	catch(InvalidPositionException &e)
-	{
-		return false;
-	}
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	return block && block->getIsUnderground(); 
 }
 
 bool Map::isValidPosition(v3s16 p)


### PR DESCRIPTION
Another exception usage nonsense to be removed. In this one the method in question throws an exception only to be caught one call level higher, slowing down the whole thing. Replaced the "one call level higher" code with call to the NoEx version and an "if" instead of try...catch.