### PR TITLE
Fix compare between pointer and 0 in unittests

### DIFF
--- a/src/unittest/test.cpp
+++ b/src/unittest/test.cpp
@@ -650,12 +650,12 @@ struct TestMapSector: public TestBase
 		// Create one with no heightmaps
 		ServerMapSector sector(&parent, v2s16(1,1));
 
-		UASSERT(sector.getBlockNoCreateNoEx(0) == 0);
-		UASSERT(sector.getBlockNoCreateNoEx(1) == 0);
+		UASSERT(sector.getBlockNoCreateNoEx(0) == nullptr);
+		UASSERT(sector.getBlockNoCreateNoEx(1) == nullptr);
 
 		MapBlock * bref = sector.createBlankBlock(-2);
 
-		UASSERT(sector.getBlockNoCreateNoEx(0) == 0);
+		UASSERT(sector.getBlockNoCreateNoEx(0) == nullptr);
 		UASSERT(sector.getBlockNoCreateNoEx(-2) == bref);
 
 		//TODO: Check for AlreadyExistsException


### PR DESCRIPTION
This bunch of comparisons between a pointer and 0 just hit my eyes.