### PR TITLE
Fix unnecessary exception use in Map::getSectorXXX

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -63,14 +63,13 @@ ClientMap::ClientMap(
 MapSector * ClientMap::emergeSector(v2s16 p2d)
 {
 	// Check that it doesn't exist already
-	try {
-		return getSectorNoGenerate(p2d);
-	} catch(InvalidPositionException &e) {
-	}
+	MapSector *sector = getSectorNoGenerate(p2d);
 
-	// Create a sector
-	MapSector *sector = new MapSector(this, p2d, m_gamedef);
-	m_sectors[p2d] = sector;
+	// Create it if it does not exist yet
+	if (!sector) {
+		sector = new MapSector(this, p2d, m_gamedef);
+		m_sectors[p2d] = sector;
+	}
 
 	return sector;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -96,7 +96,7 @@ void Map::dispatchEvent(MapEditEvent *event)
 	}
 }
 
-MapSector * Map::getSectorNoGenerateNoExNoLock(v2s16 p)
+MapSector * Map::getSectorNoGenerateNoLock(v2s16 p)
 {
 	if(m_sector_cache != NULL && p == m_sector_cache_p){
 		MapSector * sector = m_sector_cache;
@@ -117,24 +117,15 @@ MapSector * Map::getSectorNoGenerateNoExNoLock(v2s16 p)
 	return sector;
 }
 
-MapSector * Map::getSectorNoGenerateNoEx(v2s16 p)
-{
-	return getSectorNoGenerateNoExNoLock(p);
-}
-
 MapSector * Map::getSectorNoGenerate(v2s16 p)
 {
-	MapSector *sector = getSectorNoGenerateNoEx(p);
-	if(sector == NULL)
-		throw InvalidPositionException();
-
-	return sector;
+	return getSectorNoGenerateNoLock(p);
 }
 
 MapBlock * Map::getBlockNoCreateNoEx(v3s16 p3d)
 {
 	v2s16 p2d(p3d.X, p3d.Z);
-	MapSector * sector = getSectorNoGenerateNoEx(p2d);
+	MapSector * sector = getSectorNoGenerate(p2d);
 	if(sector == NULL)
 		return NULL;
 	MapBlock *block = sector->getBlockNoCreateNoEx(p3d.Y);
@@ -1410,7 +1401,7 @@ MapSector *ServerMap::createSector(v2s16 p2d)
 	/*
 		Check if it exists already in memory
 	*/
-	MapSector *sector = getSectorNoGenerateNoEx(p2d);
+	MapSector *sector = getSectorNoGenerate(p2d);
 	if (sector)
 		return sector;
 
@@ -2120,7 +2111,7 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 		Make sure sector is loaded
 		 */
 
-		MapSector *sector = getSectorNoGenerateNoEx(p2d);
+		MapSector *sector = getSectorNoGenerate(p2d);
 
 		/*
 		Make sure file exists
@@ -2163,7 +2154,7 @@ bool ServerMap::deleteBlock(v3s16 blockpos)
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if (block) {
 		v2s16 p2d(blockpos.X, blockpos.Z);
-		MapSector *sector = getSectorNoGenerateNoEx(p2d);
+		MapSector *sector = getSectorNoGenerate(p2d);
 		if (!sector)
 			return false;
 		sector->deleteBlock(block);

--- a/src/map.h
+++ b/src/map.h
@@ -155,10 +155,8 @@ public:
 	void dispatchEvent(MapEditEvent *event);
 
 	// On failure returns NULL
-	MapSector * getSectorNoGenerateNoExNoLock(v2s16 p2d);
+	MapSector * getSectorNoGenerateNoLock(v2s16 p2d);
 	// Same as the above (there exists no lock anymore)
-	MapSector * getSectorNoGenerateNoEx(v2s16 p2d);
-	// On failure throws InvalidPositionException
 	MapSector * getSectorNoGenerate(v2s16 p2d);
 	// Gets an existing sector or creates an empty one
 	//MapSector * getSectorCreate(v2s16 p2d);


### PR DESCRIPTION
The mapsector getters also mess up with exceptions unnecessarily. Get rid of the exception-full version and clean up the names of the two other methods that remain.