### PR TITLE
Mapgen v6: Fix mudflow iteration and iterate twice

### DIFF
--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -773,21 +773,21 @@ void MapgenV6::addMud()
 
 void MapgenV6::flowMud(s16 &mudflow_minpos, s16 &mudflow_maxpos)
 {
-	// 340ms @cs=8
-	//TimeTaker timer1("flow mud");
-
-	// Iterate a few times
-	for (s16 k = 0; k < 3; k++) {
+	// Iterate twice
+	for (s16 k = 0; k < 2; k++) {
 		for (s16 z = mudflow_minpos; z <= mudflow_maxpos; z++)
 		for (s16 x = mudflow_minpos; x <= mudflow_maxpos; x++) {
-			// Invert coordinates every 2nd iteration
-			if (k % 2 == 0) {
-				x = mudflow_maxpos - (x - mudflow_minpos);
-				z = mudflow_maxpos - (z - mudflow_minpos);
+			// Node column position
+			v2s16 p2d;
+			// Invert coordinates on second iteration to process columns in
+			// opposite order, to avoid a directional bias.
+			if (k == 1) {
+				p2d = v2s16(node_min.X, node_min.Z) + v2s16(
+					mudflow_maxpos - (x - mudflow_minpos),
+					mudflow_maxpos - (z - mudflow_minpos));
+			} else {
+				p2d = v2s16(node_min.X, node_min.Z) + v2s16(x, z);
 			}
-
-			// Node position in 2d
-			v2s16 p2d = v2s16(node_min.X, node_min.Z) + v2s16(x, z);
 
 			const v3s16 &em = vm->m_area.getExtent();
 			u32 i = vm->m_area.index(p2d.X, node_max.Y, p2d.Y);


### PR DESCRIPTION
 Mapgen v6: Fix mudflow iteration and iterate twice

In MapgenV6::flowMud(), the previous implementation of coordinate
inversion caused the 2 inverted mudflow iterations (out of the 3
iterations) to not loop over the area, so only 1 non-inverted
iteration occurred.

Fix this bug but only iterate mudflow twice, as mapgen v6 has only
had 1 iteration for many years. There is now a good balance of 1
non-inverted iteration and 1 inverted iteration.
///////////////////////////////////////////////

![mudflow_pr](https://user-images.githubusercontent.com/3686677/63064178-f6e65300-bef7-11e9-805a-69a0f0966362.png)

^ PR

![mud_master](https://user-images.githubusercontent.com/3686677/63064188-ff3e8e00-bef7-11e9-9b14-483ce20778b9.png)

^ Master branch

For part of #8784 see issue for details. Don't close the issue on merge.

Screenshots show PR mudflow is similar to master branch but has more 'settling' of dirt, and less dirt piled up on cliff edges, as expected from increase from 1 to 2 iterations. Looks more natural, cleaner and better to me.