### PR TITLE
Do not make a warning because of global _

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -26,6 +26,7 @@ local function create_world_formspec(dialogdata)
 
 	local gameidx = 0
 	if gameid ~= nil then
+		local _
 		_, gameidx = pkgmgr.find_by_gameid(gameid)
 
 		if gameidx == nil then


### PR DESCRIPTION
This PR fixes #8794.
According to http://lua-users.org/wiki/LuaStyleGuide, `_` is just a normal variable.

## To do

This PR is a Ready for Review.
Note: I didn't test this.

## How to test

Create a new world and watch your logs.
