### PR TITLE
Force-disable fullscreen on Linux

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -623,10 +623,10 @@ screen_h (Screen height) int 600
 #    Save window size automatically when modified.
 autosave_screensize (Autosave screen size) bool true
 
-#    Fullscreen mode.
+#    Fullscreen mode. (Ignored on Linux)
 fullscreen (Full screen) bool false
 
-#    Bits per pixel (aka color depth) in fullscreen mode.
+#    Bits per pixel (aka color depth) in fullscreen mode. (Ignored on Linux)
 fullscreen_bpp (Full screen BPP) int 24
 
 #    Vertical screen synchronization.

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -82,13 +82,11 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	sanity_check(!s_singleton);
 
 	// Resolution selection
-	bool fullscreen = g_settings->getBool("fullscreen");
 	u16 screen_w = g_settings->getU16("screen_w");
 	u16 screen_h = g_settings->getU16("screen_h");
 
-	// bpp, fsaa, vsync
+	// fsaa, vsync
 	bool vsync = g_settings->getBool("vsync");
-	u16 bits = g_settings->getU16("fullscreen_bpp");
 	u16 fsaa = g_settings->getU16("fsaa");
 
 	// stereo buffer required for pageflip stereo
@@ -98,7 +96,7 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	video::E_DRIVER_TYPE driverType = video::EDT_OPENGL;
 	const std::string &driverstring = g_settings->get("video_driver");
 	std::vector<video::E_DRIVER_TYPE> drivers =
-			RenderingEngine::getSupportedVideoDrivers();
+		RenderingEngine::getSupportedVideoDrivers();
 	u32 i;
 	for (i = 0; i != drivers.size(); i++) {
 		if (!strcasecmp(driverstring.c_str(),
@@ -109,16 +107,23 @@ RenderingEngine::RenderingEngine(IEventReceiver *receiver)
 	}
 	if (i == drivers.size()) {
 		errorstream << "Invalid video_driver specified; "
-			       "defaulting to opengl"
-			    << std::endl;
+			"defaulting to OpenGL" << std::endl;
 	}
 
 	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
 	params.DriverType = driverType;
 	params.WindowSize = core::dimension2d<u32>(screen_w, screen_h);
-	params.Bits = bits;
 	params.AntiAlias = fsaa;
-	params.Fullscreen = fullscreen;
+
+	// Fullscreen is broken on Linux. It's recommended to use
+	// the windowing manager's borderless window option instead
+#ifdef __linux__
+	params.Fullscreen = false;
+#else
+	params.Fullscreen = g_settings->getBool("fullscreen");
+	params.Bits = g_settings->getU16("fullscreen_bpp");
+#endif
+
 	params.Stencilbuffer = false;
 	params.Stereobuffer = stereo_buffer;
 	params.Vsync = vsync;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -168,8 +168,12 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("screen_w", "1024");
 	settings->setDefault("screen_h", "600");
 	settings->setDefault("autosave_screensize", "true");
+
+#ifndef __linux__
 	settings->setDefault("fullscreen", "false");
 	settings->setDefault("fullscreen_bpp", "24");
+#endif
+
 	settings->setDefault("vsync", "false");
 	settings->setDefault("fov", "72");
 	settings->setDefault("leaves_style", "fancy");


### PR DESCRIPTION
Settings "fullscreen" and "fullscreen_bpp" (dependent on "fullscreen" being enabled) are ignored on Linux.

A comment in `RenderingEngine::RenderingEngine` explains why:

> ```cpp
> // Fullscreen is broken on Linux. It's recommended to use
> // the windowing manager's borderless window option instead
> ```

Does fullscreen work on other Unix platforms like BSD? If not, should I disable fullscreen in those platforms as well?

### How does the PR work?

This PR simply force-sets `fullscreen` to false if the platform is Linux, ignoring the setting `fullscreen`.

### How to test

- Enable fullscreen, without paying heed to the description of the setting, which says it won't work. (Or simply add `fullscreen = true` to minetest.conf)
- (Re)start MT.
- Observe that MT is still windowed, to your horror and (dis)pleasure.

****

Related #4921; closes #7654.

Tested, :ok:. This PR is ready for review.