### PR TITLE
Find LuaJIT headers on vcpkg

### DIFF
--- a/cmake/Modules/FindLuaJIT.cmake
+++ b/cmake/Modules/FindLuaJIT.cmake
@@ -9,7 +9,7 @@
 FIND_PATH(LUA_INCLUDE_DIR luajit.h
 	HINTS
 	$ENV{LUA_DIR}
-	PATH_SUFFIXES include/luajit-2.1 include/luajit-2.0 include/luajit-5_1-2.1 include/luajit-5_1-2.0 include
+	PATH_SUFFIXES include/luajit-2.1 include/luajit-2.0 include/luajit-5_1-2.1 include/luajit-5_1-2.0 include luajit
 	PATHS
 	~/Library/Frameworks
 	/Library/Frameworks


### PR DESCRIPTION
LuaJIT headers were moved into a subdirectory to avoid conflicts with plain Lua

## To do

This PR is Ready for Review.

## How to test

Compile Minetest using vcpkg toolchain.