### PR TITLE
doc/client_lua_api : clarify how client side api+a mod starts

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -30,7 +30,7 @@ Startup
 Mods are loaded during client startup from the mod load paths by running
 the `init.lua` scripts in a shared environment.
 
-In order to load client-side mods in your worlds, you have 2 conditions :
+In order to load client-side mods in a world, the following conditions need to be satisfied:
 
  1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -32,7 +32,7 @@ the `init.lua` scripts in a shared environment.
 
 In order to load client-side mods in a world, the following conditions need to be satisfied:
 
- 1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
+1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 
  2) The client-side mod located in $path_user/clientmods/<modname> is added to
     $path_user/clientmods/mods.conf as `load_mod_<modname> = true`.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -35,9 +35,9 @@ In order to load client-side mods in a world, the following conditions need to b
  1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 
  2) The client-side mod located in $path_user/clientmods/<modname> is added to
-    $path_user/clientmods/mods.conf as `load_mod_<modname> = true` *.
+    $path_user/clientmods/mods.conf as `load_mod_<modname> = true`.
 
-* Note: Depending on the remote server's settings, client-side mods might not
+Note: Depending on the remote server's settings, client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.
 
 Paths

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -28,7 +28,13 @@ If you have any difficulty in understanding this, please read
 Startup
 -------
 Mods are loaded during client startup from the mod load paths by running
-the `init.lua` scripts in a shared environment.
+the `init.lua` scripts in a shared environment given 2 conditions :
+
+ 1) $path_user/minetest.conf contains "enable_client_modding = true" to allow starting client lua api
+ 
+ 2) for a mod eg called test_client sitting in $path_user/clientmods/test_client that
+$path_user/clientmods/mods.conf contains "load_mod_test_client = true" to allow selective
+module loading.
 
 Paths
 -----

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -32,7 +32,7 @@ the `init.lua` scripts in a shared environment.
 
 In order to load client-side mods in a world, the following conditions need to be satisfied:
 
-1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
+1) `$path_user/minetest.conf` contains the setting `enable_client_modding = true`
 
 2) The client-side mod located in `$path_user/clientmods/<modname>` is added to
     `$path_user/clientmods/mods.conf` as `load_mod_<modname> = true`.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -32,11 +32,10 @@ the `init.lua` scripts in a shared environment.
 
 In order to load client-side mods in your worlds, you have 2 conditions :
 
- 1) $path_user/minetest.conf contains "enable_client_modding = true" to allow starting client lua api
- 
- 2) for a mod eg called test_client sitting in $path_user/clientmods/test_client that
-$path_user/clientmods/mods.conf contains "load_mod_test_client = true" to allow selective
-module loading*.
+ 1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
+
+ 2) The client-side mod located in $path_user/clientmods/<modname> is added to
+    $path_user/clientmods/mods.conf as `load_mod_<modname> = true` in order to load*.
 
 * Note: Depending on the remote server's settings your client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -37,7 +37,7 @@ In order to load client-side mods in your worlds, you have 2 conditions :
  2) The client-side mod located in $path_user/clientmods/<modname> is added to
     $path_user/clientmods/mods.conf as `load_mod_<modname> = true` *.
 
-* Note: Depending on the remote server's settings your client-side mods might not
+* Note: Depending on the remote server's settings, client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.
 
 Paths

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -34,8 +34,8 @@ In order to load client-side mods in a world, the following conditions need to b
 
 1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 
-2) The client-side mod located in $path_user/clientmods/<modname> is added to
-    $path_user/clientmods/mods.conf as `load_mod_<modname> = true`.
+2) The client-side mod located in `$path_user/clientmods/<modname>` is added to
+    `$path_user/clientmods/mods.conf` as `load_mod_<modname> = true`.
 
 Note: Depending on the remote server's settings, client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -28,13 +28,18 @@ If you have any difficulty in understanding this, please read
 Startup
 -------
 Mods are loaded during client startup from the mod load paths by running
-the `init.lua` scripts in a shared environment given 2 conditions :
+the `init.lua` scripts in a shared environment.
+
+In order to load client-side mods in your worlds, you have 2 conditions :
 
  1) $path_user/minetest.conf contains "enable_client_modding = true" to allow starting client lua api
  
  2) for a mod eg called test_client sitting in $path_user/clientmods/test_client that
 $path_user/clientmods/mods.conf contains "load_mod_test_client = true" to allow selective
-module loading.
+module loading*.
+
+* Note: Depending on the remote server's settings your client-side mods might not
+be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.
 
 Paths
 -----

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -35,7 +35,7 @@ In order to load client-side mods in your worlds, you have 2 conditions :
  1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 
  2) The client-side mod located in $path_user/clientmods/<modname> is added to
-    $path_user/clientmods/mods.conf as `load_mod_<modname> = true` in order to load*.
+    $path_user/clientmods/mods.conf as `load_mod_<modname> = true` *.
 
 * Note: Depending on the remote server's settings your client-side mods might not
 be loaded or have limited functionality. See setting `csm_restriction_flags` for reference.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -34,7 +34,7 @@ In order to load client-side mods in a world, the following conditions need to b
 
 1) $path_user/minetest.conf contains the setting `enable_client_modding = true`
 
- 2) The client-side mod located in $path_user/clientmods/<modname> is added to
+2) The client-side mod located in $path_user/clientmods/<modname> is added to
     $path_user/clientmods/mods.conf as `load_mod_<modname> = true`.
 
 Note: Depending on the remote server's settings, client-side mods might not


### PR DESCRIPTION
Add some documentaion to clarify client side api startup, as a newcomer it would have solved my problem understanding how to use an api that is currently turned off by default.
