### PR TITLE
[no squash] Send ActiveObjects along with definitions once connection is established

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1235,42 +1235,41 @@ void Client::sendReady()
 
 void Client::sendPlayerPos()
 {
-	LocalPlayer *myplayer = m_env.getLocalPlayer();
-	if (!myplayer)
+	LocalPlayer *player = m_env.getLocalPlayer();
+	if (!player)
 		return;
 
 	ClientMap &map = m_env.getClientMap();
-
-	u8 camera_fov    = map.getCameraFov();
-	u8 wanted_range  = map.getControl().wanted_range;
+	u8 camera_fov   = map.getCameraFov();
+	u8 wanted_range = map.getControl().wanted_range;
 
 	// Save bandwidth by only updating position when
 	// player is not dead and something changed
 
-	if (m_activeobjects_received && myplayer->isDead())
+	if (m_activeobjects_received && player->isDead())
 		return;
 
 	if (
-			myplayer->last_position     == myplayer->getPosition() &&
-			myplayer->last_speed        == myplayer->getSpeed()    &&
-			myplayer->last_pitch        == myplayer->getPitch()    &&
-			myplayer->last_yaw          == myplayer->getYaw()      &&
-			myplayer->last_keyPressed   == myplayer->keyPressed    &&
-			myplayer->last_camera_fov   == camera_fov              &&
-			myplayer->last_wanted_range == wanted_range)
+			player->last_position     == player->getPosition() &&
+			player->last_speed        == player->getSpeed()    &&
+			player->last_pitch        == player->getPitch()    &&
+			player->last_yaw          == player->getYaw()      &&
+			player->last_keyPressed   == player->keyPressed    &&
+			player->last_camera_fov   == camera_fov              &&
+			player->last_wanted_range == wanted_range)
 		return;
 
-	myplayer->last_position     = myplayer->getPosition();
-	myplayer->last_speed        = myplayer->getSpeed();
-	myplayer->last_pitch        = myplayer->getPitch();
-	myplayer->last_yaw          = myplayer->getYaw();
-	myplayer->last_keyPressed   = myplayer->keyPressed;
-	myplayer->last_camera_fov   = camera_fov;
-	myplayer->last_wanted_range = wanted_range;
+	player->last_position     = player->getPosition();
+	player->last_speed        = player->getSpeed();
+	player->last_pitch        = player->getPitch();
+	player->last_yaw          = player->getYaw();
+	player->last_keyPressed   = player->keyPressed;
+	player->last_camera_fov   = camera_fov;
+	player->last_wanted_range = wanted_range;
 
 	NetworkPacket pkt(TOSERVER_PLAYERPOS, 12 + 12 + 4 + 4 + 4 + 1 + 1);
 
-	writePlayerPos(myplayer, &map, &pkt);
+	writePlayerPos(player, &map, &pkt);
 
 	Send(&pkt);
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1244,8 +1244,14 @@ void Client::sendPlayerPos()
 	u8 camera_fov    = map.getCameraFov();
 	u8 wanted_range  = map.getControl().wanted_range;
 
-	// Save bandwidth by only updating position when something changed
-	if(myplayer->last_position        == myplayer->getPosition() &&
+	// Save bandwidth by only updating position when
+	// player is not dead and something changed
+
+	if (m_activeobjects_received && myplayer->isDead())
+		return;
+
+	if (
+			myplayer->last_position     == myplayer->getPosition() &&
 			myplayer->last_speed        == myplayer->getSpeed()    &&
 			myplayer->last_pitch        == myplayer->getPitch()    &&
 			myplayer->last_yaw          == myplayer->getYaw()      &&

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -333,11 +333,11 @@ public:
 	// disconnect client when CSM failed.
 	const std::string &accessDeniedReason() const { return m_access_denied_reason; }
 
-	bool itemdefReceived()
+	const bool itemdefReceived() const
 	{ return m_itemdef_received; }
-	bool nodedefReceived()
+	const bool nodedefReceived() const
 	{ return m_nodedef_received; }
-	bool mediaReceived()
+	const bool mediaReceived() const
 	{ return !m_media_downloader; }
 	const bool activeObjectsReceived() const
 	{ return m_activeobjects_received; }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -339,6 +339,8 @@ public:
 	{ return m_nodedef_received; }
 	bool mediaReceived()
 	{ return !m_media_downloader; }
+	const bool activeObjectsReceived() const
+	{ return m_activeobjects_received; }
 
 	u16 getProtoVersion()
 	{ return m_proto_ver; }
@@ -540,6 +542,7 @@ private:
 	std::queue<ClientEvent *> m_client_event_queue;
 	bool m_itemdef_received = false;
 	bool m_nodedef_received = false;
+	bool m_activeobjects_received = false;
 	bool m_mods_loaded = false;
 	ClientMediaDownloader *m_media_downloader;
 

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -732,6 +732,11 @@ v3f LocalPlayer::getEyeOffset() const
 	return v3f(0, BS * eye_height, 0);
 }
 
+bool LocalPlayer::isDead() const
+{
+	return !getCAO()->isImmortal() && hp == 0;
+}
+
 // 3D acceleration
 void LocalPlayer::accelerate(const v3f &target_speed, const f32 max_increase_H,
 		const f32 max_increase_V, const bool use_pitch)

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -41,7 +41,7 @@ LocalPlayer::LocalPlayer(Client *client, const char *name):
 static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 {
 	if (nodeboxes.empty())
-		return aabb3f(0, 0, 0, 0, 0, 0);
+		return aabb3f(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
 
 	aabb3f b_max;
 
@@ -56,7 +56,7 @@ static aabb3f getNodeBoundingBox(const std::vector<aabb3f> &nodeboxes)
 }
 
 bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
-		const v3f &sneak_max)
+	const v3f &sneak_max)
 {
 	static const v3s16 dir9_center[9] = {
 		v3s16( 0, 0,  0),
@@ -76,12 +76,12 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 	bool new_sneak_node_exists = m_sneak_node_exists;
 
 	// We want the top of the sneak node to be below the players feet
-	f32 position_y_mod = 0.05 * BS;
+	f32 position_y_mod = 0.05f * BS;
 	if (m_sneak_node_exists)
 		position_y_mod = m_sneak_node_bb_top.MaxEdge.Y - position_y_mod;
 
 	// Get position of current standing node
-	const v3s16 current_node = floatToInt(position - v3f(0, position_y_mod, 0), BS);
+	const v3s16 current_node = floatToInt(position - v3f(0.0f, position_y_mod, 0.0f), BS);
 
 	if (current_node != m_sneak_node) {
 		new_sneak_node_exists = false;
@@ -97,7 +97,7 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 
 	// Get new sneak node
 	m_sneak_ladder_detected = false;
-	f32 min_distance_f = 100000.0 * BS;
+	f32 min_distance_f = 100000.0f * BS;
 
 	for (const auto &d : dir9_center) {
 		const v3s16 p = current_node + d;
@@ -106,8 +106,8 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 		f32 distance_f = diff.getLength();
 
 		if (distance_f > min_distance_f ||
-				fabs(diff.X) > (.5 + .1) * BS + sneak_max.X ||
-				fabs(diff.Y) > (.5 + .1) * BS + sneak_max.Z)
+				fabs(diff.X) > (0.5f + 0.1f) * BS + sneak_max.X ||
+				fabs(diff.Y) > (0.5f + 0.1f) * BS + sneak_max.Z)
 			continue;
 
 
@@ -118,9 +118,8 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 		// And the node(s) above have to be nonwalkable
 		bool ok = true;
 		if (!physics_override_sneak_glitch) {
-			u16 height = ceilf(
-					(m_collisionbox.MaxEdge.Y - m_collisionbox.MinEdge.Y) / BS
-			);
+			u16 height =
+				ceilf((m_collisionbox.MaxEdge.Y - m_collisionbox.MinEdge.Y) / BS);
 			for (u16 y = 1; y <= height; y++) {
 				node = map->getNode(p + v3s16(0, y, 0), &is_valid_position);
 				if (!is_valid_position || nodemgr->get(node).walkable) {
@@ -169,10 +168,9 @@ bool LocalPlayer::updateSneakNode(Map *map, const v3f &position,
 void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		std::vector<CollisionInfo> *collision_info)
 {
-	if (!collision_info || collision_info->empty()) {
-		// Node at feet position, update each ClientEnvironment::step()
+	// Node at feet position, update each ClientEnvironment::step()
+	if (!collision_info || collision_info->empty())
 		m_standing_node = floatToInt(m_position, BS);
-	}
 
 	// Temporary option for old move code
 	if (!physics_override_new_move) {
@@ -188,7 +186,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// Copy parent position if local player is attached
 	if (isAttached) {
 		setPosition(overridePosition);
-		added_velocity = v3f(); // ignored
+		added_velocity = v3f(0.0f); // ignored
 		return;
 	}
 
@@ -202,12 +200,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (noclip && free_move) {
 		position += m_speed * dtime;
 		setPosition(position);
-		added_velocity = v3f(); // ignored
+		added_velocity = v3f(0.0f); // ignored
 		return;
 	}
 
 	m_speed += added_velocity;
-	added_velocity = v3f();
+	added_velocity = v3f(0.0f);
 
 	/*
 		Collision detection
@@ -224,7 +222,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	// If in liquid, the threshold of coming out is at higher y
 	if (in_liquid)
 	{
-		pp = floatToInt(position + v3f(0,BS*0.1,0), BS);
+		pp = floatToInt(position + v3f(0.0f, BS * 0.1f, 0.0f), BS);
 		node = map->getNode(pp, &is_valid_position);
 		if (is_valid_position) {
 			in_liquid = nodemgr->get(node.getContent()).isLiquid();
@@ -232,11 +230,10 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		} else {
 			in_liquid = false;
 		}
-	}
-	// If not in liquid, the threshold of going in is at lower y
-	else
-	{
-		pp = floatToInt(position + v3f(0,BS*0.5,0), BS);
+	} else {
+		// If not in liquid, the threshold of going in is at lower y
+
+		pp = floatToInt(position + v3f(0.0f, BS * 0.5f, 0.0f), BS);
 		node = map->getNode(pp, &is_valid_position);
 		if (is_valid_position) {
 			in_liquid = nodemgr->get(node.getContent()).isLiquid();
@@ -250,7 +247,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Check if player is in liquid (the stable value)
 	*/
-	pp = floatToInt(position + v3f(0,0,0), BS);
+	pp = floatToInt(position + v3f(0.0f), BS);
 	node = map->getNode(pp, &is_valid_position);
 	if (is_valid_position) {
 		in_liquid_stable = nodemgr->get(node.getContent()).isLiquid();
@@ -259,12 +256,11 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	}
 
 	/*
-			Check if player is climbing
+		Check if player is climbing
 	*/
 
-
-	pp = floatToInt(position + v3f(0,0.5*BS,0), BS);
-	v3s16 pp2 = floatToInt(position + v3f(0,-0.2*BS,0), BS);
+	pp = floatToInt(position + v3f(0.0f, 0.5f * BS, 0.0f), BS);
+	v3s16 pp2 = floatToInt(position + v3f(0.0f, -0.2f * BS, 0.0f), BS);
 	node = map->getNode(pp, &is_valid_position);
 	bool is_valid_position2;
 	MapNode node2 = map->getNode(pp2, &is_valid_position2);
@@ -272,8 +268,8 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (!(is_valid_position && is_valid_position2)) {
 		is_climbing = false;
 	} else {
-		is_climbing = (nodemgr->get(node.getContent()).climbable
-				|| nodemgr->get(node2.getContent()).climbable) && !free_move;
+		is_climbing = (nodemgr->get(node.getContent()).climbable ||
+			nodemgr->get(node2.getContent()).climbable) && !free_move;
 	}
 
 	/*
@@ -282,7 +278,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	//f32 d = pos_max_d * 1.1;
 	// A fairly large value in here makes moving smoother
-	f32 d = 0.15*BS;
+	f32 d = 0.15f * BS;
 
 	// This should always apply, otherwise there are glitches
 	sanity_check(d > pos_max_d);
@@ -292,7 +288,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 	float player_stepheight = (m_cao == nullptr) ? 0.0f :
 		(touching_ground ? m_cao->getStepHeight() : (0.2f * BS));
 
-	v3f accel_f = v3f(0,0,0);
+	v3f accel_f;
 	const v3f initial_position = position;
 	const v3f initial_speed = m_speed;
 
@@ -346,7 +342,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	if (m_sneak_ladder_detected) {
 		// restore legacy behaviour (this makes the m_speed.Y hack necessary)
-		sneak_max = v3f(0.4 * BS, 0, 0.4 * BS);
+		sneak_max = v3f(0.4f * BS, 0.0f, 0.4f * BS);
 	}
 
 	/*
@@ -370,12 +366,12 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 				bmin.Z - sneak_max.Z, bmax.Z + sneak_max.Z);
 
 			if (position.X != old_pos.X)
-				m_speed.X = 0;
+				m_speed.X = 0.0f;
 			if (position.Z != old_pos.Z)
-				m_speed.Z = 0;
+				m_speed.Z = 0.0f;
 		}
 
-		if (y_diff > 0 && m_speed.Y <= 0 &&
+		if (y_diff > 0 && m_speed.Y <= 0.0f &&
 				(physics_override_sneak_glitch || y_diff < BS * 0.6f)) {
 			// Move player to the maximal height when falling or when
 			// the ledge is climbed on the next step.
@@ -383,11 +379,11 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 			// Smoothen the movement (based on 'position.Y = bmax.Y')
 			position.Y += y_diff * dtime * 22.0f + BS * 0.01f;
 			position.Y = std::min(position.Y, bmax.Y);
-			m_speed.Y = 0;
+			m_speed.Y = 0.0f;
 		}
 
 		// Allow jumping on node edges while sneaking
-		if (m_speed.Y == 0 || m_sneak_ladder_detected)
+		if (m_speed.Y == 0.0f || m_sneak_ladder_detected)
 			sneak_can_jump = true;
 
 		if (collision_info &&
@@ -419,7 +415,7 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		Report collisions
 	*/
 
-	if(!result.standing_on_object && !touching_ground_was && touching_ground) {
+	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 
 		// Set camera impact value to be used for view bobbing
@@ -430,10 +426,9 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 		camera_barely_in_ceiling = false;
 		v3s16 camera_np = floatToInt(getEyePosition(), BS);
 		MapNode n = map->getNode(camera_np);
-		if(n.getContent() != CONTENT_IGNORE){
-			if(nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2){
+		if (n.getContent() != CONTENT_IGNORE) {
+			if (nodemgr->get(n).walkable && nodemgr->get(n).solidness == 2)
 				camera_barely_in_ceiling = true;
-			}
 		}
 	}
 
@@ -444,16 +439,15 @@ void LocalPlayer::move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
-	m_can_jump = ((touching_ground && !is_climbing)
-			|| sneak_can_jump) && !m_disable_jump;
+	m_can_jump = ((touching_ground && !is_climbing) || sneak_can_jump) && !m_disable_jump;
 
 	// Jump key pressed while jumping off from a bouncy block
 	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
-		m_speed.Y >= -0.5 * BS) {
+		m_speed.Y >= -0.5f * BS) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
-		if (m_speed.Y > 1) {
+		if (m_speed.Y > 1.0f) {
 			// Reduce boost when speed already is high
-			m_speed.Y += jumpspeed / (1 + (m_speed.Y / 16 ));
+			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));
 		} else {
 			m_speed.Y += jumpspeed;
 		}
@@ -480,9 +474,8 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	setYaw(control.yaw);
 
 	// Nullify speed and don't run positioning code if the player is attached
-	if(isAttached)
-	{
-		setSpeed(v3f(0,0,0));
+	if (isAttached) {
+		setSpeed(v3f(0.0f));
 		return;
 	}
 
@@ -491,8 +484,7 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	// All vectors are relative to the player's yaw,
 	// (and pitch if pitch move mode enabled),
 	// and will be rotated at the end
-	v3f speedH = v3f(0,0,0); // Horizontal (X, Z)
-	v3f speedV = v3f(0,0,0); // Vertical (Y)
+	v3f speedH, speedV; // Horizontal (X, Z) and Vertical (Y)
 
 	bool fly_allowed = m_client->checkLocalPrivilege("fly");
 	bool fast_allowed = m_client->checkLocalPrivilege("fast");
@@ -511,76 +503,58 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		superspeed = true;
 
 	// Old descend control
-	if (player_settings.aux1_descends)
-	{
+	if (player_settings.aux1_descends) {
 		// If free movement and fast movement, always move fast
-		if(free_move && fast_move)
+		if (free_move && fast_move)
 			superspeed = true;
 
 		// Auxiliary button 1 (E)
-		if(control.aux1)
-		{
-			if(free_move)
-			{
+		if (control.aux1) {
+			if (free_move) {
 				// In free movement mode, aux1 descends
-				if(fast_move)
+				if (fast_move)
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
-			}
-			else if(in_liquid || in_liquid_stable)
-			{
+			} else if (in_liquid || in_liquid_stable) {
 				speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
-			}
-			else if(is_climbing)
-			{
+			} else if (is_climbing) {
 				speedV.Y = -movement_speed_climb;
-			}
-			else
-			{
+			} else {
 				// If not free movement but fast is allowed, aux1 is
 				// "Turbo button"
-				if(fast_move)
+				if (fast_move)
 					superspeed = true;
 			}
 		}
-	}
-	// New minecraft-like descend control
-	else
-	{
+	} else {
+		// New minecraft-like descend control
+
 		// Auxiliary button 1 (E)
-		if(control.aux1)
-		{
-			if(!is_climbing)
-			{
+		if (control.aux1) {
+			if (!is_climbing) {
 				// aux1 is "Turbo button"
-				if(fast_move)
+				if (fast_move)
 					superspeed = true;
 			}
 		}
 
-		if(control.sneak)
-		{
-			if(free_move)
-			{
+		if (control.sneak) {
+			if (free_move) {
 				// In free movement mode, sneak descends
 				if (fast_move && (control.aux1 || always_fly_fast))
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
-			}
-			else if(in_liquid || in_liquid_stable)
-			{
-				if(fast_climb)
+			} else if (in_liquid || in_liquid_stable) {
+				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_walk;
 				swimming_vertical = true;
-			}
-			else if(is_climbing)
-			{
-				if(fast_climb)
+			} else if (is_climbing) {
+				if (fast_climb)
 					speedV.Y = -movement_speed_fast;
 				else
 					speedV.Y = -movement_speed_climb;
@@ -588,34 +562,32 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 		}
 	}
 
-	if (control.up) {
-		speedH += v3f(0,0,1);
-	}
-	if (control.down) {
-		speedH -= v3f(0,0,1);
-	}
-	if (!control.up && !control.down) {
-		speedH -= v3f(0,0,1) *
-			(control.forw_move_joystick_axis / 32767.f);
-	}
-	if (control.left) {
-		speedH += v3f(-1,0,0);
-	}
-	if (control.right) {
-		speedH += v3f(1,0,0);
-	}
-	if (!control.left && !control.right) {
-		speedH += v3f(1,0,0) *
-			(control.sidew_move_joystick_axis / 32767.f);
-	}
+	if (control.up)
+		speedH += v3f(0.0f, 0.0f, 1.0f);
+
+	if (control.down)
+		speedH -= v3f(0.0f, 0.0f, 1.0f);
+
+	if (!control.up && !control.down)
+		speedH -= v3f(0.0f, 0.0f, 1.0f) * (control.forw_move_joystick_axis / 32767.f);
+
+	if (control.left)
+		speedH += v3f(-1.0f, 0.0f, 0.0f);
+
+	if (control.right)
+		speedH += v3f(1.0f, 0.0f, 0.0f);
+
+	if (!control.left && !control.right)
+		speedH += v3f(1.0f, 0.0f, 0.0f) * (control.sidew_move_joystick_axis / 32767.f);
+
 	if (m_autojump) {
 		// release autojump after a given time
 		m_autojump_time -= dtime;
 		if (m_autojump_time <= 0.0f)
 			m_autojump = false;
 	}
-	if(control.jump)
-	{
+
+	if (control.jump) {
 		if (free_move) {
 			if (player_settings.aux1_descends || always_fly_fast) {
 				if (fast_move)
@@ -623,21 +595,19 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 				else
 					speedV.Y = movement_speed_walk;
 			} else {
-				if(fast_move && control.aux1)
+				if (fast_move && control.aux1)
 					speedV.Y = movement_speed_fast;
 				else
 					speedV.Y = movement_speed_walk;
 			}
-		}
-		else if(m_can_jump)
-		{
+		} else if (m_can_jump) {
 			/*
 				NOTE: The d value in move() affects jump height by
 				raising the height at which the jump speed is kept
 				at its starting value
 			*/
 			v3f speedJ = getSpeed();
-			if(speedJ.Y >= -0.5 * BS) {
+			if (speedJ.Y >= -0.5f * BS) {
 				speedJ.Y = movement_speed_jump * physics_override_jump;
 				setSpeed(speedJ);
 				m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_JUMP));
@@ -657,29 +627,31 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 	}
 
 	// The speed of the player (Y is ignored)
-	if(superspeed || (is_climbing && fast_climb) || ((in_liquid || in_liquid_stable) && fast_climb))
+	if (superspeed || (is_climbing && fast_climb) ||
+			((in_liquid || in_liquid_stable) && fast_climb))
 		speedH = speedH.normalize() * movement_speed_fast;
-	else if(control.sneak && !free_move && !in_liquid && !in_liquid_stable)
+	else if (control.sneak && !free_move && !in_liquid && !in_liquid_stable)
 		speedH = speedH.normalize() * movement_speed_crouch;
 	else
 		speedH = speedH.normalize() * movement_speed_walk;
 
 	// Acceleration increase
-	f32 incH = 0; // Horizontal (X, Z)
-	f32 incV = 0; // Vertical (Y)
-	if((!touching_ground && !free_move && !is_climbing && !in_liquid) || (!free_move && m_can_jump && control.jump))
-	{
+	f32 incH = 0.0f; // Horizontal (X, Z)
+	f32 incV = 0.0f; // Vertical (Y)
+	if ((!touching_ground && !free_move && !is_climbing && !in_liquid) ||
+			(!free_move && m_can_jump && control.jump)) {
 		// Jumping and falling
-		if(superspeed || (fast_move && control.aux1))
+		if (superspeed || (fast_move && control.aux1))
 			incH = movement_acceleration_fast * BS * dtime;
 		else
 			incH = movement_acceleration_air * BS * dtime;
-		incV = 0; // No vertical acceleration in air
-	}
-	else if (superspeed || (is_climbing && fast_climb) || ((in_liquid || in_liquid_stable) && fast_climb))
+		incV = 0.0f; // No vertical acceleration in air
+	} else if (superspeed || (is_climbing && fast_climb) ||
+			((in_liquid || in_liquid_stable) && fast_climb)) {
 		incH = incV = movement_acceleration_fast * BS * dtime;
-	else
+	} else {
 		incH = incV = movement_acceleration_default * BS * dtime;
+	}
 
 	float slip_factor = 1.0f;
 	if (!free_move && !in_liquid && !in_liquid_stable)
@@ -694,52 +666,55 @@ void LocalPlayer::applyControl(float dtime, Environment *env)
 
 	// Accelerate to target speed with maximum increment
 	accelerate((speedH + speedV) * physics_override_speed,
-			incH * physics_override_speed * slip_factor, incV * physics_override_speed,
-			pitch_move);
+		incH * physics_override_speed * slip_factor, incV * physics_override_speed,
+		pitch_move);
 }
 
 v3s16 LocalPlayer::getStandingNodePos()
 {
-	if(m_sneak_node_exists)
+	if (m_sneak_node_exists)
 		return m_sneak_node;
+
 	return m_standing_node;
 }
 
 v3s16 LocalPlayer::getFootstepNodePos()
 {
+	// Emit swimming sound if the player is in liquid
 	if (in_liquid_stable)
-		// Emit swimming sound if the player is in liquid
 		return floatToInt(getPosition(), BS);
+
+	// BS * 0.05 below the player's feet ensures a 1/16th height
+	// nodebox is detected instead of the node below it.
 	if (touching_ground)
-		// BS * 0.05 below the player's feet ensures a 1/16th height
-		// nodebox is detected instead of the node below it.
-		return floatToInt(getPosition() - v3f(0, BS * 0.05f, 0), BS);
+		return floatToInt(getPosition() - v3f(0.0f, BS * 0.05f, 0.0f), BS);
+
 	// A larger distance below is necessary for a footstep sound
 	// when landing after a jump or fall. BS * 0.5 ensures water
 	// sounds when swimming in 1 node deep water.
-	return floatToInt(getPosition() - v3f(0, BS * 0.5f, 0), BS);
+	return floatToInt(getPosition() - v3f(0.0f, BS * 0.5f, 0.0f), BS);
 }
 
 v3s16 LocalPlayer::getLightPosition() const
 {
-	return floatToInt(m_position + v3f(0,BS+BS/2,0), BS);
+	return floatToInt(m_position + v3f(0.0f, BS * 1.5f, 0.0f), BS);
 }
 
 v3f LocalPlayer::getEyeOffset() const
 {
-	float eye_height = camera_barely_in_ceiling ?
-		m_eye_height - 0.125f : m_eye_height;
-	return v3f(0, BS * eye_height, 0);
+	float eye_height = camera_barely_in_ceiling ? m_eye_height - 0.125f : m_eye_height;
+	return v3f(0.0f, BS * eye_height, 0.0f);
 }
 
 bool LocalPlayer::isDead() const
 {
+	FATAL_ERROR_IF(!getCAO(), "LocalPlayer's CAO isn't initialized");
 	return !getCAO()->isImmortal() && hp == 0;
 }
 
 // 3D acceleration
 void LocalPlayer::accelerate(const v3f &target_speed, const f32 max_increase_H,
-		const f32 max_increase_V, const bool use_pitch)
+	const f32 max_increase_V, const bool use_pitch)
 {
 	const f32 yaw = getYaw();
 	const f32 pitch = getPitch();
@@ -750,18 +725,18 @@ void LocalPlayer::accelerate(const v3f &target_speed, const f32 max_increase_H,
 		flat_speed.rotateYZBy(-pitch);
 
 	v3f d_wanted = target_speed - flat_speed;
-	v3f d = v3f(0,0,0);
+	v3f d;
 
 	// Then compare the horizontal and vertical components with the wanted speed
-	if (max_increase_H > 0) {
-		v3f d_wanted_H = d_wanted * v3f(1,0,1);
+	if (max_increase_H > 0.0f) {
+		v3f d_wanted_H = d_wanted * v3f(1.0f, 0.0f, 1.0f);
 		if (d_wanted_H.getLength() > max_increase_H)
 			d += d_wanted_H.normalize() * max_increase_H;
 		else
 			d += d_wanted_H;
 	}
 
-	if (max_increase_V > 0) {
+	if (max_increase_V > 0.0f) {
 		f32 d_wanted_V = d_wanted.Y;
 		if (d_wanted_V > max_increase_V)
 			d.Y += max_increase_V;
@@ -781,7 +756,7 @@ void LocalPlayer::accelerate(const v3f &target_speed, const f32 max_increase_H,
 
 // Temporary option for old move code
 void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
-		std::vector<CollisionInfo> *collision_info)
+	std::vector<CollisionInfo> *collision_info)
 {
 	Map *map = &env->getMap();
 	const NodeDefManager *nodemgr = m_client->ndef();
@@ -792,7 +767,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (isAttached) {
 		setPosition(overridePosition);
 		m_sneak_node_exists = false;
-		added_velocity = v3f();
+		added_velocity = v3f(0.0f);
 		return;
 	}
 
@@ -806,12 +781,12 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		position += m_speed * dtime;
 		setPosition(position);
 		m_sneak_node_exists = false;
-		added_velocity = v3f();
+		added_velocity = v3f(0.0f);
 		return;
 	}
 
 	m_speed += added_velocity;
-	added_velocity = v3f();
+	added_velocity = v3f(0.0f);
 
 	/*
 		Collision detection
@@ -825,7 +800,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	if (in_liquid) {
 		// If in liquid, the threshold of coming out is at higher y
-		pp = floatToInt(position + v3f(0, BS * 0.1, 0), BS);
+		pp = floatToInt(position + v3f(0.0f, BS * 0.1f, 0.0f), BS);
 		node = map->getNode(pp, &is_valid_position);
 		if (is_valid_position) {
 			in_liquid = nodemgr->get(node.getContent()).isLiquid();
@@ -835,7 +810,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		}
 	} else {
 		// If not in liquid, the threshold of going in is at lower y
-		pp = floatToInt(position + v3f(0, BS * 0.5, 0), BS);
+		pp = floatToInt(position + v3f(0.0f, BS * 0.5f, 0.0f), BS);
 		node = map->getNode(pp, &is_valid_position);
 		if (is_valid_position) {
 			in_liquid = nodemgr->get(node.getContent()).isLiquid();
@@ -848,7 +823,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Check if player is in liquid (the stable value)
 	*/
-	pp = floatToInt(position + v3f(0, 0, 0), BS);
+	pp = floatToInt(position + v3f(0.0f), BS);
 	node = map->getNode(pp, &is_valid_position);
 	if (is_valid_position)
 		in_liquid_stable = nodemgr->get(node.getContent()).isLiquid();
@@ -858,8 +833,8 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Check if player is climbing
 	*/
-	pp = floatToInt(position + v3f(0, 0.5 * BS, 0), BS);
-	v3s16 pp2 = floatToInt(position + v3f(0, -0.2 * BS, 0), BS);
+	pp = floatToInt(position + v3f(0.0f, 0.5f * BS, 0.0f), BS);
+	v3s16 pp2 = floatToInt(position + v3f(0.0f, -0.2f * BS, 0.0f), BS);
 	node = map->getNode(pp, &is_valid_position);
 	bool is_valid_position2;
 	MapNode node2 = map->getNode(pp2, &is_valid_position2);
@@ -868,7 +843,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		is_climbing = false;
 	else
 		is_climbing = (nodemgr->get(node.getContent()).climbable ||
-				nodemgr->get(node2.getContent()).climbable) && !free_move;
+			nodemgr->get(node2.getContent()).climbable) && !free_move;
 
 	/*
 		Collision uncertainty radius
@@ -876,11 +851,11 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	*/
 	//f32 d = pos_max_d * 1.1;
 	// A fairly large value in here makes moving smoother
-	f32 d = 0.15 * BS;
+	f32 d = 0.15f * BS;
 	// This should always apply, otherwise there are glitches
 	sanity_check(d > pos_max_d);
 	// Maximum distance over border for sneaking
-	f32 sneak_max = BS * 0.4;
+	f32 sneak_max = BS * 0.4f;
 
 	/*
 		If sneaking, keep in range from the last walked node and don't
@@ -889,14 +864,14 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (control.sneak && m_sneak_node_exists &&
 			!(fly_allowed && player_settings.free_move) && !in_liquid &&
 			physics_override_sneak) {
-		f32 maxd = 0.5 * BS + sneak_max;
+		f32 maxd = 0.5f * BS + sneak_max;
 		v3f lwn_f = intToFloat(m_sneak_node, BS);
 		position.X = rangelim(position.X, lwn_f.X - maxd, lwn_f.X + maxd);
 		position.Z = rangelim(position.Z, lwn_f.Z - maxd, lwn_f.Z + maxd);
 
 		if (!is_climbing) {
 			// Move up if necessary
-			f32 new_y = (lwn_f.Y - 0.5 * BS) + m_sneak_node_bb_ymax;
+			f32 new_y = (lwn_f.Y - 0.5f * BS) + m_sneak_node_bb_ymax;
 			if (position.Y < new_y)
 				position.Y = new_y;
 			/*
@@ -904,15 +879,15 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 				sneaking over the edges of current sneaking_node.
 				TODO (when fixed): Set Y-speed only to 0 when position.Y < new_y.
 			*/
-			if (m_speed.Y < 0)
-				m_speed.Y = 0;
+			if (m_speed.Y < 0.0f)
+				m_speed.Y = 0.0f;
 		}
 	}
 
-	// this shouldn't be hardcoded but transmitted from server
-	float player_stepheight = touching_ground ? (BS * 0.6) : (BS * 0.2);
+	// TODO: This shouldn't be hardcoded but decided by the server
+	float player_stepheight = touching_ground ? (BS * 0.6f) : (BS * 0.2f);
 
-	v3f accel_f = v3f(0, 0, 0);
+	v3f accel_f;
 	const v3f initial_position = position;
 	const v3f initial_speed = m_speed;
 
@@ -922,7 +897,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	// Positition was slightly changed; update standing node pos
 	if (touching_ground)
-		m_standing_node = floatToInt(m_position - v3f(0, 0.1f * BS, 0), BS);
+		m_standing_node = floatToInt(m_position - v3f(0.0f, 0.1f * BS, 0.0f), BS);
 	else
 		m_standing_node = floatToInt(m_position, BS);
 
@@ -942,10 +917,10 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 		player is sneaking from, if any. If the node from under
 		the player has been removed, the player falls.
 	*/
-	f32 position_y_mod = 0.05 * BS;
-	if (m_sneak_node_bb_ymax > 0)
+	f32 position_y_mod = 0.05f * BS;
+	if (m_sneak_node_bb_ymax > 0.0f)
 		position_y_mod = m_sneak_node_bb_ymax - position_y_mod;
-	v3s16 current_node = floatToInt(position - v3f(0, position_y_mod, 0), BS);
+	v3s16 current_node = floatToInt(position - v3f(0.0f, position_y_mod, 0.0f), BS);
 	if (m_sneak_node_exists &&
 			nodemgr->get(map->getNode(m_old_node_below)).name == "air" &&
 			m_old_node_below_type != "air") {
@@ -960,10 +935,10 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	}
 
 	if (m_need_to_get_new_sneak_node && physics_override_sneak) {
-		m_sneak_node_bb_ymax = 0;
-		v3s16 pos_i_bottom = floatToInt(position - v3f(0, position_y_mod, 0), BS);
+		m_sneak_node_bb_ymax = 0.0f;
+		v3s16 pos_i_bottom = floatToInt(position - v3f(0.0f, position_y_mod, 0.0f), BS);
 		v2f player_p2df(position.X, position.Z);
-		f32 min_distance_f = 100000.0 * BS;
+		f32 min_distance_f = 100000.0f * BS;
 		// If already seeking from some node, compare to it.
 		v3s16 new_sneak_node = m_sneak_node;
 		for (s16 x= -1; x <= 1; x++)
@@ -973,11 +948,11 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			v2f node_p2df(pf.X, pf.Z);
 			f32 distance_f = player_p2df.getDistanceFrom(node_p2df);
 			f32 max_axis_distance_f = MYMAX(
-					std::fabs(player_p2df.X - node_p2df.X),
-					std::fabs(player_p2df.Y - node_p2df.Y));
+				std::fabs(player_p2df.X - node_p2df.X),
+				std::fabs(player_p2df.Y - node_p2df.Y));
 
 			if (distance_f > min_distance_f ||
-					max_axis_distance_f > 0.5 * BS + sneak_max + 0.1 * BS)
+					max_axis_distance_f > 0.5f * BS + sneak_max + 0.1f * BS)
 				continue;
 
 			// The node to be sneaked on has to be walkable
@@ -990,7 +965,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 				continue;
 			// If not 'sneak_glitch' the node 2 nodes above it has to be nonwalkable
 			if (!physics_override_sneak_glitch) {
-				node =map->getNode(p + v3s16(0, 2, 0), &is_valid_position);
+				node = map->getNode(p + v3s16(0, 2, 0), &is_valid_position);
 				if (!is_valid_position || nodemgr->get(node).walkable)
 					continue;
 			}
@@ -999,13 +974,13 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 			new_sneak_node = p;
 		}
 
-		bool sneak_node_found = (min_distance_f < 100000.0 * BS * 0.9);
+		bool sneak_node_found = (min_distance_f < 100000.0f * BS * 0.9f);
 
 		m_sneak_node = new_sneak_node;
 		m_sneak_node_exists = sneak_node_found;
 
 		if (sneak_node_found) {
-			f32 cb_max = 0;
+			f32 cb_max = 0.0f;
 			MapNode n = map->getNode(m_sneak_node);
 			std::vector<aabb3f> nodeboxes;
 			n.getCollisionBoxes(nodemgr, &nodeboxes);
@@ -1034,7 +1009,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Report collisions
 	*/
-	// Dont report if flying
+	// Don't report if flying
 	if (collision_info && !(player_settings.free_move && fly_allowed)) {
 		for (const auto &info : result.collisions) {
 			collision_info->push_back(info);
@@ -1044,7 +1019,7 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	if (!result.standing_on_object && !touching_ground_was && touching_ground) {
 		m_client->getEventManager()->put(new SimpleTriggerEvent(MtEvent::PLAYER_REGAIN_GROUND));
 		// Set camera impact value to be used for view bobbing
-		camera_impact = getSpeed().Y * -1;
+		camera_impact = getSpeed().Y * -1.0f;
 	}
 
 	{
@@ -1060,14 +1035,13 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 	/*
 		Update the node last under the player
 	*/
-	m_old_node_below = floatToInt(position - v3f(0, BS / 2, 0), BS);
+	m_old_node_below = floatToInt(position - v3f(0.0f, BS / 2.0f, 0.0f), BS);
 	m_old_node_below_type = nodemgr->get(map->getNode(m_old_node_below)).name;
 
 	/*
 		Check properties of the node on which the player is standing
 	*/
-	const ContentFeatures &f = nodemgr->get(map->getNode(
-		getStandingNodePos()));
+	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 
 	// Determine if jumping is possible
 	m_disable_jump = itemgroup_get(f.groups, "disable_jump");
@@ -1075,11 +1049,11 @@ void LocalPlayer::old_move(f32 dtime, Environment *env, f32 pos_max_d,
 
 	// Jump key pressed while jumping off from a bouncy block
 	if (m_can_jump && control.jump && itemgroup_get(f.groups, "bouncy") &&
-			m_speed.Y >= -0.5 * BS) {
+			m_speed.Y >= -0.5f * BS) {
 		float jumpspeed = movement_speed_jump * physics_override_jump;
-		if (m_speed.Y > 1) {
+		if (m_speed.Y > 1.0f) {
 			// Reduce boost when speed already is high
-			m_speed.Y += jumpspeed / (1 + (m_speed.Y / 16 ));
+			m_speed.Y += jumpspeed / (1.0f + (m_speed.Y / 16.0f));
 		} else {
 			m_speed.Y += jumpspeed;
 		}
@@ -1096,24 +1070,23 @@ float LocalPlayer::getSlipFactor(Environment *env, const v3f &speedH)
 	// Slip on slippery nodes
 	const NodeDefManager *nodemgr = env->getGameDef()->ndef();
 	Map *map = &env->getMap();
-	const ContentFeatures &f = nodemgr->get(map->getNode(
-			getStandingNodePos()));
+	const ContentFeatures &f = nodemgr->get(map->getNode(getStandingNodePos()));
 	int slippery = 0;
 	if (f.walkable)
 		slippery = itemgroup_get(f.groups, "slippery");
 
 	if (slippery >= 1) {
-		if (speedH == v3f(0.0f)) {
-			slippery = slippery * 2;
-		}
+		if (speedH == v3f(0.0f))
+			slippery *= 2;
+
 		return core::clamp(1.0f / (slippery + 1), 0.001f, 1.0f);
 	}
 	return 1.0f;
 }
 
 void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
-		const collisionMoveResult &result, const v3f &initial_position,
-		const v3f &initial_speed, f32 pos_max_d)
+	const collisionMoveResult &result, const v3f &initial_position,
+	const v3f &initial_speed, f32 pos_max_d)
 {
 	PlayerSettings &player_settings = getPlayerSettings();
 	if (!player_settings.autojump)
@@ -1123,10 +1096,12 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 		return;
 
 	bool control_forward = control.up ||
-			(!control.up && !control.down &&
-			control.forw_move_joystick_axis < -0.05);
+		(!control.up && !control.down &&
+		control.forw_move_joystick_axis < -0.05f);
+
 	bool could_autojump =
-			m_can_jump && !control.jump && !control.sneak && control_forward;
+		m_can_jump && !control.jump && !control.sneak && control_forward;
+
 	if (!could_autojump)
 		return;
 
@@ -1150,8 +1125,8 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 	v3s16 ceilpos_max = floatToInt(headpos_max, BS) + v3s16(0, 1, 0);
 	const NodeDefManager *ndef = env->getGameDef()->ndef();
 	bool is_position_valid;
-	for (s16 z = ceilpos_min.Z; z <= ceilpos_max.Z; z++) {
-		for (s16 x = ceilpos_min.X; x <= ceilpos_max.X; x++) {
+	for (s16 z = ceilpos_min.Z; z <= ceilpos_max.Z; ++z) {
+		for (s16 x = ceilpos_min.X; x <= ceilpos_max.X; ++x) {
 			MapNode n = env->getMap().getNode(v3s16(x, ceilpos_max.Y, z), &is_position_valid);
 
 			if (!is_position_valid)
@@ -1170,8 +1145,7 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 
 	// try at peak of jump, zero step height
 	collisionMoveResult jump_result = collisionMoveSimple(env, m_client, pos_max_d,
-			m_collisionbox, 0.0f, dtime, &jump_pos, &jump_speed,
-			v3f(0, 0, 0));
+		m_collisionbox, 0.0f, dtime, &jump_pos, &jump_speed, v3f(0.0f));
 
 	// see if we can get a little bit farther horizontally if we had
 	// jumped

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -158,13 +158,13 @@ public:
 
 private:
 	void accelerate(const v3f &target_speed, const f32 max_increase_H,
-			const f32 max_increase_V, const bool use_pitch);
+		const f32 max_increase_V, const bool use_pitch);
 	bool updateSneakNode(Map *map, const v3f &position, const v3f &sneak_max);
 	float getSlipFactor(Environment *env, const v3f &speedH);
 	void handleAutojump(f32 dtime, Environment *env,
-			const collisionMoveResult &result,
-			const v3f &position_before_move, const v3f &speed_before_move,
-			f32 pos_max_d);
+		const collisionMoveResult &result,
+		const v3f &position_before_move, const v3f &speed_before_move,
+		f32 pos_max_d);
 
 	v3f m_position;
 	v3s16 m_standing_node;
@@ -196,12 +196,14 @@ private:
 	f32 m_pitch = 0.0f;
 	bool camera_barely_in_ceiling = false;
 	aabb3f m_collisionbox = aabb3f(-BS * 0.30f, 0.0f, -BS * 0.30f, BS * 0.30f,
-			BS * 1.75f, BS * 0.30f);
+		BS * 1.75f, BS * 0.30f);
 	float m_eye_height = 1.625f;
 	float m_zoom_fov = 0.0f;
 	bool m_autojump = false;
 	float m_autojump_time = 0.0f;
-	v3f added_velocity = v3f(0.0f, 0.0f, 0.0f); // cleared on each move()
+
+	v3f added_velocity = v3f(0.0f); // cleared on each move()
+	// TODO: Rename to adhere to convention: added_velocity --> m_added_velocity
 
 	GenericCAO *m_cao = nullptr;
 	Client *m_client;

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -149,7 +149,7 @@ public:
 
 	bool getAutojump() const { return m_autojump; }
 
-	bool isDead() const { return hp <= 0; }
+	bool isDead() const;
 
 	inline void addVelocity(const v3f &vel)
 	{

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -463,6 +463,10 @@ void Client::handleCommand_ActiveObjectRemoveAdd(NetworkPacket* pkt)
 		infostream << "handleCommand_ActiveObjectRemoveAdd: " << e.what()
 				<< ". The packet is unreliable, ignoring" << std::endl;
 	}
+
+	// m_activeobjects_received is false before the first
+	// TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD packet is received
+	m_activeobjects_received = true;
 }
 
 void Client::handleCommand_ActiveObjectMessages(NetworkPacket* pkt)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -620,124 +620,27 @@ void Server::AsyncRunStep(bool initial_step)
 
 		m_clients.lock();
 		const RemoteClientMap &clients = m_clients.getClientList();
-		ScopeProfiler sp(g_profiler, "Server: update visible objects");
-
-		// Radius inside which objects are active
-		static thread_local const s16 radius =
-			g_settings->getS16("active_object_send_range_blocks") * MAP_BLOCKSIZE;
-
-		// Radius inside which players are active
-		static thread_local const bool is_transfer_limited =
-			g_settings->exists("unlimited_player_transfer_distance") &&
-			!g_settings->getBool("unlimited_player_transfer_distance");
-		static thread_local const s16 player_transfer_dist =
-			g_settings->getS16("player_transfer_distance") * MAP_BLOCKSIZE;
-		s16 player_radius = player_transfer_dist;
-		if (player_radius == 0 && is_transfer_limited)
-			player_radius = radius;
+		ScopeProfiler sp(g_profiler, "Server: update objects within range");
 
 		for (const auto &client_it : clients) {
 			RemoteClient *client = client_it.second;
 
-			// If definitions and textures have not been sent, don't
-			// send objects either
 			if (client->getState() < CS_DefinitionsSent)
 				continue;
 
-			RemotePlayer *player = m_env->getPlayer(client->peer_id);
-			if (!player) {
-				// This can happen if the client timeouts somehow
+			// This can happen if the client times out somehow
+			if (!m_env->getPlayer(client->peer_id))
 				continue;
-			}
 
-			PlayerSAO *playersao = player->getPlayerSAO();
+			PlayerSAO *playersao = getPlayerSAO(client->peer_id);
 			if (!playersao)
 				continue;
 
-			s16 my_radius = MYMIN(radius, playersao->getWantedRange() * MAP_BLOCKSIZE);
-			if (my_radius <= 0) my_radius = radius;
-			//infostream << "Server: Active Radius " << my_radius << std::endl;
-
-			std::queue<u16> removed_objects;
-			std::queue<u16> added_objects;
-			m_env->getRemovedActiveObjects(playersao, my_radius, player_radius,
-					client->m_known_objects, removed_objects);
-			m_env->getAddedActiveObjects(playersao, my_radius, player_radius,
-					client->m_known_objects, added_objects);
-
-			// Ignore if nothing happened
-			if (removed_objects.empty() && added_objects.empty()) {
-				continue;
-			}
-
-			std::string data_buffer;
-
-			char buf[4];
-
-			// Handle removed objects
-			writeU16((u8*)buf, removed_objects.size());
-			data_buffer.append(buf, 2);
-			while (!removed_objects.empty()) {
-				// Get object
-				u16 id = removed_objects.front();
-				ServerActiveObject* obj = m_env->getActiveObject(id);
-
-				// Add to data buffer for sending
-				writeU16((u8*)buf, id);
-				data_buffer.append(buf, 2);
-
-				// Remove from known objects
-				client->m_known_objects.erase(id);
-
-				if(obj && obj->m_known_by_count > 0)
-					obj->m_known_by_count--;
-				removed_objects.pop();
-			}
-
-			// Handle added objects
-			writeU16((u8*)buf, added_objects.size());
-			data_buffer.append(buf, 2);
-			while (!added_objects.empty()) {
-				// Get object
-				u16 id = added_objects.front();
-				ServerActiveObject* obj = m_env->getActiveObject(id);
-
-				// Get object type
-				u8 type = ACTIVEOBJECT_TYPE_INVALID;
-				if (!obj)
-					warningstream << FUNCTION_NAME << ": NULL object" << std::endl;
-				else
-					type = obj->getSendType();
-
-				// Add to data buffer for sending
-				writeU16((u8*)buf, id);
-				data_buffer.append(buf, 2);
-				writeU8((u8*)buf, type);
-				data_buffer.append(buf, 1);
-
-				if(obj)
-					data_buffer.append(serializeLongString(
-							obj->getClientInitializationData(client->net_proto_version)));
-				else
-					data_buffer.append(serializeLongString(""));
-
-				// Add to known objects
-				client->m_known_objects.insert(id);
-
-				if(obj)
-					obj->m_known_by_count++;
-
-				added_objects.pop();
-			}
-
-			u32 pktSize = SendActiveObjectRemoveAdd(client->peer_id, data_buffer);
-			verbosestream << "Server: Sent object remove/add: "
-					<< removed_objects.size() << " removed, "
-					<< added_objects.size() << " added, "
-					<< "packet size is " << pktSize << std::endl;
+			SendActiveObjectRemoveAdd(client, playersao);
 		}
 		m_clients.unlock();
 
+		// Save mod storages if modified
 		m_mod_storage_save_timer -= dtime;
 		if (m_mod_storage_save_timer <= 0.0f) {
 			infostream << "Saving registered mod storages." << std::endl;
@@ -1089,9 +992,9 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 	return playersao;
 }
 
-inline void Server::handleCommand(NetworkPacket* pkt)
+inline void Server::handleCommand(NetworkPacket *pkt)
 {
-	const ToServerCommandHandler& opHandle = toServerCommandTable[pkt->getCommand()];
+	const ToServerCommandHandler &opHandle = toServerCommandTable[pkt->getCommand()];
 	(this->*opHandle.handler)(pkt);
 }
 
@@ -1924,12 +1827,106 @@ void Server::SendPlayerFormspecPrepend(session_t peer_id)
 	Send(&pkt);
 }
 
-u32 Server::SendActiveObjectRemoveAdd(session_t peer_id, const std::string &datas)
+void Server::SendActiveObjectRemoveAdd(RemoteClient *client, PlayerSAO *playersao)
 {
-	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD, datas.size(), peer_id);
-	pkt.putRawString(datas.c_str(), datas.size());
+	// Radius inside which objects are active
+	static thread_local const s16 radius =
+		g_settings->getS16("active_object_send_range_blocks") * MAP_BLOCKSIZE;
+
+	// Radius inside which players are active
+	static thread_local const bool is_transfer_limited =
+		g_settings->exists("unlimited_player_transfer_distance") &&
+		!g_settings->getBool("unlimited_player_transfer_distance");
+
+	static thread_local const s16 player_transfer_dist =
+		g_settings->getS16("player_transfer_distance") * MAP_BLOCKSIZE;
+
+	s16 player_radius = player_transfer_dist == 0 && is_transfer_limited ?
+		radius : player_transfer_dist;
+
+	s16 my_radius = MYMIN(radius, playersao->getWantedRange() * MAP_BLOCKSIZE);
+	if (my_radius <= 0)
+		my_radius = radius;
+
+	std::queue<u16> removed_objects, added_objects;
+	m_env->getRemovedActiveObjects(playersao, my_radius, player_radius,
+		client->m_known_objects, removed_objects);
+	m_env->getAddedActiveObjects(playersao, my_radius, player_radius,
+		client->m_known_objects, added_objects);
+
+	int removed_count = removed_objects.size();
+	int added_count   = added_objects.size();
+
+	if (removed_objects.empty() && added_objects.empty())
+		return;
+
+	char buf[4];
+	std::string data;
+
+	// Handle removed objects
+	writeU16((u8*)buf, removed_objects.size());
+	data.append(buf, 2);
+	while (!removed_objects.empty()) {
+		// Get object
+		u16 id = removed_objects.front();
+		ServerActiveObject* obj = m_env->getActiveObject(id);
+
+		// Add to data buffer for sending
+		writeU16((u8*)buf, id);
+		data.append(buf, 2);
+
+		// Remove from known objects
+		client->m_known_objects.erase(id);
+
+		if (obj && obj->m_known_by_count > 0)
+			obj->m_known_by_count--;
+
+		removed_objects.pop();
+	}
+
+	// Handle added objects
+	writeU16((u8*)buf, added_objects.size());
+	data.append(buf, 2);
+	while (!added_objects.empty()) {
+		// Get object
+		u16 id = added_objects.front();
+		ServerActiveObject* obj = m_env->getActiveObject(id);
+
+		// Get object type
+		u8 type = ACTIVEOBJECT_TYPE_INVALID;
+		if (!obj)
+			warningstream << FUNCTION_NAME << ": NULL object" << std::endl;
+		else
+			type = obj->getSendType();
+
+		// Add to data buffer for sending
+		writeU16((u8*)buf, id);
+		data.append(buf, 2);
+		writeU8((u8*)buf, type);
+		data.append(buf, 1);
+
+		if (obj)
+			data.append(serializeLongString(
+				obj->getClientInitializationData(client->net_proto_version)));
+		else
+			data.append(serializeLongString(""));
+
+		// Add to known objects
+		client->m_known_objects.insert(id);
+
+		if (obj)
+			obj->m_known_by_count++;
+
+		added_objects.pop();
+	}
+
+	NetworkPacket pkt(TOCLIENT_ACTIVE_OBJECT_REMOVE_ADD, data.size(), client->peer_id);
+	pkt.putRawString(data.c_str(), data.size());
 	Send(&pkt);
-	return pkt.getSize();
+
+	verbosestream << "Server::SendActiveObjectRemoveAdd: "
+		<< removed_count << " removed, " << added_count << " added, "
+		<< "packet size is " << pkt.getSize() << std::endl;
 }
 
 void Server::SendActiveObjectMessages(session_t peer_id, const std::string &datas,

--- a/src/server.h
+++ b/src/server.h
@@ -469,7 +469,7 @@ private:
 		bool vertical, const std::string &texture,
 		const struct TileAnimationParams &animation, u8 glow);
 
-	u32 SendActiveObjectRemoveAdd(session_t peer_id, const std::string &datas);
+	void SendActiveObjectRemoveAdd(RemoteClient *client, PlayerSAO *playersao);
 	void SendActiveObjectMessages(session_t peer_id, const std::string &datas,
 		bool reliable = true);
 	void SendCSMRestrictionFlags(session_t peer_id);


### PR DESCRIPTION
- ActiveObjects are also sent once along with itemdefs and nodedefs, once the client reaches `CS_InitDone`.
  - This means that active objects are sent to the client earlier than in master, which sends activeobjects after all definitions are sent (the next step). While this isn't much of a difference, it becomes more noticeable the more the client is lagging.
  - This required some refactoring in `server.cpp` to prevent substantial code duplication.
- `LocalPlayer::isDead` always returned false if damage had been disabled, and that is now fixed - The method checks whether the player's CAO is immortal, and then whether the CAO's HP is 0.
- Lots of code-style fixes in `localplayer.cpp` and `Client::sendPlayerPos` (in client.cpp), including
  - Pointer placement
  - Spacing between keywords, parenthesis and braces. e.g. `if (` and `) {`
  - Spacing around operators in expressions
  - Merging braces and `else` keyword into one line. i.e. `} else {`
  - Removal of double-tab indents where not required.
  - Addition of missing literal `f` for floats.
