### PR TITLE
Make Mapgen::spreadLight use a queue

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -469,9 +469,8 @@ void Mapgen::lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue,
 
 	n.param1 = light;
 
-	// spread to all 6 neighbor nodes
-	for (const auto &dir : g_6dirs)
-		queue.emplace(p + dir, light);
+	// add to queue
+	queue.emplace(p, light);
 }
 
 
@@ -562,7 +561,9 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 
 	while (!queue.empty()) {
 		const auto &i = queue.front();
-		lightSpread(a, queue, i.first, i.second);
+		// spread to all 6 neighbor nodes
+		for (const auto &dir : g_6dirs)
+			lightSpread(a, queue, i.first + dir, i.second);
 		queue.pop();
 	}
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -470,9 +470,8 @@ void Mapgen::lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue,
 	n.param1 = light;
 
 	// spread to all 6 neighbor nodes
-	for (u8 i = 0; i < 6; i++) {
-		queue.emplace(p + g_6dirs[i], light);
-	}
+	for (const auto &dir : g_6dirs)
+		queue.emplace(p + dir, light);
 }
 
 
@@ -554,9 +553,8 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 				if (light) {
 					const v3s16 p(x, y, z);
 					// spread to all 6 neighbor nodes
-					for (u8 i = 0; i < 6; i++) {
-						lightSpread(a, queue, p + g_6dirs[i], light);
-					}
+					for (const auto &dir : g_6dirs)
+						lightSpread(a, queue, p + dir, light);
 				}
 			}
 		}

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -526,7 +526,7 @@ void Mapgen::propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow)
 
 void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 {
-	TimeTaker t("spreadLight");
+	//TimeTaker t("spreadLight");
 	std::queue<std::pair<v3s16, u8>> queue;
 	VoxelArea a(nmin, nmax);
 
@@ -566,7 +566,7 @@ void Mapgen::spreadLight(const v3s16 &nmin, const v3s16 &nmax)
 		queue.pop();
 	}
 
-	printf("spreadLight: %lums\n", t.stop());
+	//printf("spreadLight: %lums\n", t.stop());
 }
 
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -190,12 +190,12 @@ public:
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 
 	void setLighting(u8 light, v3s16 nmin, v3s16 nmax);
-	void lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue, v3s16 p,
-		u8 light);
+	void lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue,
+		const v3s16 &p, u8 light);
 	void calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
 		bool propagate_shadow = true);
 	void propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow);
-	void spreadLight(v3s16 nmin, v3s16 nmax);
+	void spreadLight(const v3s16 &nmin, const v3s16 &nmax);
 
 	virtual void makeChunk(BlockMakeData *data) {}
 	virtual int getGroundLevelAtPoint(v2s16 p) { return 0; }

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -190,7 +190,8 @@ public:
 	void updateLiquid(UniqueQueue<v3s16> *trans_liquid, v3s16 nmin, v3s16 nmax);
 
 	void setLighting(u8 light, v3s16 nmin, v3s16 nmax);
-	void lightSpread(VoxelArea &a, v3s16 p, u8 light);
+	void lightSpread(VoxelArea &a, std::queue<std::pair<v3s16, u8>> &queue, v3s16 p,
+		u8 light);
 	void calcLighting(v3s16 nmin, v3s16 nmax, v3s16 full_nmin, v3s16 full_nmax,
 		bool propagate_shadow = true);
 	void propagateSunlight(v3s16 nmin, v3s16 nmax, bool propagate_shadow);


### PR DESCRIPTION
- Goal of the PR: increase the performance
- How does the PR work? `Mapgen::spreadLight` fills a queue and then makes it empty again.
- Related: #8832 (This PR might be able to replace that and fix its issues, but I'm not sure.)
- Fixes #4399, fixes #7864, fixes #8763

## To do

This PR is a Ready for Review.

## How to test

Fly around and generate new mapblocks. Look into the terminal to see how long `spreadLight` takes.

I've tested this in minimal and in [lavaland](https://github.com/jastevenson303/lavaland). In both subgames the values of this PR were better.