### PR TITLE
Purge tool filtering in node drops

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -208,26 +208,10 @@ function core.get_node_drops(node, toolname)
 	local got_count = 0
 	for _, item in ipairs(drop.items) do
 		local good_rarity = true
-		local good_tool = true
 		if item.rarity ~= nil then
 			good_rarity = item.rarity < 1 or math.random(item.rarity) == 1
 		end
-		if item.tools ~= nil then
-			good_tool = false
-		end
-		if item.tools ~= nil and toolname then
-			for _, tool in ipairs(item.tools) do
-				if tool:sub(1, 1) == '~' then
-					good_tool = toolname:find(tool:sub(2)) ~= nil
-				else
-					good_tool = toolname == tool
-				end
-				if good_tool then
-					break
-				end
-			end
-		end
-		if good_rarity and good_tool then
+		if good_rarity then
 			got_count = got_count + 1
 			for _, add_item in ipairs(item.items) do
 				-- add color, if necessary

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6424,9 +6424,7 @@ Used by `minetest.register_node`.
         drop = {
             max_items = 1,
             -- Maximum number of item lists to drop.
-            -- The entries in 'items' are processed in order. For each:
-            -- Tool filtering is applied, chance of drop is applied, if both are
-            -- successful the entire item list is dropped.
+            -- The entries in 'items' are processed in order.
             -- Entry processing continues until the number of dropped item lists
             -- equals 'max_items'.
             -- Therefore, entries should progress from low to high drop chance.
@@ -6437,11 +6435,9 @@ Used by `minetest.register_node`.
                     -- Default rarity is '1'.
                     rarity = 1000,
                     items = {"default:diamond"},
+                    -- 'tools' table was removed in 5.1-dev.
                 },
                 {
-                    -- Only drop if using a tool whose name is identical to one
-                    -- of these.
-                    tools = {"default:shovel_mese", "default:shovel_diamond"},
                     rarity = 5,
                     items = {"default:dirt"},
                     -- Whether all items in the dropped item list inherit the
@@ -6450,9 +6446,6 @@ Used by `minetest.register_node`.
                     inherit_color = true,
                 },
                 {
-                    -- Only drop if using a tool whose name contains
-                    -- "default:shovel_".
-                    tools = {"~default:shovel_"},
                     rarity = 2,
                     -- The item list dropped.
                     items = {"default:sand", "default:desert_sand"},


### PR DESCRIPTION
Brings #8464 finally to an end. (Fixes #8464)
Removes tool filtering entirely. If mod issues occur, please do not assign me.

## To do

This PR is Ready for Review.

## How to test

1) Start Minetest
2) Dig a node
3) No crashing
