### PR TITLE
Improve occlusion culling

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -310,6 +310,8 @@ protected:
 	// This stores the properties of the nodes on the map.
 	const NodeDefManager *m_nodedef;
 
+	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
+		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 		float step, float stepfac, float start_offset, float end_offset,
 		u32 needed_count);


### PR DESCRIPTION
depends on #8850, reviewers see 2nd commit

In comparison this PR is much better than before with straight corridors

(before)
![screenshot_20190823_221658](https://user-images.githubusercontent.com/1042418/63621265-cb4c2280-c5f3-11e9-9280-92442665c87c.png)
(after)
![screenshot_20190823_221637](https://user-images.githubusercontent.com/1042418/63621277-cf784000-c5f3-11e9-867d-1107178d3fe7.png)

## To do

This PR is Ready for Review.
## How to test

Dig a straight (and diagonal) tunnel and observe occlusion culling behaviour.