### PR TITLE
Fix default hand definition not using wieldhand.png

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -373,6 +373,7 @@ core.register_node(":ignore", {
 -- The hand (bare definition)
 core.register_item(":", {
 	type = "none",
+	wield_image = "wieldhand.png",
 	groups = {not_in_creative_inventory=1},
 })
 


### PR DESCRIPTION
- Goal of the PR: To fix the bug that `wieldhand.png` is not used by default.
    - The bug: If no hand is defined by any mod, no texture for the wieldhand is used, instead the hand looks and behaves just really buggy, with either a "fake" texture with a single pixel, or a huge white box, or other oddities
- How does the PR work? By adding `wield_image` to the default hand definition
- Does it resolve any reported issue? Yes, the issue that's (indirectly) reported here: https://github.com/minetest/minetest/pull/8845
- If not a bug fix, why is this PR needed? What usecases does it solve? N/A

## Justification

`wieldhand.png` is mentioned in texture docs. So it should be actually used by the engine.

## How to test

* Create an empty game (no mods)
* Start it
* Select the hand

Make an before/after comparison.