### PR TITLE
Add ItemStack:get_description() to get tooltip

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5253,6 +5253,7 @@ an itemstring, a table or `nil`.
 * `get_metadata()`: (DEPRECATED) Returns metadata (a string attached to an item
   stack).
 * `set_metadata(metadata)`: (DEPRECATED) Returns true.
+* `get_description()`: returns the description shown in inventory list tooltips.
 * `clear()`: removes all items from the stack, making it empty.
 * `replace(item)`: replace the contents of this stack.
     * `item` can also be an itemstring or table.

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2856,9 +2856,10 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 
 			// Draw tooltip
 			if (hovering && !m_selected_item) {
-				std::string tooltip = item.getDescription(
-						m_tooltip_append_itemname, m_client->idef());
+				std::string tooltip = item.getDescription(m_client->idef());
 				if (!tooltip.empty()) {
+					if (m_tooltip_append_itemname)
+						tooltip += "\n[" + item.name + "]";
 					showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,
 							m_default_tooltip_bgcolor);
 				}

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2844,20 +2844,17 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 		}
 
 		if (layer == 1) {
-			// Draw item stack
 			if (selected)
 				item.takeItem(m_selected_amount);
 
 			if (!item.empty()) {
+				// Draw item stack
 				drawItemStack(driver, m_font, item,
 					rect, &AbsoluteClippingRect, m_client,
 					rotation_kind);
-			}
-
-			// Draw tooltip
-			if (hovering && !m_selected_item) {
-				std::string tooltip = item.getDescription(m_client->idef());
-				if (!tooltip.empty()) {
+				// Draw tooltip
+				if (hovering && !m_selected_item) {
+					std::string tooltip = item.getDescription(m_client->idef());
 					if (m_tooltip_append_itemname)
 						tooltip += "\n[" + item.name + "]";
 					showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2855,25 +2855,13 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 			}
 
 			// Draw tooltip
-			std::wstring tooltip_text;
 			if (hovering && !m_selected_item) {
-				const std::string &desc = item.metadata.getString("description");
-				if (desc.empty())
-					tooltip_text =
-						utf8_to_wide(item.getDefinition(m_client->idef()).description);
-				else
-					tooltip_text = utf8_to_wide(desc);
-
-				if (!item.name.empty()) {
-					if (tooltip_text.empty())
-						tooltip_text = utf8_to_wide(item.name);
-					else if (m_tooltip_append_itemname)
-						tooltip_text += utf8_to_wide("\n[" + item.name + "]");
+				std::string tooltip = item.getDescription(
+						m_tooltip_append_itemname, m_client->idef());
+				if (!tooltip.empty()) {
+					showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,
+							m_default_tooltip_bgcolor);
 				}
-			}
-			if (!tooltip_text.empty()) {
-				showTooltip(tooltip_text, m_default_tooltip_color,
-					m_default_tooltip_bgcolor);
 			}
 		}
 	}

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -246,6 +246,19 @@ std::string ItemStack::getItemString() const
 	return os.str();
 }
 
+std::string ItemStack::getDescription(bool append_itemname,
+		IItemDefManager *itemdef) const
+{
+	std::string desc = metadata.getString("description");
+	if (desc.empty())
+		desc = getDefinition(itemdef).description;
+	if (desc.empty())
+		return name;
+	if (append_itemname)
+		desc += "\n[" + name + "]";
+	return desc;
+}
+
 
 ItemStack ItemStack::addItem(ItemStack newitem, IItemDefManager *itemdef)
 {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -246,17 +246,12 @@ std::string ItemStack::getItemString() const
 	return os.str();
 }
 
-std::string ItemStack::getDescription(bool append_itemname,
-		IItemDefManager *itemdef) const
+std::string ItemStack::getDescription(IItemDefManager *itemdef) const
 {
 	std::string desc = metadata.getString("description");
 	if (desc.empty())
 		desc = getDefinition(itemdef).description;
-	if (desc.empty())
-		return name;
-	if (append_itemname)
-		desc += "\n[" + name + "]";
-	return desc;
+	return desc.empty() ? name : desc;
 }
 
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -47,6 +47,9 @@ struct ItemStack
 
 	// Returns the string used for inventory
 	std::string getItemString() const;
+	// Returns the tooltip
+	std::string getDescription(bool append_itemname,
+			IItemDefManager *itemdef) const;
 
 	/*
 		Quantity methods

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -48,8 +48,7 @@ struct ItemStack
 	// Returns the string used for inventory
 	std::string getItemString() const;
 	// Returns the tooltip
-	std::string getDescription(bool append_itemname,
-			IItemDefManager *itemdef) const;
+	std::string getDescription(IItemDefManager *itemdef) const;
 
 	/*
 		Quantity methods

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -180,7 +180,7 @@ int LuaItemStack::l_get_description(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	LuaItemStack *o = checkobject(L, 1);
-	std::string desc = o->m_stack.getDescription(false, getGameDef(L)->idef());
+	std::string desc = o->m_stack.getDescription(getGameDef(L)->idef());
 	lua_pushstring(L, desc.c_str());
 	return 1;
 }

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -175,6 +175,16 @@ int LuaItemStack::l_set_metadata(lua_State *L)
 	return 1;
 }
 
+// get_description(self)
+int LuaItemStack::l_get_description(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	LuaItemStack *o = checkobject(L, 1);
+	std::string desc = o->m_stack.getDescription(false, getGameDef(L)->idef());
+	lua_pushstring(L, desc.c_str());
+	return 1;
+}
+
 // clear(self) -> true
 int LuaItemStack::l_clear(lua_State *L)
 {
@@ -470,6 +480,7 @@ const luaL_Reg LuaItemStack::methods[] = {
 	luamethod(LuaItemStack, get_meta),
 	luamethod(LuaItemStack, get_metadata),
 	luamethod(LuaItemStack, set_metadata),
+	luamethod(LuaItemStack, get_description),
 	luamethod(LuaItemStack, clear),
 	luamethod(LuaItemStack, replace),
 	luamethod(LuaItemStack, to_string),

--- a/src/script/lua_api/l_item.h
+++ b/src/script/lua_api/l_item.h
@@ -66,6 +66,9 @@ private:
 	// set_metadata(self, string)
 	static int l_set_metadata(lua_State *L);
 
+	// get_description(self)
+	static int l_get_description(lua_State *L);
+
 	// clear(self) -> true
 	static int l_clear(lua_State *L);
 


### PR DESCRIPTION
Closes #8080

## To do

This PR is Ready for Review.

## How to test

- Check that item tooltips in inventory lists are shown correctly.
```lua
print(ItemStack("default:pick_steel"):get_description()) --> Steel Pickaxe
print(ItemStack("foobar"):get_description()) --> Unknown Item
local stack = ItemStack("default:stone")
stack:get_meta():set_string("description", "Custom description")
print(stack:get_description()) --> Custom description
print(ItemStack("beds:bed_top"):get_description()) --> beds:bed_top
```