### PR TITLE
Improve performance of occlusion culling.

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1130,8 +1130,7 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	// Check occlusion for center and all 8 corners of the mapblock
 	// Overshoot a little for less flickering
 	static const s16 bs2 = MAP_BLOCKSIZE / 2 + 1;
-	static const v3s16 dir9[9] = {
-		v3s16( 0,  0,  0),
+	static const v3s16 dir8[8] = {
 		v3s16( 1,  1,  1) * bs2,
 		v3s16( 1,  1, -1) * bs2,
 		v3s16( 1, -1,  1) * bs2,
@@ -1167,7 +1166,13 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 			return false;
 	}
 
-	for (const v3s16 &dir : dir9) {
+	// Block center, end_offset can be halfed.
+	if (!isOccluded(cam_pos_nodes, pos_blockcenter, step, stepfac,
+			start_offset, end_offset / 2.0f))
+		return false;
+
+	// All the block's corners.
+	for (const v3s16 &dir : dir8) {
 		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
 				start_offset, end_offset))
 			return false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1097,20 +1097,10 @@ bool Map::determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 }
 
 bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-	const core::aabbox3d<s16> &block_bounds, float step, float stepfac, float offset,
-	u32 needed_count)
+	float step, float stepfac, float offset, float end_offset, u32 needed_count)
 {
-	// Worst-case safety distance to keep to the target position
-	// Anything smaller than the mapblock diagonal could result in in self-occlusion
-	// Diagonal = sqrt(1*1 + 1*1 + 1*1)
-	const static float BLOCK_DIAGONAL = BS * MAP_BLOCKSIZE * 1.732f;
-
 	v3f direction = intToFloat(pos_target - pos_camera, BS);
 	float distance = direction.getLength();
-
-	// Disable occlusion culling for near mapblocks in underground
-	if (distance < BLOCK_DIAGONAL)
-		return false;
 
 	// Normalize direction vector
 	if (distance > 0.0f)
@@ -1120,16 +1110,9 @@ bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 	u32 count = 0;
 	bool is_valid_position;
 
-	for (; offset < distance; offset += step) {
+	for (; offset < distance + end_offset; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
 		v3s16 pos_node = floatToInt(pos_node_f, BS);
-
-		if (offset > distance - BLOCK_DIAGONAL) {
-			// Do accurate position checks:
-			// Check whether the node is inside the current mapblock
-			if (block_bounds.isPointInside(pos_node))
-				return false;
-		}
 
 		MapNode node = getNode(pos_node, &is_valid_position);
 
@@ -1162,36 +1145,37 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 		v3s16(-1, -1, -1) * bs2,
 	};
 
-	// Minimal and maximal positions in the mapblock
-	core::aabbox3d<s16> block_bounds = block->getBox();
+	v3s16 pos_blockcenter = block->getPosRelative() + (MAP_BLOCKSIZE / 2);
 
-	v3s16 pos_blockcenter = block_bounds.MinEdge + (MAP_BLOCKSIZE / 2);
-
-	// Starting step size, value between 1m and sqrt(3)m
-	float step = BS * 1.73206f;
+	// Starting step size, slightly > sqrt(3),
+	// so that each block is hit at most once.
+	float step = BS * 1.7321f;
 	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
-	float start_offset = step;
+	// Take the camera's front view plane into account, and start slighly back.
+	// (TODO: use near_plane config)
+	float start_offset = -BS * 0.1f;
 
-	// to reduce the likelihood of falsely occluded blocks
-	// require at least two solid blocks
-	// this is a HACK, we should think of a more precise algorithm
-	u32 needed_count = 1;
+	// The occlusion search of 'isOccluded()' must stop short of the target
+	// point by distance 'end_offset' to not enter the target mapblock.
+	// For the 8 mapblock corners 'end_offset' must therefore be the maximum
+	// diagonal of a mapblock, because we must consider all view angles.
+	// sqrt(1^2 + 1^2 + 1^2) = 1.732
+	float end_offset = -BS * MAP_BLOCKSIZE * 1.732f;
 
 	// Additional occlusion check, see comments in that function
 	v3s16 check;
 	if (determineAdditionalOcclusionCheck(cam_pos_nodes, block->getBox(), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
-		if (!isOccluded(cam_pos_nodes, check, block_bounds, step, stepfac, start_offset,
-				needed_count))
+		if (!isOccluded(cam_pos_nodes, check, step, stepfac, start_offset,
+				-1.0f, 1))
 			return false;
 	}
 
 	for (const v3s16 &dir : dir9) {
-		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, block_bounds,
-						step, stepfac,
-						start_offset, needed_count))
+		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
+				start_offset, end_offset, 1))
 			return false;
 	}
 	return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1097,7 +1097,7 @@ bool Map::determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 }
 
 bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-	float step, float stepfac, float offset, float end_offset)
+	float step, float stepfac, float end_offset)
 {
 	v3f direction = intToFloat(pos_target - pos_camera, BS);
 	float distance = direction.getLength();
@@ -1109,7 +1109,7 @@ bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 	v3f pos_origin_f = intToFloat(pos_camera, BS);
 	bool is_valid_position;
 
-	for (; offset < distance + end_offset; offset += step) {
+	for (float offset = 0.0f; offset < distance + end_offset; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
 		v3s16 pos_node = floatToInt(pos_node_f, BS);
 
@@ -1149,8 +1149,6 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
-	float start_offset = BS * 1.0f;
-
 	// The occlusion search of 'isOccluded()' must stop short of the target
 	// point by distance 'end_offset' to not enter the target mapblock.
 	// For the 8 mapblock corners 'end_offset' must therefore be the maximum
@@ -1162,19 +1160,17 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	v3s16 check;
 	if (determineAdditionalOcclusionCheck(cam_pos_nodes, block->getBox(), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
-		if (!isOccluded(cam_pos_nodes, check, step, stepfac, start_offset, -1.0f))
+		if (!isOccluded(cam_pos_nodes, check, step, stepfac, -1.0f))
 			return false;
 	}
 
 	// Block center, end_offset can be halfed.
-	if (!isOccluded(cam_pos_nodes, pos_blockcenter, step, stepfac,
-			start_offset, end_offset / 2.0f))
+	if (!isOccluded(cam_pos_nodes, pos_blockcenter, step, stepfac, end_offset / 2.0f))
 		return false;
 
 	// All the block's corners.
 	for (const v3s16 &dir : dir8) {
-		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
-				start_offset, end_offset))
+		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac, end_offset))
 			return false;
 	}
 	return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1097,10 +1097,20 @@ bool Map::determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 }
 
 bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-	float step, float stepfac, float offset, float end_offset, u32 needed_count)
+	const core::aabbox3d<s16> &block_bounds, float step, float stepfac, float offset,
+	u32 needed_count)
 {
+	// Worst-case safety distance to keep to the target position
+	// Anything smaller than the mapblock diagonal could result in in self-occlusion
+	// Diagonal = sqrt(1*1 + 1*1 + 1*1)
+	const static float BLOCK_DIAGONAL = BS * MAP_BLOCKSIZE * 1.732f;
+
 	v3f direction = intToFloat(pos_target - pos_camera, BS);
 	float distance = direction.getLength();
+
+	// Disable occlusion culling for near mapblocks in underground
+	if (distance < BLOCK_DIAGONAL)
+		return false;
 
 	// Normalize direction vector
 	if (distance > 0.0f)
@@ -1110,9 +1120,16 @@ bool Map::isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
 	u32 count = 0;
 	bool is_valid_position;
 
-	for (; offset < distance + end_offset; offset += step) {
+	for (; offset < distance; offset += step) {
 		v3f pos_node_f = pos_origin_f + direction * offset;
 		v3s16 pos_node = floatToInt(pos_node_f, BS);
+
+		if (offset > distance - BLOCK_DIAGONAL) {
+			// Do accurate position checks:
+			// Check whether the node is inside the current mapblock
+			if (block_bounds.isPointInside(pos_node))
+				return false;
+		}
 
 		MapNode node = getNode(pos_node, &is_valid_position);
 
@@ -1145,39 +1162,36 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 		v3s16(-1, -1, -1) * bs2,
 	};
 
-	v3s16 pos_blockcenter = block->getPosRelative() + (MAP_BLOCKSIZE / 2);
+	// Minimal and maximal positions in the mapblock
+	core::aabbox3d<s16> block_bounds = block->getBox();
+
+	v3s16 pos_blockcenter = block_bounds.MinEdge + (MAP_BLOCKSIZE / 2);
 
 	// Starting step size, value between 1m and sqrt(3)m
-	float step = BS * 1.2f;
+	float step = BS * 1.73206f;
 	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
-	float start_offset = BS * 1.0f;
-
-	// The occlusion search of 'isOccluded()' must stop short of the target
-	// point by distance 'end_offset' to not enter the target mapblock.
-	// For the 8 mapblock corners 'end_offset' must therefore be the maximum
-	// diagonal of a mapblock, because we must consider all view angles.
-	// sqrt(1^2 + 1^2 + 1^2) = 1.732
-	float end_offset = -BS * MAP_BLOCKSIZE * 1.732f;
+	float start_offset = step;
 
 	// to reduce the likelihood of falsely occluded blocks
 	// require at least two solid blocks
 	// this is a HACK, we should think of a more precise algorithm
-	u32 needed_count = 2;
+	u32 needed_count = 1;
 
 	// Additional occlusion check, see comments in that function
 	v3s16 check;
 	if (determineAdditionalOcclusionCheck(cam_pos_nodes, block->getBox(), check)) {
 		// node is always on a side facing the camera, end_offset can be lower
-		if (!isOccluded(cam_pos_nodes, check, step, stepfac, start_offset,
-				-1.0f, needed_count))
+		if (!isOccluded(cam_pos_nodes, check, block_bounds, step, stepfac, start_offset,
+				needed_count))
 			return false;
 	}
 
 	for (const v3s16 &dir : dir9) {
-		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, step, stepfac,
-				start_offset, end_offset, needed_count))
+		if (!isOccluded(cam_pos_nodes, pos_blockcenter + dir, block_bounds,
+						step, stepfac,
+						start_offset, needed_count))
 			return false;
 	}
 	return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1148,14 +1148,12 @@ bool Map::isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes)
 	v3s16 pos_blockcenter = block->getPosRelative() + (MAP_BLOCKSIZE / 2);
 
 	// Starting step size, slightly > sqrt(3),
-	// so that each block is hit at most once.
+	// so that each node is hit at most once.
 	float step = BS * 1.7321f;
 	// Multiply step by each iteraction by 'stepfac' to reduce checks in distance
 	float stepfac = 1.05f;
 
-	// Take the camera's front view plane into account, and start slighly back.
-	// (TODO: use near_plane config)
-	float start_offset = -BS * 0.1f;
+	float start_offset = BS * 1.0f;
 
 	// The occlusion search of 'isOccluded()' must stop short of the target
 	// point by distance 'end_offset' to not enter the target mapblock.

--- a/src/map.h
+++ b/src/map.h
@@ -313,8 +313,8 @@ protected:
 	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-		const core::aabbox3d<s16> &block_bounds, float step, float stepfac,
-		float offset, u32 needed_count);
+		float step, float stepfac, float start_offset, float end_offset,
+		u32 needed_count);
 
 private:
 	f32 m_transforming_liquid_loop_count_multiplier = 1.0f;

--- a/src/map.h
+++ b/src/map.h
@@ -313,8 +313,8 @@ protected:
 	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-		float step, float stepfac, float start_offset, float end_offset,
-		u32 needed_count);
+		const core::aabbox3d<s16> &block_bounds, float step, float stepfac,
+		float offset, u32 needed_count);
 
 private:
 	f32 m_transforming_liquid_loop_count_multiplier = 1.0f;

--- a/src/map.h
+++ b/src/map.h
@@ -313,7 +313,7 @@ protected:
 	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-		float step, float stepfac, float start_offset, float end_offset);
+		float step, float stepfac, float end_offset);
 
 private:
 	f32 m_transforming_liquid_loop_count_multiplier = 1.0f;

--- a/src/map.h
+++ b/src/map.h
@@ -313,8 +313,7 @@ protected:
 	bool determineAdditionalOcclusionCheck(const v3s16 &pos_camera,
 		const core::aabbox3d<s16> &block_bounds, v3s16 &check);
 	bool isOccluded(const v3s16 &pos_camera, const v3s16 &pos_target,
-		float step, float stepfac, float start_offset, float end_offset,
-		u32 needed_count);
+		float step, float stepfac, float start_offset, float end_offset);
 
 private:
 	f32 m_transforming_liquid_loop_count_multiplier = 1.0f;


### PR DESCRIPTION
This should do both (slightly) more accurate and faster occlusion culling.

Please have a look. The main observations ar

1. If the minimum step size is slightly >= sqrt(3) a node cannot be touched more than one.
2. ~~We should start a bit back from the camera (to account for the fact that the camera is pane - not a point.) Use the rear_pane distance for that.~~
3. Now the needed_count hack is no longer needed.
4. The start_offset should also be remove (i.e. be 0), since otherwise the visibility is camera direction dependent, which leads to weird artifacts.

In a few tests I've done this is as accurate (does not cull block that should be culled), culls slightly more of the invisible blocks, and is more performant.

BUT... As the related issues before... This needs to be very carefully tested.
So consider this experimental, play around with it.