### PR TITLE
Send cumulated inventory changes only each step

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -569,7 +569,6 @@ ItemStack InventoryList::changeItem(u32 i, const ItemStack &newitem)
 	ItemStack olditem = m_items[i];
 	m_items[i] = newitem;
 	setModified();
-	std::cout << "changeItem " << m_name << std::endl;
 	return olditem;
 }
 
@@ -848,8 +847,6 @@ void Inventory::serialize(std::ostream &os, bool incremental) const
 		if (!incremental || list->checkModified()) {
 			os << "List " << list->getName() << " " << list->getSize() << "\n";
 			list->serialize(os, incremental);
-			if (incremental)
-				std::cout << "inv::serialize " << list->getName() << std::endl;
 		} else {
 			os << "KeepList " << list->getName() << "\n";
 		}

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -569,6 +569,7 @@ ItemStack InventoryList::changeItem(u32 i, const ItemStack &newitem)
 	ItemStack olditem = m_items[i];
 	m_items[i] = newitem;
 	setModified();
+	std::cout << "changeItem " << m_name << std::endl;
 	return olditem;
 }
 
@@ -847,6 +848,8 @@ void Inventory::serialize(std::ostream &os, bool incremental) const
 		if (!incremental || list->checkModified()) {
 			os << "List " << list->getName() << " " << list->getSize() << "\n";
 			list->serialize(os, incremental);
+			if (incremental)
+				std::cout << "inv::serialize " << list->getName() << std::endl;
 		} else {
 			os << "KeepList " << list->getName() << "\n";
 		}

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -524,9 +524,9 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 		}
 	}
 
-	mgr->setInventoryModified(from_inv, false);
+	mgr->setInventoryModified(from_inv);
 	if (inv_from != inv_to)
-		mgr->setInventoryModified(to_inv, false);
+		mgr->setInventoryModified(to_inv);
 }
 
 void IMoveAction::clientApply(InventoryManager *mgr, IGameDef *gamedef)
@@ -671,7 +671,7 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 			if (item2.count != actually_dropped_count)
 				errorstream<<"Could not take dropped count of items"<<std::endl;
 
-			mgr->setInventoryModified(from_inv, false);
+			mgr->setInventoryModified(from_inv);
 		}
 	}
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -313,7 +313,7 @@ void Server::handleCommand_Init2(NetworkPacket* pkt)
 	sendMediaAnnouncement(pkt->getPeerId(), lang);
 
 	// Send detached inventories
-	sendDetachedInventories(pkt->getPeerId());
+	sendDetachedInventories(pkt->getPeerId(), false);
 
 	// Send time of day
 	u16 time = m_env->getTimeOfDay();
@@ -730,8 +730,6 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 	a->apply(this, playersao, this);
 	// Eat the action
 	delete a;
-
-	SendInventory(playersao, true);
 }
 
 void Server::handleCommand_ChatMessage(NetworkPacket* pkt)

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -608,10 +608,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		ma->from_inv.applyCurrentPlayer(player->getName());
 		ma->to_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(ma->from_inv, false);
-		if (ma->from_inv != ma->to_inv) {
-			setInventoryModified(ma->to_inv, false);
-		}
+		setInventoryModified(ma->from_inv);
+		if (ma->from_inv != ma->to_inv)
+			setInventoryModified(ma->to_inv);
 
 		bool from_inv_is_current_player =
 			(ma->from_inv.type == InventoryLocation::PLAYER) &&
@@ -676,7 +675,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		da->from_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(da->from_inv, false);
+		setInventoryModified(da->from_inv);
 
 		/*
 			Disable dropping items out of craftpreview
@@ -712,7 +711,7 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 
 		ca->craft_inv.applyCurrentPlayer(player->getName());
 
-		setInventoryModified(ca->craft_inv, false);
+		setInventoryModified(ca->craft_inv);
 
 		//bool craft_inv_is_current_player =
 		//	(ca->craft_inv.type == InventoryLocation::PLAYER) &&

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1261,7 +1261,7 @@ void Server::setInventoryModified(const InventoryLocation &loc)
 		break;
 	case InventoryLocation::DETACHED:
 	{
-		sendDetachedInventory(loc.name,PEER_ID_INEXISTENT);
+		// Updates are sent in ServerEnvironment::step()
 	}
 		break;
 	default:
@@ -2609,11 +2609,16 @@ void Server::sendDetachedInventory(const std::string &name, session_t peer_id)
 		Send(&pkt);
 }
 
-void Server::sendDetachedInventories(session_t peer_id)
+void Server::sendDetachedInventories(session_t peer_id, bool incremental)
 {
 	for (const auto &detached_inventory : m_detached_inventories) {
 		const std::string &name = detached_inventory.first;
-		//Inventory *inv = i->second;
+		if (incremental) {
+			Inventory *inv = detached_inventory.second;
+			if (!inv || !inv->checkModified())
+				continue;
+		}
+
 		sendDetachedInventory(name, peer_id);
 	}
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1234,7 +1234,7 @@ Inventory* Server::getInventory(const InventoryLocation &loc)
 	return NULL;
 }
 
-void Server::setInventoryModified(const InventoryLocation &loc, bool playerSend)
+void Server::setInventoryModified(const InventoryLocation &loc)
 {
 	switch(loc.type){
 	case InventoryLocation::UNDEFINED:
@@ -1248,15 +1248,7 @@ void Server::setInventoryModified(const InventoryLocation &loc, bool playerSend)
 			return;
 
 		player->setModified(true);
-
-		if (!playerSend)
-			return;
-
-		PlayerSAO *playersao = player->getPlayerSAO();
-		if(!playersao)
-			return;
-
-		SendInventory(playersao, true);
+		// Updates are sent in ServerEnvironment::step()
 	}
 		break;
 	case InventoryLocation::NODEMETA:

--- a/src/server.h
+++ b/src/server.h
@@ -195,7 +195,7 @@ public:
 		Shall be called with the environment and the connection locked.
 	*/
 	Inventory* getInventory(const InventoryLocation &loc);
-	void setInventoryModified(const InventoryLocation &loc, bool playerSend = true);
+	void setInventoryModified(const InventoryLocation &loc);
 
 	// Connection must be locked when called
 	std::wstring getStatusString();

--- a/src/server.h
+++ b/src/server.h
@@ -337,6 +337,8 @@ public:
 	void SendMovePlayer(session_t peer_id);
 	void SendPlayerSpeed(session_t peer_id, const v3f &added_vel);
 
+	void sendDetachedInventories(session_t peer_id, bool incremental);
+
 	virtual bool registerModStorage(ModMetadata *storage);
 	virtual void unregisterModStorage(const std::string &name);
 
@@ -443,7 +445,6 @@ private:
 			const std::vector<std::string> &tosend);
 
 	void sendDetachedInventory(const std::string &name, session_t peer_id);
-	void sendDetachedInventories(session_t peer_id);
 
 	// Adds a ParticleSpawner on peer with peer_id (PEER_ID_INEXISTENT == all)
 	void SendAddParticleSpawner(session_t peer_id, u16 protocol_version,

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1464,6 +1464,9 @@ void ServerEnvironment::step(float dtime)
 		if (sao && player->inventory.checkModified())
 			m_server->SendInventory(sao, true);
 	}
+
+	// Send outdated detached inventories
+	m_server->sendDetachedInventories(PEER_ID_INEXISTENT, true);
 }
 
 u32 ServerEnvironment::addParticleSpawner(float exptime)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1454,6 +1454,16 @@ void ServerEnvironment::step(float dtime)
 				++i;
 		}
 	}
+
+	// Send outdated player inventories
+	for (RemotePlayer *player : m_players) {
+		if (player->getPeerId() == PEER_ID_INEXISTENT)
+			continue;
+
+		PlayerSAO *sao = player->getPlayerSAO();
+		if (sao && player->inventory.checkModified())
+			m_server->SendInventory(sao, true);
+	}
 }
 
 u32 ServerEnvironment::addParticleSpawner(float exptime)


### PR DESCRIPTION
This PR does further inventory sending optimizations. Previously `setInventoryModified` sent the inventory in many cases, such as:
 - Any change by Lua
 - Most interact actions

Now all changes *from Lua* will be collected and sent at the end of each server step. Here's a before/after comparison (without second commit):

<details>
<summary>Before</summary>

```
inv::serialize main
inv::serialize main
<^ snip, 16x the same>
changeItem craft
changeItem craft
<^ snip, 8x the same>
changeItem craftpreview
inv::serialize craft
inv::serialize craftpreview
```
</details>

<details>
<summary>After</summary>

```
changeItem craft
changeItem craft
<snip, 8x the same>
changeItem craftpreview
inv::serialize main
inv::serialize craft
inv::serialize craftpreview
```
</details>

## To do

This PR is Ready for Review.

- [x] Test whether this works well on laggy servers

## How to test

1) Keep the logging lines for testing
2) Start a world using a mod that does many `inv:remove_item` or `inv:add_item` calls
  * Example: unified_inventory's "copy recipe to crafting grid" function
3) Trigger the mod so that it does many inventory changes
4) See log output. Each `inv::serialize` means it's sent to the client
