### PR TITLE
Add block meta

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -338,6 +338,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_areastore.cpp    \
 		jni/src/script/lua_api/l_auth.cpp         \
 		jni/src/script/lua_api/l_base.cpp         \
+		jni/src/script/lua_api/l_blockmeta.cpp     \
 		jni/src/script/lua_api/l_camera.cpp       \
 		jni/src/script/lua_api/l_client.cpp       \
 		jni/src/script/lua_api/l_craft.cpp        \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4216,6 +4216,8 @@ Environment access
       {pos1, pos2}.
 * `minetest.get_meta(pos)`
     * Get a `NodeMetaRef` at that position
+* `minetest.get_block_meta(blockpos)`
+    * Get a `BlockMetaRef` at that block position
 * `minetest.get_node_timer(pos)`
     * Get `NodeTimerRef`
 
@@ -5350,6 +5352,21 @@ Can be obtained via `minetest.get_meta(pos)`.
 
 * All methods in MetaDataRef
 * `get_inventory()`: returns `InvRef`
+* `mark_as_private(name or {name1, name2, ...})`: Mark specific vars as private
+  This will prevent them from being sent to the client. Note that the "private"
+  status will only be remembered if an associated key-value pair exists,
+  meaning it's best to call this when initializing all other meta (e.g.
+  `on_construct`).
+
+`BlockMetaRef`
+-------------
+
+Node metadata: reference extra data and functionality stored in a mapblock.
+Can be obtained via `minetest.get_block_meta(blockpos)`.
+
+### Methods
+
+* All methods in MetaDataRef
 * `mark_as_private(name or {name1, name2, ...})`: Mark specific vars as private
   This will prevent them from being sent to the client. Note that the "private"
   status will only be remembered if an associated key-value pair exists,

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -368,7 +368,7 @@ if map format version >= 23:
   u8 version (=1) -- Note the type is u8, while for map format version <= 22 it's u16
   u16 count of metadata
   foreach count:
-    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X)
+    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X) (if map format version >= 29, block meta is saved in 0xffff)
     u32 num_vars
     foreach num_vars:
       u16 key_len

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -144,7 +144,7 @@ bool Map::isNodeUnderground(v3s16 p)
 {
 	v3s16 blockpos = getNodeBlockPos(p);
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
-	return block && block->getIsUnderground(); 
+	return block && block->getIsUnderground();
 }
 
 bool Map::isValidPosition(v3s16 p)
@@ -976,6 +976,51 @@ void Map::removeNodeMetadata(v3s16 p)
 		return;
 	}
 	block->m_node_metadata.remove(p_rel);
+}
+
+NodeMetadata *Map::getBlockMetadata(v3s16 blockpos)//hier
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		infostream << "Map::getBlockMetadata(): Need to emerge "
+				<< PP(blockpos) << std::endl;
+		block = emergeBlock(blockpos, false);
+	}
+	if (!block) {
+		warningstream << "Map::getBlockMetadata(): Block not found"
+				<< std::endl;
+		return nullptr;
+	}
+	NodeMetadata *meta = block->m_node_metadata.get(v3s16(-1, 0, 0));
+	return meta;
+}
+
+bool Map::setBlockMetadata(v3s16 blockpos, NodeMetadata *meta)
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		infostream << "Map::setBlockMetadata(): Need to emerge "
+				<< PP(blockpos) << std::endl;
+		block = emergeBlock(blockpos, false);
+	}
+	if (!block) {
+		warningstream << "Map::setBlockMetadata(): Block not found"
+				<< std::endl;
+		return false;
+	}
+	block->m_node_metadata.set(v3s16(-1, 0, 0), meta);
+	return true;
+}
+
+void Map::removeBlockMetadata(v3s16 blockpos)
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		warningstream << "Map::removeBlockMetadata(): Block not found"
+				<< std::endl;
+		return;
+	}
+	block->m_node_metadata.remove(v3s16(-1, 0, 0));
 }
 
 NodeTimer Map::getNodeTimer(v3s16 p)

--- a/src/map.h
+++ b/src/map.h
@@ -65,6 +65,8 @@ enum MapEditEventType{
 	MEET_SWAPNODE,
 	// Node metadata changed
 	MEET_BLOCK_NODE_METADATA_CHANGED,
+	// Block metadata changed
+	MEET_BLOCK_METADATA_CHANGED,
 	// Anything else (modified_blocks are set unsent)
 	MEET_OTHER
 };
@@ -100,9 +102,11 @@ struct MapEditEvent
 		case MEET_SWAPNODE:
 			return VoxelArea(p);
 		case MEET_BLOCK_NODE_METADATA_CHANGED:
+			return VoxelArea(p);
+		case MEET_BLOCK_METADATA_CHANGED:
 		{
-			v3s16 np1 = p*MAP_BLOCKSIZE;
-			v3s16 np2 = np1 + v3s16(1,1,1)*MAP_BLOCKSIZE - v3s16(1,1,1);
+			v3s16 np1 = p * MAP_BLOCKSIZE;
+			v3s16 np2 = np1 + v3s16(1) * MAP_BLOCKSIZE - v3s16(1);
 			return VoxelArea(np1, np2);
 		}
 		case MEET_OTHER:
@@ -267,6 +271,29 @@ public:
 	 */
 	bool setNodeMetadata(v3s16 p, NodeMetadata *meta);
 	void removeNodeMetadata(v3s16 p);
+
+	/*
+		Block metadata
+	*/
+
+	NodeMetadata *getBlockMetadata(v3s16 blockpos);
+
+	/**
+	 * Sets metadata for a mapblock.
+	 * This method sets the metadata for a given mapblock.
+	 * On success, it returns @c true and the object pointed to
+	 * by @p meta is then managed by the system and should
+	 * not be deleted by the caller.
+	 *
+	 * In case of failure, the method returns @c false and the
+	 * caller is still responsible for deleting the object!
+	 *
+	 * @param blockpos block coordinates
+	 * @param meta pointer to @c NodeMetadata object
+	 * @return @c true on success, @c false on failure
+	 */
+	bool setBlockMetadata(v3s16 blockpos, NodeMetadata *meta);
+	void removeBlockMetadata(v3s16 blockpos);
 
 	/*
 		Node Timers

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -58,6 +58,7 @@ static const char *modified_reason_strings[] = {
 	"deactivateFarObjects: Static data moved out",
 	"deactivateFarObjects: Static data changed considerably",
 	"finishBlockMake: expireDayNightDiff",
+	"BlockMetaRef::reportMetadataChange",
 	"unknown",
 };
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -64,7 +64,8 @@ class VoxelManipulator;
 #define MOD_REASON_STATIC_DATA_CHANGED       (1 << 17)
 #define MOD_REASON_EXPIRE_DAYNIGHTDIFF       (1 << 18)
 #define MOD_REASON_VMANIP                    (1 << 19)
-#define MOD_REASON_UNKNOWN                   (1 << 20)
+#define MOD_REASON_REPORT_BLOCK_META_CHANGE  (1 << 20)
+#define MOD_REASON_UNKNOWN                   (1 << 21)
 
 ////
 //// MapBlock itself

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -179,11 +179,18 @@ void NodeMetadataList::deSerialize(std::istream &is,
 			p.Z = readS16(is);
 		} else {
 			u16 p16 = readU16(is);
-			p.X = p16 & (MAP_BLOCKSIZE - 1);
-			p16 /= MAP_BLOCKSIZE;
-			p.Y = p16 & (MAP_BLOCKSIZE - 1);
-			p16 /= MAP_BLOCKSIZE;
-			p.Z = p16;
+			if (p16 != 0xffff) {
+				p.X = p16 & (MAP_BLOCKSIZE - 1);
+				p16 /= MAP_BLOCKSIZE;
+				p.Y = p16 & (MAP_BLOCKSIZE - 1);
+				p16 /= MAP_BLOCKSIZE;
+				p.Z = p16;
+			} else {
+				// mapblock meta
+				p.X = -1;
+				p.Y = 0;
+				p.Z = 0;
+			}
 		}
 		if (m_data.find(p) != m_data.end()) {
 			warningstream << "NodeMetadataList::deSerialize(): "

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -68,6 +68,7 @@ private:
 
 /*
 	List of metadata of all the nodes of a block
+	(also contains block meta at pos (-1, 0, 0))
 */
 
 typedef std::map<v3s16, NodeMetadata *> NodeMetadataMap;

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -120,6 +120,7 @@ protected:
 	friend class InvRef;
 	friend class ObjectRef;
 	friend class NodeMetaRef;
+	friend class BlockMetaRef;
 	friend class ModApiBase;
 	friend class ModApiEnvMod;
 	friend class LuaVoxelManip;

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_areastore.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_auth.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_base.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_blockmeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_craft.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_env.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_http.cpp

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -1,0 +1,214 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_blockmeta.h"
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+#include "serverenvironment.h"
+#include "map.h"
+#include "mapblock.h"
+#include "server.h"
+
+/*
+	BlockMetaRef
+*/
+BlockMetaRef *BlockMetaRef::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata(L, narg, className);
+	if (!ud) luaL_typerror(L, narg, className);
+	return *(BlockMetaRef **)ud;  // unbox pointer
+}
+
+Metadata *BlockMetaRef::getmeta(bool auto_create)
+{
+	if (m_is_local)
+		return m_meta;
+
+	NodeMetadata *meta = m_env->getMap().getBlockMetadata(m_bp);
+	if (!meta && auto_create) {
+		meta = new NodeMetadata(m_env->getGameDef()->idef());
+		if (!m_env->getMap().setBlockMetadata(m_bp, meta)) {
+			delete meta;
+			return NULL;
+		}
+	}
+	return meta;
+}
+
+void BlockMetaRef::clearMeta()
+{
+	m_env->getMap().removeBlockMetadata(m_bp);
+}
+
+void BlockMetaRef::reportMetadataChange(const std::string *name)
+{
+	// NOTE: This same code is in rollback_interface.cpp
+	// Inform other things that the metadata has changed
+	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(m_meta);
+
+	MapEditEvent event;
+	event.type = MEET_BLOCK_METADATA_CHANGED;
+	event.p = m_bp;
+	event.is_private_change = name && meta && meta->isPrivate(*name);
+	m_env->getMap().dispatchEvent(&event);
+}
+
+// Exported functions
+
+// garbage collector
+int BlockMetaRef::gc_object(lua_State *L)
+{
+	BlockMetaRef *o = *(BlockMetaRef **)(lua_touserdata(L, 1));
+	delete o;
+	return 0;
+}
+
+// mark_as_private(self, <string> or {<string>, <string>, ...})
+int BlockMetaRef::l_mark_as_private(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	BlockMetaRef *ref = checkobject(L, 1);
+	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
+	assert(meta);
+
+	if (lua_istable(L, 2)) {
+		lua_pushnil(L);
+		while (lua_next(L, 2) != 0) {
+			// key at index -2 and value at index -1
+			luaL_checktype(L, -1, LUA_TSTRING);
+			meta->markPrivate(readParam<std::string>(L, -1), true);
+			// removes value, keeps key for next iteration
+			lua_pop(L, 1);
+		}
+	} else if (lua_isstring(L, 2)) {
+		meta->markPrivate(readParam<std::string>(L, 2), true);
+	}
+	ref->reportMetadataChange();
+
+	return 0;
+}
+
+
+BlockMetaRef::BlockMetaRef(v3s16 bp, ServerEnvironment *env):
+	m_bp(bp),
+	m_env(env)
+{
+}
+
+BlockMetaRef::BlockMetaRef(Metadata *meta):
+	m_meta(meta),
+	m_is_local(true)
+{
+}
+
+// Creates a BlockMetaRef and leaves it on top of stack
+// Not callable from Lua; all references are created on the C side.
+void BlockMetaRef::create(lua_State *L, v3s16 bp, ServerEnvironment *env)
+{
+	BlockMetaRef *o = new BlockMetaRef(bp, env);
+	//infostream << "BlockMetaRef::create: o=" << o <<std::endl;
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+// Client-sided version of the above
+void BlockMetaRef::createClient(lua_State *L, Metadata *meta)
+{
+	BlockMetaRef *o = new BlockMetaRef(meta);
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+const char BlockMetaRef::className[] = "BlockMetaRef";
+void BlockMetaRef::RegisterCommon(lua_State *L)
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, className);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "metadata_class");
+	lua_pushlstring(L, className, strlen(className));
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__eq");
+	lua_pushcfunction(L, l_equals);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);  // drop metatable
+}
+
+void BlockMetaRef::Register(lua_State *L)
+{
+	RegisterCommon(L);
+	luaL_openlib(L, 0, methodsServer, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+}
+
+
+const luaL_Reg BlockMetaRef::methodsServer[] = {
+	luamethod(MetaDataRef, contains),
+	luamethod(MetaDataRef, get),
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, set_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, set_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, to_table),
+	luamethod(MetaDataRef, from_table),
+	luamethod(BlockMetaRef, mark_as_private),
+	luamethod(MetaDataRef, equals),
+	{0,0}
+};
+
+
+void BlockMetaRef::RegisterClient(lua_State *L)
+{
+	RegisterCommon(L);
+	luaL_openlib(L, 0, methodsClient, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+}
+
+
+const luaL_Reg BlockMetaRef::methodsClient[] = {
+	luamethod(MetaDataRef, contains),
+	luamethod(MetaDataRef, get),
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, to_table),
+	{0,0}
+};

--- a/src/script/lua_api/l_blockmeta.h
+++ b/src/script/lua_api/l_blockmeta.h
@@ -1,0 +1,88 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "lua_api/l_base.h"
+#include "lua_api/l_metadata.h"
+#include "irrlichttypes_bloated.h"
+#include "nodemetadata.h"
+
+class ServerEnvironment;
+class NodeMetadata;
+
+/*
+	BlockMetaRef
+*/
+
+class BlockMetaRef : public MetaDataRef {
+private:
+	v3s16 m_bp;
+	ServerEnvironment *m_env = nullptr;
+	Metadata *m_meta = nullptr;
+	bool m_is_local = false;
+
+	static const char className[];
+	static const luaL_Reg methodsServer[];
+	static const luaL_Reg methodsClient[];
+
+	static BlockMetaRef *checkobject(lua_State *L, int narg);
+
+	/**
+	 * Retrieve metadata for a block.
+	 * If @p auto_create is set and the specified block has no metadata information
+	 * associated with it yet, the method attempts to attach a new metadata object
+	 * to the blck and returns a pointer to the metadata when successful.
+	 *
+	 * However, it is NOT guaranteed that the method will return a pointer,
+	 * and @c nullptr may be returned in case of an error regardless of @p auto_create.
+	 *
+	 * @param auto_create when true, try to create metadata information for the block if it has none.
+	 * @return pointer to a @c NodeMetadata object or @c nullptr in case of error.
+	 */
+	virtual Metadata *getmeta(bool auto_create);
+	virtual void clearMeta();
+
+	virtual void reportMetadataChange(const std::string *name = nullptr);
+
+	// Exported functions
+
+	// garbage collector
+	static int gc_object(lua_State *L);
+
+	// mark_as_private(self, <string> or {<string>, <string>, ...})
+	static int l_mark_as_private(lua_State *L);
+
+public:
+	BlockMetaRef(v3s16 bp, ServerEnvironment *env);
+	BlockMetaRef(Metadata *meta);
+
+	~BlockMetaRef() = default;
+
+	// Creates a BlockMetaRef and leaves it on top of stack
+	// Not callable from Lua; all references are created on the C side.
+	static void create(lua_State *L, v3s16 bp, ServerEnvironment *env);
+
+	// Client-sided version of the above
+	static void createClient(lua_State *L, Metadata *meta);
+
+	static void RegisterCommon(lua_State *L);
+	static void Register(lua_State *L);
+	static void RegisterClient(lua_State *L);
+};

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "gettext.h"
 #include "l_internal.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_item.h"
 #include "lua_api/l_nodemeta.h"
 #include "gui/mainmenumanager.h"
@@ -229,6 +230,15 @@ int ModApiClient::l_get_meta(lua_State *L)
 	return 1;
 }
 
+// get_block_meta(blockpos)
+int ModApiClient::l_get_block_meta(lua_State *L)
+{
+	v3s16 bp = read_v3s16(L, 1);
+	NodeMetadata *meta = getClient(L)->getEnv().getMap().getBlockMetadata(bp);
+	BlockMetaRef::createClient(L, meta);
+	return 1;
+}
+
 int ModApiClient::l_sound_play(lua_State *L)
 {
 	ISoundManager *sound = getClient(L)->getSoundManager();
@@ -379,6 +389,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_wielded_item);
 	API_FCT(disconnect);
 	API_FCT(get_meta);
+	API_FCT(get_block_meta);
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 	API_FCT(get_server_info);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -74,6 +74,9 @@ private:
 	// get_meta(pos)
 	static int l_get_meta(lua_State *L);
 
+	// get_block_meta(blockpos)
+	static int l_get_block_meta(lua_State *L);
+
 	static int l_sound_play(lua_State *L);
 
 	static int l_sound_stop(lua_State *L);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_env.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_nodemeta.h"
@@ -570,6 +571,17 @@ int ModApiEnvMod::l_get_meta(lua_State *L)
 	// Do it
 	v3s16 p = read_v3s16(L, 1);
 	NodeMetaRef::create(L, p, env);
+	return 1;
+}
+
+// get_block_meta(blockpos)
+int ModApiEnvMod::l_get_block_meta(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// Do it
+	v3s16 bp = read_v3s16(L, 1);
+	BlockMetaRef::create(L, bp, env);
 	return 1;
 }
 
@@ -1300,6 +1312,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(add_entity);
 	API_FCT(find_nodes_with_meta);
 	API_FCT(get_meta);
+	API_FCT(get_block_meta);
 	API_FCT(get_node_timer);
 	API_FCT(get_player_by_name);
 	API_FCT(get_objects_inside_radius);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -90,6 +90,9 @@ private:
 	// get_meta(pos)
 	static int l_get_meta(lua_State *L);
 
+	// get_block_meta(blockpos)
+	static int l_get_block_meta(lua_State *L);
+
 	// get_node_timer(pos)
 	static int l_get_node_timer(lua_State *L);
 

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_util.h"
 #include "lua_api/l_item.h"
 #include "lua_api/l_nodemeta.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_localplayer.h"
 #include "lua_api/l_camera.h"
 
@@ -70,6 +71,7 @@ void ClientScripting::InitializeModApi(lua_State *L, int top)
 	StorageRef::Register(L);
 	LuaMinimap::Register(L);
 	NodeMetaRef::RegisterClient(L);
+	BlockMetaRef::RegisterClient(L);
 	LuaLocalPlayer::Register(L);
 	LuaCamera::Register(L);
 	ModChannelRef::Register(L);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_areastore.h"
 #include "lua_api/l_auth.h"
 #include "lua_api/l_base.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_craft.h"
 #include "lua_api/l_env.h"
 #include "lua_api/l_inventory.h"
@@ -99,6 +100,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaSecureRandom::Register(L);
 	LuaVoxelManip::Register(L);
 	NodeMetaRef::Register(L);
+	BlockMetaRef::Register(L);
 	NodeTimerRef::Register(L);
 	ObjectRef::Register(L);
 	PlayerMetaRef::Register(L);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -63,13 +63,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	26: Never written; read the same as 25
 	27: Added light spreading flags to blocks
 	28: Added "private" flag to NodeMetadata
+	29: Added block meta
 */
 // This represents an uninitialized or invalid format
 #define SER_FMT_VER_INVALID 255
 // Highest supported serialization version
-#define SER_FMT_VER_HIGHEST_READ 28
+#define SER_FMT_VER_HIGHEST_READ 29
 // Saved on disk version
-#define SER_FMT_VER_HIGHEST_WRITE 28
+#define SER_FMT_VER_HIGHEST_WRITE 29
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST_READ 0
 // Lowest serialization version for writing

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -894,6 +894,22 @@ void Server::AsyncRunStep(bool initial_step)
 				}
 				break;
 			}
+			case MEET_BLOCK_METADATA_CHANGED: { //hier
+				verbosestream << "Server: MEET_BLOCK_METADATA_CHANGED" << std::endl;
+				prof.add("MEET_BLOCK_METADATA_CHANGED", 1);
+				if (!event->is_private_change) {
+					// do not send at all, because this is so hard >_< todo
+					//~ // Don't send the change yet. Collect them to eliminate dupes.
+					//~ node_meta_updates.remove(event->p);
+					//~ node_meta_updates.push_back(event->p);
+				}
+
+				if (MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(event->p)) {
+					block->raiseModified(MOD_STATE_WRITE_NEEDED,
+						MOD_REASON_REPORT_BLOCK_META_CHANGE);
+				}
+				break;
+			}
 			case MEET_OTHER:
 				infostream << "Server: MEET_OTHER" << std::endl;
 				prof.add("MEET_OTHER", 1);


### PR DESCRIPTION
- Goal of the PR: Add meta per that is saved in a whole mapblock and is not bound to a node.
- How does the PR work?
At pos `0xffff` in the node meta of a mapblock, a sort pseudo node meta, the block meta, is saved.
Mods can access this meta with `minetest.get_block_meta(blockpos)`.
- Resolves #8605.
- Usecases and co. can be discussed in #8605.

## To do

This PR is a Work in Progress.
- [ ] Implement block meta sending.

## How to test

```lua
minetest.register_chatcommand("blar", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local pp = player:get_pos()
		local bp = vector.floor(vector.multiply(pp, 1 / 16))
		local meta = minetest.get_block_meta(bp)
		return true, "blar: "..meta:get_string("test")
	end,
})

minetest.register_chatcommand("blaw", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local pp = player:get_pos()
		local bp = vector.floor(vector.multiply(pp, 1 / 16))
		local meta = minetest.get_block_meta(bp)
		meta:set_string("test", param)
		return true, "blaw: "..param
	end,
})
```
