### PR TITLE
Force item entities out of solid nodes

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -178,12 +178,16 @@ core.register_entity(":__builtin:item", {
 		end
 
 		local node_this = core.get_node_or_nil(pos)
-		local def_this
+		local is_stuck = false
 		if node_this then
-			def_this = minetest.registered_nodes[node_this.name]
+			local sdef = minetest.registered_nodes[node_this.name]
+			is_stuck = (sdef.walkable == nil or sdef.walkable == true)
+				and (sdef.collision_box == nil or sdef.collision_box.type == "regular")
+				and (sdef.node_box == nil or sdef.node_box.type == "regular")
 		end
+
 		-- Push item out when stuck inside solid node
-		if def_this and def_this.walkable then
+		if is_stuck then
 			local shootdir
 			local cx = pos.x % 1
 			local cz = pos.z % 1

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -27,6 +27,7 @@ local function enable_physics(object, luaentity)
 		object:set_acceleration({x=0,y=-gravity,z=0})
 	end
 end
+
 local function disable_physics(object, luaentity)
 	if luaentity.physical_state == true then
 		luaentity.physical_state = false
@@ -253,12 +254,19 @@ core.register_entity(":__builtin:item", {
 		-- It is responsible for making sure the entity is entirely outside the solid node
 		-- (with its full collision box), not just its center.
 		if self.force_out_timer > 0 then
-			local cbox = self.object:get_properties().collisionbox
+			local c = self.object:get_properties().collisionbox
+			local s = self.force_out_start
+			local f = self.force_out
 			local ok = false
-			if self.force_out.x > 0 and (pos.x > (self.force_out_start.x + 0.5 + (cbox[4] - cbox[1])/2)) then ok = true
-			elseif self.force_out.x < 0 and (pos.x < (self.force_out_start.x + 0.5 - (cbox[4] - cbox[1])/2)) then ok = true
-			elseif self.force_out.z > 0 and (pos.z > (self.force_out_start.z + 0.5 + (cbox[6] - cbox[3])/2)) then ok = true
-			elseif self.force_out.z < 0 and (pos.z < (self.force_out_start.z + 0.5 - (cbox[6] - cbox[3])/2)) then ok = true end
+			if f.x > 0 and (pos.x > (s.x + 0.5 + (c[4] - c[1])/2)) then
+				ok = true
+			elseif f.x < 0 and (pos.x < (s.x + 0.5 - (c[4] - c[1])/2)) then
+				ok = true
+			elseif f.z > 0 and (pos.z > (s.z + 0.5 + (c[6] - c[3])/2)) then
+				ok = true
+			elseif f.z < 0 and (pos.z < (s.z + 0.5 - (c[6] - c[3])/2)) then
+				ok = true
+			end
 			-- Item was successfully forced out. No more pushing
 			if ok then
 				self.force_out_timer = -1

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -190,8 +190,8 @@ core.register_entity(":__builtin:item", {
 		-- Push item out when stuck inside solid node
 		if is_stuck then
 			local shootdir
-			local cx = pos.x % 1
-			local cz = pos.z % 1
+			local cx = (pos.x % 1) - 0.5
+			local cz = (pos.z % 1) - 0.5
 			local order = {}
 
 			-- First prepare the order in which the 4 sides are to be checked.
@@ -199,7 +199,7 @@ core.register_entity(":__builtin:item", {
 			-- 2nd: other direction
 			-- 3rd and 4th: other axis
 			local cxcz = function(o, cw, one, zero)
-				if cw > 0 then
+				if cw < 0 then
 					table.insert(o, { [one]=1, y=0, [zero]=0 })
 					table.insert(o, { [one]=-1, y=0, [zero]=0 })
 				else
@@ -208,7 +208,7 @@ core.register_entity(":__builtin:item", {
 				end
 				return o
 			end
-			if math.abs(cx) > math.abs(cz) then
+			if math.abs(cx) < math.abs(cz) then
 				order = cxcz(order, cx, "x", "z")
 				order = cxcz(order, cz, "z", "x")
 			else


### PR DESCRIPTION
This PR makes item entities getting pushed out of solid nodes. Closes #5297.

The algorithm is mostly as described in the issue, but I explain it again in brief:

* A “solid” node is defined as a node that is walkable and has a regular collision box
* A “free” node is any non-solid node that is also not `ignore`
* If item is inside solid node, disable traditional physics, and instead apply “force-out” physics
* The “force-out” physics: If item is inside a solid node, do:
    * Disable the classic item physics. `physical` is set to false (no collision), and the speed is completely controlled by the “force-out” physics now
    * Look at the 4 direct horizontal neighboring nodes
    * If any neighbor is free, push item to the closest free node
    * If all 4 neighbors are unfree, look at node above
    * If node above is not `ignore`, push item upwards (even if the node above is also solid)
    * Otherwise, do absolutely nothing
    * When item's collision box is completely outside of any solid node, the algorithm terminates and the standard item physics are enabled again

## Analysis
To illustrate what this will do:

Items that are lost deep in the underground tend to get pushed all the way to the surface, otherwise they just go sideways.

There's one special case in which even a stuck item refuses to move: When it's at the top of the world, and is surrounded by solid nodes. It won't go up because there's an `ignore`. This is deliberate to prevent destroying the item.

## Notes
The force-out does not apply for other solid nodes, such as complex node boxes like slabs. This is deliberate, to keep things reasonably simple.
In the original issue I specified “1×1×1 or larger” but I discarded the “or larger” for complexity reasons. It would require looking deep into the collisionbox definition, not sure if this might be a performance problem.

The algorithm has been copied from MineClone 2's mod `mcl_item_entity`. The code is mostly the same, the changes are mostly just variable name changes, but the algorithm is exactly the same.

This feature in MineClone 2 is in the game for a very long time, and I have not heard of any bug reports for item entities for ages now. So I'm pretty sure the algorithm is correct and the code is well tested. One possible source of bugs are bugs that appeared by my converting the code from MCL2 to builtin.

## How to test

* Start any game which does not override item entities (e.g. Minetest Game)
* Drop some items on the ground
* Place blocks inside the item

Test cases to test:
* Try different item positons (at the left, right front or back side of node boundaries)
* Try locking the item at the top of the world (below `ignore`)
* Try forcing the item out sideways
* Try forcing the item out upwards
* Drop item in deep 1×1 hole, then drop a huge sand pile into the hole
* Hint: Fly+noclip help a lot to find stuck items! :) Or just use glass