### PR TITLE
Also print help commands to chat for server terminal

### DIFF
--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -77,6 +77,13 @@ local function do_help_cmd(name, param)
 		end
 		table.sort(cmds)
 		return true, gettext("Available commands:").."\n"..table.concat(cmds, "\n")
+    elseif INIT == "game" and param == "privs" then
+        local privs = {}
+        for priv, def in pairs(core.registered_privileges) do
+            privs[#privs + 1] = priv .. ": " .. def.description
+        end
+        table.sort(privs)
+        return true, "Available privileges:\n"..table.concat(privs, "\n")
 	else
 		local cmd = param
 		local def = core.registered_chatcommands[cmd]

--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -77,13 +77,13 @@ local function do_help_cmd(name, param)
 		end
 		table.sort(cmds)
 		return true, gettext("Available commands:").."\n"..table.concat(cmds, "\n")
-    elseif INIT == "game" and param == "privs" then
-        local privs = {}
-        for priv, def in pairs(core.registered_privileges) do
-            privs[#privs + 1] = priv .. ": " .. def.description
-        end
-        table.sort(privs)
-        return true, "Available privileges:\n"..table.concat(privs, "\n")
+	elseif INIT == "game" and param == "privs" then
+		local privs = {}
+		for priv, def in pairs(core.registered_privileges) do
+			privs[#privs + 1] = priv .. ": " .. def.description
+		end
+		table.sort(privs)
+		return true, "Available privileges:\n"..table.concat(privs, "\n")
 	else
 		local cmd = param
 		local def = core.registered_chatcommands[cmd]

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -81,7 +81,7 @@ local function build_chatcommands_formspec(name, sel, copy)
 end
 
 
--- 	PRIVILEGES FORMSPEC
+--	PRIVILEGES FORMSPEC
 
 local function build_privs_formspec(name)
 	local privs = {}
@@ -130,21 +130,21 @@ local old_help_func = help_command.func
 help_command.func = function(name, param)
 	local admin = core.settings:get("name")
 
---  If the admin ran help, put the output in the chat buffer as well to
---  work with the server terminal
+--	If the admin ran help, put the output in the chat buffer as well to
+--	work with the server terminal
 	if param == "privs" then
 		core.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))
-        if name ~= admin then
-            return
-        end
+		if name ~= admin then
+			return
+		end
 	end
 	if param == "" or param == "all" then
 		core.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name))
-        if name ~= admin then
-            return
-        end
+		if name ~= admin then
+			return
+		end
 	end
 
 	return old_help_func(name, param)

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -131,12 +131,10 @@ help_command.func = function(name, param)
 	if param == "privs" then
 		core.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))
-		return
 	end
 	if param == "" or param == "all" then
 		core.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name))
-		return
 	end
 
 	return old_help_func(name, param)

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -81,7 +81,7 @@ local function build_chatcommands_formspec(name, sel, copy)
 end
 
 
---	PRIVILEGES FORMSPEC
+-- PRIVILEGES FORMSPEC
 
 local function build_privs_formspec(name)
 	local privs = {}
@@ -130,8 +130,8 @@ local old_help_func = help_command.func
 help_command.func = function(name, param)
 	local admin = core.settings:get("name")
 
---	If the admin ran help, put the output in the chat buffer as well to
---	work with the server terminal
+	-- If the admin ran help, put the output in the chat buffer as well to
+	-- work with the server terminal
 	if param == "privs" then
 		core.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -128,13 +128,23 @@ local help_command = core.registered_chatcommands["help"]
 local old_help_func = help_command.func
 
 help_command.func = function(name, param)
+	local admin = core.settings:get("name")
+
+--  If the admin ran help, put the output in the chat buffer as well to
+--  work with the server terminal
 	if param == "privs" then
 		core.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))
+        if name ~= admin then
+            return
+        end
 	end
 	if param == "" or param == "all" then
 		core.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name))
+        if name ~= admin then
+            return
+        end
 	end
 
 	return old_help_func(name, param)


### PR DESCRIPTION
To start off I really appreciate SmallJoker's commit SmallJoker@69bf964241666428e8d1663164a443654f51d53a . It is a wonderful addition as long as you are connected to the server graphically though a client. However, it prevents the use of the commands /help, /help add, and /help priv from the server terminal. 

This pull request simply calls the previous chat output function after any formspecs are created to place the output in the chat window as well as in the formspec. Please advise if there is a better way to do this, but it seemed from my investigation that the server terminal is simply a chat terminal.

## To do
This PR is ready for review.

## How to test
Enter one of the help commands in the server terminal. This should both place the output in chat to be visible to the terminal, and open up the formspec if the admin is also graphically logged in.
