### PR TITLE
Block meta

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -338,6 +338,7 @@ LOCAL_SRC_FILES += \
 		jni/src/script/lua_api/l_areastore.cpp    \
 		jni/src/script/lua_api/l_auth.cpp         \
 		jni/src/script/lua_api/l_base.cpp         \
+		jni/src/script/lua_api/l_blockmeta.cpp     \
 		jni/src/script/lua_api/l_camera.cpp       \
 		jni/src/script/lua_api/l_client.cpp       \
 		jni/src/script/lua_api/l_craft.cpp        \

--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -109,6 +109,7 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_SRC_FILES := \
 		jni/src/ban.cpp                           \
+		jni/src/blockmetadata.cpp                 \
 		jni/src/chat.cpp                          \
 		jni/src/client/activeobjectmgr.cpp        \
 		jni/src/client/camera.cpp                 \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5361,14 +5361,15 @@ Can be obtained via `minetest.get_meta(pos)`.
 `BlockMetaRef`
 -------------
 
-Node metadata: reference extra data and functionality stored in a mapblock.
+Block metadata: reference extra data and functionality stored in a mapblock.
 Can be obtained via `minetest.get_block_meta(blockpos)`.
+Block metadata is private by default.
 
 ### Methods
 
 * All methods in MetaDataRef
-* `mark_as_private(name or {name1, name2, ...})`: Mark specific vars as private
-  This will prevent them from being sent to the client. Note that the "private"
+* `mark_as_public(name or {name1, name2, ...})`: Mark specific vars as public
+  This will prevent them from not being sent to the client. Note that the "public"
   status will only be remembered if an associated key-value pair exists,
   meaning it's best to call this when initializing all other meta (e.g.
   `on_construct`).

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4216,6 +4216,8 @@ Environment access
       {pos1, pos2}.
 * `minetest.get_meta(pos)`
     * Get a `NodeMetaRef` at that position
+* `minetest.get_block_meta(blockpos)`
+    * Get a `BlockMetaRef` at that block position
 * `minetest.get_node_timer(pos)`
     * Get `NodeTimerRef`
 
@@ -5350,6 +5352,21 @@ Can be obtained via `minetest.get_meta(pos)`.
 
 * All methods in MetaDataRef
 * `get_inventory()`: returns `InvRef`
+* `mark_as_private(name or {name1, name2, ...})`: Mark specific vars as private
+  This will prevent them from being sent to the client. Note that the "private"
+  status will only be remembered if an associated key-value pair exists,
+  meaning it's best to call this when initializing all other meta (e.g.
+  `on_construct`).
+
+`BlockMetaRef`
+-------------
+
+Node metadata: reference extra data and functionality stored in a mapblock.
+Can be obtained via `minetest.get_block_meta(blockpos)`.
+
+### Methods
+
+* All methods in MetaDataRef
 * `mark_as_private(name or {name1, name2, ...})`: Mark specific vars as private
   This will prevent them from being sent to the client. Note that the "private"
   status will only be remembered if an associated key-value pair exists,

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -368,7 +368,7 @@ if map format version >= 23:
   u8 version (=1) -- Note the type is u8, while for map format version <= 22 it's u16
   u16 count of metadata
   foreach count:
-    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X)
+    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X) (if map format version >= 29, block meta is saved in 0xffff)
     u32 num_vars
     foreach num_vars:
       u16 key_len

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -354,7 +354,7 @@ if content_width == 2:
       u8[4096]: param2 fields
 - The location of a node in each of those arrays is (z*16*16 + y*16 + x).
 
-zlib-compressed node metadata list
+zlib-compressed node metadata list and block meta
 - content:
 if map format version <= 22:
   u16 version (=1)
@@ -365,17 +365,30 @@ if map format version <= 22:
     u16 content_size
     u8[content_size] content of metadata. Format depends on type_id, see below.
 if map format version >= 23:
-  u8 version (=1) -- Note the type is u8, while for map format version <= 22 it's u16
+  u8 version (=1 for map format version < 28, else =2) -- Note the type is u8, while for map format version <= 22 it's u16
   u16 count of metadata
   foreach count:
-    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X) (if map format version >= 29, block meta is saved in 0xffff)
+    u16 position (p.Z*MAP_BLOCKSIZE*MAP_BLOCKSIZE + p.Y*MAP_BLOCKSIZE + p.X)
     u32 num_vars
     foreach num_vars:
       u16 key_len
       u8[key_len] key
       u32 val_len
       u8[val_len] value
+      u8 is_private -- only for version >= 2. 0 = not private, 1 = private
     serialized inventory
+if map format version >= 29: block meta
+  u8 version
+  if version == 0:
+    (nothing else)
+  else:
+    u32 num_vars
+    foreach num_vars:
+      u16 key_len
+      u8[key_len] key
+      u32 val_len
+      u8[val_len] value
+      u8 is_private -- only for version >= 2. 0 = not private, 1 = private
 
 - Node timers
 if map format version == 23:

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -381,14 +381,14 @@ if map format version >= 29: block meta
   u8 version
   if version == 0:
     (nothing else)
-  else:
+  if version == 1:
     u32 num_vars
     foreach num_vars:
       u16 key_len
       u8[key_len] key
       u32 val_len
       u8[val_len] value
-      u8 is_private -- only for version >= 2. 0 = not private, 1 = private
+      u8 is_private -- 0 = not private, 1 = private
 
 - Node timers
 if map format version == 23:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,6 +363,7 @@ set(common_SRCS
 	${server_SRCS}
 	${content_SRCS}
 	ban.cpp
+	blockmetadata.cpp
 	chat.cpp
 	clientiface.cpp
 	collision.cpp

--- a/src/blockmetadata.cpp
+++ b/src/blockmetadata.cpp
@@ -1,0 +1,99 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "blockmetadata.h"
+#include "exceptions.h"
+#include "gamedef.h"
+#include "log.h"
+#include "util/serialize.h"
+#include "util/basic_macros.h"
+#include "constants.h" // MAP_BLOCKSIZE
+#include <sstream>
+
+/*
+	BlockMetadata
+*/
+void BlockMetadata::serialize(std::ostream &os, u8 blockver, bool disk) const
+{
+	u8 version = blockver >= 29 ? 1 : 0; // always 1
+	writeU8(os, version);
+
+	u32 num_vars = disk ? m_stringvars.size() : countNonPrivate();
+	writeU32(os, num_vars);
+	for (const auto &sv : m_stringvars) {
+		bool priv = isPrivate(sv.first);
+		if (!disk && priv)
+			continue;
+
+		os << serializeString(sv.first);
+		os << serializeLongString(sv.second);
+		writeU8(os, priv ? 1 : 0);
+	}
+}
+
+void BlockMetadata::deSerialize(std::istream &is)
+{
+	clear();
+
+	u8 version = readU8(is);
+	if (version == 0) {
+		return;
+	} else if (version > 1) {
+		std::string err_str = std::string(FUNCTION_NAME)
+			+ ": version " + itos(version) + " not supported";
+		infostream << err_str << std::endl;
+		throw SerializationError(err_str);
+	}
+
+	u32 num_vars = readU32(is);
+	for (u32 i = 0; i < num_vars; i++) {
+		std::string name = deSerializeString(is);
+		std::string var = deSerializeLongString(is);
+		m_stringvars[name] = var;
+		if (readU8(is) == 1)
+			markPrivate(name, true);
+	}
+}
+
+void BlockMetadata::clear()
+{
+	Metadata::clear();
+	m_privatevars.clear();
+}
+
+
+void BlockMetadata::markPrivate(const std::string &name, bool set)
+{
+	if (set)
+		m_privatevars.insert(name);
+	else
+		m_privatevars.erase(name);
+}
+
+u32 BlockMetadata::countNonPrivate() const
+{
+	// m_privatevars can contain names not actually present
+	// DON'T: return m_stringvars.size() - m_privatevars.size();
+	u32 n = 0;
+	for (const auto &sv : m_stringvars) {
+		if (!isPrivate(sv.first))
+			n++;
+	}
+	return n;
+}

--- a/src/blockmetadata.cpp
+++ b/src/blockmetadata.cpp
@@ -51,11 +51,6 @@ bool BlockMetadata::deSerialize(std::istream &is)
 	u8 version = readU8(is);
 	if (version == 0) {
 		return false;
-	} else if (version > 1) {
-		std::string err_str = std::string(FUNCTION_NAME)
-			+ ": version " + itos(version) + " not supported";
-		infostream << err_str << std::endl;
-		throw SerializationError(err_str);
 	}
 
 	u32 num_vars = readU32(is);

--- a/src/blockmetadata.cpp
+++ b/src/blockmetadata.cpp
@@ -60,8 +60,8 @@ bool BlockMetadata::deSerialize(std::istream &is)
 		std::string name = deSerializeString(is);
 		std::string var = deSerializeLongString(is);
 		m_stringvars[name] = var;
-		if (readU8(is) == 1)
-			markPrivate(name, true);
+		if (readU8(is) != 1)
+			markPrivate(name, false);
 	}
 	return true;
 }
@@ -69,22 +69,22 @@ bool BlockMetadata::deSerialize(std::istream &is)
 void BlockMetadata::clear()
 {
 	Metadata::clear();
-	m_privatevars.clear();
+	m_publicvars.clear();
 }
 
 
 void BlockMetadata::markPrivate(const std::string &name, bool set)
 {
-	if (set)
-		m_privatevars.insert(name);
+	if (!set)
+		m_publicvars.insert(name);
 	else
-		m_privatevars.erase(name);
+		m_publicvars.erase(name);
 }
 
 u32 BlockMetadata::countNonPrivate() const
 {
-	// m_privatevars can contain names not actually present
-	// DON'T: return m_stringvars.size() - m_privatevars.size();
+	// m_publicvars can contain names not actually present
+	// DON'T: return m_publicvars.size();
 	u32 n = 0;
 	for (const auto &sv : m_stringvars) {
 		if (!isPrivate(sv.first))

--- a/src/blockmetadata.cpp
+++ b/src/blockmetadata.cpp
@@ -47,13 +47,13 @@ void BlockMetadata::serialize(std::ostream &os, u8 blockver, bool disk) const
 	}
 }
 
-void BlockMetadata::deSerialize(std::istream &is)
+bool BlockMetadata::deSerialize(std::istream &is)
 {
 	clear();
 
 	u8 version = readU8(is);
 	if (version == 0) {
-		return;
+		return false;
 	} else if (version > 1) {
 		std::string err_str = std::string(FUNCTION_NAME)
 			+ ": version " + itos(version) + " not supported";
@@ -62,6 +62,8 @@ void BlockMetadata::deSerialize(std::istream &is)
 	}
 
 	u32 num_vars = readU32(is);
+	if (num_vars == 0)
+		return false;
 	for (u32 i = 0; i < num_vars; i++) {
 		std::string name = deSerializeString(is);
 		std::string var = deSerializeLongString(is);
@@ -69,6 +71,7 @@ void BlockMetadata::deSerialize(std::istream &is)
 		if (readU8(is) == 1)
 			markPrivate(name, true);
 	}
+	return true;
 }
 
 void BlockMetadata::clear()

--- a/src/blockmetadata.cpp
+++ b/src/blockmetadata.cpp
@@ -19,11 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "blockmetadata.h"
 #include "exceptions.h"
-#include "gamedef.h"
 #include "log.h"
 #include "util/serialize.h"
-#include "util/basic_macros.h"
-#include "constants.h" // MAP_BLOCKSIZE
 #include <sstream>
 
 /*

--- a/src/blockmetadata.h
+++ b/src/blockmetadata.h
@@ -1,0 +1,50 @@
+/*
+Minetest
+Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <unordered_set>
+#include "metadata.h"
+
+/*
+	BlockMetadata stores arbitary amounts of data for mapblocks.
+*/
+
+class BlockMetadata : public Metadata
+{
+public:
+	BlockMetadata() = default;
+	~BlockMetadata() = default;
+
+	void serialize(std::ostream &os, u8 blockver, bool disk=true) const;
+	void deSerialize(std::istream &is);
+
+	void clear();
+
+	inline bool isPrivate(const std::string &name) const
+	{
+		return m_privatevars.count(name) != 0;
+	}
+	void markPrivate(const std::string &name, bool set);
+
+private:
+	u32 countNonPrivate() const;
+
+	std::unordered_set<std::string> m_privatevars;
+};

--- a/src/blockmetadata.h
+++ b/src/blockmetadata.h
@@ -33,7 +33,12 @@ public:
 	~BlockMetadata() = default;
 
 	void serialize(std::ostream &os, u8 blockver, bool disk=true) const;
-	void deSerialize(std::istream &is);
+	/*!
+	 * Deserialize block meta from a stream.
+	 *
+	 * @return @c true if block meta was found, else @c false.
+	 */
+	bool deSerialize(std::istream &is);
 
 	void clear();
 

--- a/src/blockmetadata.h
+++ b/src/blockmetadata.h
@@ -44,12 +44,12 @@ public:
 
 	inline bool isPrivate(const std::string &name) const
 	{
-		return m_privatevars.count(name) != 0;
+		return m_publicvars.count(name) == 0;
 	}
 	void markPrivate(const std::string &name, bool set);
 
 private:
 	u32 countNonPrivate() const;
 
-	std::unordered_set<std::string> m_privatevars;
+	std::unordered_set<std::string> m_publicvars;
 };

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -144,7 +144,7 @@ bool Map::isNodeUnderground(v3s16 p)
 {
 	v3s16 blockpos = getNodeBlockPos(p);
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
-	return block && block->getIsUnderground(); 
+	return block && block->getIsUnderground();
 }
 
 bool Map::isValidPosition(v3s16 p)
@@ -976,6 +976,51 @@ void Map::removeNodeMetadata(v3s16 p)
 		return;
 	}
 	block->m_node_metadata.remove(p_rel);
+}
+
+NodeMetadata *Map::getBlockMetadata(v3s16 blockpos)//hier
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		infostream << "Map::getBlockMetadata(): Need to emerge "
+				<< PP(blockpos) << std::endl;
+		block = emergeBlock(blockpos, false);
+	}
+	if (!block) {
+		warningstream << "Map::getBlockMetadata(): Block not found"
+				<< std::endl;
+		return nullptr;
+	}
+	NodeMetadata *meta = block->m_node_metadata.get(v3s16(-1, 0, 0));
+	return meta;
+}
+
+bool Map::setBlockMetadata(v3s16 blockpos, NodeMetadata *meta)
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		infostream << "Map::setBlockMetadata(): Need to emerge "
+				<< PP(blockpos) << std::endl;
+		block = emergeBlock(blockpos, false);
+	}
+	if (!block) {
+		warningstream << "Map::setBlockMetadata(): Block not found"
+				<< std::endl;
+		return false;
+	}
+	block->m_node_metadata.set(v3s16(-1, 0, 0), meta);
+	return true;
+}
+
+void Map::removeBlockMetadata(v3s16 blockpos)
+{
+	MapBlock *block = getBlockNoCreateNoEx(blockpos);
+	if (!block) {
+		warningstream << "Map::removeBlockMetadata(): Block not found"
+				<< std::endl;
+		return;
+	}
+	block->m_node_metadata.remove(v3s16(-1, 0, 0));
 }
 
 NodeTimer Map::getNodeTimer(v3s16 p)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include "serialization.h"
 #include "nodemetadata.h"
+#include "blockmetadata.h"
 #include "settings.h"
 #include "log.h"
 #include "profiler.h"
@@ -978,7 +979,7 @@ void Map::removeNodeMetadata(v3s16 p)
 	block->m_node_metadata.remove(p_rel);
 }
 
-NodeMetadata *Map::getBlockMetadata(v3s16 blockpos)//hier
+BlockMetadata *Map::getBlockMetadata(v3s16 blockpos)
 {
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if (!block) {
@@ -991,11 +992,11 @@ NodeMetadata *Map::getBlockMetadata(v3s16 blockpos)//hier
 				<< std::endl;
 		return nullptr;
 	}
-	NodeMetadata *meta = block->m_node_metadata.get(v3s16(-1, 0, 0));
+	BlockMetadata *meta = block->m_block_metadata;
 	return meta;
 }
 
-bool Map::setBlockMetadata(v3s16 blockpos, NodeMetadata *meta)
+bool Map::setBlockMetadata(v3s16 blockpos, BlockMetadata *meta)
 {
 	MapBlock *block = getBlockNoCreateNoEx(blockpos);
 	if (!block) {
@@ -1008,7 +1009,9 @@ bool Map::setBlockMetadata(v3s16 blockpos, NodeMetadata *meta)
 				<< std::endl;
 		return false;
 	}
-	block->m_node_metadata.set(v3s16(-1, 0, 0), meta);
+	if (block->m_block_metadata)
+		delete block->m_block_metadata;
+	block->m_block_metadata = meta;
 	return true;
 }
 
@@ -1020,7 +1023,10 @@ void Map::removeBlockMetadata(v3s16 blockpos)
 				<< std::endl;
 		return;
 	}
-	block->m_node_metadata.remove(v3s16(-1, 0, 0));
+	if (block->m_block_metadata) {
+		delete block->m_block_metadata;
+		block->m_block_metadata = nullptr;
+	}
 }
 
 NodeTimer Map::getNodeTimer(v3s16 p)

--- a/src/map.h
+++ b/src/map.h
@@ -107,7 +107,7 @@ struct MapEditEvent
 		case MEET_BLOCK_METADATA_CHANGED:
 		{
 			v3s16 np1 = p * MAP_BLOCKSIZE;
-			v3s16 np2 = np1 + v3s16(1) * MAP_BLOCKSIZE - v3s16(1);
+			v3s16 np2 = np1 + v3s16(MAP_BLOCKSIZE - 1);
 			return VoxelArea(np1, np2);
 		}
 		case MEET_OTHER:

--- a/src/map.h
+++ b/src/map.h
@@ -42,6 +42,7 @@ class MapSector;
 class ServerMapSector;
 class MapBlock;
 class NodeMetadata;
+class BlockMetadata;
 class IGameDef;
 class IRollbackManager;
 class EmergeManager;
@@ -276,7 +277,7 @@ public:
 		Block metadata
 	*/
 
-	NodeMetadata *getBlockMetadata(v3s16 blockpos);
+	BlockMetadata *getBlockMetadata(v3s16 blockpos);
 
 	/**
 	 * Sets metadata for a mapblock.
@@ -292,7 +293,7 @@ public:
 	 * @param meta pointer to @c NodeMetadata object
 	 * @return @c true on success, @c false on failure
 	 */
-	bool setBlockMetadata(v3s16 blockpos, NodeMetadata *meta);
+	bool setBlockMetadata(v3s16 blockpos, BlockMetadata *meta);
 	void removeBlockMetadata(v3s16 blockpos);
 
 	/*

--- a/src/map.h
+++ b/src/map.h
@@ -107,7 +107,7 @@ struct MapEditEvent
 		case MEET_BLOCK_METADATA_CHANGED:
 		{
 			v3s16 np1 = p * MAP_BLOCKSIZE;
-			v3s16 np2 = np1 + v3s16(MAP_BLOCKSIZE - 1);
+			v3s16 np2 = np1 + (MAP_BLOCKSIZE - 1);
 			return VoxelArea(np1, np2);
 		}
 		case MEET_OTHER:

--- a/src/map.h
+++ b/src/map.h
@@ -65,6 +65,8 @@ enum MapEditEventType{
 	MEET_SWAPNODE,
 	// Node metadata changed
 	MEET_BLOCK_NODE_METADATA_CHANGED,
+	// Block metadata changed
+	MEET_BLOCK_METADATA_CHANGED,
 	// Anything else (modified_blocks are set unsent)
 	MEET_OTHER
 };
@@ -100,9 +102,11 @@ struct MapEditEvent
 		case MEET_SWAPNODE:
 			return VoxelArea(p);
 		case MEET_BLOCK_NODE_METADATA_CHANGED:
+			return VoxelArea(p);
+		case MEET_BLOCK_METADATA_CHANGED:
 		{
-			v3s16 np1 = p*MAP_BLOCKSIZE;
-			v3s16 np2 = np1 + v3s16(1,1,1)*MAP_BLOCKSIZE - v3s16(1,1,1);
+			v3s16 np1 = p * MAP_BLOCKSIZE;
+			v3s16 np2 = np1 + v3s16(1) * MAP_BLOCKSIZE - v3s16(1);
 			return VoxelArea(np1, np2);
 		}
 		case MEET_OTHER:
@@ -267,6 +271,29 @@ public:
 	 */
 	bool setNodeMetadata(v3s16 p, NodeMetadata *meta);
 	void removeNodeMetadata(v3s16 p);
+
+	/*
+		Block metadata
+	*/
+
+	NodeMetadata *getBlockMetadata(v3s16 blockpos);
+
+	/**
+	 * Sets metadata for a mapblock.
+	 * This method sets the metadata for a given mapblock.
+	 * On success, it returns @c true and the object pointed to
+	 * by @p meta is then managed by the system and should
+	 * not be deleted by the caller.
+	 *
+	 * In case of failure, the method returns @c false and the
+	 * caller is still responsible for deleting the object!
+	 *
+	 * @param blockpos block coordinates
+	 * @param meta pointer to @c NodeMetadata object
+	 * @return @c true on success, @c false on failure
+	 */
+	bool setBlockMetadata(v3s16 blockpos, NodeMetadata *meta);
+	void removeBlockMetadata(v3s16 blockpos);
 
 	/*
 		Node Timers

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -506,9 +506,16 @@ void MapBlock::deSerialize(std::istream &is, u8 version, bool disk)
 		if (version >= 23) {
 			m_node_metadata.deSerialize(iss, m_gamedef->idef());
 			if (version >= 29) {
-				if (!m_block_metadata)
-					m_block_metadata = new BlockMetadata;
-				m_block_metadata->deSerialize(iss);
+				if (!m_block_metadata) {
+					m_block_metadata = new BlockMetadata();
+					if (!m_block_metadata->deSerialize(iss)) {
+						// there is no metadata
+						delete m_block_metadata;
+						m_block_metadata = nullptr;
+					}
+				} else {
+					m_block_metadata->deSerialize(iss);
+				}
 			}
 		} else {
 			content_nodemeta_deserialize_legacy(iss,

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -58,6 +58,7 @@ static const char *modified_reason_strings[] = {
 	"deactivateFarObjects: Static data moved out",
 	"deactivateFarObjects: Static data changed considerably",
 	"finishBlockMake: expireDayNightDiff",
+	"BlockMetaRef::reportMetadataChange",
 	"unknown",
 };
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -64,7 +64,8 @@ class VoxelManipulator;
 #define MOD_REASON_STATIC_DATA_CHANGED       (1 << 17)
 #define MOD_REASON_EXPIRE_DAYNIGHTDIFF       (1 << 18)
 #define MOD_REASON_VMANIP                    (1 << 19)
-#define MOD_REASON_UNKNOWN                   (1 << 20)
+#define MOD_REASON_REPORT_BLOCK_META_CHANGE  (1 << 20)
+#define MOD_REASON_UNKNOWN                   (1 << 21)
 
 ////
 //// MapBlock itself

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -37,6 +37,7 @@ class NodeMetadataList;
 class IGameDef;
 class MapBlockMesh;
 class VoxelManipulator;
+class BlockMetadata;
 
 #define BLOCK_TIMESTAMP_UNDEFINED 0xffffffff
 
@@ -524,6 +525,7 @@ public:
 #endif
 
 	NodeMetadataList m_node_metadata;
+	BlockMetadata *m_block_metadata = nullptr;
 	NodeTimerList m_node_timers;
 	StaticObjectList m_static_objects;
 

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -179,18 +179,11 @@ void NodeMetadataList::deSerialize(std::istream &is,
 			p.Z = readS16(is);
 		} else {
 			u16 p16 = readU16(is);
-			if (p16 != 0xffff) {
-				p.X = p16 & (MAP_BLOCKSIZE - 1);
-				p16 /= MAP_BLOCKSIZE;
-				p.Y = p16 & (MAP_BLOCKSIZE - 1);
-				p16 /= MAP_BLOCKSIZE;
-				p.Z = p16;
-			} else {
-				// mapblock meta
-				p.X = -1;
-				p.Y = 0;
-				p.Z = 0;
-			}
+			p.X = p16 & (MAP_BLOCKSIZE - 1);
+			p16 /= MAP_BLOCKSIZE;
+			p.Y = p16 & (MAP_BLOCKSIZE - 1);
+			p16 /= MAP_BLOCKSIZE;
+			p.Z = p16;
 		}
 		if (m_data.find(p) != m_data.end()) {
 			warningstream << "NodeMetadataList::deSerialize(): "

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -179,11 +179,18 @@ void NodeMetadataList::deSerialize(std::istream &is,
 			p.Z = readS16(is);
 		} else {
 			u16 p16 = readU16(is);
-			p.X = p16 & (MAP_BLOCKSIZE - 1);
-			p16 /= MAP_BLOCKSIZE;
-			p.Y = p16 & (MAP_BLOCKSIZE - 1);
-			p16 /= MAP_BLOCKSIZE;
-			p.Z = p16;
+			if (p16 != 0xffff) {
+				p.X = p16 & (MAP_BLOCKSIZE - 1);
+				p16 /= MAP_BLOCKSIZE;
+				p.Y = p16 & (MAP_BLOCKSIZE - 1);
+				p16 /= MAP_BLOCKSIZE;
+				p.Z = p16;
+			} else {
+				// mapblock meta
+				p.X = -1;
+				p.Y = 0;
+				p.Z = 0;
+			}
 		}
 		if (m_data.find(p) != m_data.end()) {
 			warningstream << "NodeMetadataList::deSerialize(): "

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -68,6 +68,7 @@ private:
 
 /*
 	List of metadata of all the nodes of a block
+	(also contains block meta at pos (-1, 0, 0))
 */
 
 typedef std::map<v3s16, NodeMetadata *> NodeMetadataMap;

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -29,6 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	There are two interaction methods: inventory menu and text input.
 	Only one can be used for a single metadata, thus only inventory OR
 	text input should exist in a metadata.
+
+	^ That text is probably very outdated.
 */
 
 class Inventory;
@@ -68,7 +70,6 @@ private:
 
 /*
 	List of metadata of all the nodes of a block
-	(also contains block meta at pos (-1, 0, 0))
 */
 
 typedef std::map<v3s16, NodeMetadata *> NodeMetadataMap;

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -120,6 +120,7 @@ protected:
 	friend class InvRef;
 	friend class ObjectRef;
 	friend class NodeMetaRef;
+	friend class BlockMetaRef;
 	friend class ModApiBase;
 	friend class ModApiEnvMod;
 	friend class LuaVoxelManip;

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -2,6 +2,7 @@ set(common_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_areastore.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_auth.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_base.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_blockmeta.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_craft.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_env.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_http.cpp

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -31,7 +31,8 @@ BlockMetaRef *BlockMetaRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);
 	void *ud = luaL_checkudata(L, narg, className);
-	if (!ud) luaL_typerror(L, narg, className);
+	if (!ud)
+		luaL_typerror(L, narg, className);
 	return *(BlockMetaRef **)ud;  // unbox pointer
 }
 
@@ -59,7 +60,7 @@ void BlockMetaRef::clearMeta()
 void BlockMetaRef::reportMetadataChange(const std::string *name)
 {
 	// Inform other things that the metadata has changed
-	BlockMetadata *meta = dynamic_cast<BlockMetadata*>(m_meta);
+	BlockMetadata *meta = dynamic_cast<BlockMetadata *>(m_meta);
 
 	MapEditEvent event;
 	event.type = MEET_BLOCK_METADATA_CHANGED;

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -79,8 +79,8 @@ int BlockMetaRef::gc_object(lua_State *L)
 	return 0;
 }
 
-// mark_as_private(self, <string> or {<string>, <string>, ...})
-int BlockMetaRef::l_mark_as_private(lua_State *L)
+// mark_as_public(self, <string> or {<string>, <string>, ...})
+int BlockMetaRef::l_mark_as_public(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
 
@@ -93,12 +93,12 @@ int BlockMetaRef::l_mark_as_private(lua_State *L)
 		while (lua_next(L, 2) != 0) {
 			// key at index -2 and value at index -1
 			luaL_checktype(L, -1, LUA_TSTRING);
-			meta->markPrivate(readParam<std::string>(L, -1), true);
+			meta->markPrivate(readParam<std::string>(L, -1), false);
 			// removes value, keeps key for next iteration
 			lua_pop(L, 1);
 		}
 	} else if (lua_isstring(L, 2)) {
-		meta->markPrivate(readParam<std::string>(L, 2), true);
+		meta->markPrivate(readParam<std::string>(L, 2), false);
 	}
 	ref->reportMetadataChange();
 
@@ -188,7 +188,7 @@ const luaL_Reg BlockMetaRef::methodsServer[] = {
 	luamethod(MetaDataRef, set_float),
 	luamethod(MetaDataRef, to_table),
 	luamethod(MetaDataRef, from_table),
-	luamethod(BlockMetaRef, mark_as_private),
+	luamethod(BlockMetaRef, mark_as_public),
 	luamethod(MetaDataRef, equals),
 	{0,0}
 };

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -47,7 +47,7 @@ Metadata *BlockMetaRef::getmeta(bool auto_create)
 		meta = new BlockMetadata();
 		if (!m_env->getMap().setBlockMetadata(m_bp, meta)) {
 			delete meta;
-			return NULL;
+			return nullptr;
 		}
 	}
 	return meta;

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -19,10 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_blockmeta.h"
 #include "lua_api/l_internal.h"
-#include "common/c_content.h"
 #include "serverenvironment.h"
 #include "map.h"
-#include "mapblock.h"
 #include "server.h"
 #include "blockmetadata.h"
 

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "mapblock.h"
 #include "server.h"
+#include "blockmetadata.h"
 
 /*
 	BlockMetaRef
@@ -41,9 +42,9 @@ Metadata *BlockMetaRef::getmeta(bool auto_create)
 	if (m_is_local)
 		return m_meta;
 
-	NodeMetadata *meta = m_env->getMap().getBlockMetadata(m_bp);
+	BlockMetadata *meta = m_env->getMap().getBlockMetadata(m_bp);
 	if (!meta && auto_create) {
-		meta = new NodeMetadata(m_env->getGameDef()->idef());
+		meta = new BlockMetadata();
 		if (!m_env->getMap().setBlockMetadata(m_bp, meta)) {
 			delete meta;
 			return NULL;
@@ -59,9 +60,8 @@ void BlockMetaRef::clearMeta()
 
 void BlockMetaRef::reportMetadataChange(const std::string *name)
 {
-	// NOTE: This same code is in rollback_interface.cpp
 	// Inform other things that the metadata has changed
-	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(m_meta);
+	BlockMetadata *meta = dynamic_cast<BlockMetadata*>(m_meta);
 
 	MapEditEvent event;
 	event.type = MEET_BLOCK_METADATA_CHANGED;
@@ -86,7 +86,7 @@ int BlockMetaRef::l_mark_as_private(lua_State *L)
 	MAP_LOCK_REQUIRED;
 
 	BlockMetaRef *ref = checkobject(L, 1);
-	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
+	BlockMetadata *meta = dynamic_cast<BlockMetadata*>(ref->getmeta(true));
 	assert(meta);
 
 	if (lua_istable(L, 2)) {

--- a/src/script/lua_api/l_blockmeta.cpp
+++ b/src/script/lua_api/l_blockmeta.cpp
@@ -1,0 +1,214 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "lua_api/l_blockmeta.h"
+#include "lua_api/l_internal.h"
+#include "common/c_content.h"
+#include "serverenvironment.h"
+#include "map.h"
+#include "mapblock.h"
+#include "server.h"
+
+/*
+	BlockMetaRef
+*/
+BlockMetaRef *BlockMetaRef::checkobject(lua_State *L, int narg)
+{
+	luaL_checktype(L, narg, LUA_TUSERDATA);
+	void *ud = luaL_checkudata(L, narg, className);
+	if (!ud) luaL_typerror(L, narg, className);
+	return *(BlockMetaRef **)ud;  // unbox pointer
+}
+
+Metadata *BlockMetaRef::getmeta(bool auto_create)
+{
+	if (m_is_local)
+		return m_meta;
+
+	NodeMetadata *meta = m_env->getMap().getBlockMetadata(m_bp);
+	if (!meta && auto_create) {
+		meta = new NodeMetadata(m_env->getGameDef()->idef());
+		if (!m_env->getMap().setBlockMetadata(m_bp, meta)) {
+			delete meta;
+			return NULL;
+		}
+	}
+	return meta;
+}
+
+void BlockMetaRef::clearMeta()
+{
+	m_env->getMap().removeBlockMetadata(m_bp);
+}
+
+void BlockMetaRef::reportMetadataChange(const std::string *name)
+{
+	// NOTE: This same code is in rollback_interface.cpp
+	// Inform other things that the metadata has changed
+	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(m_meta);
+
+	MapEditEvent event;
+	event.type = MEET_BLOCK_METADATA_CHANGED;
+	event.p = m_bp;
+	event.is_private_change = name && meta && meta->isPrivate(*name);
+	m_env->getMap().dispatchEvent(&event);
+}
+
+// Exported functions
+
+// garbage collector
+int BlockMetaRef::gc_object(lua_State *L)
+{
+	BlockMetaRef *o = *(BlockMetaRef **)(lua_touserdata(L, 1));
+	delete o;
+	return 0;
+}
+
+// mark_as_private(self, <string> or {<string>, <string>, ...})
+int BlockMetaRef::l_mark_as_private(lua_State *L)
+{
+	MAP_LOCK_REQUIRED;
+
+	BlockMetaRef *ref = checkobject(L, 1);
+	NodeMetadata *meta = dynamic_cast<NodeMetadata*>(ref->getmeta(true));
+	assert(meta);
+
+	if (lua_istable(L, 2)) {
+		lua_pushnil(L);
+		while (lua_next(L, 2) != 0) {
+			// key at index -2 and value at index -1
+			luaL_checktype(L, -1, LUA_TSTRING);
+			meta->markPrivate(readParam<std::string>(L, -1), true);
+			// removes value, keeps key for next iteration
+			lua_pop(L, 1);
+		}
+	} else if (lua_isstring(L, 2)) {
+		meta->markPrivate(readParam<std::string>(L, 2), true);
+	}
+	ref->reportMetadataChange();
+
+	return 0;
+}
+
+
+BlockMetaRef::BlockMetaRef(v3s16 bp, ServerEnvironment *env):
+	m_bp(bp),
+	m_env(env)
+{
+}
+
+BlockMetaRef::BlockMetaRef(Metadata *meta):
+	m_meta(meta),
+	m_is_local(true)
+{
+}
+
+// Creates a BlockMetaRef and leaves it on top of stack
+// Not callable from Lua; all references are created on the C side.
+void BlockMetaRef::create(lua_State *L, v3s16 bp, ServerEnvironment *env)
+{
+	BlockMetaRef *o = new BlockMetaRef(bp, env);
+	//infostream << "BlockMetaRef::create: o=" << o <<std::endl;
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+// Client-sided version of the above
+void BlockMetaRef::createClient(lua_State *L, Metadata *meta)
+{
+	BlockMetaRef *o = new BlockMetaRef(meta);
+	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	luaL_getmetatable(L, className);
+	lua_setmetatable(L, -2);
+}
+
+const char BlockMetaRef::className[] = "BlockMetaRef";
+void BlockMetaRef::RegisterCommon(lua_State *L)
+{
+	lua_newtable(L);
+	int methodtable = lua_gettop(L);
+	luaL_newmetatable(L, className);
+	int metatable = lua_gettop(L);
+
+	lua_pushliteral(L, "__metatable");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);  // hide metatable from Lua getmetatable()
+
+	lua_pushliteral(L, "metadata_class");
+	lua_pushlstring(L, className, strlen(className));
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__index");
+	lua_pushvalue(L, methodtable);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__gc");
+	lua_pushcfunction(L, gc_object);
+	lua_settable(L, metatable);
+
+	lua_pushliteral(L, "__eq");
+	lua_pushcfunction(L, l_equals);
+	lua_settable(L, metatable);
+
+	lua_pop(L, 1);  // drop metatable
+}
+
+void BlockMetaRef::Register(lua_State *L)
+{
+	RegisterCommon(L);
+	luaL_openlib(L, 0, methodsServer, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+}
+
+
+const luaL_Reg BlockMetaRef::methodsServer[] = {
+	luamethod(MetaDataRef, contains),
+	luamethod(MetaDataRef, get),
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, set_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, set_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, set_float),
+	luamethod(MetaDataRef, to_table),
+	luamethod(MetaDataRef, from_table),
+	luamethod(BlockMetaRef, mark_as_private),
+	luamethod(MetaDataRef, equals),
+	{0,0}
+};
+
+
+void BlockMetaRef::RegisterClient(lua_State *L)
+{
+	RegisterCommon(L);
+	luaL_openlib(L, 0, methodsClient, 0);  // fill methodtable
+	lua_pop(L, 1);  // drop methodtable
+}
+
+
+const luaL_Reg BlockMetaRef::methodsClient[] = {
+	luamethod(MetaDataRef, contains),
+	luamethod(MetaDataRef, get),
+	luamethod(MetaDataRef, get_string),
+	luamethod(MetaDataRef, get_int),
+	luamethod(MetaDataRef, get_float),
+	luamethod(MetaDataRef, to_table),
+	{0,0}
+};

--- a/src/script/lua_api/l_blockmeta.h
+++ b/src/script/lua_api/l_blockmeta.h
@@ -21,7 +21,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "lua_api/l_base.h"
 #include "lua_api/l_metadata.h"
-#include "irrlichttypes_bloated.h"
 
 class ServerEnvironment;
 

--- a/src/script/lua_api/l_blockmeta.h
+++ b/src/script/lua_api/l_blockmeta.h
@@ -63,8 +63,8 @@ private:
 	// garbage collector
 	static int gc_object(lua_State *L);
 
-	// mark_as_private(self, <string> or {<string>, <string>, ...})
-	static int l_mark_as_private(lua_State *L);
+	// mark_as_public(self, <string> or {<string>, <string>, ...})
+	static int l_mark_as_public(lua_State *L);
 
 public:
 	BlockMetaRef(v3s16 bp, ServerEnvironment *env);

--- a/src/script/lua_api/l_blockmeta.h
+++ b/src/script/lua_api/l_blockmeta.h
@@ -1,0 +1,88 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "lua_api/l_base.h"
+#include "lua_api/l_metadata.h"
+#include "irrlichttypes_bloated.h"
+#include "nodemetadata.h"
+
+class ServerEnvironment;
+class NodeMetadata;
+
+/*
+	BlockMetaRef
+*/
+
+class BlockMetaRef : public MetaDataRef {
+private:
+	v3s16 m_bp;
+	ServerEnvironment *m_env = nullptr;
+	Metadata *m_meta = nullptr;
+	bool m_is_local = false;
+
+	static const char className[];
+	static const luaL_Reg methodsServer[];
+	static const luaL_Reg methodsClient[];
+
+	static BlockMetaRef *checkobject(lua_State *L, int narg);
+
+	/**
+	 * Retrieve metadata for a block.
+	 * If @p auto_create is set and the specified block has no metadata information
+	 * associated with it yet, the method attempts to attach a new metadata object
+	 * to the blck and returns a pointer to the metadata when successful.
+	 *
+	 * However, it is NOT guaranteed that the method will return a pointer,
+	 * and @c nullptr may be returned in case of an error regardless of @p auto_create.
+	 *
+	 * @param auto_create when true, try to create metadata information for the block if it has none.
+	 * @return pointer to a @c NodeMetadata object or @c nullptr in case of error.
+	 */
+	virtual Metadata *getmeta(bool auto_create);
+	virtual void clearMeta();
+
+	virtual void reportMetadataChange(const std::string *name = nullptr);
+
+	// Exported functions
+
+	// garbage collector
+	static int gc_object(lua_State *L);
+
+	// mark_as_private(self, <string> or {<string>, <string>, ...})
+	static int l_mark_as_private(lua_State *L);
+
+public:
+	BlockMetaRef(v3s16 bp, ServerEnvironment *env);
+	BlockMetaRef(Metadata *meta);
+
+	~BlockMetaRef() = default;
+
+	// Creates a BlockMetaRef and leaves it on top of stack
+	// Not callable from Lua; all references are created on the C side.
+	static void create(lua_State *L, v3s16 bp, ServerEnvironment *env);
+
+	// Client-sided version of the above
+	static void createClient(lua_State *L, Metadata *meta);
+
+	static void RegisterCommon(lua_State *L);
+	static void Register(lua_State *L);
+	static void RegisterClient(lua_State *L);
+};

--- a/src/script/lua_api/l_blockmeta.h
+++ b/src/script/lua_api/l_blockmeta.h
@@ -22,10 +22,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_base.h"
 #include "lua_api/l_metadata.h"
 #include "irrlichttypes_bloated.h"
-#include "nodemetadata.h"
 
 class ServerEnvironment;
-class NodeMetadata;
 
 /*
 	BlockMetaRef

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map.h"
 #include "util/string.h"
 #include "nodedef.h"
+#include "blockmetadata.h"
 
 int ModApiClient::l_get_current_modname(lua_State *L)
 {
@@ -234,7 +235,7 @@ int ModApiClient::l_get_meta(lua_State *L)
 int ModApiClient::l_get_block_meta(lua_State *L)
 {
 	v3s16 bp = read_v3s16(L, 1);
-	NodeMetadata *meta = getClient(L)->getEnv().getMap().getBlockMetadata(bp);
+	BlockMetadata *meta = getClient(L)->getEnv().getMap().getBlockMetadata(bp);
 	BlockMetaRef::createClient(L, meta);
 	return 1;
 }

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -29,6 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "cpp_api/s_base.h"
 #include "gettext.h"
 #include "l_internal.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_item.h"
 #include "lua_api/l_nodemeta.h"
 #include "gui/mainmenumanager.h"
@@ -229,6 +230,15 @@ int ModApiClient::l_get_meta(lua_State *L)
 	return 1;
 }
 
+// get_block_meta(blockpos)
+int ModApiClient::l_get_block_meta(lua_State *L)
+{
+	v3s16 bp = read_v3s16(L, 1);
+	NodeMetadata *meta = getClient(L)->getEnv().getMap().getBlockMetadata(bp);
+	BlockMetaRef::createClient(L, meta);
+	return 1;
+}
+
 int ModApiClient::l_sound_play(lua_State *L)
 {
 	ISoundManager *sound = getClient(L)->getSoundManager();
@@ -379,6 +389,7 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_wielded_item);
 	API_FCT(disconnect);
 	API_FCT(get_meta);
+	API_FCT(get_block_meta);
 	API_FCT(sound_play);
 	API_FCT(sound_stop);
 	API_FCT(get_server_info);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -74,6 +74,9 @@ private:
 	// get_meta(pos)
 	static int l_get_meta(lua_State *L);
 
+	// get_block_meta(blockpos)
+	static int l_get_block_meta(lua_State *L);
+
 	static int l_sound_play(lua_State *L);
 
 	static int l_sound_stop(lua_State *L);

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_env.h"
 #include "lua_api/l_internal.h"
 #include "lua_api/l_nodemeta.h"
@@ -570,6 +571,17 @@ int ModApiEnvMod::l_get_meta(lua_State *L)
 	// Do it
 	v3s16 p = read_v3s16(L, 1);
 	NodeMetaRef::create(L, p, env);
+	return 1;
+}
+
+// get_block_meta(blockpos)
+int ModApiEnvMod::l_get_block_meta(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// Do it
+	v3s16 bp = read_v3s16(L, 1);
+	BlockMetaRef::create(L, bp, env);
 	return 1;
 }
 
@@ -1300,6 +1312,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(add_entity);
 	API_FCT(find_nodes_with_meta);
 	API_FCT(get_meta);
+	API_FCT(get_block_meta);
 	API_FCT(get_node_timer);
 	API_FCT(get_player_by_name);
 	API_FCT(get_objects_inside_radius);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -90,6 +90,9 @@ private:
 	// get_meta(pos)
 	static int l_get_meta(lua_State *L);
 
+	// get_block_meta(blockpos)
+	static int l_get_block_meta(lua_State *L);
+
 	// get_node_timer(pos)
 	static int l_get_node_timer(lua_State *L);
 

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -32,6 +32,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_util.h"
 #include "lua_api/l_item.h"
 #include "lua_api/l_nodemeta.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_localplayer.h"
 #include "lua_api/l_camera.h"
 
@@ -70,6 +71,7 @@ void ClientScripting::InitializeModApi(lua_State *L, int top)
 	StorageRef::Register(L);
 	LuaMinimap::Register(L);
 	NodeMetaRef::RegisterClient(L);
+	BlockMetaRef::RegisterClient(L);
 	LuaLocalPlayer::Register(L);
 	LuaCamera::Register(L);
 	ModChannelRef::Register(L);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_areastore.h"
 #include "lua_api/l_auth.h"
 #include "lua_api/l_base.h"
+#include "lua_api/l_blockmeta.h"
 #include "lua_api/l_craft.h"
 #include "lua_api/l_env.h"
 #include "lua_api/l_inventory.h"
@@ -99,6 +100,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	LuaSecureRandom::Register(L);
 	LuaVoxelManip::Register(L);
 	NodeMetaRef::Register(L);
+	BlockMetaRef::Register(L);
 	NodeTimerRef::Register(L);
 	ObjectRef::Register(L);
 	PlayerMetaRef::Register(L);

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -63,13 +63,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	26: Never written; read the same as 25
 	27: Added light spreading flags to blocks
 	28: Added "private" flag to NodeMetadata
+	29: Added block meta
 */
 // This represents an uninitialized or invalid format
 #define SER_FMT_VER_INVALID 255
 // Highest supported serialization version
-#define SER_FMT_VER_HIGHEST_READ 28
+#define SER_FMT_VER_HIGHEST_READ 29
 // Saved on disk version
-#define SER_FMT_VER_HIGHEST_WRITE 28
+#define SER_FMT_VER_HIGHEST_WRITE 29
 // Lowest supported serialization version
 #define SER_FMT_VER_LOWEST_READ 0
 // Lowest serialization version for writing

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -894,6 +894,22 @@ void Server::AsyncRunStep(bool initial_step)
 				}
 				break;
 			}
+			case MEET_BLOCK_METADATA_CHANGED: { //hier
+				verbosestream << "Server: MEET_BLOCK_METADATA_CHANGED" << std::endl;
+				prof.add("MEET_BLOCK_METADATA_CHANGED", 1);
+				if (!event->is_private_change) {
+					// do not send at all, because this is so hard >_< todo
+					//~ // Don't send the change yet. Collect them to eliminate dupes.
+					//~ node_meta_updates.remove(event->p);
+					//~ node_meta_updates.push_back(event->p);
+				}
+
+				if (MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(event->p)) {
+					block->raiseModified(MOD_STATE_WRITE_NEEDED,
+						MOD_REASON_REPORT_BLOCK_META_CHANGE);
+				}
+				break;
+			}
 			case MEET_OTHER:
 				infostream << "Server: MEET_OTHER" << std::endl;
 				prof.add("MEET_OTHER", 1);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -855,7 +855,6 @@ void Server::AsyncRunStep(bool initial_step)
 		Profiler prof;
 
 		std::list<v3s16> node_meta_updates;
-		std::list<v3s16> block_meta_updates;
 
 		while (!m_unsent_map_edit_queue.empty()) {
 			MapEditEvent* event = m_unsent_map_edit_queue.front();
@@ -895,13 +894,11 @@ void Server::AsyncRunStep(bool initial_step)
 				}
 				break;
 			}
-			case MEET_BLOCK_METADATA_CHANGED: { //hier
+			case MEET_BLOCK_METADATA_CHANGED: {
 				verbosestream << "Server: MEET_BLOCK_METADATA_CHANGED" << std::endl;
 				prof.add("MEET_BLOCK_METADATA_CHANGED", 1);
 				if (!event->is_private_change) {
-					// Don't send the change yet. Collect them to eliminate dupes.
-					block_meta_updates.remove(event->p);
-					block_meta_updates.push_back(event->p);
+					m_clients.markBlockposAsNotSent(event->p);
 				}
 
 				if (MapBlock *block = m_env->getMap().getBlockNoCreateNoEx(event->p)) {
@@ -956,8 +953,6 @@ void Server::AsyncRunStep(bool initial_step)
 		// Send all metadata updates
 		if (node_meta_updates.size())
 			sendMetadataChanged(node_meta_updates);
-		if (block_meta_updates.size())
-			sendBlockMetadataChanged(block_meta_updates);
 	}
 
 	/*
@@ -2250,57 +2245,6 @@ void Server::sendMetadataChanged(const std::list<v3s16> &meta_updates, float far
 		m_clients.send(i, 0, &pkt, true);
 
 		meta_updates_list.clear();
-	}
-
-	m_clients.unlock();
-}
-
-void Server::sendBlockMetadataChanged(const std::list<v3s16> &meta_updates, float far_d_nodes)
-{
-	float maxdsq = far_d_nodes * BS;
-	maxdsq *= maxdsq;
-	//~ NodeMetadataList meta_updates_list(false); // todo: replace this with something else
-	std::vector<session_t> clients = m_clients.getClientIDs();
-
-	m_clients.lock();
-
-	for (session_t i : clients) {
-		RemoteClient *client = m_clients.lockedGetClientNoEx(i);
-		if (!client)
-			continue;
-
-		ServerActiveObject *player = m_env->getActiveObject(i);
-		v3f player_pos = player ? player->getBasePosition() : v3f();
-
-		for (const v3s16 &blockpos : meta_updates) {
-			BlockMetadata *meta = m_env->getMap().getBlockMetadata(blockpos);
-
-			if (!meta)
-				continue;
-
-			if (!client->isBlockSent(blockpos) || (player &&
-					player_pos.getDistanceFromSQ(intToFloat(blockpos, 1.0f)) > maxdsq)) {
-				client->SetBlockNotSent(blockpos);
-				continue;
-			}
-
-			//~ // Add the change to send list
-			//~ meta_updates_list.set(pos, meta);
-		}
-		//~ if (meta_updates_list.size() == 0)
-			//~ continue;
-
-		//~ // Send the meta changes; todo
-		//~ std::ostringstream os(std::ios::binary);
-		//~ meta_updates_list.serialize(os, client->net_proto_version, false, true);
-		//~ std::ostringstream oss(std::ios::binary);
-		//~ compressZlib(os.str(), oss);
-
-		//~ NetworkPacket pkt(TOCLIENT_NODEMETA_CHANGED, 0);
-		//~ pkt.putLongString(oss.str());
-		//~ m_clients.send(i, 0, &pkt, true);
-
-		//~ meta_updates_list.clear();
 	}
 
 	m_clients.unlock();

--- a/src/server.h
+++ b/src/server.h
@@ -430,6 +430,8 @@ private:
 
 	void sendMetadataChanged(const std::list<v3s16> &meta_updates,
 			float far_d_nodes = 100);
+	void sendBlockMetadataChanged(const std::list<v3s16> &meta_updates,
+			float far_d_nodes = 100);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver, u16 net_proto_version);

--- a/src/server.h
+++ b/src/server.h
@@ -430,8 +430,6 @@ private:
 
 	void sendMetadataChanged(const std::list<v3s16> &meta_updates,
 			float far_d_nodes = 100);
-	void sendBlockMetadataChanged(const std::list<v3s16> &meta_updates,
-			float far_d_nodes = 100);
 
 	// Environment and Connection must be locked when called
 	void SendBlockNoLock(session_t peer_id, MapBlock *block, u8 ver, u16 net_proto_version);


### PR DESCRIPTION
- Goal of the PR: Add meta per that is saved in a whole mapblock and is not bound to a node.
- How does the PR work?
For each mapblock there's extra meta saved.
Mods can access this meta with `minetest.get_block_meta(blockpos)`.
When meta is changed (non-private), the mapblock is resent.
- Resolves #8605. This is the follow-up PR of #8859 which was much more hacky.
- Usecases and co. can be discussed in #8605.

## To do

This PR is a Ready for Review.

## How to test
<details>

#### Server-side:
```lua
minetest.register_chatcommand("blar", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local pp = player:get_pos()
		local bp = vector.floor(vector.multiply(pp, 1 / 16))
		local meta = minetest.get_block_meta(bp)
		return true, "blar: "..meta:get_string("test")
	end,
})

minetest.register_chatcommand("blaw", {
	params = "",
	description = "",
	privs = {},
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		local pp = player:get_pos()
		local bp = vector.floor(vector.multiply(pp, 1 / 16))
		local meta = minetest.get_block_meta(bp)
		meta:set_string("test", param)
		meta:mark_as_public("test")
		return true, "blaw: "..param
	end,
})
```

#### Client-side:
```lua
minetest.register_chatcommand("blar", {
	params = "",
	description = "",
	func = function(param)
		local pp = minetest.localplayer:get_pos()
		local bp = vector.floor(vector.multiply(pp, 1 / 16))
		local meta = minetest.get_block_meta(bp)
		return true, "blar: "..meta:get_string("test")
	end,
})
```
</details>