### PR TITLE
Send multiple occlusion rays from the camera viewpane.

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -125,6 +125,8 @@ void ClientMap::updateDrawList()
 	v3f camera_position = m_camera_position;
 	v3f camera_direction = m_camera_direction;
 	f32 camera_fov = m_camera_fov;
+	v3f y = m_camera_up * BS;
+	v3f x = m_camera_up.crossProduct(camera_direction) * BS;
 
 	// Use a higher fov to accomodate faster camera movements.
 	// Blocks are cropped better when they are drawn.
@@ -206,7 +208,7 @@ void ClientMap::updateDrawList()
 				Occlusion culling
 			*/
 			if ((!m_control.range_all && d > m_control.wanted_range * BS) ||
-					(occlusion_culling_enabled && isBlockOccluded(block, cam_pos_nodes))) {
+					(occlusion_culling_enabled && isBlockOccluded(block, camera_position, x, y))) {
 				blocks_occlusion_culled++;
 				continue;
 			}

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -65,12 +65,13 @@ public:
 		ISceneNode::drop();
 	}
 
-	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset)
+	void updateCamera(const v3f &pos, const v3f &dir, f32 fov, const v3s16 &offset, v3f &cam_up)
 	{
 		m_camera_position = pos;
 		m_camera_direction = dir;
 		m_camera_fov = fov;
 		m_camera_offset = offset;
+		m_camera_up = cam_up;
 	}
 
 	/*
@@ -123,6 +124,7 @@ private:
 
 	v3f m_camera_position = v3f(0,0,0);
 	v3f m_camera_direction = v3f(0,0,1);
+	v3f m_camera_up = v3f(0,1,0);
 	f32 m_camera_fov = M_PI;
 	v3s16 m_camera_offset;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2864,12 +2864,13 @@ void Game::updateCamera(u32 busy_time, f32 dtime)
 	v3f camera_direction = camera->getDirection();
 	f32 camera_fov = camera->getFovMax();
 	v3s16 camera_offset = camera->getOffset();
+	v3f camera_up_vector = camera->getCameraNode()->getUpVector();
 
 	m_camera_offset_changed = (camera_offset != old_camera_offset);
 
 	if (!m_flags.disable_camera_update) {
 		client->getEnv().getClientMap().updateCamera(camera_position,
-				camera_direction, camera_fov, camera_offset);
+                               camera_direction, camera_fov, camera_offset, camera_up_vector);
 
 		if (m_camera_offset_changed) {
 			client->updateCameraOffset(camera_offset);

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -136,6 +136,12 @@ void RemoteClient::GetNextBlocks (
 	v3f camera_dir = v3f(0,0,1);
 	camera_dir.rotateYZBy(sao->getLookPitch());
 	camera_dir.rotateXZBy(sao->getRotation().Y);
+	v3f x = v3f(BS,0,0);
+	x.rotateYZBy(sao->getLookPitch());
+	x.rotateXZBy(sao->getRotation().Y);
+	v3f y = v3f(0,BS,0);
+	y.rotateYZBy(sao->getLookPitch());
+	y.rotateXZBy(sao->getRotation().Y);
 
 	/*infostream<<"camera_dir=("<<camera_dir.X<<","<<camera_dir.Y<<","
 			<<camera_dir.Z<<")"<<std::endl;*/
@@ -232,8 +238,6 @@ void RemoteClient::GetNextBlocks (
 	s32 nearest_emergefull_d = -1;
 	s32 nearest_sent_d = -1;
 	//bool queue_is_full = false;
-
-	const v3s16 cam_pos_nodes = floatToInt(camera_pos, BS);
 
 	s16 d;
 	for (d = d_start; d <= d_max; d++) {
@@ -337,7 +341,7 @@ void RemoteClient::GetNextBlocks (
 				}
 
 				if (m_occ_cull && !block_is_invalid &&
-						env->getMap().isBlockOccluded(block, cam_pos_nodes)) {
+					env->getMap().isBlockOccluded(block, camera_pos, x, y)) {
 					continue;
 				}
 			}

--- a/src/map.h
+++ b/src/map.h
@@ -288,7 +288,7 @@ public:
 
 	void transforming_liquid_add(v3s16 p);
 
-	bool isBlockOccluded(MapBlock *block, v3s16 cam_pos_nodes);
+	bool isBlockOccluded(MapBlock *block, v3f cam_pos, v3f x, v3f y);
 protected:
 	friend class LuaVoxelManip;
 


### PR DESCRIPTION
Here's another attempt. Use the camera's view up vector (client) and the known camera rotation (server) to create spanning vectors on the camera pane (labeled x and y in the code). With that we can send multiple rays from the camera pane.
This takes care of the fact the view pane is not a point. Things might be hidden from the camera point and still be visible on the screen.

This includes most of the code from #8852 

(as before this cannot be perfect, there could be blocks that are visible from certain portions of the view plane only)

Please have a look and test. The extra effort (5x the rays) might not be worth it.