### PR TITLE
Inventory: Handle removeItem leftovers

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -680,7 +680,11 @@ ItemStack InventoryList::removeItem(const ItemStack &item)
 	for (auto i = m_items.rbegin(); i != m_items.rend(); ++i) {
 		if (i->name == item.name) {
 			u32 still_to_remove = item.count - removed.count;
-			removed.addItem(i->takeItem(still_to_remove), m_itemdef);
+			ItemStack leftover = removed.addItem(i->takeItem(still_to_remove),
+					m_itemdef);
+			// Allow oversized stacks
+			removed.count += leftover.count;
+
 			if (removed.count == item.count)
 				break;
 		}


### PR DESCRIPTION
Fixes #8883

New output:
```
2019-09-01 09:45:11: [Server]: Starting inventory:
2019-09-01 09:45:11: [Server]: 1 default:wood 50
2019-09-01 09:45:11: [Server]: 2 default:wood 50
2019-09-01 09:45:11: [Server]: 3 default:wood 50
2019-09-01 09:45:11: [Server]: 4 default:wood 50
2019-09-01 09:45:11: [Server]: Normal stack max is 99
2019-09-01 09:45:11: [Server]: Removing: default:wood 100
2019-09-01 09:45:11: [Server]: Removed: default:wood 100
2019-09-01 09:45:11: [Server]: Ending inventory:
2019-09-01 09:45:11: [Server]: 1 default:wood 50
2019-09-01 09:45:11: [Server]: 2 default:wood 50
```

## To do

This PR is Ready for Review.

## How to test

1) Take the code from #8883 entirely, override the chest definition
2) Fill in enough stacks
3) Punch the testing node
4) The removed count must be 100 and matches with the leftover items in the inventory.
