### PR TITLE
Non uniform fog with perlin-type noise.

### DIFF
--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -174,7 +174,7 @@ end
 
 local function formspec(tabview, name, tabdata)
 	local tab_string =
-		"box[0,0;3.75,4.5;#999999]" ..
+		"box[0,0;3.75,4.7;#999999]" ..
 		"checkbox[0.25,0;cb_smooth_lighting;" .. fgettext("Smooth Lighting") .. ";"
 				.. dump(core.settings:get_bool("smooth_lighting")) .. "]" ..
 		"checkbox[0.25,0.5;cb_particles;" .. fgettext("Particles") .. ";"
@@ -189,7 +189,7 @@ local function formspec(tabview, name, tabdata)
 				.. getSettingIndex.NodeHighlighting() .. "]" ..
 		"dropdown[0.25,3.6;3.5;dd_leaves_style;" .. dd_options.leaves[1] .. ";"
 				.. getSettingIndex.Leaves() .. "]" ..
-		"box[4,0;3.75,4.5;#999999]" ..
+		"box[4,0;3.75,4.7;#999999]" ..
 		"label[4.25,0.1;" .. fgettext("Texturing:") .. "]" ..
 		"dropdown[4.25,0.55;3.5;dd_filters;" .. dd_options.filters[1] .. ";"
 				.. getSettingIndex.Filter() .. "]" ..
@@ -201,7 +201,7 @@ local function formspec(tabview, name, tabdata)
 		"label[4.25,3.45;" .. fgettext("Screen:") .. "]" ..
 		"checkbox[4.25,3.6;cb_autosave_screensize;" .. fgettext("Autosave Screen Size") .. ";"
 				.. dump(core.settings:get_bool("autosave_screensize")) .. "]" ..
-		"box[8,0;3.75,4.5;#999999]"
+		"box[8,0;3.75,4.7;#999999]"
 
 	local video_driver = core.settings:get("video_driver")
 	local shaders_supported = video_driver == "opengl"
@@ -257,7 +257,9 @@ local function formspec(tabview, name, tabdata)
 			"checkbox[8.25,3;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
 					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
 			"checkbox[8.25,3.5;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
+					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]" ..
+			"checkbox[8.25,4.0;cb_fog_noise;" .. fgettext("Non-uniform Fog") .. ";"
+					.. dump(core.settings:get_bool("enable_fog_noise")) .. "]"
 	else
 		tab_string = tab_string ..
 			"label[8.38,0.7;" .. core.colorize("#888888",
@@ -273,7 +275,9 @@ local function formspec(tabview, name, tabdata)
 			"label[8.38,3.2;" .. core.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
 			"label[8.38,3.7;" .. core.colorize("#888888",
-					fgettext("Waving Plants")) .. "]"
+					fgettext("Waving Plants")) .. "]" ..
+			"label[8.38,4.2;" .. core.colorize("#888888",
+					fgettext("Non-uniform Fog")) .. "]"
 	end
 
 	return tab_string
@@ -342,6 +346,10 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 	if fields["cb_waving_water"] then
 		core.settings:set("enable_waving_water", fields["cb_waving_water"])
+		return true
+	end
+	if fields["cb_fog_noise"] then
+		core.settings:set("enable_fog_noise", fields["cb_fog_noise"])
 		return true
 	end
 	if fields["cb_waving_leaves"] then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -589,6 +589,20 @@ enable_waving_leaves (Waving leaves) bool false
 #    Requires shaders to be enabled.
 enable_waving_plants (Waving plants) bool false
 
+[***Non-uniform Fog]
+#    Set to true to add a bit of noise to the fog.
+#    Requires shaders to be enabled.
+enable_fog_noise (Non-uniform Fog) bool false
+
+#    Frequency of the noise function.
+#    Larger values produce a finer and more
+#    visible pattern.
+fog_noise_frequency (Fog noise frequency) int 60 1 100
+
+#    The strenght of the fog effect
+#    Larger numbers produce a stronger effect.
+fog_noise_strength (Fog noise Strengh) float 0.25 0.0 1.0
+
 [**Advanced]
 
 #    Arm inertia, gives a more realistic movement of

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -22,6 +22,7 @@ varying vec3 lightVec;
 varying vec3 tsEyeVec;
 varying vec3 tsLightVec;
 varying float area_enable_parallax;
+varying float nightRatio;
 
 // Color of the light emitted by the light sources.
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);
@@ -137,7 +138,7 @@ float disp_z;
 	// The pre-baked colors are halved to prevent overflow.
 	vec4 color;
 	// The alpha gives the ratio of sunlight in the incoming light.
-	float nightRatio = 1 - gl_Color.a;
+	nightRatio = 1 - gl_Color.a;
 	color.rgb = gl_Color.rgb * (gl_Color.a * dayLight.rgb + 
 		nightRatio * artificialLight.rgb) * 2;
 	color.a = 1;

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -686,6 +686,16 @@ ShaderInfo generate_shader(const std::string &name, u8 material_type, u8 drawtyp
 	if (g_settings->getBool("enable_bumpmapping"))
 		shaders_header += "#define ENABLE_BUMPMAPPING\n";
 
+	if (g_settings->getBool("enable_fog_noise")) {
+		shaders_header += "#define ENABLE_FOG_NOISE\n";
+		shaders_header += "#define FOG_NOISE_FREQUENCY ";
+		shaders_header += itos(g_settings->getU16("fog_noise_frequency") / 10);
+		shaders_header += "\n";
+		shaders_header += "#define FOG_NOISE_STRENGTH ";
+		shaders_header += ftos(g_settings->getFloat("fog_noise_strength") * 4.0f);
+		shaders_header += "\n";
+	}
+
 	if (g_settings->getBool("enable_parallax_occlusion")){
 		int mode = g_settings->getFloat("parallax_occlusion_mode");
 		float scale = g_settings->getFloat("parallax_occlusion_scale");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -261,6 +261,9 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_wave_speed", "5.0");
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
+	settings->setDefault("enable_fog_noise", "false");
+	settings->setDefault("fog_noise_frequency", "60");
+	settings->setDefault("fog_noise_strength", "0.25");
 
 
 	// Input


### PR DESCRIPTION
Something I was playing with.
Just uses a free GLSL perlin noise function and applies it to the fog density.
Self adjusts for the fog range (so the distinct changes of fog density are nice at various view ranges).
Also has a time component so that fog slowly moves (along the z axis, like clouds and waves).

~~Experimental...~~ Have a look. It adds quite a lot of atmosphere, all handled in the shader.

If we like it, I can put it behind an option like the other shader options.

TODO:
~~1. Optional via shader option.~~ Done
~~2. Match cloud movement (which can be configured)...?~~ Decided not to do.
~~3. Special handling under water and in caves...?~~ Done.
