### PR TITLE
Dungeons: Remove non-functional 'projecting dungeons' setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1378,9 +1378,6 @@ mapgen_limit (Map generation limit) int 31000 0 31000
 #    and junglegrass, in all other mapgens this flag controls all decorations.
 mg_flags (Mapgen flags) flags caves,dungeons,light,decorations,biomes caves,dungeons,light,decorations,biomes,nocaves,nodungeons,nolight,nodecorations,nobiomes
 
-#    Whether dungeons occasionally project from the terrain.
-projecting_dungeons (Projecting dungeons) bool true
-
 [*Biome API temperature and humidity noise parameters]
 
 #    Temperature variation for biomes.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -420,7 +420,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mg_flags", "caves,dungeons,light,decorations,biomes");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "8");
-	settings->setDefault("projecting_dungeons", "true");
 	settings->setDefault("enable_mapgen_debug_info", "false");
 
 	// Server list announcing

--- a/src/mapgen/dungeongen.cpp
+++ b/src/mapgen/dungeongen.cpp
@@ -86,8 +86,6 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 
 	//TimeTaker t("gen dungeons");
 
-	static const bool preserve_ignore = !g_settings->getBool("projecting_dungeons");
-
 	this->vm = vm;
 	this->blockseed = bseed;
 	random.seed(bseed + 2);
@@ -96,9 +94,10 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 	vm->clearFlag(VMANIP_FLAG_DUNGEON_INSIDE | VMANIP_FLAG_DUNGEON_PRESERVE);
 
 	if (dp.only_in_ground) {
-		// Set all air and liquid drawtypes to be untouchable to make dungeons
-		// open to air and liquids.
-		// Optionally set ignore to be untouchable to prevent projecting dungeons.
+		// Set all air and liquid drawtypes to be untouchable to make dungeons generate
+		// in ground only.
+		// Set 'ignore' to be untouchable to prevent generation in ungenerated neighbor
+		// mapchunks, to avoid dungeon rooms generating outside ground.
 		// Like randomwalk caves, preserve nodes that have 'is_ground_content = false',
 		// to avoid dungeons that generate out beyond the edge of a mapchunk destroying
 		// nodes added by mods in 'register_on_generated()'.
@@ -109,8 +108,7 @@ void DungeonGen::generate(MMVManip *vm, u32 bseed, v3s16 nmin, v3s16 nmax)
 					content_t c = vm->m_data[i].getContent();
 					NodeDrawType dtype = ndef->get(c).drawtype;
 					if (dtype == NDT_AIRLIKE || dtype == NDT_LIQUID ||
-							(preserve_ignore && c == CONTENT_IGNORE) ||
-							!ndef->get(c).is_ground_content)
+							c == CONTENT_IGNORE || !ndef->get(c).is_ground_content)
 						vm->m_flags[i] |= VMANIP_FLAG_DUNGEON_PRESERVE;
 					i++;
 				}


### PR DESCRIPTION
Closes #8875 
See issue for details. This setting is now non-functional for some currently unknown reason, projecting dungeons never occur.
If i can get projecting dungeons working again (i hope so) i will do so by controlling that from a new dungeon parameter instead of a global setting, so removing this setting is a good idea anyway.

If you want to test:
Use
```
mg_flags = light,nocaves,dungeons,nodecorations,biomes
mgv7_np_dungeons = {
    offset      = 8,
    scale       = 0,
    spread      = (67, 67, 67),
    seed        = 10325,
    octaves     = 3,
    persistence = 0.5,
    lacunarity  = 2.0,
    flags       =
}
```
to cause 8 dungeons per mapchunk in mgv7, fly around and check none 'project' out of the ground.