### PR TITLE
Move debug.txt after it grows too big

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1322,6 +1322,7 @@ debug_log_level (Debug log level) enum action ,none,error,warning,action,info,ve
 #    If the file size of debug.txt exceeds the number of bytes specified in
 #    this setting when it is opened, the file is moved to debug.txt.1,
 #    deleting an older debug.txt.1 if it exists.
+#    debug.txt is only moved if this setting is positive.
 debug_log_size_max (Debug log file size threshold) int 50000000
 
 #    IPv6 support.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1319,11 +1319,11 @@ language (Language) enum   ,be,ca,cs,da,de,dv,en,eo,es,et,fr,he,hu,id,it,ja,jbo,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
-#    If the file size of debug.txt exceeds the number of bytes specified in
+#    If the file size of debug.txt exceeds the number of megabytes specified in
 #    this setting when it is opened, the file is moved to debug.txt.1,
 #    deleting an older debug.txt.1 if it exists.
 #    debug.txt is only moved if this setting is positive.
-debug_log_size_max (Debug log file size threshold) int 50000000
+debug_log_size_max (Debug log file size threshold) int 50
 
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1319,10 +1319,10 @@ language (Language) enum   ,be,ca,cs,da,de,dv,en,eo,es,et,fr,he,hu,id,it,ja,jbo,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
-#    If the file size of debug.txt exceeds the amount in bytes specified in
-#    this setting, the file's content is deleted when it is opened
-#    the next time.
-debug_log_size_max (Debug log file size threshold) int 1000000
+#    If the file size of debug.txt exceeds the number of bytes specified in
+#    this setting when it is opened, the file is moved to debug.txt.1,
+#    deleting an older debug.txt.1 if it exists.
+debug_log_size_max (Debug log file size threshold) int 50000000
 
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1319,6 +1319,11 @@ language (Language) enum   ,be,ca,cs,da,de,dv,en,eo,es,et,fr,he,hu,id,it,ja,jbo,
 #    -    verbose
 debug_log_level (Debug log level) enum action ,none,error,warning,action,info,verbose
 
+#    If the file size of debug.txt exceeds the amount in bytes specified in
+#    this setting, the file's content is deleted when it is opened
+#    the next time.
+debug_log_size_max (Debug log file size threshold) int 1000000
+
 #    IPv6 support.
 enable_ipv6 (IPv6) bool true
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -385,6 +385,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
+	settings->setDefault("debug_log_size_max", "1000000");
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -385,7 +385,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
-	settings->setDefault("debug_log_size_max", "50000000");
+	settings->setDefault("debug_log_size_max", "50");
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -385,7 +385,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("ignore_world_load_errors", "false");
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
-	settings->setDefault("debug_log_size_max", "1000000");
+	settings->setDefault("debug_log_size_max", "50000000");
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -310,16 +310,29 @@ void Logger::logToOutputs(LogLevel lev, const std::string &combined,
 //// *LogOutput methods
 ////
 
-void FileLogOutput::open(const std::string &filename)
+void FileLogOutput::setFile(const std::string &filename, u64 file_size_max)
 {
-	m_stream.open(filename.c_str(), std::ios::app | std::ios::ate);
+	actionstream << "Log messages are saved to " << filename << std::endl;
+
+	std::ifstream ifile(filename.c_str(), std::ios::binary | std::ios::ate);
+	bool is_too_large = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
+	ifile.close();
+
+	if (!is_too_large) {
+		m_stream.open(filename.c_str(), std::ios::app | std::ios::ate);
+	} else {
+		actionstream << "The log file grew too big. "
+			"The older log messages will be removed." << std::endl;
+		m_stream.open(filename.c_str(), std::ios::trunc);
+	}
+
 	if (!m_stream.good())
 		throw FileNotGoodException("Failed to open log file " +
 			filename + ": " + strerror(errno));
 	m_stream << "\n\n"
-		   "-------------" << std::endl
-		<< "  Separator" << std::endl
-		<< "-------------\n" << std::endl;
+		"-------------" << std::endl <<
+		"  Separator" << std::endl <<
+		"-------------\n" << std::endl;
 }
 
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -312,8 +312,6 @@ void Logger::logToOutputs(LogLevel lev, const std::string &combined,
 
 void FileLogOutput::setFile(const std::string &filename, s64 file_size_max)
 {
-	actionstream << "Log messages are saved to " << filename << std::endl;
-
 	// Only move debug.txt if there is a valid maximum file size
 	bool is_too_large = false;
 	if (file_size_max > 0) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -310,13 +310,17 @@ void Logger::logToOutputs(LogLevel lev, const std::string &combined,
 //// *LogOutput methods
 ////
 
-void FileLogOutput::setFile(const std::string &filename, u64 file_size_max)
+void FileLogOutput::setFile(const std::string &filename, s64 file_size_max)
 {
 	actionstream << "Log messages are saved to " << filename << std::endl;
 
-	std::ifstream ifile(filename, std::ios::binary | std::ios::ate);
-	bool is_too_large = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
-	ifile.close();
+	// Only move debug.txt if there is a valid maximum file size
+	bool is_too_large = false;
+	if (file_size_max > 0) {
+		std::ifstream ifile(filename, std::ios::binary | std::ios::ate);
+		is_too_large = ifile.tellg() > file_size_max;
+		ifile.close();
+	}
 
 	if (is_too_large) {
 		std::string filename_secondary = filename + ".1";

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -314,17 +314,18 @@ void FileLogOutput::setFile(const std::string &filename, u64 file_size_max)
 {
 	actionstream << "Log messages are saved to " << filename << std::endl;
 
-	std::ifstream ifile(filename.c_str(), std::ios::binary | std::ios::ate);
+	std::ifstream ifile(filename, std::ios::binary | std::ios::ate);
 	bool is_too_large = ifile.tellg() > static_cast<std::streamoff>(file_size_max);
 	ifile.close();
 
-	if (!is_too_large) {
-		m_stream.open(filename.c_str(), std::ios::app | std::ios::ate);
-	} else {
-		actionstream << "The log file grew too big. "
-			"The older log messages will be removed." << std::endl;
-		m_stream.open(filename.c_str(), std::ios::trunc);
+	if (is_too_large) {
+		std::string filename_secondary = filename + ".1";
+		actionstream << "The log file grew too big; it is moved to " <<
+			filename_secondary << std::endl;
+		std::remove(filename_secondary.c_str());
+		std::rename(filename.c_str(), filename_secondary.c_str());
 	}
+	m_stream.open(filename, std::ios::app | std::ios::ate);
 
 	if (!m_stream.good())
 		throw FileNotGoodException("Failed to open log file " +

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -326,8 +326,8 @@ void FileLogOutput::setFile(const std::string &filename, s64 file_size_max)
 		std::string filename_secondary = filename + ".1";
 		actionstream << "The log file grew too big; it is moved to " <<
 			filename_secondary << std::endl;
-		std::remove(filename_secondary.c_str());
-		std::rename(filename.c_str(), filename_secondary.c_str());
+		remove(filename_secondary.c_str());
+		rename(filename.c_str(), filename_secondary.c_str());
 	}
 	m_stream.open(filename, std::ios::app | std::ios::ate);
 

--- a/src/log.h
+++ b/src/log.h
@@ -165,7 +165,7 @@ private:
 
 class FileLogOutput : public ICombinedLogOutput {
 public:
-	void setFile(const std::string &filename, u64 file_size_max);
+	void setFile(const std::string &filename, s64 file_size_max);
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{

--- a/src/log.h
+++ b/src/log.h
@@ -165,7 +165,7 @@ private:
 
 class FileLogOutput : public ICombinedLogOutput {
 public:
-	void open(const std::string &filename);
+	void setFile(const std::string &filename, u64 file_size_max);
 
 	void logRaw(LogLevel lev, const std::string &line)
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -580,9 +580,8 @@ static void init_log_streams(const Settings &cmd_args)
 			"using maximum." << std::endl;
 	}
 
-	verbosestream << "log_filename = " << log_filename << std::endl;
-
-	file_log_output.open(log_filename);
+	file_log_output.setFile(log_filename,
+		g_settings->getU64("debug_log_size_max"));
 	g_logger.addOutputMaxLevel(&file_log_output, log_level);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
 		} else {
 			errorstream << "Invalid --worldlist value: "
 				<< cmd_args.get("worldlist") << std::endl;
-			return 1; 
+			return 1;
 		}
 		return 0;
 	}
@@ -426,7 +426,7 @@ static bool setup_log_params(const Settings &cmd_args)
 		} else {
 			errorstream << "Invalid color mode: " << color_mode << std::endl;
 			return false;
-		}			
+		}
 	}
 
 	// If trace is enabled, enable logging of certain things
@@ -581,7 +581,7 @@ static void init_log_streams(const Settings &cmd_args)
 	}
 
 	file_log_output.setFile(log_filename,
-		g_settings->getU64("debug_log_size_max"));
+		g_settings->getU64("debug_log_size_max") * 1000000);
 	g_logger.addOutputMaxLevel(&file_log_output, log_level);
 }
 


### PR DESCRIPTION
Before opening the file for writing, its file size is tested. If it exceeds 50 MB, it is moved to debut.txt.1, otherwise the log is appended to the old messages. An old debut.txt.1 is removed if it already exists.
Additionally, information about the log file location and whether it is deleted is printed to the action log when starting minetest.

The function which opens the file is now called setFile because "open" sounds too simple for what it does.

Fixes #4449. 

## How to test

Apply the changes, adjust the `debug_log_level` setting if needed, and change `debug_log_size_max`.