### PR TITLE
lua_api.txt: Improve privilege definition docs

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7023,10 +7023,11 @@ Privilege definition
 Used by `minetest.register_privilege`.
 
     {
-        description = "Can teleport",  -- Privilege description
+        description = "",
+        -- Privilege description
 
-        give_to_singleplayer = false,
-        -- Whether to grant the privilege to singleplayer (default true).
+        give_to_singleplayer = true,
+        -- Whether to grant the privilege to singleplayer.
 
         give_to_admin = true,
         -- Whether to grant the privilege to the server admin.


### PR DESCRIPTION
The documentation of `give_to_singleplayer` confused me to the extent of ripping my hair out, as it did not follow the convention of setting the default value, and instead, setting false and noting that the default is true in the line below.

This PR is Ready for Review.
<!-- ^ delete one -->
