### PR TITLE
Dungeons: Clean up parameters, improve structure variety 

### DIFF
--- a/src/mapgen/dungeongen.h
+++ b/src/mapgen/dungeongen.h
@@ -49,7 +49,8 @@ struct DungeonParams {
 	// 3D noise that determines which c_wall nodes are converted to c_alt_wall
 	NoiseParams np_alt_wall;
 
-	// Number of dungeons generated in mapchunk
+	// Number of dungeons generated in mapchunk. All will use the same set of
+	// dungeonparams.
 	u16 num_dungeons;
 	// Dungeons only generate in ground
 	bool only_in_ground;
@@ -68,11 +69,13 @@ struct DungeonParams {
 	u16 large_room_chance;
 	// Dimensions of 3D 'brush' that creates corridors.
 	// Dimensions are of the empty space, not including walls / floor / ceilng.
+	// Diagonal corridors must have hole width >=2 to be passable.
+	// Currently, hole width >= 3 causes stair corridor bugs.
 	v3s16 holesize;
 	// Corridor length random range
 	u16 corridor_len_min;
 	u16 corridor_len_max;
-	// Diagonal corridors are possible
+	// Diagonal corridors are possible, 1 in 4 corridors will be diagonal
 	bool diagonal_dirs;
 	// Usually 'GENNOTIFY_DUNGEON', but mapgen v6 uses 'GENNOTIFY_TEMPLE' for
 	// desert dungeons.

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -889,19 +889,21 @@ void MapgenBasic::generateDungeons(s16 max_stone_y)
 		NoiseParams(-0.4, 1.0, v3f(40.0, 40.0, 40.0), 32474, 6, 1.1, 2.0);
 
 	dp.seed                = seed;
-	dp.num_dungeons        = num_dungeons;
 	dp.only_in_ground      = true;
+	dp.num_dungeons        = num_dungeons;
+	dp.notifytype          = GENNOTIFY_DUNGEON;
 	dp.num_rooms           = ps.range(2, 16);
-	dp.room_size_min       = v3s16(6, 5, 6);
-	dp.room_size_max       = v3s16(10, 6, 10);
-	dp.room_size_large_min = v3s16(10, 8, 10);
-	dp.room_size_large_max = v3s16(18, 16, 18);
-	dp.large_room_chance   = (ps.range(1, 4) == 1) ? 1 : 0;
-	dp.holesize            = v3s16(2, 3, 2);
+	dp.room_size_min       = v3s16(5, 5, 5);
+	dp.room_size_max       = v3s16(12, 6, 12);
+	dp.room_size_large_min = v3s16(12, 6, 12);
+	dp.room_size_large_max = v3s16(16, 16, 16);
+	dp.large_room_chance   = (ps.range(1, 4) == 1) ? 8 : 0;
+	dp.diagonal_dirs       = ps.range(1, 8) == 1;
+	// Diagonal corridors must have 'hole' width >=2 to be passable
+	u8 holewidth           = (dp.diagonal_dirs) ? 2 : ps.range(1, 2);
+	dp.holesize            = v3s16(holewidth, 3, holewidth);
 	dp.corridor_len_min    = 1;
 	dp.corridor_len_max    = 13;
-	dp.diagonal_dirs       = ps.range(1, 12) == 1;
-	dp.notifytype          = GENNOTIFY_DUNGEON;
 
 	// Get biome at mapchunk midpoint
 	v3s16 chunk_mid = node_min + (node_max - node_min) / v3s16(2, 2, 2);


### PR DESCRIPTION
Dungeons: Clean up parameters, improve structure variety 

While preserving the previous general character of dungeon structure.
Slightly increase the range of standard room horizontal size, while
preserving the average horizontal size.
Return to classic maximum large room size of 16x16x16.
Make 1 in 4 dungeons have a 1 in 8 chance for each room being 'large',
making multiple large rooms possible for the first time.
Make 1 in 8 dungeons allow diagonal corridors, to make these a little
more common.
Make corridor width vary from 1 to 2, but forced to 2 if diagonal
corridors are allowed, to make them passable.
Add some comments.
//////////////////////////////////////////////////

My previous dungeon work left dungeon structure in a slight mess, this PR cleans it up, carefully 
considers and designs the variation, and re-adds variation of corridor width.
Later PRs will deal with special new features like mega-dungeons or whatever.

Therefore, this should be merged for 5.1.0.