### PR TITLE
Fix error message caused by adding new parameter to background

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2100,7 +2100,7 @@ Elements
 * If `auto_clip` is `true`, the background is clipped to the formspec size
   (`x` and `y` are used as offset values, `w` and `h` are ignored)
 
-### `background[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>;<middle>]`
+### `background9[<X>,<Y>;<W>,<H>;<texture name>;<auto_clip>;<middle>]`
 
 * 9-sliced background. See https://en.wikipedia.org/wiki/9-slice_scaling
 * Middle is a rect which defines the middle of the 9-slice.

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2226,8 +2226,8 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
-	if (type == "background") {
-		parseBackground(data,description);
+	if (type == "background" || type == "background9") {
+		parseBackground(data, description);
 		return;
 	}
 


### PR DESCRIPTION
Users may have noticed errors when playing 5.1.0-dev Minetest Game with 5.0.x Minetest. This PR allows for this error to not be shown