### PR TITLE
Randomwalk caves: Add parameters for number and proportion flooded. Allow small randomwalk caves

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1417,6 +1417,12 @@ mgv5_large_cave_depth (Large cave depth) int -256
 #    Y of upper limit of lava in large caves.
 mgv5_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of small caves per mapchunk.
+mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgv5_small_cave_num_max (Small cave maximum number) int 0 0 256
+
 #    Minimum limit of random number of large caves per mapchunk.
 mgv5_large_cave_num_min (Large cave minimum number) int 0 0 64
 
@@ -1543,6 +1549,12 @@ mgv7_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgv7_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of small caves per mapchunk.
+mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgv7_small_cave_num_max (Small cave maximum number) int 0 0 256
+
 #    Minimum limit of random number of large caves per mapchunk.
 mgv7_large_cave_num_min (Large cave minimum number) int 0 0 64
 
@@ -1660,6 +1672,12 @@ mgcarpathian_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgcarpathian_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of small caves per mapchunk.
+mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgcarpathian_small_cave_num_max (Small cave maximum number) int 0 0 256
+
 #    Minimum limit of random number of large caves per mapchunk.
 mgcarpathian_large_cave_num_min (Large cave minimum number) int 0 0 64
 
@@ -1753,6 +1771,12 @@ mgflat_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgflat_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of small caves per mapchunk.
+mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgflat_small_cave_num_max (Small cave maximum number) int 0 0 256
+
 #    Minimum limit of random number of large caves per mapchunk.
 mgflat_large_cave_num_min (Large cave minimum number) int 0 0 64
 
@@ -1820,6 +1844,12 @@ mgfractal_large_cave_depth (Large cave depth) int -33
 #    Deprecated, define and locate cave liquids using biome definitions instead.
 #    Y of upper limit of lava in large caves.
 mgfractal_lava_depth (Lava depth) int -256
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgfractal_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
 mgfractal_large_cave_num_min (Large cave minimum number) int 0 0 64
@@ -1952,6 +1982,12 @@ mgvalleys_large_cave_depth (Large cave depth) int -33
 #    Deprecated, define and locate cave liquids using biome definitions instead.
 #    Y of upper limit of lava in large caves.
 mgvalleys_lava_depth (Lava depth) int 1
+
+#    Minimum limit of random number of small caves per mapchunk.
+mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256
+
+#    Maximum limit of random number of small caves per mapchunk.
+mgvalleys_small_cave_num_max (Small cave maximum number) int 0 0 256
 
 #    Minimum limit of random number of large caves per mapchunk.
 mgvalleys_large_cave_num_min (Large cave minimum number) int 0 0 64

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1417,6 +1417,15 @@ mgv5_large_cave_depth (Large cave depth) int -256
 #    Y of upper limit of lava in large caves.
 mgv5_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of large caves per mapchunk.
+mgv5_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgv5_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgv5_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
 #    Y-level of cavern upper limit.
 mgv5_cavern_limit (Cavern limit) int -256
 
@@ -1534,6 +1543,15 @@ mgv7_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgv7_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of large caves per mapchunk.
+mgv7_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
 #    Controls the density of mountain-type floatlands.
 #    Is a noise offset added to the 'mgv7_np_mountain' noise value.
 mgv7_float_mount_density (Floatland mountain density) float 0.6
@@ -1642,6 +1660,15 @@ mgcarpathian_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgcarpathian_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of large caves per mapchunk.
+mgcarpathian_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgcarpathian_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgcarpathian_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
 #    Y-level of cavern upper limit.
 mgcarpathian_cavern_limit (Cavern limit) int -256
 
@@ -1726,6 +1753,15 @@ mgflat_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgflat_lava_depth (Lava depth) int -256
 
+#    Minimum limit of random number of large caves per mapchunk.
+mgflat_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgflat_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgflat_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
+
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 mgflat_cave_width (Cave width) float 0.09
 
@@ -1784,6 +1820,15 @@ mgfractal_large_cave_depth (Large cave depth) int -33
 #    Deprecated, define and locate cave liquids using biome definitions instead.
 #    Y of upper limit of lava in large caves.
 mgfractal_lava_depth (Lava depth) int -256
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgfractal_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgfractal_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgfractal_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Lower Y limit of dungeons.
 mgfractal_dungeon_ymin (Dungeon minimum Y) int -31000
@@ -1907,6 +1952,15 @@ mgvalleys_large_cave_depth (Large cave depth) int -33
 #    Deprecated, define and locate cave liquids using biome definitions instead.
 #    Y of upper limit of lava in large caves.
 mgvalleys_lava_depth (Lava depth) int 1
+
+#    Minimum limit of random number of large caves per mapchunk.
+mgvalleys_large_cave_num_min (Large cave minimum number) int 0 0 64
+
+#    Maximum limit of random number of large caves per mapchunk.
+mgvalleys_large_cave_num_max (Large cave maximum number) int 2 0 64
+
+#    Proportion of large caves that contain liquid.
+mgvalleys_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Depth below which you'll find giant caverns.
 mgvalleys_cavern_limit (Cavern upper limit) int -256

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -280,18 +280,20 @@ CavesRandomWalk::CavesRandomWalk(
 	int water_level,
 	content_t water_source,
 	content_t lava_source,
+	float large_cave_flooded,
 	int lava_depth,
 	BiomeGen *biomegen)
 {
 	assert(ndef);
 
-	this->ndef           = ndef;
-	this->gennotify      = gennotify;
-	this->seed           = seed;
-	this->water_level    = water_level;
-	this->np_caveliquids = &nparams_caveliquids;
-	this->lava_depth     = lava_depth;
-	this->bmgn           = biomegen;
+	this->ndef               = ndef;
+	this->gennotify          = gennotify;
+	this->seed               = seed;
+	this->water_level        = water_level;
+	this->np_caveliquids     = &nparams_caveliquids;
+	this->large_cave_flooded = large_cave_flooded;
+	this->lava_depth         = lava_depth;
+	this->bmgn               = biomegen;
 
 	c_water_source = water_source;
 	if (c_water_source == CONTENT_IGNORE)
@@ -322,7 +324,7 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 
 	this->ystride = nmax.X - nmin.X + 1;
 
-	flooded = ps->range(1, 2) == 2;
+	flooded = ps->range(1, 1000) <= large_cave_flooded * 1000.0f;
 
 	// If flooded:
 	// Get biome at mapchunk midpoint. If cave liquid defined for biome, use it.

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -116,15 +116,14 @@ public:
 	s16 *heightmap;
 	BiomeGen *bmgn;
 
-	// configurable parameters
 	s32 seed;
 	int water_level;
+	float large_cave_flooded;
 	// TODO 'lava_depth' and 'np_caveliquids' are deprecated and should be removed.
 	// Cave liquids are now defined and located using biome definitions.
 	int lava_depth;
 	NoiseParams *np_caveliquids;
 
-	// intermediate state variables
 	u16 ystride;
 
 	s16 min_tunnel_diameter;
@@ -161,7 +160,8 @@ public:
 	CavesRandomWalk(const NodeDefManager *ndef, GenerateNotifier *gennotify =
 		NULL, s32 seed = 0, int water_level = 1, content_t water_source =
 		CONTENT_IGNORE, content_t lava_source = CONTENT_IGNORE,
-		int lava_depth = -256, BiomeGen *biomegen = NULL);
+		float large_cave_flooded = 0.5f, int lava_depth = -256,
+		BiomeGen *biomegen = NULL);
 
 	// vm and ps are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -843,18 +843,29 @@ void MapgenBasic::generateCavesNoiseIntersection(s16 max_stone_y)
 
 void MapgenBasic::generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_depth)
 {
-	if (node_min.Y > max_stone_y || node_max.Y > large_cave_depth)
+	if (node_min.Y > max_stone_y)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = ps.range(large_cave_num_min, large_cave_num_max);
+	// Small randomwalk caves
+	u32 num_small_caves = ps.range(small_cave_num_min, small_cave_num_max);
 
-	for (u32 i = 0; i < bruises_count; i++) {
+	for (u32 i = 0; i < num_small_caves; i++) {
 		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
 			c_water_source, c_lava_source, large_cave_flooded, lava_depth, biomegen);
+		cave.makeCave(vm, node_min, node_max, &ps, false, max_stone_y, heightmap);
+	}
 
-		cave.makeCave(vm, node_min, node_max, &ps, true, max_stone_y,
-			heightmap);
+	if (node_max.Y > large_cave_depth)
+		return;
+
+	// Large randomwalk caves below 'large_cave_depth'
+	u32 num_large_caves = ps.range(large_cave_num_min, large_cave_num_max);
+
+	for (u32 i = 0; i < num_large_caves; i++) {
+		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
+			c_water_source, c_lava_source, large_cave_flooded, lava_depth, biomegen);
+		cave.makeCave(vm, node_min, node_max, &ps, true, max_stone_y, heightmap);
 	}
 }
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -847,11 +847,11 @@ void MapgenBasic::generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_depth)
 		return;
 
 	PseudoRandom ps(blockseed + 21343);
-	u32 bruises_count = ps.range(0, 2);
+	u32 bruises_count = ps.range(large_cave_num_min, large_cave_num_max);
 
 	for (u32 i = 0; i < bruises_count; i++) {
 		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
-			c_water_source, c_lava_source, lava_depth, biomegen);
+			c_water_source, c_lava_source, large_cave_flooded, lava_depth, biomegen);
 
 		cave.makeCave(vm, node_min, node_max, &ps, true, max_stone_y,
 			heightmap);

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -280,6 +280,9 @@ protected:
 	float cavern_limit;
 	float cavern_taper;
 	float cavern_threshold;
+	int large_cave_num_min;
+	int large_cave_num_max;
+	float large_cave_flooded;
 	// TODO 'lava_depth' is deprecated and should be removed. Cave liquids are
 	// now defined and located using biome definitions.
 	int lava_depth;

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -280,6 +280,8 @@ protected:
 	float cavern_limit;
 	float cavern_taper;
 	float cavern_threshold;
+	int small_cave_num_min;
+	int small_cave_num_max;
 	int large_cave_num_min;
 	int large_cave_num_max;
 	float large_cave_flooded;

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -58,15 +58,18 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	river_depth      = params->river_depth;
 	valley_width     = params->valley_width;
 
-	spflags          = params->spflags;
-	cave_width       = params->cave_width;
-	large_cave_depth = params->large_cave_depth;
-	lava_depth       = params->lava_depth;
-	cavern_limit     = params->cavern_limit;
-	cavern_taper     = params->cavern_taper;
-	cavern_threshold = params->cavern_threshold;
-	dungeon_ymin     = params->dungeon_ymin;
-	dungeon_ymax     = params->dungeon_ymax;
+	spflags            = params->spflags;
+	cave_width         = params->cave_width;
+	large_cave_depth   = params->large_cave_depth;
+	lava_depth         = params->lava_depth;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
+	cavern_limit       = params->cavern_limit;
+	cavern_taper       = params->cavern_taper;
+	cavern_threshold   = params->cavern_threshold;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
 
 	grad_wl = 1 - water_level;
 
@@ -148,14 +151,17 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgcarpathian_river_depth",  river_depth);
 	settings->getFloatNoEx("mgcarpathian_valley_width", valley_width);
 
-	settings->getFloatNoEx("mgcarpathian_cave_width",       cave_width);
-	settings->getS16NoEx("mgcarpathian_large_cave_depth",   large_cave_depth);
-	settings->getS16NoEx("mgcarpathian_lava_depth",         lava_depth);
-	settings->getS16NoEx("mgcarpathian_cavern_limit",       cavern_limit);
-	settings->getS16NoEx("mgcarpathian_cavern_taper",       cavern_taper);
-	settings->getFloatNoEx("mgcarpathian_cavern_threshold", cavern_threshold);
-	settings->getS16NoEx("mgcarpathian_dungeon_ymin",       dungeon_ymin);
-	settings->getS16NoEx("mgcarpathian_dungeon_ymax",       dungeon_ymax);
+	settings->getFloatNoEx("mgcarpathian_cave_width",         cave_width);
+	settings->getS16NoEx("mgcarpathian_large_cave_depth",     large_cave_depth);
+	settings->getS16NoEx("mgcarpathian_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgcarpathian_large_cave_num_min",   large_cave_num_min);
+	settings->getU16NoEx("mgcarpathian_large_cave_num_max",   large_cave_num_max);
+	settings->getFloatNoEx("mgcarpathian_large_cave_flooded", large_cave_flooded);
+	settings->getS16NoEx("mgcarpathian_cavern_limit",         cavern_limit);
+	settings->getS16NoEx("mgcarpathian_cavern_taper",         cavern_taper);
+	settings->getFloatNoEx("mgcarpathian_cavern_threshold",   cavern_threshold);
+	settings->getS16NoEx("mgcarpathian_dungeon_ymin",         dungeon_ymin);
+	settings->getS16NoEx("mgcarpathian_dungeon_ymax",         dungeon_ymax);
 
 	settings->getNoiseParams("mgcarpathian_np_filler_depth",  np_filler_depth);
 	settings->getNoiseParams("mgcarpathian_np_height1",       np_height1);
@@ -186,14 +192,17 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setFloat("mgcarpathian_river_depth",  river_depth);
 	settings->setFloat("mgcarpathian_valley_width", valley_width);
 
-	settings->setFloat("mgcarpathian_cave_width",       cave_width);
-	settings->setS16("mgcarpathian_large_cave_depth",   large_cave_depth);
-	settings->setS16("mgcarpathian_lava_depth",         lava_depth);
-	settings->setS16("mgcarpathian_cavern_limit",       cavern_limit);
-	settings->setS16("mgcarpathian_cavern_taper",       cavern_taper);
-	settings->setFloat("mgcarpathian_cavern_threshold", cavern_threshold);
-	settings->setS16("mgcarpathian_dungeon_ymin",       dungeon_ymin);
-	settings->setS16("mgcarpathian_dungeon_ymax",       dungeon_ymax);
+	settings->setFloat("mgcarpathian_cave_width",         cave_width);
+	settings->setS16("mgcarpathian_large_cave_depth",     large_cave_depth);
+	settings->setS16("mgcarpathian_lava_depth",           lava_depth);
+	settings->setU16("mgcarpathian_large_cave_num_min",   large_cave_num_min);
+	settings->setU16("mgcarpathian_large_cave_num_max",   large_cave_num_max);
+	settings->setFloat("mgcarpathian_large_cave_flooded", large_cave_flooded);
+	settings->setS16("mgcarpathian_cavern_limit",         cavern_limit);
+	settings->setS16("mgcarpathian_cavern_taper",         cavern_taper);
+	settings->setFloat("mgcarpathian_cavern_threshold",   cavern_threshold);
+	settings->setS16("mgcarpathian_dungeon_ymin",         dungeon_ymin);
+	settings->setS16("mgcarpathian_dungeon_ymax",         dungeon_ymax);
 
 	settings->setNoiseParams("mgcarpathian_np_filler_depth",  np_filler_depth);
 	settings->setNoiseParams("mgcarpathian_np_height1",       np_height1);

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -62,6 +62,8 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
 	large_cave_num_max = params->large_cave_num_max;
 	large_cave_flooded = params->large_cave_flooded;
@@ -154,6 +156,8 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgcarpathian_cave_width",         cave_width);
 	settings->getS16NoEx("mgcarpathian_large_cave_depth",     large_cave_depth);
 	settings->getS16NoEx("mgcarpathian_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgcarpathian_small_cave_num_min",   small_cave_num_min);
+	settings->getU16NoEx("mgcarpathian_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgcarpathian_large_cave_num_min",   large_cave_num_min);
 	settings->getU16NoEx("mgcarpathian_large_cave_num_max",   large_cave_num_max);
 	settings->getFloatNoEx("mgcarpathian_large_cave_flooded", large_cave_flooded);
@@ -195,6 +199,8 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setFloat("mgcarpathian_cave_width",         cave_width);
 	settings->setS16("mgcarpathian_large_cave_depth",     large_cave_depth);
 	settings->setS16("mgcarpathian_lava_depth",           lava_depth);
+	settings->setU16("mgcarpathian_small_cave_num_min",   small_cave_num_min);
+	settings->setU16("mgcarpathian_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgcarpathian_large_cave_num_min",   large_cave_num_min);
 	settings->setU16("mgcarpathian_large_cave_num_max",   large_cave_num_max);
 	settings->setFloat("mgcarpathian_large_cave_flooded", large_cave_flooded);

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -41,6 +41,8 @@ struct MapgenCarpathianParams : public MapgenParams
 	float cave_width         = 0.09f;
 	s16 large_cave_depth     = -33;
 	s16 lava_depth           = -256;
+	u16 small_cave_num_min   = 0;
+	u16 small_cave_num_max   = 0;
 	u16 large_cave_num_min   = 0;
 	u16 large_cave_num_max   = 2;
 	float large_cave_flooded = 0.5f;

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -37,15 +37,18 @@ struct MapgenCarpathianParams : public MapgenParams
 	float river_depth      = 24.0f;
 	float valley_width     = 0.25f;
 
-	u32 spflags            = MGCARPATHIAN_CAVERNS;
-	float cave_width       = 0.09f;
-	s16 large_cave_depth   = -33;
-	s16 lava_depth         = -256;
-	s16 cavern_limit       = -256;
-	s16 cavern_taper       = 256;
-	float cavern_threshold = 0.7f;
-	s16 dungeon_ymin       = -31000;
-	s16 dungeon_ymax       = 31000;
+	u32 spflags              = MGCARPATHIAN_CAVERNS;
+	float cave_width         = 0.09f;
+	s16 large_cave_depth     = -33;
+	s16 lava_depth           = -256;
+	u16 large_cave_num_min   = 0;
+	u16 large_cave_num_max   = 2;
+	float large_cave_flooded = 0.5f;
+	s16 cavern_limit         = -256;
+	s16 cavern_taper         = 256;
+	float cavern_threshold   = 0.7f;
+	s16 dungeon_ymin         = -31000;
+	s16 dungeon_ymax         = 31000;
 
 	NoiseParams np_filler_depth;
 	NoiseParams np_height1;

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -55,6 +55,8 @@ MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
 	ground_level       = params->ground_level;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
 	large_cave_num_max = params->large_cave_num_max;
 	large_cave_flooded = params->large_cave_flooded;
@@ -103,6 +105,8 @@ void MapgenFlatParams::readParams(const Settings *settings)
 	settings->getS16NoEx("mgflat_ground_level",         ground_level);
 	settings->getS16NoEx("mgflat_large_cave_depth",     large_cave_depth);
 	settings->getS16NoEx("mgflat_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgflat_small_cave_num_min",   small_cave_num_min);
+	settings->getU16NoEx("mgflat_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgflat_large_cave_num_min",   large_cave_num_min);
 	settings->getU16NoEx("mgflat_large_cave_num_max",   large_cave_num_max);
 	settings->getFloatNoEx("mgflat_large_cave_flooded", large_cave_flooded);
@@ -128,6 +132,8 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setS16("mgflat_ground_level",         ground_level);
 	settings->setS16("mgflat_large_cave_depth",     large_cave_depth);
 	settings->setS16("mgflat_lava_depth",           lava_depth);
+	settings->setU16("mgflat_small_cave_num_min",   small_cave_num_min);
+	settings->setU16("mgflat_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgflat_large_cave_num_min",   large_cave_num_min);
 	settings->setU16("mgflat_large_cave_num_max",   large_cave_num_max);
 	settings->setFloat("mgflat_large_cave_flooded", large_cave_flooded);

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -51,17 +51,20 @@ FlagDesc flagdesc_mapgen_flat[] = {
 MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
 	: MapgenBasic(MAPGEN_FLAT, params, emerge)
 {
-	spflags          = params->spflags;
-	ground_level     = params->ground_level;
-	large_cave_depth = params->large_cave_depth;
-	lava_depth       = params->lava_depth;
-	cave_width       = params->cave_width;
-	lake_threshold   = params->lake_threshold;
-	lake_steepness   = params->lake_steepness;
-	hill_threshold   = params->hill_threshold;
-	hill_steepness   = params->hill_steepness;
-	dungeon_ymin     = params->dungeon_ymin;
-	dungeon_ymax     = params->dungeon_ymax;
+	spflags            = params->spflags;
+	ground_level       = params->ground_level;
+	large_cave_depth   = params->large_cave_depth;
+	lava_depth         = params->lava_depth;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
+	cave_width         = params->cave_width;
+	lake_threshold     = params->lake_threshold;
+	lake_steepness     = params->lake_steepness;
+	hill_threshold     = params->hill_threshold;
+	hill_steepness     = params->hill_steepness;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
 
 	// 2D noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
@@ -96,17 +99,20 @@ MapgenFlatParams::MapgenFlatParams():
 
 void MapgenFlatParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgflat_spflags",      spflags, flagdesc_mapgen_flat);
-	settings->getS16NoEx("mgflat_ground_level",     ground_level);
-	settings->getS16NoEx("mgflat_large_cave_depth", large_cave_depth);
-	settings->getS16NoEx("mgflat_lava_depth",       lava_depth);
-	settings->getFloatNoEx("mgflat_cave_width",     cave_width);
-	settings->getFloatNoEx("mgflat_lake_threshold", lake_threshold);
-	settings->getFloatNoEx("mgflat_lake_steepness", lake_steepness);
-	settings->getFloatNoEx("mgflat_hill_threshold", hill_threshold);
-	settings->getFloatNoEx("mgflat_hill_steepness", hill_steepness);
-	settings->getS16NoEx("mgflat_dungeon_ymin",     dungeon_ymin);
-	settings->getS16NoEx("mgflat_dungeon_ymax",     dungeon_ymax);
+	settings->getFlagStrNoEx("mgflat_spflags", spflags, flagdesc_mapgen_flat);
+	settings->getS16NoEx("mgflat_ground_level",         ground_level);
+	settings->getS16NoEx("mgflat_large_cave_depth",     large_cave_depth);
+	settings->getS16NoEx("mgflat_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgflat_large_cave_num_min",   large_cave_num_min);
+	settings->getU16NoEx("mgflat_large_cave_num_max",   large_cave_num_max);
+	settings->getFloatNoEx("mgflat_large_cave_flooded", large_cave_flooded);
+	settings->getFloatNoEx("mgflat_cave_width",         cave_width);
+	settings->getFloatNoEx("mgflat_lake_threshold",     lake_threshold);
+	settings->getFloatNoEx("mgflat_lake_steepness",     lake_steepness);
+	settings->getFloatNoEx("mgflat_hill_threshold",     hill_threshold);
+	settings->getFloatNoEx("mgflat_hill_steepness",     hill_steepness);
+	settings->getS16NoEx("mgflat_dungeon_ymin",         dungeon_ymin);
+	settings->getS16NoEx("mgflat_dungeon_ymax",         dungeon_ymax);
 
 	settings->getNoiseParams("mgflat_np_terrain",      np_terrain);
 	settings->getNoiseParams("mgflat_np_filler_depth", np_filler_depth);
@@ -118,17 +124,20 @@ void MapgenFlatParams::readParams(const Settings *settings)
 
 void MapgenFlatParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgflat_spflags",      spflags, flagdesc_mapgen_flat, U32_MAX);
-	settings->setS16("mgflat_ground_level",     ground_level);
-	settings->setS16("mgflat_large_cave_depth", large_cave_depth);
-	settings->setS16("mgflat_lava_depth",       lava_depth);
-	settings->setFloat("mgflat_cave_width",     cave_width);
-	settings->setFloat("mgflat_lake_threshold", lake_threshold);
-	settings->setFloat("mgflat_lake_steepness", lake_steepness);
-	settings->setFloat("mgflat_hill_threshold", hill_threshold);
-	settings->setFloat("mgflat_hill_steepness", hill_steepness);
-	settings->setS16("mgflat_dungeon_ymin",     dungeon_ymin);
-	settings->setS16("mgflat_dungeon_ymax",     dungeon_ymax);
+	settings->setFlagStr("mgflat_spflags", spflags, flagdesc_mapgen_flat, U32_MAX);
+	settings->setS16("mgflat_ground_level",         ground_level);
+	settings->setS16("mgflat_large_cave_depth",     large_cave_depth);
+	settings->setS16("mgflat_lava_depth",           lava_depth);
+	settings->setU16("mgflat_large_cave_num_min",   large_cave_num_min);
+	settings->setU16("mgflat_large_cave_num_max",   large_cave_num_max);
+	settings->setFloat("mgflat_large_cave_flooded", large_cave_flooded);
+	settings->setFloat("mgflat_cave_width",         cave_width);
+	settings->setFloat("mgflat_lake_threshold",     lake_threshold);
+	settings->setFloat("mgflat_lake_steepness",     lake_steepness);
+	settings->setFloat("mgflat_hill_threshold",     hill_threshold);
+	settings->setFloat("mgflat_hill_steepness",     hill_steepness);
+	settings->setS16("mgflat_dungeon_ymin",         dungeon_ymin);
+	settings->setS16("mgflat_dungeon_ymax",         dungeon_ymax);
 
 	settings->setNoiseParams("mgflat_np_terrain",      np_terrain);
 	settings->setNoiseParams("mgflat_np_filler_depth", np_filler_depth);

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -36,6 +36,8 @@ struct MapgenFlatParams : public MapgenParams
 	s16 ground_level = 8;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 small_cave_num_min = 0;
+	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;
 	u16 large_cave_num_max = 2;
 	float large_cave_flooded = 0.5f;

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -36,6 +36,9 @@ struct MapgenFlatParams : public MapgenParams
 	s16 ground_level = 8;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 large_cave_num_min = 0;
+	u16 large_cave_num_max = 2;
+	float large_cave_flooded = 0.5f;
 	float cave_width = 0.09f;
 	float lake_threshold = -0.45f;
 	float lake_steepness = 48.0f;

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -55,6 +55,8 @@ MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
 	large_cave_num_max = params->large_cave_num_max;
 	large_cave_flooded = params->large_cave_flooded;
@@ -112,6 +114,8 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgfractal_cave_width",         cave_width);
 	settings->getS16NoEx("mgfractal_large_cave_depth",     large_cave_depth);
 	settings->getS16NoEx("mgfractal_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgfractal_small_cave_num_min",   small_cave_num_min);
+	settings->getU16NoEx("mgfractal_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgfractal_large_cave_num_min",   large_cave_num_min);
 	settings->getU16NoEx("mgfractal_large_cave_num_max",   large_cave_num_max);
 	settings->getFloatNoEx("mgfractal_large_cave_flooded", large_cave_flooded);
@@ -141,6 +145,8 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setFloat("mgfractal_cave_width",         cave_width);
 	settings->setS16("mgfractal_large_cave_depth",     large_cave_depth);
 	settings->setS16("mgfractal_lava_depth",           lava_depth);
+	settings->setU16("mgfractal_small_cave_num_min",   small_cave_num_min);
+	settings->setU16("mgfractal_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgfractal_large_cave_num_min",   large_cave_num_min);
 	settings->setU16("mgfractal_large_cave_num_max",   large_cave_num_max);
 	settings->setFloat("mgfractal_large_cave_flooded", large_cave_flooded);

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -51,21 +51,24 @@ FlagDesc flagdesc_mapgen_fractal[] = {
 MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 	: MapgenBasic(MAPGEN_FRACTAL, params, emerge)
 {
-	spflags          = params->spflags;
-	cave_width       = params->cave_width;
-	large_cave_depth = params->large_cave_depth;
-	lava_depth       = params->lava_depth;
-	dungeon_ymin     = params->dungeon_ymin;
-	dungeon_ymax     = params->dungeon_ymax;
-	fractal          = params->fractal;
-	iterations       = params->iterations;
-	scale            = params->scale;
-	offset           = params->offset;
-	slice_w          = params->slice_w;
-	julia_x          = params->julia_x;
-	julia_y          = params->julia_y;
-	julia_z          = params->julia_z;
-	julia_w          = params->julia_w;
+	spflags            = params->spflags;
+	cave_width         = params->cave_width;
+	large_cave_depth   = params->large_cave_depth;
+	lava_depth         = params->lava_depth;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
+	fractal            = params->fractal;
+	iterations         = params->iterations;
+	scale              = params->scale;
+	offset             = params->offset;
+	slice_w            = params->slice_w;
+	julia_x            = params->julia_x;
+	julia_y            = params->julia_y;
+	julia_z            = params->julia_z;
+	julia_w            = params->julia_w;
 
 	//// 2D noise
 	if (spflags & MGFRACTAL_TERRAIN)
@@ -105,21 +108,24 @@ MapgenFractalParams::MapgenFractalParams():
 
 void MapgenFractalParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal);
-	settings->getFloatNoEx("mgfractal_cave_width",     cave_width);
-	settings->getS16NoEx("mgfractal_large_cave_depth", large_cave_depth);
-	settings->getS16NoEx("mgfractal_lava_depth",       lava_depth);
-	settings->getS16NoEx("mgfractal_dungeon_ymin",     dungeon_ymin);
-	settings->getS16NoEx("mgfractal_dungeon_ymax",     dungeon_ymax);
-	settings->getU16NoEx("mgfractal_fractal",          fractal);
-	settings->getU16NoEx("mgfractal_iterations",       iterations);
-	settings->getV3FNoEx("mgfractal_scale",            scale);
-	settings->getV3FNoEx("mgfractal_offset",           offset);
-	settings->getFloatNoEx("mgfractal_slice_w",        slice_w);
-	settings->getFloatNoEx("mgfractal_julia_x",        julia_x);
-	settings->getFloatNoEx("mgfractal_julia_y",        julia_y);
-	settings->getFloatNoEx("mgfractal_julia_z",        julia_z);
-	settings->getFloatNoEx("mgfractal_julia_w",        julia_w);
+	settings->getFlagStrNoEx("mgfractal_spflags", spflags, flagdesc_mapgen_fractal);
+	settings->getFloatNoEx("mgfractal_cave_width",         cave_width);
+	settings->getS16NoEx("mgfractal_large_cave_depth",     large_cave_depth);
+	settings->getS16NoEx("mgfractal_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgfractal_large_cave_num_min",   large_cave_num_min);
+	settings->getU16NoEx("mgfractal_large_cave_num_max",   large_cave_num_max);
+	settings->getFloatNoEx("mgfractal_large_cave_flooded", large_cave_flooded);
+	settings->getS16NoEx("mgfractal_dungeon_ymin",         dungeon_ymin);
+	settings->getS16NoEx("mgfractal_dungeon_ymax",         dungeon_ymax);
+	settings->getU16NoEx("mgfractal_fractal",              fractal);
+	settings->getU16NoEx("mgfractal_iterations",           iterations);
+	settings->getV3FNoEx("mgfractal_scale",                scale);
+	settings->getV3FNoEx("mgfractal_offset",               offset);
+	settings->getFloatNoEx("mgfractal_slice_w",            slice_w);
+	settings->getFloatNoEx("mgfractal_julia_x",            julia_x);
+	settings->getFloatNoEx("mgfractal_julia_y",            julia_y);
+	settings->getFloatNoEx("mgfractal_julia_z",            julia_z);
+	settings->getFloatNoEx("mgfractal_julia_w",            julia_w);
 
 	settings->getNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->getNoiseParams("mgfractal_np_filler_depth", np_filler_depth);
@@ -131,21 +137,24 @@ void MapgenFractalParams::readParams(const Settings *settings)
 
 void MapgenFractalParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgfractal_spflags",      spflags, flagdesc_mapgen_fractal, U32_MAX);
-	settings->setFloat("mgfractal_cave_width",     cave_width);
-	settings->setS16("mgfractal_large_cave_depth", large_cave_depth);
-	settings->setS16("mgfractal_lava_depth",       lava_depth);
-	settings->setS16("mgfractal_dungeon_ymin",     dungeon_ymin);
-	settings->setS16("mgfractal_dungeon_ymax",     dungeon_ymax);
-	settings->setU16("mgfractal_fractal",          fractal);
-	settings->setU16("mgfractal_iterations",       iterations);
-	settings->setV3F("mgfractal_scale",            scale);
-	settings->setV3F("mgfractal_offset",           offset);
-	settings->setFloat("mgfractal_slice_w",        slice_w);
-	settings->setFloat("mgfractal_julia_x",        julia_x);
-	settings->setFloat("mgfractal_julia_y",        julia_y);
-	settings->setFloat("mgfractal_julia_z",        julia_z);
-	settings->setFloat("mgfractal_julia_w",        julia_w);
+	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFloat("mgfractal_cave_width",         cave_width);
+	settings->setS16("mgfractal_large_cave_depth",     large_cave_depth);
+	settings->setS16("mgfractal_lava_depth",           lava_depth);
+	settings->setU16("mgfractal_large_cave_num_min",   large_cave_num_min);
+	settings->setU16("mgfractal_large_cave_num_max",   large_cave_num_max);
+	settings->setFloat("mgfractal_large_cave_flooded", large_cave_flooded);
+	settings->setS16("mgfractal_dungeon_ymin",         dungeon_ymin);
+	settings->setS16("mgfractal_dungeon_ymax",         dungeon_ymax);
+	settings->setU16("mgfractal_fractal",              fractal);
+	settings->setU16("mgfractal_iterations",           iterations);
+	settings->setV3F("mgfractal_scale",                scale);
+	settings->setV3F("mgfractal_offset",               offset);
+	settings->setFloat("mgfractal_slice_w",            slice_w);
+	settings->setFloat("mgfractal_julia_x",            julia_x);
+	settings->setFloat("mgfractal_julia_y",            julia_y);
+	settings->setFloat("mgfractal_julia_z",            julia_z);
+	settings->setFloat("mgfractal_julia_w",            julia_w);
 
 	settings->setNoiseParams("mgfractal_np_seabed",       np_seabed);
 	settings->setNoiseParams("mgfractal_np_filler_depth", np_filler_depth);

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -39,6 +39,9 @@ struct MapgenFractalParams : public MapgenParams
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 large_cave_num_min = 0;
+	u16 large_cave_num_max = 2;
+	float large_cave_flooded = 0.5f;
 	s16 dungeon_ymin = -31000;
 	s16 dungeon_ymax = 31000;
 	u16 fractal = 1;

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -39,6 +39,8 @@ struct MapgenFractalParams : public MapgenParams
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 small_cave_num_min = 0;
+	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;
 	u16 large_cave_num_max = 2;
 	float large_cave_flooded = 0.5f;

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -48,15 +48,18 @@ FlagDesc flagdesc_mapgen_v5[] = {
 MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	: MapgenBasic(MAPGEN_V5, params, emerge)
 {
-	spflags          = params->spflags;
-	cave_width       = params->cave_width;
-	large_cave_depth = params->large_cave_depth;
-	lava_depth       = params->lava_depth;
-	cavern_limit     = params->cavern_limit;
-	cavern_taper     = params->cavern_taper;
-	cavern_threshold = params->cavern_threshold;
-	dungeon_ymin     = params->dungeon_ymin;
-	dungeon_ymax     = params->dungeon_ymax;
+	spflags            = params->spflags;
+	cave_width         = params->cave_width;
+	large_cave_depth   = params->large_cave_depth;
+	lava_depth         = params->lava_depth;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
+	cavern_limit       = params->cavern_limit;
+	cavern_taper       = params->cavern_taper;
+	cavern_threshold   = params->cavern_threshold;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
 
 	// Terrain noise
 	noise_filler_depth = new Noise(&params->np_filler_depth, seed, csize.X, csize.Z);
@@ -98,15 +101,18 @@ MapgenV5Params::MapgenV5Params():
 
 void MapgenV5Params::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgv5_spflags",        spflags, flagdesc_mapgen_v5);
-	settings->getFloatNoEx("mgv5_cave_width",       cave_width);
-	settings->getS16NoEx("mgv5_large_cave_depth",   large_cave_depth);
-	settings->getS16NoEx("mgv5_lava_depth",         lava_depth);
-	settings->getS16NoEx("mgv5_cavern_limit",       cavern_limit);
-	settings->getS16NoEx("mgv5_cavern_taper",       cavern_taper);
-	settings->getFloatNoEx("mgv5_cavern_threshold", cavern_threshold);
-	settings->getS16NoEx("mgv5_dungeon_ymin",       dungeon_ymin);
-	settings->getS16NoEx("mgv5_dungeon_ymax",       dungeon_ymax);
+	settings->getFlagStrNoEx("mgv5_spflags", spflags, flagdesc_mapgen_v5);
+	settings->getFloatNoEx("mgv5_cave_width",         cave_width);
+	settings->getS16NoEx("mgv5_large_cave_depth",     large_cave_depth);
+	settings->getS16NoEx("mgv5_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgv5_large_cave_num_min",   large_cave_num_min);
+	settings->getU16NoEx("mgv5_large_cave_num_max",   large_cave_num_max);
+	settings->getFloatNoEx("mgv5_large_cave_flooded", large_cave_flooded);
+	settings->getS16NoEx("mgv5_cavern_limit",         cavern_limit);
+	settings->getS16NoEx("mgv5_cavern_taper",         cavern_taper);
+	settings->getFloatNoEx("mgv5_cavern_threshold",   cavern_threshold);
+	settings->getS16NoEx("mgv5_dungeon_ymin",         dungeon_ymin);
+	settings->getS16NoEx("mgv5_dungeon_ymax",         dungeon_ymax);
 
 	settings->getNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->getNoiseParams("mgv5_np_factor",       np_factor);
@@ -121,15 +127,18 @@ void MapgenV5Params::readParams(const Settings *settings)
 
 void MapgenV5Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv5_spflags",        spflags, flagdesc_mapgen_v5, U32_MAX);
-	settings->setFloat("mgv5_cave_width",       cave_width);
-	settings->setS16("mgv5_large_cave_depth",   large_cave_depth);
-	settings->setS16("mgv5_lava_depth",         lava_depth);
-	settings->setS16("mgv5_cavern_limit",       cavern_limit);
-	settings->setS16("mgv5_cavern_taper",       cavern_taper);
-	settings->setFloat("mgv5_cavern_threshold", cavern_threshold);
-	settings->setS16("mgv5_dungeon_ymin",       dungeon_ymin);
-	settings->setS16("mgv5_dungeon_ymax",       dungeon_ymax);
+	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, U32_MAX);
+	settings->setFloat("mgv5_cave_width",         cave_width);
+	settings->setS16("mgv5_large_cave_depth",     large_cave_depth);
+	settings->setS16("mgv5_lava_depth",           lava_depth);
+	settings->setU16("mgv5_large_cave_num_min",   large_cave_num_min);
+	settings->setU16("mgv5_large_cave_num_max",   large_cave_num_max);
+	settings->setFloat("mgv5_large_cave_flooded", large_cave_flooded);
+	settings->setS16("mgv5_cavern_limit",         cavern_limit);
+	settings->setS16("mgv5_cavern_taper",         cavern_taper);
+	settings->setFloat("mgv5_cavern_threshold",   cavern_threshold);
+	settings->setS16("mgv5_dungeon_ymin",         dungeon_ymin);
+	settings->setS16("mgv5_dungeon_ymax",         dungeon_ymax);
 
 	settings->setNoiseParams("mgv5_np_filler_depth", np_filler_depth);
 	settings->setNoiseParams("mgv5_np_factor",       np_factor);

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -52,6 +52,8 @@ MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
 	large_cave_num_max = params->large_cave_num_max;
 	large_cave_flooded = params->large_cave_flooded;
@@ -105,6 +107,8 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgv5_cave_width",         cave_width);
 	settings->getS16NoEx("mgv5_large_cave_depth",     large_cave_depth);
 	settings->getS16NoEx("mgv5_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgv5_small_cave_num_min",   small_cave_num_min);
+	settings->getU16NoEx("mgv5_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgv5_large_cave_num_min",   large_cave_num_min);
 	settings->getU16NoEx("mgv5_large_cave_num_max",   large_cave_num_max);
 	settings->getFloatNoEx("mgv5_large_cave_flooded", large_cave_flooded);
@@ -131,6 +135,8 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setFloat("mgv5_cave_width",         cave_width);
 	settings->setS16("mgv5_large_cave_depth",     large_cave_depth);
 	settings->setS16("mgv5_lava_depth",           lava_depth);
+	settings->setU16("mgv5_small_cave_num_min",   small_cave_num_min);
+	settings->setU16("mgv5_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgv5_large_cave_num_min",   large_cave_num_min);
 	settings->setU16("mgv5_large_cave_num_max",   large_cave_num_max);
 	settings->setFloat("mgv5_large_cave_flooded", large_cave_flooded);

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -35,6 +35,9 @@ struct MapgenV5Params : public MapgenParams
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -256;
 	s16 lava_depth = -256;
+	u16 large_cave_num_min = 0;
+	u16 large_cave_num_max = 2;
+	float large_cave_flooded = 0.5f;
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -35,6 +35,8 @@ struct MapgenV5Params : public MapgenParams
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -256;
 	s16 lava_depth = -256;
+	u16 small_cave_num_min = 0;
+	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;
 	u16 large_cave_num_max = 2;
 	float large_cave_flooded = 0.5f;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -62,17 +62,19 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	floatland_level      = params->floatland_level;
 	shadow_limit         = params->shadow_limit;
 
-	cave_width           = params->cave_width;
-	large_cave_depth     = params->large_cave_depth;
-	lava_depth           = params->lava_depth;
-	large_cave_num_min   = params->large_cave_num_min;
-	large_cave_num_max   = params->large_cave_num_max;
-	large_cave_flooded   = params->large_cave_flooded;
-	cavern_limit         = params->cavern_limit;
-	cavern_taper         = params->cavern_taper;
-	cavern_threshold     = params->cavern_threshold;
-	dungeon_ymin         = params->dungeon_ymin;
-	dungeon_ymax         = params->dungeon_ymax;
+	cave_width         = params->cave_width;
+	large_cave_depth   = params->large_cave_depth;
+	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
+	cavern_limit       = params->cavern_limit;
+	cavern_taper       = params->cavern_taper;
+	cavern_threshold   = params->cavern_threshold;
+	dungeon_ymin       = params->dungeon_ymin;
+	dungeon_ymax       = params->dungeon_ymax;
 
 	// This is to avoid a divide-by-zero.
 	// Parameter will be saved to map_meta.txt in limited form.
@@ -176,6 +178,8 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgv7_cave_width",           cave_width);
 	settings->getS16NoEx("mgv7_large_cave_depth",       large_cave_depth);
 	settings->getS16NoEx("mgv7_lava_depth",             lava_depth);
+	settings->getU16NoEx("mgv7_small_cave_num_min",     small_cave_num_min);
+	settings->getU16NoEx("mgv7_small_cave_num_max",     small_cave_num_max);
 	settings->getU16NoEx("mgv7_large_cave_num_min",     large_cave_num_min);
 	settings->getU16NoEx("mgv7_large_cave_num_max",     large_cave_num_max);
 	settings->getFloatNoEx("mgv7_large_cave_flooded",   large_cave_flooded);
@@ -215,6 +219,8 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setFloat("mgv7_cave_width",           cave_width);
 	settings->setS16("mgv7_large_cave_depth",       large_cave_depth);
 	settings->setS16("mgv7_lava_depth",             lava_depth);
+	settings->setU16("mgv7_small_cave_num_min",     small_cave_num_min);
+	settings->setU16("mgv7_small_cave_num_max",     small_cave_num_max);
 	settings->setU16("mgv7_large_cave_num_min",     large_cave_num_min);
 	settings->setU16("mgv7_large_cave_num_max",     large_cave_num_max);
 	settings->setFloat("mgv7_large_cave_flooded",   large_cave_flooded);

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -65,6 +65,9 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	cave_width           = params->cave_width;
 	large_cave_depth     = params->large_cave_depth;
 	lava_depth           = params->lava_depth;
+	large_cave_num_min   = params->large_cave_num_min;
+	large_cave_num_max   = params->large_cave_num_max;
+	large_cave_flooded   = params->large_cave_flooded;
 	cavern_limit         = params->cavern_limit;
 	cavern_taper         = params->cavern_taper;
 	cavern_threshold     = params->cavern_threshold;
@@ -173,6 +176,9 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getFloatNoEx("mgv7_cave_width",           cave_width);
 	settings->getS16NoEx("mgv7_large_cave_depth",       large_cave_depth);
 	settings->getS16NoEx("mgv7_lava_depth",             lava_depth);
+	settings->getU16NoEx("mgv7_large_cave_num_min",     large_cave_num_min);
+	settings->getU16NoEx("mgv7_large_cave_num_max",     large_cave_num_max);
+	settings->getFloatNoEx("mgv7_large_cave_flooded",   large_cave_flooded);
 	settings->getFloatNoEx("mgv7_float_mount_density",  float_mount_density);
 	settings->getFloatNoEx("mgv7_float_mount_height",   float_mount_height);
 	settings->getFloatNoEx("mgv7_float_mount_exponent", float_mount_exponent);
@@ -209,6 +215,9 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setFloat("mgv7_cave_width",           cave_width);
 	settings->setS16("mgv7_large_cave_depth",       large_cave_depth);
 	settings->setS16("mgv7_lava_depth",             lava_depth);
+	settings->setU16("mgv7_large_cave_num_min",     large_cave_num_min);
+	settings->setU16("mgv7_large_cave_num_max",     large_cave_num_max);
+	settings->setFloat("mgv7_large_cave_flooded",   large_cave_flooded);
 	settings->setFloat("mgv7_float_mount_density",  float_mount_density);
 	settings->setFloat("mgv7_float_mount_height",   float_mount_height);
 	settings->setFloat("mgv7_float_mount_exponent", float_mount_exponent);

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -46,6 +46,9 @@ struct MapgenV7Params : public MapgenParams {
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 large_cave_num_min = 0;
+	u16 large_cave_num_max = 2;
+	float large_cave_flooded = 0.5f;
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 256;
 	float cavern_threshold = 0.7f;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -46,6 +46,8 @@ struct MapgenV7Params : public MapgenParams {
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = -256;
+	u16 small_cave_num_min = 0;
+	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;
 	u16 large_cave_num_max = 2;
 	float large_cave_flooded = 0.5f;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -68,6 +68,8 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	small_cave_num_min = params->small_cave_num_min;
+	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
 	large_cave_num_max = params->large_cave_num_max;
 	large_cave_flooded = params->large_cave_flooded;
@@ -131,6 +133,8 @@ void MapgenValleysParams::readParams(const Settings *settings)
 	settings->getU16NoEx("mgvalleys_altitude_chill",       altitude_chill);
 	settings->getS16NoEx("mgvalleys_large_cave_depth",     large_cave_depth);
 	settings->getS16NoEx("mgvalleys_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgvalleys_small_cave_num_min",   small_cave_num_min);
+	settings->getU16NoEx("mgvalleys_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgvalleys_large_cave_num_min",   large_cave_num_min);
 	settings->getU16NoEx("mgvalleys_large_cave_num_max",   large_cave_num_max);
 	settings->getFloatNoEx("mgvalleys_large_cave_flooded", large_cave_flooded);
@@ -164,6 +168,8 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setU16("mgvalleys_altitude_chill",       altitude_chill);
 	settings->setS16("mgvalleys_large_cave_depth",     large_cave_depth);
 	settings->setS16("mgvalleys_lava_depth",           lava_depth);
+	settings->setU16("mgvalleys_small_cave_num_min",   small_cave_num_min);
+	settings->setU16("mgvalleys_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgvalleys_large_cave_num_min",   large_cave_num_min);
 	settings->setU16("mgvalleys_large_cave_num_max",   large_cave_num_max);
 	settings->setFloat("mgvalleys_large_cave_flooded", large_cave_flooded);

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -68,6 +68,9 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
 	lava_depth         = params->lava_depth;
+	large_cave_num_min = params->large_cave_num_min;
+	large_cave_num_max = params->large_cave_num_max;
+	large_cave_flooded = params->large_cave_flooded;
 	cavern_limit       = params->cavern_limit;
 	cavern_taper       = params->cavern_taper;
 	cavern_threshold   = params->cavern_threshold;
@@ -124,18 +127,21 @@ MapgenValleysParams::MapgenValleysParams():
 
 void MapgenValleysParams::readParams(const Settings *settings)
 {
-	settings->getFlagStrNoEx("mgvalleys_spflags",        spflags, flagdesc_mapgen_valleys);
-	settings->getU16NoEx("mgvalleys_altitude_chill",     altitude_chill);
-	settings->getS16NoEx("mgvalleys_large_cave_depth",   large_cave_depth);
-	settings->getS16NoEx("mgvalleys_lava_depth",         lava_depth);
-	settings->getU16NoEx("mgvalleys_river_depth",        river_depth);
-	settings->getU16NoEx("mgvalleys_river_size",         river_size);
-	settings->getFloatNoEx("mgvalleys_cave_width",       cave_width);
-	settings->getS16NoEx("mgvalleys_cavern_limit",       cavern_limit);
-	settings->getS16NoEx("mgvalleys_cavern_taper",       cavern_taper);
-	settings->getFloatNoEx("mgvalleys_cavern_threshold", cavern_threshold);
-	settings->getS16NoEx("mgvalleys_dungeon_ymin",       dungeon_ymin);
-	settings->getS16NoEx("mgvalleys_dungeon_ymax",       dungeon_ymax);
+	settings->getFlagStrNoEx("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys);
+	settings->getU16NoEx("mgvalleys_altitude_chill",       altitude_chill);
+	settings->getS16NoEx("mgvalleys_large_cave_depth",     large_cave_depth);
+	settings->getS16NoEx("mgvalleys_lava_depth",           lava_depth);
+	settings->getU16NoEx("mgvalleys_large_cave_num_min",   large_cave_num_min);
+	settings->getU16NoEx("mgvalleys_large_cave_num_max",   large_cave_num_max);
+	settings->getFloatNoEx("mgvalleys_large_cave_flooded", large_cave_flooded);
+	settings->getU16NoEx("mgvalleys_river_depth",          river_depth);
+	settings->getU16NoEx("mgvalleys_river_size",           river_size);
+	settings->getFloatNoEx("mgvalleys_cave_width",         cave_width);
+	settings->getS16NoEx("mgvalleys_cavern_limit",         cavern_limit);
+	settings->getS16NoEx("mgvalleys_cavern_taper",         cavern_taper);
+	settings->getFloatNoEx("mgvalleys_cavern_threshold",   cavern_threshold);
+	settings->getS16NoEx("mgvalleys_dungeon_ymin",         dungeon_ymin);
+	settings->getS16NoEx("mgvalleys_dungeon_ymax",         dungeon_ymax);
 
 	settings->getNoiseParams("mgvalleys_np_filler_depth",       np_filler_depth);
 	settings->getNoiseParams("mgvalleys_np_inter_valley_fill",  np_inter_valley_fill);
@@ -154,18 +160,21 @@ void MapgenValleysParams::readParams(const Settings *settings)
 
 void MapgenValleysParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgvalleys_spflags",        spflags, flagdesc_mapgen_valleys, U32_MAX);
-	settings->setU16("mgvalleys_altitude_chill",     altitude_chill);
-	settings->setS16("mgvalleys_large_cave_depth",   large_cave_depth);
-	settings->setS16("mgvalleys_lava_depth",         lava_depth);
-	settings->setU16("mgvalleys_river_depth",        river_depth);
-	settings->setU16("mgvalleys_river_size",         river_size);
-	settings->setFloat("mgvalleys_cave_width",       cave_width);
-	settings->setS16("mgvalleys_cavern_limit",       cavern_limit);
-	settings->setS16("mgvalleys_cavern_taper",       cavern_taper);
-	settings->setFloat("mgvalleys_cavern_threshold", cavern_threshold);
-	settings->setS16("mgvalleys_dungeon_ymin",       dungeon_ymin);
-	settings->setS16("mgvalleys_dungeon_ymax",       dungeon_ymax);
+	settings->setFlagStr("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys, U32_MAX);
+	settings->setU16("mgvalleys_altitude_chill",       altitude_chill);
+	settings->setS16("mgvalleys_large_cave_depth",     large_cave_depth);
+	settings->setS16("mgvalleys_lava_depth",           lava_depth);
+	settings->setU16("mgvalleys_large_cave_num_min",   large_cave_num_min);
+	settings->setU16("mgvalleys_large_cave_num_max",   large_cave_num_max);
+	settings->setFloat("mgvalleys_large_cave_flooded", large_cave_flooded);
+	settings->setU16("mgvalleys_river_depth",          river_depth);
+	settings->setU16("mgvalleys_river_size",           river_size);
+	settings->setFloat("mgvalleys_cave_width",         cave_width);
+	settings->setS16("mgvalleys_cavern_limit",         cavern_limit);
+	settings->setS16("mgvalleys_cavern_taper",         cavern_taper);
+	settings->setFloat("mgvalleys_cavern_threshold",   cavern_threshold);
+	settings->setS16("mgvalleys_dungeon_ymin",         dungeon_ymin);
+	settings->setS16("mgvalleys_dungeon_ymax",         dungeon_ymax);
 
 	settings->setNoiseParams("mgvalleys_np_filler_depth",       np_filler_depth);
 	settings->setNoiseParams("mgvalleys_np_inter_valley_fill",  np_inter_valley_fill);

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -50,6 +50,9 @@ struct MapgenValleysParams : public MapgenParams {
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = 1;
+	u16 large_cave_num_min = 0;
+	u16 large_cave_num_max = 2;
+	float large_cave_flooded = 0.5f;
 	s16 cavern_limit = -256;
 	s16 cavern_taper = 192;
 	float cavern_threshold = 0.6f;

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -50,6 +50,8 @@ struct MapgenValleysParams : public MapgenParams {
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	s16 lava_depth = 1;
+	u16 small_cave_num_min = 0;
+	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;
 	u16 large_cave_num_max = 2;
 	float large_cave_flooded = 0.5f;


### PR DESCRIPTION
Commit 1:

Randomwalk caves: Add parameters for number and proportion flooded

Add mapgen parameters to set the range of the random number of
randomwalk caves per mapchunk, and to set the proportion that are
flooded with liquids.
Default values are, for now, unchanged from the previous hardcoded
values.
//////////////////////////////////////////////////////
Commit 2:

Add parameters to allow small randomwalk caves

Disabled by default for now, later we could possibly add small
randomwalk caves to the non-mgv6 mapgens.
//////////////////////////////////////////////////////

![screenshot_20190913_013441](https://user-images.githubusercontent.com/3686677/64830110-e7c1f600-d5c6-11e9-906a-aa2d194c6e9e.png)

^ 4 large caves per mapchunk, none flooded, all other caves disabled

Closes #8599
The PR may look large but most is whitespace changes for alignment, so i recommend usng the 'hide whitepace changes' option in the 'files changed' tab.
Also, a lot of the changes are duplicated across the 6 mapgens.
The changes themselves are quite simple.

The 'randomwalk caves', also called 'large caves', are the underground caves that are sometiimes flooded. They are created by pseudorandom number generators instead of 3D noise.
To clarify, mapgen uses 2 other types of cave:
* 'tunnels' that intersect the surface, created by two 3D noises.
* 'caverns', extremely large and deep underground, also created by 3D noise.

Previously, the number of randomwalk caves per mapchunk was hardcoded to a random range of 0 to 2. The proportion flooded by liquids was also hardcoded, at 50%.

The new parameters allow setting the min and max of the random range of the number per mapchunk, and allow fine control over the proportion that are flooded by liquids.

Because the randomwalk caves have lightweight generation not requiring noise, the number of these per mapchunk can be safely significantly increased to create a more interconnected underground network of caves.

//////////////////////////////////////////////

Commit 2 adds parameters to allow the non-mgv6 mapgens to have 'small randomwalk caves'.
Also with settings for min and max of a random range per mapchunk.
Small caves are disabled by default for now, as these have never been present in these mapgens, but a later commit could possibly add some in to make the default underground more interesting.

The non-mgv6 randomwalk cave code actually has the ability to create small RW caves too, because this code was derived from mgv6 cave code. However the small RW caves are unused in non-mgv6 mapgens, partly because we have the 3D noise tunnels.

In a future PR i will create a way to disable the 3D noise tunnels so that users can use small RW caves instead, this will remove the (intensive) calculation of two 3D noises, allowing a lot of small RW caves to be used with no performance loss.

////////////////////////////////

How to test.

In minetest.conf or 'All Settings' menu, use:
mg_flags = light,caves,nodungeons,nodecorations,nobiomes
to remove dungeons.

For any of the 6 relevant mapgens (here fractal for example):
Use:
mgfractal_cave_width = 1000
to reduce tunnel width to zero to disable the 3D noise tunnels.

Use:
mgfractal_small_cave_num_min = 0
mgfractal_small_cave_num_max = 0
mgfractal_large_cave_num_min = 0
mgfractal_large_cave_num_max = 0
with zero values and various random ranges, and fly underground to check for expected behaviour.
Remember that large RW caves only appear below y = -32 (and below y = -256 in mgv5).

With large RW caves present and small RW caves disabled, use:
mgfractal_large_cave_flooded = 0.0
With values between 0.0 and 1.0 to check for expected behaviour. Here it is helpful to make water a light source for easy checking.