### PR TITLE
Make CAMERA_OFFSET configurable.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -617,7 +617,7 @@ near_plane (Near clipping plane) float 0.1 0 0.5
 #   Rendering glitches are possible at large distances from the center of the map.
 #   This setting forces a reset of the map at the specified distance.
 #   The max setting disables the logic.
-camera_offset (Camera offset) int 200 100 31000
+camera_offset (Camera offset) int 512 100 31000
 
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -614,6 +614,11 @@ viewing_range (Viewing range) int 100 20 4000
 #   0.1 = Default, 0.25 = Good value for weaker tablets.
 near_plane (Near clipping plane) float 0.1 0 0.5
 
+#   Rendering glitches are possible at large distances from the center of the map.
+#   This setting forces a reset of the map at the specified distance.
+#   The max setting disables the logic.
+camera_offset (Camera offset) int 200 100 31000
+
 #    Width component of the initial window size.
 screen_w (Screen width) int 1024
 

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -36,7 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "fontengine.h"
 #include "script/scripting_client.h"
 
-#define CAMERA_OFFSET_STEP 200
+static thread_local const s16 CAMERA_OFFSET_STEP = g_settings->getS16("camera_offset");
 #define WIELDMESH_OFFSET_X 55.0f
 #define WIELDMESH_OFFSET_Y -35.0f
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -194,7 +194,7 @@ void set_default_settings(Settings *settings)
 #endif
 	settings->setDefault("cinematic", "false");
 	settings->setDefault("camera_smoothing", "0");
-	settings->setDefault("camera_offset", "200");
+	settings->setDefault("camera_offset", "512");
 	settings->setDefault("cinematic_camera_smoothing", "0.7");
 	settings->setDefault("enable_clouds", "true");
 	settings->setDefault("view_bobbing_amount", "1.0");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -194,6 +194,7 @@ void set_default_settings(Settings *settings)
 #endif
 	settings->setDefault("cinematic", "false");
 	settings->setDefault("camera_smoothing", "0");
+	settings->setDefault("camera_offset", "200");
 	settings->setDefault("cinematic_camera_smoothing", "0.7");
 	settings->setDefault("enable_clouds", "true");
 	settings->setDefault("view_bobbing_amount", "1.0");


### PR DESCRIPTION
Title says it all.

I'd even vote for increasing the default to 1000, since only in fairly extreme situation would the glitches be noticeable. (But that's a different discussion)

Triggered in part by #8889
