### PR TITLE
Improve undersampling settings

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -508,10 +508,11 @@ texture_min_size (Minimum texture size) int 64
 #    when set to higher number than 0.
 fsaa (FSAA) enum 0 0,1,2,4,8,16
 
-#    Undersampling is similar to using lower screen resolution, but it applies
+#    Undersampling is similar to using a lower screen resolution, but it applies
 #    to the game world only, keeping the GUI intact.
-#    It should give significant performance boost at the cost of less detailed image.
-undersampling (Undersampling) enum 0 0,2,3,4
+#    It should give a significant performance boost at the cost of less detailed image.
+#    Higher values result in a less detailed image.
+undersampling (Undersampling) int 1 1 8
 
 [**Shaders]
 

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -35,7 +35,7 @@ RenderingCorePlain::RenderingCorePlain(
 
 void RenderingCorePlain::initTextures()
 {
-	if (!scale)
+	if (scale <= 1)
 		return;
 	v2u32 size{scaledown(scale, screensize.X), scaledown(scale, screensize.Y)};
 	lowres = driver->addRenderTargetTexture(
@@ -44,21 +44,21 @@ void RenderingCorePlain::initTextures()
 
 void RenderingCorePlain::clearTextures()
 {
-	if (!scale)
+	if (scale <= 1)
 		return;
 	driver->removeTexture(lowres);
 }
 
 void RenderingCorePlain::beforeDraw()
 {
-	if (!scale)
+	if (scale <= 1)
 		return;
 	driver->setRenderTarget(lowres, true, true, skycolor);
 }
 
 void RenderingCorePlain::upscale()
 {
-	if (!scale)
+	if (scale <= 1)
 		return;
 	driver->setRenderTarget(0, true, true);
 	v2u32 size{scaledown(scale, screensize.X), scaledown(scale, screensize.Y)};


### PR DESCRIPTION
The setting now accepts values between 1 and 8 in the Advanced Settings menu. Values 0 and 1 now behave the same way (setting it to 1 won't disable MSAA anymore), so there's no need to expose 0 as a value.

Very high undersampling values may be desired when playing on a 4K (or higher) display with slow graphics.

The setting description was also updated to be more detailed.

This closes #8939.

## To do

This PR is a Ready for Review.

## How to test

Set `undersampling` to various values using the Advanced Settings menu, then start a local game or connect to a server.