### PR TITLE
Inventory: Properly revert client predictions

### DIFF
--- a/src/inventory.h
+++ b/src/inventory.h
@@ -323,11 +323,14 @@ public:
 		return false;
 	}
 
-	inline void setModified(bool dirty)
+	inline void setModified(bool dirty = true)
 	{
 		m_dirty = dirty;
-		for (const auto &list : m_lists)
-			list->setModified(dirty);
+		// Set all as handled
+		if (!dirty) {
+			for (const auto &list : m_lists)
+				list->setModified(dirty);
+		}
 	}
 private:
 	// -1 if not found

--- a/src/inventorymanager.cpp
+++ b/src/inventorymanager.cpp
@@ -348,6 +348,13 @@ void IMoveAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 	/* If no items will be moved, don't go further */
 	if (count == 0) {
+		// Undo client prediction. See 'clientApply'
+		if (from_inv.type == InventoryLocation::PLAYER)
+			list_from->setModified();
+
+		if (to_inv.type == InventoryLocation::PLAYER)
+			list_to->setModified();
+
 		infostream<<"IMoveAction::apply(): move was completely disallowed:"
 				<<" count="<<old_count
 				<<" from inv=\""<<from_inv.dump()<<"\""
@@ -658,8 +665,10 @@ void IDropAction::apply(InventoryManager *mgr, ServerActiveObject *player, IGame
 
 		if (actually_dropped_count == 0) {
 			infostream<<"Actually dropped no items"<<std::endl;
-			// Revert client prediction
-			mgr->setInventoryModified(from_inv);
+
+			// Revert client prediction. See 'clientApply'
+			if (from_inv.type == InventoryLocation::PLAYER)
+				list_from->setModified();
 			return;
 		}
 


### PR DESCRIPTION
Caused by incremental inventory sending
Previously everything was overwritten by serializing the entire inventory

Ready to review.

## How to test

1) Use a mod with restricted player inventory actions, like https://github.com/SmallJoker/upgrade_packs
2) Try to move items into these slots

Option 2:
1) Drop an item using code from #8942 
2) Observe correct behaviour (code has only been improved, for less inventory sending)