### PR TITLE
Move profiler graphs to profiler screen and hide spoilers from unprivileged players

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2233,30 +2233,23 @@ void Game::toggleFog()
 
 void Game::toggleDebug()
 {
-	// Initial / 4x toggle: Chat only
+	// Initial / 3x toggle: Chat only
 	// 1x toggle: Debug text with chat
-	// 2x toggle: Debug text with profiler graph
-	// 3x toggle: Debug text and wireframe
+	// 2x toggle: Debug text with chat and wireframe
 	if (!m_game_ui->m_flags.show_debug) {
 		m_game_ui->m_flags.show_debug = true;
-		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = false;
 		m_game_ui->showTranslatedStatusText("Debug info shown");
-	} else if (!m_game_ui->m_flags.show_profiler_graph && !draw_control->show_wireframe) {
-		m_game_ui->m_flags.show_profiler_graph = true;
-		m_game_ui->showTranslatedStatusText("Profiler graph shown");
 	} else if (!draw_control->show_wireframe && client->checkPrivilege("debug")) {
-		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = true;
 		m_game_ui->showTranslatedStatusText("Wireframe shown");
 	} else {
 		m_game_ui->m_flags.show_debug = false;
-		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = false;
 		if (client->checkPrivilege("debug")) {
-			m_game_ui->showTranslatedStatusText("Debug info, profiler graph, and wireframe hidden");
+			m_game_ui->showTranslatedStatusText("Debug info and wireframe hidden");
 		} else {
-			m_game_ui->showTranslatedStatusText("Debug info and profiler graph hidden");
+			m_game_ui->showTranslatedStatusText("Debug info hidden");
 		}
 	}
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1113,7 +1113,7 @@ void Game::run()
 		updateCamera(draw_times.busy_time, dtime);
 		updateSound(dtime);
 		processPlayerInteraction(dtime, m_game_ui->m_flags.show_hud,
-			m_game_ui->m_flags.show_debug);
+			m_game_ui->m_flags.show_basic_debug);
 		updateFrame(&graph, &stats, dtime, cam_view);
 		updateProfilerGraphs(&graph);
 
@@ -2235,16 +2235,21 @@ void Game::toggleDebug()
 {
 	// Initial / 3x toggle: Chat only
 	// 1x toggle: Debug text with chat
-	// 2x toggle: Debug text with chat and wireframe
-	if (!m_game_ui->m_flags.show_debug) {
-		m_game_ui->m_flags.show_debug = true;
+	// 2x toggle: Debug text with chat and wireframe (needs "debug" priv)
+	if (!m_game_ui->m_flags.show_minimal_debug) {
+		m_game_ui->m_flags.show_minimal_debug = true;
+		if (client->checkPrivilege("debug")) {
+			m_game_ui->m_flags.show_basic_debug = true;
+		}
 		draw_control->show_wireframe = false;
 		m_game_ui->showTranslatedStatusText("Debug info shown");
 	} else if (!draw_control->show_wireframe && client->checkPrivilege("debug")) {
+		m_game_ui->m_flags.show_basic_debug = true;
 		draw_control->show_wireframe = true;
 		m_game_ui->showTranslatedStatusText("Wireframe shown");
 	} else {
-		m_game_ui->m_flags.show_debug = false;
+		m_game_ui->m_flags.show_minimal_debug = false;
+		m_game_ui->m_flags.show_basic_debug = false;
 		draw_control->show_wireframe = false;
 		if (client->checkPrivilege("debug")) {
 			m_game_ui->showTranslatedStatusText("Debug info and wireframe hidden");

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -288,6 +288,7 @@ void GameUI::toggleProfiler()
 	updateProfiler();
 
 	if (m_profiler_current_page != 0) {
+		m_flags.show_profiler_graph = true;
 		wchar_t buf[255];
 		const wchar_t* str = wgettext("Profiler shown (page %d of %d)");
 		swprintf(buf, sizeof(buf) / sizeof(wchar_t), str,
@@ -295,6 +296,7 @@ void GameUI::toggleProfiler()
 		delete[] str;
 		showStatusText(buf);
 	} else {
+		m_flags.show_profiler_graph = false;
 		showTranslatedStatusText("Profiler hidden");
 	}
 }

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -92,7 +92,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 {
 	v2u32 screensize = RenderingEngine::get_instance()->getWindowSize();
 
-	if (m_flags.show_debug) {
+	// Minimal debug text contains only info that can't give a gameplay advantage
+	if (m_flags.show_minimal_debug) {
 		static float drawtime_avg = 0;
 		drawtime_avg = drawtime_avg * 0.95 + stats.drawtime * 0.05;
 		u16 fps = 1.0 / stats.dtime_jitter.avg;
@@ -118,9 +119,10 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 	}
 
 	// Finally set the guitext visible depending on the flag
-	m_guitext->setVisible(m_flags.show_debug);
+	m_guitext->setVisible(m_flags.show_minimal_debug);
 
-	if (m_flags.show_debug) {
+	// Basic debug info contains stuff that might give a gameplay advantage
+	if (m_flags.show_basic_debug) {
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 		v3f player_position = player->getPosition();
 
@@ -153,7 +155,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		));
 	}
 
-	m_guitext2->setVisible(m_flags.show_debug);
+	m_guitext2->setVisible(m_flags.show_basic_debug);
 
 	setStaticText(m_guitext_info, translate_string(m_infotext).c_str());
 	m_guitext_info->setVisible(m_flags.show_hud && g_menumgr.menuCount() == 0);
@@ -197,7 +199,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 void GameUI::initFlags()
 {
 	m_flags = GameUI::Flags();
-	m_flags.show_debug = g_settings->getBool("show_debug");
+	m_flags.show_minimal_debug = g_settings->getBool("show_debug");
 }
 
 void GameUI::showMinimap(bool show)
@@ -219,8 +221,10 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 	// Update gui element size and position
 	s32 chat_y = 5;
 
-	if (m_flags.show_debug)
-		chat_y += 2 * g_fontengine->getLineHeight();
+	if (m_flags.show_minimal_debug)
+		chat_y += g_fontengine->getLineHeight();
+	if (m_flags.show_basic_debug)
+		chat_y += g_fontengine->getLineHeight();
 
 	// first pass to calculate height of text to be set
 	const v2u32 &window_size = RenderingEngine::get_instance()->getWindowSize();

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -57,7 +57,8 @@ public:
 		bool show_chat = true;
 		bool show_hud = true;
 		bool show_minimap = false;
-		bool show_debug = true;
+		bool show_minimal_debug = true;
+		bool show_basic_debug = false;
 		bool show_profiler_graph = false;
 	};
 


### PR DESCRIPTION
## The problem I want to solve

1) Debug screen has too many modes. The profiler graphs always bothered me. They're not that often needed. Also, we have an entire key dedicated for profiler info. It does not make sense that profiler graph is not in profiler screen
2) The F5 debug screen contains various "spoilers", e.g. info that can give you a gameplay advantage for free: position, pointed node, pointed entity (including health and armor groups). This completely ruins mods like `orienteering` and `compassgps` in which you can craft items that expose your position and more. The mods get ruined because there's no point in crafting a compass if you can get the yaw/position/whatever “for free” with a simple key press. Multiple players complained.

## What this PR does

1) Move profiler graphs to profiler screen
2) Hide the position, yaw, pitch, mapseed and pointed thing if player does not have the `debug` priv.

As a nice side effect, its now possible to have both profiler graphs and wireframe on the screen at the same time.

## To do

Nothing.

## How to test

- Join any world
- Without `debug` priv: Hit debug key (F5) multiple times, point to entities
- With `debug` priv: Hit debug key multiple times, point to entities
- Hit profiler key (F6) multiple times

If you don't have debug priv, the only debug info you get should be a single line of high-level stuff that is not a spoiler for gameplay. There is only on and off mode. The entity info should not be visible.
If you have the debug priv, there should be 2 debug screens: One with 2 lines of debug info, and one with the writeframe. The entity info should be visible.
The profiler screen should have the profiler graph.