### PR TITLE
Allow grep-ing for on_grant and on_revoke

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -186,7 +186,7 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 		return false, privs_unknown
 	end
 	for priv, _ in pairs(grantprivs) do
-		-- call the on_grant callback
+		-- call the on_grant callbacks
 		core.run_priv_callbacks(grantname, priv, caller, "grant")
 	end
 	core.set_player_privs(grantname, privs)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -259,7 +259,7 @@ core.register_chatcommand("revoke", {
 		end
 
 		for priv, _ in pairs(revoke_privs) do
-			-- call the on_revoke callback
+			-- call the on_revoke callbacks
 			core.run_priv_callbacks(revoke_name, priv, name, "revoke")
 		end
 

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -186,6 +186,7 @@ local function handle_grant_command(caller, grantname, grantprivstr)
 		return false, privs_unknown
 	end
 	for priv, _ in pairs(grantprivs) do
+		-- call the on_grant callback
 		core.run_priv_callbacks(grantname, priv, caller, "grant")
 	end
 	core.set_player_privs(grantname, privs)
@@ -258,6 +259,7 @@ core.register_chatcommand("revoke", {
 		end
 
 		for priv, _ in pairs(revoke_privs) do
+			-- call the on_revoke callback
 			core.run_priv_callbacks(revoke_name, priv, name, "revoke")
 		end
 


### PR DESCRIPTION
Just two code comments are added.

- Goal of the PR: Adding code comments to make `grep`-ing on_grant and on_revoke.
- How does the PR work? It adds two code comments.
- Does it resolve any reported issue? No, but @Wuzzy2 complained about this on irc: http://irc.minetest.net/minetest-dev/2019-09-18#i_5593423
- why is this PR needed? It is useful for looking up the source code.

Here are the callbacks in doc:
https://github.com/minetest/minetest/blob/5c9983400fb085167bf11f8a0483b8e8f6dd8a24/doc/lua_api.txt#L7107-L7113
## To do

This PR is a Ready for Review.

## How to test

See that code comments with "on_grant" and "on_revoke" in them are added.
