### PR TITLE
Punchwear (improved)

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -256,6 +256,18 @@ function core.register_tool(name, tooldef)
 	end
 	-- END Legacy stuff
 
+	-- This isn't just legacy, but more of a convenience feature
+	local toolcaps = tooldef.tool_capabilities
+	if toolcaps and toolcaps.punch_attack_uses == nil then
+		for _, cap in pairs(toolcaps.groupcaps or {}) do
+			local level = (cap.maxlevel or 0) - 1
+			if (cap.uses or 0) ~= 0 and level >= 0 then
+				toolcaps.punch_attack_uses = cap.uses * (3 ^ level)
+				break
+			end
+		end
+	end
+
 	core.register_item(name, tooldef)
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6256,7 +6256,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         liquids_pointable = false,
 
-        -- See "Tools" section
+        -- See "Tools" section for an example including explanation
         tool_capabilities = {
             full_punch_interval = 1.0,
             max_drop_level = 0,
@@ -6266,6 +6266,14 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
                          uses = 20, maxlevel = 2},
             },
             damage_groups = {groupname = damage},
+
+            punch_attack_uses = nil,
+            -- Amount of uses this tool has for attacking players and entities
+            -- by punching them (0 = infinite uses).
+            -- For compatibility, this is automatically set from the first
+            -- suitable groupcap using the forumla "uses * 3^(maxlevel - 1)".
+            -- It is recommend to set this explicitly instead of relying on the
+            -- fallback behavior.
         },
 
         node_placement_prediction = nil,

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -624,7 +624,7 @@ void LuaEntitySAO::getStaticData(std::string *result) const
 	*result = os.str();
 }
 
-int LuaEntitySAO::punch(v3f dir,
+u16 LuaEntitySAO::punch(v3f dir,
 		const ToolCapabilities *toolcap,
 		ServerActiveObject *puncher,
 		float time_from_last_punch)
@@ -1272,7 +1272,7 @@ void PlayerSAO::setLookPitchAndSend(const float pitch)
 	m_env->getGameDef()->SendMovePlayer(m_peer_id);
 }
 
-int PlayerSAO::punch(v3f dir,
+u16 PlayerSAO::punch(v3f dir,
 	const ToolCapabilities *toolcap,
 	ServerActiveObject *puncher,
 	float time_from_last_punch)

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -122,10 +122,10 @@ public:
 	bool isStaticAllowed() const
 	{ return m_prop.static_save; }
 	void getStaticData(std::string *result) const;
-	int punch(v3f dir,
+	u16 punch(v3f dir,
 		const ToolCapabilities *toolcap = nullptr,
 		ServerActiveObject *puncher = nullptr,
-		float time_from_last_punch = 1000000);
+		float time_from_last_punch = 1000000.0f);
 	void rightClick(ServerActiveObject *clicker);
 	void setPos(const v3f &pos);
 	void moveTo(v3f pos, bool continuous);
@@ -258,7 +258,7 @@ public:
 		Interaction interface
 	*/
 
-	int punch(v3f dir,
+	u16 punch(v3f dir,
 		const ToolCapabilities *toolcap,
 		ServerActiveObject *puncher,
 		float time_from_last_punch);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1162,8 +1162,12 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			u16 src_original_hp = pointed_object->getHP();
 			u16 dst_origin_hp = playersao->getHP();
 
-			pointed_object->punch(dir, &toolcap, playersao,
+			u16 wear = pointed_object->punch(dir, &toolcap, playersao,
 					time_from_last_punch);
+
+			bool changed = punchitem.addWear(wear, m_itemdef);
+			if (changed)
+				playersao->setWieldedItem(punchitem);
 
 			// If the object is a player and its HP changed
 			if (src_original_hp != pointed_object->getHP() &&

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -164,11 +164,7 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_pushboolean(L, i.liquids_pointable);
 	lua_setfield(L, -2, "liquids_pointable");
 	if (i.type == ITEM_TOOL) {
-		push_tool_capabilities(L, ToolCapabilities(
-			i.tool_capabilities->full_punch_interval,
-			i.tool_capabilities->max_drop_level,
-			i.tool_capabilities->groupcaps,
-			i.tool_capabilities->damageGroups));
+		push_tool_capabilities(L, *i.tool_capabilities);
 		lua_setfield(L, -2, "tool_capabilities");
 	}
 	push_groups(L, i.groups);
@@ -1253,7 +1249,8 @@ void push_tool_capabilities(lua_State *L,
 {
 	lua_newtable(L);
 	setfloatfield(L, -1, "full_punch_interval", toolcap.full_punch_interval);
-		setintfield(L, -1, "max_drop_level", toolcap.max_drop_level);
+	setintfield(L, -1, "max_drop_level", toolcap.max_drop_level);
+	setintfield(L, -1, "punch_attack_uses", toolcap.punch_attack_uses);
 		// Create groupcaps table
 		lua_newtable(L);
 		// For each groupcap
@@ -1375,6 +1372,7 @@ ToolCapabilities read_tool_capabilities(
 	ToolCapabilities toolcap;
 	getfloatfield(L, table, "full_punch_interval", toolcap.full_punch_interval);
 	getintfield(L, table, "max_drop_level", toolcap.max_drop_level);
+	getintfield(L, table, "punch_attack_uses", toolcap.punch_attack_uses);
 	lua_getfield(L, table, "groupcaps");
 	if(lua_istable(L, -1)){
 		int table_groupcaps = lua_gettop(L);

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -187,7 +187,8 @@ int ObjectRef::l_punch(lua_State *L)
 	u16 dst_origin_hp = puncher->getHP();
 
 	// Do it
-	co->punch(dir, &toolcap, puncher, time_from_last_punch);
+	u16 wear = co->punch(dir, &toolcap, puncher, time_from_last_punch);
+	lua_pushnumber(L, wear);
 
 	// If the punched is a player, and its HP changed
 	if (src_original_hp != co->getHP() &&
@@ -202,7 +203,7 @@ int ObjectRef::l_punch(lua_State *L)
 		getServer(L)->SendPlayerHPOrDie((PlayerSAO *)puncher,
 				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, co));
 	}
-	return 0;
+	return 1;
 }
 
 // right_click(self, clicker); clicker = an another ObjectRef

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -133,10 +133,10 @@ public:
 	{return true;}
 
 	// Returns tool wear
-	virtual int punch(v3f dir,
-			const ToolCapabilities *toolcap=NULL,
-			ServerActiveObject *puncher=NULL,
-			float time_from_last_punch=1000000)
+	virtual u16 punch(v3f dir,
+			const ToolCapabilities *toolcap = nullptr,
+			ServerActiveObject *puncher = nullptr,
+			float time_from_last_punch = 1000000.0f)
 	{ return 0; }
 	virtual void rightClick(ServerActiveObject *clicker)
 	{}

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -56,7 +56,10 @@ void ToolGroupCap::fromJson(const Json::Value &json)
 
 void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 {
-	writeU8(os, 4); // protocol_version >= 37
+	if (protocol_version >= 38)
+		writeU8(os, 5);
+	else
+		writeU8(os, 4); // proto == 37
 	writeF32(os, full_punch_interval);
 	writeS16(os, max_drop_level);
 	writeU32(os, groupcaps.size());
@@ -79,6 +82,9 @@ void ToolCapabilities::serialize(std::ostream &os, u16 protocol_version) const
 		os << serializeString(damageGroup.first);
 		writeS16(os, damageGroup.second);
 	}
+
+	if (protocol_version >= 38)
+		writeU16(os, rangelim(punch_attack_uses, 0, U16_MAX));
 }
 
 void ToolCapabilities::deSerialize(std::istream &is)
@@ -111,6 +117,9 @@ void ToolCapabilities::deSerialize(std::istream &is)
 		s16 rating = readS16(is);
 		damageGroups[name] = rating;
 	}
+
+	if (version >= 5)
+		punch_attack_uses = readU16(is);
 }
 
 void ToolCapabilities::serializeJson(std::ostream &os) const
@@ -118,6 +127,7 @@ void ToolCapabilities::serializeJson(std::ostream &os) const
 	Json::Value root;
 	root["full_punch_interval"] = full_punch_interval;
 	root["max_drop_level"] = max_drop_level;
+	root["punch_attack_uses"] = punch_attack_uses;
 
 	Json::Value groupcaps_object;
 	for (auto groupcap : groupcaps) {
@@ -144,6 +154,8 @@ void ToolCapabilities::deserializeJson(std::istream &is)
 			full_punch_interval = root["full_punch_interval"].asFloat();
 		if (root["max_drop_level"].isInt())
 			max_drop_level = root["max_drop_level"].asInt();
+		if (root["punch_attack_uses"].isInt())
+			punch_attack_uses = root["punch_attack_uses"].asInt();
 
 		Json::Value &groupcaps_object = root["groupcaps"];
 		if (groupcaps_object.isObject()) {
@@ -236,18 +248,8 @@ HitParams getHitParams(const ItemGroupList &armor_groups,
 		damage += damageGroup.second * punch_interval_multiplier * armor / 100.0;
 	}
 
-	// Just pick the first group that gives an amount of uses
-	// This should eventually be replaced with a better mechanism.
-	for (const auto &groupcap : tp->groupcaps) {
-		const ToolGroupCap &cap = groupcap.second;
-		int level = cap.maxlevel - 1;
-		if (cap.uses == 0 || level < 0)
-			continue;
-
-		result_wear = 1.0f / cap.uses / powf(3.0f, level);
-		break;
-	}
-	result_wear *= punch_interval_multiplier;
+	if (tp->punch_attack_uses > 0)
+		result_wear = 1.0f / tp->punch_attack_uses * punch_interval_multiplier;
 
 	u16 wear_i = U16_MAX * result_wear;
 	return {damage, wear_i};

--- a/src/tool.h
+++ b/src/tool.h
@@ -103,9 +103,9 @@ DigParams getDigParams(const ItemGroupList &groups,
 struct HitParams
 {
 	s16 hp;
-	s16 wear;
+	u16 wear;
 
-	HitParams(s16 hp_=0, s16 wear_=0):
+	HitParams(s16 hp_ = 0, u16 wear_ = 0):
 		hp(hp_),
 		wear(wear_)
 	{}

--- a/src/tool.h
+++ b/src/tool.h
@@ -60,17 +60,20 @@ struct ToolCapabilities
 	int max_drop_level;
 	ToolGCMap groupcaps;
 	DamageGroup damageGroups;
+	int punch_attack_uses;
 
 	ToolCapabilities(
-			float full_punch_interval_=1.4,
-			int max_drop_level_=1,
+			float full_punch_interval_ = 1.4f,
+			int max_drop_level_ = 1,
 			const ToolGCMap &groupcaps_ = ToolGCMap(),
-			const DamageGroup &damageGroups_ = DamageGroup()
+			const DamageGroup &damageGroups_ = DamageGroup(),
+			int punch_attack_uses_ = 0
 	):
 		full_punch_interval(full_punch_interval_),
 		max_drop_level(max_drop_level_),
 		groupcaps(groupcaps_),
-		damageGroups(damageGroups_)
+		damageGroups(damageGroups_),
+		punch_attack_uses(punch_attack_uses_)
 	{}
 
 	void serialize(std::ostream &os, u16 version) const;


### PR DESCRIPTION
replaces #8862 
~~Sorry for not just reviewing and allowing the submitter to fix the PR, there were too many small issues that I could more easily just solve myself.~~

Note that the number of uses calculation is identical to the old PR.

## Discussion of the implementation

Existing tools automatically receive a value for `punch_attack_uses` by inserting the first suitable  groupcap into the formula `uses * 3^(maxlevel - 1)`.
This can of course be overriden or disabled by modders.

### The formula in practice

Resulting use counts for MTG tools (full punches):

tool | uses
---- | ----
default:sword_wood | 10
default:sword_stone | 20
default:sword_bronze | 75
default:sword_steel | 90
default:sword_mese | 270
default:sword_diamond | 360

## How to test

1. Punch another player and observe how the sword gets damaged.
