### PR TITLE
Use first line of description as short description

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2863,8 +2863,13 @@ void GUIFormSpecMenu::drawList(const ListDrawSpec &s, int layer,
 				// Draw tooltip
 				if (hovering && !m_selected_item) {
 					std::string tooltip = item.getDescription(m_client->idef());
-					if (m_tooltip_append_itemname)
+					if (!isShiftPressed) {
+						// only show a short description: the first line
+						std::stringstream sstr(tooltip);
+						std::getline(sstr, tooltip, '\n');
+					} else if (m_tooltip_append_itemname) {
 						tooltip += "\n[" + item.name + "]";
+					}
 					showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,
 							m_default_tooltip_bgcolor);
 				}
@@ -3605,6 +3610,9 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			return true;
 		}
 
+		if (event.KeyInput.Key == KEY_LSHIFT)
+			isShiftPressed = event.KeyInput.PressedDown;
+
 		if (m_client != NULL && event.KeyInput.PressedDown &&
 				(kp == getKeySetting("keymap_screenshot"))) {
 			m_client->makeScreenshot();
@@ -3638,7 +3646,6 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			}
 			return true;
 		}
-
 	}
 
 	/* Mouse event other than movement, or crossing the border of inventory

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -503,6 +503,8 @@ private:
 	fs_key_pendig current_keys_pending;
 	std::string current_field_enter_pending = "";
 
+	bool isShiftPressed = false;
+
 	void parseElement(parserData* data, const std::string &element);
 
 	void parseSize(parserData* data, const std::string &element);


### PR DESCRIPTION
- If you hold shift and hover with your cursor you can see the full description, otherwise only the first line.
- Heavily related to  #8752 and  #8956. See there for justification of this PR.

## To do

This PR is a Work in Progress.

- [ ] Documentation
- [ ] Properly detect whether shift is hold. (Currently it often doesn't work, eg. when a `field` element is focused.) (How should I do this?)
- [ ] Listen to requests that other people will have.

## How to test

Use minetest_game and hover with cursor over a cart item or a screwdriver. Do this with and without holding shift.
