### PR TITLE
Disallow overflow in v3d to v3s16 conversion

### DIFF
--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -279,6 +279,7 @@ inline v3s16 floatToInt(v3f p, f32 d)
 
 /*
 	Returns integer position of node in given double precision position
+	with overflow testing
  */
 inline v3s16 doubleToInt(v3d p, double d)
 {
@@ -288,12 +289,10 @@ inline v3s16 doubleToInt(v3d p, double d)
 		(p.Y + (p.Y > 0 ? d / 2 : -d / 2)) / d,
 		(p.Z + (p.Z > 0 ? d / 2 : -d / 2)) / d);
 	// Do not overflow if p is outside map boundaries
-	const double s16_min = -32768.0;
-	const double s16_max = 32767.0;
 	return v3s16(
-		rangelim(p_adjusted.X, s16_min, s16_max),
-		rangelim(p_adjusted.Y, s16_min, s16_max),
-		rangelim(p_adjusted.Z, s16_min, s16_max));
+		rangelim(p_adjusted.X, S16_MIN, S16_MAX),
+		rangelim(p_adjusted.Y, S16_MIN, S16_MAX),
+		rangelim(p_adjusted.Z, S16_MIN, S16_MAX));
 }
 
 /*

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -282,10 +282,18 @@ inline v3s16 floatToInt(v3f p, f32 d)
  */
 inline v3s16 doubleToInt(v3d p, double d)
 {
-	return v3s16(
+	// Adjust p for correct rounding
+	v3d p_adjusted(
 		(p.X + (p.X > 0 ? d / 2 : -d / 2)) / d,
 		(p.Y + (p.Y > 0 ? d / 2 : -d / 2)) / d,
 		(p.Z + (p.Z > 0 ? d / 2 : -d / 2)) / d);
+	// Do not overflow if p is outside map boundaries
+	const double s16_min = -32768.0;
+	const double s16_max = 32767.0;
+	return v3s16(
+		rangelim(p_adjusted.X, s16_min, s16_max),
+		rangelim(p_adjusted.Y, s16_min, s16_max),
+		rangelim(p_adjusted.Z, s16_min, s16_max));
 }
 
 /*


### PR DESCRIPTION
It affects minetest.get_node and other functions if the position is outside the map boundaries.
If I remember correctly, the emerge chat command could cause a huge map generation if it is used near map boundaries and one of the positions overflows.
I did not change `floatToInt` because numbers from lua are in double format.

The PR may fix #8909.

## To do

Test if there are any regressions

## How to test

You can install the [LuaCmd mod](https://wiki.minetest.net/Mods/LuaCmd) and execute this in the chat:
`/lua p = vector.round(me:get_pos()) p.x = p.x + 0x10000 print(minetest.pos_to_string(p) .. " " .. minetest.get_node(p).name)`
Without the PR, it shows the node at the player's feed although the position is not inside the map.