### PR TITLE
Textures: Load base pack only as last fallback

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -122,9 +122,11 @@ std::string getImagePath(std::string path)
 
 	Utilizes a thread-safe cache.
 */
-std::string getTexturePath(const std::string &filename)
+std::string getTexturePath(const std::string &filename, bool *is_base_pack)
 {
 	std::string fullpath;
+	if (is_base_pack)
+		*is_base_pack = false;
 	/*
 		Check from cache
 	*/
@@ -154,6 +156,8 @@ std::string getTexturePath(const std::string &filename)
 		std::string testpath = base_path + DIR_DELIM + filename;
 		// Check all filename extensions. Returns "" if not found.
 		fullpath = getImagePath(testpath);
+		if (is_base_pack && !fullpath.empty())
+			*is_base_pack = true;
 	}
 
 	// Add to cache (also an empty result is cached)
@@ -215,9 +219,11 @@ public:
 		bool need_to_grab = true;
 
 		// Try to use local texture instead if asked to
-		if (prefer_local){
-			std::string path = getTexturePath(name);
-			if (!path.empty()) {
+		if (prefer_local) {
+			bool is_base_pack;
+			std::string path = getTexturePath(name, &is_base_pack);
+			// Ignore base pack
+			if (!path.empty() && !is_base_pack) {
 				video::IImage *img2 = RenderingEngine::get_video_driver()->
 					createImageFromFile(path.c_str());
 				if (img2){

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -125,6 +125,9 @@ std::string getImagePath(std::string path)
 std::string getTexturePath(const std::string &filename, bool *is_base_pack)
 {
 	std::string fullpath;
+
+	// This can set a wrong value on cached textures, but is irrelevant because
+	// is_base_pack is only passed when initializing the textures the first time
 	if (is_base_pack)
 		*is_base_pack = false;
 	/*

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -64,7 +64,7 @@ std::string getImagePath(std::string path);
 
 	Utilizes a thread-safe cache.
 */
-std::string getTexturePath(const std::string &filename);
+std::string getTexturePath(const std::string &filename, bool *is_base_pack = nullptr);
 
 void clearTextureNameCache();
 


### PR DESCRIPTION
Fixes #8955 by skipping the base texture pack for the initial media loading. If the texture does not exist by the time it's used first, it can be loaded from base pack as well.

## To do

Ready for Review

## How to test

1) Disable the currently active texture pack
2) Remove `player_back.png` and `player.png` from any mod that adds those but minimal
3) Use two new/different textures in `base/pack` to later tell the difference
4) Join a minimal world: The minimal game's textures are used
5) Remove the minimal textures as well
6) Join a minimal world: The base pack images are used
7) Finally remove the base pack textures
8) Generates dummy textures (sanity check, or you did something wrong)
