### PR TITLE
Waves generated with Perlin-type noise

### DIFF
--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -46,6 +46,41 @@ float smoothTriangleWave(float x)
 	return smoothCurve(triangleWave(x)) * 2.0 - 1.0;
 }
 
+#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
+
+//
+// Simple, fast noise function.
+// See: https://gist.github.com/patriciogonzalezvivo/670c22f3966e662d2f83
+//
+vec4 perm(vec4 x)
+{
+	return mod(((x * 34.0) + 1.0) * x, 289.0);
+}
+
+float snoise(vec3 p)
+{
+	vec3 a = floor(p);
+	vec3 d = p - a;
+	d = d * d * (3.0 - 2.0 * d);
+
+	vec4 b = a.xxyy + vec4(0.0, 1.0, 0.0, 1.0);
+	vec4 k1 = perm(b.xyxy);
+	vec4 k2 = perm(k1.xyxy + b.zzww);
+
+	vec4 c = k2 + a.zzzz;
+	vec4 k3 = perm(c);
+	vec4 k4 = perm(c + 1.0);
+
+	vec4 o1 = fract(k3 * (1.0 / 41.0));
+	vec4 o2 = fract(k4 * (1.0 / 41.0));
+
+	vec4 o3 = o2 * d.z + o1 * (1.0 - d.z);
+	vec2 o4 = o3.yw * d.x + o3.xz * (1.0 - d.x);
+
+	return o4.y * d.y + o4.x * (1.0 - d.y);
+}
+
+#endif
 
 void main(void)
 {
@@ -75,12 +110,19 @@ float disp_z;
 		smoothTriangleWave(animationTimer * 13.0 + tOffset)) * 0.5;
 #endif
 
+	worldPosition = (mWorld * gl_Vertex).xyz;
 
 #if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
+	// Generate waves with Perlin-type noise.
+	// The constants are calibrated such that they roughly
+	// correspond to the old sine waves.
 	vec4 pos = gl_Vertex;
-	pos.y -= 2.0;
-	float posYbuf = (pos.z / WATER_WAVE_LENGTH + animationTimer * WATER_WAVE_SPEED * WATER_WAVE_LENGTH);
-	pos.y -= sin(posYbuf) * WATER_WAVE_HEIGHT + sin(posYbuf / 7.0) * WATER_WAVE_HEIGHT;
+	vec3 wavePos = worldPosition + cameraOffset;
+	wavePos.x /= WATER_WAVE_LENGTH * 3;
+	wavePos.z /= WATER_WAVE_LENGTH * 2;
+	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10;
+	pos.y += snoise(wavePos) *
+		WATER_WAVE_HEIGHT * 5 - WATER_WAVE_HEIGHT * 5;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	vec4 pos = gl_Vertex;
@@ -101,7 +143,6 @@ float disp_z;
 
 
 	vPosition = gl_Position.xyz;
-	worldPosition = (mWorld * gl_Vertex).xyz;
 
 	// Don't generate heightmaps when too far from the eye
 	float dist = distance (vec3(0.0, 0.0, 0.0), vPosition);

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -46,7 +46,9 @@ float smoothTriangleWave(float x)
 	return smoothCurve(triangleWave(x)) * 2.0 - 1.0;
 }
 
-#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
+#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || \
+	MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || \
+	MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
 
 //
 // Simple, fast noise function.
@@ -100,7 +102,8 @@ void main(void)
 
 float disp_x;
 float disp_z;
-#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || (MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
+#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES) || \
+	(MATERIAL_TYPE == TILE_MATERIAL_WAVING_PLANTS && ENABLE_WAVING_PLANTS)
 	vec4 pos2 = mWorld * gl_Vertex;
 	float tOffset = (pos2.x + pos2.y) * 0.001 + pos2.z * 0.002;
 	disp_x = (smoothTriangleWave(animationTimer * 23.0 + tOffset) +
@@ -112,17 +115,20 @@ float disp_z;
 
 	worldPosition = (mWorld * gl_Vertex).xyz;
 
-#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
+#if (MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT || \
+	MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_OPAQUE || \
+	MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_BASIC) && ENABLE_WAVING_WATER
 	// Generate waves with Perlin-type noise.
 	// The constants are calibrated such that they roughly
 	// correspond to the old sine waves.
 	vec4 pos = gl_Vertex;
 	vec3 wavePos = worldPosition + cameraOffset;
+	// The waves are slightly stretched along the z-axis to get
+	// wave-fronts along the x-axis.
 	wavePos.x /= WATER_WAVE_LENGTH * 3;
 	wavePos.z /= WATER_WAVE_LENGTH * 2;
 	wavePos.z += animationTimer * WATER_WAVE_SPEED * 10;
-	pos.y += snoise(wavePos) *
-		WATER_WAVE_HEIGHT * 5 - WATER_WAVE_HEIGHT * 5;
+	pos.y += (snoise(wavePos) - 1) * WATER_WAVE_HEIGHT * 5;
 	gl_Position = mWorldViewProj * pos;
 #elif MATERIAL_TYPE == TILE_MATERIAL_WAVING_LEAVES && ENABLE_WAVING_LEAVES
 	vec4 pos = gl_Vertex;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -795,6 +795,7 @@ static void getTileInfo(
 		v3s16 &p_corrected,
 		v3s16 &face_dir_corrected,
 		u16 *lights,
+		u8 &waving,
 		TileSpec &tile
 	)
 {
@@ -842,6 +843,7 @@ static void getTileInfo(
 
 	getNodeTile(n, p_corrected, face_dir_corrected, data, tile);
 	const ContentFeatures &f = ndef->get(n);
+	waving = f.waving;
 	tile.emissive_light = f.light_source;
 
 	// eg. water and glass
@@ -876,6 +878,10 @@ static void updateFastFaceRow(
 		const v3s16 &&face_dir,
 		std::vector<FastFace> &dest)
 {
+	static thread_local const bool waving_liquids =
+		g_settings->getBool("enable_shaders") &&
+		g_settings->getBool("enable_waving_water");
+
 	v3s16 p = startpos;
 
 	u16 continuous_tiles_count = 1;
@@ -884,10 +890,11 @@ static void updateFastFaceRow(
 	v3s16 p_corrected;
 	v3s16 face_dir_corrected;
 	u16 lights[4] = {0, 0, 0, 0};
+	u8 waving;
 	TileSpec tile;
 	getTileInfo(data, p, face_dir,
 			makes_face, p_corrected, face_dir_corrected,
-			lights, tile);
+		    lights, waving, tile);
 
 	// Unroll this variable which has a significant build cost
 	TileSpec next_tile;
@@ -910,12 +917,15 @@ static void updateFastFaceRow(
 			getTileInfo(data, p_next, face_dir,
 					next_makes_face, next_p_corrected,
 					next_face_dir_corrected, next_lights,
+					waving,
 					next_tile);
 
 			if (next_makes_face == makes_face
 					&& next_p_corrected == p_corrected + translate_dir
 					&& next_face_dir_corrected == face_dir_corrected
 					&& memcmp(next_lights, lights, ARRLEN(lights) * sizeof(u16)) == 0
+					// don't tile waving water if we trying to animate it
+					&& (waving != 3 || !waving_liquids)
 					&& next_tile.isTileable(tile)) {
 				next_is_different = false;
 				continuous_tiles_count++;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -894,7 +894,7 @@ static void updateFastFaceRow(
 	TileSpec tile;
 	getTileInfo(data, p, face_dir,
 			makes_face, p_corrected, face_dir_corrected,
-		    lights, waving, tile);
+			lights, waving, tile);
 
 	// Unroll this variable which has a significant build cost
 	TileSpec next_tile;
@@ -924,7 +924,7 @@ static void updateFastFaceRow(
 					&& next_p_corrected == p_corrected + translate_dir
 					&& next_face_dir_corrected == face_dir_corrected
 					&& memcmp(next_lights, lights, ARRLEN(lights) * sizeof(u16)) == 0
-					// don't tile waving water if we trying to animate it
+					// Don't apply fast faces to waving water.
 					&& (waving != 3 || !waving_liquids)
 					&& next_tile.isTileable(tile)) {
 				next_is_different = false;


### PR DESCRIPTION
See #8976, for more info and a demo-video.

This is an implementation. Should be ready for testing.
The numbers on the shaders are calibrated such that the settings roughly behave like they did for the sine waves.

Note that when the waves are enabled (shaders and waves) the tiling for water surface tiles is disabled (i.e. generated more tiles for water). With an all water scene and view_range of 240 that causes about a 8% performance penalty. Again, only when shader and waving_liquids are enabled, which presumably is on fast machines only, and with many water nodes only.