### PR TITLE
Formspec: make bgcolor element less confusing and allow setting fullscreen color

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2107,9 +2107,9 @@ Elements
 ### `bgcolor[<bgcolor>;<fullscreen>;<fbgcolor>]`
 
 * Sets background color of formspec.
-* `bgcolor` and `fbgcolor` are `ColorString`s, they define the color of the
-  non-fullscreen and the fullscreen background.
-* `fullscreen` can be one of the following:
+* `bgcolor` and `fbgcolor` (optional) are `ColorString`s, they define the color
+  of the non-fullscreen and the fullscreen background.
+* `fullscreen` (optional) can be one of the following:
   * `false`: Only the non-fullscreen background color is drawn. (default)
   * `true`: Only the fullscreen background color is drawn.
   * `both`: The non-fullscreen and the fullscreen background color are drawn.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2104,11 +2104,19 @@ Elements
 
 * Show an inventory image of registered item/node
 
-### `bgcolor[<color>;<fullscreen>]`
+### `bgcolor[<bgcolor>;<fullscreen>;<fbgcolor>]`
 
-* Sets background color of formspec as `ColorString`
-* If `true`, a fullscreen background is drawn and the color is ignored
-  (does not affect the size of the formspec)
+* Sets background color of formspec.
+* `bgcolor` and `fbgcolor` are `ColorString`s, they define the color of the
+  non-fullscreen and the fullscreen background.
+* `fullscreen` can be one of the following:
+  * `false`: Only the non-fullscreen background color is drawn. (default)
+  * `true`: Only the fullscreen background color is drawn.
+  * `both`: The non-fullscreen and the fullscreen background color are drawn.
+  * `neither`: No background color is drawn.
+* Note: Leave a parameter empty to not modify the value.
+* Note: `fbgcolor`, leaving parameters empty and values for `fullscreen` that
+  are not bools are only available since formspec version 3.
 
 ### `background[<X>,<Y>;<W>,<H>;<texture name>]`
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -369,6 +369,7 @@ protected:
 	bool m_lock = false;
 	v2u32 m_lockscreensize;
 
+	bool m_bgnonfullscreen;
 	bool m_bgfullscreen;
 	bool m_slotborder;
 	video::SColor m_bgcolor;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -231,6 +231,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		background9[]: 9-slice scaling parameters
 	FORMSPEC VERSION 3:
 		Formspec elements are drawn in the order of definition
+		bgcolor[]: use 3 parameters (bgcolor, formspec (now an enum), fbgcolor)
 */
 #define FORMSPEC_API_VERSION 3
 


### PR DESCRIPTION
- Goal of the PR: less confusion and full backwards-compatibility
- Now that minetest uses formspec versions, it is possible to add a new parameter to an old element. The `bgcolor` element now uses 3 parameters: The `bgcolor`, an enum parameter to choose whether the `bgcolor`, the fullscreen background color, both or neither are drawn and the color for the fulscreen background.
- Fixes #8985.
Closes #8992. (I haven't see that PR before making this one. \>\_\<)
Closes #9018, if this PR is merged first.
Fixes #9169.

## To do

This PR is a Ready for Review.

## How to test

```lua
local base_formspec =
	"formspec_version[3]"..
	"size[10,8]"..
	"button[3.5,6.5;3,1;btn;Set]"..
	"textarea[1,1;8,5;ta;Formspec elements in here:;"

local clicked_node_pos

minetest.register_node("test:node", {
	description = "test node",
	tiles = {"default_wood.png^heart.png"},
	groups = {choppy = 3, oddly_breakable_by_hand = 3},
	on_construct = function(pos)
		local meta = minetest.get_meta(pos)
		meta:set_string("mformspec", "bgcolor[;;]")
		meta:mark_as_private("mformspec")
	end,
	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
		local f = minetest.get_meta(pos):get_string("mformspec")
		minetest.show_formspec(clicker:get_player_name(), "test:node_formspec",
				base_formspec .. minetest.formspec_escape(f) .. "]" .. f)
		clicked_node_pos = pos
	end,
})

minetest.register_on_player_receive_fields(function(player, formname, fields)
	if formname ~= "test:node_formspec" then
		return
	end
	if fields.btn and fields.ta then
		local f = fields.ta
		minetest.get_meta(clicked_node_pos):set_string("mformspec", f)
		minetest.show_formspec(player:get_player_name(), "test:node_formspec",
				base_formspec .. minetest.formspec_escape(f) .. "]" .. f)
	end
end)


minetest.register_chatcommand("bgcolor", {
	params = "<bgcolor>;<fullscreen>;<fbgcolor>",
	description = "open a formspec with the given values as parameters to bgcolor",
	privs = {},
	func = function(name, param)
		minetest.show_formspec(name, "test:chatcommand_formspec",
				"formspec_version[3]size[10,8]bgcolor[" .. param .. "]")
		return true, "showing formspec"
	end,
})
```
