### PR TITLE
Advanced settings: Count only flags without "no" prefix

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -688,14 +688,16 @@ local function create_change_setting_formspec(dialogdata)
 		height = height - 1
 
 		local fields = {} -- To build formspec
-		for i, name in ipairs(setting.possible) do
+		local j = 1
+		for _, name in ipairs(setting.possible) do
 			if name:sub(1, 2) ~= "no" then
 				local x = 0.5
-				local y = height + i / 2 - 0.75
-				if i - 1 >= flags_count / 2 then -- 2nd column
+				local y = height + j / 2 - 0.75
+				if j - 1 >= flags_count / 2 then -- 2nd column
 					x = 5
 					y = y - max_height
 				end
+				j = j + 1;
 				local checkbox_name = "cb_" .. name
 				local is_enabled = flags[name] == true -- to get false if nil
 				checkboxes[checkbox_name] = is_enabled

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1615,7 +1615,7 @@ mgv7_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0, 2
 [*Mapgen Carpathian]
 
 #    Map generation attributes specific to Mapgen Carpathian.
-mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns,norivers caverns,nocaverns,rivers,norivers
+mgcarpathian_spflags (Mapgen Carpathian specific flags) flags caverns,norivers caverns,rivers,nocaverns,norivers
 
 #    Defines the base ground level.
 mgcarpathian_base_level (Base ground level) float 12.0


### PR DESCRIPTION
In advanced settings, count only flags without "no" prefix. Don't rely on for-each variable.
In `settingtypes.txt`, reorder possible flags (without "no" prefix then with "no" prefix).
Fixes #8987. See that issue for more information.