### PR TITLE
Add dependencies for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For Fedora users:
     
 For Arch users:
 
-    sudo pacman -S base-devel gnucurl libcurl-gnutls cmake openal libvorbis vorbis-tools libxxf86vm irrlicht libpng libpng png++ glu mesa sqlite libspatialite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses doxygen
+    sudo pacman -S base-devel gnurl libcurl-gnutls cmake libxxf86vm irrlicht libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses
 
 #### Download
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For Fedora users:
     
 For Arch users:
 
-    sudo pacman -S base-devel gnurl libcurl-gnutls cmake libxxf86vm irrlicht libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses
+    sudo pacman -S base-devel libcurl-gnutls cmake libxxf86vm irrlicht libpng sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses
 
 #### Download
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ For Debian/Ubuntu users:
 For Fedora users:
 
     sudo dnf install make automake gcc gcc-c++ kernel-devel cmake libcurl-devel openal-soft-devel libvorbis-devel libXxf86vm-devel libogg-devel freetype-devel mesa-libGL-devel zlib-devel jsoncpp-devel irrlicht-devel bzip2-libs gmp-devel sqlite-devel luajit-devel leveldb-devel ncurses-devel doxygen spatialindex-devel bzip2-devel
+    
+For Arch users:
+
+    sudo pacman -S base-devel gnucurl libcurl-gnutls cmake openal libvorbis vorbis-tools libxxf86vm irrlicht libpng libpng png++ glu mesa sqlite libspatialite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses doxygen
 
 #### Download
 


### PR DESCRIPTION
This pull request adds Arch Linux dependencies (including base-devel). Arch Linux is quite popular, especially among Minetest players, as are derivatives such as Manjaro.

## To do

This PR is Ready for Review.

