### PR TITLE
Fix unwanted detaching when damage = 0

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1546,7 +1546,7 @@ void GenericCAO::processMessage(const std::string &data)
 
 		if (damage > 0)
 		{
-			if (m_hp <= 0)
+			if (m_hp == 0)
 			{
 				// TODO: Execute defined fast response
 				// As there is no definition, make a smoke puff
@@ -1562,7 +1562,9 @@ void GenericCAO::processMessage(const std::string &data)
 					m_reset_textures_timer += 0.05 * damage;
 				updateTextures(m_current_texture_modifier + "^[brighten");
 			}
-		} else {
+		}
+
+		if (m_hp == 0) {
 			// Same as 'Server::DiePlayer'
 			clearParentAttachment();
 			// Same as 'ObjectRef::l_remove'


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
don't detach player on set_hp with new hp equal to old hp
- How does the PR work?
skips detaching when the hp is positive
- Does it resolve any reported issue?
not that I could find

## To do

This PR is Ready for Review.

## How to test

play hamlet's quest as of sep 28, 2019
ride boat in water and observe not detaching after a second or so

## backporting to stable
Not sure if the bug is in stable (didn't test), if so, this pull request should be backported to stable as well.
