### PR TITLE
Add dithering

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -585,11 +585,13 @@ exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 #    screenshots and it works incorrectly if the display or operating system
 #    performs additional dithering or if the color channels are not quantized
 #    to 8 bits.
+#    If set to glsl_only, dithering is disabled only for OpenGL ES.
 #    With OpenGL ES, dithering only works if the shader supports high
-#    floating-point precision.
+#    floating-point precision and it may have a higher performance impact.
 #
 #    Requires: shaders
-debanding (Enable Debanding) bool true
+debanding (Debanding) enum glsl_only disable,enable,glsl_only
+
 
 [**Bloom]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -580,6 +580,15 @@ enable_auto_exposure (Enable Automatic Exposure) bool false
 #    Requires: shaders, enable_auto_exposure
 exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 
+#    Apply dithering to reduce colour banding artifacts.
+#    Dithering significantly increases the size of losslessly-compressed
+#    screenshots and it works incorrectly if the display or operating system
+#    performs additional dithering or if the colour channels are not quantized
+#    to 8 bits. Therefore it is disabled by default.
+#
+#    Requires: shaders
+dithering (Enable Dithering) bool false
+
 [**Bloom]
 
 #    Set to true to enable bloom effect.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -584,10 +584,10 @@ exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 #    Dithering significantly increases the size of losslessly-compressed
 #    screenshots and it works incorrectly if the display or operating system
 #    performs additional dithering or if the colour channels are not quantized
-#    to 8 bits. Therefore it is disabled by default.
+#    to 8 bits.
 #
 #    Requires: shaders
-dithering (Enable Dithering) bool false
+debanding (Enable Debanding) bool true
 
 [**Bloom]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -585,13 +585,11 @@ exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 #    screenshots and it works incorrectly if the display or operating system
 #    performs additional dithering or if the color channels are not quantized
 #    to 8 bits.
-#    If set to glsl_only, dithering is disabled only for OpenGL ES.
 #    With OpenGL ES, dithering only works if the shader supports high
 #    floating-point precision and it may have a higher performance impact.
 #
 #    Requires: shaders
-debanding (Debanding) enum glsl_only disable,enable,glsl_only
-
+debanding (Enable Debanding) bool true
 
 [**Bloom]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -580,10 +580,10 @@ enable_auto_exposure (Enable Automatic Exposure) bool false
 #    Requires: shaders, enable_auto_exposure
 exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 
-#    Apply dithering to reduce colour banding artifacts.
+#    Apply dithering to reduce color banding artifacts.
 #    Dithering significantly increases the size of losslessly-compressed
 #    screenshots and it works incorrectly if the display or operating system
-#    performs additional dithering or if the colour channels are not quantized
+#    performs additional dithering or if the color channels are not quantized
 #    to 8 bits.
 #
 #    Requires: shaders

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -585,6 +585,8 @@ exposure_compensation (Exposure compensation) float 0.0 -1.0 1.0
 #    screenshots and it works incorrectly if the display or operating system
 #    performs additional dithering or if the color channels are not quantized
 #    to 8 bits.
+#    With OpenGL ES, dithering only works if the shader supports high
+#    floating-point precision.
 #
 #    Requires: shaders
 debanding (Enable Debanding) bool true

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -79,6 +79,20 @@ vec3 applySaturation(vec3 color, float factor)
 }
 #endif
 
+#ifdef ENABLE_DITHERING
+// From http://alex.vlachos.com/graphics/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
+// and https://www.shadertoy.com/view/MslGR8 (5th one starting from the bottom)
+// NOTE: `frag_coord` is in pixels (i.e. not normalized UV).
+vec3 screen_space_dither(vec2 frag_coord) {
+	// Iestyn's RGB dither (7 asm instructions) from Portal 2 X360, slightly modified for VR.
+	vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
+	dither.rgb = fract(dither.rgb / vec3(103.0, 71.0, 97.0));
+
+	// Subtract 0.5 to avoid slightly brightening the whole viewport.
+	return (dither.rgb - 0.5) / 255.0;
+}
+#endif
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -124,6 +138,11 @@ void main(void)
 
 	// return to sRGB colorspace (approximate)
 	color.rgb = pow(color.rgb, vec3(1.0 / 2.2));
+
+#ifdef ENABLE_DITHERING
+	// Apply dithering just before quantisation
+	color.rgb += screen_space_dither(gl_FragCoord.xy);
+#endif
 
 	gl_FragColor = vec4(color.rgb, 1.0); // force full alpha to avoid holes in the image.
 }

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -1,6 +1,13 @@
 #define rendered texture0
 #define bloom texture1
 
+#ifdef GL_ES
+// Dithering requires sufficient floating-point precision
+#if GL_FRAGMENT_PRECISION_HIGH != 1
+#undef ENABLE_DITHERING
+#endif
+#endif
+
 struct ExposureParams {
 	float compensationFactor;
 };
@@ -83,9 +90,9 @@ vec3 applySaturation(vec3 color, float factor)
 // From http://alex.vlachos.com/graphics/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
 // and https://www.shadertoy.com/view/MslGR8 (5th one starting from the bottom)
 // NOTE: `frag_coord` is in pixels (i.e. not normalized UV).
-vec3 screen_space_dither(vec2 frag_coord) {
+vec3 screen_space_dither(highp vec2 frag_coord) {
 	// Iestyn's RGB dither (7 asm instructions) from Portal 2 X360, slightly modified for VR.
-	vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
+	highp vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
 	dither.rgb = fract(dither.rgb / vec3(103.0, 71.0, 97.0));
 
 	// Subtract 0.5 to avoid slightly brightening the whole viewport.

--- a/client/shaders/second_stage/opengl_fragment.glsl
+++ b/client/shaders/second_stage/opengl_fragment.glsl
@@ -3,7 +3,7 @@
 
 #ifdef GL_ES
 // Dithering requires sufficient floating-point precision
-#if GL_FRAGMENT_PRECISION_HIGH != 1
+#ifndef GL_FRAGMENT_PRECISION_HIGH
 #undef ENABLE_DITHERING
 #endif
 #endif

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -508,15 +508,6 @@
 #    type: float min: -1 max: 1
 # exposure_compensation = 0.0
 
-#    Apply dithering to reduce colour banding artifacts.
-#    Dithering significantly increases the size of losslessly-compressed
-#    screenshots and it works incorrectly if the display or operating system
-#    performs additional dithering or if the colour channels are not quantized
-#    to 8 bits.
-#    type: bool
-# debanding = true
-
-
 ### Bloom
 
 #    Set to true to enable bloom effect.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -508,6 +508,15 @@
 #    type: float min: -1 max: 1
 # exposure_compensation = 0.0
 
+#    Apply dithering to reduce colour banding artifacts.
+#    Dithering significantly increases the size of losslessly-compressed
+#    screenshots and it works incorrectly if the display or operating system
+#    performs additional dithering or if the colour channels are not quantized
+#    to 8 bits. Therefore it is disabled by default.
+#    type: bool
+# dithering = false
+
+
 ### Bloom
 
 #    Set to true to enable bloom effect.

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -512,9 +512,9 @@
 #    Dithering significantly increases the size of losslessly-compressed
 #    screenshots and it works incorrectly if the display or operating system
 #    performs additional dithering or if the colour channels are not quantized
-#    to 8 bits. Therefore it is disabled by default.
+#    to 8 bits.
 #    type: bool
-# dithering = false
+# debanding = true
 
 
 ### Bloom

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -767,8 +767,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SSAA_SCALE " << ssaa_scale << ".\n";
 	}
 
-	std::string debanding{g_settings->get("debanding")};
-	if ((debanding == "glsl_only" && !use_gles) || debanding == "enabled")
+	if (g_settings->getBool("debanding"))
 		shaders_header << "#define ENABLE_DITHERING 1\n";
 
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -767,7 +767,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SSAA_SCALE " << ssaa_scale << ".\n";
 	}
 
-	if (g_settings->getBool("dithering"))
+	if (g_settings->getBool("debanding"))
 		shaders_header << "#define ENABLE_DITHERING 1\n";
 
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -767,7 +767,8 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SSAA_SCALE " << ssaa_scale << ".\n";
 	}
 
-	if (g_settings->getBool("debanding"))
+	std::string debanding{g_settings->get("debanding")};
+	if ((debanding == "glsl_only" && !use_gles) || debanding == "enabled")
 		shaders_header << "#define ENABLE_DITHERING 1\n";
 
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -767,6 +767,9 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 		shaders_header << "#define SSAA_SCALE " << ssaa_scale << ".\n";
 	}
 
+	if (g_settings->getBool("dithering"))
+		shaders_header << "#define ENABLE_DITHERING 1\n";
+
 	shaders_header << "#line 0\n"; // reset the line counter for meaningful diagnostics
 
 	std::string common_header = shaders_header.str();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -264,7 +264,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_compensation", "0.0");
 	settings->setDefault("enable_auto_exposure", "false");
-	settings->setDefault("debanding", "true");
+	settings->setDefault("debanding", "glsl_only");
 	settings->setDefault("antialiasing", "none");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -264,6 +264,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_compensation", "0.0");
 	settings->setDefault("enable_auto_exposure", "false");
+	settings->setDefault("debanding", "true");
 	settings->setDefault("antialiasing", "none");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -264,7 +264,7 @@ void set_default_settings()
 	settings->setDefault("enable_waving_plants", "false");
 	settings->setDefault("exposure_compensation", "0.0");
 	settings->setDefault("enable_auto_exposure", "false");
-	settings->setDefault("debanding", "glsl_only");
+	settings->setDefault("debanding", "true");
 	settings->setDefault("antialiasing", "none");
 	settings->setDefault("enable_bloom", "false");
 	settings->setDefault("enable_bloom_debug", "false");
@@ -499,6 +499,7 @@ void set_default_settings()
 	settings->setDefault("active_block_range", "2");
 	settings->setDefault("viewing_range", "50");
 	settings->setDefault("leaves_style", "simple");
+	settings->setDefault("debanding", "false");
 	settings->setDefault("curl_verify_cert", "false");
 
 	// Apply settings according to screen size


### PR DESCRIPTION
Goal:
Add dithering to reduce banding artifacts

How does it work: 
Dithering is disabled by default and can be enabled with a setting.
It is applied in the second-stage shader and uses the algorithm supplied by Calinou.

> Does it resolve any reported issue?

I don't think there's an issue about this.

> If not a bug fix, why is this PR needed? What usecases does it solve?

On some displays, [banding](https://en.wikipedia.org/wiki/Colour_banding) is easily noticeable in Minetest.
Dithering before the quantisation to 8 bits can prevent banding artifacts
and an implementation requires only a few lines of code.

## How to test

It may be difficult to see banding on some screens because 8x8x8 bit colours are already a lot possible values.

Disabled dithering (current behaviour):
![dithering_off](https://github.com/minetest/minetest/assets/3192173/b3e698f0-780d-4d70-b11b-6b720328751c)
Edited with GIMP to show the bands:
![dithering_off_edited](https://github.com/minetest/minetest/assets/3192173/f50c1d44-b092-459e-af73-134882b94a6d)

Enabled dithering:
![dithering_on](https://github.com/minetest/minetest/assets/3192173/fd04169c-a6c7-410a-bd64-15b2d5e89480)
Edited with GIMP to show the dithering pattern:
![dithering_on_edited](https://github.com/minetest/minetest/assets/3192173/26da8434-594a-4a1d-83fa-e9bba3c0fd10)

Please look at the pictures in 1:1 scaling or upscaled by an integer factor without interpolation, and ideally with a black background instead of the white Github page background.