### PR TITLE
Fix upright_sprite lighting when colors are set

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1264,18 +1264,19 @@ void GenericCAO::updateTextures(std::string mod)
 					buf->getMaterial().AmbientColor = m_prop.colors[1];
 					buf->getMaterial().DiffuseColor = m_prop.colors[1];
 					buf->getMaterial().SpecularColor = m_prop.colors[1];
-					setMeshColor(mesh, m_prop.colors[1]);
 				} else if (!m_prop.colors.empty()) {
 					buf->getMaterial().AmbientColor = m_prop.colors[0];
 					buf->getMaterial().DiffuseColor = m_prop.colors[0];
 					buf->getMaterial().SpecularColor = m_prop.colors[0];
-					setMeshColor(mesh, m_prop.colors[0]);
 				}
 
 				buf->getMaterial().setFlag(video::EMF_TRILINEAR_FILTER, use_trilinear_filter);
 				buf->getMaterial().setFlag(video::EMF_BILINEAR_FILTER, use_bilinear_filter);
 				buf->getMaterial().setFlag(video::EMF_ANISOTROPIC_FILTER, use_anisotropic_filter);
 			}
+			// Set mesh color (only if lighting is disabled)
+			if (!m_prop.colors.empty() && m_glow < 0)
+				setMeshColor(mesh, m_prop.colors[0]);
 		}
 	}
 }


### PR DESCRIPTION
fixes #9020, bug was introduced in #6559
I don't know <i>[why](https://github.com/minetest/minetest_game/blob/master/mods/player_api/api.lua#L54-L59)</i> the player has a color set, but it doesn't make sense to apply it to the mesh either way since it conflicts with lighting.

## To do

This PR is Ready for Review.
## How to test

see linked issue