### PR TITLE
Revert Client::sendPlayerPos optimization (part of 81c7f0a)

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1245,8 +1245,9 @@ void Client::sendPlayerPos()
 	// Save bandwidth by only updating position when
 	// player is not dead and something changed
 
-	if (m_activeobjects_received && player->isDead())
-		return;
+	// FIXME: This part causes breakages in mods like 3d_armor, and has been commented for now
+	// if (m_activeobjects_received && player->isDead())
+	//	return;
 
 	if (
 			player->last_position     == player->getPosition() &&


### PR DESCRIPTION
While #9022 is apparently a mod issue, I think we should consider this optimisation carefully, due to the potential breakage in mods. Even if an affected mod is actively maintained, this optimisation would force users and servers to update the mod. So this PR comments out the `if` statement that prevents sending `TOSERVER_PLAYERPOS` if the player is dead, as this causes a breakage in `3D_Armor`. We'll look at this again, once 5.1.0 has been released.

Tested, works. Fixes #9022. To test, follow the testing instructions in #9022.
