### PR TITLE
Mgv7 floatlands: No longer use 'mountain' noise for floatland mountains

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1531,21 +1531,19 @@ mgv7_large_cave_depth (Large cave depth) int -33
 #    Y of upper limit of lava in large caves.
 mgv7_lava_depth (Lava depth) int -256
 
-#    Controls the density of mountain-type floatlands.
-#    Is a noise offset added to the 'mgv7_np_mountain' noise value.
-mgv7_float_mount_density (Floatland mountain density) float 0.6
-
-#    Typical maximum height, above and below midpoint, of floatland mountains.
-mgv7_float_mount_height (Floatland mountain height) float 128.0
-
-#    Alters how mountain-type floatlands taper above and below midpoint.
-mgv7_float_mount_exponent (Floatland mountain exponent) float 0.75
-
-#    Y-level of floatland midpoint and lake surface.
+#    Y-level of floatland midpoint.
 mgv7_floatland_level (Floatland level) int 1280
 
 #    Y-level to which floatland shadows extend.
 mgv7_shadow_limit (Shadow limit) int 1024
+
+#    Controls the proportion of floatland area covered by lakes.
+#    Lakes occur where 'floatland_base' noise value > this value.
+mgv7_float_lake_thresh (Floatland lake threshold) float 0.8
+
+#    Controls the proportion of floatland land area covered by mountains.
+#    Mountains occur where 'float_base_height' noise value > this value.
+mgv7_float_mount_thresh (Floatland mountain threshold) float 0.9
 
 #    Y-level of cavern upper limit.
 mgv7_cavern_limit (Cavern limit) int -256
@@ -1586,12 +1584,13 @@ mgv7_np_mount_height (Mountain height noise) noise_params_2d 256, 112, (1000, 10
 #    Defines large-scale river channel structure.
 mgv7_np_ridge_uwater (Ridge underwater noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
 
-#    Defines areas of floatland smooth terrain.
-#    Smooth floatlands occur when noise > 0.
-mgv7_np_floatland_base (Floatland base noise) noise_params_2d -0.6, 1.5, (600, 600, 600), 114, 5, 0.6, 2.0, eased
+#    Determines floatland areas and floatland lake areas.
+#    Floatlands occur where noise value > 0.
+mgv7_np_floatland_base (Floatland base noise) noise_params_2d -0.1, 1.0, (600, 600, 600), 114, 5, 0.6, 2.0, eased
 
-#    Variation of hill height and lake depth on floatland smooth terrain.
-mgv7_np_float_base_height (Floatland base height noise) noise_params_2d 48, 24, (300, 300, 300), 907, 4, 0.7, 2.0, eased
+#    Controls floatland hill and mountain height.
+#    Determines proportion of floatland land area covered by flat terrain.
+mgv7_np_float_base_height (Floatland base height noise) noise_params_2d 1.0, 0.8, (600, 600, 600), 907, 5, 0.6, 2.0, eased
 
 #    3D noise defining mountain structure and height.
 #    Also defines structure of floatland mountain terrain.

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2013-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2014-2018 paramat
+Copyright (C) 2013-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2014-2019 paramat
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -37,11 +37,10 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	s16 mount_zero_level = 0;
-	float float_mount_density = 0.6f;
-	float float_mount_height = 128.0f;
-	float float_mount_exponent = 0.75f;
 	s16 floatland_level = 1280;
 	s16 shadow_limit = 1024;
+	float float_lake_thresh = 0.8f;
+	float float_mount_thresh = 0.9f;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -60,7 +59,7 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_mount_height;
 	NoiseParams np_ridge_uwater;
 	NoiseParams np_floatland_base;
-	NoiseParams np_float_base_height;
+	NoiseParams np_float_base_amp;
 	NoiseParams np_mountain;
 	NoiseParams np_ridge;
 	NoiseParams np_cavern;
@@ -90,7 +89,6 @@ public:
 	float baseTerrainLevelFromMap(int index);
 	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
 	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
-	bool getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y);
 	void floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max, int idx_xz);
 
 	int generateTerrain();
@@ -98,11 +96,10 @@ public:
 
 private:
 	s16 mount_zero_level;
-	float float_mount_density;
-	float float_mount_height;
-	float float_mount_exponent;
 	s16 floatland_level;
 	s16 shadow_limit;
+	float float_lake_thresh;
+	float float_mount_thresh;
 
 	s16 large_cave_depth;
 	s16 dungeon_ymin;
@@ -115,7 +112,7 @@ private:
 	Noise *noise_mount_height;
 	Noise *noise_ridge_uwater;
 	Noise *noise_floatland_base;
-	Noise *noise_float_base_height;
+	Noise *noise_float_base_amp;
 	Noise *noise_mountain;
 	Noise *noise_ridge;
 };


### PR DESCRIPTION
***** WIP. DO NOT MERGE.. Dangerous in current form. Now considering removing floatlands *****

To make mountains and floatland mountains independently customisable.
Use existing floatland 2D noises to create floatland mountains.
Make floatland areas cover a larger proportion of area and more
interconnected.
Make underside lower under floatland lakes to reduce water leaks.
Shape underside using an exponent.
Lower floatland lake surface so that game biomes can be lowered to
remove sand from floatland edges, also to create gently sloping
beaches even when next to a mountain.
Remove previous floatland mountain settings, add 2 new settings.
///////////////////////////////////////////////////////////////

![screenshot_20191007_193608](https://user-images.githubusercontent.com/3686677/66340666-95fa5a80-e93d-11e9-9bd9-e7a1e55bd4ce.png)

^ Floatland mountainous area with much nicer 2D noise mountains.

![nf11_quart_IND](https://user-images.githubusercontent.com/3686677/66779272-98bcf880-eec5-11e9-8592-dc26b83c2cc6.png)

^ 4000x4000 nodes. Decorations removed for clarity. Higher hills and mountains are chopped off only for the purpose of generating this area faster during testing

I realised i had made a mistake in existing floatland generation: 'mountain' noise was also used for floatland mountains. The ideal parameters for surface mountains are different from the ideal parameters for floatland mountains. Using 1 noise for both features reduced flexibility and meant tuning one feature would usually make the other feature unoptimal.

I was also unhappy with using those crazy 3D shapes for floatland mountains.
I realised that i could use the existing 2 2D floatland noises to create the floatland mountains.
Floatland mountains are now far more consistent with, and integrated into, the floatland base structure, instead of being randomly placed and intersecting by chance.

Note that floatland terrain is documented as being 'highly unstable'.
This change will cause a significant change in floatland terrain. Those already using floatlands in their worlds will need to edit the 2D floatland noise parameters in map_meta.txt to the new values for good results, i will make a forum post explaining what to do.
Floatland terrain is still unstable, but hopefully by 5.2.0 it can be announced as 'fairly stable'.

Floatlands now cover a larger proportion of area: A little under 50%. This makes them larger and more interconneced such that large areas can be accessed by walking and bridge making.
The floatlands are now deeper under lakes to reduce water leaks, in testing i only find roughly 1 leak per large lake, before there were several per lake.
Mountains can be up to roughly 250 nodes tall.

If merged this will require a small change to MTG biome definitions. due to lake surface being lowered for the reasons in the commit message.