### PR TITLE
Correction for alpha blending issues in texture mod compositing

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1812,6 +1812,23 @@ bool TextureSource::generateImagePart(std::string part_of_name,
 }
 
 /*
+	Calculate the color of a single pixel drawn on top of another pixel.
+
+	This is a little more complicated than just video::SColor::getInterpolated
+	because getInterpolated does not handle alpha correctly.  For example, a
+	pixel with alpha=64 drawn atop a pixel with alpha=128 should yield a
+	pixel with alpha=160, while getInterpolated would yield alpha=96.
+*/
+static inline video::SColor blitPixel(const video::SColor &src_c, const video::SColor &dst_c, u32 ratio)
+{
+	if (dst_c.getAlpha() == 0)
+		return src_c;
+	video::SColor out_c = src_c.getInterpolated(dst_c, (float)ratio / 255.0f);
+	out_c.setAlpha(dst_c.getAlpha() + (255 - dst_c.getAlpha()) * src_c.getAlpha() / 255 * ratio / 255);
+	return out_c;
+}
+
+/*
 	Draw an image on top of an another one, using the alpha channel of the
 	source image
 
@@ -1830,7 +1847,7 @@ static void blit_with_alpha(video::IImage *src, video::IImage *dst,
 		s32 dst_y = dst_pos.Y + y0;
 		video::SColor src_c = src->getPixel(src_x, src_y);
 		video::SColor dst_c = dst->getPixel(dst_x, dst_y);
-		dst_c = src_c.getInterpolated(dst_c, (float)src_c.getAlpha()/255.0f);
+		dst_c = blitPixel(src_c, dst_c, src_c.getAlpha());
 		dst->setPixel(dst_x, dst_y, dst_c);
 	}
 }
@@ -1853,7 +1870,7 @@ static void blit_with_alpha_overlay(video::IImage *src, video::IImage *dst,
 		video::SColor dst_c = dst->getPixel(dst_x, dst_y);
 		if (dst_c.getAlpha() == 255 && src_c.getAlpha() != 0)
 		{
-			dst_c = src_c.getInterpolated(dst_c, (float)src_c.getAlpha()/255.0f);
+			dst_c = blitPixel(src_c, dst_c, src_c.getAlpha());
 			dst->setPixel(dst_x, dst_y, dst_c);
 		}
 	}

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1824,7 +1824,8 @@ static inline video::SColor blitPixel(const video::SColor &src_c, const video::S
 	if (dst_c.getAlpha() == 0)
 		return src_c;
 	video::SColor out_c = src_c.getInterpolated(dst_c, (float)ratio / 255.0f);
-	out_c.setAlpha(dst_c.getAlpha() + (255 - dst_c.getAlpha()) * src_c.getAlpha() * ratio / (255 * 255));
+	out_c.setAlpha(dst_c.getAlpha() + (255 - dst_c.getAlpha()) *
+		src_c.getAlpha() * ratio / (255 * 255));
 	return out_c;
 }
 

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -1824,7 +1824,7 @@ static inline video::SColor blitPixel(const video::SColor &src_c, const video::S
 	if (dst_c.getAlpha() == 0)
 		return src_c;
 	video::SColor out_c = src_c.getInterpolated(dst_c, (float)ratio / 255.0f);
-	out_c.setAlpha(dst_c.getAlpha() + (255 - dst_c.getAlpha()) * src_c.getAlpha() / 255 * ratio / 255);
+	out_c.setAlpha(dst_c.getAlpha() + (255 - dst_c.getAlpha()) * src_c.getAlpha() * ratio / (255 * 255));
 	return out_c;
 }
 


### PR DESCRIPTION
Minetest's texture modifier operators (e.g. `^` and `[combine`) are used to overlay images atop one another, but they handle the alpha component incorrectly.  This leads to visuals being noticeably incorrect when either alpha blending is enabled on a surface using the combined texture, or it's then combined with other textures.

The test case below combines 2 obvious circles (an opaque white one and a translucent black one).  The left one is merged using gimp and saved as a single pre-composited texture, while the right one is merged via in-game ^ texture combining.  Each is drawn as an upright_sprite entity in front of the checkered node background.

### Before (MT master):
![broken](https://user-images.githubusercontent.com/324806/66413191-e799f800-e9c4-11e9-9af4-aaa29824fbcd.png)

### After (with this patch):
![fixed](https://user-images.githubusercontent.com/324806/66413202-ed8fd900-e9c4-11e9-826f-dece9930b451.png)

Remaining discrepancies between the gimp reference image and MT's rendering are subtle, and probably due to perceptual/nonlinear magic that gimp does that is probably beyond what's necessary for MT.