### PR TITLE
Randomwalk caves: Reduce 'insure' value from 10 to 2

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -364,9 +364,8 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 	// Area starting point in nodes
 	of = node_min;
 
-	// Allow a bit more
-	//(this should be more than the maximum radius of the tunnel)
-	const s16 insure = 10;
+	// Allow a bit more (this should be more than the maximum radius of the tunnel)
+	const s16 insure = 2;
 	s16 more = MYMAX(MAP_BLOCKSIZE - max_tunnel_diameter / 2 - insure, 1);
 	ar += v3s16(1, 0, 1) * more * 2;
 	of -= v3s16(1, 0, 1) * more;


### PR DESCRIPTION
This value reduces how far randomwalk caves can extend into the
mapchunk padding, to avoid 'out of voxelmanip' cave nodes which cause
flattened cave walls.
Testing shows that a value of 2 (instead of 10) is enough to make
'out of area' nodes extremely rare.
Reducing this value results in a higher chance of overlap and
connection with caves of neighbour mapchunks.
//////////////////////////////////////////////////

I started investigating this by seeing the previous value of 10 and wondering why it was so large, and whether it needed to be so large. 10 reduced extension into the mapchunk padding by so much i was concerned about the effect on the desirable overlap of caves of neighbouring mapchunks.

I tested by altering code to generate 64 (!) cave systems per mapchunk, and to notify to terminal for each 'out of area' node.
Flying underground, a value of 2 resulted in a total of only 9 'out of area' cave air nodes in 5min of flying. Extremely rare and an insignificant number of nodes that would not noticeably alter cave walls.
Values of 0 and 1 caused many 'out of area' nodes, the previous value of 10 caused none during testing.

These 'out of area' nodes do not cause an error or crash, there is an 'area contains' check done before each node is placed.