### PR TITLE
Fix rotate_node to return the correct itemstack.

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -428,10 +428,9 @@ if INIT == "game" then
 	core.rotate_node = function(itemstack, placer, pointed_thing)
 		local name = placer and placer:get_player_name() or ""
 		local invert_wall = placer and placer:get_player_control().sneak or false
-		core.rotate_and_place(itemstack, placer, pointed_thing,
+		return core.rotate_and_place(itemstack, placer, pointed_thing,
 				is_creative(name),
 				{invert_wall = invert_wall}, true)
-		return itemstack
 	end
 end
 


### PR DESCRIPTION
All on_* hooks that return an itemstack are NOT guaranteed to
modify and return the original stack.  We cannot count on the
behavior of the existing builtin definitions not to be overridden
by game/mod logic.