### PR TITLE
Make natural night light as bright as MT 0.4.16

### DIFF
--- a/src/daynightratio.h
+++ b/src/daynightratio.h
@@ -30,8 +30,8 @@ inline u32 time_to_daynight_ratio(float time_of_day, bool smooth)
 		t = 24000.0f - t;
 
 	const float values[9][2] = {
-		{4250.0f + 125.0f, 150.0f},
-		{4500.0f + 125.0f, 150.0f},
+		{4250.0f + 125.0f, 175.0f},
+		{4500.0f + 125.0f, 175.0f},
 		{4750.0f + 125.0f, 250.0f},
 		{5000.0f + 125.0f, 350.0f},
 		{5250.0f + 125.0f, 500.0f},


### PR DESCRIPTION
Attends to part of #8577 

There were significant changes to lighting between 0.4.15 and 0.4.16 and between 0.4.16 and 5.0.0. Natural night light became significantly darker in 5.0.0, causing several complaints.

As discussed in the issue, the light curve parameters alpha/beta/gamma/boost only affect the shape of the light curve, the entire light curve is darkened for natural night light. So alpha/beta/gamma/boost have little effect on the brightness of natural night light, and they are not what determines the brightness of natural night light.
The lowest value in the daynightratio table is what determines the brightness of natural night light.

All screenshots are of a column of 'open to sky' nightlight falling on pure white nodes in an underground chamber, with shaders off.
All colour values are for the central 'open to sky' node.
This PR intends to make the central node as bright as the brightest of 0.4.15 and 0.4.16. The brightness of the central node is almost identical in 0.4.15 and 0.4.16.

![nightlight0415](https://user-images.githubusercontent.com/3686677/67113400-55b69a00-f1d1-11e9-9ecb-a165e00dd7ab.png)

^ 0.4.15
RGB 35 35 66
HSV 240 47 26

![nightlight0416](https://user-images.githubusercontent.com/3686677/67113425-6535e300-f1d1-11e9-98db-49f64c02b931.png)

 ^ 0.4.16
RGB 34 34 67
HSV 240 49 26

![light_nat_night_default_510](https://user-images.githubusercontent.com/3686677/67113444-6f57e180-f1d1-11e9-90bb-e5a264acd100.png)

^ 5.1.0 master
RGB 27 27 63
HSV 240 57 25

![PR_175](https://user-images.githubusercontent.com/3686677/67113460-7a127680-f1d1-11e9-882c-3b1847c08bc5.png)

^ PR
RGB 34 34 68
HSV 240 50 27
Therefore very similar brightness to 0.4.15 and 0.4.16.
The brightness is not as 'spread out' as 0.4.16 but that depends on the light curve settings alpha/beta/gamma/boost, only the brightest light level is relevant to the aim of this PR.