### PR TITLE
Fix scroll bar overlapping text (again)

### DIFF
--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -1028,7 +1028,7 @@ void GUIEditBoxWithScrollBar::breakText()
 	s32 last_line_start = 0;
 	s32 size = Text.size();
 	s32 length = 0;
-	s32 el_width = RelativeRect.getWidth() - 6;
+	s32 el_width = RelativeRect.getWidth() - m_scrollbar_width - 10;
 	wchar_t c;
 
 	for (s32 i = 0; i < size; ++i) {
@@ -1395,8 +1395,6 @@ void GUIEditBoxWithScrollBar::createVScrollBar()
 		skin = Environment->getSkin();
 
 	m_scrollbar_width = skin ? skin->getSize(gui::EGDS_SCROLLBAR_SIZE) : 16;
-
-	RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 
 	irr::core::rect<s32> scrollbarrect = m_frame_rect;
 	scrollbarrect.UpperLeftCorner.X += m_frame_rect.getWidth() - m_scrollbar_width;

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -1165,7 +1165,7 @@ void intlGUIEditBox::breakText()
 	s32 lastLineStart = 0;
 	s32 size = Text.size();
 	s32 length = 0;
-	s32 elWidth = RelativeRect.getWidth() - 6;
+	s32 elWidth = RelativeRect.getWidth() - m_scrollbar_width - 10;
 	wchar_t c;
 
 	for (s32 i=0; i<size; ++i)
@@ -1477,8 +1477,6 @@ void intlGUIEditBox::createVScrollBar()
 			}
 		}
 	}
-
-	RelativeRect.LowerRightCorner.X -= m_scrollbar_width + 4;
 
 	irr::core::rect<s32> scrollbarrect = FrameRect;
 	scrollbarrect.UpperLeftCorner.X += FrameRect.getWidth() - m_scrollbar_width;


### PR DESCRIPTION
Fixes #8949 and reverts #7816. This should be a more reliable solution, although I admit I don't fully understand the GUI code.

Edit: I should add that this does the exact same thing, it's just moved somewhere else.
Edit: [Demonstration](https://www.youtube.com/watch?v=U0NoKcE6Wew)