### PR TITLE
Change some usages of "deprecated" to "obsolete"

### DIFF
--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -20,7 +20,7 @@ function core.node_metadata_inventory_move_allow_all()
 end
 
 function core.add_to_creative_inventory(itemstring)
-	core.log("deprecated", "core.add_to_creative_inventory: This function is deprecated and does nothing.")
+	core.log("deprecated", "core.add_to_creative_inventory is obsolete and does nothing.")
 end
 
 --

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -321,11 +321,11 @@ for name in pairs(forbidden_item_names) do
 end
 
 
--- Deprecated:
+-- Obsolete:
 -- Aliases for core.register_alias (how ironic...)
---core.alias_node = core.register_alias
---core.alias_tool = core.register_alias
---core.alias_craftitem = core.register_alias
+-- core.alias_node = core.register_alias
+-- core.alias_tool = core.register_alias
+-- core.alias_craftitem = core.register_alias
 
 --
 -- Built-in node definitions. Also defined in C.

--- a/doc/world_format.txt
+++ b/doc/world_format.txt
@@ -500,10 +500,10 @@ Static objects are persistent freely moving objects in the world.
 Object types:
 1: Test object
 2: Item
-3: Rat (deprecated)
-4: Oerkki (deprecated)
-5: Firefly (deprecated)
-6: MobV2 (deprecated)
+3: Rat (obsolete)
+4: Oerkki (obsolete)
+5: Firefly (obsolete)
+6: MobV2 (obsolete)
 7: LuaEntity
 
 1: Item:

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -27,13 +27,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 enum ActiveObjectType {
 	ACTIVEOBJECT_TYPE_INVALID = 0,
 	ACTIVEOBJECT_TYPE_TEST = 1,
-// Deprecated stuff
+// Obsolete stuff
 	ACTIVEOBJECT_TYPE_ITEM = 2,
 //	ACTIVEOBJECT_TYPE_RAT = 3,
 //	ACTIVEOBJECT_TYPE_OERKKI1 = 4,
 //	ACTIVEOBJECT_TYPE_FIREFLY = 5,
 	ACTIVEOBJECT_TYPE_MOBV2 = 6,
-// End deprecated stuff
+// End obsolete stuff
 	ACTIVEOBJECT_TYPE_LUAENTITY = 7,
 // Special type, not stored as a static object
 	ACTIVEOBJECT_TYPE_PLAYER = 100,

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -985,7 +985,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 
 void PlayerSAO::getStaticData(std::string * result) const
 {
-	FATAL_ERROR("Deprecated function");
+	FATAL_ERROR("Obsolete function");
 }
 
 void PlayerSAO::step(float dtime, bool send_recommended)

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -30,10 +30,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MAPGEN_DEFAULT_NAME "v7"
 
 /////////////////// Mapgen flags
-#define MG_TREES       0x01  // Deprecated. Moved into mgv6 flags
+#define MG_TREES       0x01  // Obsolete. Moved into mgv6 flags
 #define MG_CAVES       0x02
 #define MG_DUNGEONS    0x04
-#define MG_FLAT        0x08  // Deprecated. Moved into mgv6 flags
+#define MG_FLAT        0x08  // Obsolete. Moved into mgv6 flags
 #define MG_LIGHT       0x10
 #define MG_DECORATIONS 0x20
 #define MG_BIOMES      0x40

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -83,7 +83,7 @@ void read_item_definition(lua_State* L, int index,
 	getboolfield(L, index, "liquids_pointable", def.liquids_pointable);
 
 	warn_if_field_exists(L, index, "tool_digging_properties",
-			"Deprecated; use tool_capabilities");
+			"Obsolete; use tool_capabilities");
 
 	lua_getfield(L, index, "tool_capabilities");
 	if(lua_istable(L, -1)){
@@ -643,19 +643,19 @@ ContentFeatures read_content_features(lua_State *L, int index)
 		warningstream << "Node " << f.name.c_str()
 			<< " has a palette, but not a suitable paramtype2." << std::endl;
 
-	// Warn about some deprecated fields
+	// Warn about some obsolete fields
 	warn_if_field_exists(L, index, "wall_mounted",
-			"Deprecated; use paramtype2 = 'wallmounted'");
+			"Obsolete; use paramtype2 = 'wallmounted'");
 	warn_if_field_exists(L, index, "light_propagates",
-			"Deprecated; determined from paramtype");
+			"Obsolete; determined from paramtype");
 	warn_if_field_exists(L, index, "dug_item",
-			"Deprecated; use 'drop' field");
+			"Obsolete; use 'drop' field");
 	warn_if_field_exists(L, index, "extra_dug_item",
-			"Deprecated; use 'drop' field");
+			"Obsolete; use 'drop' field");
 	warn_if_field_exists(L, index, "extra_dug_item_rarity",
-			"Deprecated; use 'drop' field");
+			"Obsolete; use 'drop' field");
 	warn_if_field_exists(L, index, "metadata_name",
-			"Deprecated; use on_add and metadata callbacks");
+			"Obsolete; use on_add and metadata callbacks");
 
 	// True for all ground-like things like stone and mud, false for eg. trees
 	getboolfield(L, index, "is_ground_content", f.is_ground_content);

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -879,7 +879,7 @@ int ModApiMapgen::l_set_mapgen_params(lua_State *L)
 		settingsmgr->setMapSetting("chunksize", readParam<std::string>(L, -1), true);
 
 	warn_if_field_exists(L, 1, "flagmask",
-		"Deprecated: flags field now includes unset flags.");
+		"Obsolete: flags field now includes unset flags.");
 
 	lua_getfield(L, 1, "flags");
 	if (lua_isstring(L, -1))


### PR DESCRIPTION
"Deprecated" means that something is still in use, but is unsupported and needs to be removed.
"Obsolete" means it is already out of use.
(See [this StackExchange answer](https://stackoverflow.com/a/9208164))

~~This PR is a work in progress for the moment.~~