### PR TITLE
Fix build issue due to conflicting s64 type definitions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "irrlichttypes.h" // must be included before anything irrlicht, see comment in the file
 #include "irrlicht.h" // createDevice
 #include "irrlichttypes_extrabloated.h"
 #include "chat_interface.h"


### PR DESCRIPTION
See comment in irrlichttypes.h and https://sourceforge.net/p/irrlicht/bugs/433/

Fixes #9056, #9063.