### PR TITLE
Add z-index management to HUD

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1260,6 +1260,10 @@ precisely positioned items in the HUD.
 **Note**: `offset` _will_ adapt to screen DPI as well as user defined scaling
 factor!
 
+The `z_index` field specifies the order of HUD elements from back to front.
+Lower z-index elements are displayed behind higher z-index elements. Elements
+with same z-index are displayed in an arbitrary order. Default 0.
+
 Below are the specific uses for fields in each type; fields not listed for that
 type are ignored.
 
@@ -7312,6 +7316,9 @@ Used by `Player:hud_add`. Returned by `Player:hud_get`.
 
         size = { x=100, y=100 },
         -- Size of element in pixels
+
+        z_index = 0,
+        -- Z index : lower z-index HUDs are displayed behind higher z-index HUDs
     }
 
 Particle definition

--- a/src/client/clientevent.h
+++ b/src/client/clientevent.h
@@ -131,6 +131,7 @@ struct ClientEvent
 			v2f *offset;
 			v3f *world_pos;
 			v2s32 *size;
+			s16 z_index;
 		} hudadd;
 		struct
 		{

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2650,6 +2650,7 @@ void Game::handleClientEvent_HudAdd(ClientEvent *event, CameraOrientation *cam)
 	e->offset = *event->hudadd.offset;
 	e->world_pos = *event->hudadd.world_pos;
 	e->size = *event->hudadd.size;
+	e->z_index = event->hudadd.z_index;
 	hud_server_to_client[server_id] = player->addHud(e);
 
 	delete event->hudadd.pos;
@@ -2727,6 +2728,10 @@ void Game::handleClientEvent_HudChange(ClientEvent *event, CameraOrientation *ca
 
 		case HUD_STAT_SIZE:
 			e->size = *event->hudchange.v2s32data;
+			break;
+
+		case HUD_STAT_Z_INDEX:
+			e->z_index = event->hudchange.data;
 			break;
 	}
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -283,10 +283,24 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 {
 	u32 text_height = g_fontengine->getTextHeight();
 	irr::gui::IGUIFont* font = g_fontengine->getFont();
+
+	// Reorder elements by z_index
+	std::vector<size_t> ids;
+
 	for (size_t i = 0; i != player->maxHudId(); i++) {
 		HudElement *e = player->getHud(i);
 		if (!e)
 			continue;
+
+		auto it = ids.begin();
+		while (it != ids.end() && player->getHud(*it)->z_index <= e->z_index)
+			++it;
+
+		ids.insert(it, i);
+	}
+
+	for (size_t i : ids) {
+		HudElement *e = player->getHud(i);
 
 		v2s32 pos(floor(e->pos.X * (float) m_screensize.X + 0.5),
 				floor(e->pos.Y * (float) m_screensize.Y + 0.5));

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -43,6 +43,8 @@ const struct EnumString es_HudElementStat[] =
 	{HUD_STAT_ALIGN,  "alignment"},
 	{HUD_STAT_OFFSET, "offset"},
 	{HUD_STAT_WORLD_POS, "world_pos"},
+	{HUD_STAT_SIZE,    "size"},
+	{HUD_STAT_Z_INDEX, "z_index"},
 	{0, NULL},
 };
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -74,7 +74,8 @@ enum HudElementStat {
 	HUD_STAT_ALIGN,
 	HUD_STAT_OFFSET,
 	HUD_STAT_WORLD_POS,
-	HUD_STAT_SIZE
+	HUD_STAT_SIZE,
+	HUD_STAT_Z_INDEX,
 };
 
 struct HudElement {
@@ -90,6 +91,7 @@ struct HudElement {
 	v2f offset;
 	v3f world_pos;
 	v2s32 size;
+	s16 z_index = 0;
 };
 
 extern const EnumString es_HudElementType[];

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1081,6 +1081,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	v2f offset;
 	v3f world_pos;
 	v2s32 size;
+	s16 z_index = 0;
 
 	*pkt >> server_id >> type >> pos >> name >> scale >> text >> number >> item
 		>> dir >> align >> offset;
@@ -1092,6 +1093,11 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	try {
 		*pkt >> size;
 	} catch(SerializationError &e) {};
+
+	try {
+		*pkt >> z_index;
+	}
+	catch(PacketError &e) {}
 
 	ClientEvent *event = new ClientEvent();
 	event->type             = CE_HUDADD;
@@ -1108,6 +1114,7 @@ void Client::handleCommand_HudAdd(NetworkPacket* pkt)
 	event->hudadd.offset    = new v2f(offset);
 	event->hudadd.world_pos = new v3f(world_pos);
 	event->hudadd.size      = new v2s32(size);
+	event->hudadd.z_index   = z_index;
 	m_client_event_queue.push(event);
 }
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -561,6 +561,7 @@ enum ToClientCommand
 		v2f1000 offset
 		v3f1000 world_pos
 		v2s32 size
+		s16 z_index
 	*/
 
 	TOCLIENT_HUDRM = 0x4a,

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1851,11 +1851,13 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->size = lua_istable(L, -1) ? read_v2s32(L, -1) : v2s32();
 	lua_pop(L, 1);
 
-	elem->name   = getstringfield_default(L, 2, "name", "");
-	elem->text   = getstringfield_default(L, 2, "text", "");
-	elem->number = getintfield_default(L, 2, "number", 0);
-	elem->item   = getintfield_default(L, 2, "item", 0);
-	elem->dir    = getintfield_default(L, 2, "direction", 0);
+	elem->name    = getstringfield_default(L, 2, "name", "");
+	elem->text    = getstringfield_default(L, 2, "text", "");
+	elem->number  = getintfield_default(L, 2, "number", 0);
+	elem->item    = getintfield_default(L, 2, "item", 0);
+	elem->dir     = getintfield_default(L, 2, "direction", 0);
+	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
+			getintfield_default(L, 2, "z_index", 0)));
 
 	// Deprecated, only for compatibility's sake
 	if (elem->dir == 0)
@@ -1921,6 +1923,9 @@ void push_hud_element(lua_State *L, HudElement *elem)
 
 	push_v3f(L, elem->world_pos);
 	lua_setfield(L, -2, "world_pos");
+
+	lua_pushnumber(L, elem->z_index);
+	lua_setfield(L, -2, "z_index");
 }
 
 HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
@@ -1977,6 +1982,10 @@ HudElementStat read_hud_change(lua_State *L, HudElement *elem, void **value)
 		case HUD_STAT_SIZE:
 			elem->size = read_v2s32(L, 4);
 			*value = &elem->size;
+			break;
+		case HUD_STAT_Z_INDEX:
+			elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX, luaL_checknumber(L, 4)));
+			*value = &elem->z_index;
 			break;
 	}
 	return stat;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1627,7 +1627,8 @@ void Server::SendHUDAdd(session_t peer_id, u32 id, HudElement *form)
 
 	pkt << id << (u8) form->type << form->pos << form->name << form->scale
 			<< form->text << form->number << form->item << form->dir
-			<< form->align << form->offset << form->world_pos << form->size;
+			<< form->align << form->offset << form->world_pos << form->size
+			<< form->z_index;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
This PR adds z-index (z-order) management to HUD elements.

Usage is simple, add a "z_index" field to the HUD definition of player:hud_add.
Lower z_index elements are displayed behind higher z_index elements.

This is done by reordering elements according to their z_index before drawing them.

This PR solves two problems : 
1. Allow to put a HUD element behind already existing ones without having to remove/re-add them;
2. Ensure correct z-ordering whatever network packet reception order;

For 2, I've never seen background HUD coming to front due to packet reception order but it could happen. Anyway, for 1, removing existing HUD and reading them (for reordering purposes) in the same server step often lead to problems.