### PR TITLE
Some CSM changes

### DIFF
--- a/clientmods/preview/example.lua
+++ b/clientmods/preview/example.lua
@@ -1,2 +1,2 @@
 print("Loaded example file!, loading more examples")
-dofile("preview:examples/first.lua")
+dofile(core.get_modpath(core.get_current_modname()) .. "examples/first.lua")

--- a/clientmods/preview/example.lua
+++ b/clientmods/preview/example.lua
@@ -1,2 +1,2 @@
 print("Loaded example file!, loading more examples")
-dofile(core.get_modpath(core.get_current_modname()) .. "examples/first.lua")
+dofile(core.get_modpath(core.get_current_modname()) .. "/examples/first.lua")

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -143,8 +143,7 @@ core.after(5, function()
 		core.ui.minimap:show()
 	end
 
-	print("[PREVIEW] Day count: " .. core.get_day_count() ..
-		" time of day " .. core.get_timeofday())
+	print("[PREVIEW] Time of day " .. core.get_timeofday())
 
 	print("[PREVIEW] Node level: " .. core.get_node_level({x=0, y=20, z=0}) ..
 		" max level " .. core.get_node_max_level({x=0, y=20, z=0}))

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -1,9 +1,9 @@
-local modname = core.get_current_modname() or "??"
+local modname = assert(core.get_current_modname())
 local modstorage = core.get_mod_storage()
 local mod_channel
 
-dofile("preview:example.lua")
--- This is an example function to ensure it's working properly, should be removed before merge
+dofile(core.get_modpath(modname) .. "example.lua")
+
 core.register_on_shutdown(function()
 	print("[PREVIEW] shutdown client")
 end)

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -30,7 +30,7 @@ Startup
 Mods are loaded during client startup from the mod load paths by running
 the `init.lua` scripts in a shared environment.
 
-In order to load client-side mods in a world, the following conditions need to be satisfied:
+In order to load client-side mods, the following conditions need to be satisfied:
 
 1) `$path_user/minetest.conf` contains the setting `enable_client_modding = true`
 
@@ -43,14 +43,10 @@ be loaded or have limited functionality. See setting `csm_restriction_flags` for
 Paths
 -----
 * `RUN_IN_PLACE=1` (Windows release, local build)
-    *  `$path_user`:
-        * Linux: `<build directory>`
-        * Windows: `<build directory>`
-    * `$path_share`
-        * Linux: `<build directory>`
-        * Windows:  `<build directory>`
+    * `$path_user`: `<build directory>`
+    * `$path_share`: `<build directory>`
 * `RUN_IN_PLACE=0`: (Linux release)
-    * `$path_share`
+    * `$path_share`:
         * Linux: `/usr/share/minetest`
         * Windows: `<install directory>/minetest-0.4.x`
     * `$path_user`:
@@ -75,7 +71,6 @@ On an installed version on Linux:
 
 Modpack support
 ----------------
-**NOTE: Not implemented yet.**
 
 Mods can be put in a subdirectory, if the parent directory, which otherwise
 should be a mod, contains a file named `modpack.conf`.
@@ -90,30 +85,36 @@ Mod directory structure
 
     clientmods
     ├── modname
-    |   ├── depends.txt
-    |   ├── init.lua
+    │   ├── mod.conf
+    │   ├── init.lua
     └── another
 
 ### modname
+
 The location of this directory.
 
-### depends.txt
-List of mods that have to be loaded before loading this mod.
+### mod.conf
 
-A single line contains a single modname.
+An (optional) settings file that provides meta information about the mod.
 
-Optional dependencies can be defined by appending a question mark
-to a single modname. Their meaning is that if the specified mod
-is missing, that does not prevent this mod from being loaded.
+* `name`: The mod name. Allows Minetest to determine the mod name even if the
+          folder is wrongly named.
+* `description`: Description of mod to be shown in the Mods tab of the main
+                 menu.
+* `depends`: A comma separated list of dependencies. These are mods that must be
+             loaded before this mod.
+* `optional_depends`: A comma separated list of optional dependencies.
+                      Like a dependency, but no error if the mod doesn't exist.
 
-### init.lua
+### `init.lua`
+
 The main Lua script. Running this script should register everything it
 wants to register. Subsequent execution depends on minetest calling the
 registered callbacks.
 
-### `sounds`
-Media files (sounds) that will be transferred to the
-client and will be available for use by the mod.
+**NOTE**: Client mods currently can't provide and textures, sounds or models by
+themselves. Any media referenced in function calls must already be loaded
+(provided by mods that exist on the server).
 
 Naming convention for registered textual names
 ----------------------------------------------
@@ -142,7 +143,7 @@ The `:` prefix can also be used for maintaining backwards compatibility.
 
 Sounds
 ------
-**NOTE: max_hear_distance and connecting to objects is not implemented.**
+**NOTE: Connecting sounds to objects is not implemented.**
 
 Only Ogg Vorbis files are supported.
 
@@ -182,13 +183,11 @@ Examples of sound parameter tables:
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0, -- default
-        max_hear_distance = 32, -- default, uses an euclidean metric
     }
     -- Play connected to an object, looped
     {
         object = <an ObjectRef>,
         gain = 1.0, -- default
-        max_hear_distance = 32, -- default, uses an euclidean metric
         loop = true,
     }
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -631,6 +631,10 @@ Minetest namespace reference
 ### Utilities
 
 * `minetest.get_current_modname()`: returns the currently loading mod's name, when we are loading a mod
+* `minetest.get_modpath(modname)`: returns virtual path of given mod including
+   the trailing separator. This is useful to load additional Lua files
+   contained in your mod:
+   e.g. `dofile(minetest.get_modpath(minetest.get_current_modname()) .. "stuff.lua")`
 * `minetest.get_language()`: returns the currently set gettext language.
 * `minetest.get_version()`: returns a table containing components of the
    engine version.  Components:

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -734,8 +734,6 @@ Call these functions only at load time!
     * Optional: Variable number of arguments that are passed to `func`
 * `minetest.get_us_time()`
     * Returns time with microsecond precision. May not return wall time.
-* `minetest.get_day_count()`
-    * Returns number days elapsed since world was created, accounting for time changes.
 * `minetest.get_timeofday()`
     * Returns the time of day: `0` for midnight, `0.5` for midday
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1881,8 +1881,17 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
 	return mesh;
 }
 
-const std::string* Client::getModFile(const std::string &filename)
+const std::string* Client::getModFile(std::string filename)
 {
+	// strip dir delimiter from beginning of path
+	auto pos = filename.find_first_of(':');
+	if (pos == std::string::npos)
+		return nullptr;
+	pos++;
+	auto pos2 = filename.find_first_not_of("/", pos);
+	if (pos2 > pos)
+		filename.erase(pos, pos2 - pos);
+
 	StringMap::const_iterator it = m_mod_vfs.find(filename);
 	if (it == m_mod_vfs.end())
 		return nullptr;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -155,6 +155,7 @@ void Client::loadMods()
 	// complain about mods with unsatisfied dependencies
 	if (!modconf.isConsistent()) {
 		modconf.printUnsatisfiedModsError();
+		return;
 	}
 
 	// Print mods

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -576,8 +576,6 @@ private:
 	// Storage for mesh data for creating multiple instances of the same mesh
 	StringMap m_mesh_data;
 
-	StringMap m_mod_files;
-
 	// own state
 	LocalClientState m_state;
 
@@ -588,11 +586,13 @@ private:
 	IntervalLimiter m_localdb_save_interval;
 	u16 m_cache_save_interval;
 
+	// Client modding
 	ClientScripting *m_script = nullptr;
 	bool m_modding_enabled;
 	std::unordered_map<std::string, ModMetadata *> m_mod_storages;
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;
+	StringMap m_mod_vfs;
 
 	bool m_shutdown = false;
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -378,7 +378,7 @@ public:
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
 	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
-	const std::string* getModFile(const std::string &filename);
+	const std::string* getModFile(std::string filename);
 
 	std::string getModStoragePath() const override;
 	bool registerModStorage(ModMetadata *meta) override;

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -372,14 +372,16 @@ bool ScriptApiSecurity::isSecure(lua_State *L)
 	return secure;
 }
 
-
-#define CHECK_FILE_ERR(ret, fp) \
-	if (ret) { \
-		lua_pushfstring(L, "%s: %s", path, strerror(errno)); \
-		if (fp) std::fclose(fp); \
-		return false; \
+bool ScriptApiSecurity::safeLoadString(lua_State *L, const std::string &code, const char *chunk_name)
+{
+	if (code.size() > 0 && code[0] == LUA_SIGNATURE[0]) {
+		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
+		return false;
 	}
-
+	if (luaL_loadbuffer(L, code.data(), code.size(), chunk_name))
+		return false;
+	return true;
+}
 
 bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char *display_name)
 {
@@ -406,68 +408,49 @@ bool ScriptApiSecurity::safeLoadFile(lua_State *L, const char *path, const char 
 	int c = std::getc(fp);
 	if (c == '#') {
 		// Skip the first line
-		while ((c = std::getc(fp)) != EOF && c != '\n');
-		if (c == '\n') c = std::getc(fp);
+		while ((c = std::getc(fp)) != EOF && c != '\n') {}
+		if (c == '\n')
+			std::getc(fp);
 		start = std::ftell(fp);
-	}
-
-	if (c == LUA_SIGNATURE[0]) {
-		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
-		std::fclose(fp);
-		if (path) {
-			delete [] chunk_name;
-		}
-		return false;
 	}
 
 	// Read the file
 	int ret = std::fseek(fp, 0, SEEK_END);
 	if (ret) {
 		lua_pushfstring(L, "%s: %s", path, strerror(errno));
-		std::fclose(fp);
 		if (path) {
+			std::fclose(fp);
 			delete [] chunk_name;
 		}
 		return false;
 	}
 
 	size_t size = std::ftell(fp) - start;
-	char *code = new char[size];
+	std::string code(size, '\0');
 	ret = std::fseek(fp, start, SEEK_SET);
 	if (ret) {
 		lua_pushfstring(L, "%s: %s", path, strerror(errno));
-		std::fclose(fp);
-		delete [] code;
 		if (path) {
+			std::fclose(fp);
 			delete [] chunk_name;
 		}
 		return false;
 	}
 
-	size_t num_read = std::fread(code, 1, size, fp);
-	if (path) {
+	size_t num_read = std::fread(&code[0], 1, size, fp);
+	if (path)
 		std::fclose(fp);
-	}
 	if (num_read != size) {
 		lua_pushliteral(L, "Error reading file to load.");
-		delete [] code;
-		if (path) {
+		if (path)
 			delete [] chunk_name;
-		}
 		return false;
 	}
 
-	if (luaL_loadbuffer(L, code, size, chunk_name)) {
-		delete [] code;
-		return false;
-	}
-
-	delete [] code;
-
-	if (path) {
+	bool result = safeLoadString(L, code, chunk_name);
+	if (path)
 		delete [] chunk_name;
-	}
-	return true;
+	return result;
 }
 
 
@@ -628,14 +611,9 @@ int ScriptApiSecurity::sl_g_load(lua_State *L)
 		code += std::string(buf, len);
 		lua_pop(L, 1); // Pop return value
 	}
-	if (code[0] == LUA_SIGNATURE[0]) {
+	if (!safeLoadString(L, code, chunk_name)) {
 		lua_pushnil(L);
-		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
-		return 2;
-	}
-	if (luaL_loadbuffer(L, code.data(), code.size(), chunk_name)) {
-		lua_pushnil(L);
-		lua_insert(L, lua_gettop(L) - 1);
+		lua_insert(L, -2);
 		return 2;
 	}
 	return 1;
@@ -694,15 +672,11 @@ int ScriptApiSecurity::sl_g_loadstring(lua_State *L)
 
 	size_t size;
 	const char *code = lua_tolstring(L, 1, &size);
+	std::string code_s(code, size);
 
-	if (size > 0 && code[0] == LUA_SIGNATURE[0]) {
+	if (!safeLoadString(L, code_s, chunk_name)) {
 		lua_pushnil(L);
-		lua_pushliteral(L, "Bytecode prohibited when mod security is enabled.");
-		return 2;
-	}
-	if (luaL_loadbuffer(L, code, size, chunk_name)) {
-		lua_pushnil(L);
-		lua_insert(L, lua_gettop(L) - 1);
+		lua_insert(L, -2);
 		return 2;
 	}
 	return 1;

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -50,6 +50,8 @@ public:
 	void initializeSecurityClient();
 	// Checks if the Lua state has been secured
 	static bool isSecure(lua_State *L);
+	// Loads a string as Lua code safely (doesn't allow bytecode).
+	static bool safeLoadString(lua_State *L, const std::string &code, const char *chunk_name);
 	// Loads a file as Lua code safely (doesn't allow bytecode).
 	static bool safeLoadFile(lua_State *L, const char *path, const char *display_name = NULL);
 	// Checks if mods are allowed to read (and optionally write) to the path

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -36,9 +36,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "nodedef.h"
 
+// get_current_modname()
 int ModApiClient::l_get_current_modname(lua_State *L)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_CURRENT_MOD_NAME);
+	return 1;
+}
+
+// get_modpath(modname)
+int ModApiClient::l_get_modpath(lua_State *L)
+{
+	std::string modname = readParam<std::string>(L, 1);
+	// Client mods use a virtual filesystem, see Client::scanModSubfolder()
+	std::string path = modname + ":";
+	lua_pushstring(L, path.c_str());
 	return 1;
 }
 
@@ -365,6 +376,7 @@ int ModApiClient::l_get_builtin_path(lua_State *L)
 void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
+	API_FCT(get_modpath);
 	API_FCT(print);
 	API_FCT(display_chat_message);
 	API_FCT(send_chat_message);

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -30,6 +30,9 @@ private:
 	// get_current_modname()
 	static int l_get_current_modname(lua_State *L);
 
+	// get_modpath(modname)
+	static int l_get_modpath(lua_State *L);
+
 	// print(text)
 	static int l_print(lua_State *L);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1330,7 +1330,6 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 void ModApiEnvMod::InitializeClient(lua_State *L, int top)
 {
 	API_FCT(get_timeofday);
-	API_FCT(get_day_count);
 	API_FCT(get_node_max_level);
 	API_FCT(get_node_level);
 	API_FCT(find_node_near);


### PR DESCRIPTION
<b>DONT SQUASH</b>

* `Load client mods into memory before execution.`
  As the commit says, server-sent CSM will eventually need this since we will not want to write mod files to disk first.
* `Introduce get_modpath() for CSM`
  The "modname:path/to/file.lua" thing is an implementation detail. We may want to change it in the future, so give mods the opportunity to be (and stay) portable.
* `Corrections to client_lua_api.txt`
  Modpacks do already work in fact. max_hear_distance is a purely server-side optimization and does not make sense in the client API.
* `[CSM] Remove non-functional minetest.get_day_count()`
  The client does not know when the world was created, so remove this API (it always returned 0).

## To do

This PR is a Ready for Review.

## How to test

Verify that the preview mod still works.