### PR TITLE
Tunnels: Completely disable generation when 'cave width' >= 10

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1470,6 +1470,8 @@ mg_biome_np_humidity_blend (Humidity blend noise) noise_params_2d 0, 1.5, (8, 8,
 mgv5_spflags (Mapgen V5 specific flags) flags caverns caverns,nocaverns
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgv5_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
@@ -1602,6 +1604,8 @@ mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,cave
 mgv7_mount_zero_level (Mountain zero level) int 0
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgv7_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
@@ -1725,6 +1729,8 @@ mgcarpathian_river_depth (River channel depth) float 24.0
 mgcarpathian_valley_width (River valley width) float 0.25
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgcarpathian_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
@@ -1849,6 +1855,8 @@ mgflat_large_cave_num_max (Large cave maximum number) int 2 0 64
 mgflat_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgflat_cave_width (Cave width) float 0.09
 
 #    Terrain noise threshold for lakes.
@@ -1898,6 +1906,8 @@ mgflat_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500), 0,
 mgfractal_spflags (Mapgen Fractal specific flags) flags terrain terrain,noterrain
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgfractal_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
@@ -2076,6 +2086,8 @@ mgvalleys_river_depth (River depth) int 4
 mgvalleys_river_size (River size) int 5
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
+#    Value >= 10.0 completely disables generation of tunnels and avoids the
+#    intensive noise calculations.
 mgvalleys_cave_width (Cave width) float 0.09
 
 #    Lower Y limit of dungeons.

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -831,7 +831,9 @@ void MapgenBasic::dustTopNodes()
 
 void MapgenBasic::generateCavesNoiseIntersection(s16 max_stone_y)
 {
-	if (node_min.Y > max_stone_y)
+	// cave_width >= 10 is used to disable generation and avoid the intensive
+	// 3D noise calculations. Tunnels already have zero width when cave_width > 1.
+	if (node_min.Y > max_stone_y || cave_width >= 10.0f)
 		return;
 
 	CavesNoiseIntersection caves_noise(ndef, m_bmgr, csize,


### PR DESCRIPTION
Previously, the only way to disable the 3D noise tunnels was to set
'cave width' > 1, however doing so did not disable the very intensive
noise calculations or the generation loop.
All the other types of cave generation (randomwalk caves, caverns)
could already be independently and completely disabled.
This feature is now needed more because the small randomwalk caves are
now available for use as an alternative to the 3D noise tunnels.
///////////////////////////////////////////

Has been tested by adding a printf() after noise calculations to check those are not triggered.