### PR TITLE
Randomwalk caves: Extend beyond mapchunk vertically also

### DIFF
--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -366,11 +366,13 @@ void CavesRandomWalk::makeCave(MMVManip *vm, v3s16 nmin, v3s16 nmax,
 	// Area starting point in nodes
 	of = node_min;
 
-	// Allow a bit more (this should be more than the maximum radius of the tunnel)
+	// Allow caves to extend up to 16 nodes beyond the mapchunk edge, to allow
+	// connecting with caves of neighbor mapchunks.
+	// 'insure' is needed to avoid many 'out of voxelmanip' cave nodes.
 	const s16 insure = 2;
 	s16 more = MYMAX(MAP_BLOCKSIZE - max_tunnel_diameter / 2 - insure, 1);
-	ar += v3s16(1, 0, 1) * more * 2;
-	of -= v3s16(1, 0, 1) * more;
+	ar += v3s16(1, 1, 1) * more * 2;
+	of -= v3s16(1, 1, 1) * more;
 
 	route_y_min = 0;
 	// Allow half a diameter + 7 over stone surface


### PR DESCRIPTION
Both screenshots below are of small randomwalk caves only (dungeons and all other cave types disabled), 32 per mapchunk, with the player at a mapchunk border y = -32.

![screenshot_20191108_222905](https://user-images.githubusercontent.com/3686677/68515507-23043c80-0279-11ea-952a-91f96bb017b9.png)

^ PR

![screenshot_20191108_223645](https://user-images.githubusercontent.com/3686677/68515539-5050ea80-0279-11ea-9676-bc045b535157.png)

^ MT master

Previously, randomwalk caves only extended beyond mapchunk borders horizontally, i cannot see why, and received no answer from celeron55, he probably does not remember anyway.
Allowing vertical 'overgeneration' removes the obvious mapchunk border effect and allows more vertical interconnection of caves across mapchunk borders.
This makes the small randomwalk caves, which are now usable in all non-mgv6 mapgens, far more suitable as a tunnel network.
Of course, this also has the same effect on large randomwalk caves.
In testing i cannot yet see any problems caused. I also checked the code to see if any problems could be caused by this.