### PR TITLE
Call on_secondary_use when object is right-clicked

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6432,9 +6432,9 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
         -- default: minetest.item_place
 
         on_secondary_use = function(itemstack, user, pointed_thing),
-        -- Same as on_place but called when pointing at nothing.
+        -- Same as on_place but called when not pointing at a node.
         -- The user may be any ObjectRef or nil.
-        -- pointed_thing: always { type = "nothing" }
+        -- default: nil
 
         on_drop = function(itemstack, dropper, pos),
         -- Shall drop item and return the leftover itemstack.

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1316,6 +1316,13 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 					<< pointed_object->getDescription() << std::endl;
 
 			// Do stuff
+			if (m_script->item_OnSecondaryUse(
+					selected_item, playersao, pointed)) {
+				if (playersao->setWieldedItem(selected_item)) {
+					SendInventory(playersao, true);
+				}
+			}
+
 			pointed_object->rightClick(playersao);
 		} else if (m_script->item_OnPlace(
 				selected_item, playersao, pointed)) {
@@ -1376,8 +1383,10 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		actionstream << player->getName() << " activates "
 				<< selected_item.name << std::endl;
 
+		pointed.type = POINTEDTHING_NOTHING; // can only ever be NOTHING
+
 		if (m_script->item_OnSecondaryUse(
-				selected_item, playersao)) {
+				selected_item, playersao, pointed)) {
 			if (playersao->setWieldedItem(selected_item)) {
 				SendInventory(playersao, true);
 			}

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -115,7 +115,8 @@ bool ScriptApiItem::item_OnUse(ItemStack &item,
 	return true;
 }
 
-bool ScriptApiItem::item_OnSecondaryUse(ItemStack &item, ServerActiveObject *user)
+bool ScriptApiItem::item_OnSecondaryUse(ItemStack &item,
+		ServerActiveObject *user, const PointedThing &pointed)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
@@ -126,8 +127,6 @@ bool ScriptApiItem::item_OnSecondaryUse(ItemStack &item, ServerActiveObject *use
 
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);
-	PointedThing pointed;
-	pointed.type = POINTEDTHING_NOTHING;
 	pushPointedThing(pointed);
 	PCALL_RES(lua_pcall(L, 3, 1, error_handler));
 	if (!lua_isnil(L, -1)) {

--- a/src/script/cpp_api/s_item.h
+++ b/src/script/cpp_api/s_item.h
@@ -42,7 +42,7 @@ public:
 	bool item_OnUse(ItemStack &item,
 			ServerActiveObject *user, const PointedThing &pointed);
 	bool item_OnSecondaryUse(ItemStack &item,
-			ServerActiveObject *user);
+			ServerActiveObject *user, const PointedThing &pointed);
 	bool item_OnCraft(ItemStack &item, ServerActiveObject *user,
 			const InventoryList *old_craft_grid, const InventoryLocation &craft_inv);
 	bool item_CraftPredict(ItemStack &item, ServerActiveObject *user,


### PR DESCRIPTION
Previously it was impossible for items to capture entity right-clicks.
fixes #8950, #8995

## To do

This PR is a Ready for Review.
