### PR TITLE
Randomwalk cave liquids: Remove deprecated 'lava depth' parameter

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1477,10 +1477,6 @@ mgv5_cave_width (Cave width) float 0.09
 #    Y of upper limit of large caves.
 mgv5_large_cave_depth (Large cave depth) int -256
 
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgv5_lava_depth (Lava depth) int -256
-
 #    Minimum limit of random number of small caves per mapchunk.
 mgv5_small_cave_num_min (Small cave minimum number) int 0 0 256
 
@@ -1611,10 +1607,6 @@ mgv7_cave_width (Cave width) float 0.09
 #    Y of upper limit of large caves.
 mgv7_large_cave_depth (Large cave depth) int -33
 
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgv7_lava_depth (Lava depth) int -256
-
 #    Minimum limit of random number of small caves per mapchunk.
 mgv7_small_cave_num_min (Small cave minimum number) int 0 0 256
 
@@ -1736,10 +1728,6 @@ mgcarpathian_cave_width (Cave width) float 0.09
 #    Y of upper limit of large caves.
 mgcarpathian_large_cave_depth (Large cave depth) int -33
 
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgcarpathian_lava_depth (Lava depth) int -256
-
 #    Minimum limit of random number of small caves per mapchunk.
 mgcarpathian_small_cave_num_min (Small cave minimum number) int 0 0 256
 
@@ -1835,10 +1823,6 @@ mgflat_ground_level (Ground level) int 8
 #    Y of upper limit of large caves.
 mgflat_large_cave_depth (Large cave depth) int -33
 
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgflat_lava_depth (Lava depth) int -256
-
 #    Minimum limit of random number of small caves per mapchunk.
 mgflat_small_cave_num_min (Small cave minimum number) int 0 0 256
 
@@ -1912,10 +1896,6 @@ mgfractal_cave_width (Cave width) float 0.09
 
 #    Y of upper limit of large caves.
 mgfractal_large_cave_depth (Large cave depth) int -33
-
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgfractal_lava_depth (Lava depth) int -256
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgfractal_small_cave_num_min (Small cave minimum number) int 0 0 256
@@ -2050,10 +2030,6 @@ mgvalleys_altitude_chill (Altitude chill) int 90
 
 #    Depth below which you'll find large caves.
 mgvalleys_large_cave_depth (Large cave depth) int -33
-
-#    Deprecated, define and locate cave liquids using biome definitions instead.
-#    Y of upper limit of lava in large caves.
-mgvalleys_lava_depth (Lava depth) int 1
 
 #    Minimum limit of random number of small caves per mapchunk.
 mgvalleys_small_cave_num_min (Small cave minimum number) int 0 0 256

--- a/src/mapgen/cavegen.cpp
+++ b/src/mapgen/cavegen.cpp
@@ -281,7 +281,6 @@ CavesRandomWalk::CavesRandomWalk(
 	content_t water_source,
 	content_t lava_source,
 	float large_cave_flooded,
-	int lava_depth,
 	BiomeGen *biomegen)
 {
 	assert(ndef);
@@ -292,7 +291,6 @@ CavesRandomWalk::CavesRandomWalk(
 	this->water_level        = water_level;
 	this->np_caveliquids     = &nparams_caveliquids;
 	this->large_cave_flooded = large_cave_flooded;
-	this->lava_depth         = lava_depth;
 	this->bmgn               = biomegen;
 
 	c_water_source = water_source;
@@ -530,12 +528,12 @@ void CavesRandomWalk::carveRoute(v3f vec, float f, bool randomize_xz)
 		if (use_biome_liquid) {
 			liquidnode = c_biome_liquid;
 		} else {
-			// TODO remove this. Cave liquids are now defined and located using biome
-			// definitions.
 			// If cave liquid not defined by biome, fallback to old hardcoded behaviour.
+			// TODO 'np_caveliquids' is deprecated and should eventually be removed.
+			// Cave liquids are now defined and located using biome definitions.
 			float nval = NoisePerlin3D(np_caveliquids, startp.X,
 				startp.Y, startp.Z, seed);
-			liquidnode = (nval < 0.40f && node_max.Y < lava_depth) ?
+			liquidnode = (nval < 0.40f && node_max.Y < water_level - 256) ?
 				lavanode : waternode;
 		}
 	}

--- a/src/mapgen/cavegen.h
+++ b/src/mapgen/cavegen.h
@@ -119,9 +119,8 @@ public:
 	s32 seed;
 	int water_level;
 	float large_cave_flooded;
-	// TODO 'lava_depth' and 'np_caveliquids' are deprecated and should be removed.
+	// TODO 'np_caveliquids' is deprecated and should eventually be removed.
 	// Cave liquids are now defined and located using biome definitions.
-	int lava_depth;
 	NoiseParams *np_caveliquids;
 
 	u16 ystride;
@@ -160,8 +159,7 @@ public:
 	CavesRandomWalk(const NodeDefManager *ndef, GenerateNotifier *gennotify =
 		NULL, s32 seed = 0, int water_level = 1, content_t water_source =
 		CONTENT_IGNORE, content_t lava_source = CONTENT_IGNORE,
-		float large_cave_flooded = 0.5f, int lava_depth = -256,
-		BiomeGen *biomegen = NULL);
+		float large_cave_flooded = 0.5f, BiomeGen *biomegen = NULL);
 
 	// vm and ps are mandatory parameters.
 	// If heightmap is NULL, the surface level at all points is assumed to

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -854,7 +854,7 @@ void MapgenBasic::generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_depth)
 
 	for (u32 i = 0; i < num_small_caves; i++) {
 		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
-			c_water_source, c_lava_source, large_cave_flooded, lava_depth, biomegen);
+			c_water_source, c_lava_source, large_cave_flooded, biomegen);
 		cave.makeCave(vm, node_min, node_max, &ps, false, max_stone_y, heightmap);
 	}
 
@@ -866,7 +866,7 @@ void MapgenBasic::generateCavesRandomWalk(s16 max_stone_y, s16 large_cave_depth)
 
 	for (u32 i = 0; i < num_large_caves; i++) {
 		CavesRandomWalk cave(ndef, &gennotify, seed, water_level,
-			c_water_source, c_lava_source, large_cave_flooded, lava_depth, biomegen);
+			c_water_source, c_lava_source, large_cave_flooded, biomegen);
 		cave.makeCave(vm, node_min, node_max, &ps, true, max_stone_y, heightmap);
 	}
 }

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -285,7 +285,4 @@ protected:
 	int large_cave_num_min;
 	int large_cave_num_max;
 	float large_cave_flooded;
-	// TODO 'lava_depth' is deprecated and should be removed. Cave liquids are
-	// now defined and located using biome definitions.
-	int lava_depth;
 };

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -61,7 +61,6 @@ MapgenCarpathian::MapgenCarpathian(MapgenCarpathianParams *params, EmergeManager
 	spflags            = params->spflags;
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -155,7 +154,6 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 
 	settings->getFloatNoEx("mgcarpathian_cave_width",         cave_width);
 	settings->getS16NoEx("mgcarpathian_large_cave_depth",     large_cave_depth);
-	settings->getS16NoEx("mgcarpathian_lava_depth",           lava_depth);
 	settings->getU16NoEx("mgcarpathian_small_cave_num_min",   small_cave_num_min);
 	settings->getU16NoEx("mgcarpathian_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgcarpathian_large_cave_num_min",   large_cave_num_min);
@@ -198,7 +196,6 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 
 	settings->setFloat("mgcarpathian_cave_width",         cave_width);
 	settings->setS16("mgcarpathian_large_cave_depth",     large_cave_depth);
-	settings->setS16("mgcarpathian_lava_depth",           lava_depth);
 	settings->setU16("mgcarpathian_small_cave_num_min",   small_cave_num_min);
 	settings->setU16("mgcarpathian_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgcarpathian_large_cave_num_min",   large_cave_num_min);

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -40,7 +40,6 @@ struct MapgenCarpathianParams : public MapgenParams
 	u32 spflags              = MGCARPATHIAN_CAVERNS;
 	float cave_width         = 0.09f;
 	s16 large_cave_depth     = -33;
-	s16 lava_depth           = -256;
 	u16 small_cave_num_min   = 0;
 	u16 small_cave_num_max   = 0;
 	u16 large_cave_num_min   = 0;

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -54,7 +54,6 @@ MapgenFlat::MapgenFlat(MapgenFlatParams *params, EmergeManager *emerge)
 	spflags            = params->spflags;
 	ground_level       = params->ground_level;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -104,7 +103,6 @@ void MapgenFlatParams::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgflat_spflags", spflags, flagdesc_mapgen_flat);
 	settings->getS16NoEx("mgflat_ground_level",         ground_level);
 	settings->getS16NoEx("mgflat_large_cave_depth",     large_cave_depth);
-	settings->getS16NoEx("mgflat_lava_depth",           lava_depth);
 	settings->getU16NoEx("mgflat_small_cave_num_min",   small_cave_num_min);
 	settings->getU16NoEx("mgflat_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgflat_large_cave_num_min",   large_cave_num_min);
@@ -131,7 +129,6 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setFlagStr("mgflat_spflags", spflags, flagdesc_mapgen_flat, U32_MAX);
 	settings->setS16("mgflat_ground_level",         ground_level);
 	settings->setS16("mgflat_large_cave_depth",     large_cave_depth);
-	settings->setS16("mgflat_lava_depth",           lava_depth);
 	settings->setU16("mgflat_small_cave_num_min",   small_cave_num_min);
 	settings->setU16("mgflat_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgflat_large_cave_num_min",   large_cave_num_min);

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -35,7 +35,6 @@ struct MapgenFlatParams : public MapgenParams
 	u32 spflags = 0;
 	s16 ground_level = 8;
 	s16 large_cave_depth = -33;
-	s16 lava_depth = -256;
 	u16 small_cave_num_min = 0;
 	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -54,7 +54,6 @@ MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 	spflags            = params->spflags;
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -113,7 +112,6 @@ void MapgenFractalParams::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgfractal_spflags", spflags, flagdesc_mapgen_fractal);
 	settings->getFloatNoEx("mgfractal_cave_width",         cave_width);
 	settings->getS16NoEx("mgfractal_large_cave_depth",     large_cave_depth);
-	settings->getS16NoEx("mgfractal_lava_depth",           lava_depth);
 	settings->getU16NoEx("mgfractal_small_cave_num_min",   small_cave_num_min);
 	settings->getU16NoEx("mgfractal_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgfractal_large_cave_num_min",   large_cave_num_min);
@@ -144,7 +142,6 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, U32_MAX);
 	settings->setFloat("mgfractal_cave_width",         cave_width);
 	settings->setS16("mgfractal_large_cave_depth",     large_cave_depth);
-	settings->setS16("mgfractal_lava_depth",           lava_depth);
 	settings->setU16("mgfractal_small_cave_num_min",   small_cave_num_min);
 	settings->setU16("mgfractal_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgfractal_large_cave_num_min",   large_cave_num_min);

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -38,7 +38,6 @@ struct MapgenFractalParams : public MapgenParams
 	u32 spflags = MGFRACTAL_TERRAIN;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
-	s16 lava_depth = -256;
 	u16 small_cave_num_min = 0;
 	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -51,7 +51,6 @@ MapgenV5::MapgenV5(MapgenV5Params *params, EmergeManager *emerge)
 	spflags            = params->spflags;
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -106,7 +105,6 @@ void MapgenV5Params::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgv5_spflags", spflags, flagdesc_mapgen_v5);
 	settings->getFloatNoEx("mgv5_cave_width",         cave_width);
 	settings->getS16NoEx("mgv5_large_cave_depth",     large_cave_depth);
-	settings->getS16NoEx("mgv5_lava_depth",           lava_depth);
 	settings->getU16NoEx("mgv5_small_cave_num_min",   small_cave_num_min);
 	settings->getU16NoEx("mgv5_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgv5_large_cave_num_min",   large_cave_num_min);
@@ -134,7 +132,6 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, U32_MAX);
 	settings->setFloat("mgv5_cave_width",         cave_width);
 	settings->setS16("mgv5_large_cave_depth",     large_cave_depth);
-	settings->setS16("mgv5_lava_depth",           lava_depth);
 	settings->setU16("mgv5_small_cave_num_min",   small_cave_num_min);
 	settings->setU16("mgv5_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgv5_large_cave_num_min",   large_cave_num_min);

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -34,7 +34,6 @@ struct MapgenV5Params : public MapgenParams
 	u32 spflags = MGV5_CAVERNS;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -256;
-	s16 lava_depth = -256;
 	u16 small_cave_num_min = 0;
 	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -64,7 +64,6 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -177,7 +176,6 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getS16NoEx("mgv7_mount_zero_level",       mount_zero_level);
 	settings->getFloatNoEx("mgv7_cave_width",           cave_width);
 	settings->getS16NoEx("mgv7_large_cave_depth",       large_cave_depth);
-	settings->getS16NoEx("mgv7_lava_depth",             lava_depth);
 	settings->getU16NoEx("mgv7_small_cave_num_min",     small_cave_num_min);
 	settings->getU16NoEx("mgv7_small_cave_num_max",     small_cave_num_max);
 	settings->getU16NoEx("mgv7_large_cave_num_min",     large_cave_num_min);
@@ -218,7 +216,6 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setS16("mgv7_mount_zero_level",       mount_zero_level);
 	settings->setFloat("mgv7_cave_width",           cave_width);
 	settings->setS16("mgv7_large_cave_depth",       large_cave_depth);
-	settings->setS16("mgv7_lava_depth",             lava_depth);
 	settings->setU16("mgv7_small_cave_num_min",     small_cave_num_min);
 	settings->setU16("mgv7_small_cave_num_max",     small_cave_num_max);
 	settings->setU16("mgv7_large_cave_num_min",     large_cave_num_min);

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -45,7 +45,6 @@ struct MapgenV7Params : public MapgenParams {
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
-	s16 lava_depth = -256;
 	u16 small_cave_num_min = 0;
 	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -67,7 +67,6 @@ MapgenValleys::MapgenValleys(MapgenValleysParams *params, EmergeManager *emerge)
 
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
-	lava_depth         = params->lava_depth;
 	small_cave_num_min = params->small_cave_num_min;
 	small_cave_num_max = params->small_cave_num_max;
 	large_cave_num_min = params->large_cave_num_min;
@@ -132,7 +131,6 @@ void MapgenValleysParams::readParams(const Settings *settings)
 	settings->getFlagStrNoEx("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys);
 	settings->getU16NoEx("mgvalleys_altitude_chill",       altitude_chill);
 	settings->getS16NoEx("mgvalleys_large_cave_depth",     large_cave_depth);
-	settings->getS16NoEx("mgvalleys_lava_depth",           lava_depth);
 	settings->getU16NoEx("mgvalleys_small_cave_num_min",   small_cave_num_min);
 	settings->getU16NoEx("mgvalleys_small_cave_num_max",   small_cave_num_max);
 	settings->getU16NoEx("mgvalleys_large_cave_num_min",   large_cave_num_min);
@@ -167,7 +165,6 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setFlagStr("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys, U32_MAX);
 	settings->setU16("mgvalleys_altitude_chill",       altitude_chill);
 	settings->setS16("mgvalleys_large_cave_depth",     large_cave_depth);
-	settings->setS16("mgvalleys_lava_depth",           lava_depth);
 	settings->setU16("mgvalleys_small_cave_num_min",   small_cave_num_min);
 	settings->setU16("mgvalleys_small_cave_num_max",   small_cave_num_max);
 	settings->setU16("mgvalleys_large_cave_num_min",   large_cave_num_min);

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -49,7 +49,6 @@ struct MapgenValleysParams : public MapgenParams {
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
-	s16 lava_depth = 1;
 	u16 small_cave_num_min = 0;
 	u16 small_cave_num_max = 0;
 	u16 large_cave_num_min = 0;


### PR DESCRIPTION
 Randomwalk cave liquids: Remove deprecated 'lava depth' parameters

Low-disruption first step towards removing the hardcoded cave liquid
code. Since MT 5.0.0 cave liquids can be defined and located by
biome definitions instead.
In games that do not yet use biome definitions to define and locate
cave liquids (MTGame does), lava will now appear below
y = water_level - 256 instead of below 'lava depth' (usually y = -256).
Therefore no change in most mapgens if using the default 'lava depth'.
////////////////////////////////////////////////////

From MT 5.0.0 it has been possible to define and locate cave liquids using biome definitions, and this is the intended method for the future. The hardcoded cave liquid code will eventually be removed.

The 'lava depth' parameter has been deprecated since MT 5.0.0, this PR removes it as a first low-disruption step towards the removal of the hardcoded cave liquid code. This will also encourage users to use biome definitions to locate lava.

If cave liquids are not defined and located using biome definitions (games other than MTGame):
* In MT master, lava appears only below 'lava depth', which by default is y = -256 for most mapgens, y = 1 in mgvalleys.
* With this PR, lava appears only below y = water_level - 256, so no change for most mapgens using the default 'lava depth'.

Note that MTGame already uses biome definitions to define and locate cave liquids, so there will be no changes for anyone using MTGame.

If merged, i will make a detailed post in the news subforum to warn of the change in case anyone will be significantly affected.
If anyone has to alter code, this will just be bringing forward the inevitable, as everyone will have to define and locate cave liquids in biome definitions when the horrible hardcoded cave liquid code is completely removed in future.