### PR TITLE
switch to smallint as position key (x,y,z) in mapblocks

### DIFF
--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -187,31 +187,31 @@ void MapDatabasePostgreSQL::initStatements()
 {
 	prepareStatement("read_block",
 		"SELECT data FROM blocks "
-			"WHERE posX = $1::smallint AND posY = $2::smallint AND "
-			"posZ = $3::smallint");
+			"WHERE posX = $1::int4 AND posY = $2::int4 AND "
+			"posZ = $3::int4");
 
 	if (getPGVersion() < 90500) {
 		prepareStatement("write_block_insert",
 			"INSERT INTO blocks (posX, posY, posZ, data) SELECT "
-				"$1::smallint, $2::smallint, $3::smallint, $4::bytea "
+				"$1::int4, $2::int4, $3::int4, $4::bytea "
 				"WHERE NOT EXISTS (SELECT true FROM blocks "
-				"WHERE posX = $1::smallint AND posY = $2::smallint AND "
-				"posZ = $3::smallint)");
+				"WHERE posX = $1::int4 AND posY = $2::int4 AND "
+				"posZ = $3::int4)");
 
 		prepareStatement("write_block_update",
 			"UPDATE blocks SET data = $4::bytea "
-				"WHERE posX = $1::smallint AND posY = $2::smallint AND "
-				"posZ = $3::smallint");
+				"WHERE posX = $1::int4 AND posY = $2::int4 AND "
+				"posZ = $3::int4");
 	} else {
 		prepareStatement("write_block",
 			"INSERT INTO blocks (posX, posY, posZ, data) VALUES "
-				"($1::smallint, $2::smallint, $3::smallint, $4::bytea) "
+				"($1::int4, $2::int4, $3::int4, $4::bytea) "
 				"ON CONFLICT ON CONSTRAINT blocks_pkey DO "
 				"UPDATE SET data = $4::bytea");
 	}
 
 	prepareStatement("delete_block", "DELETE FROM blocks WHERE "
-		"posX = $1::smallint AND posY = $2::smallint AND posZ = $3::smallint");
+		"posX = $1::int4 AND posY = $2::int4 AND posZ = $3::int4");
 
 	prepareStatement("list_all_loadable_blocks",
 		"SELECT posX, posY, posZ FROM blocks");

--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -172,9 +172,9 @@ void MapDatabasePostgreSQL::createDatabase()
 {
 	createTableIfNotExists("blocks",
 		"CREATE TABLE blocks ("
-			"posX INT NOT NULL,"
-			"posY INT NOT NULL,"
-			"posZ INT NOT NULL,"
+			"posX smallint NOT NULL,"
+			"posY smallint NOT NULL,"
+			"posZ smallint NOT NULL,"
 			"data BYTEA,"
 			"PRIMARY KEY (posX,posY,posZ)"
 			");"
@@ -187,31 +187,31 @@ void MapDatabasePostgreSQL::initStatements()
 {
 	prepareStatement("read_block",
 		"SELECT data FROM blocks "
-			"WHERE posX = $1::int4 AND posY = $2::int4 AND "
-			"posZ = $3::int4");
+			"WHERE posX = $1::smallint AND posY = $2::smallint AND "
+			"posZ = $3::smallint");
 
 	if (getPGVersion() < 90500) {
 		prepareStatement("write_block_insert",
 			"INSERT INTO blocks (posX, posY, posZ, data) SELECT "
-				"$1::int4, $2::int4, $3::int4, $4::bytea "
+				"$1::smallint, $2::smallint, $3::smallint, $4::bytea "
 				"WHERE NOT EXISTS (SELECT true FROM blocks "
-				"WHERE posX = $1::int4 AND posY = $2::int4 AND "
-				"posZ = $3::int4)");
+				"WHERE posX = $1::smallint AND posY = $2::smallint AND "
+				"posZ = $3::smallint)");
 
 		prepareStatement("write_block_update",
 			"UPDATE blocks SET data = $4::bytea "
-				"WHERE posX = $1::int4 AND posY = $2::int4 AND "
-				"posZ = $3::int4");
+				"WHERE posX = $1::smallint AND posY = $2::smallint AND "
+				"posZ = $3::smallint");
 	} else {
 		prepareStatement("write_block",
 			"INSERT INTO blocks (posX, posY, posZ, data) VALUES "
-				"($1::int4, $2::int4, $3::int4, $4::bytea) "
+				"($1::smallint, $2::smallint, $3::smallint, $4::bytea) "
 				"ON CONFLICT ON CONSTRAINT blocks_pkey DO "
 				"UPDATE SET data = $4::bytea");
 	}
 
 	prepareStatement("delete_block", "DELETE FROM blocks WHERE "
-		"posX = $1::int4 AND posY = $2::int4 AND posZ = $3::int4");
+		"posX = $1::smallint AND posY = $2::smallint AND posZ = $3::smallint");
 
 	prepareStatement("list_all_loadable_blocks",
 		"SELECT posX, posY, posZ FROM blocks");


### PR DESCRIPTION
## Overview

This PR switches the postgres position type from `integer` (4 bytes) to `smallint` (2 bytes)

## Rationale

Due to the heavy amount of rows in a minetest database the index of the primary key (composite of  `posx`/`posy`/`posz`) grows very quick in the postgres backend.

In my example:
* 77+ million mapblocks/rows
* 31 gb data size

The index is now at **8.3 gb** ! (see the results below)

## Mitigation

To mitigate this the type of the primary key can be shortened from 4 bytes (-2147483648 to +2147483647) to 2 bytes (-32768 to +32767).

* Postgres type reference: https://www.postgresql.org/docs/10/datatype-numeric.html

The new range of the `smallint` can go from -32768 to +32767 and can contain all existing coordinates (mapblocks from -2048 to 2048, until something like #8660 comes along :rofl: )

## Benefits

* Smaller disk usage
* Faster index lookup

## How to test

* Compile this branch with postgres enabled
* Start a new world with a postgres backend (map)
* **OR**: Use the new code on an existing map
* Everything should work as usual

### Testing with docker

world.mt
```
backend = postgresql
pgsql_connection = host=localhost port=5432 user=postgres password=enter dbname=postgres
```

Start a throw away postgres db
```bash
sudo docker run --rm -it -p 5432:5432 -e POSTGRES_PASSWORD=enter --name postgres postgres
```

Postgres CLI
```bash
sudo docker exec -it postgres psql -U postgres
```

## My results

Before the change to `smallint`
```
postgres=# \d+
                             List of relations
 Schema |          Name          | Type  |  Owner   |  Size   | Description
--------+------------------------+-------+----------+---------+-------------
 public | blocks                 | table | postgres | 31 GB   |
 public | player                 | table | postgres | 1216 kB |
 public | player_inventories     | table | postgres | 5400 kB |
 public | player_inventory_items | table | postgres | 68 MB   |
 public | player_metadata        | table | postgres | 14 MB   |
(5 rows)

postgres=# \di+
                                            List of relations
 Schema |            Name             | Type  |  Owner   |         Table          |  Size   | Description
--------+-----------------------------+-------+----------+------------------------+---------+-------------
 public | blocks_pkey                 | index | postgres | blocks                 | 8315 MB |
 public | blocks_time                 | index | postgres | blocks                 | 1985 MB |
 public | player_inventories_pkey     | index | postgres | player_inventories     | 3048 kB |
 public | player_inventory_items_pkey | index | postgres | player_inventory_items | 43 MB   |
 public | player_metadata_pkey        | index | postgres | player_metadata        | 9968 kB |
 public | player_pkey                 | index | postgres | player                 | 320 kB  |

44G	postgres/
44G	total
```

The migration script:
```sql
alter table blocks alter posx type smallint;
alter table blocks alter posy type smallint;
alter table blocks alter posz type smallint;
```
**NOTE**: this may blow up your database temporarily until the statement is finished (double the size in my case!)

After the migration:
```
postgres=# \d+
                             List of relations
 Schema |          Name          | Type  |  Owner   |  Size   | Description 
--------+------------------------+-------+----------+---------+-------------
 public | blocks                 | table | postgres | 31 GB   | 
 public | player                 | table | postgres | 1216 kB | 
 public | player_inventories     | table | postgres | 5400 kB | 
 public | player_inventory_items | table | postgres | 68 MB   | 
 public | player_metadata        | table | postgres | 14 MB   | 
(5 rows)

postgres=# \di+
                                            List of relations
 Schema |            Name             | Type  |  Owner   |         Table          |  Size   | Description 
--------+-----------------------------+-------+----------+------------------------+---------+-------------
 public | blocks_pkey                 | index | postgres | blocks                 | 6051 MB | 
 public | blocks_time                 | index | postgres | blocks                 | 1653 MB | 
 public | player_inventories_pkey     | index | postgres | player_inventories     | 3048 kB | 
 public | player_inventory_items_pkey | index | postgres | player_inventory_items | 43 MB   | 
 public | player_metadata_pkey        | index | postgres | player_metadata        | 9968 kB | 
 public | player_pkey                 | index | postgres | player                 | 320 kB  | 
(6 rows)

root@magellan:/data/test.pandorabox.io/data# du -sch postgres/
41G     postgres/
```

Summary:
* **Index size is over 2 gb smaller**

## Performance

I haven't done any performance tests but i think the `select` and `insert` statements should perform a lot better with the reduced integer-range

## Compatibility

Old worlds are still playeable due to the type-cast in the query (`::smallint`)