### PR TITLE
Server: Improve dtime accuracy

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1517,7 +1517,7 @@ bool Game::connectToServer(const std::string &playername,
 			client->step(dtime);
 
 			if (server != NULL)
-				server->step(dtime);
+				server->step();
 
 			// End condition
 			if (client->getState() == LC_Init) {
@@ -1591,7 +1591,7 @@ bool Game::getServerContent(bool *aborted)
 		client->step(dtime);
 
 		if (server != NULL)
-			server->step(dtime);
+			server->step();
 
 		// End condition
 		if (client->mediaReceived() && client->itemdefReceived() &&
@@ -2501,9 +2501,11 @@ inline void Game::step(f32 *dtime)
 
 	if (can_be_and_is_paused) { // This is for a singleplayer server
 		*dtime = 0;             // No time passes
+		if (server)
+			server->lockStep();
 	} else {
 		if (server)
-			server->step(*dtime);
+			server->step();
 
 		client->step(*dtime);
 	}

--- a/src/porting.h
+++ b/src/porting.h
@@ -266,17 +266,18 @@ inline u64 getTime(TimePrecision prec)
 
 /**
  * Delta calculation function arguments.
+ * WARNING: To handle overflows correctly, provide u64 only (no cast)
  * @param old_time_ms old time for delta calculation
  * @param new_time_ms new time for delta calculation
  * @return positive delta value
  */
 inline u64 getDeltaMs(u64 old_time_ms, u64 new_time_ms)
 {
-	if (new_time_ms >= old_time_ms) {
-		return (new_time_ms - old_time_ms);
-	}
+	if (new_time_ms >= old_time_ms)
+		return new_time_ms - old_time_ms;
 
-	return (old_time_ms - new_time_ms);
+	// Compensate overflows
+	return ~old_time_ms + 1 + new_time_ms;
 }
 
 inline const char *getPlatformName()

--- a/src/unittest/test_utilities.cpp
+++ b/src/unittest/test_utilities.cpp
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <cmath>
 #include "util/numeric.h"
 #include "util/string.h"
+#include "porting.h"
 
 class TestUtilities : public TestBase {
 public:
@@ -54,6 +55,7 @@ public:
 	void testMyround();
 	void testStringJoin();
 	void testEulerConversion();
+	void testGetDeltaMs();
 };
 
 static TestUtilities g_test_instance;
@@ -84,6 +86,7 @@ void TestUtilities::runTests(IGameDef *gamedef)
 	TEST(testMyround);
 	TEST(testStringJoin);
 	TEST(testEulerConversion);
+	TEST(testGetDeltaMs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -507,4 +510,14 @@ void TestUtilities::testEulerConversion()
 	// ... however the rotation matrix is the same for both
 	setPitchYawRoll(m2, v2);
 	UASSERT(within(m1, m2, tolL));
+}
+
+void TestUtilities::testGetDeltaMs()
+{
+	u64 old_ms = 3UL;
+	u64 new_ms = 8UL;
+	UASSERT(porting::getDeltaMs(old_ms, new_ms) == 5);
+	old_ms = (u64)-4;
+	new_ms = 2;
+	UASSERT(porting::getDeltaMs(old_ms, new_ms) == 6);
 }


### PR DESCRIPTION
This PR decouples `ServerThread::run()` from `dedicated_server_loop()` to measure the exact delta time rather than having multiples of `dedicated_server_step`.
`dtime` values will now be accurate due to before/after time comparisons.

## To do

This PR is Ready for Review.

## How to test
```Lua
local min_ms = 999999
local max_ms = 0
local time_s = 0

minetest.register_globalstep(function(dtime)
	time_s = time_s + dtime
	dtime = dtime * 1000

	min_ms = math.min(min_ms, dtime)
	max_ms = math.max(max_ms, dtime)

	print(("time_s=% 3.0f, min_ms=% 3.1f, max_ms=% 3.1f, dtime_ms=% 3.1f")
		:format(time_s, min_ms, max_ms, dtime))
end)
```
<details>
<summary>Before</summary>

```
time_s=  3, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  3, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  3, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  3, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
2019-11-14 19:44:03: ACTION[Server]: Krock [127.0.0.1] joins game. 
2019-11-14 19:44:03: ACTION[Server]: Krock joins game. List of players: Krock
time_s=  4, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  4, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  4, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
time_s=  4, min_ms= 0.0, max_ms= 80.0, dtime_ms= 80.0
```
</details>
<details>
<summary>After</summary>

```
time_s=  2, min_ms= 80.0, max_ms= 81.0, dtime_ms= 80.0
time_s=  3, min_ms= 80.0, max_ms= 81.0, dtime_ms= 80.0
time_s=  3, min_ms= 80.0, max_ms= 81.0, dtime_ms= 80.0
time_s=  3, min_ms= 80.0, max_ms= 81.0, dtime_ms= 80.0
2019-11-14 19:44:34: ACTION[Server]: Krock [127.0.0.1] joins game. 
2019-11-14 19:44:34: ACTION[Server]: Krock joins game. List of players: Krock
time_s=  3, min_ms= 80.0, max_ms= 92.0, dtime_ms= 92.0
time_s=  3, min_ms= 80.0, max_ms= 92.0, dtime_ms= 80.0
time_s=  3, min_ms= 80.0, max_ms= 92.0, dtime_ms= 80.0
time_s=  3, min_ms= 80.0, max_ms= 92.0, dtime_ms= 80.0
```
</details>