### PR TITLE
Fix find_path for newer jsoncpp installations

### DIFF
--- a/cmake/Modules/FindJson.cmake
+++ b/cmake/Modules/FindJson.cmake
@@ -8,7 +8,7 @@ option(ENABLE_SYSTEM_JSONCPP "Enable using a system-wide JSONCPP.  May cause seg
 
 if(ENABLE_SYSTEM_JSONCPP)
 	find_library(JSON_LIBRARY NAMES jsoncpp)
-	find_path(JSON_INCLUDE_DIR json/features.h PATH_SUFFIXES jsoncpp)
+	find_path(JSON_INCLUDE_DIR json/allocator.h PATH_SUFFIXES jsoncpp)
 
 	include(FindPackageHandleStandardArgs)
 	find_package_handle_standard_args(JSONCPP DEFAULT_MSG JSON_LIBRARY JSON_INCLUDE_DIR)


### PR DESCRIPTION
The upstream JsonCpp project has renamed the `json/features.h` file to
`json/json_features.h`. This patch fixes the JsonCpp installation search
by looking for `json/allocator.h` which has not been renamed on newer
versions of JsonCpp.

Fixes: https://github.com/minetest/minetest/issues/9119