### PR TITLE
Allow relative directories for `screenshot_path`, tweak default path

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -902,8 +902,9 @@ fallback_font_shadow_alpha (Fallback font shadow alpha) int 128 0 255
 #    This font will be used for certain languages or if the default font is unavailable.
 fallback_font_path (Fallback font path) filepath fonts/DroidSansFallbackFull.ttf
 
-#    Path to save screenshots at.
-screenshot_path (Screenshot folder) path
+#    Path to save screenshots at. Can be an absolute or relative path.
+#    The folder will be created if it doesn't already exist.
+screenshot_path (Screenshot folder) path screenshots
 
 #    Format of screenshots.
 screenshot_format (Screenshot format) enum png png,jpg,bmp,pcx,ppm,tga

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1774,12 +1774,23 @@ void Client::makeScreenshot()
 	char timetstamp_c[64];
 	strftime(timetstamp_c, sizeof(timetstamp_c), "%Y%m%d_%H%M%S", tm);
 
-	std::string filename_base = g_settings->get("screenshot_path")
+	std::string screenshot_dir;
+
+	if (fs::IsPathAbsolute(g_settings->get("screenshot_path")))
+		screenshot_dir = g_settings->get("screenshot_path");
+	else
+		screenshot_dir = porting::path_user + DIR_DELIM + g_settings->get("screenshot_path");
+
+	std::string filename_base = screenshot_dir
 			+ DIR_DELIM
 			+ std::string("screenshot_")
 			+ std::string(timetstamp_c);
 	std::string filename_ext = "." + g_settings->get("screenshot_format");
 	std::string filename;
+
+	// Create the directory if it doesn't already exist.
+	// Otherwise, saving the screenshot would fail.
+	fs::CreateDir(screenshot_dir);
 
 	u32 quality = (u32)g_settings->getS32("screenshot_quality");
 	quality = MYMIN(MYMAX(quality, 0), 100) / 100.0 * 255;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -47,7 +47,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("pitch_move", "false");
 	settings->setDefault("fast_move", "false");
 	settings->setDefault("noclip", "false");
-	settings->setDefault("screenshot_path", ".");
+	settings->setDefault("screenshot_path", "screenshots");
 	settings->setDefault("screenshot_format", "png");
 	settings->setDefault("screenshot_quality", "0");
 	settings->setDefault("client_unload_unused_data_timeout", "600");


### PR DESCRIPTION
This will likely be more intuitive for users and should play better with sandboxed distributions such as Flatpak.

In addition, the screenshot directory will now be created if it doesn't exist already.

PS: Should I update `minetest.conf.example`? If not, its header should be changed to denote that it's a generated file (it's not clear right now).

## To do

This PR is a Ready for Review.

## How to test

Build it, start Minetest and take screenshots :slightly_smiling_face: