### PR TITLE
Move duplicated mapgen parameters to class MapgenBasic

### DIFF
--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -285,4 +285,7 @@ protected:
 	int large_cave_num_min;
 	int large_cave_num_max;
 	float large_cave_flooded;
+	s16 large_cave_depth;
+	s16 dungeon_ymin;
+	s16 dungeon_ymax;
 };

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -93,10 +93,6 @@ private:
 	float river_depth;
 	float valley_width;
 
-	s16 large_cave_depth;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
-
 	Noise *noise_height1;
 	Noise *noise_height2;
 	Noise *noise_height3;

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -75,13 +75,10 @@ public:
 
 private:
 	s16 ground_level;
-	s16 large_cave_depth;
 	float lake_threshold;
 	float lake_steepness;
 	float hill_threshold;
 	float hill_steepness;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
 
 	Noise *noise_terrain;
 };

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -85,10 +85,6 @@ public:
 private:
 	u16 formula;
 	bool julia;
-
-	s16 large_cave_depth;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
 	u16 fractal;
 	u16 iterations;
 	v3f scale;

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -74,10 +74,6 @@ public:
 	int generateBaseTerrain();
 
 private:
-	s16 large_cave_depth;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
-
 	Noise *noise_factor;
 	Noise *noise_height;
 	Noise *noise_ground;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -108,10 +108,6 @@ private:
 	s16 floatland_level;
 	s16 shadow_limit;
 
-	s16 large_cave_depth;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
-
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
 	Noise *noise_terrain_persist;

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -100,10 +100,6 @@ private:
 	float river_depth_bed;
 	float river_size_factor;
 
-	s16 large_cave_depth;
-	s16 dungeon_ymin;
-	s16 dungeon_ymax;
-
 	Noise *noise_inter_valley_fill;
 	Noise *noise_inter_valley_slope;
 	Noise *noise_rivers;


### PR DESCRIPTION
These 3 mapgen parameters should have been in MapgenBasic from the start because they appear in multiple mapgens.
Now, each mapgen class only contains the parameters unique to that mapgen.

EDIT:
Now tested.