### PR TITLE
Add core.get_player_meta

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4395,6 +4395,12 @@ Environment access
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
+* `minetest.get_player_meta(name)`
+    * Get a `PlayerMetaRef` for an online or offline player
+    * Returns:
+        * `online`: boolean indicating whether the player is online
+        * `meta`: `PlayerMetaRef` or nil when the player does not exist
+    * If `online == false`: `PlayerMetaRef` is a copy. Changes will be lost.
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.
     * `radius`: using an euclidean metric

--- a/src/script/lua_api/l_playermeta.h
+++ b/src/script/lua_api/l_playermeta.h
@@ -30,6 +30,7 @@ class PlayerMetaRef : public MetaDataRef
 {
 private:
 	Metadata *metadata = nullptr;
+	bool m_is_copy;
 
 	static const char className[];
 	static const luaL_Reg methods[];
@@ -46,12 +47,21 @@ private:
 	static int gc_object(lua_State *L);
 
 public:
-	PlayerMetaRef(Metadata *metadata) : metadata(metadata) {}
-	~PlayerMetaRef() = default;
+	PlayerMetaRef(Metadata *metadata, bool copy);
+	~PlayerMetaRef();
 
 	// Creates an ItemStackMetaRef and leaves it on top of stack
 	// Not callable from Lua; all references are created on the C side.
-	static void create(lua_State *L, Metadata *metadata);
+	static void create(lua_State *L, Metadata *metadata, bool copy = false);
 
 	static void Register(lua_State *L);
+};
+
+class ModApiPlayerMeta : public ModApiBase
+{
+private:
+	static int l_get_player_meta(lua_State *L);
+
+public:
+	static void Initialize(lua_State *L, int top);
 };

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -116,6 +116,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ModApiParticles::Initialize(L, top);
 	ModApiRollback::Initialize(L, top);
 	ModApiServer::Initialize(L, top);
+	ModApiPlayerMeta::Initialize(L, top);
 	ModApiUtil::Initialize(L, top);
 	ModApiHttp::Initialize(L, top);
 	ModApiStorage::Initialize(L, top);

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -363,6 +363,7 @@ public:
 	static bool migratePlayersDatabase(const GameParams &game_params,
 			const Settings &cmd_args);
 
+	PlayerDatabase *getPlayerDatabase() { return m_player_database; }
 	AuthDatabase *getAuthDatabase() { return m_auth_database; }
 	static bool migrateAuthDatabase(const GameParams &game_params,
 			const Settings &cmd_args);


### PR DESCRIPTION
`core.get_player_meta` will load the player's metadata into memory as read-only if the player is not online. Otherwise it is equal to `player:get_meta()`.
Likely not the best solution (read-only), but I hope it's good enough.

## How to test
```Lua
minetest.register_chatcommand("get", {
	func = function(name, param)
		local online, meta = minetest.get_player_meta(param)
		print(online, dump(meta))
	end
})
```