### PR TITLE
Add core.get_player_or_load

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4655,6 +4655,17 @@ Environment access
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
+* `minetest.get_player_or_load(name)`
+    * Get an `ObjectRef` for an online or offline player
+    * Returns:
+        * `online`: boolean indicating whether the player is online
+        * `player`: `ObjectRef` or nil when the player does not exist
+    * If `online == false`:
+        * As long the `ObjectRef` is valid, the real player cannot join the
+	      server. Use `ObjectRef:close()` to unload the player after use.
+        * The returned `player` can only be used to modify player-bound
+          properties such as HP, inventory and MetaData.
+        * Use `ObjectRef:close(true)` to save changes
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.
     * `radius`: using an euclidean metric
@@ -6224,6 +6235,9 @@ object you are working with still exists.
     * Returns `false` if failed.
     * Resource intensive - use sparsely
     * To get blockpos, integer divide pos by 16
+* `close(save)`
+    * Unloads a manually loaded player. No-op for online players.
+    * `save`: boolean, whether to save the player data
 
 `PcgRandom`
 -----------

--- a/src/database/database-files.cpp
+++ b/src/database/database-files.cpp
@@ -137,6 +137,9 @@ bool PlayerDatabaseFiles::removePlayer(const std::string &name)
 
 bool PlayerDatabaseFiles::loadPlayer(RemotePlayer *player, PlayerSAO *sao)
 {
+	if (strlen(player->getName()) == 0)
+		return false;
+
 	std::string players_path = m_savedir + DIR_DELIM;
 	std::string path = players_path + player->getName();
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -83,6 +83,7 @@ struct ItemStack
 	// Maximum size of a stack
 	u16 getStackMax(IItemDefManager *itemdef) const
 	{
+		assert(itemdef);
 		return itemdef->get(name).stack_max;
 	}
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -33,13 +33,14 @@ class RemotePlayer;
 
 class ObjectRef : public ModApiBase {
 public:
-	ObjectRef(ServerActiveObject *object);
+	ObjectRef(ServerActiveObject *object, bool is_loaded_player);
 
-	~ObjectRef() = default;
+	~ObjectRef();
 
 	// Creates an ObjectRef and leaves it on top of stack
 	// Not callable from Lua; all references are created on the C side.
-	static void create(lua_State *L, ServerActiveObject *object);
+	static void create(lua_State *L, ServerActiveObject *object,
+		bool is_loaded_player = false);
 
 	static void set_null(lua_State *L);
 
@@ -50,6 +51,7 @@ public:
 	static ServerActiveObject* getobject(ObjectRef *ref);
 private:
 	ServerActiveObject *m_object = nullptr;
+	bool m_is_loaded_player;
 	static const char className[];
 	static luaL_Reg methods[];
 
@@ -64,6 +66,8 @@ private:
 
 	// garbage collector
 	static int gc_object(lua_State *L);
+
+	void deleteLoadedPlayer();
 
 	// remove(self)
 	static int l_remove(lua_State *L);
@@ -383,4 +387,16 @@ private:
 
 	// send_mapblock(pos)
 	static int l_send_mapblock(lua_State *L);
+
+	// close(self, save)
+	static int l_close(lua_State *L);
+};
+
+class ModApiObjectRef : public ModApiBase
+{
+private:
+	static int l_get_player_or_load(lua_State *L);
+
+public:
+	static void Initialize(lua_State *L, int top);
 };

--- a/src/script/lua_api/l_playermeta.cpp
+++ b/src/script/lua_api/l_playermeta.cpp
@@ -25,6 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /*
 	PlayerMetaRef
 */
+
 PlayerMetaRef *PlayerMetaRef::checkobject(lua_State *L, int narg)
 {
 	luaL_checktype(L, narg, LUA_TUSERDATA);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -116,6 +116,7 @@ void ServerScripting::InitializeModApi(lua_State *L, int top)
 	ModApiParticles::Initialize(L, top);
 	ModApiRollback::Initialize(L, top);
 	ModApiServer::Initialize(L, top);
+	ModApiObjectRef::Initialize(L, top);
 	ModApiUtil::Initialize(L, top);
 	ModApiHttp::Initialize(L, top);
 	ModApiStorage::Initialize(L, top);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -325,6 +325,12 @@ Server::~Server()
 		delete m_thread;
 	}
 
+	m_env->destructBeforeScripting();
+
+	// Deinitialize scripting before "m_env" to unload manually loaded players
+	infostream << "Server: Deinitializing scripting" << std::endl;
+	delete m_script;
+
 	// Delete things in the reverse order of creation
 	delete m_emerge;
 	delete m_env;
@@ -333,10 +339,6 @@ Server::~Server()
 	delete m_itemdef;
 	delete m_nodedef;
 	delete m_craftdef;
-
-	// Deinitialize scripting
-	infostream << "Server: Deinitializing scripting" << std::endl;
-	delete m_script;
 
 	// Delete detached inventories
 	for (auto &detached_inventory : m_detached_inventories) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -464,20 +464,9 @@ ServerEnvironment::ServerEnvironment(ServerMap *map,
 
 ServerEnvironment::~ServerEnvironment()
 {
-	// Clear active block list.
-	// This makes the next one delete all active objects.
-	m_active_blocks.clear();
-
-	// Convert all objects to static and delete the active objects
-	deactivateFarObjects(true);
 
 	// Drop/delete map
 	m_map->drop();
-
-	// Delete ActiveBlockModifiers
-	for (ABMWithState &m_abm : m_abms) {
-		delete m_abm.abm;
-	}
 
 	// Deallocate players
 	for (RemotePlayer *m_player : m_players) {
@@ -486,6 +475,26 @@ ServerEnvironment::~ServerEnvironment()
 
 	delete m_player_database;
 	delete m_auth_database;
+}
+
+void ServerEnvironment::destructBeforeScripting()
+{
+	// This function prepares for the server shutdown
+	// Delink everything from ServerScripting
+
+	// Clear active block list.
+	// This makes the next one delete all active objects.
+	m_active_blocks.clear();
+
+	// Convert all objects to static and delete the active objects
+	deactivateFarObjects(true);
+
+	// Delete ActiveBlockModifiers
+	for (ABMWithState &m_abm : m_abms) {
+		delete m_abm.abm;
+	}
+
+	m_script = nullptr;
 }
 
 Map & ServerEnvironment::getMap()

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -204,6 +204,7 @@ public:
 	ServerEnvironment(ServerMap *map, ServerScripting *scriptIface,
 		Server *server, const std::string &path_world);
 	~ServerEnvironment();
+	void destructBeforeScripting();
 
 	Map & getMap();
 
@@ -355,6 +356,7 @@ public:
 	static bool migratePlayersDatabase(const GameParams &game_params,
 			const Settings &cmd_args);
 
+	PlayerDatabase *getPlayerDatabase() { return m_player_database; }
 	AuthDatabase *getAuthDatabase() { return m_auth_database; }
 	static bool migrateAuthDatabase(const GameParams &game_params,
 			const Settings &cmd_args);


### PR DESCRIPTION
Extended functionality based on #9164.
This PR adds `minetest.get_player_or_load(name)` which returns a `PlayerRef` to read and write player data.
Because this is not a real player, the server has no control about the lifespan of this variable. Use `player:close(true)` to save changes.

EDIT: Fixes #6193

**Possible use-cases:**
1) Show inventory of an offline player
2) Modify metadata of an offline player
3) Donation box that goes directly to the offline player
4) Checking whether a certain player exists in the database

## To do

This PR is Ready for Review.

## How to test

```Lua
minetest.register_chatcommand("get", {
	func = function(name, param)
		local online, player = minetest.get_player_or_load(param)
		print(online, dump(player))
		if not player then
			return false, "Player does not exist."
		end
		local meta = player:get_meta()
		print(meta:get_string("yeet"))
		meta:set_string("yeet", "true")
		player:set_hp(15)

		local inv = player:get_inventory()
		inv:add_item("main", "default:mese")

		player:close(true)
		return true, "Saved!";
	end
})
```
