### PR TITLE
Ignore build/, except build/android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ doc/mkdocs/mkdocs.yml
 ## Build files
 CMakeFiles
 Makefile
+build
+!build/android
 !build/android/Makefile
 build/android/path.cfg
 build/android/*.apk


### PR DESCRIPTION
It's common to use `build/` as a build directory for CMake. I prefer it to be like that, because it reduces the auto-generated clutter in the root directory

## Alternatives

Move build/android somewhere else