### PR TITLE
Add standalone formspec renderer

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -40,6 +40,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 #ifdef __ANDROID__
 	#include "porting.h"
+#else
+	#include "gui/StandaloneFormspecRenderer.h"
 #endif
 
 /* mainmenumanager.h
@@ -105,7 +107,7 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	}
 
 	RenderingEngine::get_instance()->setupTopLevelWindow(PROJECT_NAME_C);
-	
+
 	/*
 		This changes the minimum allowed number of vertices in a VBO.
 		Default is 500.
@@ -161,6 +163,14 @@ bool ClientLauncher::run(GameParams &game_params, const Settings &cmd_args)
 	// Irrlicht 1.8 input colours
 	skin->setColor(gui::EGDC_EDITABLE, video::SColor(255, 128, 128, 128));
 	skin->setColor(gui::EGDC_FOCUSED_EDITABLE, video::SColor(255, 96, 134, 49));
+#endif
+
+#ifndef __ANDROID__
+	// Run formspec integration tests
+	if (cmd_args.getFlag("render-formspec")) {
+		StandaloneFormspecRenderer renderer;
+		return renderer.renderPath(cmd_args.get("file"), cmd_args.get("o"));
+	}
 #endif
 
 	// Create the menu clouds

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,5 +21,6 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/intlGUIEditBox.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/modalMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/profilergraph.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/StandaloneFormspecRenderer.cpp
 	PARENT_SCOPE
 )

--- a/src/gui/StandaloneFormspecRenderer.cpp
+++ b/src/gui/StandaloneFormspecRenderer.cpp
@@ -1,0 +1,132 @@
+#include "StandaloneFormspecRenderer.h"
+
+#include <iostream>
+
+#include "porting.h"
+#include "client/renderingengine.h"
+#include "settings.h"
+
+// Anonymous namespace
+namespace
+{
+
+class MockTextDest : public TextDest
+{
+public:
+	/**
+	 * receive fields transmitted by guiFormSpecMenu
+	 * @param fields map containing formspec field elements currently active
+	 */
+	void gotText(const StringMap &fields) override {}
+
+	/**
+	 * receive text/events transmitted by guiFormSpecMenu
+	 * @param text textual representation of event
+	 */
+	void gotText(const std::wstring &text) override {}
+};
+
+class MockMenuManager : public IMenuManager {
+	void createdMenu(gui::IGUIElement *menu) override {}
+	void deletingMenu(gui::IGUIElement *menu) override {}
+};
+
+} // End anonymous namespace
+
+
+StandaloneFormspecRenderer::StandaloneFormspecRenderer()
+{
+	// Deleted by formspec menu
+	m_buttonhandler = new MockTextDest();
+
+	m_texture_source = new MenuTextureSource(RenderingEngine::get_video_driver());
+	m_formspecgui = new FormspecFormSource("");
+	menuManager = new MockMenuManager();
+
+	root = RenderingEngine::get_gui_env()->addStaticText(
+			L"", core::rect<s32>(0, 0, 10000, 10000));
+
+	/* Create menu */
+	m_menu = new GUIFormSpecMenu(nullptr, root, -1, menuManager, NULL /* &client */,
+			m_texture_source, m_formspecgui, m_buttonhandler, "", false);
+
+	m_menu->allowClose(false);
+	m_menu->lockSize(true, v2u32(800,600));
+}
+
+StandaloneFormspecRenderer::~StandaloneFormspecRenderer()
+{
+	// TODO: delete things
+
+	// delete m_menu;
+	// delete root;
+	// delete menuManager;
+	// delete m_formspecgui;
+	// delete m_texture_source;
+}
+
+bool StandaloneFormspecRenderer::renderPath(
+		const std::string &path, const std::string &outputPath)
+{
+	std::ifstream stream(path);
+	if (!stream.good()) {
+		errorstream << "Unable to read from path: " << path << std::endl;
+		return false;
+	}
+
+	std::string source((std::istreambuf_iterator<char>(stream)),
+			std::istreambuf_iterator<char>());
+
+	return renderSource(source, outputPath);
+}
+
+bool takeScreenshot(video::IVideoDriver *driver, const std::string &outputPath)
+{
+	irr::video::IImage *const raw_image = driver->createScreenShot();
+	if (!raw_image) {
+		errorstream << "Unable to take screenshot" << std::endl;
+		return false;
+	}
+
+	irr::video::IImage *const image =
+			driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
+	if (!image) {
+		errorstream << "Unable to convert screenshot to image" << std::endl;
+		return false;
+	}
+
+	raw_image->copyTo(image);
+
+	u32 quality = (u32)g_settings->getS32("screenshot_quality");
+	quality = MYMIN(MYMAX(quality, 0), 100) / 100.0 * 255;
+
+	if (driver->writeImageToFile(image, outputPath.c_str(), quality)) {
+		infostream << "Saved screenshot to '" << outputPath << "'";
+	} else {
+		errorstream << "Failed to save screenshot '" << outputPath << "'";
+		return false;
+	}
+
+	image->drop();
+
+	return true;
+}
+
+bool StandaloneFormspecRenderer::renderSource(
+		const std::string &source, const std::string &outputPath)
+{
+	m_formspecgui->setForm(source);
+
+	bool *kill = porting::signal_handler_killstatus();
+
+	const video::SColor sky_color(255, 140, 186, 250);
+	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
+
+	assert(RenderingEngine::run() && !(*kill));
+
+	driver->beginScene(true, true, sky_color);
+	RenderingEngine::get_gui_env()->drawAll();
+	driver->endScene();
+
+	return takeScreenshot(driver, outputPath);
+}

--- a/src/gui/StandaloneFormspecRenderer.h
+++ b/src/gui/StandaloneFormspecRenderer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef __ANDROID__
+#error formspectestexecutor.h should not be included on Android
+#endif
+
+#include <string>
+#include "guiFormSpecMenu.h"
+#include "guiEngine.h"
+
+class StandaloneFormspecRenderer
+{
+	ISimpleTextureSource *m_texture_source;
+	FormspecFormSource *m_formspecgui;
+	TextDest *m_buttonhandler;
+	IMenuManager *menuManager;
+	IGUIElement *root;
+	GUIFormSpecMenu *m_menu;
+
+public:
+	StandaloneFormspecRenderer();
+	~StandaloneFormspecRenderer();
+
+	/// @param path Path to a file containing formspec code
+	/// @param outputPath Where to save the screenshot
+	bool renderPath(const std::string &testPath, const std::string &outputPath);
+
+	/// @param source The formspec source
+	/// @param outputPath Where to save the screenshot
+	bool renderSource(const std::string &source, const std::string &outputPath);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,7 +263,7 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Run the unit tests and exit"))));
 #ifndef __ANDROID__
 	allowed_options->insert(std::make_pair("render-formspec", ValueSpec(VALUETYPE_FLAG,
-			_("Batch task: render a formspec in file given by --flag, and ouput a screenshot to the path given -o, then exit"))));
+			_("Batch task: render a formspec in file given by --file, and ouput a screenshot to the path given -o, then exit"))));
 	allowed_options->insert(std::make_pair("file", ValueSpec(VALUETYPE_STRING,
 			_("Input file for batch tasks"))));
 	allowed_options->insert(std::make_pair("o", ValueSpec(VALUETYPE_STRING,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,6 +261,14 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Set network port (UDP)"))));
 	allowed_options->insert(std::make_pair("run-unittests", ValueSpec(VALUETYPE_FLAG,
 			_("Run the unit tests and exit"))));
+#ifndef __ANDROID__
+	allowed_options->insert(std::make_pair("render-formspec", ValueSpec(VALUETYPE_FLAG,
+			_("Batch task: render a formspec in file given by --flag, and ouput a screenshot to the path given -o, then exit"))));
+	allowed_options->insert(std::make_pair("file", ValueSpec(VALUETYPE_STRING,
+			_("Input file for batch tasks"))));
+	allowed_options->insert(std::make_pair("o", ValueSpec(VALUETYPE_STRING,
+			_("Output file for batch tasks"))));
+#endif
 	allowed_options->insert(std::make_pair("map-dir", ValueSpec(VALUETYPE_STRING,
 			_("Same as --world (deprecated)"))));
 	allowed_options->insert(std::make_pair("world", ValueSpec(VALUETYPE_STRING,


### PR DESCRIPTION
The aim of this PR is to introduce a new way to create formspec screenshots, for use in automated testing. This is done by adding a new formspec environment called `StandaloneFormspecRenderer`, and command line options to use it

## To do

- [ ] Implement destructor
- [ ] Improve CLI arguments

## How to test

```sh
echo "size[3,3]button[1,1;2,2;btn;Button]" > /tmp/button.fs
./bin/minetest --render-formspec --file /tmp/button.fs --o /tmp/formspec.png
xdg-open /tmp/formspec.png
```
