### PR TITLE
Add the `countdown` argument to minetest.request_shutdown

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4915,12 +4915,13 @@ Timing
 Server
 ------
 
-* `minetest.request_shutdown([message],[reconnect],[delay])`: request for
+* `minetest.request_shutdown([message],[reconnect],[delay],[countdown_msg])`: request for
   server shutdown. Will display `message` to clients.
     * `reconnect` == true displays a reconnect button
     * `delay` adds an optional delay (in seconds) before shutdown.
       Negative delay cancels the current active shutdown.
       Zero delay triggers an immediate shutdown.
+    * `countdown_msg` message displayed during countdown
 * `minetest.cancel_shutdown_requests()`: cancel current delayed shutdown
 * `minetest.get_server_status(name, joined)`
     * Returns the server status string when a player joins or when the command

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4922,6 +4922,7 @@ Server
       Negative delay cancels the current active shutdown.
       Zero delay triggers an immediate shutdown.
     * `countdown_msg` message displayed during countdown
+      The placeholder `@1` will be replaced by the countdown time.
 * `minetest.cancel_shutdown_requests()`: cancel current delayed shutdown
 * `minetest.get_server_status(name, joined)`
     * Returns the server status string when a player joins or when the command

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -35,7 +35,14 @@ int ModApiServer::l_request_shutdown(lua_State *L)
 	const char *msg = lua_tolstring(L, 1, NULL);
 	bool reconnect = readParam<bool>(L, 2);
 	float seconds_before_shutdown = lua_tonumber(L, 3);
-	getServer(L)->requestShutdown(msg ? msg : "", reconnect, seconds_before_shutdown);
+	const char *countdown_msg = lua_tolstring(L, 4, NULL);
+	Server::ShutdownInformation info {
+		.should_reconnect = reconnect,
+		.countdown_message = countdown_msg ? countdown_msg : "*** Server shutting down in @1.",
+		.message = msg ? msg : "",
+		.delay = seconds_before_shutdown
+	};
+	getServer(L)->requestShutdown(info);
 	return 0;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -372,7 +372,7 @@ private:
 		friend class TestServerShutdownState;
 		public:
 			bool is_requested = false;
-			ShutdownInformation info{.should_reconnect = false};
+			ShutdownInformation info {.should_reconnect = false};
 
 			void reset();
 			void trigger(const ShutdownInformation &info);

--- a/src/server.h
+++ b/src/server.h
@@ -204,8 +204,14 @@ public:
 	// read shutdown state
 	inline bool isShutdownRequested() const { return m_shutdown_state.is_requested; }
 
+	struct ShutdownInformation {
+		bool should_reconnect;
+		std::string countdown_message;
+		std::string message;
+		float delay;
+	};
 	// request server to shutdown
-	void requestShutdown(const std::string &msg, bool reconnect, float delay = 0.0f);
+	void requestShutdown(const ShutdownInformation &info);
 
 	// Returns -1 if failed, sound handle on success
 	// Envlock
@@ -366,16 +372,13 @@ private:
 		friend class TestServerShutdownState;
 		public:
 			bool is_requested = false;
-			bool should_reconnect = false;
-			std::string message;
+			ShutdownInformation info{.should_reconnect = false};
 
 			void reset();
-			void trigger(float delay, const std::string &msg, bool reconnect);
+			void trigger(const ShutdownInformation &info);
 			void tick(float dtime, Server *server);
 			std::wstring getShutdownTimerMessage() const;
-			bool isTimerRunning() const { return m_timer > 0.0f; }
-		private:
-			float m_timer = 0.0f;
+			bool isTimerRunning() const { return info.delay > 0.0f; }
 	};
 
 	void SendMovement(session_t peer_id);

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -88,10 +88,12 @@ void TestServerShutdownState::testReset()
 void TestServerShutdownState::testTrigger()
 {
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info{.should_reconnect = true,
-			.countdown_message = "testcountdown @1.",
-			.message = "testtrigger",
-			.delay = 3.0f};
+	Server::ShutdownInformation info {
+		.should_reconnect = true,
+		.countdown_message = "testcountdown @1.",
+		.message = "testtrigger",
+		.delay = 3.0f
+	};
 	ss.trigger(info);
 	UASSERT(!ss.is_requested);
 	UASSERT(ss.info.should_reconnect);
@@ -103,10 +105,12 @@ void TestServerShutdownState::testTick()
 {
 	std::unique_ptr<FakeServer> fakeServer(new FakeServer());
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info{.should_reconnect = true,
-			.countdown_message = "testcountdown @1.",
-			.message = "testtrigger",
-			.delay = 28.0f};
+	Server::ShutdownInformation info {
+		.should_reconnect = true,
+		.countdown_message = "testcountdown @1.",
+		.message = "testtrigger",
+		.delay = 28.0f
+	};
 	ss.trigger(info);
 	ss.tick(0.0f, fakeServer.get());
 

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -91,8 +91,7 @@ void TestServerShutdownState::testTrigger()
 	Server::ShutdownInformation info{.should_reconnect = true,
 			.countdown_message = "testcountdown @1.",
 			.message = "testtrigger",
-			.delay = 3.0f
-	};
+			.delay = 3.0f};
 	ss.trigger(info);
 	UASSERT(!ss.is_requested);
 	UASSERT(ss.info.should_reconnect);
@@ -107,8 +106,7 @@ void TestServerShutdownState::testTick()
 	Server::ShutdownInformation info{.should_reconnect = true,
 			.countdown_message = "testcountdown @1.",
 			.message = "testtrigger",
-			.delay = 28.0f
-	};
+			.delay = 28.0f};
 	ss.trigger(info);
 	ss.tick(0.0f, fakeServer.get());
 

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -88,7 +88,7 @@ void TestServerShutdownState::testReset()
 void TestServerShutdownState::testTrigger()
 {
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info {.should_reconnect = true,
+	Server::ShutdownInformation info{.should_reconnect = true,
 			.countdown_message = "testcountdown @1.",
 			.message = "testtrigger",
 			.delay = 3.0f
@@ -104,7 +104,7 @@ void TestServerShutdownState::testTick()
 {
 	std::unique_ptr<FakeServer> fakeServer(new FakeServer());
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info {.should_reconnect = true,
+	Server::ShutdownInformation info{.should_reconnect = true,
 			.countdown_message = "testcountdown @1.",
 			.message = "testtrigger",
 			.delay = 28.0f

--- a/src/unittest/test_server_shutdown_state.cpp
+++ b/src/unittest/test_server_shutdown_state.cpp
@@ -88,11 +88,10 @@ void TestServerShutdownState::testReset()
 void TestServerShutdownState::testTrigger()
 {
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info {
-		.should_reconnect = true,
-		.countdown_message = "testcountdown @1.",
-		.message = "testtrigger",
-		.delay = 3.0f
+	Server::ShutdownInformation info {.should_reconnect = true,
+			.countdown_message = "testcountdown @1.",
+			.message = "testtrigger",
+			.delay = 3.0f
 	};
 	ss.trigger(info);
 	UASSERT(!ss.is_requested);
@@ -105,11 +104,10 @@ void TestServerShutdownState::testTick()
 {
 	std::unique_ptr<FakeServer> fakeServer(new FakeServer());
 	Server::ShutdownState ss;
-	Server::ShutdownInformation info {
-		.should_reconnect = true,
-		.countdown_message = "testcountdown @1.",
-		.message = "testtrigger",
-		.delay = 28.0f
+	Server::ShutdownInformation info {.should_reconnect = true,
+			.countdown_message = "testcountdown @1.",
+			.message = "testtrigger",
+			.delay = 28.0f
 	};
 	ss.trigger(info);
 	ss.tick(0.0f, fakeServer.get());


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR : Add the `countdown_msg` argument to minetest.request_shutdown
- How does the PR work?
- Does it resolve any reported issue? no
- If not a bug fix, why is this PR needed? What usecases does it solve? custom countdown message

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

## How to test

