### PR TITLE
Make dropped items glow

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -58,6 +58,8 @@ core.register_entity(":__builtin:item", {
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 		local coll_height = size * 0.75
+		local def = core.registered_nodes[itemname]
+		local glow = def and def.light_source
 
 		self.object:set_properties({
 			is_visible = true,
@@ -69,6 +71,7 @@ core.register_entity(":__builtin:item", {
 			selectionbox = {-size, -size, -size, size, size, size},
 			automatic_rotate = math.pi * 0.5 * 0.2 / size,
 			wield_item = self.itemstring,
+			glow = glow,
 		})
 
 	end,


### PR DESCRIPTION
- Goal of the PR: Make dropped items (`__builtin:item`) glow if they are light source nodes. This brightens their texture in darkness. This does NOT affect the environment light (e.g. on surrounding nodes)
- How does the PR work? By setting the `glow` object property when spawning the item entity if the item is a node that has the `light_source` value set. So this should be extremely lightweight.
- Note: Any existing item entities won't suddenly start glowing. I have no intention of handling this case, given that this PR is just a minor graphical effect
- Does it resolve any reported issue? No, but it was suggested by @SmallJoker in #9192
- If not a bug fix, why is this PR needed? What usecases does it solve? It just looks a bit nicer. That's all.

## To do

This PR is ready.

## How to test

1. Start MTG
2. Pick up a torch, mese lamp or any other glowing node
3. Go into the dark shadows
4. Drop the item and see how it looks like

If the item entity glows, everything works. If your computer glows instead, then there's a bug.