### PR TITLE
Falling nodes: Add support for facedir, colorfacedirr, wallmounted, colorwallmounted, color, airlike, signlike, torchlike and glow

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -1,6 +1,7 @@
 -- Minetest: builtin/item.lua
 
 local builtin_shared = ...
+local SCALE = 0.667
 
 --
 -- Falling stuff
@@ -9,7 +10,7 @@ local builtin_shared = ...
 core.register_entity(":__builtin:falling_node", {
 	initial_properties = {
 		visual = "wielditem",
-		visual_size = {x = 0.667, y = 0.667},
+		visual_size = { x = SCALE, y = SCALE, z = SCALE },
 		textures = {},
 		physical = true,
 		is_visible = false,
@@ -56,10 +57,14 @@ core.register_entity(":__builtin:falling_node", {
 					textures = { def.tiles[1] }
 				end
 			end
+			local vsize
+			if def.visual_scale then
+				vsize = { x = def.visual_scale, y = def.visual_scale, z = def.visual_scale }
+			end
 			self.object:set_properties({
 				is_visible = true,
 				visual = "upright_sprite",
-				visual_size = { x=1, y=1 },
+				visual_size = vsize,
 				textures = textures,
 				glow = def.light_source,
 			})
@@ -68,9 +73,14 @@ core.register_entity(":__builtin:falling_node", {
 			if core.is_colored_paramtype(def.paramtype2) then
 				itemstring = core.itemstring_with_palette(itemstring, node.param2)
 			end
+			local vsize
+			if def.visual_scale then
+				vsize = { x = def.visual_scale * SCALE, y = def.visual_scale * SCALE, z = def.visual_scale * SCALE }
+			end
 			self.object:set_properties({
 				is_visible = true,
 				wield_item = itemstring,
+				visual_size = vsize,
 				glow = def.light_source,
 			})
 		end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -116,7 +116,9 @@ core.register_entity(":__builtin:falling_node", {
 			self.object:set_yaw(math.pi*0.25)
 		elseif (node.param2 ~= 0 and (def.wield_image == ""
 				or def.wield_image == nil))
-				or def.drawtype == "signlike" then
+				or def.drawtype == "signlike"
+				or def.drawtype == "mesh"
+				or def.drawtype == "nodebox" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				local fdir = node.param2 % 32
 				-- Get rotation from a precalculated lookup table
@@ -142,6 +144,12 @@ core.register_entity(":__builtin:falling_node", {
 					pitch = pitch - math.pi/2
 					if rot >= 0 and rot <= 1 then
 						roll = roll - math.pi/2
+					end
+				elseif def.drawtype == "mesh" then
+					if rot >= 0 and rot <= 1 then
+						roll = roll + math.pi
+					else
+						yaw = yaw + math.pi
 					end
 				end
 				self.object:set_rotation({x=pitch, y=yaw, z=roll})

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -71,7 +71,7 @@ core.register_entity(":__builtin:falling_node", {
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
 			self.object:set_yaw(math.pi*0.25)
-		elseif node.param2 ~= 0 or def.drawtype == "signlike" then
+		elseif (node.param2 ~= 0 and def.wield_image == nil) or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				-- TODO: Also colorize entity if paramtype2=colorfacedir
 				local fdir = node.param2 % 32

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -40,10 +40,7 @@ core.register_entity(":__builtin:falling_node", {
 				is_visible = false,
 			})
 		else
-			local glow
-			if def then
-				glow = def.light_source
-			end
+			local glow = def and def.light_source
 			if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 				local textures
 				if def.tiles and def.tiles[1] then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -71,9 +71,7 @@ core.register_entity(":__builtin:falling_node", {
 			return
 		end
 		self.meta = meta
-		if def.drawtype == "airlike" then
-			-- Do nothing
-		elseif def.drawtype == "torchlike" or def.drawtype == "signlike" then
+		if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
 			if def.tiles and def.tiles[1] then
 				local tile = def.tiles[1]
@@ -98,7 +96,7 @@ core.register_entity(":__builtin:falling_node", {
 				textures = textures,
 				glow = def.light_source,
 			})
-		else
+		elseif def.drawtype ~= "airlike" then
 			local itemstring = node.name
 			if core.is_colored_paramtype(def.paramtype2) then
 				itemstring = core.itemstring_with_palette(itemstring, node.param2)

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -36,7 +36,9 @@ core.register_entity(":__builtin:falling_node", {
 		local def = core.registered_nodes[node.name]
 		if not def then
 			-- Don't allow unknown nodes to fall
-			minetest.log("warning", "Unknown falling node removed at "..minetest.pos_to_string(self.object:get_pos()))
+			core.log("warning",
+				"Unknown falling node removed at "..
+				core.pos_to_string(self.object:get_pos()))
 			self.object:remove()
 			return
 		end
@@ -45,39 +47,39 @@ core.register_entity(":__builtin:falling_node", {
 			self.object:set_properties({
 				is_visible = false,
 			})
-		else
-			if def.drawtype == "torchlike" or def.drawtype == "signlike" then
-				local textures
-				if def.tiles and def.tiles[1] then
-					if def.drawtype == "torchlike" then
-						textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
-					else
-						textures = { def.tiles[1] }
-					end
+		elseif def.drawtype == "torchlike" or def.drawtype == "signlike" then
+			local textures
+			if def.tiles and def.tiles[1] then
+				if def.drawtype == "torchlike" then
+					textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
+				else
+					textures = { def.tiles[1] }
 				end
-				self.object:set_properties({
-					is_visible = true,
-					visual = "upright_sprite",
-					visual_size = { x=1, y=1 },
-					textures = textures,
-					glow = def.light_source,
-				})
-			else
-				local itemstring = node.name
-				if core.is_colored_paramtype(def.paramtype2) then
-					itemstring = core.itemstring_with_palette(itemstring, node.param2)
-				end
-				self.object:set_properties({
-					is_visible = true,
-					wield_item = itemstring,
-					glow = def.light_source,
-				})
 			end
+			self.object:set_properties({
+				is_visible = true,
+				visual = "upright_sprite",
+				visual_size = { x=1, y=1 },
+				textures = textures,
+				glow = def.light_source,
+			})
+		else
+			local itemstring = node.name
+			if core.is_colored_paramtype(def.paramtype2) then
+				itemstring = core.itemstring_with_palette(itemstring, node.param2)
+			end
+			self.object:set_properties({
+				is_visible = true,
+				wield_item = itemstring,
+				glow = def.light_source,
+			})
 		end
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
 			self.object:set_yaw(math.pi*0.25)
-		elseif (node.param2 ~= 0 and (def.wield_image == "" or def.wield_image == nil)) or def.drawtype == "signlike" then
+		elseif (node.param2 ~= 0 and (def.wield_image == ""
+				or def.wield_image == nil))
+				or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				local fdir = node.param2 % 32
 				local face = fdir % 4

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -33,10 +33,16 @@ core.register_entity(":__builtin:falling_node", {
 				end
 			end
 		end
+		local def = core.registered_nodes[node.name]
+		local glow
+		if def then
+			glow = def.light_source
+		end
 		self.meta = meta
 		self.object:set_properties({
 			is_visible = true,
 			textures = {node.name},
+			glow = glow,
 		})
 	end,
 

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -34,16 +34,22 @@ core.register_entity(":__builtin:falling_node", {
 			end
 		end
 		local def = core.registered_nodes[node.name]
-		local glow
-		if def then
-			glow = def.light_source
-		end
 		self.meta = meta
-		self.object:set_properties({
-			is_visible = true,
-			textures = {node.name},
-			glow = glow,
-		})
+		if def.drawtype == "airlike" then
+			self.object:set_properties({
+				is_visible = false,
+			})
+		else
+			local glow
+			if def then
+				glow = def.light_source
+			end
+			self.object:set_properties({
+				is_visible = true,
+				textures = {node.name},
+				glow = glow,
+			})
+		end
 		-- Rotate entity
 		if node.param2 ~= 0 then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -81,7 +81,7 @@ core.register_entity(":__builtin:falling_node", {
 				if def.drawtype == "torchlike" then
 					textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
 				else
-					textures = { def.tiles[1] }
+					textures = { def.tiles[1], "("..def.tiles[1]..")^[transformFX" }
 				end
 			end
 			local vsize
@@ -133,7 +133,7 @@ core.register_entity(":__builtin:falling_node", {
 				local rot = node.param2 % 8
 				local pitch, yaw, roll = 0, 0, 0
 				if rot == 1 then
-					pitch, yaw = -math.pi, -math.pi
+					pitch, yaw = math.pi, math.pi
 				elseif rot == 2 then
 					pitch, yaw = math.pi/2, math.pi/2
 				elseif rot == 3 then
@@ -145,8 +145,10 @@ core.register_entity(":__builtin:falling_node", {
 				end
 				if def.drawtype == "signlike" then
 					pitch = pitch - math.pi/2
-					if rot >= 0 and rot <= 1 then
-						roll = roll - math.pi/2
+					if rot == 0 then
+						yaw = yaw + math.pi/2
+					elseif rot == 1 then
+						yaw = yaw - math.pi/2
 					end
 				elseif def.drawtype == "mesh" or def.drawtype == "normal" then
 					if rot >= 0 and rot <= 1 then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -78,10 +78,16 @@ core.register_entity(":__builtin:falling_node", {
 		elseif def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
 			if def.tiles and def.tiles[1] then
-				if def.drawtype == "torchlike" then
-					textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
+				local tile
+				if type(def.tiles[1]) == "table" then
+					tile = def.tiles[1].name
 				else
-					textures = { def.tiles[1], "("..def.tiles[1]..")^[transformFX" }
+					tile = def.tiles[1]
+				end
+				if def.drawtype == "torchlike" then
+					textures = { "("..tile..")^[transformFX", tile }
+				else
+					textures = { tile, "("..tile..")^[transformFX" }
 				end
 			end
 			local vsize

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -37,7 +37,7 @@ local facedir_to_euler = {
 core.register_entity(":__builtin:falling_node", {
 	initial_properties = {
 		visual = "wielditem",
-		visual_size = { x = SCALE, y = SCALE, z = SCALE },
+		visual_size = {x = SCALE, y = SCALE, z = SCALE},
 		textures = {},
 		physical = true,
 		is_visible = false,
@@ -87,7 +87,7 @@ core.register_entity(":__builtin:falling_node", {
 			local vsize
 			if def.visual_scale then
 				local s = def.visual_scale
-				vsize = { x = s, y = s, z = s }
+				vsize = {x = s, y = s, z = s}
 			end
 			self.object:set_properties({
 				is_visible = true,
@@ -104,7 +104,7 @@ core.register_entity(":__builtin:falling_node", {
 			local vsize
 			if def.visual_scale then
 				local s = def.visual_scale * SCALE
-				vsize = { x = s, y = s, z = s }
+				vsize = {x = s, y = s, z = s}
 			end
 			self.object:set_properties({
 				is_visible = true,

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -3,6 +3,33 @@
 local builtin_shared = ...
 local SCALE = 0.667
 
+local facedir_to_euler = {
+	{y = 0, x = 0, z = 0},
+	{y = -math.pi/2, x = 0, z = 0},
+	{y = math.pi, x = 0, z = 0},
+	{y = math.pi/2, x = 0, z = 0},
+	{y = math.pi/2, x = -math.pi/2, z = math.pi/2},
+	{y = math.pi/2, x = math.pi, z = math.pi/2},
+	{y = math.pi/2, x = math.pi/2, z = math.pi/2},
+	{y = math.pi/2, x = 0, z = math.pi/2},
+	{y = -math.pi/2, x = math.pi/2, z = math.pi/2},
+	{y = -math.pi/2, x = 0, z = math.pi/2},
+	{y = -math.pi/2, x = -math.pi/2, z = math.pi/2},
+	{y = -math.pi/2, x = math.pi, z = math.pi/2},
+	{y = 0, x = 0, z = math.pi/2},
+	{y = 0, x = -math.pi/2, z = math.pi/2},
+	{y = 0, x = math.pi, z = math.pi/2},
+	{y = 0, x = math.pi/2, z = math.pi/2},
+	{y = math.pi, x = math.pi, z = math.pi/2},
+	{y = math.pi, x = math.pi/2, z = math.pi/2},
+	{y = math.pi, x = 0, z = math.pi/2},
+	{y = math.pi, x = -math.pi/2, z = math.pi/2},
+	{y = math.pi, x = math.pi, z = 0},
+	{y = -math.pi/2, x = math.pi, z = 0},
+	{y = 0, x = math.pi, z = 0},
+	{y = math.pi/2, x = math.pi, z = 0}
+}
+
 --
 -- Falling stuff
 --
@@ -92,35 +119,11 @@ core.register_entity(":__builtin:falling_node", {
 				or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				local fdir = node.param2 % 32
-				local face = fdir % 4
-				local axis = fdir - face
-				local pitch, yaw, roll
-				if axis == 4 then
-					pitch = (4 - face) * (math.pi/2) - math.pi/2
-					yaw = math.pi/2
-					roll = math.pi/2
-				elseif axis == 8 then
-					pitch = (4 - face) * (math.pi/2) - math.pi*1.5
-					yaw = math.pi*1.5
-					roll = math.pi/2
-				elseif axis == 12 then
-					pitch = (4 - face) * (math.pi/2)
-					yaw = 0
-					roll = math.pi/2
-				elseif axis == 16 then
-					pitch = (4 - face) * (math.pi/2) + math.pi
-					yaw = math.pi
-					roll = math.pi/2
-				elseif axis == 20 then
-					pitch = math.pi
-					yaw = face * (math.pi/2) + math.pi
-					roll = 0
-				else
-					pitch = 0
-					yaw = (4 - face) * (math.pi/2)
-					roll = 0
+				-- Get rotation from a precalculated lookup table
+				local euler = facedir_to_euler[fdir + 1]
+				if euler then
+					self.object:set_rotation(euler)
 				end
-				self.object:set_rotation({x=pitch, y=yaw, z=roll})
 			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
 				local rot = node.param2 % 8
 				local pitch, yaw, roll = 0, 0, 0
@@ -129,7 +132,7 @@ core.register_entity(":__builtin:falling_node", {
 				elseif rot == 2 then
 					pitch, yaw = math.pi/2, math.pi/2
 				elseif rot == 3 then
-					pitch, yaw = math.pi/2, math.pi*1.5
+					pitch, yaw = math.pi/2, -math.pi/2
 				elseif rot == 4 then
 					pitch, yaw = math.pi/2, math.pi
 				elseif rot == 5 then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -44,14 +44,30 @@ core.register_entity(":__builtin:falling_node", {
 			if def then
 				glow = def.light_source
 			end
-			self.object:set_properties({
-				is_visible = true,
-				textures = {node.name},
-				glow = glow,
-			})
+			if def.drawtype == "torchlike" then
+				local textures
+				if def.tiles and def.tiles[1] then
+					textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
+				end
+				self.object:set_properties({
+					is_visible = true,
+					visual = "upright_sprite",
+					visual_size = { x=1, y=1 },
+					textures = textures,
+					glow = glow,
+				})
+			else
+				self.object:set_properties({
+					is_visible = true,
+					textures = {node.name},
+					glow = glow,
+				})
+			end
 		end
 		-- Rotate entity
-		if node.param2 ~= 0 then
+		if def.drawtype == "torchlike" then
+			self.object:set_yaw(math.pi*0.25)
+		elseif node.param2 ~= 0 then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				-- TODO: Also colorize entity if paramtype2=colorfacedir
 				local fdir = node.param2 % 32

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -120,6 +120,7 @@ core.register_entity(":__builtin:falling_node", {
 				or def.wield_image == nil))
 				or def.drawtype == "signlike"
 				or def.drawtype == "mesh"
+				or def.drawtype == "normal"
 				or def.drawtype == "nodebox" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				local fdir = node.param2 % 32
@@ -147,7 +148,7 @@ core.register_entity(":__builtin:falling_node", {
 					if rot >= 0 and rot <= 1 then
 						roll = roll - math.pi/2
 					end
-				elseif def.drawtype == "mesh" then
+				elseif def.drawtype == "mesh" or def.drawtype == "normal" then
 					if rot >= 0 and rot <= 1 then
 						roll = roll + math.pi
 					else

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -44,10 +44,14 @@ core.register_entity(":__builtin:falling_node", {
 			if def then
 				glow = def.light_source
 			end
-			if def.drawtype == "torchlike" then
+			if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 				local textures
 				if def.tiles and def.tiles[1] then
-					textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
+					if def.drawtype == "torchlike" then
+						textures = { "("..def.tiles[1]..")^[transformFX", def.tiles[1] }
+					else
+						textures = { def.tiles[1] }
+					end
 				end
 				self.object:set_properties({
 					is_visible = true,
@@ -67,7 +71,7 @@ core.register_entity(":__builtin:falling_node", {
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
 			self.object:set_yaw(math.pi*0.25)
-		elseif node.param2 ~= 0 then
+		elseif node.param2 ~= 0 or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				-- TODO: Also colorize entity if paramtype2=colorfacedir
 				local fdir = node.param2 % 32
@@ -103,17 +107,25 @@ core.register_entity(":__builtin:falling_node", {
 			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
 				-- TODO: Also colorize entity if paramtype2=colorwallmounted
 				local rot = node.param2 % 8
+				local pitch, yaw, roll = 0, 0, 0
 				if rot == 1 then
-					self.object:set_rotation({x=-math.pi, y=-math.pi, z=0})
+					pitch, yaw = -math.pi, -math.pi
 				elseif rot == 2 then
-					self.object:set_rotation({x=math.pi/2, y=math.pi/2, z=0})
+					pitch, yaw = math.pi/2, math.pi/2
 				elseif rot == 3 then
-					self.object:set_rotation({x=math.pi/2, y=math.pi*1.5, z=0})
+					pitch, yaw = math.pi/2, math.pi*1.5
 				elseif rot == 4 then
-					self.object:set_rotation({x=math.pi/2, y=math.pi, z=0})
+					pitch, yaw = math.pi/2, math.pi
 				elseif rot == 5 then
-					self.object:set_rotation({x=math.pi/2, y=0, z=0})
+					pitch, yaw = math.pi/2, 0
 				end
+				if def.drawtype == "signlike" then
+					pitch = pitch - math.pi/2
+					if rot >= 0 and rot <= 1 then
+						roll = roll - math.pi/2
+					end
+				end
+				self.object:set_rotation({x=pitch, y=yaw, z=roll})
 			end
 		end
 	end,

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -72,9 +72,7 @@ core.register_entity(":__builtin:falling_node", {
 		end
 		self.meta = meta
 		if def.drawtype == "airlike" then
-			self.object:set_properties({
-				is_visible = false,
-			})
+			-- Do nothing
 		elseif def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
 			if def.tiles and def.tiles[1] then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -86,7 +86,8 @@ core.register_entity(":__builtin:falling_node", {
 			end
 			local vsize
 			if def.visual_scale then
-				vsize = { x = def.visual_scale, y = def.visual_scale, z = def.visual_scale }
+				local s = def.visual_scale
+				vsize = { x = s, y = s, z = s }
 			end
 			self.object:set_properties({
 				is_visible = true,
@@ -102,7 +103,8 @@ core.register_entity(":__builtin:falling_node", {
 			end
 			local vsize
 			if def.visual_scale then
-				vsize = { x = def.visual_scale * SCALE, y = def.visual_scale * SCALE, z = def.visual_scale * SCALE }
+				local s = def.visual_scale * SCALE
+				vsize = { x = s, y = s, z = s }
 			end
 			self.object:set_properties({
 				is_visible = true,

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -76,11 +76,9 @@ core.register_entity(":__builtin:falling_node", {
 		elseif def.drawtype == "torchlike" or def.drawtype == "signlike" then
 			local textures
 			if def.tiles and def.tiles[1] then
-				local tile
-				if type(def.tiles[1]) == "table" then
-					tile = def.tiles[1].name
-				else
-					tile = def.tiles[1]
+				local tile = def.tiles[1]
+				if type(tile) == "table" then
+					tile = tile.name
 				end
 				if def.drawtype == "torchlike" then
 					textures = { "("..tile..")^[transformFX", tile }

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -36,7 +36,7 @@ local facedir_to_euler = {
 
 core.register_entity(":__builtin:falling_node", {
 	initial_properties = {
-		visual = "wielditem",
+		visual = "item",
 		visual_size = {x = SCALE, y = SCALE, z = SCALE},
 		textures = {},
 		physical = true,

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -61,9 +61,13 @@ core.register_entity(":__builtin:falling_node", {
 					glow = glow,
 				})
 			else
+				local itemstring = node.name
+				if core.is_colored_paramtype(def.paramtype2) then
+					itemstring = core.itemstring_with_palette(itemstring, node.param2)
+				end
 				self.object:set_properties({
 					is_visible = true,
-					textures = {node.name},
+					wield_item = itemstring,
 					glow = glow,
 				})
 			end
@@ -73,7 +77,6 @@ core.register_entity(":__builtin:falling_node", {
 			self.object:set_yaw(math.pi*0.25)
 		elseif (node.param2 ~= 0 and def.wield_image == nil) or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
-				-- TODO: Also colorize entity if paramtype2=colorfacedir
 				local fdir = node.param2 % 32
 				local face = fdir % 4
 				local axis = fdir - face
@@ -105,7 +108,6 @@ core.register_entity(":__builtin:falling_node", {
 				end
 				self.object:set_rotation({x=pitch, y=yaw, z=roll})
 			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
-				-- TODO: Also colorize entity if paramtype2=colorwallmounted
 				local rot = node.param2 % 8
 				local pitch, yaw, roll = 0, 0, 0
 				if rot == 1 then

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -34,13 +34,18 @@ core.register_entity(":__builtin:falling_node", {
 			end
 		end
 		local def = core.registered_nodes[node.name]
+		if not def then
+			-- Don't allow unknown nodes to fall
+			minetest.log("warning", "Unknown falling node removed at "..minetest.pos_to_string(self.object:get_pos()))
+			self.object:remove()
+			return
+		end
 		self.meta = meta
 		if def.drawtype == "airlike" then
 			self.object:set_properties({
 				is_visible = false,
 			})
 		else
-			local glow = def and def.light_source
 			if def.drawtype == "torchlike" or def.drawtype == "signlike" then
 				local textures
 				if def.tiles and def.tiles[1] then
@@ -55,7 +60,7 @@ core.register_entity(":__builtin:falling_node", {
 					visual = "upright_sprite",
 					visual_size = { x=1, y=1 },
 					textures = textures,
-					glow = glow,
+					glow = def.light_source,
 				})
 			else
 				local itemstring = node.name
@@ -65,7 +70,7 @@ core.register_entity(":__builtin:falling_node", {
 				self.object:set_properties({
 					is_visible = true,
 					wield_item = itemstring,
-					glow = glow,
+					glow = def.light_source,
 				})
 			end
 		end

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -75,7 +75,7 @@ core.register_entity(":__builtin:falling_node", {
 		-- Rotate entity
 		if def.drawtype == "torchlike" then
 			self.object:set_yaw(math.pi*0.25)
-		elseif (node.param2 ~= 0 and def.wield_image == nil) or def.drawtype == "signlike" then
+		elseif (node.param2 ~= 0 and (def.wield_image == "" or def.wield_image == nil)) or def.drawtype == "signlike" then
 			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
 				local fdir = node.param2 % 32
 				local face = fdir % 4

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -37,7 +37,7 @@ core.register_entity(":__builtin:falling_node", {
 		local def = core.registered_nodes[node.name]
 		if not def then
 			-- Don't allow unknown nodes to fall
-			core.log("warning",
+			core.log("info",
 				"Unknown falling node removed at "..
 				core.pos_to_string(self.object:get_pos()))
 			self.object:remove()

--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -44,6 +44,56 @@ core.register_entity(":__builtin:falling_node", {
 			textures = {node.name},
 			glow = glow,
 		})
+		-- Rotate entity
+		if node.param2 ~= 0 then
+			if (def.paramtype2 == "facedir" or def.paramtype2 == "colorfacedir") then
+				-- TODO: Also colorize entity if paramtype2=colorfacedir
+				local fdir = node.param2 % 32
+				local face = fdir % 4
+				local axis = fdir - face
+				local pitch, yaw, roll
+				if axis == 4 then
+					pitch = (4 - face) * (math.pi/2) - math.pi/2
+					yaw = math.pi/2
+					roll = math.pi/2
+				elseif axis == 8 then
+					pitch = (4 - face) * (math.pi/2) - math.pi*1.5
+					yaw = math.pi*1.5
+					roll = math.pi/2
+				elseif axis == 12 then
+					pitch = (4 - face) * (math.pi/2)
+					yaw = 0
+					roll = math.pi/2
+				elseif axis == 16 then
+					pitch = (4 - face) * (math.pi/2) + math.pi
+					yaw = math.pi
+					roll = math.pi/2
+				elseif axis == 20 then
+					pitch = math.pi
+					yaw = face * (math.pi/2) + math.pi
+					roll = 0
+				else
+					pitch = 0
+					yaw = (4 - face) * (math.pi/2)
+					roll = 0
+				end
+				self.object:set_rotation({x=pitch, y=yaw, z=roll})
+			elseif (def.paramtype2 == "wallmounted" or def.paramtype2 == "colorwallmounted") then
+				-- TODO: Also colorize entity if paramtype2=colorwallmounted
+				local rot = node.param2 % 8
+				if rot == 1 then
+					self.object:set_rotation({x=-math.pi, y=-math.pi, z=0})
+				elseif rot == 2 then
+					self.object:set_rotation({x=math.pi/2, y=math.pi/2, z=0})
+				elseif rot == 3 then
+					self.object:set_rotation({x=math.pi/2, y=math.pi*1.5, z=0})
+				elseif rot == 4 then
+					self.object:set_rotation({x=math.pi/2, y=math.pi, z=0})
+				elseif rot == 5 then
+					self.object:set_rotation({x=math.pi/2, y=0, z=0})
+				end
+			end
+		end
 	end,
 
 	get_staticdata = function(self)


### PR DESCRIPTION
## Goal of the PR

Falling nodes are currently not supporting rotation (`facedir`, `wallmounted`) nor node colorization. This PR fixes this. There are also other rendering-related features.

Fixes #5324.

## Features

Support for these paramtype2's is added:

* `facedir`
* `colorfacedir`
* `wallmounted`
* `colorwallmounted`
* `color`

This means, falling nodes will now be properly rotated and colorized.

Falling nodes will get improved support for the following drawtypes:

* `airlike`: Nothing will render (will also be non-pointable due to how the `is_visible` property works)
* `signlike`: Fix rotation, use simple sprite
* `torchlike`: Use standing torch for dropping

Finally, `glow` is applied to the entity if the node is a `light_source`.

## To do

I think it's ready, but I urge core devs to do their own testing. Well, I did a lot of testing already, but you probably want to do you own testing since this PR touches a very sensitive part of the game.


## How to test

This is the hard part. You are going to need a LOT of nodes. To test this, you would need nodes with the properties I just listed above and some easy way to change param2 as well. And then you just make each node with “every” possible param2 value fall.

I have actually written test code to make testing this easier, but it's not released yet. I will post in this thread again when my test code is public.