### PR TITLE
Allow wave_heights up to two nodes.

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -580,10 +580,11 @@ parallax_occlusion_bias (Parallax occlusion bias) float 0.04
 enable_waving_water (Waving liquids) bool false
 
 #    The maximum height of the surface of waving liquids.
-#    1.0 = Wave reaches the top of blocks.
+#    4.0 = Wave height is two blocks.
 #    0.0 = Wave doesn't move at all.
+#    Default is 1.0 (1/2 block).
 #    Requires waving liquids to be enabled.
-water_wave_height (Waving liquids wave height) float 1.0 0.0 1.0
+water_wave_height (Waving liquids wave height) float 1.0 0.0 4.0
 
 #    Length of liquid waves.
 #    Requires waving liquids to be enabled.


### PR DESCRIPTION
Fixes #9217 

Simply allows a limit of up to two blocks high (4.0).
With any setting > 2.0 the block below the wave will be exposed, but there're no rendering glitches (the wave will not partly reach above a block as it did before #8994 .)
