### PR TITLE
Add chat_log_level setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1391,8 +1391,7 @@ debug_log_level (Debug log level) enum action ,none,error,warning,action,info,ve
 #    debug.txt is only moved if this setting is positive.
 debug_log_size_max (Debug log file size threshold) int 50
 
-#    Like "Debug log level" but shows log messages in the chat.
-#    Restart Minetest to apply changes.
+#    Minimal level of logging to be written to chat.
 chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose
 
 #    Enable IPv6 support (for both client and server).

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1391,6 +1391,10 @@ debug_log_level (Debug log level) enum action ,none,error,warning,action,info,ve
 #    debug.txt is only moved if this setting is positive.
 debug_log_size_max (Debug log file size threshold) int 50
 
+#    Like "Debug log level" but shows log messages in the chat.
+#    Restart Minetest to apply changes.
+chat_log_level (Chat log level) enum error ,none,error,warning,action,info,verbose
+
 #    Enable IPv6 support (for both client and server).
 #    Required for IPv6 connections to work at all.
 enable_ipv6 (IPv6) bool true

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -394,6 +394,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("remote_media", "");
 	settings->setDefault("debug_log_level", "action");
 	settings->setDefault("debug_log_size_max", "50");
+	settings->setDefault("chat_log_level", "error");
 	settings->setDefault("emergequeue_limit_total", "512");
 	settings->setDefault("emergequeue_limit_diskonly", "64");
 	settings->setDefault("emergequeue_limit_generate", "64");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -375,6 +375,20 @@ void StreamLogOutput::logRaw(LogLevel lev, const std::string &line)
 	}
 }
 
+void LogOutputBuffer::updateLogLevel()
+{
+	const std::string &conf_loglev = g_settings->get("chat_log_level");
+	LogLevel log_level = Logger::stringToLevel(conf_loglev);
+	if (log_level == LL_MAX) {
+		warningstream << "Supplied unrecognized chat_log_level; "
+			"showing none." << std::endl;
+		log_level = LL_NONE;
+	}
+
+	m_logger.removeOutput(this);
+	m_logger.addOutputMaxLevel(this, log_level);
+}
+
 void LogOutputBuffer::logRaw(LogLevel lev, const std::string &line)
 {
 	std::string color;
@@ -397,7 +411,7 @@ void LogOutputBuffer::logRaw(LogLevel lev, const std::string &line)
 		}
 	}
 
- 	m_buffer.push(color.append(line));
+	m_buffer.push(color.append(line));
 }
 
 ////

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "debug.h"
 #include "gettime.h"
 #include "porting.h"
+#include "settings.h"
 #include "config.h"
 #include "exceptions.h"
 #include "util/numeric.h"
@@ -338,7 +339,65 @@ void FileLogOutput::setFile(const std::string &filename, s64 file_size_max)
 		"-------------\n" << std::endl;
 }
 
+void StreamLogOutput::logRaw(LogLevel lev, const std::string &line)
+{
+	bool colored_message = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
+		(Logger::color_mode == LOG_COLOR_AUTO && is_tty);
+	if (colored_message) {
+		switch (lev) {
+		case LL_ERROR:
+			// error is red
+			m_stream << "\033[91m";
+			break;
+		case LL_WARNING:
+			// warning is yellow
+			m_stream << "\033[93m";
+			break;
+		case LL_INFO:
+			// info is a bit dark
+			m_stream << "\033[37m";
+			break;
+		case LL_VERBOSE:
+			// verbose is darker than info
+			m_stream << "\033[2m";
+			break;
+		default:
+			// action is white
+			colored_message = false;
+		}
+	}
 
+	m_stream << line << std::endl;
+
+	if (colored_message)
+		// reset to white color
+		m_stream << "\033[0m";
+}
+
+void LogOutputBuffer::logRaw(LogLevel lev, const std::string &line)
+{
+	std::string color;
+
+	if (!g_settings->getBool("disable_escape_sequences")) {
+		switch (lev) {
+		case LL_ERROR: // red
+			color = "\x1b(c@#F00)";
+			break;
+		case LL_WARNING: // yellow
+			color = "\x1b(c@#EE0)";
+			break;
+		case LL_INFO: // grey
+			color = "\x1b(c@#BBB)";
+			break;
+		case LL_VERBOSE: // dark grey
+			color = "\x1b(c@#888)";
+			break;
+		default: break;
+		}
+	}
+
+ 	m_buffer.push(color.append(line));
+}
 
 ////
 //// *Buffer methods

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -369,9 +369,10 @@ void StreamLogOutput::logRaw(LogLevel lev, const std::string &line)
 
 	m_stream << line << std::endl;
 
-	if (colored_message)
+	if (colored_message) {
 		// reset to white color
 		m_stream << "\033[0m";
+	}
 }
 
 void LogOutputBuffer::logRaw(LogLevel lev, const std::string &line)

--- a/src/log.h
+++ b/src/log.h
@@ -147,22 +147,26 @@ private:
 class LogOutputBuffer : public ICombinedLogOutput {
 public:
 	LogOutputBuffer(Logger &logger) :
-		m_logger(logger) {};
+		m_logger(logger)
+	{
+		updateLogLevel();
+	};
 
-	~LogOutputBuffer()
+	virtual ~LogOutputBuffer()
 	{
 		m_logger.removeOutput(this);
 	}
 
-	void setLogLevel(LogLevel lev)
-	{
-		m_logger.removeOutput(this);
-		m_logger.addOutputMaxLevel(this, lev);
-	}
+	void updateLogLevel();
 
 	void logRaw(LogLevel lev, const std::string &line);
 
-	bool empty()
+	void clear()
+	{
+		m_buffer = std::queue<std::string>();
+	}
+
+	bool empty() const
 	{
 		return m_buffer.empty();
 	}

--- a/src/log.h
+++ b/src/log.h
@@ -124,39 +124,7 @@ public:
 #endif
 	}
 
-	void logRaw(LogLevel lev, const std::string &line)
-	{
-		bool colored_message = (Logger::color_mode == LOG_COLOR_ALWAYS) ||
-			(Logger::color_mode == LOG_COLOR_AUTO && is_tty);
-		if (colored_message)
-			switch (lev) {
-			case LL_ERROR:
-				// error is red
-				m_stream << "\033[91m";
-				break;
-			case LL_WARNING:
-				// warning is yellow
-				m_stream << "\033[93m";
-				break;
-			case LL_INFO:
-				// info is a bit dark
-				m_stream << "\033[37m";
-				break;
-			case LL_VERBOSE:
-				// verbose is darker than info
-				m_stream << "\033[2m";
-				break;
-			default:
-				// action is white
-				colored_message = false;
-			}
-
-		m_stream << line << std::endl;
-
-		if (colored_message)
-			// reset to white color
-			m_stream << "\033[0m";
-	}
+	void logRaw(LogLevel lev, const std::string &line);
 
 private:
 	std::ostream &m_stream;
@@ -178,21 +146,21 @@ private:
 
 class LogOutputBuffer : public ICombinedLogOutput {
 public:
-	LogOutputBuffer(Logger &logger, LogLevel lev) :
-		m_logger(logger)
-	{
-		m_logger.addOutput(this, lev);
-	}
+	LogOutputBuffer(Logger &logger) :
+		m_logger(logger) {};
 
 	~LogOutputBuffer()
 	{
 		m_logger.removeOutput(this);
 	}
 
-	void logRaw(LogLevel lev, const std::string &line)
+	void setLogLevel(LogLevel lev)
 	{
-		m_buffer.push(line);
+		m_logger.removeOutput(this);
+		m_logger.addOutputMaxLevel(this, lev);
 	}
+
+	void logRaw(LogLevel lev, const std::string &line);
 
 	bool empty()
 	{


### PR DESCRIPTION
Closes #9199.

 * New setting `chat_log_level` to log to the chat
 * Colored similar to the terminal output (color codes somewhat trivial, debatable)
 * `log.h` cleanup -> move to source file for compiling time

![Preview](https://user-images.githubusercontent.com/1497498/71204359-41118380-22a0-11ea-8232-d3751fb0cc7a.png)

## To do

This PR is Ready for Review.

## How to test

1) Heat your room by recompiling the entire Minetest source code
2) minetest.conf:
```
chat_log_level = info
```
3) Get spammed.