### PR TITLE
Use appropriate locale macro for windows

### DIFF
--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -230,7 +230,7 @@ int ModApiClient::l_get_node_or_nil(lua_State *L)
 
 int ModApiClient::l_get_language(lua_State *L)
 {
-#ifdef WIN32
+#ifdef _WIN32
 	char *locale = setlocale(LC_ALL, NULL);
 #else
 	char *locale = setlocale(LC_MESSAGES, NULL);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -230,7 +230,11 @@ int ModApiClient::l_get_node_or_nil(lua_State *L)
 
 int ModApiClient::l_get_language(lua_State *L)
 {
+#ifdef WIN32
+	char *locale = setlocale(LC_ALL, NULL);
+#else
 	char *locale = setlocale(LC_MESSAGES, NULL);
+#endif
 	std::string lang = gettext("LANG_CODE");
 	if (lang == "LANG_CODE")
 		lang = "";


### PR DESCRIPTION
I compiled master from source on Windows 7 with Visual Studio Community 2019 and `vcpkg` recently. I found commit c44318a had used a macro not defined under Windows, so I needed to change that to something that would be compatible.

Windows' <locale.h> does not have LC_MESSAGES in locale.h, so the best we can do is use LC_ALL on that platform. This is achieved by wrapping the use of an LC_ macro in #ifdef.

This PR is Ready for Review.

## How to test
* Verify on a windows system that minetest compiles correctly
* Verify that localization works on all platforms with a translated mod
* If you want to be particularly thorough in ensuring the affected function, `minetest.get_language` is working, you can use  [my client side mod](https://github.com/Montandalar/langtest) to dump the result of that function.
