### PR TITLE
[wip] rename `core` to `minetest`

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,7 +24,7 @@ read_globals = {
 }
 
 globals = {
-	"core",
+	"minetest",
 	"gamedata",
 	os = { fields = { "tempfolder" } },
 	"_",

--- a/builtin/async/init.lua
+++ b/builtin/async/init.lua
@@ -1,17 +1,17 @@
 
-core.log("info", "Initializing Asynchronous environment")
+minetest.log("info", "Initializing Asynchronous environment")
 
-function core.job_processor(serialized_func, serialized_param)
+function minetest.job_processor(serialized_func, serialized_param)
 	local func = loadstring(serialized_func)
-	local param = core.deserialize(serialized_param)
+	local param = minetest.deserialize(serialized_param)
 	local retval = nil
 
 	if type(func) == "function" then
-		retval = core.serialize(func(param))
+		retval = minetest.serialize(func(param))
 	else
-		core.log("error", "ASYNC WORKER: Unable to deserialize function")
+		minetest.log("error", "ASYNC WORKER: Unable to deserialize function")
 	end
 
-	return retval or core.serialize(nil)
+	return retval or minetest.serialize(nil)
 end
 

--- a/builtin/client/chatcommands.lua
+++ b/builtin/client/chatcommands.lua
@@ -1,14 +1,14 @@
 -- Minetest: builtin/client/chatcommands.lua
 
 
-core.register_on_sending_chat_message(function(message)
+minetest.register_on_sending_chat_message(function(message)
 	if message:sub(1,2) == ".." then
 		return false
 	end
 
 	local first_char = message:sub(1,1)
 	if first_char == "/" or first_char == "." then
-		core.display_chat_message(core.gettext("issued command: ") .. message)
+		minetest.display_chat_message(minetest.gettext("issued command: ") .. message)
 	end
 
 	if first_char ~= "." then
@@ -19,52 +19,52 @@ core.register_on_sending_chat_message(function(message)
 	param = param or ""
 
 	if not cmd then
-		core.display_chat_message(core.gettext("-!- Empty command"))
+		minetest.display_chat_message(minetest.gettext("-!- Empty command"))
 		return true
 	end
 
-	local cmd_def = core.registered_chatcommands[cmd]
+	local cmd_def = minetest.registered_chatcommands[cmd]
 	if cmd_def then
-		core.set_last_run_mod(cmd_def.mod_origin)
+		minetest.set_last_run_mod(cmd_def.mod_origin)
 		local _, result = cmd_def.func(param)
 		if result then
-			core.display_chat_message(result)
+			minetest.display_chat_message(result)
 		end
 	else
-		core.display_chat_message(core.gettext("-!- Invalid command: ") .. cmd)
+		minetest.display_chat_message(minetest.gettext("-!- Invalid command: ") .. cmd)
 	end
 
 	return true
 end)
 
-core.register_chatcommand("list_players", {
-	description = core.gettext("List online players"),
+minetest.register_chatcommand("list_players", {
+	description = minetest.gettext("List online players"),
 	func = function(param)
-		local player_names = core.get_player_names()
+		local player_names = minetest.get_player_names()
 		if not player_names then
-			return false, core.gettext("This command is disabled by server.")
+			return false, minetest.gettext("This command is disabled by server.")
 		end
 
 		local players = table.concat(player_names, ", ")
-		return true, core.gettext("Online players: ") .. players
+		return true, minetest.gettext("Online players: ") .. players
 	end
 })
 
-core.register_chatcommand("disconnect", {
-	description = core.gettext("Exit to main menu"),
+minetest.register_chatcommand("disconnect", {
+	description = minetest.gettext("Exit to main menu"),
 	func = function(param)
-		core.disconnect()
+		minetest.disconnect()
 	end,
 })
 
-core.register_chatcommand("clear_chat_queue", {
-	description = core.gettext("Clear the out chat queue"),
+minetest.register_chatcommand("clear_chat_queue", {
+	description = minetest.gettext("Clear the out chat queue"),
 	func = function(param)
-		core.clear_out_chat_queue()
-		return true, core.gettext("The out chat queue is now empty")
+		minetest.clear_out_chat_queue()
+		return true, minetest.gettext("The out chat queue is now empty")
 	end,
 })
 
-function core.run_server_chatcommand(cmd, param)
-	core.send_chat_message("/" .. cmd .. " " .. param)
+function minetest.run_server_chatcommand(cmd, param)
+	minetest.send_chat_message("/" .. cmd .. " " .. param)
 end

--- a/builtin/client/death_formspec.lua
+++ b/builtin/client/death_formspec.lua
@@ -1,16 +1,16 @@
 -- CSM death formspec. Only used when clientside modding is enabled, otherwise
 -- handled by the engine.
 
-core.register_on_death(function()
-	core.display_chat_message("You died.")
+minetest.register_on_death(function()
+	minetest.display_chat_message("You died.")
 	local formspec = "size[11,5.5]bgcolor[#320000b4;true]" ..
 		"label[4.85,1.35;" .. fgettext("You died") ..
 		"]button_exit[4,3;3,0.5;btn_respawn;".. fgettext("Respawn") .."]"
-	core.show_formspec("bultin:death", formspec)
+	minetest.show_formspec("bultin:death", formspec)
 end)
 
-core.register_on_formspec_input(function(formname, fields)
+minetest.register_on_formspec_input(function(formname, fields)
 	if formname == "bultin:death" then
-		core.send_respawn()
+		minetest.send_respawn()
 	end
 end)

--- a/builtin/client/init.lua
+++ b/builtin/client/init.lua
@@ -1,5 +1,5 @@
 -- Minetest: builtin/client/init.lua
-local scriptpath = core.get_builtin_path()
+local scriptpath = minetest.get_builtin_path()
 local clientpath = scriptpath.."client"..DIR_DELIM
 local commonpath = scriptpath.."common"..DIR_DELIM
 

--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -1,10 +1,10 @@
 
-core.callback_origins = {}
+minetest.callback_origins = {}
 
 local getinfo = debug.getinfo
 debug.getinfo = nil
 
-function core.run_callbacks(callbacks, mode, ...)
+function minetest.run_callbacks(callbacks, mode, ...)
 	assert(type(callbacks) == "table")
 	local cb_len = #callbacks
 	if cb_len == 0 then
@@ -48,29 +48,29 @@ local function make_registration()
 	local t = {}
 	local registerfunc = function(func)
 		t[#t + 1] = func
-		core.callback_origins[func] = {
-			mod = core.get_current_modname() or "??",
+		minetest.callback_origins[func] = {
+			mod = minetest.get_current_modname() or "??",
 			name = getinfo(1, "n").name or "??"
 		}
-		--local origin = core.callback_origins[func]
+		--local origin = minetest.callback_origins[func]
 		--print(origin.name .. ": " .. origin.mod .. " registering cbk " .. tostring(func))
 	end
 	return t, registerfunc
 end
 
-core.registered_globalsteps, core.register_globalstep = make_registration()
-core.registered_on_mods_loaded, core.register_on_mods_loaded = make_registration()
-core.registered_on_shutdown, core.register_on_shutdown = make_registration()
-core.registered_on_receiving_chat_message, core.register_on_receiving_chat_message = make_registration()
-core.registered_on_sending_chat_message, core.register_on_sending_chat_message = make_registration()
-core.registered_on_death, core.register_on_death = make_registration()
-core.registered_on_hp_modification, core.register_on_hp_modification = make_registration()
-core.registered_on_damage_taken, core.register_on_damage_taken = make_registration()
-core.registered_on_formspec_input, core.register_on_formspec_input = make_registration()
-core.registered_on_dignode, core.register_on_dignode = make_registration()
-core.registered_on_punchnode, core.register_on_punchnode = make_registration()
-core.registered_on_placenode, core.register_on_placenode = make_registration()
-core.registered_on_item_use, core.register_on_item_use = make_registration()
-core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
-core.registered_on_modchannel_signal, core.register_on_modchannel_signal = make_registration()
-core.registered_on_inventory_open, core.register_on_inventory_open = make_registration()
+minetest.registered_globalsteps, minetest.register_globalstep = make_registration()
+minetest.registered_on_mods_loaded, minetest.register_on_mods_loaded = make_registration()
+minetest.registered_on_shutdown, minetest.register_on_shutdown = make_registration()
+minetest.registered_on_receiving_chat_message, minetest.register_on_receiving_chat_message = make_registration()
+minetest.registered_on_sending_chat_message, minetest.register_on_sending_chat_message = make_registration()
+minetest.registered_on_death, minetest.register_on_death = make_registration()
+minetest.registered_on_hp_modification, minetest.register_on_hp_modification = make_registration()
+minetest.registered_on_damage_taken, minetest.register_on_damage_taken = make_registration()
+minetest.registered_on_formspec_input, minetest.register_on_formspec_input = make_registration()
+minetest.registered_on_dignode, minetest.register_on_dignode = make_registration()
+minetest.registered_on_punchnode, minetest.register_on_punchnode = make_registration()
+minetest.registered_on_placenode, minetest.register_on_placenode = make_registration()
+minetest.registered_on_item_use, minetest.register_on_item_use = make_registration()
+minetest.registered_on_modchannel_message, minetest.register_on_modchannel_message = make_registration()
+minetest.registered_on_modchannel_signal, minetest.register_on_modchannel_signal = make_registration()
+minetest.registered_on_inventory_open, minetest.register_on_inventory_open = make_registration()

--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -2,7 +2,7 @@ local jobs = {}
 local time = 0.0
 local time_next = math.huge
 
-core.register_globalstep(function(dtime)
+minetest.register_globalstep(function(dtime)
 	time = time + dtime
 
 	if time < time_next then
@@ -16,7 +16,7 @@ core.register_globalstep(function(dtime)
 	for i = #jobs, 1, -1 do
 		local job = jobs[i]
 		if time >= job.expire then
-			core.set_last_run_mod(job.mod_origin)
+			minetest.set_last_run_mod(job.mod_origin)
 			job.func(unpack(job.arg))
 			local jobs_l = #jobs
 			jobs[i] = jobs[jobs_l]
@@ -27,7 +27,7 @@ core.register_globalstep(function(dtime)
 	end
 end)
 
-function core.after(after, func, ...)
+function minetest.after(after, func, ...)
 	assert(tonumber(after) and type(func) == "function",
 		"Invalid minetest.after invocation")
 	local expire = time + after
@@ -35,7 +35,7 @@ function core.after(after, func, ...)
 		func = func,
 		expire = expire,
 		arg = {...},
-		mod_origin = core.get_last_run_mod()
+		mod_origin = minetest.get_last_run_mod()
 	}
 	time_next = math.min(time_next, expire)
 end

--- a/builtin/common/async_event.lua
+++ b/builtin/common/async_event.lua
@@ -1,39 +1,39 @@
 
-core.async_jobs = {}
+minetest.async_jobs = {}
 
 local function handle_job(jobid, serialized_retval)
-	local retval = core.deserialize(serialized_retval)
-	assert(type(core.async_jobs[jobid]) == "function")
-	core.async_jobs[jobid](retval)
-	core.async_jobs[jobid] = nil
+	local retval = minetest.deserialize(serialized_retval)
+	assert(type(minetest.async_jobs[jobid]) == "function")
+	minetest.async_jobs[jobid](retval)
+	minetest.async_jobs[jobid] = nil
 end
 
-if core.register_globalstep then
-	core.register_globalstep(function(dtime)
-		for i, job in ipairs(core.get_finished_jobs()) do
+if minetest.register_globalstep then
+	minetest.register_globalstep(function(dtime)
+		for i, job in ipairs(minetest.get_finished_jobs()) do
 			handle_job(job.jobid, job.retval)
 		end
 	end)
 else
-	core.async_event_handler = handle_job
+	minetest.async_event_handler = handle_job
 end
 
-function core.handle_async(func, parameter, callback)
+function minetest.handle_async(func, parameter, callback)
 	-- Serialize function
 	local serialized_func = string.dump(func)
 
 	assert(serialized_func ~= nil)
 
 	-- Serialize parameters
-	local serialized_param = core.serialize(parameter)
+	local serialized_param = minetest.serialize(parameter)
 
 	if serialized_param == nil then
 		return false
 	end
 
-	local jobid = core.do_async_callback(serialized_func, serialized_param)
+	local jobid = minetest.do_async_callback(serialized_func, serialized_param)
 
-	core.async_jobs[jobid] = callback
+	minetest.async_jobs[jobid] = callback
 
 	return true
 end

--- a/builtin/common/chatcommands.lua
+++ b/builtin/common/chatcommands.lua
@@ -1,32 +1,32 @@
 -- Minetest: builtin/common/chatcommands.lua
 
-core.registered_chatcommands = {}
+minetest.registered_chatcommands = {}
 
-function core.register_chatcommand(cmd, def)
+function minetest.register_chatcommand(cmd, def)
 	def = def or {}
 	def.params = def.params or ""
 	def.description = def.description or ""
 	def.privs = def.privs or {}
-	def.mod_origin = core.get_current_modname() or "??"
-	core.registered_chatcommands[cmd] = def
+	def.mod_origin = minetest.get_current_modname() or "??"
+	minetest.registered_chatcommands[cmd] = def
 end
 
-function core.unregister_chatcommand(name)
-	if core.registered_chatcommands[name] then
-		core.registered_chatcommands[name] = nil
+function minetest.unregister_chatcommand(name)
+	if minetest.registered_chatcommands[name] then
+		minetest.registered_chatcommands[name] = nil
 	else
-		core.log("warning", "Not unregistering chatcommand " ..name..
+		minetest.log("warning", "Not unregistering chatcommand " ..name..
 			" because it doesn't exist.")
 	end
 end
 
-function core.override_chatcommand(name, redefinition)
-	local chatcommand = core.registered_chatcommands[name]
+function minetest.override_chatcommand(name, redefinition)
+	local chatcommand = minetest.registered_chatcommands[name]
 	assert(chatcommand, "Attempt to override non-existent chatcommand "..name)
 	for k, v in pairs(redefinition) do
 		rawset(chatcommand, k, v)
 	end
-	core.registered_chatcommands[name] = chatcommand
+	minetest.registered_chatcommands[name] = chatcommand
 end
 
 local cmd_marker = "/"
@@ -42,13 +42,13 @@ end
 
 if INIT == "client" then
 	cmd_marker = "."
-	gettext = core.gettext
+	gettext = minetest.gettext
 	gettext_replace = fgettext_ne
 end
 
 local function do_help_cmd(name, param)
 	local function format_help_line(cmd, def)
-		local msg = core.colorize("#00ffff", cmd_marker .. cmd)
+		local msg = minetest.colorize("#00ffff", cmd_marker .. cmd)
 		if def.params and def.params ~= "" then
 			msg = msg .. " " .. def.params
 		end
@@ -59,8 +59,8 @@ local function do_help_cmd(name, param)
 	end
 	if param == "" then
 		local cmds = {}
-		for cmd, def in pairs(core.registered_chatcommands) do
-			if INIT == "client" or core.check_player_privs(name, def.privs) then
+		for cmd, def in pairs(minetest.registered_chatcommands) do
+			if INIT == "client" or minetest.check_player_privs(name, def.privs) then
 				cmds[#cmds + 1] = cmd
 			end
 		end
@@ -70,8 +70,8 @@ local function do_help_cmd(name, param)
 				.. " or '$1help all' to list everything.", cmd_marker)
 	elseif param == "all" then
 		local cmds = {}
-		for cmd, def in pairs(core.registered_chatcommands) do
-			if INIT == "client" or core.check_player_privs(name, def.privs) then
+		for cmd, def in pairs(minetest.registered_chatcommands) do
+			if INIT == "client" or minetest.check_player_privs(name, def.privs) then
 				cmds[#cmds + 1] = format_help_line(cmd, def)
 			end
 		end
@@ -79,14 +79,14 @@ local function do_help_cmd(name, param)
 		return true, gettext("Available commands:").."\n"..table.concat(cmds, "\n")
 	elseif INIT == "game" and param == "privs" then
 		local privs = {}
-		for priv, def in pairs(core.registered_privileges) do
+		for priv, def in pairs(minetest.registered_privileges) do
 			privs[#privs + 1] = priv .. ": " .. def.description
 		end
 		table.sort(privs)
 		return true, "Available privileges:\n"..table.concat(privs, "\n")
 	else
 		local cmd = param
-		local def = core.registered_chatcommands[cmd]
+		local def = minetest.registered_chatcommands[cmd]
 		if not def then
 			return false, gettext("Command not available: ")..cmd
 		else
@@ -96,7 +96,7 @@ local function do_help_cmd(name, param)
 end
 
 if INIT == "client" then
-	core.register_chatcommand("help", {
+	minetest.register_chatcommand("help", {
 		params = gettext("[all | <cmd>]"),
 		description = gettext("Get help for commands"),
 		func = function(param)
@@ -104,7 +104,7 @@ if INIT == "client" then
 		end,
 	})
 else
-	core.register_chatcommand("help", {
+	minetest.register_chatcommand("help", {
 		params = "[all | privs | <cmd>]",
 		description = "Get help for commands or list privileges",
 		func = do_help_cmd,

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -20,8 +20,8 @@ local LIST_FORMSPEC_DESCRIPTION = [[
 		button_exit[5,7;3,1;quit;%s]
 	]]
 
-local formspec_escape = core.formspec_escape
-local check_player_privs = core.check_player_privs
+local formspec_escape = minetest.formspec_escape
+local check_player_privs = minetest.check_player_privs
 
 
 -- CHAT COMMANDS FORMSPEC
@@ -31,7 +31,7 @@ local mod_cmds = {}
 local function load_mod_command_tree()
 	mod_cmds = {}
 
-	for name, def in pairs(core.registered_chatcommands) do
+	for name, def in pairs(minetest.registered_chatcommands) do
 		mod_cmds[def.mod_origin] = mod_cmds[def.mod_origin] or {}
 		local cmds = mod_cmds[def.mod_origin]
 
@@ -47,7 +47,7 @@ local function load_mod_command_tree()
 	mod_cmds = sorted_mod_cmds
 end
 
-core.after(0, load_mod_command_tree)
+minetest.after(0, load_mod_command_tree)
 
 local function build_chatcommands_formspec(name, sel, copy)
 	local rows = {}
@@ -66,8 +66,8 @@ local function build_chatcommands_formspec(name, sel, copy)
 			if sel == #rows then
 				description = cmds[2].description
 				if copy then
-					core.chat_send_player(name, ("Command: %s %s"):format(
-						core.colorize("#0FF", "/" .. cmds[1]), cmds[2].params))
+					minetest.chat_send_player(name, ("Command: %s %s"):format(
+						minetest.colorize("#0FF", "/" .. cmds[1]), cmds[2].params))
 				end
 			end
 		end
@@ -85,7 +85,7 @@ end
 
 local function build_privs_formspec(name)
 	local privs = {}
-	for priv_name, def in pairs(core.registered_privileges) do
+	for priv_name, def in pairs(minetest.registered_privileges) do
 		privs[#privs + 1] = { priv_name, def }
 	end
 	table.sort(privs, function(a, b) return a[1] < b[1] end)
@@ -93,7 +93,7 @@ local function build_privs_formspec(name)
 	local rows = {}
 	rows[1] = "#FFF,0,Privilege,Description"
 
-	local player_privs = core.get_player_privs(name)
+	local player_privs = minetest.get_player_privs(name)
 	for i, data in ipairs(privs) do
 		rows[#rows + 1] = ("%s,0,%s,%s"):format(
 			player_privs[data[1]] and COLOR_GREEN or COLOR_GRAY,
@@ -110,7 +110,7 @@ end
 
 -- DETAILED CHAT COMMAND INFORMATION
 
-core.register_on_player_receive_fields(function(player, formname, fields)
+minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if formname ~= "__builtin:help_cmds" or fields.quit then
 		return
 	end
@@ -118,29 +118,29 @@ core.register_on_player_receive_fields(function(player, formname, fields)
 	local event = minetest.explode_table_event(fields.list)
 	if event.type ~= "INV" then
 		local name = player:get_player_name()
-		core.show_formspec(name, "__builtin:help_cmds",
+		minetest.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name, event.row, event.type == "DCL"))
 	end
 end)
 
 
-local help_command = core.registered_chatcommands["help"]
+local help_command = minetest.registered_chatcommands["help"]
 local old_help_func = help_command.func
 
 help_command.func = function(name, param)
-	local admin = core.settings:get("name")
+	local admin = minetest.settings:get("name")
 
 	-- If the admin ran help, put the output in the chat buffer as well to
 	-- work with the server terminal
 	if param == "privs" then
-		core.show_formspec(name, "__builtin:help_privs",
+		minetest.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))
 		if name ~= admin then
 			return
 		end
 	end
 	if param == "" or param == "all" then
-		core.show_formspec(name, "__builtin:help_cmds",
+		minetest.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name))
 		if name ~= admin then
 			return

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -317,7 +317,7 @@ function cleanup_path(temppath)
 	return temppath
 end
 
-function core.formspec_escape(text)
+function minetest.formspec_escape(text)
 	if text ~= nil then
 		text = string.gsub(text,"\\","\\\\")
 		text = string.gsub(text,"%]","\\]")
@@ -329,7 +329,7 @@ function core.formspec_escape(text)
 end
 
 
-function core.wrap_text(text, max_length, as_table)
+function minetest.wrap_text(text, max_length, as_table)
 	local result = {}
 	local line = {}
 	if #text <= max_length then
@@ -356,20 +356,20 @@ if INIT == "game" then
 	local dirs1 = {9, 18, 7, 12}
 	local dirs2 = {20, 23, 22, 21}
 
-	function core.rotate_and_place(itemstack, placer, pointed_thing,
+	function minetest.rotate_and_place(itemstack, placer, pointed_thing,
 			infinitestacks, orient_flags, prevent_after_place)
 		orient_flags = orient_flags or {}
 
-		local unode = core.get_node_or_nil(pointed_thing.under)
+		local unode = minetest.get_node_or_nil(pointed_thing.under)
 		if not unode then
 			return
 		end
-		local undef = core.registered_nodes[unode.name]
+		local undef = minetest.registered_nodes[unode.name]
 		if undef and undef.on_rightclick then
 			return undef.on_rightclick(pointed_thing.under, unode, placer,
 					itemstack, pointed_thing)
 		end
-		local fdir = placer and core.dir_to_facedir(placer:get_look_dir()) or 0
+		local fdir = placer and minetest.dir_to_facedir(placer:get_look_dir()) or 0
 
 		local above = pointed_thing.above
 		local under = pointed_thing.under
@@ -409,7 +409,7 @@ if INIT == "game" then
 		end
 
 		local old_itemstack = ItemStack(itemstack)
-		local new_itemstack = core.item_place_node(itemstack, placer,
+		local new_itemstack = minetest.item_place_node(itemstack, placer,
 				pointed_thing, param2, prevent_after_place)
 		return infinitestacks and old_itemstack or new_itemstack
 	end
@@ -419,23 +419,23 @@ if INIT == "game" then
 --Wrapper for rotate_and_place() to check for sneak and assume Creative mode
 --implies infinite stacks when performing a 6d rotation.
 --------------------------------------------------------------------------------
-	local creative_mode_cache = core.settings:get_bool("creative_mode")
+	local creative_mode_cache = minetest.settings:get_bool("creative_mode")
 	local function is_creative(name)
 		return creative_mode_cache or
-				core.check_player_privs(name, {creative = true})
+				minetest.check_player_privs(name, {creative = true})
 	end
 
-	core.rotate_node = function(itemstack, placer, pointed_thing)
+	minetest.rotate_node = function(itemstack, placer, pointed_thing)
 		local name = placer and placer:get_player_name() or ""
 		local invert_wall = placer and placer:get_player_control().sneak or false
-		return core.rotate_and_place(itemstack, placer, pointed_thing,
+		return minetest.rotate_and_place(itemstack, placer, pointed_thing,
 				is_creative(name),
 				{invert_wall = invert_wall}, true)
 	end
 end
 
 --------------------------------------------------------------------------------
-function core.explode_table_event(evt)
+function minetest.explode_table_event(evt)
 	if evt ~= nil then
 		local parts = evt:split(":")
 		if #parts == 3 then
@@ -452,7 +452,7 @@ function core.explode_table_event(evt)
 end
 
 --------------------------------------------------------------------------------
-function core.explode_textlist_event(evt)
+function minetest.explode_textlist_event(evt)
 	if evt ~= nil then
 		local parts = evt:split(":")
 		if #parts == 2 then
@@ -467,8 +467,8 @@ function core.explode_textlist_event(evt)
 end
 
 --------------------------------------------------------------------------------
-function core.explode_scrollbar_event(evt)
-	local retval = core.explode_textlist_event(evt)
+function minetest.explode_scrollbar_event(evt)
+	local retval = minetest.explode_textlist_event(evt)
 
 	retval.value = retval.index
 	retval.index = nil
@@ -477,13 +477,13 @@ function core.explode_scrollbar_event(evt)
 end
 
 --------------------------------------------------------------------------------
-function core.rgba(r, g, b, a)
+function minetest.rgba(r, g, b, a)
 	return a and string.format("#%02X%02X%02X%02X", r, g, b, a) or
 			string.format("#%02X%02X%02X", r, g, b)
 end
 
 --------------------------------------------------------------------------------
-function core.pos_to_string(pos, decimal_places)
+function minetest.pos_to_string(pos, decimal_places)
 	local x = pos.x
 	local y = pos.y
 	local z = pos.z
@@ -496,7 +496,7 @@ function core.pos_to_string(pos, decimal_places)
 end
 
 --------------------------------------------------------------------------------
-function core.string_to_pos(value)
+function minetest.string_to_pos(value)
 	if value == nil then
 		return nil
 	end
@@ -520,19 +520,19 @@ function core.string_to_pos(value)
 	return nil
 end
 
-assert(core.string_to_pos("10.0, 5, -2").x == 10)
-assert(core.string_to_pos("( 10.0, 5, -2)").z == -2)
-assert(core.string_to_pos("asd, 5, -2)") == nil)
+assert(minetest.string_to_pos("10.0, 5, -2").x == 10)
+assert(minetest.string_to_pos("( 10.0, 5, -2)").z == -2)
+assert(minetest.string_to_pos("asd, 5, -2)") == nil)
 
 --------------------------------------------------------------------------------
-function core.string_to_area(value)
+function minetest.string_to_area(value)
 	local p1, p2 = unpack(value:split(") ("))
 	if p1 == nil or p2 == nil then
 		return nil
 	end
 
-	p1 = core.string_to_pos(p1 .. ")")
-	p2 = core.string_to_pos("(" .. p2)
+	p1 = minetest.string_to_pos(p1 .. ")")
+	p2 = minetest.string_to_pos("(" .. p2)
 	if p1 == nil or p2 == nil then
 		return nil
 	end
@@ -541,14 +541,14 @@ function core.string_to_area(value)
 end
 
 local function test_string_to_area()
-	local p1, p2 = core.string_to_area("(10.0, 5, -2) (  30.2,   4, -12.53)")
+	local p1, p2 = minetest.string_to_area("(10.0, 5, -2) (  30.2,   4, -12.53)")
 	assert(p1.x == 10.0 and p1.y == 5 and p1.z == -2)
 	assert(p2.x == 30.2 and p2.y == 4 and p2.z == -12.53)
 
-	p1, p2 = core.string_to_area("(10.0, 5, -2  30.2,   4, -12.53")
+	p1, p2 = minetest.string_to_area("(10.0, 5, -2  30.2,   4, -12.53")
 	assert(p1 == nil and p2 == nil)
 
-	p1, p2 = core.string_to_area("(10.0, 5,) -2  fgdf2,   4, -12.53")
+	p1, p2 = minetest.string_to_area("(10.0, 5,) -2  fgdf2,   4, -12.53")
 	assert(p1 == nil and p2 == nil)
 end
 
@@ -579,8 +579,8 @@ end
 -- mainmenu only functions
 --------------------------------------------------------------------------------
 if INIT == "mainmenu" then
-	function core.get_game(index)
-		local games = core.get_games()
+	function minetest.get_game(index)
+		local games = minetest.get_games()
 
 		if index > 0 and index <= #games then
 			return games[index]
@@ -592,7 +592,7 @@ end
 
 if INIT == "client" or INIT == "mainmenu" then
 	function fgettext_ne(text, ...)
-		text = core.gettext(text)
+		text = minetest.gettext(text)
 		local arg = {n=select('#', ...), ...}
 		if arg.n >= 1 then
 			-- Insert positional parameters ($1, $2, ...)
@@ -617,45 +617,45 @@ if INIT == "client" or INIT == "mainmenu" then
 	end
 
 	function fgettext(text, ...)
-		return core.formspec_escape(fgettext_ne(text, ...))
+		return minetest.formspec_escape(fgettext_ne(text, ...))
 	end
 end
 
 local ESCAPE_CHAR = string.char(0x1b)
 
-function core.get_color_escape_sequence(color)
+function minetest.get_color_escape_sequence(color)
 	return ESCAPE_CHAR .. "(c@" .. color .. ")"
 end
 
-function core.get_background_escape_sequence(color)
+function minetest.get_background_escape_sequence(color)
 	return ESCAPE_CHAR .. "(b@" .. color .. ")"
 end
 
-function core.colorize(color, message)
+function minetest.colorize(color, message)
 	local lines = tostring(message):split("\n", true)
-	local color_code = core.get_color_escape_sequence(color)
+	local color_code = minetest.get_color_escape_sequence(color)
 
 	for i, line in ipairs(lines) do
 		lines[i] = color_code .. line
 	end
 
-	return table.concat(lines, "\n") .. core.get_color_escape_sequence("#ffffff")
+	return table.concat(lines, "\n") .. minetest.get_color_escape_sequence("#ffffff")
 end
 
 
-function core.strip_foreground_colors(str)
+function minetest.strip_foreground_colors(str)
 	return (str:gsub(ESCAPE_CHAR .. "%(c@[^)]+%)", ""))
 end
 
-function core.strip_background_colors(str)
+function minetest.strip_background_colors(str)
 	return (str:gsub(ESCAPE_CHAR .. "%(b@[^)]+%)", ""))
 end
 
-function core.strip_colors(str)
+function minetest.strip_colors(str)
 	return (str:gsub(ESCAPE_CHAR .. "%([bc]@[^)]+%)", ""))
 end
 
-function core.translate(textdomain, str, ...)
+function minetest.translate(textdomain, str, ...)
 	local start_seq
 	if textdomain == "" then
 		start_seq = ESCAPE_CHAR .. "T"
@@ -670,12 +670,12 @@ function core.translate(textdomain, str, ...)
 		if string.byte("1") <= c and c <= string.byte("9") then
 			local a = c - string.byte("0")
 			if a ~= arg_index then
-				error("Escape sequences in string given to core.translate " ..
+				error("Escape sequences in string given to minetest.translate " ..
 					"are not in the correct order: got @" .. matched ..
 					"but expected @" .. tostring(arg_index))
 			end
 			if a > arg.n then
-				error("Not enough arguments provided to core.translate")
+				error("Not enough arguments provided to minetest.translate")
 			end
 			arg_index = arg_index + 1
 			return ESCAPE_CHAR .. "F" .. arg[a] .. ESCAPE_CHAR .. "E"
@@ -686,19 +686,19 @@ function core.translate(textdomain, str, ...)
 		end
 	end)
 	if arg_index < arg.n + 1 then
-		error("Too many arguments provided to core.translate")
+		error("Too many arguments provided to minetest.translate")
 	end
 	return start_seq .. translated .. end_seq
 end
 
-function core.get_translator(textdomain)
-	return function(str, ...) return core.translate(textdomain or "", str, ...) end
+function minetest.get_translator(textdomain)
+	return function(str, ...) return minetest.translate(textdomain or "", str, ...) end
 end
 
 --------------------------------------------------------------------------------
 -- Returns the exact coordinate of a pointed surface
 --------------------------------------------------------------------------------
-function core.pointed_thing_to_face_pos(placer, pointed_thing)
+function minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 	-- Avoid crash in some situations when player is inside a node, causing
 	-- 'above' to equal 'under'.
 	if vector.equals(pointed_thing.above, pointed_thing.under) then
@@ -734,7 +734,7 @@ function core.pointed_thing_to_face_pos(placer, pointed_thing)
 	return fine_pos
 end
 
-function core.string_to_privs(str, delim)
+function minetest.string_to_privs(str, delim)
 	assert(type(str) == "string")
 	delim = delim or ','
 	local privs = {}
@@ -744,7 +744,7 @@ function core.string_to_privs(str, delim)
 	return privs
 end
 
-function core.privs_to_string(privs, delim)
+function minetest.privs_to_string(privs, delim)
 	assert(type(privs) == "table")
 	delim = delim or ','
 	local list = {}
@@ -756,5 +756,5 @@ function core.privs_to_string(privs, delim)
 	return table.concat(list, delim)
 end
 
-assert(core.string_to_privs("a,b").b == true)
-assert(core.privs_to_string({a=true,b=true}) == "a,b")
+assert(minetest.string_to_privs("a,b").b == true)
+assert(minetest.privs_to_string({a=true,b=true}) == "a,b")

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -17,7 +17,7 @@
 --   2. Recursively dump the value into a string.
 -- @param x Value to serialize (nil is allowed).
 -- @return load()able string containing the value.
-function core.serialize(x)
+function minetest.serialize(x)
 	local local_index  = 1  -- Top index of the "_" local table in the dump
 	-- table->nil/1/2 set of tables seen.
 	-- nil = not seen, 1 = seen once, 2 = seen multiple times.
@@ -185,7 +185,7 @@ local safe_env = {
 	loadstring = function() end,
 }
 
-function core.deserialize(str, safe)
+function minetest.deserialize(str, safe)
 	if type(str) ~= "string" then
 		return nil, "Cannot deserialize type '"..type(str)
 			.."'. Argument must be a string."
@@ -208,13 +208,13 @@ end
 
 -- Unit tests
 local test_in = {cat={sound="nyan", speed=400}, dog={sound="woof"}}
-local test_out = core.deserialize(core.serialize(test_in))
+local test_out = minetest.deserialize(minetest.serialize(test_in))
 
 assert(test_in.cat.sound == test_out.cat.sound)
 assert(test_in.cat.speed == test_out.cat.speed)
 assert(test_in.dog.sound == test_out.dog.sound)
 
 test_in = {escape_chars="\n\r\t\v\\\"\'", non_european="θשׁ٩∂"}
-test_out = core.deserialize(core.serialize(test_in))
+test_out = minetest.deserialize(minetest.serialize(test_in))
 assert(test_in.escape_chars == test_out.escape_chars)
 assert(test_in.non_european == test_out.non_european)

--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -5,9 +5,9 @@ local WARN_INIT = false
 
 local getinfo = debug.getinfo
 
-function core.global_exists(name)
+function minetest.global_exists(name)
 	if type(name) ~= "string" then
-		error("core.global_exists: " .. tostring(name) .. " is not a string")
+		error("minetest.global_exists: " .. tostring(name) .. " is not a string")
 	end
 	return rawget(_G, name) ~= nil
 end
@@ -26,7 +26,7 @@ function meta:__newindex(name, value)
 				info.currentline, name)
 		if not warned[warn_key] and info.what ~= "main" and
 				info.what ~= "C" then
-			core.log("warning", ("Assignment to undeclared "..
+			minetest.log("warning", ("Assignment to undeclared "..
 					"global %q inside a function at %s.")
 				:format(name, desc))
 			warned[warn_key] = true
@@ -34,8 +34,8 @@ function meta:__newindex(name, value)
 		declared[name] = true
 	end
 	-- Ignore mod namespaces
-	if WARN_INIT and name ~= core.get_current_modname() then
-		core.log("warning", ("Global variable %q created at %s.")
+	if WARN_INIT and name ~= minetest.get_current_modname() then
+		minetest.log("warning", ("Global variable %q created at %s.")
 			:format(name, desc))
 	end
 	rawset(self, name, value)
@@ -46,7 +46,7 @@ function meta:__index(name)
 	local info = getinfo(2, "Sl")
 	local warn_key = ("%s\0%d\0%s"):format(info.source, info.currentline, name)
 	if not declared[name] and not warned[warn_key] and info.what ~= "C" then
-		core.log("warning", ("Undeclared global variable %q accessed at %s:%s")
+		minetest.log("warning", ("Undeclared global variable %q accessed at %s:%s")
 				:format(name, info.short_src, info.currentline))
 		warned[warn_key] = true
 	end

--- a/builtin/fstk/tabview.lua
+++ b/builtin/fstk/tabview.lua
@@ -167,7 +167,7 @@ local function switch_to_tab(self, index)
 	self.current_tab = self.tablist[index].name
 
 	if (self.autosave_tab) then
-		core.settings:set(self.name .. "_LAST",self.current_tab)
+		minetest.settings:set(self.name .. "_LAST",self.current_tab)
 	end
 
 	-- call for tab to enter

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -59,7 +59,7 @@ function ui.update()
 
 	-- handle errors
 	if gamedata ~= nil and gamedata.reconnect_requested then
-		local error_message = core.formspec_escape(
+		local error_message = minetest.formspec_escape(
 				gamedata.errormessage or "<none available>")
 		formspec = {
 			"size[14,8]",
@@ -71,7 +71,7 @@ function ui.update()
 			"button[8,6.6;4,1;btn_reconnect_no;" .. fgettext("Main menu") .. "]"
 		}
 	elseif gamedata ~= nil and gamedata.errormessage ~= nil then
-		local error_message = core.formspec_escape(gamedata.errormessage)
+		local error_message = minetest.formspec_escape(gamedata.errormessage)
 
 		local error_title
 		if string.find(gamedata.errormessage, "ModError") then
@@ -114,18 +114,18 @@ function ui.update()
 		end
 
 		if (active_toplevel_ui_elements > 1) then
-			core.log("warning", "more than one active ui "..
+			minetest.log("warning", "more than one active ui "..
 				"element, self most likely isn't intended")
 		end
 
 		if (active_toplevel_ui_elements == 0) then
-			core.log("warning", "no toplevel ui element "..
+			minetest.log("warning", "no toplevel ui element "..
 					"active; switching to default")
 			ui.childlist[ui.default]:show()
 			formspec = {ui.childlist[ui.default]:get_formspec()}
 		end
 	end
-	core.update_formspec(table.concat(formspec))
+	minetest.update_formspec(table.concat(formspec))
 end
 
 --------------------------------------------------------------------------------
@@ -162,12 +162,12 @@ end
 -- initialize callbacks
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-core.button_handler = function(fields)
+minetest.button_handler = function(fields)
 	if fields["btn_reconnect_yes"] then
 		gamedata.reconnect_requested = false
 		gamedata.errormessage = nil
 		gamedata.do_reconnect = true
-		core.start()
+		minetest.start()
 		return
 	elseif fields["btn_reconnect_no"] or fields["btn_error_confirm"] then
 		gamedata.errormessage = nil
@@ -182,7 +182,7 @@ core.button_handler = function(fields)
 end
 
 --------------------------------------------------------------------------------
-core.event_handler = function(event)
+minetest.event_handler = function(event)
 	if ui.handle_events(event) then
 		ui.update()
 		return

--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -5,13 +5,13 @@
 --
 
 -- Make the auth object private, deny access to mods
-local core_auth = minetest.auth
+local minetest_auth = minetest.auth
 minetest.auth = nil
 
 minetest.builtin_auth_handler = {
 	get_auth = function(name)
 		assert(type(name) == "string")
-		local auth_entry = core_auth.read(name)
+		local auth_entry = minetest_auth.read(name)
 		-- If no such auth found, return nil
 		if not auth_entry then
 			return nil
@@ -49,7 +49,7 @@ minetest.builtin_auth_handler = {
 		assert(type(name) == "string")
 		assert(type(password) == "string")
 		minetest.log('info', "Built-in authentication handler adding player '"..name.."'")
-		return core_auth.create({
+		return minetest_auth.create({
 			name = name,
 			password = password,
 			privileges = minetest.string_to_privs(minetest.settings:get("default_privs")),
@@ -58,30 +58,30 @@ minetest.builtin_auth_handler = {
 	end,
 	delete_auth = function(name)
 		assert(type(name) == "string")
-		local auth_entry = core_auth.read(name)
+		local auth_entry = minetest_auth.read(name)
 		if not auth_entry then
 			return false
 		end
 		minetest.log('info', "Built-in authentication handler deleting player '"..name.."'")
-		return core_auth.delete(name)
+		return minetest_auth.delete(name)
 	end,
 	set_password = function(name, password)
 		assert(type(name) == "string")
 		assert(type(password) == "string")
-		local auth_entry = core_auth.read(name)
+		local auth_entry = minetest_auth.read(name)
 		if not auth_entry then
 			minetest.builtin_auth_handler.create_auth(name, password)
 		else
 			minetest.log('info', "Built-in authentication handler setting password of player '"..name.."'")
 			auth_entry.password = password
-			core_auth.save(auth_entry)
+			minetest_auth.save(auth_entry)
 		end
 		return true
 	end,
 	set_privileges = function(name, privileges)
 		assert(type(name) == "string")
 		assert(type(privileges) == "table")
-		local auth_entry = core_auth.read(name)
+		local auth_entry = minetest_auth.read(name)
 		if not auth_entry then
 			auth_entry = minetest.builtin_auth_handler.create_auth(name,
 				minetest.get_password_hash(name,
@@ -103,23 +103,23 @@ minetest.builtin_auth_handler = {
 		end
 
 		auth_entry.privileges = privileges
-		core_auth.save(auth_entry)
+		minetest_auth.save(auth_entry)
 		minetest.notify_authentication_modified(name)
 	end,
 	reload = function()
-		core_auth.reload()
+		minetest_auth.reload()
 		return true
 	end,
 	record_login = function(name)
 		assert(type(name) == "string")
-		local auth_entry = core_auth.read(name)
+		local auth_entry = minetest_auth.read(name)
 		assert(auth_entry)
 		auth_entry.last_login = os.time()
-		core_auth.save(auth_entry)
+		minetest_auth.save(auth_entry)
 	end,
 	iterate = function()
 		local names = {}
-		local nameslist = core_auth.list_names()
+		local nameslist = minetest_auth.list_names()
 		for k,v in pairs(nameslist) do
 			names[v] = true
 		end
@@ -131,7 +131,7 @@ minetest.register_on_prejoinplayer(function(name, ip)
 	if minetest.registered_auth_handler ~= nil then
 		return -- Don't do anything if custom auth handler registered
 	end
-	local auth_entry = core_auth.read(name)
+	local auth_entry = minetest_auth.read(name)
 	if auth_entry ~= nil then
 		return
 	end

--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -5,10 +5,10 @@
 --
 
 -- Make the auth object private, deny access to mods
-local core_auth = core.auth
-core.auth = nil
+local core_auth = minetest.auth
+minetest.auth = nil
 
-core.builtin_auth_handler = {
+minetest.builtin_auth_handler = {
 	get_auth = function(name)
 		assert(type(name) == "string")
 		local auth_entry = core_auth.read(name)
@@ -23,15 +23,15 @@ core.builtin_auth_handler = {
 			privileges[priv] = true
 		end
 		-- If singleplayer, give all privileges except those marked as give_to_singleplayer = false
-		if core.is_singleplayer() then
-			for priv, def in pairs(core.registered_privileges) do
+		if minetest.is_singleplayer() then
+			for priv, def in pairs(minetest.registered_privileges) do
 				if def.give_to_singleplayer then
 					privileges[priv] = true
 				end
 			end
 		-- For the admin, give everything
-		elseif name == core.settings:get("name") then
-			for priv, def in pairs(core.registered_privileges) do
+		elseif name == minetest.settings:get("name") then
+			for priv, def in pairs(minetest.registered_privileges) do
 				if def.give_to_admin then
 					privileges[priv] = true
 				end
@@ -48,11 +48,11 @@ core.builtin_auth_handler = {
 	create_auth = function(name, password)
 		assert(type(name) == "string")
 		assert(type(password) == "string")
-		core.log('info', "Built-in authentication handler adding player '"..name.."'")
+		minetest.log('info', "Built-in authentication handler adding player '"..name.."'")
 		return core_auth.create({
 			name = name,
 			password = password,
-			privileges = core.string_to_privs(core.settings:get("default_privs")),
+			privileges = minetest.string_to_privs(minetest.settings:get("default_privs")),
 			last_login = os.time(),
 		})
 	end,
@@ -62,7 +62,7 @@ core.builtin_auth_handler = {
 		if not auth_entry then
 			return false
 		end
-		core.log('info', "Built-in authentication handler deleting player '"..name.."'")
+		minetest.log('info', "Built-in authentication handler deleting player '"..name.."'")
 		return core_auth.delete(name)
 	end,
 	set_password = function(name, password)
@@ -70,9 +70,9 @@ core.builtin_auth_handler = {
 		assert(type(password) == "string")
 		local auth_entry = core_auth.read(name)
 		if not auth_entry then
-			core.builtin_auth_handler.create_auth(name, password)
+			minetest.builtin_auth_handler.create_auth(name, password)
 		else
-			core.log('info', "Built-in authentication handler setting password of player '"..name.."'")
+			minetest.log('info', "Built-in authentication handler setting password of player '"..name.."'")
 			auth_entry.password = password
 			core_auth.save(auth_entry)
 		end
@@ -83,28 +83,28 @@ core.builtin_auth_handler = {
 		assert(type(privileges) == "table")
 		local auth_entry = core_auth.read(name)
 		if not auth_entry then
-			auth_entry = core.builtin_auth_handler.create_auth(name,
-				core.get_password_hash(name,
-					core.settings:get("default_password")))
+			auth_entry = minetest.builtin_auth_handler.create_auth(name,
+				minetest.get_password_hash(name,
+					minetest.settings:get("default_password")))
 		end
 
 		-- Run grant callbacks
 		for priv, _ in pairs(privileges) do
 			if not auth_entry.privileges[priv] then
-				core.run_priv_callbacks(name, priv, nil, "grant")
+				minetest.run_priv_callbacks(name, priv, nil, "grant")
 			end
 		end
 
 		-- Run revoke callbacks
 		for priv, _ in pairs(auth_entry.privileges) do
 			if not privileges[priv] then
-				core.run_priv_callbacks(name, priv, nil, "revoke")
+				minetest.run_priv_callbacks(name, priv, nil, "revoke")
 			end
 		end
 
 		auth_entry.privileges = privileges
 		core_auth.save(auth_entry)
-		core.notify_authentication_modified(name)
+		minetest.notify_authentication_modified(name)
 	end,
 	reload = function()
 		core_auth.reload()
@@ -127,8 +127,8 @@ core.builtin_auth_handler = {
 	end,
 }
 
-core.register_on_prejoinplayer(function(name, ip)
-	if core.registered_auth_handler ~= nil then
+minetest.register_on_prejoinplayer(function(name, ip)
+	if minetest.registered_auth_handler ~= nil then
 		return -- Don't do anything if custom auth handler registered
 	end
 	local auth_entry = core_auth.read(name)
@@ -137,7 +137,7 @@ core.register_on_prejoinplayer(function(name, ip)
 	end
 
 	local name_lower = name:lower()
-	for k in core.builtin_auth_handler.iterate() do
+	for k in minetest.builtin_auth_handler.iterate() do
 		if k:lower() == name_lower then
 			return string.format("\nCannot create new player called '%s'. "..
 					"Another account called '%s' is already registered. "..
@@ -151,22 +151,22 @@ end)
 -- Authentication API
 --
 
-function core.register_authentication_handler(handler)
-	if core.registered_auth_handler then
-		error("Add-on authentication handler already registered by "..core.registered_auth_handler_modname)
+function minetest.register_authentication_handler(handler)
+	if minetest.registered_auth_handler then
+		error("Add-on authentication handler already registered by "..minetest.registered_auth_handler_modname)
 	end
-	core.registered_auth_handler = handler
-	core.registered_auth_handler_modname = core.get_current_modname()
-	handler.mod_origin = core.registered_auth_handler_modname
+	minetest.registered_auth_handler = handler
+	minetest.registered_auth_handler_modname = minetest.get_current_modname()
+	handler.mod_origin = minetest.registered_auth_handler_modname
 end
 
-function core.get_auth_handler()
-	return core.registered_auth_handler or core.builtin_auth_handler
+function minetest.get_auth_handler()
+	return minetest.registered_auth_handler or minetest.builtin_auth_handler
 end
 
 local function auth_pass(name)
 	return function(...)
-		local auth_handler = core.get_auth_handler()
+		local auth_handler = minetest.get_auth_handler()
 		if auth_handler[name] then
 			return auth_handler[name](...)
 		end
@@ -174,12 +174,12 @@ local function auth_pass(name)
 	end
 end
 
-core.set_player_password = auth_pass("set_password")
-core.set_player_privs    = auth_pass("set_privileges")
-core.remove_player_auth  = auth_pass("delete_auth")
-core.auth_reload         = auth_pass("reload")
+minetest.set_player_password = auth_pass("set_password")
+minetest.set_player_privs    = auth_pass("set_privileges")
+minetest.remove_player_auth  = auth_pass("delete_auth")
+minetest.auth_reload         = auth_pass("reload")
 
 local record_login = auth_pass("record_login")
-core.register_on_joinplayer(function(player)
+minetest.register_on_joinplayer(function(player)
 	record_login(player:get_player_name())
 end)

--- a/builtin/game/constants.lua
+++ b/builtin/game/constants.lua
@@ -6,26 +6,26 @@
 
 -- mapnode.h
 -- Built-in Content IDs (for use with VoxelManip API)
-core.CONTENT_UNKNOWN = 125
-core.CONTENT_AIR     = 126
-core.CONTENT_IGNORE  = 127
+minetest.CONTENT_UNKNOWN = 125
+minetest.CONTENT_AIR     = 126
+minetest.CONTENT_IGNORE  = 127
 
 -- emerge.h
--- Block emerge status constants (for use with core.emerge_area)
-core.EMERGE_CANCELLED   = 0
-core.EMERGE_ERRORED     = 1
-core.EMERGE_FROM_MEMORY = 2
-core.EMERGE_FROM_DISK   = 3
-core.EMERGE_GENERATED   = 4
+-- Block emerge status constants (for use with minetest.emerge_area)
+minetest.EMERGE_CANCELLED   = 0
+minetest.EMERGE_ERRORED     = 1
+minetest.EMERGE_FROM_MEMORY = 2
+minetest.EMERGE_FROM_DISK   = 3
+minetest.EMERGE_GENERATED   = 4
 
 -- constants.h
 -- Size of mapblocks in nodes
-core.MAP_BLOCKSIZE = 16
+minetest.MAP_BLOCKSIZE = 16
 -- Default maximal HP of a player
-core.PLAYER_MAX_HP_DEFAULT = 20
+minetest.PLAYER_MAX_HP_DEFAULT = 20
 -- Default maximal breath of a player
-core.PLAYER_MAX_BREATH_DEFAULT = 11
+minetest.PLAYER_MAX_BREATH_DEFAULT = 11
 
 -- light.h
 -- Maximum value for node 'light_source' parameter
-core.LIGHT_MAX = 14
+minetest.LIGHT_MAX = 14

--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -34,7 +34,7 @@ setmetatable(minetest.env, {
 			minetest.log("deprecated", "minetest.env:[...] is deprecated and should be replaced with minetest.[...]")
 			envref_deprecation_message_printed = true
 		end
-		local func = core[key]
+		local func = minetest[key]
 		if type(func) == "function" then
 			rawset(table, key, function(self, ...)
 				return func(...)

--- a/builtin/game/deprecated.lua
+++ b/builtin/game/deprecated.lua
@@ -4,34 +4,34 @@
 -- Default material types
 --
 local function digprop_err()
-	core.log("deprecated", "The core.digprop_* functions are obsolete and need to be replaced by item groups.")
+	minetest.log("deprecated", "The minetest.digprop_* functions are obsolete and need to be replaced by item groups.")
 end
 
-core.digprop_constanttime = digprop_err
-core.digprop_stonelike = digprop_err
-core.digprop_dirtlike = digprop_err
-core.digprop_gravellike = digprop_err
-core.digprop_woodlike = digprop_err
-core.digprop_leaveslike = digprop_err
-core.digprop_glasslike = digprop_err
+minetest.digprop_constanttime = digprop_err
+minetest.digprop_stonelike = digprop_err
+minetest.digprop_dirtlike = digprop_err
+minetest.digprop_gravellike = digprop_err
+minetest.digprop_woodlike = digprop_err
+minetest.digprop_leaveslike = digprop_err
+minetest.digprop_glasslike = digprop_err
 
-function core.node_metadata_inventory_move_allow_all()
-	core.log("deprecated", "core.node_metadata_inventory_move_allow_all is obsolete and does nothing.")
+function minetest.node_metadata_inventory_move_allow_all()
+	minetest.log("deprecated", "minetest.node_metadata_inventory_move_allow_all is obsolete and does nothing.")
 end
 
-function core.add_to_creative_inventory(itemstring)
-	core.log("deprecated", "core.add_to_creative_inventory is obsolete and does nothing.")
+function minetest.add_to_creative_inventory(itemstring)
+	minetest.log("deprecated", "minetest.add_to_creative_inventory is obsolete and does nothing.")
 end
 
 --
 -- EnvRef
 --
-core.env = {}
+minetest.env = {}
 local envref_deprecation_message_printed = false
-setmetatable(core.env, {
+setmetatable(minetest.env, {
 	__index = function(table, key)
 		if not envref_deprecation_message_printed then
-			core.log("deprecated", "core.env:[...] is deprecated and should be replaced with core.[...]")
+			minetest.log("deprecated", "minetest.env:[...] is deprecated and should be replaced with minetest.[...]")
 			envref_deprecation_message_printed = true
 		end
 		local func = core[key]
@@ -46,27 +46,27 @@ setmetatable(core.env, {
 	end
 })
 
-function core.rollback_get_last_node_actor(pos, range, seconds)
-	return core.rollback_get_node_actions(pos, range, seconds, 1)[1]
+function minetest.rollback_get_last_node_actor(pos, range, seconds)
+	return minetest.rollback_get_node_actions(pos, range, seconds, 1)[1]
 end
 
 --
--- core.setting_*
+-- minetest.setting_*
 --
 
-local settings = core.settings
+local settings = minetest.settings
 
 local function setting_proxy(name)
 	return function(...)
-		core.log("deprecated", "WARNING: minetest.setting_* "..
+		minetest.log("deprecated", "WARNING: minetest.setting_* "..
 			"functions are deprecated.  "..
 			"Use methods on the minetest.settings object.")
 		return settings[name](settings, ...)
 	end
 end
 
-core.setting_set = setting_proxy("set")
-core.setting_get = setting_proxy("get")
-core.setting_setbool = setting_proxy("set_bool")
-core.setting_getbool = setting_proxy("get_bool")
-core.setting_save = setting_proxy("write")
+minetest.setting_set = setting_proxy("set")
+minetest.setting_get = setting_proxy("get")
+minetest.setting_setbool = setting_proxy("set_bool")
+minetest.setting_getbool = setting_proxy("get_bool")
+minetest.setting_save = setting_proxy("write")

--- a/builtin/game/detached_inventory.lua
+++ b/builtin/game/detached_inventory.lua
@@ -1,8 +1,8 @@
 -- Minetest: builtin/detached_inventory.lua
 
-core.detached_inventories = {}
+minetest.detached_inventories = {}
 
-function core.create_detached_inventory(name, callbacks, player_name)
+function minetest.create_detached_inventory(name, callbacks, player_name)
 	local stuff = {}
 	stuff.name = name
 	if callbacks then
@@ -13,12 +13,12 @@ function core.create_detached_inventory(name, callbacks, player_name)
 		stuff.on_put = callbacks.on_put
 		stuff.on_take = callbacks.on_take
 	end
-	stuff.mod_origin = core.get_current_modname() or "??"
-	core.detached_inventories[name] = stuff
-	return core.create_detached_inventory_raw(name, player_name)
+	stuff.mod_origin = minetest.get_current_modname() or "??"
+	minetest.detached_inventories[name] = stuff
+	return minetest.create_detached_inventory_raw(name, player_name)
 end
 
-function core.remove_detached_inventory(name)
-	core.detached_inventories[name] = nil
-	return core.remove_detached_inventory_raw(name)
+function minetest.remove_detached_inventory(name)
+	minetest.detached_inventories[name] = nil
+	return minetest.remove_detached_inventory_raw(name)
 end

--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -1,6 +1,6 @@
 -- Minetest: builtin/features.lua
 
-core.features = {
+minetest.features = {
 	glasslike_framed = true,
 	nodebox_as_selectionbox = true,
 	get_all_craft_recipes_works = true,
@@ -17,19 +17,19 @@ core.features = {
 	area_store_persistent_ids = true,
 }
 
-function core.has_feature(arg)
+function minetest.has_feature(arg)
 	if type(arg) == "table" then
 		local missing_features = {}
 		local result = true
 		for ftr in pairs(arg) do
-			if not core.features[ftr] then
+			if not minetest.features[ftr] then
 				missing_features[ftr] = true
 				result = false
 			end
 		end
 		return result, missing_features
 	elseif type(arg) == "string" then
-		if not core.features[arg] then
+		if not minetest.features[arg] then
 			return false, {[arg]=true}
 		end
 		return true, {}

--- a/builtin/game/init.lua
+++ b/builtin/game/init.lua
@@ -1,5 +1,5 @@
 
-local scriptpath = core.get_builtin_path()
+local scriptpath = minetest.get_builtin_path()
 local commonpath = scriptpath .. "common" .. DIR_DELIM
 local gamepath   = scriptpath .. "game".. DIR_DELIM
 
@@ -13,7 +13,7 @@ dofile(gamepath .. "constants.lua")
 assert(loadfile(gamepath .. "item.lua"))(builtin_shared)
 dofile(gamepath .. "register.lua")
 
-if core.settings:get_bool("profiler.load") then
+if minetest.settings:get_bool("profiler.load") then
 	profiler = dofile(scriptpath .. "profiler" .. DIR_DELIM .. "init.lua")
 end
 

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -669,14 +669,14 @@ minetest.nodedef_default = {
 	node_placement_prediction = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
-	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
+	on_place = redef_wrapper(minetest, 'item_place'), -- minetest.item_place
+	on_drop = redef_wrapper(minetest, 'item_drop'), -- minetest.item_drop
 	on_use = nil,
 	can_dig = nil,
 
-	on_punch = redef_wrapper(core, 'node_punch'), -- minetest.node_punch
+	on_punch = redef_wrapper(minetest, 'node_punch'), -- minetest.node_punch
 	on_rightclick = nil,
-	on_dig = redef_wrapper(core, 'node_dig'), -- minetest.node_dig
+	on_dig = redef_wrapper(minetest, 'node_dig'), -- minetest.node_dig
 
 	on_receive_fields = nil,
 
@@ -731,9 +731,9 @@ minetest.craftitemdef_default = {
 	tool_capabilities = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
-	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
+	on_place = redef_wrapper(minetest, 'item_place'), -- minetest.item_place
+	on_drop = redef_wrapper(minetest, 'item_drop'), -- minetest.item_drop
+	on_secondary_use = redef_wrapper(minetest, 'item_secondary_use'),
 	on_use = nil,
 }
 
@@ -750,9 +750,9 @@ minetest.tooldef_default = {
 	tool_capabilities = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
-	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
+	on_place = redef_wrapper(minetest, 'item_place'), -- minetest.item_place
+	on_secondary_use = redef_wrapper(minetest, 'item_secondary_use'),
+	on_drop = redef_wrapper(minetest, 'item_drop'), -- minetest.item_drop
 	on_use = nil,
 }
 
@@ -769,8 +769,8 @@ minetest.noneitemdef_default = {  -- This is used for the hand and unknown items
 	tool_capabilities = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'),
-	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
+	on_place = redef_wrapper(minetest, 'item_place'),
+	on_secondary_use = redef_wrapper(minetest, 'item_secondary_use'),
 	on_drop = nil,
 	on_use = nil,
 }

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -15,7 +15,7 @@ end
 -- Item definition helpers
 --
 
-function core.inventorycube(img1, img2, img3)
+function minetest.inventorycube(img1, img2, img3)
 	img2 = img2 or img1
 	img3 = img3 or img1
 	return "[inventorycube"
@@ -24,7 +24,7 @@ function core.inventorycube(img1, img2, img3)
 			.. "{" .. img3:gsub("%^", "&")
 end
 
-function core.get_pointed_thing_position(pointed_thing, above)
+function minetest.get_pointed_thing_position(pointed_thing, above)
 	if pointed_thing.type == "node" then
 		if above then
 			-- The position where a node would be placed
@@ -37,7 +37,7 @@ function core.get_pointed_thing_position(pointed_thing, above)
 	end
 end
 
-function core.dir_to_facedir(dir, is6d)
+function minetest.dir_to_facedir(dir, is6d)
 	--account for y if requested
 	if is6d and math.abs(dir.y) > math.abs(dir.x) and math.abs(dir.y) > math.abs(dir.z) then
 
@@ -108,11 +108,11 @@ local facedir_to_dir_map = {
 	1, 6, 3, 5,
 	1, 4, 3, 2,
 }
-function core.facedir_to_dir(facedir)
+function minetest.facedir_to_dir(facedir)
 	return facedir_to_dir[facedir_to_dir_map[facedir % 32]]
 end
 
-function core.dir_to_wallmounted(dir)
+function minetest.dir_to_wallmounted(dir)
 	if math.abs(dir.y) > math.max(math.abs(dir.x), math.abs(dir.z)) then
 		if dir.y < 0 then
 			return 1
@@ -143,25 +143,25 @@ local wallmounted_to_dir = {
 	{x =  0, y =  0, z =  1},
 	{x =  0, y =  0, z = -1},
 }
-function core.wallmounted_to_dir(wallmounted)
+function minetest.wallmounted_to_dir(wallmounted)
 	return wallmounted_to_dir[wallmounted % 8]
 end
 
-function core.dir_to_yaw(dir)
+function minetest.dir_to_yaw(dir)
 	return -math.atan2(dir.x, dir.z)
 end
 
-function core.yaw_to_dir(yaw)
+function minetest.yaw_to_dir(yaw)
 	return {x = -math.sin(yaw), y = 0, z = math.cos(yaw)}
 end
 
-function core.is_colored_paramtype(ptype)
+function minetest.is_colored_paramtype(ptype)
 	return (ptype == "color") or (ptype == "colorfacedir") or
 		(ptype == "colorwallmounted")
 end
 
-function core.strip_param2_color(param2, paramtype2)
-	if not core.is_colored_paramtype(paramtype2) then
+function minetest.strip_param2_color(param2, paramtype2)
+	if not minetest.is_colored_paramtype(paramtype2) then
 		return nil
 	end
 	if paramtype2 == "colorfacedir" then
@@ -173,7 +173,7 @@ function core.strip_param2_color(param2, paramtype2)
 	return param2
 end
 
-function core.get_node_drops(node, toolname)
+function minetest.get_node_drops(node, toolname)
 	-- Compatibility, if node is string
 	local nodename = node
 	local param2 = 0
@@ -182,11 +182,11 @@ function core.get_node_drops(node, toolname)
 		nodename = node.name
 		param2 = node.param2
 	end
-	local def = core.registered_nodes[nodename]
+	local def = minetest.registered_nodes[nodename]
 	local drop = def and def.drop
 	local ptype = def and def.paramtype2
 	-- get color, if there is color (otherwise nil)
-	local palette_index = core.strip_param2_color(param2, ptype)
+	local palette_index = minetest.strip_param2_color(param2, ptype)
 	if drop == nil then
 		-- default drop
 		if palette_index then
@@ -252,10 +252,10 @@ end
 
 -- Returns a logging function. For empty names, does not log.
 local function make_log(name)
-	return name ~= "" and core.log or function() end
+	return name ~= "" and minetest.log or function() end
 end
 
-function core.item_place_node(itemstack, placer, pointed_thing, param2,
+function minetest.item_place_node(itemstack, placer, pointed_thing, param2,
 		prevent_after_place)
 	local def = itemstack:get_definition()
 	if def.type ~= "node" or pointed_thing.type ~= "node" then
@@ -263,26 +263,26 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 	end
 
 	local under = pointed_thing.under
-	local oldnode_under = core.get_node_or_nil(under)
+	local oldnode_under = minetest.get_node_or_nil(under)
 	local above = pointed_thing.above
-	local oldnode_above = core.get_node_or_nil(above)
+	local oldnode_above = minetest.get_node_or_nil(above)
 	local playername = user_name(placer)
 	local log = make_log(playername)
 
 	if not oldnode_under or not oldnode_above then
 		log("info", playername .. " tried to place"
-			.. " node in unloaded position " .. core.pos_to_string(above))
+			.. " node in unloaded position " .. minetest.pos_to_string(above))
 		return itemstack, nil
 	end
 
-	local olddef_under = core.registered_nodes[oldnode_under.name]
-	olddef_under = olddef_under or core.nodedef_default
-	local olddef_above = core.registered_nodes[oldnode_above.name]
-	olddef_above = olddef_above or core.nodedef_default
+	local olddef_under = minetest.registered_nodes[oldnode_under.name]
+	olddef_under = olddef_under or minetest.nodedef_default
+	local olddef_above = minetest.registered_nodes[oldnode_above.name]
+	olddef_above = olddef_above or minetest.nodedef_default
 
 	if not olddef_above.buildable_to and not olddef_under.buildable_to then
 		log("info", playername .. " tried to place"
-			.. " node in invalid position " .. core.pos_to_string(above)
+			.. " node in invalid position " .. minetest.pos_to_string(above)
 			.. ", replacing " .. oldnode_above.name)
 		return itemstack, nil
 	end
@@ -296,19 +296,19 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 		place_to = {x = under.x, y = under.y, z = under.z}
 	end
 
-	if core.is_protected(place_to, playername) then
+	if minetest.is_protected(place_to, playername) then
 		log("action", playername
 				.. " tried to place " .. def.name
 				.. " at protected position "
-				.. core.pos_to_string(place_to))
-		core.record_protection_violation(place_to, playername)
+				.. minetest.pos_to_string(place_to))
+		minetest.record_protection_violation(place_to, playername)
 		return itemstack, nil
 	end
 
 	log("action", playername .. " places node "
-		.. def.name .. " at " .. core.pos_to_string(place_to))
+		.. def.name .. " at " .. minetest.pos_to_string(place_to))
 
-	local oldnode = core.get_node(place_to)
+	local oldnode = minetest.get_node(place_to)
 	local newnode = {name = def.name, param1 = 0, param2 = param2 or 0}
 
 	-- Calculate direction for wall mounted stuff like torches and signs
@@ -321,7 +321,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 			y = under.y - above.y,
 			z = under.z - above.z
 		}
-		newnode.param2 = core.dir_to_wallmounted(dir)
+		newnode.param2 = minetest.dir_to_wallmounted(dir)
 	-- Calculate the direction for furnaces and chests and stuff
 	elseif (def.paramtype2 == "facedir" or
 			def.paramtype2 == "colorfacedir") and not param2 then
@@ -332,7 +332,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 				y = above.y - placer_pos.y,
 				z = above.z - placer_pos.z
 			}
-			newnode.param2 = core.dir_to_facedir(dir)
+			newnode.param2 = minetest.dir_to_facedir(dir)
 			log("action", "facedir: " .. newnode.param2)
 		end
 	end
@@ -357,15 +357,15 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 	end
 
 	-- Check if the node is attached and if it can be placed there
-	if core.get_item_group(def.name, "attached_node") ~= 0 and
+	if minetest.get_item_group(def.name, "attached_node") ~= 0 and
 		not builtin_shared.check_attached_node(place_to, newnode) then
 		log("action", "attached node " .. def.name ..
-			" can not be placed at " .. core.pos_to_string(place_to))
+			" can not be placed at " .. minetest.pos_to_string(place_to))
 		return itemstack, nil
 	end
 
 	-- Add node and update
-	core.add_node(place_to, newnode)
+	minetest.add_node(place_to, newnode)
 
 	local take_item = true
 
@@ -381,7 +381,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 	end
 
 	-- Run script hook
-	for _, callback in ipairs(core.registered_on_placenodes) do
+	for _, callback in ipairs(minetest.registered_on_placenodes) do
 		-- Deepcopy pos, node and pointed_thing because callback can modify them
 		local place_to_copy = {x=place_to.x, y=place_to.y, z=place_to.z}
 		local newnode_copy = {name=newnode.name, param1=newnode.param1, param2=newnode.param2}
@@ -399,39 +399,39 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 end
 
 -- deprecated, item_place does not call this
-function core.item_place_object(itemstack, placer, pointed_thing)
-	local pos = core.get_pointed_thing_position(pointed_thing, true)
+function minetest.item_place_object(itemstack, placer, pointed_thing)
+	local pos = minetest.get_pointed_thing_position(pointed_thing, true)
 	if pos ~= nil then
 		local item = itemstack:take_item()
-		core.add_item(pos, item)
+		minetest.add_item(pos, item)
 	end
 	return itemstack
 end
 
-function core.item_place(itemstack, placer, pointed_thing, param2)
+function minetest.item_place(itemstack, placer, pointed_thing, param2)
 	-- Call on_rightclick if the pointed node defines it
 	if pointed_thing.type == "node" and placer and
 			not placer:get_player_control().sneak then
-		local n = core.get_node(pointed_thing.under)
+		local n = minetest.get_node(pointed_thing.under)
 		local nn = n.name
-		if core.registered_nodes[nn] and core.registered_nodes[nn].on_rightclick then
-			return core.registered_nodes[nn].on_rightclick(pointed_thing.under, n,
+		if minetest.registered_nodes[nn] and minetest.registered_nodes[nn].on_rightclick then
+			return minetest.registered_nodes[nn].on_rightclick(pointed_thing.under, n,
 					placer, itemstack, pointed_thing) or itemstack, nil
 		end
 	end
 
 	-- Place if node, otherwise do nothing
 	if itemstack:get_definition().type == "node" then
-		return core.item_place_node(itemstack, placer, pointed_thing, param2)
+		return minetest.item_place_node(itemstack, placer, pointed_thing, param2)
 	end
 	return itemstack, nil
 end
 
-function core.item_secondary_use(itemstack, placer)
+function minetest.item_secondary_use(itemstack, placer)
 	return itemstack
 end
 
-function core.item_drop(itemstack, dropper, pos)
+function minetest.item_drop(itemstack, dropper, pos)
 	local dropper_is_player = dropper and dropper:is_player()
 	local p = table.copy(pos)
 	local cnt = itemstack:get_count()
@@ -439,7 +439,7 @@ function core.item_drop(itemstack, dropper, pos)
 		p.y = p.y + 1.2
 	end
 	local item = itemstack:take_item(cnt)
-	local obj = core.add_item(p, item)
+	local obj = minetest.add_item(p, item)
 	if obj then
 		if dropper_is_player then
 			local dir = dropper:get_look_dir()
@@ -455,8 +455,8 @@ function core.item_drop(itemstack, dropper, pos)
 	-- environment failed
 end
 
-function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
-	for _, callback in pairs(core.registered_on_item_eats) do
+function minetest.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
+	for _, callback in pairs(minetest.registered_on_item_eats) do
 		local result = callback(hp_change, replace_with_item, itemstack, user, pointed_thing)
 		if result then
 			return result
@@ -481,7 +481,7 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 				else
 					local pos = user:get_pos()
 					pos.y = math.floor(pos.y + 0.5)
-					core.add_item(pos, replace_with_item)
+					minetest.add_item(pos, replace_with_item)
 				end
 			end
 		end
@@ -489,17 +489,17 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 	return itemstack
 end
 
-function core.item_eat(hp_change, replace_with_item)
+function minetest.item_eat(hp_change, replace_with_item)
 	return function(itemstack, user, pointed_thing)  -- closure
 		if user then
-			return core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
+			return minetest.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed_thing)
 		end
 	end
 end
 
-function core.node_punch(pos, node, puncher, pointed_thing)
+function minetest.node_punch(pos, node, puncher, pointed_thing)
 	-- Run script hook
-	for _, callback in ipairs(core.registered_on_punchnodes) do
+	for _, callback in ipairs(minetest.registered_on_punchnodes) do
 		-- Copy pos and node because callback can modify them
 		local pos_copy = vector.new(pos)
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
@@ -508,7 +508,7 @@ function core.node_punch(pos, node, puncher, pointed_thing)
 	end
 end
 
-function core.handle_node_drops(pos, drops, digger)
+function minetest.handle_node_drops(pos, drops, digger)
 	-- Add dropped items to object's inventory
 	local inv = digger and digger:get_inventory()
 	local give_item
@@ -531,50 +531,50 @@ function core.handle_node_drops(pos, drops, digger)
 				y = pos.y + math.random()/2-0.25,
 				z = pos.z + math.random()/2-0.25,
 			}
-			core.add_item(p, left)
+			minetest.add_item(p, left)
 		end
 	end
 end
 
-function core.node_dig(pos, node, digger)
+function minetest.node_dig(pos, node, digger)
 	local diggername = user_name(digger)
 	local log = make_log(diggername)
-	local def = core.registered_nodes[node.name]
+	local def = minetest.registered_nodes[node.name]
 	if def and (not def.diggable or
 			(def.can_dig and not def.can_dig(pos, digger))) then
 		log("info", diggername .. " tried to dig "
 			.. node.name .. " which is not diggable "
-			.. core.pos_to_string(pos))
+			.. minetest.pos_to_string(pos))
 		return
 	end
 
-	if core.is_protected(pos, diggername) then
+	if minetest.is_protected(pos, diggername) then
 		log("action", diggername
 				.. " tried to dig " .. node.name
 				.. " at protected position "
-				.. core.pos_to_string(pos))
-		core.record_protection_violation(pos, diggername)
+				.. minetest.pos_to_string(pos))
+		minetest.record_protection_violation(pos, diggername)
 		return
 	end
 
 	log('action', diggername .. " digs "
-		.. node.name .. " at " .. core.pos_to_string(pos))
+		.. node.name .. " at " .. minetest.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name())
+	local drops = minetest.get_node_drops(node, wielded and wielded:get_name())
 
 	if wielded then
 		local wdef = wielded:get_definition()
 		local tp = wielded:get_tool_capabilities()
-		local dp = core.get_dig_params(def and def.groups, tp)
+		local dp = minetest.get_dig_params(def and def.groups, tp)
 		if wdef and wdef.after_use then
 			wielded = wdef.after_use(wielded, digger, node, dp) or wielded
 		else
 			-- Wear out tool
-			if not core.settings:get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				wielded:add_wear(dp.wear)
 				if wielded:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-					core.sound_play(wdef.sound.breaks, {pos = pos, gain = 0.5})
+					minetest.sound_play(wdef.sound.breaks, {pos = pos, gain = 0.5})
 				end
 			end
 		end
@@ -583,7 +583,7 @@ function core.node_dig(pos, node, digger)
 
 	-- Check to see if metadata should be preserved.
 	if def and def.preserve_metadata then
-		local oldmeta = core.get_meta(pos):to_table().fields
+		local oldmeta = minetest.get_meta(pos):to_table().fields
 		-- Copy pos and node because the callback can modify them.
 		local pos_copy = {x=pos.x, y=pos.y, z=pos.z}
 		local node_copy = {name=node.name, param1=node.param1, param2=node.param2}
@@ -596,15 +596,15 @@ function core.node_dig(pos, node, digger)
 	end
 
 	-- Handle drops
-	core.handle_node_drops(pos, drops, digger)
+	minetest.handle_node_drops(pos, drops, digger)
 
 	local oldmetadata = nil
 	if def and def.after_dig_node then
-		oldmetadata = core.get_meta(pos):to_table()
+		oldmetadata = minetest.get_meta(pos):to_table()
 	end
 
 	-- Remove node and update
-	core.remove_node(pos)
+	minetest.remove_node(pos)
 
 	-- Run callback
 	if def and def.after_dig_node then
@@ -615,10 +615,10 @@ function core.node_dig(pos, node, digger)
 	end
 
 	-- Run script hook
-	for _, callback in ipairs(core.registered_on_dignodes) do
-		local origin = core.callback_origins[callback]
+	for _, callback in ipairs(minetest.registered_on_dignodes) do
+		local origin = minetest.callback_origins[callback]
 		if origin then
-			core.set_last_run_mod(origin.mod)
+			minetest.set_last_run_mod(origin.mod)
 		end
 
 		-- Copy pos and node because callback can modify them
@@ -628,19 +628,19 @@ function core.node_dig(pos, node, digger)
 	end
 end
 
-function core.itemstring_with_palette(item, palette_index)
+function minetest.itemstring_with_palette(item, palette_index)
 	local stack = ItemStack(item) -- convert to ItemStack
 	stack:get_meta():set_int("palette_index", palette_index)
 	return stack:to_string()
 end
 
-function core.itemstring_with_color(item, colorstring)
+function minetest.itemstring_with_color(item, colorstring)
 	local stack = ItemStack(item) -- convert to ItemStack
 	stack:get_meta():set_string("color", colorstring)
 	return stack:to_string()
 end
 
--- This is used to allow mods to redefine core.item_place and so on
+-- This is used to allow mods to redefine minetest.item_place and so on
 -- NOTE: This is not the preferred way. Preferred way is to provide enough
 --       callbacks to not require redefining global functions. -celeron55
 local function redef_wrapper(table, name)
@@ -653,7 +653,7 @@ end
 -- Item definition defaults
 --
 
-core.nodedef_default = {
+minetest.nodedef_default = {
 	-- Item properties
 	type="node",
 	-- name intentionally not defined here
@@ -669,20 +669,20 @@ core.nodedef_default = {
 	node_placement_prediction = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
-	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
+	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
+	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
 	on_use = nil,
 	can_dig = nil,
 
-	on_punch = redef_wrapper(core, 'node_punch'), -- core.node_punch
+	on_punch = redef_wrapper(core, 'node_punch'), -- minetest.node_punch
 	on_rightclick = nil,
-	on_dig = redef_wrapper(core, 'node_dig'), -- core.node_dig
+	on_dig = redef_wrapper(core, 'node_dig'), -- minetest.node_dig
 
 	on_receive_fields = nil,
 
-	on_metadata_inventory_move = core.node_metadata_inventory_move_allow_all,
-	on_metadata_inventory_offer = core.node_metadata_inventory_offer_allow_all,
-	on_metadata_inventory_take = core.node_metadata_inventory_take_allow_all,
+	on_metadata_inventory_move = minetest.node_metadata_inventory_move_allow_all,
+	on_metadata_inventory_offer = minetest.node_metadata_inventory_offer_allow_all,
+	on_metadata_inventory_take = minetest.node_metadata_inventory_take_allow_all,
 
 	-- Node properties
 	drawtype = "normal",
@@ -718,7 +718,7 @@ core.nodedef_default = {
 	legacy_wallmounted = false,
 }
 
-core.craftitemdef_default = {
+minetest.craftitemdef_default = {
 	type="craft",
 	-- name intentionally not defined here
 	description = "",
@@ -731,13 +731,13 @@ core.craftitemdef_default = {
 	tool_capabilities = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
-	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
+	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
+	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
 	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
 	on_use = nil,
 }
 
-core.tooldef_default = {
+minetest.tooldef_default = {
 	type="tool",
 	-- name intentionally not defined here
 	description = "",
@@ -750,13 +750,13 @@ core.tooldef_default = {
 	tool_capabilities = nil,
 
 	-- Interaction callbacks
-	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
+	on_place = redef_wrapper(core, 'item_place'), -- minetest.item_place
 	on_secondary_use = redef_wrapper(core, 'item_secondary_use'),
-	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
+	on_drop = redef_wrapper(core, 'item_drop'), -- minetest.item_drop
 	on_use = nil,
 }
 
-core.noneitemdef_default = {  -- This is used for the hand and unknown items
+minetest.noneitemdef_default = {  -- This is used for the hand and unknown items
 	type="none",
 	-- name intentionally not defined here
 	description = "",

--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -1,9 +1,9 @@
 -- Minetest: builtin/item_entity.lua
 
-function core.spawn_item(pos, item)
+function minetest.spawn_item(pos, item)
 	-- Take item in any format
 	local stack = ItemStack(item)
-	local obj = core.add_entity(pos, "__builtin:item")
+	local obj = minetest.add_entity(pos, "__builtin:item")
 	-- Don't use obj if it couldn't be added to the map.
 	if obj then
 		obj:get_luaentity():set_item(stack:to_string())
@@ -14,11 +14,11 @@ end
 -- If item_entity_ttl is not set, enity will have default life time
 -- Setting it to -1 disables the feature
 
-local time_to_live = tonumber(core.settings:get("item_entity_ttl")) or 900
-local gravity = tonumber(core.settings:get("movement_gravity")) or 9.81
+local time_to_live = tonumber(minetest.settings:get("item_entity_ttl")) or 900
+local gravity = tonumber(minetest.settings:get("movement_gravity")) or 9.81
 
 
-core.register_entity(":__builtin:item", {
+minetest.register_entity(":__builtin:item", {
 	initial_properties = {
 		hp_max = 1,
 		physical = true,
@@ -58,7 +58,7 @@ core.register_entity(":__builtin:item", {
 		local count = math.min(stack:get_count(), max_count)
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 		local coll_height = size * 0.75
-		local def = core.registered_nodes[itemname]
+		local def = minetest.registered_nodes[itemname]
 		local glow = def and def.light_source
 
 		self.object:set_properties({
@@ -77,7 +77,7 @@ core.register_entity(":__builtin:item", {
 	end,
 
 	get_staticdata = function(self)
-		return core.serialize({
+		return minetest.serialize({
 			itemstring = self.itemstring,
 			age = self.age,
 			dropped_by = self.dropped_by
@@ -86,7 +86,7 @@ core.register_entity(":__builtin:item", {
 
 	on_activate = function(self, staticdata, dtime_s)
 		if string.sub(staticdata, 1, string.len("return")) == "return" then
-			local data = core.deserialize(staticdata)
+			local data = minetest.deserialize(staticdata)
 			if data and type(data) == "table" then
 				self.itemstring = data.itemstring
 				self.age = (data.age or 0) + dtime_s
@@ -166,7 +166,7 @@ core.register_entity(":__builtin:item", {
 		end
 
 		local pos = self.object:get_pos()
-		local node = core.get_node_or_nil({
+		local node = minetest.get_node_or_nil({
 			x = pos.x,
 			y = pos.y + self.object:get_properties().collisionbox[2] - 0.05,
 			z = pos.z
@@ -179,9 +179,9 @@ core.register_entity(":__builtin:item", {
 		end
 
 		local is_stuck = false
-		local snode = core.get_node_or_nil(pos)
+		local snode = minetest.get_node_or_nil(pos)
 		if snode then
-			local sdef = core.registered_nodes[snode.name] or {}
+			local sdef = minetest.registered_nodes[snode.name] or {}
 			is_stuck = (sdef.walkable == nil or sdef.walkable == true)
 				and (sdef.collision_box == nil or sdef.collision_box.type == "regular")
 				and (sdef.node_box == nil or sdef.node_box.type == "regular")
@@ -197,8 +197,8 @@ core.register_entity(":__builtin:item", {
 
 			-- Check which one of the 4 sides is free
 			for o = 1, #order do
-				local cnode = core.get_node(vector.add(pos, order[o])).name
-				local cdef = core.registered_nodes[cnode] or {}
+				local cnode = minetest.get_node(vector.add(pos, order[o])).name
+				local cdef = minetest.registered_nodes[cnode] or {}
 				if cnode ~= "ignore" and cdef.walkable == false then
 					shootdir = order[o]
 					break
@@ -207,7 +207,7 @@ core.register_entity(":__builtin:item", {
 			-- If none of the 4 sides is free, check upwards
 			if not shootdir then
 				shootdir = {x=0, y=1, z=0}
-				local cnode = core.get_node(vector.add(pos, shootdir)).name
+				local cnode = minetest.get_node(vector.add(pos, shootdir)).name
 				if cnode == "ignore" then
 					shootdir = nil -- Do not push into ignore
 				end
@@ -247,13 +247,13 @@ core.register_entity(":__builtin:item", {
 
 		-- Slide on slippery nodes
 		local vel = self.object:get_velocity()
-		local def = node and core.registered_nodes[node.name]
+		local def = node and minetest.registered_nodes[node.name]
 		local is_moving = (def and not def.walkable) or
 			vel.x ~= 0 or vel.y ~= 0 or vel.z ~= 0
 		local is_slippery = false
 
 		if def and def.walkable then
-			local slippery = core.get_item_group(node.name, "slippery")
+			local slippery = minetest.get_item_group(node.name, "slippery")
 			is_slippery = slippery ~= 0
 			if is_slippery and (math.abs(vel.x) > 0.2 or math.abs(vel.z) > 0.2) then
 				-- Horizontal deceleration
@@ -293,7 +293,7 @@ core.register_entity(":__builtin:item", {
 		if own_stack:get_free_space() == 0 then
 			return
 		end
-		local objects = core.get_objects_inside_radius(pos, 1.0)
+		local objects = minetest.get_objects_inside_radius(pos, 1.0)
 		for k, obj in pairs(objects) do
 			local entity = obj:get_luaentity()
 			if entity and entity.name == "__builtin:item" then

--- a/builtin/game/knockback.lua
+++ b/builtin/game/knockback.lua
@@ -1,5 +1,5 @@
 -- can be overriden by mods
-function core.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, distance, damage)
+function minetest.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, distance, damage)
 	if damage == 0 or player:get_armor_groups().immortal then
 		return 0.0
 	end
@@ -22,7 +22,7 @@ local function vector_absmax(v)
 	return max(max(abs(v.x), abs(v.y)), abs(v.z))
 end
 
-core.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, unused_dir, damage)
+minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, unused_dir, damage)
 	if player:get_hp() == 0 then
 		return -- RIP
 	end
@@ -35,7 +35,7 @@ core.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool
 		dir = vector.divide(dir, d)
 	end
 
-	local k = core.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, d, damage)
+	local k = minetest.calculate_knockback(player, hitter, time_from_last_punch, tool_capabilities, dir, d, damage)
 
 	local kdir = vector.multiply(dir, k)
 	if vector_absmax(kdir) < 1.0 then

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -4,16 +4,16 @@
 -- Misc. API functions
 --
 
-function core.check_player_privs(name, ...)
-	if core.is_player(name) then
+function minetest.check_player_privs(name, ...)
+	if minetest.is_player(name) then
 		name = name:get_player_name()
 	elseif type(name) ~= "string" then
-		error("core.check_player_privs expects a player or playername as " ..
+		error("minetest.check_player_privs expects a player or playername as " ..
 			"argument.", 2)
 	end
 
 	local requested_privs = {...}
-	local player_privs = core.get_player_privs(name)
+	local player_privs = minetest.get_player_privs(name)
 	local missing_privileges = {}
 
 	if type(requested_privs[1]) == "table" then
@@ -43,43 +43,43 @@ end
 local player_list = {}
 
 
-function core.send_join_message(player_name)
-	if not core.is_singleplayer() then
-		core.chat_send_all("*** " .. player_name .. " joined the game.")
+function minetest.send_join_message(player_name)
+	if not minetest.is_singleplayer() then
+		minetest.chat_send_all("*** " .. player_name .. " joined the game.")
 	end
 end
 
 
-function core.send_leave_message(player_name, timed_out)
+function minetest.send_leave_message(player_name, timed_out)
 	local announcement = "*** " ..  player_name .. " left the game."
 	if timed_out then
 		announcement = announcement .. " (timed out)"
 	end
-	core.chat_send_all(announcement)
+	minetest.chat_send_all(announcement)
 end
 
 
-core.register_on_joinplayer(function(player)
+minetest.register_on_joinplayer(function(player)
 	local player_name = player:get_player_name()
 	player_list[player_name] = player
-	if not core.is_singleplayer() then
-		local status = core.get_server_status(player_name, true)
+	if not minetest.is_singleplayer() then
+		local status = minetest.get_server_status(player_name, true)
 		if status and status ~= "" then
-			core.chat_send_player(player_name, status)
+			minetest.chat_send_player(player_name, status)
 		end
 	end
-	core.send_join_message(player_name)
+	minetest.send_join_message(player_name)
 end)
 
 
-core.register_on_leaveplayer(function(player, timed_out)
+minetest.register_on_leaveplayer(function(player, timed_out)
 	local player_name = player:get_player_name()
 	player_list[player_name] = nil
-	core.send_leave_message(player_name, timed_out)
+	minetest.send_leave_message(player_name, timed_out)
 end)
 
 
-function core.get_connected_players()
+function minetest.get_connected_players()
 	local temp_table = {}
 	for index, value in pairs(player_list) do
 		if value:is_player_connected() then
@@ -90,7 +90,7 @@ function core.get_connected_players()
 end
 
 
-function core.is_player(player)
+function minetest.is_player(player)
 	-- a table being a player is also supported because it quacks sufficiently
 	-- like a player if it has the is_player function
 	local t = type(player)
@@ -99,16 +99,16 @@ function core.is_player(player)
 end
 
 
-function core.player_exists(name)
-	return core.get_auth_handler().get_auth(name) ~= nil
+function minetest.player_exists(name)
+	return minetest.get_auth_handler().get_auth(name) ~= nil
 end
 
 
 -- Returns two position vectors representing a box of `radius` in each
 -- direction centered around the player corresponding to `player_name`
 
-function core.get_player_radius_area(player_name, radius)
-	local player = core.get_player_by_name(player_name)
+function minetest.get_player_radius_area(player_name, radius)
+	local player = minetest.get_player_by_name(player_name)
 	if player == nil then
 		return nil
 	end
@@ -125,14 +125,14 @@ function core.get_player_radius_area(player_name, radius)
 end
 
 
-function core.hash_node_position(pos)
+function minetest.hash_node_position(pos)
 	return (pos.z + 32768) * 65536 * 65536
 		 + (pos.y + 32768) * 65536
 		 +  pos.x + 32768
 end
 
 
-function core.get_position_from_hash(hash)
+function minetest.get_position_from_hash(hash)
 	local pos = {}
 	pos.x = (hash % 65536) - 32768
 	hash  = math.floor(hash / 65536)
@@ -143,39 +143,39 @@ function core.get_position_from_hash(hash)
 end
 
 
-function core.get_item_group(name, group)
-	if not core.registered_items[name] or not
-			core.registered_items[name].groups[group] then
+function minetest.get_item_group(name, group)
+	if not minetest.registered_items[name] or not
+			minetest.registered_items[name].groups[group] then
 		return 0
 	end
-	return core.registered_items[name].groups[group]
+	return minetest.registered_items[name].groups[group]
 end
 
 
-function core.get_node_group(name, group)
-	core.log("deprecated", "Deprecated usage of get_node_group, use get_item_group instead")
-	return core.get_item_group(name, group)
+function minetest.get_node_group(name, group)
+	minetest.log("deprecated", "Deprecated usage of get_node_group, use get_item_group instead")
+	return minetest.get_item_group(name, group)
 end
 
 
-function core.setting_get_pos(name)
-	local value = core.settings:get(name)
+function minetest.setting_get_pos(name)
+	local value = minetest.settings:get(name)
 	if not value then
 		return nil
 	end
-	return core.string_to_pos(value)
+	return minetest.string_to_pos(value)
 end
 
 
 -- To be overriden by protection mods
 
-function core.is_protected(pos, name)
+function minetest.is_protected(pos, name)
 	return false
 end
 
 
-function core.record_protection_violation(pos, name)
-	for _, func in pairs(core.registered_on_protection_violation) do
+function minetest.record_protection_violation(pos, name)
+	for _, func in pairs(minetest.registered_on_protection_violation) do
 		func(pos, name)
 	end
 end
@@ -183,7 +183,7 @@ end
 
 -- Checks if specified volume intersects a protected volume
 
-function core.is_area_protected(minp, maxp, player_name, interval)
+function minetest.is_area_protected(minp, maxp, player_name, interval)
 	-- 'interval' is the largest allowed interval for the 3D lattice of checks.
 
 	-- Compute the optimal float step 'd' for each axis so that all corners and
@@ -218,7 +218,7 @@ function core.is_area_protected(minp, maxp, player_name, interval)
 			for xf = minp.x, maxp.x, d.x do
 				local x = math.floor(xf + 0.5)
 				local pos = {x = x, y = y, z = z}
-				if core.is_protected(pos, player_name) then
+				if minetest.is_protected(pos, player_name) then
 					return pos
 				end
 			end
@@ -230,7 +230,7 @@ end
 
 local raillike_ids = {}
 local raillike_cur_id = 0
-function core.raillike_group(name)
+function minetest.raillike_group(name)
 	local id = raillike_ids[name]
 	if not id then
 		raillike_cur_id = raillike_cur_id + 1
@@ -243,7 +243,7 @@ end
 
 -- HTTP callback interface
 
-function core.http_add_fetch(httpenv)
+function minetest.http_add_fetch(httpenv)
 	httpenv.fetch = function(req, callback)
 		local handle = httpenv.fetch_async(req)
 
@@ -252,21 +252,21 @@ function core.http_add_fetch(httpenv)
 			if res.completed then
 				callback(res)
 			else
-				core.after(0, update_http_status)
+				minetest.after(0, update_http_status)
 			end
 		end
-		core.after(0, update_http_status)
+		minetest.after(0, update_http_status)
 	end
 
 	return httpenv
 end
 
 
-function core.close_formspec(player_name, formname)
-	return core.show_formspec(player_name, formname, "")
+function minetest.close_formspec(player_name, formname)
+	return minetest.show_formspec(player_name, formname, "")
 end
 
 
-function core.cancel_shutdown_requests()
-	core.request_shutdown("", false, -1)
+function minetest.cancel_shutdown_requests()
+	minetest.request_shutdown("", false, -1)
 end

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -4,9 +4,9 @@
 -- Privileges
 --
 
-core.registered_privileges = {}
+minetest.registered_privileges = {}
 
-function core.register_privilege(name, param)
+function minetest.register_privilege(name, param)
 	local function fill_defaults(def)
 		if def.give_to_singleplayer == nil then
 			def.give_to_singleplayer = true
@@ -25,77 +25,77 @@ function core.register_privilege(name, param)
 		def = {description = param}
 	end
 	fill_defaults(def)
-	core.registered_privileges[name] = def
+	minetest.registered_privileges[name] = def
 end
 
-core.register_privilege("interact", "Can interact with things and modify the world")
-core.register_privilege("shout", "Can speak in chat")
-core.register_privilege("basic_privs", "Can modify 'shout' and 'interact' privileges")
-core.register_privilege("privs", "Can modify privileges")
+minetest.register_privilege("interact", "Can interact with things and modify the world")
+minetest.register_privilege("shout", "Can speak in chat")
+minetest.register_privilege("basic_privs", "Can modify 'shout' and 'interact' privileges")
+minetest.register_privilege("privs", "Can modify privileges")
 
-core.register_privilege("teleport", {
+minetest.register_privilege("teleport", {
 	description = "Can teleport self",
 	give_to_singleplayer = false,
 })
-core.register_privilege("bring", {
+minetest.register_privilege("bring", {
 	description = "Can teleport other players",
 	give_to_singleplayer = false,
 })
-core.register_privilege("settime", {
+minetest.register_privilege("settime", {
 	description = "Can set the time of day using /time",
 	give_to_singleplayer = false,
 })
-core.register_privilege("server", {
+minetest.register_privilege("server", {
 	description = "Can do server maintenance stuff",
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
-core.register_privilege("protection_bypass", {
+minetest.register_privilege("protection_bypass", {
 	description = "Can bypass node protection in the world",
 	give_to_singleplayer = false,
 })
-core.register_privilege("ban", {
+minetest.register_privilege("ban", {
 	description = "Can ban and unban players",
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
-core.register_privilege("kick", {
+minetest.register_privilege("kick", {
 	description = "Can kick players",
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
-core.register_privilege("give", {
+minetest.register_privilege("give", {
 	description = "Can use /give and /giveme",
 	give_to_singleplayer = false,
 })
-core.register_privilege("password", {
+minetest.register_privilege("password", {
 	description = "Can use /setpassword and /clearpassword",
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
-core.register_privilege("fly", {
+minetest.register_privilege("fly", {
 	description = "Can use fly mode",
 	give_to_singleplayer = false,
 })
-core.register_privilege("fast", {
+minetest.register_privilege("fast", {
 	description = "Can use fast mode",
 	give_to_singleplayer = false,
 })
-core.register_privilege("noclip", {
+minetest.register_privilege("noclip", {
 	description = "Can fly through solid nodes using noclip mode",
 	give_to_singleplayer = false,
 })
-core.register_privilege("rollback", {
+minetest.register_privilege("rollback", {
 	description = "Can use the rollback functionality",
 	give_to_singleplayer = false,
 })
-core.register_privilege("debug", {
+minetest.register_privilege("debug", {
 	description = "Allows enabling various debug options that may affect gameplay",
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
 
-core.register_can_bypass_userlimit(function(name, ip)
-	local privs = core.get_player_privs(name)
+minetest.register_can_bypass_userlimit(function(name, ip)
+	local privs = minetest.get_player_privs(name)
 	return privs["server"] or privs["ban"] or privs["privs"] or privs["password"]
 end)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -611,7 +611,8 @@ minetest.registered_can_bypass_userlimit, minetest.register_can_bypass_userlimit
 minetest.registered_on_modchannel_message, minetest.register_on_modchannel_message = make_registration()
 minetest.registered_on_auth_fail, minetest.register_on_auth_fail = make_registration()
 minetest.registered_on_player_inventory_actions, minetest.register_on_player_inventory_action = make_registration()
-minetest.registered_allow_player_inventory_actions, minetest.register_allow_player_inventory_action = make_registration()
+minetest.registered_allow_player_inventory_actions,
+	minetest.register_allow_player_inventory_action = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -456,7 +456,7 @@ function minetest.run_priv_callbacks(name, priv, caller, method)
 	local def = minetest.registered_privileges[priv]
 	if not def or not def["on_" .. method] or
 			not def["on_" .. method](name, caller) then
-		for _, func in ipairs(core["registered_on_priv_" .. method]) do
+		for _, func in ipairs(minetest["registered_on_priv_" .. method]) do
 			if not func(name, caller, priv) then
 				break
 			end
@@ -499,8 +499,8 @@ end
 local function make_registration_wrap(reg_fn_name, clear_fn_name)
 	local list = {}
 
-	local orig_reg_fn = core[reg_fn_name]
-	core[reg_fn_name] = function(def)
+	local orig_reg_fn = minetest[reg_fn_name]
+	minetest[reg_fn_name] = function(def)
 		local retval = orig_reg_fn(def)
 		if retval ~= nil then
 			if def.name ~= nil then
@@ -512,8 +512,8 @@ local function make_registration_wrap(reg_fn_name, clear_fn_name)
 		return retval
 	end
 
-	local orig_clear_fn = core[clear_fn_name]
-	core[clear_fn_name] = function()
+	local orig_clear_fn = minetest[clear_fn_name]
+	minetest[clear_fn_name] = function()
 		for k in pairs(list) do
 			list[k] = nil
 		end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -4,39 +4,39 @@
 -- Make raw registration functions inaccessible to anyone except this file
 --
 
-local register_item_raw = core.register_item_raw
-core.register_item_raw = nil
+local register_item_raw = minetest.register_item_raw
+minetest.register_item_raw = nil
 
-local unregister_item_raw = core.unregister_item_raw
-core.unregister_item_raw = nil
+local unregister_item_raw = minetest.unregister_item_raw
+minetest.unregister_item_raw = nil
 
-local register_alias_raw = core.register_alias_raw
-core.register_alias_raw = nil
+local register_alias_raw = minetest.register_alias_raw
+minetest.register_alias_raw = nil
 
 --
 -- Item / entity / ABM / LBM registration functions
 --
 
-core.registered_abms = {}
-core.registered_lbms = {}
-core.registered_entities = {}
-core.registered_items = {}
-core.registered_nodes = {}
-core.registered_craftitems = {}
-core.registered_tools = {}
-core.registered_aliases = {}
+minetest.registered_abms = {}
+minetest.registered_lbms = {}
+minetest.registered_entities = {}
+minetest.registered_items = {}
+minetest.registered_nodes = {}
+minetest.registered_craftitems = {}
+minetest.registered_tools = {}
+minetest.registered_aliases = {}
 
 -- For tables that are indexed by item name:
--- If table[X] does not exist, default to table[core.registered_aliases[X]]
+-- If table[X] does not exist, default to table[minetest.registered_aliases[X]]
 local alias_metatable = {
 	__index = function(t, name)
-		return rawget(t, core.registered_aliases[name])
+		return rawget(t, minetest.registered_aliases[name])
 	end
 }
-setmetatable(core.registered_items, alias_metatable)
-setmetatable(core.registered_nodes, alias_metatable)
-setmetatable(core.registered_craftitems, alias_metatable)
-setmetatable(core.registered_tools, alias_metatable)
+setmetatable(minetest.registered_items, alias_metatable)
+setmetatable(minetest.registered_nodes, alias_metatable)
+setmetatable(minetest.registered_craftitems, alias_metatable)
+setmetatable(minetest.registered_tools, alias_metatable)
 
 -- These item names may not be used because they would interfere
 -- with legacy itemstrings
@@ -60,7 +60,7 @@ local function check_modname_prefix(name)
 		return name:sub(2)
 	else
 		-- Enforce that the name starts with the correct mod name.
-		local expected_prefix = core.get_current_modname() .. ":"
+		local expected_prefix = minetest.get_current_modname() .. ":"
 		if name:sub(1, #expected_prefix) ~= expected_prefix then
 			error("Name " .. name .. " does not follow naming conventions: " ..
 				"\"" .. expected_prefix .. "\" or \":\" prefix required")
@@ -77,22 +77,22 @@ local function check_modname_prefix(name)
 	end
 end
 
-function core.register_abm(spec)
-	-- Add to core.registered_abms
+function minetest.register_abm(spec)
+	-- Add to minetest.registered_abms
 	assert(type(spec.action) == "function", "Required field 'action' of type function")
-	core.registered_abms[#core.registered_abms + 1] = spec
-	spec.mod_origin = core.get_current_modname() or "??"
+	minetest.registered_abms[#minetest.registered_abms + 1] = spec
+	spec.mod_origin = minetest.get_current_modname() or "??"
 end
 
-function core.register_lbm(spec)
-	-- Add to core.registered_lbms
+function minetest.register_lbm(spec)
+	-- Add to minetest.registered_lbms
 	check_modname_prefix(spec.name)
 	assert(type(spec.action) == "function", "Required field 'action' of type function")
-	core.registered_lbms[#core.registered_lbms + 1] = spec
-	spec.mod_origin = core.get_current_modname() or "??"
+	minetest.registered_lbms[#minetest.registered_lbms + 1] = spec
+	spec.mod_origin = minetest.get_current_modname() or "??"
 end
 
-function core.register_entity(name, prototype)
+function minetest.register_entity(name, prototype)
 	-- Check name
 	if name == nil then
 		error("Unable to register entity: Name is nil")
@@ -102,12 +102,12 @@ function core.register_entity(name, prototype)
 	prototype.name = name
 	prototype.__index = prototype  -- so that it can be used as a metatable
 
-	-- Add to core.registered_entities
-	core.registered_entities[name] = prototype
-	prototype.mod_origin = core.get_current_modname() or "??"
+	-- Add to minetest.registered_entities
+	minetest.registered_entities[name] = prototype
+	prototype.mod_origin = minetest.get_current_modname() or "??"
 end
 
-function core.register_item(name, itemdef)
+function minetest.register_item(name, itemdef)
 	-- Check name
 	if name == nil then
 		error("Unable to register item: Name is nil")
@@ -129,21 +129,21 @@ function core.register_item(name, itemdef)
 				fixed = {-1/8, -1/2, -1/8, 1/8, 1/2, 1/8},
 			}
 		end
-		if itemdef.light_source and itemdef.light_source > core.LIGHT_MAX then
-			itemdef.light_source = core.LIGHT_MAX
-			core.log("warning", "Node 'light_source' value exceeds maximum," ..
+		if itemdef.light_source and itemdef.light_source > minetest.LIGHT_MAX then
+			itemdef.light_source = minetest.LIGHT_MAX
+			minetest.log("warning", "Node 'light_source' value exceeds maximum," ..
 				" limiting to maximum: " ..name)
 		end
-		setmetatable(itemdef, {__index = core.nodedef_default})
-		core.registered_nodes[itemdef.name] = itemdef
+		setmetatable(itemdef, {__index = minetest.nodedef_default})
+		minetest.registered_nodes[itemdef.name] = itemdef
 	elseif itemdef.type == "craft" then
-		setmetatable(itemdef, {__index = core.craftitemdef_default})
-		core.registered_craftitems[itemdef.name] = itemdef
+		setmetatable(itemdef, {__index = minetest.craftitemdef_default})
+		minetest.registered_craftitems[itemdef.name] = itemdef
 	elseif itemdef.type == "tool" then
-		setmetatable(itemdef, {__index = core.tooldef_default})
-		core.registered_tools[itemdef.name] = itemdef
+		setmetatable(itemdef, {__index = minetest.tooldef_default})
+		minetest.registered_tools[itemdef.name] = itemdef
 	elseif itemdef.type == "none" then
-		setmetatable(itemdef, {__index = core.noneitemdef_default})
+		setmetatable(itemdef, {__index = minetest.noneitemdef_default})
 	else
 		error("Unable to register item: Type is invalid: " .. dump(itemdef))
 	end
@@ -155,7 +155,7 @@ function core.register_item(name, itemdef)
 
 	-- BEGIN Legacy stuff
 	if itemdef.cookresult_itemstring ~= nil and itemdef.cookresult_itemstring ~= "" then
-		core.register_craft({
+		minetest.register_craft({
 			type="cooking",
 			output=itemdef.cookresult_itemstring,
 			recipe=itemdef.name,
@@ -163,7 +163,7 @@ function core.register_item(name, itemdef)
 		})
 	end
 	if itemdef.furnace_burntime ~= nil and itemdef.furnace_burntime >= 0 then
-		core.register_craft({
+		minetest.register_craft({
 			type="fuel",
 			recipe=itemdef.name,
 			burntime=itemdef.furnace_burntime
@@ -171,44 +171,44 @@ function core.register_item(name, itemdef)
 	end
 	-- END Legacy stuff
 
-	itemdef.mod_origin = core.get_current_modname() or "??"
+	itemdef.mod_origin = minetest.get_current_modname() or "??"
 
 	-- Disable all further modifications
 	getmetatable(itemdef).__newindex = {}
 
-	--core.log("Registering item: " .. itemdef.name)
-	core.registered_items[itemdef.name] = itemdef
-	core.registered_aliases[itemdef.name] = nil
+	--minetest.log("Registering item: " .. itemdef.name)
+	minetest.registered_items[itemdef.name] = itemdef
+	minetest.registered_aliases[itemdef.name] = nil
 	register_item_raw(itemdef)
 end
 
-function core.unregister_item(name)
-	if not core.registered_items[name] then
-		core.log("warning", "Not unregistering item " ..name..
+function minetest.unregister_item(name)
+	if not minetest.registered_items[name] then
+		minetest.log("warning", "Not unregistering item " ..name..
 			" because it doesn't exist.")
 		return
 	end
 	-- Erase from registered_* table
-	local type = core.registered_items[name].type
+	local type = minetest.registered_items[name].type
 	if type == "node" then
-		core.registered_nodes[name] = nil
+		minetest.registered_nodes[name] = nil
 	elseif type == "craft" then
-		core.registered_craftitems[name] = nil
+		minetest.registered_craftitems[name] = nil
 	elseif type == "tool" then
-		core.registered_tools[name] = nil
+		minetest.registered_tools[name] = nil
 	end
-	core.registered_items[name] = nil
+	minetest.registered_items[name] = nil
 
 
 	unregister_item_raw(name)
 end
 
-function core.register_node(name, nodedef)
+function minetest.register_node(name, nodedef)
 	nodedef.type = "node"
-	core.register_item(name, nodedef)
+	minetest.register_item(name, nodedef)
 end
 
-function core.register_craftitem(name, craftitemdef)
+function minetest.register_craftitem(name, craftitemdef)
 	craftitemdef.type = "craft"
 
 	-- BEGIN Legacy stuff
@@ -217,10 +217,10 @@ function core.register_craftitem(name, craftitemdef)
 	end
 	-- END Legacy stuff
 
-	core.register_item(name, craftitemdef)
+	minetest.register_item(name, craftitemdef)
 end
 
-function core.register_tool(name, tooldef)
+function minetest.register_tool(name, tooldef)
 	tooldef.type = "tool"
 	tooldef.stack_max = 1
 
@@ -268,46 +268,46 @@ function core.register_tool(name, tooldef)
 		end
 	end
 
-	core.register_item(name, tooldef)
+	minetest.register_item(name, tooldef)
 end
 
-function core.register_alias(name, convert_to)
+function minetest.register_alias(name, convert_to)
 	if forbidden_item_names[name] then
 		error("Unable to register alias: Name is forbidden: " .. name)
 	end
-	if core.registered_items[name] ~= nil then
-		core.log("warning", "Not registering alias, item with same name" ..
+	if minetest.registered_items[name] ~= nil then
+		minetest.log("warning", "Not registering alias, item with same name" ..
 			" is already defined: " .. name .. " -> " .. convert_to)
 	else
-		--core.log("Registering alias: " .. name .. " -> " .. convert_to)
-		core.registered_aliases[name] = convert_to
+		--minetest.log("Registering alias: " .. name .. " -> " .. convert_to)
+		minetest.registered_aliases[name] = convert_to
 		register_alias_raw(name, convert_to)
 	end
 end
 
-function core.register_alias_force(name, convert_to)
+function minetest.register_alias_force(name, convert_to)
 	if forbidden_item_names[name] then
 		error("Unable to register alias: Name is forbidden: " .. name)
 	end
-	if core.registered_items[name] ~= nil then
-		core.unregister_item(name)
-		core.log("info", "Removed item " ..name..
+	if minetest.registered_items[name] ~= nil then
+		minetest.unregister_item(name)
+		minetest.log("info", "Removed item " ..name..
 			" while attempting to force add an alias")
 	end
-	--core.log("Registering alias: " .. name .. " -> " .. convert_to)
-	core.registered_aliases[name] = convert_to
+	--minetest.log("Registering alias: " .. name .. " -> " .. convert_to)
+	minetest.registered_aliases[name] = convert_to
 	register_alias_raw(name, convert_to)
 end
 
-function core.on_craft(itemstack, player, old_craft_list, craft_inv)
-	for _, func in ipairs(core.registered_on_crafts) do
+function minetest.on_craft(itemstack, player, old_craft_list, craft_inv)
+	for _, func in ipairs(minetest.registered_on_crafts) do
 		itemstack = func(itemstack, player, old_craft_list, craft_inv) or itemstack
 	end
 	return itemstack
 end
 
-function core.craft_predict(itemstack, player, old_craft_list, craft_inv)
-	for _, func in ipairs(core.registered_craft_predicts) do
+function minetest.craft_predict(itemstack, player, old_craft_list, craft_inv)
+	for _, func in ipairs(minetest.registered_craft_predicts) do
 		itemstack = func(itemstack, player, old_craft_list, craft_inv) or itemstack
 	end
 	return itemstack
@@ -316,33 +316,33 @@ end
 -- Alias the forbidden item names to "" so they can't be
 -- created via itemstrings (e.g. /give)
 for name in pairs(forbidden_item_names) do
-	core.registered_aliases[name] = ""
+	minetest.registered_aliases[name] = ""
 	register_alias_raw(name, "")
 end
 
 
 -- Obsolete:
--- Aliases for core.register_alias (how ironic...)
--- core.alias_node = core.register_alias
--- core.alias_tool = core.register_alias
--- core.alias_craftitem = core.register_alias
+-- Aliases for minetest.register_alias (how ironic...)
+-- minetest.alias_node = minetest.register_alias
+-- minetest.alias_tool = minetest.register_alias
+-- minetest.alias_craftitem = minetest.register_alias
 
 --
 -- Built-in node definitions. Also defined in C.
 --
 
-core.register_item(":unknown", {
+minetest.register_item(":unknown", {
 	type = "none",
 	description = "Unknown Item",
 	inventory_image = "unknown_item.png",
-	on_place = core.item_place,
-	on_secondary_use = core.item_secondary_use,
-	on_drop = core.item_drop,
+	on_place = minetest.item_place,
+	on_secondary_use = minetest.item_secondary_use,
+	on_drop = minetest.item_drop,
 	groups = {not_in_creative_inventory=1},
 	diggable = true,
 })
 
-core.register_node(":air", {
+minetest.register_node(":air", {
 	description = "Air",
 	inventory_image = "air.png",
 	wield_image = "air.png",
@@ -359,7 +359,7 @@ core.register_node(":air", {
 	groups = {not_in_creative_inventory=1},
 })
 
-core.register_node(":ignore", {
+minetest.register_node(":ignore", {
 	description = "Ignore",
 	inventory_image = "ignore.png",
 	wield_image = "ignore.png",
@@ -374,30 +374,30 @@ core.register_node(":ignore", {
 	drop = "",
 	groups = {not_in_creative_inventory=1},
 	on_place = function(itemstack, placer, pointed_thing)
-		core.chat_send_player(
+		minetest.chat_send_player(
 				placer:get_player_name(),
-				core.colorize("#FF0000",
+				minetest.colorize("#FF0000",
 				"You can't place 'ignore' nodes!"))
 		return ""
 	end,
 })
 
 -- The hand (bare definition)
-core.register_item(":", {
+minetest.register_item(":", {
 	type = "none",
 	wield_image = "wieldhand.png",
 	groups = {not_in_creative_inventory=1},
 })
 
 
-function core.override_item(name, redefinition)
+function minetest.override_item(name, redefinition)
 	if redefinition.name ~= nil then
 		error("Attempt to redefine name of "..name.." to "..dump(redefinition.name), 2)
 	end
 	if redefinition.type ~= nil then
 		error("Attempt to redefine type of "..name.." to "..dump(redefinition.type), 2)
 	end
-	local item = core.registered_items[name]
+	local item = minetest.registered_items[name]
 	if not item then
 		error("Attempt to override non-existent item "..name, 2)
 	end
@@ -408,9 +408,9 @@ function core.override_item(name, redefinition)
 end
 
 
-core.callback_origins = {}
+minetest.callback_origins = {}
 
-function core.run_callbacks(callbacks, mode, ...)
+function minetest.run_callbacks(callbacks, mode, ...)
 	assert(type(callbacks) == "table")
 	local cb_len = #callbacks
 	if cb_len == 0 then
@@ -422,9 +422,9 @@ function core.run_callbacks(callbacks, mode, ...)
 	end
 	local ret = nil
 	for i = 1, cb_len do
-		local origin = core.callback_origins[callbacks[i]]
+		local origin = minetest.callback_origins[callbacks[i]]
 		if origin then
-			core.set_last_run_mod(origin.mod)
+			minetest.set_last_run_mod(origin.mod)
 		end
 		local cb_ret = callbacks[i](...)
 
@@ -452,8 +452,8 @@ function core.run_callbacks(callbacks, mode, ...)
 	return ret
 end
 
-function core.run_priv_callbacks(name, priv, caller, method)
-	local def = core.registered_privileges[priv]
+function minetest.run_priv_callbacks(name, priv, caller, method)
+	local def = minetest.registered_privileges[priv]
 	if not def or not def["on_" .. method] or
 			not def["on_" .. method](name, caller) then
 		for _, func in ipairs(core["registered_on_priv_" .. method]) do
@@ -472,11 +472,11 @@ local function make_registration()
 	local t = {}
 	local registerfunc = function(func)
 		t[#t + 1] = func
-		core.callback_origins[func] = {
-			mod = core.get_current_modname() or "??",
+		minetest.callback_origins[func] = {
+			mod = minetest.get_current_modname() or "??",
 			name = debug.getinfo(1, "n").name or "??"
 		}
-		--local origin = core.callback_origins[func]
+		--local origin = minetest.callback_origins[func]
 		--print(origin.name .. ": " .. origin.mod .. " registering cbk " .. tostring(func))
 	end
 	return t, registerfunc
@@ -486,11 +486,11 @@ local function make_registration_reverse()
 	local t = {}
 	local registerfunc = function(func)
 		table.insert(t, 1, func)
-		core.callback_origins[func] = {
-			mod = core.get_current_modname() or "??",
+		minetest.callback_origins[func] = {
+			mod = minetest.get_current_modname() or "??",
 			name = debug.getinfo(1, "n").name or "??"
 		}
-		--local origin = core.callback_origins[func]
+		--local origin = minetest.callback_origins[func]
 		--print(origin.name .. ": " .. origin.mod .. " registering cbk " .. tostring(func))
 	end
 	return t, registerfunc
@@ -542,12 +542,12 @@ local function make_wrap_deregistration(reg_fn, clear_fn, list)
 	return unregister
 end
 
-core.registered_on_player_hpchanges = { modifiers = { }, loggers = { } }
+minetest.registered_on_player_hpchanges = { modifiers = { }, loggers = { } }
 
-function core.registered_on_player_hpchange(player, hp_change, reason)
+function minetest.registered_on_player_hpchange(player, hp_change, reason)
 	local last
-	for i = #core.registered_on_player_hpchanges.modifiers, 1, -1 do
-		local func = core.registered_on_player_hpchanges.modifiers[i]
+	for i = #minetest.registered_on_player_hpchanges.modifiers, 1, -1 do
+		local func = minetest.registered_on_player_hpchanges.modifiers[i]
 		hp_change, last = func(player, hp_change, reason)
 		if type(hp_change) ~= "number" then
 			local debuginfo = debug.getinfo(func)
@@ -558,63 +558,63 @@ function core.registered_on_player_hpchange(player, hp_change, reason)
 			break
 		end
 	end
-	for i, func in ipairs(core.registered_on_player_hpchanges.loggers) do
+	for i, func in ipairs(minetest.registered_on_player_hpchanges.loggers) do
 		func(player, hp_change, reason)
 	end
 	return hp_change
 end
 
-function core.register_on_player_hpchange(func, modifier)
+function minetest.register_on_player_hpchange(func, modifier)
 	if modifier then
-		core.registered_on_player_hpchanges.modifiers[#core.registered_on_player_hpchanges.modifiers + 1] = func
+		minetest.registered_on_player_hpchanges.modifiers[#minetest.registered_on_player_hpchanges.modifiers + 1] = func
 	else
-		core.registered_on_player_hpchanges.loggers[#core.registered_on_player_hpchanges.loggers + 1] = func
+		minetest.registered_on_player_hpchanges.loggers[#minetest.registered_on_player_hpchanges.loggers + 1] = func
 	end
-	core.callback_origins[func] = {
-		mod = core.get_current_modname() or "??",
+	minetest.callback_origins[func] = {
+		mod = minetest.get_current_modname() or "??",
 		name = debug.getinfo(1, "n").name or "??"
 	}
 end
 
-core.registered_biomes      = make_registration_wrap("register_biome",      "clear_registered_biomes")
-core.registered_ores        = make_registration_wrap("register_ore",        "clear_registered_ores")
-core.registered_decorations = make_registration_wrap("register_decoration", "clear_registered_decorations")
+minetest.registered_biomes      = make_registration_wrap("register_biome",      "clear_registered_biomes")
+minetest.registered_ores        = make_registration_wrap("register_ore",        "clear_registered_ores")
+minetest.registered_decorations = make_registration_wrap("register_decoration", "clear_registered_decorations")
 
-core.unregister_biome = make_wrap_deregistration(core.register_biome,
-		core.clear_registered_biomes, core.registered_biomes)
+minetest.unregister_biome = make_wrap_deregistration(minetest.register_biome,
+		minetest.clear_registered_biomes, minetest.registered_biomes)
 
-core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
-core.registered_globalsteps, core.register_globalstep = make_registration()
-core.registered_playerevents, core.register_playerevent = make_registration()
-core.registered_on_mods_loaded, core.register_on_mods_loaded = make_registration()
-core.registered_on_shutdown, core.register_on_shutdown = make_registration()
-core.registered_on_punchnodes, core.register_on_punchnode = make_registration()
-core.registered_on_placenodes, core.register_on_placenode = make_registration()
-core.registered_on_dignodes, core.register_on_dignode = make_registration()
-core.registered_on_generateds, core.register_on_generated = make_registration()
-core.registered_on_newplayers, core.register_on_newplayer = make_registration()
-core.registered_on_dieplayers, core.register_on_dieplayer = make_registration()
-core.registered_on_respawnplayers, core.register_on_respawnplayer = make_registration()
-core.registered_on_prejoinplayers, core.register_on_prejoinplayer = make_registration()
-core.registered_on_joinplayers, core.register_on_joinplayer = make_registration()
-core.registered_on_leaveplayers, core.register_on_leaveplayer = make_registration()
-core.registered_on_player_receive_fields, core.register_on_player_receive_fields = make_registration_reverse()
-core.registered_on_cheats, core.register_on_cheat = make_registration()
-core.registered_on_crafts, core.register_on_craft = make_registration()
-core.registered_craft_predicts, core.register_craft_predict = make_registration()
-core.registered_on_protection_violation, core.register_on_protection_violation = make_registration()
-core.registered_on_item_eats, core.register_on_item_eat = make_registration()
-core.registered_on_punchplayers, core.register_on_punchplayer = make_registration()
-core.registered_on_priv_grant, core.register_on_priv_grant = make_registration()
-core.registered_on_priv_revoke, core.register_on_priv_revoke = make_registration()
-core.registered_can_bypass_userlimit, core.register_can_bypass_userlimit = make_registration()
-core.registered_on_modchannel_message, core.register_on_modchannel_message = make_registration()
-core.registered_on_auth_fail, core.register_on_auth_fail = make_registration()
-core.registered_on_player_inventory_actions, core.register_on_player_inventory_action = make_registration()
-core.registered_allow_player_inventory_actions, core.register_allow_player_inventory_action = make_registration()
+minetest.registered_on_chat_messages, minetest.register_on_chat_message = make_registration()
+minetest.registered_globalsteps, minetest.register_globalstep = make_registration()
+minetest.registered_playerevents, minetest.register_playerevent = make_registration()
+minetest.registered_on_mods_loaded, minetest.register_on_mods_loaded = make_registration()
+minetest.registered_on_shutdown, minetest.register_on_shutdown = make_registration()
+minetest.registered_on_punchnodes, minetest.register_on_punchnode = make_registration()
+minetest.registered_on_placenodes, minetest.register_on_placenode = make_registration()
+minetest.registered_on_dignodes, minetest.register_on_dignode = make_registration()
+minetest.registered_on_generateds, minetest.register_on_generated = make_registration()
+minetest.registered_on_newplayers, minetest.register_on_newplayer = make_registration()
+minetest.registered_on_dieplayers, minetest.register_on_dieplayer = make_registration()
+minetest.registered_on_respawnplayers, minetest.register_on_respawnplayer = make_registration()
+minetest.registered_on_prejoinplayers, minetest.register_on_prejoinplayer = make_registration()
+minetest.registered_on_joinplayers, minetest.register_on_joinplayer = make_registration()
+minetest.registered_on_leaveplayers, minetest.register_on_leaveplayer = make_registration()
+minetest.registered_on_player_receive_fields, minetest.register_on_player_receive_fields = make_registration_reverse()
+minetest.registered_on_cheats, minetest.register_on_cheat = make_registration()
+minetest.registered_on_crafts, minetest.register_on_craft = make_registration()
+minetest.registered_craft_predicts, minetest.register_craft_predict = make_registration()
+minetest.registered_on_protection_violation, minetest.register_on_protection_violation = make_registration()
+minetest.registered_on_item_eats, minetest.register_on_item_eat = make_registration()
+minetest.registered_on_punchplayers, minetest.register_on_punchplayer = make_registration()
+minetest.registered_on_priv_grant, minetest.register_on_priv_grant = make_registration()
+minetest.registered_on_priv_revoke, minetest.register_on_priv_revoke = make_registration()
+minetest.registered_can_bypass_userlimit, minetest.register_can_bypass_userlimit = make_registration()
+minetest.registered_on_modchannel_message, minetest.register_on_modchannel_message = make_registration()
+minetest.registered_on_auth_fail, minetest.register_on_auth_fail = make_registration()
+minetest.registered_on_player_inventory_actions, minetest.register_on_player_inventory_action = make_registration()
+minetest.registered_allow_player_inventory_actions, minetest.register_allow_player_inventory_action = make_registration()
 
 --
 -- Compatibility for on_mapgen_init()
 --
 
-core.register_on_mapgen_init = function(func) func(core.get_mapgen_params()) end
+minetest.register_on_mapgen_init = function(func) func(minetest.get_mapgen_params()) end

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -1,11 +1,11 @@
 -- cache setting
-local enable_damage = core.settings:get_bool("enable_damage")
+local enable_damage = minetest.settings:get_bool("enable_damage")
 
 local health_bar_definition = {
 	hud_elem_type = "statbar",
 	position = { x=0.5, y=1 },
 	text = "heart.png",
-	number = core.PLAYER_MAX_HP_DEFAULT,
+	number = minetest.PLAYER_MAX_HP_DEFAULT,
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = { x=(-10*24)-25, y=-(48+24+16)},
@@ -15,7 +15,7 @@ local breath_bar_definition = {
 	hud_elem_type = "statbar",
 	position = { x=0.5, y=1 },
 	text = "bubble.png",
-	number = core.PLAYER_MAX_BREATH_DEFAULT,
+	number = minetest.PLAYER_MAX_BREATH_DEFAULT,
 	direction = 0,
 	size = { x=24, y=24 },
 	offset = {x=25,y=-(48+24+16)},
@@ -123,7 +123,7 @@ local function player_event_handler(player,eventname)
 	return false
 end
 
-function core.hud_replace_builtin(hud_name, definition)
+function minetest.hud_replace_builtin(hud_name, definition)
 
 	if type(definition) ~= "table" or
 			definition.hud_elem_type ~= "statbar" then
@@ -134,7 +134,7 @@ function core.hud_replace_builtin(hud_name, definition)
 		health_bar_definition = definition
 
 		for name, ids in pairs(hud_ids) do
-			local player = core.get_player_by_name(name)
+			local player = minetest.get_player_by_name(name)
 			if player and ids.id_healthbar then
 				player:hud_remove(ids.id_healthbar)
 				ids.id_healthbar = nil
@@ -148,7 +148,7 @@ function core.hud_replace_builtin(hud_name, definition)
 		breath_bar_definition = definition
 
 		for name, ids in pairs(hud_ids) do
-			local player = core.get_player_by_name(name)
+			local player = minetest.get_player_by_name(name)
 			if player and ids.id_breathbar then
 				player:hud_remove(ids.id_breathbar)
 				ids.id_breathbar = nil
@@ -163,8 +163,8 @@ end
 
 -- Append "update_builtin_statbars" as late as possible
 -- This ensures that the HUD is hidden when the flags are updated in this callback
-core.register_on_mods_loaded(function()
-	core.register_on_joinplayer(update_builtin_statbars)
+minetest.register_on_mods_loaded(function()
+	minetest.register_on_joinplayer(update_builtin_statbars)
 end)
-core.register_on_leaveplayer(cleanup_builtin_statbars)
-core.register_playerevent(player_event_handler)
+minetest.register_on_leaveplayer(cleanup_builtin_statbars)
+minetest.register_playerevent(player_event_handler)

--- a/builtin/game/statbars.lua
+++ b/builtin/game/statbars.lua
@@ -26,7 +26,7 @@ local hud_ids = {}
 local function scaleToDefault(player, field)
 	-- Scale "hp" or "breath" to the default dimensions
 	local current = player["get_" .. field](player)
-	local nominal = core["PLAYER_MAX_".. field:upper() .. "_DEFAULT"]
+	local nominal = minetest["PLAYER_MAX_".. field:upper() .. "_DEFAULT"]
 	local max_display = math.max(nominal,
 		math.max(player:get_properties()[field .. "_max"], current))
 	return current / max_display * nominal

--- a/builtin/game/static_spawn.lua
+++ b/builtin/game/static_spawn.lua
@@ -1,23 +1,23 @@
 -- Minetest: builtin/static_spawn.lua
 
-local static_spawnpoint_string = core.settings:get("static_spawnpoint")
+local static_spawnpoint_string = minetest.settings:get("static_spawnpoint")
 if static_spawnpoint_string and
 		static_spawnpoint_string ~= "" and
-		not core.setting_get_pos("static_spawnpoint") then
+		not minetest.setting_get_pos("static_spawnpoint") then
 	error('The static_spawnpoint setting is invalid: "' ..
 			static_spawnpoint_string .. '"')
 end
 
 local function put_player_in_spawn(player_obj)
-	local static_spawnpoint = core.setting_get_pos("static_spawnpoint")
+	local static_spawnpoint = minetest.setting_get_pos("static_spawnpoint")
 	if not static_spawnpoint then
 		return false
 	end
-	core.log("action", "Moving " .. player_obj:get_player_name() ..
-		" to static spawnpoint at " .. core.pos_to_string(static_spawnpoint))
+	minetest.log("action", "Moving " .. player_obj:get_player_name() ..
+		" to static spawnpoint at " .. minetest.pos_to_string(static_spawnpoint))
 	player_obj:set_pos(static_spawnpoint)
 	return true
 end
 
-core.register_on_newplayer(put_player_in_spawn)
-core.register_on_respawnplayer(put_player_in_spawn)
+minetest.register_on_newplayer(put_player_in_spawn)
+minetest.register_on_respawnplayer(put_player_in_spawn)

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -8,7 +8,7 @@
 -- Initialize some very basic things
 function minetest.debug(...) minetest.log(table.concat({...}, "\t")) end
 if minetest.print then
-	local core_print = minetest.print
+	local minetest_print = minetest.print
 	-- Override native print and use
 	-- terminal if that's turned on
 	function print(...)
@@ -16,7 +16,7 @@ if minetest.print then
 		for i = 1, n do
 			t[i] = tostring(t[i])
 		end
-		core_print(table.concat(t, "\t"))
+		minetest_print(table.concat(t, "\t"))
 	end
 	minetest.print = nil -- don't pollute our namespace
 end

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -6,9 +6,9 @@
 --
 
 -- Initialize some very basic things
-function core.debug(...) core.log(table.concat({...}, "\t")) end
-if core.print then
-	local core_print = core.print
+function minetest.debug(...) minetest.log(table.concat({...}, "\t")) end
+if minetest.print then
+	local core_print = minetest.print
 	-- Override native print and use
 	-- terminal if that's turned on
 	function print(...)
@@ -18,13 +18,12 @@ if core.print then
 		end
 		core_print(table.concat(t, "\t"))
 	end
-	core.print = nil -- don't pollute our namespace
+	minetest.print = nil -- don't pollute our namespace
 end
 math.randomseed(os.time())
-minetest = core
 
 -- Load other files
-local scriptdir = core.get_builtin_path()
+local scriptdir = minetest.get_builtin_path()
 local gamepath = scriptdir .. "game" .. DIR_DELIM
 local clientpath = scriptdir .. "client" .. DIR_DELIM
 local commonpath = scriptdir .. "common" .. DIR_DELIM
@@ -37,11 +36,11 @@ dofile(commonpath .. "misc_helpers.lua")
 if INIT == "game" then
 	dofile(gamepath .. "init.lua")
 elseif INIT == "mainmenu" then
-	local mm_script = core.settings:get("main_menu_script")
+	local mm_script = minetest.settings:get("main_menu_script")
 	if mm_script and mm_script ~= "" then
 		dofile(mm_script)
 	else
-		dofile(core.get_mainmenu_path() .. DIR_DELIM .. "init.lua")
+		dofile(minetest.get_mainmenu_path() .. DIR_DELIM .. "init.lua")
 	end
 elseif INIT == "async" then
 	dofile(asyncpath .. "init.lua")

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -25,8 +25,8 @@ menudata = {}
 local min_supp_proto, max_supp_proto
 
 function common_update_cached_supp_proto()
-	min_supp_proto = core.get_min_supp_proto()
-	max_supp_proto = core.get_max_supp_proto()
+	min_supp_proto = minetest.get_min_supp_proto()
+	max_supp_proto = minetest.get_max_supp_proto()
 end
 common_update_cached_supp_proto()
 --------------------------------------------------------------------------------
@@ -43,23 +43,23 @@ end
 local function configure_selected_world_params(idx)
 	local worldconfig = pkgmgr.get_worldconfig(menudata.worldlist:get_list()[idx].path)
 	if worldconfig.creative_mode then
-		core.settings:set("creative_mode", worldconfig.creative_mode)
+		minetest.settings:set("creative_mode", worldconfig.creative_mode)
 	end
 	if worldconfig.enable_damage then
-		core.settings:set("enable_damage", worldconfig.enable_damage)
+		minetest.settings:set("enable_damage", worldconfig.enable_damage)
 	end
 end
 
 --------------------------------------------------------------------------------
 function image_column(tooltip, flagname)
-	return "image,tooltip=" .. core.formspec_escape(tooltip) .. "," ..
-		"0=" .. core.formspec_escape(defaulttexturedir .. "blank.png") .. "," ..
-		"1=" .. core.formspec_escape(defaulttexturedir ..
+	return "image,tooltip=" .. minetest.formspec_escape(tooltip) .. "," ..
+		"0=" .. minetest.formspec_escape(defaulttexturedir .. "blank.png") .. "," ..
+		"1=" .. minetest.formspec_escape(defaulttexturedir ..
 			(flagname and "server_flags_" .. flagname .. ".png" or "blank.png")) .. "," ..
-		"2=" .. core.formspec_escape(defaulttexturedir .. "server_ping_4.png") .. "," ..
-		"3=" .. core.formspec_escape(defaulttexturedir .. "server_ping_3.png") .. "," ..
-		"4=" .. core.formspec_escape(defaulttexturedir .. "server_ping_2.png") .. "," ..
-		"5=" .. core.formspec_escape(defaulttexturedir .. "server_ping_1.png")
+		"2=" .. minetest.formspec_escape(defaulttexturedir .. "server_ping_4.png") .. "," ..
+		"3=" .. minetest.formspec_escape(defaulttexturedir .. "server_ping_3.png") .. "," ..
+		"4=" .. minetest.formspec_escape(defaulttexturedir .. "server_ping_2.png") .. "," ..
+		"5=" .. minetest.formspec_escape(defaulttexturedir .. "server_ping_1.png")
 end
 
 --------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ end
 function render_serverlist_row(spec, is_favorite)
 	local text = ""
 	if spec.name then
-		text = text .. core.formspec_escape(spec.name:trim())
+		text = text .. minetest.formspec_escape(spec.name:trim())
 	elseif spec.address then
 		text = text .. spec.address:trim()
 		if spec.port then
@@ -164,8 +164,8 @@ end
 
 --------------------------------------------------------------------------------
 os.tempfolder = function()
-	if core.settings:get("TMPFolder") then
-		return core.settings:get("TMPFolder") .. DIR_DELIM .. "MT_" .. math.random(0,10000)
+	if minetest.settings:get("TMPFolder") then
+		return minetest.settings:get("TMPFolder") .. DIR_DELIM .. "MT_" .. math.random(0,10000)
 	end
 
 	local filetocheck = os.tmpname()
@@ -202,8 +202,8 @@ function menu_render_worldlist()
 
 	for i, v in ipairs(current_worldlist) do
 		if retval ~= "" then retval = retval .. "," end
-		retval = retval .. core.formspec_escape(v.name) ..
-				" \\[" .. core.formspec_escape(v.gameid) .. "\\]"
+		retval = retval .. minetest.formspec_escape(v.name) ..
+				" \\[" .. minetest.formspec_escape(v.gameid) .. "\\]"
 	end
 
 	return retval
@@ -211,7 +211,7 @@ end
 
 --------------------------------------------------------------------------------
 function menu_handle_key_up_down(fields, textlist, settingname)
-	local oldidx, newidx = core.get_textlist_index(textlist), 1
+	local oldidx, newidx = minetest.get_textlist_index(textlist), 1
 	if fields.key_up or fields.key_down then
 		if fields.key_up and oldidx and oldidx > 1 then
 			newidx = oldidx - 1
@@ -219,7 +219,7 @@ function menu_handle_key_up_down(fields, textlist, settingname)
 				oldidx < menudata.worldlist:size() then
 			newidx = oldidx + 1
 		end
-		core.settings:set(settingname, menudata.worldlist:get_raw_index(newidx))
+		minetest.settings:set(settingname, menudata.worldlist:get_raw_index(newidx))
 		configure_selected_world_params(newidx)
 		return true
 	end
@@ -243,9 +243,9 @@ function asyncOnlineFavourites()
 		return
 	end
 
-	core.handle_async(
+	minetest.handle_async(
 		function(param)
-			return core.get_favorites("online")
+			return minetest.get_favorites("online")
 		end,
 		nil,
 		function(result)
@@ -256,20 +256,20 @@ function asyncOnlineFavourites()
 				menudata.favorites = menudata.public_known
 				menudata.favorites_is_public = true
 			end
-			core.event_handler("Refresh")
+			minetest.event_handler("Refresh")
 		end
 	)
 end
 
 --------------------------------------------------------------------------------
 function text2textlist(xpos, ypos, width, height, tl_name, textlen, text, transparency)
-	local textlines = core.wrap_text(text, textlen, true)
+	local textlines = minetest.wrap_text(text, textlen, true)
 	local retval = "textlist[" .. xpos .. "," .. ypos .. ";" .. width ..
 			"," .. height .. ";" .. tl_name .. ";"
 
 	for i = 1, #textlines do
 		textlines[i] = textlines[i]:gsub("\r", "")
-		retval = retval .. core.formspec_escape(textlines[i]) .. ","
+		retval = retval .. minetest.formspec_escape(textlines[i]) .. ","
 	end
 
 	retval = retval .. ";0;"
@@ -324,7 +324,7 @@ function menu_worldmt(selected, setting, value)
 
 		if value then
 			if not world_conf:write() then
-				core.log("error", "Failed to write world config file")
+				minetest.log("error", "Failed to write world config file")
 			end
 			world_conf:set(setting, value)
 			world_conf:write()
@@ -341,9 +341,9 @@ function menu_worldmt_legacy(selected)
 	for _, mode_name in pairs(modes_names) do
 		local mode_val = menu_worldmt(selected, mode_name)
 		if mode_val then
-			core.settings:set(mode_name, mode_val)
+			minetest.settings:set(mode_name, mode_val)
 		else
-			menu_worldmt(selected, mode_name, core.settings:get(mode_name))
+			menu_worldmt(selected, mode_name, minetest.settings:get(mode_name))
 		end
 	end
 end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -33,7 +33,7 @@ local function get_formspec(data)
 
 	if mod.is_modpack or mod.type == "game" then
 		local info = minetest.formspec_escape(
-			core.get_content_info(mod.path).description)
+			minetest.get_content_info(mod.path).description)
 		if info == "" then
 			if mod.is_modpack then
 				info = fgettext("No modpack description provided.")
@@ -126,9 +126,9 @@ end
 
 local function handle_buttons(this, fields)
 	if fields.world_config_modlist then
-		local event = core.explode_table_event(fields.world_config_modlist)
+		local event = minetest.explode_table_event(fields.world_config_modlist)
 		this.data.selected_mod = event.row
-		core.settings:set("world_config_selected_mod", event.row)
+		minetest.settings:set("world_config_selected_mod", event.row)
 
 		if event.type == "DCL" then
 			pkgmgr.enable_mod(this)
@@ -143,7 +143,7 @@ local function handle_buttons(this, fields)
 	end
 
 	if fields.cb_mod_enable ~= nil then
-		pkgmgr.enable_mod(this, core.is_yes(fields.cb_mod_enable))
+		pkgmgr.enable_mod(this, minetest.is_yes(fields.cb_mod_enable))
 		return true
 	end
 
@@ -186,7 +186,7 @@ local function handle_buttons(this, fields)
 		end
 
 		if not worldfile:write() then
-			core.log("error", "Failed to write world config file")
+			minetest.log("error", "Failed to write world config file")
 		end
 
 		this:delete()
@@ -231,9 +231,9 @@ function create_configure_world_dlg(worldidx)
 	local dlg = dialog_create("sp_config_world", get_formspec, handle_buttons)
 
 	dlg.data.selected_mod = tonumber(
-			core.settings:get("world_config_selected_mod")) or 0
+			minetest.settings:get("world_config_selected_mod")) or 0
 
-	dlg.data.worldspec = core.get_worlds()[worldidx]
+	dlg.data.worldspec = minetest.get_worlds()[worldidx]
 	if not dlg.data.worldspec then
 		dlg:delete()
 		return

--- a/builtin/mainmenu/dlg_contentstore.lua
+++ b/builtin/mainmenu/dlg_contentstore.lua
@@ -19,8 +19,8 @@ local store = { packages = {}, packages_full = {} }
 local package_dialog = {}
 
 -- Screenshot
-local screenshot_dir = core.get_cache_path() .. DIR_DELIM .. "cdb"
-assert(core.create_dir(screenshot_dir))
+local screenshot_dir = minetest.get_cache_path() .. DIR_DELIM .. "cdb"
+assert(minetest.create_dir(screenshot_dir))
 local screenshot_downloading = {}
 local screenshot_downloaded = {}
 
@@ -47,14 +47,14 @@ local filter_types_type = {
 
 
 local function download_package(param)
-	if core.download_file(param.package.url, param.filename) then
+	if minetest.download_file(param.package.url, param.filename) then
 		return {
 			package = param.package,
 			filename = param.filename,
 			successful = true,
 		}
 	else
-		core.log("error", "downloading " .. dump(param.package.url) .. " failed")
+		minetest.log("error", "downloading " .. dump(param.package.url) .. " failed")
 		return {
 			package = param.package,
 			successful = false,
@@ -76,7 +76,7 @@ local function start_install(calling_dialog, package)
 			if not path then
 				gamedata.errormessage = msg
 			else
-				core.log("action", "Installed package to " .. path)
+				minetest.log("action", "Installed package to " .. path)
 
 				local conf_path
 				local name_is_title = false
@@ -116,14 +116,14 @@ local function start_install(calling_dialog, package)
 		end
 
 		if gamedata.errormessage == nil then
-			core.button_handler({btn_hidden_close_download=result})
+			minetest.button_handler({btn_hidden_close_download=result})
 		else
-			core.button_handler({btn_hidden_close_download={successful=false}})
+			minetest.button_handler({btn_hidden_close_download={successful=false}})
 		end
 	end
 
-	if not core.handle_async(download_package, params, callback) then
-		core.log("error", "ERROR: async event failed")
+	if not minetest.handle_async(download_package, params, callback) then
+		minetest.log("error", "ERROR: async event failed")
 		gamedata.errormessage = fgettext("Failed to download $1", package.name)
 	end
 
@@ -174,21 +174,21 @@ local function get_screenshot(package)
 	-- Download
 
 	local function download_screenshot(params)
-		return core.download_file(params.url, params.dest)
+		return minetest.download_file(params.url, params.dest)
 	end
 	local function callback(success)
 		screenshot_downloading[package.thumbnail] = nil
 		screenshot_downloaded[package.thumbnail] = true
 		if not success then
-			core.log("warning", "Screenshot download failed for some reason")
+			minetest.log("warning", "Screenshot download failed for some reason")
 		end
 		ui.update()
 	end
-	if core.handle_async(download_screenshot,
+	if minetest.handle_async(download_screenshot,
 			{ dest = filepath, url = package.thumbnail }, callback) then
 		screenshot_downloading[package.thumbnail] = true
 	else
-		core.log("error", "ERROR: async event failed")
+		minetest.log("error", "ERROR: async event failed")
 		return defaulttexturedir .. "error_screenshot.png"
 	end
 
@@ -204,11 +204,11 @@ function package_dialog.get_formspec()
 
 	local formspec = {
 		"size[9,4;true]",
-		"image[0,1;4.5,3;", core.formspec_escape(get_screenshot(package)), ']',
+		"image[0,1;4.5,3;", minetest.formspec_escape(get_screenshot(package)), ']',
 		"label[3.8,1;",
-		minetest.colorize(mt_color_green, core.formspec_escape(package.title)), "\n",
-		minetest.colorize('#BFBFBF', "by " .. core.formspec_escape(package.author)), "]",
-		"textarea[4,2;5.3,2;;;", core.formspec_escape(package.short_description), "]",
+		minetest.colorize(mt_color_green, minetest.formspec_escape(package.title)), "\n",
+		minetest.colorize('#BFBFBF', "by " .. minetest.formspec_escape(package.author)), "]",
+		"textarea[4,2;5.3,2;;;", minetest.formspec_escape(package.short_description), "]",
 		"button[0,0;2,1;back;", fgettext("Back"), "]",
 	}
 
@@ -267,25 +267,25 @@ function store.load()
 	local tmpdir = os.tempfolder()
 	local target = tmpdir .. DIR_DELIM .. "packages.json"
 
-	assert(core.create_dir(tmpdir))
+	assert(minetest.create_dir(tmpdir))
 
-	local base_url     = core.settings:get("contentdb_url")
+	local base_url     = minetest.settings:get("contentdb_url")
 	local url = base_url ..
 		"/api/packages/?type=mod&type=game&type=txp&protocol_version=" ..
-		core.get_max_supp_proto()
+		minetest.get_max_supp_proto()
 
-	for _, item in pairs(core.settings:get("contentdb_flag_blacklist"):split(",")) do
+	for _, item in pairs(minetest.settings:get("contentdb_flag_blacklist"):split(",")) do
 		item = item:trim()
 		if item ~= "" then
 			url = url .. "&hide=" .. item
 		end
 	end
 
-	core.download_file(url, target)
+	minetest.download_file(url, target)
 
 	local file = io.open(target, "r")
 	if file then
-		store.packages_full = core.parse_json(file:read("*all")) or {}
+		store.packages_full = minetest.parse_json(file:read("*all")) or {}
 		file:close()
 
 		for _, package in pairs(store.packages_full) do
@@ -305,7 +305,7 @@ function store.load()
 		store.loaded = true
 	end
 
-	core.delete_dir(tmpdir)
+	minetest.delete_dir(tmpdir)
 end
 
 function store.update_paths()
@@ -401,7 +401,7 @@ function store.get_formspec(dlgdata)
 			"size[12,7;true]",
 			"position[0.5,0.55]",
 			"field[0.2,0.1;7.8,1;search_string;;",
-			core.formspec_escape(search_string), "]",
+			minetest.formspec_escape(search_string), "]",
 			"field_close_on_enter[search_string;false]",
 			"button[7.7,-0.2;2,1;search;",
 			fgettext("Search"), "]",
@@ -452,12 +452,12 @@ function store.get_formspec(dlgdata)
 
 		-- image
 		formspec[#formspec + 1] = "image[-0.4,0;1.5,1;"
-		formspec[#formspec + 1] = core.formspec_escape(get_screenshot(package))
+		formspec[#formspec + 1] = minetest.formspec_escape(get_screenshot(package))
 		formspec[#formspec + 1] = "]"
 
 		-- title
 		formspec[#formspec + 1] = "label[1,-0.1;"
-		formspec[#formspec + 1] = core.formspec_escape(
+		formspec[#formspec + 1] = minetest.formspec_escape(
 				minetest.colorize(mt_color_green, package.title) ..
 				minetest.colorize("#BFBFBF", " by " .. package.author))
 		formspec[#formspec + 1] = "]"
@@ -468,7 +468,7 @@ function store.get_formspec(dlgdata)
 		else
 			formspec[#formspec + 1] = "textarea[1.25,0.3;9,1;;;"
 		end
-		formspec[#formspec + 1] = core.formspec_escape(package.short_description)
+		formspec[#formspec + 1] = minetest.formspec_escape(package.short_description)
 		formspec[#formspec + 1] = "]"
 
 		-- buttons

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -18,11 +18,11 @@
 local worldname = ""
 
 local function create_world_formspec(dialogdata)
-	local mapgens = core.get_mapgen_names()
+	local mapgens = minetest.get_mapgen_names()
 
-	local current_seed = core.settings:get("fixed_map_seed") or ""
-	local current_mg   = core.settings:get("mg_name")
-	local gameid = core.settings:get("menu_last_game")
+	local current_seed = minetest.settings:get("fixed_map_seed") or ""
+	local current_mg   = minetest.settings:get("mg_name")
+	local gameid = minetest.settings:get("menu_last_game")
 
 	local gameidx = 0
 	if gameid ~= nil then
@@ -34,7 +34,7 @@ local function create_world_formspec(dialogdata)
 		end
 	end
 
-	local game_by_gameidx = core.get_game(gameidx)
+	local game_by_gameidx = minetest.get_game(gameidx)
 	if game_by_gameidx ~= nil then
 		local gamepath = game_by_gameidx.path
 		local gameconfig = Settings(gamepath.."/game.conf")
@@ -65,7 +65,7 @@ local function create_world_formspec(dialogdata)
 	end
 	mglist = mglist:sub(1, -2)
 
-	current_seed = core.formspec_escape(current_seed)
+	current_seed = minetest.formspec_escape(current_seed)
 	local retval =
 		"size[11.5,6.5,true]" ..
 		"label[2,0;" .. fgettext("World name") .. "]"..
@@ -104,7 +104,7 @@ local function create_world_buttonhandler(this, fields)
 		fields["key_enter"] then
 
 		local worldname = fields["te_world_name"]
-		local gameindex = core.get_textlist_index("games")
+		local gameindex = minetest.get_textlist_index("games")
 
 		if gameindex ~= nil then
 			if worldname == "" then
@@ -113,12 +113,12 @@ local function create_world_buttonhandler(this, fields)
 				worldname = random_world_name
 			end
 
-			core.settings:set("fixed_map_seed", fields["te_seed"])
+			minetest.settings:set("fixed_map_seed", fields["te_seed"])
 
 			local message
 			if not menudata.worldlist:uid_exists_raw(worldname) then
-				core.settings:set("mg_name",fields["dd_mapgen"])
-				message = core.create_world(worldname,gameindex)
+				minetest.settings:set("mg_name",fields["dd_mapgen"])
+				message = minetest.create_world(worldname,gameindex)
 			else
 				message = fgettext("A world named \"$1\" already exists", worldname)
 			end
@@ -126,13 +126,13 @@ local function create_world_buttonhandler(this, fields)
 			if message ~= nil then
 				gamedata.errormessage = message
 			else
-				core.settings:set("menu_last_game",pkgmgr.games[gameindex].id)
+				minetest.settings:set("menu_last_game",pkgmgr.games[gameindex].id)
 				if this.data.update_worldlist_filter then
 					menudata.worldlist:set_filtercriteria(pkgmgr.games[gameindex].id)
 					mm_texture.update("singleplayer", pkgmgr.games[gameindex].id)
 				end
 				menudata.worldlist:refresh()
-				core.settings:set("mainmenu_last_selected_world",
+				minetest.settings:set("mainmenu_last_selected_world",
 									menudata.worldlist:raw_index_by_uid(worldname))
 			end
 		else
@@ -145,8 +145,8 @@ local function create_world_buttonhandler(this, fields)
 	worldname = fields.te_world_name
 
 	if fields["games"] then
-		local gameindex = core.get_textlist_index("games")
-		core.settings:set("menu_last_game", pkgmgr.games[gameindex].id)
+		local gameindex = minetest.get_textlist_index("games")
+		minetest.settings:set("menu_last_game", pkgmgr.games[gameindex].id)
 		return true
 	end
 

--- a/builtin/mainmenu/dlg_delete_content.lua
+++ b/builtin/mainmenu/dlg_delete_content.lua
@@ -35,10 +35,10 @@ local function delete_content_buttonhandler(this, fields)
 
 		if this.data.content.path ~= nil and
 				this.data.content.path ~= "" and
-				this.data.content.path ~= core.get_modpath() and
-				this.data.content.path ~= core.get_gamepath() and
-				this.data.content.path ~= core.get_texturepath() then
-			if not core.delete_dir(this.data.content.path) then
+				this.data.content.path ~= minetest.get_modpath() and
+				this.data.content.path ~= minetest.get_gamepath() and
+				this.data.content.path ~= minetest.get_texturepath() then
+			if not minetest.delete_dir(this.data.content.path) then
 				gamedata.errormessage = fgettext("pkgmgr: failed to delete \"$1\"", this.data.content.path)
 			end
 

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -31,7 +31,7 @@ local function delete_world_buttonhandler(this, fields)
 	if fields["world_delete_confirm"] then
 		if this.data.delete_index > 0 and
 				this.data.delete_index <= #menudata.worldlist:get_raw_list() then
-			core.delete_world(this.data.delete_index)
+			minetest.delete_world(this.data.delete_index)
 			menudata.worldlist:refresh()
 		end
 		this:delete()

--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -311,7 +311,7 @@ local function parse_single_file(file, filepath, read_all, result, base_level, a
 	while line do
 		local error_msg = parse_setting_line(result, line, read_all, base_level, allow_secure)
 		if error_msg then
-			core.log("error", error_msg .. " in " .. filepath .. " \"" .. line .. "\"")
+			minetest.log("error", error_msg .. " in " .. filepath .. " \"" .. line .. "\"")
 		end
 		line = file:read("*line")
 	end
@@ -325,10 +325,10 @@ local function parse_config_file(read_all, parse_mods)
 	local settings = {}
 
 	do
-		local builtin_path = core.get_builtin_path() .. FILENAME
+		local builtin_path = minetest.get_builtin_path() .. FILENAME
 		local file = io.open(builtin_path, "r")
 		if not file then
-			core.log("error", "Can't load " .. FILENAME)
+			minetest.log("error", "Can't load " .. FILENAME)
 			return settings
 		end
 
@@ -374,7 +374,7 @@ local function parse_config_file(read_all, parse_mods)
 		-- Parse mods
 		local mods_category_initialized = false
 		local mods = {}
-		get_mods(core.get_modpath(), mods)
+		get_mods(minetest.get_modpath(), mods)
 		for _, mod in ipairs(mods) do
 			local path = mod.path .. DIR_DELIM .. FILENAME
 			local file = io.open(path, "r")
@@ -484,7 +484,7 @@ local settings = full_settings
 local selected_setting = 1
 
 local function get_current_value(setting)
-	local value = core.settings:get(setting.name)
+	local value = minetest.settings:get(setting.name)
 	if value == nil then
 		value = setting.default
 	end
@@ -492,7 +492,7 @@ local function get_current_value(setting)
 end
 
 local function get_current_np_group(setting)
-	local value = core.settings:get_np_group(setting.name)
+	local value = minetest.settings:get_np_group(setting.name)
 	local t = {}
 	if value == nil then
 		t = setting.values
@@ -512,7 +512,7 @@ local function get_current_np_group(setting)
 end
 
 local function get_current_np_group_as_string(setting)
-	local value = core.settings:get_np_group(setting.name)
+	local value = minetest.settings:get_np_group(setting.name)
 	local t
 	if value == nil then
 		t = setting.default
@@ -547,7 +547,7 @@ local function create_change_setting_formspec(dialogdata)
 	-- Setting-specific formspec elements
 	if setting.type == "bool" then
 		local selected_index = 1
-		if core.is_yes(get_current_value(setting)) then
+		if minetest.is_yes(get_current_value(setting)) then
 			selected_index = 2
 		end
 		formspec = "dropdown[3," .. height .. ";4,1;dd_setting_value;"
@@ -561,7 +561,7 @@ local function create_change_setting_formspec(dialogdata)
 		for index, value in ipairs(setting.values) do
 			-- translating value is not possible, since it's the value
 			--  that we set the setting to
-			formspec = formspec ..  core.formspec_escape(value) .. ","
+			formspec = formspec ..  minetest.formspec_escape(value) .. ","
 			if get_current_value(setting) == value then
 				selected_index = index
 			end
@@ -578,7 +578,7 @@ local function create_change_setting_formspec(dialogdata)
 			current_value = get_current_value(setting)
 		end
 		formspec = "field[0.28," .. height + 0.15 .. ";8,1;te_setting_value;;"
-				.. core.formspec_escape(current_value) .. "]"
+				.. minetest.formspec_escape(current_value) .. "]"
 				.. "button[8," .. height - 0.15 .. ";2,1;btn_browser_"
 				.. setting.type .. ";" .. fgettext("Browse") .. "]"
 		height = height + 1.15
@@ -597,7 +597,7 @@ local function create_change_setting_formspec(dialogdata)
 		local fields = {}
 		local function add_field(x, name, label, value)
 			fields[#fields + 1] = ("field[%f,%f;3.3,1;%s;%s;%s]"):format(
-				x, height, name, label, core.formspec_escape(value or "")
+				x, height, name, label, minetest.formspec_escape(value or "")
 			)
 		end
 		-- First row
@@ -660,13 +660,13 @@ local function create_change_setting_formspec(dialogdata)
 		formspec = formspec
 				.. "field[0.3," .. height .. ";3.3,1;te_x;"
 				.. fgettext("X") .. ";" -- X
-				.. core.formspec_escape(v3f[1] or "") .. "]"
+				.. minetest.formspec_escape(v3f[1] or "") .. "]"
 				.. "field[3.6," .. height .. ";3.3,1;te_y;"
 				.. fgettext("Y") .. ";" -- Y
-				.. core.formspec_escape(v3f[2] or "") .. "]"
+				.. minetest.formspec_escape(v3f[2] or "") .. "]"
 				.. "field[6.9," .. height .. ";3.3,1;te_z;"
 				.. fgettext("Z") .. ";" -- Z
-				.. core.formspec_escape(v3f[3] or "") .. "]"
+				.. minetest.formspec_escape(v3f[3] or "") .. "]"
 		height = height + 1.1
 
 	elseif setting.type == "flags" then
@@ -717,7 +717,7 @@ local function create_change_setting_formspec(dialogdata)
 			text = dialogdata.entered_text
 		end
 		formspec = "field[0.28," .. height + 0.15 .. ";" .. width .. ",1;te_setting_value;;"
-				.. core.formspec_escape(text) .. "]"
+				.. minetest.formspec_escape(text) .. "]"
 		height = height + 1.15
 	end
 
@@ -732,7 +732,7 @@ local function create_change_setting_formspec(dialogdata)
 		return ("box[%f,%f;%f,%f;%s]textarea[%f,%f;%f,%f;;%s;%s]"):format(
 			size.x, size.y, size.w, size.h, bg_color or "#000",
 			textarea.x, textarea.y, textarea.w, textarea.h,
-			core.formspec_escape(label), core.formspec_escape(text)
+			minetest.formspec_escape(label), minetest.formspec_escape(text)
 		)
 
 	end
@@ -788,55 +788,55 @@ local function handle_change_setting_buttons(this, fields)
 		if setting.type == "bool" then
 			local new_value = fields["dd_setting_value"]
 			-- Note: new_value is the actual (translated) value shown in the dropdown
-			core.settings:set_bool(setting.name, new_value == fgettext("Enabled"))
+			minetest.settings:set_bool(setting.name, new_value == fgettext("Enabled"))
 
 		elseif setting.type == "enum" then
 			local new_value = fields["dd_setting_value"]
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 
 		elseif setting.type == "int" then
 			local new_value = tonumber(fields["te_setting_value"])
 			if not new_value or math.floor(new_value) ~= new_value then
 				this.data.error_message = fgettext_ne("Please enter a valid integer.")
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
 			if setting.min and new_value < setting.min then
 				this.data.error_message = fgettext_ne("The value must be at least $1.", setting.min)
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
 			if setting.max and new_value > setting.max then
 				this.data.error_message = fgettext_ne("The value must not be larger than $1.", setting.max)
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 
 		elseif setting.type == "float" then
 			local new_value = tonumber(fields["te_setting_value"])
 			if not new_value then
 				this.data.error_message = fgettext_ne("Please enter a valid number.")
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
 			if setting.min and new_value < setting.min then
 				this.data.error_message = fgettext_ne("The value must be at least $1.", setting.min)
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
 			if setting.max and new_value > setting.max then
 				this.data.error_message = fgettext_ne("The value must not be larger than $1.", setting.max)
 				this.data.entered_text = fields["te_setting_value"]
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 
 		elseif setting.type == "flags" then
 			local values = {}
@@ -853,7 +853,7 @@ local function handle_change_setting_buttons(this, fields)
 			checkboxes = {}
 
 			local new_value = table.concat(values, ", ")
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 
 		elseif setting.type == "noise_params_2d" or setting.type == "noise_params_3d" then
 			local np_flags = {}
@@ -882,20 +882,20 @@ local function handle_change_setting_buttons(this, fields)
 				lacunarity = fields["te_lacun"],
 				flags = table.concat(np_flags, ", ")
 			}
-			core.settings:set_np_group(setting.name, new_value)
+			minetest.settings:set_np_group(setting.name, new_value)
 
 		elseif setting.type == "v3f" then
 			local new_value = "("
 					.. fields["te_x"] .. ", "
 					.. fields["te_y"] .. ", "
 					.. fields["te_z"] .. ")"
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 
 		else
 			local new_value = fields["te_setting_value"]
-			core.settings:set(setting.name, new_value)
+			minetest.settings:set(setting.name, new_value)
 		end
-		core.settings:write()
+		minetest.settings:write()
 		this:delete()
 		return true
 	end
@@ -906,18 +906,18 @@ local function handle_change_setting_buttons(this, fields)
 	end
 
 	if fields["btn_browser_path"] then
-		core.show_path_select_dialog("dlg_browse_path",
+		minetest.show_path_select_dialog("dlg_browse_path",
 			fgettext_ne("Select directory"), false)
 	end
 
 	if fields["btn_browser_filepath"] then
-		core.show_path_select_dialog("dlg_browse_path",
+		minetest.show_path_select_dialog("dlg_browse_path",
 			fgettext_ne("Select file"), true)
 	end
 
 	if fields["dlg_browse_path_accepted"] then
 		this.data.selected_path = fields["dlg_browse_path_accepted"]
-		core.update_formspec(this:get_formspec())
+		minetest.update_formspec(this:get_formspec())
 	end
 
 	if setting.type == "flags"
@@ -937,7 +937,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 	local formspec = "size[12,5.4;true]" ..
 			"tablecolumns[color;tree;text,width=28;text]" ..
 			"tableoptions[background=#00000000;border=false]" ..
-			"field[0.3,0.1;10.2,1;search_string;;" .. core.formspec_escape(search_string) .. "]" ..
+			"field[0.3,0.1;10.2,1;search_string;;" .. minetest.formspec_escape(search_string) .. "]" ..
 			"field_close_on_enter[search_string;false]" ..
 			"button[10.2,-0.2;2,1;search;" .. fgettext("Search") .. "]" ..
 			"table[0,0.8;12,3.5;list_settings;"
@@ -945,7 +945,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 	local current_level = 0
 	for _, entry in ipairs(settings) do
 		local name
-		if not core.settings:get_bool("main_menu_technical_settings") and entry.readable_name then
+		if not minetest.settings:get_bool("main_menu_technical_settings") and entry.readable_name then
 			name = fgettext_ne(entry.readable_name)
 		else
 			name = entry.name
@@ -957,24 +957,24 @@ local function create_settings_formspec(tabview, _, tabdata)
 
 		elseif entry.type == "bool" then
 			local value = get_current_value(entry)
-			if core.is_yes(value) then
+			if minetest.is_yes(value) then
 				value = fgettext("Enabled")
 			else
 				value = fgettext("Disabled")
 			end
-			formspec = formspec .. "," .. (current_level + 1) .. "," .. core.formspec_escape(name) .. ","
+			formspec = formspec .. "," .. (current_level + 1) .. "," .. minetest.formspec_escape(name) .. ","
 					.. value .. ","
 
 		elseif entry.type == "key" then --luacheck: ignore
 			-- ignore key settings, since we have a special dialog for them
 
 		elseif entry.type == "noise_params_2d" or entry.type == "noise_params_3d" then
-			formspec = formspec .. "," .. (current_level + 1) .. "," .. core.formspec_escape(name) .. ","
-					.. core.formspec_escape(get_current_np_group_as_string(entry)) .. ","
+			formspec = formspec .. "," .. (current_level + 1) .. "," .. minetest.formspec_escape(name) .. ","
+					.. minetest.formspec_escape(get_current_np_group_as_string(entry)) .. ","
 
 		else
-			formspec = formspec .. "," .. (current_level + 1) .. "," .. core.formspec_escape(name) .. ","
-					.. core.formspec_escape(get_current_value(entry)) .. ","
+			formspec = formspec .. "," .. (current_level + 1) .. "," .. minetest.formspec_escape(name) .. ","
+					.. minetest.formspec_escape(get_current_value(entry)) .. ","
 		end
 	end
 
@@ -986,7 +986,7 @@ local function create_settings_formspec(tabview, _, tabdata)
 			"button[10,4.9;2,1;btn_edit;" .. fgettext("Edit") .. "]" ..
 			"button[7,4.9;3,1;btn_restore;" .. fgettext("Restore Default") .. "]" ..
 			"checkbox[0,4.3;cb_tech_settings;" .. fgettext("Show technical names") .. ";"
-					.. dump(core.settings:get_bool("main_menu_technical_settings")) .. "]"
+					.. dump(minetest.settings:get_bool("main_menu_technical_settings")) .. "]"
 
 	return formspec
 end
@@ -994,14 +994,14 @@ end
 local function handle_settings_buttons(this, fields, tabname, tabdata)
 	local list_enter = false
 	if fields["list_settings"] then
-		selected_setting = core.get_table_index("list_settings")
-		if core.explode_table_event(fields["list_settings"]).type == "DCL" then
+		selected_setting = minetest.get_table_index("list_settings")
+		if minetest.explode_table_event(fields["list_settings"]).type == "DCL" then
 			-- Directly toggle booleans
 			local setting = settings[selected_setting]
 			if setting and setting.type == "bool" then
 				local current_value = get_current_value(setting)
-				core.settings:set_bool(setting.name, not core.is_yes(current_value))
-				core.settings:write()
+				minetest.settings:set_bool(setting.name, not minetest.is_yes(current_value))
+				minetest.settings:write()
 				return true
 			else
 				list_enter = true
@@ -1029,14 +1029,14 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 					end
 				end
 				selected_setting = i
-				core.update_formspec(this:get_formspec())
+				minetest.update_formspec(this:get_formspec())
 				return true
 			end
 		else
 			-- Search for setting
 			search_string = fields.search_string
 			settings, selected_setting = filter_settings(full_settings, search_string)
-			core.update_formspec(this:get_formspec())
+			minetest.update_formspec(this:get_formspec())
 		end
 		return true
 	end
@@ -1056,9 +1056,9 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	if fields["btn_restore"] then
 		local setting = settings[selected_setting]
 		if setting and setting.type ~= "category" then
-			core.settings:remove(setting.name)
-			core.settings:write()
-			core.update_formspec(this:get_formspec())
+			minetest.settings:remove(setting.name)
+			minetest.settings:write()
+			minetest.update_formspec(this:get_formspec())
 		end
 		return true
 	end
@@ -1069,9 +1069,9 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 	end
 
 	if fields["cb_tech_settings"] then
-		core.settings:set("main_menu_technical_settings", fields["cb_tech_settings"])
-		core.settings:write()
-		core.update_formspec(this:get_formspec())
+		minetest.settings:set("main_menu_technical_settings", fields["cb_tech_settings"])
+		minetest.settings:write()
+		minetest.update_formspec(this:get_formspec())
 		return true
 	end
 
@@ -1091,5 +1091,5 @@ end
 -- For RUN_IN_PLACE the generated files may appear in the 'bin' folder.
 -- See comment and alternative line at the end of 'generate_from_settingtypes.lua'.
 
---assert(loadfile(core.get_builtin_path().."mainmenu"..DIR_DELIM..
+--assert(loadfile(minetest.get_builtin_path().."mainmenu"..DIR_DELIM..
 --		"generate_from_settingtypes.lua"))(parse_config_file(true, false))

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -22,10 +22,10 @@ mt_color_dark_green = "#25C191"
 
 --for all other colors ask sfan5 to complete his work!
 
-local menupath = core.get_mainmenu_path()
-local basepath = core.get_builtin_path()
-local menustyle = core.settings:get("main_menu_style")
-defaulttexturedir = core.get_texturepath_share() .. DIR_DELIM .. "base" ..
+local menupath = minetest.get_mainmenu_path()
+local basepath = minetest.get_builtin_path()
+local menustyle = minetest.settings:get("main_menu_style")
+defaulttexturedir = minetest.get_texturepath_share() .. DIR_DELIM .. "base" ..
 					DIR_DELIM .. "pack" .. DIR_DELIM
 
 dofile(basepath .. "common" .. DIR_DELIM .. "async_event.lua")
@@ -63,7 +63,7 @@ end
 --------------------------------------------------------------------------------
 local function main_event_handler(tabview, event)
 	if event == "MenuQuit" then
-		core.close()
+		minetest.close()
 	end
 	return true
 end
@@ -74,7 +74,7 @@ local function init_globals()
 	gamedata.worldindex = 0
 
 	if menustyle == "simple" then
-		local world_list = core.get_worlds()
+		local world_list = minetest.get_worlds()
 		local world_index
 
 		local found_singleplayerworld = false
@@ -87,9 +87,9 @@ local function init_globals()
 		end
 
 		if not found_singleplayerworld then
-			core.create_world("singleplayerworld", 1)
+			minetest.create_world("singleplayerworld", 1)
 
-			world_list = core.get_worlds()
+			world_list = minetest.get_worlds()
 
 			for i, world in ipairs(world_list) do
 				if world.name == "singleplayerworld" then
@@ -102,7 +102,7 @@ local function init_globals()
 		gamedata.worldindex = world_index
 	else
 		menudata.worldlist = filterlist.create(
-			core.get_worlds,
+			minetest.get_worlds,
 			compare_worlds,
 			-- Unique id comparison function
 			function(element, uid)
@@ -117,9 +117,9 @@ local function init_globals()
 		menudata.worldlist:add_sort_mechanism("alphabetic", sort_worlds_alphabetic)
 		menudata.worldlist:set_sortmode("alphabetic")
 
-		if not core.settings:get("menu_last_game") then
-			local default_game = core.settings:get("default_game") or "minetest"
-			core.settings:set("menu_last_game", default_game)
+		if not minetest.settings:get("menu_last_game") then
+			local default_game = minetest.settings:get("default_game") or "minetest"
+			minetest.settings:set("menu_last_game", default_game)
 		end
 
 		mm_texture.init()
@@ -144,7 +144,7 @@ local function init_globals()
 	tv_main:set_fixed_size(false)
 
 	if menustyle ~= "simple" then
-		local last_tab = core.settings:get("maintab_LAST")
+		local last_tab = minetest.settings:get("maintab_LAST")
 		if last_tab and tv_main.current_tab ~= last_tab then
 			tv_main:set_tab(last_tab)
 		end
@@ -154,7 +154,7 @@ local function init_globals()
 
 	ui.update()
 
-	core.sound_play("main_menu", true)
+	minetest.sound_play("main_menu", true)
 end
 
 init_globals()

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -17,7 +17,7 @@
 
 --------------------------------------------------------------------------------
 function get_mods(path,retval,modpack)
-	local mods = core.get_dir_list(path, true)
+	local mods = minetest.get_dir_list(path, true)
 
 	for _, name in ipairs(mods) do
 		if name:sub(1, 1) ~= "." then
@@ -79,11 +79,11 @@ end
 pkgmgr = {}
 
 function pkgmgr.get_texture_packs()
-	local txtpath = core.get_texturepath()
-	local list = core.get_dir_list(txtpath, true)
+	local txtpath = minetest.get_texturepath()
+	local list = minetest.get_dir_list(txtpath, true)
 	local retval = {}
 
-	local current_texture_path = core.settings:get("texture_path")
+	local current_texture_path = minetest.settings:get("texture_path")
 
 	for _, item in ipairs(list) do
 		if item ~= "base" then
@@ -122,8 +122,8 @@ function pkgmgr.extract(modfile)
 
 		if tempfolder ~= nil and
 			tempfolder ~= "" then
-			core.create_dir(tempfolder)
-			if core.extract_zip(modfile.name,tempfolder) then
+			minetest.create_dir(tempfolder)
+			if minetest.extract_zip(modfile.name,tempfolder) then
 				return tempfolder
 			end
 		end
@@ -176,7 +176,7 @@ function pkgmgr.get_base_folder(temppath)
 		return ret
 	end
 
-	local subdirs = core.get_dir_list(temppath, true)
+	local subdirs = minetest.get_dir_list(temppath, true)
 	if #subdirs == 1 then
 		ret = pkgmgr.get_folder_type(temppath .. DIR_DELIM .. subdirs[1])
 		if ret then
@@ -320,7 +320,7 @@ function pkgmgr.render_packagelist(render_list)
 		else
 			retval[#retval + 1] = "0"
 		end
-		retval[#retval + 1] = core.formspec_escape(v.list_name or v.name)
+		retval[#retval + 1] = minetest.formspec_escape(v.list_name or v.name)
 	end
 
 	return table.concat(retval, ",")
@@ -332,7 +332,7 @@ function pkgmgr.get_dependencies(path)
 		return {}, {}
 	end
 
-	local info = core.get_content_info(path)
+	local info = minetest.get_content_info(path)
 	return info.depends or {}, info.optional_depends or {}
 end
 
@@ -500,12 +500,12 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 
 		local from = basefolder and basefolder.path or path
 		if targetpath then
-			core.delete_dir(targetpath)
-			core.create_dir(targetpath)
+			minetest.delete_dir(targetpath)
+			minetest.create_dir(targetpath)
 		else
-			targetpath = core.get_texturepath() .. DIR_DELIM .. basename
+			targetpath = minetest.get_texturepath() .. DIR_DELIM .. basename
 		end
-		if not core.copy_dir(from, targetpath) then
+		if not minetest.copy_dir(from, targetpath) then
 			return nil,
 				fgettext("Failed to install $1 to $2", basename, targetpath)
 		end
@@ -525,8 +525,8 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 
 		-- Get destination name for modpack
 		if targetpath then
-			core.delete_dir(targetpath)
-			core.create_dir(targetpath)
+			minetest.delete_dir(targetpath)
+			minetest.create_dir(targetpath)
 		else
 			local clean_path = nil
 			if basename ~= nil then
@@ -536,7 +536,7 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 				clean_path = get_last_folder(cleanup_path(basefolder.path))
 			end
 			if clean_path then
-				targetpath = core.get_modpath() .. DIR_DELIM .. clean_path
+				targetpath = minetest.get_modpath() .. DIR_DELIM .. clean_path
 			else
 				return nil,
 					fgettext("Install Mod: Unable to find suitable folder name for modpack $1",
@@ -549,8 +549,8 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 		end
 
 		if targetpath then
-			core.delete_dir(targetpath)
-			core.create_dir(targetpath)
+			minetest.delete_dir(targetpath)
+			minetest.create_dir(targetpath)
 		else
 			local targetfolder = basename
 			if targetfolder == nil then
@@ -563,7 +563,7 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 			end
 
 			if targetfolder ~= nil and pkgmgr.isValidModname(targetfolder) then
-				targetpath = core.get_modpath() .. DIR_DELIM .. targetfolder
+				targetpath = minetest.get_modpath() .. DIR_DELIM .. targetfolder
 			else
 				return nil, fgettext("Install Mod: Unable to find real mod name for: $1", path)
 			end
@@ -575,15 +575,15 @@ function pkgmgr.install_dir(type, path, basename, targetpath)
 		end
 
 		if targetpath then
-			core.delete_dir(targetpath)
-			core.create_dir(targetpath)
+			minetest.delete_dir(targetpath)
+			minetest.create_dir(targetpath)
 		else
-			targetpath = core.get_gamepath() .. DIR_DELIM .. basename
+			targetpath = minetest.get_gamepath() .. DIR_DELIM .. basename
 		end
 	end
 
 	-- Copy it
-	if not core.copy_dir(basefolder.path, targetpath) then
+	if not minetest.copy_dir(basefolder.path, targetpath) then
 		return nil,
 			fgettext("Failed to install $1 to $2", basename, targetpath)
 	end
@@ -610,7 +610,7 @@ function pkgmgr.install(type, modfilename, basename, dest)
 	end
 
 	local targetpath, msg = pkgmgr.install_dir(type, path, basename, dest)
-	core.delete_dir(path)
+	minetest.delete_dir(path)
 	return targetpath, msg
 end
 
@@ -622,7 +622,7 @@ function pkgmgr.preparemodlist(data)
 	local game_mods = {}
 
 	--read global mods
-	local modpath = core.get_modpath()
+	local modpath = minetest.get_modpath()
 
 	if modpath ~= nil and
 		modpath ~= "" then
@@ -680,7 +680,7 @@ function pkgmgr.preparemodlist(data)
 			if element ~= nil then
 				element.enabled = value ~= "false" and value ~= "nil" and value
 			else
-				core.log("info", "Mod: " .. key .. " " .. dump(value) .. " but not found")
+				minetest.log("info", "Mod: " .. key .. " " .. dump(value) .. " but not found")
 			end
 		end
 	end
@@ -842,17 +842,17 @@ end
 
 --------------------------------------------------------------------------------
 function pkgmgr.update_gamelist()
-	pkgmgr.games = core.get_games()
+	pkgmgr.games = minetest.get_games()
 end
 
 --------------------------------------------------------------------------------
 function pkgmgr.gamelist()
 	local retval = ""
 	if #pkgmgr.games > 0 then
-		retval = retval .. core.formspec_escape(pkgmgr.games[1].name)
+		retval = retval .. minetest.formspec_escape(pkgmgr.games[1].name)
 
 		for i=2,#pkgmgr.games,1 do
-			retval = retval .. "," .. core.formspec_escape(pkgmgr.games[i].name)
+			retval = retval .. "," .. minetest.formspec_escape(pkgmgr.games[i].name)
 		end
 	end
 	return retval

--- a/builtin/mainmenu/tab_content.lua
+++ b/builtin/mainmenu/tab_content.lua
@@ -81,15 +81,15 @@ local function get_formspec(tabview, name, tabdata)
 				modscreenshot = defaulttexturedir .. "no_screenshot.png"
 		end
 
-		local info = core.get_content_info(selected_pkg.path)
+		local info = minetest.get_content_info(selected_pkg.path)
 		local desc = fgettext("No package description available")
 		if info.description and info.description:trim() ~= "" then
 			desc = info.description
 		end
 
 		retval = retval ..
-				"image[5.5,0;3,2;" .. core.formspec_escape(modscreenshot) .. "]" ..
-				"label[8.25,0.6;" .. core.formspec_escape(selected_pkg.name) .. "]" ..
+				"image[5.5,0;3,2;" .. minetest.formspec_escape(modscreenshot) .. "]" ..
+				"label[8.25,0.6;" .. minetest.formspec_escape(selected_pkg.name) .. "]" ..
 				"box[5.5,2.2;6.15,2.35;#000]"
 
 		if selected_pkg.type == "mod" then
@@ -136,7 +136,7 @@ local function get_formspec(tabview, name, tabdata)
 		retval = retval .. "textarea[5.85,2.2;6.35,2.9;;" ..
 			fgettext("Information:") .. ";" .. desc .. "]"
 
-		if core.may_modify_path(selected_pkg.path) then
+		if minetest.may_modify_path(selected_pkg.path) then
 			retval = retval ..
 				"button[5.5,4.65;3.25,1;btn_mod_mgr_delete_mod;" ..
 				fgettext("Uninstall Package") .. "]"
@@ -148,7 +148,7 @@ end
 --------------------------------------------------------------------------------
 local function handle_buttons(tabview, fields, tabname, tabdata)
 	if fields["pkglist"] ~= nil then
-		local event = core.explode_table_event(fields["pkglist"])
+		local event = minetest.explode_table_event(fields["pkglist"])
 		tabdata.selected_pkg = event.row
 		return true
 	end
@@ -184,14 +184,14 @@ local function handle_buttons(tabview, fields, tabname, tabdata)
 
 	if fields.btn_mod_mgr_use_txp then
 		local txp = packages:get_list()[tabdata.selected_pkg]
-		core.settings:set("texture_path", txp.path)
+		minetest.settings:set("texture_path", txp.path)
 		packages = nil
 		return true
 	end
 
 
 	if fields.btn_mod_mgr_disable_txp then
-		core.settings:set("texture_path", "")
+		minetest.settings:set("texture_path", "")
 		packages = nil
 		return true
 	end

--- a/builtin/mainmenu/tab_credits.lua
+++ b/builtin/mainmenu/tab_credits.lua
@@ -102,7 +102,7 @@ local previous_contributors = {
 local function buildCreditList(source)
 	local ret = {}
 	for i = 1, #source do
-		ret[i] = core.formspec_escape(source[i])
+		ret[i] = minetest.formspec_escape(source[i])
 	end
 	return table.concat(ret, ",,")
 end
@@ -112,8 +112,8 @@ return {
 	caption = fgettext("Credits"),
 	cbf_formspec = function(tabview, name, tabdata)
 		local logofile = defaulttexturedir .. "logo.png"
-		local version = core.get_version()
-		return "image[0.5,1;" .. core.formspec_escape(logofile) .. "]" ..
+		local version = minetest.get_version()
+		return "image[0.5,1;" .. minetest.formspec_escape(logofile) .. "]" ..
 			"label[0.5,3.2;" .. version.project .. " " .. version.string .. "]" ..
 			"label[0.5,3.5;http://minetest.net]" ..
 			"tablecolumns[color;text]" ..

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -20,7 +20,7 @@ local enable_gamebar = PLATFORM ~= "Android"
 local current_game, singleplayer_refresh_gamebar
 if enable_gamebar then
 	function current_game()
-		local last_game_id = core.settings:get("menu_last_game")
+		local last_game_id = minetest.settings:get("menu_last_game")
 		local game = pkgmgr.find_by_gameid(last_game_id)
 
 		return game
@@ -39,13 +39,13 @@ if enable_gamebar then
 				for j=1,#pkgmgr.games,1 do
 					if ("game_btnbar_" .. pkgmgr.games[j].id == key) then
 						mm_texture.update("singleplayer", pkgmgr.games[j])
-						core.set_topleft_text(pkgmgr.games[j].name)
-						core.settings:set("menu_last_game",pkgmgr.games[j].id)
+						minetest.set_topleft_text(pkgmgr.games[j].name)
+						minetest.settings:set("menu_last_game",pkgmgr.games[j].id)
 						menudata.worldlist:set_filtercriteria(pkgmgr.games[j].id)
 						local index = filterlist.get_current_index(menudata.worldlist,
-							tonumber(core.settings:get("mainmenu_last_selected_world")))
+							tonumber(minetest.settings:get("mainmenu_last_selected_world")))
 						if not index or index < 1 then
-							local selected = core.get_textlist_index("sp_worlds")
+							local selected = minetest.get_textlist_index("sp_worlds")
 							if selected ~= nil and selected < #menudata.worldlist:get_list() then
 								index = selected
 							else
@@ -68,11 +68,11 @@ if enable_gamebar then
 
 			local image = nil
 			local text = nil
-			local tooltip = core.formspec_escape(pkgmgr.games[i].name)
+			local tooltip = minetest.formspec_escape(pkgmgr.games[i].name)
 
 			if pkgmgr.games[i].menuicon_path ~= nil and
 				pkgmgr.games[i].menuicon_path ~= "" then
-				image = core.formspec_escape(pkgmgr.games[i].menuicon_path)
+				image = minetest.formspec_escape(pkgmgr.games[i].menuicon_path)
 			else
 
 				local part1 = pkgmgr.games[i].id:sub(1,5)
@@ -98,7 +98,7 @@ local function get_formspec(tabview, name, tabdata)
 	local retval = ""
 
 	local index = filterlist.get_current_index(menudata.worldlist,
-				tonumber(core.settings:get("mainmenu_last_selected_world"))
+				tonumber(minetest.settings:get("mainmenu_last_selected_world"))
 				)
 
 	retval = retval ..
@@ -107,36 +107,36 @@ local function get_formspec(tabview, name, tabdata)
 			"button[9.2,3.95;2.5,1;world_create;".. fgettext("New") .. "]" ..
 			"label[4,-0.25;".. fgettext("Select World:") .. "]"..
 			"checkbox[0.25,0.25;cb_creative_mode;".. fgettext("Creative Mode") .. ";" ..
-			dump(core.settings:get_bool("creative_mode")) .. "]"..
+			dump(minetest.settings:get_bool("creative_mode")) .. "]"..
 			"checkbox[0.25,0.7;cb_enable_damage;".. fgettext("Enable Damage") .. ";" ..
-			dump(core.settings:get_bool("enable_damage")) .. "]"..
+			dump(minetest.settings:get_bool("enable_damage")) .. "]"..
 			"checkbox[0.25,1.15;cb_server;".. fgettext("Host Server") ..";" ..
-			dump(core.settings:get_bool("enable_server")) .. "]" ..
+			dump(minetest.settings:get_bool("enable_server")) .. "]" ..
 			"textlist[4,0.25;7.5,3.7;sp_worlds;" ..
 			menu_render_worldlist() ..
 			";" .. index .. "]"
 
-	if core.settings:get_bool("enable_server") then
+	if minetest.settings:get_bool("enable_server") then
 		retval = retval ..
 				"button[8.5,4.8;3.2,1;play;".. fgettext("Host Game") .. "]" ..
 				"checkbox[0.25,1.6;cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
-				dump(core.settings:get_bool("server_announce")) .. "]" ..
+				dump(minetest.settings:get_bool("server_announce")) .. "]" ..
 				"label[0.25,2.2;" .. fgettext("Name/Password") .. "]" ..
 				"field[0.55,3.2;3.5,0.5;te_playername;;" ..
-				core.formspec_escape(core.settings:get("name")) .. "]" ..
+				minetest.formspec_escape(minetest.settings:get("name")) .. "]" ..
 				"pwdfield[0.55,4;3.5,0.5;te_passwd;]"
 
-		local bind_addr = core.settings:get("bind_address")
+		local bind_addr = minetest.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
 			retval = retval ..
 				"field[0.55,5.2;2.25,0.5;te_serveraddr;" .. fgettext("Bind Address") .. ";" ..
-				core.formspec_escape(core.settings:get("bind_address")) .. "]" ..
+				minetest.formspec_escape(minetest.settings:get("bind_address")) .. "]" ..
 				"field[2.8,5.2;1.25,0.5;te_serverport;" .. fgettext("Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				minetest.formspec_escape(minetest.settings:get("port")) .. "]"
 		else
 			retval = retval ..
 				"field[0.55,5.2;3.5,0.5;te_serverport;" .. fgettext("Server Port") .. ";" ..
-				core.formspec_escape(core.settings:get("port")) .. "]"
+				minetest.formspec_escape(minetest.settings:get("port")) .. "]"
 		end
 	else
 		retval = retval ..
@@ -153,8 +153,8 @@ local function main_button_handler(this, fields, name, tabdata)
 	local world_doubleclick = false
 
 	if fields["sp_worlds"] ~= nil then
-		local event = core.explode_textlist_event(fields["sp_worlds"])
-		local selected = core.get_textlist_index("sp_worlds")
+		local event = minetest.explode_textlist_event(fields["sp_worlds"])
+		local selected = minetest.get_textlist_index("sp_worlds")
 
 		menu_worldmt_legacy(selected)
 
@@ -163,7 +163,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		end
 
 		if event.type == "CHG" and selected ~= nil then
-			core.settings:set("mainmenu_last_selected_world",
+			minetest.settings:set("mainmenu_last_selected_world",
 				menudata.worldlist:get_raw_index(selected))
 			return true
 		end
@@ -174,59 +174,59 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["cb_creative_mode"] then
-		core.settings:set("creative_mode", fields["cb_creative_mode"])
-		local selected = core.get_textlist_index("sp_worlds")
+		minetest.settings:set("creative_mode", fields["cb_creative_mode"])
+		local selected = minetest.get_textlist_index("sp_worlds")
 		menu_worldmt(selected, "creative_mode", fields["cb_creative_mode"])
 
 		return true
 	end
 
 	if fields["cb_enable_damage"] then
-		core.settings:set("enable_damage", fields["cb_enable_damage"])
-		local selected = core.get_textlist_index("sp_worlds")
+		minetest.settings:set("enable_damage", fields["cb_enable_damage"])
+		local selected = minetest.get_textlist_index("sp_worlds")
 		menu_worldmt(selected, "enable_damage", fields["cb_enable_damage"])
 
 		return true
 	end
 
 	if fields["cb_server"] then
-		core.settings:set("enable_server", fields["cb_server"])
+		minetest.settings:set("enable_server", fields["cb_server"])
 
 		return true
 	end
 
 	if fields["cb_server_announce"] then
-		core.settings:set("server_announce", fields["cb_server_announce"])
-		local selected = core.get_textlist_index("srv_worlds")
+		minetest.settings:set("server_announce", fields["cb_server_announce"])
+		local selected = minetest.get_textlist_index("srv_worlds")
 		menu_worldmt(selected, "server_announce", fields["cb_server_announce"])
 
 		return true
 	end
 
 	if fields["play"] ~= nil or world_doubleclick or fields["key_enter"] then
-		local selected = core.get_textlist_index("sp_worlds")
+		local selected = minetest.get_textlist_index("sp_worlds")
 		gamedata.selected_world = menudata.worldlist:get_raw_index(selected)
 
-		if core.settings:get_bool("enable_server") then
+		if minetest.settings:get_bool("enable_server") then
 			if selected ~= nil and gamedata.selected_world ~= 0 then
 				gamedata.playername = fields["te_playername"]
 				gamedata.password   = fields["te_passwd"]
 				gamedata.port       = fields["te_serverport"]
 				gamedata.address    = ""
 
-				core.settings:set("port",gamedata.port)
+				minetest.settings:set("port",gamedata.port)
 				if fields["te_serveraddr"] ~= nil then
-					core.settings:set("bind_address",fields["te_serveraddr"])
+					minetest.settings:set("bind_address",fields["te_serveraddr"])
 				end
 
 				--update last game
 				local world = menudata.worldlist:get_raw_element(gamedata.selected_world)
 				if world then
 					local game = pkgmgr.find_by_gameid(world.gameid)
-					core.settings:set("menu_last_game", game.id)
+					minetest.settings:set("menu_last_game", game.id)
 				end
 
-				core.start()
+				minetest.start()
 			else
 				gamedata.errormessage =
 					fgettext("No world created or selected!")
@@ -234,7 +234,7 @@ local function main_button_handler(this, fields, name, tabdata)
 		else
 			if selected ~= nil and gamedata.selected_world ~= 0 then
 				gamedata.singleplayer = true
-				core.start()
+				minetest.start()
 			else
 				gamedata.errormessage =
 					fgettext("No world created or selected!")
@@ -253,7 +253,7 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["world_delete"] ~= nil then
-		local selected = core.get_textlist_index("sp_worlds")
+		local selected = minetest.get_textlist_index("sp_worlds")
 		if selected ~= nil and
 			selected <= menudata.worldlist:size() then
 			local world = menudata.worldlist:get_list()[selected]
@@ -273,7 +273,7 @@ local function main_button_handler(this, fields, name, tabdata)
 	end
 
 	if fields["world_configure"] ~= nil then
-		local selected = core.get_textlist_index("sp_worlds")
+		local selected = minetest.get_textlist_index("sp_worlds")
 		if selected ~= nil then
 			local configdialog =
 				create_configure_world_dlg(
@@ -299,7 +299,7 @@ if enable_gamebar then
 
 			if game then
 				menudata.worldlist:set_filtercriteria(game.id)
-				core.set_topleft_text(game.name)
+				minetest.set_topleft_text(game.name)
 				mm_texture.update("singleplayer",game)
 			end
 
@@ -311,7 +311,7 @@ if enable_gamebar then
 			if gamebar then
 				gamebar:hide()
 			end
-			core.set_topleft_text("")
+			minetest.set_topleft_text("")
 			mm_texture.update(new_tab,nil)
 		end
 	end

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -33,22 +33,22 @@ local function get_formspec(tabview, name, tabdata)
 
 	local retval =
 		-- Search
-		"field[0.15,0.075;5.91,1;te_search;;" .. core.formspec_escape(tabdata.search_for) .. "]" ..
+		"field[0.15,0.075;5.91,1;te_search;;" .. minetest.formspec_escape(tabdata.search_for) .. "]" ..
 		"button[5.62,-0.25;1.5,1;btn_mp_search;" .. fgettext("Search") .. "]" ..
-		"image_button[6.97,-.165;.83,.83;" .. core.formspec_escape(defaulttexturedir .. "refresh.png")
+		"image_button[6.97,-.165;.83,.83;" .. minetest.formspec_escape(defaulttexturedir .. "refresh.png")
 			.. ";btn_mp_refresh;]" ..
 
 		-- Address / Port
 		"label[7.75,-0.25;" .. fgettext("Address / Port") .. "]" ..
 		"field[8,0.65;3.25,0.5;te_address;;" ..
-			core.formspec_escape(core.settings:get("address")) .. "]" ..
+			minetest.formspec_escape(minetest.settings:get("address")) .. "]" ..
 		"field[11.1,0.65;1.4,0.5;te_port;;" ..
-			core.formspec_escape(core.settings:get("remote_port")) .. "]" ..
+			minetest.formspec_escape(minetest.settings:get("remote_port")) .. "]" ..
 
 		-- Name / Password
 		"label[7.75,0.95;" .. fgettext("Name / Password") .. "]" ..
 		"field[8,1.85;2.9,0.5;te_name;;" ..
-			core.formspec_escape(core.settings:get("name")) .. "]" ..
+			minetest.formspec_escape(minetest.settings:get("name")) .. "]" ..
 		"pwdfield[10.73,1.85;1.77,0.5;te_pwd;]" ..
 
 		-- Description Background
@@ -64,7 +64,7 @@ local function get_formspec(tabview, name, tabdata)
 		end
 		if fav_selected.description then
 			retval = retval .. "textarea[8.1,2.3;4.23,2.9;;;" ..
-				core.formspec_escape((gamedata.serverdescription or ""), true) .. "]"
+				minetest.formspec_escape((gamedata.serverdescription or ""), true) .. "]"
 		end
 	end
 
@@ -85,7 +85,7 @@ local function get_formspec(tabview, name, tabdata)
 
 	if menudata.search_result then
 		for i = 1, #menudata.search_result do
-			local favs = core.get_favorites("local")
+			local favs = minetest.get_favorites("local")
 			local server = menudata.search_result[i]
 
 			for fav_id = 1, #favs do
@@ -102,7 +102,7 @@ local function get_formspec(tabview, name, tabdata)
 			retval = retval .. render_serverlist_row(server, server.is_favorite)
 		end
 	elseif #menudata.favorites > 0 then
-		local favs = core.get_favorites("local")
+		local favs = minetest.get_favorites("local")
 		if #favs > 0 then
 			for i = 1, #favs do
 			for j = 1, #menudata.favorites do
@@ -137,11 +137,11 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 	if fields.te_name then
 		gamedata.playername = fields.te_name
-		core.settings:set("name", fields.te_name)
+		minetest.settings:set("name", fields.te_name)
 	end
 
 	if fields.favourites then
-		local event = core.explode_table_event(fields.favourites)
+		local event = minetest.explode_table_event(fields.favourites)
 		local fav = serverlist[event.row]
 
 		if event.type == "DCL" then
@@ -165,9 +165,9 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				gamedata.serverdescription = fav.description
 
 				if gamedata.address and gamedata.port then
-					core.settings:set("address", gamedata.address)
-					core.settings:set("remote_port", gamedata.port)
-					core.start()
+					minetest.settings:set("address", gamedata.address)
+					minetest.settings:set("remote_port", gamedata.port)
+					minetest.start()
 				end
 			end
 			return true
@@ -176,7 +176,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		if event.type == "CHG" then
 			if event.row <= #serverlist then
 				gamedata.fav = false
-				local favs = core.get_favorites("local")
+				local favs = minetest.get_favorites("local")
 				local address = fav.address
 				local port    = fav.port
 				gamedata.serverdescription = fav.description
@@ -189,8 +189,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				end
 
 				if address and port then
-					core.settings:set("address", address)
-					core.settings:set("remote_port", port)
+					minetest.settings:set("address", address)
+					minetest.settings:set("remote_port", port)
 				end
 				tabdata.fav_selected = event.row
 			end
@@ -199,7 +199,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	end
 
 	if fields.key_up or fields.key_down then
-		local fav_idx = core.get_table_index("favourites")
+		local fav_idx = minetest.get_table_index("favourites")
 		local fav = serverlist[fav_idx]
 
 		if fav_idx then
@@ -221,8 +221,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		local port    = fav.port
 		gamedata.serverdescription = fav.description
 		if address and port then
-			core.settings:set("address", address)
-			core.settings:set("remote_port", port)
+			minetest.settings:set("address", address)
+			minetest.settings:set("remote_port", port)
 		end
 
 		tabdata.fav_selected = fav_idx
@@ -230,15 +230,15 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	end
 
 	if fields.btn_delete_favorite then
-		local current_favourite = core.get_table_index("favourites")
+		local current_favourite = minetest.get_table_index("favourites")
 		if not current_favourite then return end
 
-		core.delete_favorite(current_favourite)
+		minetest.delete_favorite(current_favourite)
 		asyncOnlineFavourites()
 		tabdata.fav_selected = nil
 
-		core.settings:set("address", "")
-		core.settings:set("remote_port", "30000")
+		minetest.settings:set("address", "")
+		minetest.settings:set("remote_port", "30000")
 		return true
 	end
 
@@ -296,8 +296,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			end)
 			menudata.search_result = search_result
 			local first_server = search_result[1]
-			core.settings:set("address",     first_server.address)
-			core.settings:set("remote_port", first_server.port)
+			minetest.settings:set("address",     first_server.address)
+			minetest.settings:set("remote_port", first_server.port)
 			gamedata.serverdescription = first_server.description
 		end
 		return true
@@ -315,7 +315,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		gamedata.address    = fields.te_address
 		gamedata.port       = fields.te_port
 		gamedata.selected_world = 0
-		local fav_idx = core.get_table_index("favourites")
+		local fav_idx = minetest.get_table_index("favourites")
 		local fav = serverlist[fav_idx]
 
 		if fav_idx and fav_idx <= #serverlist and
@@ -335,10 +335,10 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			gamedata.serverdescription = ""
 		end
 
-		core.settings:set("address",     fields.te_address)
-		core.settings:set("remote_port", fields.te_port)
+		minetest.settings:set("address",     fields.te_address)
+		minetest.settings:set("remote_port", fields.te_port)
 
-		core.start()
+		minetest.start()
 		return true
 	end
 	return false

--- a/builtin/mainmenu/tab_settings.lua
+++ b/builtin/mainmenu/tab_settings.lua
@@ -71,39 +71,39 @@ local dd_options = {
 
 local getSettingIndex = {
 	Leaves = function()
-		local style = core.settings:get("leaves_style")
+		local style = minetest.settings:get("leaves_style")
 		for idx, name in pairs(dd_options.leaves[2]) do
 			if style == name then return idx end
 		end
 		return 1
 	end,
 	NodeHighlighting = function()
-		local style = core.settings:get("node_highlighting")
+		local style = minetest.settings:get("node_highlighting")
 		for idx, name in pairs(dd_options.node_highlighting[2]) do
 			if style == name then return idx end
 		end
 		return 1
 	end,
 	Filter = function()
-		if core.settings:get(dd_options.filters[2][3]) == "true" then
+		if minetest.settings:get(dd_options.filters[2][3]) == "true" then
 			return 3
-		elseif core.settings:get(dd_options.filters[2][3]) == "false" and
-				core.settings:get(dd_options.filters[2][2]) == "true" then
+		elseif minetest.settings:get(dd_options.filters[2][3]) == "false" and
+				minetest.settings:get(dd_options.filters[2][2]) == "true" then
 			return 2
 		end
 		return 1
 	end,
 	Mipmap = function()
-		if core.settings:get(dd_options.mipmap[2][3]) == "true" then
+		if minetest.settings:get(dd_options.mipmap[2][3]) == "true" then
 			return 3
-		elseif core.settings:get(dd_options.mipmap[2][3]) == "false" and
-				core.settings:get(dd_options.mipmap[2][2]) == "true" then
+		elseif minetest.settings:get(dd_options.mipmap[2][3]) == "false" and
+				minetest.settings:get(dd_options.mipmap[2][2]) == "true" then
 			return 2
 		end
 		return 1
 	end,
 	Antialiasing = function()
-		local antialiasing_setting = core.settings:get("fsaa")
+		local antialiasing_setting = minetest.settings:get("fsaa")
 		for i = 1, #dd_options.antialiasing[2] do
 			if antialiasing_setting == dd_options.antialiasing[2][i] then
 				return i
@@ -132,7 +132,7 @@ end
 local function dlg_confirm_reset_btnhandler(this, fields, dialogdata)
 
 	if fields["dlg_reset_singleplayer_confirm"] ~= nil then
-		local worldlist = core.get_worlds()
+		local worldlist = minetest.get_worlds()
 		local found_singleplayerworld = false
 
 		for i = 1, #worldlist do
@@ -143,11 +143,11 @@ local function dlg_confirm_reset_btnhandler(this, fields, dialogdata)
 		end
 
 		if found_singleplayerworld then
-			core.delete_world(gamedata.worldindex)
+			minetest.delete_world(gamedata.worldindex)
 		end
 
-		core.create_world("singleplayerworld", 1)
-		worldlist = core.get_worlds()
+		minetest.create_world("singleplayerworld", 1)
+		worldlist = minetest.get_worlds()
 
 		for i = 1, #worldlist do
 			if worldlist[i].name == "singleplayerworld" then
@@ -176,15 +176,15 @@ local function formspec(tabview, name, tabdata)
 	local tab_string =
 		"box[0,0;3.75,4.5;#999999]" ..
 		"checkbox[0.25,0;cb_smooth_lighting;" .. fgettext("Smooth Lighting") .. ";"
-				.. dump(core.settings:get_bool("smooth_lighting")) .. "]" ..
+				.. dump(minetest.settings:get_bool("smooth_lighting")) .. "]" ..
 		"checkbox[0.25,0.5;cb_particles;" .. fgettext("Particles") .. ";"
-				.. dump(core.settings:get_bool("enable_particles")) .. "]" ..
+				.. dump(minetest.settings:get_bool("enable_particles")) .. "]" ..
 		"checkbox[0.25,1;cb_3d_clouds;" .. fgettext("3D Clouds") .. ";"
-				.. dump(core.settings:get_bool("enable_3d_clouds")) .. "]" ..
+				.. dump(minetest.settings:get_bool("enable_3d_clouds")) .. "]" ..
 		"checkbox[0.25,1.5;cb_opaque_water;" .. fgettext("Opaque Water") .. ";"
-				.. dump(core.settings:get_bool("opaque_water")) .. "]" ..
+				.. dump(minetest.settings:get_bool("opaque_water")) .. "]" ..
 		"checkbox[0.25,2.0;cb_connected_glass;" .. fgettext("Connected Glass") .. ";"
-				.. dump(core.settings:get_bool("connected_glass")) .. "]" ..
+				.. dump(minetest.settings:get_bool("connected_glass")) .. "]" ..
 		"dropdown[0.25,2.8;3.5;dd_node_highlighting;" .. dd_options.node_highlighting[1] .. ";"
 				.. getSettingIndex.NodeHighlighting() .. "]" ..
 		"dropdown[0.25,3.6;3.5;dd_leaves_style;" .. dd_options.leaves[1] .. ";"
@@ -200,25 +200,25 @@ local function formspec(tabview, name, tabdata)
 				.. getSettingIndex.Antialiasing() .. "]" ..
 		"label[4.25,3.45;" .. fgettext("Screen:") .. "]" ..
 		"checkbox[4.25,3.6;cb_autosave_screensize;" .. fgettext("Autosave Screen Size") .. ";"
-				.. dump(core.settings:get_bool("autosave_screensize")) .. "]" ..
+				.. dump(minetest.settings:get_bool("autosave_screensize")) .. "]" ..
 		"box[8,0;3.75,4.5;#999999]"
 
-	local video_driver = core.settings:get("video_driver")
+	local video_driver = minetest.settings:get("video_driver")
 	local shaders_supported = video_driver == "opengl"
 	local shaders_enabled = false
 	if shaders_supported then
-		shaders_enabled = core.settings:get_bool("enable_shaders")
+		shaders_enabled = minetest.settings:get_bool("enable_shaders")
 		tab_string = tab_string ..
 			"checkbox[8.25,0;cb_shaders;" .. fgettext("Shaders") .. ";"
 					.. tostring(shaders_enabled) .. "]"
 	else
-		core.settings:set_bool("enable_shaders", false)
+		minetest.settings:set_bool("enable_shaders", false)
 		tab_string = tab_string ..
-			"label[8.38,0.2;" .. core.colorize("#888888",
+			"label[8.38,0.2;" .. minetest.colorize("#888888",
 					fgettext("Shaders (unavailable)")) .. "]"
 	end
 
-	if core.settings:get("main_menu_style") == "simple" then
+	if minetest.settings:get("main_menu_style") == "simple" then
 		-- 'Reset singleplayer world' only functions with simple menu
 		tab_string = tab_string ..
 			"button[8,4.75;3.95,1;btn_reset_singleplayer;"
@@ -234,45 +234,45 @@ local function formspec(tabview, name, tabdata)
 		.. fgettext("All Settings") .. "]"
 
 
-	if core.settings:get("touchscreen_threshold") ~= nil then
+	if minetest.settings:get("touchscreen_threshold") ~= nil then
 		tab_string = tab_string ..
 			"label[4.3,4.2;" .. fgettext("Touchthreshold: (px)") .. "]" ..
 			"dropdown[4.25,4.65;3.5;dd_touchthreshold;0,10,20,30,40,50;" ..
-			((tonumber(core.settings:get("touchscreen_threshold")) / 10) + 1) ..
+			((tonumber(minetest.settings:get("touchscreen_threshold")) / 10) + 1) ..
 			"]box[4.0,4.5;3.75,1.0;#999999]"
 	end
 
 	if shaders_enabled then
 		tab_string = tab_string ..
 			"checkbox[8.25,0.5;cb_bumpmapping;" .. fgettext("Bump Mapping") .. ";"
-					.. dump(core.settings:get_bool("enable_bumpmapping")) .. "]" ..
+					.. dump(minetest.settings:get_bool("enable_bumpmapping")) .. "]" ..
 			"checkbox[8.25,1;cb_tonemapping;" .. fgettext("Tone Mapping") .. ";"
-					.. dump(core.settings:get_bool("tone_mapping")) .. "]" ..
+					.. dump(minetest.settings:get_bool("tone_mapping")) .. "]" ..
 			"checkbox[8.25,1.5;cb_generate_normalmaps;" .. fgettext("Generate Normal Maps") .. ";"
-					.. dump(core.settings:get_bool("generate_normalmaps")) .. "]" ..
+					.. dump(minetest.settings:get_bool("generate_normalmaps")) .. "]" ..
 			"checkbox[8.25,2;cb_parallax;" .. fgettext("Parallax Occlusion") .. ";"
-					.. dump(core.settings:get_bool("enable_parallax_occlusion")) .. "]" ..
+					.. dump(minetest.settings:get_bool("enable_parallax_occlusion")) .. "]" ..
 			"checkbox[8.25,2.5;cb_waving_water;" .. fgettext("Waving Liquids") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_water")) .. "]" ..
+					.. dump(minetest.settings:get_bool("enable_waving_water")) .. "]" ..
 			"checkbox[8.25,3;cb_waving_leaves;" .. fgettext("Waving Leaves") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_leaves")) .. "]" ..
+					.. dump(minetest.settings:get_bool("enable_waving_leaves")) .. "]" ..
 			"checkbox[8.25,3.5;cb_waving_plants;" .. fgettext("Waving Plants") .. ";"
-					.. dump(core.settings:get_bool("enable_waving_plants")) .. "]"
+					.. dump(minetest.settings:get_bool("enable_waving_plants")) .. "]"
 	else
 		tab_string = tab_string ..
-			"label[8.38,0.7;" .. core.colorize("#888888",
+			"label[8.38,0.7;" .. minetest.colorize("#888888",
 					fgettext("Bump Mapping")) .. "]" ..
-			"label[8.38,1.2;" .. core.colorize("#888888",
+			"label[8.38,1.2;" .. minetest.colorize("#888888",
 					fgettext("Tone Mapping")) .. "]" ..
-			"label[8.38,1.7;" .. core.colorize("#888888",
+			"label[8.38,1.7;" .. minetest.colorize("#888888",
 					fgettext("Generate Normal Maps")) .. "]" ..
-			"label[8.38,2.2;" .. core.colorize("#888888",
+			"label[8.38,2.2;" .. minetest.colorize("#888888",
 					fgettext("Parallax Occlusion")) .. "]" ..
-			"label[8.38,2.7;" .. core.colorize("#888888",
+			"label[8.38,2.7;" .. minetest.colorize("#888888",
 					fgettext("Waving Liquids")) .. "]" ..
-			"label[8.38,3.2;" .. core.colorize("#888888",
+			"label[8.38,3.2;" .. minetest.colorize("#888888",
 					fgettext("Waving Leaves")) .. "]" ..
-			"label[8.38,3.7;" .. core.colorize("#888888",
+			"label[8.38,3.7;" .. minetest.colorize("#888888",
 					fgettext("Waving Plants")) .. "]"
 	end
 
@@ -291,72 +291,72 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 		return true
 	end
 	if fields["cb_smooth_lighting"] then
-		core.settings:set("smooth_lighting", fields["cb_smooth_lighting"])
+		minetest.settings:set("smooth_lighting", fields["cb_smooth_lighting"])
 		return true
 	end
 	if fields["cb_particles"] then
-		core.settings:set("enable_particles", fields["cb_particles"])
+		minetest.settings:set("enable_particles", fields["cb_particles"])
 		return true
 	end
 	if fields["cb_3d_clouds"] then
-		core.settings:set("enable_3d_clouds", fields["cb_3d_clouds"])
+		minetest.settings:set("enable_3d_clouds", fields["cb_3d_clouds"])
 		return true
 	end
 	if fields["cb_opaque_water"] then
-		core.settings:set("opaque_water", fields["cb_opaque_water"])
+		minetest.settings:set("opaque_water", fields["cb_opaque_water"])
 		return true
 	end
 	if fields["cb_connected_glass"] then
-		core.settings:set("connected_glass", fields["cb_connected_glass"])
+		minetest.settings:set("connected_glass", fields["cb_connected_glass"])
 		return true
 	end
 	if fields["cb_autosave_screensize"] then
-		core.settings:set("autosave_screensize", fields["cb_autosave_screensize"])
+		minetest.settings:set("autosave_screensize", fields["cb_autosave_screensize"])
 		return true
 	end
 	if fields["cb_shaders"] then
-		if (core.settings:get("video_driver") == "direct3d8" or
-				core.settings:get("video_driver") == "direct3d9") then
-			core.settings:set("enable_shaders", "false")
+		if (minetest.settings:get("video_driver") == "direct3d8" or
+				minetest.settings:get("video_driver") == "direct3d9") then
+			minetest.settings:set("enable_shaders", "false")
 			gamedata.errormessage = fgettext("To enable shaders the OpenGL driver needs to be used.")
 		else
-			core.settings:set("enable_shaders", fields["cb_shaders"])
+			minetest.settings:set("enable_shaders", fields["cb_shaders"])
 		end
 		return true
 	end
 	if fields["cb_bumpmapping"] then
-		core.settings:set("enable_bumpmapping", fields["cb_bumpmapping"])
+		minetest.settings:set("enable_bumpmapping", fields["cb_bumpmapping"])
 		return true
 	end
 	if fields["cb_tonemapping"] then
-		core.settings:set("tone_mapping", fields["cb_tonemapping"])
+		minetest.settings:set("tone_mapping", fields["cb_tonemapping"])
 		return true
 	end
 	if fields["cb_generate_normalmaps"] then
-		core.settings:set("generate_normalmaps", fields["cb_generate_normalmaps"])
+		minetest.settings:set("generate_normalmaps", fields["cb_generate_normalmaps"])
 		return true
 	end
 	if fields["cb_parallax"] then
-		core.settings:set("enable_parallax_occlusion", fields["cb_parallax"])
+		minetest.settings:set("enable_parallax_occlusion", fields["cb_parallax"])
 		return true
 	end
 	if fields["cb_waving_water"] then
-		core.settings:set("enable_waving_water", fields["cb_waving_water"])
+		minetest.settings:set("enable_waving_water", fields["cb_waving_water"])
 		return true
 	end
 	if fields["cb_waving_leaves"] then
-		core.settings:set("enable_waving_leaves", fields["cb_waving_leaves"])
+		minetest.settings:set("enable_waving_leaves", fields["cb_waving_leaves"])
 	end
 	if fields["cb_waving_plants"] then
-		core.settings:set("enable_waving_plants", fields["cb_waving_plants"])
+		minetest.settings:set("enable_waving_plants", fields["cb_waving_plants"])
 		return true
 	end
 	if fields["btn_change_keys"] then
-		core.show_keys_menu()
+		minetest.show_keys_menu()
 		return true
 	end
 	if fields["cb_touchscreen_target"] then
-		core.settings:set("touchtarget", fields["cb_touchscreen_target"])
+		minetest.settings:set("touchtarget", fields["cb_touchscreen_target"])
 		return true
 	end
 	if fields["btn_reset_singleplayer"] then
@@ -369,49 +369,49 @@ local function handle_settings_buttons(this, fields, tabname, tabdata)
 
 	for i = 1, #labels.leaves do
 		if fields["dd_leaves_style"] == labels.leaves[i] then
-			core.settings:set("leaves_style", dd_options.leaves[2][i])
+			minetest.settings:set("leaves_style", dd_options.leaves[2][i])
 			ddhandled = true
 		end
 	end
 	for i = 1, #labels.node_highlighting do
 		if fields["dd_node_highlighting"] == labels.node_highlighting[i] then
-			core.settings:set("node_highlighting", dd_options.node_highlighting[2][i])
+			minetest.settings:set("node_highlighting", dd_options.node_highlighting[2][i])
 			ddhandled = true
 		end
 	end
 	if fields["dd_filters"] == labels.filters[1] then
-		core.settings:set("bilinear_filter", "false")
-		core.settings:set("trilinear_filter", "false")
+		minetest.settings:set("bilinear_filter", "false")
+		minetest.settings:set("trilinear_filter", "false")
 		ddhandled = true
 	elseif fields["dd_filters"] == labels.filters[2] then
-		core.settings:set("bilinear_filter", "true")
-		core.settings:set("trilinear_filter", "false")
+		minetest.settings:set("bilinear_filter", "true")
+		minetest.settings:set("trilinear_filter", "false")
 		ddhandled = true
 	elseif fields["dd_filters"] == labels.filters[3] then
-		core.settings:set("bilinear_filter", "false")
-		core.settings:set("trilinear_filter", "true")
+		minetest.settings:set("bilinear_filter", "false")
+		minetest.settings:set("trilinear_filter", "true")
 		ddhandled = true
 	end
 	if fields["dd_mipmap"] == labels.mipmap[1] then
-		core.settings:set("mip_map", "false")
-		core.settings:set("anisotropic_filter", "false")
+		minetest.settings:set("mip_map", "false")
+		minetest.settings:set("anisotropic_filter", "false")
 		ddhandled = true
 	elseif fields["dd_mipmap"] == labels.mipmap[2] then
-		core.settings:set("mip_map", "true")
-		core.settings:set("anisotropic_filter", "false")
+		minetest.settings:set("mip_map", "true")
+		minetest.settings:set("anisotropic_filter", "false")
 		ddhandled = true
 	elseif fields["dd_mipmap"] == labels.mipmap[3] then
-		core.settings:set("mip_map", "true")
-		core.settings:set("anisotropic_filter", "true")
+		minetest.settings:set("mip_map", "true")
+		minetest.settings:set("anisotropic_filter", "true")
 		ddhandled = true
 	end
 	if fields["dd_antialiasing"] then
-		core.settings:set("fsaa",
+		minetest.settings:set("fsaa",
 			antialiasing_fname_to_name(fields["dd_antialiasing"]))
 		ddhandled = true
 	end
 	if fields["dd_touchthreshold"] then
-		core.settings:set("touchscreen_threshold", fields["dd_touchthreshold"])
+		minetest.settings:set("touchscreen_threshold", fields["dd_touchthreshold"])
 		ddhandled = true
 	end
 

--- a/builtin/mainmenu/tab_simple_main.lua
+++ b/builtin/mainmenu/tab_simple_main.lua
@@ -25,12 +25,12 @@ local function get_formspec(tabview, name, tabdata)
 	local retval =
 		"label[9.5,0;".. fgettext("Name / Password") .. "]" ..
 		"field[0.25,3.35;5.5,0.5;te_address;;" ..
-			core.formspec_escape(core.settings:get("address")) .."]" ..
+			minetest.formspec_escape(minetest.settings:get("address")) .."]" ..
 		"field[5.75,3.35;2.25,0.5;te_port;;" ..
-			core.formspec_escape(core.settings:get("remote_port")) .."]" ..
+			minetest.formspec_escape(minetest.settings:get("remote_port")) .."]" ..
 		"button[10,2.6;2,1.5;btn_mp_connect;".. fgettext("Connect") .. "]" ..
 		"field[9.8,1;2.6,0.5;te_name;;" ..
-			core.formspec_escape(core.settings:get("name")) .."]" ..
+			minetest.formspec_escape(minetest.settings:get("name")) .."]" ..
 		"pwdfield[9.8,2;2.6,0.5;te_pwd;]"
 
 
@@ -56,7 +56,7 @@ local function get_formspec(tabview, name, tabdata)
 		"table[-0.05,0;9.2,2.75;favourites;"
 
 	if #menudata.favorites > 0 then
-		local favs = core.get_favorites("local")
+		local favs = minetest.get_favorites("local")
 		if #favs > 0 then
 			for i = 1, #favs do
 				for j = 1, #menudata.favorites do
@@ -89,9 +89,9 @@ local function get_formspec(tabview, name, tabdata)
 	-- checkboxes
 	retval = retval ..
 		"checkbox[8.0,3.9;cb_creative;".. fgettext("Creative Mode") .. ";" ..
-			dump(core.settings:get_bool("creative_mode")) .. "]"..
+			dump(minetest.settings:get_bool("creative_mode")) .. "]"..
 		"checkbox[8.0,4.4;cb_damage;".. fgettext("Enable Damage") .. ";" ..
-			dump(core.settings:get_bool("enable_damage")) .. "]"
+			dump(minetest.settings:get_bool("enable_damage")) .. "]"
 	-- buttons
 	retval = retval ..
 		"button[0,3.7;8,1.5;btn_start_singleplayer;" .. fgettext("Start Singleplayer") .. "]" ..
@@ -105,16 +105,16 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_start_singleplayer then
 		gamedata.selected_world	= gamedata.worldindex
 		gamedata.singleplayer	= true
-		core.start()
+		minetest.start()
 		return true
 	end
 
 	if fields.favourites then
-		local event = core.explode_table_event(fields.favourites)
+		local event = minetest.explode_table_event(fields.favourites)
 		if event.type == "CHG" then
 			if event.row <= #menudata.favorites then
 				gamedata.fav = false
-				local favs = core.get_favorites("local")
+				local favs = minetest.get_favorites("local")
 				local fav = menudata.favorites[event.row]
 				local address = fav.address
 				local port    = fav.port
@@ -128,8 +128,8 @@ local function main_button_handler(tabview, fields, name, tabdata)
 				end
 
 				if address and port then
-					core.settings:set("address", address)
-					core.settings:set("remote_port", port)
+					minetest.settings:set("address", address)
+					minetest.settings:set("remote_port", port)
 				end
 				tabdata.fav_selected = event.row
 			end
@@ -138,25 +138,25 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	end
 
 	if fields.btn_delete_favorite then
-		local current_favourite = core.get_table_index("favourites")
+		local current_favourite = minetest.get_table_index("favourites")
 		if not current_favourite then return end
 
-		core.delete_favorite(current_favourite)
+		minetest.delete_favorite(current_favourite)
 		asyncOnlineFavourites()
 		tabdata.fav_selected = nil
 
-		core.settings:set("address", "")
-		core.settings:set("remote_port", "30000")
+		minetest.settings:set("address", "")
+		minetest.settings:set("remote_port", "30000")
 		return true
 	end
 
 	if fields.cb_creative then
-		core.settings:set("creative_mode", fields.cb_creative)
+		minetest.settings:set("creative_mode", fields.cb_creative)
 		return true
 	end
 
 	if fields.cb_damage then
-		core.settings:set("enable_damage", fields.cb_damage)
+		minetest.settings:set("enable_damage", fields.cb_damage)
 		return true
 	end
 
@@ -165,7 +165,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		gamedata.password   = fields.te_pwd
 		gamedata.address    = fields.te_address
 		gamedata.port	    = fields.te_port
-		local fav_idx = core.get_textlist_index("favourites")
+		local fav_idx = minetest.get_textlist_index("favourites")
 
 		if fav_idx and fav_idx <= #menudata.favorites and
 				menudata.favorites[fav_idx].address == fields.te_address and
@@ -186,10 +186,10 @@ local function main_button_handler(tabview, fields, name, tabdata)
 
 		gamedata.selected_world = 0
 
-		core.settings:set("address", fields.te_address)
-		core.settings:set("remote_port", fields.te_port)
+		minetest.settings:set("address", fields.te_address)
+		minetest.settings:set("remote_port", fields.te_port)
 
-		core.start()
+		minetest.start()
 		return true
 	end
 

--- a/builtin/mainmenu/textures.lua
+++ b/builtin/mainmenu/textures.lua
@@ -20,11 +20,11 @@ mm_texture = {}
 
 --------------------------------------------------------------------------------
 function mm_texture.init()
-	mm_texture.defaulttexturedir = core.get_texturepath() .. DIR_DELIM .. "base" ..
+	mm_texture.defaulttexturedir = minetest.get_texturepath() .. DIR_DELIM .. "base" ..
 						DIR_DELIM .. "pack" .. DIR_DELIM
 	mm_texture.basetexturedir = mm_texture.defaulttexturedir
 
-	mm_texture.texturepack = core.settings:get("texture_path")
+	mm_texture.texturepack = minetest.settings:get("texture_path")
 
 	mm_texture.gameid = nil
 end
@@ -55,14 +55,14 @@ function mm_texture.reset()
 
 	mm_texture.clear("header")
 	mm_texture.clear("footer")
-	core.set_clouds(false)
+	minetest.set_clouds(false)
 
 	mm_texture.set_generic("footer")
 	mm_texture.set_generic("header")
 
 	if not have_bg then
-		if core.settings:get_bool("menu_clouds") then
-			core.set_clouds(true)
+		if minetest.settings:get_bool("menu_clouds") then
+			minetest.set_clouds(true)
 		else
 			mm_texture.set_dirt_bg()
 		end
@@ -84,12 +84,12 @@ function mm_texture.update_game(gamedetails)
 
 	mm_texture.clear("header")
 	mm_texture.clear("footer")
-	core.set_clouds(false)
+	minetest.set_clouds(false)
 
 	if not have_bg then
 
-		if core.settings:get_bool("menu_clouds") then
-			core.set_clouds(true)
+		if minetest.settings:get_bool("menu_clouds") then
+			minetest.set_clouds(true)
 		else
 			mm_texture.set_dirt_bg()
 		end
@@ -103,7 +103,7 @@ end
 
 --------------------------------------------------------------------------------
 function mm_texture.clear(identifier)
-	core.set_background(identifier,"")
+	minetest.set_background(identifier,"")
 end
 
 --------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ function mm_texture.set_generic(identifier)
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM .."menu_" ..
 										identifier .. ".png"
-		if core.set_background(identifier,path) then
+		if minetest.set_background(identifier,path) then
 			return true
 		end
 	end
@@ -120,7 +120,7 @@ function mm_texture.set_generic(identifier)
 	if mm_texture.defaulttexturedir ~= nil then
 		local path = mm_texture.defaulttexturedir .. DIR_DELIM .."menu_" ..
 										identifier .. ".png"
-		if core.set_background(identifier,path) then
+		if minetest.set_background(identifier,path) then
 			return true
 		end
 	end
@@ -138,7 +138,7 @@ function mm_texture.set_game(identifier, gamedetails)
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM ..
 			gamedetails.id .. "_menu_" .. identifier .. ".png"
-		if core.set_background(identifier, path) then
+		if minetest.set_background(identifier, path) then
 			return true
 		end
 	end
@@ -146,7 +146,7 @@ function mm_texture.set_game(identifier, gamedetails)
 	-- Find out how many randomized textures the game provides
 	local n = 0
 	local filename
-	local menu_files = core.get_dir_list(gamedetails.path .. DIR_DELIM .. "menu", false)
+	local menu_files = minetest.get_dir_list(gamedetails.path .. DIR_DELIM .. "menu", false)
 	for i = 1, #menu_files do
 		filename = identifier .. "." .. i .. ".png"
 		if table.indexof(menu_files, filename) == -1 then
@@ -164,7 +164,7 @@ function mm_texture.set_game(identifier, gamedetails)
 
 	local path = gamedetails.path .. DIR_DELIM .. "menu" ..
 		DIR_DELIM .. filename
-	if core.set_background(identifier, path) then
+	if minetest.set_background(identifier, path) then
 		return true
 	end
 
@@ -174,12 +174,12 @@ end
 function mm_texture.set_dirt_bg()
 	if mm_texture.texturepack ~= nil then
 		local path = mm_texture.texturepack .. DIR_DELIM .."default_dirt.png"
-		if core.set_background("background", path, true, 128) then
+		if minetest.set_background("background", path, true, 128) then
 			return true
 		end
 	end
 
 	-- Use universal fallback texture in textures/base/pack
 	local minimalpath = defaulttexturedir .. "menu_bg.png"
-	core.set_background("background", minimalpath, true, 128)
+	minetest.set_background("background", minimalpath, true, 128)
 end

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -16,14 +16,14 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 local function get_bool_default(name, default)
-	local val = core.settings:get_bool(name)
+	local val = minetest.settings:get_bool(name)
 	if val == nil then
 		return default
 	end
 	return val
 end
 
-local profiler_path = core.get_builtin_path().."profiler"..DIR_DELIM
+local profiler_path = minetest.get_builtin_path().."profiler"..DIR_DELIM
 local profiler = {}
 local sampler = assert(loadfile(profiler_path .. "sampling.lua"))(profiler)
 local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler, get_bool_default)
@@ -32,7 +32,7 @@ profiler.instrument = instrumentation.instrument
 
 ---
 -- Delayed registration of the /profiler chat command
--- Is called later, after `core.register_chatcommand` was set up.
+-- Is called later, after `minetest.register_chatcommand` was set up.
 --
 function profiler.init_chatcommand()
 	local instrument_profiler = get_bool_default("instrument.profiler", false)
@@ -41,7 +41,7 @@ function profiler.init_chatcommand()
 	end
 
 	local param_usage = "print [filter] | dump [filter] | save [format [filter]] | reset"
-	core.register_chatcommand("profiler", {
+	minetest.register_chatcommand("profiler", {
 		description = "handle the profiler and profiling data",
 		params = param_usage,
 		privs = { server=true },
@@ -50,7 +50,7 @@ function profiler.init_chatcommand()
 			local args = arg0 and string.split(arg0, " ")
 
 			if command == "dump" then
-				core.log("action", reporter.print(sampler.profile, arg0))
+				minetest.log("action", reporter.print(sampler.profile, arg0))
 				return true, "Statistics written to action log"
 			elseif command == "print" then
 				return true, reporter.print(sampler.profile, arg0)

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -209,7 +209,7 @@ local function init()
 
 	if get_bool_default("instrument.global_callback", true) then
 		for func_name, _ in pairs(register_functions) do
-			core[func_name] = instrument_register(core[func_name], func_name)
+			minetest[func_name] = instrument_register(minetest[func_name], func_name)
 		end
 	end
 

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -16,7 +16,7 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 local format, pairs, type = string.format, pairs, type
-local core, get_current_modname = core, minetest.get_current_modname
+local minetest, get_current_modname = minetest, minetest.get_current_modname
 local profiler, sampler, get_bool_default = ...
 
 local instrument_builtin = get_bool_default("instrument.builtin", false)

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -16,7 +16,7 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 local format, pairs, type = string.format, pairs, type
-local core, get_current_modname = core, core.get_current_modname
+local core, get_current_modname = core, minetest.get_current_modname
 local profiler, sampler, get_bool_default = ...
 
 local instrument_builtin = get_bool_default("instrument.builtin", false)
@@ -71,7 +71,7 @@ end
 -- Keep `measure` and the closure in `instrument` lean, as these, and their
 -- directly called functions are the overhead that is caused by instrumentation.
 --
-local time, log = core.get_us_time, sampler.log
+local time, log = minetest.get_us_time, sampler.log
 local function measure(modname, instrument_name, start, ...)
 	log(modname, instrument_name, time() - start)
 	return ...
@@ -140,8 +140,8 @@ end
 
 local function init_chatcommand()
 	if get_bool_default("instrument.chatcommand", true) then
-		local orig_register_chatcommand = core.register_chatcommand
-		core.register_chatcommand = function(cmd, def)
+		local orig_register_chatcommand = minetest.register_chatcommand
+		minetest.register_chatcommand = function(cmd, def)
 			def.func = instrument {
 				func = def.func,
 				label = "/" .. cmd,
@@ -166,8 +166,8 @@ local function init()
 			"get_staticdata",
 		}
 		-- Wrap register_entity() to instrument them on registration.
-		local orig_register_entity = core.register_entity
-		core.register_entity = function(name, prototype)
+		local orig_register_entity = minetest.register_entity
+		minetest.register_entity = function(name, prototype)
 			local modname = get_current_modname()
 			for _, func_name in pairs(entity_instrumentation) do
 				prototype[func_name] = instrument {
@@ -183,8 +183,8 @@ local function init()
 
 	if get_bool_default("instrument.abm", true) then
 		-- Wrap register_abm() to automatically instrument abms.
-		local orig_register_abm = core.register_abm
-		core.register_abm = function(spec)
+		local orig_register_abm = minetest.register_abm
+		minetest.register_abm = function(spec)
 			spec.action = instrument {
 				func = spec.action,
 				class = "ABM",
@@ -196,8 +196,8 @@ local function init()
 
 	if get_bool_default("instrument.lbm", true) then
 		-- Wrap register_lbm() to automatically instrument lbms.
-		local orig_register_lbm = core.register_lbm
-		core.register_lbm = function(spec)
+		local orig_register_lbm = minetest.register_lbm
+		minetest.register_lbm = function(spec)
 			spec.action = instrument {
 				func = spec.action,
 				class = "LBM",

--- a/builtin/profiler/reporter.lua
+++ b/builtin/profiler/reporter.lua
@@ -18,7 +18,7 @@
 local DIR_DELIM, LINE_DELIM = DIR_DELIM, "\n"
 local table, unpack, string, pairs, io, os = table, unpack, string, pairs, io, os
 local rep, sprintf, tonumber = string.rep, string.format, tonumber
-local core, settings = core, core.settings
+local core, settings = core, minetest.settings
 local reporter = {}
 
 ---
@@ -216,22 +216,22 @@ local function serialize_profile(profile, format, filter)
 			end
 		end
 		if format == "lua" then
-			return core.serialize(stats)
+			return minetest.serialize(stats)
 		elseif format == "json" then
-			return core.write_json(stats)
+			return minetest.write_json(stats)
 		elseif format == "json_pretty" then
-			return core.write_json(stats, true)
+			return minetest.write_json(stats, true)
 		end
 	end
 	-- Fall back to textual formats.
 	return format_statistics(profile, format, filter)
 end
 
-local worldpath = core.get_worldpath()
+local worldpath = minetest.get_worldpath()
 local function get_save_path(format, filter)
 	local report_path = settings:get("profiler.report_path") or ""
 	if report_path ~= "" then
-		core.mkdir(sprintf("%s%s%s", worldpath, DIR_DELIM, report_path))
+		minetest.mkdir(sprintf("%s%s%s", worldpath, DIR_DELIM, report_path))
 	end
 	return (sprintf(
 		"%s/%s/profile-%s%s.%s",
@@ -270,7 +270,7 @@ function reporter.save(profile, format, filter)
 	output:close()
 
 	local logmessage = "Profile saved to " .. path
-	core.log("action", logmessage)
+	minetest.log("action", logmessage)
 	return true, logmessage
 end
 

--- a/builtin/profiler/reporter.lua
+++ b/builtin/profiler/reporter.lua
@@ -18,7 +18,7 @@
 local DIR_DELIM, LINE_DELIM = DIR_DELIM, "\n"
 local table, unpack, string, pairs, io, os = table, unpack, string, pairs, io, os
 local rep, sprintf, tonumber = string.rep, string.format, tonumber
-local core, settings = core, minetest.settings
+local minetest, settings = minetest, minetest.settings
 local reporter = {}
 
 ---

--- a/builtin/profiler/sampling.lua
+++ b/builtin/profiler/sampling.lua
@@ -76,7 +76,7 @@ function sampler.log(modname, instrument_name, time_diff)
 		if time_diff < 0 then
 			-- This **might** have happened on a semi-regular basis with huge mods,
 			-- resulting in negative statistics (perhaps midnight time jumps or ntp corrections?).
-			core.log("warning", format(
+			minetest.log("warning", format(
 					"Time travel of %s::%s by %dµs.",
 					modname, instrument_name, time_diff
 			))
@@ -185,21 +185,21 @@ end
 function sampler.init()
 	sampler.reset()
 
-	if core.settings:get_bool("instrument.profiler") then
-		core.register_globalstep(function()
+	if minetest.settings:get_bool("instrument.profiler") then
+		minetest.register_globalstep(function()
 			if logged_time == 0 then
 				return
 			end
 			return profiler.empty_instrument()
 		end)
-		core.register_globalstep(profiler.instrument {
+		minetest.register_globalstep(profiler.instrument {
 			func = sample,
 			mod = "*profiler*",
 			class = "Sampler (update stats)",
 			label = false,
 		})
 	else
-		core.register_globalstep(sample)
+		minetest.register_globalstep(sample)
 	end
 end
 

--- a/builtin/profiler/sampling.lua
+++ b/builtin/profiler/sampling.lua
@@ -17,7 +17,7 @@
 local setmetatable = setmetatable
 local pairs, format = pairs, string.format
 local min, max, huge = math.min, math.max, math.huge
-local core = core
+local minetest = minetest
 
 local profiler = ...
 -- Split sampler and profile up, to possibly allow for rotation later.

--- a/clientmods/preview/example.lua
+++ b/clientmods/preview/example.lua
@@ -1,2 +1,2 @@
 print("Loaded example file!, loading more examples")
-dofile(core.get_modpath(core.get_current_modname()) .. "/examples/first.lua")
+dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/examples/first.lua")

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -1,37 +1,37 @@
-local modname = assert(core.get_current_modname())
-local modstorage = core.get_mod_storage()
+local modname = assert(minetest.get_current_modname())
+local modstorage = minetest.get_mod_storage()
 local mod_channel
 
-dofile(core.get_modpath(modname) .. "example.lua")
+dofile(minetest.get_modpath(modname) .. "example.lua")
 
-core.register_on_shutdown(function()
+minetest.register_on_shutdown(function()
 	print("[PREVIEW] shutdown client")
 end)
 local id = nil
 
 do
-	local server_info = core.get_server_info()
+	local server_info = minetest.get_server_info()
 	print("Server version: " .. server_info.protocol_version)
 	print("Server ip: " .. server_info.ip)
 	print("Server address: " .. server_info.address)
 	print("Server port: " .. server_info.port)
 
-	print("CSM restrictions: " .. dump(core.get_csm_restrictions()))
+	print("CSM restrictions: " .. dump(minetest.get_csm_restrictions()))
 
-	local l1, l2 = core.get_language()
+	local l1, l2 = minetest.get_language()
 	print("Configured language: " .. l1 .. " / " .. l2)
 end
 
-mod_channel = core.mod_channel_join("experimental_preview")
+mod_channel = minetest.mod_channel_join("experimental_preview")
 
-core.after(4, function()
+minetest.after(4, function()
 	if mod_channel:is_writeable() then
 		mod_channel:send_all("preview talk to experimental")
 	end
 end)
 
-core.after(1, function()
-	id = core.localplayer:hud_add({
+minetest.after(1, function()
+	id = minetest.localplayer:hud_add({
 			hud_elem_type = "text",
 			name = "example",
 			number = 0xff0000,
@@ -43,33 +43,33 @@ core.after(1, function()
 	})
 end)
 
-core.register_on_modchannel_message(function(channel, sender, message)
+minetest.register_on_modchannel_message(function(channel, sender, message)
 	print("[PREVIEW][modchannels] Received message `" .. message .. "` on channel `"
 			.. channel .. "` from sender `" .. sender .. "`")
-	core.after(1, function()
+	minetest.after(1, function()
 		mod_channel:send_all("CSM preview received " .. message)
 	end)
 end)
 
-core.register_on_modchannel_signal(function(channel, signal)
+minetest.register_on_modchannel_signal(function(channel, signal)
 	print("[PREVIEW][modchannels] Received signal id `" .. signal .. "` on channel `"
 			.. channel)
 end)
 
-core.register_on_inventory_open(function(inventory)
+minetest.register_on_inventory_open(function(inventory)
 	print("INVENTORY OPEN")
 	print(dump(inventory))
 	return false
 end)
 
-core.register_on_placenode(function(pointed_thing, node)
+minetest.register_on_placenode(function(pointed_thing, node)
 	print("The local player place a node!")
 	print("pointed_thing :" .. dump(pointed_thing))
 	print("node placed :" .. dump(node))
 	return false
 end)
 
-core.register_on_item_use(function(itemstack, pointed_thing)
+minetest.register_on_item_use(function(itemstack, pointed_thing)
 	print("The local player used an item!")
 	print("pointed_thing :" .. dump(pointed_thing))
 	print("item = " .. itemstack:get_name())
@@ -78,17 +78,17 @@ core.register_on_item_use(function(itemstack, pointed_thing)
 		return false
 	end
 
-	local pos = vector.add(core.localplayer:get_pos(), core.camera:get_offset())
-	local pos2 = vector.add(pos, vector.multiply(core.camera:get_look_dir(), 100))
+	local pos = vector.add(minetest.localplayer:get_pos(), minetest.camera:get_offset())
+	local pos2 = vector.add(pos, vector.multiply(minetest.camera:get_look_dir(), 100))
 
-	local rc = core.raycast(pos, pos2)
+	local rc = minetest.raycast(pos, pos2)
 	local i = rc:next()
 	print("[PREVIEW] raycast next: " .. dump(i))
 	if i then
-		print("[PREVIEW] line of sight: " .. (core.line_of_sight(pos, i.above) and "yes" or "no"))
+		print("[PREVIEW] line of sight: " .. (minetest.line_of_sight(pos, i.above) and "yes" or "no"))
 
-		local n1 = core.find_nodes_in_area(pos, i.under, {"default:stone"})
-		local n2 = core.find_nodes_in_area_under_air(pos, i.under, {"default:stone"})
+		local n1 = minetest.find_nodes_in_area(pos, i.under, {"default:stone"})
+		local n2 = minetest.find_nodes_in_area_under_air(pos, i.under, {"default:stone"})
 		print(("[PREVIEW] found %s nodes, %s nodes under air"):format(
 				n1 and #n1 or "?", n2 and #n2 or "?"))
 	end
@@ -97,49 +97,49 @@ core.register_on_item_use(function(itemstack, pointed_thing)
 end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
-core.register_on_receiving_chat_message(function(message)
+minetest.register_on_receiving_chat_message(function(message)
 	print("[PREVIEW] Received message " .. message)
 	return false
 end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
-core.register_on_sending_chat_message(function(message)
+minetest.register_on_sending_chat_message(function(message)
 	print("[PREVIEW] Sending message " .. message)
 	return false
 end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
-core.register_on_hp_modification(function(hp)
+minetest.register_on_hp_modification(function(hp)
 	print("[PREVIEW] HP modified " .. hp)
 end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
-core.register_on_damage_taken(function(hp)
+minetest.register_on_damage_taken(function(hp)
 	print("[PREVIEW] Damage taken " .. hp)
 end)
 
 -- This is an example function to ensure it's working properly, should be removed before merge
-core.register_chatcommand("dump", {
+minetest.register_chatcommand("dump", {
 	func = function(param)
 		return true, dump(_G)
 	end,
 })
 
-core.register_chatcommand("colorize_test", {
+minetest.register_chatcommand("colorize_test", {
 	func = function(param)
-		return true, core.colorize("red", param)
+		return true, minetest.colorize("red", param)
 	end,
 })
 
-core.register_chatcommand("test_node", {
+minetest.register_chatcommand("test_node", {
 	func = function(param)
-		core.display_chat_message(dump(core.get_node({x=0, y=0, z=0})))
-		core.display_chat_message(dump(core.get_node_or_nil({x=0, y=0, z=0})))
+		minetest.display_chat_message(dump(minetest.get_node({x=0, y=0, z=0})))
+		minetest.display_chat_message(dump(minetest.get_node_or_nil({x=0, y=0, z=0})))
 	end,
 })
 
 local function preview_minimap()
-	local minimap = core.ui.minimap
+	local minimap = minetest.ui.minimap
 	if not minimap then
 		print("[PREVIEW] Minimap is disabled. Skipping.")
 		return
@@ -154,37 +154,37 @@ local function preview_minimap()
 			" angle => " .. dump(minimap:get_angle()))
 end
 
-core.after(2, function()
+minetest.after(2, function()
 	print("[PREVIEW] loaded " .. modname .. " mod")
 	modstorage:set_string("current_mod", modname)
 	print(modstorage:get_string("current_mod"))
 	preview_minimap()
 end)
 
-core.after(5, function()
-	if core.ui.minimap then
-		core.ui.minimap:show()
+minetest.after(5, function()
+	if minetest.ui.minimap then
+		minetest.ui.minimap:show()
 	end
 
-	print("[PREVIEW] Time of day " .. core.get_timeofday())
+	print("[PREVIEW] Time of day " .. minetest.get_timeofday())
 
-	print("[PREVIEW] Node level: " .. core.get_node_level({x=0, y=20, z=0}) ..
-		" max level " .. core.get_node_max_level({x=0, y=20, z=0}))
+	print("[PREVIEW] Node level: " .. minetest.get_node_level({x=0, y=20, z=0}) ..
+		" max level " .. minetest.get_node_max_level({x=0, y=20, z=0}))
 
-	print("[PREVIEW] Find node near: " .. dump(core.find_node_near({x=0, y=20, z=0}, 10,
+	print("[PREVIEW] Find node near: " .. dump(minetest.find_node_near({x=0, y=20, z=0}, 10,
 		{"group:tree", "default:dirt", "default:stone"})))
 end)
 
-core.register_on_dignode(function(pos, node)
+minetest.register_on_dignode(function(pos, node)
 	print("The local player dug a node!")
 	print("pos:" .. dump(pos))
 	print("node:" .. dump(node))
 	return false
 end)
 
-core.register_on_punchnode(function(pos, node)
+minetest.register_on_punchnode(function(pos, node)
 	print("The local player punched a node!")
-	local itemstack = core.get_wielded_item()
+	local itemstack = minetest.get_wielded_item()
 	--[[
 	-- getters
 	print(dump(itemstack:is_empty()))
@@ -211,19 +211,19 @@ core.register_on_punchnode(function(pos, node)
 	return false
 end)
 
-core.register_chatcommand("privs", {
+minetest.register_chatcommand("privs", {
 	func = function(param)
-		return true, core.privs_to_string(minetest.get_privilege_list())
+		return true, minetest.privs_to_string(minetest.get_privilege_list())
 	end,
 })
 
-core.register_chatcommand("text", {
+minetest.register_chatcommand("text", {
 	func = function(param)
-		return core.localplayer:hud_change(id, "text", param)
+		return minetest.localplayer:hud_change(id, "text", param)
 	end,
 })
 
 
-core.register_on_mods_loaded(function()
-	core.log("Yeah preview mod is loaded with other CSM mods.")
+minetest.register_on_mods_loaded(function()
+	minetest.log("Yeah preview mod is loaded with other CSM mods.")
 end)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2277,7 +2277,6 @@ Elements
 * Index to be selected within textlist
 * `true`/`false`: draw transparent background
 * See also `minetest.explode_textlist_event`
-  (main menu: `core.explode_textlist_event`).
 
 ### `tabheader[<X>,<Y>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
@@ -2367,7 +2366,6 @@ Elements
 * Fieldname data is transferred to Lua
 * Value of this trackbar is set to (`0`-`1000`) by default
 * See also `minetest.explode_scrollbar_event`
-  (main menu: `core.explode_scrollbar_event`).
 
 ### `scrollbaroptions[opt1;opt2;...]`
 * Sets options for all following `scrollbar[]` elements
@@ -2401,7 +2399,6 @@ Elements
 * `cell 1`...`cell n`: cell contents given in row-major order
 * `selected idx`: index of row to be selected within table (first row = `1`)
 * See also `minetest.explode_table_event`
-  (main menu: `core.explode_table_event`).
 
 ### `tableoptions[<opt 1>;<opt 2>;...]`
 

--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -8,14 +8,14 @@ Description of formspec language to show your menu is in lua_api.txt
 
 Callbacks
 ---------
-core.buttonhandler(fields): called when a button is pressed.
+minetest.buttonhandler(fields): called when a button is pressed.
 ^ fields = {name1 = value1, name2 = value2, ...}
-core.event_handler(event)
+minetest.event_handler(event)
 ^ event: "MenuQuit", "KeyEnter", "ExitButton" or "EditBoxEnter"
 
 Gamedata
 --------
-The "gamedata" table is read when calling core.start(). It should contain:
+The "gamedata" table is read when calling minetest.start(). It should contain:
 {
 	playername     = <name>,
 	password       = <password>,
@@ -27,71 +27,71 @@ The "gamedata" table is read when calling core.start(). It should contain:
 
 Functions
 ---------
-core.start()
-core.close()
+minetest.start()
+minetest.close()
 
 Filesystem:
-core.get_builtin_path()
+minetest.get_builtin_path()
 ^ returns path to builtin root
-core.create_dir(absolute_path) (possible in async calls)
+minetest.create_dir(absolute_path) (possible in async calls)
 ^ absolute_path to directory to create (needs to be absolute)
 ^ returns true/false
-core.delete_dir(absolute_path) (possible in async calls)
+minetest.delete_dir(absolute_path) (possible in async calls)
 ^ absolute_path to directory to delete (needs to be absolute)
 ^ returns true/false
-core.copy_dir(source,destination,keep_soure) (possible in async calls)
+minetest.copy_dir(source,destination,keep_soure) (possible in async calls)
 ^ source folder
 ^ destination folder
 ^ keep_source DEFAULT true --> if set to false source is deleted after copying
 ^ returns true/false
-core.extract_zip(zipfile,destination) [unzip within path required]
+minetest.extract_zip(zipfile,destination) [unzip within path required]
 ^ zipfile to extract
 ^ destination folder to extract to
 ^ returns true/false
-core.download_file(url,target) (possible in async calls)
+minetest.download_file(url,target) (possible in async calls)
 ^ url to download
 ^ target to store to
 ^ returns true/false
-core.get_version() (possible in async calls)
-^ returns current core version
-core.sound_play(spec, looped) -> handle
+minetest.get_version() (possible in async calls)
+^ returns current minetest version
+minetest.sound_play(spec, looped) -> handle
 ^ spec = SimpleSoundSpec (see lua-api.txt)
 ^ looped = bool
-core.sound_stop(handle)
-core.get_video_drivers()
+minetest.sound_stop(handle)
+minetest.get_video_drivers()
 ^ get list of video drivers supported by engine (not all modes are guaranteed to work)
 ^ returns list of available video drivers' settings name and 'friendly' display name
 ^ e.g. { {name="opengl", friendly_name="OpenGL"}, {name="software", friendly_name="Software Renderer"} }
 ^ first element of returned list is guaranteed to be the NULL driver
-core.get_mapgen_names([include_hidden=false]) -> table of map generator algorithms
-    registered in the core (possible in async calls)
-core.get_cache_path() -> path of cache
+minetest.get_mapgen_names([include_hidden=false]) -> table of map generator algorithms
+    registered in the minetest (possible in async calls)
+minetest.get_cache_path() -> path of cache
 
 Formspec:
-core.update_formspec(formspec)
-core.get_table_index(tablename) -> index
+minetest.update_formspec(formspec)
+minetest.get_table_index(tablename) -> index
 ^ can also handle textlists
-core.formspec_escape(string) -> string
+minetest.formspec_escape(string) -> string
 ^ escapes characters [ ] \ , ; that can not be used in formspecs
-core.explode_table_event(string) -> table
+minetest.explode_table_event(string) -> table
 ^ returns e.g. {type="CHG", row=1, column=2}
 ^ type: "INV" (no row selected), "CHG" (selected) or "DCL" (double-click)
-core.explode_textlist_event(string) -> table
+minetest.explode_textlist_event(string) -> table
 ^ returns e.g. {type="CHG", index=1}
 ^ type: "INV" (no row selected), "CHG" (selected) or "DCL" (double-click)
-core.set_formspec_prepend(formspec)
+minetest.set_formspec_prepend(formspec)
 ^ string to be added to every mainmenu formspec, to be used for theming.
 
 GUI:
-core.set_background(type, texturepath,[tile],[minsize])
+minetest.set_background(type, texturepath,[tile],[minsize])
 ^ type: "background", "overlay", "header" or "footer"
 ^ tile: tile the image instead of scaling (background only)
 ^ minsize: minimum tile size, images are scaled to at least this size prior
 ^   doing tiling (background only)
-core.set_clouds(<true/false>)
-core.set_topleft_text(text)
-core.show_keys_menu()
-core.show_path_select_dialog(formname, caption, is_file_select)
+minetest.set_clouds(<true/false>)
+minetest.set_topleft_text(text)
+minetest.show_keys_menu()
+minetest.show_path_select_dialog(formname, caption, is_file_select)
 ^ shows a path select dialog
 ^ formname is base name of dialog response returned in fields
 ^     -if dialog was accepted "_accepted"
@@ -100,7 +100,7 @@ core.show_path_select_dialog(formname, caption, is_file_select)
 ^        will be added to fieldname value is set to formname itself
 ^ if `is_file_select` is `true`, a file and not a folder will be selected
 ^ returns nil or selected file/folder
-core.get_screen_info()
+minetest.get_screen_info()
 ^ returns {
 	density         = <screen density 0.75,1.0,2.0,3.0 ... (dpi)>,
 	display_width   = <width of display>,
@@ -114,15 +114,15 @@ core.get_screen_info()
 Content - an installed mod, modpack, game, or texture pack (txt)
 Package - content which is downloadable from the content db, may or may not be installed.
 
-* core.get_modpath() (possible in async calls)
+* minetest.get_modpath() (possible in async calls)
 	* returns path to global modpath
-* core.get_clientmodpath() (possible in async calls)
+* minetest.get_clientmodpath() (possible in async calls)
 	* returns path to global client-side modpath
-* core.get_gamepath() (possible in async calls)
+* minetest.get_gamepath() (possible in async calls)
 	* returns path to global gamepath
-* core.get_texturepath() (possible in async calls)
+* minetest.get_texturepath() (possible in async calls)
 	* returns path to default textures
-* core.get_game(index)
+* minetest.get_game(index)
 	* returns:
 
 		{
@@ -136,8 +136,8 @@ Package - content which is downloadable from the content db, may or may not be i
 			addon_mods_paths = {[1] = <path>,},
 		}
 
-* core.get_games() -> table of all games in upper format (possible in async calls)
-* core.get_content_info(path)
+* minetest.get_games() -> table of all games in upper format (possible in async calls)
+* minetest.get_content_info(path)
 	* returns
 
 		{
@@ -152,7 +152,7 @@ Package - content which is downloadable from the content db, may or may not be i
 
 
 Favorites:
-core.get_favorites(location) -> list of favorites (possible in async calls)
+minetest.get_favorites(location) -> list of favorites (possible in async calls)
 ^ location: "local" or "online"
 ^ returns {
 	[1] = {
@@ -169,27 +169,27 @@ core.get_favorites(location) -> list of favorites (possible in async calls)
 	port          = <port>
 	},
 }
-core.delete_favorite(id, location) -> success
+minetest.delete_favorite(id, location) -> success
 
 Logging:
-core.debug(line) (possible in async calls)
+minetest.debug(line) (possible in async calls)
 ^ Always printed to stderr and logfile (print() is redirected here)
-core.log(line) (possible in async calls)
-core.log(loglevel, line) (possible in async calls)
+minetest.log(line) (possible in async calls)
+minetest.log(loglevel, line) (possible in async calls)
 ^ loglevel one of "error", "action", "info", "verbose"
 
 Settings:
-core.settings:set(name, value)
-core.settings:get(name) -> string or nil (possible in async calls)
-core.settings:set_bool(name, value)
-core.settings:get_bool(name) -> bool or nil (possible in async calls)
-core.settings:save() -> nil, save all settings to config file
+minetest.settings:set(name, value)
+minetest.settings:get(name) -> string or nil (possible in async calls)
+minetest.settings:set_bool(name, value)
+minetest.settings:get_bool(name) -> bool or nil (possible in async calls)
+minetest.settings:save() -> nil, save all settings to config file
 
 For a complete list of methods of the Settings object see
 [lua_api.txt](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt)
 
 Worlds:
-core.get_worlds() -> list of worlds (possible in async calls)
+minetest.get_worlds() -> list of worlds (possible in async calls)
 ^ returns {
 	[1] = {
 	path   = <full path to world>,
@@ -197,28 +197,28 @@ core.get_worlds() -> list of worlds (possible in async calls)
 	gameid = <gameid of world>,
 	},
 }
-core.create_world(worldname, gameid)
-core.delete_world(index)
+minetest.create_world(worldname, gameid)
+minetest.delete_world(index)
 
 Helpers:
-core.get_us_time()
+minetest.get_us_time()
 ^ returns time with microsecond precision
-core.gettext(string) -> string
+minetest.gettext(string) -> string
 ^ look up the translation of a string in the gettext message catalog
 fgettext_ne(string, ...)
-^ call core.gettext(string), replace "$1"..."$9" with the given
+^ call minetest.gettext(string), replace "$1"..."$9" with the given
 ^ extra arguments and return the result
 fgettext(string, ...) -> string
-^ same as fgettext_ne(), but calls core.formspec_escape before returning result
-core.parse_json(string[, nullvalue]) -> something (possible in async calls)
-^ see core.parse_json (lua_api.txt)
+^ same as fgettext_ne(), but calls minetest.formspec_escape before returning result
+minetest.parse_json(string[, nullvalue]) -> something (possible in async calls)
+^ see minetest.parse_json (lua_api.txt)
 dump(obj, dumped={})
 ^ Return object serialized as a string
 string:split(separator)
 ^ eg. string:split("a,b", ",") == {"a","b"}
 string:trim()
 ^ eg. string.trim("\n \t\tfoo bar\t ") == "foo bar"
-core.is_yes(arg) (possible in async calls)
+minetest.is_yes(arg) (possible in async calls)
 ^ returns whether arg can be interpreted as yes
 minetest.encode_base64(string) (possible in async calls)
 ^ Encodes a string in base64.
@@ -226,13 +226,13 @@ minetest.decode_base64(string) (possible in async calls)
 ^ Decodes a string encoded in base64.
 
 Version compat:
-core.get_min_supp_proto()
+minetest.get_min_supp_proto()
 ^ returns the minimum supported network protocol version
-core.get_max_supp_proto()
+minetest.get_max_supp_proto()
 ^ returns the maximum supported network protocol version
 
 Async:
-core.handle_async(async_job,parameters,finished)
+minetest.handle_async(async_job,parameters,finished)
 ^ execute a function asynchronously
 ^ async_job is a function receiving one parameter and returning one parameter
 ^ parameters parameter table passed to async_job
@@ -242,5 +242,5 @@ core.handle_async(async_job,parameters,finished)
 Limitations of Async operations
  -No access to global lua variables, don't even try
  -Limited set of available functions
-	e.g. No access to functions modifying menu like core.start,core.close,
-	core.show_path_select_dialog
+	e.g. No access to functions modifying menu like minetest.start,minetest.close,
+	minetest.show_path_select_dialog

--- a/games/minimal/mods/experimental/init.lua
+++ b/games/minimal/mods/experimental/init.lua
@@ -815,8 +815,8 @@ minetest.log("info", "experimental modpath="..dump(minetest.get_modpath("experim
 minetest.log("info", "experimental worldpath="..dump(minetest.get_worldpath()))
 
 
-core.register_on_mods_loaded(function()
-	core.log("action", "Yeah experimental loaded mods.")
+minetest.register_on_mods_loaded(function()
+	minetest.log("action", "Yeah experimental loaded mods.")
 end)
 
 -- END

--- a/games/minimal/mods/experimental/modchannels.lua
+++ b/games/minimal/mods/experimental/modchannels.lua
@@ -1,9 +1,9 @@
 --
 -- Mod channels experimental handlers
 --
-local mod_channel = core.mod_channel_join("experimental_preview")
+local mod_channel = minetest.mod_channel_join("experimental_preview")
 
-core.register_on_modchannel_message(function(channel, sender, message)
+minetest.register_on_modchannel_message(function(channel, sender, message)
 	print("[minimal][modchannels] Server received message `" .. message
 			.. "` on channel `" .. channel .. "` from sender `" .. sender .. "`")
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1588,7 +1588,7 @@ std::vector<ItemStack> read_items(lua_State *L, int index, Server *srv)
 void luaentity_get(lua_State *L, u16 id)
 {
 	// Get luaentities[i]
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "luaentities");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_pushnumber(L, id);
@@ -1825,7 +1825,7 @@ void push_pointed_thing(lua_State *L, const PointedThing &pointed, bool csm,
 void push_objectRef(lua_State *L, const u16 id)
 {
 	// Get core.object_refs[i]
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "object_refs");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_pushnumber(L, id);

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -116,7 +116,7 @@ void script_run_callbacks_f(lua_State *L, int nargs,
 	lua_insert(L, error_handler);
 
 	// Insert run_callbacks between error handler and table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "run_callbacks");
 	lua_remove(L, -2);
 	lua_insert(L, error_handler + 1);

--- a/src/script/cpp_api/s_async.cpp
+++ b/src/script/cpp_api/s_async.cpp
@@ -133,7 +133,7 @@ void AsyncEngine::putJobResult(const LuaJobInfo &result)
 void AsyncEngine::step(lua_State *L)
 {
 	int error_handler = PUSH_ERROR_HANDLER(L);
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	resultQueueMutex.lock();
 	while (!resultQueue.empty()) {
 		LuaJobInfo jobDone = resultQueue.front();
@@ -204,7 +204,7 @@ AsyncWorkerThread::AsyncWorkerThread(AsyncEngine* jobDispatcher,
 	lua_State *L = getStack();
 
 	// Prepare job lua environment
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	int top = lua_gettop(L);
 
 	// Push builtin initialization type
@@ -236,7 +236,7 @@ void* AsyncWorkerThread::run()
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	if (lua_isnil(L, -1)) {
 		FATAL_ERROR("Unable to find core within async environment!");
 	}

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -109,7 +109,7 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 
 	// Add basic globals
 	lua_newtable(m_luastack);
-	lua_setglobal(m_luastack, "core");
+	lua_setglobal(m_luastack, "minetest");
 
 	if (m_type == ScriptingType::Client)
 		lua_pushstring(m_luastack, "/");
@@ -255,7 +255,7 @@ void ScriptApiBase::runCallbacksRaw(int nargs,
 	lua_insert(L, error_handler);
 
 	// Insert run_callbacks between error handler and table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "run_callbacks");
 	lua_remove(L, -2);
 	lua_insert(L, error_handler + 1);
@@ -343,7 +343,7 @@ void ScriptApiBase::addObjectReference(ServerActiveObject *cobj)
 	int object = lua_gettop(L);
 
 	// Get core.object_refs table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "object_refs");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int objectstable = lua_gettop(L);
@@ -360,7 +360,7 @@ void ScriptApiBase::removeObjectReference(ServerActiveObject *cobj)
 	//infostream<<"scriptapi_rm_object_reference: id="<<cobj->getId()<<std::endl;
 
 	// Get core.object_refs table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "object_refs");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int objectstable = lua_gettop(L);

--- a/src/script/cpp_api/s_client.cpp
+++ b/src/script/cpp_api/s_client.cpp
@@ -30,7 +30,7 @@ void ScriptApiClient::on_mods_loaded()
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get registered shutdown hooks
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_mods_loaded");
 	// Call callbacks
 	runCallbacks(0, RUN_CALLBACKS_MODE_FIRST);
@@ -41,7 +41,7 @@ void ScriptApiClient::on_shutdown()
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get registered shutdown hooks
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_shutdown");
 	// Call callbacks
 	runCallbacks(0, RUN_CALLBACKS_MODE_FIRST);
@@ -52,7 +52,7 @@ bool ScriptApiClient::on_sending_message(const std::string &message)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_sending_chat_message");
 	// Call callbacks
 	lua_pushstring(L, message.c_str());
@@ -65,7 +65,7 @@ bool ScriptApiClient::on_receiving_message(const std::string &message)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_receiving_chat_message");
 	// Call callbacks
 	lua_pushstring(L, message.c_str());
@@ -78,7 +78,7 @@ void ScriptApiClient::on_damage_taken(int32_t damage_amount)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_damage_taken");
 	// Call callbacks
 	lua_pushinteger(L, damage_amount);
@@ -90,7 +90,7 @@ void ScriptApiClient::on_hp_modification(int32_t newhp)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_hp_modification");
 	// Call callbacks
 	lua_pushinteger(L, newhp);
@@ -102,7 +102,7 @@ void ScriptApiClient::on_death()
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get registered shutdown hooks
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_death");
 	// Call callbacks
 	runCallbacks(0, RUN_CALLBACKS_MODE_FIRST);
@@ -113,7 +113,7 @@ void ScriptApiClient::environment_step(float dtime)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_globalsteps
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_globalsteps");
 	// Call callbacks
 	lua_pushnumber(L, dtime);
@@ -131,7 +131,7 @@ void ScriptApiClient::on_formspec_input(const std::string &formname,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_formspec_input");
 	// Call callbacks
 	// param 1
@@ -156,7 +156,7 @@ bool ScriptApiClient::on_dignode(v3s16 p, MapNode node)
 	const NodeDefManager *ndef = getClient()->ndef();
 
 	// Get core.registered_on_dignode
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_dignode");
 
 	// Push data
@@ -175,7 +175,7 @@ bool ScriptApiClient::on_punchnode(v3s16 p, MapNode node)
 	const NodeDefManager *ndef = getClient()->ndef();
 
 	// Get core.registered_on_punchgnode
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_punchnode");
 
 	// Push data
@@ -192,7 +192,7 @@ bool ScriptApiClient::on_placenode(const PointedThing &pointed, const ItemDefini
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_placenode
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_placenode");
 
 	// Push data
@@ -209,7 +209,7 @@ bool ScriptApiClient::on_item_use(const ItemStack &item, const PointedThing &poi
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_item_use
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_item_use");
 
 	// Push data
@@ -225,7 +225,7 @@ bool ScriptApiClient::on_inventory_open(Inventory *inventory)
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_inventory_open");
 
 	std::vector<const InventoryList*> lists = inventory->getLists();

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -33,7 +33,7 @@ bool ScriptApiEntity::luaentity_Add(u16 id, const char *name)
 			<<name<<"\""<<std::endl;
 
 	// Get core.registered_entities[name]
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_entities");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_pushstring(L, name);
@@ -64,7 +64,7 @@ bool ScriptApiEntity::luaentity_Add(u16 id, const char *name)
 	lua_setfield(L, -2, "object");
 
 	// core.luaentities[id] = object
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "luaentities");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_pushnumber(L, id); // Push id
@@ -110,7 +110,7 @@ void ScriptApiEntity::luaentity_Remove(u16 id)
 	verbosestream << "scriptapi_luaentity_rm: id=" << id << std::endl;
 
 	// Get core.luaentities table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "luaentities");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int objectstable = lua_gettop(L);

--- a/src/script/cpp_api/s_env.cpp
+++ b/src/script/cpp_api/s_env.cpp
@@ -32,7 +32,7 @@ void ScriptApiEnv::environment_OnGenerated(v3s16 minp, v3s16 maxp,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_generateds
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_generateds");
 	// Call callbacks
 	push_v3s16(L, minp);
@@ -47,7 +47,7 @@ void ScriptApiEnv::environment_Step(float dtime)
 	//infostream << "scriptapi_environment_step" << std::endl;
 
 	// Get core.registered_globalsteps
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_globalsteps");
 	// Call callbacks
 	lua_pushnumber(L, dtime);
@@ -94,7 +94,7 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 	*/
 
 	// Get core.registered_abms
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_abms");
 	int registered_abms = lua_gettop(L);
 
@@ -166,7 +166,7 @@ void ScriptApiEnv::initializeEnvironment(ServerEnvironment *env)
 	lua_pop(L, 1);
 
 	// Get core.registered_lbms
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_lbms");
 	int registered_lbms = lua_gettop(L);
 

--- a/src/script/cpp_api/s_inventory.cpp
+++ b/src/script/cpp_api/s_inventory.cpp
@@ -191,7 +191,7 @@ bool ScriptApiDetached::getDetachedInventoryCallback(
 {
 	lua_State *L = getStack();
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "detached_inventories");
 	lua_remove(L, -2);
 	luaL_checktype(L, -1, LUA_TTABLE);

--- a/src/script/cpp_api/s_item.cpp
+++ b/src/script/cpp_api/s_item.cpp
@@ -147,7 +147,7 @@ bool ScriptApiItem::item_OnCraft(ItemStack &item, ServerActiveObject *user,
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "on_craft");
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);
@@ -179,7 +179,7 @@ bool ScriptApiItem::item_CraftPredict(ItemStack &item, ServerActiveObject *user,
 	sanity_check(old_craft_grid);
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "craft_predict");
 	LuaItemStack::create(L, item);
 	objectrefGetOrCreate(L, user);
@@ -215,7 +215,7 @@ bool ScriptApiItem::getItemCallback(const char *name, const char *callbackname,
 {
 	lua_State* L = getStack();
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_items");
 	lua_remove(L, -2); // Remove core
 	luaL_checktype(L, -1, LUA_TTABLE);
@@ -231,7 +231,7 @@ bool ScriptApiItem::getItemCallback(const char *name, const char *callbackname,
 		lua_pop(L, 1);
 
 		// Try core.nodedef_default instead
-		lua_getglobal(L, "core");
+		lua_getglobal(L, "minetest");
 		lua_getfield(L, -1, "nodedef_default");
 		lua_remove(L, -2);
 		luaL_checktype(L, -1, LUA_TTABLE);

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -45,7 +45,7 @@ void ScriptApiMainMenu::handleMainMenuEvent(std::string text)
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get handler function
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "event_handler");
 	lua_remove(L, -2); // Remove core
 	if (lua_isnil(L, -1)) {
@@ -67,7 +67,7 @@ void ScriptApiMainMenu::handleMainMenuButtons(const StringMap &fields)
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get handler function
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "button_handler");
 	lua_remove(L, -2); // Remove core
 	if (lua_isnil(L, -1)) {

--- a/src/script/cpp_api/s_modchannels.cpp
+++ b/src/script/cpp_api/s_modchannels.cpp
@@ -26,7 +26,7 @@ void ScriptApiModChannels::on_modchannel_message(const std::string &channel,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_generateds
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_modchannel_message");
 	// Call callbacks
 	lua_pushstring(L, channel.c_str());
@@ -41,7 +41,7 @@ void ScriptApiModChannels::on_modchannel_signal(
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_generateds
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_modchannel_signal");
 	// Call callbacks
 	lua_pushstring(L, channel.c_str());

--- a/src/script/cpp_api/s_player.cpp
+++ b/src/script/cpp_api/s_player.cpp
@@ -32,7 +32,7 @@ void ScriptApiPlayer::on_newplayer(ServerActiveObject *player)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_newplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_newplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -44,7 +44,7 @@ void ScriptApiPlayer::on_dieplayer(ServerActiveObject *player, const PlayerHPCha
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get callback table
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_dieplayers");
 
 	// Push arguments
@@ -64,7 +64,7 @@ bool ScriptApiPlayer::on_punchplayer(ServerActiveObject *player,
 {
 	SCRIPTAPI_PRECHECKHEADER
 	// Get core.registered_on_punchplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_punchplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -85,7 +85,7 @@ s32 ScriptApiPlayer::on_player_hpchange(ServerActiveObject *player,
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get core.registered_on_player_hpchange
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_player_hpchange");
 	lua_remove(L, -2);
 
@@ -106,7 +106,7 @@ bool ScriptApiPlayer::on_respawnplayer(ServerActiveObject *player)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_respawnplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_respawnplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -122,7 +122,7 @@ bool ScriptApiPlayer::on_prejoinplayer(
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_prejoinplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_prejoinplayers");
 	lua_pushstring(L, name.c_str());
 	lua_pushstring(L, ip.c_str());
@@ -139,7 +139,7 @@ bool ScriptApiPlayer::can_bypass_userlimit(const std::string &name, const std::s
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_prejoinplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_can_bypass_userlimit");
 	lua_pushstring(L, name.c_str());
 	lua_pushstring(L, ip.c_str());
@@ -152,7 +152,7 @@ void ScriptApiPlayer::on_joinplayer(ServerActiveObject *player)
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_joinplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_joinplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -165,7 +165,7 @@ void ScriptApiPlayer::on_leaveplayer(ServerActiveObject *player,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_leaveplayers
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_leaveplayers");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -179,7 +179,7 @@ void ScriptApiPlayer::on_cheat(ServerActiveObject *player,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_cheats
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_cheats");
 	// Call callbacks
 	objectrefGetOrCreate(L, player);
@@ -196,7 +196,7 @@ void ScriptApiPlayer::on_playerReceiveFields(ServerActiveObject *player,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_player_receive_fields
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_player_receive_fields");
 	// Call callbacks
 	// param 1
@@ -221,7 +221,7 @@ void ScriptApiPlayer::on_auth_failure(const std::string &name, const std::string
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_auth_failure
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_auth_fail");
 	lua_pushstring(L, name.c_str());
 	lua_pushstring(L, ip.c_str());
@@ -284,7 +284,7 @@ int ScriptApiPlayer::player_inventory_AllowMove(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_allow_player_inventory_actions");
 	pushMoveArguments(ma, count, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_OR_SC);
@@ -299,7 +299,7 @@ int ScriptApiPlayer::player_inventory_AllowPut(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_allow_player_inventory_actions");
 	pushPutTakeArguments("put", ma.to_inv, ma.to_list, ma.to_i, stack, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_OR_SC);
@@ -314,7 +314,7 @@ int ScriptApiPlayer::player_inventory_AllowTake(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_allow_player_inventory_actions");
 	pushPutTakeArguments("take", ma.from_inv, ma.from_list, ma.from_i, stack, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_OR_SC);
@@ -329,7 +329,7 @@ void ScriptApiPlayer::player_inventory_OnMove(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_player_inventory_actions");
 	pushMoveArguments(ma, count, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_FIRST);
@@ -342,7 +342,7 @@ void ScriptApiPlayer::player_inventory_OnPut(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_player_inventory_actions");
 	pushPutTakeArguments("put", ma.to_inv, ma.to_list, ma.to_i, stack, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_FIRST);
@@ -355,7 +355,7 @@ void ScriptApiPlayer::player_inventory_OnTake(
 {
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_player_inventory_actions");
 	pushPutTakeArguments("take", ma.from_inv, ma.from_list, ma.from_i, stack, player);
 	runCallbacks(4, RUN_CALLBACKS_MODE_FIRST);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -60,7 +60,7 @@ void ScriptApiSecurity::initializeSecurity()
 {
 	static const char *whitelist[] = {
 		"assert",
-		"core",
+		"minetest",
 		"collectgarbage",
 		"DIR_DELIM",
 		"error",
@@ -228,7 +228,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 {
 	static const char *whitelist[] = {
 		"assert",
-		"core",
+		"minetest",
 		"collectgarbage",
 		"DIR_DELIM",
 		"error",

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -63,7 +63,7 @@ void ScriptApiServer::getAuthHandler()
 {
 	lua_State *L = getStack();
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_auth_handler");
 	if (lua_isnil(L, -1)){
 		lua_pop(L, 1);
@@ -137,7 +137,7 @@ bool ScriptApiServer::on_chat_message(const std::string &name,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get core.registered_on_chat_messages
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_chat_messages");
 	// Call callbacks
 	lua_pushstring(L, name.c_str());
@@ -151,7 +151,7 @@ void ScriptApiServer::on_mods_loaded()
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get registered shutdown hooks
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_mods_loaded");
 	// Call callbacks
 	runCallbacks(0, RUN_CALLBACKS_MODE_FIRST);
@@ -162,7 +162,7 @@ void ScriptApiServer::on_shutdown()
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Get registered shutdown hooks
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_on_shutdown");
 	// Call callbacks
 	runCallbacks(0, RUN_CALLBACKS_MODE_FIRST);
@@ -174,7 +174,7 @@ std::string ScriptApiServer::formatChatMessage(const std::string &name,
 	SCRIPTAPI_PRECHECKHEADER
 
 	// Push function onto stack
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "format_chat_message");
 
 	// Push arguments onto stack

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -31,7 +31,7 @@ LuaCamera::LuaCamera(Camera *m) : m_camera(m)
 
 void LuaCamera::create(lua_State *L, Camera *m)
 {
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int objectstable = lua_gettop(L);
 	lua_getfield(L, -1, "camera");

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -66,7 +66,7 @@ void LuaABM::trigger(ServerEnvironment *env, v3s16 p, MapNode n,
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get registered_abms
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_abms");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_remove(L, -2); // Remove core
@@ -109,7 +109,7 @@ void LuaLBM::trigger(ServerEnvironment *env, v3s16 p, MapNode n)
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Get registered_lbms
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_lbms");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_remove(L, -2); // Remove core
@@ -626,7 +626,7 @@ int ModApiEnvMod::l_add_item(lua_State *L)
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	// Use spawn_item to spawn a __builtin:item
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "spawn_item");
 	lua_remove(L, -2); // Remove core
 	if(lua_isnil(L, -1))

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -166,7 +166,7 @@ int ModApiHttp::l_request_http_api(lua_State *L)
 		return 1;
 	}
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "http_add_fetch");
 
 	lua_newtable(L);

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -297,7 +297,7 @@ int LuaItemStack::l_get_definition(lua_State *L)
 	ItemStack &item = o->m_stack;
 
 	// Get registered_items[name]
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "registered_items");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	lua_getfield(L, -1, item.name.c_str());

--- a/src/script/lua_api/l_localplayer.cpp
+++ b/src/script/lua_api/l_localplayer.cpp
@@ -30,7 +30,7 @@ LuaLocalPlayer::LuaLocalPlayer(LocalPlayer *m) : m_localplayer(m)
 
 void LuaLocalPlayer::create(lua_State *L, LocalPlayer *m)
 {
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int objectstable = lua_gettop(L);
 	lua_getfield(L, -1, "localplayer");

--- a/src/script/lua_api/l_minimap.cpp
+++ b/src/script/lua_api/l_minimap.cpp
@@ -39,7 +39,7 @@ void LuaMinimap::create(lua_State *L, Minimap *m)
 	// Keep minimap object stack id
 	int minimap_object = lua_gettop(L);
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	lua_getfield(L, -1, "ui");
 	luaL_checktype(L, -1, LUA_TTABLE);
 	int uitable = lua_gettop(L);

--- a/src/script/scripting_client.cpp
+++ b/src/script/scripting_client.cpp
@@ -46,7 +46,7 @@ ClientScripting::ClientScripting(Client *client):
 	// Security is mandatory client side
 	initializeSecurityClient();
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	int top = lua_gettop(L);
 
 	lua_newtable(L);

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -41,7 +41,7 @@ MainMenuScripting::MainMenuScripting(GUIEngine* guiengine):
 
 	SCRIPTAPI_PRECHECKHEADER
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	int top = lua_gettop(L);
 
 	lua_newtable(L);

--- a/src/script/scripting_server.cpp
+++ b/src/script/scripting_server.cpp
@@ -64,7 +64,7 @@ ServerScripting::ServerScripting(Server* server):
 		initializeSecurity();
 	}
 
-	lua_getglobal(L, "core");
+	lua_getglobal(L, "minetest");
 	int top = lua_gettop(L);
 
 	lua_newtable(L);


### PR DESCRIPTION
Because `core` and` minetest` are identical objects, there is no need to have two.

this pr depends on https://github.com/minetest/minetest_game/pull/2552