### PR TITLE
Map download: Escape ':' to '_'

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -782,10 +782,13 @@ void Client::initLocalMapSaving(const Address &address,
 		return;
 	}
 
+	std::string hostname_escaped = hostname;
+	str_replace(hostname_escaped, ':', '_');
+
 	const std::string world_path = porting::path_user
 		+ DIR_DELIM + "worlds"
 		+ DIR_DELIM + "server_"
-		+ hostname + "_" + std::to_string(address.getPort());
+		+ hostname_escaped + "_" + std::to_string(address.getPort());
 
 	fs::CreateAllDirs(world_path);
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -782,14 +782,20 @@ void Client::initLocalMapSaving(const Address &address,
 		return;
 	}
 
-	std::string hostname_escaped = hostname;
-	str_replace(hostname_escaped, ':', '_');
+	std::string world_path;
+#define set_world_path(hostname) \
+	world_path = porting::path_user \
+		+ DIR_DELIM + "worlds" \
+		+ DIR_DELIM + "server_" \
+		+ hostname + "_" + std::to_string(address.getPort());
 
-	const std::string world_path = porting::path_user
-		+ DIR_DELIM + "worlds"
-		+ DIR_DELIM + "server_"
-		+ hostname_escaped + "_" + std::to_string(address.getPort());
-
+	set_world_path(hostname);
+	if (!fs::IsDir(world_path)) {
+		std::string hostname_escaped = hostname;
+		str_replace(hostname_escaped, ':', '_');
+		set_world_path(hostname_escaped);
+	}
+#undef set_world_path
 	fs::CreateAllDirs(world_path);
 
 	m_localdb = new MapDatabaseSQLite3(world_path);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

Under windows, clients that direct connect to a server by its IPv6 address and have map saving enabling crash upon trying to create the save directory, which will contain ':' (a disallowed character on Windows).

This PR resolves #9215 

Starting from now, any new map saves on all platforms will replace ':' in the hostname with '_'. To preserve backwards compatibility with any IPv6 worlds made on systems that *do* support ':' in filenames, the presence of a directory with the un-escaped hostname is first checked before trying to escape.

This PR is Ready for Review.

## How to test
* Connect to a server by IPv6 e.g. LinuxWorks Next Generation 2a03:4000:35:2c0::1, in the follow cases:
* With a Windows system
* With a linux system before and after compiling this branch, to make sure the old save is loaded instead
* With a linux system after compiling this branch and without any map save for the server.