### PR TITLE
Document permissible group ratings

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1481,7 +1481,8 @@ Usage
 -----
 
 Groups are stored in a table, having the group names with keys and the
-group ratings as values. For example:
+group ratings as values. Group ratings are integer values within the
+range [-32767, 32767]. For example:
 
     -- Default dirt
     groups = {crumbly=3, soil=1}


### PR DESCRIPTION
This very small PR adds documentation in `lua_api.txt` to describe the data type and permissible value range of group ratings.

According to `src/itemgroup.h`, group ratings are of type `int`.

According to <https://en.wikipedia.org/wiki/C_data_types>, `int`, only guarantees a value range of `[-32767, 32767]`, so this range is documented as officially supported.