### PR TITLE
Remove Mapgen V7 floatlands in preparation for new implementation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1622,22 +1622,6 @@ mgv7_large_cave_num_max (Large cave maximum number) int 2 0 64
 #    Proportion of large caves that contain liquid.
 mgv7_large_cave_flooded (Large cave proportion flooded) float 0.5 0.0 1.0
 
-#    Controls the density of mountain-type floatlands.
-#    Is a noise offset added to the 'mgv7_np_mountain' noise value.
-mgv7_float_mount_density (Floatland mountain density) float 0.6
-
-#    Typical maximum height, above and below midpoint, of floatland mountains.
-mgv7_float_mount_height (Floatland mountain height) float 128.0
-
-#    Alters how mountain-type floatlands taper above and below midpoint.
-mgv7_float_mount_exponent (Floatland mountain exponent) float 0.75
-
-#    Y-level of floatland midpoint and lake surface.
-mgv7_floatland_level (Floatland level) int 1280
-
-#    Y-level to which floatland shadows extend.
-mgv7_shadow_limit (Shadow limit) int 1024
-
 #    Y-level of cavern upper limit.
 mgv7_cavern_limit (Cavern limit) int -256
 
@@ -1676,13 +1660,6 @@ mgv7_np_mount_height (Mountain height noise) noise_params_2d 256, 112, (1000, 10
 
 #    Defines large-scale river channel structure.
 mgv7_np_ridge_uwater (Ridge underwater noise) noise_params_2d 0, 1, (1000, 1000, 1000), 85039, 5, 0.6, 2.0, eased
-
-#    Defines areas of floatland smooth terrain.
-#    Smooth floatlands occur when noise > 0.
-mgv7_np_floatland_base (Floatland base noise) noise_params_2d -0.6, 1.5, (600, 600, 600), 114, 5, 0.6, 2.0, eased
-
-#    Variation of hill height and lake depth on floatland smooth terrain.
-mgv7_np_float_base_height (Floatland base height noise) noise_params_2d 48, 24, (300, 300, 300), 907, 4, 0.7, 2.0, eased
 
 #    3D noise defining mountain structure and height.
 #    Also defines structure of floatland mountain terrain.

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2013-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2014-2018 paramat
+Copyright (C) 2013-2019 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2014-2019 paramat
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -55,12 +55,8 @@ FlagDesc flagdesc_mapgen_v7[] = {
 MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	: MapgenBasic(MAPGEN_V7, params, emerge)
 {
-	spflags              = params->spflags;
-	mount_zero_level     = params->mount_zero_level;
-	float_mount_density  = params->float_mount_density;
-	float_mount_exponent = params->float_mount_exponent;
-	floatland_level      = params->floatland_level;
-	shadow_limit         = params->shadow_limit;
+	spflags            = params->spflags;
+	mount_zero_level   = params->mount_zero_level;
 
 	cave_width         = params->cave_width;
 	large_cave_depth   = params->large_cave_depth;
@@ -75,11 +71,6 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	dungeon_ymin       = params->dungeon_ymin;
 	dungeon_ymax       = params->dungeon_ymax;
 
-	// This is to avoid a divide-by-zero.
-	// Parameter will be saved to map_meta.txt in limited form.
-	params->float_mount_height = std::fmax(params->float_mount_height, 1.0f);
-	float_mount_height   = params->float_mount_height;
-
 	// 2D noise
 	noise_terrain_base =
 		new Noise(&params->np_terrain_base,    seed, csize.X, csize.Z);
@@ -92,34 +83,29 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeManager *emerge)
 	noise_filler_depth =
 		new Noise(&params->np_filler_depth,    seed, csize.X, csize.Z);
 
-	if (spflags & MGV7_MOUNTAINS)
+	if (spflags & MGV7_MOUNTAINS) {
+		// 2D noise
 		noise_mount_height =
-			new Noise(&params->np_mount_height,      seed, csize.X, csize.Z);
-
-	if (spflags & MGV7_FLOATLANDS) {
-		noise_floatland_base =
-			new Noise(&params->np_floatland_base,    seed, csize.X, csize.Z);
-		noise_float_base_height =
-			new Noise(&params->np_float_base_height, seed, csize.X, csize.Z);
+			new Noise(&params->np_mount_height, seed, csize.X, csize.Z);
+		// 3D noise, 1 up, 1 down overgeneration
+		noise_mountain =
+			new Noise(&params->np_mountain,     seed, csize.X, csize.Y + 2, csize.Z);
 	}
 
 	if (spflags & MGV7_RIDGES) {
+		// 2D noise
 		noise_ridge_uwater =
-			new Noise(&params->np_ridge_uwater,      seed, csize.X, csize.Z);
-	// 3D noise, 1 up, 1 down overgeneration
+			new Noise(&params->np_ridge_uwater, seed, csize.X, csize.Z);
+		// 3D noise, 1 up, 1 down overgeneration
 		noise_ridge =
-			new Noise(&params->np_ridge,    seed, csize.X, csize.Y + 2, csize.Z);
+			new Noise(&params->np_ridge,        seed, csize.X, csize.Y + 2, csize.Z);
 	}
-
-	// 3D noise, 1 up, 1 down overgeneration
-	if ((spflags & MGV7_MOUNTAINS) || (spflags & MGV7_FLOATLANDS))
-		noise_mountain =
-			new Noise(&params->np_mountain, seed, csize.X, csize.Y + 2, csize.Z);
 
 	// 3D noise, 1 down overgeneration
 	MapgenBasic::np_cave1    = params->np_cave1;
 	MapgenBasic::np_cave2    = params->np_cave2;
 	MapgenBasic::np_cavern   = params->np_cavern;
+	// 3D noise
 	MapgenBasic::np_dungeons = params->np_dungeons;
 }
 
@@ -132,21 +118,15 @@ MapgenV7::~MapgenV7()
 	delete noise_height_select;
 	delete noise_filler_depth;
 
-	if (spflags & MGV7_MOUNTAINS)
+	if (spflags & MGV7_MOUNTAINS) {
 		delete noise_mount_height;
-
-	if (spflags & MGV7_FLOATLANDS) {
-		delete noise_floatland_base;
-		delete noise_float_base_height;
+		delete noise_mountain;
 	}
 
 	if (spflags & MGV7_RIDGES) {
 		delete noise_ridge_uwater;
 		delete noise_ridge;
 	}
-
-	if ((spflags & MGV7_MOUNTAINS) || (spflags & MGV7_FLOATLANDS))
-		delete noise_mountain;
 }
 
 
@@ -158,8 +138,6 @@ MapgenV7Params::MapgenV7Params():
 	np_filler_depth      (0.0,   1.2,   v3f(150,  150,  150),  261,   3, 0.7,  2.0),
 	np_mount_height      (256.0, 112.0, v3f(1000, 1000, 1000), 72449, 3, 0.6,  2.0),
 	np_ridge_uwater      (0.0,   1.0,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0),
-	np_floatland_base    (-0.6,  1.5,   v3f(600,  600,  600),  114,   5, 0.6,  2.0),
-	np_float_base_height (48.0,  24.0,  v3f(300,  300,  300),  907,   4, 0.7,  2.0),
 	np_mountain          (-0.6,  1.0,   v3f(250,  350,  250),  5333,  5, 0.63, 2.0),
 	np_ridge             (0.0,   1.0,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0),
 	np_cavern            (0.0,   1.0,   v3f(384,  128,  384),  723,   5, 0.63, 2.0),
@@ -181,72 +159,58 @@ void MapgenV7Params::readParams(const Settings *settings)
 	settings->getU16NoEx("mgv7_large_cave_num_min",     large_cave_num_min);
 	settings->getU16NoEx("mgv7_large_cave_num_max",     large_cave_num_max);
 	settings->getFloatNoEx("mgv7_large_cave_flooded",   large_cave_flooded);
-	settings->getFloatNoEx("mgv7_float_mount_density",  float_mount_density);
-	settings->getFloatNoEx("mgv7_float_mount_height",   float_mount_height);
-	settings->getFloatNoEx("mgv7_float_mount_exponent", float_mount_exponent);
-	settings->getS16NoEx("mgv7_floatland_level",        floatland_level);
-	settings->getS16NoEx("mgv7_shadow_limit",           shadow_limit);
 	settings->getS16NoEx("mgv7_cavern_limit",           cavern_limit);
 	settings->getS16NoEx("mgv7_cavern_taper",           cavern_taper);
 	settings->getFloatNoEx("mgv7_cavern_threshold",     cavern_threshold);
 	settings->getS16NoEx("mgv7_dungeon_ymin",           dungeon_ymin);
 	settings->getS16NoEx("mgv7_dungeon_ymax",           dungeon_ymax);
 
-	settings->getNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
-	settings->getNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
-	settings->getNoiseParams("mgv7_np_terrain_persist",   np_terrain_persist);
-	settings->getNoiseParams("mgv7_np_height_select",     np_height_select);
-	settings->getNoiseParams("mgv7_np_filler_depth",      np_filler_depth);
-	settings->getNoiseParams("mgv7_np_mount_height",      np_mount_height);
-	settings->getNoiseParams("mgv7_np_ridge_uwater",      np_ridge_uwater);
-	settings->getNoiseParams("mgv7_np_floatland_base",    np_floatland_base);
-	settings->getNoiseParams("mgv7_np_float_base_height", np_float_base_height);
-	settings->getNoiseParams("mgv7_np_mountain",          np_mountain);
-	settings->getNoiseParams("mgv7_np_ridge",             np_ridge);
-	settings->getNoiseParams("mgv7_np_cavern",            np_cavern);
-	settings->getNoiseParams("mgv7_np_cave1",             np_cave1);
-	settings->getNoiseParams("mgv7_np_cave2",             np_cave2);
-	settings->getNoiseParams("mgv7_np_dungeons",          np_dungeons);
+	settings->getNoiseParams("mgv7_np_terrain_base",    np_terrain_base);
+	settings->getNoiseParams("mgv7_np_terrain_alt",     np_terrain_alt);
+	settings->getNoiseParams("mgv7_np_terrain_persist", np_terrain_persist);
+	settings->getNoiseParams("mgv7_np_height_select",   np_height_select);
+	settings->getNoiseParams("mgv7_np_filler_depth",    np_filler_depth);
+	settings->getNoiseParams("mgv7_np_mount_height",    np_mount_height);
+	settings->getNoiseParams("mgv7_np_ridge_uwater",    np_ridge_uwater);
+	settings->getNoiseParams("mgv7_np_mountain",        np_mountain);
+	settings->getNoiseParams("mgv7_np_ridge",           np_ridge);
+	settings->getNoiseParams("mgv7_np_cavern",          np_cavern);
+	settings->getNoiseParams("mgv7_np_cave1",           np_cave1);
+	settings->getNoiseParams("mgv7_np_cave2",           np_cave2);
+	settings->getNoiseParams("mgv7_np_dungeons",        np_dungeons);
 }
 
 
 void MapgenV7Params::writeParams(Settings *settings) const
 {
 	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7, U32_MAX);
-	settings->setS16("mgv7_mount_zero_level",       mount_zero_level);
-	settings->setFloat("mgv7_cave_width",           cave_width);
-	settings->setS16("mgv7_large_cave_depth",       large_cave_depth);
-	settings->setU16("mgv7_small_cave_num_min",     small_cave_num_min);
-	settings->setU16("mgv7_small_cave_num_max",     small_cave_num_max);
-	settings->setU16("mgv7_large_cave_num_min",     large_cave_num_min);
-	settings->setU16("mgv7_large_cave_num_max",     large_cave_num_max);
-	settings->setFloat("mgv7_large_cave_flooded",   large_cave_flooded);
-	settings->setFloat("mgv7_float_mount_density",  float_mount_density);
-	settings->setFloat("mgv7_float_mount_height",   float_mount_height);
-	settings->setFloat("mgv7_float_mount_exponent", float_mount_exponent);
-	settings->setS16("mgv7_floatland_level",        floatland_level);
-	settings->setS16("mgv7_shadow_limit",           shadow_limit);
-	settings->setS16("mgv7_cavern_limit",           cavern_limit);
-	settings->setS16("mgv7_cavern_taper",           cavern_taper);
-	settings->setFloat("mgv7_cavern_threshold",     cavern_threshold);
-	settings->setS16("mgv7_dungeon_ymin",           dungeon_ymin);
-	settings->setS16("mgv7_dungeon_ymax",           dungeon_ymax);
+	settings->setS16("mgv7_mount_zero_level",           mount_zero_level);
+	settings->setFloat("mgv7_cave_width",               cave_width);
+	settings->setS16("mgv7_large_cave_depth",           large_cave_depth);
+	settings->setU16("mgv7_small_cave_num_min",         small_cave_num_min);
+	settings->setU16("mgv7_small_cave_num_max",         small_cave_num_max);
+	settings->setU16("mgv7_large_cave_num_min",         large_cave_num_min);
+	settings->setU16("mgv7_large_cave_num_max",         large_cave_num_max);
+	settings->setFloat("mgv7_large_cave_flooded",       large_cave_flooded);
+	settings->setS16("mgv7_cavern_limit",               cavern_limit);
+	settings->setS16("mgv7_cavern_taper",               cavern_taper);
+	settings->setFloat("mgv7_cavern_threshold",         cavern_threshold);
+	settings->setS16("mgv7_dungeon_ymin",               dungeon_ymin);
+	settings->setS16("mgv7_dungeon_ymax",               dungeon_ymax);
 
-	settings->setNoiseParams("mgv7_np_terrain_base",      np_terrain_base);
-	settings->setNoiseParams("mgv7_np_terrain_alt",       np_terrain_alt);
-	settings->setNoiseParams("mgv7_np_terrain_persist",   np_terrain_persist);
-	settings->setNoiseParams("mgv7_np_height_select",     np_height_select);
-	settings->setNoiseParams("mgv7_np_filler_depth",      np_filler_depth);
-	settings->setNoiseParams("mgv7_np_mount_height",      np_mount_height);
-	settings->setNoiseParams("mgv7_np_ridge_uwater",      np_ridge_uwater);
-	settings->setNoiseParams("mgv7_np_floatland_base",    np_floatland_base);
-	settings->setNoiseParams("mgv7_np_float_base_height", np_float_base_height);
-	settings->setNoiseParams("mgv7_np_mountain",          np_mountain);
-	settings->setNoiseParams("mgv7_np_ridge",             np_ridge);
-	settings->setNoiseParams("mgv7_np_cavern",            np_cavern);
-	settings->setNoiseParams("mgv7_np_cave1",             np_cave1);
-	settings->setNoiseParams("mgv7_np_cave2",             np_cave2);
-	settings->setNoiseParams("mgv7_np_dungeons",          np_dungeons);
+	settings->setNoiseParams("mgv7_np_terrain_base",    np_terrain_base);
+	settings->setNoiseParams("mgv7_np_terrain_alt",     np_terrain_alt);
+	settings->setNoiseParams("mgv7_np_terrain_persist", np_terrain_persist);
+	settings->setNoiseParams("mgv7_np_height_select",   np_height_select);
+	settings->setNoiseParams("mgv7_np_filler_depth",    np_filler_depth);
+	settings->setNoiseParams("mgv7_np_mount_height",    np_mount_height);
+	settings->setNoiseParams("mgv7_np_ridge_uwater",    np_ridge_uwater);
+	settings->setNoiseParams("mgv7_np_mountain",        np_mountain);
+	settings->setNoiseParams("mgv7_np_ridge",           np_ridge);
+	settings->setNoiseParams("mgv7_np_cavern",          np_cavern);
+	settings->setNoiseParams("mgv7_np_cave1",           np_cave1);
+	settings->setNoiseParams("mgv7_np_cave2",           np_cave2);
+	settings->setNoiseParams("mgv7_np_dungeons",        np_dungeons);
 }
 
 
@@ -386,10 +350,9 @@ void MapgenV7::makeChunk(BlockMakeData *data)
 	// Update liquids
 	updateLiquid(&data->transforming_liquid, full_node_min, full_node_max);
 
-	// Calculate lighting.
-	// Limit floatland shadow.
-	bool propagate_shadow = !((spflags & MGV7_FLOATLANDS) &&
-		node_min.Y <= shadow_limit && node_max.Y >= shadow_limit);
+	// Calculate lighting
+	// TODO disable in and just below floatlands
+	bool propagate_shadow = true;
 
 	if (flags & MG_LIGHT)
 		calcLighting(node_min - v3s16(0, 1, 0), node_max + v3s16(0, 1, 0),
@@ -458,53 +421,6 @@ bool MapgenV7::getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y)
 }
 
 
-bool MapgenV7::getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y)
-{
-	// Make rim 2 nodes thick to match floatland base terrain
-	float density_gradient = (y >= floatland_level) ?
-		-std::pow((float)(y - floatland_level) / float_mount_height,
-		float_mount_exponent) :
-		-std::pow((float)(floatland_level - 1 - y) / float_mount_height,
-		float_mount_exponent);
-
-	float floatn = noise_mountain->result[idx_xyz] + float_mount_density;
-
-	return floatn + density_gradient >= 0.0f;
-}
-
-
-void MapgenV7::floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max,
-	int idx_xz)
-{
-	// '+1' to avoid a layer of stone at y = MAX_MAP_GENERATION_LIMIT
-	s16 base_min = MAX_MAP_GENERATION_LIMIT + 1;
-	s16 base_max = MAX_MAP_GENERATION_LIMIT;
-
-	float n_base = noise_floatland_base->result[idx_xz];
-	if (n_base > 0.0f) {
-		float n_base_height =
-				std::fmax(noise_float_base_height->result[idx_xz], 1.0f);
-		float amp = n_base * n_base_height;
-		float ridge = n_base_height / 3.0f;
-		base_min = floatland_level - amp / 1.5f;
-
-		if (amp > ridge * 2.0f) {
-			// Lake bed
-			base_max = floatland_level - (amp - ridge * 2.0f) / 2.0f;
-		} else {
-			// Hills and ridges
-			float diff = std::fabs(amp - ridge) / ridge;
-			// Smooth ridges using the 'smoothstep function'
-			float smooth_diff = diff * diff * (3.0f - 2.0f * diff);
-			base_max = floatland_level + ridge - smooth_diff * ridge;
-		}
-	}
-
-	*float_base_min = base_min;
-	*float_base_max = base_max;
-}
-
-
 int MapgenV7::generateTerrain()
 {
 	MapNode n_air(CONTENT_AIR);
@@ -519,17 +435,9 @@ int MapgenV7::generateTerrain()
 	noise_terrain_alt->perlinMap2D(node_min.X, node_min.Z, persistmap);
 	noise_height_select->perlinMap2D(node_min.X, node_min.Z);
 
-	if ((spflags & MGV7_MOUNTAINS) || (spflags & MGV7_FLOATLANDS)) {
-		noise_mountain->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
-	}
-
 	if (spflags & MGV7_MOUNTAINS) {
 		noise_mount_height->perlinMap2D(node_min.X, node_min.Z);
-	}
-
-	if (spflags & MGV7_FLOATLANDS) {
-		noise_floatland_base->perlinMap2D(node_min.X, node_min.Z);
-		noise_float_base_height->perlinMap2D(node_min.X, node_min.Z);
+		noise_mountain->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);
 	}
 
 	//// Place nodes
@@ -542,13 +450,6 @@ int MapgenV7::generateTerrain()
 		s16 surface_y = baseTerrainLevelFromMap(index2d);
 		if (surface_y > stone_surface_max_y)
 			stone_surface_max_y = surface_y;
-
-		// Get extent of floatland base terrain
-		// '+1' to avoid a layer of stone at y = MAX_MAP_GENERATION_LIMIT
-		s16 float_base_min = MAX_MAP_GENERATION_LIMIT + 1;
-		s16 float_base_max = MAX_MAP_GENERATION_LIMIT;
-		if (spflags & MGV7_FLOATLANDS)
-			floatBaseExtentFromMap(&float_base_min, &float_base_max, index2d);
 
 		u32 vi = vm->m_area.index(x, node_min.Y - 1, z);
 		u32 index3d = (z - node_min.Z) * zstride_1u1d + (x - node_min.X);
@@ -567,16 +468,8 @@ int MapgenV7::generateTerrain()
 				vm->m_data[vi] = n_stone; // Mountain terrain
 				if (y > stone_surface_max_y)
 					stone_surface_max_y = y;
-			} else if ((spflags & MGV7_FLOATLANDS) &&
-					((y >= float_base_min && y <= float_base_max) ||
-					getFloatlandMountainFromMap(index3d, index2d, y))) {
-				vm->m_data[vi] = n_stone; // Floatland terrain
-				stone_surface_max_y = node_max.Y;
 			} else if (y <= water_level) {
-				vm->m_data[vi] = n_water; // Ground level water
-			} else if ((spflags & MGV7_FLOATLANDS) &&
-					(y >= float_base_max && y <= floatland_level)) {
-				vm->m_data[vi] = n_water; // Floatland water
+				vm->m_data[vi] = n_water;
 			} else {
 				vm->m_data[vi] = n_air;
 			}
@@ -589,8 +482,8 @@ int MapgenV7::generateTerrain()
 
 void MapgenV7::generateRidgeTerrain()
 {
-	if (node_max.Y < water_level - 16 ||
-			((spflags & MGV7_FLOATLANDS) && node_max.Y > shadow_limit))
+	// TODO disable river canyons in floatlands
+	if (node_max.Y < water_level - 16)
 		return;
 
 	noise_ridge->perlinMap3D(node_min.X, node_min.Y - 1, node_min.Z);

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -37,11 +37,6 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	s16 mount_zero_level = 0;
-	float float_mount_density = 0.6f;
-	float float_mount_height = 128.0f;
-	float float_mount_exponent = 0.75f;
-	s16 floatland_level = 1280;
-	s16 shadow_limit = 1024;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -63,8 +58,6 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_filler_depth;
 	NoiseParams np_mount_height;
 	NoiseParams np_ridge_uwater;
-	NoiseParams np_floatland_base;
-	NoiseParams np_float_base_height;
 	NoiseParams np_mountain;
 	NoiseParams np_ridge;
 	NoiseParams np_cavern;
@@ -94,19 +87,12 @@ public:
 	float baseTerrainLevelFromMap(int index);
 	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
 	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
-	bool getFloatlandMountainFromMap(int idx_xyz, int idx_xz, s16 y);
-	void floatBaseExtentFromMap(s16 *float_base_min, s16 *float_base_max, int idx_xz);
 
 	int generateTerrain();
 	void generateRidgeTerrain();
 
 private:
 	s16 mount_zero_level;
-	float float_mount_density;
-	float float_mount_height;
-	float float_mount_exponent;
-	s16 floatland_level;
-	s16 shadow_limit;
 
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
@@ -114,8 +100,6 @@ private:
 	Noise *noise_height_select;
 	Noise *noise_mount_height;
 	Noise *noise_ridge_uwater;
-	Noise *noise_floatland_base;
-	Noise *noise_float_base_height;
 	Noise *noise_mountain;
 	Noise *noise_ridge;
 };


### PR DESCRIPTION
Preserve the floatland flag of existing worlds, to be used again
when the new implementation is added.
//////////////////////////////

First step for #9076 
Tested that the floatland flag is preserved in a world when switching from master -> PR -> master.
Once merged i will immediately start work on the replacement, to be in place for MT 5.2.0 stable release. Code for the new implementation has already been partly developed in my Watershed C++ mapgen.
I will merge this in 1 week.