### PR TITLE
Fix item eat sound not played if last item

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -462,10 +462,10 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 			return result
 		end
 	end
+	local def = itemstack:get_definition()
 	if itemstack:take_item() ~= nil then
 		user:set_hp(user:get_hp() + hp_change)
 
-		local def = itemstack:get_definition()
 		if def and def.sound and def.sound.eat then
 			minetest.sound_play(def.sound.eat, { pos = user:get_pos(), max_hear_distance = 16 })
 		end


### PR DESCRIPTION
The bug:
If you eat an item (`minetest.item_eat`) and consumed the last item in the process (see test code below), the `eat` sound is NOT played. It is only played if the item stack had a size of >1.

This PR fixes this bug.

## To do
Ready for Review.

## How to test

```
  minetest.register_craftitem("soundstuff:eat", {
          description = "Eat Sound Item",
          inventory_image = "soundstuff_node_blank.png",
          on_use = minetest.item_eat(0),
          sound = {
                  eat = { name = "soundstuff_sound", gain = 1.0 },
          }
  })
```

This is an example item. Press punch key to eat it. The sound must play every time you eat.
Test this with multiple stack sizes (1, 2, 3, ...).