### PR TITLE
FormSpec: Support custom size and spacing for slots in list (#7971) rebased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.orig
 # Vim
 *.vim
+.ycm_extra_conf.py
 # Kate
 .*.kate-swp
 .swp.*

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2084,6 +2084,19 @@ Elements
 * Sets default background color of tooltips
 * Sets default font color of tooltips
 
+### `listoptions[<spacing factor width>,<spacing factor height>;<img factor size>;<border>]`
+
+* Set style options for inventory lists
+* `spacing factor width` and `spacing factor height` are spacing factor sizes (relative to the slot size) of a slot
+  example 1 : (0.0,0.0) for spacing means that there are no space between slots
+  example 2 : (1.0,1.0) for spacing means that default space between slots is used
+  example 3 : (2.0,2.0) for spacing means that default space between slots x2 is used
+* `img factor size` is the size factor (relative to the screen size) of a slot : a slot is always a square
+  the default value for the `img factor size` is 1.0 (42 pixels with border included for a 800x600 screen size)
+  example 1 : 1.0 for `img factor size` means that you use the default size for a slot
+  example 2 : 2.0 for `img factor size` means that you use the default size x2 for a slot
+* `border` is the border of a slot, 1 is the default and 0 means no border
+
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 
 * Adds tooltip for an element

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -440,8 +440,8 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 		} else {
 			pos = getElementBasePos(&v_pos);
 			rect = core::rect<s32>(pos.X, pos.Y,
-					pos.X + (geom.X - 1) * spacing.X + imgsize.X,
-					pos.Y + (geom.Y - 1) * spacing.Y + imgsize.Y);
+					pos.X + (geom.X - 1) * data->list_spacing.X + data->list_imgsize.X,
+					pos.Y + (geom.Y - 1) * data->list_spacing.Y + data->list_imgsize.Y);
 		}
 
 		gui::IGUIElement *e = new gui::IGUIElement(EGUIET_ELEMENT, Environment,

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -83,11 +83,14 @@ class GUIFormSpecMenu : public GUIModalMenu
 		ItemSpec() = default;
 
 		ItemSpec(const InventoryLocation &a_inventoryloc,
-				const std::string &a_listname,
-				s32 a_i) :
+				const std::string &a_listname, s32 a_i,
+				const v2s32 &a_spacing, const v2s32 &a_imgsize, s32 a_border) :
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
-			i(a_i)
+			i(a_i),
+			spacing(a_spacing),
+			imgsize(a_imgsize),
+			border(a_border)
 		{
 		}
 
@@ -96,6 +99,11 @@ class GUIFormSpecMenu : public GUIModalMenu
 		InventoryLocation inventoryloc;
 		std::string listname;
 		s32 i = -1;
+
+		// listoptions
+		v2s32 spacing;
+		v2s32 imgsize;
+		s32 border = 1;
 	};
 
 	struct ListDrawSpec
@@ -105,13 +113,16 @@ class GUIFormSpecMenu : public GUIModalMenu
 		ListDrawSpec(const InventoryLocation &a_inventoryloc,
 				const std::string &a_listname,
 				IGUIElement *elem, v2s32 a_geom, s32 a_start_item_i,
-				bool a_real_coordinates):
+				bool a_real_coordinates, v2s32 a_spacing, v2s32 a_imgsize, s32 a_border):
 			inventoryloc(a_inventoryloc),
 			listname(a_listname),
 			e(elem),
 			geom(a_geom),
 			start_item_i(a_start_item_i),
-			real_coordinates(a_real_coordinates)
+			real_coordinates(a_real_coordinates),
+			spacing(a_spacing),
+			imgsize(a_imgsize),
+			border(a_border)
 		{
 		}
 
@@ -121,6 +132,11 @@ class GUIFormSpecMenu : public GUIModalMenu
 		v2s32 geom;
 		s32 start_item_i;
 		bool real_coordinates;
+
+		// listoptions
+		v2s32 spacing;
+		v2s32 imgsize;
+		s32 border = 1;
 	};
 
 	struct ListRingSpec
@@ -414,6 +430,11 @@ private:
 
 		// used to restore table selection/scroll/treeview state
 		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
+
+		// listoptions
+		v2s32 list_imgsize;
+		v2s32 list_spacing;
+		s32 list_border = 1;
 	} parserData;
 
 	typedef struct {
@@ -462,6 +483,7 @@ private:
 	void parseBox(parserData* data, const std::string &element);
 	void parseBackgroundColor(parserData* data, const std::string &element);
 	void parseListColors(parserData* data, const std::string &element);
+	void parseListOptions(parserData* data, const std::string &element);
 	void parseTooltip(parserData* data, const std::string &element);
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);


### PR DESCRIPTION
See #7971, I just rebased it in another branch to make things easier for me.

~There is a small problem with this one after rebase though, when resizing craft preview over it's original size, the square will stay the same size but the item inside will scale up. I don't understand why it's happing because it's the only slot with an issue, other slots are fine.~

I tried to make the exact same changes in the files and I don't remember much about how this PR works, especially because I wasn't the original author.

![screenshot-20191224141345](https://user-images.githubusercontent.com/554446/71395047-a75b2500-2657-11ea-814d-a9df176920e2.png)