### PR TITLE
Fix MSAA stripes

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -517,8 +517,8 @@ texture_min_size (Minimum texture size) int 64
 #    This algorithm smooths out the 3D viewport while keeping the image sharp,
 #    but it doesn't affect the insides of textures
 #    (which is especially noticeable with transparent textures).
-#    This option is experimental and might cause visible spaces between blocks
-#    when set above 0.
+#    Visible spaces appear between nodes when shaders are disabled.
+#    If set to 0, MSAA is disabled.
 #    A restart is required after changing this option.
 fsaa (FSAA) enum 0 0,1,2,4,8,16
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -16,7 +16,7 @@ varying vec3 vPosition;
 // precision must be considered).
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
-varying mediump vec2 varTexCoord;
+centroid varying mediump vec2 varTexCoord;
 varying vec3 eyeVec;
 
 const float fogStart = FOG_START;
@@ -46,7 +46,7 @@ vec4 applyToneMapping(vec4 color)
 	const float gamma = 1.6;
 	const float exposureBias = 5.5;
 	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
-	// Precalculated white_scale from 
+	// Precalculated white_scale from
 	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
 	vec3 whiteScale = vec3(1.036015346);
 	color.rgb *= whiteScale;
@@ -72,7 +72,7 @@ void main(void)
 	color = base.rgb;
 
 	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);
-	
+
 #ifdef ENABLE_TONE_MAPPING
 	col = applyToneMapping(col);
 #endif

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -16,7 +16,10 @@ varying vec3 vPosition;
 // precision must be considered).
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
-varying mediump vec2 varTexCoord;
+// The centroid keyword ensures that after interpolation the texture coordinates
+// lie within the same bounds when MSAA is en- and disabled.
+// This fixes the stripes problem with nearest-neighbour textures and MSAA.
+centroid varying mediump vec2 varTexCoord;
 varying vec3 eyeVec;
 
 // Color of the light emitted by the light sources.
@@ -142,7 +145,7 @@ void main(void)
 	vec4 color;
 	// The alpha gives the ratio of sunlight in the incoming light.
 	float nightRatio = 1.0 - inVertexColor.a;
-	color.rgb = inVertexColor.rgb * (inVertexColor.a * dayLight.rgb + 
+	color.rgb = inVertexColor.rgb * (inVertexColor.a * dayLight.rgb +
 		nightRatio * artificialLight.rgb) * 2.0;
 	color.a = 1.0;
 

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -9,7 +9,7 @@ varying vec3 vNormal;
 varying vec3 vPosition;
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
-varying mediump vec2 varTexCoord;
+centroid varying mediump vec2 varTexCoord;
 
 varying vec3 eyeVec;
 varying float vIDiff;
@@ -43,7 +43,7 @@ vec4 applyToneMapping(vec4 color)
 	const float gamma = 1.6;
 	const float exposureBias = 5.5;
 	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
-	// Precalculated white_scale from 
+	// Precalculated white_scale from
 	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
 	vec3 whiteScale = vec3(1.036015346);
 	color.rgb *= whiteScale;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -7,7 +7,7 @@ varying vec3 vNormal;
 varying vec3 vPosition;
 varying vec3 worldPosition;
 varying lowp vec4 varColor;
-varying mediump vec2 varTexCoord;
+centroid varying mediump vec2 varTexCoord;
 
 varying vec3 eyeVec;
 varying float vIDiff;


### PR DESCRIPTION
This only works when shaders are enabled.
The centroid varying avoids that the textures (which repeat themselves out of bounds) are sampled out of bounds in MSAA.
If MSAA (called FSAA in minetest) is disabled, the centroid keyword does nothing.

Related issue: #6860
An older related PR: #8123 