### PR TITLE
Add table.key_value_swap

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -575,6 +575,15 @@ function table.insert_all(t, other)
 end
 
 
+function table.invert(t)
+	local ti = {}
+	for k,v in pairs(t) do
+		ti[v] = k
+	end
+	return ti
+end
+
+
 --------------------------------------------------------------------------------
 -- mainmenu only functions
 --------------------------------------------------------------------------------

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -575,7 +575,7 @@ function table.insert_all(t, other)
 end
 
 
-function table.invert(t)
+function table.key_value_swap(t)
 	local ti = {}
 	for k,v in pairs(t) do
 		ti[v] = k

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2901,7 +2901,7 @@ Helper functions
 * `table.insert_all(table, other_table)`:
     * Appends all values in `other_table` to `table` - uses `#table + 1` to
       find new indices.
-* `table.invert(t)`: returns a table with keys and values swapped
+* `table.key_value_swap(t)`: returns a table with keys and values swapped
     * If multiple keys in `t` map to the same value, the result is undefined.
 * `minetest.pointed_thing_to_face_pos(placer, pointed_thing)`: returns a
   position.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2901,6 +2901,8 @@ Helper functions
 * `table.insert_all(table, other_table)`:
     * Appends all values in `other_table` to `table` - uses `#table + 1` to
       find new indices.
+* `table.invert(t)`: returns a table with keys and values swapped
+    * If multiple keys in `t` map to the same value, the result is undefined.
 * `minetest.pointed_thing_to_face_pos(placer, pointed_thing)`: returns a
   position.
     * returns the exact position on the surface of a pointed node


### PR DESCRIPTION
- Goal of the PR

A simple helper function which inverts a lua table

- How does the PR work?

See the code and api doc additions

- Does it resolve any reported issue?

No

- If not a bug fix, why is this PR needed? What usecases does it solve?

If you have a list of nodes, e.g. `{"farming:soil", "default:dirt", "default:stone", "default:mese", "default:cobble"}`, and you want to test if nodes at many positions are in this list, you probably do not want to iterate over the list for each node. The proposed function swaps keys and values, so you can use it to convert the list to a set (both are lua tables):
```lua
t = table.key_value_swap{"farming:soil", "default:dirt", "default:stone", "default:mese", "default:cobble"}

local n_found = 0
for i in 1,#nodes_list do
	local node = nodes_list[i]
	if t[node.name] then
		n_found = n_found+1
	end
end
```

## How to test

Try table.key_value_swap(table.key_value_swap(<your_table>)) and see if the table is still the same,
or simply test table.key_value_swap with some example tables.
