### PR TITLE
Minimap: gamma-correct average texture colour calculation

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -2205,13 +2205,16 @@ video::ITexture* TextureSource::getNormalTexture(const std::string &name)
 }
 
 namespace {
-	float linear_to_srgb_component(const float v)
+	// For more colourspace transformations, see for example
+	// https://github.com/tobspr/GLSL-Color-Spaces/blob/master/ColorSpaces.inc.glsl
+
+	inline float linear_to_srgb_component(float v)
 	{
 		if (v > 0.0031308f)
 			return 1.055f * powf(v, 1.0f / 2.4f) - 0.055f;
 		return 12.92f * v;
 	}
-	float srgb_to_linear_component(const float v)
+	inline float srgb_to_linear_component(float v)
 	{
 		if (v > 0.04045f)
 			return powf((v + 0.055f) / 1.055f, 2.4f);
@@ -2221,7 +2224,7 @@ namespace {
 	v3f srgb_to_linear(const video::SColor &col_srgb)
 	{
 		v3f col(col_srgb.getRed(), col_srgb.getGreen(), col_srgb.getBlue());
-		col *= 1.0f / 255.0f;
+		col /= 255.0f;
 		col.X = srgb_to_linear_component(col.X);
 		col.Y = srgb_to_linear_component(col.Y);
 		col.Z = srgb_to_linear_component(col.Z);
@@ -2268,7 +2271,7 @@ video::SColor TextureSource::getTextureAverageColor(const std::string &name)
 	}
 	image->drop();
 	if (total > 0) {
-		col_acc *= 1.0f / total;
+		col_acc /= total;
 		c = linear_to_srgb(col_acc);
 	}
 	c.setAlpha(255);

--- a/src/irr_v3d.h
+++ b/src/irr_v3d.h
@@ -27,4 +27,5 @@ typedef core::vector3df v3f;
 typedef core::vector3d<double> v3d;
 typedef core::vector3d<s16> v3s16;
 typedef core::vector3d<u16> v3u16;
+typedef core::vector3d<u8> v3u8;
 typedef core::vector3d<s32> v3s32;

--- a/src/irr_v3d.h
+++ b/src/irr_v3d.h
@@ -27,5 +27,4 @@ typedef core::vector3df v3f;
 typedef core::vector3d<double> v3d;
 typedef core::vector3d<s16> v3s16;
 typedef core::vector3d<u16> v3u16;
-typedef core::vector3d<u8> v3u8;
 typedef core::vector3d<s32> v3s32;


### PR DESCRIPTION
- Goal of the PR

Calculate the average texture colour while heeding the sRGB colourspace.

- How does the PR work?

#808080 sRGB is a lot darker than 0.5 gray, this should not be ignored when calculating an average colour for a texture.

- Does it resolve any reported issue?

No

- If not a bug fix, why is this PR needed? What usecases does it solve?

I have tested the minimap with a chessboard texture, and noticed that the average colour is wrong.
![chessboard_pic](https://user-images.githubusercontent.com/3192173/71443696-c9fb4580-270c-11ea-8cd5-cd611bc06072.png)
Before the changes:
![current_minetest](https://user-images.githubusercontent.com/3192173/71443708-d5e70780-270c-11ea-891f-617db5154374.png)
After the changes:
![gammacorrect_average_color](https://user-images.githubusercontent.com/3192173/71443709-d5e70780-270c-11ea-9ec3-c52c0afb2333.png)

Note that browsers do incorrect image scaling, so the images must be viewed at 1:1 resolution or with nearest neighbour scaling.

‪

I also tried gamma-correct shading, but the results did look bad, and correct mini map shading is not important:
![linear_phong_shading](https://user-images.githubusercontent.com/3192173/71443710-d5e70780-270c-11ea-901e-3bf5c31cbdd5.png)



## To do

This PR is a Ready for Review.

## How to test

Try textures with high contrast, such as chessboard.