### PR TITLE
Make clipping of formspec elements more consistent

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2548,6 +2548,8 @@ Some types may inherit styles from parent types.
 
 ### Valid Properties
 
+* box
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * button, button_exit, image_button, item_image_button
     * alpha - boolean, whether to draw alpha in bgimg. Default true.
     * bgcolor - color, sets button tint.
@@ -2571,6 +2573,8 @@ Some types may inherit styles from parent types.
     * border - set to false to hide the textbox background and border. Default true.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * textcolor - color. Default white.
+* image, item_image
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * image_button (additional properties)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2550,6 +2550,7 @@ Some types may inherit styles from parent types.
 
 * box
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+        * Default to true in formspec_version version 3 or higher
 * button, button_exit, image_button, item_image_button
     * alpha - boolean, whether to draw alpha in bgimg. Default true.
     * bgcolor - color, sets button tint.
@@ -2573,8 +2574,11 @@ Some types may inherit styles from parent types.
     * border - set to false to hide the textbox background and border. Default true.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
     * textcolor - color. Default white.
-* image, item_image
+* image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
+        * Default to true in formspec_version version 3 or higher
+* item_image
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to true.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * image_button (additional properties)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2550,7 +2550,7 @@ Some types may inherit styles from parent types.
 
 * box
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-        * Default to true in formspec_version version 3 or higher
+        * Default to false in formspec_version version 3 or higher
 * button, button_exit, image_button, item_image_button
     * alpha - boolean, whether to draw alpha in bgimg. Default true.
     * bgcolor - color, sets button tint.
@@ -2576,9 +2576,9 @@ Some types may inherit styles from parent types.
     * textcolor - color. Default white.
 * image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
-        * Default to true in formspec_version version 3 or higher
+        * Default to false in formspec_version version 3 or higher
 * item_image
-    * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to true.
+    * noclip - boolean, set to true to allow the element to exceed formspec bounds. Default to false.
 * label, vertlabel
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * image_button (additional properties)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2105,7 +2105,8 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 
 			GUIBox *e = new GUIBox(Environment, this, spec.fid, rect, tmp_color);
 
-			e->setNotClipped(true);
+			auto style = getStyleForElement("box", spec.fname);
+			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
 			e->drop();
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -741,7 +741,8 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		gui::IGUIImage *e = Environment->addImage(rect, this, spec.fid, 0, true);
 		e->setImage(texture);
 		e->setScaleImage(true);
-		e->setNotClipped(true);
+		auto style = getStyleForElement("image", spec.fname);
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		m_fields.push_back(spec);
 
 		return;
@@ -773,7 +774,8 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		);
 		gui::IGUIImage *e = Environment->addImage(texture, pos, true, this,
 				spec.fid, 0);
-		e->setNotClipped(true);
+		auto style = getStyleForElement("image", spec.fname);
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		m_fields.push_back(spec);
 
 		return;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -742,7 +742,7 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		e->setImage(texture);
 		e->setScaleImage(true);
 		auto style = getStyleForElement("image", spec.fname);
-		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 		m_fields.push_back(spec);
 
 		return;
@@ -775,7 +775,7 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		gui::IGUIImage *e = Environment->addImage(texture, pos, true, this,
 				spec.fid, 0);
 		auto style = getStyleForElement("image", spec.fname);
-		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 		m_fields.push_back(spec);
 
 		return;
@@ -2106,7 +2106,7 @@ void GUIFormSpecMenu::parseBox(parserData* data, const std::string &element)
 			GUIBox *e = new GUIBox(Environment, this, spec.fid, rect, tmp_color);
 
 			auto style = getStyleForElement("box", spec.fname);
-			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 
 			e->drop();
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -823,6 +823,8 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 
 		GUIItemImage *e = new GUIItemImage(Environment, this, spec.fid,
 				core::rect<s32>(pos, pos + geom), name,	m_font, m_client);
+		auto style = getStyleForElement("item_image", spec.fname);
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->drop();
 
 		m_fields.push_back(spec);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -232,6 +232,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	FORMSPEC VERSION 3:
 		Formspec elements are drawn in the order of definition
 		bgcolor[]: use 3 parameters (bgcolor, formspec (now an enum), fbgcolor)
+		box[] and image[] elements enable clipping by default
 */
 #define FORMSPEC_API_VERSION 3
 


### PR DESCRIPTION
This PR makes the `image`, `item_image`, and `box` formspec elements handle clipping like most other elements do, to make them more consistent with other formspec elements. The behavior is as follows:
- By default, the elements are clipped
- To manually enable/disable clipping, the `noclip` style element can be used. Since the above elements don't have names they can only be configured via the `style_type` element.

## Breaking Changes
In the case of `image` and `box`, this changes the default behavior from not clipping by default to clipping by default. Regardless, I think API consistency is important and we should make this change. 
UPDATE: The defaults will only change if the formspec api version is set to **3**

## Testing
To test, create a formspec with `image`/`item_image`/`box` elements off the side of a clipping area. They should be clipped, and you should be able to disable the clipping using the `noclip` style property. To showcase this behavior, I've created a simple test mod: [test_image_clip.zip](https://github.com/minetest/minetest/files/4007555/test_image_clip.zip)
To see how this works with different formspec API versions, remove the `style_type[x;noclip=false]` lines and set `formspec_version[x]` at the top.