### PR TITLE
Add allowed_mapgens option in game.conf.

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -39,9 +39,22 @@ local function create_world_formspec(dialogdata)
 		local gamepath = game_by_gameidx.path
 		local gameconfig = Settings(gamepath.."/game.conf")
 
+		local allowed_mapgens = (gameconfig:get("allowed_mapgens") or ""):split()
+		for key, value in pairs(allowed_mapgens) do
+			allowed_mapgens[key] = value:trim()
+		end
+
 		local disallowed_mapgens = (gameconfig:get("disallowed_mapgens") or ""):split()
 		for key, value in pairs(disallowed_mapgens) do
 			disallowed_mapgens[key] = value:trim()
+		end
+
+		if #allowed_mapgens > 0 then
+			for i = #mapgens, 1, -1 do
+				if table.indexof(allowed_mapgens, mapgens[i]) == -1 then
+					table.remove(mapgens, i)
+				end
+			end
 		end
 
 		if disallowed_mapgens then

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -64,6 +64,10 @@ The game directory can contain the following files:
 * `game.conf`, with the following keys:
     * `name`: Required, human readable name  e.g. `name = Minetest`
     * `description`: Short description to be shown in the content tab
+    * `allowed_mapgens = <comma-separated mapgens>`
+      e.g. `allowed_mapgens = v5,v6,flat`
+      Mapgens not in this list are removed from the list of mapgens for
+      the game.
     * `disallowed_mapgens = <comma-separated mapgens>`
       e.g. `disallowed_mapgens = v5,v6,flat`
       These mapgens are removed from the list of mapgens for the game.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -72,8 +72,9 @@ The game directory can contain the following files:
     * `disallowed_mapgens = <comma-separated mapgens>`
       e.g. `disallowed_mapgens = v5,v6,flat`
       These mapgens are removed from the list of mapgens for the game.
-      When both `allowed_mapgens` and `disallowed_mapgens` are both
-      specified, `allowed` is applied before `disallowed'.
+      When both `allowed_mapgens` and `disallowed_mapgens` are
+      specified, `allowed_mapgens` is applied before
+      `disallowed_mapgens`.
 * `minetest.conf`:
   Used to set default settings when running this game.
 * `settingtypes.txt`:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -68,9 +68,12 @@ The game directory can contain the following files:
       e.g. `allowed_mapgens = v5,v6,flat`
       Mapgens not in this list are removed from the list of mapgens for
       the game.
+      If not specified, all mapgens are allowed.
     * `disallowed_mapgens = <comma-separated mapgens>`
       e.g. `disallowed_mapgens = v5,v6,flat`
       These mapgens are removed from the list of mapgens for the game.
+      When both `allowed_mapgens` and `disallowed_mapgens` are both
+      specified, `allowed` is applied before `disallowed'.
 * `minetest.conf`:
   Used to set default settings when running this game.
 * `settingtypes.txt`:


### PR DESCRIPTION
The game.conf has a disallowed_mapgens option. However, some games
require a certain mapgen to be used, like the CTF plugin. This change
adds an option to specify allowed mapgens so that the setting can be
specified in a way that needn't be updated as map generators are added
to minetest.

This change doens't address any outstanding issue that I found on github.
I found the issue while my son was trying to play with the CTF mod. When
I finally realized that the problem was that the wrong mapgen was used, this
idea came to me. I hope you find it useful.

## Status

This PR is Ready for Review.

## How to test

* Add the following to games/minimal/game.conf:

    allowed_mapgens = v7,v6

* Start minetest and create a new map for the minimal game. You should only
  be given the v6 and v7 options for mapgens.