### PR TITLE
Formspec: Fix clicking on tooltip-obstructed elements

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -447,6 +447,9 @@ void GUIFormSpecMenu::parseList(parserData* data, const std::string &element)
 		gui::IGUIElement *e = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
 				this, spec.fid, rect);
 
+		// the element the list is bound to should not block mouse-clicks
+		e->setVisible(false);
+
 		m_inventorylists.emplace_back(loc, listname, e, geom, start_i,
 				data->real_coordinates);
 		m_fields.push_back(spec);
@@ -2242,6 +2245,9 @@ void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 
 		gui::IGUIElement *e = new gui::IGUIElement(EGUIET_ELEMENT, Environment,
 				this, fieldspec.fid, rect);
+
+		// the element the rect tooltip is bound to should not block mouse-clicks
+		e->setVisible(false);
 
 		m_fields.push_back(fieldspec);
 		m_tooltip_rects.emplace_back(e, spec);


### PR DESCRIPTION
- Goal of the PR: Fixing a bug.
- How does the PR work?
[`irr::gui::IGUIElement::getElementFromPoint`](http://irrlicht.sourceforge.net/docu/classirr_1_1gui_1_1_i_g_u_i_element.html#ae49f8a5228ce0c18e0c98becf74ee56a) ignores invisible elements. Tooltips and inventorylists do not need to be visible to be drawn as they don't use the draw function.
- Fixes #9264.
- Side-note: This fix wouldn't work for other elements, and inventorylists should be done properly one day (with their own class instead of being drawn in `GUIFormspecMenu`). Other not-rectangular or holey elements need (best non-hacky) a way to pass not handled callbacks to elements below them.

## To do

This PR is a Ready for Review.

## How to test

```lua
local elements = [[
	list[current_player;main;0,0;4,4;]
	button[5,0;2,1;btn;Button]
	button[3,1.5;3,1;btn;Button2]
]]

local fs = [[
	size[11,10]
]] .. elements .. [[
	tooltip[0,0;10,5;<rect_mode tooltip defined after other elements>]
	container[0,6]
	tooltip[0,0;10,5;<rect_mode tooltip defined before other elements>]
]] .. elements .. [[
	container_end[]
]]

minetest.register_on_joinplayer(function(player)
	minetest.show_formspec(player:get_player_name(), "fs_test", fs)
end)

minetest.register_chatcommand("fs", {
	params = "",
	description = "Show the test formspec.",
	privs = {},
	func = function(name, param)
		minetest.show_formspec(name, "fs", fs)
		return true
	end,
})
```
