### PR TITLE
Allow texture modifiers in hotbar textures.

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -221,19 +221,13 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 	// Store hotbar_image in member variable, used by drawItem()
 	if (hotbar_image != player->hotbar_image) {
 		hotbar_image = player->hotbar_image;
-		if (!hotbar_image.empty())
-			use_hotbar_image = tsrc->isKnownSourceImage(hotbar_image);
-		else
-			use_hotbar_image = false;
+		use_hotbar_image = !hotbar_image.empty();
 	}
 
 	// Store hotbar_selected_image in member variable, used by drawItem()
 	if (hotbar_selected_image != player->hotbar_selected_image) {
 		hotbar_selected_image = player->hotbar_selected_image;
-		if (!hotbar_selected_image.empty())
-			use_hotbar_selected_image = tsrc->isKnownSourceImage(hotbar_selected_image);
-		else
-			use_hotbar_selected_image = false;
+		use_hotbar_selected_image = !hotbar_selected_image.empty();
 	}
 
 	// draw customized item background

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1219,21 +1219,9 @@ void Client::handleCommand_HudSetParam(NetworkPacket* pkt)
 			player->hud_hotbar_itemcount = hotbar_itemcount;
 	}
 	else if (param == HUD_PARAM_HOTBAR_IMAGE) {
-		// If value not empty verify image exists in texture source
-		if (!value.empty() && !getTextureSource()->isKnownSourceImage(value)) {
-			errorstream << "Server sent wrong Hud hotbar image (sent value: '"
-				<< value << "')" << std::endl;
-			return;
-		}
 		player->hotbar_image = value;
 	}
 	else if (param == HUD_PARAM_HOTBAR_SELECTED_IMAGE) {
-		// If value not empty verify image exists in texture source
-		if (!value.empty() && !getTextureSource()->isKnownSourceImage(value)) {
-			errorstream << "Server sent wrong Hud hotbar selected image (sent value: '"
-					<< value << "')" << std::endl;
-			return;
-		}
 		player->hotbar_selected_image = value;
 	}
 }


### PR DESCRIPTION
Resolves #9268 

There were checks in both of the affected files to require a texture to be physically present as a file before allowing it to be used in hotbar or hotbar_selected background textures.  I found no justification for this restriction, and when it was removed, (1) texture mods started working as expected, and (2) I was unable to observe any new undesirable behavior as a result.

It looks as though the check may have been added to be consistent with the way things like the crosshair or sun/moon operate, where the mere presence of a texture with the expected filename causes an automatic override ... however, it doesn't appear that the hotbar textures actually _have_ such a standard filename, so it doesn't seem to apply anyway.

Minimal test case described in #9268.  In addition, if you want a more non-trivial test case, you can find an intended real-world use case in https://gitlab.com/sztest/nodecore/commit/32e9c306b7aaaafba910dd75942f358c2ff4df43#d96a657ab89c26a10ad7ad9695a1d1423d9a849d_37_39.