### PR TITLE
Add missing defaults for mapgen-specific flags

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -427,6 +427,13 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mapgen_limit", "31000");
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "caves,dungeons,light,decorations,biomes");
+	settings->setDefault("mgv5_spflags", "caverns");
+	settings->setDefault("mgv6_spflags", "jungles,biomeblend,mudflow,snowbiomes,noflat,trees");
+	settings->setDefault("mgv7_spflags", "mountains,ridges,nofloatlands,caverns");
+	settings->setDefault("mgcarpathian_spflags", "caverns,norivers");
+	settings->setDefault("mgflat_spflags", "nolakes,nohills");
+	settings->setDefault("mgfractal_spflags", "terrain");
+	settings->setDefault("mgvalleys_spflags", "altitude_chill,humid_rivers,vary_river_depth,altitude_dry");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "8");
 	settings->setDefault("enable_mapgen_debug_info", "false");


### PR DESCRIPTION
What is says on the tin.

In C++ code, the defaults for the flags were oddly missing. I just copied the defaults over from `builtin/settingtypes.txt`.

@SmallJoker.