### PR TITLE
Client-side translations: gettext support

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -710,13 +710,13 @@ bool Client::loadMedia(const std::string &data, const std::string &filename)
 	}
 
 	const char *translate_ext[] = {
-		".tr", NULL
+		".tr", ".po", ".mo", NULL
 	};
 	name = removeStringEnd(filename, translate_ext);
 	if (!name.empty()) {
 		verbosestream << "Client: Loading translation: "
 				<< "\"" << filename << "\"" << std::endl;
-		g_translations->loadTranslation(data);
+		g_translations->loadTranslation(filename, data);
 		return true;
 	}
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2413,8 +2413,8 @@ void Server::fillMediaCache()
 				".pcx", ".ppm", ".psd", ".wal", ".rgb",
 				".ogg",
 				".x", ".b3d", ".md2", ".obj",
-				// Custom translation file format
-				".tr",
+				// Translation file format
+				".tr", ".po", ".mo",
 				NULL
 			};
 			if (removeStringEnd(filename, supported_ext).empty()){
@@ -2483,19 +2483,34 @@ void Server::sendMediaAnnouncement(session_t peer_id, const std::string &lang_co
 	NetworkPacket pkt(TOCLIENT_ANNOUNCE_MEDIA, 0, peer_id);
 
 	u16 media_sent = 0;
-	std::string lang_suffix;
-	lang_suffix.append(".").append(lang_code).append(".tr");
+	std::string translation_formats[3] = { ".tr", ".po", ".mo" };
+	std::string lang_suffixes[3];
+	for (size_t i = 0; i < 3; i++) {
+		lang_suffixes[i].append(".").append(lang_code).append(translation_formats[i]);
+	}
 	for (const auto &i : m_media) {
-		if (str_ends_with(i.first, ".tr") && !str_ends_with(i.first, lang_suffix))
-			continue;
+		bool ok = true;
+		for (size_t j = 0; j < 3; j++) {
+			if (str_ends_with(i.first, translation_formats[j]) && !str_ends_with(i.first, lang_suffixes[j])) {
+				ok = false;
+				break;
+			}
+		}
+		if (!ok) continue;
 		media_sent++;
 	}
 
 	pkt << media_sent;
 
 	for (const auto &i : m_media) {
-		if (str_ends_with(i.first, ".tr") && !str_ends_with(i.first, lang_suffix))
-			continue;
+		bool ok = true;
+		for (size_t j = 0; j < 3; j++) {
+			if (str_ends_with(i.first, translation_formats[j]) && !str_ends_with(i.first, lang_suffixes[j])) {
+				ok = false;
+				break;
+			}
+		}
+		if (!ok) continue;
 		pkt << i.first << i.second.sha1_digest;
 	}
 

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "translation.h"
 #include "log.h"
+#include "util/hex.h"
 #include "util/string.h"
 
 static Translations main_translations;
@@ -50,7 +51,7 @@ const std::wstring &Translations::getTranslation(
 	}
 }
 
-void Translations::loadTranslation(const std::string &data)
+void Translations::loadTrTranslation(const std::string &data)
 {
 	std::istringstream is(data);
 	std::wstring textdomain;
@@ -152,5 +153,229 @@ void Translations::loadTranslation(const std::string &data)
 		std::wstring translation_index = textdomain + L"|";
 		translation_index.append(oword1);
 		m_translations[translation_index] = oword2;
+	}
+}
+
+std::wstring Translations::unescapeC(const std::wstring &str) {
+	// Process escape sequences in str as if it were a C string
+	std::wstring result;
+	size_t i = 0;
+	while (i < str.length()) {
+		if (str[i] != L'\\') {
+			result.push_back(str[i]);
+			i++;
+			continue;
+		}
+		i++;
+		if (i == str.length()) {
+			errorstream << "Unfinished escape sequence at the end of \"" << wide_to_utf8(str) << "\"" << std::endl;
+			break;
+		}
+		switch (str[i]) {
+			// From https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
+			case L'a': result.push_back(L'\a'); break;
+			case L'b': result.push_back(L'\b'); break;
+			case L'e': result.push_back(L'\x1b'); break;
+			case L'f': result.push_back(L'\f'); break;
+			case L'n': result.push_back(L'\n'); break;
+			case L'r': result.push_back(L'\r'); break;
+			case L't': result.push_back(L'\t'); break;
+			case L'v': result.push_back(L'\v'); break;
+			case L'\\': result.push_back(L'\\'); break;
+			case L'\'': result.push_back(L'\''); break;
+			case L'"': result.push_back(L'"'); break;
+			case L'?': result.push_back(L'?'); break;
+			case L'0' ... L'7': {
+				size_t j = 0;
+				wchar_t c = 0;
+				for (; j < 3 && i+j < str.length() && L'0' <= str[i+j] && str[i+j] <= L'7'; j++) {
+					c = c * 8 + (str[i+j] - L'0');
+				}
+				if (c <= 0xff)
+					result.push_back(c);
+				i += j;
+				continue;
+			}
+			case L'x': {
+				i++;
+				if (i >= str.length()) {
+					errorstream << "Unfinished escape sequence at the end of \"" << wide_to_utf8(str) << "\"" << std::endl;
+				}
+				char32_t c = 0;
+				size_t j = 0;
+				unsigned char v;
+				for (; i+j < str.length() && hex_digit_decode((char)str[i+j], v); j++) {
+					c = c * 16 + v;
+				}
+				if (j == 0) {
+					errorstream << "Invalid escape sequence \\x, ignoring" << std::endl;
+					continue;
+				}
+				// If character fits in 16 bits and is not part of surrogate pair, insert it.
+				// Otherwise, silently drop it: this is valid since \x escape sequences with
+				// values above 0xff are implementation-defined
+				if ((c < 0xd800) || (0xe000 <= c && c <= 0xffff)) result.push_back(c);
+				i += j;
+				continue;
+			}
+			case L'u': {
+				i++;
+				if (i + 4 > str.length()) {
+					errorstream << "Unfinished escape sequence at the end of \"" << wide_to_utf8(str) << "\"" << std::endl;
+				}
+				char16_t c = 0;
+				bool ok = true;
+				for (size_t j = 0; j < 4; j++) {
+					unsigned char v;
+					if (str[i+j] <= 0xff && hex_digit_decode((char)str[i+j], v)) {
+						c = c * 16 + v;
+					} else {
+						errorstream << "Invalid unicode escape sequence \"\\u" << wide_to_utf8(str.substr(i, 4)) << "\", ignoring" << std::endl;
+						ok = false;
+						break;
+					}
+				}
+				if (ok) wide_add_codepoint(result, c);
+				i += 4;
+				continue;
+			}
+			case L'U': {
+				i++;
+				if (i + 8 > str.length()) {
+					errorstream << "Unfinished escape sequence at the end of \"" << wide_to_utf8(str) << "\"" << std::endl;
+				}
+				char32_t c = 0;
+				bool ok = true;
+				for (size_t j = 0; j < 8; j++) {
+					unsigned char v;
+					if (str[i+j] <= 0xff && hex_digit_decode((char)str[i+j], v)) {
+						c = c * 16 + v;
+					} else {
+						errorstream << "Invalid unicode escape sequence \"\\U" << wide_to_utf8(str.substr(i, 8)) << "\", ignoring" << std::endl;
+						ok = false;
+						break;
+					}
+				}
+				if (ok) wide_add_codepoint(result, c);
+				i += 8;
+				continue;
+			}
+			default: {
+				errorstream << "Unknown escape sequence \"\\" << str[i] << "\", ignoring" << std::endl;
+				break;
+			}
+		}
+		i++;
+	}
+	return result;
+}
+
+void Translations::loadPoEntry(const std::map<std::wstring, std::wstring> &entry) {
+	// Process an entry from a PO file and add it to the translation table
+	// Assumes that entry[L"msgid"] is always defined
+	std::wstring translation_index;
+	auto ctx = entry.find(L"msgctx");
+	if (ctx != entry.end()) {
+		translation_index = ctx->second + L"|";
+	} else {
+		translation_index = L"|";
+	}
+	translation_index.append(entry.at(L"msgid"));
+	
+	auto plural = entry.find(L"msgid_plural");
+	if (plural == entry.end()) {
+		auto translated = entry.find(L"msgstr");
+		if (translated == entry.end()) {
+			errorstream << "Could not load translation: entry for msgid \"" << wide_to_utf8(entry.at(L"msgid")) << "\" does not contain a msgstr field" << std::endl;
+			return;
+		}
+		m_translations[translation_index] = translated->second;
+	} else {
+		errorstream << "Translations with plurals are unsupported for now" << std::endl;
+	}
+}
+
+void Translations::loadPoTranslation(const std::string &data) {
+	std::istringstream is(data);
+	std::string line;
+	std::map<std::wstring, std::wstring> last_entry;
+	std::wstring last_key;
+
+	while (is.good()) {
+		std::getline(is, line);
+		// Trim last character if file was using a \r\n line ending
+		if (line.length () > 0 && line[line.length() - 1] == '\r')
+			line.resize(line.length() - 1);
+
+		if (line.empty() || line[0] == '#')
+			continue;
+
+		std::wstring wline = utf8_to_wide(line);
+		// Defend against some possibly malformed utf8 string, which
+		// is empty after converting to wide string
+		if (wline.empty())
+			continue;
+
+		if (wline[0] == L'"') {
+			// Continuation of previous line
+			if (wline.length() < 2 || wline[wline.length()-1] != L'"') {
+				errorstream << "Unable to parse po file line: " << line << std::endl;
+				continue;
+			}
+
+			if (last_key == L"") {
+				errorstream << "Unable to parse po file: continuation of non-existant previous line" << std::endl;
+				continue;
+			}
+
+			std::wstring s = unescapeC(wline.substr(1, wline.length() - 2));
+			last_entry[last_key].append(s);
+			continue;
+		}
+
+		std::size_t pos = wline.find(' ');
+		if (pos == std::wstring::npos || wline.length() < pos+3 || wline[pos+1] != L'"' || wline[wline.length() - 1] != L'"') {
+			errorstream << "Unable to parse po file line: " << line << std::endl;
+			continue;			
+		}
+		std::wstring prefix = wline.substr(0, pos);
+		std::wstring s = unescapeC(wline.substr(pos+2, wline.length()-pos-3));
+
+		if (prefix == L"msgctxt" || (prefix == L"msgid" && last_entry.find(L"msgid") != last_entry.end())) {
+			if (last_entry.find(L"msgid") != last_entry.end()) {
+				loadPoEntry(last_entry);
+				last_entry.clear();
+			} else if (!last_entry.empty()) {
+				errorstream << "Unable to parse po file: previous entry has no \"msgid\" field but is not empty" << std::endl;
+				last_entry.clear();
+			}
+		}
+		if (last_entry.find(prefix) != last_entry.end()) {
+			errorstream << "Unable to parse po file: Key \"" << wide_to_utf8(prefix) << "\" was already present in previous entry" << std::endl;
+			continue;
+		}
+		last_key = prefix;
+		last_entry[prefix] = s;
+	}
+
+	if (last_entry.find(L"msgid") != last_entry.end()) {
+		loadPoEntry(last_entry);
+	} else if (!last_entry.empty()) {
+		errorstream << "Unable to parse po file: Last entry has no \"msgid\" field" << std::endl;
+	}
+}
+
+void Translations::loadTranslation(const std::string &filename, const std::string &data) {
+	const char *trExtension[] = { ".tr", NULL };
+	const char *poExtension[] = { ".po", NULL };
+	if (!removeStringEnd(filename, trExtension).empty()) {
+		loadTrTranslation(data);
+		return;
+	} else if (!removeStringEnd(filename, poExtension).empty()) {
+		loadPoTranslation(data);
+		return;
+	} else {
+		errorstream << "loadTranslation called with invalid filename: \"" << filename << "\"" << std::endl;
+		return;
 	}
 }

--- a/src/translation.h
+++ b/src/translation.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #include <unordered_map>
+#include <map>
 #include <string>
 
 class Translations;
@@ -32,11 +33,16 @@ public:
 
 	~Translations();
 
-	void loadTranslation(const std::string &data);
+	void loadTranslation(const std::string &filename, const std::string &data);
 	void clear();
 	const std::wstring &getTranslation(
 			const std::wstring &textdomain, const std::wstring &s);
 
 private:
 	std::unordered_map<std::wstring, std::wstring> m_translations;
+
+	std::wstring unescapeC(const std::wstring &str);
+	void loadPoEntry(const std::map<std::wstring, std::wstring> &entry);
+	void loadTrTranslation(const std::string &data);
+	void loadPoTranslation(const std::string &data);
 };

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -139,6 +139,17 @@ std::string wide_to_utf8(const std::wstring &input)
 }
 
 #endif
+
+void wide_add_codepoint(std::wstring &result, char32_t codepoint)
+{
+	if ((0xD800 <= codepoint && codepoint <= 0xDFFF) || (0x10FFFF < codepoint)) {
+		// Invalid codepoint, replace with unicode replacement character
+		result.push_back(0xFFFD);
+		return;
+	}
+	result.push_back(codepoint);
+}
+
 #else // _WIN32
 
 std::wstring utf8_to_wide(const std::string &input)
@@ -163,6 +174,29 @@ std::string wide_to_utf8(const std::wstring &input)
 	std::string out(outbuf);
 	delete[] outbuf;
 	return out;
+}
+
+void wide_add_codepoint(std::wstring &result, char32_t codepoint)
+{
+	if (codepoint < 0x10000) {
+		if (0xD800 <= codepoint && codepoint <= 0xDFFF) {
+			// Invalid codepoint, part of a surrogate pair
+			// Replace with unicode replacement character
+			result.put(0xFFFD);
+			return;
+		} 
+		result.push_back((wchar_t) codepoint);
+		return;
+	}
+	codepoint -= 0x10000;
+	if (codepoint >= 0x100000) {
+		// original codepoint was above 0x10FFFF, so invalid
+		// replace with unicode replacement character
+		result.put(0xFFFD);
+		return;
+	}
+	result.push_back((wchar_t) ((codepoint >> 10) | 0xD800));
+	result.push_back((wchar_t) ((codepoint & 0x3FF) | 
 }
 
 #endif // _WIN32

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -69,6 +69,8 @@ std::string wide_to_utf8(const std::wstring &input);
 
 wchar_t *utf8_to_wide_c(const char *str);
 
+void wide_add_codepoint(std::wstring &result, char32_t codepoint);
+
 // NEVER use those two functions unless you have a VERY GOOD reason to
 // they just convert between wide and multibyte encoding
 // multibyte encoding depends on current locale, this is no good, especially on Windows


### PR DESCRIPTION
Add gettext support for client-side translations. This allows using existing gettext tooling, and will allow using plurals in translated strings (`ngettext` and the like).

## To do

This PR is a Work in Progress.

- [ ] Support MO files
- [ ] Support plurals
- [ ] Testing
  + [ ] escape sequence handling, on different platforms (especially Windows) for the handling of surrogate pairs
  + [ ] Lots of PO files (to check that the parser works with all automatically-produced PO files)
  + [ ] Malformed files (check against possible attack by buffer overflow in the parsing code)
- [ ] Add tooling for extraction of strings?

## How to test

For now, take a mod using client-side translations, and replace the .tr file with a .po one, with the following entries for each original translated string:
```
msgctx "<textdomain>"
msgid "<original string>"
msgstr "<translated string>"
```
