### PR TITLE
Settings: Add get_flags API for mapgen flags (mg_flags, mgv6_spflags, ...)

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6040,6 +6040,9 @@ It can be created via `Settings(filename)`.
     * `default` is the value returned if `key` is not found.
     * Returns `nil` if `key` is not found and `default` not specified.
 * `get_np_group(key)`: returns a NoiseParams table
+* `get_flags(key)`:
+    * Returns `{flag = true/false, ...}` according to the set flags.
+    * Is currently limited to mapgen settings like `mgv5_spflags`.
 * `set(key, value)`
     * Setting names can't contain whitespace or any of `="{}#`.
     * Setting values can't contain the sequence `\n"""`.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6042,7 +6042,8 @@ It can be created via `Settings(filename)`.
 * `get_np_group(key)`: returns a NoiseParams table
 * `get_flags(key)`:
     * Returns `{flag = true/false, ...}` according to the set flags.
-    * Is currently limited to mapgen settings like `mgv5_spflags`.
+    * Is currently limited to mapgen flags `mg_flags` and mapgen-specific
+      flags like `mgv5_spflags`.
 * `set(key, value)`
     * Setting names can't contain whitespace or any of `="{}#`.
     * Setting values can't contain the sequence `\n"""`.

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -427,6 +427,13 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("mapgen_limit", "31000");
 	settings->setDefault("chunksize", "5");
 	settings->setDefault("mg_flags", "caves,dungeons,light,decorations,biomes");
+	settings->setDefault("mgv5_spflags", "caverns");
+	settings->setDefault("mgv6_spflags", "jungles,biomeblend,mudflow,snowbiomes,noflat,trees");
+	settings->setDefault("mgv7_spflags", "mountains,ridges,nofloatlands,caverns");
+	settings->setDefault("mgcarpathian_spflags", "caverns,norivers");
+	settings->setDefault("mgflat_spflags", "nolakes,nohills");
+	settings->setDefault("mgfractal_spflags", "terrain");
+	settings->setDefault("mgvalleys_spflags", "altitude_chill,humid_rivers,vary_river_depth,altitude_dry");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "8");
 	settings->setDefault("enable_mapgen_debug_info", "false");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h"
 #include "constants.h"
 #include "porting.h"
+#include "mapgen/mapgen.h" // Mapgen::setDefaultSettings
 #include "util/string.h"
 
 void set_default_settings(Settings *settings)
@@ -426,17 +427,10 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("water_level", "1");
 	settings->setDefault("mapgen_limit", "31000");
 	settings->setDefault("chunksize", "5");
-	settings->setDefault("mg_flags", "caves,dungeons,light,decorations,biomes");
-	settings->setDefault("mgv5_spflags", "caverns");
-	settings->setDefault("mgv6_spflags", "jungles,biomeblend,mudflow,snowbiomes,noflat,trees");
-	settings->setDefault("mgv7_spflags", "mountains,ridges,nofloatlands,caverns");
-	settings->setDefault("mgcarpathian_spflags", "caverns,norivers");
-	settings->setDefault("mgflat_spflags", "nolakes,nohills");
-	settings->setDefault("mgfractal_spflags", "terrain");
-	settings->setDefault("mgvalleys_spflags", "altitude_chill,humid_rivers,vary_river_depth,altitude_dry");
 	settings->setDefault("fixed_map_seed", "");
 	settings->setDefault("max_block_generate_distance", "8");
 	settings->setDefault("enable_mapgen_debug_info", "false");
+	Mapgen::setDefaultSettings(settings);
 
 	// Server list announcing
 	settings->setDefault("server_announce", "false");

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -215,6 +215,25 @@ void Mapgen::getMapgenNames(std::vector<const char *> *mgnames, bool include_hid
 	}
 }
 
+void Mapgen::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mg_flags", flagdesc_mapgen,
+		 "caves,dungeons,light,decorations,biomes");
+	settings->setDefault("mgv5_spflags", flagdesc_mapgen_v5,
+		"caverns");
+	settings->setDefault("mgv6_spflags", flagdesc_mapgen_v6,
+		"jungles,biomeblend,mudflow,snowbiomes,noflat,trees");
+	settings->setDefault("mgv7_spflags", flagdesc_mapgen_v7,
+		"mountains,ridges,nofloatlands,caverns");
+	settings->setDefault("mgcarpathian_spflags", flagdesc_mapgen_carpathian,
+		"caverns,norivers");
+	settings->setDefault("mgflat_spflags", flagdesc_mapgen_flat,
+		"nolakes,nohills");
+	settings->setDefault("mgfractal_spflags", flagdesc_mapgen_fractal,
+		"terrain");
+	settings->setDefault("mgvalleys_spflags", flagdesc_mapgen_valleys,
+		"altitude_chill,humid_rivers,vary_river_depth,altitude_dry");
+}
 
 u32 Mapgen::getBlockSeed(v3s16 p, s32 seed)
 {

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -217,10 +217,6 @@ void Mapgen::getMapgenNames(std::vector<const char *> *mgnames, bool include_hid
 
 void Mapgen::setDefaultSettings(Settings *settings)
 {
-	// Option 1: List all defaults here as an overview
-	// Option 2: Each mapgen contains its own default setter function
-	// This is option 2.
-
 	settings->setDefault("mg_flags", flagdesc_mapgen,
 		 MG_CAVES | MG_DUNGEONS | MG_LIGHT | MG_DECORATIONS | MG_BIOMES);
 

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -217,22 +217,18 @@ void Mapgen::getMapgenNames(std::vector<const char *> *mgnames, bool include_hid
 
 void Mapgen::setDefaultSettings(Settings *settings)
 {
+	// Option 1: List all defaults here as an overview
+	// Option 2: Each mapgen contains its own default setter function
+	// This is option 2.
+
 	settings->setDefault("mg_flags", flagdesc_mapgen,
-		 "caves,dungeons,light,decorations,biomes");
-	settings->setDefault("mgv5_spflags", flagdesc_mapgen_v5,
-		"caverns");
-	settings->setDefault("mgv6_spflags", flagdesc_mapgen_v6,
-		"jungles,biomeblend,mudflow,snowbiomes,noflat,trees");
-	settings->setDefault("mgv7_spflags", flagdesc_mapgen_v7,
-		"mountains,ridges,nofloatlands,caverns");
-	settings->setDefault("mgcarpathian_spflags", flagdesc_mapgen_carpathian,
-		"caverns,norivers");
-	settings->setDefault("mgflat_spflags", flagdesc_mapgen_flat,
-		"nolakes,nohills");
-	settings->setDefault("mgfractal_spflags", flagdesc_mapgen_fractal,
-		"terrain");
-	settings->setDefault("mgvalleys_spflags", flagdesc_mapgen_valleys,
-		"altitude_chill,humid_rivers,vary_river_depth,altitude_dry");
+		 MG_CAVES | MG_DUNGEONS | MG_LIGHT | MG_DECORATIONS | MG_BIOMES);
+
+	for (int i = 0; i < (int)MAPGEN_INVALID; ++i) {
+		MapgenParams *params = createMapgenParams((MapgenType)i);
+		params->setDefaultSettings(settings);
+		delete params;
+	}
 }
 
 u32 Mapgen::getBlockSeed(v3s16 p, s32 seed)
@@ -1087,7 +1083,7 @@ void MapgenParams::writeParams(Settings *settings) const
 	settings->setS16("water_level", water_level);
 	settings->setS16("mapgen_limit", mapgen_limit);
 	settings->setS16("chunksize", chunksize);
-	settings->setFlagStr("mg_flags", flags, flagdesc_mapgen, U32_MAX);
+	settings->setFlagStr("mg_flags", flags, flagdesc_mapgen);
 
 	if (bparams)
 		bparams->writeParams(settings);

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -124,10 +124,9 @@ struct MapgenParams {
 	u64 seed = 0;
 	s16 water_level = 1;
 	s16 mapgen_limit = MAX_MAP_GENERATION_LIMIT;
-	u32 flags = MG_CAVES | MG_LIGHT | MG_DECORATIONS | MG_BIOMES;
-	// TODO: Remove the default "spflags" values from the mapgens
-	// They are now overwritten by Settings::getFlagStr
-	//u32 spflags = 0;
+	// Flags set in readParams
+	u32 flags = 0;
+	u32 spflags = 0;
 
 	BiomeParams *bparams = nullptr;
 
@@ -136,6 +135,8 @@ struct MapgenParams {
 
 	virtual void readParams(const Settings *settings);
 	virtual void writeParams(Settings *settings) const;
+	// Default settings for g_settings such as flags
+	virtual void setDefaultSettings(Settings *settings) {};
 
 	s32 getSpawnRangeMax();
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -125,6 +125,9 @@ struct MapgenParams {
 	s16 water_level = 1;
 	s16 mapgen_limit = MAX_MAP_GENERATION_LIMIT;
 	u32 flags = MG_CAVES | MG_LIGHT | MG_DECORATIONS | MG_BIOMES;
+	// TODO: Remove the default "spflags" values from the mapgens
+	// They are now overwritten by Settings::getFlagStr
+	//u32 spflags = 0;
 
 	BiomeParams *bparams = nullptr;
 
@@ -214,6 +217,7 @@ public:
 		EmergeManager *emerge);
 	static MapgenParams *createMapgenParams(MapgenType mgtype);
 	static void getMapgenNames(std::vector<const char *> *mgnames, bool include_hidden);
+	static void setDefaultSettings(Settings *settings);
 
 private:
 	// isLiquidHorizontallyFlowable() is a helper function for updateLiquid()

--- a/src/mapgen/mapgen_carpathian.cpp
+++ b/src/mapgen/mapgen_carpathian.cpp
@@ -187,7 +187,7 @@ void MapgenCarpathianParams::readParams(const Settings *settings)
 
 void MapgenCarpathianParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgcarpathian_spflags", spflags, flagdesc_mapgen_carpathian, U32_MAX);
+	settings->setFlagStr("mgcarpathian_spflags", spflags, flagdesc_mapgen_carpathian);
 
 	settings->setFloat("mgcarpathian_base_level",   base_level);
 	settings->setFloat("mgcarpathian_river_width",  river_width);
@@ -226,6 +226,12 @@ void MapgenCarpathianParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgcarpathian_np_dungeons",      np_dungeons);
 }
 
+
+void MapgenCarpathianParams::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgcarpathian_spflags", flagdesc_mapgen_carpathian,
+		MGCARPATHIAN_CAVERNS);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/mapgen/mapgen_carpathian.h
+++ b/src/mapgen/mapgen_carpathian.h
@@ -37,7 +37,6 @@ struct MapgenCarpathianParams : public MapgenParams
 	float river_depth      = 24.0f;
 	float valley_width     = 0.25f;
 
-	u32 spflags              = MGCARPATHIAN_CAVERNS;
 	float cave_width         = 0.09f;
 	s16 large_cave_depth     = -33;
 	u16 small_cave_num_min   = 0;
@@ -74,6 +73,7 @@ struct MapgenCarpathianParams : public MapgenParams
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 class MapgenCarpathian : public MapgenBasic

--- a/src/mapgen/mapgen_flat.cpp
+++ b/src/mapgen/mapgen_flat.cpp
@@ -126,7 +126,7 @@ void MapgenFlatParams::readParams(const Settings *settings)
 
 void MapgenFlatParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgflat_spflags", spflags, flagdesc_mapgen_flat, U32_MAX);
+	settings->setFlagStr("mgflat_spflags", spflags, flagdesc_mapgen_flat);
 	settings->setS16("mgflat_ground_level",         ground_level);
 	settings->setS16("mgflat_large_cave_depth",     large_cave_depth);
 	settings->setU16("mgflat_small_cave_num_min",   small_cave_num_min);
@@ -147,6 +147,12 @@ void MapgenFlatParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgflat_np_cave1",        np_cave1);
 	settings->setNoiseParams("mgflat_np_cave2",        np_cave2);
 	settings->setNoiseParams("mgflat_np_dungeons",     np_dungeons);
+}
+
+
+void MapgenFlatParams::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgflat_spflags", flagdesc_mapgen_flat, 0);
 }
 
 

--- a/src/mapgen/mapgen_flat.h
+++ b/src/mapgen/mapgen_flat.h
@@ -32,7 +32,6 @@ extern FlagDesc flagdesc_mapgen_flat[];
 
 struct MapgenFlatParams : public MapgenParams
 {
-	u32 spflags = 0;
 	s16 ground_level = 8;
 	s16 large_cave_depth = -33;
 	u16 small_cave_num_min = 0;
@@ -59,6 +58,7 @@ struct MapgenFlatParams : public MapgenParams
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 class MapgenFlat : public MapgenBasic

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -139,7 +139,7 @@ void MapgenFractalParams::readParams(const Settings *settings)
 
 void MapgenFractalParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal, U32_MAX);
+	settings->setFlagStr("mgfractal_spflags", spflags, flagdesc_mapgen_fractal);
 	settings->setFloat("mgfractal_cave_width",         cave_width);
 	settings->setS16("mgfractal_large_cave_depth",     large_cave_depth);
 	settings->setU16("mgfractal_small_cave_num_min",   small_cave_num_min);
@@ -164,6 +164,13 @@ void MapgenFractalParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgfractal_np_cave1",        np_cave1);
 	settings->setNoiseParams("mgfractal_np_cave2",        np_cave2);
 	settings->setNoiseParams("mgfractal_np_dungeons",     np_dungeons);
+}
+
+
+void MapgenFractalParams::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgfractal_spflags", flagdesc_mapgen_fractal,
+		MGFRACTAL_TERRAIN);
 }
 
 

--- a/src/mapgen/mapgen_fractal.h
+++ b/src/mapgen/mapgen_fractal.h
@@ -35,7 +35,6 @@ extern FlagDesc flagdesc_mapgen_fractal[];
 
 struct MapgenFractalParams : public MapgenParams
 {
-	u32 spflags = MGFRACTAL_TERRAIN;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
 	u16 small_cave_num_min = 0;
@@ -66,6 +65,7 @@ struct MapgenFractalParams : public MapgenParams
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 

--- a/src/mapgen/mapgen_v5.cpp
+++ b/src/mapgen/mapgen_v5.cpp
@@ -129,7 +129,7 @@ void MapgenV5Params::readParams(const Settings *settings)
 
 void MapgenV5Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5, U32_MAX);
+	settings->setFlagStr("mgv5_spflags", spflags, flagdesc_mapgen_v5);
 	settings->setFloat("mgv5_cave_width",         cave_width);
 	settings->setS16("mgv5_large_cave_depth",     large_cave_depth);
 	settings->setU16("mgv5_small_cave_num_min",   small_cave_num_min);
@@ -152,6 +152,15 @@ void MapgenV5Params::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgv5_np_cavern",       np_cavern);
 	settings->setNoiseParams("mgv5_np_dungeons",     np_dungeons);
 }
+
+
+void MapgenV5Params::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgv5_spflags", flagdesc_mapgen_v5, MGV5_CAVERNS);
+}
+
+
+/////////////////////////////////////////////////////////////////
 
 
 int MapgenV5::getSpawnLevelAtPoint(v2s16 p)

--- a/src/mapgen/mapgen_v5.h
+++ b/src/mapgen/mapgen_v5.h
@@ -31,7 +31,6 @@ extern FlagDesc flagdesc_mapgen_v5[];
 
 struct MapgenV5Params : public MapgenParams
 {
-	u32 spflags = MGV5_CAVERNS;
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -256;
 	u16 small_cave_num_min = 0;
@@ -59,6 +58,7 @@ struct MapgenV5Params : public MapgenParams
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 class MapgenV5 : public MapgenBasic

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -190,7 +190,7 @@ void MapgenV6Params::readParams(const Settings *settings)
 
 void MapgenV6Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv6_spflags", spflags, flagdesc_mapgen_v6, U32_MAX);
+	settings->setFlagStr("mgv6_spflags", spflags, flagdesc_mapgen_v6);
 	settings->setFloat("mgv6_freq_desert", freq_desert);
 	settings->setFloat("mgv6_freq_beach",  freq_beach);
 	settings->setS16("mgv6_dungeon_ymin",  dungeon_ymin);
@@ -210,7 +210,15 @@ void MapgenV6Params::writeParams(Settings *settings) const
 }
 
 
+void MapgenV6Params::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgv6_spflags", flagdesc_mapgen_v6, MGV6_JUNGLES |
+		MGV6_SNOWBIOMES | MGV6_TREES | MGV6_BIOMEBLEND | MGV6_MUDFLOW);
+}
+
+
 //////////////////////// Some helper functions for the map generator
+
 
 // Returns Y one under area minimum if not found
 s16 MapgenV6::find_stone_level(v2s16 p2d)

--- a/src/mapgen/mapgen_v6.h
+++ b/src/mapgen/mapgen_v6.h
@@ -55,8 +55,6 @@ enum BiomeV6Type
 
 
 struct MapgenV6Params : public MapgenParams {
-	u32 spflags = MGV6_JUNGLES | MGV6_SNOWBIOMES | MGV6_TREES |
-		MGV6_BIOMEBLEND | MGV6_MUDFLOW;
 	float freq_desert = 0.45f;
 	float freq_beach = 0.15f;
 	s16 dungeon_ymin = -31000;
@@ -79,6 +77,7 @@ struct MapgenV6Params : public MapgenParams {
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -183,7 +183,7 @@ void MapgenV7Params::readParams(const Settings *settings)
 
 void MapgenV7Params::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7, U32_MAX);
+	settings->setFlagStr("mgv7_spflags", spflags, flagdesc_mapgen_v7);
 	settings->setS16("mgv7_mount_zero_level",           mount_zero_level);
 	settings->setFloat("mgv7_cave_width",               cave_width);
 	settings->setS16("mgv7_large_cave_depth",           large_cave_depth);
@@ -211,6 +211,13 @@ void MapgenV7Params::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgv7_np_cave1",           np_cave1);
 	settings->setNoiseParams("mgv7_np_cave2",           np_cave2);
 	settings->setNoiseParams("mgv7_np_dungeons",        np_dungeons);
+}
+
+
+void MapgenV7Params::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgv7_spflags", flagdesc_mapgen_v7,
+		MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS);
 }
 
 

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -35,7 +35,6 @@ extern FlagDesc flagdesc_mapgen_v7[];
 
 
 struct MapgenV7Params : public MapgenParams {
-	u32 spflags = MGV7_MOUNTAINS | MGV7_RIDGES | MGV7_CAVERNS;
 	s16 mount_zero_level = 0;
 
 	float cave_width = 0.09f;
@@ -70,6 +69,7 @@ struct MapgenV7Params : public MapgenParams {
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 

--- a/src/mapgen/mapgen_valleys.cpp
+++ b/src/mapgen/mapgen_valleys.cpp
@@ -162,7 +162,7 @@ void MapgenValleysParams::readParams(const Settings *settings)
 
 void MapgenValleysParams::writeParams(Settings *settings) const
 {
-	settings->setFlagStr("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys, U32_MAX);
+	settings->setFlagStr("mgvalleys_spflags", spflags, flagdesc_mapgen_valleys);
 	settings->setU16("mgvalleys_altitude_chill",       altitude_chill);
 	settings->setS16("mgvalleys_large_cave_depth",     large_cave_depth);
 	settings->setU16("mgvalleys_small_cave_num_min",   small_cave_num_min);
@@ -192,6 +192,17 @@ void MapgenValleysParams::writeParams(Settings *settings) const
 	settings->setNoiseParams("mgvalleys_np_cavern",             np_cavern);
 	settings->setNoiseParams("mgvalleys_np_dungeons",           np_dungeons);
 }
+
+
+void MapgenValleysParams::setDefaultSettings(Settings *settings)
+{
+	settings->setDefault("mgvalleys_spflags", flagdesc_mapgen_valleys,
+		MGVALLEYS_ALT_CHILL | MGVALLEYS_HUMID_RIVERS |
+		MGVALLEYS_VARY_RIVER_DEPTH | MGVALLEYS_ALT_DRY);
+}
+
+
+/////////////////////////////////////////////////////////////////
 
 
 void MapgenValleys::makeChunk(BlockMakeData *data)

--- a/src/mapgen/mapgen_valleys.h
+++ b/src/mapgen/mapgen_valleys.h
@@ -41,8 +41,6 @@ extern FlagDesc flagdesc_mapgen_valleys[];
 
 
 struct MapgenValleysParams : public MapgenParams {
-	u32 spflags = MGVALLEYS_ALT_CHILL | MGVALLEYS_HUMID_RIVERS |
-		MGVALLEYS_VARY_RIVER_DEPTH | MGVALLEYS_ALT_DRY;
 	u16 altitude_chill = 90;
 	u16 river_depth = 4;
 	u16 river_size = 5;
@@ -78,6 +76,7 @@ struct MapgenValleysParams : public MapgenParams {
 
 	void readParams(const Settings *settings);
 	void writeParams(Settings *settings) const;
+	void setDefaultSettings(Settings *settings);
 };
 
 

--- a/src/script/lua_api/l_settings.h
+++ b/src/script/lua_api/l_settings.h
@@ -42,6 +42,9 @@ private:
 	// get_np_group(self, key) -> noiseparam
 	static int l_get_np_group(lua_State *L);
 
+	// get_flags(self, key) -> key/value table
+	static int l_get_flags(lua_State *L);
+
 	// set(self, key, value)
 	static int l_set(lua_State *L);
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -484,12 +484,33 @@ v3f Settings::getV3F(const std::string &name) const
 u32 Settings::getFlagStr(const std::string &name, const FlagDesc *flagdesc,
 	u32 *flagmask) const
 {
-	std::string val = get(name);
-	return std::isdigit(val[0])
-		? stoi(val)
-		: readFlagString(val, flagdesc, flagmask);
-}
+	u32 flags = 0;
+	u32 mask_default = 0;
 
+	std::string value;
+	// Read default value (if there is any)
+	if (getDefaultNoEx(name, value)) {
+		flags = std::isdigit(value[0])
+			? stoi(value)
+			: readFlagString(value, flagdesc, &mask_default);
+	}
+
+	// Apply custom flags "on top"
+	value = get(name);
+	u32 flags_user;
+	u32 mask_user = U32_MAX;
+	flags_user = std::isdigit(value[0])
+		? stoi(value) // Override default
+		: readFlagString(value, flagdesc, &mask_user);
+
+	flags &= ~mask_user;
+	flags |=  flags_user;
+
+	if (flagmask)
+		*flagmask = mask_default | mask_user;
+
+	return flags;
+}
 
 // N.B. if getStruct() is used to read a non-POD aggregate type,
 // the behavior is undefined.
@@ -736,19 +757,20 @@ bool Settings::getV3FNoEx(const std::string &name, v3f &val) const
 }
 
 
-// N.B. getFlagStrNoEx() does not set val, but merely modifies it.  Thus,
-// val must be initialized before using getFlagStrNoEx().  The intention of
-// this is to simplify modifying a flags field from a default value.
 bool Settings::getFlagStrNoEx(const std::string &name, u32 &val,
-	FlagDesc *flagdesc) const
+	const FlagDesc *flagdesc) const
 {
+	if (!flagdesc) {
+		// Fallback
+		auto it = m_flags.find(name);
+		if (it == m_flags.end())
+			return false;
+
+		flagdesc = it->second;
+	}
+
 	try {
-		u32 flags, flagmask;
-
-		flags = getFlagStr(name, flagdesc, &flagmask);
-
-		val &= ~flagmask;
-		val |=  flags;
+		val = getFlagStr(name, flagdesc, nullptr);
 
 		return true;
 	} catch (SettingNotFoundException &e) {
@@ -1018,6 +1040,18 @@ void Settings::clearDefaultsNoLock()
 	m_defaults.clear();
 }
 
+void Settings::setDefault(const std::string &name, const FlagDesc *flagdesc,
+		const std::string &value)
+{
+	m_flags[name] = flagdesc;
+	setDefault(name, value);
+}
+
+const FlagDesc *Settings::getFlagDescFallback(const std::string &name) const
+{
+	auto it = m_flags.find(name);
+	return it == m_flags.end() ? nullptr : it->second;
+}
 
 void Settings::registerChangedCallback(const std::string &name,
 	SettingsChangedCallback cbf, void *userdata)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -761,12 +761,8 @@ bool Settings::getFlagStrNoEx(const std::string &name, u32 &val,
 	const FlagDesc *flagdesc) const
 {
 	if (!flagdesc) {
-		// Fallback
-		auto it = m_flags.find(name);
-		if (it == m_flags.end())
-			return false;
-
-		flagdesc = it->second;
+		if (!(flagdesc = getFlagDescFallback(name)))
+			return false; // Not found
 	}
 
 	try {
@@ -895,6 +891,11 @@ bool Settings::setV3F(const std::string &name, v3f value)
 bool Settings::setFlagStr(const std::string &name, u32 flags,
 	const FlagDesc *flagdesc, u32 flagmask)
 {
+	if (!flagdesc) {
+		if (!(flagdesc = getFlagDescFallback(name)))
+			return false; // Not found
+	}
+
 	return set(name, writeFlagString(flags, flagdesc, flagmask));
 }
 
@@ -1041,10 +1042,10 @@ void Settings::clearDefaultsNoLock()
 }
 
 void Settings::setDefault(const std::string &name, const FlagDesc *flagdesc,
-		const std::string &value)
+	u32 flags)
 {
 	m_flags[name] = flagdesc;
-	setDefault(name, value);
+	setDefault(name, writeFlagString(flags, flagdesc, U32_MAX));
 }
 
 const FlagDesc *Settings::getFlagDescFallback(const std::string &name) const

--- a/src/settings.h
+++ b/src/settings.h
@@ -203,7 +203,7 @@ public:
 	bool setV2F(const std::string &name, v2f value);
 	bool setV3F(const std::string &name, v3f value);
 	bool setFlagStr(const std::string &name, u32 flags,
-		const FlagDesc *flagdesc, u32 flagmask);
+		const FlagDesc *flagdesc = nullptr, u32 flagmask = U32_MAX);
 	bool setNoiseParams(const std::string &name, const NoiseParams &np,
 		bool set_default=false);
 	// N.B. if setStruct() is used to write a non-POD aggregate type,
@@ -221,8 +221,7 @@ public:
 	 * Miscellany *
 	 **************/
 
-	void setDefault(const std::string &name, const FlagDesc *flagdesc,
-		const std::string &value);
+	void setDefault(const std::string &name, const FlagDesc *flagdesc, u32 flags);
 	const FlagDesc *getFlagDescFallback(const std::string &name) const;
 
 	void registerChangedCallback(const std::string &name,

--- a/src/settings.h
+++ b/src/settings.h
@@ -174,10 +174,12 @@ public:
 	bool getFloatNoEx(const std::string &name, float &val) const;
 	bool getV2FNoEx(const std::string &name, v2f &val) const;
 	bool getV3FNoEx(const std::string &name, v3f &val) const;
-	// N.B. getFlagStrNoEx() does not set val, but merely modifies it.  Thus,
-	// val must be initialized before using getFlagStrNoEx().  The intention of
-	// this is to simplify modifying a flags field from a default value.
-	bool getFlagStrNoEx(const std::string &name, u32 &val, FlagDesc *flagdesc) const;
+
+	// Like other getters, but handling each flag individualy:
+	// 1) Read default flags (or 0)
+	// 2) Override using user-defined flags
+	bool getFlagStrNoEx(const std::string &name, u32 &val,
+		const FlagDesc *flagdesc) const;
 
 
 	/***********
@@ -215,6 +217,14 @@ public:
 	void updateValue(const Settings &other, const std::string &name);
 	void update(const Settings &other);
 
+	/**************
+	 * Miscellany *
+	 **************/
+
+	void setDefault(const std::string &name, const FlagDesc *flagdesc,
+		const std::string &value);
+	const FlagDesc *getFlagDescFallback(const std::string &name) const;
+
 	void registerChangedCallback(const std::string &name,
 		SettingsChangedCallback cbf, void *userdata = NULL);
 	void deregisterChangedCallback(const std::string &name,
@@ -229,6 +239,7 @@ private:
 
 	SettingEntries m_settings;
 	SettingEntries m_defaults;
+	std::unordered_map<std::string, const FlagDesc *> m_flags;
 
 	SettingsCallbackMap m_callbacks;
 

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -31,6 +31,7 @@ public:
 	void runTests(IGameDef *gamedef);
 
 	void testAllSettings();
+	void testFlagDesc();
 
 	static const char *config_text_before;
 	static const std::string config_text_after;
@@ -41,6 +42,7 @@ static TestSettings g_test_instance;
 void TestSettings::runTests(IGameDef *gamedef)
 {
 	TEST(testAllSettings);
+	TEST(testFlagDesc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -205,4 +207,38 @@ void TestSettings::testAllSettings()
 	} catch (SettingNotFoundException &e) {
 		UASSERT(!"Setting not found!");
 	}
+}
+
+void TestSettings::testFlagDesc()
+{
+	Settings s;
+	FlagDesc flagdesc[] = {
+		{ "biomes",  0x01 },
+		{ "trees",   0x02 },
+		{ "jungles", 0x04 },
+		{ "oranges", 0x08 },
+		{ "tables",  0x10 },
+		{ nullptr,      0 }
+	};
+
+	// Enabled: biomes, jungles, oranges (default)
+	s.setDefault("test_desc", flagdesc, "biomes,notrees,jungles,oranges");
+	UASSERT(s.getFlagStr("test_desc", flagdesc, nullptr) == (0x01 | 0x04 | 0x08));
+
+	// Enabled: jungles, oranges, tables
+	s.set("test_desc", "nobiomes,tables");
+	UASSERT(s.getFlagStr("test_desc", flagdesc, nullptr) == (0x04 | 0x08 | 0x10));
+
+	// Enabled: (nothing)
+	s.set("test_desc", "nobiomes,nojungles,nooranges,notables");
+	UASSERT(s.getFlagStr("test_desc", flagdesc, nullptr) == 0x00);
+
+	// Numeric flag tests (override)
+	// Enabled: trees, tables
+	s.setDefault("test_flags", flagdesc, "18");
+	UASSERT(s.getFlagStr("test_flags", flagdesc, nullptr) == (0x02 | 0x10));
+
+	// Enabled: tables
+	s.set("test_flags", "16");
+	UASSERT(s.getFlagStr("test_flags", flagdesc, nullptr) == 0x10);
 }

--- a/src/unittest/test_settings.cpp
+++ b/src/unittest/test_settings.cpp
@@ -222,7 +222,8 @@ void TestSettings::testFlagDesc()
 	};
 
 	// Enabled: biomes, jungles, oranges (default)
-	s.setDefault("test_desc", flagdesc, "biomes,notrees,jungles,oranges");
+	s.setDefault("test_desc", flagdesc, readFlagString(
+		"biomes,notrees,jungles,oranges", flagdesc, nullptr));
 	UASSERT(s.getFlagStr("test_desc", flagdesc, nullptr) == (0x01 | 0x04 | 0x08));
 
 	// Enabled: jungles, oranges, tables
@@ -235,7 +236,7 @@ void TestSettings::testFlagDesc()
 
 	// Numeric flag tests (override)
 	// Enabled: trees, tables
-	s.setDefault("test_flags", flagdesc, "18");
+	s.setDefault("test_flags", flagdesc, 0x02 | 0x10);
 	UASSERT(s.getFlagStr("test_flags", flagdesc, nullptr) == (0x02 | 0x10));
 
 	// Enabled: tables


### PR DESCRIPTION
Replaces #9279 by implementing a proper API to setting flags.
In order to get the flags to work, their default value has to be specified using an additional `FlagDesc` struct array. The mapgen default flags are now defined in `mapgen.cpp`.

**Implementation goals:**

1) Unified flags handling in C++ and Lua Settings API
    * Reading only, for now. Writing can be implemented later, if needed.
2) API function to read the currently active flags
    * Currently impossible from Lua


## To do

This PR is Ready for Review.

## How to test

1) Run unittests. The Settings tests may not fail.
2) Code for mainmenu or a server-side mod:
```Lua
core.settings:set("mg_flags", "nocaves,nodecorations")
local t

t = core.settings:get_flags("mg_flags")
print(dump(t))
assert(t.caves == false);
assert(t.dungeons == true);
assert(t.light == true);
assert(t.decorations == false);
assert(t.biomes == true);

core.settings:set("mg_flags", "nodecorations,nobiomes")
t = core.settings:get_flags("mg_flags")
print(dump(t))
assert(t.caves == true);
assert(t.dungeons == true);
assert(t.light == true);
assert(t.decorations == false);
assert(t.biomes == false);

core.settings:remove("mg_flags")
```

@Wuzzy2 and @pauloue might be interested.