### PR TITLE
Formspec: create a new class for inventorylists

### DIFF
--- a/build/android/jni/Android.mk
+++ b/build/android/jni/Android.mk
@@ -189,6 +189,7 @@ LOCAL_SRC_FILES := \
 		jni/src/gui/guiEngine.cpp                 \
 		jni/src/gui/guiFormSpecMenu.cpp           \
 		jni/src/gui/guiHyperText.cpp              \
+		jni/src/gui/guiInventoryList.cpp          \
 		jni/src/gui/guiItemImage.cpp              \
 		jni/src/gui/guiKeyChangeMenu.cpp          \
 		jni/src/gui/guiPasswordChange.cpp         \

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1931,8 +1931,6 @@ For coloured text you can use `minetest.colorize`.
 
 Since formspec version 3, elements drawn in the order they are defined. All
 background elements are drawn before all other elements.
-`list` elements are an exception here. They are drawn last. This, however, might
-be changed at any time.
 
 **WARNING**: do _not_ use a element name starting with `key_`; those names are
 reserved to pass key press events to formspec!
@@ -2043,7 +2041,6 @@ Elements
   be shown if the inventory list is of size 0.
 * **Note**: With the new coordinate system, the spacing between inventory
   slots is one-fourth the size of an inventory slot.
-* **Note**: Lists are drawn after every other element. This might change at any time.
 
 ### `list[<inventory location>;<list name>;<X>,<Y>;<W>,<H>;<starting item index>]`
 
@@ -2051,7 +2048,6 @@ Elements
   be shown if the inventory list is of size 0.
 * **Note**: With the new coordinate system, the spacing between inventory
   slots is one-fourth the size of an inventory slot.
-* **Note**: Lists are drawn after every other element. This might change at any time.
 
 ### `listring[<inventory location>;<list name>]`
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -9,6 +9,7 @@ set(gui_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEditBoxWithScrollbar.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiEngine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiFormSpecMenu.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/guiInventoryList.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiItemImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiKeyChangeMenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiPasswordChange.cpp

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -442,10 +442,7 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 
 		GUIInventoryList *e = new GUIInventoryList(Environment, this, spec.fid,
 				rect, m_invmgr, loc, listname, geom, start_i, imgsize, slot_spacing,
-				this, data->inventorylist_options.slotbg_n,
-				data->inventorylist_options.slotbg_h,
-				data->inventorylist_options.slotborder,
-				data->inventorylist_options.slotbordercolor, m_font);
+				this, data->inventorylist_options, m_font);
 
 		m_inventorylists.push_back(e);
 		m_fields.push_back(spec);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -442,7 +442,10 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 
 		GUIInventoryList *e = new GUIInventoryList(Environment, this, spec.fid,
 				rect, m_invmgr, loc, listname, geom, start_i, imgsize, slot_spacing,
-				this, m_slotbg_n, m_slotbg_h, m_slotborder, m_slotbordercolor, m_font);
+				this, data->inventorylist_options.slotbg_n,
+				data->inventorylist_options.slotbg_h,
+				data->inventorylist_options.slotborder,
+				data->inventorylist_options.slotbordercolor, m_font);
 
 		//~ // the element the list is bound to should not block mouse-clicks (todo)
 		//~ e->setVisible(false);
@@ -2156,13 +2159,13 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 	if (((parts.size() == 2) || (parts.size() == 3) || (parts.size() == 5)) ||
 		((parts.size() > 5) && (m_formspec_version > FORMSPEC_API_VERSION)))
 	{
-		// todo: update all m_inventorylists
-		parseColorString(parts[0], m_slotbg_n, false);
-		parseColorString(parts[1], m_slotbg_h, false);
+		parseColorString(parts[0], data->inventorylist_options.slotbg_n, false);
+		parseColorString(parts[1], data->inventorylist_options.slotbg_h, false);
 
 		if (parts.size() >= 3) {
-			if (parseColorString(parts[2], m_slotbordercolor, false)) {
-				m_slotborder = true;
+			if (parseColorString(parts[2], data->inventorylist_options.slotbordercolor,
+					false)) {
+				data->inventorylist_options.slotborder = true;
 			}
 		}
 		if (parts.size() == 5) {
@@ -2172,6 +2175,14 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 				m_default_tooltip_bgcolor = tmp_color;
 			if (parseColorString(parts[4], tmp_color, false))
 				m_default_tooltip_color = tmp_color;
+		}
+
+		// update all already parsed inventorylists
+		for (GUIInventoryList *e : m_inventorylists) {
+			e->setSlotBGColors(data->inventorylist_options.slotbg_n,
+					data->inventorylist_options.slotbg_h);
+			e->setSlotBorders(data->inventorylist_options.slotborder,
+					data->inventorylist_options.slotbordercolor);
 		}
 		return;
 	}
@@ -2718,14 +2729,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		);
 	}
 
-	m_slotbg_n = video::SColor(255,128,128,128);
-	m_slotbg_h = video::SColor(255,192,192,192);
-
 	m_default_tooltip_bgcolor = video::SColor(255,110,130,60);
 	m_default_tooltip_color = video::SColor(255,255,255,255);
-
-	m_slotbordercolor = video::SColor(200,0,0,0);
-	m_slotborder = false;
 
 	// Add tooltip
 	{

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2683,8 +2683,6 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// Base position of contents of form
 	mydata.basepos = getBasePos();
 
-	/* Convert m_init_draw_spec to m_inventorylists (todo: what does that mean?) */
-
 	m_inventorylists.clear();
 	m_backgrounds.clear();
 	m_tables.clear();

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -447,9 +447,6 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 				data->inventorylist_options.slotborder,
 				data->inventorylist_options.slotbordercolor, m_font);
 
-		//~ // the element the list is bound to should not block mouse-clicks (todo)
-		//~ e->setVisible(false);
-
 		m_inventorylists.push_back(e);
 		m_fields.push_back(spec);
 		return;
@@ -3303,7 +3300,7 @@ void GUIFormSpecMenu::showTooltip(const std::wstring &text,
 	bringToFront(m_tooltip_element);
 }
 
-void GUIFormSpecMenu::updateSelectedItem()//todo
+void GUIFormSpecMenu::updateSelectedItem()
 {
 	verifySelectedItem();
 
@@ -3349,7 +3346,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 	// If the selected stack has become smaller, adjust m_selected_amount.
 	// Return the selected stack.
 
-	if(m_selected_item) {
+	if (m_selected_item) {
 		if (m_selected_item->isValid()) {
 			Inventory *inv = m_invmgr->getInventory(m_selected_item->inventoryloc);
 			if (inv) {
@@ -3512,9 +3509,9 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 	}
 }
 
-static bool isChild(gui::IGUIElement * tocheck, gui::IGUIElement * parent)
+static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)
 {
-	while(tocheck != NULL) {
+	while (tocheck) {
 		if (tocheck == parent) {
 			return true;
 		}
@@ -3551,8 +3548,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	}
 
 	// Fix Esc/Return key being eaten by checkboxen and tables
-	if(event.EventType==EET_KEY_INPUT_EVENT) {
-		KeyPress kp(event.KeyInput);
+	if (event.EventType == EET_KEY_INPUT_EVENT) {
+			KeyPress kp(event.KeyInput);
 		if (kp == EscapeKey || kp == CancelKey
 				|| kp == getKeySetting("keymap_inventory")
 				|| event.KeyInput.Key==KEY_RETURN) {
@@ -3591,7 +3588,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 		if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN) {
 			m_old_tooltip_id = -1;
 		}
-		if (!isChild(hovered,this)) {
+		if (!isChild(hovered, this)) {
 			if (DoubleClickDetection(event)) {
 				return true;
 			}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "irrlichttypes_extrabloated.h"
 #include "inventorymanager.h"
 #include "modalMenu.h"
+#include "guiInventoryList.h"
 #include "guiTable.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
@@ -78,51 +79,6 @@ public:
 
 class GUIFormSpecMenu : public GUIModalMenu
 {
-	struct ItemSpec
-	{
-		ItemSpec() = default;
-
-		ItemSpec(const InventoryLocation &a_inventoryloc,
-				const std::string &a_listname,
-				s32 a_i) :
-			inventoryloc(a_inventoryloc),
-			listname(a_listname),
-			i(a_i)
-		{
-		}
-
-		bool isValid() const { return i != -1; }
-
-		InventoryLocation inventoryloc;
-		std::string listname;
-		s32 i = -1;
-	};
-
-	struct ListDrawSpec
-	{
-		ListDrawSpec() = default;
-
-		ListDrawSpec(const InventoryLocation &a_inventoryloc,
-				const std::string &a_listname,
-				IGUIElement *elem, v2s32 a_geom, s32 a_start_item_i,
-				bool a_real_coordinates):
-			inventoryloc(a_inventoryloc),
-			listname(a_listname),
-			e(elem),
-			geom(a_geom),
-			start_item_i(a_start_item_i),
-			real_coordinates(a_real_coordinates)
-		{
-		}
-
-		InventoryLocation inventoryloc;
-		std::string listname;
-		IGUIElement *e;
-		v2s32 geom;
-		s32 start_item_i;
-		bool real_coordinates;
-	};
-
 	struct ListRingSpec
 	{
 		ListRingSpec() = default;
@@ -181,35 +137,6 @@ class GUIFormSpecMenu : public GUIModalMenu
 		std::wstring tooltip;
 		irr::video::SColor bgcolor;
 		irr::video::SColor color;
-	};
-
-	struct StaticTextSpec
-	{
-		StaticTextSpec():
-			parent_button(NULL)
-		{
-		}
-
-		StaticTextSpec(const std::wstring &a_text,
-				const core::rect<s32> &a_rect):
-			text(a_text),
-			rect(a_rect),
-			parent_button(NULL)
-		{
-		}
-
-		StaticTextSpec(const std::wstring &a_text,
-				const core::rect<s32> &a_rect,
-				gui::IGUIButton *a_parent_button):
-			text(a_text),
-			rect(a_rect),
-			parent_button(a_parent_button)
-		{
-		}
-
-		std::wstring text;
-		core::rect<s32> rect;
-		gui::IGUIButton *parent_button;
 	};
 
 public:
@@ -280,13 +207,42 @@ public:
 		m_focused_element = elementname;
 	}
 
+	Client *getClient() const
+	{
+		return m_client;
+	}
+
+	const GUIInventoryList::ItemSpec *getSelectedItem() const
+	{
+		return m_selected_item;
+	}
+
+	const u16 getSelectedAmount() const
+	{
+		return m_selected_amount;
+	}
+
+	const v2s32 &getPointer() const
+	{
+		return m_pointer;
+	}
+
+	bool doTooltipAppendItemname() const
+	{
+		return m_tooltip_append_itemname;
+	}
+
+	void addHoveredItemTooltip(const std::string &name)
+	{
+		m_hovered_item_tooltips.emplace_back(name);
+	}
+
 	/*
 		Remove and re-add (or reposition) stuff
 	*/
 	void regenerateGui(v2u32 screensize);
 
-	ItemSpec getItemAtPos(v2s32 p) const;
-	void drawList(const ListDrawSpec &s, int layer,	bool &item_hovered);
+	GUIInventoryList::ItemSpec getItemAtPos(v2s32 p) const;
 	void drawSelectedItem();
 	void drawMenu();
 	void updateSelectedItem();
@@ -339,7 +295,7 @@ protected:
 	std::string m_formspec_prepend;
 	InventoryLocation m_current_inventory_location;
 
-	std::vector<ListDrawSpec> m_inventorylists;
+	std::vector<GUIInventoryList *> m_inventorylists;
 	std::vector<ListRingSpec> m_inventory_rings;
 	std::vector<gui::IGUIElement *> m_backgrounds;
 	std::unordered_map<std::string, bool> field_close_on_enter;
@@ -351,7 +307,7 @@ protected:
 	std::vector<std::pair<FieldSpec, GUIScrollBar *>> m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string>>> m_dropdowns;
 
-	ItemSpec *m_selected_item = nullptr;
+	GUIInventoryList::ItemSpec *m_selected_item = nullptr;
 	u16 m_selected_amount = 0;
 	bool m_selected_dragging = false;
 	ItemStack m_selected_swap;
@@ -374,7 +330,7 @@ protected:
 	bool m_slotborder;
 	video::SColor m_bgcolor;
 	video::SColor m_fullscreen_bgcolor;
-	video::SColor m_slotbg_n;
+	video::SColor m_slotbg_n;//todo:remove from here
 	video::SColor m_slotbg_h;
 	video::SColor m_slotbordercolor;
 	video::SColor m_default_tooltip_bgcolor;
@@ -425,6 +381,7 @@ private:
 
 	fs_key_pendig current_keys_pending;
 	std::string current_field_enter_pending = "";
+	std::vector<std::string> m_hovered_item_tooltips;
 
 	void parseElement(parserData* data, const std::string &element);
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -222,11 +222,6 @@ public:
 		return m_selected_amount;
 	}
 
-	const v2s32 &getPointer() const
-	{
-		return m_pointer;
-	}
-
 	bool doTooltipAppendItemname() const
 	{
 		return m_tooltip_append_itemname;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -327,12 +327,8 @@ protected:
 
 	bool m_bgnonfullscreen;
 	bool m_bgfullscreen;
-	bool m_slotborder;
 	video::SColor m_bgcolor;
 	video::SColor m_fullscreen_bgcolor;
-	video::SColor m_slotbg_n;//todo:remove from here
-	video::SColor m_slotbg_h;
-	video::SColor m_slotbordercolor;
 	video::SColor m_default_tooltip_bgcolor;
 	video::SColor m_default_tooltip_color;
 
@@ -358,6 +354,13 @@ private:
 		std::string focused_fieldname;
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
+
+		struct {
+			bool slotborder = false;
+			video::SColor slotbg_n = video::SColor(255, 128, 128, 128);
+			video::SColor slotbg_h = video::SColor(255, 192, 192, 192);
+			video::SColor slotbordercolor = video::SColor(200, 0, 0, 0);
+		} inventorylist_options;
 
 		struct {
 			s32 max = 1000;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -350,12 +350,7 @@ private:
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
 
-		struct {
-			bool slotborder = false;
-			video::SColor slotbg_n = video::SColor(255, 128, 128, 128);
-			video::SColor slotbg_h = video::SColor(255, 192, 192, 192);
-			video::SColor slotbordercolor = video::SColor(200, 0, 0, 0);
-		} inventorylist_options;
+		GUIInventoryList::Options inventorylist_options;
 
 		struct {
 			s32 max = 1000;

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -158,6 +158,25 @@ void GUIInventoryList::draw()
 	IGUIElement::draw();
 }
 
+bool GUIInventoryList::OnEvent(const SEvent &event)
+{
+	if (event.EventType != EET_MOUSE_INPUT_EVENT)
+		return IGUIElement::OnEvent(event);
+
+	bool was_visible = IsVisible;
+	IsVisible = false;
+
+	IGUIElement *hovered =
+		Environment->getRootGUIElement()->getElementFromPoint(
+			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
+
+	bool ret = hovered && hovered->OnEvent(event);
+
+	IsVisible = was_visible;
+
+	return ret || IGUIElement::OnEvent(event);
+}
+
 s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const
 {
 	if (!IsVisible || AbsoluteClippingRect.getArea() <= 0 ||

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -165,7 +165,7 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 
 	m_hovered_i = getItemIndexAtPos(v2s32(event.MouseInput.X, event.MouseInput.Y));
 
-	if (getItemIndexAtPos(v2s32(event.MouseInput.X, event.MouseInput.Y)) != -1)
+	if (m_hovered_i != -1)
 		return IGUIElement::OnEvent(event);
 
 	// no item slot at pos of mouse event => allow clicking through
@@ -175,9 +175,12 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 	IGUIElement *hovered =
 		Environment->getRootGUIElement()->getElementFromPoint(
 			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
+
+	bool ret = hovered && hovered->OnEvent(event);
+
 	IsVisible = was_visible;
 
-	return hovered && hovered->OnEvent(event);
+	return ret;
 }
 
 s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -120,18 +120,21 @@ void GUIInventoryList::draw()
 			s32 x2 = rect.LowerRightCorner.X;
 			s32 y2 = rect.LowerRightCorner.Y;
 			s32 border = 1;
+			core::rect<s32> clipping_rect = Parent ? Parent->getAbsoluteClippingRect()
+					: core::rect<s32>();
+			core::rect<s32> *clipping_rect_ptr = Parent ? &clipping_rect : nullptr;
 			driver->draw2DRectangle(m_slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y1 - border),
-								v2s32(x2 + border, y1)), &AbsoluteClippingRect);
+								v2s32(x2 + border, y1)), clipping_rect_ptr);
 			driver->draw2DRectangle(m_slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y2),
-								v2s32(x2 + border, y2 + border)), &AbsoluteClippingRect);
+								v2s32(x2 + border, y2 + border)), clipping_rect_ptr);
 			driver->draw2DRectangle(m_slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y1),
-								v2s32(x1, y2)), &AbsoluteClippingRect);
+								v2s32(x1, y2)), clipping_rect_ptr);
 			driver->draw2DRectangle(m_slotbordercolor,
 				core::rect<s32>(v2s32(x2, y1),
-								v2s32(x2 + border, y2)), &AbsoluteClippingRect);
+								v2s32(x2 + border, y2)), clipping_rect_ptr);
 		}
 
 		// layer 1

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -160,21 +160,20 @@ void GUIInventoryList::draw()
 
 bool GUIInventoryList::OnEvent(const SEvent &event)
 {
-	if (event.EventType != EET_MOUSE_INPUT_EVENT)
+	if (event.EventType != EET_MOUSE_INPUT_EVENT ||
+			getItemIndexAtPos(v2s32(event.MouseInput.X, event.MouseInput.Y)) != -1)
 		return IGUIElement::OnEvent(event);
 
+	// no item slot at pos of mouse event => allow clicking through
+	// find the element that would be hovered if this inventorylist was invisible
 	bool was_visible = IsVisible;
 	IsVisible = false;
-
 	IGUIElement *hovered =
 		Environment->getRootGUIElement()->getElementFromPoint(
 			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
-
-	bool ret = hovered && hovered->OnEvent(event);
-
 	IsVisible = was_visible;
 
-	return ret || IGUIElement::OnEvent(event);
+	return hovered && hovered->OnEvent(event);
 }
 
 s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -34,10 +34,7 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	const v2s32 &slot_size,
 	const v2f32 &slot_spacing,
 	GUIFormSpecMenu *fs_menu,
-	const video::SColor &slotbg_n,
-	const video::SColor &slotbg_h,
-	bool slotborder,
-	const video::SColor &slotbordercolor,
+	const Options &options,
 	gui::IGUIFont *font) :
 	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
 	m_invmgr(invmgr),
@@ -48,10 +45,7 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	m_slot_size(slot_size),
 	m_slot_spacing(slot_spacing),
 	m_fs_menu(fs_menu),
-	m_slotbg_n(slotbg_n),
-	m_slotbg_h(slotbg_h),
-	m_slotborder(slotborder),
-	m_slotbordercolor(slotbordercolor),
+	m_options(options),
 	m_font(font),
 	m_hovered_i(-1)
 {
@@ -108,13 +102,13 @@ void GUIInventoryList::draw()
 
 		// layer 0
 		if (hovering) {
-			driver->draw2DRectangle(m_slotbg_h, rect, &AbsoluteClippingRect);
+			driver->draw2DRectangle(m_options.slotbg_h, rect, &AbsoluteClippingRect);
 		} else {
-			driver->draw2DRectangle(m_slotbg_n, rect, &AbsoluteClippingRect);
+			driver->draw2DRectangle(m_options.slotbg_n, rect, &AbsoluteClippingRect);
 		}
 
 		// Draw inv slot borders
-		if (m_slotborder) {
+		if (m_options.slotborder) {
 			s32 x1 = rect.UpperLeftCorner.X;
 			s32 y1 = rect.UpperLeftCorner.Y;
 			s32 x2 = rect.LowerRightCorner.X;
@@ -123,16 +117,16 @@ void GUIInventoryList::draw()
 			core::rect<s32> clipping_rect = Parent ? Parent->getAbsoluteClippingRect()
 					: core::rect<s32>();
 			core::rect<s32> *clipping_rect_ptr = Parent ? &clipping_rect : nullptr;
-			driver->draw2DRectangle(m_slotbordercolor,
+			driver->draw2DRectangle(m_options.slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y1 - border),
 								v2s32(x2 + border, y1)), clipping_rect_ptr);
-			driver->draw2DRectangle(m_slotbordercolor,
+			driver->draw2DRectangle(m_options.slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y2),
 								v2s32(x2 + border, y2 + border)), clipping_rect_ptr);
-			driver->draw2DRectangle(m_slotbordercolor,
+			driver->draw2DRectangle(m_options.slotbordercolor,
 				core::rect<s32>(v2s32(x1 - border, y1),
 								v2s32(x1, y2)), clipping_rect_ptr);
-			driver->draw2DRectangle(m_slotbordercolor,
+			driver->draw2DRectangle(m_options.slotbordercolor,
 				core::rect<s32>(v2s32(x2, y1),
 								v2s32(x2 + border, y2)), clipping_rect_ptr);
 		}

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -48,6 +48,16 @@ public:
 		s32 i = -1;
 	};
 
+	// options for inventorylists that are setable with the lua api
+	struct Options {
+		// whether a one-pixel border for the slots should be drawn and its color
+		bool slotborder = false;
+		video::SColor slotbordercolor = video::SColor(200, 0, 0, 0);
+		// colors for normal and highlighted slot background
+		video::SColor slotbg_n = video::SColor(255, 128, 128, 128);
+		video::SColor slotbg_h = video::SColor(255, 192, 192, 192);
+	};
+
 	GUIInventoryList(gui::IGUIEnvironment *env,
 		gui::IGUIElement *parent,
 		s32 id,
@@ -60,10 +70,7 @@ public:
 		const v2s32 &slot_size,
 		const v2f32 &slot_spacing,
 		GUIFormSpecMenu *fs_menu,
-		const video::SColor &slotbg_n,
-		const video::SColor &slotbg_h,
-		bool slotborder,
-		const video::SColor &slotbordercolor,
+		const Options &options,
 		gui::IGUIFont *font);
 
 	virtual void draw() override;
@@ -82,14 +89,14 @@ public:
 
 	void setSlotBGColors(const video::SColor &slotbg_n, const video::SColor &slotbg_h)
 	{
-		m_slotbg_n = slotbg_n;
-		m_slotbg_h = slotbg_h;
+		m_options.slotbg_n = slotbg_n;
+		m_options.slotbg_h = slotbg_h;
 	}
 
 	void setSlotBorders(bool slotborder, const video::SColor &slotbordercolor)
 	{
-		m_slotborder = slotborder;
-		m_slotbordercolor = slotbordercolor;
+		m_options.slotborder = slotborder;
+		m_options.slotbordercolor = slotbordercolor;
 	}
 
 	// returns -1 if not item is at pos p
@@ -113,13 +120,7 @@ private:
 	// the GUIFormSpecMenu can have an item selected and co.
 	GUIFormSpecMenu *m_fs_menu;
 
-	// normal and highlighted background color
-	video::SColor m_slotbg_n;
-	video::SColor m_slotbg_h;
-
-	// slotboarder
-	bool m_slotborder;
-	video::SColor m_slotbordercolor;
+	Options m_options;
 
 	// the font
 	gui::IGUIFont *m_font;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -68,6 +68,8 @@ public:
 
 	virtual void draw() override;
 
+	virtual bool OnEvent(const SEvent &event) override;
+
 	const InventoryLocation &getInventoryloc() const
 	{
 		return m_inventoryloc;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -84,6 +84,12 @@ public:
 		m_slotbg_h = slotbg_h;
 	}
 
+	void setSlotBorders(bool slotborder, const video::SColor &slotbordercolor)
+	{
+		m_slotborder = slotborder;
+		m_slotbordercolor = slotbordercolor;
+	}
+
 	// returns -1 if not item is at pos p
 	s32 getItemIndexAtPos(v2s32 p) const;
 

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -123,4 +123,7 @@ private:
 
 	// the font
 	gui::IGUIFont *m_font;
+
+	// the index of the hovered item; -1 if no item is hovered
+	s32 m_hovered_i;
 };

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -1,0 +1,118 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "inventorymanager.h"
+#include "irrlichttypes_extrabloated.h"
+#include "util/string.h"
+
+class GUIFormSpecMenu;
+
+class GUIInventoryList : public gui::IGUIElement
+{
+public:
+	struct ItemSpec
+	{
+		ItemSpec() = default;
+
+		ItemSpec(const InventoryLocation &a_inventoryloc,
+				const std::string &a_listname,
+				s32 a_i) :
+			inventoryloc(a_inventoryloc),
+			listname(a_listname),
+			i(a_i)
+		{
+		}
+
+		bool isValid() const { return i != -1; }
+
+		InventoryLocation inventoryloc;
+		std::string listname;
+		s32 i = -1;
+	};
+
+	GUIInventoryList(gui::IGUIEnvironment *env,
+		gui::IGUIElement *parent,
+		s32 id,
+		const core::rect<s32> &rectangle,
+		InventoryManager *invmgr,
+		const InventoryLocation &inventoryloc,
+		const std::string &listname,
+		const v2s32 &geom,
+		const s32 start_item_i,
+		const v2s32 &slot_size,
+		const v2f32 &slot_spacing,
+		GUIFormSpecMenu *fs_menu,
+		const video::SColor &slotbg_n,
+		const video::SColor &slotbg_h,
+		bool slotborder,
+		const video::SColor &slotbordercolor,
+		gui::IGUIFont *font);
+
+	virtual void draw() override;
+
+	const InventoryLocation &getInventoryloc() const
+	{
+		return m_inventoryloc;
+	}
+
+	const std::string &getListname() const
+	{
+		return m_listname;
+	}
+
+	void setSlotBGColors(const video::SColor &slotbg_n, const video::SColor &slotbg_h)
+	{
+		m_slotbg_n = slotbg_n;
+		m_slotbg_h = slotbg_h;
+	}
+
+	// returns -1 if not item is at pos p
+	s32 getItemIndexAtPos(v2s32 p) const;
+
+private:
+	InventoryManager *m_invmgr;
+	const InventoryLocation m_inventoryloc;
+	const std::string m_listname;
+
+	// specifies the width and height of the inventorylist in itemslots
+	const v2s32 m_geom;
+	// the first item's index in inventory
+	const s32 m_start_item_i;
+
+	// specifies how large the slot rects are
+	const v2s32 m_slot_size;
+	// specifies how large the space between slots is (space between is spacing-size)
+	const v2f32 m_slot_spacing;
+
+	// the GUIFormSpecMenu can have an item selected and co.
+	GUIFormSpecMenu *m_fs_menu;
+
+	// normal and highlighted background color
+	video::SColor m_slotbg_n;
+	video::SColor m_slotbg_h;
+
+	// slotboarder
+	bool m_slotborder;
+	video::SColor m_slotbordercolor;
+
+	// the font
+	gui::IGUIFont *m_font;
+};

--- a/util/travis/clang-format-whitelist.txt
+++ b/util/travis/clang-format-whitelist.txt
@@ -177,6 +177,8 @@ src/gui/guiFormSpecMenu.h
 src/gui/guiKeyChangeMenu.cpp
 src/gui/guiHyperText.cpp
 src/gui/guiHyperText.h
+src/gui/guiInventoryList.cpp
+src/gui/guiInventoryList.h
 src/gui/guiItemImage.cpp
 src/gui/guiItemImage.h
 src/gui/guiMainMenu.h


### PR DESCRIPTION
- Goal of the PR: Complete #8740.
- There's a new class `GUIInventoryList` which is the element class for inventorylists.
- Fixes #4844 (in formspec version 3).
(Btw. there was a little clipping-bug with slotborders (probably introduced by #8740) which is fixed now.)
- This PR also makes it easier to implement things like customizable slot-spacing and slot-size and per-inventorylist colors and borders.
- It might be possible to move more code to the new class, eg. the event handler, and to improve the code-structure. But I didn't want to make this PR even larger (I'm lazy).

## To do

This PR is a Ready for Review.
(Note that there's still a new `todo`, see line comment.)

## How to test

I've used this for testing:
```lua
local elements = [[
	list[current_player;main;0,0;4,4;]
	button[5,0;2,1;btn;Button]
	button[3,1.5;3,1;btn;Button2]
]]

local fs = [[
	size[11,10]
]] .. elements .. [[
	tooltip[0,0;10,5;<rect_mode tooltip defined after other elements>]

	listcolors[#000;#fff;#f00;#0f0;#00f]

	container[0,6]
	tooltip[0,0;10,5;<rect_mode tooltip defined before other elements>]
]] .. elements .. [[
	container_end[]
]]

minetest.register_on_joinplayer(function(player)
	minetest.show_formspec(player:get_player_name(), "fs_test", fs)
end)

minetest.register_chatcommand("fs", {
	params = "",
	description = "Show the test formspec.",
	privs = {},
	func = function(name, param)
		minetest.show_formspec(name, "fs", fs)
		return true
	end,
})
```
It's suggest testing by clicking around.