### PR TITLE
Add callbacks for falling and attached nodes

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7885,6 +7885,30 @@ Used by `minetest.register_node`.
         -- Default: nil
         -- Warning: making a liquid node 'floodable' will cause problems.
 
+        on_fall = function(pos, node)
+        -- Called before node starts to fall.
+        -- If a boolean is returned, the builtin falling node
+        -- handling is skipped. `true` denotes successful falling.
+        -- By default, the node is removed and a falling node
+        -- entity is spawned at `pos`.
+        -- default: nil
+
+        after_fall = function(pos, oldnode, oldmeta, obj),
+        -- Called when node started to fall and a falling node entity
+        -- has been spawned. `obj` is the falling node entity.
+        -- default: nil
+
+        on_detach = function(pos, oldnode)
+        -- Called when an `attached_node` is about to be detached.
+        -- If a boolean is returned, the builtin node detachment
+        -- handling is skipped. `true` denotes a successful detachment.
+        -- By default, the node is removed and is turned into drops.
+        -- default: nil
+
+        after_detach = function(pos, oldnode, oldmeta)
+        -- Called when an `attached_node` was detached.
+        -- default: nil
+
         preserve_metadata = function(pos, oldnode, oldmeta, drops),
         -- Called when oldnode is about be converted to an item, but before the
         -- node is deleted from the world or the drops are added. This is

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7887,26 +7887,38 @@ Used by `minetest.register_node`.
 
         on_fall = function(pos, node)
         -- Called before node starts to fall.
-        -- If a boolean is returned, the builtin falling node
-        -- handling is skipped. `true` denotes successful falling.
-        -- By default, the node is removed and a falling node
-        -- entity is spawned at `pos`.
+        -- Optionally should return `<boolean>, <obj>`.
+        -- If `boolean` is returned as a boolean, the builtin falling node
+        -- handling is skipped.
+        -- `boolean=true` means an object was created by the function which
+        -- must be returned in `obj`.
+        -- `boolean=false` means no object was created and `obj` must be `nil`;
+        -- `boolean=nil` means the builtin falling handling is executed.
+        -- The builtin falling node falling means that the node at `pos` is
+        -- removed and a `__builtin:falling_node` entity spawns in its place.
+        -- `after_fall` is only called if `boolean` `nil`.
         -- default: nil
 
         after_fall = function(pos, oldnode, oldmeta, obj),
         -- Called when node started to fall and a falling node entity
-        -- has been spawned. `obj` is the falling node entity.
+        -- has been spawned due to the builtin falling node handler.
+        -- `obj` is the falling node entity.
         -- default: nil
 
-        on_detach = function(pos, oldnode)
+        on_detach = function(pos, node)
         -- Called when an `attached_node` is about to be detached.
         -- If a boolean is returned, the builtin node detachment
-        -- handling is skipped. `true` denotes a successful detachment.
-        -- By default, the node is removed and is turned into drops.
+        -- handling is skipped.
+        -- `true` means that one or more objects were created,
+        -- `false` means this was not the case.
+        -- The builtin node attachment handling means that the node
+        -- is removed, drops as item(s).
+        -- `after_detach` is only called if `nil` is returned.
         -- default: nil
 
         after_detach = function(pos, oldnode, oldmeta)
-        -- Called when an `attached_node` was detached.
+        -- Called when an `attached_node` was detached using the builtin
+        -- node detachment handler.
         -- default: nil
 
         preserve_metadata = function(pos, oldnode, oldmeta, drops),


### PR DESCRIPTION
This adds 4 callbacks for nodes:

- `on_fall`: Before node falls
- `after_fall`: After node *started* to fall
- `on_detach`: Before an `attached_node` detaches
- `after_detach`: After node has been detached

See the changes in `lua_api.txt` for details.

It's also possible to overwrite the builtin handling of node falling/detaching.

Fixes #6943.

## Justification

See #6943 for justification of `on_detach` and `after_detach`. This issue is supported by core dev.

`on_fall` and `after_fall` are added because they are functionally similar.

## To do

This PR is ready.

## How to test

Here are two test nodes to play around with (basically just outputting the params into chat):

```
-- Is supposed to fall when it doesn't rest on solid ground
minetest.register_node("testnodes:falling", {
	description = "Falling Node",
	tiles = {
		"testnodes_node.png",
		"testnodes_node.png",
		"testnodes_node_falling.png",
	},
	groups = { falling_node = 1, dig_immediate = 2 },

	on_construct = function(pos)
		local m = minetest.get_meta(pos)
		m:set_string("hello", "world")
	end,
	on_fall = function(pos, node)
		minetest.log("error", "on_fall")
		minetest.log("error", "   pos = "..minetest.pos_to_string(pos))
		minetest.log("error", "   node = "..tostring(node.name))
		--Uncomment to test overwrite behavior
		--minetest.remove_node(pos)
		--return true
	end,
	after_fall = function(pos, oldnode, oldmeta, obj)
		minetest.log("error", "after_fall")
		minetest.log("error", "   pos = "..minetest.pos_to_string(pos))
		minetest.log("error", "   oldnode = "..tostring(oldnode.name))
		minetest.log("error", "   oldmeta = "..tostring(dump(oldmeta)))
		minetest.log("error", "   obj = "..tostring(obj))
	end,
})

-- This node attaches to the floor and drops as item
-- when the floor is gone.
minetest.register_node("testnodes:attached", {
	description = "Floor-Attached Node",
	tiles = {
		"testnodes_attached_top.png",
		"testnodes_attached_bottom.png",
		"testnodes_attached_side.png",
	},
	groups = { attached_node = 1, dig_immediate = 2 },

	on_construct = function(pos)
		local m = minetest.get_meta(pos)
		m:set_string("hello", "world")
	end,
	on_detach = function(pos, node)
		minetest.log("error", "on_detach")
		minetest.log("error", "   pos = "..minetest.pos_to_string(pos))
		minetest.log("error", "   node = "..tostring(node.name))
		--Uncomment to test overwrite behavior
		--minetest.remove_node(pos)
		--return true
	end,
	after_detach = function(pos, oldnode, oldmeta)
		minetest.log("error", "after_detach")
		minetest.log("error", "   pos = "..minetest.pos_to_string(pos))
		minetest.log("error", "   oldnode = "..tostring(oldnode.name))
		minetest.log("error", "   oldmeta = "..tostring(dump(oldmeta)))
	end,
})
```