### PR TITLE
Add new Mapgen V7 floatland implementation

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1604,11 +1604,24 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 [*Mapgen V7]
 
 #    Map generation attributes specific to Mapgen v7.
-#    'ridges' enables the rivers.
+#    'ridges': Rivers.
+#    'floatlands': Floating land masses throughout the atmosphere.
+#    'caverns': Giant caves deep underground.
 mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
 mgv7_mount_zero_level (Mountain zero level) int 0
+
+#    Lower Y limit of floatlands.
+mgv7_floatland_ymin (Floatland minimum Y) int 1024
+
+#    Upper Y limit of floatlands.
+mgv7_floatland_ymax (Floatland maximum Y) int 30000
+
+#    Adjusts the density of the floatland realm.
+#    Increase value to increase density.
+#    Can be positive or negative.
+mgv7_floatland_density (Floatland density) float -0.9
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -1678,6 +1691,9 @@ mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333
 
 #    3D noise defining structure of river canyon walls.
 mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
+
+#    3D noise defining structure of floatlands.
+mgv7_np_floatland (Floatland noise) noise_params_3d 0, 1, (600, 150, 600), 1009, 5, 0.75, 1.618
 
 #    3D noise defining giant caverns.
 mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1607,13 +1607,7 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 #    'ridges': Rivers.
 #    'floatlands': Floating land masses in the atmosphere.
 #    'caverns': Giant caves deep underground.
-#    'floatwater': Lakes and seas placed on a solid floatland layer.
-#    *WARNING*:
-#    When enabling 'floatwater' the floatlands must be configured to be a solid
-#    layer by setting 'mgv7_floatland_density' to roughly 2.0 to 3.0, to avoid
-#    server-intensive extreme water flow and to avoid flooding of the world
-#    surface below.
-mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns,nofloatwater mountains,ridges,floatlands,caverns,floatwater,nomountains,noridges,nofloatlands,nocaverns,nofloatwater
+mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
 mgv7_mount_zero_level (Mountain zero level) int 0
@@ -1625,25 +1619,37 @@ mgv7_floatland_ymin (Floatland minimum Y) int 1024
 mgv7_floatland_ymax (Floatland maximum Y) int 4096
 
 #    Y-distance over which floatlands taper from full density to nothing.
+#    Tapering starts at this distance from the Y limit.
 #    For a solid floatland layer, this controls the height of hills/mountains.
+#    Must be less than or equal to half the distance between the Y limits.
 mgv7_floatland_taper (Floatland tapering distance) int 256
 
 #    Exponent of the floatland tapering. Alters the tapering behaviour.
-#    Values > 1.0 create a smooth, rounded tapering suitable for the default
-#    separated floatlands.
-#    Values < 1.0 create a more defined surface level with flatter lowlands
-#    and more extreme hills/mountains, suitable for a solid floatland layer.
+#    Value = 1.0 creates a uniform, linear tapering.
+#    Values > 1.0 create a smooth tapering suitable for the default separated
+#    floatlands.
+#    Values < 1.0 (for example 0.25) create a more defined surface level with
+#    flatter lowlands, suitable for a solid floatland layer.
 mgv7_float_taper_exp (Floatland taper exponent) float 2.0
 
-#    Adjusts the density of the floatland realm.
+#    Adjusts the density of the floatland layer.
 #    Increase value to increase density. Can be positive or negative.
-#    Values of roughly 2.0 to 3.0 create a solid floatland layer.
+#    Value = 0.0: 50% of volume is floatland.
+#    Value = 2.0 (can be higher depending on 'mgv7_np_floatland', always test
+#    to be sure) creates a solid floatland layer.
 mgv7_floatland_density (Floatland density) float -0.9
 
-#    Y-level of the floatland water surface.
-#    Should be set to somewhere between
-#    'mgv7_floatland_ymax' - 'mgv7_floatland_taper' and 'mgv7_floatland_ymax'.
-mgv7_floatland_ywater (Floatland water level) int 3968
+#    Surface level of optional water placed on a solid floatland layer.
+#    Water is disabled by default and will only be placed if this value is set
+#    to above 'mgv7_floatland_ymax' - 'mgv7_floatland_taper' (the start of the
+#    upper tapering).
+#    ***WARNING, POTENTIAL DANGER TO WORLDS AND SERVER PERFORMANCE***:
+#    When enabling water placement the floatlands must be configured and tested
+#    to be a solid layer by setting 'mgv7_floatland_density' to 2.0 (or other
+#    required value depending on 'mgv7_np_floatland'), to avoid
+#    server-intensive extreme water flow and to avoid vast flooding of the
+#    world surface below.
+mgv7_floatland_ywater (Floatland water level) int -31000
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -1715,7 +1721,10 @@ mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333
 mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
 
 #    3D noise defining structure of floatlands.
-mgv7_np_floatland (Floatland noise) noise_params_3d 0, 1, (384, 96, 384), 1009, 4, 0.75, 1.618
+#    If altered from the default, the noise 'scale' (0.7 by default) may need
+#    to be adjusted, as floatland tapering functions best when this noise has
+#    a value range of approximately -2.0 to 2.0.
+mgv7_np_floatland (Floatland noise) noise_params_3d 0, 0.7, (384, 96, 384), 1009, 4, 0.75, 1.618
 
 #    3D noise defining giant caverns.
 mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1622,14 +1622,14 @@ mgv7_mount_zero_level (Mountain zero level) int 0
 mgv7_floatland_ymin (Floatland minimum Y) int 1024
 
 #    Upper Y limit of floatlands.
-mgv7_floatland_ymax (Floatland maximum Y) int 30000
+mgv7_floatland_ymax (Floatland maximum Y) int 4096
 
 #    Y-distance over which floatlands taper from full density to nothing.
 #    For a solid floatland layer, this controls the height of hills/mountains.
 mgv7_floatland_taper (Floatland tapering distance) int 256
 
 #    Exponent of the floatland tapering. Alters the tapering behaviour.
-#    Values > 1.0 create a smooth. rounded tapering, suitable for the default
+#    Values > 1.0 create a smooth, rounded tapering suitable for the default
 #    separated floatlands.
 #    Values < 1.0 create a more defined surface level with flatter lowlands
 #    and more extreme hills/mountains, suitable for a solid floatland layer.
@@ -1643,7 +1643,7 @@ mgv7_floatland_density (Floatland density) float -0.9
 #    Y-level of the floatland water surface.
 #    Should be set to somewhere between
 #    'mgv7_floatland_ymax' - 'mgv7_floatland_taper' and 'mgv7_floatland_ymax'.
-mgv7_floatland_ywater (Floatland water level) int 29872
+mgv7_floatland_ywater (Floatland water level) int 3968
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the
@@ -1715,7 +1715,7 @@ mgv7_np_mountain (Mountain noise) noise_params_3d -0.6, 1, (250, 350, 250), 5333
 mgv7_np_ridge (Ridge noise) noise_params_3d 0, 1, (100, 100, 100), 6467, 4, 0.75, 2.0
 
 #    3D noise defining structure of floatlands.
-mgv7_np_floatland (Floatland noise) noise_params_3d 0, 1, (600, 150, 600), 1009, 5, 0.75, 1.618
+mgv7_np_floatland (Floatland noise) noise_params_3d 0, 1, (384, 96, 384), 1009, 4, 0.75, 1.618
 
 #    3D noise defining giant caverns.
 mgv7_np_cavern (Cavern noise) noise_params_3d 0, 1, (384, 128, 384), 723, 5, 0.63, 2.0

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1605,9 +1605,15 @@ mgv6_np_apple_trees (Apple trees noise) noise_params_2d 0, 1, (100, 100, 100), 3
 
 #    Map generation attributes specific to Mapgen v7.
 #    'ridges': Rivers.
-#    'floatlands': Floating land masses throughout the atmosphere.
+#    'floatlands': Floating land masses in the atmosphere.
 #    'caverns': Giant caves deep underground.
-mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns mountains,ridges,floatlands,caverns,nomountains,noridges,nofloatlands,nocaverns
+#    'floatwater': Lakes and seas placed on a solid floatland layer.
+#    *WARNING*:
+#    When enabling 'floatwater' the floatlands must be configured to be a solid
+#    layer by setting 'mgv7_floatland_density' to roughly 2.0 to 3.0, to avoid
+#    server-intensive extreme water flow and to avoid flooding of the world
+#    surface below.
+mgv7_spflags (Mapgen V7 specific flags) flags mountains,ridges,nofloatlands,caverns,nofloatwater mountains,ridges,floatlands,caverns,floatwater,nomountains,noridges,nofloatlands,nocaverns,nofloatwater
 
 #    Y of mountain density gradient zero level. Used to shift mountains vertically.
 mgv7_mount_zero_level (Mountain zero level) int 0
@@ -1618,10 +1624,26 @@ mgv7_floatland_ymin (Floatland minimum Y) int 1024
 #    Upper Y limit of floatlands.
 mgv7_floatland_ymax (Floatland maximum Y) int 30000
 
+#    Y-distance over which floatlands taper from full density to nothing.
+#    For a solid floatland layer, this controls the height of hills/mountains.
+mgv7_floatland_taper (Floatland tapering distance) int 256
+
+#    Exponent of the floatland tapering. Alters the tapering behaviour.
+#    Values > 1.0 create a smooth. rounded tapering, suitable for the default
+#    separated floatlands.
+#    Values < 1.0 create a more defined surface level with flatter lowlands
+#    and more extreme hills/mountains, suitable for a solid floatland layer.
+mgv7_float_taper_exp (Floatland taper exponent) float 2.0
+
 #    Adjusts the density of the floatland realm.
-#    Increase value to increase density.
-#    Can be positive or negative.
+#    Increase value to increase density. Can be positive or negative.
+#    Values of roughly 2.0 to 3.0 create a solid floatland layer.
 mgv7_floatland_density (Floatland density) float -0.9
+
+#    Y-level of the floatland water surface.
+#    Should be set to somewhere between
+#    'mgv7_floatland_ymax' - 'mgv7_floatland_taper' and 'mgv7_floatland_ymax'.
+mgv7_floatland_ywater (Floatland water level) int 29872
 
 #    Controls width of tunnels, a smaller value creates wider tunnels.
 #    Value >= 10.0 completely disables generation of tunnels and avoids the

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -44,7 +44,6 @@ FlagDesc flagdesc_mapgen_v7[] = {
 	{"ridges",      MGV7_RIDGES},
 	{"floatlands",  MGV7_FLOATLANDS},
 	{"caverns",     MGV7_CAVERNS},
-	{"floatwater",  MGV7_FLOATWATER},
 	{NULL,          0}
 };
 
@@ -156,7 +155,7 @@ MapgenV7Params::MapgenV7Params():
 	np_ridge_uwater      (0.0,   1.0,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0),
 	np_mountain          (-0.6,  1.0,   v3f(250,  350,  250),  5333,  5, 0.63, 2.0),
 	np_ridge             (0.0,   1.0,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0),
-	np_floatland         (0.0,   1.0,   v3f(384,  96,   384),  1009,  4, 0.75, 1.618),
+	np_floatland         (0.0,   0.7,   v3f(384,  96,   384),  1009,  4, 0.75, 1.618),
 	np_cavern            (0.0,   1.0,   v3f(384,  128,  384),  723,   5, 0.63, 2.0),
 	np_cave1             (0.0,   12.0,  v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
 	np_cave2             (0.0,   12.0,  v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
@@ -489,7 +488,7 @@ int MapgenV7::generateTerrain()
 
 	//// Floatlands
 	// 'Generate floatlands in this mapchunk' bool for
-	// optimisation of condition checks in y-loop.
+	// simplification of condition checks in y-loop.
 	bool gen_floatlands = false;
 	float *float_offset_cache = new float[csize.Y + 2];
 	u8 cache_index = 0;
@@ -508,10 +507,10 @@ int MapgenV7::generateTerrain()
 			float float_offset = 0.0f;
 			if (y > float_taper_ymax) {
 				float_offset = std::pow((y - float_taper_ymax) / (float)floatland_taper,
-					float_taper_exp) * 8.0f;
+					float_taper_exp) * 4.0f;
 			} else if (y < float_taper_ymin) {
 				float_offset = std::pow((float_taper_ymin - y) / (float)floatland_taper,
-					float_taper_exp) * 8.0f;
+					float_taper_exp) * 4.0f;
 			}
 			float_offset_cache[cache_index] = float_offset;
 		}
@@ -555,9 +554,8 @@ int MapgenV7::generateTerrain()
 					stone_surface_max_y = y;
 			} else if (y <= water_level) { // Surface water
 				vm->m_data[vi] = n_water;
-			} else if (gen_floatlands && (spflags & MGV7_FLOATWATER) &&
-					y >= float_taper_ymax && y <= floatland_ywater) {
-				vm->m_data[vi] = n_water; // Floatland water
+			} else if (gen_floatlands && y >= float_taper_ymax && y <= floatland_ywater) {
+				vm->m_data[vi] = n_water; // Water for solid floatland layer only
 			} else {
 				vm->m_data[vi] = n_air; // Air
 			}

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -76,6 +76,9 @@ MapgenV7::MapgenV7(MapgenV7Params *params, EmergeParams *emerge)
 	dungeon_ymin       = params->dungeon_ymin;
 	dungeon_ymax       = params->dungeon_ymax;
 
+	// Allocate floatland noise offset cache
+	this->float_offset_cache = new float[csize.Y + 2];
+
 	// 2D noise
 	noise_terrain_base =
 		new Noise(&params->np_terrain_base,    seed, csize.X, csize.Z);
@@ -142,6 +145,8 @@ MapgenV7::~MapgenV7()
 	if (spflags & MGV7_FLOATLANDS) {
 		delete noise_floatland;
 	}
+
+	delete []float_offset_cache;
 }
 
 
@@ -490,7 +495,6 @@ int MapgenV7::generateTerrain()
 	// 'Generate floatlands in this mapchunk' bool for
 	// simplification of condition checks in y-loop.
 	bool gen_floatlands = false;
-	float *float_offset_cache = new float[csize.Y + 2];
 	u8 cache_index = 0;
 	// Y values where floatland tapering starts
 	s16 float_taper_ymax = floatland_ymax - floatland_taper;
@@ -561,8 +565,6 @@ int MapgenV7::generateTerrain()
 			}
 		}
 	}
-
-	delete []float_offset_cache;
 
 	return stone_surface_max_y;
 }

--- a/src/mapgen/mapgen_v7.cpp
+++ b/src/mapgen/mapgen_v7.cpp
@@ -1,7 +1,7 @@
 /*
 Minetest
 Copyright (C) 2014-2020 paramat
-Copyright (C) 2013-2020 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2013-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -156,7 +156,7 @@ MapgenV7Params::MapgenV7Params():
 	np_ridge_uwater      (0.0,   1.0,   v3f(1000, 1000, 1000), 85039, 5, 0.6,  2.0),
 	np_mountain          (-0.6,  1.0,   v3f(250,  350,  250),  5333,  5, 0.63, 2.0),
 	np_ridge             (0.0,   1.0,   v3f(100,  100,  100),  6467,  4, 0.75, 2.0),
-	np_floatland         (0.0,   1.0,   v3f(600,  150,  600),  1009,  5, 0.75, 1.618),
+	np_floatland         (0.0,   1.0,   v3f(384,  96,   384),  1009,  4, 0.75, 1.618),
 	np_cavern            (0.0,   1.0,   v3f(384,  128,  384),  723,   5, 0.63, 2.0),
 	np_cave1             (0.0,   12.0,  v3f(61,   61,   61),   52534, 3, 0.5,  2.0),
 	np_cave2             (0.0,   12.0,  v3f(67,   67,   67),   10325, 3, 0.5,  2.0),
@@ -491,7 +491,7 @@ int MapgenV7::generateTerrain()
 	// 'Generate floatlands in this mapchunk' bool for
 	// optimisation of condition checks in y-loop.
 	bool gen_floatlands = false;
-	float float_offset_cache[csize.Y + 2];
+	float *float_offset_cache = new float[csize.Y + 2];
 	u8 cache_index = 0;
 	// Y values where floatland tapering starts
 	s16 float_taper_ymax = floatland_ymax - floatland_taper;
@@ -563,6 +563,8 @@ int MapgenV7::generateTerrain()
 			}
 		}
 	}
+
+	delete []float_offset_cache;
 
 	return stone_surface_max_y;
 }

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2013-2018 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2014-2018 paramat
+Copyright (C) 2013-2019 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2014-2019 paramat
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -36,6 +36,9 @@ extern FlagDesc flagdesc_mapgen_v7[];
 
 struct MapgenV7Params : public MapgenParams {
 	s16 mount_zero_level = 0;
+	s16 floatland_ymin = 1024;
+	s16 floatland_ymax = 30000;
+	float floatland_density = -0.9f;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -59,6 +62,7 @@ struct MapgenV7Params : public MapgenParams {
 	NoiseParams np_ridge_uwater;
 	NoiseParams np_mountain;
 	NoiseParams np_ridge;
+	NoiseParams np_floatland;
 	NoiseParams np_cavern;
 	NoiseParams np_cave1;
 	NoiseParams np_cave2;
@@ -87,12 +91,16 @@ public:
 	float baseTerrainLevelFromMap(int index);
 	bool getMountainTerrainAtPoint(s16 x, s16 y, s16 z);
 	bool getMountainTerrainFromMap(int idx_xyz, int idx_xz, s16 y);
+	bool getFloatlandTerrainFromMap(int idx_xyz, float float_offset);
 
 	int generateTerrain();
 	void generateRidgeTerrain();
 
 private:
 	s16 mount_zero_level;
+	s16 floatland_ymin;
+	s16 floatland_ymax;
+	float floatland_density;
 
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
@@ -102,4 +110,5 @@ private:
 	Noise *noise_ridge_uwater;
 	Noise *noise_mountain;
 	Noise *noise_ridge;
+	Noise *noise_floatland;
 };

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2013-2019 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
-Copyright (C) 2014-2019 paramat
+Copyright (C) 2014-2020 paramat
+Copyright (C) 2013-2020 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV7_FLOATLANDS  0x04
 #define MGV7_CAVERNS     0x08
 #define MGV7_BIOMEREPEAT 0x10 // Now unused
+#define MGV7_FLOATWATER  0x20
 
 class BiomeManager;
 
@@ -38,7 +39,10 @@ struct MapgenV7Params : public MapgenParams {
 	s16 mount_zero_level = 0;
 	s16 floatland_ymin = 1024;
 	s16 floatland_ymax = 30000;
+	s16 floatland_taper = 256;
+	float float_taper_exp = 2.0f;
 	float floatland_density = -0.9f;
+	s16 floatland_ywater = 29872;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;
@@ -100,7 +104,10 @@ private:
 	s16 mount_zero_level;
 	s16 floatland_ymin;
 	s16 floatland_ymax;
+	s16 floatland_taper;
+	float float_taper_exp;
 	float floatland_density;
+	s16 floatland_ywater;
 
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -28,7 +28,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MGV7_FLOATLANDS  0x04
 #define MGV7_CAVERNS     0x08
 #define MGV7_BIOMEREPEAT 0x10 // Now unused
-#define MGV7_FLOATWATER  0x20
 
 class BiomeManager;
 
@@ -41,8 +40,8 @@ struct MapgenV7Params : public MapgenParams {
 	s16 floatland_ymax = 4096;
 	s16 floatland_taper = 256;
 	float float_taper_exp = 2.0f;
-	float floatland_density = -0.9f;
-	s16 floatland_ywater = 3968;
+	float floatland_density = -0.6f;
+	s16 floatland_ywater = -31000;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -1,7 +1,7 @@
 /*
 Minetest
 Copyright (C) 2014-2020 paramat
-Copyright (C) 2013-2020 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
+Copyright (C) 2013-2016 kwolekr, Ryan Kwolek <kwolekr@minetest.net>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -38,11 +38,11 @@ extern FlagDesc flagdesc_mapgen_v7[];
 struct MapgenV7Params : public MapgenParams {
 	s16 mount_zero_level = 0;
 	s16 floatland_ymin = 1024;
-	s16 floatland_ymax = 30000;
+	s16 floatland_ymax = 4096;
 	s16 floatland_taper = 256;
 	float float_taper_exp = 2.0f;
 	float floatland_density = -0.9f;
-	s16 floatland_ywater = 29872;
+	s16 floatland_ywater = 3968;
 
 	float cave_width = 0.09f;
 	s16 large_cave_depth = -33;

--- a/src/mapgen/mapgen_v7.h
+++ b/src/mapgen/mapgen_v7.h
@@ -108,6 +108,8 @@ private:
 	float floatland_density;
 	s16 floatland_ywater;
 
+	float *float_offset_cache = nullptr;
+
 	Noise *noise_terrain_base;
 	Noise *noise_terrain_alt;
 	Noise *noise_terrain_persist;


### PR DESCRIPTION
First commit:

Floatland structure is vertically-compressed 3D noise.
Uses a lacunarity of 1.618 (the golden ratio) for high quality
noise.
Floatlands appear between user-settable Y limits, with smooth
tapering at each limit.
Simple user-settable density adjustment.
Shadow propagation is disabled in and just below floatlands, no
shadows are cast on the world surface.

/////////////////////////////////////////////////

Closes #9076 
Screenshots in following posts.

Floatlands throughout the atmosphere, between user-set y limits.
Smooth tapering to nothing at y limits.
Simple parameter for floatland density (no need to mess with noise parameters to do that).
Floatland 3D noise is compressed vertically by factor 4 to form flattened shapes.
Uses 5 octaves with lacunarity 1.618, the golden ratio, for higher quality noise and a minimum of coinciding patterns.
Shadow propagation is disabled in and just below the floatlands, no shadows cast on world surface.

Because river generation is disabled in floatland volumes, river 3D and 2D noises are not calculated, and floatland 3D noise is, so mapgen performance does not drop in floatland volumes.
Note that Mapgen V7 floatlands remain disabled by default and documented as 'highly unstable', so further tuning may occur later. I am submitting this now as MT 5.2.0 is planned to be soon.