### PR TITLE
Fix z-fighting of large firelike, torchlike, signlike, plantlike nodes

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -892,14 +892,25 @@ void MapblockMeshGenerator::drawSignlikeNode()
 {
 	u8 wall = n.getWallMounted(nodedef);
 	useTile(0, MATERIAL_FLAG_CRACK_OVERLAY, MATERIAL_FLAG_BACKFACE_CULLING);
-	static const float offset = BS / 16;
+	static const float wall_offset = BS / 16;
 	float size = BS / 2 * f->visual_scale;
+
+	// Anti-z-fighting offset
+	int o;
+	if (p.Z % 2 == 0) {
+		o = p.X % 4;
+	} else {
+		o = p.X % 4 + 2;
+	}
+	o = (o + (p.Y % 4)) % 4;
+	float azf_offset = (o * 0.01 - 0.04);
+
 	// Wall at X+ of node
 	v3f vertices[4] = {
-		v3f(BS / 2 - offset,  size,  size),
-		v3f(BS / 2 - offset,  size, -size),
-		v3f(BS / 2 - offset, -size, -size),
-		v3f(BS / 2 - offset, -size,  size),
+		v3f(BS / 2 - wall_offset + azf_offset,  size,  size),
+		v3f(BS / 2 - wall_offset + azf_offset,  size, -size),
+		v3f(BS / 2 - wall_offset + azf_offset, -size, -size),
+		v3f(BS / 2 - wall_offset + azf_offset, -size,  size),
 	};
 
 	for (v3f &vertex : vertices) {

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -857,12 +857,23 @@ void MapblockMeshGenerator::drawTorchlikeNode()
 		v3f(-size, -size, 0),
 	};
 
+	// Tiny offset to fix z-fighting
+	offset = v3f(0, 0, 0);
+	if (wall == DWM_YP) {
+		offset.X = BS * (p.Y % 4) * 0.001 - 0.004;
+	} else if (wall == DWM_YN) {
+		offset.Z = BS * (p.Y % 4) * 0.001 - 0.004;
+	} else {
+		offset.X = BS * ((p.Z % 4 + p.Y % 4) * 0.001 - 0.004);
+		offset.Z = BS * ((p.X % 4 + p.Y % 4) * 0.001 - 0.004);
+	}
+
 	for (v3f &vertex : vertices) {
 		switch (wall) {
 			case DWM_YP:
-				vertex.rotateXZBy(-45); break;
+				vertex.rotateXZBy(-44); break;
 			case DWM_YN:
-				vertex.rotateXZBy( 45); break;
+				vertex.rotateXZBy( 46); break;
 			case DWM_XP:
 				vertex.rotateXZBy(  0); break;
 			case DWM_XN:
@@ -872,6 +883,7 @@ void MapblockMeshGenerator::drawTorchlikeNode()
 			case DWM_ZN:
 				vertex.rotateXZBy(-90); break;
 		}
+		vertex += offset;
 	}
 	drawQuad(vertices);
 }

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -860,9 +860,9 @@ void MapblockMeshGenerator::drawTorchlikeNode()
 	// Tiny offset to fix z-fighting
 	offset = v3f(0, 0, 0);
 	if (wall == DWM_YP) {
-		offset.X = BS * (p.Y % 4) * 0.001 - 0.004;
+		offset.X = BS * (p.Y % 4) * 0.01 - 0.04;
 	} else if (wall == DWM_YN) {
-		offset.Z = BS * (p.Y % 4) * 0.001 - 0.004;
+		offset.Z = BS * (p.Y % 4) * 0.01 - 0.04;
 	} else {
 		offset.X = BS * ((p.Z % 4 + p.Y % 4) * 0.001 - 0.004);
 		offset.Z = BS * ((p.X % 4 + p.Y % 4) * 0.001 - 0.004);

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1050,6 +1050,7 @@ void MapblockMeshGenerator::drawFirelikeQuad(float rotation, float opening_angle
 		vertex.Z += offset_h;
 		vertex.rotateXZBy(rotation);
 		vertex.Y += offset_v;
+		vertex += offset;
 	}
 	drawQuad(vertices);
 }
@@ -1075,6 +1076,11 @@ void MapblockMeshGenerator::drawFirelikeNode()
 	bool drawBasicFire = neighbor[D6D_YN] || !neighbors;
 	bool drawBottomFire = neighbor[D6D_YP];
 
+	// Tiny X/Z offset to prevent z-fighting
+	offset = v3f(0, 0, 0);
+	offset.X = BS * ((p.Z % 4 + p.Y % 4) * 0.001 - 0.004);
+	offset.Z = BS * ((p.X % 4 + p.Y % 4) * 0.001 - 0.004);
+
 	if (drawBasicFire || neighbor[D6D_ZP])
 		drawFirelikeQuad(0, -10, 0.4 * BS);
 	else if (drawBottomFire)
@@ -1096,8 +1102,13 @@ void MapblockMeshGenerator::drawFirelikeNode()
 		drawFirelikeQuad(270, 70, 0.47 * BS, 0.484 * BS);
 
 	if (drawBasicFire) {
-		drawFirelikeQuad(45, 0, 0.0);
-		drawFirelikeQuad(-45, 0, 0.0);
+		if (p.Y % 2 == 0) {
+			drawFirelikeQuad(46, 0, 0.0);
+			drawFirelikeQuad(-44, 0, 0.0);
+		} else {
+			drawFirelikeQuad(44, 0, 0.0);
+			drawFirelikeQuad(-46, 0, 0.0);
+		}
 	}
 }
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -981,35 +981,42 @@ void MapblockMeshGenerator::drawPlantlike()
 		break;
 	}
 
+	int o;
+	if (p.Y % 2 == 0) {
+		o = 1;
+	} else {
+		o = -1;
+	}
+
 	switch (draw_style) {
 	case PLANT_STYLE_CROSS:
-		drawPlantlikeQuad(46);
-		drawPlantlikeQuad(-44);
+		drawPlantlikeQuad( 45 + o);
+		drawPlantlikeQuad(-45 + o);
 		break;
 
 	case PLANT_STYLE_CROSS2:
-		drawPlantlikeQuad(91);
-		drawPlantlikeQuad(1);
+		drawPlantlikeQuad(90 + o);
+		drawPlantlikeQuad(o % 360);
 		break;
 
 	case PLANT_STYLE_STAR:
-		drawPlantlikeQuad(121);
-		drawPlantlikeQuad(241);
-		drawPlantlikeQuad(1);
+		drawPlantlikeQuad(120 + o);
+		drawPlantlikeQuad(240 + o);
+		drawPlantlikeQuad(o % 360);
 		break;
 
 	case PLANT_STYLE_HASH:
-		drawPlantlikeQuad(  1, BS / 4);
-		drawPlantlikeQuad( 91, BS / 4);
-		drawPlantlikeQuad(181, BS / 4);
-		drawPlantlikeQuad(271, BS / 4);
+		drawPlantlikeQuad(  o % 360, BS / 4);
+		drawPlantlikeQuad( 90 + o  , BS / 4);
+		drawPlantlikeQuad(180 + o  , BS / 4);
+		drawPlantlikeQuad(270 + o  , BS / 4);
 		break;
 
 	case PLANT_STYLE_HASH2:
-		drawPlantlikeQuad(  1, -BS / 2, true);
-		drawPlantlikeQuad( 91, -BS / 2, true);
-		drawPlantlikeQuad(181, -BS / 2, true);
-		drawPlantlikeQuad(271, -BS / 2, true);
+		drawPlantlikeQuad(  o % 360, -BS / 2, true);
+		drawPlantlikeQuad( 90 + o  , -BS / 2, true);
+		drawPlantlikeQuad(180 + o  , -BS / 2, true);
+		drawPlantlikeQuad(270 + o  , -BS / 2, true);
 		break;
 	}
 }

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -138,7 +138,6 @@ public:
 
 // plantlike-specific
 	PlantlikeStyle draw_style;
-	v3f offset;
 	int rotate_degree;
 	bool random_offset_Y;
 	int face_num;
@@ -168,6 +167,7 @@ public:
 	void drawMeshNode();
 
 // common
+	v3f offset;
 	void errorUnknownDrawtype();
 	void drawNode();
 


### PR DESCRIPTION
Fixes #9292.

Nodes of drawtype `firelike`, `torchlike` and `signlike` will no longer z-fight if they have a large `visual_scale`.

This is done by applying a tiny X/Z offset based on their position in the world. For `torchlike` and `firelike`, the diagonal quads are also rotated by 1° (like for `plantlike`).

This also fixes slightly different z-fighting with `plantlike` when those are stacked vertically. Here, the 1° difference is changed based on the Y level, so that it's +1°, -1°, +1°, -1°. That way, even vertically stacked `plantlike` nodes will no longer z-fight.

## To do

Testing by someone who is not me.
Code review by someone who is not me.

## How to test

Place many large (`visual_scale > 1.25`) `firelike`, `torchlike`, `signlike`, `plantlike` nodes next to each other or stack them and try everything to make them z-fight.

In `devtest`, you will find example nodes for everything. https://git.minetest.land/Wuzzy/devtest
