### PR TITLE
Make image of resized `torchlike` attach to side

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6557,8 +6557,9 @@ Used by `minetest.register_node`.
         -- Supported for drawtypes "plantlike", "signlike", "torchlike",
         -- "firelike", "mesh".
         -- For plantlike and firelike, the image will start at the bottom of the
-        -- node, for the other drawtypes the image will be centered on the node.
-        -- Note that positioning for "torchlike" may still change.
+        -- node. For torchlike, the image will start at the surface to which the
+        -- node "attaches". For the other drawtypes the image will be centered
+        -- on the node.
 
         tiles = {tile definition 1, def2, def3, def4, def5, def6},
         -- Textures of node; +Y, -Y, +X, -X, +Z, -Z

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -860,17 +860,27 @@ void MapblockMeshGenerator::drawTorchlikeNode()
 	for (v3f &vertex : vertices) {
 		switch (wall) {
 			case DWM_YP:
-				vertex.rotateXZBy(-45); break;
+				vertex.Y += -size + BS/2;
+				vertex.rotateXZBy(-45);
+				break;
 			case DWM_YN:
-				vertex.rotateXZBy( 45); break;
+				vertex.Y += size - BS/2;
+				vertex.rotateXZBy(45);
+				break;
 			case DWM_XP:
-				vertex.rotateXZBy(  0); break;
+				vertex.X += -size + BS/2;
+				break;
 			case DWM_XN:
-				vertex.rotateXZBy(180); break;
+				vertex.X += -size + BS/2;
+				vertex.rotateXZBy(180);
+				break;
 			case DWM_ZP:
-				vertex.rotateXZBy( 90); break;
+				vertex.X += -size + BS/2;
+				vertex.rotateXZBy(90);
+				break;
 			case DWM_ZN:
-				vertex.rotateXZBy(-90); break;
+				vertex.X += -size + BS/2;
+				vertex.rotateXZBy(-90);
 		}
 	}
 	drawQuad(vertices);


### PR DESCRIPTION
Fixes #9221.

The image of `torchlike` nodes with a custom `visual_scale` will now visually attach to the side instead of being centered.

## To do

Ready for testing.

## How to test

Place `torchlike` nodes with a `visual_scale` other than `1.0` on all 6 possible sides and see how it looks like.

![SHZOpcSJQs_hf](https://user-images.githubusercontent.com/3686677/72210089-f99ca280-34ad-11ea-9af5-0ad62d577ca7.png)

You can use `devtest` to obtain example `torchlike` nodes: https://git.minetest.land/Wuzzy/devtest