### PR TITLE
Increase star count to 1000 and decrease radius slightly.

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -269,7 +269,7 @@ void Sky::render()
 				(0.25 - fabs(wicked_time_of_day < 0.5 ?
 				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 20));
 			float f = starbrightness;
-			float d = 1.0f / 360.0f;
+			float d = 0.006f / 2.0f;
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
 			// Stars are only drawn when brighter than skycolor
 			if (starcolor.getBlue() < m_skycolor.getBlue())

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -269,7 +269,7 @@ void Sky::render()
 				(0.25 - fabs(wicked_time_of_day < 0.5 ?
 				wicked_time_of_day : (1.0 - wicked_time_of_day))) * 20));
 			float f = starbrightness;
-			float d = 0.007 / 2;
+			float d = 1.0f / 360.0f;
 			video::SColor starcolor(255, f * 90, f * 90, f * 90);
 			// Stars are only drawn when brighter than skycolor
 			if (starcolor.getBlue() < m_skycolor.getBlue())

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -25,7 +25,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #pragma once
 
 #define SKY_MATERIAL_COUNT 5
-#define SKY_STAR_COUNT 200
+#define SKY_STAR_COUNT 1000
 
 class ITextureSource;
 


### PR DESCRIPTION
See #8924 for background and images.

This simply increases the star count to 1000 and decreases the radius a bit from 0.007/2 = 0.0035 to 1/360 = 0.00277 (I have not observed any flickering with default settings).
