### PR TITLE
Require 'basic_debug' priv to view gameplay-relevant debug info (2nd try), require 'debug' priv to view wireframe

### DIFF
--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -100,7 +100,6 @@ core.register_privilege("rollback", {
 core.register_privilege("basic_debug", {
 	description = S("Can view more debug info that might give a gameplay advantage"),
 	give_to_singleplayer = false,
-	give_to_admin = true,
 })
 core.register_privilege("debug", {
 	description = S("Can enable wireframe"),

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -102,6 +102,10 @@ core.register_privilege("debug", {
 	give_to_singleplayer = false,
 	give_to_admin = true,
 })
+core.register_privilege("wireframe", {
+	description = "Can enable wireframe",
+	give_to_singleplayer = false,
+})
 
 core.register_can_bypass_userlimit(function(name, ip)
 	local privs = core.get_player_privs(name)

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -99,8 +99,6 @@ core.register_privilege("rollback", {
 })
 core.register_privilege("debug", {
 	description = S("Allows enabling various debug options that may affect gameplay"),
-	give_to_singleplayer = false,
-	give_to_admin = true,
 })
 core.register_privilege("wireframe", {
 	description = S("Can enable wireframe"),

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -97,10 +97,12 @@ core.register_privilege("rollback", {
 	description = S("Can use the rollback functionality"),
 	give_to_singleplayer = false,
 })
-core.register_privilege("debug", {
-	description = S("Allows enabling various debug options that may affect gameplay"),
+core.register_privilege("basic_debug", {
+	description = S("Can view more debug info that might give a gameplay advantage"),
+	give_to_singleplayer = false,
+	give_to_admin = true,
 })
-core.register_privilege("wireframe", {
+core.register_privilege("debug", {
 	description = S("Can enable wireframe"),
 	give_to_singleplayer = false,
 })

--- a/builtin/game/privileges.lua
+++ b/builtin/game/privileges.lua
@@ -103,7 +103,7 @@ core.register_privilege("debug", {
 	give_to_admin = true,
 })
 core.register_privilege("wireframe", {
-	description = "Can enable wireframe",
+	description = S("Can enable wireframe"),
 	give_to_singleplayer = false,
 })
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -676,6 +676,7 @@ protected:
 	bool handleCallbacks();
 	void processQueues();
 	void updateProfilers(const RunStats &stats, const FpsControl &draw_times, f32 dtime);
+	void updateBasicDebugState();
 	void updateStats(RunStats *stats, const FpsControl &draw_times, f32 dtime);
 	void updateProfilerGraphs(ProfilerGraph *graph);
 
@@ -1108,6 +1109,7 @@ void Game::run()
 		m_game_ui->clearInfoText();
 		hud->resizeHotbar();
 
+
 		updateProfilers(stats, draw_times, dtime);
 		processUserInput(dtime);
 		// Update camera before player movement to avoid camera lag of one frame
@@ -1119,6 +1121,7 @@ void Game::run()
 		updatePlayerControl(cam_view);
 		step(&dtime);
 		processClientEvents(&cam_view_target);
+		updateBasicDebugState();
 		updateCamera(draw_times.busy_time, dtime);
 		updateSound(dtime);
 		processPlayerInteraction(dtime, m_game_ui->m_flags.show_hud,
@@ -1723,6 +1726,18 @@ void Game::processQueues()
 	shader_src->processQueue();
 }
 
+void Game::updateBasicDebugState()
+{
+	if (m_game_ui->m_flags.show_basic_debug) {
+		if (!client->checkPrivilege("basic_debug")) {
+			m_game_ui->m_flags.show_basic_debug = false;
+		}
+	} else if (m_game_ui->m_flags.show_minimal_debug) {
+		if (client->checkPrivilege("basic_debug")) {
+			m_game_ui->m_flags.show_basic_debug = true;
+		}
+	}
+}
 
 void Game::updateProfilers(const RunStats &stats, const FpsControl &draw_times,
 		f32 dtime)

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2239,7 +2239,7 @@ void Game::toggleDebug()
 	// Initial: No debug info
 	// 1x toggle: Debug text
 	// 2x toggle: Debug text with profiler graph
-	// 3x toggle: Debug text and wireframe (needs "debug" priv)
+	// 3x toggle: Debug text and wireframe (needs "wireframe" priv)
 	// Next toggle: Back to initial
 	//
 	// The debug text can be in 2 modes: minimal and basic.
@@ -2261,7 +2261,7 @@ void Game::toggleDebug()
 		}
 		m_game_ui->m_flags.show_profiler_graph = true;
 		m_game_ui->showTranslatedStatusText("Profiler graph shown");
-	} else if (!draw_control->show_wireframe && client->checkPrivilege("debug")) {
+	} else if (!draw_control->show_wireframe && client->checkPrivilege("wireframe")) {
 		m_game_ui->m_flags.show_basic_debug = true;
 		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = true;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2239,30 +2239,32 @@ void Game::toggleDebug()
 	// Initial: No debug info
 	// 1x toggle: Debug text
 	// 2x toggle: Debug text with profiler graph
-	// 3x toggle: Debug text and wireframe (needs "wireframe" priv)
+	// 3x toggle: Debug text and wireframe (needs "debug" priv)
 	// Next toggle: Back to initial
 	//
 	// The debug text can be in 2 modes: minimal and basic.
 	// * Minimal: Only technical client info that not gameplay-relevant
 	// * Basic: Info that might give gameplay advantage, e.g. pos, angle
-	// Basic mode is used when player has "debug" priv,
+	// Basic mode is used when player has "basic_debug" priv,
 	// otherwise the Minimal mode is used.
 	if (!m_game_ui->m_flags.show_minimal_debug) {
 		m_game_ui->m_flags.show_minimal_debug = true;
-		if (client->checkPrivilege("debug")) {
+		if (client->checkPrivilege("basic_debug")) {
 			m_game_ui->m_flags.show_basic_debug = true;
 		}
 		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = false;
 		m_game_ui->showTranslatedStatusText("Debug info shown");
 	} else if (!m_game_ui->m_flags.show_profiler_graph && !draw_control->show_wireframe) {
-		if (client->checkPrivilege("debug")) {
+		if (client->checkPrivilege("basic_debug")) {
 			m_game_ui->m_flags.show_basic_debug = true;
 		}
 		m_game_ui->m_flags.show_profiler_graph = true;
 		m_game_ui->showTranslatedStatusText("Profiler graph shown");
-	} else if (!draw_control->show_wireframe && client->checkPrivilege("wireframe")) {
-		m_game_ui->m_flags.show_basic_debug = true;
+	} else if (!draw_control->show_wireframe && client->checkPrivilege("debug")) {
+		if (client->checkPrivilege("basic_debug")) {
+			m_game_ui->m_flags.show_basic_debug = true;
+		}
 		m_game_ui->m_flags.show_profiler_graph = false;
 		draw_control->show_wireframe = true;
 		m_game_ui->showTranslatedStatusText("Wireframe shown");

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -694,6 +694,7 @@ protected:
 	void toggleFast();
 	void toggleNoClip();
 	void toggleCinematic();
+	void toggleBlockBounds();
 	void toggleAutoforward();
 
 	void toggleMinimap(bool shift_pressed);
@@ -1731,6 +1732,7 @@ void Game::updateBasicDebugState()
 	if (m_game_ui->m_flags.show_basic_debug) {
 		if (!client->checkPrivilege("basic_debug")) {
 			m_game_ui->m_flags.show_basic_debug = false;
+			hud->disableBlockBounds();
 		}
 	} else if (m_game_ui->m_flags.show_minimal_debug) {
 		if (client->checkPrivilege("basic_debug")) {
@@ -1950,7 +1952,7 @@ void Game::processKeyInput()
 	} else if (wasKeyDown(KeyType::SCREENSHOT)) {
 		client->makeScreenshot();
 	} else if (wasKeyDown(KeyType::TOGGLE_BLOCK_BOUNDS)) {
-		hud->toggleBlockBounds();
+		toggleBlockBounds();
 	} else if (wasKeyDown(KeyType::TOGGLE_HUD)) {
 		m_game_ui->toggleHud();
 	} else if (wasKeyDown(KeyType::MINIMAP)) {
@@ -2186,6 +2188,15 @@ void Game::toggleCinematic()
 		m_game_ui->showTranslatedStatusText("Cinematic mode enabled");
 	else
 		m_game_ui->showTranslatedStatusText("Cinematic mode disabled");
+}
+
+void Game::toggleBlockBounds()
+{
+	if (client->checkPrivilege("basic_debug")) {
+		hud->toggleBlockBounds();
+	} else {
+		m_game_ui->showTranslatedStatusText("Can't show block bounds (need 'basic_debug' privilege)");
+	}
 }
 
 // Autoforward by toggling continuous forward.

--- a/src/client/gameui.cpp
+++ b/src/client/gameui.cpp
@@ -99,7 +99,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 {
 	v2u32 screensize = RenderingEngine::getWindowSize();
 
-	if (m_flags.show_debug) {
+	// Minimal debug text must only contain info that can't give a gameplay advantage
+	if (m_flags.show_minimal_debug) {
 		static float drawtime_avg = 0;
 		drawtime_avg = drawtime_avg * 0.95 + stats.drawtime * 0.05;
 		u16 fps = 1.0 / stats.dtime_jitter.avg;
@@ -125,9 +126,10 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 	}
 
 	// Finally set the guitext visible depending on the flag
-	m_guitext->setVisible(m_flags.show_debug);
+	m_guitext->setVisible(m_flags.show_minimal_debug);
 
-	if (m_flags.show_debug) {
+	// Basic debug text also shows info that might give a gameplay advantage
+	if (m_flags.show_basic_debug) {
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 		v3f player_position = player->getPosition();
 
@@ -160,7 +162,7 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 		));
 	}
 
-	m_guitext2->setVisible(m_flags.show_debug);
+	m_guitext2->setVisible(m_flags.show_basic_debug);
 
 	setStaticText(m_guitext_info, m_infotext.c_str());
 	m_guitext_info->setVisible(m_flags.show_hud && g_menumgr.menuCount() == 0);
@@ -204,7 +206,8 @@ void GameUI::update(const RunStats &stats, Client *client, MapDrawControl *draw_
 void GameUI::initFlags()
 {
 	m_flags = GameUI::Flags();
-	m_flags.show_debug = g_settings->getBool("show_debug");
+	m_flags.show_minimal_debug = g_settings->getBool("show_debug");
+	m_flags.show_basic_debug = false;
 }
 
 void GameUI::showMinimap(bool show)
@@ -225,8 +228,10 @@ void GameUI::setChatText(const EnrichedString &chat_text, u32 recent_chat_count)
 	// Update gui element size and position
 	s32 chat_y = 5;
 
-	if (m_flags.show_debug)
-		chat_y += 2 * g_fontengine->getLineHeight();
+	if (m_flags.show_minimal_debug)
+		chat_y += g_fontengine->getLineHeight();
+	if (m_flags.show_basic_debug)
+		chat_y += g_fontengine->getLineHeight();
 
 	const v2u32 &window_size = RenderingEngine::getWindowSize();
 

--- a/src/client/gameui.h
+++ b/src/client/gameui.h
@@ -58,7 +58,8 @@ public:
 		bool show_chat = true;
 		bool show_hud = true;
 		bool show_minimap = false;
-		bool show_debug = true;
+		bool show_minimal_debug = false;
+		bool show_basic_debug = false;
 		bool show_profiler_graph = false;
 	};
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -870,6 +870,11 @@ void Hud::toggleBlockBounds()
 	}
 }
 
+void Hud::disableBlockBounds()
+{
+	m_block_bounds_mode = BLOCK_BOUNDS_OFF;
+}
+
 void Hud::drawBlockBounds()
 {
 	if (m_block_bounds_mode == BLOCK_BOUNDS_OFF) {

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -52,6 +52,7 @@ public:
 	~Hud();
 
 	void toggleBlockBounds();
+	void disableBlockBounds();
 	void drawBlockBounds();
 
 	void drawHotbar(u16 playeritem);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -896,6 +896,10 @@ void Client::handleCommand_Privileges(NetworkPacket* pkt)
 		m_privileges.insert(priv);
 		infostream << priv << " ";
 	}
+
+	if(m_proto_ver < 40)
+		m_privileges.insert("basic_debug");
+
 	infostream << std::endl;
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -897,7 +897,8 @@ void Client::handleCommand_Privileges(NetworkPacket* pkt)
 		infostream << priv << " ";
 	}
 
-	if(m_proto_ver < 40)
+	// Enable basic_debug on server versions before it was added
+	if (m_proto_ver < 40)
 		m_privileges.insert("basic_debug");
 
 	infostream << std::endl;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -205,9 +205,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Updated set_sky packet
 		Adds new sun, moon and stars packets
 		Minimap modes
+	PROTOCOL VERSION 40:
+		Added 'basic_debug' privilege
 */
 
-#define LATEST_PROTOCOL_VERSION 39
+#define LATEST_PROTOCOL_VERSION 40
 #define LATEST_PROTOCOL_VERSION_STRING TOSTRING(LATEST_PROTOCOL_VERSION)
 
 // Server's supported network protocol range


### PR DESCRIPTION
Fixes #7245.

This is a revival of PR #8951, but with these changes:

* Profiler screen is no longer touched (it was a huge mistake to add this completely unrelated feature in the PR)
* Added `basic_debug` priv

## What this PR does

* Hide the position, yaw, pitch, mapseed and pointed thing if player does not have the `basic_debug` priv. In practice, the 2nd line of the debug text at the top will disappear and also the entity info when you point an entity. Additionally, the block bounds can't be used as well
* Add `basic_debug` priv to unlock various debug info that could be considered a gameplay advantage if they were accessible by default. NOT granted by default
* With the `debug` priv (which is not new) you also unlock the wireframe

## Justification

The F5 debug screen contains various "spoilers", e.g. info that can give you a gameplay advantage for free: position, pointed node, pointed entity (including health and armor groups). This completely ruins mods like `orienteering` and `compassgps` in which you can craft items that expose your position and more. The mods get ruined because there's no point in crafting a compass if you can get the yaw/position/whatever “for free” with a single key press, and it's unfair to force players to resist the temptation. Players complained, as evidenced by #7245, which also has core dev support.

This PR gets rid of those spoilers unless you have `basic_debug` priv. `orienteering`-style mods can now be created with peace-of-mind.

## To do

Nothing, for now.

## How to test

* Join any world
* Press F5 while you have one of the 4 possible combinations of “you have / have not `debug` priv” and “you have / have not `basic_debug` priv”.

## Expected questions and counter-arguments

1. “This PR is pointless because it's the player's fault for pressing F5.” This argument is bad because it's not good to force players to resist the temptation to enable a cheat that is only 1 keypress away. You could also press F5 by accident, and you can't “unsee” the coordinates. This is not good if a key element of a game is to “earn” the privilege to learn your coordinates through gameplay
2. “Why not using HUD flags?”. HUD flags are controlled by mods. This implies that mods can screw around with the debug info at will. All it takes is one poorly-coded mod to strip away the extended debug info from the admin, which is not fun to track down. Privileges, by comparison, are much more reliable and predictable and there are no ugly surprises.
3. “But how do I get the old behavior back?”: Type `/grantme basic_debug`.
4. “My game/mod/server depends on the pos/angle/pointed thing be visible in debug screen, this PR ruins everything!”. It was never a good idea for a mod to depend on anything written in the debug screen. As the name suggests, its for debugging primarily. The fact that it's currently being abused heavily for gameplay as well is just an excuse for bad practice. Instead of depending on the debug screen, add a mod that exposes the desired info itself, there are countless mods that do this which also can do this with a much nicer HUD than the debug screen. “Knowing the coordinates” is a gameplay advantage and should be considered as such. But you don't need to install any mods, `/grantme basic_debug` still works.
