### PR TITLE
Replace stray tab with whitespace in guiFormSpecMenu.cpp

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -825,7 +825,7 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 		spec.ftype = f_ItemImage;
 
 		GUIItemImage *e = new GUIItemImage(Environment, this, spec.fid,
-				core::rect<s32>(pos, pos + geom), name,	m_font, m_client);
+				core::rect<s32>(pos, pos + geom), name, m_font, m_client);
 		auto style = getStyleForElement("item_image", spec.fname);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->drop();


### PR DESCRIPTION
Introduced by #9262, this stray tab wouldn't have been visible if I hadn't turned on whitespace visualization in VSCode. ;)
