### PR TITLE
Always use same default tabheader height

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1898,7 +1898,7 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 		// Width is not here because tabs are the width of the text, and
 		// there's no reason to change that.
 		unsigned int i = 0;
-		std::vector<std::string> v_geom = {"1", "0.75"}; // Dummy width and default height
+		std::vector<std::string> v_geom = {"1", "1"}; // Dummy width and height
 		bool auto_width = true;
 		if (parts.size() == 7) {
 			i++;
@@ -1942,6 +1942,9 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 			pos = getRealCoordinateBasePos(v_pos);
 
 			geom = getRealCoordinateGeometry(v_geom);
+			// Set default height
+			if (parts.size() <= 6)
+				geom.Y = m_btn_height * 2;
 			pos.Y -= geom.Y; // TabHeader base pos is the bottom, not the top.
 			if (auto_width)
 				geom.X = DesiredRect.getWidth(); // Set automatic width


### PR DESCRIPTION
Previously the default tabheader height was different when using
real coordinates. This resulted in the height of tabs changing when
switching tabs in sfinv if some tabs used real coordinates.

## To do

This PR is a Ready for Review.
<!-- ^ delete one -->

## How to test

<!-- Example code or instructions -->

Apply the patch below to sfinv. Open sfinv and switch between the crafting tab and other tabs (ignore the messed up contents of the crafting tab).
Before this PR: tabheader height changes when switching between crafting tab and other tabs.
After: tabheader hight unchanged between tabs.
```diff
diff --git a/mods/sfinv/init.lua b/mods/sfinv/init.lua
index 71e9ee7..47424ea 100644
--- a/mods/sfinv/init.lua
+++ b/mods/sfinv/init.lua
@@ -14,6 +14,6 @@ sfinv.register_page("sfinv:crafting", {
                                image[4.75,1.5;1,1;sfinv_crafting_arrow.png]
                                listring[current_player;main]
                                listring[current_player;craft]
-                       ]], true)
+                       ]], true, "formspec_version[3]size[10.5,11.375]")
        end
 })
```
Note: the form width of 10.5 comes from the conversion formula in lua_api.txt, but that formula did not give the correct height (I arrived at 11.375 by guess and check, the formula suggested 11.875). Not sure what's going on there.