### PR TITLE
Collision temporary fix for issue #6886

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -212,7 +212,7 @@ static inline void getNeighborConnectingFace(const v3s16 &p,
 }
 
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
-		f32 pos_max_d, const aabb3f &box_0,		//TODO: get rid of pos_max_d parm as soon as collision algorithm fixed
+		f32 pos_max_d, const aabb3f &box_0,
 		f32 stepheight, f32 dtime,
 		v3f *pos_f, v3f *speed_f,
 		v3f accel_f, ActiveObject *self,
@@ -419,7 +419,7 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	f32 d = 0.01f;	// Temporary fix, any nonzero d causes collision glitches, the more the greater it is.
 	// ultimately it has to be determined if any uncertainty is involved, and if it is, eliminated
-	// and the d param removed from function calls.
+	// and d & pos_max_d params removed from function calls.
 
 	int loopcount = 0;
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -212,7 +212,7 @@ static inline void getNeighborConnectingFace(const v3s16 &p,
 }
 
 collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
-		f32 pos_max_d, const aabb3f &box_0,
+		f32 pos_max_d, const aabb3f &box_0,		//TODO: get rid of pos_max_d parm as soon as collision algorithm fixed
 		f32 stepheight, f32 dtime,
 		v3f *pos_f, v3f *speed_f,
 		v3f accel_f, ActiveObject *self,
@@ -415,12 +415,11 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		Collision uncertainty radius
 		Make it a bit larger than the maximum distance of movement
 	*/
-	f32 d = pos_max_d * 1.1f;
-	// A fairly large value in here makes moving smoother
-	//f32 d = 0.15*BS;
+	//f32 d = pos_max_d * 1.1f;
 
-	// This should always apply, otherwise there are glitches
-	assert(d > pos_max_d);	// invariant
+	f32 d = 0.01f;	// Temporary fix, any nonzero d causes collision glitches, the more the greater it is.
+	// ultimately it has to be determined if any uncertainty is involved, and if it is, eliminated
+	// and the d param removed from function calls.
 
 	int loopcount = 0;
 


### PR DESCRIPTION
This is a temporary fix for collision detection issues described in #6886, #9143 and #9305
The symptoms were random false positive collisions when an object or player was lifting off the ground (roughly less than 1 in 4 times, depending on relative position of collisionbox and node faces.

The problem in collision.cpp is caused by the d uncertainty radius. 
The fix has been tested using d=0.0f with no adverse effects, however this PR uses d=0.01f just in case there are occasional floating point precision errors, hence I consider it temporary. However it is usable as expected frequency of false positives is not to exceed 1 in 1000.

Also the comment saying increrasing this value makes movement smoother has been removed as misleading, it's actually the opposite.
Probably both the comment and the d uncertainty parameter were carried over from an old version of the algorithm where they could have made sense.

## To do

This Ready for Review.

## How to test

- have an object lift off the ground (e.g. set_velocity({x=2,y=2,z=0}) a number of times and verify if there are no false positive collisions along a horizontal axis. More info: https://github.com/minetest/minetest/issues/6886#issuecomment-574751745
- verify that otherwise collision detection works at least as well as before