### PR TITLE
Formspec: Don't start a button click when the pointer isn't on top

### DIFF
--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -203,8 +203,12 @@ bool GUIButton::OnEvent(const SEvent& event)
 	case EET_MOUSE_INPUT_EVENT:
 		if (event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN)
 		{
-			if (!IsPushButton)
+			// Sometimes formspec elements can receive mouse events when the
+			// mouse is outside of the formspec. Thus, we test the position here.
+			if ( !IsPushButton && AbsoluteClippingRect.isPointInside(
+						core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y ))) {
 				setPressed(true);
+			}
 
 			return true;
 		}


### PR DESCRIPTION
Partially resolves #9330 by preventing buttons from entering pressed state from a click event if the mouse is somewhere else. The GUIButton code already checks if the mouse is over it on release, so I've simply added a second check on press.

## Limitations
As mentioned above, this fix is only for buttons. I expect that any formspec element receiving mouse clicks can be affected by this (I can confirm that this affects `dropdown` elements as well, which appear to be a builtin Irrlicht gui element), and honestly the ideal would be to fix the issue at the source... However, I get the impression that this might be an Irrlicht bug so workarounds might be the best we can do.

## Testing
To test, just open a formspec and click any button once to make it active. After that, click outside of the formspec window and remark that it doesn't get pressed. I've taken the liberty of testing how this interacts with buttons clipping with the window, this works on my end but you should probably test it as well.