### PR TITLE
Fix pathfinder bugs: returning nil frequently, broken A*, jump through solid nodes

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -15,6 +15,7 @@ core.features = {
 	httpfetch_binary_data = true,
 	formspec_version_element = true,
 	area_store_persistent_ids = true,
+	pathfinder_works = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3981,6 +3981,8 @@ Utilities
           formspec_version_element = true,
           -- Whether AreaStore's IDs are kept on save/load (5.1.0)
           area_store_persistent_ids = true,
+          -- Whether minetest.find_path is functional (5.2.0)
+          pathfinder_works = true,
       }
 
 * `minetest.has_feature(arg)`: returns `boolean, missing_features`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4643,17 +4643,22 @@ Environment access
     * returns a table of 3D points representing a path from `pos1` to `pos2` or
       `nil` on failure.
     * Reasons for failure:
-        * No path exists
-        * End pos out of `searchdistance` range
+        * No path exists at all
+        * No path exists within `searchdistance` (see below)
         * End pos is not directly above walkable node
         * Start or end pos is buried in land
     * `pos1`: start position
     * `pos2`: end position
-    * `searchdistance`: number of blocks to search in each direction using a
-      maximum metric.
+    * `searchdistance`: maximum distance from the search positions to search in.
+      In detail: Path must be completely inside a cuboid. The minimum
+      `searchdistance` of 1 will confine search between `pos1` and `pos2`.
+      Larger values will increase the size of this cuboid in all directions
     * `max_jump`: maximum height difference to consider walkable
     * `max_drop`: maximum height difference to consider droppable
-    * `algorithm`: One of `"A*_noprefetch"` (default), `"A*"`, `"Dijkstra"`
+    * `algorithm`: One of `"A*_noprefetch"` (default), `"A*"`, `"Dijkstra"`.
+      Difference between `"A*"` and `"A*_noprefetch"` is that
+      `"A*"` will pre-calculate the cost-data, the other will calculate it
+      on-the-fly
 * `minetest.spawn_tree (pos, {treedef})`
     * spawns L-system tree at given `pos` with definition in `treedef` table
 * `minetest.transforming_liquid_add(pos)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4645,7 +4645,6 @@ Environment access
     * Reasons for failure:
         * No path exists at all
         * No path exists within `searchdistance` (see below)
-        * End pos is not directly above walkable node
         * Start or end pos is buried in land
     * `pos1`: start position
     * `pos2`: end position

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4639,9 +4639,14 @@ Environment access
     * `objects`: if false, only nodes will be returned. Default is `true`.
     * `liquids`: if false, liquid nodes won't be returned. Default is `false`.
 * `minetest.find_path(pos1,pos2,searchdistance,max_jump,max_drop,algorithm)`
-    * returns table containing path
+    * returns table containing path that can be walked on
     * returns a table of 3D points representing a path from `pos1` to `pos2` or
-      `nil`.
+      `nil` on failure.
+    * Reasons for failure:
+        * No path exists
+        * End pos out of `searchdistance` range
+        * End pos is not directly above walkable node
+        * Start or end pos is buried in land
     * `pos1`: start position
     * `pos2`: end position
     * `searchdistance`: number of blocks to search in each direction using a

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -823,7 +823,7 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 		}
 		else {
 			//test if we can fall a couple of nodes (m_maxdrop)
-			v3s16 testpos = pos2 - v3s16(0, -1, 0);
+			v3s16 testpos = pos2 + v3s16(0, -1, 0);
 			MapNode node_at_pos = m_env->getMap().getNode(testpos);
 
 			while ((node_at_pos.param0 != CONTENT_IGNORE) &&

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -227,8 +227,8 @@ private:
 	PathGridnode &getIdxElem(s16 x, s16 y, s16 z);
 
 	/**
-	 * invert a 3d position
-	 * @param pos 3d position
+	 * invert a 3D position (change sign of coordinates)
+	 * @param pos 3D position
 	 * @return pos *-1
 	 */
 	v3s16          invert(v3s16 pos);
@@ -240,28 +240,15 @@ private:
 	 */
 	bool           isValidIndex(v3s16 index);
 
-	/**
-	 * translate position to float position
-	 * @param pos integer position
-	 * @return float position
-	 */
-	v3f            tov3f(v3s16 pos);
-
 
 	/* algorithm functions */
 
 	/**
-	 * calculate 2d manahttan distance to target
+	 * calculate 2D Manhattan distance to target
 	 * @param pos position to calc distance
 	 * @return integer distance
 	 */
 	int           getXZManhattanDist(v3s16 pos);
-
-	/**
-	 * build internal data representation of search area
-	 * @return true/false if costmap creation was successfull
-	 */
-	bool          buildCostmap();
 
 	/**
 	 * calculate cost of movement
@@ -282,7 +269,8 @@ private:
 	bool          updateAllCosts(v3s16 ipos, v3s16 srcdir, int current_cost, int level);
 
 	/**
-	 * try to find a path to destination
+	 * try to find a path to destination using a heuristic function
+	 * to estimate distance to target (A* search algorithm)
 	 * @param ipos1 start position (index pos)
 	 * @param ipos2 end position (index pos)
 	 * @return true/false path to destination has been found
@@ -591,7 +579,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 
 	//check parameters
 	if (env == 0) {
-		ERROR_TARGET << "missing environment pointer" << std::endl;
+		ERROR_TARGET << "Missing environment pointer" << std::endl;
 		return retval;
 	}
 
@@ -667,7 +655,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 			source = testpos;
 		}
 		else {
-			VERBOSE_TARGET << "source pos too far above ground: " <<
+			VERBOSE_TARGET << "Source pos too far above ground: " <<
 				"Index: " << PP(getIndexPos(testpos)) <<
 				"Realpos: " << PP(getRealPos(getIndexPos(testpos))) << std::endl;
 			return retval;
@@ -684,13 +672,13 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 	PathGridnode &endpos   = getIndexElement(EndIndex);
 
 	if (!startpos.valid) {
-		VERBOSE_TARGET << "invalid startpos" <<
+		VERBOSE_TARGET << "Invalid startpos " <<
 				"Index: " << PP(StartIndex) <<
 				"Realpos: " << PP(getRealPos(StartIndex)) << std::endl;
 		return retval;
 	}
 	if (!endpos.valid) {
-		VERBOSE_TARGET << "invalid stoppos" <<
+		VERBOSE_TARGET << "Invalid stoppos " <<
 				"Index: " << PP(EndIndex) <<
 				"Realpos: " << PP(getRealPos(EndIndex)) << std::endl;
 		return retval;
@@ -711,7 +699,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 			update_cost_retval = updateCostHeuristic(StartIndex, EndIndex);
 			break;
 		default:
-			ERROR_TARGET << "missing PathAlgorithm"<< std::endl;
+			ERROR_TARGET << "Missing PathAlgorithm" << std::endl;
 			break;
 	}
 
@@ -743,7 +731,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 		}
 
 #ifdef PATHFINDER_DEBUG
-		std::cout << "full path:" << std::endl;
+		std::cout << "Full path:" << std::endl;
 		printPath(full_path);
 #endif
 #ifdef PATHFINDER_CALC_TIME
@@ -764,7 +752,7 @@ std::vector<v3s16> Pathfinder::getPath(ServerEnvironment *env,
 #ifdef PATHFINDER_DEBUG
 		printPathLen();
 #endif
-		ERROR_TARGET << "failed to update cost map"<< std::endl;
+		INFO_TARGET << "No path found" << std::endl;
 	}
 
 
@@ -1125,14 +1113,14 @@ void Pathfinder::buildPath(std::vector<v3s16> &path, v3s16 pos, int level)
 	level ++;
 	if (level > 700) {
 		ERROR_TARGET
-			<< LVL "Pathfinder: path is too long aborting" << std::endl;
+			<< LVL "Pathfinder: buildPath: path is too long, aborting" << std::endl;
 		return;
 	}
 
 	PathGridnode &g_pos = getIndexElement(pos);
 	if (!g_pos.valid) {
 		ERROR_TARGET
-			<< LVL "Pathfinder: invalid next pos detected aborting" << std::endl;
+			<< LVL "Pathfinder: buildPath: invalid next pos detected, aborting" << std::endl;
 		return;
 	}
 
@@ -1146,12 +1134,6 @@ void Pathfinder::buildPath(std::vector<v3s16> &path, v3s16 pos, int level)
 
 	buildPath(path, pos + g_pos.sourcedir, level);
 	path.push_back(pos);
-}
-
-/******************************************************************************/
-v3f Pathfinder::tov3f(v3s16 pos)
-{
-	return v3f(BS * pos.X, BS * pos.Y, BS * pos.Z);
 }
 
 #ifdef PATHFINDER_DEBUG

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -295,15 +295,15 @@ private:
 	 */
 	bool          buildPath(std::vector<v3s16> &path, v3s16 ipos);
 
-        /**
-         * go downwards from a position until some barrier
-         * is hit.
-         * @param pos position from which to go downwards
-         * @param max_down maximum distance to go downwards
-         * @return new position after movement; if too far down,
-                   pos is returned
-         */
-        v3s16         walkDownwards(v3s16 pos, unsigned int max_down);
+	/**
+	 * go downwards from a position until some barrier
+	 * is hit.
+	 * @param pos position from which to go downwards
+	 * @param max_down maximum distance to go downwards
+	 * @return new position after movement; if too far down,
+	 * pos is returned
+	 */
+	v3s16         walkDownwards(v3s16 pos, unsigned int max_down);
 
 	/* variables */
 	int m_max_index_x = 0;            /**< max index of search area in x direction  */
@@ -387,22 +387,21 @@ private:
 class PathfinderCompareHeuristic
 {
 	private:
-		Pathfinder* myPathfinder;
+		Pathfinder *myPathfinder;
 	public:
-		PathfinderCompareHeuristic(Pathfinder* pf) {
+		PathfinderCompareHeuristic(Pathfinder *pf)
+		{
 			myPathfinder = pf;
 		}
 		bool operator() (v3s16 pos1, v3s16 pos2) {
 			v3s16 ipos1 = myPathfinder->getIndexPos(pos1);
 			v3s16 ipos2 = myPathfinder->getIndexPos(pos2);
-			PathGridnode& g_pos1 = myPathfinder->getIndexElement(ipos1);
-			PathGridnode& g_pos2 = myPathfinder->getIndexElement(ipos2);
-			if (!g_pos1.valid) {
+			PathGridnode &g_pos1 = myPathfinder->getIndexElement(ipos1);
+			PathGridnode &g_pos2 = myPathfinder->getIndexElement(ipos2);
+			if (!g_pos1.valid)
 				return false;
-			}
-			if (!g_pos2.valid) {
+			if (!g_pos2.valid)
 				return false;
-			}
 			return g_pos1.estimated_cost > g_pos2.estimated_cost;
 		}
 };
@@ -937,8 +936,8 @@ PathCost Pathfinder::calcCost(v3s16 pos, v3s16 dir)
 				(targetpos.Y < m_limits.MaxEdge.Y)) {
 			//if the jump would hit any solid node, discard
 			if ((node_jump.param0 == CONTENT_IGNORE) ||
-				(ndef->get(node_jump).walkable)) {
-				headbanger = true;
+					(ndef->get(node_jump).walkable)) {
+					headbanger = true;
 				break;
 			}
 			targetpos += v3s16(0, 1, 0);
@@ -1127,9 +1126,11 @@ bool Pathfinder::updateCostHeuristic(v3s16 isource, v3s16 idestination)
 {
 	// A* search algorithm.
 
-	// The open list contains the pathfinder nodes that still need to be checked.
-	// The priority queue sorts the pathfinder nodes by estimated cost, with lowest cost on the top.
-	std::priority_queue<v3s16, std::vector<v3s16>, PathfinderCompareHeuristic> openList(PathfinderCompareHeuristic(this));
+	// The open list contains the pathfinder nodes that still need to be
+	// checked. The priority queue sorts the pathfinder nodes by
+	// estimated cost, with lowest cost on the top.
+	std::priority_queue<v3s16, std::vector<v3s16>, PathfinderCompareHeuristic>
+			openList(PathfinderCompareHeuristic(this));
 
 	v3s16 source = getRealPos(isource);
 	v3s16 destination = getRealPos(idestination);
@@ -1198,9 +1199,9 @@ bool Pathfinder::updateCostHeuristic(v3s16 isource, v3s16 idestination)
 			// get position of true neighbor
 			v3s16 neighbor = current_pos + direction_3d;
 			v3s16 ineighbor = getIndexPos(neighbor);
-			PathGridnode& n_pos = getIndexElement(ineighbor);
+			PathGridnode &n_pos = getIndexElement(ineighbor);
 
-			if (cost.valid && (!n_pos.is_closed && !n_pos.is_open)) {
+			if (cost.valid && !n_pos.is_closed && !n_pos.is_open) {
 				// heuristic function; estimate cost from neighbor to destination
 				cur_manhattan = getXZManhattanDist(neighbor);
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1179,7 +1179,7 @@ int ModApiEnvMod::l_find_path(lua_State *L)
 	unsigned int max_jump       = luaL_checkint(L, 4);
 	unsigned int max_drop       = luaL_checkint(L, 5);
 	PathAlgorithm algo          = PA_PLAIN_NP;
-	if (!lua_isnil(L, 6)) {
+	if (!lua_isnoneornil(L, 6)) {
 		std::string algorithm = luaL_checkstring(L,6);
 
 		if (algorithm == "A*")


### PR DESCRIPTION
## Goal
Fix the biggest bugs of the pathfinder (`minetest.find_path`).

## Changes
* Fix failure if start or end pos are hovering a few nodes above air (#1701):
    * NOTE: I consider this to be an **important bugfix**. #1701 causes `minetest.find_path` to fail very frequently in common scenarios
    * If startpos is over air, pathfinder will first simulate a drop of `maxdrop` to surface. If surface was found, pos above that will become the start of the algorithm 
    * If destinationpos is over air, pathfinder will also simulate a drop, but with using `maxjump` as limit. If surface was found, pos above that will become the end of the algorithm
    * If startpos and/or destinationpos have been manipulated by the method above, the original startpos/destinationpos will be preserved in the end result, so there will be no ugly surprises on the Lua side
* Fix jumping going through solid matter
* Complete new implementation of `A*` / `A*_noprefetch`. It is now the *real* A* algorithm, not the fake one. The hilariously inefficient paths of Fake A* are gone
* Update documentation of `minetest.find_path`

## Notes
The so-called A* algorithm was completely bonkers (#9331) and also it wasn't even real A*. The offending function was `updateCostHeuristic`. This function is supposedly A* but it's actually not A* at all, it's a greedy recursive non-optimal algorithm, there's not even a concept of an open or closed list. If I understood the code correctly, neighbor nodes are usually just expanded immediately instead of putting them into a list. That's totally not A*. Often generating sometimes very long-winded paths instead of the optimal path. So yeah, completely bonkers.
Thus I decided to replace the function completely.

The new implementation of A* as well as `buildPath` is non-recursive (is there even a recursive A*?). The only function that is still recursive is `updateCostAll` (=Dijkstra).

Question: What is better?
Using the current heuristic function, that is, Manhattan distance on XZ plane only?
Or is it Manhattan distance on all XYZ coords?
In my tests, both function properly, but XYZ has tendency to go up and down on difficult terrain.
Currently, I did not touch the heuristic function.

## Resolved issues (hopefully)
* #1701
* #4198
* #9331 (@SmallJoker: this one is currently NOT on the “list of pathfinder issues” issue #8642)

## To do

It seems to work nicely so far, but needs more testing.

The code is not well-optimized and cleaned up yet, I appreciate any review.
I plan to switch the data structures of the A* search to boost performance, and maybe also seek out redundancies …
Currently, the way how `updateCostHeuristic` keeps track of open and closed list is kind of stupid by redundantly saving a boolean, but it works. I haven't figured out how to do it properly. `openList` is a set, but I think it should be a priority queue.

Known old bug (not caused by PR): Start/end position is one lower than it should be if Y < 0. Probably bad rounding error?

Please do NOT request any features, or this PR will blow up. Direct such comments to one of the pathfinder issues instead, or open a new issue. Concentrate on bugs in this PR, oddities, bad code, bad efficiency, etc.

After this PR, there's obviously still room for new fancy features. But before we even think about them, pathfinder must first become stable, that's very important.

## How to test

Download the `devtest` “game” and use the Pathfinder Tester (`testpathfinder:testpathfinder`) to play around with the pathfinder. Try everything to break it as hard as you can. ;)
Try to reproduce the listed issues. Test `A*` and `A*_noprefetch` extensively. Compare behaviour of previous version.

Try to see what happens if …
* goal or target or both are buried
* goal or target or both are above air (but within `maxdrop`/`maxjump` distance)
* you build a structure that provokes jumping, but something's in the way
* you are creative with your tests ;-)

Usage of Pathfinder Tester: Rightclick places target, punching searches path, sneak-punching changes. Note that jump height, drop height, search distance are hardcoded, so you need to get your hands dirty to change them.