### PR TITLE
API: Ephemeral sounds, Game: dug/place sounds hearable for other players

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -128,7 +128,7 @@ core.register_entity(":__builtin:falling_node", {
 					meta:from_table(self.meta)
 				end
 				if def.sounds and def.sounds.place then
-					core.sound_play(def.sounds.place, {pos = np})
+					core.sound_play(def.sounds.place, {pos = np}, true)
 				end
 			end
 			self.object:remove()
@@ -154,7 +154,7 @@ local function convert_to_falling_node(pos, node)
 
 	local def = core.registered_nodes[node.name]
 	if def and def.sounds and def.sounds.fall then
-		core.sound_play(def.sounds.fall, {pos = pos})
+		core.sound_play(def.sounds.fall, {pos = pos}, true)
 	end
 
 	obj:get_luaentity():set_node(node, metatable)
@@ -187,7 +187,7 @@ local function drop_attached_node(p)
 		def.preserve_metadata(pos_copy, node_copy, oldmeta, drops)
 	end
 	if def and def.sounds and def.sounds.fall then
-		core.sound_play(def.sounds.fall, {pos = p})
+		core.sound_play(def.sounds.fall, {pos = p}, true)
 	end
 	core.remove_node(p)
 	for _, item in pairs(drops) do

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -305,9 +305,6 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 		return itemstack, nil
 	end
 
-	log("action", playername .. " places node "
-		.. def.name .. " at " .. core.pos_to_string(place_to))
-
 	local oldnode = core.get_node(place_to)
 	local newnode = {name = def.name, param1 = 0, param2 = param2 or 0}
 
@@ -333,7 +330,7 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 				z = above.z - placer_pos.z
 			}
 			newnode.param2 = core.dir_to_facedir(dir)
-			log("action", "facedir: " .. newnode.param2)
+			log("info", "facedir: " .. newnode.param2)
 		end
 	end
 
@@ -364,8 +361,19 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 		return itemstack, nil
 	end
 
+	log("action", playername .. " places node "
+		.. def.name .. " at " .. core.pos_to_string(place_to))
+
 	-- Add node and update
 	core.add_node(place_to, newnode)
+
+	-- Play sound if it was done by a player
+	if playername ~= "" and def.sounds and def.sounds.place then
+		core.sound_play(def.sounds.place, {
+			pos = place_to,
+			exclude_player = playername,
+		}, true)
+	end
 
 	local take_item = true
 
@@ -605,6 +613,14 @@ function core.node_dig(pos, node, digger)
 
 	-- Remove node and update
 	core.remove_node(pos)
+
+	-- Play sound if it was done by a player
+	if diggername ~= "" and def.sounds and def.sounds.dug then
+		core.sound_play(def.sounds.dug, {
+			pos = pos,
+			exclude_player = diggername,
+		}, true)
+	end
 
 	-- Run callback
 	if def and def.after_dig_node then

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -475,7 +475,10 @@ function core.do_item_eat(hp_change, replace_with_item, itemstack, user, pointed
 		user:set_hp(user:get_hp() + hp_change)
 
 		if def and def.sound and def.sound.eat then
-			minetest.sound_play(def.sound.eat, { pos = user:get_pos(), max_hear_distance = 16 })
+			core.sound_play(def.sound.eat, {
+				pos = user:get_pos(),
+				max_hear_distance = 16
+			}, true)
 		end
 
 		if replace_with_item then
@@ -582,7 +585,10 @@ function core.node_dig(pos, node, digger)
 			if not core.settings:get_bool("creative_mode") then
 				wielded:add_wear(dp.wear)
 				if wielded:get_count() == 0 and wdef.sound and wdef.sound.breaks then
-					core.sound_play(wdef.sound.breaks, {pos = pos, gain = 0.5})
+					core.sound_play(wdef.sound.breaks, {
+						pos = pos,
+						gain = 0.5
+					}, true)
 				end
 			end
 		end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -826,7 +826,7 @@ Examples of sound parameter tables:
         gain = 1.0,  -- default
         loop = true,
     }
-    -- Play in a location
+    -- Play at a location
     {
         pos = {x = 1, y = 2, z = 3},
         gain = 1.0,  -- default
@@ -839,12 +839,21 @@ Examples of sound parameter tables:
         max_hear_distance = 32,  -- default, uses an euclidean metric
         loop = true,
     }
+    -- Play at a location, heard by anyone *but* the given player
+    {
+        pos = {x = 32, y = 0, z = 100},
+        max_hear_distance = 40,
+        exclude_player = name,
+    }
 
 Looped sounds must either be connected to an object or played locationless to
-one player using `to_player = name,`.
+one player using `to_player = name`.
 
 A positional sound will only be heard by players that are within
 `max_hear_distance` of the sound position, at the start of the sound.
+
+`exclude_player = name` can be applied to locationless, positional and object-
+bound sounds to exclude a single player from hearing them.
 
 `SimpleSoundSpec`
 -----------------
@@ -4922,10 +4931,15 @@ Defaults for the `on_punch` and `on_dig` node definition callbacks
 Sounds
 ------
 
-* `minetest.sound_play(spec, parameters)`: returns a handle
+* `minetest.sound_play(spec, parameters, [ephemeral])`: returns a handle
     * `spec` is a `SimpleSoundSpec`
     * `parameters` is a sound parameter table
+    * `ephemeral` is a boolean (default: false)
+      Ephemeral sounds will not return a handle and can't be stopped or faded.
+      It is recommend to use this for short sounds that happen in response to
+      player actions (e.g. door closing).
 * `minetest.sound_stop(handle)`
+    * `handle` is a handle returned by `minetest.sound_play`
 * `minetest.sound_fade(handle, step, gain)`
     * `handle` is a handle returned by `minetest.sound_play`
     * `step` determines how fast a sound will fade.

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1106,7 +1106,7 @@ void Client::sendRemovedSounds(std::vector<s32> &soundList)
 
 	pkt << (u16) (server_ids & 0xFFFF);
 
-	for (int sound_id : soundList)
+	for (s32 sound_id : soundList)
 		pkt << sound_id;
 
 	Send(&pkt);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -561,7 +561,7 @@ private:
 	std::unordered_map<s32, int> m_sounds_server_to_client;
 	// And the other way!
 	std::unordered_map<int, s32> m_sounds_client_to_server;
-	// And relations to objects
+	// Relation of client id to object id
 	std::unordered_map<int, u16> m_sounds_to_objects;
 
 	// Map server hud ids to client hud ids

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -200,6 +200,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		Unknown inventory serialization fields no longer throw an error
 		Mod-specific formspec version
 		Player FOV override API
+		"ephemeral" added to TOCLIENT_PLAY_SOUND
 */
 
 #define LATEST_PROTOCOL_VERSION 38
@@ -450,6 +451,7 @@ enum ToClientCommand
 		s32[3] pos_nodes*10000
 		u16 object_id
 		u8 loop (bool)
+		u8 ephemeral (bool)
 	*/
 
 	TOCLIENT_STOP_SOUND = 0x40,

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1019,6 +1019,7 @@ void read_server_sound_params(lua_State *L, int index,
 		params.max_hear_distance = BS*getfloatfield_default(L, index,
 				"max_hear_distance", params.max_hear_distance/BS);
 		getboolfield(L, index, "loop", params.loop);
+		getstringfield(L, index, "exclude_player", params.exclude_player);
 	}
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -429,7 +429,7 @@ int ModApiServer::l_get_worldpath(lua_State *L)
 	return 1;
 }
 
-// sound_play(spec, parameters)
+// sound_play(spec, parameters, [ephemeral])
 int ModApiServer::l_sound_play(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -437,8 +437,14 @@ int ModApiServer::l_sound_play(lua_State *L)
 	read_soundspec(L, 1, spec);
 	ServerSoundParams params;
 	read_server_sound_params(L, 2, params);
-	s32 handle = getServer(L)->playSound(spec, params);
-	lua_pushinteger(L, handle);
+	bool ephemeral = lua_gettop(L) > 2 && readParam<bool>(L, 3);
+	if (ephemeral) {
+		getServer(L)->playSound(spec, params, true);
+		lua_pushnil(L);
+	} else {
+		s32 handle = getServer(L)->playSound(spec, params);
+		lua_pushinteger(L, handle);
+	}
 	return 1;
 }
 
@@ -446,7 +452,7 @@ int ModApiServer::l_sound_play(lua_State *L)
 int ModApiServer::l_sound_stop(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	int handle = luaL_checkinteger(L, 1);
+	s32 handle = luaL_checkinteger(L, 1);
 	getServer(L)->stopSound(handle);
 	return 0;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -98,6 +98,7 @@ struct ServerSoundParams
 	v3f pos;
 	u16 object = 0;
 	std::string to_player = "";
+	std::string exclude_player = "";
 
 	v3f getPos(ServerEnvironment *env, bool *pos_exists) const;
 };
@@ -209,7 +210,8 @@ public:
 
 	// Returns -1 if failed, sound handle on success
 	// Envlock
-	s32 playSound(const SimpleSoundSpec &spec, const ServerSoundParams &params);
+	s32 playSound(const SimpleSoundSpec &spec, const ServerSoundParams &params,
+			bool ephemeral=false);
 	void stopSound(s32 handle);
 	void fadeSound(s32 handle, float step, float gain);
 
@@ -646,7 +648,8 @@ private:
 		Sounds
 	*/
 	std::unordered_map<s32, ServerPlayingSound> m_playing_sounds;
-	s32 m_next_sound_id = 0;
+	s32 m_next_sound_id = 0; // positive values only
+	s32 nextSoundId();
 
 	/*
 		Detached inventories (behind m_env_mutex)


### PR DESCRIPTION
Why "ephemeral" sounds?
The client & server do some book-keeping + packet sending so that sounds can be stopped or faded from the server.
But for many of the sounds played during gameplay this is not needed: The server does not want to stop or fade them nor does it care if/when the sound has finished (`TOSERVER_REMOVESOUNDS`).
Enabling this flag simply disables the (unnecessary) state-keeping.

## Features
implements #7996
<b>DO NOT SQUASH</b>

* sound_play: new `ephemeral` paramter
* `exclude_player` added in sound parameter table
* Dug/Place sounds can be heard by other players

## To do

This PR is a Ready for Review.

## How to test

* join with two clients, mute sound on 1, place/break node on 1, hear sound on 2
* observe that falling nodes still make place sound when they land 