### PR TITLE
Add string.is_match helper function

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -191,6 +191,15 @@ function string.split(str, delim, include_empty, max_splits, sep_is_pattern)
 end
 
 --------------------------------------------------------------------------------
+function string.is_match(str, pattern)
+     -- Use underscore variable to preserve captures
+     _ = {string.match(str, pattern)}
+     return #_ > 0
+end
+
+_ = nil	 -- Suppress warning of undeclared global variable
+
+--------------------------------------------------------------------------------
 function table.indexof(list, val)
 	for i, v in ipairs(list) do
 		if v == val then
@@ -496,25 +505,16 @@ function core.string_to_pos(value)
 		return nil
 	end
 
-	local p = {}
-	p.x, p.y, p.z = string.match(value, "^([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+)$")
-	if p.x and p.y and p.z then
-		p.x = tonumber(p.x)
-		p.y = tonumber(p.y)
-		p.z = tonumber(p.z)
-		return p
-	end
-	p = {}
-	p.x, p.y, p.z = string.match(value, "^%( *([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+) *%)$")
-	if p.x and p.y and p.z then
-		p.x = tonumber(p.x)
-		p.y = tonumber(p.y)
-		p.z = tonumber(p.z)
-		return p
+	if string.is_match(value, "^%( *([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+) *%)$") or
+			string.is_match(value, "^([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+)$") then
+		return {
+			x = tonumber(_[1]),
+			y = tonumber(_[2]),
+			z = tonumber(_[3])
+		}
 	end
 	return nil
 end
-
 
 --------------------------------------------------------------------------------
 function core.string_to_area(value)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2889,6 +2889,11 @@ Helper functions
     * `sep_is_pattern`: boolean, it specifies whether separator is a plain
       string or a pattern (regex), default: `false`
     * e.g. `"a,b":split","` returns `{"a","b"}`
+* `string.is_match(str, pattern)`: returns a boolean
+    * Returns true if the pattern matches.
+    * The list of captures is stored in the global `_` variable.
+    * The number of captures can be obtained from `#_`.
+    * For non-matching patterns, `_` will be set to an empty list.
 * `string:trim()`: returns the string without whitespace pre- and suffixes
     * e.g. `"\n \t\tfoo bar\t ":trim()` returns `"foo bar"`
 * `minetest.wrap_text(str, limit, as_table)`: returns a string or table


### PR DESCRIPTION
This PR adds a string library function for conditional pattern matching with capture groups stored to the underscore variable. The concept is intended to be similar to the way that Perl handles captures.

I often find myself re-implementing this functionality in various mods to better structure my code (less redundancy and duplication). Traditionally, this required cascading if/else blocks, which obfuscates the logic and results in extraneous variables. I feel it is suitable for the official Minetest API.

Possible use-cases:

- Serial if/elseif blocks in combination with multiple captures for input validation.
- Easier localization of capture variables within the scope of each conditional branch

This is an example of a snippet of code from my Bitwise Operators mod:

```
if option == "b" and
		(is_match(attrs, "^([0-]?)([0-9]*)$") or is_match(attrs, "^([0-]?)([0-9]*):([0-9]+)$")) then
	return parse_token(remove(args, 1), _[ 1 ], _[ 2 ], _[ 3 ])
else
	return string.format(token, remove(args, 1))
end
```

Without is_match(), the code expands from 6 to 15 lines, with significant repetition:

```
if option == "b" then
	local a1, a2 = string.match(attrs, "^([0-]?)([0-9]*)$")
	if a1 and a2 then
		parse_token(remove(args, 1), a1, a2)
	else
		local a1, a2, a3 = string.match(attrs, "^([0-]?)([0-9]*):([0-9]+)$")
		if a1 and a2 then
			parse_token(remove(args, 1), a1, a2, a3)
		else
			return string.format(token, remove(args, 1))
		end
	end
else
	return string.format(token, remove(args, 1))
end
```

## To do

This is my first PR on GitHub. So, I'm open to core dev feedback if there is anything I did wrong or that I need to fix. I really look forward to learning and contributing!

## How to test

Edit the `/sethome` chat command in Minetest Game as follows:

```
minetest.register_chatcommand("sethome", {
	description = "Set your home point",
	privs = {home = true},
	func = function(name,params)
		name = name or "" -- fallback to blank name if nil
		local player = minetest.get_player_by_name(name)

		if not player then
			return false, "Player not found!"
		end

		local pos = minetest.string_to_pos(params) or player:get_pos()
		sethome.set(name,pos)
		return true, "Home set!"
	end,
})
```

Then in singleplayer, issue the chat commands `/sethome 0 10 0` and `/sethome (5,0,5)`.
