### PR TITLE
Disallow the unpack crash

### DIFF
--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -55,3 +55,10 @@ end
 
 setmetatable(_G, meta)
 
+--------------------------------------------------------------------------------
+-- Workaround for bug https://www.lua.org/bugs.html#5.2.3-1
+local actual_unpack = unpack
+function unpack(t, a, b)
+	assert(not b or b < 2^30)
+	return actual_unpack(t, a, b)
+end


### PR DESCRIPTION
Without this fix here or in the mesecons mod, players on servers with mesecons can crash the server, which might lead to data loss.
![luac](https://user-images.githubusercontent.com/3192173/73595237-9636eb00-4516-11ea-81d8-7e728e0c3be9.png)
