### PR TITLE
Allow FormSpec elements to be focused with `set_focus`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2396,8 +2396,8 @@ Elements
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
-* `transparent` (optional): show transparent
-* `draw_border` (optional): draw border
+* `transparent`: show transparent
+* `draw_border`: draw border
 
 ### `tabheader[<X>,<Y>;<W>,<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
@@ -2409,8 +2409,8 @@ Elements
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
-* `transparent` (optional): show transparent
-* `draw_border` (optional): draw border
+* `transparent`: show transparent
+* `draw_border`: draw border
 
 ### `box[<X>,<Y>;<W>,<H>;<color>]`
 
@@ -2459,7 +2459,7 @@ Elements
 * There are two ways to use it:
     1. handle the changed event (only changed scrollbar is available)
     2. read the value on pressing a button (all scrollbars are available)
-* `orientation`:  `vertical`/`horizontal`
+* `orientation`: `vertical`/`horizontal`. Default horizontal.
 * Fieldname data is transferred to Lua
 * Value of this trackbar is set to (`0`-`1000`) by default
 * See also `minetest.explode_scrollbar_event`
@@ -2572,6 +2572,31 @@ Elements
     * If a state is provided, the style will only take effect when the element is in that state.
     * All provided states must be active for the style to apply.
 * See [Styling Formspecs].
+
+### `set_focus[<name>;<always set>]`
+
+* Sets the focus to the element with the same `name` parameter.
+* **Note**: This element must be placed before the element it focuses.
+* `always set` (optional, default `false`): If false, this sets the focus to the
+  element specified only if the formspec is not being reshown. For instance, if
+  the formspec with the name "test:example" is shown, the focus will be set, but
+  if the same formspec is shown again consecutively, the focus will be set to
+  the last thing the user focused before reshowing. If true, the focus will always
+  be set in any circumstance.
+* The following elements have the ability to be focused:
+    * checkbox
+    * button
+    * button_exit
+    * image_button
+    * image_button_exit
+    * item_image_button
+    * table
+    * textlist
+    * dropdown
+    * field
+    * pwdfield
+    * textarea
+    * scrollbar
 
 Migrating to Real Coordinates
 -----------------------------
@@ -4400,7 +4425,7 @@ Call these functions only at load time!
           * a button was pressed,
           * Enter was pressed while the focus was on a text field
           * a checkbox was toggled,
-          * something was selecteed in a drop-down list,
+          * something was selected in a dropdown list,
           * a different tab was selected,
           * selection was changed in a textlist or table,
           * an entry was double-clicked in a textlist or table,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2396,8 +2396,8 @@ Elements
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
-* `transparent`: show transparent
-* `draw_border`: draw border
+* `transparent` (optional): show transparent
+* `draw_border` (optional): draw border
 
 ### `tabheader[<X>,<Y>;<W>,<H>;<name>;<caption 1>,<caption 2>,...,<caption n>;<current_tab>;<transparent>;<draw_border>]`
 
@@ -2409,8 +2409,8 @@ Elements
 * `name` fieldname data is transferred to Lua
 * `caption 1`...: name shown on top of tab
 * `current_tab`: index of selected tab 1...
-* `transparent`: show transparent
-* `draw_border`: draw border
+* `transparent` (optional): show transparent
+* `draw_border` (optional): draw border
 
 ### `box[<X>,<Y>;<W>,<H>;<color>]`
 
@@ -2573,16 +2573,13 @@ Elements
     * All provided states must be active for the style to apply.
 * See [Styling Formspecs].
 
-### `set_focus[<name>;<always set>]`
+### `set_focus[<name>;<force>]`
 
 * Sets the focus to the element with the same `name` parameter.
 * **Note**: This element must be placed before the element it focuses.
-* `always set` (optional, default `false`): If false, this sets the focus to the
-  element specified only if the formspec is not being reshown. For instance, if
-  the formspec with the name "test:example" is shown, the focus will be set, but
-  if the same formspec is shown again consecutively, the focus will be set to
-  the last thing the user focused before reshowing. If true, the focus will always
-  be set in any circumstance.
+* `force` (optional, default `false`): By default, focus is not applied for
+  re-sent formspecs with the same name so that player-set focus is kept.
+  `true` sets the focus to the specified element for every sent formspec.
 * The following elements have the ability to be focused:
     * checkbox
     * button

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2694,12 +2694,13 @@ void GUIFormSpecMenu::parseSetFocus(const std::string &element)
 	if (parts.size() <= 2 ||
 		(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION))
 	{
-		if (!m_is_form_regenerated && // Never focus on resizing
-			((parts.size() == 2 && is_yes(parts[1])) || // Always focus on any form
-			m_text_dst->m_formname != m_last_formname)) // Only focus on new form
-		{
+		if (m_is_form_regenerated)
+			return; // Never focus on resizing
+
+		bool force_focus = parts.size() >= 2 && is_yes(parts[1]);
+		if (force_focus || m_text_dst->m_formname != m_last_formname)
 			setFocus(parts[0]);
-		}
+
 		return;
 	}
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -655,7 +655,7 @@ void GUIFormSpecMenu::parseCheckbox(parserData* data, const std::string &element
 		auto style = getDefaultStyleForElement("checkbox", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -730,6 +730,10 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 		s32 scrollbar_size = is_horizontal ? dim.X : dim.Y;
 
 		e->setPageSize(scrollbar_size * (max - min + 1) / data->scrollbar_options.thumb_size);
+
+		if (spec.fname == m_focused_element) {
+			Environment->setFocus(e);
+		}
 
 		m_scrollbars.emplace_back(spec,e);
 		m_fields.push_back(spec);
@@ -1055,7 +1059,7 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		auto style = getStyleForElement(type, name, (type != "button") ? "button" : "");
 		e->setStyles(style);
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -1244,7 +1248,7 @@ void GUIFormSpecMenu::parseTable(parserData* data, const std::string &element)
 		GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 				rect, m_tsrc);
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -1321,7 +1325,7 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 		GUITable *e = new GUITable(Environment, data->current_parent, spec.fid,
 				rect, m_tsrc);
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -1398,7 +1402,7 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 		gui::IGUIComboBox *e = Environment->addComboBox(rect, data->current_parent,
 				spec.fid);
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -1485,7 +1489,7 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		gui::IGUIEditBox *e = Environment->addEditBox(0, rect, true,
 				data->current_parent, spec.fid);
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -1562,7 +1566,7 @@ void GUIFormSpecMenu::createTextField(parserData *data, FieldSpec &spec,
 	auto style = getDefaultStyleForElement(is_multiline ? "textarea" : "field", spec.fname);
 
 	if (e) {
-		if (is_editable && spec.fname == data->focused_fieldname)
+		if (is_editable && spec.fname == m_focused_element)
 			Environment->setFocus(e);
 
 		if (is_multiline) {
@@ -2011,7 +2015,7 @@ void GUIFormSpecMenu::parseImageButton(parserData* data, const std::string &elem
 		GUIButtonImage *e = GUIButtonImage::addButton(Environment, rect, m_tsrc,
 				data->current_parent, spec.fid, spec.flabel.c_str());
 
-		if (spec.fname == data->focused_fieldname) {
+		if (spec.fname == m_focused_element) {
 			Environment->setFocus(e);
 		}
 
@@ -2121,10 +2125,6 @@ void GUIFormSpecMenu::parseTabHeader(parserData* data, const std::string &elemen
 				irr::gui::EGUIA_UPPERLEFT, irr::gui::EGUIA_LOWERRIGHT);
 		e->setTabHeight(geom.Y);
 
-		if (spec.fname == data->focused_fieldname) {
-			Environment->setFocus(e);
-		}
-
 		auto style = getDefaultStyleForElement("tabheader", name);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, true));
 
@@ -2216,7 +2216,7 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 		auto style = getStyleForElement("item_image_button", spec_btn.fname, "image_button");
 		e_btn->setStyles(style);
 
-		if (spec_btn.fname == data->focused_fieldname) {
+		if (spec_btn.fname == m_focused_element) {
 			Environment->setFocus(e_btn);
 		}
 
@@ -2687,6 +2687,26 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 	return true;
 }
 
+void GUIFormSpecMenu::parseSetFocus(const std::string &element)
+{
+	std::vector<std::string> parts = split(element, ';');
+
+	if (parts.size() <= 2 ||
+		(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION))
+	{
+		if (!m_is_form_regenerated && // Never focus on resizing
+			((parts.size() == 2 && is_yes(parts[1])) || // Always focus on any form
+			m_text_dst->m_formname != m_last_formname)) // Only focus on new form
+		{
+			setFocus(parts[0]);
+		}
+		return;
+	}
+
+	errorstream << "Invalid set_focus element (" << parts.size() << "): '" << element
+		<< "'" << std::endl;
+}
+
 void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 {
 	//some prechecks
@@ -2890,6 +2910,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "set_focus") {
+		parseSetFocus(description);
+		return;
+	}
+
 	// Ignore others
 	infostream << "Unknown DrawSpec: type=" << type << ", data=\"" << description << "\""
 			<< std::endl;
@@ -2897,36 +2922,38 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 {
-	/* useless to regenerate without a screensize */
+	// Useless to regenerate without a screensize
 	if ((screensize.X <= 0) || (screensize.Y <= 0)) {
 		return;
 	}
 
 	parserData mydata;
 
-	//preserve tables
-	for (auto &m_table : m_tables) {
-		std::string tablename = m_table.first.fname;
-		GUITable *table = m_table.second;
-		mydata.table_dyndata[tablename] = table->getDynamicData();
-	}
+	// Preserve stuff only on same form, not on a new form.
+	if (m_text_dst->m_formname == m_last_formname) {
+		// Preserve tables/textlists
+		for (auto &m_table : m_tables) {
+			std::string tablename = m_table.first.fname;
+			GUITable *table = m_table.second;
+			mydata.table_dyndata[tablename] = table->getDynamicData();
+		}
 
-	//set focus
-	if (!m_focused_element.empty())
-		mydata.focused_fieldname = m_focused_element;
-
-	//preserve focus
-	gui::IGUIElement *focused_element = Environment->getFocus();
-	if (focused_element && focused_element->getParent() == this) {
-		s32 focused_id = focused_element->getID();
-		if (focused_id > 257) {
-			for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {
-				if (field.fid == focused_id) {
-					mydata.focused_fieldname = field.fname;
-					break;
+		// Preserve focus
+		gui::IGUIElement *focused_element = Environment->getFocus();
+		if (focused_element && focused_element->getParent() == this) {
+			s32 focused_id = focused_element->getID();
+			if (focused_id > 257) {
+				for (const GUIFormSpecMenu::FieldSpec &field : m_fields) {
+					if (field.fid == focused_id) {
+						m_focused_element = field.fname;
+						break;
+					}
 				}
 			}
 		}
+	} else {
+		// Don't keep old focus value
+		m_focused_element = "";
 	}
 
 	// Remove children
@@ -3285,8 +3312,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		}
 	}
 
-	//set initial focus if parser didn't set it
-	focused_element = Environment->getFocus();
+	// Set initial focus if parser didn't set it
+	gui::IGUIElement *focused_element = Environment->getFocus();
 	if (!focused_element
 			|| !isMyChild(focused_element)
 			|| focused_element->getType() == gui::EGUIET_TAB_CONTROL)
@@ -3297,6 +3324,13 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	// legacy sorting
 	if (m_formspec_version < 3)
 		legacySortElements(legacy_sort_start);
+
+	// Formname and regeneration setting
+	if (!m_is_form_regenerated) {
+		// Only set previous form name if we purposefully showed a new formspec
+		m_last_formname = m_text_dst->m_formname;
+		m_is_form_regenerated = true;
+	}
 }
 
 void GUIFormSpecMenu::legacySortElements(core::list<IGUIElement *>::Iterator from)
@@ -3414,6 +3448,7 @@ void GUIFormSpecMenu::drawMenu()
 		const std::string &newform = m_form_src->getForm();
 		if (newform != m_formspec_string) {
 			m_formspec_string = newform;
+			m_is_form_regenerated = false;
 			regenerateGui(m_screensize_old);
 		}
 	}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -363,7 +363,6 @@ private:
 		core::rect<s32> rect;
 		v2s32 basepos;
 		v2u32 screensize;
-		std::string focused_fieldname;
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
 		gui::IGUIElement *current_parent = nullptr;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -168,6 +168,7 @@ public:
 	{
 		m_formspec_string = formspec_string;
 		m_current_inventory_location = current_inventory_location;
+		m_is_form_regenerated = false;
 		regenerateGui(m_screensize_old);
 	}
 
@@ -299,6 +300,10 @@ protected:
 	std::string m_formspec_prepend;
 	InventoryLocation m_current_inventory_location;
 
+	// Default true because we can't control regeneration on resizing, but
+	// we can control cases when the formspec is shown intentionally.
+	bool m_is_form_regenerated = true;
+
 	std::vector<GUIInventoryList *> m_inventorylists;
 	std::vector<ListRingSpec> m_inventory_rings;
 	std::vector<gui::IGUIElement *> m_backgrounds;
@@ -338,10 +343,10 @@ protected:
 	video::SColor m_default_tooltip_bgcolor;
 	video::SColor m_default_tooltip_color;
 
-
 private:
 	IFormSource        *m_form_src;
 	TextDest           *m_text_dst;
+	std::string         m_last_formname;
 	u16                 m_formspec_version = 1;
 	std::string         m_focused_element = "";
 	JoystickController *m_joystick;
@@ -438,6 +443,7 @@ private:
 	bool parseAnchorDirect(parserData *data, const std::string &element);
 	void parseAnchor(parserData *data, const std::string &element);
 	bool parseStyle(parserData *data, const std::string &element, bool style_type);
+	void parseSetFocus(const std::string &element);
 
 	void tryClose();
 


### PR DESCRIPTION
This allows you to specify a FormSpec element to set the focus of with `set_focus[<name>;<always set>]`.  Closes #8029.

## Documentation from `lua_api.txt`

<blockquote>

### `set_focus[<name>;<always set>]`

* Sets the focus to the element with the same `name` parameter.
* **Note**: This element must be placed before the element it focuses.
* `always set` (optional, default `false`): If false, this sets the focus to the
  element specified only if the formspec is not being reshown. For instance, if
  the formspec with the name "test:example" is shown, the focus will be set, but
  if the same formspec is shown again consecutively, the focus will be set to
  the last thing the user focused before reshowing. If true, the focus will always
  be set in any circumstance.
* The following elements have the ability to be focused:
    * checkbox
    * button
    * button_exit
    * image_button
    * image_button_exit
    * item_image_button
    * table
    * textlist
    * dropdown
    * field
    * pwdfield
    * textarea
    * scrollbar
</blockquote>

Funny thing: Everything needed to make this PR was already implemented but unused.  I simply exposed this functionality to the API.

Note: Tabheaders and inventory lists aren't on this list because they aren't focusable in the first place -- try tabbing to either one.  It doesn't work.  That is work for another PR since I have no idea how to fix that.

## To do

This PR is Ready for Review.

## How to test

OK, to test.  What I did was to have every focusable element in a formspec all together.  Then, I created a copy of every one but with a new ID, and I tried focusing every one of these secondary elements.  Why second?  Because earlier elements are focused by default without `set_focus` according to some complicated rules, so we have to check that `set_focus` bypasses these.  Note that `button_exit` and `image_button_exit` work exactly the same as their non-exit counterparts, so they aren't included.

So, to test, use this formspec and change the `set_focus` to any secondary element, i.e. anything with a `-2` at the end of its ID and then press space or arrows, depending on the element.  If you remove the `set_focus`, `pwdfield-1` should be focused.  Also try testing the second parameter.

```lua
"formspec_version[3]"..
"size[9,11]"..
"set_focus[textlist-2]"..

"checkbox[1,0.5;checkbox-1;checkbox-1]"..
"button[1,1;3,0.7;button-1;button-1]"..
"image_button[1,2;3,0.7;air.png;image_button-1;image_button-1]"..
"item_image_button[1,3;3,0.7;air;item_image_button-1;item_image_button-1]"..
"table[1,4;3,0.7;table-1;table-1,-;1]"..
"textlist[1,5;3,0.7;textlist-1;textlist-1,-;1]"..
"dropdown[1,6;3,0.7;dropdown-1;dropdown-1,-;1]"..
"field[1,7;3,0.7;field-1;field-1;field-1]"..
"pwdfield[1,8;3,0.7;pwdfield-1;pwdfield-1]"..
"textarea[1,9;3,0.7;textarea-1;textarea-1;textarea-1]"..
"scrollbar[1,10;3,0.7;;scrollbar-1;scrollbar-1;0]"..

"checkbox[5,0.5;checkbox-2;checkbox-2]"..
"button[5,1;3,0.7;button-2;button-2]"..
"image_button[5,2;3,0.7;air.png;image_button-2;image_button-2]"..
"item_image_button[5,3;3,0.7;air;item_image_button-2;item_image_button-2]"..
"table[5,4;3,0.7;table-2;table-2,-;1]"..
"textlist[5,5;3,0.7;textlist-2;textlist-2,-;1]"..
"dropdown[5,6;3,0.7;dropdown-2;dropdown-2,-;1]"..
"field[5,7;3,0.7;field-2;field-2;field-2]"..
"pwdfield[5,8;3,0.7;pwdfield-2;pwdfield-2]"..
"textarea[5,9;3,0.7;textarea-2;textarea-2;textarea-2]"..
"scrollbar[5,10;3,0.7;;scrollbar-2;scrollbar-2;0]"
```