### PR TITLE
Allow setting item texture from stack metadata

### DIFF
--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -646,7 +646,7 @@ void drawItemStack(
 	}
 
 	const ItemDefinition &def = item.getDefinition(client->idef());
-	ItemMesh *imesh = client->idef()->getWieldMesh(def.name, client, item);
+	ItemMesh *imesh = client->idef()->getWieldMesh(client, item);
 
 	if (imesh && imesh->mesh) {
 		scene::IMesh *mesh = imesh->mesh;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -646,7 +646,7 @@ void drawItemStack(
 	}
 
 	const ItemDefinition &def = item.getDefinition(client->idef());
-	ItemMesh *imesh = client->idef()->getWieldMesh(def.name, client);
+	ItemMesh *imesh = client->idef()->getWieldMesh(def.name, client, item);
 
 	if (imesh && imesh->mesh) {
 		scene::IMesh *mesh = imesh->mesh;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -367,7 +367,16 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 
 	// Handle nodes
 	// See also CItemDefManager::createClientCached()
-	if (def.type == ITEM_NODE) {
+
+	// If texture is overriden in stack metadata, ignore all else
+	if (!item.metadata.getString("texture").empty()){
+		setExtruded(item.metadata.getString("texture"), def.inventory_overlay, def.wield_scale,
+			tsrc, 1);
+		m_colors.emplace_back();
+		// overlay is white, if present
+		m_colors.emplace_back(true, video::SColor(0xFFFFFFFF));
+		return;
+	} else if (def.type == ITEM_NODE) {
 		if (f.mesh_ptr[0]) {
 			// e.g. mesh nodes and nodeboxes
 			mesh = cloneMesh(f.mesh_ptr[0]);
@@ -511,8 +520,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 	result->needs_shading = true;
 
 	// If inventory_image is defined, it overrides everything else
-	if (!def.inventory_image.empty()) {
-		mesh = getExtrudedMesh(tsrc, def.inventory_image,
+	if (!item.getTexture(idef).empty()) {
+		mesh = getExtrudedMesh(tsrc, item.getTexture(idef),
 			def.inventory_overlay);
 		result->buffer_colors.emplace_back();
 		// overlay is white, if present

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -247,6 +247,15 @@ std::string ItemStack::getItemString() const
 	return os.str();
 }
 
+std::string ItemStack::getTexture(IItemDefManager *itemdef) const
+{
+	std::string texture = metadata.getString("texture");
+	if (texture.empty())
+		texture = getDefinition(itemdef).inventory_image;
+
+	return texture;
+}
+
 std::string ItemStack::getDescription(IItemDefManager *itemdef) const
 {
 	std::string desc = metadata.getString("description");

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -49,7 +49,9 @@ struct ItemStack
 	std::string getItemString() const;
 	// Returns the tooltip
 	std::string getDescription(IItemDefManager *itemdef) const;
-
+	// Returns the item texture from either definition or metadata
+	std::string getTexture(IItemDefManager *itemdef) const;
+	
 	/*
 		Quantity methods
 	*/

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -117,10 +117,10 @@ public:
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+			Client *client, const ItemStack &item) const=0;
 	// Get item wield mesh
 	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+		Client *client, const ItemStack &item) const=0;
 	// Get item palette
 	virtual Palette* getPalette(const std::string &name,
 		Client *client) const = 0;
@@ -151,10 +151,10 @@ public:
 #ifndef SERVER
 	// Get item inventory texture
 	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client) const=0;
+			Client *client, const ItemStack &item) const=0;
 	// Get item wield mesh
 	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client) const=0;
+		Client *client, const ItemStack &item) const=0;
 #endif
 
 	// Remove all registered item and node definitions and aliases

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -116,14 +116,14 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client, const ItemStack &item) const=0;
+	virtual video::ITexture* getInventoryTexture(Client *client, 
+			const ItemStack &item) const=0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client, const ItemStack &item) const=0;
+	virtual ItemMesh* getWieldMesh(Client *client, 
+			const ItemStack &item) const=0;
 	// Get item palette
-	virtual Palette* getPalette(const std::string &name,
-		Client *client) const = 0;
+	virtual Palette* getPalette(Client *client, 
+			const ItemStack &item) const = 0;
 	// Returns the base color of an item stack: the color of all
 	// tiles that do not define their own color.
 	virtual video::SColor getItemstackColor(const ItemStack &stack,
@@ -150,11 +150,11 @@ public:
 	virtual bool isKnown(const std::string &name) const=0;
 #ifndef SERVER
 	// Get item inventory texture
-	virtual video::ITexture* getInventoryTexture(const std::string &name,
-			Client *client, const ItemStack &item) const=0;
+	virtual video::ITexture* getInventoryTexture(Client *client, 
+			const ItemStack &item) const=0;
 	// Get item wield mesh
-	virtual ItemMesh* getWieldMesh(const std::string &name,
-		Client *client, const ItemStack &item) const=0;
+	virtual ItemMesh* getWieldMesh(Client *client,
+			const ItemStack &item) const=0;
 #endif
 
 	// Remove all registered item and node definitions and aliases


### PR DESCRIPTION
Solves #5686  

## To do  

This PR is a Work in Progress  

- [ ] Fix things like rails not properly changing texture in both wield model and inventory  
- [x] Use ItemStack::getTexture in more places instead of manually checking if metadata exists  

## How to test  
 ```lua
minetest.register_chatcommand("test",` {  
    params = "",  
    func = function(name, param)  
               local player = minetest.get_player_by_name(name)  
               local stack = player:get_wielded_item()  
               stack:get_meta():set_string("texture", "default_leaves.png")  
               player:set_wielded_item(stack)  
           end,  
})  
```
