### PR TITLE
Fix potential security issue(s), documentation on minetest.deserialize()

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -177,16 +177,16 @@ end
 
 -- Deserialization
 
-local env = {
-	loadstring = function(...)
-		local func, err = loadstring(...)
-		if func then
-			setfenv(func, {})
-			return func
-		end
-		return nil, err
-	end,
-}
+local function safe_loadstring(...)
+	local func, err = loadstring(...)
+	if func then
+		setfenv(func, {})
+		return func
+	end
+	return nil, err
+end
+
+local function dummy_func() end
 
 function core.deserialize(str, safe)
 	if type(str) ~= "string" then
@@ -199,9 +199,9 @@ function core.deserialize(str, safe)
 	local f, err = loadstring(str)
 	if not f then return nil, err end
 
-	-- The safe environment is recreated every time so deseralized code cannot
-	-- pollute the safe environment with permanent references.
-	setfenv(f, safe and {loadstring = function() end} or env)
+	-- The environment is recreated every time so deseralized code cannot
+	-- pollute it with permanent references.
+	setfenv(f, {loadstring = safe and dummy_func or safe_loadstring})
 
 	local good, data = pcall(f)
 	if good then

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -198,6 +198,9 @@ function core.deserialize(str, safe)
 	end
 	local f, err = loadstring(str)
 	if not f then return nil, err end
+
+	-- The safe environment is recreated every time so deseralized code cannot
+	-- pollute the safe environment with permanent references.
 	setfenv(f, safe and {loadstring = function() end} or env)
 
 	local good, data = pcall(f)

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -178,11 +178,14 @@ end
 -- Deserialization
 
 local env = {
-	loadstring = loadstring,
-}
-
-local safe_env = {
-	loadstring = function() end,
+	loadstring = function(...)
+		local func, err = loadstring(...)
+		if func then
+			setfenv(func, {})
+			return func
+		end
+		return nil, err
+	end,
 }
 
 function core.deserialize(str, safe)
@@ -195,7 +198,7 @@ function core.deserialize(str, safe)
 	end
 	local f, err = loadstring(str)
 	if not f then return nil, err end
-	setfenv(f, safe and safe_env or env)
+	setfenv(f, safe and {loadstring = function() end} or env)
 
 	local good, data = pcall(f)
 	if good then

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -1,6 +1,6 @@
 _G.core = {}
 
-_G.setfenv = function() end
+_G.setfenv = require 'busted.compatibility'.setfenv
 
 dofile("builtin/common/serialize.lua")
 
@@ -24,5 +24,21 @@ describe("serialize", function()
 
 		local test_out = core.deserialize(core.serialize(test_in))
 		assert.same(test_in, test_out)
+	end)
+
+	it("strips functions in safe mode", function()
+		local test_in = {
+			func = function(a, b)
+				error("test")
+			end,
+			foo = "bar"
+		}
+
+		local str = core.serialize(test_in)
+		assert.not_nil(str:find("loadstring"))
+
+		local test_out = core.deserialize(str, true)
+		assert.is_nil(test_out.func)
+		assert.equals(test_out.foo, "bar")
 	end)
 end)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5219,7 +5219,8 @@ Misc.
     * `string` is loaded in an empty sandbox environment.
     * Will load functions if safe is false or omitted. Although these functions
       cannot directly access the global environment, they could bypass this
-      restriction with maliciously crafted Lua bytecode.
+      restriction with maliciously crafted Lua bytecode if mod security is
+      disabled.
     * This function should not be used on untrusted data, regardless of the
       value of safe.
     * Example: `deserialize('return { ["foo"] = "bar" }')`,

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5222,7 +5222,8 @@ Misc.
       restriction with maliciously crafted Lua bytecode if mod security is
       disabled.
     * This function should not be used on untrusted data, regardless of the
-      value of safe.
+     value of `safe`. It is fine to serialize then deserialize user-provided
+     data, but directly providing user-input to deserialize is not safe.
     * Example: `deserialize('return { ["foo"] = "bar" }')`,
       returns `{foo='bar'}`
     * Example: `deserialize('print("foo")')`, returns `nil`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5223,7 +5223,7 @@ Misc.
       disabled.
     * This function should not be used on untrusted data, regardless of the
      value of `safe`. It is fine to serialize then deserialize user-provided
-     data, but directly providing user-input to deserialize is not safe.
+     data, but directly providing user input to deserialize is always unsafe.
     * Example: `deserialize('return { ["foo"] = "bar" }')`,
       returns `{foo='bar'}`
     * Example: `deserialize('print("foo")')`, returns `nil`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5214,10 +5214,14 @@ Misc.
     * Convert a table containing tables, strings, numbers, booleans and `nil`s
       into string form readable by `minetest.deserialize`
     * Example: `serialize({foo='bar'})`, returns `'return { ["foo"] = "bar" }'`
-* `minetest.deserialize(string)`: returns a table
+* `minetest.deserialize(string[, safe])`: returns a table
     * Convert a string returned by `minetest.deserialize` into a table
     * `string` is loaded in an empty sandbox environment.
-    * Will load functions, but they cannot access the global environment.
+    * Will load functions if safe is false or omitted. Although these functions
+      cannot directly access the global environment, they could bypass this
+      restriction with maliciously crafted Lua bytecode.
+    * This function should not be used on untrusted data, regardless of the
+      value of safe.
     * Example: `deserialize('return { ["foo"] = "bar" }')`,
       returns `{foo='bar'}`
     * Example: `deserialize('print("foo")')`, returns `nil`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5215,7 +5215,7 @@ Misc.
       into string form readable by `minetest.deserialize`
     * Example: `serialize({foo='bar'})`, returns `'return { ["foo"] = "bar" }'`
 * `minetest.deserialize(string[, safe])`: returns a table
-    * Convert a string returned by `minetest.deserialize` into a table
+    * Convert a string returned by `minetest.serialize` into a table
     * `string` is loaded in an empty sandbox environment.
     * Will load functions if safe is false or omitted. Although these functions
       cannot directly access the global environment, they could bypass this


### PR DESCRIPTION
- Goal of the PR

This PR makes the documentation on minetest.deserialize() less misleading and prevents functions from (easily) accessing the global environment.

- How does the PR work?

When loadstring is called inside `minetest.deserialize()` code, the resulting function will have an empty environment.

- Does it resolve any reported issue?

No.

## To do

This PR is a ready for review.

## How to test

The following code will no longer work:
```lua
minetest.deserialize('loadstring("minetest.after(0, error)")()')
```
