### PR TITLE
Play 'player_jump' when player jumps

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -889,6 +889,7 @@ These sound files are played back by the engine if provided.
  * `player_damage`: Played when the local player takes damage (gain = 0.5)
  * `player_falling_damage`: Played when the local player takes
    damage by falling (gain = 0.5)
+ * `player_jump`: Played when the local player jumps
  * `default_dig_<groupname>`: Default node digging sound
    (see node sound definition for details)
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -276,8 +276,8 @@ public:
 		m_sound(sound),
 		m_ndef(ndef),
 		makes_footstep_sound(true),
-		m_player_step_timer(0),
-		m_player_jump_timer(0)
+		m_player_step_timer(0.0f),
+		m_player_jump_timer(0.0f)
 	{
 	}
 
@@ -292,9 +292,9 @@ public:
 
 	void playPlayerJump()
 	{
-		if (m_player_jump_timer <= 0) {
-			m_player_jump_timer = 0.2;
-			m_sound->playSound(SimpleSoundSpec("player_jump", 0.5), false);
+		if (m_player_jump_timer <= 0.0f) {
+			m_player_jump_timer = 0.2f;
+			m_sound->playSound(SimpleSoundSpec("player_jump", 0.5f), false);
 		}
 	}
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -266,6 +266,7 @@ class SoundMaker
 public:
 	bool makes_footstep_sound;
 	float m_player_step_timer;
+	float m_player_jump_timer;
 
 	SimpleSoundSpec m_player_step_sound;
 	SimpleSoundSpec m_player_leftpunch_sound;
@@ -275,7 +276,8 @@ public:
 		m_sound(sound),
 		m_ndef(ndef),
 		makes_footstep_sound(true),
-		m_player_step_timer(0)
+		m_player_step_timer(0),
+		m_player_jump_timer(0)
 	{
 	}
 
@@ -285,6 +287,14 @@ public:
 			m_player_step_timer = 0.03;
 			if (makes_footstep_sound)
 				m_sound->playSound(m_player_step_sound, false);
+		}
+	}
+
+	void playPlayerJump()
+	{
+		if (m_player_jump_timer <= 0) {
+			m_player_jump_timer = 0.2;
+			m_sound->playSound(SimpleSoundSpec("player_jump", 0.5), false);
 		}
 	}
 
@@ -302,7 +312,8 @@ public:
 
 	static void playerJump(MtEvent *e, void *data)
 	{
-		//SoundMaker *sm = (SoundMaker*)data;
+		SoundMaker *sm = (SoundMaker *)data;
+		sm->playPlayerJump();
 	}
 
 	static void cameraPunchLeft(MtEvent *e, void *data)
@@ -351,6 +362,7 @@ public:
 	void step(float dtime)
 	{
 		m_player_step_timer -= dtime;
+		m_player_jump_timer -= dtime;
 	}
 };
 


### PR DESCRIPTION
This PR adds a new sound `player_jump` which is played when the local player jumps.

## To do

Ready for Review.

## How to test

* Add a mod with a sound file: `sounds/player_jump.ogg`
* Turn on the loudspeakers and volume to 100%
* Start the game and jump