### PR TITLE
Preserve field values on FormSpec refresh

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2295,7 +2295,8 @@ Elements
   element.
 * `listelements` can be prepended by #RRGGBB (only) in hexadecimal format
     * if you want a listelement to start with "#" write "##"
-* Index to be selected within textlist
+* `selected idx`: index of row to be selected within textlist (first row = `1`).
+  If set to `0`, no item will be selected.
 * `true`/`false`: draw transparent background
 * See also `minetest.explode_textlist_event`
   (main menu: `core.explode_textlist_event`).
@@ -2353,7 +2354,8 @@ Elements
 * `W`: width of the dropdown. Height is automatically chosen with this syntax.
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
-* Index of currently selected dropdown item
+* `selected idx`: index of currently selected dropdown item (first row = `1`).
+  If set to `0`, no item will be selected.
 
 ### `dropdown[<X>,<Y>;<W>,<H>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
 
@@ -2367,7 +2369,8 @@ Elements
 * `W` and `H`: width and height of the dropdown
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
-* Index of currently selected dropdown item
+* `selected idx`: index of currently selected dropdown item (first row = `1`).
+  If set to `0`, no item will be selected.
 
 ### `checkbox[<X>,<Y>;<name>;<label>;<selected>]`
 
@@ -2420,7 +2423,8 @@ Elements
 * Displays cells as defined by the previous `tablecolumns[]`
 * `name`: fieldname sent to server on row select or doubleclick
 * `cell 1`...`cell n`: cell contents given in row-major order
-* `selected idx`: index of row to be selected within table (first row = `1`)
+* `selected idx`: index of row to be selected within table (first row = `1`).
+  If set to `0`, no item will be selected.
 * See also `minetest.explode_table_event`
   (main menu: `core.explode_table_event`).
 
@@ -4275,7 +4279,7 @@ Call these functions only at load time!
         * `button` and variants: If pressed, contains the user-facing button
           text as value. If not pressed, is `nil`
         * `field`, `textarea` and variants: Text in the field
-        * `dropdown`: Text of selected item
+        * `dropdown`: Text of selected item or `""` if no item is selected.
         * `tabheader`: Tab index, starting with `"1"` (only if tab changed)
         * `checkbox`: `"true"` if checked, `"false"` if unchecked
         * `textlist`: See `minetest.explode_textlist_event`

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -1474,6 +1474,28 @@ void GUIEditBoxWithScrollBar::setBackgroundColor(const video::SColor &bg_color)
 	m_bg_color_used = true;
 }
 
+GUIEditBoxWithScrollBar::DynamicData GUIEditBoxWithScrollBar::getDynamicData()
+{
+	return {
+		Text,
+		{m_hscroll_pos, m_vscroll_pos},
+		m_cursor_pos,
+		m_mark_begin,
+		m_mark_end
+	};
+}
+
+void GUIEditBoxWithScrollBar::setDynamicData(
+	const GUIEditBoxWithScrollBar::DynamicData &dyndata)
+{
+	Text =          dyndata.text;
+	m_hscroll_pos = dyndata.scroll_pos.X;
+	m_vscroll_pos = dyndata.scroll_pos.Y;
+	m_cursor_pos  = dyndata.cursor_pos;
+	m_mark_begin  = dyndata.mark_begin;
+	m_mark_end    = dyndata.mark_end;
+}
+
 //! Writes attributes of the element.
 void GUIEditBoxWithScrollBar::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options = 0) const
 {

--- a/src/gui/guiEditBoxWithScrollbar.h
+++ b/src/gui/guiEditBoxWithScrollbar.h
@@ -122,6 +122,16 @@ public:
 	//! Change the background color
 	virtual void setBackgroundColor(const video::SColor &bg_color);
 
+	struct DynamicData {
+		core::stringw text;
+		core::position2d<s32> scroll_pos;
+		s32 cursor_pos;
+		s32 mark_begin, mark_end;
+	};
+
+	virtual DynamicData getDynamicData();
+	virtual void setDynamicData(const DynamicData &dyndata);
+
 	//! Writes attributes of the element.
 	virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -28,6 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "modalMenu.h"
 #include "guiInventoryList.h"
 #include "guiTable.h"
+#include "guiEditBoxWithScrollbar.h"
 #include "network/networkprotocol.h"
 #include "client/joystick_controller.h"
 #include "util/string.h"
@@ -48,6 +49,11 @@ typedef enum {
 	f_ScrollBar,
 	f_Box,
 	f_ItemImage,
+	f_PwdField,
+	f_Field,
+	f_TextArea,
+	f_IntlTextArea,
+	f_HyperText,
 	f_Unknown
 } FormspecFieldType;
 
@@ -164,6 +170,7 @@ public:
 	{
 		m_formspec_string = formspec_string;
 		m_current_inventory_location = current_inventory_location;
+		m_is_form_regenerated = false;
 		regenerateGui(m_screensize_old);
 	}
 
@@ -293,6 +300,10 @@ protected:
 	std::string m_formspec_prepend;
 	InventoryLocation m_current_inventory_location;
 
+	// Default true because we can't control regeneration on resizing, but
+	// we can control cases when the formspec is shown intentionally.
+	bool m_is_form_regenerated = true;
+
 	std::vector<GUIInventoryList *> m_inventorylists;
 	std::vector<ListRingSpec> m_inventory_rings;
 	std::vector<gui::IGUIElement *> m_backgrounds;
@@ -364,8 +375,11 @@ private:
 			GUIScrollBar::ArrowVisibility arrow_visiblity = GUIScrollBar::DEFAULT;
 		} scrollbar_options;
 
-		// used to restore table selection/scroll/treeview state
+		// Preservation of formspec elements
 		std::unordered_map<std::string, GUITable::DynamicData> table_dyndata;
+		std::unordered_map<s32, GUIEditBoxWithScrollBar::DynamicData> field_dyndata;
+		std::unordered_map<s32, core::position2d<s32>> preserved_scrolling;
+		std::unordered_map<s32, s32> preserved_etc;
 	} parserData;
 
 	typedef struct {

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1047,6 +1047,17 @@ void GUIHyperText::checkHover(s32 X, s32 Y)
 				gui::ECI_NORMAL);
 }
 
+core::position2d<s32> GUIHyperText::getScrollPosition()
+{
+	return m_text_scrollpos;
+}
+
+void GUIHyperText::setScrollPosition(const core::position2d<s32> &scrollpos)
+{
+	m_text_scrollpos = scrollpos;
+	m_vscrollbar->setPos(-m_text_scrollpos.Y);
+}
+
 bool GUIHyperText::OnEvent(const SEvent &event)
 {
 	// Scroll bar

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -205,6 +205,9 @@ public:
 	//! draws the element and its children
 	virtual void draw();
 
+	virtual core::position2d<s32> getScrollPosition();
+	virtual void setScrollPosition(const core::position2d<s32> &scrollpos);
+
 	core::dimension2du getTextDimension();
 
 	bool OnEvent(const SEvent &event);

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -606,7 +606,8 @@ void GUITable::setDynamicData(const DynamicData &dyndata)
 	m_keynav_time = dyndata.keynav_time;
 	m_keynav_buffer = dyndata.keynav_buffer;
 
-	setSelected(dyndata.selected);
+	if (dyndata.selected > -1)
+		setSelected(dyndata.selected);
 	m_sel_column = 0;
 	m_sel_doubleclick = false;
 

--- a/src/gui/intlGUIEditBox.cpp
+++ b/src/gui/intlGUIEditBox.cpp
@@ -1545,6 +1545,27 @@ void intlGUIEditBox::setWritable(bool can_write_text)
 	m_writable = can_write_text;
 }
 
+GUIEditBoxWithScrollBar::DynamicData intlGUIEditBox::getDynamicData()
+{
+	return {
+		Text,
+		{HScrollPos, VScrollPos},
+		CursorPos,
+		MarkBegin,
+		MarkEnd
+	};
+}
+
+void intlGUIEditBox::setDynamicData(
+	const GUIEditBoxWithScrollBar::DynamicData &dyndata)
+{
+	HScrollPos = dyndata.scroll_pos.X;
+	VScrollPos = dyndata.scroll_pos.Y;
+	CursorPos  = dyndata.cursor_pos;
+	MarkBegin  = dyndata.mark_begin;
+	MarkEnd    = dyndata.mark_end;
+}
+
 //! Writes attributes of the element.
 void intlGUIEditBox::serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options=0) const
 {

--- a/src/gui/intlGUIEditBox.h
+++ b/src/gui/intlGUIEditBox.h
@@ -11,6 +11,8 @@
 #include "irrArray.h"
 #include "IOSOperator.h"
 #include "guiScrollBar.h"
+#include "guiEditBoxWithScrollbar.h"
+
 
 namespace irr
 {
@@ -126,6 +128,10 @@ namespace gui
 
 		//! set true if this EditBox is writable
 		virtual void setWritable(bool can_write_text);
+
+		virtual GUIEditBoxWithScrollBar::DynamicData getDynamicData();
+		virtual void setDynamicData(
+			const GUIEditBoxWithScrollBar::DynamicData &dyndata);
 
 		//! Writes attributes of the element.
 		virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const;


### PR DESCRIPTION
This PR makes it so that all FormSpec elements automatically retain their state when the Minetest window is resized.  They are not affected when the FormSpec is intentionally reshown by Lua.  The following elements are affected:
- `field`/`pwdfield`/`textarea`: The text inside them stays the same.
- `scrollbar`: The scroll position stays the same.
- `table`/`textlist`/`dropdown`/`tabheader`: The selected index is retained
- `checkbox`: Whether it has been checked or unchecked is kept

Note that, since I was fixing table and dropdown selection, I added the functionality that they can have no selection at all by default (selected index of `0`).  This actually simplifies the code, so I hope that it wasn't too presumptuous of me to add that in this PR.

This PR fixes what is said in #3732 and #5161.  Who said it's a `can't fix`?  :)

Note that #9353 improves the table restoration behaviour for scroll position because that will be preserved across the same form being reshown from Lua.  I won't add that functionality to this PR to minimize rebasing.

And another note:  I don't preserve `field`/`pwdfield` cursor position/scroll position because there is no built-in way to do that, and I don't want to clone Irrlicht's entire `IGUIEditBox`, especially because we already have `GUIEditBoxWithScrollBar` and `intlGUIEditBox` as well as the fact that this PR is already getting very big.  Plus, I don't really know how to do that.  So, I'll probably leave that for another PR, unless I rack up the nerve to try copying all that stuff.

## To do

This PR is a Work in Progress.

## How to test

Note that this is basically copied verbatim from `set_focus`, so some elements are extraneous.  Try messing around with the elements and then resizing the window, and find that they're all exactly the same.
```
"formspec_version[3]"..
"size[9,13]"..

"checkbox[1,0.5;checkbox-1;checkbox-1]"..
"button[1,1;3,0.7;button-1;button-1]"..
"image_button[1,2;3,0.7;air.png;image_button-1;image_button-1]"..
"item_image_button[1,3;3,0.7;air;item_image_button-1;item_image_button-1]"..
"table[1,4;3,0.7;table-1;table-1,-;1]"..
"textlist[1,5;3,0.7;textlist-1;textlist-1,-;0]"..
"dropdown[1,6;3,0.7;dropdown-1;dropdown-1,-;0]"..
"field[1,7;3,0.7;field-1;field-1;field-1]"..
"pwdfield[1,8;3,0.7;pwdfield-1;pwdfield-1]"..
"textarea[1,9;3,0.7;textarea-1;textarea-1;textarea-1]"..
"scrollbar[1,10;3,0.7;;scrollbar-1;scrollbar-1;0]"..
"tabheader[1,11.7;3,0.7;tabheader-1;tab-1,-,-;1;;]"..
"hypertext[1,12;3,.7;hypertext-1;<global background=white>This\nis\nthe\nhypertext-1\nelement]"..

"checkbox[5,0.5;checkbox-2;checkbox-2]"..
"button[5,1;3,0.7;button-2;button-2]"..
"image_button[5,2;3,0.7;air.png;image_button-2;image_button-2]"..
"item_image_button[5,3;3,0.7;air;item_image_button-2;item_image_button-2]"..
"table[5,4;3,0.7;table-2;table-2,-;1]"..
"textlist[5,5;3,0.7;textlist-2;textlist-2,-;1]"..
"dropdown[5,6;3,0.7;dropdown-2;dropdown-2,-;1]"..
"field[5,7;3,0.7;field-2;field-2;field-2]"..
"pwdfield[5,8;3,0.7;pwdfield-2;pwdfield-2]"..
"textarea[5,9;3,0.7;textarea-2;textarea-2;textarea-2]"..
"scrollbar[5,10;3,0.7;;scrollbar-2;scrollbar-2;0]"..
"tabheader[5,11.7;3,0.7;tabheader-2;tab-2,-,-;1;;]"..
"hypertext[5,12;3,.7;hypertext-2;<global background=white>This\nis\nthe\nhypertext-2\nelement]"
```
