### PR TITLE
Add multiple element selection to `style` and `style_type`

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2495,14 +2495,14 @@ Elements
         * `span=<value>`: number of following columns to affect
           (default: infinite).
 
-### `style[<name>;<prop1>;<prop2>;...]`
+### `style[<name 1>,<name 2>,...;<prop1>;<prop2>;...]`
 
 * Set the style for the named element(s) `name`.
 * Note: this **must** be before the element is defined.
 * See [Styling Formspecs].
 
 
-### `style_type[<type>;<prop1>;<prop2>;...]`
+### `style_type[<type 1>,<type 2>,...;<prop1>;<prop2>;...]`
 
 * Sets the style for all elements of type(s) `type` which appear after this element.
 * See [Styling Formspecs].
@@ -2547,17 +2547,17 @@ Styling Formspecs
 
 Formspec elements can be themed using the style elements:
 
-    style[<name>;<prop1>;<prop2>;...]
-    style_type[<type>;<prop1>;<prop2>;...]
+    style[<name 1>,<name 2>,...;<prop1>;<prop2>;...]
+    style_type[<type 1>,<type 2>,...;<prop1>;<prop2>;...]
 
 Where a prop is:
 
-    `property_name=property_value`
+    property_name=property_value
 
-A name/type can be a comma separated list of names/types, like so:
+A name/type can optionally be a comma separated list of names/types, like so:
 
-    `world_delete,world_create,world_configure`
-    `button,image_button`
+    world_delete,world_create,world_configure
+    button,image_button
 
 For example:
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2497,14 +2497,14 @@ Elements
 
 ### `style[<name>;<prop1>;<prop2>;...]`
 
-* Set the style for the named element `name`.
+* Set the style for the named element(s) `name`.
 * Note: this **must** be before the element is defined.
 * See [Styling Formspecs].
 
 
 ### `style_type[<type>;<prop1>;<prop2>;...]`
 
-* Sets the style for all elements of type `type` which appear after this element.
+* Sets the style for all elements of type(s) `type` which appear after this element.
 * See [Styling Formspecs].
 
 Migrating to Real Coordinates
@@ -2552,7 +2552,12 @@ Formspec elements can be themed using the style elements:
 
 Where a prop is:
 
-    property_name=property_value
+    `property_name=property_value`
+
+A name/type can be a comma separated list of names/types, like so:
+
+    `world_delete,world_create,world_configure`
+    `button,image_button`
 
 For example:
 

--- a/games/minimal/mods/test/formspec.lua
+++ b/games/minimal/mods/test/formspec.lua
@@ -1,18 +1,9 @@
 local color = minetest.colorize
 
 local clip_fs = [[
-	style_type[label;noclip=%c]
-	style_type[button;noclip=%c]
-	style_type[image_button;noclip=%c]
-	style_type[item_image_button;noclip=%c]
-	style_type[tabheader;noclip=%c]
-	style_type[field;noclip=%c]
-	style_type[textarea;noclip=%c]
-	style_type[checkbox;noclip=%c]
-	style_type[dropdown;noclip=%c]
-	style_type[scrollbar;noclip=%c]
-	style_type[table;noclip=%c]
-	style_type[animated_image;noclip=%c]
+	style_type[label,button,image_button,item_image_button,
+			tabheader,scrollbar,table,animated_image
+			,field,textarea,checkbox,dropdown;noclip=%c]
 
 	label[0,0;A clipping test]
 	button[0,1;3,0.8;x;A clipping test]

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2450,13 +2450,6 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 		return false;
 	}
 
-	std::string selector = trim(parts[0]);
-	if (selector.empty()) {
-		errorstream << "Invalid style element (Selector required): '" << element
-					<< "'" << std::endl;
-		return false;
-	}
-
 	StyleSpec spec;
 
 	for (size_t i = 1; i < parts.size(); i++) {
@@ -2486,10 +2479,21 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 		spec.set(prop, value);
 	}
 
-	if (style_type) {
-		theme_by_type[selector] |= spec;
-	} else {
-		theme_by_name[selector] |= spec;
+	std::vector<std::string> selectors = split(parts[0], ',');
+	for (size_t sel = 0; sel < selectors.size(); sel++) {
+		std::string selector = trim(selectors[sel]);
+
+		if (selector.empty()) {
+			errorstream << "Invalid style element (Selector required): '" << element
+				<< "'" << std::endl;
+			continue;
+		}
+
+		if (style_type) {
+			theme_by_type[selector] |= spec;
+		} else {
+			theme_by_name[selector] |= spec;
+		}
 	}
 
 	return true;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2484,7 +2484,7 @@ bool GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element, b
 		std::string selector = trim(selectors[sel]);
 
 		if (selector.empty()) {
-			errorstream << "Invalid style element (Selector required): '" << element
+			errorstream << "Invalid style element (Empty selector): '" << element
 				<< "'" << std::endl;
 			continue;
 		}


### PR DESCRIPTION
This PR add multiple element selection to `style` and `style_type` using comma-separated names/types.  Syntax:
```
style[button1,image_button2;textcolor=red]
style_type[button,image_button;textcolor=blue]
```
Assuming that there are two buttons with the IDs `button1` and `image_button2`, they will both have their text colors set to red, and all buttons and image buttons will have their textcolors set to blue (except for `button1` and `image_button2`, of course).  This PR will integrate well with state selection, e.g.
```
style_type[button,image_button:hovered;textcolor=blue]
```

## To do

This PR is Ready for Review.  This PR is _very_ simple, it could probably be merged very soon.

## How to test

Very simple this time.  The buttons show their name and the color they should be.  Rather self-explanatory, I think.

```lua
"formspec_version[3]"..
"size[9,7]"..
"style[button1,image_button2;textcolor=red]"..
"style_type[button,image_button;textcolor=blue]"..
"button[1,1;3,1;button1;Button 1: Red]"..
"button[1,3;3,1;button2;Button 2: Blue]"..
"button[1,5;3,1;button3;Button 3: Blue]"..
"image_button[5,1;3,1;air.png;image_button1;Image Button 1: Blue]"..
"image_button[5,3;3,1;air.png;image_button2;Image Button 2: Red]"..
"image_button[5,5;3,1;air.png;image_button3;Image Button 3: Blue]"
```


