### PR TITLE
CSM client-side camera control

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1300,7 +1300,8 @@ server_side_occlusion_culling (Server side occlusion culling) bool true
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
-csm_restriction_flags (Client side modding restrictions) int 62
+#    CAMERA_CONTROL: 64 (disable 'CUSTOM' camera mode client-side)
+csm_restriction_flags (Client side modding restrictions) int 126
 
 #   If the CSM restriction for node range is enabled, get_node calls are limited
 #   to this distance from the player to the node.

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -223,6 +223,18 @@ core.register_chatcommand("text", {
 	end,
 })
 
+core.register_chatcommand("cam_lock", {
+	func = function(param)
+		core.camera:set_camera_custom_state(core.camera:get_pos(), core.camera:get_look_dir(), vector.new(0,1,0))
+		core.camera:set_camera_mode(3)
+	end
+})
+
+core.register_chatcommand("cam_unlock", {
+	func = function(param)
+		core.camera:set_camera_mode(0)
+	end
+})
 
 core.register_on_mods_loaded(function()
 	core.log("Yeah preview mod is loaded with other CSM mods.")

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -655,7 +655,8 @@ Minetest namespace reference
    restrictions applied to the current mod.
    * If a flag in this table is set to true, the feature is RESTRICTED.
    * Possible flags: `load_client_mods`, `chat_messages`, `read_itemdefs`,
-                   `read_nodedefs`, `lookup_nodes`, `read_playerinfo`
+                   `read_nodedefs`, `lookup_nodes`, `read_playerinfo`,
+                   `camera_control`
 
 ### Logging
 * `minetest.debug(...)`
@@ -958,9 +959,12 @@ Please do not try to access the reference until the camera is initialized, other
 
 #### Methods
 * `set_camera_mode(mode)`
-    * Pass `0` for first-person, `1` for third person, and `2` for third person front
+    * Pass `0` for first-person, `1` for third person, `2` for third person front, and `3` for custom
+    * Note that CUSTOM cannot be set if camera_control is restricted.
 * `get_camera_mode()`
-    * Returns 0, 1, or 2 as described above
+    * Returns 0, 1, 2, or 3 as described above
+* `set_camera_custom_state(pos, look_dir, up)`
+    * Sets the state of the camera in custom mode; takes 3 vectors.
 * `get_fov()`
     * Returns:
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1570,8 +1570,9 @@
 #    LOOKUP_NODES_LIMIT: 16 (limits get_node call client-side to
 #    csm_restriction_noderange)
 #    READ_PLAYERINFO: 32 (disable get_player_names call client-side)
+#    CAMERA_CONTROL: 64 (disable 'CUSTOM' camera mode client-side)
 #    type: int
-# csm_restriction_flags = 62
+# csm_restriction_flags = 126
 
 #    If the CSM restriction for node range is enabled, get_node calls are limited
 #    to this distance from the player to the node.

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -311,7 +311,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Fall bobbing animation
 	float fall_bobbing = 0;
-	if(player->camera_impact >= 1 && m_camera_mode < CAMERA_MODE_THIRD)
+	if(player->camera_impact >= 1 && m_camera_mode == CAMERA_MODE_FIRST)
 	{
 		if(m_view_bobbing_fall == -1) // Effect took place and has finished
 			player->camera_impact = m_view_bobbing_fall = 0;
@@ -346,7 +346,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	v3f rel_cam_up = v3f(0,1,0);
 
 	if (m_cache_view_bobbing_amount != 0.0f && m_view_bobbing_anim != 0.0f &&
-		m_camera_mode < CAMERA_MODE_THIRD) {
+		m_camera_mode == CAMERA_MODE_FIRST) {
 		f32 bobfrac = my_modf(m_view_bobbing_anim * 2);
 		f32 bobdir = (m_view_bobbing_anim < 0.5) ? 1.0 : -1.0;
 
@@ -397,8 +397,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 	// Seperate camera position for calculation
 	v3f my_cp = m_camera_position;
 
-	// Reposition the camera for third person view
-	if (m_camera_mode > CAMERA_MODE_FIRST)
+	// Reposition the camera for special (non-firstperson) view modes
+	if ((m_camera_mode == CAMERA_MODE_THIRD_FRONT) || (m_camera_mode == CAMERA_MODE_THIRD))
 	{
 		if (m_camera_mode == CAMERA_MODE_THIRD_FRONT)
 			m_camera_direction *= -1;
@@ -431,6 +431,9 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 		// If node blocks camera position don't move y to heigh
 		if (abort && my_cp.Y > player_position.Y+BS*2)
 			my_cp.Y = player_position.Y+BS*2;
+	} else if (m_camera_mode == CAMERA_MODE_CUSTOM) {
+		my_cp = m_camera_custom_position;
+		m_camera_direction = m_camera_custom_direction;
 	}
 
 	// Update offset if too far away from the center of the map
@@ -443,7 +446,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Set camera node transformation
 	m_cameranode->setPosition(my_cp-intToFloat(m_camera_offset, BS));
-	m_cameranode->setUpVector(abs_cam_up);
+	m_cameranode->setUpVector(m_camera_mode == CAMERA_MODE_CUSTOM ? m_camera_custom_up : abs_cam_up);
 	// *100.0 helps in large map coordinates
 	m_cameranode->setTarget(my_cp-intToFloat(m_camera_offset, BS) + 100 * m_camera_direction);
 

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -311,7 +311,7 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 busytime, f32 tool_r
 
 	// Fall bobbing animation
 	float fall_bobbing = 0;
-	if(player->camera_impact >= 1 && m_camera_mode == CAMERA_MODE_FIRST)
+	if (player->camera_impact >= 1 && m_camera_mode == CAMERA_MODE_FIRST)
 	{
 		if(m_view_bobbing_fall == -1) // Effect took place and has finished
 			player->camera_impact = m_view_bobbing_fall = 0;

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -230,9 +230,9 @@ private:
 	ItemStack m_wield_item_next;
 
 	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
-	v3f m_camera_custom_position = v3f(0.0, 0.0, 0.0);
-	v3f m_camera_custom_direction = v3f(0.0, 0.0, 1.0);
-	v3f m_camera_custom_up = v3f(0.0, 1.0, 0.0);
+	v3f m_camera_custom_position = v3f(0.0f, 0.0f, 0.0f);
+	v3f m_camera_custom_direction = v3f(0.0f, 0.0f, 1.0f);
+	v3f m_camera_custom_up = v3f(0.0f, 1.0f, 0.0f);
 
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -48,7 +48,7 @@ struct Nametag {
 	v3f nametag_pos;
 };
 
-enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT};
+enum CameraMode {CAMERA_MODE_FIRST, CAMERA_MODE_THIRD, CAMERA_MODE_THIRD_FRONT, CAMERA_MODE_CUSTOM};
 
 /*
 	Client camera class, manages the player and camera scene nodes, the viewing distance
@@ -138,8 +138,9 @@ public:
 			m_camera_mode = CAMERA_MODE_THIRD;
 		else if (m_camera_mode == CAMERA_MODE_THIRD)
 			m_camera_mode = CAMERA_MODE_THIRD_FRONT;
-		else
+		else if (m_camera_mode == CAMERA_MODE_THIRD_FRONT)
 			m_camera_mode = CAMERA_MODE_FIRST;
+		// CUSTOM is a CSM-controlled mode; do not enter or leave it
 	}
 
 	// Set the current camera mode
@@ -149,9 +150,17 @@ public:
 	}
 
 	//read the current camera mode
-	inline CameraMode getCameraMode()
+	inline CameraMode getCameraMode() const
 	{
 		return m_camera_mode;
+	}
+
+	// Set the current CUSTOM camera position
+	inline void setCameraCustomState(v3f position, v3f direction, v3f up)
+	{
+		m_camera_custom_position = position;
+		m_camera_custom_direction = direction;
+		m_camera_custom_up = up;
 	}
 
 	Nametag *addNametag(scene::ISceneNode *parent_node,
@@ -221,6 +230,9 @@ private:
 	ItemStack m_wield_item_next;
 
 	CameraMode m_camera_mode = CAMERA_MODE_FIRST;
+	v3f m_camera_custom_position = v3f(0.0, 0.0, 0.0);
+	v3f m_camera_custom_direction = v3f(0.0, 0.0, 1.0);
+	v3f m_camera_custom_up = v3f(0.0, 1.0, 0.0);
 
 	f32 m_cache_fall_bobbing_amount;
 	f32 m_cache_view_bobbing_amount;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -374,7 +374,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("max_block_send_distance", "10");
 	settings->setDefault("block_send_optimize_distance", "4");
 	settings->setDefault("server_side_occlusion_culling", "true");
-	settings->setDefault("csm_restriction_flags", "62");
+	settings->setDefault("csm_restriction_flags", "126");
 	settings->setDefault("csm_restriction_noderange", "0");
 	settings->setDefault("max_clearobjects_extra_loaded_blocks", "4096");
 	settings->setDefault("time_speed", "72");

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -991,6 +991,7 @@ enum CSMRestrictionFlags : u64 {
 	CSM_RF_READ_NODEDEFS = 0x00000008,    // Disable nodedef lookups
 	CSM_RF_LOOKUP_NODES = 0x00000010,     // Limit node lookups
 	CSM_RF_READ_PLAYERINFO = 0x00000020,  // Disable player info lookups
+	CSM_RF_CAMERA_CONTROL = 0x00000040,   // Disable camera control
 	CSM_RF_ALL = 0xFFFFFFFF,
 };
 

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -74,10 +74,13 @@ int LuaCamera::l_set_camera_mode(lua_State *L)
 
 int LuaCamera::l_set_camera_custom_state(lua_State *L)
 {
+	v3f a = check_v3f(L, 2);
+	v3f b = check_v3f(L, 3);
+	v3f c = check_v3f(L, 4);
 	Camera *camera = getobject(L, 1);
 	if (!camera)
 		return 0;
-	camera->setCameraCustomState(read_v3f(L, 2), read_v3f(L, 3), read_v3f(L, 4));
+	camera->setCameraCustomState(a, b, c);
 	return 0;
 }
 

--- a/src/script/lua_api/l_camera.cpp
+++ b/src/script/lua_api/l_camera.cpp
@@ -61,9 +61,23 @@ int LuaCamera::l_set_camera_mode(lua_State *L)
 	if (!lua_isnumber(L, 2))
 		return 0;
 
-	camera->setCameraMode((CameraMode)((int)lua_tonumber(L, 2)));
+	CameraMode mode = (CameraMode)((int)lua_tonumber(L, 2));
+
+	if ((mode == CAMERA_MODE_CUSTOM) && getClient(L)->checkCSMRestrictionFlag(CSMRestrictionFlags::CSM_RF_CAMERA_CONTROL))
+		return 0;
+
+	camera->setCameraMode(mode);
 	playercao->setVisible(camera->getCameraMode() > CAMERA_MODE_FIRST);
 	playercao->setChildrenVisible(camera->getCameraMode() > CAMERA_MODE_FIRST);
+	return 0;
+}
+
+int LuaCamera::l_set_camera_custom_state(lua_State *L)
+{
+	Camera *camera = getobject(L, 1);
+	if (!camera)
+		return 0;
+	camera->setCameraCustomState(read_v3f(L, 2), read_v3f(L, 3), read_v3f(L, 4));
 	return 0;
 }
 
@@ -217,6 +231,7 @@ void LuaCamera::Register(lua_State *L)
 
 const char LuaCamera::className[] = "Camera";
 const luaL_Reg LuaCamera::methods[] = {luamethod(LuaCamera, set_camera_mode),
+		luamethod(LuaCamera, set_camera_custom_state),
 		luamethod(LuaCamera, get_camera_mode), luamethod(LuaCamera, get_fov),
 		luamethod(LuaCamera, get_pos), luamethod(LuaCamera, get_offset),
 		luamethod(LuaCamera, get_look_dir),

--- a/src/script/lua_api/l_camera.h
+++ b/src/script/lua_api/l_camera.h
@@ -33,6 +33,7 @@ private:
 	static int gc_object(lua_State *L);
 
 	static int l_set_camera_mode(lua_State *L);
+	static int l_set_camera_custom_state(lua_State *L);
 	static int l_get_camera_mode(lua_State *L);
 
 	static int l_get_fov(lua_State *L);

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -57,6 +57,7 @@ const static CSMFlagDesc flagdesc_csm_restriction[] = {
 	{"read_nodedefs",     CSM_RF_READ_NODEDEFS},
 	{"lookup_nodes",      CSM_RF_LOOKUP_NODES},
 	{"read_playerinfo",   CSM_RF_READ_PLAYERINFO},
+	{"camera_control",    CSM_RF_CAMERA_CONTROL},
 	{NULL,      0}
 };
 


### PR DESCRIPTION
This commit adds functions for client-side-mods to control the camera.
(It's client-side for latency reasons. Supposedly CSMs are going to be server-sent at some point anyway. So having CSMs control the camera is the most flexible solution.)

It also adds a new restriction flag to prevent misuse of this for cheating, CAMERA\_CONTROL.

Add compact, short information about your PR for easier understanding:

- Goal of the PR
 Allow client-side-mods (presumably under the indirect control of the server) to control the camera.
- How does the PR work?
 A new camera mode is introduced that cannot be toggled into/out of, called CUSTOM. There is additional Camera state introduced to control the CUSTOM camera.
- Does it resolve any reported issue?
 Long-term, (post-server-sent-CSMs) this PR implements part of #3070
- If not a bug fix, why is this PR needed? What usecases does it solve?
 See #3070.

## To do

This PR is Ready for Review.

However, possible future things to consider: Without access to the keys/joystick & without a way to lock the player controls, it's limited in what it can do.

## How to test

Ensure that client-side-modding is enabled, specifically the "preview" clientmod.

Then use the `.cam_lock` and `cam_unlock` commands to test locking the camera to the player's current view and unlocking it again.
