### PR TITLE
fix segfault on returned null-pointer player object

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1794,6 +1794,10 @@ void Server::SendMovePlayer(session_t peer_id)
 {
 	RemotePlayer *player = m_env->getPlayer(peer_id);
 	assert(player);
+	if (player == NULL)
+		// player with peer vanished
+		return;
+
 	PlayerSAO *sao = player->getPlayerSAO();
 	assert(sao);
 


### PR DESCRIPTION
This PR should fix #9387

It checks if the resulting `RemotePlayer` from `ServerEnvironment::getPlayer(peer_id)` is null and skips the further processing/packet-sending.

## To do

* [ ] check if the `assert(player);` is still needed

This PR is Ready for Review.

## How to test

Everything should work as before

**EDIT**; what happened to the automated PR-checks...? :confused: 