### PR TITLE
Throw an error when too many noise octaves

### DIFF
--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -503,22 +503,31 @@ void Noise::setOctaves(int octaves)
 
 void Noise::resizeNoiseBuf(bool is3d)
 {
-	//maximum possible spread value factor
+	// Maximum possible spread value factor
 	float ofactor = (np.lacunarity > 1.0) ?
 		pow(np.lacunarity, np.octaves - 1) :
 		np.lacunarity;
 
-	// noise lattice point count
+	// Noise lattice point count
 	// (int)(sz * spread * ofactor) is # of lattice points crossed due to length
 	float num_noise_points_x = sx * ofactor / np.spread.X;
 	float num_noise_points_y = sy * ofactor / np.spread.Y;
 	float num_noise_points_z = sz * ofactor / np.spread.Z;
 
-	// protect against obviously invalid parameters
+	// Protect against obviously invalid parameters
 	if (num_noise_points_x > 1000000000.f ||
-		num_noise_points_y > 1000000000.f ||
-		num_noise_points_z > 1000000000.f)
+			num_noise_points_y > 1000000000.f ||
+			num_noise_points_z > 1000000000.f)
 		throw InvalidNoiseParamsException();
+
+	// Protect against an octave having a spread < 1, causing broken noise values
+	if (np.spread.X / ofactor < 1.0f ||
+			np.spread.Y / ofactor < 1.0f ||
+			np.spread.Z / ofactor < 1.0f) {
+		errorstream << "A noise parameter has too many octaves: "
+			<< np.octaves << " octaves" << std::endl;
+		throw InvalidNoiseParamsException("A noise parameter has too many octaves");
+	}
 
 	// + 2 for the two initial endpoints
 	// + 1 for potentially crossing a boundary due to offset


### PR DESCRIPTION
In MT master:
If the number of octaves in noise parameters is set too high (easily and often done when altering mapgen noise parameters), such that the smallest octave has a spread of less than 1, the resulting noise values become random-looking and unusable. However this occurs without any specific error message, causing users to wonder what the problem is. Sometimes the effect on noise values is easy to miss, resulting in undetected broken noise values.

For a mapgen example:
The screenshot below shows the effect of altering the number of octaves of Mapgen V7  'height_select' noise, which selects low or high terrain to create cliffs and plateaus.
The terrain on the left has the smallest octave with a spread slightly larger than 1, creating very finely detailed noise. This behaves correctly.
The terrain on the right has 1 more octave added, such that the smallest octave has a spread slightly smaller than 1. This causes random-looking and unusable noise values.

![screenshot_20200211_224815](https://user-images.githubusercontent.com/3686677/74290053-97db8c80-4d28-11ea-9dce-41cc0793b8cc.png)

This PR prints an error to make the problem clear, then throws a 'invalid noise params' exception (used elsewhere in that function) to shut down the engine.

This noise parameter check function `resizeNoiseBuf` is applied to any perlinmap type noise, either core mapgen or Lua API. It runs once per perlinmap type noise on world startup.