### PR TITLE
Fix param2 set to 240 if liquid source was renewed

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -762,7 +762,7 @@ void Map::transformLiquids(std::map<v3s16, MapBlock*> &modified_blocks,
 			n0.param2 = (flowing_down ? LIQUID_FLOW_DOWN_MASK : 0x00) | (new_node_level & LIQUID_LEVEL_MASK);
 		} else {
 			// set the liquid level and flow bit to 0
-			n0.param2 = ~(LIQUID_LEVEL_MASK | LIQUID_FLOW_DOWN_MASK);
+			n0.param2 = n0.param2 & ~(LIQUID_LEVEL_MASK | LIQUID_FLOW_DOWN_MASK);
 		}
 
 		// change the node.


### PR DESCRIPTION
When a liquid source spawns due to liquid renewing (`liquid_renewable=true`), it spawns with a `param2=240`.

I suppose this was unintentional, as the code responsible for this behavior doesn't match the comment above. See code.

The value 240 can be explained by the value of the constants being used.

## To do

This PR is ready for review.

## How to test

* Place two renewable liquid sources in such a way that a 3rd liquid node spawns
* Select a tool that points to liquids (like a bucket)
* Enable debug screen (F5)
* Point to the new liquid
* Check the value of `param2`

After this PR: 0
Without this PR: 240

## Warning
I *think* this PR should be harmless, as there's no `paramtype2` dedicated to liquid sources. But please still verify if everything is correct.