### PR TITLE
Hungarian: Disable fallback font

### DIFF
--- a/po/hu/minetest.po
+++ b/po/hu/minetest.po
@@ -875,7 +875,7 @@ msgstr "A megadott útvonalon nem létezik világ: "
 
 #: src/client/fontengine.cpp
 msgid "needs_fallback_font"
-msgstr "yes"
+msgstr "no"
 
 #: src/client/game.cpp
 msgid ""


### PR DESCRIPTION
Ref: #9383 

Disables fallback font for Hungarian as special characters are not showing up.

## How to test
1. Change the language to Hungarian (`hu`)
2. The "New" button for creating a new world will now correctly read "Új" instead of missing the Ú character.