### PR TITLE
Settings: Fix game minetest.conf flags overriding defaults

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -23,7 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "settings.h"
 #include "log.h"
 #include "util/strfnd.h"
-#include "defaultsettings.h" // for override_default_settings
+#include "defaultsettings.h" // for set_default_settings
 #include "mapgen/mapgen.h"   // for MapgenParams
 #include "util/string.h"
 
@@ -298,7 +298,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 	set_default_settings(g_settings);
 	Settings game_defaults;
 	getGameMinetestConfig(gamespec.path, game_defaults);
-	override_default_settings(g_settings, &game_defaults);
+	g_settings->overrideDefaults(&game_defaults);
 
 	infostream << "Initializing world at " << path << std::endl;
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -498,10 +498,3 @@ void set_default_settings(Settings *settings)
 #endif
 }
 
-void override_default_settings(Settings *settings, Settings *from)
-{
-	std::vector<std::string> names = from->getNames();
-	for (const auto &name : names) {
-		settings->setDefault(name, from->get(name));
-	}
-}

--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -32,6 +32,7 @@ MapSettingsManager::MapSettingsManager(Settings *user_settings,
 	m_user_settings(user_settings)
 {
 	assert(m_user_settings != NULL);
+	Mapgen::setDefaultSettings(m_map_settings);
 }
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -222,6 +222,8 @@ public:
 	 **************/
 
 	void setDefault(const std::string &name, const FlagDesc *flagdesc, u32 flags);
+	// Takes the provided setting values and uses them as new defaults
+	void overrideDefaults(Settings *other);
 	const FlagDesc *getFlagDescFallback(const std::string &name) const;
 
 	void registerChangedCallback(const std::string &name,


### PR DESCRIPTION
This is the fourth and hopefully last bug that I found during tests in #9374.

The game minetest.conf flags directly overwrote the global minetest.conf default values, resulting in unwanted erased mapgen flags. This commit will now combine the flags as follows:

1) `defaultsettings.cpp`
2) Global `minetest.conf`
3) Game `minetest.conf` (using default values from 2 and 1)
4) Global `minetest.conf` defaults are set to the outcome of 3
5) World is created by using the new setting value combined by the global `minetest.conf` defaults and value.

## To do

This PR is Ready for Review.

## How to test

1) Install the [repixture](https://forum.minetest.net/viewtopic.php?t=23235) game
2) Check whether the game's `minetest.conf` file contains a `mg*_*flags` override (as of right now it does)
3) Create a new world and join it
4) The world must be lit, latest after `/time 6000`

Additionally, run the test code from #9284 to ensure the flags are properly set after overriding the defaults. If it doesn't work, then your `minetest.conf` settings might be the problem.

