### PR TITLE
Show item description as statustext

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -609,6 +609,9 @@ enable_waving_plants (Waving plants) bool false
 #    the arm when the camera moves.
 arm_inertia (Arm inertia) bool true
 
+#    Show wielditem description when changing
+wielditem_statustext (Wielditem Statustext) bool true
+
 #    If FPS would go higher than this, limit it by sleeping
 #    to not waste CPU power for no benefit.
 fps_max (Maximum FPS) int 60 1

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -866,6 +866,7 @@ private:
 	scene::ISceneManager *smgr;
 	bool *kill;
 	std::string *error_message;
+	std::string wield_name;
 	bool *reconnect_requested;
 	scene::ISceneNode *skybox;
 
@@ -3767,6 +3768,13 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		ItemStack selected_item, hand_item;
 		ItemStack &tool_item = player->getWieldedItem(&selected_item, &hand_item);
 		camera->wield(tool_item);
+
+		// Show item description as statustext
+		std::string item_desc = selected_item.getDefinition(itemdef_manager).description;
+		if (wield_name != item_desc) {
+			m_game_ui->showStatusText(utf8_to_wide(item_desc));
+			wield_name = item_desc;
+		}
 	}
 
 	/*

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3770,10 +3770,12 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		camera->wield(tool_item);
 
 		// Show item description as statustext
-		std::string item_desc = selected_item.getDefinition(itemdef_manager).description;
-		if (wield_name != item_desc) {
-			m_game_ui->showStatusText(utf8_to_wide(item_desc));
-			wield_name = item_desc;
+		if (g_settings->getBool("wielditem_statustext")) {
+			std::string item_desc = selected_item.getDefinition(itemdef_manager).description;
+			if (wield_name != item_desc) {
+				m_game_ui->showStatusText(utf8_to_wide(item_desc));
+				wield_name = item_desc;
+			}
 		}
 	}
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -234,6 +234,7 @@ void set_default_settings(Settings *settings)
 #endif
 	settings->setDefault("enable_particles", "true");
 	settings->setDefault("arm_inertia", "true");
+	settings->setDefault("wielditem_statustext", "true");
 
 	settings->setDefault("enable_minimap", "true");
 	settings->setDefault("minimap_shape_round", "true");


### PR DESCRIPTION
A very simple change that will show the description of the item in hand as a statustext.

This was very lacking for playing on servers with a huge amount of items unknown to me.
The Lua implementation using hud is so slow and not stable in multiplayer that I decided to do it in C++.

**Lua examples:**
1) https://repo.or.cz/minetest_show_wielded_item.git/blob_plain/HEAD:/init.lua (107 lines)
2) https://github.com/minetest-mods/unified_inventory/blob/master/item_names.lua (76 lines)

My implementation is just... **actually 6 lines**. And this is handled on the **client side**, not the server. This means that it **works as quickly as changing a item in a wield**.
It supports color descriptions, by the way.

Used in MultiCraft since September 23.

This PR is a Ready for Review.

## How to test

Just start the game and select items in the inventory with the mouse wheel or buttons 1-9.