### PR TITLE
Updated manifest to fix crash loop on Android 10 when building from source

### DIFF
--- a/build/android/src/main/AndroidManifest.xml
+++ b/build/android/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
 		android:icon="@mipmap/ic_launcher"
 		android:label="${project}"
 		android:resizeableActivity="false"
+		android:testOnly="false"
+		android:requestLegacyExternalStorage="true"
 		tools:targetApi="n">
 
 		<meta-data


### PR DESCRIPTION
- Goal of the PR
Fixes boot loop in Android 10 caused by changes to how external storage is managed in this api version
- How does the PR work?
Adds 2 lines to AndroidManifest.xml.  `android:requestLegacyExternalStorage="true"` lets an Android 10 device use the now deprecated WRITE_EXTERNAL_STORAGE permission.  `android:testOnly="false"` is to prevent Android Studio from setting this value to true, which causes `adb install` to fail without the `-t` flag.
- Does it resolve any reported issue?
None that I have found
- If not a bug fix, why is this PR needed? What usecases does it solve?
This PR is needed to allow development on Android 10.  Without these changes a debug signed APK will always fail to read the `/sdcard/Minetest` folder on the device and crash.  I had no issues downloading and running the signed APK from the Play Store, however.

## To do
I built this branch off of the `stable-5` branch, not sure if this would need to go in `master`.  If there is documentation about how this project handles branch propagation, I have missed it.

This PR is Ready for Review.

## How to test
* Clone branch
* [Set up for development as per instructions here](https://dev.minetest.net/Android)
* make
* Install on Android 10 device
* Write permission properly granted to the `/sdcard/Minetest` folder, app does not crash loop on startup.