### PR TITLE
Add waypoint precision

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1392,6 +1392,10 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
+* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+  If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
+  Accordingly, there will be `n` steps behind the decimal dot.
+  `precision = 1000`, for example, would show values like `0.999`.
 * `number:` An integer containing the RGB value of the color used to draw the text.
 * `world_pos`: World position of the waypoint.
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1354,7 +1354,10 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `item`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons). If set to 0, distance is not shown.
+* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+  If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
+  Accordingly, there will be `n` steps behind the decimal dot.
+  `precision = 1000`, for example, would show values like `0.999`.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1354,6 +1354,7 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
+* `item`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons). If set to 0, distance is not shown.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -370,7 +370,7 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
-				// waypoints reusing item for precision, item = precision + 1
+				// waypoints reuse item to store the precision, item = precision + 1
 				u32 item = e->item;
 				float precision = item == 0 ? 10.0f : (item - 1);
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -373,11 +373,10 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				// item = precision + 1
 				float precision;
 				u32 item = e->item;
-				if (item == 0) {
+				if (item == 0)
 					precision = 10.0f;
-				} else {
+				else
 					precision = item - 1;
-				}
 
 				if (precision > 0) {
 					std::ostringstream os;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -370,13 +370,9 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
-				// item = precision + 1
-				float precision;
+				// waypoints reusing item for precision, item = precision + 1
 				u32 item = e->item;
-				if (item == 0)
-					precision = 10.0f;
-				else
-					precision = item - 1;
+				float precision = item == 0 ? 10.0f : (item - 1);
 
 				if (precision > 0) {
 					std::ostringstream os;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -351,8 +351,6 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 			case HUD_ELEM_WAYPOINT: {
 				v3f p_pos = player->getPosition() / BS;
 				v3f w_pos = e->world_pos * BS;
-				float distance = std::floor(10 * p_pos.getDistanceFrom(e->world_pos)) /
-					10.0f;
 				scene::ICameraSceneNode* camera =
 					RenderingEngine::get_scene_manager()->getActiveCamera();
 				w_pos -= intToFloat(camera_offset, BS);
@@ -372,11 +370,23 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
-				std::ostringstream os;
-				os << distance << e->text;
-				text = unescape_translate(utf8_to_wide(os.str()));
-				pos.Y += text_height;
-				font->draw(text.c_str(), size + pos, color);
+				// item = precision + 1
+				float precision;
+				u32 item = e->item;
+				if (item == 0) {
+					precision = 10.0f;
+				} else {
+					precision = item - 1;
+				}
+
+				if (precision > 0) {
+					std::ostringstream os;
+					float distance = std::floor(precision * p_pos.getDistanceFrom(e->world_pos)) / precision;
+					os << distance << e->text;
+					text = unescape_translate(utf8_to_wide(os.str()));
+					pos.Y += text_height;
+					font->draw(text.c_str(), size + pos, color);
+				}
 				break; }
 			default:
 				infostream << "Hud::drawLuaElements: ignoring drawform " << e->type <<

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,7 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
-		elem->item = getintfield_default(L, 2, "item", -1) + 1;
+		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,6 +1852,9 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	elem->item    = getintfield_default(L, 2, "item", 0);
+	if (elem->type == HUD_ELEM_WAYPOINT) {
+		elem->item = getintfield_default(L, 2, "item", -1) + 1;
+	}
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1851,10 +1851,10 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->name    = getstringfield_default(L, 2, "name", "");
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
-	elem->item    = getintfield_default(L, 2, "item", 0);
-	if (elem->type == HUD_ELEM_WAYPOINT) {
+	if (elem->type == HUD_ELEM_WAYPOINT)
 		elem->item = getintfield_default(L, 2, "item", -1) + 1;
-	}
+	else
+		elem->item    = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,6 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
+		// for waypoints, item = precision + 1
 		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1854,7 +1854,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	if (elem->type == HUD_ELEM_WAYPOINT)
 		elem->item = getintfield_default(L, 2, "item", -1) + 1;
 	else
-		elem->item    = getintfield_default(L, 2, "item", 0);
+		elem->item = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,7 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
-		// for waypoints, item = precision + 1
+		// waypoints reusing item for precision, item = precision + 1
 		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);


### PR DESCRIPTION
# Overview

- Goal of the PR: Add waypoint precision ("digits-after-dot"). If set to 0, distance is not shown.
- How does the PR work? It uses the `item` field to store precision.
- If not a bug fix, why is this PR needed? What usecases does it solve? Closes [this feature request](https://github.com/minetest/minetest/issues/8141).

## To do

This PR is Ready for Review.

## How to test

Create a mod with the following `init.lua`:
```lua
minetest.register_chatcommand(
	"test_waypoints",
	{
		description = "tests waypoints",
		func = function(sendername, params)
			local player = minetest.get_player_by_name(sendername)
			minetest.chat_send_all(
				"regular waypoint: " ..
					player:hud_add(
						{
							hud_elem_type = "waypoint",
							name = "origin",
							text = "",
							number = 0xFF0000,
							world_pos = vector.add(player:get_pos(), {x = 0, y = 2, z = 0})
						}
					)
			)
			minetest.chat_send_all(
				"better waypoint: " ..
					player:hud_add(
						{
							hud_elem_type = "waypoint",
							name = "origin",
							text = "",
							item = 5,
							number = 0xFF0000,
							world_pos = player:get_pos()
						}
					)
			)
			minetest.chat_send_all(
				"better waypoint without distance: " ..
					player:hud_add(
						{
							hud_elem_type = "waypoint",
							name = "origin",
							text = "",
							item = 0,
							number = 0xFF0000,
							world_pos = player:get_pos()
						}
					)
			)
		end
	}
)
```

## Screenshot

![Screenshot](https://user-images.githubusercontent.com/34514239/75459984-2be06180-5981-11ea-87bf-eaca5f11b917.png)