### PR TITLE
GUIInventoryList: fix dropping items when clicking outside of formspec window

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -176,7 +176,10 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 		Environment->getRootGUIElement()->getElementFromPoint(
 			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
 
-	bool ret = hovered && hovered->OnEvent(event);
+	if (!hovered || hovered->getID() == -1)
+		hovered = m_fs_menu;
+
+	bool ret = hovered->OnEvent(event);
 
 	IsVisible = was_visible;
 

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -176,6 +176,10 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 		Environment->getRootGUIElement()->getElementFromPoint(
 			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
 
+	// if the player clicks outside of the formspec window, hovered is not
+	// m_fs_menu, but some other weird element (with ID -1). we do however need
+	// hovered to be m_fs_menu as item dropping when clicking outside of the
+	// formspec window is handled in its OnEvent callback
 	if (!hovered || hovered->getID() == -1)
 		hovered = m_fs_menu;
 


### PR DESCRIPTION
Goal: Fix #9420.
For details see https://github.com/minetest/minetest/issues/9420#issuecomment-589985997.

## To do

This PR is a Ready for Review.

## How to test

- Open inventory.
- Pick an item.
- Move your cursor out of the formspec window.
- Click.
- Expected: The item is dropped.
