### PR TITLE
GUIFormSpecMenu: Add basic element highlighing debug feature

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3315,10 +3315,8 @@ void GUIFormSpecMenu::drawMenu()
 
 	if (hovered != NULL) {
 		if (m_show_debug) {
-			core::rect<s32> hovered_pos = hovered->getAbsolutePosition();
-			driver->draw2DRectangle(0x22FFFF00,
-				hovered->getAbsoluteClippingRect(),
-				&hovered_pos);
+			core::rect<s32> rect = hovered->getAbsoluteClippingRect();
+			driver->draw2DRectangle(0x22FFFF00, rect, &rect);
 		}
 
 		s32 id = hovered->getID();
@@ -3845,7 +3843,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		}
 
 		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug"))
-			m_show_debug ^= true;
+			m_show_debug = !m_show_debug;
 
 		if (event.KeyInput.PressedDown &&
 			(event.KeyInput.Key==KEY_RETURN ||

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3314,8 +3314,14 @@ void GUIFormSpecMenu::drawMenu()
 	bool hovered_element_found = false;
 
 	if (hovered != NULL) {
-		s32 id = hovered->getID();
+		if (m_show_debug) {
+			core::rect<s32> hovered_pos = hovered->getAbsolutePosition();
+			driver->draw2DRectangle(0x22FFFF00,
+				hovered->getAbsoluteClippingRect(),
+				&hovered_pos);
+		}
 
+		s32 id = hovered->getID();
 		u64 delta = 0;
 		if (id == -1) {
 			m_old_tooltip_id = id;
@@ -3837,6 +3843,10 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				(kp == getKeySetting("keymap_screenshot"))) {
 			m_client->makeScreenshot();
 		}
+
+		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug"))
+			m_show_debug ^= true;
+
 		if (event.KeyInput.PressedDown &&
 			(event.KeyInput.Key==KEY_RETURN ||
 			 event.KeyInput.Key==KEY_UP ||

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -341,6 +341,7 @@ private:
 	u16                 m_formspec_version = 1;
 	std::string         m_focused_element = "";
 	JoystickController *m_joystick;
+	bool m_show_debug = false;
 
 	typedef struct {
 		bool explicit_size;


### PR DESCRIPTION
This PR adds a highlighting feature to all formspecs which can be enabled using the debug key.
Possible additions in the future: a static text to describe the highlighted element (type name, ID, etc)

## To do

This PR is Ready for Review.

## How to test

1) Press the debug key (default: F5)

![grafik](https://user-images.githubusercontent.com/1497498/75098129-c40dcd80-55b2-11ea-8acf-50efc129c4e9.png)

