### PR TITLE
Implement the 'userdata' commandline option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,11 +158,15 @@ int main(int argc, char *argv[])
 
 	porting::signal_handler_init();
 
+	std::string userdata;
+	if (cmd_args.exists("userdata"))
+		userdata = cmd_args.get("userdata");
+
 #ifdef __ANDROID__
 	porting::initAndroid();
-	porting::initializePathsAndroid();
+	porting::initializePathsAndroid(userdata);
 #else
-	porting::initializePaths();
+	porting::initializePaths(userdata);
 #endif
 
 	if (!create_userdata_path()) {
@@ -328,6 +332,8 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Feature an interactive terminal (Only works when using minetestserver or with --server)"))));
 	allowed_options->insert(std::make_pair("recompress", ValueSpec(VALUETYPE_FLAG,
 			_("Recompress the blocks of the given map database."))));
+	allowed_options->insert(std::make_pair("userdata", ValueSpec(VALUETYPE_STRING,
+			_("Set directory for storing user data"))));
 #ifndef SERVER
 	allowed_options->insert(std::make_pair("speedtests", ValueSpec(VALUETYPE_FLAG,
 			_("Run speed tests"))));

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -403,7 +403,7 @@ const char *getHomeOrFail()
 //// Windows
 #if defined(_WIN32)
 
-bool setSystemPaths()
+bool setSystemPaths(const std::string &userdata)
 {
 	char buf[BUFSIZ];
 
@@ -426,7 +426,10 @@ bool setSystemPaths()
 	DWORD len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
 	FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
 
-	path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
+	if (userdata.empty())
+		path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
+	else
+		path_user = userdata;
 	return true;
 }
 
@@ -434,7 +437,7 @@ bool setSystemPaths()
 //// Linux
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 
-bool setSystemPaths()
+bool setSystemPaths(const std::string &userdata)
 {
 	char buf[BUFSIZ];
 
@@ -486,8 +489,11 @@ bool setSystemPaths()
 	}
 
 #ifndef __ANDROID__
-	path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
-		+ PROJECT_NAME;
+	if (userdata.empty())
+		path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
+			+ PROJECT_NAME;
+	else
+		path_user = userdata;
 #endif
 
 	return true;
@@ -497,7 +503,7 @@ bool setSystemPaths()
 //// Mac OS X
 #elif defined(__APPLE__)
 
-bool setSystemPaths()
+bool setSystemPaths(const std::string &userdata)
 {
 	CFBundleRef main_bundle = CFBundleGetMainBundle();
 	CFURLRef resources_url = CFBundleCopyResourcesDirectoryURL(main_bundle);
@@ -510,20 +516,26 @@ bool setSystemPaths()
 	}
 	CFRelease(resources_url);
 
-	path_user = std::string(getHomeOrFail())
-		+ "/Library/Application Support/"
-		+ PROJECT_NAME;
+	if (userdata.empty())
+		path_user = std::string(getHomeOrFail())
+			+ "/Library/Application Support/"
+			+ PROJECT_NAME;
+	else
+		path_user = userdata;
 	return true;
 }
 
 
 #else
 
-bool setSystemPaths()
+bool setSystemPaths(const std::string &userdata)
 {
 	path_share = STATIC_SHAREDIR;
-	path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
-		+ lowercase(PROJECT_NAME);
+	if (userdata.empty())
+		path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
+			+ lowercase(PROJECT_NAME);
+	else
+		path_user = userdata;
 	return true;
 }
 
@@ -550,7 +562,7 @@ void migrateCachePath()
 	}
 }
 
-void initializePaths()
+void initializePaths(const std::string &userdata)
 {
 #if RUN_IN_PLACE
 	char buf[BUFSIZ];
@@ -597,7 +609,7 @@ void initializePaths()
 #else
 	infostream << "Using system-wide paths (NOT RUN_IN_PLACE)" << std::endl;
 
-	if (!setSystemPaths())
+	if (!setSystemPaths(userdata))
 		errorstream << "Failed to get one or more system-wide path" << std::endl;
 
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -170,7 +170,7 @@ void migrateCachePath();
 /*
 	Initialize path_*.
 */
-void initializePaths();
+void initializePaths(const std::string &userdata);
 
 /*
 	Return system information

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -152,7 +152,7 @@ static std::string javaStringToUTF8(jstring js)
 	return str;
 }
 
-void initializePathsAndroid()
+void initializePathsAndroid(const std::string &userdata)
 {
 	// Set user and share paths
 	{
@@ -162,7 +162,10 @@ void initializePathsAndroid()
 				"porting::initializePathsAndroid unable to find Java getUserDataPath method");
 		jobject result = jnienv->CallObjectMethod(app_global->activity->clazz, getUserDataPath);
 		const char *javachars = jnienv->GetStringUTFChars((jstring) result, nullptr);
-		path_user = javachars;
+		if (userdata.empty())
+			path_user = javachars;
+		else
+			path_user = userdata;
 		path_share = javachars;
 		path_locale  = path_share + DIR_DELIM + "locale";
 		jnienv->ReleaseStringUTFChars((jstring) result, javachars);

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -45,7 +45,7 @@ void cleanupAndroid();
  * Initializes path_* variables for Android
  * @param env Android JNI environment
  */
-void initializePathsAndroid();
+void initializePathsAndroid(const std::string &userdata);
 
 /**
  * show text input dialog in java


### PR DESCRIPTION
This patch adds support for a 'userdata' commandline option to allow
users to configure the path for storing user data. This should give
users more control over where data is stored on their systems.

See: https://github.com/minetest/minetest/issues/6869