### PR TITLE
Sanitize world names when creating them, and store the original name elsewhere

### DIFF
--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -213,6 +213,21 @@ bool getWorldExists(const std::string &world_path)
 			fs::PathExists(world_path + DIR_DELIM + "world.mt"));
 }
 
+//! Try to get the displayed name of a world
+std::string getWorldName(const std::string &world_path, const std::string &default_name)
+{
+	std::string conf_path = world_path + DIR_DELIM + "world.mt";
+	Settings conf;
+	bool succeeded = conf.readConfigFile(conf_path.c_str());
+	if (!succeeded) {
+		return default_name;
+	}
+
+	if (!conf.exists("world_name"))
+		return default_name;
+	return conf.get("world_name");
+}
+
 std::string getWorldGameId(const std::string &world_path, bool can_be_legacy)
 {
 	std::string conf_path = world_path + DIR_DELIM + "world.mt";
@@ -259,7 +274,7 @@ std::vector<WorldSpec> getAvailableWorlds()
 			if (!dln.dir)
 				continue;
 			std::string fullpath = worldspath + DIR_DELIM + dln.name;
-			std::string name = dln.name;
+			std::string name = getWorldName(fullpath, dln.name);
 			// Just allow filling in the gameid always for now
 			bool can_be_legacy = true;
 			std::string gameid = getWorldGameId(fullpath, can_be_legacy);
@@ -288,8 +303,19 @@ std::vector<WorldSpec> getAvailableWorlds()
 	return worlds;
 }
 
-bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamespec)
+bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+		const SubgameSpec &gamespec, bool mustCreateNew)
 {
+	std::string final_path = path;
+
+	// If we're creating a new world, ensure that the path isn't already taken
+	int counter = 1;
+	while(mustCreateNew && fs::PathExists(final_path) && counter < 100)
+	{
+		final_path = path + "_" + std::to_string(counter);
+		counter++;
+	}
+
 	// Override defaults with those provided by the game.
 	// We clear and reload the defaults because the defaults
 	// might have been overridden by other subgame config
@@ -300,15 +326,16 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 	getGameMinetestConfig(gamespec.path, game_defaults);
 	g_settings->overrideDefaults(&game_defaults);
 
-	infostream << "Initializing world at " << path << std::endl;
+	infostream << "Initializing world at " << final_path << std::endl;
 
-	fs::CreateAllDirs(path);
+	fs::CreateAllDirs(final_path);
 
 	// Create world.mt if does not already exist
-	std::string worldmt_path = path + DIR_DELIM "world.mt";
+	std::string worldmt_path = final_path + DIR_DELIM "world.mt";
 	if (!fs::PathExists(worldmt_path)) {
 		Settings conf;
 
+		conf.set("world_name", name);
 		conf.set("gameid", gamespec.id);
 		conf.set("backend", "sqlite3");
 		conf.set("player_backend", "sqlite3");
@@ -321,11 +348,10 @@ bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamesp
 	}
 
 	// Create map_meta.txt if does not already exist
-	std::string map_meta_path = path + DIR_DELIM + "map_meta.txt";
+	std::string map_meta_path = final_path + DIR_DELIM + "map_meta.txt";
 	if (!fs::PathExists(map_meta_path)) {
 		verbosestream << "Creating map_meta.txt (" << map_meta_path << ")"
 			      << std::endl;
-		fs::CreateAllDirs(path);
 		std::ostringstream oss(std::ios_base::binary);
 
 		Settings conf;

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -360,7 +360,7 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 	std::string map_meta_path = final_path + DIR_DELIM + "map_meta.txt";
 	if (!fs::PathExists(map_meta_path)) {
 		verbosestream << "Creating map_meta.txt (" << map_meta_path << ")"
-				  << std::endl;
+			      << std::endl;
 		std::ostringstream oss(std::ios_base::binary);
 
 		Settings conf;

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -310,8 +310,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 
 	// If we're creating a new world, ensure that the path isn't already taken
 	int counter = 1;
-	while(mustCreateNew && fs::PathExists(final_path) && counter < 100)
-	{
+	while(mustCreateNew && fs::PathExists(final_path) && counter < 100) {
 		final_path = path + "_" + std::to_string(counter);
 		counter++;
 	}

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -306,8 +306,8 @@ std::vector<WorldSpec> getAvailableWorlds()
 	return worlds;
 }
 
-bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool create_world, std::string *error)
+void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+		const SubgameSpec &gamespec, bool create_world)
 {
 	std::string final_path = path;
 
@@ -320,10 +320,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		}
 
 		if (fs::PathExists(final_path)) {
-			if (error != nullptr) {
-				*error = "Too many similar filenames";
-			}
-			return false;
+			throw BaseException("Too many similar filenames");
 		}
 	}
 
@@ -355,10 +352,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		conf.setBool("enable_damage", g_settings->getBool("enable_damage"));
 
 		if (!conf.updateConfigFile(worldmt_path.c_str())) {
-			if (error != nullptr) {
-				*error = "Failed to update the config file";
-			}
-			return false;
+			throw BaseException("Failed to update the config file");
 		}
 	}
 
@@ -366,7 +360,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 	std::string map_meta_path = final_path + DIR_DELIM + "map_meta.txt";
 	if (!fs::PathExists(map_meta_path)) {
 		verbosestream << "Creating map_meta.txt (" << map_meta_path << ")"
-			      << std::endl;
+				  << std::endl;
 		std::ostringstream oss(std::ios_base::binary);
 
 		Settings conf;
@@ -379,5 +373,4 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 
 		fs::safeWriteToFile(map_meta_path, oss.str());
 	}
-	return true;
 }

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -307,12 +307,12 @@ std::vector<WorldSpec> getAvailableWorlds()
 }
 
 bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool mustCreateNew, std::string *error)
+		const SubgameSpec &gamespec, bool create_world, std::string *error)
 {
 	std::string final_path = path;
 
 	// If we're creating a new world, ensure that the path isn't already taken
-	if (mustCreateNew) {
+	if (create_world) {
 		int counter = 1;
 		while (fs::PathExists(final_path) && counter < MAX_WORLD_NAMES) {
 			final_path = path + "_" + std::to_string(counter);

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -310,7 +310,7 @@ bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 
 	// If we're creating a new world, ensure that the path isn't already taken
 	int counter = 1;
-	while(mustCreateNew && fs::PathExists(final_path) && counter < 100) {
+	while (mustCreateNew && fs::PathExists(final_path) && counter < 100) {
 		final_path = path + "_" + std::to_string(counter);
 		counter++;
 	}

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -91,4 +91,4 @@ std::vector<WorldSpec> getAvailableWorlds();
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
 bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool mustCreateNew, std::string *error);
+		const SubgameSpec &gamespec, bool create_world, std::string *error);

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -90,5 +90,5 @@ std::vector<WorldSpec> getAvailableWorlds();
 
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
-bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool create_world, std::string *error);
+void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+		const SubgameSpec &gamespec, bool create_world);

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -91,4 +91,4 @@ std::vector<WorldSpec> getAvailableWorlds();
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
 bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool mustCreateNew);
+		const SubgameSpec &gamespec, bool mustCreateNew, std::string *error);

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -63,6 +63,8 @@ std::set<std::string> getAvailableGameIds();
 std::vector<SubgameSpec> getAvailableGames();
 
 bool getWorldExists(const std::string &world_path);
+//! Try to get the displayed name of a world
+std::string getWorldName(const std::string &world_path, const std::string &default_name);
 std::string getWorldGameId(const std::string &world_path, bool can_be_legacy = false);
 
 struct WorldSpec
@@ -88,4 +90,5 @@ std::vector<WorldSpec> getAvailableWorlds();
 
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
-bool loadGameConfAndInitWorld(const std::string &path, const SubgameSpec &gamespec);
+bool loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+		const SubgameSpec &gamespec, bool mustCreateNew);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -626,8 +626,9 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 			(gameidx < (int) games.size())) {
 
 		// Create world if it doesn't exist
-		if (!loadGameConfAndInitWorld(path, name, games[gameidx], true)) {
-			lua_pushstring(L, "Failed to initialize world");
+		std::string error;
+		if (!loadGameConfAndInitWorld(path, name, games[gameidx], true, &error)) {
+			lua_pushstring(L, std::string("Failed to initialize world: " + error).c_str());
 		} else {
 			lua_pushnil(L);
 		}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -618,7 +618,7 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 
 	std::string path = porting::path_user + DIR_DELIM
 			"worlds" + DIR_DELIM
-			+ name;
+			+ "world_" + sanitizeDirName(name);
 
 	std::vector<SubgameSpec> games = getAvailableGames();
 
@@ -626,7 +626,7 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 			(gameidx < (int) games.size())) {
 
 		// Create world if it doesn't exist
-		if (!loadGameConfAndInitWorld(path, games[gameidx])) {
+		if (!loadGameConfAndInitWorld(path, name, games[gameidx], true)) {
 			lua_pushstring(L, "Failed to initialize world");
 		} else {
 			lua_pushnil(L);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -626,11 +626,11 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 			(gameidx < (int) games.size())) {
 
 		// Create world if it doesn't exist
-		std::string error;
-		if (!loadGameConfAndInitWorld(path, name, games[gameidx], true, &error)) {
-			lua_pushstring(L, (std::string("Failed to initialize world: ") + error).c_str());
-		} else {
+		try {
+			loadGameConfAndInitWorld(path, name, games[gameidx], true);
 			lua_pushnil(L);
+		} catch (const BaseException &e) {
+			lua_pushstring(L, (std::string("Failed to initialize world: ") + e.what()).c_str());
 		}
 	} else {
 		lua_pushstring(L, "Invalid game index");

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -618,7 +618,7 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 
 	std::string path = porting::path_user + DIR_DELIM
 			"worlds" + DIR_DELIM
-			+ "world_" + sanitizeDirName(name);
+			+ sanitizeDirName(name, "world_");
 
 	std::vector<SubgameSpec> games = getAvailableGames();
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -628,7 +628,7 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 		// Create world if it doesn't exist
 		std::string error;
 		if (!loadGameConfAndInitWorld(path, name, games[gameidx], true, &error)) {
-			lua_pushstring(L, std::string("Failed to initialize world: " + error).c_str());
+			lua_pushstring(L, (std::string("Failed to initialize world: ") + error).c_str());
 		} else {
 			lua_pushnil(L);
 		}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -358,8 +358,8 @@ void Server::init()
 	// Create world if it doesn't exist
 	std::string error;
 	if (!loadGameConfAndInitWorld(m_path_world,
-            fs::GetFilenameFromPath(m_path_world.c_str()),
-            m_gamespec, false, &error))
+			fs::GetFilenameFromPath(m_path_world.c_str()),
+			m_gamespec, false, &error))
 		throw ServerError("Failed to initialize world: " + error);
 
 	// Create emerge manager

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -356,7 +356,9 @@ void Server::init()
 	infostream << "- game:   " << m_gamespec.path << std::endl;
 
 	// Create world if it doesn't exist
-	if (!loadGameConfAndInitWorld(m_path_world, m_gamespec))
+	if (!loadGameConfAndInitWorld(m_path_world,
+				fs::GetFilenameFromPath(m_path_world.c_str()),
+				m_gamespec, false))
 		throw ServerError("Failed to initialize world");
 
 	// Create emerge manager

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -356,11 +356,13 @@ void Server::init()
 	infostream << "- game:   " << m_gamespec.path << std::endl;
 
 	// Create world if it doesn't exist
-	std::string error;
-	if (!loadGameConfAndInitWorld(m_path_world,
-			fs::GetFilenameFromPath(m_path_world.c_str()),
-			m_gamespec, false, &error))
-		throw ServerError("Failed to initialize world: " + error);
+	try {
+		loadGameConfAndInitWorld(m_path_world,
+				fs::GetFilenameFromPath(m_path_world.c_str()),
+				m_gamespec, false);
+	} catch (const BaseException &e) {
+		throw ServerError(std::string("Failed to initialize world: ") + e.what());
+	}
 
 	// Create emerge manager
 	m_emerge = new EmergeManager(this);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -358,8 +358,8 @@ void Server::init()
 	// Create world if it doesn't exist
 	std::string error;
 	if (!loadGameConfAndInitWorld(m_path_world,
-				fs::GetFilenameFromPath(m_path_world.c_str()),
-				m_gamespec, false, &error))
+            fs::GetFilenameFromPath(m_path_world.c_str()),
+            m_gamespec, false, &error))
 		throw ServerError("Failed to initialize world: " + error);
 
 	// Create emerge manager

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -356,10 +356,11 @@ void Server::init()
 	infostream << "- game:   " << m_gamespec.path << std::endl;
 
 	// Create world if it doesn't exist
+	std::string error;
 	if (!loadGameConfAndInitWorld(m_path_world,
 				fs::GetFilenameFromPath(m_path_world.c_str()),
-				m_gamespec, false))
-		throw ServerError("Failed to initialize world");
+				m_gamespec, false, &error))
+		throw ServerError("Failed to initialize world: " + error);
 
 	// Create emerge manager
 	m_emerge = new EmergeManager(this);

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -890,7 +890,7 @@ std::wstring translate_string(const std::wstring &s)
 #endif
 }
 
-static const std::wstring disallowed_dir_names[] {
+static const std::array<std::wstring, 22> disallowed_dir_names = {
 	// Problematic filenames from here:
 	// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
 	L"CON",
@@ -916,28 +916,26 @@ static const std::wstring disallowed_dir_names[] {
 	L"LPT8",
 	L"LPT9",
 };
-static const int disallowed_name_count = 22;
 
 /**
  * List of characters that are blacklisted from created directories
  */
-static const wchar_t disallowed_path_chars[] {
-    // Problematic characters from here:
-    // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
-    '<',
-    '>',
-    ':',
-    '\"',
-    '/',
-    '\\',
-    '|',
-    '?',
-    '*',
+static const std::array<wchar_t, 10> disallowed_path_chars = {
+	// Problematic characters from here:
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
+	'<',
+	'>',
+	':',
+	'\"',
+	'/',
+	'\\',
+	'|',
+	'?',
+	'*',
 
-    // Disallowed to avoid patterns that resolve into path segments, like '..'
-    '.',
+	// Disallowed to avoid patterns that resolve into path segments, like '..'
+	'.',
 };
-static const int disallowed_char_count = 10;
 
 /**
  * Sanitize the name of a new directory. This consists of two stages:
@@ -949,8 +947,8 @@ std::string sanitizeDirName(const std::string &str, const std::string &unsafe_pr
 {
 	std::wstring tmp = utf8_to_wide(str);
 
-	for(int i = 0; i < disallowed_name_count; ++i) {
-		if (str_equal(tmp, disallowed_dir_names[i], true)) {
+	for(std::wstring disallowed_name : disallowed_dir_names) {
+		if (str_equal(tmp, disallowed_name, true)) {
 			tmp = utf8_to_wide(unsafe_prefix) + tmp;
 		}
 	}
@@ -962,8 +960,8 @@ std::string sanitizeDirName(const std::string &str, const std::string &unsafe_pr
 		if (tmp[i] < 32) {
 			is_valid = false;
 		} else if (tmp[i] < 128) {
-			for (int j = 0; j < disallowed_char_count; ++j) {
-				if (tmp[i] == disallowed_path_chars[j]) {
+			for (wchar_t disallowed_char : disallowed_path_chars) {
+				if (tmp[i] == disallowed_char) {
 					is_valid = false;
 					break;
 				}

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -889,3 +889,21 @@ std::wstring translate_string(const std::wstring &s)
 	return translate_string(s, g_client_translations);
 #endif
 }
+
+/**
+ * Remove 'unsafe' characters from a directory name by replacing them with '_'
+ */
+std::string sanitizeDirName(const std::string &str)
+{
+	std::string tmp = str;
+	for(ulong i = 0; i < str.length(); i++) {
+		if (tmp[i] < '0'
+				|| (tmp[i] > '9' && tmp[i] < 'A')
+				|| (tmp[i] > 'Z' && tmp[i] < 'a')
+				|| (tmp[i] > 'z')) {
+			tmp[i] = '_';
+		}
+	}
+
+	return tmp;
+}

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -933,9 +933,10 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
 {
 	std::wstring safe_name = utf8_to_wide(str);
 
-	for(std::wstring disallowed_name : disallowed_dir_names) {
+	for (std::wstring disallowed_name : disallowed_dir_names) {
 		if (str_equal(safe_name, disallowed_name, true)) {
 			safe_name = utf8_to_wide(optional_prefix) + safe_name;
+			break;
 		}
 	}
 
@@ -950,9 +951,8 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
 					== std::wstring::npos;
 		}
 
-		if (!is_valid) {
+		if (!is_valid)
 			safe_name[i] = '_';
-		}
 	}
 
 	return wide_to_utf8(safe_name);

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "translation.h"
 
 #include <algorithm>
+#include <array>
 #include <sstream>
 #include <iomanip>
 #include <map>

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -946,7 +946,8 @@ std::string sanitizeDirName(const std::string &str, const std::string &optional_
 		if (safe_name[i] < 32) {
 			is_valid = false;
 		} else if (safe_name[i] < 128) {
-			is_valid = disallowed_path_chars.find_first_of(safe_name[i]) == std::wstring::npos;
+			is_valid = disallowed_path_chars.find_first_of(safe_name[i])
+					== std::wstring::npos;
 		}
 
 		if (!is_valid) {

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -896,7 +896,7 @@ std::wstring translate_string(const std::wstring &s)
 std::string sanitizeDirName(const std::string &str)
 {
 	std::string tmp = str;
-	for(ulong i = 0; i < str.length(); i++) {
+	for(unsigned long i = 0; i < str.length(); i++) {
 		if (tmp[i] < '0'
 				|| (tmp[i] > '9' && tmp[i] < 'A')
 				|| (tmp[i] > 'Z' && tmp[i] < 'a')

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -748,6 +748,9 @@ inline irr::core::stringw utf8_to_stringw(const std::string &input)
 }
 
 /**
- * Remove 'unsafe' characters from a directory name by replacing them with '_'
+ * Sanitize the name of a new directory. This consists of two stages:
+ * 1. Check for 'reserved filenames' that can't be used on some filesystems
+ *    and prefix them
+ * 2. Remove 'unsafe' characters from the name by replacing them with '_'
  */
-std::string sanitizeDirName(const std::string &str);
+std::string sanitizeDirName(const std::string &str, const std::string &unsafe_prefix);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -753,4 +753,4 @@ inline irr::core::stringw utf8_to_stringw(const std::string &input)
  *    and prefix them
  * 2. Remove 'unsafe' characters from the name by replacing them with '_'
  */
-std::string sanitizeDirName(const std::string &str, const std::string &unsafe_prefix);
+std::string sanitizeDirName(const std::string &str, const std::string &optional_prefix);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -746,3 +746,8 @@ inline irr::core::stringw utf8_to_stringw(const std::string &input)
 	std::wstring str = utf8_to_wide(input);
 	return irr::core::stringw(str.c_str());
 }
+
+/**
+ * Remove 'unsafe' characters from a directory name by replacing them with '_'
+ */
+std::string sanitizeDirName(const std::string &str);


### PR DESCRIPTION
This PR addresses #4875 by preventing potentially invalid paths from being created when making a new world.

The way it works is fairly simplistic: If a character matches against a blacklist (containing path characters and chars forbidden by certain filesystems), it is replaced by '\_' in the path. The display name is stored in `world.mt`, and duplicate file names are resolved by adding an incrementing suffix (\_1, \_2, \_3, etc) as suggested in the original issue. Additionally, the world_ prefix is added if the name matches a blacklist of 'reserved names' that some filesystems have trouble with (see the original issue for more details).

## Testing
Create worlds, and put garbage into their names. Try making worlds with different names but duplicate sanitized names. Try hosting/launching these worlds. Ensure that these worlds aren't being duplicated disappearing for any reason. Check anywhere in the UI that you would expect to see the world name: Is the name you entered there, or is it the sanitized version?

## Known Issues
- Names are still case-sensitive. On case-insensitive filesystems, collisions can probably still happen (needs testing)