### PR TITLE
GUIHyperText: Fix bug with UTF-8 chars in action name

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -405,7 +405,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 	AttrsList attrs;
 	while (c != L'>') {
 		std::string attr_name = "";
-		std::string attr_val = "";
+		core::stringw attr_val = L"";
 
 		while (c == ' ') {
 			c = text[++cursor];
@@ -435,13 +435,13 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 			return 0;
 
 		while (c != L'>' && c != L' ') {
-			attr_val += (char)c;
+			attr_val += c;
 			c = text[++cursor];
 			if (c == L'\0')
 				return 0;
 		}
 
-		attrs[attr_name] = attr_val;
+		attrs[attr_name] = stringw_to_utf8(attr_val);
 	}
 
 	++cursor; // Last ">"
@@ -486,7 +486,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 		else
 			enterElement(ELEMENT_ITEM);
 
-		m_element->text = strtostrw(attrs["name"]);
+		m_element->text = utf8_to_stringw(attrs["name"]);
 
 		if (attrs.count("float")) {
 			if (attrs["float"] == "left")
@@ -626,7 +626,7 @@ TextDrawer::TextDrawer(const wchar_t *text, Client *client,
 				if (e.type == ParsedText::ELEMENT_IMAGE) {
 					video::ITexture *texture =
 						m_client->getTextureSource()->
-							getTexture(strwtostr(e.text));
+							getTexture(stringw_to_utf8(e.text));
 					if (texture)
 						dim = texture->getOriginalSize();
 				}
@@ -952,7 +952,7 @@ void TextDrawer::draw(const core::rect<s32> &dest_rect,
 			case ParsedText::ELEMENT_IMAGE: {
 				video::ITexture *texture =
 						m_client->getTextureSource()->getTexture(
-								strwtostr(el.text));
+								stringw_to_utf8(el.text));
 				if (texture != 0)
 					m_environment->getVideoDriver()->draw2DImage(
 							texture, rect,
@@ -965,7 +965,7 @@ void TextDrawer::draw(const core::rect<s32> &dest_rect,
 			case ParsedText::ELEMENT_ITEM: {
 				IItemDefManager *idef = m_client->idef();
 				ItemStack item;
-				item.deSerialize(strwtostr(el.text), idef);
+				item.deSerialize(stringw_to_utf8(el.text), idef);
 
 				drawItemStack(
 						m_environment->getVideoDriver(),
@@ -1083,7 +1083,7 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 				for (auto &tag : element->tags) {
 					if (tag->name == "action") {
 						Text = core::stringw(L"action:") +
-						       strtostrw(tag->attrs["name"]);
+						       utf8_to_stringw(tag->attrs["name"]);
 						if (Parent) {
 							SEvent newEvent;
 							newEvent.EventType = EET_GUI_EVENT;

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -860,28 +860,3 @@ std::wstring translate_string(const std::wstring &s) {
 	translate_all(s, i, res);
 	return res;
 }
-
-/**
- * Create a std::string from a irr::core:stringw.
- */
-std::string strwtostr(const irr::core::stringw &str)
-{
-	std::string text = core::stringc(str.c_str()).c_str();
-	return text;
-}
-
-/**
- * Create a irr::core:stringw from a std::string.
- */
-irr::core::stringw strtostrw(const std::string &str)
-{
-	size_t size = str.size();
-	// s.size() doesn't include NULL terminator
-	wchar_t *text = new wchar_t[size + sizeof(wchar_t)];
-	const char *data = &str[0];
-
-	mbsrtowcs(text, &data, size, NULL);
-
-	text[size] = L'\0';
-	return text;
-}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -726,11 +726,19 @@ inline std::string str_join(const std::vector<std::string> &list,
 }
 
 /**
- * Create a std::string from a irr::core::stringw.
+ * Create a UTF8 std::string from a irr::core::stringw.
  */
-std::string strwtostr(const irr::core::stringw &str);
+inline std::string stringw_to_utf8(const irr::core::stringw &input)
+{
+	std::wstring str(input.c_str());
+	return wide_to_utf8(str);
+}
 
-/**
- * Create a irr::core:stringw from a std::string.
- */
-irr::core::stringw strtostrw(const std::string &str);
+ /**
+  * Create a irr::core:stringw from a UTF8 std::string.
+  */
+inline irr::core::stringw utf8_to_stringw(const std::string &input)
+{
+	std::wstring str = utf8_to_wide(input);
+	return irr::core::stringw(str.c_str());
+}


### PR DESCRIPTION
A patch provided by [EvidenceBKidscode](https://www.evidenceb.com) that fixes a bug when the action name have accented characters. The string received by the fields handler is invalid.

This also simplify the UTF-8 stringw conversion.