### PR TITLE
Chatcommand: Show help message if func returns false without message

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -70,9 +70,11 @@ core.register_on_chat_message(function(name, message)
 		if success == false and result == nil then
 			core.chat_send_player(name, "-!- Invalid command usage")
 			local help_def = core.registered_chatcommands["help"]
-			local _, helpmsg = help_def.func(name, cmd)
-			if helpmsg then
-				core.chat_send_player(name, helpmsg)
+			if help_def then
+				local _, helpmsg = help_def.func(name, cmd)
+				if helpmsg then
+					core.chat_send_player(name, helpmsg)
+				end
 			end
 		elseif result then
 			core.chat_send_player(name, result)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -67,7 +67,7 @@ core.register_on_chat_message(function(name, message)
 	if has_privs then
 		core.set_last_run_mod(cmd_def.mod_origin)
 		local success, result = cmd_def.func(name, param)
-		if success == false and result == "/help" then
+		if success == false and result == nil then
 			core.chat_send_player(name, "-!- Invalid command usage")
 			local help_def = core.registered_chatcommands["help"]
 			local _, helpmsg = help_def.func(name, cmd)

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -66,8 +66,15 @@ core.register_on_chat_message(function(name, message)
 	local has_privs, missing_privs = core.check_player_privs(name, cmd_def.privs)
 	if has_privs then
 		core.set_last_run_mod(cmd_def.mod_origin)
-		local _, result = cmd_def.func(name, param)
-		if result then
+		local success, result = cmd_def.func(name, param)
+		if success == false and result == "/help" then
+			core.chat_send_player(name, "-!- Invalid command usage")
+			local help_def = core.registered_chatcommands["help"]
+			local _, helpmsg = help_def.func(name, cmd)
+			if helpmsg then
+				core.chat_send_player(name, helpmsg)
+			end
+		elseif result then
 			core.chat_send_player(name, result)
 		end
 	else

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7413,8 +7413,8 @@ Used by `minetest.register_chatcommand`.
 
         func = function(name, param),
         -- Called when command is run. Returns boolean success and text output.
-        -- Special case: The help message is shown to the player if it
-        -- returns `false, "/help"`
+        -- Special case: The help message is shown to the player if `func`
+        -- returns false without a text output.
     }
 
 Note that in params, use of symbols is as follows:

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7413,6 +7413,8 @@ Used by `minetest.register_chatcommand`.
 
         func = function(name, param),
         -- Called when command is run. Returns boolean success and text output.
+        -- Special case: The help message is shown to the player if it
+        -- returns `false, "/help"`
     }
 
 Note that in params, use of symbols is as follows:


### PR DESCRIPTION
This makes it easier to show how to use a chatcommand to the player if he/she uses it incorrectly.
Usually, `/help <command>` should show how to invoke `<command>`, so there's often no need for individual parsing error messages.