### PR TITLE
Add support for wielditem textures glowing in the dark

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7340,7 +7340,7 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         light_source = 0,
         -- When used for nodes: Defines amount of light emitted by node.
-        -- Otherwise: Defines texture glow when viewed as a dropped item
+        -- Otherwise: Defines texture glow when viewed as a dropped/wielded item
         -- To set the maximum (14), use the value 'minetest.LIGHT_MAX'.
         -- A value outside the range 0 to minetest.LIGHT_MAX causes undefined
         -- behavior.

--- a/games/devtest/mods/basetools/init.lua
+++ b/games/devtest/mods/basetools/init.lua
@@ -312,11 +312,12 @@ minetest.register_tool("basetools:sword_steel", {
 	}
 })
 
--- Fire/Ice sword: Deal damage to non-fleshy damage groups
+-- Fire/Ice sword: Deal damage to non-fleshy damage groups and glow
 minetest.register_tool("basetools:sword_fire", {
 	description = "Fire Sword".."\n"..
 		"Damage: icy=6",
 	inventory_image = "basetools_firesword.png",
+	light_source = 10,
 	tool_capabilities = {
 		full_punch_interval = 1.0,
 		max_drop_level=0,

--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -296,7 +296,17 @@ void ClientEnvironment::step(float dtime)
 		node_at_lplayer = m_map->getNode(p);
 
 		u16 light = getInteriorLight(node_at_lplayer, 0, m_client->ndef());
+
+		ItemStack wielditem;
+		wielditem = lplayer->getWieldedItem(&wielditem, nullptr);
+		ItemDefinition wielddef = wielditem.getDefinition(m_client->getItemDefManager());
+
+		u8 wieldlight = decode_light(wielddef.light_source);
+
 		final_color_blend(&lplayer->light_color, light, day_night_ratio);
+
+		if (wielddef.light_source > 0 && wieldlight > lplayer->light_color.getLuminance())
+			lplayer->light_color = irr::video::SColor(255,wieldlight,wieldlight,wieldlight);
 	}
 
 	/*

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -81,6 +81,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	range = def.range;
 	palette_image = def.palette_image;
 	color = def.color;
+	light_source = def.light_source;
 	return *this;
 }
 
@@ -108,6 +109,7 @@ void ItemDefinition::reset()
 	wield_overlay = "";
 	palette_image = "";
 	color = video::SColor(0xFFFFFFFF);
+	light_source = 0;
 	wield_scale = v3f(1.0, 1.0, 1.0);
 	stack_max = 99;
 	usable = false;
@@ -166,6 +168,8 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	os << serializeString16(short_description);
 
 	os << place_param2;
+
+	writeU8(os, light_source);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)
@@ -214,6 +218,10 @@ void ItemDefinition::deSerialize(std::istream &is)
 	color = readARGB8(is);
 	inventory_overlay = deSerializeString16(is);
 	wield_overlay = deSerializeString16(is);
+
+	try {
+		light_source = readU8(is);
+	} catch(SerializationError &e) {};
 
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -219,16 +219,14 @@ void ItemDefinition::deSerialize(std::istream &is)
 	inventory_overlay = deSerializeString16(is);
 	wield_overlay = deSerializeString16(is);
 
-	try {
-		light_source = readU8(is);
-	} catch(SerializationError &e) {};
-
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.
 	try {
 		short_description = deSerializeString16(is);
 
 		place_param2 = readU8(is); // 0 if missing
+
+		light_source = readU8(is);
 	} catch(SerializationError &e) {};
 }
 

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -68,6 +68,7 @@ struct ItemDefinition
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.
 	v3f wield_scale;
+	u8 light_source;
 
 	/*
 		Item stack and interaction properties

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -68,6 +68,8 @@ void read_item_definition(lua_State* L, int index,
 	read_color(L, -1, &def.color);
 	lua_pop(L, 1);
 
+	def.light_source = getintfield_default(L, index, "light_source", def.light_source);
+
 	lua_getfield(L, index, "wield_scale");
 	if(lua_istable(L, -1)){
 		def.wield_scale = check_v3f(L, -1);


### PR DESCRIPTION
Closes https://github.com/minetest/minetest/issues/9192
#

### How to use

Add `light_source = x` to your item definition. `x` being a number from 1 to minetest.LIGHT_MAX

![image](https://user-images.githubusercontent.com/28972859/75588868-59cfaf80-5a2e-11ea-83c2-7fd0e35a7b20.png)

## How to test
* Join a devtest world
* Play around with items that have light_source in their definition. I'd recommend the fire sword and a lightsource node.
* Test as a wielded and dropped item