### PR TITLE
Improve minetest.spawn_item and include in API documentation

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -1,12 +1,19 @@
 -- Minetest: builtin/item_entity.lua
 
-function core.spawn_item(pos, item)
+function core.spawn_item(pos, item, horz, vert)
 	-- Take item in any format
 	local stack = ItemStack(item)
 	local obj = core.add_entity(pos, "__builtin:item")
+
 	-- Don't use obj if it couldn't be added to the map.
 	if obj then
 		obj:get_luaentity():set_item(stack:to_string())
+
+		if horz then
+			obj:set_velocity(vector.new(
+				math.random(-horz, horz), vert or 0, math.random(-horz, horz)
+			))
+		end
 	end
 	return obj
 end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -4461,6 +4461,11 @@ Environment access
     * Returns `ObjectRef`, or `nil` if failed
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
+* `minetest.spawn_item(pos, item, horz, vert)`
+    * Same as `add_item, but with an optional spontaneous velocity applied
+    * `horz` is the maximum velocity along both horizontal axes.
+    * `vert` is the vertical velocity, which may be negative for downward or
+      positive for upward
 * `minetest.get_player_by_name(name)`: Get an `ObjectRef` to a player
 * `minetest.get_objects_inside_radius(pos, radius)`: returns a list of
   ObjectRefs.


### PR DESCRIPTION
This PR from the _Minetest S3_ fork allows the builtin `spawn_item()` function (currently aliased from `add_item()` within lua_api/l_env.cpp) to accept a horizontal and vertical velocity parameter for a randomly oriented "tossing" effect.

Unlike `item_drop()`, this function is more suitable for incidental drops that are independent of the player, such as the drops from TNT explosions.

![explosion](https://user-images.githubusercontent.com/24327224/75599173-c0bd8a80-5a67-11ea-9aba-55b87bd68014.gif)

The underlying logic is the same as the `minetest.drop_item()` function [that I published a few years ago](https://forum.minetest.net/viewtopic.php?p=295360#p295360) on the forums, but it has since been integrated into `spawn_item()` instead (which makes more sense, although I didn't know about this builtin function at the time, since it's undocumented :)

## To do

This PR is Ready for Review.

## How to test

Create a mod with the following init.lua. Then, place a Nyan Cat node and punch it for goodies :)

```
minetest.override_item("nyancat:nyancat", {
	on_punch = function (pos)
		minetest.spawn_item(pos, "nyancat:nyancat", 2.5, 5.0)
	end,
})
```
