### PR TITLE
Render base cube of plantlike_rooted when falling

### DIFF
--- a/builtin/game/falling.lua
+++ b/builtin/game/falling.lua
@@ -96,6 +96,25 @@ core.register_entity(":__builtin:falling_node", {
 				textures = textures,
 				glow = def.light_source,
 			})
+		elseif def.drawtype == "plantlike_rooted" then
+			-- This renders the "base cube" but not the plant
+			if def.tiles then
+				local textures = {}
+				local tile
+				for i=1, 6 do
+					if def.tiles[i] then
+						tile = def.tiles[i]
+					end
+					textures[i] = tile
+				end
+				self.object:set_properties({
+					is_visible = true,
+					visual = "cube",
+					visual_size = { x = 1.0, y = 1.0, z = 1.0 },
+					textures = textures,
+					glow = def.light_source,
+				})
+			end
 		elseif def.drawtype ~= "airlike" then
 			local itemstring = node.name
 			if core.is_colored_paramtype(def.paramtype2) then


### PR DESCRIPTION
Currently, when a `plantlike_rooted` node falls, it looks a little weird (the base cube is replaced with a flat plant image).

This PR changes the rendering of a falling `plantlike_rooted` node to a different approximation, by rendering the base cube.

Downsides:

* Due to limitations of the entity visuals, the actual plant on top of the base cube is not rendered
* The `cube` visual is used, which doesn't support shading (yet)

I consider the new rendering t

## To do

This PR is ready for review.

## How to test

* Play `devtest` https://forum.minetest.net/viewtopic.php?f=50&t=24030&p=364956
* Place one of the “Rooted Plantlike” test nodes
* Make it fall with the falling node tool