### PR TITLE
Cleanup global namespace pollution in builtin

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -5,7 +5,7 @@
 local string_sub, string_find = string.sub, string.find
 
 --------------------------------------------------------------------------------
-function basic_dump(o)
+local function basic_dump(o)
 	local tp = type(o)
 	if tp == "number" then
 		return tostring(o)
@@ -201,18 +201,6 @@ function table.indexof(list, val)
 end
 
 --------------------------------------------------------------------------------
-if INIT ~= "client" then
-	function file_exists(filename)
-		local f = io.open(filename, "r")
-		if f == nil then
-			return false
-		else
-			f:close()
-			return true
-		end
-	end
-end
---------------------------------------------------------------------------------
 function string:trim()
 	return (self:gsub("^%s*(.-)%s*$", "%1"))
 end
@@ -252,64 +240,6 @@ function math.factorial(x)
 		v = v * k
 	end
 	return v
-end
-
---------------------------------------------------------------------------------
-function get_last_folder(text,count)
-	local parts = text:split(DIR_DELIM)
-
-	if count == nil then
-		return parts[#parts]
-	end
-
-	local retval = ""
-	for i=1,count,1 do
-		retval = retval .. parts[#parts - (count-i)] .. DIR_DELIM
-	end
-
-	return retval
-end
-
---------------------------------------------------------------------------------
-function cleanup_path(temppath)
-
-	local parts = temppath:split("-")
-	temppath = ""
-	for i=1,#parts,1 do
-		if temppath ~= "" then
-			temppath = temppath .. "_"
-		end
-		temppath = temppath .. parts[i]
-	end
-
-	parts = temppath:split(".")
-	temppath = ""
-	for i=1,#parts,1 do
-		if temppath ~= "" then
-			temppath = temppath .. "_"
-		end
-		temppath = temppath .. parts[i]
-	end
-
-	parts = temppath:split("'")
-	temppath = ""
-	for i=1,#parts,1 do
-		if temppath ~= "" then
-			temppath = temppath .. ""
-		end
-		temppath = temppath .. parts[i]
-	end
-
-	parts = temppath:split(" ")
-	temppath = ""
-	for i=1,#parts,1 do
-		if temppath ~= "" then
-			temppath = temppath
-		end
-		temppath = temppath .. parts[i]
-	end
-
-	return temppath
 end
 
 function core.formspec_escape(text)

--- a/builtin/mainmenu/pkgmgr.lua
+++ b/builtin/mainmenu/pkgmgr.lua
@@ -16,6 +16,62 @@
 --51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 --------------------------------------------------------------------------------
+local function get_last_folder(text,count)
+	local parts = text:split(DIR_DELIM)
+
+	if count == nil then
+		return parts[#parts]
+	end
+
+	local retval = ""
+	for i=1,count,1 do
+		retval = retval .. parts[#parts - (count-i)] .. DIR_DELIM
+	end
+
+	return retval
+end
+
+local function cleanup_path(temppath)
+
+	local parts = temppath:split("-")
+	temppath = ""
+	for i=1,#parts,1 do
+		if temppath ~= "" then
+			temppath = temppath .. "_"
+		end
+		temppath = temppath .. parts[i]
+	end
+
+	parts = temppath:split(".")
+	temppath = ""
+	for i=1,#parts,1 do
+		if temppath ~= "" then
+			temppath = temppath .. "_"
+		end
+		temppath = temppath .. parts[i]
+	end
+
+	parts = temppath:split("'")
+	temppath = ""
+	for i=1,#parts,1 do
+		if temppath ~= "" then
+			temppath = temppath .. ""
+		end
+		temppath = temppath .. parts[i]
+	end
+
+	parts = temppath:split(" ")
+	temppath = ""
+	for i=1,#parts,1 do
+		if temppath ~= "" then
+			temppath = temppath
+		end
+		temppath = temppath .. parts[i]
+	end
+
+	return temppath
+end
+
 function get_mods(path,retval,modpack)
 	local mods = core.get_dir_list(path, true)
 


### PR DESCRIPTION
Partial fix for #4733. The fix is partial because `INIT` and `DIR_DELIM` are not touched. Everything else of #4733 will be fixed.

All global function that builtin accidentally pollutes the global namespace with are `local`ized and removed. With this PR, builtin no longer pollutes the global namespace with anything except `INIT` and `DIR_DELIM`.

List of changes:
* `file_exists` function removed (it's not used anywhere)
* `cleanup_path` and `get_last_folder` functions moved to `/builtin/mainmenu/pkgmgr.lua` (as this the only file in which these are called) and `local`ized
* `basic_dump` function `local`ized

How to verify: Use the `qa_block` mod to analyze the global namespace in an ultra-minimal test game.