### PR TITLE
Document builtin entities

### DIFF
--- a/doc/builtin_entities.txt
+++ b/doc/builtin_entities.txt
@@ -8,28 +8,26 @@ This entity is created by `minetest.check_for_falling` in place of a node
 with the special group `falling_node=1`. Falling nodes can also be created
 artificially with `minetest.spawn_falling_node`.
 
-Spawning a falling node with `/spawnentity` won't work.
+Needs manual initialization when spawned using `/spawnentity`.
 
 Default behaviour:
 
 * Falls down in a straight line (gravity = `movement_gravity` setting)
-* It collides with `walkable` nodes and physical objects
-* If falls through players
+* Collides with `walkable` node
+* Collides with all physical objects but players
 * If the node group `float=1` is set, it also collides with liquid nodes
 * When it hits a solid (=`walkable`) node, it will try to place itself as a
   node, replacing the node above.
-    * If the destination node is not `buildable_to`, the *destination node*
-      drops as an item
-    * If the destination node is a leveled node (`paramtype2="leveled"`),
-      the level (=`param2`) of the destination node will be increased
-      (sum of destination node's level and falling node's level)
-    * If the falling node fails to place itself, it drops as an item
+    * If the falling node cannot replace the destination node, it is dropped.
+    * If the destination node is a leveled node (`paramtype2="leveled"`) of the
+      same node name, the levels of both are summed.
 
 ### Entity fields
 
-* `set_node(self, node, meta)`: Call this function to set the node type that
-  is falling. `node` and `meta` are explained below. The `meta` argument
-  is optional.
+* `set_node(self, node[, meta])`
+    * Function to initialize the falling node
+    * `node` and `meta` are explained below.
+    * The `meta` argument is optional.
 * `node`: Node table of the node (`name`, `param1`, `param2`) that this
   entity represents. Read-only.
 * `meta`: Node metadata of the falling node. Will be used when the falling
@@ -39,7 +37,6 @@ Default behaviour:
 
 Falling nodes have visuals to look as close as possible to the original node.
 This works for most drawtypes, but there are limitations.
-Falling nodes use the `item` entity visual for most nodes.
 
 Supported drawtypes:
 
@@ -71,33 +68,33 @@ Supported `paramtype2` values:
 
 ## Dropped item stack (`__builtin:item`)
 
-This is an item stack in a collectable form. Common cases that spawn a
-dropped item:
+This is an item stack in a collectable form.
+
+Common cases that spawn a dropped item:
 
 * Item dropped by player
 * The root node of a node with the group `attached_node=1` is removed
 * `minetest.add_item` is called
 
-Spawning this entity using `/spawnentity` will not work.
+Needs manual initialization when spawned using `/spawnentity`.
 
 ### Behavior
 
-* Players will collect it by punching
-* It will disappear after `item_entity_ttl` seconds after its creation
-  (unless item timeout is disabled)
-* It will slide on `slippery` nodes
-* It is subject to gravity (uses `movement_gravity` setting)
-* It collides with `walkable` nodes
-* It does not collide physical objects
+* Players can collect it by punching
+* Lifespan is defined by the setting `item_entity_ttl`
+* Slides on `slippery` nodes
+* Subject to gravity (uses `movement_gravity` setting)
+* Collides with `walkable` nodes
+* Does not collide physical objects
 * When it's inside a solid (`walkable=true`) node, it tries to escape to a
   neighboring non-solid (`walkable=false`) node
 
 ### Entity fields
 
-* `set_item(self, item)`: Function to initialize this entity to its
-  representing `item` (type `ItemStack`).
-* `age`: Age in seconds. When this exceeds `item_entity_ttl`, the entity
-  is removed (unless item timeout is disabled)
+* `set_item(self, item)`:
+    * Function to initialize the dropped item
+    * `item` (type `ItemStack`) specifies the item to represent
+* `age`: Age in seconds. Behaviour according to the setting `item_entity_ttl`
 * `itemstring`: Itemstring of the item that this item entity represents.
   Read-only.
 

--- a/doc/builtin_entities.txt
+++ b/doc/builtin_entities.txt
@@ -14,7 +14,7 @@ Default behaviour:
 
 * Falls down in a straight line (gravity = `movement_gravity` setting)
 * Collides with `walkable` node
-* Collides with all physical objects but players
+* Collides with all physical objects except players
 * If the node group `float=1` is set, it also collides with liquid nodes
 * When it hits a solid (=`walkable`) node, it will try to place itself as a
   node, replacing the node above.

--- a/doc/builtin_entities.txt
+++ b/doc/builtin_entities.txt
@@ -1,0 +1,104 @@
+# Builtin Entities
+Minetest registers two entities by default: Falling nodes and dropped items.
+This document describes how they behave and what you can do with them.
+
+## Falling node (`__builtin:falling_node`)
+
+This entity is created by `minetest.check_for_falling` in place of a node
+with the special group `falling_node=1`. Falling nodes can also be created
+artificially with `minetest.spawn_falling_node`.
+
+Spawning a falling node with `/spawnentity` won't work.
+
+Default behaviour:
+
+* Falls down in a straight line (gravity = `movement_gravity` setting)
+* It collides with `walkable` nodes and physical objects
+* If falls through players
+* If the node group `float=1` is set, it also collides with liquid nodes
+* When it hits a solid (=`walkable`) node, it will try to place itself as a
+  node, replacing the node above.
+    * If the destination node is not `buildable_to`, the *destination node*
+      drops as an item
+    * If the destination node is a leveled node (`paramtype2="leveled"`),
+      the level (=`param2`) of the destination node will be increased
+      (sum of destination node's level and falling node's level)
+    * If the falling node fails to place itself, it drops as an item
+
+### Entity fields
+
+* `set_node(self, node, meta)`: Call this function to set the node type that
+  is falling. `node` and `meta` are explained below. The `meta` argument
+  is optional.
+* `node`: Node table of the node (`name`, `param1`, `param2`) that this
+  entity represents. Read-only.
+* `meta`: Node metadata of the falling node. Will be used when the falling
+  nodes tries to place itself as a node. Read-only.
+
+### Rendering / supported nodes
+
+Falling nodes have visuals to look as close as possible to the original node.
+This works for most drawtypes, but there are limitations.
+Falling nodes use the `item` entity visual for most nodes.
+
+Supported drawtypes:
+
+* `normal`
+* `signlike`
+* `torchlike`
+* `nodebox`
+* `raillike`
+* `glasslike`
+* `glasslike_framed`
+* `glasslike_framed_optional`
+* `allfaces`
+* `allfaces_optional`
+* `firelike`
+* `mesh`
+* `fencelike`
+* `liquid`
+* `airlike` (not pointable)
+
+Other drawtypes still kinda work, but they might look weird.
+
+Supported `paramtype2` values:
+
+* `wallmounted`
+* `facedir`
+* `colorwallmounted`
+* `colorfacedir`
+* `color`
+
+## Dropped item stack (`__builtin:item`)
+
+This is an item stack in a collectable form. Common cases that spawn a
+dropped item:
+
+* Item dropped by player
+* The root node of a node with the group `attached_node=1` is removed
+* `minetest.add_item` is called
+
+Spawning this entity using `/spawnentity` will not work.
+
+### Behavior
+
+* Players will collect it by punching
+* It will disappear after `item_entity_ttl` seconds after its creation
+  (unless item timeout is disabled)
+* It will slide on `slippery` nodes
+* It is subject to gravity (uses `movement_gravity` setting)
+* It collides with `walkable` nodes
+* It does not collide physical objects
+* When it's inside a solid (`walkable=true`) node, it tries to escape to a
+  neighboring non-solid (`walkable=false`) node
+
+### Entity fields
+
+* `set_item(self, item)`: Function to initialize this entity to its
+  representing `item` (type `ItemStack`).
+* `age`: Age in seconds. When this exceeds `item_entity_ttl`, the entity
+  is removed (unless item timeout is disabled)
+* `itemstring`: Itemstring of the item that this item entity represents.
+  Read-only.
+
+Other fields are for internal use only.


### PR DESCRIPTION
This PR adds a new text file `doc/builtin_entities.txt` which explains how the two builtin entities `__builtin:item` and `__builtin:falling_node` work.