### PR TITLE
minetest.get_content_id: error on unknown node

### DIFF
--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -612,9 +612,11 @@ int ModApiItemMod::l_get_content_id(lua_State *L)
 	std::string name = luaL_checkstring(L, 1);
 
 	const NodeDefManager *ndef = getGameDef(L)->getNodeDefManager();
-	content_t c = ndef->getId(name);
+	content_t content_id;
+	if (!ndef->getId(name, content_id))
+		throw LuaError("Unknown node: " + name);
 
-	lua_pushinteger(L, c);
+	lua_pushinteger(L, content_id);
 	return 1; /* number of results */
 }
 


### PR DESCRIPTION
If the node does not exists, the function causes an error instead of returning the node id of `ignore`.

Without these changes, a typo in the application of `minetest.get_content_id` can be a difficult-to-find bug. For example, someone may accidentally write `minetest.get_content_id("default:sand_stone")` instead of `minetest.get_content_id("default:sandstone")`.