### PR TITLE
Fixes around ServerActiveObject on_punch handling

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3895,6 +3895,7 @@ Callbacks:
     * `dir`: unit vector of direction of punch. Always defined. Points from the
       puncher to the punched.
     * `damage`: damage that will be done to entity.
+    * Can return `true` to prevent the default damage mechanism.
 * `on_death(self, killer)`
     * Called when the object dies.
     * `killer`: an `ObjectRef` (can be `nil`)

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -653,7 +653,7 @@ u16 LuaEntitySAO::punch(v3f dir,
 	if (!damage_handled) {
 		if (result.did_punch) {
 			setHP((s32)getHP() - result.damage,
-				PlayerHPChangeReason(PlayerHPChangeReason::SET_HP));
+				PlayerHPChangeReason(PlayerHPChangeReason::PLAYER_PUNCH, puncher));
 
 			std::string str = gob_cmd_punched(getHP());
 			// create message and add to list
@@ -663,10 +663,10 @@ u16 LuaEntitySAO::punch(v3f dir,
 	}
 
 	if (getHP() == 0 && !isGone()) {
-		m_pending_removal = true;
 		clearParentAttachment();
 		clearChildAttachments();
 		m_env->getScriptIface()->luaentity_on_death(m_id, puncher);
+		m_pending_removal = true;
 	}
 
 	actionstream << puncher->getDescription() << " (id=" << puncher->getId() <<
@@ -675,6 +675,7 @@ u16 LuaEntitySAO::punch(v3f dir,
 			"), damage=" << (old_hp - (s32)getHP()) <<
 			(damage_handled ? " (handled by Lua)" : "") << std::endl;
 
+	// TODO: give Lua control over wear
 	return result.wear;
 }
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1166,6 +1166,8 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			u16 wear = pointed_object->punch(dir, &toolcap, playersao,
 					time_from_last_punch);
 
+			// Callback may have changed item, so get it again
+			playersao->getWieldedItem(&selected_item);
 			bool changed = selected_item.addWear(wear, m_itemdef);
 			if (changed)
 				playersao->setWieldedItem(selected_item);


### PR DESCRIPTION
* Fixes <i>2.</i> from this comment https://github.com/minetest/minetest/pull/8959#issuecomment-594632035
* Fixes inaccurate hpchange reason (currently irrelevant, since unused)
* Document return value of LuaEntity `on_punch`
* Fix ObjectRef being unusable at the time `on_death` is called

## To do

This PR is a Ready for Review.