### PR TITLE
Hide Wself-assign-overloaded and Wself-move unittest compilation warnings

### DIFF
--- a/src/unittest/test_irrptr.cpp
+++ b/src/unittest/test_irrptr.cpp
@@ -91,6 +91,12 @@ void TestIrrPtr::testRefCounting()
 			obj->getReferenceCount());
 }
 
+#if defined(__clang__)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+	#pragma GCC diagnostic ignored "-Wself-move"
+#endif
+
 void TestIrrPtr::testSelfAssignment()
 {
 	irr_ptr<IReferenceCounted> p1{new IReferenceCounted()};
@@ -129,3 +135,7 @@ void TestIrrPtr::testNullHandling()
 	UASSERT(!p2);
 	UASSERT(!p3);
 }
+
+#if defined(__clang__)
+	#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
I use clang and get warnings when compiling the irrptr unittests.
```
[…]/minetest/src/unittest/test_irrptr.cpp:99:5: warning: explicitly assigning value of variable of type 'irr_ptr<irr::IReferenceCounted>' to itself [-Wself-assign-overloaded]
        p1 = p1;
        ~~ ^ ~~
[…]/minetest/src/unittest/test_irrptr.cpp:102:5: warning: explicitly moving variable of type 'irr_ptr<irr::IReferenceCounted>' to itself [-Wself-move]
        p1 = std::move(p1);
        ~~ ^           ~~
[…]/minetest/src/unittest/test_irrptr.cpp:121:5: warning: explicitly assigning value of variable of type 'irr_ptr<irr::IReferenceCounted>' to itself [-Wself-assign-overloaded]
        p2 = p2;
        ~~ ^ ~~
[…]/minetest/src/unittest/test_irrptr.cpp:123:5: warning: explicitly moving variable of type 'irr_ptr<irr::IReferenceCounted>' to itself [-Wself-move]
        p2 = std::move(p2);
        ~~ ^           ~~
4 warnings generated.
```

The self-assignments are probably intentional because it is test code, so I've disabled the warnings in the affected code region.