### PR TITLE
Fix Media... 0% on loading screen

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1637,7 +1637,10 @@ bool Game::getServerContent(bool *aborted)
 			std::stringstream message;
 			std::fixed(message);
 			message.precision(0);
-			message << gettext("Media...") << " " << (client->mediaReceiveProgress()*100) << "%";
+			if (client->mediaReceiveProgress() > 0)
+				message << gettext("Media... ") << (client->mediaReceiveProgress() * 100) << "%";
+			else
+				message << gettext("Media...");
 			message.precision(2);
 
 			if ((USE_CURL == 0) ||

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1637,10 +1637,10 @@ bool Game::getServerContent(bool *aborted)
 			std::stringstream message;
 			std::fixed(message);
 			message.precision(0);
-			if (client->mediaReceiveProgress() > 0)
-				message << gettext("Media... ") << (client->mediaReceiveProgress() * 100) << "%";
-			else
-				message << gettext("Media...");
+			float receive = client->mediaReceiveProgress() * 100;
+			message << gettext("Media...");
+			if (receive > 0)
+				message << " " << receive << "%";
 			message.precision(2);
 
 			if ((USE_CURL == 0) ||


### PR DESCRIPTION
Who was not annoyed that when loading a game with large textures and models while checking cached resources, the client can show Media...0% for a long time?
Especially during a singleplayer game on a weak PC.

(Only "Media" show % when loading, by the way.)

**Now it will look as it should:**
Item definitions...
Node definitions...
Media...
Media... *%