### PR TITLE
Improve waypoints and add image variant

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1395,8 +1395,8 @@ Displays distance to specified world position, and some text. Accepts offset.
 * `text`: Distance suffix. Can be blank.
 * `precision`: Waypoint precision. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
-  Accordingly, there will be `n` steps behind the decimal dot.
-  `precision = 1000`, for example, would show values like `0.999`.
+  When the precision is an integer multiple of 10, there will `log_10(precision)` digits after the decimal point.
+  `precision = 1000`, for example, will show 3 decimal places (eg: `0.999`).
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1392,6 +1392,10 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
+* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+  If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
+  Accordingly, there will be `n` steps behind the decimal dot.
+  `precision = 1000`, for example, would show values like `0.999`.
 * `number:` An integer containing the RGB value of the color used to draw the text.
 * `world_pos`: World position of the waypoint.
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1393,7 +1393,7 @@ Displays distance to specified world position, and some text. Accepts offset.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+* `precision`: Waypoint precision. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
   Accordingly, there will be `n` steps behind the decimal dot.
   `precision = 1000`, for example, would show values like `0.999`.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1388,7 +1388,8 @@ Displays a horizontal bar made up of half-images.
 * `offset`: offset in pixels from position.
 
 ### `waypoint`
-Displays distance to selected world position.
+
+Displays distance to selected world position. Accepts offset.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
@@ -1396,8 +1397,13 @@ Displays distance to selected world position.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
   Accordingly, there will be `n` steps behind the decimal dot.
   `precision = 1000`, for example, would show values like `0.999`.
-* `number:` An integer containing the RGB value of the color used to draw the text.
+* `number:` An integer containing the RGB value of the color used to draw the
+  text.
 * `world_pos`: World position of the waypoint.
+
+### `image_waypoint`
+
+Same as `image`, but does not accept a `position`; the position is instead determined by `world_pos`, the world position of the waypoint.
 
 ### Particle definition (`add_particle`)
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1389,22 +1389,32 @@ Displays a horizontal bar made up of half-images.
 
 ### `waypoint`
 
-Displays distance to specified world position, and some text. Accepts offset.
+Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `precision`: Waypoint precision. Defaults to 10.
+* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
-  When the precision is an integer multiple of 10, there will `log_10(precision)` digits after the decimal point.
-  `precision = 1000`, for example, will show 3 decimal places (eg: `0.999`).
+  Accordingly, there will be `n` steps behind the decimal dot.
+  `precision = 1000`, for example, would show values like `0.999`.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.
+* `offset`: offset in pixels from position.
 * `alignment`: The alignment of the waypoint.
 
 ### `image_waypoint`
 
 Same as `image`, but does not accept a `position`; the position is instead determined by `world_pos`, the world position of the waypoint.
+
+* `scale`: The scale of the image, with 1 being the original texture size.
+  Only the X coordinate scale is used (positive values).
+  Negative values represent that percentage of the screen it
+  should take; e.g. `x=-100` means 100% (width).
+* `text`: The name of the texture that is displayed.
+* `alignment`: The alignment of the image.
+* `world_pos`: World position of the waypoint.
+* `offset`: offset in pixels from position.
 
 ### Particle definition (`add_particle`)
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1393,7 +1393,7 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+* `precision`: Waypoint precision, integer >= 0. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
   Accordingly, there will be `n` steps behind the decimal dot.
   `precision = 1000`, for example, would show values like `0.999`.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1400,6 +1400,7 @@ Displays distance to selected world position. Accepts offset.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.
+* `alignment`: The alignment of the waypoint.
 
 ### `image_waypoint`
 

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1389,7 +1389,7 @@ Displays a horizontal bar made up of half-images.
 
 ### `waypoint`
 
-Displays distance to selected world position. Accepts offset.
+Displays distance to specified world position, and some text. Accepts offset.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.

--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -1395,8 +1395,10 @@ Displays distance to selected world position.
 * `text`: Distance suffix. Can be blank.
 * `precision`: Waypoint precision, integer >= 0. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
-  Accordingly, there will be `n` steps behind the decimal dot.
-  `precision = 1000`, for example, would show values like `0.999`.
+  When the precision is an integer multiple of 10, there will be `log_10(precision)` digits after the decimal point.
+  `precision = 1000`, for example, will show 3 decimal places (eg: `0.999`).
+  `precision = 2` will show multiples of `0.5`; precision = 5 will show multiples of `0.2` and so on:
+  `precision = n` will show multiples of `1/n`
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1361,7 +1361,20 @@ Displays distance to selected world position.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.
+* `offset`: offset in pixels from position.
 
+### `image_waypoint`
+
+Same as `image`, but does not accept a `position`; the position is instead determined by `world_pos`, the world position of the waypoint.
+
+* `scale`: The scale of the image, with 1 being the original texture size.
+  Only the X coordinate scale is used (positive values).
+  Negative values represent that percentage of the screen it
+  should take; e.g. `x=-100` means 100% (width).
+* `text`: The name of the texture that is displayed.
+* `alignment`: The alignment of the image.
+* `world_pos`: World position of the waypoint.
+* `offset`: offset in pixels from position.
 
 
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1356,8 +1356,10 @@ Displays distance to selected world position.
 * `text`: Distance suffix. Can be blank.
 * `precision`: Waypoint precision, integer >= 0. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
-  Accordingly, there will be `n` steps behind the decimal dot.
-  `precision = 1000`, for example, would show values like `0.999`.
+  When the precision is an integer multiple of 10, there will be `log_10(precision)` digits after the decimal point.
+  `precision = 1000`, for example, will show 3 decimal places (eg: `0.999`).
+  `precision = 2` will show multiples of `0.5`; precision = 5 will show multiples of `0.2` and so on:
+  `precision = n` will show multiples of `1/n`
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1354,7 +1354,10 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `item`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons). If set to 0, distance is not shown.
+* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+  If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
+  Accordingly, there will be `n` steps behind the decimal dot.
+  `precision = 1000`, for example, would show values like `0.999`.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1354,6 +1354,7 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
+* `item`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons). If set to 0, distance is not shown.
 * `number:` An integer containing the RGB value of the color used to draw the
   text.
 * `world_pos`: World position of the waypoint.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1362,6 +1362,7 @@ Displays distance to selected world position.
   text.
 * `world_pos`: World position of the waypoint.
 * `offset`: offset in pixels from position.
+* `alignment`: The alignment of the waypoint.
 
 ### `image_waypoint`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -1354,7 +1354,7 @@ Displays distance to selected world position.
 
 * `name`: The name of the waypoint.
 * `text`: Distance suffix. Can be blank.
-* `precision`: Waypoint precision. Defaults to 10 if not set (for compatibility reasons).
+* `precision`: Waypoint precision, integer >= 0. Defaults to 10.
   If set to 0, distance is not shown. Shown value is `floor(distance*precision)/precision`.
   Accordingly, there will be `n` steps behind the decimal dot.
   `precision = 1000`, for example, would show values like `0.999`.

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -278,7 +278,8 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 	}
 }
 
-bool Hud::calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos) {
+bool Hud::calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos)
+{
 	v3f w_pos = e->world_pos * BS;
 	scene::ICameraSceneNode* camera =
 		RenderingEngine::get_scene_manager()->getActiveCamera();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -373,11 +373,10 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				// item = precision + 1
 				float precision;
 				u32 item = e->item;
-				if (item == 0) {
+				if (item == 0)
 					precision = 10.0f;
-				} else {
+				else
 					precision = item - 1;
-				}
 
 				if (precision > 0) {
 					std::ostringstream os;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -370,13 +370,9 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
-				// item = precision + 1
-				float precision;
+				// waypoints reusing item for precision, item = precision + 1
 				u32 item = e->item;
-				if (item == 0)
-					precision = 10.0f;
-				else
-					precision = item - 1;
+				float precision = item == 0 ? 10.0f : (item - 1);
 
 				if (precision > 0) {
 					std::ostringstream os;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -278,6 +278,7 @@ void Hud::drawItems(v2s32 upperleftpos, v2s32 screen_offset, s32 itemcount,
 	}
 }
 
+// Calculates screen position of waypoint. Returns true if waypoint is behind player (and thus not visible).
 bool Hud::calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos)
 {
 	v3f w_pos = e->world_pos * BS;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -351,8 +351,6 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 			case HUD_ELEM_WAYPOINT: {
 				v3f p_pos = player->getPosition() / BS;
 				v3f w_pos = e->world_pos * BS;
-				float distance = std::floor(10 * p_pos.getDistanceFrom(e->world_pos)) /
-					10.0f;
 				scene::ICameraSceneNode* camera =
 					RenderingEngine::get_scene_manager()->getActiveCamera();
 				w_pos -= intToFloat(camera_offset, BS);
@@ -372,11 +370,23 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
 				font->draw(text.c_str(), size + pos, color);
-				std::ostringstream os;
-				os << distance << e->text;
-				text = unescape_translate(utf8_to_wide(os.str()));
-				pos.Y += text_height;
-				font->draw(text.c_str(), size + pos, color);
+				// item = precision + 1
+				float precision;
+				u32 item = e->item;
+				if (item == 0) {
+					precision = 10.0f;
+				} else {
+					precision = item - 1;
+				}
+
+				if (precision > 0) {
+					std::ostringstream os;
+					float distance = std::floor(precision * p_pos.getDistanceFrom(e->world_pos)) / precision;
+					os << distance << e->text;
+					text = unescape_translate(utf8_to_wide(os.str()));
+					pos.Y += text_height;
+					font->draw(text.c_str(), size + pos, color);
+				}
 				break; }
 			default:
 				infostream << "Hud::drawLuaElements: ignoring drawform " << e->type <<

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -348,19 +348,22 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				video::SColor color(255, (e->number >> 16) & 0xFF,
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
-				core::rect<s32> size(0, 0, 200, 2 * text_height);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
-				font->draw(text.c_str(), size + pos, color);
 				// waypoints reuse the item field to store precision, item = precision + 1
 				u32 item = e->item;
 				float precision = item == 0 ? 10.0f : (item - 1);
-				if (precision > 0) {
+				bool draw_precision = precision > 0;
+				core::rect<s32> size(0, 0, font->getDimension(text.c_str()).Width, (draw_precision ? 2:1) * text_height);
+				pos.Y += (e->align.Y - 1.0) * size.getHeight() / 2;
+				size += pos;
+				font->draw(text.c_str(), size + v2s32((e->align.X - 1.0) * size.getWidth() / 2, 0), color);
+				if (draw_precision) {
 					std::ostringstream os;
 					float distance = std::floor(precision * p_pos.getDistanceFrom(e->world_pos)) / precision;
 					os << distance << e->text;
 					text = unescape_translate(utf8_to_wide(os.str()));
-					pos.Y += text_height;
-					font->draw(text.c_str(), size + pos, color);
+					size.LowerRightCorner.X = size.UpperLeftCorner.X + font->getDimension(text.c_str()).Width;
+					font->draw(text.c_str(), size + v2s32((e->align.X - 1.0) * size.getWidth() / 2, text_height), color);
 				}
 				break; }
 			case HUD_ELEM_IMAGE_WAYPOINT: {

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -354,10 +354,12 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 										 (e->number >> 8)  & 0xFF,
 										 (e->number >> 0)  & 0xFF);
 				std::wstring text = unescape_translate(utf8_to_wide(e->name));
+				const std::string &unit = e->text;
 				// waypoints reuse the item field to store precision, item = precision + 1
 				u32 item = e->item;
-				float precision = item == 0 ? 10.0f : (item - 1);
+				float precision = (item == 0) ? 10.0f : (item - 1.f);
 				bool draw_precision = precision > 0;
+
 				core::rect<s32> size(0, 0, font->getDimension(text.c_str()).Width, (draw_precision ? 2:1) * text_height);
 				pos.Y += (e->align.Y - 1.0) * size.getHeight() / 2;
 				size += pos;
@@ -365,10 +367,10 @@ void Hud::drawLuaElements(const v3s16 &camera_offset)
 				if (draw_precision) {
 					std::ostringstream os;
 					float distance = std::floor(precision * p_pos.getDistanceFrom(e->world_pos)) / precision;
-					os << distance << e->text;
+					os << distance << unit;
 					text = unescape_translate(utf8_to_wide(os.str()));
 					size.LowerRightCorner.X = size.UpperLeftCorner.X + font->getDimension(text.c_str()).Width;
-					font->draw(text.c_str(), size + v2s32((e->align.X - 1.0) * size.getWidth() / 2, text_height), color);
+					font->draw(text.c_str(), size + v2s32((e->align.X - 1.0f) * size.getWidth() / 2, text_height), color);
 				}
 				break; }
 			case HUD_ELEM_IMAGE_WAYPOINT: {

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -81,6 +81,7 @@ public:
 	void drawLuaElements(const v3s16 &camera_offset);
 
 private:
+	bool calculateScreenPos(const v3s16 &camera_offset, HudElement *e, v2s32 *pos);
 	void drawStatbar(v2s32 pos, u16 corner, u16 drawdir, const std::string &texture,
 			s32 count, v2s32 offset, v2s32 size = v2s32());
 

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -27,6 +27,7 @@ const struct EnumString es_HudElementType[] =
 	{HUD_ELEM_STATBAR,   "statbar"},
 	{HUD_ELEM_INVENTORY, "inventory"},
 	{HUD_ELEM_WAYPOINT,  "waypoint"},
+	{HUD_ELEM_IMAGE_WAYPOINT, "image_waypoint"},
 	{0, NULL},
 };
 

--- a/src/hud.h
+++ b/src/hud.h
@@ -61,6 +61,7 @@ enum HudElementType {
 	HUD_ELEM_STATBAR   = 2,
 	HUD_ELEM_INVENTORY = 3,
 	HUD_ELEM_WAYPOINT  = 4,
+	HUD_ELEM_IMAGE_WAYPOINT = 5
 };
 
 enum HudElementStat {

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,7 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
-		elem->item = getintfield_default(L, 2, "item", -1) + 1;
+		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,6 +1852,9 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	elem->item    = getintfield_default(L, 2, "item", 0);
+	if (elem->type == HUD_ELEM_WAYPOINT) {
+		elem->item = getintfield_default(L, 2, "item", -1) + 1;
+	}
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1851,10 +1851,10 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->name    = getstringfield_default(L, 2, "name", "");
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
-	elem->item    = getintfield_default(L, 2, "item", 0);
-	if (elem->type == HUD_ELEM_WAYPOINT) {
+	if (elem->type == HUD_ELEM_WAYPOINT)
 		elem->item = getintfield_default(L, 2, "item", -1) + 1;
-	}
+	else
+		elem->item    = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,6 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
+		// for waypoints, item = precision + 1
 		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,7 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
-		// waypoints reusing item for precision, item = precision + 1
+		// waypoints reuse the item field to store precision, item = precision + 1
 		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1854,7 +1854,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	if (elem->type == HUD_ELEM_WAYPOINT)
 		elem->item = getintfield_default(L, 2, "item", -1) + 1;
 	else
-		elem->item    = getintfield_default(L, 2, "item", 0);
+		elem->item = getintfield_default(L, 2, "item", 0);
 	elem->dir     = getintfield_default(L, 2, "direction", 0);
 	elem->z_index = MYMAX(S16_MIN, MYMIN(S16_MAX,
 			getintfield_default(L, 2, "z_index", 0)));

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1852,7 +1852,7 @@ void read_hud_element(lua_State *L, HudElement *elem)
 	elem->text    = getstringfield_default(L, 2, "text", "");
 	elem->number  = getintfield_default(L, 2, "number", 0);
 	if (elem->type == HUD_ELEM_WAYPOINT)
-		// for waypoints, item = precision + 1
+		// waypoints reusing item for precision, item = precision + 1
 		elem->item = getintfield_default(L, 2, "precision", -1) + 1;
 	else
 		elem->item = getintfield_default(L, 2, "item", 0);


### PR DESCRIPTION
## Goal of the PR

Improves waypoints by supporting a precision & offset field (see [previous PR](https://github.com/minetest/minetest/pull/9421) which is incorporated inside this one)

Now also supports an alignment field (not only for image waypoints).

Works by storing precision inside the item field. Image waypoints resemble images + `world_pos` (see the API diff for details).

Closes [the request for hidden distance](https://github.com/minetest/minetest/issues/8141). Also closes [the one for image waypoints](https://github.com/minetest/minetest/issues/9447). Partially clo/ses [the request for alignment & default center alignment](https://github.com/minetest/minetest/issues/9511).

This PR is ready for review.

## Screenshot

Shows the waypoints created by `/test_waypoints`. The lowest one is a large wieldhand image waypoint. Waypoints are center-aligned by default.
![Screenshot](https://user-images.githubusercontent.com/34514239/76684159-dd31f900-6609-11ea-97b3-632131763a80.png)


## How to test

Create a waypoint testmod with this [`init.lua`](https://gist.github.com/appgurueu/79fee6fa43f802907f7b34b3dba05163). Then execute the `/test_waypoints` command.
