### PR TITLE
Play place_failed sound if node is occupied or attaching node fails

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -7214,10 +7214,13 @@ Used by `minetest.register_node`.
             -- Node was placed. Also played after falling
 
             place_failed = <SimpleSoundSpec>,
-            -- When node placement failed
+            -- When node placement failed.
+            -- Note: This happens if the _built-in_ node placement failed.
+            -- This sound will still be played if the node is placed in the
+            -- `on_place` callback manually.
 
             fall = <SimpleSoundSpec>,
-            -- When node starts to fall
+            -- When node starts to fall or is detached
         },
 
         drop = "",

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3393,6 +3393,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 		} else {
 			node = map.getNode(p, &is_valid_position);
 			if (is_valid_position && !nodedef->get(node).buildable_to) {
+				soundmaker->m_player_rightpunch_sound = selected_def.sound_place_failed;
 				// Report to server
 				client->interact(INTERACT_PLACE, pointed);
 				return false;
@@ -3465,6 +3466,7 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 			pp = p + v3s16(0, -1, 0);
 
 		if (!nodedef->get(map.getNode(pp)).walkable) {
+			soundmaker->m_player_rightpunch_sound = selected_def.sound_place_failed;
 			// Report to server
 			client->interact(INTERACT_PLACE, pointed);
 			return false;


### PR DESCRIPTION
Fixes #9289.

* Plays the `place_failed` sound if you try to place a node inside a position that is already occupied by another node that is not `buildable_to` (e.g. stair, slab, fence)
* Plays the `place_failed` sound if you try to place an `attached_node` where it doesn't attach

Note: The `place_failed` sound will not take into account if the server will place a node anyway using `on_place`. This warning has been included in the docs.

## To do

Review.

## How to test

* Download `devtest`.

Test 1:
* Get yourself `soundstuff:place_fail`
* Place some fences or any other nodebox
* Try to place the soundstuff node inside the node occupied by the fence (it should fail and a sound must play)

Test 2:
* Get yourself `soundstuff:place_fail_attached` (=floor-attached node)
* Try placing this node as a wall (it should fail and a sound must play)