### PR TITLE
Fix memory leak in guihypertext

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1662,8 +1662,9 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	);
 
 	spec.ftype = f_Unknown;
-	(new GUIHyperText(spec.flabel.c_str(), Environment, this, spec.fid, rect,
-			m_client, m_tsrc))->drop();
+	GUIHyperText *e = new GUIHyperText(spec.flabel.c_str(), Environment, this,
+			spec.fid, rect, m_client, m_tsrc);
+	e->drop();
 
 	m_fields.push_back(spec);
 }

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1662,8 +1662,8 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	);
 
 	spec.ftype = f_Unknown;
-	new GUIHyperText(
-		spec.flabel.c_str(), Environment, this, spec.fid, rect, m_client, m_tsrc);
+	(new GUIHyperText(spec.flabel.c_str(), Environment, this, spec.fid, rect,
+			m_client, m_tsrc))->drop();
 
 	m_fields.push_back(spec);
 }

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -109,7 +109,6 @@ ParsedText::ParsedText(const wchar_t *text)
 	m_root_tag.style["color"] = "#EEEEEE";
 	m_root_tag.style["hovercolor"] = m_root_tag.style["color"];
 
-	m_tags.push_back(&m_root_tag);
 	m_active_tags.push_front(&m_root_tag);
 	m_style = m_root_tag.style;
 
@@ -174,7 +173,7 @@ ParsedText::ParsedText(const wchar_t *text)
 
 ParsedText::~ParsedText()
 {
-	for (auto &tag : m_tags)
+	for (auto &tag : m_not_root_tags)
 		delete tag;
 }
 
@@ -289,7 +288,7 @@ ParsedText::Tag *ParsedText::newTag(const std::string &name, const AttrsList &at
 	Tag *newtag = new Tag();
 	newtag->name = name;
 	newtag->attrs = attrs;
-	m_tags.push_back(newtag);
+	m_not_root_tags.push_back(newtag);
 	return newtag;
 }
 
@@ -1012,6 +1011,7 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 GUIHyperText::~GUIHyperText()
 {
 	m_vscrollbar->remove();
+	m_vscrollbar->drop();
 }
 
 ParsedText::Element *GUIHyperText::getElementAt(s32 X, s32 Y)

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -153,7 +153,7 @@ protected:
 	std::unordered_map<std::string, StyleList> m_elementtags;
 	std::unordered_map<std::string, StyleList> m_paragraphtags;
 
-	std::vector<Tag *> m_tags;
+	std::vector<Tag *> m_not_root_tags;
 	std::list<Tag *> m_active_tags;
 
 	// Current values


### PR DESCRIPTION
- The dynamically allocated GUIHyperText in parseHyperText wasn't deallocated before. And dropping it would have resulted in double-freeing of an attribute of ParsedText (`m_root_tag`).
`m_vscrollbar` wasn't dropped either.
- Note: I've taken this from #9487 so that this can be merged in feature freeze.

## To do

This PR is a Ready for Review.

## How to test

Look for segfaults, use valgrind, idk.
Or just look at the code, it should be obvious.
Formspec I've used for testing:
```lua
local my_formspec =
	"formspec_version[3]"..
	"size[10,8]"..
	"hypertext[1,1;5,5;htxt;Bla]"..
	""
```
