### PR TITLE
Make dropdowns optionally return event based on index, not value

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2469,6 +2469,12 @@ Elements
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
 
+### `dropdown_index_event[<name>;<use indexing>]`
+
+* `name`: Name of the dropdown
+* `use indexing`: If true, dropdowns will return the index of the currently
+  selected item instead of the value.
+
 ### `checkbox[<X>,<Y>;<name>;<label>;<selected>]`
 
 * Show a checkbox
@@ -4485,7 +4491,7 @@ Call these functions only at load time!
         * `button` and variants: If pressed, contains the user-facing button
           text as value. If not pressed, is `nil`
         * `field`, `textarea` and variants: Text in the field
-        * `dropdown`: Text of selected item
+        * `dropdown`: Text of selected item or index if `dropdown_index_event` is true
         * `tabheader`: Tab index, starting with `"1"` (only if tab changed)
         * `checkbox`: `"true"` if checked, `"false"` if unchecked
         * `textlist`: See `minetest.explode_textlist_event`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2443,7 +2443,7 @@ Elements
 * `color` is color specified as a `ColorString`.
   If the alpha component is left blank, the box will be semitransparent.
 
-### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
+### `dropdown[<X>,<Y>;<W>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>;<index event>]`
 
 * Show a dropdown field
 * **Important note**: There are two different operation modes:
@@ -2454,8 +2454,12 @@ Elements
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
+* `index event` (optional, allowed parameter since formspec version 4): Specifies the
+  event field value for selected items.
+    * `true`: Selected item index
+    * `false` (default): Selected item value
 
-### `dropdown[<X>,<Y>;<W>,<H>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>]`
+### `dropdown[<X>,<Y>;<W>,<H>;<name>;<item 1>,<item 2>, ...,<item n>;<selected idx>;<index event>]`
 
 * Show a dropdown field
 * **Important note**: This syntax for dropdowns can only be used with the
@@ -2468,12 +2472,10 @@ Elements
 * Fieldname data is transferred to Lua
 * Items to be shown in dropdown
 * Index of currently selected dropdown item
-
-### `dropdown_index_event[<name>;<use indexing>]`
-
-* `name`: Name of the dropdown
-* `use indexing`: If true, dropdowns will return the index of the currently
-  selected item instead of the value.
+* `index event` (optional, allowed parameter since formspec version 4): Specifies the
+  event field value for selected items.
+    * `true`: Selected item index
+    * `false` (default): Selected item value
 
 ### `checkbox[<X>,<Y>;<name>;<label>;<selected>]`
 
@@ -4491,7 +4493,8 @@ Call these functions only at load time!
         * `button` and variants: If pressed, contains the user-facing button
           text as value. If not pressed, is `nil`
         * `field`, `textarea` and variants: Text in the field
-        * `dropdown`: Text of selected item or index if `dropdown_index_event` is true
+        * `dropdown`: Either the index or value, depending on the `index event`
+          dropdown argument.
         * `tabheader`: Tab index, starting with `"1"` (only if tab changed)
         * `checkbox`: `"true"` if checked, `"false"` if unchecked
         * `textlist`: See `minetest.explode_textlist_event`

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1318,7 +1318,6 @@ void GUIFormSpecMenu::parseTextList(parserData* data, const std::string &element
 	errorstream<< "Invalid textlist element(" << parts.size() << "): '" << element << "'"  << std::endl;
 }
 
-
 void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
@@ -1401,6 +1400,16 @@ void GUIFormSpecMenu::parseDropDown(parserData* data, const std::string &element
 				<< element << "'"  << std::endl;
 }
 
+void GUIFormSpecMenu::parseDropDownIndexEvent(const std::string &element)
+{
+	std::vector<std::string> parts = split(element, ';');
+	if (parts.size() == 2 ||
+		(parts.size() > 2 && m_formspec_version > FORMSPEC_API_VERSION))
+	{
+		m_dropdown_index_event[parts[0]] = is_yes(parts[1]);
+	}
+}
+
 void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string &element)
 {
 	std::vector<std::string> parts = split(element,';');
@@ -1414,8 +1423,8 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 {
 	std::vector<std::string> parts = split(element,';');
 
-	if ((parts.size() == 4) ||
-		((parts.size() > 4) && (m_formspec_version > FORMSPEC_API_VERSION)))
+	if (parts.size() == 4 ||
+		(parts.size() > 4 && m_formspec_version > FORMSPEC_API_VERSION))
 	{
 		std::vector<std::string> v_pos = split(parts[0],',');
 		std::vector<std::string> v_geom = split(parts[1],',');
@@ -2755,6 +2764,11 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 		return;
 	}
 
+	if (type == "dropdown_index_event") {
+		parseDropDownIndexEvent(description);
+		return;
+	}
+
 	if (type == "field_close_on_enter") {
 		parseFieldCloseOnEnter(data, description);
 		return;
@@ -2940,6 +2954,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	theme_by_name.clear();
 	theme_by_type.clear();
 	m_clickthrough_elements.clear();
+	field_close_on_enter.clear();
+	m_dropdown_index_event.clear();
 
 	m_bgnonfullscreen = true;
 	m_bgfullscreen = false;
@@ -3727,10 +3743,15 @@ void GUIFormSpecMenu::acceptInput(FormspecQuitMode quitmode=quit_mode_no)
 					}
 					s32 selected = e->getSelected();
 					if (selected >= 0) {
-						std::vector<std::string> *dropdown_values =
-							getDropDownValues(s.fname);
-						if (dropdown_values && selected < (s32)dropdown_values->size()) {
-							fields[name] = (*dropdown_values)[selected];
+						if (m_dropdown_index_event.find(s.fname) !=
+							m_dropdown_index_event.end())
+						{
+							fields[name] = std::to_string(selected + 1);
+						} else {
+							std::vector<std::string> *dropdown_values =
+								getDropDownValues(s.fname);
+							if (dropdown_values && selected < (s32)dropdown_values->size())
+								fields[name] = (*dropdown_values)[selected];
 						}
 					}
 				} else if (s.ftype == f_TabHeader) {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -303,6 +303,7 @@ protected:
 	std::vector<ListRingSpec> m_inventory_rings;
 	std::vector<gui::IGUIElement *> m_backgrounds;
 	std::unordered_map<std::string, bool> field_close_on_enter;
+	std::unordered_map<std::string, bool> m_dropdown_index_event;
 	std::vector<FieldSpec> m_fields;
 	std::vector<std::pair<FieldSpec, GUITable *>> m_tables;
 	std::vector<std::pair<FieldSpec, gui::IGUICheckBox *>> m_checkboxes;
@@ -410,6 +411,7 @@ private:
 	void parseTable(parserData* data, const std::string &element);
 	void parseTextList(parserData* data, const std::string &element);
 	void parseDropDown(parserData* data, const std::string &element);
+	void parseDropDownIndexEvent(const std::string &element);
 	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
 	void parsePwdField(parserData* data, const std::string &element);
 	void parseField(parserData* data, const std::string &element, const std::string &type);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -411,7 +411,6 @@ private:
 	void parseTable(parserData* data, const std::string &element);
 	void parseTextList(parserData* data, const std::string &element);
 	void parseDropDown(parserData* data, const std::string &element);
-	void parseDropDownIndexEvent(const std::string &element);
 	void parseFieldCloseOnEnter(parserData *data, const std::string &element);
 	void parsePwdField(parserData* data, const std::string &element);
 	void parseField(parserData* data, const std::string &element, const std::string &type);

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -238,8 +238,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 		bgcolor[]: use 3 parameters (bgcolor, formspec (now an enum), fbgcolor)
 		box[] and image[] elements enable clipping by default
 		new element: scroll_container[]
+	FORMSPEC VERSION 4:
+		Allow dropdown indexing events
 */
-#define FORMSPEC_API_VERSION 3
+#define FORMSPEC_API_VERSION 4
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 


### PR DESCRIPTION
This PR allows dropdown events to give the dropdown index instead of the value.  The syntax is `dropdown_index_event[<name>;<use indexing>]` where `name` is the dropdown name and `use indexing` sets the use of indexed events.  It can come before or after the dropdown; it doesn't matter.

Many people have expressed desire for this (sorcerykid and orwell are the ones I remember from off the top of my head).

## To do

This PR is Ready for Review.

## How to test

```lua
minetest.register_globalstep(function(dtime)
	local player = minetest.get_player_by_name("singleplayer")
	if player then
		local controls = player:get_player_control()
		if controls.jump then
			minetest.show_formspec("singleplayer", "formspec:test", [[
				formspec_version[4]
				size[4,5]
				dropdown[.5,.5;3,1;default;Default 1,Default 2,Default 3;2]
				dropdown[.5,2;3,1;value;Value 1,Value 2,Value 3;2;false]
				dropdown[.5,3.5;3,1;index;Index 1,Index 2,Index 3;2;true]
			]])
		end
	end
end)

minetest.register_on_player_receive_fields(function(player, formname, fields)
	if fields.default then
		minetest.chat_send_all(fields.default)
	end
	if fields.value then
		minetest.chat_send_all(fields.value)
	end
	if fields.index then
		minetest.chat_send_all(fields.index)
	end
end)
```