### PR TITLE
Remove unnecessary checks before delete

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1285,8 +1285,7 @@ ServerMap::~ServerMap()
 		Close database if it was opened
 	*/
 	delete dbase;
-	if (dbase_ro)
-		delete dbase_ro;
+	delete dbase_ro;
 
 #if 0
 	/*

--- a/src/mapgen/mapgen_fractal.cpp
+++ b/src/mapgen/mapgen_fractal.cpp
@@ -90,9 +90,7 @@ MapgenFractal::MapgenFractal(MapgenFractalParams *params, EmergeManager *emerge)
 
 MapgenFractal::~MapgenFractal()
 {
-	if (noise_seabed)
-		delete noise_seabed;
-
+	delete noise_seabed;
 	delete noise_filler_depth;
 }
 


### PR DESCRIPTION
Removes all the checks of the format

    if (object)
        delete object;

Should close #4617, although there could be more non-trivial unnecessary checks.