### PR TITLE
Color gradient for default and 'regular' type sky

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -252,7 +252,6 @@ void Sky::render()
 		if (m_visible) {
 			driver->setMaterial(m_materials[1]);
 			for (u32 j = 0; j < 4; j++) {
-				video::SColor c = cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
 				vertices[0] = video::S3DVertex(-1, -0.02, -1, 0, 0, 1, m_bgcolor, t, t);
 				vertices[1] = video::S3DVertex( 1, -0.02, -1, 0, 0, 1, m_bgcolor, o, t);
 				vertices[2] = video::S3DVertex( 1, 0.45, -1, 0, 0, 1, m_skycolor, o, o);

--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -253,34 +253,10 @@ void Sky::render()
 			driver->setMaterial(m_materials[1]);
 			for (u32 j = 0; j < 4; j++) {
 				video::SColor c = cloudyfogcolor.getInterpolated(m_skycolor, 0.45);
-				vertices[0] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( 1, 0.12, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-1, 0.12, -1, 0, 0, 1, c, t, o);
-				for (video::S3DVertex &vertex : vertices) {
-					if (j == 0)
-						// Don't switch
-						{}
-					else if (j == 1)
-						// Switch from -Z (south) to +X (east)
-						vertex.Pos.rotateXZBy(90);
-					else if (j == 2)
-						// Switch from -Z (south) to -X (west)
-						vertex.Pos.rotateXZBy(-90);
-					else
-						// Switch from -Z (south) to +Z (north)
-						vertex.Pos.rotateXZBy(-180);
-				}
-				driver->drawIndexedTriangleFan(&vertices[0], 4, indices, 2);
-			}
-
-			// Draw far cloudy fog thing at and below all horizons
-			for (u32 j = 0; j < 4; j++) {
-				video::SColor c = cloudyfogcolor;
-				vertices[0] = video::S3DVertex(-1, -1.0, -1, 0, 0, 1, c, t, t);
-				vertices[1] = video::S3DVertex( 1, -1.0, -1, 0, 0, 1, c, o, t);
-				vertices[2] = video::S3DVertex( 1, 0.08, -1, 0, 0, 1, c, o, o);
-				vertices[3] = video::S3DVertex(-1, 0.08, -1, 0, 0, 1, c, t, o);
+				vertices[0] = video::S3DVertex(-1, -0.02, -1, 0, 0, 1, m_bgcolor, t, t);
+				vertices[1] = video::S3DVertex( 1, -0.02, -1, 0, 0, 1, m_bgcolor, o, t);
+				vertices[2] = video::S3DVertex( 1, 0.45, -1, 0, 0, 1, m_skycolor, o, o);
+				vertices[3] = video::S3DVertex(-1, 0.45, -1, 0, 0, 1, m_skycolor, t, o);
 				for (video::S3DVertex &vertex : vertices) {
 					if (j == 0)
 						// Don't switch

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -76,12 +76,12 @@ public:
 	{
 		SkyColor sky;
 		// Horizon colors
-		sky.day_horizon = video::SColor(255, 149, 219, 255);
+		sky.day_horizon = video::SColor(255, 144, 211, 246);
 		sky.indoors = video::SColor(255, 100, 100, 100);
 		sky.dawn_horizon = video::SColor(255, 186, 193, 240);
 		sky.night_horizon = video::SColor(255, 64, 144, 255);
 		// Sky colors
-		sky.day_sky = video::SColor(255, 101, 188, 253);
+		sky.day_sky = video::SColor(255, 97, 181, 245);
 		sky.dawn_sky = video::SColor(255, 180, 186, 250);
 		sky.night_sky = video::SColor(255, 0, 107, 255);
 		return sky;

--- a/src/skyparams.h
+++ b/src/skyparams.h
@@ -76,12 +76,12 @@ public:
 	{
 		SkyColor sky;
 		// Horizon colors
-		sky.day_horizon = video::SColor(255, 155, 193, 240);
+		sky.day_horizon = video::SColor(255, 149, 219, 255);
 		sky.indoors = video::SColor(255, 100, 100, 100);
 		sky.dawn_horizon = video::SColor(255, 186, 193, 240);
 		sky.night_horizon = video::SColor(255, 64, 144, 255);
 		// Sky colors
-		sky.day_sky = video::SColor(255, 140, 186, 250);
+		sky.day_sky = video::SColor(255, 101, 188, 253);
 		sky.dawn_sky = video::SColor(255, 180, 186, 250);
 		sky.night_sky = video::SColor(255, 0, 107, 255);
 		return sky;


### PR DESCRIPTION
Adds sky color gradient which extends from the horizon up to roughly 25 degrees above it.
Should also increase client performance somewhat, as one of the 'far cloudy fog things' has been removed as redundant.
It works with default and type='regular' sky. Tested with #8964 in effect.

Change of default colors is not essential for this PR, however I put it up for serious consideration.
- sky color, previously it extended from the horizon line all the way to the zenith. Here, flat sky color occupies only the top part of the sky 'dome', so in my opinion, it's no longer justified for it to be this dull.
- background color, it's dirty gray, not a good choice because fog inherits this color effectively overlaying everything with it, I think it has to go.

The picture below uses my proposed colors. I'm not claiming they are the best possible, but I think it's the right direction. Please don't judge the colors based on the image, check em out in game.

![grad2](https://user-images.githubusercontent.com/55103816/76354543-f3426f80-6312-11ea-9013-257861787ea5.jpg)

## To do

This PR is Ready for Review.

Please consider not doing coding style reviews. This PR doesn't add a single line of code, it's all modifications and deletions, all coding style is received