### PR TITLE
Fix some chatcommands not returning a value

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -136,14 +136,14 @@ help_command.func = function(name, param)
 		core.show_formspec(name, "__builtin:help_privs",
 			build_privs_formspec(name))
 		if name ~= admin then
-			return
+			return true
 		end
 	end
 	if param == "" or param == "all" then
 		core.show_formspec(name, "__builtin:help_cmds",
 			build_chatcommands_formspec(name))
 		if name ~= admin then
-			return
+			return true
 		end
 	end
 

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -115,6 +115,7 @@ core.register_chatcommand("me", {
 	privs = {shout=true},
 	func = function(name, param)
 		core.chat_send_all("* " .. name .. " " .. param)
+		return true
 	end,
 })
 
@@ -919,6 +920,7 @@ core.register_chatcommand("shutdown", {
 			core.chat_send_all("*** Server shutting down (operator request).")
 		end
 		core.request_shutdown(message:trim(), core.is_yes(reconnect), delay)
+		return true
 	end,
 })
 
@@ -1001,6 +1003,7 @@ core.register_chatcommand("clearobjects", {
 		core.clear_objects(options)
 		core.log("action", "Object clearing done.")
 		core.chat_send_all("*** Cleared all objects.")
+		return true
 	end,
 })
 


### PR DESCRIPTION
Some chat commands in `builtin` did not have a boolean return value. This PR fixes this.

Affected commands: `me`, `shutdown`, `clearobjects` and `help`.

## To do

This PR is ready for review.

