### PR TITLE
Add comments for translators

### DIFF
--- a/builtin/mainmenu/dlg_settings_advanced.lua
+++ b/builtin/mainmenu/dlg_settings_advanced.lua
@@ -639,12 +639,23 @@ local function create_change_setting_formspec(dialogdata)
 		-- Flags
 		formspec = table.concat(fields)
 				.. "checkbox[0.5," .. height - 0.6 .. ";cb_defaults;"
+				--[[~ "defaults" is a noise parameter flag.
+				It describes the default processing options
+				for noise settings in main menu -> "All Settings". ]]
 				.. fgettext("defaults") .. ";" -- defaults
 				.. tostring(flags["defaults"] == true) .. "]" -- to get false if nil
 				.. "checkbox[5," .. height - 0.6 .. ";cb_eased;"
+				--[[~ "eased" is a noise parameter flag.
+				It is used to make the map smoother and
+				can be enabled in noise settings in
+				main menu -> "All Settings". ]]
 				.. fgettext("eased") .. ";" -- eased
 				.. tostring(flags["eased"] == true) .. "]"
 				.. "checkbox[5," .. height - 0.15 .. ";cb_absvalue;"
+				--[[~ "absvalue" is a noise parameter flag.
+				It is short for "absolute value".
+				It can be enabled in noise settings in
+				main menu -> "All Settings". ]]
 				.. fgettext("absvalue") .. ";" -- absvalue
 				.. tostring(flags["absvalue"] == true) .. "]"
 		height = height + 1

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -78,6 +78,7 @@ local function get_formspec(tabview, name, tabdata)
 		"text,align=right,padding=0.25;" ..   -- clients_max
 		image_column(fgettext("Creative mode"), "creative") .. ",padding=1;" ..
 		image_column(fgettext("Damage enabled"), "damage") .. ",padding=0.25;" ..
+		--~ PvP = Player versus Player
 		image_column(fgettext("PvP enabled"), "pvp") .. ",padding=0.25;" ..
 		"color,span=1;" ..
 		"text,padding=1]" ..

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -194,6 +194,14 @@ void FontEngine::readSettings()
 		m_default_size[FM_Fallback] = m_settings->getU16("fallback_font_size");
 		m_default_size[FM_Mono]     = m_settings->getU16("mono_font_size");
 
+		/*~ DO NOT TRANSLATE THIS LITERALLY!
+		This is a special string. Put either "no" or "yes"
+		into the translation field (literally).
+		Choose "yes" if the language requires use of the fallback
+		font, "no" otherwise.
+		The fallback font is (normally) required for languages with
+		non-Latin script, like Chinese.
+		When in doubt, test your translation. */
 		m_currentMode = is_yes(gettext("needs_fallback_font")) ?
 				FM_Fallback : FM_Standard;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4184,6 +4184,7 @@ void Game::showPauseMenu()
 				<< strgettext("- Creative Mode: ") << creative << "\n";
 		if (!simple_singleplayer_mode) {
 			const std::string &pvp = g_settings->getBool("enable_pvp") ? on : off;
+			//~ PvP = Player versus Player
 			os << strgettext("- PvP: ") << pvp << "\n"
 					<< strgettext("- Public: ") << announced << "\n";
 			std::string server_name = g_settings->get("server_name");

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -109,6 +109,7 @@ static const struct table_key table[] = {
 	DEFINEKEY1(KEY_RETURN, N_("Return"))
 	DEFINEKEY1(KEY_SHIFT, N_("Shift"))
 	DEFINEKEY1(KEY_CONTROL, N_("Control"))
+	//~ Key name, common on Windows keyboards
 	DEFINEKEY1(KEY_MENU, N_("Menu"))
 	DEFINEKEY1(KEY_PAUSE, N_("Pause"))
 	DEFINEKEY1(KEY_CAPITAL, N_("Caps Lock"))
@@ -121,7 +122,9 @@ static const struct table_key table[] = {
 	DEFINEKEY1(KEY_UP, N_("Up"))
 	DEFINEKEY1(KEY_RIGHT, N_("Right"))
 	DEFINEKEY1(KEY_DOWN, N_("Down"))
+	//~ Key name
 	DEFINEKEY1(KEY_SELECT, N_("Select"))
+	//~ "Print screen" key
 	DEFINEKEY1(KEY_PRINT, N_("Print"))
 	DEFINEKEY1(KEY_EXECUT, N_("Execute"))
 	DEFINEKEY1(KEY_SNAPSHOT, N_("Snapshot"))

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -134,6 +134,8 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 				return retval;
 
 			m_jni_field_name = field_name;
+			/*~ Imperative, as in "Enter/type in text".
+			Don't forget the space. */
 			std::string message = gettext("Enter ");
 			std::string label = wide_to_utf8(getLabelByID(hovered->getID()));
 			if (label.empty())

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -135,6 +135,9 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 					<< m_recommended_send_interval<<std::endl;
 
 	// Reply to server
+	/*~ DO NOT TRANSLATE THIS LITERALLY!
+	This is a special string which needs to contain the translation's
+	language code (e.g. "de" for German). */
 	std::string lang = gettext("LANG_CODE");
 	if (lang == "LANG_CODE")
 		lang = "";

--- a/util/updatepo.sh
+++ b/util/updatepo.sh
@@ -49,6 +49,7 @@ cd ..
 # --package-name
 potfile=po/minetest.pot
 xgettext --package-name=minetest \
+	--add-comments='~' \
 	--sort-by-file \
 	--add-location=file \
 	--keyword=N_ \


### PR DESCRIPTION
Fixes #8178.

I also added comments for other strings that are probably confusing and ambigious to translators.

##### How to test

1. Run `util/updatepo.sh`
2. Check if the new PO files include translator-directed comments for e.g. `LANG_CODE` (line starting with "`#. ~`". Alternatively, check with software like Poedit)