### PR TITLE
Transform texture UVs with provided tex. matrix (#9481)

### DIFF
--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -27,7 +27,7 @@ float directional_ambient(vec3 normal)
 
 void main(void)
 {
-	gl_TexCoord[0] = gl_MultiTexCoord0;
+	gl_TexCoord[0] = gl_MultiTexCoord0 * gl_TextureMatrix[0];
 	gl_Position = mWorldViewProj * gl_Vertex;
 
 	vPosition = gl_Position.xyz;

--- a/client/shaders/object_shader/opengl_vertex.glsl
+++ b/client/shaders/object_shader/opengl_vertex.glsl
@@ -27,7 +27,7 @@ float directional_ambient(vec3 normal)
 
 void main(void)
 {
-	gl_TexCoord[0] = gl_MultiTexCoord0 * gl_TextureMatrix[0];
+	gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;
 	gl_Position = mWorldViewProj * gl_Vertex;
 
 	vPosition = gl_Position.xyz;


### PR DESCRIPTION
Fixes #9481. Object shader was ignoring texture transformation matrix.

## How to test

- Play the [devtest](https://git.minetest.land/Wuzzy/devtest) game
- Give yourself the entity spawner (testtools:entity_spawner)
- Punch to select entity type, place to spawn entity
- Spawn experimental:yawsprite or experimental:armorball

Expected: Displays a single sprite
