### PR TITLE
FormspecMenu: make drawing of backgrounds less hacky

### DIFF
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -430,6 +430,33 @@ mouse control = true]
 			checkbox[0.5,5.5.5;snd_chk;Sound;]
 			tabheader[0.5,7;8,0.65;snd_tab;Soundtab1,Soundtab2,Soundtab3;1;false;false]
 		]],
+
+	-- Background
+		[[
+			formspec_version[3]
+			size[12,13]
+			box[0,0;12,13;#f0f1]
+			background[0,0;0,0;testformspec_bg.png;true]
+			box[3.9,2.9;6.2,4.2;#d00f]
+			scroll_container[4,3;6,4;scrbar;vertical]
+				background9[1,0.5;0,0;testformspec_bg_9slice.png;true;4,6]
+				label[0,0.2;Backgrounds are not be applied to scroll containers,]
+				label[0,0.5;but to the whole form.]
+			scroll_container_end[]
+			scrollbar[3.5,3;0.3,4;vertical;scrbar;0]
+			container[2,11]
+				box[-0.1,0.5;3.2,1;#fff5]
+				background[0,0;2,3;testformspec_bg.png;false]
+				background9[1,0;2,3;testformspec_bg_9slice.png;false;4,6]
+			container_end[]
+		]],
+
+	-- Unsized
+		[[
+			formspec_version[3]
+			background9[0,0;0,0;testformspec_bg_9slice.png;true;4,6]
+			background[1,1;0,0;testformspec_bg.png;true]
+		]],
 }
 
 local page_id = 2
@@ -439,7 +466,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;8,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Sound,Background,Unsized;" .. page_id .. ";false;false]"
 
 	minetest.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/src/gui/guiBackgroundImage.cpp
+++ b/src/gui/guiBackgroundImage.cpp
@@ -44,7 +44,7 @@ void GUIBackgroundImage::draw()
 
 	core::rect<s32> rect = AbsoluteRect;
 	if (m_autoclip)
-		rect.LowerRightCorner += Parent->getAbsolutePosition().getSize();
+		rect.LowerRightCorner += Parent->getAbsoluteClippingRect().getSize();
 
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -24,6 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <unordered_set>
 
 #include "irrlichttypes_extrabloated.h"
+#include "irr_ptr.h"
 #include "inventorymanager.h"
 #include "modalMenu.h"
 #include "guiInventoryList.h"
@@ -313,7 +314,6 @@ protected:
 
 	std::vector<GUIInventoryList *> m_inventorylists;
 	std::vector<ListRingSpec> m_inventory_rings;
-	std::vector<gui::IGUIElement *> m_backgrounds;
 	std::unordered_map<std::string, bool> field_close_on_enter;
 	std::unordered_map<std::string, bool> m_dropdown_index_event;
 	std::vector<FieldSpec> m_fields;
@@ -375,6 +375,7 @@ private:
 		GUITable::TableOptions table_options;
 		GUITable::TableColumns table_columns;
 		gui::IGUIElement *current_parent = nullptr;
+		irr_ptr<gui::IGUIElement> background_parent;
 
 		GUIInventoryList::Options inventorylist_options;
 


### PR DESCRIPTION
- Goal of the PR:
Since #8740, all backgrounds are set invisible and set visible only while they are drawn. They are drawn manually and stored separately. This is hacky and weird. The goal is to change this.
- How does the PR work?
In regenerateGui, a new element is added to hold all background elements as its children. Because it's the first element that is added, it and its children (hence all backgrounds) will be the first elements to be drawn. This means all backgrounds are in the back.
- Does it resolve any reported issue?
Probably not.
- Why is this PR needed?
The old way is more hacky.

## To do

This PR is a Ready for Review.
(I didn't really test this yet.)

## How to test

- Look at the new `/test_formspec` tabs.
- Make screenshots of the Background tab and `compare` master with this PR.
You should see this:
![scrnsht_tst_fs](https://user-images.githubusercontent.com/7613443/147715181-51a97910-9526-4b04-8cdb-7ca6159014f8.png)

