### PR TITLE
Fix mouse events sent to wrong GUI elements when dragging

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3649,7 +3649,8 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	// Mouse wheel and move events: send to hovered element instead of focused
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
 			(event.MouseInput.Event == EMIE_MOUSE_WHEEL ||
-			 event.MouseInput.Event == EMIE_MOUSE_MOVED)) {
+			(event.MouseInput.Event == EMIE_MOUSE_MOVED &&
+			event.MouseInput.ButtonStates == 0))) {
 		s32 x = event.MouseInput.X;
 		s32 y = event.MouseInput.Y;
 		gui::IGUIElement *hovered =


### PR DESCRIPTION
fixes #9518

## To do

This PR is a Ready for Review.

## How to test

Reproduction GIF from the issue, you can test this in the "Online" tab of the mainmenu.
![](https://user-images.githubusercontent.com/24327224/76702503-5bd57780-6698-11ea-8982-a4376cb239ec.gif)