### PR TITLE
Add tone mapping for entities

### DIFF
--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -25,6 +25,38 @@ const float BS = 10.0;
 const float fogStart = FOG_START;
 const float fogShadingParameter = 1 / ( 1 - fogStart);
 
+#ifdef ENABLE_TONE_MAPPING
+
+/* Hable's UC2 Tone mapping parameters
+	A = 0.22;
+	B = 0.30;
+	C = 0.10;
+	D = 0.20;
+	E = 0.01;
+	F = 0.30;
+	W = 11.2;
+	equation used:  ((x * (A * x + C * B) + D * E) / (x * (A * x + B) + D * F)) - E / F
+*/
+
+vec3 uncharted2Tonemap(vec3 x)
+{
+	return ((x * (0.22 * x + 0.03) + 0.002) / (x * (0.22 * x + 0.3) + 0.06)) - 0.03333;
+}
+
+vec4 applyToneMapping(vec4 color)
+{
+	color = vec4(pow(color.rgb, vec3(2.2)), color.a);
+	const float gamma = 1.6;
+	const float exposureBias = 5.5;
+	color.rgb = uncharted2Tonemap(exposureBias * color.rgb);
+	// Precalculated white_scale from 
+	//vec3 whiteScale = 1.0 / uncharted2Tonemap(vec3(W));
+	vec3 whiteScale = vec3(1.036015346);
+	color.rgb *= whiteScale;
+	return vec4(pow(color.rgb, vec3(1.0 / gamma)), color.a);
+}
+#endif
+
 void get_texture_flags()
 {
 	vec4 flags = texture2D(textureFlags, vec2(0.0, 0.0));
@@ -114,6 +146,11 @@ void main(void)
 	vec4 col = vec4(color.rgb, base.a);
 
 	col.rgb *= emissiveColor.rgb * vIDiff;
+		
+#ifdef ENABLE_TONE_MAPPING
+	col = applyToneMapping(col);
+#endif
+
 	// Due to a bug in some (older ?) graphics stacks (possibly in the glsl compiler ?),
 	// the fog will only be rendered correctly if the last operation before the
 	// clamp() is an addition. Else, the clamp() seems to be ignored.


### PR DESCRIPTION
Fixes #9301. I just copied the code from frag. shader of nodes. Not the most elegant solution, comparing to adding actual post-processing, but at least it works for now.

## How to test

Launch the game with and without tone mapping and look at the entities. Try spawning different types of renderables with [Wuzzy's devtest](https://git.minetest.land/Wuzzy/devtest)

![изображение](https://user-images.githubusercontent.com/12214069/76804874-702b8880-67ee-11ea-84a4-180a73acc45d.png)

