### PR TITLE
Add object crosshair and disable entity selectionboxes by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -746,6 +746,12 @@ crosshair_color (Crosshair color) string (255,255,255)
 #    Crosshair alpha (opaqueness, between 0 and 255).
 crosshair_alpha (Crosshair alpha) int 255 0 255
 
+#    Selectionindicator color (R,G,B).
+selectionindicator_color (Selection indicator color) string (255,255,255)
+
+#    Selectionindicator alpha (opaqueness, between 0 and 255).
+selectionindicator_alpha (Selection indicator alpha) int 255 0 255
+
 #    Maximum number of recent chat messages to show
 recent_chat_messages (Recent Chat Messages) int 6 2 20
 
@@ -817,7 +823,8 @@ world_aligned_mode (World-aligned textures mode) enum enable disable,enable,forc
 autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 
 #    Show entity selection boxes
-show_entity_selectionbox (Show entity selection boxes) bool true
+#    A restart is required after changing this.
+show_entity_selectionbox (Show entity selection boxes) bool false
 
 [*Menus]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -741,16 +741,12 @@ selectionbox_color (Selection box color) string (0,0,0)
 selectionbox_width (Selection box width) int 2 1 5
 
 #    Crosshair color (R,G,B).
+#    Also controls the object crosshair color
 crosshair_color (Crosshair color) string (255,255,255)
 
 #    Crosshair alpha (opaqueness, between 0 and 255).
+#    Also controls the object crosshair color
 crosshair_alpha (Crosshair alpha) int 255 0 255
-
-#    Object crosshair color (R,G,B).
-object_crosshair_color (Object Crosshair color) string (255,255,255)
-
-#    Object crosshair alpha (opaqueness, between 0 and 255).
-object_crosshair_alpha (Object Crosshair alpha) int 255 0 255
 
 #    Maximum number of recent chat messages to show
 recent_chat_messages (Recent Chat Messages) int 6 2 20

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -746,11 +746,11 @@ crosshair_color (Crosshair color) string (255,255,255)
 #    Crosshair alpha (opaqueness, between 0 and 255).
 crosshair_alpha (Crosshair alpha) int 255 0 255
 
-#    Selectionindicator color (R,G,B).
-selectionindicator_color (Selection indicator color) string (255,255,255)
+#    Object crosshair color (R,G,B).
+object_crosshair_color (Object Crosshair color) string (255,255,255)
 
-#    Selectionindicator alpha (opaqueness, between 0 and 255).
-selectionindicator_alpha (Selection indicator alpha) int 255 0 255
+#    Object crosshair alpha (opaqueness, between 0 and 255).
+object_crosshair_alpha (Object Crosshair alpha) int 255 0 255
 
 #    Maximum number of recent chat messages to show
 recent_chat_messages (Recent Chat Messages) int 6 2 20

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -74,9 +74,9 @@ by texture packs. All existing fallback textures can be found in the directory
       `crosshair_color` and `crosshair_alpha` are used to create a cross
       when no texture was found
 
-* `selectionindicator.png`
+* `object_crosshair.png`
 * the dot above the crosshair seen when pointing at an entity. Will replace crosshair when shown. The settings
-`selectionindicator_color` and `selectionindicator_alpha` are used to create a cross
+`object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
 when no texture was found
 
 * `halo.png`: used for the node highlighting mesh

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -72,12 +72,12 @@ by texture packs. All existing fallback textures can be found in the directory
 * `crosshair.png`
     * the crosshair texture in the center of the screen. The settings
       `crosshair_color` and `crosshair_alpha` are used to create a cross
-      when no texture was found
+      when no texture is found.
 
 * `object_crosshair.png`
     * the crosshair seen when pointing at an object. The settings
     `object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
-    when no texture was found
+    when no texture is found.
 
 * `halo.png`: used for the node highlighting mesh
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -75,7 +75,7 @@ by texture packs. All existing fallback textures can be found in the directory
       when no texture was found
 
 * `selectionindicator.png`
-* the entity selection indicator texture above the crosshair. The settings
+* the dot above the crosshair seen when pointing at an entity. Will replace crosshair when shown. The settings
 `selectionindicator_color` and `selectionindicator_alpha` are used to create a cross
 when no texture was found
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -74,6 +74,11 @@ by texture packs. All existing fallback textures can be found in the directory
       `crosshair_color` and `crosshair_alpha` are used to create a cross
       when no texture was found
 
+* `selectionindicator.png`
+* the entity selection indicator texture above the crosshair. The settings
+`selectionindicator_color` and `selectionindicator_alpha` are used to create a cross
+when no texture was found
+
 * `halo.png`: used for the node highlighting mesh
 
 * `heart.png`: used to display the health points of the player

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -75,7 +75,7 @@ by texture packs. All existing fallback textures can be found in the directory
       when no texture was found
 
 * `object_crosshair.png`
-* the dot above the crosshair seen when pointing at an entity. Will replace crosshair when shown. The settings
+* the crosshair seen when pointing at an object. The settings
 `object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
 when no texture was found
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -75,9 +75,9 @@ by texture packs. All existing fallback textures can be found in the directory
       when no texture was found
 
 * `object_crosshair.png`
-* the crosshair seen when pointing at an object. The settings
-`object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
-when no texture was found
+    * the crosshair seen when pointing at an object. The settings
+    `object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
+    when no texture was found
 
 * `halo.png`: used for the node highlighting mesh
 

--- a/doc/texture_packs.txt
+++ b/doc/texture_packs.txt
@@ -76,7 +76,7 @@ by texture packs. All existing fallback textures can be found in the directory
 
 * `object_crosshair.png`
     * the crosshair seen when pointing at an object. The settings
-    `object_crosshair_color` and `object_crosshair_alpha` are used to create a cross
+    `crosshair_color` and `crosshair_alpha` are used to create a cross
     when no texture is found.
 
 * `halo.png`: used for the node highlighting mesh

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -955,8 +955,9 @@
 # autoscale_mode = disable
 
 #    Show entity selection boxes
+#    A restart is required after changing this.
 #    type: bool
-# show_entity_selectionbox = true
+# show_entity_selectionbox = false
 
 ## Menus
 
@@ -3374,4 +3375,3 @@
 #    so see a full list at https://content.minetest.net/help/content_flags/
 #    type: string
 # contentdb_flag_blacklist = nonfree, desktop_default
-

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -955,8 +955,9 @@
 # autoscale_mode = disable
 
 #    Show entity selection boxes
+#    A restart is required after changing this.
 #    type: bool
-# show_entity_selectionbox = true
+# show_entity_selectionbox = false
 
 ## Menus
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -955,9 +955,8 @@
 # autoscale_mode = disable
 
 #    Show entity selection boxes
-#    A restart is required after changing this.
 #    type: bool
-# show_entity_selectionbox = false
+# show_entity_selectionbox = true
 
 ## Menus
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3198,8 +3198,7 @@ PointedThing Game::updatePointedThing(
 	PointedThing result;
 	env.continueRaycast(&s, &result);
 	if (result.type == POINTEDTHING_OBJECT) {
-		if (!hud->can_draw_selectionindicator)
-			hud->can_draw_selectionindicator = true;
+		hud->can_draw_selectionindicator = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
 		aabb3f selection_box;
@@ -3231,8 +3230,7 @@ PointedThing Game::updatePointedThing(
 			result.intersection_normal.Y,
 			result.intersection_normal.Z));
 
-		if (hud->can_draw_selectionindicator)
-			hud->can_draw_selectionindicator = false;
+		hud->can_draw_selectionindicator = false;
 	}
 
 	// Update selection mesh light level and vertex colors

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3199,7 +3199,8 @@ PointedThing Game::updatePointedThing(
 	PointedThing result;
 	env.continueRaycast(&s, &result);
 	if (result.type == POINTEDTHING_OBJECT) {
-		hud->can_draw_selectionindicator = true;
+		if (!hud->can_draw_selectionindicator)
+			hud->can_draw_selectionindicator = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
 		aabb3f selection_box;
@@ -3231,6 +3232,11 @@ PointedThing Game::updatePointedThing(
 			result.intersection_normal.Y,
 			result.intersection_normal.Z));
 
+<<<<<<< HEAD
+=======
+		if (hud->can_draw_selectionindicator)
+			hud->can_draw_selectionindicator = false;
+>>>>>>> The PR is born
 	}
 
 	// Update selection mesh light level and vertex colors

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3193,14 +3193,13 @@ PointedThing Game::updatePointedThing(
 	const NodeDefManager *nodedef = map.getNodeDefManager();
 
 	runData.selected_object = NULL;
-	hud->can_draw_selectionindicator = false;
+	hud->can_draw_object_crosshair = false;
 
 	RaycastState s(shootline, look_for_object, liquids_pointable);
 	PointedThing result;
 	env.continueRaycast(&s, &result);
 	if (result.type == POINTEDTHING_OBJECT) {
-		if (!hud->can_draw_selectionindicator)
-			hud->can_draw_selectionindicator = true;
+		hud->can_draw_object_crosshair = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
 		aabb3f selection_box;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3193,6 +3193,7 @@ PointedThing Game::updatePointedThing(
 	const NodeDefManager *nodedef = map.getNodeDefManager();
 
 	runData.selected_object = NULL;
+	hud->can_draw_selectionindicator = false;
 
 	RaycastState s(shootline, look_for_object, liquids_pointable);
 	PointedThing result;
@@ -3230,7 +3231,6 @@ PointedThing Game::updatePointedThing(
 			result.intersection_normal.Y,
 			result.intersection_normal.Z));
 
-		hud->can_draw_selectionindicator = false;
 	}
 
 	// Update selection mesh light level and vertex colors

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3193,13 +3193,13 @@ PointedThing Game::updatePointedThing(
 	const NodeDefManager *nodedef = map.getNodeDefManager();
 
 	runData.selected_object = NULL;
-	hud->can_draw_object_crosshair = false;
+	hud->pointing_at_object = false;
 
 	RaycastState s(shootline, look_for_object, liquids_pointable);
 	PointedThing result;
 	env.continueRaycast(&s, &result);
 	if (result.type == POINTEDTHING_OBJECT) {
-		hud->can_draw_object_crosshair = true;
+		hud->pointing_at_object = true;
 
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
 		aabb3f selection_box;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3230,12 +3230,6 @@ PointedThing Game::updatePointedThing(
 			result.intersection_normal.X,
 			result.intersection_normal.Y,
 			result.intersection_normal.Z));
-
-<<<<<<< HEAD
-=======
-		if (hud->can_draw_selectionindicator)
-			hud->can_draw_selectionindicator = false;
->>>>>>> The PR is born
 	}
 
 	// Update selection mesh light level and vertex colors

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3198,6 +3198,9 @@ PointedThing Game::updatePointedThing(
 	PointedThing result;
 	env.continueRaycast(&s, &result);
 	if (result.type == POINTEDTHING_OBJECT) {
+		if (!hud->can_draw_selectionindicator)
+			hud->can_draw_selectionindicator = true;
+
 		runData.selected_object = client->getEnv().getActiveObject(result.object_id);
 		aabb3f selection_box;
 		if (show_entity_selectionbox && runData.selected_object->doShowSelectionBox() &&
@@ -3227,6 +3230,9 @@ PointedThing Game::updatePointedThing(
 			result.intersection_normal.X,
 			result.intersection_normal.Y,
 			result.intersection_normal.Z));
+
+		if (hud->can_draw_selectionindicator)
+			hud->can_draw_selectionindicator = false;
 	}
 
 	// Update selection mesh light level and vertex colors

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -41,6 +41,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "gui/touchscreengui.h"
 #endif
 
+#define OBJECT_CROSSHAIR_LINE_SIZE 8
+#define CROSSHAIR_LINE_SIZE 10
+
 Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 		Inventory *inventory)
 {
@@ -620,9 +623,17 @@ void Hud::drawCrosshair()
 					core::rect<s32>(0, 0, size.X, size.Y),
 					nullptr, object_crosshair_argb, true);
 		} else {
-			driver->draw2DLine(m_displaycenter - v2s32(8, 8), m_displaycenter + v2s32(8, 8),
+			driver->draw2DLine(
+					m_displaycenter - v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
+					OBJECT_CROSSHAIR_LINE_SIZE),
+					m_displaycenter + v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
+					OBJECT_CROSSHAIR_LINE_SIZE),
 					object_crosshair_argb);
-			driver->draw2DLine(m_displaycenter + v2s32(8, -8), m_displaycenter + v2s32(-8, 8),
+			driver->draw2DLine(
+					m_displaycenter + v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
+					-OBJECT_CROSSHAIR_LINE_SIZE),
+					m_displaycenter + v2s32(-OBJECT_CROSSHAIR_LINE_SIZE,
+					OBJECT_CROSSHAIR_LINE_SIZE),
 					object_crosshair_argb);
 		}
 	} else if (use_crosshair_image) {
@@ -634,10 +645,10 @@ void Hud::drawCrosshair()
 				core::rect<s32>(0, 0, size.X, size.Y),
 				nullptr, crosshair_argb, true);
 	} else {
-		driver->draw2DLine(m_displaycenter - v2s32(10, 0),
-				m_displaycenter + v2s32(10, 0), crosshair_argb);
-		driver->draw2DLine(m_displaycenter - v2s32(0, 10),
-				m_displaycenter + v2s32(0, 10), crosshair_argb);
+		driver->draw2DLine(m_displaycenter - v2s32(CROSSHAIR_LINE_SIZE, 0),
+				m_displaycenter + v2s32(CROSSHAIR_LINE_SIZE, 0), crosshair_argb);
+		driver->draw2DLine(m_displaycenter - v2s32(0, CROSSHAIR_LINE_SIZE),
+				m_displaycenter + v2s32(0, CROSSHAIR_LINE_SIZE), crosshair_argb);
 	}
 }
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -638,7 +638,7 @@ void Hud::drawSelectionIndicator()
 		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
 		v2u32 size  = selectionindicator->getOriginalSize();
 		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
-				m_displaycenter.Y - size.Y - y_offset+5);
+				m_displaycenter.Y - (size.Y / 2));
 		driver->draw2DImage(selectionindicator, lsize,
 				core::rect<s32>(0, 0, size.X, size.Y),
 				0, selectionindicator_argb, true);

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -609,8 +609,22 @@ void Hud::drawHotbar(u16 playeritem) {
 
 void Hud::drawCrosshair()
 {
-	if (can_draw_selectionindicator && use_selectionindicator_image)
-		return;
+	if (can_draw_selectionindicator)
+	{
+		if (use_selectionindicator_image) {
+			video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
+			v2u32 size  = selectionindicator->getOriginalSize();
+			v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
+					m_displaycenter.Y - (size.Y / 2));
+			driver->draw2DImage(selectionindicator, lsize,
+					core::rect<s32>(0, 0, size.X, size.Y),
+					nullptr, selectionindicator_argb, true);
+
+			return;
+		} else {
+			driver->draw2DPolygon(irr::core::vector2di(m_displaycenter.X, m_displaycenter.Y - 22), 7, selectionindicator_argb, 4);
+		}
+	}
 
 	if (use_crosshair_image) {
 		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
@@ -619,30 +633,12 @@ void Hud::drawCrosshair()
 				m_displaycenter.Y - (size.Y / 2));
 		driver->draw2DImage(crosshair, lsize,
 				core::rect<s32>(0, 0, size.X, size.Y),
-				0, crosshair_argb, true);
+				nullptr, crosshair_argb, true);
 	} else {
 		driver->draw2DLine(m_displaycenter - v2s32(10, 0),
 				m_displaycenter + v2s32(10, 0), crosshair_argb);
 		driver->draw2DLine(m_displaycenter - v2s32(0, 10),
 				m_displaycenter + v2s32(0, 10), crosshair_argb);
-	}
-}
-
-void Hud::drawSelectionIndicator()
-{
-	int y_offset = 15;
-
-	if (use_selectionindicator_image) {
-		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
-		v2u32 size  = selectionindicator->getOriginalSize();
-		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
-				m_displaycenter.Y - (size.Y / 2));
-		driver->draw2DImage(selectionindicator, lsize,
-				core::rect<s32>(0, 0, size.X, size.Y),
-				0, selectionindicator_argb, true);
-	} else {
-		driver->draw2DRectangle(selectionindicator_argb, core::rect<s32>(m_displaycenter.X-4,
-		m_displaycenter.Y-y_offset-8, m_displaycenter.X+4, m_displaycenter.Y-y_offset), nullptr);
 	}
 }
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -609,6 +609,9 @@ void Hud::drawHotbar(u16 playeritem) {
 
 void Hud::drawCrosshair()
 {
+	if (can_draw_selectionindicator && use_selectionindicator_image)
+		return;
+
 	if (use_crosshair_image) {
 		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
 		v2u32 size  = crosshair->getOriginalSize();
@@ -628,11 +631,6 @@ void Hud::drawCrosshair()
 void Hud::drawSelectionIndicator()
 {
 	int y_offset = 15;
-
-	if (use_crosshair_image) {
-		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
-		y_offset = (crosshair->getOriginalSize().Height/2) + 5;
-	}
 
 	if (use_selectionindicator_image) {
 		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -69,12 +69,12 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 	u32 cross_a = rangelim(g_settings->getS32("crosshair_alpha"), 0, 255);
 	crosshair_argb = video::SColor(cross_a, cross_r, cross_g, cross_b);
 
-	v3f selectionindicator_color = g_settings->getV3F("selectionindicator_color");
-	u32 selecind_r = rangelim(myround(selectionindicator_color.X), 0, 255);
-	u32 selecind_g = rangelim(myround(selectionindicator_color.Y), 0, 255);
-	u32 selecind_b = rangelim(myround(selectionindicator_color.Z), 0, 255);
-	u32 selecind_a = rangelim(g_settings->getS32("selectionindicator_alpha"), 0, 255);
-	selectionindicator_argb = video::SColor(selecind_a, selecind_r, selecind_g, selecind_b);
+	v3f object_crosshair_color = g_settings->getV3F("object_crosshair_color");
+	u32 selecind_r = rangelim(myround(object_crosshair_color.X), 0, 255);
+	u32 selecind_g = rangelim(myround(object_crosshair_color.Y), 0, 255);
+	u32 selecind_b = rangelim(myround(object_crosshair_color.Z), 0, 255);
+	u32 selecind_a = rangelim(g_settings->getS32("object_crosshair_alpha"), 0, 255);
+	object_crosshair_argb = video::SColor(selecind_a, selecind_r, selecind_g, selecind_b);
 
 	v3f selectionbox_color = g_settings->getV3F("selectionbox_color");
 	u32 sbox_r = rangelim(myround(selectionbox_color.X), 0, 255);
@@ -83,7 +83,7 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 	selectionbox_argb = video::SColor(255, sbox_r, sbox_g, sbox_b);
 
 	use_crosshair_image = tsrc->isKnownSourceImage("crosshair.png");
-	use_selectionindicator_image = tsrc->isKnownSourceImage("selectionindicator.png");
+	use_object_crosshair_image = tsrc->isKnownSourceImage("object_crosshair.png");
 
 	m_selection_boxes.clear();
 	m_halo_boxes.clear();
@@ -609,21 +609,21 @@ void Hud::drawHotbar(u16 playeritem) {
 
 void Hud::drawCrosshair()
 {
-	if (can_draw_selectionindicator)
+	if (can_draw_object_crosshair)
 	{
-		if (use_selectionindicator_image) {
-			video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
-			v2u32 size  = selectionindicator->getOriginalSize();
+		if (use_object_crosshair_image) {
+			video::ITexture *object_crosshair = tsrc->getTexture("object_crosshair.png");
+			v2u32 size  = object_crosshair->getOriginalSize();
 			v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
 					m_displaycenter.Y - (size.Y / 2));
-			driver->draw2DImage(selectionindicator, lsize,
+			driver->draw2DImage(object_crosshair, lsize,
 					core::rect<s32>(0, 0, size.X, size.Y),
-					nullptr, selectionindicator_argb, true);
+					nullptr, object_crosshair_argb, true);
 		} else {
 			driver->draw2DLine(m_displaycenter - v2s32(8, 8), m_displaycenter + v2s32(8, 8),
-					selectionindicator_argb);
+					object_crosshair_argb);
 			driver->draw2DLine(m_displaycenter + v2s32(8, -8), m_displaycenter + v2s32(-8, 8),
-					selectionindicator_argb);
+					object_crosshair_argb);
 		}
 	} else if (use_crosshair_image) {
 		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -72,13 +72,6 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 	u32 cross_a = rangelim(g_settings->getS32("crosshair_alpha"), 0, 255);
 	crosshair_argb = video::SColor(cross_a, cross_r, cross_g, cross_b);
 
-	v3f object_crosshair_color = g_settings->getV3F("object_crosshair_color");
-	u32 selecind_r = rangelim(myround(object_crosshair_color.X), 0, 255);
-	u32 selecind_g = rangelim(myround(object_crosshair_color.Y), 0, 255);
-	u32 selecind_b = rangelim(myround(object_crosshair_color.Z), 0, 255);
-	u32 selecind_a = rangelim(g_settings->getS32("object_crosshair_alpha"), 0, 255);
-	object_crosshair_argb = video::SColor(selecind_a, selecind_r, selecind_g, selecind_b);
-
 	v3f selectionbox_color = g_settings->getV3F("selectionbox_color");
 	u32 sbox_r = rangelim(myround(selectionbox_color.X), 0, 255);
 	u32 sbox_g = rangelim(myround(selectionbox_color.Y), 0, 255);
@@ -612,7 +605,7 @@ void Hud::drawHotbar(u16 playeritem) {
 
 void Hud::drawCrosshair()
 {
-	if (can_draw_object_crosshair) {
+	if (pointing_at_object) {
 		if (use_object_crosshair_image) {
 			video::ITexture *object_crosshair = tsrc->getTexture("object_crosshair.png");
 			v2u32 size  = object_crosshair->getOriginalSize();
@@ -620,22 +613,24 @@ void Hud::drawCrosshair()
 					m_displaycenter.Y - (size.Y / 2));
 			driver->draw2DImage(object_crosshair, lsize,
 					core::rect<s32>(0, 0, size.X, size.Y),
-					nullptr, object_crosshair_argb, true);
+					nullptr, crosshair_argb, true);
 		} else {
 			driver->draw2DLine(
 					m_displaycenter - v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
 					OBJECT_CROSSHAIR_LINE_SIZE),
 					m_displaycenter + v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
-					OBJECT_CROSSHAIR_LINE_SIZE),
-					object_crosshair_argb);
+					OBJECT_CROSSHAIR_LINE_SIZE), crosshair_argb);
 			driver->draw2DLine(
 					m_displaycenter + v2s32(OBJECT_CROSSHAIR_LINE_SIZE,
 					-OBJECT_CROSSHAIR_LINE_SIZE),
 					m_displaycenter + v2s32(-OBJECT_CROSSHAIR_LINE_SIZE,
-					OBJECT_CROSSHAIR_LINE_SIZE),
-					object_crosshair_argb);
+					OBJECT_CROSSHAIR_LINE_SIZE), crosshair_argb);
 		}
-	} else if (use_crosshair_image) {
+
+		return;
+	}
+
+	if (use_crosshair_image) {
 		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
 		v2u32 size  = crosshair->getOriginalSize();
 		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -69,6 +69,13 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 	u32 cross_a = rangelim(g_settings->getS32("crosshair_alpha"), 0, 255);
 	crosshair_argb = video::SColor(cross_a, cross_r, cross_g, cross_b);
 
+	v3f selectionindicator_color = g_settings->getV3F("selectionindicator_color");
+	u32 selecind_r = rangelim(myround(selectionindicator_color.X), 0, 255);
+	u32 selecind_g = rangelim(myround(selectionindicator_color.Y), 0, 255);
+	u32 selecind_b = rangelim(myround(selectionindicator_color.Z), 0, 255);
+	u32 selecind_a = rangelim(g_settings->getS32("selectionindicator_alpha"), 0, 255);
+	selectionindicator_argb = video::SColor(selecind_a, selecind_r, selecind_g, selecind_b);
+
 	v3f selectionbox_color = g_settings->getV3F("selectionbox_color");
 	u32 sbox_r = rangelim(myround(selectionbox_color.X), 0, 255);
 	u32 sbox_g = rangelim(myround(selectionbox_color.Y), 0, 255);
@@ -76,6 +83,7 @@ Hud::Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 	selectionbox_argb = video::SColor(255, sbox_r, sbox_g, sbox_b);
 
 	use_crosshair_image = tsrc->isKnownSourceImage("crosshair.png");
+	use_selectionindicator_image = tsrc->isKnownSourceImage("selectionindicator.png");
 
 	m_selection_boxes.clear();
 	m_halo_boxes.clear();
@@ -614,6 +622,29 @@ void Hud::drawCrosshair()
 				m_displaycenter + v2s32(10, 0), crosshair_argb);
 		driver->draw2DLine(m_displaycenter - v2s32(0, 10),
 				m_displaycenter + v2s32(0, 10), crosshair_argb);
+	}
+}
+
+void Hud::drawSelectionIndicator()
+{
+	int y_offset = 15;
+
+	if (use_crosshair_image) {
+		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
+		y_offset = (crosshair->getOriginalSize().Height/2) + 5;
+	}
+
+	if (use_selectionindicator_image) {
+		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
+		v2u32 size  = selectionindicator->getOriginalSize();
+		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
+				m_displaycenter.Y - size.Y - y_offset+5);
+		driver->draw2DImage(selectionindicator, lsize,
+				core::rect<s32>(0, 0, size.X, size.Y),
+				0, selectionindicator_argb, true);
+	} else {
+		driver->draw2DRectangle(selectionindicator_argb, core::rect<s32>(m_displaycenter.X-4,
+		m_displaycenter.Y-y_offset-8, m_displaycenter.X+4, m_displaycenter.Y-y_offset), nullptr);
 	}
 }
 

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -619,14 +619,13 @@ void Hud::drawCrosshair()
 			driver->draw2DImage(selectionindicator, lsize,
 					core::rect<s32>(0, 0, size.X, size.Y),
 					nullptr, selectionindicator_argb, true);
-
-			return;
 		} else {
-			driver->draw2DPolygon(irr::core::vector2di(m_displaycenter.X, m_displaycenter.Y - 22), 7, selectionindicator_argb, 4);
+			driver->draw2DLine(m_displaycenter - v2s32(9, 9), m_displaycenter + v2s32(9, 9),
+					selectionindicator_argb);
+			driver->draw2DLine(m_displaycenter + v2s32(9, -9), m_displaycenter + v2s32(-9, 9),
+					selectionindicator_argb);
 		}
-	}
-
-	if (use_crosshair_image) {
+	} else if (use_crosshair_image) {
 		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
 		v2u32 size  = crosshair->getOriginalSize();
 		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -620,9 +620,9 @@ void Hud::drawCrosshair()
 					core::rect<s32>(0, 0, size.X, size.Y),
 					nullptr, selectionindicator_argb, true);
 		} else {
-			driver->draw2DLine(m_displaycenter - v2s32(9, 9), m_displaycenter + v2s32(9, 9),
+			driver->draw2DLine(m_displaycenter - v2s32(8, 8), m_displaycenter + v2s32(8, 8),
 					selectionindicator_argb);
-			driver->draw2DLine(m_displaycenter + v2s32(9, -9), m_displaycenter + v2s32(-9, 9),
+			driver->draw2DLine(m_displaycenter + v2s32(8, -8), m_displaycenter + v2s32(-8, 8),
 					selectionindicator_argb);
 		}
 	} else if (use_crosshair_image) {

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -612,8 +612,7 @@ void Hud::drawHotbar(u16 playeritem) {
 
 void Hud::drawCrosshair()
 {
-	if (can_draw_object_crosshair)
-	{
+	if (can_draw_object_crosshair) {
 		if (use_object_crosshair_image) {
 			video::ITexture *object_crosshair = tsrc->getTexture("object_crosshair.png");
 			v2u32 size  = object_crosshair->getOriginalSize();

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -641,6 +641,29 @@ void Hud::drawCrosshair()
 	}
 }
 
+void Hud::drawSelectionIndicator()
+{
+	int y_offset = 15;
+
+	if (use_crosshair_image) {
+		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
+		y_offset = (crosshair->getOriginalSize().Height/2) + 5;
+	}
+
+	if (use_selectionindicator_image) {
+		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
+		v2u32 size  = selectionindicator->getOriginalSize();
+		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
+				m_displaycenter.Y - size.Y - y_offset+5);
+		driver->draw2DImage(selectionindicator, lsize,
+				core::rect<s32>(0, 0, size.X, size.Y),
+				0, selectionindicator_argb, true);
+	} else {
+		driver->draw2DRectangle(selectionindicator_argb, core::rect<s32>(m_displaycenter.X-4,
+		m_displaycenter.Y-y_offset-8, m_displaycenter.X+4, m_displaycenter.Y-y_offset), nullptr);
+	}
+}
+
 void Hud::setSelectionPos(const v3f &pos, const v3s16 &camera_offset)
 {
 	m_camera_offset = camera_offset;

--- a/src/client/hud.cpp
+++ b/src/client/hud.cpp
@@ -641,29 +641,6 @@ void Hud::drawCrosshair()
 	}
 }
 
-void Hud::drawSelectionIndicator()
-{
-	int y_offset = 15;
-
-	if (use_crosshair_image) {
-		video::ITexture *crosshair = tsrc->getTexture("crosshair.png");
-		y_offset = (crosshair->getOriginalSize().Height/2) + 5;
-	}
-
-	if (use_selectionindicator_image) {
-		video::ITexture *selectionindicator = tsrc->getTexture("selectionindicator.png");
-		v2u32 size  = selectionindicator->getOriginalSize();
-		v2s32 lsize = v2s32(m_displaycenter.X - (size.X / 2),
-				m_displaycenter.Y - size.Y - y_offset+5);
-		driver->draw2DImage(selectionindicator, lsize,
-				core::rect<s32>(0, 0, size.X, size.Y),
-				0, selectionindicator_argb, true);
-	} else {
-		driver->draw2DRectangle(selectionindicator_argb, core::rect<s32>(m_displaycenter.X-4,
-		m_displaycenter.Y-y_offset-8, m_displaycenter.X+4, m_displaycenter.Y-y_offset), nullptr);
-	}
-}
-
 void Hud::setSelectionPos(const v3f &pos, const v3s16 &camera_offset)
 {
 	m_camera_offset = camera_offset;

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -63,7 +63,6 @@ public:
 	void drawHotbar(u16 playeritem);
 	void resizeHotbar();
 	void drawCrosshair();
-	void drawSelectionIndicator();
 	void drawSelectionMesh();
 	void updateSelectionMesh(const v3s16 &camera_offset);
 

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -44,17 +44,17 @@ public:
 	ITextureSource *tsrc;
 
 	video::SColor crosshair_argb;
-	video::SColor selectionindicator_argb;
+	video::SColor object_crosshair_argb;
 	video::SColor selectionbox_argb;
 
 	bool use_crosshair_image = false;
-	bool use_selectionindicator_image = false;
+	bool use_object_crosshair_image = false;
 	std::string hotbar_image = "";
 	bool use_hotbar_image = false;
 	std::string hotbar_selected_image = "";
 	bool use_hotbar_selected_image = false;
 
-	bool can_draw_selectionindicator = false;
+	bool can_draw_object_crosshair = false;
 
 	Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 			Inventory *inventory);

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -44,12 +44,17 @@ public:
 	ITextureSource *tsrc;
 
 	video::SColor crosshair_argb;
+	video::SColor selectionindicator_argb;
 	video::SColor selectionbox_argb;
+
 	bool use_crosshair_image = false;
+	bool use_selectionindicator_image = false;
 	std::string hotbar_image = "";
 	bool use_hotbar_image = false;
 	std::string hotbar_selected_image = "";
 	bool use_hotbar_selected_image = false;
+
+	bool can_draw_selectionindicator = false;
 
 	Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 			Inventory *inventory);
@@ -58,6 +63,7 @@ public:
 	void drawHotbar(u16 playeritem);
 	void resizeHotbar();
 	void drawCrosshair();
+	void drawSelectionIndicator();
 	void drawSelectionMesh();
 	void updateSelectionMesh(const v3s16 &camera_offset);
 

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -44,7 +44,6 @@ public:
 	ITextureSource *tsrc;
 
 	video::SColor crosshair_argb;
-	video::SColor object_crosshair_argb;
 	video::SColor selectionbox_argb;
 
 	bool use_crosshair_image = false;

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -63,6 +63,7 @@ public:
 	void drawHotbar(u16 playeritem);
 	void resizeHotbar();
 	void drawCrosshair();
+	void drawSelectionIndicator();
 	void drawSelectionMesh();
 	void updateSelectionMesh(const v3s16 &camera_offset);
 

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -54,7 +54,7 @@ public:
 	std::string hotbar_selected_image = "";
 	bool use_hotbar_selected_image = false;
 
-	bool can_draw_object_crosshair = false;
+	bool pointing_at_object = false;
 
 	Hud(gui::IGUIEnvironment *guienv, Client *client, LocalPlayer *player,
 			Inventory *inventory);

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -84,8 +84,12 @@ void RenderingCore::draw3D()
 void RenderingCore::drawHUD()
 {
 	if (show_hud) {
-		if (draw_crosshair)
+		if (draw_crosshair) {
 			hud->drawCrosshair();
+
+			if (hud->can_draw_selectionindicator)
+				hud->drawSelectionIndicator();
+		}
 		hud->drawHotbar(client->getEnv().getLocalPlayer()->getWieldIndex());
 		hud->drawLuaElements(camera->getOffset());
 		camera->drawNametags();

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -84,9 +84,12 @@ void RenderingCore::draw3D()
 void RenderingCore::drawHUD()
 {
 	if (show_hud) {
-		if (draw_crosshair)
+		if (draw_crosshair) {
 			hud->drawCrosshair();
 
+			if (hud->can_draw_selectionindicator)
+				hud->drawSelectionIndicator();
+		}
 		hud->drawHotbar(client->getEnv().getLocalPlayer()->getWieldIndex());
 		hud->drawLuaElements(camera->getOffset());
 		camera->drawNametags();

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -84,12 +84,9 @@ void RenderingCore::draw3D()
 void RenderingCore::drawHUD()
 {
 	if (show_hud) {
-		if (draw_crosshair) {
+		if (draw_crosshair)
 			hud->drawCrosshair();
 
-			if (hud->can_draw_selectionindicator)
-				hud->drawSelectionIndicator();
-		}
 		hud->drawHotbar(client->getEnv().getLocalPlayer()->getWieldIndex());
 		hud->drawLuaElements(camera->getOffset());
 		camera->drawNametags();

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -84,12 +84,9 @@ void RenderingCore::draw3D()
 void RenderingCore::drawHUD()
 {
 	if (show_hud) {
-		if (draw_crosshair) {
+		if (draw_crosshair)
 			hud->drawCrosshair();
-
-			if (hud->can_draw_selectionindicator)
-				hud->drawSelectionIndicator();
-		}
+	
 		hud->drawHotbar(client->getEnv().getLocalPlayer()->getWieldIndex());
 		hud->drawLuaElements(camera->getOffset());
 		camera->drawNametags();

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -217,6 +217,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("node_highlighting", "box");
 	settings->setDefault("crosshair_color", "(255,255,255)");
 	settings->setDefault("crosshair_alpha", "255");
+	settings->setDefault("selectionindicator_color", "(255,255,255)");
+	settings->setDefault("selectionindicator_alpha", "255");
 	settings->setDefault("recent_chat_messages", "6");
 	settings->setDefault("hud_scaling", "1.0");
 	settings->setDefault("gui_scaling", "1.0");
@@ -225,7 +227,7 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("desynchronize_mapblock_texture_animation", "true");
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
-	settings->setDefault("show_entity_selectionbox", "true");
+	settings->setDefault("show_entity_selectionbox", "false");
 	settings->setDefault("texture_clean_transparent", "false");
 	settings->setDefault("texture_min_size", "64");
 	settings->setDefault("ambient_occlusion_gamma", "2.2");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -217,8 +217,8 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("node_highlighting", "box");
 	settings->setDefault("crosshair_color", "(255,255,255)");
 	settings->setDefault("crosshair_alpha", "255");
-	settings->setDefault("selectionindicator_color", "(255,255,255)");
-	settings->setDefault("selectionindicator_alpha", "255");
+	settings->setDefault("object_crosshair_color", "(255,255,255)");
+	settings->setDefault("object_crosshair_alpha", "255");
 	settings->setDefault("recent_chat_messages", "6");
 	settings->setDefault("hud_scaling", "1.0");
 	settings->setDefault("gui_scaling", "1.0");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -217,8 +217,6 @@ void set_default_settings(Settings *settings)
 	settings->setDefault("node_highlighting", "box");
 	settings->setDefault("crosshair_color", "(255,255,255)");
 	settings->setDefault("crosshair_alpha", "255");
-	settings->setDefault("object_crosshair_color", "(255,255,255)");
-	settings->setDefault("object_crosshair_alpha", "255");
 	settings->setDefault("recent_chat_messages", "6");
 	settings->setDefault("hud_scaling", "1.0");
 	settings->setDefault("gui_scaling", "1.0");


### PR DESCRIPTION
## Goal of the PR
 Add an indicator on the HUD to indicate when you are pointing at an entity. Similar to Minecraft's:
 ![image](https://cdn.discordapp.com/attachments/369137254641303560/689622438530646081/unknown.png)
## How does the PR work?
 Replaces the default crosshair with a X when you are pointing at an entity
 Comparison between HUD when pointing/not pointing at an entity:
![image](https://user-images.githubusercontent.com/28972859/78454713-a2424480-764e-11ea-9510-739244a2b4a6.png)

The object crosshair is pretty much exactly like the regular crosshair in customization, it also uses the crosshair HUD flag to determine appearance
* To define a custom texture for it use `object_crosshair.png`
* To define a custom color use the `object_crosshair_color` setting
* To define a custom alpha use the `object_crosshair_alpha` setting

This also disables entity selectionboxes by default
## Does it resolve any reported issue?
Not a reported one, but @tacotexmex has been wanting entity selectionboxes removed for a while now.
Entity selectionboxes break immersion and are better suited for dev work IMO. 
This PR will disable them by default without preventing players from knowing when they're pointing at an entity.

## To do

This PR is Ready for Review.

## How to test

* Join the game and put your crosshair over an entity while within range of it (dropped items work well)
* Make sure the object_crosshair settings (color/alpha) work
* Make sure the crosshair/object_crosshair textures work and work together
* Make sure the object crosshair doesn't appear when the HUD flag for the crosshair is disabled

I have tested all of the above without finding anything wrong
