### PR TITLE
Fix GUI element click-through by changing visibility

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -95,6 +95,31 @@ inline u32 clamp_u8(s32 value)
 	return (u32) MYMIN(MYMAX(value, 0), 255);
 }
 
+// meins
+// Helper struct
+// instances makes all elements given to it invisible as long as the instance lives
+struct ClickThroughablemaker
+{
+	const std::vector<gui::IGUIElement *> &elems;
+
+	ClickThroughablemaker(const std::vector<gui::IGUIElement *> &elements) :
+		elems(elements)
+	{
+		for (gui::IGUIElement *e : elems) {
+			errorstream << "making " << e << " invisible" << std::endl;
+			e->setVisible(false);
+		}
+	}
+
+	~ClickThroughablemaker()
+	{
+		for (gui::IGUIElement *e : elems) {
+			errorstream << "making " << e << " visible again" << std::endl;
+			e->setVisible(true);
+		}
+	}
+};
+
 GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		Client *client, ISimpleTextureSource *tsrc, IFormSource *fsrc, TextDest *tdst,
@@ -141,6 +166,8 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 		background_it->drop();
 	for (auto &tooltip_rect_it : m_tooltip_rects)
 		tooltip_rect_it.first->drop();
+	for (auto &clickthrough_it : m_clickthrough_elements)
+		clickthrough_it->drop();
 
 	delete m_selected_item;
 	delete m_form_src;
@@ -742,6 +769,10 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
 		m_fields.push_back(spec);
 
+		//meins
+		// images should let elements through
+		e->grab();
+		m_clickthrough_elements.push_back(e);
 		return;
 	}
 
@@ -949,6 +980,10 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element,
 		}
 
 		m_fields.push_back(spec);
+
+		//meins test
+		e->grab();
+		m_clickthrough_elements.push_back(e);
 		return;
 	}
 	errorstream<< "Invalid button element(" << parts.size() << "): '" << element << "'"  << std::endl;
@@ -2745,6 +2780,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		background_it->drop();
 	for (auto &tooltip_rect_it : m_tooltip_rects)
 		tooltip_rect_it.first->drop();
+	for (auto &clickthrough_it : m_clickthrough_elements)
+		clickthrough_it->drop();
 
 	mydata.size= v2s32(100,100);
 	mydata.screensize = screensize;
@@ -2767,6 +2804,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_dropdowns.clear();
 	theme_by_name.clear();
 	theme_by_type.clear();
+	m_clickthrough_elements.clear();
 
 	m_bgnonfullscreen = true;
 	m_bgfullscreen = false;
@@ -3615,6 +3653,22 @@ static bool isChild(gui::IGUIElement *tocheck, gui::IGUIElement *parent)
 }
 
 bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
+{
+	//meins
+	// there are elements that should not capture any event, hence they are made
+	// invisible while processing events
+	// bla (todo: name) keeps such elements invisible as long as it lives
+	errorstream << "creating ClickThroughablemaker" << std::endl;
+	ClickThroughablemaker bla(m_clickthrough_elements);
+	errorstream << "ClickThroughablemaker made" << std::endl;
+
+	bool ret = real_preprocess_event(event);
+	errorstream << "real_preprocess_event called; ret=" << ret << std::endl;
+	//~ return ret;
+	return true;
+}
+
+bool GUIFormSpecMenu::real_preprocess_event(const SEvent& event)
 {
 	// The IGUITabControl renders visually using the skin's selected
 	// font, which we override for the duration of form drawing,

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -890,7 +890,9 @@ void GUIFormSpecMenu::parseItemImage(parserData* data, const std::string &elemen
 				core::rect<s32>(pos, pos + geom), name, m_font, m_client);
 		auto style = getStyleForElement("item_image", spec.fname);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->drop();
+
+		// item images should let events through
+		m_clickthrough_elements.push_back(e);
 
 		m_fields.push_back(spec);
 		return;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -309,8 +309,6 @@ protected:
 	std::vector<std::pair<FieldSpec, std::vector<std::string>>> m_dropdowns;
 	std::vector<gui::IGUIElement *> m_clickthrough_elements;
 
-bool real_preprocess_event(const SEvent& event);
-
 	GUIInventoryList::ItemSpec *m_selected_item = nullptr;
 	u16 m_selected_amount = 0;
 	bool m_selected_dragging = false;

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -307,6 +307,9 @@ protected:
 	std::vector<std::pair<gui::IGUIElement *, TooltipSpec>> m_tooltip_rects;
 	std::vector<std::pair<FieldSpec, GUIScrollBar *>> m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string>>> m_dropdowns;
+	std::vector<gui::IGUIElement *> m_clickthrough_elements;
+
+bool real_preprocess_event(const SEvent& event);
 
 	GUIInventoryList::ItemSpec *m_selected_item = nullptr;
 	u16 m_selected_amount = 0;


### PR DESCRIPTION
- Fixes #9361
- Closes #9516. Main difference: This PR doesn't move code from irrlicht into minetest.
- This PR adds a vector that holds pointers to elements that should only be visible while being drawn.
In the guifsmenu's draw func, all elements in this vector are made visible and invisible again. Apart from there they are always invisible. (Well they are still visible before the first drawn, does this matter? If yes, it could be fixed easily with some lines of code everywhere.)
- Q: Why not only make them invisible on event?
A: I would like to do that but don't know how. `preprocessEvent` doesn't work, see http://irc.minetest.net/minetest-dev/2020-03-21#i_5654023 and first commit.

## To do

This PR is a Ready for Review.
(It might however be possible that I forgot some element. Please tell me.)
Some elements that need to be tested / are likely to cause the issue:
- [x] rect mode tooltip (already invisible)
- [x] backgrounds (in the back)
- [x] boxes (moved to the back in old versions)
- [x] images (fixed by this PR)
- [x] item images (fixed by this PR)
- [x] inventorylists (should be fixed in the class)
- [x] label (fixed by this PR)
- [x] vertlabel (fixed by this PR; it is part of the regression, right?)
- [x] other static text elements (there should be none)

## How to test

(Stolen from issue / other PR.)
```lua
local my_formspec =
	[[
		formspec_version[3]
		size[6,6]
		button[1,1;4,4;btn;Hello]
		image[2,2;1,1;default_dirt.png]
		label[1,4;#####################]
		item_image[3,3;1,1;default:dirt]
	]]


minetest.register_on_joinplayer(function(player)
	minetest.after(0.5, function()
		minetest.show_formspec(player:get_player_name(), "ss", my_formspec)
	end)
end)
```
