### PR TITLE
Smaller fix for falling nodes glow in the dark

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -826,7 +826,11 @@ void GenericCAO::setNodeLight(u8 light)
 {
 	video::SColor color(255, light, light, light);
 
-	if (m_enable_shaders) {
+	if (m_prop.visual == "wielditem" || m_prop.visual == "item") {
+		// Since these types of visuals are using their own shader
+		// they should be handled separately
+		m_wield_meshnode->setColor(color);
+	} else if (m_enable_shaders) {
 		scene::ISceneNode *node = getSceneNode();
 
 		if (node == nullptr)
@@ -850,8 +854,6 @@ void GenericCAO::setNodeLight(u8 light)
 			setMeshColor(m_meshnode->getMesh(), color);
 		} else if (m_animated_meshnode) {
 			setAnimatedMeshColor(m_animated_meshnode, color);
-		} else if (m_wield_meshnode) {
-			m_wield_meshnode->setColor(color);
 		} else if (m_spritenode) {
 			m_spritenode->setColor(color);
 		}


### PR DESCRIPTION
Fixes #9525. This is smaller fix suggested by @sfan5. An alternative to #9537 

Ready for Review.

# How to test

Original bug can be tested with minetest game: go into a dark cave and place sand block. Before this fix, sand block would glow. Now it shouldn't.