### PR TITLE
Sprite animation for players, sprite texture position fix, local player sprite animation

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6086,6 +6086,12 @@ object you are working with still exists.
       amount.
     * `nil`: Disables override, defaulting to sunlight based on day-night cycle
 * `get_day_night_ratio()`: returns the ratio or nil if it isn't overridden
+* `set_local_sprite(stand/idle, walk, dig, walk+dig, framelength, select_horiz_by_yawpitch)`:
+  set animation for player sprite in third person view.
+  Each of stand/idle, walk, dig, walk+dig is a tuple {p = {x, y}, num_frame=z}
+  see `set_sprite` all arguments.
+* `get_local_sprite`: returns stand, walk, dig, dig+walk tuples, `framelength`
+  and `select_horiz_by_yawpitch`.
 * `set_local_animation(stand/idle, walk, dig, walk+dig, frame_speed=frame_speed)`:
   set animation for player model in third person view
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5778,6 +5778,17 @@ object you are working with still exists.
   successful.
 * `set_armor_groups({group1=rating, group2=rating, ...})`
 * `get_armor_groups()`: returns a table with the armor group ratings
+* `set_texture_mod(mod)`
+* `get_texture_mod()` returns current texture modifier
+* `set_sprite(p, num_frames, framelength, select_horiz_by_yawpitch)`
+    * Select sprite from spritesheet with optional animation and Dungeon Master
+      style texture selection based on yaw relative to camera
+    * `p`: {x=number, y=number}, the coordinate of the first frame
+      (x: column, y: row), default: `{x=0, y=0}`
+    * `num_frames`: number, default: `1`
+    * `framelength`: number, default: `0.2`
+    * `select_horiz_by_yawpitch`: boolean, this was once used for the Dungeon
+      Master mob, default: `false`
 * `set_animation(frame_range, frame_speed, frame_blend, frame_loop)`
     * `frame_range`: table {x=num, y=num}, default: `{x=1, y=1}`
     * `frame_speed`: number, default: `15.0`
@@ -5838,17 +5849,6 @@ object you are working with still exists.
 * `get_rotation()`: returns the rotation, a vector (radians)
 * `set_yaw(radians)`: sets the yaw (heading).
 * `get_yaw()`: returns number in radians
-* `set_texture_mod(mod)`
-* `get_texture_mod()` returns current texture modifier
-* `set_sprite(p, num_frames, framelength, select_horiz_by_yawpitch)`
-    * Select sprite from spritesheet with optional animation and Dungeon Master
-      style texture selection based on yaw relative to camera
-    * `p`: {x=number, y=number}, the coordinate of the first frame
-      (x: column, y: row), default: `{x=0, y=0}`
-    * `num_frames`: number, default: `1`
-    * `framelength`: number, default: `0.2`
-    * `select_horiz_by_yawpitch`: boolean, this was once used for the Dungeon
-      Master mob, default: `false`
 * `get_entity_name()` (**Deprecated**: Will be removed in a future version)
 * `get_luaentity()`
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5781,14 +5781,24 @@ object you are working with still exists.
 * `set_texture_mod(mod)`
 * `get_texture_mod()` returns current texture modifier
 * `set_sprite(p, num_frames, framelength, select_horiz_by_yawpitch)`
-    * Select sprite from spritesheet with optional animation and Dungeon Master
-      style texture selection based on yaw relative to camera
-    * `p`: {x=number, y=number}, the coordinate of the first frame
-      (x: column, y: row), default: `{x=0, y=0}`
-    * `num_frames`: number, default: `1`
+    * Select sprite from spritesheet with optional animation.
+      Used only when visual = "sprite" and used along textures to set the
+      spritesheet to use and spritediv to get the size of each frame.
+      A spritesheet is animated from top to bottom and may use multiple columns
+      to show different faces when `select_horiz_by_yawpitch` is `true`.
+    * `p`: {x=number, y=number}, the coordinate of the first frame to use for
+      this sprite (x: column, y: row), default: `{x=0, y=0}`
+    * `num_frames`: number, default: `1`, the number of frames (rows) used by
+       the animation.
     * `framelength`: number, default: `0.2`
-    * `select_horiz_by_yawpitch`: boolean, this was once used for the Dungeon
-      Master mob, default: `false`
+    * `select_horiz_by_yawpitch`: when `false` (default), only the first column
+      is used no matter the viewing angle. When `true` 6 columns are used:
+        * First column:  subject looking to the right
+        * Second column: subject facing the camera
+        * Third column:  subject looking to the left
+        * Fourth column: subject backing the camera
+        * Fifth column:  subject viewed from above
+        * Sixth column:  subject viewed from below
 * `set_animation(frame_range, frame_speed, frame_blend, frame_loop)`
     * `frame_range`: table {x=num, y=num}, default: `{x=1, y=1}`
     * `frame_speed`: number, default: `15.0`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5799,6 +5799,8 @@ object you are working with still exists.
         * Fourth column: subject backing the camera
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
+* `set_sprite_framelength(framelength)`
+    * `framelength`: number, update the duration of each frame of the sprite.
 * `set_animation(frame_range, frame_speed, frame_blend, frame_loop)`
     * `frame_range`: table {x=num, y=num}, default: `{x=1, y=1}`
     * `frame_speed`: number, default: `15.0`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5802,6 +5802,7 @@ object you are working with still exists.
         * Fourth column: subject backing the camera
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
+* `get_sprite()`: returns `p`, `num_frames`, `framelength` and `select_horiz_by_yawpitch`.
 * `set_sprite_framelength(framelength)`
     * `framelength`: number, update the duration of each frame of the sprite.
 * `set_animation(frame_range, frame_speed, frame_blend, frame_loop)`

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5779,6 +5779,9 @@ object you are working with still exists.
 * `set_armor_groups({group1=rating, group2=rating, ...})`
 * `get_armor_groups()`: returns a table with the armor group ratings
 * `set_texture_mod(mod)`
+    * Add a texture modifier to the base texture, for sprites and meshes.
+    * When calling `set_texture_mod` again, the previous one is discarded.
+    * `mod` the texture modifier. See [Texture modifiers].
 * `get_texture_mod()` returns current texture modifier
 * `set_sprite(p, num_frames, framelength, select_horiz_by_yawpitch)`
     * Select sprite from spritesheet with optional animation.

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5796,10 +5796,10 @@ object you are working with still exists.
     * `framelength`: number, default: `0.2`
     * `select_horiz_by_yawpitch`: when `false` (default), only the first column
       is used no matter the viewing angle. When `true` 6 columns are used:
-        * First column:  subject looking to the right
-        * Second column: subject facing the camera
-        * Third column:  subject looking to the left
-        * Fourth column: subject backing the camera
+        * First column:  subject facing the camera
+        * Second column: subject looking to the left
+        * Third column:  subject backing the camera
+        * Fourth column: subject looking to the right
         * Fifth column:  subject viewed from above
         * Sixth column:  subject viewed from below
 * `get_sprite()`: returns `p`, `num_frames`, `framelength` and `select_horiz_by_yawpitch`.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -223,6 +223,7 @@ public:
 	void handleCommand_HudSetStars(NetworkPacket* pkt);
 	void handleCommand_CloudParams(NetworkPacket* pkt);
 	void handleCommand_OverrideDayNightRatio(NetworkPacket* pkt);
+	void handleCommand_LocalPlayerSprite(NetworkPacket* pkt);
 	void handleCommand_LocalPlayerAnimations(NetworkPacket* pkt);
 	void handleCommand_EyeOffset(NetworkPacket* pkt);
 	void handleCommand_UpdatePlayerList(NetworkPacket* pkt);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -629,6 +629,11 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 			setBillboardTextureMatrix(m_spritenode,
 					txs, tys, 0, 0);
 		}
+		if (m_is_player) {
+			// Move minimal Y position to 0 (feet position)
+			double dy = BS * m_prop.visual_size.Y / 2;
+			m_spritenode->setPosition(v3f(0, dy, 0));
+		}
 	} else if (m_prop.visual == "upright_sprite") {
 		grabMatrixNode();
 		scene::SMesh *mesh = new scene::SMesh();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1141,7 +1141,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 void GenericCAO::updateTexturePos()
 {
-	if(m_spritenode)
+	if(m_spritenode && (!m_is_local_player || m_is_visible))
 	{
 		scene::ICameraSceneNode* camera =
 				m_spritenode->getSceneManager()->getActiveCamera();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1163,6 +1163,8 @@ void GenericCAO::updateTexturePos()
 				float mob_dir =
 						atan2(cam_to_entity.Z, cam_to_entity.X) / M_PI * 180.;
 				float dir = mob_dir - m_rotation.Y;
+				if (m_is_local_player)
+					dir -= 90;
 				dir = wrapDegrees_180(dir);
 				if (std::fabs(wrapDegrees_180(dir - 0)) <= 45.1f)
 					col += 2;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -629,14 +629,21 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 			setBillboardTextureMatrix(m_spritenode,
 					txs, tys, 0, 0);
 		}
-		if (m_is_player) {
-			// Move minimal Y position to 0 (feet position)
-			double dy = BS * m_prop.visual_size.Y / 2;
-			m_spritenode->setPosition(v3f(0, dy, 0));
-		}
+		// Adjust the position according to the collision box
+		v3f collis_size = v3f(
+			abs(m_prop.collisionbox.MaxEdge.X - m_prop.collisionbox.MinEdge.X),
+			abs(m_prop.collisionbox.MaxEdge.Y - m_prop.collisionbox.MinEdge.Y),
+			abs(m_prop.collisionbox.MaxEdge.Z - m_prop.collisionbox.MinEdge.Z));
+		v3f collis_center = (m_prop.collisionbox.MinEdge + collis_size / 2.0) * BS;
+		m_spritenode->setPosition(collis_center);
 	} else if (m_prop.visual == "upright_sprite") {
 		grabMatrixNode();
 		scene::SMesh *mesh = new scene::SMesh();
+		v2f collis_size = v2f(
+			abs(m_prop.collisionbox.MaxEdge.X - m_prop.collisionbox.MinEdge.X),
+			abs(m_prop.collisionbox.MaxEdge.Y - m_prop.collisionbox.MinEdge.Y));
+		v2f d0 = (v2f(m_prop.collisionbox.MinEdge.X, m_prop.collisionbox.MinEdge.Y)
+			+ collis_size / 2.0) * BS;
 		double dx = BS * m_prop.visual_size.X / 2;
 		double dy = BS * m_prop.visual_size.Y / 2;
 		video::SColor c(0xFFFFFFFF);
@@ -644,16 +651,11 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		{ // Front
 			scene::IMeshBuffer *buf = new scene::SMeshBuffer();
 			video::S3DVertex vertices[4] = {
-				video::S3DVertex(-dx, -dy, 0, 0,0,1, c, 1,1),
-				video::S3DVertex( dx, -dy, 0, 0,0,1, c, 0,1),
-				video::S3DVertex( dx,  dy, 0, 0,0,1, c, 0,0),
-				video::S3DVertex(-dx,  dy, 0, 0,0,1, c, 1,0),
+				video::S3DVertex(-dx + d0.X, -dy + d0.Y, 0, 0,0,1, c, 1,1),
+				video::S3DVertex( dx + d0.X, -dy + d0.Y, 0, 0,0,1, c, 0,1),
+				video::S3DVertex( dx + d0.X,  dy + d0.Y, 0, 0,0,1, c, 0,0),
+				video::S3DVertex(-dx + d0.X,  dy + d0.Y, 0, 0,0,1, c, 1,0),
 			};
-			if (m_is_player) {
-				// Move minimal Y position to 0 (feet position)
-				for (video::S3DVertex &vertex : vertices)
-					vertex.Pos.Y += dy;
-			}
 			u16 indices[] = {0,1,2,2,3,0};
 			buf->append(vertices, 4, indices, 6);
 			// Set material
@@ -675,16 +677,11 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 		{ // Back
 			scene::IMeshBuffer *buf = new scene::SMeshBuffer();
 			video::S3DVertex vertices[4] = {
-				video::S3DVertex( dx,-dy, 0, 0,0,-1, c, 1,1),
-				video::S3DVertex(-dx,-dy, 0, 0,0,-1, c, 0,1),
-				video::S3DVertex(-dx, dy, 0, 0,0,-1, c, 0,0),
-				video::S3DVertex( dx, dy, 0, 0,0,-1, c, 1,0),
+				video::S3DVertex( dx + d0.X, -dy + d0.Y, 0, 0,0,-1, c, 1,1),
+				video::S3DVertex(-dx + d0.X, -dy + d0.Y, 0, 0,0,-1, c, 0,1),
+				video::S3DVertex(-dx + d0.X,  dy + d0.Y, 0, 0,0,-1, c, 0,0),
+				video::S3DVertex( dx + d0.X,  dy + d0.Y, 0, 0,0,-1, c, 1,0),
 			};
-			if (m_is_player) {
-				// Move minimal Y position to 0 (feet position)
-				for (video::S3DVertex &vertex : vertices)
-					vertex.Pos.Y += dy;
-			}
 			u16 indices[] = {0,1,2,2,3,0};
 			buf->append(vertices, 4, indices, 6);
 			// Set material

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -985,7 +985,6 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 
 		removeFromScene(false);
 		addToScene(m_client->tsrc());
-
 		// Attachments, part 2: Now that the parent has been refreshed, put its attachments back
 		for (u16 cao_id : m_attachment_child_ids) {
 			ClientActiveObject *obj = m_env->getActiveObject(cao_id);
@@ -1110,7 +1109,7 @@ void GenericCAO::updateTexturePos()
 				m_spritenode->getSceneManager()->getActiveCamera();
 		if(!camera)
 			return;
-		v3f cam_to_entity = m_spritenode->getAbsolutePosition()
+		v3f cam_to_entity = getPosRotMatrix().getTranslation()
 				- camera->getAbsolutePosition();
 		cam_to_entity.normalize();
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1513,6 +1513,11 @@ void GenericCAO::processMessage(const std::string &data)
 		m_anim_framelength = framelength;
 		m_tx_select_horiz_by_yawpitch = select_horiz_by_yawpitch;
 
+		if (m_anim_frame >= m_anim_num_frames)
+			m_anim_frame = 0;
+		if (m_anim_timer >= m_anim_framelength)
+			m_anim_timer = 0.0f;
+
 		updateTexturePos();
 	} else if (cmd == GENERIC_CMD_SET_SPRITE_FRAMELENGTH) {
 		float frame_length = readF32(is);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1515,6 +1515,12 @@ void GenericCAO::processMessage(const std::string &data)
 		m_tx_select_horiz_by_yawpitch = select_horiz_by_yawpitch;
 
 		updateTexturePos();
+	} else if (cmd == GENERIC_CMD_SET_SPRITE_FRAMELENGTH) {
+		float frame_length = readF32(is);
+		// When reducing length, ignore extra time to prevent skipping a frame
+		if (m_anim_timer > frame_length)
+			m_anim_timer = frame_length;
+		m_anim_framelength = frame_length;
 	} else if (cmd == GENERIC_CMD_SET_PHYSICS_OVERRIDE) {
 		float override_speed = readF32(is);
 		float override_jump = readF32(is);

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -167,6 +167,14 @@ void UnitSAO::setSprite(v2s16 p, int num_frames, float framelength,
 	m_messages_out.push(aom);
 }
 
+void UnitSAO::setSpriteFramelength(float framelength)
+{
+	std::string str = gob_cmd_set_sprite_framelength(framelength);
+	// create message and add to list
+	ActiveObjectMessage aom(getId(), true, str);
+	m_messages_out.push(aom);
+}
+
 void UnitSAO::setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop)
 {
 	// store these so they can be updated to clients

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -164,6 +164,15 @@ void UnitSAO::setSprite(v2s16 p, int num_frames, float framelength,
 	m_set_sprite_sent = false;
 }
 
+void UnitSAO::getSprite(v2s16 *p, int *num_frames, float *framelength,
+		bool *select_horiz_by_yawpitch)
+{
+	*p = m_sprite_tx_basepos;
+	*num_frames = m_sprite_num_frames;
+	*framelength = m_sprite_framelength;
+	*select_horiz_by_yawpitch = m_sprite_select_horiz_by_yawpitch;
+}
+
 void UnitSAO::setSpriteFramelength(float framelength)
 {
 	m_sprite_framelength = framelength;

--- a/src/content_sao.cpp
+++ b/src/content_sao.cpp
@@ -139,6 +139,34 @@ const ItemGroupList &UnitSAO::getArmorGroups() const
 	return m_armor_groups;
 }
 
+void UnitSAO::setTextureMod(const std::string &mod)
+{
+	std::string str = gob_cmd_set_texture_mod(mod);
+	m_current_texture_modifier = mod;
+	// create message and add to list
+	ActiveObjectMessage aom(getId(), true, str);
+	m_messages_out.push(aom);
+}
+
+std::string UnitSAO::getTextureMod() const
+{
+	return m_current_texture_modifier;
+}
+
+void UnitSAO::setSprite(v2s16 p, int num_frames, float framelength,
+		bool select_horiz_by_yawpitch)
+{
+	std::string str = gob_cmd_set_sprite(
+		p,
+		num_frames,
+		framelength,
+		select_horiz_by_yawpitch
+	);
+	// create message and add to list
+	ActiveObjectMessage aom(getId(), true, str);
+	m_messages_out.push(aom);
+}
+
 void UnitSAO::setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop)
 {
 	// store these so they can be updated to clients
@@ -748,34 +776,6 @@ void LuaEntitySAO::setAcceleration(v3f acceleration)
 v3f LuaEntitySAO::getAcceleration()
 {
 	return m_acceleration;
-}
-
-void LuaEntitySAO::setTextureMod(const std::string &mod)
-{
-	std::string str = gob_cmd_set_texture_mod(mod);
-	m_current_texture_modifier = mod;
-	// create message and add to list
-	ActiveObjectMessage aom(getId(), true, str);
-	m_messages_out.push(aom);
-}
-
-std::string LuaEntitySAO::getTextureMod() const
-{
-	return m_current_texture_modifier;
-}
-
-void LuaEntitySAO::setSprite(v2s16 p, int num_frames, float framelength,
-		bool select_horiz_by_yawpitch)
-{
-	std::string str = gob_cmd_set_sprite(
-		p,
-		num_frames,
-		framelength,
-		select_horiz_by_yawpitch
-	);
-	// create message and add to list
-	ActiveObjectMessage aom(getId(), true, str);
-	m_messages_out.push(aom);
 }
 
 std::string LuaEntitySAO::getName()

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -55,6 +55,8 @@ public:
 	std::string getTextureMod() const;
 	void setSprite(v2s16 p, int num_frames, float framelength,
 			bool select_horiz_by_yawpitch);
+	void getSprite(v2s16 *p, int *num_frames, float *framelength,
+			bool *select_horiz_by_yawpitch);
 	void setSpriteFramelength(float framelength);
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop);
 	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend, bool *frame_loop);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -51,6 +51,10 @@ public:
 
 	void setArmorGroups(const ItemGroupList &armor_groups);
 	const ItemGroupList &getArmorGroups() const;
+	void setTextureMod(const std::string &mod);
+	std::string getTextureMod() const;
+	void setSprite(v2s16 p, int num_frames, float framelength,
+			bool select_horiz_by_yawpitch);
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop);
 	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend, bool *frame_loop);
 	void setAnimationSpeed(float frame_speed);
@@ -78,6 +82,7 @@ protected:
 	ItemGroupList m_armor_groups;
 	bool m_armor_groups_sent = false;
 
+	std::string m_current_texture_modifier = "";
 	v2f m_animation_range;
 	float m_animation_speed = 0.0f;
 	float m_animation_blend = 0.0f;
@@ -144,10 +149,6 @@ public:
 	void setAcceleration(v3f acceleration);
 	v3f getAcceleration();
 
-	void setTextureMod(const std::string &mod);
-	std::string getTextureMod() const;
-	void setSprite(v2s16 p, int num_frames, float framelength,
-			bool select_horiz_by_yawpitch);
 	std::string getName();
 	bool getCollisionBox(aabb3f *toset) const;
 	bool getSelectionBox(aabb3f *toset) const;
@@ -168,7 +169,6 @@ private:
 	v3f m_last_sent_rotation;
 	float m_last_sent_position_timer = 0.0f;
 	float m_last_sent_move_precision = 0.0f;
-	std::string m_current_texture_modifier = "";
 };
 
 /*

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -55,6 +55,7 @@ public:
 	std::string getTextureMod() const;
 	void setSprite(v2s16 p, int num_frames, float framelength,
 			bool select_horiz_by_yawpitch);
+	void setSpriteFramelength(float framelength);
 	void setAnimation(v2f frame_range, float frame_speed, float frame_blend, bool frame_loop);
 	void getAnimation(v2f *frame_range, float *frame_speed, float *frame_blend, bool *frame_loop);
 	void setAnimationSpeed(float frame_speed);

--- a/src/content_sao.h
+++ b/src/content_sao.h
@@ -84,6 +84,12 @@ protected:
 	bool m_armor_groups_sent = false;
 
 	std::string m_current_texture_modifier = "";
+	v2s16 m_sprite_tx_basepos;
+	int m_sprite_num_frames = 0;
+	float m_sprite_framelength = 0.0f;
+	bool m_sprite_select_horiz_by_yawpitch = false;
+	bool m_set_sprite_sent = false;
+	bool m_set_sprite_framelength_sent = false;
 	v2f m_animation_range;
 	float m_animation_speed = 0.0f;
 	float m_animation_blend = 0.0f;

--- a/src/genericobject.cpp
+++ b/src/genericobject.cpp
@@ -92,6 +92,16 @@ std::string gob_cmd_set_sprite(
 	return os.str();
 }
 
+std::string gob_cmd_set_sprite_framelength(float frame_length)
+{
+	std::ostringstream os(std::ios::binary);
+	// command
+	writeU8(os, GENERIC_CMD_SET_SPRITE_FRAMELENGTH);
+	// parameters
+	writeF32(os, frame_length);
+	return os.str();
+}
+
 std::string gob_cmd_punched(u16 result_hp)
 {
 	std::ostringstream os(std::ios::binary);

--- a/src/genericobject.h
+++ b/src/genericobject.h
@@ -37,7 +37,8 @@ enum GenericCMD {
 	GENERIC_CMD_SET_PHYSICS_OVERRIDE,
 	GENERIC_CMD_UPDATE_NAMETAG_ATTRIBUTES,
 	GENERIC_CMD_SPAWN_INFANT,
-	GENERIC_CMD_SET_ANIMATION_SPEED
+	GENERIC_CMD_SET_ANIMATION_SPEED,
+	GENERIC_CMD_SET_SPRITE_FRAMELENGTH
 };
 
 #include "object_properties.h"
@@ -62,6 +63,8 @@ std::string gob_cmd_set_sprite(
 	f32 framelength,
 	bool select_horiz_by_yawpitch
 );
+
+std::string gob_cmd_set_sprite_framelength(float framelength);
 
 std::string gob_cmd_punched(u16 result_hp);
 

--- a/src/network/clientopcodes.cpp
+++ b/src/network/clientopcodes.cpp
@@ -117,7 +117,7 @@ const ToClientCommandHandler toClientCommandTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SET_SUN",                  TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetSun }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetMoon }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                TOCLIENT_STATE_CONNECTED, &Client::handleCommand_HudSetStars }, // 0x5c
-	null_command_handler,
+	{ "TOCLIENT_LOCAL_PLAYER_SPRITE",      TOCLIENT_STATE_CONNECTED, &Client::handleCommand_LocalPlayerSprite }, // 0x5d
 	null_command_handler,
 	null_command_handler,
 	{ "TOCLIENT_SRP_BYTES_S_B",            TOCLIENT_STATE_NOT_CONNECTED, &Client::handleCommand_SrpBytesSandB }, // 0x60

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1409,6 +1409,23 @@ void Client::handleCommand_OverrideDayNightRatio(NetworkPacket* pkt)
 	m_client_event_queue.push(event);
 }
 
+void Client::handleCommand_LocalPlayerSprite(NetworkPacket* pkt)
+{
+	LocalPlayer *player = m_env.getLocalPlayer();
+	assert(player != NULL);
+
+	*pkt >> player->local_sprite_tx_basepos[0];
+	*pkt >> player->local_sprite_tx_basepos[1];
+	*pkt >> player->local_sprite_tx_basepos[2];
+	*pkt >> player->local_sprite_tx_basepos[3];
+	*pkt >> player->local_sprite_num_frames[0];
+	*pkt >> player->local_sprite_num_frames[1];
+	*pkt >> player->local_sprite_num_frames[2];
+	*pkt >> player->local_sprite_num_frames[3];
+	*pkt >> player->local_sprite_framelength;
+	*pkt >> player->local_sprite_select_horiz_by_yawpitch;
+}
+
 void Client::handleCommand_LocalPlayerAnimations(NetworkPacket* pkt)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();

--- a/src/network/networkpacket.cpp
+++ b/src/network/networkpacket.cpp
@@ -437,6 +437,16 @@ NetworkPacket& NetworkPacket::operator<<(s32 src)
 	return *this;
 }
 
+NetworkPacket& NetworkPacket::operator>>(v2s16& dst)
+{
+	checkReadOffset(m_read_offset, 4);
+
+	dst = readV2S16(&m_data[m_read_offset]);
+
+	m_read_offset += 4;
+	return *this;
+}
+
 NetworkPacket& NetworkPacket::operator>>(v3s16& dst)
 {
 	checkReadOffset(m_read_offset, 6);
@@ -479,6 +489,13 @@ NetworkPacket& NetworkPacket::operator<<(v3f src)
 	*this << (float) src.X;
 	*this << (float) src.Y;
 	*this << (float) src.Z;
+	return *this;
+}
+
+NetworkPacket& NetworkPacket::operator<<(v2s16 src)
+{
+	*this << (s16) src.X;
+	*this << (s16) src.Y;
 	return *this;
 }
 

--- a/src/network/networkpacket.h
+++ b/src/network/networkpacket.h
@@ -106,6 +106,9 @@ public:
 	NetworkPacket &operator>>(v2s32 &dst);
 	NetworkPacket &operator<<(v2s32 src);
 
+	NetworkPacket &operator>>(v2s16 &dst);
+	NetworkPacket &operator<<(v2s16 src);
+
 	NetworkPacket &operator>>(v3s16 &dst);
 	NetworkPacket &operator<<(v3s16 src);
 

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -204,6 +204,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	PROTOCOL VERSION 39:
 		Updated set_sky packet
 		Adds new sun, moon and stars packets
+		Add TOCLIENT_LOCAL_PLAYER_SPRITE
 */
 
 #define LATEST_PROTOCOL_VERSION 39
@@ -735,6 +736,20 @@ enum ToClientCommand
 		f32 scale
 	*/
 
+	TOCLIENT_LOCAL_PLAYER_SPRITE = 0x5d,
+	/*
+		v2s32 stand/idle tx_basepos
+		v2s32 walk tx_basepos
+		v2s32 dig tx_basepos
+		v2s32 walk+dig tx_basepos
+		int stand/idle num_frames
+		int walk num_frames
+		int dig num_frames
+		int walk+dig num_frames
+		float framelength
+		bool select_horiz_by_yawpitch
+	*/
+
 	TOCLIENT_SRP_BYTES_S_B = 0x60,
 	/*
 		Belonging to AUTH_MECHANISM_SRP.
@@ -750,6 +765,7 @@ enum ToClientCommand
 	*/
 
 	TOCLIENT_NUM_MSG_TYPES = 0x62,
+
 };
 
 enum ToServerCommand

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -206,7 +206,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_SET_SUN",                  0, true }, // 0x5a
 	{ "TOCLIENT_SET_MOON",                 0, true }, // 0x5b
 	{ "TOCLIENT_SET_STARS",                0, true }, // 0x5c
-	null_command_factory, // 0x5d
+	{ "TOCLIENT_LOCAL_PLAYER_SPRITE",      0, true }, // 0x5d
 	null_command_factory, // 0x5e
 	null_command_factory, // 0x5f
 	{ "TOSERVER_SRP_BYTES_S_B",            0, true }, // 0x60

--- a/src/player.h
+++ b/src/player.h
@@ -168,6 +168,11 @@ public:
 	f32 movement_liquid_sink;
 	f32 movement_gravity;
 
+	v2s16 local_sprite_tx_basepos[4];
+	int local_sprite_num_frames[4];
+	float local_sprite_framelength;
+	bool local_sprite_select_horiz_by_yawpitch;
+
 	v2s32 local_animations[4];
 	float local_animation_speed;
 

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -114,6 +114,26 @@ public:
 
 	inline void setModified(const bool x) { m_dirty = x; }
 
+	void setLocalSprite(v2s16 tx_basepos[4], int num_frames[4], float framelength, bool select_horiz_by_yawpitch)
+	{
+		for (int i = 0; i < 4; i++) {
+			local_sprite_tx_basepos[i] = tx_basepos[i];
+			local_sprite_num_frames[i] = num_frames[i];
+		}
+		local_sprite_framelength = framelength;
+		local_sprite_select_horiz_by_yawpitch = select_horiz_by_yawpitch;
+	}
+
+	void getLocalSprite(v2s16 *tx_basepos, int *num_frames, float *framelength, bool *select_horiz_by_yawpitch)
+	{
+		for (int i = 0; i < 4; i++) {
+			tx_basepos[i] = local_sprite_tx_basepos[i];
+			num_frames[i] = local_sprite_num_frames[i];
+		}
+		*framelength = local_sprite_framelength;
+		*select_horiz_by_yawpitch = local_sprite_select_horiz_by_yawpitch;
+	}
+
 	void setLocalAnimations(v2s32 frames[4], float frame_speed)
 	{
 		for (int i = 0; i < 4; i++)

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -461,6 +461,57 @@ int ObjectRef::l_get_physics_override(lua_State *L)
 	return 1;
 }
 
+// set_texture_mod(self, mod)
+int ObjectRef::l_set_texture_mod(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	std::string mod = luaL_checkstring(L, 2);
+	co->setTextureMod(mod);
+	return 0;
+}
+
+// get_texture_mod(self)
+int ObjectRef::l_get_texture_mod(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	std::string mod = co->getTextureMod();
+	lua_pushstring(L, mod.c_str());
+	return 1;
+}
+
+// set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
+//           select_horiz_by_yawpitch=false)
+int ObjectRef::l_set_sprite(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	v2s16 p(0,0);
+	if (!lua_isnil(L, 2))
+		p = readParam<v2s16>(L, 2);
+	int num_frames = 1;
+	if (!lua_isnil(L, 3))
+		num_frames = lua_tonumber(L, 3);
+	float framelength = 0.2;
+	if (!lua_isnil(L, 4))
+		framelength = lua_tonumber(L, 4);
+	bool select_horiz_by_yawpitch = false;
+	if (!lua_isnil(L, 5))
+		select_horiz_by_yawpitch = readParam<bool>(L, 5);
+	co->setSprite(p, num_frames, framelength, select_horiz_by_yawpitch);
+	return 0;
+}
+
 // set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 int ObjectRef::l_set_animation(lua_State *L)
 {
@@ -977,57 +1028,6 @@ int ObjectRef::l_get_yaw(lua_State *L)
 	float yaw = co->getRotation().Y * core::DEGTORAD;
 	lua_pushnumber(L, yaw);
 	return 1;
-}
-
-// set_texture_mod(self, mod)
-int ObjectRef::l_set_texture_mod(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	LuaEntitySAO *co = getluaobject(ref);
-	if (co == NULL) return 0;
-	// Do it
-	std::string mod = luaL_checkstring(L, 2);
-	co->setTextureMod(mod);
-	return 0;
-}
-
-// get_texture_mod(self)
-int ObjectRef::l_get_texture_mod(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	LuaEntitySAO *co = getluaobject(ref);
-	if (co == NULL) return 0;
-	// Do it
-	std::string mod = co->getTextureMod();
-	lua_pushstring(L, mod.c_str());
-	return 1;
-}
-
-// set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
-//           select_horiz_by_yawpitch=false)
-int ObjectRef::l_set_sprite(lua_State *L)
-{
-	NO_MAP_LOCK_REQUIRED;
-	ObjectRef *ref = checkobject(L, 1);
-	LuaEntitySAO *co = getluaobject(ref);
-	if (co == NULL) return 0;
-	// Do it
-	v2s16 p(0,0);
-	if (!lua_isnil(L, 2))
-		p = readParam<v2s16>(L, 2);
-	int num_frames = 1;
-	if (!lua_isnil(L, 3))
-		num_frames = lua_tonumber(L, 3);
-	float framelength = 0.2;
-	if (!lua_isnil(L, 4))
-		framelength = lua_tonumber(L, 4);
-	bool select_horiz_by_yawpitch = false;
-	if (!lua_isnil(L, 5))
-		select_horiz_by_yawpitch = readParam<bool>(L, 5);
-	co->setSprite(p, num_frames, framelength, select_horiz_by_yawpitch);
-	return 0;
 }
 
 // DEPRECATED

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -512,6 +512,24 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	return 0;
 }
 
+// set_sprite_framelength(self, framelength)
+int ObjectRef::l_set_sprite_framelength(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	if (!lua_isnil(L, 2)) {
+		float framelength = lua_tonumber(L, 2);
+		co->setSpriteFramelength(framelength);
+		lua_pushboolean(L, true);
+	} else {
+		lua_pushboolean(L, false);
+	}
+	return 1;
+}
+
 // set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 int ObjectRef::l_set_animation(lua_State *L)
 {
@@ -2275,6 +2293,9 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_wielded_item),
 	luamethod(ObjectRef, set_armor_groups),
 	luamethod(ObjectRef, get_armor_groups),
+	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
+	luamethod_aliased(ObjectRef, set_sprite, setsprite),
+	luamethod(ObjectRef, set_sprite_framelength),
 	luamethod(ObjectRef, set_animation),
 	luamethod(ObjectRef, get_animation),
 	luamethod(ObjectRef, set_animation_frame_speed),
@@ -2297,8 +2318,6 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod_aliased(ObjectRef, get_yaw, getyaw),
 	luamethod(ObjectRef, set_rotation),
 	luamethod(ObjectRef, get_rotation),
-	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
-	luamethod_aliased(ObjectRef, set_sprite, setsprite),
 	luamethod(ObjectRef, get_entity_name),
 	luamethod(ObjectRef, get_luaentity),
 	// Player-only

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2294,6 +2294,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod(ObjectRef, set_armor_groups),
 	luamethod(ObjectRef, get_armor_groups),
 	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
+	luamethod(ObjectRef, get_texture_mod),
 	luamethod_aliased(ObjectRef, set_sprite, setsprite),
 	luamethod(ObjectRef, set_sprite_framelength),
 	luamethod(ObjectRef, set_animation),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -512,6 +512,26 @@ int ObjectRef::l_set_sprite(lua_State *L)
 	return 0;
 }
 
+// get_sprite(self)
+int ObjectRef::l_get_sprite(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	ServerActiveObject *co = getobject(ref);
+	if (co == NULL) return 0;
+	// Do it
+	v2s16 tx_basepos;
+	int num_frames;
+	float framelength;
+	bool get_horiz_by_yawpitch;
+	co->getSprite(&tx_basepos, &num_frames, &framelength, &get_horiz_by_yawpitch);
+	push_v2s16(L, tx_basepos);
+	lua_pushnumber(L, num_frames);
+	lua_pushnumber(L, framelength);
+	lua_pushboolean(L, get_horiz_by_yawpitch);
+	return 4;
+}
+
 // set_sprite_framelength(self, framelength)
 int ObjectRef::l_set_sprite_framelength(lua_State *L)
 {
@@ -2296,6 +2316,7 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod_aliased(ObjectRef, set_texture_mod, settexturemod),
 	luamethod(ObjectRef, get_texture_mod),
 	luamethod_aliased(ObjectRef, set_sprite, setsprite),
+	luamethod(ObjectRef, get_sprite),
 	luamethod(ObjectRef, set_sprite_framelength),
 	luamethod(ObjectRef, set_animation),
 	luamethod(ObjectRef, get_animation),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -132,6 +132,9 @@ private:
 	//           select_horiz_by_yawpitch=false)
 	static int l_set_sprite(lua_State *L);
 
+	// get_sprite()
+	static int l_get_sprite(lua_State *L);
+
 	// set_sprite_framelength(self, framelength)
 	static int l_set_sprite_framelength(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -122,6 +122,16 @@ private:
 	// get_physics_override(self)
 	static int l_get_physics_override(lua_State *L);
 
+	// set_texture_mod(self, mod)
+	static int l_set_texture_mod(lua_State *L);
+
+	// l_get_texture_mod(self)
+	static int l_get_texture_mod(lua_State *L);
+
+	// set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
+	//           select_horiz_by_yawpitch=false)
+	static int l_set_sprite(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 	static int l_set_animation(lua_State *L);
 
@@ -183,16 +193,6 @@ private:
 
 	// get_yaw(self)
 	static int l_get_yaw(lua_State *L);
-
-	// set_texture_mod(self, mod)
-	static int l_set_texture_mod(lua_State *L);
-
-	// l_get_texture_mod(self)
-	static int l_get_texture_mod(lua_State *L);
-
-	// set_sprite(self, p={x=0,y=0}, num_frames=1, framelength=0.2,
-	//           select_horiz_by_yawpitch=false)
-	static int l_set_sprite(lua_State *L);
 
 	// DEPRECATED
 	// get_entity_name(self)

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -369,6 +369,12 @@ private:
 	// get_day_night_ratio(self)
 	static int l_get_day_night_ratio(lua_State *L);
 
+	// set_local_sprite(self, {stand/idle}, {walk}, {dig}, {walk+dig}, framelength, select_horiz_by_yawpitch)
+	static int l_set_local_sprite(lua_State *L);
+
+	// get_local_sprite(self)
+	static int l_get_local_sprite(lua_State *L);
+
 	// set_local_animation(self, {stand/idle}, {walk}, {dig}, {walk+dig}, frame_speed)
 	static int l_set_local_animation(lua_State *L);
 

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -132,6 +132,9 @@ private:
 	//           select_horiz_by_yawpitch=false)
 	static int l_set_sprite(lua_State *L);
 
+	// set_sprite_framelength(self, framelength)
+	static int l_set_sprite_framelength(lua_State *L);
+
 	// set_animation(self, frame_range, frame_speed, frame_blend, frame_loop)
 	static int l_set_animation(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1863,6 +1863,19 @@ void Server::SendPlayerFov(session_t peer_id)
 	Send(&pkt);
 }
 
+void Server::SendLocalPlayerSprite(session_t peer_id, v2s16 tx_basepos[4],
+		int num_frames[4], float framelength, bool select_horiz_by_yawpitch)
+{
+	NetworkPacket pkt(TOCLIENT_LOCAL_PLAYER_SPRITE, 0,
+		peer_id);
+
+	pkt << tx_basepos[0] << tx_basepos[1] << tx_basepos[2] << tx_basepos[3]
+		<< num_frames[0] << num_frames[1] << num_frames[2] << num_frames[3]
+		<< framelength << select_horiz_by_yawpitch;
+
+	Send(&pkt);
+}
+
 void Server::SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed)
 {
@@ -3346,6 +3359,15 @@ void Server::hudSetHotbarSelectedImage(RemotePlayer *player, const std::string &
 Address Server::getPeerAddress(session_t peer_id)
 {
 	return m_con->GetPeerAddress(peer_id);
+}
+
+void Server::setLocalPlayerSprite(RemotePlayer *player,
+		v2s16 tx_basepos[4], int num_frames[4],
+		float framelength, bool select_horiz_by_yawpitch)
+{
+	sanity_check(player);
+	player->setLocalSprite(tx_basepos, num_frames, framelength, select_horiz_by_yawpitch);
+	SendLocalPlayerSprite(player->getPeerId(), tx_basepos, num_frames, framelength, select_horiz_by_yawpitch);
 }
 
 void Server::setLocalPlayerAnimations(RemotePlayer *player,

--- a/src/server.h
+++ b/src/server.h
@@ -307,6 +307,8 @@ public:
 
 	Address getPeerAddress(session_t peer_id);
 
+	void setLocalPlayerSprite(RemotePlayer *player, v2s16 tx_basepos[4],
+			int num_frames[4], float framelength, bool select_horiz_by_yawpitch);
 	void setLocalPlayerAnimations(RemotePlayer *player, v2s32 animation_frames[4],
 			f32 frame_speed);
 	void setPlayerEyeOffset(RemotePlayer *player, const v3f &first, const v3f &third);
@@ -406,6 +408,8 @@ private:
 	void SendTimeOfDay(session_t peer_id, u16 time, f32 time_speed);
 	void SendPlayerHP(session_t peer_id);
 
+	void SendLocalPlayerSprite(session_t peer_id, v2s16 tx_basepos[4],
+		int num_frames[4], float framelength, bool select_horiz_by_yawpitch);
 	void SendLocalPlayerAnimations(session_t peer_id, v2s32 animation_frames[4],
 		f32 animation_speed);
 	void SendEyeOffset(session_t peer_id, v3f first, v3f third);

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -157,6 +157,8 @@ public:
 	{ return ""; }
 	virtual void setSprite(v2s16 p, int num_frames, float framelength, bool select_horiz_by_yawpitch)
 	{}
+	virtual void getSprite(v2s16 *p, int *num_frames, float *framelength, bool *select_horiz_by_yawpitch)
+	{}
 	virtual void setSpriteFramelength(float framelength)
 	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -151,6 +151,12 @@ public:
 	{ static ItemGroupList rv; return rv; }
 	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
 	{}
+	virtual void setTextureMod(std::string &mod)
+	{}
+	virtual std::string getTextureMod()
+	{ return ""; }
+	virtual void setSprite(v2s16 p, int num_frames, float framelength, bool select_horiz_by_yawpitch)
+	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)
 	{}
 	virtual void getAnimation(v2f *frames, float *frame_speed, float *frame_blend, bool *frame_loop)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -151,7 +151,7 @@ public:
 	{ static ItemGroupList rv; return rv; }
 	virtual void setPhysicsOverride(float physics_override_speed, float physics_override_jump, float physics_override_gravity)
 	{}
-	virtual void setTextureMod(std::string &mod)
+	virtual void setTextureMod(const std::string &mod)
 	{}
 	virtual std::string getTextureMod()
 	{ return ""; }

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -157,6 +157,8 @@ public:
 	{ return ""; }
 	virtual void setSprite(v2s16 p, int num_frames, float framelength, bool select_horiz_by_yawpitch)
 	{}
+	virtual void setSpriteFramelength(float framelength)
+	{}
 	virtual void setAnimation(v2f frames, float frame_speed, float frame_blend, bool frame_loop)
 	{}
 	virtual void getAnimation(v2f *frames, float *frame_speed, float *frame_blend, bool *frame_loop)

--- a/src/serverobject.h
+++ b/src/serverobject.h
@@ -153,7 +153,7 @@ public:
 	{}
 	virtual void setTextureMod(const std::string &mod)
 	{}
-	virtual std::string getTextureMod()
+	virtual std::string getTextureMod() const
 	{ return ""; }
 	virtual void setSprite(v2s16 p, int num_frames, float framelength, bool select_horiz_by_yawpitch)
 	{}


### PR DESCRIPTION
Some fixes and additions to visual = "sprite" entities and players.

Added:
- Allow to use visual="sprite" for players (moved set_sprite to Object instead of Lua Entity only so you could set a sprite animation for a player, either self or an other one)
- Allow to use get/set_texture_mod for players (moved to Object instead of Lua Entity only)
- Add set_local_sprite and get_local_sprite for local animation management like it is done with set_local_animations.
- Add some details about the spritesheet in lua_api.txt
- Add set_sprite_framelength, sprite counterpart of set_animation_frame_speed for sprite animations
- Add get_sprite, sprite counterpart of get_animation for sprite animations

Changes:
- The texture of sprites and upright sprites are placed around the middle of the collision box instead of putting the center of the texture at 0,0,0


Fixes:
- Fix changing texture making the sprite visually pointing at world coordinate {0,0,0} for 1 frame
- Fix sprite animation data not being sent when initializing an entity (when connecting to an existing game).


See https://forum.minetest.net/viewtopic.php?f=7&t=24015 to get a simple mod that set sprite to players and entities and test the changes.
