### PR TITLE
Fix alignment tags adding unwanted newlines

### DIFF
--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -134,11 +134,13 @@ public:
 	Tag m_root_tag;
 
 protected:
+	typedef enum { ER_NONE, ER_TAG, ER_NEWLINE } EndReason;
+
 	// Parser functions
 	void enterElement(ElementType type);
 	void endElement();
 	void enterParagraph();
-	void endParagraph();
+	void endParagraph(EndReason reason);
 	void pushChar(wchar_t c);
 	ParsedText::Tag *newTag(const std::string &name, const AttrsList &attrs);
 	ParsedText::Tag *openTag(const std::string &name, const AttrsList &attrs);
@@ -160,6 +162,8 @@ protected:
 	StyleList m_style;
 	Element *m_element;
 	Paragraph *m_paragraph;
+	bool m_empty_paragraph;
+	EndReason m_end_paragraph_reason;
 };
 
 class TextDrawer


### PR DESCRIPTION
This PR fixes issue #9535 "Hypertext alignment tags add extra newline"

Parser now ignores: 
- Separator chars (space and tab) at paragraph start;
- Empty paragraph started by alignment tag and ended by new line;
- Empty paragraph ended by alignment tag;

## To do

This PR is Ready for Review.

## How to test

You can use the example given in issue or try this one (more cases) :

```
size[10,10]hypertext[0.2,1;10,9;test;
		AA<center>BB</center>CC
		<center>DD
		</center>EE
		<center>
		FF
		</center>
		<center></center>
		GG

		HH]
```

No empty lines should show up except explicit one between GG and HH