### PR TITLE
Show player nametag in third-person view

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -633,6 +633,8 @@ void Camera::drawNametags()
 			i = m_nametags.begin();
 			i != m_nametags.end(); ++i) {
 		Nametag *nametag = *i;
+		if (!nametag->parent_node->isVisible())
+			continue;
 		if (nametag->nametag_color.getAlpha() == 0) {
 			// Enforce hiding nametag,
 			// because if freetype is enabled, a grey

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -775,7 +775,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc)
 	if (node && m_matrixnode)
 		node->setParent(m_matrixnode);
 
-	if (node && !m_prop.nametag.empty() && !m_is_local_player) {
+	if (node && !m_prop.nametag.empty()) {
 		// Add nametag
 		v3f pos;
 		pos.Y = m_prop.selectionbox.MaxEdge.Y + 0.3f;
@@ -1451,7 +1451,7 @@ void GenericCAO::processMessage(const std::string &data)
 			player->setZoomFOV(m_prop.zoom_fov);
 		}
 
-		if ((m_is_player && !m_is_local_player) && m_prop.nametag.empty())
+		if (m_is_player && m_prop.nametag.empty())
 			m_prop.nametag = m_name;
 
 		expireVisuals();


### PR DESCRIPTION
## Goals:
Two very simple changes in one.
1) Hide nametag for invisible entity. Instead of using hacking with alpha 0. If the entity is invisible (no matter why), the nametag must also be hidden!
2) Show nametag in third-person mode.
The changes are extremely simple, almost trivial. But I'm sure modders and players will like them.

## To do

This PR is Ready for Review.

## How to test

1. Compile.
2. a) set is `visible = false` for an entity with nametag
    b) Press the F7 key
