### PR TITLE
Fix texture distortion on side-faces of flowing liquid nodes

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -556,17 +556,24 @@ void MapblockMeshGenerator::drawLiquidSides()
 		for (int j = 0; j < 4; j++) {
 			const UV &vertex = base_vertices[j];
 			const v3s16 &base = face.p[vertex.u];
+			float v = vertex.v;
+
 			v3f pos;
-			pos.X = (base.X - 0.5) * BS;
-			pos.Z = (base.Z - 0.5) * BS;
-			if (vertex.v)
-				pos.Y = neighbor.is_same_liquid ? corner_levels[base.Z][base.X] : -0.5 * BS;
-			else
-				pos.Y =     !top_is_same_liquid ? corner_levels[base.Z][base.X] :  0.5 * BS;
+			pos.X = (base.X - 0.5f) * BS;
+			pos.Z = (base.Z - 0.5f) * BS;
+			if (vertex.v) {
+				pos.Y = neighbor.is_same_liquid ? corner_levels[base.Z][base.X] : -0.5f * BS;
+			} else if (top_is_same_liquid) {
+				pos.Y = 0.5f * BS;
+			} else {
+				pos.Y = corner_levels[base.Z][base.X];
+				v += (0.5f * BS - corner_levels[base.Z][base.X]) / BS;
+			}
+
 			if (data->m_smooth_lighting)
 				color = blendLightColor(pos);
 			pos += origin;
-			vertices[j] = video::S3DVertex(pos.X, pos.Y, pos.Z, 0, 0, 0, color, vertex.u, vertex.v);
+			vertices[j] = video::S3DVertex(pos.X, pos.Y, pos.Z, 0, 0, 0, color, vertex.u, v);
 		};
 		collector->append(tile_liquid, vertices, 4, quad_indices, 6);
 	}


### PR DESCRIPTION
- In the current Minetest version textures of the side faces of flowing nodes will look distorted depending on the liquid level. This looks especially bad on liquid faces where the face height is very small and the entire texture is compressed to an area over 16 times smaller than normal node faces.

- This solves that problem by adjusting the texture coordinates for the vertices making up the top of the face, so the textures will not look compressed for smaller faces.

- The differences is illustrated in the picture below. The picture on the right is the current version of Minetest. Notice how the side-faces on the flowing liquid node at the top look stretched, its small front face looks which has a weird line containing many colors in the y-axis at very small space. These differences also stand out more when the liquid is animated. When the liquid is animated, it also creates the illusion that liquid flows slower in nodes with less liquid in them (because the animation is compressed to fit a smaller face surface).

- The picture on the left shows what it looks like with the new code.

![liquid-texturing](https://user-images.githubusercontent.com/11559411/77798010-5e5da700-7072-11ea-8ee1-42b2d35b98ff.png)

## How to test

Place lava or water blocks, let them flow and look at the texturing of the side faces on the flowing liquid nodes.

