### PR TITLE
Per Node Enabled Digging/Placing Animation

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -728,6 +728,7 @@ core.nodedef_default = {
 	climbable = false,
 	buildable_to = false,
 	floodable = false,
+	use_wield_anim = true,
 	liquidtype = "none",
 	liquid_alternative_flowing = "",
 	liquid_alternative_source = "",
@@ -751,7 +752,8 @@ core.craftitemdef_default = {
 	stack_max = 99,
 	liquids_pointable = false,
 	tool_capabilities = nil,
-
+	use_wield_anim = true,
+	
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
 	on_drop = redef_wrapper(core, 'item_drop'), -- core.item_drop
@@ -770,6 +772,7 @@ core.tooldef_default = {
 	stack_max = 1,
 	liquids_pointable = false,
 	tool_capabilities = nil,
+	use_wield_anim = true,
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'), -- core.item_place
@@ -789,6 +792,7 @@ core.noneitemdef_default = {  -- This is used for the hand and unknown items
 	stack_max = 99,
 	liquids_pointable = false,
 	tool_capabilities = nil,
+	use_wield_anim = true,
 
 	-- Interaction callbacks
 	on_place = redef_wrapper(core, 'item_place'),

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6651,6 +6651,9 @@ Used by `minetest.register_node`, `minetest.register_craftitem`, and
 
         liquids_pointable = false,
 
+        use_wield_anim = true,
+        -- Enables or disables the digging and placing animation.
+
         -- See "Tools" section for an example including explanation
         tool_capabilities = {
             full_punch_interval = 1.0,

--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -582,15 +582,18 @@ void Camera::updateViewingRange()
 
 void Camera::setDigging(s32 button)
 {
-	if (m_digging_button == -1)
+	if (m_digging_button == -1 && m_use_wield_anim)
 		m_digging_button = button;
 }
 
-void Camera::wield(const ItemStack &item)
+void Camera::wield(Client* client, const ItemStack &item)
 {
 	if (item.name != m_wield_item_next.name ||
 			item.metadata != m_wield_item_next.metadata) {
+		IItemDefManager* idef = client->getItemDefManager();
+		const ItemDefinition& def = item.getDefinition(idef);
 		m_wield_item_next = item;
+		m_use_wield_anim = def.use_wield_anim;
 		if (m_wield_change_timer > 0)
 			m_wield_change_timer = -m_wield_change_timer;
 		else if (m_wield_change_timer == 0)

--- a/src/client/camera.h
+++ b/src/client/camera.h
@@ -125,7 +125,7 @@ public:
 	void setDigging(s32 button);
 
 	// Replace the wielded item mesh
-	void wield(const ItemStack &item);
+	void wield(Client* client, const ItemStack &item);
 
 	// Draw the wielded tool.
 	// This has to happen *after* the main scene is drawn.
@@ -215,6 +215,7 @@ private:
 	// If 0, left-click digging animation
 	// If 1, right-click digging animation
 	s32 m_digging_button = -1;
+	bool m_use_wield_anim = true;
 
 	// Animation when changing wielded item
 	f32 m_wield_change_timer = 0.125f;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3816,7 +3816,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		// Update wielded tool
 		ItemStack selected_item, hand_item;
 		ItemStack &tool_item = player->getWieldedItem(&selected_item, &hand_item);
-		camera->wield(tool_item);
+		camera->wield(client, tool_item);
 	}
 
 	/*

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -214,6 +214,8 @@ void ItemDefinition::deSerialize(std::istream &is)
 	wield_overlay = deSerializeString(is);
 
 	use_wield_anim = readU8(is);
+	if (is.eof()) // Check for old servers without wield_anim support
+		use_wield_anim = true;
 
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.

--- a/src/itemdef.cpp
+++ b/src/itemdef.cpp
@@ -67,6 +67,7 @@ ItemDefinition& ItemDefinition::operator=(const ItemDefinition &def)
 	wield_image = def.wield_image;
 	wield_overlay = def.wield_overlay;
 	wield_scale = def.wield_scale;
+	use_wield_anim = def.use_wield_anim;
 	stack_max = def.stack_max;
 	usable = def.usable;
 	liquids_pointable = def.liquids_pointable;
@@ -106,6 +107,7 @@ void ItemDefinition::reset()
 	inventory_overlay = "";
 	wield_image = "";
 	wield_overlay = "";
+	use_wield_anim = true;
 	palette_image = "";
 	color = video::SColor(0xFFFFFFFF);
 	wield_scale = v3f(1.0, 1.0, 1.0);
@@ -118,7 +120,6 @@ void ItemDefinition::reset()
 	sound_place = SimpleSoundSpec();
 	sound_place_failed = SimpleSoundSpec();
 	range = -1;
-
 	node_placement_prediction = "";
 }
 
@@ -162,6 +163,7 @@ void ItemDefinition::serialize(std::ostream &os, u16 protocol_version) const
 	writeARGB8(os, color);
 	os << serializeString(inventory_overlay);
 	os << serializeString(wield_overlay);
+	writeU8(os, use_wield_anim);
 }
 
 void ItemDefinition::deSerialize(std::istream &is)
@@ -210,6 +212,8 @@ void ItemDefinition::deSerialize(std::istream &is)
 	color = readARGB8(is);
 	inventory_overlay = deSerializeString(is);
 	wield_overlay = deSerializeString(is);
+
+	use_wield_anim = readU8(is);
 
 	// If you add anything here, insert it primarily inside the try-catch
 	// block to not need to increase the version.

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -66,6 +66,7 @@ struct ItemDefinition
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.
 	v3f wield_scale;
+	bool use_wield_anim; // Enables or disables digging or placing animations.
 
 	/*
 		Item stack and interaction properties

--- a/src/itemdef.h
+++ b/src/itemdef.h
@@ -66,7 +66,7 @@ struct ItemDefinition
 	std::string palette_image; // If specified, the item will be colorized based on this
 	video::SColor color; // The fallback color of the node.
 	v3f wield_scale;
-	bool use_wield_anim; // Enables or disables digging or placing animations.
+	bool use_wield_anim = true; // Enables or disables digging or placing animations.
 
 	/*
 		Item stack and interaction properties

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -368,6 +368,7 @@ void ContentFeatures::reset()
 	floodable = false;
 	rightclickable = true;
 	leveled = 0;
+	use_wield_anim = true;
 	liquid_type = LIQUID_NONE;
 	liquid_alternative_flowing = "";
 	liquid_alternative_source = "";
@@ -435,6 +436,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		writeU16(os, connects_to_id);
 	writeARGB8(os, post_effect_color);
 	writeU8(os, leveled);
+	writeU8(os, use_wield_anim);
 
 	// lighting
 	writeU8(os, light_propagates);
@@ -541,6 +543,7 @@ void ContentFeatures::deSerialize(std::istream &is)
 		connects_to_ids.push_back(readU16(is));
 	post_effect_color = readARGB8(is);
 	leveled = readU8(is);
+	use_wield_anim = readU8(is);
 
 	// lighting-related
 	light_propagates = readU8(is);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -436,7 +436,6 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 		writeU16(os, connects_to_id);
 	writeARGB8(os, post_effect_color);
 	writeU8(os, leveled);
-	writeU8(os, use_wield_anim);
 
 	// lighting
 	writeU8(os, light_propagates);
@@ -480,6 +479,7 @@ void ContentFeatures::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, legacy_wallmounted);
 
 	os << serializeString(node_dig_prediction);
+	writeU8(os, use_wield_anim);
 }
 
 void ContentFeatures::correctAlpha(TileDef *tiles, int length)
@@ -543,7 +543,6 @@ void ContentFeatures::deSerialize(std::istream &is)
 		connects_to_ids.push_back(readU16(is));
 	post_effect_color = readARGB8(is);
 	leveled = readU8(is);
-	use_wield_anim = readU8(is);
 
 	// lighting-related
 	light_propagates = readU8(is);
@@ -583,13 +582,17 @@ void ContentFeatures::deSerialize(std::istream &is)
 	sound_dig.deSerialize(is, version);
 	sound_dug.deSerialize(is, version);
 
-	// read legacy properties
+	// read legacy properties>
 	legacy_facedir_simple = readU8(is);
 	legacy_wallmounted = readU8(is);
 
 	try {
 		node_dig_prediction = deSerializeString(is);
 	} catch(SerializationError &e) {};
+
+	use_wield_anim = readU8(is);
+	if (is.eof()) // Check for old servers without wield_anim support
+		use_wield_anim = true;
 }
 
 #ifndef SERVER

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -327,6 +327,8 @@ struct ContentFeatures
 	video::SColor post_effect_color;
 	// Flowing liquid or snow, value = default level
 	u8 leveled;
+	// Whether the node has a digging or placing animation
+	bool use_wield_anim;
 
 	// --- LIGHTING-RELATED ---
 

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -328,7 +328,7 @@ struct ContentFeatures
 	// Flowing liquid or snow, value = default level
 	u8 leveled;
 	// Whether the node has a digging or placing animation
-	bool use_wield_anim;
+	bool use_wield_anim = true;
 
 	// --- LIGHTING-RELATED ---
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -76,6 +76,8 @@ void read_item_definition(lua_State* L, int index,
 	int stack_max = getintfield_default(L, index, "stack_max", def.stack_max);
 	def.stack_max = rangelim(stack_max, 1, U16_MAX);
 
+	getboolfield(L, index, "use_wield_anim", def.use_wield_anim);
+
 	lua_getfield(L, index, "on_use");
 	def.usable = lua_isfunction(L, -1);
 	lua_pop(L, 1);
@@ -159,6 +161,8 @@ void push_item_definition_full(lua_State *L, const ItemDefinition &i)
 	lua_setfield(L, -2, "wield_scale");
 	lua_pushinteger(L, i.stack_max);
 	lua_setfield(L, -2, "stack_max");
+	lua_pushboolean(L, i.use_wield_anim);
+	lua_setfield(L, -2, "use_wield_anim");
 	lua_pushboolean(L, i.usable);
 	lua_setfield(L, -2, "usable");
 	lua_pushboolean(L, i.liquids_pointable);
@@ -670,6 +674,8 @@ ContentFeatures read_content_features(lua_State *L, int index)
 	getboolfield(L, index, "buildable_to", f.buildable_to);
 	// Liquids flow into and replace node
 	getboolfield(L, index, "floodable", f.floodable);
+	// Whether the node has a digging or placing animation.
+	getboolfield(L, index, "use_wield_anim", f.use_wield_anim);
 	// Whether the node is non-liquid, source liquid or flowing liquid
 	f.liquid_type = (LiquidType)getenumfield(L, index, "liquidtype",
 			ScriptApiNode::es_LiquidType, LIQUID_NONE);
@@ -853,6 +859,8 @@ void push_content_features(lua_State *L, const ContentFeatures &c)
 	lua_setfield(L, -2, "post_effect_color");
 	lua_pushnumber(L, c.leveled);
 	lua_setfield(L, -2, "leveled");
+	lua_pushboolean(L, c.use_wield_anim);
+	lua_setfield(L, -2, "use_wield_anim");
 	lua_pushboolean(L, c.sunlight_propagates);
 	lua_setfield(L, -2, "sunlight_propagates");
 	lua_pushnumber(L, c.light_source);


### PR DESCRIPTION
- Enables turning wield digging and placing off for specific nodes, items and tools; or keeping them enabled.
- This PR is useful for games (or mods) that use left mouse button for shooting or other various uses that do not need to use punch/place animation. This effect can be seen on Rubenwardy's CTF server.

## To do

Verify that connections to 5.1 and earlier 5.2-dev servers keep full place/digging animations.

Ready for Review.

## How to test

[no_wield_anim.zip](https://github.com/minetest/minetest/files/4394712/no_wield_anim.zip)

Drop this mod into `/mods` and use `/giveme`
```
/giveme test:wield_node_on
/giveme test:wield_node_off
/giveme test:wield_item_on
/giveme test:wield_item_off
/giveme test:wield_tool_on
/giveme test:wield_tool_off
```

## What it doesn't do:

Adds mod defined animations for digging / placing.