### PR TITLE
Set -DNDEBUG flag when CMAKE_BUILD_TYPE=None is used

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -725,6 +725,17 @@ else()
 	set(CMAKE_CXX_FLAGS_SEMIDEBUG "-g -O1 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS}")
 	set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wabi ${WARNING_FLAGS} ${OTHER_FLAGS}")
 
+	# We don't *want* to support this mode, but Debian (and by extension Ubuntu)
+	# build their packages with -DCMAKE_BUILD_TYPE=None, probably so they can
+	# get their custom compiler flags in. This causes -DNDEBUG to *not* be set,
+	# leaving rarely tested debug code in and other annoyances.
+	# So when we see that build type, at least make sure this is detected as a
+	# release build.
+	if(CMAKE_BUILD_TYPE STREQUAL "None")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG")
+	endif()
+	#
+
 	if(USE_GPROF)
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
 	endif()


### PR DESCRIPTION
Comprehensive fix for #9543 

Debian/Ubuntu and **even our own PPA** build with `-DCMAKE_BUILD_TYPE=None`, resulting in `-DNDEBUG` <i>not</i> being set, this causes:
* The in-game debug view being left enabled by default
* Very rarely tested debug code being left in production (\*ahem\* #9543)
* potentially more unexpected behaviour

Both are obviously undesirable, so add a workaround.

## To do

This PR is a Ready for Review.

## How to test

Observe the spectacularly retarded build setup of Debian and decide it needs a workaround.