### PR TITLE
idletime/lifetime for PlayerSAO API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6358,6 +6358,8 @@ object you are working with still exists.
     * Server-sent FOV value. Returns 0 if an FOV override doesn't exist.
     * Boolean indicating whether the FOV value is a multiplier.
     * Time (in seconds) taken for the FOV transition. Set by `set_fov`.
+* `get_lifetime()`: returns the elapsed time since the player joined the game.
+* `get_idletime()`: returns the elapsed time since the player was last active.
 * `set_attribute(attribute, value)`:  DEPRECATED, use get_meta() instead
     * Sets an extra attribute with value on player.
     * `value` must be a string, or a number which will be converted to a

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -504,6 +504,9 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	player->control.place = (keyPressed & (0x1 << 8));
 	player->control.zoom  = (keyPressed & (0x1 << 9));
 
+	// Player change detected, so reset idle timer
+	player->resetIdletime();
+
 	if (playersao->checkMovementCheat()) {
 		// Call callbacks
 		m_script->on_cheat(playersao, "moved_too_fast");
@@ -743,6 +746,9 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		return;
 	}
 
+	// Player is active, so reset idle timer
+	player->resetIdletime( );
+
 	// Do the action
 	a->apply(m_inventory_mgr.get(), playersao, this);
 }
@@ -778,6 +784,9 @@ void Server::handleCommand_ChatMessage(NetworkPacket* pkt)
 	// Get player name of this client
 	std::string name = player->getName();
 	std::wstring wname = narrow_to_wide(name);
+
+	// Player is active, so reset idle timer
+	player->resetIdletime( );
 
 	std::wstring answer_to_sender = handleChat(name, wname, message, true, player);
 	if (!answer_to_sender.empty()) {
@@ -1398,6 +1407,9 @@ void Server::handleCommand_NodeMetaFields(NetworkPacket* pkt)
 	// Check the target node for rollback data; leave others unnoticed
 	RollbackNode rn_old(&m_env->getMap(), p, this);
 
+	// Player is active, so reset idle timer
+	player->resetIdletime( );
+
 	m_script->node_on_receive_fields(p, formname, fields, playersao);
 
 	// Report rollback data
@@ -1442,6 +1454,9 @@ void Server::handleCommand_InventoryFields(NetworkPacket* pkt)
 		DisconnectPeer(peer_id);
 		return;
 	}
+
+	// Player is active, so reset idle timer
+	player->resetIdletime( );
 
 	if (client_formspec_name.empty()) { // pass through inventory submits
 		m_script->on_playerReceiveFields(playersao, client_formspec_name, fields);

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -110,30 +110,15 @@ public:
 
 	const CloudParams &getCloudParams() const { return m_cloud_params; }
 
-	u32 getLifetime() const
-	{
-		return (time(NULL) - m_oldtime);
-	}
+	u32 getLifetime() const { return (time(NULL) - m_oldtime); }
 
-	u32 getIdletime() const
-	{
-		return (time(NULL) - m_newtime);
-	}
+	u32 getIdletime() const { return (time(NULL) - m_newtime); }
 
-	inline void resetIdletime()
-	{
-		this->m_newtime = time(NULL);
-	}
+	inline void resetIdletime() { this->m_newtime = time(NULL); }
 
-	inline bool checkModified() const
-	{
-		return m_dirty || inventory.checkModified();
-	}
+	inline bool checkModified() const { return m_dirty || inventory.checkModified(); }
 
-	inline void setModified(const bool dirty = true)
-	{
-		m_dirty = dirty;
-	}
+	inline void setModified(const bool dirty = true) { m_dirty = dirty; }
 
 	void setLocalAnimations(v2s32 frames[4], float frame_speed)
 	{

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -110,9 +110,30 @@ public:
 
 	const CloudParams &getCloudParams() const { return m_cloud_params; }
 
-	bool checkModified() const { return m_dirty || inventory.checkModified(); }
+	u32 getLifetime() const
+	{
+		return (time(NULL) - m_oldtime);
+	}
 
-	inline void setModified(const bool x) { m_dirty = x; }
+	u32 getIdletime() const
+	{
+		return (time(NULL) - m_newtime);
+	}
+
+	inline void resetIdletime()
+	{
+		this->m_newtime = time(NULL);
+	}
+
+	inline bool checkModified() const
+	{
+		return m_dirty || inventory.checkModified();
+	}
+
+	inline void setModified(const bool dirty = true)
+	{
+		m_dirty = dirty;
+	}
 
 	void setLocalAnimations(v2s32 frames[4], float frame_speed)
 	{
@@ -152,6 +173,8 @@ private:
 
 	PlayerSAO *m_sao = nullptr;
 	bool m_dirty = false;
+	time_t m_oldtime = time(NULL);
+	time_t m_newtime = m_oldtime;
 
 	static bool m_setting_cache_loaded;
 	static float m_setting_chat_message_limit_per_10sec;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1011,6 +1011,32 @@ int ObjectRef::l_get_player_name(lua_State *L)
 	return 1;
 }
 
+// get_lifetime(self)
+int ObjectRef::l_get_lifetime(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+        if (player == nullptr)
+                 return 0;
+
+	lua_pushinteger(L, player->getLifetime());
+	return 1;
+}
+
+// get_idletime(self)
+int ObjectRef::l_get_idletime(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+        if (player == nullptr)
+                 return 0;
+
+	lua_pushinteger(L, player->getIdletime());
+	return 1;
+}
+
 // get_look_dir(self)
 int ObjectRef::l_get_look_dir(lua_State *L)
 {
@@ -2339,6 +2365,8 @@ luaL_Reg ObjectRef::methods[] = {
 	// Player-only
 	luamethod(ObjectRef, is_player),
 	luamethod(ObjectRef, get_player_name),
+	luamethod(ObjectRef, get_lifetime),
+	luamethod(ObjectRef, get_idletime),
 	luamethod(ObjectRef, get_look_dir),
 	luamethod(ObjectRef, get_look_pitch),
 	luamethod(ObjectRef, get_look_yaw),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -202,6 +202,12 @@ private:
 	// get_player_name(self)
 	static int l_get_player_name(lua_State *L);
 
+	// get_lifetime(self)
+	static int l_get_lifetime(lua_State *L);
+
+	// get_idletime(self)
+	static int l_get_idletime(lua_State *L);
+
 	// get_fov(self)
 	static int l_get_fov(lua_State *L);
 


### PR DESCRIPTION
This PR adds an `on_rightclickplayer` callback, thereby resolving #9128, as well as two additional object methods for players: `get_lifetime()` and `get_idletime()`. All three features have been in use on my server early 2017. I'm porting them from the Minetest S3 fork.

The `get_idletime()` method eases the burden of continuously polling player keystates in order to determine which players are still active, as in the case case of the afkkick mod. The `get_lifetime()` method resolves the need for maintaining a table of timestamps as players join and leave simply to calculate how long they have been in-game. Given that the engine can supply both of these metrics at basically no-cost, it just makes sense to have them as part of the Lua API.

The utility of the `on_rightclickplayer` callback is fairly self-explanatory. It exactly mimics that of the on_rightclick callback for entities. One of my planned uses for this feature is [player profiles](https://forum.minetest.net/viewtopic.php?t=23961&p=364164), but there are many other possibilities as well.

## To do

This PR is Ready for Review.

## How to test

Join a multiplayer game. Stand still for a while, then move around to see the status messages change. Join as a second player and right-click one another to be notified of the action.

```
local ctime = 0
local check_interval = 10

minetest.register_globalstep( function ( dtime )
        ctime = ctime + dtime

        if ctime > check_interval then
                local obj = minetest.add_item( { x = 0, y = 10, z = 0 }, "default:cobble" )
                minetest.chat_send_all( "Get lifetime of object? " ..
                         ( obj:get_lifetime( ) == nil and "None" or "Not nil!" ) )
                minetest.chat_send_all( "Get idletime of object? " ..
                         ( obj:get_idletime( ) == nil and "None" or "Not nil!" ) )

                for i, v in ipairs( minetest.get_connected_players( ) ) do
                        minetest.chat_send_all( string.format(
                                "Player %s was active %s secs ago (joined %d secs ago).",
                                 v:get_player_name( ), v:get_idletime( ), v:get_lifetime( )
                        ) )
                end
                ctime = 0
        end
end )

minetest.register_on_rightclickplayer( function ( target, source )
        minetest.chat_send_all( string.format( "Player %s right-clicked player %s",
                source:get_player_name( ), target:get_player_name( )
        ) )
end )
```
