### PR TITLE
Add warning to set_sky() docs about unstable dawn and night sky colours

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5996,12 +5996,20 @@ object you are working with still exists.
               `"regular"` skybox during the day. (default: `#9bc1f0`)
             * `dawn_sky`: ColorSpec, for the top half of the `"regular"`
               skybox during dawn/sunset. (default: `#b4bafa`)
+              The resulting sky color will be a darkened version of the ColorSpec.
+              Warning: The darkening of the ColorSpec is subject to change.
             * `dawn_horizon`: ColorSpec, for the bottom half of the `"regular"`
               skybox during dawn/sunset. (default: `#bac1f0`)
+              The resulting sky color will be a darkened version of the ColorSpec.
+              Warning: The darkening of the ColorSpec is subject to change.
             * `night_sky`: ColorSpec, for the top half of the `"regular"`
               skybox during the night. (default: `#006aff`)
+              The resulting sky color will be a dark version of the ColorSpec.
+              Warning: The darkening of the ColorSpec is subject to change.
             * `night_horizon`: ColorSpec, for the bottom half of the `"regular"`
               skybox during the night. (default: `#4090ff`)
+              The resulting sky color will be a dark version of the ColorSpec.
+              Warning: The darkening of the ColorSpec is subject to change.
             * `indoors`: ColorSpec, for when you're either indoors or 
               underground. Only applies to the `"regular"` skybox.
               (default: `#646464`)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5991,27 +5991,27 @@ object you are working with still exists.
         * `clouds`: Boolean for whether clouds appear. (default: `true`)
         * `sky_color`: A table containing the following values, alpha is ignored:
             * `day_sky`: ColorSpec, for the top half of the `"regular"`
-              skybox during the day. (default: `#8cbafa`)
+              sky during the day. (default: `#8cbafa`)
             * `day_horizon`: ColorSpec, for the bottom half of the 
-              `"regular"` skybox during the day. (default: `#9bc1f0`)
+              `"regular"` sky during the day. (default: `#9bc1f0`)
             * `dawn_sky`: ColorSpec, for the top half of the `"regular"`
-              skybox during dawn/sunset. (default: `#b4bafa`)
+              sky during dawn/sunset. (default: `#b4bafa`)
               The resulting sky color will be a darkened version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `dawn_horizon`: ColorSpec, for the bottom half of the `"regular"`
-              skybox during dawn/sunset. (default: `#bac1f0`)
+              sky during dawn/sunset. (default: `#bac1f0`)
               The resulting sky color will be a darkened version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `night_sky`: ColorSpec, for the top half of the `"regular"`
-              skybox during the night. (default: `#006aff`)
+              sky during the night. (default: `#006aff`)
               The resulting sky color will be a dark version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `night_horizon`: ColorSpec, for the bottom half of the `"regular"`
-              skybox during the night. (default: `#4090ff`)
+              sky during the night. (default: `#4090ff`)
               The resulting sky color will be a dark version of the ColorSpec.
               Warning: The darkening of the ColorSpec is subject to change.
             * `indoors`: ColorSpec, for when you're either indoors or 
-              underground. Only applies to the `"regular"` skybox.
+              underground. Only applies to the `"regular"` sky.
               (default: `#646464`)
             * `fog_sun_tint`: ColorSpec, changes the fog tinting for the sun
               at sunrise and sunset.
@@ -6055,7 +6055,7 @@ object you are working with still exists.
         * `visible`: Boolean for whether the stars are visible.
             (default: `true`)
         * `count`: Integer number to set the number of stars in 
-            the skybox. Only applies to `"skybox"` and `"regular"` skyboxes.
+            the skybox. Only applies to `"skybox"` and `"regular"` sky types.
             (default: `1000`)
         * `star_color`: ColorSpec, sets the colors of the stars,
             alpha channel is used to set overall star brightness.


### PR DESCRIPTION
Closes #9560 
Also warns for dawn sky colours as those are darkened like night sky colours are (tested).

2nd Commit:
In docs, the word 'skybox' refers to 1 of the 3 sky types, but this word was also being used to generally refer to sky, causing a confusing double meaning.
Fix this, the word 'skybox' now only has 1 meaning, as a sky type.