### PR TITLE
Print error message if an invalid mapgen alias was detected

### DIFF
--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -629,6 +629,13 @@ MapgenBasic::MapgenBasic(int mapgenid, MapgenParams *params, EmergeManager *emer
 	// Lava falls back to water as both are suitable as cave liquids.
 	if (c_lava_source == CONTENT_IGNORE)
 		c_lava_source = c_water_source;
+
+	if (c_stone == CONTENT_IGNORE)
+		errorstream << "Mapgen: Mapgen alias 'mapgen_stone' is invalid!" << std::endl;
+	if (c_water_source == CONTENT_IGNORE)
+		errorstream << "Mapgen: Mapgen alias 'mapgen_water_source' is invalid!" << std::endl;
+	if (c_river_water_source == CONTENT_IGNORE)
+		warningstream << "Mapgen: Mapgen alias 'mapgen_river_water_source' is invalid!" << std::endl;
 }
 
 

--- a/src/mapgen/mapgen_v6.cpp
+++ b/src/mapgen/mapgen_v6.cpp
@@ -132,6 +132,21 @@ MapgenV6::MapgenV6(MapgenV6Params *params, EmergeManager *emerge)
 		c_stair_cobble = c_cobble;
 	if (c_stair_desert_stone == CONTENT_IGNORE)
 		c_stair_desert_stone = c_desert_stone;
+
+	if (c_stone == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_stone' is invalid!" << std::endl;
+	if (c_dirt == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_dirt' is invalid!" << std::endl;
+	if (c_dirt_with_grass == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_dirt_with_grass' is invalid!" << std::endl;
+	if (c_sand == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_sand' is invalid!" << std::endl;
+	if (c_water_source == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_water_source' is invalid!" << std::endl;
+	if (c_lava_source == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_lava_source' is invalid!" << std::endl;
+	if (c_cobble == CONTENT_IGNORE)
+		errorstream << "Mapgen v6: Mapgen alias 'mapgen_cobble' is invalid!" << std::endl;
 }
 
 

--- a/src/mapgen/treegen.cpp
+++ b/src/mapgen/treegen.cpp
@@ -44,6 +44,12 @@ void make_tree(MMVManip &vmanip, v3s16 p0, bool is_apple_tree,
 	MapNode treenode(ndef->getId("mapgen_tree"));
 	MapNode leavesnode(ndef->getId("mapgen_leaves"));
 	MapNode applenode(ndef->getId("mapgen_apple"));
+	if (treenode == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_tree' is invalid!" << std::endl;
+	if (leavesnode == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_leaves' is invalid!" << std::endl;
+	if (applenode == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_apple' is invalid!" << std::endl;
 
 	PseudoRandom pr(seed);
 	s16 trunk_h = pr.range(4, 5);
@@ -145,6 +151,9 @@ treegen::error make_ltree(MMVManip &vmanip, v3s16 p0,
 	const NodeDefManager *ndef, TreeDef tree_definition)
 {
 	MapNode dirtnode(ndef->getId("mapgen_dirt"));
+	if (dirtnode == CONTENT_IGNORE)
+		errorstream << "Treegen (make_ltree): Mapgen alias 'mapgen_dirt' is invalid!" << std::endl;
+
 	s32 seed;
 	if (tree_definition.explicit_seed)
 		seed = tree_definition.seed + 14002;
@@ -662,6 +671,10 @@ void make_jungletree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 		c_tree = ndef->getId("mapgen_tree");
 	if (c_leaves == CONTENT_IGNORE)
 		c_leaves = ndef->getId("mapgen_leaves");
+	if (c_tree == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_jungletree' is invalid!" << std::endl;
+	if (c_leaves == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_jungleleaves' is invalid!" << std::endl;
 
 	MapNode treenode(c_tree);
 	MapNode leavesnode(c_leaves);
@@ -765,6 +778,10 @@ void make_pine_tree(MMVManip &vmanip, v3s16 p0, const NodeDefManager *ndef,
 		c_leaves = ndef->getId("mapgen_leaves");
 	if (c_snow == CONTENT_IGNORE)
 		c_snow = CONTENT_AIR;
+	if (c_tree == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_pine_tree' is invalid!" << std::endl;
+	if (c_leaves == CONTENT_IGNORE)
+		errorstream << "Treegen: Mapgen alias 'mapgen_pine_needles' is invalid!" << std::endl;
 
 	MapNode treenode(c_tree);
 	MapNode leavesnode(c_leaves);


### PR DESCRIPTION
This PR adds a couple of checks into the mapgen to see if any mapgen alias resolves to `CONTENT_IGNORE`.
If yes, an error message is reported.

## To do

This PR is Ready for Review.

## How to test

Create a game and intentionally put in mapgen aliases that are invalid.
Or just don't create any mapgen aliases as well (which is also incorrect most of the time).

Example:
```
minetest.register_alias("mapgen_stone", "a_node_that_does_not_exist")
minetest.register_alias("mapgen_cobble", "another_node_that_does_not_exist")
-- and so on ...
```

Test out different mapgens: v6, v5, v7, flat, … your choice.

## Downside
For some strange reason, when you first start Minetest in a game with invalid mapgen aliases, the error is properly logged but not screamed into the chat. You will see it on the 2nd start, however.

I don't know if I can do anything about it, my guess is that it's a limitation of the debug logging system maybe. But really I have no clue. It's a minor downside IMO, the fact that it's logged at all is still an improvement.

## Justification
Invalid mapgen aliases make the mapgen choke, and you will find `ignore` in the world where it shouldn't be. So it's critical to get the mapgen aliases right, as a gamedev.

Currently, if the gamedev forgets a mapgen alias, it might be tricky to figure out that this is the reason. It might also be very suble, if you only forgot `mapgen_apple` or `mapgen_cobble` in v6, you only occassionally run into `ignore` areas and in case of `mapgen_apple`, it's so subtle this bug can go unnoticed for a good amount of time, as `ignore` is completely invisible.

Reporting this as error should allow gamedevs to quickly eliminate this kind of bug.