### PR TITLE
Fix hovercolor not working in global tag

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -107,7 +107,7 @@ ParsedText::ParsedText(const wchar_t *text)
 	m_root_tag.style["underline"] = "false";
 	m_root_tag.style["halign"] = "left";
 	m_root_tag.style["color"] = "#EEEEEE";
-	m_root_tag.style["hovercolor"] = m_root_tag.style["color"];
+	m_root_tag.style["hovercolor"] = "#FF0000";
 
 	m_active_tags.push_front(&m_root_tag);
 	m_style = m_root_tag.style;
@@ -115,7 +115,6 @@ ParsedText::ParsedText(const wchar_t *text)
 	// Default simple tags definitions
 	StyleList style;
 
-	style["hovercolor"] = "#FF0000";
 	style["color"] = "#0000FF";
 	style["underline"] = "true";
 	m_elementtags["action"] = style;


### PR DESCRIPTION
This fixes #9557, making hovercolor global tag attribute working as expected and as told in lua_api.txt. 

Anyway, I'm wondering if this is behavior is really adequate. There is a <tag> tag that allow to create new tags or redefine existing ones. So changing `action` color and hover color can be done with :

`<tag name=action hovercolor=blue color=red>`

I think hovercolor should be removed from `<global>` (or actually change hovercolor of all elements) in profit of `<tag>`.

Something can be improved in `<tag>`, if you use :

`<tag name=action hovercolor=blue>`

This resets "color" for `<action>` to default color (instead of the default specific actions color). Maybe it should only change mentioned styles on existing tags and leave other styles unchanged.

#### TL;DR:

This proposal: Fix global hovercolor.

Alternative proposal: Remove hovercolor from `<global>`, use `<tag name=action hovercolor=...>` instead.

## How to test
Test with formspec: 
`size[10,10]hypertext[0.2,1;10,9;test;<global hovercolor=green><action name=test>Test</action>"]`

Should display a "Test" link, when hovered should turn to green instead of default red.

