### PR TITLE
Add max_viewrange setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1243,6 +1243,9 @@ server_unload_unused_data_timeout (Unload unused server data) int 29
 #    Maximum number of statically stored objects in a block.
 max_objects_per_block (Maximum objects per block) int 64
 
+#    Limits the maximum viewrange for objects
+max_viewrange (Maximum object view range) float 0
+
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 sqlite_synchronous (Synchronous SQLite) enum 2 0,1,2
 

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -1502,6 +1502,9 @@
 #    type: int
 # max_objects_per_block = 64
 
+#    Limits the maximum viewrange for objects
+# max_viewrange = 0
+
 #    See https://www.sqlite.org/pragma.html#pragma_synchronous
 #    type: enum values: 0, 1, 2
 # sqlite_synchronous = 2

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1519,6 +1519,16 @@ u16 ServerEnvironment::addActiveObject(ServerActiveObject *object)
 }
 
 /*
+	Gets player radius, limited through the max_viewrange setting
+*/
+float getPlayerRadius(float player_radius_f)
+{
+	float max_viewrange_f = g_settings->getFloat("max_viewrange");
+	if (player_radius_f <= 0.0f || player_radius_f > max_viewrange_f)
+		return max_viewrange_f;
+	return player_radius_f;
+}
+/*
 	Finds out what new objects have been added to
 	inside a radius around a position
 */
@@ -1530,11 +1540,8 @@ void ServerEnvironment::getAddedActiveObjects(PlayerSAO *playersao, s16 radius,
 	f32 radius_f = radius * BS;
 	f32 player_radius_f = player_radius * BS;
 
-	if (player_radius_f < 0.0f)
-		player_radius_f = 0.0f;
-
 	m_ao_manager.getAddedActiveObjectsAroundPos(playersao->getBasePosition(), radius_f,
-		player_radius_f, current_objects, added_objects);
+		getPlayerRadius(player_radius_f), current_objects, added_objects);
 }
 
 /*
@@ -1549,8 +1556,7 @@ void ServerEnvironment::getRemovedActiveObjects(PlayerSAO *playersao, s16 radius
 	f32 radius_f = radius * BS;
 	f32 player_radius_f = player_radius * BS;
 
-	if (player_radius_f < 0)
-		player_radius_f = 0;
+	player_radius_f = getPlayerRadius(player_radius_f);
 	/*
 		Go through current_objects; object is removed if:
 		- object is not found in m_active_objects (this is actually an


### PR DESCRIPTION
- Goal of the PR: adds the `max_viewrange` setting (default: `0`) which limits player viewrange regarding objects.
- How does the PR work? Simply clamps the object sending range in add & remove functions.
- If not a bug fix, why is this PR needed? What usecases does it solve? PvP servers have to deal with the problem that players see opponents by using a simple glitch: They set the viewrange very low, trigger mapblock unloading, and then quickly set it to infinite viewrange. During a short blink, they are able to spot all players on the map, no matter the distance.

## To do

This PR is Ready for Review.

- [ ] Consider applying the same to mapblocks

## How to test

Set `max_viewrange` to any value and have two players which are far away. They won't see each other.
