### PR TITLE
Add relative numbers for commands by prepending ~

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -444,6 +444,14 @@ end
 
 
 --------------------------------------------------------------------------------
+
+local function parse_area_string(pos, sub1, sub2, relative_to)
+	local newpos = string.sub(pos, sub1, sub2)
+	local pp = {}
+	pp.x, pp.y, pp.z = string.match(newpos, "([%d.~-]+)[, ] *([%d.~-]+)[, ] *([%d.~-]+)")
+	return core.parse_coordinates(pp.x, pp.y, pp.z, relative_to)
+end
+
 function core.string_to_area(value, relative_to)
 	local p1, p2 = unpack(value:split(") ("))
 	if p1 == nil or p2 == nil then
@@ -451,13 +459,8 @@ function core.string_to_area(value, relative_to)
 	end
 
 	if relative_to then
-		p1 = string.sub(p1, 2)
-		p2 = string.sub(p2, 1, -2)
-		local pp1, pp2 = {}, {}
-		pp1.x, pp1.y, pp1.z = string.match(p1, "([%d.~-]+)[, ] *([%d.~-]+)[, ] *([%d.~-]+)")
-		pp2.x, pp2.y, pp2.z = string.match(p2, "([%d.~-]+)[, ] *([%d.~-]+)[, ] *([%d.~-]+)")
-		p1 = core.parse_coordinates(pp1.x, pp1.y, pp1.z, relative_to)
-		p2 = core.parse_coordinates(pp2.x, pp2.y, pp2.z, relative_to)
+		p1 = parse_area_string(p1, 2, nil, relative_to)
+		p2 = parse_area_string(p2, 1, -2, relative_to)
 	else
 		p1 = core.string_to_pos(p1 .. ")")
 		p2 = core.string_to_pos("(" .. p2)
@@ -726,10 +729,10 @@ of a chat command parameter, using the chat command tilde notation.
 Parameters:
 * arg: String snippet containing the number; possible values:
     * "<number>": return as number
-    * "~<number>": return absvalue + <number>
-    * "~": return absvalue
+    * "~<number>": return relative_to + <number>
+    * "~": return relative_to
     * Anything else will return `nil`
-* absvalue: Number to which the `arg` number might be relative to
+* relative_to: Number to which the `arg` number might be relative to
 
 Returns:
 A number or `nil`, depending on `arg.
@@ -739,17 +742,17 @@ Examples:
 * `core.parse_relative_number("~5", 10)` returns 15
 * `core.parse_relative_number("~", 10)` returns 10
 ]]
-function core.parse_relative_number(arg, absvalue)
+function core.parse_relative_number(arg, relative_to)
 	if not arg then
 		return nil
 	elseif arg == "~" then
-		return absvalue
+		return relative_to
 	elseif string.sub(arg, 1, 1) == "~" then
 		local number = tonumber(string.sub(arg, 2))
 		if not number then
 			return nil
 		end
-		return absvalue + number
+		return relative_to + number
 	else
 		return tonumber(arg)
 	end

--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -425,20 +425,16 @@ function core.string_to_pos(value)
 		return nil
 	end
 
-	local x, y, z = string.match(value, "^([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+)$")
+	value = value:match("^%((.-)%)$") or value -- strip parentheses
+
+	local x, y, z = value:trim():match("^([%d.-]+)[,%s]%s*([%d.-]+)[,%s]%s*([%d.-]+)$")
 	if x and y and z then
 		x = tonumber(x)
 		y = tonumber(y)
 		z = tonumber(z)
 		return vector.new(x, y, z)
 	end
-	x, y, z = string.match(value, "^%( *([%d.-]+)[, ] *([%d.-]+)[, ] *([%d.-]+) *%)$")
-	if x and y and z then
-		x = tonumber(x)
-		y = tonumber(y)
-		z = tonumber(z)
-		return vector.new(x, y, z)
-	end
+
 	return nil
 end
 

--- a/builtin/common/tests/misc_helpers_spec.lua
+++ b/builtin/common/tests/misc_helpers_spec.lua
@@ -66,6 +66,96 @@ describe("pos", function()
 	end)
 end)
 
+describe("area parsing", function()
+	describe("valid inputs", function()
+		it("accepts absolute numbers", function()
+			local p1, p2 = core.string_to_area("(10.0, 5, -2) (  30.2 4 -12.53)")
+			assert(p1.x == 10 and p1.y == 5 and p1.z == -2)
+			assert(p2.x == 30.2 and p2.y == 4 and p2.z == -12.53)
+		end)
+
+		it("accepts relative numbers", function()
+			local p1, p2 = core.string_to_area("(1,2,3) (~5,~-5,~)", {x=10,y=10,z=10})
+			assert(type(p1) == "table" and type(p2) == "table")
+			assert(p1.x == 1 and p1.y == 2 and p1.z == 3)
+			assert(p2.x == 15 and p2.y == 5 and p2.z == 10)
+
+			p1, p2 = core.string_to_area("(1 2 3) (~5 ~-5 ~)", {x=10,y=10,z=10})
+			assert(type(p1) == "table" and type(p2) == "table")
+			assert(p1.x == 1 and p1.y == 2 and p1.z == 3)
+			assert(p2.x == 15 and p2.y == 5 and p2.z == 10)
+		end)
+	end)
+	describe("invalid inputs", function()
+		it("rejects too few numbers", function()
+			local p1, p2 = core.string_to_area("(1,1) (1,1,1,1)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+		end)
+
+		it("rejects too many numbers", function()
+			local p1, p2 = core.string_to_area("(1,1,1,1) (1,1,1,1)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+		end)
+
+		it("rejects nan & inf", function()
+			local p1, p2 = core.string_to_area("(1,1,1) (1,1,nan)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(1,1,1) (1,1,~nan)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(1,1,1) (1,~nan,1)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(1,1,1) (1,1,inf)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(1,1,1) (1,1,~inf)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(1,1,1) (1,~inf,1)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(nan,nan,nan) (nan,nan,nan)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(nan,nan,nan) (nan,nan,nan)")
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(inf,inf,inf) (-inf,-inf,-inf)", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(inf,inf,inf) (-inf,-inf,-inf)")
+			assert(p1 == nil and p2 == nil)
+		end)
+
+		it("rejects words", function()
+			local p1, p2 = core.string_to_area("bananas", {x=1,y=1,z=1})
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("bananas", "foobar")
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("bananas")
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(bananas,bananas,bananas)")
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(bananas,bananas,bananas) (bananas,bananas,bananas)")
+			assert(p1 == nil and p2 == nil)
+		end)
+
+		it("requires parenthesis & valid numbers", function()
+			local p1, p2 = core.string_to_area("(10.0, 5, -2  30.2,   4, -12.53")
+			assert(p1 == nil and p2 == nil)
+
+			p1, p2 = core.string_to_area("(10.0, 5,) -2  fgdf2,   4, -12.53")
+			assert(p1 == nil and p2 == nil)
+		end)
+	end)
+end)
+
 describe("table", function()
 	it("indexof()", function()
 		assert.equal(1, table.indexof({"foo", "bar"}, "foo"))

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1064,13 +1064,7 @@ core.register_chatcommand("time", {
 			return false, S("You don't have permission to run "
 				.. "this command (missing privilege: @1).", "settime")
 		end
-		local hour, minute = param:match("^([%d~-]+):([%d-]+)$")
-		if hour then
-			hour = string.trim(hour)
-		end
-		if minute then
-			minute = string.trim(minute)
-		end
+		local hour, minute = param:match("^(~?[-]?%d+):([-]?%d+)$")
 		if not hour or not minute then
 			local new_time = core.parse_relative_number(param, core.get_timeofday() * 24000)
 			if not new_time then

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -582,7 +582,6 @@ core.register_chatcommand("teleport", {
 		local p = {}
 		p.x, p.y, p.z = string.match(param, "^([%d.~-]+)[, ] *([%d.~-]+)[, ] *([%d.~-]+)$")
 		p = core.parse_coordinates(p.x, p.y, p.z, relpos)
-		local teleportee = core.get_player_by_name(name)
 		if p and p.x and p.y and p.z then
 			return teleport_to_pos(name, p)
 		end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3488,8 +3488,16 @@ Helper functions
 * `minetest.string_to_pos(string)`: returns a position or `nil`
     * Same but in reverse.
     * If the string can't be parsed to a position, nothing is returned.
-* `minetest.string_to_area("(X1, Y1, Z1) (X2, Y2, Z2)")`: returns two positions
+* `minetest.string_to_area("(X1, Y1, Z1) (X2, Y2, Z2)", relative_to)`:
+    * returns two positions
     * Converts a string representing an area box into two positions
+    * X1, Y1, ... Z2 are coordinates
+    * `relative_to`: Optional. If set to a position, each coordinate
+      can use the tilde notation for relative positions
+    * Tilde notation: "~": Relative coordinate
+                      "~<number>": Relative coordinate plus <number>
+    * Example: `minetest.string_to_area("(1,2,3) (~5,~-5,~)", {x=10,y=10,z=10})`
+      returns `{x=1,y=2,z=3}, {x=15,y=5,z=10}`
 * `minetest.formspec_escape(string)`: returns a string
     * escapes the characters "[", "]", "\", "," and ";", which can not be used
       in formspecs.


### PR DESCRIPTION
I extended the commands with relative numbers. A relative number is a number in a chat command parameter that is relative to some known absolute value. It is useful to add or subtract something, instead of setting the value directly. The idea is to add support for relative numbers in commands where it makes sense.

From the player's point of view, a number is made relative by prepending the tilde character to the number. For example, instead of `/time 2000`, you can write `/time ~2000`, this means that the value is added to the current time of day instead of setting it. If the time of day was `5000`, this command will result in a time of day of `7000` instead of `2000`.
The `hh:mm` syntax is also supported, just prepend the tilde before the whole time. With the tilde, you can also use negative values for time:

* `/time ~-2:30`: Subtacts 2 hours and 30 minutes from the current time of day.

Another major supported command is `/teleport`. Each coordinate supports relative numbers.

As a shortcut, just entering the tilde without any number is the same as `~0`.

`/teleport ~ ~100 ~` will raise you by 100 nodes, while X and Z stay the same.

The following commands are supported:

* `/teleport`
* `/spawnentity`
* `/deleteblocks`
* `/emergeblocks`
* `/fixlight`
* `/time`

Note that not all commands that contain numbers have relative number support because relative numbers don't always make sense (like for a radius of `/deleteblocks`).

## To do

This PR is a Work in Progress (more or less).

* Figure out how to document this new syntax without massively blowing up the `/help` text
* The code in general feels a little “dirty” to me. Feel free to whine about it, I will understand
* This adds a couple of helper functions, but they are in `core` because I want to use them across files. The helper functions are NOT meant for the official Lua API (so far). Is there a way to mark these functions as “not for Lua API use”?
* Maybe (!) add the helper functions to the Lua API anyway, but easier and more straight-forwards to use, so that games and mods can easily introduce relative numbers as well

## How to test

* `/teleport ~ ~10 ~0`: Raise by 10 nodes
* `/teleport ~10 ~10 ~10`: Add 10 to X, Y and Z of your current position
* `/teleport ~0 ~0 ~-20`: Move -20 on the Z axis
* `/teleport ~ 10 ~`: Teleport to (current\_x, 10, current\_z)
* `/time ~1111`: Advance time by 1111 millihours
* `/time ~2:00`: Advance time by 2 hours
* `/time ~-0:05`: Go back in time by 5 minutes
* `/deleteblocks (~ ~ ~) (~25 ~25 ~25)`: Delete blocks between your current position and [your current position +25 on each axis]
* (also try out the non-relative versions of each command, obviously they must still work perfectly)

## Justification

`/teleport` just got so more convenient as you do not have to memorize your current coords anymore.
