### PR TITLE
Revert collision tweaks #9365 and #9327

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -415,12 +415,12 @@ collisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		Collision uncertainty radius
 		Make it a bit larger than the maximum distance of movement
 	*/
-	//f32 d = pos_max_d * 1.1f;
+	f32 d = pos_max_d * 1.1f;
+	// A fairly large value in here makes moving smoother
+	//f32 d = 0.15*BS;
 
-
-	f32 d = 0.3f;	// Temporary fix, any nonzero d causes collision glitches, the more the greater it is.
-	// ultimately it has to be determined if any uncertainty is involved, and if it is, eliminated
-	// and d & pos_max_d params removed from function calls.
+	// This should always apply, otherwise there are glitches
+	assert(d > pos_max_d);	// invariant
 
 	int loopcount = 0;
 


### PR DESCRIPTION
This reverts commit df74d369a395f0b99bd23fa3e7fb4c628c3df336.
This reverts commit 908e76247922d4adf879b3996c4f75bdbb4e536d.

Restores the original collision detection bugs to release 5.2.0 prior the large collision detection fix.

Fixes #9375

## How to test

1) Compare `collision.cpp` with [the stable version](https://github.com/minetest/minetest/commits/stable-5/src/collision.cpp).