### PR TITLE
Builtin: Make item entities glow less

### DIFF
--- a/builtin/game/item_entity.lua
+++ b/builtin/game/item_entity.lua
@@ -59,7 +59,7 @@ core.register_entity(":__builtin:item", {
 		local size = 0.2 + 0.1 * (count / max_count) ^ (1 / 3)
 		local coll_height = size * 0.75
 		local def = core.registered_nodes[itemname]
-		local glow = def and def.light_source
+		local glow = def and math.floor(def.light_source / 2 + 0.5)
 
 		self.object:set_properties({
 			is_visible = true,


### PR DESCRIPTION
Dropped torches glowed so much that I thought it was a bug at first, but it's not.
To make the glow less annoying, halve the light level.

before:
![grafik](https://user-images.githubusercontent.com/1042418/78459106-013ba400-76b7-11ea-9633-c6be72d49aab.png)
after:
![grafik](https://user-images.githubusercontent.com/1042418/78459109-04cf2b00-76b7-11ea-9deb-8897fee28c6f.png)
for comparison, an unlit item:
![grafik](https://user-images.githubusercontent.com/1042418/78459141-4bbd2080-76b7-11ea-8ea8-a5ce2161ecb9.png)


## To do

This PR is a Ready for Review.

## How to test

Drop torch at night